### PR TITLE
[Merged by Bors] - feat(NumberTheory/Height/Basic): positivity extensions

### DIFF
--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -6,6 +6,7 @@ Authors: Michael Stoll
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Log.Basic
+public import Mathlib.Tactic.Positivity.Core
 
 import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Data.Fintype.Order
@@ -149,6 +150,36 @@ lemma logHeight₁_one : logHeight₁ (1 : K) = 0 := by
 lemma zero_le_logHeight₁ (x : K) : 0 ≤ logHeight₁ x :=
   Real.log_nonneg <| one_le_mulHeight₁ x
 
+end Height
+
+/-!
+### Positivity extension for mulHeight₁, logHeight₁
+-/
+
+namespace Mathlib.Meta.Positivity
+
+open Lean.Meta Qq Height
+
+/-- Extension for the `positivity` tactic: `Height.mulHeight₁` is always positive. -/
+@[positivity Height.mulHeight₁ _]
+meta def evalMulHeight₁ : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@mulHeight₁ $K $KF $KA $a) =>
+    assertInstancesCommute
+    pure (.positive q(@mulHeight₁_pos $K $KF $KA $a))
+  | _, _, _ => throwError "not Height.mulHeight₁"
+
+/-- Extension for the `positivity` tactic: `Height.logHeight₁` is always nonnegative. -/
+@[positivity Height.logHeight₁ _]
+meta def evalLogHeight₁ : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@logHeight₁ $K $KF $KA $a) =>
+    assertInstancesCommute
+    pure (.nonnegative q(@zero_le_logHeight₁ $K $KF $KA $a))
+  | _, _, _ => throwError "not Height.logHeight₁"
+
+end Mathlib.Meta.Positivity
+
 /-!
 ### Heights of tuples and finitely supported maps
 
@@ -162,7 +193,12 @@ For a finitely supported function `x : ι →₀ K`, we define the height as the
 restricted to its support.
 -/
 
-variable {ι : Type*}
+
+namespace Height
+
+open AdmissibleAbsValues Real
+
+variable {K : Type*} [Field K] [AdmissibleAbsValues K] {ι : Type*}
 
 /-- The multiplicative height of a tuple of elements of `K`.
 For the zero tuple we take the junk value `1`. -/
@@ -222,7 +258,7 @@ lemma _root_.Finsupp.logHeight_eq_log_mulHeight (x : α →₀ K) :
     logHeight x = log (mulHeight x) := rfl
 
 /-!
-### Properties of heights
+### First properties of heights
 -/
 
 private lemma max_eq_iSup {α : Type*} [ConditionallyCompleteLattice α] (a b : α) :
@@ -290,6 +326,61 @@ lemma mulHeight.ne_zero (x : ι → K) : mulHeight x ≠ 0 :=
 lemma zero_le_logHeight {x : ι → K} : 0 ≤ logHeight x :=
   log_nonneg <| one_le_mulHeight x
 
+end Height
+
+/-!
+### Positivity extension for mulHeight, logHeight
+-/
+
+namespace Mathlib.Meta.Positivity
+
+open Lean.Meta Qq Height
+
+/-- Extension for the `positivity` tactic: `Height.mulHeight` is always positive. -/
+@[positivity Height.mulHeight _]
+meta def evalMulHeight : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@mulHeight $K $KF $KA $ι $a) =>
+    assertInstancesCommute
+    -- Check wether there is a `Finite` instance for `$ι` around.
+    let o : Option Q(Finite $ι) := ← do
+      let .some instFinite ← trySynthInstanceQ q(Finite $ι) | return none
+      return some instFinite
+    match o with
+    | some instFinite =>
+      assertInstancesCommute
+      return .positive q(@mulHeight_pos $K $KF $KA $ι $instFinite $a)
+    | none => throwError "index type in Height.mulHeight not known to be finite"
+  | _, _, _ => throwError "not Height.mulHeight"
+
+/-- Extension for the `positivity` tactic: `Height.logHeight` is always nonnegative. -/
+@[positivity Height.logHeight _]
+meta def evalLogHeight : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@logHeight $K $KF $KA $ι $a) =>
+    assertInstancesCommute
+    -- Check wether there is a `Finite` instance for `$ι` around.
+    let o : Option Q(Finite $ι) := ← do
+      let .some instFinite ← trySynthInstanceQ q(Finite $ι) | return none
+      return some instFinite
+    match o with
+    | some instFinite =>
+      assertInstancesCommute
+      return .nonnegative q(@zero_le_logHeight $K $KF $KA $ι $instFinite $a)
+    | none => throwError "index type in Height.logHeight not known to be finite"
+  | _, _, _ => throwError "not Height.logHeight"
+
+end Mathlib.Meta.Positivity
+
+/-!
+### Further properties of heights
+-/
+
+namespace Height
+
+open AdmissibleAbsValues Real
+
+variable {K : Type*} [Field K] [AdmissibleAbsValues K] {ι : Type*} {α : Type*} [Finite ι]
 /-- The logarithmic height of a tuple does not change under scaling. -/
 lemma logHeight_smul_eq_logHeight (x : ι → K) {c : K} (hc : c ≠ 0) :
     logHeight (c • x) = logHeight x := by

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -6,7 +6,6 @@ Authors: Michael Stoll
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Log.Basic
-public import Mathlib.Tactic.Positivity.Core
 
 import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Data.Fintype.Order
@@ -341,7 +340,6 @@ open Lean.Meta Qq Height
 meta def evalMulHeight : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@mulHeight $K $KF $KA $ι $a) =>
-    assertInstancesCommute
     -- Check whether there is a `Finite` instance for `$ι` around.
     match ← trySynthInstanceQ q(Finite $ι) with
     | .some _instFinite =>
@@ -355,7 +353,6 @@ meta def evalMulHeight : PositivityExt where eval {u α} _ _ e := do
 meta def evalLogHeight : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@logHeight $K $KF $KA $ι $a) =>
-    assertInstancesCommute
     -- Check whether there is a `Finite` instance for `$ι` around.
     match ← trySynthInstanceQ q(Finite $ι) with
     | .some _instFinite =>

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -166,7 +166,7 @@ meta def evalMulHeight₁ : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@mulHeight₁ $K $KF $KA $a) =>
     assertInstancesCommute
-    pure (.positive q(@mulHeight₁_pos $K $KF $KA $a))
+    pure (.positive q(mulHeight₁_pos $a))
   | _, _, _ => throwError "not Height.mulHeight₁"
 
 /-- Extension for the `positivity` tactic: `Height.logHeight₁` is always nonnegative. -/
@@ -175,7 +175,7 @@ meta def evalLogHeight₁ : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@logHeight₁ $K $KF $KA $a) =>
     assertInstancesCommute
-    pure (.nonnegative q(@zero_le_logHeight₁ $K $KF $KA $a))
+    pure (.nonnegative q(zero_le_logHeight₁ $a))
   | _, _, _ => throwError "not Height.logHeight₁"
 
 end Mathlib.Meta.Positivity
@@ -342,15 +342,12 @@ meta def evalMulHeight : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@mulHeight $K $KF $KA $ι $a) =>
     assertInstancesCommute
-    -- Check wether there is a `Finite` instance for `$ι` around.
-    let o : Option Q(Finite $ι) := ← do
-      let .some instFinite ← trySynthInstanceQ q(Finite $ι) | return none
-      return some instFinite
-    match o with
-    | some instFinite =>
+    -- Check whether there is a `Finite` instance for `$ι` around.
+    match ← trySynthInstanceQ q(Finite $ι) with
+    | .some _instFinite =>
       assertInstancesCommute
-      return .positive q(@mulHeight_pos $K $KF $KA $ι $instFinite $a)
-    | none => throwError "index type in Height.mulHeight not known to be finite"
+      return .positive q(mulHeight_pos $a)
+    | _ => throwError "index type in Height.mulHeight not known to be finite"
   | _, _, _ => throwError "not Height.mulHeight"
 
 /-- Extension for the `positivity` tactic: `Height.logHeight` is always nonnegative. -/
@@ -359,15 +356,12 @@ meta def evalLogHeight : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@logHeight $K $KF $KA $ι $a) =>
     assertInstancesCommute
-    -- Check wether there is a `Finite` instance for `$ι` around.
-    let o : Option Q(Finite $ι) := ← do
-      let .some instFinite ← trySynthInstanceQ q(Finite $ι) | return none
-      return some instFinite
-    match o with
-    | some instFinite =>
+    -- Check whether there is a `Finite` instance for `$ι` around.
+    match ← trySynthInstanceQ q(Finite $ι) with
+    | .some _instFinite =>
       assertInstancesCommute
-      return .nonnegative q(@zero_le_logHeight $K $KF $KA $ι $instFinite $a)
-    | none => throwError "index type in Height.logHeight not known to be finite"
+      return .nonnegative q(zero_le_logHeight)
+    | _ => throwError "index type in Height.logHeight not known to be finite"
   | _, _, _ => throwError "not Height.logHeight"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -322,7 +322,7 @@ lemma mulHeight_pos (x : ι → K) : 0 < mulHeight x :=
 lemma mulHeight.ne_zero (x : ι → K) : mulHeight x ≠ 0 :=
   (mulHeight_pos x).ne'
 
-lemma zero_le_logHeight {x : ι → K} : 0 ≤ logHeight x :=
+lemma zero_le_logHeight (x : ι → K) : 0 ≤ logHeight x :=
   log_nonneg <| one_le_mulHeight x
 
 end Height
@@ -357,7 +357,7 @@ meta def evalLogHeight : PositivityExt where eval {u α} _ _ e := do
     match ← trySynthInstanceQ q(Finite $ι) with
     | .some _instFinite =>
       assertInstancesCommute
-      return .nonnegative q(zero_le_logHeight)
+      return .nonnegative q(zero_le_logHeight $a)
     | _ => throwError "index type in Height.logHeight not known to be finite"
   | _, _, _ => throwError "not Height.logHeight"
 


### PR DESCRIPTION
This PR adds extensions for the `positivity` tactic so that it knows that `Height.mulHeight₁ x` and `Height.mulHeight x` are positive and `Height.logHeight₁ x` and `Height.logHeight` are nonnegative.

---

(This is cargo-culted code, but it seems to be working).

This is used in [#34330](https://github.com/leanprover-community/mathlib4/pull/34330).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
