### PR TITLE
[Merged by Bors] - style: fix whitespace

### DIFF
--- a/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
@@ -230,7 +230,7 @@ open Submonoid in
 lemma IsMulIndecomposable.apply_ne_one_iff_mem_closure
     [Finite ι] [InvolutiveInv ι] [CommGroup S] [IsOrderedMonoid S]
     (v : ι → G) (f : G →* S) (i : ι) (hi : v i ≠ 1) (hi' : v i⁻¹ = (v i)⁻¹) :
-    f (v i) ≠ 1 ↔ v i    ∈ closure (v '' baseOf v f) ∨
+    f (v i) ≠ 1 ↔ v i ∈ closure (v '' baseOf v f) ∨
                  (v i)⁻¹ ∈ closure (v '' baseOf v f) :=
   ⟨fun h ↦ mem_or_inv_mem_closure_baseOf v f i h hi',
     apply_ne_one_of_mem_or_inv_mem_closure v f (baseOf v f) (baseOf_subset_one_lt v f) i hi hi'⟩

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -255,7 +255,7 @@ lemma appIso_inv_app_presheafMap (U : X.Opens) :
 
 @[simp]
 lemma id_appIso (U : X.Opens) :
-    (𝟙 X:).appIso U = X.presheaf.mapIso (eqToIso (by simp)).op := by
+    (𝟙 X :).appIso U = X.presheaf.mapIso (eqToIso (by simp)).op := by
   ext; simp [appIso_hom]
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Extremal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Extremal.lean
@@ -145,7 +145,7 @@ theorem sumNodes_eq_sumNodes_T_iff {n : ℕ} {c : ℕ → ℝ}
     simpa [negOnePow_mul_negOnePow_mul_cancel]
   have h_le {i : ℕ} (hi : i ∈ Finset.Iic n) :
     (-1) ^ i * P.eval (node n i) * ((-1) ^ i * c i) ≤
-    (-1) ^ i * (T ℝ n).eval (node n i)  * ((-1) ^ i * c i) := by
+    (-1) ^ i * (T ℝ n).eval (node n i) * ((-1) ^ i * c i) := by
     refine mul_le_mul_of_nonneg_right ?_ (le_of_lt (hcpos i (Finset.mem_Iic.mp hi)))
     rw [eval_T_real_node hi, ← neg_pow', neg_neg, one_pow]
     exact negOnePow_mul_le (hPbnd _ node_mem_Icc)

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -311,7 +311,7 @@ instance : Countable (constantsOn α).Symbols := by
   simpa only [card_constantsOn, mk_le_aleph0_iff]
 
 instance : Countable L[[α]].Symbols := by
-  simp only [←mk_le_aleph0_iff]
+  simp only [← mk_le_aleph0_iff]
   change L[[α]].card ≤ ℵ₀
   simp only [withConstants, card_sum, add_le_aleph0, lift_le_aleph0]
   simp only [card, mk_le_aleph0_iff]

--- a/Mathlib/ModelTheory/Topology/Types.lean
+++ b/Mathlib/ModelTheory/Topology/Types.lean
@@ -40,7 +40,7 @@ public lemma isTopologicalBasis_range_typesWith :
     rw [typesWith_inf, ht₁, ht₂]
     exact ⟨hx, fun _ ↦ id⟩
   sUnion_eq := by
-    rw [←Set.univ_subset_iff]
+    rw [← Set.univ_subset_iff]
     exact Set.subset_sUnion_of_mem ⟨_, typesWith_top⟩
   eq_generateFrom := rfl
 
@@ -48,7 +48,7 @@ public lemma isOpen_typesWith (φ : L[[α]].Sentence) : IsOpen (typesWith (T := 
   isOpen_generateFrom_of_mem ⟨φ, rfl⟩
 
 public lemma isClosed_typesWith (φ : L[[α]].Sentence) : IsClosed (typesWith (T := T) φ) where
-  isOpen_compl := by rw [←typesWith_not]; exact isOpen_typesWith _
+  isOpen_compl := by rw [← typesWith_not]; exact isOpen_typesWith _
 
 public lemma isClopen_typesWith (φ : L[[α]].Sentence) : IsClopen (typesWith (T := T) φ) where
   left := isClosed_typesWith _

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -193,8 +193,8 @@ lemma mem_typesWith_iff (φ : L[[α]].Sentence) (p : CompleteType T α) : p ∈ 
 lemma typesWith_inf (φ ψ : L[[α]].Sentence) :
     typesWith (T := T) (φ ⊓ ψ) = typesWith φ ∩ typesWith ψ := by
   ext p
-  simp only [mem_typesWith_iff, mem_inter_iff, ←SetLike.mem_coe, p.isMaximal.mem_iff_models,
-    ModelsBoundedFormula, ←forall_and]
+  simp only [mem_typesWith_iff, mem_inter_iff, ← SetLike.mem_coe, p.isMaximal.mem_iff_models,
+    ModelsBoundedFormula, ← forall_and]
   exact forall₃_congr fun _ _ _ ↦ BoundedFormula.realize_inf
 
 lemma typesWith_eq_univ_of_mem_onTheory_lhomWithConstants {φ}

--- a/Mathlib/NumberTheory/MahlerMeasure.lean
+++ b/Mathlib/NumberTheory/MahlerMeasure.lean
@@ -165,6 +165,7 @@ theorem isIntegral_of_mahlerMeasure_eq_one : IsIntegral ℤ z := by
   have : (C (1 / p.leadingCoeff) * p).Monic := by aesop (add safe (by simp [Monic.def]))
   grind [IsIntegral, RingHom.IsIntegralElem, mem_roots', IsRoot.def, eval₂_mul, eval_map]
 
+set_option linter.style.whitespace false in -- manual alignment is not recognised
 open Multiset in
 include h hz in
 /-- If an integer polynomial has Mahler measure equal to 1, then all its complex roots have norm at
@@ -190,7 +191,7 @@ to `ℚ`.
   let : NumberField K := {
     to_charZero := ℚ⟮z⟯.charZero,
     to_finiteDimensional := adjoin.finiteDimensional
-      (isIntegral_of_mahlerMeasure_eq_one h hz).tower_top}
+      (isIntegral_of_mahlerMeasure_eq_one h hz).tower_top }
 -- `y` is `z` as an element of `K`
   let y : K := ⟨z, mem_adjoin_simple_self ℚ z⟩
   suffices ∃ (n : ℕ) (_ : 0 < n), y ^ n = 1 by

--- a/Mathlib/RingTheory/EssentialFiniteness.lean
+++ b/Mathlib/RingTheory/EssentialFiniteness.lean
@@ -231,7 +231,7 @@ lemma EssFiniteType.of_surjective (f : S →ₐ[R] T) (hf : Function.Surjective 
 variable {R S T} in
 lemma EssFiniteType.iff_of_algEquiv (f : S ≃ₐ[R] T) :
     EssFiniteType R S ↔ EssFiniteType R T where
-  mp  _ := .of_surjective f.toAlgHom f.surjective
+  mp _ := .of_surjective f.toAlgHom f.surjective
   mpr _ := .of_surjective f.symm.toAlgHom f.symm.surjective
 
 variable {R S} in

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -986,7 +986,7 @@ instance [IsCancelAdd R] [IsCancelMulZero R] : IsCancelMulZero R⟦Γ⟧ where
     · simp [hx]
       grind
     · simp +contextual only [mem_union, mem_addAntidiagonal, mul_eq_mul_left_iff, Prod.mk.injEq,
-        ne_eq, ← and_or_left, ← or_and_right, or_false, and_imp, Prod.forall,  mem_support, not_and]
+        ne_eq, ← and_or_left, ← or_and_right, or_false, and_imp, Prod.forall, mem_support, not_and]
       rintro b c hxb - hbc hbc'
       contrapose! hbc'
       rwa [eq_comm, eq_comm (a := c), ← add_eq_add_iff_eq_and_eq (order_le_of_coeff_ne_zero hxb)
@@ -1008,7 +1008,7 @@ instance [IsCancelAdd R] [IsCancelMulZero R] : IsCancelMulZero R⟦Γ⟧ where
     · simp [hx]
       grind
     · simp +contextual only [mem_union, mem_addAntidiagonal, mul_eq_mul_right_iff, Prod.mk.injEq,
-        ne_eq, ← or_and_right, or_false, and_imp, Prod.forall,  mem_support, not_and]
+        ne_eq, ← or_and_right, or_false, and_imp, Prod.forall, mem_support, not_and]
       rintro b c - hxb hbc hbc'
       contrapose! hbc'
       rwa [eq_comm, eq_comm (a := c), ← add_eq_add_iff_eq_and_eq

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -764,7 +764,7 @@ lemma eq_open_union_nat [HereditarilyLindelofSpace X] {ι : Type*} [Nonempty ι]
     rwa [biUnion_range] at htu
 
 lemma eq_closed_inter_countable [HereditarilyLindelofSpace X] {ι : Type*} (C : ι → Set X)
-    (h : ∀ i, IsClosed (C i)) : ∃ t : Set ι, t.Countable ∧ ⋂ i∈t, C i = ⋂ i, C i := by
+    (h : ∀ i, IsClosed (C i)) : ∃ t : Set ι, t.Countable ∧ ⋂ i ∈ t, C i = ⋂ i, C i := by
   conv in _ = _ => rw [← compl_inj_iff]; simp
   exact eq_open_union_countable (fun i ↦ (C i)ᶜ) (fun i ↦ (h i).isOpen_compl)
 

--- a/Mathlib/Topology/Covering/Basic.lean
+++ b/Mathlib/Topology/Covering/Basic.lean
@@ -536,7 +536,7 @@ theorem IsClosedMap.isEvenlyCovered_of_openPartialHomeomorph [T2Space E] {x : X}
   have : Nonempty E := ⟨Classical.arbitrary (f ⁻¹' {x})⟩
   refine .of_trivialization (t := hU'.trivializationDiscrete _ _
     (fun e s hs ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩) (fun e ↦ ?_)
-    (fun e ↦  .mono subset_rfl (hUV e) (surjOn_image f _))
+    (fun e ↦ .mono subset_rfl (hUV e) (surjOn_image f _))
     (pairwise_disjoint_mono disj.subtype fun e ↦ inter_subset_left)
     ((preimage_mono (inter_subset_left.trans hUW)).trans hWV))
     ⟨hxU, Set.mem_iInter.mpr fun e ↦ ⟨e, ⟨(hV e).1, (hφ e).1⟩, e.2⟩⟩


### PR DESCRIPTION
Found by extending the whitespace linter to proof bodies in #30658.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
