### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Single): generalize single_eq_set_indicator

### DIFF
--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -66,6 +66,13 @@ theorem single_eq_set_indicator : ⇑(single a b) = Set.indicator {a} fun _ => b
   ext
   simp [single_apply, Set.indicator, @eq_comm _ a]
 
+theorem single_eq_set_indicator' (a : α) (f : α → M) :
+    ⇑(single a (f a)) = Set.indicator {a} f := by
+  classical
+  ext x
+  simp only [single_apply, Set.indicator, Set.mem_singleton_iff, @eq_comm _ a]
+  split_ifs with h <;> simp [h]
+
 @[simp]
 theorem single_eq_same : (single a b : α →₀ M) a = b := by
   classical exact Pi.single_eq_same (M := fun _ ↦ M) a b

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -61,17 +61,15 @@ theorem single_apply [Decidable (a = a')] : single a b a' = if a = a' then b els
 theorem single_apply_left {f : α → β} (hf : Function.Injective f) (x z : α) (y : M) :
     single (f x) y (f z) = single x y z := by classical simp only [single_apply, hf.eq_iff]
 
-theorem single_eq_set_indicator : ⇑(single a b) = Set.indicator {a} fun _ => b := by
-  classical
-  ext
-  simp [single_apply, Set.indicator, @eq_comm _ a]
-
-theorem single_eq_set_indicator' (a : α) (f : α → M) :
+theorem single_eq_set_indicator (a : α) (f : α → M) :
     ⇑(single a (f a)) = Set.indicator {a} f := by
   classical
   ext x
   simp only [single_apply, Set.indicator, Set.mem_singleton_iff, @eq_comm _ a]
   split_ifs with h <;> simp [h]
+
+theorem single_eq_set_indicator' : ⇑(single a b) = Set.indicator {a} fun _ => b :=
+  single_eq_set_indicator a fun _ => b
 
 @[simp]
 theorem single_eq_same : (single a b : α →₀ M) a = b := by
@@ -87,7 +85,7 @@ theorem single_eq_of_ne' (h : a ≠ a') : (single a b : α →₀ M) a' = 0 := b
 
 theorem single_eq_update [DecidableEq α] (a : α) (b : M) :
     ⇑(single a b) = Function.update (0 : _) a b := by
-  classical rw [single_eq_set_indicator, ← Set.piecewise_eq_indicator, Set.piecewise_singleton]
+  classical rw [single_eq_set_indicator', ← Set.piecewise_eq_indicator, Set.piecewise_singleton]
 
 theorem single_eq_pi_single [DecidableEq α] (a : α) (b : M) : ⇑(single a b) = Pi.single a b :=
   single_eq_update a b
@@ -123,7 +121,7 @@ theorem single_injective (a : α) : Function.Injective (single a : M → α →�
   rwa [single_eq_same, single_eq_same] at this
 
 theorem single_apply_eq_zero {a x : α} {b : M} : single a b x = 0 ↔ x = a → b = 0 := by
-  simp [single_eq_set_indicator]
+  simp [single_eq_set_indicator']
 
 theorem single_apply_ne_zero {a x : α} {b : M} : single a b x ≠ 0 ↔ x = a ∧ b ≠ 0 := by
   simp [single_apply_eq_zero]
@@ -172,7 +170,7 @@ theorem support_single_disjoint {b' : M} (hb : b ≠ 0) (hb' : b' ≠ 0) {i j : 
 
 @[simp]
 theorem single_eq_zero : single a b = 0 ↔ b = 0 := by
-  simp [DFunLike.ext_iff, single_eq_set_indicator]
+  simp [DFunLike.ext_iff, single_eq_set_indicator']
 
 theorem single_ne_zero : single a b ≠ 0 ↔ b ≠ 0 :=
   single_eq_zero.not

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -61,15 +61,17 @@ theorem single_apply [Decidable (a = a')] : single a b a' = if a = a' then b els
 theorem single_apply_left {f : α → β} (hf : Function.Injective f) (x z : α) (y : M) :
     single (f x) y (f z) = single x y z := by classical simp only [single_apply, hf.eq_iff]
 
-theorem single_eq_set_indicator (a : α) (f : α → M) :
-    ⇑(single a (f a)) = Set.indicator {a} f := by
+theorem single_eq_set_indicator : ⇑(single a b) = Set.indicator {a} fun _ => b := by
   classical
   ext x
   simp only [single_apply, Set.indicator, Set.mem_singleton_iff, @eq_comm _ a]
-  split_ifs with h <;> simp [h]
 
-theorem single_eq_set_indicator' : ⇑(single a b) = Set.indicator {a} fun _ => b :=
-  single_eq_set_indicator a fun _ => b
+theorem Set.indicator_singleton_eq (a : α) (f : α → M) :
+    Set.indicator {a} f = ⇑(single a (f a)) := by
+  classical
+  ext x
+  simp only [Set.indicator, Set.mem_singleton_iff, single_apply, @eq_comm _ a]
+  split_ifs with h <;> simp [h]
 
 @[simp]
 theorem single_eq_same : (single a b : α →₀ M) a = b := by
@@ -85,7 +87,7 @@ theorem single_eq_of_ne' (h : a ≠ a') : (single a b : α →₀ M) a' = 0 := b
 
 theorem single_eq_update [DecidableEq α] (a : α) (b : M) :
     ⇑(single a b) = Function.update (0 : _) a b := by
-  classical rw [single_eq_set_indicator', ← Set.piecewise_eq_indicator, Set.piecewise_singleton]
+  classical rw [single_eq_set_indicator, ← Set.piecewise_eq_indicator, Set.piecewise_singleton]
 
 theorem single_eq_pi_single [DecidableEq α] (a : α) (b : M) : ⇑(single a b) = Pi.single a b :=
   single_eq_update a b
@@ -121,7 +123,7 @@ theorem single_injective (a : α) : Function.Injective (single a : M → α →�
   rwa [single_eq_same, single_eq_same] at this
 
 theorem single_apply_eq_zero {a x : α} {b : M} : single a b x = 0 ↔ x = a → b = 0 := by
-  simp [single_eq_set_indicator']
+  simp [single_eq_set_indicator]
 
 theorem single_apply_ne_zero {a x : α} {b : M} : single a b x ≠ 0 ↔ x = a ∧ b ≠ 0 := by
   simp [single_apply_eq_zero]
@@ -170,7 +172,7 @@ theorem support_single_disjoint {b' : M} (hb : b ≠ 0) (hb' : b' ≠ 0) {i j : 
 
 @[simp]
 theorem single_eq_zero : single a b = 0 ↔ b = 0 := by
-  simp [DFunLike.ext_iff, single_eq_set_indicator']
+  simp [DFunLike.ext_iff, single_eq_set_indicator]
 
 theorem single_ne_zero : single a b ≠ 0 ↔ b ≠ 0 :=
   single_eq_zero.not


### PR DESCRIPTION
Generalize `Finsupp.single_eq_set_indicator` to arbitrary functions, with the old statement available as `single_eq_set_indicator'`:

```lean
theorem single_eq_set_indicator (a : α) (f : α → M) :
    ⇑(single a (f a)) = Set.indicator {a} f
