### PR TITLE
[Merged by Bors] - chore(Tactic/Observe): improve `observe` docstring

### DIFF
--- a/Mathlib/Tactic/Observe.lean
+++ b/Mathlib/Tactic/Observe.lean
@@ -22,7 +22,8 @@ namespace Mathlib.Tactic.LibrarySearch
 
 open Lean Meta Elab Tactic Meta.Tactic.TryThis LibrarySearch
 
-/-- `observe hp : p` asserts the proposition `p`, and tries to prove it using `exact?`.
+/-- `observe hp : p` asserts the proposition `p` as a hypothesis named `hp`, and tries to prove it
+using `exact?`.
 If no proof is found, the tactic fails.
 In other words, this tactic is equivalent to `have hp : p := by exact?`.
 

--- a/Mathlib/Tactic/Observe.lean
+++ b/Mathlib/Tactic/Observe.lean
@@ -26,10 +26,11 @@ open Lean Meta Elab Tactic Meta.Tactic.TryThis LibrarySearch
 If no proof is found, the tactic fails.
 In other words, this tactic is equivalent to `have hp : p := by exact?`.
 
-If `hp` is omitted, then the placeholder `this` is used.
-
-The variant `observe? hp : p` will emit a trace message of the form `have hp : p := proof_term`.
-This may be particularly useful to speed up proofs. -/
+* `observe : p` uses the name `this` for the new hypothesis.
+* `observe? hp : p` will emit a trace message of the form `have hp : p := proof_term`.
+  This may be particularly useful to speed up proofs.
+-/
+-- TODO: the syntax `observe hp : p using e1, e2, ...` exists but does not appear to do anything.
 syntax (name := observe) "observe" "?"? (ppSpace ident)? " : " term
   (" using " (colGt term),+)? : tactic
 


### PR DESCRIPTION
This PR (re)writes the docstring for the `observe` tactic to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long.

It turns out there is the syntax `observe hp : p using e1, e2, ...` which does not seem to do anything. (This syntax has been there since the Lean 3 port.) I left a TODO comment, but we can also drop the syntax altogether.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
