### PR TITLE
[Merged by Bors] - feat(MeasureTheory/MeasurableSpace/Constructions): add comap_le_comap_pi lemma

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -568,15 +568,13 @@ theorem measurable_pi_iff {g : α → ∀ a, X a} : Measurable g ↔ ∀ a, Meas
   simp_rw [measurable_iff_comap_le, MeasurableSpace.pi, MeasurableSpace.comap_iSup,
     MeasurableSpace.comap_comp, Function.comp_def, iSup_le_iff]
 
-theorem MeasurableSpace.comap_le_comap_pi {g : ∀ a, β → X a} (a : δ) :
-    MeasurableSpace.comap (g a) inferInstance ≤
-    MeasurableSpace.comap (fun b c ↦ g c b) MeasurableSpace.pi := by
-  rw [MeasurableSpace.pi, MeasurableSpace.comap_iSup]
-  exact le_iSup_of_le a (by measurability)
-
 @[fun_prop]
 theorem measurable_pi_apply (a : δ) : Measurable fun f : ∀ a, X a => f a :=
   measurable_pi_iff.1 measurable_id a
+
+theorem MeasurableSpace.comap_le_comap_pi {g : (a : δ) → β → X a} (a : δ) :
+    .comap (g a) inferInstance ≤ pi.comap (fun b c ↦ g c b) := by
+  simpa only [pi, comap_iSup] using le_iSup_of_le a <| by measurability
 
 theorem Measurable.eval {a : δ} {g : α → ∀ a, X a} (hg : Measurable g) :
     Measurable fun x => g x a :=

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -568,6 +568,12 @@ theorem measurable_pi_iff {g : α → ∀ a, X a} : Measurable g ↔ ∀ a, Meas
   simp_rw [measurable_iff_comap_le, MeasurableSpace.pi, MeasurableSpace.comap_iSup,
     MeasurableSpace.comap_comp, Function.comp_def, iSup_le_iff]
 
+theorem MeasurableSpace.comap_le_comap_pi {g : ∀ a, β → X a} (a : δ) :
+    MeasurableSpace.comap (g a) inferInstance ≤
+    MeasurableSpace.comap (fun b c ↦ g c b) MeasurableSpace.pi := by
+  rw [MeasurableSpace.pi, MeasurableSpace.comap_iSup]
+  exact le_iSup_of_le a (by measurability)
+
 @[fun_prop]
 theorem measurable_pi_apply (a : δ) : Measurable fun f : ∀ a, X a => f a :=
   measurable_pi_iff.1 measurable_id a


### PR DESCRIPTION
---
a useful lemma for a stochastic process `X : T → Ω → E`, which states that for any `t : T` the comap generated by `X t` is smaller than the comap generated by the whole process `t ↦ X t`.

@CoolRmal suggested to write this lemma.
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
