### PR TITLE
[Merged by Bors] - ci: set timeout-minutes to 30 on flaky linting step

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -499,6 +499,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
+        timeout-minutes: 30
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -509,6 +509,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
+        timeout-minutes: 30
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -515,6 +515,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
+        timeout-minutes: 30
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -513,6 +513,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
+        timeout-minutes: 30
         run: |
           cd pr-branch
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master


### PR DESCRIPTION
This should help mitigate congestion caused by runners being stuck on the linting step due to the issue being discussed in [#mathlib4 > slow linting step CI?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/slow.20linting.20step.20CI.3F/with/567814494).

---

I recommend we merge this with priority > 0 so that it will get merged after the current batch finishes. (`bors p=10 r+` should work.)


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
