### PR TITLE
[Merged by Bors] - feat(RingTheory): Add `RingHom.QuasiFinite`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6285,6 +6285,7 @@ public import Mathlib.RingTheory.RingHom.Injective
 public import Mathlib.RingTheory.RingHom.Integral
 public import Mathlib.RingTheory.RingHom.Locally
 public import Mathlib.RingTheory.RingHom.OpenImmersion
+public import Mathlib.RingTheory.RingHom.QuasiFinite
 public import Mathlib.RingTheory.RingHom.Smooth
 public import Mathlib.RingTheory.RingHom.StandardSmooth
 public import Mathlib.RingTheory.RingHom.Surjective

--- a/Mathlib/RingTheory/RingHom/QuasiFinite.lean
+++ b/Mathlib/RingTheory/RingHom/QuasiFinite.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+module
+
+public import Mathlib.RingTheory.LocalProperties.Basic
+public import Mathlib.RingTheory.QuasiFinite.Basic
+
+/-! # The meta properties of quasi-finite ring homomorphisms. -/
+
+@[expose] public section
+
+universe u
+
+namespace RingHom
+
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
+
+/-- A ring hom `R →+* S` is quasi-finite if `S` is a quasi-finite `R`-algebra. -/
+@[algebraize RingHom.QuasiFinite.toAlgebra]
+def QuasiFinite {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S) : Prop :=
+  @Algebra.QuasiFinite R S _ _ f.toAlgebra
+
+/-- Helper lemma for the `algebraize` tactic -/
+lemma QuasiFinite.toAlgebra {f : R →+* S} (hf : QuasiFinite f) :
+    @Algebra.QuasiFinite R S _ _ f.toAlgebra := hf
+
+variable {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S)
+
+lemma quasiFinite_algebraMap [Algebra R S] :
+    (algebraMap R S).QuasiFinite ↔ Algebra.QuasiFinite R S := by
+  rw [RingHom.QuasiFinite, toAlgebra_algebraMap]
+
+lemma QuasiFinite.comp {f : S →+* T} {g : R →+* S} (hf : f.QuasiFinite) (hg : g.QuasiFinite) :
+    (f.comp g).QuasiFinite := by
+  algebraize [f, g, (f.comp g)]
+  exact .trans R S T
+
+lemma QuasiFinite.of_comp {f : S →+* T} {g : R →+* S} (h : (f.comp g).QuasiFinite) :
+    f.QuasiFinite := by
+  algebraize [f, g, (f.comp g)]
+  exact .of_restrictScalars R S T
+
+lemma QuasiFinite.of_finite {f : S →+* T} (hf : f.Finite) : f.QuasiFinite := by
+  algebraize [f]
+  exact inferInstanceAs (Algebra.QuasiFinite _ _)
+
+lemma QuasiFinite.stableUnderComposition : StableUnderComposition QuasiFinite :=
+  fun _ _ _ _ _ _ _ _ hf hg ↦ comp hg hf
+
+lemma QuasiFinite.of_surjective {f : R →+* S} (hf : Function.Surjective f) : f.QuasiFinite := by
+  algebraize [f]
+  exact .of_surjective_algHom (Algebra.ofId R S) hf
+
+lemma QuasiFinite.respectsIso : RespectsIso QuasiFinite :=
+  stableUnderComposition.respectsIso fun e ↦ .of_surjective (f := e.toRingHom) e.surjective
+
+lemma QuasiFinite.isStableUnderBaseChange : IsStableUnderBaseChange QuasiFinite := by
+  refine .mk respectsIso ?_
+  introv H
+  rw [quasiFinite_algebraMap] at H ⊢
+  infer_instance
+
+lemma QuasiFinite.holdsForLocalizationAway : HoldsForLocalizationAway QuasiFinite := by
+  introv R _
+  exact quasiFinite_algebraMap.mpr (.of_isLocalization (.powers r))
+
+attribute [local instance high] Algebra.TensorProduct.leftAlgebra Algebra.toModule
+    IsScalarTower.right DivisionRing.instIsArtinianRing in
+lemma QuasiFinite.ofLocalizationSpanTarget : OfLocalizationSpanTarget QuasiFinite := by
+  rw [RingHom.ofLocalizationSpanTarget_iff_finite]
+  introv R hs H
+  let := f.toAlgebra
+  refine ⟨fun P _ ↦ ?_⟩
+  have (r : s) : Module.Finite P.ResidueField (P.Fiber (Localization.Away r.1)) := by
+    have : Algebra.QuasiFinite R (Localization.Away r.1) := quasiFinite_algebraMap.mp (H r)
+    infer_instance
+  let φ (r : s) : P.Fiber S →ₐ[P.ResidueField] P.Fiber (Localization.Away r.1) :=
+    Algebra.TensorProduct.map (.id _ _) (IsScalarTower.toAlgHom _ _ _)
+  let f : P.Fiber S →ₐ[P.ResidueField] Π r : s, (P.Fiber (Localization.Away r.1)) :=
+    Pi.algHom _ _ φ
+  have : IsNoetherian P.ResidueField (Π r : s, (P.Fiber (Localization.Away r.1))) :=
+    isNoetherian_of_isNoetherianRing_of_finite ..
+  suffices Function.Injective f from .of_injective f.toLinearMap this
+  rw [injective_iff_map_eq_zero]
+  intro a ha
+  apply eq_zero_of_localization _ fun J hJ ↦ ?_
+  let I := (PrimeSpectrum.primesOverOrderIsoFiber R S P).symm ⟨J, inferInstance⟩
+  have : ¬ (s : Set S) ⊆ I.1 := fun h ↦
+    Ideal.IsPrime.ne_top' (top_le_iff.mp (hs.symm.trans_le (Ideal.span_le.mpr h)))
+  obtain ⟨r, hrs, hrI⟩ := Set.not_subset.mp this
+  let ψ : P.Fiber (Localization.Away r) →ₐ[P.ResidueField] Localization.AtPrime J :=
+    Algebra.TensorProduct.lift (Algebra.ofId _ _) ⟨IsLocalization.map (M := .powers r)
+      (T := J.primeCompl) _ Algebra.TensorProduct.includeRight.toRingHom (by
+        simpa [Submonoid.powers_le] using hrI), by
+          simp [IsScalarTower.algebraMap_apply R S (Localization.Away r),
+            -Algebra.TensorProduct.algebraMap_apply,
+            ← IsScalarTower.algebraMap_apply R _ (Localization.AtPrime J)]⟩ (fun _ _ ↦ .all _ _)
+  have hψ : ψ.comp (φ ⟨r, hrs⟩) = IsScalarTower.toAlgHom _ _ _ := by ext; simp [φ, ψ]
+  refine congr($hψ a).symm.trans
+    (show ψ (f a ⟨r, hrs⟩) = 0 by simp only [ha, Pi.zero_apply, map_zero])
+
+lemma QuasiFinite.propertyIsLocal : PropertyIsLocal QuasiFinite where
+  localizationAwayPreserves := isStableUnderBaseChange.localizationPreserves.away
+  ofLocalizationSpanTarget := ofLocalizationSpanTarget
+  ofLocalizationSpan := ofLocalizationSpanTarget.ofLocalizationSpan
+    (stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      holdsForLocalizationAway).left
+  StableUnderCompositionWithLocalizationAwayTarget :=
+    (stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      holdsForLocalizationAway).right
+
+open TensorProduct in
+/-- If `T` is both a finite type `R`-algebra, and the localization of an integral `R`-algebra,
+then `T` is quasi-finite over `R` -/
+lemma QuasiFinite.of_isIntegral_of_finiteType
+    {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] {f : R →+* S} (hf : f.IsIntegral)
+    {g : R →+* T} (hg : g.FiniteType)
+    [Algebra S T] (s : S) [IsLocalization.Away s T] (H : (algebraMap S T).comp f = g) :
+    g.QuasiFinite := by
+  algebraize [f, g]
+  have : IsScalarTower R S T := .of_algebraMap_eq' H.symm
+  exact Algebra.QuasiFinite.of_isIntegral_of_finiteType s
+
+end RingHom


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
