### PR TITLE
[Merged by Bors] - feat(Computability/Primrec): add list_modify and list_set

### DIFF
--- a/Mathlib/Computability/Primrec/List.lean
+++ b/Mathlib/Computability/Primrec/List.lean
@@ -393,6 +393,35 @@ theorem list_dropWhile {p : α → Bool} (hp : Primrec p) : Primrec (List.dropWh
   (list_drop.comp (list_findIdx Primrec.id (Primrec.not.comp (hp.comp snd)).to₂)
     Primrec.id).of_eq fun _ => List.dropWhile_eq_drop_findIdx_not.symm
 
+/-- `List.modifyHead` with a function depending on external data is primitive recursive. -/
+theorem list_modifyHead' {g : β → α → α} (hg : Primrec₂ g) :
+    Primrec₂ fun (l : List α) (b : β) => l.modifyHead (g b) :=
+  (list_casesOn fst (const [])
+    (list_cons.comp (hg.comp (snd.comp fst) (fst.comp snd)) (snd.comp snd)).to₂).to₂.of_eq
+    fun l b => by cases l <;> rfl
+
+/-- `List.modifyHead` by a primitive recursive function is primitive recursive. -/
+theorem list_modifyHead {f : α → α} (hf : Primrec f) : Primrec (List.modifyHead f) :=
+  (list_modifyHead' (hf.comp snd).to₂).comp Primrec.id (const ())
+
+/-- `List.modify` with a function depending on external data is primitive recursive. -/
+theorem list_modify' {g : β → α → α} (hg : Primrec₂ g) :
+    Primrec₂ fun (l : List α) (p : ℕ × β) => l.modify p.1 (g p.2) :=
+  -- l.modify n (g b) = l.take n ++ (l.drop n).modifyHead (g b)
+  (list_append.comp
+    (list_take.comp (fst.comp snd) fst)
+    ((list_modifyHead' hg).comp (list_drop.comp (fst.comp snd) fst) (snd.comp snd))).to₂.of_eq
+  fun l ⟨n, b⟩ => (List.modify_eq_take_drop (g b) l n).symm
+
+/-- `List.modify` by a primitive recursive function is primitive recursive. -/
+theorem list_modify {f : α → α} (hf : Primrec f) :
+    Primrec₂ fun (l : List α) (n : ℕ) => l.modify n f :=
+  ((list_modify' (hf.comp snd).to₂).comp fst (pair snd (const ()))).to₂
+
+/-- `List.set` is primitive recursive. -/
+theorem list_set : Primrec₂ fun (l : List α) (p : ℕ × α) => l.set p.1 p.2 :=
+  (list_modify' fst.to₂).of_eq fun l ⟨n, v⟩ => (List.set_eq_modify v n l).symm
+
 end Primrec
 
 namespace PrimrecPred


### PR DESCRIPTION
This PR shows that several list operations from Lean core are primitive recursive:

- `list_modifyHead'`: [`List.modifyHead`](https://github.com/leanprover/lean4/blob/master/src/Init/Data/List/Nat/Modify.lean) with external data
- `list_modifyHead`: [`List.modifyHead`](https://github.com/leanprover/lean4/blob/master/src/Init/Data/List/Nat/Modify.lean)
- `list_modify'`: [`List.modify`](https://github.com/leanprover/lean4/blob/master/src/Init/Data/List/Nat/Modify.lean) with external data
- `list_modify`: [`List.modify`](https://github.com/leanprover/lean4/blob/master/src/Init/Data/List/Nat/Modify.lean)
- `list_set`: [`List.set`](https://github.com/leanprover/lean4/blob/master/src/Init/Prelude.lean)

The primed versions (`list_modifyHead'`, `list_modify'`) take a function `g : β → α → α` that depends on external data of type `β`. This generalization enables deriving the other operations:
- `list_modifyHead` specializes `list_modifyHead'` with `β = Unit`
- `list_modify` specializes `list_modify'` with `β = Unit`
- `list_set` uses `list_modify'` via `List.set_eq_modify`