### PR TITLE
[Merged by Bors] - chore(Algebra): move `LinearMap.ker_restrictScalars`

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -462,23 +462,6 @@ alias NoZeroSMulDivisors.iff_algebraMap_injective := isTorsionFree_iff_algebraMa
 @[deprecated (since := "2026-01-21")]
 alias NoZeroSMulDivisors.iff_faithfulSMul := isTorsionFree_iff_faithfulSMul
 
-/-! TODO: The following lemmas no longer involve `Algebra` at all, and could be moved closer
-to `Algebra/Module/Submodule.lean`. Currently this is tricky because `ker`, `range`, `⊤`, and `⊥`
-are all defined in `LinearAlgebra/Basic.lean`. -/
-
-section Module
-
-variable (R : Type*) {S M N : Type*} [Semiring R] [Semiring S] [SMul R S]
-variable [AddCommMonoid M] [Module R M] [Module S M] [IsScalarTower R S M]
-variable [AddCommMonoid N] [Module R N] [Module S N] [IsScalarTower R S N]
-
-@[simp]
-theorem LinearMap.ker_restrictScalars (f : M →ₗ[S] N) :
-    LinearMap.ker (f.restrictScalars R) = (LinearMap.ker f).restrictScalars R :=
-  rfl
-
-end Module
-
 example {R A} [CommSemiring R] [Semiring A] [Module R A] [SMulCommClass R A A]
     [IsScalarTower R A A] : Algebra R A :=
   Algebra.ofModule smul_mul_assoc mul_smul_comm

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -8,6 +8,7 @@ module
 
 public import Mathlib.Algebra.Group.Subgroup.Ker
 public import Mathlib.Algebra.Module.Submodule.Map
+public import Mathlib.Algebra.Module.Submodule.RestrictScalars
 
 /-!
 # Kernel of a linear map
@@ -272,6 +273,19 @@ theorem ker_comp_of_ker_eq_bot (f : M →ₛₗ[τ₁₂] M₂) {g : M₂ →ₛ
     ker (g.comp f : M →ₛₗ[τ₁₃] M₃) = ker f := by rw [ker_comp, hg, Submodule.comap_bot]
 
 end Semiring
+
+section RestrictScalars
+
+variable (R : Type*) {S M N : Type*} [Semiring R] [Semiring S] [SMul R S]
+variable [AddCommMonoid M] [Module R M] [Module S M] [IsScalarTower R S M]
+variable [AddCommMonoid N] [Module R N] [Module S N] [IsScalarTower R S N]
+
+@[simp]
+theorem ker_restrictScalars (f : M →ₗ[S] N) :
+    ker (f.restrictScalars R) = (ker f).restrictScalars R :=
+  rfl
+
+end RestrictScalars
 
 end LinearMap
 


### PR DESCRIPTION
Resolve an old TODO by moving `LinearMap.ker_restrictScalars` to a location in `Mathlib/Algebra/Module/Submodule`.

The TODO referenced lemmas in plural, but only `LinearMap.ker_restrictScalars` seemed to fit. I assume any other lemmas might already have been moved at an earlier point.

---

Note for reviewers:
- The new location in `Mathlib/Algebra/Module/Submodule/Ker.lean` was chosen somewhat arbitrarily in favor of `Mathlib/Algebra/Module/Submodule/RestrictScalars.lean`. Please consider whether `Ker.lean` is the optimal location for this lemma.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
