### PR TITLE
[Merged by Bors] - chore: allow PR authors to set topic labels via comments

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Add / remove label based on comment
       run: |
-        labelArray=("awaiting-author" "WIP" "easy" "brownian" "carleson" "CFT" "FLT" "sphere-packing" "toric")
+        labelArray=("awaiting-author" "WIP" "easy" "brownian" "carleson" "CFT" "FLT" "sphere-packing" "toric" "t-algebra" "t-algebraic-geometry" "t-algebraic-topology" "t-analysis" "t-category-theory" "t-combinatorics" "t-computability" "t-condensed" "t-convex-geometry" "t-data" "t-differential-geometry" "t-dynamics" "t-euclidean-geometry" "t-geometric-group-theory" "t-group-theory" "t-linter" "t-logic" "t-measure-probability" "t-meta" "t-number-theory" "t-order" "t-ring-theory" "t-set-theory" "t-topology")
 
         # we strip `\r` since line endings from GitHub contain this character
         COMMENT="${COMMENT//$'\r'/}"


### PR DESCRIPTION
This PR adds all topic labels (`t-*`) to the comment-to-label workflow, allowing PR authors to manually add or remove topic labels by commenting on their PRs.

Currently, PR authors cannot manage labels themselves (they need triage access), but topic labels are automatically applied by the `lake exe autolabel` workflow based on the diff. This PR enables manual override when the auto-labeling is incorrect or incomplete.

## Usage

Authors can now comment with lines like:
- `t-algebra` to add the label
- `-t-algebra` to remove the label

## Context

This addresses the issue discussed in https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/auto-label/near/570347828, where it was noted that PR authors should be able to pick topic labels themselves, especially since many PRs end up with no labels at all.

This follows the pattern established in https://github.com/leanprover-community/mathlib4/pull/34296, which added project-specific labels to the comment-to-label system.

🤖 Prepared with Claude Code