### PR TITLE
[Merged by Bors] - ci: Fix propagating linting errors

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -519,7 +519,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -513,6 +513,7 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
+        shell: bash
         run: |
           cd pr-branch
           set -o pipefail
@@ -522,7 +523,7 @@ jobs:
             if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
-            status=$?
+            status=${PIPESTATUS[0]}
             if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
               echo ""
               echo "=============================================================================="

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -513,7 +513,6 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
-        shell: bash
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -519,7 +519,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -523,7 +523,6 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
-        shell: bash
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -529,7 +529,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -523,6 +523,7 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
+        shell: bash
         run: |
           cd pr-branch
           set -o pipefail
@@ -532,7 +533,7 @@ jobs:
             if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
-            status=$?
+            status=${PIPESTATUS[0]}
             if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
               echo ""
               echo "=============================================================================="

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -529,7 +529,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,6 +529,7 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
+        shell: bash
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,6 +529,7 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
+        shell: bash
         run: |
           cd pr-branch
           set -o pipefail
@@ -538,7 +539,7 @@ jobs:
             if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
-            status=$?
+            status=${PIPESTATUS[0]}
             if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
               echo ""
               echo "=============================================================================="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,7 +535,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,7 +535,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,7 +529,6 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
-        shell: bash
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -527,7 +527,6 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
-        shell: bash
         run: |
           cd pr-branch
           set -o pipefail

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -533,7 +533,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -533,7 +533,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 1m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -527,6 +527,7 @@ jobs:
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
         timeout-minutes: 40
+        shell: bash
         run: |
           cd pr-branch
           set -o pipefail
@@ -536,7 +537,7 @@ jobs:
             if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
-            status=$?
+            status=${PIPESTATUS[0]}
             if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
               echo ""
               echo "=============================================================================="

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -487,8 +487,8 @@ theorem card_roots_of_discr_ne_zero [DecidableEq K] (ha : P.a ≠ 0) (h3 : (P.to
     (hd : P.discr ≠ 0) : (map φ P).roots.toFinset.card = 3 := by
   rwa [toFinset_card_of_nodup <| (discr_ne_zero_iff_roots_nodup ha h3).mp hd,
     ← splits_iff_card_roots ha]
-
-@[deprecated (since := "2025-10-20")] alias disc := discr
+-- fail deprecatedNoSince
+@[deprecated] alias disc := discr
 @[deprecated (since := "2025-10-20")] alias disc_eq_prod_three_roots := discr_eq_prod_three_roots
 @[deprecated (since := "2025-10-20")] alias disc_ne_zero_iff_roots_ne := discr_ne_zero_iff_roots_ne
 @[deprecated (since := "2025-10-20")] alias disc_ne_zero_iff_roots_nodup :=

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -487,8 +487,8 @@ theorem card_roots_of_discr_ne_zero [DecidableEq K] (ha : P.a ≠ 0) (h3 : (P.to
     (hd : P.discr ≠ 0) : (map φ P).roots.toFinset.card = 3 := by
   rwa [toFinset_card_of_nodup <| (discr_ne_zero_iff_roots_nodup ha h3).mp hd,
     ← splits_iff_card_roots ha]
--- fail deprecatedNoSince
-@[deprecated] alias disc := discr
+
+@[deprecated (since := "2025-10-20")] alias disc := discr
 @[deprecated (since := "2025-10-20")] alias disc_eq_prod_three_roots := discr_eq_prod_three_roots
 @[deprecated (since := "2025-10-20")] alias disc_ne_zero_iff_roots_ne := discr_ne_zero_iff_roots_ne
 @[deprecated (since := "2025-10-20")] alias disc_ne_zero_iff_roots_nodup :=


### PR DESCRIPTION
It seems like as it stands, failures in runLinter are not propagated to $?, which I would expect based on set -o pipefail. Maybe it's a landrun thing. I'm not sure if I introduced it but let's change it to PIPESTATUS[0] which is more reliable.