### PR TITLE
feat(Topology/Homotopy): add Path.subpathOn for restricting paths to subintervals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7896,6 +7896,7 @@ public import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
 public import Mathlib.Topology.UniformSpace.UniformEmbedding
 public import Mathlib.Topology.UniformSpace.Uniformizable
 public import Mathlib.Topology.UnitInterval
+public import Mathlib.Topology.UnitInterval.ConvexSpace
 public import Mathlib.Topology.UrysohnsBounded
 public import Mathlib.Topology.UrysohnsLemma
 public import Mathlib.Topology.VectorBundle.Basic

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -469,7 +469,7 @@ variable {X : Type*} [TopologicalSpace X] {x y : X}
 
 /-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
 This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
-def subpathOn (γ : Path x y) (a b : unitInterval) (_hab : a ≤ b) : Path (γ a) (γ b) where
+def subpathOn (γ : Path x y) (a b : unitInterval) (_ : a ≤ b) : Path (γ a) (γ b) where
   toFun t := γ (convexCombo a b t)
   source' := by simp
   target' := by simp

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -476,35 +476,15 @@ theorem _root_.unitInterval.coe_half : (unitInterval.half : ℝ) = 1 / 2 := rfl
 /-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
 This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
 def subpathOn (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) : Path (γ a) (γ b) where
-  toFun t := γ ⟨(a : ℝ) + t * ((b : ℝ) - a), by
-    constructor
-    · apply add_nonneg a.2.1
-      apply mul_nonneg t.2.1
-      linarith [show (a : ℝ) ≤ b from hab]
-    · calc (a : ℝ) + t * ((b : ℝ) - a)
-          ≤ a + 1 * ((b : ℝ) - a) := by
-            apply add_le_add_right
-            apply mul_le_mul_of_nonneg_right t.2.2
-            linarith [show (a : ℝ) ≤ b from hab]
-        _ = b := by ring
-        _ ≤ 1 := b.2.2⟩
+  toFun t := γ (convexCombo a b t)
   source' := by simp
   target' := by simp
 
 @[simp]
 theorem subpathOn_apply (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) (t : unitInterval) :
-    (γ.subpathOn a b hab) t = γ ⟨(a : ℝ) + t * ((b : ℝ) - a), by
-      constructor
-      · apply add_nonneg a.2.1
-        apply mul_nonneg t.2.1
-        linarith [show (a : ℝ) ≤ b from hab]
-      · calc (a : ℝ) + t * ((b : ℝ) - a)
-            ≤ a + 1 * ((b : ℝ) - a) := by
-              apply add_le_add_right
-              apply mul_le_mul_of_nonneg_right t.2.2
-              linarith [show (a : ℝ) ≤ b from hab]
-          _ = b := by ring
-          _ ≤ 1 := b.2.2⟩ := rfl
+    (γ.subpathOn a b hab) t = γ (convexCombo a b t) := by
+  unfold subpathOn convexCombo
+  simp only [Path.coe_mk_mk]
 
 /-- Splitting a sub-path in halves rejoining them gives the original path. -/
 theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) :
@@ -514,9 +494,9 @@ theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤
       (Set.Icc.convexCombo_le hab _))) =
     (γ.subpathOn a b hab) := by
   ext t
-  simp only [trans, one_div, extend, Set.IccExtend, subpathOn, coe_convexCombo, coe_mk',
+  simp only [trans, one_div, extend, Set.IccExtend, subpathOn, coe_mk',
     ContinuousMap.coe_mk, Function.comp_apply, Set.projIcc]
-  split_ifs with h <;> (congr 1; ext; simp only [half, one_div, add_right_inj]; norm_num)
+  split_ifs with h <;> (congr 1; ext; simp only [half, one_div]; norm_num)
   · have := t.2.1; have := t.2.2
     rw [min_eq_right (by linarith : 2 * (t : ℝ) ≤ 1),
         max_eq_right (by linarith : 0 ≤ 2 * (t : ℝ))]; ring
@@ -541,7 +521,7 @@ theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab : a ≤
       ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
         (γ.subpathOn (convexCombo a b (convexCombo s t u)) b (convexCombo_le hab _))) v
     continuous_toFun := by
-      simp only [trans_apply, one_div, subpathOn_apply, coe_convexCombo]
+      simp only [trans_apply, one_div, subpathOn_apply, convexCombo]
       simp only [← extend_apply, dite_eq_ite]
       apply continuous_if_le (hfg := by grind) <;> fun_prop
     map_zero_left v := by simp [Path.trans_apply]

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -467,26 +467,24 @@ open Set.Icc
 
 variable {X : Type*} [TopologicalSpace X] {x y : X}
 
-/-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
-This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
-def subpathOn (γ : Path x y) (a b : unitInterval) (_ : a ≤ b) : Path (γ a) (γ b) where
+/-- Extract a subpath from `γ` on the interval `[a, b]`.
+This is `γ` reparametrized via the affine map `t ↦ a + t (b - a)`. -/
+def subpathOn (γ : Path x y) (a b : unitInterval) : Path (γ a) (γ b) where
   toFun t := γ (convexCombo a b t)
   source' := by simp
   target' := by simp
 
 @[simp]
-theorem subpathOn_apply (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) (t : unitInterval) :
-    (γ.subpathOn a b hab) t = γ (convexCombo a b t) := by
+theorem subpathOn_apply (γ : Path x y) (a b : unitInterval) (t : unitInterval) :
+    (γ.subpathOn a b) t = γ (convexCombo a b t) := by
   unfold subpathOn convexCombo
   simp only [Path.coe_mk_mk]
 
 /-- Splitting a sub-path in halves rejoining them gives the original path. -/
-private theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) :
-    ((γ.subpathOn a (Set.Icc.convexCombo a b unitInterval.half)
-      (Set.Icc.le_convexCombo hab _)).trans
-      (γ.subpathOn (Set.Icc.convexCombo a b unitInterval.half) b
-      (Set.Icc.convexCombo_le hab _))) =
-    (γ.subpathOn a b hab) := by
+private theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (_hab : a ≤ b) :
+    ((γ.subpathOn a (Set.Icc.convexCombo a b unitInterval.half)).trans
+      (γ.subpathOn (Set.Icc.convexCombo a b unitInterval.half) b)) =
+    (γ.subpathOn a b) := by
   ext t
   simp only [trans, one_div, extend, Set.IccExtend, subpathOn, coe_mk',
     ContinuousMap.coe_mk, Function.comp_apply, Set.projIcc]
@@ -502,17 +500,17 @@ private theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab
 Splitting a sub-path into pieces and rejoining them is independent, up to homotopy,
 of the splitting point.
 -/
-private theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b)
+private theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (_hab : a ≤ b)
     (s t : unitInterval) :
     Path.Homotopic
-      ((γ.subpathOn a (convexCombo a b s) (le_convexCombo hab _)).trans
-        (γ.subpathOn (convexCombo a b s) b (convexCombo_le hab _)))
-      ((γ.subpathOn a (convexCombo a b t) (le_convexCombo hab _)).trans
-        (γ.subpathOn (convexCombo a b t) b (convexCombo_le hab _))) := by
+      ((γ.subpathOn a (convexCombo a b s)).trans
+        (γ.subpathOn (convexCombo a b s) b))
+      ((γ.subpathOn a (convexCombo a b t)).trans
+        (γ.subpathOn (convexCombo a b t) b)) := by
   refine ⟨{
       toFun := fun ⟨u, v⟩ =>
-        ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
-          (γ.subpathOn (convexCombo a b (convexCombo s t u)) b (convexCombo_le hab _))) v
+        ((γ.subpathOn a (convexCombo a b (convexCombo s t u))).trans
+          (γ.subpathOn (convexCombo a b (convexCombo s t u)) b)) v
       continuous_toFun := by
         simp only [trans_apply, one_div, subpathOn_apply, convexCombo]
         simp only [← extend_apply, dite_eq_ite]
@@ -533,40 +531,55 @@ the subpath from a to c.
 theorem subpathOn_trans
     (γ : Path x y) (a b c : unitInterval) (hab : a ≤ b) (hbc : b ≤ c) :
     Path.Homotopic
-      ((γ.subpathOn a b hab).trans (γ.subpathOn b c hbc))
-      (γ.subpathOn a c (hab.trans hbc)) := by
+      ((γ.subpathOn a b).trans (γ.subpathOn b c))
+      (γ.subpathOn a c) := by
   suffices ∀ s : unitInterval,
     Path.Homotopic
-      ((γ.subpathOn a (Set.Icc.convexCombo a c s) (Set.Icc.le_convexCombo (hab.trans hbc) _)).trans
-        (γ.subpathOn (Set.Icc.convexCombo a c s) c (Set.Icc.convexCombo_le (hab.trans hbc) _)))
-      (γ.subpathOn a c (hab.trans hbc)) by
-    have hb := Set.Icc.eq_convexCombo hab hbc
-    convert this ?_ <;> exact hb
+      ((γ.subpathOn a (Set.Icc.convexCombo a c s)).trans
+        (γ.subpathOn (Set.Icc.convexCombo a c s) c))
+      (γ.subpathOn a c) by
+    have hac : (a : ℝ) ≤ c := hab.trans hbc
+    have hab' : (a : ℝ) ≤ b := hab
+    have hbc' : (b : ℝ) ≤ c := hbc
+    let s : unitInterval :=
+      ⟨((b - a) / (c - a)),
+        by
+          by_cases hca : (c : ℝ) - a = 0
+          · have hba : (b : ℝ) - a = 0 := by linarith
+            simp [hca, hba]
+          · exact div_nonneg (sub_nonneg.mpr hab') (sub_nonneg.mpr hac),
+        by
+          by_cases hca : (c : ℝ) - a = 0
+          · have hba : (b : ℝ) - a = 0 := by linarith
+            simp [hca, hba]
+          · have hca_nonneg : 0 ≤ (c : ℝ) - a := sub_nonneg.mpr hac
+            exact div_le_one_of_le₀ (by linarith) hca_nonneg⟩
+    convert this s <;> exact Set.Icc.eq_convexCombo hab hbc
   intro s
-  rw [← Path.subpathOn_trans_aux₁ γ a c]
+  rw [← Path.subpathOn_trans_aux₁ γ a c (hab.trans hbc)]
   apply Path.subpathOn_trans_aux₂ γ a c (hab.trans hbc) s
 
 /-- A subpath from a point to itself is the constant path. -/
 theorem subpathOn_self_eq_refl (γ : Path x y) (a : unitInterval) :
-    γ.subpathOn a a (le_refl a) = Path.refl (γ a) := by
+    γ.subpathOn a a = Path.refl (γ a) := by
   ext t
   simp [Path.refl, Path.subpathOn]
 
 /-- A subpath from a point to itself is homotopic to the constant path. -/
 theorem subpathOn_self (γ : Path x y) (a : unitInterval) :
-    Homotopic (γ.subpathOn a a (le_refl a)) (Path.refl (γ a)) := by
+    Homotopic (γ.subpathOn a a) (Path.refl (γ a)) := by
   simpa [subpathOn_self_eq_refl] using Homotopic.refl (Path.refl (γ a))
 
 /-- The subpath from `0` to `1`, after casting endpoints, is the original path. -/
 theorem subpathOn_zero_one_cast (γ : Path x y) :
-    ((γ.subpathOn 0 1 zero_le_one).cast (by simp [γ.source]) (by simp [γ.target])) = γ := by
+    ((γ.subpathOn 0 1).cast (by simp [γ.source]) (by simp [γ.target])) = γ := by
   ext t
   simp [Path.cast, Path.subpathOn]
 
 /-- The subpath from 0 to 1 is homotopic to the original path (up to casting endpoints). -/
 theorem subpathOn_zero_one (γ : Path x y) :
     Homotopic
-      ((γ.subpathOn 0 1 zero_le_one).cast (by simp [γ.source]) (by simp [γ.target])) γ := by
+      ((γ.subpathOn 0 1).cast (by simp [γ.source]) (by simp [γ.target])) γ := by
   simpa [subpathOn_zero_one_cast] using Homotopic.refl γ
 
 namespace Homotopic.Quotient
@@ -574,20 +587,20 @@ namespace Homotopic.Quotient
 @[simp]
 theorem subpathOn_trans {x y : X} (p : Path x y)
     (a b c : unitInterval) (hab : a ≤ b) (hbc : b ≤ c) :
-    trans (mk (p.subpathOn a b hab)) (mk (p.subpathOn b c hbc)) =
-      mk (p.subpathOn a c (hab.trans hbc)) := by
+    trans (mk (p.subpathOn a b)) (mk (p.subpathOn b c)) =
+      mk (p.subpathOn a c) := by
   simp only [← mk_trans, eq]
   exact Path.subpathOn_trans p a b c hab hbc
 
 @[simp]
 theorem subpathOn_self {x y : X} (p : Path x y) (a : unitInterval) :
-    mk (p.subpathOn a a (le_refl a)) = refl (p a) := by
+    mk (p.subpathOn a a) = refl (p a) := by
   simp only [← mk_refl, eq]
   exact Path.subpathOn_self p a
 
 @[simp]
 theorem subpathOn_zero_one {x y : X} (p : Path x y) :
-    mk (p.subpathOn 0 1 zero_le_one) = (mk p).cast (by simp) (by simp) := by
+    mk (p.subpathOn 0 1) = (mk p).cast (by simp) (by simp) := by
   simp only [← mk_cast, eq]
   exact Path.subpathOn_zero_one p
 

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -469,7 +469,7 @@ variable {X : Type*} [TopologicalSpace X] {x y : X}
 
 /-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
 This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
-def subpathOn (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) : Path (γ a) (γ b) where
+def subpathOn (γ : Path x y) (a b : unitInterval) (_hab : a ≤ b) : Path (γ a) (γ b) where
   toFun t := γ (convexCombo a b t)
   source' := by simp
   target' := by simp
@@ -481,7 +481,7 @@ theorem subpathOn_apply (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) (t 
   simp only [Path.coe_mk_mk]
 
 /-- Splitting a sub-path in halves rejoining them gives the original path. -/
-theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) :
+private theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) :
     ((γ.subpathOn a (Set.Icc.convexCombo a b unitInterval.half)
       (Set.Icc.le_convexCombo hab _)).trans
       (γ.subpathOn (Set.Icc.convexCombo a b unitInterval.half) b
@@ -502,14 +502,13 @@ theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤
 Splitting a sub-path into pieces and rejoining them is independent, up to homotopy,
 of the splitting point.
 -/
-theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b)
+private theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b)
     (s t : unitInterval) :
     Path.Homotopic
       ((γ.subpathOn a (convexCombo a b s) (le_convexCombo hab _)).trans
         (γ.subpathOn (convexCombo a b s) b (convexCombo_le hab _)))
       ((γ.subpathOn a (convexCombo a b t) (le_convexCombo hab _)).trans
         (γ.subpathOn (convexCombo a b t) b (convexCombo_le hab _))) := by
-  -- Construct explicit homotopy: at parameter u, split at convexCombo(a, b, convexCombo(s, t, u))
   refine ⟨{
     toFun := fun ⟨u, v⟩ =>
       ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
@@ -536,7 +535,6 @@ theorem subpathOn_trans
     Path.Homotopic
       ((γ.subpathOn a b hab).trans (γ.subpathOn b c hbc))
       (γ.subpathOn a c (hab.trans hbc)) := by
-  -- This is an easy combination of `eq_convexCombo` and the two auxiliary lemmas above.
   suffices ∀ s : unitInterval,
     Path.Homotopic
       ((γ.subpathOn a (Set.Icc.convexCombo a c s) (Set.Icc.le_convexCombo (hab.trans hbc) _)).trans
@@ -548,20 +546,28 @@ theorem subpathOn_trans
   rw [← Path.subpathOn_trans_aux₁ γ a c]
   apply Path.subpathOn_trans_aux₂ γ a c (hab.trans hbc) s
 
+/-- A subpath from a point to itself is the constant path. -/
+theorem subpathOn_self_eq_refl (γ : Path x y) (a : unitInterval) :
+    γ.subpathOn a a (le_refl a) = Path.refl (γ a) := by
+  ext t
+  simp [Path.refl, Path.subpathOn]
+
 /-- A subpath from a point to itself is homotopic to the constant path. -/
 theorem subpathOn_self (γ : Path x y) (a : unitInterval) :
     Homotopic (γ.subpathOn a a (le_refl a)) (Path.refl (γ a)) := by
-  convert Homotopic.refl _
+  simpa [subpathOn_self_eq_refl] using Homotopic.refl (Path.refl (γ a))
+
+/-- The subpath from `0` to `1`, after casting endpoints, is the original path. -/
+theorem subpathOn_zero_one_cast (γ : Path x y) :
+    ((γ.subpathOn 0 1 zero_le_one).cast (by simp [γ.source]) (by simp [γ.target])) = γ := by
   ext t
-  simp [Path.refl, Path.subpathOn]
+  simp [Path.cast, Path.subpathOn]
 
 /-- The subpath from 0 to 1 is homotopic to the original path (up to casting endpoints). -/
 theorem subpathOn_zero_one (γ : Path x y) :
     Homotopic
-      ((γ.subpathOn 0 1 (zero_le_one)).cast (by simp [γ.source]) (by simp [γ.target])) γ := by
-  convert Homotopic.refl _
-  ext t
-  simp [Path.cast, Path.subpathOn]
+      ((γ.subpathOn 0 1 zero_le_one).cast (by simp [γ.source]) (by simp [γ.target])) γ := by
+  simpa [subpathOn_zero_one_cast] using Homotopic.refl γ
 
 namespace Homotopic.Quotient
 
@@ -580,11 +586,8 @@ theorem subpathOn_self {x y : X} (p : Path x y) (a : unitInterval) :
   exact Path.subpathOn_self p a
 
 @[simp]
-theorem subpathOn_zero_one {x y : X} (p : Path x y) (s t : unitInterval)
-    (hs : s = 0) (ht : t = 1) :
-    mk (p.subpathOn s t (by grind [zero_le_one])) =
-      (mk p).cast (by grind) (by grind) := by
-  subst hs ht
+theorem subpathOn_zero_one {x y : X} (p : Path x y) :
+    mk (p.subpathOn 0 1 zero_le_one) = (mk p).cast (by simp) (by simp) := by
   simp only [← mk_cast, eq]
   exact Path.subpathOn_zero_one p
 

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -510,21 +510,21 @@ private theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab
       ((γ.subpathOn a (convexCombo a b t) (le_convexCombo hab _)).trans
         (γ.subpathOn (convexCombo a b t) b (convexCombo_le hab _))) := by
   refine ⟨{
-    toFun := fun ⟨u, v⟩ =>
-      ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
-        (γ.subpathOn (convexCombo a b (convexCombo s t u)) b (convexCombo_le hab _))) v
-    continuous_toFun := by
-      simp only [trans_apply, one_div, subpathOn_apply, convexCombo]
-      simp only [← extend_apply, dite_eq_ite]
-      apply continuous_if_le (hfg := by grind) <;> fun_prop
-    map_zero_left v := by simp [Path.trans_apply]
-    map_one_left v := by simp [Path.trans_apply]
-    prop' u x hx := by
-      rcases hx with rfl | rfl
-      · simp [Path.trans]
-      · simp [Path.trans]
-        norm_num
-  }⟩
+      toFun := fun ⟨u, v⟩ =>
+        ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
+          (γ.subpathOn (convexCombo a b (convexCombo s t u)) b (convexCombo_le hab _))) v
+      continuous_toFun := by
+        simp only [trans_apply, one_div, subpathOn_apply, convexCombo]
+        simp only [← extend_apply, dite_eq_ite]
+        apply continuous_if_le (hfg := by grind) <;> fun_prop
+      map_zero_left v := by simp [Path.trans_apply]
+      map_one_left v := by simp [Path.trans_apply]
+      prop' u x hx := by
+        rcases hx with rfl | rfl
+        · simp [Path.trans]
+        · simp [Path.trans]
+          norm_num
+    }⟩
 
 /--
 A subpath from a to b composed with a subpath from b to c is homotopic to

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -467,12 +467,6 @@ open Set.Icc
 
 variable {X : Type*} [TopologicalSpace X] {x y : X}
 
-/-- The midpoint of the unit interval. -/
-def _root_.unitInterval.half : I := ⟨1 / 2, by constructor <;> linarith⟩
-
-@[simp]
-theorem _root_.unitInterval.coe_half : (unitInterval.half : ℝ) = 1 / 2 := rfl
-
 /-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
 This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
 def subpathOn (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) : Path (γ a) (γ b) where
@@ -496,7 +490,7 @@ theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤
   ext t
   simp only [trans, one_div, extend, Set.IccExtend, subpathOn, coe_mk',
     ContinuousMap.coe_mk, Function.comp_apply, Set.projIcc]
-  split_ifs with h <;> (congr 1; ext; simp only [half, one_div]; norm_num)
+  split_ifs with h <;> (congr 1; ext; simp only [unitInterval.half, one_div]; norm_num)
   · have := t.2.1; have := t.2.2
     rw [min_eq_right (by linarith : 2 * (t : ℝ) ≤ 1),
         max_eq_right (by linarith : 0 ≤ 2 * (t : ℝ))]; ring

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -458,3 +458,162 @@ theorem pathExtend_evalAt {f g : C(X, Y)} (H : f.Homotopy g) (x : X) :
     (H.evalAt x).extend = (fun t ↦ H.extend t x) := rfl
 
 end ContinuousMap.Homotopy
+
+namespace Path
+
+/-! ### Path restriction to subintervals -/
+
+open Set.Icc
+
+variable {X : Type*} [TopologicalSpace X] {x y : X}
+
+/-- The midpoint of the unit interval. -/
+def _root_.unitInterval.half : I := ⟨1 / 2, by constructor <;> linarith⟩
+
+@[simp]
+theorem _root_.unitInterval.coe_half : (unitInterval.half : ℝ) = 1 / 2 := rfl
+
+/-- Extract a subpath from γ on the interval [a, b] ⊆ [0, 1].
+This is γ reparametrized via the affine map t ↦ a + t(b - a). -/
+def subpathOn (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) : Path (γ a) (γ b) where
+  toFun t := γ ⟨(a : ℝ) + t * ((b : ℝ) - a), by
+    constructor
+    · apply add_nonneg a.2.1
+      apply mul_nonneg t.2.1
+      linarith [show (a : ℝ) ≤ b from hab]
+    · calc (a : ℝ) + t * ((b : ℝ) - a)
+          ≤ a + 1 * ((b : ℝ) - a) := by
+            apply add_le_add_right
+            apply mul_le_mul_of_nonneg_right t.2.2
+            linarith [show (a : ℝ) ≤ b from hab]
+        _ = b := by ring
+        _ ≤ 1 := b.2.2⟩
+  source' := by simp
+  target' := by simp
+
+@[simp]
+theorem subpathOn_apply (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) (t : unitInterval) :
+    (γ.subpathOn a b hab) t = γ ⟨(a : ℝ) + t * ((b : ℝ) - a), by
+      constructor
+      · apply add_nonneg a.2.1
+        apply mul_nonneg t.2.1
+        linarith [show (a : ℝ) ≤ b from hab]
+      · calc (a : ℝ) + t * ((b : ℝ) - a)
+            ≤ a + 1 * ((b : ℝ) - a) := by
+              apply add_le_add_right
+              apply mul_le_mul_of_nonneg_right t.2.2
+              linarith [show (a : ℝ) ≤ b from hab]
+          _ = b := by ring
+          _ ≤ 1 := b.2.2⟩ := rfl
+
+/-- Splitting a sub-path in halves rejoining them gives the original path. -/
+theorem subpathOn_trans_aux₁ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b) :
+    ((γ.subpathOn a (Set.Icc.convexCombo a b unitInterval.half)
+      (Set.Icc.le_convexCombo hab _)).trans
+      (γ.subpathOn (Set.Icc.convexCombo a b unitInterval.half) b
+      (Set.Icc.convexCombo_le hab _))) =
+    (γ.subpathOn a b hab) := by
+  ext t
+  simp only [trans, one_div, extend, Set.IccExtend, subpathOn, coe_convexCombo, coe_mk',
+    ContinuousMap.coe_mk, Function.comp_apply, Set.projIcc]
+  split_ifs with h <;> (congr 1; ext; simp only [half, one_div, add_right_inj]; norm_num)
+  · have := t.2.1; have := t.2.2
+    rw [min_eq_right (by linarith : 2 * (t : ℝ) ≤ 1),
+        max_eq_right (by linarith : 0 ≤ 2 * (t : ℝ))]; ring
+  · have := t.2.1; have := t.2.2
+    rw [min_eq_right (by linarith : 2 * (t : ℝ) - 1 ≤ 1),
+        max_eq_right (by linarith : 0 ≤ 2 * (t : ℝ) - 1)]; ring
+
+/--
+Splitting a sub-path into pieces and rejoining them is independent, up to homotopy,
+of the splitting point.
+-/
+theorem subpathOn_trans_aux₂ (γ : Path x y) (a b : unitInterval) (hab : a ≤ b)
+    (s t : unitInterval) :
+    Path.Homotopic
+      ((γ.subpathOn a (convexCombo a b s) (le_convexCombo hab _)).trans
+        (γ.subpathOn (convexCombo a b s) b (convexCombo_le hab _)))
+      ((γ.subpathOn a (convexCombo a b t) (le_convexCombo hab _)).trans
+        (γ.subpathOn (convexCombo a b t) b (convexCombo_le hab _))) := by
+  -- Construct explicit homotopy: at parameter u, split at convexCombo(a, b, convexCombo(s, t, u))
+  refine ⟨{
+    toFun := fun ⟨u, v⟩ =>
+      ((γ.subpathOn a (convexCombo a b (convexCombo s t u)) (le_convexCombo hab _)).trans
+        (γ.subpathOn (convexCombo a b (convexCombo s t u)) b (convexCombo_le hab _))) v
+    continuous_toFun := by
+      simp only [trans_apply, one_div, subpathOn_apply, coe_convexCombo]
+      simp only [← extend_apply, dite_eq_ite]
+      apply continuous_if_le (hfg := by grind) <;> fun_prop
+    map_zero_left v := by simp [Path.trans_apply]
+    map_one_left v := by simp [Path.trans_apply]
+    prop' u x hx := by
+      rcases hx with rfl | rfl
+      · simp [Path.trans]
+      · simp [Path.trans]
+        norm_num
+  }⟩
+
+/--
+A subpath from a to b composed with a subpath from b to c is homotopic to
+the subpath from a to c.
+-/
+theorem subpathOn_trans
+    (γ : Path x y) (a b c : unitInterval) (hab : a ≤ b) (hbc : b ≤ c) :
+    Path.Homotopic
+      ((γ.subpathOn a b hab).trans (γ.subpathOn b c hbc))
+      (γ.subpathOn a c (hab.trans hbc)) := by
+  -- This is an easy combination of `eq_convexCombo` and the two auxiliary lemmas above.
+  suffices ∀ s : unitInterval,
+    Path.Homotopic
+      ((γ.subpathOn a (Set.Icc.convexCombo a c s) (Set.Icc.le_convexCombo (hab.trans hbc) _)).trans
+        (γ.subpathOn (Set.Icc.convexCombo a c s) c (Set.Icc.convexCombo_le (hab.trans hbc) _)))
+      (γ.subpathOn a c (hab.trans hbc)) by
+    have hb := Set.Icc.eq_convexCombo hab hbc
+    convert this ?_ <;> exact hb
+  intro s
+  rw [← Path.subpathOn_trans_aux₁ γ a c]
+  apply Path.subpathOn_trans_aux₂ γ a c (hab.trans hbc) s
+
+/-- A subpath from a point to itself is homotopic to the constant path. -/
+theorem subpathOn_self (γ : Path x y) (a : unitInterval) :
+    Homotopic (γ.subpathOn a a (le_refl a)) (Path.refl (γ a)) := by
+  convert Homotopic.refl _
+  ext t
+  simp [Path.refl, Path.subpathOn]
+
+/-- The subpath from 0 to 1 is homotopic to the original path (up to casting endpoints). -/
+theorem subpathOn_zero_one (γ : Path x y) :
+    Homotopic
+      ((γ.subpathOn 0 1 (zero_le_one)).cast (by simp [γ.source]) (by simp [γ.target])) γ := by
+  convert Homotopic.refl _
+  ext t
+  simp [Path.cast, Path.subpathOn]
+
+namespace Homotopic.Quotient
+
+@[simp]
+theorem subpathOn_trans {x y : X} (p : Path x y)
+    (a b c : unitInterval) (hab : a ≤ b) (hbc : b ≤ c) :
+    trans (mk (p.subpathOn a b hab)) (mk (p.subpathOn b c hbc)) =
+      mk (p.subpathOn a c (hab.trans hbc)) := by
+  simp only [← mk_trans, eq]
+  exact Path.subpathOn_trans p a b c hab hbc
+
+@[simp]
+theorem subpathOn_self {x y : X} (p : Path x y) (a : unitInterval) :
+    mk (p.subpathOn a a (le_refl a)) = refl (p a) := by
+  simp only [← mk_refl, eq]
+  exact Path.subpathOn_self p a
+
+@[simp]
+theorem subpathOn_zero_one {x y : X} (p : Path x y) (s t : unitInterval)
+    (hs : s = 0) (ht : t = 1) :
+    mk (p.subpathOn s t (by grind [zero_le_one])) =
+      (mk p).cast (by grind) (by grind) := by
+  subst hs ht
+  simp only [← mk_cast, eq]
+  exact Path.subpathOn_zero_one p
+
+end Homotopic.Quotient
+
+end Path

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -126,6 +126,11 @@ def symmHomeomorph : I ≃ₜ I where
 
 theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := ℝ) h _
 
+/-- The midpoint of the unit interval. -/
+def half : I := ⟨1 / 2, by constructor <;> linarith⟩
+
+@[simp]
+theorem coe_half : (half : ℝ) = 1 / 2 := rfl
 
 @[simp]
 theorem symm_inj {i j : I} : σ i = σ j ↔ i = j := symm_bijective.injective.eq_iff

--- a/Mathlib/Topology/UnitInterval/ConvexSpace.lean
+++ b/Mathlib/Topology/UnitInterval/ConvexSpace.lean
@@ -42,11 +42,11 @@ noncomputable def convexCombo (t : unitInterval) (x y : M) : M :=
 
 @[simp]
 theorem convexCombo_zero (x y : M) : convexCombo 0 x y = x := by
-  simpa [convexCombo] using convexComboPair_one (R := ℝ) (x := x) (y := y)
+  simp [convexCombo]
 
 @[simp]
 theorem convexCombo_one (x y : M) : convexCombo 1 x y = y := by
-  simpa [convexCombo] using convexComboPair_zero (R := ℝ) (x := x) (y := y)
+  simp [convexCombo]
 
 @[simp]
 theorem convexCombo_same (t : unitInterval) (x : M) : convexCombo t x x = x := by

--- a/Mathlib/Topology/UnitInterval/ConvexSpace.lean
+++ b/Mathlib/Topology/UnitInterval/ConvexSpace.lean
@@ -42,13 +42,11 @@ noncomputable def convexCombo (t : unitInterval) (x y : M) : M :=
 
 @[simp]
 theorem convexCombo_zero (x y : M) : convexCombo 0 x y = x := by
-  unfold convexCombo
-  convert convexComboPair_one (R := ℝ) (x := x) (y := y) using 2; norm_num
+  simpa [convexCombo] using convexComboPair_one (R := ℝ) (x := x) (y := y)
 
 @[simp]
 theorem convexCombo_one (x y : M) : convexCombo 1 x y = y := by
-  unfold convexCombo
-  convert convexComboPair_zero (R := ℝ) (x := x) (y := y) using 2; norm_num
+  simpa [convexCombo] using convexComboPair_zero (R := ℝ) (x := x) (y := y)
 
 @[simp]
 theorem convexCombo_same (t : unitInterval) (x : M) : convexCombo t x x = x := by

--- a/Mathlib/Topology/UnitInterval/ConvexSpace.lean
+++ b/Mathlib/Topology/UnitInterval/ConvexSpace.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import Mathlib.LinearAlgebra.ConvexSpace
+public import Mathlib.Topology.UnitInterval
+
+/-!
+# Convex combinations parameterized by the unit interval
+
+This file provides the definition `unitInterval.convexCombo` for computing convex combinations
+in any convex space, parameterized by a point in the unit interval.
+
+## Main definitions
+
+* `unitInterval.convexCombo`: Given `t : unitInterval` and `x y : M` in a convex space,
+  returns the convex combination `(1 - t) * x + t * y`.
+
+## Main results
+
+* `unitInterval.convexCombo_zero`: `convexCombo 0 x y = x`
+* `unitInterval.convexCombo_one`: `convexCombo 1 x y = y`
+* `unitInterval.convexCombo_same`: `convexCombo t x x = x`
+
+-/
+
+@[expose] public section
+
+open scoped unitInterval
+
+namespace unitInterval
+
+variable {M : Type*} [ConvexSpace ℝ M]
+
+/-- Convex combination in a convex space, parameterized by a point in the unit interval.
+`convexCombo t x y` computes `(1 - t) * x + t * y`. -/
+noncomputable def convexCombo (t : unitInterval) (x y : M) : M :=
+  convexComboPair (1 - (t : ℝ)) (t : ℝ) (by nlinarith [t.2.1, t.2.2]) t.2.1 (by ring) x y
+
+@[simp]
+theorem convexCombo_zero (x y : M) : convexCombo 0 x y = x := by
+  unfold convexCombo
+  convert convexComboPair_one (R := ℝ) (x := x) (y := y) using 2; norm_num
+
+@[simp]
+theorem convexCombo_one (x y : M) : convexCombo 1 x y = y := by
+  unfold convexCombo
+  convert convexComboPair_zero (R := ℝ) (x := x) (y := y) using 2; norm_num
+
+@[simp]
+theorem convexCombo_same (t : unitInterval) (x : M) : convexCombo t x x = x := by
+  unfold convexCombo
+  exact convexComboPair_same _ _ _
+
+end unitInterval


### PR DESCRIPTION
This PR adds `Path.subpathOn`, which extracts a subpath from a path γ on an interval [a, b] ⊆ [0, 1] by reparametrizing via the affine map t ↦ a + t(b - a).

### Main results

- `Path.subpathOn`: definition of the restricted path
- `Path.subpathOn_trans`: composing subpaths is homotopic to the combined subpath
- `Path.subpathOn_self`: the trivial subpath [a,a] is homotopic to the constant path
- `Path.subpathOn_zero_one`: the full subpath [0,1] is homotopic to the original path
- Quotient-level versions of these theorems

This material is split out from https://github.com/leanprover-community/mathlib4/pull/31576 to allow independent review. PR #31576 will depend on this PR once merged.

🤖 Prepared with Claude Code