### PR TITLE
[Merged by Bors] - feat: add `Module.Finite.of_exact`

### DIFF
--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -235,6 +235,7 @@ variable {S} {P : Type*} [Semiring S] [AddCommMonoid P] [Module S P]
   {σ : R →+* S} [RingHomSurjective σ]
 
 -- TODO: remove RingHomSurjective
+@[stacks 0519 "(3)"]
 theorem of_surjective [hM : Module.Finite R M] (f : M →ₛₗ[σ] P) (hf : Surjective f) :
     Module.Finite S P :=
   ⟨by

--- a/Mathlib/RingTheory/Finiteness/Finsupp.lean
+++ b/Mathlib/RingTheory/Finiteness/Finsupp.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.MonoidAlgebra.Module
 public import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 public import Mathlib.LinearAlgebra.Quotient.Basic
 public import Mathlib.RingTheory.Finiteness.Basic
+public import Mathlib.Algebra.Exact
 
 /-!
 # Finiteness of (sub)modules and finitely supported functions
@@ -113,11 +114,23 @@ theorem fg_ker_comp (f : M →ₗ[R] N) (g : N →ₗ[R] P)
   · rwa [inf_of_le_right (show (LinearMap.ker f) ≤
       (LinearMap.ker g).comap f from comap_mono bot_le)]
 
+/-- If $0 → M → N → P → 0$ is exact and $M$ and $P$ are finitely generated then so is $N$.
+
+This is the `Module.Finite` version of `Submodule.fg_of_fg_map_of_fg_inf_ker`. -/
+lemma _root_.Module.Finite.of_exact {f : M →ₗ[R] N} {g : N →ₗ[R] P}
+    (h_exact : Function.Exact f g) (h_surj : Function.Surjective g)
+    [Module.Finite R M] [Module.Finite R P] : Module.Finite R N := by
+  refine ⟨(⊤ : Submodule R _).fg_of_fg_map_of_fg_inf_ker g ?_ ?_⟩
+  · rw [← LinearMap.range_eq_top] at h_surj
+    rw [Submodule.map_top, h_surj]
+    exact Module.Finite.fg_top
+  · simp [LinearMap.exact_iff.1 h_exact]
+
 theorem _root_.Module.Finite.of_submodule_quotient (N : Submodule R M) [Module.Finite R N]
-    [Module.Finite R (M ⧸ N)] : Module.Finite R M where
-  fg_top := fg_of_fg_map_of_fg_inf_ker N.mkQ
-    (by simpa only [map_top, range_mkQ] using Module.finite_def.mp ‹_›) <| by
-    simpa only [top_inf_eq, ker_mkQ] using .of_finite
+    [Module.Finite R (M ⧸ N)] : Module.Finite R M := by
+  refine .of_exact (f := N.subtype) (g := N.mkQ) ?_ (Quotient.mk_surjective _)
+  rw [LinearMap.exact_iff]
+  simp
 
 end Submodule
 

--- a/Mathlib/RingTheory/Finiteness/Finsupp.lean
+++ b/Mathlib/RingTheory/Finiteness/Finsupp.lean
@@ -114,7 +114,7 @@ theorem fg_ker_comp (f : M →ₗ[R] N) (g : N →ₗ[R] P)
   · rwa [inf_of_le_right (show (LinearMap.ker f) ≤
       (LinearMap.ker g).comap f from comap_mono bot_le)]
 
-/-- If $0 → M → N → P → 0$ is exact and $M$ and $P$ are finitely generated then so is $N$.
+/-- If $M → N → P → 0$ is exact and $M$ and $P$ are finitely generated then so is $N$.
 
 This is the `Module.Finite` version of `Submodule.fg_of_fg_map_of_fg_inf_ker`. -/
 @[stacks 0519 "(1)"]
@@ -128,10 +128,8 @@ lemma _root_.Module.Finite.of_exact {f : M →ₗ[R] N} {g : N →ₗ[R] P}
   · simp [LinearMap.exact_iff.1 h_exact]
 
 theorem _root_.Module.Finite.of_submodule_quotient (N : Submodule R M) [Module.Finite R N]
-    [Module.Finite R (M ⧸ N)] : Module.Finite R M := by
-  refine .of_exact (f := N.subtype) (g := N.mkQ) ?_ (Quotient.mk_surjective _)
-  rw [LinearMap.exact_iff]
-  simp
+    [Module.Finite R (M ⧸ N)] : Module.Finite R M :=
+  .of_exact (LinearMap.exact_subtype_mkQ N) (Quotient.mk_surjective _)
 
 end Submodule
 

--- a/Mathlib/RingTheory/Finiteness/Finsupp.lean
+++ b/Mathlib/RingTheory/Finiteness/Finsupp.lean
@@ -117,6 +117,7 @@ theorem fg_ker_comp (f : M →ₗ[R] N) (g : N →ₗ[R] P)
 /-- If $0 → M → N → P → 0$ is exact and $M$ and $P$ are finitely generated then so is $N$.
 
 This is the `Module.Finite` version of `Submodule.fg_of_fg_map_of_fg_inf_ker`. -/
+@[stacks 0519 "(1)"]
 lemma _root_.Module.Finite.of_exact {f : M →ₗ[R] N} {g : N →ₗ[R] P}
     (h_exact : Function.Exact f g) (h_surj : Function.Surjective g)
     [Module.Finite R M] [Module.Finite R P] : Module.Finite R N := by


### PR DESCRIPTION
Also add two `stacks` tags for https://stacks.math.columbia.edu/tag/0519.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
