### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/BilinearForm): sort out namespaces

### DIFF
--- a/Counterexamples/CliffordAlgebraNotInjective.lean
+++ b/Counterexamples/CliffordAlgebraNotInjective.lean
@@ -290,7 +290,7 @@ theorem CliffordAlgebra.not_forall_algebraMap_injective.{v} :
 
 open Q60596 in
 /-- The general bonus statement: not every quadratic form is the diagonal of a bilinear form. -/
-theorem BilinMap.not_forall_toQuadraticMap_surjective.{v} :
+theorem LinearMap.BilinMap.not_forall_toQuadraticMap_surjective.{v} :
     -- TODO: make `R` universe polymorphic
     ¬∀ (R : Type) (M : Type v) [CommRing R] [AddCommGroup M] [Module R M],
       Function.Surjective (BilinMap.toQuadraticMap : BilinForm R M → QuadraticForm R M) :=

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -61,8 +61,10 @@ theorem Matrix.toBilin'Aux_single [Fintype n] [DecidableEq n] (M : Matrix n n R�
 /-- The linear map from bilinear forms to `Matrix n n R` given an `n`-indexed basis.
 
 This is an auxiliary definition for the equivalence `Matrix.toBilin'`. -/
-def BilinForm.toMatrixAux (b : n → M₁) : BilinForm R₁ M₁ →ₗ[R₁] Matrix n n R₁ :=
+def LinearMap.BilinForm.toMatrixAux (b : n → M₁) : BilinForm R₁ M₁ →ₗ[R₁] Matrix n n R₁ :=
   LinearMap.toMatrix₂Aux R₁ b b
+
+@[deprecated (since := "2026-01-16")] alias BilinForm.toMatrixAux := LinearMap.BilinForm.toMatrixAux
 
 @[simp]
 theorem LinearMap.BilinForm.toMatrixAux_apply (B : BilinForm R₁ M₁) (b : n → M₁) (i j : n) :
@@ -71,9 +73,12 @@ theorem LinearMap.BilinForm.toMatrixAux_apply (B : BilinForm R₁ M₁) (b : n �
 
 variable [Fintype n] [Fintype o]
 
-theorem toBilin'Aux_toMatrixAux [DecidableEq n] (B₂ : BilinForm R₁ (n → R₁)) :
+theorem LinearMap.toBilin'Aux_toMatrixAux [DecidableEq n] (B₂ : BilinForm R₁ (n → R₁)) :
     Matrix.toBilin'Aux (BilinForm.toMatrixAux (fun j => Pi.single j 1) B₂) = B₂ := by
   rw [BilinForm.toMatrixAux, Matrix.toBilin'Aux, toLinearMap₂'Aux_toMatrix₂Aux]
+
+@[deprecated (since := "2026-01-16")] alias toBilin'Aux_toMatrixAux :=
+  LinearMap.toBilin'Aux_toMatrixAux
 
 section ToMatrix'
 
@@ -184,26 +189,38 @@ variable [DecidableEq n] (b : Basis n R₁ M₁)
 
 /-- `BilinForm.toMatrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def BilinForm.toMatrix : BilinForm R₁ M₁ ≃ₗ[R₁] Matrix n n R₁ :=
+noncomputable def LinearMap.BilinForm.toMatrix : BilinForm R₁ M₁ ≃ₗ[R₁] Matrix n n R₁ :=
   LinearMap.toMatrix₂ b b
+
+@[deprecated (since := "2026-01-16")] alias BilinForm.toMatrix := LinearMap.BilinForm.toMatrix
 
 /-- `BilinForm.toMatrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
 noncomputable def Matrix.toBilin : Matrix n n R₁ ≃ₗ[R₁] BilinForm R₁ M₁ :=
-  (BilinForm.toMatrix b).symm
+  (LinearMap.BilinForm.toMatrix b).symm
 
 @[simp]
-theorem BilinForm.toMatrix_apply (B : BilinForm R₁ M₁) (i j : n) :
+theorem LinearMap.BilinForm.toMatrix_apply (B : BilinForm R₁ M₁) (i j : n) :
     BilinForm.toMatrix b B i j = B (b i) (b j) :=
   LinearMap.toMatrix₂_apply _ _ B _ _
 
-theorem BilinForm.dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : n → R₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_apply := LinearMap.BilinForm.toMatrix_apply
+
+theorem LinearMap.BilinForm.dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : n → R₁) :
     x ⬝ᵥ (BilinForm.toMatrix b B) *ᵥ y = B (b.equivFun.symm x) (b.equivFun.symm y) :=
   dotProduct_toMatrix₂_mulVec b b B x y
 
-lemma BilinForm.apply_eq_dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : M₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.dotProduct_toMatrix_mulVec := LinearMap.BilinForm.dotProduct_toMatrix_mulVec
+
+lemma LinearMap.BilinForm.apply_eq_dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : M₁) :
     B x y = (b.repr x) ⬝ᵥ (BilinForm.toMatrix b B) *ᵥ (b.repr y) :=
   apply_eq_dotProduct_toMatrix₂_mulVec b b B x y
+
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.apply_eq_dotProduct_toMatrix_mulVec :=
+  LinearMap.BilinForm.apply_eq_dotProduct_toMatrix_mulVec
 
 @[simp]
 theorem Matrix.toBilin_apply (M : Matrix n n R₁) (x y : M₁) :
@@ -212,78 +229,112 @@ theorem Matrix.toBilin_apply (M : Matrix n n R₁) (x y : M₁) :
     (by simp only [smul_eq_mul, mul_comm, mul_left_comm])
 
 -- Not a `simp` lemma since `BilinForm.toMatrix` needs an extra argument
-theorem BilinearForm.toMatrixAux_eq (B : BilinForm R₁ M₁) :
+theorem LinearMap.BilinForm.toMatrixAux_eq (B : BilinForm R₁ M₁) :
     BilinForm.toMatrixAux (R₁ := R₁) b B = BilinForm.toMatrix b B :=
   LinearMap.toMatrix₂Aux_eq _ _ B
 
-@[simp]
-theorem BilinForm.toMatrix_symm : (BilinForm.toMatrix b).symm = Matrix.toBilin b :=
-  rfl
+@[deprecated (since := "2026-01-16")]
+alias BilinearForm.toMatrixAux_eq := LinearMap.BilinForm.toMatrixAux_eq
 
 @[simp]
-theorem Matrix.toBilin_symm : (Matrix.toBilin b).symm = BilinForm.toMatrix b :=
-  (BilinForm.toMatrix b).symm_symm
+theorem LinearMap.BilinForm.toMatrix_symm : (BilinForm.toMatrix b).symm = Matrix.toBilin b :=
+  rfl
+
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_symm := LinearMap.BilinForm.toMatrix_symm
+
+@[simp]
+theorem Matrix.toBilin_symm : (Matrix.toBilin b).symm = LinearMap.BilinForm.toMatrix b :=
+  (LinearMap.BilinForm.toMatrix b).symm_symm
 
 theorem Matrix.toBilin_basisFun : Matrix.toBilin (Pi.basisFun R₁ n) = Matrix.toBilin' := by
   ext M
   simp only [coe_comp, coe_single, Function.comp_apply, toBilin_apply, Pi.basisFun_repr,
     toBilin'_apply]
 
-theorem BilinForm.toMatrix_basisFun :
+theorem LinearMap.BilinForm.toMatrix_basisFun :
     BilinForm.toMatrix (Pi.basisFun R₁ n) = BilinForm.toMatrix' := by
   rw [BilinForm.toMatrix, BilinForm.toMatrix', LinearMap.toMatrix₂_basisFun]
 
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_basisFun := LinearMap.BilinForm.toMatrix_basisFun
+
 @[simp]
 theorem Matrix.toBilin_toMatrix (B : BilinForm R₁ M₁) :
-    Matrix.toBilin b (BilinForm.toMatrix b B) = B :=
+    Matrix.toBilin b (B.toMatrix b) = B :=
   (Matrix.toBilin b).apply_symm_apply B
 
 @[simp]
-theorem BilinForm.toMatrix_toBilin (M : Matrix n n R₁) :
+theorem LinearMap.BilinForm.toMatrix_toBilin (M : Matrix n n R₁) :
     BilinForm.toMatrix b (Matrix.toBilin b M) = M :=
   (BilinForm.toMatrix b).apply_symm_apply M
+
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_toBilin := LinearMap.BilinForm.toMatrix_toBilin
 
 variable {M₂' : Type*} [AddCommMonoid M₂'] [Module R₁ M₂']
 variable (c : Basis o R₁ M₂')
 variable [DecidableEq o]
 
 -- Cannot be a `simp` lemma because `b` must be inferred.
-theorem BilinForm.toMatrix_comp (B : BilinForm R₁ M₁) (l r : M₂' →ₗ[R₁] M₁) :
+theorem LinearMap.BilinForm.toMatrix_comp (B : BilinForm R₁ M₁) (l r : M₂' →ₗ[R₁] M₁) :
     BilinForm.toMatrix c (B.comp l r) =
       (LinearMap.toMatrix c b l)ᵀ * BilinForm.toMatrix b B * LinearMap.toMatrix c b r :=
   LinearMap.toMatrix₂_compl₁₂ _ _ _ _ B _ _
 
-theorem BilinForm.toMatrix_compLeft (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_comp := LinearMap.BilinForm.toMatrix_comp
+
+theorem LinearMap.BilinForm.toMatrix_compLeft (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
     BilinForm.toMatrix b (B.compLeft f) = (LinearMap.toMatrix b b f)ᵀ * BilinForm.toMatrix b B :=
   LinearMap.toMatrix₂_comp _ _ _ B _
 
-theorem BilinForm.toMatrix_compRight (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_compLeft := LinearMap.BilinForm.toMatrix_compLeft
+
+theorem LinearMap.BilinForm.toMatrix_compRight (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
     BilinForm.toMatrix b (B.compRight f) = BilinForm.toMatrix b B * LinearMap.toMatrix b b f :=
   LinearMap.toMatrix₂_compl₂ _ _ _ B _
 
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_compRight := LinearMap.BilinForm.toMatrix_compRight
+
 @[simp]
-theorem BilinForm.toMatrix_mul_basis_toMatrix (c : Basis o R₁ M₁) (B : BilinForm R₁ M₁) :
+theorem LinearMap.BilinForm.toMatrix_mul_basis_toMatrix (c : Basis o R₁ M₁) (B : BilinForm R₁ M₁) :
     (b.toMatrix c)ᵀ * BilinForm.toMatrix b B * b.toMatrix c = BilinForm.toMatrix c B :=
   LinearMap.toMatrix₂_mul_basis_toMatrix _ _ _ _ B
 
-theorem BilinForm.mul_toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix o n R₁) (N : Matrix n o R₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_mul_basis_toMatrix := LinearMap.BilinForm.toMatrix_mul_basis_toMatrix
+
+theorem LinearMap.BilinForm.mul_toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix o n R₁)
+    (N : Matrix n o R₁) :
     M * BilinForm.toMatrix b B * N =
       BilinForm.toMatrix c (B.comp (Matrix.toLin c b Mᵀ) (Matrix.toLin c b N)) :=
   LinearMap.mul_toMatrix₂_mul _ _ _ _ B _ _
 
-theorem BilinForm.mul_toMatrix (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.mul_toMatrix_mul := LinearMap.BilinForm.mul_toMatrix_mul
+
+theorem LinearMap.BilinForm.mul_toMatrix (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
     M * BilinForm.toMatrix b B = BilinForm.toMatrix b (B.compLeft (Matrix.toLin b b Mᵀ)) :=
   LinearMap.mul_toMatrix₂ _ _ _ B _
 
-theorem BilinForm.toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.mul_toMatrix := LinearMap.BilinForm.mul_toMatrix
+
+theorem LinearMap.BilinForm.toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
     BilinForm.toMatrix b B * M = BilinForm.toMatrix b (B.compRight (Matrix.toLin b b M)) :=
   LinearMap.toMatrix₂_mul _ _ _ B _
+
+@[deprecated (since := "2026-01-16")]
+alias BilinForm.toMatrix_mul := LinearMap.BilinForm.toMatrix_mul
 
 theorem Matrix.toBilin_comp (M : Matrix n n R₁) (P Q : Matrix n o R₁) :
     (Matrix.toBilin b M).comp (toLin c b P) (toLin c b Q) = Matrix.toBilin c (Pᵀ * M * Q) := by
   ext x y
-  rw [Matrix.toBilin, BilinForm.toMatrix, Matrix.toBilin, BilinForm.toMatrix, toMatrix₂_symm,
-    toMatrix₂_symm, ← Matrix.toLinearMap₂_compl₁₂ b b c c]
+  rw [Matrix.toBilin, LinearMap.BilinForm.toMatrix, Matrix.toBilin, LinearMap.BilinForm.toMatrix,
+    toMatrix₂_symm, toMatrix₂_symm, ← Matrix.toLinearMap₂_compl₁₂ b b c c]
   simp
 
 end ToMatrix

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -71,7 +71,7 @@ lemma cartanMatrixIn_mul_diagonal_eq {P : RootPairing ι R M N} [P.IsRootSystem]
     (B : P.InvariantForm) (b : P.Base) [DecidableEq ι] :
     (b.cartanMatrixIn S).map (algebraMap S R) *
       (Matrix.diagonal fun i : b.support ↦ B.form (P.root i) (P.root i)) =
-      (2 : R) • BilinForm.toMatrix b.toWeightBasis B.form := by
+      (2 : R) • B.form.toMatrix b.toWeightBasis := by
   ext
   simp [B.two_mul_apply_root_root]
 
@@ -82,7 +82,7 @@ lemma cartanMatrixIn_nondegenerate [IsDomain R] [NeZero (2 : R)] [FaithfulSMul S
   classical
   obtain ⟨B, hB⟩ : ∃ B : P.InvariantForm, B.form.Nondegenerate :=
     ⟨P.toInvariantForm, P.rootForm_nondegenerate⟩
-  replace hB : ((2 : R) • BilinForm.toMatrix b.toWeightBasis B.form).Nondegenerate := by
+  replace hB : ((2 : R) • B.form.toMatrix b.toWeightBasis).Nondegenerate := by
     rwa [Matrix.Nondegenerate.smul_iff two_ne_zero, LinearMap.BilinForm.nondegenerate_toMatrix_iff]
   have aux : (Matrix.diagonal fun i : b.support ↦ B.form (P.root i) (P.root i)).Nondegenerate := by
     rw [Matrix.nondegenerate_iff_det_ne_zero, Matrix.det_diagonal, Finset.prod_ne_zero_iff]

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -65,7 +65,7 @@ open Matrix
 open scoped Matrix
 
 theorem Algebra.traceForm_toMatrix_powerBasis (h : PowerBasis R S) :
-    BilinForm.toMatrix h.basis (traceForm R S) = of fun i j => trace R S (h.gen ^ (i.1 + j.1)) := by
+    (traceForm R S).toMatrix h.basis = of fun i j => trace R S (h.gen ^ (i.1 + j.1)) := by
   ext; rw [traceForm_toMatrix, of_apply, pow_add, h.basis_eq_pow, h.basis_eq_pow]
 
 section EqSumRoots
@@ -377,7 +377,7 @@ theorem traceMatrix_of_matrix_mulVec [Fintype κ] (b : κ → B) (P : Matrix κ 
     traceMatrix_of_matrix_vecMul, transpose_transpose]
 
 theorem traceMatrix_of_basis [Fintype κ] [DecidableEq κ] (b : Basis κ A B) :
-    traceMatrix A b = BilinForm.toMatrix b (traceForm A B) := by
+    traceMatrix A b = (traceForm A B).toMatrix b := by
   ext (i j)
   rw [traceMatrix_apply, traceForm_apply, traceForm_toMatrix]
 
@@ -475,10 +475,10 @@ theorem det_traceMatrix_ne_zero' [Algebra.IsSeparable K L] : det (traceMatrix K 
 
 theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [Fintype ι] [DecidableEq ι]
     (b : Basis ι K L) :
-    det (BilinForm.toMatrix b (traceForm K L)) ≠ 0 := by
+    det ((traceForm K L).toMatrix b) ≠ 0 := by
   haveI : FiniteDimensional K L := b.finiteDimensional_of_finite
   let pb : PowerBasis K L := Field.powerBasisOfFiniteOfSeparable _ _
-  rw [← BilinForm.toMatrix_mul_basis_toMatrix pb.basis b, ←
+  rw [← LinearMap.BilinForm.toMatrix_mul_basis_toMatrix pb.basis b, ←
     det_comm' (pb.basis.toMatrix_mul_toMatrix_flip b) _, ← Matrix.mul_assoc, det_mul]
   swap; · apply Basis.toMatrix_mul_toMatrix_flip
   refine

--- a/Mathlib/RingTheory/Trace/Defs.lean
+++ b/Mathlib/RingTheory/Trace/Defs.lean
@@ -163,7 +163,7 @@ theorem trace_prod [Module.Free R S] [Module.Free R T] [Module.Finite R S] [Modu
 section TraceForm
 
 variable (R S)
-
+open LinearMap
 /-- The `traceForm` maps `x y : S` to the trace of `x * y`.
 It is a symmetric bilinear form and is nondegenerate if the extension is separable. -/
 @[stacks 0BIK "Trace pairing"]
@@ -181,8 +181,8 @@ theorem traceForm_isSymm : (traceForm R S).IsSymm :=
   ⟨fun _ _ => congr_arg (trace R S) (mul_comm _ _)⟩
 
 theorem traceForm_toMatrix [DecidableEq ι] (b : Basis ι R S) (i j) :
-    BilinForm.toMatrix b (traceForm R S) i j = trace R S (b i * b j) := by
-  rw [BilinForm.toMatrix_apply, traceForm_apply]
+    (traceForm R S).toMatrix b i j = trace R S (b i * b j) := by
+  rw [LinearMap.BilinForm.toMatrix_apply, traceForm_apply]
 
 end TraceForm
 


### PR DESCRIPTION
About 90% of the defs and theorems about bilinear forms are in the `LinearMap.BilinForm` namespace, but there are a dozen or so which are in `BilinForm` or `BilinearForm`. This PR imposes a consistent naming scheme.

This is a preliminary to refactoring `LinearAlgebra.BilinForm.Nondegenerate` as discussed in [this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Nondegenerate.20bilinear.20.2F.20quadratic.20forms/with/568588749).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
