### PR TITLE
fix: don't warn when tag not found locally in verify_version_tags

### DIFF
--- a/scripts/verify_version_tags.py
+++ b/scripts/verify_version_tags.py
@@ -231,12 +231,11 @@ def verify_local_remote_consistency(tag: str) -> VerificationResult:
     code, stdout, _ = run_cmd(['git', 'rev-parse', tag])
     if code != 0:
         # Tag not found locally - this is expected when running from release_checklist.py
-        # which doesn't have a local mathlib4 checkout with tags fetched.
-        # The GitHub check below will verify the tag exists remotely.
+        # which uses a shallow clone without tags. The GitHub check (verify_github_tag)
+        # verifies the tag exists remotely, so this is not an error or warning.
         return VerificationResult(
             True,
-            f"Tag {tag} not found locally (not in a mathlib4 checkout?)",
-            warning=True
+            f"Skipped (tag not in local checkout; GitHub check will verify)"
         )
     local_sha = stdout.strip()
 


### PR DESCRIPTION
When `verify_version_tags.py` is run from lean4's `release_checklist.py`, it runs in a shallow clone without tags. The local/remote consistency check would return a warning in this case, causing the script to exit with code 1 in single-tag mode (where warnings are treated as failures).

This scenario is explicitly expected (as the existing comment noted), and the GitHub API check verifies the tag exists remotely. Treat this as a successful skip rather than a warning.

🤖 Prepared with Claude Code