### PR TITLE
[Merged by Bors] - feat(MeasureTheory): the `supClosure` of a semiring of sets is a ring

### DIFF
--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -9,6 +9,8 @@ public import Mathlib.Data.Nat.Lattice
 public import Mathlib.Data.Set.Accumulate
 public import Mathlib.Data.Set.Pairwise.Lattice
 public import Mathlib.MeasureTheory.PiSystem
+public import Mathlib.Order.Partition.Finpartition
+public import Mathlib.Order.SupClosed
 
 /-! # Semirings and rings of sets
 
@@ -66,9 +68,82 @@ structure IsSetSemiring (C : Set (Set α)) : Prop where
   diff_eq_sUnion' : ∀ s ∈ C, ∀ t ∈ C,
     ∃ I : Finset (Set α), ↑I ⊆ C ∧ PairwiseDisjoint (I : Set (Set α)) id ∧ s \ t = ⋃₀ I
 
+/-- A ring of sets `C` is a family of sets containing `∅`, stable by union and set difference.
+It is then also stable by intersection (see `IsSetRing.inter_mem`). -/
+structure IsSetRing (C : Set (Set α)) : Prop where
+  empty_mem : ∅ ∈ C
+  union_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
+  diff_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s \ t ∈ C
+
 namespace IsSetSemiring
 
 lemma isPiSystem (hC : IsSetSemiring C) : IsPiSystem C := fun s hs t ht _ ↦ hC.inter_mem s hs t ht
+
+theorem exists_finpartition_diff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
+    ∃ P : Finpartition (s \ t), ↑P.parts ⊆ C := by
+  classical
+  obtain ⟨I, hIC, hI, hst⟩ := hC.diff_eq_sUnion' s hs t ht
+  refine ⟨.ofErase I (supIndep_iff_pairwiseDisjoint.mpr hI) ?_, ?_⟩
+  · rw [sup_id_eq_sSup, sSup_eq_sUnion, hst]
+  · grw [Finpartition.ofErase_parts, Finset.erase_subset, hIC]
+
+set_option pp.funBinderTypes true in
+theorem mem_supClosure_iff (hC : IsSetSemiring C) :
+    s ∈ supClosure C ↔ ∃ P : Finpartition s, ↑P.parts ⊆ C where
+  mp := by
+    classical
+    rintro ⟨S, hS, hSC, rfl⟩
+    rw [sup'_eq_sup]
+    clear hS
+    induction S using Finset.cons_induction with
+    | empty =>
+      rw [sup_empty]
+      exact ⟨.empty _, hSC⟩
+    | cons s S _ ih =>
+      rw [coe_cons, insert_subset_iff] at hSC
+      obtain ⟨hsC, hSC⟩ := hSC
+      obtain ⟨P, hP⟩ := ih hSC
+      rw [sup_cons, sup_comm, id]
+      rcases eq_or_ne s ⊥ with rfl | hs
+      · rw [sup_bot_eq]; exact ⟨P, hP⟩
+      choose Q hQ using show ∀ t ∈ (P.avoid s).parts, ∃ Q : Finpartition t, ↑Q.parts ⊆ C by
+        simp_rw [Finpartition.mem_avoid]
+        rintro _ ⟨t, ht, -, rfl⟩
+        exact hC.exists_finpartition_diff (hP ht) hsC
+      exists P.avoid s |>.bind Q |>.extend hs disjoint_sdiff_left (sdiff_sup_self _ _)
+      rw [Finpartition.extend_parts, coe_insert, insert_subset_iff, Finpartition.bind_parts,
+        coe_biUnion, iUnion₂_subset_iff, Subtype.forall]
+      exact ⟨hsC, fun t ht _ => hQ t ht⟩
+  mpr := by
+    intro ⟨P, hP⟩
+    rw [← P.sup_parts, sup_id_set_eq_sUnion]
+    exact supClosed_supClosure.sSup_mem
+      (Finset.finite_toSet _)
+      (subset_supClosure hC.empty_mem)
+      (hP.trans subset_supClosure)
+
+theorem diff_mem_supClosure (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t ∈ C) :
+    s \ t ∈ supClosure C :=
+  hC.mem_supClosure_iff.mpr <| hC.exists_finpartition_diff hs ht
+
+theorem isSetRing_supClosure (hC : IsSetSemiring C) : IsSetRing (supClosure C) where
+  empty_mem := subset_supClosure hC.empty_mem
+  union_mem _ _ h₁ h₂ := supClosed_supClosure h₁ h₂
+  diff_mem := by
+    rintro s _ hs ⟨T, hT, hTC, rfl⟩
+    rw [sup'_eq_sup]
+    clear hT
+    induction T using Finset.cons_induction generalizing s with
+    | empty => simpa
+    | cons t T _ ih =>
+      simp_rw [sup_cons, id, sup_eq_union, ← diff_diff]
+      rw [coe_cons, insert_subset_iff] at hTC
+      obtain ⟨htC, hTC⟩ := hTC
+      refine ih ?_ hTC
+      obtain ⟨S, hS, hSC, rfl⟩ := hs
+      rw [sup'_eq_sup, ← Finset.sup_sdiff_right]
+      refine supClosed_supClosure.finsetSup_mem hS fun s hs => ?_
+      exact hC.diff_mem_supClosure (hSC hs) htC
 
 section disjointOfDiff
 
@@ -439,13 +514,6 @@ lemma sUnion_disjointOfUnion (hC : IsSetSemiring C) (hJ : ↑J ⊆ C) :
 end disjointOfUnion
 
 end IsSetSemiring
-
-/-- A ring of sets `C` is a family of sets containing `∅`, stable by union and set difference.
-It is then also stable by intersection (see `IsSetRing.inter_mem`). -/
-structure IsSetRing (C : Set (Set α)) : Prop where
-  empty_mem : ∅ ∈ C
-  union_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s ∪ t ∈ C
-  diff_mem ⦃s t : Set α⦄ : s ∈ C → t ∈ C → s \ t ∈ C
 
 namespace IsSetRing
 

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -87,7 +87,6 @@ theorem exists_finpartition_diff (hC : IsSetSemiring C) (hs : s ∈ C) (ht : t �
   · rw [sup_id_eq_sSup, sSup_eq_sUnion, hst]
   · grw [Finpartition.ofErase_parts, Finset.erase_subset, hIC]
 
-set_option pp.funBinderTypes true in
 theorem mem_supClosure_iff (hC : IsSetSemiring C) :
     s ∈ supClosure C ↔ ∃ P : Finpartition s, ↑P.parts ⊆ C where
   mp := by
@@ -95,15 +94,15 @@ theorem mem_supClosure_iff (hC : IsSetSemiring C) :
     rintro ⟨S, hS, hSC, rfl⟩
     rw [sup'_eq_sup]
     clear hS
-    induction S using Finset.cons_induction with
+    induction S using Finset.induction with
     | empty =>
       rw [sup_empty]
       exact ⟨.empty _, hSC⟩
-    | cons s S _ ih =>
-      rw [coe_cons, insert_subset_iff] at hSC
+    | insert s S _ ih =>
+      rw [coe_insert, insert_subset_iff] at hSC
       obtain ⟨hsC, hSC⟩ := hSC
       obtain ⟨P, hP⟩ := ih hSC
-      rw [sup_cons, sup_comm, id]
+      rw [sup_insert, sup_comm, id]
       rcases eq_or_ne s ⊥ with rfl | hs
       · rw [sup_bot_eq]; exact ⟨P, hP⟩
       choose Q hQ using show ∀ t ∈ (P.avoid s).parts, ∃ Q : Finpartition t, ↑Q.parts ⊆ C by
@@ -130,14 +129,15 @@ theorem isSetRing_supClosure (hC : IsSetSemiring C) : IsSetRing (supClosure C) w
   empty_mem := subset_supClosure hC.empty_mem
   union_mem _ _ h₁ h₂ := supClosed_supClosure h₁ h₂
   diff_mem := by
+    classical
     rintro s _ hs ⟨T, hT, hTC, rfl⟩
     rw [sup'_eq_sup]
     clear hT
-    induction T using Finset.cons_induction generalizing s with
+    induction T using Finset.induction generalizing s with
     | empty => simpa
-    | cons t T _ ih =>
-      simp_rw [sup_cons, id, sup_eq_union, ← diff_diff]
-      rw [coe_cons, insert_subset_iff] at hTC
+    | insert t T _ ih =>
+      simp_rw [sup_insert, id, sup_eq_union, ← diff_diff]
+      rw [coe_insert, insert_subset_iff] at hTC
       obtain ⟨htC, hTC⟩ := hTC
       refine ih ?_ hTC
       obtain ⟨S, hS, hSC, rfl⟩ := hs


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
