### PR TITLE
[Merged by Bors] - chore(*): use `apply +allowSynthFailures` syntax

### DIFF
--- a/Mathlib/Algebra/Category/Grp/AB.lean
+++ b/Mathlib/Algebra/Category/Grp/AB.lean
@@ -61,7 +61,7 @@ attribute [local instance] Abelian.hasFiniteBiproducts
 instance : AB4 AddCommGrpCat.{u} := AB4.of_AB5 _
 
 instance : HasExactLimitsOfShape (Discrete J) (AddCommGrpCat.{u}) := by
-  apply (config := { allowSynthFailures := true }) hasExactLimitsOfShape_of_preservesEpi
+  apply +allowSynthFailures hasExactLimitsOfShape_of_preservesEpi
   exact {
     preserves {X Y} f hf := by
       let iX : limit X ≅ AddCommGrpCat.of ((i : J) → X.obj ⟨i⟩) := (Pi.isoLimit X).symm ≪≫

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -204,7 +204,7 @@ radical containing `J`. This uses Noetherianness. -/
 instance ideal_powers_initial [hR : IsNoetherian R R] :
     Functor.Initial (idealPowersToSelfLERadical J) where
   out J' := by
-    apply (config := { allowSynthFailures := true }) zigzag_isConnected
+    apply +allowSynthFailures zigzag_isConnected
     · obtain ⟨k, hk⟩ := Ideal.exists_pow_le_of_le_radical_of_fg J'.2 (isNoetherian_def.mp hR _)
       exact ⟨CostructuredArrow.mk (⟨⟨⟨hk⟩⟩⟩ : (idealPowersToSelfLERadical J).obj (op k) ⟶ J')⟩
     · intro j1 j2

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -232,9 +232,8 @@ instance hasLimits : HasLimits AffineScheme.{u} := by
 noncomputable instance Γ_preservesLimits : PreservesLimits Γ.{u}.rightOp := inferInstance
 
 noncomputable instance forgetToScheme_preservesLimits : PreservesLimits forgetToScheme := by
-  apply (config := { allowSynthFailures := true })
-    @preservesLimits_of_natIso _ _ _ _ _ _
-      (Functor.isoWhiskerRight equivCommRingCat.unitIso forgetToScheme).symm
+  apply +allowSynthFailures @preservesLimits_of_natIso _ _ _ _ _ _
+    (Functor.isoWhiskerRight equivCommRingCat.unitIso forgetToScheme).symm
   change PreservesLimits (equivCommRingCat.functor ⋙ Scheme.Spec)
   infer_instance
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -84,9 +84,9 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
     let c' : LimitCone F := ⟨_, (IsLimit.postcomposeInvEquiv (asIso e) _).symm
       (isLimitOfPreserves Scheme.Spec (limit.isLimit (F ⋙ Scheme.Γ.rightOp)))⟩
     have : Nonempty c'.1.pt := by
-      apply (config := { allowSynthFailures := true }) PrimeSpectrum.instNonemptyOfNontrivial
+      apply +allowSynthFailures PrimeSpectrum.instNonemptyOfNontrivial
       have (i' : _) : Nontrivial ((F ⋙ Scheme.Γ.rightOp).leftOp.obj i') := by
-        apply (config := { allowSynthFailures := true }) Scheme.component_nontrivial
+        apply +allowSynthFailures Scheme.component_nontrivial
         simp
       exact CommRingCat.FilteredColimits.nontrivial
         (isColimitCoconeLeftOpOfCone _ (limit.isLimit (F ⋙ Scheme.Γ.rightOp)))

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -409,7 +409,7 @@ instance isIso_locallyRingedSpaceAdjunction_counit :
   (NatIso.op SpecΓIdentity).isIso_inv
 
 instance isIso_adjunction_counit : IsIso ΓSpec.adjunction.counit := by
-  apply (config := { allowSynthFailures := true }) NatIso.isIso_of_isIso_app
+  apply +allowSynthFailures NatIso.isIso_of_isIso_app
   intro R
   rw [adjunction_counit_app]
   infer_instance

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -540,7 +540,7 @@ lemma exists_of_pullback_V_V {i j k : J} (x : pullback (C := Scheme) (V F i j).�
         (le_iSup_of_le ⟨l, hli ≫ k₁.2.1, hlk ≫ k₂.2.2⟩ le_rfl))
       (by simp)
   have : IsOpenImmersion α := by
-    apply (config := { allowSynthFailures := true }) IsOpenImmersion.of_comp
+    apply +allowSynthFailures IsOpenImmersion.of_comp
     · exact inferInstanceAs (IsOpenImmersion (pullback.fst _ _))
     · simp only [limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, α]
       infer_instance

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -105,7 +105,7 @@ instance spec_punit_isEmpty : IsEmpty (Spec <| .of PUnit.{u + 1}) :=
 
 instance (priority := 100) isOpenImmersion_of_isEmpty {X Y : Scheme} (f : X ⟶ Y)
     [IsEmpty X] : IsOpenImmersion f := by
-  apply (config := { allowSynthFailures := true }) IsOpenImmersion.of_isIso_stalkMap
+  apply +allowSynthFailures IsOpenImmersion.of_isIso_stalkMap
   · exact .of_isEmpty (X := X) _
   · intro (i : X); exact isEmptyElim i
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Immersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Immersion.lean
@@ -109,7 +109,7 @@ instance : IsZariskiLocalAtTarget @IsImmersion := by
   suffices IsZariskiLocalAtTarget
       (topologically fun {X Y} _ _ f ↦ IsLocallyClosed (Set.range f)) from
     isImmersion_eq_inf ▸ inferInstance
-  apply (config := { allowSynthFailures := true }) topologically_isZariskiLocalAtTarget'
+  apply +allowSynthFailures topologically_isZariskiLocalAtTarget'
   · refine { precomp := ?_, postcomp := ?_ }
     · intro X Y Z i hi f hf
       change IsIso i at hi

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -450,7 +450,7 @@ instance isIso_ΓSpec_adjunction_unit_app_basicOpen
   refine @IsIso.of_isIso_comp_right _ _ _ _ _ _ (X.presheaf.map
     (eqToHom (Scheme.toSpecΓ_preimage_basicOpen _ _).symm).op) _ ?_
   rw [ConcreteCategory.isIso_iff_bijective]
-  apply (config := { allowSynthFailures := true }) IsLocalization.bijective
+  apply +allowSynthFailures IsLocalization.bijective
   · exact StructureSheaf.IsLocalization.to_basicOpen _ _
   · refine isLocalization_basicOpen_of_qcqs ?_ ?_ _
     · exact isCompact_univ

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -164,7 +164,7 @@ theorem sourceAffineLocally_isLocal (h₁ : RingHom.RespectsIso P)
     rw [← f.appLE_congr (by simp [Scheme.Hom.appLE]) rfl this (fun f => P f.hom),
       IsAffineOpen.appLE_eq_away_map f (isAffineOpen_top Y) U.2 _ r]
     simp only [CommRingCat.hom_ofHom]
-    apply (config := { allowSynthFailures := true }) h₂
+    apply +allowSynthFailures h₂
     exact H U
   · introv hs hs' U
     apply h₃ _ _ hs

--- a/Mathlib/AlgebraicGeometry/Morphisms/Separated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Separated.lean
@@ -288,7 +288,7 @@ lemma ext_of_isDominant_of_isSeparated [IsReduced X] {f g : X ⟶ Y}
   let ι' : U' ⟶ X' := Over.homMk ι
   have : IsSeparated Y'.hom := ‹_›
   have : IsDominant (equalizer.ι f' g').left := by
-    apply (config := { allowSynthFailures := true }) IsDominant.of_comp (equalizer.lift ι' ?_).left
+    apply +allowSynthFailures IsDominant.of_comp (equalizer.lift ι' ?_).left
     · rwa [← Over.comp_left, equalizer.lift_ι]
     · ext1; exact hU
   have : Surjective (equalizer.ι f' g').left :=
@@ -332,7 +332,7 @@ instance (priority := low) {X : Scheme.{u}} [X.IsSeparated] : QuasiSeparatedSpac
   quasiSeparatedSpace_of_quasiSeparated (terminal.from X)
 
 instance (priority := 900) [X.IsSeparated] : IsSeparated f := by
-  apply (config := { allowSynthFailures := true }) @IsSeparated.of_comp (g := terminal.from Y)
+  apply +allowSynthFailures @IsSeparated.of_comp (g := terminal.from Y)
   rw [terminal.comp_from]
   infer_instance
 

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -39,7 +39,7 @@ instance : T0Space X :=
     (isAffineOpen_opensRange (X.affineCover.f _)).isoSpec.schemeIsoToHomeo.isEmbedding⟩
 
 instance : QuasiSober X := by
-  apply (config := { allowSynthFailures := true })
+  apply +allowSynthFailures
     quasiSober_of_open_cover (Set.range fun x => Set.range <| (X.affineCover.f x))
   · rintro ⟨_, i, rfl⟩; exact (X.affineCover.f i).isOpenEmbedding.isOpen_range
   · rintro ⟨_, i, rfl⟩
@@ -94,7 +94,7 @@ theorem isReduced_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [IsOpenImmersi
     (asIso <| f.app (f ''ᵁ U) : Γ(Y, f ''ᵁ U) ≅ _).symm.commRingCatIsoToRingEquiv.injective
 
 instance {R : CommRingCat.{u}} [H : _root_.IsReduced R] : IsReduced (Spec R) := by
-  apply (config := { allowSynthFailures := true }) isReduced_of_isReduced_stalk
+  apply +allowSynthFailures isReduced_of_isReduced_stalk
   intro x; dsimp
   have : _root_.IsReduced (CommRingCat.of <| Localization.AtPrime (PrimeSpectrum.asIdeal x)) := by
     dsimp; infer_instance
@@ -272,7 +272,7 @@ theorem isIntegral_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [IsOpenImmers
   intro U hU
   rw [← f.preimage_image_eq U]
   have : IsDomain Γ(Y, f ''ᵁ U) := by
-    apply (config := { allowSynthFailures := true }) IsIntegral.component_integral
+    apply +allowSynthFailures IsIntegral.component_integral
     exact ⟨⟨_, _, hU.some.prop, rfl⟩⟩
   exact (asIso <| f.app (f ''ᵁ U) :
     Γ(Y, f ''ᵁ U) ≅ _).symm.commRingCatIsoToRingEquiv.toMulEquiv.isDomain _

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Presentable.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Presentable.lean
@@ -38,8 +38,7 @@ lemma exists_epi_from_isCardinalPresentable (X : SSet.{u}) [X.Finite] :
       (p : Y ⟶ X), Epi p := by
   refine ⟨∐ (fun (s : X.N) ↦ Δ[s.dim]), inferInstance, ?_,
     Sigma.desc (fun s ↦ yonedaEquiv.symm s.simplex), ?_⟩
-  · apply (config := { allowSynthFailures := true })
-      isCardinalPresentable_of_isColimit' _ (coproductIsCoproduct _)
+  · apply +allowSynthFailures isCardinalPresentable_of_isColimit' _ (coproductIsCoproduct _)
     · exact hasCardinalLT_of_finite _ _ (by rfl)
     · rintro s
       dsimp
@@ -53,8 +52,7 @@ instance (X : SSet.{u}) [X.Finite] : IsFinitelyPresentable.{u} X := by
   obtain ⟨Z, _, _, q, _⟩ := exists_epi_from_isCardinalPresentable (pullback p p)
   have := Cardinal.fact_isRegular_aleph0.{u}
   have := IsRegularEpiCategory.regularEpiOfEpi p
-  apply (config := { allowSynthFailures := true })
-    isCardinalPresentable_of_isColimit' _
+  apply +allowSynthFailures isCardinalPresentable_of_isColimit' _
       (isCoequalizerEpiComp ((EffectiveEpi.getStruct p).isColimitCoforkOfIsPullback
         (IsPullback.of_hasPullback p p)) q) _
   · exact hasCardinalLT_of_finite _ _ (by rfl)

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
@@ -536,8 +536,7 @@ category has finite biproducts and finite limits.
 -/
 lemma CountableAB4.of_hasExactColimitsOfShape_nat [HasFiniteLimits C] [HasCountableCoproducts C]
     [HasExactColimitsOfShape (Discrete ℕ) C] : CountableAB4 C := by
-  apply (config := { allowSynthFailures := true })
-      CountableAB4.of_hasExactColimitsOfShape_nat_and_finite
+  apply +allowSynthFailures CountableAB4.of_hasExactColimitsOfShape_nat_and_finite
   exact fun _ ↦ inferInstance
 
 /--
@@ -546,8 +545,7 @@ category has finite biproducts and finite colimits.
 -/
 lemma CountableAB4Star.of_hasExactLimitsOfShape_nat [HasFiniteColimits C]
     [HasCountableProducts C] [HasExactLimitsOfShape (Discrete ℕ) C] : CountableAB4Star C := by
-  apply (config := { allowSynthFailures := true })
-      CountableAB4Star.of_hasExactLimitsOfShape_nat_and_finite
+  apply +allowSynthFailures CountableAB4Star.of_hasExactLimitsOfShape_nat_and_finite
   exact fun _ ↦ inferInstance
 
 end
@@ -564,7 +562,7 @@ colimits of shape `J`.
 lemma hasExactColimitsOfShape_of_preservesMono [HasColimitsOfShape J C]
     [PreservesMonomorphisms (colim (J := J) (C := C))] : HasExactColimitsOfShape J C where
   preservesFiniteLimits := by
-    apply (config := { allowSynthFailures := true }) preservesFiniteLimits_of_preservesHomology
+    apply +allowSynthFailures preservesFiniteLimits_of_preservesHomology
     · exact preservesHomology_of_preservesMonos_and_cokernels _
     · exact additive_of_preservesBinaryBiproducts _
 
@@ -575,7 +573,7 @@ limits of shape `J`.
 lemma hasExactLimitsOfShape_of_preservesEpi [HasLimitsOfShape J C]
     [PreservesEpimorphisms (lim (J := J) (C := C))] : HasExactLimitsOfShape J C where
   preservesFiniteColimits := by
-    apply (config := { allowSynthFailures := true }) preservesFiniteColimits_of_preservesHomology
+    apply +allowSynthFailures preservesFiniteColimits_of_preservesHomology
     · exact preservesHomology_of_preservesEpis_and_kernels _
     · exact additive_of_preservesBinaryBiproducts _
 

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -387,11 +387,11 @@ instance (D : GlueData' C) (i : D.J) :
 instance (D : GlueData' C) (i j k : D.J) :
     HasPullback (D.f' i j) (D.f' i k) := by
   if hij : i = j then
-    apply (config := { allowSynthFailures := true }) hasPullback_of_left_iso
+    apply +allowSynthFailures hasPullback_of_left_iso
     simp only [GlueData'.f', dif_pos hij]
     infer_instance
   else if hik : i = k then
-    apply (config := { allowSynthFailures := true }) hasPullback_of_right_iso
+    apply +allowSynthFailures hasPullback_of_right_iso
     simp only [GlueData'.f', dif_pos hik]
     infer_instance
   else
@@ -413,7 +413,7 @@ def GlueData'.t'' (D : GlueData' C) (i j k : D.J) :
       eqToHom (dif_neg (Ne.symm hij)).symm ≫ inv (pullback.snd _ _)
   else if hjk : j = k then
     have : IsIso (pullback.snd (D.f' j k) (D.f' j i)) := by
-      apply (config := { allowSynthFailures := true }) pullback_snd_iso_of_left_iso
+      apply +allowSynthFailures pullback_snd_iso_of_left_iso
       simp only [hjk, GlueData'.f', ↓reduceDIte]
       infer_instance
     pullback.fst _ _ ≫ eqToHom (dif_neg hij) ≫ D.t _ _ _ ≫

--- a/Mathlib/CategoryTheory/Limits/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/Limits/MorphismProperty.lean
@@ -159,7 +159,7 @@ variable (X : T)
 
 noncomputable instance [P.ContainsIdentities] [P.RespectsIso] :
     CreatesLimitsOfShape (Discrete PEmpty.{1}) (Over.forget P ⊤ X) := by
-  apply (config := { allowSynthFailures := true }) forgetCreatesLimitsOfShapeOfClosed
+  apply +allowSynthFailures forgetCreatesLimitsOfShapeOfClosed
   · exact inferInstanceAs (HasLimitsOfShape _ (Over X))
   · apply Over.closedUnderLimitsOfShape_discrete_empty _
 
@@ -187,7 +187,7 @@ instance [P.ContainsIdentities] : HasTerminal (P.Over ⊤ X) :=
 noncomputable instance createsLimitsOfShape_walkingCospan [HasPullbacks T]
     [P.IsStableUnderComposition] [P.IsStableUnderBaseChange] [P.HasOfPostcompProperty P] :
     CreatesLimitsOfShape WalkingCospan (Over.forget P ⊤ X) := by
-  apply (config := { allowSynthFailures := true }) forgetCreatesLimitsOfShapeOfClosed
+  apply +allowSynthFailures forgetCreatesLimitsOfShapeOfClosed
   · exact inferInstanceAs (HasLimitsOfShape WalkingCospan (Over X))
   · apply Over.closedUnderLimitsOfShape_pullback
 
@@ -195,8 +195,7 @@ noncomputable instance createsLimitsOfShape_walkingCospan [HasPullbacks T]
 `P.Over ⊤ X` has pullbacks -/
 instance (priority := 900) hasPullbacks [HasPullbacks T] [P.IsStableUnderComposition]
     [P.IsStableUnderBaseChange] [P.HasOfPostcompProperty P] : HasPullbacks (P.Over ⊤ X) := by
-  apply (config := { allowSynthFailures := true })
-    hasLimitsOfShape_of_closedUnderLimitsOfShape
+  apply +allowSynthFailures hasLimitsOfShape_of_closedUnderLimitsOfShape
   · exact inferInstanceAs (HasLimitsOfShape WalkingCospan (Over X))
   · apply Over.closedUnderLimitsOfShape_pullback
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -471,7 +471,7 @@ products. -/
 lemma preservesFiniteProducts_op (F : C ⥤ D) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.op where
   preserves n := by
-    apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_op
+    apply +allowSynthFailures preservesLimitsOfShape_op
     exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite coproducts, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
@@ -479,7 +479,7 @@ products. -/
 lemma preservesFiniteProducts_leftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.leftOp where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_leftOp
+    apply +allowSynthFailures preservesLimitsOfShape_leftOp
     exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite coproducts, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
@@ -487,7 +487,7 @@ products. -/
 lemma preservesFiniteProducts_rightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.rightOp where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_rightOp
+    apply +allowSynthFailures preservesLimitsOfShape_rightOp
     exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite coproducts, then `F.unop : C ⥤ D` preserves finite
@@ -495,7 +495,7 @@ products. -/
 lemma preservesFiniteProducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteCoproducts F] :
     PreservesFiniteProducts F.unop where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesLimitsOfShape_unop
+    apply +allowSynthFailures preservesLimitsOfShape_unop
     exact preservesColimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ D` preserves finite products, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite
@@ -503,7 +503,7 @@ coproducts. -/
 lemma preservesFiniteCoproducts_op (F : C ⥤ D) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.op where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_op
+    apply +allowSynthFailures preservesColimitsOfShape_op
     exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : C ⥤ Dᵒᵖ` preserves finite products, then `F.leftOp : Cᵒᵖ ⥤ D` preserves finite
@@ -511,7 +511,7 @@ coproducts. -/
 lemma preservesFiniteCoproducts_leftOp (F : C ⥤ Dᵒᵖ) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.leftOp where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_leftOp
+    apply +allowSynthFailures preservesColimitsOfShape_leftOp
     exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ D` preserves finite products, then `F.rightOp : C ⥤ Dᵒᵖ` preserves finite
@@ -519,7 +519,7 @@ coproducts. -/
 lemma preservesFiniteCoproducts_rightOp (F : Cᵒᵖ ⥤ D) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.rightOp where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_rightOp
+    apply +allowSynthFailures preservesColimitsOfShape_rightOp
     exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 /-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` preserves finite products, then `F.unop : C ⥤ D` preserves finite
@@ -527,7 +527,7 @@ coproducts. -/
 lemma preservesFiniteCoproducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteProducts F] :
     PreservesFiniteCoproducts F.unop where
   preserves _ := by
-    apply (config := { allowSynthFailures := true }) preservesColimitsOfShape_unop
+    apply +allowSynthFailures preservesColimitsOfShape_unop
     exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
@@ -217,15 +217,15 @@ attribute [local instance] hasBinaryBiproducts_of_finite_biproducts
 
 lemma functorMap_epi (n : ℕ) : Epi (functorMap f n) := by
   rw [functorMap, Pi.map_eq_prod_map (P := fun m : ℕ ↦ m < n + 1)]
-  apply (config := { allowSynthFailures := true }) epi_comp
-  apply (config := { allowSynthFailures := true }) epi_comp
-  apply (config := { allowSynthFailures := true }) prod.map_epi
-  · apply (config := { allowSynthFailures := true }) Pi.map_epi
+  apply +allowSynthFailures epi_comp
+  apply +allowSynthFailures epi_comp
+  apply +allowSynthFailures prod.map_epi
+  · apply +allowSynthFailures Pi.map_epi
     intro ⟨_, _⟩
     split
     all_goals infer_instance
-  · apply (config := { allowSynthFailures := true }) IsIso.epi_of_iso
-    apply (config := { allowSynthFailures := true }) Pi.map_isIso
+  · apply +allowSynthFailures IsIso.epi_of_iso
+    apply +allowSynthFailures Pi.map_isIso
     intro ⟨_, _⟩
     split
     all_goals infer_instance

--- a/Mathlib/CategoryTheory/Monad/Comonadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Comonadicity.lean
@@ -224,7 +224,7 @@ Beck's comonadicity theorem, the converse is given in `comonadicOfCreatesFSplitE
 -/
 def createsFSplitEqualizersOfComonadic [ComonadicLeftAdjoint F] ⦃A B⦄ (f g : A ⟶ B)
     [F.IsCosplitPair f g] : CreatesLimit (parallelPair f g) F := by
-  apply (config := { allowSynthFailures := true }) comonadicCreatesLimitOfPreservesLimit
+  apply +allowSynthFailures comonadicCreatesLimitOfPreservesLimit
   all_goals
     apply @preservesLimit_of_iso_diagram _ _ _ _ _ _ _ _ _ (diagramIsoParallelPair.{v₁} _).symm ?_
     dsimp

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -230,8 +230,8 @@ monadicity theorem, the converse is given in `monadicOfCreatesGSplitCoequalizers
 -/
 def createsGSplitCoequalizersOfMonadic [MonadicRightAdjoint G] ⦃A B⦄ (f g : A ⟶ B)
     [G.IsSplitPair f g] : CreatesColimit (parallelPair f g) G := by
-  apply (config := { allowSynthFailures := true }) monadicCreatesColimitOfPreservesColimit
-    -- Porting note: oddly (config := {allowSynthFailures := true}) had no effect here and below
+  apply +allowSynthFailures monadicCreatesColimitOfPreservesColimit
+    -- Porting note: oddly +allowSynthFailures had no effect here and below
   all_goals
     apply @preservesColimit_of_iso_diagram _ _ _ _ _ _ _ _ _ (diagramIsoParallelPair.{v₁} _).symm ?_
     dsimp

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveColimits.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveColimits.lean
@@ -37,7 +37,7 @@ lemma isSheaf_pointwiseColimit [PreservesFiniteProducts (colim (J := J) (C := A)
     Presheaf.IsSheaf (extensiveTopology C) (pointwiseCocone (G ⋙ sheafToPresheaf _ A)).pt := by
   rw [Presheaf.isSheaf_iff_preservesFiniteProducts]
   dsimp only [pointwiseCocone_pt]
-  apply (config := { allowSynthFailures := true }) comp_preservesFiniteProducts
+  apply +allowSynthFailures comp_preservesFiniteProducts
   have : ∀ (i : J), PreservesFiniteProducts ((G ⋙ sheafToPresheaf _ A).obj i) := fun i ↦ by
     rw [← Presheaf.isSheaf_iff_preservesFiniteProducts]
     exact Sheaf.cond _
@@ -46,8 +46,7 @@ lemma isSheaf_pointwiseColimit [PreservesFiniteProducts (colim (J := J) (C := A)
 
 instance [Preadditive A] : PreservesFiniteProducts (colim (J := J) (C := A)) where
   preserves _ := by
-    apply (config := { allowSynthFailures := true })
-      preservesProductsOfShape_of_preservesBiproductsOfShape
+    apply +allowSynthFailures preservesProductsOfShape_of_preservesBiproductsOfShape
     apply preservesBiproductsOfShape_of_preservesCoproductsOfShape
 
 instance [PreservesFiniteProducts (colim (J := J) (C := A))] :

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/SheafEquiv.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/SheafEquiv.lean
@@ -99,11 +99,10 @@ lemma isIso_ranCounit_app_of_isDenseSubsite (Y : Sheaf J A) (U X) :
       simp [← Functor.map_comp, ← op_comp, hiUV]
 
 instance (Y : Sheaf J A) : IsIso ((G.sheafAdjunctionCocontinuous A J K).counit.app Y) := by
-  apply (config := { allowSynthFailures := true })
-    ReflectsIsomorphisms.reflects (sheafToPresheaf J A)
+  apply +allowSynthFailures ReflectsIsomorphisms.reflects (sheafToPresheaf J A)
   rw [NatTrans.isIso_iff_isIso_app]
   intro ⟨U⟩
-  apply (config := { allowSynthFailures := true }) ReflectsIsomorphisms.reflects yoneda
+  apply +allowSynthFailures ReflectsIsomorphisms.reflects yoneda
   rw [NatTrans.isIso_iff_isIso_app]
   intro ⟨X⟩
   simp only [comp_obj, sheafToPresheaf_obj, sheafPushforwardContinuous_obj_val_obj, yoneda_obj_obj,

--- a/Mathlib/Condensed/TopComparison.lean
+++ b/Mathlib/Condensed/TopComparison.lean
@@ -112,7 +112,7 @@ def TopCat.toSheafCompHausLike :
     have := CompHausLike.preregular hs
     rw [Presheaf.isSheaf_iff_preservesFiniteProducts_and_equalizerCondition]
     refine ⟨inferInstance, ?_⟩
-    apply (config := { allowSynthFailures := true }) equalizerCondition_yonedaPresheaf
+    apply +allowSynthFailures equalizerCondition_yonedaPresheaf
       (CompHausLike.compHausLikeToTop.{u} P) X
     intro Z B π he
     apply IsQuotientMap.of_surjective_continuous (hs _ he) π.hom.hom.continuous

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -392,7 +392,7 @@ lemma exists_finset_maximalFor_isTranscendenceBasis_separableClosure
     simp [Set.Finite, ← Cardinal.mk_lt_aleph0_iff, ht.cardinalMk_eq hs, Cardinal.natCast_lt_aleph0]
   lift t to Finset E using this
   have : Module.Finite (adjoin F (s : Set E)) E := by
-    apply (config := { allowSynthFailures := true }) Algebra.finite_of_essFiniteType_of_isAlgebraic
+    apply +allowSynthFailures Algebra.finite_of_essFiniteType_of_isAlgebraic
     · exact .of_comp F _ _
     · convert hs.isAlgebraic_field <;> simp [s]
   have : Module.Finite ((separableClosure (adjoin F (s : Set E)) E).restrictScalars F) E :=

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
@@ -129,7 +129,7 @@ def comp {X Y Z : LocallyRingedSpace.{u}} (f : Hom X Y) (g : Hom Y Z) : Hom X Z 
   toHom := (f.toHom ≫ g.toHom : X.toPresheafedSpace ⟶ Z.toPresheafedSpace)
   prop x := by
     rw [PresheafedSpace.stalkMap.comp]
-    apply (config := { allowSynthFailures := true }) RingHom.isLocalHom_comp
+    apply +allowSynthFailures RingHom.isLocalHom_comp
     all_goals apply isLocalHomValStalkMap
 
 /-- The category of locally ringed spaces. -/

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
@@ -136,8 +136,8 @@ theorem coequalizer_π_app_isLocalHom
   haveI : IsIso (PreservesCoequalizer.iso
       SheafedSpace.forgetToPresheafedSpace f.toShHom g.toShHom).hom.c :=
     inferInstance
-  apply (config := { allowSynthFailures := true }) RingHom.isLocalHom_comp
-  · apply (config := { allowSynthFailures := true }) RingHom.isLocalHom_comp
+  apply +allowSynthFailures RingHom.isLocalHom_comp
+  · apply +allowSynthFailures RingHom.isLocalHom_comp
     · apply CommRingCat.equalizer_ι_isLocalHom'
     · apply isLocalHom_of_isIso
   · apply isLocalHom_of_isIso

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -275,7 +275,7 @@ theorem to_iso [h' : Epi f.base] : IsIso f := by
       exact (Set.image_preimage_eq _ ((TopCat.epi_iff_surjective _).mp h')).symm
     convert H.c_iso (Opens.map f.base |>.obj <| unop U)
   have : IsIso f.c := NatIso.isIso_of_isIso_app _
-  apply (config := { allowSynthFailures := true }) isIso_of_components
+  apply +allowSynthFailures isIso_of_components
   let t : X ≃ₜ Y := H.base_open.isEmbedding.toHomeomorph.trans
     { toFun := Subtype.val
       invFun := fun x =>
@@ -735,8 +735,7 @@ theorem of_stalk_iso {X Y : SheafedSpace C} (f : X ⟶ Y) (hf : IsOpenEmbedding 
     [H : ∀ x : X.1, IsIso (f.hom.stalkMap x)] : SheafedSpace.IsOpenImmersion f :=
   { base_open := hf
     c_iso := fun U => by
-      apply (config := { allowSynthFailures := true })
-        TopCat.Presheaf.app_isIso_of_stalkFunctor_map_iso
+      apply +allowSynthFailures TopCat.Presheaf.app_isIso_of_stalkFunctor_map_iso
           (show Y.sheaf ⟶ (TopCat.Sheaf.pushforward _ f.hom.base).obj X.sheaf from ⟨f.hom.c⟩)
       rintro ⟨_, y, hy, rfl⟩
       specialize H y
@@ -1049,18 +1048,12 @@ instance forgetToTop_preservesPullback_of_left :
   change PreservesLimit _ <|
     (LocallyRingedSpace.forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace) ⋙
     PresheafedSpace.forget _
-  -- Porting note: was `apply (config := { instances := False }) ...`
-  -- See https://github.com/leanprover/lean4/issues/2273
-  have : PreservesLimit
-      (cospan ((cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace).map
-        WalkingCospan.Hom.inl)
-      ((cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace).map
-        WalkingCospan.Hom.inr)) (PresheafedSpace.forget CommRingCat) := by
-    dsimp; infer_instance
-  have : PreservesLimit (cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace)
-      (PresheafedSpace.forget CommRingCat) := by
-    apply preservesLimit_of_iso_diagram _ (diagramIsoCospan _).symm
-  apply Limits.comp_preservesLimit
+  apply +allowSynthFailures Limits.comp_preservesLimit
+  dsimp
+  apply +allowSynthFailures preservesLimit_of_iso_diagram
+  · exact (diagramIsoCospan _).symm
+  dsimp
+  infer_instance
 
 instance forget_reflectsPullback_of_left :
     ReflectsLimit (cospan f g) LocallyRingedSpace.forgetToSheafedSpace :=
@@ -1091,9 +1084,9 @@ instance forgetToPresheafedSpace_reflectsPullback_of_right :
 
 theorem pullback_snd_isIso_of_range_subset (H' : Set.range g.base ⊆ Set.range f.base) :
     IsIso (pullback.snd f g) := by
-  apply (config := { allowSynthFailures := true }) Functor.ReflectsIsomorphisms.reflects
+  apply +allowSynthFailures Functor.ReflectsIsomorphisms.reflects
     (F := LocallyRingedSpace.forgetToSheafedSpace)
-  apply (config := { allowSynthFailures := true }) Functor.ReflectsIsomorphisms.reflects
+  apply +allowSynthFailures Functor.ReflectsIsomorphisms.reflects
     (F := SheafedSpace.forgetToPresheafedSpace)
   erw [← PreservesPullback.iso_hom_snd
       (LocallyRingedSpace.forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace) f g]

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -435,10 +435,10 @@ theorem π_ιInvApp_π (i j : D.J) (U : Opens (D.U i).carrier) :
       limit.w (componentwiseDiagram 𝖣.diagram.multispan _)
         (Quiver.Hom.op (WalkingMultispan.Hom.fst (i, j)))
   · rw [Category.comp_id]
-    apply (config := { allowSynthFailures := true }) mono_comp
+    apply +allowSynthFailures mono_comp
     change Mono ((_ ≫ D.f j i).c.app _)
     rw [comp_c_app]
-    apply (config := { allowSynthFailures := true }) mono_comp
+    apply +allowSynthFailures mono_comp
     · erw [D.ι_image_preimage_eq i j U]
       infer_instance
     · have : IsIso (D.t i j).c := by apply c_isIso_of_iso
@@ -634,8 +634,8 @@ theorem ι_isoSheafedSpace_inv (i : D.J) :
 instance ι_isOpenImmersion (i : D.J) : IsOpenImmersion (𝖣.ι i) := by
   dsimp [IsOpenImmersion]
   rw [← D.ι_isoSheafedSpace_inv]
-  apply (config := { allowSynthFailures := true }) PresheafedSpace.IsOpenImmersion.comp
-  -- Porting note: this was automatic
+  -- Porting note: the next lines were a single `apply_instance`
+  apply +allowSynthFailures PresheafedSpace.IsOpenImmersion.comp
   exact (D.toSheafedSpaceGlueData).ιIsOpenImmersion i
 
 instance (i j k : D.J) : PreservesLimit (cospan (𝖣.f i j) (𝖣.f i k)) forgetToSheafedSpace :=

--- a/Mathlib/RingTheory/Spectrum/Prime/Polynomial.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Polynomial.lean
@@ -173,7 +173,7 @@ lemma comap_C_surjective : Function.Surjective (comap (R := R) C) := by
 
 lemma exists_image_comap_of_monic (f g : R[X]) (hg : g.Monic) :
     ∃ t : Finset R, comap C '' (zeroLocus {g} \ zeroLocus {f}) = (zeroLocus t)ᶜ := by
-  apply (config := { allowSynthFailures := true }) exists_image_comap_of_finite_of_free
+  apply +allowSynthFailures exists_image_comap_of_finite_of_free
   · exact .of_basis (AdjoinRoot.powerBasis' hg).basis
   · exact .of_basis (AdjoinRoot.powerBasis' hg).basis
 

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -137,7 +137,7 @@ noncomputable def toTotalQuotientPresheaf : F ⟶ F.totalQuotientPresheaf :=
 deriving Epi
 
 instance (F : X.Sheaf CommRingCat.{w}) : Mono F.presheaf.toTotalQuotientPresheaf := by
-  apply (config := { allowSynthFailures := true }) NatTrans.mono_of_mono_app
+  apply +allowSynthFailures NatTrans.mono_of_mono_app
   intro U
   apply ConcreteCategory.mono_of_injective
   dsimp [toTotalQuotientPresheaf]


### PR DESCRIPTION
This PR updates Mathlib to use `apply +allowSynthFailures` everywhere instead of the old `apply (config := { allowSynthFailures := true})` syntax. En passant, we solve a porting note that never got fixed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #34524

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
