### PR TITLE
[Merged by Bors] - chore(positivity): make tactic lemmas public

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -262,8 +262,7 @@ end AbsoluteValue
 namespace Mathlib.Meta.Positivity
 open Qq Lean Meta Finset
 
-set_option backward.privateInPublic true in
-private alias ⟨_, prod_ne_zero⟩ := prod_ne_zero_iff
+alias ⟨_, prod_ne_zero⟩ := prod_ne_zero_iff
 
 attribute [local instance] monadLiftOptionMetaM in
 /-- The `positivity` extension which proves that `∏ i ∈ s, f i` is nonnegative if `f` is, and

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -661,26 +661,21 @@ open Lean Meta Qq
 section LinearOrderedSemifield
 variable {α : Type*} [Semifield α] [LinearOrder α] [IsStrictOrderedRing α] {a b : α}
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private lemma div_nonneg_of_pos_of_nonneg (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a / b :=
+lemma div_nonneg_of_pos_of_nonneg (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a / b :=
   div_nonneg ha.le hb
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private lemma div_nonneg_of_nonneg_of_pos (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a / b :=
+lemma div_nonneg_of_nonneg_of_pos (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a / b :=
   div_nonneg ha hb.le
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
 omit [IsStrictOrderedRing α] in
-private lemma div_ne_zero_of_pos_of_ne_zero (ha : 0 < a) (hb : b ≠ 0) : a / b ≠ 0 :=
+lemma div_ne_zero_of_pos_of_ne_zero (ha : 0 < a) (hb : b ≠ 0) : a / b ≠ 0 :=
   div_ne_zero ha.ne' hb
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
 omit [IsStrictOrderedRing α] in
-private lemma div_ne_zero_of_ne_zero_of_pos (ha : a ≠ 0) (hb : 0 < b) : a / b ≠ 0 :=
+lemma div_ne_zero_of_ne_zero_of_pos (ha : a ≠ 0) (hb : 0 < b) : a / b ≠ 0 :=
   div_ne_zero ha hb.ne'
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private lemma zpow_zero_pos (a : α) : 0 < a ^ (0 : ℤ) := zero_lt_one.trans_eq (zpow_zero a).symm
+lemma zpow_zero_pos (a : α) : 0 < a ^ (0 : ℤ) := zero_lt_one.trans_eq (zpow_zero a).symm
 
 end LinearOrderedSemifield
 

--- a/Mathlib/Algebra/Order/Floor/Extended.lean
+++ b/Mathlib/Algebra/Order/Floor/Extended.lean
@@ -219,8 +219,7 @@ end ENat
 namespace Mathlib.Meta.Positivity
 open Lean.Meta Qq
 
-set_option backward.privateInPublic true in
-private alias ⟨_, natCeil_pos⟩ := ENat.ceil_pos
+alias ⟨_, natCeil_pos⟩ := ENat.ceil_pos
 
 /-- Extension for the `positivity` tactic: `ENat.ceil` is positive if its input is. -/
 @[positivity ⌈_⌉ₑ]

--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -39,13 +39,11 @@ open Lean.Meta Qq
 
 variable {α : Type*}
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem int_floor_nonneg [Ring α] [LinearOrder α] [FloorRing α] {a : α} (ha : 0 ≤ a) :
+theorem int_floor_nonneg [Ring α] [LinearOrder α] [FloorRing α] {a : α} (ha : 0 ≤ a) :
     0 ≤ ⌊a⌋ :=
   Int.floor_nonneg.2 ha
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem int_floor_nonneg_of_pos [Ring α] [LinearOrder α] [FloorRing α] {a : α}
+theorem int_floor_nonneg_of_pos [Ring α] [LinearOrder α] [FloorRing α] {a : α}
     (ha : 0 < a) :
     0 ≤ ⌊a⌋ :=
   int_floor_nonneg ha.le
@@ -65,8 +63,7 @@ meta def evalIntFloor : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure .none
   | _, _, _ => throwError "failed to match on Int.floor application"
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem nat_ceil_pos [Semiring α] [LinearOrder α] [FloorSemiring α] {a : α} :
+theorem nat_ceil_pos [Semiring α] [LinearOrder α] [FloorSemiring α] {a : α} :
     0 < a → 0 < ⌈a⌉₊ :=
   Nat.ceil_pos.2
 
@@ -85,8 +82,7 @@ meta def evalNatCeil : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure .none
   | _, _, _ => throwError "failed to match on Nat.ceil application"
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem int_ceil_pos [Ring α] [LinearOrder α] [FloorRing α] {a : α} : 0 < a → 0 < ⌈a⌉ :=
+theorem int_ceil_pos [Ring α] [LinearOrder α] [FloorRing α] {a : α} : 0 < a → 0 < ⌈a⌉ :=
   Int.ceil_pos.2
 
 /-- Extension for the `positivity` tactic: `Int.ceil` is positive/nonnegative if its input is. -/

--- a/Mathlib/Algebra/Order/Module/Field.lean
+++ b/Mathlib/Algebra/Order/Module/Field.lean
@@ -77,16 +77,13 @@ section PosSMulMono
 variable [Zero α] [Zero β] [SMulZeroClass α β] [Preorder α] [Preorder β] [PosSMulMono α β] {a : α}
   {b : β}
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem smul_nonneg_of_pos_of_nonneg (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a • b :=
+theorem smul_nonneg_of_pos_of_nonneg (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a • b :=
   smul_nonneg ha.le hb
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem smul_nonneg_of_nonneg_of_pos (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a • b :=
+theorem smul_nonneg_of_nonneg_of_pos (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a • b :=
   smul_nonneg ha hb.le
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem smul_nonneg_of_pos_of_pos (ha : 0 < a) (hb : 0 < b) : 0 ≤ a • b :=
+theorem smul_nonneg_of_pos_of_pos (ha : 0 < a) (hb : 0 < b) : 0 ≤ a • b :=
   smul_nonneg ha.le hb.le
 
 end PosSMulMono
@@ -94,12 +91,10 @@ end PosSMulMono
 section NoZeroSMulDivisors
 variable [Zero α] [Zero β] [SMul α β] [NoZeroSMulDivisors α β] {a : α} {b : β}
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem smul_ne_zero_of_pos_of_ne_zero [Preorder α] (ha : 0 < a) (hb : b ≠ 0) : a • b ≠ 0 :=
+theorem smul_ne_zero_of_pos_of_ne_zero [Preorder α] (ha : 0 < a) (hb : b ≠ 0) : a • b ≠ 0 :=
   smul_ne_zero ha.ne' hb
 
-set_option backward.privateInPublic true in -- used by the positivity tactic
-private theorem smul_ne_zero_of_ne_zero_of_pos [Preorder β] (ha : a ≠ 0) (hb : 0 < b) : a • b ≠ 0 :=
+theorem smul_ne_zero_of_ne_zero_of_pos [Preorder β] (ha : a ≠ 0) (hb : 0 < b) : a • b ≠ 0 :=
   smul_ne_zero ha hb.ne'
 
 end NoZeroSMulDivisors

--- a/Mathlib/Analysis/Complex/Order.lean
+++ b/Mathlib/Analysis/Complex/Order.lean
@@ -134,12 +134,9 @@ namespace Mathlib.Meta.Positivity
 open Lean Meta Qq Complex
 open scoped ComplexOrder
 
-set_option backward.privateInPublic true in
-private alias ⟨_, ofReal_pos⟩ := zero_lt_real
-set_option backward.privateInPublic true in
-private alias ⟨_, ofReal_nonneg⟩ := zero_le_real
-set_option backward.privateInPublic true in
-private alias ⟨_, ofReal_ne_zero_of_ne_zero⟩ := ofReal_ne_zero
+alias ⟨_, ofReal_pos⟩ := zero_lt_real
+alias ⟨_, ofReal_nonneg⟩ := zero_le_real
+alias ⟨_, ofReal_ne_zero_of_ne_zero⟩ := ofReal_ne_zero
 
 /-- Extension for the `positivity` tactic: `Complex.ofReal` is positive/nonnegative/nonzero if its
 input is. -/

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/DerivHyp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/DerivHyp.lean
@@ -791,12 +791,9 @@ end
 namespace Mathlib.Meta.Positivity
 open Lean Meta Qq
 
-set_option backward.privateInPublic true in
-private alias ⟨_, sinh_pos_of_pos⟩ := Real.sinh_pos_iff
-set_option backward.privateInPublic true in
-private alias ⟨_, sinh_nonneg_of_nonneg⟩ := Real.sinh_nonneg_iff
-set_option backward.privateInPublic true in
-private alias ⟨_, sinh_ne_zero_of_ne_zero⟩ := Real.sinh_ne_zero
+alias ⟨_, sinh_pos_of_pos⟩ := Real.sinh_pos_iff
+alias ⟨_, sinh_nonneg_of_nonneg⟩ := Real.sinh_nonneg_iff
+alias ⟨_, sinh_ne_zero_of_ne_zero⟩ := Real.sinh_ne_zero
 
 /-- Extension for the `positivity` tactic: `Real.sinh` is positive/nonnegative/nonzero if its input
 is. -/

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -987,8 +987,7 @@ namespace Mathlib.Meta.Positivity
 
 open Lean Meta Qq
 
-set_option backward.privateInPublic true in
-private alias ⟨_, nnreal_coe_pos⟩ := coe_pos
+alias ⟨_, nnreal_coe_pos⟩ := coe_pos
 
 /-- Extension for the `positivity` tactic: cast from `ℝ≥0` to `ℝ`. -/
 @[positivity NNReal.toReal _]
@@ -1013,8 +1012,7 @@ meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => failure
   | _, _, _ => throwError "not Real.toNNReal"
 
-set_option backward.privateInPublic true in
-private alias ⟨_, nnabs_pos_of_pos⟩ := Real.nnabs_pos
+alias ⟨_, nnabs_pos_of_pos⟩ := Real.nnabs_pos
 
 /-- Extension for the `positivity` tactic: `Real.nnabs. -/
 @[positivity Real.nnabs _]

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -31,32 +31,25 @@ open Lean Meta Qq Function
 section ite
 variable [Zero α] (p : Prop) [Decidable p] {a b : α}
 
-set_option backward.privateInPublic true in
-private lemma ite_pos [LT α] (ha : 0 < a) (hb : 0 < b) : 0 < ite p a b := by
+lemma ite_pos [LT α] (ha : 0 < a) (hb : 0 < b) : 0 < ite p a b := by
   by_cases p <;> simp [*]
 
-set_option backward.privateInPublic true in
-private lemma ite_nonneg [LE α] (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ ite p a b := by
+lemma ite_nonneg [LE α] (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ ite p a b := by
   by_cases p <;> simp [*]
 
-set_option backward.privateInPublic true in
-private lemma ite_nonneg_of_pos_of_nonneg [Preorder α] (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ ite p a b :=
+lemma ite_nonneg_of_pos_of_nonneg [Preorder α] (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ ite p a b :=
   ite_nonneg _ ha.le hb
 
-set_option backward.privateInPublic true in
-private lemma ite_nonneg_of_nonneg_of_pos [Preorder α] (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ ite p a b :=
+lemma ite_nonneg_of_nonneg_of_pos [Preorder α] (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ ite p a b :=
   ite_nonneg _ ha hb.le
 
-set_option backward.privateInPublic true in
-private lemma ite_ne_zero (ha : a ≠ 0) (hb : b ≠ 0) : ite p a b ≠ 0 := by by_cases p <;> simp [*]
+lemma ite_ne_zero (ha : a ≠ 0) (hb : b ≠ 0) : ite p a b ≠ 0 := by by_cases p <;> simp [*]
 
-set_option backward.privateInPublic true in
-private lemma ite_ne_zero_of_pos_of_ne_zero [Preorder α] (ha : 0 < a) (hb : b ≠ 0) :
+lemma ite_ne_zero_of_pos_of_ne_zero [Preorder α] (ha : 0 < a) (hb : b ≠ 0) :
     ite p a b ≠ 0 :=
   ite_ne_zero _ ha.ne' hb
 
-set_option backward.privateInPublic true in
-private lemma ite_ne_zero_of_ne_zero_of_pos [Preorder α] (ha : a ≠ 0) (hb : 0 < b) :
+lemma ite_ne_zero_of_ne_zero_of_pos [Preorder α] (ha : a ≠ 0) (hb : 0 < b) :
     ite p a b ≠ 0 :=
   ite_ne_zero _ ha hb.ne'
 
@@ -98,22 +91,14 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 section LinearOrder
 variable {R : Type*} [LinearOrder R] {a b c : R}
 
-set_option backward.privateInPublic true in
-private lemma le_min_of_lt_of_le (ha : a < b) (hb : a ≤ c) : a ≤ min b c := le_min ha.le hb
-set_option backward.privateInPublic true in
-private lemma le_min_of_le_of_lt (ha : a ≤ b) (hb : a < c) : a ≤ min b c := le_min ha hb.le
-set_option backward.privateInPublic true in
-private lemma min_ne (ha : a ≠ c) (hb : b ≠ c) : min a b ≠ c := by
-  grind
+lemma le_min_of_lt_of_le (ha : a < b) (hb : a ≤ c) : a ≤ min b c := le_min ha.le hb
+lemma le_min_of_le_of_lt (ha : a ≤ b) (hb : a < c) : a ≤ min b c := le_min ha hb.le
+lemma min_ne (ha : a ≠ c) (hb : b ≠ c) : min a b ≠ c := by grind
 
-set_option backward.privateInPublic true in
-private lemma min_ne_of_ne_of_lt (ha : a ≠ c) (hb : c < b) : min a b ≠ c := min_ne ha hb.ne'
-set_option backward.privateInPublic true in
-private lemma min_ne_of_lt_of_ne (ha : c < a) (hb : b ≠ c) : min a b ≠ c := min_ne ha.ne' hb
+lemma min_ne_of_ne_of_lt (ha : a ≠ c) (hb : c < b) : min a b ≠ c := min_ne ha hb.ne'
+lemma min_ne_of_lt_of_ne (ha : c < a) (hb : b ≠ c) : min a b ≠ c := min_ne ha.ne' hb
 
-set_option backward.privateInPublic true in
-private lemma max_ne (ha : a ≠ c) (hb : b ≠ c) : max a b ≠ c := by
-  grind
+lemma max_ne (ha : a ≠ c) (hb : b ≠ c) : max a b ≠ c := by grind
 
 end LinearOrder
 
@@ -227,20 +212,16 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   result ← orElse result (tryProveNonzero ra.toNonzero rb.toNonzero)
   return result
 
-set_option backward.privateInPublic true in
-private lemma int_div_self_pos {a : ℤ} (ha : 0 < a) : 0 < a / a := by
+lemma int_div_self_pos {a : ℤ} (ha : 0 < a) : 0 < a / a := by
   rw [Int.ediv_self ha.ne']; exact zero_lt_one
 
-set_option backward.privateInPublic true in
-private lemma int_div_nonneg_of_pos_of_nonneg {a b : ℤ} (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a / b :=
+lemma int_div_nonneg_of_pos_of_nonneg {a b : ℤ} (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a / b :=
   Int.ediv_nonneg ha.le hb
 
-set_option backward.privateInPublic true in
-private lemma int_div_nonneg_of_nonneg_of_pos {a b : ℤ} (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a / b :=
+lemma int_div_nonneg_of_nonneg_of_pos {a b : ℤ} (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a / b :=
   Int.ediv_nonneg ha hb.le
 
-set_option backward.privateInPublic true in
-private lemma int_div_nonneg_of_pos_of_pos {a b : ℤ} (ha : 0 < a) (hb : 0 < b) : 0 ≤ a / b :=
+lemma int_div_nonneg_of_pos_of_pos {a b : ℤ} (ha : 0 < a) (hb : 0 < b) : 0 ≤ a / b :=
   Int.ediv_nonneg ha.le hb.le
 
 /-- The `positivity` extension which identifies expressions of the form `a / b`,
@@ -266,8 +247,7 @@ where `a` and `b` are integers. -/
     | _, _ => pure .none
   | _, _, _ => throwError "not /"
 
-set_option backward.privateInPublic true in
-private theorem pow_zero_pos [Semiring α] [PartialOrder α] [IsOrderedRing α] [Nontrivial α]
+theorem pow_zero_pos [Semiring α] [PartialOrder α] [IsOrderedRing α] [Nontrivial α]
     (a : α) : 0 < a ^ 0 :=
   zero_lt_one.trans_le (pow_zero a).ge
 
@@ -335,8 +315,7 @@ meta def evalPow : PositivityExt where eval {u α} zα pα e := do
         ofNonzero q($pa) q($sα) q($oα)
     | .none => pure .none
 
-set_option backward.privateInPublic true in
-private theorem abs_pos_of_ne_zero {α : Type*} [AddGroup α] [LinearOrder α]
+theorem abs_pos_of_ne_zero {α : Type*} [AddGroup α] [LinearOrder α]
     [AddLeftMono α] {a : α} : a ≠ 0 → 0 < |a| := abs_pos.mpr
 
 /-- The `positivity` extension which identifies expressions of the form `|a|`. -/
@@ -356,8 +335,7 @@ meta def evalAbs : PositivityExt where eval {_u} (α zα pα) (e : Q($α)) := do
     let pa' ← mkAppM ``abs_nonneg #[a]
     pure (.nonnegative pa')
 
-set_option backward.privateInPublic true in
-private theorem int_natAbs_pos {n : ℤ} (hn : 0 < n) : 0 < n.natAbs :=
+theorem int_natAbs_pos {n : ℤ} (hn : 0 < n) : 0 < n.natAbs :=
   Int.natAbs_pos.mpr hn.ne'
 
 /-- Extension for the `positivity` tactic: `Int.natAbs` is positive when its input is.
@@ -546,10 +524,8 @@ meta def evalIntLCM : PositivityExt where eval {u α} _ _ e := do
 section NNRat
 open NNRat
 
-set_option backward.privateInPublic true in
-private alias ⟨_, NNRat.num_pos_of_pos⟩ := num_pos
-set_option backward.privateInPublic true in
-private alias ⟨_, NNRat.num_ne_zero_of_ne_zero⟩ := num_ne_zero
+alias ⟨_, NNRat.num_pos_of_pos⟩ := num_pos
+alias ⟨_, NNRat.num_ne_zero_of_ne_zero⟩ := num_ne_zero
 
 /-- The `positivity` extension which identifies expressions of the form `NNRat.num q`,
 such that `positivity` successfully recognises `q`. -/
@@ -585,12 +561,9 @@ end NNRat
 
 open Rat
 
-set_option backward.privateInPublic true in
-private alias ⟨_, num_pos_of_pos⟩ := num_pos
-set_option backward.privateInPublic true in
-private alias ⟨_, num_nonneg_of_nonneg⟩ := num_nonneg
-set_option backward.privateInPublic true in
-private alias ⟨_, num_ne_zero_of_ne_zero⟩ := num_ne_zero
+alias ⟨_, num_pos_of_pos⟩ := num_pos
+alias ⟨_, num_nonneg_of_nonneg⟩ := num_nonneg
+alias ⟨_, num_ne_zero_of_ne_zero⟩ := num_ne_zero
 
 /-- The `positivity` extension which identifies expressions of the form `Rat.num a`,
 such that `positivity` successfully recognises `a`. -/

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -410,7 +410,6 @@ def core (e : Q($α)) : MetaM (Strictness zα pα e) := do
   trace[Tactic.positivity] "{e} => {result.toString}"
   throwNone (pure result)
 
-set_option backward.privateInPublic true in
 private inductive OrderRel : Type
 | le : OrderRel -- `0 ≤ a`
 | lt : OrderRel -- `0 < a`


### PR DESCRIPTION
This PR removes `privateInPublic` and `private` from all lemmas used by the `positivity` tactic. These lemmas are part of the public API of the `positivity` tactic, so it makes sense for the lemmas to be public. They all live in the `Mathlib.Meta.Positivity` namespace, so they can't be confused with user-facing lemmas.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
