### PR TITLE
feat(FieldTheory/RatFunc): Generalize lifts/maps to FunLike

### DIFF
--- a/Mathlib/FieldTheory/Laurent.lean
+++ b/Mathlib/FieldTheory/Laurent.lean
@@ -76,7 +76,7 @@ theorem laurentAux_algebraMap : laurentAux r (algebraMap _ _ p) = algebraMap _ _
 
 /-- The Laurent expansion of rational functions about a value. -/
 def laurent : RatFunc R →ₐ[R] RatFunc R :=
-  RatFunc.mapAlgHom (.ofLinearMap (taylor r) (taylor_one _) (taylor_mul _))
+  RatFunc.mapAlgHom (AlgHom.ofLinearMap (taylor r) (taylor_one _) (taylor_mul _))
     (taylor_mem_nonZeroDivisors _)
 
 theorem laurent_div :

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -88,13 +88,13 @@ theorem aeval_X_left_eq_algebraMap (p : K[X]) :
   induction p using Polynomial.induction_on' <;> simp_all
 
 @[simp]
-lemma liftRingHom_C {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) (x : K) :
-    liftRingHom φ hφ (C x) = φ (.C x) :=
+lemma liftRingHom_C {L F : Type*} [Field L] [FunLike F K[X] L] [RingHomClass F K[X] L] (φ : F)
+  (hφ : K[X]⁰ ≤ L⁰.comap φ) (x : K) : liftRingHom φ hφ (C x) = φ (.C x) :=
   RatFunc.liftRingHom_algebraMap _ _ _
 
 @[simp]
-lemma liftRingHom_X {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) :
-    RatFunc.liftRingHom φ hφ X = φ (.X) :=
+lemma liftRingHom_X {L F : Type*} [Field L] [FunLike F K[X] L] [RingHomClass F K[X] L] (φ : F)
+  (hφ : K[X]⁰ ≤ L⁰.comap φ) : RatFunc.liftRingHom φ hφ X = φ (.X) :=
   RatFunc.liftRingHom_algebraMap _ _ _
 
 end Domain

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -473,7 +473,7 @@ lemma liftRingHom_ofFractionRing_algebraMap (φ : F) (hφ : R[X]⁰ ≤ L⁰.com
   rw [← Localization.mk_one_eq_algebraMap, liftRingHom_apply_ofFractionRing_mk]
   simp
 
-theorem liftRingHom_injective [Nontrivial R] (φ : R[X] →+* L) (hφ : Function.Injective φ)
+theorem liftRingHom_injective [Nontrivial R] (φ : F) (hφ : Function.Injective φ)
     (hφ' : R[X]⁰ ≤ L⁰.comap φ := nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hφ) :
     Function.Injective (liftRingHom φ hφ') :=
   liftMonoidWithZeroHom_injective _ hφ
@@ -614,8 +614,8 @@ lemma liftRingHom_algebraMap {L F : Type*} [Field L] [FunLike F K[X] L] [RingHom
   simpa using liftRingHom_apply_div' φ hφ x 1
 
 @[simp]
-lemma liftRingHom_comp_algebraMap {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) :
-    (liftRingHom φ hφ).comp (algebraMap K[X] _) = φ :=
+lemma liftRingHom_comp_algebraMap {L F : Type*} [Field L] [FunLike F K[X] L] [RingHomClass F K[X] L]
+  (φ : F) (hφ : K[X]⁰ ≤ L⁰.comap φ) : (liftRingHom φ hφ).comp (algebraMap K[X] _) = φ :=
   RingHom.ext fun _ ↦ liftRingHom_algebraMap _ hφ _
 
 variable (K)
@@ -630,24 +630,31 @@ theorem algebraMap_injective : Function.Injective (algebraMap K[X] (RatFunc K)) 
 
 variable {K}
 
-section LiftAlgHom
+section MapAlgHom
 
-variable {L R S : Type*} [Field L] [CommRing R] [IsDomain R] [CommSemiring S] [Algebra S K[X]]
-  [Algebra S L] [Algebra S R[X]] (φ : K[X] →ₐ[S] L) (hφ : K[X]⁰ ≤ L⁰.comap φ)
+variable {R S F : Type*} [CommRing R] [IsDomain R] [CommSemiring S] [Algebra S K[X]]
+  [Algebra S R[X]] [FunLike F K[X] R[X]] [AlgHomClass F S K[X] R[X]]
+  (φ : F) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ)
 
 /-- Lift an algebra homomorphism that maps polynomials `φ : K[X] →ₐ[S] R[X]`
 to a `RatFunc K →ₐ[S] RatFunc R`,
 on the condition that `φ` maps non-zero-divisors to non-zero-divisors,
 by mapping both the numerator and denominator and quotienting them. -/
-def mapAlgHom (φ : K[X] →ₐ[S] R[X]) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) : RatFunc K →ₐ[S] RatFunc R :=
+def mapAlgHom : RatFunc K →ₐ[S] RatFunc R :=
   { mapRingHom φ hφ with
     commutes' := fun r => by
       simp_rw [RingHom.toFun_eq_coe, coe_mapRingHom_eq_coe_map, algebraMap_apply r, map_apply_div,
-        map_one, AlgHom.commutes] }
+        map_one, AlgHomClass.commutes] }
 
-theorem coe_mapAlgHom_eq_coe_map (φ : K[X] →ₐ[S] R[X]) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) :
-    (mapAlgHom φ hφ : RatFunc K → RatFunc R) = map φ hφ :=
-  rfl
+theorem coe_mapAlgHom_eq_coe_map : (mapAlgHom φ hφ : RatFunc K → RatFunc R) = map φ hφ := rfl
+
+end MapAlgHom
+
+section LiftAlgHom
+
+variable {L R S F : Type*} [Field L] [CommRing R] [IsDomain R] [CommSemiring S] [Algebra S K[X]]
+  [Algebra S L] [Algebra S R[X]] [FunLike F K[X] L] [AlgHomClass F S K[X] L] (φ : K[X] →ₐ[S] L)
+  (hφ : K[X]⁰ ≤ L⁰.comap φ)
 
 /-- Lift an injective algebra homomorphism `K[X] →ₐ[S] L` to a `RatFunc K →ₐ[S] L`
 by mapping both the numerator and denominator and quotienting them. -/
@@ -655,13 +662,13 @@ def liftAlgHom : RatFunc K →ₐ[S] L :=
   { liftRingHom φ.toRingHom hφ with
     commutes' := fun r => by
       simp_rw [RingHom.toFun_eq_coe, AlgHom.toRingHom_eq_coe, algebraMap_apply r,
-        liftRingHom_apply_div, AlgHom.coe_toRingHom, map_one, div_one, AlgHom.commutes] }
+        liftRingHom_apply_div, AlgHom.coe_toRingHom, map_one, div_one, AlgHomClass.commutes] }
 
 theorem liftAlgHom_apply_ofFractionRing_mk (n : K[X]) (d : K[X]⁰) :
     liftAlgHom φ hφ (ofFractionRing (Localization.mk n d)) = φ n / φ d :=
   liftMonoidWithZeroHom_apply_ofFractionRing_mk _ hφ _ _
 
-theorem liftAlgHom_injective (φ : K[X] →ₐ[S] L) (hφ : Function.Injective φ)
+theorem liftAlgHom_injective (hφ : Function.Injective φ)
     (hφ' : K[X]⁰ ≤ L⁰.comap φ := nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hφ) :
     Function.Injective (liftAlgHom φ hφ') :=
   liftMonoidWithZeroHom_injective _ hφ

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -398,7 +398,6 @@ def liftMonoidWithZeroHom (φ : F) (hφ : R[X]⁰ ≤ G₀⁰.comap φ) : RatFun
     RatFunc.liftOn f (fun p q => φ p / φ q) fun {p q p' q'} hq hq' h => by
       cases subsingleton_or_nontrivial R
       · rw [Subsingleton.elim p q, Subsingleton.elim p' q, Subsingleton.elim q' q]
-      dsimp
       rw [div_eq_div_iff, ← map_mul, mul_comm p, h, map_mul, mul_comm] <;>
         exact nonZeroDivisors.ne_zero (hφ ‹_›)
   map_one' := by


### PR DESCRIPTION
This was mentioned as a TODO in the file.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
