### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/Analysis/Asymptotics/LinearGrowth.lean
+++ b/Mathlib/Analysis/Asymptotics/LinearGrowth.lean
@@ -440,9 +440,8 @@ lemma linearGrowthInf_comp_nonneg (h : Monotone u) (h' : u ≠ ⊥) (hv : Tendst
     0 ≤ linearGrowthInf (u ∘ v) := by
   simp only [ne_eq, funext_iff, not_forall] at h'
   obtain ⟨m, hum⟩ := h'
-  have um_uvn : ∀ᶠ n in atTop, u m ≤ (u ∘ v) n := by
-    apply (eventually_map (P := fun n : ℕ ↦ u m ≤ u n)).2
-    exact (eventually_atTop.2 ⟨m, fun n m_n ↦ h m_n⟩).filter_mono hv
+  have um_uvn : ∀ᶠ n in atTop, u m ≤ (u ∘ v) n :=
+    (eventually_atTop.2 ⟨m, fun n m_n ↦ h m_n⟩).filter_mono hv
   apply (linearGrowthInf_eventually_monotone um_uvn).trans'
   rcases eq_or_ne (u m) ⊤ with hum' | hum'
   · rw [hum', ← Pi.top_def, linearGrowthInf_top]; exact le_top

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -174,7 +174,6 @@ lemma preservesLimit_of_preservesEqualizers_and_product :
     · intro f
       dsimp [P, Q, t, Fan.mk]
       simp only [← G.map_comp, limit.lift_π]
-      apply congrArg G.map
       dsimp
     · apply Fork.ofι (G.map i)
       rw [← G.map_comp, ← G.map_comp]

--- a/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
@@ -68,7 +68,6 @@ lemma Pi.map_eq_prod_map [∀ i, Decidable (P i)] : Pi.map f =
         ((Pi.binaryFanOfPropIsLimit Y P).conePointUniqueUpToIso (prodIsProd _ _)).inv := by
   rw [← Category.assoc, Iso.eq_comp_inv]
   dsimp only [IsLimit.conePointUniqueUpToIso, binaryFanOfProp, prodIsProd]
-  apply prod.hom_ext
-  all_goals cat_disch
+  cat_disch
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Presentable/Basic.lean
+++ b/Mathlib/CategoryTheory/Presentable/Basic.lean
@@ -189,7 +189,6 @@ lemma isCardinalPresentable_of_equivalence
       (Equiv.ulift.trans ((e.toAdjunction.homEquiv X Z).trans Equiv.ulift.symm)).toIso) (by
         intro _ _ f
         ext ⟨g⟩
-        apply Equiv.ulift.injective
         simp [Adjunction.homEquiv_unit])
   exact preservesColimit_of_natIso Y iso.symm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -243,7 +243,6 @@ lemma dist_le_diam (h : G.ediam ≠ ⊤) {u v : α} : G.dist u v ≤ G.diam :=
   ENat.toNat_le_toNat edist_le_ediam h
 
 lemma nontrivial_of_diam_ne_zero (h : G.diam ≠ 0) : Nontrivial α := by
-  apply G.nontrivial_of_ediam_ne_zero
   contrapose! h
   simp [diam, h]
 

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -410,8 +410,7 @@ theorem univ_eq_singleton_of_card_one {α} [Fintype α] (x : α) (h : Fintype.ca
     (univ : Finset α) = {x} := by
   symm
   apply eq_of_subset_of_card_le (subset_univ {x})
-  apply le_of_eq
-  simp [h, Finset.card_univ]
+  simp [h]
 
 namespace Finite
 

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -474,7 +474,6 @@ theorem getElem_leftInvSeq_alternatingWord
     simp only [CoxeterSystem.getElem_leftInvSeq cs (alternatingWord i j (2 * p)) 0 (by simp [h]),
       take_zero, wordProd_nil, one_mul, inv_one, mul_one, alternatingWord, concat_eq_append,
       nil_append, wordProd_singleton]
-    apply congr_arg
     simp only [getElem_alternatingWord i j (2 * p) 0 (by simp [h]), add_zero, even_two,
       Even.mul_right, ↓reduceIte]
   | succ k hk =>

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -257,9 +257,7 @@ def mapGL : Matrix.SpecialLinearGroup n R →* Matrix.GeneralLinearGroup n S :=
 @[simp]
 lemma mapGL_inj [FaithfulSMul R S] (g g' : SpecialLinearGroup n R) :
     mapGL S g = mapGL S g' ↔ g = g' := by
-  refine ⟨fun h ↦ ?_, by tauto⟩
-  apply SpecialLinearGroup.ext
-  simpa [mapGL, toGL_inj, ext_iff, (FaithfulSMul.algebraMap_injective R S).eq_iff] using h
+  simp [mapGL, ext_iff]
 
 lemma mapGL_injective [FaithfulSMul R S] :
     Function.Injective (mapGL (R := R) (n := n) S) :=

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -734,12 +734,8 @@ theorem reindex_symm (e : ι ≃ ι₂) :
 
 @[simp]
 theorem reindex_refl : reindex R s (Equiv.refl ι) = LinearEquiv.refl R _ := by
-  apply LinearEquiv.toLinearMap_injective
   ext
-  simp only [Equiv.refl_symm, Equiv.refl_apply, reindex, domDomCongrLinearEquiv',
-    LinearEquiv.coe_symm_mk, LinearMap.compMultilinearMap_apply, LinearEquiv.coe_coe,
-    LinearEquiv.refl_toLinearMap, LinearMap.id_coe, id_eq]
-  simp
+  simp [reindex, domDomCongrLinearEquiv']
 
 variable {t : ι → Type*}
 variable [∀ i, AddCommMonoid (t i)] [∀ i, Module R (t i)]

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -234,8 +234,6 @@ theorem ofModule_asModule_act (g : G) (x : RestrictScalars k k[G] ρ.asModule) :
     ofModule ρ.asModule g x =
       (RestrictScalars.addEquiv _ _ _).symm
         (ρ.asModuleEquiv.symm (ρ g (ρ.asModuleEquiv (RestrictScalars.addEquiv _ _ _ x)))) := by
-  apply_fun RestrictScalars.addEquiv _ _ ρ.asModule using
-    (RestrictScalars.addEquiv _ _ ρ.asModule).injective
   dsimp [ofModule, RestrictScalars.lsmul_apply_apply]
   simp
 


### PR DESCRIPTION
---
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `LinearGrowth.linearGrowthInf_comp_nonneg`: 29 ms before, 17 ms after  🎉
* `CategoryTheory.Limits.preservesLimit_of_preservesEqualizers_and_product`: 821 ms before, 530 ms after  🎉
* `CategoryTheory.Limits.Pi.map_eq_prod_map`: 161 ms before, 101 ms after  🎉
* `CategoryTheory.isCardinalPresentable_of_equivalence`: 116 ms before, 107 ms after  🎉
* `SimpleGraph.nontrivial_of_diam_ne_zero`: <10 ms before, <10 ms after  🎉
* `univ_eq_singleton_of_card_one`: 14 ms before, <10 ms after  🎉
* `CoxeterSystem.getElem_leftInvSeq_alternatingWord`: 41 ms before, 40 ms after  🎉
* `Matrix.SpecialLinearGroup.mapGL_inj`: 73 ms before, 45 ms after  🎉
* `PiTensorProduct.reindex_refl`: 88 ms before, 65 ms after  🎉
* `MeasureTheory.continuous_diracProbaEquivSymm`: 17 ms before, <10 ms after  🎉
* `Representation.ofModule_asModule_act`: 78 ms before, 61 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
