### PR TITLE
[Merged by Bors] - feat(TangentCone/Pi): drop an unneeded `Finite` assumption

### DIFF
--- a/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
@@ -55,7 +55,7 @@ theorem UniqueDiffWithinAt.univ_pi {s : ∀ i, Set (E i)} {x : ∀ i, E i}
   gcongr
   exact mapsTo_tangentConeAt_pi (fun j _ ↦ (h j).2) |>.image_subset
 
-/-- The finite product of a family of sets of unique differentiability is a set of unique
+/-- The product of a family of sets of unique differentiability is a set of unique
 differentiability. -/
 theorem UniqueDiffOn.univ_pi {s : ∀ i, Set (E i)} (h : ∀ i, UniqueDiffOn 𝕜 (s i)) :
     UniqueDiffOn 𝕜 (Set.pi univ s) :=
@@ -70,7 +70,7 @@ theorem UniqueDiffWithinAt.pi (h : ∀ i ∈ I, UniqueDiffWithinAt 𝕜 (s i) (x
   refine UniqueDiffWithinAt.univ_pi fun i => ?_
   by_cases hi : i ∈ I <;> simp [*, uniqueDiffWithinAt_univ]
 
-/-- The finite product of a family of sets of unique differentiability is a set of unique
+/-- The product of a family of sets of unique differentiability is a set of unique
 differentiability. -/
 theorem UniqueDiffOn.pi (h : ∀ i ∈ I, UniqueDiffOn 𝕜 (s i)) : UniqueDiffOn 𝕜 (Set.pi I s) :=
   fun x hx => UniqueDiffWithinAt.pi fun i hi => h i hi (x i) (hx i hi)

--- a/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
@@ -44,35 +44,33 @@ theorem mapsTo_tangentConeAt_pi [DecidableEq ι] {i : ι} (hi : ∀ j ≠ i, x j
       refine squeeze_zero_norm (fun n => (hcd' n j hj).le) ?_
       exact tendsto_pow_atTop_nhds_zero_of_lt_one one_half_pos.le one_half_lt_one
 
-variable (ι E)
-variable [Finite ι]
-
-theorem UniqueDiffWithinAt.univ_pi (s : ∀ i, Set (E i)) (x : ∀ i, E i)
+theorem UniqueDiffWithinAt.univ_pi {s : ∀ i, Set (E i)} {x : ∀ i, E i}
     (h : ∀ i, UniqueDiffWithinAt 𝕜 (s i) (x i)) : UniqueDiffWithinAt 𝕜 (Set.pi univ s) x := by
   classical
   simp only [uniqueDiffWithinAt_iff, closure_pi_set] at h ⊢
-  refine ⟨(dense_pi univ fun i _ => (h i).1).mono ?_, fun i _ => (h i).2⟩
-  norm_cast
-  simp only [← Submodule.iSup_map_single, iSup_le_iff, LinearMap.map_span, Submodule.span_le,
-    ← mapsTo_iff_image_subset]
-  exact fun i => (mapsTo_tangentConeAt_pi fun j _ => (h j).2).mono Subset.rfl Submodule.subset_span
+  refine ⟨.of_closure <| (dense_pi univ fun i _ ↦ (h i).1).closure.mono ?_, fun i _ => (h i).2⟩
+  simp only [closure_pi_set, ← Submodule.closure_coe_iSup_map_single, Submodule.map_span]
+  gcongr
+  refine iSup_le fun i ↦ ?_
+  gcongr
+  exact mapsTo_tangentConeAt_pi (fun j _ ↦ (h j).2) |>.image_subset
 
-theorem UniqueDiffWithinAt.pi (s : ∀ i, Set (E i)) (x : ∀ i, E i)
-    (I : Set ι) (h : ∀ i ∈ I, UniqueDiffWithinAt 𝕜 (s i) (x i)) :
+/-- The finite product of a family of sets of unique differentiability is a set of unique
+differentiability. -/
+theorem UniqueDiffOn.univ_pi {s : ∀ i, Set (E i)} (h : ∀ i, UniqueDiffOn 𝕜 (s i)) :
+    UniqueDiffOn 𝕜 (Set.pi univ s) :=
+  fun _x hx ↦ .univ_pi fun i ↦ h i _ <| hx i (mem_univ i)
+
+variable {I : Set ι}
+
+theorem UniqueDiffWithinAt.pi (h : ∀ i ∈ I, UniqueDiffWithinAt 𝕜 (s i) (x i)) :
     UniqueDiffWithinAt 𝕜 (Set.pi I s) x := by
   classical
   rw [← Set.univ_pi_piecewise_univ]
-  refine UniqueDiffWithinAt.univ_pi ι E _ _ fun i => ?_
+  refine UniqueDiffWithinAt.univ_pi fun i => ?_
   by_cases hi : i ∈ I <;> simp [*, uniqueDiffWithinAt_univ]
 
 /-- The finite product of a family of sets of unique differentiability is a set of unique
 differentiability. -/
-theorem UniqueDiffOn.pi (s : ∀ i, Set (E i)) (I : Set ι)
-    (h : ∀ i ∈ I, UniqueDiffOn 𝕜 (s i)) : UniqueDiffOn 𝕜 (Set.pi I s) :=
-  fun x hx => UniqueDiffWithinAt.pi _ _ _ _ _ fun i hi => h i hi (x i) (hx i hi)
-
-/-- The finite product of a family of sets of unique differentiability is a set of unique
-differentiability. -/
-theorem UniqueDiffOn.univ_pi (s : ∀ i, Set (E i)) (h : ∀ i, UniqueDiffOn 𝕜 (s i)) :
-    UniqueDiffOn 𝕜 (Set.pi univ s) :=
-  UniqueDiffOn.pi _ _ _ _ fun i _ => h i
+theorem UniqueDiffOn.pi (h : ∀ i ∈ I, UniqueDiffOn 𝕜 (s i)) : UniqueDiffOn 𝕜 (Set.pi I s) :=
+  fun x hx => UniqueDiffWithinAt.pi fun i hi => h i hi (x i) (hx i hi)


### PR DESCRIPTION
Also change some arguments from explicit to implicit.
I have no specific reasons for this generalization.
I've noticed that we can do this while working on generalization to TVS.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

<!-- Message of single commit: -->