### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/LinearIndependent): linear independence given a dual family

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.Torsion.Field
 public import Mathlib.Data.Fin.Tuple.Reflection
+public import Mathlib.LinearAlgebra.Dual.Defs
 public import Mathlib.LinearAlgebra.Finsupp.SumProd
 public import Mathlib.LinearAlgebra.LinearIndependent.Basic
 public import Mathlib.LinearAlgebra.Pi
@@ -510,6 +511,20 @@ lemma LinearIndepOn.insert' {s : Set ι} {i : ι} (hs : LinearIndepOn R v s)
 lemma LinearIndepOn.id_insert' {s : Set M} {x : M} (hs : LinearIndepOn R id s)
     (hx : ∀ r : R, r • x ∈ Submodule.span R s → r = 0) : LinearIndepOn R id (insert x s) :=
   hs.insert' <| by simpa
+
+/-- If `v : ι → M` is a family of vectors and there exists a family of linear forms
+`dv : ι → (M →ₗ[R] R)` such that `dv i (v j)` is `1` for `i = j` and `0` for `i ≠ j`, then
+`v` is linearly independent. -/
+theorem LinearIndependent.ofDualFamily (v : ι → M) (dv : ι → Module.Dual R M)
+    (h1 : ∀ (a : ι) (b : ι), a ≠ b → (dv a) (v b) = 0) (h2 : ∀ (a : ι), (dv a) (v a) = 1) :
+    LinearIndependent R v := by
+  rw [linearIndependent_iff']
+  intro s g hrel i hi
+  apply_fun (fun x => dv i x) at hrel
+  simp only [map_sum, map_smul, smul_eq_mul, _root_.map_zero] at hrel
+  rw [Finset.sum_eq_single i (fun j _ hj ↦ by rw [h1 i j (Ne.symm hj), mul_zero])
+    (fun hi' ↦ False.elim (hi' hi)), h2 i, mul_one] at hrel
+  exact hrel
 
 end Module
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -513,18 +513,15 @@ lemma LinearIndepOn.id_insert' {s : Set M} {x : M} (hs : LinearIndepOn R id s)
   hs.insert' <| by simpa
 
 /-- If `v : ι → M` is a family of vectors and there exists a family of linear forms
-`dv : ι → (M →ₗ[R] R)` such that `dv i (v j)` is `1` for `i = j` and `0` for `i ≠ j`, then
+`f : ι → Dual R M` such that `f i (v j)` is `1` for `i = j` and `0` for `i ≠ j`, then
 `v` is linearly independent. -/
-theorem LinearIndependent.ofDualFamily (v : ι → M) (dv : ι → Module.Dual R M)
-    (h1 : ∀ (a : ι) (b : ι), a ≠ b → (dv a) (v b) = 0) (h2 : ∀ (a : ι), (dv a) (v a) = 1) :
+theorem LinearIndependent.of_pairwise_dual_eq_zero_one (v : ι → M) (f : ι → Dual R M)
+    (h1 : Pairwise fun i j ↦ f i (v j) = 0)
+    (h2 : ∀ i, (f i) (v i) = 1) :
     LinearIndependent R v := by
-  rw [linearIndependent_iff']
-  intro s g hrel i hi
-  apply_fun (fun x => dv i x) at hrel
-  simp only [map_sum, map_smul, smul_eq_mul, _root_.map_zero] at hrel
-  rw [Finset.sum_eq_single i (fun j _ hj ↦ by rw [h1 i j (Ne.symm hj), mul_zero])
-    (fun hi' ↦ False.elim (hi' hi)), h2 i, mul_one] at hrel
-  exact hrel
+  refine linearIndependent_iff'.mpr fun s g hrel i hi ↦ ?_
+  have aux (j : ι) (hjs : j ∈ s) (hji : j ≠ i) : g j * (f i) (v j) = 0 := by simp [h1 hji.symm]
+  simpa [s.sum_eq_single i aux (by aesop), h2 i] using congr_arg (f i) hrel
 
 end Module
 


### PR DESCRIPTION
Adds the lemma `LinearlyIndependent.ofDualFamily` which proves linear independence given a family of dual elements.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
