### PR TITLE
[Merged by Bors] - feat(UniformSpace/Closeds): add `DiscreteUniformity` instances

### DIFF
--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -45,6 +45,10 @@ theorem hausdorffEntourage_mono {U V : SetRel α α} (h : U ⊆ V) :
 theorem monotone_hausdorffEntourage : Monotone (hausdorffEntourage (α := α)) :=
   fun _ _ => hausdorffEntourage_mono
 
+@[simp]
+theorem hausdorffEntourage_id : hausdorffEntourage (.id : SetRel α α) = .id := by
+  simp_rw [hausdorffEntourage, preimage_id, image_id, ← subset_antisymm_iff, SetRel.id]
+
 instance isRefl_hausdorffEntourage (U : SetRel α α) [U.IsRefl] :
     (hausdorffEntourage U).IsRefl :=
   ⟨fun _ => ⟨U.self_subset_preimage _, U.self_subset_image _⟩⟩
@@ -212,6 +216,11 @@ theorem isUniformInducing_closure : IsUniformInducing (closure (X := α)) := by
 theorem nhds_closure (s : Set α) : 𝓝 (closure s) = 𝓝 s := by
   simp_rw +singlePass [isUniformInducing_closure.isInducing.nhds_eq_comap, closure_closure]
 
+instance [DiscreteUniformity α] : DiscreteUniformity (Set α) := by
+  rw [discreteUniformity_iff_setRelId_mem_uniformity]
+  convert Filter.mem_lift' (DiscreteUniformity.relId_mem_uniformity α)
+  rw [hausdorffEntourage_id]
+
 end UniformSpace.hausdorff
 
 /-- When `Set` is equipped with the Hausdorff uniformity, taking the image under a uniformly
@@ -288,6 +297,9 @@ theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBound
     TotallyBounded {F : Closeds α | ↑F ⊆ t} :=
   totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
 
+instance [DiscreteUniformity α] : DiscreteUniformity (Closeds α) :=
+  isUniformEmbedding_coe.discreteUniformity
+
 section T0Space
 
 variable [T0Space α]
@@ -313,6 +325,10 @@ theorem isClosedEmbedding_singleton : Topology.IsClosedEmbedding ({·} : α → 
     rw [← SetLike.coe_injective.preimage_image (s := Set.range ({·})), ← Set.range_comp]
     exact UniformSpace.hausdorff.isClosedEmbedding_singleton.isClosed_range.preimage
       uniformContinuous_coe.continuous
+
+@[simp]
+theorem discreteUniformity_iff : DiscreteUniformity (Closeds α) ↔ DiscreteUniformity α :=
+  ⟨fun _ => isUniformEmbedding_singleton.discreteUniformity, fun _ => inferInstance⟩
 
 end T0Space
 
@@ -432,6 +448,13 @@ theorem _root_.IsUniformEmbedding.compacts_map {f : α → β} (hf : IsUniformEm
   __ := hf.isUniformInducing.compacts_map
   injective := map_injective hf.uniformContinuous.continuous hf.injective
 
+instance [DiscreteUniformity α] : DiscreteUniformity (Compacts α) :=
+  isUniformEmbedding_coe.discreteUniformity
+
+@[simp]
+theorem discreteUniformity_iff : DiscreteUniformity (Compacts α) ↔ DiscreteUniformity α :=
+  ⟨fun _ => isUniformEmbedding_singleton.discreteUniformity, fun _ => inferInstance⟩
+
 end TopologicalSpace.Compacts
 
 namespace TopologicalSpace.NonemptyCompacts
@@ -528,5 +551,12 @@ theorem _root_.IsUniformEmbedding.nonemptyCompacts_map {f : α → β} (hf : IsU
     IsUniformEmbedding (NonemptyCompacts.map f hf.uniformContinuous.continuous) where
   __ := hf.isUniformInducing.nonemptyCompacts_map
   injective := map_injective hf.uniformContinuous.continuous hf.injective
+
+instance [DiscreteUniformity α] : DiscreteUniformity (NonemptyCompacts α) :=
+  isUniformEmbedding_coe.discreteUniformity
+
+@[simp]
+theorem discreteUniformity_iff : DiscreteUniformity (NonemptyCompacts α) ↔ DiscreteUniformity α :=
+  ⟨fun _ => isUniformEmbedding_singleton.discreteUniformity, fun _ => inferInstance⟩
 
 end TopologicalSpace.NonemptyCompacts

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -418,6 +418,12 @@ instance CompleteSpace.sum [CompleteSpace α] [CompleteSpace β] : CompleteSpace
   exact isUniformEmbedding_inl.isUniformInducing.isComplete_range.union
     isUniformEmbedding_inr.isUniformInducing.isComplete_range
 
+theorem IsUniformEmbedding.discreteUniformity [DiscreteUniformity β] {f : α → β}
+    (hf : IsUniformEmbedding f) : DiscreteUniformity α := by
+  simp_rw [discreteUniformity_iff_eq_principal_setRelId, ← hf.comap_uniformity,
+    DiscreteUniformity.eq_principal_setRelId, comap_principal, SetRel.id, preimage_setOf_eq,
+    hf.injective.eq_iff]
+
 end
 
 theorem isUniformEmbedding_comap {α : Type*} {β : Type*} {f : α → β} [u : UniformSpace β]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
