### PR TITLE
test: debugging mfderiv_smul erws

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -878,15 +878,43 @@ theorem MDifferentiableAt.const_smul (hf : MDifferentiableAt I 𝓘(𝕜, E') f 
 theorem MDifferentiable.const_smul (s : 𝕜) (hf : MDifferentiable I 𝓘(𝕜, E') f) :
     MDifferentiable I 𝓘(𝕜, E') (s • f) := fun x => (hf x).const_smul s
 
+-- this lemma produces an ungood goal state: left and right hand side naturally live in different tnagent spaces,
+-- is only correct semi-reducibly.
 theorem const_smul_mfderiv (hf : MDifferentiableAt I 𝓘(𝕜, E') f z) (s : 𝕜) :
     (mfderiv I 𝓘(𝕜, E') (s • f) z : TangentSpace I z →L[𝕜] E') =
       (s • mfderiv I 𝓘(𝕜, E') f z : TangentSpace I z →L[𝕜] E') :=
   (hf.hasMFDerivAt.const_smul s).mfderiv
+-- TODO: replace and inline this lemma! and rename to the name below
 
+-- systematische, aber nervige Lösung
+-- T_xM → T_yM given a proof x = y (namely, the identity map);
+-- make TangentSpace irreducible
+-- but: this happens everywhere, hm! Floris is not sure if we want this;
+-- has added many lemmas using this identification!
+-- most computational lemmas use such identification... will be cumbersome...
+
+-- this lemma has the same issue...
 lemma mfderiv_const_smul {x : M} (a : 𝕜) (v : TangentSpace I x) :
     mfderiv I 𝓘(𝕜, E') (a • f) x v = a • mfderiv I 𝓘(𝕜, E') f x v := by
   by_cases hs : MDifferentiableAt I 𝓘(𝕜, E') f x
-  · rw [const_smul_mfderiv hs]; rfl
+  · rw [const_smul_mfderiv hs]
+
+    --have := true
+    -- erw? does nothing now, oops!
+    -- message is strange LHS meantions a • f, is on previous line
+    -- missing withMainContext in erw?
+    --set_option pp.explicit true in
+    --refine (ContinuousLinearMap.smul_apply a (mfderiv I 𝓘(𝕜, E') f x) v).trans ?_
+    --with_reducible rfl
+    --#guard_msgs in
+    /-
+    Tactic `rewrite` failed: Did not find an occurrence of the pattern
+  (a • mfderiv I 𝓘(𝕜, E') f x) v
+in the target expression
+  (a • mfderiv I 𝓘(𝕜, E') f x) v = a • (mfderiv I 𝓘(𝕜, E') f x) v
+    -/
+    --rw [ContinuousLinearMap.smul_apply a (mfderiv I 𝓘(𝕜, E') f x) v]
+    --; rfl
   · by_cases ha : a = 0
     · have : a • f = 0 := by ext; simp [ha]
       have aux : (fun _ ↦ 0 : M → E') = 0 := by rfl

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -883,6 +883,21 @@ theorem const_smul_mfderiv (hf : MDifferentiableAt I 𝓘(𝕜, E') f z) (s : �
       (s • mfderiv I 𝓘(𝕜, E') f z : TangentSpace I z →L[𝕜] E') :=
   (hf.hasMFDerivAt.const_smul s).mfderiv
 
+lemma mfderiv_const_smul {x : M} (a : 𝕜) (v : TangentSpace I x) :
+    mfderiv I 𝓘(𝕜, E') (a • f) x v = a • mfderiv I 𝓘(𝕜, E') f x v := by
+  by_cases hs : MDifferentiableAt I 𝓘(𝕜, E') f x
+  · rw [const_smul_mfderiv hs]; rfl
+  · by_cases ha : a = 0
+    · have : a • f = 0 := by ext; simp [ha]
+      have aux : (fun _ ↦ 0 : M → E') = 0 := by rfl
+      rw [this, ha, ← aux]
+      simp
+    have hs' : ¬ MDifferentiableAt I 𝓘(𝕜, E') (a • f) x :=
+      fun h ↦ hs (by simpa [ha] using h.const_smul a⁻¹)
+    rw [mfderiv_zero_of_not_mdifferentiableAt hs, mfderiv_zero_of_not_mdifferentiableAt hs']
+    simp
+    rfl
+
 theorem HasMFDerivWithinAt.neg {s : Set M} (hf : HasMFDerivWithinAt I 𝓘(𝕜, E') f s z f') :
     HasMFDerivWithinAt I 𝓘(𝕜, E') (-f) s z (-f') :=
   ⟨hf.1.neg, hf.2.neg⟩


### PR DESCRIPTION
Not meant for landing.

---

- [ ] depends on: #34262

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
