### PR TITLE
[Merged by Bors] - fix(ci): show helpful message when runLinter needs master merge

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -502,8 +502,9 @@ jobs:
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
-          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
-            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+          # We use .lake/ for the output file because landrun restricts /tmp access
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -501,7 +501,24 @@ jobs:
         id: lint
         run: |
           cd pr-branch
-          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib
+          # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
+            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
+            fi
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -512,8 +512,9 @@ jobs:
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
+          # We use .lake/ for the output file because landrun restricts /tmp access
           if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
-            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -512,7 +512,7 @@ jobs:
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
-          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
             if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
               echo ""
               echo "=============================================================================="

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -511,7 +511,24 @@ jobs:
         id: lint
         run: |
           cd pr-branch
-          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib
+          # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
+            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
+            fi
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -517,7 +517,24 @@ jobs:
         id: lint
         run: |
           cd pr-branch
-          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib
+          # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
+            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
+            fi
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,8 +518,9 @@ jobs:
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
-          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
-            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+          # We use .lake/ for the output file because landrun restricts /tmp access
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -516,8 +516,9 @@ jobs:
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
-          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
-            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+          # We use .lake/ for the output file because landrun restricts /tmp access
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -515,7 +515,24 @@ jobs:
         id: lint
         run: |
           cd pr-branch
-          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib
+          # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
+          if ! env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --trace Mathlib 2>&1 | tee /tmp/lint_output.txt; then
+            if grep -q "cannot parse arguments" /tmp/lint_output.txt; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
+            fi
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23


### PR DESCRIPTION
This PR improves the CI error message when a contributor's branch is based on an older version of master that doesn't have the updated `runLinter` with `--trace` support.

Previously, the lint step would fail with a cryptic "cannot parse arguments" error. Now it detects that specific error and shows a clear message explaining the contributor needs to merge master:

```
==============================================================================
ERROR: Your branch uses an older version of runLinter that doesn't support
the --trace flag. Please merge 'master' into your PR branch to get the
updated linter, then push again.

You can do this with:
  git fetch upstream
  git merge upstream/master
  git push
==============================================================================
```

🤖 Prepared with Claude Code