### PR TITLE
[Merged by Bors] - ci: add nanoda verification to daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -283,3 +283,164 @@ jobs:
           topic: 'mathlib test executable failure'
           content: |
             ❌ mathlib_test_executable [${{ needs.check-mathlib_test_executable.result }}](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+
+  check-nanoda:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch_type: [master, nightly]
+    steps:
+      # Checkout repository, so that we can fetch tags to decide which branch we want.
+      - name: Checkout branch or tag
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Fetch latest tags (if nightly)
+        if: matrix.branch_type == 'nightly'
+        run: |
+          # When in nightly mode, fetch tags from the nightly-testing repository
+          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+          git fetch nightly-testing --tags
+          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
+          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+
+      - name: Set branch ref
+        run: |
+          if [ "${{ matrix.branch_type }}" == "master" ]; then
+            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
+          else
+            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
+          fi
+
+      # Checkout the branch or tag we want to test.
+      - name: Checkout branch or tag
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: ${{ matrix.branch_type == 'nightly' && 'leanprover-community/mathlib4-nightly-testing' || github.repository }}
+          ref: ${{ env.BRANCH_REF }}
+
+      - name: Configure Lean
+        uses: leanprover/lean-action@434f25c2f80ded67bba02502ad3a86f25db50709 # v1.3.0
+        with:
+          auto-config: false
+          use-github-cache: false
+          use-mathlib-cache: true
+          reinstall-transient-toolchain: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check Mathlib using nanoda # make sure this name is consistent with "Get job status and URLs" in the notify job
+        id: nanoda
+        continue-on-error: true
+        run: |
+          # Clone and build lean4export
+          # TODO: Once https://github.com/leanprover/lean4export/pull/11 is merged,
+          # switch to leanprover/lean4export and remove the `git checkout` line below.
+          git clone https://github.com/kim-em/lean4export
+          cd lean4export
+          git checkout fix-nondep-normalization
+          # Match toolchain to mathlib
+          cp ../lean-toolchain .
+          lake build
+          cd ..
+
+          # Clone and build nanoda_lib
+          git clone https://github.com/ammkrn/nanoda_lib
+          cd nanoda_lib
+          git checkout debug
+          cargo build --release
+          cd ..
+
+          # Export Mathlib
+          lake env lean4export/.lake/build/bin/lean4export Mathlib > mathlib_export.txt
+
+          # Create config
+          cat > nanoda_config.json << 'EOF'
+          {
+              "export_file_path": "mathlib_export.txt",
+              "permitted_axioms": [
+                  "propext",
+                  "Classical.choice",
+                  "Quot.sound",
+                  "Lean.trustCompiler"
+              ],
+              "unpermitted_axiom_hard_error": false,
+              "nat_extension": true,
+              "string_extension": true,
+              "print_success_message": true
+          }
+          EOF
+
+          # Run nanoda
+          nanoda_lib/target/release/nanoda_bin nanoda_config.json
+
+  notify-nanoda:
+    runs-on: ubuntu-latest
+    needs: check-nanoda
+    if: github.repository == 'leanprover-community/mathlib4' && always()
+    strategy:
+      fail-fast: false
+      matrix:
+        branch_type: [master, nightly]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Get job status and URLs
+        id: get-status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          JOB_NAME="check-nanoda (${{ matrix.branch_type }})"
+
+          # Get URL to the specific step
+          NANODA_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
+            ".jobs[] | select(.name == \"$JOB_NAME\") \
+            | (.url + (.steps[] | select(.name == \"Check Mathlib using nanoda\") \
+              | \"#step:\(.number):1\"))")
+
+          echo "nanoda_url=${NANODA_URL}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Fetch latest tags (if nightly)
+        if: matrix.branch_type == 'nightly'
+        run: |
+          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+          git fetch nightly-testing --tags
+          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
+          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
+
+      - name: Set branch ref
+        run: |
+          if [ "${{ matrix.branch_type }}" == "master" ]; then
+            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
+          else
+            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Post success message for nanoda on Zulip
+        if: needs.check-nanoda.result == 'success'
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'nightly-testing'
+          type: 'stream'
+          topic: 'nanoda'
+          content: |
+            ✅ nanoda [succeeded](${{ steps.get-status.outputs.nanoda_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+
+      - name: Post failure / cancelled message for nanoda on Zulip
+        if: needs.check-nanoda.result != 'success'
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'nightly-testing'
+          type: 'stream'
+          topic: 'nanoda failure'
+          content: |
+            ❌ nanoda [${{ needs.check-nanoda.result }}](${{ steps.get-status.outputs.nanoda_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})


### PR DESCRIPTION
This PR adds a new daily CI job that verifies Mathlib using [nanoda_lib](https://github.com/ammkrn/nanoda_lib), an independent Lean 4 type checker written in Rust.

Like lean4checker, this runs daily on both master and nightly-testing, and reports results to Zulip (in the `nightly-testing` stream, topic `nanoda` for successes and `nanoda failure` for failures).

**Temporary workaround**: This uses a fork of lean4export with https://github.com/leanprover/lean4export/pull/11 applied, which fixes nonDep normalization for export. Once that PR is merged, we can switch back to the official repo.

🤖 Prepared with Claude Code