### PR TITLE
ci: Revert "Retry logic for linting step (#34059)"

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -512,18 +512,13 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 40
+        timeout-minutes: 30
         run: |
           cd pr-branch
-          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              break
-            fi
-            status=$?
-            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
@@ -536,24 +531,9 @@ jobs:
               echo "  git push"
               echo "=============================================================================="
               echo ""
-              exit 1
             fi
-            if [ "$status" -eq 124 ]; then
-              echo "runLinter timed out (attempt $attempt)."
-              if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
-                echo "Retrying runLinter after timeout..."
-                continue
-              fi
-            fi
-            exit $status
-          done
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -522,18 +522,13 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 40
+        timeout-minutes: 30
         run: |
           cd pr-branch
-          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              break
-            fi
-            status=$?
-            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
@@ -546,24 +541,9 @@ jobs:
               echo "  git push"
               echo "=============================================================================="
               echo ""
-              exit 1
             fi
-            if [ "$status" -eq 124 ]; then
-              echo "runLinter timed out (attempt $attempt)."
-              if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
-                echo "Retrying runLinter after timeout..."
-                continue
-              fi
-            fi
-            exit $status
-          done
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,18 +528,13 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 40
+        timeout-minutes: 30
         run: |
           cd pr-branch
-          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              break
-            fi
-            status=$?
-            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
@@ -552,24 +547,9 @@ jobs:
               echo "  git push"
               echo "=============================================================================="
               echo ""
-              exit 1
             fi
-            if [ "$status" -eq 124 ]; then
-              echo "runLinter timed out (attempt $attempt)."
-              if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
-                echo "Retrying runLinter after timeout..."
-                continue
-              fi
-            fi
-            exit $status
-          done
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -526,18 +526,13 @@ jobs:
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
-        timeout-minutes: 40
+        timeout-minutes: 30
         run: |
           cd pr-branch
-          set -o pipefail
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
-          for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
-              break
-            fi
-            status=$?
-            if grep -q "cannot parse arguments" ".lake/lint_output_attempt_${attempt}.txt"; then
+          if ! env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee .lake/lint_output.txt; then
+            if grep -q "cannot parse arguments" .lake/lint_output.txt; then
               echo ""
               echo "=============================================================================="
               echo "ERROR: Your branch uses an older version of runLinter that doesn't support"
@@ -550,24 +545,9 @@ jobs:
               echo "  git push"
               echo "=============================================================================="
               echo ""
-              exit 1
             fi
-            if [ "$status" -eq 124 ]; then
-              echo "runLinter timed out (attempt $attempt)."
-              if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
-                echo "Retrying runLinter after timeout..."
-                continue
-              fi
-            fi
-            exit $status
-          done
+            exit 1
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23


### PR DESCRIPTION
This reverts commit 9b524ac2e0df0a162e9d37e2002eaa920efb3fd4. It seems like as it stands, failures in `runLinter` are not propagated to `$?`, which I would expect based on `set -o pipefail`. Maybe it's a landrun thing. I'm not sure if I introduced it but I want to revert just to be safe.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
