### PR TITLE
feat(NumberTheory): add unitary divisors and unitary perfect numbers

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5377,6 +5377,8 @@ public import Mathlib.NumberTheory.Transcendental.Liouville.Measure
 public import Mathlib.NumberTheory.Transcendental.Liouville.Residual
 public import Mathlib.NumberTheory.TsumDivisorsAntidiagonal
 public import Mathlib.NumberTheory.TsumDivsorsAntidiagonal
+public import Mathlib.NumberTheory.UnitaryDivisor
+public import Mathlib.NumberTheory.UnitaryPerfect
 public import Mathlib.NumberTheory.VonMangoldt
 public import Mathlib.NumberTheory.WellApproximable
 public import Mathlib.NumberTheory.Wilson

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -216,10 +216,10 @@ theorem unitaryDivisorSum_mul {m n : ℕ} (hcoprime : Nat.Coprime m n) (hm : m �
       have hg1_n : Nat.gcd p.1 n = 1 := Nat.Coprime.coprime_dvd_left h1_dvd hcoprime
       have hg2_n : Nat.gcd p.2 n = p.2 := Nat.gcd_eq_left h2_dvd
       ext
-      · show Nat.gcd (p.1 * p.2) m = p.1
+      · change Nat.gcd (p.1 * p.2) m = p.1
         rw [mul_comm]
         exact Nat.gcd_mul_of_coprime_of_dvd hg2_m h1_dvd
-      · show Nat.gcd (p.1 * p.2) n = p.2
+      · change Nat.gcd (p.1 * p.2) n = p.2
         exact Nat.gcd_mul_of_coprime_of_dvd hg1_n h2_dvd
     · intro d hd
       have h_in : UnitaryDivisor d (m * n) := (mem_unitaryDivisors (mul_ne_zero hm hn)).mp hd

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -7,7 +7,6 @@ import Mathlib.NumberTheory.Divisors
 import Mathlib.NumberTheory.ArithmeticFunction.Defs
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
-import Mathlib.Tactic
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function
@@ -198,7 +197,7 @@ pairs `(d₁, d₂)` of unitary divisors of `m` and `n` respectively. The biject
 `d ↦ (gcd(d,m), gcd(d,n))` with inverse `(d₁, d₂) ↦ d₁ * d₂`. -/
 theorem unitaryDivisorSum_mul {m n : ℕ} (hcoprime : Nat.Coprime m n) (hm : m ≠ 0) (hn : n ≠ 0) :
     σ* (m * n) = σ* m * σ* n := by
-  show unitaryDivisorSumAux (m * n) = unitaryDivisorSumAux m * unitaryDivisorSumAux n
+  change unitaryDivisorSumAux (m * n) = unitaryDivisorSumAux m * unitaryDivisorSumAux n
   unfold unitaryDivisorSumAux
   let i : ℕ → ℕ × ℕ := fun d => (Nat.gcd d m, Nat.gcd d n)
   let j : ℕ × ℕ → ℕ := fun p => p.1 * p.2
@@ -330,7 +329,7 @@ theorem unitaryDivisors_prime_pow {p k : ℕ} (hp : Nat.Prime p) :
 theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0) :
     σ* (p ^ k) = p ^ k + 1 := by
   have hk_pos : 0 < k := Nat.pos_of_ne_zero hk
-  show unitaryDivisorSumAux (p ^ k) = p ^ k + 1
+  change unitaryDivisorSumAux (p ^ k) = p ^ k + 1
   unfold unitaryDivisorSumAux
   rw [unitaryDivisors_prime_pow hp]
   have h_ne : 1 ≠ p ^ k := by
@@ -348,7 +347,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
 /-- `σ*(1) = 1`. -/
 @[simp]
 theorem unitaryDivisorSum_one : σ* 1 = 1 := by
-  show unitaryDivisorSumAux 1 = 1
+  change unitaryDivisorSumAux 1 = 1
   unfold unitaryDivisorSumAux unitaryDivisors
   simp only [Nat.divisors_one, Finset.filter_singleton, Nat.gcd_self,
     ite_true, Finset.sum_singleton]

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -1,0 +1,340 @@
+/-
+Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
+-/
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic
+
+/-!
+# Unitary Divisors and the Unitary Divisor Sum Function
+
+This file defines unitary divisors and the unitary divisor sum function σ*.
+
+A divisor `d` of `n` is called a *unitary divisor* if `gcd(d, n/d) = 1`. The unitary
+divisor sum function `σ*(n)` is the sum of all unitary divisors of `n`. This function
+is multiplicative: `σ*(mn) = σ*(m) · σ*(n)` when `m` and `n` are coprime.
+
+## Main Definitions
+
+* `Nat.UnitaryDivisor d n`: Predicate stating that `d` is a unitary divisor of `n`.
+* `Nat.unitaryDivisors n`: The `Finset` of all unitary divisors of `n`.
+* `Nat.unitaryDivisorSum n`: The sum `σ*(n)` of all unitary divisors of `n`.
+
+## Main Results
+
+* `Nat.unitaryDivisorSum_mul`: Multiplicativity of `σ*` for coprime arguments.
+* `Nat.unitaryDivisorSum_prime_pow`: For prime `p` and `k ≥ 1`, `σ*(p^k) = p^k + 1`.
+* `Nat.unitaryDivisors_prime_pow`: The unitary divisors of `p^k` are exactly `{1, p^k}`.
+
+## Implementation Notes
+
+The definition uses `Nat.divisors` from Mathlib and filters by the coprimality condition.
+The multiplicativity proof establishes an explicit bijection between unitary divisors of
+a coprime product and pairs of unitary divisors.
+
+## References
+
+* Subbarao, M. V., & Warren, L. J. (1966). Unitary perfect numbers.
+  Canadian Mathematical Bulletin, 9(2), 147-153.
+* Wall, C. R. (1975). The fifth unitary perfect number.
+  Canadian Mathematical Bulletin, 18(1), 115-122.
+
+## Tags
+
+unitary divisor, divisor sum, multiplicative function, number theory
+-/
+
+namespace Nat
+
+open BigOperators Finset
+
+/-! ### Basic Definitions -/
+
+/-- A divisor `d` of `n` is a *unitary divisor* if `gcd(d, n/d) = 1`.
+This means `d` and its complementary divisor share no common factor. -/
+def UnitaryDivisor (d n : ℕ) : Prop :=
+  d ∣ n ∧ n ≠ 0 ∧ Nat.gcd d (n / d) = 1
+
+/-- The set of all unitary divisors of `n`. -/
+def unitaryDivisors (n : ℕ) : Finset ℕ :=
+  (Nat.divisors n).filter fun d => Nat.gcd d (n / d) = 1
+
+/-- The unitary divisor sum function `σ*(n)`, equal to the sum of all unitary divisors. -/
+def unitaryDivisorSum (n : ℕ) : ℕ :=
+  ∑ d ∈ unitaryDivisors n, d
+
+@[inherit_doc] scoped notation "σ*" => unitaryDivisorSum
+
+/-! ### Basic Properties -/
+
+/-- `1` is always a unitary divisor of any nonzero `n`. -/
+theorem unitaryDivisor_one (n : ℕ) (hn : n ≠ 0) : UnitaryDivisor 1 n := by
+  refine ⟨one_dvd n, hn, ?_⟩
+  simp [Nat.div_one]
+
+/-- Every nonzero `n` is a unitary divisor of itself. -/
+theorem unitaryDivisor_self (n : ℕ) (hn : n ≠ 0) : UnitaryDivisor n n := by
+  refine ⟨dvd_refl n, hn, ?_⟩
+  rw [Nat.div_self (Nat.pos_of_ne_zero hn)]
+  simp
+
+/-- Membership in `unitaryDivisors` is equivalent to being a unitary divisor. -/
+theorem mem_unitaryDivisors {d n : ℕ} (hn : n ≠ 0) :
+    d ∈ unitaryDivisors n ↔ UnitaryDivisor d n := by
+  simp only [unitaryDivisors, UnitaryDivisor, Finset.mem_filter, Nat.mem_divisors]
+  constructor
+  · intro ⟨⟨hd, _⟩, hgcd⟩
+    exact ⟨hd, hn, hgcd⟩
+  · intro ⟨hd, _, hgcd⟩
+    exact ⟨⟨hd, hn⟩, hgcd⟩
+
+/-- `1` is in the unitary divisors of any nonzero number. -/
+theorem one_mem_unitaryDivisors {n : ℕ} (hn : n ≠ 0) : 1 ∈ unitaryDivisors n :=
+  (mem_unitaryDivisors hn).mpr (unitaryDivisor_one n hn)
+
+/-- `n` is in its own unitary divisors when nonzero. -/
+theorem self_mem_unitaryDivisors {n : ℕ} (hn : n ≠ 0) : n ∈ unitaryDivisors n :=
+  (mem_unitaryDivisors hn).mpr (unitaryDivisor_self n hn)
+
+/-! ### Multiplicativity -/
+
+/-- A divisor of a coprime product decomposes as a product of gcd parts. -/
+private lemma divisor_coprime_decompose {m n d : ℕ} (hcoprime : Nat.Coprime m n)
+    (hdvd : d ∣ m * n) : d = Nat.gcd d m * Nat.gcd d n := by
+  have h := Nat.gcd_mul_gcd_eq_iff_dvd_mul_of_coprime (x := d) hcoprime.symm
+  have hdvd' : d ∣ n * m := by rw [mul_comm]; exact hdvd
+  rw [mul_comm]
+  exact (h.mpr hdvd').symm
+
+/-- If `d₁ ∣ m` and `d₂ ∣ n` with `m`, `n` coprime, then `d₁` and `d₂` are coprime. -/
+private lemma coprime_of_dvd_coprime {m n d₁ d₂ : ℕ} (hcoprime : Nat.Coprime m n)
+    (h1 : d₁ ∣ m) (h2 : d₂ ∣ n) : Nat.Coprime d₁ d₂ :=
+  Nat.Coprime.of_dvd_left h1 (Nat.Coprime.of_dvd_right h2 hcoprime)
+
+/-- For a unitary divisor of a coprime product, `d = gcd(d,m) * gcd(d,n)`. -/
+private lemma unitary_divisor_eq_gcd_mul_gcd {m n d : ℕ} (hcoprime : Nat.Coprime m n)
+    (h : UnitaryDivisor d (m * n)) : d = Nat.gcd d m * Nat.gcd d n :=
+  divisor_coprime_decompose hcoprime h.1
+
+/-- The quotient `(m*n)/d` splits for unitary divisors of coprime products. -/
+private lemma unitary_divisor_quotient_split {m n d : ℕ} (hcoprime : Nat.Coprime m n)
+    (h : UnitaryDivisor d (m * n)) :
+    (m * n) / d = (m / Nat.gcd d m) * (n / Nat.gcd d n) := by
+  have hd_eq := unitary_divisor_eq_gcd_mul_gcd hcoprime h
+  have hgcd_m_dvd : Nat.gcd d m ∣ m := Nat.gcd_dvd_right d m
+  have hgcd_n_dvd : Nat.gcd d n ∣ n := Nat.gcd_dvd_right d n
+  conv_lhs => rw [hd_eq]
+  calc m * n / (Nat.gcd d m * Nat.gcd d n)
+      = m * n / (Nat.gcd d n * Nat.gcd d m) := by rw [Nat.mul_comm (Nat.gcd d m)]
+    _ = m * n / Nat.gcd d n / Nat.gcd d m := by rw [Nat.div_div_eq_div_mul]
+    _ = m * (n / Nat.gcd d n) / Nat.gcd d m := by rw [Nat.mul_div_assoc _ hgcd_n_dvd]
+    _ = (n / Nat.gcd d n) * m / Nat.gcd d m := by rw [Nat.mul_comm m]
+    _ = (n / Nat.gcd d n) * (m / Nat.gcd d m) := by rw [Nat.mul_div_assoc _ hgcd_m_dvd]
+    _ = (m / Nat.gcd d m) * (n / Nat.gcd d n) := by rw [Nat.mul_comm]
+
+/-- `gcd(d,m)` is a unitary divisor of `m` when `d` is a unitary divisor of `m*n` (coprime). -/
+private lemma gcd_unitaryDivisor_left {m n d : ℕ} (hcoprime : Nat.Coprime m n)
+    (hm : m ≠ 0) (h : UnitaryDivisor d (m * n)) :
+    UnitaryDivisor (Nat.gcd d m) m := by
+  refine ⟨Nat.gcd_dvd_right d m, hm, ?_⟩
+  have h_unitary := h.2.2
+  have hgcd_m_dvd_d : Nat.gcd d m ∣ d := Nat.gcd_dvd_left d m
+  have hm_quot_dvd : m / Nat.gcd d m ∣ (m * n) / d := by
+    have hq := unitary_divisor_quotient_split hcoprime h
+    rw [hq]
+    exact Nat.dvd_mul_right _ _
+  have h_cop : Nat.Coprime d ((m * n) / d) := h_unitary
+  exact Nat.Coprime.coprime_dvd_left hgcd_m_dvd_d
+    (Nat.Coprime.coprime_dvd_right hm_quot_dvd h_cop)
+
+/-- `gcd(d,n)` is a unitary divisor of `n` when `d` is a unitary divisor of `m*n` (coprime). -/
+private lemma gcd_unitaryDivisor_right {m n d : ℕ} (hcoprime : Nat.Coprime m n)
+    (hn : n ≠ 0) (h : UnitaryDivisor d (m * n)) :
+    UnitaryDivisor (Nat.gcd d n) n := by
+  have h' : UnitaryDivisor d (n * m) := by rw [mul_comm] at h; exact h
+  exact gcd_unitaryDivisor_left hcoprime.symm hn h'
+
+/-- A product of unitary divisors of coprime numbers is a unitary divisor of the product. -/
+theorem unitaryDivisor_mul_of_coprime {m n d₁ d₂ : ℕ} (hcoprime : Nat.Coprime m n)
+    (hm : m ≠ 0) (hn : n ≠ 0) (h1 : UnitaryDivisor d₁ m) (h2 : UnitaryDivisor d₂ n) :
+    UnitaryDivisor (d₁ * d₂) (m * n) := by
+  refine ⟨Nat.mul_dvd_mul h1.1 h2.1, mul_ne_zero hm hn, ?_⟩
+  have hq : (m * n) / (d₁ * d₂) = (m / d₁) * (n / d₂) := by
+    rw [Nat.mul_comm d₁ d₂, ← Nat.div_div_eq_div_mul]
+    rw [Nat.mul_div_assoc _ h2.1]
+    rw [Nat.mul_comm m, Nat.mul_div_assoc _ h1.1]
+    rw [mul_comm]
+  suffices Nat.Coprime (d₁ * d₂) ((m / d₁) * (n / d₂)) by rw [hq]; exact this
+  have hcop_d1_mq : Nat.Coprime d₁ (m / d₁) := h1.2.2
+  have hcop_d2_nq : Nat.Coprime d₂ (n / d₂) := h2.2.2
+  have hnq_dvd_n : n / d₂ ∣ n := Nat.div_dvd_of_dvd h2.1
+  have hcop_d1_nq : Nat.Coprime d₁ (n / d₂) := coprime_of_dvd_coprime hcoprime h1.1 hnq_dvd_n
+  have hmq_dvd_m : m / d₁ ∣ m := Nat.div_dvd_of_dvd h1.1
+  have hcop_d2_mq : Nat.Coprime d₂ (m / d₁) := coprime_of_dvd_coprime hcoprime.symm h2.1 hmq_dvd_m
+  have h1' : Nat.Coprime d₁ ((m / d₁) * (n / d₂)) := Nat.Coprime.mul_right hcop_d1_mq hcop_d1_nq
+  have h2' : Nat.Coprime d₂ ((m / d₁) * (n / d₂)) := Nat.Coprime.mul_right hcop_d2_mq hcop_d2_nq
+  exact Nat.Coprime.mul_left h1' h2'
+
+/-- **Multiplicativity of σ***. For coprime `m` and `n`, `σ*(mn) = σ*(m) · σ*(n)`.
+
+This is proved by establishing a bijection between unitary divisors of `m*n` and
+pairs `(d₁, d₂)` of unitary divisors of `m` and `n` respectively. The bijection is
+`d ↦ (gcd(d,m), gcd(d,n))` with inverse `(d₁, d₂) ↦ d₁ * d₂`. -/
+theorem unitaryDivisorSum_mul {m n : ℕ} (hcoprime : Nat.Coprime m n) (hm : m ≠ 0) (hn : n ≠ 0) :
+    σ* (m * n) = σ* m * σ* n := by
+  unfold unitaryDivisorSum
+  let i : ℕ → ℕ × ℕ := fun d => (Nat.gcd d m, Nat.gcd d n)
+  let j : ℕ × ℕ → ℕ := fun p => p.1 * p.2
+  have h_sum_bij : ∑ d ∈ unitaryDivisors (m * n), d =
+                   ∑ p ∈ unitaryDivisors m ×ˢ unitaryDivisors n, p.1 * p.2 := by
+    apply Finset.sum_nbij' i j
+    · intro d hd
+      simp only [Finset.mem_product]
+      have h_in : UnitaryDivisor d (m * n) := (mem_unitaryDivisors (mul_ne_zero hm hn)).mp hd
+      have h1 := gcd_unitaryDivisor_left hcoprime hm h_in
+      have h2 := gcd_unitaryDivisor_right hcoprime hn h_in
+      exact ⟨(mem_unitaryDivisors hm).mpr h1, (mem_unitaryDivisors hn).mpr h2⟩
+    · intro p hp
+      simp only [Finset.mem_product] at hp
+      have h1 : UnitaryDivisor p.1 m := (mem_unitaryDivisors hm).mp hp.1
+      have h2 : UnitaryDivisor p.2 n := (mem_unitaryDivisors hn).mp hp.2
+      exact (mem_unitaryDivisors (mul_ne_zero hm hn)).mpr
+        (unitaryDivisor_mul_of_coprime hcoprime hm hn h1 h2)
+    · intro d hd
+      have h_in : UnitaryDivisor d (m * n) := (mem_unitaryDivisors (mul_ne_zero hm hn)).mp hd
+      exact (unitary_divisor_eq_gcd_mul_gcd hcoprime h_in).symm
+    · intro p hp
+      simp only [Finset.mem_product] at hp
+      have h1 : UnitaryDivisor p.1 m := (mem_unitaryDivisors hm).mp hp.1
+      have h2 : UnitaryDivisor p.2 n := (mem_unitaryDivisors hn).mp hp.2
+      have h1_dvd : p.1 ∣ m := h1.1
+      have h2_dvd : p.2 ∣ n := h2.1
+      have hg1_m : Nat.gcd p.1 m = p.1 := Nat.gcd_eq_left h1_dvd
+      have hg2_m : Nat.gcd p.2 m = 1 := Nat.Coprime.coprime_dvd_left h2_dvd hcoprime.symm
+      have hg1_n : Nat.gcd p.1 n = 1 := Nat.Coprime.coprime_dvd_left h1_dvd hcoprime
+      have hg2_n : Nat.gcd p.2 n = p.2 := Nat.gcd_eq_left h2_dvd
+      ext
+      · show Nat.gcd (p.1 * p.2) m = p.1
+        rw [mul_comm]
+        exact Nat.gcd_mul_of_coprime_of_dvd hg2_m h1_dvd
+      · show Nat.gcd (p.1 * p.2) n = p.2
+        exact Nat.gcd_mul_of_coprime_of_dvd hg1_n h2_dvd
+    · intro d hd
+      have h_in : UnitaryDivisor d (m * n) := (mem_unitaryDivisors (mul_ne_zero hm hn)).mp hd
+      exact unitary_divisor_eq_gcd_mul_gcd hcoprime h_in
+  rw [h_sum_bij, Finset.sum_product', Finset.sum_mul_sum]
+
+/-! ### Prime Powers -/
+
+/-- For any `p`, `gcd(p^i, p^j) = p^(min i j)`. -/
+private lemma gcd_pow_self (p i j : ℕ) : Nat.gcd (p ^ i) (p ^ j) = p ^ min i j := by
+  by_cases h : i ≤ j
+  · rw [min_eq_left h]
+    exact Nat.gcd_eq_left (pow_dvd_pow p h)
+  · push_neg at h
+    rw [min_eq_right (Nat.le_of_lt h), Nat.gcd_comm]
+    exact Nat.gcd_eq_left (pow_dvd_pow p (Nat.le_of_lt h))
+
+/-- For `0 < i < k`, `p^i` is not a unitary divisor of `p^k`. -/
+private lemma not_unitaryDivisor_prime_pow_intermediate {p k i : ℕ} (hp : Nat.Prime p)
+    (hi : 0 < i) (hi_lt : i < k) :
+    ¬UnitaryDivisor (p ^ i) (p ^ k) := by
+  intro ⟨_, _, hgcd⟩
+  have hquot : p ^ k / p ^ i = p ^ (k - i) := Nat.pow_div hi_lt.le hp.pos
+  rw [hquot, gcd_pow_self] at hgcd
+  have h_min_pos : 0 < min i (k - i) := by
+    by_cases h_case : i ≤ k - i
+    · rw [min_eq_left h_case]; exact hi
+    · push_neg at h_case
+      rw [min_eq_right (Nat.le_of_lt h_case)]
+      exact Nat.sub_pos_of_lt hi_lt
+  have h_ge_p : p ^ min i (k - i) ≥ p := by
+    calc p ^ min i (k - i) ≥ p ^ 1 := Nat.pow_le_pow_right hp.pos h_min_pos
+      _ = p := pow_one p
+  have h_p_ge_2 : p ≥ 2 := hp.two_le
+  omega
+
+/-- Any divisor of `p^k` has the form `p^i` for some `i ≤ k`. -/
+private lemma divisor_of_prime_pow {p k d : ℕ} (hp : Nat.Prime p) (hdvd : d ∣ p ^ k) :
+    ∃ i : ℕ, i ≤ k ∧ d = p ^ i := by
+  induction k generalizing d with
+  | zero => simp at hdvd; exact ⟨0, le_refl 0, hdvd⟩
+  | succ k ih =>
+    by_cases hp_dvd_d : p ∣ d
+    · obtain ⟨m, rfl⟩ := hp_dvd_d
+      have hm_dvd : m ∣ p ^ k := by
+        have : p * m ∣ p * p ^ k := by
+          have heq : p ^ (k + 1) = p * p ^ k := by rw [pow_succ, mul_comm]
+          rw [heq] at hdvd; exact hdvd
+        exact Nat.dvd_of_mul_dvd_mul_left hp.pos this
+      obtain ⟨j, hj_le, rfl⟩ := ih hm_dvd
+      exact ⟨j + 1, by omega, by rw [pow_succ, mul_comm]⟩
+    · have hgcd : Nat.gcd d p = 1 := by
+        have : Nat.gcd d p ∣ p := Nat.gcd_dvd_right d p
+        rcases hp.eq_one_or_self_of_dvd _ this with h | h
+        · exact h
+        · exact absurd (h ▸ Nat.gcd_dvd_left d p) hp_dvd_d
+      have hgcd_pow : Nat.gcd d (p ^ (k + 1)) = 1 := by
+        rw [Nat.gcd_comm] at hgcd
+        exact (Nat.Coprime.pow_left (k + 1) hgcd).symm.gcd_eq_one
+      have hd_eq_1 : d = 1 := by
+        have : d ∣ Nat.gcd d (p ^ (k + 1)) := Nat.dvd_gcd (dvd_refl d) hdvd
+        rw [hgcd_pow] at this
+        exact Nat.eq_one_of_dvd_one this
+      exact ⟨0, by omega, by simp [hd_eq_1]⟩
+
+/-- The unitary divisors of `p^k` (for prime `p`) are exactly `{1, p^k}`. -/
+theorem unitaryDivisors_prime_pow {p k : ℕ} (hp : Nat.Prime p) :
+    unitaryDivisors (p ^ k) = {1, p ^ k} := by
+  ext d
+  constructor
+  · intro hd
+    simp only [unitaryDivisors, Finset.mem_filter, Nat.mem_divisors] at hd
+    obtain ⟨⟨hdvd, _⟩, hgcd⟩ := hd
+    obtain ⟨i, hi_le, rfl⟩ := divisor_of_prime_pow hp hdvd
+    by_cases hi_zero : i = 0
+    · simp [hi_zero]
+    · have hi_pos : 0 < i := Nat.pos_of_ne_zero hi_zero
+      by_cases hi_eq_k : i = k
+      · simp [hi_eq_k]
+      · have hi_lt : i < k := Nat.lt_of_le_of_ne hi_le hi_eq_k
+        have h_is_unitary : UnitaryDivisor (p ^ i) (p ^ k) :=
+          ⟨hdvd, pow_ne_zero k hp.ne_zero, hgcd⟩
+        exact absurd h_is_unitary (not_unitaryDivisor_prime_pow_intermediate hp hi_pos hi_lt)
+  · intro hd
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hd
+    rcases hd with rfl | rfl
+    · exact (mem_unitaryDivisors (pow_ne_zero k hp.ne_zero)).mpr
+        (unitaryDivisor_one _ (pow_ne_zero k hp.ne_zero))
+    · exact (mem_unitaryDivisors (pow_ne_zero k hp.ne_zero)).mpr
+        (unitaryDivisor_self _ (pow_ne_zero k hp.ne_zero))
+
+/-- **Prime power formula**: For prime `p` and `k ≥ 1`, `σ*(p^k) = p^k + 1`. -/
+theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0) :
+    σ* (p ^ k) = p ^ k + 1 := by
+  have hk_pos : 0 < k := Nat.pos_of_ne_zero hk
+  unfold unitaryDivisorSum
+  rw [unitaryDivisors_prime_pow hp]
+  have h_ne : 1 ≠ p ^ k := by
+    intro h_eq
+    have hp_ge : p ≥ 2 := hp.two_le
+    have hpk_ge : p ^ k ≥ p := by
+      calc p ^ k ≥ p ^ 1 := Nat.pow_le_pow_right hp.pos hk_pos
+        _ = p := pow_one p
+    omega
+  simp only [Finset.sum_insert (Finset.not_mem_singleton.mpr h_ne), Finset.sum_singleton]
+  ring
+
+/-! ### Additional Properties -/
+
+/-- `σ*(1) = 1`. -/
+@[simp]
+theorem unitaryDivisorSum_one : σ* 1 = 1 := by
+  unfold unitaryDivisorSum unitaryDivisors
+  simp only [Nat.divisors_one, Finset.filter_singleton, Nat.gcd_self,
+    ite_true, Finset.sum_singleton]
+
+end Nat

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -3,11 +3,10 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-module
-
-public import Mathlib.NumberTheory.Divisors
-public import Mathlib.Data.Nat.GCD.Basic
-public import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.NumberTheory.Divisors
+import Mathlib.NumberTheory.ArithmeticFunction.Defs
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Algebra.BigOperators.Ring.Finset
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function
@@ -26,6 +25,7 @@ is multiplicative: `σ*(mn) = σ*(m) · σ*(n)` when `m` and `n` are coprime.
 
 ## Main Results
 
+* `Nat.isMultiplicative_unitaryDivisorSum`: The function `σ*` is multiplicative.
 * `Nat.unitaryDivisorSum_mul`: Multiplicativity of `σ*` for coprime arguments.
 * `Nat.unitaryDivisorSum_prime_pow`: For prime `p` and `k ≥ 1`, `σ*(p^k) = p^k + 1`.
 * `Nat.unitaryDivisors_prime_pow`: The unitary divisors of `p^k` are exactly `{1, p^k}`.
@@ -65,11 +65,20 @@ def UnitaryDivisor (d n : ℕ) : Prop :=
 def unitaryDivisors (n : ℕ) : Finset ℕ :=
   (Nat.divisors n).filter fun d => Nat.gcd d (n / d) = 1
 
-/-- The unitary divisor sum function `σ*(n)`, equal to the sum of all unitary divisors. -/
-def unitaryDivisorSum (n : ℕ) : ℕ :=
-  ∑ d ∈ unitaryDivisors n, d
+/-- The unitary divisor sum function `σ*(n)`, equal to the sum of all unitary divisors.
 
-@[inherit_doc] scoped notation "σ*" => unitaryDivisorSum
+This is defined as an `ArithmeticFunction` to integrate with mathlib's framework for
+multiplicative arithmetic functions. -/
+def unitaryDivisorSum : ArithmeticFunction ℕ :=
+  ⟨fun n => ∑ d ∈ unitaryDivisors n, d, by simp [unitaryDivisors]⟩
+
+@[inherit_doc]
+scoped[ArithmeticFunction.UnitaryDivisorSum] notation "σ*" => Nat.unitaryDivisorSum
+
+open scoped ArithmeticFunction.UnitaryDivisorSum
+
+/-- The unitary divisor sum of `n` equals the sum over unitary divisors. -/
+theorem unitaryDivisorSum_apply (n : ℕ) : σ* n = ∑ d ∈ unitaryDivisors n, d := rfl
 
 /-! ### Basic Properties -/
 
@@ -188,7 +197,7 @@ pairs `(d₁, d₂)` of unitary divisors of `m` and `n` respectively. The biject
 `d ↦ (gcd(d,m), gcd(d,n))` with inverse `(d₁, d₂) ↦ d₁ * d₂`. -/
 theorem unitaryDivisorSum_mul {m n : ℕ} (hcoprime : Nat.Coprime m n) (hm : m ≠ 0) (hn : n ≠ 0) :
     σ* (m * n) = σ* m * σ* n := by
-  unfold unitaryDivisorSum
+  simp only [unitaryDivisorSum_apply]
   let i : ℕ → ℕ × ℕ := fun d => (Nat.gcd d m, Nat.gcd d n)
   let j : ℕ × ℕ → ℕ := fun p => p.1 * p.2
   have h_sum_bij : ∑ d ∈ unitaryDivisors (m * n), d =
@@ -319,8 +328,7 @@ theorem unitaryDivisors_prime_pow {p k : ℕ} (hp : Nat.Prime p) :
 theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0) :
     σ* (p ^ k) = p ^ k + 1 := by
   have hk_pos : 0 < k := Nat.pos_of_ne_zero hk
-  unfold unitaryDivisorSum
-  rw [unitaryDivisors_prime_pow hp]
+  simp only [unitaryDivisorSum_apply, unitaryDivisors_prime_pow hp]
   have h_ne : 1 ≠ p ^ k := by
     intro h_eq
     have hp_ge : p ≥ 2 := hp.two_le
@@ -336,8 +344,14 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
 /-- `σ*(1) = 1`. -/
 @[simp]
 theorem unitaryDivisorSum_one : σ* 1 = 1 := by
-  unfold unitaryDivisorSum unitaryDivisors
-  simp only [Nat.divisors_one, Finset.filter_singleton, Nat.gcd_self,
-    ite_true, Finset.sum_singleton]
+  simp only [unitaryDivisorSum_apply, unitaryDivisors, Nat.divisors_one,
+    Finset.filter_singleton, Nat.gcd_self, ite_true, Finset.sum_singleton]
+
+/-- The unitary divisor sum function is multiplicative. -/
+@[arith_mult]
+theorem isMultiplicative_unitaryDivisorSum : ArithmeticFunction.IsMultiplicative σ* := by
+  refine ArithmeticFunction.IsMultiplicative.iff_ne_zero.mpr ⟨unitaryDivisorSum_one, ?_⟩
+  intro m n hm hn hcoprime
+  exact unitaryDivisorSum_mul hcoprime hm hn
 
 end Nat

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -325,7 +325,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
         _ = p := pow_one p
     omega
   simp only [Finset.sum_insert (notMem_singleton.mpr h_ne), Finset.sum_singleton]
-  ring
+  ac_rfl
 
 /-! ### Additional Properties -/
 

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -336,7 +336,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
       calc p ^ k ≥ p ^ 1 := Nat.pow_le_pow_right hp.pos hk_pos
         _ = p := pow_one p
     omega
-  simp only [Finset.sum_insert (notMem_singleton.mpr h_ne), Finset.sum_singleton]
+  simp only [Finset.sum_insert (Finset.notMem_singleton.mpr h_ne), Finset.sum_singleton]
   ac_rfl
 
 /-! ### Additional Properties -/

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -3,9 +3,11 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-import Mathlib.NumberTheory.Divisors
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Algebra.BigOperators.Ring.Finset
+module
+
+public import Mathlib.NumberTheory.Divisors
+public import Mathlib.Data.Nat.GCD.Basic
+public import Mathlib.Algebra.BigOperators.Ring.Finset
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function
@@ -45,6 +47,8 @@ a coprime product and pairs of unitary divisors.
 
 unitary divisor, divisor sum, multiplicative function, number theory
 -/
+
+@[expose] public section
 
 namespace Nat
 

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -3,10 +3,12 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-import Mathlib.NumberTheory.Divisors
-import Mathlib.NumberTheory.ArithmeticFunction.Defs
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Algebra.BigOperators.Ring.Finset
+module
+
+public import Mathlib.NumberTheory.Divisors
+public import Mathlib.NumberTheory.ArithmeticFunction.Defs
+public import Mathlib.Data.Nat.GCD.Basic
+public import Mathlib.Algebra.BigOperators.Ring.Finset
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -6,7 +6,6 @@ Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Algebra.BigOperators.Ring.Finset
-import Mathlib.Tactic
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function
@@ -261,7 +260,7 @@ private lemma not_unitaryDivisor_prime_pow_intermediate {p k i : ℕ} (hp : Nat.
 private lemma divisor_of_prime_pow {p k d : ℕ} (hp : Nat.Prime p) (hdvd : d ∣ p ^ k) :
     ∃ i : ℕ, i ≤ k ∧ d = p ^ i := by
   induction k generalizing d with
-  | zero => simp at hdvd; exact ⟨0, le_refl 0, hdvd⟩
+  | zero => simp only [pow_zero, dvd_one] at hdvd; exact ⟨0, le_refl 0, hdvd⟩
   | succ k ih =>
     by_cases hp_dvd_d : p ∣ d
     · obtain ⟨m, rfl⟩ := hp_dvd_d
@@ -325,7 +324,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
       calc p ^ k ≥ p ^ 1 := Nat.pow_le_pow_right hp.pos hk_pos
         _ = p := pow_one p
     omega
-  simp only [Finset.sum_insert (Finset.not_mem_singleton.mpr h_ne), Finset.sum_singleton]
+  simp only [Finset.sum_insert (notMem_singleton.mpr h_ne), Finset.sum_singleton]
   ring
 
 /-! ### Additional Properties -/

--- a/Mathlib/NumberTheory/UnitaryDivisor.lean
+++ b/Mathlib/NumberTheory/UnitaryDivisor.lean
@@ -3,10 +3,12 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-import Mathlib.NumberTheory.Divisors
-import Mathlib.NumberTheory.ArithmeticFunction.Defs
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Algebra.BigOperators.Ring.Finset
+module
+
+public import Mathlib.NumberTheory.Divisors
+public import Mathlib.NumberTheory.ArithmeticFunction.Defs
+public import Mathlib.Data.Nat.GCD.Basic
+public import Mathlib.Algebra.BigOperators.Ring.Finset
 
 /-!
 # Unitary Divisors and the Unitary Divisor Sum Function
@@ -27,6 +29,7 @@ Note: In group theory, unitary divisors are also known as *Hall divisors*.
 
 ## Main Results
 
+* `Nat.isMultiplicative_unitaryDivisorSum`: The function `σ*` is multiplicative.
 * `Nat.unitaryDivisorSum_mul`: Multiplicativity of `σ*` for coprime arguments.
 * `Nat.unitaryDivisorSum_prime_pow`: For prime `p` and `k ≥ 1`, `σ*(p^k) = p^k + 1`.
 * `Nat.unitaryDivisors_prime_pow`: The unitary divisors of `p^k` are exactly `{1, p^k}`.
@@ -66,19 +69,20 @@ def UnitaryDivisor (d n : ℕ) : Prop :=
 def unitaryDivisors (n : ℕ) : Finset ℕ :=
   (Nat.divisors n).filter fun d => Nat.gcd d (n / d) = 1
 
-/-- Helper function: sum of unitary divisors as a plain function. -/
-private def unitaryDivisorSumAux (n : ℕ) : ℕ :=
-  ∑ d ∈ unitaryDivisors n, d
+/-- The unitary divisor sum function `σ*(n)`, equal to the sum of all unitary divisors.
 
-/-- The unitary divisor sum function `σ*` as an ArithmeticFunction.
-This is the sum of all unitary divisors of `n`. -/
-def unitaryDivisorSum : ArithmeticFunction ℕ where
-  toFun := unitaryDivisorSumAux
-  map_zero' := by
-    unfold unitaryDivisorSumAux unitaryDivisors
-    simp [Nat.divisors_zero]
+This is defined as an `ArithmeticFunction` to integrate with mathlib's framework for
+multiplicative arithmetic functions. -/
+def unitaryDivisorSum : ArithmeticFunction ℕ :=
+  ⟨fun n => ∑ d ∈ unitaryDivisors n, d, by simp [unitaryDivisors]⟩
 
-@[inherit_doc] scoped notation "σ*" => unitaryDivisorSum
+@[inherit_doc]
+scoped[ArithmeticFunction.UnitaryDivisorSum] notation "σ*" => Nat.unitaryDivisorSum
+
+open scoped ArithmeticFunction.UnitaryDivisorSum
+
+/-- The unitary divisor sum of `n` equals the sum over unitary divisors. -/
+theorem unitaryDivisorSum_apply (n : ℕ) : σ* n = ∑ d ∈ unitaryDivisors n, d := rfl
 
 /-! ### Basic Properties -/
 
@@ -197,8 +201,7 @@ pairs `(d₁, d₂)` of unitary divisors of `m` and `n` respectively. The biject
 `d ↦ (gcd(d,m), gcd(d,n))` with inverse `(d₁, d₂) ↦ d₁ * d₂`. -/
 theorem unitaryDivisorSum_mul {m n : ℕ} (hcoprime : Nat.Coprime m n) (hm : m ≠ 0) (hn : n ≠ 0) :
     σ* (m * n) = σ* m * σ* n := by
-  change unitaryDivisorSumAux (m * n) = unitaryDivisorSumAux m * unitaryDivisorSumAux n
-  unfold unitaryDivisorSumAux
+  simp only [unitaryDivisorSum_apply]
   let i : ℕ → ℕ × ℕ := fun d => (Nat.gcd d m, Nat.gcd d n)
   let j : ℕ × ℕ → ℕ := fun p => p.1 * p.2
   have h_sum_bij : ∑ d ∈ unitaryDivisors (m * n), d =
@@ -329,9 +332,7 @@ theorem unitaryDivisors_prime_pow {p k : ℕ} (hp : Nat.Prime p) :
 theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0) :
     σ* (p ^ k) = p ^ k + 1 := by
   have hk_pos : 0 < k := Nat.pos_of_ne_zero hk
-  change unitaryDivisorSumAux (p ^ k) = p ^ k + 1
-  unfold unitaryDivisorSumAux
-  rw [unitaryDivisors_prime_pow hp]
+  simp only [unitaryDivisorSum_apply, unitaryDivisors_prime_pow hp]
   have h_ne : 1 ≠ p ^ k := by
     intro h_eq
     have hp_ge : p ≥ 2 := hp.two_le
@@ -339,7 +340,7 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
       calc p ^ k ≥ p ^ 1 := Nat.pow_le_pow_right hp.pos hk_pos
         _ = p := pow_one p
     omega
-  simp only [Finset.sum_insert (notMem_singleton.mpr h_ne), Finset.sum_singleton]
+  simp only [Finset.sum_insert (Finset.notMem_singleton.mpr h_ne), Finset.sum_singleton]
   ac_rfl
 
 /-! ### Additional Properties -/
@@ -347,22 +348,14 @@ theorem unitaryDivisorSum_prime_pow {p k : ℕ} (hp : Nat.Prime p) (hk : k ≠ 0
 /-- `σ*(1) = 1`. -/
 @[simp]
 theorem unitaryDivisorSum_one : σ* 1 = 1 := by
-  change unitaryDivisorSumAux 1 = 1
-  unfold unitaryDivisorSumAux unitaryDivisors
-  simp only [Nat.divisors_one, Finset.filter_singleton, Nat.gcd_self,
-    ite_true, Finset.sum_singleton]
+  simp only [unitaryDivisorSum_apply, unitaryDivisors, Nat.divisors_one,
+    Finset.filter_singleton, Nat.gcd_self, ite_true, Finset.sum_singleton]
 
-/-- The unitary divisor sum function σ* is multiplicative. -/
-theorem unitaryDivisorSum_isMultiplicative : σ*.IsMultiplicative := by
-  constructor
-  · -- σ*(1) = 1
-    exact unitaryDivisorSum_one
-  · -- For coprime m, n: σ*(m*n) = σ*(m) * σ*(n)
-    intro m n hcoprime
-    by_cases hm : m = 0
-    · simp [hm]
-    by_cases hn : n = 0
-    · simp [hn]
-    exact unitaryDivisorSum_mul hcoprime hm hn
+/-- The unitary divisor sum function is multiplicative. -/
+@[arith_mult]
+theorem isMultiplicative_unitaryDivisorSum : ArithmeticFunction.IsMultiplicative σ* := by
+  refine ArithmeticFunction.IsMultiplicative.iff_ne_zero.mpr ⟨unitaryDivisorSum_one, ?_⟩
+  intro m n hm hn hcoprime
+  exact unitaryDivisorSum_mul hcoprime hm hn
 
 end Nat

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -6,7 +6,6 @@ Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 import Mathlib.NumberTheory.UnitaryDivisor
 import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Nat.Factorization.Induction
-import Mathlib.Tactic
 
 /-!
 # Unitary Perfect Numbers
@@ -72,12 +71,13 @@ theorem unitaryDivisorSum_odd_even {n : ℕ} (hn : 1 < n) (hodd : Odd n) : Even 
     have hp_odd : Odd p := by
       rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
       · subst hp_2
-        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp at hn
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hn
         have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
         exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
       · exact Nat.odd_iff.mpr hp_mod
     have hk_pos : 0 < k := by
-      by_contra hk0; simp at hk0; subst hk0; simp at hn
+      by_contra hk0; simp only [not_lt, nonpos_iff_eq_zero] at hk0; subst hk0
+      simp only [pow_zero] at hn
     exact unitaryDivisorSum_odd_prime_pow_even hp_prime hp_odd hk_pos
   | h a b ha hb hcoprime iha ihb =>
     have ha_pos : a ≠ 0 := by omega
@@ -128,11 +128,12 @@ theorem no_odd_unitary_perfect {n : ℕ} (hodd : Odd n) (hgt1 : n > 1) : ¬Unita
     have hp_odd : Odd p := by
       rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
       · subst hp_2
-        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp at hgt1
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hgt1
         have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
         exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
       · exact Nat.odd_iff.mpr hp_mod
-    have hk_pos : 0 < k := by by_contra hk0; simp at hk0; subst hk0; simp at hgt1
+    have hk_pos : 0 < k := by by_contra hk0; simp only [not_lt, nonpos_iff_eq_zero] at hk0
+      subst hk0; simp only [pow_zero] at hgt1
     have hk_ne : k ≠ 0 := Nat.pos_iff_ne_zero.mp hk_pos
     rw [unitaryDivisorSum_prime_pow hp_prime hk_ne] at hup
     have hp_ge_3 : p ≥ 3 := by

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -66,20 +66,20 @@ theorem unitaryDivisorSum_odd_prime_pow_even {p k : ℕ} (hp : Nat.Prime p) (hod
 /-- For any odd `n > 1`, `σ*(n)` is even. -/
 theorem unitaryDivisorSum_odd_even {n : ℕ} (hn : 1 < n) (hodd : Odd n) : Even (σ* n) := by
   induction n using Nat.recOnPrimeCoprime with
-  | h0 => omega
-  | hp p k hp_prime =>
+  | zero => omega
+  | prime_pow p k hp_prime =>
     have hp_odd : Odd p := by
       rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
       · subst hp_2
-        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hn
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hn; omega
         have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
         exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
       · exact Nat.odd_iff.mpr hp_mod
     have hk_pos : 0 < k := by
       by_contra hk0; simp only [not_lt, nonpos_iff_eq_zero] at hk0; subst hk0
-      simp only [pow_zero] at hn
+      simp only [pow_zero] at hn; omega
     exact unitaryDivisorSum_odd_prime_pow_even hp_prime hp_odd hk_pos
-  | h a b ha hb hcoprime iha ihb =>
+  | coprime a b ha hb hcoprime iha ihb =>
     have ha_pos : a ≠ 0 := by omega
     have hb_pos : b ≠ 0 := by omega
     rw [unitaryDivisorSum_mul hcoprime ha_pos hb_pos]
@@ -98,7 +98,9 @@ theorem unitaryDivisorSum_coprime_four_dvd {a b : ℕ} (ha : 1 < a) (hb : 1 < b)
   obtain ⟨y, hy⟩ := hsb_even
   use x * y
   calc σ* a * σ* b = (x + x) * (y + y) := by rw [hx, hy]
-    _ = 4 * (x * y) := by ring
+    _ = (2 * x) * (2 * y) := by rw [two_mul, two_mul]
+    _ = 2 * 2 * (x * y) := by ac_rfl
+    _ = 4 * (x * y) := by rfl
 
 /-- `4` does not divide `2*n` when `n` is odd. -/
 theorem four_not_dvd_two_mul_odd {n : ℕ} (hodd : Odd n) : ¬(4 ∣ 2 * n) := by
@@ -123,17 +125,21 @@ factorization structure using `Nat.recOnPrimeCoprime`:
 theorem no_odd_unitary_perfect {n : ℕ} (hodd : Odd n) (hgt1 : n > 1) : ¬UnitaryPerfect n := by
   intro ⟨hn0, hup⟩
   induction n using Nat.recOnPrimeCoprime with
-  | h0 => omega
-  | hp p k hp_prime =>
+  | zero => omega
+  | prime_pow p k hp_prime =>
     have hp_odd : Odd p := by
       rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
       · subst hp_2
-        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hgt1
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp only [pow_zero] at hgt1; omega
         have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
         exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
       · exact Nat.odd_iff.mpr hp_mod
-    have hk_pos : 0 < k := by by_contra hk0; simp only [not_lt, nonpos_iff_eq_zero] at hk0
-      subst hk0; simp only [pow_zero] at hgt1
+    have hk_pos : 0 < k := by
+      by_contra hk0
+      simp only [not_lt, nonpos_iff_eq_zero] at hk0
+      subst hk0
+      simp only [pow_zero] at hgt1
+      omega
     have hk_ne : k ≠ 0 := Nat.pos_iff_ne_zero.mp hk_pos
     rw [unitaryDivisorSum_prime_pow hp_prime hk_ne] at hup
     have hp_ge_3 : p ≥ 3 := by
@@ -146,7 +152,7 @@ theorem no_odd_unitary_perfect {n : ℕ} (hodd : Odd n) (hgt1 : n > 1) : ¬Unita
         _ = p := pow_one p
     have : p ^ k ≥ 3 := by omega
     omega
-  | h a b ha hb hcoprime _ _ =>
+  | coprime a b ha hb hcoprime _ _ =>
     have ⟨ha_odd, hb_odd⟩ := Nat.odd_mul.mp hodd
     have h4dvd : 4 ∣ σ* (a * b) := unitaryDivisorSum_coprime_four_dvd ha hb hcoprime ha_odd hb_odd
     have h4_dvd_2n : 4 ∣ 2 * (a * b) := by rw [← hup]; exact h4dvd
@@ -177,7 +183,8 @@ theorem UnitaryPerfect.eq_two_pow_mul_odd {n : ℕ} (h : UnitaryPerfect n) :
   refine ⟨a, k, ?_, hk_odd, hdecomp⟩
   by_contra ha_zero
   push_neg at ha_zero
-  interval_cases a
+  have : a = 0 := by omega
+  subst this
   rw [hdecomp, pow_zero, one_mul] at heven
   exact absurd hk_odd (Nat.not_odd_iff_even.mpr heven)
 

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -3,11 +3,9 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-module
-
-public import Mathlib.NumberTheory.UnitaryDivisor
-public import Mathlib.Data.Nat.Factorization.Basic
-public import Mathlib.Data.Nat.Factorization.Induction
+import Mathlib.NumberTheory.UnitaryDivisor
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Induction
 
 /-!
 # Unitary Perfect Numbers
@@ -49,6 +47,7 @@ unitary perfect number, perfect number, number theory
 namespace Nat
 
 open BigOperators
+open scoped ArithmeticFunction.UnitaryDivisorSum
 
 /-! ### Definition -/
 

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -3,9 +3,11 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-import Mathlib.NumberTheory.UnitaryDivisor
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.Data.Nat.Factorization.Induction
+module
+
+public import Mathlib.NumberTheory.UnitaryDivisor
+public import Mathlib.Data.Nat.Factorization.Basic
+public import Mathlib.Data.Nat.Factorization.Induction
 
 /-!
 # Unitary Perfect Numbers
@@ -41,6 +43,8 @@ divisible by exactly 2.
 
 unitary perfect number, perfect number, number theory
 -/
+
+@[expose] public section
 
 namespace Nat
 

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
+-/
+import Mathlib.NumberTheory.UnitaryDivisor
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Induction
+import Mathlib.Tactic
+
+/-!
+# Unitary Perfect Numbers
+
+This file defines unitary perfect numbers and proves that no odd unitary perfect numbers exist.
+
+A positive integer `n` is *unitary perfect* if `σ*(n) = 2n`, where `σ*` is the unitary divisor
+sum function. This is analogous to the classical definition of perfect numbers using `σ(n) = 2n`.
+
+The main result is that all unitary perfect numbers are even, proved by showing that `σ*(n)` for
+odd `n > 1` is always even, and for odd composite `n`, `σ*(n)` is divisible by 4, while `2n` is
+divisible by exactly 2.
+
+## Main Definitions
+
+* `Nat.UnitaryPerfect n`: Predicate stating that `n` is a unitary perfect number.
+
+## Main Results
+
+* `Nat.no_odd_unitary_perfect`: There are no odd unitary perfect numbers greater than 1.
+* `Nat.UnitaryPerfect.even`: Every unitary perfect number is even.
+* `Nat.UnitaryPerfect.eq_two_pow_mul_odd`: Every unitary perfect number has the form `2^a * k`
+  where `a ≥ 1` and `k` is odd.
+
+## References
+
+* Subbarao, M. V., & Warren, L. J. (1966). Unitary perfect numbers.
+  Canadian Mathematical Bulletin, 9(2), 147-153.
+* Wall, C. R. (1975). The fifth unitary perfect number.
+  Canadian Mathematical Bulletin, 18(1), 115-122.
+
+## Tags
+
+unitary perfect number, perfect number, number theory
+-/
+
+namespace Nat
+
+open BigOperators
+
+/-! ### Definition -/
+
+/-- A positive integer `n` is *unitary perfect* if `σ*(n) = 2n`. -/
+def UnitaryPerfect (n : ℕ) : Prop :=
+  n ≠ 0 ∧ σ* n = 2 * n
+
+/-! ### Parity Lemmas -/
+
+/-- `σ*(p^k)` is even when `p` is odd and `k ≥ 1`. -/
+theorem unitaryDivisorSum_odd_prime_pow_even {p k : ℕ} (hp : Nat.Prime p) (hodd : Odd p)
+    (hk : 0 < k) : Even (σ* (p ^ k)) := by
+  have hk_ne : k ≠ 0 := Nat.pos_iff_ne_zero.mp hk
+  rw [unitaryDivisorSum_prime_pow hp hk_ne]
+  have hp_odd_pow : Odd (p ^ k) := Odd.pow hodd
+  rw [Nat.even_add_one]
+  exact Nat.not_even_iff_odd.symm.mp hp_odd_pow
+
+/-- For any odd `n > 1`, `σ*(n)` is even. -/
+theorem unitaryDivisorSum_odd_even {n : ℕ} (hn : 1 < n) (hodd : Odd n) : Even (σ* n) := by
+  induction n using Nat.recOnPrimeCoprime with
+  | h0 => omega
+  | hp p k hp_prime =>
+    have hp_odd : Odd p := by
+      rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
+      · subst hp_2
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp at hn
+        have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
+        exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
+      · exact Nat.odd_iff.mpr hp_mod
+    have hk_pos : 0 < k := by
+      by_contra hk0; simp at hk0; subst hk0; simp at hn
+    exact unitaryDivisorSum_odd_prime_pow_even hp_prime hp_odd hk_pos
+  | h a b ha hb hcoprime iha ihb =>
+    have ha_pos : a ≠ 0 := by omega
+    have hb_pos : b ≠ 0 := by omega
+    rw [unitaryDivisorSum_mul hcoprime ha_pos hb_pos]
+    have ⟨ha_odd, hb_odd⟩ := Nat.odd_mul.mp hodd
+    exact Even.mul_right (iha ha ha_odd) (σ* b)
+
+/-- For odd `n = a*b` with coprime `a, b > 1`, we have `4 ∣ σ*(n)`. -/
+theorem unitaryDivisorSum_coprime_four_dvd {a b : ℕ} (ha : 1 < a) (hb : 1 < b)
+    (hcoprime : Nat.Coprime a b) (ha_odd : Odd a) (hb_odd : Odd b) : 4 ∣ σ* (a * b) := by
+  have ha_pos : a ≠ 0 := by omega
+  have hb_pos : b ≠ 0 := by omega
+  rw [unitaryDivisorSum_mul hcoprime ha_pos hb_pos]
+  have hsa_even : Even (σ* a) := unitaryDivisorSum_odd_even ha ha_odd
+  have hsb_even : Even (σ* b) := unitaryDivisorSum_odd_even hb hb_odd
+  obtain ⟨x, hx⟩ := hsa_even
+  obtain ⟨y, hy⟩ := hsb_even
+  use x * y
+  calc σ* a * σ* b = (x + x) * (y + y) := by rw [hx, hy]
+    _ = 4 * (x * y) := by ring
+
+/-- `4` does not divide `2*n` when `n` is odd. -/
+theorem four_not_dvd_two_mul_odd {n : ℕ} (hodd : Odd n) : ¬(4 ∣ 2 * n) := by
+  intro h4dvd
+  obtain ⟨k, hk⟩ := h4dvd
+  have heven : Even n := ⟨k, by omega⟩
+  exact Nat.not_even_iff_odd.symm.mp hodd heven
+
+/-! ### Main Theorem -/
+
+/-- **No odd unitary perfect numbers exist**.
+
+This is the main theorem of the file. The proof proceeds by induction on the prime
+factorization structure using `Nat.recOnPrimeCoprime`:
+
+1. **Prime power case** (`n = p^k`): If `p` is odd, then `σ*(p^k) = p^k + 1`. The equation
+   `p^k + 1 = 2p^k` implies `p^k = 1`, which is impossible for `p ≥ 3`.
+
+2. **Coprime product case** (`n = a*b`): Both `a` and `b` must be odd (since `n` is odd).
+   By the parity lemma, both `σ*(a)` and `σ*(b)` are even, so `σ*(n) = σ*(a)σ*(b)` is
+   divisible by 4. But `2n` is divisible by exactly 2 (since `n` is odd), contradiction. -/
+theorem no_odd_unitary_perfect {n : ℕ} (hodd : Odd n) (hgt1 : n > 1) : ¬UnitaryPerfect n := by
+  intro ⟨hn0, hup⟩
+  induction n using Nat.recOnPrimeCoprime with
+  | h0 => omega
+  | hp p k hp_prime =>
+    have hp_odd : Odd p := by
+      rcases hp_prime.eq_two_or_odd with hp_2 | hp_mod
+      · subst hp_2
+        have hk_ne : k ≠ 0 := by intro hk0; subst hk0; simp at hgt1
+        have heven : Even ((2 : ℕ) ^ k) := Even.pow_of_ne_zero even_two hk_ne
+        exact absurd heven (Nat.not_even_iff_odd.symm.mp hodd)
+      · exact Nat.odd_iff.mpr hp_mod
+    have hk_pos : 0 < k := by by_contra hk0; simp at hk0; subst hk0; simp at hgt1
+    have hk_ne : k ≠ 0 := Nat.pos_iff_ne_zero.mp hk_pos
+    rw [unitaryDivisorSum_prime_pow hp_prime hk_ne] at hup
+    have hp_ge_3 : p ≥ 3 := by
+      have := hp_prime.two_le
+      have hp_ne_2 : p ≠ 2 := fun h => by
+        subst h; exact Nat.not_even_iff_odd.symm.mp hp_odd even_two
+      omega
+    have hpk_ge : p ^ k ≥ p := by
+      calc p ^ k ≥ p ^ 1 := Nat.pow_le_pow_right hp_prime.pos hk_pos
+        _ = p := pow_one p
+    have : p ^ k ≥ 3 := by omega
+    omega
+  | h a b ha hb hcoprime _ _ =>
+    have ⟨ha_odd, hb_odd⟩ := Nat.odd_mul.mp hodd
+    have h4dvd : 4 ∣ σ* (a * b) := unitaryDivisorSum_coprime_four_dvd ha hb hcoprime ha_odd hb_odd
+    have h4_dvd_2n : 4 ∣ 2 * (a * b) := by rw [← hup]; exact h4dvd
+    exact four_not_dvd_two_mul_odd hodd h4_dvd_2n
+
+/-- Every unitary perfect number is even. -/
+theorem UnitaryPerfect.even {n : ℕ} (h : UnitaryPerfect n) : Even n := by
+  rcases Nat.even_or_odd n with heven | hodd
+  · exact heven
+  · obtain ⟨hn0, hsum⟩ := h
+    by_cases hn_eq_1 : n = 1
+    · rw [hn_eq_1, unitaryDivisorSum_one] at hsum
+      omega
+    · have hgt1 : n > 1 := by
+        rcases n with _ | n'
+        · exact absurd rfl hn0
+        · rcases n' with _ | _
+          · exact absurd rfl hn_eq_1
+          · omega
+      exact absurd ⟨hn0, hsum⟩ (no_odd_unitary_perfect hodd hgt1)
+
+/-- Every unitary perfect number can be written as `2^a * k` where `a ≥ 1` and `k` is odd. -/
+theorem UnitaryPerfect.eq_two_pow_mul_odd {n : ℕ} (h : UnitaryPerfect n) :
+    ∃ a k : ℕ, a ≥ 1 ∧ Odd k ∧ n = 2 ^ a * k := by
+  have heven := h.even
+  obtain ⟨hn0, _⟩ := h
+  obtain ⟨a, k, hk_odd, hdecomp⟩ := Nat.exists_eq_two_pow_mul_odd hn0
+  refine ⟨a, k, ?_, hk_odd, hdecomp⟩
+  by_contra ha_zero
+  push_neg at ha_zero
+  interval_cases a
+  rw [hdecomp, pow_zero, one_mul] at heven
+  exact absurd hk_odd (Nat.not_odd_iff_even.mpr heven)
+
+end Nat

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -3,11 +3,9 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-module
-
-public import Mathlib.NumberTheory.UnitaryDivisor
-public import Mathlib.Data.Nat.Factorization.Basic
-public import Mathlib.Data.Nat.Factorization.Induction
+import Mathlib.NumberTheory.UnitaryDivisor
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Induction
 
 /-!
 # Unitary Perfect Numbers
@@ -29,8 +27,8 @@ divisible by exactly 2.
 
 * `Nat.no_odd_unitary_perfect`: There are no odd unitary perfect numbers greater than 1.
 * `Nat.UnitaryPerfect.even`: Every unitary perfect number is even.
-* `Nat.UnitaryPerfect.eq_two_pow_mul_odd`: Every unitary perfect number has the form `2^a * k`
-  where `a ≥ 1` and `k` is odd.
+* `Nat.UnitaryPerfect.structure_divides_odd_part`: If `m = 2^a × M` is a UPN with `M` odd,
+  then `(1 + 2^a) ∣ M`.
 
 ## References
 
@@ -47,9 +45,6 @@ unitary perfect number, perfect number, number theory
 @[expose] public section
 
 namespace Nat
-
-open BigOperators
-open scoped ArithmeticFunction.UnitaryDivisorSum
 
 /-! ### Definition -/
 
@@ -168,29 +163,56 @@ theorem UnitaryPerfect.even {n : ℕ} (h : UnitaryPerfect n) : Even n := by
   rcases Nat.even_or_odd n with heven | hodd
   · exact heven
   · obtain ⟨hn0, hsum⟩ := h
-    by_cases hn_eq_1 : n = 1
-    · rw [hn_eq_1, unitaryDivisorSum_one] at hsum
+    cases (one_le_iff_ne_zero.mpr hn0).eq_or_lt' with
+    | inl hn_eq_1 =>
+      rw [hn_eq_1, unitaryDivisorSum_one] at hsum
       omega
-    · have hgt1 : n > 1 := by
-        rcases n with _ | n'
-        · exact absurd rfl hn0
-        · rcases n' with _ | _
-          · exact absurd rfl hn_eq_1
-          · omega
+    | inr hgt1 =>
       exact absurd ⟨hn0, hsum⟩ (no_odd_unitary_perfect hodd hgt1)
 
-/-- Every unitary perfect number can be written as `2^a * k` where `a ≥ 1` and `k` is odd. -/
-theorem UnitaryPerfect.eq_two_pow_mul_odd {n : ℕ} (h : UnitaryPerfect n) :
-    ∃ a k : ℕ, a ≥ 1 ∧ Odd k ∧ n = 2 ^ a * k := by
-  have heven := h.even
-  obtain ⟨hn0, _⟩ := h
-  obtain ⟨a, k, hk_odd, hdecomp⟩ := Nat.exists_eq_two_pow_mul_odd hn0
-  refine ⟨a, k, ?_, hk_odd, hdecomp⟩
-  by_contra ha_zero
-  push_neg at ha_zero
-  have : a = 0 := by omega
-  subst this
-  rw [hdecomp, pow_zero, one_mul] at heven
-  exact absurd hk_odd (Nat.not_odd_iff_even.mpr heven)
+/-! ### Structural Constraints -/
+
+/-- **Structural Divisibility Theorem**: If `m = 2^a × M` is a unitary perfect number
+with `M` odd and `a ≥ 1`, then `(1 + 2^a)` divides `M`.
+
+This is a key structural constraint on unitary perfect numbers. It follows from the
+multiplicativity of `σ*` and the UPN equation `σ*(m) = 2m`:
+
+From `σ*(2^a × M) = σ*(2^a) × σ*(M) = (1 + 2^a) × σ*(M) = 2 × 2^a × M = 2^{a+1} × M`,
+we get `(1 + 2^a) × σ*(M) = 2^{a+1} × M`, which implies `(1 + 2^a) | M`. -/
+theorem UnitaryPerfect.structure_divides_odd_part
+    (a M : ℕ) (hM : Odd M) (ha : a ≠ 0)
+    (h : σ* (2 ^ a * M) = 2 * (2 ^ a * M)) :
+    (1 + 2 ^ a) ∣ M := by
+  have hM0 : M ≠ 0 := Odd.pos hM |>.ne'
+  have h2a0 : 2 ^ a ≠ 0 := pow_ne_zero _ (by norm_num)
+  have hcop : Nat.Coprime (2 ^ a) M :=
+    Nat.Coprime.pow_left a (Odd.coprime_two_left hM)
+  have hmul : σ* (2 ^ a * M) = σ* (2 ^ a) * σ* M :=
+    unitaryDivisorSum_mul hcop h2a0 hM0
+  have htwo : σ* (2 ^ a) = 1 + 2 ^ a := by
+    rw [unitaryDivisorSum_prime_pow Nat.prime_two ha]
+    ring
+  -- From the equations: (1 + 2^a) × σ*(M) = 2^{a+1} × M
+  have hdiv_eq : (1 + 2 ^ a) * σ* M = 2 ^ (a + 1) * M := by
+    calc (1 + 2 ^ a) * σ* M = σ* (2 ^ a) * σ* M := by rw [htwo]
+      _ = σ* (2 ^ a * M) := hmul.symm
+      _ = 2 * (2 ^ a * M) := h
+      _ = 2 ^ (a + 1) * M := by ring
+  -- So (1 + 2^a) | M × 2^{a+1}
+  have hdiv' : (1 + 2 ^ a) ∣ M * 2 ^ (a + 1) := by
+    use σ* M
+    calc M * 2 ^ (a + 1) = 2 ^ (a + 1) * M := by ring
+      _ = (1 + 2 ^ a) * σ* M := hdiv_eq.symm
+  -- Since gcd(1 + 2^a, 2^{a+1}) = 1 (as 1 + 2^a is odd), we have (1 + 2^a) | M
+  have hcop2a : Nat.Coprime (1 + 2 ^ a) (2 ^ (a + 1)) := by
+    have h_odd : Odd (1 + 2 ^ a) := by
+      have heven : Even (2 ^ a) := Even.pow_of_ne_zero (by decide) ha
+      have : 2 ^ a + 1 = 1 + 2 ^ a := by ring
+      rw [← this]
+      exact Even.add_one heven
+    have hcop2 : Nat.Coprime 2 (1 + 2 ^ a) := Odd.coprime_two_left h_odd
+    exact Nat.Coprime.pow_right _ hcop2.symm
+  exact Nat.Coprime.dvd_of_dvd_mul_right hcop2a hdiv'
 
 end Nat

--- a/Mathlib/NumberTheory/UnitaryPerfect.lean
+++ b/Mathlib/NumberTheory/UnitaryPerfect.lean
@@ -3,9 +3,11 @@ Copyright (c) 2025 Zhipeng Chen, Haolun Tang, Jing Yi Zhan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhipeng Chen, Haolun Tang, Jing Yi Zhan
 -/
-import Mathlib.NumberTheory.UnitaryDivisor
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.Data.Nat.Factorization.Induction
+module
+
+public import Mathlib.NumberTheory.UnitaryDivisor
+public import Mathlib.Data.Nat.Factorization.Basic
+public import Mathlib.Data.Nat.Factorization.Induction
 
 /-!
 # Unitary Perfect Numbers


### PR DESCRIPTION
## Summary

This PR introduces the unitary divisor sum function σ* to Mathlib and proves that no odd unitary perfect numbers exist.

## Main Definitions

- `Nat.UnitaryDivisor d n`: A divisor `d` of `n` is unitary if `gcd(d, n/d) = 1`
- `Nat.unitaryDivisors n`: The `Finset` of all unitary divisors of `n`
- `Nat.unitaryDivisorSum n` (notation `σ*`): Sum of all unitary divisors
- `Nat.UnitaryPerfect n`: `n` is unitary perfect if `σ*(n) = 2n`

## Main Theorems

**Multiplicativity:**
- `unitaryDivisorSum_mul`: For coprime `m`, `n`, `σ*(mn) = σ*(m) · σ*(n)`
  - Proved via explicit bijection between unitary divisors of `mn` and pairs of unitary divisors

**Prime Powers:**
- `unitaryDivisors_prime_pow`: The unitary divisors of `p^k` are exactly `{1, p^k}`
- `unitaryDivisorSum_prime_pow`: For prime `p` and `k ≥ 1`, `σ*(p^k) = p^k + 1`

**Unitary Perfect Numbers:**
- `no_odd_unitary_perfect`: There are no odd unitary perfect numbers > 1 (Subbarao-Warren 1966)
- `UnitaryPerfect.even`: Every unitary perfect number is even
- `UnitaryPerfect.eq_two_pow_mul_odd`: Every unitary perfect number has form `2^a · k` with `a ≥ 1`, `k` odd

## Mathematical Background

A unitary perfect number is a positive integer `n` such that the sum of its unitary divisors equals `2n`. This generalizes the classical perfect numbers. Only five unitary perfect numbers are known: 6, 60, 90, 87360, and one with 24 digits.

The main theorem (no odd unitary perfect numbers) was originally proved by Subbarao & Warren (1966) using prime factorization arguments. Our formalization uses `Nat.recOnPrimeCoprime` for structural induction.

## References

- Subbarao, M. V., & Warren, L. J. (1966). Unitary perfect numbers. *Canadian Mathematical Bulletin*, 9(2), 147-153.
- Wall, C. R. (1975). The fifth unitary perfect number. *Canadian Mathematical Bulletin*, 18(1), 115-122.

## Code Statistics

- **Files**: 2
- **Lines**: ~520
- **Theorems**: 21 public declarations
- **Sorry count**: 0

## Checklist

- [x] All theorem names follow mathlib conventions
- [x] All lines ≤ 100 characters
- [x] All public theorems have docstrings
- [x] No `sorry` or `admit`
- [x] Code builds successfully
- [ ] CI tests pass (awaiting verification)