### PR TITLE
[Merged by Bors] - chore(Order/Defs/Unbundled): deprecate `IsRefl` in favor of core's `Std.Refl`

### DIFF
--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -120,7 +120,7 @@ theorem dvd_refl (a : α) : a ∣ a :=
 
 theorem dvd_rfl : ∀ {a : α}, a ∣ a := fun {a} => dvd_refl a
 
-instance : IsRefl α (· ∣ ·) :=
+instance : @Std.Refl α (· ∣ ·) :=
   ⟨dvd_refl⟩
 
 theorem one_dvd (a : α) : 1 ∣ a :=

--- a/Mathlib/Algebra/Group/Commute/Defs.lean
+++ b/Mathlib/Algebra/Group/Commute/Defs.lean
@@ -73,12 +73,12 @@ protected theorem symm_iff {a b : S} : Commute a b ↔ Commute b a :=
   ⟨Commute.symm, Commute.symm⟩
 
 @[to_additive]
-instance : IsRefl S Commute :=
+instance : @Std.Refl S Commute :=
   ⟨Commute.refl⟩
 
 -- This instance is useful for `Finset.noncommProd`
 @[to_additive]
-instance on_isRefl {f : G → S} : IsRefl G fun a b => Commute (f a) (f b) :=
+instance on_refl {f : G → S} : Std.Refl fun a b => Commute (f a) (f b) :=
   ⟨fun _ => Commute.refl _⟩
 
 end Mul

--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -42,7 +42,7 @@ protected theorem refl [Monoid M] (x : M) : x ~ᵤ x :=
 protected theorem rfl [Monoid M] {x : M} : x ~ᵤ x :=
   .refl x
 
-instance [Monoid M] : IsRefl M Associated :=
+instance [Monoid M] : @Std.Refl M Associated :=
   ⟨Associated.refl⟩
 
 @[symm]

--- a/Mathlib/Algebra/ModEq.lean
+++ b/Mathlib/Algebra/ModEq.lean
@@ -77,7 +77,7 @@ theorem ModEq.trans : a ≡ b [PMOD p] → b ≡ c [PMOD p] → a ≡ c [PMOD p]
 instance : IsTrans α (ModEq p) where
   trans _ _ _ := ModEq.trans
 
-instance : IsRefl _ (ModEq p) :=
+instance : Std.Refl (ModEq p) :=
   ⟨modEq_refl⟩
 
 @[simp]

--- a/Mathlib/Data/Finset/Defs.lean
+++ b/Mathlib/Data/Finset/Defs.lean
@@ -205,8 +205,8 @@ instance partialOrder : PartialOrder (Finset α) := inferInstance
 
 theorem subset_of_le : s ≤ t → s ⊆ t := id
 
-instance : IsRefl (Finset α) (· ⊆ ·) :=
-  inferInstanceAs <| IsRefl (Finset α) (· ≤ ·)
+instance : @Std.Refl (Finset α) (· ⊆ ·) :=
+  inferInstanceAs <| Std.Refl (· ≤ ·)
 
 instance : IsTrans (Finset α) (· ⊆ ·) :=
   inferInstanceAs <| IsTrans (Finset α) (· ≤ ·)

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -46,7 +46,7 @@ def noncommFoldr (s : Multiset α)
     (comm : { x | x ∈ s }.Pairwise fun x y => ∀ b, f x (f y b) = f y (f x b)) (b : β) : β :=
   letI : LeftCommutative (α := { x // x ∈ s }) (f ∘ Subtype.val) :=
     ⟨fun ⟨_, hx⟩ ⟨_, hy⟩ =>
-      haveI : IsRefl α fun x y => ∀ b, f x (f y b) = f y (f x b) := ⟨fun _ _ => rfl⟩
+      haveI : Std.Refl fun x y => ∀ b, f x (f y b) = f y (f x b) := ⟨fun _ _ => rfl⟩
       comm.of_refl hx hy⟩
   s.attach.foldr (f ∘ Subtype.val) b
 

--- a/Mathlib/Data/Int/ModEq.lean
+++ b/Mathlib/Data/Int/ModEq.lean
@@ -46,7 +46,7 @@ protected theorem refl (a : ℤ) : a ≡ a [ZMOD n] :=
 protected theorem rfl : a ≡ a [ZMOD n] :=
   ModEq.refl _
 
-instance : IsRefl _ (ModEq n) :=
+instance : Std.Refl (ModEq n) :=
   ⟨ModEq.refl⟩
 
 @[symm]

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -46,7 +46,7 @@ theorem forall₂_same : ∀ {l : List α}, Forall₂ Rₐ l l ↔ ∀ x ∈ l, 
   | [] => by simp
   | a :: l => by simp [@forall₂_same l]
 
-theorem forall₂_refl [IsRefl α Rₐ] (l : List α) : Forall₂ Rₐ l l :=
+theorem forall₂_refl [Std.Refl Rₐ] (l : List α) : Forall₂ Rₐ l l :=
   forall₂_same.2 fun _ _ => refl _
 
 @[simp]
@@ -295,7 +295,7 @@ theorem sublistForall₂_iff {l₁ : List α} {l₂ : List β} :
       obtain - | ⟨hr, hl⟩ := hl1
       exact SublistForall₂.cons hr (ih hl)
 
-instance SublistForall₂.is_refl [IsRefl α Rₐ] : IsRefl (List α) (SublistForall₂ Rₐ) :=
+instance SublistForall₂.is_refl [Std.Refl Rₐ] : Std.Refl (SublistForall₂ Rₐ) :=
   ⟨fun l => sublistForall₂_iff.2 ⟨l, forall₂_refl l, Sublist.refl l⟩⟩
 
 instance SublistForall₂.is_trans [IsTrans α Rₐ] : IsTrans (List α) (SublistForall₂ Rₐ) :=
@@ -317,11 +317,11 @@ instance SublistForall₂.is_trans [IsTrans α Rₐ] : IsTrans (List α) (Sublis
         · exact SublistForall₂.cons_right (ih _ _ atb tbc)
       · exact SublistForall₂.cons_right (ih _ _ h1 btc)⟩
 
-theorem Sublist.sublistForall₂ {l₁ l₂ : List α} (h : l₁ <+ l₂) [IsRefl α Rₐ] :
+theorem Sublist.sublistForall₂ {l₁ l₂ : List α} (h : l₁ <+ l₂) [Std.Refl Rₐ] :
     SublistForall₂ Rₐ l₁ l₂ :=
   sublistForall₂_iff.2 ⟨l₁, forall₂_refl l₁, h⟩
 
-theorem tail_sublistForall₂_self [IsRefl α Rₐ] (l : List α) : SublistForall₂ Rₐ l.tail l :=
+theorem tail_sublistForall₂_self [Std.Refl Rₐ] (l : List α) : SublistForall₂ Rₐ l.tail l :=
   l.tail_sublist.sublistForall₂
 
 @[simp]

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -76,7 +76,7 @@ theorem Pairwise.rel_head_of_rel_head_head (h₁ : l.Pairwise R) (ha : a ∈ l)
   | nil => simp at ha
   | cons b l => exact (mem_cons.mp ha).elim (· ▸ hhead) ((pairwise_cons.1 h₁).1 _)
 
-theorem Pairwise.rel_head [IsRefl α R] (h₁ : l.Pairwise R) (ha : a ∈ l) :
+theorem Pairwise.rel_head [Std.Refl R] (h₁ : l.Pairwise R) (ha : a ∈ l) :
     R (l.head <| ne_nil_of_mem ha) a :=
   h₁.rel_head_of_rel_head_head ha (refl_of ..)
 
@@ -92,13 +92,13 @@ theorem Pairwise.rel_getLast_of_rel_getLast_getLast (h₁ : l.Pairwise R) (ha : 
   rw [← dropLast_concat_getLast (ne_nil_of_mem ha), mem_append, List.mem_singleton] at ha
   exact ha.elim h₁.rel_dropLast_getLast (· ▸ hlast)
 
-theorem Pairwise.rel_getLast [IsRefl α R] (h₁ : l.Pairwise R) (ha : a ∈ l) :
+theorem Pairwise.rel_getLast [Std.Refl R] (h₁ : l.Pairwise R) (ha : a ∈ l) :
     R a (l.getLast <| ne_nil_of_mem ha) :=
   h₁.rel_getLast_of_rel_getLast_getLast ha (refl_of ..)
 
 protected alias ⟨Pairwise.of_reverse, Pairwise.reverse⟩ := pairwise_reverse
 
-theorem Pairwise.head!_le [Inhabited α] [IsRefl α R] (h : l.Pairwise R)
+theorem Pairwise.head!_le [Inhabited α] [Std.Refl R] (h : l.Pairwise R)
     (ha : a ∈ l) : R l.head! a := by
   cases l
   · contradiction
@@ -112,7 +112,7 @@ alias Sorted.head!_le := Pairwise.head!_le
 @[deprecated (since := "2025-10-11")]
 alias Sorted.le_head! := Pairwise.head!_le
 
-theorem pairwise_replicate_of_refl {n} [IsRefl α R] : (replicate n a).Pairwise R :=
+theorem pairwise_replicate_of_refl {n} [Std.Refl R] : (replicate n a).Pairwise R :=
   pairwise_replicate.mpr (Or.inr <| refl_of ..)
 
 @[deprecated (since := "2025-10-11")]
@@ -144,7 +144,7 @@ theorem Pairwise.rel_get_of_lt {l : List α} (h : l.Pairwise R) {a b : Fin l.len
 @[deprecated (since := "2025-10-11")]
 alias Sorted.rel_get_of_lt := Pairwise.rel_get_of_lt
 
-theorem Pairwise.rel_get_of_le [IsRefl α R] {l : List α} (h : l.Pairwise R) {a b : Fin l.length}
+theorem Pairwise.rel_get_of_le [Std.Refl R] {l : List α} (h : l.Pairwise R) {a b : Fin l.length}
     (hab : a ≤ b) : R (l.get a) (l.get b) := by
   obtain rfl | hlt := Fin.eq_or_lt_of_le hab; exacts [refl _, (pairwise_iff_get.1 h) _ _ hlt]
 

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -159,15 +159,15 @@ theorem Pairwise.insertionSort_eq {l : List α} : Pairwise r l → insertionSort
 alias Sorted.insertionSort_eq := Pairwise.insertionSort_eq
 
 /-- For a reflexive relation, insert then erasing is the identity. -/
-theorem erase_orderedInsert [DecidableEq α] [IsRefl α r] (x : α) (xs : List α) :
+theorem erase_orderedInsert [DecidableEq α] [Std.Refl r] (x : α) (xs : List α) :
     (xs.orderedInsert r x).erase x = xs := by
-  induction xs <;> grind [IsRefl]
+  induction xs <;> grind [Std.Refl]
 
 /-- Inserting then erasing an element that is absent is the identity. -/
 theorem erase_orderedInsert_of_notMem [DecidableEq α]
     {x : α} {xs : List α} (hx : x ∉ xs) :
     (xs.orderedInsert r x).erase x = xs := by
-  induction xs <;> grind [IsRefl]
+  induction xs <;> grind
 
 /-- For an antisymmetric relation, erasing then inserting is the identity. -/
 theorem orderedInsert_erase [DecidableEq α] [Std.Antisymm r] (x : α) (xs : List α) (hx : x ∈ xs)

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -52,7 +52,7 @@ protected theorem refl (a : ℕ) : a ≡ a [MOD n] := rfl
 protected theorem rfl : a ≡ a [MOD n] :=
   ModEq.refl _
 
-instance : IsRefl _ (ModEq n) :=
+instance : Std.Refl (ModEq n) :=
   ⟨ModEq.refl⟩
 
 @[symm]

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -139,17 +139,17 @@ instance Lex.decidable [DecidableEq α]
   fun _ _ ↦ decidable_of_decidable_of_iff lex_def.symm
 
 @[refl]
-theorem Lex.refl_left (r : α → α → Prop) (s : β → β → Prop) [IsRefl α r] : ∀ x, Prod.Lex r s x x
+theorem Lex.refl_left (r : α → α → Prop) (s : β → β → Prop) [Std.Refl r] : ∀ x, Prod.Lex r s x x
   | (_, _) => Lex.left _ _ (refl _)
 
-instance {r : α → α → Prop} {s : β → β → Prop} [IsRefl α r] : IsRefl (α × β) (Prod.Lex r s) :=
+instance {r : α → α → Prop} {s : β → β → Prop} [Std.Refl r] : Std.Refl (Prod.Lex r s) :=
   ⟨Lex.refl_left _ _⟩
 
 @[refl]
-theorem Lex.refl_right (r : α → α → Prop) (s : β → β → Prop) [IsRefl β s] : ∀ x, Prod.Lex r s x x
+theorem Lex.refl_right (r : α → α → Prop) (s : β → β → Prop) [Std.Refl s] : ∀ x, Prod.Lex r s x x
   | (_, _) => Lex.right _ (refl _)
 
-instance {r : α → α → Prop} {s : β → β → Prop} [IsRefl β s] : IsRefl (α × β) (Prod.Lex r s) :=
+instance {r : α → α → Prop} {s : β → β → Prop} [Std.Refl s] : Std.Refl (Prod.Lex r s) :=
   ⟨Lex.refl_right _ _⟩
 
 instance [Std.Irrefl r] [Std.Irrefl s] : Std.Irrefl (Prod.Lex r s) :=

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -361,7 +361,7 @@ variable {R R₁ R₂ : SetRel α α} {S : SetRel β β} {a b c : α}
 
 variable (R) in
 /-- A relation `R` is reflexive if `a ~[R] a`. -/
-protected abbrev IsRefl : Prop := IsRefl α (· ~[R] ·)
+protected abbrev IsRefl : Prop := Std.Refl (· ~[R] ·)
 
 variable (R) in
 protected lemma refl [R.IsRefl] (a : α) : a ~[R] a := refl_of (· ~[R] ·) a

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -221,8 +221,8 @@ theorem setOf_or {p q : α → Prop} : { a | p a ∨ q a } = { a | p a } ∪ { a
 /-! ### Subset and strict subset relations -/
 
 
-instance : IsRefl (Set α) (· ⊆ ·) :=
-  show IsRefl (Set α) (· ≤ ·) by infer_instance
+instance : @Std.Refl (Set α) (· ⊆ ·) :=
+  show Std.Refl (· ≤ ·) by infer_instance
 
 instance : IsTrans (Set α) (· ⊆ ·) :=
   show IsTrans (Set α) (· ≤ ·) by infer_instance

--- a/Mathlib/Data/Set/Pairwise/Basic.lean
+++ b/Mathlib/Data/Set/Pairwise/Basic.lean
@@ -91,7 +91,7 @@ theorem pairwise_empty (r : α → α → Prop) : (∅ : Set α).Pairwise r :=
 theorem pairwise_singleton (a : α) (r : α → α → Prop) : Set.Pairwise {a} r :=
   subsingleton_singleton.pairwise r
 
-theorem pairwise_iff_of_refl [IsRefl α r] : s.Pairwise r ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → r a b :=
+theorem pairwise_iff_of_refl [Std.Refl r] : s.Pairwise r ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → r a b :=
   forall₄_congr fun _ _ _ _ => or_iff_not_imp_left.symm.trans <| or_iff_right_of_imp of_eq
 
 alias ⟨Pairwise.of_refl, _⟩ := pairwise_iff_of_refl
@@ -102,7 +102,7 @@ theorem Nonempty.pairwise_iff_exists_forall [IsEquiv α r] {s : Set ι} (hs : s.
   · rcases hs with ⟨y, hy⟩
     refine fun H => ⟨f y, fun x hx => ?_⟩
     rcases eq_or_ne x y with (rfl | hne)
-    · apply IsRefl.refl
+    · apply Std.Refl.refl
     · exact H hx hy hne
   · rintro ⟨z, hz⟩ x hx y hy _
     exact @IsTrans.trans α r _ (f x) z (f y) (hz _ hx) (symm <| hz _ hy)

--- a/Mathlib/Data/Sigma/Lex.lean
+++ b/Mathlib/Data/Sigma/Lex.lean
@@ -80,7 +80,7 @@ theorem lex_swap : Lex (Function.swap r) s a b ↔ Lex r (fun i => Function.swap
       · exact Lex.left _ _ h
       · exact Lex.right _ _ h
 
-instance [∀ i, IsRefl (α i) (s i)] : IsRefl _ (Lex r s) :=
+instance [∀ i, Std.Refl (s i)] : Std.Refl (Lex r s) :=
   ⟨fun ⟨_, _⟩ => Lex.right _ _ <| refl _⟩
 
 instance [Std.Irrefl r] [∀ i, Std.Irrefl (s i)] : Std.Irrefl (Lex r s) :=

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -43,11 +43,11 @@ section LiftRel
 variable (r : α → α → Prop) (s : β → β → Prop)
 
 @[refl]
-theorem LiftRel.refl [IsRefl α r] [IsRefl β s] : ∀ x, LiftRel r s x x
+theorem LiftRel.refl [Std.Refl r] [Std.Refl s] : ∀ x, LiftRel r s x x
   | inl a => LiftRel.inl (_root_.refl a)
   | inr a => LiftRel.inr (_root_.refl a)
 
-instance [IsRefl α r] [IsRefl β s] : IsRefl (α ⊕ β) (LiftRel r s) :=
+instance [Std.Refl r] [Std.Refl s] : Std.Refl (LiftRel r s) :=
   ⟨LiftRel.refl _ _⟩
 
 instance [Std.Irrefl r] [Std.Irrefl s] : Std.Irrefl (LiftRel r s) :=
@@ -71,7 +71,7 @@ section Lex
 
 variable (r : α → α → Prop) (s : β → β → Prop)
 
-instance [IsRefl α r] [IsRefl β s] : IsRefl (α ⊕ β) (Lex r s) :=
+instance [Std.Refl r] [Std.Refl s] : Std.Refl (Lex r s) :=
   ⟨by
     rintro (a | a)
     exacts [Lex.inl (refl _), Lex.inr (refl _)]⟩

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -204,7 +204,7 @@ theorem exists_maximal_linearIndepOn' (v : ι → M) :
     intro f hfsupp g hgsupp hsum
     rcases eq_empty_or_nonempty c with (rfl | hn)
     · rw [show f = 0 by simpa using hfsupp, show g = 0 by simpa using hgsupp]
-    haveI : IsRefl X r := ⟨fun _ => Set.Subset.refl _⟩
+    haveI : Std.Refl r := ⟨fun _ => Set.Subset.refl _⟩
     classical
     obtain ⟨I, _I_mem, hI⟩ : ∃ I ∈ c, (f.support ∪ g.support : Set ι) ⊆ I :=
       f.support.coe_union _ ▸ hc.directedOn.exists_mem_subset_of_finset_subset_biUnion hn <| by

--- a/Mathlib/LinearAlgebra/SModEq/Basic.lean
+++ b/Mathlib/LinearAlgebra/SModEq/Basic.lean
@@ -67,7 +67,7 @@ protected theorem refl (x : M) : x ≡ x [SMOD U] :=
 protected theorem rfl : x ≡ x [SMOD U] :=
   SModEq.refl _
 
-instance : IsRefl _ (SModEq U) :=
+instance : Std.Refl (SModEq U) :=
   ⟨SModEq.refl⟩
 
 @[symm]

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -56,7 +56,7 @@ section NeImp
 
 variable {r : α → α → Prop}
 
-theorem IsRefl.reflexive [IsRefl α r] : Reflexive r := fun x ↦ IsRefl.refl x
+theorem Std.Refl.reflexive [Std.Refl r] : Reflexive r := fun x ↦ Std.Refl.refl x
 
 /-- To show a reflexive relation `r : α → α → Prop` holds over `x y : α`,
 it suffices to show it holds when `x ≠ y`. -/
@@ -69,9 +69,9 @@ theorem Reflexive.ne_imp_iff (h : Reflexive r) {x y : α} : x ≠ y → r x y �
   ⟨h.rel_of_ne_imp, fun hr _ ↦ hr⟩
 
 /-- If a reflexive relation `r : α → α → Prop` holds over `x y : α`,
-then it holds whether or not `x ≠ y`. Unlike `Reflexive.ne_imp_iff`, this uses `[IsRefl α r]`. -/
-theorem reflexive_ne_imp_iff [IsRefl α r] {x y : α} : x ≠ y → r x y ↔ r x y :=
-  IsRefl.reflexive.ne_imp_iff
+then it holds whether or not `x ≠ y`. Unlike `Reflexive.ne_imp_iff`, this uses `[Std.Refl r]`. -/
+theorem reflexive_ne_imp_iff [Std.Refl r] {x y : α} : x ≠ y → r x y ↔ r x y :=
+  Std.Refl.reflexive.ne_imp_iff
 
 theorem reflexive_iff_subrelation_eq : Reflexive r ↔ Subrelation Eq r := by
   grind [Reflexive, Subrelation]
@@ -324,7 +324,7 @@ theorem mono {p : α → α → Prop} (hp : ∀ a b, r a b → p a b) : ∀ {a b
   | a, _, ReflGen.refl => by rfl
   | a, b, single h => single (hp a b h)
 
-instance : IsRefl α (ReflGen r) :=
+instance : Std.Refl (ReflGen r) :=
   ⟨@refl α r⟩
 
 end ReflGen
@@ -595,7 +595,7 @@ instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
 instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
   ⟨tail⟩
 
-instance : IsRefl α (ReflTransGen r) :=
+instance : Std.Refl (ReflTransGen r) :=
   ⟨@ReflTransGen.refl α r⟩
 
 instance : IsTrans α (ReflTransGen r) :=

--- a/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
@@ -75,7 +75,7 @@ protected theorem refl {_m0 : MeasurableSpace α} (μ : Measure α) : μ ≪ μ 
 
 protected theorem rfl : μ ≪ μ := fun _s hs => hs
 
-instance instIsRefl {_ : MeasurableSpace α} : IsRefl (Measure α) (· ≪ ·) :=
+instance instRefl {_ : MeasurableSpace α} : @Std.Refl (Measure α) (· ≪ ·) :=
   ⟨fun _ => AbsolutelyContinuous.rfl⟩
 
 @[simp]

--- a/Mathlib/ModelTheory/Equivalence.lean
+++ b/Mathlib/ModelTheory/Equivalence.lean
@@ -49,7 +49,7 @@ namespace Imp
 @[refl]
 protected theorem refl (φ : L.BoundedFormula α n) : φ ⟹[T] φ := fun _ _ _ => id
 
-instance : IsRefl (L.BoundedFormula α n) T.Imp := ⟨Imp.refl⟩
+instance : @Std.Refl (L.BoundedFormula α n) T.Imp := ⟨Imp.refl⟩
 
 @[trans]
 protected theorem trans {φ ψ θ : L.BoundedFormula α n} (h1 : φ ⟹[T] ψ) (h2 : ψ ⟹[T] θ) :
@@ -136,7 +136,7 @@ protected theorem mpr {φ ψ : L.BoundedFormula α n} (h : φ ⇔[T] ψ) :
 protected theorem refl (φ : L.BoundedFormula α n) : φ ⇔[T] φ :=
   fun M v xs => by rw [BoundedFormula.realize_iff]
 
-instance : IsRefl (L.BoundedFormula α n) T.Iff :=
+instance : @Std.Refl (L.BoundedFormula α n) T.Iff :=
   ⟨Iff.refl⟩
 
 @[symm]

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -324,7 +324,7 @@ theorem eq (hs : IsStrongAntichain r s) {a b c : α} (ha : a ∈ s) (hb : b ∈ 
   (Set.Pairwise.eq hs ha hb) fun h =>
     False.elim <| (h c).elim (not_not_intro hac) (not_not_intro hbc)
 
-protected theorem isAntichain [IsRefl α r] (h : IsStrongAntichain r s) : IsAntichain r s :=
+protected theorem isAntichain [Std.Refl r] (h : IsStrongAntichain r s) : IsAntichain r s :=
   h.imp fun _ b hab => (hab b).resolve_right (not_not_intro <| refl _)
 
 protected theorem subsingleton [IsDirected α r] (h : IsStrongAntichain r s) : s.Subsingleton :=

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -47,18 +47,18 @@ theorem antisymmRel_swap_apply : AntisymmRel (swap r) a b ↔ AntisymmRel r a b 
   and_comm
 
 @[simp, refl]
-theorem AntisymmRel.refl [IsRefl α r] (a : α) : AntisymmRel r a a :=
+theorem AntisymmRel.refl [Std.Refl r] (a : α) : AntisymmRel r a a :=
   ⟨_root_.refl _, _root_.refl _⟩
 
 variable {r} in
-lemma AntisymmRel.rfl [IsRefl α r] {a : α} : AntisymmRel r a a := .refl ..
+lemma AntisymmRel.rfl [Std.Refl r] {a : α} : AntisymmRel r a a := .refl ..
 
-instance [IsRefl α r] : IsRefl α (AntisymmRel r) where
+instance [Std.Refl r] : Std.Refl (AntisymmRel r) where
   refl := .refl r
 
 variable {r}
 
-theorem AntisymmRel.of_eq [IsRefl α r] {a b : α} (h : a = b) : AntisymmRel r a b := h ▸ .rfl
+theorem AntisymmRel.of_eq [Std.Refl r] {a b : α} (h : a = b) : AntisymmRel r a b := h ▸ .rfl
 alias Eq.antisymmRel := AntisymmRel.of_eq
 
 @[symm]
@@ -83,7 +83,7 @@ instance AntisymmRel.decidableRel [DecidableRel r] : DecidableRel (AntisymmRel r
   fun _ _ ↦ instDecidableAnd
 
 @[simp]
-theorem antisymmRel_iff_eq [IsRefl α r] [Std.Antisymm r] : AntisymmRel r a b ↔ a = b :=
+theorem antisymmRel_iff_eq [Std.Refl r] [Std.Antisymm r] : AntisymmRel r a b ↔ a = b :=
   antisymm_iff
 
 alias ⟨AntisymmRel.eq, _⟩ := antisymmRel_iff_eq

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -601,10 +601,10 @@ theorem Pi.compl_apply [∀ i, HasCompl (π i)] (x : ∀ i, π i) (i : ι) :
     xᶜ i = (x i)ᶜ :=
   rfl
 
-instance Std.Irrefl.compl (r) [Std.Irrefl r] : IsRefl α rᶜ :=
+instance Std.Irrefl.compl (r : α → α → Prop) [Std.Irrefl r] : Std.Refl rᶜ :=
   ⟨@irrefl α r _⟩
 
-instance IsRefl.compl (r) [IsRefl α r] : Std.Irrefl rᶜ :=
+instance Std.Refl.compl (r : α → α → Prop) [Std.Refl r] : Std.Irrefl rᶜ :=
   ⟨fun a ↦ not_not_intro (refl a)⟩
 
 theorem compl_lt [LinearOrder α] : (· < · : α → α → _)ᶜ = (· ≥ ·) := by simp [compl]

--- a/Mathlib/Order/Comparable.lean
+++ b/Mathlib/Order/Comparable.lean
@@ -63,12 +63,12 @@ theorem compRel_swap_apply (r : α → α → Prop) : CompRel (swap r) a b ↔ C
   or_comm
 
 @[simp, refl]
-theorem CompRel.refl (r : α → α → Prop) [IsRefl α r] (a : α) : CompRel r a a :=
+theorem CompRel.refl (r : α → α → Prop) [Std.Refl r] (a : α) : CompRel r a a :=
   .of_rel (_root_.refl _)
 
-theorem CompRel.rfl [IsRefl α r] : CompRel r a a := .refl ..
+theorem CompRel.rfl [Std.Refl r] : CompRel r a a := .refl ..
 
-instance [IsRefl α r] : IsRefl α (CompRel r) where
+instance [Std.Refl r] : Std.Refl (CompRel r) where
   refl := .refl r
 
 @[symm]
@@ -199,7 +199,7 @@ theorem IncompRel.refl [Std.Irrefl r] (a : α) : IncompRel r a a :=
 variable {r} in
 theorem IncompRel.rfl [Std.Irrefl r] {a : α} : IncompRel r a a := .refl ..
 
-instance [Std.Irrefl r] : IsRefl α (IncompRel r) where
+instance [Std.Irrefl r] : Std.Refl (IncompRel r) where
   refl := .refl r
 
 variable {r}

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -79,7 +79,7 @@ theorem wcovBy_congr_right (hab : AntisymmRel (· ≤ ·) a b) : c ⩿ a ↔ c �
 theorem not_wcovBy_iff (h : a ≤ b) : ¬a ⩿ b ↔ ∃ c, a < c ∧ c < b := by
   simp_rw [WCovBy, h, true_and, not_forall, exists_prop, not_not]
 
-instance WCovBy.isRefl : IsRefl α (· ⩿ ·) :=
+instance WCovBy.stdRefl : @Std.Refl α (· ⩿ ·) :=
   ⟨WCovBy.refl⟩
 
 theorem WCovBy.Ioo_eq (h : a ⩿ b) : Ioo a b = ∅ :=

--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -32,8 +32,8 @@ holds). -/
 abbrev IsIrrefl (α : Sort*) (r : α → α → Prop) : Prop := Std.Irrefl r
 
 /-- `IsRefl X r` means the binary relation `r` on `X` is reflexive. -/
-class IsRefl (α : Sort*) (r : α → α → Prop) : Prop where
-  refl : ∀ a, r a a
+@[deprecated Std.Refl (since := "2026-01-08")]
+abbrev IsRefl (α : Sort*) (r : α → α → Prop) : Prop := Std.Refl r
 
 /-- `IsSymm X r` means the binary relation `r` on `X` is symmetric. -/
 @[deprecated Std.Symm (since := "2025-12-26")]
@@ -65,7 +65,7 @@ class IsTotal (α : Sort*) (r : α → α → Prop) : Prop where
 
 /-- `IsPreorder X r` means that the binary relation `r` on `X` is a pre-order, that is, reflexive
 and transitive. -/
-class IsPreorder (α : Sort*) (r : α → α → Prop) : Prop extends IsRefl α r, IsTrans α r
+class IsPreorder (α : Sort*) (r : α → α → Prop) : Prop extends Std.Refl r, IsTrans α r
 
 /-- `IsPartialOrder X r` means that the binary relation `r` on `X` is a partial order, that is,
 `IsPreorder X r` and `Std.Antisymm r`. -/
@@ -118,7 +118,7 @@ variable {α : Sort*} {r : α → α → Prop} {a b c : α}
 local infixl:50 " ≺ " => r
 
 lemma irrefl [Std.Irrefl r] (a : α) : ¬a ≺ a := Std.Irrefl.irrefl a
-lemma refl [IsRefl α r] (a : α) : a ≺ a := IsRefl.refl a
+lemma refl [Std.Refl r] (a : α) : a ≺ a := Std.Refl.refl a
 lemma trans [IsTrans α r] : a ≺ b → b ≺ c → a ≺ c := IsTrans.trans _ _ _
 lemma symm [Std.Symm r] : a ≺ b → b ≺ a := Std.Symm.symm _ _
 lemma antisymm [Std.Antisymm r] : a ≺ b → b ≺ a → a = b := Std.Antisymm.antisymm _ _
@@ -134,8 +134,8 @@ instance Std.Irrefl.decide [DecidableRel r] [Std.Irrefl r] :
     Std.Irrefl (fun a b => decide (r a b) = true) where
   irrefl := fun a => by simpa using irrefl a
 
-instance IsRefl.decide [DecidableRel r] [IsRefl α r] :
-    IsRefl α (fun a b => decide (r a b) = true) where
+instance Std.Refl.decide [DecidableRel r] [Std.Refl r] :
+    Std.Refl (fun a b => decide (r a b) = true) where
   refl := fun a => by simpa using refl a
 
 instance IsTrans.decide [DecidableRel r] [IsTrans α r] :
@@ -165,7 +165,7 @@ instance IsTrichotomous.decide [DecidableRel r] [IsTrichotomous α r] :
 variable (r)
 
 @[elab_without_expected_type] lemma irrefl_of [Std.Irrefl r] (a : α) : ¬a ≺ a := irrefl a
-@[elab_without_expected_type] lemma refl_of [IsRefl α r] (a : α) : a ≺ a := refl a
+@[elab_without_expected_type] lemma refl_of [Std.Refl r] (a : α) : a ≺ a := refl a
 @[elab_without_expected_type] lemma trans_of [IsTrans α r] : a ≺ b → b ≺ c → a ≺ c := _root_.trans
 @[elab_without_expected_type] lemma symm_of [Std.Symm r] : a ≺ b → b ≺ a := symm
 @[elab_without_expected_type] lemma asymm_of [Std.Asymm r] : a ≺ b → ¬b ≺ a := asymm
@@ -178,7 +178,7 @@ lemma trichotomous_of [IsTrichotomous α r] : ∀ a b : α, a ≺ b ∨ a = b �
 
 section
 
-/-- `IsRefl` as a definition, suitable for use in proofs. -/
+/-- `Std.Refl` as a definition, suitable for use in proofs. -/
 def Reflexive := ∀ x, x ≺ x
 
 /-- `Std.Symm` as a definition, suitable for use in proofs. -/
@@ -310,7 +310,7 @@ extend_docs RelLowerSet before "The type of lower sets of an order relative to `
 
 variable {α β : Type*} {r : α → α → Prop} {s : β → β → Prop}
 
-theorem of_eq [IsRefl α r] : ∀ {a b}, a = b → r a b
+theorem of_eq [Std.Refl r] : ∀ {a b}, a = b → r a b
   | _, _, .refl _ => refl _
 
 theorem comm [Std.Symm r] {a b : α} : r a b ↔ r b a :=
@@ -318,7 +318,7 @@ theorem comm [Std.Symm r] {a b : α} : r a b ↔ r b a :=
 
 theorem antisymm' [Std.Antisymm r] {a b : α} : r a b → r b a → b = a := fun h h' => antisymm h' h
 
-theorem antisymm_iff [IsRefl α r] [Std.Antisymm r] {a b : α} : r a b ∧ r b a ↔ a = b :=
+theorem antisymm_iff [Std.Refl r] [Std.Antisymm r] {a b : α} : r a b ∧ r b a ↔ a = b :=
   ⟨fun h => antisymm h.1 h.2, by
     rintro rfl
     exact ⟨refl _, refl _⟩⟩
@@ -357,7 +357,7 @@ protected theorem IsTotal.isTrichotomous (r) [IsTotal α r] : IsTrichotomous α 
   ⟨fun a b => or_left_comm.1 (Or.inr <| total_of r a b)⟩
 
 -- see Note [lower instance priority]
-instance (priority := 100) IsTotal.to_isRefl (r) [IsTotal α r] : IsRefl α r :=
+instance (priority := 100) IsTotal.to_refl (r) [IsTotal α r] : Std.Refl r :=
   ⟨fun a => or_self_iff.1 <| total_of r a a⟩
 
 theorem ne_of_irrefl {r} [Std.Irrefl r] : ∀ {x y : α}, r x y → x ≠ y
@@ -369,7 +369,7 @@ theorem ne_of_irrefl' {r} [Std.Irrefl r] : ∀ {x y : α}, r x y → y ≠ x
 theorem not_rel_of_subsingleton (r : α → α → Prop) [Std.Irrefl r] [Subsingleton α] (x y) : ¬r x y :=
   Subsingleton.elim x y ▸ irrefl x
 
-theorem rel_of_subsingleton (r) [IsRefl α r] [Subsingleton α] (x y) : r x y :=
+theorem rel_of_subsingleton (r : α → α → Prop) [Std.Refl r] [Subsingleton α] (x y) : r x y :=
   Subsingleton.elim x y ▸ refl x
 
 @[simp]

--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -69,7 +69,7 @@ theorem IsBoundedUnder.mono_ge [Preorder β] {l : Filter α} {u v : α → β}
     (hu : IsBoundedUnder (· ≥ ·) l u) (hv : u ≤ᶠ[l] v) : IsBoundedUnder (· ≥ ·) l v :=
   IsBoundedUnder.mono_le (β := βᵒᵈ) hu hv
 
-theorem isBoundedUnder_const [IsRefl α r] {l : Filter β} {a : α} : IsBoundedUnder r l fun _ => a :=
+theorem isBoundedUnder_const [Std.Refl r] {l : Filter β} {a : α} : IsBoundedUnder r l fun _ => a :=
   ⟨a, eventually_map.2 <| Eventually.of_forall fun _ => refl _⟩
 
 theorem IsBounded.isBoundedUnder {q : β → β → Prop} {u : α → β}

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -1136,7 +1136,7 @@ restricted to pairs satisfying `a ⋖ b`. -/
 lemma monotone_iff_forall_covBy [PartialOrder α] [LocallyFiniteOrder α] [Preorder β]
     (f : α → β) : Monotone f ↔ ∀ a b : α, a ⋖ b → f a ≤ f b := by
   refine ⟨fun hf _ _ h ↦ hf h.le, fun h a b hab ↦ ?_⟩
-  simpa [reflTransGen_eq_self (r := (· ≤ · : β → β → Prop)) IsRefl.reflexive transitive_le]
+  simpa [reflTransGen_eq_self (r := (· ≤ · : β → β → Prop)) Std.Refl.reflexive transitive_le]
     using ReflTransGen.lift f h <| le_iff_reflTransGen_covBy.mp hab
 
 /-- A function from a locally finite preorder is strictly monotone if and only if it is strictly

--- a/Mathlib/Order/Lattice/Congruence.lean
+++ b/Mathlib/Order/Lattice/Congruence.lean
@@ -82,7 +82,7 @@ private lemma transitive {r : α → α → Prop}
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in
 /-- Alternative conditions for a lattice congruence. -/
-def mk' [Lattice α] (r : α → α → Prop) [h₁ : IsRefl α r]
+def mk' [Lattice α] (r : α → α → Prop) [h₁ : Std.Refl r]
     (h₂ : ∀ ⦃x y : α⦄, r x y ↔ r (x ⊓ y) (x ⊔ y))
     (h₃ : ∀ ⦃x y z : α⦄, x ≤ y → y ≤ z → r x y → r y z → r x z)
     (h₄ : ∀ ⦃x y t : α⦄, x ≤ y → r x y → r (x ⊓ t) (y ⊓ t) ∧ r (x ⊔ t) (y ⊔ t)) : LatticeCon α where

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -534,7 +534,7 @@ theorem Nat.rel_of_forall_rel_succ_of_le_of_lt (r : β → β → Prop) [IsTrans
   | refl => exact h _ hab
   | step b_lt_k r_b_k => exact _root_.trans r_b_k (h _ (hab.trans_lt b_lt_k).le)
 
-theorem Nat.rel_of_forall_rel_succ_of_le_of_le (r : β → β → Prop) [IsRefl β r] [IsTrans β r]
+theorem Nat.rel_of_forall_rel_succ_of_le_of_le (r : β → β → Prop) [Std.Refl r] [IsTrans β r]
     {f : ℕ → β} {a : ℕ} (h : ∀ n, a ≤ n → r (f n) (f (n + 1)))
     ⦃b c : ℕ⦄ (hab : a ≤ b) (hbc : b ≤ c) : r (f b) (f c) :=
   hbc.eq_or_lt.elim (fun h ↦ h ▸ refl _) (Nat.rel_of_forall_rel_succ_of_le_of_lt r h hab)
@@ -543,7 +543,7 @@ theorem Nat.rel_of_forall_rel_succ_of_lt (r : β → β → Prop) [IsTrans β r]
     (h : ∀ n, r (f n) (f (n + 1))) ⦃a b : ℕ⦄ (hab : a < b) : r (f a) (f b) :=
   Nat.rel_of_forall_rel_succ_of_le_of_lt r (fun n _ ↦ h n) le_rfl hab
 
-theorem Nat.rel_of_forall_rel_succ_of_le (r : β → β → Prop) [IsRefl β r] [IsTrans β r] {f : ℕ → β}
+theorem Nat.rel_of_forall_rel_succ_of_le (r : β → β → Prop) [Std.Refl r] [IsTrans β r] {f : ℕ → β}
     (h : ∀ n, r (f n) (f (n + 1))) ⦃a b : ℕ⦄ (hab : a ≤ b) : r (f a) (f b) :=
   Nat.rel_of_forall_rel_succ_of_le_of_le r (fun n _ ↦ h n) le_rfl hab
 
@@ -649,7 +649,7 @@ theorem Int.rel_of_forall_rel_succ_of_lt (r : β → β → Prop) [IsTrans β r]
   | zero => rw [Int.ofNat_one]; apply h
   | succ n ihn => rw [Int.natCast_succ, ← Int.add_assoc]; exact _root_.trans ihn (h _)
 
-theorem Int.rel_of_forall_rel_succ_of_le (r : β → β → Prop) [IsRefl β r] [IsTrans β r] {f : ℤ → β}
+theorem Int.rel_of_forall_rel_succ_of_le (r : β → β → Prop) [Std.Refl r] [IsTrans β r] {f : ℤ → β}
     (h : ∀ n, r (f n) (f (n + 1))) ⦃a b : ℤ⦄ (hab : a ≤ b) : r (f a) (f b) :=
   hab.eq_or_lt.elim (fun h ↦ h ▸ refl _) fun h' ↦ Int.rel_of_forall_rel_succ_of_lt r h h'
 

--- a/Mathlib/Order/Preorder/Chain.lean
+++ b/Mathlib/Order/Preorder/Chain.lean
@@ -193,7 +193,7 @@ end Rel
 
 section Total
 
-variable [IsRefl α r]
+variable [Std.Refl r]
 
 theorem IsChain.total (h : IsChain r s) (hx : x ∈ s) (hy : y ∈ s) : x ≺ y ∨ y ≺ x :=
   (eq_or_ne x y).elim (fun e => Or.inl <| e ▸ refl _) (h hx hy)

--- a/Mathlib/Order/Quotient.lean
+++ b/Mathlib/Order/Quotient.lean
@@ -39,7 +39,7 @@ instance : LE (Quotient s) where
 theorem le_def {x y : α} :
     Quotient.mk s x ≤ Quotient.mk s y ↔ Relation.TransGen (fun x y ↦ x ≤ y ∨ x ≈ y) x y := .rfl
 
-instance : IsRefl (Quotient s) (· ≤ ·) where
+instance : @Std.Refl (Quotient s) (· ≤ ·) where
   refl x := by
     induction x using Quotient.inductionOn with | h x
     exact .single <| .inr (refl x)

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -26,7 +26,7 @@ variable {α : Type u} {β : Type v} {r : α → α → Prop} {s : β → β →
 
 open Function
 
-theorem IsRefl.swap (r) [IsRefl α r] : IsRefl α (swap r) :=
+theorem Std.Refl.swap (r : α → α → Prop) [Std.Refl r] : Std.Refl (swap r) :=
   ⟨refl_of r⟩
 
 theorem Std.Irrefl.swap (r : α → α → Prop) [Std.Irrefl r] : Std.Irrefl (swap r) :=
@@ -48,13 +48,13 @@ theorem IsTrichotomous.swap (r) [IsTrichotomous α r] : IsTrichotomous α (swap 
   ⟨fun a b => by simpa [Function.swap, or_comm, or_left_comm] using trichotomous_of r a b⟩
 
 theorem IsPreorder.swap (r) [IsPreorder α r] : IsPreorder α (swap r) :=
-  { @IsRefl.swap α r _, @IsTrans.swap α r _ with }
+  { Std.Refl.swap r, IsTrans.swap r with }
 
 theorem IsStrictOrder.swap (r) [IsStrictOrder α r] : IsStrictOrder α (swap r) :=
-  { @Std.Irrefl.swap α r _, @IsTrans.swap α r _ with }
+  { Std.Irrefl.swap r, IsTrans.swap r with }
 
 theorem IsPartialOrder.swap (r) [IsPartialOrder α r] : IsPartialOrder α (swap r) :=
-  { @IsPreorder.swap α r _, @Std.Antisymm.swap α r _ with }
+  { IsPreorder.swap r, Std.Antisymm.swap r with }
 
 theorem eq_empty_relation (r : α → α → Prop) [Std.Irrefl r] [Subsingleton α] : r = emptyRelation :=
   funext₂ <| by simpa using not_rel_of_subsingleton r
@@ -397,7 +397,7 @@ end Set
 
 namespace Order.Preimage
 
-instance instIsRefl [IsRefl α r] {f : β → α} : IsRefl β (f ⁻¹'o r) :=
+instance instRefl [Std.Refl r] {f : β → α} : Std.Refl (f ⁻¹'o r) :=
   ⟨fun _ => refl_of r _⟩
 
 instance instIrrefl [Std.Irrefl r] {f : β → α} : Std.Irrefl (f ⁻¹'o r) :=
@@ -465,17 +465,17 @@ lemma subset_of_eq_of_subset (hab : a = b) (hbc : b ⊆ c) : a ⊆ c := by rwa [
 lemma subset_of_subset_of_eq (hab : a ⊆ b) (hbc : b = c) : a ⊆ c := by rwa [← hbc]
 
 @[refl, simp]
-lemma subset_refl [IsRefl α (· ⊆ ·)] (a : α) : a ⊆ a := refl _
+lemma subset_refl [@Std.Refl α (· ⊆ ·)] (a : α) : a ⊆ a := refl _
 
-lemma subset_rfl [IsRefl α (· ⊆ ·)] : a ⊆ a := refl _
+lemma subset_rfl [@Std.Refl α (· ⊆ ·)] : a ⊆ a := refl _
 
-lemma subset_of_eq [IsRefl α (· ⊆ ·)] : a = b → a ⊆ b := fun h => h ▸ subset_rfl
+lemma subset_of_eq [@Std.Refl α (· ⊆ ·)] : a = b → a ⊆ b := fun h => h ▸ subset_rfl
 
-lemma superset_of_eq [IsRefl α (· ⊆ ·)] : a = b → b ⊆ a := fun h => h ▸ subset_rfl
+lemma superset_of_eq [@Std.Refl α (· ⊆ ·)] : a = b → b ⊆ a := fun h => h ▸ subset_rfl
 
-lemma ne_of_not_subset [IsRefl α (· ⊆ ·)] : ¬a ⊆ b → a ≠ b := mt subset_of_eq
+lemma ne_of_not_subset [@Std.Refl α (· ⊆ ·)] : ¬a ⊆ b → a ≠ b := mt subset_of_eq
 
-lemma ne_of_not_superset [IsRefl α (· ⊆ ·)] : ¬a ⊆ b → b ≠ a := mt superset_of_eq
+lemma ne_of_not_superset [@Std.Refl α (· ⊆ ·)] : ¬a ⊆ b → b ≠ a := mt superset_of_eq
 
 @[trans]
 lemma subset_trans [IsTrans α (· ⊆ ·)] {a b c : α} : a ⊆ b → b ⊆ c → a ⊆ c := _root_.trans
@@ -498,10 +498,11 @@ alias HasSubset.Subset.antisymm := subset_antisymm
 
 alias HasSubset.Subset.antisymm' := superset_antisymm
 
-theorem subset_antisymm_iff [IsRefl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] : a = b ↔ a ⊆ b ∧ b ⊆ a :=
+theorem subset_antisymm_iff [@Std.Refl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] :
+    a = b ↔ a ⊆ b ∧ b ⊆ a :=
   ⟨fun h => ⟨h.subset', h.superset⟩, fun h => h.1.antisymm h.2⟩
 
-theorem superset_antisymm_iff [IsRefl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] :
+theorem superset_antisymm_iff [@Std.Refl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] :
     a = b ↔ b ⊆ a ∧ a ⊆ b :=
   ⟨fun h => ⟨h.superset, h.subset'⟩, fun h => h.1.antisymm' h.2⟩
 
@@ -611,7 +612,7 @@ alias HasSubset.Subset.eq_of_not_ssuperset := eq_of_superset_of_not_ssuperset
 theorem ssubset_iff_subset_ne [@Std.Antisymm α (· ⊆ ·)] : a ⊂ b ↔ a ⊆ b ∧ a ≠ b :=
   ⟨fun h => ⟨h.subset, h.ne⟩, fun h => h.1.ssubset_of_ne h.2⟩
 
-theorem subset_iff_ssubset_or_eq [IsRefl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] :
+theorem subset_iff_ssubset_or_eq [@Std.Refl α (· ⊆ ·)] [@Std.Antisymm α (· ⊆ ·)] :
     a ⊆ b ↔ a ⊂ b ∨ a = b :=
   ⟨fun h => h.ssubset_or_eq, fun h => h.elim subset_of_ssubset subset_of_eq⟩
 
@@ -638,8 +639,8 @@ end SubsetSsubset
 /-! ### Conversion of bundled order typeclasses to unbundled relation typeclasses -/
 
 
-@[to_dual instIsReflGe]
-instance [Preorder α] : IsRefl α (· ≤ ·) :=
+@[to_dual instReflGe]
+instance instReflLe [Preorder α] : @Std.Refl α (· ≤ ·) :=
   ⟨le_refl⟩
 
 @[to_dual instIsTransGe]

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -301,8 +301,10 @@ protected theorem irrefl (f : r ↪r s) [Std.Irrefl s] : Std.Irrefl r :=
 
 @[deprecated (since := "2026-01-07")] protected alias isIrrefl := RelEmbedding.irrefl
 
-protected theorem isRefl (f : r ↪r s) [IsRefl β s] : IsRefl α r :=
+protected theorem stdRefl (f : r ↪r s) [Std.Refl s] : Std.Refl r :=
   ⟨fun _ => f.map_rel_iff.1 <| refl _⟩
+
+@[deprecated (since := "2026-01-08")] protected alias isRefl := RelEmbedding.stdRefl
 
 protected theorem symm (f : r ↪r s) [Std.Symm s] : Std.Symm r :=
   ⟨fun _ _ => imp_imp_imp f.map_rel_iff.2 f.map_rel_iff.1 symm⟩
@@ -326,7 +328,7 @@ protected theorem isTotal : ∀ (_ : r ↪r s) [IsTotal β s], IsTotal α r
   | ⟨_, o⟩, ⟨H⟩ => ⟨fun _ _ => (or_congr o o).1 (H _ _)⟩
 
 protected theorem isPreorder : ∀ (_ : r ↪r s) [IsPreorder β s], IsPreorder α r
-  | f, _ => { f.isRefl, f.isTrans with }
+  | f, _ => { f.stdRefl, f.isTrans with }
 
 protected theorem isPartialOrder : ∀ (_ : r ↪r s) [IsPartialOrder β s], IsPartialOrder α r
   | f, _ => { f.isPreorder, f.antisymm with }
@@ -432,14 +434,14 @@ namespace RelEmbedding
 /-- To define a relation embedding from an antisymmetric relation `r` to a reflexive relation `s`
 it suffices to give a function together with a proof that it satisfies `s (f a) (f b) ↔ r a b`.
 -/
-def ofMapRelIff (f : α → β) [Std.Antisymm r] [IsRefl β s] (hf : ∀ a b, s (f a) (f b) ↔ r a b) :
+def ofMapRelIff (f : α → β) [Std.Antisymm r] [Std.Refl s] (hf : ∀ a b, s (f a) (f b) ↔ r a b) :
     r ↪r s where
   toFun := f
   inj' _ _ h := antisymm ((hf _ _).1 (h ▸ refl _)) ((hf _ _).1 (h ▸ refl _))
   map_rel_iff' := hf _ _
 
 @[simp]
-theorem ofMapRelIff_coe (f : α → β) [Std.Antisymm r] [IsRefl β s]
+theorem ofMapRelIff_coe (f : α → β) [Std.Antisymm r] [Std.Refl s]
     (hf : ∀ a b, s (f a) (f b) ↔ r a b) :
     (ofMapRelIff f hf : r ↪r s) = f :=
   rfl
@@ -806,7 +808,7 @@ def ofUniqueOfIrrefl (r : α → α → Prop) (s : β → β → Prop) [Std.Irre
       (not_rel_of_subsingleton r _ _) ⟩
 
 /-- Two reflexive relations on a unique type are isomorphic. -/
-def ofUniqueOfRefl (r : α → α → Prop) (s : β → β → Prop) [IsRefl α r] [IsRefl β s]
+def ofUniqueOfRefl (r : α → α → Prop) (s : β → β → Prop) [Std.Refl r] [Std.Refl s]
     [Unique α] [Unique β] : r ≃r s :=
   ⟨Equiv.ofUnique α β, iff_of_true (rel_of_subsingleton s _ _) (rel_of_subsingleton r _ _)⟩
 

--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -89,20 +89,20 @@ theorem coe_inclusionEmbedding (r : α → α → Prop) {s t : Set α} (h : s �
     (Subrel.inclusionEmbedding r h : s → t) = Set.inclusion h :=
   rfl
 
-instance (r : α → α → Prop) [IsRefl α r] (p : α → Prop) : IsRefl _ (Subrel r p) :=
-  ⟨fun x => @IsRefl.refl α r _ x⟩
+instance (r : α → α → Prop) [Std.Refl r] (p : α → Prop) : Std.Refl (Subrel r p) :=
+  ⟨fun x => Std.Refl.refl (r := r) x⟩
 
 instance (r : α → α → Prop) [Std.Symm r] (p : α → Prop) : Std.Symm (Subrel r p) :=
-  ⟨fun x y => @Std.Symm.symm α r _ x y⟩
+  ⟨fun x y => Std.Symm.symm (r := r) x y⟩
 
 instance (r : α → α → Prop) [Std.Asymm r] (p : α → Prop) : Std.Asymm (Subrel r p) :=
-  ⟨fun x y => @Std.Asymm.asymm α r _ x y⟩
+  ⟨fun x y => Std.Asymm.asymm (r := r) x y⟩
 
 instance (r : α → α → Prop) [IsTrans α r] (p : α → Prop) : IsTrans _ (Subrel r p) :=
-  ⟨fun x y z => @IsTrans.trans α r _ x y z⟩
+  ⟨fun x y z => IsTrans.trans (r := r) x y z⟩
 
 instance (r : α → α → Prop) [Std.Irrefl r] (p : α → Prop) : Std.Irrefl (Subrel r p) :=
-  ⟨fun x => @Std.Irrefl.irrefl α r _ x⟩
+  ⟨fun x => Std.Irrefl.irrefl (r := r) x⟩
 
 instance (r : α → α → Prop) [IsTrichotomous α r] (p : α → Prop) : IsTrichotomous _ (Subrel r p) :=
   ⟨fun x y => by rw [Subtype.ext_iff]; exact @IsTrichotomous.trichotomous α r _ x y⟩

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -310,8 +310,8 @@ theorem _root_.IsAntichain.finite_of_partiallyWellOrderedOn (ha : IsAntichain r 
   exact hmn.ne ((hi.natEmbedding _).injective <| Subtype.val_injective <|
     ha.eq (hi.natEmbedding _ m).2 (hi.natEmbedding _ n).2 h)
 
-section IsRefl
-variable [IsRefl α r]
+section Refl
+variable [Std.Refl r]
 
 protected theorem Finite.partiallyWellOrderedOn (hs : s.Finite) : s.PartiallyWellOrderedOn r :=
   hs.to_subtype.wellQuasiOrdered _
@@ -358,7 +358,7 @@ theorem partiallyWellOrderedOn_iff_finite_antichains [Std.Symm r] :
   · exact H _ _ h
   · exact mt symm (H _ _ h)
 
-end IsRefl
+end Refl
 
 section IsPreorder
 variable [IsPreorder α r]
@@ -588,7 +588,7 @@ namespace Finset
 variable {r : α → α → Prop}
 
 @[simp]
-protected theorem partiallyWellOrderedOn [IsRefl α r] (s : Finset α) :
+protected theorem partiallyWellOrderedOn [Std.Refl r] (s : Finset α) :
     (s : Set α).PartiallyWellOrderedOn r :=
   s.finite_toSet.partiallyWellOrderedOn
 

--- a/Mathlib/Order/WellQuasiOrder.lean
+++ b/Mathlib/Order/WellQuasiOrder.lean
@@ -52,7 +52,7 @@ theorem IsAntichain.finite_of_wellQuasiOrdered {s : Set α} (hs : IsAntichain r 
   exact hmn.ne ((hi.natEmbedding _).injective <| Subtype.val_injective <|
     hs.eq (hi.natEmbedding _ m).2 (hi.natEmbedding _ n).2 h)
 
-theorem Finite.wellQuasiOrdered (r : α → α → Prop) [Finite α] [IsRefl α r] :
+theorem Finite.wellQuasiOrdered (r : α → α → Prop) [Finite α] [Std.Refl r] :
     WellQuasiOrdered r := by
   intro f
   obtain ⟨m, n, h, hf⟩ := Set.finite_univ.exists_lt_map_eq_of_forall_mem (f := f)

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -43,7 +43,7 @@ variable {α : Type u} {β : Type v} {r : α → α → Prop} {s : β → β →
 
 /-! ### Cofinality of orders -/
 
-attribute [local instance] IsRefl.swap
+attribute [local instance] Std.Refl.swap
 
 namespace Order
 
@@ -53,14 +53,14 @@ def cof (r : α → α → Prop) : Cardinal :=
   sInf { c | ∃ S : Set α, (∀ a, ∃ b ∈ S, r a b) ∧ #S = c }
 
 /-- The set in the definition of `Order.cof` is nonempty. -/
-private theorem cof_nonempty (r : α → α → Prop) [IsRefl α r] :
+private theorem cof_nonempty (r : α → α → Prop) [Std.Refl r] :
     { c | ∃ S : Set α, (∀ a, ∃ b ∈ S, r a b) ∧ #S = c }.Nonempty :=
   ⟨_, Set.univ, fun a => ⟨a, ⟨⟩, refl _⟩, rfl⟩
 
 theorem cof_le (r : α → α → Prop) {S : Set α} (h : ∀ a, ∃ b ∈ S, r a b) : cof r ≤ #S :=
   csInf_le' ⟨S, h, rfl⟩
 
-theorem le_cof [IsRefl α r] (c : Cardinal) :
+theorem le_cof [Std.Refl r] (c : Cardinal) :
     c ≤ cof r ↔ ∀ {S : Set α}, (∀ a, ∃ b ∈ S, r a b) → c ≤ #S := by
   rw [cof, le_csInf_iff'' (cof_nonempty r)]
   use fun H S h => H _ ⟨S, h, rfl⟩
@@ -71,7 +71,7 @@ end Order
 
 namespace RelIso
 
-private theorem cof_le_lift [IsRefl β s] (f : r ≃r s) :
+private theorem cof_le_lift [Std.Refl s] (f : r ≃r s) :
     Cardinal.lift.{v} (Order.cof r) ≤ Cardinal.lift.{u} (Order.cof s) := by
   rw [Order.cof, Order.cof, lift_sInf, lift_sInf, le_csInf_iff'' ((Order.cof_nonempty s).image _)]
   rintro - ⟨-, ⟨u, H, rfl⟩, rfl⟩
@@ -81,12 +81,12 @@ private theorem cof_le_lift [IsRefl β s] (f : r ≃r s) :
   refine ⟨f.symm b, mem_image_of_mem _ hb, f.map_rel_iff.1 ?_⟩
   rwa [RelIso.apply_symm_apply]
 
-theorem cof_eq_lift [IsRefl β s] (f : r ≃r s) :
+theorem cof_eq_lift [Std.Refl s] (f : r ≃r s) :
     Cardinal.lift.{v} (Order.cof r) = Cardinal.lift.{u} (Order.cof s) :=
-  have := f.toRelEmbedding.isRefl
+  have := f.toRelEmbedding.stdRefl
   (f.cof_le_lift).antisymm (f.symm.cof_le_lift)
 
-theorem cof_eq {α β : Type u} {r : α → α → Prop} {s} [IsRefl β s] (f : r ≃r s) :
+theorem cof_eq {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} [Std.Refl s] (f : r ≃r s) :
     Order.cof r = Order.cof s :=
   lift_inj.1 (f.cof_eq_lift)
 

--- a/Mathlib/SetTheory/PGame/Basic.lean
+++ b/Mathlib/SetTheory/PGame/Basic.lean
@@ -382,7 +382,7 @@ theorem identical_of_isEmpty (x y : PGame)
 def identicalSetoid : Setoid PGame :=
   ⟨Identical, Identical.refl, Identical.symm, Identical.trans⟩
 
-instance : IsRefl PGame (· ≡ ·) := ⟨Identical.refl⟩
+instance : Std.Refl (· ≡ ·) := ⟨Identical.refl⟩
 instance : Std.Symm (· ≡ ·) := ⟨fun _ _ ↦ Identical.symm⟩
 instance : IsTrans PGame (· ≡ ·) := ⟨fun _ _ _ ↦ Identical.trans⟩
 instance : IsEquiv PGame (· ≡ ·) := { }

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -231,7 +231,7 @@ instance : HasSSubset ZFSet := ⟨(· < ·)⟩
 theorem subset_def {x y : ZFSet.{u}} : x ⊆ y ↔ ∀ ⦃z⦄, z ∈ x → z ∈ y :=
   Iff.rfl
 
-instance : IsRefl ZFSet (· ⊆ ·) :=
+instance : @Std.Refl ZFSet (· ⊆ ·) :=
   ⟨fun _ _ => id⟩
 
 instance : IsTrans ZFSet (· ⊆ ·) :=

--- a/Mathlib/SetTheory/ZFC/PSet.lean
+++ b/Mathlib/SetTheory/ZFC/PSet.lean
@@ -120,7 +120,7 @@ protected def Subset (x y : PSet) : Prop :=
 instance : HasSubset PSet :=
   ⟨PSet.Subset⟩
 
-instance : IsRefl PSet (· ⊆ ·) :=
+instance : @Std.Refl PSet (· ⊆ ·) :=
   ⟨fun _ a => ⟨a, Equiv.refl _⟩⟩
 
 instance : IsTrans PSet (· ⊆ ·) :=


### PR DESCRIPTION
---
[Mathlib's `IsRefl`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Defs/Unbundled.html#IsRefl)
[Core's `Std.Refl`](https://leanprover-community.github.io/mathlib4_docs/Init/Core.html#Std.Refl)

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Relation.20properties.20duplication/near/544638270)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
