### PR TITLE
[Merged by Bors] - doc(Tactic): improve `ring`/`ring1`/`ring_nf` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -1426,17 +1426,17 @@ where
       return q(of_eq $pa $pb)
 
 /--
-Tactic for solving equations of *commutative* (semi)rings,
+`ring1` solves the goal when it is an equality in *commutative* (semi)rings,
 allowing variables in the exponent.
 
-* This version of `ring` fails if the target is not an equality.
-* The variant `ring1!` will use a more aggressive reducibility setting
-  to determine equality of atoms.
+This version of `ring` fails if the target is not an equality.
+
+* `ring1!` uses a more aggressive reducibility setting to determine equality of atoms.
 -/
 elab (name := ring1) "ring1" tk:"!"? : tactic => liftMetaMAtMain fun g ↦ do
   AtomM.run (if tk.isSome then .default else .reducible) (proveEq g)
 
-@[inherit_doc ring1] macro "ring1!" : tactic => `(tactic| ring1 !)
+@[tactic_alt ring1] macro "ring1!" : tactic => `(tactic| ring1 !)
 
 end Ring
 

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -136,16 +136,22 @@ initialize ringCleanupRef.set fun e => do
 open Elab.Tactic Parser.Tactic
 
 /--
-Simplification tactic for expressions in the language of commutative (semi)rings,
-which rewrites all ring expressions into a normal form.
+`ring_nf` simplifies expressions in the language of commutative (semi)rings,
+which rewrites all ring expressions into a normal form, allowing variables in the exponents.
+
+`ring_nf` works as both a tactic and a conv tactic.
+
+See also the `ring` tactic for solving a goal which is an equation in the language
+of commutative (semi)rings.
+
 * `ring_nf!` will use a more aggressive reducibility setting to identify atoms.
-* `ring_nf (config := cfg)` allows for additional configuration:
+* `ring_nf (config := cfg)` allows for additional configuration (see `RingNF.Config`):
   * `red`: the reducibility setting (overridden by `!`)
   * `zetaDelta`: if true, local let variables can be unfolded (overridden by `!`)
   * `recursive`: if true, `ring_nf` will also recurse into atoms
-* `ring_nf` works as both a tactic and a conv tactic.
-  In tactic mode, `ring_nf at h` can be used to rewrite in a hypothesis.
+* `ring_nf at l1 l2 ...` can be used to rewrite at the given locations.
 
+Examples:
 This can be used non-terminally to normalize ring expressions in the goal such as
 `⊢ P (x + x + x)` ~> `⊢ P (x * 3)`, as well as being able to prove some equations that
 `ring` cannot because they involve ring reasoning inside a subterm, such as
@@ -159,25 +165,27 @@ elab (name := ringNF) "ring_nf" tk:"!"? cfg:optConfig loc:(location)? : tactic =
   let m := AtomM.recurse s cfg.toConfig evalExpr (cleanup cfg)
   transformAtLocation (m ·) "ring_nf" loc cfg.failIfUnchanged false
 
-@[inherit_doc ringNF] macro "ring_nf!" cfg:optConfig loc:(location)? : tactic =>
+@[tactic_alt ringNF] macro "ring_nf!" cfg:optConfig loc:(location)? : tactic =>
   `(tactic| ring_nf ! $cfg:optConfig $(loc)?)
 
 @[inherit_doc ringNF] syntax (name := ringNFConv) "ring_nf" "!"? optConfig : conv
 
 /--
-Tactic for solving equations of *commutative* (semi)rings, allowing variables in the exponent.
-
-* This version of `ring1` uses `ring_nf` to simplify in atoms.
-* The variant `ring1_nf!` will use a more aggressive reducibility setting
+* `ring1_nf` additionally uses `ring_nf` to simplify in atoms.
+* `ring1_nf!` will use a more aggressive reducibility setting
   to determine equality of atoms.
 -/
+tactic_extension ring1
+
+@[tactic_alt ring1]
 elab (name := ring1NF) "ring1_nf" tk:"!"? cfg:optConfig : tactic => do
   let mut cfg ← elabConfig cfg
   if tk.isSome then cfg := { cfg with red := .default, zetaDelta := true }
   let s ← IO.mkRef {}
   liftMetaMAtMain fun g ↦ AtomM.RecurseM.run s cfg.toConfig evalExpr (cleanup cfg) <| proveEq g
 
-@[inherit_doc ring1NF] macro "ring1_nf!" cfg:optConfig : tactic =>
+@[tactic_alt ring1]
+macro "ring1_nf!" cfg:optConfig : tactic =>
   `(tactic| ring1_nf ! $cfg:optConfig)
 
 /-- Elaborator for the `ring_nf` tactic. -/
@@ -194,14 +202,13 @@ elab (name := ring1NF) "ring1_nf" tk:"!"? cfg:optConfig : tactic => do
   `(conv| ring_nf ! $cfg:optConfig)
 
 /--
-Tactic for evaluating expressions in *commutative* (semi)rings, allowing for variables in the
+`ring` solves equations in *commutative* (semi)rings, allowing for variables in the
 exponent. If the goal is not appropriate for `ring` (e.g. not an equality) `ring_nf` will be
-suggested.
+suggested. See also `ring1`, which fails if the goal is not an equality.
 
 * `ring!` will use a more aggressive reducibility setting to determine equality of atoms.
-* `ring1` fails if the target is not an equality.
 
-For example:
+Examples:
 ```
 example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
 example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
@@ -215,7 +222,7 @@ macro (name := ring) "ring" : tactic =>
   \nNote that `ring` works primarily in *commutative* rings. \
   If you have a noncommutative ring, abelian group or module, consider using \
   `noncomm_ring`, `abel` or `module` instead.")
-@[inherit_doc ring] macro "ring!" : tactic =>
+@[tactic_alt ring] macro "ring!" : tactic =>
   `(tactic| first | ring1! | try_this ring_nf!
   "\n\nThe `ring!` tactic failed to close the goal. Use `ring_nf!` to obtain a normal form.
   \nNote that `ring!` works primarily in *commutative* rings. \


### PR DESCRIPTION
This PR rewrites the docstring for the `ring` family of tactics to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long. Additionally: Instead of `@[inherit_doc]` we should be using `@[tactic_alt]` for tactics that "are considered one" and share docstrings.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
