### PR TITLE
[Merged by Bors] - fix(AlgebraicTopology/SimplicialNerve): make `SimplicialThickening` a one field structure

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialNerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialNerve.lean
@@ -51,10 +51,9 @@ section SimplicialNerve
 
 /-- A type synonym for a linear order `J`, will be equipped with a simplicial category structure. -/
 @[nolint unusedArguments]
-def SimplicialThickening (J : Type*) [LinearOrder J] : Type _ := J
-
-instance (J : Type*) [LinearOrder J] : LinearOrder (SimplicialThickening J) :=
-  inferInstanceAs (LinearOrder J)
+structure SimplicialThickening (J : Type*) [LinearOrder J] : Type _ where
+  /-- The underlying object of the linear order. -/
+  as : J
 
 namespace SimplicialThickening
 
@@ -79,8 +78,8 @@ instance {J : Type*} [LinearOrder J] (i j : J) : Category (Path i j) :=
 
 @[simps]
 instance (J : Type*) [LinearOrder J] : CategoryStruct (SimplicialThickening J) where
-  Hom i j := Path i j
-  id i := { I := {i} }
+  Hom i j := Path i.as j.as
+  id i := { I := {i.as} }
   comp {i j k} f g := {
     I := f.I ∪ g.I
     left := Or.inl f.left
@@ -93,7 +92,7 @@ instance (J : Type*) [LinearOrder J] : CategoryStruct (SimplicialThickening J) w
       exacts [(f.le_right _ h).trans (Path.le g), (g.le_right l h)] }
 
 instance {J : Type*} [LinearOrder J] (i j : SimplicialThickening J) : Category (i ⟶ j) :=
-  inferInstanceAs (Category (Path _ _))
+  inferInstanceAs (Category (Path i.as j.as))
 
 @[ext]
 lemma hom_ext {J : Type*} [LinearOrder J]
@@ -160,13 +159,10 @@ noncomputable instance (J : Type*) [LinearOrder J] :
   homEquiv {i j} :=
     nerveEquiv.symm.trans (SSet.unitHomEquiv (SimplicialCategory.Hom i j)).symm
 
-/-- Auxiliary definition for `SimplicialThickening.functorMap` -/
-def orderHom {J K : Type*} [LinearOrder J] [LinearOrder K] (f : J →o K) :
-    SimplicialThickening J →o SimplicialThickening K := f
-
 /-- Auxiliary definition for `SimplicialThickening.functor` -/
 noncomputable abbrev functorMap {J K : Type u} [LinearOrder J] [LinearOrder K]
-    (f : J →o K) (i j : SimplicialThickening J) : (i ⟶ j) ⥤ ((orderHom f i) ⟶ (orderHom f j)) where
+    (f : J →o K) (i j : SimplicialThickening J) :
+      (i ⟶ j) ⥤ ((SimplicialThickening.mk <| f i.as) ⟶ (SimplicialThickening.mk <| f j.as)) where
   obj I := ⟨f '' I.I, Set.mem_image_of_mem f I.left, Set.mem_image_of_mem f I.right,
     by rintro _ ⟨k, hk, rfl⟩; exact f.monotone (I.left_le k hk),
     by rintro _ ⟨k, hk, rfl⟩; exact f.monotone (I.le_right k hk)⟩
@@ -181,7 +177,7 @@ simplicial categories
 @[simps]
 noncomputable def functor {J K : Type u} [LinearOrder J] [LinearOrder K]
     (f : J →o K) : EnrichedFunctor SSet (SimplicialThickening J) (SimplicialThickening K) where
-  obj := f
+  obj x := .mk (f x.as)
   map i j := nerveMap ((functorMap f i j))
   map_id i := by
     ext

--- a/Mathlib/AlgebraicTopology/SimplicialNerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialNerve.lean
@@ -168,6 +168,9 @@ noncomputable abbrev functorMap {J K : Type u} [LinearOrder J] [LinearOrder K]
     by rintro _ ⟨k, hk, rfl⟩; exact f.monotone (I.le_right k hk)⟩
   map f := ⟨⟨⟨Set.image_mono f.1.1.1⟩⟩⟩
 
+@[deprecated "No replacement, was using a bad instance" (since := "01-12-2026")]
+alias orderHom := functorMap
+
 attribute [local simp] nerveMap_app
 
 /--


### PR DESCRIPTION
When debugging #33822, a build failure occured in `AlgebraicTopology/SimplicialNerve`, which was due to a bad
instance: linear orders  have an automatic `Category` instance. Thus, recording a `LinearOrder` instance on `SimplicialThickening J` (a type alias for `J` when `J` is a linear order) would conflict with the second `Category` instance put later on that type (where the homs are the type of paths).

This is fixed by making `SimplicialThickening J` a one-field structure.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
