### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift): more API for NatTrans.CommShift

### DIFF
--- a/Mathlib/CategoryTheory/NatIso.lean
+++ b/Mathlib/CategoryTheory/NatIso.lean
@@ -248,4 +248,14 @@ def isoCopyObj : F ≅ F.copyObj obj e :=
 
 end Functor
 
+@[reassoc]
+lemma NatTrans.naturality_1 {F G : C ⥤ D} (α : F ⟶ G) {X Y : C} (e : X ≅ Y) :
+    F.map e.inv ≫ α.app X ≫ G.map e.hom = α.app Y := by
+  simp
+
+@[reassoc]
+lemma NatTrans.naturality_2 {F G : C ⥤ D} (α : F ⟶ G) {X Y : C} (e : X ≅ Y) :
+    F.map e.hom ≫ α.app Y ≫ G.map e.inv = α.app X := by
+  simp
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -499,8 +499,8 @@ def ofHasShiftOfFullyFaithful :
 end CommShift
 
 lemma shiftFunctorIso_ofHasShiftOfFullyFaithful (a : A) :
-    letI := hF.hasShift s i;
-    letI := CommShift.ofHasShiftOfFullyFaithful hF s i;
+    letI := hF.hasShift s i
+    letI := CommShift.ofHasShiftOfFullyFaithful hF s i
     F.commShiftIso a = i a := by
   rfl
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -520,8 +520,6 @@ lemma map_shiftFunctorComm
   dsimp
   simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, Category.assoc,
     ← reassoc_of% this, shiftFunctorComm_eq C a b _ rfl]
-  dsimp
-  rw [Functor.map_comp]
   simp [NatTrans.congr_app (congr_arg Iso.hom (F.commShiftIso_add' (add_comm b a))) X,
     ← Functor.map_comp_assoc]
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 module
 
 public import Mathlib.CategoryTheory.Shift.Basic
+public import Mathlib.CategoryTheory.NatIso
 
 /-!
 # Functors which commute with shifts
@@ -101,6 +102,41 @@ lemma isoAdd_inv_app {a b : A}
         (shiftFunctor D b).map (e₁.inv.app X) ≫ e₂.inv.app ((shiftFunctor C a).obj X) ≫
         F.map ((shiftFunctorAdd C a b).inv.app X) := by
   simp only [isoAdd, isoAdd'_inv_app, shiftFunctorAdd'_eq_shiftFunctorAdd]
+
+lemma isoAdd'_isoZero {a : A}
+    (e : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a) :
+    isoAdd' (add_zero a) e (isoZero F A) = e := by
+  ext X
+  simp [shiftFunctorAdd'_add_zero_hom_app, ← Functor.map_comp_assoc,
+    shiftFunctorAdd'_add_zero_inv_app]
+
+lemma isoZero_isoAdd'_ {a : A}
+    (e : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a) :
+    isoAdd' (zero_add a) (isoZero F A) e = e := by
+  ext X
+  have := e.hom.naturality ((shiftFunctorZero C A).inv.app X)
+  dsimp at this
+  simp [shiftFunctorAdd'_zero_add_hom_app,
+    shiftFunctorAdd'_zero_add_inv_app, ← map_comp,
+    reassoc_of% this]
+
+lemma isoAdd'_assoc {a b c ab bc abc : A}
+    (ea : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a)
+    (eb : shiftFunctor C b ⋙ F ≅ F ⋙ shiftFunctor D b)
+    (ec : shiftFunctor C c ⋙ F ≅ F ⋙ shiftFunctor D c)
+    (hab : a + b = ab) (hbc : b + c = bc) (h : a + b + c = abc) :
+    isoAdd' (show ab + c = abc by rwa [← hab]) (isoAdd' hab ea eb) ec =
+      isoAdd' (by rwa [← hbc, ← add_assoc]) ea (isoAdd' hbc eb ec) := by
+  ext X
+  have := NatTrans.naturality_2 ec.hom ((shiftFunctorAdd' C a b ab hab).app X)
+  dsimp at this ⊢
+  simp only [isoAdd'_hom_app, Category.assoc]
+  rw [← NatTrans.naturality_assoc, ← this, Category.assoc, ← F.map_comp_assoc,
+    shiftFunctorAdd'_assoc_hom_app a b c ab bc abc hab hbc h,
+    Functor.map_comp_assoc, Category.assoc]
+  nth_rw 2 [← Functor.map_comp_assoc]
+  nth_rw 2 [← Functor.map_comp_assoc]
+  simp [shiftFunctorAdd'_assoc_inv_app a b c ab bc abc hab hbc h]
 
 end CommShift
 
@@ -245,6 +281,66 @@ variable {C D E J : Type*} [Category* C] [Category* D] [Category* E] [Category* 
   [F₁.CommShift A] [F₂.CommShift A] [F₃.CommShift A]
     [G.CommShift A] [G'.CommShift A] [H.CommShift A]
 
+variable {A} in
+/-- Auxiliary structure for `NatTrans.CommShift` when we need to
+show a compatibility of a natural transformation `τ : F₁ ⟶ F₂` with
+respect to the shift by a specific element `a`. See also
+`NatTrans.CommShift.of_core` -/
+structure CommShiftCore (a : A) : Prop where
+  shift_comm : (F₁.commShiftIso a).hom ≫ Functor.whiskerRight τ _ =
+    Functor.whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom
+
+namespace CommShiftCore
+
+section
+
+variable {A} {a : A} (hτ : CommShiftCore τ a)
+
+include hτ
+
+@[reassoc]
+lemma shift_app_comm (X : C) :
+    (F₁.commShiftIso a).hom.app X ≫ (τ.app X)⟦a⟧' =
+      τ.app (X⟦a⟧) ≫ (F₂.commShiftIso a).hom.app X :=
+  congr_app hτ.shift_comm X
+
+@[reassoc]
+lemma shift_app (X : C) :
+    (τ.app X)⟦a⟧' = (F₁.commShiftIso a).inv.app X ≫
+      τ.app (X⟦a⟧) ≫ (F₂.commShiftIso a).hom.app X := by
+  rw [← hτ.shift_app_comm, Iso.inv_hom_id_app_assoc]
+
+@[reassoc]
+lemma app_shift (X : C) :
+    τ.app (X⟦a⟧) = (F₁.commShiftIso a).hom.app X ≫ (τ.app X)⟦a⟧' ≫
+      (F₂.commShiftIso a).inv.app X := by
+  simp [hτ.shift_app_comm_assoc τ X]
+
+end
+
+variable {τ}
+
+lemma zero : CommShiftCore τ (0 : A) where
+  shift_comm := by
+    ext X
+    simp [Functor.commShiftIso_zero, ← NatTrans.naturality]
+
+variable {A}
+
+lemma add {a b : A} (ha : CommShiftCore τ a) (hb : CommShiftCore τ b) :
+    CommShiftCore τ (a + b) where
+  shift_comm := by
+    ext X
+    have := (shiftFunctorAdd D a b).inv.naturality (τ.app X)
+    dsimp at this ⊢
+    simp only [Functor.commShiftIso_add, Functor.CommShift.isoAdd_hom_app,
+      ← NatTrans.naturality_2 τ ((shiftFunctorAdd C a b).app X),
+      Functor.comp_obj, hb.app_shift_assoc, ha.app_shift, assoc,
+      (shiftFunctor D b).map_comp_assoc]
+    simp [← Functor.map_comp_assoc, this]
+
+end CommShiftCore
+
 /-- If `τ : F₁ ⟶ F₂` is a natural transformation between two functors
 which commute with a shift by an additive monoid `A`, this typeclass
 asserts a compatibility of `τ` with these shifts. -/
@@ -254,7 +350,14 @@ class CommShift : Prop where
 
 section
 
-variable {A} [NatTrans.CommShift τ A]
+variable {A}
+
+variable {τ} in
+lemma CommShift.of_core (h : ∀ (a : A), CommShiftCore τ a) :
+    CommShift τ A where
+  shift_comm a := (h a).shift_comm
+
+variable [NatTrans.CommShift τ A]
 
 @[reassoc]
 lemma shift_comm (a : A) :
@@ -361,6 +464,135 @@ lemma ofIso_compatibility :
     NatTrans.CommShift e.hom A := by
   letI := ofIso e A
   exact ⟨fun a => by ext; simp [ofIso_commShiftIso_hom_app]⟩
+
+end CommShift
+
+end Functor
+
+namespace Functor
+
+variable {C D E : Type*} [Category* C] [Category* D] [Category* E] {A : Type*}
+
+section hasShiftOfFullyFaithful
+
+variable [AddMonoid A] [HasShift D A]
+  {F : C ⥤ D} (hF : F.FullyFaithful)
+  (s : A → C ⥤ C) (i : ∀ i, s i ⋙ F ≅ F ⋙ shiftFunctor D i)
+
+namespace CommShift
+
+/-- If `F : C ⥤ D` is a fully faithful functor which is used
+to construct a shift by `A` on `C` from a shift on `D`,
+then the functor `F` itself commutes with the shift by `A`. -/
+def ofHasShiftOfFullyFaithful :
+    letI := hF.hasShift s i; F.CommShift A := by
+  letI := hF.hasShift s i
+  exact
+  { commShiftIso := i
+    commShiftIso_zero := by
+      ext X
+      simp [ShiftMkCore.shiftFunctorZero_eq]
+    commShiftIso_add := fun a b => by
+      ext X
+      simp [ShiftMkCore.shiftFunctorAdd_eq, ShiftMkCore.shiftFunctor_eq,
+        ← Functor.map_comp_assoc] }
+
+end CommShift
+
+lemma shiftFunctorIso_ofHasShiftOfFullyFaithful (a : A) :
+    letI := hF.hasShift s i;
+    letI := CommShift.ofHasShiftOfFullyFaithful hF s i;
+    F.commShiftIso a = i a := by
+  rfl
+
+end hasShiftOfFullyFaithful
+
+lemma map_shiftFunctorComm
+    [AddCommMonoid A] [HasShift C A] [HasShift D A]
+    (F : C ⥤ D) [F.CommShift A] (X : C) (a b : A) :
+    F.map ((shiftFunctorComm C a b).hom.app X) = (F.commShiftIso b).hom.app (X⟦a⟧) ≫
+      ((F.commShiftIso a).hom.app X)⟦b⟧' ≫ (shiftFunctorComm D a b).hom.app (F.obj X) ≫
+      ((F.commShiftIso b).inv.app X)⟦a⟧' ≫ (F.commShiftIso a).inv.app (X⟦b⟧) := by
+  have := NatTrans.congr_app (congr_arg Iso.hom (F.commShiftIso_add a b)) X
+  simp only [comp_obj, CommShift.isoAdd_hom_app,
+    ← cancel_epi (F.map ((shiftFunctorAdd C a b).inv.app X)),
+    ← F.map_comp_assoc, Iso.inv_hom_id_app, F.map_id, Category.id_comp] at this
+  simp only [shiftFunctorComm_eq D a b _ rfl]
+  dsimp
+  simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, Category.assoc,
+    ← reassoc_of% this, shiftFunctorComm_eq C a b _ rfl]
+  dsimp
+  rw [Functor.map_comp]
+  simp [NatTrans.congr_app (congr_arg Iso.hom (F.commShiftIso_add' (add_comm b a))) X,
+    ← Functor.map_comp_assoc]
+
+namespace CommShift
+
+variable {F : C ⥤ D} {G : D ⥤ E} {H : C ⥤ E} (e : F ⋙ G ≅ H)
+  [Full G] [Faithful G]
+  (A : Type*) [AddMonoid A] [HasShift C A] [HasShift D A] [HasShift E A]
+  [G.CommShift A] [H.CommShift A]
+
+namespace OfComp
+
+variable {A}
+
+/-- Auxiliary definition for `Functor.CommShift.ofComp`. -/
+noncomputable def iso (a : A) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a :=
+  ((whiskeringRight C D E).obj G).preimageIso (Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft _ e ≪≫
+    H.commShiftIso a ≪≫ isoWhiskerRight e.symm _ ≪≫ Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft F (G.commShiftIso a).symm ≪≫ (Functor.associator _ _ _).symm)
+
+@[simp]
+lemma map_iso_hom_app (a : A) (X : C) :
+    G.map ((iso e a).hom.app X) = e.hom.app (X⟦a⟧) ≫
+      (H.commShiftIso a).hom.app X ≫ (e.inv.app X)⟦a⟧' ≫
+      (G.commShiftIso a).inv.app (F.obj X) := by
+  have h : ((whiskeringRight C D E).obj G).map (iso e a).hom = _ :=
+    Functor.map_preimage _ _
+  simpa using congr_app h X
+
+@[simp]
+lemma map_iso_inv_app (a : A) (X : C) :
+    G.map ((iso e a).inv.app X) =
+      (G.commShiftIso a).hom.app (F.obj X) ≫ (e.hom.app X)⟦a⟧' ≫
+      (H.commShiftIso a).inv.app X ≫ e.inv.app (X⟦a⟧) := by
+  have h : ((whiskeringRight C D E).obj G).map (iso e a).inv = _ :=
+    Functor.map_preimage _ _
+  simpa using congr_app h X
+
+attribute [irreducible] iso
+
+end OfComp
+
+/-- Given an isomorphism `e : F ⋙ G ≅ H` where `G` is fully faithful,
+the functor `F` commutes with shifts by `A` if `G` and `H` do. -/
+noncomputable def ofComp : F.CommShift A where
+  commShiftIso := OfComp.iso e
+  commShiftIso_zero := by
+    ext X
+    apply G.map_injective
+    simp [G.commShiftIso_zero, H.commShiftIso_zero]
+  commShiftIso_add a b := by
+    ext X
+    apply G.map_injective
+    simp only [comp_obj, OfComp.map_iso_hom_app, H.commShiftIso_add, isoAdd_hom_app,
+      G.commShiftIso_add, isoAdd_inv_app, NatTrans.naturality_assoc, comp_map, assoc,
+      Iso.inv_hom_id_app_assoc, map_comp]
+    simp only [← NatTrans.naturality_assoc, ← commShiftIso_inv_naturality_assoc,
+      ← Functor.map_comp_assoc]
+    congr 4
+    simp
+
+lemma ofComp_compatibility :
+    letI := ofComp e
+    NatTrans.CommShift e.hom A := by
+  letI := ofComp e
+  refine ⟨fun a ↦ ?_⟩
+  ext X
+  simp [commShiftIso_comp_hom_app, show F.commShiftIso a = OfComp.iso e a from rfl,
+    ← Functor.map_comp]
 
 end CommShift
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -543,7 +543,7 @@ noncomputable def iso (a : A) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D 
       H.commShiftIso a ≪≫ isoWhiskerRight e.symm _ ≪≫ Functor.associator _ _ _ ≪≫
         isoWhiskerLeft F (G.commShiftIso a).symm ≪≫ (Functor.associator _ _ _).symm)
 
-@[simp]
+@[simp, reassoc]
 lemma map_iso_hom_app (a : A) (X : C) :
     G.map ((iso e a).hom.app X) = e.hom.app (X⟦a⟧) ≫
       (H.commShiftIso a).hom.app X ≫ (e.inv.app X)⟦a⟧' ≫

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -506,6 +506,7 @@ lemma shiftFunctorIso_ofHasShiftOfFullyFaithful (a : A) :
 
 end hasShiftOfFullyFaithful
 
+@[reassoc]
 lemma map_shiftFunctorComm
     [AddCommMonoid A] [HasShift C A] [HasShift D A]
     (F : C ⥤ D) [F.CommShift A] (X : C) (a b : A) :

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -291,6 +291,8 @@ structure CommShiftCore (a : A) : Prop where
 
 namespace CommShiftCore
 
+attribute [reassoc] shift_comm
+
 section
 
 variable {A} {a : A} (hτ : CommShiftCore τ a)

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -134,8 +134,7 @@ lemma isoAdd'_assoc {a b c ab bc abc : A}
   rw [← NatTrans.naturality_assoc, ← this, Category.assoc, ← F.map_comp_assoc,
     shiftFunctorAdd'_assoc_hom_app a b c ab bc abc hab hbc h,
     Functor.map_comp_assoc, Category.assoc]
-  nth_rw 2 [← Functor.map_comp_assoc]
-  nth_rw 2 [← Functor.map_comp_assoc]
+  simp_rw [← Functor.map_comp_assoc]
   simp [shiftFunctorAdd'_assoc_inv_app a b c ab bc abc hab hbc h]
 
 end CommShift

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -126,7 +126,7 @@ lemma isoAdd'_assoc {a b c ab bc abc : A}
     (ec : shiftFunctor C c ⋙ F ≅ F ⋙ shiftFunctor D c)
     (hab : a + b = ab) (hbc : b + c = bc) (h : a + b + c = abc) :
     isoAdd' (show ab + c = abc by rwa [← hab]) (isoAdd' hab ea eb) ec =
-      isoAdd' (by rwa [← hbc, ← add_assoc]) ea (isoAdd' hbc eb ec) := by
+      isoAdd' (show a + bc = abc by grind) ea (isoAdd' hbc eb ec) := by
   ext X
   have := NatTrans.naturality_2 ec.hom ((shiftFunctorAdd' C a b ab hab).app X)
   dsimp at this ⊢

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -539,10 +539,10 @@ variable {A}
 
 /-- Auxiliary definition for `Functor.CommShift.ofComp`. -/
 noncomputable def iso (a : A) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a :=
-  ((whiskeringRight C D E).obj G).preimageIso (Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft _ e ≪≫
-    H.commShiftIso a ≪≫ isoWhiskerRight e.symm _ ≪≫ Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft F (G.commShiftIso a).symm ≪≫ (Functor.associator _ _ _).symm)
+  ((whiskeringRight C D E).obj G).preimageIso
+    (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ e ≪≫
+      H.commShiftIso a ≪≫ isoWhiskerRight e.symm _ ≪≫ Functor.associator _ _ _ ≪≫
+        isoWhiskerLeft F (G.commShiftIso a).symm ≪≫ (Functor.associator _ _ _).symm)
 
 @[simp]
 lemma map_iso_hom_app (a : A) (X : C) :

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -553,7 +553,7 @@ lemma map_iso_hom_app (a : A) (X : C) :
     Functor.map_preimage _ _
   simpa using congr_app h X
 
-@[simp]
+@[simp, reassoc]
 lemma map_iso_inv_app (a : A) (X : C) :
     G.map ((iso e a).inv.app X) =
       (G.commShiftIso a).hom.app (F.obj X) ≫ (e.hom.app X)⟦a⟧' ≫


### PR DESCRIPTION
We introduce a structure `NatTrans.CommShiftCore` which allows to state that a natural transformation is compatible with shifts in a specific degree. We obtain a few additional results, including that it we have a natural isomorphism `e : F ⋙ G ≅ H` with `G` fully faithful, then the functor `F` commutes with shifts by `A` if `G` and `H` do.

This is part of a formalization of spectral sequences #33842.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
