### PR TITLE
[Merged by Bors] - chore: make fun_prop an autoparam for the proof fields in Measurable{Inf,Sup}

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -602,8 +602,6 @@ variable [TopologicalSpace γ] {mγ : MeasurableSpace γ} [BorelSpace γ]
 
 instance (priority := 100) ContinuousSup.measurableSup [Max γ] [ContinuousSup γ] :
     MeasurableSup γ where
-  measurable_const_sup _ := (continuous_const.sup continuous_id).measurable
-  measurable_sup_const _ := (continuous_id.sup continuous_const).measurable
 
 instance (priority := 100) ContinuousSup.measurableSup₂ [SecondCountableTopology γ] [Max γ]
     [ContinuousSup γ] : MeasurableSup₂ γ :=
@@ -611,8 +609,6 @@ instance (priority := 100) ContinuousSup.measurableSup₂ [SecondCountableTopolo
 
 instance (priority := 100) ContinuousInf.measurableInf [Min γ] [ContinuousInf γ] :
     MeasurableInf γ where
-  measurable_const_inf _ := (continuous_const.inf continuous_id).measurable
-  measurable_inf_const _ := (continuous_id.inf continuous_const).measurable
 
 instance (priority := 100) ContinuousInf.measurableInf₂ [SecondCountableTopology γ] [Min γ]
     [ContinuousInf γ] : MeasurableInf₂ γ :=

--- a/Mathlib/MeasureTheory/Order/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Lattice.lean
@@ -37,13 +37,13 @@ open MeasureTheory
 /-- We say that a type has `MeasurableSup` if `(c ⊔ ·)` and `(· ⊔ c)` are measurable functions.
 For a typeclass assuming measurability of `uncurry (· ⊔ ·)` see `MeasurableSup₂`. -/
 class MeasurableSup (M : Type*) [MeasurableSpace M] [Max M] : Prop where
-  measurable_const_sup : ∀ c : M, Measurable (c ⊔ ·)
-  measurable_sup_const : ∀ c : M, Measurable (· ⊔ c)
+  measurable_const_sup : ∀ c : M, Measurable (c ⊔ ·) := by intro c; fun_prop
+  measurable_sup_const : ∀ c : M, Measurable (· ⊔ c) := by intro c; fun_prop
 
 /-- We say that a type has `MeasurableSup₂` if `uncurry (· ⊔ ·)` is a measurable functions.
 For a typeclass assuming measurability of `(c ⊔ ·)` and `(· ⊔ c)` see `MeasurableSup`. -/
 class MeasurableSup₂ (M : Type*) [MeasurableSpace M] [Max M] : Prop where
-  measurable_sup : Measurable fun p : M × M => p.1 ⊔ p.2
+  measurable_sup : Measurable fun p : M × M => p.1 ⊔ p.2 := by intro p; fun_prop
 
 export MeasurableSup₂ (measurable_sup)
 
@@ -52,13 +52,13 @@ export MeasurableSup (measurable_const_sup measurable_sup_const)
 /-- We say that a type has `MeasurableInf` if `(c ⊓ ·)` and `(· ⊓ c)` are measurable functions.
 For a typeclass assuming measurability of `uncurry (· ⊓ ·)` see `MeasurableInf₂`. -/
 class MeasurableInf (M : Type*) [MeasurableSpace M] [Min M] : Prop where
-  measurable_const_inf : ∀ c : M, Measurable (c ⊓ ·)
-  measurable_inf_const : ∀ c : M, Measurable (· ⊓ c)
+  measurable_const_inf : ∀ c : M, Measurable (c ⊓ ·) := by intro c; fun_prop
+  measurable_inf_const : ∀ c : M, Measurable (· ⊓ c) := by intro c; fun_prop
 
 /-- We say that a type has `MeasurableInf₂` if `uncurry (· ⊓ ·)` is a measurable functions.
 For a typeclass assuming measurability of `(c ⊓ ·)` and `(· ⊓ c)` see `MeasurableInf`. -/
 class MeasurableInf₂ (M : Type*) [MeasurableSpace M] [Min M] : Prop where
-  measurable_inf : Measurable fun p : M × M => p.1 ⊓ p.2
+  measurable_inf : Measurable fun p : M × M => p.1 ⊓ p.2 := by intro p; fun_prop
 
 export MeasurableInf₂ (measurable_inf)
 
@@ -138,8 +138,7 @@ theorem AEMeasurable.sup (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun a => f a ⊔ g a) μ :=
   measurable_sup.comp_aemeasurable (hf.prodMk hg)
 
-instance (priority := 100) MeasurableSup₂.toMeasurableSup : MeasurableSup M :=
-  ⟨fun _ => measurable_const.sup measurable_id, fun _ => measurable_id.sup measurable_const⟩
+instance (priority := 100) MeasurableSup₂.toMeasurableSup : MeasurableSup M where
 
 end MeasurableSup₂
 
@@ -195,8 +194,7 @@ theorem AEMeasurable.inf (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun a => f a ⊓ g a) μ :=
   measurable_inf.comp_aemeasurable (hf.prodMk hg)
 
-instance (priority := 100) MeasurableInf₂.to_hasMeasurableInf : MeasurableInf M :=
-  ⟨fun _ => measurable_const.inf measurable_id, fun _ => measurable_id.inf measurable_const⟩
+instance (priority := 100) MeasurableInf₂.to_hasMeasurableInf : MeasurableInf M where
 
 end MeasurableInf₂
 


### PR DESCRIPTION
Requested by `YaelDillies` in #34441.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
