### PR TITLE
[Merged by Bors] - chore(Tactic): remove duplicate instances

### DIFF
--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -36,32 +36,6 @@ public meta section
 open Batteries
 open Std (format ToFormat TreeSet)
 
-namespace Std.TreeSet
-
-variable {α : Type*} {cmp}
-
-/--
-`O(n₂ * log (n₁ + n₂))`. Merges the maps `t₁` and `t₂`.
-If equal keys exist in both, the key from `t₂` is preferred.
-
-Note: this has been renamed to `union'` as there is now an upstream definition.
-The new definition has a different implementation,
-and switching to using the upstream definition below breaks some tests.
-
-I've made this definition private to avoid confusion.
--/
-private def union' (t₁ t₂ : TreeSet α cmp) : TreeSet α cmp :=
-  t₂.foldl .insert t₁
-
-/--
-`O(n₁ * (log n₁ + log n₂))`. Constructs the set of all elements of `t₁` that are not in `t₂`.
--/
-def sdiff (t₁ t₂ : TreeSet α cmp) : TreeSet α cmp := t₁.filter (!t₂.contains ·)
-
-instance : SDiff (TreeSet α cmp) := ⟨TreeSet.sdiff⟩
-
-end Std.TreeSet
-
 namespace Mathlib.Tactic.Linarith
 
 /-!
@@ -170,7 +144,7 @@ iff `k' ≥ k`. Thus we can compute the intersection of officially and implicitl
 by taking the set of implicitly eliminated variables with indices ≥ `elimedGE`.
 -/
 def PComp.maybeMinimal (c : PComp) (elimedGE : ℕ) : Bool :=
-  c.history.size ≤ 1 + ((c.implicit.filter (· ≥ elimedGE)).union' c.effective).size
+  c.history.size ≤ 1 + ((c.implicit.filter (· ≥ elimedGE)).union c.effective).size
 
 /--
 The `src : CompSource` field is ignored when comparing `PComp`s. Two `PComp`s proving the same
@@ -204,10 +178,10 @@ this formula would leave them always empty.)
 def PComp.add (c1 c2 : PComp) (elimVar : ℕ) : PComp :=
   let c := c1.c.add c2.c
   let src := c1.src.add c2.src
-  let history := c1.history.union' c2.history
-  let vars := c1.vars.union' c2.vars
-  let effective := (c1.effective.union' c2.effective).insert elimVar
-  let implicit := (vars.sdiff (.ofList c.vars _)).sdiff effective
+  let history := c1.history.union c2.history
+  let vars := c1.vars.union c2.vars
+  let effective := (c1.effective.union c2.effective).insert elimVar
+  let implicit := (vars.diff (.ofList c.vars _)).diff effective
   ⟨c, src, history, effective, implicit, vars⟩
 
 /--
@@ -339,7 +313,7 @@ def elimVarM (a : ℕ) : LinarithM Unit := do
     let ⟨pos, neg, notPresent⟩ := splitSetByVarSign a (← getPCompSet)
     update (vs - 1) (← pos.foldlM (fun s p => do
       Lean.Core.checkSystem decl_name%.toString
-      pure (s.union' (elimWithSet a p neg))) notPresent)
+      pure (s.union (elimWithSet a p neg))) notPresent)
   else
     pure ()
 

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -313,7 +313,9 @@ def elimVarM (a : ℕ) : LinarithM Unit := do
     let ⟨pos, neg, notPresent⟩ := splitSetByVarSign a (← getPCompSet)
     update (vs - 1) (← pos.foldlM (fun s p => do
       Lean.Core.checkSystem decl_name%.toString
-      pure (s.union (elimWithSet a p neg))) notPresent)
+      -- FIXME: `.foldl .insert` should be equivalent to `.union`,
+      -- but this breaks a test.
+      pure ((elimWithSet a p neg).foldl .insert s)) notPresent)
   else
     pure ()
 

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -313,8 +313,8 @@ def elimVarM (a : ℕ) : LinarithM Unit := do
     let ⟨pos, neg, notPresent⟩ := splitSetByVarSign a (← getPCompSet)
     update (vs - 1) (← pos.foldlM (fun s p => do
       Lean.Core.checkSystem decl_name%.toString
-      -- FIXME: `.foldl .insert` should be equivalent to `.union`,
-      -- but this breaks a test.
+      -- FIXME: `.foldl .insert` should be equivalent to `.union`, but this breaks the test from
+      -- https://github.com/leanprover-community/mathlib4/issues/8875
       pure ((elimWithSet a p neg).foldl .insert s)) notPresent)
   else
     pure ()

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -79,7 +79,7 @@ theorem isNat_intOfNat : {n n' : ℕ} → IsNat n n' → IsNat (Int.ofNat n) n'
 @[norm_num Int.ofNat _] def evalIntOfNat : NormNumExt where eval {u α} e := do
   let .app (.const ``Int.ofNat _) (n : Q(ℕ)) ← whnfR e | failure
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q Int := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let sℤ : Q(AddMonoidWithOne ℤ) := q(instAddMonoidWithOne)
   let ⟨n', p⟩ ← deriveNat n sℕ
   haveI' x : $e =Q Int.ofNat $n := ⟨⟩
@@ -111,7 +111,7 @@ theorem isNat_natAbs_neg : {n : ℤ} → {a : ℕ} → IsInt n (.negOfNat a) →
   let .app (.const ``Int.natAbs _) (x : Q(ℤ)) ← whnfR e | failure
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
   haveI' : $e =Q Int.natAbs $x := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   match ← derive (u := .zero) x with
   | .isNat    _ a p => assumeInstancesCommute; return .isNat sℕ a q(isNat_natAbs_pos $p)
   | .isNegNat _ a p => assumeInstancesCommute; return .isNat sℕ a q(isNat_natAbs_neg $p)
@@ -127,7 +127,7 @@ theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
   let sα ← inferAddMonoidWithOne α
   let .app n (a : Q(ℕ)) ← whnfR e | failure
   guard <|← withNewMCtxDepth <| isDefEq n q(Nat.cast (R := $α))
-  let ⟨na, pa⟩ ← deriveNat a q(instAddMonoidWithOneNat)
+  let ⟨na, pa⟩ ← deriveNat a q(Nat.instAddMonoidWithOne)
   haveI' : $e =Q $a := ⟨⟩
   return .isNat sα na q(isNat_natCast $a $na $pa)
 
@@ -643,7 +643,7 @@ such that `norm_num` successfully recognises `a`. -/
   guard <|← withNewMCtxDepth <| isDefEq f q(Nat.succ)
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
   haveI' : $e =Q Nat.succ $a := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit!.succ)
   haveI' : $nc =Q ($na).succ := ⟨⟩
@@ -662,7 +662,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   guard <|← withNewMCtxDepth <| isDefEq f q(HSub.hSub (α := ℕ))
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
   haveI' : $e =Q $a - $b := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! - nb.natLit!)
   haveI' : Nat.sub $na $nb =Q $nc := ⟨⟩
@@ -681,7 +681,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   haveI' : $e =Q $a % $b := ⟨⟩
   -- We assert that the default instance for `HMod` is `Nat.mod` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HMod.hMod (α := ℕ))
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! % nb.natLit!)
   haveI' : Nat.mod $na $nb =Q $nc := ⟨⟩
@@ -700,7 +700,7 @@ def evalNatDiv : NormNumExt where eval {u α} e := do
   haveI' : $e =Q $a / $b := ⟨⟩
   -- We assert that the default instance for `HDiv` is `Nat.div` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HDiv.hDiv (α := ℕ))
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! / nb.natLit!)
   haveI' : Nat.div $na $nb =Q $nc := ⟨⟩
@@ -720,7 +720,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let .app (.app f (a : Q(ℕ))) (b : Q(ℕ)) ← whnfR e | failure
   -- We assert that the default instance for `Dvd` is `Nat.dvd` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(Dvd.dvd (α := ℕ))
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   match nb.natLit! % na.natLit! with
   | 0 =>

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -84,7 +84,7 @@ initialize normNumExt : ScopedEnvExtension Entry (Entry × NormNumExt) NormNums 
 def derive {α : Q(Type u)} (e : Q($α)) (post := false) : MetaM (Result e) := do
   if e.isRawNatLit then
     let lit : Q(ℕ) := e
-    return .isNat (q(instAddMonoidWithOneNat) : Q(AddMonoidWithOne ℕ))
+    return .isNat (q(Nat.instAddMonoidWithOne) : Q(AddMonoidWithOne ℕ))
       lit (q(IsNat.raw_refl $lit) : Expr)
   profileitM Exception "norm_num" (← getOptions) do
     let s ← saveState

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -135,7 +135,7 @@ def evalNatGCD : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
   haveI' : $e =Q Nat.gcd $x $y := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, q⟩ ← deriveNat y sℕ
   let ⟨ed, pf⟩ := proveNatGCD ex ey
@@ -164,7 +164,7 @@ def evalNatLCM : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
   haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
   haveI' : $e =Q Nat.lcm $x $y := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, q⟩ ← deriveNat y sℕ
   let ⟨ed, pf⟩ := proveNatLCM ex ey

--- a/Mathlib/Tactic/NormNum/NatFactorial.lean
+++ b/Mathlib/Tactic/NormNum/NatFactorial.lean
@@ -67,7 +67,7 @@ lemma isNat_factorial {n x : ℕ} (h₁ : IsNat n x) (a : ℕ) (h₂ : (1).ascFa
 def evalNatFactorial : NormNumExt where eval {u α} e := do
   let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.factorial $x := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨_, val, ascPrf⟩ := proveAscFactorial 1 ex.natLit! q(nat_lit 1) ex
   return .isNat sℕ q($val) q(isNat_factorial $p $val $ascPrf)
@@ -82,7 +82,7 @@ lemma isNat_ascFactorial {n x l y : ℕ} (h₁ : IsNat n x) (h₂ : IsNat l y) (
 def evalNatAscFactorial : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.ascFactorial $x $y := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex₁, p₁⟩ ← deriveNat x sℕ
   let ⟨ex₂, p₂⟩ ← deriveNat y sℕ
   let ⟨_, val, ascPrf⟩ := proveAscFactorial ex₁.natLit! ex₂.natLit! ex₁ ex₂
@@ -120,7 +120,7 @@ def evalNatDescFactorial : NormNumExt where eval {u α} e := do
   have : u =QL 0 := ⟨⟩
   have : $α =Q ℕ := ⟨⟩
   have : $e =Q Nat.descFactorial $x' $y' := ⟨⟩
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨x, p₁⟩ ← deriveNat x' sℕ
   let ⟨y, p₂⟩ ← deriveNat y' sℕ
   if x.natLit! ≥ y.natLit! then

--- a/Mathlib/Tactic/NormNum/NatFib.lean
+++ b/Mathlib/Tactic/NormNum/NatFib.lean
@@ -109,7 +109,7 @@ theorem isNat_fib : {x nx z : ℕ} → IsNat x nx → Nat.fib nx = z → IsNat (
 @[norm_num Nat.fib _]
 def evalNatFib : NormNumExt where eval {_ _} e := do
   let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, pf⟩ := proveNatFib ex
   let pf' : Q(IsNat (Nat.fib $x) $ey) := q(isNat_fib $p $pf)

--- a/Mathlib/Tactic/NormNum/NatLog.lean
+++ b/Mathlib/Tactic/NormNum/NatLog.lean
@@ -62,7 +62,7 @@ Evaluates the `Nat.log` function.
 @[norm_num Nat.log _ _]
 def evalNatLog : NormNumExt where eval {u α} e := do
   let mkApp2 _ (b : Q(ℕ)) (n : Q(ℕ)) ← Meta.whnfR e | failure
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨eb, pb⟩ ← deriveNat b sℕ
   let ⟨en, pn⟩ ← deriveNat n sℕ
   let ⟨ek, pf⟩ := proveNatLog eb en
@@ -119,7 +119,7 @@ Evaluates the `Nat.clog` function.
 @[norm_num Nat.clog _ _]
 def evalNatClog : NormNumExt where eval {u α} e := do
   let mkApp2 _ (b : Q(ℕ)) (n : Q(ℕ)) ← Meta.whnfR e | failure
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨eb, pb⟩ ← deriveNat b sℕ
   let ⟨en, pn⟩ ← deriveNat n sℕ
   let ⟨ek, pf⟩ := proveNatClog eb en

--- a/Mathlib/Tactic/NormNum/NatSqrt.lean
+++ b/Mathlib/Tactic/NormNum/NatSqrt.lean
@@ -47,7 +47,7 @@ def proveNatSqrt (ex : Q(ℕ)) : (ey : Q(ℕ)) × Q(Nat.sqrt $ex = $ey) :=
 @[norm_num Nat.sqrt _]
 def evalNatSqrt : NormNumExt where eval {_ _} e := do
   let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, pf⟩ := proveNatSqrt ex
   let pf' : Q(IsNat (Nat.sqrt $x) $ey) := q(isNat_sqrt $p $pf)

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -214,7 +214,7 @@ such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -
 @[norm_num _ ^ (_ : ℕ)]
 def evalPow : NormNumExt where eval {u α} e := do
   let .app (.app (f : Q($α → ℕ → $α)) (a : Q($α))) (b : Q(ℕ)) ← whnfR e | failure
-  let ⟨nb, pb⟩ ← deriveNat b q(instAddMonoidWithOneNat)
+  let ⟨nb, pb⟩ ← deriveNat b q(Nat.instAddMonoidWithOne)
   let sα ← inferSemiring α
   let ra ← derive a
   guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))

--- a/Mathlib/Tactic/NormNum/Prime.lean
+++ b/Mathlib/Tactic/NormNum/Prime.lean
@@ -123,7 +123,7 @@ theorem isNat_minFac_4 : {n n' k : ℕ} →
 /-- The `norm_num` extension which identifies expressions of the form `minFac n`. -/
 @[norm_num Nat.minFac _] partial def evalMinFac : NormNumExt where eval {_ _} e := do
   let .app (.const ``Nat.minFac _) (n : Q(ℕ)) ← whnfR e | failure
-  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨nn, pn⟩ ← deriveNat n sℕ
   let n' := nn.natLit!
   let rec aux (ek : Q(ℕ)) (prf : Q(MinFacHelper $nn $ek)) :

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -38,9 +38,6 @@ namespace Meta.NormNum
 
 variable {u : Level}
 
-/-- A shortcut (non)instance for `AddMonoidWithOne ℕ` to shrink generated proofs. -/
-def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
-
 /-- A shortcut (non)instance for `AddMonoidWithOne α`
 from `Semiring α` to shrink generated proofs. -/
 def instAddMonoidWithOne' {α : Type u} [Semiring α] : AddMonoidWithOne α := inferInstance

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -80,7 +80,7 @@ mutual
       (_ : Q(Ring $α)) (instCharP : Q(CharP $α $n)) : MetaM (Result e) := do
     let .app (.app (f : Q($α → ℕ → $α)) (a : Q($α))) (b : Q(ℕ)) ← whnfR e | failure
     let .isNat sα na pa ← normIntNumeral' n n' pn a _ instCharP | failure
-    let ⟨nb, pb⟩ ← Mathlib.Meta.NormNum.deriveNat b q(instAddMonoidWithOneNat)
+    let ⟨nb, pb⟩ ← Mathlib.Meta.NormNum.deriveNat b q(Nat.instAddMonoidWithOne)
     guard <|← withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
     haveI' : $e =Q $a ^ $b := ⟨⟩
     haveI' : $f =Q HPow.hPow := ⟨⟩
@@ -104,7 +104,7 @@ lemma CharP.intCast_eq_mod (R : Type _) [Ring R] (p : ℕ) [CharP R p] (k : ℤ)
 reduce `e` modulo `n`. -/
 partial def normIntNumeral {α : Q(Type u)} (n : Q(ℕ)) (e : Q($α)) (_ : Q(Ring $α))
     (instCharP : Q(CharP $α $n)) : MetaM (Result e) := do
-  let ⟨n', pn⟩ ← deriveNat n q(instAddMonoidWithOneNat)
+  let ⟨n', pn⟩ ← deriveNat n q(Nat.instAddMonoidWithOne)
   normIntNumeral' n n' pn e _ instCharP
 
 lemma CharP.neg_eq_sub_one_mul {α : Type _} [Ring α] (n : ℕ) (inst : CharP α n) (b : α)

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -686,6 +686,19 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     False := by
   intros; linarith
 
+/--
+error: linarith failed to find a contradiction
+case h1.h
+a b c d e : ℚ
+ha : 2 * a + b + c + d + e = 4
+hb : a + 2 * b + c + d + e = 5
+hc : a + b + 2 * c + d + e = 6
+hd : a + b + c + 2 * d + e = 7
+he : a + b + c + d + 2 * e = 8
+a✝ : e < 3
+⊢ False
+failed
+-/
 #guard_msgs in
 /-- https://github.com/leanprover-community/mathlib4/issues/8875 -/
 example (a b c d e : ℚ)

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -686,19 +686,6 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     False := by
   intros; linarith
 
-/--
-error: linarith failed to find a contradiction
-case h1.h
-a b c d e : ℚ
-ha : 2 * a + b + c + d + e = 4
-hb : a + 2 * b + c + d + e = 5
-hc : a + b + 2 * c + d + e = 6
-hd : a + b + c + 2 * d + e = 7
-he : a + b + c + d + 2 * e = 8
-a✝ : e < 3
-⊢ False
-failed
--/
 #guard_msgs in
 /-- https://github.com/leanprover-community/mathlib4/issues/8875 -/
 example (a b c d e : ℚ)


### PR DESCRIPTION
This PR removes the two duplicate instances that were detected in `Mathlib.Tactic`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
