### PR TITLE
[Merged by Bors] - feat(CategoryTheory): the yoneda embedding to sheaves preserves disjoint coproducts

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/DisjointCoproduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/DisjointCoproduct.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 public import Mathlib.CategoryTheory.Limits.Shapes.Products
+public import Mathlib.CategoryTheory.Limits.Shapes.StrictInitial
 
 /-!
 # Disjoint coproducts
@@ -120,6 +121,15 @@ noncomputable def ofCoproductDisjointOfIsLimit
     [HasCoproduct X] {s : PullbackCone (Sigma.ι X i) (Sigma.ι X j)} (hs : IsLimit s) :
     IsInitial s.pt :=
   ofCoproductDisjointOfIsColimitOfIsLimit hij (colimit.isColimit _) hs
+
+/-- If `C` has strict initial objects and there is a commutative square `Xᵢ ← Z → Xⱼ`
+over `∐ X`, then `Z` is initial. -/
+noncomputable def ofCoproductDisjointOfCommSq [HasStrictInitialObjects C]
+    {c : Cofan X} (hc : IsColimit c) {Z : C} (fst : Z ⟶ X i) (snd : Z ⟶ X j)
+    (h : fst ≫ c.inj i = snd ≫ c.inj j) [HasPullback (c.inj i) (c.inj j)] :
+    Limits.IsInitial Z :=
+  .ofStrict (pullback.lift fst snd h) <|
+    .ofCoproductDisjointOfIsColimitOfIsLimit hij hc (limit.isLimit _)
 
 end IsInitial
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -651,6 +651,18 @@ theorem sigmaComparison_map_desc [HasCoproduct f] [HasCoproduct fun b => G.obj (
   simp only [ι_comp_sigmaComparison_assoc, ← G.map_comp, colimit.ι_desc,
     Cofan.mk_pt, Cofan.mk_ι_app]
 
+/-- `F.mapCone c` being limiting is the same as the induced fan being limiting. -/
+def Fan.isLimitMapConeEquiv (F : C ⥤ D) {ι : Type*} (X : ι → C) (c : Fan X) :
+    IsLimit (F.mapCone c) ≃ IsLimit (Fan.mk _ fun i ↦ F.map (c.proj i)) :=
+  (IsLimit.postcomposeHomEquiv Discrete.natIsoFunctor (F.mapCone c)).symm.trans <|
+    IsLimit.equivIsoLimit (Cones.ext (Iso.refl _))
+
+/-- `F.mapCocone c` being colimiting is the same as the induced cofan being colimiting. -/
+def Cofan.isColimitMapCoconeEquiv (F : C ⥤ D) {ι : Type*} (X : ι → C) (c : Cofan X) :
+    IsColimit (F.mapCocone c) ≃ IsColimit (Cofan.mk _ fun i ↦ F.map (c.inj i)) :=
+  (IsColimit.precomposeHomEquiv Discrete.natIsoFunctor.symm (F.mapCocone c)).symm.trans <|
+    IsColimit.equivIsoColimit (Cocones.ext (Iso.refl _))
+
 end Comparison
 
 variable (C)

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -1078,6 +1078,12 @@ def natTransOfLe {S T : Sieve X} (h : S ≤ T) : S.functor ⟶ T.functor where a
 @[simps]
 def functorInclusion (S : Sieve X) : S.functor ⟶ yoneda.obj X where app _ f := f.1
 
+/-- Any component `f : Y ⟶ X` of the sieve `S` induces a natural transformation from `yoneda.obj Y`
+to the presheaf induced by `S`. -/
+@[simps]
+def toFunctor (S : Sieve X) {Y : C} (f : Y ⟶ X) (hf : S f) : yoneda.obj Y ⟶ S.functor where
+  app Z g := ⟨g ≫ f, S.downward_closed hf g⟩
+
 theorem natTransOfLe_comm {S T : Sieve X} (h : S ≤ T) :
     natTransOfLe h ≫ functorInclusion _ = functorInclusion _ :=
   rfl

--- a/Mathlib/CategoryTheory/Sites/Subcanonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Subcanonical.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Limits.Preserves.Ulift
 public import Mathlib.CategoryTheory.Sites.Canonical
 public import Mathlib.CategoryTheory.Sites.Whiskering
+public import Mathlib.CategoryTheory.Limits.Shapes.DisjointCoproduct
 /-!
 
 # Subcanonical Grothendieck topologies
@@ -258,5 +259,71 @@ lemma uliftYonedaOpCompCoyoneda_inv_app_app (X : Cᵒᵖ) (F : Sheaf J (Type max
 lemma uliftYonedaOpCompCoyoneda_app_app (X : Cᵒᵖ) (F : Sheaf J (Type (max v v'))) :
     (J.uliftYonedaOpCompCoyoneda.app X).app F = (J.uliftYonedaEquiv.trans Equiv.ulift.symm).toIso :=
   rfl
+
+open Limits
+
+instance preservesLimitsOfShape_yoneda {I : Type*} [Category I] :
+    PreservesLimitsOfShape I J.yoneda :=
+  have : PreservesLimitsOfShape I (J.yoneda ⋙ sheafToPresheaf J _) :=
+    inferInstanceAs <| PreservesLimitsOfShape I CategoryTheory.yoneda
+  preservesLimitsOfShape_of_reflects_of_preserves _ (sheafToPresheaf J _)
+
+/--
+Let `{ Xᵢ ⟶ Y }` be a family of pairwise disjoint maps that form a cover in `J`. Then its
+image under the yoneda embedding to `J`-sheaves is a coproduct.
+-/
+noncomputable def isColimitCofanMkYoneda {ι : Type*} (X : ι → C) {c : Cofan X}
+    (H : (Sieve.ofArrows _ c.inj) ∈ J c.pt) [∀ (i : ι), Mono (c.inj i)]
+    (hempty : (Y : C) → IsInitial Y → ⊥ ∈ J Y)
+    (hdisj : ∀ {i j : ι} (_ : i ≠ j) {Y : C} (a : Y ⟶ X i)
+      (b : Y ⟶ X j), a ≫ c.inj i = b ≫ c.inj j → Nonempty (IsInitial Y)) :
+    IsColimit (Cofan.mk _ fun i ↦ J.yoneda.map (c.inj i)) := by
+  have heq (s : Cofan fun i ↦ J.yoneda.obj (X i))
+      {Y : C} {i j : ι} (a : Y ⟶ X i) (b : Y ⟶ X j) (hab : a ≫ c.inj i = b ≫ c.inj j) :
+      (s.inj i).val.app (op Y) a = (s.inj j).val.app (op Y) b := by
+    by_cases h : i = j
+    · subst h
+      rw [(cancel_mono _).mp hab]
+    · obtain ⟨h⟩ := hdisj h a b hab
+      have := Types.isTerminalEquivUnique _ (Sheaf.isTerminalOfBotCover s.pt _ (hempty Y h))
+      exact Subsingleton.elim _ _
+  refine mkCofanColimit _ (fun s ↦ ⟨?_⟩) (fun s j ↦ ?_) fun s m hm ↦ ?_
+  · refine (s.pt.2.isSheafFor _ H).extend ?_
+    refine ⟨fun Y g ↦ ((s.inj (Sieve.ofArrows.i g.2)).val.app Y) (Sieve.ofArrows.h g.2), ?_⟩
+    intro ⟨Y⟩ ⟨Z⟩ ⟨(g : Z ⟶ Y)⟩
+    ext u
+    dsimp
+    rw [← heq s (g ≫ Sieve.ofArrows.h u.2)
+      (Sieve.ofArrows.h <| Sieve.downward_closed _ u.2 g) (by simp)]
+    exact congrFun ((s.inj _).val.naturality g.op) _
+  · ext : 1
+    let u (j : ι) : CategoryTheory.yoneda.obj (X j) ⟶ (Sieve.ofArrows _ c.inj).functor :=
+      (Sieve.ofArrows _ c.inj).toFunctor (c.inj j) (Sieve.ofArrows_mk _ _ j)
+    have (j : ι) : u j ≫ (Sieve.ofArrows _ c.inj).functorInclusion =
+      CategoryTheory.yoneda.map (c.inj j) := rfl
+    dsimp
+    simp only [← this, Category.assoc, Presieve.IsSheafFor.functorInclusion_comp_extend]
+    ext Z (g : Z.unop ⟶ X j)
+    have h : Sieve.ofArrows X c.inj (g ≫ c.inj j) :=
+      Sieve.downward_closed _ (Sieve.ofArrows_mk _ _ j) _
+    exact heq s (Sieve.ofArrows.h h) g (by simp)
+  · ext : 1
+    dsimp
+    apply Presieve.IsSheafFor.unique_extend
+    ext Y ⟨g, hg⟩
+    simp [← hm (Sieve.ofArrows.i hg)]
+
+/-- If the coproduct inclusions form a covering of `J` and coproducts are disjoint,
+the yoneda embedding to `J`-sheaves preserves coproducts. -/
+lemma preservesColimitsOfShape_yoneda_of_ofArrows_inj_mem {ι : Type*}
+    [CoproductsOfShapeDisjoint C ι] [HasPullbacks C] [HasStrictInitialObjects C]
+    (hcov : ∀ {X : ι → C} {c : Cofan X} (_ : IsColimit c), Sieve.ofArrows X c.inj ∈ J c.pt)
+    (htriv : ∀ (Y : C), IsInitial Y → ⊥ ∈ J Y) :
+    PreservesColimitsOfShape (Discrete ι) J.yoneda := by
+  apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_of_discrete
+  refine fun X ↦ ⟨fun {c : Cofan X} hc ↦ ⟨(Limits.Cofan.isColimitMapCoconeEquiv _ _ _).symm ?_⟩⟩
+  have (i : ι) : Mono (c.inj i) := .of_coproductDisjoint hc _
+  refine isColimitCofanMkYoneda _ _ (hcov hc) htriv fun hij Y a b hab ↦ ⟨?_⟩
+  exact .ofCoproductDisjointOfCommSq hij hc _ _ hab
 
 end CategoryTheory.GrothendieckTopology

--- a/Mathlib/CategoryTheory/Sites/Subcanonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Subcanonical.lean
@@ -262,11 +262,11 @@ lemma uliftYonedaOpCompCoyoneda_app_app (X : Cᵒᵖ) (F : Sheaf J (Type (max v 
 
 open Limits
 
-instance preservesLimitsOfShape_yoneda {I : Type*} [Category I] :
-    PreservesLimitsOfShape I J.yoneda :=
+instance preservesLimitsOfSize_yoneda : PreservesLimitsOfSize J.yoneda := by
+  refine ⟨fun {I} _ ↦ ?_⟩
   have : PreservesLimitsOfShape I (J.yoneda ⋙ sheafToPresheaf J _) :=
     inferInstanceAs <| PreservesLimitsOfShape I CategoryTheory.yoneda
-  preservesLimitsOfShape_of_reflects_of_preserves _ (sheafToPresheaf J _)
+  exact preservesLimitsOfShape_of_reflects_of_preserves _ (sheafToPresheaf J _)
 
 /--
 Let `{ Xᵢ ⟶ Y }` be a family of pairwise disjoint maps that form a cover in `J`. Then its


### PR DESCRIPTION
From Proetale.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
