### PR TITLE
[Merged by Bors] - chore: golf using `grind`

### DIFF
--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -632,10 +632,8 @@ def sModNat (q : ℕ) : ℕ → ℕ
   | i + 1 => (sModNat q i ^ 2 + (q - 2)) % q
 
 theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : ℤ) = sMod p k := by
-  have h1 := calc
-    4 = 2 ^ 2 := by simp
-    _ ≤ 2 ^ p := Nat.pow_le_pow_right (by simp) hp
-  induction k with grind [sModNat, sMod, Int.add_emod, Int.emod_eq_add_self_emod]
+  have : 4 ≤ 2 ^ p := by grind [Int.two_pow_pred_sub_two_pow']
+  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod]
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -632,8 +632,7 @@ def sModNat (q : ℕ) : ℕ → ℕ
   | i + 1 => (sModNat q i ^ 2 + (q - 2)) % q
 
 theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : ℤ) = sMod p k := by
-  have : 4 ≤ 2 ^ p := by grind [Int.two_pow_pred_sub_two_pow']
-  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod]
+  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod, Int.two_pow_pred_sub_two_pow']
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -632,7 +632,11 @@ def sModNat (q : ℕ) : ℕ → ℕ
   | i + 1 => (sModNat q i ^ 2 + (q - 2)) % q
 
 theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : ℤ) = sMod p k := by
-  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod]
+  induction k with
+  | zero => grind [sModNat, sMod]
+  | succ =>
+    have : 2 ^ 2 ≤ 2 ^ p := Nat.pow_le_pow_right (by lia) hp
+    grind [sModNat, sMod, Int.emod_eq_add_self_emod]
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -642,14 +642,7 @@ theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : �
     simp [h2]
   | succ k ih =>
     rw [sModNat, sMod, ← ih]
-    have h3 : 2 ≤ 2 ^ p - 1 := by
-      zify [h2]
-      calc (2 : ℤ)
-        _ ≤ 4 - 1 := by simp
-        _ ≤ 2 ^ p - 1 := by zify at h1; exact Int.sub_le_sub_right h1 _
-    zify [h2, h3]
-    rw [← add_sub_assoc, sub_eq_add_neg, add_assoc, add_comm _ (-2), ← add_assoc,
-      Int.add_emod_right, ← sub_eq_add_neg]
+    grind [Int.emod_eq_emod_iff_emod_sub_eq_zero, Int.add_emod, Int.emod_eq_add_self_emod]
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -635,14 +635,7 @@ theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : �
   have h1 := calc
     4 = 2 ^ 2 := by simp
     _ ≤ 2 ^ p := Nat.pow_le_pow_right (by simp) hp
-  have h2 : 1 ≤ 2 ^ p := by lia
-  induction k with
-  | zero =>
-    rw [sModNat, sMod, Int.natCast_emod]
-    simp [h2]
-  | succ k ih =>
-    rw [sModNat, sMod, ← ih]
-    grind [Int.emod_eq_emod_iff_emod_sub_eq_zero, Int.add_emod, Int.emod_eq_add_self_emod]
+  induction k with grind [sModNat, sMod, Int.add_emod, Int.emod_eq_add_self_emod]
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -632,7 +632,7 @@ def sModNat (q : ℕ) : ℕ → ℕ
   | i + 1 => (sModNat q i ^ 2 + (q - 2)) % q
 
 theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : ℤ) = sMod p k := by
-  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod, Int.two_pow_pred_sub_two_pow']
+  induction k with grind [sModNat, sMod, Int.emod_eq_add_self_emod]
 
 /-- Tail-recursive version of `sModNat`. -/
 meta def sModNatTR (q k : ℕ) : ℕ :=


### PR DESCRIPTION
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `LucasLehmer.norm_num_ext.sModNat_eq_sMod`: 950 ms before, 758 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
