### PR TITLE
[Merged by Bors] - chore: avoid redundant error message in differential geometry elaborators

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -299,7 +299,10 @@ def findModel (e : Expr) (baseInfo : Option (Expr × Expr) := none) : TermElabM 
   if let some m ← tryStrategy m!"Sphere"              fromSphere         then return m
   if let some m ← tryStrategy m!"NormedField"         fromNormedField    then return m
   if let some m ← tryStrategy m!"InnerProductSpace"   fromInnerProductSpace then return m
-  throwError "Could not find a model with corners for `{e}`.
+  if (← getOptions).get `trace.Elab.DiffGeo false || (← getOptions).get `trace.Elab.DiffGeo.MDiff false then
+    throwError m!"Could not find a model with corners for `{e}`."
+  else
+  throwError m!"Could not find a model with corners for `{e}`.
 
 Hint: failures to find a model with corners can be debugged with the command \
 `set_option trace.Elab.DiffGeo.MDiff true`."

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -299,7 +299,7 @@ def findModel (e : Expr) (baseInfo : Option (Expr × Expr) := none) : TermElabM 
   if let some m ← tryStrategy m!"Sphere"              fromSphere         then return m
   if let some m ← tryStrategy m!"NormedField"         fromNormedField    then return m
   if let some m ← tryStrategy m!"InnerProductSpace"   fromInnerProductSpace then return m
-  if (← getOptions).get `trace.Elab.DiffGeo false || (← getOptions).get `trace.Elab.DiffGeo.MDiff false then
+  if ← isTracingEnabledFor `Elab.DiffGeo.MDiff then
     throwError m!"Could not find a model with corners for `{e}`."
   else
   throwError m!"Could not find a model with corners for `{e}`.

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -302,7 +302,7 @@ def findModel (e : Expr) (baseInfo : Option (Expr × Expr) := none) : TermElabM 
   if ← isTracingEnabledFor `Elab.DiffGeo.MDiff then
     throwError m!"Could not find a model with corners for `{e}`."
   else
-  throwError m!"Could not find a model with corners for `{e}`.
+    throwError m!"Could not find a model with corners for `{e}`.
 
 Hint: failures to find a model with corners can be debugged with the command \
 `set_option trace.Elab.DiffGeo.MDiff true`."

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -929,8 +929,6 @@ variable {f : Unit → Unit}
 
 /--
 error: Could not find a model with corners for `Unit`.
-
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model for: Unit
 [Elab.DiffGeo.MDiff] ❌️ TotalSpace

--- a/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
+++ b/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
@@ -277,8 +277,6 @@ set_option trace.Elab.DiffGeo.MDiff true in
 variable {f : M → E'' →SL[id'] E'''} in
 /--
 error: Could not find a model with corners for `E'' →SL[id'] E'''`.
-
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model for: M
 [Elab.DiffGeo.MDiff] ❌️ TotalSpace
@@ -527,8 +525,6 @@ noncomputable instance : ChartedSpace (EuclideanHalfSpace 1) ↑(Set.Icc x y) :=
 set_option trace.Elab.DiffGeo.MDiff true in
 /--
 error: Could not find a model with corners for `↑(Set.Icc x y)`.
-
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model for: ↑(Set.Icc x y)
 [Elab.DiffGeo.MDiff] ❌️ TotalSpace

--- a/MathlibTest/DifferentialGeometry/NotationSphere.lean
+++ b/MathlibTest/DifferentialGeometry/NotationSphere.lean
@@ -178,8 +178,6 @@ set_option trace.Elab.DiffGeo true in
 variable [Fact (Module.finrank ℝ E = 3)] in
 /--
 error: Could not find a model with corners for `↑(Metric.sphere 0 1)`.
-
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
 ---
 trace: [Elab.DiffGeo.MDiff] Finding a model for: ↑(Metric.sphere 0 1)
 [Elab.DiffGeo.MDiff] ❌️ TotalSpace


### PR DESCRIPTION
When a tracing option is already set, we don't need to tell the user about it. Follow-up to #30744.

---

- [x] depends on: #30744

My main question is if there's a better way to do this, e.g. doing only one check instead of two.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
