### PR TITLE
[Merged by Bors] - ci: Retry logic for linting step

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -519,40 +519,40 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              status=$?
-              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
-                echo ""
-                echo "=============================================================================="
-                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-                echo "updated linter, then push again."
-                echo ""
-                echo "You can do this with:"
-                echo "  git fetch upstream"
-                echo "  git merge upstream/master"
-                echo "  git push"
-                echo "=============================================================================="
-                echo ""
-                exit 1
-              fi
-              if [ "$status" -eq 124 ]; then
-                echo "runLinter timed out (attempt $attempt)."
-                if [ "$attempt" -lt 2 ]; then
-                  echo "Checking for runLinter processes..."
-                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                    echo "Killing runLinter processes..."
-                    pkill -f runLinter || true
-                  else
-                    echo "No stray runLinter processes found."
-                  fi
-                  echo "Retrying runLinter after timeout..."
-                  continue
-                fi
-              fi
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              break
+            fi
+            status=$?
+            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
               exit 1
             fi
-            break
+            if [ "$status" -eq 124 ]; then
+              echo "runLinter timed out (attempt $attempt)."
+              if [ "$attempt" -lt 2 ]; then
+                echo "Checking for runLinter processes..."
+                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                  echo "Killing runLinter processes..."
+                  pkill -f runLinter || true
+                else
+                  echo "No stray runLinter processes found."
+                fi
+                echo "Retrying runLinter after timeout..."
+                continue
+              fi
+            fi
+            exit $status
           done
 
       - name: end gh-problem-match-wrap for shake and lint steps

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -512,7 +512,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 60
+        timeout-minutes: 40
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -512,28 +512,48 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd pr-branch
+          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
-            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
-              echo ""
-              echo "=============================================================================="
-              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-              echo "updated linter, then push again."
-              echo ""
-              echo "You can do this with:"
-              echo "  git fetch upstream"
-              echo "  git merge upstream/master"
-              echo "  git push"
-              echo "=============================================================================="
-              echo ""
+          for attempt in 1 2; do
+            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              status=$?
+              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+                echo ""
+                echo "=============================================================================="
+                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+                echo "updated linter, then push again."
+                echo ""
+                echo "You can do this with:"
+                echo "  git fetch upstream"
+                echo "  git merge upstream/master"
+                echo "  git push"
+                echo "=============================================================================="
+                echo ""
+                exit 1
+              fi
+              if [ "$status" -eq 124 ]; then
+                echo "runLinter timed out (attempt $attempt)."
+                if [ "$attempt" -lt 2 ]; then
+                  echo "Checking for runLinter processes..."
+                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                    echo "Killing runLinter processes..."
+                    pkill -f runLinter || true
+                  else
+                    echo "No stray runLinter processes found."
+                  fi
+                  echo "Retrying runLinter after timeout..."
+                  continue
+                fi
+              fi
+              exit 1
             fi
-            exit 1
-          fi
+            break
+          done
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -522,28 +522,48 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd pr-branch
+          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
-            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
-              echo ""
-              echo "=============================================================================="
-              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-              echo "updated linter, then push again."
-              echo ""
-              echo "You can do this with:"
-              echo "  git fetch upstream"
-              echo "  git merge upstream/master"
-              echo "  git push"
-              echo "=============================================================================="
-              echo ""
+          for attempt in 1 2; do
+            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              status=$?
+              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+                echo ""
+                echo "=============================================================================="
+                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+                echo "updated linter, then push again."
+                echo ""
+                echo "You can do this with:"
+                echo "  git fetch upstream"
+                echo "  git merge upstream/master"
+                echo "  git push"
+                echo "=============================================================================="
+                echo ""
+                exit 1
+              fi
+              if [ "$status" -eq 124 ]; then
+                echo "runLinter timed out (attempt $attempt)."
+                if [ "$attempt" -lt 2 ]; then
+                  echo "Checking for runLinter processes..."
+                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                    echo "Killing runLinter processes..."
+                    pkill -f runLinter || true
+                  else
+                    echo "No stray runLinter processes found."
+                  fi
+                  echo "Retrying runLinter after timeout..."
+                  continue
+                fi
+              fi
+              exit 1
             fi
-            exit 1
-          fi
+            break
+          done
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -529,40 +529,40 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              status=$?
-              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
-                echo ""
-                echo "=============================================================================="
-                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-                echo "updated linter, then push again."
-                echo ""
-                echo "You can do this with:"
-                echo "  git fetch upstream"
-                echo "  git merge upstream/master"
-                echo "  git push"
-                echo "=============================================================================="
-                echo ""
-                exit 1
-              fi
-              if [ "$status" -eq 124 ]; then
-                echo "runLinter timed out (attempt $attempt)."
-                if [ "$attempt" -lt 2 ]; then
-                  echo "Checking for runLinter processes..."
-                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                    echo "Killing runLinter processes..."
-                    pkill -f runLinter || true
-                  else
-                    echo "No stray runLinter processes found."
-                  fi
-                  echo "Retrying runLinter after timeout..."
-                  continue
-                fi
-              fi
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              break
+            fi
+            status=$?
+            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
               exit 1
             fi
-            break
+            if [ "$status" -eq 124 ]; then
+              echo "runLinter timed out (attempt $attempt)."
+              if [ "$attempt" -lt 2 ]; then
+                echo "Checking for runLinter processes..."
+                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                  echo "Killing runLinter processes..."
+                  pkill -f runLinter || true
+                else
+                  echo "No stray runLinter processes found."
+                fi
+                echo "Retrying runLinter after timeout..."
+                continue
+              fi
+            fi
+            exit $status
           done
 
       - name: end gh-problem-match-wrap for shake and lint steps

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -522,7 +522,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 60
+        timeout-minutes: 40
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,40 +535,40 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              status=$?
-              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
-                echo ""
-                echo "=============================================================================="
-                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-                echo "updated linter, then push again."
-                echo ""
-                echo "You can do this with:"
-                echo "  git fetch upstream"
-                echo "  git merge upstream/master"
-                echo "  git push"
-                echo "=============================================================================="
-                echo ""
-                exit 1
-              fi
-              if [ "$status" -eq 124 ]; then
-                echo "runLinter timed out (attempt $attempt)."
-                if [ "$attempt" -lt 2 ]; then
-                  echo "Checking for runLinter processes..."
-                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                    echo "Killing runLinter processes..."
-                    pkill -f runLinter || true
-                  else
-                    echo "No stray runLinter processes found."
-                  fi
-                  echo "Retrying runLinter after timeout..."
-                  continue
-                fi
-              fi
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              break
+            fi
+            status=$?
+            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
               exit 1
             fi
-            break
+            if [ "$status" -eq 124 ]; then
+              echo "runLinter timed out (attempt $attempt)."
+              if [ "$attempt" -lt 2 ]; then
+                echo "Checking for runLinter processes..."
+                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                  echo "Killing runLinter processes..."
+                  pkill -f runLinter || true
+                else
+                  echo "No stray runLinter processes found."
+                fi
+                echo "Retrying runLinter after timeout..."
+                continue
+              fi
+            fi
+            exit $status
           done
 
       - name: end gh-problem-match-wrap for shake and lint steps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,28 +528,48 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd pr-branch
+          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
-            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
-              echo ""
-              echo "=============================================================================="
-              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-              echo "updated linter, then push again."
-              echo ""
-              echo "You can do this with:"
-              echo "  git fetch upstream"
-              echo "  git merge upstream/master"
-              echo "  git push"
-              echo "=============================================================================="
-              echo ""
+          for attempt in 1 2; do
+            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              status=$?
+              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+                echo ""
+                echo "=============================================================================="
+                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+                echo "updated linter, then push again."
+                echo ""
+                echo "You can do this with:"
+                echo "  git fetch upstream"
+                echo "  git merge upstream/master"
+                echo "  git push"
+                echo "=============================================================================="
+                echo ""
+                exit 1
+              fi
+              if [ "$status" -eq 124 ]; then
+                echo "runLinter timed out (attempt $attempt)."
+                if [ "$attempt" -lt 2 ]; then
+                  echo "Checking for runLinter processes..."
+                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                    echo "Killing runLinter processes..."
+                    pkill -f runLinter || true
+                  else
+                    echo "No stray runLinter processes found."
+                  fi
+                  echo "Retrying runLinter after timeout..."
+                  continue
+                fi
+              fi
+              exit 1
             fi
-            exit 1
-          fi
+            break
+          done
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 60
+        timeout-minutes: 40
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -526,7 +526,7 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 60
+        timeout-minutes: 40
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -533,40 +533,40 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              status=$?
-              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
-                echo ""
-                echo "=============================================================================="
-                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-                echo "updated linter, then push again."
-                echo ""
-                echo "You can do this with:"
-                echo "  git fetch upstream"
-                echo "  git merge upstream/master"
-                echo "  git push"
-                echo "=============================================================================="
-                echo ""
-                exit 1
-              fi
-              if [ "$status" -eq 124 ]; then
-                echo "runLinter timed out (attempt $attempt)."
-                if [ "$attempt" -lt 2 ]; then
-                  echo "Checking for runLinter processes..."
-                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                    echo "Killing runLinter processes..."
-                    pkill -f runLinter || true
-                  else
-                    echo "No stray runLinter processes found."
-                  fi
-                  echo "Retrying runLinter after timeout..."
-                  continue
-                fi
-              fi
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              break
+            fi
+            status=$?
+            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+              echo ""
+              echo "=============================================================================="
+              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+              echo "updated linter, then push again."
+              echo ""
+              echo "You can do this with:"
+              echo "  git fetch upstream"
+              echo "  git merge upstream/master"
+              echo "  git push"
+              echo "=============================================================================="
+              echo ""
               exit 1
             fi
-            break
+            if [ "$status" -eq 124 ]; then
+              echo "runLinter timed out (attempt $attempt)."
+              if [ "$attempt" -lt 2 ]; then
+                echo "Checking for runLinter processes..."
+                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                  echo "Killing runLinter processes..."
+                  pkill -f runLinter || true
+                else
+                  echo "No stray runLinter processes found."
+                fi
+                echo "Retrying runLinter after timeout..."
+                continue
+              fi
+            fi
+            exit $status
           done
 
       - name: end gh-problem-match-wrap for shake and lint steps

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -526,28 +526,48 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd pr-branch
+          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
-            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
-              echo ""
-              echo "=============================================================================="
-              echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
-              echo "the --trace flag. Please merge 'master' into your PR branch to get the"
-              echo "updated linter, then push again."
-              echo ""
-              echo "You can do this with:"
-              echo "  git fetch upstream"
-              echo "  git merge upstream/master"
-              echo "  git push"
-              echo "=============================================================================="
-              echo ""
+          for attempt in 1 2; do
+            if ! timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+              status=$?
+              if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+                echo ""
+                echo "=============================================================================="
+                echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
+                echo "the --trace flag. Please merge 'master' into your PR branch to get the"
+                echo "updated linter, then push again."
+                echo ""
+                echo "You can do this with:"
+                echo "  git fetch upstream"
+                echo "  git merge upstream/master"
+                echo "  git push"
+                echo "=============================================================================="
+                echo ""
+                exit 1
+              fi
+              if [ "$status" -eq 124 ]; then
+                echo "runLinter timed out (attempt $attempt)."
+                if [ "$attempt" -lt 2 ]; then
+                  echo "Checking for runLinter processes..."
+                  if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+                    echo "Killing runLinter processes..."
+                    pkill -f runLinter || true
+                  else
+                    echo "No stray runLinter processes found."
+                  fi
+                  echo "Retrying runLinter after timeout..."
+                  continue
+                fi
+              fi
+              exit 1
             fi
-            exit 1
-          fi
+            break
+          done
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23


### PR DESCRIPTION
We should continue our investigation in the separate mirror pipeline and do this to avoid blocking our users: for this, let's make the linting invocation auto-retry after a 20 minute timeout. We still keep a 60min step timeout for good measure, but it shouldn't be necessary.