### PR TITLE
[Merged by Bors] - doc(CategoryTheory/Adjunction): fix typos and update docs

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/AdjointFunctorTheorems.lean
+++ b/Mathlib/CategoryTheory/Adjunction/AdjointFunctorTheorems.lean
@@ -17,7 +17,7 @@ public import Mathlib.CategoryTheory.Subobject.Comma
 
 This file proves the (general) adjoint functor theorem, in the form:
 * If `G : D ⥤ C` preserves limits and `D` has limits, and satisfies the solution set condition,
-  then it has a left adjoint: `isRightAdjoint_of_preservesLimits_of_isCoseparating`.
+  then it has a left adjoint: `isRightAdjoint_of_preservesLimits_of_solutionSetCondition`.
 
 We show that the converse holds, i.e. that if `G` has a left adjoint then it satisfies the solution
 set condition, see `solutionSetCondition_of_isRightAdjoint`

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -25,7 +25,7 @@ We provide various useful constructors:
 * `adjunctionOfEquivLeft` / `adjunctionOfEquivRight` witness that these constructions
   give adjunctions.
 
-There are also typeclasses `IsLeftAdjoint` / `IsRightAdjoint`, which asserts the
+There are also typeclasses `IsLeftAdjoint` / `IsRightAdjoint`, which assert the
 existence of an adjoint functor. Given `[F.IsLeftAdjoint]`, a chosen right
 adjoint can be obtained as `F.rightAdjoint`.
 
@@ -39,8 +39,11 @@ Conversely `Equivalence.toAdjunction` recovers the underlying adjunction from an
 
 * Adjoint lifting theorems are in the directory `Lifting`.
 * The file `AdjointFunctorTheorems` proves the adjoint functor theorems.
+* The file `Additive` develops adjunctions between additive functors.
 * The file `Comma` shows that for a functor `G : D ⥤ C` the data of an initial object in each
   `StructuredArrow` category on `G` is equivalent to a left adjoint to `G`, as well as the dual.
+* The file `CompositionIso` derives compatibilities for compositions of left adjoints from the
+  corresponding data on right adjoints.
 * The file `Evaluation` shows that products and coproducts are adjoint to evaluation of functors.
 * The file `FullyFaithful` characterizes when adjoints are full or faithful in terms of the unit
   and counit.
@@ -57,11 +60,14 @@ Conversely `Equivalence.toAdjunction` recovers the underlying adjunction from an
   `R₁ R₂ : D ⥤ C`, it provides equivalences `(L₂ ⟶ L₁) ≃ (R₁ ⟶ R₂)` and `(L₂ ≅ L₁) ≃ (R₁ ≅ R₂)`.
 * The file `Opposites` contains constructions to relate adjunctions of functors to adjunctions of
   their opposites.
+* The file `Parametrized` defines adjunctions with a parameter.
+* The file `PartialAdjoint` studies the domain of definition of partial adjoints (left/right).
 * The file `Reflective` defines reflective functors, i.e. fully faithful right adjoints. Note that
   many facts about reflective functors are proved in the earlier file `FullyFaithful`.
 * The file `Restrict` defines the restriction of an adjunction along fully faithful functors.
 * The file `Triple` proves that in an adjoint triple, the left adjoint is fully faithful if and
   only if the right adjoint is.
+* The file `Quadruple` bundles adjoint quadruples and compares induced natural transformations.
 * The file `Unique` proves uniqueness of adjoints.
 * The file `Whiskering` proves that functors `F : D ⥤ E` and `G : E ⥤ D` with an adjunction
   `F ⊣ G`, induce adjunctions between the functor categories `C ⥤ D` and `C ⥤ E`,
@@ -364,7 +370,7 @@ This structure won't typically be used anywhere else.
 structure CoreUnitCounit (F : C ⥤ D) (G : D ⥤ C) where
   /-- The unit of an adjunction between `F` and `G` -/
   unit : 𝟭 C ⟶ F.comp G
-  /-- The counit of an adjunction between `F` and `G`s -/
+  /-- The counit of an adjunction between `F` and `G` -/
   counit : G.comp F ⟶ 𝟭 D
   /-- Equality of the composition of the unit, associator, and counit with the identity
   `F ⟶ (F G) F ⟶ F (G F) ⟶ F = NatTrans.id F` -/
@@ -572,7 +578,7 @@ def leftAdjointOfEquiv (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.ma
 variable (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g)
 
 /-- Show that the functor given by `leftAdjointOfEquiv` is indeed left adjoint to `G`. Dual
-to `adjunctionOfRightEquiv`. -/
+to `adjunctionOfEquivRight`. -/
 @[simps!]
 def adjunctionOfEquivLeft : leftAdjointOfEquiv e he ⊣ G :=
   mkOfHomEquiv
@@ -597,7 +603,7 @@ private theorem he'' (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y 
 
 /-- Construct a right adjoint functor to `F`, given the functor's value on objects `G_obj` and
 a bijection `e` between `F.obj X ⟶ Y` and `X ⟶ G_obj Y` satisfying a naturality law
-`he : ∀ X Y Y' g h, e X' Y (F.map f ≫ g) = f ≫ e X Y g`.
+`he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g`.
 Dual to `leftAdjointOfEquiv`. -/
 @[simps!]
 def rightAdjointOfEquiv (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g) : D ⥤ C where
@@ -611,7 +617,7 @@ def rightAdjointOfEquiv (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X
     simp
 
 /-- Show that the functor given by `rightAdjointOfEquiv` is indeed right adjoint to `F`. Dual
-to `adjunctionOfEquivRight`. -/
+to `adjunctionOfEquivLeft`. -/
 @[simps!]
 def adjunctionOfEquivRight (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g) :
     F ⊣ (rightAdjointOfEquiv e he) :=

--- a/Mathlib/CategoryTheory/Adjunction/Comma.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Comma.lean
@@ -105,7 +105,7 @@ def rightAdjointOfCostructuredArrowTerminalsAux (B : D) (A : C) :
 
 /--
 If each costructured arrow category on `G` has a terminal object, construct a right adjoint to `G`.
-It is shown that it is a right adjoint in `adjunctionOfStructuredArrowInitials`.
+It is shown that it is a right adjoint in `adjunctionOfCostructuredArrowTerminals`.
 -/
 def rightAdjointOfCostructuredArrowTerminals : C ⥤ D :=
   Adjunction.rightAdjointOfEquiv (rightAdjointOfCostructuredArrowTerminalsAux G)

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -101,7 +101,7 @@ theorem inv_map_unit {X : C} [IsIso (h.unit.app X)] :
     inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
   IsIso.inv_eq_of_hom_inv_id (h.left_triangle_components X)
 
-/-- If the unit is an isomorphism, bundle one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
+/-- If the unit of an adjunction is an isomorphism, then one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
 @[simps!]
 noncomputable def whiskerLeftLCounitIsoOfIsIsoUnit [IsIso h.unit] : L ⋙ R ⋙ L ≅ L :=
   (L.associator R L).symm ≪≫ isoWhiskerRight (asIso h.unit).symm L ≪≫ Functor.leftUnitor _
@@ -113,7 +113,8 @@ theorem inv_counit_map {X : D} [IsIso (h.counit.app X)] :
     inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
   IsIso.inv_eq_of_inv_hom_id (h.right_triangle_components X)
 
-/-- If the counit of an is an isomorphism, one has an isomorphism `(R ⋙ L ⋙ R) ≅ R`. -/
+/-- If the counit of an adjunction is an isomorphism, then one has an isomorphism
+`(R ⋙ L ⋙ R) ≅ R`. -/
 @[simps!]
 noncomputable def whiskerLeftRUnitIsoOfIsIsoCounit [IsIso h.counit] : R ⋙ L ⋙ R ≅ R :=
   (R.associator L R).symm ≪≫ isoWhiskerRight (asIso h.counit) R ≪≫ Functor.leftUnitor _

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -97,7 +97,7 @@ def counitCoequalises (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) (X : B) 
 /-- (Implementation)
 To construct the left adjoint, we use the coequalizer of `F' U ε_Y` with the composite
 
-`F' U F U X ⟶ F' U F U R F U' X ⟶ F' U R F' U X ⟶ F' U X`
+`F' U F U X ⟶ F' U F U R F' U X ⟶ F' U R F' U X ⟶ F' U X`
 
 where the first morphism is `F' U F ι_UX`, the second is `F' U ε_RF'UX`, and the third is `δ_F'UX`.
 We will show that this coequalizer exists and that it forms the object map for a left adjoint to

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -211,7 +211,7 @@ variable [Category.{v₄} D]
     A → B
   U ↓   ↓ V
     C → D
-      R
+      L
 ```
 
 where `U` has a right adjoint, `A` has coreflexive equalizers and `V` has a right adjoint such that
@@ -234,7 +234,7 @@ lemma isLeftAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C
     A → B
   U ↓   ↓ V
     C → D
-      R
+      L
 ```
 
 where `U` has a right adjoint, `A` has reflexive equalizers and `V` is comonadic.

--- a/Mathlib/CategoryTheory/Adjunction/Limits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Limits.lean
@@ -51,7 +51,7 @@ variable {J : Type u} [Category.{v} J] (K : J ⥤ C)
 
 /-- The right adjoint of `Cocones.functoriality K F : Cocone K ⥤ Cocone (K ⋙ F)`.
 
-Auxiliary definition for `functorialityIsLeftAdjoint`.
+Auxiliary definition for `functorialityAdjunction`.
 -/
 def functorialityRightAdjoint : Cocone (K ⋙ F) ⥤ Cocone K :=
   Cocones.functoriality _ G ⋙
@@ -61,7 +61,7 @@ attribute [local simp] functorialityRightAdjoint
 
 /-- The unit for the adjunction for `Cocones.functoriality K F : Cocone K ⥤ Cocone (K ⋙ F)`.
 
-Auxiliary definition for `functorialityIsLeftAdjoint`.
+Auxiliary definition for `functorialityAdjunction`.
 -/
 @[simps]
 def functorialityUnit :
@@ -70,7 +70,7 @@ def functorialityUnit :
 
 /-- The counit for the adjunction for `Cocones.functoriality K F : Cocone K ⥤ Cocone (K ⋙ F)`.
 
-Auxiliary definition for `functorialityIsLeftAdjoint`.
+Auxiliary definition for `functorialityAdjunction`.
 -/
 @[simps]
 def functorialityCounit :
@@ -161,7 +161,7 @@ variable {J : Type u} [Category.{v} J] (K : J ⥤ D)
 
 /-- The left adjoint of `Cones.functoriality K G : Cone K ⥤ Cone (K ⋙ G)`.
 
-Auxiliary definition for `functorialityIsRightAdjoint`.
+Auxiliary definition for `functorialityAdjunction'`.
 -/
 def functorialityLeftAdjoint : Cone (K ⋙ G) ⥤ Cone K :=
   Cones.functoriality _ F ⋙
@@ -171,7 +171,7 @@ attribute [local simp] functorialityLeftAdjoint
 
 /-- The unit for the adjunction for `Cones.functoriality K G : Cone K ⥤ Cone (K ⋙ G)`.
 
-Auxiliary definition for `functorialityIsRightAdjoint`.
+Auxiliary definition for `functorialityAdjunction'`.
 -/
 @[simps]
 def functorialityUnit' :
@@ -180,7 +180,7 @@ def functorialityUnit' :
 
 /-- The counit for the adjunction for `Cones.functoriality K G : Cone K ⥤ Cone (K ⋙ G)`.
 
-Auxiliary definition for `functorialityIsRightAdjoint`.
+Auxiliary definition for `functorialityAdjunction'`.
 -/
 @[simps]
 def functorialityCounit' :

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -31,11 +31,11 @@ other side is as well). This demonstrates that adjoints to a given functor are u
 isomorphism (since if `L₁ ≅ L₂` then we deduce `R₁ ≅ R₂`).
 
 Another example arises from considering the square representing that a functor `H` preserves
-products, in particular the morphism `HA ⨯ H- ⟶ H(A ⨯ -)`. Then provided `(A ⨯ -)` and `HA ⨯ -`
+products, in particular the morphism `H A ⨯ H- ⟶ H (A ⨯ -)`. Then provided `(A ⨯ -)` and `H A ⨯ -`
 have left adjoints (for instance if the relevant categories are Cartesian closed), the transferred
-natural transformation is the exponential comparison morphism: `H(A ^ -) ⟶ HA ^ H-`.
+natural transformation is the exponential comparison morphism: `H (A ^ -) ⟶ H A ^ H-`.
 Furthermore if `H` has a left adjoint `L`, this morphism is an isomorphism iff its mate
-`L(HA ⨯ -) ⟶ A ⨯ L-` is an isomorphism, see
+`L (H A ⨯ -) ⟶ A ⨯ L-` is an isomorphism, see
 https://ncatlab.org/nlab/show/Frobenius+reciprocity#InCategoryTheory.
 This also relates to Grothendieck's yoga of six operations, though this is not spelled out in
 mathlib: https://ncatlab.org/nlab/show/six+operations.
@@ -387,7 +387,7 @@ instance conjugateEquiv_symm_iso (α : R₁ ⟶ R₂) [IsIso α] :
       ⟨conjugateEquiv_symm_comm _ _ (by simp), conjugateEquiv_symm_comm _ _ (by simp)⟩⟩⟩
 
 /-- If `α` is a natural transformation between left adjoints whose conjugate natural transformation
-is an isomorphism, then `α` is an isomorphism. The converse is given in `Conjugate_iso`.
+is an isomorphism, then `α` is an isomorphism. The converse is given in `conjugateEquiv_iso`.
 -/
 theorem conjugateEquiv_of_iso (α : L₂ ⟶ L₁) [IsIso (conjugateEquiv adj₁ adj₂ α)] :
     IsIso α := by

--- a/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
+++ b/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
@@ -16,17 +16,17 @@ Given a functor `F : D ⥤ C`, we define a functor
 `F.partialLeftAdjoint : F.PartialLeftAdjointSource ⥤ D` which is
 defined on the full subcategory of `C` consisting of those objects `X : C`
 such that `F ⋙ coyoneda.obj (op X) : D ⥤ Type _` is corepresentable.
-We have a natural bijection
+For `X : F.PartialLeftAdjointSource` and `Y : D`, we have a natural bijection
 `(F.partialLeftAdjoint.obj X ⟶ Y) ≃ (X.obj ⟶ F.obj Y)`
 that is similar to what we would expect for the image of the object `X`
 by the left adjoint of `F`, if such an adjoint existed.
 
-Indeed, if the predicate `F.LeftAdjointObjIsDefined` which defines
+Indeed, if the predicate `F.leftAdjointObjIsDefined` which defines
 the `F.PartialLeftAdjointSource` holds for all
 objects `X : C`, then `F` has a left adjoint.
 
 When colimits indexed by a category `J` exist in `D`, we show that
-the predicate `F.LeftAdjointObjIsDefined` is stable under colimits indexed by `J`.
+the predicate `F.leftAdjointObjIsDefined` is stable under colimits indexed by `J`.
 
 ## TODO
 * consider dualizing the results to right adjoints
@@ -223,7 +223,7 @@ instance (Y : F.PartialRightAdjointSource) :
 
 /-- Given `F : C ⥤ D`, this is `F.partialRightAdjoint` on objects: it sends
 `X : D` such that `F.rightAdjointObjIsDefined X` holds to an object of `C`
-which represents the functor `F ⋙ coyoneda.obj (op X.obj)`. -/
+which represents the functor `F.op ⋙ yoneda.obj X.obj`. -/
 noncomputable def partialRightAdjointObj (Y : F.PartialRightAdjointSource) : C :=
   (F.op ⋙ yoneda.obj Y.obj).reprX
 
@@ -273,7 +273,7 @@ lemma partialRightAdjointHomEquiv_symm_comp {X : C} {Y Y' : F.PartialRightAdjoin
       F.partialRightAdjointHomEquiv.symm (f ≫ g.hom) := by
   simp [Equiv.eq_symm_apply, partialRightAdjointHomEquiv_map_comp]
 
-/-- Given `F : C ⥤ D`, this is the partial adjoint functor `F.PartialLeftAdjointSource ⥤ C`. -/
+/-- Given `F : C ⥤ D`, this is the partial adjoint functor `F.PartialRightAdjointSource ⥤ C`. -/
 @[simps]
 noncomputable def partialRightAdjoint : F.PartialRightAdjointSource ⥤ C where
   obj := F.partialRightAdjointObj

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -40,8 +40,8 @@ bundle the adjunctions in a structure `Triple F G H`.
 * `mono_leftToRight_app_iff_mono_adj₂_unit_app`: `leftToRight : F ⟶ H` is monic at `X` iff
   `adj₂.unit` is monic at `F.obj X`.
 * `mono_leftToRight_app_iff_mono_adj₁_counit_app`: `leftToRight : F ⟶ H` is monic at `X` iff
-  `adj₁.unit` is monic at `H.obj X`.
-* `mono_leftToRight_app_iff`: `leftToRight : H ⟶ F` is componentwise monic iff
+  `adj₁.counit` is monic at `H.obj X`.
+* `mono_leftToRight_app_iff`: `leftToRight : F ⟶ H` is componentwise monic iff
   `adj₁.counit ≫ adj₂.unit : G ⋙ F ⟶ G ⋙ H` is.
 -/
 


### PR DESCRIPTION


---

Issues found and fixed by Codex.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
