### PR TITLE
[Merged by Bors] - refactor: Restrict quiver homs to Type*

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -51,7 +51,7 @@ universe v u
 
 namespace FreeBicategory
 
-variable {B : Type u} [Quiver.{v + 1} B]
+variable {B : Type u} [Quiver.{v} B]
 
 /-- Auxiliary definition for `inclusionPath`. -/
 @[simp]
@@ -69,14 +69,14 @@ local instance homCategory' (a b : B) : Category (Hom a b) :=
 /-- The discrete category on the paths includes into the category of 1-morphisms in the free
 bicategory.
 -/
-def inclusionPath (a b : B) : Discrete (Path.{v + 1} a b) ⥤ Hom a b :=
+def inclusionPath (a b : B) : Discrete (Path.{v} a b) ⥤ Hom a b :=
   Discrete.functor inclusionPathAux
 
 /-- The inclusion from the locally discrete bicategory on the path category into the free bicategory
 as a prelax functor. This will be promoted to a pseudofunctor after proving the coherence theorem.
 See `inclusion`.
 -/
-def preinclusion (B : Type u) [Quiver.{v + 1} B] :
+def preinclusion (B : Type u) [Quiver.{v} B] :
     PrelaxFunctor (LocallyDiscrete (Paths B)) (FreeBicategory B) where
   obj a := a.as
   map {a b} f := (@inclusionPath B _ a.as b.as).obj f
@@ -87,7 +87,7 @@ theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
   rfl
 
 @[simp]
-theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
+theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v} a b)) (η : f ⟶ g) :
     (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) :=
   rfl
 
@@ -181,7 +181,7 @@ theorem normalizeAux_nil_comp {a b c : B} (f : Hom a b) (g : Hom b c) :
   | comp g _ ihf ihg => erw [ihg (f.comp g), ihf f, ihg g, comp_assoc]
 
 /-- The normalization pseudofunctor for the free bicategory on a quiver `B`. -/
-def normalize (B : Type u) [Quiver.{v + 1} B] :
+def normalize (B : Type u) [Quiver.{v} B] :
     FreeBicategory B ⥤ᵖ (LocallyDiscrete (Paths B)) where
   obj a := ⟨a⟩
   map f := ⟨normalizeAux nil f⟩
@@ -200,7 +200,7 @@ def normalizeUnitIso (a b : FreeBicategory B) :
       exact normalize_naturality nil η)
 
 /-- Normalization as an equivalence of categories. -/
-def normalizeEquiv (a b : B) : Hom a b ≌ Discrete (Path.{v + 1} a b) :=
+def normalizeEquiv (a b : B) : Hom a b ≌ Discrete (Path.{v} a b) :=
   Equivalence.mk ((normalize _).mapFunctor a b) (inclusionPath a b) (normalizeUnitIso a b)
     (Discrete.natIso fun f => eqToIso (by
       obtain ⟨f⟩ := f
@@ -227,7 +227,7 @@ def inclusionMapCompAux {a b : B} :
 /-- The inclusion pseudofunctor from the locally discrete bicategory on the path category into the
 free bicategory.
 -/
-def inclusion (B : Type u) [Quiver.{v + 1} B] :
+def inclusion (B : Type u) [Quiver.{v} B] :
     LocallyDiscrete (Paths B) ⥤ᵖ (FreeBicategory B) :=
   { -- All the conditions for 2-morphisms are trivial thanks to the coherence theorem!
     preinclusion B with

--- a/Mathlib/CategoryTheory/Bicategory/Free.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Free.lean
@@ -45,7 +45,7 @@ namespace FreeBicategory
 
 section
 
-variable {B : Type u} [Quiver.{v + 1} B]
+variable {B : Type u} [Quiver.{v} B]
 
 /-- 1-morphisms in the free bicategory. -/
 inductive Hom : B → B → Type max u v
@@ -56,7 +56,7 @@ inductive Hom : B → B → Type max u v
 instance (a b : B) [Inhabited (a ⟶ b)] : Inhabited (Hom a b) :=
   ⟨Hom.of default⟩
 
-instance quiver : Quiver.{max u v + 1} (FreeBicategory B) where
+instance quiver : Quiver.{max u v} (FreeBicategory B) where
   Hom := fun a b : B => Hom a b
 
 set_option linter.style.whitespace false in -- manual alignment is not recognised
@@ -278,7 +278,7 @@ end
 
 section
 
-variable {B : Type u₁} [Quiver.{v₁ + 1} B] {C : Type u₂} [CategoryStruct.{v₂} C]
+variable {B : Type u₁} [Quiver.{v₁} B] {C : Type u₂} [CategoryStruct.{v₂} C]
 variable (F : Prefunctor B C)
 
 /-- Auxiliary definition for `lift`. -/
@@ -301,7 +301,7 @@ end
 
 section
 
-variable {B : Type u₁} [Quiver.{v₁ + 1} B] {C : Type u₂} [Bicategory.{w₂, v₂} C]
+variable {B : Type u₁} [Quiver.{v₁} B] {C : Type u₂} [Bicategory.{w₂, v₂} C]
 variable (F : Prefunctor B C)
 
 /-- Auxiliary definition for `lift`. -/

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
@@ -49,9 +49,9 @@ universe w₁ w₂ w₃ v₁ v₂ v₃ u₁ u₂ u₃
 
 section
 
-variable (B : Type u₁) [Quiver.{v₁ + 1} B] [∀ a b : B, Quiver.{w₁ + 1} (a ⟶ b)]
-variable (C : Type u₂) [Quiver.{v₂ + 1} C] [∀ a b : C, Quiver.{w₂ + 1} (a ⟶ b)]
-variable {D : Type u₃} [Quiver.{v₃ + 1} D] [∀ a b : D, Quiver.{w₃ + 1} (a ⟶ b)]
+variable (B : Type u₁) [Quiver.{v₁} B] [∀ a b : B, Quiver.{w₁} (a ⟶ b)]
+variable (C : Type u₂) [Quiver.{v₂} C] [∀ a b : C, Quiver.{w₂} (a ⟶ b)]
+variable {D : Type u₃} [Quiver.{v₃} D] [∀ a b : D, Quiver.{w₃} (a ⟶ b)]
 
 /-- A `PrelaxFunctorStruct` between bicategories consists of functions between objects,
 1-morphisms, and 2-morphisms. This structure will be extended to define `PrelaxFunctor`.
@@ -80,7 +80,7 @@ def mkOfHomPrefunctors (F : B → C) (F' : (a : B) → (b : B) → Prefunctor (a
 
 /-- The identity lax prefunctor. -/
 @[simps]
-def id (B : Type u₁) [Quiver.{v₁ + 1} B] [∀ a b : B, Quiver.{w₁ + 1} (a ⟶ b)] :
+def id (B : Type u₁) [Quiver.{v₁} B] [∀ a b : B, Quiver.{w₁} (a ⟶ b)] :
     PrelaxFunctorStruct B B :=
   { Prefunctor.id B with map₂ := fun η => η }
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -86,7 +86,7 @@ namespace CategoryTheory
 /-- A preliminary structure on the way to defining a category,
 containing the data, but none of the axioms. -/
 @[pp_with_univ]
-class CategoryStruct (obj : Type u) : Type max u (v + 1) extends Quiver.{v + 1} obj where
+class CategoryStruct (obj : Type u) : Type max u (v + 1) extends Quiver.{v} obj where
   /-- The identity morphism on an object. -/
   id : ∀ X : obj, Hom X X
   /-- Composition of morphisms in a category, written `f ≫ g`. -/

--- a/Mathlib/CategoryTheory/Category/Quiv.lean
+++ b/Mathlib/CategoryTheory/Category/Quiv.lean
@@ -25,17 +25,17 @@ namespace CategoryTheory
 /-- Category of quivers. -/
 @[nolint checkUnivs]
 def Quiv :=
-  Bundled Quiver.{v + 1, u}
+  Bundled Quiver.{v, u}
 
 namespace Quiv
 
 instance : CoeSort Quiv (Type u) where coe := Bundled.α
 
-instance str' (C : Quiv.{v, u}) : Quiver.{v + 1, u} C :=
+instance str' (C : Quiv.{v, u}) : Quiver.{v, u} C :=
   C.str
 
 /-- Construct a bundled `Quiv` from the underlying type and the typeclass. -/
-def of (C : Type u) [Quiver.{v + 1} C] : Quiv.{v, u} :=
+def of (C : Type u) [Quiver.{v} C] : Quiv.{v, u} :=
   Bundled.of C
 
 instance : Inhabited Quiv :=
@@ -64,7 +64,7 @@ end Quiv
 namespace Prefunctor
 
 /-- Prefunctors between quivers define arrows in `Quiv`. -/
-def toQuivHom {C D : Type u} [Quiver.{v + 1} C] [Quiver.{v + 1} D] (F : C ⥤q D) :
+def toQuivHom {C D : Type u} [Quiver.{v} C] [Quiver.{v} D] (F : C ⥤q D) :
     Quiv.of C ⟶ Quiv.of D := F
 
 /-- Arrows in `Quiv` define prefunctors. -/
@@ -99,14 +99,14 @@ theorem freeMap_id (V : Type*) [Quiver V] :
 to equality. -/
 @[simps!]
 def freeMapCompIso {V₁ : Type u₁} {V₂ : Type u₂} {V₃ : Type u₃}
-    [Quiver.{v₁ + 1} V₁] [Quiver.{v₂ + 1} V₂] [Quiver.{v₃ + 1} V₃] (F : V₁ ⥤q V₂) (G : V₂ ⥤q V₃) :
+    [Quiver.{v₁} V₁] [Quiver.{v₂} V₂] [Quiver.{v₃} V₃] (F : V₁ ⥤q V₂) (G : V₂ ⥤q V₃) :
     freeMap (F ⋙q G) ≅ freeMap F ⋙ freeMap G :=
   NatIso.ofComponents (fun _ ↦ Iso.refl _) (fun f ↦ by
     dsimp
     simp only [Category.comp_id, Category.id_comp, Prefunctor.mapPath_comp_apply])
 
 theorem freeMap_comp {V₁ : Type u₁} {V₂ : Type u₂} {V₃ : Type u₃}
-    [Quiver.{v₁ + 1} V₁] [Quiver.{v₂ + 1} V₂] [Quiver.{v₃ + 1} V₃]
+    [Quiver.{v₁} V₁] [Quiver.{v₂} V₂] [Quiver.{v₃} V₃]
     (F : V₁ ⥤q V₂) (G : V₂ ⥤q V₃) :
     freeMap (F ⋙q G) = freeMap F ⋙ freeMap G :=
   Functor.ext_of_iso (freeMapCompIso F G) (fun _ ↦ rfl)
@@ -190,7 +190,7 @@ end
 
 /-- Any prefunctor into a category lifts to a functor from the path category. -/
 @[simps]
-def lift {V : Type u} [Quiver.{v + 1} V] {C : Type u₁} [Category.{v₁} C]
+def lift {V : Type u} [Quiver.{v} V] {C : Type u₁} [Category.{v₁} C]
     (F : Prefunctor V C) : Paths V ⥤ C where
   obj X := F.obj X
   map f := composePath (F.mapPath f)
@@ -211,15 +211,15 @@ theorem pathComposition_naturality {C : Type u} {D : Type u₁}
 /-- Naturality of `Paths.of`, which defines a natural transformation
 ` 𝟭 _⟶ Cat.free ⋙ Quiv.forget`. -/
 lemma pathsOf_freeMap_toPrefunctor
-    {V : Type u} {W : Type u₁} [Quiver.{v + 1} V] [Quiver.{v₁ + 1} W] (F : V ⥤q W) :
+    {V : Type u} {W : Type u₁} [Quiver.{v} V] [Quiver.{v₁} W] (F : V ⥤q W) :
     Paths.of V ⋙q (Cat.freeMap F).toPrefunctor = F ⋙q Paths.of W := rfl
 
 /-- The left triangle identity of `Cat.free ⊣ Quiv.forget` as a natural isomorphism -/
-def freeMapPathsOfCompPathCompositionIso (V : Type u) [Quiver.{v + 1} V] :
+def freeMapPathsOfCompPathCompositionIso (V : Type u) [Quiver.{v} V] :
     Cat.freeMap (Paths.of V) ⋙ pathComposition (Paths V) ≅ 𝟭 (Paths V) :=
   Paths.liftNatIso (fun v ↦ Iso.refl _) (by simp)
 
-lemma freeMap_pathsOf_pathComposition (V : Type u) [Quiver.{v + 1} V] :
+lemma freeMap_pathsOf_pathComposition (V : Type u) [Quiver.{v} V] :
     Cat.freeMap (Paths.of (V := V)) ⋙ pathComposition (Paths V) = 𝟭 (Paths V) :=
   Paths.ext_functor rfl (by simp)
 
@@ -250,7 +250,7 @@ def adj : Cat.free ⊣ Quiv.forget :=
   }
 
 /-- The universal property of the path category of a quiver. -/
-def pathsEquiv {V : Type u} {C : Type u₁} [Quiver.{v + 1} V] [Category.{v₁} C] :
+def pathsEquiv {V : Type u} {C : Type u₁} [Quiver.{v} V] [Category.{v₁} C] :
     (Paths V ⥤ C) ≃ V ⥤q C where
   toFun F := (Paths.of V).comp F.toPrefunctor
   invFun G := Cat.freeMap G ⋙ pathComposition C
@@ -265,7 +265,7 @@ def pathsEquiv {V : Type u} {C : Type u₁} [Quiver.{v + 1} V] [Category.{v₁} 
       pathsOf_pathComposition_toPrefunctor, Prefunctor.comp_id]
 
 @[simp]
-lemma adj_homEquiv {V C : Type u} [Quiver.{max u v + 1} V] [Category.{max u v} C] :
+lemma adj_homEquiv {V C : Type u} [Quiver.{max u v} V] [Category.{max u v} C] :
     adj.homEquiv (Quiv.of V) (Cat.of C) =
       (Cat.Hom.equivFunctor (.of (Paths V)) (.of C)).trans (pathsEquiv (V := V) (C := C)) := rfl
 

--- a/Mathlib/CategoryTheory/Category/ReflQuiv.lean
+++ b/Mathlib/CategoryTheory/Category/ReflQuiv.lean
@@ -24,19 +24,19 @@ universe v u v₁ v₂ u₁ u₂
 /-- Category of refl quivers. -/
 @[nolint checkUnivs]
 def ReflQuiv :=
-  Bundled ReflQuiver.{v + 1, u}
+  Bundled ReflQuiver.{v, u}
 
 namespace ReflQuiv
 
 instance : CoeSort ReflQuiv (Type u) where coe := Bundled.α
 
-instance (C : ReflQuiv.{v, u}) : ReflQuiver.{v + 1, u} C := C.str
+instance (C : ReflQuiv.{v, u}) : ReflQuiver.{v, u} C := C.str
 
 /-- The underlying quiver of a reflexive quiver -/
 def toQuiv (C : ReflQuiv.{v, u}) : Quiv.{v, u} := Quiv.of C.α
 
 /-- Construct a bundled `ReflQuiv` from the underlying type and the typeclass. -/
-def of (C : Type u) [ReflQuiver.{v + 1} C] : ReflQuiv.{v, u} := Bundled.of C
+def of (C : Type u) [ReflQuiver.{v} C] : ReflQuiv.{v, u} := Bundled.of C
 
 instance : Inhabited ReflQuiv := ⟨ReflQuiv.of (Discrete default)⟩
 
@@ -348,7 +348,7 @@ lemma freeReflMap_map {v w : V} (f : v ⟶ w) :
     (freeReflMap F).map (FreeRefl.homMk f) = FreeRefl.homMk (F.map f) := rfl
 
 theorem freeReflMap_naturality
-    {V W : Type*} [ReflQuiver.{v₁ + 1} V] [ReflQuiver.{v₂ + 1} W] (F : V ⥤rq W) :
+    {V W : Type*} [ReflQuiver.{v₁} V] [ReflQuiver.{v₂} W] (F : V ⥤rq W) :
     FreeRefl.quotientFunctor V ⋙ freeReflMap F =
     freeMap F.toPrefunctor ⋙ FreeRefl.quotientFunctor W :=
   Paths.ext_functor rfl (by cat_disch)
@@ -417,12 +417,12 @@ lemma adj_counit_app (D : Type u) [Category.{max u v} D] :
 variable {V : Type*} [ReflQuiver V]
   {C : Type*} [Category* C]
 
-lemma adj_homEquiv (V : Type u) [ReflQuiver.{max u v + 1} V] (C : Type u) [Category.{max u v} C] :
+lemma adj_homEquiv (V : Type u) [ReflQuiver.{max u v} V] (C : Type u) [Category.{max u v} C] :
     (adj).homEquiv (.of V) (.of C) = (Cat.Hom.equivFunctor _ _).trans adj.homEquiv := by
   ext F
   apply Adjunction.homEquiv_unit
 
-lemma adj.unit.map_app_eq (V : Type u) [ReflQuiver.{max u v + 1} V] :
+lemma adj.unit.map_app_eq (V : Type u) [ReflQuiver.{max u v} V] :
     (adj.unit.app (.of V)).toPrefunctor = Quiv.adj.unit.app (.of V) ⋙q
       (Cat.FreeRefl.quotientFunctor V).toPrefunctor := rfl
 

--- a/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/FreeGroupoid.lean
@@ -42,7 +42,7 @@ open CategoryTheory
 
 universe u v u' v' u'' v''
 
-variable {V : Type u} [Quiver.{v + 1} V]
+variable {V : Type u} [Quiver.{v} V]
 
 /-- Shorthand for the "forward" arrow corresponding to `f` in `paths <| symmetrify V` -/
 abbrev Hom.toPosPath {X Y : V} (f : X ⟶ Y) :
@@ -178,7 +178,7 @@ section Functoriality
 
 open FreeGroupoid
 
-variable {V' : Type u'} [Quiver.{v' + 1} V'] {V'' : Type u''} [Quiver.{v'' + 1} V'']
+variable {V' : Type u'} [Quiver.{v'} V'] {V'' : Type u''} [Quiver.{v''} V'']
 
 /-- The functor of free groupoid induced by a prefunctor of quivers -/
 def freeGroupoidFunctor (φ : V ⥤q V') : Quiver.FreeGroupoid V ⥤ Quiver.FreeGroupoid V' :=

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -37,7 +37,7 @@ instance (V : Type u₁) [Inhabited V] : Inhabited (Paths V) := ⟨(default : V)
 instance (V : Type u₁) [Unique V] : Unique (Paths V) where
   uniq _ := Subsingleton.elim (α := V) _ _
 
-variable (V : Type u₁) [Quiver.{v₁ + 1} V]
+variable (V : Type u₁) [Quiver.{v₁} V]
 
 namespace Paths
 
@@ -185,7 +185,7 @@ theorem ext_functor {C} [Category* C] {F G : Paths V ⥤ C} (h_obj : F.obj = G.o
 
 end Paths
 
-variable (W : Type u₂) [Quiver.{v₂ + 1} W]
+variable (W : Type u₂) [Quiver.{v₂} W]
 
 -- A restatement of `Prefunctor.mapPath_comp` using `f ≫ g` instead of `f.comp g`.
 @[simp]

--- a/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
@@ -23,7 +23,7 @@ universe v₁ u₁
 namespace CategoryTheory.Paths
 
 section
-variable (V : Type u₁) [Quiver.{v₁ + 1} V]
+variable (V : Type u₁) [Quiver.{v₁} V]
 
 /-- A reformulation of `CategoryTheory.Paths.induction` in terms of `MorphismProperty`. -/
 lemma morphismProperty_eq_top
@@ -54,7 +54,7 @@ lemma morphismProperty_eq_top_of_isMultiplicative (P : MorphismProperty (Paths V
 end
 section
 
-variable {C : Type*} [Category* C] {V : Type u₁} [Quiver.{v₁ + 1} V]
+variable {C : Type*} [Category* C] {V : Type u₁} [Quiver.{v₁} V]
 
 /-- A natural transformation between `F G : Paths V ⥤ C` is defined by its components and
 its unary naturality squares. -/

--- a/Mathlib/Combinatorics/Quiver/Arborescence.lean
+++ b/Mathlib/Combinatorics/Quiver/Arborescence.lean
@@ -101,7 +101,7 @@ attribute [instance] RootedConnected.nonempty_path
 
 section GeodesicSubtree
 
-variable {V : Type u} [Quiver.{v + 1} V] (r : V) [RootedConnected r]
+variable {V : Type u} [Quiver.{v} V] (r : V) [RootedConnected r]
 
 /-- A path from `r` of minimal length. -/
 noncomputable def shortestPath (b : V) : Path r b :=

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -13,15 +13,8 @@ public import Mathlib.Tactic.ToDual
 
 This module defines quivers. A quiver on a type `V` of vertices assigns to every
 pair `a b : V` of vertices a type `a ⟶ b` of arrows from `a` to `b`. This
-is a very permissive notion of directed graph.
+is a generalization of `Digraph V`, which can be thought of as "a proposition `a ⟶ b` of arrows".
 
-## Implementation notes
-
-Currently `Quiver` is defined with `Hom : V → V → Sort v`.
-This is different from the category theory setup,
-where we insist that morphisms live in some `Type`.
-There's some balance here: it's nice to allow `Prop` to ensure there are no multiple arrows,
-but it also results in error-prone universe signatures when constraints require a `Type`.
 -/
 
 @[expose] public section
@@ -33,18 +26,18 @@ open Opposite
 universe v v₁ v₂ u u₁ u₂
 
 /-- A quiver `G` on a type `V` of vertices assigns to every pair `a b : V` of vertices
-a type `a ⟶ b` of arrows from `a` to `b`.
+a type `a ⟶ b` of arrows from `a` to `b`. This is hence a form of directed multigraphs.
 
-For graphs with no repeated edges, one can use `Quiver.{0} V`, which ensures
-`a ⟶ b : Prop`. For multigraphs, one can use `Quiver.{v+1} V`, which ensures
-`a ⟶ b : Type v`.
+For graphs with no repeated edges, one can either use `Quiver.IsThin` to demand
+that the hom sets are subsingletons, or `Digraph V` (where the hom sets
+are Prop-valued).
 
 Because `Category` will later extend this class, we call the field `Hom`.
 Except when constructing instances, you should rarely see this, and use the `⟶` notation instead.
 -/
 class Quiver (V : Type u) where
   /-- The type of edges/arrows/morphisms between a given source and target. -/
-  Hom : V → V → Sort v
+  Hom : V → V → Type v
 
 attribute [to_dual self (reorder := 3 4)] Quiver.Hom
 

--- a/Mathlib/Combinatorics/Quiver/Cast.lean
+++ b/Mathlib/Combinatorics/Quiver/Cast.lean
@@ -22,7 +22,7 @@ rewriting arrows and paths along equalities of their endpoints.
 
 universe v v₁ v₂ u u₁ u₂
 
-variable {U : Type*} [Quiver.{u + 1} U]
+variable {U : Type*} [Quiver.{u} U]
 
 
 namespace Quiver

--- a/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
+++ b/Mathlib/Combinatorics/Quiver/ConnectedComponent.lean
@@ -32,7 +32,7 @@ universe v u
 
 namespace Quiver
 
-variable (V : Type*) [Quiver.{u + 1} V]
+variable (V : Type*) [Quiver.{u} V]
 
 /-- Two vertices are related in the zigzag setoid if there is a
 zigzag of arrows from one to the other. -/

--- a/Mathlib/Combinatorics/Quiver/Covering.lean
+++ b/Mathlib/Combinatorics/Quiver/Covering.lean
@@ -50,8 +50,8 @@ open Function Quiver
 
 universe u v w
 
-variable {U : Type _} [Quiver.{u + 1} U] {V : Type _} [Quiver.{v + 1} V] (φ : U ⥤q V) {W : Type _}
-  [Quiver.{w + 1} W] (ψ : V ⥤q W)
+variable {U : Type _} [Quiver.{u} U] {V : Type _} [Quiver.{v} V] (φ : U ⥤q V) {W : Type _}
+  [Quiver.{w} W] (ψ : V ⥤q W)
 
 /-- The `Quiver.Star` at a vertex is the collection of arrows whose source is the vertex.
 The type `Quiver.Star u` is defined to be `Σ (v : U), (u ⟶ v)`. -/

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -25,7 +25,7 @@ universe v v₁ v₂ v₃ u u₁ u₂ u₃
 namespace Quiver
 
 /-- `Path a b` is the type of paths from `a` to `b` through the arrows of `G`. -/
-inductive Path {V : Type u} [Quiver.{v} V] (a : V) : V → Sort max (u + 1) v
+inductive Path {V : Type u} [Quiver.{v} V] (a : V) : V → Type max u v
   | nil : Path a a
   | cons : ∀ {b c : V}, Path a b → (b ⟶ c) → Path a c
 

--- a/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
+++ b/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
@@ -28,7 +28,7 @@ universe v v₁ v₂ u u₁ u₂
 type of objects. We denote these arrows by `id` since categories can be understood as an extension
 of refl quivers.
 -/
-class ReflQuiver (obj : Type u) : Type max u v extends Quiver.{v} obj where
+class ReflQuiver (obj : Type u) : Type max u (v + 1) extends Quiver.{v} obj where
   /-- The identity morphism on an object. -/
   id : ∀ X : obj, Hom X X
 
@@ -39,7 +39,7 @@ scoped notation "𝟙rq" => ReflQuiver.id  -- type as \b1
 theorem ReflQuiver.homOfEq_id {V : Type*} [ReflQuiver V] {X X' : V} (hX : X = X') :
     Quiver.homOfEq (𝟙rq X) hX hX = 𝟙rq X' := by subst hX; rfl
 
-instance catToReflQuiver {C : Type u} [inst : Category.{v} C] : ReflQuiver.{v + 1, u} C :=
+instance catToReflQuiver {C : Type u} [inst : Category.{v} C] : ReflQuiver.{v, u} C :=
   { inst with }
 
 @[simp] theorem ReflQuiver.id_eq_id {C : Type*} [Category* C] (X : C) : 𝟙rq X = 𝟙 X := rfl
@@ -159,7 +159,7 @@ open Opposite
 instance opposite {V} [ReflQuiver V] : ReflQuiver Vᵒᵖ where
   id X := op (𝟙rq X.unop)
 
-instance discreteReflQuiver (V : Type u) : ReflQuiver.{u + 1} (Discrete V) :=
+instance discreteReflQuiver (V : Type u) : ReflQuiver.{u} (Discrete V) :=
   { discreteCategory V with }
 
 end ReflQuiver

--- a/Mathlib/Combinatorics/Quiver/Subquiver.lean
+++ b/Mathlib/Combinatorics/Quiver/Subquiver.lean
@@ -23,9 +23,8 @@ universe v u
 /--
 A wide subquiver `H` of `G` picks out a set `H a b` of arrows from `a` to `b`
 for every pair of vertices `a b`.
-
-NB: this does not work for `Prop`-valued quivers. It requires `G : Quiver.{v+1} V`. -/
-def WideSubquiver (V) [Quiver.{v + 1} V] :=
+-/
+def WideSubquiver (V) [Quiver.{v} V] :=
   ∀ a b : V, Set (a ⟶ b)
 
 /-- A type synonym for `V`, when thought of as a quiver having only the arrows from
@@ -55,7 +54,7 @@ noncomputable instance {V} [Quiver V] : Inhabited (WideSubquiver V) :=
 -- TODO Unify with `CategoryTheory.Arrow`? (The fields have been named to match.)
 /-- `Total V` is the type of _all_ arrows of `V`. -/
 @[ext]
-structure Total (V : Type u) [Quiver.{v} V] : Sort max (u + 1) v where
+structure Total (V : Type u) [Quiver.{v} V] : Type (max u v) where
   /-- the source vertex of an arrow -/
   left : V
   /-- the target vertex of an arrow -/

--- a/Mathlib/Combinatorics/Quiver/Subquiver.lean
+++ b/Mathlib/Combinatorics/Quiver/Subquiver.lean
@@ -54,7 +54,7 @@ noncomputable instance {V} [Quiver V] : Inhabited (WideSubquiver V) :=
 -- TODO Unify with `CategoryTheory.Arrow`? (The fields have been named to match.)
 /-- `Total V` is the type of _all_ arrows of `V`. -/
 @[ext]
-structure Total (V : Type u) [Quiver.{v} V] : Type (max u v) where
+structure Total (V : Type u) [Quiver.{v} V] : Type max u v where
   /-- the source vertex of an arrow -/
   left : V
   /-- the target vertex of an arrow -/

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -29,13 +29,13 @@ universe v u w v'
 namespace Quiver
 
 /-- A type synonym for the symmetrized quiver (with an arrow both ways for each original arrow).
-    NB: this does not work for `Prop`-valued quivers. It requires `[Quiver.{v+1} V]`. -/
+-/
 def Symmetrify (V : Type*) := V
 
 instance symmetrifyQuiver (V : Type u) [Quiver V] : Quiver (Symmetrify V) :=
   ⟨fun a b : V ↦ (a ⟶ b) ⊕ (b ⟶ a)⟩
 
-variable (U V W : Type*) [Quiver.{u + 1} U] [Quiver.{v + 1} V] [Quiver.{w + 1} W]
+variable (U V W : Type*) [Quiver.{u} U] [Quiver.{v} V] [Quiver.{w} W]
 
 /-- A quiver `HasReverse` if we can reverse an arrow `p` from `a` to `b` to get an arrow
     `p.reverse` from `b` to `a`. -/
@@ -44,7 +44,7 @@ class HasReverse where
   reverse' : ∀ {a b : V}, (a ⟶ b) → (b ⟶ a)
 
 /-- Reverse the direction of an arrow. -/
-def reverse {V} [Quiver.{v + 1} V] [HasReverse V] {a b : V} : (a ⟶ b) → (b ⟶ a) :=
+def reverse {V} [Quiver.{v} V] [HasReverse V] {a b : V} : (a ⟶ b) → (b ⟶ a) :=
   HasReverse.reverse'
 
 /-- A quiver `HasInvolutiveReverse` if reversing twice is the identity. -/
@@ -157,7 +157,7 @@ def of : Prefunctor V (Symmetrify V) where
   obj := id
   map := Sum.inl
 
-variable {V' : Type*} [Quiver.{v' + 1} V']
+variable {V' : Type*} [Quiver.{v'} V']
 
 /-- Given a quiver `V'` with reversible arrows, a prefunctor to `V'` can be lifted to one from
     `Symmetrify V` to `V'` -/

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -75,7 +75,7 @@ A groupoid `G` is free when we have the following data:
 This definition is nonstandard. Normally one would require that functors `G ⥤ X`
 to any _groupoid_ `X` are given by graph homomorphisms from `generators`. -/
 class IsFreeGroupoid (G) [Groupoid.{v} G] where
-  quiverGenerators : Quiver.{v + 1} (IsFreeGroupoid.Generators G)
+  quiverGenerators : Quiver.{v} (IsFreeGroupoid.Generators G)
   of : ∀ {a b : IsFreeGroupoid.Generators G}, (a ⟶ b) → ((show G from a) ⟶ b)
   unique_lift :
     ∀ {X : Type v} [Group X] (f : Labelling (IsFreeGroupoid.Generators G) X),

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -50,6 +50,11 @@ Throughout we work over a `LinearOrderedRing R`. Some results require stronger a
 like `PosMulStrictMono R` or `Nontrivial R`. Some statements expand matrix powers and thus require
 `[DecidableEq n]` to reason about finite sums.
 
+## TODO
+
+Refactor to use digraphs instead of quivers. A prerequisite for this refactor
+is paths in digraphs.
+
 ## References
 
 * [E. Seneta, *Non-negative Matrices and Markov Chains*][seneta2006]

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -69,7 +69,7 @@ variable {n R : Type*} [Ring R] [LinearOrder R]
 /-- The directed graph (quiver) associated with a matrix `A`,
 with an edge `i ⟶ j` iff `0 < A i j`. -/
 def toQuiver (A : Matrix n n R) : Quiver n :=
-  ⟨fun i j => 0 < A i j⟩
+  ⟨fun i j => PLift (0 < A i j)⟩
 
 /-- A matrix `A` is irreducible if it is entrywise nonnegative and
 its quiver of positive entries (`toQuiver A`) is strongly connected. -/
@@ -92,7 +92,7 @@ lemma IsIrreducible.exists_pos [Nontrivial n]
   letI : Quiver n := toQuiver A
   by_contra h_row
   have no_out : ∀ j : n, IsEmpty (i ⟶ j) :=
-    fun j => ⟨fun e => h_row ⟨j, e⟩⟩
+    fun j => ⟨fun e => h_row ⟨j, e.down⟩⟩
   obtain ⟨j, hij⟩ := exists_pair_ne n
   obtain ⟨p, hp_pos⟩ := h_irr.connected i j
   have h_le : 1 ≤ p.length := Nat.succ_le_of_lt hp_pos
@@ -133,7 +133,7 @@ theorem pow_apply_pos_iff_nonempty_path
       have h_Am : 0 < (A ^ m) i l := by by_contra! h; simp [le_antisymm h hAm_nonneg] at hl_pos
       have h_A : 0 < A l j := by by_contra! h; simp [le_antisymm h hA_nonneg'] at hl_pos
       obtain ⟨⟨p, rfl⟩⟩ := (ih i l).mp h_Am
-      exact ⟨p.cons h_A, by simp⟩
+      exact ⟨p.cons (PLift.up h_A), by simp⟩
     · rintro ⟨p, hp_len⟩
       cases p with
       | nil => simp [Quiver.Path.length] at hp_len
@@ -141,7 +141,7 @@ theorem pow_apply_pos_iff_nonempty_path
         simp only [Quiver.Path.length_cons, Nat.succ.injEq] at hp_len
         have h_Am_pos : 0 < (A ^ m) i b := (ih i b).mpr ⟨q, hp_len⟩
         let h_A_pos := e
-        have h_prod : 0 < (A ^ m) i b * A b j := mul_pos h_Am_pos h_A_pos
+        have h_prod : 0 < (A ^ m) i b * A b j := mul_pos h_Am_pos h_A_pos.down
         exact
           (Finset.sum_pos_iff_of_nonneg
             (fun x _ => mul_nonneg (pow_apply_nonneg hA m i x) (hA x j))).2
@@ -190,10 +190,10 @@ def transposePath {i j : n} (p : @Quiver.Path n A.toQuiver i j) :
   | nil =>
     exact (@Quiver.Path.nil _ (toQuiver Aᵀ) _)
   | @cons b c q e ih =>
-    have eT : @Quiver.Hom n (toQuiver Aᵀ) c b := by
-      change 0 < (Aᵀ) c b
-      simpa [Matrix.transpose_apply] using e
-    exact (@Quiver.Path.comp n (toQuiver Aᵀ) c b i (@Quiver.Hom.toPath n (toQuiver Aᵀ) c b eT) ih)
+    have eT : 0 < (Aᵀ) c b := by
+      simpa [Matrix.transpose_apply] using e.down
+    exact (@Quiver.Path.comp n (toQuiver Aᵀ) c b i (@Quiver.Hom.toPath n (toQuiver Aᵀ) c b
+      (PLift.up eT)) ih)
 
 /-- Irreducibility is invariant under transpose. -/
 theorem IsIrreducible.transpose (hA : IsIrreducible A) : IsIrreducible Aᵀ := by


### PR DESCRIPTION
The current definition of `Quiver`  allows morphisms to be in `Prop`. The docstring explicitly mentions that if you want to use Props as morphisms, you can do this with `Quiver.{0}`. But in fact there are only two occurrences of the string `Quiver.{0}` in mathlib, one in the docstring of `Quiver`, and one in the docstring of `Digraph` explaining why `Quiver.{0}` was not suitable for digraphs (because `Quiver` is a class); the definition of `Digraph` is precisely `Quiver.{0}` but as a structure. In contrast, there are many many occurrences of `Quiver.{v + 1}` in mathlib, all of which can be removed with this refactor.

It turns out that there is actually one `Quiver.{0}` in Mathlib: `Matrix.toQuiver` associates a Prop-valued quiver to a matrix with entries in a linearly ordered ring. There are two possible fixes here; I use `PLift` which was the easier one; another possibility is to make `Matrix.toDigraph` instead.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
