### PR TITLE
[Merged by Bors] - doc: add `recommended_spelling` for `Max.max`

### DIFF
--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -196,6 +196,12 @@ recommended_spelling "hnot" for "￢" in [HNot.hnot, «term￢_»]
 recommended_spelling "top" for "⊤" in [Top.top, «term⊤»]
 recommended_spelling "bot" for "⊥" in [Bot.bot, «term⊥»]
 
--- Don't recommend in `Max.max` and `Min.min`!
 recommended_spelling "sup" for "⊔" in [«term_⊔_»]
 recommended_spelling "inf" for "⊓" in [«term_⊓_»]
+
+recommended_spelling "max" for "max" in [Max.max]
+recommended_spelling "min" for "min" in [Min.min]
+/-- `⊔` is the more preferred notation for `max` when the type is not linear order. -/
+recommended_spelling "sup" for "⊔" in [Max.max]
+/-- `⊓` is the more preferred notation for `min` when the type is not linear order. -/
+recommended_spelling "inf" for "⊓" in [Min.min]

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -201,7 +201,7 @@ recommended_spelling "inf" for "⊓" in [«term_⊓_»]
 
 recommended_spelling "max" for "max" in [Max.max]
 recommended_spelling "min" for "min" in [Min.min]
-/-- `⊔` is the more preferred notation for `max` when the type is not linear order. -/
+/-- `⊔` is the preferred notation for `max` when the type is not linearly ordered. -/
 recommended_spelling "sup" for "⊔" in [Max.max]
-/-- `⊓` is the more preferred notation for `min` when the type is not linear order. -/
+/-- `⊓` is the preferred notation for `min` when the type is not linearly ordered. -/
 recommended_spelling "inf" for "⊓" in [Min.min]


### PR DESCRIPTION
This is the follow-up PR to #34181.

In #34181, I avoided adding `recommended_spelling "sup"` to `Max.max` because it could be confusing for linear order types. However, this confusion can be resolved by adding both `recommended_spelling "max"` and `recommended_spelling "sup"` with additional documentation.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
