### PR TITLE
[Merged by Bors] - ci: Add workflow to collect and export some CI telemetry

### DIFF
--- a/.github/workflows/export_telemetry.yaml
+++ b/.github/workflows/export_telemetry.yaml
@@ -1,0 +1,27 @@
+name: Export workflow telemetry
+
+on:
+  workflow_run:
+    workflows:
+      # The *names* of the workflows to collect telemetry for
+      - "continuous integration"
+      - "continuous integration (mathlib forks)"
+      - "continuous integration (staging)"
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  otel-export:
+    if: github.repository == 'leanprover-community/mathlib4'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export workflow telemetry
+        uses: corentinmusard/otel-cicd-action@769ccb38830ff3d1600ffb2f35ba9da6724e6b3e # v2.2.4
+        with:
+          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
This workflow will export some OpenTelemetry traces at the workflow-level to improve CI observability