### PR TITLE
[Merged by Bors] - chore(Algebra/*/Shrink): use `noncomputable section` with `to_additive`

### DIFF
--- a/Mathlib/Algebra/Group/Shrink.lean
+++ b/Mathlib/Algebra/Group/Shrink.lean
@@ -13,11 +13,7 @@ public import Mathlib.Tactic.SuppressCompilation
 # Transfer group structures from `α` to `Shrink α`
 -/
 
-@[expose] public section
-
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+@[expose] public noncomputable section
 
 universe v
 variable {M α : Type*} [Small.{v} α]

--- a/Mathlib/Algebra/Module/Shrink.lean
+++ b/Mathlib/Algebra/Module/Shrink.lean
@@ -12,11 +12,7 @@ public import Mathlib.Algebra.Module.TransferInstance
 # Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
-@[expose] public section
-
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+@[expose] public noncomputable section
 
 universe v
 variable {R α : Type*} [Small.{v} α] [Semiring R] [AddCommMonoid α] [Module R α]


### PR DESCRIPTION
It was fixed some time ago that `@[to_additive]` works correctly with `noncomputable section`, so we can use that now.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
