### PR TITLE
feat: remove `Membership` instance for `SetLike`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -529,7 +529,7 @@ variable [Semiring A] [Algebra R A] [Semiring B] [Algebra R B] [Semiring C] [Alg
 variable (φ : A →ₐ[R] B)
 
 /-- Range of an `AlgHom` as a subalgebra. -/
-@[simps! coe toSubsemiring]
+@[simps! -isSimp coe toSubsemiring]
 protected def range (φ : A →ₐ[R] B) : Subalgebra R B :=
   { φ.toRingHom.rangeS with algebraMap_mem' := fun r => ⟨algebraMap R A r, φ.commutes r⟩ }
 
@@ -571,8 +571,7 @@ abbrev rangeRestrict (f : A →ₐ[R] B) : A →ₐ[R] f.range :=
   f.codRestrict f.range f.mem_range_self
 
 theorem val_comp_rangeRestrict :
-    (Subalgebra.val _).comp φ.rangeRestrict = φ := by -- simp
-  sorry -- requires a def for coercion of SetLike to Type*
+    φ.range.val.comp φ.rangeRestrict = φ := by simp
 
 theorem rangeRestrict_surjective (f : A →ₐ[R] B) : Function.Surjective (f.rangeRestrict) :=
   fun ⟨_y, hy⟩ =>

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -571,7 +571,8 @@ abbrev rangeRestrict (f : A →ₐ[R] B) : A →ₐ[R] f.range :=
   f.codRestrict f.range f.mem_range_self
 
 theorem val_comp_rangeRestrict :
-    (Subalgebra.val _).comp φ.rangeRestrict = φ := by simp
+    (Subalgebra.val _).comp φ.rangeRestrict = φ := by -- simp
+  sorry -- requires a def for coercion of SetLike to Type*
 
 theorem rangeRestrict_surjective (f : A →ₐ[R] B) : Function.Surjective (f.rangeRestrict) :=
   fun ⟨_y, hy⟩ =>

--- a/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
@@ -503,12 +503,14 @@ theorem adjoin_eq_of_le (S : Subalgebra R A) (h₁ : s ⊆ S) (h₂ : S ≤ adjo
 theorem adjoin_eq (S : Subalgebra R A) : adjoin R ↑S = S :=
   adjoin_eq_of_le _ (Set.Subset.refl _) subset_adjoin
 
-theorem adjoin_iUnion {α : Type*} (s : α → Set A) :
+theorem adjoin_iUnion {α : Sort*} (s : α → Set A) :
     adjoin R (Set.iUnion s) = ⨆ i : α, adjoin R (s i) :=
   (@Algebra.gc R A _ _ _).l_iSup
 
 theorem adjoin_attach_biUnion [DecidableEq A] {α : Type*} {s : Finset α} (f : s → Finset A) :
-    adjoin R (s.attach.biUnion f : Set A) = ⨆ x, adjoin R (f x) := by simp [adjoin_iUnion]
+    adjoin R (s.attach.biUnion f : Set A) = ⨆ x, adjoin R (f x) := by
+  show_term push_cast
+  simp [adjoin_iUnion]
 
 @[elab_as_elim]
 theorem adjoin_induction {p : (x : A) → x ∈ adjoin R s → Prop}

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -177,7 +177,7 @@ theorem prod_add (f g : ι → R) (s : Finset ι) :
       sum_bij'
         (fun f _ ↦ {a ∈ s | ∃ h : a ∈ s, f a h})
         (fun t _ a _ => a ∈ t)
-        (by simp)
+        (by grind)
         (by simp [Classical.em])
         (by simp_rw [mem_filter, funext_iff, eq_iff_iff, mem_pi, mem_insert]; tauto)
         (by simp_rw [Finset.ext_iff, @mem_filter _ _ (id _), mem_powerset]; tauto)

--- a/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
@@ -159,7 +159,7 @@ theorem finset_prod_singleton {M ι : Type*} [CommMonoid M] (s : Finset ι) (I :
 theorem image_finset_prod_pi (l : Finset ι) (S : ι → Set α) :
     (fun f : ι → α => ∏ i ∈ l, f i) '' (l : Set ι).pi S = ∏ i ∈ l, S i := by
   ext
-  simp_rw [mem_finset_prod, mem_image, mem_pi, exists_prop, Finset.mem_coe]
+  simp_rw [mem_finset_prod, mem_image, mem_pi, exists_prop]
 
 /-- A special case of `Set.image_finset_prod_pi` for `Finset.univ`. -/
 @[to_additive /-- A special case of `Set.image_finset_sum_pi` for `Finset.univ`. -/]

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -374,7 +374,7 @@ theorem pointwise_smul_def {a : α} (S : Subgroup G) :
     a • S = S.map (MulDistribMulAction.toMonoidEnd _ _ a) :=
   rfl
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_pointwise_smul (a : α) (S : Subgroup G) : ↑(a • S) = a • (S : Set G) :=
   rfl
 

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -99,7 +99,8 @@ theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Submonoid M} (hS : D
 theorem mem_sSup_of_directedOn {S : Set (Submonoid M)} (Sne : S.Nonempty)
     (hS : DirectedOn (· ≤ ·) S) {x : M} : x ∈ sSup S ↔ ∃ s ∈ S, x ∈ s := by
   haveI : Nonempty S := Sne.to_subtype
-  simp [sSup_eq_iSup', mem_iSup_of_directed hS.directed_val]
+  rw [sSup_eq_iSup', mem_iSup_of_directed hS.directed_val]
+  simp
 
 @[to_additive]
 theorem coe_sSup_of_directedOn {S : Set (Submonoid M)} (Sne : S.Nonempty)

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -180,7 +180,7 @@ def comap (f : F) (S : Submonoid N) :
   one_mem' := show f 1 ∈ S by rw [map_one]; exact S.one_mem
   mul_mem' ha hb := show f (_ * _) ∈ S by rw [map_mul]; exact S.mul_mem ha hb
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := norm_cast)]
 theorem coe_comap (S : Submonoid N) (f : F) : (S.comap f : Set M) = f ⁻¹' S :=
   rfl
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -226,7 +226,7 @@ theorem subsingleton_of_subsingleton [Subsingleton (Subsemigroup M)] : Subsingle
 instance [hn : Nonempty M] : Nontrivial (Subsemigroup M) :=
   ⟨⟨⊥, ⊤, fun h => by
       obtain ⟨x⟩ := id hn
-      refine absurd (?_ : x ∈ ⊥) notMem_bot
+      refine absurd (?_ : x ∈ (⊥ : Subsemigroup M)) notMem_bot
       simp [h]⟩⟩
 
 end Subsemigroup

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -257,7 +257,7 @@ theorem mem_sInf {S : Set (Submodule R M)} {x : M} : x ∈ sInf S ↔ ∀ p ∈ 
 
 @[simp]
 theorem mem_iInf {ι} (p : ι → Submodule R M) {x} : x ∈ ⨅ i, p i ↔ ∀ i, x ∈ p i := by
-  rw [← SetLike.mem_coe, coe_iInf, Set.mem_iInter]; rfl
+  rw [coe_iInf, Set.mem_iInter]
 
 @[simp]
 theorem mem_finsetInf {ι} {s : Finset ι} {p : ι → Submodule R M} {x : M} :

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -174,7 +174,7 @@ def comap (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R₂ M₂) : Submodule
     -- Note: https://github.com/leanprover-community/mathlib4/pull/8386 added `map_smulₛₗ _`
     smul_mem' := fun a x h => by simp [p.smul_mem (σ₁₂ a) h, map_smulₛₗ _] }
 
-@[simp]
+@[norm_cast]
 theorem comap_coe (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R₂ M₂) : (comap f p : Set M) = f ⁻¹' p :=
   rfl
 

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -197,7 +197,7 @@ scoped[Pointwise] attribute [instance] Submodule.pointwiseDistribMulAction
 
 open Pointwise
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_pointwise_smul (a : α) (S : Submodule R M) : ↑(a • S) = a • (S : Set M) :=
   rfl
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -339,28 +339,28 @@ variable [DecidableEq α] {s : Finset α} {B : Finset (Finset α)} {n : ℕ}
 
 /-- If every element belongs to at most `n` Finsets, then the sum of their sizes is at most `n`
 times how many they are. -/
-theorem sum_card_inter_le (h : ∀ a ∈ s, #{b ∈ B | a ∈ b} ≤ n) : (∑ t ∈ B, #(s ∩ t)) ≤ #s * n := by
+theorem sum_card_inter_le (h : ∀ a ∈ s, #{b ∈ B | a ∈ ↑b} ≤ n) : (∑ t ∈ B, #(s ∩ t)) ≤ #s * n := by
   refine le_trans ?_ (s.sum_le_card_nsmul _ _ h)
   simp_rw [← filter_mem_eq_inter, card_eq_sum_ones, sum_filter]
   exact sum_comm.le
 
 /-- If every element belongs to at most `n` Finsets, then the sum of their sizes is at most `n`
 times how many they are. -/
-lemma sum_card_le [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ b} ≤ n) : ∑ s ∈ B, #s ≤ Fintype.card α * n :=
+lemma sum_card_le [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ ↑b} ≤ n) : ∑ s ∈ B, #s ≤ Fintype.card α * n :=
   calc
     ∑ s ∈ B, #s = ∑ s ∈ B, #(univ ∩ s) := by simp_rw [univ_inter]
     _ ≤ Fintype.card α * n := sum_card_inter_le fun a _ ↦ h a
 
 /-- If every element belongs to at least `n` Finsets, then the sum of their sizes is at least `n`
 times how many they are. -/
-theorem le_sum_card_inter (h : ∀ a ∈ s, n ≤ #{b ∈ B | a ∈ b}) : #s * n ≤ ∑ t ∈ B, #(s ∩ t) := by
+theorem le_sum_card_inter (h : ∀ a ∈ s, n ≤ #{b ∈ B | a ∈ ↑b}) : #s * n ≤ ∑ t ∈ B, #(s ∩ t) := by
   apply (s.card_nsmul_le_sum _ _ h).trans
   simp_rw [← filter_mem_eq_inter, card_eq_sum_ones, sum_filter]
   exact sum_comm.le
 
 /-- If every element belongs to at least `n` Finsets, then the sum of their sizes is at least `n`
 times how many they are. -/
-theorem le_sum_card [Fintype α] (h : ∀ a, n ≤ #{b ∈ B | a ∈ b}) :
+theorem le_sum_card [Fintype α] (h : ∀ a, n ≤ #{b ∈ B | a ∈ ↑b}) :
     Fintype.card α * n ≤ ∑ s ∈ B, #s :=
   calc
     Fintype.card α * n ≤ ∑ s ∈ B, #(univ ∩ s) := le_sum_card_inter fun a _ ↦ h a
@@ -368,13 +368,13 @@ theorem le_sum_card [Fintype α] (h : ∀ a, n ≤ #{b ∈ B | a ∈ b}) :
 
 /-- If every element belongs to exactly `n` Finsets, then the sum of their sizes is `n` times how
 many they are. -/
-theorem sum_card_inter (h : ∀ a ∈ s, #{b ∈ B | a ∈ b} = n) :
+theorem sum_card_inter (h : ∀ a ∈ s, #{b ∈ B | a ∈ ↑b} = n) :
     (∑ t ∈ B, #(s ∩ t)) = #s * n :=
   (sum_card_inter_le fun a ha ↦ (h a ha).le).antisymm (le_sum_card_inter fun a ha ↦ (h a ha).ge)
 
 /-- If every element belongs to exactly `n` Finsets, then the sum of their sizes is `n` times how
 many they are. -/
-theorem sum_card [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ b} = n) :
+theorem sum_card [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ ↑b} = n) :
     ∑ s ∈ B, #s = Fintype.card α * n := by
   simp_rw [Fintype.card, ← sum_card_inter fun a _ ↦ h a, univ_inter]
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -837,7 +837,7 @@ def ofLeftInverseS {g : S → R} {f : R →+* S} (h : Function.LeftInverse g f) 
     right_inv := fun x =>
       Subtype.ext <| by
         let ⟨x', hx'⟩ := RingHom.mem_rangeS.mp x.prop
-        simp [← hx', h x'] }
+        simp [← hx', h x', -RingHom.coe_rangeS] }
 
 @[simp]
 theorem ofLeftInverseS_apply {g : S → R} {f : R →+* S} (h : Function.LeftInverse g f) (x : R) :

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -676,7 +676,7 @@ theorem exists_eq_insert_iff [DecidableEq α] {s t : Finset α} :
   · rintro ⟨hst, h⟩
     obtain ⟨a, ha⟩ : ∃ a, t \ s = {a} := card_eq_one.mp (by grind)
     exact
-      ⟨a, fun hs => (by grind : a ∉ {a}) <| mem_singleton_self _, by
+      ⟨a, (by grind [mem_singleton_self]), by
         rw [insert_eq, ← ha, sdiff_union_of_subset hst]⟩
 
 theorem card_le_one : #s ≤ 1 ↔ ∀ a ∈ s, ∀ b ∈ s, a = b := by

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -737,14 +737,14 @@ lemma exists_of_one_lt_card_pi {ι : Type*} {α : ι → Type*} [∀ i, Decidabl
   exacts [⟨a1, h1, hne⟩, ⟨a2, h2, hne⟩]
 
 theorem card_eq_succ_iff_cons :
-    #s = n + 1 ↔ ∃ a t, ∃ (h : a ∉ t), cons a t h = s ∧ #t = n :=
+    #s = n + 1 ↔ ∃ a t, ∃ (h : a ∉ ↑t), cons a t h = s ∧ #t = n :=
   ⟨cons_induction_on s (by simp) fun a s _ _ _ => ⟨a, s, by simp_all⟩,
    fun ⟨a, t, _, hs, _⟩ => by simpa [← hs]⟩
 
 section DecidableEq
 variable [DecidableEq α]
 
-theorem card_eq_succ : #s = n + 1 ↔ ∃ a t, a ∉ t ∧ insert a t = s ∧ #t = n :=
+theorem card_eq_succ : #s = n + 1 ↔ ∃ a t, a ∉ ↑t ∧ insert a t = s ∧ #t = n :=
   ⟨fun h =>
     let ⟨a, has⟩ := card_pos.mp (h.symm ▸ Nat.zero_lt_succ _ : 0 < #s)
     ⟨a, s.erase a, s.notMem_erase a, insert_erase has, by
@@ -832,7 +832,7 @@ theorem strongInductionOn_eq {p : Finset α → Sort*} (s : Finset α)
 
 @[elab_as_elim]
 theorem case_strong_induction_on [DecidableEq α] {p : Finset α → Prop} (s : Finset α) (h₀ : p ∅)
-    (h₁ : ∀ a s, a ∉ s → (∀ t ⊆ s, p t) → p (insert a s)) : p s :=
+    (h₁ : ∀ a s, a ∉ ↑s → (∀ t ⊆ s, p t) → p (insert a s)) : p s :=
   Finset.strongInductionOn s fun s =>
     Finset.induction_on s (fun _ => h₀) fun a s n _ ih =>
       (h₁ a s n) fun t ss => ih _ (lt_of_le_of_lt ss (ssubset_insert n) : t < _)

--- a/Mathlib/Data/Finset/Defs.lean
+++ b/Mathlib/Data/Finset/Defs.lean
@@ -99,8 +99,10 @@ instance decidableEq [DecidableEq α] : DecidableEq (Finset α)
 /-! ### membership -/
 
 
-instance : Membership α (Finset α) :=
-  ⟨fun s a => a ∈ s.1⟩
+/-- Convert a finset to a set in the natural way. -/
+instance : SetLike (Finset α) α where
+  coe s := {a | a ∈ s.1}
+  coe_injective' s₁ s₂ h := (val_inj.symm.trans <| s₁.nodup.ext s₂.nodup).2 <| Set.ext_iff.mp h
 
 theorem mem_def {a : α} {s : Finset α} : a ∈ s ↔ a ∈ s.1 :=
   Iff.rfl
@@ -123,19 +125,14 @@ instance decidableMem [_h : DecidableEq α] (a : α) (s : Finset α) : Decidable
 /-! ### set coercion -/
 
 /-- Convert a finset to a set in the natural way. -/
-instance : SetLike (Finset α) α where
-  coe s := {a | a ∈ s}
-  coe_injective' s₁ s₂ h := (val_inj.symm.trans <| s₁.nodup.ext s₂.nodup).2 <| Set.ext_iff.mp h
-
-/-- Convert a finset to a set in the natural way. -/
 @[deprecated SetLike.coe (since := "2025-10-22")]
 abbrev toSet (s : Finset α) : Set α := s
 
-@[norm_cast, grind =]
+@[deprecated "this now a syntactic equality" (since := "2026-01-26")]
 theorem mem_coe {a : α} {s : Finset α} : a ∈ (s : Set α) ↔ a ∈ (s : Finset α) :=
   Iff.rfl
 
-@[simp]
+@[deprecated Set.setOf_mem_eq (since := "2026-01-26")]
 theorem setOf_mem {α} {s : Finset α} : { a | a ∈ s } = s :=
   rfl
 
@@ -246,7 +243,6 @@ theorem Subset.trans {s₁ s₂ s₃ : Finset α} : s₁ ⊆ s₂ → s₂ ⊆ s
 theorem Superset.trans {s₁ s₂ s₃ : Finset α} : s₁ ⊇ s₂ → s₂ ⊇ s₃ → s₁ ⊇ s₃ := fun h' h =>
   Subset.trans h h'
 
-@[gcongr]
 theorem mem_of_subset {s₁ s₂ : Finset α} {a : α} : s₁ ⊆ s₂ → a ∈ s₁ → a ∈ s₂ :=
   Multiset.mem_of_subset
 
@@ -275,7 +271,7 @@ theorem val_le_iff {s₁ s₂ : Finset α} : s₁.1 ≤ s₂.1 ↔ s₁ ⊆ s₂
 theorem Subset.antisymm_iff {s₁ s₂ : Finset α} : s₁ = s₂ ↔ s₁ ⊆ s₂ ∧ s₂ ⊆ s₁ :=
   le_antisymm_iff
 
-theorem not_subset : ¬s ⊆ t ↔ ∃ x ∈ s, x ∉ t := by simp only [← coe_subset, Set.not_subset, mem_coe]
+theorem not_subset : ¬s ⊆ t ↔ ∃ x ∈ s, x ∉ t := by simp only [← coe_subset, Set.not_subset]
 
 @[simp]
 theorem le_eq_subset : ((· ≤ ·) : Finset α → Finset α → Prop) = (· ⊆ ·) :=

--- a/Mathlib/Data/Finset/Erase.lean
+++ b/Mathlib/Data/Finset/Erase.lean
@@ -91,7 +91,7 @@ theorem erase_subset (a : α) (s : Finset α) : erase s a ⊆ s :=
 
 theorem subset_erase {a : α} {s t : Finset α} : s ⊆ t.erase a ↔ s ⊆ t ∧ a ∉ s := by grind
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_erase (a : α) (s : Finset α) : ↑(erase s a) = (s \ {a} : Set α) := by grind
 
 theorem erase_idem {a : α} {s : Finset α} : erase (erase s a) a = erase s a := by simp

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -93,7 +93,7 @@ theorem forall_mem_map {f : α ↪ β} {s : Finset α} {p : ∀ a, a ∈ s.map f
 theorem apply_coe_mem_map (f : α ↪ β) (s : Finset α) (x : s) : f x ∈ s.map f :=
   mem_map_of_mem f x.prop
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_map (f : α ↪ β) (s : Finset α) : (s.map f : Set β) = f '' s := by grind
 
 theorem coe_map_subset_range (f : α ↪ β) (s : Finset α) : (s.map f : Set β) ⊆ Set.range f := by

--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -514,7 +514,7 @@ obtained by inserting an element in `t`. -/
 @[elab_as_elim]
 theorem Nonempty.cons_induction {α : Type*} {motive : ∀ s : Finset α, s.Nonempty → Prop}
     (singleton : ∀ a, motive {a} (singleton_nonempty _))
-    (cons : ∀ a s (h : a ∉ s) (hs), motive s hs → motive (Finset.cons a s h) (cons_nonempty h))
+    (cons : ∀ a s (h : a ∉ ↑s) (hs), motive s hs → motive (Finset.cons a s h) (cons_nonempty h))
     {s : Finset α} (hs : s.Nonempty) : motive s hs := by
   induction s using Finset.cons_induction with
   | empty => exact (not_nonempty_empty hs).elim

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -455,7 +455,7 @@ theorem card_le_diff_of_interleaved {s t : Finset α}
   implies `p (insert a s)`. -/
 @[elab_as_elim]
 theorem induction_on_max [DecidableEq α] {p : Finset α → Prop} (s : Finset α) (h0 : p ∅)
-    (step : ∀ a s, (∀ x ∈ s, x < a) → p s → p (insert a s)) : p s := by
+    (step : ∀ a s, (∀ x ∈ ↑s, x < a) → p s → p (insert a s)) : p s := by
   induction s using Finset.eraseInduction with | _ s ih
   rcases s.eq_empty_or_nonempty with (rfl | hne)
   · exact h0
@@ -471,7 +471,7 @@ theorem induction_on_max [DecidableEq α] {p : Finset α → Prop} (s : Finset �
   implies `p (insert a s)`. -/
 @[elab_as_elim]
 theorem induction_on_min [DecidableEq α] {p : Finset α → Prop} (s : Finset α) (h0 : p ∅)
-    (step : ∀ a s, (∀ x ∈ s, a < x) → p s → p (insert a s)) : p s :=
+    (step : ∀ a s, (∀ x ∈ ↑s, a < x) → p s → p (insert a s)) : p s :=
   @induction_on_max αᵒᵈ _ _ _ s h0 step
 
 end MaxMin
@@ -488,7 +488,7 @@ ordered type : a predicate is true on all `s : Finset α` provided that:
   `f x ≤ f a`, `p s` implies `p (insert a s)`. -/
 @[elab_as_elim]
 theorem induction_on_max_value [DecidableEq ι] (f : ι → α) {p : Finset ι → Prop} (s : Finset ι)
-    (h0 : p ∅) (step : ∀ a s, a ∉ s → (∀ x ∈ s, f x ≤ f a) → p s → p (insert a s)) : p s := by
+    (h0 : p ∅) (step : ∀ a s, a ∉ ↑s → (∀ x ∈ ↑s, f x ≤ f a) → p s → p (insert a s)) : p s := by
   induction s using Finset.eraseInduction with | _ s ihs
   rcases (s.image f).eq_empty_or_nonempty with (hne | hne)
   · simp only [image_eq_empty] at hne
@@ -509,7 +509,7 @@ ordered type : a predicate is true on all `s : Finset α` provided that:
   `f a ≤ f x`, `p s` implies `p (insert a s)`. -/
 @[elab_as_elim]
 theorem induction_on_min_value [DecidableEq ι] (f : ι → α) {p : Finset ι → Prop} (s : Finset ι)
-    (h0 : p ∅) (step : ∀ a s, a ∉ s → (∀ x ∈ s, f a ≤ f x) → p s → p (insert a s)) : p s :=
+    (h0 : p ∅) (step : ∀ a s, a ∉ ↑s → (∀ x ∈ ↑s, f a ≤ f x) → p s → p (insert a s)) : p s :=
   @induction_on_max_value αᵒᵈ ι _ _ _ _ s h0 step
 
 end MaxMinInductionValue

--- a/Mathlib/Data/Finset/NAry.lean
+++ b/Mathlib/Data/Finset/NAry.lean
@@ -88,11 +88,11 @@ theorem image_subset_image₂_right (ha : a ∈ s) : t.image (fun b => f a b) �
 
 lemma forall_mem_image₂ {p : γ → Prop} :
     (∀ z ∈ image₂ f s t, p z) ↔ ∀ x ∈ s, ∀ y ∈ t, p (f x y) := by
-  simp_rw [← mem_coe, coe_image₂, forall_mem_image2]
+  simp_rw [coe_image₂, forall_mem_image2]
 
 lemma exists_mem_image₂ {p : γ → Prop} :
     (∃ z ∈ image₂ f s t, p z) ↔ ∃ x ∈ s, ∃ y ∈ t, p (f x y) := by
-  simp_rw [← mem_coe, coe_image₂, exists_mem_image2]
+  simp_rw [coe_image₂, exists_mem_image2]
 
 @[simp]
 theorem image₂_subset_iff : image₂ f s t ⊆ u ↔ ∀ x ∈ s, ∀ y ∈ t, f x y ∈ u :=

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -358,7 +358,7 @@ theorem noncommProd_eq_prod {β : Type*} [CommMonoid β] (s : Finset α) (f : α
 /-- The non-commutative version of `Finset.prod_union` -/
 @[to_additive /-- The non-commutative version of `Finset.sum_union` -/]
 theorem noncommProd_union_of_disjoint [DecidableEq α] {s t : Finset α} (h : Disjoint s t)
-    (f : α → β) (comm : { x | x ∈ s ∪ t }.Pairwise (Commute on f)) :
+    (f : α → β) (comm : Set.Pairwise (s ∪ t : Finset α) (Commute on f)) :
     noncommProd (s ∪ t) f comm =
       noncommProd s f (comm.mono <| coe_subset.2 subset_union_left) *
         noncommProd t f (comm.mono <| coe_subset.2 subset_union_right) := by
@@ -367,7 +367,7 @@ theorem noncommProd_union_of_disjoint [DecidableEq α] {s t : Finset α} (h : Di
   rw [List.disjoint_toFinset_iff_disjoint] at h
   calc noncommProd (List.toFinset sl ∪ List.toFinset tl) f comm
     _ = noncommProd ⟨↑(sl ++ tl), Multiset.coe_nodup.2 (sl'.append tl' h)⟩ f
-          (by convert comm; simp [Set.ext_iff]) :=
+          (by convert comm using 1; simp [Set.ext_iff]) :=
       noncommProd_congr (by ext; simp) (by simp) _
     _ = noncommProd (List.toFinset sl) f (comm.mono <| coe_subset.2 subset_union_left) *
          noncommProd (List.toFinset tl) f (comm.mono <| coe_subset.2 subset_union_right) := by

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -104,7 +104,7 @@ theorem powerset_insert [DecidableEq α] (s : Finset α) (a : α) :
 
 lemma pairwiseDisjoint_pair_insert [DecidableEq α] {a : α} (ha : a ∉ s) :
     (s.powerset : Set (Finset α)).PairwiseDisjoint fun t ↦ ({t, insert a t} : Set (Finset α)) := by
-  simp_rw [Set.pairwiseDisjoint_iff, mem_coe, mem_powerset]
+  simp_rw [Set.pairwiseDisjoint_iff, mem_powerset]
   rintro i hi j hj
   simp only [Set.Nonempty, Set.mem_inter_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
     exists_eq_or_imp, exists_eq_left, or_imp, imp_self, true_and]

--- a/Mathlib/Data/Finset/Preimage.lean
+++ b/Mathlib/Data/Finset/Preimage.lean
@@ -101,7 +101,7 @@ theorem image_preimage [DecidableEq β] (f : α → β) (s : Finset β) [∀ x, 
     (hf : Set.InjOn f (f ⁻¹' ↑s)) : image f (preimage s f hf) = {x ∈ s | x ∈ Set.range f} :=
   Finset.coe_inj.1 <| by
     simp only [coe_image, coe_preimage, coe_filter, Set.image_preimage_eq_inter_range,
-      ← Set.sep_mem_eq]; rfl
+      ← Set.sep_mem_eq]
 
 theorem image_preimage_of_bij [DecidableEq β] (f : α → β) (s : Finset β)
     (hf : Set.BijOn f (f ⁻¹' ↑s) ↑s) : image f (preimage s f hf.injOn) = s :=

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -102,7 +102,9 @@ theorem prodMap_image_product {δ : Type*} [DecidableEq β] [DecidableEq δ]
 
 theorem prodMap_map_product {δ : Type*} (f : α ↪ β) (g : γ ↪ δ) (s : Finset α) (t : Finset γ) :
     (s ×ˢ t).map (f.prodMap g) = s.map f ×ˢ t.map g := by
-  simpa [← coe_inj] using Set.prodMap_image_prod f g s t
+  rw [← coe_inj]
+  push_cast
+  apply Set.prodMap_image_prod
 
 theorem map_swap_product (s : Finset α) (t : Finset β) :
     (t ×ˢ s).map ⟨Prod.swap, Prod.swap_injective⟩ = s ×ˢ t :=

--- a/Mathlib/Data/Finset/Sigma.lean
+++ b/Mathlib/Data/Finset/Sigma.lean
@@ -106,7 +106,7 @@ theorem inf_sigma [SemilatticeInf β] [OrderTop β] :
 
 theorem _root_.biSup_finsetSigma [CompleteLattice β] (s : Finset ι) (t : ∀ i, Finset (α i))
     (f : Sigma α → β) : ⨆ ij ∈ s.sigma t, f ij = ⨆ (i ∈ s) (j ∈ t i), f ⟨i, j⟩ := by
-  simp_rw [← Finset.iSup_coe, Finset.coe_sigma, biSup_sigma]
+  simp_rw [Finset.coe_sigma, biSup_sigma]
 
 theorem _root_.biSup_finsetSigma' [CompleteLattice β] (s : Finset ι) (t : ∀ i, Finset (α i))
     (f : ∀ i, α i → β) : ⨆ (i ∈ s) (j ∈ t i), f i j = ⨆ ij ∈ s.sigma t, f ij.fst ij.snd :=

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -200,7 +200,7 @@ protected def biUnion (s : Finset α) (t : α → Finset β) : Finset β :=
 @[simp, grind =] lemma mem_biUnion {b : β} : b ∈ s.biUnion t ↔ ∃ a ∈ s, b ∈ t a := by
   simp only [mem_def, biUnion_val, Multiset.mem_dedup, Multiset.mem_bind]
 
-@[simp, norm_cast]
+@[norm_cast]
 lemma coe_biUnion : (s.biUnion t : Set β) = ⋃ x ∈ (s : Set α), t x := by
   simp [Set.ext_iff, mem_biUnion, Set.mem_iUnion]
 

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -367,7 +367,7 @@ theorem mapDomain_support_of_injOn [DecidableEq β] {f : α → β} (s : α →�
     simp only [mem_support_iff, Ne]
     rw [mapDomain_apply' (↑s.support : Set _) _ _ hf]
     · exact hx_h_left
-    · simp_rw [mem_coe, mem_support_iff, Ne]
+    · simp_rw [mem_support_iff, Ne]
       exact hx_h_left
     · exact Subset.refl _
 

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -381,7 +381,8 @@ lemma exists_of_card_eq_finset [Fintype α] {s : Finset β} (hsn : Fintype.card 
   obtain ⟨f : α ↪ β, hf⟩ := exists_of_card_le_finset (Nat.le_of_eq hsn)
   use f
   apply Finset.eq_of_subset_of_card_le
-  · simp [← coe_subset, hf]
+  · rw [← coe_subset, coe_map]
+    simp [hf]
   · simp [← hsn]
 
 end Function.Embedding

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -839,7 +839,7 @@ noncomputable def Infinite.natEmbedding (s : Set α) (h : s.Infinite) : ℕ ↪ 
 
 theorem Infinite.exists_subset_card_eq {s : Set α} (hs : s.Infinite) (n : ℕ) :
     ∃ t : Finset α, ↑t ⊆ s ∧ t.card = n :=
-  ⟨((Finset.range n).map (hs.natEmbedding _)).map (Embedding.subtype _), by simp⟩
+  ⟨((Finset.range n).map (hs.natEmbedding _)).map (Embedding.subtype _), by push_cast; simp⟩
 
 theorem infinite_of_finite_compl [Infinite α] {s : Set α} (hs : sᶜ.Finite) : s.Infinite := fun h =>
   Set.infinite_univ (α := α) (by simpa using hs.union h)

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -220,10 +220,13 @@ lemma span_range_inclusion_eq_top (p : Submodule R M) (q : Submodule S M)
     rw [this, q.map_subtype_top]
   rw [map_span]
   suffices q.subtype '' ((LinearMap.range (inclusion h₁)) : Set <| q.restrictScalars R) = p by
-    refine this ▸ le_antisymm ?_ h₂
-    simpa using span_mono (R := S) h₁
+    sorry
+    -- refine this ▸ le_antisymm ?_ h₂
+    -- simpa using span_mono (R := S) h₁
   ext x
-  simpa [range_inclusion] using fun hx ↦ h₁ hx
+  sorry -- requires a def for coercion of SetLike to Type*
+  -- simpa [range_inclusion] using fun hx ↦ h₁ hx
+
 
 @[simp]
 theorem span_range_inclusion_restrictScalars_eq_top :
@@ -332,9 +335,7 @@ theorem singleton_span_isCompactElement (x : M) :
 /-- The span of a finite subset is compact in the lattice of submodules. -/
 theorem finset_span_isCompactElement (S : Finset M) :
     IsCompactElement (span R S : Submodule R M) := by
-  rw [span_eq_iSup_of_singleton_spans]
-  simp only [Finset.mem_coe]
-  rw [← Finset.sup_eq_iSup]
+  rw [span_eq_iSup_of_singleton_spans, ← Finset.sup_eq_iSup]
   exact
     CompleteLattice.isCompactElement_finsetSup S fun x _ => singleton_span_isCompactElement x
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -218,14 +218,10 @@ lemma span_range_inclusion_eq_top (p : Submodule R M) (q : Submodule S M)
   suffices (span S (range (inclusion h₁))).map q.subtype = q by
     apply map_injective_of_injective q.injective_subtype
     rw [this, q.map_subtype_top]
-  rw [map_span]
-  suffices q.subtype '' ((LinearMap.range (inclusion h₁)) : Set <| q.restrictScalars R) = p by
-    sorry
-    -- refine this ▸ le_antisymm ?_ h₂
-    -- simpa using span_mono (R := S) h₁
-  ext x
-  sorry -- requires a def for coercion of SetLike to Type*
-  -- simpa [range_inclusion] using fun hx ↦ h₁ hx
+  simp_rw [map_span, ← range_comp', coe_subtype, coe_inclusion, Subtype.range_val]
+  refine le_antisymm ?_ h₂
+  grw [h₁]
+  simp
 
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -290,7 +290,7 @@ theorem span_iUnion₂ {ι} {κ : ι → Sort*} (s : ∀ i, κ i → Set M) :
   (Submodule.gi R M).gc.l_iSup₂
 
 theorem span_attach_biUnion [DecidableEq M] {α : Type*} (s : Finset α) (f : s → Finset M) :
-    span R (s.attach.biUnion f : Set M) = ⨆ x, span R (f x) := by simp [span_iUnion]
+    span R (s.attach.biUnion f : Set M) = ⨆ x, span R (f x) := by push_cast; simp [span_iUnion]
 
 theorem sup_span : p ⊔ span R s = span R (p ∪ s) := by rw [Submodule.span_union, p.span_eq]
 
@@ -338,8 +338,7 @@ theorem coe_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M)
 @[simp]
 theorem mem_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M) (H : Directed (· ≤ ·) S) {x} :
     x ∈ iSup S ↔ ∃ i, x ∈ S i := by
-  rw [← SetLike.mem_coe, coe_iSup_of_directed S H, mem_iUnion]
-  rfl
+  rw [coe_iSup_of_directed S H, mem_iUnion]
 
 theorem mem_sSup_of_directed {s : Set (Submodule R M)} {z} (hs : s.Nonempty)
     (hdir : DirectedOn (· ≤ ·) s) : z ∈ sSup s ↔ ∃ y ∈ s, z ∈ y := by
@@ -387,8 +386,7 @@ variable (p p')
 
 theorem coe_sup : ↑(p ⊔ p') = (p + p' : Set M) := by
   ext
-  rw [SetLike.mem_coe, mem_sup, Set.mem_add]
-  simp
+  rw [mem_sup, Set.mem_add]
 
 theorem sup_toAddSubmonoid : (p ⊔ p').toAddSubmonoid = p.toAddSubmonoid ⊔ p'.toAddSubmonoid := by
   ext x
@@ -654,7 +652,7 @@ theorem Module.isPrincipal_submodule_iff {p : Submodule R M} :
   simp_rw [IsPrincipal, isPrincipal_iff]
   constructor <;> rintro ⟨a, ha⟩
   · refine ⟨a, le_antisymm (fun m hm ↦ ?_) <| (span_singleton_le_iff_mem ..).mpr a.2⟩
-    have ⟨r, hr⟩ := mem_span_singleton.mp (ha ▸ (trivial : (⟨m, hm⟩ : p) ∈ ⊤))
+    have ⟨r, hr⟩ := mem_span_singleton.mp (ha ▸ (mem_top : (⟨m, hm⟩ : p) ∈ ↑⊤))
     exact mem_span_singleton.mpr ⟨r, congr($hr)⟩
   · refine ⟨⟨a, ha ▸ mem_span_singleton_self a⟩, .symm <| top_unique fun x _ ↦ ?_⟩
     have ⟨r, hr⟩ := mem_span_singleton.mp (ha.le x.2)

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -222,7 +222,7 @@ theorem subtype_apply {α} {p : α → Prop} (x : Subtype p) : subtype p x = x :
 theorem subtype_injective {α} (p : α → Prop) : Function.Injective (subtype p) :=
   Subtype.coe_injective
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_subtype {α} (p : α → Prop) : ↑(subtype p) = Subtype.val :=
   rfl
 
@@ -230,7 +230,7 @@ theorem coe_subtype {α} (p : α → Prop) : ↑(subtype p) = Subtype.val :=
 noncomputable def quotientOut (α) [s : Setoid α] : Quotient s ↪ α :=
   ⟨_, Quotient.out_injective⟩
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_quotientOut (α) [Setoid α] : ↑(quotientOut α) = Quotient.out :=
   rfl
 
@@ -262,7 +262,7 @@ def sectR {α : Sort _} (a : α) (β : Sort _) : β ↪ α × β :=
 def prodMap {α β γ δ : Type*} (e₁ : α ↪ β) (e₂ : γ ↪ δ) : α × γ ↪ β × δ :=
   ⟨Prod.map e₁ e₂, e₁.injective.prodMap e₂.injective⟩
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_prodMap {α β γ δ : Type*} (e₁ : α ↪ β) (e₂ : γ ↪ δ) :
     e₁.prodMap e₂ = Prod.map e₁ e₂ :=
   rfl
@@ -280,7 +280,7 @@ open Sum
 def sumMap {α β γ δ : Type*} (e₁ : α ↪ β) (e₂ : γ ↪ δ) : α ⊕ γ ↪ β ⊕ δ :=
   ⟨Sum.map e₁ e₂, e₁.injective.sumMap e₂.injective⟩
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_sumMap {α β γ δ} (e₁ : α ↪ β) (e₂ : γ ↪ δ) : sumMap e₁ e₂ = Sum.map e₁ e₂ :=
   rfl
 

--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -463,7 +463,7 @@ theorem le_iff_subset (s : Set β) (S : α) : l s ≤ S ↔ s ⊆ S :=
   l.gc s S
 
 theorem mem_iff (s : Set β) (x : β) : x ∈ l s ↔ ∀ S : α, s ⊆ S → x ∈ S := by
-  simp_rw [← SetLike.mem_coe, ← Set.singleton_subset_iff, ← l.le_iff_subset]
+  simp_rw [← Set.singleton_subset_iff, ← l.le_iff_subset]
   exact ⟨fun h S => h.trans, fun h => h _ le_rfl⟩
 
 theorem eq_of_le {s : Set β} {S : α} (h₁ : s ⊆ S) (h₂ : S ≤ l s) : l s = S :=

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -711,6 +711,16 @@ theorem iSup_sup_eq : ⨆ x, f x ⊔ g x = (⨆ x, f x) ⊔ ⨆ x, g x :=
 theorem iInf_inf_eq : ⨅ x, f x ⊓ g x = (⨅ x, f x) ⊓ ⨅ x, g x :=
   @iSup_sup_eq αᵒᵈ _ _ _ _
 
+@[simp]
+theorem iSup_coe_set {ι : Type*} (s : Set ι) (f : s → α) :
+    ⨆ i, f i = ⨆ i ∈ s, f ⟨i, ‹i ∈ s›⟩ :=
+  iSup_subtype
+
+@[simp]
+theorem iInf_coe_set {ι : Type*} (s : Set ι) (f : s → α) :
+    ⨅ i, f i = ⨅ i ∈ s, f ⟨i, ‹i ∈ s›⟩ :=
+  iInf_subtype
+
 lemma Equiv.biSup_comp {ι ι' : Type*} {g : ι' → α} (e : ι ≃ ι') (s : Set ι') :
     ⨆ i ∈ e.symm '' s, g (e i) = ⨆ i ∈ s, g i := by
   simpa only [iSup_subtype'] using (image e.symm s).symm.iSup_comp (g := g ∘ (↑))

--- a/Mathlib/Order/CompleteLattice/Finset.lean
+++ b/Mathlib/Order/CompleteLattice/Finset.lean
@@ -124,9 +124,11 @@ end minimal
 
 section Lattice
 
+@[deprecated "this now a syntactic equality" (since := "2026-01-26")]
 theorem iSup_coe [SupSet β] (f : α → β) (s : Finset α) : ⨆ x ∈ (↑s : Set α), f x = ⨆ x ∈ s, f x :=
   rfl
 
+@[deprecated "this now a syntactic equality" (since := "2026-01-26")]
 theorem iInf_coe [InfSet β] (f : α → β) (s : Finset α) : ⨅ x ∈ (↑s : Set α), f x = ⨅ x ∈ s, f x :=
   rfl
 
@@ -184,9 +186,11 @@ theorem iInf_biUnion (s : Finset γ) (t : γ → Finset α) (f : α → β) :
 
 end Lattice
 
+@[deprecated "this now a syntactic equality" (since := "2026-01-26")]
 theorem set_biUnion_coe (s : Finset α) (t : α → Set β) : ⋃ x ∈ (↑s : Set α), t x = ⋃ x ∈ s, t x :=
   rfl
 
+@[deprecated "this now a syntactic equality" (since := "2026-01-26")]
 theorem set_biInter_coe (s : Finset α) (t : α → Set β) : ⋂ x ∈ (↑s : Set α), t x = ⋂ x ∈ s, t x :=
   rfl
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -94,13 +94,11 @@ theorem Finset.ciInf_mem_image {s : Finset ι} (h : ∃ x ∈ s, f x ≤ sInf �
 theorem Set.Finite.ciSup_mem_image {s : Set ι} (hs : s.Finite) (h : ∃ x ∈ s, sSup ∅ ≤ f x) :
     ⨆ i ∈ s, f i ∈ f '' s := by
   lift s to Finset ι using hs
-  simp only [Finset.mem_coe] at h
   simpa using Finset.ciSup_mem_image f h
 
 theorem Set.Finite.ciInf_mem_image {s : Set ι} (hs : s.Finite) (h : ∃ x ∈ s, f x ≤ sInf ∅) :
     ⨅ i ∈ s, f i ∈ f '' s := by
   lift s to Finset ι using hs
-  simp only [Finset.mem_coe] at h
   simpa using Finset.ciInf_mem_image f h
 
 theorem Set.Finite.ciSup_lt_iff {s : Set ι} {f : ι → α} (hs : s.Finite)

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -569,16 +569,20 @@ section DecidableEq
 variable [DecidableEq α]
 
 @[simp]
-theorem Icc_erase_left (a b : α) : (Icc a b).erase a = Ioc a b := by simp [← coe_inj]
+theorem Icc_erase_left (a b : α) : (Icc a b).erase a = Ioc a b := by
+  rw [← coe_inj, coe_erase]; simp
 
 @[simp]
-theorem Icc_erase_right (a b : α) : (Icc a b).erase b = Ico a b := by simp [← coe_inj]
+theorem Icc_erase_right (a b : α) : (Icc a b).erase b = Ico a b := by
+  rw [← coe_inj, coe_erase]; simp
 
 @[simp]
-theorem Ico_erase_left (a b : α) : (Ico a b).erase a = Ioo a b := by simp [← coe_inj]
+theorem Ico_erase_left (a b : α) : (Ico a b).erase a = Ioo a b := by
+  rw [← coe_inj, coe_erase]; simp
 
 @[simp]
-theorem Ioc_erase_right (a b : α) : (Ioc a b).erase b = Ioo a b := by simp [← coe_inj]
+theorem Ioc_erase_right (a b : α) : (Ioc a b).erase b = Ioo a b := by
+  rw [← coe_inj, coe_erase]; simp
 
 @[simp]
 theorem Icc_diff_both (a b : α) : Icc a b \ {a, b} = Ioo a b := by simp [← coe_inj]

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -486,7 +486,7 @@ scoped[FinsetInterval] notation "[[" a ", " b "]]" => Finset.uIcc a b
 theorem mem_uIcc : x ∈ uIcc a b ↔ a ⊓ b ≤ x ∧ x ≤ a ⊔ b :=
   mem_Icc
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_uIcc (a b : α) : (Finset.uIcc a b : Set α) = Set.uIcc a b :=
   coe_Icc _ _
 

--- a/MathlibTest/set_like.lean
+++ b/MathlibTest/set_like.lean
@@ -14,7 +14,7 @@ variable {M : Type u} [Monoid M] (S S' : Submonoid M)
 /-- info: ↥S : Type u -/
 #guard_msgs in #check {x // x ∈ S}
 
-/-- info: { x // 1 * x ∈ S } : Type u -/
+/-- info: { x // 1 * x ∈ ↑S } : Type u -/
 #guard_msgs in #check {x // 1 * x ∈ S}
 
 end Delab


### PR DESCRIPTION
This PR is an attempt to change the underlying expression of `x ∈ s` when `s` is not a `Set α`, but a `SetLike`, such as `Finset α` or `Subgroup α`. Instead of having a `Membership` instance, we use the membership instance on `Set α`, combined with the coercion to `Set α`. This has various benefits
- There is now only one form instead of two to say the same thing. This saves us a lot of rewrites that will now become syntactic equalities.
- It is not needed anymore to create a `mem_` lemma for every single `coe_` lemma in order to maintain simp confluence

Unfortunately, doing this refactor is going to be a very big task, simply because so many proofs break as a result of `simp` now trying to simplify away the coercion where there was no coercion before.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
