### PR TITLE
[Merged by Bors] - style: make fun_prop tests match the mathlib style guide better

### DIFF
--- a/MathlibTest/fun_prop.lean
+++ b/MathlibTest/fun_prop.lean
@@ -78,7 +78,7 @@ to see what is going on
 set_option trace.Meta.Tactic.fun_prop true in
 -/
 example {α} [MeasurableSpace α] (f : α → α → α) (hf : Measurable fun (x, y) ↦ f x y) (a : α) :
-    Measurable (fun x => (f x a, f (f x x) (f (f x x) x))) := by
+    Measurable (fun x ↦ (f x a, f (f x x) (f (f x x) x))) := by
   -- This now takes longer than 200,000 heartbeats to fail, so I've commented it out.
   -- fail_if_success measurability
   fun_prop
@@ -163,7 +163,7 @@ measurable.
 -/
 
 example (f : ℝ → ℝ → ℝ) (hf : Continuous fun (x, y) ↦ f x y) (a : ℝ) :
-    Measurable (fun x => (f x a, f (f x x) (f (f x x) x))) := by fun_prop
+    Measurable (fun x ↦ (f x a, f (f x x) (f (f x x) x))) := by fun_prop
 
 
 /-!
@@ -201,7 +201,7 @@ A silly example that everything together works as expected
 -/
 
 example (f : ℝ → ℝ → (ℝ →L[ℝ] ℝ)) (hf : Continuous (fun (x, y) ↦ f x y)) :
-    Measurable fun x => (f (x / x) (x * x) 1 + x) := by fun_prop
+    Measurable fun x ↦ (f (x / x) (x * x) 1 + x) := by fun_prop
 
 set_option linter.style.longLine false in
 /-!

--- a/MathlibTest/fun_prop2.lean
+++ b/MathlibTest/fun_prop2.lean
@@ -17,18 +17,17 @@ example (y : ℝ) (hy : y ≠ 0) : ContinuousAt (fun x => x * (Real.log x) ^ 2 -
 
 
 example : DifferentiableOn ℝ foo {0}ᶜ := by
-  unfold foo; fun_prop (disch:=aesop)
+  fun_prop (disch := aesop) [foo] -- equivalent to `unfold foo; fun_prop (disch := aesop)`
 
-example (y : ℝ) (hy : y ≠ 0) :
-    DifferentiableAt ℝ foo y := by
-  unfold foo; fun_prop (disch:=aesop)
+example (y : ℝ) (hy : y ≠ 0) : DifferentiableAt ℝ foo y := by
+  unfold foo; fun_prop (disch := aesop)
 
 example {n} : ContDiffOn ℝ n foo {0}ᶜ := by
-  unfold foo; fun_prop (disch:=aesop)
+  unfold foo; fun_prop (disch := aesop)
 
 example {n} (y : ℝ) (hy : y ≠ 0) :
     ContDiffAt ℝ n foo y := by
-  unfold foo; fun_prop (disch:=aesop)
+  unfold foo; fun_prop (disch := aesop)
 
 example : Continuous fun ((x, _, _) : ℝ × ℝ × ℝ) ↦ x := by fun_prop
 example : Continuous fun ((_, y, _) : ℝ × ℝ × ℝ) ↦ y := by fun_prop
@@ -40,11 +39,11 @@ example : Continuous fun ((_, _, z) : ℝ × ℝ × ℝ) ↦ z := by fun_prop
 theorem ContinuousOn.log' : ContinuousOn Real.log {0}ᶜ := ContinuousOn.log (by fun_prop) (by aesop)
 
 -- Notice that no theorems about measuability of log are used. It is inferred from continuity.
-example : Measurable (fun x => x * (Real.log x) ^ 2 - Real.exp x / x) := by
+example : Measurable (fun x ↦ x * (Real.log x) ^ 2 - Real.exp x / x) := by
   fun_prop
 
 -- Notice that no theorems about measuability of log are used. It is inferred from continuity.
-example : AEMeasurable (fun x => x * (Real.log x) ^ 2 - Real.exp x / x) := by
+example : AEMeasurable (fun x ↦ x * (Real.log x) ^ 2 - Real.exp x / x) := by
   fun_prop (maxTransitionDepth := 2)
 
 
@@ -57,16 +56,16 @@ private noncomputable def T (t : ℝ) : ℝ := S 1 (1 - t) t (t * (1 - t))
 
 example : ContinuousOn T (Set.Icc 0 1) := by
   unfold T S
-  fun_prop (disch:=(rintro x ⟨a,b⟩; nlinarith))
+  fun_prop (disch := (rintro x ⟨a,b⟩; nlinarith))
 
 
 example : DifferentiableOn ℝ T (Set.Icc 0 1) := by
   unfold T S
-  fun_prop (disch:=(rintro x ⟨a,b⟩; nlinarith))
+  fun_prop (disch := (rintro x ⟨a,b⟩; nlinarith))
 
 example {n}: ContDiffOn ℝ n T (Set.Icc 0 1) := by
   unfold T S
-  fun_prop (disch:=(rintro x ⟨a,b⟩; nlinarith))
+  fun_prop (disch := (rintro x ⟨a,b⟩; nlinarith))
 
 example : Measurable T := by
   unfold T S

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -69,11 +69,11 @@ theorem chabam (f : α → β) (hf : Con f) : Con f := hf
 -- theorems about function in the environment --
 ------------------------------------------------
 @[fun_prop]
-theorem prod_mk_Con (fst : α → β) (snd : α → γ) (hfst : Con fst) (hsnd : Con snd)
-  : Con fun x => (fst x, snd x) := silentSorry
+theorem prod_mk_Con (fst : α → β) (snd : α → γ) (hfst : Con fst) (hsnd : Con snd) :
+    Con fun x => (fst x, snd x) := silentSorry
 @[fun_prop]
-theorem prod_mk_Lin (fst : α → β) (snd : α → γ) (hfst : Lin fst) (hsnd : Lin snd)
-  : Lin fun x => (fst x, snd x) := silentSorry
+theorem prod_mk_Lin (fst : α → β) (snd : α → γ) (hfst : Lin fst) (hsnd : Lin snd) :
+    Lin fun x => (fst x, snd x) := silentSorry
 
 
 
@@ -316,13 +316,12 @@ example (x) : Con fun (f : α ->> α) => f (f (f x)) := by fun_prop
 
 example [Zero α] [Add α] : Lin (fun x : α => (0 : α) + x + (0 : α) + (0 : α) + x) := by fun_prop
 
-noncomputable
-def foo : α ->> α ->> α := silentSorry
-noncomputable
-def bar : α ->> α ->> α := silentSorry
+noncomputable def foo : α ->> α ->> α := silentSorry
+noncomputable def bar : α ->> α ->> α := silentSorry
 
 @[fun_prop]
 theorem foo_lin : Lin fun x : α => foo x := silentSorry
+
 @[fun_prop]
 theorem bar_lin (y) : Lin fun x : α => bar x y := silentSorry
 
@@ -371,7 +370,7 @@ theorem foo2_lin : Lin (foo2 : α → α) := silentSorry
 
 example : Con (fun x : α => foo1 (foo2 x)) := by fun_prop
 
-
+-- Test for unfolding names using the `fun_prop [foo]` syntax.
 def foo3 [Add α] (x : α) := x + x
 example [Add α] : Con (fun x : α => foo3 x) := by fun_prop [foo3]
 
@@ -379,7 +378,8 @@ def myUncurry (f : α → β → γ) : α×β → γ := fun (x,y) => f x y
 def diag (f : α → α → α) (x : α) := f x x
 
 theorem diag_Con (f : α → α → α) (hf : Con (myUncurry f)) : Con (fun x => diag f x) := by
-  fun_prop [diag,myUncurry]
+  fun_prop [diag, myUncurry]
+
 namespace MultipleLambdaTheorems
 
 opaque A : Prop


### PR DESCRIPTION
Also add a very basic test about combining the unfolding and discharging behaviour.

---

Noticed while reviewing #33998.
The general test set-up for these files is a bit non-standard; changing this is left to a future PR.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
