### PR TITLE
feat(Data): a monad for partial computations

### DIFF
--- a/Mathlib/Data/OmegaPart.lean
+++ b/Mathlib/Data/OmegaPart.lean
@@ -181,7 +181,7 @@ open OmegaCompletePartialOrder
 instance [OmegaCompletePartialOrder A] : OmegaCompletePartialOrder (ΩPart A) where
   ωSup c := {
     Dom := .any fun n ↦ (c n).Dom
-    get h := Quot.recOn (ΩProp.find h)
+    get h := Quot.recOn (ΩProp.find (ΩProp.coe_any.mp h))
       (fun n ↦ ωSup {
         toFun m := (c (m + n)).get (by
           obtain ⟨_, ⟨h, _⟩, _⟩ := c.monotone
@@ -204,17 +204,15 @@ instance [OmegaCompletePartialOrder A] : OmegaCompletePartialOrder (ΩPart A) wh
   le_ωSup c i a ha := by
     rcases ha with ⟨ha, rfl⟩
     simp only [eq_rec_constant, mem_mk, ↓existsAndEq, true_and]
-    have : ↑(ΩProp.any fun n ↦ (c n).Dom) := by
-      simp only [ΩProp.coe_any]
-      use i
-    use this
+    have : ∃n, (c n).Dom := by use i
+    use ΩProp.coe_any.mpr this
     induction ΩProp.find this using Quot.ind with | mk n =>
     apply le_ωSup_of_le i (get_mono (c.monotone (Nat.le_add_right i n)) ha)
   ωSup_le c x h a ha := by
     rcases ha with ⟨ha, rfl⟩
     simp only [eq_rec_constant]
     dsimp only at ha
-    induction ΩProp.find ha using Quot.ind with | mk n =>
+    induction ΩProp.find (ΩProp.coe_any.mp ha) using Quot.ind with | mk n =>
     use x.get (dom_mono (h n) n.property)
     simp only [mem_get, ωSup_le_iff, true_and]
     intro i
@@ -253,7 +251,7 @@ lemma ωSup_some [OmegaCompletePartialOrder A] (a : A) : ωSup (Chain.some a) = 
     ΩProp.any_const, ΩProp.coe_true, exists_true_left, mem_some]
   have : ↑(ΩProp.any fun n ↦ ((Chain.some b) n).Dom) := by
     simp only [Chain.some_coe, some_Dom, ΩProp.any_const, ΩProp.coe_true]
-  induction ΩProp.find this using Quot.ind with | mk c =>
+  induction ΩProp.find (ΩProp.coe_any.mp this) using Quot.ind with | mk c =>
   have : ωSup { toFun := fun m ↦ a, monotone' _ _ _ := by rfl } = a := by
     apply le_antisymm
     · simp only [ωSup_le_iff, Chain, OrderHom.coe_mk, le_refl, implies_true]

--- a/Mathlib/Data/OmegaPart.lean
+++ b/Mathlib/Data/OmegaPart.lean
@@ -1,0 +1,268 @@
+module
+
+public import Mathlib.Data.OmegaProp
+public import Mathlib.Control.LawfulFix
+
+/-!
+# Semi-Computable Optional Values
+
+This file defines `ΩPart α`, the type of _semi-computable values_. It is classically equivalent
+to `Option`, but supports a different set of operations without giving up computability.
+`ΩPart α` behaves the same as `Option α` except that `o : Option α` is decidably none or some a for
+some `a : α`, while the domain of `o : Part α` need only be semi-decidable.
+
+# Main Declarations
+
+* `ΩPart.none`: The partial value whose domain is `ΩProp.false`.
+* `ΩPart.some a`: The partial value whose domain is `ΩProp.true` and whose value is `a`.
+* `ΩPart.bind`: `o.bind f` has value `(f (o.get _)).get _` (`f o` morally) and is defined when `o`
+  and `f (o.get _)` are defined.
+* A computable `OmegaCompletePartialOrder` instance.
+* `ΩPart.unwrap`: Gets the value of a partial value regardless of its domain. Logically unsound, but
+  operationally sound (i.e., it will throw an error or not terminate if the value does not exist.)
+-/
+
+public section
+
+/-- Semi-computable optional values. -/
+structure ΩPart (A : Type*) where
+  Dom : ΩProp
+  get : Dom → A
+
+namespace ΩPart
+
+variable {A B C : Type*}
+
+instance : Membership A (ΩPart A) where
+  mem x a := ∃d, a = x.get d
+
+@[simp]
+lemma mem_mk (a : A) (Dom : ΩProp) (get : Dom → A) : a ∈ mk Dom get ↔ ∃h, a = get h := by
+  rfl
+
+@[simp]
+lemma mem_get {x : ΩPart A} (h : x.Dom) : x.get h ∈ x := by
+  simp only [Membership.mem, exists_prop, and_true, h]
+
+@[ext]
+lemma ext {x y : ΩPart A} (h : ∀ a, a ∈ x ↔ a ∈ y) : x = y := by
+  rcases x with ⟨x₁, x₂⟩
+  rcases y with ⟨y₁, y₂⟩
+  have : x₁ = y₁ := by
+    ext
+    cases x₁
+    · specialize h (x₂ (by simp only [ΩProp.coe_true]))
+      simp only [mem_mk, ΩProp.coe_true, exists_const, true_iff] at h
+      grind
+    · simpa only [
+        ΩProp.coe_false, false_iff, mem_mk, IsEmpty.exists_iff,
+        not_exists, forall_eq_apply_imp_iff, imp_false] using h
+  subst this
+  simp only [mk.injEq, heq_eq_eq, true_and]
+  ext h'
+  simp only [mem_mk, h', exists_true_left, eq_iff_eq_cancel_left] at h
+  exact h
+
+@[grind →]
+lemma mem_unique {a b} {x : ΩPart A} (h₁ : a ∈ x) (h₂ : b ∈ x) : a = b := by
+  simp only [Membership.mem] at h₁ h₂
+  grind
+
+/-- An empty optional value. Corresponds to non-termination. -/
+@[simps, expose]
+def none : ΩPart A where
+  Dom := .false
+  get h := by simp only [ΩProp.coe_false] at h
+
+@[simp]
+lemma mem_none {a : A} : a ∉ none := by
+  simp only [Membership.mem, none, ΩProp.coe_false, IsEmpty.exists_iff, not_false_eq_true]
+
+/-- A present optional value. -/
+@[simps, expose]
+def some (a : A) : ΩPart A where
+  Dom := .true
+  get _ := a
+
+@[simp]
+lemma mem_some {a b : A} : a ∈ some b ↔ a = b := by
+  simp only [Membership.mem, some, ΩProp.coe_true, exists_const]
+
+@[elab_as_elim, cases_eliminator]
+lemma cases {p : ΩPart A → Prop} (none : p none) (some : ∀ x, p (some x)) (x) : p x := by
+  rcases x with ⟨Dom, get⟩
+  cases Dom with
+  | true =>
+    change p ⟨.true, fun _ ↦ get (by simp only [ΩProp.coe_true])⟩
+    apply some
+  | false =>
+    have : get = fun h ↦ by simp only [ΩProp.coe_false] at h := by
+      ext h
+      simp only [ΩProp.coe_false] at h
+    simp only [this]
+    apply none
+
+/-- Monadic bind for optional values. -/
+def bind (f : A → ΩPart B) (x : ΩPart A) : ΩPart B where
+  Dom := x.Dom.bind fun h ↦ (f (x.get h)).Dom
+  get h :=
+    have : ∃h' : x.Dom, (f (x.get h')).Dom := by
+      simpa only [ΩProp.coe_bind] using h
+    (f (x.get this.choose)).get this.choose_spec
+
+@[simp]
+lemma mem_bind (f : A → ΩPart B) (x : ΩPart A) (b : B) : b ∈ bind f x ↔ ∃a ∈ x, b ∈ f a := by
+  simp only [Membership.mem, bind, ΩProp.coe_bind, ↓existsAndEq, true_and]
+  apply Iff.intro
+  · grind
+  · rintro ⟨h₁, h₂, rfl⟩
+    grind
+
+@[simp]
+lemma bind_none (f : A → ΩPart B) : bind f none = none := by
+  ext
+  simp only [mem_bind, mem_none, false_and, exists_false]
+
+@[simp]
+lemma none_bind : bind (fun _ ↦ none) = fun _ : ΩPart A ↦ (none : ΩPart B) := by
+  ext
+  simp only [mem_bind, mem_none, and_false, exists_false]
+
+@[simp]
+lemma some_bind : bind (some (A := A)) = id := by
+  ext
+  simp only [mem_bind, mem_some, exists_eq_right', id_eq]
+
+@[simp]
+lemma bind_some (f : A → ΩPart B) (x : A) : bind f (some x) = f x := by
+  ext
+  simp only [mem_bind, mem_some, exists_eq_left]
+
+lemma bind_bind
+    (f : B → ΩPart C) (g : A → ΩPart B) (x : ΩPart A)
+    : bind f (bind g x) = bind (bind f ∘ g) x := by
+  ext
+  simp only [mem_bind, Function.comp_apply]
+  grind
+
+@[simps -isSimp]
+instance [LE A] : LE (ΩPart A) where
+  le x y := ∀a ∈ x, ∃b ∈ y, a ≤ b
+
+lemma dom_mono [LE A] {x y : ΩPart A} (h : x ≤ y) : Dom x ≤ Dom y := by
+  intro h'
+  obtain ⟨b, hb⟩ := h (x.get h') (by simp only [mem_get])
+  exact hb.1.1
+
+lemma get_mono [LE A] {x y : ΩPart A} (h : x ≤ y) (hx : _) : x.get hx ≤ y.get (dom_mono h hx) := by
+  specialize h (x.get hx)
+  simp only [mem_get, forall_const] at h
+  rcases h with ⟨b, hb₁, hb₂⟩
+  simp only [Membership.mem] at hb₁
+  rcases hb₁ with ⟨b, rfl⟩
+  exact hb₂
+
+instance [Preorder A] : Preorder (ΩPart A) where
+  le_refl := by
+    simp only [le_def]
+    grind
+  le_trans := by
+    simp only [le_def]
+    grind
+
+instance [PartialOrder A] : PartialOrder (ΩPart A) where
+  le_antisymm x y h₁ h₂ := by
+    simp only [le_def] at h₁ h₂
+    ext a
+    grind
+
+open OmegaCompletePartialOrder
+
+instance [OmegaCompletePartialOrder A] : OmegaCompletePartialOrder (ΩPart A) where
+  ωSup c := {
+    Dom := .any fun n ↦ (c n).Dom
+    get h := Quot.recOn (ΩProp.find h)
+      (fun n ↦ ωSup {
+        toFun m := (c (m + n)).get (by
+          obtain ⟨_, ⟨h, _⟩, _⟩ := c.monotone
+            (by grind : n ≤ m + n)
+            ((c n).get n.property)
+            (by simp only [mem_get])
+          exact h)
+        monotone' i₁ i₂ hi := get_mono (c.monotone (by grind)) _
+      })
+      (by intro n₁ n₂ _
+          simp only [eq_rec_constant]
+          apply le_antisymm
+          · simp only [ωSup_le_iff]
+            intro m
+            apply le_ωSup_of_le (m + n₁) (get_mono (c.monotone (Nat.le_add_right _ _)) _)
+          · simp only [ωSup_le_iff]
+            intro m
+            apply le_ωSup_of_le (m + n₂) (get_mono (c.monotone (Nat.le_add_right _ _)) _))
+  }
+  le_ωSup c i a ha := by
+    rcases ha with ⟨ha, rfl⟩
+    simp only [eq_rec_constant, mem_mk, ↓existsAndEq, true_and]
+    have : ↑(ΩProp.any fun n ↦ (c n).Dom) := by
+      simp only [ΩProp.coe_any]
+      use i
+    use this
+    induction ΩProp.find this using Quot.ind with | mk n =>
+    apply le_ωSup_of_le i (get_mono (c.monotone (Nat.le_add_right i n)) ha)
+  ωSup_le c x h a ha := by
+    rcases ha with ⟨ha, rfl⟩
+    simp only [eq_rec_constant]
+    dsimp only at ha
+    induction ΩProp.find ha using Quot.ind with | mk n =>
+    use x.get (dom_mono (h n) n.property)
+    simp only [mem_get, ωSup_le_iff, true_and]
+    intro i
+    apply get_mono (h (i + n))
+
+def Chain.none [Preorder A] : Chain (ΩPart A) where
+  toFun _ := .none
+  monotone' _ _ _ := by grind
+
+@[simp]
+lemma Chain.none_coe [Preorder A] n : Chain.none (A := A) n = .none := by
+  rfl
+
+@[simp]
+lemma ωSup_none [OmegaCompletePartialOrder A] : ωSup Chain.none = (none : ΩPart A) := by
+  ext a
+  simp only [
+    ωSup, eq_rec_constant, mem_mk, ΩProp.coe_any,
+    mem_none, iff_false, not_exists, forall_exists_index]
+  intro n h₁ rfl
+  simp only [Chain.none_coe, none_Dom, ΩProp.coe_false] at h₁
+
+def Chain.some [Preorder A] (a : A) : Chain (ΩPart A) where
+  toFun _ := .some a
+  monotone' _ _ _ := by grind
+
+@[simp]
+lemma Chain.some_coe [Preorder A] (a : A) (n) : Chain.some a n = .some a := by
+  rfl
+
+@[simp]
+lemma ωSup_some [OmegaCompletePartialOrder A] (a : A) : ωSup (Chain.some a) = some a := by
+  ext b
+  simp only [
+    ωSup, Chain.some_coe, some_get, eq_rec_constant, mem_mk, some_Dom,
+    ΩProp.any_const, ΩProp.coe_true, exists_true_left, mem_some]
+  have : ↑(ΩProp.any fun n ↦ ((Chain.some b) n).Dom) := by
+    simp only [Chain.some_coe, some_Dom, ΩProp.any_const, ΩProp.coe_true]
+  induction ΩProp.find this using Quot.ind with | mk c =>
+  have : ωSup { toFun := fun m ↦ a, monotone' _ _ _ := by rfl } = a := by
+    apply le_antisymm
+    · simp only [ωSup_le_iff, Chain, OrderHom.coe_mk, le_refl, implies_true]
+    · simp only [Chain, OrderHom.coe_mk, le_refl, le_ωSup_of_le 0]
+  simp only [this]
+
+/-- `unwrap o` gets the value at `o`, ignoring the condition. This
+function is logically unsound, but operationally sound  (i.e., it
+will throw an error or not terminate if the value does not exist.). -/
+unsafe def unwrap (o : ΩPart A) : A := o.get lcProof
+
+end ΩPart

--- a/Mathlib/Data/OmegaProp.lean
+++ b/Mathlib/Data/OmegaProp.lean
@@ -336,9 +336,9 @@ The function `find` computes such an `n`.
 Note that we cannot know _which_ `n` it is because `any p` is
 equal to `any q` for any `q : ℕ → Bool` satisfying `∃m, q m = true`.
 Hence the return type of this function must be `Squash`ed. -/
-def find {p : ℕ → ΩProp} : ↑(any p) → Squash { n // p n } :=
+def find {p : ℕ → ΩProp} : (∃ n, p n) → Squash { n // p n } :=
   elimOnPiSubsingleton p fun p hp ↦ by
-    simp only [coe_any, coe_mk] at hp
+    simp only [coe_mk] at hp
     have : ∃n : ℕ, p n.unpair.1 n.unpair.2 := by
       rcases hp with ⟨m, n, h⟩
       use Nat.pair m n

--- a/Mathlib/Data/OmegaProp.lean
+++ b/Mathlib/Data/OmegaProp.lean
@@ -1,0 +1,621 @@
+module
+
+import Mathlib.Data.Nat.Find
+import Mathlib.Data.Nat.Notation
+import Mathlib.Data.Nat.Pairing
+import Mathlib.Data.Quot
+public import Mathlib.Order.OmegaCompletePartialOrder
+
+/-!
+# Semi-Computable Propositions
+
+This file defines `ΩProp`, the type of _semi-computable propositions_. It is classically equivalent
+to `Bool` and `Prop`, but supports some operations which are not computable with the other types.
+Operationally, an `p : ΩProp` is a sequence of booleans such that `p` is "true" iff at least one
+boolean in the sequence is `true`.
+
+# Main Declarations
+
+* `ΩProp.true`, `ΩProp.false`: Analogues of `True` and `False`.
+* `ΩProp.and`, `ΩProp.or`: Analogues of `∧` and `∨`.
+* `ΩProp.bind`: Dependent conjunction (`ΩProp.bind p q ↔ ∃h : p, q h`).
+* `ΩProp.any`: Existential quantification over `ℕ`.
+  This is also the implementation of `OmegaCompletePartialOrder.ωSup`.
+* `ΩProp.find`: Computes a `Squash`ed witness (of type `ℕ`) from an `ΩProp.any` proof.
+-/
+
+public section
+
+private def ΩProp.setoid : Setoid (ℕ → Bool) where
+  r p q := (∃n, p n) ↔ (∃n, q n)
+  iseqv := by constructor <;> grind
+
+/-- The type of semi-decidable propositions. -/
+structure ΩProp : Type where
+  private mk' ::
+  private get : Quotient ΩProp.setoid
+
+namespace ΩProp
+
+/-- Given a sequence `p : ℕ → Bool`, the proposition
+`mk p` is `true` iff `p n = true` for some `n`. -/
+def mk (p : ℕ → Bool) : ΩProp where
+  get := ⟦p⟧
+
+@[simp]
+lemma mk_eq_iff {p₁ p₂} : mk p₁ = mk p₂ ↔ ((∃ n, p₁ n) ↔ (∃ n, p₂ n)) := by
+  apply Iff.intro (fun h ↦ ?_) (fun h ↦ ?_)
+  · simp only [mk, mk'.injEq, Quotient.eq_iff_equiv] at h
+    exact h
+  · unfold mk
+    simp only [mk'.injEq]
+    apply Quotient.sound h
+
+@[elab_as_elim, induction_eliminator]
+lemma induction {p : ΩProp → Prop} (mk : ∀ f, p (mk f)) (a : ΩProp) : p a := by
+  rcases a with ⟨a⟩
+  cases a using Quotient.ind with | _ q =>
+  apply mk
+
+@[elab_as_elim]
+lemma inductionPi
+    {p : (ℕ → ΩProp) → Prop}
+    (mk : ∀ f : ℕ → ℕ → Bool, p fun n ↦ mk (f n))
+    (c : ℕ → ΩProp) : p c := by
+  have : c = fun n ↦ ⟨⟦(c n).get.out⟧⟩ := by
+    ext n
+    rw [Quotient.out_eq]
+  rw [this]
+  apply mk
+
+/-- Dependent elimination by applying a function to the underlying sequence. -/
+@[elab_as_elim]
+def elim
+    {P : ΩProp → Type*} (mk : (p : ℕ → Bool) → P (mk p))
+    (mk_coe : ∀ (p₁ p₂ : ℕ → Bool) (h : (∃ n, p₁ n) ↔ (∃ n, p₂ n)), mk_eq_iff.2 h ▸ mk p₁ = mk p₂)
+    (a : ΩProp) : P a :=
+  Quotient.recOn (motive := fun a ↦ P ⟨a⟩) a.get mk fun p₁ p₂ h ↦ by
+    simp only [eqRec_eq_cast] at ⊢ mk_coe
+    apply mk_coe
+    apply h
+
+@[simp]
+lemma elim_mk
+    {P : ΩProp → Type*} (mk : (p : ℕ → Bool) → P (mk p))
+    (mk_coe : ∀ (p₁ p₂ : ℕ → Bool) (h : (∃ n, p₁ n) ↔ (∃ n, p₂ n)), mk_eq_iff.2 h ▸ mk p₁ = mk p₂)
+    (a : ℕ → Bool) : elim mk mk_coe (.mk a) = mk a := by
+  rfl
+
+/-- Dependent elimination of a sequence of `ΩProp`s into a subsingleton. -/
+@[elab_as_elim]
+def elimPiSubsingleton
+    {P : (ℕ → ΩProp) → Type*} [∀ p, Subsingleton (P p)]
+    (mk : (p : ℕ → ℕ → Bool) → P (fun n ↦ mk (p n)))
+    (a : ℕ → ΩProp) : P a :=
+  let x := Quotient.recOnSubsingleton
+    (motive := fun a ↦ P fun n ↦ ⟨a.eval n⟩)
+    (Quotient.countableChoice fun i ↦ (a i).get)
+    mk
+  cast
+    (by dsimp only
+        congr 1
+        ext n
+        rw [Quotient.eval_countableChoice])
+    x
+
+@[simp]
+lemma elimPiSubsingleton_mk
+    {P : (ℕ → ΩProp) → Type*} [∀ p, Subsingleton (P p)]
+    (mk : (p : ℕ → ℕ → Bool) → P (fun n ↦ mk (p n)))
+    (a : ℕ → ℕ → Bool) : elimPiSubsingleton mk (fun n ↦ .mk (a n)) = mk a := by
+  subsingleton
+
+/-- Dependent elimination of a sequence of `ΩProp`s into a subsingleton. -/
+@[elab_as_elim]
+def elimOnPiSubsingleton
+    {P : (ℕ → ΩProp) → Type*} [∀ p, Subsingleton (P p)]
+    (a : ℕ → ΩProp)
+    (mk : (p : ℕ → ℕ → Bool) → P (fun n ↦ mk (p n)))
+    : P a :=
+  elimPiSubsingleton mk a
+
+@[simp]
+lemma elimOnPiSubsingleton_mk
+    {P : (ℕ → ΩProp) → Type*} [∀ p, Subsingleton (P p)]
+    (mk : (p : ℕ → ℕ → Bool) → P (fun n ↦ mk (p n)))
+    (a : ℕ → ℕ → Bool) : elimOnPiSubsingleton (fun n ↦ .mk (a n)) mk = mk a := by
+  subsingleton
+
+/-- Lifts a function on the underlying sequence to a function on `ΩProp`,
+requiring that it respects the quotient's equivalence relation.
+-/
+def lift
+    {A : Type*} (mk : (ℕ → Bool) → A)
+    (mk_coe : ∀ p₁ p₂, ((∃ n, p₁ n) ↔ (∃ n, p₂ n)) → mk p₁ = mk p₂)
+    (a : ΩProp) : A :=
+  a.get.lift mk mk_coe
+
+@[simp]
+lemma lift_mk {A f} (hf p) : lift (A := A) f hf (mk p) = f p := by
+  rfl
+
+/-- Like `lift`, but for two argument functions. -/
+def lift₂
+    {A : Type*} (mk : (ℕ → Bool) → (ℕ → Bool) → A)
+    (mk_coe :
+      ∀ p₁ p₂, ((∃ n, p₁ n) ↔ (∃ n, p₂ n)) →
+      ∀ q₁ q₂, ((∃ n, q₁ n) ↔ (∃ n, q₂ n)) →
+        mk p₁ q₁ = mk p₂ q₂)
+    (a b : ΩProp) : A :=
+  lift
+    (fun f ↦ lift (mk f) (by grind) b)
+    (by intro p₁ p₂ hp
+        induction b
+        grind [lift_mk])
+    a
+
+@[simp]
+lemma lift₂_mk
+    {A : Type*} (mk : (ℕ → Bool) → (ℕ → Bool) → A)
+    (mk_coe :
+      ∀ p₁ p₂, ((∃ n, p₁ n) ↔ (∃ n, p₂ n)) →
+      ∀ q₁ q₂, ((∃ n, q₁ n) ↔ (∃ n, q₂ n)) →
+        mk p₁ q₁ = mk p₂ q₂)
+    (p q) : lift₂ mk mk_coe (.mk p) (.mk q) = mk p q := by
+  rfl
+
+/-- Like `lift`, but for `ℕ`-ary functions. -/
+def liftPi
+    {A : Type*} (mk : (ℕ → ℕ → Bool) → A)
+    (mk_coe : ∀ p q, (∀ i, (∃ n, p i n) ↔ (∃ n, q i n)) → mk p = mk q)
+    (a : ℕ → ΩProp) : A :=
+  Quotient.liftOn (Quotient.countableChoice fun i ↦ (a i).get)
+    mk
+    mk_coe
+
+@[simp]
+lemma liftPi_mk
+    {A : Type*} (mk : (ℕ → ℕ → Bool) → A)
+    (mk_coe : ∀ p q, (∀ i, (∃ n, p i n) ↔ (∃ n, q i n)) → mk p = mk q)
+    (a : ℕ → ℕ → Bool) : liftPi mk mk_coe (fun n ↦ .mk (a n)) = mk a := by
+  dsimp only [liftPi, ΩProp.mk]
+  rw [Quotient.countableChoice_eq]
+  rfl
+
+/-- The `ΩProp` analogue to the proposition `True`. -/
+def true : ΩProp := mk fun _ ↦ .true
+
+/-- The `ΩProp` analogue to the proposition `False`. -/
+def false : ΩProp := mk fun _ ↦ .false
+
+@[simp]
+lemma false_ne_true : false ≠ true := by
+  simp only [
+    false, true, ne_eq, mk_eq_iff, Bool.false_eq_true,
+    exists_const, iff_true, not_false_eq_true]
+
+@[simp]
+lemma true_ne_false : true ≠ false := by
+  symm
+  simp only [ne_eq, false_ne_true, not_false_eq_true]
+
+@[elab_as_elim, cases_eliminator]
+lemma cases {p : ΩProp → Prop} (true : p true) (false : p false) (a : ΩProp) : p a := by
+  induction a with | mk q =>
+  by_cases h : ∃n, q n
+  · have : mk q = ΩProp.true := by
+      simp only [ΩProp.true, mk_eq_iff, h, exists_const]
+    simp only [this, true]
+  · have : mk q = ΩProp.false := by
+      simp only [ΩProp.false, mk_eq_iff, h, Bool.false_eq_true, exists_const]
+    simp only [this, false]
+
+/-- An `ΩProp` may be treated as a normal `Prop`. -/
+@[coe]
+def coe := (· = true)
+
+instance : CoeSort ΩProp Prop where
+  coe := coe
+
+@[simp]
+lemma coe_true : true ↔ _root_.True := by
+  simp only [coe]
+
+@[simp]
+lemma coe_false : false ↔ _root_.False := by
+  simp only [coe, false_ne_true]
+
+@[simp]
+lemma coe_mk {p} : mk p ↔ ∃n, p n := by
+  simp only [coe, true, mk_eq_iff, exists_const, iff_true]
+
+@[ext]
+lemma ext {a b : ΩProp} (h : a ↔ b) : a = b := by
+  cases a
+  · cases b
+    · simp only
+    · simp only [coe_true, coe_false, iff_false, not_true_eq_false] at h
+  · cases b
+    · simp only [coe_false, coe_true, iff_true] at h
+    · simp only
+
+@[simp]
+lemma eq_true_iff_coe (a) : a = true ↔ a := by rfl
+
+@[simp]
+lemma eq_false_iff_not_coe (a) : a = false ↔ ¬a := by
+  cases a
+  · simp only [true_ne_false, coe_true, not_true_eq_false]
+  · simp only [coe_false, not_false_eq_true]
+
+@[simp]
+lemma neg_eq_true (a) : ¬a = true ↔ a = false := by
+  cases a
+  · simp only [not_true_eq_false, true_ne_false]
+  · simp only [false_ne_true, not_false_eq_true]
+
+@[simp]
+lemma neg_eq_false (a) : ¬a = false ↔ a = true := by
+  cases a
+  · simp only [true_ne_false, not_false_eq_true]
+  · simp only [not_true_eq_false, false_ne_true]
+
+/-- The disjunction of a countable number of `ΩProp`s. -/
+def any : (ℕ → ΩProp) → ΩProp :=
+  liftPi (fun p ↦ mk fun n ↦ p n.unpair.1 n.unpair.2) (by
+    intro p q hpq
+    simp only [mk_eq_iff]
+    apply Iff.intro
+    · rintro ⟨n, hn⟩
+      obtain ⟨m, hm⟩ := (hpq n.unpair.1).1 ⟨n.unpair.2, hn⟩
+      use Nat.pair n.unpair.1 m
+      simp only [Nat.unpair_pair, hm]
+    · rintro ⟨n, hn⟩
+      obtain ⟨m, hm⟩ := (hpq n.unpair.1).2 ⟨n.unpair.2, hn⟩
+      use Nat.pair n.unpair.1 m
+      simp only [Nat.unpair_pair, hm])
+
+@[simp]
+lemma coe_any {c : ℕ → ΩProp} : any c ↔ ∃n, c n := by
+  induction c using inductionPi with | mk p =>
+  simp only [coe, any, liftPi_mk, true, mk_eq_iff, exists_const, iff_true]
+  apply Iff.intro
+  · grind
+  · rintro ⟨n, m, h⟩
+    use Nat.pair n m
+    simp only [Nat.unpair_pair, h]
+
+@[simp]
+lemma any_const (a) : any (fun _ ↦ a) = a := by
+  ext
+  simp only [coe_any, exists_const]
+
+/-- The disjunction of two `ΩProp`s. -/
+def or (a b : ΩProp) : ΩProp := any fun
+  | 0 => a
+  | _ => b
+
+@[simp]
+lemma coe_or (a b : ΩProp) : or a b ↔ a ∨ b := by
+  simp only [or, coe_any]
+  apply Iff.intro
+  · rintro ⟨⟨_|n⟩, hn⟩ <;> grind
+  · rintro ⟨rfl|rfl⟩
+    · use 0
+      simp only [coe_true]
+    · use 1
+
+@[simp]
+lemma true_or (a : ΩProp) : or true a = true := by
+  ext
+  simp only [coe_or, coe_true, _root_.true_or]
+
+@[simp]
+lemma false_or (a : ΩProp) : or false a = a := by
+  ext
+  simp only [coe_or, coe_false, _root_.false_or]
+
+@[simp]
+lemma or_true (a : ΩProp) : or a true = true := by
+  ext
+  simp only [coe_or, coe_true, _root_.or_true]
+
+@[simp]
+lemma or_false (a : ΩProp) : or a false = a := by
+  ext
+  simp only [coe_or, coe_false, _root_.or_false]
+
+@[simp]
+lemma or_self (a : ΩProp) : or a a = a := by
+  ext
+  simp only [coe_or, _root_.or_self]
+
+/-- If `ΩProp.any p` holds, then `p n` holds for some `n`.
+The function `find` computes such an `n`.
+
+Note that we cannot know _which_ `n` it is because `any p` is
+equal to `any q` for any `q : ℕ → Bool` satisfying `∃m, q m = true`.
+Hence the return type of this function must be `Squash`ed. -/
+def find {p : ℕ → ΩProp} : ↑(any p) → Squash { n // p n } :=
+  elimOnPiSubsingleton p fun p hp ↦ by
+    simp only [coe_any, coe_mk] at hp
+    have : ∃n : ℕ, p n.unpair.1 n.unpair.2 := by
+      rcases hp with ⟨m, n, h⟩
+      use Nat.pair m n
+      simp only [Nat.unpair_pair, h]
+    apply Squash.mk
+    use (Nat.find this).unpair.1
+    simp only [coe_mk]
+    use (Nat.find this).unpair.2
+    exact Nat.find_spec this
+
+@[simps -isSimp]
+instance : OmegaCompletePartialOrder ΩProp where
+  le a b := a → b
+  le_refl a := by grind
+  le_trans a b c h₁ h₂ := by grind
+  le_antisymm a b h₁ h₂ := by ext; grind
+  ωSup c := any c
+  le_ωSup c i h := by
+    simp only [coe_any]
+    use i
+  ωSup_le c a h₁ h₂ := by
+    simp only [coe_any] at h₂
+    grind
+
+@[simp]
+lemma false_le (a : ΩProp) : false ≤ a := by
+  simp only [le_def, coe_false, IsEmpty.forall_iff]
+
+@[simp]
+lemma le_false (a : ΩProp) : a ≤ false ↔ ¬a := by
+  simp only [le_def, coe_false, imp_false]
+
+@[simp]
+lemma true_le (a : ΩProp) : true ≤ a ↔ a := by
+  simp only [le_def, coe_true, forall_const]
+
+@[simp]
+lemma le_true (a : ΩProp) : a ≤ true := by
+  simp only [le_def, coe_true, implies_true]
+
+private lemma bind_helper
+    {A B : Type*} {P : A → Sort*} {a b} (f : P a → B) (h : a = b)
+    : Eq.rec (motive := fun a _ ↦ P a → B) f h
+    = fun x ↦ f (h ▸ x) := by
+  induction h
+  rfl
+
+/-- The dependent conjunction of `ΩProp`s. -/
+def bind : (a : ΩProp) → (a → ΩProp) → ΩProp :=
+  elim
+    (fun p f ↦ any fun n ↦
+      if h : p n
+      then f (by simp only [coe_mk]; use n)
+      else false)
+    (by intro p₁ p₂ h
+        have hp : mk p₁ = mk p₂ := by simp only [mk_eq_iff, h]
+        rw [bind_helper (P := fun a : ΩProp ↦ a → ΩProp)]
+        ext f
+        simp only [coe_any]
+        apply Iff.intro
+        · simp only [forall_exists_index]
+          intro n hn
+          cases hp₁ : p₁ n with
+          | false => simp only [hp₁, Bool.false_eq_true, ↓reduceDIte, coe_false] at hn
+          | true =>
+            simp only [hp₁, ↓reduceDIte] at hn
+            obtain ⟨m, hm⟩ := h.1 (by grind)
+            use m
+            simp only [hm, ↓reduceDIte]
+            rw [bind_helper] at hn
+            exact hn
+        · simp only [forall_exists_index]
+          intro n hn
+          cases hp₂ : p₂ n with
+          | false => simp only [hp₂, Bool.false_eq_true, ↓reduceDIte, coe_false] at hn
+          | true =>
+            simp only [hp₂, ↓reduceDIte] at hn
+            obtain ⟨m, hm⟩ := h.2 (by grind)
+            use m
+            simp only [hm, ↓reduceDIte]
+            rw [bind_helper]
+            exact hn)
+
+@[simp]
+lemma coe_bind
+    (a : ΩProp) (f : a → ΩProp)
+    : bind a f ↔ ∃h : a, f h := by
+  induction a with | mk p =>
+  simp only [bind, elim_mk, coe_any, coe_mk]
+  apply Iff.intro
+  · rintro ⟨n, hn⟩
+    cases hp : p n with
+    | true =>
+      simp only [hp, ↓reduceDIte] at hn
+      use ⟨n, hp⟩
+    | false =>
+      simp only [hp, Bool.false_eq_true, ↓reduceDIte, coe_false] at hn
+  · rintro ⟨⟨n, hn⟩, hp⟩
+    use n
+    simp only [hn, ↓reduceDIte, hp]
+
+@[simp]
+lemma true_bind (f : true → ΩProp) : bind true f = f (by simp only [coe_true]) := by
+  ext
+  simp only [coe_bind, coe_true, exists_true_left]
+
+@[simp]
+lemma false_bind (f : false → ΩProp) : bind false f = false := by
+  ext
+  simp only [coe_bind, coe_false, IsEmpty.exists_iff]
+
+/-- The conjunction of two `ΩProp`s. -/
+def and (a b : ΩProp) : ΩProp := bind a fun _ ↦ b
+
+@[simp]
+lemma bind_const (a b : ΩProp) : bind a (fun _ ↦ b) = and a b := by rfl
+
+@[simp]
+lemma coe_and {a b} : and a b ↔ a ∧ b := by
+  simp only [← bind_const, coe_bind, exists_prop]
+
+@[simp]
+lemma and_true (a : ΩProp) : and a true = a := by
+  ext
+  simp only [coe_and, coe_true, _root_.and_true]
+
+@[simp]
+lemma and_false (a : ΩProp) : and a false = false := by
+  ext
+  simp only [coe_and, coe_false, _root_.and_false]
+
+@[simp]
+lemma true_and (a : ΩProp) : and true a = a := by
+  ext
+  simp only [coe_and, coe_true, _root_.true_and]
+
+@[simp]
+lemma false_and (a : ΩProp) : and false a = false := by
+  ext
+  simp only [coe_and, coe_false, _root_.false_and]
+
+@[simp]
+lemma and_self (a : ΩProp) : and a a = a := by
+  ext
+  simp only [coe_and, _root_.and_self]
+
+open OmegaCompletePartialOrder
+
+def Chain.true (n : ℕ) : Chain ΩProp where
+  toFun k := if k < n then .false else .true
+  monotone' _ _ _ := by
+    dsimp only
+    split_ifs <;> grind [le_true]
+
+@[simp]
+lemma Chain.true_coe (k n) : true n k = if k < n then .false else .true := by rfl
+
+def Chain.false : Chain ΩProp where
+  toFun _ := .false
+  monotone' _ _ _ := by simp only [le_refl]
+
+@[simp]
+lemma Chain.false_coe (n) : false n = .false := by rfl
+
+@[elab_as_elim]
+lemma Chain.cases
+    {p : Chain ΩProp → Prop}
+    (true : ∀ n, p (true n))
+    (false : p false)
+    (c) : p c := by
+  classical
+  by_cases h : ∃n, c n
+  · have : c = Chain.true (Nat.find h) := by
+      ext n
+      simp only [true_coe, Nat.lt_find_iff]
+      split_ifs with h'
+      · simp only [le_refl, h', coe_false]
+      · simp only [not_forall, Decidable.not_not] at h'
+        rcases h' with ⟨m, hn, hm⟩
+        have := c.monotone hn
+        simp only [coe_true, iff_true]
+        apply this hm
+    rw [this]
+    apply true
+  · have : c = Chain.false := by
+      ext n
+      simp only [not_exists, false_coe, coe_false, iff_false] at ⊢ h
+      apply h
+    simp only [this, false]
+
+@[simp]
+lemma ωSup_true (n) : ωSup (Chain.true n) = true := by
+  apply le_antisymm
+  · simp only [ωSup_le_iff, Chain.true_coe, le_true, implies_true]
+  · simp only [ωSup, true_le, coe_any, Chain.true_coe]
+    use n + 1
+    simp only [(by grind : ¬n + 1 < n), ↓reduceIte, coe_true]
+
+@[simp]
+lemma ωSup_false : ωSup Chain.false = false := by
+  apply le_antisymm
+  · simp only [ωSup_le_iff, Chain.false_coe, le_refl, implies_true]
+  · simp only [false_le]
+
+@[simp, fun_prop]
+lemma ωScottContinuous_and : ωScottContinuous fun x : ΩProp × ΩProp ↦ and x.1 x.2 := by
+  refine ωScottContinuous.of_monotone_map_ωSup ⟨?_, fun c ↦ ?_⟩
+  · rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ h
+    simp only [Prod.mk_le_mk] at ⊢ h
+    cases a₁
+    · cases b₁
+      · simpa only [and_self, true_le, coe_and] using h
+      · simp only [and_false, false_le]
+    · cases b₁
+      · simp only [and_true, false_le]
+      · simp only [and_self, false_le]
+  · simp only [Prod.ωSup_fst, Prod.ωSup_snd]
+    generalize h₁ : c.map OrderHom.fst = c₁
+    generalize h₂ : c.map OrderHom.snd = c₂
+    have : c = Chain.zip c₁ c₂ := by
+      simp only [← h₁, ← h₂]
+      rfl
+    simp only [this]
+    cases c₁ using Chain.cases with
+    | true n =>
+      simp only [ωSup_true, true_and]
+      apply le_antisymm
+      · simp only [ωSup_le_iff]
+        intro i
+        apply le_ωSup_of_le (i ⊔ n)
+        simp only [
+          Chain.map_coe, OrderHom.coe_mk, Function.comp_apply, Chain.zip_coe, Chain.true_coe,
+          sup_lt_iff, lt_self_iff_false, _root_.and_false, ↓reduceIte, true_and]
+        apply c₂.monotone
+        grind
+      · simp only [
+          ωSup_le_iff, Chain.map_coe, OrderHom.coe_mk,
+          Function.comp_apply, Chain.zip_coe, Chain.true_coe]
+        intro i
+        split_ifs
+        · simp only [false_and, false_le]
+        · simp only [true_and]
+          apply le_ωSup
+    | false =>
+      simp only [ωSup_false, false_and]
+      apply le_antisymm
+      · simp only [false_le]
+      · simp only [
+          ωSup_le_iff, Chain.map_coe, OrderHom.coe_mk, Function.comp_apply,
+          Chain.zip_coe, Chain.false_coe, false_and, le_refl, implies_true]
+
+@[simp, fun_prop]
+lemma ωScottContinuous_any
+    {α : Type*} [OmegaCompletePartialOrder α]
+    {f : α → ℕ → ΩProp} (hf : ∀ n, ωScottContinuous (f · n))
+    : ωScottContinuous fun x ↦ any (f x) := by
+  apply ωScottContinuous.of_monotone_map_ωSup ⟨?_, fun c ↦ ?_⟩
+  · intro x y h₁ h₂
+    simp only [coe_any] at ⊢ h₂
+    rcases h₂ with ⟨n, h₂⟩
+    exact ⟨n, (hf n).monotone h₁ h₂⟩
+  · ext
+    simp only [
+      coe_any, (hf _).map_ωSup c, ωSup_def, Chain.map_coe,
+      OrderHom.coe_mk, Function.comp_apply]
+    grind
+
+@[simp, fun_prop]
+lemma ωScottContinuous_or : ωScottContinuous fun x : ΩProp × ΩProp ↦ or x.1 x.2 := by
+  apply ωScottContinuous_any fun n ↦ ?_
+  cases n <;> fun_prop
+
+@[simp, fun_prop]
+lemma ωScottContinuous_coe : ωScottContinuous fun a : ΩProp ↦ (a : Prop) := by
+  apply ωScottContinuous.of_monotone_map_ωSup ⟨?_, fun c ↦ ?_⟩
+  · intro a₁ a₂ h
+    exact h
+  · simp only [ωSup, coe_any, Chain.map_coe, OrderHom.coe_mk, Function.comp_apply, iSup_Prop_eq]
+
+end ΩProp

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -592,6 +592,34 @@ protected theorem nonempty (q : Trunc α) : Nonempty α :=
 
 end Trunc
 
+def Quotient.dependentChoiceExists
+    {α : Sort*} {s : Setoid α} (f : α → Quotient s) (init : α)
+    : Nonempty (Trunc { seq : Nat → α //
+        seq 0 = init ∧
+        ∀ n, f (seq n) = Quotient.mk s (seq (n + 1)) }) := by
+  constructor
+  apply Trunc.mk
+  use Nat.rec init (fun _ x ↦ (f x).out)
+  simp only [Quotient.out_eq, implies_true, and_true]
+  rfl
+
+attribute [local instance] Quotient.dependentChoiceExists in
+partial def Quotient.dependentChoice {α : Sort*} {s : Setoid α} (f : α → Quotient s) (init : α) :
+    Trunc { seq : Nat → α // seq 0 = init ∧ ∀ n, f (seq n) = Quotient.mk s (seq (n + 1)) } :=
+  Quotient.recOnSubsingleton (motive := fun a ↦ a = f init → _) (f init) (fun a h ↦
+  Quotient.recOnSubsingleton (Quotient.dependentChoice f a) (fun s ↦
+    ⟦{
+      val
+        | 0 => init
+        | n + 1 => s.val n
+      property := by
+        simp only [true_and]
+        intro n
+        cases n
+        · simp only [s.property.1, h]
+        · simp only [s.property.2]
+    }⟧)) rfl
+
 /-! ### `Quotient` with implicit `Setoid` -/
 
 

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -593,6 +593,9 @@ def Simps.apply (h : α →𝒄 β) : α → β :=
 
 initialize_simps_projections ContinuousHom (toFun → apply)
 
+/-- Constructs a `ContinuousHom` from a function `f` and a proof of `ωScottContinuous f`.
+By default, the proof is inferred by `fun_prop`, which makes it ideal for simple cases.
+-/
 @[simps!]
 def ofFun (f : α → β) (hf : ωScottContinuous f := by fun_prop) : α →𝒄 β where
   toFun := f

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -249,6 +249,7 @@ variable {f : α → β} {g : β → γ}
 
 /-- A function `f` between `ω`-complete partial orders is `ωScottContinuous` if it is
 Scott continuous over chains. -/
+@[fun_prop]
 def ωScottContinuous (f : α → β) : Prop :=
     ScottContinuousOn (Set.range fun c : Chain α => Set.range c) f
 
@@ -264,7 +265,11 @@ lemma ωScottContinuous.isLUB {c : Chain α} (hf : ωScottContinuous f) :
   simpa [map_coe, OrderHom.coe_mk, Set.range_comp]
     using hf (by simp) (Set.range_nonempty _) (isChain_range c).directedOn (isLUB_range_ωSup c)
 
+@[fun_prop]
 lemma ωScottContinuous.id : ωScottContinuous (id : α → α) := ScottContinuousOn.id
+
+@[fun_prop]
+lemma ωScottContinuous.id' : ωScottContinuous (fun x : α ↦ x) := ScottContinuousOn.id
 
 lemma ωScottContinuous.map_ωSup (hf : ωScottContinuous f) (c : Chain α) :
     f (ωSup c) = ωSup (c.map ⟨f, hf.monotone⟩) := ωSup_eq_of_isLUB hf.isLUB
@@ -291,13 +296,24 @@ lemma ωScottContinuous_iff_map_ωSup_of_orderHom {f : α →o β} :
 alias ⟨ωScottContinuous.map_ωSup_of_orderHom, ωScottContinuous.of_map_ωSup_of_orderHom⟩ :=
   ωScottContinuous_iff_map_ωSup_of_orderHom
 
+@[fun_prop]
 lemma ωScottContinuous.comp (hg : ωScottContinuous g) (hf : ωScottContinuous f) :
     ωScottContinuous (g.comp f) :=
   ωScottContinuous.of_monotone_map_ωSup
     ⟨hg.monotone.comp hf.monotone, by simp [hf.map_ωSup, hg.map_ωSup, map_comp]⟩
 
+@[fun_prop]
+lemma ωScottContinuous.comp' (hg : ωScottContinuous g) (hf : ωScottContinuous f) :
+    ωScottContinuous (fun x ↦ g (f x)) :=
+  comp hg hf
+
+@[fun_prop]
 lemma ωScottContinuous.const {x : β} : ωScottContinuous (Function.const α x) := by
   simp [ωScottContinuous, ScottContinuousOn, Set.range_nonempty]
+
+@[fun_prop]
+lemma ωScottContinuous.const' {x : β} : ωScottContinuous (fun _ : α ↦ x) :=
+  const
 
 end Continuity
 
@@ -400,6 +416,11 @@ lemma ωScottContinuous.apply₂ (hf : ωScottContinuous f) (a : α) : ωScottCo
   ωScottContinuous.of_monotone_map_ωSup
     ⟨fun _ _ h ↦ hf.monotone h a, fun c ↦ congr_fun (hf.map_ωSup c) a⟩
 
+@[fun_prop]
+lemma ωScottContinuous.apply (x : α) : ωScottContinuous (fun f : ∀x, β x ↦ f x) :=
+  apply₂ id x
+
+@[fun_prop]
 lemma ωScottContinuous.of_apply₂ (hf : ∀ a, ωScottContinuous (f · a)) : ωScottContinuous f :=
   ωScottContinuous.of_monotone_map_ωSup
     ⟨fun _ _ h a ↦ (hf a).monotone h, fun c ↦ by ext a; apply (hf a).map_ωSup c⟩
@@ -430,6 +451,26 @@ instance : OmegaCompletePartialOrder (α × β) where
 
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := rfl
 
+@[fun_prop]
+lemma ωScottContinuous.prodMk
+    {f : α → β} (hf : ωScottContinuous f)
+    {g : α → γ} (hg : ωScottContinuous g)
+    : ωScottContinuous fun x ↦ (f x, g x) :=
+  ScottContinuousOn.prodMk (fun a b hab ↦ by
+    use pair a b hab
+    exact range_pair a b hab
+  ) hf hg
+
+@[fun_prop]
+lemma ωScottContinuous_fst : ωScottContinuous (Prod.fst : α × β → α) := by
+  rw [ωScottContinuous_iff_monotone_map_ωSup]
+  exact ⟨monotone_fst, fun _ ↦ rfl⟩
+
+@[fun_prop]
+lemma ωScottContinuous_snd : ωScottContinuous (Prod.snd : α × β → β) := by
+  rw [ωScottContinuous_iff_monotone_map_ωSup]
+  exact ⟨monotone_snd, fun _ ↦ rfl⟩
+
 end Prod
 
 namespace CompleteLattice
@@ -443,13 +484,6 @@ instance (priority := 100) [CompleteLattice α] : OmegaCompletePartialOrder α w
   le_ωSup := fun ⟨c, _⟩ i => le_iSup_of_le i le_rfl
 
 variable [OmegaCompletePartialOrder α] [CompleteLattice β] {f g : α → β}
-
--- TODO Prove this result for `ScottContinuousOn` and deduce this as a special case
--- https://github.com/leanprover-community/mathlib4/pull/15412
-open Chain in
-lemma ωScottContinuous.prodMk (hf : ωScottContinuous f) (hg : ωScottContinuous g) :
-    ωScottContinuous fun x => (f x, g x) := ScottContinuousOn.prodMk (fun a b hab => by
-  use pair a b hab; exact range_pair a b hab) hf hg
 
 lemma ωScottContinuous.iSup {f : ι → α → β} (hf : ∀ i, ωScottContinuous (f i)) :
     ωScottContinuous (⨆ i, f i) := by
@@ -540,6 +574,7 @@ instance : PartialOrder (α →𝒄 β) :=
 
 namespace ContinuousHom
 
+@[fun_prop]
 protected lemma ωScottContinuous (f : α →𝒄 β) : ωScottContinuous f :=
   ωScottContinuous.of_map_ωSup_of_orderHom f.map_ωSup'
 
@@ -557,6 +592,12 @@ def Simps.apply (h : α →𝒄 β) : α → β :=
   h
 
 initialize_simps_projections ContinuousHom (toFun → apply)
+
+@[simps!]
+def ofFun (f : α → β) (hf : ωScottContinuous f := by fun_prop) : α →𝒄 β where
+  toFun := f
+  monotone' := hf.monotone
+  map_ωSup' := hf.map_ωSup
 
 protected theorem congr_fun {f g : α →𝒄 β} (h : f = g) (x : α) : f x = g x :=
   DFunLike.congr_fun h x
@@ -699,34 +740,42 @@ instance : OmegaCompletePartialOrder (α →𝒄 β) :=
   OmegaCompletePartialOrder.lift ContinuousHom.toMono ContinuousHom.ωSup
     (fun _ _ h => h) (fun _ => rfl)
 
-namespace Prod
-
-/-- The application of continuous functions as a continuous function. -/
-@[simps]
-def apply : (α →𝒄 β) × α →𝒄 β where
-  toFun f := f.1 f.2
-  monotone' x y h := by
-    dsimp
-    trans y.fst x.snd <;> [apply h.1; apply y.1.monotone h.2]
-  map_ωSup' c := by
+@[fun_prop]
+lemma ωScottContinuous_apply
+    {f : α → β →𝒄 γ} (hf : ωScottContinuous f)
+    {g : α → β} (hg : ωScottContinuous g)
+    : ωScottContinuous fun x ↦ f x (g x) := by
+  apply ωScottContinuous.of_monotone_map_ωSup ⟨?_, fun c ↦ ?_⟩
+  · intro x y hxy
+    apply OrderHom.apply_mono (hf.monotone hxy) (hg.monotone hxy)
+  · rw [hf.map_ωSup, hg.map_ωSup]
+    simp only [ωSup_def, ωSup_apply]
     apply le_antisymm
     · apply ωSup_le
       intro i
-      dsimp
-      rw [(c _).fst.continuous]
+      dsimp only [
+        map_coe, OrderHom.apply_coe, OrderHom.coe_mk, Function.comp_apply,
+        toMono_coe, OrderHomClass.coe_coe, Function.eval]
+      rw [(f (c i)).continuous]
       apply ωSup_le
       intro j
-      apply le_ωSup_of_le (max i j)
+      apply le_ωSup_of_le (i ⊔ j)
       apply apply_mono
-      · exact monotone_fst (OrderHom.mono _ (le_max_left _ _))
-      · exact monotone_snd (OrderHom.mono _ (le_max_right _ _))
-    · apply ωSup_le
+      · apply hf.monotone (c.monotone le_sup_left)
+      · apply hg.monotone (c.monotone le_sup_right)
+    · simp only [ωSup_le_iff]
       intro i
       apply le_ωSup_of_le i
-      dsimp
-      apply OrderHom.mono _
+      apply (f (c i)).monotone
       apply le_ωSup_of_le i
       rfl
+
+namespace Prod
+
+/-- The application of continuous functions as a continuous function. -/
+@[simps!]
+def apply : (α →𝒄 β) × α →𝒄 β :=
+  ofFun (fun f ↦ f.1 f.2)
 
 end Prod
 
@@ -734,11 +783,9 @@ theorem ωSup_apply_ωSup (c₀ : Chain (α →𝒄 β)) (c₁ : Chain α) :
     ωSup c₀ (ωSup c₁) = Prod.apply (ωSup (c₀.zip c₁)) := by simp [Prod.apply_apply, Prod.ωSup_zip]
 
 /-- A family of continuous functions yields a continuous family of functions. -/
-@[simps]
-def flip {α : Type*} (f : α → β →𝒄 γ) : β →𝒄 α → γ where
-  toFun x y := f y x
-  monotone' _ _ h a := (f a).monotone h
-  map_ωSup' _ := by ext x; change f _ _ = _; rw [(f _).continuous]; rfl
+@[simps!]
+def flip {α : Type*} (f : α → β →𝒄 γ) : β →𝒄 α → γ :=
+  ofFun fun x y ↦ f y x
 
 /-- `Part.bind` as a continuous function. -/
 @[simps! apply]

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -265,7 +265,6 @@ lemma ωScottContinuous.isLUB {c : Chain α} (hf : ωScottContinuous f) :
   simpa [map_coe, OrderHom.coe_mk, Set.range_comp]
     using hf (by simp) (Set.range_nonempty _) (isChain_range c).directedOn (isLUB_range_ωSup c)
 
-@[fun_prop]
 lemma ωScottContinuous.id : ωScottContinuous (id : α → α) := ScottContinuousOn.id
 
 @[fun_prop]
@@ -296,7 +295,6 @@ lemma ωScottContinuous_iff_map_ωSup_of_orderHom {f : α →o β} :
 alias ⟨ωScottContinuous.map_ωSup_of_orderHom, ωScottContinuous.of_map_ωSup_of_orderHom⟩ :=
   ωScottContinuous_iff_map_ωSup_of_orderHom
 
-@[fun_prop]
 lemma ωScottContinuous.comp (hg : ωScottContinuous g) (hf : ωScottContinuous f) :
     ωScottContinuous (g.comp f) :=
   ωScottContinuous.of_monotone_map_ωSup

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -306,8 +306,8 @@ lemma ωScottContinuous.comp' (hg : ωScottContinuous g) (hf : ωScottContinuous
   comp hg hf
 
 @[fun_prop]
-lemma ωScottContinuous.const {x : β} : ωScottContinuous (Function.const α x) := by
-  simp [ωScottContinuous, ScottContinuousOn, Set.range_nonempty]
+lemma ωScottContinuous.const {x : β} : ωScottContinuous (Function.const α x) :=
+  ScottContinuousOn.const x
 
 @[fun_prop]
 lemma ωScottContinuous.const' {x : β} : ωScottContinuous (fun _ : α ↦ x) :=
@@ -460,14 +460,12 @@ lemma ωScottContinuous.prodMk
   ) hf hg
 
 @[fun_prop]
-lemma ωScottContinuous_fst : ωScottContinuous (Prod.fst : α × β → α) := by
-  rw [ωScottContinuous_iff_monotone_map_ωSup]
-  exact ⟨monotone_fst, fun _ ↦ rfl⟩
+lemma ωScottContinuous_fst : ωScottContinuous (Prod.fst : α × β → α) :=
+  ScottContinuousOn.fst
 
 @[fun_prop]
-lemma ωScottContinuous_snd : ωScottContinuous (Prod.snd : α × β → β) := by
-  rw [ωScottContinuous_iff_monotone_map_ωSup]
-  exact ⟨monotone_snd, fun _ ↦ rfl⟩
+lemma ωScottContinuous_snd : ωScottContinuous (Prod.snd : α × β → β) :=
+  ScottContinuousOn.snd
 
 end Prod
 

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -5,7 +5,9 @@ Authors: Christopher Hoskin
 -/
 module
 
+import Mathlib.Order.Bounds.Image
 public import Mathlib.Order.Bounds.Basic
+public import Mathlib.Tactic.FunProp.Attr
 
 /-!
 # Scott continuity
@@ -33,10 +35,10 @@ in this file, and ωScott Continuity on chains later in
 
 open Set
 
-variable {α β : Type*}
+variable {α β γ : Type*}
 
 section ScottContinuous
-variable [Preorder α] [Preorder β] {D D₁ D₂ : Set (Set α)}
+variable [Preorder α] [Preorder β] [Preorder γ] {D D₁ D₂ : Set (Set α)}
   {f : α → β}
 
 /-- A function between preorders is said to be Scott continuous on a set `D` of directed sets if it
@@ -50,6 +52,7 @@ The dual notion
 
 does not appear to play a significant role in the literature, so is omitted here.
 -/
+@[fun_prop]
 def ScottContinuousOn (D : Set (Set α)) (f : α → β) : Prop :=
   ∀ ⦃d : Set α⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → IsLUB (f '' d) (f a)
 
@@ -65,11 +68,23 @@ protected theorem ScottContinuousOn.monotone (D : Set (Set α)) (hD : ∀ a b : 
     inter_eq_self_of_subset_right (Ici_subset_Ici.2 hab)]
   exact isLeast_Ici
 
-@[simp] lemma ScottContinuousOn.id : ScottContinuousOn D (id : α → α) := by simp [ScottContinuousOn]
+@[simp, fun_prop]
+lemma ScottContinuousOn.id : ScottContinuousOn D (id : α → α) := by simp [ScottContinuousOn]
 
-variable {γ : Type*} [Preorder γ] {g : α → γ}
+@[simp, fun_prop]
+lemma ScottContinuousOn.const (x : β) : ScottContinuousOn D (Function.const α x) := by
+  rintro s _ ⟨a⟩ _ _ _
+  simp only [
+    IsLUB, IsLeast, upperBounds, Function.const_apply, mem_image, exists_and_right,
+    and_imp, forall_exists_index, forall_apply_eq_imp_iff₂, mem_setOf_eq, le_refl,
+    implies_true, lowerBounds, true_and]
+  grind
 
-lemma ScottContinuousOn.prodMk (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
+@[simp, fun_prop]
+lemma ScottContinuousOn.const' (x : β) : ScottContinuousOn D (fun _ : α ↦ x) :=
+  ScottContinuousOn.const x
+
+lemma ScottContinuousOn.prodMk {g : α → γ} (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
     (hf : ScottContinuousOn D f) (hg : ScottContinuousOn D g) :
     ScottContinuousOn D fun x => (f x, g x) := fun d hd₁ hd₂ hd₃ a hda => by
   rw [IsLUB, IsLeast, upperBounds]
@@ -91,10 +106,23 @@ lemma ScottContinuousOn.prodMk (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
       intro _ hb
       exact (hp _ hb).2
 
+@[simp, fun_prop]
+lemma ScottContinuousOn.fst {D} : ScottContinuousOn D (Prod.fst : α × β → α) := by
+  intro d hd₁ hd₂ hd₃ a ha
+  simp only [isLUB_prod] at ha
+  exact ha.1
+
+@[simp, fun_prop]
+lemma ScottContinuousOn.snd {D} : ScottContinuousOn D (Prod.snd : α × β → β) := by
+  intro d hd₁ hd₂ hd₃ a ha
+  simp only [isLUB_prod] at ha
+  exact ha.2
+
 /-- A function between preorders is said to be Scott continuous if it preserves `IsLUB` on directed
 sets. It can be shown that a function is Scott continuous if and only if it is continuous w.r.t. the
 Scott topology.
 -/
+@[fun_prop]
 def ScottContinuous (f : α → β) : Prop :=
   ∀ ⦃d : Set α⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → IsLUB (f '' d) (f a)
 
@@ -107,7 +135,50 @@ lemma ScottContinuous.scottContinuousOn {D : Set (Set α)} :
 protected theorem ScottContinuous.monotone (h : ScottContinuous f) : Monotone f :=
   h.scottContinuousOn.monotone univ (fun _ _ _ ↦ mem_univ _)
 
-@[simp] lemma ScottContinuous.id : ScottContinuous (id : α → α) := by simp [ScottContinuous]
+@[simp, fun_prop]
+lemma ScottContinuous.id : ScottContinuous (id : α → α) := by simp [ScottContinuous]
+
+@[simp, fun_prop]
+lemma ScottContinuous.const (x : β) : ScottContinuous (Function.const α x) := by
+  simp only [← scottContinuousOn_univ, ScottContinuousOn.const]
+
+@[simp, fun_prop]
+lemma ScottContinuous.const' (x : β) : ScottContinuous (fun _ : α ↦ x) := by
+  simp only [← scottContinuousOn_univ, ScottContinuousOn.const']
+
+lemma ScottContinuous.comp {g : β → γ}
+    (hf : ScottContinuous f) (hg : ScottContinuous g)
+    : ScottContinuous (g ∘ f) := by
+  intro d hd₁ hd₂ a ha
+  have hd₁' : (f '' d).Nonempty := ⟨f hd₁.choose, by grind⟩
+  have hd₂' : DirectedOn (fun x1 x2 ↦ x1 ≤ x2) (f '' d) := by
+    have := hf.monotone
+    simp only [Monotone, DirectedOn] at ⊢ this hd₂
+    grind
+  rw [Set.image_comp]
+  exact hg hd₁' hd₂' (hf hd₁ hd₂ ha)
+
+@[fun_prop]
+lemma ScottContinuous.comp' {g : β → γ}
+    (hf : ScottContinuous f) (hg : ScottContinuous g)
+    : ScottContinuous (fun x ↦ g (f x)) :=
+  ScottContinuous.comp hf hg
+
+@[fun_prop]
+lemma ScottContinuous.prodMk {g : α → γ}
+    (hf : ScottContinuous f) (hg : ScottContinuous g) :
+    ScottContinuous fun x => (f x, g x) := by
+  simp only [← scottContinuousOn_univ] at ⊢ hf hg
+  apply ScottContinuousOn.prodMk ?_ hf hg
+  grind
+
+@[simp, fun_prop]
+lemma ScottContinuous.fst : ScottContinuous (Prod.fst : α × β → α) := by
+  simp only [← scottContinuousOn_univ, ScottContinuousOn.fst]
+
+@[simp, fun_prop]
+lemma ScottContinuous.snd : ScottContinuous (Prod.snd : α × β → β) := by
+  simp only [← scottContinuousOn_univ, ScottContinuousOn.snd]
 
 end ScottContinuous
 
@@ -116,6 +187,7 @@ section SemilatticeSup
 variable [SemilatticeSup β]
 
 /-- The join operation is Scott continuous -/
+@[fun_prop]
 lemma ScottContinuous.sup₂ :
     ScottContinuous fun b : β × β => (b.1 ⊔ b.2 : β) := fun d _ _ ⟨p₁, p₂⟩ hdp => by
   simp only [IsLUB, IsLeast, upperBounds, Prod.forall, mem_setOf_eq, Prod.mk_le_mk] at hdp

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -84,6 +84,53 @@ lemma ScottContinuousOn.const (x : β) : ScottContinuousOn D (Function.const α 
 lemma ScottContinuousOn.const' (x : β) : ScottContinuousOn D (fun _ : α ↦ x) :=
   ScottContinuousOn.const x
 
+theorem ScottContinuousOn.comp
+    {g : β → γ} {D'}
+    (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
+    (hD' : ∀ d ∈ D, f '' d ∈ D')
+    (hg : ScottContinuousOn D' g)
+    (hf : ScottContinuousOn D f)
+    : ScottContinuousOn D (g ∘ f) := by
+  intro d hd₁ hd₂ hd₃ a ha
+  have hd₁' : f '' d ∈ D' := by grind
+  have hd₂' : (f '' d).Nonempty := ⟨f hd₂.choose, by grind⟩
+  have hd₃' : DirectedOn (fun x1 x2 ↦ x1 ≤ x2) (f '' d) := by
+    have := hf.monotone
+    simp only [
+      Monotone, DirectedOn, mem_image, exists_exists_and_eq_and,
+      forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at ⊢ this hd₃
+    grind
+  rw [Set.image_comp]
+  refine hg hd₁' ⟨f hd₂.choose, by grind⟩ hd₃' (hf hd₁ hd₂ hd₃ ha)
+
+theorem ScottContinuousOn.comp_image
+    {g : β → γ}
+    (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
+    (hg : ScottContinuousOn ((f '' ·) '' D) g)
+    (hf : ScottContinuousOn D f)
+    : ScottContinuousOn D (g ∘ f) :=
+  ScottContinuousOn.comp hD (by grind) hg hf
+
+@[fun_prop]
+theorem ScottContinuousOn.comp'
+    {g : β → γ} {D'}
+    (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
+    (hD' : ∀ d ∈ D, f '' d ∈ D')
+    (hg : ScottContinuousOn D' g)
+    (hf : ScottContinuousOn D f)
+    : ScottContinuousOn D (fun x ↦ g (f x)) :=
+  ScottContinuousOn.comp hD hD' hg hf
+
+@[fun_prop]
+theorem ScottContinuousOn.comp_image'
+    {g : β → γ}
+    (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
+    (hg : ScottContinuousOn ((f '' ·) '' D) g)
+    (hf : ScottContinuousOn D f)
+    : ScottContinuousOn D (fun x ↦ g (f x)) :=
+  ScottContinuousOn.comp_image hD hg hf
+
+@[fun_prop]
 lemma ScottContinuousOn.prodMk {g : α → γ} (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
     (hf : ScottContinuousOn D f) (hg : ScottContinuousOn D g) :
     ScottContinuousOn D fun x => (f x, g x) := fun d hd₁ hd₂ hd₃ a hda => by

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -103,7 +103,7 @@ theorem ScottContinuousOn.comp
   rw [Set.image_comp]
   refine hg hd₁' hd₂' hd₃' (hf hd₁ hd₂ hd₃ ha)
 
-theorem ScottContinuousOn.comp_image
+theorem ScottContinuousOn.image_comp
     {g : β → γ}
     (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
     (hg : ScottContinuousOn ((f '' ·) '' D) g)
@@ -122,13 +122,13 @@ theorem ScottContinuousOn.comp'
   ScottContinuousOn.comp hD hD' hg hf
 
 @[fun_prop]
-theorem ScottContinuousOn.comp_image'
+theorem ScottContinuousOn.image_comp'
     {g : β → γ}
     (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
     (hg : ScottContinuousOn ((f '' ·) '' D) g)
     (hf : ScottContinuousOn D f)
     : ScottContinuousOn D (fun x ↦ g (f x)) :=
-  ScottContinuousOn.comp_image hD hg hf
+  ScottContinuousOn.image_comp hD hg hf
 
 @[fun_prop]
 lemma ScottContinuousOn.prodMk {g : α → γ} (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -247,6 +247,7 @@ lemma ScottContinuous.sup₂ :
   · rw [sup_le_iff]
     exact e1 _ _ fun b₁ b₂ hb' => sup_le_iff.mp (hb b₁ b₂ hb' rfl)
 
+@[fun_prop]
 lemma ScottContinuousOn.sup₂ {D : Set (Set (β × β))} :
     ScottContinuousOn D fun (a, b) => (a ⊔ b : β) :=
   ScottContinuous.sup₂.scottContinuousOn

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -67,7 +67,7 @@ protected theorem ScottContinuousOn.monotone (D : Set (Set α)) (hD : ∀ a b : 
 
 @[simp] lemma ScottContinuousOn.id : ScottContinuousOn D (id : α → α) := by simp [ScottContinuousOn]
 
-variable {g : α → β}
+variable {γ : Type*} [Preorder γ] {g : α → γ}
 
 lemma ScottContinuousOn.prodMk (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
     (hf : ScottContinuousOn D f) (hg : ScottContinuousOn D g) :

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -87,12 +87,12 @@ lemma ScottContinuousOn.const' (x : β) : ScottContinuousOn D (fun _ : α ↦ x)
 theorem ScottContinuousOn.comp
     {g : β → γ} {D'}
     (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)
-    (hD' : ∀ d ∈ D, f '' d ∈ D')
+    (hD' : Set.MapsTo (f '' ·) D D')
     (hg : ScottContinuousOn D' g)
     (hf : ScottContinuousOn D f)
     : ScottContinuousOn D (g ∘ f) := by
   intro d hd₁ hd₂ hd₃ a ha
-  have hd₁' : f '' d ∈ D' := by grind
+  have hd₁' : f '' d ∈ D' := hD' hd₁
   have hd₂' : (f '' d).Nonempty := ⟨f hd₂.choose, by grind⟩
   have hd₃' : DirectedOn (fun x1 x2 ↦ x1 ≤ x2) (f '' d) := by
     have := hf.monotone
@@ -101,7 +101,7 @@ theorem ScottContinuousOn.comp
       forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at ⊢ this hd₃
     grind
   rw [Set.image_comp]
-  refine hg hd₁' ⟨f hd₂.choose, by grind⟩ hd₃' (hf hd₁ hd₂ hd₃ ha)
+  refine hg hd₁' hd₂' hd₃' (hf hd₁ hd₂ hd₃ ha)
 
 theorem ScottContinuousOn.comp_image
     {g : β → γ}
@@ -109,7 +109,7 @@ theorem ScottContinuousOn.comp_image
     (hg : ScottContinuousOn ((f '' ·) '' D) g)
     (hf : ScottContinuousOn D f)
     : ScottContinuousOn D (g ∘ f) :=
-  ScottContinuousOn.comp hD (by grind) hg hf
+  ScottContinuousOn.comp hD (Set.mapsTo_image  (f '' ·) D) hg hf
 
 @[fun_prop]
 theorem ScottContinuousOn.comp'


### PR DESCRIPTION
This is the code corresponding to [mathlib4 > A monad for partial computations](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/A.20monad.20for.20partial.20computations/with/569619800). Not currently intended to be merged.

This PR depends on #33941. The only changes relevant to this discussion are in `OmegaPart.lean`, `OmegaProp.lean`, and `Quot.lean`.

# Original Message

Inspired by @**Aaron Liu**'s comments in #**mathlib4>deprecate Mathlib.Data.Nat.PartENat?@538009243** and #**Is there code for X?>Divergence monad@538020049** I made an attempt at constructing a monad for partial computations with a computable `OmegaCompletePartialOrder` instance (neither `Option` nor `Part` support this use case). My solution consists of three parts.

**A computable version of `Quotient.choice`.** As mentioned in #**lean4>Quot.lift for dependent products@467436416** , the "obvious" computational interpretation of `Quotient.choice : (∀i:I, @Quotient (A i) …) → @Quotient (∀i:I, A i)` is not sound. However, we _can_ provide a sound computational interpretation when we restrict `I` to `ℕ`: 

```lean
unsafe def Quotient.countableChoice_impl {α : Nat → Type*} {S : ∀ i, Setoid (α i)}
    (f : ∀ i, Quotient (S i)) :
    @Quotient (∀ i, α i) (by infer_instance) :=
  Quotient.lift₂
    (fun z s ↦ ⟦fun | .zero => z | .succ n => s n⟧)
    (fun z₁ s₁ z₂ s₂ h₁ h₂ ↦ by
      apply sound
      rintro ⟨_|n⟩
      · apply h₁
      · apply h₂)
    (f 0)
    (countableChoice_impl (fun n ↦ f n.succ))

@[implemented_by Quotient.countableChoice_impl]
def Quotient.countableChoice {α : Nat → Type*} {S : ∀ i, Setoid (α i)}
    (f : ∀ i, Quotient (S i)) :
    @Quotient (∀ i, α i) (by infer_instance) :=
  Quotient.choice f
```

My justification for the soundness of this implementation comes from the fact that only uses existing (sound and computable) functions + general recursion. The implementation is found [here](https://github.com/YellPika/mathlib4/blob/99d38f164a97c7aa225283ef6016f0279419a994/Mathlib/Data/Quot.lean#L430) (it uses `unquot` instead of recursion for performance reasons, but should be equivalent).

**A type of semi-computable propositions.** Next, I define a type of semi-computable propositions `ΩProp` as a quotient of the type of boolean sequences `(ℕ → Bool) / ≈`, where `p ≈ q ≝ (∃n, p n) ↔ (∃n, q n)`. A sequence is interpreted as "true" if at least one element in the sequence is `true`, and the quotient relation ensures that we cannot observe the difference between different "true" sequences. The `ΩProp` type has a (computable) `OmegaCompletePartialOrder`, and `Quotient.countableChoice` is used in the implementation of `ωSup`.

The implementation of this type is [here](https://github.com/YellPika/mathlib4/blob/quot-choice-compute/Mathlib/Data/OmegaProp.lean).

**A type of semi-computable computations.** Finally, I define the type `ΩPart A` of semi-computable computations returning a value of type `A`. The definition of `ΩPart` is the same as `Part` with `ΩProp` swapped for `Prop`. Again, `ΩPart A` has a (computable) `OmegaCompletePartialOrder` instance. The implementation can be found [here](https://github.com/YellPika/mathlib4/blob/quot-choice-compute/Mathlib/Data/OmegaPart.lean).

This was mainly just a fun experiment and the code is not ready to be (or perhaps should not be) put in mathlib. I thought I should post it here to see if 1) there is any interest or 2) an implementation already exists that has escaped my notice.