### PR TITLE
[Merged by Bors] - feat(GraphTheory): supports of top and bot graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -348,7 +348,7 @@ theorem emptyGraph_eq_bot (V : Type u) : emptyGraph V = ⊥ :=
 instance (V : Type u) : Inhabited (SimpleGraph V) :=
   ⟨⊥⟩
 
-instance [Subsingleton V] : Unique (SimpleGraph V) where
+instance uniqueOfSubsingleton [Subsingleton V] : Unique (SimpleGraph V) where
   default := ⊥
   uniq G := by ext a b; have := Subsingleton.elim a b; simp [this]
 
@@ -396,21 +396,18 @@ theorem support_mono {G G' : SimpleGraph V} (h : G ≤ G') : G.support ⊆ G'.su
 
 /-- All vertices are in the support of the complete graph if there is more than one vertex. -/
 @[simp]
-theorem support_top_ofNontrivial [Nontrivial V] :
-    (⊤ : SimpleGraph V).support = Set.univ := by
-  ext v
-  have := exists_ne v
-  tauto
-
-/-- The support of a graph is empty if there at most one vertex. -/
-@[simp]
-theorem support_of_subsingleton [Subsingleton V] (G : SimpleGraph V) : G.support = ∅ :=
-  Set.eq_empty_of_forall_notMem fun v ⟨w, h⟩ => G.irrefl <| Subsingleton.elim v w ▸ h
+theorem support_top_of_nontrivial [Nontrivial V] : (⊤ : SimpleGraph V).support = Set.univ :=
+  Set.eq_univ_of_forall fun v₁ => exists_ne v₁ |>.imp fun _ h => h.symm
 
 /-- The support of the empty graph is empty. -/
 @[simp]
-theorem support_bot : (⊥ : SimpleGraph V).support = ∅ := by
+theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
   Set.eq_empty_of_forall_notMem fun _ ⟨_, h⟩ => h
+
+/-- The support of a graph is empty if there at most one vertex. -/
+@[simp]
+theorem support_of_subsingleton [Subsingleton V] : G.support = ∅ :=
+  SimpleGraph.uniqueOfSubsingleton.uniq G ▸ support_bot
 
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -402,10 +402,10 @@ theorem support_top_ofNontrivial [Nontrivial V] :
   have := exists_ne v
   tauto
 
-/-- The support of the complete graph is empty if there at most one vertex. -/
+/-- The support of a graph is empty if there at most one vertex. -/
 @[simp]
-theorem support_top_ofSubsingleton [Subsingleton V] : (⊤ : SimpleGraph V).support = ∅ :=
-  Set.ext fun v => ⟨fun ⟨w, hw⟩ => hw (Subsingleton.elim v w), (·.elim)⟩
+theorem support_of_subsingleton [Subsingleton V] (G : SimpleGraph V) : G.support = ∅ :=
+  Set.eq_empty_of_forall_notMem fun v ⟨w, h⟩ => G.irrefl <| Subsingleton.elim v w ▸ h
 
 /-- The support of the empty graph is empty. -/
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -344,6 +344,9 @@ theorem completeGraph_eq_top (V : Type u) : completeGraph V = ⊤ :=
 theorem emptyGraph_eq_bot (V : Type u) : emptyGraph V = ⊥ :=
   rfl
 
+theorem eq_bot_iff_forall_not_adj : G = ⊥ ↔ ∀ a b : V, ¬G.Adj a b := by
+  simp [← le_bot_iff, le_iff_adj]
+
 @[simps]
 instance (V : Type u) : Inhabited (SimpleGraph V) :=
   ⟨⊥⟩
@@ -397,12 +400,19 @@ theorem support_mono {G G' : SimpleGraph V} (h : G ≤ G') : G.support ⊆ G'.su
 /-- All vertices are in the support of the complete graph if there is more than one vertex. -/
 @[simp]
 theorem support_top_of_nontrivial [Nontrivial V] : (⊤ : SimpleGraph V).support = Set.univ :=
-  Set.eq_univ_of_forall fun v₁ => exists_ne v₁ |>.imp fun _ h => h.symm
+  Set.eq_univ_of_forall fun v₁ => exists_ne v₁ |>.imp fun _v₂ h => h.symm
 
 /-- The support of the empty graph is empty. -/
 @[simp]
 theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
-  Set.eq_empty_of_forall_notMem fun _ ⟨_, h⟩ => h
+  SetRel.dom_eq_empty_iff.mpr <| Set.empty_def.symm
+
+/-- Only the empty graph has empty support. -/
+@[simp]
+theorem support_eq_bot_iff : G.support = ∅ ↔ G = ⊥ :=
+  ⟨fun h ↦ by rw [eq_bot_iff_forall_not_adj]; exact fun v w nadj ↦
+    Set.ext_iff.mp (SetRel.dom_eq_empty_iff.mp h) (v, w) |>.mp nadj |>.elim,
+   (· ▸ support_bot)⟩
 
 /-- The support of a graph is empty if there at most one vertex. -/
 @[simp]
@@ -531,9 +541,6 @@ theorem adj_iff_exists_edge {v w : V} : G.Adj v w ↔ v ≠ w ∧ ∃ e ∈ G.ed
 
 theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, b) := by
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
-
-theorem eq_bot_iff_forall_not_adj : G = ⊥ ↔ ∀ a b : V, ¬G.Adj a b := by
-  simp [← le_bot_iff, le_iff_adj]
 
 theorem ne_bot_iff_exists_adj : G ≠ ⊥ ↔ ∃ a b : V, G.Adj a b := by
   simp [eq_bot_iff_forall_not_adj]

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -407,7 +407,7 @@ theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
 /-- The support of a graph is empty if there at most one vertex. -/
 @[simp]
 theorem support_of_subsingleton [Subsingleton V] : G.support = ∅ :=
-  SimpleGraph.uniqueOfSubsingleton.uniq G ▸ support_bot
+  uniqueOfSubsingleton.uniq G ▸ support_bot
 
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -409,8 +409,8 @@ theorem support_top_ofSubsingleton [Subsingleton V] : (⊤ : SimpleGraph V).supp
 
 /-- The support of the empty graph is empty. -/
 @[simp]
-theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
-  by grind only [mem_support, Set.mem_empty_iff_false, bot_adj]
+theorem support_bot : (⊥ : SimpleGraph V).support = ∅ := by
+  grind only [mem_support, Set.mem_empty_iff_false, bot_adj]
 
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -410,7 +410,7 @@ theorem support_of_subsingleton [Subsingleton V] (G : SimpleGraph V) : G.support
 /-- The support of the empty graph is empty. -/
 @[simp]
 theorem support_bot : (⊥ : SimpleGraph V).support = ∅ := by
-  grind only [mem_support, Set.mem_empty_iff_false, bot_adj]
+  Set.eq_empty_of_forall_notMem fun _ ⟨_, h⟩ => h
 
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -394,6 +394,24 @@ theorem mem_support {v : V} : v ∈ G.support ↔ ∃ w, G.Adj v w :=
 theorem support_mono {G G' : SimpleGraph V} (h : G ≤ G') : G.support ⊆ G'.support :=
   SetRel.dom_mono fun _uv huv ↦ h huv
 
+/-- All vertices are in the support of the complete graph if there is more than one vertex. -/
+@[simp]
+theorem support_top_ofNontrivial [Nontrivial V] :
+    (⊤ : SimpleGraph V).support = Set.univ := by
+  ext v
+  have := exists_ne v
+  tauto
+
+/-- The support of the complete graph is empty if there at most one vertex. -/
+@[simp]
+theorem support_top_ofSubsingleton [Subsingleton V] : (⊤ : SimpleGraph V).support = ∅ :=
+  Set.ext fun v => ⟨fun ⟨w, hw⟩ => hw (Subsingleton.elim v w), (·.elim)⟩
+
+/-- The support of the empty graph is empty. -/
+@[simp]
+theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
+  by grind only [mem_support, Set.mem_empty_iff_false, bot_adj]
+
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -344,8 +344,21 @@ theorem completeGraph_eq_top (V : Type u) : completeGraph V = ⊤ :=
 theorem emptyGraph_eq_bot (V : Type u) : emptyGraph V = ⊥ :=
   rfl
 
+variable {G}
+
 theorem eq_bot_iff_forall_not_adj : G = ⊥ ↔ ∀ a b : V, ¬G.Adj a b := by
   simp [← le_bot_iff, le_iff_adj]
+
+theorem ne_bot_iff_exists_adj : G ≠ ⊥ ↔ ∃ a b : V, G.Adj a b := by
+  simp [eq_bot_iff_forall_not_adj]
+
+theorem eq_top_iff_forall_ne_adj : G = ⊤ ↔ ∀ a b : V, a ≠ b → G.Adj a b := by
+  simp [← top_le_iff, le_iff_adj]
+
+theorem ne_top_iff_exists_not_adj : G ≠ ⊤ ↔ ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
+  simp [eq_top_iff_forall_ne_adj]
+
+variable (G)
 
 @[simps]
 instance (V : Type u) : Inhabited (SimpleGraph V) :=
@@ -410,7 +423,7 @@ theorem support_bot : (⊥ : SimpleGraph V).support = ∅ :=
 /-- Only the empty graph has empty support. -/
 @[simp]
 theorem support_eq_bot_iff : G.support = ∅ ↔ G = ⊥ :=
-  ⟨fun h ↦ by rw [eq_bot_iff_forall_not_adj]; exact fun v w nadj ↦
+  ⟨fun h ↦ eq_bot_iff_forall_not_adj.mpr fun v w nadj ↦
     Set.ext_iff.mp (SetRel.dom_eq_empty_iff.mp h) (v, w) |>.mp nadj |>.elim,
    (· ▸ support_bot)⟩
 
@@ -541,15 +554,6 @@ theorem adj_iff_exists_edge {v w : V} : G.Adj v w ↔ v ≠ w ∧ ∃ e ∈ G.ed
 
 theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, b) := by
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
-
-theorem ne_bot_iff_exists_adj : G ≠ ⊥ ↔ ∃ a b : V, G.Adj a b := by
-  simp [eq_bot_iff_forall_not_adj]
-
-theorem eq_top_iff_forall_ne_adj : G = ⊤ ↔ ∀ a b : V, a ≠ b → G.Adj a b := by
-  simp [← top_le_iff, le_iff_adj]
-
-theorem ne_top_iff_exists_not_adj : G ≠ ⊤ ↔ ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
-  simp [eq_top_iff_forall_ne_adj]
 
 variable (G G₁ G₂)
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -130,6 +130,10 @@ def cod : Set β := {b | ∃ a, a ~[R] b}
   ⟨fun h ↦ Set.eq_empty_iff_forall_notMem.mpr <| by simp_all [Set.eq_empty_iff_forall_notMem],
    (· ▸ dom_empty)⟩
 
+@[simp] lemma cod_eq_empty_iff : R.cod = ∅ ↔ R = (∅ : SetRel α β) :=
+  ⟨fun h ↦ Set.eq_empty_iff_forall_notMem.mpr <| by simp_all [Set.eq_empty_iff_forall_notMem],
+   (· ▸ cod_empty)⟩
+
 @[simp] lemma dom_univ [Nonempty β] : dom (.univ : SetRel α β) = .univ := by aesop
 @[simp] lemma cod_univ [Nonempty α] : cod (.univ : SetRel α β) = .univ := by aesop
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -126,6 +126,10 @@ def cod : Set β := {b | ∃ a, a ~[R] b}
 @[simp] lemma dom_empty : (∅ : SetRel α β).dom = ∅ := by aesop
 @[simp] lemma cod_empty : (∅ : SetRel α β).cod = ∅ := by aesop
 
+@[simp] lemma dom_eq_empty_iff : R.dom = ∅ ↔ R = (∅ : SetRel α β) :=
+  ⟨fun h ↦ Set.eq_empty_iff_forall_notMem.mpr <| by simp_all [Set.eq_empty_iff_forall_notMem],
+   (· ▸ dom_empty)⟩
+
 @[simp] lemma dom_univ [Nonempty β] : dom (.univ : SetRel α β) = .univ := by aesop
 @[simp] lemma cod_univ [Nonempty α] : cod (.univ : SetRel α β) = .univ := by aesop
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I'm not 100% sure if these should be `simp` (but I'm not sure they shouldn't be either)?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
