### PR TITLE
feat(Algebra/Order/Ring): add constructors for linear ordered rings

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -159,6 +159,26 @@ lemma IsStrictOrderedRing.of_mul_pos [Ring R] [PartialOrder R] [IsOrderedAddMono
   mul_lt_mul_of_pos_right a ha b c hbc := by
     simpa only [sub_mul, sub_pos] using mul_pos _ _ (sub_pos.2 hbc) ha
 
+lemma IsOrderedRing.of_mul_nonneg_linearOrder [Ring R] [LinearOrder R] [IsOrderedAddMonoid R]
+    (mul_nonneg : ∀ a b : R, 0 ≤ a → 0 ≤ b → 0 ≤ a * b) : IsOrderedRing R :=
+  have : ZeroLEOneClass R := {
+    zero_le_one := by
+      rcases le_total (0 : R) 1 with h | h
+      · exact h
+      · rw [← mul_one 1, ← neg_mul_neg]
+        exact mul_nonneg _ _ (neg_nonneg.mpr h) (neg_nonneg.mpr h) }
+  IsOrderedRing.of_mul_nonneg mul_nonneg
+
+lemma IsStrictOrderedRing.of_mul_pos_linearOrder [Ring R] [LinearOrder R] [IsOrderedAddMonoid R]
+    [Nontrivial R] (mul_pos : ∀ a b : R, 0 < a → 0 < b → 0 < a * b) : IsStrictOrderedRing R :=
+  have : ZeroLEOneClass R := {
+    zero_le_one := by
+      rcases le_or_gt (0 : R) 1 with h | h
+      · exact h
+      · rw [← mul_one 1, ← neg_mul_neg]
+        exact le_of_lt <| mul_pos _ _ (neg_pos.mpr h) (neg_pos.mpr h) }
+  IsStrictOrderedRing.of_mul_pos mul_pos
+
 -- see Note [lower instance priority]
 /-- Turn an ordered domain into a strict ordered ring. -/
 instance (priority := 50) IsOrderedRing.toIsStrictOrderedRing (R : Type*)

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -159,24 +159,30 @@ lemma IsStrictOrderedRing.of_mul_pos [Ring R] [PartialOrder R] [IsOrderedAddMono
   mul_lt_mul_of_pos_right a ha b c hbc := by
     simpa only [sub_mul, sub_pos] using mul_pos _ _ (sub_pos.2 hbc) ha
 
-lemma IsOrderedRing.of_mul_nonneg_linearOrder [Ring R] [LinearOrder R] [IsOrderedAddMonoid R]
-    (mul_nonneg : ∀ a b : R, 0 ≤ a → 0 ≤ b → 0 ≤ a * b) : IsOrderedRing R :=
+lemma IsOrderedRing.of_mul_nonneg_linearOrder [Ring R] [LinearOrder R] [AddLeftMono R]
+    (mul_nonneg : ∀ a b : R, 0 ≤ a → 0 ≤ b → 0 ≤ a * b) :
+    IsOrderedRing R :=
   have : ZeroLEOneClass R := {
     zero_le_one := by
       rcases le_total (0 : R) 1 with h | h
       · exact h
       · rw [← mul_one 1, ← neg_mul_neg]
         exact mul_nonneg _ _ (neg_nonneg.mpr h) (neg_nonneg.mpr h) }
+  have : IsOrderedAddMonoid R := {
+    add_le_add_left _ _ h c := add_le_add_left h c }
   IsOrderedRing.of_mul_nonneg mul_nonneg
 
-lemma IsStrictOrderedRing.of_mul_pos_linearOrder [Ring R] [LinearOrder R] [IsOrderedAddMonoid R]
-    [Nontrivial R] (mul_pos : ∀ a b : R, 0 < a → 0 < b → 0 < a * b) : IsStrictOrderedRing R :=
+lemma IsStrictOrderedRing.of_mul_pos_linearOrder [Ring R] [LinearOrder R] [AddLeftMono R]
+    [Nontrivial R] (mul_pos : ∀ a b : R, 0 < a → 0 < b → 0 < a * b) :
+    IsStrictOrderedRing R :=
   have : ZeroLEOneClass R := {
     zero_le_one := by
       rcases le_or_gt (0 : R) 1 with h | h
       · exact h
       · rw [← mul_one 1, ← neg_mul_neg]
         exact le_of_lt <| mul_pos _ _ (neg_pos.mpr h) (neg_pos.mpr h) }
+  have : IsOrderedAddMonoid R := {
+    add_le_add_left _ _ h c := add_le_add_left h c }
   IsStrictOrderedRing.of_mul_pos mul_pos
 
 -- see Note [lower instance priority]

--- a/Mathlib/RingTheory/HahnSeries/Lex.lean
+++ b/Mathlib/RingTheory/HahnSeries/Lex.lean
@@ -359,20 +359,11 @@ section OrderedRing
 variable [LinearOrder R] [Ring R] [AddCommMonoid Γ] [LinearOrder Γ]
   [IsOrderedCancelAddMonoid Γ]
 
-instance [IsOrderedRing R] [NoZeroDivisors R] : IsOrderedRing (Lex R⟦Γ⟧) where
-  zero_le_one := by simp [← leadingCoeff_nonneg_iff]
-  mul_le_mul_of_nonneg_left a ha b c hbc := by
-    rw [← sub_nonneg] at hbc ⊢
-    rw [← mul_sub, ← leadingCoeff_nonneg_iff, ofLex_mul, leadingCoeff_mul]
-    apply mul_nonneg
-    · simpa
-    · rwa [leadingCoeff_nonneg_iff]
-  mul_le_mul_of_nonneg_right a ha b c hbc := by
-    rw [← sub_nonneg] at hbc ⊢
-    rw [← sub_mul, ← leadingCoeff_nonneg_iff, ofLex_mul, leadingCoeff_mul]
-    apply mul_nonneg
-    · rwa [leadingCoeff_nonneg_iff]
-    · simpa
+instance [IsOrderedRing R] [NoZeroDivisors R] : IsOrderedRing (Lex R⟦Γ⟧) := by
+  apply IsOrderedRing.of_mul_nonneg_linearOrder
+  intro a b ha hb
+  rw [← leadingCoeff_nonneg_iff, ofLex_mul, leadingCoeff_mul]
+  exact mul_nonneg (leadingCoeff_nonneg_iff.mpr ha) (leadingCoeff_nonneg_iff.mpr hb)
 
 instance [IsDomain R] [IsStrictOrderedRing R] : IsStrictOrderedRing (Lex R⟦Γ⟧) where
 


### PR DESCRIPTION
Add constructors for ordered rings from `mul_nonneg` / `mul_pos` that derive `ZeroLEOneClass` from a linear order.