### PR TITLE
[Merged by Bors] - refactor(RingTheory/Spectrum/Prime/Noetherian): generalize finiteness of minimal primes to `CommSemiring`

### DIFF
--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -43,24 +43,10 @@ lemma finite_setOf_isMin :
   exact (minimalPrimes.finite_of_isNoetherianRing R).subset (Set.image_preimage_subset _ _)
 
 lemma _root_.Ideal.finite_minimalPrimes_of_isNoetherianRing (I : Ideal R) :
-    I.minimalPrimes.Finite := by
-  classical
-  obtain ⟨t, ht, ht', hs⟩ :=
-    NoetherianSpace.exists_finset_isClosed_irreducible (isClosed_zeroLocus (I : Set R))
-  suffices ∀ p ∈ I.minimalPrimes, p ∈ t.image vanishingIdeal from
-    (t.image vanishingIdeal).finite_toSet.subset this
-  rintro p ⟨⟨hp, hIp⟩, h⟩
-  have key := isIrreducible_iff_sUnion_isClosed.mp
-    ((isIrreducible_zeroLocus_iff_of_radical p hp.isRadical).mpr hp) t ht
-  rw [← Finset.sup_id_set_eq_sUnion, ← hs] at key
-  obtain ⟨c, hct, hpc⟩ := key (zeroLocus_anti_mono hIp)
-  suffices vanishingIdeal c ≤ p by
-    refine Finset.mem_image.mpr ⟨c, hct, le_antisymm this
-      (h ⟨isIrreducible_iff_vanishingIdeal_isPrime.mp (ht' c hct), ?_⟩ this)⟩
-    rw [← subset_zeroLocus_iff_le_vanishingIdeal, hs]
-    exact Finset.le_sup_of_le hct le_rfl
-  rw [← hp.radical, ← vanishingIdeal_zeroLocus_eq_radical]
-  exact vanishingIdeal_anti_mono hpc
+    I.minimalPrimes.Finite :=
+  Ideal.minimalPrimes.equivIrreducibleComponents I
+    |>.set_finite_iff
+    |>.mpr NoetherianSpace.finite_irreducibleComponents
 
 end IsNoetherianRing
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -25,7 +25,7 @@ open TopologicalSpace
 
 section IsNoetherianRing
 
-variable (R : Type u) [CommRing R] [IsNoetherianRing R]
+variable (R : Type u) [CommSemiring R] [IsNoetherianRing R]
 
 instance : NoetherianSpace (PrimeSpectrum R) :=
   ((noetherianSpace_TFAE <| PrimeSpectrum R).out 0 1).mpr (closedsEmbedding R).dual.wellFoundedLT
@@ -44,9 +44,23 @@ lemma finite_setOf_isMin :
 
 lemma _root_.Ideal.finite_minimalPrimes_of_isNoetherianRing (I : Ideal R) :
     I.minimalPrimes.Finite := by
-  rw [I.minimalPrimes_eq_comap]
-  apply Set.Finite.image
-  apply minimalPrimes.finite_of_isNoetherianRing
+  classical
+  obtain ⟨t, ht, ht', hs⟩ :=
+    NoetherianSpace.exists_finset_isClosed_irreducible (isClosed_zeroLocus (I : Set R))
+  suffices ∀ p ∈ I.minimalPrimes, p ∈ t.image vanishingIdeal from
+    (t.image vanishingIdeal).finite_toSet.subset this
+  rintro p ⟨⟨hp, hIp⟩, h⟩
+  have key := isIrreducible_iff_sUnion_isClosed.mp
+    ((isIrreducible_zeroLocus_iff_of_radical p hp.isRadical).mpr hp) t ht
+  rw [← Finset.sup_id_set_eq_sUnion, ← hs] at key
+  obtain ⟨c, hct, hpc⟩ := key (zeroLocus_anti_mono hIp)
+  suffices vanishingIdeal c ≤ p by
+    refine Finset.mem_image.mpr ⟨c, hct, le_antisymm this
+      (h ⟨isIrreducible_iff_vanishingIdeal_isPrime.mp (ht' c hct), ?_⟩ this)⟩
+    rw [← subset_zeroLocus_iff_le_vanishingIdeal, hs]
+    exact Finset.le_sup_of_le hct le_rfl
+  rw [← hp.radical, ← vanishingIdeal_zeroLocus_eq_radical]
+  exact vanishingIdeal_anti_mono hpc
 
 end IsNoetherianRing
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -281,6 +281,9 @@ instance quasiSober : QuasiSober (PrimeSpectrum R) :=
     ⟨⟨_, isIrreducible_iff_vanishingIdeal_isPrime.1 h₁⟩, by
       rw [IsGenericPoint, closure_singleton, zeroLocus_vanishingIdeal_eq_closure, h₂.closure_eq]⟩⟩
 
+instance (I : Set R) : QuasiSober (zeroLocus I) :=
+  (isClosed_zeroLocus I).isClosedEmbedding_subtypeVal.quasiSober
+
 /-- The prime spectrum of a commutative (semi)ring is a compact topological space. -/
 instance compactSpace : CompactSpace (PrimeSpectrum R) := by
   refine compactSpace_of_finite_subfamily_closed fun S S_closed S_empty ↦ ?_
@@ -889,6 +892,16 @@ protected def pointsEquivIrreducibleCloseds :
   map_rel_iff' {p q} :=
     (RelIso.symm irreducibleSetEquivPoints).map_rel_iff.trans (le_iff_specializes p q).symm
 
+/--
+Zero loci of prime ideals are closed irreducible sets in the Zariski topology and any closed
+irreducible set is a zero locus of some prime ideal.
+-/
+protected def zeroLocusEquivIrreducibleCloseds (I : Set R) :
+    zeroLocus I ≃o (TopologicalSpace.IrreducibleCloseds (zeroLocus I))ᵒᵈ where
+  __ := irreducibleSetEquivPoints.toEquiv.symm.trans OrderDual.toDual
+  map_rel_iff' {p q} := (RelIso.symm irreducibleSetEquivPoints).map_rel_iff.trans
+    ((subtype_specializes_iff p q).trans (le_iff_specializes p.1 q.1).symm)
+
 lemma stableUnderSpecialization_singleton {x : PrimeSpectrum R} :
     StableUnderSpecialization {x} ↔ x.asIdeal.IsMaximal := by
   simp_rw [← isMax_iff, StableUnderSpecialization, ← le_iff_specializes, Set.mem_singleton_iff,
@@ -1130,6 +1143,18 @@ lemma _root_.RingHom.IsIntegral.comap_surjective {f : R →+* S} (hf : f.IsInteg
 alias _root_.RingHom.IsIntegral.specComap_surjective := _root_.RingHom.IsIntegral.comap_surjective
 
 end IsIntegral
+
+/-- Zero loci of minimal prime ideals over `I` are irreducible components in `zeroLocus I` and any
+irreducible component is a zero locus of some minimal prime ideal. -/
+@[stacks 00ES]
+protected def _root_.Ideal.minimalPrimes.equivIrreducibleComponents (I : Ideal R) :
+    I.minimalPrimes ≃o (irreducibleComponents <| (zeroLocus (I : Set R)))ᵒᵈ := by
+  let e : {p : Ideal R | p.IsPrime ∧ I ≤ p} ≃o zeroLocus (I : Set R) :=
+    ⟨⟨fun x ↦ ⟨⟨x.1, x.2.1⟩, x.2.2⟩, fun x ↦ ⟨x.1.1, x.1.2, x.2⟩, fun _ ↦ rfl, fun _ ↦ rfl⟩, .rfl⟩
+  rw [irreducibleComponents_eq_maximals_closed]
+  exact OrderIso.setOfMinimalIsoSetOfMaximal
+    (e.trans ((PrimeSpectrum.zeroLocusEquivIrreducibleCloseds (I : Set R)).trans
+    (TopologicalSpace.IrreducibleCloseds.orderIsoSubtype' (zeroLocus (I : Set R))).dual))
 
 variable (R)
 

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -185,6 +185,12 @@ theorem NoetherianSpace.exists_finset_irreducible [NoetherianSpace α] (s : Clos
   simpa [Set.exists_finite_iff_finset, Finset.sup_id_eq_sSup]
     using NoetherianSpace.exists_finite_set_closeds_irreducible s
 
+theorem NoetherianSpace.exists_finset_isClosed_irreducible [NoetherianSpace α]
+    {s : Set α} (hs : IsClosed s) : ∃ S : Finset (Set α),
+      (∀ c ∈ S, IsClosed c) ∧ (∀ c ∈ S, IsIrreducible c) ∧ s = S.sup id := by
+  obtain ⟨S, hS, _⟩ := NoetherianSpace.exists_finite_set_isClosed_irreducible hs
+  exact ⟨hS.toFinset, by simpa [← Set.sUnion_eq_biUnion]⟩
+
 @[stacks 0052 "(2)"]
 theorem NoetherianSpace.finite_irreducibleComponents [NoetherianSpace α] :
     (irreducibleComponents α).Finite := by

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -185,12 +185,6 @@ theorem NoetherianSpace.exists_finset_irreducible [NoetherianSpace α] (s : Clos
   simpa [Set.exists_finite_iff_finset, Finset.sup_id_eq_sSup]
     using NoetherianSpace.exists_finite_set_closeds_irreducible s
 
-theorem NoetherianSpace.exists_finset_isClosed_irreducible [NoetherianSpace α]
-    {s : Set α} (hs : IsClosed s) : ∃ S : Finset (Set α),
-      (∀ c ∈ S, IsClosed c) ∧ (∀ c ∈ S, IsIrreducible c) ∧ s = S.sup id := by
-  obtain ⟨S, hS, _⟩ := NoetherianSpace.exists_finite_set_isClosed_irreducible hs
-  exact ⟨hS.toFinset, by simpa [← Set.sUnion_eq_biUnion]⟩
-
 @[stacks 0052 "(2)"]
 theorem NoetherianSpace.finite_irreducibleComponents [NoetherianSpace α] :
     (irreducibleComponents α).Finite := by


### PR DESCRIPTION
This PR generalizes finiteness of minimal primes to `CommSemiring` at the cost of duplicating some `PrimeSpectrum` API for `zeroLocus` (since we can no longer pass to the quotient). This will be helpful for follow-up work on associated primes.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
