### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MorphismProperty): improve def-eqs and add missing `MorphismProperty.Over.map` isomorphisms

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
@@ -48,10 +48,24 @@ lemma Over.map_comp {f : X ⟶ Y} (hf : P f) {g : Y ⟶ Z} (hg : P g) :
     ext
     simp
 
+/-- Promote an equality to an isomorphism of `Over.map` functors. -/
+@[simps!]
+def Over.mapCongr [Q.RespectsIso] {X Y : T} {f g : X ⟶ Y} (hfg : f = g) (hf : P f) :
+    Over.map Q hf ≅ Over.map (f := g) Q (by cat_disch) :=
+  NatIso.ofComponents (fun Y ↦ Over.isoMk (Iso.refl _))
+
+/-- `Over.map` preserves identities. -/
+@[simps!]
+def Over.mapId [P.IsMultiplicative] [Q.RespectsIso] (X : T) (f : X ⟶ X := 𝟙 X)
+    (hf : f = 𝟙 X := by cat_disch) :
+    Over.map (f := f) (P := P) Q (by subst hf; exact P.id_mem X) ≅ 𝟭 _ :=
+  NatIso.ofComponents (fun Y ↦ Over.isoMk (Iso.refl _))
+
 /-- `Over.map` commutes with composition. -/
 @[simps! hom_app_left inv_app_left]
-def Over.mapComp {f : X ⟶ Y} (hf : P f) {g : Y ⟶ Z} (hg : P g) [Q.RespectsIso] :
-    map Q (P.comp_mem f g hf hg) ≅ map Q hf ⋙ map Q hg :=
+def Over.mapComp {f : X ⟶ Y} (hf : P f) {g : Y ⟶ Z} (hg : P g) [Q.RespectsIso]
+    (fg : X ⟶ Z := f ≫ g) (hfg : fg = f ≫ g := by cat_disch) :
+    map (f := fg) Q (by subst hfg; exact P.comp_mem f g hf hg) ≅ map Q hf ⋙ map Q hg :=
   NatIso.ofComponents (fun X ↦ Over.isoMk (Iso.refl _))
 
 end Map
@@ -85,10 +99,15 @@ variable {P} {Q}
 @[simps! hom_app_left inv_app_left]
 noncomputable def Over.pullbackComp (f : X ⟶ Y) (g : Y ⟶ Z)
     [P.IsStableUnderBaseChangeAlong f] [P.IsStableUnderBaseChangeAlong g]
-    [P.HasPullbacksAlong f] [P.HasPullbacksAlong g] [Q.RespectsIso] [Q.IsStableUnderBaseChange] :
-    Over.pullback P Q (f ≫ g) ≅ Over.pullback P Q g ⋙ Over.pullback P Q f :=
-  NatIso.ofComponents
-    (fun X ↦ Over.isoMk ((pullbackLeftPullbackSndIso X.hom g f).symm) (by simp))
+    [P.HasPullbacksAlong f] [P.HasPullbacksAlong g] [Q.RespectsIso] [Q.IsStableUnderBaseChange]
+    (fg : X ⟶ Z := f ≫ g) (hfg : fg = f ≫ g := by cat_disch) :
+    haveI : P.HasPullbacksAlong fg := by subst hfg; infer_instance
+    haveI : P.IsStableUnderBaseChangeAlong fg := by subst hfg; infer_instance
+    Over.pullback P Q fg ≅ Over.pullback P Q g ⋙ Over.pullback P Q f :=
+  haveI : P.HasPullbacksAlong fg := by subst hfg; infer_instance
+  NatIso.ofComponents fun X ↦
+    haveI : HasPullback X.hom fg := HasPullbacksAlong.hasPullback _ X.prop
+    Over.isoMk (pullback.congrHom rfl hfg ≪≫ (pullbackLeftPullbackSndIso X.hom g f).symm) (by simp)
 
 lemma Over.pullbackComp_left_fst_fst (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderBaseChangeAlong f]
     [P.IsStableUnderBaseChangeAlong g] [P.HasPullbacksAlong f] [P.HasPullbacksAlong g]
@@ -100,18 +119,35 @@ lemma Over.pullbackComp_left_fst_fst (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnde
 /-- If `f = g`, then base change along `f` is naturally isomorphic to base change along `g`. -/
 noncomputable def Over.pullbackCongr {f : X ⟶ Y} [P.HasPullbacksAlong f]
     [P.IsStableUnderBaseChangeAlong f] [Q.IsStableUnderBaseChange] {g : X ⟶ Y} (h : f = g) :
-    have : P.HasPullbacksAlong g := by subst h; infer_instance
-    have : P.IsStableUnderBaseChangeAlong g := by subst h; infer_instance
+    haveI : P.HasPullbacksAlong g := by subst h; infer_instance
+    haveI : P.IsStableUnderBaseChangeAlong g := by subst h; infer_instance
     Over.pullback P Q f ≅ Over.pullback P Q g :=
-  NatIso.ofComponents (fun X ↦ eqToIso (by simp [h]))
+  haveI : P.HasPullbacksAlong g := by subst h; infer_instance
+  NatIso.ofComponents fun X ↦
+    haveI : HasPullback X.hom g := HasPullbacksAlong.hasPullback _ X.prop
+    Over.isoMk (pullback.congrHom rfl h)
 
 @[reassoc (attr := simp)]
 lemma Over.pullbackCongr_hom_app_left_fst {f : X ⟶ Y} [P.HasPullbacksAlong f] {g : X ⟶ Y}
     [P.IsStableUnderBaseChangeAlong f] [Q.IsStableUnderBaseChange] (h : f = g) (A : P.Over Q Y) :
-    have : P.HasPullbacksAlong g := by subst h; infer_instance
+    haveI : P.HasPullbacksAlong g := by subst h; infer_instance
     ((Over.pullbackCongr h).hom.app A).left ≫ pullback.fst A.hom g = pullback.fst A.hom f := by
   subst h
   simp [pullbackCongr]
+
+/-- The natural map between pullback functors induced by `pullback.map`. -/
+@[simps]
+noncomputable def Over.pullbackMapHomPullback [P.IsStableUnderComposition]
+    {X Y Z : T} (f : X ⟶ Y) (hPf : P f) (hQf : Q f) (g : Y ⟶ Z)
+    [P.IsStableUnderBaseChangeAlong f] [P.IsStableUnderBaseChangeAlong g]
+    [Q.IsStableUnderBaseChange] [HasPullbacks T]
+    (fg : X ⟶ Z := f ≫ g) (hfg : f ≫ g = fg := by cat_disch) :
+    haveI : P.IsStableUnderBaseChangeAlong fg := by subst hfg; infer_instance
+    Over.pullback P Q fg ⋙ Over.map (f := f) _ hPf ⟶
+      Over.pullback P Q g where
+  app A :=
+    Over.homMk (pullback.map _ _ _ _ (𝟙 A.left) f (𝟙 Z) (by simp) (by cat_disch))
+    (by simp) (Q.pullback_map (Q.id_mem _) hQf (by simp) (by cat_disch))
 
 end Pullback
 
@@ -121,6 +157,7 @@ variable [P.IsStableUnderComposition] [Q.IsStableUnderBaseChange]
 
 /-- `P.Over.map` is left adjoint to `P.Over.pullback` if pullbacks of morphisms satisfying `P`
 exist along `f` and are also in `P`, and `f` is in both `P` and `Q`. -/
+@[simps! unit_app counit_app]
 noncomputable def Over.mapPullbackAdj (f : X ⟶ Y) [P.HasPullbacksAlong f]
     [P.IsStableUnderBaseChangeAlong f] [Q.HasOfPostcompProperty Q] (hPf : P f) (hQf : Q f) :
     Over.map Q hPf ⊣ Over.pullback P Q f :=


### PR DESCRIPTION
We replace some `eqToIso`s by constructions with more API and make composition isomorphisms more flexible by replacing `f ≫ g` with an arbitrary prop-eq one.

From Pi1.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
