### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/Trace): the trace map is surjective

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -267,8 +267,8 @@ end single
 theorem trace_surjective [AddCommMonoid R] [Nonempty n] :
     Function.Surjective (trace : Matrix n n R → R) := fun r ↦ by
   classical
-  let i := Classical.arbitrary n
-  exact ⟨single i i r, trace_single_eq_same i r⟩
+  inhabit n
+  exact ⟨single default default r, trace_single_eq_same default r⟩
 
 /-- Matrices `A` and `B` are equal iff `(x * A).trace = (x * B).trace` for all `x`. -/
 theorem ext_iff_trace_mul_left [NonAssocSemiring R] {A B : Matrix m n R} :

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -264,6 +264,19 @@ theorem trace_mul_single [NonUnitalNonAssocSemiring R] [Fintype m]
 
 end single
 
+section Surjective
+
+variable {n : Type*} {R : Type*} [Fintype n] [AddCommMonoid R]
+
+theorem trace_surjective [Nonempty n] :
+    Function.Surjective (trace : Matrix n n R → R) := fun r => by
+  classical
+  exact ⟨single (Classical.arbitrary n) (Classical.arbitrary n) r,
+    @trace_single_eq_same _ _ _ _ _ (Classical.arbitrary n) r⟩
+
+end Surjective
+
+
 /-- Matrices `A` and `B` are equal iff `(x * A).trace = (x * B).trace` for all `x`. -/
 theorem ext_iff_trace_mul_left [NonAssocSemiring R] {A B : Matrix m n R} :
     A = B ↔ ∀ x, (x * A).trace = (x * B).trace := by

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -264,18 +264,11 @@ theorem trace_mul_single [NonUnitalNonAssocSemiring R] [Fintype m]
 
 end single
 
-section Surjective
-
-variable {n : Type*} {R : Type*} [Fintype n] [AddCommMonoid R]
-
-theorem trace_surjective [Nonempty n] :
-    Function.Surjective (trace : Matrix n n R → R) := fun r => by
+theorem trace_surjective [AddCommMonoid R] [Nonempty n] :
+    Function.Surjective (trace : Matrix n n R → R) := fun r ↦ by
   classical
-  exact ⟨single (Classical.arbitrary n) (Classical.arbitrary n) r,
-    @trace_single_eq_same _ _ _ _ _ (Classical.arbitrary n) r⟩
-
-end Surjective
-
+  let i := Classical.arbitrary n
+  exact ⟨single i i r, trace_single_eq_same i r⟩
 
 /-- Matrices `A` and `B` are equal iff `(x * A).trace = (x * B).trace` for all `x`. -/
 theorem ext_iff_trace_mul_left [NonAssocSemiring R] {A B : Matrix m n R} :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
