### PR TITLE
[Merged by Bors] - feat(CI): strengthen validation of PR titles, and improve error messages

### DIFF
--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -96,6 +96,6 @@ public def validateTitle (title : String) : Array String := Id.run do
     if title.contains "  " then
       errors := errors.push
         "error: the PR title contains multiple consecutive spaces; please add just one"
-    else if title.endsWith "." then
+    if title.endsWith "." then
       errors := errors.push "error: the PR title should not end with a full stop"
     return errors

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -93,4 +93,9 @@ public def validateTitle (title : String) : Array String := Id.run do
       errors := errors.push s!"error: the PR title should be of the form \
         \"kind: main title\" or \"kind(scope): main title\"\n
         Known PR title kinds are {knownKinds}"
+    if title.contains "  " then
+      errors := errors.push
+        "error: the PR title contains multiple consecutive spaces; please add just one"
+    else if title.endsWith "." then
+      errors := errors.push "error: the PR title should not end with a full stop"
     return errors

--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -75,14 +75,16 @@ public def validateTitle (title : String) : Array String := Id.run do
   -- but give some custom errors in some easily detectable cases.
   if !title.contains ':' then
     return #["error: the PR title does not contain a colon"]
+  let mut errors : Array String := #[]
+  if title.startsWith " " then
+    errors := #["error: the PR title starts with a space"]
 
-  match Parser.run prTitle title with
+  match Parser.run prTitle title.trimAsciiStart.copy with
   | Except.error _ =>
-    return #[s!"error: the PR title should be of the form\n  abbrev: main title\nor\n  \
-      abbrev(scope): main title"]
+    return errors.push s!"error: the PR title should be of the form\n  abbrev: main title\n\
+      or\n  abbrev(scope): main title"
   | Except.ok (kind, _scope?) =>
     -- Future: also check scope (and the main PR title)
-    let mut errors := #[]
     let knownKinds := ["feat", "chore", "perf", "refactor", "style", "fix", "doc", "test", "ci"]
     let mut isFine := false
     for k in knownKinds do

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -23,7 +23,10 @@ elab "#check_title " title:str : command => do
 #check_title "my short PR title"
 
 /--
-info: Message: 'error: the PR type should be one of "feat", "chore", "perf", "refactor", "style", "fix", "doc", "test"'
+info: Message: 'error: the PR title should be of the form
+  abbrev: main title
+or
+  abbrev(scope): main title'
 -/
 #guard_msgs in
 #check_title "fsdfs: bad title"
@@ -40,3 +43,27 @@ info: Message: 'error: the PR type should be one of "feat", "chore", "perf", "re
 -- Acronyms are valid PR titles, in any case.
 #guard_msgs in
 #check_title "feat: RPC acronyms are fine"
+
+/--
+info: Message: 'error: the PR title contains multiple consecutive spaces; please add just one'
+---
+info: Message: 'error: the PR title should not end with a full stop'
+-/
+#guard_msgs in
+#check_title "chore: bad   Title."
+
+/-- info: Message: 'error: the PR title starts with a space' -/
+#guard_msgs in
+#check_title " feat: bad title"
+
+-- Brackets in the PR title are allowed.
+#guard_msgs in
+#check_title "feat: (confusing) but legal title"
+
+/-- info: Message: 'error: the PR title does not contain a colon' -/
+#guard_msgs in
+#check_title "feat(test) (confusing) bad title"
+
+-- TODO: should this error?
+#guard_msgs in
+#check_title "feat(confusing) (forbidden): title"

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -1,0 +1,42 @@
+import Mathlib.Tactic.Linter.ValidatePRTitle
+
+-- Tests for the PR title validation logic.
+open Lean in
+/--
+`#check_title title` takes as input the `String` `title`, expected to be a mathlib PR title.
+It logs details of what the linter would report if the `title` is "malformed".
+-/
+elab "#check_title " title:str : command => do
+  let title := title.getString
+  for err in validateTitle title do
+    logInfo m!"Message: '{err}'"
+
+-- two well-formed examples
+#guard_msgs in
+#check_title "feat: my short PR title"
+
+#guard_msgs in
+#check_title "feat(Algebra): my short PR title"
+
+/-- info: Message: 'error: the PR title does not contain a colon' -/
+#guard_msgs in
+#check_title "my short PR title"
+
+/--
+info: Message: 'error: the PR type should be one of "feat", "chore", "perf", "refactor", "style", "fix", "doc", "test"'
+-/
+#guard_msgs in
+#check_title "fsdfs: bad title"
+
+/-- info: Message: 'error: the PR title should not end with a full stop' -/
+#guard_msgs in
+#check_title "feat: bad title."
+
+-- Enable if/when we decide to enforce lower-cased titles.
+-- /-- info: Message: 'error: the main PR title should be lowercased' -/
+-- #guard_msgs in
+-- #check_title "feat: My Bad Title"
+
+-- Acronyms are valid PR titles, in any case.
+#guard_msgs in
+#check_title "feat: RPC acronyms are fine"


### PR DESCRIPTION
Enforce a bit more of the commit message guidelines in the PR description,
add a dedicated error message for PR titles starting with a space, and add end-to-end-tests for the errors.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
