### PR TITLE
[Merged by Bors] - feat(FieldTheory/Minpoly/IsConjRoot): generalize `IsEquiv` and add small commutativity lemmas

### DIFF
--- a/Mathlib/FieldTheory/Minpoly/IsConjRoot.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsConjRoot.lean
@@ -86,6 +86,9 @@ def setoid : Setoid A where
   r := IsConjRoot R
   iseqv := ⟨fun _ => refl, symm, trans⟩
 
+theorem comm {x y : A} : IsConjRoot R x y ↔ IsConjRoot R y x :=
+  ⟨symm, symm⟩
+
 /--
 Let `p` be the minimal polynomial of `x`. If `y` is a conjugate root of `x`, then `p y = 0`.
 -/
@@ -239,9 +242,9 @@ instance decidable [Normal K L] [DecidableEq L] [Fintype Gal(L/K)] (x y : L) :
     Decidable (IsConjRoot K x y) :=
   decidable_of_iff _ isConjRoot_iff_exists_algEquiv.symm
 
-instance : IsEquiv L (IsConjRoot K) :=
-  letI := IsConjRoot.setoid K L
-  inferInstanceAs <| IsEquiv L (· ≈ ·)
+instance : IsEquiv A (IsConjRoot R) :=
+  letI := IsConjRoot.setoid R A
+  inferInstanceAs <| IsEquiv A (· ≈ ·)
 
 /--
 If `y` is a conjugate root of an integral element `x` over `R`, then `y` is also integral
@@ -250,6 +253,9 @@ over `R`.
 theorem isIntegral {x y : A} (hx : IsIntegral R x) (h : IsConjRoot R x y) :
     IsIntegral R y :=
   ⟨minpoly R x, minpoly.monic hx, h ▸ minpoly.aeval R y⟩
+
+theorem isIntegral_iff {x y : A} (h : IsConjRoot R x y) : IsIntegral R x ↔ IsIntegral R y :=
+  ⟨fun hx ↦ isIntegral hx h, fun hy ↦ isIntegral hy h.symm⟩
 
 /--
 A variant of `IsConjRoot.eq_of_isConjRoot_algebraMap`, only assuming `IsDomain R`,


### PR DESCRIPTION
The signature of `IsConjRoot` is:
```lean
def IsConjRoot (R : Type*) {A : Type*} [CommRing R] [Ring A] [Algebra R A] (x y : A) : Prop
```
and the signature of the `IsEquiv` instance is:
```lean
instance IsConjRoot.instIsEquiv {K L : Type*} [Field K] [Field L] [Algebra K L] : IsEquiv L (IsConjRoot K)
```
This generalizes the instance to `CommRing`+`Ring` like `IsConjRoot` itself.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
