### PR TITLE
[Merged by Bors] - feat(DihedralGroup): center of D_n for odd n \ne 1 is trivial

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -302,5 +302,29 @@ lemma card_conjClasses_odd (hn : Odd n) :
   rw [← Nat.mul_div_mul_left _ 2 hn.pos, ← card_commute_odd hn, mul_comm,
     card_comm_eq_card_conjClasses_mul_card, nat_card, Nat.mul_div_left _ (mul_pos two_pos hn.pos)]
 
+theorem center_eq_bot_odd_ge_three (hodd : Odd n) (h3 : 3 ≤ n) :
+    Subgroup.center (DihedralGroup n) = ⊥ := by
+  haveI : NeZero n := ⟨hodd.pos.ne'⟩
+  have hunit : IsUnit (2 : ZMod n) :=
+    ZMod.isUnit_prime_of_not_dvd Nat.prime_two hodd.not_two_dvd_nat
+  ext x
+  simp only [Subgroup.mem_center_iff, Subgroup.mem_bot]
+  refine ⟨fun hx => ?_, fun hx => by simp [hx]⟩
+  rcases x with i | i
+  · have heq := sr.inj (hx (sr 0))
+    simp only [zero_add, zero_sub] at heq
+    have hi : (2 : ZMod n) * i = 0 := by
+      calc 2 * i = i + i := two_mul i
+        _ = i + (-i) := by rw [← heq]
+        _ = 0 := add_neg_cancel i
+    simp [hunit.mul_right_eq_zero.mp hi]
+  · have heq := sr.inj (hx (r 1))
+    have h2 : (2 : ZMod n) = 0 := by
+      calc (2 : ZMod n) = (i + 1) - (i - 1) := by ring
+        _ = (i - 1) - (i - 1) := by rw [heq]
+        _ = 0 := by simp only [sub_self]
+    have h2' : (2 : ZMod n) = ((2 : ℕ) : ZMod n) := by norm_cast
+    rw [h2', CharP.cast_eq_zero_iff (ZMod n) n] at h2
+    exact absurd (Nat.le_of_dvd (by norm_num) h2) (by omega)
 
 end DihedralGroup

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Shing Tak Lam. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shing Tak Lam
+Authors: Shing Tak Lam, Seewoo Lee
 -/
 module
 

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -313,10 +313,7 @@ theorem center_eq_bot_odd_ge_three (hodd : Odd n) (h3 : 3 ≤ n) :
   rcases x with i | i
   · have heq := sr.inj (hx (sr 0))
     simp only [zero_add, zero_sub] at heq
-    have hi : (2 : ZMod n) * i = 0 := by
-      calc 2 * i = i + i := two_mul i
-        _ = i + (-i) := by rw [← heq]
-        _ = 0 := add_neg_cancel i
+    have hi : (2 : ZMod n) * i = 0 := by simpa [two_mul, ←heq] using add_neg_cancel i
     simp [hunit.mul_right_eq_zero.mp hi]
   · have heq := sr.inj (hx (r 1))
     have h2 : (2 : ZMod n) = 0 := by

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -302,7 +302,7 @@ lemma card_conjClasses_odd (hn : Odd n) :
   rw [← Nat.mul_div_mul_left _ 2 hn.pos, ← card_commute_odd hn, mul_comm,
     card_comm_eq_card_conjClasses_mul_card, nat_card, Nat.mul_div_left _ (mul_pos two_pos hn.pos)]
 
-theorem center_eq_bot_odd_ge_three (hodd : Odd n) (h3 : 3 ≤ n) :
+theorem center_eq_bot_odd_ne_one (hodd : Odd n) (hne1 : n ≠ 1) :
     Subgroup.center (DihedralGroup n) = ⊥ := by
   have : Fact (1 < n) := ⟨by grind⟩
   ext x

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Shing Tak Lam. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Shing Tak Lam, Seewoo Lee
+Authors: Shing Tak Lam
 -/
 module
 

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -304,24 +304,16 @@ lemma card_conjClasses_odd (hn : Odd n) :
 
 theorem center_eq_bot_odd_ge_three (hodd : Odd n) (h3 : 3 ≤ n) :
     Subgroup.center (DihedralGroup n) = ⊥ := by
-  haveI : NeZero n := ⟨hodd.pos.ne'⟩
-  have hunit : IsUnit (2 : ZMod n) :=
-    ZMod.isUnit_prime_of_not_dvd Nat.prime_two hodd.not_two_dvd_nat
+  have : Fact (1 < n) := ⟨by grind⟩
   ext x
   simp only [Subgroup.mem_center_iff, Subgroup.mem_bot]
-  refine ⟨fun hx => ?_, fun hx => by simp [hx]⟩
+  refine ⟨fun hx ↦ ?_, fun hx ↦ by simp [hx]⟩
   rcases x with i | i
   · have heq := sr.inj (hx (sr 0))
-    simp only [zero_add, zero_sub] at heq
-    have hi : (2 : ZMod n) * i = 0 := by simpa [two_mul, ←heq] using add_neg_cancel i
-    simp [hunit.mul_right_eq_zero.mp hi]
+    rw [zero_add, zero_sub, eq_neg_iff_add_eq_zero, ZMod.add_self_eq_zero_iff_eq_zero hodd] at heq
+    rw [heq, r_zero]
   · have heq := sr.inj (hx (r 1))
-    have h2 : (2 : ZMod n) = 0 := by
-      calc (2 : ZMod n) = (i + 1) - (i - 1) := by ring
-        _ = (i - 1) - (i - 1) := by rw [heq]
-        _ = 0 := by simp only [sub_self]
-    have h2' : (2 : ZMod n) = ((2 : ℕ) : ZMod n) := by norm_cast
-    rw [h2', CharP.cast_eq_zero_iff (ZMod n) n] at h2
-    exact absurd (Nat.le_of_dvd (by norm_num) h2) (by omega)
+    rw [sub_eq_iff_eq_add, add_assoc, left_eq_add, ZMod.add_self_eq_zero_iff_eq_zero hodd] at heq
+    exact (one_ne_zero heq).elim
 
 end DihedralGroup

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -302,7 +302,7 @@ lemma card_conjClasses_odd (hn : Odd n) :
   rw [← Nat.mul_div_mul_left _ 2 hn.pos, ← card_commute_odd hn, mul_comm,
     card_comm_eq_card_conjClasses_mul_card, nat_card, Nat.mul_div_left _ (mul_pos two_pos hn.pos)]
 
-theorem center_eq_bot_odd_ne_one (hodd : Odd n) (hne1 : n ≠ 1) :
+theorem center_eq_bot_of_odd_ne_one (hodd : Odd n) (hne1 : n ≠ 1) :
     Subgroup.center (DihedralGroup n) = ⊥ := by
   have : Fact (1 < n) := ⟨by grind⟩
   ext x

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -304,16 +304,12 @@ lemma card_conjClasses_odd (hn : Odd n) :
 
 theorem center_eq_bot_of_odd_ne_one (hodd : Odd n) (hne1 : n ≠ 1) :
     Subgroup.center (DihedralGroup n) = ⊥ := by
-  have : Fact (1 < n) := ⟨by grind⟩
-  ext x
-  simp only [Subgroup.mem_center_iff, Subgroup.mem_bot]
-  refine ⟨fun hx ↦ ?_, fun hx ↦ by simp [hx]⟩
-  rcases x with i | i
-  · have heq := sr.inj (hx (sr 0))
-    rw [zero_add, zero_sub, eq_neg_iff_add_eq_zero, ZMod.add_self_eq_zero_iff_eq_zero hodd] at heq
-    rw [heq, r_zero]
-  · have heq := sr.inj (hx (r 1))
-    rw [sub_eq_iff_eq_add, add_assoc, left_eq_add, ZMod.add_self_eq_zero_iff_eq_zero hodd] at heq
-    exact (one_ne_zero heq).elim
+  simp only [Subgroup.eq_bot_iff_forall, Subgroup.mem_center_iff]
+  rintro (i | i) h
+  · have heq := sr.inj (h (sr i))
+    simp_all
+  · have heq := sr.inj (h (r 1))
+    have : Fact (1 < n) := ⟨by grind⟩
+    simp [sub_eq_iff_eq_add, add_assoc, ZMod.add_self_eq_zero_iff_eq_zero hodd] at heq
 
 end DihedralGroup


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Center of dihedral group $D_n$ for odd $n \ge 3$ is trivial. Note that initial code was written by Claude Opus 4.5.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
