### PR TITLE
[Merged by Bors] - refactor(RingTheory/Spectrum/Prime/Noetherian): move finiteness of minimal primes into a separate file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6057,6 +6057,7 @@ public import Mathlib.RingTheory.Ideal.Maps
 public import Mathlib.RingTheory.Ideal.Maximal
 public import Mathlib.RingTheory.Ideal.MinimalPrime.Basic
 public import Mathlib.RingTheory.Ideal.MinimalPrime.Localization
+public import Mathlib.RingTheory.Ideal.MinimalPrime.Noetherian
 public import Mathlib.RingTheory.Ideal.NatInt
 public import Mathlib.RingTheory.Ideal.Nonunits
 public import Mathlib.RingTheory.Ideal.Norm.AbsNorm

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -477,5 +477,3 @@ lemma Ring.krullDimLE_of_isLocalization_maximal {n : ℕ}
   exact h P
 
 end isLocalization
-
-#min_imports

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -6,8 +6,8 @@ Authors: Wanyi He, Jiedong Jiang, Jingting Wang, Andrew Yang, Shouxin Zhang
 module
 
 public import Mathlib.Algebra.Module.SpanRank
-public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
-public import Mathlib.RingTheory.Ideal.MinimalPrime.Localization
+public import Mathlib.RingTheory.Ideal.MinimalPrime.Noetherian
+public import Mathlib.RingTheory.Spectrum.Prime.Topology
 
 /-!
 # The Height of an Ideal
@@ -477,3 +477,5 @@ lemma Ring.krullDimLE_of_isLocalization_maximal {n : ℕ}
   exact h P
 
 end isLocalization
+
+#min_imports

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -6,8 +6,8 @@ Authors: Wanyi He, Jiedong Jiang, Jingting Wang, Andrew Yang, Shouxin Zhang
 module
 
 public import Mathlib.Algebra.Module.SpanRank
-public import Mathlib.RingTheory.Ideal.MinimalPrime.Noetherian
-public import Mathlib.RingTheory.Spectrum.Prime.Topology
+public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
+public import Mathlib.RingTheory.Ideal.MinimalPrime.Localization
 
 /-!
 # The Height of an Ideal

--- a/Mathlib/RingTheory/Ideal/MinimalPrime/Noetherian.lean
+++ b/Mathlib/RingTheory/Ideal/MinimalPrime/Noetherian.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+
+module
+
+public import Mathlib.RingTheory.Ideal.MinimalPrime.Basic
+public import Mathlib.RingTheory.Noetherian.Defs
+
+/-!
+
+# Finiteness of minimal primes
+
+We prove finiteness of minimal primes above an ideal.
+
+This is proved without reference to `PrimeSpectrum` to avoid heavy imports.
+
+-/
+
+@[expose] public section
+
+variable (R : Type*) [CommSemiring R] [hR : IsNoetherianRing R]
+
+lemma Ideal.finite_minimalPrimes_of_isNoetherianRing (I : Ideal R) :
+    I.minimalPrimes.Finite := by
+  by_contra hI
+  obtain ⟨I : Ideal R, hI : ¬ I.minimalPrimes.Finite, hmax⟩ :=
+    set_has_maximal_iff_noetherian.mpr hR {I : Ideal R | ¬ I.minimalPrimes.Finite} ⟨I, hI⟩
+  simp only [Set.mem_setOf_eq, not_imp_not] at hmax
+  have h1 : ¬ I.IsPrime := by contrapose! hI; simp [minimalPrimes_eq_subsingleton_self]
+  have h2 : I ≠ ⊤ := by contrapose! hI; simp [hI, minimalPrimes_top]
+  obtain ⟨x, hx, y, hy, h⟩ := (not_isPrime_iff.mp h1).resolve_left h2
+  rw [← Ideal.span_singleton_le_iff_mem, ← left_lt_sup] at hx hy
+  refine hI (((hmax _ hx).union (hmax _ hy)).subset fun p ⟨⟨hp, hI⟩, hmin⟩ ↦ ?_)
+  rcases hp.2 (hI h) with hxp | hyp
+  · exact Or.inl ⟨⟨hp, sup_le hI (p.span_singleton_le_iff_mem.mpr hxp)⟩,
+      fun q hq hqp ↦ hmin ⟨hq.1, hx.le.trans hq.2⟩ hqp⟩
+  · exact Or.inr ⟨⟨hp, sup_le hI (p.span_singleton_le_iff_mem.mpr hyp)⟩,
+      fun q hq hqp ↦ hmin ⟨hq.1, hy.le.trans hq.2⟩ hqp⟩
+
+lemma minimalPrimes.finite_of_isNoetherianRing : (minimalPrimes R).Finite :=
+  Ideal.finite_minimalPrimes_of_isNoetherianRing R ⊥

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -71,5 +71,3 @@ lemma _root_.IsArtinianRing.exists_not_mem_forall_mem_of_ne (p : Ideal R) [p.IsP
 end IsArtinianRing
 
 end PrimeSpectrum
-
-#min_imports

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -5,10 +5,9 @@ Authors: Filippo A. E. Nuccio, Andrew Yang
 -/
 module
 
-public import Mathlib.RingTheory.Spectrum.Prime.Topology
-public import Mathlib.RingTheory.Ideal.Quotient.Noetherian
 public import Mathlib.RingTheory.Artinian.Module
-public import Mathlib.Topology.NoetherianSpace
+public import Mathlib.RingTheory.Ideal.MinimalPrime.Noetherian
+public import Mathlib.RingTheory.Spectrum.Prime.Topology
 
 /-!
 This file proves additional properties of the prime spectrum a ring is Noetherian.
@@ -30,23 +29,12 @@ variable (R : Type u) [CommSemiring R] [IsNoetherianRing R]
 instance : NoetherianSpace (PrimeSpectrum R) :=
   ((noetherianSpace_TFAE <| PrimeSpectrum R).out 0 1).mpr (closedsEmbedding R).dual.wellFoundedLT
 
-lemma _root_.minimalPrimes.finite_of_isNoetherianRing : (minimalPrimes R).Finite :=
-  minimalPrimes.equivIrreducibleComponents R
-    |>.set_finite_iff
-    |>.mpr NoetherianSpace.finite_irreducibleComponents
-
 lemma finite_setOf_isMin :
     {x : PrimeSpectrum R | IsMin x}.Finite := by
   have : Function.Injective (asIdeal (R := R)) := @PrimeSpectrum.ext _ _
   refine Set.Finite.of_finite_image (f := asIdeal) ?_ this.injOn
   simp_rw [isMin_iff]
   exact (minimalPrimes.finite_of_isNoetherianRing R).subset (Set.image_preimage_subset _ _)
-
-lemma _root_.Ideal.finite_minimalPrimes_of_isNoetherianRing (I : Ideal R) :
-    I.minimalPrimes.Finite :=
-  Ideal.minimalPrimes.equivIrreducibleComponents I
-    |>.set_finite_iff
-    |>.mpr NoetherianSpace.finite_irreducibleComponents
 
 end IsNoetherianRing
 
@@ -83,3 +71,5 @@ lemma _root_.IsArtinianRing.exists_not_mem_forall_mem_of_ne (p : Ideal R) [p.IsP
 end IsArtinianRing
 
 end PrimeSpectrum
+
+#min_imports

--- a/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Noetherian.lean
@@ -7,7 +7,9 @@ module
 
 public import Mathlib.RingTheory.Artinian.Module
 public import Mathlib.RingTheory.Ideal.MinimalPrime.Noetherian
+public import Mathlib.RingTheory.Ideal.Quotient.Noetherian
 public import Mathlib.RingTheory.Spectrum.Prime.Topology
+public import Mathlib.Topology.NoetherianSpace
 
 /-!
 This file proves additional properties of the prime spectrum a ring is Noetherian.


### PR DESCRIPTION
This PR moves finiteness of minimal primes into a separate file with a more elementary proof that avoids the heavy imports of `PrimeSpectrum`.

The motivation for this was that importing finiteness of minimal primes into `RingTheory/Ideal/AssociatedPrime/Basic` in #34221 was resulting in +50% imports, which is reduced to +7% after this change.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
