### PR TITLE
[Merged by Bors] - feat: congruence and similarity are preserved under isometries and dilations

### DIFF
--- a/Mathlib/Topology/MetricSpace/Congruence.lean
+++ b/Mathlib/Topology/MetricSpace/Congruence.lean
@@ -97,16 +97,19 @@ lemma index_map (h : v₁ ≅ v₂) (f : ι' → ι) : (v₁ ∘ f) ≅ (v₂ �
   simpa [(EquivLike.toEquiv f).right_inv i₁, (EquivLike.toEquiv f).right_inv i₂]
     using edist_eq h ((EquivLike.toEquiv f).symm i₁) ((EquivLike.toEquiv f).symm i₂)
 
-lemma comp_isometry {f : P₁ → P₂} (hf : Isometry f) : f ∘ v₁ ≅ v₁ :=
-  fun _ _ ↦ hf _ _
+lemma comp_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ≅ v₂) : f ∘ v₁ ≅ v₂ :=
+  .trans (fun _ _ ↦ hf _ _) h
+
+lemma comp_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ≅ v₂) : v₁ ≅ f ∘ v₂ :=
+  .trans h (.symm <| fun _ _ ↦ hf _ _)
 
 @[simp]
-lemma comp_left_isometry_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ≅ v₂ ↔ v₁ ≅ v₂ :=
-  ⟨(comp_isometry hf).symm.trans, (comp_isometry hf).trans⟩
+lemma comp_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ≅ v₂ ↔ v₁ ≅ v₂ :=
+  ⟨.trans <| .comp_right hf (.refl _), .comp_left hf⟩
 
 @[simp]
-lemma comp_right_isometry_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
-  rw [congruent_comm, comp_left_isometry_iff hf, congruent_comm]
+lemma comp_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
+  rw [congruent_comm, comp_left_iff hf, congruent_comm]
 
 end Congruent
 

--- a/Mathlib/Topology/MetricSpace/Congruence.lean
+++ b/Mathlib/Topology/MetricSpace/Congruence.lean
@@ -6,6 +6,7 @@ Authors: Jovan Gerbscheid, Newell Jensen
 module
 
 public import Mathlib.Topology.MetricSpace.Pseudo.Defs
+public import Mathlib.Topology.MetricSpace.Isometry
 
 /-!
 # Congruences
@@ -95,6 +96,17 @@ lemma index_map (h : v₁ ≅ v₂) (f : ι' → ι) : (v₁ ∘ f) ≅ (v₂ �
   refine ⟨fun h i₁ i₂ ↦ ?_, fun h ↦ index_map h f⟩
   simpa [(EquivLike.toEquiv f).right_inv i₁, (EquivLike.toEquiv f).right_inv i₂]
     using edist_eq h ((EquivLike.toEquiv f).symm i₁) ((EquivLike.toEquiv f).symm i₂)
+
+lemma comp_isometry {f : P₁ → P₂} (hf : Isometry f) : f ∘ v₁ ≅ v₁ :=
+  fun _ _ ↦ hf _ _
+
+@[simp]
+lemma comp_left_isometry_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ≅ v₂ ↔ v₁ ≅ v₂ :=
+  ⟨(comp_isometry hf).symm.trans, (comp_isometry hf).trans⟩
+
+@[simp]
+lemma comp_right_isometry_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
+  rw [congruent_comm, comp_left_isometry_iff hf, congruent_comm]
 
 end Congruent
 

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -113,6 +113,14 @@ lemma index_equiv (f : ι' ≃ ι) (v₁ : ι → P₁) (v₂ : ι → P₂) :
   refine ⟨r, hr, fun i₁ i₂ => ?_⟩
   simpa [f.right_inv i₁, f.right_inv i₂] using h (f.symm i₁) (f.symm i₂)
 
+@[simp]
+lemma comp_left_isometry_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+  ⟨(Congruent.comp_isometry hf).symm.similar.trans, (Congruent.comp_isometry hf).similar.trans⟩
+
+@[simp]
+lemma comp_right_isometry_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
+  rw [similar_comm, comp_left_isometry_iff hf, similar_comm]
+
 section Triangle
 
 variable {a b c : P₁} {a' b' c' : P₂}

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -6,6 +6,7 @@ Authors: Jovan Gerbscheid, Newell Jensen
 module
 
 public import Mathlib.Topology.MetricSpace.Congruence
+public import Mathlib.Topology.MetricSpace.Dilation
 public import Mathlib.Tactic.FinCases
 
 /-!
@@ -113,19 +114,36 @@ lemma index_equiv (f : ι' ≃ ι) (v₁ : ι → P₁) (v₂ : ι → P₂) :
   refine ⟨r, hr, fun i₁ i₂ => ?_⟩
   simpa [f.right_inv i₁, f.right_inv i₂] using h (f.symm i₁) (f.symm i₂)
 
-lemma comp_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
-  ((Congruent.refl _).comp_left hf).similar.trans h
+variable {F}
 
-lemma comp_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
-  h.trans ((Congruent.refl _).comp_right hf).similar
+lemma comp_left [FunLike F P₁ P₃] [DilationClass F P₁ P₃] (f : F) (h : v₁ ∼ v₂) :
+    f ∘ v₁ ∼ v₂ :=
+  .trans ⟨Dilation.ratio f, Dilation.ratio_ne_zero f, fun _ _ => Dilation.edist_eq f _ _⟩ h
+
+lemma comp_right (f : P₂ →ᵈ P₃) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
+  .symm (h.symm.comp_left f)
 
 @[simp]
-lemma comp_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
-  ⟨.trans <| .comp_right hf (.refl _), .comp_left hf⟩
+lemma comp_left_iff (f : P₁ →ᵈ P₃) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+  ⟨.trans <| .comp_right f (.refl _), .comp_left f⟩
 
 @[simp]
-lemma comp_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
-  rw [similar_comm, comp_left_iff hf, similar_comm]
+lemma comp_right_iff (f : P₂ →ᵈ P₃) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
+  rw [similar_comm, comp_left_iff, similar_comm]
+
+lemma comp_isometry_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
+  comp_left hf.toDilation h
+
+lemma comp_isometry_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
+  comp_right hf.toDilation h
+
+@[simp]
+lemma comp_isometry_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+  comp_left_iff hf.toDilation
+
+@[simp]
+lemma comp_isometry_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ :=
+  comp_right_iff hf.toDilation
 
 section Triangle
 

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -113,13 +113,19 @@ lemma index_equiv (f : ι' ≃ ι) (v₁ : ι → P₁) (v₂ : ι → P₂) :
   refine ⟨r, hr, fun i₁ i₂ => ?_⟩
   simpa [f.right_inv i₁, f.right_inv i₂] using h (f.symm i₁) (f.symm i₂)
 
-@[simp]
-lemma comp_left_isometry_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
-  ⟨(Congruent.comp_isometry hf).symm.similar.trans, (Congruent.comp_isometry hf).similar.trans⟩
+lemma comp_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
+  ((Congruent.refl _).comp_left hf).similar.trans h
+
+lemma comp_right {f : P₂ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
+  h.trans ((Congruent.refl _).comp_right hf).similar
 
 @[simp]
-lemma comp_right_isometry_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
-  rw [similar_comm, comp_left_isometry_iff hf, similar_comm]
+lemma comp_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+  ⟨.trans <| .comp_right hf (.refl _), .comp_left hf⟩
+
+@[simp]
+lemma comp_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
+  rw [similar_comm, comp_left_iff hf, similar_comm]
 
 section Triangle
 

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -114,22 +114,36 @@ lemma index_equiv (f : ι' ≃ ι) (v₁ : ι → P₁) (v₂ : ι → P₂) :
   refine ⟨r, hr, fun i₁ i₂ => ?_⟩
   simpa [f.right_inv i₁, f.right_inv i₂] using h (f.symm i₁) (f.symm i₂)
 
+/-! Similarity is preserved under dilations. -/
+
+section Dilation
 variable {F}
 
 lemma comp_left [FunLike F P₁ P₃] [DilationClass F P₁ P₃] (f : F) (h : v₁ ∼ v₂) :
     f ∘ v₁ ∼ v₂ :=
   .trans ⟨Dilation.ratio f, Dilation.ratio_ne_zero f, fun _ _ => Dilation.edist_eq f _ _⟩ h
 
-lemma comp_right (f : P₂ →ᵈ P₃) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
+lemma comp_right [FunLike F P₂ P₃] [DilationClass F P₂ P₃] (f : F) (h : v₁ ∼ v₂) : v₁ ∼ f ∘ v₂ :=
   .symm (h.symm.comp_left f)
 
 @[simp]
-lemma comp_left_iff (f : P₁ →ᵈ P₃) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
+lemma comp_left_iff [FunLike F P₁ P₃] [DilationClass F P₁ P₃] (f : F) : f ∘ v₁ ∼ v₂ ↔ v₁ ∼ v₂ :=
   ⟨.trans <| .comp_right f (.refl _), .comp_left f⟩
 
 @[simp]
-lemma comp_right_iff (f : P₂ →ᵈ P₃) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
+lemma comp_right_iff [FunLike F P₂ P₃] [DilationClass F P₂ P₃] (f : F) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ := by
   rw [similar_comm, comp_left_iff, similar_comm]
+
+end Dilation
+
+/-! Similarity is preserved under isometries.
+
+While these are trivial consequences of the dilation results, they avoid ending up with a
+`toDilation` in the expression, and so are easier to apply to plain functions.
+If `Dilation` were a predicate like `Isometry` then these would not be needed.
+-/
+
+section Isometry
 
 lemma comp_isometry_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ∼ v₂) : f ∘ v₁ ∼ v₂ :=
   comp_left hf.toDilation h
@@ -144,6 +158,8 @@ lemma comp_isometry_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ 
 @[simp]
 lemma comp_isometry_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ∼ f ∘ v₂ ↔ v₁ ∼ v₂ :=
   comp_right_iff hf.toDilation
+
+end Isometry
 
 section Triangle
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
