### PR TITLE
[Merged by Bors] - feat(Analysis/NormedSpace/FiniteDimension): affine maps from finite-dimensional spaces are Lipschitz and anti-Lipschitz

### DIFF
--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -236,7 +236,7 @@ theorem LinearMap.injective_iff_antilipschitz [FiniteDimensional 𝕜 E] (f : E 
 /-- An injective affine map from a finite-dimensional space is automatically anti-Lipschitz. -/
 theorem AffineMap.antilipschitzWith_of_finiteDimensional {PE PF : Type*} [MetricSpace PE]
     [NormedAddTorsor E PE] [MetricSpace PF] [NormedAddTorsor F PF] [FiniteDimensional 𝕜 E]
-    (f : PE →ᵃ[𝕜] PF) (hf : Function.Injective f) :
+    {f : PE →ᵃ[𝕜] PF} (hf : Function.Injective f) :
     ∃ K : ℝ≥0, AntilipschitzWith K f := by
   obtain ⟨K, -, hK⟩ := f.linear.injective_iff_antilipschitz.mp (f.linear_injective_iff.mpr hf)
   refine ⟨K, AntilipschitzWith.of_le_mul_dist fun x y ↦ ?_⟩

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -152,7 +152,7 @@ theorem AffineEquiv.coe_toHomeomorphOfFiniteDimensional_symm (f : PE ≃ᵃ[𝕜
 theorem AffineMap.lipschitzWith_of_finiteDimensional (f : PE →ᵃ[𝕜] PF) :
     ∃ K : ℝ≥0, LipschitzWith K f := by
   let fL : E →L[𝕜] F := f.linear.toContinuousLinearMap
-  refine ⟨⟨‖fL‖₊, LipschitzWith.of_dist_le_mul fun x y ↦ ?_⟩
+  refine ⟨‖fL‖₊, LipschitzWith.of_dist_le_mul fun x y ↦ ?_⟩
   rw [NormedAddTorsor.dist_eq_norm', NormedAddTorsor.dist_eq_norm', ← f.linearMap_vsub]
   exact fL.le_opNorm _
 

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -152,7 +152,7 @@ theorem AffineEquiv.coe_toHomeomorphOfFiniteDimensional_symm (f : PE ≃ᵃ[𝕜
 theorem AffineMap.lipschitzWith_of_finiteDimensional (f : PE →ᵃ[𝕜] PF) :
     ∃ K : ℝ≥0, LipschitzWith K f := by
   let fL : E →L[𝕜] F := f.linear.toContinuousLinearMap
-  refine ⟨⟨‖fL‖, norm_nonneg _⟩, LipschitzWith.of_dist_le_mul fun x y ↦ ?_⟩
+  refine ⟨⟨‖fL‖₊, LipschitzWith.of_dist_le_mul fun x y ↦ ?_⟩
   rw [NormedAddTorsor.dist_eq_norm', NormedAddTorsor.dist_eq_norm', ← f.linearMap_vsub]
   exact fL.le_opNorm _
 

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -148,6 +148,14 @@ theorem AffineEquiv.coe_toHomeomorphOfFiniteDimensional_symm (f : PE ≃ᵃ[𝕜
     ⇑f.toHomeomorphOfFiniteDimensional.symm = f.symm :=
   rfl
 
+/-- An affine map from a finite-dimensional space is automatically Lipschitz. -/
+theorem AffineMap.lipschitzWith_of_finiteDimensional (f : PE →ᵃ[𝕜] PF) :
+    ∃ K : ℝ≥0, LipschitzWith K f := by
+  let fL : E →L[𝕜] F := f.linear.toContinuousLinearMap
+  refine ⟨⟨‖fL‖, norm_nonneg _⟩, LipschitzWith.of_dist_le_mul fun x y ↦ ?_⟩
+  rw [NormedAddTorsor.dist_eq_norm', NormedAddTorsor.dist_eq_norm', ← f.linearMap_vsub]
+  exact fL.le_opNorm _
+
 end Affine
 
 theorem ContinuousLinearMap.continuous_det : Continuous fun f : E →L[𝕜] E => f.det := by
@@ -224,6 +232,16 @@ theorem LinearMap.injective_iff_antilipschitz [FiniteDimensional 𝕜 E] (f : E 
     exact f.exists_antilipschitzWith
   · rintro ⟨K, -, H⟩
     exact H.injective
+
+/-- An injective affine map from a finite-dimensional space is automatically anti-Lipschitz. -/
+theorem AffineMap.antilipschitzWith_of_finiteDimensional {PE PF : Type*} [MetricSpace PE]
+    [NormedAddTorsor E PE] [MetricSpace PF] [NormedAddTorsor F PF] [FiniteDimensional 𝕜 E]
+    (f : PE →ᵃ[𝕜] PF) (hf : Function.Injective f) :
+    ∃ K : ℝ≥0, AntilipschitzWith K f := by
+  obtain ⟨K, -, hK⟩ := f.linear.injective_iff_antilipschitz.mp (f.linear_injective_iff.mpr hf)
+  refine ⟨K, AntilipschitzWith.of_le_mul_dist fun x y ↦ ?_⟩
+  rw [dist_eq_norm_vsub E, dist_eq_norm_vsub F, ← f.linearMap_vsub]
+  exact ZeroHomClass.bound_of_antilipschitz f.linear hK (x -ᵥ y)
 
 open Function in
 /-- The set of injective continuous linear maps `E → F` is open,


### PR DESCRIPTION

This PR adds results showing that affine maps from finite-dimensional spaces are automatically Lipschitz, and injective affine maps are anti-Lipschitz. These are the affine analogues of the existing results for linear maps.

## Main results
- `AffineMap.lipschitzWith_of_finiteDimensional`: An affine map from a finite-dimensional space is Lipschitz
- `AffineMap.antilipschitzWith_of_finiteDimensional`: An injective affine map from a finite-dimensional space is anti-Lipschitz  

These results lift the corresponding linear map results to the affine setting by using the relationship between affine maps and their underlying linear parts.

### Note

These results were requested by @AntoineChambert-Loir in [#27069](https://github.com/leanprover-community/mathlib4/pull/27069) to support Hausdorff dimension calculations for affine subspaces and segments. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
