### PR TITLE
[Merged by Bors] - feat: IncompRel.ne

### DIFF
--- a/Mathlib/Order/Comparable.lean
+++ b/Mathlib/Order/Comparable.lean
@@ -237,9 +237,6 @@ theorem IncompRel.ne [Std.Refl r] {a b : α} (h : IncompRel r a b) : a ≠ b := 
   rintro rfl
   exact h.1 <| refl_of r a
 
-theorem IncompRel.ne' [Std.Refl r] {a b : α} (h : IncompRel r a b) : b ≠ a :=
-  h.ne.symm
-
 end Relation
 
 section LE

--- a/Mathlib/Order/Comparable.lean
+++ b/Mathlib/Order/Comparable.lean
@@ -196,13 +196,12 @@ theorem incompRel_swap_apply : IncompRel (swap r) a b ↔ IncompRel r a b :=
 theorem IncompRel.refl [Std.Irrefl r] (a : α) : IncompRel r a a :=
   AntisymmRel.refl rᶜ a
 
-variable {r} in
+variable {r}
+
 theorem IncompRel.rfl [Std.Irrefl r] {a : α} : IncompRel r a a := .refl ..
 
 instance [Std.Irrefl r] : Std.Refl (IncompRel r) where
   refl := .refl r
-
-variable {r}
 
 @[symm]
 theorem IncompRel.symm : IncompRel r a b → IncompRel r b a :=
@@ -233,6 +232,13 @@ theorem not_incompRel_iff : ¬ IncompRel r a b ↔ CompRel r a b := by
 theorem IsTotal.not_incompRel [IsTotal α r] (a b : α) : ¬ IncompRel r a b := by
   rw [not_incompRel_iff]
   exact IsTotal.compRel a b
+
+theorem IncompRel.ne [Std.Refl r] {a b : α} (h : IncompRel r a b) : a ≠ b := by
+  rintro rfl
+  exact h.1 <| refl_of r a
+
+theorem IncompRel.ne' [Std.Refl r] {a b : α} (h : IncompRel r a b) : b ≠ a :=
+  h.ne.symm
 
 end Relation
 


### PR DESCRIPTION
Used in the CGT repo.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
