### PR TITLE
[Merged by Bors] - feat(Topology/Inseparable): condition for the compactness of a subset

### DIFF
--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -212,6 +212,17 @@ theorem IsClosed.continuous_piecewise_of_specializes [DecidablePred (· ∈ s)] 
     Continuous (s.piecewise f g) := by
   simpa only [piecewise_compl] using hs.isOpen_compl.continuous_piecewise_of_specializes hg hf hspec
 
+theorem Specializes.clusterPt {f : Filter X} (h : x ⤳ y) (hx : ClusterPt x f) :
+    ClusterPt y f :=
+  Filter.NeBot.mono hx <| inf_le_inf_right _ h
+
+theorem IsCompact.subset_of_specializes {s t : Set X} (hs : IsCompact s) (hts : t ⊆ s)
+    (h : ∀ x ∈ s, ∃ y ∈ t, x ⤳ y) : IsCompact t := by
+  intro f _ hf
+  obtain ⟨x, hxs, hxf⟩ := hs <| hf.trans <| Filter.monotone_principal hts
+  obtain ⟨y, hyt, hxy⟩ := h x hxs
+  exact ⟨y, hyt, hxy.clusterPt hxf⟩
+
 attribute [local instance] specializationPreorder
 
 /-- A continuous function is monotone with respect to the specialization preorders on the domain and

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -216,7 +216,7 @@ theorem Specializes.clusterPt {f : Filter X} (h : x ⤳ y) (hx : ClusterPt x f) 
     ClusterPt y f :=
   Filter.NeBot.mono hx <| inf_le_inf_right _ h
 
-theorem IsCompact.subset_of_specializes {s t : Set X} (hs : IsCompact s) (hts : t ⊆ s)
+theorem IsCompact.of_subset_of_specializes {s t : Set X} (hs : IsCompact s) (hts : t ⊆ s)
     (h : ∀ x ∈ s, ∃ y ∈ t, x ⤳ y) : IsCompact t := by
   intro f _ hf
   obtain ⟨x, hxs, hxf⟩ := hs <| hf.trans <| Filter.monotone_principal hts


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
