### PR TITLE
fix: manually normalise Finsupp.lsum universes

### DIFF
--- a/Mathlib/LinearAlgebra/Finsupp/LSum.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LSum.lean
@@ -58,7 +58,21 @@ theorem sum_smul_index_linearMap' [Semiring R] [AddCommMonoid M] [Module R M] [A
 
 end SMul
 
-variable {α : Type*} {M N P : Type*} {R R₂ R₃ : Type*} {S : Type*}
+/-
+α : Type u_1
+M✝ : Type u_2
+N✝ : Type u_3
+P : Type u_4
+R✝ : Type u_5
+R₂ : Type u_6
+R₃ : Type u_7
+S✝ : Type u_8
+-/
+
+universe u_1 u_2 u_3 u_4 u_5 u_6 u_7 u_8
+
+variable {α : Type u_1} {M : Type u_2} {N : Type u_3} {P : Type u_4}
+variable {R : Type u_5} {R₂ : Type u_6} {R₃ : Type u_7} {S : Type u_8}
 variable [Semiring R] [Semiring R₂] [Semiring R₃] [Semiring S]
 variable [AddCommMonoid M] [Module R M]
 variable [AddCommMonoid N] [Module R₂ N]
@@ -94,7 +108,10 @@ variable [Module S N] [SMulCommClass R₂ S N]
 
 See note [bundled maps over different rings] for why separate `R` and `S` semirings are used.
 -/
-def lsum : (α → M →ₛₗ[σ] N) ≃ₗ[S] (α →₀ M) →ₛₗ[σ] N where
+def lsum :
+    LinearEquiv.{u_8, u_8, max u_3 u_2 u_1, max u_3 u_2 u_1} (RingHom.id.{u_8} S)
+      (α → LinearMap.{u_5, u_6, u_2, u_3} σ M N)
+      (LinearMap.{u_5, u_6, max u_2 u_1, u_3} σ (Finsupp.{u_1, u_2} α M) N) where
   toFun F :=
     { toFun := fun d => d.sum fun i => F i
       map_add' := (liftAddHom (α := α) (M := M) (N := N) fun x => (F x).toAddMonoidHom).map_add


### PR DESCRIPTION
WIP.

On `master`, with universes on, the type of `Finsupp.lsum` is `LinearEquiv.{u_8, u_8, max (max u_1 u_2) u_3, max u_3 u_2 u_1} ...`. Note that the same universe appears twice but normalised differently. We change it to `LinearEquiv.{u_8, u_8, max u_3 u_2 u_1, max u_3 u_2 u_1} ...` (by just supplying the universes explicitly). 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
