### PR TITLE
[Merged by Bors] - refactor(AlgebraicGeometry/Cover): make `Scheme.Cover.Hom` an `abbrev` for `ZeroHypercover.Hom`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -247,62 +247,32 @@ instance : Precoverage.Small.{u} (precoverage P) where
 
 section category
 
--- TODO: replace this by `ZeroHypercover.Hom`
 /--
 A morphism between covers `𝒰 ⟶ 𝒱` indicates that `𝒰` is a refinement of `𝒱`.
 Since covers of schemes are indexed, the definition also involves a map on the
 indexing types.
+This is implemented as an `abbrev` for `CategoryTheory.Precoverage.ZeroHypercover.Hom`.
 -/
-@[ext]
-structure Cover.Hom {X : Scheme.{u}} (𝒰 𝒱 : Cover.{v} (precoverage P) X) where
-  /-- The map on indexing types associated to a morphism of covers. -/
-  idx : 𝒰.I₀ → 𝒱.I₀
-  /-- The morphism between open subsets associated to a morphism of covers. -/
-  app (j : 𝒰.I₀) : 𝒰.X j ⟶ 𝒱.X (idx j)
-  app_prop (j : 𝒰.I₀) : P (app j) := by infer_instance
-  w (j : 𝒰.I₀) : app j ≫ 𝒱.f _ = 𝒰.f _ := by cat_disch
+abbrev Cover.Hom {X : Scheme.{u}} (𝒰 𝒱 : Cover.{v} K X) :=
+  Precoverage.ZeroHypercover.Hom K 𝒰 𝒱
 
-attribute [reassoc (attr := simp)] Cover.Hom.w
+@[deprecated (since := "2026-01-13")] alias Cover.Hom.idx := PreZeroHypercover.Hom.s₀
 
-/-- The identity morphism in the category of covers of a scheme. -/
-def Cover.Hom.id [P.ContainsIdentities] {X : Scheme.{u}} (𝒰 : Cover.{v} (precoverage P) X) :
-    𝒰.Hom 𝒰 where
-  idx j := j
-  app _ := 𝟙 _
-  app_prop _ := P.id_mem _
+@[deprecated (since := "2026-01-13")] alias Cover.Hom.app := PreZeroHypercover.Hom.h₀
 
-/-- The composition of two morphisms in the category of covers of a scheme. -/
-def Cover.Hom.comp [P.IsStableUnderComposition] {X : Scheme.{u}}
-    {𝒰 𝒱 𝒲 : Cover.{v} (precoverage P) X} (f : 𝒰.Hom 𝒱) (g : 𝒱.Hom 𝒲) : 𝒰.Hom 𝒲 where
-  idx j := g.idx <| f.idx j
-  app _ := f.app _ ≫ g.app _
-  app_prop _ := P.comp_mem _ _ (f.app_prop _) (g.app_prop _)
+@[deprecated (since := "2026-01-13")] alias Cover.Hom.w := PreZeroHypercover.Hom.w₀
 
-instance Cover.category [P.IsMultiplicative] {X : Scheme.{u}} :
-    Category (Cover.{v} (precoverage P) X) where
-  Hom 𝒰 𝒱 := 𝒰.Hom 𝒱
-  id := Cover.Hom.id
-  comp f g := f.comp g
+@[deprecated (since := "2026-01-13")] alias Cover.Hom.id := PreZeroHypercover.Hom.id
 
-variable [P.IsMultiplicative]
+@[deprecated (since := "2026-01-13")] alias Cover.Hom.comp := PreZeroHypercover.Hom.comp
 
-@[simp]
-lemma Cover.id_idx_apply {X : Scheme.{u}} (𝒰 : X.Cover (precoverage P)) (j : 𝒰.I₀) :
-    (𝟙 𝒰 : 𝒰 ⟶ 𝒰).idx j = j := rfl
+@[deprecated (since := "2026-01-13")] alias Cover.id_idx_apply := PreZeroHypercover.id_s₀
 
-@[simp]
-lemma Cover.id_app {X : Scheme.{u}} (𝒰 : X.Cover (precoverage P)) (j : 𝒰.I₀) :
-    (𝟙 𝒰 : 𝒰 ⟶ 𝒰).app j = 𝟙 _ := rfl
+@[deprecated (since := "2026-01-13")] alias Cover.id_app := PreZeroHypercover.id_h₀
 
-@[simp]
-lemma Cover.comp_idx_apply {X : Scheme.{u}} {𝒰 𝒱 𝒲 : X.Cover (precoverage P)}
-    (f : 𝒰 ⟶ 𝒱) (g : 𝒱 ⟶ 𝒲) (j : 𝒰.I₀) :
-    (f ≫ g).idx j = g.idx (f.idx j) := rfl
+@[deprecated (since := "2026-01-13")] alias Cover.comp_idx_apply := PreZeroHypercover.comp_s₀
 
-@[simp]
-lemma Cover.comp_app {X : Scheme.{u}} {𝒰 𝒱 𝒲 : X.Cover (precoverage P)}
-    (f : 𝒰 ⟶ 𝒱) (g : 𝒱 ⟶ 𝒲) (j : 𝒰.I₀) :
-    (f ≫ g).app j = f.app j ≫ g.app _ := rfl
+@[deprecated (since := "2026-01-13")] alias Cover.comp_app := PreZeroHypercover.comp_h₀
 
 end category
 

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -212,8 +212,8 @@ def affineOpenCoverOfSpanRangeEqTop {R : CommRingCat} {ι : Type*} (s : ι → R
 /-- Given any open cover `𝓤`, this is an affine open cover which refines it. -/
 def OpenCover.fromAffineRefinement {X : Scheme.{u}} (𝓤 : X.OpenCover) :
     𝓤.affineRefinement.openCover ⟶ 𝓤 where
-  idx j := j.fst
-  app j := (𝓤.X j.fst).affineCover.f _
+  s₀ j := j.fst
+  h₀ j := (𝓤.X j.fst).affineCover.f _
 
 /-- If two global sections agree after restriction to each member of an open cover, then
 they agree globally. -/

--- a/Mathlib/AlgebraicGeometry/Cover/Sigma.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Sigma.lean
@@ -45,35 +45,27 @@ instance : Unique 𝒰.sigma.I₀ := inferInstanceAs <| Unique PUnit.{v + 1}
 /-- `𝒰` refines the single object cover defined by `𝒰`. -/
 @[simps]
 noncomputable def toSigma (𝒰 : Cover.{v} (precoverage P) S) : 𝒰 ⟶ 𝒰.sigma where
-  idx _ := default
-  app i := Sigma.ι _ i
-  app_prop _ := IsZariskiLocalAtSource.of_isOpenImmersion _
+  s₀ _ := default
+  h₀ i := Sigma.ι _ i
 
 /-- A refinement of coverings induces a refinement on the single object coverings. -/
 @[simps]
 noncomputable def Hom.sigma (f : 𝒰 ⟶ 𝒱) : 𝒰.sigma ⟶ 𝒱.sigma where
-  idx _ := default
-  app _ := Sigma.desc fun j ↦ f.app j ≫ Sigma.ι _ (f.idx j)
-  w _ := Sigma.hom_ext _ _ (by simp)
-  app_prop _ := by
-    simp only [sigma_X, sigma_I₀, PUnit.default_eq_unit,
-      IsZariskiLocalAtSource.iff_of_openCover (Scheme.IsLocallyDirected.openCover _),
-      Discrete.functor_obj_eq_as, IsLocallyDirected.openCover_I₀, IsLocallyDirected.openCover_X,
-      IsLocallyDirected.openCover_f, colimit.ι_desc, Cofan.mk_pt, Cofan.mk_ι_app]
-    intro i
-    exact P.comp_mem _ _ (f.app_prop i.1) (IsZariskiLocalAtSource.of_isOpenImmersion _)
+  s₀ _ := default
+  h₀ _ := Sigma.desc fun j ↦ f.h₀ j ≫ Sigma.ι _ (f.s₀ j)
+  w₀ _ := Sigma.hom_ext _ _ (by simp)
 
 /-- Collapsing a cover to a single object cover is functorial. -/
 @[simps]
 noncomputable def sigmaFunctor : S.Cover (precoverage P) ⥤ S.Cover (precoverage P) where
   obj 𝒰 := 𝒰.sigma
-  map f := f.sigma
-  map_id 𝒰 := Scheme.Cover.Hom.ext rfl <| by
-    simp only [sigma_I₀, sigma_X, Hom.sigma_idx, PUnit.default_eq_unit, id_idx_apply, heq_eq_eq]
+  map f := Scheme.Cover.Hom.sigma f
+  map_id 𝒰 := PreZeroHypercover.Hom.ext rfl <| by
+    simp only [sigma_I₀, sigma_X, heq_eq_eq]
     ext j : 1
     exact Sigma.hom_ext _ _ (by simp)
-  map_comp f g := Scheme.Cover.Hom.ext rfl <| by
-    simp only [sigma_I₀, sigma_X, Hom.sigma_idx, PUnit.default_eq_unit, comp_idx_apply, heq_eq_eq]
+  map_comp f g := PreZeroHypercover.Hom.ext rfl <| by
+    simp only [sigma_I₀, sigma_X, heq_eq_eq]
     ext j : 1
     exact Sigma.hom_ext _ _ (by simp)
 


### PR DESCRIPTION
This slightly changes the meaning of `Scheme.Cover.Hom (precoverage P)`, because the old definition required the transition maps to satisfy `P` (where `P` is a morphism property of schemes). In the general definition, this condition does not make sense.
The meaning remains unchanged for every `P` that satisfies a suitable cancellation property (`HasOfPostcompProperty`), in particular for open covers.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
