### PR TITLE
[Merged by Bors] - chore(LinearAlgebra,Order): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
@@ -39,7 +39,7 @@ Some key definitions are not yet present.
   coordinates, with appropriate proofs of existence when `k` is a field.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/LinearAlgebra/AffineSpace/MidpointZero.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/MidpointZero.lean
@@ -18,7 +18,7 @@ We collect lemmas that require that the underlying ring has characteristic zero.
 midpoint
 -/
 
-@[expose] public section
+public section
 
 
 open AffineMap AffineEquiv

--- a/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
@@ -28,7 +28,7 @@ for an ordered module interpreted as an affine space.
 affine space, ordered module, slope
 -/
 
-@[expose] public section
+public section
 
 
 open AffineMap

--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Centroid.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Centroid.lean
@@ -15,7 +15,7 @@ This file proves some basic properties of the centroid of a simplex in affine sp
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/Basis/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Basis/Bilinear.lean
@@ -12,7 +12,7 @@ public import Mathlib.LinearAlgebra.Basis.Defs
 # Lemmas about bilinear maps with a basis over each argument
 -/
 
-@[expose] public section
+public section
 
 open Module
 

--- a/Mathlib/LinearAlgebra/Basis/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Basis/Cardinality.lean
@@ -14,7 +14,7 @@ public import Mathlib.SetTheory.Cardinal.Pigeonhole
 # Results relating bases and cardinality.
 -/
 
-@[expose] public section
+public section
 
 section Finite
 

--- a/Mathlib/LinearAlgebra/Charpoly/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/BaseChange.lean
@@ -13,7 +13,7 @@ public import Mathlib.LinearAlgebra.TensorProduct.Tower
 
 /-! # The characteristic polynomial of base change -/
 
-@[expose] public section
+public section
 
 variable {R M} [CommRing R] [AddCommGroup M] [Module R M]
     [Module.Free R M] [Module.Finite R M] (f : M →ₗ[R] M)

--- a/Mathlib/LinearAlgebra/Charpoly/ToMatrix.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/ToMatrix.lean
@@ -20,7 +20,7 @@ public import Mathlib.RingTheory.Finiteness.Prod
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
+++ b/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
@@ -19,7 +19,7 @@ public import Mathlib.SetTheory.Cardinal.Subfield
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/Dimension/Subsingleton.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Subsingleton.lean
@@ -11,7 +11,7 @@ public import Mathlib.LinearAlgebra.Dimension.Basic
 # Dimension of trivial modules
 -/
 
-@[expose] public section
+public section
 
 variable (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M]
 

--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
@@ -17,7 +17,7 @@ public import Mathlib.LinearAlgebra.Dimension.Subsingleton
 - `rank_quotient_eq_of_le_torsion` : `rank M/N = rank M` if `N ≤ torsion M`.
 -/
 
-@[expose] public section
+public section
 
 open Submodule
 

--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Finite.lean
@@ -13,7 +13,7 @@ public import Mathlib.LinearAlgebra.Dimension.Finite
 
 -/
 
-@[expose] public section
+public section
 
 variable {R M : Type*} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M]
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
@@ -17,7 +17,7 @@ public import Mathlib.LinearAlgebra.Eigenspace.Basic
 eigenvalue, characteristic polynomial
 -/
 
-@[expose] public section
+public section
 
 namespace Module
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
@@ -19,7 +19,7 @@ eigenspace, eigenvector, eigenvalue, spectrum, matrix
 
 -/
 
-@[expose] public section
+public section
 
 section SpectrumDiagonal
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Pi.lean
@@ -26,7 +26,7 @@ for commuting endomorphisms but there are important more general situations wher
 
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -21,7 +21,7 @@ endomorphisms.
 
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
@@ -40,7 +40,7 @@ generalized eigenspaces span the whole space.
 eigenspace, eigenvector, eigenvalue, eigen
 -/
 
-@[expose] public section
+public section
 
 open Set Function Module Module
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -32,7 +32,7 @@ such as being nilpotent, having determinant equal to 0, having a non-trivial ker
 
 -/
 
-@[expose] public section
+public section
 
 variable {R K M : Type*} [CommRing R] [IsDomain R] [Field K] [AddCommGroup M]
 variable [Module R M] [Module.Finite R M] [Module.Free R M]

--- a/Mathlib/LinearAlgebra/FiniteSpan.lean
+++ b/Mathlib/LinearAlgebra/FiniteSpan.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Module.Equiv.Basic
 
 -/
 
-@[expose] public section
+public section
 
 open Set Function
 open Submodule (span)

--- a/Mathlib/LinearAlgebra/Finsupp/Span.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Span.lean
@@ -16,7 +16,7 @@ public import Mathlib.LinearAlgebra.Span.Basic
 function with finite support, module, linear algebra
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/FreeModule/Determinant.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Determinant.lean
@@ -20,7 +20,7 @@ free (finite) modules over any commutative ring.
   nontrivial module.
 -/
 
-@[expose] public section
+public section
 
 
 @[simp high]

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -20,7 +20,7 @@ public import Mathlib.LinearAlgebra.FreeModule.Finite.Quotient
 
 -/
 
-@[expose] public section
+public section
 
 open Module Submodule
 

--- a/Mathlib/LinearAlgebra/FreeModule/Int.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Int.lean
@@ -17,7 +17,7 @@ index.
 
 -/
 
-@[expose] public section
+public section
 
 
 variable {ι R M : Type*} {n : ℕ} [CommRing R] [AddCommGroup M]

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -36,7 +36,7 @@ The proof given here uses Newton's method and is taken from Chambert-Loir's note
 
 -/
 
-@[expose] public section
+public section
 
 open Algebra Polynomial
 

--- a/Mathlib/LinearAlgebra/LeftExact.lean
+++ b/Mathlib/LinearAlgebra/LeftExact.lean
@@ -21,7 +21,7 @@ the injectivity part is `LinearMap.lcomp_injective_of_surjective` in the file
 
 -/
 
-@[expose] public section
+public section
 
 namespace LinearMap
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -40,7 +40,7 @@ linearly dependent, linear dependence, linearly independent, linear independence
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Cardinal
 

--- a/Mathlib/LinearAlgebra/Matrix/AbsoluteValue.lean
+++ b/Mathlib/LinearAlgebra/Matrix/AbsoluteValue.lean
@@ -25,7 +25,7 @@ This file proves some bounds on matrices involving absolute values.
   then the determinant of the linear combination is bounded by `n! (s * y * x)^n`
 -/
 
-@[expose] public section
+public section
 
 
 open Matrix

--- a/Mathlib/LinearAlgebra/Matrix/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BaseChange.lean
@@ -21,7 +21,7 @@ This file is a home for results about base change for matrices.
 
 -/
 
-@[expose] public section
+public section
 
 namespace Matrix
 

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Eigs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Eigs.lean
@@ -50,7 +50,7 @@ dependencies are not general enough to unify them. We should refactor
 arbitrary map.
 -/
 
-@[expose] public section
+public section
 
 
 variable {n : Type*} [Fintype n] [DecidableEq n]

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/FiniteField.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/FiniteField.lean
@@ -13,7 +13,7 @@ public import Mathlib.LinearAlgebra.Matrix.CharP
 # Results on characteristic polynomials and traces over finite fields.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean
@@ -15,7 +15,7 @@ public import Mathlib.RingTheory.PowerBasis
 This also includes some miscellaneous results about `minpoly` on matrices.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Ring.NegOnePow
 In this file, we collect various formulas about determinant of matrices.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TwoSidedIdeal
 

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -19,7 +19,7 @@ diagonal matrix (`range`, `ker` and `rank`).
 matrix, diagonal, linear_map
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -28,7 +28,7 @@ matrix
 
 -/
 
-@[expose] public section
+public section
 
 
 variable {m n p R : Type*}

--- a/Mathlib/LinearAlgebra/Matrix/Gershgorin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Gershgorin.lean
@@ -20,7 +20,7 @@ of matrices and some applications.
 * https://en.wikipedia.org/wiki/Gershgorin_circle_theorem
 -/
 
-@[expose] public section
+public section
 
 variable {K n : Type*} [NormedField K] [Fintype n] [DecidableEq n] {A : Matrix n n K}
 

--- a/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
@@ -26,7 +26,7 @@ In particular, we give results about the polynomial given by
 matrix determinant, polynomial
 -/
 
-@[expose] public section
+public section
 
 
 open Matrix Polynomial

--- a/Mathlib/LinearAlgebra/Matrix/ZPow.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ZPow.lean
@@ -25,7 +25,7 @@ The lemma names are taken from `Algebra.GroupWithZero.Power`.
 matrix inverse, matrix powers
 -/
 
-@[expose] public section
+public section
 
 
 open Matrix

--- a/Mathlib/LinearAlgebra/PID.lean
+++ b/Mathlib/LinearAlgebra/PID.lean
@@ -23,7 +23,7 @@ algebra import hierarchy have to depend on the theory of PIDs.
 
 -/
 
-@[expose] public section
+public section
 
 namespace LinearMap
 

--- a/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
@@ -21,7 +21,7 @@ The file contains results connecting perfect pairings and matrices.
 
 -/
 
-@[expose] public section
+public section
 
 namespace Matrix
 

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -23,7 +23,7 @@ We provide API for restricting perfect pairings to submodules and for restrictin
 
 -/
 
-@[expose] public section
+public section
 
 open Function Module Set
 open Submodule (span subset_span)

--- a/Mathlib/LinearAlgebra/Quotient/Card.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Card.lean
@@ -11,7 +11,7 @@ public import Mathlib.GroupTheory.Coset.Basic
 
 /-! Results about the cardinality of a quotient module. -/
 
-@[expose] public section
+public section
 
 namespace Submodule
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -29,7 +29,7 @@ root pairings.
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -13,7 +13,7 @@ public import Mathlib.LinearAlgebra.RootSystem.Finite.G2
 # Supporting lemmas for Geck's construction of a Lie algebra associated to a root system
 -/
 
-@[expose] public section
+public section
 
 open Set
 open FaithfulSMul (algebraMap_injective)

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
@@ -25,7 +25,7 @@ satisfying relations associated to the Cartan matrix of the input root system.
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/SModEq/Pointwise.lean
+++ b/Mathlib/LinearAlgebra/SModEq/Pointwise.lean
@@ -15,7 +15,7 @@ In this file, we record more lemmas about `SModEq` on elements
 of modules or rings.
 -/
 
-@[expose] public section
+public section
 
 open Submodule
 

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Star.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Star.lean
@@ -14,7 +14,7 @@ This file provides some properties about sesquilinear forms `M →ₗ⋆[R] M �
 `StarRing`.
 -/
 
-@[expose] public section
+public section
 
 open Module LinearMap
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -38,7 +38,7 @@ tensor product, finitely generated
 
 -/
 
-@[expose] public section
+public section
 
 open scoped TensorProduct
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Matrix.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Matrix.lean
@@ -19,7 +19,7 @@ Notably, `TensorProduct.toMatrix_map` shows that taking the tensor product of li
 equivalent to taking the Kronecker product of their matrix representations.
 -/
 
-@[expose] public section
+public section
 
 open Matrix Module LinearMap
 open scoped Kronecker

--- a/Mathlib/Order/Bounded.lean
+++ b/Mathlib/Order/Bounded.lean
@@ -15,7 +15,7 @@ the same ideas, or similar results with a few minor differences. The file is div
 different general ideas.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso
 

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -22,7 +22,7 @@ This file contains miscellaneous lemmas about lattices with top or bottom elemen
   Typical examples include `Prop` and `Set α`.
 -/
 
-@[expose] public section
+public section
 
 open Function OrderDual
 

--- a/Mathlib/Order/BoundedOrder/Monotone.lean
+++ b/Mathlib/Order/BoundedOrder/Monotone.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Monotone.Basic
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists SemilatticeSup
 

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.Bounds.Basic
 In this file we prove various results about the behaviour of bounds under monotone/antitone maps.
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/Order/Bounds/Lattice.lean
+++ b/Mathlib/Order/Bounds/Lattice.lean
@@ -18,7 +18,7 @@ In a separate file as we need to import `Mathlib/Data/Set/Lattice.lean`.
 
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*} [Preorder α] {ι : Sort*} {s : ι → Set α}
 

--- a/Mathlib/Order/Bounds/OrderIso.lean
+++ b/Mathlib/Order/Bounds/OrderIso.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Hom.Set
 # Order isomorphisms and bounds.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/CompleteLattice/Finset.lean
+++ b/Mathlib/Order/CompleteLattice/Finset.lean
@@ -17,7 +17,7 @@ See also `Mathlib/Data/Finset/Lattice/Fold.lean`, which is concerned with foldin
 operations over a finset.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid MonoidWithZero
 

--- a/Mathlib/Order/CompleteLattice/Group.lean
+++ b/Mathlib/Order/CompleteLattice/Group.lean
@@ -11,7 +11,7 @@ public import Mathlib.Order.CompleteLattice.Basic
 
 /-! # Complete lattices and groups -/
 
-@[expose] public section
+public section
 
 variable {α : Type*} {ι : Sort*} {κ : ι → Sort*}
   [CompleteLattice α] [Mul α] [MulLeftMono α] [MulRightMono α]

--- a/Mathlib/Order/CompleteLattice/SetLike.lean
+++ b/Mathlib/Order/CompleteLattice/SetLike.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.CompleteSublattice
 This file provides lemmas for the `SetLike` instance for elements of `CompleteSublattice (Set X)`
 -/
 
-@[expose] public section
+public section
 
 attribute [local instance] SetLike.instSubtypeSet
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -15,7 +15,7 @@ rather than complete, lattice. We add a prefix `c` to distinguish them from the 
 complete lattices, giving names `ciSup_xxx` or `ciInf_xxx`.
 -/
 
-@[expose] public section
+public section
 
 -- Guard against import creep
 assert_not_exists Multiset

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -16,7 +16,7 @@ public import Mathlib.Tactic.Subsingleton
 In this file we prove many lemmas like “if `f → +∞`, then `f ± c → +∞`”.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/BigOperators.lean
+++ b/Mathlib/Order/Filter/AtTopBot/BigOperators.lean
@@ -16,7 +16,7 @@ about `Filter.atTop : Filter (Finset _)` and `∏ b ∈ s, f b`.
 These lemmas are useful to build the theory of absolutely convergent series.
 -/
 
-@[expose] public section
+public section
 
 open Filter Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/CompleteLattice.lean
+++ b/Mathlib/Order/Filter/AtTopBot/CompleteLattice.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Filter.AtTopBot.Tendsto
 # `Filter.atTop` and `Filter.atBot` in (conditionally) complete lattices
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/Disjoint.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Disjoint.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Interval.Set.Disjoint
 # Disjointness of `Filter.atTop` and `Filter.atBot`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/Field.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Field.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Filter.AtTopBot.Ring
 # Convergence to ±infinity in linear ordered (semi)fields
 -/
 
-@[expose] public section
+public section
 
 namespace Filter
 

--- a/Mathlib/Order/Filter/AtTopBot/Finite.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Finite.lean
@@ -16,7 +16,7 @@ This file contains results on `Filter.atTop` and `Filter.atBot` that depend on
 the finiteness theory developed in Mathlib.
 -/
 
-@[expose] public section
+public section
 
 variable {ι ι' α β γ : Type*}
 

--- a/Mathlib/Order/Filter/AtTopBot/Finset.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Finset.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Interval.Finset.Defs
 # `Filter.atTop` and `Filter.atBot` filters and finite sets.
 -/
 
-@[expose] public section
+public section
 
 variable {ι ι' α β γ : Type*}
 

--- a/Mathlib/Order/Filter/AtTopBot/Floor.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Floor.lean
@@ -14,7 +14,7 @@ public import Mathlib.Tactic.Positivity.Basic
 # `a * c ^ n < (n - d)!` holds true for sufficiently large `n`.
 -/
 
-@[expose] public section
+public section
 
 open Filter
 open scoped Nat

--- a/Mathlib/Order/Filter/AtTopBot/Group.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Group.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Filter.AtTopBot.Monoid
 # Convergence to ±infinity in ordered commutative groups
 -/
 
-@[expose] public section
+public section
 
 variable {α G : Type*}
 open Set

--- a/Mathlib/Order/Filter/AtTopBot/Interval.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Interval.lean
@@ -16,7 +16,7 @@ This file contains some lemmas about how filters `Ixx` behave as the endpoints t
 
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/Map.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Map.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Interval.Set.OrderIso
 # Map and comap of `Filter.atTop` and `Filter.atBot`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Order/Filter/AtTopBot/ModEq.lean
+++ b/Mathlib/Order/Filter/AtTopBot/ModEq.lean
@@ -19,7 +19,7 @@ public import Mathlib.Order.Filter.AtTopBot.Monoid
 In this file we prove that `m ≡ d [MOD n]` frequently as `m → ∞`.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter

--- a/Mathlib/Order/Filter/AtTopBot/Monoid.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Monoid.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Filter.AtTopBot.Tendsto
 # Convergence to ±infinity in ordered commutative monoids
 -/
 
-@[expose] public section
+public section
 
 variable {α M : Type*}
 

--- a/Mathlib/Order/Filter/AtTopBot/Prod.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Prod.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Filter.Prod
 # `Filter.atTop` and `Filter.atBot` filters on products
 -/
 
-@[expose] public section
+public section
 
 variable {ι ι' α β γ : Type*}
 

--- a/Mathlib/Order/Filter/AtTopBot/Ring.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Ring.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Filter.AtTopBot.Group
 # Convergence to ±infinity in ordered rings
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*}
 

--- a/Mathlib/Order/Filter/AtTopBot/Tendsto.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Tendsto.lean
@@ -15,7 +15,7 @@ In this file we prove many lemmas on the combination of `Filter.atTop` and `Filt
 and `Tendsto`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Order/Filter/Curry.lean
+++ b/Mathlib/Order/Filter/Curry.lean
@@ -46,7 +46,7 @@ describing the product of two sets, namely `s ×ˢ t = fst ⁻¹' s ∩ snd ⁻�
 uniform convergence, curried filters, product filters
 -/
 
-@[expose] public section
+public section
 
 
 namespace Filter

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.Metrizable.Real
 This file compiles filter-related results about `ℝ`, `ℝ≥0` and `ℝ≥0∞`.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter ENNReal

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.Filter.Basic
 This file proves that finitely many conditions eventually hold if each of them eventually holds.
 -/
 
-@[expose] public section
+public section
 
 open Function Set Order
 open scoped symmDiff

--- a/Mathlib/Order/Filter/IndicatorFunction.lean
+++ b/Mathlib/Order/Filter/IndicatorFunction.lean
@@ -20,7 +20,7 @@ Properties of additive and multiplicative indicator functions involving `=ᶠ` a
 indicator, characteristic, filter
 -/
 
-@[expose] public section
+public section
 
 variable {α β M E : Type*}
 

--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -18,7 +18,7 @@ This file proves several lemmas about
 `IsBounded`, `IsBoundedUnder`, `IsCobounded` and `IsCoboundedUnder`.
 -/
 
-@[expose] public section
+public section
 
 open Set Function
 

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.Filter.Bases.Basic
 
 assert_not_exists Set.Finite
 
-@[expose] public section
+public section
 
 open Set Filter Function
 

--- a/Mathlib/Order/Filter/ListTraverse.lean
+++ b/Mathlib/Order/Filter/ListTraverse.lean
@@ -14,7 +14,7 @@ In this file we prove basic properties (monotonicity, membership)
 for `Traversable.traverse f l`, where `f : β → Filter α` and `l : List β`.
 -/
 
-@[expose] public section
+public section
 
 open Set List
 

--- a/Mathlib/Order/Filter/Tendsto.lean
+++ b/Mathlib/Order/Filter/Tendsto.lean
@@ -20,7 +20,7 @@ some `x` and `u n` belongs to a set `M` for `n` large enough then `x` is in the 
 which is a special case of `mem_closure_of_tendsto` from `Topology/Basic`.
 -/
 
-@[expose] public section
+public section
 
 open Set Filter
 

--- a/Mathlib/Order/Interval/Finset/DenselyOrdered.lean
+++ b/Mathlib/Order/Interval/Finset/DenselyOrdered.lean
@@ -16,7 +16,7 @@ public import Mathlib.Order.Interval.Finset.Basic
 
 -/
 
-@[expose] public section
+public section
 
 variable {X : Type*} [LinearOrder X] [LocallyFiniteOrder X]
 

--- a/Mathlib/Order/Interval/Finset/SuccPred.lean
+++ b/Mathlib/Order/Interval/Finset/SuccPred.lean
@@ -25,7 +25,7 @@ Please keep in sync with:
 Copy over `insert` lemmas from `Mathlib/Order/Interval/Finset/Nat.lean`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -19,7 +19,7 @@ in this file can use definitions from `Data.Set.Lattice`, including `Disjoint`.
 We consider various intersections and unions of half infinite intervals.
 -/
 
-@[expose] public section
+public section
 
 
 universe u v w

--- a/Mathlib/Order/Interval/Set/Fin.lean
+++ b/Mathlib/Order/Interval/Set/Fin.lean
@@ -25,7 +25,7 @@ under the following operations:
 - `Fin.rev`.
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/Order/Interval/Set/Image.lean
+++ b/Mathlib/Order/Interval/Set/Image.lean
@@ -16,7 +16,7 @@ This file shows many variants of the fact that a monotone function `f` sends an 
 endpoints `a` and `b` to the interval with endpoints `f a` and `f b`.
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*} {f : α → β}
 

--- a/Mathlib/Order/Interval/Set/Limit.lean
+++ b/Mathlib/Order/Interval/Set/Limit.lean
@@ -17,7 +17,7 @@ and `m : Set.Ici j` is successor limit, then
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -14,7 +14,7 @@ Since every pair of elements are comparable in a linear order, intervals over th
 better behaved. This file collects their properties under this assumption.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso
 

--- a/Mathlib/Order/Interval/Set/Monotone.lean
+++ b/Mathlib/Order/Interval/Set/Monotone.lean
@@ -16,7 +16,7 @@ In this file we prove that `Set.Ici` etc. are monotone/antitone functions. We al
 about functions monotone on intervals in `SuccOrder`s.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
@@ -28,7 +28,7 @@ some convenience lemmas for characterising closed intervals in certain concrete 
 * `Set.Nonempty.eq_Icc_iff_int`: characterisation of closed intervals for `ℤ`.
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*} {I : Set α}
 

--- a/Mathlib/Order/Interval/Set/OrderEmbedding.lean
+++ b/Mathlib/Order/Interval/Set/OrderEmbedding.lean
@@ -17,7 +17,7 @@ is an interval in the domain.
 Note that similar statements about images require the range to be order-connected.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/Interval/Set/Pi.lean
+++ b/Mathlib/Order/Interval/Set/Pi.lean
@@ -19,7 +19,7 @@ In this we prove various simple lemmas about intervals in `Π i, α i`. Closed i
 usually include the corresponding products as proper subsets.
 -/
 
-@[expose] public section
+public section
 
 -- Porting note: Added, since dot notation no longer works on `Function.update`
 open Function

--- a/Mathlib/Order/Interval/Set/SuccOrder.lean
+++ b/Mathlib/Order/Interval/Set/SuccOrder.lean
@@ -17,7 +17,7 @@ which is not the maximum, we have `↑(Order.succ i) = Order.succ ↑i`.
 
 -/
 
-@[expose] public section
+public section
 
 namespace Set
 

--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -25,7 +25,7 @@ Please keep in sync with:
 Copy over `insert` lemmas from `Mathlib/Order/Interval/Finset/Nat.lean`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Order/Interval/Set/SurjOn.lean
+++ b/Mathlib/Order/Interval/Set/SurjOn.lean
@@ -16,7 +16,7 @@ endpoints in the range.  This is expressed in this file using `Set.surjOn`, and 
 permutations of interval endpoints.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*} {β : Type*} [LinearOrder α] [PartialOrder β] {f : α → β}

--- a/Mathlib/Order/Interval/Set/Union.lean
+++ b/Mathlib/Order/Interval/Set/Union.lean
@@ -17,7 +17,7 @@ concerning infinite unions in `Mathlib/Order/Interval/Set/Disjoint.lean` because
 `Finset.range`.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/Interval/Set/WithBotTop.lean
+++ b/Mathlib/Order/Interval/Set/WithBotTop.lean
@@ -16,7 +16,7 @@ In this file we prove various lemmas about `Set.image`s and `Set.preimage`s of i
 `some : α → WithTop α` and `some : α → WithBot α`.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/Iterate.lean
+++ b/Mathlib/Order/Iterate.lean
@@ -18,7 +18,7 @@ Current selection of inequalities is motivated by formalization of the rotation 
 a circle homeomorphism.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Order/KonigLemma.lean
+++ b/Mathlib/Order/KonigLemma.lean
@@ -52,7 +52,7 @@ Formulate the lemma as a statement about graphs.
 
 -/
 
-@[expose] public section
+public section
 
 open Set
 section Sequence

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -51,7 +51,7 @@ monotone, strictly monotone, antitone, strictly antitone, increasing, strictly i
 decreasing, strictly decreasing
 -/
 
-@[expose] public section
+public section
 
 open Function OrderDual
 

--- a/Mathlib/Order/Monotone/Extension.lean
+++ b/Mathlib/Order/Monotone/Extension.lean
@@ -15,7 +15,7 @@ In this file we prove that if a function is monotone and is bounded on a set `s`
 monotone extension to the whole space.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Order/Monotone/Odd.lean
+++ b/Mathlib/Order/Monotone/Odd.lean
@@ -17,7 +17,7 @@ provided that it is monotone on `Set.Ici 0`, see `monotone_of_odd_of_monotoneOn_
 prove versions of this lemma for `Antitone`, `StrictMono`, and `StrictAnti`.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Order/Monotone/Union.lean
+++ b/Mathlib/Order/Monotone/Union.lean
@@ -17,7 +17,7 @@ of a more general statement where one deduces monotonicity on a union from monot
 set.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -15,7 +15,7 @@ This file shows that non-empty finite sets in a preorder have minimal/maximal el
 contrapositively that non-empty sets without minimal or maximal elements are infinite.
 -/
 
-@[expose] public section
+public section
 
 variable {ι α β : Type*}
 

--- a/Mathlib/Order/PrimeSeparator.lean
+++ b/Mathlib/Order/PrimeSeparator.lean
@@ -26,7 +26,7 @@ ideal, filter, prime, distributive lattice
 (1938)][Sto1938]
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Order/ScottContinuity/Complete.lean
+++ b/Mathlib/Order/ScottContinuity/Complete.lean
@@ -18,7 +18,7 @@ public import Mathlib.Order.ScottContinuity.Prod
 
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*}
 

--- a/Mathlib/Order/ScottContinuity/Prod.lean
+++ b/Mathlib/Order/ScottContinuity/Prod.lean
@@ -19,7 +19,7 @@ public import Mathlib.Order.Bounds.Lattice
 
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/Set.lean
+++ b/Mathlib/Order/Set.lean
@@ -10,7 +10,7 @@ public import Mathlib.Order.TypeTags
 
 /-! # `Set.range` on `WithBot` and `WithTop` -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -16,7 +16,7 @@ then `↑m : J` is not maximal in `J`.
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Order/SuccPred/InitialSeg.lean
+++ b/Mathlib/Order/SuccPred/InitialSeg.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.SuccPred.Limit
 We establish some connections between initial segment embeddings and successors and predecessors.
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*} {a b : α} [PartialOrder α] [PartialOrder β]
 

--- a/Mathlib/Order/SuccPred/IntervalSucc.lean
+++ b/Mathlib/Order/SuccPred/IntervalSucc.lean
@@ -25,7 +25,7 @@ In this file we prove
 For the latter lemma, we also prove various order dual versions.
 -/
 
-@[expose] public section
+public section
 
 
 open Set Order

--- a/Mathlib/Order/SuccPred/Relation.lean
+++ b/Mathlib/Order/SuccPred/Relation.lean
@@ -14,7 +14,7 @@ This file contains properties about relations on types with a `SuccOrder`
 and their closure operations (like the transitive closure).
 -/
 
-@[expose] public section
+public section
 
 open Function Order Relation Set
 

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -23,7 +23,7 @@ on the underlying order (such as `PartialOrder` and `LinearOrder`).
 * Order equivalence between upper/lower sets and antichains.
 -/
 
-@[expose] public section
+public section
 
 open OrderDual Set
 

--- a/Mathlib/Order/UpperLower/Fibration.lean
+++ b/Mathlib/Order/UpperLower/Fibration.lean
@@ -11,7 +11,7 @@ public import Mathlib.Order.UpperLower.Basic
 # Upper/lower sets and fibrations
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Order/UpperLower/LocallyFinite.lean
+++ b/Mathlib/Order/UpperLower/LocallyFinite.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.UpperLower.Closure
 In this file we characterise the interaction of `UpperSet`/`LowerSet` and `LocallyFiniteOrder`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Set

--- a/Mathlib/Order/ZornAtoms.lean
+++ b/Mathlib/Order/ZornAtoms.lean
@@ -16,7 +16,7 @@ In this file we use Zorn's lemma to prove that a partial order is atomic if ever
 statement.
 -/
 
-@[expose] public section
+public section
 
 
 open Set


### PR DESCRIPTION
Removes `@[expose]` from 122 files in LinearAlgebra and Order.

🤖 Prepared with Claude Code