### PR TITLE
[Merged by Bors] - feat(Data/List): `a :: l ~r l ++ [a]`

### DIFF
--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -459,7 +459,7 @@ theorem IsRotated.map {β : Type*} {l₁ l₂ : List α} (h : l₁ ~r l₂) (f :
   rw [map_rotate]
   use n
 
-lemma isRotated_cons_append_singleton : a :: l ~r l ++ [a] := by
+lemma IsRotated.cons_append_singleton : a :: l ~r l ++ [a] := by
   simpa using isRotated_append (l := [a])
 
 theorem IsRotated.cons_getLast_dropLast

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -360,7 +360,7 @@ def IsRotated : Prop :=
 -- This matches the precedence of the infix `~` for `List.Perm`, and of other relation infixes
 infixr:50 " ~r " => IsRotated
 
-variable {l l'}
+variable {l l'} {a : α}
 
 @[refl]
 theorem IsRotated.refl (l : List α) : l ~r l :=
@@ -458,6 +458,8 @@ theorem IsRotated.map {β : Type*} {l₁ l₂ : List α} (h : l₁ ~r l₂) (f :
   obtain ⟨n, rfl⟩ := h
   rw [map_rotate]
   use n
+
+lemma isRotated_cons_concat : a :: l ~r l.concat a := by simpa using isRotated_append (l := [a])
 
 theorem IsRotated.cons_getLast_dropLast
     (L : List α) (hL : L ≠ []) : L.getLast hL :: L.dropLast ~r L := by

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -459,7 +459,8 @@ theorem IsRotated.map {β : Type*} {l₁ l₂ : List α} (h : l₁ ~r l₂) (f :
   rw [map_rotate]
   use n
 
-lemma isRotated_cons_concat : a :: l ~r l.concat a := by simpa using isRotated_append (l := [a])
+lemma isRotated_cons_append_singleton : a :: l ~r l ++ [a] := by
+  simpa using isRotated_append (l := [a])
 
 theorem IsRotated.cons_getLast_dropLast
     (L : List α) (hL : L ≠ []) : L.getLast hL :: L.dropLast ~r L := by


### PR DESCRIPTION
From ProofBench


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
