### PR TITLE
[Merged by Bors] - fix(Tactic/Linter): support Verso docstrings in header style linter

### DIFF
--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -351,6 +351,13 @@ def duplicateImportsCheck (imports : Array Syntax)  : CommandElabM Unit := do
       else
         importsSoFar := importsSoFar.push info
 
+/--
+The set of files outside the `Mathlib` package to run the header style linter on,
+because they are files that test the linter.
+-/
+def headerTestFiles : NameSet := .ofList
+  [`MathlibTest.Header, `MathlibTest.HeaderFail, `MathlibTest.VersoHeader, `MathlibTest.DirectoryDependencyLinter.Test]
+
 @[inherit_doc Mathlib.Linter.linter.style.header]
 def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let mainModule ← getMainModule
@@ -365,7 +372,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- The linter skips files not imported in `Mathlib.lean`, to avoid linting "scratch files".
   -- It is however active in the test files for the linter itself.
   unless inMathlib? ||
-    mainModule == `MathlibTest.Header || mainModule == `MathlibTest.DirectoryDependencyLinter.Test do return
+    mainModule ∈ headerTestFiles do return
   unless getLinterValue linter.style.header (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -371,8 +371,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
       return val
   -- The linter skips files not imported in `Mathlib.lean`, to avoid linting "scratch files".
   -- It is however active in the test files for the linter itself.
-  unless inMathlib? ||
-    mainModule ∈ headerTestFiles do return
+  unless inMathlib? || headerTestFiles.contains mainModule do return
   unless getLinterValue linter.style.header (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -386,8 +386,8 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- For robustness, we assume Markdown and Verso docstrings can be arbitrarily mixed,
   -- so we get the end pos for both types of docstrings and take their minimum as the first.
   let firstMDDocModPos := match mdDocs[0]? with
-                          | none     => fm.positions.back!
-                          | some doc => fm.ofPosition doc.declarationRange.endPos
+  | none     => fm.positions.back!
+  | some doc => fm.ofPosition doc.declarationRange.endPos
   let firstVersoDocModPos := match versoDocs[0]? with
   | none     => fm.positions.back!
   | some doc => fm.ofPosition doc.declarationRange.endPos

--- a/MathlibTest/HeaderFail.lean
+++ b/MathlibTest/HeaderFail.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+
+import Mathlib.Tactic.Linter.Header
+
+/- Test that the module header linter correctly complains about missing headers,
+even if we set `doc.verso` to `true. -/
+
+/--
+warning: The module doc-string for a file should be the first command after the imports.
+Please, add a module doc-string before `def foo :=
+  37`.
+
+Note: This linter can be disabled with `set_option linter.style.header false`
+-/
+#guard_msgs in
+set_option linter.style.header true in
+set_option doc.verso true in
+
+def foo := 37

--- a/MathlibTest/VersoHeader.lean
+++ b/MathlibTest/VersoHeader.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2026 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+
+import Mathlib.Tactic.Linter.Header
+
+-- This should error, but does not...
+#guard_msgs in
+set_option linter.style.header true in
+set_option doc.verso true in
+
+def foo := 37

--- a/MathlibTest/VersoHeader.lean
+++ b/MathlibTest/VersoHeader.lean
@@ -15,3 +15,21 @@ set_option doc.verso true in
 set_option linter.style.header true in
 set_option doc.verso true in
 def foo : Nat := 37
+
+
+-- Make sure Verso is indeed enabled when we do `set_option docs.verso true`.
+
+/--
+warning: Code block could be more specific.
+
+Hint: Insert a specific kind of code block:
+  ```l̲e̲a̲n̲
+-/
+#guard_msgs in
+set_option doc.verso true in
+/--
+```
+#check foo
+```
+-/
+def bar : Nat := 37 * 2

--- a/MathlibTest/VersoHeader.lean
+++ b/MathlibTest/VersoHeader.lean
@@ -6,9 +6,12 @@ Authors: Anne Baanen
 
 import Mathlib.Tactic.Linter.Header
 
--- This should error, but does not...
+set_option doc.verso true in
+/-!
+# Test that Verso docstrings are recognized as module docs.
+-/
+
 #guard_msgs in
 set_option linter.style.header true in
 set_option doc.verso true in
-
-def foo := 37
+def foo : Nat := 37


### PR DESCRIPTION
This PR teaches the header style linter to also allow a Verso docstring for the first module docstring. On a file with the option `doc.verso` set to `true` (set this in the Lakefile), the header style linter previously thought there were no docstrings at all, and complained about a missing module docstring.

Also fix a docstring that Verso failed to parse (a bit of text should have been code).


---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
