### PR TITLE
[Merged by Bors] - fix: add missing Std.LawfulOrder instances for linear orders

### DIFF
--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -36,6 +36,12 @@ theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
 theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
   le_sup_iff
 
+instance [LinearOrder α] : Std.LawfulOrderSup α where
+  max_le_iff _ _ _ := max_le_iff
+
+instance [LinearOrder α] : Std.LawfulOrderInf α where
+  le_min_iff _ _ _ := le_min_iff
+
 theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
   inf_le_iff
 

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -36,17 +36,17 @@ theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
 theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
   le_sup_iff
 
-instance [LinearOrder α] : Std.LawfulOrderSup α where
-  max_le_iff _ _ _ := max_le_iff
-
-instance [LinearOrder α] : Std.LawfulOrderInf α where
-  le_min_iff _ _ _ := le_min_iff
-
 theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
   inf_le_iff
 
 theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
   sup_le_iff
+
+instance [LinearOrder α] : Std.LawfulOrderSup α where
+  max_le_iff _ _ _ := max_le_iff
+
+instance [LinearOrder α] : Std.LawfulOrderInf α where
+  le_min_iff _ _ _ := le_min_iff
 
 theorem lt_min_iff : a < min b c ↔ a < b ∧ a < c :=
   lt_inf_iff


### PR DESCRIPTION
See [#lean4 > No Std.MaxOrEq Int instance, but yes Std.MinOrEq Int @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/No.20Std.2EMaxOrEq.20Int.20instance.2C.20but.20yes.20Std.2EMinOrEq.20Int/near/570198709).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
