### PR TITLE
[Merged by Bors] - feat: more `Finset.disjiUnion` lemmas

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -333,6 +333,16 @@ theorem filter_cons {a : α} (s : Finset α) (ha : a ∉ s) :
     (s.cons a ha).filter p =
       if p a then (s.filter p).cons a ((mem_of_mem_filter _).mt ha) else s.filter p := by grind
 
+@[simp]
+theorem disjoint_disjUnion_left {s t u : Finset α} (h : Disjoint s t) :
+    Disjoint (s.disjUnion t h) u ↔ Disjoint s u ∧ Disjoint t u := by
+  simp only [disjoint_left, mem_disjUnion, or_imp, forall_and]
+
+@[simp]
+theorem disjoint_disjUnion_right {s t u : Finset α} (h : Disjoint t u) :
+    Disjoint s (t.disjUnion u h) ↔ Disjoint s t ∧ Disjoint s u := by
+  simp only [disjoint_right, mem_disjUnion, or_imp, forall_and]
+
 section
 variable [DecidableEq α]
 

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -149,39 +149,33 @@ theorem filter_disjiUnion (s : Finset α) (f : α → Finset β) (h) (p : β →
       = s.disjiUnion (fun a ↦ (f a).filter p) (pairwiseDisjoint_filter h p) := by grind
 
 theorem disjiUnion_singleton {f : α → β} (hf : f.Injective) :
-    s.disjiUnion (fun a => {f a}) (fun _ _ _ _ => disjoint_singleton.mpr ∘ hf.ne) = s.map ⟨f, hf⟩ := by
+    s.disjiUnion (fun a ↦ {f a}) (fun _ _ _ _ ↦ disjoint_singleton.mpr ∘ hf.ne) =
+      s.map ⟨f, hf⟩ := by
   ext; simp [eq_comm]
 
-@[simp]
-theorem disjoint_disjUnion_left  {s t u : Finset α} (h : Disjoint s t) :
-    Disjoint (s.disjUnion t h) u ↔ Disjoint s u ∧ Disjoint t u := by
-  simp only [disjoint_left, mem_disjUnion, or_imp, forall_and]
-
-@[simp]
-theorem disjoint_disjUnion_right {s t u : Finset α} (h : Disjoint t u) :
-    Disjoint s (t.disjUnion u h) ↔ Disjoint s t ∧ Disjoint s u := by
-  simp only [disjoint_right, mem_disjUnion, or_imp, forall_and]
-
-lemma disjoint_disjiUnion_left (s : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint s f) (t : Finset β) :
+lemma disjoint_disjiUnion_left
+    (s : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint s f) (t : Finset β) :
     Disjoint (s.disjiUnion f hf) t ↔ ∀ i ∈ s, Disjoint (f i) t := by
   induction s using Finset.cons_induction <;> simp_all
 
-lemma disjoint_disjiUnion_right (s : Finset β) (t : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint t f):
+lemma disjoint_disjiUnion_right
+    (s : Finset β) (t : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint t f) :
     Disjoint s (t.disjiUnion f hf) ↔ ∀ i ∈ t, Disjoint s (f i) := by
   simpa only [_root_.disjoint_comm] using disjoint_disjiUnion_left t f hf s
 
 theorem pairwiseDisjoint_disjUnion {f g : α → Finset β}
     (hfg : ∀ a, Disjoint (f a) (g a))
-    (hfg' : Set.Pairwise s fun a₁ a₂ => Disjoint (f a₁) (g a₂))
+    (hfg' : Set.Pairwise s fun a₁ a₂ ↦ Disjoint (f a₁) (g a₂))
     (hf : Set.PairwiseDisjoint s f) (hg : Set.PairwiseDisjoint s g) :
-    Set.PairwiseDisjoint s (fun a => (f a).disjUnion (g a) (hfg a)) := by
+    Set.PairwiseDisjoint s (fun a ↦ (f a).disjUnion (g a) (hfg a)) := by
   intros i hi j hj hij
   simp [hf hi hj hij, hg hi hj hij, hfg' hi hj hij, (hfg' hj hi hij.symm).symm]
 
 theorem disjiUnion_disjUnion {f g : α → Finset β} (hfg : ∀ a, Disjoint (f a) (g a))
-    (hfg' : Set.Pairwise s fun a₁ a₂ => Disjoint (f a₁) (g a₂))
+    (hfg' : Set.Pairwise s fun a₁ a₂ ↦ Disjoint (f a₁) (g a₂))
     (hf : Set.PairwiseDisjoint s f) (hg : Set.PairwiseDisjoint s g) :
-    s.disjiUnion (fun a => (f a).disjUnion (g a) (hfg a)) (pairwiseDisjoint_disjUnion hfg hfg' hf hg) =
+    s.disjiUnion (fun a ↦ (f a).disjUnion (g a) (hfg a))
+        (pairwiseDisjoint_disjUnion hfg hfg' hf hg) =
       (s.disjiUnion f hf).disjUnion (s.disjiUnion g hg) (by
         simp_rw [disjoint_disjiUnion_left, disjoint_disjiUnion_right]
         intros i hi j hj

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -127,6 +127,13 @@ theorem disjiUnion_map {s : Finset α} {t : α → Finset β} {f : β ↪ γ} {h
       s.disjiUnion (fun a => (t a).map f) (h.mono' fun _ _ ↦ (disjoint_map _).2) :=
   eq_of_veq <| Multiset.map_bind _ _ _
 
+@[simp]
+theorem disjiUnion_singleton_eq_self (s : Finset α) :
+    s.disjiUnion singleton (fun _ _ => by simp) = s := by
+  grind
+
+section
+
 variable {f : α → β} {op : β → β → β} [hc : Std.Commutative op] [ha : Std.Associative op]
 
 theorem fold_disjiUnion {ι : Type*} {s : Finset ι} {t : ι → Finset α} {b : ι → β} {b₀ : β} (h) :
@@ -140,6 +147,50 @@ lemma pairwiseDisjoint_filter {f : α → Finset β} (h : Set.PairwiseDisjoint �
 theorem filter_disjiUnion (s : Finset α) (f : α → Finset β) (h) (p : β → Prop) [DecidablePred p] :
     (s.disjiUnion f h).filter p
       = s.disjiUnion (fun a ↦ (f a).filter p) (pairwiseDisjoint_filter h p) := by grind
+
+
+theorem disjiUnion_singleton {f : α → β} (hf : f.Injective) :
+    s.disjiUnion (fun a => {f a}) (fun _ _ _ _ => disjoint_singleton.mpr ∘ hf.ne) = s.map ⟨f, hf⟩ := by
+  ext; simp [eq_comm]
+
+@[simp]
+theorem disjoint_disjUnion_left  {s t u : Finset α} (h : Disjoint s t) :
+    Disjoint (s.disjUnion t h) u ↔ Disjoint s u ∧ Disjoint t u := by
+  simp only [disjoint_left, mem_disjUnion, or_imp, forall_and]
+
+@[simp]
+theorem disjoint_disjUnion_right {s t u : Finset α} (h : Disjoint t u) :
+    Disjoint s (t.disjUnion u h) ↔ Disjoint s t ∧ Disjoint s u := by
+  simp only [disjoint_right, mem_disjUnion, or_imp, forall_and]
+
+lemma disjoint_disjiUnion_left (s : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint s f) (t : Finset β) :
+    Disjoint (s.disjiUnion f hf) t ↔ ∀ i ∈ s, Disjoint (f i) t := by
+  induction s using Finset.cons_induction <;> simp_all
+    
+lemma disjoint_disjiUnion_right (s : Finset β) (t : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint t f):
+    Disjoint s (t.disjiUnion f hf) ↔ ∀ i ∈ t, Disjoint s (f i) := by
+  simpa only [_root_.disjoint_comm] using disjoint_disjiUnion_left t f hf s
+
+theorem pairwiseDisjoint_disjUnion {f g : α → Finset β}
+    (hfg : ∀ a, Disjoint (f a) (g a))
+    (hfg' : Set.Pairwise s fun a₁ a₂ => Disjoint (f a₁) (g a₂))
+    (hf : Set.PairwiseDisjoint s f) (hg : Set.PairwiseDisjoint s g) :
+    Set.PairwiseDisjoint s (fun a => (f a).disjUnion (g a) (hfg a)) := by
+  intros i hi j hj hij
+  simp [hf hi hj hij, hg hi hj hij, hfg' hi hj hij, (hfg' hj hi hij.symm).symm]
+
+theorem disjiUnion_disjUnion {f g : α → Finset β} (hfg : ∀ a, Disjoint (f a) (g a))
+    (hfg' : Set.Pairwise s fun a₁ a₂ => Disjoint (f a₁) (g a₂))
+    (hf : Set.PairwiseDisjoint s f) (hg : Set.PairwiseDisjoint s g) :
+    s.disjiUnion (fun a => (f a).disjUnion (g a) (hfg a)) (pairwiseDisjoint_disjUnion hfg hfg' hf hg) =
+      (s.disjiUnion f hf).disjUnion (s.disjiUnion g hg) (by
+        simp_rw [disjoint_disjiUnion_left, disjoint_disjiUnion_right]
+        intros i hi j hj
+        specialize hfg' hi hj
+        grind) := by
+  grind
+
+end
 
 end DisjiUnion
 

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -166,7 +166,7 @@ theorem disjoint_disjUnion_right {s t u : Finset α} (h : Disjoint t u) :
 lemma disjoint_disjiUnion_left (s : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint s f) (t : Finset β) :
     Disjoint (s.disjiUnion f hf) t ↔ ∀ i ∈ s, Disjoint (f i) t := by
   induction s using Finset.cons_induction <;> simp_all
-    
+
 lemma disjoint_disjiUnion_right (s : Finset β) (t : Finset α) (f : α → Finset β) (hf : Set.PairwiseDisjoint t f):
     Disjoint s (t.disjiUnion f hf) ↔ ∀ i ∈ t, Disjoint s (f i) := by
   simpa only [_root_.disjoint_comm] using disjoint_disjiUnion_left t f hf s

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -148,7 +148,6 @@ theorem filter_disjiUnion (s : Finset α) (f : α → Finset β) (h) (p : β →
     (s.disjiUnion f h).filter p
       = s.disjiUnion (fun a ↦ (f a).filter p) (pairwiseDisjoint_filter h p) := by grind
 
-
 theorem disjiUnion_singleton {f : α → β} (hf : f.Injective) :
     s.disjiUnion (fun a => {f a}) (fun _ _ _ _ => disjoint_singleton.mpr ∘ hf.ne) = s.map ⟨f, hf⟩ := by
   ext; simp [eq_comm]

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -132,8 +132,6 @@ theorem disjiUnion_singleton_eq_self (s : Finset α) :
     s.disjiUnion singleton (fun _ _ => by simp) = s := by
   grind
 
-section
-
 variable {f : α → β} {op : β → β → β} [hc : Std.Commutative op] [ha : Std.Associative op]
 
 theorem fold_disjiUnion {ι : Type*} {s : Finset ι} {t : ι → Finset α} {b : ι → β} {b₀ : β} (h) :
@@ -182,8 +180,6 @@ theorem disjiUnion_disjUnion {f g : α → Finset β} (hfg : ∀ a, Disjoint (f 
         specialize hfg' hi hj
         grind) := by
   grind
-
-end
 
 end DisjiUnion
 


### PR DESCRIPTION

These all match existing `biUnion` lemmas further down the file.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
