### PR TITLE
[Merged by Bors] - doc(Tactic): improve `tfae_have`/`tfae_finish` tactic docstring

### DIFF
--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -93,12 +93,11 @@ destructuring, and goal creation.
 
 * `tfae_have i ← j := t` adds a hypothesis in the reverse direction, of type `Pⱼ → Pᵢ`.
 * `tfae_have i ↔ j := t` adds a hypothesis in the both directions, of type `Pᵢ ↔ Pⱼ`.
-* **All features of `have` are supported by `tfae_have`**. In particular:
-  * `tfae_have hij : i → j := t` names the introduced hypothesis `hij`.
-  * `tfae_have i j | p₁ => t₁ | ...` matches on the assumption `p : Pᵢ`.
-  * `tfae_have ⟨hij, hji⟩ : i ↔ j := t` destructures the bi-implication into `hij : Pᵢ → Pⱼ`
-    and `hji : Pⱼ → Pⱼ`.
-  * `tfae_have i → j := t ?a` creates a new goal for `?a`.
+* `tfae_have hij : i → j := t` names the introduced hypothesis `hij`.
+* `tfae_have i j | p₁ => t₁ | ...` matches on the assumption `p : Pᵢ`.
+* `tfae_have ⟨hij, hji⟩ : i ↔ j := t` destructures the bi-implication into `hij : Pᵢ → Pⱼ`
+  and `hji : Pⱼ → Pⱼ`.
+* `tfae_have i → j := t ?a` creates a new goal for `?a`.
 
 Examples:
 ```lean4

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -81,22 +81,35 @@ end Parser
 open Parser
 
 /--
-`tfae_have` introduces hypotheses for proving goals of the form `TFAE [P₁, P₂, ...]`. Specifically,
-`tfae_have i <arrow> j := ...` introduces a hypothesis of type `Pᵢ <arrow> Pⱼ` to the local
-context, where `<arrow>` can be `→`, `←`, or `↔`. Note that `i` and `j` are natural number indices
-(beginning at 1) used to specify the propositions `P₁, P₂, ...` that appear in the goal.
+`tfae_have i → j := t`, where the goal is `TFAE [P₁, P₂, ...]` introduces a hypothesis of type
+`Pᵢ → Pⱼ` and proof `t` to the local context. Note that `i` and `j` are natural number literals
+(beginning at 1) used as indices to specify the propositions `P₁, P₂, ...` that appear in the goal.
 
+Once sufficient hypotheses have been introduced by `tfae_have`, `tfae_finish` can be used to close
+the goal.
+
+All features of `have` are supported by `tfae_have`, including naming, matching,
+destructuring, and goal creation.
+
+* `tfae_have i ← j := t` adds a hypothesis in the reverse direction, of type `Pⱼ → Pᵢ`.
+* `tfae_have i ↔ j := t` adds a hypothesis in the both directions, of type `Pᵢ ↔ Pⱼ`.
+* **All features of `have` are supported by `tfae_have`**. In particular:
+  * `tfae_have hij : i → j := t` names the introduced hypothesis `hij`.
+  * `tfae_have i j | p₁ => t₁ | ...` matches on the assumption `p : Pᵢ`.
+  * `tfae_have ⟨hij, hji⟩ : i ↔ j := t` destructures the bi-implication into `hij : Pᵢ → Pⱼ`
+    and `hji : Pⱼ → Pⱼ`.
+  * `tfae_have i → j := t ?a` creates a new goal for `?a`.
+
+Examples:
 ```lean4
 example (h : P → R) : TFAE [P, Q, R] := by
   tfae_have 1 → 3 := h
-  ...
+  -- The resulting context now includes `tfae_1_to_3 : P → R`.
+  sorry
 ```
-The resulting context now includes `tfae_1_to_3 : P → R`.
-
-Once sufficient hypotheses have been introduced by `tfae_have`, `tfae_finish` can be used to close
-the goal. For example,
 
 ```lean4
+-- An example of `tfae_have` and `tfae_finish`:
 example : TFAE [P, Q, R] := by
   tfae_have 1 → 2 := sorry /- proof of P → Q -/
   tfae_have 2 → 1 := sorry /- proof of Q → P -/
@@ -104,10 +117,8 @@ example : TFAE [P, Q, R] := by
   tfae_finish
 ```
 
-All features of `have` are supported by `tfae_have`, including naming, matching,
-destructuring, and goal creation. These are demonstrated below.
-
 ```lean4
+-- All features of `have` are supported by `tfae_have`:
 example : TFAE [P, Q] := by
   -- assert `tfae_1_to_2 : P → Q`:
   tfae_have 1 → 2 := sorry
@@ -124,13 +135,14 @@ example : TFAE [P, Q] := by
 
   -- assert `h : P → Q`; `?a` is a new goal:
   tfae_have h : 1 → 2 := f ?a
-  ...
+
+  sorry
 ```
 -/
 syntax (name := tfaeHave) "tfae_have " tfaeHaveDecl : tactic
 
 /--
-`tfae_finish` is used to close goals of the form `TFAE [P₁, P₂, ...]` once a sufficient collection
+`tfae_finish` closes goals of the form `TFAE [P₁, P₂, ...]` once a sufficient collection
 of hypotheses of the form `Pᵢ → Pⱼ` or `Pᵢ ↔ Pⱼ` have been introduced to the local context.
 
 `tfae_have` can be used to conveniently introduce these hypotheses; see `tfae_have`.

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -94,7 +94,7 @@ destructuring, and goal creation.
 
 * `tfae_have i ← j := t` adds a hypothesis in the reverse direction, of type `Pⱼ → Pᵢ`.
 * `tfae_have i ↔ j := t` adds a hypothesis in the both directions, of type `Pᵢ ↔ Pⱼ`.
-* `tfae_have hij : i → j := t` names the introduced hypothesis `hij`.
+* `tfae_have hij : i → j := t` names the introduced hypothesis `hij` instead of `tfae_i_to_j`.
 * `tfae_have i j | p₁ => t₁ | ...` matches on the assumption `p : Pᵢ`.
 * `tfae_have ⟨hij, hji⟩ : i ↔ j := t` destructures the bi-implication into `hij : Pᵢ → Pⱼ`
   and `hji : Pⱼ → Pⱼ`.

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -81,9 +81,10 @@ end Parser
 open Parser
 
 /--
-`tfae_have i → j := t`, where the goal is `TFAE [P₁, P₂, ...]` introduces a hypothesis of type
-`Pᵢ → Pⱼ` and proof `t` to the local context. Note that `i` and `j` are natural number literals
-(beginning at 1) used as indices to specify the propositions `P₁, P₂, ...` that appear in the goal.
+`tfae_have i → j := t`, where the goal is `TFAE [P₁, P₂, ...]` introduces a hypothesis
+`tfae_i_to_j : Pᵢ → Pⱼ` and proof `t` to the local context. Note that `i` and `j` are
+natural number literals (beginning at 1) used as indices to specify the propositions
+`P₁, P₂, ...` that appear in the goal.
 
 Once sufficient hypotheses have been introduced by `tfae_have`, `tfae_finish` can be used to close
 the goal.


### PR DESCRIPTION
This PR rewrites the docstring for the `tfae` family of tactics to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
