### PR TITLE
[Merged by Bors] - chore(Algebra): deduplicate `IsReduced` lemmas

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -250,7 +250,7 @@ variable [IsReduced M₀]
 
 @[deprecated (since := "2025-10-14")] alias pow_eq_zero := eq_zero_of_pow_eq_zero
 
-@[simp] theorem pow_eq_zero_iff (hn : n ≠ 0) : a ^ n = 0 ↔ a = 0 :=
+@[simp] lemma pow_eq_zero_iff (hn : n ≠ 0) : a ^ n = 0 ↔ a = 0 :=
   ⟨eq_zero_of_pow_eq_zero, (·.symm ▸ zero_pow hn)⟩
 
 lemma pow_ne_zero_iff (hn : n ≠ 0) : a ^ n ≠ 0 ↔ a ≠ 0 := (pow_eq_zero_iff hn).not

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -239,6 +239,13 @@ lemma pow_mul_eq_zero_of_le {a b : M₀} {m n : ℕ} (hmn : m ≤ n)
   rw [show n = n - m + m by lia, pow_add, mul_assoc, h]
   simp
 
+instance (priority := 900) isReduced_of_noZeroDivisors [NoZeroDivisors M₀] :
+    IsReduced M₀ :=
+  ⟨fun a ⟨n, ha⟩ ↦ by
+    induction n with
+    | zero => simpa using congr_arg (a * ·) ha
+    | succ n ih => rw [pow_succ, mul_eq_zero] at ha; exact ha.elim ih id⟩
+
 variable [IsReduced M₀]
 
 @[deprecated (since := "2025-10-14")] alias pow_eq_zero := eq_zero_of_pow_eq_zero

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -139,6 +139,77 @@ theorem right_ne_zero_of_mul_eq_one (h : a * b = 1) : b ≠ 0 :=
 
 end
 
+section Nilpotent
+
+variable {R S : Type*} {x y : R}
+
+/-- An element is said to be nilpotent if some natural-number-power of it equals zero.
+
+Note that we require only the bare minimum assumptions for the definition to make sense. Even
+`MonoidWithZero` is too strong since nilpotency is important in the study of rings that are only
+power-associative. -/
+def IsNilpotent [Zero R] [Pow R ℕ] (x : R) : Prop :=
+  ∃ n : ℕ, x ^ n = 0
+
+theorem IsNilpotent.mk [Zero R] [Pow R ℕ] (x : R) (n : ℕ) (e : x ^ n = 0) : IsNilpotent x :=
+  ⟨n, e⟩
+
+@[simp] lemma isNilpotent_of_subsingleton [Zero R] [Pow R ℕ] [Subsingleton R] : IsNilpotent x :=
+  ⟨0, Subsingleton.elim _ _⟩
+
+@[simp] theorem IsNilpotent.zero [MonoidWithZero R] : IsNilpotent (0 : R) :=
+  ⟨1, pow_one 0⟩
+
+theorem not_isNilpotent_one [MonoidWithZero R] [Nontrivial R] :
+    ¬ IsNilpotent (1 : R) := fun ⟨_, H⟩ ↦ zero_ne_one (H.symm.trans (one_pow _))
+
+lemma IsNilpotent.pow_succ (n : ℕ) {S : Type*} [MonoidWithZero S] {x : S}
+    (hx : IsNilpotent x) : IsNilpotent (x ^ n.succ) :=
+  have ⟨N, hN⟩ := hx
+  ⟨N, by rw [← pow_mul, Nat.succ_mul, pow_add, hN, mul_zero]⟩
+
+theorem IsNilpotent.of_pow [MonoidWithZero R] {x : R} {m : ℕ}
+    (h : IsNilpotent (x ^ m)) : IsNilpotent x :=
+  have ⟨n, h⟩ := h
+  ⟨m * n, by rw [← h, pow_mul x m n]⟩
+
+lemma IsNilpotent.pow_of_pos {n} {S : Type*} [MonoidWithZero S] {x : S}
+    (hx : IsNilpotent x) (hn : n ≠ 0) : IsNilpotent (x ^ n) := by
+  cases n with
+  | zero => contradiction
+  | succ => exact IsNilpotent.pow_succ _ hx
+
+@[simp]
+lemma IsNilpotent.pow_iff_pos {n} {S : Type*} [MonoidWithZero S] {x : S} (hn : n ≠ 0) :
+    IsNilpotent (x ^ n) ↔ IsNilpotent x :=
+  ⟨of_pow, (pow_of_pos · hn)⟩
+
+/-- A structure that has zero and pow is reduced if it has no nonzero nilpotent elements. -/
+@[mk_iff]
+class IsReduced (R : Type*) [Zero R] [Pow R ℕ] : Prop where
+  /-- A reduced structure has no nonzero nilpotent elements. -/
+  eq_zero : ∀ x : R, IsNilpotent x → x = 0
+
+theorem eq_zero_of_pow_eq_zero [Zero R] [Pow R ℕ] [IsReduced R] {n : ℕ} (h : x ^ n = 0) :
+    x = 0 := IsReduced.eq_zero x ⟨n, h⟩
+
+instance (priority := 900) isReduced_of_subsingleton [Zero R] [Pow R ℕ] [Subsingleton R] :
+    IsReduced R :=
+  ⟨fun _ _ => Subsingleton.elim ..⟩
+
+theorem IsNilpotent.eq_zero [Zero R] [Pow R ℕ] [IsReduced R] (h : IsNilpotent x) : x = 0 :=
+  IsReduced.eq_zero x h
+
+@[simp]
+theorem isNilpotent_iff_eq_zero [MonoidWithZero R] [IsReduced R] : IsNilpotent x ↔ x = 0 :=
+  ⟨fun h => h.eq_zero, fun h => h.symm ▸ IsNilpotent.zero⟩
+
+lemma exists_isNilpotent_of_not_isReduced {R : Type*} [Zero R] [Pow R ℕ] (h : ¬IsReduced R) :
+    ∃ x : R, x ≠ 0 ∧ IsNilpotent x := by
+  simpa [isReduced_iff, not_forall, and_comm] using h
+
+end Nilpotent
+
 section MonoidWithZero
 variable [MonoidWithZero M₀] {a : M₀} {n : ℕ}
 
@@ -168,16 +239,12 @@ lemma pow_mul_eq_zero_of_le {a b : M₀} {m n : ℕ} (hmn : m ≤ n)
   rw [show n = n - m + m by lia, pow_add, mul_assoc, h]
   simp
 
-variable [NoZeroDivisors M₀]
-
-lemma eq_zero_of_pow_eq_zero : ∀ {n}, a ^ n = 0 → a = 0
-  | 0, ha => by simpa using congr_arg (a * ·) ha
-  | n + 1, ha => by rw [pow_succ, mul_eq_zero] at ha; exact ha.elim eq_zero_of_pow_eq_zero id
+variable [IsReduced M₀]
 
 @[deprecated (since := "2025-10-14")] alias pow_eq_zero := eq_zero_of_pow_eq_zero
 
-@[simp] lemma pow_eq_zero_iff (hn : n ≠ 0) : a ^ n = 0 ↔ a = 0 :=
-  ⟨eq_zero_of_pow_eq_zero, by rintro rfl; exact zero_pow hn⟩
+@[simp] theorem pow_eq_zero_iff (hn : n ≠ 0) : a ^ n = 0 ↔ a = 0 :=
+  ⟨eq_zero_of_pow_eq_zero, (·.symm ▸ zero_pow hn)⟩
 
 lemma pow_ne_zero_iff (hn : n ≠ 0) : a ^ n ≠ 0 ↔ a ≠ 0 := (pow_eq_zero_iff hn).not
 
@@ -187,8 +254,15 @@ instance NeZero.pow [NeZero a] : NeZero (a ^ n) := ⟨pow_ne_zero n NeZero.out�
 
 lemma sq_eq_zero_iff : a ^ 2 = 0 ↔ a = 0 := pow_eq_zero_iff two_ne_zero
 
+/-- A variant of `pow_eq_zero_iff` assuming `M₀` is not trivial. -/
 @[simp] lemma pow_eq_zero_iff' [Nontrivial M₀] : a ^ n = 0 ↔ a = 0 ∧ n ≠ 0 := by
   obtain rfl | hn := eq_or_ne n 0 <;> simp [*]
+
+@[deprecated (since := "2026-01-08")] alias IsReduced.pow_eq_zero := eq_zero_of_pow_eq_zero
+@[deprecated (since := "2026-01-08")] alias IsReduced.pow_eq_zero_iff := pow_eq_zero_iff
+@[deprecated (since := "2026-01-08")] alias IsReduced.pow_ne_zero_iff := pow_ne_zero_iff
+@[deprecated (since := "2026-01-08")] alias IsReduced.pow_ne_zero := pow_ne_zero
+@[deprecated (since := "2026-01-08")] alias IsReduced.pow_eq_zero_iff' := pow_eq_zero_iff'
 
 theorem exists_right_inv_of_exists_left_inv {α} [MonoidWithZero α]
     (h : ∀ a : α, a ≠ 0 → ∃ b : α, b * a = 1) {a : α} (ha : a ≠ 0) : ∃ b : α, a * b = 1 := by

--- a/Mathlib/Algebra/GroupWithZero/Torsion.lean
+++ b/Mathlib/Algebra/GroupWithZero/Torsion.lean
@@ -27,6 +27,7 @@ theorem IsMulTorsionFree.mk' (ih : ∀ x ≠ 0, ∀ y ≠ 0, ∀ n ≠ 0, (x ^ n
   refine ⟨fun n hn x y hxy ↦ ?_⟩
   by_cases h : x ≠ 0 ∧ y ≠ 0
   · exact ih x h.1 y h.2 n hn hxy
+  have : IsReduced M := inferInstance
   grind [eq_zero_of_pow_eq_zero, zero_pow]
 
 variable [UniqueFactorizationMonoid M] [NormalizationMonoid M] [IsMulTorsionFree Mˣ]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -402,7 +402,7 @@ lemma j_eq_zero (h : W.c₄ = 0) : W.j = 0 := by
   rw [j_eq_zero_iff', h, zero_pow three_ne_zero]
 
 lemma j_eq_zero_iff [IsReduced R] : W.j = 0 ↔ W.c₄ = 0 := by
-  rw [j_eq_zero_iff', IsReduced.pow_eq_zero_iff three_ne_zero]
+  rw [j_eq_zero_iff', pow_eq_zero_iff three_ne_zero]
 
 section CharTwo
 
@@ -419,7 +419,7 @@ lemma j_eq_zero_of_char_two (h : W.a₁ = 0) : W.j = 0 := by
   rw [j_eq_zero_iff_of_char_two', h, zero_pow (Nat.succ_ne_zero _)]
 
 lemma j_eq_zero_iff_of_char_two [IsReduced R] : W.j = 0 ↔ W.a₁ = 0 := by
-  rw [j_eq_zero_iff_of_char_two', IsReduced.pow_eq_zero_iff (Nat.succ_ne_zero _)]
+  rw [j_eq_zero_iff_of_char_two', pow_eq_zero_iff (Nat.succ_ne_zero _)]
 
 end CharTwo
 
@@ -438,7 +438,7 @@ lemma j_eq_zero_of_char_three (h : W.b₂ = 0) : W.j = 0 := by
   rw [j_eq_zero_iff_of_char_three', h, zero_pow (Nat.succ_ne_zero _)]
 
 lemma j_eq_zero_iff_of_char_three [IsReduced R] : W.j = 0 ↔ W.b₂ = 0 := by
-  rw [j_eq_zero_iff_of_char_three', IsReduced.pow_eq_zero_iff (Nat.succ_ne_zero _)]
+  rw [j_eq_zero_iff_of_char_three', pow_eq_zero_iff (Nat.succ_ne_zero _)]
 
 end CharThree
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/FinTwo.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/FinTwo.lean
@@ -54,7 +54,7 @@ lemma isParabolic_iff_of_upperTriangular [IsReduced R] (hm : m 1 0 = 0) :
   rw [IsParabolic]
   have aux : m.discr = 0 ↔ m 0 0 = m 1 1 := by
     suffices m.discr = (m 0 0 - m 1 1) ^ 2 by
-      rw [this, IsReduced.pow_eq_zero_iff two_ne_zero, sub_eq_zero]
+      rw [this, pow_eq_zero_iff two_ne_zero, sub_eq_zero]
     grind [discr_fin_two, trace_fin_two, det_fin_two]
   have (h : m 0 0 = m 1 1) : m ∈ Set.range (scalar _) ↔ m 0 1 = 0 := by
     constructor

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -568,7 +568,7 @@ theorem degree_pow [IsReduced R] (f : MvPolynomial σ R) (n : ℕ) :
     · rw [hn, pow_zero, degree_one]
     · rw [zero_pow hn, degree_zero]
   apply degree_pow_of_pow_leadingCoeff_ne_zero
-  apply IsReduced.pow_ne_zero
+  apply pow_ne_zero
   rw [leadingCoeff_ne_zero_iff]
   exact hf
 

--- a/Mathlib/RingTheory/Nilpotent/Defs.lean
+++ b/Mathlib/RingTheory/Nilpotent/Defs.lean
@@ -13,13 +13,12 @@ public import Mathlib.Data.Nat.Lattice
 /-!
 # Definition of nilpotent elements
 
-This file defines the notion of a nilpotent element and proves the immediate consequences.
+This file proves basic facts about nilpotent elements.
 For results that require further theory, see `Mathlib/RingTheory/Nilpotent/Basic.lean`
 and `Mathlib/RingTheory/Nilpotent/Lemmas.lean`.
 
 ## Main definitions
 
-  * `IsNilpotent`
   * `Commute.isNilpotent_mul_left`
   * `Commute.isNilpotent_mul_right`
   * `nilpotencyClass`

--- a/Mathlib/RingTheory/Nilpotent/Defs.lean
+++ b/Mathlib/RingTheory/Nilpotent/Defs.lean
@@ -28,54 +28,9 @@ and `Mathlib/RingTheory/Nilpotent/Lemmas.lean`.
 
 @[expose] public section
 
-universe u v
-
-open Function Set
+open Set
 
 variable {R S : Type*} {x y : R}
-
-/-- An element is said to be nilpotent if some natural-number-power of it equals zero.
-
-Note that we require only the bare minimum assumptions for the definition to make sense. Even
-`MonoidWithZero` is too strong since nilpotency is important in the study of rings that are only
-power-associative. -/
-def IsNilpotent [Zero R] [Pow R ℕ] (x : R) : Prop :=
-  ∃ n : ℕ, x ^ n = 0
-
-theorem IsNilpotent.mk [Zero R] [Pow R ℕ] (x : R) (n : ℕ) (e : x ^ n = 0) : IsNilpotent x :=
-  ⟨n, e⟩
-
-@[simp] lemma isNilpotent_of_subsingleton [Zero R] [Pow R ℕ] [Subsingleton R] : IsNilpotent x :=
-  ⟨0, Subsingleton.elim _ _⟩
-
-@[simp] theorem IsNilpotent.zero [MonoidWithZero R] : IsNilpotent (0 : R) :=
-  ⟨1, pow_one 0⟩
-
-theorem not_isNilpotent_one [MonoidWithZero R] [Nontrivial R] :
-    ¬ IsNilpotent (1 : R) := fun ⟨_, H⟩ ↦ zero_ne_one (H.symm.trans (one_pow _))
-
-lemma IsNilpotent.pow_succ (n : ℕ) {S : Type*} [MonoidWithZero S] {x : S}
-    (hx : IsNilpotent x) : IsNilpotent (x ^ n.succ) := by
-  obtain ⟨N, hN⟩ := hx
-  use N
-  rw [← pow_mul, Nat.succ_mul, pow_add, hN, mul_zero]
-
-theorem IsNilpotent.of_pow [MonoidWithZero R] {x : R} {m : ℕ}
-    (h : IsNilpotent (x ^ m)) : IsNilpotent x := by
-  obtain ⟨n, h⟩ := h
-  use m * n
-  rw [← h, pow_mul x m n]
-
-lemma IsNilpotent.pow_of_pos {n} {S : Type*} [MonoidWithZero S] {x : S}
-    (hx : IsNilpotent x) (hn : n ≠ 0) : IsNilpotent (x ^ n) := by
-  cases n with
-  | zero => contradiction
-  | succ => exact IsNilpotent.pow_succ _ hx
-
-@[simp]
-lemma IsNilpotent.pow_iff_pos {n} {S : Type*} [MonoidWithZero S] {x : S} (hn : n ≠ 0) :
-    IsNilpotent (x ^ n) ↔ IsNilpotent x :=
-  ⟨of_pow, (pow_of_pos · hn)⟩
 
 theorem IsNilpotent.map [MonoidWithZero R] [MonoidWithZero S] {r : R} {F : Type*}
     [FunLike F R S] [MonoidWithZeroHomClass F R S] (hr : IsNilpotent r) (f : F) :
@@ -166,50 +121,6 @@ end MonoidWithZero
 
 end NilpotencyClass
 
-/-- A structure that has zero and pow is reduced if it has no nonzero nilpotent elements. -/
-@[mk_iff]
-class IsReduced (R : Type*) [Zero R] [Pow R ℕ] : Prop where
-  /-- A reduced structure has no nonzero nilpotent elements. -/
-  eq_zero : ∀ x : R, IsNilpotent x → x = 0
-
-namespace IsReduced
-
-theorem pow_eq_zero [Zero R] [Pow R ℕ] [IsReduced R] {n : ℕ} (h : x ^ n = 0) :
-    x = 0 := IsReduced.eq_zero x ⟨n, h⟩
-
-@[simp]
-theorem pow_eq_zero_iff [MonoidWithZero R] [IsReduced R] {n : ℕ} (hn : n ≠ 0) :
-    x ^ n = 0 ↔ x = 0 := ⟨pow_eq_zero, fun h ↦ h.symm ▸ zero_pow hn⟩
-
-theorem pow_ne_zero_iff [MonoidWithZero R] [IsReduced R] {n : ℕ} (hn : n ≠ 0) :
-    x ^ n ≠ 0 ↔ x ≠ 0 := not_congr (pow_eq_zero_iff hn)
-
-theorem pow_ne_zero [Zero R] [Pow R ℕ] [IsReduced R] (n : ℕ) (h : x ≠ 0) :
-    x ^ n ≠ 0 := fun H ↦ h (pow_eq_zero H)
-
-/-- A variant of `IsReduced.pow_eq_zero_iff` assuming `R` is not trivial. -/
-@[simp]
-theorem pow_eq_zero_iff' [MonoidWithZero R] [IsReduced R] [Nontrivial R] {n : ℕ} :
-    x ^ n = 0 ↔ x = 0 ∧ n ≠ 0 := by
-  cases n <;> simp
-
-end IsReduced
-
-instance (priority := 900) isReduced_of_noZeroDivisors [MonoidWithZero R] [NoZeroDivisors R] :
-    IsReduced R :=
-  ⟨fun _ ⟨_, hn⟩ => eq_zero_of_pow_eq_zero hn⟩
-
-instance (priority := 900) isReduced_of_subsingleton [Zero R] [Pow R ℕ] [Subsingleton R] :
-    IsReduced R :=
-  ⟨fun _ _ => Subsingleton.elim _ _⟩
-
-theorem IsNilpotent.eq_zero [Zero R] [Pow R ℕ] [IsReduced R] (h : IsNilpotent x) : x = 0 :=
-  IsReduced.eq_zero x h
-
-@[simp]
-theorem isNilpotent_iff_eq_zero [MonoidWithZero R] [IsReduced R] : IsNilpotent x ↔ x = 0 :=
-  ⟨fun h => h.eq_zero, fun h => h.symm ▸ IsNilpotent.zero⟩
-
 theorem isReduced_of_injective [MonoidWithZero R] [MonoidWithZero S] {F : Type*}
     [FunLike F R S] [MonoidWithZeroHomClass F R S]
     (f : F) (hf : Function.Injective f) [IsReduced S] :
@@ -219,10 +130,6 @@ theorem isReduced_of_injective [MonoidWithZero R] [MonoidWithZero S] {F : Type*}
   apply hf
   rw [map_zero]
   exact (hx.map f).eq_zero
-
-lemma exists_isNilpotent_of_not_isReduced {R : Type*} [Zero R] [Pow R ℕ] (h : ¬IsReduced R) :
-    ∃ x : R, x ≠ 0 ∧ IsNilpotent x := by
-  rw [isReduced_iff, not_forall] at h; tauto
 
 instance (ι) (R : ι → Type*) [∀ i, Zero (R i)] [∀ i, Pow (R i) ℕ]
     [∀ i, IsReduced (R i)] : IsReduced (∀ i, R i) where


### PR DESCRIPTION
Replace the less general versions (assuming `NoZeroDivisors`) under the root namespace by more general versions assuming `IsReduced`, and deprecate the versions under `IsReduced` namespace.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
