### PR TITLE
feat: Generalization of FixedPointApproximants to CompletePartialOrder

### DIFF
--- a/Mathlib/Order/CompletePartialOrder.lean
+++ b/Mathlib/Order/CompletePartialOrder.lean
@@ -65,13 +65,9 @@ hf.directedOn_range.le_sSup <| Set.mem_range_self _
 protected lemma Directed.iSup_le (hf : Directed (· ≤ ·) f) (ha : ∀ i, f i ≤ a) : ⨆ i, f i ≤ a :=
 hf.directedOn_range.sSup_le <| Set.forall_mem_range.2 ha
 
-protected lemma DirectedOn.sSup_le_sSup (hd : DirectedOn (· ≤ ·) d) (hd' : DirectedOn (· ≤ ·) d') :
-    d ⊆ d' → sSup d ≤ sSup d' := by
-  intro h
-  apply hd.sSup_le
-  intro a h_a
-  apply hd'.le_sSup
-  exact Set.mem_of_subset_of_mem h h_a
+protected lemma DirectedOn.sSup_le_sSup (hd : DirectedOn (· ≤ ·) d) (hd' : DirectedOn (· ≤ ·) d')
+    (h : d ⊆ d') : sSup d ≤ sSup d' :=
+  hd.sSup_le fun _ ha ↦ hd'.le_sSup <| Set.mem_of_subset_of_mem h ha
 
 
 --TODO: We could mimic more `sSup`/`iSup` lemmas

--- a/Mathlib/Order/CompletePartialOrder.lean
+++ b/Mathlib/Order/CompletePartialOrder.lean
@@ -45,13 +45,16 @@ class CompletePartialOrder (α : Type*) extends PartialOrder α, SupSet α where
   /-- For each directed set `d`, `sSup d` is the least upper bound of `d`. -/
   lubOfDirected : ∀ d, DirectedOn (· ≤ ·) d → IsLUB d (sSup d)
 
-variable [CompletePartialOrder α] [Preorder β] {f : ι → α} {d : Set α} {a : α}
+variable [CompletePartialOrder α] [Preorder β] {f : ι → α} {d d' : Set α} {a b : α}
 
 protected lemma DirectedOn.isLUB_sSup : DirectedOn (· ≤ ·) d → IsLUB d (sSup d) :=
 CompletePartialOrder.lubOfDirected _
 
 protected lemma DirectedOn.le_sSup (hd : DirectedOn (· ≤ ·) d) (ha : a ∈ d) : a ≤ sSup d :=
 hd.isLUB_sSup.1 ha
+
+protected lemma DirectedOn.le_sSup_of_le (hd : DirectedOn (· ≤ ·) d) (hb : b ∈ d) (ha : a ≤ b) :
+    a ≤ sSup d := le_trans ha (hd.le_sSup hb)
 
 protected lemma DirectedOn.sSup_le (hd : DirectedOn (· ≤ ·) d) (ha : ∀ b ∈ d, b ≤ a) : sSup d ≤ a :=
 hd.isLUB_sSup.2 ha
@@ -61,6 +64,15 @@ hf.directedOn_range.le_sSup <| Set.mem_range_self _
 
 protected lemma Directed.iSup_le (hf : Directed (· ≤ ·) f) (ha : ∀ i, f i ≤ a) : ⨆ i, f i ≤ a :=
 hf.directedOn_range.sSup_le <| Set.forall_mem_range.2 ha
+
+protected lemma DirectedOn.sSup_le_sSup (hd : DirectedOn (· ≤ ·) d) (hd' : DirectedOn (· ≤ ·) d') :
+    d ⊆ d' → sSup d ≤ sSup d' := by
+  intro h
+  apply hd.sSup_le
+  intro a h_a
+  apply hd'.le_sSup
+  exact Set.mem_of_subset_of_mem h h_a
+
 
 --TODO: We could mimic more `sSup`/`iSup` lemmas
 

--- a/Mathlib/Order/CompletePartialOrder.lean
+++ b/Mathlib/Order/CompletePartialOrder.lean
@@ -69,7 +69,6 @@ protected lemma DirectedOn.sSup_le_sSup (hd : DirectedOn (· ≤ ·) d) (hd' : D
     (h : d ⊆ d') : sSup d ≤ sSup d' :=
   hd.sSup_le fun _ ha ↦ hd'.le_sSup <| Set.mem_of_subset_of_mem h ha
 
-
 --TODO: We could mimic more `sSup`/`iSup` lemmas
 
 /-- Scott-continuity takes on a simpler form in complete partial orders. -/

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -97,54 +97,38 @@ theorem directedOn_lfpApprox (a : Ordinal.{u}) (h : x ≤ f x) :
   induction a using Ordinal.induction with
   | h i ih =>
     rintro z (⟨b, h_b, h_z⟩ | h_z) y (⟨c, h_c, h_y⟩ | h_y)
-    · cases le_total b c
-      case inl h_bc =>
-        use y
-        apply And.intro (by left; use c)
-        apply And.intro ?_ (by rfl)
-        rw [← h_z, ← h_y]
+    · wlog h_bc : b ≤ c
+      · have h_cb : c ≤ b := le_of_lt <| not_le.mp h_bc
+        conv => right; intro _; right; rw [And.comm]
+        exact this _ _ h _ ih _ _ h_c h_y _ _ h_b h_z h_cb
+      · use y
+        simp only [exists_prop, Set.union_singleton, Set.mem_insert_iff, Set.mem_setOf_eq, le_refl,
+          and_true, ← h_z, ← h_y]
+        apply And.intro (by right; use c)
         apply f.mono
         unfold lfpApprox
         apply DirectedOn.sSup_le_sSup (ih b h_b) (ih c h_c)
         grind only [= Set.subset_def, = Set.setOf_true, = Set.mem_union, usr Set.mem_setOf_eq]
-      case inr h_cb =>
-        use z
-        apply And.intro (by left; use b)
-        apply And.intro (by rfl)
-        simp only
-        rw [← h_z, ← h_y]
-        apply f.mono
-        unfold lfpApprox
-        apply DirectedOn.sSup_le_sSup (ih c h_c) (ih b h_b)
-        grind only [= Set.subset_def, = Set.setOf_true, = Set.mem_union, usr Set.mem_setOf_eq]
     · use z
-      apply And.intro (by left; use b)
-      apply And.intro (by rfl)
-      simp only
-      rw [← h_z, h_y]
-      apply le_trans h
-      apply f.mono
+      simp only [exists_prop, Set.union_singleton, Set.mem_insert_iff, Set.mem_setOf_eq, le_refl,
+        true_and, ← h_z]
+      rw [h_y]
+      apply And.intro (by right; use b)
+      apply le_trans h (f.mono _)
       unfold lfpApprox
-      apply (ih b h_b).le_sSup
-      right
-      rfl
+      exact (ih b h_b).le_sSup (Or.inr rfl)
     · use y
-      apply And.intro (by left; use c)
-      apply And.intro ?_ (by rfl)
-      simp only
-      rw [← h_y, h_z]
-      apply le_trans h
-      apply f.mono
+      simp only [exists_prop, Set.union_singleton, ← h_y, Set.mem_insert_iff, Set.mem_setOf_eq,
+        le_refl, and_true]
+      rw [h_z]
+      apply And.intro (by right; use c)
+      apply le_trans h (f.mono _)
       unfold lfpApprox
-      apply (ih c h_c).le_sSup
-      right
-      rfl
+      exact (ih c h_c).le_sSup (Or.inr rfl)
     · use x
-      apply And.intro
-      · right
-        rfl
-      · rw [h_z, h_y]
-        trivial
+      rw [h_z, h_y]
+      simp only [exists_prop, Set.union_singleton, Set.mem_insert_iff, Set.mem_setOf_eq, true_or,
+        le_refl, and_self]
 
 theorem lfpApprox_monotone_of_le (h_f : x ≤ f x) : Monotone (lfpApprox f x) := by
   intro a b h

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -65,16 +65,16 @@ namespace OrdinalApprox
 
 universe u
 variable {α : Type u}
-variable [CompletePartialOrder α] (f : α →o α) (x : α)
+variable [CompletePartialOrder α] {f : α →o α} (x : α)
 
 set_option linter.unusedVariables false in
 /-- The ordinal-indexed sequence approximating the least fixed point greater than
 an initial value `x`. It is defined in such a way that we have `lfpApprox 0 x = x` and
 `lfpApprox a x = ⨆ b < a, f (lfpApprox b x)`. -/
 def lfpApprox (a : Ordinal.{u}) : α :=
-  sSup ({ f (lfpApprox b) | (b : Ordinal) (h : b < a) } ∪ {x})
+  sSup ({ f (lfpApprox b) | (b : Ordinal) (_ : b < a) } ∪ {x})
 termination_by a
-decreasing_by exact h
+decreasing_by assumption
 
 variable {β : Type u}
 variable [CompleteLattice β] (g : β →o β) (y : β)
@@ -84,16 +84,14 @@ set_option linter.unusedVariables false in
 an initial value `x`. It is defined in such a way that we have `gfpApprox 0 x = x` and
 `gfpApprox a x = ⨅ b < a, f (lfpApprox b x)`. -/
 def gfpApprox (a : Ordinal.{u}) : β :=
-  sInf ({ g (gfpApprox b) | (b : Ordinal) (h : b < a) } ∪ {y})
+  sInf ({ g (gfpApprox b) | (b : Ordinal) (_ : b < a) } ∪ {y})
 termination_by a
-decreasing_by exact h
+decreasing_by assumption
 
 open Function fixedPoints Cardinal Order OrderHom
 
-
-
 theorem directedOn_lfpApprox (a : Ordinal.{u}) (h : x ≤ f x) :
-    DirectedOn (· ≤ ·) ({ f (lfpApprox f x b) | (b : Ordinal) (h : b < a) } ∪ {x}) := by
+    DirectedOn (· ≤ ·) ({ f (lfpApprox f x b) | (b : Ordinal) (_ : b < a) } ∪ {x}) := by
   induction a using Ordinal.induction with
   | h i ih =>
     rintro z (⟨b, h_b, h_z⟩ | h_z) y (⟨c, h_c, h_y⟩ | h_y)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This PR provides a generalization of FixedPointApproximants to CompletePartialOrder. Not every theorem can be generalized, as sometimes we require additional conditions (namely `x  ≤ f x`) in order to guarantee that the set is directed and thus the supremum is well-defined. This is not necessary in a CompleteLattice.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
