### PR TITLE
[Merged by Bors] - feat: more basic API on vector measures

### DIFF
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -49,9 +49,9 @@ vector measure, signed measure, complex measure
 
 noncomputable section
 
-open NNReal ENNReal
+open NNReal ENNReal Filter
 
-open scoped Function -- required for scoped `on` notation
+open scoped Topology Function -- required for scoped `on` notation
 namespace MeasureTheory
 
 variable {α β : Type*} {m : MeasurableSpace α}
@@ -154,6 +154,11 @@ theorem of_diff {M : Type*} [AddCommGroup M] [TopologicalSpace M] [T2Space M]
     (h : A ⊆ B) : v (B \ A) = v B - v A := by
   rw [← of_add_of_diff hA hB h, add_sub_cancel_left]
 
+theorem of_compl {M : Type*} [AddCommGroup M] [TopologicalSpace M] [T2Space M]
+    {v : VectorMeasure α M} {A : Set α} (hA : MeasurableSet A) :
+    v Aᶜ = v univ - v A := by
+  simpa [compl_eq_univ_diff] using of_diff hA .univ (v := v) (subset_univ _)
+
 theorem of_diff_of_diff_eq_zero {A B : Set α} (hA : MeasurableSet A) (hB : MeasurableSet B)
     (h' : v (B \ A) = 0) : v (A \ B) + v B = v A := by
   symm
@@ -195,6 +200,50 @@ theorem of_nonpos_disjoint_union_eq_zero {s : SignedMeasure α} {A B : Set α} (
     (hAB : s (A ∪ B) = 0) : s A = 0 := by
   rw [of_union h hA₁ hB₁] at hAB
   linarith
+
+lemma of_biUnion_finset {ι : Type*} {s : Finset ι} {f : ι → Set α} (hd : PairwiseDisjoint (↑s) f)
+    (hm : ∀ b ∈ s, MeasurableSet (f b)) : v (⋃ b ∈ s, f b) = ∑ p ∈ s, v (f p) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s has ih =>
+    simp only [Finset.mem_insert, iUnion_iUnion_eq_or_left, has, not_false_eq_true,
+      Finset.sum_insert]
+    rw [of_union, ih]
+    · exact hd.subset (by simp)
+    · grind
+    · simp only [disjoint_iUnion_right]
+      exact fun i hi ↦  hd (by simp) (by simp [hi]) (by grind)
+    · apply hm _ (by simp)
+    · apply Finset.measurableSet_biUnion _ (by grind)
+
+theorem tendsto_vectorMeasure_iUnion_atTop_nat
+    {s : ℕ → Set α} (hm : Monotone s) (hs : ∀ i, MeasurableSet (s i)) :
+    Tendsto (fun n ↦ v (s n)) atTop (𝓝 (v (⋃ n, s n))) := by
+  set t : ℕ → Set α := disjointed s
+  have ht n : MeasurableSet (t n) := .disjointed (fun n ↦ hs n) n
+  have : HasSum (fun n ↦ v (t n)) (v (⋃ n, s n)) := by
+    rw [← iUnion_disjointed]
+    apply m_iUnion _ ht (disjoint_disjointed _)
+  convert (HasSum.tendsto_sum_nat this).comp (tendsto_add_atTop_nat 1) with n
+  dsimp
+  rw [← of_biUnion_finset]
+  · rw [biUnion_range_succ_disjointed, Monotone.partialSups_eq hm]
+  · exact fun i hi j hj hij ↦ disjoint_disjointed _ hij
+  · exact fun b hb ↦ ht _
+
+theorem tendsto_vectorMeasure_iInter_atTop_nat
+    {M : Type*} [AddCommGroup M] [TopologicalSpace M] [T2Space M] [ContinuousSub M]
+    {v : VectorMeasure α M} {s : ℕ → Set α} (hm : Antitone s) (hs : ∀ i, MeasurableSet (s i)) :
+    Tendsto (fun n ↦ v (s n)) atTop (𝓝 (v (⋂ n, s n))) := by
+  have I n : v (s n) = v univ - v (s n)ᶜ := by simp [of_compl (hs n)]
+  have J : v (⋂ n, s n) = v univ - v (⋃ n, (s n)ᶜ) := by
+    rw [← of_compl (MeasurableSet.iUnion (fun n ↦ (hs n).compl))]
+    simp
+  simp_rw [I, J]
+  apply tendsto_const_nhds.sub
+  exact tendsto_vectorMeasure_iUnion_atTop_nat (fun i j hij ↦ by simpa using hm hij)
+    (fun i ↦ (hs i).compl)
 
 end
 
@@ -324,6 +373,40 @@ instance instModule [ContinuousAdd M] : Module R (VectorMeasure α M) :=
   Function.Injective.module R coeFnAddMonoidHom coe_injective coe_smul
 
 end Module
+
+section Dirac
+
+variable {M : Type*} [AddCommMonoid M] [TopologicalSpace M] [MeasurableSpace β]
+  {x : β} {v : M} {s : Set β}
+
+open scoped Classical in
+/-- The Dirac vector measure with mass `v` at a point `x`. It gives mass `v` to measurable sets
+containing `x`, and `0` otherwise. -/
+def dirac (x : β) (v : M) : VectorMeasure β M where
+  measureOf' s := if MeasurableSet s ∧ x ∈ s then v else 0
+  empty' := by simp
+  not_measurable' := by simp +contextual
+  m_iUnion' f f_meas f_disj := by
+    by_cases hx : x ∈ ⋃ i, f i; swap
+    · simp only [mem_iUnion, not_exists] at hx
+      simp [hx, hasSum_zero]
+    have : MeasurableSet (⋃ i, f i) := by
+      apply MeasurableSet.iUnion f_meas
+    simp only [f_meas, true_and, MeasurableSet.iUnion f_meas, hx, and_self, ↓reduceIte]
+    obtain ⟨j, hj⟩ : ∃ j, x ∈ f j := by simpa using hx
+    nth_rewrite 2 [show v = if x ∈ f j then v else 0 by simp [hj]]
+    apply hasSum_single
+    intro i hi
+    have : Disjoint (f i) (f j) := f_disj hi
+    grind
+
+@[simp] lemma dirac_apply_of_mem (hs : MeasurableSet s) (hx : x ∈ s) : dirac x v s = v := by
+  simp [dirac, hs, hx]
+
+@[simp] lemma dirac_apply_of_notMem (hx : x ∉ s) : dirac x v s = 0 := by
+  simp [dirac, hx]
+
+end Dirac
 
 end VectorMeasure
 


### PR DESCRIPTION
Cherry picked from #34055.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
