### PR TITLE
[Merged by Bors] - doc(Tactic): improve `push`/`push_neg`/`pull`/`pull_neg` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -334,7 +334,7 @@ macro "push_neg" cfg:optConfig : conv => `(conv| push $cfg Not)
 
 /--
 `#push head e`, where `head` is a constant and `e` is an expression,
-will print the `push head` form of `e`.
+prints the `push head` form of `e`.
 
 `#push` understands local variables, so you can use them to introduce parameters.
 -/
@@ -344,7 +344,7 @@ macro (name := pushCommand) tk:"#push" cfg:optConfig disch?:(discharger)? ppSpac
 
 /--
 `#push_neg e`, where `e` is an expression,
-which will print the `push_neg` form of `e`.
+prints the `push_neg` form of `e`.
 
 `#push_neg` understands local variables, so you can use them to introduce parameters.
 -/

--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -215,21 +215,28 @@ def push (cfg : Config) (disch? : Option Simp.Discharge) (head : Head) (loc : Lo
   transformAtLocation (pushCore head cfg disch? ·) "push" loc failIfUnchanged
 
 /--
-`push` pushes the given constant away from the head of the expression. For example
-- `push _ ∈ _` rewrites `x ∈ {y} ∪ zᶜ` into `x = y ∨ ¬ x ∈ z`.
-- `push (disch := positivity) Real.log` rewrites `log (a * b ^ 2)` into `log a + 2 * log b`.
-- `push ¬ _` is the same as `push_neg` or `push Not`, and it rewrites
-  `¬ ∀ ε > 0, ∃ δ > 0, δ < ε` into `∃ ε > 0, ∀ δ > 0, ε ≤ δ`.
-
-In addition to constants, `push` can be used to push `fun` and `∀` binders:
-- `push fun _ ↦ _` rewrites `fun x => f x ^ 2 + 5` into `f ^ 2 + 5`
-- `push ∀ _, _` rewrites `∀ a, p a ∧ q a` into `(∀ a, p a) ∧ (∀ a, q a)`.
-
-The `push` tactic can be extended using the `@[push]` attribute.
+`push c` rewrites the goal by pushing the constant `c` deeper into an expression.
+For instance, `push _ ∈ _` rewrites `x ∈ {y} ∪ zᶜ` into `x = y ∨ ¬ x ∈ z`.
+More precisely, the `push` tactic repeatedly rewrites an expression by applying lemmas
+of the form `c ... = ... (c ...)` (where `c` can appear 0 or more times on the right hand side).
+To extend the `push` tactic, you can tag a lemma of this form with the `@[push]` attribute.
 
 To instead move a constant closer to the head of the expression, use the `pull` tactic.
 
-To push a constant at a hypothesis, use the `push ... at h` or `push ... at *` syntax.
+`push` works as both a tactic and a conv tactic.
+
+* `push _ ~ _` pushes the (binary) operator `~`, `push ~ _` pushes the (unary) operator `~`.
+* `push c at l1 l2 ...` rewrites at the given locations.
+* `push c at *` rewrites at all hypotheses and the goal.
+* `push (disch := tac) c` uses the tactic `tac` to discharge any hypotheses for `@[push]` lemmas.
+
+Examples:
+* `push _ ∈ _` rewrites `x ∈ {y} ∪ zᶜ` into `x = y ∨ ¬ x ∈ z`.
+* `push (disch := positivity) Real.log` rewrites `log (a * b ^ 2)` into `log a + 2 * log b`.
+* `push ¬ _` is the same as `push_neg` or `push Not`, and it rewrites
+  `¬ ∀ ε > 0, ∃ δ > 0, δ < ε` into `∃ ε > 0, ∀ δ > 0, ε ≤ δ`.
+* `push fun _ ↦ _` rewrites `fun x => f x ^ 2 + 5` into `f ^ 2 + 5`
+* `push ∀ _, _` rewrites `∀ a, p a ∧ q a` into `(∀ a, p a) ∧ (∀ a, q a)`.
 -/
 elab (name := pushStx) "push" cfg:optConfig disch?:(discharger)? head:(ppSpace colGt term)
     loc:(location)? : tactic => do
@@ -238,41 +245,44 @@ elab (name := pushStx) "push" cfg:optConfig disch?:(discharger)? head:(ppSpace c
   push (← elabPushConfig cfg) disch? (← elabHead head) loc
 
 /--
-Push negations into the conclusion or a hypothesis.
-For instance, a hypothesis `h : ¬ ∀ x, ∃ y, x ≤ y` will be transformed by `push_neg at h` into
-`h : ∃ x, ∀ y, y < x`. Binder names are preserved.
+`push_neg` rewrites the goal by pushing negations deeper into an expression.
+For instance, the goal `¬ ∀ x, ∃ y, x ≤ y` will be transformed by `push_neg` into
+`∃ x, ∀ y, y < x`. Binder names are preserved (contrary to what would happen with `simp`
+using the relevant lemmas). `push_neg` works as both a tactic and a conv tactic.
 
 `push_neg` is a special case of the more general `push` tactic, namely `push Not`.
 The `push` tactic can be extended using the `@[push]` attribute. `push` has special-casing
-built in for `push Not`, so that it can preserve binder names, and so that `¬ (p ∧ q)` can be
-transformed to either `p → ¬ q` (default) or `¬ p ∨ ¬ q` (`push_neg +distrib`).
+built in for `push Not`.
 
 Tactics that introduce a negation usually have a version that automatically calls `push_neg` on
 that negation. These include `by_cases!`, `contrapose!` and `by_contra!`.
 
-Another example: given a hypothesis
+* `push_neg at l1 l2 ...` rewrites at the given locations.
+* `push_neg at *` rewrites at each hypothesis and the goal.
+* `push_neg +distrib` rewrites `¬ (p ∧ q)` into `¬ p ∨ ¬ q` (by default, the tactic rewrites it
+  into `p → ¬ q` instead).
+
+Example:
+
 ```lean
-h : ¬ ∀ ε > 0, ∃ δ > 0, ∀ x, |x - x₀| ≤ δ → |f x - y₀| ≤ ε
+example (h : ¬ ∀ ε > 0, ∃ δ > 0, ∀ x, |x - x₀| ≤ δ → |f x - y₀| ≤ ε) :
+    ∃ ε > 0, ∀ δ > 0, ∃ x, |x - x₀| ≤ δ ∧ ε < |f x - y₀| := by
+  push_neg at h
+  -- Now we have the hypothesis `h : ∃ ε > 0, ∀ δ > 0, ∃ x, |x - x₀| ≤ δ ∧ ε < |f x - y₀|`
+  exact h
 ```
-writing `push_neg at h` will turn `h` into
-```lean
-h : ∃ ε > 0, ∀ δ > 0, ∃ x, |x - x₀| ≤ δ ∧ ε < |f x - y₀|
-```
-Note that binder names are preserved by this tactic, contrary to what would happen with `simp`
-using the relevant lemmas. One can use this tactic at the goal using `push_neg`,
-at every hypothesis and the goal using `push_neg at *` or at selected hypotheses and the goal
-using say `push_neg at h h' ⊢`, as usual.
 -/
 elab (name := push_neg) "push_neg" cfg:optConfig loc:(location)? : tactic => do
   let loc := (loc.map expandLocation).getD (.targets #[] true)
   push (← elabPushConfig cfg) none (.const ``Not) loc
 
 /--
-`pull` is the inverse tactic to `push`.
-It pulls the given constant towards the head of the expression. For example
-- `pull _ ∈ _` rewrites `x ∈ y ∨ ¬ x ∈ z` into `x ∈ y ∪ zᶜ`.
-- `pull (disch := positivity) Real.log` rewrites `log a + 2 * log b` into `log (a * b ^ 2)`.
-- `pull fun _ ↦ _` rewrites `f ^ 2 + 5` into `fun x => f x ^ 2 + 5` where `f` is a function.
+`pull c` rewrites the goal by pulling the constant `c` closer to the head of the expression.
+For instance, `pull _ ∈ _` rewrites `x ∈ y ∨ ¬ x ∈ z` into `x ∈ y ∪ zᶜ`.
+More precisely, the `pull` tactic repeatedly rewrites an expression by applying lemmas
+of the form `... (c ...) = c ...` (where `c` can appear 1 or more times on the left hand side).
+`pull` is the inverse tactic to `push`. To extend the `pull` tactic, you can tag a lemma
+with the `@[push]` attribute. `pull` works as both a tactic and a conv tactic.
 
 A lemma is considered a `pull` lemma if its reverse direction is a `push` lemma
 that actually moves the given constant away from the head. For example
@@ -282,6 +292,16 @@ that actually moves the given constant away from the head. For example
   `pull` lemmas for `fun`, because every `push fun _ ↦ _` lemma is also considered a `pull` lemma.
 
 TODO: define a `@[pull]` attribute for tagging `pull` lemmas that are not `push` lemmas.
+
+* `pull _ ~ _` pulls the operator or relation `~`.
+* `pull c at l1 l2 ...` rewrites at the given locations.
+* `pull c at *` rewrites at all hypotheses and the goal.
+* `pull (disch := tac) c` uses the tactic `tac` to discharge any hypotheses for `@[push]` lemmas.
+
+Examples:
+* `pull _ ∈ _` rewrites `x ∈ y ∨ ¬ x ∈ z` into `x ∈ y ∪ zᶜ`.
+* `pull (disch := positivity) Real.log` rewrites `log a + 2 * log b` into `log (a * b ^ 2)`.
+* `pull fun _ ↦ _` rewrites `f ^ 2 + 5` into `fun x => f x ^ 2 + 5` where `f` is a function.
 -/
 elab (name := pull) "pull" disch?:(discharger)? head:(ppSpace colGt term) loc:(location)? :
     tactic => do
@@ -313,8 +333,8 @@ elab "push" cfg:optConfig disch?:(discharger)? head:(ppSpace colGt term) : conv 
 macro "push_neg" cfg:optConfig : conv => `(conv| push $cfg Not)
 
 /--
-The syntax is `#push head e`, where `head` is a constant and `e` is an expression,
-which will print the `push head` form of `e`.
+`#push head e`, where `head` is a constant and `e` is an expression,
+will print the `push head` form of `e`.
 
 `#push` understands local variables, so you can use them to introduce parameters.
 -/
@@ -323,7 +343,7 @@ macro (name := pushCommand) tk:"#push" cfg:optConfig disch?:(discharger)? ppSpac
   `(command| #conv%$tk push $cfg $[$disch?:discharger]? $head:term => $e)
 
 /--
-The syntax is `#push_neg e`, where `e` is an expression,
+`#push_neg e`, where `e` is an expression,
 which will print the `push_neg` form of `e`.
 
 `#push_neg` understands local variables, so you can use them to introduce parameters.


### PR DESCRIPTION
This PR rewrites the docstring for the `push` family of tactics to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
