### PR TITLE
[Merged by Bors] - feat: additive content on open-closed intervals, mapping `(u, v]` to `f v - f u`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -54,6 +54,8 @@ If `C` is a set ring (`MeasureTheory.IsSetRing C`), we have
 * `MeasureTheory.isSigmaSubadditive_of_addContent_iUnion_eq_tsum`: if an `AddContent` is
   σ-additive on a set ring, then it is σ-subadditive.
 
+We define a specific example of `AddContent`, called `AddContent.onIoc`, on the semiring of sets
+made of open-closed intervals, mapping `(a, b]` to `f b - f a`.
 -/
 
 @[expose] public section
@@ -267,6 +269,133 @@ theorem addContent_iUnion_eq_tsum_of_disjoint_of_IsSigmaSubadditive {m : AddCont
     (fun _ hf hf_Union _ ↦ m_subadd hf hf_Union) f hf hf_Union hf_disj
 
 end IsSetSemiring
+
+section OnIoc
+
+variable [LinearOrder α] {G : Type*} [AddCommGroup G]
+
+open scoped Classical in
+/-- The function associating to an interval `Ioc u v` the difference `f v - f u`.
+Use instead `AddContent.ofIoc` which upgrades this function to an additive content. -/
+noncomputable def AddContent.onIocAux (f : α → G) (s : Set α) : G :=
+  if h : ∃ (p : α × α), p.1 ≤ p.2 ∧ s = Set.Ioc p.1 p.2
+    then f h.choose.2 - f h.choose.1 else 0
+
+lemma AddContent.onIocAux_apply {f : α → G} {u v : α} (h : u ≤ v) :
+    AddContent.onIocAux f (Ioc u v) = f v - f u := by
+  have h' : ∃ (p : α × α), p.1 ≤ p.2 ∧ Ioc u v = Ioc p.1 p.2 := ⟨(u, v), h, rfl⟩
+  simp only [onIocAux, h', ↓reduceDIte]
+  set u' := h'.choose.1
+  set v' := h'.choose.2
+  have hu'v' : u' ≤ v' ∧ Ioc u v = Ioc u' v' := h'.choose_spec
+  rcases h.eq_or_lt with rfl | huv
+  · simp only [lt_self_iff_false, not_false_eq_true, Set.Ioc_eq_empty] at hu'v'
+    have : ¬ u' < v' := Set.Ioc_eq_empty_iff.1 hu'v'.2.symm
+    have : u' = v' := by order
+    simp [this]
+  have : ¬(Set.Ioc u v = ∅) := by simp [Set.Ioc_eq_empty_iff, huv]
+  rw [hu'v'.2, Set.Ioc_eq_empty_iff, not_not] at this
+  have I1 : v ≤ v' ∧ u' ≤ u := (Ioc_subset_Ioc_iff huv).1 hu'v'.2.subset
+  have I2 : v' ≤ v ∧ u ≤ u' := (Ioc_subset_Ioc_iff this).1 hu'v'.2.symm.subset
+  grind
+
+lemma AddContent.onIocAux_empty (f : α → G) :
+    AddContent.onIocAux f ∅ = 0 := by
+  rcases isEmpty_or_nonempty α with hα | hα
+  · simp [onIocAux]
+  inhabit α
+  have : Ioc (default : α) default = ∅ := by simp
+  rw [← this, AddContent.onIocAux_apply le_rfl]
+  simp
+
+/-- The additive content on the set of open-closed intervals, associating to an interval `Ioc u v`
+the difference `f v - f u`. -/
+noncomputable def AddContent.onIoc (f : α → G) :
+    AddContent G {s : Set α | ∃ u v, u ≤ v ∧ s = Set.Ioc u v} where
+  toFun := AddContent.onIocAux f
+  empty' := AddContent.onIocAux_empty f
+  sUnion' := by
+    classical
+    /- Consider a finite union of open-closed intervals whose union is again an open-closed
+    interval `(u, v]`. We have to show that the sum of `f b - f a` over the intervals gives
+    `f v - f u`. Informally, `(u, v]` is an ordered
+    union `(a₀, a₁] ∪ (a₁, a₂] ∪ ... ∪ (a_{n-1}, aₙ]` and there is a telescoping sum.
+    For the formal argument, we argue by induction on the number of intervals, and remove the
+    right-most one (i.e., the one that contains `v`) to reduce to one interval less. Denoting
+    this right-most interval by `(u', v]`, then the union of the other intervals
+    is exactly `(u, u']`. From this and the induction assumption, the conclusion follows. -/
+    intro I hI h'I h''I
+    induction hn : Finset.card I generalizing I with
+    | zero =>
+      have : I = ∅ := by grind
+      simp [this, AddContent.onIocAux_empty f]
+    | succ n ih =>
+      rcases h''I with ⟨u, v, huv, h'uv⟩
+      -- If the interval `(u, v]` is empty, i.e., `u = v`, then the result is easy.
+      rcases huv.eq_or_lt with rfl | huv
+      · rw [h'uv]
+        simp only [lt_self_iff_false, not_false_eq_true, Set.Ioc_eq_empty, sUnion_eq_empty,
+          SetLike.mem_coe] at h'uv
+        have : onIocAux f (Set.Ioc u u) =  ∑ u ∈ I, 0 := by simp [onIocAux_empty f]
+        rw [this]
+        apply Finset.sum_congr rfl (fun i hi ↦ ?_)
+        simp [h'uv i hi, onIocAux_empty]
+      -- otherwise, `v` is in `(u, v]`, therefore it belongs to some interval `(u', v']`
+      -- featuring in the union.
+      have : v ∈ ⋃₀ ↑I := by simp [h'uv, huv]
+      obtain ⟨t, tI, ht⟩ : ∃ t ∈ I, v ∈ t := by simpa using this
+      rcases hI tI with ⟨u', v', hu'v', rfl⟩
+      -- we have `v' = v` since `(u', v']` is part of the union, and therefore
+      -- contained in `(u, v]`.
+      have : v = v' := by
+        apply le_antisymm ht.2
+        suffices v' ∈ Ioc u v from this.2
+        rw [← h'uv]
+        simp only [mem_sUnion, SetLike.mem_coe]
+        exact ⟨_, tI, ht.1.trans_le ht.2, le_rfl⟩
+      subst this
+      -- also `u ≤ u'` for the same reason.
+      have uu' : u ≤ u' := by
+        by_contra! hu'u
+        have : u ∈ Set.Ioc u v := by
+          simp only [← h'uv, mem_sUnion, SetLike.mem_coe]
+          exact ⟨_, tI, hu'u, huv.le⟩
+        simp at this
+      rw [h'uv, onIocAux_apply huv.le]
+      -- let us remove the right-most interval `(u', v]` from the union, and let `I'` be the
+      -- remaining set of intervals.
+      let I' := I.erase (Set.Ioc u' v)
+      have I'I : I' ⊆ I := erase_subset (Set.Ioc u' v) I
+      have I_eq_insert : I = insert (Set.Ioc u' v) I' := by simp [I', tI]
+      -- the intervals in `I'` cover exactly `(u, u']`.
+      have UI' : ⋃₀ ↑I' = Set.Ioc u u' := by
+        simp only [I_eq_insert, coe_insert, sUnion_insert] at h'uv
+        have : (Set.Ioc u' v ∪ ⋃₀ ↑I') \ Ioc u' v = ⋃₀ ↑I' := by
+          refine union_diff_cancel_left ?_
+          rintro x ⟨hx, h'x⟩
+          obtain ⟨s, sI', hxs⟩ : ∃ s ∈ I', x ∈ s := by simpa using h'x
+          simp only [mem_erase, ne_eq, I'] at sI'
+          have := h'I sI'.2 tI sI'.1
+          grind
+        rw [h'uv] at this
+        rw [← this]
+        grind
+      -- by the inductive assumption, the sum over `I'` is exactly `f u' - f u`.
+      have IH : onIocAux f (⋃₀ ↑I') = ∑ u ∈ I', onIocAux f u := by
+        apply ih _ (Subset.trans I'I hI) (h'I.subset I'I)
+        · exact ⟨u, u', uu', UI'⟩
+        · have := card_erase_add_one tI
+          grind
+      -- the conclusion follows.
+      rw [I_eq_insert, sum_insert, ← IH, UI', onIocAux_apply hu'v', onIocAux_apply uu']
+      · simp
+      · simp [I']
+
+lemma AddContent.onIoc_apply {f : α → G} {u v : α} (h : u ≤ v) :
+    AddContent.onIoc f (Ioc u v) = f v - f u :=
+  AddContent.onIocAux_apply h
+
+end OnIoc
 
 section AddContentExtend
 

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -290,7 +290,7 @@ lemma AddContent.onIocAux_apply {f : α → G} {u v : α} (h : u ≤ v) :
   have hu'v' : u' ≤ v' ∧ Ioc u v = Ioc u' v' := h'.choose_spec
   rcases h.eq_or_lt with rfl | huv
   · grind [Set.Ioc_eq_empty_iff]
-  rw [Set.Ioc_eq_Ioc_iff huv] at hu'v'
+  rw [Ioc_eq_Ioc_iff (Or.inl huv)] at hu'v'
   grind
 
 lemma AddContent.onIocAux_empty (f : α → G) :

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -101,6 +101,14 @@ theorem Ico_subset_Ico_iff (h₁ : a₁ < b₁) : Ico a₁ b₁ ⊆ Ico a₂ b�
 theorem Ioc_subset_Ioc_iff (h₁ : a₁ < b₁) : Ioc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ b₁ ≤ b₂ ∧ a₂ ≤ a₁ := by
   convert @Ico_subset_Ico_iff αᵒᵈ _ b₁ b₂ a₁ a₂ h₁ using 2 <;> exact (@Ico_toDual α _ _ _).symm
 
+theorem Ioc_eq_Ioc_iff {a b c d : α} (hab : a < b ∨ c < d) : Ioc a b = Ioc c d ↔ a = c ∧ b = d := by
+  refine ⟨fun h ↦ ?_, by grind⟩
+  have hab : a < b := by grind [Set.nonempty_Ioc]
+  have hcd : c < d := by grind [Set.nonempty_Ioc]
+  have : b ≤ d ∧ c ≤ a := (Ioc_subset_Ioc_iff hab).1 h.subset
+  have : d ≤ b ∧ a ≤ c := (Ioc_subset_Ioc_iff hcd).1 h.superset
+  grind
+
 theorem Ioo_subset_Ioo_iff [DenselyOrdered α] (h₁ : a₁ < b₁) :
     Ioo a₁ b₁ ⊆ Ioo a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
   ⟨fun h => by

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -101,12 +101,16 @@ theorem Ico_subset_Ico_iff (h₁ : a₁ < b₁) : Ico a₁ b₁ ⊆ Ico a₂ b�
 theorem Ioc_subset_Ioc_iff (h₁ : a₁ < b₁) : Ioc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ b₁ ≤ b₂ ∧ a₂ ≤ a₁ := by
   convert @Ico_subset_Ico_iff αᵒᵈ _ b₁ b₂ a₁ a₂ h₁ using 2 <;> exact (@Ico_toDual α _ _ _).symm
 
-theorem Ioc_eq_Ioc_iff {a b c d : α} (hab : a < b ∨ c < d) : Ioc a b = Ioc c d ↔ a = c ∧ b = d := by
+theorem Ico_eq_Ico_iff (h : a < b ∨ c < d) : Ico a b = Ico c d ↔ a = c ∧ b = d := by
   refine ⟨fun h ↦ ?_, by grind⟩
-  have hab : a < b := by grind [Set.nonempty_Ioc]
-  have hcd : c < d := by grind [Set.nonempty_Ioc]
-  have : b ≤ d ∧ c ≤ a := (Ioc_subset_Ioc_iff hab).1 h.subset
-  have : d ≤ b ∧ a ≤ c := (Ioc_subset_Ioc_iff hcd).1 h.superset
+  have : c ≤ a ∧ b ≤ d := (Ico_subset_Ico_iff (show a < b by grind [Set.nonempty_Ico])).1 h.subset
+  have : a ≤ c ∧ d ≤ b := (Ico_subset_Ico_iff (show c < d by grind [Set.nonempty_Ico])).1 h.superset
+  grind
+
+theorem Ioc_eq_Ioc_iff (hab : a < b ∨ c < d) : Ioc a b = Ioc c d ↔ a = c ∧ b = d := by
+  refine ⟨fun h ↦ ?_, by grind⟩
+  have : b ≤ d ∧ c ≤ a := (Ioc_subset_Ioc_iff (show a < b by grind [Set.nonempty_Ioc])).1 h.subset
+  have : d ≤ b ∧ a ≤ c := (Ioc_subset_Ioc_iff (show c < d by grind [Set.nonempty_Ioc])).1 h.superset
   grind
 
 theorem Ioo_subset_Ioo_iff [DenselyOrdered α] (h₁ : a₁ < b₁) :
@@ -119,17 +123,6 @@ theorem Ioo_subset_Ioo_iff [DenselyOrdered α] (h₁ : a₁ < b₁) :
     · have ab := xa.trans (h ⟨xa, xb⟩).2
       exact lt_irrefl _ (h ⟨ab, h'⟩).2,
     fun ⟨h₁, h₂⟩ => Ioo_subset_Ioo h₁ h₂⟩
-
-theorem Ico_eq_Ico_iff (h : a₁ < b₁ ∨ a₂ < b₂) : Ico a₁ b₁ = Ico a₂ b₂ ↔ a₁ = a₂ ∧ b₁ = b₂ :=
-  ⟨fun e => by
-      simp only [Subset.antisymm_iff] at e
-      simp only [le_antisymm_iff]
-      rcases h with h | h <;>
-      simp only [Ico_subset_Ico_iff h] at e <;>
-      [ rcases e with ⟨⟨h₁, h₂⟩, e'⟩; rcases e with ⟨e', ⟨h₁, h₂⟩⟩ ] <;>
-      have hab := (Ico_subset_Ico_iff <| h₁.trans_lt <| h.trans_le h₂).1 e' <;>
-      tauto,
-    fun ⟨h₁, h₂⟩ => by rw [h₁, h₂]⟩
 
 lemma Ici_eq_singleton_iff_isTop {x : α} : (Ici x = {x}) ↔ IsTop x := by
   refine ⟨fun h y ↦ ?_, fun h ↦ by ext y; simp [(h y).ge_iff_eq]⟩


### PR DESCRIPTION
Cherry picked from #34055. It is the first step of the construction of the vector measure associated to a bounded variation function: later, we will extend the finite additivity given by the current PR to countable additivity thanks to general extension theorems for vector measures.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
