### PR TITLE
feat: `a / b ≤ a * b ↔ 1 ≤ b`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -127,6 +127,12 @@ theorem div_le_mul_self_iff : a / b ≤ a * b ↔ 1 ≤ b := by simp [div_eq_mul
 @[to_additive (attr := simp)]
 theorem div_lt_mul_self_iff : a / b < a * b ↔ 1 < b := by simp [div_eq_mul_inv]
 
+@[to_additive (attr := simp)]
+theorem mul_le_div_self_iff : a * b ≤ a / b ↔ b ≤ 1 := by simp [div_eq_mul_inv, mul_assoc]
+
+@[to_additive (attr := simp)]
+theorem mul_lt_div_self_iff : a * b < a / b ↔ b < 1 := by simp [div_eq_mul_inv, mul_assoc]
+
 end LinearOrderedCommGroup
 
 section NormNumLemmas

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -121,6 +121,12 @@ theorem le_inv_self_iff : a ≤ a⁻¹ ↔ a ≤ 1 := by contrapose!; exact inv_
 @[to_additive (attr := simp)]
 theorem lt_inv_self_iff : a < a⁻¹ ↔ a < 1 := by contrapose!; exact inv_le_self_iff
 
+@[to_additive (attr := simp)]
+theorem div_le_mul_self_iff : x / y ≤ x * y ↔ 1 ≤ y := by simp [div_eq_mul_inv]
+
+@[to_additive (attr := simp)]
+theorem div_lt_mul_self_iff : x / y < x * y ↔ 1 < y := by simp [div_eq_mul_inv]
+
 end LinearOrderedCommGroup
 
 section NormNumLemmas

--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -69,7 +69,7 @@ insert_to_additive_translation LinearOrderedCommGroup LinearOrderedAddCommGroup
 
 section LinearOrderedCommGroup
 
-variable [CommGroup α] [LinearOrder α] [IsOrderedMonoid α] {a : α}
+variable [CommGroup α] [LinearOrder α] [IsOrderedMonoid α] {a b : α}
 
 @[deprecated (since := "2025-10-06")]
 alias LinearOrderedCommGroup.mul_lt_mul_left' := mul_lt_mul_right
@@ -122,10 +122,10 @@ theorem le_inv_self_iff : a ≤ a⁻¹ ↔ a ≤ 1 := by contrapose!; exact inv_
 theorem lt_inv_self_iff : a < a⁻¹ ↔ a < 1 := by contrapose!; exact inv_le_self_iff
 
 @[to_additive (attr := simp)]
-theorem div_le_mul_self_iff : x / y ≤ x * y ↔ 1 ≤ y := by simp [div_eq_mul_inv]
+theorem div_le_mul_self_iff : a / b ≤ a * b ↔ 1 ≤ b := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem div_lt_mul_self_iff : x / y < x * y ↔ 1 < y := by simp [div_eq_mul_inv]
+theorem div_lt_mul_self_iff : a / b < a * b ↔ 1 < b := by simp [div_eq_mul_inv]
 
 end LinearOrderedCommGroup
 


### PR DESCRIPTION
Upstreamed from the CGT repo.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
