### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Indicator): add Pi. mulIndicator_singleton

### DIFF
--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -196,12 +196,12 @@ theorem apply_mulIndicator_symmDiff {g : G → β} (hg : ∀ x, g x⁻¹ = g x)
 
 end Group
 
-/- Relationship with Pi.mulSingle/Pi.single -/
+/-! ### Relationship with `Pi.mulSingle`/`Pi.single` -/
 
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 
 /-- On non-dependent functions, `Set.mulIndicator` on a singleton set equals `Pi.mulSingle`. -/
-@[to_additive
+@[to_additive (attr := simp)
   /-- On non-dependent functions, `Set.indicator` on a singleton set equals `Pi.single`. -/]
 theorem mulIndicator_singleton (i : ι) (f : ι → M) :
     Set.mulIndicator {i} f = Pi.mulSingle i (f i) := by

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -201,7 +201,7 @@ end Group
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 
 /-- On non-dependent functions, `Set.mulIndicator` on a singleton set equals `Pi.mulSingle`. -/
-@[to_additive (attr := simp)
+@[to_additive
   /-- On non-dependent functions, `Set.indicator` on a singleton set equals `Pi.single`. -/]
 theorem mulIndicator_singleton (i : ι) (f : ι → M) :
     Set.mulIndicator {i} f = Pi.mulSingle i (f i) := by

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -204,15 +204,13 @@ namespace Pi
 
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 
-/-- On non-dependent functions, `Pi.mulSingle` equals `Set.mulIndicator` on a singleton set.
-This is the Pi analog of `Finsupp.single_eq_set_indicator`. -/
+/-- On non-dependent functions, `Set.mulIndicator` on a singleton set equals `Pi.mulSingle`. -/
 @[to_additive
-  /-- On non-dependent functions, `Pi.single` equals `Set.indicator` on a singleton set.
-  This is the Pi analog of `Finsupp.single_eq_set_indicator`. -/]
-theorem mulSingle_eq_mulIndicator (i : ι) (x : M) :
-    (Pi.mulSingle i x : ι → M) = Set.mulIndicator {i} (fun _ => x) := by
+  /-- On non-dependent functions, `Set.indicator` on a singleton set equals `Pi.single`. -/]
+theorem mulIndicator_singleton_eq_mulSingle (i : ι) (x : M) :
+    Set.mulIndicator {i} (fun _ => x) = (Pi.mulSingle i x : ι → M) := by
   ext j
-  simp only [Pi.mulSingle_apply, Set.mulIndicator_apply, Set.mem_singleton_iff]
+  simp only [Set.mulIndicator_apply, Pi.mulSingle_apply, Set.mem_singleton_iff]
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -201,12 +201,13 @@ end Group
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 
 /-- On non-dependent functions, `Set.mulIndicator` on a singleton set equals `Pi.mulSingle`. -/
-@[to_additive
+@[to_additive (attr := simp)
   /-- On non-dependent functions, `Set.indicator` on a singleton set equals `Pi.single`. -/]
-theorem mulIndicator_singleton (i : ι) (x : M) :
-    Set.mulIndicator {i} (fun _ => x) = (Pi.mulSingle i x : ι → M) := by
+theorem mulIndicator_singleton (i : ι) (f : ι → M) :
+    Set.mulIndicator {i} f = Pi.mulSingle i (f i) := by
   ext j
   simp only [Set.mulIndicator_apply, Pi.mulSingle_apply, Set.mem_singleton_iff]
+  split_ifs with h <;> simp [h]
 
 end Set
 

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -198,6 +198,24 @@ end Group
 
 end Set
 
+/-! ### Relationship with Pi.mulSingle/Pi.single -/
+
+namespace Pi
+
+variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
+
+/-- On non-dependent functions, `Pi.mulSingle` equals `Set.mulIndicator` on a singleton set.
+This is the Pi analog of `Finsupp.single_eq_set_indicator`. -/
+@[to_additive
+  /-- On non-dependent functions, `Pi.single` equals `Set.indicator` on a singleton set.
+  This is the Pi analog of `Finsupp.single_eq_set_indicator`. -/]
+theorem mulSingle_eq_mulIndicator (i : ι) (x : M) :
+    (Pi.mulSingle i x : ι → M) = Set.mulIndicator {i} (fun _ => x) := by
+  ext j
+  simp only [Pi.mulSingle_apply, Set.mulIndicator_apply, Set.mem_singleton_iff]
+
+end Pi
+
 @[to_additive]
 theorem map_mulIndicator {M N F : Type*} [One M] [One N] [FunLike F M N] [OneHomClass F M N] (f : F)
     (s : Set α) (g : α → M) (x : α) : f (s.mulIndicator g x) = s.mulIndicator (f ∘ g) x := by

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -196,11 +196,7 @@ theorem apply_mulIndicator_symmDiff {g : G → β} (hg : ∀ x, g x⁻¹ = g x)
 
 end Group
 
-end Set
-
 /-! ### Relationship with Pi.mulSingle/Pi.single -/
-
-namespace Pi
 
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 
@@ -212,7 +208,7 @@ theorem mulIndicator_singleton_eq_mulSingle (i : ι) (x : M) :
   ext j
   simp only [Set.mulIndicator_apply, Pi.mulSingle_apply, Set.mem_singleton_iff]
 
-end Pi
+end Set
 
 @[to_additive]
 theorem map_mulIndicator {M N F : Type*} [One M] [One N] [FunLike F M N] [OneHomClass F M N] (f : F)

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -196,7 +196,7 @@ theorem apply_mulIndicator_symmDiff {g : G → β} (hg : ∀ x, g x⁻¹ = g x)
 
 end Group
 
-/-! ### Relationship with Pi.mulSingle/Pi.single -/
+/- Relationship with Pi.mulSingle/Pi.single -/
 
 variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -203,7 +203,7 @@ variable {ι : Type*} [DecidableEq ι] {M : Type*} [One M]
 /-- On non-dependent functions, `Set.mulIndicator` on a singleton set equals `Pi.mulSingle`. -/
 @[to_additive
   /-- On non-dependent functions, `Set.indicator` on a singleton set equals `Pi.single`. -/]
-theorem mulIndicator_singleton_eq_mulSingle (i : ι) (x : M) :
+theorem mulIndicator_singleton (i : ι) (x : M) :
     Set.mulIndicator {i} (fun _ => x) = (Pi.mulSingle i x : ι → M) := by
   ext j
   simp only [Set.mulIndicator_apply, Pi.mulSingle_apply, Set.mem_singleton_iff]

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -36,9 +36,24 @@ namespace NNReal
 noncomputable instance : FloorSemiring ℝ≥0 := Nonneg.floorSemiring
 
 @[simp, norm_cast]
+theorem coe_mulIndicator {α} (s : Set α) (f : α → ℝ≥0) (a : α) :
+    ((s.mulIndicator f a : ℝ≥0) : ℝ) = s.mulIndicator (fun x => ↑(f x)) a :=
+  map_mulIndicator toRealHom _ _ _
+
+@[simp, norm_cast]
 theorem coe_indicator {α} (s : Set α) (f : α → ℝ≥0) (a : α) :
     ((s.indicator f a : ℝ≥0) : ℝ) = s.indicator (fun x => ↑(f x)) a :=
   map_indicator toRealHom _ _ _
+
+@[simp, norm_cast]
+theorem coe_mulSingle {α} [DecidableEq α] (a : α) (b : ℝ≥0) (c : α) :
+    ((Pi.mulSingle a b : α → ℝ≥0) c : ℝ) = (Pi.mulSingle a b : α → ℝ) c := by
+  simpa using coe_mulIndicator {a} (fun _ ↦ b) c
+
+@[simp, norm_cast]
+theorem coe_single {α} [DecidableEq α] (a : α) (b : ℝ≥0) (c : α) :
+    ((Pi.single a b : α → ℝ≥0) c : ℝ) = (Pi.single a b : α → ℝ) c := by
+  simpa using coe_indicator {a} (fun _ ↦ b) c
 
 @[norm_cast]
 theorem coe_list_sum (l : List ℝ≥0) : ((l.sum : ℝ≥0) : ℝ) = (l.map (↑)).sum :=


### PR DESCRIPTION
Add `Pi.mulIndicator_singleton ` and `Pi.indicator_singleton ` (via `@[to_additive]`), showing that on non-dependent functions:

```lean
Set.mulIndicator {i} f = Pi.mulSingle i (f i)
Set.indicator {i} f = Pi.single i (f i)
```

This is the direct `Pi` analog of [`Finsupp.single_eq_set_indicator`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Finsupp/Single.html#Finsupp.single_eq_set_indicator), without involving Finsupp.

Also add confluence lemmas about `NNReal.toReal` to fix compile.