### PR TITLE
feat(Order/ModularLattice): add some dual codisjoint lemma for modular lattices

### DIFF
--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -345,34 +345,55 @@ end DistribLattice
 
 namespace Disjoint
 
-variable {a b c : α}
+variable {a b c : α} [Lattice α] [IsModularLattice α]
 
-theorem disjoint_sup_right_of_disjoint_sup_left [Lattice α] [OrderBot α]
-    [IsModularLattice α] (h : Disjoint a b) (hsup : Disjoint (a ⊔ b) c) :
-    Disjoint a (b ⊔ c) := by
+theorem disjoint_sup_right_of_disjoint_sup_left [OrderBot α]
+    (h : Disjoint a b) (hsup : Disjoint (a ⊔ b) c) : Disjoint a (b ⊔ c) := by
   rw [disjoint_iff_inf_le, ← h.eq_bot, sup_comm]
   apply le_inf inf_le_left
   apply (inf_le_inf_right (c ⊔ b) le_sup_right).trans
   rw [sup_comm, IsModularLattice.sup_inf_sup_assoc, hsup.eq_bot, bot_sup_eq]
 
-theorem disjoint_sup_left_of_disjoint_sup_right [Lattice α] [OrderBot α]
-    [IsModularLattice α] (h : Disjoint b c) (hsup : Disjoint a (b ⊔ c)) :
-    Disjoint (a ⊔ b) c := by
+theorem disjoint_sup_left_of_disjoint_sup_right [OrderBot α]
+    (h : Disjoint b c) (hsup : Disjoint a (b ⊔ c)) : Disjoint (a ⊔ b) c := by
   rw [disjoint_comm, sup_comm]
   apply Disjoint.disjoint_sup_right_of_disjoint_sup_left h.symm
   rwa [sup_comm, disjoint_comm] at hsup
 
-theorem isCompl_sup_right_of_isCompl_sup_left [Lattice α] [BoundedOrder α] [IsModularLattice α]
-    (h : Disjoint a b) (hcomp : IsCompl (a ⊔ b) c) :
-    IsCompl a (b ⊔ c) :=
+theorem isCompl_sup_right_of_isCompl_sup_left [BoundedOrder α]
+    (h : Disjoint a b) (hcomp : IsCompl (a ⊔ b) c) : IsCompl a (b ⊔ c) :=
   ⟨h.disjoint_sup_right_of_disjoint_sup_left hcomp.disjoint, codisjoint_assoc.mp hcomp.codisjoint⟩
 
-theorem isCompl_sup_left_of_isCompl_sup_right [Lattice α] [BoundedOrder α] [IsModularLattice α]
-    (h : Disjoint b c) (hcomp : IsCompl a (b ⊔ c)) :
-    IsCompl (a ⊔ b) c :=
+theorem isCompl_sup_left_of_isCompl_sup_right [BoundedOrder α]
+    (h : Disjoint b c) (hcomp : IsCompl a (b ⊔ c)) : IsCompl (a ⊔ b) c :=
   ⟨h.disjoint_sup_left_of_disjoint_sup_right hcomp.disjoint, codisjoint_assoc.mpr hcomp.codisjoint⟩
 
 end Disjoint
+
+namespace Codisjoint
+
+variable {a b c : α} [Lattice α] [IsModularLattice α]
+
+theorem codisjoint_inf_right_of_codisjoint_inf_left [OrderTop α]
+    (h : Codisjoint a b) (hsup : Codisjoint (a ⊓ b) c) : Codisjoint a (b ⊓ c) := by
+  rw [← disjoint_toDual_iff] at *
+  exact Disjoint.disjoint_sup_right_of_disjoint_sup_left h hsup
+
+theorem codisjoint_inf_left_of_codisjoint_inf_right [OrderTop α]
+    (h : Codisjoint b c) (hsup : Codisjoint a (b ⊓ c)) : Codisjoint (a ⊓ b) c := by
+  rw [← disjoint_toDual_iff] at *
+  exact Disjoint.disjoint_sup_left_of_disjoint_sup_right h hsup
+
+theorem isCompl_inf_right_of_isCompl_inf_left [BoundedOrder α]
+    (h : Codisjoint a b) (hcomp : IsCompl (a ⊓ b) c) : IsCompl a (b ⊓ c) :=
+  ⟨disjoint_assoc.mp hcomp.disjoint, h.codisjoint_inf_right_of_codisjoint_inf_left hcomp.codisjoint⟩
+
+theorem isCompl_inf_left_of_isCompl_inf_right [BoundedOrder α]
+    (h : Codisjoint b c) (hcomp : IsCompl a (b ⊓ c)) : IsCompl (a ⊓ b) c :=
+  ⟨disjoint_assoc.mpr hcomp.disjoint,
+    h.codisjoint_inf_left_of_codisjoint_inf_right hcomp.codisjoint⟩
+
+end Codisjoint
 
 lemma Set.Iic.isCompl_inf_inf_of_isCompl_of_le [Lattice α] [BoundedOrder α] [IsModularLattice α]
     {a b c : α} (h₁ : IsCompl b c) (h₂ : b ≤ a) :


### PR DESCRIPTION
Add four codisjoint lemmas dual to existing disjoint lemmas for modular lattices:
* Add `codisjoint_inf_right_of_codisjoint_inf_left`
* Add `codisjoint_inf_left_of_codisjoint_inf_right`
* Add `isCompl_inf_right_of_isCompl_inf_left`
* Add `isCompl_inf_left_of_isCompl_inf_right`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
