### PR TITLE
[Merged by Bors] - fix: add missing deprecations

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -545,6 +545,8 @@ theorem one_lt_finprod_cond {M : Type*} [CommMonoid M] [PartialOrder M] [IsOrder
     · aesop
   · simp +contextual
 
+@[deprecated (since := "2026-01-06")] alias finprod_cond_pos := finsum_cond_pos
+
 @[to_additive finsum_pos]
 theorem one_lt_finprod {M : Type*} [CommMonoid M] [PartialOrder M] [IsOrderedCancelMonoid M]
     {f : ι → M}

--- a/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
@@ -111,6 +111,10 @@ lemma Submonoid.closure_image_isMulIndecomposable_baseOf [Finite ι]
   replace hjk : v i ∈ closure (v '' t) := hjk ▸ mul_mem hj' hk'
   exact hi₁ hjk
 
+@[deprecated (since := "2025-12-30")]
+alias Submonoid.closure_image_one_lt_and_isMulIndecomposable :=
+  Submonoid.closure_image_isMulIndecomposable_baseOf
+
 @[to_additive]
 lemma Subgroup.closure_image_isMulIndecomposable_baseOf [Finite ι] [InvolutiveInv ι]
     [CommGroup S] [IsOrderedMonoid S]

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -401,6 +401,9 @@ noncomputable def derivativeFinsupp : R[X] →ₗ[R] ℕ →₀ R[X] where
   map_add' _ _ := by ext; simp
   map_smul' _ _ := by ext; simp
 
+@[deprecated (since := "2025-12-15")]
+alias derivativeFinsupp_apply_toFun := derivativeFinsupp_apply_apply
+
 @[simp]
 theorem support_derivativeFinsupp_subset_range {p : R[X]} {n : ℕ} (h : p.natDegree < n) :
     (derivativeFinsupp p).support ⊆ range n := by

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -307,6 +307,8 @@ theorem roots_eq_of_degree_eq_card {S : Finset R}
     (hS : ∀ x ∈ S, p.eval x = 0) (hcard : S.card = p.degree) : p.roots = S.val :=
   roots_eq_of_degree_le_card_of_ne_zero hS (by lia) (by contrapose! hcard; simp [hcard])
 
+@[deprecated (since := "2025-12-16")] alias roots_eq_of_degree_le_card := roots_eq_of_degree_eq_card
+
 theorem roots_eq_of_natDegree_le_card_of_ne_zero {S : Finset R}
     (hS : ∀ x ∈ S, p.eval x = 0) (hcard : p.natDegree ≤ S.card) (hp : p ≠ 0) : p.roots = S.val :=
   roots_eq_of_degree_le_card_of_ne_zero hS (degree_le_of_natDegree_le hcard) hp

--- a/Mathlib/Analysis/Calculus/ImplicitContDiff.lean
+++ b/Mathlib/Analysis/Calculus/ImplicitContDiff.lean
@@ -70,6 +70,12 @@ namespace IsContDiffImplicitAt
 variable
   {n : WithTop ℕ∞} {f : E × F → G} {f' : E × F →L[𝕜] G} {a : E × F}
 
+omit [CompleteSpace E] [CompleteSpace F] [CompleteSpace G] in
+@[deprecated IsContDiffImplicitAt.ne_zero (since := "2025-12-22")]
+theorem one_le (h : IsContDiffImplicitAt n f f' a) : 1 ≤ n := by
+  rw [ENat.one_le_iff_ne_zero_withTop]
+  exact h.ne_zero
+
 /-- We record the parameters of our specific case in order to apply the general implicit function
 theorem. -/
 def implicitFunctionData (h : IsContDiffImplicitAt n f f' a) :
@@ -105,9 +111,19 @@ lemma implicitFunctionData_pt (h : IsContDiffImplicitAt n f f' a) :
 lemma implicitFunctionData_leftFun_apply {h : IsContDiffImplicitAt n f f' a} {xy : E × F} :
     h.implicitFunctionData.leftFun xy = xy.1 := rfl
 
+@[deprecated "use simp" (since := "2026-01-08")]
+lemma implicitFunctionData_leftFun_pt (h : IsContDiffImplicitAt n f f' a) :
+    h.implicitFunctionData.leftFun h.implicitFunctionData.pt = a.1 := by
+  simp
+
 @[simp]
 lemma implicitFunctionData_rightFun_apply {h : IsContDiffImplicitAt n f f' a} {xy : E × F} :
     h.implicitFunctionData.rightFun xy = f xy := rfl
+
+@[deprecated "use simp" (since := "2026-01-08")]
+lemma implicitFunctionData_rightFun_pt (h : IsContDiffImplicitAt n f f' a) :
+    h.implicitFunctionData.rightFun h.implicitFunctionData.pt = f a := by
+  simp
 
 /-- The implicit function provided by the general theorem, from which we construct the more useful
 form `IsContDiffImplicitAt.implicitFunction`. -/

--- a/Mathlib/Analysis/Distribution/TemperedDistribution.lean
+++ b/Mathlib/Analysis/Distribution/TemperedDistribution.lean
@@ -413,6 +413,9 @@ theorem fourier_toTemperedDistributionCLM_eq (f : 𝓢(E, F)) :
   ext g
   simpa using integral_fourier_smul_eq g f
 
+@[deprecated (since := "2026-01-14")]
+alias fourierTransform_toTemperedDistributionCLM_eq := fourier_toTemperedDistributionCLM_eq
+
 /-- The distributional inverse Fourier transform and the classical inverse Fourier transform
 coincide on `𝓢(E, F)`. -/
 theorem fourierInv_toTemperedDistributionCLM_eq (f : 𝓢(E, F)) :
@@ -422,6 +425,9 @@ theorem fourierInv_toTemperedDistributionCLM_eq (f : 𝓢(E, F)) :
   _ = 𝓕⁻ (𝓕 (toTemperedDistributionCLM E F volume (𝓕⁻ f))) := by
     rw [fourier_toTemperedDistributionCLM_eq]
   _ = _ := fourierInv_fourier_eq _
+
+@[deprecated (since := "2026-01-14")]
+alias fourierTransformInv_toTemperedDistributionCLM_eq := fourierInv_toTemperedDistributionCLM_eq
 
 end Fourier
 

--- a/Mathlib/Analysis/Fourier/LpSpace.lean
+++ b/Mathlib/Analysis/Fourier/LpSpace.lean
@@ -103,6 +103,9 @@ theorem SchwartzMap.toLp_fourier_eq (f : 𝓢(E, F)) : 𝓕 (f.toLp 2) = (𝓕 f
   rw [one_mul]
   exact (norm_fourier_toL2_eq f).le
 
+@[deprecated (since := "2025-12-31")]
+alias SchwartzMap.toLp_fourierTransform_eq := SchwartzMap.toLp_fourier_eq
+
 @[simp]
 theorem SchwartzMap.toLp_fourierInv_eq (f : 𝓢(E, F)) : 𝓕⁻ (f.toLp 2) = (𝓕⁻ f).toLp 2 := by
   apply LinearMap.extendOfNorm_eq
@@ -112,6 +115,9 @@ theorem SchwartzMap.toLp_fourierInv_eq (f : 𝓢(E, F)) : 𝓕⁻ (f.toLp 2) = (
   rw [one_mul]
   convert (norm_fourier_toL2_eq (𝓕⁻ f)).symm.le
   simp
+
+@[deprecated (since := "2025-12-31")]
+alias SchwartzMap.toLp_fourierTransformInv_eq := SchwartzMap.toLp_fourierInv_eq
 
 namespace MeasureTheory.Lp
 

--- a/Mathlib/Analysis/Fourier/Notation.lean
+++ b/Mathlib/Analysis/Fourier/Notation.lean
@@ -138,6 +138,11 @@ def fourierₗ : E →ₗ[R] F where
 @[simp]
 lemma fourierₗ_apply (f : E) : fourierₗ R E f = 𝓕 f := rfl
 
+include R in
+variable (R) in
+lemma fourier_zero : 𝓕 (0 : E) = 0 :=
+  (fourierₗ R E).map_zero
+
 variable [TopologicalSpace E] [TopologicalSpace F] [ContinuousFourier E F]
 
 variable (R E) in
@@ -164,6 +169,11 @@ def fourierInvₗ : E →ₗ[R] F where
 
 @[simp]
 lemma fourierInvₗ_apply (f : E) : fourierInvₗ R E f = 𝓕⁻ f := rfl
+
+include R in
+variable (R) in
+lemma fourierInv_zero : 𝓕⁻ (0 : E) = 0 :=
+  (fourierInvₗ R E).map_zero
 
 variable [TopologicalSpace E] [TopologicalSpace F] [ContinuousFourierInv E F]
 

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -330,6 +330,11 @@ protected theorem deriv [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜} (h : Merom
     MeromorphicAt.meromorphicAt_congr this]
   fun_prop
 
+@[deprecated MeromorphicAt.deriv (since := "2025-12-21")]
+theorem fun_deriv [CompleteSpace E] {f : 𝕜 → E} {x : 𝕜} (h : MeromorphicAt f x) :
+    MeromorphicAt (fun z ↦ _root_.deriv f z) x :=
+  h.deriv
+
 /--
 Iterated derivatives of meromorphic functions are meromorphic.
 -/
@@ -339,6 +344,12 @@ Iterated derivatives of meromorphic functions are meromorphic.
   induction n with
   | zero => exact h
   | succ n IH => simpa only [Function.iterate_succ', Function.comp_apply] using IH.deriv
+
+@[deprecated MeromorphicAt.iterated_deriv (since := "2025-12-21")]
+theorem fun_iterated_deriv [CompleteSpace E] {n : ℕ} {f : 𝕜 → E} {x : 𝕜}
+    (h : MeromorphicAt f x) :
+    MeromorphicAt (fun z ↦ _root_.deriv^[n] f z) x :=
+  h.iterated_deriv
 
 end MeromorphicAt
 
@@ -523,9 +534,19 @@ include hf in
 protected theorem deriv [CompleteSpace E] : MeromorphicOn (deriv f) U := fun z hz ↦ (hf z hz).deriv
 
 include hf in
+@[deprecated MeromorphicOn.deriv (since := "2025-12-21")]
+theorem fun_deriv [CompleteSpace E] : MeromorphicOn (fun z ↦ _root_.deriv f z) U := hf.deriv
+
+include hf in
 /-- Iterated derivatives of meromorphic functions are meromorphic. -/
 theorem iterated_deriv [CompleteSpace E] {n : ℕ} : MeromorphicOn (_root_.deriv^[n] f) U :=
   fun z hz ↦ (hf z hz).iterated_deriv
+
+include hf in
+@[deprecated MeromorphicOn.iterated_deriv (since := "2025-12-21")]
+theorem fun_iterated_deriv [CompleteSpace E] {n : ℕ} :
+    MeromorphicOn (fun z ↦ _root_.deriv^[n] f z) U :=
+  hf.iterated_deriv
 
 end arithmetic
 
@@ -636,6 +657,8 @@ theorem countable_compl_analyticAt [SecondCountableTopology 𝕜] [CompleteSpace
 
 @[deprecated (since := "2025-12-21")] alias MeromorphicOn.countable_compl_analyticAt :=
   countable_compl_analyticAt
+@[deprecated (since := "2025-12-21")] alias _root_.MeromorphicOn.countable_compl_analyticAt :=
+  countable_compl_analyticAt
 
 /--
 Meromorphic functions are measurable.
@@ -652,5 +675,6 @@ theorem measurable [MeasurableSpace 𝕜] [SecondCountableTopology 𝕜] [BorelS
     (by simp [-mem_compl_iff]) h₃.restrict.measurable (measurable_of_countable _)
 
 @[deprecated (since := "2025-12-21")] alias MeromorphicOn.measurable := measurable
+@[deprecated (since := "2025-12-21")] alias _root_.MeromorphicOn.measurable := measurable
 
 end Meromorphic

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -1199,6 +1199,8 @@ def withLpProdCongr (f : α ≃ₗᵢ[𝕜] α') (g : β ≃ₗᵢ[𝕜] β') :
   __ := (f.toLinearEquiv.prodCongr g.toLinearEquiv).withLpCongr p
   norm_map' := (f.toLinearIsometry.withLpProdMap p g.toLinearIsometry).norm_map
 
+@[deprecated (since := "2025-12-22")] alias _root_.LinearIsometry.withLpProdCongr := withLpProdCongr
+
 /-- Commutativity of the `L^p` product as a linear isometric equivalence. -/
 def withLpProdComm : WithLp p (α × β) ≃ₗᵢ[𝕜] WithLp p (β × α) where
   __ := (LinearEquiv.prodComm 𝕜 α β).withLpCongr p

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -280,6 +280,11 @@ theorem Adj.diff_dist_adj (hadj : G.Adj v w) :
   have : G.dist u v ≤ G.dist u w + G.dist w v := huw.dist_triangle_left v
   lia
 
+@[deprecated Adj.diff_dist_adj (since := "2025-12-11")]
+theorem Connected.diff_dist_adj (_ : G.Connected) (hadj : G.Adj v w) :
+    G.dist u w = G.dist u v ∨ G.dist u w = G.dist u v + 1 ∨ G.dist u w = G.dist u v - 1 := by
+  apply Adj.diff_dist_adj hadj
+
 theorem Walk.isPath_of_length_eq_dist (p : G.Walk u v) (hp : p.length = G.dist u v) :
     p.IsPath := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -280,7 +280,7 @@ theorem Adj.diff_dist_adj (hadj : G.Adj v w) :
   have : G.dist u v ≤ G.dist u w + G.dist w v := huw.dist_triangle_left v
   lia
 
-@[deprecated Adj.diff_dist_adj (since := "2025-12-11")]
+@[deprecated Adj.diff_dist_adj (since := "2025-12-11"), nolint unusedArguments]
 theorem Connected.diff_dist_adj (_ : G.Connected) (hadj : G.Adj v w) :
     G.dist u w = G.dist u v ∨ G.dist u w = G.dist u v + 1 ∨ G.dist u w = G.dist u v - 1 := by
   apply Adj.diff_dist_adj hadj

--- a/Mathlib/Combinatorics/SimpleGraph/VertexCover.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/VertexCover.lean
@@ -190,6 +190,11 @@ theorem IsContained.vertexCoverNum_le_vertexCoverNum (h : G ⊑ H) :
   grw [this.vertexCoverNum_le, ← hs₁]
   exact Function.Embedding.encard_le <| Function.Embedding.mk f hf |>.subtypeMap (by simp)
 
+@[deprecated IsContained.vertexCoverNum_le_vertexCoverNum (since := "2026-01-07")]
+theorem vertexCoverNum_le_vertexCoverNum_of_injective (f : G →g H) (hf : Function.Injective f) :
+    vertexCoverNum G ≤ vertexCoverNum H :=
+  IsContained.vertexCoverNum_le_vertexCoverNum ⟨f, hf⟩
+
 @[gcongr]
 theorem vertexCoverNum_mono (h : G ≤ G') : vertexCoverNum G ≤ vertexCoverNum G' :=
   (IsContained.of_le h).vertexCoverNum_le_vertexCoverNum

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1121,6 +1121,9 @@ theorem subtypeDomain_not_piecewise (f : Subtype P →₀ M) (g : {a // ¬ P a} 
 @[simps! (attr := grind =) support apply]
 def extendDomain (f : Subtype P →₀ M) : α →₀ M := piecewise f 0
 
+@[deprecated (since := "2025-12-15")]
+alias extendDomain_toFun := extendDomain_apply
+
 theorem extendDomain_eq_embDomain_subtype (f : Subtype P →₀ M) :
     extendDomain f = embDomain (.subtype _) f := by
   ext a

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -67,6 +67,9 @@ def rangeIcc (f g : ι →₀ α) : ι →₀ Finset α where
     rw [mem_union, ← not_iff_not, not_or, notMem_support_iff, notMem_support_iff, not_ne_iff]
     exact Icc_eq_singleton_iff.symm
 
+@[deprecated (since := "2025-12-15")]
+alias rangeIcc_toFun := rangeIcc_apply
+
 lemma coe_rangeIcc (f g : ι →₀ α) : rangeIcc f g i = Icc (f i) (g i) := rfl
 
 @[simp]

--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -80,4 +80,6 @@ lemma IsCover.of_maximal_isSeparated [U.IsRefl] [U.IsSymm]
 
 @[simp] lemma isCover_id : IsCover .id s N ↔ s ⊆ N := by simp [IsCover, subset_def]
 
+@[deprecated (since := "2025-12-19")] alias isCover_relId := isCover_id
+
 end SetRel

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -38,6 +38,8 @@ lemma inner_ortho_nonneg {x y : V} (hx : ‖x‖ = 1) (hy : ‖y‖ = 1) : 0 ≤
     inner_self_eq_one_of_norm_eq_one hx, real_inner_smul_right, real_inner_comm, sub_nonneg]
   grw [← sq, sq_le_one_iff_abs_le_one, abs_real_inner_le_norm, hx, hy, one_mul]
 
+@[deprecated (since := "2025-12-20")] alias inner_ortho_nonneg_of_norm_eq_one := inner_ortho_nonneg
+
 lemma inner_normalize_ortho (x y : V) : ⟪y, normalize (ortho y x)⟫ = 0 := by
   simp only [NormedSpace.normalize, real_inner_smul_right, mul_eq_zero, inv_eq_zero, norm_eq_zero]
   right; rw [ortho, real_inner_comm, Submodule.starProjection_inner_eq_zero]

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -409,6 +409,8 @@ lemma of_opens [IsManifold I n M] (s : TopologicalSpace.Opens M) (y : s) :
     simp_all
   · exact I.right_inv (by simp_all)
 
+@[deprecated (since := "2025-12-16")] alias ofOpen := of_opens
+
 end IsImmersionAtOfComplement
 
 namespace IsImmersionAt
@@ -580,6 +582,8 @@ lemma of_opens [IsManifold I n M] (s : TopologicalSpace.Opens M) (hx : x ∈ s) 
   use PUnit, by infer_instance, by infer_instance
   apply Manifold.IsImmersionAtOfComplement.of_opens
 
+@[deprecated (since := "2025-12-16")] alias ofOpen := of_opens
+
 end IsImmersionAt
 
 variable (F I J n) in
@@ -673,6 +677,8 @@ lemma of_opens [IsManifold I n M] (s : TopologicalSpace.Opens M) :
     IsImmersionOfComplement PUnit I I n (Subtype.val : s → M) :=
   fun y ↦ IsImmersionAtOfComplement.of_opens s y
 
+@[deprecated (since := "2025-12-16")] alias ofOpen := of_opens
+
 end IsImmersionOfComplement
 
 namespace IsImmersion
@@ -729,6 +735,8 @@ protected lemma id [IsManifold I n M] : IsImmersion I I n (@id M) :=
 lemma of_opens [IsManifold I n M] (s : TopologicalSpace.Opens M) :
     IsImmersion I I n (Subtype.val : s → M) :=
   ⟨PUnit, by infer_instance, by infer_instance, IsImmersionOfComplement.of_opens s⟩
+
+@[deprecated (since := "2025-12-16")] alias ofOpen := of_opens
 
 end IsImmersion
 

--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -743,3 +743,16 @@ theorem isPreprimitive_of_three_le_card (h : 3 ≤ Nat.card α) :
   { isTrivialBlock_of_isBlock := isTrivialBlock_of_isBlock α }
 
 end alternatingGroup
+
+namespace AlternatingGroup
+
+@[deprecated (since := "2025-12-16")]
+alias isMultiplyPretransitive := alternatingGroup.isMultiplyPretransitive
+@[deprecated (since := "2025-12-16")]
+alias isPretransitive_of_three_le_card := alternatingGroup.isPretransitive_of_three_le_card
+@[deprecated (since := "2025-12-16")]
+alias isTrivialBlock_of_isBlock := alternatingGroup.isTrivialBlock_of_isBlock
+@[deprecated (since := "2025-12-16")]
+alias isPreprimitive_of_three_le_card := alternatingGroup.isPreprimitive_of_three_le_card
+
+end AlternatingGroup

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -130,6 +130,8 @@ theorem exists_mem_stabilizer_smul_eq :
   classical
   exact ⟨swap a b, swap_mem_stabilizer ha hb, swap_apply_left a b⟩
 
+@[deprecated (since := "2025-12-16")] alias moves_in := exists_mem_stabilizer_smul_eq
+
 theorem stabilizer.surjective_toPerm (s : Set α) :
     Function.Surjective (toPerm : stabilizer (Perm α) s → Perm s) := fun g ↦ by
   classical
@@ -252,6 +254,10 @@ lemma subsingleton_of_ssubset_of_stabilizer_le
   rw [isPreprimitive_congr hG hf]
   infer_instance
 
+@[deprecated (since := "2025-12-16")]
+alias _root_.IsBlock.subsingleton_of_ssubset_compl_of_stabilizer_le :=
+  subsingleton_of_ssubset_of_stabilizer_le
+
 lemma subsingleton_of_ssubset_of_stabilizer_Perm_le
     {B : Set α} {G : Subgroup (Perm α)} (hB : IsBlock G B)
     (hB_ss_sc : B ⊂ s) (hG : stabilizer (Perm α) s ≤ G) :
@@ -328,6 +334,10 @@ lemma compl_subset_of_stabilizer_le_of_not_subset_of_not_subset_compl
     rw [← is_one_pretransitive_iff]
     apply ofFixingSubgroup.isMultiplyPretransitive M s rfl
 
+@[deprecated (since := "2025-12-16")]
+alias _root_.IsBlock.compl_subset_of_stabilizer_le_of_not_subset_of_not_subset_compl :=
+  compl_subset_of_stabilizer_le_of_not_subset_of_not_subset_compl
+
 end MulAction.IsBlock
 
 namespace Equiv.Perm
@@ -393,7 +403,8 @@ theorem isCoatom_stabilizer_of_ncard_lt_ncard_compl
     hB.subsingleton_of_stabilizer_lt_of_subset hB_not_le_sc hG hBs
   -- Step 4 : `sᶜ ⊆ B`
   have _ := isMultiplyPretransitive α (s.ncard + 1)
-  apply IsBlock.compl_subset_of_stabilizer_le_of_not_subset_of_not_subset_compl hG.le <;> grind
+  apply MulAction.IsBlock.compl_subset_of_stabilizer_le_of_not_subset_of_not_subset_compl hG.le <;>
+    grind
 
 /-- `MulAction.stabilizer (Perm α) s` is a maximal subgroup of `Perm α`,
 provided `s` and `sᶜ` are nonempty, and `Nat.card α ≠ 2 * Nat.card s`.

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -60,6 +60,8 @@ variable {r : α → α → Prop}
 
 theorem Std.Refl.reflexive [Std.Refl r] : Reflexive r := fun x ↦ Std.Refl.refl x
 
+@[deprecated (since := "2026-01-09")] alias IsRefl.reflexive := Std.Refl.reflexive
+
 /-- To show a reflexive relation `r : α → α → Prop` holds over `x y : α`,
 it suffices to show it holds when `x ≠ y`. -/
 theorem Reflexive.rel_of_ne_imp (h : Reflexive r) {x y : α} (hr : x ≠ y → r x y) : r x y := by

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
@@ -166,6 +166,11 @@ lemma linear_isTheta_right_add (c e : ℤ) (z : ℂ) :
   simpa [-Int.cofinite_eq] using
     .inr <| tendsto_norm_comp_cofinite_atTop_of_isClosedEmbedding Int.isClosedEmbedding_coe_real
 
+@[deprecated linear_isTheta_right_add (since := "2025-12-27")]
+lemma linear_isTheta_right (c : ℤ) (z : ℂ) :
+    (fun (d : ℤ) ↦ (c * z + d)) =Θ[cofinite] fun n ↦ (n : ℝ) := by
+  simpa using linear_isTheta_right_add c 0 z
+
 lemma linear_isTheta_left (d : ℤ) {z : ℂ} (hz : z ≠ 0) :
     (fun (c : ℤ) ↦ (c * z + d)) =Θ[cofinite] fun n ↦ (n : ℝ) := by
   apply IsTheta.add_isLittleO

--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -343,11 +343,13 @@ theorem comm_of (r : α → α → Prop) [Std.Symm r] {a b : α} : r a b ↔ r b
 protected theorem Std.Asymm.antisymm (r : α → α → Prop) [Std.Asymm r] : Std.Antisymm r :=
   inferInstance
 
+@[deprecated (since := "2026-01-05")] protected alias IsAsymm.isAntisymm := Std.Asymm.antisymm
 @[deprecated (since := "2026-01-06")] protected alias Std.Asymm.isAntisymm := Std.Asymm.antisymm
 
 protected theorem Std.Asymm.irrefl [Std.Asymm r] : Std.Irrefl r :=
   inferInstance
 
+@[deprecated (since := "2026-01-05")] protected alias IsAsymm.isIrrefl := Std.Asymm.irrefl
 @[deprecated (since := "2026-01-07")] protected alias Std.Asymm.isIrrefl := Std.Asymm.irrefl
 
 protected theorem IsTotal.isTrichotomous (r) [IsTotal α r] : IsTrichotomous α r :=

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -29,6 +29,8 @@ open Function
 theorem Std.Refl.swap (r : α → α → Prop) [Std.Refl r] : Std.Refl (swap r) :=
   ⟨refl_of r⟩
 
+@[deprecated (since := "2026-01-09")] alias IsRefl.swap := Std.Refl.swap
+
 theorem Std.Irrefl.swap (r : α → α → Prop) [Std.Irrefl r] : Std.Irrefl (swap r) :=
   ⟨irrefl_of r⟩
 
@@ -40,6 +42,8 @@ theorem Std.Antisymm.swap (r : α → α → Prop) [Std.Antisymm r] : Std.Antisy
 
 theorem Std.Asymm.swap (r : α → α → Prop) [Std.Asymm r] : Std.Asymm (swap r) :=
   ⟨fun _ _ h₁ h₂ => asymm_of r h₂ h₁⟩
+
+@[deprecated (since := "2026-01-05")] alias IsAsymm.swap := Std.Asymm.swap
 
 theorem IsTotal.swap (r) [IsTotal α r] : IsTotal α (swap r) :=
   ⟨fun a b => (total_of r a b).symm⟩
@@ -373,6 +377,9 @@ instance Prod.wellFoundedLT [Preorder α] [WellFoundedLT α] [Preorder β] [Well
     obtain ⟨ha', hb⟩ | ⟨ha', hb⟩ := Prod.lt_iff.1 hx
     · exact iha x.1 (ha'.trans_le ha) x.1 le_rfl x.2
     · exact ihb x.2 hb x.1 (ha'.trans ha)
+
+@[deprecated (since := "2026-01-12")] alias Prod.wellFoundedLT' := Prod.wellFoundedLT
+@[deprecated (since := "2026-01-12")] alias Prod.wellFoundedGT' := Prod.wellFoundedGT
 
 namespace Set
 

--- a/Mathlib/Probability/Process/Adapted.lean
+++ b/Mathlib/Probability/Process/Adapted.lean
@@ -52,7 +52,9 @@ section Adapted
 variable {β : ι → Type*} [∀ i, MeasurableSpace (β i)] {u v : (i : ι) → Ω → β i}
 
 /-- A sequence of functions `u` is adapted to a filtration `f` if for all `i`,
-`u i` is `f i`-measurable. -/
+`u i` is `f i`-measurable.
+
+The definition known as `Adapted` before 2026-01-13 is now `StronglyAdapted`. -/
 def Adapted (f : Filtration ι m) (u : (i : ι) → Ω → β i) : Prop :=
   ∀ i : ι, Measurable[f i] (u i)
 

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -69,6 +69,9 @@ then a basis for `M` as `R`-module is also a basis for `M` as `R'`-module. -/
 noncomputable def algebraMapCoeffs : Basis ι A M :=
   b.mapCoeffs (RingEquiv.ofBijective _ h) fun c x => by simp
 
+@[deprecated (since := "2025-12-15")]
+alias algebraMapCoeffs_repr_apply_toFun := algebraMapCoeffs_repr_apply_apply
+
 @[simp]
 theorem algebraMapCoeffs_repr (m : M) :
     (b.algebraMapCoeffs A h).repr m = (b.repr m).mapRange (algebraMap R A) (map_zero _) := by

--- a/Mathlib/RingTheory/Filtration.lean
+++ b/Mathlib/RingTheory/Filtration.lean
@@ -460,6 +460,10 @@ theorem Ideal.iInf_pow_smul_eq_bot_of_isTorsionFree [IsDomain R]
   have := smul_left_injective _ hx' (hr.trans (one_smul _ x).symm)
   exact I.eq_top_iff_one.not.mp h (this ▸ r.prop)
 
+@[deprecated (since := "2026-01-17")]
+alias Ideal.iInf_pow_smul_eq_bot_of_noZeroSMulDivisors :=
+  Ideal.iInf_pow_smul_eq_bot_of_isTorsionFree
+
 /-- **Krull's intersection theorem** for Noetherian domains. -/
 theorem Ideal.iInf_pow_eq_bot_of_isDomain [IsNoetherianRing R] [IsDomain R] (h : I ≠ ⊤) :
     ⨅ i : ℕ, I ^ i = ⊥ := by

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -957,6 +957,8 @@ lemma sPolynomial_monomial_mul [NoZeroDivisors R] (p₁ p₂ : MvPolynomial σ R
     tsub_add_eq_add_tsub le_sup_left, tsub_add_eq_add_tsub le_sup_right,
     add_comm d₁, add_comm d₂, add_tsub_add_eq_tsub_right, add_tsub_add_eq_tsub_right]
 
+@[deprecated (since := "2025-12-15")] alias sPolynomial_mul_monomial := sPolynomial_monomial_mul
+
 lemma sPolynomial_monomial_mul' [NoZeroDivisors R] (p₁ p₂ : MvPolynomial σ R) (d₁ d₂ : σ →₀ ℕ)
     (c₁ c₂ : R) :
     m.sPolynomial (monomial d₁ c₁ * p₁) (monomial d₂ c₂ * p₂) =

--- a/Mathlib/RingTheory/Smooth/NoetherianDescent.lean
+++ b/Mathlib/RingTheory/Smooth/NoetherianDescent.lean
@@ -201,6 +201,13 @@ public theorem exists_subalgebra_fg [Smooth A B] :
     D.fg_subalgebra R, ⟨.of_split _ σ₀ hσ₀, inferInstance⟩,
     ⟨(P.tensorModelOfHasCoeffsEquiv (D.subalgebra R)).symm⟩⟩
 
+@[deprecated exists_subalgebra_fg (since := "2026-01-07")]
+public theorem exists_subalgebra_finiteType [Smooth A B] :
+    ∃ (A₀ : Subalgebra R A) (B₀ : Type u) (_ : CommRing B₀) (_ : Algebra A₀ B₀),
+      FiniteType R A₀ ∧ Smooth A₀ B₀ ∧ Nonempty (B ≃ₐ[A] A ⊗[A₀] B₀) := by
+  obtain ⟨A₀, B₀, _, _, h0, h1, h2⟩ := exists_subalgebra_fg R A B
+  exact ⟨A₀, B₀, inferInstance, inferInstance, (Subalgebra.fg_iff_finiteType A₀).mp h0, h1, h2⟩
+
 /--
 Let `A` be an `R`-algebra. If `B` is a smooth `A`-algebra, there exists an
 `R`-algebra of finite type `A₀` and a smooth `A₀`-algebra `B₀` such that `B ≃ₐ A ⊗[A₀] B₀`

--- a/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
@@ -131,11 +131,19 @@ lemma _root_.HasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc {a : α}
   simpa [Pi.div_def, fun N : ℕ ↦ prod_Icc_eq_prod_Ico_mul f (show (-N : ℤ) ≤ N by lia)]
     using hf2
 
+@[deprecated (since := "2025-12-15")]
+alias HasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc :=
+  _root_.HasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc
+
 @[to_additive]
 lemma multipliable_symmetricIco_of_multipliable_symmetricIcc
     (hf : Multipliable f (symmetricIcc ℤ)) (hf2 : Tendsto (fun N : ℕ ↦ (f N)⁻¹) atTop (𝓝 1)) :
     Multipliable f (symmetricIco ℤ) :=
   (hf.hasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc hf2).multipliable
+
+@[deprecated (since := "2025-12-15")]
+alias multipliable_symmetricIco_of_multiplible_symmetricIcc :=
+  multipliable_symmetricIco_of_multipliable_symmetricIcc
 
 @[to_additive]
 lemma tprod_symmetricIcc_eq_tprod_symmetricIco [T2Space α]


### PR DESCRIPTION
From #33633, #30563, #33771, #33755, #31988, #33622, #32837, #33638, #33503, #33321, #33242, #32955, #33159, #33152, #33131, #33144, #32116, #31259, #26831, #32917, #32589, #32584, #32562, #32788, and #32568.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
