### PR TITLE
[Merged by Bors] - feat: `NNRat` is countable

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3763,6 +3763,7 @@ public import Mathlib.Data.Multiset.UnionInter
 public import Mathlib.Data.Multiset.ZeroCons
 public import Mathlib.Data.NNRat.BigOperators
 public import Mathlib.Data.NNRat.Defs
+public import Mathlib.Data.NNRat.Encodable
 public import Mathlib.Data.NNRat.Floor
 public import Mathlib.Data.NNRat.Lemmas
 public import Mathlib.Data.NNRat.Order

--- a/Mathlib/Data/NNRat/Encodable.lean
+++ b/Mathlib/Data/NNRat/Encodable.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+module
+
+public import Mathlib.Logic.Encodable.Basic
+public import Mathlib.Data.NNRat.Defs
+
+/-! # The nonnegative rationals are `Encodable`.
+
+As a consequence we also get the instance `Countable ℚ≥0`.
+-/
+
+namespace NNRat
+
+public instance : Encodable ℚ≥0 :=
+  Encodable.ofEquiv (Σ n : ℕ, { d : ℕ // 0 < d ∧ n.Coprime d })
+    ⟨fun q => ⟨q.num, q.den, q.den_pos, q.coprime_num_den⟩,
+      fun ⟨num, den, prop⟩ => ⟨⟨num, den, Nat.pos_iff_ne_zero.mp prop.1, prop.2⟩,
+        Rat.num_nonneg.mp (Int.natCast_nonneg num)⟩,
+      fun ⟨⟨num, _, _, _⟩, hq⟩ => by lift num to ℕ using Rat.num_nonneg.mpr hq; rfl,
+      Eq.refl⟩
+
+end NNRat

--- a/Mathlib/Data/Rat/Encodable.lean
+++ b/Mathlib/Data/Rat/Encodable.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Logic.Encodable.Basic
 public import Mathlib.Data.Rat.Init
+public import Mathlib.Data.NNRat.Defs
 
 /-! # The rationals are `Encodable`.
 
@@ -30,6 +31,12 @@ end Rat
 
 namespace NNRat
 
-instance : Encodable NNRat := Subtype.encodable
+instance : Encodable ℚ≥0 :=
+  Encodable.ofEquiv (Σ n : ℕ, { d : ℕ // 0 < d ∧ n.Coprime d })
+    ⟨fun q => ⟨q.num, q.den, q.den_pos, q.coprime_num_den⟩,
+      fun ⟨num, den, prop⟩ => ⟨⟨num, den, Nat.pos_iff_ne_zero.mp prop.1, prop.2⟩,
+        Rat.num_nonneg.mp (Int.natCast_nonneg num)⟩,
+      fun ⟨⟨num, _, _, _⟩, hq⟩ => by lift num to ℕ using Rat.num_nonneg.mpr hq; rfl,
+      Eq.refl⟩
 
 end NNRat

--- a/Mathlib/Data/Rat/Encodable.lean
+++ b/Mathlib/Data/Rat/Encodable.lean
@@ -27,3 +27,12 @@ instance : Encodable ℚ :=
       fun _ => rfl, fun ⟨_, _, _, _⟩ => rfl⟩
 
 end Rat
+
+namespace NNRat
+
+instance : Encodable NNRat :=
+  Encodable.ofEquiv ({ q : ℚ // 0 ≤ q })
+    ⟨fun ⟨q, hq⟩ => ⟨q, hq⟩, fun ⟨q, hq⟩ => ⟨q, hq⟩,
+      Eq.refl, Eq.refl⟩
+
+end NNRat

--- a/Mathlib/Data/Rat/Encodable.lean
+++ b/Mathlib/Data/Rat/Encodable.lean
@@ -30,9 +30,6 @@ end Rat
 
 namespace NNRat
 
-instance : Encodable NNRat :=
-  Encodable.ofEquiv ({ q : ℚ // 0 ≤ q })
-    ⟨fun ⟨q, hq⟩ => ⟨q, hq⟩, fun ⟨q, hq⟩ => ⟨q, hq⟩,
-      Eq.refl, Eq.refl⟩
+instance : Encodable NNRat := Subtype.encodable
 
 end NNRat

--- a/Mathlib/Data/Rat/Encodable.lean
+++ b/Mathlib/Data/Rat/Encodable.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Logic.Encodable.Basic
 public import Mathlib.Data.Rat.Init
-public import Mathlib.Data.NNRat.Defs
 
 /-! # The rationals are `Encodable`.
 
@@ -28,15 +27,3 @@ instance : Encodable ℚ :=
       fun _ => rfl, fun ⟨_, _, _, _⟩ => rfl⟩
 
 end Rat
-
-namespace NNRat
-
-instance : Encodable ℚ≥0 :=
-  Encodable.ofEquiv (Σ n : ℕ, { d : ℕ // 0 < d ∧ n.Coprime d })
-    ⟨fun q => ⟨q.num, q.den, q.den_pos, q.coprime_num_den⟩,
-      fun ⟨num, den, prop⟩ => ⟨⟨num, den, Nat.pos_iff_ne_zero.mp prop.1, prop.2⟩,
-        Rat.num_nonneg.mp (Int.natCast_nonneg num)⟩,
-      fun ⟨⟨num, _, _, _⟩, hq⟩ => by lift num to ℕ using Rat.num_nonneg.mpr hq; rfl,
-      Eq.refl⟩
-
-end NNRat


### PR DESCRIPTION
We provide an `Encodable NNRat` instance. As a consequence we also get the instance `Countable NNRat`.

See also [Zulip](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/NNRat.20not.20countable.3F/near/566916284)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
