### PR TITLE
[Merged by Bors] - feat: establish function properties of the Nevanlinna functions

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -75,7 +75,7 @@ theorem characteristic_even {a : WithTop E} :
 For `1 ≤ r`, the characteristic function is non-negative.
 -/
 theorem characteristic_nonneg {r : ℝ} {a : WithTop E} (hr : 1 ≤ r) :
-    0 ≤ characteristic f a r := 
+    0 ≤ characteristic f a r :=
   add_nonneg (proximity_nonneg r) (logCounting_nonneg hr)
 
 /--

--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -69,15 +69,14 @@ lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : Meromorp
 The characteristic function is even.
 -/
 theorem characteristic_even {a : WithTop E} :
-    Function.Even (characteristic f a) := Function.Even.add proximity_even logCounting_even
+    (characteristic f a).Even := proximity_even.add logCounting_even
 
 /--
 For `1 ≤ r`, the characteristic function is non-negative.
 -/
 theorem characteristic_nonneg {r : ℝ} {a : WithTop E} (hr : 1 ≤ r) :
-    0 ≤ characteristic f a r := by
-  simp only [characteristic, Pi.add_apply]
-  exact add_nonneg (proximity_nonneg r) (logCounting_nonneg hr)
+    0 ≤ characteristic f a r := 
+  add_nonneg (proximity_nonneg r) (logCounting_nonneg hr)
 
 /--
 The characteristic function is asymptotically non-negative.

--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -65,6 +65,27 @@ lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : Meromorp
     characteristic f ⊤ - characteristic (f · - a₀) ⊤ = proximity f ⊤ - proximity (f · - a₀) ⊤ := by
   simp [← Pi.sub_def, characteristic, logCounting_sub_const h]
 
+/--
+The characteristic function is even.
+-/
+theorem characteristic_even {a : WithTop E} :
+    Function.Even (characteristic f a) := Function.Even.add proximity_even logCounting_even
+
+/--
+For `1 ≤ r`, the characteristic function is non-negative.
+-/
+theorem characteristic_nonneg {r : ℝ} {a : WithTop E} (hr : 1 ≤ r) :
+    0 ≤ characteristic f a r := by
+  simp only [characteristic, Pi.add_apply]
+  exact add_nonneg (proximity_nonneg r) (logCounting_nonneg hr)
+
+/--
+The characteristic function is asymptotically non-negative.
+-/
+theorem characteristic_eventually_nonneg {f : ℂ → ℂ} {a : WithTop ℂ} :
+    0 ≤ᶠ[Filter.atTop] characteristic f a  := by
+  filter_upwards [Filter.eventually_ge_atTop 1] using fun _ hr ↦ by simp [characteristic_nonneg hr]
+
 /-!
 ## Behaviour under Arithmetic Operations
 -/

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -71,6 +71,11 @@ lemma toClosedBall_divisor {r : ℝ} {f : ℂ → ℂ} (h : Meromorphic f) :
     (divisor f (closedBall 0 |r|)) = (locallyFinsuppWithin.toClosedBall r) (divisor f univ) := by
   simp_all [locallyFinsuppWithin.toClosedBall]
 
+lemma toClosedBall_support_subset_closedBall {E : Type*} [NormedAddCommGroup E] {r : ℝ}
+    (f : locallyFinsuppWithin (univ : Set E) ℤ) :
+    (toClosedBall r f).support ⊆ closedBall 0 |r| := by
+  simp_all [toClosedBall, restrict_apply]
+
 /-!
 ## The Logarithmic Counting Function of a Function with Locally Finite Support
 -/
@@ -118,6 +123,50 @@ Evaluation of the logarithmic counting function at zero yields zero.
     (D : locallyFinsuppWithin (univ : Set E) ℤ) :
     logCounting D 0 = 0 := by
   simp [logCounting]
+
+/--
+The logarithmic counting function is even.
+-/
+lemma logCounting_even [ProperSpace E] (D : locallyFinsuppWithin (univ : Set E) ℤ) :
+    (logCounting D).Even := fun r ↦ by simp [logCounting, toClosedBall, restrict_apply]
+
+/--
+The logarithmic counting function is monotonous.
+-/
+lemma logCounting_mono [ProperSpace E] {D : locallyFinsuppWithin (univ : Set E) ℤ} (hD : 0 ≤ D) :
+    MonotoneOn (logCounting D) (Ioi 0) := by
+  intro a ha b hb _
+  simp_all only [mem_Ioi, logCounting, AddMonoidHom.coe_mk, ZeroHom.coe_mk]
+  gcongr
+  · let s := (toClosedBall b D).support
+    have hs : s.Finite := (toClosedBall b D).finiteSupport (isCompact_closedBall 0 |b|)
+    repeat rw [finsum_eq_sum_of_support_subset (s := hs.toFinset)]
+    · gcongr 1 with z hz
+      by_cases h₂z : z = 0
+      · simp [h₂z]
+      · have := (toClosedBall_support_subset_closedBall D (hs.mem_toFinset.1 hz))
+        rw [toClosedBall_eval_within _ this]
+        by_cases h₃z : z ∈ closedBall 0 |a|
+        · rw [toClosedBall_eval_within _ h₃z]
+          gcongr
+          exact Int.cast_nonneg (hD z)
+        · simp only [h₃z, not_false_eq_true, apply_eq_zero_of_notMem, Int.cast_zero, zero_mul,
+            ge_iff_le]
+          apply mul_nonneg (Int.cast_nonneg (hD z)) (log_nonneg _)
+          apply (le_mul_inv_iff₀ (norm_pos_iff.mpr h₂z)).2
+          simp_all [abs_of_pos hb]
+    · intro z
+      aesop
+    · intro z
+      simp only [support_mul, mem_inter_iff, mem_support, ne_eq, Int.cast_eq_zero, log_eq_zero,
+        mul_eq_zero, inv_eq_zero, norm_eq_zero, not_or, Finite.coe_toFinset, and_imp, s]
+      intro h₁ _ _ _ _
+      have : z ∈ closedBall 0 |a| := mem_of_indicator_ne_zero h₁
+      rw [toClosedBall_eval_within _ this] at h₁
+      rwa [toClosedBall_eval_within]
+      · simp_all only [abs_of_pos ha, mem_closedBall, dist_zero_right, abs_of_pos hb]
+        linarith
+  · exact Int.cast_nonneg (hD 0)
 
 /--
 For `1 ≤ r`, the logarithmic counting function is non-negative.
@@ -250,6 +299,44 @@ The logarithmic counting function of the constant function zero is zero.
 @[simp] theorem logCounting_const_zero {e : WithTop E} :
     logCounting (0 : 𝕜 → E) e = 0 := logCounting_const
 
+/--
+The logarithmic counting function is even.
+-/
+theorem logCounting_even {f : 𝕜 → E} {e : WithTop E} :
+    Function.Even (logCounting f e) := by
+  intro r
+  by_cases h : e = ⊤
+  all_goals simp [logCounting, h, Function.locallyFinsuppWithin.logCounting_even _ r]
+
+/--
+The logarithmic counting function is monotonous.
+-/
+theorem logCounting_monotoneOn {f : 𝕜 → E} {e : WithTop E} :
+    MonotoneOn (logCounting f e) (Ioi 0) := by
+  unfold logCounting
+  by_cases h : e = ⊤
+  · simp only [h]
+    apply locallyFinsuppWithin.logCounting_mono (negPart_nonneg _)
+  · simp only [h]
+    apply locallyFinsuppWithin.logCounting_mono (posPart_nonneg _)
+
+/--
+For `1 ≤ r`, the logarithmic counting function is non-negative.
+-/
+theorem logCounting_nonneg {r : ℝ} {f : 𝕜 → E} {e : WithTop E} (hr : 1 ≤ r) :
+    0 ≤ logCounting f e r := by
+  by_cases h : e = ⊤
+  · simp [logCounting, h, locallyFinsuppWithin.logCounting_nonneg
+      (negPart_nonneg (MeromorphicOn.divisor f univ)) hr]
+  · simp [logCounting, h, locallyFinsuppWithin.logCounting_nonneg
+      (posPart_nonneg (MeromorphicOn.divisor (f · - e.untop₀) univ)) hr]
+
+/--
+The logarithmic counting function is asymptotically non-negative.
+-/
+theorem logCounting_eventually_nonneg {f : 𝕜 → E} {e : WithTop E} :
+    0 ≤ᶠ[Filter.atTop] logCounting f e  := by
+  filter_upwards [Filter.eventually_ge_atTop 1] using fun _ hr ↦ by simp [logCounting_nonneg hr]
 
 /-!
 ## Elementary Properties of the Logarithmic Counting Function

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -314,11 +314,7 @@ The logarithmic counting function is monotonous.
 theorem logCounting_monotoneOn {f : 𝕜 → E} {e : WithTop E} :
     MonotoneOn (logCounting f e) (Ioi 0) := by
   unfold logCounting
-  by_cases h : e = ⊤
-  · simp only [h]
-    apply locallyFinsuppWithin.logCounting_mono (negPart_nonneg _)
-  · simp only [h]
-    apply locallyFinsuppWithin.logCounting_mono (posPart_nonneg _)
+  all_goals simpa [h] using locallyFinsuppWithin.logCounting_mono (by positivity))
 
 /--
 For `1 ≤ r`, the logarithmic counting function is non-negative.

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -303,18 +303,18 @@ The logarithmic counting function of the constant function zero is zero.
 The logarithmic counting function is even.
 -/
 theorem logCounting_even {f : 𝕜 → E} {e : WithTop E} :
-    Function.Even (logCounting f e) := by
+    (logCounting f e).Even := by
   intro r
   by_cases h : e = ⊤
-  all_goals simp [logCounting, h, Function.locallyFinsuppWithin.logCounting_even _ r]
+  all_goals simp [logCounting, h, locallyFinsuppWithin.logCounting_even _ r]
 
 /--
 The logarithmic counting function is monotonous.
 -/
 theorem logCounting_monotoneOn {f : 𝕜 → E} {e : WithTop E} :
     MonotoneOn (logCounting f e) (Ioi 0) := by
-  unfold logCounting
-  all_goals simpa [h] using locallyFinsuppWithin.logCounting_mono (by positivity))
+  by_cases h : e = ⊤
+  all_goals simpa [logCounting, h] using locallyFinsuppWithin.logCounting_mono (by positivity)
 
 /--
 For `1 ≤ r`, the logarithmic counting function is non-negative.
@@ -382,8 +382,8 @@ theorem logCounting_add_top_le {f₁ f₂ : 𝕜 → E} {r : ℝ} (h₁f₁ : Me
     (h₁f₂ : Meromorphic f₂) (hr : 1 ≤ r) :
     logCounting (f₁ + f₂) ⊤ r ≤ (logCounting f₁ ⊤ + logCounting f₂ ⊤) r := by
   simp only [logCounting, ↓reduceDIte]
-  rw [← Function.locallyFinsuppWithin.logCounting.map_add]
-  exact Function.locallyFinsuppWithin.logCounting_le
+  rw [← locallyFinsuppWithin.logCounting.map_add]
+  exact locallyFinsuppWithin.logCounting_le
     (negPart_divisor_add_le_add h₁f₁.meromorphicOn h₁f₂.meromorphicOn) hr
 
 /--
@@ -447,9 +447,9 @@ theorem logCounting_mul_zero_le {f₁ f₂ : 𝕜 → 𝕜} {r : ℝ} (hr : 1 �
     logCounting (f₁ * f₂) 0 r ≤ (logCounting f₁ 0 + logCounting f₂ 0) r := by
   simp only [logCounting, WithTop.zero_ne_top, reduceDIte, WithTop.untop₀_zero, sub_zero]
   rw [divisor_mul h₁f₁.meromorphicOn h₁f₂.meromorphicOn (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
-    ← Function.locallyFinsuppWithin.logCounting.map_add]
-  apply Function.locallyFinsuppWithin.logCounting_le _ hr
-  apply Function.locallyFinsuppWithin.posPart_add
+    ← locallyFinsuppWithin.logCounting.map_add]
+  apply locallyFinsuppWithin.logCounting_le _ hr
+  apply locallyFinsuppWithin.posPart_add
 
 @[deprecated (since := "2025-12-11")] alias logCounting_zero_mul_le := logCounting_mul_zero_le
 
@@ -477,9 +477,9 @@ theorem logCounting_mul_top_le {f₁ f₂ : 𝕜 → 𝕜} {r : ℝ} (hr : 1 ≤
     logCounting (f₁ * f₂) ⊤ r ≤ (logCounting f₁ ⊤ + logCounting f₂ ⊤) r := by
   simp only [logCounting, reduceDIte]
   rw [divisor_mul h₁f₁.meromorphicOn h₁f₂.meromorphicOn (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
-    ← Function.locallyFinsuppWithin.logCounting.map_add]
-  apply Function.locallyFinsuppWithin.logCounting_le _ hr
-  apply Function.locallyFinsuppWithin.negPart_add
+    ← locallyFinsuppWithin.logCounting.map_add]
+  apply locallyFinsuppWithin.logCounting_le _ hr
+  apply locallyFinsuppWithin.negPart_add
 
 @[deprecated (since := "2025-12-11")] alias logCounting_top_mul_le := logCounting_mul_top_le
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -110,6 +110,25 @@ theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : 
   · simp_rw [← norm_inv]
     apply circleIntegrable_posLog_norm_meromorphicOn h₁f.inv.meromorphicOn
 
+/--
+The proximity function is even.
+-/
+theorem proximity_even : Function.Even (proximity f a) := by
+  intro r
+  by_cases h : a = ⊤
+  all_goals simp [proximity, h]
+
+/--
+The proximity function is non-negative.
+-/
+theorem proximity_nonneg {a : WithTop E} :
+    0 ≤ proximity f a := by
+  by_cases h : a = ⊤
+  all_goals
+    intro r
+    simp only [Pi.zero_apply, proximity, h, ↓reduceDIte]
+    exact circleAverage_nonneg_of_nonneg (fun x _ ↦ posLog_nonneg)
+
 /-!
 ## Behaviour under Arithmetic Operations
 -/

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -113,7 +113,7 @@ theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : 
 /--
 The proximity function is even.
 -/
-theorem proximity_even : Function.Even (proximity f a) := by
+theorem proximity_even : (proximity f a).Even := by
   intro r
   by_cases h : a = ⊤
   all_goals simp [proximity, h]
@@ -126,8 +126,7 @@ theorem proximity_nonneg {a : WithTop E} :
   by_cases h : a = ⊤
   all_goals
     intro r
-    simp only [Pi.zero_apply, proximity, h, ↓reduceDIte]
-    exact circleAverage_nonneg_of_nonneg (fun x _ ↦ posLog_nonneg)
+    simpa [proximity, h] using circleAverage_nonneg_of_nonneg (fun x _ ↦ posLog_nonneg)
 
 /-!
 ## Behaviour under Arithmetic Operations

--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -57,6 +57,13 @@ noncomputable def circleAverage : E :=
 lemma circleAverage_def :
     circleAverage f c R = (2 * π)⁻¹ • ∫ θ in 0..2 * π, f (circleMap c R θ) := rfl
 
+/--
+If 'f' is *not* circle integrable, then the circle average is zero by definition.
+-/
+theorem circleAverage.integral_undef (hf : ¬CircleIntegrable f c R) :
+    circleAverage f c R = 0 := by
+  simp_all [circleAverage, CircleIntegrable, intervalIntegral.integral_undef]
+
 /-- Expression of `circleAverage` in terms of interval averages. -/
 lemma circleAverage_eq_intervalAverage :
     circleAverage f c R = ⨍ θ in 0..2 * π, f (circleMap c R θ) := by
@@ -238,6 +245,19 @@ theorem abs_circleAverage_le_circleAverage_abs {f : ℂ → ℝ} :
   rw [circleAverage, circleAverage, smul_eq_mul, smul_eq_mul, abs_mul,
     abs_of_pos (inv_pos.2 two_pi_pos), mul_le_mul_iff_of_pos_left (inv_pos.2 two_pi_pos)]
   exact intervalIntegral.abs_integral_le_integral_abs (le_of_lt two_pi_pos)
+
+/--
+The circle average of a nonnegative function is nonnegative.
+-/
+theorem circleAverage_nonneg_of_nonneg {c : ℂ} {R : ℝ} {f : ℂ → ℝ}
+    (h₂f : ∀ x ∈ Metric.sphere c |R|, 0 ≤ f x) :
+    0 ≤ circleAverage f c R := by
+  by_cases hf : CircleIntegrable f c R
+  · rw [← circleAverage_const 0 c |R|, circleAverage, circleAverage, smul_eq_mul, smul_eq_mul,
+      mul_le_mul_iff_of_pos_left (inv_pos.2 two_pi_pos)]
+    apply intervalIntegral.integral_mono_on_of_le_Ioo (le_of_lt two_pi_pos)
+      intervalIntegrable_const hf (fun θ _ ↦ h₂f (circleMap c R θ) (circleMap_mem_sphere' c R θ))
+  · rw [circleAverage.integral_undef hf]
 
 /-!
 ## Commutativity with Linear Maps


### PR DESCRIPTION
Establish parity, monotonicity, and non-negativity of the main Nevanlinna functions. Note: Monotonicity of the Nevanlinna height is a (surprisingly non-trivial) consequence of Cartan's theorem, which will be submitted in a separate PR.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), formalizing Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
