### PR TITLE
[Merged by Bors] - doc(Tactic): improve `fun_prop` tactic docstring

### DIFF
--- a/Mathlib/Tactic/FunProp.lean
+++ b/Mathlib/Tactic/FunProp.lean
@@ -27,7 +27,7 @@ public import Mathlib.Tactic.FunProp.Types
 **Basic use:**
 Using the `fun_prop` tactic should be as simple as:
 ```lean
-example : Continuous (fun x : ℝ => x * sin x) := by fun_prop
+example : Continuous (fun x : ℝ ↦ x * sin x) := by fun_prop
 ```
 Mathlib sets up `fun_prop` for many different properties like `Continuous`, `Measurable`,
 `Differentiable`, `ContDiff`, etc., so `fun_prop` should work for such goals. The basic idea behind
@@ -35,23 +35,23 @@ Mathlib sets up `fun_prop` for many different properties like `Continuous`, `Mea
 checks if every single elementary function is, e.g., `Continuous`.
 
 For `ContinuousAt/On/Within` variants, one has to specify a tactic to solve potential side goals
-with `disch:=<tactic>`. For example:
+with `disch := <tactic>`. For example:
 ```lean
-example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ => 1/x) y := by fun_prop (disch:=assumption)
+example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ ↦ 1/x) y := by fun_prop (disch := assumption)
 ```
 
 **Basic debugging:**
 The most common issue is that a function is missing the appropriate theorem. For example:
 ```lean
 import Mathlib.Analysis.Complex.Trigonometric
-example : Continuous (fun x : ℝ => x * Real.sin x) := by fun_prop
+example : Continuous (fun x : ℝ ↦ x * Real.sin x) := by fun_prop
 ```
 Fails with the error:
 ```lean
-`fun_prop` was unable to prove `Continuous fun x => x * x.sin`
+`fun_prop` was unable to prove `Continuous fun x ↦ x * x.sin`
 
 Issues:
-  No theorems found for `Real.sin` in order to prove `Continuous fun x => x.sin`
+  No theorems found for `Real.sin` in order to prove `Continuous fun x ↦ x.sin`
 ```
 This can be easily fixed by importing `Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean`
 where the theorem `Real.continuous_sin` is marked with the `fun_prop` attribute.
@@ -80,46 +80,46 @@ attribute [fun_prop] Continuous
 theorems:
 ```lean
 @[fun_prop]
-theorem continuous_id : Continuous (fun x => x) := ...
+theorem continuous_id : Continuous (fun x ↦ x) := ...
 
 @[fun_prop]
-theorem continuous_const (y : Y) : Continuous (fun x => y) := ...
+theorem continuous_const (y : Y) : Continuous (fun x ↦ y) := ...
 
 @[fun_prop]
 theorem continuous_comp (f : Y → Z) (g : X → Y) (hf : Continuous f) (hg : Continuous g) :
-  Continuous (fun x => f (g x)) := ...
+  Continuous (fun x ↦ f (g x)) := ...
 ```
-The constant theorem is not absolutely necessary as, for example, `IsLinearMap ℝ (fun x => y)` does
+The constant theorem is not absolutely necessary as, for example, `IsLinearMap ℝ (fun x ↦ y)` does
 not hold, but we almost certainly want to mark it if it is available.
 
 You should also provide theorems for `Prod.mk`, `Prod.fst`, and `Prod.snd`:
 ```lean
 @[fun_prop]
-theorem continuous_fst (f : X → Y × Z) (hf : Continuous f) : Continuous (fun x => (f x).fst) := ...
+theorem continuous_fst (f : X → Y × Z) (hf : Continuous f) : Continuous (fun x ↦ (f x).fst) := ...
 @[fun_prop]
-theorem continuous_snd (f : X → Y × Z) (hf : Continuous f) : Continuous (fun x => (f x).snd) := ...
+theorem continuous_snd (f : X → Y × Z) (hf : Continuous f) : Continuous (fun x ↦ (f x).snd) := ...
 @[fun_prop]
 theorem continuous_prod_mk (f : X → Y) (g : X → Z) (hf : Continuous f) (hg : Continuous g) :
-    Continuous (fun x => Prod.mk (f x) (g x)) := ...
+    Continuous (fun x ↦ Prod.mk (f x) (g x)) := ...
 ```
 
 3. Mark function theorems. They can be stated simply as:
 ```lean
 @[fun_prop]
-theorem continuous_neg : Continuous (fun x => - x) := ...
+theorem continuous_neg : Continuous (fun x ↦ - x) := ...
 
 @[fun_prop]
-theorem continuous_add : Continuous (fun x : X × X => x.1 + x.2) := ...
+theorem continuous_add : Continuous (fun x : X × X ↦ x.1 + x.2) := ...
 ```
 where functions of multiple arguments have to be appropriately uncurried. Alternatively, they can
 be stated in compositional form as:
 ```lean
 @[fun_prop]
-theorem continuous_neg (f : X → Y) (hf : Continuous f) : Continuous (fun x => - f x) := ...
+theorem continuous_neg (f : X → Y) (hf : Continuous f) : Continuous (fun x ↦ - f x) := ...
 
 @[fun_prop]
 theorem continuous_add (f g : X → Y) (hf : Continuous f) (hg : Continuous g) :
-  Continuous (fun x => f x + g x) := ...
+  Continuous (fun x ↦ f x + g x) := ...
 ```
 It is enough to provide function theorems in either form. It is mainly a matter of convenience.
 
@@ -132,7 +132,7 @@ You can do this by turning on the `Meta.Tactic.fun_prop.attr` option. For exampl
 set_option trace.Meta.Tactic.fun_prop.attr true
 @[fun_prop]
 theorem continuous_add (f g : X → Y) (hf : Continuous f) (hg : Continuous g) :
-  Continuous (fun x => @HAdd.hAdd X Y Y _ (f x) (g x)) := ...
+  Continuous (fun x ↦ @HAdd.hAdd X Y Y _ (f x) (g x)) := ...
 ```
 displays:
 ```lean
@@ -163,39 +163,39 @@ There are four types of theorems that are used a bit differently.
     - Identity Theorem
     ```lean
     @[fun_prop]
-    theorem continuous_id : Continuous (fun (x : X) => x) := ..
+    theorem continuous_id : Continuous (fun (x : X) ↦ x) := ..
     ```
 
     - Constant Theorem
     ```lean
     @[fun_prop]
-    theorem continuous_const (y : Y) : Continuous (fun (x : X) => y) := ..
+    theorem continuous_const (y : Y) : Continuous (fun (x : X) ↦ y) := ..
     ```
 
     - Composition Theorem
     ```lean
     @[fun_prop]
     theorem continuous_comp (f : Y → Z) (g : X → Y) (hf : Continuous f) (hg : Continuous g) :
-      Continuous (fun (x : X) => f (g x)) := ..
+      Continuous (fun (x : X) ↦ f (g x)) := ..
     ```
 
     - Apply Theorem
       It can be either non-dependent version
     ```lean
     @[fun_prop]
-    theorem continuous_apply (a : α) : Continuous (fun f : (α → X) => f a) := ..
+    theorem continuous_apply (a : α) : Continuous (fun f : (α → X) ↦ f a) := ..
     ```
       or dependent version
     ```lean
     @[fun_prop]
-    theorem continuous_apply (a : α) : Continuous (fun f : ((a' : α) → E a') => f a) := ..
+    theorem continuous_apply (a : α) : Continuous (fun f : ((a' : α) → E a') ↦ f a) := ..
     ```
 
     - Pi Theorem
     ```lean
     @[fun_prop]
     theorem continuous_pi (f : X → α → Y) (hf : ∀ a, Continuous (f x a)) :
-       Continuous (fun x a => f x a) := ..
+       Continuous (fun x a ↦ f x a) := ..
     ```
 
     Not all of these theorems have to be provided, but at least the identity and composition
@@ -208,13 +208,13 @@ There are four types of theorems that are used a bit differently.
     ```lean
     @[fun_prop]
     theorem continuous_fst (f : X → Y × Z) (hf : Continuous f) :
-        Continuous (fun x => (f x).fst) := ...
+        Continuous (fun x ↦ (f x).fst) := ...
     @[fun_prop]
     theorem continuous_snd (f : X → Y × Z) (hf : Continuous f) :
-        Continuous (fun x => (f x).snd) := ...
+        Continuous (fun x ↦ (f x).snd) := ...
     @[fun_prop]
     theorem continuous_prod_mk (f : X → Y) (g : X → Z) (hf : Continuous f) (hg : Continuous g) :
-        Continuous (fun x => (f x, g x)) := ...
+        Continuous (fun x ↦ (f x, g x)) := ...
     ```
 
 - Function Theorems:
@@ -224,12 +224,12 @@ There are four types of theorems that are used a bit differently.
     The function theorem for `Neg.neg` and `Continuous` can be stated as:
     ```lean
     @[fun_prop]
-    theorem continuous_neg : Continuous (fun x => - x) := ...
+    theorem continuous_neg : Continuous (fun x ↦ - x) := ...
     ```
     or as:
     ```lean
     @[fun_prop]
-    theorem continuous_neg (f : X → Y) (hf : Continuous f) : Continuous (fun x => - f x) := ...
+    theorem continuous_neg (f : X → Y) (hf : Continuous f) : Continuous (fun x ↦ - f x) := ...
     ```
     The first form is called *uncurried form* and the second form is called *compositional form*.
     You can provide either form; it is mainly a matter of convenience. You can check if the form of
@@ -248,13 +248,13 @@ There are four types of theorems that are used a bit differently.
     arguments, we have to uncurry the function:
     ```lean
     @[fun_prop]
-    theorem continuous_add : Continuous (fun (x : X × X) => x.1 + x.2) := ...
+    theorem continuous_add : Continuous (fun (x : X × X) ↦ x.1 + x.2) := ...
     ```
     and the *compositional form* of this theorem is:
     ```lean
     @[fun_prop]
     theorem continuous_add (f g : X → Y) (hf : Continuous f) (hg : Continuous g) :
-        Continuous (fun x => f x + g x) := ...
+        Continuous (fun x ↦ f x + g x) := ...
     ```
 
     When dealing with functions with multiple arguments, you need to state, e.g., continuity only
@@ -268,7 +268,7 @@ There are four types of theorems that are used a bit differently.
     continuous linear function is indeed continuous:
     ```lean
     @[fun_prop]
-    theorem continuous_clm_eval (f : X →L[𝕜] Y) : Continuous 𝕜 (fun x => f x) := ...
+    theorem continuous_clm_eval (f : X →L[𝕜] Y) : Continuous 𝕜 (fun x ↦ f x) := ...
     ```
     In this case, the head of the function body `f x` is `DFunLike.coe`. This function is
     treated differently and its theorems are tracked separately.
@@ -278,10 +278,10 @@ There are four types of theorems that are used a bit differently.
     ```lean
     @[fun_prop]
     theorem continuous_clm_apply (f : X → Y →L[𝕜] Z) (hf : Continuous f) (y : Y) :
-       Continuous 𝕜 (fun x => f x y) := ...
+       Continuous 𝕜 (fun x ↦ f x y) := ...
     ```
     Note that without notation and coercion, the function looks like
-    `fun x => DFunLike.coe (f x) y`.
+    `fun x ↦ DFunLike.coe (f x) y`.
 
     In fact, not only `DFunLike.coe` but any function coercion is treated this way. Such function
     coercion has to be registered with `Lean.Meta.registerCoercion` with coercion type `.coeFun`.
@@ -291,7 +291,7 @@ There are four types of theorems that are used a bit differently.
     structure MyFunLike (α β : Type) where
       toFun : α → β
 
-    instance {α β} : CoeFun (MyFunLike α β) (fun _ => α → β) := ⟨MyFunLike.toFun⟩
+    instance {α β} : CoeFun (MyFunLike α β) (fun _ ↦ α → β) := ⟨MyFunLike.toFun⟩
 
     #eval Lean.Elab.Command.liftTermElabM do
       Lean.Meta.registerCoercion ``MyFunLike.toFun
@@ -318,12 +318,12 @@ There are four types of theorems that are used a bit differently.
     if you have a theorem:
     ```lean
     @[fun_prop]
-    theorem differentiable_neg : Differentiable ℝ (fun x => -x) := ...
+    theorem differentiable_neg : Differentiable ℝ (fun x ↦ -x) := ...
     ```
     you should also state the continuous theorem:
     ```lean
     @[fun_prop]
-    theorem continuous_neg : Continuous ℝ (fun x => -x) := ...
+    theorem continuous_neg : Continuous ℝ (fun x ↦ -x) := ...
     ```
     even though `fun_prop` can already prove `continuous_neg` from `differentiable_continuous` and
     `differentiable_neg`. Doing this will have a considerable impact on `fun_prop` speed.
@@ -338,7 +338,7 @@ There are four types of theorems that are used a bit differently.
     Transition theorems do not have to be between two completely different properties. They can be
     between the same property differing by a parameter. Consider this example:
     ```lean
-    example (f : X → Y) (hf : ContDiff ℝ ∞ f) : ContDiff ℝ 2 (fun x => f x + f x) := by
+    example (f : X → Y) (hf : ContDiff ℝ ∞ f) : ContDiff ℝ 2 (fun x ↦ f x + f x) := by
       fun_prop (disch := aesop)
     ```
     which is first reduced to `ContDiff ℝ 2 f` using lambda theorems and then the transition

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -169,7 +169,7 @@ def tryTheorem? (e : Expr) (thmOrigin : Origin) (funProp : Expr → FunPropM (Op
 /--
 Try to prove `e` using the *identity lambda theorem*.
 
-For example, `e = q(Continuous fun x => x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
+For example, `e = q(Continuous fun x ↦ x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
 def applyIdRule (funPropDecl : FunPropDecl) (e : Expr)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
@@ -189,7 +189,7 @@ def applyIdRule (funPropDecl : FunPropDecl) (e : Expr)
 /--
 Try to prove `e` using the *constant lambda theorem*.
 
-For example, `e = q(Continuous fun x => y)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
+For example, `e = q(Continuous fun x ↦ y)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
 def applyConstRule (funPropDecl : FunPropDecl) (e : Expr)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
@@ -209,7 +209,7 @@ def applyConstRule (funPropDecl : FunPropDecl) (e : Expr)
 /--
 Try to prove `e` using the *apply lambda theorem*.
 
-For example, `e = q(Continuous fun f => f x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
+For example, `e = q(Continuous fun f ↦ f x)` and `funPropDecl` is `FunPropDecl` for `Continuous`.
 -/
 def applyApplyRule (funPropDecl : FunPropDecl) (e : Expr)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
@@ -223,7 +223,7 @@ def applyApplyRule (funPropDecl : FunPropDecl) (e : Expr)
 /--
 Try to prove `e` using *composition lambda theorem*.
 
-For example, `e = q(Continuous fun x => f (g x))` and `funPropDecl` is `FunPropDecl` for
+For example, `e = q(Continuous fun x ↦ f (g x))` and `funPropDecl` is `FunPropDecl` for
 `Continuous`
 
 You also have to provide the functions `f` and `g`. -/
@@ -247,7 +247,7 @@ def applyCompRule (funPropDecl : FunPropDecl) (e f g : Expr)
 /--
 Try to prove `e` using *pi lambda theorem*.
 
-For example, `e = q(Continuous fun x y => f x y)` and `funPropDecl` is `FunPropDecl` for
+For example, `e = q(Continuous fun x y ↦ f x y)` and `funPropDecl` is `FunPropDecl` for
 `Continuous`
 -/
 def applyPiRule (funPropDecl : FunPropDecl) (e : Expr)
@@ -268,12 +268,12 @@ def applyPiRule (funPropDecl : FunPropDecl) (e : Expr)
 
 
 /--
-Try to prove `e = q(P (fun x => let y := φ x; ψ x y)`.
+Try to prove `e = q(P (fun x ↦ let y := φ x; ψ x y)`.
 
 For example,
   - `funPropDecl` is `FunPropDecl` for `Continuous`
-  - `e = q(Continuous fun x => let y := φ x; ψ x y)`
-  - `f = q(fun x => let y := φ x; ψ x y)`
+  - `e = q(Continuous fun x ↦ let y := φ x; ψ x y)`
+  - `f = q(fun x ↦ let y := φ x; ψ x y)`
 -/
 def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
     (funProp : Expr → FunPropM (Option Result)) :
@@ -284,7 +284,7 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
     let yValue := yValue.consumeMData
     let yBody  := yBody.consumeMData
     -- We perform reduction because the type is quite often of the form
-    -- `(fun x => Y) #0` which is just `Y`
+    -- `(fun x ↦ Y) #0` which is just `Y`
     -- Usually this is caused by the usage of `FunLike`
     let yType := yType.headBeta
     if (yType.hasLooseBVar 0) then
@@ -313,7 +313,7 @@ def letCase (funPropDecl : FunPropDecl) (e : Expr) (f : Expr)
       let f := Expr.lam xName xType (yBody.lowerLooseBVars 1 1) xBi
       funProp (e.setArg (funPropDecl.funArgId) f)
 
-  | _ => throwError "expected expression of the form `fun x => lam y := ..; ..`"
+  | _ => throwError "expected expression of the form `fun x ↦ lam y := ..; ..`"
 
 
 /-- Prove function property of using *morphism theorems*. -/
@@ -359,13 +359,13 @@ def applyTransitionRules (e : Expr) (funProp : Expr → FunPropM (Option Result)
   trace[Debug.Meta.Tactic.fun_prop] "no theorem matched"
   return none
 
-/-- Try to remove applied argument i.e. prove `P (fun x => f x y)` from `P (fun x => f x)`.
+/-- Try to remove applied argument i.e. prove `P (fun x ↦ f x y)` from `P (fun x ↦ f x)`.
 
 For example
   - `funPropDecl` is `FunPropDecl` for `Continuous`
-  - `e = q(Continuous fun x => foo (bar x) y)`
-  - `fData` contains info on `fun x => foo (bar x) y`
-  This tries to prove `Continuous fun x => foo (bar x) y` from `Continuous fun x => foo (bar x)`
+  - `e = q(Continuous fun x ↦ foo (bar x) y)`
+  - `fData` contains info on `fun x ↦ foo (bar x) y`
+  This tries to prove `Continuous fun x ↦ foo (bar x) y` from `Continuous fun x ↦ foo (bar x)`
 -/
 def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) :
@@ -384,7 +384,7 @@ def removeArgRule (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       applyCompRule funPropDecl e f g funProp
 
 
-/-- Prove function property of `fun f => f x₁ ... xₙ`. -/
+/-- Prove function property of `fun f ↦ f x₁ ... xₙ`. -/
 def bvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
 
@@ -524,7 +524,7 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       -- todo: decompose if uncurried and arguments do not match exactly
   return none
 
-/-- Prove function property of `fun x => f x₁ ... xₙ` where `f` is free variable. -/
+/-- Prove function property of `fun x ↦ f x₁ ... xₙ` where `f` is free variable. -/
 def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
 
@@ -560,7 +560,7 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     return none
 
 
-/-- Prove function property of `fun x => f x₁ ... xₙ` where `f` is declared function. -/
+/-- Prove function property of `fun x ↦ f x₁ ... xₙ` where `f` is declared function. -/
 def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
 

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -111,7 +111,7 @@ def getFunProp? (e : Expr) : MetaM (Option (FunPropDecl × Expr)) := do
 /-- Is `e` a function property statement? -/
 def isFunProp (e : Expr) : MetaM Bool := do return (← getFunProp? e).isSome
 
-/-- Is `e` a `fun_prop` goal? For example `∀ y z, Continuous fun x => f x y z` -/
+/-- Is `e` a `fun_prop` goal? For example `∀ y z, Continuous fun x ↦ f x y z` -/
 def isFunPropGoal (e : Expr) : MetaM Bool := do
   forallTelescope e fun _ b =>
   return (← getFunProp? b).isSome

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -45,7 +45,11 @@ example : Continuous (fun x : ℝ ↦ x * sin x) := by fun_prop
 
 ```lean
 -- Specify a discharger to solve `ContinuousAt`/`Within`/`On` goals:
-example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ ↦ 1/x) y := by fun_prop (disch := assumption)
+example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ ↦ 1/x) y := by
+  fun_prop (disch := assumption)
+
+example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x => x * (Real.log x) ^ 2 - Real.exp x / x) y := by
+  fun_prop (disch := aesop)
 ```
 
 -/

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -23,7 +23,32 @@ open Lean.Parser.Tactic
 /-- `fun_prop` config elaborator -/
 declare_config_elab elabFunPropConfig FunProp.Config
 
-/-- Tactic to prove function properties -/
+/-- `fun_prop` solves a goal of the form `P f`, where `P` is a predicate and `f` is a function,
+by decomposing `f` into a composition of elementary functions, and proving `P` on each of those
+by matching against a set of `@[fun_prop]` lemmas.
+
+If `fun_prop` fails to solve a goal with the error "No theorems found", you can solve this issue
+by importing or adding new theorems tagged with the `@[fun_prop]` attribute. See the module
+documentation for `Mathlib/Tactic/FunProp.lean` for a detailed explanation.
+
+* `fun_prop (disch := tac)` uses `tac` to solve potential side goals. Setting this option is
+  required to solve `ContinuousAt/On/Within` goals.
+* `fun_prop [c, ...]` will unfold the constant(s) `c`, ... before decomposing `f`.
+* `fun_prop (config := cfg)` sets advanced configuration options using `cfg : FunProp.Config`
+  (see `FunProp.Config` for details).
+
+Examples:
+
+```lean
+example : Continuous (fun x : ℝ => x * sin x) := by fun_prop
+```
+
+```lean
+-- Specify a discharger to solve `ContinuousAt`/`Within`/`On` goals:
+example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ => 1/x) y := by fun_prop (disch:=assumption)
+```
+
+-/
 syntax (name := funPropTacStx)
   "fun_prop" optConfig (discharger)? (" [" withoutPosition(ident,*,?) "]")? : tactic
 

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -40,12 +40,12 @@ documentation for `Mathlib/Tactic/FunProp.lean` for a detailed explanation.
 Examples:
 
 ```lean
-example : Continuous (fun x : ℝ => x * sin x) := by fun_prop
+example : Continuous (fun x : ℝ ↦ x * sin x) := by fun_prop
 ```
 
 ```lean
 -- Specify a discharger to solve `ContinuousAt`/`Within`/`On` goals:
-example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ => 1/x) y := by fun_prop (disch:=assumption)
+example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x : ℝ ↦ 1/x) y := by fun_prop (disch := assumption)
 ```
 
 -/

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -14,7 +14,7 @@ public meta import Std.Do
 /-!
 ## `funProp` data structure holding information about a function
 
-`FunctionData` holds data about function in the form `fun x => f x₁ ... xₙ`.
+`FunctionData` holds data about function in the form `fun x ↦ f x₁ ... xₙ`.
 -/
 
 public meta section
@@ -106,7 +106,7 @@ def getFunctionData (f : Expr) : MetaM FunctionData := do
       }
 
 /-- Result of `getFunctionData?`. It returns function data if the function is in the form
-`fun x => f y₁ ... yₙ`. Two other cases are `fun x => let y := ...` or `fun x y => ...` -/
+`fun x ↦ f y₁ ... yₙ`. Two other cases are `fun x ↦ let y := ...` or `fun x y ↦ ...` -/
 inductive MaybeFunctionData where
   /-- Can't generate function data as function body has let binder. -/
   | letE (f : Expr)
@@ -186,12 +186,12 @@ def FunctionData.isMorApplication (f : FunctionData) : MetaM MorApplication := d
       return .none
 
 
-/-- Decomposes `fun x => f y₁ ... yₙ` into `(fun g => g yₙ) ∘ (fun x y => f y₁ ... yₙ₋₁ y)`
+/-- Decomposes `fun x ↦ f y₁ ... yₙ` into `(fun g ↦ g yₙ) ∘ (fun x y ↦ f y₁ ... yₙ₋₁ y)`
 
 Returns none if:
   - `n=0`
   - `yₙ` contains `x`
-  - `n=1` and `(fun x y => f y)` is identity function i.e. `x=f` -/
+  - `n=1` and `(fun x y ↦ f y)` is identity function i.e. `x=f` -/
 def FunctionData.peeloffArgDecomposition (fData : FunctionData) : MetaM (Option (Expr × Expr)) := do
   unless fData.args.size > 0 do return none
   withLCtx fData.lctx fData.insts do
@@ -263,11 +263,11 @@ def FunctionData.nontrivialDecomposition (fData : FunctionData) : MetaM (Option 
     return (f, g)
 
 
-/-- Decompose function `fun x => f y₁ ... yₙ` over specified argument indices `#[i, j, ...]`.
+/-- Decompose function `fun x ↦ f y₁ ... yₙ` over specified argument indices `#[i, j, ...]`.
 
 The result is:
 ```
-(fun (yᵢ',yⱼ',...) => f y₁ .. yᵢ' .. yⱼ' .. yₙ) ∘ (fun x => (yᵢ, yⱼ, ...))
+(fun (yᵢ',yⱼ',...) ↦ f y₁ .. yᵢ' .. yⱼ' .. yₙ) ∘ (fun x ↦ (yᵢ, yⱼ, ...))
 ```
 
 This is not possible if `yₗ` for `l ∉ #[i,j,...]` still contains `x`.

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -29,32 +29,32 @@ namespace Meta.FunProp
 /-- Tag for one of the 5 basic lambda theorems, that also hold extra data for composition theorem
 -/
 inductive LambdaTheoremArgs
-  /-- Identity theorem e.g. `Continuous fun x => x` -/
+  /-- Identity theorem e.g. `Continuous fun x ↦ x` -/
   | id
-  /-- Constant theorem e.g. `Continuous fun x => y` -/
+  /-- Constant theorem e.g. `Continuous fun x ↦ y` -/
   | const
-  /-- Apply theorem e.g. `Continuous fun (f : (x : X) → Y x => f x)` -/
+  /-- Apply theorem e.g. `Continuous fun (f : (x : X) → Y x ↦ f x)` -/
   | apply
-  /-- Composition theorem e.g. `Continuous f → Continuous g → Continuous fun x => f (g x)`
+  /-- Composition theorem e.g. `Continuous f → Continuous g → Continuous fun x ↦ f (g x)`
 
   The numbers `fArgId` and `gArgId` store the argument index for `f` and `g` in the composition
   theorem. -/
   | comp (fArgId gArgId : Nat)
-  /-- Pi theorem e.g. `∀ y, Continuous (f · y) → Continuous fun x y => f x y` -/
+  /-- Pi theorem e.g. `∀ y, Continuous (f · y) → Continuous fun x y ↦ f x y` -/
   | pi
   deriving Inhabited, BEq, Repr, Hashable
 
 /-- Tag for one of the 5 basic lambda theorems -/
 inductive LambdaTheoremType
-  /-- Identity theorem e.g. `Continuous fun x => x` -/
+  /-- Identity theorem e.g. `Continuous fun x ↦ x` -/
   | id
-  /-- Constant theorem e.g. `Continuous fun x => y` -/
+  /-- Constant theorem e.g. `Continuous fun x ↦ y` -/
   | const
-  /-- Apply theorem e.g. `Continuous fun (f : (x : X) → Y x => f x)` -/
+  /-- Apply theorem e.g. `Continuous fun (f : (x : X) → Y x ↦ f x)` -/
   | apply
-  /-- Composition theorem e.g. `Continuous f → Continuous g → Continuous fun x => f (g x)` -/
+  /-- Composition theorem e.g. `Continuous f → Continuous g → Continuous fun x ↦ f (g x)` -/
   | comp
-  /-- Pi theorem e.g. `∀ y, Continuous (f · y) → Continuous fun x y => f x y` -/
+  /-- Pi theorem e.g. `∀ y, Continuous (f · y) → Continuous fun x y ↦ f x y` -/
   | pi
   deriving Inhabited, BEq, Repr, Hashable
 
@@ -139,12 +139,12 @@ def getLambdaTheorems (funPropName : Name) (type : LambdaTheoremType) :
 
 uncurried
 ```
-theorem Continuous_add : Continuous (fun x => x.1 + x.2)
+theorem Continuous_add : Continuous (fun x ↦ x.1 + x.2)
 ```
 
 compositional
 ```
-theorem Continuous_add (hf : Continuous f) (hg : Continuous g) : Continuous (fun x => (f x) + (g x))
+theorem Continuous_add (hf : Continuous f) (hg : Continuous g) : Continuous (fun x ↦ (f x) + (g x))
 ```
 -/
 inductive TheoremForm where
@@ -284,20 +284,20 @@ def getMorphismTheorems (e : Expr) : FunPropM (Array GeneralTheorem) := do
 Examples:
 - lam
 ```
-  theorem Continuous_id : Continuous fun x => x
-  theorem Continuous_comp (hf : Continuous f) (hg : Continuous g) : Continuous fun x => f (g x)
+  theorem Continuous_id : Continuous fun x ↦ x
+  theorem Continuous_comp (hf : Continuous f) (hg : Continuous g) : Continuous fun x ↦ f (g x)
 ```
 - function
 ```
-  theorem Continuous_add : Continuous (fun x => x.1 + x.2)
+  theorem Continuous_add : Continuous (fun x ↦ x.1 + x.2)
   theorem Continuous_add (hf : Continuous f) (hg : Continuous g) :
-      Continuous (fun x => (f x) + (g x))
+      Continuous (fun x ↦ (f x) + (g x))
 ```
 - mor - the head of function body has to be `DFunLike.coe`
 ```
   theorem ContDiff.clm_apply {f : E → F →L[𝕜] G} {g : E → F}
       (hf : ContDiff 𝕜 n f) (hg : ContDiff 𝕜 n g) :
-      ContDiff 𝕜 n fun x => (f x) (g x)
+      ContDiff 𝕜 n fun x ↦ (f x) (g x)
   theorem clm_linear {f : E →L[𝕜] F} : IsLinearMap 𝕜 f
 ```
 - transition - the conclusion has to be in the form `P f` where `f` is a free variable


### PR DESCRIPTION
This PR (re)writes the docstring for the `fun_prop` tactic to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long.

Also update docstrings and error messages to match Mathlib style guide: use spaces around `:=` and prefer `↦` over `=>`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
