### PR TITLE
[Merged by Bors] - fix(Tactic/TacticAnalysis): analyze tactics inside `have ... := by ...`

### DIFF
--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -71,6 +71,29 @@ example : Fact (x = z) where
     rw [xy]
     rw [yz]
 
+-- Tactics inside `have ... := by ...` should be analyzed.
+-- Previously these were missed because `have ... := by ...` is parsed as one node.
+/--
+warning: Try this: rw [xy, yz]
+-/
+#guard_msgs in
+example : x = z := by
+  have _h : x = z := by
+    rw [xy]
+    rw [yz]
+  exact _h
+
+-- Same for `let ... := by ...`
+/--
+warning: Try this: rw [xy, yz]
+-/
+#guard_msgs in
+example : x = z := by
+  let _h : x = z := by
+    rw [xy]
+    rw [yz]
+  exact _h
+
 universe u
 
 def a : PUnit.{u} := ⟨⟩
@@ -208,6 +231,15 @@ example : ∀ a b : Unit, a = b := by
 example : ∀ a b : Unit, a = b := by
   intro a b
   rfl
+
+-- Intros separated by an intervening tactic should NOT be merged.
+-- Regression test for a bug where tactics were incorrectly grouped across intervening tactics.
+#guard_msgs in
+example : True → ∀ n > 0, True := by
+  intro h
+  have := 0
+  intro n hn
+  trivial
 
 end introMerge
 


### PR DESCRIPTION
This PR fixes TacticAnalysis to correctly process tactics inside term-level `by` blocks such as `have h := by ...`. Previously, these tactics were missed.

The fix is simple: move the sequencing operator check before the `.original` head info check. This is needed because the `tacticSeq` nodes inside `have := by` have synthetic source info rather than `.original`.

See: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/TacticAnalysis.20ignores.20tactics.20in.20have/near/565486129

🤖 Prepared with Claude Code