### PR TITLE
[Merged by Bors] - feat: Finsupp.linearEquivFunOnFinite_symm_apply

### DIFF
--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -209,7 +209,6 @@ lemma exists_finsetSum_norm_rpow_le_tsum :
     simp only [Submodule.norm_coe]
     convert sum_piFinset_Icc_rpow_le b rfl n r hr with x
     simp [e, Finsupp.linearCombination]
-    rfl
   by_cases hA' : A ≤ 1
   · refine ⟨B, hB, fun r hr s ↦ (H r hr s).trans ?_⟩
     rw [mul_assoc]

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -157,7 +157,6 @@ def latticeEquivProd : L.lattice ≃ₗ[ℤ] ℤ × ℤ :=
 lemma latticeEquiv_symm_apply (x : ℤ × ℤ) :
     (L.latticeEquivProd.symm x).1 = x.1 * L.ω₁ + x.2 * L.ω₂ := by
   simp [latticeEquivProd, Finsupp.linearCombination]
-  rfl
 
 lemma hasSumLocallyUniformly_aux (f : L.lattice → ℂ → ℂ)
     (u : ℝ → L.lattice → ℝ) (hu : ∀ r > 0, Summable (u r))

--- a/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -78,6 +78,11 @@ theorem linearEquivFunOnFinite_symm_single [DecidableEq α] (x : α) (m : M) :
 theorem linearEquivFunOnFinite_symm_coe (f : α →₀ M) : (linearEquivFunOnFinite R M α).symm f = f :=
   (linearEquivFunOnFinite R M α).symm_apply_apply f
 
+@[simp]
+theorem linearEquivFunOnFinite_symm_apply (f : α → M) (x) :
+    (linearEquivFunOnFinite R M α).symm f x = f x :=
+  rfl
+
 end LinearEquivFunOnFinite
 
 /-- Interpret `Finsupp.single a` as a linear map. -/

--- a/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -79,8 +79,7 @@ theorem linearEquivFunOnFinite_symm_coe (f : α →₀ M) : (linearEquivFunOnFin
   (linearEquivFunOnFinite R M α).symm_apply_apply f
 
 @[simp]
-theorem linearEquivFunOnFinite_symm_apply (f : α → M) (x) :
-    (linearEquivFunOnFinite R M α).symm f x = f x :=
+theorem linearEquivFunOnFinite_symm_apply (f : α → M) : (linearEquivFunOnFinite R M α).symm f = f :=
   rfl
 
 end LinearEquivFunOnFinite


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
