### PR TITLE
[Merged by Bors] - perf(CategoryTheory/Limits/Pullback/Categorical/Basic): abstract `CatCommSqOver`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -221,7 +221,7 @@ namespace CatCommSqOver
 /-- The Hom types for the categorical commutative squares over X are given by pairs of natural
 transformations compatible with the structural isomorphisms. -/
 @[ext]
-structure Hom (x y : (CatCommSqOver F G X)) where
+structure Hom (x y : CatCommSqOver F G X) where
   /-- the first component of `f : Hom x y` is a morphism `x.fst ⟶ y.fst` -/
   fst : x.fst ⟶ y.fst
   /-- the second component of `f : Hom x y` is a morphism `x.snd ⟶ y.snd` -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -467,7 +467,7 @@ variable {A₁ : Type u₄} {B₁ : Type u₅} {C₁ : Type u₆}
 
 /-- Functorially transform a `CatCommSqOver F G X` by whiskering it with a
 `CatCospanTransform`. -/
-@[simps]
+@[simps!]
 def transform (X : Type u₇) [Category.{v₇} X] :
     CatCospanTransform F G F₁ G₁ ⥤
       CatCommSqOver F G X ⥤ CatCommSqOver F₁ G₁ X where
@@ -513,10 +513,11 @@ of `CatCospanTransform`s. -/
 def transformObjComp (X : Type u₁₀) [Category.{v₁₀} X]
     (ψ : CatCospanTransform F G F₁ G₁) (ψ' : CatCospanTransform F₁ G₁ F₂ G₂) :
     (transform X).obj (ψ.comp ψ') ≅ (transform X).obj ψ ⋙ (transform X).obj ψ' :=
-  NatIso.ofComponents fun _ =>
+  NatIso.ofComponents (fun _ =>
     CatCommSqOver.mkIso
       (Functor.associator _ _ _).symm
-      (Functor.associator _ _ _).symm
+      (Functor.associator _ _ _).symm)
+    (fun {x y} f ↦ by ext <;> simp)
 
 /-- The construction `CatCommSqOver.transform` respects the identity
 `CatCospanTransform`s. -/
@@ -596,7 +597,7 @@ variable
 /-- A functor `U : X ⥤ Y` (functorially) induces a functor
 `CatCommSqOver F G Y ⥤ CatCommSqOver F G X` by whiskering left the underlying
 categorical commutative square by U. -/
-@[simps]
+@[simps!]
 def precompose :
     (X ⥤ Y) ⥤ CatCommSqOver F G Y ⥤ CatCommSqOver F G X where
   obj U :=
@@ -697,10 +698,11 @@ instance precomposeObjTransformObjSquare
     CatCommSq
       (precompose F G |>.obj U) (transform Y |>.obj ψ)
       (transform X |>.obj ψ) (precompose F₁ G₁ |>.obj U) where
-  iso := NatIso.ofComponents fun _ =>
+  iso := NatIso.ofComponents (fun _ =>
     CatCommSqOver.mkIso
       (Functor.associator _ _ _)
-      (Functor.associator _ _ _)
+      (Functor.associator _ _ _))
+    (fun {x y} f ↦ by ext <;> simp)
 
 -- Compare the next 3 lemmas with the components of a strong natural transform
 -- of pseudofunctors
@@ -758,10 +760,11 @@ instance transformObjPrecomposeObjSquare
     CatCommSq
       (transform Y |>.obj ψ) (precompose F G |>.obj U)
       (precompose F₁ G₁ |>.obj U) (transform X |>.obj ψ) where
-  iso := NatIso.ofComponents fun _ =>
+  iso := NatIso.ofComponents (fun _ =>
     CatCommSqOver.mkIso
       (Functor.associator _ _ _).symm
-      (Functor.associator _ _ _).symm
+      (Functor.associator _ _ _).symm)
+    (fun {x y} f ↦ by ext <;> simp)
 
 -- Compare the next 3 lemmas with the components of a strong natural transform
 -- of pseudofunctors

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -232,6 +232,7 @@ structure Hom (x y : CatCommSqOver F G X) where
 
 attribute [reassoc (attr := simp)] Hom.w
 
+@[simps! id_fst_app id_snd_app comp_fst_app comp_snd_app]
 instance : Category (CatCommSqOver F G X) where
   Hom x y := CatCommSqOver.Hom X x y
   id x :=
@@ -243,26 +244,8 @@ instance : Category (CatCommSqOver F G X) where
 
 @[ext]
 lemma hom_ext {S S' : CatCommSqOver F G X} {f g : S ⟶ S'}
-    (h₁ : f.fst = g.fst) (h₂ : f.snd = g.snd) : f = g := by
-  cases f
-  cases g
-  grind
-
-@[simp]
-lemma id_fst_app (S : CatCommSqOver F G X) (x : X) : (𝟙 S : S ⟶ S).fst.app x = 𝟙 _ := rfl
-
-@[simp]
-lemma id_snd_app (S : CatCommSqOver F G X) (x : X) : (𝟙 S : S ⟶ S).snd.app x = 𝟙 _ := rfl
-
-@[simp, reassoc]
-lemma comp_fst_app {S S' S'' : CatCommSqOver F G X} (f : S ⟶ S') (g : S' ⟶ S'') (x : X) :
-    (f ≫ g).fst.app x = f.fst.app x ≫ g.fst.app x :=
-  rfl
-
-@[simp, reassoc]
-lemma comp_snd_app {S S' S'' : CatCommSqOver F G X} (f : S ⟶ S') (g : S' ⟶ S'') (x : X) :
-    (f ≫ g).snd.app x = f.snd.app x ≫ g.snd.app x :=
-  rfl
+    (h₁ : f.fst = g.fst) (h₂ : f.snd = g.snd) : f = g :=
+  Hom.ext h₁ h₂
 
 /-- Interpret a `CatCommSqOver F G X` as a `CatCommSq`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -209,11 +209,11 @@ so `CatCommSqOver F G X` is in equivalent to
 `((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)`,
 though it is defined separately for performance reasons. -/
 structure CatCommSqOver where
-  /- The first projection functor. -/
+  /-- The first projection functor. -/
   fst : X ⥤ A
-  /- The second projection functor. -/
+  /-- The second projection functor. -/
   snd : X ⥤ C
-  /- The structural natural isomorphism. -/
+  /-- The structural natural isomorphism. -/
   iso : fst ⋙ F ≅ snd ⋙ G
 
 namespace CatCommSqOver

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -170,17 +170,17 @@ instance : IsIso f.fst :=
 instance : IsIso f.snd :=
   inferInstanceAs (IsIso ((π₂ _ _).mapIso (asIso f)).hom)
 
-@[simp]
+@[simp, push ←]
 lemma inv_fst : (inv f).fst = inv f.fst := by
   symm
   apply IsIso.inv_eq_of_hom_inv_id
-  simpa [-IsIso.hom_inv_id] using congrArg (fun t ↦ t.fst) (IsIso.hom_inv_id f)
+  simp [← comp_fst]
 
-@[simp]
+@[simp, push ←]
 lemma inv_snd : (inv f).snd = inv f.snd := by
   symm
   apply IsIso.inv_eq_of_hom_inv_id
-  simpa [-IsIso.hom_inv_id] using congrArg (fun t ↦ t.snd) (IsIso.hom_inv_id f)
+  simp [← comp_snd]
 
 end
 
@@ -202,12 +202,64 @@ variable (F G) in
 that of a functor `T : X ⥤ A`, a functor `L : X ⥤ C`, and a `CatCommSqOver T L F G`.
 Note that this is *exactly* what an object of
 `((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)` is,
-so `CatCommSqOver F G X` is in fact an abbreviation for
-`((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)`. -/
-abbrev CatCommSqOver :=
-  (whiskeringRight X A B |>.obj F) ⊡ (whiskeringRight X C B |>.obj G)
+so `CatCommSqOver F G X` is in equivalent to
+`((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)`,
+though it is defined separately for performance reasons. -/
+structure CatCommSqOver where
+  /- The first projection functor. -/
+  fst : X ⥤ A
+  /- The second projection functor. -/
+  snd : X ⥤ C
+  /- The structural natural isomorphism. -/
+  iso : fst ⋙ F ≅ snd ⋙ G
 
 namespace CatCommSqOver
+
+/-- The Hom types for the categorical commutative squares over X are given by pairs of natural
+transformations compatible with the structural isomorphisms. -/
+@[ext]
+structure Hom (x y : (CatCommSqOver F G X)) where
+  /-- the first component of `f : Hom x y` is a morphism `x.fst ⟶ y.fst` -/
+  fst : x.fst ⟶ y.fst
+  /-- the second component of `f : Hom x y` is a morphism `x.snd ⟶ y.snd` -/
+  snd : x.snd ⟶ y.snd
+  /-- the compatibility condition on `fst` and `snd` with respect to the structure
+  isomorphisms -/
+  w : whiskerRight fst F ≫ y.iso.hom = x.iso.hom ≫ whiskerRight snd G := by cat_disch
+
+attribute [reassoc (attr := simp)] Hom.w
+
+instance : Category (CatCommSqOver F G X) where
+  Hom x y := CatCommSqOver.Hom X x y
+  id x :=
+    { fst := 𝟙 x.fst
+      snd := 𝟙 x.snd }
+  comp f g :=
+    { fst := f.fst ≫ g.fst
+      snd := f.snd ≫ g.snd }
+
+@[ext]
+lemma hom_ext {S S' : CatCommSqOver F G X} {f g : S ⟶ S'}
+    (h₁ : f.fst = g.fst) (h₂ : f.snd = g.snd) : f = g := by
+  cases f
+  cases g
+  grind
+
+@[simp]
+lemma id_fst_app (S : CatCommSqOver F G X) (x : X) : (𝟙 S : S ⟶ S).fst.app x = 𝟙 _ := rfl
+
+@[simp]
+lemma id_snd_app (S : CatCommSqOver F G X) (x : X) : (𝟙 S : S ⟶ S).snd.app x = 𝟙 _ := rfl
+
+@[simp, reassoc]
+lemma comp_fst_app {S S' S'' : CatCommSqOver F G X} (f : S ⟶ S') (g : S' ⟶ S'') (x : X) :
+    (f ≫ g).fst.app x = f.fst.app x ≫ g.fst.app x :=
+  rfl
+
+@[simp, reassoc]
+lemma comp_snd_app {S S' S'' : CatCommSqOver F G X} (f : S ⟶ S') (g : S' ⟶ S'') (x : X) :
+    (f ≫ g).snd.app x = f.snd.app x ≫ g.snd.app x :=
+  rfl
 
 /-- Interpret a `CatCommSqOver F G X` as a `CatCommSq`. -/
 @[simps]
@@ -229,16 +281,36 @@ lemma w_app {S S' : CatCommSqOver F G X} (φ : S ⟶ S') (x : X) :
 variable (F G)
 
 /-- The "first projection" of a CatCommSqOver as a functor. -/
-abbrev fstFunctor : CatCommSqOver F G X ⥤ X ⥤ A := π₁ _ _
+@[simps!]
+def fstFunctor : CatCommSqOver F G X ⥤ X ⥤ A where
+  obj S := S.fst
+  map f := f.fst
 
 /-- The "second projection" of a CatCommSqOver as a functor. -/
-abbrev sndFunctor : CatCommSqOver F G X ⥤ X ⥤ C := π₂ _ _
+@[simps!]
+def sndFunctor : CatCommSqOver F G X ⥤ X ⥤ C where
+  obj S := S.snd
+  map f := f.snd
 
 /-- The structure isomorphism of a `CatCommSqOver` as a natural transformation. -/
-abbrev e :
+@[simps!]
+def e :
     fstFunctor F G X ⋙ (whiskeringRight X A B).obj F ≅
     sndFunctor F G X ⋙ (whiskeringRight X C B).obj G :=
   NatIso.ofComponents (fun S ↦ S.iso)
+
+variable {F G X} in
+/-- A constructor for isomorphisms in CatCommSqOver -/
+@[simps!]
+def mkIso {S S' : CatCommSqOver F G X}
+    (eₗ : S.fst ≅ S'.fst) (eᵣ : S.snd ≅ S'.snd)
+    (w : whiskerRight eₗ.hom F ≫ S'.iso.hom = S.iso.hom ≫ whiskerRight eᵣ.hom G := by cat_disch) :
+    S ≅ S' where
+  hom := ⟨eₗ.hom, eᵣ.hom, w⟩
+  inv := ⟨eₗ.inv, eᵣ.inv, by
+    ext t
+    simpa [← Functor.map_comp_assoc, ← Functor.map_comp] using
+      congr_app (whiskerRight eₗ.inv F ≫= w.symm =≫ whiskerRight eᵣ.inv G) t⟩
 
 end CatCommSqOver
 
@@ -282,7 +354,7 @@ def CatCommSqOver.toFunctorToCategoricalPullback :
 /-- The universal property of categorical pullbacks, stated as an equivalence
 of categories between functors `X ⥤ (F ⊡ G)` and categorical commutative squares
 over X. -/
-@[simps]
+@[simps!]
 def functorEquiv : (X ⥤ F ⊡ G) ≌ CatCommSqOver F G X where
   functor := toCatCommSqOver F G X
   inverse := CatCommSqOver.toFunctorToCategoricalPullback F G X
@@ -292,7 +364,7 @@ def functorEquiv : (X ⥤ F ⊡ G) ≌ CatCommSqOver F G X where
         (fun _ ↦ CategoricalPullback.mkIso (.refl _) (.refl _)))
   counitIso :=
     NatIso.ofComponents
-      (fun _ ↦ CategoricalPullback.mkIso
+      (fun _ ↦ CatCommSqOver.mkIso
         (NatIso.ofComponents (fun _ ↦ .refl _)) (NatIso.ofComponents (fun _ ↦ .refl _)))
 
 variable {F G X}
@@ -336,6 +408,9 @@ section
 
 variable {J K : X ⥤ F ⊡ G}
     (e₁ : J ⋙ π₁ F G ≅ K ⋙ π₁ F G) (e₂ : J ⋙ π₂ F G ≅ K ⋙ π₂ F G)
+
+@[simp]
+lemma toCatCommSqOver_mapIso_mkNatIso_eq_mkIso
     (coh :
       whiskerRight e₁.hom F ≫ (associator _ _ _).hom ≫
         whiskerLeft K (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
@@ -343,29 +418,30 @@ variable {J K : X ⥤ F ⊡ G}
       (associator _ _ _).hom ≫
         whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
         (associator _ _ _).inv ≫
-        whiskerRight e₂.hom G := by cat_disch)
-
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
-@[simp]
-lemma toCatCommSqOver_mapIso_mkNatIso_eq_mkIso :
+        whiskerRight e₂.hom G := by cat_disch) :
     (toCatCommSqOver F G X).mapIso (mkNatIso e₁ e₂ coh) =
-    CategoricalPullback.mkIso e₁ e₂
+    CatCommSqOver.mkIso e₁ e₂
       (by simpa [functorEquiv, toCatCommSqOver] using coh) := by
-  cat_disch
+  ext <;> simp
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 /-- Comparing mkNatIso with the corresponding construction one can deduce from
 `functorEquiv`. -/
-lemma mkNatIso_eq :
+lemma mkNatIso_eq
+    (coh :
+      whiskerRight e₁.hom F ≫ (associator _ _ _).hom ≫
+        whiskerLeft K (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
+        (associator _ _ _).inv =
+      (associator _ _ _).hom ≫
+        whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
+        (associator _ _ _).inv ≫
+        whiskerRight e₂.hom G := by cat_disch) :
     mkNatIso e₁ e₂ coh =
     (functorEquiv F G X).fullyFaithfulFunctor.preimageIso
-      (CategoricalPullback.mkIso e₁ e₂
+      (CatCommSqOver.mkIso e₁ e₂
         (by simpa [functorEquiv, toCatCommSqOver] using coh)) := by
   rw [← toCatCommSqOver_mapIso_mkNatIso_eq_mkIso e₁ e₂ coh]
   dsimp [Equivalence.fullyFaithfulFunctor]
-  cat_disch
+  ext <;> simp
 
 end
 
@@ -429,7 +505,7 @@ def transformObjComp (X : Type u₁₀) [Category.{v₁₀} X]
     (ψ : CatCospanTransform F G F₁ G₁) (ψ' : CatCospanTransform F₁ G₁ F₂ G₂) :
     (transform X).obj (ψ.comp ψ') ≅ (transform X).obj ψ ⋙ (transform X).obj ψ' :=
   NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso
+    CatCommSqOver.mkIso
       (Functor.associator _ _ _).symm
       (Functor.associator _ _ _).symm
 
@@ -440,7 +516,7 @@ def transformObjId (X : Type u₄) [Category.{v₄} X]
     (F : A ⥤ B) (G : C ⥤ B) :
     (transform X).obj (CatCospanTransform.id F G) ≅ 𝟭 _ :=
   NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso
+    CatCommSqOver.mkIso
       (Functor.rightUnitor _)
       (Functor.rightUnitor _)
 
@@ -454,7 +530,7 @@ lemma transform_map_whiskerLeft
     (transformObjComp X ψ φ).hom ≫
       whiskerLeft (transform X |>.obj ψ) (transform X |>.map α) ≫
       (transformObjComp X ψ φ').inv := by
-  cat_disch
+  ext <;> simp
 
 lemma transform_map_whiskerRight
     (X : Type u₇) [Category.{v₇} X]
@@ -464,7 +540,7 @@ lemma transform_map_whiskerRight
     (transformObjComp X ψ φ).hom ≫
       whiskerRight (transform X |>.map α) (transform X |>.obj φ) ≫
       (transformObjComp X ψ' φ).inv := by
-  cat_disch
+  ext <;> simp
 
 lemma transform_map_associator
     {A₃ : Type u₁₀} {B₃ : Type u₁₁} {C₃ : Type u₁₂}
@@ -480,7 +556,7 @@ lemma transform_map_associator
         (transform X |>.obj φ) (transform X |>.obj τ)).hom ≫
       whiskerLeft (transform X |>.obj ψ) (transformObjComp X φ τ).inv ≫
       (transformObjComp X ψ (φ.comp τ)).inv := by
-  cat_disch
+  ext <;> simp
 
 lemma transform_map_leftUnitor (X : Type u₇) [Category.{v₇} X]
     (ψ : CatCospanTransform F G F₁ G₁) :
@@ -488,7 +564,7 @@ lemma transform_map_leftUnitor (X : Type u₇) [Category.{v₇} X]
     (transformObjComp X (.id F G) ψ).hom ≫
       whiskerRight (transformObjId X F G).hom (transform X |>.obj ψ) ≫
       (transform X |>.obj ψ).leftUnitor.hom := by
-  cat_disch
+  ext <;> simp
 
 lemma transform_map_rightUnitor (X : Type u₇) [Category.{v₇} X]
     (ψ : CatCospanTransform F G F₁ G₁) :
@@ -496,7 +572,7 @@ lemma transform_map_rightUnitor (X : Type u₇) [Category.{v₇} X]
     (transformObjComp X ψ (.id F₁ G₁)).hom ≫
       whiskerLeft (transform X |>.obj ψ) (transformObjId X F₁ G₁).hom ≫
       (transform X |>.obj ψ).rightUnitor.hom := by
-  cat_disch
+  ext <;> simp
 
 end transform
 
@@ -536,7 +612,7 @@ variable (X) in
 def precomposeObjId :
     (precompose F G).obj (𝟭 X) ≅ 𝟭 (CatCommSqOver F G X) :=
   NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso (Functor.leftUnitor _) (Functor.leftUnitor _)
+    CatCommSqOver.mkIso (Functor.leftUnitor _) (Functor.leftUnitor _)
 
 /-- The construction `precompose` respects functor composition. -/
 @[simps!]
@@ -544,7 +620,7 @@ def precomposeObjComp (U : X ⥤ Y) (V : Y ⥤ Z) :
     (precompose F G).obj (U ⋙ V) ≅
     (precompose F G).obj V ⋙ (precompose F G).obj U :=
   NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso
+    CatCommSqOver.mkIso
       (Functor.associator _ _ _)
       (Functor.associator _ _ _)
 
@@ -553,14 +629,14 @@ lemma precompose_map_whiskerLeft (U : X ⥤ Y) {V W : Y ⥤ Z} (α : V ⟶ W) :
     (precomposeObjComp F G U V).hom ≫
       whiskerRight (precompose F G |>.map α) (precompose F G |>.obj U) ≫
       (precomposeObjComp F G U W).inv := by
-  cat_disch
+  ext <;> simp
 
 lemma precompose_map_whiskerRight {U V : X ⥤ Y} (α : U ⟶ V) (W : Y ⥤ Z) :
     (precompose F G).map (whiskerRight α W) =
     (precomposeObjComp F G U W).hom ≫
       whiskerLeft (precompose F G |>.obj W) (precompose F G |>.map α) ≫
       (precomposeObjComp F G V W).inv := by
-  cat_disch
+  ext <;> simp
 
 lemma precompose_map_associator {T : Type u₇} [Category.{v₇} T]
     (U : X ⥤ Y) (V : Y ⥤ Z) (W : Z ⥤ T) :
@@ -570,21 +646,21 @@ lemma precompose_map_associator {T : Type u₇} [Category.{v₇} T]
       ((precompose F G |>.obj W).associator _ _).inv ≫
       whiskerRight (precomposeObjComp F G V W).inv (precompose F G |>.obj U) ≫
       (precomposeObjComp F G _ _).inv := by
-  cat_disch
+  ext <;> simp
 
 lemma precompose_map_leftUnitor (U : X ⥤ Y) :
     (precompose F G).map U.leftUnitor.hom =
     (precomposeObjComp F G (𝟭 _) U).hom ≫
       whiskerLeft (precompose F G |>.obj U) (precomposeObjId F G X).hom ≫
       (Functor.rightUnitor _).hom := by
-  cat_disch
+  ext <;> simp
 
 lemma precompose_map_rightUnitor (U : X ⥤ Y) :
     (precompose F G).map U.rightUnitor.hom =
     (precomposeObjComp F G U (𝟭 _)).hom ≫
       whiskerRight (precomposeObjId F G Y).hom (precompose F G |>.obj U) ≫
       (Functor.leftUnitor _).hom := by
-  cat_disch
+  ext <;> simp
 
 end precompose
 
@@ -609,7 +685,7 @@ instance precomposeObjTransformObjSquare
       (precompose F G |>.obj U) (transform Y |>.obj ψ)
       (transform X |>.obj ψ) (precompose F₁ G₁ |>.obj U) where
   iso := NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso
+    CatCommSqOver.mkIso
       (Functor.associator _ _ _)
       (Functor.associator _ _ _)
 
@@ -625,7 +701,7 @@ lemma precomposeObjTransformObjSquare_iso_hom_naturality₂
       (CatCommSq.iso _ (transform Y |>.obj ψ) _ (precompose F₁ G₁ |>.obj V)).hom =
     (CatCommSq.iso _ (transform Y |>.obj ψ) _ (precompose F₁ G₁ |>.obj U)).hom ≫
       whiskerLeft (transform Y |>.obj ψ) (precompose F₁ G₁ |>.map α) := by
-  cat_disch
+  ext <;> simp
 
 /-- The square `precomposeObjTransformOBjSquare` respects identities. -/
 lemma precomposeObjTransformObjSquare_iso_hom_id
@@ -635,7 +711,7 @@ lemma precomposeObjTransformObjSquare_iso_hom_id
       whiskerLeft (transform X |>.obj ψ) (precomposeObjId F₁ G₁ X).hom =
     whiskerRight (precomposeObjId F G X).hom (transform X |>.obj ψ) ≫
       (Functor.leftUnitor _).hom ≫ (Functor.rightUnitor _).inv := by
-  cat_disch
+  ext <;> simp
 
 /-- The square `precomposeTransformSquare` respects compositions. -/
 lemma precomposeObjTransformObjSquare_iso_hom_comp
@@ -654,7 +730,7 @@ lemma precomposeObjTransformObjSquare_iso_hom_comp
       whiskerRight (CatCommSq.iso _ _ _ _).hom
         (precompose F₁ G₁ |>.obj U) ≫
       (Functor.associator _ _ _).hom := by
-  cat_disch
+  ext <;> simp
 
 /-- The canonical compatibility square between (the object components of)
 `transform` and `precompose`.
@@ -670,7 +746,7 @@ instance transformObjPrecomposeObjSquare
       (transform Y |>.obj ψ) (precompose F G |>.obj U)
       (precompose F₁ G₁ |>.obj U) (transform X |>.obj ψ) where
   iso := NatIso.ofComponents fun _ =>
-    CategoricalPullback.mkIso
+    CatCommSqOver.mkIso
       (Functor.associator _ _ _).symm
       (Functor.associator _ _ _).symm
 
@@ -685,7 +761,7 @@ lemma transformObjPrecomposeObjSquare_iso_hom_naturality₂
       (CatCommSq.iso _ (precompose F G |>.obj U) _ (transform X |>.obj ψ')).hom =
     (CatCommSq.iso _ (precompose F G |>.obj U) _ (transform X |>.obj ψ)).hom ≫
       whiskerLeft (precompose F G |>.obj U) (transform X |>.map η) := by
-  cat_disch
+  ext <;> simp
 
 /-- The square `transformObjPrecomposeObjSquare` respects identities. -/
 lemma transformObjPrecomposeObjSquare_iso_hom_id
@@ -697,7 +773,7 @@ lemma transformObjPrecomposeObjSquare_iso_hom_id
     whiskerRight (transformObjId Y F G).hom (precompose F G |>.obj U) ≫
       (precompose F G |>.obj U).leftUnitor.hom ≫
       (precompose F G |>.obj U).rightUnitor.inv := by
-  cat_disch
+  ext <;> simp
 
 /-- The square `transformPrecomposeSquare` respects compositions. -/
 lemma transformPrecomposeObjSquare_iso_hom_comp
@@ -718,7 +794,7 @@ lemma transformPrecomposeObjSquare_iso_hom_comp
       (Functor.associator _ _ _).inv ≫
       whiskerRight (CatCommSq.iso _ _ _ _).hom (transform X |>.obj ψ') ≫
       (Functor.associator _ _ _).hom := by
-  cat_disch
+  ext <;> simp
 
 end compatibility
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -333,6 +333,8 @@ def toCatCommSqOver : (X ⥤ F ⊡ G) ⥤ CatCommSqOver F G X where
   map {J J'} F :=
     { fst := whiskerRight F (π₁ _ _)
       snd := whiskerRight F (π₂ _ _) }
+  map_id := by intros; ext <;> simp
+  map_comp := by intros; ext <;> simp
 
 /-- Interpret a `CatCommSqOver` as a functor to the categorical pullback. -/
 @[simps!]
@@ -350,6 +352,8 @@ def CatCommSqOver.toFunctorToCategoricalPullback :
     { app x :=
         { fst := φ.fst.app x
           snd := φ.snd.app x } }
+  map_id := by intros; ext <;> simp
+  map_comp := by intros; ext <;> simp
 
 /-- The universal property of categorical pullbacks, stated as an equivalence
 of categories between functors `X ⥤ (F ⊡ G)` and categorical commutative squares
@@ -366,6 +370,7 @@ def functorEquiv : (X ⥤ F ⊡ G) ≌ CatCommSqOver F G X where
     NatIso.ofComponents
       (fun _ ↦ CatCommSqOver.mkIso
         (NatIso.ofComponents (fun _ ↦ .refl _)) (NatIso.ofComponents (fun _ ↦ .refl _)))
+  functor_unitIso_comp := by intros; ext <;> simp
 
 variable {F G X}
 
@@ -482,7 +487,9 @@ def transform (X : Type u₇) [Category.{v₇} X] :
           snd := whiskerRight f.snd ψ.right
           w := by
             ext x
-            simp [← Functor.map_comp_assoc] } }
+            simp [← Functor.map_comp_assoc] }
+      map_id := by intros; ext <;> simp
+      map_comp := by intros; ext <;> simp }
   map {ψ ψ'} η :=
     { app S :=
       { fst := { app y := η.left.app (S.fst.obj y) }
@@ -493,6 +500,8 @@ def transform (X : Type u₇) [Category.{v₇} X] :
             η.left_coherence_app (S.fst.obj t)
           simp only [Iso.inv_hom_id_app_assoc] at this
           simp [this] } }
+  map_id := by intros; ext <;> simp
+  map_comp := by intros; ext <;> simp
 
 variable {A₂ : Type u₇} {B₂ : Type u₈} {C₂ : Type u₉}
   [Category.{v₇} A₂] [Category.{v₈} B₂] [Category.{v₉} C₂]
@@ -600,11 +609,15 @@ def precompose :
               (Functor.associator _ _ _).symm }
       map {S S'} φ :=
         { fst := whiskerLeft U φ.fst
-          snd := whiskerLeft U φ.snd } }
+          snd := whiskerLeft U φ.snd }
+      map_id := by intros; ext <;> simp
+      map_comp := by intros; ext <;> simp }
   map {U V} α :=
     { app x :=
       { fst := whiskerRight α x.fst
         snd := whiskerRight α x.snd } }
+  map_id := by intros; ext <;> simp
+  map_comp := by intros; ext <;> simp
 
 variable (X) in
 /-- The construction `precompose` respects functor identities. -/


### PR DESCRIPTION
When benchmarking #33822, it appeared that the file `CategoryTheory/Limits/Pullback/Categorical/Basic` was very slow.

`CatCommSqOver F G X` used to be an abbrev for `((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)`. This
seemed to be one of the reasons for the bad performances in the file. The structure is now defined as a standalone structure, with some API. This does duplicate a small amount of code, but speeds up the file quite a bit.

In addition, the multiple calls to `cat_disch` (either explicit, or via autoparams) within the file accumulated some slowdowns. Most of the time, the proofs are `intros; ext <;> simp`, which is faster.

A small note is added to the module docstring for the file, precising that not using some autoparams is in fact intentional.

two `push ←` annotations are sneaked in.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
