### PR TITLE
[Merged by Bors] - chore(Geometry/Euclidean/SignedDist): remove `privateInPublic`

### DIFF
--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -39,18 +39,15 @@ variable [NormedAddTorsor V P]
 
 section signedDist
 
-set_option backward.privateInPublic true in
 /-- Auxiliary definition for `signedDist`. It is the underlying linear map of `signedDist`. -/
-private noncomputable def signedDistLinear (v : V) : V →ₗ[ℝ] P →ᴬ[ℝ] ℝ where
+noncomputable def signedDistLinear (v : V) : V →ₗ[ℝ] P →ᴬ[ℝ] ℝ where
   toFun w := .const ℝ P ⟪-normalize v, w⟫
   map_add' x y := by ext; simp [inner_add_right]
   map_smul' r x := by ext; simp [inner_smul_right]
 
-private lemma signedDistLinear_apply (v w : V) :
+lemma signedDistLinear_apply (v w : V) :
     signedDistLinear v w = .const ℝ P ⟪-normalize v, w⟫ := rfl
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 /--
 The signed distance between two points `p` and `q`, in the direction of a reference vector `v`.
 It is the size of `q - p` in the direction of `v`.

--- a/Mathlib/Geometry/Euclidean/SignedDist.lean
+++ b/Mathlib/Geometry/Euclidean/SignedDist.lean
@@ -39,15 +39,6 @@ variable [NormedAddTorsor V P]
 
 section signedDist
 
-/-- Auxiliary definition for `signedDist`. It is the underlying linear map of `signedDist`. -/
-noncomputable def signedDistLinear (v : V) : V →ₗ[ℝ] P →ᴬ[ℝ] ℝ where
-  toFun w := .const ℝ P ⟪-normalize v, w⟫
-  map_add' x y := by ext; simp [inner_add_right]
-  map_smul' r x := by ext; simp [inner_smul_right]
-
-lemma signedDistLinear_apply (v w : V) :
-    signedDistLinear v w = .const ℝ P ⟪-normalize v, w⟫ := rfl
-
 /--
 The signed distance between two points `p` and `q`, in the direction of a reference vector `v`.
 It is the size of `q - p` in the direction of `v`.
@@ -58,10 +49,12 @@ TODO: once we have a topology on `P →ᴬ[ℝ] ℝ`, the type should be `P →�
 noncomputable def signedDist (v : V) : P →ᵃ[ℝ] P →ᴬ[ℝ] ℝ where
   toFun p := (innerSL ℝ (normalize v)).toContinuousAffineMap.comp
     (ContinuousAffineMap.id ℝ P -ᵥ .const ℝ P p)
-  linear := signedDistLinear v
+  linear := {
+    toFun w := .const ℝ P ⟪-normalize v, w⟫
+    map_add' x y := by ext; simp [inner_add_right]
+    map_smul' r x := by ext; simp [inner_smul_right] }
   map_vadd' p v' := by
     ext q
-    rw [signedDistLinear_apply]
     simp [vsub_vadd_eq_vsub_sub, inner_sub_right, ← sub_eq_neg_add]
 
 variable (v w : V) (p q r : P)


### PR DESCRIPTION
When I originally PRed `signedDistLinear`, I wasn't sure whether it should be marked `private`. It seems now that it should not have been private, because this violates `privateInPublic`. This PR fixes that.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
