### PR TITLE
[Merged by Bors] - feat(Order/Minimal): Minimal is equivalent to IsLeast if LE is total

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -699,7 +699,7 @@ end
 
 section Minimal
 
-variable [PartialOrder α] {s : Set α} {a b : α}
+variable [Preorder α] {s : Set α} {a b : α}
 
 theorem DirectedOn.le_of_minimal (h : DirectedOn (fun x y ↦ y ≤ x) s) (hMin : Minimal (· ∈ s) a)
     (hb : b ∈ s) : a ≤ b := by

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -697,6 +697,38 @@ theorem isGLB_upperBounds : IsGLB (upperBounds s) a ↔ IsLUB s a :=
 
 end
 
+section Minimal
+
+variable [PartialOrder α] {s : Set α} {a b : α}
+
+theorem DirectedOn.le_of_minimal (h : DirectedOn (fun x y ↦ y ≤ x) s) (hMin : Minimal (· ∈ s) a)
+    (hb : b ∈ s) : a ≤ b := by
+  obtain ⟨z, hz, hza, hzb⟩ := h a hMin.1 b hb
+  exact (hMin.2 hz hza).trans hzb
+
+theorem DirectedOn.le_of_maximal (h : DirectedOn (· ≤ ·) s) (hMax : Maximal (· ∈ s) a)
+    (hb : b ∈ s) : b ≤ a := by
+  obtain ⟨z, hz, haz, hbz⟩ := h a hMax.1 b hb
+  exact hbz.trans (hMax.2 hz haz)
+
+theorem DirectedOn.minimal_iff_isLeast (h : DirectedOn (fun x y ↦ y ≤ x) s) :
+    Minimal (· ∈ s) a ↔ IsLeast s a :=
+  ⟨fun hMin ↦ ⟨hMin.1, fun _ hy ↦ h.le_of_minimal hMin hy⟩, fun h ↦ ⟨h.1, fun _ hy _ ↦ h.2 hy⟩⟩
+
+theorem DirectedOn.maximal_iff_isGreatest (h : DirectedOn (· ≤ ·) s) :
+    Maximal (· ∈ s) a ↔ IsGreatest s a :=
+  minimal_iff_isLeast (α := αᵒᵈ) h
+
+end Minimal
+
+theorem minimal_iff_isLeast [LinearOrder α] {s : Set α} {a : α} :
+    Minimal (· ∈ s) a ↔ IsLeast s a :=
+  (Std.Total.directedOn s).minimal_iff_isLeast
+
+theorem maximal_iff_isGreatest [LinearOrder α] {s : Set α} {a : α} :
+    Maximal (· ∈ s) a ↔ IsGreatest s a :=
+  (Std.Total.directedOn s).maximal_iff_isGreatest
+
 /-!
 ### (In)equalities with the least upper bound and the greatest lower bound
 -/

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -129,6 +129,9 @@ theorem directedOn_of_inf_mem [SemilatticeInf α] {S : Set α}
 theorem Std.Total.directed [Std.Total r] (f : ι → α) : Directed r f := fun i j =>
   Or.casesOn (total_of r (f i) (f j)) (fun h => ⟨j, h, refl _⟩) fun h => ⟨i, refl _, h⟩
 
+theorem Std.Total.directedOn [Std.Total r] (s : Set α) : DirectedOn r s := fun a ha b hb =>
+  Or.casesOn (total_of r a b) (fun h => ⟨b, hb, h, refl _⟩) fun h => ⟨a, ha, refl _, h⟩
+
 /-- `IsDirected α r` states that for any elements `a`, `b` there exists an element `c` such that
 `r a c` and `r b c`. -/
 class IsDirected (α : Type*) (r : α → α → Prop) : Prop where

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -314,6 +314,34 @@ theorem maximal_iff_maximal_of_imp_of_forall (hPQ : ∀ ⦃x⦄, Q x → P x)
 
 end PartialOrder
 
+section LinearOrder
+/- The following set of theorems only require `≤` to be a total order. However, `LinearOrder` is the
+minimal structure that satisfies this requirement as of now.-/
+
+variable [LinearOrder α]
+
+variable {i j : ι} {Q : ι → Prop} {f : ι → α}
+
+theorem Minimal.le (h : Minimal P x) (hy : P y) : x ≤ y :=
+  (le_total x y).elim id (h.2 hy)
+
+theorem Maximal.le (h : Maximal P x) (hy : P y) : y ≤ x :=
+  (le_total y x).elim id (h.2 hy)
+
+theorem MinimalFor.le (h : MinimalFor Q f i) (hj : Q j) : f i ≤ f j :=
+  (le_total (f i) (f j)).elim id (h.2 hj)
+
+theorem MaximalFor.le (h : MaximalFor Q f i) (hj : Q j) : f j ≤ f i :=
+  (le_total (f j) (f i)).elim id (h.2 hj)
+
+theorem minimal_iff_isLeast : Minimal P x ↔ IsLeast {x | P x} x :=
+  ⟨fun h ↦ ⟨h.1, fun _ hy ↦ h.le hy⟩, fun h ↦ ⟨h.1, fun _ hy _ ↦ h.2 hy⟩⟩
+
+theorem maximal_iff_isGreatest : Maximal P x ↔ IsGreatest {x | P x} x :=
+  minimal_iff_isLeast (α := αᵒᵈ)
+
+end LinearOrder
+
 section Subset
 
 variable {P : Set α → Prop} {s t : Set α}

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -316,7 +316,7 @@ end PartialOrder
 
 section LinearOrder
 /- The following set of theorems only require `≤` to be a total order. However, `LinearOrder` is the
-minimal structure that satisfies this requirement as of now.-/
+minimal structure that satisfies this requirement as of now. -/
 
 variable [LinearOrder α]
 

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -334,12 +334,6 @@ theorem MinimalFor.le (h : MinimalFor Q f i) (hj : Q j) : f i ≤ f j :=
 theorem MaximalFor.le (h : MaximalFor Q f i) (hj : Q j) : f j ≤ f i :=
   (le_total (f j) (f i)).elim id (h.2 hj)
 
-theorem minimal_iff_isLeast : Minimal P x ↔ IsLeast {x | P x} x :=
-  ⟨fun h ↦ ⟨h.1, fun _ hy ↦ h.le hy⟩, fun h ↦ ⟨h.1, fun _ hy _ ↦ h.2 hy⟩⟩
-
-theorem maximal_iff_isGreatest : Maximal P x ↔ IsGreatest {x | P x} x :=
-  minimal_iff_isLeast (α := αᵒᵈ)
-
 end LinearOrder
 
 section Subset

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -180,7 +180,7 @@ end LE
 
 section Preorder
 
-variable [Preorder α]
+variable [Preorder α] {Q : ι → Prop} {f : ι → α} {i j : ι}
 
 theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → ¬ P y := by
   simp [Minimal, lt_iff_le_not_ge, imp.swap]
@@ -188,17 +188,35 @@ theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → �
 theorem maximal_iff_forall_gt : Maximal P x ↔ P x ∧ ∀ ⦃y⦄, x < y → ¬ P y :=
   minimal_iff_forall_lt (α := αᵒᵈ)
 
+theorem minimalFor_iff_forall_lt : MinimalFor Q f i ↔ Q i ∧ ∀ ⦃j⦄, f j < f i → ¬ Q j := by
+  simp [MinimalFor, lt_iff_le_not_ge, imp.swap]
+
+theorem maximalFor_iff_forall_gt : MaximalFor Q f i ↔ Q i ∧ ∀ ⦃j⦄, f i < f j → ¬ Q j :=
+  minimalFor_iff_forall_lt (α := αᵒᵈ)
+
 theorem Minimal.not_prop_of_lt (h : Minimal P x) (hlt : y < x) : ¬ P y :=
   (minimal_iff_forall_lt.1 h).2 hlt
 
 theorem Maximal.not_prop_of_gt (h : Maximal P x) (hlt : x < y) : ¬ P y :=
   (maximal_iff_forall_gt.1 h).2 hlt
 
+theorem MinimalFor.not_prop_of_lt (h : MinimalFor Q f i) (hlt : f j < f i) : ¬ Q j :=
+  (minimalFor_iff_forall_lt.1 h).2 hlt
+
+theorem MaximalFor.not_prop_of_gt (h : MaximalFor Q f i) (hgt : f i < f j) : ¬ Q j :=
+  (maximalFor_iff_forall_gt.1 h).2 hgt
+
 theorem Minimal.not_lt (h : Minimal P x) (hy : P y) : ¬(y < x) :=
   fun hlt ↦ h.not_prop_of_lt hlt hy
 
 theorem Maximal.not_gt (h : Maximal P x) (hy : P y) : ¬(x < y) :=
   fun hlt ↦ h.not_prop_of_gt hlt hy
+
+theorem MinimalFor.not_lt (h : MinimalFor Q f i) (hj : Q j) : ¬(f j < f i) :=
+  fun hlt ↦ h.not_prop_of_lt hlt hj
+
+theorem MaximalFor.not_gt (h : MaximalFor Q f i) (hj : Q j) : ¬(f i < f j) :=
+  fun hgt ↦ h.not_prop_of_gt hgt hj
 
 @[simp] theorem minimal_le_iff : Minimal (· ≤ y) x ↔ x ≤ y ∧ IsMin x :=
   minimal_iff_isMin (fun _ _ h h' ↦ h'.trans h)
@@ -323,16 +341,16 @@ variable [LinearOrder α]
 variable {i j : ι} {Q : ι → Prop} {f : ι → α}
 
 theorem Minimal.le (h : Minimal P x) (hy : P y) : x ≤ y :=
-  (le_total x y).elim id (h.2 hy)
+  le_of_not_gt (h.not_lt hy)
 
 theorem Maximal.le (h : Maximal P x) (hy : P y) : y ≤ x :=
-  (le_total y x).elim id (h.2 hy)
+  le_of_not_gt (h.not_gt hy)
 
 theorem MinimalFor.le (h : MinimalFor Q f i) (hj : Q j) : f i ≤ f j :=
-  (le_total (f i) (f j)).elim id (h.2 hj)
+  le_of_not_gt (h.not_lt hj)
 
 theorem MaximalFor.le (h : MaximalFor Q f i) (hj : Q j) : f j ≤ f i :=
-  (le_total (f j) (f i)).elim id (h.2 hj)
+  le_of_not_gt (h.not_gt hj)
 
 end LinearOrder
 

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -333,12 +333,8 @@ theorem maximal_iff_maximal_of_imp_of_forall (hPQ : ∀ ⦃x⦄, Q x → P x)
 end PartialOrder
 
 section LinearOrder
-/- The following set of theorems only require `≤` to be a total order. However, `LinearOrder` is the
-minimal structure that satisfies this requirement as of now. -/
 
-variable [LinearOrder α]
-
-variable {i j : ι} {Q : ι → Prop} {f : ι → α}
+variable [LinearOrder α] {i j : ι} {Q : ι → Prop} {f : ι → α}
 
 theorem Minimal.le (h : Minimal P x) (hy : P y) : x ≤ y :=
   le_of_not_gt (h.not_lt hy)


### PR DESCRIPTION
If a set is `DirectedOn`, then `Minimal`(and `Maximal`) is equivalent to `IsLeast`(and `IsGreatest`).

If the type has a total order, every set is `DirectedOn` and therefore the proof of `DirectedOn` is not needed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
