### PR TITLE
[Merged by Bors] - feat: congruence is preserved under matching dilations

### DIFF
--- a/Mathlib/Topology/MetricSpace/Congruence.lean
+++ b/Mathlib/Topology/MetricSpace/Congruence.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Topology.MetricSpace.Pseudo.Defs
 public import Mathlib.Topology.MetricSpace.Isometry
+public import Mathlib.Topology.MetricSpace.Dilation
 
 /-!
 # Congruences
@@ -31,11 +32,12 @@ For more details see the [Zulip discussion](https://leanprover.zulipchat.com/#na
 
 @[expose] public section
 
-variable {ι ι' : Type*} {P₁ P₂ P₃ : Type*} {v₁ : ι → P₁} {v₂ : ι → P₂} {v₃ : ι → P₃}
+variable {ι ι' : Type*} {P₁ P₂ P₃ P₄ : Type*} {v₁ : ι → P₁} {v₂ : ι → P₂} {v₃ : ι → P₃}
 
 section PseudoEMetricSpace
 
-variable [PseudoEMetricSpace P₁] [PseudoEMetricSpace P₂] [PseudoEMetricSpace P₃]
+variable [PseudoEMetricSpace P₁] [PseudoEMetricSpace P₂]
+variable [PseudoEMetricSpace P₃] [PseudoEMetricSpace P₄]
 
 /-- A congruence between indexed sets of vertices v₁ and v₂.
 Use `open scoped Congruent` to access the `v₁ ≅ v₂` notation. -/
@@ -97,6 +99,11 @@ lemma index_map (h : v₁ ≅ v₂) (f : ι' → ι) : (v₁ ∘ f) ≅ (v₂ �
   simpa [(EquivLike.toEquiv f).right_inv i₁, (EquivLike.toEquiv f).right_inv i₂]
     using edist_eq h ((EquivLike.toEquiv f).symm i₁) ((EquivLike.toEquiv f).symm i₂)
 
+/-- Families with at most a single point are always congruent. -/
+@[nontriviality, simp]
+lemma of_subsingleton_index [Subsingleton ι] : v₁ ≅ v₂ :=
+  fun i j => by simp [Subsingleton.elim i j]
+
 lemma comp_left {f : P₁ → P₃} (hf : Isometry f) (h : v₁ ≅ v₂) : f ∘ v₁ ≅ v₂ :=
   .trans (fun _ _ ↦ hf _ _) h
 
@@ -110,6 +117,13 @@ lemma comp_left_iff {f : P₁ → P₃} (hf : Isometry f) : f ∘ v₁ ≅ v₂ 
 @[simp]
 lemma comp_right_iff {f : P₂ → P₃} (hf : Isometry f) : v₁ ≅ f ∘ v₂ ↔ v₁ ≅ v₂ := by
   rw [congruent_comm, comp_left_iff hf, congruent_comm]
+
+/-- Two sets of vertices remain congruent under a dilation if the dilations have equal ratios. -/
+lemma comp_dilation {F₁ F₂}
+    [FunLike F₁ P₁ P₃] [DilationClass F₁ P₁ P₃] [FunLike F₂ P₂ P₄] [DilationClass F₂ P₂ P₄]
+    {f₁ : F₁} {f₂ : F₂} (h : v₁ ≅ v₂) (hf : Dilation.ratio f₁ = Dilation.ratio f₂) :
+    f₁ ∘ v₁ ≅ f₂ ∘ v₂ :=
+  fun i j => by simp [hf, h i j]
 
 end Congruent
 

--- a/Mathlib/Topology/MetricSpace/Similarity.lean
+++ b/Mathlib/Topology/MetricSpace/Similarity.lean
@@ -114,6 +114,11 @@ lemma index_equiv (f : ι' ≃ ι) (v₁ : ι → P₁) (v₂ : ι → P₂) :
   refine ⟨r, hr, fun i₁ i₂ => ?_⟩
   simpa [f.right_inv i₁, f.right_inv i₂] using h (f.symm i₁) (f.symm i₂)
 
+/-- Families with at most a single point are always similar. -/
+@[nontriviality, simp]
+lemma of_subsingleton_index [Subsingleton ι] : v₁ ∼ v₂ :=
+  Congruent.of_subsingleton_index.similar
+
 /-! Similarity is preserved under dilations. -/
 
 section Dilation


### PR DESCRIPTION
Also some trivialities for subsingleton index types.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
