### PR TITLE
[Merged by Bors] - chore(Topology/Order/Lattice): tag continuity lemmas with `fun_prop`

### DIFF
--- a/Mathlib/Topology/Order/Lattice.lean
+++ b/Mathlib/Topology/Order/Lattice.lean
@@ -172,6 +172,7 @@ section Sup
 
 variable [Max L] [ContinuousSup L] {f g : X → L} {s : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.sup' (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (f ⊔ g) x :=
   hf.sup_nhds' hg
@@ -181,14 +182,17 @@ lemma ContinuousAt.sup (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (fun a ↦ f a ⊔ g a) x :=
   hf.sup' hg
 
+@[fun_prop]
 lemma ContinuousWithinAt.sup' (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
     ContinuousWithinAt (f ⊔ g) s x :=
   hf.sup_nhds' hg
 
+@[fun_prop]
 lemma ContinuousWithinAt.sup (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
     ContinuousWithinAt (fun a ↦ f a ⊔ g a) s x :=
   hf.sup' hg
 
+@[fun_prop]
 lemma ContinuousOn.sup' (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (f ⊔ g) s := fun x hx ↦
   (hf x hx).sup' (hg x hx)
@@ -198,6 +202,7 @@ lemma ContinuousOn.sup (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a ↦ f a ⊔ g a) s :=
   hf.sup' hg
 
+@[fun_prop]
 lemma Continuous.sup' (hf : Continuous f) (hg : Continuous g) : Continuous (f ⊔ g) := hf.sup hg
 
 end Sup
@@ -206,6 +211,7 @@ section Inf
 
 variable [Min L] [ContinuousInf L] {f g : X → L} {s : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.inf' (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (f ⊓ g) x :=
   hf.inf_nhds' hg
@@ -215,14 +221,17 @@ lemma ContinuousAt.inf (hf : ContinuousAt f x) (hg : ContinuousAt g x) :
     ContinuousAt (fun a ↦ f a ⊓ g a) x :=
   hf.inf' hg
 
+@[fun_prop]
 lemma ContinuousWithinAt.inf' (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
     ContinuousWithinAt (f ⊓ g) s x :=
   hf.inf_nhds' hg
 
+@[fun_prop]
 lemma ContinuousWithinAt.inf (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
     ContinuousWithinAt (fun a ↦ f a ⊓ g a) s x :=
   hf.inf' hg
 
+@[fun_prop]
 lemma ContinuousOn.inf' (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (f ⊓ g) s := fun x hx ↦
   (hf x hx).inf' (hg x hx)
@@ -232,6 +241,7 @@ lemma ContinuousOn.inf (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
     ContinuousOn (fun a ↦ f a ⊓ g a) s :=
   hf.inf' hg
 
+@[fun_prop]
 lemma Continuous.inf' (hf : Continuous f) (hg : Continuous g) : Continuous (f ⊓ g) := hf.inf hg
 
 end Inf
@@ -241,36 +251,44 @@ section FinsetSup'
 variable {ι : Type*} [SemilatticeSup L] [ContinuousSup L] {s : Finset ι}
   {f : ι → X → L} {t : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.finset_sup'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (fun a ↦ s.sup' hne (f · a)) x :=
   Tendsto.finset_sup'_nhds_apply hne hs
 
+@[fun_prop]
 lemma ContinuousAt.finset_sup' (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (s.sup' hne f) x := by
   simpa only [← Finset.sup'_apply] using finset_sup'_apply hne hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_sup'_apply (hne : s.Nonempty)
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) :
     ContinuousWithinAt (fun a ↦ s.sup' hne (f · a)) t x :=
   Tendsto.finset_sup'_nhds_apply hne hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_sup' (hne : s.Nonempty)
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) : ContinuousWithinAt (s.sup' hne f) t x := by
   simpa only [← Finset.sup'_apply] using finset_sup'_apply hne hs
 
+@[fun_prop]
 lemma ContinuousOn.finset_sup'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (fun a ↦ s.sup' hne (f · a)) t := fun x hx ↦
   ContinuousWithinAt.finset_sup'_apply hne fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma ContinuousOn.finset_sup' (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (s.sup' hne f) t := fun x hx ↦
   ContinuousWithinAt.finset_sup' hne fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma Continuous.finset_sup'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (fun a ↦ s.sup' hne (f · a)) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_sup'_apply _ fun i hi ↦
     (hs i hi).continuousAt
 
+@[fun_prop]
 lemma Continuous.finset_sup' (hne : s.Nonempty) (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (s.sup' hne f) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_sup' _ fun i hi ↦ (hs i hi).continuousAt
@@ -282,36 +300,44 @@ section FinsetSup
 variable {ι : Type*} [SemilatticeSup L] [OrderBot L] [ContinuousSup L] {s : Finset ι}
   {f : ι → X → L} {t : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.finset_sup_apply (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (fun a ↦ s.sup (f · a)) x :=
   Tendsto.finset_sup_nhds_apply hs
 
+@[fun_prop]
 lemma ContinuousAt.finset_sup (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (s.sup f) x := by
   simpa only [← Finset.sup_apply] using finset_sup_apply hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_sup_apply
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) :
     ContinuousWithinAt (fun a ↦ s.sup (f · a)) t x :=
   Tendsto.finset_sup_nhds_apply hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_sup
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) : ContinuousWithinAt (s.sup f) t x := by
   simpa only [← Finset.sup_apply] using finset_sup_apply hs
 
+@[fun_prop]
 lemma ContinuousOn.finset_sup_apply (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (fun a ↦ s.sup (f · a)) t := fun x hx ↦
   ContinuousWithinAt.finset_sup_apply fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma ContinuousOn.finset_sup (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (s.sup f) t := fun x hx ↦
   ContinuousWithinAt.finset_sup fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma Continuous.finset_sup_apply (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (fun a ↦ s.sup (f · a)) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_sup_apply fun i hi ↦
     (hs i hi).continuousAt
 
+@[fun_prop]
 lemma Continuous.finset_sup (hs : ∀ i ∈ s, Continuous (f i)) : Continuous (s.sup f) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_sup fun i hi ↦ (hs i hi).continuousAt
 
@@ -322,36 +348,44 @@ section FinsetInf'
 variable {ι : Type*} [SemilatticeInf L] [ContinuousInf L] {s : Finset ι}
   {f : ι → X → L} {t : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.finset_inf'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (fun a ↦ s.inf' hne (f · a)) x :=
   Tendsto.finset_inf'_nhds_apply hne hs
 
+@[fun_prop]
 lemma ContinuousAt.finset_inf' (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (s.inf' hne f) x := by
   simpa only [← Finset.inf'_apply] using finset_inf'_apply hne hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_inf'_apply (hne : s.Nonempty)
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) :
     ContinuousWithinAt (fun a ↦ s.inf' hne (f · a)) t x :=
   Tendsto.finset_inf'_nhds_apply hne hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_inf' (hne : s.Nonempty)
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) : ContinuousWithinAt (s.inf' hne f) t x := by
   simpa only [← Finset.inf'_apply] using finset_inf'_apply hne hs
 
+@[fun_prop]
 lemma ContinuousOn.finset_inf'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (fun a ↦ s.inf' hne (f · a)) t := fun x hx ↦
   ContinuousWithinAt.finset_inf'_apply hne fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma ContinuousOn.finset_inf' (hne : s.Nonempty) (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (s.inf' hne f) t := fun x hx ↦
   ContinuousWithinAt.finset_inf' hne fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma Continuous.finset_inf'_apply (hne : s.Nonempty) (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (fun a ↦ s.inf' hne (f · a)) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_inf'_apply _ fun i hi ↦
     (hs i hi).continuousAt
 
+@[fun_prop]
 lemma Continuous.finset_inf' (hne : s.Nonempty) (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (s.inf' hne f) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_inf' _ fun i hi ↦ (hs i hi).continuousAt
@@ -363,36 +397,44 @@ section FinsetInf
 variable {ι : Type*} [SemilatticeInf L] [OrderTop L] [ContinuousInf L] {s : Finset ι}
   {f : ι → X → L} {t : Set X} {x : X}
 
+@[fun_prop]
 lemma ContinuousAt.finset_inf_apply (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (fun a ↦ s.inf (f · a)) x :=
   Tendsto.finset_inf_nhds_apply hs
 
+@[fun_prop]
 lemma ContinuousAt.finset_inf (hs : ∀ i ∈ s, ContinuousAt (f i) x) :
     ContinuousAt (s.inf f) x := by
   simpa only [← Finset.inf_apply] using finset_inf_apply hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_inf_apply
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) :
     ContinuousWithinAt (fun a ↦ s.inf (f · a)) t x :=
   Tendsto.finset_inf_nhds_apply hs
 
+@[fun_prop]
 lemma ContinuousWithinAt.finset_inf
     (hs : ∀ i ∈ s, ContinuousWithinAt (f i) t x) : ContinuousWithinAt (s.inf f) t x := by
   simpa only [← Finset.inf_apply] using finset_inf_apply hs
 
+@[fun_prop]
 lemma ContinuousOn.finset_inf_apply (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (fun a ↦ s.inf (f · a)) t := fun x hx ↦
   ContinuousWithinAt.finset_inf_apply fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma ContinuousOn.finset_inf (hs : ∀ i ∈ s, ContinuousOn (f i) t) :
     ContinuousOn (s.inf f) t := fun x hx ↦
   ContinuousWithinAt.finset_inf fun i hi ↦ hs i hi x hx
 
+@[fun_prop]
 lemma Continuous.finset_inf_apply (hs : ∀ i ∈ s, Continuous (f i)) :
     Continuous (fun a ↦ s.inf (f · a)) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_inf_apply fun i hi ↦
     (hs i hi).continuousAt
 
+@[fun_prop]
 lemma Continuous.finset_inf (hs : ∀ i ∈ s, Continuous (f i)) : Continuous (s.inf f) :=
   continuous_iff_continuousAt.2 fun _ ↦ ContinuousAt.finset_inf fun i hi ↦ (hs i hi).continuousAt
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
