### PR TITLE
[Merged by Bors] - chore(Cache): add README and rename USE_FRO_CACHE to MATHLIB_CACHE_USE_CLOUDFLARE

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -395,7 +395,7 @@ jobs:
           # do not try to upload files just downloaded
 
           echo "Uploading cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 
@@ -451,8 +451,8 @@ jobs:
           export MATHLIB_CACHE_SAS="${MATHLIB_CACHE_SAS_RAW%"${MATHLIB_CACHE_SAS_RAW##*[![:space:]]}"}"
 
           echo "Uploading Archive and Counterexamples cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -405,7 +405,7 @@ jobs:
           # do not try to upload files just downloaded
 
           echo "Uploading cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 
@@ -461,8 +461,8 @@ jobs:
           export MATHLIB_CACHE_SAS="${MATHLIB_CACHE_SAS_RAW%"${MATHLIB_CACHE_SAS_RAW##*[![:space:]]}"}"
 
           echo "Uploading Archive and Counterexamples cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,7 +411,7 @@ jobs:
           # do not try to upload files just downloaded
 
           echo "Uploading cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 
@@ -467,8 +467,8 @@ jobs:
           export MATHLIB_CACHE_SAS="${MATHLIB_CACHE_SAS_RAW%"${MATHLIB_CACHE_SAS_RAW##*[![:space:]]}"}"
 
           echo "Uploading Archive and Counterexamples cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -409,7 +409,7 @@ jobs:
           # do not try to upload files just downloaded
 
           echo "Uploading cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 
@@ -465,8 +465,8 @@ jobs:
           export MATHLIB_CACHE_SAS="${MATHLIB_CACHE_SAS_RAW%"${MATHLIB_CACHE_SAS_RAW##*[![:space:]]}"}"
 
           echo "Uploading Archive and Counterexamples cache to Azure..."
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
-          USE_FRO_CACHE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Archive.lean
+          MATHLIB_CACHE_USE_CLOUDFLARE=0 ../master-branch/.lake/build/bin/cache --repo=${{ github.event.pull_request.head.repo.full_name || github.repository }} put-unpacked Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS_RAW: ${{ secrets.MATHLIB_CACHE_SAS }}
 

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -7,7 +7,7 @@ Authors: Arthur Paulino, Jon Eugster
 import Cache.Requests
 
 def help : String := "Mathlib4 caching CLI
-Usage: cache [COMMAND]
+Usage: cache [COMMAND] [OPTIONS]
 
 Commands:
   # No privilege required
@@ -20,15 +20,17 @@ Commands:
   unpack!       Decompress linked already downloaded files (no skipping)
   clean         Delete non-linked files
   clean!        Delete everything on the local cache
-  lookup [ARGS] Show information about cache files for the given lean files
+  lookup [ARGS] Show information about cache files for the given Lean files
 
   # Privilege required
-  put          Run 'mk' then upload linked files missing on the server
-  put!         Run 'mk' then upload all linked files
+  put          Run 'pack' then upload linked files missing on the server
+  put!         Run 'pack' then upload all linked files
   put-unpacked 'put' only files not already 'pack'ed; intended for CI use
   commit       Write a commit on the server
   commit!      Overwrite a commit on the server
-  collect      TODO
+
+Options:
+  --repo=OWNER/REPO  Override the repository to fetch/push cache from
 
 * Linked files refer to local cache files with corresponding Lean sources
 * Commands ending with '!' should be used manually, when hot-fixes are needed
@@ -46,6 +48,15 @@ Valid arguments are:
 * Folder names like 'Mathlib/Data/' (find all Lean files inside `Mathlib/Data/`)
 * With bash's automatic glob expansion one can also write things like
   'Mathlib/**/Order/*.lean'.
+
+# Environment variables
+
+* MATHLIB_CACHE_DIR       Local cache directory (default: ~/.cache/mathlib)
+* MATHLIB_CACHE_USE_CLOUDFLARE  Set to '1' to use Cloudflare instead of Azure
+* MATHLIB_CACHE_GET_URL   Override the download URL
+* MATHLIB_CACHE_PUT_URL   Override the upload URL
+
+See Cache/README.md for more details.
 "
 
 /-- Commands which (potentially) call `curl` for downloading files -/

--- a/Cache/README.md
+++ b/Cache/README.md
@@ -1,0 +1,244 @@
+# Mathlib Cache
+
+This directory contains the implementation of Mathlib's build cache system (`lake exe cache`), which downloads pre-built `.olean` files to avoid recompiling the entire library.
+
+> **Note**: A new `lake cache` command is currently being designed and implemented in Lake itself. This will eventually replace the Mathlib-specific `lake exe cache` and work for all repositories. Until then, this cache system remains the primary way to get pre-built artifacts for Mathlib.
+
+## Quick Start
+
+```bash
+# Download and unpack cache for all of Mathlib
+lake exe cache get
+
+# Force re-download everything
+lake exe cache get!
+
+# Download cache for specific files only (and their dependencies)
+lake exe cache get Mathlib/Algebra/Group/Basic.lean
+lake exe cache get Mathlib.Algebra.Group.Basic
+```
+
+## Commands
+
+### No Privilege Required
+
+| Command         | Description                                                         |
+|-----------------|---------------------------------------------------------------------|
+| `get [ARGS]`    | Download linked files missing on the local cache and decompress     |
+| `get! [ARGS]`   | Download all linked files and decompress (force re-download)        |
+| `get- [ARGS]`   | Download linked files missing to local cache, but do not decompress |
+| `pack`          | Compress non-compressed build files into the local cache            |
+| `pack!`         | Compress build files into the local cache (no skipping)             |
+| `unpack`        | Decompress linked already downloaded files                          |
+| `unpack!`       | Decompress linked already downloaded files (no skipping)            |
+| `clean`         | Delete non-linked files                                             |
+| `clean!`        | Delete everything on the local cache                                |
+| `lookup [ARGS]` | Show information about cache files for the given Lean files         |
+
+### Privilege Required (CI/Maintainers)
+
+| Command        | Description                                               |
+|----------------|-----------------------------------------------------------|
+| `put`          | Run `pack` then upload linked files missing on the server |
+| `put!`         | Run `pack` then upload all linked files                   |
+| `put-unpacked` | `put` only files not already packed; intended for CI use  |
+| `commit`       | Write a commit on the server                              |
+| `commit!`      | Overwrite a commit on the server                          |
+
+### Arguments
+
+The `get`, `get!`, `get-`, and `lookup` commands accept:
+
+- Module names: `Mathlib.Algebra.Group.Basic`
+- File paths: `Mathlib/Algebra/Group/Basic.lean`
+- Folder names: `Mathlib/Data/` (finds all Lean files inside)
+- Glob patterns: `Mathlib/**/Order/*.lean` (via shell expansion)
+
+When arguments are provided, only the specified files and their transitive imports are downloaded.
+
+### Options
+
+| Option              | Description                                                                                |
+|---------------------|--------------------------------------------------------------------------------------------|
+| `--repo=OWNER/REPO` | Override the repository to fetch cache from (e.g., `--repo=leanprover-community/mathlib4`) |
+
+## Environment Variables
+
+### Cache Location
+
+| Variable            | Description                        | Default                                         |
+|---------------------|------------------------------------|-------------------------------------------------|
+| `MATHLIB_CACHE_DIR` | Directory for cached `.ltar` files | `$XDG_CACHE_HOME/mathlib` or `~/.cache/mathlib` |
+
+### Cache Backend Selection
+
+| Variable                       | Description                                              | Default     |
+|--------------------------------|----------------------------------------------------------|-------------|
+| `MATHLIB_CACHE_USE_CLOUDFLARE` | Set to `1` or `true` to use Cloudflare R2 instead of Azure | Azure cache |
+
+### Custom Cache URLs
+
+These allow overriding the cache endpoints, useful for mirrors or custom deployments:
+
+| Variable                | Description                     | Default                                                           |
+|-------------------------|---------------------------------|-------------------------------------------------------------------|
+| `MATHLIB_CACHE_GET_URL` | URL for downloading cache files | Azure or Cloudflare URL based on `MATHLIB_CACHE_USE_CLOUDFLARE`   |
+| `MATHLIB_CACHE_PUT_URL` | URL for uploading cache files   | Azure or Cloudflare URL based on `MATHLIB_CACHE_USE_CLOUDFLARE`   |
+
+### Authentication (for uploads)
+
+| Variable                 | Description                                    |
+|--------------------------|------------------------------------------------|
+| `MATHLIB_CACHE_SAS`      | Azure SAS token (when using Azure backend)     |
+| `MATHLIB_CACHE_S3_TOKEN` | S3 credentials (when using Cloudflare backend) |
+
+## How It Works
+
+### File Hashing
+
+Each Lean file's cache is identified by a hash computed from:
+
+1. **Root hash**: A combination of:
+   - `lakefile.lean` content
+   - `lean-toolchain` content
+   - `lake-manifest.json` content
+   - The Lean compiler's git hash
+   - A generation counter (bumped to invalidate all caches)
+
+2. **File hash**: Mixing:
+   - The root hash
+   - The file's path relative to its package
+   - The file's content hash
+   - Hashes of all imported files
+
+This ensures that any change to toolchain, dependencies, or source files produces a different cache key.
+
+### Cache File Format
+
+Cache files use the `.ltar` format (Lean tar), handled by [leantar](https://github.com/digama0/leangz). Each `.ltar` contains:
+
+- `.olean` files (compiled Lean)
+- `.ilean` files (interface info)
+- `.trace` files (build traces)
+- `.c` files (generated C code)
+- Associated `.hash` files
+
+### Cached Packages
+
+The cache covers these packages:
+
+- `Mathlib`
+- `Batteries`
+- `Aesop`
+- `Cli`
+- `ImportGraph`
+- `LeanSearchClient`
+- `Plausible`
+- `Qq`
+- `ProofWidgets`
+- `Archive`
+- `Counterexamples`
+
+## Default Cache Backends
+
+### Azure Blob Storage (Default)
+
+- **Download URL**: `https://lakecache.blob.core.windows.net/mathlib4`
+- Used by default for downloads and uploads
+
+### Cloudflare R2
+
+- **Download URL**: `https://mathlib4.lean-cache.cloud`
+- **Upload URL**: `https://a09a7664adc082e00f294ac190827820.r2.cloudflarestorage.com/mathlib4`
+- Enable with `MATHLIB_CACHE_USE_CLOUDFLARE=1`
+
+## Setting Up Your Own Cache Endpoint
+
+You can host your own cache mirror or private cache using any S3-compatible storage or HTTP server.
+
+### Requirements
+
+Your endpoint must support:
+
+1. **GET requests** for downloading files at:
+   - `/f/{repo}/{hash}.ltar` - for fork caches
+   - `/f/{hash}.ltar` - for main mathlib cache (Azure only)
+   - `/c/{commit_hash}` - for commit manifests
+
+2. **PUT requests** for uploading (if you need upload capability)
+
+### Using a Custom Endpoint
+
+```bash
+# Download from a custom mirror
+export MATHLIB_CACHE_GET_URL="https://my-mirror.example.com/mathlib4"
+lake exe cache get
+
+# Upload to a custom endpoint
+export MATHLIB_CACHE_PUT_URL="https://my-upload.example.com/mathlib4"
+export MATHLIB_CACHE_SAS="your-auth-token"  # or MATHLIB_CACHE_S3_TOKEN for S3
+lake exe cache put
+```
+
+### Example: S3-Compatible Storage
+
+For S3-compatible storage (MinIO, Cloudflare R2, AWS S3, etc.):
+
+1. Create a bucket (e.g., `mathlib-cache`)
+2. Configure public read access for downloads (or use signed URLs)
+3. Set up authentication for uploads
+4. Set the environment variables:
+
+```bash
+export MATHLIB_CACHE_GET_URL="https://your-bucket.s3.region.amazonaws.com/mathlib-cache"
+export MATHLIB_CACHE_PUT_URL="https://your-bucket.s3.region.amazonaws.com/mathlib-cache"
+export MATHLIB_CACHE_USE_CLOUDFLARE=1  # Use S3-style auth
+export MATHLIB_CACHE_S3_TOKEN="ACCESS_KEY:SECRET_KEY"
+```
+
+### Example: Simple HTTP Mirror
+
+For a read-only mirror using nginx or any static file server:
+
+1. Periodically sync files from the official cache
+2. Serve them at a public URL
+3. Point users to your mirror:
+
+```bash
+export MATHLIB_CACHE_GET_URL="https://mathlib-mirror.myorg.com"
+lake exe cache get
+```
+
+### URL Structure
+
+The cache uses this URL pattern:
+
+```
+{BASE_URL}/f/{repo}/{filename}.ltar  # Fork/branch caches
+{BASE_URL}/f/{filename}.ltar         # Main mathlib cache (Azure)
+{BASE_URL}/c/{commit_hash}           # Commit manifests
+```
+
+Where:
+- `{repo}` is like `leanprover-community/mathlib4` or `username/mathlib4`
+- `{filename}` is a hash like `1234567890abcdef`
+- `{commit_hash}` is a git commit SHA
+
+## Dependencies
+
+The cache system automatically downloads and manages:
+
+- **curl** (>=7.70, preferably >=7.81) - for HTTP transfers
+- **leantar** - for `.ltar` compression/decompression
+
+If your system curl is too old, a static binary is downloaded automatically on Linux.
+
+## File Locations
+
+| Path                        | Description                  |
+|-----------------------------|------------------------------|
+| `~/.cache/mathlib/`         | Default cache directory      |
+| `~/.cache/mathlib/*.ltar`   | Cached build artifacts       |
+| `~/.cache/mathlib/curl.cfg` | Temporary curl configuration |
+| `.lake/build/lib/lean/`     | Unpacked `.olean` files      |
+| `.lake/build/ir/`           | Unpacked `.c` files          |

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -11,10 +11,10 @@ namespace Cache.Requests
 
 open System (FilePath)
 
--- FRO cache may be flaky: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/The.20cache.20doesn't.20work/near/411058849
-initialize useFROCache : Bool ← do
-  let froCache ← IO.getEnv "USE_FRO_CACHE"
-  return froCache == some "1" || froCache == some "true"
+-- Cloudflare cache may be flaky: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/The.20cache.20doesn't.20work/near/411058849
+initialize useCloudflareCache : Bool ← do
+  let cache ← IO.getEnv "MATHLIB_CACHE_USE_CLOUDFLARE"
+  return cache == some "1" || cache == some "true"
 
 /--
 Structure to hold repository information with priority ordering
@@ -177,7 +177,7 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
 
     if shouldUseNightlyTesting then
       let repo := "leanprover-community/mathlib4-nightly-testing"
-      let cacheService := if useFROCache then "Cloudflare" else "Azure"
+      let cacheService := if useCloudflareCache then "Cloudflare" else "Azure"
       IO.println s!"Using cache ({cacheService}) from nightly-testing remote: {repo}"
       return {repo := repo, useFirst := true}
 
@@ -239,20 +239,20 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
 
   let repo ← getRepoFromRemote mathlibDepPath remoteName
     s!"Ensure Git is installed and the '{remoteName}' remote points to its GitHub repository."
-  let cacheService := if useFROCache then "Cloudflare" else "Azure"
+  let cacheService := if useCloudflareCache then "Cloudflare" else "Azure"
   IO.println s!"Using cache ({cacheService}) from {remoteName}: {repo}"
   return {repo := repo, useFirst := false}
 
 /-- Public URL for mathlib cache -/
 def URL : String :=
-  if useFROCache then
+  if useCloudflareCache then
     "https://mathlib4.lean-cache.cloud"
   else
     "https://lakecache.blob.core.windows.net/mathlib4"
 
 /-- Retrieves the azure token from the environment -/
 def getToken : IO String := do
-  let envVar := if useFROCache then "MATHLIB_CACHE_S3_TOKEN" else "MATHLIB_CACHE_SAS"
+  let envVar := if useCloudflareCache then "MATHLIB_CACHE_S3_TOKEN" else "MATHLIB_CACHE_SAS"
   let some token ← IO.getEnv envVar
     | throw <| IO.userError s!"environment variable {envVar} must be set to upload caches"
   return token
@@ -266,7 +266,7 @@ Given a file name like `"1234.tar.gz"`, makes the URL to that file on the server
 The `f/` prefix means that it's a common file for caching.
 -/
 def mkFileURL (repo URL fileName : String) : String :=
-  let pre := if !useFROCache && repo == MATHLIBREPO then "" else s!"{repo}/"
+  let pre := if !useCloudflareCache && repo == MATHLIBREPO then "" else s!"{repo}/"
   s!"{URL}/f/{pre}{fileName}"
 
 section Get
@@ -507,16 +507,16 @@ end Get
 
 section Put
 
-/-- FRO cache S3 URL -/
+/-- Cloudflare cache S3 URL -/
 def UPLOAD_URL : String :=
-  if useFROCache then
+  if useCloudflareCache then
     "https://a09a7664adc082e00f294ac190827820.r2.cloudflarestorage.com/mathlib4"
   else
     URL
 
 /-- Formats the config file for `curl`, containing the list of files to be uploaded -/
 def mkPutConfigContent (repo : String) (fileNames : Array String) (token : String) : IO String := do
-  let token := if useFROCache then "" else s!"?{token}" -- the FRO cache doesn't pass the token here
+  let token := if useCloudflareCache then "" else s!"?{token}" -- the Cloudflare cache doesn't pass the token here
   let l ← fileNames.toList.mapM fun fileName : String => do
     pure s!"-T {(IO.CACHEDIR / fileName).toString}\nurl = {mkFileURL repo UPLOAD_URL fileName}{token}"
   return "\n".intercalate l
@@ -531,7 +531,7 @@ def putFiles
   if size > 0 then
     IO.FS.writeFile IO.CURLCFG (← mkPutConfigContent repo fileNames token)
     IO.println s!"Attempting to upload {size} file(s) to {repo} cache"
-    let args := if useFROCache then
+    let args := if useCloudflareCache then
       -- TODO: reimplement using HEAD requests?
       let _ := overwrite
       #["--aws-sigv4", "aws:amz:auto:s3", "--user", token]
@@ -567,7 +567,7 @@ def commit (hashMap : IO.ModuleHashMap) (overwrite : Bool) (token : String) : IO
   let path := IO.CACHEDIR / hash
   IO.FS.createDirAll IO.CACHEDIR
   IO.FS.writeFile path <| ("\n".intercalate <| hashMap.hashes.toList.map toString) ++ "\n"
-  if useFROCache then
+  if useCloudflareCache then
     -- TODO: reimplement using HEAD requests?
     let _ := overwrite
     discard <| IO.runCurl #["-T", path.toString,
@@ -605,8 +605,8 @@ Retrieves metadata about hosted files: their names and the timestamps of last mo
 Example: `["f/39476538726384726.tar.gz", "Sat, 24 Dec 2022 17:33:01 GMT"]`
 -/
 def getFilesInfo (q : QueryType) : IO <| List (String × String) := do
-  if useFROCache then
-    throw <| .userError "FIXME: getFilesInfo is not adapted to FRO cache yet"
+  if useCloudflareCache then
+    throw <| .userError "FIXME: getFilesInfo is not adapted to Cloudflare cache yet"
   IO.println s!"Downloading info list of {q.desc}"
   let ret ← IO.runCurl #["-X", "GET", s!"{URL}?comp=list&restype=container{q.prefix}"]
   match ret.splitOn "<Name>" with


### PR DESCRIPTION
This PR:
- Adds `Cache/README.md` documenting the cache system, environment variables, and how to set up custom endpoints
- Renames `USE_FRO_CACHE` to `MATHLIB_CACHE_USE_CLOUDFLARE` for consistent `MATHLIB_CACHE_*` prefix across all cache environment variables
- Updates the help text in `Cache/Main.lean` to document the `--repo` option and environment variables
- Fixes help text saying "Run 'mk'" (should be "Run 'pack'")

🤖 Prepared with Claude Code