### PR TITLE
[Merged by Bors] - fix(Cache): option order in usage & error messages

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -472,6 +472,9 @@ Note: An argument like `Archive` is treated as module, not a path.
 -/
 def leanModulesFromSpec (sp : SearchPath) (argₛ : String) :
     IO <| Except String <| Array (Name × FilePath) := do
+  if argₛ.startsWith "-" then
+    -- provided option after command
+    return .error s!"Invalid argument: option must come before command {argₛ}"
   -- TODO: This could be just `FilePath.normalize` if the TODO there was addressed
   let arg : FilePath := System.mkFilePath <|
     (argₛ : FilePath).normalize.components.filter (· != "")
@@ -491,6 +494,9 @@ def leanModulesFromSpec (sp : SearchPath) (argₛ : String) :
   else
     -- provided a module
     let mod := argₛ.toName
+    if mod.isAnonymous then
+      -- provided a module name which is not a valid Lean identifier
+      return .error s!"Invalid argument: expected path or module name, not {argₛ}"
     let sourceFile ← Lean.findLean sp mod
     if ← sourceFile.pathExists then
       -- (1.) provided valid module

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -7,7 +7,7 @@ Authors: Arthur Paulino, Jon Eugster
 import Cache.Requests
 
 def help : String := "Mathlib4 caching CLI
-Usage: cache [COMMAND] [OPTIONS]
+Usage: cache [OPTIONS] [COMMAND]
 
 Commands:
   # No privilege required


### PR DESCRIPTION
This PR fixes cache's help text to indicate that options must come before the command (in `Usage:`). It also improves the error messages produced when an option or other invalid identifier appears as an argument.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
