### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -268,7 +268,6 @@ lemma topologically_iso_le
     (hP : ∀ {α β : Type u} [TopologicalSpace α] [TopologicalSpace β] (f : α ≃ₜ β), P f) :
     MorphismProperty.isomorphisms Scheme ≤ (topologically P) := by
   intro X Y e (he : IsIso e)
-  have : IsIso e := he
   exact hP (TopCat.homeoOfIso (asIso e.base))
 
 /-- If a property of maps of topological spaces is satisfied by homeomorphisms and is stable

--- a/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
@@ -60,7 +60,6 @@ See also `rootSet_derivative_subset_convexHull_rootSet` below.
 theorem eq_centerMass_of_eval_derivative_eq_zero (hP : 0 < P.degree)
     (hz : P.derivative.eval z = 0) :
     z = P.roots.toFinset.centerMass (P.derivRootWeight z) id := by
-  have hP₀ : P ≠ 0 := by rintro rfl; simp at hP
   set weight : ℂ → ℝ := P.derivRootWeight z
   set s := P.roots.toFinset
   suffices ∑ x ∈ s, weight x • (z - x) = 0 by calc

--- a/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
+++ b/Mathlib/Analysis/Distribution/AEEqOfIntegralContDiff.lean
@@ -51,7 +51,6 @@ theorem ae_eq_zero_of_integral_contMDiff_smul_eq_zero [SigmaCompactSpace M]
   have := ChartedSpace.locallyCompactSpace H M
   have := I.secondCountableTopology
   have := ChartedSpace.secondCountable_of_sigmaCompact H M
-  have := Manifold.metrizableSpace I M
   let _ : MetricSpace M := TopologicalSpace.metrizableSpaceMetric M
   -- it suffices to show that the integral of the function vanishes on any compact set `s`
   apply ae_eq_zero_of_forall_setIntegral_isCompact_eq_zero' hf (fun s hs ↦ Eq.symm ?_)

--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -150,7 +150,6 @@ theorem add_rpow_le_rpow_add {p : ℝ} (a b : ℝ≥0) (hp1 : 1 ≤ p) : a ^ p +
   have h := add_rpow_le_one_of_add_le_one (a / (a + b)) (b / (a + b)) h_add.le hp1
   rw [div_rpow a (a + b), div_rpow b (a + b)] at h
   have hab_0 : (a + b) ^ p ≠ 0 := by simp [h_nonzero]
-  have hab_0' : 0 < (a + b) ^ p := zero_lt_iff.mpr hab_0
   have h_mul : (a + b) ^ p * (a ^ p / (a + b) ^ p + b ^ p / (a + b) ^ p) ≤ (a + b) ^ p := by
     nth_rw 4 [← mul_one ((a + b) ^ p)]; gcongr
   rwa [div_eq_mul_inv, div_eq_mul_inv, mul_add, mul_comm (a ^ p), mul_comm (b ^ p), ← mul_assoc, ←

--- a/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
@@ -132,16 +132,10 @@ theorem ACF_isSatisfiable {p : ℕ} (hp : p.Prime ∨ p = 0) :
   | inl hp =>
     have : Fact p.Prime := ⟨hp⟩
     let _ := compatibleRingOfRing (AlgebraicClosure (ZMod p))
-    have : CharP (AlgebraicClosure (ZMod p)) p :=
-      charP_of_injective_algebraMap
-        (RingHom.injective (algebraMap (ZMod p) (AlgebraicClosure (ZMod p)))) p
     exact ⟨⟨AlgebraicClosure (ZMod p)⟩⟩
   | inr hp =>
     subst hp
     let _ := compatibleRingOfRing (AlgebraicClosure ℚ)
-    have : CharP (AlgebraicClosure ℚ) 0 :=
-      charP_of_injective_algebraMap
-        (RingHom.injective (algebraMap ℚ (AlgebraicClosure ℚ))) 0
     exact ⟨⟨AlgebraicClosure ℚ⟩⟩
 
 open Cardinal

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -314,7 +314,6 @@ lemma continuousOn_LFunctionResidueClassAux' :
   simp only [LFunctionResidueClassAux, sub_eq_add_neg]
   refine continuousOn_const.mul <| ContinuousOn.add ?_ ?_
   · refine (continuousOn_neg_logDeriv_LFunctionTrivChar₁ q).mono fun s hs ↦ ?_
-    have := LFunction_ne_zero_of_one_le_re (1 : DirichletCharacter ℂ q) (s := s)
     simp only [ne_eq, Set.mem_setOf_eq] at hs
     tauto
   · simp only [← Finset.sum_neg_distrib, mul_div_assoc, ← mul_neg, ← neg_div]

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -115,7 +115,6 @@ theorem map_eq_span_zeta_sub_one_pow :
 
 theorem ramificationIdx_span_zeta_sub_one :
     ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 (span {hζ.toInteger - 1}) = p ^ k * (p - 1) := by
-  have := liesOver_span_zeta_sub_one p k hζ
   have h := isPrime_span_zeta_sub_one p k hζ
   rw [← Nat.totient_prime_pow_succ hp.out, ← finrank _ K,
     IsDedekindDomain.ramificationIdx_eq_multiplicity _ h, map_eq_span_zeta_sub_one_pow p k hζ,

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Three.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Three.lean
@@ -99,7 +99,6 @@ theorem eq_one_or_neg_one_of_unit_of_congruent
   replace hcong : ∃ n : ℤ, (3 : 𝓞 K) ∣ (↑u - n : 𝓞 K) := by
     obtain ⟨n, x, hx⟩ := hcong
     exact ⟨n, -η * x, by rw [← mul_assoc, mul_neg, ← neg_mul, ← lambda_sq, hx]⟩
-  have hζ := IsCyclotomicExtension.zeta_spec 3 ℚ K
   have := Units.mem hζ u
   fin_cases this
   · left; rfl

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -506,7 +506,7 @@ lemma roughNumbersUpTo_eq_biUnion (N k) :
     show ∀ P Q : Prop, P ∧ (P → Q) ↔ P ∧ Q by tauto]
   simp_rw [← exists_and_left, ← not_lt]
   refine exists_congr fun p ↦ ?_
-  have H₂ : m ≠ 0 → p ∣ m → ¬ m < p :=
+  have H : m ≠ 0 → p ∣ m → ¬ m < p :=
     fun h₁ h₂ ↦ not_lt.mpr <| le_of_dvd (Nat.pos_of_ne_zero h₁) h₂
   grind
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -506,8 +506,6 @@ lemma roughNumbersUpTo_eq_biUnion (N k) :
     show ∀ P Q : Prop, P ∧ (P → Q) ↔ P ∧ Q by tauto]
   simp_rw [← exists_and_left, ← not_lt]
   refine exists_congr fun p ↦ ?_
-  have H₁ : m ≠ 0 → p ∣ m → m < N + 1 → p < N + 1 :=
-    fun h₁ h₂ h₃ ↦ (le_of_dvd (Nat.pos_of_ne_zero h₁) h₂).trans_lt h₃
   have H₂ : m ≠ 0 → p ∣ m → ¬ m < p :=
     fun h₁ h₂ ↦ not_lt.mpr <| le_of_dvd (Nat.pos_of_ne_zero h₁) h₂
   grind

--- a/Mathlib/NumberTheory/WellApproximable.lean
+++ b/Mathlib/NumberTheory/WellApproximable.lean
@@ -323,7 +323,6 @@ lemma _root_.NormedAddCommGroup.exists_norm_nsmul_le {A : Type*}
     [MeasurableSpace A] [BorelSpace A] {μ : Measure A} [μ.IsAddHaarMeasure]
     (ξ : A) {n : ℕ} (hn : 0 < n) (δ : ℝ) (hδ : μ univ ≤ (n + 1) • μ (closedBall (0 : A) (δ / 2))) :
     ∃ j ∈ Icc 1 n, ‖j • ξ‖ ≤ δ := by
-  have : IsFiniteMeasure μ := CompactSpace.isFiniteMeasure
   let B : Icc 0 n → Set A := fun j ↦ closedBall ((j : ℕ) • ξ) (δ / 2)
   have hB : ∀ j, IsClosed (B j) := fun j ↦ isClosed_closedBall
   suffices ¬ Pairwise (Disjoint on B) by

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -227,7 +227,6 @@ lemma condDistrib_fst_prod {γ : Type*} {mγ : MeasurableSpace γ}
     condDistrib (fun ω ↦ Y ω.1) (fun ω ↦ X ω.1) (μ.prod ν) =ᵐ[μ.map X] condDistrib Y X μ := by
   by_cases hX : AEMeasurable X μ
   swap; · simp [Measure.map_of_not_aemeasurable hX, Filter.EventuallyEq]
-  have : μ = (μ.prod ν).map (fun ω ↦ ω.1) := by simp [Measure.map_fst_prod]
   have h_map := condDistrib_map (X := X) (Y := Y) (f := Prod.fst (α := α) (β := γ))
       (ν := μ.prod ν) (mα := inferInstance) (mβ := inferInstance)
       (by simpa) (by simpa) (by fun_prop)
@@ -240,7 +239,6 @@ lemma condDistrib_snd_prod {γ : Type*} {mγ : MeasurableSpace γ}
     condDistrib (fun ω ↦ Y ω.2) (fun ω ↦ X ω.2) (ν.prod μ) =ᵐ[μ.map X] condDistrib Y X μ := by
   by_cases hX : AEMeasurable X μ
   swap; · simp [Measure.map_of_not_aemeasurable hX, Filter.EventuallyEq]
-  have : μ = (μ.prod ν).map (fun ω ↦ ω.1) := by simp [Measure.map_fst_prod]
   have h_map := condDistrib_map (X := X) (Y := Y) (f := Prod.snd (β := α) (α := γ))
       (ν := ν.prod μ) (mα := inferInstance) (mβ := inferInstance)
       (by simpa) (by simpa) (by fun_prop)

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -483,8 +483,6 @@ lemma coeSubmodule_differentIdeal_fractionRing [Algebra.IsIntegral A B]
     [FiniteDimensional (FractionRing A) (FractionRing B)] :
     coeSubmodule (FractionRing B) (differentIdeal A B) =
       1 / Submodule.traceDual A (FractionRing A) 1 := by
-  have : IsIntegralClosure B A (FractionRing B) :=
-    IsIntegralClosure.of_isIntegrallyClosed _ _ _
   rw [coeSubmodule, differentIdeal, Submodule.map_comap_eq, inf_eq_right]
   have := FractionalIdeal.dual_inv_le (A := A) (K := FractionRing A)
     (1 : FractionalIdeal B⁰ (FractionRing B))
@@ -544,9 +542,6 @@ theorem differentIdeal_ne_bot [Module.Finite A B]
     differentIdeal A B ≠ ⊥ := by
   let K := FractionRing A
   let L := FractionRing B
-  have : IsLocalization (Algebra.algebraMapSubmonoid B A⁰) L :=
-    IsIntegralClosure.isLocalization _ K _ _
-  have : FiniteDimensional K L := .of_isLocalization A B A⁰
   rw [ne_eq, ← FractionalIdeal.coeIdeal_inj (K := L), coeIdeal_differentIdeal (K := K)]
   simp
 
@@ -857,9 +852,6 @@ lemma dvd_differentIdeal_of_not_isSeparable
       (by rw [pow_two, ha]; exact mul_dvd_mul_left _ hPa)
   let K := FractionRing A
   let L := FractionRing B
-  have : IsLocalization (Algebra.algebraMapSubmonoid B A⁰) L :=
-    IsIntegralClosure.isLocalization _ K _ _
-  have : FiniteDimensional K L := .of_isLocalization A B A⁰
   have hp' := (Ideal.map_eq_bot_iff_of_injective
     (FaithfulSMul.algebraMap_injective A B)).not.mpr hp
   have habot : a ≠ ⊥ := fun ha' ↦ hp' (by simpa [ha'] using ha)
@@ -918,7 +910,6 @@ theorem not_dvd_differentIdeal_iff
     simp only [Submodule.zero_eq_bot, differentIdeal_ne_bot, not_false_eq_true, true_iff]
     let K := FractionRing A
     let L := FractionRing B
-    have : FiniteDimensional K L := .of_isLocalization A B A⁰
     have : IsLocalization B⁰ (Localization.AtPrime (⊥ : Ideal B)) := by
       convert (inferInstanceAs
         (IsLocalization (⊥ : Ideal B).primeCompl (Localization.AtPrime (⊥ : Ideal B))))

--- a/Mathlib/RingTheory/Frobenius.lean
+++ b/Mathlib/RingTheory/Frobenius.lean
@@ -164,8 +164,6 @@ lemma eq_of_isUnramifiedAt
     (H' : ψ.IsArithFrobAt Q) [Q.IsPrime] (hQ : Q.primeCompl ≤ S⁰)
     [Algebra.IsUnramifiedAt R Q] [IsNoetherianRing S] : φ = ψ := by
   have : H.localize = H'.localize := by
-    have : IsNoetherianRing (Localization.AtPrime Q) :=
-      IsLocalization.isNoetherianRing Q.primeCompl _ inferInstance
     apply Algebra.FormallyUnramified.ext_of_iInf _
       (Ideal.iInf_pow_eq_bot_of_isLocalRing (maximalIdeal _) Ideal.IsPrime.ne_top')
     intro x
@@ -217,7 +215,6 @@ lemma exists_of_isInvariant [Q.IsPrime] [Finite (S ⧸ Q)] : ∃ σ : G, IsArith
   let P := Q.under R
   have := Algebra.IsInvariant.isIntegral R S G
   have : Q.IsMaximal := Ideal.Quotient.maximal_of_isField _ (Finite.isField_of_domain (S ⧸ Q))
-  have : P.IsMaximal := Ideal.isMaximal_comap_of_isIntegral_of_isMaximal Q
   obtain ⟨p, hc⟩ := CharP.exists (R ⧸ P)
   have : Finite (R ⧸ P) := .of_injective _ Ideal.algebraMap_quotient_injective
   cases nonempty_fintype (R ⧸ P)

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -125,8 +125,6 @@ theorem Module.projective_of_localization_maximal (H : ∀ (I : Ideal R) (_ : I.
     Module.Projective (Localization.AtPrime I) (LocalizedModule I.primeCompl M))
     [Module.FinitePresentation R M] : Module.Projective R M := by
   have : Module.Finite R M := by infer_instance
-  have : (⊤ : Submodule R M).FG := this.fg_top
-  have : ∃ (s : Finset M), _ := this
   obtain ⟨s, hs⟩ := this
   let N := s →₀ R
   let f : N →ₗ[R] M := Finsupp.linearCombination R (Subtype.val : s → M)

--- a/Mathlib/RingTheory/LocalRing/Quotient.lean
+++ b/Mathlib/RingTheory/LocalRing/Quotient.lean
@@ -64,8 +64,6 @@ variable [Module.Free R S] {ι : Type*}
 theorem finrank_quotient_map :
     finrank (R ⧸ p) (S ⧸ pS) = finrank R S := by
   classical
-  have : Module.Finite R (S ⧸ pS) := Module.Finite.of_surjective
-    (IsScalarTower.toAlgHom R S (S ⧸ pS)).toLinearMap (Ideal.Quotient.mk_surjective (I := pS))
   have : Module.Finite (R ⧸ p) (S ⧸ pS) := Module.Finite.of_restrictScalars_finite R _ _
   apply le_antisymm
   · let b := Module.Free.chooseBasis R S

--- a/Mathlib/RingTheory/RingHom/Unramified.lean
+++ b/Mathlib/RingTheory/RingHom/Unramified.lean
@@ -72,7 +72,6 @@ lemma ofLocalizationPrime :
   intro x
   let Rₓ := Localization.AtPrime (x.asIdeal.comap f)
   let Sₓ := Localization.AtPrime x.asIdeal
-  have := Algebra.FormallyUnramified.of_isLocalization (Rₘ := Rₓ) (x.asIdeal.comap f).primeCompl
   letI : Algebra Rₓ Sₓ := (Localization.localRingHom _ _ _ rfl).toAlgebra
   have : IsScalarTower R Rₓ Sₓ := .of_algebraMap_eq
     fun x ↦ (Localization.localRingHom_to_map _ _ _ rfl x).symm

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -76,8 +76,6 @@ attribute [local instance] RingHomInvPair.of_ringEquiv in
 lemma mem_freeLocus_iff_tensor (p : PrimeSpectrum R)
     (Rₚ) [CommRing Rₚ] [Algebra R Rₚ] [IsLocalization.AtPrime Rₚ p.asIdeal] :
     p ∈ freeLocus R M ↔ Module.Free Rₚ (Rₚ ⊗[R] M) := by
-  have := (isLocalizedModule_iff_isBaseChange p.asIdeal.primeCompl _ _).mpr
-    (TensorProduct.isBaseChange R M Rₚ)
   exact mem_freeLocus_of_isLocalization p Rₚ (f := TensorProduct.mk R Rₚ M 1)
 
 lemma freeLocus_congr {M'} [AddCommGroup M'] [Module R M'] (e : M ≃ₗ[R] M') :

--- a/Mathlib/RingTheory/Valuation/Archimedean.lean
+++ b/Mathlib/RingTheory/Valuation/Archimedean.lean
@@ -75,7 +75,6 @@ lemma isPrincipalIdealRing_iff_not_denselyOrdered [MulArchimedean (MonoidHom.mra
     exact .of_surjective _ (RingEquiv.ofBijective _ this).symm.surjective
   have : IsDomain O := hv.hom_inj.isDomain
   have : ValuationRing O := ValuationRing.of_integers v hv
-  have : IsBezout O := ValuationRing.instIsBezout
   have := ((IsBezout.TFAE (R := O)).out 1 3)
   rw [this, hv.wfDvdMonoid_iff_wellFounded_gt_on_v, hv.wellFounded_gt_on_v_iff_discrete_mrange,
     LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered]


### PR DESCRIPTION
---
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `AlgebraicGeometry.topologically_iso_le`: <10 ms before, <10 ms after  🎉
* `Polynomial.eq_centerMass_of_eval_derivative_eq_zero`: 634 ms before, 487 ms after  🎉
* `ae_eq_zero_of_integral_contMDiff_smul_eq_zero`: 573 ms before, 546 ms after  🎉
* `NNReal.add_rpow_le_rpow_add`: 240 ms before, 235 ms after  🎉
* `FirstOrder.Field.ACF_isSatisfiable`: 75 ms before, 68 ms after  🎉
* `ArithmeticFunction.vonMangoldt.continuousOn_LFunctionResidueClassAux'`: 132 ms before, 105 ms after  🎉
* `IsCyclotomicExtension.Rat.ramificationIdx_span_zeta_sub_one`: 87 ms before, 82 ms after  🎉
* `IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent`: 247 ms before, 237 ms after  🎉
* `Nat.roughNumbersUpTo_eq_biUnion`: 82 ms before, 67 ms after  🎉
* `NormedAddCommGroup.exists_norm_nsmul_le`: 312 ms before, 306 ms after  🎉
* `ProbabilityTheory.condDistrib_fst_prod`: 363 ms before, 235 ms after  🎉
* `ProbabilityTheory.condDistrib_snd_prod`: 432 ms before, 246 ms after  🎉
* `coeSubmodule_differentIdeal_fractionRing`: 1147 ms before, 1107 ms after  🎉
* `differentIdeal_ne_bot`: 1070 ms before, 457 ms after  🎉
* `dvd_differentIdeal_of_not_isSeparable`: 3317 ms before, 2878 ms after  🎉
* `not_dvd_differentIdeal_iff`: 910 ms before, 631 ms after  🎉
* `AlgHom.IsArithFrobAt.eq_of_isUnramifiedAt`: 337 ms before, 332 ms after  🎉
* `IsArithFrobAt.exists_of_isInvariant`: 131 ms before, 122 ms after  🎉
* `Module.projective_of_localization_maximal`: 190 ms before, 162 ms after  🎉
* `IsLocalRing.finrank_quotient_map`: 423 ms before, 418 ms after  🎉
* `RingHom.FormallyUnramified.ofLocalizationPrime`: 312 ms before, 299 ms after  🎉
* `Module.mem_freeLocus_iff_tensor`: 98 ms before, 71 ms after  🎉
* `Valuation.Integers.isPrincipalIdealRing_iff_not_denselyOrdered`: 519 ms before, 478 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
