### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Subgroup/Pointwise): Add conj_smul_eq_of_mem, Move conj_smul_le_of_le and conj_smul_subgroupOf

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -439,7 +439,7 @@ theorem conj_smul_le_of_le {P H : Subgroup G} (hP : P ≤ H) (h : H) :
   rintro - ⟨g, hg, rfl⟩
   exact H.mul_mem (H.mul_mem h.2 (hP hg)) (H.inv_mem h.2)
 
-theorem conj_smul_eq_of_mem {G : Type*} [Group G] {H : Subgroup G} {h : G} (hh : h ∈ H) :
+theorem conj_smul_eq_self_of_mem {G : Type*} [Group G] {H : Subgroup G} {h : G} (hh : h ∈ H) :
     MulAut.conj h • H = H := by
   refine le_antisymm ?_ ?_
   · exact (conj_smul_le_of_le (le_refl H) ⟨h, hh⟩)

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -407,19 +407,6 @@ instance pointwise_isCentralScalar [MulDistribMulAction αᵐᵒᵖ G] [IsCentra
     IsCentralScalar α (Subgroup G) :=
   ⟨fun _ S => (congr_arg fun f => S.map f) <| MonoidHom.ext <| op_smul_eq_smul _⟩
 
-theorem conj_smul_le_of_le {P H : Subgroup G} (hP : P ≤ H) (h : H) :
-    MulAut.conj (h : G) • P ≤ H := by
-  rintro - ⟨g, hg, rfl⟩
-  exact H.mul_mem (H.mul_mem h.2 (hP hg)) (H.inv_mem h.2)
-
-theorem conj_smul_subgroupOf {P H : Subgroup G} (hP : P ≤ H) (h : H) :
-    MulAut.conj h • P.subgroupOf H = (MulAut.conj (h : G) • P).subgroupOf H := by
-  refine le_antisymm ?_ ?_
-  · rintro - ⟨g, hg, rfl⟩
-    exact ⟨g, hg, rfl⟩
-  · rintro p ⟨g, hg, hp⟩
-    exact ⟨⟨g, hP hg⟩, hg, Subtype.ext hp⟩
-
 end Monoid
 
 section Group
@@ -446,6 +433,26 @@ theorem pointwise_smul_subset_iff {a : α} {S T : Subgroup G} : a • S ≤ T �
 
 theorem subset_pointwise_smul_iff {a : α} {S T : Subgroup G} : S ≤ a • T ↔ a⁻¹ • S ≤ T :=
   subset_smul_set_iff
+
+theorem conj_smul_le_of_le {P H : Subgroup G} (hP : P ≤ H) (h : H) :
+    MulAut.conj (h : G) • P ≤ H := by
+  rintro - ⟨g, hg, rfl⟩
+  exact H.mul_mem (H.mul_mem h.2 (hP hg)) (H.inv_mem h.2)
+
+theorem conj_smul_eq_of_mem {G : Type*} [Group G] {H : Subgroup G} {h : G} (hh : h ∈ H) :
+    MulAut.conj h • H = H := by
+  refine le_antisymm ?_ ?_
+  · exact (conj_smul_le_of_le (le_refl H) ⟨h, hh⟩)
+  · rw [subset_pointwise_smul_iff, ← map_inv]
+    exact conj_smul_le_of_le (le_refl H) ⟨h⁻¹, H.inv_mem hh⟩
+
+theorem conj_smul_subgroupOf {P H : Subgroup G} (hP : P ≤ H) (h : H) :
+    MulAut.conj h • P.subgroupOf H = (MulAut.conj (h : G) • P).subgroupOf H := by
+  refine le_antisymm ?_ ?_
+  · rintro - ⟨g, hg, rfl⟩
+    exact ⟨g, hg, rfl⟩
+  · rintro p ⟨g, hg, hp⟩
+    exact ⟨⟨g, hP hg⟩, hg, Subtype.ext hp⟩
 
 @[simp]
 theorem smul_inf (a : α) (S T : Subgroup G) : a • (S ⊓ T) = a • S ⊓ a • T := by

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -439,7 +439,7 @@ theorem conj_smul_le_of_le {P H : Subgroup G} (hP : P ≤ H) (h : H) :
   rintro - ⟨g, hg, rfl⟩
   exact H.mul_mem (H.mul_mem h.2 (hP hg)) (H.inv_mem h.2)
 
-theorem conj_smul_eq_self_of_mem {G : Type*} [Group G] {H : Subgroup G} {h : G} (hh : h ∈ H) :
+theorem conj_smul_eq_self_of_mem {H : Subgroup G} {h : G} (hh : h ∈ H) :
     MulAut.conj h • H = H := by
   refine le_antisymm ?_ ?_
   · exact (conj_smul_le_of_le (le_refl H) ⟨h, hh⟩)


### PR DESCRIPTION
Moved `conj_smul_le_of_le` and `conj_smul_subgroupOf` since they are lemmas regarding subgroups, and also because the added lemma `conj_smul_eq_of_mem`  which uses `conj_smul_le_of_le`  also depends on `subset_pointwise_smul_iff` which is in this Group section.

---

I think this is an instance of some missing API which I personally found this useful in my project where I heavily use conjugation.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
