### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): completeness of `(Nonempty)Compacts`

### DIFF
--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -275,13 +275,6 @@ theorem isClosed_in_closeds [CompleteSpace α] :
         _ = ε := ENNReal.add_halves _
     exact mem_biUnion hy this
 
-/-- In a complete space, the type of nonempty compact subsets is complete. This follows
-from the same statement for closed subsets -/
-instance instCompleteSpace [CompleteSpace α] : CompleteSpace (NonemptyCompacts α) :=
-  (completeSpace_iff_isComplete_range
-        isometry_toCloseds.isUniformInducing).2 <|
-    isClosed_in_closeds.isComplete
-
 /-- In a second countable space, the type of nonempty compact subsets is second countable -/
 instance instSecondCountableTopology [SecondCountableTopology α] :
     SecondCountableTopology (NonemptyCompacts α) :=

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -22,7 +22,7 @@ induced by the Hausdorff metric to hyperspaces of uniform spaces.
 @[expose] public section
 
 open Topology
-open scoped Uniformity
+open scoped Uniformity Filter
 
 variable {α β : Type*}
 
@@ -497,6 +497,53 @@ instance [DiscreteUniformity α] : DiscreteUniformity (Compacts α) :=
 theorem discreteUniformity_iff : DiscreteUniformity (Compacts α) ↔ DiscreteUniformity α :=
   ⟨fun _ => isUniformEmbedding_singleton.discreteUniformity, fun _ => inferInstance⟩
 
+instance [CompleteSpace α] : CompleteSpace (Compacts α) := by
+  refine ⟨fun {f} ⟨_, hf⟩ => ?_⟩
+  grw [← Filter.curry_le_prod, (𝓤 α).basis_sets.uniformity_compacts.ge_iff] at hf
+  change ∀ {U} (hU : U ∈ 𝓤 α), ∀ᶠ K in f, ∀ᶠ K' in f, (↑K, ↑K') ∈ hausdorffEntourage U at hf
+  let l : Filter α := f.lift' fun s => ⋃ K ∈ s, K
+  have hl : l.TotallyBounded := by
+    intro U hU
+    obtain ⟨V : SetRel α α, hV, hVU⟩ := comp_mem_uniformity_sets hU
+    obtain ⟨K, hK⟩ := hf (symm_le_uniformity hV) |>.exists
+    obtain ⟨t, ht₁, ht₂⟩ := K.isCompact.totallyBounded V hV
+    rw [← SetRel.preimage_eq_biUnion] at ht₂
+    refine ⟨t, ht₁, Filter.mem_of_superset (Filter.mem_lift' hK) ?_⟩
+    rw [Set.iUnion₂_subset_iff]
+    intro K' ⟨_, (hK' : ↑K' ⊆ V.preimage K)⟩
+    grw [← hVU, SetRel.preimage_comp, ← ht₂, hK']
+  let L : Compacts α := ⟨{x | ClusterPt x l}, hl.isCompact_setOf_clusterPt⟩
+  exists L
+  simp_rw [nhds_eq_comap_uniformity']
+  rw [uniformity_hasBasis_closed.uniformity_compacts.comap _ |>.ge_iff]
+  intro U ⟨hU₁, hU₂⟩
+  filter_upwards [hf hU₁] with K hK
+  simp_rw [Set.mem_preimage, Prod.map, id, mem_hausdorffEntourage]
+  constructor
+  · intro x hx
+    let lx := l ⊓ 𝓟 (UniformSpace.ball x U)
+    have hlx : lx.TotallyBounded := hl.mono inf_le_left
+    have : lx.NeBot := by
+      unfold lx l
+      rw [Filter.lift'_inf_principal_eq, Filter.lift'_neBot_iff fun _ _ h =>
+        Set.inter_subset_inter_left _ <| Set.biUnion_subset_biUnion_left h]
+      intro s hs
+      obtain ⟨K', ⟨h₁, -⟩, h₂⟩ := Filter.nonempty_of_mem <| Filter.inter_mem hK hs
+      obtain ⟨y, hy, hxy⟩ := h₁ hx
+      exact ⟨y, Set.mem_iUnion₂_of_mem h₂ hy, hxy⟩
+    obtain ⟨y, hy⟩ := hlx.exists_clusterPt
+    have hy₁ : ClusterPt y l := .of_inf_left hy
+    have hy₂ : ClusterPt y (𝓟 (UniformSpace.ball x U)) := .of_inf_right hy
+    rw [← mem_closure_iff_clusterPt, (UniformSpace.isClosed_ball x hU₂).closure_eq] at hy₂
+    exact ⟨y, hy₁, hy₂⟩
+  · intro x (hx : ClusterPt x l)
+    rw [← (hU₂.relImage_of_isCompact K.isCompact).closure_eq, mem_closure_iff_clusterPt]
+    refine hx.mono ?_
+    rw [Filter.le_principal_iff]
+    refine Filter.mem_of_superset (Filter.mem_lift' hK) ?_
+    rw [Set.iUnion₂_subset_iff]
+    exact fun _ ⟨_, h⟩ => h
+
 end TopologicalSpace.Compacts
 
 namespace TopologicalSpace.NonemptyCompacts
@@ -585,5 +632,28 @@ instance [DiscreteUniformity α] : DiscreteUniformity (NonemptyCompacts α) :=
 @[simp]
 theorem discreteUniformity_iff : DiscreteUniformity (NonemptyCompacts α) ↔ DiscreteUniformity α :=
   ⟨fun _ => isUniformEmbedding_singleton.discreteUniformity, fun _ => inferInstance⟩
+
+instance [CompleteSpace α] : CompleteSpace (NonemptyCompacts α) :=
+  isUniformEmbedding_toCompacts.completeSpace isClosedEmbedding_toCompacts.isClosed_range.isComplete
+
+@[simp]
+theorem completeSpace_iff : CompleteSpace (NonemptyCompacts α) ↔ CompleteSpace α := by
+  refine ⟨fun _ => ⟨fun {f} hf => ?_⟩, fun _ => inferInstance⟩
+  obtain ⟨K, hK⟩ := CompleteSpace.complete <| hf.map uniformContinuous_singleton
+  obtain ⟨x, hx⟩ := K.nonempty
+  exists x
+  rw [(nhds_basis_opens x).ge_iff]
+  intro U ⟨hxU, hU⟩
+  filter_upwards [hK <| (isOpen_inter_nonempty_of_isOpen hU).mem_nhds ⟨x, hx, hxU⟩]
+  simp
+
+@[simp]
+theorem _root_.TopologicalSpace.Compacts.completeSpace_iff :
+    CompleteSpace (Compacts α) ↔ CompleteSpace α where
+  mp _ :=
+    NonemptyCompacts.completeSpace_iff.mp <|
+      NonemptyCompacts.isUniformEmbedding_toCompacts.completeSpace
+        isClosedEmbedding_toCompacts.isClosed_range.isComplete
+  mpr _ := inferInstance
 
 end TopologicalSpace.NonemptyCompacts

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -521,11 +521,10 @@ instance [CompleteSpace α] : CompleteSpace (Compacts α) := by
   simp_rw [Set.mem_preimage, Prod.map, id, mem_hausdorffEntourage]
   constructor
   · intro x hx
-    let lx := l ⊓ 𝓟 (UniformSpace.ball x U)
+    set lx := l ⊓ 𝓟 (UniformSpace.ball x U) with le_def
     have hlx : lx.TotallyBounded := hl.mono inf_le_left
     have : lx.NeBot := by
-      unfold lx l
-      rw [Filter.lift'_inf_principal_eq, Filter.lift'_neBot_iff fun _ _ h =>
+      rw [le_def, Filter.lift'_inf_principal_eq, Filter.lift'_neBot_iff fun _ _ h =>
         Set.inter_subset_inter_left _ <| Set.biUnion_subset_biUnion_left h]
       intro s hs
       obtain ⟨K', ⟨h₁, -⟩, h₂⟩ := Filter.nonempty_of_mem <| Filter.inter_mem hK hs


### PR DESCRIPTION
This PR generalizes the completeness result of `NonemptyCompacts` from metric spaces to uniform spaces.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #34036

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
