### PR TITLE
[Merged by Bors] - feat: `r < stdPart x → r < x`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -440,7 +440,7 @@ theorem lt_of_stdPart_lt (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : std
 theorem stdPart_le_of_le (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : x ≤ f r) : stdPart x ≤ r :=
   le_imp_le_iff_lt_imp_lt.2 (lt_of_lt_stdPart f hx) h
 
-theorem lt_stdPart_of_lt (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : f r ≤ x) : r ≤ stdPart x :=
+theorem le_stdPart_of_le (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : f r ≤ x) : r ≤ stdPart x :=
   le_imp_le_iff_lt_imp_lt.2 (lt_of_stdPart_lt f hx) h
 
 theorem stdPart_eq (f : ℝ →+*o K) {r : ℝ} (hl : ∀ s < r, f s ≤ x) (hr : ∀ s > r, x ≤ f s) :

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -392,13 +392,13 @@ theorem stdPart_ofNat (n : ℕ) [n.AtLeastTwo] : stdPart (ofNat(n) : K) = n :=
   stdPart_natCast n
 
 @[simp]
-theorem stdPart_of_archimedean (f : ℝ →+*o K) (r : ℝ) : stdPart (f r) = r := by
+theorem stdPart_map_real (f : ℝ →+*o K) (r : ℝ) : stdPart (f r) = r := by
   rw [stdPart, dif_pos]
   exact r.ringHom_apply <| OrderRingHom.comp _ (FiniteResidueField.ofArchimedean f)
 
 @[simp]
 theorem stdPart_real (r : ℝ) : stdPart r = r :=
-  stdPart_of_archimedean (.id ℝ) r
+  stdPart_map_real (.id ℝ) r
 
 theorem ofArchimedean_stdPart (f : ℝ →+*o K) (hx : 0 ≤ mk x) :
     FiniteResidueField.ofArchimedean f (stdPart x) = .mk (.mk x hx) := by

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -447,22 +447,12 @@ theorem stdPart_eq (f : ℝ →+*o K) {r : ℝ} (hl : ∀ s < r, f s ≤ x) (hr 
     stdPart x = r := by
   have hx : 0 ≤ mk x := by
     apply mk_nonneg_of_le_of_le_of_archimedean f (hl (r - 1) _) (hr (r + 1) _) <;> simp
-  by_contra h
-  obtain h | h := lt_or_gt_of_ne h
+  obtain h | rfl | h := lt_trichotomy (stdPart x) r
   · obtain ⟨s, hs, hs'⟩ := exists_between h
-    apply (mk_sub_pos_iff f hx).not.2 hs.ne <|
-      (mk_sub_stdPart_pos f hx).trans_le (mk_antitoneOn _ _ _)
-    · simpa using hl _ hs'
-    · simpa using hl _ h
-    · rw [sub_le_sub_iff_left]
-      exact f.monotone' hs.le
-  · obtain ⟨s, hs', hs⟩ := exists_between h
-    apply (mk_sub_pos_iff f hx).not.2 hs.ne' <|
-      (mk_sub_stdPart_pos f hx).trans_le (mk_monotoneOn _ _ _)
-    · simpa using hr _ h
-    · simpa using hr _ hs'
-    · rw [sub_le_sub_iff_left]
-      exact f.monotone' hs.le
+    cases (le_stdPart_of_le f hx (hl _ hs')).not_gt hs
+  · rfl
+  · obtain ⟨s, hs, hs'⟩ := exists_between h
+    cases (stdPart_le_of_le f hx (hr _ hs)).not_gt hs'
 
 theorem stdPart_eq_sInf (f : ℝ →+*o K) (x : K) : stdPart x = sInf {r | x < f r} := by
   obtain hx | hx := le_or_gt 0 (mk x)

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -364,8 +364,7 @@ theorem stdPart_sub_eq_right (hx : 0 < mk x) : stdPart (x - y) = -stdPart y := b
 theorem stdPart_sub_eq_left (hy : 0 < mk y) : stdPart (x - y) = stdPart x := by
   rw [sub_eq_add_neg, stdPart_add_eq_left (by simpa)]
 
-theorem stdPart_mul {x y : K} (hx : 0 ≤ mk x) (hy : 0 ≤ mk y) :
-    stdPart (x * y) = stdPart x * stdPart y := by
+theorem stdPart_mul (hx : 0 ≤ mk x) (hy : 0 ≤ mk y) : stdPart (x * y) = stdPart x * stdPart y := by
   unfold stdPart
   rw [dif_pos hx, dif_pos hy, dif_pos]
   exact map_mul _ (FiniteElement.mk x hx) (.mk y hy)
@@ -393,9 +392,13 @@ theorem stdPart_ofNat (n : ℕ) [n.AtLeastTwo] : stdPart (ofNat(n) : K) = n :=
   stdPart_natCast n
 
 @[simp]
-theorem stdPart_real (f : ℝ →+*o K) (r : ℝ) : stdPart (f r) = r := by
+theorem stdPart_of_archimedean (f : ℝ →+*o K) (r : ℝ) : stdPart (f r) = r := by
   rw [stdPart, dif_pos]
   exact r.ringHom_apply <| OrderRingHom.comp _ (FiniteResidueField.ofArchimedean f)
+
+@[simp]
+theorem stdPart_real (r : ℝ) : stdPart r = r :=
+  stdPart_of_archimedean (.id ℝ) r
 
 theorem ofArchimedean_stdPart (f : ℝ →+*o K) (hx : 0 ≤ mk x) :
     FiniteResidueField.ofArchimedean f (stdPart x) = .mk (.mk x hx) := by
@@ -422,7 +425,25 @@ theorem mk_sub_pos_iff (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) :
 theorem mk_sub_stdPart_pos (f : ℝ →+*o K) (hx : 0 ≤ mk x) : 0 < mk (x - f (stdPart x)) :=
   (mk_sub_pos_iff f hx).2 rfl
 
-theorem stdPart_eq (f : ℝ →+*o K) {x : K} {r : ℝ} (hl : ∀ s < r, f s ≤ x) (hr : ∀ s > r, x ≤ f s) :
+theorem lt_of_lt_stdPart (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : r < stdPart x) : f r < x := by
+  rw [← sub_lt_sub_iff_right (c := f (stdPart x)), ← map_sub]
+  apply lt_of_mk_lt_mk_of_nonpos
+  · rw [mk_map_of_archimedean', mk_sub_pos_iff f hx]
+    rw [ne_eq, sub_eq_zero]
+    exact h.ne
+  · simpa using f.monotone' h.le
+
+theorem lt_of_stdPart_lt (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : stdPart x < r) : x < f r := by
+  rw [← neg_lt_neg_iff, ← map_neg]
+  apply lt_of_lt_stdPart <;> simpa
+
+theorem stdPart_le_of_le (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : x ≤ f r) : stdPart x ≤ r :=
+  le_imp_le_iff_lt_imp_lt.2 (lt_of_lt_stdPart f hx) h
+
+theorem lt_stdPart_of_lt (f : ℝ →+*o K) {r : ℝ} (hx : 0 ≤ mk x) (h : f r ≤ x) : r ≤ stdPart x :=
+  le_imp_le_iff_lt_imp_lt.2 (lt_of_stdPart_lt f hx) h
+
+theorem stdPart_eq (f : ℝ →+*o K) {r : ℝ} (hl : ∀ s < r, f s ≤ x) (hr : ∀ s > r, x ≤ f s) :
     stdPart x = r := by
   have hx : 0 ≤ mk x := by
     apply mk_nonneg_of_le_of_le_of_archimedean f (hl (r - 1) _) (hr (r + 1) _) <;> simp


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
