### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus): generalize scalar multiplication actions

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
@@ -36,7 +36,7 @@ variable (c f s x) in
 theorem derivWithin_comp_mul_left :
     derivWithin (f <| c * ·) s x = c • derivWithin f (c • s) (c * x) := by
   simp only [← smul_eq_mul]
-  rw [← derivWithin_const_smul', derivWithin, derivWithin,
+  rw [← derivWithin_const_smul_field, derivWithin, derivWithin,
     fderivWithin_comp_smul_eq_fderivWithin_smul, Pi.smul_def]
 
 variable (c f x) in

--- a/Mathlib/Analysis/Calculus/Deriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Mul.lean
@@ -85,7 +85,7 @@ section SMul
 /-! ### Derivative of the multiplication of a scalar function and a vector function -/
 
 
-variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' F]
+variable {𝕜' : Type*} [NormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [Module 𝕜' F] [IsBoundedSMul 𝕜' F]
   [IsScalarTower 𝕜 𝕜' F] {c : 𝕜 → 𝕜'} {c' : 𝕜'}
 
 @[to_fun]
@@ -139,6 +139,8 @@ theorem HasDerivAt.smul_const (hc : HasDerivAt c c' x) (f : F) :
   rw [← hasDerivWithinAt_univ] at *
   exact hc.smul_const f
 
+-- TODO: Version of this without differentiability assumptions when `c` takes values in a
+-- division ring (seems non-trivial)
 theorem derivWithin_smul_const (hc : DifferentiableWithinAt 𝕜 c s x) (f : F) :
     derivWithin (fun y => c y • f) s x = derivWithin c s x • f := by
   by_cases hsx : UniqueDiffWithinAt 𝕜 s x
@@ -153,7 +155,11 @@ end SMul
 
 section ConstSMul
 
-variable {R : Type*} [Semiring R] [Module R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F]
+variable
+  {R : Type*} [Monoid R] [DistribMulAction R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F]
+  -- TODO: all results involving `𝕝` would actually work for a `GroupWithZero` if we had a
+  -- `DistribMulActionWithZero` typeclass
+  {𝕝 : Type*} [DivisionSemiring 𝕝] [Module 𝕝 F] [SMulCommClass 𝕜 𝕝 F] [ContinuousConstSMul 𝕝 F]
 
 @[to_fun]
 theorem HasStrictDerivAt.const_smul (c : R) (hf : HasStrictDerivAt f f' x) :
@@ -186,20 +192,24 @@ theorem derivWithin_const_smul (c : R) (hf : DifferentiableWithinAt 𝕜 f s x) 
   derivWithin_fun_const_smul c hf
 
 /-- A variant of `derivWithin_fun_const_smul` without differentiability assumption when the scalar
-multiplication is by field elements. -/
-lemma derivWithin_fun_const_smul' {f : 𝕜 → F} {x : 𝕜} {R : Type*} [Field R] [Module R F]
-    [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F] (c : R) :
+multiplication is by division ring elements. -/
+lemma derivWithin_fun_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
     derivWithin (fun y ↦ c • f y) s x = c • derivWithin f s x := by
   by_cases hsx : UniqueDiffWithinAt 𝕜 s x
   · simp [← fderivWithin_derivWithin, ← Pi.smul_def, fderivWithin_const_smul_field c hsx]
   · simp [derivWithin_zero_of_not_uniqueDiffWithinAt hsx]
 
+@[deprecated (since := "2026-01-11")] alias derivWithin_fun_const_smul' :=
+  derivWithin_fun_const_smul_field
+
 /-- A variant of `derivWithin_const_smul` without differentiability assumption when the scalar
-multiplication is by field elements. -/
-lemma derivWithin_const_smul' {f : 𝕜 → F} {x : 𝕜} {R : Type*} [Field R] [Module R F]
-    [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F] (c : R) :
+multiplication is by division ring elements. -/
+lemma derivWithin_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
     derivWithin (c • f) s x = c • derivWithin f s x :=
-  derivWithin_fun_const_smul' c
+  derivWithin_fun_const_smul_field c f
+
+@[deprecated (since := "2026-01-11")] alias derivWithin_const_smul' :=
+  derivWithin_const_smul_field
 
 theorem deriv_fun_const_smul (c : R) (hf : DifferentiableAt 𝕜 f x) :
     deriv (fun y => c • f y) x = c • deriv f x :=
@@ -209,19 +219,21 @@ theorem deriv_const_smul (c : R) (hf : DifferentiableAt 𝕜 f x) :
     deriv (c • f) x = c • deriv f x :=
   (hf.hasDerivAt.const_smul c).deriv
 
-/-- A variant of `deriv_const_smul` without differentiability assumption when the scalar
-multiplication is by field elements. -/
-lemma deriv_fun_const_smul' {f : 𝕜 → F} {x : 𝕜}
-    {R : Type*} [Field R] [Module R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F] (c : R) :
+/-- A variant of `deriv_fun_const_smul` without differentiability assumption when the scalar
+multiplication is by division ring elements. -/
+lemma deriv_fun_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
     deriv (fun y ↦ c • f y) x = c • deriv f x := by
-  simp only [← derivWithin_univ, derivWithin_fun_const_smul']
+  simp only [← derivWithin_univ, derivWithin_fun_const_smul_field]
+
+@[deprecated (since := "2026-01-11")] alias deriv_fun_const_smul' := deriv_fun_const_smul_field
 
 /-- A variant of `deriv_const_smul` without differentiability assumption when the scalar
-multiplication is by field elements. -/
-lemma deriv_const_smul' {f : 𝕜 → F} {x : 𝕜}
-    {R : Type*} [Field R] [Module R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F] (c : R) :
+multiplication is by division ring elements. -/
+lemma deriv_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
     deriv (c • f) x = c • deriv f x := by
-  simp only [← derivWithin_univ, derivWithin_const_smul']
+  simp only [← derivWithin_univ, derivWithin_const_smul_field]
+
+@[deprecated (since := "2026-01-11")] alias deriv_const_smul' := deriv_const_smul_field
 
 end ConstSMul
 
@@ -230,8 +242,8 @@ section Mul
 /-! ### Derivative of the multiplication of two functions -/
 
 
-variable {𝕜' 𝔸 : Type*} [NormedField 𝕜'] [NormedRing 𝔸] [NormedAlgebra 𝕜 𝕜'] [NormedAlgebra 𝕜 𝔸]
-  {c d : 𝕜 → 𝔸} {c' d' : 𝔸} {u v : 𝕜 → 𝕜'}
+variable {𝕜' 𝔸 : Type*} [NormedDivisionRing 𝕜'] [NormedRing 𝔸] [NormedAlgebra 𝕜 𝕜']
+  [NormedAlgebra 𝕜 𝔸] {c d : 𝕜 → 𝔸} {c' d' : 𝔸} {u v : 𝕜 → 𝕜'}
 
 @[to_fun]
 theorem HasDerivWithinAt.mul (hc : HasDerivWithinAt c c' s x) (hd : HasDerivWithinAt d d' s x) :
@@ -347,17 +359,20 @@ theorem derivWithin_const_mul (c : 𝔸) (hd : DifferentiableWithinAt 𝕜 d s x
   · exact (hd.hasDerivWithinAt.const_mul c).derivWithin hsx
   · simp [derivWithin_zero_of_not_uniqueDiffWithinAt hsx]
 
+/-- A variant of `derivWithin_const_mul` without differentiability assumption when the scalar
+multiplication is by division ring elements. -/
 lemma derivWithin_const_mul_field (u : 𝕜') :
     derivWithin (fun y => u * v y) s x = u * derivWithin v s x := by
-  simp_rw [mul_comm u]
-  exact derivWithin_mul_const_field u
+  apply derivWithin_const_smul_field (c := u)
 
 theorem deriv_const_mul (c : 𝔸) (hd : DifferentiableAt 𝕜 d x) :
     deriv (fun y => c * d y) x = c * deriv d x :=
   (hd.hasDerivAt.const_mul c).deriv
 
+/-- A variant of `deriv_const_mul` without differentiability assumption when the scalar
+multiplication is by division ring elements. -/
 theorem deriv_const_mul_field (u : 𝕜') : deriv (fun y => u * v y) x = u * deriv v x := by
-  simp only [mul_comm u, deriv_mul_const_field]
+  simpa only [← derivWithin_univ] using derivWithin_const_mul_field u
 
 @[simp]
 theorem deriv_const_mul_field' (u : 𝕜') : (deriv fun x => u * v x) = fun x => u * deriv v x :=
@@ -472,7 +487,7 @@ end Prod
 
 section Div
 
-variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {c : 𝕜 → 𝕜'} {c' : 𝕜'}
+variable {𝕜' : Type*} [NormedDivisionRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] {c : 𝕜 → 𝕜'} {c' : 𝕜'}
 
 theorem HasDerivAt.div_const (hc : HasDerivAt c c' x) (d : 𝕜') :
     HasDerivAt (fun x => c x / d) (c' / d) x := by
@@ -504,9 +519,9 @@ theorem DifferentiableOn.div_const (hc : DifferentiableOn 𝕜 c s) (d : 𝕜') 
 theorem Differentiable.div_const (hc : Differentiable 𝕜 c) (d : 𝕜') :
     Differentiable 𝕜 fun x => c x / d := fun x => (hc x).div_const d
 
-theorem derivWithin_div_const (hc : DifferentiableWithinAt 𝕜 c s x) (d : 𝕜') :
+theorem derivWithin_div_const (c : 𝕜 → 𝕜') (d : 𝕜') :
     derivWithin (fun x => c x / d) s x = derivWithin c s x / d := by
-  simp [div_eq_inv_mul, derivWithin_const_mul, hc]
+  simp [div_eq_mul_inv, derivWithin_mul_const_field]
 
 @[simp]
 theorem deriv_div_const (d : 𝕜') : deriv (fun x => c x / d) x = deriv c x / d := by

--- a/Mathlib/Analysis/Calculus/DifferentialForm/Basic.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/Basic.lean
@@ -115,7 +115,7 @@ theorem extDeriv_fun_add (hω₁ : DifferentiableAt 𝕜 ω₁ x) (hω₂ : Diff
 
 theorem extDerivWithin_smul (c : 𝕜) (ω : E → E [⋀^Fin n]→L[𝕜] F) (hsx : UniqueDiffWithinAt 𝕜 s x) :
     extDerivWithin (c • ω) s x = c • extDerivWithin ω s x := by
-  simp [extDerivWithin, fderivWithin_const_smul_of_field, hsx, alternatizeUncurryFin_smul]
+  simp [extDerivWithin, fderivWithin_const_smul_field, hsx, alternatizeUncurryFin_smul]
 
 theorem extDerivWithin_fun_smul (c : 𝕜) (ω : E → E [⋀^Fin n]→L[𝕜] F)
     (hsx : UniqueDiffWithinAt 𝕜 s x) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -43,7 +43,8 @@ variable {L : Filter E}
 
 section ConstSMul
 
-variable {R : Type*} [Semiring R] [Module R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F]
+variable {R : Type*} [Monoid R] [DistribMulAction R F] [SMulCommClass 𝕜 R F]
+  [ContinuousConstSMul R F]
 
 /-! ### Derivative of a function multiplied by a constant -/
 
@@ -109,22 +110,11 @@ theorem fderivWithin_const_smul_of_invertible (c : R) [Invertible c]
     fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
   by_cases h : DifferentiableWithinAt 𝕜 f s x
   · exact (h.hasFDerivWithinAt.const_smul c).fderivWithin hs
-  · obtain (rfl | hc) := eq_or_ne c 0
-    · simp
-    have : ¬DifferentiableWithinAt 𝕜 (c • f) s x := by
+  · have : ¬DifferentiableWithinAt 𝕜 (c • f) s x := by
       contrapose! h
       exact (differentiableWithinAt_smul_iff c).mp h
     simp [fderivWithin_zero_of_not_differentiableWithinAt h,
       fderivWithin_zero_of_not_differentiableWithinAt this]
-
-/-- Special case of `fderivWithin_const_smul_of_invertible` over a field: any constant is allowed -/
-lemma fderivWithin_const_smul_of_field (c : 𝕜) (hs : UniqueDiffWithinAt 𝕜 s x) :
-    fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
-  obtain (rfl | ha) := eq_or_ne c 0
-  · simp
-  · have : Invertible c := invertibleOfNonzero ha
-    ext x
-    simp [fderivWithin_const_smul_of_invertible c (f := f) hs]
 
 theorem fderiv_fun_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     fderiv 𝕜 (fun y => c • f y) x = c • fderiv 𝕜 f x :=
@@ -145,13 +135,42 @@ theorem fderiv_const_smul_of_invertible (c : R) [Invertible c] :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x := by
   simp [← fderivWithin_univ, fderivWithin_const_smul_of_invertible c uniqueDiffWithinAt_univ]
 
-/-- Special case of `fderiv_const_smul_of_invertible` over a field: any constant is allowed -/
-lemma fderiv_const_smul_of_field (c : 𝕜) : fderiv 𝕜 (c • f) = c • fderiv 𝕜 f := by
+end ConstSMul
+
+section ConstSMulDivisionRing
+
+variable {R : Type*} [DivisionSemiring R] [Module R F] [SMulCommClass 𝕜 R F]
+  [ContinuousConstSMul R F]
+
+/-- Special case of `fderivWithin_const_smul_of_invertible` over a division semiring: any constant
+is allowed.
+
+TODO: This would work for scalars in a `GroupWithZero` if we had a `DistribMulActionWithZero`
+typeclass. -/
+lemma fderivWithin_const_smul_field (c : R) (hs : UniqueDiffWithinAt 𝕜 s x) :
+    fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
+  obtain (rfl | ha) := eq_or_ne c 0
+  · simp
+  · have : Invertible c := invertibleOfNonzero ha
+    ext x
+    simp [fderivWithin_const_smul_of_invertible c (f := f) hs]
+
+@[deprecated (since := "2026-01-11")] alias fderivWithin_const_smul_of_field :=
+  fderivWithin_const_smul_field
+
+/-- Special case of `fderiv_const_smul_of_invertible` over a division semiring: any constant is
+allowed.
+
+TODO: This would work for scalars in a `GroupWithZero` if we had a `DistribMulActionWithZero`
+typeclass. -/
+lemma fderiv_const_smul_field (c : R) : fderiv 𝕜 (c • f) = c • fderiv 𝕜 f := by
   simp_rw [← fderivWithin_univ]
   ext x
-  simp [fderivWithin_const_smul_of_field c uniqueDiffWithinAt_univ]
+  simp [fderivWithin_const_smul_field c uniqueDiffWithinAt_univ]
 
-end ConstSMul
+@[deprecated (since := "2026-01-11")] alias fderiv_const_smul_of_field := fderiv_const_smul_field
+
+end ConstSMulDivisionRing
 
 section Add
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -6,8 +6,7 @@ Authors: Jeremy Avigad, Sébastien Gouëzel, Yury Kudryashov
 module
 
 public import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
-public import Mathlib.Analysis.Calculus.FDeriv.Comp
-public import Mathlib.Analysis.Calculus.FDeriv.Const
+public import Mathlib.Analysis.Calculus.FDeriv.Add
 public import Mathlib.Analysis.Calculus.FDeriv.Linear
 
 /-!
@@ -501,12 +500,16 @@ theorem ContinuousLinearEquiv.uniqueDiffOn_preimage_iff (e : F ≃L[𝕜] E) :
     UniqueDiffOn 𝕜 (e ⁻¹' s) ↔ UniqueDiffOn 𝕜 s := by
   rw [← e.image_symm_eq_preimage, e.symm.uniqueDiffOn_image_iff]
 
-protected theorem UniqueDiffWithinAt.smul (h : UniqueDiffWithinAt 𝕜 s x) {c : 𝕜} (hc : c ≠ 0) :
+protected theorem UniqueDiffWithinAt.smul (h : UniqueDiffWithinAt 𝕜 s x)
+    {G : Type*} [GroupWithZero G] [DistribMulAction G E] [ContinuousConstSMul G E]
+    [SMulCommClass G 𝕜 E] {c : G} (hc : c ≠ 0) :
     UniqueDiffWithinAt 𝕜 (c • s) (c • x) :=
   (ContinuousLinearEquiv.smulLeft <| Units.mk0 c hc).hasFDerivWithinAt
     |>.uniqueDiffWithinAt_of_continuousLinearEquiv _ h
 
-protected theorem UniqueDiffWithinAt.smul_iff {c : 𝕜} (hc : c ≠ 0) :
+protected theorem UniqueDiffWithinAt.smul_iff
+    {G : Type*} [GroupWithZero G] [DistribMulAction G E] [ContinuousConstSMul G E]
+    [SMulCommClass G 𝕜 E] {c : G} (hc : c ≠ 0) :
     UniqueDiffWithinAt 𝕜 (c • s) (c • x) ↔ UniqueDiffWithinAt 𝕜 s x :=
   ⟨fun h ↦ by simpa [hc] using h.smul (inv_ne_zero hc), (.smul · hc)⟩
 
@@ -517,15 +520,6 @@ section SMulLeft
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
   [NormedSpace 𝕜 E] {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : E → F} {s : Set E}
   {f' : E →L[𝕜] F} {x : E}
-
-theorem fderivWithin_const_smul_field {R : Type*} [DivisionRing R] [Module R F]
-    [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F] (c : R) (hs : UniqueDiffWithinAt 𝕜 s x) :
-    fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
-  rcases eq_or_ne c 0 with rfl | hc
-  · simp
-  · lift c to Rˣ using IsUnit.mk0 _ hc
-    have : SMulCommClass Rˣ 𝕜 F := .symm _ _ _
-    exact (ContinuousLinearEquiv.smulLeft c).comp_fderivWithin hs
 
 theorem hasFDerivWithinAt_comp_smul_smul_iff {c : 𝕜} :
     HasFDerivWithinAt (f <| c • ·) (c • f') s x ↔ HasFDerivWithinAt f f' (c • s) (c • x) := by

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -43,14 +43,14 @@ section SMul
 /-! ### Derivative of the product of a scalar-valued function and a vector-valued function
 
 If `c` is a differentiable scalar-valued function and `f` is a differentiable vector-valued
-function, then `fun x ↦ c x • f x` is differentiable as well. Lemmas in this section works for
-function `c` taking values in the base field, as well as in a normed algebra over the base
+function, then `fun x ↦ c x • f x` is differentiable as well. Lemmas in this section work for
+functions `c` taking values in the base field, as well as in a normed algebra over the base
 field: e.g., they work for `c : E → ℂ` and `f : E → F` provided that `F` is a complex
 normed vector space.
 -/
 
 
-variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' F]
+variable {𝕜' : Type*} [NormedRing 𝕜'] [NormedAlgebra 𝕜 𝕜'] [Module 𝕜' F] [IsBoundedSMul 𝕜' F]
   [IsScalarTower 𝕜 𝕜' F]
 
 variable {c : E → 𝕜'} {c' : E →L[𝕜] 𝕜'}

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -270,7 +270,7 @@ lemma iteratedDeriv_comp_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
     have ih' : iteratedDeriv n (fun x ↦ f (-x)) = fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (-x) :=
       funext ih
     rw [iteratedDeriv_succ, iteratedDeriv_succ, ih', pow_succ', neg_mul, one_mul,
-      deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_fun_const_smul',
+      deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_fun_const_smul_field,
       neg_smul]
 
 lemma iteratedDeriv_id {n : ℕ} {x : 𝕜} :


### PR DESCRIPTION
Relax hypotheses on `smul` lemmas about `deriv` and `fderiv`. Also unify [fderivWithin_const_smul_field](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Calculus/FDeriv/Equiv.html#fderivWithin_const_smul_field) and [fderivWithin_const_smul_of_field](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Calculus/FDeriv/Add.html#fderivWithin_const_smul_of_field) which are duplicates.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
