### PR TITLE
[Merged by Bors] - ci: add `splice-bot` action

### DIFF
--- a/.github/workflows/splice_bot.yaml
+++ b/.github/workflows/splice_bot.yaml
@@ -1,0 +1,16 @@
+name: splice-bot
+
+on:
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  call-splice-bot:
+    uses: leanprover-community/SpliceBot/.github/workflows/splice.yaml@master
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      # optional branch to which the PR will point — defaults to "master"
+      base_ref: master
+    secrets: inherit

--- a/.github/workflows/splice_bot.yaml
+++ b/.github/workflows/splice_bot.yaml
@@ -4,13 +4,12 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   call-splice-bot:
+    if: ${{ contains(github.event.comment.body, 'splice-bot') }}
     uses: leanprover-community/SpliceBot/.github/workflows/splice.yaml@master
-    permissions:
-      contents: write
-      pull-requests: write
     with:
-      # optional branch to which the PR will point — defaults to "master"
+      # Optional override; omit to use the reusable workflow's default "master"
       base_ref: master
-    secrets: inherit

--- a/.github/workflows/splice_bot_wf_run.yaml
+++ b/.github/workflows/splice_bot_wf_run.yaml
@@ -13,11 +13,11 @@ jobs:
     uses: leanprover-community/SpliceBot/.github/workflows/splice_wf_run.yaml@master
     with:
       source_workflow: ${{ github.event.workflow_run.name }}
-      push_to_fork: leanprover-community/SpliceBot-testing-fork
+      push_to_fork: leanprover-community/mathlib4_copy
       # Installation owner used when minting token from app secrets below.
       token_app_owner: leanprover-community
     secrets:
       token_app_id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
       token_app_private_key: ${{ secrets.MATHLIB_SPLICEBOT_PRIVATE_KEY }}
-      branch_token_app_id: ${{ secrets.SPLICEBOT_TESTING_APP_ID }}
-      branch_token_app_private_key: ${{ secrets.SPLICEBOT_TESTING_PRIVATE_KEY }}
+      branch_token_app_id: ${{ secrets.MATHLIB_COPY_SPLICEBOT_APP_ID }}
+      branch_token_app_private_key: ${{ secrets.MATHLIB_COPY_SPLICEBOT_PRIVATE_KEY }}

--- a/.github/workflows/splice_bot_wf_run.yaml
+++ b/.github/workflows/splice_bot_wf_run.yaml
@@ -1,0 +1,23 @@
+name: splice-bot (workflow_run)
+
+on:
+  workflow_run:
+    workflows: ["splice-bot"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  run-reusable:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: leanprover-community/SpliceBot/.github/workflows/splice_wf_run.yaml@master
+    with:
+      source_workflow: ${{ github.event.workflow_run.name }}
+      push_to_fork: leanprover-community/SpliceBot-testing-fork
+      # Installation owner used when minting token from app secrets below.
+      token_app_owner: leanprover-community
+    secrets:
+      token_app_id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
+      token_app_private_key: ${{ secrets.MATHLIB_SPLICEBOT_PRIVATE_KEY }}
+      branch_token_app_id: ${{ secrets.SPLICEBOT_TESTING_APP_ID }}
+      branch_token_app_private_key: ${{ secrets.SPLICEBOT_TESTING_PRIVATE_KEY }}

--- a/.github/workflows/splice_bot_wf_run.yaml
+++ b/.github/workflows/splice_bot_wf_run.yaml
@@ -17,6 +17,7 @@ jobs:
       allow_pr_author: true
       allowed_teams: |
         leanprover-community/mathlib-reviewers
+        leanprover-community/mathlib-maintainers
       # Installation owner used when minting token from app secrets below.
       token_app_owner: leanprover-community
     secrets:

--- a/.github/workflows/splice_bot_wf_run.yaml
+++ b/.github/workflows/splice_bot_wf_run.yaml
@@ -14,10 +14,15 @@ jobs:
     with:
       source_workflow: ${{ github.event.workflow_run.name }}
       push_to_fork: leanprover-community/mathlib4_copy
+      allow_pr_author: true
+      allowed_teams: |
+        leanprover-community/mathlib-reviewers
       # Installation owner used when minting token from app secrets below.
       token_app_owner: leanprover-community
     secrets:
       token_app_id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
       token_app_private_key: ${{ secrets.MATHLIB_SPLICEBOT_PRIVATE_KEY }}
+      authz_token_app_id: ${{ secrets.LPC_TEAM_CHECK_APP_ID }}
+      authz_token_app_private_key: ${{ secrets.LPC_TEAM_CHECK_PRIVATE_KEY }}
       branch_token_app_id: ${{ secrets.MATHLIB_COPY_SPLICEBOT_APP_ID }}
       branch_token_app_private_key: ${{ secrets.MATHLIB_COPY_SPLICEBOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds a CI action that inspects review comments.

If a review comment posted by the PR author or a member of the reviewer or maintainer teams selects at least one line and contains the string `splice-bot` at the start of some line, then the bot will create a branch in the new [mathlib4_copy repo](https://github.com/leanprover-community/mathlib4_copy) with just the changes to the selected file, clearing all history, and then open a new PR from that branch. 

mathlib4_copy is a repo with GitHub actions disabled on it so that people cannot use SpliceBot to trigger workflows they otherwise couldn't. Reviewers and maintainers also have write permissions to mathlib4_copy so that they can make changes to the PR branches created by this bot if necessary.

See https://github.com/leanprover-community/SpliceBot

---

Before merging:
- [x] Add GitHub apps + secrets needed
- [x] Update workflow for new version of Splicebot (will be 2 workflow files instead of 1)
- [x] Mark ready for review

After merging:
- [ ] Make sure that CI runs on the PRs created by the action.
- [ ] Confirm that PRs generated from forks also work as expected.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
