### PR TITLE
feat(Analysis/Normed/Algebra): matrix exponential of nilpotent matrix

### DIFF
--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -169,8 +169,7 @@ variable (𝕂)
 theorem exp_eq_finset_sum_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = ∑ i ∈ Finset.range (nilpotencyClass x), (i ! : 𝕂)⁻¹ • x ^ i := by
   rw [exp_eq_tsum]
-  dsimp only
-  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass x))]
+  apply tsum_eq_sum
   intro _ hb
   rw [Finset.mem_range, not_lt] at hb
   rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
@@ -217,13 +216,10 @@ variable (𝕂)
 
 theorem exp_eq_finset_sum_div_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = ∑ i ∈ Finset.range (nilpotencyClass x), x ^ i / i ! := by
-  rw [exp_eq_tsum_div]
-  dsimp only
-  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass x))]
-  intro _ hb
-  rw [Finset.mem_range, not_lt] at hb
-  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
-  norm_num
+  rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
+  apply Finset.sum_congr <| by rfl
+  intros
+  exact expSeries_apply_eq (𝕂 := 𝕂) x _ ▸ expSeries_apply_eq_div x _
 
 lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = IsNilpotent.exp x := by
@@ -231,7 +227,7 @@ lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 
   apply Finset.sum_congr <| by rfl
   intros
   rw [← Rat.cast_inv_nat]
-  exact Rat.cast_smul_eq_qsmul 𝕂 _ _
+  apply Rat.cast_smul_eq_qsmul
 
 end TopologicalDivisionAlgebra
 

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -223,7 +223,7 @@ theorem exp_eq_finset_sum_div_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
 
 lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = IsNilpotent.exp x := by
-  rw [IsNilpotent.exp, exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
+  rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
   apply Finset.sum_congr <| by rfl
   intros
   rw [← Rat.cast_inv_nat]

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -217,15 +217,14 @@ variable (𝕂)
 theorem exp_eq_finset_sum_div_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = ∑ i ∈ Finset.range (nilpotencyClass x), x ^ i / i ! := by
   rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
-  apply Finset.sum_congr <| by rfl
-  intros
+  congr! 1
   exact expSeries_apply_eq (𝕂 := 𝕂) x _ ▸ expSeries_apply_eq_div x _
 
 lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 𝔸} (ha : IsNilpotent x) :
     exp 𝕂 x = IsNilpotent.exp x := by
   rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
-  apply Finset.sum_congr <| by rfl
-  intros
+  congr
+  ext
   rw [← Rat.cast_inv_nat]
   apply Rat.cast_smul_eq_qsmul
 

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Analytic.ChangeOrigin
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.Data.Nat.Choose.Cast
 public import Mathlib.Analysis.Analytic.OfScalars
+public import Mathlib.RingTheory.Nilpotent.Exp
 
 /-!
 # Exponential in a Banach algebra
@@ -165,6 +166,16 @@ theorem star_exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] (x : 𝔸)
 
 variable (𝕂)
 
+theorem exp_eq_finset_sum {x : 𝔸} (ha : IsNilpotent x) :
+    (exp 𝕂 x) = ∑ i ∈ Finset.range (nilpotencyClass x), (i.factorial : 𝕂)⁻¹ • x ^ i := by
+  rw [exp_eq_tsum]
+  dsimp only
+  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass x))]
+  intro b hb
+  rw [Finset.mem_range, not_lt] at hb
+  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
+  norm_num
+
 @[aesop safe apply]
 theorem _root_.IsSelfAdjoint.exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] {x : 𝔸}
     (h : IsSelfAdjoint x) : IsSelfAdjoint (exp 𝕂 x) :=
@@ -201,6 +212,17 @@ theorem expSeries_sum_eq_div (x : 𝔸) : (expSeries 𝕂 𝔸).sum x = ∑' n :
 
 theorem exp_eq_tsum_div : exp 𝕂 = fun x : 𝔸 => ∑' n : ℕ, x ^ n / n ! :=
   funext expSeries_sum_eq_div
+
+variable (𝕂)
+
+lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 𝔸} (ha : IsNilpotent x) :
+    (exp 𝕂 x) = IsNilpotent.exp x := by
+  rw [IsNilpotent.exp, exp_eq_finset_sum 𝕂 ha]
+  apply Finset.sum_equiv (Equiv.refl _) (by simp)
+  have h (b : ℕ) : (b.factorial : 𝕂)⁻¹ • (x ^ b) = (b.factorial : ℚ)⁻¹ • (x ^ b) := by
+    rw [← Rat.cast_inv_nat]
+    exact Rat.cast_smul_eq_qsmul 𝕂 _ _
+  simp [h]
 
 end TopologicalDivisionAlgebra
 

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -166,12 +166,12 @@ theorem star_exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] (x : 𝔸)
 
 variable (𝕂)
 
-theorem exp_eq_finset_sum {x : 𝔸} (ha : IsNilpotent x) :
-    (exp 𝕂 x) = ∑ i ∈ Finset.range (nilpotencyClass x), (i.factorial : 𝕂)⁻¹ • x ^ i := by
+theorem exp_eq_finset_sum_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
+    exp 𝕂 x = ∑ i ∈ Finset.range (nilpotencyClass x), (i ! : 𝕂)⁻¹ • x ^ i := by
   rw [exp_eq_tsum]
   dsimp only
   rw [tsum_eq_sum (s := Finset.range (nilpotencyClass x))]
-  intro b hb
+  intro _ hb
   rw [Finset.mem_range, not_lt] at hb
   rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
   norm_num
@@ -215,14 +215,23 @@ theorem exp_eq_tsum_div : exp 𝕂 = fun x : 𝔸 => ∑' n : ℕ, x ^ n / n ! :
 
 variable (𝕂)
 
+theorem exp_eq_finset_sum_div_of_isNilpotent {x : 𝔸} (ha : IsNilpotent x) :
+    exp 𝕂 x = ∑ i ∈ Finset.range (nilpotencyClass x), x ^ i / i ! := by
+  rw [exp_eq_tsum_div]
+  dsimp only
+  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass x))]
+  intro _ hb
+  rw [Finset.mem_range, not_lt] at hb
+  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
+  norm_num
+
 lemma exp_eq_isNilpotent_exp [CharZero 𝔸] [IsScalarTower ℚ 𝕂 𝔸] {x : 𝔸} (ha : IsNilpotent x) :
-    (exp 𝕂 x) = IsNilpotent.exp x := by
-  rw [IsNilpotent.exp, exp_eq_finset_sum 𝕂 ha]
-  apply Finset.sum_equiv (Equiv.refl _) (by simp)
-  have h (b : ℕ) : (b.factorial : 𝕂)⁻¹ • (x ^ b) = (b.factorial : ℚ)⁻¹ • (x ^ b) := by
-    rw [← Rat.cast_inv_nat]
-    exact Rat.cast_smul_eq_qsmul 𝕂 _ _
-  simp [h]
+    exp 𝕂 x = IsNilpotent.exp x := by
+  rw [IsNilpotent.exp, exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
+  apply Finset.sum_congr <| by rfl
+  intros
+  rw [← Rat.cast_inv_nat]
+  exact Rat.cast_smul_eq_qsmul 𝕂 _ _
 
 end TopologicalDivisionAlgebra
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -104,8 +104,7 @@ lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionR
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : exp 𝕂 A = IsNilpotent.exp A := by
   rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
-  apply Finset.sum_congr <| by rfl
-  intros
+  congrm ∑ _ ∈ _, ?_
   rw [← Rat.cast_inv_nat]
   apply Rat.cast_smul_eq_qsmul
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -103,7 +103,7 @@ end Ring
 lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : exp 𝕂 A = IsNilpotent.exp A := by
-  rw [IsNilpotent.exp, exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
+  rw [exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
   apply Finset.sum_congr <| by rfl
   intros
   rw [← Rat.cast_inv_nat]

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -107,7 +107,7 @@ lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionR
   apply Finset.sum_congr <| by rfl
   intros
   rw [← Rat.cast_inv_nat]
-  exact Rat.cast_smul_eq_qsmul 𝕂 _ _
+  apply Rat.cast_smul_eq_qsmul
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -101,8 +101,7 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
 
 omit [T2Space 𝔸] in
 private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : IsNilpotent A)
-    (hA : ∀ (k : 𝕂) (q : ℚ), k = q → k • A = q • A)
-    (h1 : ∀ (k : 𝕂) (q : ℚ), k = q → k • (1 : Matrix m m 𝔸) = q • (1 : Matrix m m 𝔸)) :
+    (h : ∀ (k : 𝕂) (q : ℚ) (n : ℕ) (_ : k = q), k • A ^ n = q • A ^ n) :
     (exp 𝕂 A) = IsNilpotent.exp A := by
   rw [IsNilpotent.exp, exp_eq_tsum]
   dsimp only
@@ -112,17 +111,9 @@ private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) 
     rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
     norm_num
   rw [tsum_eq_sum ha']
-  have h' (k : 𝕂) (q : ℚ) (n : ℕ) (hkq : k = q) : k • A ^ n = q • A ^ n := by
-    cases eq_zero_or_pos n
-    all_goals rename_i hn
-    · simp only [hn]
-      exact h1 k q hkq
-    · rw [← mul_pow_sub_one (by bound : n ≠ 0)]
-      repeat rw [← smul_mul_assoc]
-      rw [hA k q hkq]
-  have h'' (b : ℕ) := h' (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b (by rw [Rat.cast_inv_nat])
+  have h' (b : ℕ) := h (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b (by rw [Rat.cast_inv_nat])
   apply Finset.sum_equiv (Equiv.refl _) (by simp)
-  simp [h'']
+  simp [h']
 
 end Ring
 
@@ -130,10 +121,21 @@ theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [Divisio
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     (A : Matrix m m 𝔸) (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
   apply exp_eq_isNilpotent_exp' 𝕂 A ha
-  all_goals {
+  intro k q n hkq
+  have h1 : ∀ (k : 𝕂) (q : ℚ), k = q → k • (1 : Matrix m m 𝔸) = q • (1 : Matrix m m 𝔸) := ?_
+  focus have hA : ∀ (k : 𝕂) (q : ℚ), k = q → k • A = q • A := ?_
+  rotate_left
+  repeat {
     intro k q hkq
     rw [hkq]
     exact Rat.cast_smul_eq_qsmul 𝕂 q _
+  }
+  match n with
+  | 0 => exact h1 k q hkq
+  | Nat.succ bb => {
+    rw [← mul_pow_sub_one (by bound)]
+    iterate 2 rw [← smul_mul_assoc]
+    rw [hA k q hkq]
   }
 
 section CommRing

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -10,7 +10,6 @@ public import Mathlib.Analysis.Matrix.Normed
 public import Mathlib.LinearAlgebra.Matrix.ZPow
 public import Mathlib.LinearAlgebra.Matrix.Hermitian
 public import Mathlib.LinearAlgebra.Matrix.Symmetric
-public import Mathlib.RingTheory.Nilpotent.Exp
 public import Mathlib.Topology.UniformSpace.Matrix
 
 /-!
@@ -98,17 +97,6 @@ theorem exp_conjTranspose [StarRing 𝔸] [ContinuousStar 𝔸] (A : Matrix m m 
 theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m 𝔸} (h : A.IsHermitian) :
     (exp 𝕂 A).IsHermitian :=
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
-
-omit [T2Space 𝔸] in
-theorem exp_eq_finset_sum {A : Matrix m m 𝔸} (ha : IsNilpotent A) :
-    (exp 𝕂 A) = ∑ i ∈ Finset.range (nilpotencyClass A), (i.factorial : 𝕂)⁻¹ • A ^ i := by
-  rw [exp_eq_tsum]
-  dsimp only
-  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass A))]
-  intro b hb
-  rw [Finset.mem_range, not_lt] at hb
-  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
-  norm_num
 
 end Ring
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -105,15 +105,13 @@ private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] {A : Matrix m m 𝔸} 
     (exp 𝕂 A) = IsNilpotent.exp A := by
   rw [IsNilpotent.exp, exp_eq_tsum]
   dsimp only
-  have ha' : ∀ b ∉ Finset.range (nilpotencyClass A), (b.factorial : 𝕂)⁻¹ • A ^ b = 0 := by
-    intro b hb
-    rw [Finset.mem_range, not_lt] at hb
-    rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
-    norm_num
-  rw [tsum_eq_sum ha']
-  have h' (b : ℕ) := h (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b (by rw [Rat.cast_inv_nat])
-  apply Finset.sum_equiv (Equiv.refl _) (by simp)
-  simp [h']
+  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass A))]
+  · apply Finset.sum_equiv (Equiv.refl _) (by simp)
+    simp [fun (b : ℕ) ↦ h (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b]
+  intro b hb
+  rw [Finset.mem_range, not_lt] at hb
+  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
+  norm_num
 
 end Ring
 
@@ -121,16 +119,14 @@ theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [Divisio
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
   apply exp_eq_isNilpotent_exp' 𝕂 ha
-  intro k q n hkq
-  have hB (B : Matrix m m 𝔸) {k : 𝕂} {q : ℚ} (hkq: k = q) : k • B = q • B := by
-    rw [hkq]
-    exact Rat.cast_smul_eq_qsmul 𝕂 q _
+  intro k q n h
+  have h' (B : Matrix m m 𝔸) : k • B = q • B := by rw [h]; exact Rat.cast_smul_eq_qsmul 𝕂 q _
   match n with
-  | 0 => exact (hB 1) hkq
+  | 0 => exact h' 1
   | Nat.succ bb =>
     rw [← mul_pow_sub_one (by bound)]
     iterate 2 rw [← smul_mul_assoc]
-    rw [(hB A) hkq]
+    rw [h' A]
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -102,13 +102,12 @@ end Ring
 
 lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
-    {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
-  rw [IsNilpotent.exp, exp_eq_finset_sum 𝕂 ha]
-  apply Finset.sum_equiv (Equiv.refl _) (by simp)
-  have h (b : ℕ) : (b.factorial : 𝕂)⁻¹ • (A ^ b) = (b.factorial : ℚ)⁻¹ • (A ^ b) := by
-    rw [← Rat.cast_inv_nat]
-    exact Rat.cast_smul_eq_qsmul 𝕂 _ _
-  simp [h]
+    {A : Matrix m m 𝔸} (ha : IsNilpotent A) : exp 𝕂 A = IsNilpotent.exp A := by
+  rw [IsNilpotent.exp, exp_eq_finset_sum_of_isNilpotent 𝕂 ha]
+  apply Finset.sum_congr <| by rfl
+  intros
+  rw [← Rat.cast_inv_nat]
+  exact Rat.cast_smul_eq_qsmul 𝕂 _ _
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -100,7 +100,7 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
 
 omit [T2Space 𝔸] in
-private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : IsNilpotent A)
+private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] {A : Matrix m m 𝔸} (ha : IsNilpotent A)
     (h : ∀ (k : 𝕂) (q : ℚ) (n : ℕ) (_ : k = q), k • A ^ n = q • A ^ n) :
     (exp 𝕂 A) = IsNilpotent.exp A := by
   rw [IsNilpotent.exp, exp_eq_tsum]
@@ -119,24 +119,18 @@ end Ring
 
 theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
-    (A : Matrix m m 𝔸) (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
-  apply exp_eq_isNilpotent_exp' 𝕂 A ha
+    {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
+  apply exp_eq_isNilpotent_exp' 𝕂 ha
   intro k q n hkq
-  have h1 : ∀ (k : 𝕂) (q : ℚ), k = q → k • (1 : Matrix m m 𝔸) = q • (1 : Matrix m m 𝔸) := ?_
-  focus have hA : ∀ (k : 𝕂) (q : ℚ), k = q → k • A = q • A := ?_
-  rotate_left
-  repeat {
-    intro k q hkq
+  have hB (B : Matrix m m 𝔸) {k : 𝕂} {q : ℚ} (hkq: k = q) : k • B = q • B := by
     rw [hkq]
     exact Rat.cast_smul_eq_qsmul 𝕂 q _
-  }
   match n with
-  | 0 => exact h1 k q hkq
-  | Nat.succ bb => {
+  | 0 => exact (hB 1) hkq
+  | Nat.succ bb =>
     rw [← mul_pow_sub_one (by bound)]
     iterate 2 rw [← smul_mul_assoc]
-    rw [hA k q hkq]
-  }
+    rw [(hB A) hkq]
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -115,12 +115,12 @@ end Ring
 lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
-  have h' (b : ℕ) (k : 𝕂) (q : ℚ) (h : k = q) : k • (A ^ b) = q • (A ^ b) := by
-    rw [h]
-    exact Rat.cast_smul_eq_qsmul 𝕂 q _
   rw [IsNilpotent.exp, exp_eq_finset_sum 𝕂 ha]
   apply Finset.sum_equiv (Equiv.refl _) (by simp)
-  simp [fun (b : ℕ) ↦ h' b (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹]
+  have h (b : ℕ) : (b.factorial : 𝕂)⁻¹ • (A ^ b) = (b.factorial : ℚ)⁻¹ • (A ^ b) := by
+    rw [← Rat.cast_inv_nat]
+    exact Rat.cast_smul_eq_qsmul 𝕂 _ _
+  simp [h]
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Matrix.Normed
 public import Mathlib.LinearAlgebra.Matrix.ZPow
 public import Mathlib.LinearAlgebra.Matrix.Hermitian
 public import Mathlib.LinearAlgebra.Matrix.Symmetric
+public import Mathlib.RingTheory.Nilpotent.Exp
 public import Mathlib.Topology.UniformSpace.Matrix
 
 /-!
@@ -98,7 +99,47 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
     (exp 𝕂 A).IsHermitian :=
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
 
+omit [T2Space 𝔸] in
+theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : IsNilpotent A)
+    (hA : ∀ (k : 𝕂) (q : ℚ), k = q → k • A = q • A)
+    (h1 : ∀ (k : 𝕂) (q : ℚ), k = q → k • (1 : Matrix m m 𝔸) = q • (1 : Matrix m m 𝔸)) :
+    (exp 𝕂 A) = IsNilpotent.exp A := by
+  rw [IsNilpotent.exp, exp_eq_tsum]
+  dsimp only
+  have ha' : ∀ b ∉ Finset.range (nilpotencyClass A), (b.factorial : 𝕂)⁻¹ • A ^ b = 0 := by
+    intro b hb
+    rw [Finset.mem_range, not_lt] at hb
+    rw [smul_eq_zero, inv_eq_zero]
+    right
+    have hfact : b = (b - nilpotencyClass A) + (nilpotencyClass A) := by simp [hb]
+    rw [hfact, pow_add A (b - nilpotencyClass A) (nilpotencyClass A), pow_nilpotencyClass ha]
+    norm_num
+  rw [tsum_eq_sum ha']
+  have h' (k : 𝕂) (q : ℚ) (n : ℕ) (hkq : k = q) : k • A ^ n = q • A ^ n := by
+    cases eq_zero_or_pos n
+    · rename_i hn
+      simp only [hn]
+      exact h1 k q hkq
+    · rename_i hn
+      rw [← mul_pow_sub_one (by bound : n ≠ 0)]
+      repeat rw [← smul_mul_assoc]
+      rw [hA]
+      exact hkq
+  have h'' (b : ℕ) := h' (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b (by rw [Rat.cast_inv_nat])
+  apply Finset.sum_equiv (Equiv.refl _) (by simp)
+  simp [h'']
+
 end Ring
+
+theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
+    [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
+    (A : Matrix m m 𝔸) (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
+  apply exp_eq_isNilpotent_exp' 𝕂 A ha
+  all_goals {
+    intro k q hkq
+    rw [hkq]
+    exact Rat.cast_smul_eq_qsmul 𝕂 q _
+  }
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -100,14 +100,11 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
 
 omit [T2Space 𝔸] in
-private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] {A : Matrix m m 𝔸} (ha : IsNilpotent A)
-    (h : ∀ (k : 𝕂) (q : ℚ) (n : ℕ) (_ : k = q), k • A ^ n = q • A ^ n) :
-    (exp 𝕂 A) = IsNilpotent.exp A := by
-  rw [IsNilpotent.exp, exp_eq_tsum]
+private theorem exp_eq_isNilpotent_exp' (A : Matrix m m 𝔸) (ha : IsNilpotent A) :
+    (exp 𝕂 A) = ∑ i ∈ Finset.range (nilpotencyClass A), (i.factorial : 𝕂)⁻¹ • A ^ i := by
+  rw [exp_eq_tsum]
   dsimp only
   rw [tsum_eq_sum (s := Finset.range (nilpotencyClass A))]
-  · apply Finset.sum_equiv (Equiv.refl _) (by simp)
-    simp [fun (b : ℕ) ↦ h (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b]
   intro b hb
   rw [Finset.mem_range, not_lt] at hb
   rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
@@ -118,15 +115,18 @@ end Ring
 theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
-  apply exp_eq_isNilpotent_exp' 𝕂 ha
-  intro k q n h
-  have h' (B : Matrix m m 𝔸) : k • B = q • B := by rw [h]; exact Rat.cast_smul_eq_qsmul 𝕂 q _
-  match n with
-  | 0 => exact h' 1
-  | Nat.succ bb =>
-    rw [← mul_pow_sub_one (by bound)]
-    iterate 2 rw [← smul_mul_assoc]
-    rw [h' A]
+  have h' (b : ℕ) (k : 𝕂) (q : ℚ) (h : k = q) : k • (A ^ b) = q • (A ^ b) := by
+    rw [h]
+    exact Rat.cast_smul_eq_qsmul 𝕂 q _
+  rw [IsNilpotent.exp, exp_eq_tsum]
+  dsimp only
+  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass A))]
+  · apply Finset.sum_equiv (Equiv.refl _) (by simp)
+    simp [fun (b : ℕ) ↦ h' b (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹]
+  intro b hb
+  rw [Finset.mem_range, not_lt] at hb
+  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
+  norm_num
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -100,7 +100,7 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
 
 omit [T2Space 𝔸] in
-private theorem exp_eq_isNilpotent_exp' (A : Matrix m m 𝔸) (ha : IsNilpotent A) :
+theorem exp_eq_finset_sum {A : Matrix m m 𝔸} (ha : IsNilpotent A) :
     (exp 𝕂 A) = ∑ i ∈ Finset.range (nilpotencyClass A), (i.factorial : 𝕂)⁻¹ • A ^ i := by
   rw [exp_eq_tsum]
   dsimp only
@@ -112,21 +112,15 @@ private theorem exp_eq_isNilpotent_exp' (A : Matrix m m 𝔸) (ha : IsNilpotent 
 
 end Ring
 
-theorem exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
+lemma exp_eq_isNilpotent_exp [Fintype m] [DecidableEq m] [Field 𝕂] [DivisionRing 𝔸] [CharZero 𝔸]
     [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸] [IsScalarTower ℚ 𝕂 𝔸]
     {A : Matrix m m 𝔸} (ha : IsNilpotent A) : (exp 𝕂 A) = IsNilpotent.exp A := by
   have h' (b : ℕ) (k : 𝕂) (q : ℚ) (h : k = q) : k • (A ^ b) = q • (A ^ b) := by
     rw [h]
     exact Rat.cast_smul_eq_qsmul 𝕂 q _
-  rw [IsNilpotent.exp, exp_eq_tsum]
-  dsimp only
-  rw [tsum_eq_sum (s := Finset.range (nilpotencyClass A))]
-  · apply Finset.sum_equiv (Equiv.refl _) (by simp)
-    simp [fun (b : ℕ) ↦ h' b (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹]
-  intro b hb
-  rw [Finset.mem_range, not_lt] at hb
-  rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
-  norm_num
+  rw [IsNilpotent.exp, exp_eq_finset_sum 𝕂 ha]
+  apply Finset.sum_equiv (Equiv.refl _) (by simp)
+  simp [fun (b : ℕ) ↦ h' b (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹]
 
 section CommRing
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -100,7 +100,7 @@ theorem IsHermitian.exp [StarRing 𝔸] [ContinuousStar 𝔸] {A : Matrix m m �
   (exp_conjTranspose _ _).symm.trans <| congr_arg _ h
 
 omit [T2Space 𝔸] in
-theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : IsNilpotent A)
+private theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : IsNilpotent A)
     (hA : ∀ (k : 𝕂) (q : ℚ), k = q → k • A = q • A)
     (h1 : ∀ (k : 𝕂) (q : ℚ), k = q → k • (1 : Matrix m m 𝔸) = q • (1 : Matrix m m 𝔸)) :
     (exp 𝕂 A) = IsNilpotent.exp A := by
@@ -109,22 +109,17 @@ theorem exp_eq_isNilpotent_exp' [Module ℚ 𝔸] (A : Matrix m m 𝔸) (ha : Is
   have ha' : ∀ b ∉ Finset.range (nilpotencyClass A), (b.factorial : 𝕂)⁻¹ • A ^ b = 0 := by
     intro b hb
     rw [Finset.mem_range, not_lt] at hb
-    rw [smul_eq_zero, inv_eq_zero]
-    right
-    have hfact : b = (b - nilpotencyClass A) + (nilpotencyClass A) := by simp [hb]
-    rw [hfact, pow_add A (b - nilpotencyClass A) (nilpotencyClass A), pow_nilpotencyClass ha]
+    rw [← Nat.sub_add_cancel hb, pow_add, pow_nilpotencyClass ha]
     norm_num
   rw [tsum_eq_sum ha']
   have h' (k : 𝕂) (q : ℚ) (n : ℕ) (hkq : k = q) : k • A ^ n = q • A ^ n := by
     cases eq_zero_or_pos n
-    · rename_i hn
-      simp only [hn]
+    all_goals rename_i hn
+    · simp only [hn]
       exact h1 k q hkq
-    · rename_i hn
-      rw [← mul_pow_sub_one (by bound : n ≠ 0)]
+    · rw [← mul_pow_sub_one (by bound : n ≠ 0)]
       repeat rw [← smul_mul_assoc]
-      rw [hA]
-      exact hkq
+      rw [hA k q hkq]
   have h'' (b : ℕ) := h' (b.factorial : 𝕂)⁻¹ (b.factorial : ℚ)⁻¹ b (by rw [Rat.cast_inv_nat])
   apply Finset.sum_equiv (Equiv.refl _) (by simp)
   simp [h'']


### PR DESCRIPTION
Where the matrix exponential and nilpotent elements are defined, both the matrix exponential and the nilpotent element exponential. I had to add a different theorem for normed space exponential and the matrix exponential since the right instances wouldn't be synthesized. Help with golfing would be appreciated.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
