### PR TITLE
refactor(RingTheory/Polynomial/SmallDegreeVieta): convert to {p : R[X]} (hp : p.natDegree = 2) 

### DIFF
--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -492,6 +492,7 @@ theorem monomial_one_right_eq_X_pow (n : ℕ) : monomial n (1 : R) = X ^ n := by
 theorem toFinsupp_X : X.toFinsupp = .single 1 (1 : R) :=
   rfl
 
+@[simp]
 theorem X_ne_C [Nontrivial R] (a : R) : X ≠ C a := by
   intro he
   simpa using monomial_eq_monomial_iff.1 he

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -115,6 +115,10 @@ theorem ne_zero_of_mem_roots (h : a ∈ p.roots) : p ≠ 0 :=
 theorem isRoot_of_mem_roots (h : a ∈ p.roots) : IsRoot p a :=
   (mem_roots'.1 h).2
 
+theorem ne_zero_of_roots_ne_zero (h : p.roots ≠ 0) : p ≠ 0 := by
+  rintro rfl
+  simp at h
+
 theorem roots_eq_zero_iff_isRoot_eq_bot (hp0 : p ≠ 0) : p.roots = 0 ↔ p.IsRoot = ⊥ := by
   refine ⟨fun h ↦ ?_, fun h ↦ eq_zero_of_forall_notMem fun x hx ↦ h ▸ mem_roots hp0 |>.mp hx⟩
   ext a

--- a/Mathlib/RingTheory/Polynomial/SmallDegreeVieta.lean
+++ b/Mathlib/RingTheory/Polynomial/SmallDegreeVieta.lean
@@ -5,9 +5,10 @@ Authors: Qinchuan Zhang
 -/
 module
 
-public import Mathlib.Tactic.FieldSimp
-public import Mathlib.Tactic.LinearCombination
 public import Mathlib.RingTheory.Polynomial.Vieta
+
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # Vieta's Formula for polynomial of small degrees.
@@ -26,89 +27,147 @@ lemma eq_quadratic_of_degree_le_two [Semiring R] {p : R[X]} (hp : p.degree ≤ 2
   simp [Finset.sum_range_succ]
   abel
 
-/-- **Vieta's formula** for quadratics. -/
+private theorem vieta_aux [CommRing R] [IsDomain R] {x1 x2 : R} {p : R[X]}
+    (hp : p.degree ≤ 2) (hroots : p.roots = {x1, x2}) :
+    p.coeff 1 = -p.coeff 2 * (x1 + x2) ∧ p.coeff 0 = p.coeff 2 * x1 * x2 := by
+  have hn : p ≠ 0 := p.ne_zero_of_roots_ne_zero (by simp [hroots])
+  have c2 : 2 = p.roots.card := by rw [hroots, Multiset.card_pair]
+  have hpr := (hp.trans_eq (congrArg Nat.cast c2)).antisymm (card_roots hn)
+  have hp' : p.degree = 2 := by rw [hpr, ← c2, Nat.cast_ofNat]
+  have H (k) (hk : k ≤ 2) :=
+    coeff_eq_esymm_roots_of_card (natDegree_eq_of_degree_eq_some hpr).symm (k := k)
+    (by simpa [natDegree_eq_of_degree_eq_some hp'])
+  simpa [leadingCoeff, natDegree_eq_of_degree_eq_some hp', hroots, mul_assoc, add_comm x1] using
+    And.intro (H 1 (by norm_num)) (H 0 (by norm_num))
+
+/-- **Vieta's formula** for quadratics, linear coefficient. -/
+lemma eq_neg_mul_add_of_degree_two_of_roots_eq_pair [CommRing R] [IsDomain R] {x1 x2 : R} {p : R[X]}
+    (hp : p.degree ≤ 2) (hroots : p.roots = {x1, x2}) : p.coeff 1 = -p.coeff 2 * (x1 + x2) :=
+  (vieta_aux hp hroots).1
+
+@[deprecated eq_neg_mul_add_of_degree_two_of_roots_eq_pair (since := "2026-01-10")]
 lemma eq_neg_mul_add_of_roots_quadratic_eq_pair [CommRing R] [IsDomain R] {a b c x1 x2 : R}
     (hroots : (C a * X ^ 2 + C b * X + C c).roots = {x1, x2}) :
     b = -a * (x1 + x2) := by
-  let p : R[X] := C a * X ^ 2 + C b * X + C c
-  have hp_natDegree : p.natDegree = 2 := le_antisymm natDegree_quadratic_le
-    (by convert p.card_roots'; rw [hroots, Multiset.card_pair])
-  have hp_roots_card : p.roots.card = p.natDegree := by
-    rw [hp_natDegree, hroots, Multiset.card_pair]
-  simpa [leadingCoeff, hp_natDegree, p, hroots, mul_assoc, add_comm x1] using
-    coeff_eq_esymm_roots_of_card hp_roots_card (k := 1) (by simp [hp_natDegree])
+  convert eq_neg_mul_add_of_degree_two_of_roots_eq_pair degree_quadratic_le hroots <;> simp
 
-/-- **Vieta's formula** for quadratics. -/
+/-- **Vieta's formula** for quadratics, constant coefficient. -/
+lemma eq_mul_mul_of_roots_degree_two_eq_pair [CommRing R] [IsDomain R] {x1 x2 : R} {p : R[X]}
+    (hp : p.degree ≤ 2) (hroots : p.roots = {x1, x2}) : p.coeff 0 = p.coeff 2 * x1 * x2 :=
+  (vieta_aux hp hroots).2
+
+@[deprecated eq_mul_mul_of_roots_degree_two_eq_pair (since := "2026-01-10")]
 lemma eq_mul_mul_of_roots_quadratic_eq_pair [CommRing R] [IsDomain R] {a b c x1 x2 : R}
     (hroots : (C a * X ^ 2 + C b * X + C c).roots = {x1, x2}) :
     c = a * x1 * x2 := by
-  let p : R[X] := C a * X ^ 2 + C b * X + C c
-  have hp_natDegree : p.natDegree = 2 := le_antisymm natDegree_quadratic_le
-    (by convert p.card_roots'; rw [hroots, Multiset.card_pair])
-  have hp_roots_card : p.roots.card = p.natDegree := by
-    rw [hp_natDegree, hroots, Multiset.card_pair]
-  simpa [leadingCoeff, hp_natDegree, p, hroots, mul_assoc, add_comm x1] using
-    coeff_eq_esymm_roots_of_card hp_roots_card (k := 0) (by simp [hp_natDegree])
+  convert eq_mul_mul_of_roots_degree_two_eq_pair degree_quadratic_le hroots <;> simp
 
-/-- **Vieta's formula** for quadratics (`aroots` version). -/
+/-- **Vieta's formula** for quadratics (`aroots` version), linear coefficient. -/
+lemma eq_neg_mul_add_of_aroots_degree_two_eq_pair
+    [CommRing T] [CommRing S] [IsDomain S] [Algebra T S] {p : T[X]} {x1 x2 : S}
+    (hp : p.degree ≤ 2) (haroots : p.aroots S = {x1, x2}) :
+    algebraMap T S (p.coeff 1) = -algebraMap T S (p.coeff 2) * (x1 + x2) := by
+  simp_rw [← coeff_map]
+  exact eq_neg_mul_add_of_degree_two_of_roots_eq_pair (degree_map_le.trans hp) haroots
+
+@[deprecated eq_neg_mul_add_of_aroots_degree_two_eq_pair (since := "2026-01-10")]
 lemma eq_neg_mul_add_of_aroots_quadratic_eq_pair
     [CommRing T] [CommRing S] [IsDomain S] [Algebra T S] {a b c : T} {x1 x2 : S}
     (haroots : (C a * X ^ 2 + C b * X + C c).aroots S = {x1, x2}) :
     algebraMap T S b = -algebraMap T S a * (x1 + x2) := by
-  rw [aroots_def, show map (algebraMap T S) (C a * X ^ 2 + C b * X + C c) = C ((algebraMap T S) a) *
-    X ^ 2 + C ((algebraMap T S) b) * X + C ((algebraMap T S) c) by simp] at haroots
-  exact eq_neg_mul_add_of_roots_quadratic_eq_pair haroots
+  convert eq_neg_mul_add_of_aroots_degree_two_eq_pair degree_quadratic_le haroots <;> simp
 
-/-- **Vieta's formula** for quadratics (`aroots` version). -/
+/-- **Vieta's formula** for quadratics (`aroots` version), constant coefficient. -/
+lemma eq_mul_mul_of_aroots_degree_two_eq_pair [CommRing T] [CommRing S] [IsDomain S] [Algebra T S]
+    {p : T[X]} {x1 x2 : S} (hp : p.degree ≤ 2) (haroots : p.aroots S = {x1, x2}) :
+    algebraMap T S (p.coeff 0) = algebraMap T S (p.coeff 2) * x1 * x2 := by
+  simp_rw [← coeff_map]
+  exact eq_mul_mul_of_roots_degree_two_eq_pair (degree_map_le.trans hp) haroots
+
+@[deprecated eq_mul_mul_of_aroots_degree_two_eq_pair (since := "2026-01-10")]
 lemma eq_mul_mul_of_aroots_quadratic_eq_pair [CommRing T] [CommRing S] [IsDomain S] [Algebra T S]
     {a b c : T} {x1 x2 : S} (haroots : (C a * X ^ 2 + C b * X + C c).aroots S = {x1, x2}) :
     algebraMap T S c = algebraMap T S a * x1 * x2 := by
-  rw [aroots_def, show map (algebraMap T S) (C a * X ^ 2 + C b * X + C c) = C ((algebraMap T S) a) *
-    X ^ 2 + C ((algebraMap T S) b) * X + C ((algebraMap T S) c) by simp] at haroots
-  exact eq_mul_mul_of_roots_quadratic_eq_pair haroots
+  convert eq_mul_mul_of_aroots_degree_two_eq_pair degree_quadratic_le haroots <;> simp
 
 /-- **Vieta's formula** for quadratics as an iff. -/
+lemma roots_degree_two_eq_pair_iff_of_ne_zero [CommRing R] [IsDomain R] {x1 x2 : R} {p : R[X]}
+    (hp : p.degree = 2) :
+    p.roots = {x1, x2} ↔ p.coeff 1 = -p.coeff 2 * (x1 + x2) ∧ p.coeff 0 = p.coeff 2 * x1 * x2 := by
+  refine ⟨vieta_aux hp.le, fun ⟨h₁, h₂⟩ ↦ ?_⟩
+  suffices p = (X - C x1) * (X - C x2) * C (p.coeff 2) by
+    have h : (X - C x1) * (X - C x2) ≠ 0 := by simp [sub_eq_zero]
+    rw [this, roots_mul (mul_ne_zero h _), roots_mul h]
+    · simp
+    · simpa using coeff_ne_zero_of_eq_degree hp
+  rw [eq_quadratic_of_degree_le_two hp.le]
+  simpa [h₁, h₂] using by ring
+
+@[deprecated roots_degree_two_eq_pair_iff_of_ne_zero (since := "2026-01-10")]
 lemma roots_quadratic_eq_pair_iff_of_ne_zero [CommRing R] [IsDomain R] {a b c x1 x2 : R}
     (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).roots = {x1, x2} ↔
-      b = -a * (x1 + x2) ∧ c = a * x1 * x2 :=
-  have roots_of_ne_zero_of_vieta (hvieta : b = -a * (x1 + x2) ∧ c = a * x1 * x2) :
-      (C a * X ^ 2 + C b * X + C c).roots = {x1, x2} := by
-    suffices C a * X ^ 2 + C b * X + C c = C a * (X - C x1) * (X - C x2) by
-      have h1 : C a * (X - C x1) ≠ 0 := mul_ne_zero (by simpa) (Polynomial.X_sub_C_ne_zero _)
-      have h2 : C a * (X - C x1) * (X - C x2) ≠ 0 := mul_ne_zero h1 (Polynomial.X_sub_C_ne_zero _)
-      simp [this, Polynomial.roots_mul h2, Polynomial.roots_mul h1]
-    simpa [hvieta.1, hvieta.2] using by ring
-  ⟨fun h => ⟨eq_neg_mul_add_of_roots_quadratic_eq_pair h, eq_mul_mul_of_roots_quadratic_eq_pair h⟩,
-    roots_of_ne_zero_of_vieta⟩
+      b = -a * (x1 + x2) ∧ c = a * x1 * x2 := by
+  convert roots_degree_two_eq_pair_iff_of_ne_zero (degree_quadratic ha) <;> simp
 
 /-- **Vieta's formula** for quadratics as an iff (`aroots` version). -/
+lemma aroots_degree_two_eq_pair_iff_of_ne_zero [CommRing T] [CommRing S] [IsDomain S]
+    [Algebra T S] {p : T[X]} {x1 x2 : S} (ha : (map (algebraMap T S) p).degree = 2) :
+    p.aroots S = {x1, x2} ↔
+      algebraMap T S (p.coeff 1) = -algebraMap T S (p.coeff 2) * (x1 + x2) ∧
+      algebraMap T S (p.coeff 0) = algebraMap T S (p.coeff 2) * x1 * x2 := by
+  rw [roots_degree_two_eq_pair_iff_of_ne_zero ha, coeff_map, coeff_map, coeff_map]
+
+@[deprecated aroots_degree_two_eq_pair_iff_of_ne_zero (since := "2026-01-10")]
 lemma aroots_quadratic_eq_pair_iff_of_ne_zero [CommRing T] [CommRing S] [IsDomain S]
     [Algebra T S] {a b c : T} {x1 x2 : S} (ha : algebraMap T S a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).aroots S = {x1, x2} ↔
       algebraMap T S b = -algebraMap T S a * (x1 + x2) ∧
       algebraMap T S c = algebraMap T S a * x1 * x2 := by
-  rw [aroots_def, show map (algebraMap T S) (C a * X ^ 2 + C b * X + C c) = C ((algebraMap T S) a) *
-    X ^ 2 + C ((algebraMap T S) b) * X + C ((algebraMap T S) c) by simp]
-  exact roots_quadratic_eq_pair_iff_of_ne_zero ha
+  convert aroots_degree_two_eq_pair_iff_of_ne_zero _
+  · simp
+  · simp
+  · simp
+  · simp
+  · simpa using degree_quadratic ha
 
 /-- **Vieta's formula** for quadratics as an iff (`Field` version). -/
+lemma roots_degree_two_eq_pair_iff_of_ne_zero' [Field R] {p : R[X]} {x1 x2 : R}
+    (hp : p.degree = 2) : p.roots = {x1, x2} ↔
+      x1 + x2 = -p.coeff 1 / p.coeff 2 ∧ x1 * x2 = p.coeff 0 / p.coeff 2 := by
+  have hp' := coeff_ne_zero_of_eq_degree hp
+  rw [roots_degree_two_eq_pair_iff_of_ne_zero hp]
+  apply and_congr
+  · rw [eq_div_iff hp', eq_comm, ← neg_eq_iff_eq_neg]
+    ring_nf
+  · rw [eq_div_iff hp', eq_comm]
+    ring_nf
+
+@[deprecated roots_degree_two_eq_pair_iff_of_ne_zero' (since := "2026-01-10")]
 lemma roots_quadratic_eq_pair_iff_of_ne_zero' [Field R] {a b c x1 x2 : R} (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).roots = {x1, x2} ↔
       x1 + x2 = -b / a ∧ x1 * x2 = c / a := by
-  rw [roots_quadratic_eq_pair_iff_of_ne_zero ha]
-  field_simp
-  exact and_congr ⟨fun h => by linear_combination h, fun h => by linear_combination h⟩
-    ⟨fun h => by linear_combination -h, fun h => by linear_combination -h⟩
+  convert roots_degree_two_eq_pair_iff_of_ne_zero' (degree_quadratic ha) <;> simp
 
 /-- **Vieta's formula** for quadratics as an iff (`aroots, Field` version). -/
+lemma aroots_degree_two_eq_pair_iff_of_ne_zero' [CommRing T] [Field S] [Algebra T S] {p : T[X]}
+    {x1 x2 : S} (ha : (map (algebraMap T S) p).degree = 2) :
+    p.aroots S = {x1, x2} ↔
+      x1 + x2 = -algebraMap T S (p.coeff 1) / algebraMap T S (p.coeff 2) ∧
+      x1 * x2 = algebraMap T S (p.coeff 0) / algebraMap T S (p.coeff 2) := by
+  rw [aroots_def, roots_degree_two_eq_pair_iff_of_ne_zero' ha, coeff_map, coeff_map, coeff_map]
+
+@[deprecated aroots_degree_two_eq_pair_iff_of_ne_zero' (since := "2026-01-10")]
 lemma aroots_quadratic_eq_pair_iff_of_ne_zero' [CommRing T] [Field S] [Algebra T S] {a b c : T}
     {x1 x2 : S} (ha : algebraMap T S a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).aroots S = {x1, x2} ↔
       x1 + x2 = -algebraMap T S b / algebraMap T S a ∧
       x1 * x2 = algebraMap T S c / algebraMap T S a := by
-  rw [aroots_def, show map (algebraMap T S) (C a * X ^ 2 + C b * X + C c) = C ((algebraMap T S) a) *
-    X ^ 2 + C ((algebraMap T S) b) * X + C ((algebraMap T S) c) by simp]
-  exact roots_quadratic_eq_pair_iff_of_ne_zero' ha
+  convert aroots_degree_two_eq_pair_iff_of_ne_zero' _
+  · simp
+  · simp
+  · simp
+  · simp
+  · simpa using degree_quadratic ha
 
 end Polynomial


### PR DESCRIPTION

Co-authored-by: Christopher Hoskin <christopher.hoskin@gmail.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Adopted from #29921. I've applied all pending suggestions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
