### PR TITLE
feat: missing order instances for `Matrix`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Defs.lean
@@ -212,6 +212,15 @@ instance distribMulAction [Monoid R] [AddMonoid α] [DistribMulAction R α] :
 instance module [Semiring R] [AddCommMonoid α] [Module R α] : Module R (Matrix m n α) :=
   Pi.module _ _ _
 
+instance hasLE [LE α] : LE (Matrix m n α) :=
+  Pi.hasLe
+
+instance preorder [Preorder α] : Preorder (Matrix m n α) :=
+  Pi.preorder
+
+instance partialOrder [PartialOrder α] : PartialOrder (Matrix m n α) :=
+  Pi.partialOrder
+
 section
 
 @[simp]


### PR DESCRIPTION
Found when trying to formalise Theorem 11 from [Kozen's 1994 paper on Kleene algebras](https://www.cs.cornell.edu/~kozen/Papers/ka.pdf).