### PR TITLE
[Merged by Bors] - doc(Order/Defs/PartialOrder): clarify definition of `<` in `Preorder` 

### DIFF
--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -42,8 +42,7 @@ section Preorder
 
 /--
 A preorder is a reflexive, transitive relation `≤`.
-We also say `Preorder`s must have a `<` relation
-where `a < b` is equivalent to `a ≤ b ∧ ¬b ≤ a`.
+A preorder defines a `<` relation given by `a ≤ b ∧ ¬b ≤ a`.
 -/
 class Preorder (α : Type*) extends LE α, LT α where
   protected le_refl : ∀ a : α, a ≤ a

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -42,7 +42,8 @@ section Preorder
 
 /--
 A preorder is a reflexive, transitive relation `≤`.
-A preorder defines a `<` relation given by `a ≤ b ∧ ¬b ≤ a`.
+A preorder defines a `<` given `a ≤ b ∧ ¬b ≤ a` and defined this way by default.
+You can override this definition to set a better def-eq.
 -/
 class Preorder (α : Type*) extends LE α, LT α where
   protected le_refl : ∀ a : α, a ≤ a

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -42,7 +42,7 @@ section Preorder
 
 /--
 A preorder is a reflexive, transitive relation `≤`.
-A preorder defines a `<` given `a ≤ b ∧ ¬b ≤ a` and defined this way by default.
+In a preorder, `a < b` means `a ≤ b ∧ ¬b ≤ a`, and `<` is defined this way by default.
 You can override this definition to set a better def-eq.
 -/
 class Preorder (α : Type*) extends LE α, LT α where

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -42,7 +42,8 @@ section Preorder
 
 /--
 A preorder is a reflexive, transitive relation `≤`.
-We define `a < b` directly from `≤` as `a ≤ b ∧ ¬b ≤ a`.
+We also say `Preorder`s must have a `<` relation
+where `a < b` is equivalent to `a ≤ b ∧ ¬b ≤ a`.
 -/
 class Preorder (α : Type*) extends LE α, LT α where
   protected le_refl : ∀ a : α, a ≤ a

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -40,7 +40,10 @@ section Preorder
 ### Definition of `Preorder` and lemmas about types with a `Preorder`
 -/
 
-/-- A preorder is a reflexive, transitive relation `≤` with `a < b` defined in the obvious way. -/
+/--
+A preorder is a reflexive, transitive relation `≤`.
+We define `a < b` directly from `≤` as `a ≤ b ∧ ¬b ≤ a`.
+-/
 class Preorder (α : Type*) extends LE α, LT α where
   protected le_refl : ∀ a : α, a ≤ a
   protected le_trans : ∀ a b c : α, a ≤ b → b ≤ c → a ≤ c


### PR DESCRIPTION
Per [this](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Preorder.20.2F.20PartialOrder.20synthesised.20.3C/with/570466143) Zulip discussion, some people feel this documentation could be improved, so I am changing this to make clear what the definition is for `<`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
