### PR TITLE
fix: typecheck speedup by filling in hole

### DIFF
--- a/Mathlib/RingTheory/Kaehler/Polynomial.lean
+++ b/Mathlib/RingTheory/Kaehler/Polynomial.lean
@@ -30,7 +30,7 @@ section MvPolynomial
 `{ dx | x ∈ σ }`. Also see `KaehlerDifferential.mvPolynomialBasis`. -/
 def KaehlerDifferential.mvPolynomialEquiv (σ : Type*) :
     Ω[MvPolynomial σ R⁄R] ≃ₗ[MvPolynomial σ R] σ →₀ MvPolynomial σ R where
-  __ := (MvPolynomial.mkDerivation _ (Finsupp.single · 1)).liftKaehlerDifferential
+  __ := (MvPolynomial.mkDerivation R (Finsupp.single · 1)).liftKaehlerDifferential
   invFun := Finsupp.linearCombination (α := σ) _ (fun x ↦ D _ _ (MvPolynomial.X x))
   right_inv := by
     intro x


### PR DESCRIPTION
This innocuous-looking change (filling in a hole that is trivially fillable by unification) produces a huge speed-up in typechecking of the resulting term, for the highly non-obvious reason that filling in the hole somehow affects a universe computation, changing it from `max u_1 u` to the defeq `max u u_1` , which is enough to give a speed-up because of issue #26018 .

Before the change we have
```
[Kernel] [54494265.000000] ✅️ typechecking declarations [KaehlerDifferential.mvPolynomialEquiv._proof_2]
```

and after it is 
```
[Kernel] [7866781.000000] ✅️ typechecking declarations [KaehlerDifferential.mvPolynomialEquiv._proof_2] 
```

(a 7x speed-up).

Note also #34088 , which makes a change of a completely different nature (changing the alphabetical order of universes); this causes several defeq universe changes and results in an even higher speed-up.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
