### PR TITLE
[Merged by Bors] - chore(RingTheory/Morita/Matrix): remove uses of `default`

### DIFF
--- a/Mathlib/RingTheory/Morita/Matrix.lean
+++ b/Mathlib/RingTheory/Morita/Matrix.lean
@@ -68,7 +68,7 @@ lemma mem_toModuleCatObj (i : ι) {x : M} :
 
 variable {R} in
 /-- An `R`-linear map between `Eᵢᵢ • M` and `Eᵢᵢ • N` induced by an `Mₙ(R)`-linear map
-  from `M` to `N`.-/
+  from `M` to `N`. -/
 @[simps!]
 def fromMatrixLinear {N : Type*} [AddCommGroup N] [Module (Matrix ι ι R) N] (i : ι)
     [Module R N] [IsScalarTower R (Matrix ι ι R) N] [Module R M] [IsScalarTower R (Matrix ι ι R) M]
@@ -97,7 +97,8 @@ def MatrixModCat.toModuleCat (i : ι) : ModuleCat (Matrix ι ι R) ⥤ ModuleCat
 open MatrixModCat Matrix
 
 /-- The linear equiv induced by the equality `toModuleCat (toMatrixModCat M) = Eᵢᵢ • Mⁿ`. -/
-def fromModuleCatToModuleCatLinearEquivtoModuleCatObj (M : Type*) [AddCommGroup M] [Module R M] (i : ι) :
+def fromModuleCatToModuleCatLinearEquivtoModuleCatObj
+    (M : Type*) [AddCommGroup M] [Module R M] (i : ι) :
     (ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i).obj (.of R M) ≃ₗ[R]
     MatrixModCat.toModuleCatObj R (ι → M) i where
   __ := AddEquiv.refl _

--- a/Mathlib/RingTheory/Morita/Matrix.lean
+++ b/Mathlib/RingTheory/Morita/Matrix.lean
@@ -37,6 +37,8 @@ def ModuleCat.toMatrixModCat : ModuleCat R ⥤ ModuleCat (Matrix ι ι R) where
   map_id _ := ModuleCat.hom_ext <| LinearMap.mapMatrixModule_id
   map_comp f g := ModuleCat.hom_ext (LinearMap.mapMatrixModule_comp f.hom g.hom)
 
+variable {ι}
+
 namespace MatrixModCat
 
 open Matrix
@@ -44,7 +46,7 @@ open Matrix
 variable {M : Type*} [AddCommGroup M] [Module (Matrix ι ι R) M] [Module R M]
   [IsScalarTower R (Matrix ι ι R) M]
 
-variable {ι} (M) in
+variable (M) in
 /-- The image of `Eᵢᵢ` (the elementary matrix) acting on all elements in `M`. -/
 def toModuleCatObj (i : ι) : Submodule R M :=
   LinearMap.range (τ₁₂ := .id _) <|
@@ -58,13 +60,13 @@ def toModuleCatObj (i : ι) : Submodule R M :=
         nth_rw 1 [← one_smul (Matrix ι ι R) x]
         rw [smul_assoc] }
 
-variable {R ι} in
+variable {R} in
 @[simp]
 lemma mem_toModuleCatObj (i : ι) {x : M} :
     x ∈ toModuleCatObj R M i ↔ ∃ y : M, single i i (1 : R) • y = x :=
   Iff.rfl
 
-variable {R ι} in
+variable {R} in
 /-- An `R`-linear map between `Eᵢᵢ • M` and `Eᵢᵢ • N` induced by an `Mₙ(R)`-linear map
   from `M` to `N` -/
 @[simps!]
@@ -82,24 +84,22 @@ universe w
 /-- The functor from the category of modules over `Mₙ(R)` to the category of modules over `R`
   induced by sending `M` to the image of `Eᵢᵢ • ·` where `Eᵢᵢ` is the elementary matrix -/
 @[simps]
-def MatrixModCat.toModuleCat [Inhabited ι] : ModuleCat (Matrix ι ι R) ⥤ ModuleCat R :=
+def MatrixModCat.toModuleCat (i : ι) : ModuleCat (Matrix ι ι R) ⥤ ModuleCat R :=
   letI (M : ModuleCat (Matrix ι ι R)) := Module.compHom M (Matrix.scalar (α := R) ι)
   haveI (M : ModuleCat (Matrix ι ι R)) : IsScalarTower R (Matrix ι ι R) M :=
-    { smul_assoc r m x := show _ = (Matrix.scalar ι r) • (m • x) by
+    { smul_assoc r m x := show _ = Matrix.scalar ι r • (m • x) by
         rw [← mul_smul, Matrix.scalar_apply, Matrix.smul_eq_diagonal_mul] }
-  { obj M := ModuleCat.of R (MatrixModCat.toModuleCatObj R M default)
-    map {M N} f := ModuleCat.ofHom <| fromMatrixLinear default f.hom
+  { obj M := ModuleCat.of R (MatrixModCat.toModuleCatObj R M i)
+    map {M N} f := ModuleCat.ofHom <| fromMatrixLinear i f.hom
     map_id _ := rfl
     map_comp _ _ := rfl }
 
 open MatrixModCat Matrix
 
-variable [Inhabited ι]
-
 /-- The linear equiv induced by the equality `toModuleCat (toMatrixModCat M) = Eᵢᵢ • Mⁿ` -/
-def fromModuleCatToModuleCatLinearEquivtoModuleCatObj (M : Type*) [AddCommGroup M] [Module R M] :
-    (ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R ι).obj (.of R M) ≃ₗ[R]
-    MatrixModCat.toModuleCatObj R (ι := ι) (ι → M) default where
+def fromModuleCatToModuleCatLinearEquivtoModuleCatObj (M : Type*) [AddCommGroup M] [Module R M] (i : ι) :
+    (ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i).obj (.of R M) ≃ₗ[R]
+    MatrixModCat.toModuleCatObj R (ι → M) i where
   __ := AddEquiv.refl _
   map_smul' _ _ := Subtype.ext <| scalar_smul _ _
 
@@ -112,16 +112,16 @@ def fromModuleCatToModuleCatLinearEquiv (M : Type*) [AddCommGroup M] [Module R M
   map_smul' r := fun ⟨x, hx⟩ ↦ by simp [Finset.smul_sum]
   invFun x := ⟨Pi.single i x, Function.const ι x, by simp⟩
   left_inv := fun ⟨x, hx⟩ ↦ by
-    obtain ⟨y, hy⟩ := mem_toModuleCatObj i|>.1 hx
+    obtain ⟨y, hy⟩ := mem_toModuleCatObj i |>.1 hx
     rw [single_smul] at hy
     simp [← hy]
   right_inv x := by simp
 
 /-- the natural isomorphism showing that `toModuleCat` is the left inverse of `toMatrixModCat` -/
-def MatrixModCat.unitIso :
-    ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R ι ≅ 𝟭 (ModuleCat R) :=
-  NatIso.ofComponents (fun X ↦ (fromModuleCatToModuleCatLinearEquivtoModuleCatObj R ι X ≪≫ₗ
-    (fromModuleCatToModuleCatLinearEquiv R ι X default)).toModuleIso) <| by
+def MatrixModCat.unitIso (i : ι):
+    ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i ≅ 𝟭 (ModuleCat R) :=
+  NatIso.ofComponents (fun X ↦ (fromModuleCatToModuleCatLinearEquivtoModuleCatObj R X i ≪≫ₗ
+    (fromModuleCatToModuleCatLinearEquiv R X i)).toModuleIso) <| by
     intros
     ext
     simp [fromModuleCatToModuleCatLinearEquivtoModuleCatObj]

--- a/Mathlib/RingTheory/Morita/Matrix.lean
+++ b/Mathlib/RingTheory/Morita/Matrix.lean
@@ -68,7 +68,7 @@ lemma mem_toModuleCatObj (i : ι) {x : M} :
 
 variable {R} in
 /-- An `R`-linear map between `Eᵢᵢ • M` and `Eᵢᵢ • N` induced by an `Mₙ(R)`-linear map
-  from `M` to `N` -/
+  from `M` to `N`.-/
 @[simps!]
 def fromMatrixLinear {N : Type*} [AddCommGroup N] [Module (Matrix ι ι R) N] (i : ι)
     [Module R N] [IsScalarTower R (Matrix ι ι R) N] [Module R M] [IsScalarTower R (Matrix ι ι R) M]
@@ -82,7 +82,7 @@ end MatrixModCat
 universe w
 
 /-- The functor from the category of modules over `Mₙ(R)` to the category of modules over `R`
-  induced by sending `M` to the image of `Eᵢᵢ • ·` where `Eᵢᵢ` is the elementary matrix -/
+  induced by sending `M` to the image of `Eᵢᵢ • ·` where `Eᵢᵢ` is the elementary matrix. -/
 @[simps]
 def MatrixModCat.toModuleCat (i : ι) : ModuleCat (Matrix ι ι R) ⥤ ModuleCat R :=
   letI (M : ModuleCat (Matrix ι ι R)) := Module.compHom M (Matrix.scalar (α := R) ι)
@@ -96,14 +96,14 @@ def MatrixModCat.toModuleCat (i : ι) : ModuleCat (Matrix ι ι R) ⥤ ModuleCat
 
 open MatrixModCat Matrix
 
-/-- The linear equiv induced by the equality `toModuleCat (toMatrixModCat M) = Eᵢᵢ • Mⁿ` -/
+/-- The linear equiv induced by the equality `toModuleCat (toMatrixModCat M) = Eᵢᵢ • Mⁿ`. -/
 def fromModuleCatToModuleCatLinearEquivtoModuleCatObj (M : Type*) [AddCommGroup M] [Module R M] (i : ι) :
     (ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i).obj (.of R M) ≃ₗ[R]
     MatrixModCat.toModuleCatObj R (ι → M) i where
   __ := AddEquiv.refl _
   map_smul' _ _ := Subtype.ext <| scalar_smul _ _
 
-/-- auxilary isomorphism showing that compose two functors gives `id` on objects. -/
+/-- Auxilary isomorphism showing that compose two functors gives `id` on objects. -/
 @[simps]
 def fromModuleCatToModuleCatLinearEquiv (M : Type*) [AddCommGroup M] [Module R M] (i : ι) :
     MatrixModCat.toModuleCatObj R (ι → M) i ≃ₗ[R] M where
@@ -117,7 +117,7 @@ def fromModuleCatToModuleCatLinearEquiv (M : Type*) [AddCommGroup M] [Module R M
     simp [← hy]
   right_inv x := by simp
 
-/-- the natural isomorphism showing that `toModuleCat` is the left inverse of `toMatrixModCat` -/
+/-- The natural isomorphism showing that `toModuleCat` is the left inverse of `toMatrixModCat`. -/
 def MatrixModCat.unitIso (i : ι):
     ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i ≅ 𝟭 (ModuleCat R) :=
   NatIso.ofComponents (fun X ↦ (fromModuleCatToModuleCatLinearEquivtoModuleCatObj R X i ≪≫ₗ

--- a/Mathlib/RingTheory/Morita/Matrix.lean
+++ b/Mathlib/RingTheory/Morita/Matrix.lean
@@ -118,7 +118,7 @@ def fromModuleCatToModuleCatLinearEquiv (M : Type*) [AddCommGroup M] [Module R M
   right_inv x := by simp
 
 /-- The natural isomorphism showing that `toModuleCat` is the left inverse of `toMatrixModCat`. -/
-def MatrixModCat.unitIso (i : ι):
+def MatrixModCat.unitIso (i : ι) :
     ModuleCat.toMatrixModCat R ι ⋙ MatrixModCat.toModuleCat R i ≅ 𝟭 (ModuleCat R) :=
   NatIso.ofComponents (fun X ↦ (fromModuleCatToModuleCatLinearEquivtoModuleCatObj R X i ≪≫ₗ
     (fromModuleCatToModuleCatLinearEquiv R X i)).toModuleIso) <| by


### PR DESCRIPTION
Using `default` here just makes the spelling longer and less general. The docstring already say `Eᵢᵢ`, so these functions should take `i`.

Follows on from https://github.com/leanprover-community/mathlib4/pull/32988#discussion_r2658016014.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
