### PR TITLE
feat: A linter for instances that overlap on data

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6648,6 +6648,7 @@ public import Mathlib.Tactic.Linter.Lint
 public import Mathlib.Tactic.Linter.MinImports
 public import Mathlib.Tactic.Linter.Multigoal
 public import Mathlib.Tactic.Linter.OldObtain
+public import Mathlib.Tactic.Linter.OverlappingInstances
 public import Mathlib.Tactic.Linter.PPRoundtrip
 public import Mathlib.Tactic.Linter.PrivateModule
 public import Mathlib.Tactic.Linter.Style

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -169,6 +169,7 @@ public import Mathlib.Tactic.Linter.Lint
 public import Mathlib.Tactic.Linter.MinImports
 public import Mathlib.Tactic.Linter.Multigoal
 public import Mathlib.Tactic.Linter.OldObtain
+public import Mathlib.Tactic.Linter.OverlappingInstances
 public import Mathlib.Tactic.Linter.PPRoundtrip
 public import Mathlib.Tactic.Linter.PrivateModule
 public import Mathlib.Tactic.Linter.Style

--- a/Mathlib/Tactic/Linter/OverlappingInstances.lean
+++ b/Mathlib/Tactic/Linter/OverlappingInstances.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Jovan Gerbscheid. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jovan Gerbscheid
+-/
+module
+
+public import Mathlib.Init
+
+/-
+# A linter to declarations with local instances that have overlapping data
+
+We want to avoid this because this lead to instance diamonds
+-/
+
+open Lean Meta Batteries Tactic Lint
+
+public meta section
+
+/-- Given an instance `e`, conpute return all data carrying classes that are
+the type of `e` itself, or a child class. -/
+private partial def getStructureDataProjections (e : Expr) (acc : Array Expr := #[]) :
+    StateRefT NameSet MetaM (Array Expr) := do
+  let eType ← whnf (← inferType e)
+  if ← isProp eType then return acc
+  let .const structName us := eType.getForallBody.getAppFn
+    | throwError "{e} is not an instance of a structure"
+  if (← get).contains structName then return acc
+  modify (·.insert structName)
+  let some info := getStructureInfo? (← getEnv) structName | return acc
+  info.parentInfo.foldlM (init := acc.push eType) fun acc info ↦ do
+    if ← isInstance info.projFn then
+      let proj := Expr.app (mkAppN (.const info.projFn us) eType.getAppArgs) e
+      getStructureDataProjections proj acc
+    else
+      return acc
+
+/-- Run the overlapping instances linter on `declName`. -/
+def findDuplicateDataInstances (declName : Name) : CoreM (Option MessageData) := MetaM.run' do
+  Core.checkSystem "overlappingInstances"
+  forallTelescope (← getConstInfo declName).type fun _ _ ↦ do
+  let mut result := none
+  let mut insts : Std.HashMap Expr Expr := {}
+  for { fvar, .. } in ← getLocalInstances do
+    unless (← fvar.fvarId!.getBinderInfo).isInstImplicit do continue
+    let projClasses ← forallTelescope (← inferType fvar) fun xs _ ↦ do
+      (← getStructureDataProjections (mkAppN fvar xs) |>.run' {}).mapM (mkForallFVars xs)
+
+    for cls in projClasses do
+      if let some fvar' := insts[cls]? then
+        let type ← inferType fvar; let type' ← inferType fvar'
+        if type == type' then
+          result := m!"{result.getD m!""}There are multiple different instances of `{type}`\n\n"
+          break
+        else
+          result := m!"{result.getD m!""}`{type}` and `{type'}` both imply `{cls}`\n\n"
+      else
+        insts := insts.insert cls fvar
+  result.mapM addMessageContextFull
+
+/-- A linter for declarations which have instance hypotheses that have overlapping data. -/
+@[env_linter] def overlappingInstances : Lint.Linter where
+  noErrorsFound := "No declarations have overlapping instance arguments"
+  errorsFound := "Some declarations have overlapping instance arguments"
+  test := fun declName => do
+    if declName.isInternal then return none
+    if congrKindsExt.contains (← getEnv) declName then return none
+    findDuplicateDataInstances declName


### PR DESCRIPTION
This PR defines a linter for overlapping instances in declarations. We want to warn users about this, because it leads to local instance diamonds.

TODO
- expand documentation
- Ideally, the linter would be active at all times, included in the standard linter set, and it should also be able to fire on partial declarations, since it only works with the type of the declaration.

closes: https://github.com/mathlib-initiative/TaskList/issues/15

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
