### PR TITLE
[Merged by Bors] - feat(scripts): add auto_commit.sh and support rebase-friendly prefix

### DIFF
--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -22,7 +22,9 @@ permissions:
 
 env:
   TRANSIENT_PREFIX: "transient: "
-  AUTO_PREFIX: "x: "
+  # Support both "x: " (legacy) and "x " (rebase-friendly) prefixes
+  AUTO_PREFIX_COLON: "x: "
+  AUTO_PREFIX_SPACE: "x "
 
 jobs:
   verify:
@@ -46,8 +48,9 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           # Check if any commits have transient or auto prefix
+          # Auto prefix can be "x: " (legacy) or "x " (rebase-friendly)
           HAS_SPECIAL=$(git log --format="%s" "$BASE_SHA..$HEAD_SHA" | \
-            grep -E "^(${TRANSIENT_PREFIX}|${AUTO_PREFIX})" || true)
+            grep -E "^(${TRANSIENT_PREFIX}|${AUTO_PREFIX_COLON}|${AUTO_PREFIX_SPACE})" || true)
 
           if [[ -n "$HAS_SPECIAL" ]]; then
             echo "has_special=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   TRANSIENT_PREFIX: "transient: "
-  # Support both "x: " (legacy) and "x " (rebase-friendly) prefixes
+  # Support both "x " and "x: " (legacy) prefixes
   AUTO_PREFIX_COLON: "x: "
   AUTO_PREFIX_SPACE: "x "
 
@@ -48,7 +48,7 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           # Check if any commits have transient or auto prefix
-          # Auto prefix can be "x: " (legacy) or "x " (rebase-friendly)
+          # Auto prefix can be "x " or "x: " (legacy)
           HAS_SPECIAL=$(git log --format="%s" "$BASE_SHA..$HEAD_SHA" | \
             grep -E "^(${TRANSIENT_PREFIX}|${AUTO_PREFIX_COLON}|${AUTO_PREFIX_SPACE})" || true)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -116,9 +116,16 @@ to learn about it as well!
   with respect to `master`, and posts a comment on github with the result.
 - `autolabel.lean` is the Lean script in charge of automatically adding a `t-`label on eligible PRs.
   Autolabelling is inferred by which directories the current PR modifies.
+- `auto_commit.sh` runs a command and creates a commit with the result. The commit message format
+  `x scripts/auto_commit.sh <command>` enables a rebase workflow: during interactive rebase,
+  you can convert `pick abc x scripts/auto_commit.sh cmd` to `x scripts/auto_commit.sh cmd`
+  (by deleting the "pick abc " prefix), and git will re-run the command via exec.
+  Example: `scripts/auto_commit.sh lake exe mk_all`
 - `verify_commits.sh` verifies special commits in a PR:
   - **Transient commits** (prefix `transient: `) must have zero net effect on the final tree
-  - **Automated commits** (prefix `x: <command>`) must match the output of re-running the command
+  - **Automated commits** (prefix `x: <command>` or `x <command>`)
+    must match the effect of re-running the command.
+    The `x scripts/auto_commit.sh <command>` variant is rebase-friendly.
   Supports `--json` for machine-readable output and `--json-file PATH` to write JSON while
   displaying human-readable output.
 - `verify_commits_summary.sh` generates a markdown PR comment from `verify_commits.sh` JSON output.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -118,8 +118,8 @@ to learn about it as well!
   Autolabelling is inferred by which directories the current PR modifies.
 - `auto_commit.sh` runs a command and creates a commit with the result. The commit message format
   `x scripts/auto_commit.sh <command>` enables a rebase workflow: during interactive rebase,
-  you can convert `pick abc x scripts/auto_commit.sh cmd` to `x scripts/auto_commit.sh cmd`
-  (by deleting the "pick abc " prefix), and git will re-run the command via exec.
+  you can convert `pick abc # x scripts/auto_commit.sh cmd` to `x scripts/auto_commit.sh cmd`
+  (by deleting the "pick abc # " prefix), and git will re-run the command via exec.
   Example: `scripts/auto_commit.sh lake exe mk_all`
 - `verify_commits.sh` verifies special commits in a PR:
   - **Transient commits** (prefix `transient: `) must have zero net effect on the final tree

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -123,9 +123,8 @@ to learn about it as well!
   Example: `scripts/auto_commit.sh lake exe mk_all`
 - `verify_commits.sh` verifies special commits in a PR:
   - **Transient commits** (prefix `transient: `) must have zero net effect on the final tree
-  - **Automated commits** (prefix `x: <command>` or `x <command>`)
+  - **Automated commits** (prefix `x <command>`; or legacy `x: <command>`)
     must match the effect of re-running the command.
-    The `x scripts/auto_commit.sh <command>` variant is rebase-friendly.
   Supports `--json` for machine-readable output and `--json-file PATH` to write JSON while
   displaying human-readable output.
 - `verify_commits_summary.sh` generates a markdown PR comment from `verify_commits.sh` JSON output.

--- a/scripts/auto_commit.sh
+++ b/scripts/auto_commit.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Auto-Commit Script
+# Runs a command and creates a commit with the result
+#
+# Usage: scripts/auto_commit.sh <command>...
+#
+# The commit message will be: x scripts/auto_commit.sh <command>
+#
+# This format enables a rebase workflow: during interactive rebase, you can
+# convert "pick abc123 x scripts/auto_commit.sh <cmd>" to "x scripts/auto_commit.sh <cmd>"
+# (by deleting the "pick abc123 " prefix), and git will re-run the command via exec.
+#
+# Examples:
+#   scripts/auto_commit.sh lake exe mk_all
+#   scripts/auto_commit.sh ./scripts/fix_unused.py
+#
+# Exit codes:
+#   0 - Success (commit created or no changes to commit)
+#   1 - Command failed
+#   2 - Usage error
+
+set -euo pipefail
+
+# --- Colors (disabled if not a terminal) ---
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' BLUE='' NC=''
+fi
+
+log_info()  { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+log_ok()    { echo -e "${GREEN}[OK]${NC} $*" >&2; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+usage() {
+  echo "Usage: $0 <command>..."
+  echo ""
+  echo "Runs a command and creates a commit with message:"
+  echo "  x scripts/auto_commit.sh <command>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 lake exe mk_all"
+  echo "  $0 ./scripts/fix_unused.py"
+  exit 2
+}
+
+if [[ $# -eq 0 ]]; then
+  log_error "No command specified"
+  usage
+fi
+
+COMMAND="$*"
+COMMIT_MSG="x scripts/auto_commit.sh $COMMAND"
+
+log_info "Running: $COMMAND"
+
+# Run the command
+cmd_exit=0
+bash -c "$COMMAND" || cmd_exit=$?
+
+if [[ $cmd_exit -ne 0 ]]; then
+  log_error "Command failed with exit code $cmd_exit"
+  exit 1
+fi
+
+log_ok "Command completed successfully"
+
+# Stage all changes (modifications to tracked files + new untracked files)
+# Note: We use -A to add everything, matching what verify_commits.sh expects
+git add -A
+
+# Check if there are any staged changes
+if git diff --cached --quiet; then
+  log_warn "No changes to commit"
+  exit 0
+fi
+
+# Show what we're about to commit
+log_info "Changes to commit:"
+git diff --cached --stat >&2
+
+# Create the commit
+log_info "Creating commit: $COMMIT_MSG"
+git commit -m "$COMMIT_MSG"
+
+log_ok "Commit created successfully"

--- a/scripts/verify_commits.sh
+++ b/scripts/verify_commits.sh
@@ -14,7 +14,9 @@ set -euo pipefail
 # --- Configuration ---
 TIMEOUT_SECONDS=600  # 10 minutes per command
 TRANSIENT_PREFIX="${TRANSIENT_PREFIX:-transient: }"
-AUTO_PREFIX="${AUTO_PREFIX:-x: }"
+# Support both "x: <cmd>" (legacy) and "x <cmd>" (rebase-friendly) formats
+AUTO_PREFIX_COLON="${AUTO_PREFIX_COLON:-x: }"
+AUTO_PREFIX_SPACE="${AUTO_PREFIX_SPACE:-x }"
 
 # --- Colors (disabled if not a terminal) ---
 if [[ -t 1 ]]; then
@@ -47,6 +49,24 @@ show_diff_stat() {
     echo "  ... and $((line_count - max_lines)) more lines" >&2
   else
     echo "$diff_output" >&2
+  fi
+}
+
+# Check if a subject matches an auto-commit prefix
+# Returns 0 if it matches, 1 otherwise
+is_auto_commit() {
+  local subject="$1"
+  [[ "$subject" == "$AUTO_PREFIX_COLON"* || "$subject" == "$AUTO_PREFIX_SPACE"* ]]
+}
+
+# Extract the command from an auto-commit subject
+# Assumes is_auto_commit has already returned true
+get_auto_command() {
+  local subject="$1"
+  if [[ "$subject" == "$AUTO_PREFIX_COLON"* ]]; then
+    echo "${subject#$AUTO_PREFIX_COLON}"
+  else
+    echo "${subject#$AUTO_PREFIX_SPACE}"
   fi
 }
 
@@ -139,7 +159,7 @@ for commit in "${ALL_COMMITS[@]}"; do
     TRANSIENT_COMMITS+=("$commit")
   else
     NON_TRANSIENT_COMMITS+=("$commit")
-    if [[ "$subject" == "$AUTO_PREFIX"* ]]; then
+    if is_auto_commit "$subject"; then
       AUTO_COMMITS+=("$commit")
     else
       SUBSTANTIVE_COMMITS+=("$commit")
@@ -233,7 +253,8 @@ verify_auto_commit() {
   local commit="$1"
   local subject
   subject=$(git log -1 --format="%s" "$commit")
-  local command="${subject#$AUTO_PREFIX}"
+  local command
+  command=$(get_auto_command "$subject")
   local short_sha="${commit:0:7}"
 
   log_info "Verifying auto commit $short_sha: $command"

--- a/scripts/verify_commits.sh
+++ b/scripts/verify_commits.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # --- Configuration ---
 TIMEOUT_SECONDS=600  # 10 minutes per command
 TRANSIENT_PREFIX="${TRANSIENT_PREFIX:-transient: }"
-# Support both "x: <cmd>" (legacy) and "x <cmd>" (rebase-friendly) formats
+# Support both "x <cmd>" and "x: <cmd>" (legacy) formats
 AUTO_PREFIX_COLON="${AUTO_PREFIX_COLON:-x: }"
 AUTO_PREFIX_SPACE="${AUTO_PREFIX_SPACE:-x }"
 


### PR DESCRIPTION
This PR enables a rebase friendly workflow for auto-commits.
During `git rebase -i`, any lines of the form `x <command>` will execute `<command>`.
So a commit of the form `x scripts/auto_commit.sh <command>` will create an entry of the form
```
pick 123abc x scripts/auto_commit.sh <command>
```
By removing the prefix `pick 123abc `, the rebase will then execute `scripts/auto_commit.sh <command>`.
The effect is that `<command>` is run, and all changes to the worktree are committed with commit message
`x scripts/auto_commit.sh <command>`.

Specifically, this PR does the following:
- Add scripts/auto_commit.sh: runs a command and commits with message
  `x scripts/auto_commit.sh <command>`, enabling rebase workflow
- Update verify_commits.sh to support both `x: ` and `x ` prefixes
- Update CI workflow to detect both prefix formats

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
