### PR TITLE
[Merged by Bors] - feat(Topology/Sets): local connectedness of `(Nonempty)Compacts`

### DIFF
--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -139,6 +139,21 @@ theorem _root_.TopologicalSpace.IsTopologicalBasis.vietoris
     grw [← hfU U hU]
     exact ht₂ hU
 
+theorem closure_finite_subsets (s : Set α) :
+    closure {t | t.Finite ∧ t ⊆ s} = (closure s).powerset := by
+  refine subset_antisymm ?_ (fun K hKs => ?_)
+  · rw [isClosed_closure.powerset_vietoris.closure_subset_iff]
+    exact fun K ⟨_, h⟩ => h.trans subset_closure
+  · rw [isTopologicalBasis.mem_closure_iff, forall_mem_image]
+    rintro u ⟨hu₁, hu₂⟩ ⟨ht₁, ht₂⟩
+    choose x hxU hxs using fun U : u => show (↑U ∩ s).Nonempty by
+      obtain ⟨x, hxK, hxV⟩ := ht₂ U U.prop
+      exact mem_closure_iff.mp (hKs hxK) _ (hu₂ _ U.prop) hxV
+    have := hu₁.to_subtype
+    exact ⟨range x, ⟨range_subset_iff.mpr fun V => mem_sUnion_of_mem (hxU V) V.prop,
+      fun U hU => ⟨x ⟨U, hU⟩, mem_range_self _, hxU ⟨U, hU⟩⟩⟩,
+      finite_range _, range_subset_iff.mpr hxs⟩
+
 theorem continuous_iff {f : α → Set β} :
     Continuous f ↔ (∀ U, IsOpen U → IsOpen (f ⁻¹' U.powerset)) ∧
       (∀ F, IsClosed F → IsClosed (f ⁻¹' F.powerset)) := by
@@ -331,6 +346,17 @@ theorem isClosed_inter_nonempty_of_isClosed {F : Set α} (h : IsClosed F) :
 theorem isClopen_singleton_bot : IsClopen {(⊥ : Compacts α)} := by
   convert vietoris.isClopen_singleton_empty.preimage continuous_coe
   rw [← coe_bot, ← image_singleton (f := SetLike.coe), SetLike.coe_injective.preimage_image]
+
+theorem closure_finite_subsets (s : Set α) :
+    closure {K : Compacts α | (K : Set α).Finite ∧ ↑K ⊆ s} = {K : Compacts α | ↑K ⊆ closure s} := by
+  change closure (SetLike.coe ⁻¹' {K : Set α | K.Finite ∧ K ⊆ s}) =
+    SetLike.coe ⁻¹' (closure s).powerset
+  rw [isEmbedding_coe.closure_eq_preimage_closure_image, image_preimage_eq_of_subset ?_,
+    vietoris.closure_finite_subsets]
+  exact fun K ⟨hK, _⟩ => ⟨⟨K, hK.isCompact⟩, rfl⟩
+
+theorem dense_setOf_finite : Dense {K : Compacts α | (K : Set α).Finite} := by
+  simpa [dense_iff_closure_eq] using closure_finite_subsets (α := α) Set.univ
 
 /-- Given a basis `B` on a topological space `α`, the topology of `Compacts α` has a basis
 consisting of sets of the form `{K | K ⊆ U₁ ∪ … ∪ Uₙ, K ∩ U₁ ≠ ∅, …, K ∩ Uₙ ≠ ∅}`, where
@@ -588,6 +614,15 @@ theorem isClosed_subsets_of_isClosed {F : Set α} (h : IsClosed F) :
 theorem isClosed_inter_nonempty_of_isClosed {F : Set α} (h : IsClosed F) :
     IsClosed {K : NonemptyCompacts α | (↑K ∩ F).Nonempty} :=
   (vietoris.isClosed_inter_nonempty_of_isClosed h).preimage continuous_coe
+
+theorem closure_finite_subsets (s : Set α) :
+    closure {K : NonemptyCompacts α | (K : Set α).Finite ∧ ↑K ⊆ s} =
+      {K : NonemptyCompacts α | ↑K ⊆ closure s} := by
+  simpa only [isOpenEmbedding_toCompacts.isOpenMap.preimage_closure_eq_closure_preimage
+    continuous_toCompacts] using congr(toCompacts ⁻¹' $(Compacts.closure_finite_subsets s))
+
+theorem dense_setOf_finite : Dense {K : NonemptyCompacts α | (K : Set α).Finite} :=
+  Compacts.dense_setOf_finite.preimage isOpenEmbedding_toCompacts.isOpenMap
 
 /-- Given a basis `B` on a topological space `α`, the topology of `NonemptyCompacts α` has a basis
 consisting of sets of the form `{K | K ⊆ U₁ ∪ … ∪ Uₙ, K ∩ U₁ ≠ ∅, …, K ∩ Uₙ ≠ ∅}`, where

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -308,6 +308,50 @@ theorem specializes_of_subset_closure {s t : Set α} (hst : s ⊆ t) (hts : t �
 theorem specializes_closure {s : Set α} : s ⤳ closure s :=
   specializes_of_subset_closure subset_closure .rfl
 
+theorem isPreconnected_nonempty_finite_subsets {s : Set α} (hs : IsPreconnected s) :
+    IsPreconnected {t | t.Nonempty ∧ t.Finite ∧ t ⊆ s} := by
+  rcases eq_empty_or_nonempty s with rfl | ⟨x, hx⟩
+  · convert isPreconnected_empty
+    grind [Set.not_nonempty_empty]
+  conv => arg 1; equals ⋃ n : ℕ+, range (ι := Fin n) '' Set.pi univ fun _ => s =>
+    refine subset_antisymm (fun t ht => ?_)
+      (iUnion_subset fun _ => image_subset_iff.mpr fun f hf =>
+        ⟨range_nonempty _, finite_range _, by grind⟩)
+    obtain ⟨ht₁, ht₂, hts⟩ := ht
+    obtain ⟨n, f, -, rfl⟩ := ht₂.fin_param
+    rw [range_subset_iff] at hts
+    rw [range_nonempty_iff_nonempty] at ht₁
+    lift n to ℕ+ using Fin.pos'
+    exact mem_iUnion_of_mem n <| mem_image_of_mem _ <| mem_univ_pi.mpr hts
+  exact isPreconnected_iUnion
+    ⟨{x}, mem_iInter_of_mem fun n => ⟨fun _ => x, by grind⟩⟩
+    (fun n => .image (isPreconnected_univ_pi fun _ => hs) _ (by fun_prop))
+
+theorem isPreconnected_sUnion {s : Set (Set α)} (hs : IsPreconnected s)
+    (h : ∃ t ∈ s, IsPreconnected t) : IsPreconnected (⋃₀ s) := by
+  obtain ⟨t, hts, ht⟩ := h
+  have hts' := subset_sUnion_of_mem hts
+  intro U V hU hV hUV
+  by_cases! ht' : t ⊆ U ∨ t ⊆ V
+  · wlog htU : t ⊆ U generalizing U V
+    · grind
+    rintro - ⟨y, hys, hyV⟩
+    obtain ⟨u, hus, hyu⟩ := mem_sUnion.mpr hys
+    have : s ⊆ {v | (v ∩ V).Nonempty} ∪ U.powerset := by
+      simp_rw [← diff_subset_iff, ← not_disjoint_iff_nonempty_inter]
+      grind
+    obtain ⟨v, hvs, hvU, hvV⟩ :=
+      hs _ _ (isOpen_inter_nonempty_of_isOpen hV) hU.powerset_vietoris this
+        ⟨u, hus, y, hyu, hyV⟩ ⟨t, by grind⟩
+    apply hvU.mono
+    grind
+  · rintro - -
+    grw [← hts'] at hUV ⊢
+    have htU : ¬ Disjoint t U := by grind
+    have htV : ¬ Disjoint t V := by grind
+    rw [not_disjoint_iff_nonempty_inter] at htU htV
+    exact ht U V hU hV hUV htU htV
+
 end vietoris
 
 namespace Compacts
@@ -559,6 +603,21 @@ instance [LocallyCompactSpace α] : LocallyCompactSpace (Compacts α) := by
       vietoris.specializes_of_subset_closure ?_ ?_⟩ <;>
       grind [coe_mk, subset_closure]
 
+theorem isPreconnected_nonempty_finite_subsets {s : Set α} (hs : IsPreconnected s) :
+    IsPreconnected {K : Compacts α | (K : Set α).Nonempty ∧ (K : Set α).Finite ∧ ↑K ⊆ s} := by
+  rw [← isEmbedding_coe.isPreconnected_image]
+  convert vietoris.isPreconnected_nonempty_finite_subsets hs
+  exact subset_antisymm (image_subset_iff.mpr .rfl) (fun t ht => ⟨⟨t, ht.2.1.isCompact⟩, ht, rfl⟩)
+
+theorem isPreconnected_nonempty_subsets {s : Set α} (hs : IsPreconnected s) :
+    IsPreconnected {K : Compacts α | (K : Set α).Nonempty ∧ ↑K ⊆ s} := by
+  refine (isPreconnected_nonempty_finite_subsets hs).subset_closure (by grind) ?_
+  conv_lhs => rw [setOf_and]
+  conv_rhs => rw [setOf_and]
+  simp_rw [nonempty_iff_ne_empty, ← coe_bot, SetLike.coe_ne_coe, Ne, ← compl_singleton_eq]
+  grw [← isClopen_singleton_bot.compl.isOpen.inter_closure, closure_finite_subsets,
+    ← subset_closure]
+
 end Compacts
 
 namespace NonemptyCompacts
@@ -760,6 +819,55 @@ theorem _root_.TopologicalSpace.Compacts.locallyCompactSpace_iff :
     LocallyCompactSpace (Compacts α) ↔ LocallyCompactSpace α :=
   ⟨fun _ => NonemptyCompacts.locallyCompactSpace_iff.mp
     isOpenEmbedding_toCompacts.locallyCompactSpace, fun _ => inferInstance⟩
+
+theorem isPreconnected_finite_subsets {s : Set α} (hs : IsPreconnected s) :
+    IsPreconnected {K : NonemptyCompacts α | (K : Set α).Finite ∧ ↑K ⊆ s} := by
+  rw [← isEmbedding_toCompacts.isPreconnected_image]
+  convert Compacts.isPreconnected_nonempty_finite_subsets hs
+  exact subset_antisymm
+    (image_subset_iff.mpr fun K hK => ⟨K.nonempty, hK⟩)
+    (fun K hK => ⟨⟨K, hK.1⟩, hK.2, rfl⟩)
+
+theorem isPreconnected_subsets {s : Set α} (hs : IsPreconnected s) :
+    IsPreconnected {K : NonemptyCompacts α | ↑K ⊆ s} := by
+  rw [← isEmbedding_toCompacts.isPreconnected_image]
+  convert Compacts.isPreconnected_nonempty_subsets hs
+  exact subset_antisymm
+    (image_subset_iff.mpr fun K hK => ⟨K.nonempty, hK⟩)
+    (fun K hK => ⟨⟨K, hK.1⟩, hK.2, rfl⟩)
+
+instance [PreconnectedSpace α] : PreconnectedSpace (NonemptyCompacts α) where
+  isPreconnected_univ := by
+    convert isPreconnected_subsets (α := α) isPreconnected_univ
+    simp
+
+@[simp]
+theorem preconnectedSpace_iff : PreconnectedSpace (NonemptyCompacts α) ↔ PreconnectedSpace α := by
+  refine ⟨fun h => ?_, fun h => inferInstance⟩
+  rw [preconnectedSpace_iff_clopen] at h ⊢
+  intro s hs
+  rcases (h {K | ↑K ⊆ s}
+    ⟨isClosed_subsets_of_isClosed hs.isClosed, isOpen_subsets_of_isOpen hs.isOpen⟩) with h | h
+  · left
+    rw [Set.eq_empty_iff_forall_notMem] at h ⊢
+    exact fun x hx => h {x} (Set.singleton_subset_iff.mpr hx)
+  · right
+    rw [Set.eq_univ_iff_forall] at h ⊢
+    exact fun x => Set.singleton_subset_iff.mp (h {x})
+
+instance [ConnectedSpace α] : ConnectedSpace (NonemptyCompacts α) where
+  toNonempty := inferInstance
+
+@[simp]
+theorem connectedSpace_iff : ConnectedSpace (NonemptyCompacts α) ↔ ConnectedSpace α := by
+  refine ⟨fun h => ?_, fun _ => inferInstance⟩
+  have := preconnectedSpace_iff.mp h.toPreconnectedSpace;
+  constructor
+  rw [← not_isEmpty_iff]
+  intro
+  absurd h.toNonempty
+  rw [not_nonempty_iff]
+  infer_instance
 
 end NonemptyCompacts
 

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -618,6 +618,36 @@ theorem isPreconnected_nonempty_subsets {s : Set α} (hs : IsPreconnected s) :
   grw [← isClopen_singleton_bot.compl.isOpen.inter_closure, closure_finite_subsets,
     ← subset_closure]
 
+instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
+  rw [locallyConnectedSpace_iff_isTopologicalBasis_isOpen_isPreconnected]
+  have basis := IsTopologicalBasis.isOpen_isPreconnected.compacts (α := α)
+  refine basis.of_isOpen_of_subset (by grind) (fun U hU => ⟨basis.isOpen hU, ?_⟩)
+  suffices IsPreconnected (U ∩ {K | (K : Set α).Finite}) by
+    refine this.subset_closure (by grind) ?_
+    grw [← (basis.isOpen hU).inter_closure, dense_setOf_finite.closure_eq, inter_univ]
+  obtain ⟨u, ⟨hu', hu⟩, rfl⟩ := hU
+  lift u to Finset (Set α) using hu'
+  conv => arg 1; equals Finset.univ.sup '' Set.pi univ fun U : u =>
+      {K : Compacts α | (K : Set α).Nonempty ∧ (K : Set α).Finite ∧ (K : Set α) ⊆ U} =>
+    apply subset_antisymm
+    · refine fun K ⟨⟨hK₁, hK₂⟩, hK₃⟩ => ⟨fun U : u => ⟨K ∩ U, (hK₃.inter_of_left _).isCompact⟩,
+        fun U _ => ⟨hK₂ U U.prop, hK₃.inter_of_left _, inter_subset_right⟩, ?_⟩
+      ext1
+      simp_rw [coe_finset_sup, Finset.sup_eq_iSup, iSup_eq_iUnion, Finset.mem_univ, iUnion_true,
+        coe_mk, ← inter_iUnion, iUnion_subtype, ← SetLike.mem_coe, ← sUnion_eq_biUnion,
+        inter_eq_left.mpr hK₁]
+    · simp_rw [image_subset_iff, preimage_inter, preimage_setOf_eq, coe_finset_sup,
+        Finset.sup_eq_iSup, iSup_eq_iUnion, Finset.mem_univ, iUnion_true, iUnion_subset_iff]
+      refine fun f hf => ⟨
+        ⟨fun U => subset_sUnion_of_subset _ _ (hf U trivial).2.2 U.prop, fun U hU => ?_⟩,
+        finite_iUnion fun U => (hf U trivial).2.1⟩
+      lift U to u using hU
+      obtain ⟨h₁, -, h₂⟩ := hf U trivial
+      exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
+  exact .image
+    (isPreconnected_univ_pi fun U => isPreconnected_nonempty_finite_subsets (hu U.prop).2)
+    _ (by fun_prop)
+
 end Compacts
 
 namespace NonemptyCompacts
@@ -868,6 +898,35 @@ theorem connectedSpace_iff : ConnectedSpace (NonemptyCompacts α) ↔ ConnectedS
   absurd h.toNonempty
   rw [not_nonempty_iff]
   infer_instance
+
+instance [LocallyConnectedSpace α] : LocallyConnectedSpace (NonemptyCompacts α) :=
+  isOpenEmbedding_toCompacts.locallyConnectedSpace
+
+@[simp]
+theorem locallyConnectedSpace_iff :
+    LocallyConnectedSpace (NonemptyCompacts α) ↔ LocallyConnectedSpace α := by
+  refine ⟨fun h => ?_, fun _ => inferInstance⟩
+  rw [locallyConnectedSpace_iff_connected_basis]
+  intro x
+  refine (nhds_basis_opens x).to_hasBasis' (fun U ⟨hx, hU⟩ => ?_) (by grind)
+  obtain ⟨V, ⟨hV₁, hV₂⟩, hxV, hKV⟩ :=
+    IsTopologicalBasis.isOpen_isPreconnected.exists_subset_of_mem_open
+      (show {x} ∈ {K : NonemptyCompacts α | ↑K ⊆ U} by simpa)
+      (isOpen_subsets_of_isOpen hU)
+  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, ?_⟩, ?_⟩
+  · filter_upwards [continuous_singleton.tendsto x (hV₁.mem_nhds hxV)] with y hy
+    exact mem_iUnion₂_of_mem hy rfl
+  · rw [← sUnion_image]
+    refine vietoris.isPreconnected_sUnion (hV₂.image _ (by fun_prop)) ?_
+    rw [exists_mem_image]
+    exact ⟨{x}, hxV, isPreconnected_singleton⟩
+  · rwa [id, iUnion₂_subset_iff]
+
+@[simp]
+theorem _root_.TopologicalSpace.Compacts.locallyConnectedSpace_iff :
+    LocallyConnectedSpace (Compacts α) ↔ LocallyConnectedSpace α :=
+  ⟨fun _ => NonemptyCompacts.locallyConnectedSpace_iff.mp
+    isOpenEmbedding_toCompacts.locallyConnectedSpace, fun _ => inferInstance⟩
 
 end NonemptyCompacts
 

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -773,6 +773,44 @@ theorem isPreconnected_Ioc {K L : Compacts α} (hL : IsPreconnected (L : Set α)
   isPreconnected_of_forall L fun M hM => ⟨Icc M L, Icc_subset_Ioc_left hM.1, right_mem_Icc.mpr hM.2,
     left_mem_Icc.mpr hM.2, isPreconnected_Icc (ne_bot_of_gt hM.1) hL⟩
 
+instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
+  rw [locallyConnectedSpace_iff_isTopologicalBasis_isOpen_isPreconnected]
+  have basis := IsTopologicalBasis.isOpen_isPreconnected.compacts (α := α)
+  -- We show that the basic open sets induced by a connected basis are connected.
+  refine basis.of_isOpen_of_subset (by grind) (fun U hU => ⟨basis.isOpen hU, ?_⟩)
+  -- By density, it is enough to show connectedness for finite sets in the basic open set.
+  suffices IsPreconnected (U ∩ {K | (K : Set α).Finite}) by
+    refine this.subset_closure inter_subset_left ?_
+    grw [← (basis.isOpen hU).inter_closure, dense_setOfPred_finite.closure_eq, inter_univ]
+  obtain ⟨u, ⟨hu', hu⟩, rfl⟩ := hU
+  simp_rw [← ofPred_and, and_assoc]
+  lift u to Finset (Set α) using hu'
+  /- The finite sets in the basic open set are can be written as the unions of finite sets from
+  each connected neighborhood. By the continuity of union, these form a connected set. -/
+  suffices {K : Compacts α | ↑K ⊆ ⋃₀ (u : Set (Set α)) ∧ (∀ U ∈ (u : Set (Set α)),
+      (↑K ∩ U).Nonempty) ∧ (K : Set α).Finite} = Finset.univ.sup '' Set.pi univ fun U : u =>
+        {K : Compacts α | (K : Set α).Nonempty ∧ (K : Set α).Finite ∧ (K : Set α) ⊆ U} by
+    rw [this]
+    exact .image
+      (isPreconnected_univ_pi fun U => isPreconnected_nonempty_finite_subsets (hu U.2).2)
+      _ (by fun_prop)
+  apply subset_antisymm
+  · refine fun K ⟨hK₁, hK₂, hK₃⟩ => ⟨fun U : u => ⟨K ∩ U, (hK₃.inter_of_left _).isCompact⟩,
+      fun U _ => ⟨hK₂ U U.2, hK₃.inter_of_left _, inter_subset_right⟩, ?_⟩
+    ext1
+    simp_rw [coe_finset_sup, Finset.sup_eq_iSup, iSup_eq_iUnion, Finset.mem_univ, iUnion_true,
+      coe_mk, ← inter_iUnion, iUnion_subtype, ← SetLike.mem_coe, ← sUnion_eq_biUnion,
+      inter_eq_left.mpr hK₁]
+  · simp_rw [image_subset_iff, preimage_ofPred_eq, coe_finset_sup, Finset.sup_eq_iSup,
+      iSup_eq_iUnion, Finset.mem_univ, iUnion_true, iUnion_subset_iff]
+    refine fun f hf => ⟨
+      fun U => subset_sUnion_of_subset _ _ (hf U trivial).2.2 U.2, fun U hU => ?_,
+      finite_iUnion fun U => (hf U trivial).2.1⟩
+    lift U to u using hU
+    obtain ⟨h₁, -, h₂⟩ := hf U trivial
+    exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
+
+
 end Compacts
 
 namespace NonemptyCompacts
@@ -1083,6 +1121,35 @@ instance [ConnectedSpace α] : ConnectedSpace (NonemptyCompacts α) where
 @[simp]
 protected theorem connectedSpace_iff : ConnectedSpace (NonemptyCompacts α) ↔ ConnectedSpace α := by
   simp [connectedSpace_iff]
+
+instance [LocallyConnectedSpace α] : LocallyConnectedSpace (NonemptyCompacts α) :=
+  isOpenEmbedding_toCompacts.locallyConnectedSpace
+
+@[simp]
+theorem locallyConnectedSpace_iff :
+    LocallyConnectedSpace (NonemptyCompacts α) ↔ LocallyConnectedSpace α := by
+  refine ⟨fun h => ?_, fun _ => inferInstance⟩
+  rw [locallyConnectedSpace_iff_connected_basis]
+  intro x
+  refine (nhds_basis_opens x).to_hasBasis' (fun U ⟨hx, hU⟩ => ?_) (by grind)
+  obtain ⟨V, ⟨hV₁, hV₂⟩, hxV, hKV⟩ :=
+    IsTopologicalBasis.isOpen_isPreconnected.exists_subset_of_mem_open
+      (show {x} ∈ {K : NonemptyCompacts α | ↑K ⊆ U} by simpa)
+      (isOpen_subsets_of_isOpen hU)
+  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, ?_⟩, ?_⟩
+  · filter_upwards [continuous_singleton.tendsto x (hV₁.mem_nhds hxV)] with y hy
+    exact mem_iUnion₂_of_mem hy rfl
+  · rw [← sUnion_image]
+    refine vietoris.isPreconnected_sUnion (hV₂.image _ (by fun_prop)) ?_
+    rw [exists_mem_image]
+    exact ⟨{x}, hxV, isPreconnected_singleton⟩
+  · rwa [id, iUnion₂_subset_iff]
+
+@[simp]
+theorem _root_.TopologicalSpace.Compacts.locallyConnectedSpace_iff :
+    LocallyConnectedSpace (Compacts α) ↔ LocallyConnectedSpace α :=
+  ⟨fun _ => NonemptyCompacts.locallyConnectedSpace_iff.mp
+    isOpenEmbedding_toCompacts.locallyConnectedSpace, fun _ => inferInstance⟩
 
 end NonemptyCompacts
 

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -805,11 +805,8 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
       fun U _ => ⟨hK₂ U U.2, hK₃.inter_of_left _, inter_subset_right⟩, by aesop⟩
   · simp_rw [image_subset_iff, preimage_ofPred_eq, coe_finset_sup, Finset.sup_eq_iSup,
       iSup_eq_iUnion, Finset.mem_univ, iUnion_true, iUnion_subset_iff]
-    refine fun f hf => ⟨
-      fun U => subset_sUnion_of_subset _ _ (hf U trivial).2.2 U.2, fun U hU => ?_,
-      finite_iUnion fun U => (hf U trivial).2.1⟩
-    lift U to u using hU
-    obtain ⟨h₁, -, h₂⟩ := hf U trivial
+    refine fun f hf => ⟨by grind, fun U hU => ?_, finite_iUnion (by grind)⟩
+    obtain ⟨h₁, -, h₂⟩ := hf ⟨U, hU⟩ trivial
     exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
 end Compacts
 

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -808,6 +808,7 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
     refine fun f hf => ⟨by grind, fun U hU => ?_, finite_iUnion (by grind)⟩
     obtain ⟨h₁, -, h₂⟩ := hf ⟨U, hU⟩ trivial
     exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
+    
 end Compacts
 
 namespace NonemptyCompacts
@@ -1131,10 +1132,10 @@ theorem locallyConnectedSpace_iff :
     IsTopologicalBasis.isOpen_isPreconnected.exists_subset_of_mem_open
       (show {x} ∈ {K : NonemptyCompacts α | ↑K ⊆ U} by simpa)
       (isOpen_subsets_of_isOpen hU)
-  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, vietoris.isPreconnected_biUnion hV₂ (by fun_prop)
-    ⟨{x}, hxV, isPreconnected_singleton⟩⟩, ?_⟩
+  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, ?_⟩, ?_⟩
   · filter_upwards [continuous_singleton.tendsto x (hV₁.mem_nhds hxV)] with y hy
     exact mem_iUnion₂_of_mem hy rfl
+  · exact vietoris.isPreconnected_biUnion hV₂ (by fun_prop) ⟨{x}, hxV, isPreconnected_singleton⟩
   · rwa [id, iUnion₂_subset_iff]
 
 @[simp]

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -808,7 +808,7 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
     refine fun f hf => ⟨by grind, fun U hU => ?_, finite_iUnion (by grind)⟩
     obtain ⟨h₁, -, h₂⟩ := hf ⟨U, hU⟩ trivial
     exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
-    
+
 end Compacts
 
 namespace NonemptyCompacts

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -388,6 +388,12 @@ theorem isPreconnected_sUnion {s : Set (Set α)} (hs : IsPreconnected s)
     grw [← hts'] at hUV ⊢
     exact ht U V hU hV hUV htU htV
 
+theorem isPreconnected_biUnion {s : Set α} {f : α → Set β} (hs : IsPreconnected s)
+    (hf : ContinuousOn f s) (h : ∃ x ∈ s, IsPreconnected (f x)) :
+    IsPreconnected (⋃ x ∈ s, f x) := by
+  rw [← sUnion_image]
+  exact isPreconnected_sUnion (hs.image _ hf) (by grind)
+
 end vietoris
 
 namespace Compacts
@@ -1136,13 +1142,10 @@ theorem locallyConnectedSpace_iff :
     IsTopologicalBasis.isOpen_isPreconnected.exists_subset_of_mem_open
       (show {x} ∈ {K : NonemptyCompacts α | ↑K ⊆ U} by simpa)
       (isOpen_subsets_of_isOpen hU)
-  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, ?_⟩, ?_⟩
+  refine ⟨⋃ L ∈ V, ↑L, ⟨?_, vietoris.isPreconnected_biUnion hV₂ (by fun_prop)
+    ⟨{x}, hxV, isPreconnected_singleton⟩⟩, ?_⟩
   · filter_upwards [continuous_singleton.tendsto x (hV₁.mem_nhds hxV)] with y hy
     exact mem_iUnion₂_of_mem hy rfl
-  · rw [← sUnion_image]
-    refine vietoris.isPreconnected_sUnion (hV₂.image _ (by fun_prop)) ?_
-    rw [exists_mem_image]
-    exact ⟨{x}, hxV, isPreconnected_singleton⟩
   · rwa [id, iUnion₂_subset_iff]
 
 @[simp]

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -790,23 +790,19 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
     grw [← (basis.isOpen hU).inter_closure, dense_setOfPred_finite.closure_eq, inter_univ]
   obtain ⟨u, ⟨hu', hu⟩, rfl⟩ := hU
   simp_rw [← ofPred_and, and_assoc]
-  lift u to Finset (Set α) using hu'
+  let := hu'.fintype
   /- The finite sets in the basic open set are can be written as the unions of finite sets from
   each connected neighborhood. By the continuity of union, these form a connected set. -/
-  suffices {K : Compacts α | ↑K ⊆ ⋃₀ (u : Set (Set α)) ∧ (∀ U ∈ (u : Set (Set α)),
-      (↑K ∩ U).Nonempty) ∧ (K : Set α).Finite} = Finset.univ.sup '' Set.pi univ fun U : u =>
-        {K : Compacts α | (K : Set α).Nonempty ∧ (K : Set α).Finite ∧ (K : Set α) ⊆ U} by
+  suffices {K : Compacts α | ↑K ⊆ ⋃₀ u ∧ (∀ U ∈ u, (↑K ∩ U).Nonempty) ∧ (K : Set α).Finite} =
+    Finset.univ.sup '' Set.pi univ fun U : u =>
+      {K : Compacts α | (K : Set α).Nonempty ∧ (K : Set α).Finite ∧ (K : Set α) ⊆ U} by
     rw [this]
     exact .image
       (isPreconnected_univ_pi fun U => isPreconnected_nonempty_finite_subsets (hu U.2).2)
       _ (by fun_prop)
   apply subset_antisymm
-  · refine fun K ⟨hK₁, hK₂, hK₃⟩ => ⟨fun U : u => ⟨K ∩ U, (hK₃.inter_of_left _).isCompact⟩,
-      fun U _ => ⟨hK₂ U U.2, hK₃.inter_of_left _, inter_subset_right⟩, ?_⟩
-    ext1
-    simp_rw [coe_finset_sup, Finset.sup_eq_iSup, iSup_eq_iUnion, Finset.mem_univ, iUnion_true,
-      coe_mk, ← inter_iUnion, iUnion_subtype, ← SetLike.mem_coe, ← sUnion_eq_biUnion,
-      inter_eq_left.mpr hK₁]
+  · exact fun K ⟨hK₁, hK₂, hK₃⟩ => ⟨fun U => ⟨K ∩ U, (hK₃.inter_of_left _).isCompact⟩,
+      fun U _ => ⟨hK₂ U U.2, hK₃.inter_of_left _, inter_subset_right⟩, by aesop⟩
   · simp_rw [image_subset_iff, preimage_ofPred_eq, coe_finset_sup, Finset.sup_eq_iSup,
       iSup_eq_iUnion, Finset.mem_univ, iUnion_true, iUnion_subset_iff]
     refine fun f hf => ⟨
@@ -815,8 +811,6 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (Compacts α) := by
     lift U to u using hU
     obtain ⟨h₁, -, h₂⟩ := hf U trivial
     exact h₁.mono (subset_inter (subset_iUnion _ _) h₂)
-
-
 end Compacts
 
 namespace NonemptyCompacts
@@ -1134,9 +1128,7 @@ instance [LocallyConnectedSpace α] : LocallyConnectedSpace (NonemptyCompacts α
 @[simp]
 theorem locallyConnectedSpace_iff :
     LocallyConnectedSpace (NonemptyCompacts α) ↔ LocallyConnectedSpace α := by
-  refine ⟨fun h => ?_, fun _ => inferInstance⟩
-  rw [locallyConnectedSpace_iff_connected_basis]
-  intro x
+  refine ⟨fun h => locallyConnectedSpace_iff_connected_basis.2 fun x ↦ ?_, fun _ => inferInstance⟩
   refine (nhds_basis_opens x).to_hasBasis' (fun U ⟨hx, hU⟩ => ?_) (by grind)
   obtain ⟨V, ⟨hV₁, hV₂⟩, hxV, hKV⟩ :=
     IsTopologicalBasis.isOpen_isPreconnected.exists_subset_of_mem_open


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #34278 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
