### PR TITLE
[Merged by Bors] - feat(RingTheory/MvPowerSeries): some inequalities related to order

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -306,6 +306,20 @@ theorem le_weightedOrder_prod {R : Type*} [CommSemiring R] {ι : Type*} (w : σ 
 
 alias weightedOrder_mul_ge := le_weightedOrder_mul
 
+theorem le_weightedOrder_smul {a : R} :
+    f.weightedOrder w ≤ (a • f).weightedOrder w :=
+  le_weightedOrder _ fun i hi => by simp [coeff_eq_zero_of_lt_weightedOrder _ hi]
+
+section
+
+variable {S : Type*} [Semiring S]
+
+theorem le_weightedOrder_map (φ : R →+* S) :
+    f.weightedOrder w ≤ (f.map φ).weightedOrder w :=
+  le_weightedOrder w fun i hi => by simp [coeff_eq_zero_of_lt_weightedOrder _ hi]
+
+end
+
 section Ring
 
 variable {R : Type*} [Ring R] {f g : MvPowerSeries σ R}
@@ -461,16 +475,37 @@ theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*}
     (f : ι → MvPowerSeries σ R) (s : Finset ι) : ∑ i ∈ s, (f i).order ≤ (∏ i ∈ s, f i).order :=
   le_weightedOrder_prod _ _ _
 
-theorem order_ne_zero_iff_constCoeff_eq_zero :
-    f.order ≠ 0 ↔ f.constantCoeff = 0 := by
+theorem one_le_order_iff_constCoeff_eq_zero :
+    1 ≤ f.order ↔ f.constantCoeff = 0 := by
   constructor
   · intro h
     apply coeff_of_lt_order
-    simpa using pos_of_ne_zero h
+    simpa using Order.one_le_iff_pos.mp h
   · intro h
-    refine ENat.one_le_iff_ne_zero.mp <| MvPowerSeries.le_order fun d hd ↦ ?_
+    refine MvPowerSeries.le_order fun d hd ↦ ?_
     rw [Nat.cast_lt_one] at hd
     simp [(degree_eq_zero_iff d).mp hd, h]
+
+theorem order_ne_zero_iff_constCoeff_eq_zero :
+    f.order ≠ 0 ↔ f.constantCoeff = 0 :=
+  ⟨fun h => one_le_order_iff_constCoeff_eq_zero.mp (ENat.one_le_iff_ne_zero.mpr h),
+    fun h => ENat.one_le_iff_ne_zero.mp (one_le_order_iff_constCoeff_eq_zero.mpr h)⟩
+
+theorem le_order_pow' (n : ℕ) (hf : f.constantCoeff = 0) :
+    n ≤ (f ^ n).order := by
+  refine .trans ?_ (le_order_pow n)
+  simpa using le_mul_of_one_le_right' (one_le_order_iff_constCoeff_eq_zero.mpr hf)
+
+theorem le_order_smul {a : R} : f.order ≤ (a • f).order := le_weightedOrder_smul _
+
+section
+
+variable {S : Type*} [Semiring S]
+
+theorem le_order_map (f : R →+* S) {φ : MvPowerSeries σ R} : φ.order ≤ (φ.map f).order :=
+  le_weightedOrder_map _ _
+
+end
 
 section Ring
 

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -487,11 +487,10 @@ theorem one_le_order_iff_constCoeff_eq_zero :
     simp [(degree_eq_zero_iff d).mp hd, h]
 
 theorem order_ne_zero_iff_constCoeff_eq_zero :
-    f.order ≠ 0 ↔ f.constantCoeff = 0 :=
-  ⟨fun h => one_le_order_iff_constCoeff_eq_zero.mp (ENat.one_le_iff_ne_zero.mpr h),
-    fun h => ENat.one_le_iff_ne_zero.mp (one_le_order_iff_constCoeff_eq_zero.mpr h)⟩
+    f.order ≠ 0 ↔ f.constantCoeff = 0 := by
+  rw [← ENat.one_le_iff_ne_zero, one_le_order_iff_constCoeff_eq_zero]
 
-theorem le_order_pow' (n : ℕ) (hf : f.constantCoeff = 0) :
+theorem le_order_pow_of_constantCoeff_eq_zero (n : ℕ) (hf : f.constantCoeff = 0) :
     n ≤ (f ^ n).order := by
   refine .trans ?_ (le_order_pow n)
   simpa using le_mul_of_one_le_right' (one_le_order_iff_constCoeff_eq_zero.mpr hf)

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -178,6 +178,14 @@ theorem order_add_of_order_ne (φ ψ : R⟦X⟧) (h : order φ ≠ order ψ) :
 
 @[deprecated (since := "2025-09-17")] alias order_add_of_order_eq := order_add_of_order_ne
 
+theorem le_order_map {S : Type*} [Semiring S] (f : R →+* S) :
+    φ.order ≤ (φ.map f).order :=
+  le_order _ _ fun i hi => by simp [coeff_of_lt_order i hi]
+
+theorem le_order_smul {a : R} :
+    φ.order ≤ (a • φ).order :=
+  le_order _ φ.order fun i hi => by simp [coeff_of_lt_order i hi]
+
 /-- The order of the product of two formal power series
 is at least the sum of their orders. -/
 theorem le_order_mul (φ ψ : R⟦X⟧) : order φ + order ψ ≤ order (φ * ψ) := by
@@ -206,17 +214,27 @@ theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*} (φ : ι → R�
 
 alias order_mul_ge := le_order_mul
 
-theorem order_ne_zero_iff_constCoeff_eq_zero {φ : R⟦X⟧} :
-    φ.order ≠ 0 ↔ φ.constantCoeff = 0 := by
+theorem one_le_order_iff_constCoeff_eq_zero :
+    1 ≤ φ.order ↔ φ.constantCoeff = 0 := by
   constructor
   · intro h
-    rw [← PowerSeries.coeff_zero_eq_constantCoeff]
+    rw [← coeff_zero_eq_constantCoeff]
     apply coeff_of_lt_order
-    simpa using pos_of_ne_zero h
+    simpa using Order.one_le_iff_pos.mp h
   · intro h
-    refine ENat.one_le_iff_ne_zero.mp <| PowerSeries.le_order _ _ fun d hd ↦ ?_
+    refine le_order _ _ fun d hd ↦ ?_
     rw [Nat.cast_lt_one] at hd
     simp [hd, h]
+
+theorem order_ne_zero_iff_constCoeff_eq_zero {φ : R⟦X⟧} :
+    φ.order ≠ 0 ↔ φ.constantCoeff = 0 :=
+  ⟨fun h => one_le_order_iff_constCoeff_eq_zero.mp (ENat.one_le_iff_ne_zero.mpr h),
+    fun h => ENat.one_le_iff_ne_zero.mp (one_le_order_iff_constCoeff_eq_zero.mpr h)⟩
+
+theorem le_order_pow' (n : ℕ) (hf : φ.constantCoeff = 0) :
+    n ≤ (φ ^ n).order := by
+  refine .trans ?_ (le_order_pow _ n)
+  simpa using le_mul_of_one_le_right' (one_le_order_iff_constCoeff_eq_zero.mpr hf)
 
 /-- The order of the monomial `a*X^n` is infinite if `a = 0` and `n` otherwise. -/
 theorem order_monomial (n : ℕ) (a : R) [Decidable (a = 0)] :

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -227,11 +227,10 @@ theorem one_le_order_iff_constCoeff_eq_zero :
     simp [hd, h]
 
 theorem order_ne_zero_iff_constCoeff_eq_zero {φ : R⟦X⟧} :
-    φ.order ≠ 0 ↔ φ.constantCoeff = 0 :=
-  ⟨fun h => one_le_order_iff_constCoeff_eq_zero.mp (ENat.one_le_iff_ne_zero.mpr h),
-    fun h => ENat.one_le_iff_ne_zero.mp (one_le_order_iff_constCoeff_eq_zero.mpr h)⟩
+    φ.order ≠ 0 ↔ φ.constantCoeff = 0 := by
+  rw [← ENat.one_le_iff_ne_zero, one_le_order_iff_constCoeff_eq_zero]
 
-theorem le_order_pow' (n : ℕ) (hf : φ.constantCoeff = 0) :
+theorem le_order_pow_of_constantCoeff_eq_zero (n : ℕ) (hf : φ.constantCoeff = 0) :
     n ≤ (φ ^ n).order := by
   refine .trans ?_ (le_order_pow _ n)
   simpa using le_mul_of_one_le_right' (one_le_order_iff_constCoeff_eq_zero.mpr hf)

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -283,6 +283,26 @@ theorem le_order_subst (a : MvPowerSeries τ S) (ha : HasSubst a) (f : PowerSeri
   refine .trans ?_ (MvPowerSeries.le_order_subst (PowerSeries.hasSubst_iff.mp ha) _)
   simp [order_eq_order]
 
+theorem le_order_subst_left {f : MvPowerSeries τ R} {φ : PowerSeries R}
+    (hf : f.constantCoeff = 0) : φ.order ≤ (φ.subst f).order :=
+  .trans (ENat.self_le_mul_left φ.order (f.order_ne_zero_iff_constCoeff_eq_zero.mpr hf))
+    (PowerSeries.le_order_subst f (HasSubst.of_constantCoeff_zero hf) _)
+
+theorem le_order_subst_right {f : MvPowerSeries τ R} {φ : PowerSeries R}
+    (hf : f.constantCoeff = 0) (hφ : φ.constantCoeff = 0) : f.order ≤ (φ.subst f).order :=
+  .trans (ENat.self_le_mul_right _ (order_ne_zero_iff_constCoeff_eq_zero.mpr hφ))
+    (PowerSeries.le_order_subst f (HasSubst.of_constantCoeff_zero hf) _)
+
+theorem le_order_subst_left' {f φ : PowerSeries R} (hf : f.constantCoeff = 0) :
+    φ.order ≤ PowerSeries.order (φ.subst f) := by
+  conv_rhs => rw [order_eq_order]
+  exact le_order_subst_left hf
+
+theorem le_order_subst_right' {f φ : PowerSeries R} (hf : f.constantCoeff = 0)
+    (hφ : φ.constantCoeff = 0) : f.order ≤ PowerSeries.order (φ.subst f) := by
+  simp_rw [order_eq_order]
+  exact le_order_subst_right hf hφ
+
 end
 
 theorem HasSubst.comp


### PR DESCRIPTION
Some inequalities related to order of (mv) power series. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
