### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): `(Nonempty)Compacts.toCloseds` is a closed embedding

### DIFF
--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -272,41 +272,12 @@ theorem isometry_toCompacts : Isometry (NonemptyCompacts.toCompacts (α := α)) 
   fun _ _ => rfl
 
 /-- The range of `NonemptyCompacts.toCloseds` is closed in a complete space -/
+@[deprecated
+  "Use `TopologicalSpace.NonemptyCompacts.isClosedEmbedding_toCloseds.isClosed_range` instead"
+  (since := "2026-01-28")]
 theorem isClosed_in_closeds [CompleteSpace α] :
-    IsClosed (range <| @NonemptyCompacts.toCloseds α _ _) := by
-  have :
-    range NonemptyCompacts.toCloseds =
-      { s : Closeds α | (s : Set α).Nonempty ∧ IsCompact (s : Set α) } := by
-    ext s
-    refine ⟨?_, fun h => ⟨⟨⟨s, h.2⟩, h.1⟩, Closeds.ext rfl⟩⟩
-    rintro ⟨s, hs, rfl⟩
-    exact ⟨s.nonempty, s.isCompact⟩
-  rw [this]
-  refine isClosed_of_closure_subset fun s hs => ⟨?_, ?_⟩
-  · -- take a set t which is nonempty and at a finite distance of s
-    rcases EMetric.mem_closure_iff.1 hs ⊤ ENNReal.coe_lt_top with ⟨t, ht, Dst⟩
-    rw [edist_comm] at Dst
-    -- since `t` is nonempty, so is `s`
-    exact nonempty_of_hausdorffEDist_ne_top ht.1 (ne_of_lt Dst)
-  · refine isCompact_iff_totallyBounded_isComplete.2 ⟨?_, s.isClosed.isComplete⟩
-    refine EMetric.totallyBounded_iff.2 fun ε (εpos : 0 < ε) => ?_
-    -- we have to show that s is covered by finitely many eballs of radius ε
-    -- pick a nonempty compact set t at distance at most ε/2 of s
-    rcases EMetric.mem_closure_iff.1 hs (ε / 2) (ENNReal.half_pos εpos.ne') with ⟨t, ht, Dst⟩
-    -- cover this space with finitely many balls of radius ε/2
-    rcases EMetric.totallyBounded_iff.1 (isCompact_iff_totallyBounded_isComplete.1 ht.2).1 (ε / 2)
-        (ENNReal.half_pos εpos.ne') with ⟨u, fu, ut⟩
-    refine ⟨u, ⟨fu, fun x hx => ?_⟩⟩
-    -- u : set α, fu : u.finite, ut : t ⊆ ⋃ (y : α) (H : y ∈ u), eball y (ε / 2)
-    -- then s is covered by the union of the balls centered at u of radius ε
-    rcases exists_edist_lt_of_hausdorffEDist_lt hx Dst with ⟨z, hz, Dxz⟩
-    rcases mem_iUnion₂.1 (ut hz) with ⟨y, hy, Dzy⟩
-    have : edist x y < ε :=
-      calc
-        edist x y ≤ edist x z + edist z y := edist_triangle _ _ _
-        _ < ε / 2 + ε / 2 := ENNReal.add_lt_add Dxz Dzy
-        _ = ε := ENNReal.add_halves _
-    exact mem_biUnion hy this
+    IsClosed (range <| @NonemptyCompacts.toCloseds α _ _) :=
+  NonemptyCompacts.isClosedEmbedding_toCloseds.isClosed_range
 
 /-- In a second countable space, the type of nonempty compact subsets is second countable -/
 instance instSecondCountableTopology [SecondCountableTopology α] :

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -230,6 +230,18 @@ theorem isUniformInducing_closure : IsUniformInducing (closure (X := α)) := by
 theorem nhds_closure (s : Set α) : 𝓝 (closure s) = 𝓝 s := by
   simp_rw +singlePass [isUniformInducing_closure.isInducing.nhds_eq_comap, closure_closure]
 
+theorem isClosed_setOf_totallyBounded : IsClosed {s : Set α | TotallyBounded s} := by
+  simp_rw [isClosed_iff_frequently, nhds_eq_comap_uniformity]
+  intro s hs U hU
+  obtain ⟨V : SetRel α α, hV, hVU⟩ := comp_mem_uniformity_sets hU
+  rw [(𝓤 α).basis_sets.uniformity_hausdorff.comap _ |>.frequently_iff] at hs
+  obtain ⟨t, ⟨hst : s ⊆ V.preimage t, -⟩, ht⟩ := hs V hV
+  obtain ⟨u, hu, htu⟩ := ht V hV
+  refine ⟨u, hu, ?_⟩
+  grw [hst, htu, ← hVU]
+  simp [Set.subset_def]
+  grind
+
 instance [DiscreteUniformity α] : DiscreteUniformity (Set α) := by
   rw [discreteUniformity_iff_setRelId_mem_uniformity]
   convert Filter.mem_lift' (DiscreteUniformity.relId_mem_uniformity α)
@@ -365,6 +377,9 @@ theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBound
     TotallyBounded {F : Closeds α | ↑F ⊆ t} :=
   totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
 
+theorem isClosed_setOf_totallyBounded : IsClosed {s : Closeds α | TotallyBounded (s : Set α)} :=
+  UniformSpace.hausdorff.isClosed_setOf_totallyBounded.preimage uniformContinuous_coe.continuous
+
 instance [DiscreteUniformity α] : DiscreteUniformity (Closeds α) :=
   isUniformEmbedding_coe.discreteUniformity
 
@@ -499,6 +514,16 @@ theorem isEmbedding_toCloseds [T2Space α] : IsEmbedding (toCloseds (α := α)) 
 theorem continuous_toCloseds [T2Space α] : Continuous (toCloseds (α := α)) :=
   uniformContinuous_toCloseds.continuous
 
+@[fun_prop]
+theorem isClosedEmbedding_toCloseds [T2Space α] [CompleteSpace α] :
+    IsClosedEmbedding (toCloseds (α := α)) where
+  __ := isEmbedding_toCloseds
+  isClosed_range := by
+    convert Closeds.isClosed_setOf_totallyBounded
+    exact subset_antisymm
+      (Set.range_subset_iff.mpr fun K => K.isCompact.totallyBounded)
+      (fun K hK => ⟨⟨K, hK.isCompact_of_isClosed K.isClosed⟩, rfl⟩)
+
 theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
     TotallyBounded {K : Compacts α | ↑K ⊆ t} :=
   totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
@@ -626,6 +651,11 @@ theorem isEmbedding_toCloseds [T2Space α] : IsEmbedding (toCloseds (α := α)) 
 @[fun_prop]
 theorem continuous_toCloseds [T2Space α] : Continuous (toCloseds (α := α)) :=
   uniformContinuous_toCloseds.continuous
+
+@[fun_prop]
+theorem isClosedEmbedding_toCloseds [T2Space α] [CompleteSpace α] :
+    IsClosedEmbedding (toCloseds (α := α)) :=
+  Compacts.isClosedEmbedding_toCloseds.comp isClosedEmbedding_toCompacts
 
 theorem isUniformEmbedding_toCompacts : IsUniformEmbedding (toCompacts (α := α)) where
   injective := toCompacts_injective


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
