### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Elements): initially small if functor is (co)representable

### DIFF
--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -306,6 +306,32 @@ end CategoryOfElements
 
 namespace Functor
 
+/-- The initial object in `F.Elements` if `F` is representable. -/
+@[simps]
+def Elements.initialOfRepresentableBy {F : Cᵒᵖ ⥤ Type*} {X : C} (h : F.RepresentableBy X) :
+    F.Elements :=
+  ⟨.op X, h.homEquiv (𝟙 X)⟩
+
+/-- If `F` is represented by `X`, `X` with its universal element is the initial object of
+`F.Elements.` -/
+def Elements.isInitialOfRepresentableBy {F : Cᵒᵖ ⥤ Type*} {X : C} (h : F.RepresentableBy X) :
+    Limits.IsInitial (initialOfRepresentableBy h) :=
+  .ofUniqueHom (fun Y ↦ ⟨h.homEquiv.symm Y.snd |>.op, by simp [← h.homEquiv_comp]⟩) fun Y m ↦ by
+    simp [← m.2, ← h.homEquiv_unop_comp]
+
+/-- The initial object in `F.Elements` if `F` is corepresentable. -/
+@[simps]
+def Elements.initialOfCorepresentableBy {F : C ⥤ Type*} {X : C} (h : F.CorepresentableBy X) :
+    F.Elements :=
+  ⟨X, h.homEquiv (𝟙 X)⟩
+
+/-- If `F` is corepresented by `X`, `X` with its universal element is the initial object of
+`F.Elements.` -/
+def Elements.isInitialOfCorepresentableBy {F : C ⥤ Type*} {X : C} (h : F.CorepresentableBy X) :
+    Limits.IsInitial (initialOfCorepresentableBy h) :=
+  .ofUniqueHom (fun Y ↦ ⟨h.homEquiv.symm Y.snd, by simp [← h.homEquiv_comp]⟩) fun Y m ↦ by
+    simp [← m.2, ← h.homEquiv_comp]
+
 /--
 The initial object in the category of elements for a representable functor. In `isInitial` it is
 shown that this is initial.
@@ -315,13 +341,8 @@ def Elements.initial (A : C) : (yoneda.obj A).Elements :=
 
 /-- Show that `Elements.initial A` is initial in the category of elements for the `yoneda` functor.
 -/
-def Elements.isInitial (A : C) : Limits.IsInitial (Elements.initial A) where
-  desc s := ⟨s.pt.2.op, Category.comp_id _⟩
-  uniq s m _ := by
-    simp_rw [← m.2]
-    dsimp [Elements.initial]
-    simp
-  fac := by rintro s ⟨⟨⟩⟩
+def Elements.isInitial (A : C) : Limits.IsInitial (Elements.initial A) :=
+  isInitialOfRepresentableBy (.yoneda A)
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Limits/Elements.lean
+++ b/Mathlib/CategoryTheory/Limits/Elements.lean
@@ -9,6 +9,7 @@ public import Mathlib.CategoryTheory.Elements
 public import Mathlib.CategoryTheory.Limits.Types.Limits
 public import Mathlib.CategoryTheory.Limits.Creates
 public import Mathlib.CategoryTheory.Limits.Preserves.Limits
+public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 
 /-!
 # Limits in the category of elements
@@ -104,6 +105,16 @@ noncomputable instance : CreatesLimitsOfShape I (π A) where
 
 instance : HasLimitsOfShape I A.Elements :=
   hasLimitsOfShape_of_hasLimitsOfShape_createsLimitsOfShape (π A)
+
+section Initial
+
+instance {F : Cᵒᵖ ⥤ Type*} [F.IsRepresentable] : HasInitial F.Elements :=
+  (Functor.Elements.isInitialOfRepresentableBy F.representableBy).hasInitial
+
+instance {F : C ⥤ Type*} [F.IsCorepresentable] : HasInitial F.Elements :=
+  (Functor.Elements.isInitialOfCorepresentableBy F.corepresentableBy).hasInitial
+
+end Initial
 
 end CategoryOfElements
 

--- a/Mathlib/CategoryTheory/Limits/Elements.lean
+++ b/Mathlib/CategoryTheory/Limits/Elements.lean
@@ -18,6 +18,14 @@ We show that if `C` has limits of shape `I` and `A : C ⥤ Type w` preserves lim
 the category of elements of `A` has limits of shape `I` and the forgetful functor
 `π : A.Elements ⥤ C` creates them.
 
+## Further results
+
+- If `A` is (co)representable, then `A.Elements` has an initial object.
+
+## TODOs
+
+- Show that `A` is (co)representable if `A.Elements` has an initial object.
+
 -/
 
 @[expose] public section

--- a/Mathlib/CategoryTheory/Limits/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Limits/FinallySmall.lean
@@ -81,6 +81,10 @@ theorem finallySmall_of_final_of_essentiallySmall [EssentiallySmall.{w} K] (F : 
   have := finallySmall_of_essentiallySmall K
   finallySmall_of_final_of_finallySmall F
 
+instance [Limits.HasTerminal J] : FinallySmall.{w} J :=
+  have := Functor.final_const_terminal (C := PUnit.{w + 1}) (D := J)
+  .mk' ((Functor.const PUnit.{w + 1}).obj (⊤_ J))
+
 end FinallySmall
 
 section InitiallySmall
@@ -129,6 +133,10 @@ theorem initiallySmall_of_initial_of_essentiallySmall [EssentiallySmall.{w} K]
     (F : K ⥤ J) [Initial F] : InitiallySmall.{w} J :=
   have := initiallySmall_of_essentiallySmall K
   initiallySmall_of_initial_of_initiallySmall F
+
+instance [Limits.HasInitial J] : InitiallySmall.{w} J :=
+  have := Functor.initial_const_initial (C := PUnit.{w + 1}) (D := J)
+  .mk' ((Functor.const PUnit.{w + 1}).obj (⊥_ J))
 
 end InitiallySmall
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -336,9 +336,13 @@ def representableByEquiv {F : Cᵒᵖ ⥤ Type v₁} {Y : C} :
       homEquiv_comp := fun {X X'} f g ↦ congr_fun (e.hom.naturality f.op) g }
 
 /-- `yoneda.obj X` is represented by `X`. -/
-@[simps!]
 protected def RepresentableBy.yoneda (X : C) : (yoneda.obj X).RepresentableBy X :=
   Functor.representableByEquiv.symm (Iso.refl _)
+
+@[simp]
+lemma RepresentableBy.coyoneda_homEquiv (X Y : C) :
+    (RepresentableBy.yoneda X).homEquiv = Equiv.refl (Y ⟶ X) :=
+  rfl
 
 /-- The isomorphism `yoneda.obj Y ≅ F` induced by `e : F.RepresentableBy Y`. -/
 def RepresentableBy.toIso {F : Cᵒᵖ ⥤ Type v₁} {Y : C} (e : F.RepresentableBy Y) :
@@ -357,10 +361,14 @@ def corepresentableByEquiv {F : C ⥤ Type v₁} {X : C} :
       homEquiv_comp := fun {X X'} f g ↦ congr_fun (e.hom.naturality f) g }
 
 /-- `coyoneda.obj X` is represented by `X`. -/
-@[simps!]
 protected def CorepresentableBy.coyoneda (X : Cᵒᵖ) :
     (coyoneda.obj X).CorepresentableBy X.unop :=
   Functor.corepresentableByEquiv.symm (Iso.refl _)
+
+@[simp]
+lemma CorepresentableBy.coyoneda_homEquiv (X : Cᵒᵖ) (Y : C) :
+    (CorepresentableBy.coyoneda X).homEquiv = Equiv.refl (X.unop ⟶ Y) :=
+  rfl
 
 /-- The isomorphism `coyoneda.obj (op X) ≅ F` induced by `e : F.CorepresentableBy X`. -/
 def CorepresentableBy.toIso {F : C ⥤ Type v₁} {X : C} (e : F.CorepresentableBy X) :

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -242,6 +242,11 @@ lemma RepresentableBy.comp_homEquiv_symm {F : Cᵒᵖ ⥤ Type v} {Y : C}
     f ≫ e.homEquiv.symm x = e.homEquiv.symm (F.map f.op x) :=
   e.homEquiv.injective (by simp [homEquiv_comp])
 
+lemma RepresentableBy.homEquiv_unop_comp {F : Cᵒᵖ ⥤ Type*} {Y : C}
+    (h : F.RepresentableBy Y) {X : Cᵒᵖ} {X' : C} (f : Opposite.op X' ⟶ X) (g : X' ⟶ Y) :
+    h.homEquiv (f.unop ≫ g) = F.map f (h.homEquiv g) :=
+  h.homEquiv_comp _ _
+
 /-- If `F ≅ F'`, and `F` is representable, then `F'` is representable. -/
 def RepresentableBy.ofIso {F F' : Cᵒᵖ ⥤ Type v} {Y : C} (e : F.RepresentableBy Y) (e' : F ≅ F') :
     F'.RepresentableBy Y where
@@ -330,6 +335,11 @@ def representableByEquiv {F : Cᵒᵖ ⥤ Type v₁} {Y : C} :
     { homEquiv := (e.app _).toEquiv
       homEquiv_comp := fun {X X'} f g ↦ congr_fun (e.hom.naturality f.op) g }
 
+/-- `yoneda.obj X` is represented by `X`. -/
+@[simps!]
+protected def RepresentableBy.yoneda (X : C) : (yoneda.obj X).RepresentableBy X :=
+  Functor.representableByEquiv.symm (Iso.refl _)
+
 /-- The isomorphism `yoneda.obj Y ≅ F` induced by `e : F.RepresentableBy Y`. -/
 def RepresentableBy.toIso {F : Cᵒᵖ ⥤ Type v₁} {Y : C} (e : F.RepresentableBy Y) :
     yoneda.obj Y ≅ F :=
@@ -345,6 +355,12 @@ def corepresentableByEquiv {F : C ⥤ Type v₁} {X : C} :
   invFun e :=
     { homEquiv := (e.app _).toEquiv
       homEquiv_comp := fun {X X'} f g ↦ congr_fun (e.hom.naturality f) g }
+
+/-- `coyoneda.obj X` is represented by `X`. -/
+@[simps!]
+protected def CorepresentableBy.coyoneda (X : Cᵒᵖ) :
+    (coyoneda.obj X).CorepresentableBy X.unop :=
+  Functor.corepresentableByEquiv.symm (Iso.refl _)
 
 /-- The isomorphism `coyoneda.obj (op X) ≅ F` induced by `e : F.CorepresentableBy X`. -/
 def CorepresentableBy.toIso {F : C ⥤ Type v₁} {X : C} (e : F.CorepresentableBy X) :


### PR DESCRIPTION
We show that `Functor.Elements F` has an initial element if `F` is (co)representable and that categories with initial element are initially small.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
