### PR TITLE
[Merged by Bors] - feat(MeasureTheory): characterise when a measure is supported on a finset

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -194,7 +194,7 @@ open Measure
 theorem mem_ae_dirac_iff {a : α} (hs : MeasurableSet s) : s ∈ ae (dirac a) ↔ a ∈ s := by
   by_cases a ∈ s <;> simp [mem_ae_iff, dirac_apply', hs.compl, *]
 
-theorem ae_dirac_iff {a : α} {p : α → Prop} (hp : MeasurableSet { x | p x }) :
+@[simp] theorem ae_dirac_iff {a : α} {p : α → Prop} (hp : MeasurableSet { x | p x }) :
     (∀ᵐ x ∂dirac a, p x) ↔ p a :=
   mem_ae_dirac_iff hp
 
@@ -313,3 +313,42 @@ lemma injective_dirac [SeparatesPoints α] :
 end dirac_injective
 
 end MeasureTheory
+
+namespace MeasureTheory.Measure
+variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  [MeasurableSingletonClass α] {f : β → α} {μ : Measure α} {s : Finset α} {a₁ a₂ : α}
+
+lemma ae_mem_finset_iff : (∀ᵐ a ∂μ, a ∈ s) ↔ μ = ∑ a ∈ s, μ {a} • .dirac a where
+  mp hμ := by
+    ext t ht
+    rw [← measure_diff_null (s := t) hμ]
+    dsimp
+    classical
+    rw [Set.diff_compl, ← (s : Set α).biUnion_of_singleton]
+    simp_rw [Finset.mem_coe, Set.inter_iUnion]
+    rw [measure_biUnion_finset (fun i hi j hj hij ↦ .inter_left' _ <| .inter_right' _ ?_)
+      (by measurability)]
+    · simp only [coe_finset_sum, Finset.sum_apply, smul_apply]
+      congr! 1 with a ha
+      by_cases ha₁ : a ∈ t <;> simp [*]
+    simpa [Function.onFun]
+  mpr hμ := by rw [hμ, ae_sum_measure_iff]; rintro i hi; refine ae_smul_measure (by simpa) _
+
+lemma ae_eq_or_eq_iff_eq_dirac_add_dirac (ha : a₁ ≠ a₂) :
+    (∀ᵐ a ∂μ, a = a₁ ∨ a = a₂) ↔ μ = μ {a₁} • .dirac a₁ + μ {a₂} • .dirac a₂ := by
+  -- FIXME: Why does `simpa using ...` not work?
+  convert ae_mem_finset_iff (s := .cons a₁ {a₂} <| by simpa) (μ := μ) <;> simp
+
+lemma ae_mem_finset_iff_map_eq_sum_dirac {μ : Measure β} (hf : AEMeasurable f μ) :
+    (∀ᵐ b ∂μ, f b ∈ s) ↔ μ.map f = ∑ a ∈ s, μ (f ⁻¹' {a}) • .dirac a := by
+  rw [← ae_map_iff hf (by measurability), ae_mem_finset_iff]
+  simp [map_apply₀ hf]
+
+lemma ae_eq_or_eq_iff_map_eq_dirac_add_dirac {μ : Measure β} (hf : AEMeasurable f μ)
+    (ha : a₁ ≠ a₂) :
+    (∀ᵐ b ∂μ, f b = a₁ ∨ f b = a₂) ↔
+      μ.map f = μ (f ⁻¹' {a₁}) • .dirac a₁ + μ (f ⁻¹' {a₂}) • .dirac a₂ := by
+  -- FIXME: Why does `simpa using ...` not work?
+  convert ae_mem_finset_iff_map_eq_sum_dirac (s := .cons a₁ {a₂} <| by simpa) (μ := μ) hf <;> simp
+
+end MeasureTheory.Measure

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -329,15 +329,15 @@ lemma ae_mem_finset_iff : (∀ᵐ a ∂μ, a ∈ s) ↔ μ = ∑ a ∈ s, μ {a}
     rw [measure_biUnion_finset (fun i hi j hj hij ↦ .inter_left' _ <| .inter_right' _ ?_)
       (by measurability)]
     · simp only [coe_finset_sum, Finset.sum_apply, smul_apply]
-      congr! 1 with a ha
-      by_cases ha₁ : a ∈ t <;> simp [*]
-    simpa [Function.onFun]
-  mpr hμ := by rw [hμ, ae_sum_measure_iff]; rintro i hi; refine ae_smul_measure (by simpa) _
+      congr with a
+      by_cases ha : a ∈ t <;> simp [*]
+    simpa
+  mpr hμ := by rw [hμ, ae_finsetSum_measure_iff]; exact fun i hi ↦ ae_smul_measure (by simpa) _
 
 lemma ae_eq_or_eq_iff_eq_dirac_add_dirac (ha : a₁ ≠ a₂) :
     (∀ᵐ a ∂μ, a = a₁ ∨ a = a₂) ↔ μ = μ {a₁} • .dirac a₁ + μ {a₂} • .dirac a₂ := by
   -- FIXME: Why does `simpa using ...` not work?
-  convert ae_mem_finset_iff (s := .cons a₁ {a₂} <| by simpa) (μ := μ) <;> simp
+  convert ae_mem_finset_iff (s := .cons a₁ {a₂} <| by simpa) <;> simp
 
 lemma ae_mem_finset_iff_map_eq_sum_dirac {μ : Measure β} (hf : AEMeasurable f μ) :
     (∀ᵐ b ∂μ, f b ∈ s) ↔ μ.map f = ∑ a ∈ s, μ (f ⁻¹' {a}) • .dirac a := by
@@ -349,6 +349,6 @@ lemma ae_eq_or_eq_iff_map_eq_dirac_add_dirac {μ : Measure β} (hf : AEMeasurabl
     (∀ᵐ b ∂μ, f b = a₁ ∨ f b = a₂) ↔
       μ.map f = μ (f ⁻¹' {a₁}) • .dirac a₁ + μ (f ⁻¹' {a₂}) • .dirac a₂ := by
   -- FIXME: Why does `simpa using ...` not work?
-  convert ae_mem_finset_iff_map_eq_sum_dirac (s := .cons a₁ {a₂} <| by simpa) (μ := μ) hf <;> simp
+  convert ae_mem_finset_iff_map_eq_sum_dirac (s := .cons a₁ {a₂} <| by simpa) hf <;> simp
 
 end MeasureTheory.Measure

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -646,9 +646,14 @@ theorem mem_map_restrict_ae_iff {β} {s : Set α} {t : Set β} {f : α → β} (
     t ∈ Filter.map f (ae (μ.restrict s)) ↔ μ ((f ⁻¹' t)ᶜ ∩ s) = 0 := by
   rw [mem_map, mem_ae_iff, Measure.restrict_apply' hs]
 
-theorem ae_add_measure_iff {p : α → Prop} {ν} :
+@[simp] theorem ae_add_measure_iff {p : α → Prop} {ν} :
     (∀ᵐ x ∂μ + ν, p x) ↔ (∀ᵐ x ∂μ, p x) ∧ ∀ᵐ x ∂ν, p x :=
   add_eq_zero
+
+/-- See also `Measure.ae_sum_iff`. -/
+@[simp] lemma ae_sum_measure_iff {p : α → Prop} {s : Finset ι} {μ : ι → Measure α} :
+    (∀ᵐ x ∂∑ i ∈ s, μ i, p x) ↔ ∀ i ∈ s, ∀ᵐ x ∂μ i, p x := by
+  induction s using Finset.cons_induction <;> simp [*]
 
 theorem ae_eq_comp' {ν : Measure β} {f : α → β} {g g' : β → δ} (hf : AEMeasurable f μ)
     (h : g =ᵐ[ν] g') (h2 : μ.map f ≪ ν) : g ∘ f =ᵐ[μ] g' ∘ f :=

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -651,7 +651,7 @@ theorem mem_map_restrict_ae_iff {β} {s : Set α} {t : Set β} {f : α → β} (
   add_eq_zero
 
 /-- See also `Measure.ae_sum_iff`. -/
-@[simp] lemma ae_sum_measure_iff {p : α → Prop} {s : Finset ι} {μ : ι → Measure α} :
+@[simp] lemma ae_finsetSum_measure_iff {p : α → Prop} {s : Finset ι} {μ : ι → Measure α} :
     (∀ᵐ x ∂∑ i ∈ s, μ i, p x) ↔ ∀ i ∈ s, ∀ᵐ x ∂μ i, p x := by
   induction s using Finset.cons_induction <;> simp [*]
 


### PR DESCRIPTION



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
