### PR TITLE
[Merged by Bors] - doc(Tactic): improve `wlog` tactic docstring

### DIFF
--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -150,7 +150,7 @@ there will be two additional assumptions:
 * `wlog! h : P` also calls `push_neg` at the generated hypothesis `h`.
   `wlog! h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P → ¬ Q`
 * `wlog! +distrib h : P` also calls `push_neg +distrib` at the generated hypothesis `h`.
-  `wlog! +distrib h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P ∨ Q`.
+  `wlog! +distrib h : P ∧ Q` will transform `¬ (P ∧ Q)` to `¬P ∨ ¬Q`.
 -/
 syntax (name := wlog) "wlog " binderIdent " : " term
   (" generalizing" (ppSpace colGt ident)*)? (" with " binderIdent)? : tactic

--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -135,22 +135,23 @@ def wlogCore (h : TSyntax ``binderIdent) (P : Term) (xs : Option (TSyntaxArray `
       Push.push (← Push.elabPushConfig cfg) none (.const ``Not) (.targets #[(negHygName)] false)
           (failIfUnchanged := false)
 
-/-- `wlog h : P` will add an assumption `h : P` to the main goal, and add a side goal that requires
-showing that the case `h : ¬ P` can be reduced to the case where `P` holds (typically by symmetry).
-
-The side goal will be at the top of the stack. In this side goal, there will be two additional
-assumptions:
+/-- `wlog h : P` adds an assumption `h : P` to the main goal, and adds a side goal that
+requires showing that the case `h : ¬ P` can be reduced to the case where `P` holds
+(typically by symmetry). The side goal will be at the top of the stack. In this side goal,
+there will be two additional assumptions:
 - `h : ¬ P`: the assumption that `P` does not hold
 - `this`: which is the statement that in the old context `P` suffices to prove the goal.
-  By default, the name `this` is used, but the idiom `with H` can be added to specify the name:
-  `wlog h : P with H`.
+  By default, the entire context is reverted to produce `this`.
 
-Typically, it is useful to use the variant `wlog h : P generalizing x y`,
-to revert certain parts of the context before creating the new goal.
-In this way, the wlog-claim `this` can be applied to `x` and `y` in different orders
-(exploiting symmetry, which is the typical use case).
-
-By default, the entire context is reverted. -/
+* `wlog h : P with H` gives the name `H` to the statement that `P` proves the goal.
+* `wlog h : P generalizing x y ...` reverts certain parts of the context before creating the new
+  goal. In this way, the wlog-claim `this` can be applied to `x` and `y` in different orders
+  (exploiting symmetry, which is the typical use case).
+* `wlog! h : P` also calls `push_neg` at the generated hypothesis `h`.
+  `wlog! h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P → ¬ Q`
+* `wlog! +distrib h : P` also calls `push_neg +distrib` at the generated hypothesis `h`.
+  `wlog! +distrib h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P ∨ Q`.
+-/
 syntax (name := wlog) "wlog " binderIdent " : " term
   (" generalizing" (ppSpace colGt ident)*)? (" with " binderIdent)? : tactic
 
@@ -158,12 +159,7 @@ elab_rules : tactic
 | `(tactic| wlog $h:binderIdent : $P:term $[ generalizing $xs*]? $[ with $H:ident]?) =>
   wlogCore h P xs H
 
-/--
-`wlog! h : P` is a variant of the `wlog h : P` tactic that also calls `push_neg` at the generated
-hypothesis `h : ¬ p` in the side goal. `wlog! h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P → ¬ Q`,
-while  `wlog! +distrib h : P ∧ Q` will transform `¬ (P ∧ Q)` to `P ∨ Q`. For more information, see
-the documentation on `push_neg`.
--/
+@[tactic_alt wlog]
 syntax (name := wlog!) "wlog! " optConfig binderIdent " : " term
   (" generalizing" (ppSpace colGt ident)*)? (" with " binderIdent)? : tactic
 


### PR DESCRIPTION
This PR rewrites the docstring for the `wlog` tactic to match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long. Additionally: Instead of `@[inherit_doc]` we should be using `@[tactic_alt]` for tactics that "are considered one" and share docstrings.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
