### PR TITLE
[Merged by Bors] - feat(Analysis/Analytic, Analysis/Calculus): allow more general types in SMul

### DIFF
--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -34,8 +34,8 @@ variable {E F G H : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAd
   [NormedSpace 𝕜 F] [NormedAddCommGroup G] [NormedSpace 𝕜 G] [NormedAddCommGroup H]
   [NormedSpace 𝕜 H]
 
-variable {𝕝 : Type*} [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝]
 variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
+variable {𝕝 : Type*} [NormedDivisionRing 𝕝] [NormedAlgebra 𝕜 𝕝]
 
 /-!
 ### Constants are analytic
@@ -70,7 +70,7 @@ theorem analyticOn_const {v : F} {s : Set E} : AnalyticOn 𝕜 (fun _ => v) s :=
 section
 
 variable {f g : E → F} {pf pg : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞}
-  {c : 𝕜}
+  {R : Type*} [NormedRing R] [Module R F] [IsBoundedSMul R F] [SMulCommClass 𝕜 R F] {c : R}
 
 theorem HasFPowerSeriesWithinOnBall.add (hf : HasFPowerSeriesWithinOnBall f pf s x r)
     (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
@@ -108,6 +108,14 @@ theorem AnalyticAt.add (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
   let ⟨_, hpf⟩ := hf
   let ⟨_, hqf⟩ := hg
   (hpf.add hqf).analyticAt
+
+theorem AnalyticOn.add (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
+    AnalyticOn 𝕜 (f + g) s :=
+  fun z hz => (hf z hz).add (hg z hz)
+
+theorem AnalyticOnNhd.add (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
+    AnalyticOnNhd 𝕜 (f + g) s :=
+  fun z hz => (hf z hz).add (hg z hz)
 
 theorem HasFPowerSeriesWithinOnBall.neg (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
     HasFPowerSeriesWithinOnBall (-f) (-pf) s x r :=
@@ -147,6 +155,12 @@ theorem AnalyticAt.neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (-f) x :=
   mp hf := by simpa using hf.neg
   mpr := .neg
 
+theorem AnalyticOn.neg (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (-f) s :=
+  fun z hz ↦ (hf z hz).neg
+
+theorem AnalyticOnNhd.neg (hf : AnalyticOnNhd 𝕜 f s) : AnalyticOnNhd 𝕜 (-f) s :=
+  fun z hz ↦ (hf z hz).neg
+
 theorem HasFPowerSeriesWithinOnBall.sub (hf : HasFPowerSeriesWithinOnBall f pf s x r)
     (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
     HasFPowerSeriesWithinOnBall (f - g) (pf - pg) s x r := by
@@ -173,6 +187,14 @@ theorem AnalyticWithinAt.sub (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWi
 theorem AnalyticAt.sub (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
     AnalyticAt 𝕜 (f - g) x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem AnalyticOn.sub (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
+    AnalyticOn 𝕜 (f - g) s :=
+  fun z hz => (hf z hz).sub (hg z hz)
+
+theorem AnalyticOnNhd.sub (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
+    AnalyticOnNhd 𝕜 (f - g) s :=
+  fun z hz => (hf z hz).sub (hg z hz)
 
 theorem HasFPowerSeriesWithinOnBall.const_smul (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
     HasFPowerSeriesWithinOnBall (c • f) (c • pf) s x r where
@@ -206,27 +228,30 @@ theorem AnalyticAt.const_smul (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (c �
   let ⟨_, hpf⟩ := hf
   hpf.const_smul.analyticAt
 
-theorem AnalyticOn.add (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
-    AnalyticOn 𝕜 (f + g) s :=
-  fun z hz => (hf z hz).add (hg z hz)
+@[to_fun]
+theorem AnalyticOn.const_smul (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (c • f) s :=
+  fun x hx ↦ (hf x hx).const_smul
 
-theorem AnalyticOnNhd.add (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
-    AnalyticOnNhd 𝕜 (f + g) s :=
-  fun z hz => (hf z hz).add (hg z hz)
+@[to_fun]
+theorem AnalyticOnNhd.const_smul (hf : AnalyticOnNhd 𝕜 f s) : AnalyticOnNhd 𝕜 (c • f) s :=
+  fun x hx ↦ (hf x hx).const_smul
 
-theorem AnalyticOn.neg (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (-f) s :=
-  fun z hz ↦ (hf z hz).neg
+lemma AnalyticWithinAt.div_const {f : E → 𝕝} (hf : AnalyticWithinAt 𝕜 f s x) {c : 𝕝} :
+    AnalyticWithinAt 𝕜 (f · / c) s x := by
+  simpa [div_eq_mul_inv] using hf.const_smul (R := 𝕝ᵐᵒᵖ)
 
-theorem AnalyticOnNhd.neg (hf : AnalyticOnNhd 𝕜 f s) : AnalyticOnNhd 𝕜 (-f) s :=
-  fun z hz ↦ (hf z hz).neg
+@[fun_prop]
+lemma AnalyticAt.div_const {f : E → 𝕝} (hf : AnalyticAt 𝕜 f x) {c : 𝕝} :
+    AnalyticAt 𝕜 (f · / c) x := by
+  simpa [div_eq_mul_inv] using hf.const_smul (R := 𝕝ᵐᵒᵖ)
 
-theorem AnalyticOn.sub (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
-    AnalyticOn 𝕜 (f - g) s :=
-  fun z hz => (hf z hz).sub (hg z hz)
+lemma AnalyticOn.div_const {f : E → 𝕝} (hf : AnalyticOn 𝕜 f s) {c : 𝕝} :
+    AnalyticOn 𝕜 (f · / c) s := by
+  simpa [div_eq_mul_inv] using hf.const_smul (R := 𝕝ᵐᵒᵖ)
 
-theorem AnalyticOnNhd.sub (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
-    AnalyticOnNhd 𝕜 (f - g) s :=
-  fun z hz => (hf z hz).sub (hg z hz)
+lemma AnalyticOnNhd.div_const {f : E → 𝕝} (hf : AnalyticOnNhd 𝕜 f s) {c : 𝕝} :
+    AnalyticOnNhd 𝕜 (f · / c) s := by
+  simpa [div_eq_mul_inv] using hf.const_smul (R := 𝕝ᵐᵒᵖ)
 
 end
 
@@ -565,44 +590,41 @@ end
 -/
 
 /-- Scalar multiplication is analytic (jointly in both variables). The statement is a little
-pedantic to allow towers of field extensions.
-
-TODO: can we replace `𝕜'` with a "normed module" in such a way that `analyticAt_mul` is a special
-case of this? -/
+pedantic to allow towers of field extensions. -/
 @[fun_prop]
-lemma analyticAt_smul [NormedSpace 𝕝 E] [IsScalarTower 𝕜 𝕝 E] (z : 𝕝 × E) :
-    AnalyticAt 𝕜 (fun x : 𝕝 × E ↦ x.1 • x.2) z :=
-  (ContinuousLinearMap.lsmul 𝕜 𝕝).analyticAt_bilinear z
+lemma analyticAt_smul [Module A E] [IsBoundedSMul A E] [IsScalarTower 𝕜 A E] (z : A × E) :
+    AnalyticAt 𝕜 (fun x : A × E ↦ x.1 • x.2) z :=
+  (ContinuousLinearMap.lsmul 𝕜 A).analyticAt_bilinear z
 
 /-- Multiplication in a normed algebra over `𝕜` is analytic. -/
 @[fun_prop]
 lemma analyticAt_mul (z : A × A) : AnalyticAt 𝕜 (fun x : A × A ↦ x.1 * x.2) z :=
-  (ContinuousLinearMap.mul 𝕜 A).analyticAt_bilinear z
+  analyticAt_smul z
 
 /-- Scalar multiplication of one analytic function by another. -/
-lemma AnalyticWithinAt.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
-    {f : E → 𝕝} {g : E → F} {s : Set E} {z : E}
+lemma AnalyticWithinAt.smul [Module A F] [IsBoundedSMul A F] [IsScalarTower 𝕜 A F]
+    {f : E → A} {g : E → F} {s : Set E} {z : E}
     (hf : AnalyticWithinAt 𝕜 f s z) (hg : AnalyticWithinAt 𝕜 g s z) :
     AnalyticWithinAt 𝕜 (fun x ↦ f x • g x) s z :=
   (analyticAt_smul _).comp₂_analyticWithinAt hf hg
 
 /-- Scalar multiplication of one analytic function by another. -/
 @[to_fun (attr := fun_prop)]
-lemma AnalyticAt.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝} {g : E → F} {z : E}
-    (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
+lemma AnalyticAt.smul [Module A F] [IsBoundedSMul A F] [IsScalarTower 𝕜 A F] {f : E → A}
+    {g : E → F} {z : E} (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
     AnalyticAt 𝕜 (f • g) z :=
   (analyticAt_smul _).comp₂ hf hg
 
 /-- Scalar multiplication of one analytic function by another. -/
-lemma AnalyticOn.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
-    {f : E → 𝕝} {g : E → F} {s : Set E}
+lemma AnalyticOn.smul [Module A F] [IsBoundedSMul A F] [IsScalarTower 𝕜 A F]
+    {f : E → A} {g : E → F} {s : Set E}
     (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (fun x ↦ f x • g x) s :=
   fun _ m ↦ (hf _ m).smul (hg _ m)
 
 /-- Scalar multiplication of one analytic function by another. -/
-lemma AnalyticOnNhd.smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝} {g : E → F} {s : Set E}
-    (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
+lemma AnalyticOnNhd.smul [Module A F] [IsBoundedSMul A F] [IsScalarTower 𝕜 A F]
+    {f : E → A} {g : E → F} {s : Set E} (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
     AnalyticOnNhd 𝕜 (fun x ↦ f x • g x) s :=
   fun _ m ↦ (hf _ m).smul (hg _ m)
 
@@ -616,19 +638,19 @@ lemma AnalyticWithinAt.mul {f g : E → A} {s : Set E} {z : E}
 @[to_fun (attr := fun_prop)]
 lemma AnalyticAt.mul {f g : E → A} {z : E} (hf : AnalyticAt 𝕜 f z) (hg : AnalyticAt 𝕜 g z) :
     AnalyticAt 𝕜 (f * g) z :=
-  (analyticAt_mul _).comp₂ hf hg
+  hf.smul hg
 
 /-- Multiplication of analytic functions (valued in a normed `𝕜`-algebra) is analytic. -/
 lemma AnalyticOn.mul {f g : E → A} {s : Set E}
     (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (fun x ↦ f x * g x) s :=
-  fun _ m ↦ (hf _ m).mul (hg _ m)
+  hf.smul hg
 
 /-- Multiplication of analytic functions (valued in a normed `𝕜`-algebra) is analytic. -/
 lemma AnalyticOnNhd.mul {f g : E → A} {s : Set E}
     (hf : AnalyticOnNhd 𝕜 f s) (hg : AnalyticOnNhd 𝕜 g s) :
     AnalyticOnNhd 𝕜 (fun x ↦ f x * g x) s :=
-  fun _ m ↦ (hf _ m).mul (hg _ m)
+  hf.smul hg
 
 /-- Powers of analytic functions (into a normed `𝕜`-algebra) are analytic. -/
 @[to_fun]
@@ -662,31 +684,31 @@ lemma AnalyticOnNhd.pow {f : E → A} {s : Set E} (hf : AnalyticOnNhd 𝕜 f s) 
     AnalyticOnNhd 𝕜 (f ^ n) s :=
   fun _ m ↦ (hf _ m).pow n
 
-/-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic if the exponent is
-nonnegative. -/
+/-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
+exponent is nonnegative. -/
 @[to_fun]
 lemma AnalyticWithinAt.zpow_nonneg {f : E → 𝕝} {z : E} {s : Set E} {n : ℤ}
     (hf : AnalyticWithinAt 𝕜 f s z) (hn : 0 ≤ n) :
     AnalyticWithinAt 𝕜 (f ^ n) s z := by
   simpa [← zpow_natCast, hn] using hf.pow n.toNat
 
-/-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic if the exponent is
-nonnegative. -/
+/-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
+exponent is nonnegative. -/
 @[to_fun]
 lemma AnalyticAt.zpow_nonneg {f : E → 𝕝} {z : E} {n : ℤ} (hf : AnalyticAt 𝕜 f z) (hn : 0 ≤ n) :
     AnalyticAt 𝕜 (f ^ n) z := by
   simpa [← zpow_natCast, hn] using hf.pow n.toNat
 
-/-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic if the exponent is
-nonnegative. -/
+/-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
+exponent is nonnegative. -/
 @[to_fun]
 lemma AnalyticOn.zpow_nonneg {f : E → 𝕝} {s : Set E} {n : ℤ} (hf : AnalyticOn 𝕜 f s)
     (hn : 0 ≤ n) :
     AnalyticOn 𝕜 (f ^ n) s := by
   simpa [← zpow_natCast, hn] using hf.pow n.toNat
 
-/-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic if the exponent is
-nonnegative. -/
+/-- ZPowers of analytic functions (into a normed division algebra over `𝕜`) are analytic if the
+exponent is nonnegative. -/
 @[to_fun]
 lemma AnalyticOnNhd.zpow_nonneg {f : E → 𝕝} {s : Set E} {n : ℤ} (hf : AnalyticOnNhd 𝕜 f s)
     (hn : 0 ≤ n) :
@@ -749,8 +771,7 @@ end
 -/
 
 section Geometric
-
-variable (𝕜 A : Type*) [NontriviallyNormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A]
+variable (𝕜 A)
 
 /-- The geometric series `1 + x + x ^ 2 + ...` as a `FormalMultilinearSeries`. -/
 def formalMultilinearSeries_geometric : FormalMultilinearSeries 𝕜 A A :=
@@ -771,10 +792,7 @@ lemma formalMultilinearSeries_geometric_apply_norm [NormOneClass A] (n : ℕ) :
     ‖formalMultilinearSeries_geometric 𝕜 A n‖ = 1 :=
   ContinuousMultilinearMap.norm_mkPiAlgebraFin
 
-end Geometric
-
-lemma one_le_formalMultilinearSeries_geometric_radius (𝕜 : Type*) [NontriviallyNormedField 𝕜]
-    (A : Type*) [NormedRing A] [NormedAlgebra 𝕜 A] :
+lemma one_le_formalMultilinearSeries_geometric_radius :
     1 ≤ (formalMultilinearSeries_geometric 𝕜 A).radius := by
   convert formalMultilinearSeries_geometric_eq_ofScalars 𝕜 A ▸
     FormalMultilinearSeries.inv_le_ofScalars_radius_of_tendsto A _ one_ne_zero (by simp)
@@ -786,9 +804,7 @@ lemma formalMultilinearSeries_geometric_radius (𝕜 : Type*) [NontriviallyNorme
   formalMultilinearSeries_geometric_eq_ofScalars 𝕜 A ▸
     FormalMultilinearSeries.ofScalars_radius_eq_of_tendsto A _ one_ne_zero (by simp)
 
-lemma hasFPowerSeriesOnBall_inverse_one_sub
-    (𝕜 : Type*) [NontriviallyNormedField 𝕜]
-    (A : Type*) [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] :
+lemma hasFPowerSeriesOnBall_inverse_one_sub [HasSummableGeomSeries A] :
     HasFPowerSeriesOnBall (fun x : A ↦ Ring.inverse (1 - x))
       (formalMultilinearSeries_geometric 𝕜 A) 0 1 := by
   constructor
@@ -802,16 +818,16 @@ lemma hasFPowerSeriesOnBall_inverse_one_sub
     exact (summable_geometric_of_norm_lt_one hy).hasSum
 
 @[fun_prop]
-lemma analyticAt_inverse_one_sub (𝕜 : Type*) [NontriviallyNormedField 𝕜]
-    (A : Type*) [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] :
+lemma analyticAt_inverse_one_sub [HasSummableGeomSeries A] :
     AnalyticAt 𝕜 (fun x : A ↦ Ring.inverse (1 - x)) 0 :=
   ⟨_, ⟨_, hasFPowerSeriesOnBall_inverse_one_sub 𝕜 A⟩⟩
+
+end Geometric
 
 /-- If `A` is a normed algebra over `𝕜` with summable geometric series, then inversion on `A` is
 analytic at any unit. -/
 @[fun_prop]
-lemma analyticAt_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-    {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] (z : Aˣ) :
+lemma analyticAt_inverse [HasSummableGeomSeries A] (z : Aˣ) :
     AnalyticAt 𝕜 Ring.inverse (z : A) := by
   rcases subsingleton_or_nontrivial A with hA | hA
   · convert analyticAt_const (v := (0 : A))
@@ -840,20 +856,19 @@ lemma analyticAt_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
       exact analyticAt_inverse_one_sub 𝕜 A
     · exact analyticAt_const.sub (analyticAt_const.mul analyticAt_id)
 
-lemma analyticOnNhd_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-    {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] :
+lemma analyticOnNhd_inverse [HasSummableGeomSeries A] :
     AnalyticOnNhd 𝕜 Ring.inverse {x : A | IsUnit x} :=
   fun _ hx ↦ analyticAt_inverse (IsUnit.unit hx)
 
-lemma hasFPowerSeriesOnBall_inv_one_sub
-    (𝕜 𝕝 : Type*) [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝] :
+variable (𝕜 𝕝) in
+lemma hasFPowerSeriesOnBall_inv_one_sub :
     HasFPowerSeriesOnBall (fun x : 𝕝 ↦ (1 - x)⁻¹) (formalMultilinearSeries_geometric 𝕜 𝕝) 0 1 := by
   convert hasFPowerSeriesOnBall_inverse_one_sub 𝕜 𝕝
   exact Ring.inverse_eq_inv'.symm
 
+variable (𝕝) in
 @[fun_prop]
-lemma analyticAt_inv_one_sub (𝕝 : Type*) [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝] :
-    AnalyticAt 𝕜 (fun x : 𝕝 ↦ (1 - x)⁻¹) 0 :=
+lemma analyticAt_inv_one_sub : AnalyticAt 𝕜 (fun x : 𝕝 ↦ (1 - x)⁻¹) 0 :=
   ⟨_, ⟨_, hasFPowerSeriesOnBall_inv_one_sub 𝕜 𝕝⟩⟩
 
 /-- If `𝕝` is a normed field extension of `𝕜`, then the inverse map `𝕝 → 𝕝` is `𝕜`-analytic
@@ -937,8 +952,8 @@ lemma AnalyticOnNhd.zpow {f : E → 𝕝} {s : Set E} {n : ℤ} (h₁f : Analyti
 
 /- A function is analytic at a point iff it is analytic after scalar
   multiplication with a non-vanishing analytic function. -/
-theorem analyticAt_iff_analytic_fun_smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝}
-    {g : E → F} {z : E} (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
+theorem analyticAt_iff_analytic_fun_smul [Module 𝕝 F] [IsBoundedSMul 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
+    {f : E → 𝕝} {g : E → F} {z : E} (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
     AnalyticAt 𝕜 g z ↔ AnalyticAt 𝕜 (fun z ↦ f z • g z) z := by
   constructor
   · exact fun a ↦ h₁f.smul a
@@ -952,8 +967,8 @@ theorem analyticAt_iff_analytic_fun_smul [NormedSpace 𝕝 F] [IsScalarTower �
 
 /- A function is analytic at a point iff it is analytic after scalar
   multiplication with a non-vanishing analytic function. -/
-theorem analyticAt_iff_analytic_smul [NormedSpace 𝕝 F] [IsScalarTower 𝕜 𝕝 F] {f : E → 𝕝}
-    {g : E → F} {z : E} (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
+theorem analyticAt_iff_analytic_smul [Module 𝕝 F] [IsBoundedSMul 𝕝 F] [IsScalarTower 𝕜 𝕝 F]
+    {f : E → 𝕝} {g : E → F} {z : E} (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
     AnalyticAt 𝕜 g z ↔ AnalyticAt 𝕜 (f • g) z :=
   analyticAt_iff_analytic_fun_smul h₁f h₂f
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -798,8 +798,7 @@ lemma one_le_formalMultilinearSeries_geometric_radius :
     FormalMultilinearSeries.inv_le_ofScalars_radius_of_tendsto A _ one_ne_zero (by simp)
   simp
 
-lemma formalMultilinearSeries_geometric_radius (𝕜 : Type*) [NontriviallyNormedField 𝕜]
-    (A : Type*) [NormedRing A] [NormOneClass A] [NormedAlgebra 𝕜 A] :
+lemma formalMultilinearSeries_geometric_radius [NormOneClass A] :
     (formalMultilinearSeries_geometric 𝕜 A).radius = 1 :=
   formalMultilinearSeries_geometric_eq_ofScalars 𝕜 A ▸
     FormalMultilinearSeries.ofScalars_radius_eq_of_tendsto A _ one_ne_zero (by simp)

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -295,16 +295,18 @@ theorem min_radius_le_radius_add (p q : FormalMultilinearSeries 𝕜 E F) :
 theorem radius_neg (p : FormalMultilinearSeries 𝕜 E F) : (-p).radius = p.radius := by
   simp only [radius, neg_apply, norm_neg]
 
-theorem radius_le_smul {p : FormalMultilinearSeries 𝕜 E F} {c : 𝕜} : p.radius ≤ (c • p).radius := by
+theorem radius_le_smul {p : FormalMultilinearSeries 𝕜 E F} {𝕜' : Type*} {c : 𝕜'} [NormedRing 𝕜']
+    [Module 𝕜' F] [SMulCommClass 𝕜 𝕜' F] [IsBoundedSMul 𝕜' F] :
+    p.radius ≤ (c • p).radius := by
   simp only [radius, smul_apply]
   refine iSup_mono fun r ↦ iSup_mono' fun C ↦ ⟨‖c‖ * C, iSup_mono' fun h ↦ ?_⟩
   simp only [le_refl, exists_prop, and_true]
   intro n
-  rw [norm_smul c (p n), mul_assoc]
-  gcongr
-  exact h n
+  grw [norm_smul_le, mul_assoc, h]
 
-theorem radius_smul_eq (p : FormalMultilinearSeries 𝕜 E F) {c : 𝕜} (hc : c ≠ 0) :
+theorem radius_smul_eq (p : FormalMultilinearSeries 𝕜 E F)
+    {𝕜' : Type*} {c : 𝕜'} [NormedDivisionRing 𝕜'] [Module 𝕜' F] [NormSMulClass 𝕜' F]
+    [SMulCommClass 𝕜 𝕜' F] (hc : c ≠ 0) :
     (c • p).radius = p.radius := by
   apply eq_of_le_of_ge _ radius_le_smul
   exact radius_le_smul.trans_eq (congr_arg _ <| inv_smul_smul₀ hc p)

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -358,3 +358,11 @@ theorem iteratedDerivWithin_const {n : ℕ} {c : F} {s : Set 𝕜} {x : 𝕜} :
   induction n generalizing c with
   | zero => simp
   | succ n h => simp [iteratedDerivWithin_succ', Pi.zero_def, h]
+
+@[simp]
+lemma iteratedDeriv_fun_const_zero : iteratedDeriv n (fun _ ↦ 0) x = (0 : F) := by
+  simpa using @iteratedDeriv_const 𝕜 _ F _ _ n 0
+
+@[simp]
+lemma iteratedDeriv_const_zero : iteratedDeriv n (0 : 𝕜 → F) x = (0 : F) := by
+  simp [Pi.zero_def]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -366,3 +366,13 @@ lemma iteratedDeriv_fun_const_zero : iteratedDeriv n (fun _ ↦ 0) x = (0 : F) :
 @[simp]
 lemma iteratedDeriv_const_zero : iteratedDeriv n (0 : 𝕜 → F) x = (0 : F) := by
   simp [Pi.zero_def]
+
+@[simp]
+lemma iteratedDerivWithin_fun_const_zero {s : Set 𝕜} :
+    iteratedDerivWithin n (fun _ ↦ 0) s x = (0 : F) := by
+  simpa using @iteratedDerivWithin_const 𝕜 _ F _ _ n 0
+
+@[simp]
+lemma iteratedDerivWithin_const_zero {s : Set 𝕜} :
+    iteratedDerivWithin n (0 : 𝕜 → F) s x = (0 : F) := by
+  simp [Pi.zero_def]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -19,15 +19,26 @@ than are available in `Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean`.
 
 public section
 
-section one_dimensional
-
 variable
   {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {R : Type*} [Semiring R] [Module R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F]
   {n : ℕ} {x : 𝕜} {s : Set 𝕜} (hx : x ∈ s) (h : UniqueDiffOn 𝕜 s) {f g : 𝕜 → F}
-  {𝕜' : Type*} [NontriviallyNormedField 𝕜']
-  [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' F] [IsScalarTower 𝕜 𝕜' F]
+  -- For maximum generality, results about `smul` involve a second type besides `𝕜`,
+  -- with varying hypotheses.
+  -- * `R`: general type.
+  {R : Type*} [DistribSMul R F] [SMulCommClass 𝕜 R F] [ContinuousConstSMul R F]
+  -- * `𝕝`: division semiring. (Addition in `𝕝` is not used, so the results would work with a
+  -- `GroupWithZero` if we had a `DistribSMulWithZero` typeclass.)
+  {𝕝 : Type*} [DivisionSemiring 𝕝] [Module 𝕝 F] [SMulCommClass 𝕜 𝕝 F] [ContinuousConstSMul 𝕝 F]
+  -- * `𝔸`: normed `𝕜`-algebra.
+  {𝔸 : Type*} [NormedRing 𝔸] [NormedAlgebra 𝕜 𝔸] [Module 𝔸 F] [IsBoundedSMul 𝔸 F]
+    [IsScalarTower 𝕜 𝔸 F]
+  -- * `𝕜'`: normed `𝕜`-division algebra.
+  {𝕜' : Type*} [NormedDivisionRing 𝕜'] [NormedAlgebra 𝕜 𝕜']
+    [Module 𝕜' F] [SMulCommClass 𝕜 𝕜' F] [ContinuousSMul 𝕜' F]
+
+section one_dimensional
+
 
 open scoped Topology
 
@@ -82,16 +93,66 @@ include h hx in
 theorem iteratedDerivWithin_const_smul (c : R) (hf : ContDiffWithinAt 𝕜 n f s x) :
     iteratedDerivWithin n (c • f) s x = c • iteratedDerivWithin n f s x := by
   simp_rw [iteratedDerivWithin]
-  rw [iteratedFDerivWithin_const_smul_apply hf h hx]
+  rw [iteratedFDerivWithin_const_smul_apply (a := c) hf h hx]
   simp only [ContinuousMultilinearMap.smul_apply]
 
 include h hx in
-theorem iteratedDerivWithin_const_mul (c : 𝕜) {f : 𝕜 → 𝕜} (hf : ContDiffWithinAt 𝕜 n f s x) :
-    iteratedDerivWithin n (fun z => c * f z) s x = c * iteratedDerivWithin n f s x := by
-  simpa using iteratedDerivWithin_const_smul (F := 𝕜) hx h c hf
+theorem iteratedDerivWithin_fun_const_smul (c : R) (hf : ContDiffWithinAt 𝕜 n f s x) :
+    iteratedDerivWithin n (fun w ↦ c • f w) s x = c • iteratedDerivWithin n f s x :=
+  iteratedDerivWithin_const_smul hx h c hf
+
+/-- A variant of `iteratedDerivWithin_const_smul` without differentiability assumption when
+the scalar multiplication is by division ring elements. -/
+@[simp]
+theorem iteratedDerivWithin_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
+    iteratedDerivWithin n (c • f) s x = c • iteratedDerivWithin n f s x := by
+  induction n generalizing f x with
+  | zero => simp
+  | succ n IH =>
+    simp_rw [iteratedDerivWithin_succ, funext (@IH · f), ← Pi.smul_def,
+      derivWithin_const_smul_field]
+
+include h hx in
+theorem iteratedDerivWithin_const_mul (c : 𝔸) {f : 𝕜 → 𝔸} (hf : ContDiffWithinAt 𝕜 n f s x) :
+    iteratedDerivWithin n (fun z => c * f z) s x = c * iteratedDerivWithin n f s x :=
+  iteratedDerivWithin_fun_const_smul hx h c hf
+
+/-- A variant of `iteratedDerivWithin_fun_const_smul` without differentiability assumption when
+the scalar multiplication is by division ring elements. -/
+@[simp]
+theorem iteratedDerivWithin_fun_const_smul_field (c : 𝕝) (f : 𝕜 → F) :
+    iteratedDerivWithin n (fun z => c • f z) s x = c • iteratedDerivWithin n f s x :=
+  iteratedDerivWithin_const_smul_field c f
+
+@[simp]
+theorem iteratedDerivWithin_const_mul_field (c : 𝕜') (f : 𝕜 → 𝕜') :
+    iteratedDerivWithin n (fun z => c * f z) s x = c * iteratedDerivWithin n f s x :=
+  iteratedDerivWithin_fun_const_smul_field c f
+
+include h hx in
+theorem iteratedDerivWithin_smul_const {f : 𝕜 → 𝔸} (hf : ContDiffWithinAt 𝕜 n f s x) (v : F) :
+    iteratedDerivWithin n (fun y ↦ f y • v) s x = iteratedDerivWithin n f s x • v := by
+  simp [iteratedDerivWithin, iteratedFDerivWithin_smul_const_apply hf h hx]
+
+include h hx in
+@[simp]
+theorem iteratedDerivWithin_mul_const {f : 𝕜 → 𝔸} (hf : ContDiffWithinAt 𝕜 n f s x) (d : 𝔸) :
+    iteratedDerivWithin n (fun z ↦ f z * d) s x = iteratedDerivWithin n f s x * d :=
+  iteratedDerivWithin_smul_const hx h hf d
+
+/-- A variant of `iteratedDerivWithin_mul_const` without differentiability assumption when
+the scalar multiplication is by division ring elements. -/
+@[simp]
+theorem iteratedDerivWithin_mul_const_field (f : 𝕜 → 𝕜') (d : 𝕜') :
+    iteratedDerivWithin n (fun z ↦ f z * d) s x = iteratedDerivWithin n f s x * d := by
+  induction n generalizing f x with
+  | zero => simp
+  | succ n IH =>
+    simp_rw [iteratedDerivWithin_succ, funext (@IH · f), derivWithin_mul_const_field]
 
 variable (f) in
 omit h hx in
+@[simp]
 theorem iteratedDerivWithin_neg :
     iteratedDerivWithin n (-f) s x = -iteratedDerivWithin n f s x := by
   induction n generalizing x with
@@ -154,8 +215,7 @@ lemma iteratedDerivWithin_fun_id :
     iteratedDerivWithin n (·) s x = if n = 0 then x else if n = 1 then 1 else 0 :=
   iteratedDerivWithin_id hx h
 
--- TODO: `𝕜'` could be generalized to normed algebras not necessarily fields.
-lemma iteratedDerivWithin_smul {f : 𝕜 → 𝕜'} {g : 𝕜 → F}
+lemma iteratedDerivWithin_smul {f : 𝕜 → 𝔸} {g : 𝕜 → F}
     (hf : ContDiffWithinAt 𝕜 (↑n) f s x) (hg : ContDiffWithinAt 𝕜 (↑n) g s x) :
     iteratedDerivWithin n (f • g) s x = ∑ i ∈ .range (n + 1),
       n.choose i • iteratedDerivWithin i f s x • iteratedDerivWithin (n - i) g s x := by
@@ -176,7 +236,7 @@ lemma iteratedDerivWithin_smul {f : 𝕜 → 𝕜'} {g : 𝕜 → F}
       rw [derivWithin_smul (hfy.differentiableWithinAt _) (hgy.differentiableWithinAt _)]
       all_goals simp
 
-lemma iteratedDerivWithin_mul {f g : 𝕜 → 𝕜'}
+lemma iteratedDerivWithin_mul {f g : 𝕜 → 𝔸}
     (hf : ContDiffWithinAt 𝕜 n f s x) (hg : ContDiffWithinAt 𝕜 n g s x) :
     iteratedDerivWithin n (f * g) s x = ∑ i ∈ .range (n + 1),
       n.choose i * iteratedDerivWithin i f s x * iteratedDerivWithin (n - i) g s x := by
@@ -222,10 +282,12 @@ theorem iteratedDeriv_const_sub (hn : 0 < n) (c : F) :
     iteratedDeriv n (fun z => c - f z) x = iteratedDeriv n (-f) x := by
   simpa only [← iteratedDerivWithin_univ] using iteratedDerivWithin_const_sub hn c
 
+@[simp]
 lemma iteratedDeriv_fun_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
     iteratedDeriv n (fun x ↦ -(f x)) a = -(iteratedDeriv n f a) := by
   simpa only [← iteratedDerivWithin_univ] using iteratedDerivWithin_neg f
 
+@[simp]
 lemma iteratedDeriv_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
     iteratedDeriv n (-f) a = -(iteratedDeriv n f a) := by
   simpa only [← iteratedDerivWithin_univ] using iteratedDerivWithin_neg f
@@ -239,17 +301,61 @@ lemma iteratedDeriv_fun_sub (hf : ContDiffAt 𝕜 n f x) (hg : ContDiffAt 𝕜 n
     iteratedDeriv n (fun z ↦ f z - g z) x = iteratedDeriv n f x - iteratedDeriv n g x :=
   iteratedDeriv_sub hf hg
 
-theorem iteratedDeriv_const_smul {n : ℕ} {f : 𝕜 → F} (h : ContDiffAt 𝕜 n f x) (c : 𝕜) :
+theorem iteratedDeriv_const_smul {n : ℕ} {f : 𝕜 → F} (h : ContDiffAt 𝕜 n f x) (c : R) :
     iteratedDeriv n (c • f) x = c • iteratedDeriv n f x := by
   simpa only [iteratedDerivWithin_univ] using
     iteratedDerivWithin_const_smul (Set.mem_univ x) uniqueDiffOn_univ
       c (contDiffWithinAt_univ.mpr h)
 
-theorem iteratedDeriv_const_mul {n : ℕ} {f : 𝕜 → 𝕜} (h : ContDiffAt 𝕜 n f x) (c : 𝕜) :
-    iteratedDeriv n (fun z => c * f z) x = c * iteratedDeriv n f x := by
+theorem iteratedDeriv_fun_const_smul {n : ℕ} {f : 𝕜 → F} (h : ContDiffAt 𝕜 n f x) (c : R) :
+    iteratedDeriv n (c • f ·) x = c • iteratedDeriv n f x :=
+  iteratedDeriv_const_smul h c
+
+/-- A variant of `iteratedDeriv_const_smul` without differentiability assumption when
+the scalar multiplication is by division ring elements. -/
+@[simp]
+theorem iteratedDeriv_const_smul_field {n : ℕ} (c : 𝕝) (f : 𝕜 → F) :
+    iteratedDeriv n (c • f) x = c • iteratedDeriv n f x := by
   simpa only [iteratedDerivWithin_univ] using
-    iteratedDerivWithin_const_mul (Set.mem_univ x) uniqueDiffOn_univ
-      c (contDiffWithinAt_univ.mpr h)
+    iteratedDerivWithin_const_smul_field (s := Set.univ) c f
+
+/-- A variant of `iteratedDeriv_fun_const_smul` without differentiability assumption when
+the scalar multiplication is by division ring elements. -/
+@[simp]
+theorem iteratedDeriv_fun_const_smul_field {n : ℕ} (c : 𝕝) (f : 𝕜 → F) :
+    iteratedDeriv n (c • f ·) x = c • iteratedDeriv n f x := by
+  simpa only [iteratedDerivWithin_univ] using
+    iteratedDerivWithin_fun_const_smul_field (s := Set.univ) c f
+
+theorem iteratedDeriv_smul_const {f : 𝕜 → 𝔸} (hf : ContDiffAt 𝕜 n f x) (v : F) :
+    iteratedDeriv n (fun y ↦ f y • v) x = iteratedDeriv n f x • v := by
+  simp [iteratedDeriv, iteratedFDeriv_smul_const_apply hf]
+
+theorem iteratedDeriv_const_mul {n : ℕ} {f : 𝕜 → 𝔸} (c : 𝔸) (hf : ContDiffAt 𝕜 n f x) :
+    iteratedDeriv n (c * f ·) x = c * iteratedDeriv n f x := by
+  simpa only [iteratedDerivWithin_univ] using
+    iteratedDerivWithin_const_mul (Set.mem_univ x) uniqueDiffOn_univ c hf
+
+/-- A variant of `iteratedDeriv_const_mul` without differentiability assumption when
+the multiplication is in a division ring. -/
+@[simp]
+theorem iteratedDeriv_const_mul_field {n : ℕ} (c : 𝕜') (f : 𝕜 → 𝕜') :
+    iteratedDeriv n (c * f ·) x = c * iteratedDeriv n f x := by
+  simpa only [iteratedDerivWithin_univ] using
+    iteratedDerivWithin_const_mul_field (s := .univ) c f
+
+/-- A variant of `iteratedDeriv_mul_const` without differentiability assumption when
+the multiplication is in a division ring. -/
+@[simp]
+theorem iteratedDeriv_mul_const_field {n : ℕ} (f : 𝕜 → 𝕜') (c : 𝕜') :
+    iteratedDeriv n (f · * c) x = iteratedDeriv n f x * c := by
+  simpa only [iteratedDerivWithin_univ] using
+    iteratedDerivWithin_mul_const_field (s := .univ) f c
+
+@[simp]
+theorem iteratedDeriv_div_const {n : ℕ} (f : 𝕜 → 𝕜') (c : 𝕜') :
+    iteratedDeriv n (f · / c) x = iteratedDeriv n f x / c := by
+  simp [div_eq_mul_inv]
 
 theorem iteratedDeriv_comp_const_smul {n : ℕ} {f : 𝕜 → F} (h : ContDiff 𝕜 n f) (c : 𝕜) :
     iteratedDeriv n (fun x => f (c * x)) = fun x => c ^ n • iteratedDeriv n f (c * x) := by
@@ -286,7 +392,7 @@ lemma iteratedDeriv_fun_id_zero :
     iteratedDeriv n (fun a ↦ a) (0 : 𝕜) = if n = 1 then 1 else 0 := by
   simp +contextual [iteratedDeriv_fun_id]
 
-lemma iteratedDeriv_mul {f g : 𝕜 → 𝕜'} (hf : ContDiffAt 𝕜 n f x) (hg : ContDiffAt 𝕜 n g x) :
+lemma iteratedDeriv_mul {f g : 𝕜 → 𝔸} (hf : ContDiffAt 𝕜 n f x) (hg : ContDiffAt 𝕜 n g x) :
     iteratedDeriv n (f * g) x = ∑ i ∈ .range (n + 1),
       n.choose i * iteratedDeriv i f x * iteratedDeriv (n - i) g x := by
   simpa using iteratedDerivWithin_mul
@@ -297,7 +403,7 @@ theorem iteratedDeriv_pow (m : ℕ) (k : ℕ) :
     iteratedDeriv k (· ^ m) x = m.descFactorial k * x ^ (m - k) := by
   simpa using iteratedDerivWithin_pow (Set.mem_univ x) uniqueDiffOn_univ m k
 
-lemma iteratedDeriv_fun_mul {f g : 𝕜 → 𝕜'} (hf : ContDiffAt 𝕜 n f x) (hg : ContDiffAt 𝕜 n g x) :
+lemma iteratedDeriv_fun_mul {f g : 𝕜 → 𝔸} (hf : ContDiffAt 𝕜 n f x) (hg : ContDiffAt 𝕜 n g x) :
     iteratedDeriv n (fun x ↦ f x * g x) x = ∑ i ∈ .range (n + 1),
       n.choose i * iteratedDeriv i f x * iteratedDeriv (n - i) g x :=
   iteratedDeriv_mul hf hg
@@ -326,7 +432,6 @@ end one_dimensional
 
 section shift_invariance
 
-variable {𝕜 F} [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 variable (n : ℕ) (f : 𝕜 → F) (s : 𝕜)
 
 /-- The iterated derivative commutes with shifting the function by a constant on the left. -/
@@ -355,3 +460,28 @@ lemma iteratedDeriv_comp_const_sub :
     iteratedDeriv_comp_neg n (fun z => f (z + s))
 
 end shift_invariance
+
+section sums
+
+/-!
+### Iterated derivatives of sums
+-/
+open Finset
+variable {ι : Type*} {n : ℕ} {x : 𝕜} {f : ι → 𝕜 → F} {s : Finset ι}
+
+lemma iteratedDeriv_sum {ι : Type*} {n : ℕ} {x : 𝕜} {f : ι → 𝕜 → F}
+    {s : Finset ι} (hf : ∀ i ∈ s, ContDiffAt 𝕜 n (f i) x) :
+    iteratedDeriv n (∑ i ∈ s, f i) x = ∑ i ∈ s, iteratedDeriv n (f i) x := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp
+  | insert i t hi IH =>
+    rw [forall_mem_insert] at hf
+    simp only [sum_insert hi, sum_fn] at IH ⊢
+    rw [iteratedDeriv_add hf.1 (.sum hf.2), IH hf.2]
+
+lemma iteratedDeriv_fun_sum (hf : ∀ i ∈ s, ContDiffAt 𝕜 n (f i) x) :
+    iteratedDeriv n (fun z ↦ ∑ i ∈ s, f i z) x = ∑ i ∈ s, iteratedDeriv n (f i) x :=
+  by simpa [sum_fn] using iteratedDeriv_sum hf
+
+end sums

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -467,21 +467,31 @@ section sums
 ### Iterated derivatives of sums
 -/
 open Finset
-variable {ι : Type*} {n : ℕ} {x : 𝕜} {f : ι → 𝕜 → F} {s : Finset ι}
+variable {ι : Type*} {n : ℕ} {x : 𝕜} {f : ι → 𝕜 → F} {I : Finset ι}
 
-lemma iteratedDeriv_sum {ι : Type*} {n : ℕ} {x : 𝕜} {f : ι → 𝕜 → F}
-    {s : Finset ι} (hf : ∀ i ∈ s, ContDiffAt 𝕜 n (f i) x) :
-    iteratedDeriv n (∑ i ∈ s, f i) x = ∑ i ∈ s, iteratedDeriv n (f i) x := by
+lemma iteratedDerivWithin_sum {s : Set 𝕜} (hx : x ∈ s) (hs : UniqueDiffOn 𝕜 s)
+    (hf : ∀ i ∈ I, ContDiffWithinAt 𝕜 n (f i) s x) :
+    iteratedDerivWithin n (∑ i ∈ I, f i) s x =
+      ∑ i ∈ I, iteratedDerivWithin n (f i) s x := by
   classical
-  induction s using Finset.induction_on with
+  induction I using Finset.induction_on with
   | empty => simp
   | insert i t hi IH =>
     rw [forall_mem_insert] at hf
     simp only [sum_insert hi, sum_fn] at IH ⊢
-    rw [iteratedDeriv_add hf.1 (.sum hf.2), IH hf.2]
+    rw [iteratedDerivWithin_add hx hs hf.1 (.sum hf.2), IH hf.2]
 
-lemma iteratedDeriv_fun_sum (hf : ∀ i ∈ s, ContDiffAt 𝕜 n (f i) x) :
-    iteratedDeriv n (fun z ↦ ∑ i ∈ s, f i z) x = ∑ i ∈ s, iteratedDeriv n (f i) x :=
+lemma iteratedDerivWithin_fun_sum {s : Set 𝕜} (hx : x ∈ s) (hs : UniqueDiffOn 𝕜 s)
+    (hf : ∀ i ∈ I, ContDiffWithinAt 𝕜 n (f i) s x) :
+    iteratedDerivWithin n (∑ i ∈ I, f i ·) s x = ∑ i ∈ I, iteratedDerivWithin n (f i) s x :=
+  by simpa [sum_fn] using iteratedDerivWithin_sum hx hs hf
+
+lemma iteratedDeriv_sum (hf : ∀ i ∈ I, ContDiffAt 𝕜 n (f i) x) :
+    iteratedDeriv n (∑ i ∈ I, f i) x = ∑ i ∈ I, iteratedDeriv n (f i) x := by
+  simpa using iteratedDerivWithin_sum (Set.mem_univ x) uniqueDiffOn_univ hf
+
+lemma iteratedDeriv_fun_sum (hf : ∀ i ∈ I, ContDiffAt 𝕜 n (f i) x) :
+    iteratedDeriv n (fun z ↦ ∑ i ∈ I, f i z) x = ∑ i ∈ I, iteratedDeriv n (f i) x :=
   by simpa [sum_fn] using iteratedDeriv_sum hf
 
 end sums

--- a/Mathlib/Analysis/InnerProductSpace/Calculus.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Calculus.lean
@@ -374,10 +374,10 @@ namespace OpenPartialHomeomorph
 variable {c : E} {r : ℝ}
 
 theorem contDiff_unitBallBall (hr : 0 < r) : ContDiff ℝ n (unitBallBall c r hr) :=
-  (contDiff_id.const_smul _).add contDiff_const
+  (contDiff_id.const_smul r).add contDiff_const
 
 theorem contDiff_unitBallBall_symm (hr : 0 < r) : ContDiff ℝ n (unitBallBall c r hr).symm :=
-  (contDiff_id.sub contDiff_const).const_smul _
+  (contDiff_id.sub contDiff_const).const_smul r⁻¹
 
 theorem contDiff_univBall : ContDiff ℝ n (univBall c r) := by
   unfold univBall; split_ifs with h

--- a/Mathlib/Probability/Moments/MGFAnalytic.lean
+++ b/Mathlib/Probability/Moments/MGFAnalytic.lean
@@ -240,7 +240,7 @@ lemma iteratedDeriv_two_cgf_eq_integral (h : v ∈ interior (integrableExpSet X 
     iteratedDeriv 2 (cgf X μ) v
       = μ[fun ω ↦ (X ω - deriv (cgf X μ) v) ^ 2 * exp (v * X ω)] / mgf X μ v := by
   by_cases hμ : μ = 0
-  · simp [hμ, iteratedDeriv_succ]
+  · simp [hμ]
   rw [iteratedDeriv_two_cgf h]
   calc (∫ ω, (X ω) ^ 2 * exp (v * X ω) ∂μ) / mgf X μ v - deriv (cgf X μ) v ^ 2
   _ = (∫ ω, (X ω) ^ 2 * exp (v * X ω) ∂μ - 2 * (∫ ω, X ω * exp (v * X ω) ∂μ) * deriv (cgf X μ) v


### PR DESCRIPTION
Relax typeclass assumptions in many lemmas about SMul on iterated derivs and analytic functions, and add variants without differentiability assumptions when the scalar type is a field/division ring.

---
Spin-off from the review process of https://github.com/leanprover-community/mathlib4/pull/33723.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
