### PR TITLE
fix(CI): report correct per-matrix-leg results in daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -65,7 +65,7 @@ jobs:
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      - name: Check environments using lean4checker # make sure this name is consistent with "Get job status and URLs" in the notify job
+      - name: Check environments using lean4checker
         id: lean4checker
         continue-on-error: true
         run: |
@@ -96,51 +96,8 @@ jobs:
           # so we explicitly check Batteries as well here.
           lake env lean4checker/.lake/build/bin/lean4checker Batteries Mathlib
 
-  notify-lean4checker:
-    runs-on: ubuntu-latest
-    needs: check-lean4checker
-    if: github.repository == 'leanprover-community/mathlib4' && always()
-    strategy:
-      fail-fast: false
-      matrix:
-        branch_type: [master, nightly]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Get job status and URLs
-        id: get-status
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          JOB_NAME="check-lean4checker (${{ matrix.branch_type }})"
-          
-          # Get URL to the specific step
-          LEAN4CHECKER_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
-            ".jobs[] | select(.name == \"$JOB_NAME\") \
-            | (.url + (.steps[] | select(.name == \"Check environments using lean4checker\") \
-              | \"#step:\(.number):1\"))")
-          
-          echo "lean4checker_url=${LEAN4CHECKER_URL}" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Fetch latest tags (if nightly)
-        if: matrix.branch_type == 'nightly'
-        run: |
-          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
-          git fetch nightly-testing --tags
-          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
-          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
-
-      - name: Set branch ref
-        run: |
-          if [ "${{ matrix.branch_type }}" == "master" ]; then
-            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
-          else
-            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
-          fi
-
       - name: Post success message for lean4checker on Zulip
-        if: needs.check-lean4checker.result == 'success'
+        if: steps.lean4checker.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -150,10 +107,10 @@ jobs:
           type: 'stream'
           topic: 'lean4checker'
           content: |
-            ✅ lean4checker [succeeded](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ✅ lean4checker succeeded on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
-      - name: Post failure / cancelled message for lean4checker on Zulip
-        if: needs.check-lean4checker.result != 'success'
+      - name: Post failure message for lean4checker on Zulip
+        if: steps.lean4checker.outcome != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -163,7 +120,7 @@ jobs:
           type: 'stream'
           topic: 'lean4checker failure'
           content: |
-            ❌ lean4checker [${{ needs.check-lean4checker.result }}](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ lean4checker ${{ steps.lean4checker.outcome }} on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
   check-mathlib_test_executable:
     runs-on: ubuntu-latest
@@ -209,57 +166,14 @@ jobs:
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      - name: Run mathlib_test_executable # make sure this name is consistent with "Get job status and URLs" in the notify job
+      - name: Run mathlib_test_executable
         id: mathlib-test
         continue-on-error: true
         run: |
           lake exe mathlib_test_executable
 
-  notify-mathlib_test_executable:
-    runs-on: ubuntu-latest
-    needs: check-mathlib_test_executable
-    if: github.repository == 'leanprover-community/mathlib4' && always()
-    strategy:
-      fail-fast: false
-      matrix:
-        branch_type: [master, nightly]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Get job status and URLs
-        id: get-status
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          JOB_NAME="check-mathlib_test_executable (${{ matrix.branch_type }})"
-          
-          # Get URL to the specific step
-          MATHLIB_TEST_EXECUTABLE_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
-            ".jobs[] | select(.name == \"$JOB_NAME\") \
-            | (.url + (.steps[] | select(.name == \"Run mathlib_test_executable\") \
-              | \"#step:\(.number):1\"))")
-          
-          echo "mathlib_test_executable_url=${MATHLIB_TEST_EXECUTABLE_URL}" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Fetch latest tags (if nightly)
-        if: matrix.branch_type == 'nightly'
-        run: |
-          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
-          git fetch nightly-testing --tags
-          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
-          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
-
-      - name: Set branch ref
-        run: |
-          if [ "${{ matrix.branch_type }}" == "master" ]; then
-            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
-          else
-            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
-          fi
-
       - name: Post success message for mathlib_test_executable on Zulip
-        if: needs.check-mathlib_test_executable.result == 'success'
+        if: steps.mathlib-test.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -269,10 +183,10 @@ jobs:
           type: 'stream'
           topic: 'mathlib test executable'
           content: |
-            ✅ mathlib_test_executable [succeeded](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ✅ mathlib_test_executable succeeded on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
-      - name: Post failure / cancelled message for mathlib_test_executable on Zulip
-        if: needs.check-mathlib_test_executable.result != 'success'
+      - name: Post failure message for mathlib_test_executable on Zulip
+        if: steps.mathlib-test.outcome != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -282,7 +196,7 @@ jobs:
           type: 'stream'
           topic: 'mathlib test executable failure'
           content: |
-            ❌ mathlib_test_executable [${{ needs.check-mathlib_test_executable.result }}](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ mathlib_test_executable ${{ steps.mathlib-test.outcome }} on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
   check-nanoda:
     runs-on: ubuntu-latest
@@ -331,7 +245,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Check Mathlib using nanoda # make sure this name is consistent with "Get job status and URLs" in the notify job
+      - name: Check Mathlib using nanoda
         id: nanoda
         continue-on-error: true
         run: |
@@ -376,51 +290,8 @@ jobs:
           # Run nanoda
           nanoda_lib/target/release/nanoda_bin nanoda_config.json
 
-  notify-nanoda:
-    runs-on: ubuntu-latest
-    needs: check-nanoda
-    if: github.repository == 'leanprover-community/mathlib4' && always()
-    strategy:
-      fail-fast: false
-      matrix:
-        branch_type: [master, nightly]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Get job status and URLs
-        id: get-status
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          JOB_NAME="check-nanoda (${{ matrix.branch_type }})"
-
-          # Get URL to the specific step
-          NANODA_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
-            ".jobs[] | select(.name == \"$JOB_NAME\") \
-            | (.url + (.steps[] | select(.name == \"Check Mathlib using nanoda\") \
-              | \"#step:\(.number):1\"))")
-
-          echo "nanoda_url=${NANODA_URL}" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Fetch latest tags (if nightly)
-        if: matrix.branch_type == 'nightly'
-        run: |
-          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
-          git fetch nightly-testing --tags
-          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
-          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
-
-      - name: Set branch ref
-        run: |
-          if [ "${{ matrix.branch_type }}" == "master" ]; then
-            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
-          else
-            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
-          fi
-
       - name: Post success message for nanoda on Zulip
-        if: needs.check-nanoda.result == 'success'
+        if: steps.nanoda.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -430,10 +301,10 @@ jobs:
           type: 'stream'
           topic: 'nanoda'
           content: |
-            ✅ nanoda [succeeded](${{ steps.get-status.outputs.nanoda_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ✅ nanoda succeeded on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
-      - name: Post failure / cancelled message for nanoda on Zulip
-        if: needs.check-nanoda.result != 'success'
+      - name: Post failure message for nanoda on Zulip
+        if: steps.nanoda.outcome != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -443,4 +314,4 @@ jobs:
           type: 'stream'
           topic: 'nanoda failure'
           content: |
-            ❌ nanoda [${{ needs.check-nanoda.result }}](${{ steps.get-status.outputs.nanoda_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ nanoda ${{ steps.nanoda.outcome }} on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})


### PR DESCRIPTION
This PR fixes a bug in the daily CI workflow where Zulip notifications would incorrectly report failures for matrix legs that actually succeeded.

**The bug:** The notify-* jobs used `needs.<job>.result`, which gives the aggregate result across all matrix legs. When one leg (e.g., nightly) failed but the other (e.g., master) succeeded, both would be incorrectly reported as failures.

**The fix:** Move the Zulip notification steps into each check job, using `steps.<step-id>.outcome` to report the actual result for that specific matrix leg.

**Evidence:**
- **nanoda (2026-01-08):** `check-nanoda (master)` succeeded but was [reported as failed](https://github.com/leanprover-community/mathlib4/actions/runs/20800961995)
- **lean4checker (2026-01-06):** `check-lean4checker (nightly)` succeeded but was [reported as failed](https://github.com/leanprover-community/mathlib4/actions/runs/20733417965)

🤖 Prepared with Claude Code