### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): morphisms of finite type induce essentially of finite type stalk maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6303,6 +6303,7 @@ public import Mathlib.RingTheory.Regular.Flat
 public import Mathlib.RingTheory.Regular.IsSMulRegular
 public import Mathlib.RingTheory.Regular.RegularSequence
 public import Mathlib.RingTheory.RingHom.Bijective
+public import Mathlib.RingTheory.RingHom.EssFiniteType
 public import Mathlib.RingTheory.RingHom.Etale
 public import Mathlib.RingTheory.RingHom.FaithfullyFlat
 public import Mathlib.RingTheory.RingHom.Finite

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -86,6 +86,11 @@ instance (f : X ⟶ Y) (U : X.Opens) (V : Y.Opens) (e) [LocallyOfFiniteType f] :
     LocallyOfFiniteType (f.resLE V U e) := by
   delta Scheme.Hom.resLE; infer_instance
 
+lemma LocallyOfFiniteType.stalkMap [LocallyOfFiniteType f] (x : X) :
+    (f.stalkMap x).hom.EssFiniteType :=
+  HasRingHomProperty.stalkMap_of_respectsIso RingHom.EssFiniteType.respectsIso
+    (fun f hf _ _ ↦ (RingHom.FiniteType.essFiniteType hf).localRingHom _) ‹_› x
+
 instance {R} [CommRing R] [IsJacobsonRing R] : JacobsonSpace <| Spec <| .of R :=
   inferInstanceAs (JacobsonSpace (PrimeSpectrum R))
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -6,6 +6,7 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
+public import Mathlib.RingTheory.RingHom.EssFiniteType
 public import Mathlib.RingTheory.RingHom.FiniteType
 public import Mathlib.RingTheory.Spectrum.Prime.Jacobson
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -90,7 +90,10 @@ instance (f : X ⟶ Y) (U : X.Opens) (V : Y.Opens) (e) [LocallyOfFiniteType f] :
 lemma LocallyOfFiniteType.stalkMap [LocallyOfFiniteType f] (x : X) :
     (f.stalkMap x).hom.EssFiniteType :=
   HasRingHomProperty.stalkMap_of_respectsIso RingHom.EssFiniteType.respectsIso
-    (fun f hf _ _ ↦ (RingHom.FiniteType.essFiniteType hf).localRingHom _) ‹_› x
+    (fun f hf _ _ ↦ RingHom.EssFiniteType.holdsForLocalization.localRingHom
+      RingHom.EssFiniteType.stableUnderComposition
+      RingHom.EssFiniteType.isStableUnderBaseChange.localizationPreserves _
+      (RingHom.FiniteType.essFiniteType hf)) ‹_› x
 
 instance {R} [CommRing R] [IsJacobsonRing R] : JacobsonSpace <| Spec <| .of R :=
   inferInstanceAs (JacobsonSpace (PrimeSpectrum R))

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -675,35 +675,43 @@ lemma of_stalkMap (hQ : OfLocalizationPrime Q) (H : ∀ x, Q (f.stalkMap x).hom)
   specialize H ⟨P, hP⟩
   rwa [hQi.arrow_mk_iso_iff (Scheme.arrowStalkMapSpecIso φ _)] at H
 
-/-- Let `Q` be a property of ring maps that is stable under localization.
-Then if the associated property of scheme morphisms holds for `f`, `Q` holds on all stalks. -/
-lemma stalkMap
+/-- Let `Q` be a property of ring maps that implies `Q'` on stalks.
+Then if the associated property of scheme morphisms holds for `f`, `Q'` holds on all stalks. -/
+lemma stalkMap_of_respectsIso
+    {Q' : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop}
+    (hQ' : RingHom.RespectsIso Q')
     (hQ : ∀ {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (_ : Q f)
-      (J : Ideal S) (_ : J.IsPrime), Q (Localization.localRingHom _ J f rfl))
-    (hf : P f) (x : X) : Q (f.stalkMap x).hom := by
-  have hQi := (HasRingHomProperty.isLocal_ringHomProperty P).respectsIso
+      (J : Ideal S) (_ : J.IsPrime), Q' (Localization.localRingHom _ J f rfl))
+    (hf : P f) (x : X) : Q' (f.stalkMap x).hom := by
   wlog h : IsAffine X ∧ IsAffine Y generalizing X Y f
   · obtain ⟨U, hU, hfx, _⟩ := Opens.isBasis_iff_nbhd.mp Y.isBasis_affineOpens
       (Opens.mem_top <| f x)
     obtain ⟨V, hV, hx, e⟩ := Opens.isBasis_iff_nbhd.mp X.isBasis_affineOpens
       (show x ∈ f ⁻¹ᵁ U from hfx)
-    rw [← hQi.arrow_mk_iso_iff (Scheme.Hom.resLEStalkMap f e ⟨x, hx⟩)]
+    rw [← hQ'.arrow_mk_iso_iff (Scheme.Hom.resLEStalkMap f e ⟨x, hx⟩)]
     exact this (IsZariskiLocalAtSource.resLE _ hf) _ ⟨hV, hU⟩
   obtain ⟨hX, hY⟩ := h
   wlog hXY : ∃ R S, Y = Spec R ∧ X = Spec S generalizing X Y
-  · have : Q ((X.isoSpec.inv ≫ f ≫ Y.isoSpec.hom).stalkMap (X.isoSpec.hom x)).hom := by
+  · have : Q' ((X.isoSpec.inv ≫ f ≫ Y.isoSpec.hom).stalkMap (X.isoSpec.hom x)).hom := by
       refine this ?_ (X.isoSpec.hom x) inferInstance inferInstance ?_
       · rwa [P.cancel_left_of_respectsIso, P.cancel_right_of_respectsIso]
       · use Γ(Y, ⊤), Γ(X, ⊤)
     rw [Scheme.Hom.stalkMap_comp, Scheme.Hom.stalkMap_comp, CommRingCat.hom_comp,
-      hQi.cancel_right_isIso, CommRingCat.hom_comp, hQi.cancel_left_isIso] at this
+      hQ'.cancel_right_isIso, CommRingCat.hom_comp, hQ'.cancel_left_isIso] at this
     have heq : (X.isoSpec.inv (X.isoSpec.hom x)) = x := by simp
-    rwa [hQi.arrow_mk_iso_iff (f.arrowStalkMapIsoOfEq heq)] at this
+    rwa [hQ'.arrow_mk_iso_iff (f.arrowStalkMapIsoOfEq heq)] at this
   obtain ⟨R, S, rfl, rfl⟩ := hXY
   obtain ⟨φ, rfl⟩ := Spec.map_surjective f
-  rw [hQi.arrow_mk_iso_iff (Scheme.arrowStalkMapSpecIso φ _)]
+  rw [hQ'.arrow_mk_iso_iff (Scheme.arrowStalkMapSpecIso φ _)]
   rw [Spec_iff (P := P)] at hf
   apply hQ _ hf
+
+/-- Let `Q` be a property of ring maps that is stable under localization.
+Then if the associated property of scheme morphisms holds for `f`, `Q` holds on all stalks. -/
+lemma stalkMap (hQ : ∀ {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) (_ : Q f)
+      (J : Ideal S) (_ : J.IsPrime), Q (Localization.localRingHom _ J f rfl))
+    (hf : P f) (x : X) : Q (f.stalkMap x).hom :=
+  stalkMap_of_respectsIso (HasRingHomProperty.isLocal_ringHomProperty P).respectsIso hQ hf x
 
 end HasRingHomProperty
 

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -6,7 +6,8 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.RingTheory.FiniteType
-public import Mathlib.RingTheory.Localization.Defs
+public import Mathlib.RingTheory.Localization.AtPrime.Basic
+public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 public import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
@@ -241,24 +242,69 @@ def EssFiniteType (f : R →+* S) : Prop :=
   letI := f.toAlgebra
   Algebra.EssFiniteType R S
 
-/-- A choice of "essential generators" for a ring hom essentially of finite type.
-See `Algebra.EssFiniteType.ext`. -/
-noncomputable
-def EssFiniteType.finset (hf : f.EssFiniteType) : Finset S :=
-  letI := f.toAlgebra
-  haveI : Algebra.EssFiniteType R S := hf
-  Algebra.EssFiniteType.finset R S
+lemma essFiniteType_algebraMap {R S : Type*} [CommRing R] [CommRing S]
+    [Algebra R S] : (algebraMap R S).EssFiniteType ↔ Algebra.EssFiniteType R S := by
+  rw [RingHom.EssFiniteType, toAlgebra_algebraMap]
 
 lemma FiniteType.essFiniteType (hf : f.FiniteType) : f.EssFiniteType := by
   algebraize [f]
   change Algebra.EssFiniteType R S
   infer_instance
 
-lemma EssFiniteType.ext (hf : f.EssFiniteType) {g₁ g₂ : S →+* T}
+namespace EssFiniteType
+
+/-- A choice of "essential generators" for a ring hom essentially of finite type.
+See `Algebra.EssFiniteType.ext`. -/
+noncomputable
+def finset (hf : f.EssFiniteType) : Finset S :=
+  letI := f.toAlgebra
+  haveI : Algebra.EssFiniteType R S := hf
+  Algebra.EssFiniteType.finset R S
+
+lemma ext (hf : f.EssFiniteType) {g₁ g₂ : S →+* T}
     (h₁ : g₁.comp f = g₂.comp f) (h₂ : ∀ x ∈ hf.finset, g₁ x = g₂ x) : g₁ = g₂ := by
   algebraize [f, g₁.comp f]
   ext x
   exact DFunLike.congr_fun (Algebra.EssFiniteType.algHom_ext T
     ⟨g₁, fun _ ↦ rfl⟩ ⟨g₂, DFunLike.congr_fun h₁.symm⟩ h₂) x
 
-end RingHom
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
+
+lemma comp {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) (hg : g.EssFiniteType) :
+    (g.comp f).EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.comp R S T
+
+lemma comp_iff {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) :
+    (g.comp f).EssFiniteType ↔ g.EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.comp_iff R S T
+
+lemma of_comp (f : R →+* S) {g : S →+* T} (h : (g.comp f).EssFiniteType) :
+    g.EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.of_comp R S T
+
+lemma isLocalizationMap {M : Submonoid R} [Algebra R S] [IsLocalization M S]
+    {P : Type*} [CommRing P] {T : Submonoid P} (Q : Type*) [CommRing Q] [Algebra P Q]
+    [IsLocalization T Q] {g : R →+* P} (hy : M ≤ Submonoid.comap g T) (hg : g.EssFiniteType) :
+    (IsLocalization.map (S := S) Q g hy).EssFiniteType := by
+  refine .of_comp (algebraMap R S) ?_
+  rw [IsLocalization.map_comp]
+  refine hg.comp ?_
+  rw [RingHom.essFiniteType_algebraMap]
+  exact .of_isLocalization _ T
+
+lemma localRingHom {p : Ideal R} [p.IsPrime] {q : Ideal S} [q.IsPrime]
+    {f : R →+* S} (h : p = q.comap f) (hf : f.EssFiniteType) :
+    (Localization.localRingHom p q f h).EssFiniteType :=
+  hf.isLocalizationMap _ _
+
+lemma residueFieldMap {f : R →+* S} [IsLocalRing R] [IsLocalRing S] [IsLocalHom f]
+    (hf : f.EssFiniteType) :
+    (IsLocalRing.ResidueField.map f).EssFiniteType := by
+  refine .of_comp (IsLocalRing.residue R) ?_
+  rw [IsLocalRing.ResidueField.map_comp_residue]
+  exact .comp hf (FiniteType.of_surjective _ <| IsLocalRing.residue_surjective).essFiniteType
+
+end RingHom.EssFiniteType

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -9,6 +9,7 @@ public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Localization.AtPrime.Basic
 public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 public import Mathlib.RingTheory.TensorProduct.Basic
+public import Mathlib.RingTheory.RingHomProperties
 
 /-!
 # Essentially of finite type algebras
@@ -284,6 +285,12 @@ lemma of_comp (f : R →+* S) {g : S →+* T} (h : (g.comp f).EssFiniteType) :
     g.EssFiniteType := by
   algebraize [f, g, g.comp f]
   exact Algebra.EssFiniteType.of_comp R S T
+
+lemma stableUnderComposition : StableUnderComposition EssFiniteType :=
+  fun _ _ _ _ _ _ _ _ hf hg ↦ hf.comp hg
+
+lemma respectsIso : RespectsIso EssFiniteType :=
+  stableUnderComposition.respectsIso fun e ↦ (FiniteType.of_surjective _ e.surjective).essFiniteType
 
 lemma isLocalizationMap {M : Submonoid R} [Algebra R S] [IsLocalization M S]
     {P : Type*} [CommRing P] {T : Submonoid P} (Q : Type*) [CommRing Q] [Algebra P Q]

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -6,10 +6,8 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.RingTheory.FiniteType
-public import Mathlib.RingTheory.Localization.AtPrime.Basic
-public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
+public import Mathlib.RingTheory.Localization.Defs
 public import Mathlib.RingTheory.TensorProduct.Basic
-public import Mathlib.RingTheory.RingHomProperties
 
 /-!
 # Essentially of finite type algebras
@@ -252,66 +250,19 @@ lemma FiniteType.essFiniteType (hf : f.FiniteType) : f.EssFiniteType := by
   change Algebra.EssFiniteType R S
   infer_instance
 
-namespace EssFiniteType
-
 /-- A choice of "essential generators" for a ring hom essentially of finite type.
 See `Algebra.EssFiniteType.ext`. -/
 noncomputable
-def finset (hf : f.EssFiniteType) : Finset S :=
+def EssFiniteType.finset (hf : f.EssFiniteType) : Finset S :=
   letI := f.toAlgebra
   haveI : Algebra.EssFiniteType R S := hf
   Algebra.EssFiniteType.finset R S
 
-lemma ext (hf : f.EssFiniteType) {g₁ g₂ : S →+* T}
+lemma EssFiniteType.ext (hf : f.EssFiniteType) {g₁ g₂ : S →+* T}
     (h₁ : g₁.comp f = g₂.comp f) (h₂ : ∀ x ∈ hf.finset, g₁ x = g₂ x) : g₁ = g₂ := by
   algebraize [f, g₁.comp f]
   ext x
   exact DFunLike.congr_fun (Algebra.EssFiniteType.algHom_ext T
     ⟨g₁, fun _ ↦ rfl⟩ ⟨g₂, DFunLike.congr_fun h₁.symm⟩ h₂) x
 
-variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
-
-lemma comp {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) (hg : g.EssFiniteType) :
-    (g.comp f).EssFiniteType := by
-  algebraize [f, g, g.comp f]
-  exact Algebra.EssFiniteType.comp R S T
-
-lemma comp_iff {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) :
-    (g.comp f).EssFiniteType ↔ g.EssFiniteType := by
-  algebraize [f, g, g.comp f]
-  exact Algebra.EssFiniteType.comp_iff R S T
-
-lemma of_comp (f : R →+* S) {g : S →+* T} (h : (g.comp f).EssFiniteType) :
-    g.EssFiniteType := by
-  algebraize [f, g, g.comp f]
-  exact Algebra.EssFiniteType.of_comp R S T
-
-lemma stableUnderComposition : StableUnderComposition EssFiniteType :=
-  fun _ _ _ _ _ _ _ _ hf hg ↦ hf.comp hg
-
-lemma respectsIso : RespectsIso EssFiniteType :=
-  stableUnderComposition.respectsIso fun e ↦ (FiniteType.of_surjective _ e.surjective).essFiniteType
-
-lemma isLocalizationMap {M : Submonoid R} [Algebra R S] [IsLocalization M S]
-    {P : Type*} [CommRing P] {T : Submonoid P} (Q : Type*) [CommRing Q] [Algebra P Q]
-    [IsLocalization T Q] {g : R →+* P} (hy : M ≤ Submonoid.comap g T) (hg : g.EssFiniteType) :
-    (IsLocalization.map (S := S) Q g hy).EssFiniteType := by
-  refine .of_comp (algebraMap R S) ?_
-  rw [IsLocalization.map_comp]
-  refine hg.comp ?_
-  rw [RingHom.essFiniteType_algebraMap]
-  exact .of_isLocalization _ T
-
-lemma localRingHom {p : Ideal R} [p.IsPrime] {q : Ideal S} [q.IsPrime]
-    {f : R →+* S} (h : p = q.comap f) (hf : f.EssFiniteType) :
-    (Localization.localRingHom p q f h).EssFiniteType :=
-  hf.isLocalizationMap _ _
-
-lemma residueFieldMap {f : R →+* S} [IsLocalRing R] [IsLocalRing S] [IsLocalHom f]
-    (hf : f.EssFiniteType) :
-    (IsLocalRing.ResidueField.map f).EssFiniteType := by
-  refine .of_comp (IsLocalRing.residue R) ?_
-  rw [IsLocalRing.ResidueField.map_comp_residue]
-  exact .comp hf (FiniteType.of_surjective _ <| IsLocalRing.residue_surjective).essFiniteType
-
-end RingHom.EssFiniteType
+end RingHom

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -245,11 +245,6 @@ lemma essFiniteType_algebraMap {R S : Type*} [CommRing R] [CommRing S]
     [Algebra R S] : (algebraMap R S).EssFiniteType ↔ Algebra.EssFiniteType R S := by
   rw [RingHom.EssFiniteType, toAlgebra_algebraMap]
 
-lemma FiniteType.essFiniteType (hf : f.FiniteType) : f.EssFiniteType := by
-  algebraize [f]
-  change Algebra.EssFiniteType R S
-  infer_instance
-
 /-- A choice of "essential generators" for a ring hom essentially of finite type.
 See `Algebra.EssFiniteType.ext`. -/
 noncomputable
@@ -257,6 +252,11 @@ def EssFiniteType.finset (hf : f.EssFiniteType) : Finset S :=
   letI := f.toAlgebra
   haveI : Algebra.EssFiniteType R S := hf
   Algebra.EssFiniteType.finset R S
+
+lemma FiniteType.essFiniteType (hf : f.FiniteType) : f.EssFiniteType := by
+  algebraize [f]
+  change Algebra.EssFiniteType R S
+  infer_instance
 
 lemma EssFiniteType.ext (hf : f.EssFiniteType) {g₁ g₂ : S →+* T}
     (h₁ : g₁.comp f = g₂.comp f) (h₂ : ∀ x ∈ hf.finset, g₁ x = g₂ x) : g₁ = g₂ := by

--- a/Mathlib/RingTheory/LocalProperties/Basic.lean
+++ b/Mathlib/RingTheory/LocalProperties/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Localization.AtPrime.Basic
 public import Mathlib.RingTheory.Localization.BaseChange
+public import Mathlib.RingTheory.Localization.LocalizationLocalization
 public import Mathlib.RingTheory.Localization.Submodule
 public import Mathlib.RingTheory.LocalProperties.Submodule
 public import Mathlib.RingTheory.RingHomProperties
@@ -117,6 +118,12 @@ def RingHom.OfLocalizationSpan :=
   ∀ ⦃R S : Type u⦄ [CommRing R] [CommRing S] (f : R →+* S) (s : Set R) (_ : Ideal.span s = ⊤)
     (_ : ∀ r : s, P (Localization.awayMap f r)), P f
 
+/-- A property `P` of ring homs satisfies `RingHom.HoldsForLocalization`
+if `P` holds for each localization map `R →+* M⁻¹R`. -/
+def RingHom.HoldsForLocalization : Prop :=
+  ∀ ⦃R : Type u⦄ (S : Type u) [CommRing R] [CommRing S] [Algebra R S] (M : Submonoid R)
+    [IsLocalization M S], P (algebraMap R S)
+
 /-- A property `P` of ring homs satisfies `RingHom.HoldsForLocalizationAway`
 if `P` holds for each localization map `R →+* Rᵣ`. -/
 def RingHom.HoldsForLocalizationAway : Prop :=
@@ -226,6 +233,55 @@ lemma RingHom.OfLocalizationSpan.mk (hP : RingHom.RespectsIso P)
       Algebra.TensorProduct.tmul_one_eq_one_tmul, RingHom.algebraMap_toAlgebra]
   rw [this]
   exact hP.1 _ _ (hf ⟨r, hr⟩)
+
+section HoldsForLocalization
+
+variable {P}
+
+lemma RingHom.HoldsForLocalization.mk (hP : RespectsIso P)
+    (H : ∀ {R : Type u} [CommRing R] (M : Submonoid R), P (algebraMap R (Localization M))) :
+    HoldsForLocalization P := by
+  introv R _
+  rw [← (IsLocalization.algEquiv M (Localization M) S).toAlgHom.comp_algebraMap]
+  exact hP.1 _ _ (H _)
+
+lemma RingHom.HoldsForLocalization.holdsForLocalizationAway (hP : HoldsForLocalization P) :
+    HoldsForLocalizationAway P :=
+  fun _ _ _ _ _ r _ ↦ hP _ (Submonoid.powers r)
+
+lemma RingHom.HoldsForLocalization.isLocalizationMap
+    (hPc : StableUnderComposition P) (hPp : LocalizationPreserves P)
+    (hPl : HoldsForLocalization P)
+    {M : Submonoid R} {T : Submonoid S}
+    {R' : Type u} [CommRing R'] [Algebra R R'] [IsLocalization M R']
+    (S' : Type u) [CommRing S'] [Algebra S S'] [IsLocalization T S']
+    {f : R →+* S} (hy : M ≤ Submonoid.comap f T) (hf : P f) :
+    P (IsLocalization.map (S := R') S' f hy) := by
+  have hle : Submonoid.map f M ≤ T := by simpa [Submonoid.map_le_iff_le_comap]
+  letI : Algebra (Localization (M.map f)) S' :=
+    IsLocalization.localizationAlgebraOfSubmonoidLe _ _ (M.map f) T hle
+  have : IsScalarTower S (Localization (Submonoid.map f M)) S' :=
+    IsLocalization.localization_isScalarTower_of_submonoid_le _ _ _ _ _
+  have : IsLocalization (T.map (algebraMap S (Localization (M.map f)))) S' :=
+    IsLocalization.isLocalization_of_submonoid_le _ _ (M.map f) T hle
+  have heq : IsLocalization.map (S := R') S' f hy =
+      (algebraMap _ _).comp
+        (IsLocalization.map (M := M) (T := M.map f) (S := R') (Localization (M.map f)) f
+          (M.le_comap_map)) := by
+    apply IsLocalization.ringHom_ext M
+    ext
+    simp [← IsScalarTower.algebraMap_apply]
+  rw [heq]
+  exact hPc _ _ (hPp _ _ _ _ hf) (hPl _ (T.map (algebraMap S (Localization (M.map f)))))
+
+lemma RingHom.HoldsForLocalization.localRingHom (hPc : StableUnderComposition P)
+    (hPp : LocalizationPreserves P) (hPl : HoldsForLocalization P)
+    {R S : Type u} [CommRing R] [CommRing S] {p : Ideal R} [p.IsPrime] {q : Ideal S} [q.IsPrime]
+    {f : R →+* S} (h : p = q.comap f) (hf : P f) :
+    P (Localization.localRingHom p q f h) :=
+  hPl.isLocalizationMap hPc hPp _ _ hf
+
+end HoldsForLocalization
 
 theorem RingHom.HoldsForLocalizationAway.of_bijective
     (H : RingHom.HoldsForLocalizationAway P) (hf : Function.Bijective f) :

--- a/Mathlib/RingTheory/RingHom/EssFiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/EssFiniteType.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.RingTheory.EssentialFiniteness
 public import Mathlib.RingTheory.Localization.AtPrime.Basic
 public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
-public import Mathlib.RingTheory.RingHomProperties
+public import Mathlib.RingTheory.LocalProperties.Basic
 
 /-!
 # Meta properties of essentially of finite type ring homomorphisms
@@ -46,20 +46,10 @@ lemma isStableUnderBaseChange : IsStableUnderBaseChange EssFiniteType :=
     rw [essFiniteType_algebraMap] at h ⊢
     infer_instance
 
-lemma isLocalizationMap {M : Submonoid R} [Algebra R S] [IsLocalization M S]
-    {P : Type*} [CommRing P] {T : Submonoid P} (Q : Type*) [CommRing Q] [Algebra P Q]
-    [IsLocalization T Q] {g : R →+* P} (hy : M ≤ Submonoid.comap g T) (hg : g.EssFiniteType) :
-    (IsLocalization.map (S := S) Q g hy).EssFiniteType := by
-  refine .of_comp (algebraMap R S) ?_
-  rw [IsLocalization.map_comp]
-  refine hg.comp ?_
-  rw [RingHom.essFiniteType_algebraMap]
-  exact .of_isLocalization _ T
-
-lemma localRingHom {p : Ideal R} [p.IsPrime] {q : Ideal S} [q.IsPrime]
-    {f : R →+* S} (h : p = q.comap f) (hf : f.EssFiniteType) :
-    (Localization.localRingHom p q f h).EssFiniteType :=
-  hf.isLocalizationMap _ _
+lemma holdsForLocalization : HoldsForLocalization EssFiniteType := by
+  introv R _
+  rw [essFiniteType_algebraMap]
+  exact .of_isLocalization _ M
 
 lemma residueFieldMap {f : R →+* S} [IsLocalRing R] [IsLocalRing S] [IsLocalHom f]
     (hf : f.EssFiniteType) :

--- a/Mathlib/RingTheory/RingHom/EssFiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/EssFiniteType.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.RingTheory.EssentialFiniteness
+public import Mathlib.RingTheory.Localization.AtPrime.Basic
+public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
+public import Mathlib.RingTheory.RingHomProperties
+
+/-!
+# Meta properties of essentially of finite type ring homomorphisms
+-/
+
+@[expose] public section
+
+namespace RingHom.EssFiniteType
+
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
+
+lemma comp {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) (hg : g.EssFiniteType) :
+    (g.comp f).EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.comp R S T
+
+lemma comp_iff {f : R →+* S} {g : S →+* T} (hf : f.EssFiniteType) :
+    (g.comp f).EssFiniteType ↔ g.EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.comp_iff R S T
+
+lemma of_comp (f : R →+* S) {g : S →+* T} (h : (g.comp f).EssFiniteType) :
+    g.EssFiniteType := by
+  algebraize [f, g, g.comp f]
+  exact Algebra.EssFiniteType.of_comp R S T
+
+lemma stableUnderComposition : StableUnderComposition EssFiniteType :=
+  fun _ _ _ _ _ _ _ _ hf hg ↦ hf.comp hg
+
+lemma respectsIso : RespectsIso EssFiniteType :=
+  stableUnderComposition.respectsIso fun e ↦ (FiniteType.of_surjective _ e.surjective).essFiniteType
+
+lemma isStableUnderBaseChange : IsStableUnderBaseChange EssFiniteType :=
+  .mk respectsIso fun R S T _ _ _ _ _ h ↦ by
+    rw [essFiniteType_algebraMap] at h ⊢
+    infer_instance
+
+lemma isLocalizationMap {M : Submonoid R} [Algebra R S] [IsLocalization M S]
+    {P : Type*} [CommRing P] {T : Submonoid P} (Q : Type*) [CommRing Q] [Algebra P Q]
+    [IsLocalization T Q] {g : R →+* P} (hy : M ≤ Submonoid.comap g T) (hg : g.EssFiniteType) :
+    (IsLocalization.map (S := S) Q g hy).EssFiniteType := by
+  refine .of_comp (algebraMap R S) ?_
+  rw [IsLocalization.map_comp]
+  refine hg.comp ?_
+  rw [RingHom.essFiniteType_algebraMap]
+  exact .of_isLocalization _ T
+
+lemma localRingHom {p : Ideal R} [p.IsPrime] {q : Ideal S} [q.IsPrime]
+    {f : R →+* S} (h : p = q.comap f) (hf : f.EssFiniteType) :
+    (Localization.localRingHom p q f h).EssFiniteType :=
+  hf.isLocalizationMap _ _
+
+lemma residueFieldMap {f : R →+* S} [IsLocalRing R] [IsLocalRing S] [IsLocalHom f]
+    (hf : f.EssFiniteType) :
+    (IsLocalRing.ResidueField.map f).EssFiniteType := by
+  refine .of_comp (IsLocalRing.residue R) ?_
+  rw [IsLocalRing.ResidueField.map_comp_residue]
+  exact .comp hf (FiniteType.of_surjective _ <| IsLocalRing.residue_surjective).essFiniteType
+
+end RingHom.EssFiniteType


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Is the import increase fine? If not, I can make a new file `RingHom.EssFiniteType`

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
