### PR TITLE
feat(Algebra/Module/Equiv): add funRight and funCongrRight

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -830,6 +830,79 @@ end LinearEquiv
 
 end FunLeft
 
+section FunRight
+
+variable {N P : Type*} (m : Type*) (R) [Semiring R] [AddCommMonoid M] [Module R M]
+  [AddCommMonoid N] [Module R N] [AddCommMonoid P] [Module R P]
+
+namespace LinearMap
+
+/-- Given an arbitrary type `m` and `R`-linear map `f : M →ₗ[R] N`, construct a linear map
+`(m → M) →ₗ[R] (m → N)` -/
+def funRight (f : M →ₗ[R] N) : (m → M) →ₗ[R] m → N where
+  toFun := (f ∘ ·)
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+
+@[simp]
+theorem funRight_apply (f : M →ₗ[R] N) (g : m → M) (i : m) : funRight R m f g i = f (g i) :=
+  rfl
+
+@[simp]
+theorem funRight_id (g : m → M) : funRight R m id g = g :=
+  rfl
+
+theorem funRight_comp (f₁ : N →ₗ[R] P) (f₂ : M →ₗ[R] N) :
+    funRight R m (f₁ ∘ₗ f₂) = (funRight R m f₁) ∘ₗ (funRight R m f₂) :=
+  rfl
+
+theorem funRight_injective (f : M →ₗ[R] N) (hf : Injective f) :
+    Injective (funRight R m f) :=
+  hf.comp_left
+
+theorem funRight_surjective (f : M →ₗ[R] N) (hf : Surjective f) :
+    Surjective (funRight R m f) :=
+  hf.comp_left
+
+end LinearMap
+
+namespace LinearEquiv
+
+open LinearMap
+
+/-- Given an arbitrary type `m` and `R`-linear equivalence `f : M ≃ₗ[R] N`, construct a linear
+equivalence `(m → M) ≃ₗ[R] (m → N)`. -/
+def funCongrRight (e : M ≃ₗ[R] N) : (m → M) ≃ₗ[R] m → N :=
+  LinearEquiv.ofLinear (funRight R m e) (funRight R m e.symm)
+    (LinearMap.ext fun x ↦ funext fun i ↦ by
+      rw [id_apply, ← funRight_comp, LinearEquiv.comp_symm, LinearMap.funRight_id])
+    (LinearMap.ext fun x ↦ funext fun i ↦ by
+      rw [id_apply, ← funRight_comp, LinearEquiv.symm_comp, LinearMap.funRight_id])
+
+@[simp]
+theorem funCongrRight_apply (e : M ≃ₗ[R] N) (x : m → M) :
+    funCongrRight R m e x = funRight R m e x :=
+  rfl
+
+@[simp]
+theorem funCongrRight_id : funCongrRight R m (LinearEquiv.refl R M) = LinearEquiv.refl R (m → M) :=
+  rfl
+
+@[simp]
+theorem funCongrRight_comp (e₁ : M ≃ₗ[R] N) (e₂ : N ≃ₗ[R] P) :
+    funCongrRight R m (LinearEquiv.trans e₁ e₂) =
+      LinearEquiv.trans (funCongrRight R m e₁) (funCongrRight R m e₂) :=
+  rfl
+
+@[simp]
+theorem funCongrRight_symm (e : M ≃ₗ[R] N) :
+    (funCongrRight R m e).symm = funCongrRight R m e.symm :=
+  rfl
+
+end LinearEquiv
+
+end FunRight
+
 section Pi
 
 namespace LinearEquiv


### PR DESCRIPTION
This PR adds two maps for working with maps from a general type into a module along with some basic lemmas.

* funRight : given an arbitrary type `m` and `R`-linear map `f : M →ₗ[R] N`, constructs a linear map
`(m → M) →ₗ[R] (m → N)`
* funCongrRight : upgrades `funRight` to a linear equivalence when `f` is an equivalence

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
