### PR TITLE
[Merged by Bors] - ci: Tidy up CI after investigation

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -541,7 +541,7 @@ jobs:
         shell: bash
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+          if pgrep -af runLinter; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -495,20 +495,6 @@ jobs:
       #   run: |
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: kill stray runLinter processes
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "Killing runLinter processes..."
-            pkill -f runLinter || true
-          else
-            echo "No stray runLinter processes found."
-          fi
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -519,7 +505,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 10m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}
@@ -541,19 +527,26 @@ jobs:
             if [ "$status" -eq 124 ]; then
               echo "runLinter timed out (attempt $attempt)."
               if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
                 echo "Retrying runLinter after timeout..."
                 continue
               fi
             fi
             exit $status
           done
+
+      # We need to separate this step from the previous script because it needs to run outside of landrun
+      - name: kill stray runLinter processes
+        if: ${{ steps.lint.outcome == 'failure' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
@@ -577,15 +570,6 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
-          fi
-
-      - name: list stray runLinter processes
-        shell: bash
-        if: always()
-        run: |
-          echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -505,20 +505,6 @@ jobs:
       #   run: |
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: kill stray runLinter processes
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "Killing runLinter processes..."
-            pkill -f runLinter || true
-          else
-            echo "No stray runLinter processes found."
-          fi
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -529,7 +515,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 10m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}
@@ -551,19 +537,26 @@ jobs:
             if [ "$status" -eq 124 ]; then
               echo "runLinter timed out (attempt $attempt)."
               if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
                 echo "Retrying runLinter after timeout..."
                 continue
               fi
             fi
             exit $status
           done
+
+      # We need to separate this step from the previous script because it needs to run outside of landrun
+      - name: kill stray runLinter processes
+        if: ${{ steps.lint.outcome == 'failure' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
@@ -587,15 +580,6 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
-          fi
-
-      - name: list stray runLinter processes
-        shell: bash
-        if: always()
-        run: |
-          echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -551,7 +551,7 @@ jobs:
         shell: bash
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+          if pgrep -af runLinter; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,7 @@ jobs:
         shell: bash
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+          if pgrep -af runLinter; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,20 +511,6 @@ jobs:
       #   run: |
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: kill stray runLinter processes
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "Killing runLinter processes..."
-            pkill -f runLinter || true
-          else
-            echo "No stray runLinter processes found."
-          fi
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -535,7 +521,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 10m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}
@@ -557,19 +543,26 @@ jobs:
             if [ "$status" -eq 124 ]; then
               echo "runLinter timed out (attempt $attempt)."
               if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
                 echo "Retrying runLinter after timeout..."
                 continue
               fi
             fi
             exit $status
           done
+
+      # We need to separate this step from the previous script because it needs to run outside of landrun
+      - name: kill stray runLinter processes
+        if: ${{ steps.lint.outcome == 'failure' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
@@ -593,15 +586,6 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
-          fi
-
-      - name: list stray runLinter processes
-        shell: bash
-        if: always()
-        run: |
-          echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -555,7 +555,7 @@ jobs:
         shell: bash
         run: |
           echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+          if pgrep -af runLinter; then
             echo "Killing runLinter processes..."
             pkill -f runLinter || true
           else

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -509,20 +509,6 @@ jobs:
       #   run: |
       #     cd pr-branch
       #     env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: kill stray runLinter processes
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "Checking for runLinter processes..."
-          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "Killing runLinter processes..."
-            pkill -f runLinter || true
-          else
-            echo "No stray runLinter processes found."
-          fi
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -533,7 +519,7 @@ jobs:
           # Try running with --trace; if it fails due to argument parsing, the PR needs to merge master
           # We use .lake/ for the output file because landrun restricts /tmp access
           for attempt in 1 2; do
-            if timeout 15m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
+            if timeout 10m env LEAN_ABORT_ON_PANIC=1 stdbuf -oL lake exe runLinter --trace Mathlib 2>&1 | tee ".lake/lint_output_attempt_${attempt}.txt"; then
               break
             fi
             status=${PIPESTATUS[0]}
@@ -555,19 +541,26 @@ jobs:
             if [ "$status" -eq 124 ]; then
               echo "runLinter timed out (attempt $attempt)."
               if [ "$attempt" -lt 2 ]; then
-                echo "Checking for runLinter processes..."
-                if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-                  echo "Killing runLinter processes..."
-                  pkill -f runLinter || true
-                else
-                  echo "No stray runLinter processes found."
-                fi
                 echo "Retrying runLinter after timeout..."
                 continue
               fi
             fi
             exit $status
           done
+
+      # We need to separate this step from the previous script because it needs to run outside of landrun
+      - name: kill stray runLinter processes
+        if: ${{ steps.lint.outcome == 'failure' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "Checking for runLinter processes..."
+          if ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
+            echo "Killing runLinter processes..."
+            pkill -f runLinter || true
+          else
+            echo "No stray runLinter processes found."
+          fi
 
       - name: end gh-problem-match-wrap for shake and lint steps
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
@@ -591,15 +584,6 @@ jobs:
           then
             printf $'%s\n' "${buildMsgs}"
             exit 1
-          fi
-
-      - name: list stray runLinter processes
-        shell: bash
-        if: always()
-        run: |
-          echo "Checking for runLinter processes..."
-          if ! ps -eo pid,lstart,command | grep -F runLinter | grep -v grep; then
-            echo "No stray runLinter processes found."
           fi
 
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches


### PR DESCRIPTION
Clean up some steps now that we're done with the runLinter hang investigation. We should keep the retry+timeout+kill for the sake of forks (but down to 10min because we know the step shouldn't take more than 5).