### PR TITLE
[Merged by Bors] - fix: prevent duplicate Zulip posts in nightly failure workflow

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -112,12 +112,18 @@ jobs:
         import zulip
         client = zulip.Client(email=os.getenv('ZULIP_EMAIL'), api_key=os.getenv('ZULIP_API_KEY'), site=os.getenv('ZULIP_SITE'))
 
-        # Get the last message in the 'status updates' topic
+        # Get the last message from the bot in the 'status updates' topic.
+        # We narrow by sender to ignore human replies in between.
+        bot_email = 'github-mathlib4-bot@leanprover.zulipchat.com'
         request = {
           'anchor': 'newest',
           'num_before': 1,
           'num_after': 0,
-          'narrow': [{'operator': 'stream', 'operand': 'nightly-testing'}, {'operator': 'topic', 'operand': 'Mathlib status updates'}],
+          'narrow': [
+            {'operator': 'stream', 'operand': 'nightly-testing'},
+            {'operator': 'topic', 'operand': 'Mathlib status updates'},
+            {'operator': 'sender', 'operand': bot_email}
+          ],
           'apply_markdown': False    # Otherwise the content test below fails.
         }
         response = client.get_messages(request)
@@ -355,20 +361,23 @@ jobs:
         print(f'Current version: {current_version}, Bump version: {bump_version}, SHA: {sha}')
         if current_version > bump_version:
             print('Lean toolchain in `nightly-testing` is ahead of the bump branch.')
-            # Get recent messages in the 'Mathlib bump branch reminders' topic
-            # We fetch multiple messages to find the last bot message, ignoring human replies.
+            # Get the last message from the bot in the 'Mathlib bump branch reminders' topic.
+            # We narrow by sender to ignore human replies in between.
+            bot_email = 'github-mathlib4-bot@leanprover.zulipchat.com'
             request = {
               'anchor': 'newest',
-              'num_before': 20,
+              'num_before': 1,
               'num_after': 0,
-              'narrow': [{'operator': 'stream', 'operand': 'nightly-testing'}, {'operator': 'topic', 'operand': 'Mathlib bump branch reminders'}],
+              'narrow': [
+                {'operator': 'stream', 'operand': 'nightly-testing'},
+                {'operator': 'topic', 'operand': 'Mathlib bump branch reminders'},
+                {'operator': 'sender', 'operand': bot_email}
+              ],
               'apply_markdown': False    # Otherwise the content test below fails.
             }
             response = client.get_messages(request)
             messages = response['messages']
-            # Find the last message from the bot (ignoring human messages in between)
-            bot_email = 'github-mathlib4-bot@leanprover.zulipchat.com'
-            last_bot_message = next((m for m in messages if m['sender_email'] == bot_email), None)
+            last_bot_message = messages[0] if messages else None
             bump_branch_suffix = bump_branch.replace('bump/', '')
             failed_link = f"https://github.com/{repository}/actions/runs/{current_run_id}"
             payload = f"🛠️: Automatic PR creation [failed]({failed_link}). Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -343,6 +343,7 @@ jobs:
       shell: python
       run: |
         import os
+        import re
         import zulip
         client = zulip.Client(config_file="~/.zuliprc")
         current_version = os.getenv('NIGHTLY')
@@ -369,17 +370,27 @@ jobs:
             payload = f"🛠️: Automatic PR creation [failed]({failed_link}). Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
             payload += "To do so semi-automatically, run the following script from mathlib root:\n\n"
             payload += f"```bash\n./scripts/create-adaptation-pr.sh --bumpversion={bump_branch_suffix} --nightlydate={current_version} --nightlysha={sha}\n```\n"
-            # Only post if the message is different
-            # We compare the first 160 characters, since that includes the date and bump version
-            if not messages or messages[0]['content'][:160] != payload[:160]:
-                # Log messages, because the bot seems to repeat itself...
+            # Check if we already posted a message for this nightly date and bump branch.
+            # We extract these fields from the last message rather than comparing substrings,
+            # since the message also contains a run ID that differs between workflow runs.
+            should_post = True
+            if messages:
+                last_content = messages[0]['content']
+                # Extract nightly date and bump branch from last message
+                date_match = re.search(r'bump/nightly-(\d{4}-\d{2}-\d{2})', last_content)
+                branch_match = re.search(r'PR that to (bump/v[\d.]+)', last_content)
+                if date_match and branch_match:
+                    last_date = date_match.group(1)
+                    last_branch = branch_match.group(1)
+                    if last_date == current_version and last_branch == bump_branch:
+                        should_post = False
+                        print(f'Already posted for nightly {current_version} and {bump_branch}')
+            if should_post:
                 if messages:
                     print("###### Last message:")
                     print(messages[0]['content'])
                     print("###### Current message:")
                     print(payload)
-                else:
-                    print('The strings match!')
                 # Post the reminder message
                 request = {
                     'type': 'stream',

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -355,28 +355,32 @@ jobs:
         print(f'Current version: {current_version}, Bump version: {bump_version}, SHA: {sha}')
         if current_version > bump_version:
             print('Lean toolchain in `nightly-testing` is ahead of the bump branch.')
-            # Get the last message in the 'Mathlib bump branch reminders' topic
+            # Get recent messages in the 'Mathlib bump branch reminders' topic
+            # We fetch multiple messages to find the last bot message, ignoring human replies.
             request = {
               'anchor': 'newest',
-              'num_before': 1,
+              'num_before': 20,
               'num_after': 0,
               'narrow': [{'operator': 'stream', 'operand': 'nightly-testing'}, {'operator': 'topic', 'operand': 'Mathlib bump branch reminders'}],
               'apply_markdown': False    # Otherwise the content test below fails.
             }
             response = client.get_messages(request)
             messages = response['messages']
+            # Find the last message from the bot (ignoring human messages in between)
+            bot_email = 'github-mathlib4-bot@leanprover.zulipchat.com'
+            last_bot_message = next((m for m in messages if m['sender_email'] == bot_email), None)
             bump_branch_suffix = bump_branch.replace('bump/', '')
             failed_link = f"https://github.com/{repository}/actions/runs/{current_run_id}"
             payload = f"🛠️: Automatic PR creation [failed]({failed_link}). Please create a new bump/nightly-{current_version} branch from nightly-testing (specifically {sha}), and then PR that to {bump_branch}. "
             payload += "To do so semi-automatically, run the following script from mathlib root:\n\n"
             payload += f"```bash\n./scripts/create-adaptation-pr.sh --bumpversion={bump_branch_suffix} --nightlydate={current_version} --nightlysha={sha}\n```\n"
             # Check if we already posted a message for this nightly date and bump branch.
-            # We extract these fields from the last message rather than comparing substrings,
+            # We extract these fields from the last bot message rather than comparing substrings,
             # since the message also contains a run ID that differs between workflow runs.
             should_post = True
-            if messages:
-                last_content = messages[0]['content']
-                # Extract nightly date and bump branch from last message
+            if last_bot_message:
+                last_content = last_bot_message['content']
+                # Extract nightly date and bump branch from last bot message
                 date_match = re.search(r'bump/nightly-(\d{4}-\d{2}-\d{2})', last_content)
                 branch_match = re.search(r'PR that to (bump/v[\d.]+)', last_content)
                 if date_match and branch_match:
@@ -386,9 +390,9 @@ jobs:
                         should_post = False
                         print(f'Already posted for nightly {current_version} and {bump_branch}')
             if should_post:
-                if messages:
-                    print("###### Last message:")
-                    print(messages[0]['content'])
+                if last_bot_message:
+                    print("###### Last bot message:")
+                    print(last_bot_message['content'])
                     print("###### Current message:")
                     print(payload)
                 # Post the reminder message


### PR DESCRIPTION
This PR fixes a bug in the `nightly_detect_failure.yml` workflow where duplicate messages were being posted to Zulip for the same nightly date.

The deduplication logic compared the first 160 characters of the message, but the GitHub Actions run ID appears within those characters. Different workflow runs have different IDs, so the comparison always failed and duplicates were posted.

Now we extract and compare the nightly date and bump branch explicitly using regex, which correctly identifies duplicate messages.

**Update:** Also now fetches the last 20 messages and looks for the most recent one from the bot, ignoring human replies in between. This handles the case where someone replies to a bot message before the next workflow run.

See https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Cslib.20bump.20branch.20reminders/near/569853848 for context.
Suggested improvement by Chris Henson: https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Cslib.20bump.20branch.20reminders/near/569945200

🤖 Prepared with Claude Code