### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal): more lemmas about `ENat`

### DIFF
--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -159,7 +159,7 @@ namespace ENat
 theorem card_eq_coe_natCard (α : Type*) [Finite α] : card α = Nat.card α := by
   unfold ENat.card
   apply symm
-  rw [Cardinal.natCast_eq_toENat_iff]
+  rw [Cardinal.natCast_eq_toENat]
   exact Nat.cast_card
 
 end ENat

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -206,6 +206,8 @@ theorem encard_diff (h : s ⊆ t) (hs : s.Finite) :
 @[simp] theorem one_le_encard_iff_nonempty : 1 ≤ s.encard ↔ s.Nonempty := by
   rw [nonempty_iff_ne_empty, Ne, ← encard_eq_zero, ENat.one_le_iff_ne_zero]
 
+@[simp] lemma encard_lt_one : s.encard < 1 ↔ s = ∅ := by simp [← not_le, not_nonempty_iff_eq_empty]
+
 theorem encard_diff_add_encard_inter (s t : Set α) :
     (s \ t).encard + (s ∩ t).encard = s.encard := by
   rw [← encard_union_eq disjoint_sdiff_inter, diff_union_inter]

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -839,7 +839,7 @@ theorem lift_word_prod_nontrivial_of_head_eq_last {i} (w : NeWord H i i) :
 
 theorem lift_word_prod_nontrivial_of_head_card {i j} (w : NeWord H i j)
     (hcard : 3 ≤ #(H i)) (hheadtail : i ≠ j) : lift f w.prod ≠ 1 := by
-  obtain ⟨h, hn1, hnh⟩ := Cardinal.three_le hcard 1 w.head⁻¹
+  obtain ⟨h, hn1, hnh⟩ := Cardinal.exists_ne_ne_of_three_le hcard 1 w.head⁻¹
   have hnot1 : h * w.head ≠ 1 := by
     rw [← div_inv_eq_mul]
     exact div_ne_one_of_ne hnh
@@ -857,7 +857,7 @@ theorem lift_word_prod_nontrivial_of_not_empty {i j} (w : NeWord H i j) :
     lift f w.prod ≠ 1 := by
   classical
     rcases hcard with hcard | hcard
-    · obtain ⟨i, h1, h2⟩ := Cardinal.three_le hcard i j
+    · obtain ⟨i, h1, h2⟩ := Cardinal.exists_ne_ne_of_three_le hcard i j
       exact lift_word_prod_nontrivial_of_other_i f X hXnonempty hXdisj hpp w h1 h2
     · obtain ⟨k, hcard⟩ := hcard
       by_cases hh : i = k <;> by_cases hl : j = k

--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -99,7 +99,7 @@ lemma eRank_le_card_width [StrongRankCondition R] (A : Matrix m n R) : A.eRank �
   wlog hfin : Finite n
   · simp [ENat.card_eq_top.2 (by simpa using hfin)]
   have _ := Fintype.ofFinite n
-  rw [ENat.card_eq_coe_fintype_card, eRank, toENat_le_nat]
+  rw [ENat.card_eq_coe_fintype_card, eRank, toENat_le_natCast]
   exact A.cRank_le_card_width
 
 lemma eRank_le_card_height [StrongRankCondition R] (A : Matrix m n R) : A.eRank ≤ ENat.card m := by
@@ -107,7 +107,7 @@ lemma eRank_le_card_height [StrongRankCondition R] (A : Matrix m n R) : A.eRank 
   wlog hfin : Finite m
   · simp [ENat.card_eq_top.2 (by simpa using hfin)]
   have _ := Fintype.ofFinite m
-  rw [ENat.card_eq_coe_fintype_card, eRank, toENat_le_nat]
+  rw [ENat.card_eq_coe_fintype_card, eRank, toENat_le_natCast]
   exact A.cRank_le_card_height
 
 end Infinite

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -258,7 +258,7 @@ variable (R M) in
 lemma Module.length_of_free_of_finite
     [StrongRankCondition R] [Module.Free R M] [Module.Finite R M] :
     Module.length R M = Module.finrank R M * Module.length R R := by
-  rw [length_of_free, Cardinal.toENat_eq_nat.mpr (finrank_eq_rank _ _).symm]
+  rw [length_of_free, Cardinal.toENat_eq_natCast.mpr (finrank_eq_rank _ _).symm]
 
 lemma Module.length_eq_one_iff :
     Module.length R M = 1 ↔ IsSimpleModule R M := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -989,11 +989,13 @@ theorem exists_notMem_of_length_lt {α : Type*} (l : List α) (h : ↑l.length <
     _ = l.toFinset.card := Cardinal.mk_coe_finset
     _ ≤ l.length := Nat.cast_le.mpr (List.toFinset_card_le l)
 
-theorem three_le {α : Type*} (h : 3 ≤ #α) (x : α) (y : α) : ∃ z : α, z ≠ x ∧ z ≠ y := by
+theorem exists_ne_ne_of_three_le {α : Type*} (h : 3 ≤ #α) (x y : α) : ∃ z : α, z ≠ x ∧ z ≠ y := by
   have : ↑(3 : ℕ) ≤ #α := by simpa using h
   have : ↑(2 : ℕ) < #α := by rwa [← succ_le_iff, ← Cardinal.nat_succ]
   have := exists_notMem_of_length_lt [x, y] this
   simpa [not_or] using this
+
+@[deprecated (since := "2026-02-17")] alias three_le := exists_ne_ne_of_three_le
 
 /-! ### `powerlt` operation -/
 

--- a/Mathlib/SetTheory/Cardinal/ENat.lean
+++ b/Mathlib/SetTheory/Cardinal/ENat.lean
@@ -246,46 +246,69 @@ lemma ofENat_toENat_eq_self {a : Cardinal} : toENat a = a ↔ a ≤ ℵ₀ := by
 
 lemma toENat_nat (n : ℕ) : toENat n = n := map_natCast _ n
 
-@[simp] lemma toENat_le_nat {a : Cardinal} {n : ℕ} : toENat a ≤ n ↔ a ≤ n := toENatAux_le_nat
-@[simp] lemma toENat_eq_nat {a : Cardinal} {n : ℕ} : toENat a = n ↔ a = n := toENatAux_eq_nat
-@[simp] lemma toENat_eq_zero {a : Cardinal} : toENat a = 0 ↔ a = 0 := toENatAux_eq_zero
-@[simp] lemma toENat_le_one {a : Cardinal} : toENat a ≤ 1 ↔ a ≤ 1 := toENat_le_nat
-@[simp] lemma toENat_eq_one {a : Cardinal} : toENat a = 1 ↔ a = 1 := toENat_eq_nat
+@[simp] lemma toENat_ofNat (n : ℕ) [n.AtLeastTwo] : toENat ofNat(n) = ofNat(n) := toENat_nat _
 
-@[simp] lemma toENat_le_ofNat {a : Cardinal} {n : ℕ} [n.AtLeastTwo] :
-    toENat a ≤ ofNat(n) ↔ a ≤ OfNat.ofNat n := toENat_le_nat
+variable {c c' : Cardinal.{u}} {n : ℕ}
 
-@[simp] lemma toENat_eq_ofNat {a : Cardinal} {n : ℕ} [n.AtLeastTwo] :
-    toENat a = ofNat(n) ↔ a = OfNat.ofNat n := toENat_eq_nat
+@[simp] lemma toENat_le_natCast : toENat c ≤ n ↔ c ≤ n := toENatAux_le_nat
+@[simp] lemma toENat_le_one : toENat c ≤ 1 ↔ c ≤ 1 := toENat_le_natCast
+@[simp] lemma toENat_le_ofNat [n.AtLeastTwo] : toENat c ≤ ofNat(n) ↔ c ≤ ofNat(n) :=
+  toENat_le_natCast
 
-@[simp] lemma toENat_eq_top {a : Cardinal} : toENat a = ⊤ ↔ ℵ₀ ≤ a := enat_gc.u_eq_top
+@[deprecated (since := "2026-01-13")] alias toENat_le_nat := toENat_le_natCast
 
-lemma toENat_ne_top {a : Cardinal} : toENat a ≠ ⊤ ↔ a < ℵ₀ := by simp
+lemma toENat_le_iff_of_le_aleph0 (hc : c ≤ ℵ₀) : toENat c ≤ toENat c' ↔ c ≤ c' := by
+  lift c to ℕ∞ using hc; simp_rw [toENat_ofENat, enat_gc _]
 
-@[simp] lemma toENat_lt_top {a : Cardinal} : toENat a < ⊤ ↔ a < ℵ₀ := by simp [lt_top_iff_ne_top]
+lemma toENat_le_iff_of_lt_aleph0 (hc' : c' < ℵ₀) : toENat c ≤ toENat c' ↔ c ≤ c' := by
+  lift c' to ℕ using hc'; simp_rw [toENat_nat, ← toENat_le_natCast]
+
+lemma toENat_eq_iff_of_le_aleph0 (hc : c ≤ ℵ₀) (hc' : c' ≤ ℵ₀) : toENat c = toENat c' ↔ c = c' :=
+  toENat_strictMonoOn.injOn.eq_iff hc hc'
+
+@[simp] lemma natCast_le_toENat : n ≤ toENat c ↔ n ≤ c := by
+  rw [← toENat_nat n, toENat_le_iff_of_le_aleph0 natCast_le_aleph0]
+
+@[simp] lemma one_le_toENat : 1 ≤ toENat c ↔ 1 ≤ c := natCast_le_toENat
+@[simp] lemma ofNat_le_toENat [n.AtLeastTwo] : ofNat(n) ≤ toENat c ↔ ofNat(n) ≤ c :=
+  natCast_le_toENat
+
+@[simp] lemma toENat_lt_natCast : toENat c < n ↔ c < n := by simp [← not_le]
+@[simp] lemma toENat_lt_one : toENat c < 1 ↔ c < 1 := toENat_lt_natCast
+@[simp] lemma toENat_lt_ofNat [n.AtLeastTwo] : toENat c < ofNat(n) ↔ c < ofNat(n) :=
+  toENat_lt_natCast
+
+@[simp] lemma natCast_lt_toENat : n < toENat c ↔ n < c := by simp [← not_le]
+@[simp] lemma one_lt_toENat : 1 < toENat c ↔ 1 < c := natCast_lt_toENat
+@[simp] lemma ofNat_lt_toENat [n.AtLeastTwo] : ofNat(n) < toENat c ↔ ofNat(n) < c :=
+  natCast_lt_toENat
+
+@[simp] lemma toENat_eq_natCast : toENat c = n ↔ c = n := toENatAux_eq_nat
+@[simp] lemma toENat_eq_zero : toENat c = 0 ↔ c = 0 := toENat_eq_natCast
+@[simp] lemma toENat_eq_one : toENat c = 1 ↔ c = 1 := toENat_eq_natCast
+@[simp] lemma toENat_eq_ofNat [n.AtLeastTwo] : toENat c = ofNat(n) ↔ c = ofNat(n) :=
+  toENat_eq_natCast
+
+@[deprecated (since := "2026-01-13")] alias toENat_eq_nat := toENat_eq_natCast
+
+@[simp] lemma natCast_eq_toENat : n = toENat c ↔ n = c := by simp [eq_comm (a := Nat.cast _)]
+@[simp] lemma ofNat_eq_toENat [n.AtLeastTwo] : ofNat(n) = toENat c ↔ ofNat(n) = c :=
+  natCast_eq_toENat
+
+@[simp] lemma toENat_eq_top : toENat c = ⊤ ↔ ℵ₀ ≤ c := enat_gc.u_eq_top
+
+lemma toENat_ne_top : toENat c ≠ ⊤ ↔ c < ℵ₀ := by simp
+
+@[simp] lemma toENat_lt_top : toENat c < ⊤ ↔ c < ℵ₀ := by simp [lt_top_iff_ne_top]
 
 @[simp]
-theorem toENat_lift {a : Cardinal.{v}} : toENat (lift.{u} a) = toENat a := by
-  cases le_total a ℵ₀ with
-  | inl ha => lift a to ℕ∞ using ha; simp
+theorem toENat_lift : toENat (lift.{v} c) = toENat c := by
+  cases le_total c ℵ₀ with
+  | inl ha => lift c to ℕ∞ using ha; simp
   | inr ha => simp [toENat_eq_top.2, ha]
 
 theorem toENat_congr {α : Type u} {β : Type v} (e : α ≃ β) : toENat #α = toENat #β := by
   rw [← toENat_lift, lift_mk_eq.{_, _, v}.mpr ⟨e⟩, toENat_lift]
-
-lemma toENat_le_iff_of_le_aleph0 {c c' : Cardinal} (h : c ≤ ℵ₀) :
-    toENat c ≤ toENat c' ↔ c ≤ c' := by
-  lift c to ℕ∞ using h
-  simp_rw [toENat_ofENat, enat_gc _]
-
-lemma toENat_le_iff_of_lt_aleph0 {c c' : Cardinal} (hc' : c' < ℵ₀) :
-    toENat c ≤ toENat c' ↔ c ≤ c' := by
-  lift c' to ℕ using hc'
-  simp_rw [toENat_nat, ← toENat_le_nat]
-
-lemma toENat_eq_iff_of_le_aleph0 {c c' : Cardinal} (hc : c ≤ ℵ₀) (hc' : c' ≤ ℵ₀) :
-    toENat c = toENat c' ↔ c = c' :=
-  toENat_strictMonoOn.injOn.eq_iff hc hc'
 
 @[simp, norm_cast]
 lemma ofENat_add (m n : ℕ∞) : ofENat (m + n) = m + n := by apply toENat_injOn <;> simp
@@ -314,7 +337,5 @@ def ofENatHom : ℕ∞ →+*o Cardinal where
   map_zero' := ofENat_zero
   map_add' := ofENat_add
   monotone' := ofENat_mono
-
-
 
 end Cardinal

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -316,32 +316,33 @@ lemma card_le_card_of_injective {α β : Type*} {f : α → β} (hf : Injective 
   rw [← card_ulift α, ← card_ulift β]
   exact Cardinal.gciENat.gc.monotone_u <| Cardinal.lift_mk_le_lift_mk_of_injective hf
 
-@[simp]
+@[deprecated natCast_le_toENat (since := "2026-01-13")]
 theorem _root_.Cardinal.natCast_le_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n ≤ toENat c ↔ ↑n ≤ c := by
   rw [← toENat_nat n, toENat_le_iff_of_le_aleph0 natCast_le_aleph0]
 
+@[deprecated toENat_le_natCast (since := "2026-01-13")]
 theorem _root_.Cardinal.toENat_le_natCast_iff {c : Cardinal} {n : ℕ} :
     toENat c ≤ n ↔ c ≤ n := by simp
 
-@[simp]
+@[deprecated natCast_eq_toENat (since := "2026-01-13")]
 theorem _root_.Cardinal.natCast_eq_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n = toENat c ↔ ↑n = c := by
-  rw [le_antisymm_iff, le_antisymm_iff, Cardinal.toENat_le_natCast_iff,
-    Cardinal.natCast_le_toENat_iff]
+  rw [le_antisymm_iff, le_antisymm_iff, Cardinal.toENat_le_natCast, Cardinal.natCast_le_toENat]
 
+@[deprecated toENat_eq_natCast (since := "2026-01-13")]
 theorem _root_.Cardinal.toENat_eq_natCast_iff {c : Cardinal} {n : ℕ} :
     Cardinal.toENat c = n ↔ c = n := by simp
 
-@[simp]
+@[deprecated natCast_lt_toENat (since := "2026-01-13")]
 theorem _root_.Cardinal.natCast_lt_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n < toENat c ↔ ↑n < c := by
-  simp only [← not_le, Cardinal.toENat_le_natCast_iff]
+  simp only [← not_le, Cardinal.toENat_le_natCast]
 
-@[simp]
+@[deprecated toENat_lt_natCast (since := "2026-01-13")]
 theorem _root_.Cardinal.toENat_lt_natCast_iff {n : ℕ} {c : Cardinal} :
     toENat c < ↑n ↔ c < ↑n := by
-  simp only [← not_le, Cardinal.natCast_le_toENat_iff]
+  simp only [← not_le, Cardinal.natCast_le_toENat]
 
 theorem card_eq_zero_iff_empty (α : Type*) : card α = 0 ↔ IsEmpty α := by
   rw [← Cardinal.mk_eq_zero_iff]
@@ -356,6 +357,9 @@ theorem one_le_card_iff_nonempty (α : Type*) : 1 ≤ card α ↔ Nonempty α :=
 @[simp] lemma card_pos [Nonempty α] : 0 < card α := by
   simpa [pos_iff_ne_zero, card_ne_zero_iff_nonempty]
 
+lemma card_pos_iff_nonempty : 0 < ENat.card α ↔ Nonempty α := by
+  simp [pos_iff_ne_zero, card_ne_zero_iff_nonempty]
+
 theorem card_le_one_iff_subsingleton (α : Type*) : card α ≤ 1 ↔ Subsingleton α := by
   rw [← le_one_iff_subsingleton]
   simp [card]
@@ -369,10 +373,13 @@ lemma card_eq_one_iff_unique {α : Type*} : card α = 1 ↔ Nonempty (Unique α)
 theorem one_lt_card_iff_nontrivial (α : Type*) : 1 < card α ↔ Nontrivial α := by
   rw [← Cardinal.one_lt_iff_nontrivial]
   conv_rhs => rw [← Nat.cast_one]
-  rw [← natCast_lt_toENat_iff]
+  rw [← natCast_lt_toENat]
   simp only [ENat.card, Nat.cast_one]
 
 @[simp] lemma one_lt_card [Nontrivial α] : 1 < card α := by simpa [one_lt_card_iff_nontrivial]
+
+lemma three_le_card (h : 3 ≤ ENat.card α) (x y : α) : ∃ z, z ≠ x ∧ z ≠ y :=
+  Cardinal.three_le (by simpa [ENat.card] using h) x y
 
 @[simp]
 theorem card_prod (α β : Type*) : card (α × β) = card α * card β := by

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -316,30 +316,30 @@ lemma card_le_card_of_injective {α β : Type*} {f : α → β} (hf : Injective 
   rw [← card_ulift α, ← card_ulift β]
   exact Cardinal.gciENat.gc.monotone_u <| Cardinal.lift_mk_le_lift_mk_of_injective hf
 
-@[deprecated natCast_le_toENat (since := "2026-01-13")]
+@[deprecated natCast_le_toENat (since := "2026-02-17")]
 theorem _root_.Cardinal.natCast_le_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n ≤ toENat c ↔ ↑n ≤ c := by
   rw [← toENat_nat n, toENat_le_iff_of_le_aleph0 natCast_le_aleph0]
 
-@[deprecated toENat_le_natCast (since := "2026-01-13")]
+@[deprecated toENat_le_natCast (since := "2026-02-17")]
 theorem _root_.Cardinal.toENat_le_natCast_iff {c : Cardinal} {n : ℕ} :
     toENat c ≤ n ↔ c ≤ n := by simp
 
-@[deprecated natCast_eq_toENat (since := "2026-01-13")]
+@[deprecated natCast_eq_toENat (since := "2026-02-17")]
 theorem _root_.Cardinal.natCast_eq_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n = toENat c ↔ ↑n = c := by
   rw [le_antisymm_iff, le_antisymm_iff, Cardinal.toENat_le_natCast, Cardinal.natCast_le_toENat]
 
-@[deprecated toENat_eq_natCast (since := "2026-01-13")]
+@[deprecated toENat_eq_natCast (since := "2026-02-17")]
 theorem _root_.Cardinal.toENat_eq_natCast_iff {c : Cardinal} {n : ℕ} :
     Cardinal.toENat c = n ↔ c = n := by simp
 
-@[deprecated natCast_lt_toENat (since := "2026-01-13")]
+@[deprecated natCast_lt_toENat (since := "2026-02-17")]
 theorem _root_.Cardinal.natCast_lt_toENat_iff {n : ℕ} {c : Cardinal} :
     ↑n < toENat c ↔ ↑n < c := by
   simp only [← not_le, Cardinal.toENat_le_natCast]
 
-@[deprecated toENat_lt_natCast (since := "2026-01-13")]
+@[deprecated toENat_lt_natCast (since := "2026-02-17")]
 theorem _root_.Cardinal.toENat_lt_natCast_iff {n : ℕ} {c : Cardinal} :
     toENat c < ↑n ↔ c < ↑n := by
   simp only [← not_le, Cardinal.natCast_le_toENat]
@@ -378,8 +378,8 @@ theorem one_lt_card_iff_nontrivial (α : Type*) : 1 < card α ↔ Nontrivial α 
 
 @[simp] lemma one_lt_card [Nontrivial α] : 1 < card α := by simpa [one_lt_card_iff_nontrivial]
 
-lemma three_le_card (h : 3 ≤ ENat.card α) (x y : α) : ∃ z, z ≠ x ∧ z ≠ y :=
-  Cardinal.three_le (by simpa [ENat.card] using h) x y
+lemma exists_ne_ne_of_three_le (h : 3 ≤ ENat.card α) (x y : α) : ∃ z, z ≠ x ∧ z ≠ y :=
+  Cardinal.exists_ne_ne_of_three_le (by simpa [ENat.card] using h) x y
 
 @[simp]
 theorem card_prod (α β : Type*) : card (α × β) = card α * card β := by

--- a/Mathlib/SetTheory/Cardinal/NatCount.lean
+++ b/Mathlib/SetTheory/Cardinal/NatCount.lean
@@ -27,7 +27,7 @@ theorem count_le_cardinal : (count p n : Cardinal) ≤ Cardinal.mk { k | p k } :
   exact Cardinal.mk_subtype_mono fun x hx ↦ hx.2
 
 theorem count_le_setENCard : count p n ≤ Set.encard { k | p k } := by
-  simp only [Set.encard, ENat.card, Set.coe_setOf, Cardinal.natCast_le_toENat_iff]
+  simp only [Set.encard, ENat.card, Set.coe_setOf, Cardinal.natCast_le_toENat]
   exact Nat.count_le_cardinal n
 
 theorem count_le_setNCard (h : { k | p k }.Finite) : count p n ≤ Set.ncard { k | p k } := by

--- a/Mathlib/SetTheory/Cardinal/ToNat.lean
+++ b/Mathlib/SetTheory/Cardinal/ToNat.lean
@@ -120,7 +120,7 @@ theorem zero_toNat : toNat 0 = 0 := map_zero _
 theorem one_toNat : toNat 1 = 1 := map_one _
 
 theorem toNat_eq_iff {n : ℕ} (hn : n ≠ 0) : toNat c = n ↔ c = n := by
-  rw [← toNat_toENat, ENat.toNat_eq_iff hn, toENat_eq_nat]
+  rw [← toNat_toENat, ENat.toNat_eq_iff hn, toENat_eq_natCast]
 
 /-- A version of `toNat_eq_iff` for literals -/
 theorem toNat_eq_ofNat {n : ℕ} [Nat.AtLeastTwo n] :


### PR DESCRIPTION
and deduplicate a few pairs.

From ProofBench


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
