### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): fix name of Fan.IsLimit.desc

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/CombinedProducts.lean
@@ -48,10 +48,10 @@ variable {c₁ c₂ bc}
 points, then the fan constructed from `combPairHoms` is a limit cone. -/
 def combPairIsLimit : IsLimit (Fan.mk bc.pt (combPairHoms c₁ c₂ bc)) :=
   mkFanLimit _
-    (fun s ↦ Fan.IsLimit.desc h <| fun i ↦ by
+    (fun s ↦ Fan.IsLimit.lift h <| fun i ↦ by
       cases i
-      · exact Fan.IsLimit.desc h₁ (fun a ↦ s.proj (.inl a))
-      · exact Fan.IsLimit.desc h₂ (fun a ↦ s.proj (.inr a)))
+      · exact Fan.IsLimit.lift h₁ (fun a ↦ s.proj (.inl a))
+      · exact Fan.IsLimit.lift h₂ (fun a ↦ s.proj (.inr a)))
     (fun s w ↦ by
       cases w <;>
       · simp only [fan_mk_proj, combPairHoms]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -337,11 +337,11 @@ def multicospan : WalkingMulticospan J ⥤ C where
 
 /-- The induced map `∏ᶜ I.left ⟶ ∏ᶜ I.right` via `I.fst` for limiting fans. -/
 def fstPiMapOfIsLimit (c : Fan I.left) {d : Fan I.right} (hd : IsLimit d) : c.pt ⟶ d.pt :=
-  Fan.IsLimit.desc hd fun i ↦ c.proj _ ≫ I.fst i
+  Fan.IsLimit.lift hd fun i ↦ c.proj _ ≫ I.fst i
 
 /-- The induced map `∏ᶜ I.left ⟶ ∏ᶜ I.right` via `I.snd` for limiting fans. -/
 def sndPiMapOfIsLimit (c : Fan I.left) {d : Fan I.right} (hd : IsLimit d) : c.pt ⟶ d.pt :=
-  Fan.IsLimit.desc hd fun i ↦ c.proj _ ≫ I.snd i
+  Fan.IsLimit.lift hd fun i ↦ c.proj _ ≫ I.snd i
 
 @[reassoc (attr := simp)]
 lemma fstPiMapOfIsLimit_proj (c : Fan I.left) {d : Fan I.right} (hd : IsLimit d) (i) :
@@ -615,8 +615,8 @@ variable {c : Fan I.left} (hc : IsLimit c) {d : Fan I.right} (hd : IsLimit d)
 
 @[reassoc (attr := simp)]
 theorem pi_condition :
-    Fan.IsLimit.desc hc K.ι ≫ I.fstPiMapOfIsLimit c hd =
-      Fan.IsLimit.desc hc K.ι ≫ I.sndPiMapOfIsLimit c hd := by
+    Fan.IsLimit.lift hc K.ι ≫ I.fstPiMapOfIsLimit c hd =
+      Fan.IsLimit.lift hc K.ι ≫ I.sndPiMapOfIsLimit c hd := by
   apply Fan.IsLimit.hom_ext hd
   simp
 
@@ -624,17 +624,17 @@ theorem pi_condition :
 @[simps! pt]
 def toPiFork (K : Multifork I) :
     Fork (I.fstPiMapOfIsLimit c hd) (I.sndPiMapOfIsLimit c hd) :=
-  .ofι (Fan.IsLimit.desc hc K.ι) (by simp)
+  .ofι (Fan.IsLimit.lift hc K.ι) (by simp)
 
 @[simp]
 theorem toPiFork_π_app_zero :
-    (K.toPiFork hc hd).ι = Fan.IsLimit.desc hc K.ι :=
+    (K.toPiFork hc hd).ι = Fan.IsLimit.lift hc K.ι :=
   rfl
 
 @[simp]
 theorem toPiFork_π_app_one :
     (K.toPiFork hc hd).π.app WalkingParallelPair.one =
-      Fan.IsLimit.desc hc K.ι ≫ I.fstPiMapOfIsLimit c hd :=
+      Fan.IsLimit.lift hc K.ι ≫ I.fstPiMapOfIsLimit c hd :=
   rfl
 
 variable {hd} in
@@ -688,10 +688,6 @@ def toPiForkFunctor :
         · apply Fan.IsLimit.hom_ext hc
           simp
         · apply Fan.IsLimit.hom_ext hd
-          intro j
-          simp only [Multifork.toPiFork_π_app_one, Multifork.pi_condition,
-            Category.assoc]
-          dsimp [MulticospanIndex.sndPiMapOfIsLimit, Fan.proj, Fan.IsLimit.desc]
           simp }
 
 /-- `Multifork.ofPiFork` as a functor. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -118,14 +118,16 @@ def mkFanLimit {f : β → C} (t : Fan f) (lift : ∀ s : Fan f, s.pt ⟶ t.pt)
   { lift }
 
 /-- Constructor for morphisms to the point of a limit fan. -/
-def Fan.IsLimit.desc {F : β → C} {c : Fan F} (hc : IsLimit c) {A : C}
+def Fan.IsLimit.lift {F : β → C} {c : Fan F} (hc : IsLimit c) {A : C}
     (f : ∀ i, A ⟶ F i) : A ⟶ c.pt :=
   hc.lift (Fan.mk A f)
+
+@[deprecated (since := "2026-01-12")] alias Fan.IsLimit.desc := Fan.IsLimit.lift
 
 @[reassoc (attr := simp)]
 lemma Fan.IsLimit.fac {F : β → C} {c : Fan F} (hc : IsLimit c) {A : C}
     (f : ∀ i, A ⟶ F i) (i : β) :
-    Fan.IsLimit.desc hc f ≫ c.proj i = f i :=
+    Fan.IsLimit.lift hc f ≫ c.proj i = f i :=
   hc.fac (Fan.mk A f) ⟨i⟩
 
 @[reassoc (attr := simp)]
@@ -887,7 +889,7 @@ def Fan.IsLimit.prod (c : ∀ i : ι, Fan (fun j : ι' ↦ X i j)) (hc : ∀ i :
     (c' : Fan (fun i : ι ↦ (c i).pt)) (hc' : IsLimit c') :
     (IsLimit <| Fan.mk c'.pt fun p : ι × ι' ↦ c'.proj _ ≫ (c p.1).proj p.2) := by
   refine mkFanLimit _ (fun t ↦ ?_) ?_ fun t m hm ↦ ?_
-  · exact Fan.IsLimit.desc hc' fun i ↦ Fan.IsLimit.desc (hc i) fun j ↦ t.proj (i, j)
+  · exact Fan.IsLimit.lift hc' fun i ↦ Fan.IsLimit.lift (hc i) fun j ↦ t.proj (i, j)
   · simp
   · refine Fan.IsLimit.hom_ext hc' _ _ fun i ↦ ?_
     exact Fan.IsLimit.hom_ext (hc i) _ _ fun j ↦ (by simpa using hm (i, j))


### PR DESCRIPTION
This is renamed as `Fan.IsLimit.lift`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
