### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MorphismProperty): add trivial instances for `HasOfPostcompProperty`, etc.

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -361,6 +361,14 @@ instance [W.HasOfPrecompProperty W'] : W.op.HasOfPostcompProperty W'.op where
 
 instance [W.HasTwoOutOfThreeProperty] : W.op.HasTwoOutOfThreeProperty where
 
+instance : (⊤ : MorphismProperty C).HasOfPostcompProperty W where
+  of_postcomp _ _ _ _ := trivial
+
+instance : (⊤ : MorphismProperty C).HasOfPrecompProperty W where
+  of_precomp _ _ _ _ := trivial
+
+instance : (⊤ : MorphismProperty C).HasTwoOutOfThreeProperty where
+
 end
 
 section

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -369,6 +369,24 @@ instance : (⊤ : MorphismProperty C).HasOfPrecompProperty W where
 
 instance : (⊤ : MorphismProperty C).HasTwoOutOfThreeProperty where
 
+variable (P Q : MorphismProperty C)
+
+instance [P.HasOfPostcompProperty W] [Q.HasOfPostcompProperty W] :
+    (P ⊓ Q).HasOfPostcompProperty W where
+  of_postcomp f g hg hfg := ⟨P.of_postcomp f g hg hfg.1, Q.of_postcomp f g hg hfg.2⟩
+
+instance [P.HasOfPrecompProperty W] [Q.HasOfPrecompProperty W] :
+    (P ⊓ Q).HasOfPrecompProperty W where
+  of_precomp f g hg hfg := ⟨P.of_precomp f g hg hfg.1, Q.of_precomp f g hg hfg.2⟩
+
+instance [P.HasTwoOutOfThreeProperty] [Q.HasTwoOutOfThreeProperty] :
+    (P ⊓ Q).HasTwoOutOfThreeProperty := by
+  have : P.HasOfPostcompProperty (P ⊓ Q) := .of_le _ _ inf_le_left
+  have : P.HasOfPrecompProperty (P ⊓ Q) := .of_le _ _ inf_le_left
+  have : Q.HasOfPostcompProperty (P ⊓ Q) := .of_le _ _ inf_le_right
+  have : Q.HasOfPrecompProperty (P ⊓ Q) := .of_le _ _ inf_le_right
+  constructor
+
 end
 
 section


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
