### PR TITLE
[Merged by Bors] - feat: open-closed intervals form a semiring of sets

### DIFF
--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -438,13 +438,6 @@ lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
 
 end disjointOfUnion
 
-/-- Finite disjoint unions of elements of a set of sets. -/
-def _root_.Set.finiteUnions (C : Set (Set α)) : Set (Set α) :=
-  {s | ∃ (J : Finset (Set α)), ↑J ⊆ C ∧ (PairwiseDisjoint (J : Set (Set α)) id) ∧ s = ⋃₀ ↑J}
-
-lemma _root_.Set.self_subset_finiteUnions (C : Set (Set α)) : C ⊆ C.finiteUnions :=
-  fun s hs ↦ ⟨{s}, by simp [hs], by simp, by simp⟩
-
 lemma _root_.Set.Ioc_mem_setOf_Ioc_le {α : Type*} [LinearOrder α] (u v : α) :
     Set.Ioc u v ∈ {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} := by
   rcases le_or_gt u v with h | h
@@ -566,58 +559,5 @@ theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i 
   | succ n hn => rw [accumulate_succ]; exact hC.union_mem hn (hs _)
 
 end IsSetRing
-
-lemma IsSetSemiring.diff_mem_finiteUnions
-    (hC : IsSetSemiring C) {s t : Set α} (hs : s ∈ C.finiteUnions) (ht : t ∈ C.finiteUnions) :
-    s \ t ∈ C.finiteUnions := by
-  classical
-  rcases hs with ⟨I, IC, Idisj, rfl⟩
-  rcases ht with ⟨J, JC, Jdisj, rfl⟩
-  have A (i) (hi : i ∈ I) : ∃ J' : Finset (Set α), ↑J' ⊆ C ∧
-      PairwiseDisjoint (J' : Set (Set α)) id ∧ i \ ⋃₀ J = ⋃₀ J' :=
-    hC.exists_disjoint_finset_diff_eq (IC hi) JC
-  choose! J' hJ'C hJ'disj hiJ' using A
-  have H {a i} (hi : i ∈ I) (ha : a ∈ J' i) : a ⊆ i \ ⋃₀ ↑J := by
-    rw [hiJ' i hi]
-    simp only [sUnion_eq_biUnion, SetLike.mem_coe]
-    exact Set.subset_biUnion_of_mem (u := id) ha
-  refine ⟨I.biUnion J', ?_, ?_, ?_⟩
-  · simpa using hJ'C
-  · intro s hs t ht hst
-    simp only [coe_biUnion, SetLike.mem_coe, mem_iUnion, exists_prop] at hs ht
-    rcases hs with ⟨i, iI, hi⟩
-    rcases ht with ⟨j, jI, hj⟩
-    rcases eq_or_ne i j with rfl | hij
-    · exact hJ'disj i iI hi hj hst
-    · exact (Idisj iI jI hij).mono ((H iI hi).trans diff_subset)
-        ((H jI hj).trans diff_subset)
-  · simp only [sUnion_eq_biUnion, SetLike.mem_coe, iUnion_diff, coe_biUnion, mem_iUnion,
-      exists_prop, iUnion_exists, biUnion_and']
-    apply iUnion_congr (fun i ↦ iUnion_congr (fun hi ↦ ?_))
-    simpa [sUnion_eq_biUnion] using hiJ' i hi
-
-/-- Given a semi-ring of sets, finite unions of these form a ring of sets. -/
-lemma IsSetSemiring.isSetRing_finiteUnions (hC : IsSetSemiring C) :
-    IsSetRing C.finiteUnions where
-  empty_mem := ⟨∅, by simp⟩
-  diff_mem s t := hC.diff_mem_finiteUnions
-  union_mem s t hs ht := by
-    classical
-    wlog! H : Disjoint s t generalizing s
-    · rw [← diff_union_self]
-      exact this _ (hC.diff_mem_finiteUnions hs ht) disjoint_sdiff_left
-    rcases hs with ⟨I, IC, Idisj, rfl⟩
-    rcases ht with ⟨J, JC, Jdisj, rfl⟩
-    refine ⟨I ∪ J, by grind, ?_, by grind⟩
-    have K {a b} (ha : a ∈ I) (hb : b ∈ J) : Disjoint a b :=
-      H.mono (subset_sUnion_of_mem ha) (subset_sUnion_of_mem hb)
-    intro i hi j hj hij
-    simp only [Function.onFun, id_eq]
-    simp only [coe_union, Set.mem_union, SetLike.mem_coe] at hi hj
-    rcases hi with hi | hi <;> rcases hj with hj | hj
-    · exact Idisj hi hj hij
-    · exact K hi hj
-    · exact (K hj hi).symm
-    · exact Jdisj hi hj hij
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -438,17 +438,12 @@ lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
 
 end disjointOfUnion
 
-lemma _root_.Set.Ioc_mem_setOf_Ioc_le [LinearOrder α] (u v : α) :
-    Set.Ioc u v ∈ {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} := by
-  rcases le_or_gt u v with h | h
-  · exact ⟨u, v, h, rfl⟩
-  · have : Set.Ioc u v = ∅ := by
-      simpa only [Set.Ioc_eq_empty_iff, not_lt] using h.le
-    rw [this]
-    exact ⟨u, u, le_rfl, by simp⟩
+private lemma _root_.Set.Ioc_mem_setOf_Ioc_le [LinearOrder α] (u v : α) :
+    Set.Ioc u v ∈ {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} :=
+  ⟨u, max u v, by grind, by grind⟩
 
 /-- The set of open-closed intervals is a semi-ring of sets. -/
-protected lemma Ioc {α : Type*} [LinearOrder α] [Nonempty α] :
+protected lemma Ioc [LinearOrder α] [Nonempty α] :
     IsSetSemiring {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} where
   empty_mem := by
     inhabit α

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -438,6 +438,53 @@ lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
 
 end disjointOfUnion
 
+/-- Finite disjoint unions of elements of a set of sets. -/
+def _root_.Set.finiteUnions (C : Set (Set α)) : Set (Set α) :=
+  {s | ∃ (J : Finset (Set α)), ↑J ⊆ C ∧ (PairwiseDisjoint (J : Set (Set α)) id) ∧ s = ⋃₀ ↑J}
+
+lemma _root_.Set.self_subset_finiteUnions (C : Set (Set α)) : C ⊆ C.finiteUnions :=
+  fun s hs ↦ ⟨{s}, by simp [hs], by simp, by simp⟩
+
+lemma _root_.Set.Ioc_mem_setOf_Ioc_le {α : Type*} [LinearOrder α] (u v : α) :
+    Set.Ioc u v ∈ {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} := by
+  rcases le_or_gt u v with h | h
+  · exact ⟨u, v, h, rfl⟩
+  · have : Set.Ioc u v = ∅ := by
+      simpa only [Set.Ioc_eq_empty_iff, not_lt] using h.le
+    rw [this]
+    exact ⟨u, u, le_rfl, by simp⟩
+
+/-- The set of open-closed intervals is a semi-ring of sets. -/
+lemma Ioc {α : Type*} [LinearOrder α] [Nonempty α] :
+    IsSetSemiring {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} where
+  empty_mem := by
+    inhabit α
+    exact ⟨default, default, le_rfl, by simp⟩
+  inter_mem := by
+    rintro s ⟨u, v, huv, rfl⟩ t ⟨u', v', hu'v', rfl⟩
+    rw [Set.Ioc_inter_Ioc]
+    apply Ioc_mem_setOf_Ioc_le
+  diff_eq_sUnion' := by
+    classical
+    rintro s ⟨u, v, huv, rfl⟩ t ⟨u', v', hu'v', rfl⟩
+    rcases le_or_gt u' u with hu | hu
+    · have : Set.Ioc u v \ Set.Ioc u' v' = Set.Ioc (max u v') v := by
+        ext; simp; grind
+      rcases Ioc_mem_setOf_Ioc_le (max u v') v with ⟨u'', v'', h'', heq⟩
+      rw [this, heq]
+      exact ⟨{Set.Ioc u'' v''}, by grind, by simp, by simp⟩
+    rcases le_or_gt v v' with hv | hv
+    · have : Set.Ioc u v \ Set.Ioc u' v' = Set.Ioc u (min u' v) := by
+        ext; simp; grind
+      rcases Ioc_mem_setOf_Ioc_le u (min u' v) with ⟨u'', v'', h'', heq⟩
+      rw [this, heq]
+      exact ⟨{Set.Ioc u'' v''}, by grind, by simp, by simp⟩
+    rw [show Set.Ioc u v \ Set.Ioc u' v' = Set.Ioc u u' ∪ Set.Ioc v' v by ext; simp; grind]
+    refine ⟨{Set.Ioc u u', Set.Ioc v' v}, by grind, ?_, by simp⟩
+    intro a ha b hb hab
+    simp [Function.onFun]
+    grind
+
 end IsSetSemiring
 
 /-- A ring of sets `C` is a family of sets containing `∅`, stable by union and set difference.
@@ -519,5 +566,58 @@ theorem accumulate_mem (hC : IsSetRing C) {s : ℕ → Set α} (hs : ∀ i, s i 
   | succ n hn => rw [accumulate_succ]; exact hC.union_mem hn (hs _)
 
 end IsSetRing
+
+lemma IsSetSemiring.diff_mem_finiteUnions
+    (hC : IsSetSemiring C) {s t : Set α} (hs : s ∈ C.finiteUnions) (ht : t ∈ C.finiteUnions) :
+    s \ t ∈ C.finiteUnions := by
+  classical
+  rcases hs with ⟨I, IC, Idisj, rfl⟩
+  rcases ht with ⟨J, JC, Jdisj, rfl⟩
+  have A (i) (hi : i ∈ I) : ∃ J' : Finset (Set α), ↑J' ⊆ C ∧
+      PairwiseDisjoint (J' : Set (Set α)) id ∧ i \ ⋃₀ J = ⋃₀ J' :=
+    hC.exists_disjoint_finset_diff_eq (IC hi) JC
+  choose! J' hJ'C hJ'disj hiJ' using A
+  have H {a i} (hi : i ∈ I) (ha : a ∈ J' i) : a ⊆ i \ ⋃₀ ↑J := by
+    rw [hiJ' i hi]
+    simp only [sUnion_eq_biUnion, SetLike.mem_coe]
+    exact Set.subset_biUnion_of_mem (u := id) ha
+  refine ⟨I.biUnion J', ?_, ?_, ?_⟩
+  · simpa using hJ'C
+  · intro s hs t ht hst
+    simp only [coe_biUnion, SetLike.mem_coe, mem_iUnion, exists_prop] at hs ht
+    rcases hs with ⟨i, iI, hi⟩
+    rcases ht with ⟨j, jI, hj⟩
+    rcases eq_or_ne i j with rfl | hij
+    · exact hJ'disj i iI hi hj hst
+    · exact (Idisj iI jI hij).mono ((H iI hi).trans diff_subset)
+        ((H jI hj).trans diff_subset)
+  · simp only [sUnion_eq_biUnion, SetLike.mem_coe, iUnion_diff, coe_biUnion, mem_iUnion,
+      exists_prop, iUnion_exists, biUnion_and']
+    apply iUnion_congr (fun i ↦ iUnion_congr (fun hi ↦ ?_))
+    simpa [sUnion_eq_biUnion] using hiJ' i hi
+
+/-- Given a semi-ring of sets, finite unions of these form a ring of sets. -/
+lemma IsSetSemiring.isSetRing_finiteUnions (hC : IsSetSemiring C) :
+    IsSetRing C.finiteUnions where
+  empty_mem := ⟨∅, by simp⟩
+  diff_mem s t := hC.diff_mem_finiteUnions
+  union_mem s t hs ht := by
+    classical
+    wlog! H : Disjoint s t generalizing s
+    · rw [← diff_union_self]
+      exact this _ (hC.diff_mem_finiteUnions hs ht) disjoint_sdiff_left
+    rcases hs with ⟨I, IC, Idisj, rfl⟩
+    rcases ht with ⟨J, JC, Jdisj, rfl⟩
+    refine ⟨I ∪ J, by grind, ?_, by grind⟩
+    have K {a b} (ha : a ∈ I) (hb : b ∈ J) : Disjoint a b :=
+      H.mono (subset_sUnion_of_mem ha) (subset_sUnion_of_mem hb)
+    intro i hi j hj hij
+    simp only [Function.onFun, id_eq]
+    simp only [coe_union, Set.mem_union, SetLike.mem_coe] at hi hj
+    rcases hi with hi | hi <;> rcases hj with hj | hj
+    · exact Idisj hi hj hij
+    · exact K hi hj
+    · exact (K hj hi).symm
+    · exact Jdisj hi hj hij
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -438,7 +438,7 @@ lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
 
 end disjointOfUnion
 
-lemma _root_.Set.Ioc_mem_setOf_Ioc_le {α : Type*} [LinearOrder α] (u v : α) :
+lemma _root_.Set.Ioc_mem_setOf_Ioc_le [LinearOrder α] (u v : α) :
     Set.Ioc u v ∈ {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} := by
   rcases le_or_gt u v with h | h
   · exact ⟨u, v, h, rfl⟩
@@ -448,7 +448,7 @@ lemma _root_.Set.Ioc_mem_setOf_Ioc_le {α : Type*} [LinearOrder α] (u v : α) :
     exact ⟨u, u, le_rfl, by simp⟩
 
 /-- The set of open-closed intervals is a semi-ring of sets. -/
-lemma Ioc {α : Type*} [LinearOrder α] [Nonempty α] :
+protected lemma Ioc {α : Type*} [LinearOrder α] [Nonempty α] :
     IsSetSemiring {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} where
   empty_mem := by
     inhabit α


### PR DESCRIPTION
Needed for #34055.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
