### PR TITLE
[Merged by Bors] - chore(Data/Nat/Factorial): remove TODO about factorial notation

### DIFF
--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -40,8 +40,7 @@ In Lean, names can end with exclamation marks (e.g. `List.get!`), so you cannot 
 `n!` in Lean, but must write `(n)!` or `n !` instead. The former is preferred, since
 Lean can confuse the `!` in `n !` as the (prefix) Boolean negation operation in some
 cases.
-For numerals the parentheses are not required, so e.g. `0!` or `1!` work fine.
-Todo: replace occurrences of `n !` with `(n)!` in Mathlib. -/
+For numerals the parentheses are not required, so e.g. `0!` or `1!` work fine. -/
 scoped notation:10000 n "!" => Nat.factorial n
 
 section Factorial


### PR DESCRIPTION
Removes ``Todo: replace occurrences of `n !` with `(n)!` in Mathlib.`` as it was decided to keep it as a style decision up to authors.

---

## Old description:

Fixes ``Todo: replace occurrences of `n !` with `(n)!` in Mathlib.`` from `Data/Nat/Factorial/Basic.lean`.
Only literals are allowed to use factorial unparenthesized, e.g. `5!`.

---
The TODO was introduced in #18085, with an accompanying [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/precedence.20of.20Nat.2Efactorial) that decided on this.

The factorial notation is used in Mathlib on the following kinds of expressions:
- `Nat` numerals, e.g. `5`, there are 20 such cases
- Identifiers, e.g. `n` or `n.succ` or `l.length` or `p.natDegree`, there are 433 such cases
- Structure projection, e.g. `n.1`, there are 20 such cases
- Parenthesized expressions, e.g. `(n + k)`, there are 293 such cases
- Type ascriptions, e.g. `(n : ℕ)` (these don't count as parenthesized in `Lean.Syntax`), there are [3](https://github.com/leanprover-community/mathlib4/blob/b2f24e70b375e42e5a60251a2f43baa20ca668f1/MathlibTest/norm_num_ext.lean#L625) [such](https://github.com/leanprover-community/mathlib4/blob/b2f24e70b375e42e5a60251a2f43baa20ca668f1/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean#L378) [cases](https://github.com/leanprover-community/mathlib4/blob/b2f24e70b375e42e5a60251a2f43baa20ca668f1/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean#L384)

This PR normalizes everything to use `(...)!` notation, except for numerals which don't require parentheses.
Note that structure projections also don't require parentheses but it looks confusing (see [this](https://github.com/leanprover-community/mathlib4/blob/4baa44807be87d9aba67c680ae68c2ba4a7fc29b/Mathlib/Data/Nat/Factorial/NatCast.lean#L106) and [this](https://github.com/leanprover-community/mathlib4/blob/4baa44807be87d9aba67c680ae68c2ba4a7fc29b/Mathlib/NumberTheory/Bernoulli.lean#L150)), so parentheses were added.

I used metaprogramming + Python to create this PR; these are the non-formulaic changes:
- Deleted the TODO in `Data/Nat/Factorial/Basic.lean`
- Fixed 3 comments in `Data/Nat/Factorial/Basic.lean` that used ` !`
- The replacement caused these lines to go over the length limit, so I fixed them manually:
  - `Archive/Imo/Imo2019Q4.lean:84`
  - `Mathlib/Data/Nat/Choose/Basic.lean:289`
  - `Mathlib/RingTheory/DividedPowers/RatAlgebra.lean:134`
  - `Mathlib/RingTheory/Polynomial/ShiftedLegendre.lean:71`

In a future PR I'll add a linter that requires parentheses inside factorials for non-numerals, then the whitespace linter will lint against spaces between `)` and `!`.
(though the pretty printer's parenthesizer still prefers adding spaces instead of parentheses, not sure how to fix it)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
