### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Action): fix typos and update docs

### DIFF
--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -370,8 +370,7 @@ instance : (res V f).Faithful where
     rw [← res_map_hom _ f g₁, ← res_map_hom _ f g₂, h]
 
 /-- The functor from `Action V H` to `Action V G` induced by a monoid homomorphism
-`f : G →* H` is full
-if `f` is surjective. -/
+`f : G →* H` is full if `f` is surjective. -/
 lemma full_res (f_surj : Function.Surjective f) : (res V f).Full where
   map_surjective {X} {Y} g := by
     use ⟨g.hom, fun h ↦ ?_⟩

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -68,7 +68,7 @@ variable (G : Type*) [Monoid G]
 
 section
 
-/-- The action defined by sending every group element to the identity. -/
+/-- The action defined by sending every monoid element to the identity. -/
 @[simps]
 def trivial (X : V) : Action V G := { V := X, ρ := 1 }
 
@@ -297,7 +297,7 @@ theorem Iso.conj_ρ {M N : Action V G} (f : M ≅ N) (g : G) :
     N.ρ g = ((forget V G).mapIso f).conj (M.ρ g) := by
       rw [Iso.conj_apply, Iso.eq_inv_comp]; simp [f.hom.comm]
 
-/-- Actions/representations of the trivial group are just objects in the ambient category. -/
+/-- Actions/representations of the trivial monoid are just objects in the ambient category. -/
 def actionPunitEquivalence : Action V PUnit ≌ V where
   functor := forget V _
   inverse :=
@@ -312,7 +312,7 @@ def actionPunitEquivalence : Action V PUnit ≌ V where
 
 variable (V)
 
-/-- The "restriction" functor along a monoid homomorphism `f : G ⟶ H`,
+/-- The "restriction" functor along a monoid homomorphism `f : G →* H`,
 taking actions of `H` to actions of `G`.
 
 (This makes sense for any homomorphism, but the name is natural when `f` is a monomorphism.)
@@ -362,13 +362,15 @@ def resEquiv {G H : Type*} [Monoid G] [Monoid H] (f : G ≃* H) :
 
 variable {G H : Type*} [Monoid G] [Monoid H] (f : G →* H)
 
-/-- The functor from `Action V H` to `Action V G` induced by a morphism `f : G → H` is faithful. -/
+/-- The functor from `Action V H` to `Action V G` induced by a monoid homomorphism
+`f : G →* H` is faithful. -/
 instance : (res V f).Faithful where
   map_injective {X} {Y} g₁ g₂ h := by
     ext
     rw [← res_map_hom _ f g₁, ← res_map_hom _ f g₂, h]
 
-/-- The functor from `Action V H` to `Action V G` induced by a morphism `f : G → H` is full
+/-- The functor from `Action V H` to `Action V G` induced by a monoid homomorphism
+`f : G →* H` is full
 if `f` is surjective. -/
 lemma full_res (f_surj : Function.Surjective f) : (res V f).Full where
   map_surjective {X} {Y} g := by

--- a/Mathlib/CategoryTheory/Action/Limits.lean
+++ b/Mathlib/CategoryTheory/Action/Limits.lean
@@ -19,6 +19,8 @@ We show:
 
 * When `V` has (co)limits so does `Action V G`.
 * When `V` is preadditive, linear, or abelian so is `Action V G`.
+* The forgetful functor `Action V G ⥤ V` preserves any (co)limit whose image in `V` exists,
+  and reflects all (co)limits.
 -/
 
 @[expose] public section

--- a/Mathlib/CategoryTheory/Action/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Action/Monoidal.lean
@@ -20,6 +20,7 @@ public import Mathlib.CategoryTheory.Action.Limits
 We show:
 
 * When `V` is monoidal, braided, or symmetric, so is `Action V G`.
+* When `V` is rigid and `G` is a group, `Action V G` is also rigid.
 -/
 
 @[expose] public section
@@ -69,7 +70,7 @@ instance : (Action.forget V G).Monoidal :=
 open Functor.LaxMonoidal Functor.OplaxMonoidal
 
 @[simp] lemma forget_ε : ε (Action.forget V G) = 𝟙 _ := rfl
-@[simp] lemma forget_η : ε (Action.forget V G) = 𝟙 _ := rfl
+@[simp] lemma forget_η : η (Action.forget V G) = 𝟙 _ := rfl
 
 variable {V G}
 


### PR DESCRIPTION
Issues found and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
