### PR TITLE
[Merged by Bors] - chore(Tactic/NormNum): improve `norm_num`, `norm_num1` and `@[norm_num]` docstrings

### DIFF
--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -27,7 +27,13 @@ public meta section
 open Lean
 open Lean.Meta Qq Lean.Elab Term
 
-/-- Attribute for identifying `norm_num` extensions. -/
+/-- `@[norm_num e]`, where `e` is an expression (optionally with `_`s) adds the tagged definition,
+of type `NormNumExt`, to the set of normalization procedures used by the `norm_num` tactic, such
+that it will fire on expressions matching the form `e`. Use holes in `e` to indicate arbitrary
+subexpressions, for example `@[norm_num _ + _]` will match any addition.
+
+* `@[norm_num e1, e2, ...]` will match either `e1` or `e2` or ...
+-/
 syntax (name := norm_num) "norm_num " term,+ : attr
 
 namespace Mathlib
@@ -259,16 +265,46 @@ namespace Tactic
 open Lean.Parser.Tactic Meta.NormNum
 
 /--
-Normalize numerical expressions. Supports the operations `+` `-` `*` `/` `⁻¹` `^` and `%`
-over numerical types such as `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ` and some general algebraic types,
-and can prove goals of the form `A = B`, `A ≠ B`, `A < B` and `A ≤ B`, where `A` and `B` are
-numerical expressions. It also has a relatively simple primality prover.
+`norm_num` normalizes numerical expressions in the goal. By default, it supports the operations
+`+` `-` `*` `/` `⁻¹` `^` and `%` over `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ` and all types with the appropriate
+algebraic structures. In addition to evaluating numerical expressions, `norm_num` will use `simp`
+to simplify the goal. If the goal has the form `A = B`, `A ≠ B`, `A < B` or `A ≤ B`, where `A` and
+`B` are numerical expressions, `norm_num` will try to close it. It also has a relatively simple
+primality prover.
+
+This tactic is extensible. Extensions can allow `norm_num` to evaluate more kinds of expressions, or
+to prove more kinds of propositions. See the `@[norm_num]` attribute for further information on
+extending `norm_num`.
+
+* `norm_num at l` normalizes at location(s) `l`.
+* `norm_num [h1, ...]` adds the arguments `h1, ...` to the `simp` set in addition to the default
+  `simp` set. All options for `simp` arguments are supported, in particular `←`, `↑` and `↓`.
+* `norm_num only` does not use the default `simp` set for simplification. `norm_num only [h1, ...]`
+  uses only the arguments `h1, ...` in addition to the routines tagged `@[norm_num]`.
+  `norm_num only` still performs post-processing steps, like `simp only`, use `norm_num1` if you
+  exclusively want to normalize numerical expressions.
+* `norm_num (config := cfg)` uses `cfg` as configuration for `simp` calls (see the `simp` tactic for
+  further details).
 -/
 elab (name := normNum)
     "norm_num" cfg:optConfig only:&" only"? args:(simpArgs ?) loc:(location ?) : tactic =>
   elabNormNum cfg args loc (simpOnly := only.isSome) (useSimp := true)
 
-/-- Basic version of `norm_num` that does not call `simp`. -/
+/--
+`norm_num1` normalizes numerical expressions in the goal. It is a basic version of `norm_num`
+that does not call `simp`.
+
+By default, it supports the operations `+` `-` `*` `/` `⁻¹` `^` and `%` over `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`
+and all types with the appropriate algebraic structures. If the goal has the form `A = B`, `A ≠ B`,
+`A < B` or `A ≤ B`, where `A` and `B` are numerical expressions, `norm_num1` will try to close it.
+It also has a relatively simple primality prover.
+
+This tactic is extensible. Extensions can allow `norm_num1` to evaluate more kinds of expressions,
+or to prove more kinds of propositions. See the `@[norm_num]` attribute for further information on
+extending `norm_num1`.
+
+* `norm_num1 at l` normalizes at location(s) `l`.
+-/
 elab (name := normNum1) "norm_num1" loc:(location ?) : tactic =>
   elabNormNum mkNullNode mkNullNode loc (simpOnly := true) (useSimp := false)
 
@@ -289,21 +325,19 @@ open Lean Elab Tactic
   let ctx ← getSimpContext stx[1] stx[3] !stx[2].isNone
   Conv.applySimpResult (← deriveSimp ctx (← instantiateMVars (← Conv.getLhs)) (useSimp := true))
 
-/--
-The basic usage is `#norm_num e`, where `e` is an expression,
-which will print the `norm_num` form of `e`.
-
-Syntax: `#norm_num` (`only`)? (`[` simp lemma list `]`)? `:`? expression
-
-This accepts the same options as the `#simp` command.
-You can specify additional simp lemmas as usual, for example using `#norm_num [f, g] : e`.
-(The colon is optional but helpful for the parser.)
-The `only` restricts `norm_num` to using only the provided lemmas, and so
-`#norm_num only : e` behaves similarly to `norm_num1`.
-
+/-- `#norm_num e`, where `e` is an expression, will print the `norm_num` form of `e`.
 Unlike `norm_num`, this command does not fail when no simplifications are made.
-
 `#norm_num` understands local variables, so you can use them to introduce parameters.
+
+(In the variants below, the `:` is optional but helpful for the parser.)
+
+* `#norm_num [h1, ...] : e` adds the arguments `h1, ...` to the `simp` set in addition to the
+  default `simp` set. All options for `simp` arguments are supported, in particular `←`, `↑`
+  and `↓`.
+* `#norm_num only : e` and `#norm_num only [h1, ...] : e` do not use the default `simp` set for
+  simplification.
+* `#norm_num (config := cfg) : e` uses `cfg` as configuration for `simp` calls (see the `simp`
+  tactic for further details).
 -/
 macro (name := normNumCmd) "#norm_num" cfg:optConfig o:(&" only")?
     args:(Parser.Tactic.simpArgs)? " :"? ppSpace e:term : command =>

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -33,6 +33,15 @@ that it will fire on expressions matching the form `e`. Use holes in `e` to indi
 subexpressions, for example `@[norm_num _ + _]` will match any addition.
 
 * `@[norm_num e1, e2, ...]` will match either `e1` or `e2` or ...
+
+Example:
+```lean
+@[norm_num -_] def evalNeg : NormNumExt where eval {u α} e := do
+  let .app (f : Q($α → $α)) (a : Q($α)) ← whnfR e | failure
+  let ra ← derive a
+  let rα ← inferRing α
+  ra.neg
+```
 -/
 syntax (name := norm_num) "norm_num " term,+ : attr
 
@@ -285,6 +294,12 @@ extending `norm_num`.
   exclusively want to normalize numerical expressions.
 * `norm_num (config := cfg)` uses `cfg` as configuration for `simp` calls (see the `simp` tactic for
   further details).
+
+Examples:
+```lean
+example : 43 ≤ 74 + (33 : ℤ) := by norm_num
+example : ¬ (7-2)/(2*3) ≥ (1:ℝ) + 2/(3^2) := by norm_num
+```
 -/
 elab (name := normNum)
     "norm_num" cfg:optConfig only:&" only"? args:(simpArgs ?) loc:(location ?) : tactic =>
@@ -298,12 +313,18 @@ By default, it supports the operations `+` `-` `*` `/` `⁻¹` `^` and `%` over 
 an `AddMonoidWithOne` instance, such as `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`. If the goal has the form `A = B`,
 `A ≠ B`, `A < B` or `A ≤ B`, where `A` and `B` are numerical expressions, `norm_num1` will try to
 close it. It also has a relatively simple primality prover.
-
+:e
 This tactic is extensible. Extensions can allow `norm_num1` to evaluate more kinds of expressions,
 or to prove more kinds of propositions. See the `@[norm_num]` attribute for further information on
 extending `norm_num1`.
 
 * `norm_num1 at l` normalizes at location(s) `l`.
+
+Examples:
+```lean
+example : 43 ≤ 74 + (33 : ℤ) := by norm_num1
+example : ¬ (7-2)/(2*3) ≥ (1:ℝ) + 2/(3^2) := by norm_num1
+```
 -/
 elab (name := normNum1) "norm_num1" loc:(location ?) : tactic =>
   elabNormNum mkNullNode mkNullNode loc (simpOnly := true) (useSimp := false)

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -266,8 +266,8 @@ open Lean.Parser.Tactic Meta.NormNum
 
 /--
 `norm_num` normalizes numerical expressions in the goal. By default, it supports the operations
-`+` `-` `*` `/` `⁻¹` `^` and `%` over `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ` and all types with the appropriate
-algebraic structures. In addition to evaluating numerical expressions, `norm_num` will use `simp`
+`+` `-` `*` `/` `⁻¹` `^` and `%` over types with (at least) an `AddMonoidWithOne` instance, such as
+`ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`. In addition to evaluating numerical expressions, `norm_num` will use `simp`
 to simplify the goal. If the goal has the form `A = B`, `A ≠ B`, `A < B` or `A ≤ B`, where `A` and
 `B` are numerical expressions, `norm_num` will try to close it. It also has a relatively simple
 primality prover.
@@ -294,10 +294,10 @@ elab (name := normNum)
 `norm_num1` normalizes numerical expressions in the goal. It is a basic version of `norm_num`
 that does not call `simp`.
 
-By default, it supports the operations `+` `-` `*` `/` `⁻¹` `^` and `%` over `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`
-and all types with the appropriate algebraic structures. If the goal has the form `A = B`, `A ≠ B`,
-`A < B` or `A ≤ B`, where `A` and `B` are numerical expressions, `norm_num1` will try to close it.
-It also has a relatively simple primality prover.
+By default, it supports the operations `+` `-` `*` `/` `⁻¹` `^` and `%` over types with (at least)
+an `AddMonoidWithOne` instance, such as `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`. If the goal has the form `A = B`,
+`A ≠ B`, `A < B` or `A ≤ B`, where `A` and `B` are numerical expressions, `norm_num1` will try to
+close it. It also has a relatively simple primality prover.
 
 This tactic is extensible. Extensions can allow `norm_num1` to evaluate more kinds of expressions,
 or to prove more kinds of propositions. See the `@[norm_num]` attribute for further information on


### PR DESCRIPTION
This PR (re)writes the docstring for the `norm_num` and `norm_num1` tactic to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure it is complete while not getting too long. We also rewrite the `@[norm_num]` attribute docstring to explain how to extend the tactic.

I chose to make the `norm_num1` docstring separate from `norm_num` since its syntax and supported features are quite different. We could also choose to merge them (but we also have e.g. `ring1` as its own thing).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
