### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Connectivity): add lemma `not_reachable_of_{left, right}_degree_zero`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -183,20 +183,18 @@ lemma Reachable.of_subsingleton {G : SimpleGraph V} [Subsingleton V] {u v : V} :
     G.Reachable u v := by
   rw [Subsingleton.allEq u v]
 
-lemma not_reachable_of_degree_zero {V : Type*} {G : SimpleGraph V} {u v : V}
-    (huv : u ≠ v) [Fintype (G.neighborSet u)] (hu : G.degree u = 0) :
-    ¬G.Reachable u v := by
+lemma not_reachable_of_left_degree_zero {G : SimpleGraph V} {u v : V} [Fintype (G.neighborSet u)]
+    (huv : u ≠ v) (hu : G.degree u = 0) : ¬G.Reachable u v := by
   rintro ⟨_ | @⟨u, x, v, hadj, w'⟩⟩
   · contradiction
   · have : 0 < G.degree u := (G.degree_pos_iff_exists_adj u).mpr ⟨x, hadj⟩
     rw [hu] at this
     contradiction
 
-lemma not_reachable_of_degree_zero' {V : Type*} {G : SimpleGraph V} {u v : V}
-    (huv : u ≠ v) [Fintype (G.neighborSet v)] (hu : G.degree v = 0) :
-    ¬G.Reachable u v := by
+lemma not_reachable_of_right_degree_zero {G : SimpleGraph V} {u v : V} [Fintype (G.neighborSet v)]
+    (huv : u ≠ v) (hu : G.degree v = 0) : ¬G.Reachable u v := by
   rw [reachable_comm]
-  exact not_reachable_of_degree_zero huv.symm hu
+  exact not_reachable_of_left_degree_zero huv.symm hu
 
 /-- The equivalence relation on vertices given by `SimpleGraph.Reachable`. -/
 def reachableSetoid : Setoid V := Setoid.mk _ G.reachable_is_equivalence

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -183,6 +183,21 @@ lemma Reachable.of_subsingleton {G : SimpleGraph V} [Subsingleton V] {u v : V} :
     G.Reachable u v := by
   rw [Subsingleton.allEq u v]
 
+lemma not_reachable_of_degree_zero {V : Type*} {G : SimpleGraph V} {u v : V}
+    (huv : u ≠ v) [Fintype (G.neighborSet u)] (hu : G.degree u = 0) :
+    ¬G.Reachable u v := by
+  rintro ⟨_ | @⟨u, x, v, hadj, w'⟩⟩
+  · contradiction
+  · have : 0 < G.degree u := (G.degree_pos_iff_exists_adj u).mpr ⟨x, hadj⟩
+    rw [hu] at this
+    contradiction
+
+lemma not_reachable_of_degree_zero' {V : Type*} {G : SimpleGraph V} {u v : V}
+    (huv : u ≠ v) [Fintype (G.neighborSet v)] (hu : G.degree v = 0) :
+    ¬G.Reachable u v := by
+  rw [reachable_comm]
+  exact not_reachable_of_degree_zero huv.symm hu
+
 /-- The equivalence relation on vertices given by `SimpleGraph.Reachable`. -/
 def reachableSetoid : Setoid V := Setoid.mk _ G.reachable_is_equivalence
 


### PR DESCRIPTION
---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
