### PR TITLE
[Merged by Bors] - perf(CategoryTheory/Monoidal/Closed/FunctorCategory/Groupoid): remove universe mvars

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Closed/FunctorCategory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/FunctorCategory/Groupoid.lean
@@ -17,6 +17,7 @@ public import Mathlib.CategoryTheory.Monoidal.FunctorCategory
 
 @[expose] public section
 
+universe v u
 
 noncomputable section
 
@@ -24,7 +25,8 @@ open CategoryTheory CategoryTheory.MonoidalCategory CategoryTheory.MonoidalClose
 
 namespace CategoryTheory.Functor
 
-variable {D C : Type*} [Groupoid D] [Category* C] [MonoidalCategory C] [MonoidalClosed C]
+variable {D : Type u} {C : Type*} [Groupoid.{v} D] [Category* C]
+  [MonoidalCategory C] [MonoidalClosed C]
 
 /-- Auxiliary definition for `CategoryTheory.Functor.closed`.
 The internal hom functor `F ⟶[C] -` -/


### PR DESCRIPTION
The file `CategoryTheory/Monoidal/Closed/FunctorCategory/Groupoid` is rather slow. One of the reason is that it uses `{D : Type*} [Groupoid D]`, instead of specifying the universe level for the groupoid instance on `D`.

Found during debugging of #33822.

This is a strong hint that we need `Groupoid*` (and `Quiver*`, `CategoryStruct*`, `Bicategory*` etc.) in addition to the existing `Category*`.

The fix here is minimal. What should really be done about this file is to think about its relevance given that we now have a general way to have `MonoidalClosed` instances on functor categories. The two ways will most likely conflict when they intersect, e.g for functors from a groupoid to a suitably complete monoidal category (recall that `MonoidalClosed` instances carry the data of chosen internal homs).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
