### PR TITLE
[Merged by Bors] - feat(Topology/Connected/PathConnected): relate `ZerothHomotopy` and `ConnectedComponents`

### DIFF
--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -341,12 +341,20 @@ theorem Quot.mk_surjective {r : α → α → Prop} : Function.Surjective (Quot.
 /-- `Quotient.mk` is a surjective function. -/
 theorem Quotient.mk_surjective {s : Setoid α} :
     Function.Surjective (Quotient.mk s) :=
-  Quot.exists_rep
+  Quot.mk_surjective
 
 /-- `Quotient.mk'` is a surjective function. -/
 theorem Quotient.mk'_surjective [s : Setoid α] :
     Function.Surjective (Quotient.mk' : α → Quotient s) :=
-  Quot.exists_rep
+  Quot.mk_surjective
+
+theorem Quot.map_surjective {ra : α → α → Prop} {rb : β → β → Prop} {f : α → β}
+    (h : ∀ ⦃a b : α⦄, ra a b → rb (f a) (f b)) (hf : f.Surjective) : Quot.map f h |>.Surjective :=
+  surjective_lift _ |>.mpr <| .comp Quot.mk_surjective hf
+
+theorem Quotient.map_surjective {sa : Setoid α} {sb : Setoid β} {f : α → β}
+    (h : ∀ ⦃a b : α⦄, a ≈ b → f a ≈ f b) (hf : f.Surjective) : Quotient.map f h |>.Surjective :=
+  lift_surjective _ _ <| .comp Quot.mk_surjective hf
 
 /-- Choose an element of the equivalence class using the axiom of choice.
   Sound but noncomputable. -/

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -109,12 +109,22 @@ theorem pathComponent_eq_connectedComponent (x : X) : pathComponent x = connecte
   (pathComponent_subset_component x).antisymm <|
     (IsClopen.pathComponent x).connectedComponent_subset (mem_pathComponent_self _)
 
-theorem zerothHomotopy_eq_connectedComponents : ZerothHomotopy X = ConnectedComponents X := by
-  unfold ZerothHomotopy pathSetoid
-  congr
-  ext x y
+theorem connectedComponent_eq_iff_joined (x y : X) :
+    connectedComponent x = connectedComponent y ↔ Joined x y := by
   rw [← mem_pathComponent_iff, pathComponent_eq_connectedComponent, eq_comm]
-  exact connectedComponent_eq_iff_mem.symm
+  exact connectedComponent_eq_iff_mem
+
+theorem connectedComponentSetoid_eq_pathSetoid : connectedComponentSetoid X = pathSetoid X :=
+  Setoid.ext connectedComponent_eq_iff_joined
+
+/-- In a locally path-connected space, connected components and path-connected components align -/
+def connectedComponentsEquivZerothHomotopy : ConnectedComponents X ≃ ZerothHomotopy X where
+  toFun := Quotient.lift Quotient.mk''
+    (Quotient.sound <| connectedComponent_eq_iff_joined · · |>.mp ·)
+  invFun := Quotient.lift Quotient.mk''
+    (Quotient.sound <| connectedComponent_eq_iff_joined · · |>.mpr ·)
+  left_inv := Quot.ind <| congrFun rfl
+  right_inv := Quot.ind <| congrFun rfl
 
 theorem pathConnected_subset_basis {U : Set X} (h : IsOpen U) (hx : x ∈ U) :
     (𝓝 x).HasBasis (fun s : Set X => s ∈ 𝓝 x ∧ IsPathConnected s ∧ s ⊆ U) id :=

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -109,6 +109,13 @@ theorem pathComponent_eq_connectedComponent (x : X) : pathComponent x = connecte
   (pathComponent_subset_component x).antisymm <|
     (IsClopen.pathComponent x).connectedComponent_subset (mem_pathComponent_self _)
 
+theorem pathComponents_eq_connectedComponents : ZerothHomotopy X = ConnectedComponents X := by
+  unfold ZerothHomotopy pathSetoid
+  congr
+  ext x y
+  rw [← mem_pathComponent_iff, pathComponent_eq_connectedComponent, eq_comm]
+  exact connectedComponent_eq_iff_mem.symm
+
 theorem pathConnected_subset_basis {U : Set X} (h : IsOpen U) (hx : x ∈ U) :
     (𝓝 x).HasBasis (fun s : Set X => s ∈ 𝓝 x ∧ IsPathConnected s ∧ s ⊆ U) id :=
   (path_connected_basis x).hasBasis_self_subset (IsOpen.mem_nhds h hx)

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -109,7 +109,7 @@ theorem pathComponent_eq_connectedComponent (x : X) : pathComponent x = connecte
   (pathComponent_subset_component x).antisymm <|
     (IsClopen.pathComponent x).connectedComponent_subset (mem_pathComponent_self _)
 
-theorem pathComponents_eq_connectedComponents : ZerothHomotopy X = ConnectedComponents X := by
+theorem zerothHomotopy_eq_connectedComponents : ZerothHomotopy X = ConnectedComponents X := by
   unfold ZerothHomotopy pathSetoid
   congr
   ext x y

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -126,7 +126,8 @@ def connectedComponentsEquivZerothHomotopy : ConnectedComponents X ≃ ZerothHom
 
 @[simp]
 lemma connectedComponentsEquivZerothHomotopy_apply (x : X) :
-    connectedComponentsEquivZerothHomotopy ⟦x⟧ = ⟦x⟧ := rfl
+    connectedComponentsEquivZerothHomotopy ⟦x⟧ = ⟦x⟧ :=
+  rfl
 
 @[simp]
 lemma coe_connectedComponentsEquivZerothHomotopy_symm :
@@ -134,7 +135,8 @@ lemma coe_connectedComponentsEquivZerothHomotopy_symm :
   rfl
 
 lemma connectedComponentsEquivZerothHomotopy_symm_apply (x : X) :
-    connectedComponentsEquivZerothHomotopy.symm ⟦x⟧ = ⟦x⟧ := by simp
+    connectedComponentsEquivZerothHomotopy.symm ⟦x⟧ = ⟦x⟧ :=
+  rfl
 
 theorem pathConnected_subset_basis {U : Set X} (h : IsOpen U) (hx : x ∈ U) :
     (𝓝 x).HasBasis (fun s : Set X => s ∈ 𝓝 x ∧ IsPathConnected s ∧ s ⊆ U) id :=

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -119,12 +119,22 @@ theorem connectedComponentSetoid_eq_pathSetoid : connectedComponentSetoid X = pa
 
 /-- In a locally path-connected space, connected components and path-connected components align -/
 def connectedComponentsEquivZerothHomotopy : ConnectedComponents X ≃ ZerothHomotopy X where
-  toFun := Quotient.lift Quotient.mk''
-    (Quotient.sound <| connectedComponent_eq_iff_joined · · |>.mp ·)
-  invFun := Quotient.lift Quotient.mk''
-    (Quotient.sound <| connectedComponent_eq_iff_joined · · |>.mpr ·)
+  toFun := Quotient.map id (connectedComponent_eq_iff_joined · · |>.mp ·)
+  invFun := ZerothHomotopy.toConnectedComponents
   left_inv := Quot.ind <| congrFun rfl
   right_inv := Quot.ind <| congrFun rfl
+
+@[simp]
+lemma connectedComponentsEquivZerothHomotopy_apply (x : X) :
+    connectedComponentsEquivZerothHomotopy ⟦x⟧ = ⟦x⟧ := rfl
+
+@[simp]
+lemma coe_connectedComponentsEquivZerothHomotopy_symm :
+    ⇑connectedComponentsEquivZerothHomotopy.symm = ZerothHomotopy.toConnectedComponents (X := X) :=
+  rfl
+
+lemma connectedComponentsEquivZerothHomotopy_symm_apply (x : X) :
+    connectedComponentsEquivZerothHomotopy.symm ⟦x⟧ = ⟦x⟧ := by simp
 
 theorem pathConnected_subset_basis {U : Set X} (h : IsOpen U) (hx : x ∈ U) :
     (𝓝 x).HasBasis (fun s : Set X => s ∈ 𝓝 x ∧ IsPathConnected s ∧ s ⊆ U) id :=

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -264,6 +264,22 @@ theorem pathComponent_subset_component (x : X) : pathComponent x ⊆ connectedCo
   fun y h =>
   (isConnected_range h.somePath.continuous).subset_connectedComponent ⟨0, by simp⟩ ⟨1, by simp⟩
 
+/-- Every connected component is a union of path connected components -/
+theorem iUnion_connectedComponent_pathComponent_eq (x : X) :
+    (⋃ y ∈ connectedComponent x, pathComponent y) = connectedComponent x := by
+  ext z
+  refine ⟨fun h ↦ ?_, fun hz ↦ mem_iUnion₂.mpr ⟨z, hz, mem_pathComponent_self z⟩⟩
+  have ⟨y, hy, hz⟩ := mem_iUnion₂.mp h
+  exact connectedComponent_eq hy ▸ pathComponent_subset_component _ hz
+
+/-- There are at least as many path connected components as there are connected components -/
+theorem exists_zerothHomotopy_to_connectedComponents_surjective :
+    ∃ (f : ZerothHomotopy X → ConnectedComponents X), f.Surjective := by
+  refine ⟨.lift (⟦·⟧) ?_, ?_⟩
+  · exact fun _ _ h ↦ Quotient.sound <| connectedComponent_eq <| pathComponent_subset_component _ h
+  rintro ⟨x⟩
+  exact ⟨⟦x⟧, rfl⟩
+
 /-- The path component of `x` in `F` is the set of points that can be joined to `x` in `F`. -/
 def pathComponentIn (F : Set X) (x : X) :=
   { y | JoinedIn F x y }

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -265,7 +265,7 @@ theorem pathComponent_subset_component (x : X) : pathComponent x ⊆ connectedCo
   (isConnected_range h.somePath.continuous).subset_connectedComponent ⟨0, by simp⟩ ⟨1, by simp⟩
 
 /-- Every connected component is a union of path connected components -/
-theorem iUnion_connectedComponent_pathComponent_eq (x : X) :
+theorem biUnion_connectedComponent_pathComponent_eq (x : X) :
     (⋃ y ∈ connectedComponent x, pathComponent y) = connectedComponent x := by
   ext z
   refine ⟨fun h ↦ ?_, fun hz ↦ mem_iUnion₂.mpr ⟨z, hz, mem_pathComponent_self z⟩⟩

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -267,10 +267,9 @@ theorem pathComponent_subset_component (x : X) : pathComponent x ⊆ connectedCo
 /-- Every connected component is a union of path connected components -/
 theorem biUnion_connectedComponent_pathComponent_eq (x : X) :
     (⋃ y ∈ connectedComponent x, pathComponent y) = connectedComponent x := by
-  ext z
-  refine ⟨fun h ↦ ?_, fun hz ↦ mem_iUnion₂.mpr ⟨z, hz, mem_pathComponent_self z⟩⟩
-  have ⟨y, hy, hz⟩ := mem_iUnion₂.mp h
-  exact connectedComponent_eq hy ▸ pathComponent_subset_component _ hz
+  simp only [Set.ext_iff, mem_iUnion₂]
+  exact fun z ↦ ⟨fun ⟨y, hy, hz⟩ ↦ connectedComponent_eq hy ▸ pathComponent_subset_component _ hz,
+    (⟨z, ·, mem_pathComponent_self z⟩)⟩
 
 /-- There are at least as many path connected components as there are connected components -/
 theorem exists_zerothHomotopy_to_connectedComponents_surjective :

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -274,7 +274,7 @@ theorem biUnion_connectedComponent_pathComponent_eq (x : X) :
 /-- The canonical map which sends a path component of `X` (as a term of `ZerothHomotopy X`) to the
 connected component containing it (as a term of `ConnectedComponents X`). -/
 def ZerothHomotopy.toConnectedComponents : ZerothHomotopy X → ConnectedComponents X :=
-  Quotient.map id fun _ _ h ↦ connectedComponent_eq <| pathComponent_subset_component _ h
+  Quotient.map id fun x _ h ↦ connectedComponent_eq <| pathComponent_subset_component x h
 
 @[simp]
 theorem ZerothHomotopy.toConnectedComponents_apply (x : X) : toConnectedComponents ⟦x⟧ = ⟦x⟧ :=
@@ -282,8 +282,8 @@ theorem ZerothHomotopy.toConnectedComponents_apply (x : X) : toConnectedComponen
 
 /-- There are at least as many path connected components as there are connected components -/
 theorem ZerothHomotopy.toConnectedComponents_surjective :
-    (toConnectedComponents (X := X)).Surjective :=
-  Quotient.lift_surjective _ _ Quotient.mk_surjective
+    toConnectedComponents (X := X) |>.Surjective :=
+  Quotient.map_surjective _ surjective_id
 
 /-- The path component of `x` in `F` is the set of points that can be joined to `x` in `F`. -/
 def pathComponentIn (F : Set X) (x : X) :=

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -271,13 +271,19 @@ theorem biUnion_connectedComponent_pathComponent_eq (x : X) :
   exact fun z ↦ ⟨fun ⟨y, hy, hz⟩ ↦ connectedComponent_eq hy ▸ pathComponent_subset_component _ hz,
     (⟨z, ·, mem_pathComponent_self z⟩)⟩
 
+/-- The canonical map which sends a path component of `X` (as a term of `ZerothHomotopy X`) to the
+connected component containing it (as a term of `ConnectedComponents X`). -/
+def ZerothHomotopy.toConnectedComponents : ZerothHomotopy X → ConnectedComponents X :=
+  Quotient.map id fun _ _ h ↦ connectedComponent_eq <| pathComponent_subset_component _ h
+
+@[simp]
+theorem ZerothHomotopy.toConnectedComponents_apply (x : X) : toConnectedComponents ⟦x⟧ = ⟦x⟧ :=
+  rfl
+
 /-- There are at least as many path connected components as there are connected components -/
-theorem exists_zerothHomotopy_to_connectedComponents_surjective :
-    ∃ (f : ZerothHomotopy X → ConnectedComponents X), f.Surjective := by
-  refine ⟨.lift (⟦·⟧) ?_, ?_⟩
-  · exact fun _ _ h ↦ Quotient.sound <| connectedComponent_eq <| pathComponent_subset_component _ h
-  rintro ⟨x⟩
-  exact ⟨⟦x⟧, rfl⟩
+theorem ZerothHomotopy.toConnectedComponents_surjective :
+    (toConnectedComponents (X := X)).Surjective :=
+  Quotient.lift_surjective _ _ Quotient.mk_surjective
 
 /-- The path component of `x` in `F` is the set of points that can be joined to `x` in `F`. -/
 def pathComponentIn (F : Set X) (x : X) :=


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
