### PR TITLE
[Merged by Bors] - chore: golf with `grind` to reduce explicit lemma references

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -64,8 +64,7 @@ is equal to a multiplication on the left by `x * y`.
 @[to_additive (attr := simp) /-- Composing two additions on the left by `y` then `x`
 is equal to an addition on the left by `x + y`. -/]
 theorem comp_mul_left (x y : α) : (x * ·) ∘ (y * ·) = (x * y * ·) := by
-  ext z
-  simp [mul_assoc]
+  grind
 
 /-- Composing two multiplications on the right by `y` and `x`
 is equal to a multiplication on the right by `y * x`.
@@ -73,8 +72,7 @@ is equal to a multiplication on the right by `y * x`.
 @[to_additive (attr := simp) /-- Composing two additions on the right by `y` and `x`
 is equal to an addition on the right by `y + x`. -/]
 theorem comp_mul_right (x y : α) : (· * x) ∘ (· * y) = (· * (y * x)) := by
-  ext z
-  simp [mul_assoc]
+  grind
 
 end Semigroup
 
@@ -117,15 +115,15 @@ variable [CommSemigroup G]
 
 @[to_additive]
 theorem mul_left_comm (a b c : G) : a * (b * c) = b * (a * c) := by
-  rw [← mul_assoc, mul_comm a, mul_assoc]
+  grind
 
 @[to_additive]
 theorem mul_right_comm (a b c : G) : a * b * c = a * c * b := by
-  rw [mul_assoc, mul_comm b, mul_assoc]
+  grind
 
 @[to_additive]
 theorem mul_mul_mul_comm (a b c d : G) : a * b * (c * d) = a * c * (b * d) := by
-  simp only [mul_left_comm, mul_assoc]
+  grind
 
 @[to_additive]
 theorem mul_mul_mul_comm' (a b c d : G) : a * b * c * d = a * c * b * d := by
@@ -133,11 +131,11 @@ theorem mul_mul_mul_comm' (a b c d : G) : a * b * c * d = a * c * b * d := by
 
 @[to_additive]
 theorem mul_rotate (a b c : G) : a * b * c = b * c * a := by
-  simp only [mul_left_comm, mul_comm]
+  grind
 
 @[to_additive]
 theorem mul_rotate' (a b c : G) : a * (b * c) = b * (c * a) := by
-  simp only [mul_left_comm, mul_comm]
+  grind
 
 end CommSemigroup
 
@@ -178,7 +176,7 @@ lemma pow_eq_pow_mod (m : ℕ) (ha : a ^ n = 1) : a ^ m = a ^ (m % n) := by
   | n + 1, h =>
     calc
       a ^ n.succ * b ^ n.succ = a ^ n * a * (b * b ^ n) := by rw [pow_succ, pow_succ']
-      _ = a ^ n * (a * b) * b ^ n := by simp only [mul_assoc]
+      _ = a ^ n * (a * b) * b ^ n := by grind
       _ = 1 := by simp [h, pow_mul_pow_eq_one]
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -279,7 +279,7 @@ theorem reverse_bijective : Bijective (@reverse α) :=
   reverse_involutive.bijective
 
 theorem concat_eq_reverse_cons (a : α) (l : List α) : concat l a = reverse (a :: reverse l) := by
-  simp only [concat_eq_append, reverse_cons, reverse_reverse]
+  grind
 
 theorem map_reverseAux (f : α → β) (l₁ l₂ : List α) :
     map f (reverseAux l₁ l₂) = reverseAux (map f l₁) (map f l₂) := by

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -65,12 +65,12 @@ theorem map_snd' (f : α → γ) (g : β → δ) : Prod.snd ∘ map f g = g ∘ 
 theorem mk_inj {a₁ a₂ : α} {b₁ b₂ : β} : (a₁, b₁) = (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ = b₂ := by simp
 
 theorem mk_right_injective {α β : Type*} (a : α) : (mk a : β → α × β).Injective := by
-  intro b₁ b₂ h
-  simpa only [true_and, Prod.mk_inj, eq_self_iff_true] using h
+  intro
+  grind
 
 theorem mk_left_injective {α β : Type*} (b : β) : (fun a ↦ mk a b : α → α × β).Injective := by
-  intro b₁ b₂ h
-  simpa only [and_true, eq_self_iff_true, mk_inj] using h
+  intro
+  grind
 
 lemma mk_right_inj {a : α} {b₁ b₂ : β} : (a, b₁) = (a, b₂) ↔ b₁ = b₂ :=
     (mk_right_injective _).eq_iff

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -291,7 +291,7 @@ theorem notMem_subset (h : s ⊆ t) : a ∉ t → a ∉ s :=
   mt <| mem_of_subset_of_mem h
 
 theorem not_subset : ¬s ⊆ t ↔ ∃ a ∈ s, a ∉ t := by
-  simp only [subset_def, not_forall, exists_prop]
+  grind
 
 theorem not_top_subset : ¬⊤ ⊆ s ↔ ∃ a, a ∉ s := by
   simp [not_subset]
@@ -963,7 +963,7 @@ theorem powerset_univ : 𝒫 (univ : Set α) = univ :=
 
 theorem mem_dite_univ_right (p : Prop) [Decidable p] (t : p → Set α) (x : α) :
     (x ∈ if h : p then t h else univ) ↔ ∀ h : p, x ∈ t h := by
-  simp [mem_dite]
+  grind
 
 @[simp]
 theorem mem_ite_univ_right (p : Prop) [Decidable p] (t : Set α) (x : α) :

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -71,7 +71,7 @@ theorem min_eq_bot {a b : α} : min a b = ⊥ ↔ a = ⊥ ∨ b = ⊥ := by
 
 @[to_dual (attr := aesop (rule_sets := [finiteness]) safe apply)]
 lemma min_ne_bot {a b : α} (ha : a ≠ ⊥) (hb : b ≠ ⊥) : min a b ≠ ⊥ := by
-  grind [max_eq_top]
+  grind
 
 end LinearOrder
 


### PR DESCRIPTION
---
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `comp_mul_left`: <10 ms before, <10 ms after  🎉
* `comp_mul_right`: <10 ms before, <10 ms after  🎉
* `mul_left_comm`: <10 ms before, <10 ms after  🎉
* `mul_right_comm`: <10 ms before, <10 ms after  🎉
* `mul_mul_mul_comm`: <10 ms before, <10 ms after  🎉
* `mul_rotate`: <10 ms before, <10 ms after  🎉
* `mul_rotate'`: <10 ms before, <10 ms after  🎉
* `pow_eq_pow_mod`: <10 ms before, <10 ms after  🎉
* `List.concat_eq_reverse_cons`: <10 ms before, <10 ms after  🎉
* `Prod.mk_right_injective`: <10 ms before, <10 ms after  🎉
* `Prod.mk_left_injective`: <10 ms before, <10 ms after  🎉
* `Set.not_subset`: <10 ms before, <10 ms after  🎉
* `Set.mem_dite_univ_right`: <10 ms before, <10 ms after  🎉
* `forall_existsUnique_iff'`: 13 ms before, 13 ms after  🎉
* `min_ne_bot`: 18 ms before, 13 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
