### PR TITLE
[Merged by Bors] - feat(Order): `OrderIso`  involving `Prod` and `Lex`

### DIFF
--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -717,6 +717,12 @@ theorem sumLexDualAntidistrib_symm_inr :
     (sumLexDualAntidistrib α β).symm (inr (toDual a)) = toDual (inl a) :=
   rfl
 
+def sumLexEmpty (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
+    Lex (α ⊕ β) ≃o α := @RelIso.sumLexEmpty α β _ _ _
+
+def emptySumLex (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
+    Lex (β ⊕ α) ≃o α := @RelIso.emptySumLex β α _ _ _
+
 end OrderIso
 
 variable [LE α]

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -718,16 +718,20 @@ theorem sumLexDualAntidistrib_symm_inr :
   rfl
 
 /-- `Equiv.sumEmpty` as an `OrderIso` with the lexicographic sum. -/
-def sumLexEmpty (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
+def sumLexEmpty [IsEmpty β] :
     Lex (α ⊕ β) ≃o α := RelIso.sumLexEmpty ..
 
 /-- `Equiv.emptySum` as an `OrderIso` with the lexicographic sum. -/
-def emptySumLex (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
+def emptySumLex [IsEmpty β] :
     Lex (β ⊕ α) ≃o α := RelIso.emptySumLex ..
 
 @[simp]
-lemma sumLexEmpty_apply_inl (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] (x : α) :
-  sumLexEmpty α β (toLex <| .inl x) = x := rfl
+lemma sumLexEmpty_apply_inl [IsEmpty β] (x : α) :
+  sumLexEmpty (β := β) (toLex <| .inl x) = x := rfl
+
+@[simp]
+lemma sumLexEmpty_apply_inr [IsEmpty β] (x : α) :
+  emptySumLex (β := β) (toLex <| .inr x) = x := rfl
 
 end OrderIso
 

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -730,7 +730,7 @@ lemma sumLexEmpty_apply_inl [IsEmpty β] (x : α) :
   sumLexEmpty (β := β) (toLex <| .inl x) = x := rfl
 
 @[simp]
-lemma sumLexEmpty_apply_inr [IsEmpty β] (x : α) :
+lemma emptySumLex_apply_inr [IsEmpty β] (x : α) :
   emptySumLex (β := β) (toLex <| .inr x) = x := rfl
 
 end OrderIso

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -721,8 +721,13 @@ theorem sumLexDualAntidistrib_symm_inr :
 def sumLexEmpty (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
     Lex (α ⊕ β) ≃o α := RelIso.sumLexEmpty ..
 
+/-- `Equiv.emptySum` as an `OrderIso` with the lexicographic sum. -/
 def emptySumLex (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
-    Lex (β ⊕ α) ≃o α := @RelIso.emptySumLex β α _ _ _
+    Lex (β ⊕ α) ≃o α := RelIso.emptySumLex ..
+
+@[simp]
+lemma sumLexEmpty_apply_inl (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] (x : α) :
+  sumLexEmpty α β (toLex <| .inl x) = x := rfl
 
 end OrderIso
 

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -717,8 +717,9 @@ theorem sumLexDualAntidistrib_symm_inr :
     (sumLexDualAntidistrib α β).symm (inr (toDual a)) = toDual (inl a) :=
   rfl
 
+/-- `Equiv.sumEmpty` as an `OrderIso` with the lexicographic sum. -/
 def sumLexEmpty (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
-    Lex (α ⊕ β) ≃o α := @RelIso.sumLexEmpty α β _ _ _
+    Lex (α ⊕ β) ≃o α := RelIso.sumLexEmpty ..
 
 def emptySumLex (α β : Type*) [Preorder α] [IsEmpty β] [Preorder β] :
     Lex (β ⊕ α) ≃o α := @RelIso.emptySumLex β α _ _ _

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -884,6 +884,13 @@ def prodComm : α × β ≃o β × α where
   toEquiv := Equiv.prodComm α β
   map_rel_iff' := Prod.swap_le_swap
 
+/-- `Equiv.prodAssoc` promoted to an order isomorphism. -/
+@[simps! (attr := grind =)]
+def prodAssoc (α β γ : Type*) [LE α] [LE β] [LE γ] :
+    (α × β) × γ ≃o α × (β × γ) where
+  toEquiv := .prodAssoc α β γ
+  map_rel_iff' := @fun ⟨⟨_, _⟩, _⟩ ⟨⟨_, _⟩, _⟩ ↦ by simp [Equiv.prodAssoc, and_assoc]
+
 @[simp]
 theorem coe_prodComm : ⇑(prodComm : α × β ≃o β × α) = Prod.swap :=
   rfl
@@ -1068,6 +1075,10 @@ noncomputable def ofUnique
     α ≃o β where
   toEquiv := Equiv.ofUnique α β
   map_rel_iff' := by simp
+
+/-- `Equiv.equivOfIsEmpty` promoted to an `OrderIso`. -/
+def ofIsEmpty (α β : Type*) [Preorder α] [Preorder β] [IsEmpty α] [IsEmpty β] : α ≃o β :=
+  ⟨Equiv.equivOfIsEmpty α β, @isEmptyElim _ _ _⟩
 
 end OrderIso
 

--- a/Mathlib/Order/Hom/Lex.lean
+++ b/Mathlib/Order/Hom/Lex.lean
@@ -180,7 +180,8 @@ theorem uniqueProd_apply [Preorder α] [Unique α] [LE β] (x : α ×ₗ β) :
     uniqueProd α β x = (ofLex x).2 := rfl
 
 /-- `Equiv.prodAssoc` promoted to an order isomorphism of lexicographic products. -/
-def prodAssoc (α β γ : Type*)
+@[simps!]
+def prodLexAssoc (α β γ : Type*)
     [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ×ₗ β) ×ₗ γ ≃o α ×ₗ β ×ₗ γ :=
   { toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
       .trans (.prodAssoc α β γ) <| .trans (.prodCongr (.refl _) toLex) <| toLex
@@ -189,8 +190,11 @@ def prodAssoc (α β γ : Type*)
       Equiv.prodAssoc_apply]; grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
    }
 
-/-- `Equiv.sumProdDistrib` promoted to an order isomorphism of lexicographic products. -/
-def sumProdDistrib (α β γ : Type*)
+/-- `Equiv.sumProdDistrib` promoted to an order isomorphism of lexicographic products.
+
+Right distributivity doesn't hold. A counterexample is `ℕ ×ₗ (Unit ⊕ₗ Unit) ≃o ℕ` which is not isomorphic to `ℕ ×ₗ Unit ⊕ₗ ℕ ×ₗ Unit ≃o ℕ ⊕ₗ ℕ`. -/
+@[simps!]
+def sumLexProdLexDistrib (α β γ : Type*)
     [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ⊕ₗ β) ×ₗ γ ≃o α ×ₗ γ ⊕ₗ β ×ₗ γ where
   toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
     .trans (.sumProdDistrib α β γ) <| .trans (.sumCongr toLex toLex) toLex
@@ -198,7 +202,7 @@ def sumProdDistrib (α β γ : Type*)
 
 /-- `Equiv.prodCongr` promoted to an order isomorphism between lexicographic products. -/
 @[simps! apply]
-def prodCongr {α β γ δ : Type*} [LinearOrder α] [LinearOrder β]
+def prodLexCongr {α β γ δ : Type*} [LinearOrder α] [LinearOrder β]
     [LinearOrder γ] [LinearOrder δ] (ea : α ≃o β) (eb : γ ≃o δ) : α ×ₗ γ ≃o β ×ₗ δ where
   toEquiv := ofLex.trans ((Equiv.prodCongr ea eb).trans toLex)
   map_rel_iff' := by simp [Prod.Lex.le_iff]

--- a/Mathlib/Order/Hom/Lex.lean
+++ b/Mathlib/Order/Hom/Lex.lean
@@ -179,4 +179,28 @@ variable {α β} in
 theorem uniqueProd_apply [Preorder α] [Unique α] [LE β] (x : α ×ₗ β) :
     uniqueProd α β x = (ofLex x).2 := rfl
 
+/-- `Equiv.prodAssoc` promoted to an order isomorphism of lexicographic products. -/
+def prodAssoc (α β γ : Type*)
+    [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ×ₗ β) ×ₗ γ ≃o α ×ₗ β ×ₗ γ :=
+  { toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
+      .trans (.prodAssoc α β γ) <| .trans (.prodCongr (.refl _) toLex) <| toLex
+    map_rel_iff' := by
+      simp only [Prod.Lex.le_iff, Prod.Lex.lt_iff, Equiv.trans_apply, Equiv.prodCongr_apply,
+      Equiv.prodAssoc_apply]; grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
+   }
+
+/-- `Equiv.sumProdDistrib` promoted to an order isomorphism of lexicographic products. -/
+def sumProdDistrib (α β γ : Type*)
+    [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ⊕ₗ β) ×ₗ γ ≃o α ×ₗ γ ⊕ₗ β ×ₗ γ where
+  toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
+    .trans (.sumProdDistrib α β γ) <| .trans (.sumCongr toLex toLex) toLex
+  map_rel_iff' := by simp [Prod.Lex.le_iff]
+
+/-- `Equiv.prodCongr` promoted to an order isomorphism between lexicographic products. -/
+@[simps! apply]
+def prodCongr {α β γ δ : Type*} [LinearOrder α] [LinearOrder β]
+    [LinearOrder γ] [LinearOrder δ] (ea : α ≃o β) (eb : γ ≃o δ) : α ×ₗ γ ≃o β ×ₗ δ where
+  toEquiv := ofLex.trans ((Equiv.prodCongr ea eb).trans toLex)
+  map_rel_iff' := by simp [Prod.Lex.le_iff]
+
 end Prod.Lex

--- a/Mathlib/Order/Hom/Lex.lean
+++ b/Mathlib/Order/Hom/Lex.lean
@@ -182,28 +182,28 @@ theorem uniqueProd_apply [Preorder α] [Unique α] [LE β] (x : α ×ₗ β) :
 /-- `Equiv.prodAssoc` promoted to an order isomorphism of lexicographic products. -/
 @[simps!]
 def prodLexAssoc (α β γ : Type*)
-    [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ×ₗ β) ×ₗ γ ≃o α ×ₗ β ×ₗ γ :=
-  { toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
+    [Preorder α] [Preorder β] [Preorder γ] : (α ×ₗ β) ×ₗ γ ≃o α ×ₗ β ×ₗ γ where
+  toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
       .trans (.prodAssoc α β γ) <| .trans (.prodCongr (.refl _) toLex) <| toLex
-    map_rel_iff' := by
-      simp only [Prod.Lex.le_iff, Prod.Lex.lt_iff, Equiv.trans_apply, Equiv.prodCongr_apply,
-      Equiv.prodAssoc_apply]; grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
-   }
+  map_rel_iff' := by
+    simp only [Prod.Lex.le_iff, Prod.Lex.lt_iff, Equiv.trans_apply, Equiv.prodCongr_apply,
+    Equiv.prodAssoc_apply]; grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
 
 /-- `Equiv.sumProdDistrib` promoted to an order isomorphism of lexicographic products.
 
-Right distributivity doesn't hold. A counterexample is `ℕ ×ₗ (Unit ⊕ₗ Unit) ≃o ℕ` which is not isomorphic to `ℕ ×ₗ Unit ⊕ₗ ℕ ×ₗ Unit ≃o ℕ ⊕ₗ ℕ`. -/
+Right distributivity doesn't hold. A counterexample is `ℕ ×ₗ (Unit ⊕ₗ Unit) ≃o ℕ`
+which is not isomorphic to `ℕ ×ₗ Unit ⊕ₗ ℕ ×ₗ Unit ≃o ℕ ⊕ₗ ℕ`. -/
 @[simps!]
 def sumLexProdLexDistrib (α β γ : Type*)
-    [LinearOrder α] [LinearOrder β] [LinearOrder γ] : (α ⊕ₗ β) ×ₗ γ ≃o α ×ₗ γ ⊕ₗ β ×ₗ γ where
+    [Preorder α] [Preorder β] [Preorder γ] : (α ⊕ₗ β) ×ₗ γ ≃o α ×ₗ γ ⊕ₗ β ×ₗ γ where
   toEquiv := .trans ofLex <| .trans (.prodCongr ofLex <| .refl _) <|
     .trans (.sumProdDistrib α β γ) <| .trans (.sumCongr toLex toLex) toLex
   map_rel_iff' := by simp [Prod.Lex.le_iff]
 
 /-- `Equiv.prodCongr` promoted to an order isomorphism between lexicographic products. -/
 @[simps! apply]
-def prodLexCongr {α β γ δ : Type*} [LinearOrder α] [LinearOrder β]
-    [LinearOrder γ] [LinearOrder δ] (ea : α ≃o β) (eb : γ ≃o δ) : α ×ₗ γ ≃o β ×ₗ δ where
+def prodLexCongr {α β γ δ : Type*} [Preorder α] [Preorder β]
+    [Preorder γ] [Preorder δ] (ea : α ≃o β) (eb : γ ≃o δ) : α ×ₗ γ ≃o β ×ₗ δ where
   toEquiv := ofLex.trans ((Equiv.prodCongr ea eb).trans toLex)
   map_rel_iff' := by simp [Prod.Lex.le_iff]
 

--- a/Mathlib/Order/Hom/Lex.lean
+++ b/Mathlib/Order/Hom/Lex.lean
@@ -187,7 +187,8 @@ def prodLexAssoc (α β γ : Type*)
       .trans (.prodAssoc α β γ) <| .trans (.prodCongr (.refl _) toLex) <| toLex
   map_rel_iff' := by
     simp only [Prod.Lex.le_iff, Prod.Lex.lt_iff, Equiv.trans_apply, Equiv.prodCongr_apply,
-    Equiv.prodAssoc_apply]; grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
+      Equiv.prodAssoc_apply]
+    grind [EmbeddingLike.apply_eq_iff_eq, ofLex_toLex]
 
 /-- `Equiv.sumProdDistrib` promoted to an order isomorphism of lexicographic products.
 


### PR DESCRIPTION

Adding some results that are needed for order types, in particular the monoids on them(see #33420).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
