### PR TITLE
[Merged by Bors] - refactor(Topology/Irreducible): weaken assumptions of `preimage_mem_irreducibleComponents_of_isPreirreducible_fiber`

### DIFF
--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -418,7 +418,8 @@ def irreducibleComponentsEquivOfIsPreirreducibleFiber :
   invFun W := ⟨f '' W.1,
     image_mem_irreducibleComponents_of_isPreirreducible_fiber f hf₁ hf₂ hf₃ hf₄ W.2⟩
   toFun W := ⟨f ⁻¹' W.1,
-    preimage_mem_irreducibleComponents_of_isPreirreducible_fiber f hf₁ hf₂ hf₃ hf₄ W.2⟩
+    preimage_mem_irreducibleComponents_of_isPreirreducible_fiber W.2 hf₁ hf₂ hf₃
+      (by simp [hf₄.range_eq, W.2.1.1])⟩
   right_inv W := Subtype.ext <| by
     refine (Set.subset_preimage_image _ _).antisymm' (W.2.2 ?_ (Set.subset_preimage_image _ _))
     refine ⟨?_, (W.2.1.image _ hf₁.continuousOn).2.preimage_of_isPreirreducible_fiber _ hf₂ hf₃⟩

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -347,6 +347,11 @@ theorem IsPreirreducible.preimage (ht : IsPreirreducible t) {f : Y → X}
   cases hf.injective h₄
   exact ⟨y, h₁, h₂, h₃⟩
 
+theorem IsIrreducible.preimage (ht : IsIrreducible t) {f : Y → X}
+    (hf : IsOpenEmbedding f) (h : (t ∩ Set.range f).Nonempty) : IsIrreducible (f ⁻¹' t) := by
+  obtain ⟨-, hx, x, rfl⟩ := h
+  exact ⟨⟨x, hx⟩, ht.2.preimage hf⟩
+
 section
 
 open Set.Notation
@@ -371,6 +376,19 @@ lemma IsPreirreducible.preimage_of_isPreirreducible_fiber
   refine hV.preimage_of_dense_isPreirreducible_fiber f hf' ?_
   simp [hf'', subset_closure]
 
+theorem preimage_mem_irreducibleComponents {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    {C : Set Y} (hC : C ∈ irreducibleComponents Y)
+    {f : X → Y} (hf : Topology.IsOpenEmbedding f)
+    (h : (C ∩ Set.range f).Nonempty) :
+    f ⁻¹' C ∈ irreducibleComponents X := by
+  refine ⟨hC.1.preimage hf h, fun S hS hfS ↦ ?_⟩
+  replace hC := @hC.2 (closure (f '' S)) ?_ ?_
+  · exact Set.image_subset_iff.mp (subset_closure.trans hC)
+  · exact IsIrreducible.closure (hS.image f hf.continuous.continuousOn)
+  · suffices C ≤ closure (f '' (f ⁻¹' C)) from this.trans (closure_mono (Set.image_mono hfS))
+    rw [Set.image_preimage_eq_inter_range]
+    exact subset_closure_inter_of_isPreirreducible_of_isOpen hC.1.2 hf.isOpen_range h
+
 variable (f : X → Y) (hf₁ : Continuous f) (hf₂ : IsOpenMap f)
 variable (hf₃ : ∀ x, IsPreirreducible (f ⁻¹' {x})) (hf₄ : Function.Surjective f)
 
@@ -391,6 +409,27 @@ lemma preimage_mem_irreducibleComponents_of_isPreirreducible_fiber
       ((Set.image_preimage_eq V hf₄).symm.trans_le (Set.image_mono hWZ))
   rw [hWZ']
   exact ⟨hZ', fun s hs hs' ↦ (H s hs.2 hs').le⟩
+
+omit hf₄ in
+lemma preimage_mem_irreducibleComponents_of_isPreirreducible_fiber'
+    {V : Set Y} (hV : V ∈ irreducibleComponents Y) (h : (V ∩ Set.range f).Nonempty) :
+    f ⁻¹' V ∈ irreducibleComponents X := by
+  have key := hV.1.2.preimage_of_isPreirreducible_fiber f hf₂ hf₃
+  refine ⟨⟨by obtain ⟨-, hx, x, rfl⟩ := h; exact ⟨x, hx⟩, key⟩, fun U hU hVU ↦ ?_⟩
+  refine Set.image_subset_iff.mp ?_
+  replace hV := preimage_mem_irreducibleComponents hV  hf₂.isOpen_range.isOpenEmbedding_subtypeVal
+    (by rwa [Subtype.range_coe_subtype])
+  let g := Set.codRestrict f (Set.range f) mem_range_self
+  have hg₁ : Continuous g := Continuous.codRestrict hf₁ mem_range_self
+  suffices g '' U ⊆ Subtype.val ⁻¹' V by simpa using this
+  refine hV.2 (IsIrreducible.image hU g hg₁.continuousOn) ?_
+  simp only [le_eq_subset]
+  simp only [le_eq_subset] at hVU
+  rw [← Set.image_subset_image_iff Subtype.val_injective]
+  simp only [Subtype.image_preimage_coe]
+  replace hVU := Set.image_mono (f := f) hVU
+  rw [Set.image_preimage_eq_inter_range, inter_comm] at hVU
+  grind
 
 lemma image_mem_irreducibleComponents_of_isPreirreducible_fiber
     {V : Set X} (hV : V ∈ irreducibleComponents X) :

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -338,20 +338,6 @@ theorem IsPreirreducible.open_subset {U : Set X} (ht : IsPreirreducible t) (hU :
 theorem IsPreirreducible.interior (ht : IsPreirreducible t) : IsPreirreducible (interior t) :=
   ht.open_subset isOpen_interior interior_subset
 
-theorem IsPreirreducible.preimage (ht : IsPreirreducible t) {f : Y → X}
-    (hf : IsOpenEmbedding f) : IsPreirreducible (f ⁻¹' t) := by
-  rintro U V hU hV ⟨x, hx, hx'⟩ ⟨y, hy, hy'⟩
-  obtain ⟨_, h₁, ⟨y, h₂, rfl⟩, ⟨y', h₃, h₄⟩⟩ :=
-    ht _ _ (hf.isOpenMap _ hU) (hf.isOpenMap _ hV) ⟨f x, hx, Set.mem_image_of_mem f hx'⟩
-      ⟨f y, hy, Set.mem_image_of_mem f hy'⟩
-  cases hf.injective h₄
-  exact ⟨y, h₁, h₂, h₃⟩
-
-theorem IsIrreducible.preimage (ht : IsIrreducible t) {f : Y → X}
-    (hf : IsOpenEmbedding f) (h : (t ∩ Set.range f).Nonempty) : IsIrreducible (f ⁻¹' t) := by
-  obtain ⟨-, hx, x, rfl⟩ := h
-  exact ⟨⟨x, hx⟩, ht.2.preimage hf⟩
-
 section
 
 open Set.Notation
@@ -375,6 +361,24 @@ lemma IsPreirreducible.preimage_of_isPreirreducible_fiber
     IsPreirreducible (f ⁻¹' V) := by
   refine hV.preimage_of_dense_isPreirreducible_fiber f hf' ?_
   simp [hf'', subset_closure]
+
+lemma IsPreirreducible.preimage (ht : IsPreirreducible t) {f : Y → X} (hf : IsOpenEmbedding f) :
+    IsPreirreducible (f ⁻¹' t) :=
+  IsPreirreducible.preimage_of_isPreirreducible_fiber ht f hf.isOpenMap
+    fun _ ↦ (subsingleton_singleton.preimage hf.injective).isPreirreducible
+
+lemma IsIrreducible.preimage_of_isIrreducible_fiber (ht : IsIrreducible t)
+    (f : Y → X) (hf : IsOpenMap f) (hf' : ∀ x, IsPreirreducible (f ⁻¹' {x}))
+    (h : (t ∩ Set.range f).Nonempty) :
+    IsIrreducible (f ⁻¹' t) := by
+  refine ⟨?_, IsPreirreducible.preimage_of_isPreirreducible_fiber ht.2 f hf hf'⟩
+  obtain ⟨-, hx, x, rfl⟩ := h
+  exact ⟨x, hx⟩
+
+lemma IsIrreducible.preimage (ht : IsIrreducible t) {f : Y → X}
+    (hf : IsOpenEmbedding f) (h : (t ∩ Set.range f).Nonempty) : IsIrreducible (f ⁻¹' t) := by
+  refine IsIrreducible.preimage_of_isIrreducible_fiber ht f hf.isOpenMap
+    (fun _ ↦ (subsingleton_singleton.preimage hf.injective).isPreirreducible) h
 
 theorem preimage_mem_irreducibleComponents {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
     {C : Set Y} (hC : C ∈ irreducibleComponents Y)

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -368,10 +368,10 @@ lemma IsPreirreducible.preimage (ht : IsPreirreducible t) {f : Y → X} (hf : Is
     fun _ ↦ (subsingleton_singleton.preimage hf.injective).isPreirreducible
 
 lemma IsIrreducible.preimage_of_isPreirreducible_fiber (ht : IsIrreducible t)
-    (f : Y → X) (hf : IsOpenMap f) (hf' : ∀ x, IsPreirreducible (f ⁻¹' {x}))
+    (f : Y → X) (hf₂ : IsOpenMap f) (hf₃ : ∀ x, IsPreirreducible (f ⁻¹' {x}))
     (h : (t ∩ Set.range f).Nonempty) :
     IsIrreducible (f ⁻¹' t) := by
-  refine ⟨?_, IsPreirreducible.preimage_of_isPreirreducible_fiber ht.2 f hf hf'⟩
+  refine ⟨?_, IsPreirreducible.preimage_of_isPreirreducible_fiber ht.2 f hf₂ hf₃⟩
   obtain ⟨-, hx, x, rfl⟩ := h
   exact ⟨x, hx⟩
 
@@ -381,14 +381,14 @@ lemma IsIrreducible.preimage (ht : IsIrreducible t) {f : Y → X}
     (fun _ ↦ (subsingleton_singleton.preimage hf.injective).isPreirreducible) h
 
 lemma preimage_mem_irreducibleComponents_of_isPreirreducible_fiber
-    (ht : t ∈ irreducibleComponents X) {f : Y → X} (hf₀ : Continuous f) (hf : IsOpenMap f)
-    (hf' : ∀ x, IsPreirreducible (f ⁻¹'{x})) (h : (t ∩ Set.range f).Nonempty) :
+    (ht : t ∈ irreducibleComponents X) {f : Y → X} (hf₁ : Continuous f) (hf₂ : IsOpenMap f)
+    (hf₃ : ∀ x, IsPreirreducible (f ⁻¹'{x})) (h : (t ∩ range f).Nonempty) :
     f ⁻¹' t ∈ irreducibleComponents Y := by
-  refine ⟨ht.1.preimage_of_isPreirreducible_fiber f hf hf' h, fun u hu htu ↦ Set.image_subset_iff.mp
-    (subset_closure.trans (ht.2 (hu.image f hf₀.continuousOn).closure ?_))⟩
-  suffices t ≤ closure (f '' (f ⁻¹' t)) from this.trans (closure_mono (Set.image_mono htu))
-  rw [Set.image_preimage_eq_inter_range]
-  exact subset_closure_inter_of_isPreirreducible_of_isOpen ht.1.2 hf.isOpen_range h
+  refine ⟨ht.1.preimage_of_isPreirreducible_fiber f hf₂ hf₃ h, fun u hu htu ↦ image_subset_iff.mp
+    (subset_closure.trans (ht.2 (hu.image f hf₁.continuousOn).closure ?_))⟩
+  suffices t ≤ closure (f '' (f ⁻¹' t)) from this.trans (closure_mono (image_mono htu))
+  rw [image_preimage_eq_inter_range]
+  exact subset_closure_inter_of_isPreirreducible_of_isOpen ht.1.2 hf₂.isOpen_range h
 
 lemma preimage_mem_irreducibleComponents (ht : t ∈ irreducibleComponents X) {f : Y → X}
     (hf : IsOpenEmbedding f) (h : (t ∩ Set.range f).Nonempty) :


### PR DESCRIPTION
This PR weakens the surjectivity assumption of `preimage_mem_irreducibleComponents_of_isPreirreducible_fiber` to `(t ∩ Set.range f).Nonempty`. I also took the liberty of systematizing the file slightly, so that now there are 6 lemmas: preimage of (preirreducible / irreducible / irreducible component) assuming (preirreducible fibers / open embedding).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
