### PR TITLE
[Merged by Bors] - feat(RingTheory/MvPowerSeries): some theorems about expand

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -51,12 +51,13 @@ theorem expand_monomial (d : σ →₀ ℕ) (r : R) :
   · simp [pow_mul, algebraMap_apply, Algebra.algebraMap_self]
   · simp
 
-@[simp]
 theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := by
   ext1 i
   simp [expand, subst_self]
 
-theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by simp
+@[simp]
+theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by
+  rw [expand_one, AlgHom.id_apply]
 
 @[simp]
 theorem map_expand (f : R →+* S) (φ : MvPowerSeries σ R) :

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -56,6 +56,7 @@ theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := 
   ext1 i
   simp [expand, subst_self]
 
+@[simp]
 theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by simp
 
 @[simp]
@@ -77,6 +78,10 @@ theorem expand_comp_substAlgHom {f : σ → MvPowerSeries τ S} (hf : HasSubst f
 theorem expand_substAlgHom {f : σ → MvPowerSeries τ S} (hf : HasSubst f) {φ : MvPowerSeries σ S} :
     expand p hp (substAlgHom hf φ) = substAlgHom (HasSubst.expand p hp hf) φ := by
   rw [← AlgHom.comp_apply, expand_comp_substAlgHom]
+
+theorem expand_subst {f : σ → MvPowerSeries τ R} (hf : HasSubst f) {φ : MvPowerSeries σ R} :
+    expand p hp (subst f φ) = subst (fun i ↦ (f i).expand p hp) φ := by
+  rw [← substAlgHom_apply hf, expand_substAlgHom, substAlgHom_apply]
 
 end
 
@@ -108,6 +113,12 @@ theorem coeff_expand_smul (φ : MvPowerSeries σ R) (m : σ →₀ ℕ) :
   · intro d hd
     rw [this, coeff_monomial, if_neg _, mul_zero]
     simp [nsmul_right_inj hp, hd.symm]
+
+@[simp]
+theorem constantCoeff_expand (φ : MvPowerSeries σ R) :
+    (φ.expand p hp).constantCoeff = φ.constantCoeff := by
+  conv_lhs => rw [← coeff_zero_eq_constantCoeff, ← smul_zero p, coeff_expand_smul]
+  simp
 
 theorem coeff_expand_of_not_dvd (φ : MvPowerSeries σ R) {m : σ →₀ ℕ} {i : σ} (h : ¬ p ∣ m i) :
     (expand p hp φ).coeff m = 0 := by
@@ -147,6 +158,26 @@ theorem support_expand (φ : MvPowerSeries σ R) :
   by_contra hc
   rw [Function.mem_support, ← coeff_apply φ, ← coeff_expand_smul p hp, coeff_apply, hc] at hn₁
   contradiction
+
+@[simp]
+theorem order_expand (φ : MvPowerSeries σ R) :
+    (φ.expand p hp).order = p • φ.order := by
+  by_cases! hφ : φ = 0
+  · simpa [hφ] using (ENat.mul_top (by norm_cast)).symm
+  · apply eq_of_le_of_ge
+    · obtain ⟨d, hd₁, hd₂⟩ := exists_coeff_ne_zero_and_order (ne_zero_iff_order_finite.mp hφ)
+      have : p • φ.order = (p • d).degree := by simp [← hd₂]
+      rw [this]
+      exact order_le <| (coeff_expand_smul p hp φ _) ▸ hd₁
+    · refine MvPowerSeries.le_order fun d hd => by
+        by_cases! h : ∀ i, p ∣ d i
+        · obtain ⟨m, hm⟩ : ∃ m, d = p • m := ⟨Finsupp.equivFunOnFinite.symm fun i => d i / p,
+            by ext i; simp [(Nat.mul_div_cancel' (h i))]⟩
+          rw [hm, coeff_expand_smul, coeff_of_lt_order]
+          simp only [hm, map_nsmul, smul_eq_mul, Nat.cast_mul, nsmul_eq_mul] at hd
+          exact lt_of_mul_lt_mul_left' hd
+        · obtain ⟨i, hi⟩ := h
+          exact coeff_expand_of_not_dvd p hp φ hi
 
 section MvPolynomial
 

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -51,11 +51,11 @@ theorem expand_monomial (d : σ →₀ ℕ) (r : R) :
   · simp [pow_mul, algebraMap_apply, Algebra.algebraMap_self]
   · simp
 
+@[simp]
 theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := by
   ext1 i
   simp [expand, subst_self]
 
-@[simp]
 theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by
   rw [expand_one, AlgHom.id_apply]
 

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -56,8 +56,7 @@ theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := 
   ext1 i
   simp [expand, subst_self]
 
-theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by
-  rw [expand_one, AlgHom.id_apply]
+theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by simp
 
 @[simp]
 theorem map_expand (f : R →+* S) (φ : MvPowerSeries σ R) :

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -56,7 +56,6 @@ theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := 
   ext1 i
   simp [expand, subst_self]
 
-@[simp]
 theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by simp
 
 @[simp]

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -283,6 +283,21 @@ theorem constantCoeff_subst (ha : HasSubst a) (f : MvPowerSeries σ R) :
       finsum (fun d ↦ coeff d f • (constantCoeff (d.prod fun s e => (a s) ^ e))) := by
   simp only [← coeff_zero_eq_constantCoeff_apply, coeff_subst ha f 0]
 
+theorem constantCoeff_subst_zero [Fintype σ] (ha : ∀ i, (a i).constantCoeff = 0)
+    (f : MvPowerSeries σ R) (hf : f.constantCoeff = 0) :
+    MvPowerSeries.constantCoeff (subst a f) = 0 := by
+  rw [constantCoeff_subst (hasSubst_of_constantCoeff_zero ha), finsum_eq_zero_of_forall_eq_zero]
+  intro d
+  by_cases hd : d = 0
+  · simp [hd, hf]
+  · have : constantCoeff (d.prod fun s e ↦ a s ^ e) = 0 := by
+      obtain ⟨i, hi⟩ : ∃ i : σ, d i ≠ 0 := by
+        by_contra! hc
+        exact hd <| Finsupp.ext hc
+      simp_rw [Finsupp.prod_pow, map_prod, map_pow]
+      exact Finset.prod_eq_zero (i := i) (by simp) (by simp [ha, zero_pow hi])
+    rw [this, smul_zero]
+
 theorem map_algebraMap_eq_subst_X (f : MvPowerSeries σ R) :
     map (algebraMap R S) f = subst X f := by
   ext e

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -283,10 +283,10 @@ theorem constantCoeff_subst (ha : HasSubst a) (f : MvPowerSeries σ R) :
       finsum (fun d ↦ coeff d f • (constantCoeff (d.prod fun s e => (a s) ^ e))) := by
   simp only [← coeff_zero_eq_constantCoeff_apply, coeff_subst ha f 0]
 
-theorem constantCoeff_subst_zero [Fintype σ] (ha : ∀ i, (a i).constantCoeff = 0)
-    (f : MvPowerSeries σ R) (hf : f.constantCoeff = 0) :
+theorem constantCoeff_subst_eq_zero (ha : HasSubst a) (ha' : ∀ i, (a i).constantCoeff = 0)
+    {f : MvPowerSeries σ R} (hf : f.constantCoeff = 0) :
     MvPowerSeries.constantCoeff (subst a f) = 0 := by
-  rw [constantCoeff_subst (hasSubst_of_constantCoeff_zero ha), finsum_eq_zero_of_forall_eq_zero]
+  rw [constantCoeff_subst ha, finsum_eq_zero_of_forall_eq_zero]
   intro d
   by_cases hd : d = 0
   · simp [hd, hf]
@@ -294,8 +294,8 @@ theorem constantCoeff_subst_zero [Fintype σ] (ha : ∀ i, (a i).constantCoeff =
       obtain ⟨i, hi⟩ : ∃ i : σ, d i ≠ 0 := by
         by_contra! hc
         exact hd <| Finsupp.ext hc
-      simp_rw [Finsupp.prod_pow, map_prod, map_pow]
-      exact Finset.prod_eq_zero (i := i) (by simp) (by simp [ha, zero_pow hi])
+      simpa [map_finsuppProd, ha'] using
+        Finset.prod_eq_zero (i := i) (by simp [hi]) (by simp [zero_pow hi])
     rw [this, smul_zero]
 
 theorem map_algebraMap_eq_subst_X (f : MvPowerSeries σ R) :

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -60,11 +60,12 @@ theorem expand_monomial (d : ℕ) (r : R) :
     expand p hp (monomial d r) = monomial (p * d) r := by
   simp [expand, monomial, MvPowerSeries.expand_monomial]
 
-theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (PowerSeries R) := by
-  simp [expand, MvPowerSeries.expand_one]
-
 @[simp]
-theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by simp [expand]
+theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (PowerSeries R) := by
+  simp [expand]
+
+theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by
+  rw [expand_one, AlgHom.id_apply]
 
 @[simp]
 theorem map_expand (f : R →+* S) (φ : PowerSeries R) :

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -64,8 +64,7 @@ theorem expand_monomial (d : ℕ) (r : R) :
 theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (PowerSeries R) := by
   simp [expand]
 
-theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by
-  rw [expand_one, AlgHom.id_apply]
+theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by simp
 
 @[simp]
 theorem map_expand (f : R →+* S) (φ : PowerSeries R) :

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -60,11 +60,11 @@ theorem expand_monomial (d : ℕ) (r : R) :
     expand p hp (monomial d r) = monomial (p * d) r := by
   simp [expand, monomial, MvPowerSeries.expand_monomial]
 
-@[simp]
 theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (PowerSeries R) := by
-  simp [expand]
+  simp [expand, MvPowerSeries.expand_one]
 
-theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by simp
+@[simp]
+theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by simp [expand]
 
 @[simp]
 theorem map_expand (f : R →+* S) (φ : PowerSeries R) :

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -222,6 +222,14 @@ theorem constantCoeff_subst (ha : HasSubst a) (f : PowerSeries R) :
       finsum (fun d ↦ coeff d f • MvPowerSeries.constantCoeff (a ^ d)) := by
   simp only [← MvPowerSeries.coeff_zero_eq_constantCoeff_apply, coeff_subst ha f 0]
 
+theorem constantCoeff_subst_zero (ha : a.constantCoeff = 0) (f : PowerSeries R)
+    (hf : f.constantCoeff = 0) : MvPowerSeries.constantCoeff (subst a f) = 0 := by
+  rw [constantCoeff_subst (HasSubst.of_constantCoeff_zero ha), finsum_eq_zero_of_forall_eq_zero]
+  intro d
+  by_cases hd : d = 0
+  · simp [hd, hf]
+  · simp [ha, zero_pow hd]
+
 theorem map_algebraMap_eq_subst_X (f : R⟦X⟧) :
     map (algebraMap R S) f = subst X f :=
   MvPowerSeries.map_algebraMap_eq_subst_X f

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -222,7 +222,7 @@ theorem constantCoeff_subst (ha : HasSubst a) (f : PowerSeries R) :
       finsum (fun d ↦ coeff d f • MvPowerSeries.constantCoeff (a ^ d)) := by
   simp only [← MvPowerSeries.coeff_zero_eq_constantCoeff_apply, coeff_subst ha f 0]
 
-theorem constantCoeff_subst_zero (ha : a.constantCoeff = 0) (f : PowerSeries R)
+theorem constantCoeff_subst_eq_zero (ha : a.constantCoeff = 0) (f : PowerSeries R)
     (hf : f.constantCoeff = 0) : MvPowerSeries.constantCoeff (subst a f) = 0 := by
   rw [constantCoeff_subst (HasSubst.of_constantCoeff_zero ha), finsum_eq_zero_of_forall_eq_zero]
   intro d


### PR DESCRIPTION
---
I add some theorems for `MvPowerSeries.expand` to make it reusable. 
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
