### PR TITLE
[Merged by Bors] - feat(Order/WithBot): `∀ x > ↑a, p x` iff `∀ b > a, p ↑b`

### DIFF
--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -628,23 +628,23 @@ lemma forall_le_coe_iff_le [NoBotOrder α] : (∀ a : α, y ≤ a → x ≤ a) �
   · exact ⟨fun h ↦ h _ le_rfl, fun hmn a ham ↦ hmn.trans ham⟩
 
 @[to_dual (attr := simp) forall_lt_coe]
-theorem forall_coe_lt {P : WithBot α → Prop} :
-    (∀ x, (a : WithBot α) < x → P x) ↔ ∀ b, a < b → P b := by
+theorem forall_coe_lt {p : WithBot α → Prop} :
+    (∀ x, (a : WithBot α) < x → p x) ↔ ∀ b, a < b → p b := by
   simp [WithBot.forall]
 
 @[to_dual (attr := simp) exists_lt_coe]
-theorem exists_coe_lt {P : WithBot α → Prop} :
-    (∃ x, (a : WithBot α) < x ∧ P x) ↔ ∃ b, a < b ∧ P b := by
+theorem exists_coe_lt {p : WithBot α → Prop} :
+    (∃ x, (a : WithBot α) < x ∧ p x) ↔ ∃ b, a < b ∧ p b := by
   simp [WithBot.exists]
 
 @[to_dual (attr := simp) forall_le_coe]
-theorem forall_coe_le {P : WithBot α → Prop} :
-    (∀ x, (a : WithBot α) ≤ x → P x) ↔ ∀ b, a ≤ b → P b := by
+theorem forall_coe_le {p : WithBot α → Prop} :
+    (∀ x, (a : WithBot α) ≤ x → p x) ↔ ∀ b, a ≤ b → p b := by
   simp [WithBot.forall]
 
 @[to_dual (attr := simp) exists_le_coe]
-theorem exists_coe_le {P : WithBot α → Prop} :
-    (∃ x, (a : WithBot α) ≤ x ∧ P x) ↔ ∃ b, a ≤ b ∧ P b := by
+theorem exists_coe_le {p : WithBot α → Prop} :
+    (∃ x, (a : WithBot α) ≤ x ∧ p x) ↔ ∃ b, a ≤ b ∧ p b := by
   simp [WithBot.exists]
 
 end Preorder

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -193,7 +193,7 @@ lemma eq_bot_iff_forall_ne {x : WithBot α} : x = ⊥ ↔ ∀ a : α, ↑a ≠ x
   Option.eq_none_iff_forall_some_ne
 
 @[to_dual]
-theorem forall_ne_bot {p : WithBot α → Prop} : (∀ x, x ≠ ⊥ → p x) ↔ ∀ x : α, p x := by
+theorem forall_ne_bot {p : WithBot α → Prop} : (∀ x ≠ ⊥, p x) ↔ ∀ x : α, p x := by
   simp [ne_bot_iff_exists]
 
 @[to_dual]
@@ -626,6 +626,26 @@ lemma forall_le_coe_iff_le [NoBotOrder α] : (∀ a : α, y ≤ a → x ≤ a) �
   obtain _ | y := y
   · simp [WithBot.none_eq_bot, eq_bot_iff_forall_le]
   · exact ⟨fun h ↦ h _ le_rfl, fun hmn a ham ↦ hmn.trans ham⟩
+
+@[to_dual (attr := simp) forall_lt_coe]
+theorem forall_coe_lt {P : WithBot α → Prop} :
+    (∀ x, (a : WithBot α) < x → P x) ↔ ∀ b, a < b → P b := by
+  simp [WithBot.forall]
+
+@[to_dual (attr := simp) exists_lt_coe]
+theorem exists_coe_lt {P : WithBot α → Prop} :
+    (∃ x, (a : WithBot α) < x ∧ P x) ↔ ∃ b, a < b ∧ P b := by
+  simp [WithBot.exists]
+
+@[to_dual (attr := simp) forall_le_coe]
+theorem forall_coe_le {P : WithBot α → Prop} :
+    (∀ x, (a : WithBot α) ≤ x → P x) ↔ ∀ b, a ≤ b → P b := by
+  simp [WithBot.forall]
+
+@[to_dual (attr := simp) exists_le_coe]
+theorem exists_coe_le {P : WithBot α → Prop} :
+    (∃ x, (a : WithBot α) ≤ x ∧ P x) ↔ ∃ b, a ≤ b ∧ P b := by
+  simp [WithBot.exists]
 
 end Preorder
 


### PR DESCRIPTION
Upstreamed from the CGT repo.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
