### PR TITLE
[Merged by Bors] - feat(Tactic/Set): use `binderIdent` instead of `ident`

### DIFF
--- a/MathlibTest/Set.lean
+++ b/MathlibTest/Set.lean
@@ -49,3 +49,10 @@ set_option maxHeartbeats 3000 in
 example {_a _b _c _d _e _f _g _h : Nat} : 1 = 1 := by
   set a : Nat := test with _h
   trivial
+
+example : 1 + 2 = 3 := by
+  set _ := 1 + 2
+  guard_target =ₛ ‹Nat› = 3
+  set u := 3 with ← _
+  guard_hyp ‹3 = u› :ₛ 3 = u
+  conv => rhs; guard_target =ₛ u


### PR DESCRIPTION
This let both `a` and `h` be replaced with `_` in the syntax `set a := val with ← h`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
