### PR TITLE
feat(RingTheory/Ideal/Colon): add more API for `sup` and `inf`

### DIFF
--- a/Mathlib/RingTheory/Ideal/Colon.lean
+++ b/Mathlib/RingTheory/Ideal/Colon.lean
@@ -60,6 +60,20 @@ theorem colon_bot : colon ⊥ N = N.annihilator := by
 theorem colon_mono (hn : N₁ ≤ N₂) (hp : P₁ ≤ P₂) : N₁.colon P₂ ≤ N₂.colon P₁ := fun _ hrnp =>
   mem_colon.2 fun p₁ hp₁ => hn <| mem_colon.1 hrnp p₁ <| hp hp₁
 
+@[simp]
+theorem colon_inf : (N₁ ⊓ N₂).colon P = N₁.colon P ⊓ N₂.colon P := by
+  simp [Submodule.ext_iff, colon]
+
+@[simp]
+theorem colon_iInf {ι : Sort*} (f : ι → Submodule R M) :
+    (⨅ i, f i).colon N = ⨅ i, (f i).colon N := by
+  simp [Submodule.ext_iff, colon]
+
+@[simp]
+theorem colon_finset_inf {ι : Type*} (s : Finset ι) (f : ι → Submodule R M) :
+    (s.inf f).colon N = s.inf (fun i ↦ (f i).colon N) := by
+  simp [Finset.inf_eq_iInf]
+
 theorem _root_.Ideal.le_colon {I J : Ideal R} [I.IsTwoSided] : I ≤ I.colon J := by
   calc I = I.colon ⊤ := colon_top.symm
        _ ≤ I.colon J := colon_mono (le_refl I) le_top
@@ -69,23 +83,28 @@ end Semiring
 section CommSemiring
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
-variable {N P : Submodule R M}
+variable {N P Q : Submodule R M}
 
-theorem mem_colon' {r} : r ∈ N.colon P ↔ P ≤ comap (r • (LinearMap.id : M →ₗ[R] M)) N :=
-  mem_colon
+theorem mem_colon' {r} : r ∈ N.colon P ↔ r • P ≤ N :=
+  Iff.rfl
+
+@[simp]
+theorem colon_sup : N.colon (P ⊔ Q) = N.colon P ⊓ N.colon Q := by
+  simp [Submodule.ext_iff, mem_colon', smul_sup']
+
+@[simp]
+theorem colon_iSup {ι : Sort*} (f : ι → Submodule R M) :
+    N.colon (⨆ i, f i) = ⨅ i, N.colon (f i) := by
+  simp [Submodule.ext_iff, mem_colon', smul_iSup']
+
+@[simp]
+theorem colon_finset_sup {ι : Type*} (s : Finset ι) (f : ι → Submodule R M) :
+    N.colon (s.sup f) = s.inf (fun i ↦ N.colon (f i)) := by
+  simp [Finset.inf_eq_iInf, Finset.sup_eq_iSup]
 
 theorem iInf_colon_iSup (ι₁ : Sort*) (f : ι₁ → Submodule R M) (ι₂ : Sort*)
-    (g : ι₂ → Submodule R M) : (⨅ i, f i).colon (⨆ j, g j) = ⨅ (i) (j), (f i).colon (g j) :=
-  le_antisymm (le_iInf fun _ => le_iInf fun _ => colon_mono (iInf_le _ _) (le_iSup _ _)) fun _ H =>
-    mem_colon'.2 <|
-      iSup_le fun j =>
-        map_le_iff_le_comap.1 <|
-          le_iInf fun i =>
-            map_le_iff_le_comap.2 <|
-              mem_colon'.1 <|
-                have := (mem_iInf _).1 H i
-                have := (mem_iInf _).1 this j
-                this
+    (g : ι₂ → Submodule R M) : (⨅ i, f i).colon (⨆ j, g j) = ⨅ (i) (j), (f i).colon (g j) := by
+  simp_rw [colon_iInf, colon_iSup]
 
 @[simp]
 theorem mem_colon_singleton {x : M} {r : R} : r ∈ N.colon (Submodule.span R {x}) ↔ r • x ∈ N :=


### PR DESCRIPTION
This PR adds more API for `sup` and `inf` of `Ideal.colon`. I also took the liberty of modifying the statement of `mem_colon'` from a rather hacky statement used only in the existing proof of `iInf_colon_iSup` to a cleaner formulation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
