### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Quotient): lift bilinear forms to quotients

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4775,6 +4775,7 @@ public import Mathlib.LinearAlgebra.QuadraticForm.Real
 public import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
 public import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct.Isometries
 public import Mathlib.LinearAlgebra.Quotient.Basic
+public import Mathlib.LinearAlgebra.Quotient.Bilinear
 public import Mathlib.LinearAlgebra.Quotient.Card
 public import Mathlib.LinearAlgebra.Quotient.Defs
 public import Mathlib.LinearAlgebra.Quotient.Pi

--- a/Mathlib/LinearAlgebra/Quotient/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Bilinear.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+module
+
+public import Mathlib.LinearAlgebra.Quotient.Basic
+public import Mathlib.LinearAlgebra.SesquilinearForm.Basic
+
+/-!
+# Lifting bilinear forms to quotients
+-/
+@[expose] public section
+
+namespace LinearMap
+
+section Asymmetric -- "asymmetric" case of a form `M × N → P`
+
+variable {R R₂ S S₂ M N P : Type*} [Ring R] [Ring R₂] [Ring S] [Ring S₂]
+    [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [Module R M] [Module S N] [Module R₂ P]
+    [Module S₂ P] [SMulCommClass R₂ S₂ P] {ρ : R →+* R₂} {σ : S →+* S₂}
+
+attribute [local instance] SMulCommClass.symm -- should this be global?
+
+/-- Lift a bilinear form from `M × N → P` to `(M ⧸ M') × (N ⧸ N') → P`. -/
+def liftQ₂ (M' : Submodule R M) (N' : Submodule S N) (f : M →ₛₗ[ρ] N →ₛₗ[σ] P)
+    (hM' : M' ≤ f.ker) (hN' : N' ≤ f.flip.ker) :
+    M ⧸ M' →ₛₗ[ρ] N ⧸ N' →ₛₗ[σ] P :=
+  have : ∀ n ∈ N', n ∈ (M'.liftQ f hM').flip.ker := fun n hn ↦ by
+    simp_rw [LinearMap.mem_ker, LinearMap.ext_iff, LinearMap.flip_apply, Submodule.Quotient.forall,
+      Submodule.liftQ_apply, ← f.flip_apply, show f.flip n = 0 from hN' hn, LinearMap.zero_apply,
+      forall_true_iff]
+  (N'.liftQ (M'.liftQ f hM').flip this).flip
+
+@[simp]
+lemma liftQ₂_mk {M' : Submodule R M} {N' : Submodule S N} {f : M →ₛₗ[ρ] N →ₛₗ[σ] P}
+    (hM' : M' ≤ f.ker) (hN' : N' ≤ f.flip.ker) (m : M) (n : N) :
+    f.liftQ₂ M' N' hM' hN' (Submodule.Quotient.mk m) (Submodule.Quotient.mk n) = f m n :=
+  rfl
+
+end Asymmetric
+
+section Symmetric -- "symmetric" case of a form `M × M → P`
+
+variable {R S M P : Type*} [AddCommGroup M] [CommRing R] [CommRing S]
+    [Module R M] [AddCommGroup P] [Module S P] {I₁ I₂ : R →+* S}
+
+/-- Special case of `LinearMap.liftQ₂` with left and right spaces the same. Reducible so
+that simp lemmas about `LinearMap.liftQ₂` apply to it. -/
+abbrev IsRefl.liftQ₂ (f : M →ₛₗ[I₁] M →ₛₗ[I₂] P)
+    (N : Submodule R M) (hf : f.IsRefl) (hN : N ≤ f.ker) :
+    M ⧸ N →ₛₗ[I₁] M ⧸ N →ₛₗ[I₂] P :=
+  f.liftQ₂ N N hN (hf.ker_flip ▸ hN)
+
+end Symmetric
+
+end LinearMap

--- a/Mathlib/LinearAlgebra/Quotient/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Bilinear.lean
@@ -21,7 +21,7 @@ variable {R R₂ S S₂ M N P : Type*} [Ring R] [Ring R₂] [Ring S] [Ring S₂]
     [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [Module R M] [Module S N] [Module R₂ P]
     [Module S₂ P] [SMulCommClass R₂ S₂ P] {ρ : R →+* R₂} {σ : S →+* S₂}
 
-attribute [local instance] SMulCommClass.symm -- should this be global?
+attribute [local instance] SMulCommClass.symm
 
 /-- Lift a bilinear form from `M × N → P` to `(M ⧸ M') × (N ⧸ N') → P`. -/
 def liftQ₂ (M' : Submodule R M) (N' : Submodule S N) (f : M →ₛₗ[ρ] N →ₛₗ[σ] P)

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
@@ -170,19 +170,21 @@ theorem domRestrict (p : Submodule R₁ M₁) : (B.domRestrict₁₂ p p).IsRefl
   simp_rw [domRestrict₁₂_apply]
   exact H _ _
 end
+
 @[simp]
 theorem flip_isRefl_iff : B.flip.IsRefl ↔ B.IsRefl :=
-  ⟨fun h x y H ↦ h y x ((B.flip_apply _ _).trans H), fun h x y ↦ h y x⟩
+  forall_comm
+
+lemma ker_flip (H : B.IsRefl) : B.flip.ker = B.ker := by
+  ext x
+  simp [LinearMap.ext_iff, H.eq_iff]
 
 theorem ker_flip_eq_bot (H : B.IsRefl) (h : LinearMap.ker B = ⊥) : LinearMap.ker B.flip = ⊥ := by
-  refine ker_eq_bot'.mpr fun _ hx ↦ ker_eq_bot'.mp h _ ?_
-  ext
-  exact H _ _ (LinearMap.congr_fun hx _)
+  rwa [H.ker_flip]
 
 theorem ker_eq_bot_iff_ker_flip_eq_bot (H : B.IsRefl) :
     LinearMap.ker B = ⊥ ↔ LinearMap.ker B.flip = ⊥ := by
-  refine ⟨ker_flip_eq_bot H, fun h ↦ ?_⟩
-  exact (congr_arg _ B.flip_flip.symm).trans (ker_flip_eq_bot (flip_isRefl_iff.mpr H) h)
+  rwa [ker_flip]
 
 end IsRefl
 


### PR DESCRIPTION
We add `LinearMap.liftQ₂`, which is a bilinear-map variant of the existing `LinearMap.liftQ`, lifting a bilinear map to a quotient by a submodule in both arguments. This is a prerequisite for Sylvester's law of inertia.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
