### PR TITLE
[Merged by Bors] - feat: an additive content on a semiring of sets extends to the generated ring of sets

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -227,12 +227,12 @@ theorem sum_addContent_eq_of_sUnion_eq (hC : IsSetSemiring C) (J J' : Finset (Se
 open scoped Classical in
 /-- Extend a content over `C` to the finite unions of elements of `C` by additivity.
 Use instead `AddContent.supClosure` which is the same function bundled as an `AddContent`. -/
-noncomputable def AddContent.supClosureFun (m : AddContent G C) (s : Set α) : G :=
+private noncomputable def AddContent.supClosureFun (m : AddContent G C) (s : Set α) : G :=
   if h : ∃ (J : Finset (Set α)), ↑J ⊆ C ∧ (PairwiseDisjoint (J : Set (Set α)) id) ∧ s = ⋃₀ ↑J
     then ∑ s ∈ h.choose, m s
   else 0
 
-lemma AddContent.supClosureFun_apply (hC : IsSetSemiring C)
+private lemma AddContent.supClosureFun_apply (hC : IsSetSemiring C)
     (m : AddContent G C) {s : Set α} {J : Finset (Set α)}
     (hJ : ↑J ⊆ C) (h'J : PairwiseDisjoint (J : Set (Set α)) id) (hs : s = ⋃₀ ↑J) :
     m.supClosureFun s = ∑ s ∈ J, m s := by
@@ -243,7 +243,7 @@ lemma AddContent.supClosureFun_apply (hC : IsSetSemiring C)
   rw [← hs]
   exact h.choose_spec.2.2.symm
 
-lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
+private lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
     (m : AddContent G C) {s : Set α} (hs : s ∈ C) :
     m.supClosureFun s = m s := by
   have : m.supClosureFun s = ∑ t ∈ {s}, m t :=
@@ -251,7 +251,7 @@ lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
   simp [this]
 
 /-- Extend a content over `C` to the finite unions of elements of `C` by additivity. -/
-noncomputable def AddContent.supClosure (m : AddContent G C) (hC : IsSetSemiring C) :
+@[no_expose] noncomputable def AddContent.supClosure (m : AddContent G C) (hC : IsSetSemiring C) :
     AddContent G (supClosure C) where
   toFun := m.supClosureFun
   empty' := by rw [m.supClosureFun_apply_of_mem hC hC.empty_mem, addContent_empty]
@@ -290,8 +290,8 @@ noncomputable def AddContent.supClosure (m : AddContent G C) (hC : IsSetSemiring
         exact this.mono (H hi hk.1) (H hj hk.2)
       simp only [disjoint_self, Set.bot_eq_empty] at this
       simp [this]
-    apply Finset.sum_congr rfl (fun i hi ↦ ?_)
-    exact (m.supClosureFun_apply hC (hJC i hi) (hJdisj i hi) (hJs i hi)).symm
+    apply Finset.sum_congr rfl (fun i hi ↦ Eq.symm ?_)
+    exact m.supClosureFun_apply hC (hJC i hi) (hJdisj i hi) (hJs i hi)
 
 lemma AddContent.supClosure_apply (hC : IsSetSemiring C)
     (m : AddContent G C) {s : Set α} {J : Finset (Set α)}

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -272,13 +272,10 @@ private lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
     have : ⋃₀ ↑I = ⋃₀ (↑K : Set (Set α)) := by
       simp [K, sUnion_eq_biUnion] at hJs ⊢; grind
     rw [this, m.supClosureFun_apply hC (J := K) (by simpa [K] using hJC) _ rfl]; swap
-    · intro a ha b hb hab
-      simp only [coe_biUnion, SetLike.mem_coe, mem_iUnion, exists_prop, K] at ha hb
-      rcases ha with ⟨i, iI, hi⟩
-      rcases hb with ⟨j, jI, hj⟩
-      rcases eq_or_ne i j with rfl | hij
-      · exact hJdisj i iI hi hj hab
-      · exact (h'I iI jI hij).mono (H iI hi) (H jI hj)
+    · simp only [K, coe_biUnion]
+      refine (h'I.mono_on ?_).biUnion hJdisj
+      simp
+      grind
     simp only [K]
     rw [sum_biUnion_of_pairwise_eq_zero]; swap
     · intro i hi j hj hij k hk

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -112,11 +112,8 @@ lemma addContent_biUnion {ι : Type*} {a : Finset ι} {f : ι → Set α} (hf : 
   have A : ⋃ i ∈ a, f i = ⋃₀ b := by simp [b]
   rw [A, addContent_sUnion]; rotate_left
   · simp [b]; grind
-  · intro s hs t ht hst
-    simp only [coe_image, Set.mem_image, SetLike.mem_coe, b] at hs ht
-    rcases hs with ⟨i, hi, rfl⟩
-    rcases ht with ⟨j, hj, rfl⟩
-    exact h_dis hi hj (by grind)
+  · rw [Finset.coe_image]
+    exact h_dis.image
   · rwa [← A]
   simp only [b]
   rw [sum_image_of_pairwise_eq_zero]

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -108,14 +108,12 @@ lemma addContent_biUnion {ι : Type*} {a : Finset ι} {f : ι → Set α} (hf : 
     (h_dis : PairwiseDisjoint ↑a f) (h_mem : ⋃ i ∈ a, f i ∈ C) :
     m (⋃ i ∈ a, f i) = ∑ i ∈ a, m (f i) := by
   classical
-  let b : Finset (Set α) := Finset.image f a
-  have A : ⋃ i ∈ a, f i = ⋃₀ b := by simp [b]
+  have A : ⋃ i ∈ a, f i = ⋃₀ (a.image f) := by simp
   rw [A, addContent_sUnion]; rotate_left
-  · simp [b]; grind
+  · grind
   · rw [Finset.coe_image]
     exact h_dis.image
   · rwa [← A]
-  simp only [b]
   rw [sum_image_of_pairwise_eq_zero]
   intro i hi j hj hij h'ij
   have : Disjoint (f i) (f j) := h_dis hi hj hij

--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -112,14 +112,11 @@ lemma addContent_biUnion {ι : Type*} {a : Finset ι} {f : ι → Set α} (hf : 
   have A : ⋃ i ∈ a, f i = ⋃₀ (a.image f) := by simp
   rw [A, addContent_sUnion]; rotate_left
   · grind
-  · rw [Finset.coe_image]
-    exact h_dis.image
+  · simpa using h_dis.image
   · rwa [← A]
   rw [sum_image_of_pairwise_eq_zero]
-  intro i hi j hj hij h'ij
-  have : Disjoint (f i) (f j) := h_dis hi hj hij
-  simp only [← h'ij, disjoint_self, Set.bot_eq_empty] at this
-  simp [this]
+  refine h_dis.imp ?_
+  grind [Set.bot_eq_empty (α := α), addContent_empty]
 
 lemma addContent_iUnion {ι : Type*} [Fintype ι] {f : ι → Set α} (hf : ∀ i, f i ∈ C)
     (h_dis : Pairwise (Disjoint on f)) (h_mem : ⋃ i, f i ∈ C) :
@@ -185,40 +182,30 @@ In other words, `m` can be canonically extended to finite unions of elements of 
 theorem sum_addContent_eq_of_sUnion_eq (hC : IsSetSemiring C) (J J' : Finset (Set α))
     (hJ : ↑J ⊆ C) (hJdisj : PairwiseDisjoint (J : Set (Set α)) id)
     (hJ' : ↑J' ⊆ C) (hJ'disj : PairwiseDisjoint (J' : Set (Set α)) id)
-    (h : ⋃₀ (↑J : Set (Set α)) = ⋃₀ ↑J') :
+    (h : ⋃₀ (J : Set (Set α)) = ⋃₀ J') :
     ∑ s ∈ J, m s = ∑ t ∈ J', m t := by
   calc ∑ s ∈ J, m s
   _ = ∑ s ∈ J, (∑ t ∈ J', m (s ∩ t)) := by
     apply Finset.sum_congr rfl (fun s hs ↦ ?_)
     have : s = ⋃ t ∈ J', s ∩ t := by
-      apply Set.Subset.antisymm _ (by simp)
-      intro x hx
-      have A : x ∈ ⋃₀ ↑J' := by
-        rw [← h]
-        simp only [mem_sUnion, SetLike.mem_coe]
-        exact ⟨s, hs, hx⟩
-      simpa [mem_iUnion, mem_inter_iff, exists_and_left, exists_prop, hx] using A
+      simp_rw [← Finset.set_biUnion_coe, ← inter_iUnion, left_eq_inter, ← sUnion_eq_biUnion, ← h]
+      exact subset_sUnion_of_mem hs
     nth_rewrite 1 [this]
     apply addContent_biUnion
     · exact fun t ht ↦ hC.inter_mem _ (hJ hs) _ (hJ' ht)
-    · exact fun i hi j hj hij ↦ (hJ'disj hi hj hij).mono (by simp) (by simp)
+    · exact hJ'disj.mono fun _ ↦ by simp
     · rw [← this]
       exact hJ hs
   _ = ∑ t ∈ J', (∑ s ∈ J, m (s ∩ t)) := sum_comm
   _ = ∑ t ∈ J', m t := by
     apply Finset.sum_congr rfl (fun t ht ↦ ?_)
     have : t = ⋃ s ∈ J, s ∩ t := by
-      apply Set.Subset.antisymm _ (by simp)
-      intro x hx
-      have A : x ∈ ⋃₀ ↑J := by
-        rw [h]
-        simp only [mem_sUnion, SetLike.mem_coe]
-        exact ⟨t, ht, hx⟩
-      simpa [mem_iUnion, mem_inter_iff, exists_and_left, exists_prop, hx] using A
+      simp_rw [← Finset.set_biUnion_coe, ← iUnion_inter, right_eq_inter, ← sUnion_eq_biUnion, h]
+      exact subset_sUnion_of_mem ht
     nth_rewrite 2 [this]
     apply (addContent_biUnion _ _ _).symm
     · exact fun s hs ↦ hC.inter_mem _ (hJ hs) _ (hJ' ht)
-    · exact fun i hi j hj hij ↦ (hJdisj hi hj hij).mono (by simp) (by simp)
+    · exact hJdisj.mono fun _ ↦ by simp
     · rw [← this]
       exact hJ' ht
 
@@ -266,8 +253,7 @@ private lemma AddContent.supClosureFun_apply_of_mem (hC : IsSetSemiring C)
     choose! J hJC hJdisj hJs using A
     have H {a i} (hi : i ∈ I) (ha : a ∈ J i) : a ⊆ i := by
       rw [hJs i hi]
-      simp only [sUnion_eq_biUnion, SetLike.mem_coe]
-      exact Set.subset_biUnion_of_mem (u := id) ha
+      exact subset_sUnion_of_mem ha
     let K : Finset (Set α) := Finset.biUnion I J
     have : ⋃₀ ↑I = ⋃₀ (↑K : Set (Set α)) := by
       simp [K, sUnion_eq_biUnion] at hJs ⊢; grind


### PR DESCRIPTION
Needed for #34055.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
