### PR TITLE
[Merged by Bors] - chore: remove superfluous 'by fun_prop' parameters

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
+++ b/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
@@ -54,7 +54,6 @@ noncomputable def homeomorphSphereProd (E : Type*) [NormedAddCommGroup E] [Norme
   continuous_toFun := by
     simp only
     fun_prop (disch := simp)
-  continuous_invFun := by fun_prop
 
 /-- The natural homeomorphism between nonzero elements of a normed space `E`
 and `Metric.sphere (0 : E) 1 × Set.Ioi (0 : ℝ)`.

--- a/Mathlib/Dynamics/Flow.lean
+++ b/Mathlib/Dynamics/Flow.lean
@@ -283,8 +283,6 @@ def toHomeomorph (t : τ) : (α ≃ₜ α) where
   invFun := ϕ (-t)
   left_inv x := by rw [← map_add, neg_add_cancel, map_zero_apply]
   right_inv x := by rw [← map_add, add_neg_cancel, map_zero_apply]
-  continuous_toFun := by fun_prop
-  continuous_invFun := by fun_prop
 
 theorem image_eq_preimage_symm (t : τ) (s : Set α) : ϕ t '' s = ϕ (-t) ⁻¹' s :=
   (ϕ.toHomeomorph t).toEquiv.image_eq_preimage_symm s

--- a/Mathlib/Topology/Algebra/Group/AddTorsor.lean
+++ b/Mathlib/Topology/Algebra/Group/AddTorsor.lean
@@ -86,8 +86,6 @@ theorem IsTopologicalAddTorsor.to_isTopologicalAddGroup : IsTopologicalAddGroup 
 @[simps!]
 def Homeomorph.vaddConst (p : P) : V ≃ₜ P where
   __ := Equiv.vaddConst p
-  continuous_toFun := by fun_prop
-  continuous_invFun := by fun_prop
 
 end AddTorsor
 


### PR DESCRIPTION
The continuity proof fields for Homeomorph have auto-para `by fun_prop` now, so these lines are superfluous.
(They were useful before #28926: until then, the parameter was `by continuity`, which could be slower.)


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
