### PR TITLE
[Merged by Bors] - feat: behavior under addition of the characteristic function of Value Distribution Theory

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -81,11 +81,12 @@ theorem characteristic_add_top_le {f₁ f₂ : ℂ → E} {r : ℝ} (h₁f₁ : 
   calc proximity (f₁ + f₂) ⊤ r + logCounting (f₁ + f₂) ⊤ r
     _ ≤ (proximity f₁ ⊤ r + proximity f₂ ⊤ r + log 2)
       + (logCounting f₁ ⊤ r + logCounting f₂ ⊤ r) := by
-    gcongr
-    · apply proximity_add_top_le h₁f₁ h₁f₂
-    · exact logCounting_add_top_le h₁f₁ h₁f₂ hr
-  _ = proximity f₁ ⊤ r + logCounting f₁ ⊤ r + (proximity f₂ ⊤ r + logCounting f₂ ⊤ r) + log 2 := by
-    ring
+      gcongr
+      · apply proximity_add_top_le h₁f₁ h₁f₂
+      · exact logCounting_add_top_le h₁f₁ h₁f₂ hr
+    _ = proximity f₁ ⊤ r + logCounting f₁ ⊤ r + (proximity f₂ ⊤ r + logCounting f₂ ⊤ r)
+      + log 2 := by
+      ring
 
 /--
 Asymptotically, the characteristic function of `f + g` at `⊤` is less than or equal to the sum of
@@ -95,11 +96,12 @@ theorem characteristic_add_top_eventuallyLE {f₁ f₂ : ℂ → E} (h₁f₁ : 
     (h₁f₂ : Meromorphic f₂) :
     characteristic (f₁ + f₂) ⊤
       ≤ᶠ[Filter.atTop] characteristic f₁ ⊤ + characteristic f₂ ⊤ + fun _ ↦ log 2 := by
-  filter_upwards [Filter.eventually_ge_atTop 1] with r hr using characteristic_add_top_le h₁f₁ h₁f₂ hr
+  filter_upwards [Filter.eventually_ge_atTop 1] with r hr
+    using characteristic_add_top_le h₁f₁ h₁f₂ hr
 
 /--
 For `1 ≤ r`, the characteristic function of a sum `∑ a, f a` at `⊤` is less than or equal to the sum
-of the characteristic functions of `f ·`.
+of the characteristic functions of `f ·`, plus `log s.card`.
 -/
 theorem characteristic_sum_top_le {α : Type*} (s : Finset α) (f : α → ℂ → E) {r : ℝ}
     (hf : ∀ a, Meromorphic (f a)) (hr : 1 ≤ r) :
@@ -107,13 +109,13 @@ theorem characteristic_sum_top_le {α : Type*} (s : Finset α) (f : α → ℂ �
   simp only [characteristic, Pi.add_apply, Finset.sum_apply]
   calc proximity (∑ a ∈ s, f a) ⊤ r + logCounting (∑ a ∈ s, f a) ⊤ r
   _ ≤ ((∑ a ∈ s, proximity (f a) ⊤) r) + log s.card + (∑ a ∈ s, (logCounting (f a) ⊤)) r := by
-    apply add_le_add
-    · apply proximity_sum_top_le s f hf r
-    · apply logCounting_sum_top_le s f hf hr
-  _ = ((∑ a ∈ s, proximity (f a) ⊤) r) + (∑ a ∈ s, (logCounting (f a) ⊤)) r + log s.card := by
-    ring
-  _ = ∑ x ∈ s, (proximity (f x) ⊤ r + logCounting (f x) ⊤ r) + log s.card := by
-    simp [Finset.sum_add_distrib]
+      gcongr
+      · apply proximity_sum_top_le s f hf r
+      · apply logCounting_sum_top_le s f hf hr
+    _ = ((∑ a ∈ s, proximity (f a) ⊤) r) + (∑ a ∈ s, (logCounting (f a) ⊤)) r + log s.card := by
+      ring
+    _ = ∑ x ∈ s, (proximity (f x) ⊤ r + logCounting (f x) ⊤ r) + log s.card := by
+      simp [Finset.sum_add_distrib]
 
 /--
 Asymptotically, the characteristic function of a sum `∑ a, f a` at `⊤` is less than or equal to the
@@ -124,7 +126,7 @@ theorem characteristic_sum_top_eventuallyLE {α : Type*} (s : Finset α) (f : α
     characteristic (∑ a ∈ s, f a) ⊤
       ≤ᶠ[Filter.atTop] ∑ a ∈ s, (characteristic (f a) ⊤) + fun _ ↦ log s.card := by
   filter_upwards [Filter.eventually_ge_atTop 1]
-  exact fun _ hr ↦ characteristic_sum_top_le s f hf hr
+    using fun _ hr ↦ characteristic_sum_top_le s f hf hr
 
 /--
 For `1 ≤ r`, the characteristic function for the zeros of `f * g` is less than or equal to the sum
@@ -150,7 +152,7 @@ theorem characteristic_mul_zero_eventuallyLE {f₁ f₂ : ℂ → ℂ}
     (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) 0 ≤ᶠ[Filter.atTop] characteristic f₁ 0 + characteristic f₂ 0 := by
   filter_upwards [Filter.eventually_ge_atTop 1]
-  exact fun _ hr ↦ characteristic_mul_zero_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
+    using fun _ hr ↦ characteristic_mul_zero_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
 
 @[deprecated (since := "2025-12-11")]
 alias characteristic_zero_mul_eventually_le := characteristic_mul_zero_eventuallyLE
@@ -179,7 +181,7 @@ theorem characteristic_mul_top_eventuallyLE {f₁ f₂ : ℂ → ℂ}
     (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) ⊤ ≤ᶠ[Filter.atTop] characteristic f₁ ⊤ + characteristic f₂ ⊤ := by
   filter_upwards [Filter.eventually_ge_atTop 1]
-  exact fun _ hr ↦ characteristic_mul_top_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
+    using fun _ hr ↦ characteristic_mul_top_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
 
 @[deprecated (since := "2025-12-11")]
 alias characteristic_top_mul_eventually_le := characteristic_mul_top_eventuallyLE

--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -70,6 +70,63 @@ lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : Meromorp
 -/
 
 /--
+For `1 ≤ r`, the characteristic function of `f + g` at `⊤` is less than or equal to the sum of the
+characteristic functions of `f` and `g`, respectively.
+-/
+theorem characteristic_add_top_le {f₁ f₂ : ℂ → E} {r : ℝ} (h₁f₁ : Meromorphic f₁)
+    (h₁f₂ : Meromorphic f₂) (hr : 1 ≤ r) :
+    characteristic (f₁ + f₂) ⊤ r ≤ characteristic f₁ ⊤ r + characteristic f₂ ⊤ r + log 2 := by
+  simp only [characteristic]
+  calc proximity (f₁ + f₂) ⊤ r + logCounting (f₁ + f₂) ⊤ r
+  _ ≤ (proximity f₁ ⊤ r + proximity f₂ ⊤ r + log 2)
+      + (logCounting f₁ ⊤ r + logCounting f₂ ⊤ r) := by
+    apply add_le_add
+    · apply proximity_add_top_le h₁f₁ h₁f₂
+    · exact logCounting_add_top_le h₁f₁ h₁f₂ hr
+  _ = proximity f₁ ⊤ r + logCounting f₁ ⊤ r + (proximity f₂ ⊤ r + logCounting f₂ ⊤ r) + log 2 := by
+    ring
+
+/--
+Asymptotically, the characteristic function of `f + g` at `⊤` is less than or equal to the sum of
+the characteristic functions of `f` and `g`, respectively.
+-/
+theorem characteristic_add_top_eventuallyLE {f₁ f₂ : ℂ → E} (h₁f₁ : Meromorphic f₁)
+    (h₁f₂ : Meromorphic f₂) :
+    characteristic (f₁ + f₂) ⊤
+      ≤ᶠ[Filter.atTop] characteristic f₁ ⊤ + characteristic f₂ ⊤ + fun _ ↦ log 2 := by
+  filter_upwards [Filter.eventually_ge_atTop 1]
+  exact fun _ hr ↦ characteristic_add_top_le h₁f₁ h₁f₂ hr
+
+/--
+For `1 ≤ r`, the characteristic function of a sum `∑ a, f a` at `⊤` is less than or equal to the sum
+of the characteristic functions of `f ·`.
+-/
+theorem characteristic_sum_top_le {α : Type*} (s : Finset α) (f : α → ℂ → E) {r : ℝ}
+    (hf : ∀ a, Meromorphic (f a)) (hr : 1 ≤ r) :
+    characteristic (∑ a ∈ s, f a) ⊤ r ≤ (∑ a ∈ s, (characteristic (f a) ⊤)) r + log s.card := by
+  simp only [characteristic, Pi.add_apply, Finset.sum_apply]
+  calc proximity (∑ a ∈ s, f a) ⊤ r + logCounting (∑ a ∈ s, f a) ⊤ r
+  _ ≤ ((∑ a ∈ s, proximity (f a) ⊤) r) + log s.card + (∑ a ∈ s, (logCounting (f a) ⊤)) r := by
+    apply add_le_add
+    · apply proximity_sum_top_le s f hf r
+    · apply logCounting_sum_top_le s f hf hr
+  _ = ((∑ a ∈ s, proximity (f a) ⊤) r) + (∑ a ∈ s, (logCounting (f a) ⊤)) r + log s.card := by
+    ring
+  _ = ∑ x ∈ s, (proximity (f x) ⊤ r + logCounting (f x) ⊤ r) + log s.card := by
+    simp [Finset.sum_add_distrib]
+
+/--
+Asymptotically, the characteristic function of a sum `∑ a, f a` at `⊤` is less than or equal to the
+sum of the characteristic functions of `f ·`.
+-/
+theorem characteristic_sum_top_eventuallyLE {α : Type*} (s : Finset α) (f : α → ℂ → E)
+    (hf : ∀ a, Meromorphic (f a)) :
+    characteristic (∑ a ∈ s, f a) ⊤
+      ≤ᶠ[Filter.atTop] ∑ a ∈ s, (characteristic (f a) ⊤) + fun _ ↦ log s.card := by
+  filter_upwards [Filter.eventually_ge_atTop 1]
+  exact fun _ hr ↦ characteristic_sum_top_le s f hf hr
+
+/--
 For `1 ≤ r`, the characteristic function for the zeros of `f * g` is less than or equal to the sum
 of the characteristic functions for the zeros of `f` and `g`, respectively.
 -/

--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -71,16 +71,17 @@ lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : Meromorp
 
 /--
 For `1 ≤ r`, the characteristic function of `f + g` at `⊤` is less than or equal to the sum of the
-characteristic functions of `f` and `g`, respectively.
+characteristic functions of `f` and `g`, respectively, plus `log 2` (where `2` is the number of
+summands).
 -/
 theorem characteristic_add_top_le {f₁ f₂ : ℂ → E} {r : ℝ} (h₁f₁ : Meromorphic f₁)
     (h₁f₂ : Meromorphic f₂) (hr : 1 ≤ r) :
     characteristic (f₁ + f₂) ⊤ r ≤ characteristic f₁ ⊤ r + characteristic f₂ ⊤ r + log 2 := by
   simp only [characteristic]
   calc proximity (f₁ + f₂) ⊤ r + logCounting (f₁ + f₂) ⊤ r
-  _ ≤ (proximity f₁ ⊤ r + proximity f₂ ⊤ r + log 2)
+    _ ≤ (proximity f₁ ⊤ r + proximity f₂ ⊤ r + log 2)
       + (logCounting f₁ ⊤ r + logCounting f₂ ⊤ r) := by
-    apply add_le_add
+    gcongr
     · apply proximity_add_top_le h₁f₁ h₁f₂
     · exact logCounting_add_top_le h₁f₁ h₁f₂ hr
   _ = proximity f₁ ⊤ r + logCounting f₁ ⊤ r + (proximity f₂ ⊤ r + logCounting f₂ ⊤ r) + log 2 := by
@@ -94,8 +95,7 @@ theorem characteristic_add_top_eventuallyLE {f₁ f₂ : ℂ → E} (h₁f₁ : 
     (h₁f₂ : Meromorphic f₂) :
     characteristic (f₁ + f₂) ⊤
       ≤ᶠ[Filter.atTop] characteristic f₁ ⊤ + characteristic f₂ ⊤ + fun _ ↦ log 2 := by
-  filter_upwards [Filter.eventually_ge_atTop 1]
-  exact fun _ hr ↦ characteristic_add_top_le h₁f₁ h₁f₂ hr
+  filter_upwards [Filter.eventually_ge_atTop 1] with r hr using characteristic_add_top_le h₁f₁ h₁f₂ hr
 
 /--
 For `1 ≤ r`, the characteristic function of a sum `∑ a, f a` at `⊤` is less than or equal to the sum


### PR DESCRIPTION
Combine results of PR #32311 and #31556 to establish the behavior under addition of the characteristic function of Value Distribution Theory.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), formalizing Value Distribution Theory for meromorphic functions on the complex plane. The formula established here is part of a larger package discussing the behavior of the Nenvanlinna height under algebraic manipulations of the functions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
