### PR TITLE
[Merged by Bors] - feat(MeasureTheory): add MeasurableEmbedding.map_injective

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Map.lean
+++ b/Mathlib/MeasureTheory/Measure/Map.lean
@@ -284,8 +284,7 @@ nonrec theorem map_apply (hf : MeasurableEmbedding f) (μ : Measure α) (s : Set
 theorem map_injective (hf : MeasurableEmbedding f) : Function.Injective (Measure.map f) := by
   intro μ ν h
   ext s hs
-  rw [← Set.preimage_image_eq s hf.injective]
-  rw [← hf.map_apply, ← hf.map_apply]
+  rw [← Set.preimage_image_eq s hf.injective, ← hf.map_apply, ← hf.map_apply]
   congr
 
 end MeasurableEmbedding

--- a/Mathlib/MeasureTheory/Measure/Map.lean
+++ b/Mathlib/MeasureTheory/Measure/Map.lean
@@ -281,6 +281,13 @@ nonrec theorem map_apply (hf : MeasurableEmbedding f) (μ : Measure α) (s : Set
     μ.map f s ≤ μ.map f t := by gcongr
     _ = μ (f ⁻¹' s) := by rw [map_apply hf.measurable htm, hft, measure_toMeasurable]
 
+theorem map_injective (hf : MeasurableEmbedding f) : Function.Injective (Measure.map f) := by
+  intro μ ν h
+  ext s hs
+  rw [← Set.preimage_image_eq s hf.injective]
+  rw [← hf.map_apply, ← hf.map_apply]
+  congr
+
 end MeasurableEmbedding
 
 namespace MeasurableEquiv


### PR DESCRIPTION
This adds a lemma showing that `Measure.map f` is injective when `f` is a `MeasurableEmbedding`.

This is useful for pulling back measure equalities, e.g., simplifying proofs in #34435.