### PR TITLE
[Merged by Bors] - feat(Analysis/Convex): diameter of a standard simplex

### DIFF
--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -231,12 +231,11 @@ variable {ι}
 
 /-- The (sup metric) diameter of a standard simplex is less than or equal to 1. -/
 theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
-    Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
-      (dist_pi_le_iff zero_le_one).2 fun i ↦ by
-  have hx := mem_Icc_of_mem_stdSimplex hx i
-  have hy := mem_Icc_of_mem_stdSimplex hy i
-  rw [Real.dist_eq, abs_sub_le_iff]
-  constructor <;> linarith [hx.1, hx.2, hy.1, hy.2]
+  Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
+    (dist_pi_le_iff zero_le_one).2 fun i ↦ by
+      have hx := mem_Icc_of_mem_stdSimplex hx i
+      have hy := mem_Icc_of_mem_stdSimplex hy i
+      grind [Real.dist_eq]
 
 /-- The diameter of the standard simplex over a subsingleton index type is 0. -/
 @[simp]

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -238,11 +238,13 @@ theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
   rw [Real.dist_eq, abs_sub_le_iff]
   constructor <;> linarith [hx.1, hx.2, hy.1, hy.2]
 
-/-- The diameter of the standard 0-simplex is 0. -/
+/-- The diameter of the standard simplex over a subsingleton index type is 0. -/
 @[simp]
-theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] [Nonempty ι] :
+theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] :
     Metric.diam (stdSimplex ℝ ι) = 0 := by
-  rw [stdSimplex_unique, Metric.diam_singleton]
+  cases isEmpty_or_nonempty ι with
+  | inl h => rw [stdSimplex_of_isEmpty_index, Metric.diam_empty]
+  | inr h => rw [stdSimplex_unique, Metric.diam_singleton]
 
 /-- The (sup metric) distance between distinct vertices (Pi.single) of a standard simplex is 1. -/
 theorem dist_single_single [DecidableEq ι] (i j : ι) (h : i ≠ j) :

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -246,7 +246,9 @@ theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] :
   | inl h => rw [stdSimplex_of_isEmpty_index, Metric.diam_empty]
   | inr h => rw [stdSimplex_unique, Metric.diam_singleton]
 
-/-- The (sup metric) distance between distinct vertices (Pi.single) of a standard simplex is 1. -/
+/-- The (product metric) distance between distinct vertices (Pi.single) of a standard simplex is 1.
+
+Note: This is a special case of a more general fact about product metrics. -/
 theorem dist_single_single [DecidableEq ι] (i j : ι) (h : i ≠ j) :
     dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) = 1 := by
   refine le_antisymm ((dist_pi_le_iff zero_le_one).2 fun k ↦ ?_) ?_

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -225,6 +225,44 @@ lemma stdSimplexHomeomorphUnitInterval_zero :
 lemma stdSimplexHomeomorphUnitInterval_one :
     stdSimplexHomeomorphUnitInterval ⟨_, single_mem_stdSimplex _ 1⟩ = 1 := rfl
 
+/-! ### Diameter of a Standard Simplex (sup metric) -/
+
+variable {ι}
+
+/-- The (sup metric) diameter of a standard simplex is less than or equal to 1. -/
+theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
+    Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
+      (dist_pi_le_iff zero_le_one).2 fun i ↦ by
+  have hx := mem_Icc_of_mem_stdSimplex hx i
+  have hy := mem_Icc_of_mem_stdSimplex hy i
+  rw [Real.dist_eq, abs_sub_le_iff]
+  constructor <;> linarith [hx.1, hx.2, hy.1, hy.2]
+
+/-- The diameter of the standard 0-simplex is 0. -/
+@[simp]
+theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] [Nonempty ι] :
+    Metric.diam (stdSimplex ℝ ι) = 0 := by
+  rw [stdSimplex_unique, Metric.diam_singleton]
+
+/-- The (sup metric) distance between distinct vertices (Pi.single) of a standard simplex is 1. -/
+theorem dist_single_single [DecidableEq ι] (i j : ι) (h : i ≠ j) :
+    dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) = 1 := by
+  refine le_antisymm ((dist_pi_le_iff zero_le_one).2 fun k ↦ ?_) ?_
+  · simp only [Pi.single_apply, Real.dist_eq]
+    split_ifs <;> simp
+  · simpa [Real.dist_eq, h] using dist_le_pi_dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) i
+
+/-- For `n > 0`, the (sup metric) diameter of a standard n-simplex is 1. -/
+@[simp]
+theorem diam_stdSimplex [Nontrivial ι] : Metric.diam (stdSimplex ℝ ι) = 1 := by
+  refine le_antisymm diam_stdSimplex_le ?_
+  obtain ⟨i, j, hij⟩ := exists_pair_ne ι
+  classical
+  rw [← dist_single_single i j hij]
+  exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _) (single_mem_stdSimplex _ _)
+    (single_mem_stdSimplex _ _)
+
+
 end Topology
 
 namespace stdSimplex

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -231,11 +231,11 @@ variable {ι}
 
 /-- The (sup metric) diameter of a standard simplex is less than or equal to 1. -/
 theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
-    Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
-      (dist_pi_le_iff zero_le_one).2 fun i ↦ by
-        have hx := mem_Icc_of_mem_stdSimplex hx i
-        have hy := mem_Icc_of_mem_stdSimplex hy i
-        grind [Real.dist_eq]
+  Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
+    (dist_pi_le_iff zero_le_one).2 fun i ↦ by
+      have hx := mem_Icc_of_mem_stdSimplex hx i
+      have hy := mem_Icc_of_mem_stdSimplex hy i
+      grind [Real.dist_eq]
 
 /-- The (sup metric) diameter of a standard simplex indexed by a subsingleton is 0. -/
 @[simp]
@@ -252,7 +252,7 @@ theorem diam_stdSimplex [Nontrivial ι] : Metric.diam (stdSimplex ℝ ι) = 1 :=
   obtain ⟨i, j, hij⟩ := exists_pair_ne ι
   classical
   rw [show (1 : ℝ) = dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) by
-        simp [dist_single_single i j (1 : ℝ) 1 hij, Real.dist_eq]]
+    simp [dist_single_single i j (1 : ℝ) 1 hij, Real.dist_eq]]
   exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _)
     (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
 

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -231,13 +231,13 @@ variable {ι}
 
 /-- The (sup metric) diameter of a standard simplex is less than or equal to 1. -/
 theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
-  Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
-    (dist_pi_le_iff zero_le_one).2 fun i ↦ by
-      have hx := mem_Icc_of_mem_stdSimplex hx i
-      have hy := mem_Icc_of_mem_stdSimplex hy i
-      grind [Real.dist_eq]
+    Metric.diam_le_of_forall_dist_le zero_le_one fun x hx y hy ↦
+      (dist_pi_le_iff zero_le_one).2 fun i ↦ by
+        have hx := mem_Icc_of_mem_stdSimplex hx i
+        have hy := mem_Icc_of_mem_stdSimplex hy i
+        grind [Real.dist_eq]
 
-/-- The diameter of the standard simplex over a subsingleton index type is 0. -/
+/-- The (sup metric) diameter of a standard simplex indexed by a subsingleton is 0. -/
 @[simp]
 theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] :
     Metric.diam (stdSimplex ℝ ι) = 0 := by
@@ -245,26 +245,16 @@ theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] :
   | inl h => rw [stdSimplex_of_isEmpty_index, Metric.diam_empty]
   | inr h => rw [stdSimplex_unique, Metric.diam_singleton]
 
-/-- The (product metric) distance between distinct vertices (Pi.single) of a standard simplex is 1.
-
-Note: This is a special case of a more general fact about product metrics. -/
-theorem dist_single_single [DecidableEq ι] (i j : ι) (h : i ≠ j) :
-    dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) = 1 := by
-  refine le_antisymm ((dist_pi_le_iff zero_le_one).2 fun k ↦ ?_) ?_
-  · simp only [Pi.single_apply, Real.dist_eq]
-    split_ifs <;> simp
-  · simpa [Real.dist_eq, h] using dist_le_pi_dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) i
-
-/-- For `n > 0`, the (sup metric) diameter of a standard n-simplex is 1. -/
+/-- The (sup metric) diameter of a standard simplex indexed by a nontrivial index is 1. -/
 @[simp]
 theorem diam_stdSimplex [Nontrivial ι] : Metric.diam (stdSimplex ℝ ι) = 1 := by
   refine le_antisymm diam_stdSimplex_le ?_
   obtain ⟨i, j, hij⟩ := exists_pair_ne ι
   classical
-  rw [← dist_single_single i j hij]
-  exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _) (single_mem_stdSimplex _ _)
-    (single_mem_stdSimplex _ _)
-
+  rw [show (1 : ℝ) = dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) by
+        simp [dist_single_single i j (1 : ℝ) 1 hij, Real.dist_eq]]
+  exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _)
+    (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
 
 end Topology
 

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -239,8 +239,7 @@ theorem diam_stdSimplex_le : Metric.diam (stdSimplex ℝ ι) ≤ 1 :=
 
 /-- The (sup metric) diameter of a standard simplex indexed by a subsingleton is 0. -/
 @[simp]
-theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] :
-    Metric.diam (stdSimplex ℝ ι) = 0 := by
+theorem diam_stdSimplex_of_subsingleton [Subsingleton ι] : Metric.diam (stdSimplex ℝ ι) = 0 := by
   cases isEmpty_or_nonempty ι with
   | inl h => rw [stdSimplex_of_isEmpty_index, Metric.diam_empty]
   | inr h => rw [stdSimplex_unique, Metric.diam_singleton]

--- a/Mathlib/Topology/MetricSpace/Pseudo/Pi.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Pi.lean
@@ -161,3 +161,21 @@ lemma Fin.dist_insertNth_insertNth {n : ℕ} {α : Fin (n + 1) → Type*}
     [∀ i, PseudoMetricSpace (α i)] (i : Fin (n + 1)) (x y : α i) (f g : ∀ j, α (i.succAbove j)) :
     dist (i.insertNth x f) (i.insertNth y g) = max (dist x y) (dist f g) := by
   simp only [dist_nndist, Fin.nndist_insertNth_insertNth, NNReal.coe_max]
+
+/-- The (sup metric) nonnegative distance between `Pi.single i a` and `Pi.single j b` for
+`i ≠ j` is `max (nndist a 0) (nndist b 0)`. -/
+lemma nndist_single_single {Y : Type*} [PseudoMetricSpace Y] [Zero Y] [DecidableEq β]
+    (i j : β) (a b : Y) (h : i ≠ j) :
+    nndist (Pi.single i a : β → Y) (Pi.single j b) = max (nndist a 0) (nndist b 0) := by
+  refine le_antisymm (nndist_pi_le_iff.2 fun k ↦ ?_) (max_le ?_ ?_)
+  · simp only [Pi.single_apply]
+    by_cases hki : k = i <;> by_cases hkj : k = j <;> simp_all [nndist_comm]
+  · simpa [h] using nndist_le_pi_nndist (Pi.single i a : β → Y) (Pi.single j b) i
+  · simpa [h, nndist_comm] using nndist_le_pi_nndist (Pi.single i a : β → Y) (Pi.single j b) j
+
+/-- The (sup metric) distance between `Pi.single i a` and `Pi.single j b` for
+`i ≠ j` is `max (dist a 0) (dist b 0)`. -/
+lemma dist_single_single {Y : Type*} [PseudoMetricSpace Y] [Zero Y] [DecidableEq β]
+    (i j : β) (a b : Y) (h : i ≠ j) :
+    dist (Pi.single i a : β → Y) (Pi.single j b) = max (dist a 0) (dist b 0) := by
+  simp only [dist_nndist, nndist_single_single i j a b h, NNReal.coe_max]


### PR DESCRIPTION
diameter of a standard simplex

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
