### PR TITLE
[Merged by Bors] - chore: golf and reduce compilation time

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -347,7 +347,7 @@ theorem prod_eq_single {s : Finset ι} {f : ι → M} (a : ι) (h₀ : ∀ b ∈
 @[to_additive (attr := simp)]
 lemma prod_ite_mem_eq [Fintype ι] (s : Finset ι) (f : ι → M) [DecidablePred (· ∈ s)] :
     (∏ i, if i ∈ s then f i else 1) = ∏ i ∈ s, f i := by
-  rw [← Finset.prod_filter]; congr; aesop
+  rw [← Finset.prod_filter]; congr; grind
 
 @[to_additive]
 lemma prod_eq_ite [DecidableEq ι] {s : Finset ι} {f : ι → M} (a : ι)
@@ -355,7 +355,7 @@ lemma prod_eq_ite [DecidableEq ι] {s : Finset ι} {f : ι → M} (a : ι)
     ∏ x ∈ s, f x = if a ∈ s then f a else 1 := by
   by_cases h : a ∈ s
   · simp [Finset.prod_eq_single_of_mem a h h₀, h]
-  · replace h₀ : ∀ b ∈ s, f b = 1 := by aesop
+  · replace h₀ : ∀ b ∈ s, f b = 1 := by grind
     simp +contextual [h₀]
 
 @[to_additive]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
@@ -79,7 +79,7 @@ lemma prod_ite_of_false {p : ι → Prop} [DecidablePred p] (h : ∀ x ∈ s, ¬
 lemma prod_dite_of_true {p : ι → Prop} [DecidablePred p] (h : ∀ i ∈ s, p i) (f : ∀ i, p i → M)
     (g : ∀ i, ¬ p i → M) :
     ∏ i ∈ s, (if hi : p i then f i hi else g i hi) = ∏ i : s, f i.1 (h _ i.2) := by
-  refine prod_bij' (fun x hx => ⟨x, hx⟩) (fun x _ ↦ x) ?_ ?_ ?_ ?_ ?_ <;> aesop
+  refine prod_bij' (fun x hx => ⟨x, hx⟩) (fun x _ ↦ x) ?_ ?_ ?_ ?_ ?_ <;> grind
 
 @[to_additive]
 lemma prod_ite_of_true {p : ι → Prop} [DecidablePred p] (h : ∀ x ∈ s, p x) (f g : ι → M) :

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -606,8 +606,7 @@ variable {P : C → Prop}
 @[to_additive, simp high]
 lemma forall_mem_sup :
     (∀ x ∈ s ⊔ t, P x) ↔ (∀ x₁ ∈ s, ∀ x₂ ∈ t, P (x₁ * x₂)) := by
-  simp [mem_sup]
-  aesop
+  grind [mem_sup]
 
 @[to_additive, simp high]
 lemma exists_mem_sup :

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -228,7 +228,7 @@ lemma nsmul_piAntidiag [DecidableEq (ι → ℕ)] (s : Finset ι) (m : ℕ) {n :
       exact dvd_zero _
   refine ⟨fun i ↦ f i / n, ?_⟩
   simp [funext_iff, Nat.mul_div_cancel', ← Nat.sum_div, *]
-  aesop
+  grind
 
 lemma map_nsmul_piAntidiag (s : Finset ι) (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
     (piAntidiag s m).map

--- a/Mathlib/Combinatorics/Additive/Dissociation.lean
+++ b/Mathlib/Combinatorics/Additive/Dissociation.lean
@@ -64,7 +64,7 @@ lemma mulDissociated_singleton : MulDissociated ({a} : Set α) ↔ a ≠ 1 := by
 lemma not_mulDissociated :
     ¬ MulDissociated s ↔
       ∃ t : Finset α, ↑t ⊆ s ∧ ∃ u : Finset α, ↑u ⊆ s ∧ t ≠ u ∧ ∏ x ∈ t, x = ∏ x ∈ u, x := by
-  simp [MulDissociated, InjOn]; aesop
+  grind [MulDissociated, InjOn]
 
 @[to_additive]
 lemma not_mulDissociated_iff_exists_disjoint :

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -129,8 +129,7 @@ def falling : Finset (Finset α) :=
 variable {𝒜 k} {s : Finset α}
 
 theorem mem_falling : s ∈ falling k 𝒜 ↔ (∃ t ∈ 𝒜, s ⊆ t) ∧ #s = k := by
-  simp_rw [falling, mem_sup, mem_powersetCard]
-  aesop
+  grind [falling, mem_sup]
 
 variable (𝒜 k)
 

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -276,7 +276,7 @@ variable (s)
 @[simp]
 theorem image_diag [DecidableEq β] (f : α × α → β) (s : Finset α) :
     s.diag.image f = s.image fun x ↦ f (x, x) := by
-  aesop
+  grind
 
 @[simp, norm_cast]
 theorem coe_offDiag : (s.offDiag : Set (α × α)) = (s : Set α).offDiag :=

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -170,7 +170,7 @@ lemma biUnion_insert [DecidableEq α] {a : α} : (insert a s).biUnion t = t a �
 
 lemma biUnion_congr (hs : s₁ = s₂) (ht : ∀ a ∈ s₁, t₁ a = t₂ a) :
     s₁.biUnion t₁ = s₂.biUnion t₂ := by
-  aesop
+  grind
 
 @[simp]
 lemma disjiUnion_eq_biUnion (s : Finset α) (f : α → Finset β) (hf) :

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -38,8 +38,7 @@ theorem count_lt_length_iff {a : α} : l.count a < l.length ↔ ∃ b ∈ l, b �
 
 lemma countP_erase (p : α → Bool) (l : List α) (a : α) :
     countP p (l.erase a) = countP p l - if a ∈ l ∧ p a then 1 else 0 := by
-  rw [countP_eq_length_filter, countP_eq_length_filter, ← erase_filter, length_erase]
-  aesop
+  grind [countP_eq_length_filter]
 
 lemma count_diff (a : α) (l₁ : List α) :
     ∀ l₂, count a (l₁.diff l₂) = count a l₁ - count a l₂

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -103,7 +103,7 @@ lemma Coprime.primeFactors_mul {a b : ℕ} (hab : Coprime a b) :
 
 lemma primeFactors_gcd (ha : a ≠ 0) (hb : b ≠ 0) :
     (a.gcd b).primeFactors = a.primeFactors ∩ b.primeFactors := by
-  ext; simp [dvd_gcd_iff, ha, hb, gcd_ne_zero_left ha]; aesop
+  grind [dvd_gcd_iff]
 
 @[simp] lemma disjoint_primeFactors (ha : a ≠ 0) (hb : b ≠ 0) :
     Disjoint a.primeFactors b.primeFactors ↔ Coprime a b := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -406,7 +406,7 @@ theorem encard_eq_four {α : Type u_1} {s : Set α} :
     · rintro rfl; exact (hs.symm.subset (Or.inr (Or.inr rfl))).2 rfl
     rw [← hs, insert_diff_singleton, insert_eq_of_mem hx]
   rw [hs, encard_insert_of_notMem, encard_insert_of_notMem, encard_insert_of_notMem,
-    encard_singleton] <;> aesop
+    encard_singleton] <;> grind
 
 theorem Nat.encard_range (k : ℕ) : {i | i < k}.encard = k := by
   convert encard_coe_eq_coe_finsetCard (Finset.range k) using 1

--- a/Mathlib/Data/Set/NAry.lean
+++ b/Mathlib/Data/Set/NAry.lean
@@ -52,10 +52,10 @@ theorem image_subset_image2_right (ha : a ∈ s) : f a '' t ⊆ image2 f s t :=
   forall_mem_image.2 fun _ => mem_image2_of_mem ha
 
 lemma forall_mem_image2 {p : γ → Prop} :
-    (∀ z ∈ image2 f s t, p z) ↔ ∀ x ∈ s, ∀ y ∈ t, p (f x y) := by aesop
+    (∀ z ∈ image2 f s t, p z) ↔ ∀ x ∈ s, ∀ y ∈ t, p (f x y) := by grind
 
 lemma exists_mem_image2 {p : γ → Prop} :
-    (∃ z ∈ image2 f s t, p z) ↔ ∃ x ∈ s, ∃ y ∈ t, p (f x y) := by aesop
+    (∃ z ∈ image2 f s t, p z) ↔ ∃ x ∈ s, ∃ y ∈ t, p (f x y) := by grind
 
 @[simp]
 theorem image2_subset_iff {u : Set γ} : image2 f s t ⊆ u ↔ ∀ x ∈ s, ∀ y ∈ t, f x y ∈ u :=

--- a/Mathlib/Data/Set/Pairwise/Basic.lean
+++ b/Mathlib/Data/Set/Pairwise/Basic.lean
@@ -132,8 +132,7 @@ theorem pairwise_eq_iff_exists_eq [Nonempty ι] (s : Set α) (f : α → ι) :
 theorem pairwise_union :
     (s ∪ t).Pairwise r ↔
     s.Pairwise r ∧ t.Pairwise r ∧ ∀ a ∈ s, ∀ b ∈ t, a ≠ b → r a b ∧ r b a := by
-  simp only [Set.Pairwise, mem_union, or_imp, forall_and]
-  aesop
+  grind [Set.Pairwise]
 
 theorem pairwise_union_of_symmetric (hr : Symmetric r) :
     (s ∪ t).Pairwise r ↔ s.Pairwise r ∧ t.Pairwise r ∧ ∀ a ∈ s, ∀ b ∈ t, a ≠ b → r a b :=

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
@@ -161,8 +161,7 @@ theorem mem_ofFixingSubgroup_insert_iff {a : α} {s : Set (ofStabilizer M a)} {x
     x ∈ ofFixingSubgroup M (insert a ((fun x ↦ x.val) '' s)) ↔
       ∃ (hx : x ∈ ofStabilizer M a),
         (⟨x, hx⟩ : ofStabilizer M a) ∈ ofFixingSubgroup (stabilizer M a) s := by
-  simp_rw [mem_ofFixingSubgroup_iff, mem_ofStabilizer_iff]
-  aesop
+  grind [mem_ofFixingSubgroup_iff, mem_ofStabilizer_iff]
 
 /-- The natural group isomorphism between fixing subgroups. -/
 @[to_additive /-- The natural additive group isomorphism between fixing additive subgroups. -/]

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -459,7 +459,7 @@ theorem mem_affineSpan {p : P} {s : Set P} (hp : p ∈ s) : p ∈ affineSpan k s
 lemma vectorSpan_add_self (s : Set V) : (vectorSpan k s : Set V) + s = affineSpan k s := by
   ext
   simp [mem_add, spanPoints]
-  aesop
+  grind
 
 variable {k}
 

--- a/Mathlib/LinearAlgebra/Finsupp/Span.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Span.lean
@@ -117,5 +117,5 @@ theorem Submodule.mem_sSup_iff_exists_finset {S : Set (Submodule R M)} {m : M} :
   · simpa using fun x _ ↦ x.property
   · suffices m ∈ ⨆ (i) (hi : i ∈ S) (_ : ⟨i, hi⟩ ∈ s), i by simpa
     rwa [iSup_subtype']
-  · have : ⨆ (i) (_ : i ∈ S ∧ i ∈ s), i = ⨆ (i) (_ : i ∈ s), i := by convert rfl; aesop
+  · have : ⨆ (i) (_ : i ∈ S ∧ i ∈ s), i = ⨆ (i) (_ : i ∈ s), i := by convert rfl; grind
     simpa only [Finset.mem_preimage, iSup_subtype, iSup_and', this]

--- a/Mathlib/LinearAlgebra/Matrix/Kronecker.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Kronecker.lean
@@ -118,7 +118,7 @@ theorem kroneckerMap_single_single
     kroneckerMap f (single i₁ j₁ a) (single i₂ j₂ b) = single (i₁, i₂) (j₁, j₂) (f a b) := by
   ext ⟨i₁', i₂'⟩ ⟨j₁', j₂'⟩
   dsimp [single]
-  aesop
+  grind
 
 theorem kroneckerMap_diagonal_diagonal [Zero α] [Zero β] [Zero γ] [DecidableEq m] [DecidableEq n]
     (f : α → β → γ) (hf₁ : ∀ b, f 0 b = 0) (hf₂ : ∀ a, f a 0 = 0) (a : m → α) (b : n → β) :

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -191,7 +191,7 @@ theorem integral_biUnion_eq_sum_powerset {ι : Type*} {t : Finset ι} {s : ι �
   simp_rw [← integral_smul, ← integral_indicator (Finset.measurableSet_biUnion _ hs)]
   have A (u) (hu : u ∈ t.powerset.filter (·.Nonempty)) : MeasurableSet (⋂ i ∈ u, s i) := by
     refine u.measurableSet_biInter fun i hi ↦ hs i ?_
-    aesop
+    grind
   have : ∑ x ∈ t.powerset with x.Nonempty, ∫ (a : X) in ⋂ i ∈ x, s i, (-1 : ℝ) ^ (#x + 1) • f a ∂μ
       = ∑ x ∈ t.powerset with x.Nonempty, ∫ a, indicator (⋂ i ∈ x, s i)
         (fun a ↦ (-1 : ℝ) ^ (#x + 1) • f a) a ∂μ := by

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -591,7 +591,7 @@ theorem card_isPrincipal_dvd_norm_le (s : ℝ) :
         (p := fun I : (Ideal (𝓞 K))⁰ ↦ J.1 ∣ I.1 ∧ IsPrincipal I.1 ∧ absNorm I.1 ≤ ⌊s⌋₊)
         (q := fun I ↦ absNorm I.1 = i))
       _ ≃ {I : (Ideal (𝓞 K))⁰ // J.1 ∣ I.1 ∧ IsPrincipal I.1 ∧ absNorm I.1 = i}
-            × torsion K := Equiv.prodCongrLeft fun _ ↦ Equiv.subtypeEquivRight fun _ ↦ by aesop
+            × torsion K := Equiv.prodCongrLeft fun _ ↦ Equiv.subtypeEquivRight fun _ ↦ by grind
       _ ≃ {a : idealSet K J // mixedEmbedding.norm (a : mixedSpace K) = i} :=
             (idealSetEquivNorm K J i).symm
       _ ≃ {a : idealSet K J // intNorm (idealSetEquiv K J a).1 = i} := by

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -118,8 +118,7 @@ theorem compl_ne_univ : sᶜ ≠ univ ↔ s.Nonempty :=
 
 lemma inl_compl_union_inr_compl {s : Set α} {t : Set β} :
     Sum.inl '' sᶜ ∪ Sum.inr '' tᶜ = (Sum.inl '' s ∪ Sum.inr '' t)ᶜ := by
-  rw [compl_union]
-  aesop
+  grind
 
 theorem nonempty_compl : sᶜ.Nonempty ↔ s ≠ univ :=
   (ne_univ_iff_exists_notMem s).symm
@@ -384,7 +383,7 @@ lemma _root_.HasSubset.Subset.diff_ssubset_of_nonempty (hst : s ⊆ t) (hs : s.N
   simpa [inter_eq_self_of_subset_right hst]
 
 lemma ssubset_iff_sdiff_singleton : s ⊂ t ↔ ∃ a ∈ t, s ⊆ t \ {a} := by
-  simp [ssubset_iff_insert, subset_diff, insert_subset_iff]; aesop
+  grind
 
 @[simp]
 lemma diff_singleton_subset_iff : s \ {a} ⊆ t ↔ s ⊆ insert a t := by

--- a/Mathlib/Order/Sublattice.lean
+++ b/Mathlib/Order/Sublattice.lean
@@ -385,7 +385,7 @@ attribute [norm_cast] coe_pi
 lemma pi_univ_bot [Nonempty κ] : (pi univ fun _ ↦ ⊥ : Sublattice (∀ i, π i)) = ⊥ := by simp
 
 lemma le_pi {s : Set κ} {L : ∀ i, Sublattice (π i)} {M : Sublattice (∀ i, π i)} :
-    M ≤ pi s L ↔ ∀ i ∈ s, M ≤ comap (Pi.evalLatticeHom i) (L i) := by simp [SetLike.le_def]; aesop
+    M ≤ pi s L ↔ ∀ i ∈ s, M ≤ comap (Pi.evalLatticeHom i) (L i) := by simp [SetLike.le_def]; grind
 
 @[simp] lemma pi_univ_eq_bot_iff {L : ∀ i, Sublattice (π i)} : pi univ L = ⊥ ↔ ∃ i, L i = ⊥ := by
   simp_rw [← coe_inj]; simp

--- a/Mathlib/Probability/Kernel/Composition/CompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/CompProd.lean
@@ -542,7 +542,7 @@ lemma comapRight_compProd_id_prod {δ : Type*} {mδ : MeasurableSpace δ}
   · refine lintegral_congr fun b ↦ ?_
     rw [comapRight_apply']
     · congr with x
-      aesop
+      grind
     · exact measurable_prodMk_left ht
   · exact (MeasurableEmbedding.id.prodMap hf).measurableSet_image.mpr ht
 

--- a/Mathlib/RingTheory/Adjoin/Polynomial.lean
+++ b/Mathlib/RingTheory/Adjoin/Polynomial.lean
@@ -72,7 +72,7 @@ theorem _root_.Algebra.adjoin_singleton_induction {M : (adjoin R {x}) → Prop}
     M (⟨aeval x p, aeval_mem_adjoin_singleton R x⟩ : adjoin R {x})) :
     M a := by
   obtain ⟨p, hp⟩ := Algebra.adjoin_eq_exists_aeval _ x a
-  aesop
+  grind
 
 instance instCommSemiringAdjoinSingleton :
     CommSemiring <| adjoin R {x} :=

--- a/Mathlib/RingTheory/Ideal/Prime.lean
+++ b/Mathlib/RingTheory/Ideal/Prime.lean
@@ -102,7 +102,7 @@ theorem IsPrime.pow_mem_iff_mem {I : Ideal α} (hI : I.IsPrime) {r : α} (n : �
 
 lemma IsPrime.mul_mem_left_iff {I : Ideal α} [I.IsTwoSided] [I.IsPrime]
     {x y : α} (hx : x ∉ I) : x * y ∈ I ↔ y ∈ I := by
-  rw [Ideal.IsPrime.mul_mem_iff_mem_or_mem] <;> aesop
+  grind [Ideal.IsPrime.mul_mem_iff_mem_or_mem]
 
 lemma IsPrime.mul_mem_right_iff {I : Ideal α} [I.IsTwoSided] [I.IsPrime]
     {x y : α} (hx : y ∉ I) : x * y ∈ I ↔ x ∈ I := by

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -218,7 +218,7 @@ theorem Dense.ciSup' {α : Type*} [TopologicalSpace α]
     simpa [← Function.comp_def, range_comp] using hf.range_subset_closure_image_dense hS
   · suffices ¬ BddAbove (range f) by simp [ciSup_of_not_bddAbove, this, h]
     contrapose h
-    exact h.mono fun _ ↦ by aesop
+    grind [h.mono]
 
 /-- This is an analogue of `Dense.continuous_inf` for functions taking values in a conditionally
 complete linear order. The assumption of `BddBelow (range f)` is not needed in this theorem. -/


### PR DESCRIPTION
---
Trace profiling results (shown if ≥10 ms before or after):
* `Finset.prod_ite_mem_eq`: 38 ms before, 16 ms after  🎉
* `Finset.prod_eq_ite`: 82 ms before, 38 ms after  🎉
* `Finset.prod_dite_of_true`: 69 ms before, 30 ms after  🎉
* `Subgroup.forall_mem_sup`: 268 ms before, 51 ms after  🎉
* `Finset.nsmul_piAntidiag`: 277 ms before, 167 ms after  🎉
* `not_mulDissociated`: 642 ms before, 48 ms after  🎉
* `Finset.mem_falling`: 126 ms before, 35 ms after  🎉
* `Finset.image_diag`: 66 ms before, 44 ms after  🎉
* `Finset.biUnion_congr`: 241 ms before, 110 ms after  🎉
* `List.countP_erase`: 197 ms before, 136 ms after  🎉
* `List.triplewise_cons`: 209 ms before, 25 ms after  🎉
* `List.triplewise_append`: 298 ms before, 47 ms after  🎉
* `Nat.primeFactors_gcd`: 77 ms before, 32 ms after  🎉
* `Prod.swap_eq_iff_eq_swap`: 148 ms before, 12 ms after  🎉
* `Set.encard_eq_four`: 1034 ms before, 962 ms after  🎉
* `Set.forall_mem_image2`: 376 ms before, 33 ms after  🎉
* `Set.exists_mem_image2`: 386 ms before, 82 ms after  🎉
* `Set.pairwise_union`: 1219 ms before, 182 ms after  🎉
* `SubMulAction.mem_ofFixingSubgroup_insert_iff`: 310 ms before, 61 ms after  🎉
* `vectorSpan_add_self`: 1727 ms before, 180 ms after  🎉
* `Submodule.mem_sSup_iff_exists_finset`: 1233 ms before, 315 ms after  🎉
* `Matrix.kroneckerMap_single_single`: 436 ms before, 179 ms after  🎉
* `MeasureTheory.integral_biUnion_eq_sum_powerset`: 550 ms before, 247 ms after  🎉
* `NumberField.mixedEmbedding.fundamentalCone.card_isPrincipal_dvd_norm_le`: 945 ms before, 266 ms after  🎉
* `Set.inl_compl_union_inr_compl`: 263 ms before, 167 ms after  🎉
* `Set.ssubset_iff_sdiff_singleton`: 345 ms before, 78 ms after  🎉
* `Sublattice.le_pi`: 398 ms before, 189 ms after  🎉
* `ProbabilityTheory.Kernel.comapRight_compProd_id_prod`: 250 ms before, 145 ms after  🎉
* `Algebra.adjoin_singleton_induction`: 48 ms before, 22 ms after  🎉
* `Ideal.IsPrime.mul_mem_left_iff`: 146 ms before, 141 ms after  🎉
* `Dense.ciSup'`: 277 ms before, 150 ms after  🎉

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
