### PR TITLE
[Merged by Bors] - chore(Lean/Meta/RefinedDiscrTree/Basic): remove `privateInPublic`

### DIFF
--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -293,7 +293,12 @@ namespace RefinedDiscrTree
 
 variable {α : Type}
 
-/-- Format a `RefinedDiscrTree`. -/
+/-- Format a `RefinedDiscrTree` as a flowchart.
+- Non-terminal nodes are of the form `{key} =>`, followed by all of the following nodes,
+  indented with 2 more spaces.
+- Terminal nodes have either "entries", containing the return values,
+  or "pending entries", for nodes that have not been evaluated/expanded.
+-/
 partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   let lines := tree.root.fold (init := #[]) fun lines key trie =>
     lines.push (Format.nest 2 f!"{key} =>{Format.line}{go trie}")

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -298,6 +298,33 @@ variable {α : Type}
   indented with 2 more spaces.
 - Terminal nodes have either "entries", containing the return values,
   or "pending entries", for nodes that have not been evaluated/expanded.
+
+For example:
+```
+Discrimination tree flowchart:
+⟨HMul.hMul, 6⟩ =>
+  ⟨Int, 0⟩ =>
+    ⟨Int, 0⟩ =>
+      * =>
+        * =>
+          *0 =>
+            *0 =>
+              pending entries: #[mul_self]
+            *1 =>
+              entries: #[mul_comm]
+            ⟨Neg.neg, 3⟩ =>
+              ⟨Int, 0⟩ =>
+                * =>
+                  *1 =>
+                    entries: #[mul_neg]
+            1 =>
+              pending entries: #[mul_one]
+          ⟨Neg.neg, 3⟩ =>
+            pending entries: #[neg_mul]
+          1 =>
+            *0 =>
+              entries: #[one_mul]
+```
 -/
 partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   let lines := tree.root.fold (init := #[]) fun lines key trie =>
@@ -305,7 +332,7 @@ partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   if lines.size = 0 then
     f!"<empty discrimination tree>"
   else
-    "Discrimination tree flowchart:" ++ Format.joinSep lines.toList "\n"
+    "Discrimination tree flowchart:\n" ++ Format.joinSep lines.toList "\n"
 where
   /-- Auxiliary function for `RefinedDiscrTree.format`. -/
   go (trie : TrieIndex) : Format := Id.run do

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -51,13 +51,12 @@ inductive Key where
   | proj (typeName : Name) (idx nargs : Nat)
   deriving Inhabited, BEq
 
-set_option backward.privateInPublic true in
 /-
 At the root, `.const` is the most common key, and it is very uncommon
 to get the same constant name with a different arity.
 So for performance, we just use `hash name` to hash `.const name _`.
 -/
-private nonrec def Key.hash : Key → UInt64
+protected def Key.hash : Key → UInt64
   | .star                => 0
   | .labelledStar id     => mixHash 5 <| hash id
   | .opaque              => 1
@@ -70,12 +69,9 @@ private nonrec def Key.hash : Key → UInt64
   | .«forall»            => 4
   | .proj name idx nargs => mixHash (hash nargs) <| mixHash (hash name) (hash idx)
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 instance : Hashable Key := ⟨Key.hash⟩
 
-set_option backward.privateInPublic true in
-private def Key.format : Key → Format
+def Key.format : Key → Format
   | .star                   => f!"*"
   | .labelledStar id        => f!"*{id}"
   | .opaque                 => "◾"
@@ -89,12 +85,8 @@ private def Key.format : Key → Format
   | .forall                 => "∀"
   | .proj name idx nargs    => f!"⟨{name}.{idx}, {nargs}⟩"
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 instance : ToFormat Key := ⟨Key.format⟩
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 /--
 Converts an entry (i.e., `List Key`) to the discrimination tree into
 `MessageData` that is more user-friendly.
@@ -187,13 +179,10 @@ inductive StackEntry where
   /-- `.expr` is an expression that will be indexed. -/
   | expr (info : ExprInfo)
 
-set_option backward.privateInPublic true in
-private def StackEntry.format : StackEntry → Format
+def StackEntry.format : StackEntry → Format
   | .star => f!".star"
   | .expr info => f!".expr {info.expr}"
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 instance : ToFormat StackEntry := ⟨StackEntry.format⟩
 
 /-- A `LazyEntry` represents a snapshot of the computation of encoding an `Expr` as `Array Key`.
@@ -241,8 +230,7 @@ def mkInitLazyEntry (labelledStars : Bool) : MetaM LazyEntry :=
     labelledStars? := if labelledStars then some #[] else none
   }
 
-set_option backward.privateInPublic true in
-private def LazyEntry.format (entry : LazyEntry) : Format := Id.run do
+def LazyEntry.format (entry : LazyEntry) : Format := Id.run do
   let mut parts := #[f!"stack: {entry.stack}"]
   unless entry.computedKeys == [] do
     parts := parts.push f!"results: {entry.computedKeys}"
@@ -250,8 +238,6 @@ private def LazyEntry.format (entry : LazyEntry) : Format := Id.run do
     parts := parts.push f!"todo: {info.expr}"
   return Format.joinSep parts.toList ", "
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 instance : ToFormat LazyEntry := ⟨LazyEntry.format⟩
 
 /-- Array index of a `Trie α` in the `tries` of a `RefinedDiscrTree`. -/
@@ -303,8 +289,7 @@ namespace RefinedDiscrTree
 
 variable {α : Type}
 
-set_option backward.privateInPublic true in
-private partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
+partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   let lines := tree.root.fold (init := #[]) fun lines key trie =>
     lines.push (Format.nest 2 f!"{key} =>{Format.line}{go trie}")
   if lines.size = 0 then
@@ -330,8 +315,6 @@ where
     else
       Format.joinSep lines.toList "\n"
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 instance [ToFormat α] : ToFormat (RefinedDiscrTree α) := ⟨format⟩
 
 end Lean.Meta.RefinedDiscrTree

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -302,6 +302,7 @@ partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   else
     "Discrimination tree flowchart:" ++ Format.joinSep lines.toList "\n"
 where
+  /-- Auxiliary function for `RefinedDiscrTree.format`. -/
   go (trie : TrieIndex) : Format := Id.run do
     let { values, star, labelledStars, children, pending } := tree.tries[trie]!
     let mut lines := #[]

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -51,8 +51,9 @@ inductive Key where
   | proj (typeName : Name) (idx nargs : Nat)
   deriving Inhabited, BEq
 
-/-
-At the root, `.const` is the most common key, and it is very uncommon
+/-- Compute the hash of a `RefinedDiscrTree.Key`.
+
+Note: at the root, `.const` is the most common key, and it is very uncommon
 to get the same constant name with a different arity.
 So for performance, we just use `hash name` to hash `.const name _`.
 -/
@@ -71,6 +72,7 @@ protected def Key.hash : Key → UInt64
 
 instance : Hashable Key := ⟨Key.hash⟩
 
+/-- Format a `RefinedDiscrTree.Key`. -/
 def Key.format : Key → Format
   | .star                   => f!"*"
   | .labelledStar id        => f!"*{id}"
@@ -179,6 +181,7 @@ inductive StackEntry where
   /-- `.expr` is an expression that will be indexed. -/
   | expr (info : ExprInfo)
 
+/-- Format a `RefinedDiscrTree.StackEntry`. -/
 def StackEntry.format : StackEntry → Format
   | .star => f!".star"
   | .expr info => f!".expr {info.expr}"
@@ -230,6 +233,7 @@ def mkInitLazyEntry (labelledStars : Bool) : MetaM LazyEntry :=
     labelledStars? := if labelledStars then some #[] else none
   }
 
+/-- Format a `RefinedDiscrTree.LazyEntry`. -/
 def LazyEntry.format (entry : LazyEntry) : Format := Id.run do
   let mut parts := #[f!"stack: {entry.stack}"]
   unless entry.computedKeys == [] do
@@ -289,6 +293,7 @@ namespace RefinedDiscrTree
 
 variable {α : Type}
 
+/-- Format a `RefinedDiscrTree`. -/
 partial def format [ToFormat α] (tree : RefinedDiscrTree α) : Format :=
   let lines := tree.root.fold (init := #[]) fun lines key trie =>
     lines.push (Format.nest 2 f!"{key} =>{Format.line}{go trie}")


### PR DESCRIPTION
This PR fixes cases of `privateInPublic` in the `RefinedDiscrTree` code. The offending pattern is that an instance is defined using a private definition. The solution is to not mark that definition as `private`.

As a result, this PR also adds some documentation to those functions, in particular to `RefinedDiscrTree.format`. I've added an example of what the output may look like.  I also made a small fix to that function, adding a missing newline.

Also avoid a use of `nonrec`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
