### PR TITLE
[Merged by Bors] - fix: declaration diff includes private

### DIFF
--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -62,7 +62,7 @@ else
   git diff origin/master...HEAD
 fi |
   ## purge `@[...]`, to attempt to catch declaration names
-  sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==; s=protected ==' |
+  sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==; s=protected ==; s=private ==' |
   ## this sed "splits" `[+-]alias ⟨d1, d2⟩ := d` into
   ## `[+-]alias d1 := d` and `[+-]alias d2 := d`
   sed 's=^\([+-]\)alias ⟨\([^,]*\), *\([^⟩]*\)⟩\(.*\)=\1alias \2\4\n\1alias \3\4=' |
@@ -192,5 +192,6 @@ def testingLongDiff2 im a def
 def testingLongDiff3 im a def
 @[trying to fool you] instance. the messing dot
 alias ⟨d1, d2⟩ := d  check the "split an iff alias"
-abbrev a_new_one := I was not here before
+private abbrev a_new_one := I was not here before, but I was not private
+private abbrev made it private := should be accounted for
 ReferenceTest

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -193,5 +193,5 @@ def testingLongDiff3 im a def
 @[trying to fool you] instance. the messing dot
 alias ⟨d1, d2⟩ := d  check the "split an iff alias"
 private abbrev a_new_one := I was not here before, but I was not private
-private abbrev made it private := should be accounted for
+private abbrev made_it_private := should be accounted for
 ReferenceTest


### PR DESCRIPTION
I noticed this in #34143.  With the advent of the module system, `private` modifiers are more common.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
