### PR TITLE
[Merged by Bors] - chore(Algebra/Ring): semireal definition lemmas

### DIFF
--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -27,9 +27,8 @@ not.
 
 @[expose] public section
 
-variable {R : Type*}
+variable (R : Type*)
 
-variable (R) in
 /--
 A semireal ring is a commutative ring (with unit) in which `-1` is *not* a sum of
 squares. We define the predicate `IsSemireal R` for structures `R` equipped with
@@ -42,6 +41,16 @@ class IsSemireal [Add R] [Mul R] [One R] [Zero R] : Prop where
 /-- In a semireal ring, `-1` is not a sum of squares. -/
 theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal R] :
     ¬ IsSumSq (-1 : R) := (by simpa using one_add_ne_zero ·)
+
+variable {R} in
+theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
+    IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
+  mp _ := IsSemireal.not_isSumSq_neg_one _
+  mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
+
+variable {R} in
+theorem IsSemireal.of_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] (h : ¬ IsSumSq (-1 : R)) :
+    IsSemireal R := isSemireal_iff_not_isSumSq_neg_one.mpr h
 
 /--
 Linearly ordered semirings with the property `a ≤ b → ∃ c, a + c = b` (e.g. `ℕ`)

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -45,7 +45,7 @@ theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal 
 variable {R} in
 theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
     IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
-  mp := IsSemireal.not_isSumSq_neg_one _
+  mp _ := IsSemireal.not_isSumSq_neg_one _
   mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
 
 alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -48,9 +48,7 @@ theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
   mp _ := IsSemireal.not_isSumSq_neg_one _
   mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
 
-variable {R} in
-theorem IsSemireal.of_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] (h : ¬ IsSumSq (-1 : R)) :
-    IsSemireal R := isSemireal_iff_not_isSumSq_neg_one.mpr h
+alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one
 
 /--
 Linearly ordered semirings with the property `a ≤ b → ∃ c, a + c = b` (e.g. `ℕ`)

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -45,7 +45,7 @@ theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal 
 variable {R} in
 theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
     IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
-  mp := .not_isSumSq_neg_one
+  mp := IsSemireal.not_isSumSq_neg_one
   mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
 
 alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -45,7 +45,7 @@ theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal 
 variable {R} in
 theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
     IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
-  mp _ := IsSemireal.not_isSumSq_neg_one _
+  mp := .not_isSumSq_neg_one
   mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
 
 alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -45,7 +45,7 @@ theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal 
 variable {R} in
 theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
     IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
-  mp := IsSemireal.not_isSumSq_neg_one
+  mp := IsSemireal.not_isSumSq_neg_one _
   mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
 
 alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one


### PR DESCRIPTION
* Add converse to `IsSemireal.not_isSumSq_neg_one `

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
