### PR TITLE
[Merged by Bors] - ci: detect and kill stray runLinter processes before linting

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -499,6 +499,7 @@ jobs:
       - name: kill stray runLinter processes
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         continue-on-error: true
+        shell: bash
         run: |
           echo "Checking for runLinter processes..."
           if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
@@ -559,6 +560,7 @@ jobs:
           fi
 
       - name: list stray runLinter processes
+        shell: bash
         if: always()
         run: |
           echo "Checking for runLinter processes..."

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -501,7 +501,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | rg runLinter; then
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else
@@ -562,7 +562,7 @@ jobs:
         if: always()
         run: |
           echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | rg runLinter; then
+          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "No stray runLinter processes found."
           fi
 

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -496,6 +496,18 @@ jobs:
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
 
+      - name: kill stray runLinter processes
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | rg runLinter; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
+
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -544,6 +556,14 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
+          fi
+
+      - name: list stray runLinter processes
+        if: always()
+        run: |
+          echo "Checking for runLinter processes..."
+          if ! ps -eo pid,lstart,command | rg runLinter; then
+            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -506,6 +506,18 @@ jobs:
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
 
+      - name: kill stray runLinter processes
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | rg runLinter; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
+
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -554,6 +566,14 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
+          fi
+
+      - name: list stray runLinter processes
+        if: always()
+        run: |
+          echo "Checking for runLinter processes..."
+          if ! ps -eo pid,lstart,command | rg runLinter; then
+            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -511,7 +511,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | rg runLinter; then
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else
@@ -572,7 +572,7 @@ jobs:
         if: always()
         run: |
           echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | rg runLinter; then
+          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "No stray runLinter processes found."
           fi
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -509,6 +509,7 @@ jobs:
       - name: kill stray runLinter processes
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         continue-on-error: true
+        shell: bash
         run: |
           echo "Checking for runLinter processes..."
           if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
@@ -569,6 +570,7 @@ jobs:
           fi
 
       - name: list stray runLinter processes
+        shell: bash
         if: always()
         run: |
           echo "Checking for runLinter processes..."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -515,6 +515,7 @@ jobs:
       - name: kill stray runLinter processes
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         continue-on-error: true
+        shell: bash
         run: |
           echo "Checking for runLinter processes..."
           if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
@@ -575,6 +576,7 @@ jobs:
           fi
 
       - name: list stray runLinter processes
+        shell: bash
         if: always()
         run: |
           echo "Checking for runLinter processes..."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -517,7 +517,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | rg runLinter; then
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else
@@ -578,7 +578,7 @@ jobs:
         if: always()
         run: |
           echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | rg runLinter; then
+          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "No stray runLinter processes found."
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,6 +512,18 @@ jobs:
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
 
+      - name: kill stray runLinter processes
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | rg runLinter; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
+
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -560,6 +572,14 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
+          fi
+
+      - name: list stray runLinter processes
+        if: always()
+        run: |
+          echo "Checking for runLinter processes..."
+          if ! ps -eo pid,lstart,command | rg runLinter; then
+            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -515,7 +515,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | rg runLinter; then
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else
@@ -576,7 +576,7 @@ jobs:
         if: always()
         run: |
           echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | rg runLinter; then
+          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
             echo "No stray runLinter processes found."
           fi
 

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -513,6 +513,7 @@ jobs:
       - name: kill stray runLinter processes
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         continue-on-error: true
+        shell: bash
         run: |
           echo "Checking for runLinter processes..."
           if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
@@ -573,6 +574,7 @@ jobs:
           fi
 
       - name: list stray runLinter processes
+        shell: bash
         if: always()
         run: |
           echo "Checking for runLinter processes..."

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -510,6 +510,18 @@ jobs:
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
 
+      - name: kill stray runLinter processes
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | rg runLinter; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
+
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -558,6 +570,14 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
+          fi
+
+      - name: list stray runLinter processes
+        if: always()
+        run: |
+          echo "Checking for runLinter processes..."
+          if ! ps -eo pid,lstart,command | rg runLinter; then
+            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches


### PR DESCRIPTION
Part of an investigation of hanging 'lint mathlib' steps across workflows. We have noticed stray instances of these processes active in subsequent runs. Let's see if the hangs can be mitigated by killing these before starting the linting step. This would point to some synchronization issue between these stray instances - a bit of a long shot, but worth a try.

Identifying where these strays are coming from might also give some insight. System logs show that sometimes these processes are affected by the Linux OOM killer.