### PR TITLE
[Merged by Bors] - feat(Tactic/ApplyWith): use a `config_elab` for `apply (config := cfg)`

### DIFF
--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -18,14 +18,23 @@ The `applyWith` tactic is like `apply`, but allows passing a custom configuratio
 public meta section
 
 namespace Mathlib.Tactic
-open Lean Meta Elab Tactic Term
+open Lean Parser Meta Elab Tactic Term
+
+declare_config_elab elabApplyConfig ApplyConfig
 
 /--
-`apply (config := cfg) e` is like `apply e` but allows you to provide a configuration
-`cfg : ApplyConfig` to pass to the underlying `apply` operation.
+* `apply (config := cfg) e` allows for additional confiugration (see `Lean.Meta.ApplyConfig`):
+  * `newGoals` controls which new goals are added by `apply`, in which order.
+  * `-synthAssignedInstances` will not synthesize instance implicit arguments even if they have been
+    assigned by `isDefEq`.
+  * `+allowSynthFailures` will create new goals when instance synthesis fails, rather than erroring.
+  * `+approx` enables `isDefEq` approximations (see `Lean.Meta.approxDefEq`).
 -/
-elab (name := applyWith) "apply" " (" &"config" " := " cfg:term ") " e:term : tactic => do
-  let cfg ← unsafe evalTerm ApplyConfig (mkConst ``ApplyConfig) cfg
+tactic_extension Lean.Parser.Tactic.apply
+
+@[tactic_alt Lean.Parser.Tactic.apply]
+elab (name := applyWith) "apply" cfg:optConfig e:term : tactic => do
+  let cfg ← elabApplyConfig cfg
   evalApplyLikeTactic (·.apply · cfg) e
 
 end Mathlib.Tactic

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -24,7 +24,7 @@ open Lean Parser Meta Elab Tactic Term
 declare_config_elab elabApplyConfig ApplyConfig
 
 /--
-* `apply (config := cfg) e` allows for additional confiugration (see `Lean.Meta.ApplyConfig`):
+* `apply (config := cfg) e` allows for additional configuration (see `Lean.Meta.ApplyConfig`):
   * `newGoals` controls which new goals are added by `apply`, in which order.
   * `-synthAssignedInstances` will not synthesize instance implicit arguments even if they have been
     assigned by `isDefEq`.

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -20,6 +20,7 @@ public meta section
 namespace Mathlib.Tactic
 open Lean Parser Meta Elab Tactic Term
 
+/-- Elaborator for the configuration in `apply (config := cfg)` syntax. -/
 declare_config_elab elabApplyConfig ApplyConfig
 
 /--

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -26,7 +26,7 @@ declare_config_elab elabApplyConfig ApplyConfig
 /--
 * `apply (config := cfg) e` allows for additional configuration (see `Lean.Meta.ApplyConfig`):
   * `newGoals` controls which new goals are added by `apply`, in which order.
-  * `-synthAssignedInstances` will not synthesize instance implicit arguments even if they have been
+  * `-synthAssignedInstances` will not synthesize instance implicit arguments if they have been
     assigned by `isDefEq`.
   * `+allowSynthFailures` will create new goals when instance synthesis fails, rather than erroring.
   * `+approx` enables `isDefEq` approximations (see `Lean.Meta.approxDefEq`).

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -34,7 +34,7 @@ declare_config_elab elabApplyConfig ApplyConfig
 tactic_extension Lean.Parser.Tactic.apply
 
 @[tactic_alt Lean.Parser.Tactic.apply]
-elab (name := applyWith) "apply" cfg:optConfig e:term : tactic => do
+elab (name := applyWith) "apply" cfg:optConfig ppSpace e:term : tactic => do
   let cfg ← elabApplyConfig cfg
   evalApplyLikeTactic (·.apply · cfg) e
 

--- a/MathlibTest/apply_with.lean
+++ b/MathlibTest/apply_with.lean
@@ -14,3 +14,18 @@ example (f : ∀ x : Nat, x = x → α) : α := by
   apply (config := { newGoals := .all }) f
   apply 1
   apply rfl
+
+class Foo where
+  val : Nat
+
+def foo : Foo where
+  val := 37
+
+def takeImplicit [f : Foo] : Nat :=
+  f.val
+
+example : Nat := by
+  fail_if_success apply takeImplicit -- Default behaviour is `-allowSynthFailures`
+  fail_if_success apply -allowSynthFailures takeImplicit
+  apply +allowSynthFailures takeImplicit
+  apply foo


### PR DESCRIPTION
This PR replaces the custom syntax for `apply (config := cfg)` with the standard `optConfig` and `declare_config_elab`. This means we can now write `apply +allowSynthFailures` instead of `apply (config := { allowSynthFailures := true })`.

Also redo the tactic doc so it is alternative of the plain `apply` tactic, rather than having it have own documentation.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
