### PR TITLE
[Merged by Bors] - chore: remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -50,7 +50,7 @@ polynomials `preΨₙ`, `ΨSqₙ`, and `Φₙ` all have their expected leading t
 elliptic curve, division polynomial, torsion point
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/IsomOfJ.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/IsomOfJ.lean
@@ -20,7 +20,7 @@ public import Mathlib.FieldTheory.IsSepClosed
 
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Descent.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Descent.lean
@@ -30,7 +30,7 @@ that `P` descends along `P'` from a codescent property of ring homomorphisms.
 
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/FlatMono.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FlatMono.lean
@@ -13,7 +13,7 @@ public import Mathlib.AlgebraicGeometry.Morphisms.FlatDescent
 We show the titular result `AlgebraicGeometry.IsOpenImmersion.of_flat_of_mono` by fpqc descent.
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -27,7 +27,7 @@ statement vanishing statement `σ_comp_P_eq_zero` for the `P q`.
 
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory CategoryTheory.Category CategoryTheory.Limits

--- a/Mathlib/AlgebraicTopology/DoldKan/Notations.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Notations.lean
@@ -19,7 +19,7 @@ as `N[X]` for the normalized subcomplex in the case `C` is an abelian category.
 
 -/
 
-@[expose] public section
+public section
 
 
 @[inherit_doc]

--- a/Mathlib/AlgebraicTopology/ModelCategory/JoyalTrick.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/JoyalTrick.lean
@@ -23,7 +23,7 @@ namely that cofibrations are stable under composition and cobase change.
 
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Category Limits MorphismProperty
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory/MorphismProperty.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/MorphismProperty.lean
@@ -20,7 +20,7 @@ the category `SimplexCategory.Truncated d`.
 
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveNondegenerate.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveNondegenerate.lean
@@ -17,7 +17,7 @@ the monotone map `s.obj : Fin (n + 1) → X` is strictly monotone.
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Condensed/Epi.lean
+++ b/Mathlib/Condensed/Epi.lean
@@ -19,7 +19,7 @@ as those morphisms which are objectwise surjective on `Stonean` (see
 `CondensedSet.epi_iff_surjective_on_stonean` and `CondensedMod.epi_iff_surjective_on_stonean`).
 -/
 
-@[expose] public section
+public section
 
 universe v u w u' v'
 

--- a/Mathlib/Condensed/Light/TopComparison.lean
+++ b/Mathlib/Condensed/Light/TopComparison.lean
@@ -16,7 +16,7 @@ We define the functor `topCatToLightCondSet : TopCat.{u} ⥤ LightCondSet.{u}`.
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Control/Lawful.lean
+++ b/Mathlib/Control/Lawful.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.Basic
 # Functor Laws, applicative laws, and monad Laws
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Deprecated/Aliases.lean
+++ b/Mathlib/Deprecated/Aliases.lean
@@ -12,4 +12,4 @@ Deprecated aliases can be dumped here if they are no longer used in Mathlib,
 to avoid needing their imports if they are otherwise unnecessary.
 -/
 
-@[expose] public section
+public section

--- a/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
@@ -19,7 +19,7 @@ are motivated by the proof of the von Neumann Mean Ergodic Theorem,
 see `LinearIsometry.tendsto_birkhoffAverage_orthogonalProjection`.
 -/
 
-@[expose] public section
+public section
 
 open Function Set Filter
 open scoped Topology ENNReal Uniformity

--- a/Mathlib/Dynamics/BirkhoffSum/QuasiMeasurePreserving.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/QuasiMeasurePreserving.lean
@@ -21,7 +21,7 @@ Given a map `f` and measure `μ`, under the assumption of `QuasiMeasurePreservin
 
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory.Measure.QuasiMeasurePreserving
 

--- a/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
@@ -30,7 +30,7 @@ if it is surjective and the preimages of `1` under iterations of `f` are dense i
 This theorem applies, e.g., to the map `z ↦ n • z` on the additive circle or a torus.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Filter Set Function
 open scoped Pointwise Topology

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -30,7 +30,7 @@ This file contains proofs of ergodicity for maps of the additive circle.
 
 -/
 
-@[expose] public section
+public section
 
 
 open Set Function MeasureTheory MeasureTheory.Measure Filter Metric

--- a/Mathlib/Dynamics/Ergodic/AddCircleAdd.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircleAdd.lean
@@ -16,7 +16,7 @@ In this file we prove that rotation of `AddCircle p` by `a` is ergodic
 if and only if `a` has infinite order (in other words, if `a / p` is irrational).
 -/
 
-@[expose] public section
+public section
 
 open Metric MeasureTheory AddSubgroup
 open scoped Pointwise

--- a/Mathlib/Dynamics/Ergodic/Extreme.lean
+++ b/Mathlib/Dynamics/Ergodic/Extreme.lean
@@ -18,7 +18,7 @@ iff it is an extreme point of the set of invariant measures of `f` with the same
 We also specialize this result to probability measures.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set Function MeasureTheory Measure ProbabilityTheory
 open scoped NNReal ENNReal Topology

--- a/Mathlib/Dynamics/Ergodic/Function.lean
+++ b/Mathlib/Dynamics/Ergodic/Function.lean
@@ -18,7 +18,7 @@ We also formulate a version for `MeasureTheory.AEEqFun` functions
 with all a.e. equalities replaced with equalities in the quotient space.
 -/
 
-@[expose] public section
+public section
 
 open Function Set Filter MeasureTheory Topology TopologicalSpace
 

--- a/Mathlib/Dynamics/Ergodic/RadonNikodym.lean
+++ b/Mathlib/Dynamics/Ergodic/RadonNikodym.lean
@@ -25,7 +25,7 @@ It isn't clear if the finiteness assumptions are optimal in this file.
 We should either weaken them, or describe an example showing that it's impossible.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Measure Set
 

--- a/Mathlib/Dynamics/FixedPoints/Prufer.lean
+++ b/Mathlib/Dynamics/FixedPoints/Prufer.lean
@@ -12,7 +12,7 @@ public import Mathlib.Dynamics.FixedPoints.Basic
 # Results about pointwise operations on sets with iteration.
 -/
 
-@[expose] public section
+public section
 
 
 open Pointwise

--- a/Mathlib/Dynamics/FixedPoints/Topology.lean
+++ b/Mathlib/Dynamics/FixedPoints/Topology.lean
@@ -21,7 +21,7 @@ Currently this file contains two lemmas:
 fixed points, iterates
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*} [TopologicalSpace α] [T2Space α] {f : α → α}

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -19,7 +19,7 @@ public import Mathlib.Dynamics.PeriodicPts.Defs
 # Extra lemmas about periodic points
 -/
 
-@[expose] public section
+public section
 
 open Nat Set
 

--- a/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
@@ -53,7 +53,7 @@ the entropy of `φ '' F` is lower than the entropy of `F` if `φ` is uniformly c
 entropy, semiconjugacy
 -/
 
-@[expose] public section
+public section
 
 open Function Prod Set Uniformity UniformSpace
 open scoped SetRel

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -62,7 +62,7 @@ All linters imported here have no bulk imports;
 
 -/
 
-@[expose] public section
+public section
 
 /-- Define a linter set of all mathlib syntax linters which are enabled by default.
 

--- a/Mathlib/Lean/LocalContext.lean
+++ b/Mathlib/Lean/LocalContext.lean
@@ -12,7 +12,7 @@ public import Lean.LocalContext
 # Additional methods about `LocalContext`
 -/
 
-@[expose] public section
+public section
 
 namespace Lean.LocalContext
 

--- a/Mathlib/Logic/Encodable/Lattice.lean
+++ b/Mathlib/Logic/Encodable/Lattice.lean
@@ -21,7 +21,7 @@ This is a separate file, to avoid unnecessary imports in basic files.
 Previously some of these results were in the `MeasureTheory` folder.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Logic/Equiv/Pairwise.lean
+++ b/Mathlib/Logic/Equiv/Pairwise.lean
@@ -12,7 +12,7 @@ public import Mathlib.Logic.Pairwise
 # Interaction of equivalences with `Pairwise`
 -/
 
-@[expose] public section
+public section
 
 open scoped Function -- required for scoped `on` notation
 

--- a/Mathlib/Logic/Function/ULift.lean
+++ b/Mathlib/Logic/Function/ULift.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.TypeStar
 # `ULift` and `PLift`
 -/
 
-@[expose] public section
+public section
 
 theorem ULift.down_injective {α : Type*} : Function.Injective (@ULift.down α)
   | ⟨a⟩, ⟨b⟩, _ => by congr

--- a/Mathlib/Logic/Lemmas.lean
+++ b/Mathlib/Logic/Lemmas.lean
@@ -20,7 +20,7 @@ We spell those lemmas out with `dite` and `ite` rather than the `if then else` n
 would result in less delta-reduced statements.
 -/
 
-@[expose] public section
+public section
 
 theorem iff_assoc {a b c : Prop} : ((a ↔ b) ↔ c) ↔ (a ↔ (b ↔ c)) := by tauto
 theorem iff_left_comm {a b c : Prop} : (a ↔ (b ↔ c)) ↔ (b ↔ (a ↔ c)) := by tauto

--- a/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
@@ -18,7 +18,7 @@ This file proves that the set of zeros of a multivariable polynomial is a defina
 
 -/
 
-@[expose] public section
+public section
 
 namespace FirstOrder
 

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LongExactSequence.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LongExactSequence.lean
@@ -27,7 +27,7 @@ to specialize API about long exact sequences to group cohomology.
 
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LongExactSequence.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LongExactSequence.lean
@@ -27,7 +27,7 @@ to specialize API about long exact sequences to group homology.
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -25,7 +25,7 @@ use of ordinal numbers. This is done within this file.
 cardinal arithmetic (for infinite cardinals)
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Module Finsupp Ordinal.log
 

--- a/Mathlib/SetTheory/Cardinal/CountableCover.lean
+++ b/Mathlib/SetTheory/Cardinal/CountableCover.lean
@@ -19,7 +19,7 @@ cardinality `≤ a`. Then `t` itself has cardinality at most `a`. This is proved
 Versions are also given when `t = univ`, and with `= a` instead of `≤ a`.
 -/
 
-@[expose] public section
+public section
 
 open Set Order Filter
 open scoped Cardinal

--- a/Mathlib/SetTheory/Cardinal/Embedding.lean
+++ b/Mathlib/SetTheory/Cardinal/Embedding.lean
@@ -33,7 +33,7 @@ Let `s : Set α` be a finite set.
   map from `Fin (m + n) ↪ α` to `Fin m ↪ α` is surjective.
 -/
 
-@[expose] public section
+public section
 
 open Set Fin Function Function.Embedding
 

--- a/Mathlib/SetTheory/Cardinal/Finsupp.lean
+++ b/Mathlib/SetTheory/Cardinal/Finsupp.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Finsupp.Multiset
 
 /-! # Results on the cardinality of finitely supported functions and multisets. -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/SetTheory/Cardinal/NatCount.lean
+++ b/Mathlib/SetTheory/Cardinal/NatCount.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Set.Card
 This file provides lemmas about the relation of `Nat.count` with cardinality functions.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -14,7 +14,7 @@ public import Mathlib.SetTheory.Ordinal.Principal
 This file collects results about the cardinality of different ordinal operations.
 -/
 
-@[expose] public section
+public section
 
 universe u v
 open Cardinal Ordinal Set

--- a/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
+++ b/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
@@ -18,7 +18,7 @@ This file proves variants of the infinite pigeonhole principle.
 Generalize universes of results.
 -/
 
-@[expose] public section
+public section
 
 open Order Ordinal Set
 

--- a/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
+++ b/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
@@ -27,7 +27,7 @@ Cardinals are naturally ordered by `α ≤ β ↔ ∃ f : a → β, Injective f`
 Cardinals are defined and further developed in the folder `SetTheory.Cardinal`.
 -/
 
-@[expose] public section
+public section
 
 
 open Set Function

--- a/Mathlib/SetTheory/Cardinal/Subfield.lean
+++ b/Mathlib/SetTheory/Cardinal/Subfield.lean
@@ -21,7 +21,7 @@ explicit universal objects.
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/SetTheory/Cardinal/UnivLE.lean
+++ b/Mathlib/SetTheory/Cardinal/UnivLE.lean
@@ -12,7 +12,7 @@ public import Mathlib.SetTheory.Ordinal.Basic
 # UnivLE and cardinals
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Testing/Plausible/Sampleable.lean
+++ b/Mathlib/Testing/Plausible/Sampleable.lean
@@ -15,7 +15,7 @@ This module contains `Plausible.Shrinkable` and `Plausible.SampleableExt` instan
 types.
 -/
 
-@[expose] public section
+public section
 
 namespace Plausible
 

--- a/Mathlib/Testing/Plausible/Testable.lean
+++ b/Mathlib/Testing/Plausible/Testable.lean
@@ -12,7 +12,7 @@ public import Mathlib.Logic.Basic
 This module contains `Plausible.Testable` and `Plausible.PrintableProb` instances for mathlib types.
 -/
 
-@[expose] public section
+public section
 
 namespace Plausible
 


### PR DESCRIPTION
Removes `@[expose]` from 47 files in SetTheory, Dynamics, RepresentationTheory, AlgebraicTopology, and other directories.

🤖 Prepared with Claude Code