### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/ContinuousMonoidHom): add missing API for monoid structure

### DIFF
--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -239,6 +239,20 @@ instance : CommMonoid (A →ₜ* E) where
   one_mul f := ext fun x => one_mul (f x)
   mul_one f := ext fun x => mul_one (f x)
 
+@[to_additive (attr := simp)]
+theorem mul_apply {A B : Type*} [Monoid A] [CommMonoid B]
+    [TopologicalSpace A] [TopologicalSpace B] [ContinuousMul B]
+    (f g : ContinuousMonoidHom A B) (a : A) : (f * g) a = f a * g a := by
+  rfl
+
+@[to_additive (attr := simp)]
+theorem pow_apply {A B : Type*} [Monoid A] [CommMonoid B]
+    [TopologicalSpace A] [TopologicalSpace B] [ContinuousMul B]
+    (f : ContinuousMonoidHom A B) (n : ℕ) (a : A) : (f ^ n) a = (f a) ^ n := by
+  induction n
+  case zero => rw [pow_zero, pow_zero, one_toFun]
+  case succ n ih => rw [pow_succ, pow_succ, ContinuousMonoidHom.mul_apply, ih]
+
 /-- Coproduct of two continuous homomorphisms to the same space. -/
 @[to_additive (attr := simps!) /-- Coproduct of two continuous homomorphisms to the same space. -/]
 def coprod (f : ContinuousMonoidHom A E) (g : ContinuousMonoidHom B E) :

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -240,15 +240,11 @@ instance : CommMonoid (A →ₜ* E) where
   mul_one f := ext fun x => mul_one (f x)
 
 @[to_additive (attr := simp)]
-theorem mul_apply {A B : Type*} [Monoid A] [CommMonoid B]
-    [TopologicalSpace A] [TopologicalSpace B] [ContinuousMul B]
-    (f g : ContinuousMonoidHom A B) (a : A) : (f * g) a = f a * g a := by
+theorem mul_apply (f g : A →ₜ* E) (a : A) : (f * g) a = f a * g a := by
   rfl
 
 @[to_additive (attr := simp)]
-theorem pow_apply {A B : Type*} [Monoid A] [CommMonoid B]
-    [TopologicalSpace A] [TopologicalSpace B] [ContinuousMul B]
-    (f : ContinuousMonoidHom A B) (n : ℕ) (a : A) : (f ^ n) a = (f a) ^ n := by
+theorem pow_apply (f : A →ₜ* E) (n : ℕ) (a : A) : (f ^ n) a = (f a) ^ n := by
   induction n
   case zero => rw [pow_zero, pow_zero, one_toFun]
   case succ n ih => rw [pow_succ, pow_succ, ContinuousMonoidHom.mul_apply, ih]


### PR DESCRIPTION
This PR adds missing API for the monoid structure on `ContinuousMonoidHom`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
