### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Diam): drop `Finite α` from `ediam_le_two_mul_radius`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -357,19 +357,21 @@ lemma radius_eq_zero_iff : G.radius = 0 ↔ Nonempty α ∧ Subsingleton α := b
 lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
   iInf_le_iSup
 
+lemma ediam_le_two_mul_eccent (u : α) : G.ediam ≤ 2 * G.eccent u := by
+  refine ediam_le_of_edist_le fun v w ↦ ?_
+  calc
+    G.edist v w
+      ≤ G.edist v u + G.edist u w := G.edist_triangle
+    _ = G.edist u v + G.edist u w := by rw [edist_comm]
+    _ ≤ G.eccent u + G.eccent u := add_le_add edist_le_eccent edist_le_eccent
+    _ = 2 * G.eccent u := (two_mul _).symm
+
 lemma ediam_eq_top_iff_radius_eq_top [Nonempty α] : G.ediam = ⊤ ↔ G.radius = ⊤ := by
   refine ⟨?_, fun hr ↦ eq_top_iff.mpr (hr ▸ radius_le_ediam)⟩
   contrapose
   intro hr
   obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
-  have hdiam : G.ediam ≤ 2 * G.eccent w := by
-    refine ediam_le_of_edist_le fun u v ↦ ?_
-    calc
-      G.edist u v
-        ≤ G.edist u w + G.edist w v := G.edist_triangle
-      _ = G.edist w u + G.edist w v := by rw [edist_comm]
-      _ ≤ G.eccent w + G.eccent w := add_le_add edist_le_eccent edist_le_eccent
-      _ = 2 * G.eccent w := (two_mul _).symm
+  have hdiam : G.ediam ≤ 2 * G.eccent w := ediam_le_two_mul_eccent w
   refine ne_top_of_lt <| lt_of_le_of_lt hdiam (WithTop.mul_lt_top (ENat.coe_lt_top 2) ?_)
   exact lt_top_iff_ne_top.mpr (hw ▸ hr)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -225,6 +225,15 @@ lemma ediam_eq_one [Nontrivial α] : G.ediam = 1 ↔ G = ⊤ := by
   rw [Order.one_le_iff_pos, pos_iff_ne_zero]
   exact eccent_ne_zero u
 
+lemma ediam_le_two_mul_eccent (u : α) : G.ediam ≤ 2 * G.eccent u := by
+  refine ediam_le_of_edist_le fun v w ↦ ?_
+  calc
+    G.edist v w
+      ≤ G.edist v u + G.edist u w := G.edist_triangle
+    _ = G.edist u v + G.edist u w := by rw [edist_comm]
+    _ ≤ G.eccent u + G.eccent u := add_le_add edist_le_eccent edist_le_eccent
+    _ = 2 * G.eccent u := (two_mul _).symm
+
 end ediam
 
 section diam
@@ -356,15 +365,6 @@ lemma radius_eq_zero_iff : G.radius = 0 ↔ Nonempty α ∧ Subsingleton α := b
 
 lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
   iInf_le_iSup
-
-lemma ediam_le_two_mul_eccent (u : α) : G.ediam ≤ 2 * G.eccent u := by
-  refine ediam_le_of_edist_le fun v w ↦ ?_
-  calc
-    G.edist v w
-      ≤ G.edist v u + G.edist u w := G.edist_triangle
-    _ = G.edist u v + G.edist u w := by rw [edist_comm]
-    _ ≤ G.eccent u + G.eccent u := add_le_add edist_le_eccent edist_le_eccent
-    _ = 2 * G.eccent u := (two_mul _).symm
 
 lemma ediam_eq_top_iff_radius_eq_top [Nonempty α] : G.ediam = ⊤ ↔ G.radius = ⊤ := by
   refine ⟨?_, fun hr ↦ eq_top_iff.mpr (hr ▸ radius_le_ediam)⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -358,25 +358,20 @@ lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
   iInf_le_iSup
 
 lemma ediam_eq_top_iff_radius_eq_top [Nonempty α] : G.ediam = ⊤ ↔ G.radius = ⊤ := by
-  constructor
-  · contrapose
-    intro hr
-    obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
-    have hw' : G.eccent w ≠ ⊤ := hw ▸ hr
-    have hle : ∀ u v, G.edist u v ≤ 2 * G.eccent w := by
-      intro u v
-      calc
-        G.edist u v
-          ≤ G.edist u w + G.edist w v := G.edist_triangle
-        _ = G.edist w u + G.edist w v := by rw [edist_comm]
-        _ ≤ G.eccent w + G.eccent w := add_le_add edist_le_eccent edist_le_eccent
-        _ = 2 * G.eccent w := Eq.comm.mp (two_mul _)
-    have hdiam : G.ediam ≤ 2 * G.eccent w := ediam_le_of_edist_le hle
-    have ediam' : G.ediam < ⊤ := lt_of_le_of_lt hdiam (WithTop.mul_lt_top (ENat.coe_lt_top 2)
-      (lt_top_iff_ne_top.mpr hw'))
-    exact ediam'.ne_top
-  · intro hr
-    exact eq_top_iff.mpr (hr ▸ radius_le_ediam)
+  refine ⟨?_, fun hr ↦ eq_top_iff.mpr (hr ▸ radius_le_ediam)⟩
+  contrapose
+  intro hr
+  obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
+  have hdiam : G.ediam ≤ 2 * G.eccent w := by
+    refine ediam_le_of_edist_le fun u v ↦ ?_
+    calc
+      G.edist u v
+        ≤ G.edist u w + G.edist w v := G.edist_triangle
+      _ = G.edist w u + G.edist w v := by rw [edist_comm]
+      _ ≤ G.eccent w + G.eccent w := add_le_add edist_le_eccent edist_le_eccent
+      _ = 2 * G.eccent w := (two_mul _).symm
+  refine ne_top_of_lt <| lt_of_le_of_lt hdiam (WithTop.mul_lt_top (ENat.coe_lt_top 2) ?_)
+  exact lt_top_iff_ne_top.mpr (hw ▸ hr)
 
 lemma ediam_le_two_mul_radius : G.ediam ≤ 2 * G.radius := by
   cases isEmpty_or_nonempty α

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -357,18 +357,38 @@ lemma radius_eq_zero_iff : G.radius = 0 ↔ Nonempty α ∧ Subsingleton α := b
 lemma radius_le_ediam [Nonempty α] : G.radius ≤ G.ediam :=
   iInf_le_iSup
 
-lemma ediam_le_two_mul_radius [Finite α] : G.ediam ≤ 2 * G.radius := by
+lemma ediam_eq_top_iff_radius_eq_top [Nonempty α] : G.ediam = ⊤ ↔ G.radius = ⊤ := by
+  constructor
+  · contrapose
+    intro hr
+    obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
+    have hw' : G.eccent w ≠ ⊤ := hw ▸ hr
+    have hle : ∀ u v, G.edist u v ≤ 2 * G.eccent w := by
+      intro u v
+      calc
+        G.edist u v
+          ≤ G.edist u w + G.edist w v := G.edist_triangle
+        _ = G.edist w u + G.edist w v := by rw [edist_comm]
+        _ ≤ G.eccent w + G.eccent w := add_le_add edist_le_eccent edist_le_eccent
+        _ = 2 * G.eccent w := Eq.comm.mp (two_mul _)
+    have hdiam : G.ediam ≤ 2 * G.eccent w := ediam_le_of_edist_le hle
+    have ediam' : G.ediam < ⊤ := lt_of_le_of_lt hdiam (WithTop.mul_lt_top (ENat.coe_lt_top 2)
+      (lt_top_iff_ne_top.mpr hw'))
+    exact ediam'.ne_top
+  · intro hr
+    exact eq_top_iff.mpr (hr ▸ radius_le_ediam)
+
+lemma ediam_le_two_mul_radius : G.ediam ≤ 2 * G.radius := by
   cases isEmpty_or_nonempty α
   · rw [radius_eq_top_of_isEmpty]
     exact le_top
-  · by_cases h : G.Connected
+  · by_cases hdiam : G.ediam = ⊤
+    · simp [hdiam, ediam_eq_top_iff_radius_eq_top.mp hdiam]
     · obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
-      obtain ⟨_, _, h⟩ := G.exists_edist_eq_ediam_of_ne_top (connected_iff_ediam_ne_top.mp h)
+      obtain ⟨_, _, h⟩ := G.exists_edist_eq_ediam_of_ne_top hdiam
       apply le_trans (h ▸ G.edist_triangle (v := w))
       rw [two_mul]
       exact hw ▸ add_le_add (G.edist_comm ▸ G.edist_le_eccent) G.edist_le_eccent
-    · rw [G.radius_eq_top_of_not_connected h]
-      exact le_top
 
 lemma radius_eq_ediam_iff [Nonempty α] :
     G.radius = G.ediam ↔ ∃ e, ∀ u, G.eccent u = e := by

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -372,8 +372,8 @@ lemma ediam_eq_top_iff_radius_eq_top [Nonempty α] : G.ediam = ⊤ ↔ G.radius 
   intro hr
   obtain ⟨w, hw⟩ := G.exists_eccent_eq_radius
   have hdiam : G.ediam ≤ 2 * G.eccent w := ediam_le_two_mul_eccent w
-  refine ne_top_of_lt <| lt_of_le_of_lt hdiam (WithTop.mul_lt_top (ENat.coe_lt_top 2) ?_)
-  exact lt_top_iff_ne_top.mpr (hw ▸ hr)
+  exact ne_top_of_lt <| lt_of_le_of_lt hdiam <| WithTop.mul_lt_top (ENat.coe_lt_top 2) <|
+    lt_top_iff_ne_top.mpr (hw ▸ hr)
 
 lemma ediam_le_two_mul_radius : G.ediam ≤ 2 * G.radius := by
   cases isEmpty_or_nonempty α


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
