### PR TITLE
[Merged by Bors] - fix(CI): run leanchecker in mathlib4 repo for both master and nightly

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,12 +22,12 @@ permissions:
 
 jobs:
   check-leanchecker:
-    runs-on: ubuntu-latest  # lean4checker
-    if: github.repository == 'leanprover-community/mathlib4-nightly-testing'
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
     strategy:
       fail-fast: false
       matrix:
-        branch_type: [nightly] #[master, nightly]  # TODO: reactivate master when leanchecker has landed there
+        branch_type: [master, nightly]
     steps:
       # Checkout repository, so that we can fetch tags to decide which branch we want.
       - name: Checkout branch or tag
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch_type: [nightly]  # [master, nightly]
+        branch_type: [master, nightly]
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
This PR fixes the daily CI workflow for leanchecker.

The `check-leanchecker` job was configured to run only in `mathlib4-nightly-testing`, but the `notify-leanchecker` job runs in `mathlib4` and tries to query the job status from the current workflow run. Since the job was skipped in `mathlib4`, the notification produced broken Zulip messages with empty URLs (see https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/leanchecker.20failure/near/570212817).

This PR:
- Moves `check-leanchecker` to run in `mathlib4` (matching `check-nanoda` and `check-mathlib_test_executable`)
- Enables both `master` and `nightly` branches for leanchecker (the TODO comment indicated this was waiting for leanchecker to land on master)

🤖 Prepared with Claude Code