### PR TITLE
[Merged by Bors] - feat(RingTheory/UniqueFactorizationDomain/Defs): irreducible element has one factor

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -206,6 +206,12 @@ theorem exists_mem_factors {x : α} (hx : x ≠ 0) (h : ¬IsUnit x) : ∃ p, p �
   obtain ⟨p, hp, _⟩ := exists_mem_factors_of_dvd hx hp' hp'x
   exact ⟨p, hp⟩
 
+theorem factors_eq_singleton_of_irreducible {a : α} (ha : Irreducible a) :
+    ∃ b, Associated a b ∧ factors a = {b} := by
+  obtain ⟨b, hbmem, hab⟩ := exists_mem_factors_of_dvd ha.ne_zero ha dvd_rfl
+  exact ⟨b, hab, .symm <| Multiset.eq_of_le_of_card_le (Multiset.singleton_le.mpr hbmem)
+    (by rw [card_factors_of_irreducible ha, Multiset.card_singleton])⟩
+
 open Classical in
 theorem factors_mul {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
     Multiset.Rel Associated (factors (x * y)) (factors x + factors y) := by

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -199,4 +199,17 @@ theorem prime_of_factor {a : α} (x : α) (hx : x ∈ factors a) : Prime x := by
 theorem irreducible_of_factor {a : α} : ∀ x : α, x ∈ factors a → Irreducible x := fun x h =>
   (prime_of_factor x h).irreducible
 
+open Multiset in
+theorem card_factors_of_irreducible {a : α} (ha : Irreducible a) : (factors a).card = 1 := by
+  by_cases hf : factors a = 0
+  · simpa [hf, Associated.comm, ha.not_isUnit] using factors_prod ha.ne_zero
+  · obtain ⟨b, hb⟩ := exists_mem_of_ne_zero hf
+    obtain ⟨f, hf⟩ := exists_cons_of_mem hb
+    rw [hf, card_cons, add_eq_right, card_eq_zero, eq_zero_iff_forall_notMem]
+    intro c hc
+    obtain ⟨f, rfl⟩ := exists_cons_of_mem hc
+    replace hb := (irreducible_of_factor b hb).not_isUnit
+    replace hc := (irreducible_of_factor c (hf ▸ mem_cons_of_mem hc)).not_isUnit
+    simp [← (factors_prod ha.ne_zero).irreducible_iff, hf, irreducible_mul_iff, hb, hc] at ha
+
 end UniqueFactorizationMonoid

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Defs.lean
@@ -201,15 +201,16 @@ theorem irreducible_of_factor {a : α} : ∀ x : α, x ∈ factors a → Irreduc
 
 open Multiset in
 theorem card_factors_of_irreducible {a : α} (ha : Irreducible a) : (factors a).card = 1 := by
-  by_cases hf : factors a = 0
-  · simpa [hf, Associated.comm, ha.not_isUnit] using factors_prod ha.ne_zero
-  · obtain ⟨b, hb⟩ := exists_mem_of_ne_zero hf
-    obtain ⟨f, hf⟩ := exists_cons_of_mem hb
-    rw [hf, card_cons, add_eq_right, card_eq_zero, eq_zero_iff_forall_notMem]
-    intro c hc
-    obtain ⟨f, rfl⟩ := exists_cons_of_mem hc
-    replace hb := (irreducible_of_factor b hb).not_isUnit
-    replace hc := (irreducible_of_factor c (hf ▸ mem_cons_of_mem hc)).not_isUnit
-    simp [← (factors_prod ha.ne_zero).irreducible_iff, hf, irreducible_mul_iff, hb, hc] at ha
+  have hf : factors a ≠ 0 := by
+    intro hf
+    simpa [hf, Associated.comm, ha.not_isUnit] using factors_prod ha.ne_zero
+  obtain ⟨b, hb⟩ := exists_mem_of_ne_zero hf
+  obtain ⟨f, hf⟩ := exists_cons_of_mem hb
+  rw [hf, card_cons, add_eq_right, card_eq_zero, eq_zero_iff_forall_notMem]
+  intro c hc
+  obtain ⟨f, rfl⟩ := exists_cons_of_mem hc
+  replace hb := (irreducible_of_factor b hb).not_isUnit
+  replace hc := (irreducible_of_factor c (hf ▸ mem_cons_of_mem hc)).not_isUnit
+  simp [← (factors_prod ha.ne_zero).irreducible_iff, hf, irreducible_mul_iff, hb, hc] at ha
 
 end UniqueFactorizationMonoid


### PR DESCRIPTION
This PR adds a `card_factors_of_irreducible` stating that irreducible elements have `(factors a).card = 1`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
