### PR TITLE
feat(Topology): add StrictMono finite partition lemmas and path partitioning

### DIFF
--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -666,15 +666,11 @@ theorem exists_partition_in_cover
     ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
       Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ j : ι,
-        Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U j) := by
-  -- Pull back the cover along γ to get an open cover of unitInterval
-  let V : ι → Set unitInterval := fun i => γ ⁻¹' (U i)
-  have hV_open : ∀ i, IsOpen (V i) := fun i => (hU_open i).preimage γ.continuous
-  have hV_cover : (Set.univ : Set unitInterval) ⊆ ⋃ i, V i := by
-    intro s _
-    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp (hU_cover (Set.mem_range_self s))
-    exact Set.mem_iUnion.mpr ⟨i, hi⟩
-  exact exists_monotone_partition_unitInterval hV_open hV_cover
+        Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U j) :=
+  -- Pull back the cover along `γ`; the result is an open cover of `unitInterval`.
+  exists_monotone_partition_unitInterval
+    (fun i ↦ (hU_open i).preimage γ.continuous)
+    (fun s _ ↦ by rw [← Set.preimage_iUnion]; exact hU_cover ⟨s, rfl⟩)
 
 /-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
 has a neighborhood with property P, then there exists a partition such that each segment lies
@@ -685,17 +681,12 @@ theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → 
       Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
         Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U) := by
-  -- For each z, choose a neighborhood U z with property P
   choose U hU_open hU_mem hU_P using h
-  -- These form an open cover of the path's range
-  have h_cover : Set.range γ ⊆ ⋃ z : Set.range γ, U z.val z.property := fun w hw =>
-    Set.mem_iUnion.mpr ⟨⟨w, hw⟩, hU_mem w hw⟩
-  -- Apply the cover version
   obtain ⟨n, t, h_mono, h_start, h_end, h_segments⟩ :=
-    exists_partition_in_cover (fun z : Set.range γ => U z.val z.property)
-      (fun z => hU_open z.val z.property) γ h_cover
-  refine ⟨n, t, h_mono, h_start, h_end, ?_⟩
-  intro i
+    exists_partition_in_cover (fun z : Set.range γ ↦ U z.val z.property)
+      (fun z ↦ hU_open z.val z.property) γ
+      (fun w hw ↦ Set.mem_iUnion.mpr ⟨⟨w, hw⟩, hU_mem w hw⟩)
+  refine ⟨n, t, h_mono, h_start, h_end, fun i ↦ ?_⟩
   obtain ⟨⟨z, hz⟩, h_seg⟩ := h_segments i
   exact ⟨U z hz, hU_open z hz, hU_P z hz, h_seg⟩
 

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -664,7 +664,7 @@ theorem exists_partition_in_cover
     {ι : Type*} (U : ι → Set X) (hU_open : ∀ i, IsOpen (U i))
     {x y : X} (γ : Path x y) (hU_cover : Set.range γ ⊆ ⋃ i, U i) :
     ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
-      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ j : ι,
         Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U j) := by
   -- Pull back the cover along γ to get an open cover of unitInterval
@@ -674,9 +674,7 @@ theorem exists_partition_in_cover
     intro s _
     obtain ⟨i, hi⟩ := Set.mem_iUnion.mp (hU_cover (Set.mem_range_self s))
     exact Set.mem_iUnion.mpr ⟨i, hi⟩
-  obtain ⟨n, t, ht_strict, ht0, htn, ht_cover⟩ :=
-    exists_strictMono_Icc_subset_open_cover_unitInterval hV_open hV_cover
-  exact ⟨n, t, ht_strict, ht0, htn, ht_cover⟩
+  exact exists_monotone_partition_unitInterval hV_open hV_cover
 
 /-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
 has a neighborhood with property P, then there exists a partition such that each segment lies
@@ -684,7 +682,7 @@ in an open set with property P. This follows immediately from the cover version.
 theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → Prop)
     (h : ∀ z ∈ Set.range γ, ∃ U : Set X, IsOpen U ∧ z ∈ U ∧ P U) :
     ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
-      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
         Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U) := by
   -- For each z, choose a neighborhood U z with property P

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -666,7 +666,7 @@ theorem exists_partition_in_cover
     ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
       StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ j : ι,
-        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U j) := by
+        Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U j) := by
   -- Pull back the cover along γ to get an open cover of unitInterval
   let V : ι → Set unitInterval := fun i => γ ⁻¹' (U i)
   have hV_open : ∀ i, IsOpen (V i) := fun i => (hU_open i).preimage γ.continuous
@@ -676,11 +676,7 @@ theorem exists_partition_in_cover
     exact Set.mem_iUnion.mpr ⟨i, hi⟩
   obtain ⟨n, t, ht_strict, ht0, htn, ht_cover⟩ :=
     exists_strictMono_Icc_subset_open_cover_unitInterval hV_open hV_cover
-  refine ⟨n, t, ht_strict, ht0, htn, ?_⟩
-  -- Each segment is in some U j
-  intro i
-  obtain ⟨j, hj⟩ := ht_cover i
-  refine ⟨j, fun s hs => hj hs⟩
+  exact ⟨n, t, ht_strict, ht0, htn, ht_cover⟩
 
 /-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
 has a neighborhood with property P, then there exists a partition such that each segment lies
@@ -690,7 +686,7 @@ theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → 
     ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
       StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       (∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
-        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U) := by
+        Icc (t i.castSucc) (t i.succ) ⊆ γ ⁻¹' U) := by
   -- For each z, choose a neighborhood U z with property P
   choose U hU_open hU_mem hU_P using h
   -- These form an open cover of the path's range

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -680,8 +680,7 @@ theorem exists_partition_in_cover
   -- Each segment is in some U j
   intro i
   obtain ⟨j, hj⟩ := ht_cover i
-  refine ⟨j, fun s hs => ?_⟩
-  exact hj ⟨hs.1, hs.2⟩
+  refine ⟨j, fun s hs => hj hs⟩
 
 /-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
 has a neighborhood with property P, then there exists a partition such that each segment lies
@@ -695,9 +694,8 @@ theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → 
   -- For each z, choose a neighborhood U z with property P
   choose U hU_open hU_mem hU_P using h
   -- These form an open cover of the path's range
-  have h_cover : Set.range γ ⊆ ⋃ z : Set.range γ, U z.val z.property := by
-    intro w hw
-    exact Set.mem_iUnion.mpr ⟨⟨w, hw⟩, hU_mem w hw⟩
+  have h_cover : Set.range γ ⊆ ⋃ z : Set.range γ, U z.val z.property := fun w hw =>
+    Set.mem_iUnion.mpr ⟨⟨w, hw⟩, hU_mem w hw⟩
   -- Apply the cover version
   obtain ⟨n, t, h_mono, h_start, h_end, h_segments⟩ :=
     exists_partition_in_cover (fun z : Set.range γ => U z.val z.property)

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -655,4 +655,56 @@ theorem refl_reparam {f : I → I} (hfcont : Continuous f) (hf₀ : f 0 = 0) (hf
   ext
   simp
 
+/-! ### Partitioning paths using Lebesgue numbers -/
+
+/-- Lebesgue partition lemma for paths: Any open cover of a path's range can be refined to a
+finite partition of the parameter interval such that each segment's image lies in some cover
+element. -/
+theorem exists_partition_in_cover
+    {ι : Type*} (U : ι → Set X) (hU_open : ∀ i, IsOpen (U i))
+    {x y : X} (γ : Path x y) (hU_cover : Set.range γ ⊆ ⋃ i, U i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
+      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      (∀ i : Fin n, ∃ j : ι,
+        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U j) := by
+  -- Pull back the cover along γ to get an open cover of unitInterval
+  let V : ι → Set unitInterval := fun i => γ ⁻¹' (U i)
+  have hV_open : ∀ i, IsOpen (V i) := fun i => (hU_open i).preimage γ.continuous
+  have hV_cover : (Set.univ : Set unitInterval) ⊆ ⋃ i, V i := by
+    intro s _
+    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp (hU_cover (Set.mem_range_self s))
+    exact Set.mem_iUnion.mpr ⟨i, hi⟩
+  obtain ⟨n, t, ht_strict, ht0, htn, ht_cover⟩ :=
+    exists_strictMono_Icc_subset_open_cover_unitInterval hV_open hV_cover
+  refine ⟨n, t, ht_strict, ht0, htn, ?_⟩
+  -- Each segment is in some U j
+  intro i
+  obtain ⟨j, hj⟩ := ht_cover i
+  refine ⟨j, fun s hs => ?_⟩
+  exact hj ⟨hs.1, hs.2⟩
+
+/-- Generic Lebesgue partition lemma for paths, neighborhood version: If every point on a path
+has a neighborhood with property P, then there exists a partition such that each segment lies
+in an open set with property P. This follows immediately from the cover version. -/
+theorem exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → Prop)
+    (h : ∀ z ∈ Set.range γ, ∃ U : Set X, IsOpen U ∧ z ∈ U ∧ P U) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → unitInterval),
+      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      (∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
+        ∀ s : unitInterval, (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U) := by
+  -- For each z, choose a neighborhood U z with property P
+  choose U hU_open hU_mem hU_P using h
+  -- These form an open cover of the path's range
+  have h_cover : Set.range γ ⊆ ⋃ z : Set.range γ, U z.val z.property := by
+    intro w hw
+    exact Set.mem_iUnion.mpr ⟨⟨w, hw⟩, hU_mem w hw⟩
+  -- Apply the cover version
+  obtain ⟨n, t, h_mono, h_start, h_end, h_segments⟩ :=
+    exists_partition_in_cover (fun z : Set.range γ => U z.val z.property)
+      (fun z => hU_open z.val z.property) γ h_cover
+  refine ⟨n, t, h_mono, h_start, h_end, ?_⟩
+  intro i
+  obtain ⟨⟨z, hz⟩, h_seg⟩ := h_segments i
+  exact ⟨U z hz, hU_open z hz, hU_P z hz, h_seg⟩
+
 end Path

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -544,7 +544,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
           _ = b := by field_simp [hn_pos'.ne']; ring⟩
     have ht_strict : StrictMono t := by
       intro i j hij
-      change (t i : ℝ) < (t j : ℝ)
+      rw [← Subtype.coe_lt_coe]
       simp only [t]
       have hij' : (i : ℝ) < (j : ℝ) := Nat.cast_lt.mpr hij
       have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -401,13 +401,11 @@ theorem convexCombo_assoc {a b : ℝ} (x y z : Icc a b) (s t : unitInterval) :
   · simp only [hs]
     by_cases ht : (t : ℝ) = 1
     · simp [ht]
-    · have h1t : (1 - t : ℝ) ≠ 0 := one_sub_coe_ne_zero ht
-      field_simp
-      simp
+    · field_simp [one_sub_coe_ne_zero ht]
+      ring
   · by_cases ht : (t : ℝ) = 1
     · simp [ht]
-    · have h1st : (1 - s * t : ℝ) ≠ 0 := one_sub_mul_coe_ne_zero ht
-      field_simp
+    · field_simp [one_sub_mul_coe_ne_zero ht]
       ring_nf
 
 /--
@@ -476,20 +474,18 @@ open scoped unitInterval
 private theorem mem_ball_addNSMul_of_mem_Icc {a b δ : ℝ} (h : a ≤ b) (δ_pos : 0 < δ)
     (n : ℕ) {t : Icc a b}
     (ht : t ∈ Icc (addNSMul h (δ / 2) n) (addNSMul h (δ / 2) (n + 1))) :
-    t ∈ Metric.ball (addNSMul h (δ / 2) n) δ := by
-  have hδ : 0 < δ / 2 := half_pos δ_pos
-  exact Metric.mem_ball.mpr <|
-    (abs_sub_addNSMul_le h hδ.le n ht).trans_lt <| half_lt_self δ_pos
+    t ∈ Metric.ball (addNSMul h (δ / 2) n) δ :=
+  Metric.mem_ball.mpr <|
+    (abs_sub_addNSMul_le h (half_pos δ_pos).le n ht).trans_lt <| half_lt_self δ_pos
 
 private theorem mem_ball_addNSMul_prod_of_mem_Icc {δ : ℝ} (δ_pos : 0 < δ)
     (n m : ℕ) {t : I × I}
     (ht₁ : t.1 ∈ Icc (addNSMul zero_le_one (δ / 2) n) (addNSMul zero_le_one (δ / 2) (n + 1)))
     (ht₂ : t.2 ∈ Icc (addNSMul zero_le_one (δ / 2) m) (addNSMul zero_le_one (δ / 2) (m + 1))) :
-    t ∈ Metric.ball (addNSMul zero_le_one (δ / 2) n, addNSMul zero_le_one (δ / 2) m) δ := by
-  have hδ : 0 < δ / 2 := half_pos δ_pos
-  exact Metric.mem_ball.mpr <|
-    (max_le (abs_sub_addNSMul_le zero_le_one hδ.le n ht₁)
-      (abs_sub_addNSMul_le zero_le_one hδ.le m ht₂)).trans_lt <| half_lt_self δ_pos
+    t ∈ Metric.ball (addNSMul zero_le_one (δ / 2) n, addNSMul zero_le_one (δ / 2) m) δ :=
+  Metric.mem_ball.mpr <|
+    (max_le (abs_sub_addNSMul_le zero_le_one (half_pos δ_pos).le n ht₁)
+      (abs_sub_addNSMul_le zero_le_one (half_pos δ_pos).le m ht₂)).trans_lt <| half_lt_self δ_pos
 
 /-- Any open cover `c` of a closed interval `[a, b]` in ℝ
 can be refined to a finite partition into subintervals. -/

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -500,107 +500,30 @@ lemma exists_monotone_Icc_subset_open_cover_unitInterval_prod_self {ι} {c : ι 
   exact ⟨i, fun t ht ↦ hsub (Metric.mem_ball.mpr <| (max_le (abs_sub_addNSMul_le h hδ.le n ht.1) <|
     abs_sub_addNSMul_le h hδ.le m ht.2).trans_lt <| half_lt_self δ_pos)⟩
 
-/-- Finite partition variant: Any open cover of `[a, b]` can be refined to a finite partition
-with strictly monotone partition points indexed by `Fin (n + 1)`. -/
-lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
+/-- Finite-`Fin` partition variant: Any open cover of `[a, b]` can be refined to a monotone
+partition indexed by `Fin (n + 1)`. -/
+lemma exists_monotone_partition_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
     (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
     ∃ (n : ℕ) (t : Fin (n + 1) → Icc a b),
-      StrictMono t ∧ t 0 = a ∧ t (Fin.last n) = b ∧
+      Monotone t ∧ t 0 = a ∧ t (Fin.last n) = b ∧
       ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
-  -- Get Lebesgue number
-  obtain ⟨δ, δ_pos, hδ⟩ := lebesgue_number_lemma_of_metric isCompact_univ hc₁ hc₂
-  -- Pick n: if a = b then n = 0, otherwise pick n large enough so that (b - a) / n < δ
-  by_cases hab : a = b
-  · -- Case a = b: take n = 0 with single partition point
-    subst hab
-    exact ⟨0, fun _ => ⟨a, by simp⟩, Subsingleton.strictMono (α := Fin 1) _, rfl, rfl,
-      fun i => i.elim0⟩
-  · -- Case a < b: pick n with (b - a) / n < δ
-    have hab_pos : 0 < b - a := sub_pos.mpr (Ne.lt_of_le hab h)
-    obtain ⟨n, hn_pos, hn_small⟩ : ∃ n : ℕ, 0 < n ∧ (b - a) / n < δ := by
-      obtain ⟨n, hn⟩ := exists_nat_gt ((b - a) / δ)
-      have hn_pos : 0 < n := by
-        have h1 : 0 < (b - a) / δ := div_pos hab_pos δ_pos
-        have h2 : (0 : ℝ) < n := by linarith
-        exact Nat.cast_pos.mp h2
-      refine ⟨n, hn_pos, ?_⟩
-      have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
-      -- From (b - a) / δ < n, multiply both sides by δ to get b - a < n * δ
-      have h_mul : b - a < n * δ := calc
-        b - a = (b - a) / δ * δ := by field_simp [δ_pos.ne']
-        _ < n * δ := by nlinarith [δ_pos]
-      calc (b - a) / n < (n * δ) / n := by gcongr
-        _ = δ := by field_simp
-    -- Define partition: t k = a + k * (b - a) / n
-    let t : Fin (n + 1) → Icc a b := fun k => ⟨a + k * (b - a) / n, by
-      constructor
-      · linarith [mul_nonneg (Nat.cast_nonneg (k : ℕ)) (sub_nonneg.mpr h),
-          div_nonneg (mul_nonneg (Nat.cast_nonneg (k : ℕ)) (sub_nonneg.mpr h)) (Nat.cast_nonneg n)]
-      · have hk : (k : ℝ) ≤ n := Nat.cast_le.mpr (Nat.lt_succ_iff.mp k.is_lt)
-        have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
-        calc a + k * (b - a) / n ≤ a + n * (b - a) / n := by {
-              have : k * (b - a) ≤ n * (b - a) := by nlinarith
-              linarith [div_le_div_of_nonneg_right this hn_pos'.le] }
-          _ = b := by field_simp [hn_pos'.ne']; ring⟩
-    have ht_strict : StrictMono t := by
-      intro i j hij
-      rw [← Subtype.coe_lt_coe]
-      simp only [t]
-      have hij' : (i : ℝ) < (j : ℝ) := Nat.cast_lt.mpr hij
-      have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
-      have : i * (b - a) < j * (b - a) := by nlinarith [hab_pos]
-      linarith [div_lt_div_of_pos_right this hn_pos']
-    refine ⟨n, t, ht_strict, ?_, ?_, ?_⟩
-    · -- t 0 = a
-      simp [t]
-    · -- t (Fin.last n) = b
-      simp [t]
-      field_simp [Nat.cast_pos.mpr hn_pos]
-      ring
-    · -- Covering property
-      intro i
-      -- Use StrictMono to get that t i.castSucc < t i.succ
-      have h_mono : (t i.castSucc : ℝ) < (t i.succ : ℝ) := ht_strict i.castSucc_lt_succ
-      -- Define the midpoint
-      let m : Icc a b := ⟨((t i.castSucc : ℝ) + (t i.succ : ℝ)) / 2, by
-        constructor
-        · linarith [(t i.castSucc).2.1, (t i.succ).2.1]
-        · linarith [(t i.castSucc).2.2, (t i.succ).2.2]⟩
-      -- The segment is contained in ball m δ
-      have h_subset : Icc (t i.castSucc) (t i.succ) ⊆ Metric.ball m δ := by
-        intro x hx
-        simp only [Metric.ball, mem_setOf_eq]
-        have segment_len : (t i.succ : ℝ) - (t i.castSucc : ℝ) = (b - a) / n := by
-          simp [t]
-          field_simp
-          ring
-        -- x is in the segment, so its distance from midpoint is at most (b-a)/(2n) < δ
-        have hx_bounds : (t i.castSucc : ℝ) ≤ (x : ℝ) ∧ (x : ℝ) ≤ (t i.succ : ℝ) := ⟨hx.1, hx.2⟩
-        have dist_bound : dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := by
-          rw [dist_comm, Real.dist_eq]
-          simp only [m, abs_sub_le_iff]
-          constructor <;>
-          · linarith [hx_bounds.1, hx_bounds.2, segment_len]
-        -- Since (b-a)/n < δ, we have (b-a)/(2n) < δ/2 < δ
-        calc dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := dist_bound
-          _ < δ / 2 := by linarith [hn_small]
-          _ < δ := by linarith [δ_pos]
-      -- Apply Lebesgue number property to get the covering set
-      obtain ⟨j, hj⟩ := hδ m trivial
-      exact ⟨j, Subset.trans h_subset hj⟩
+  obtain ⟨t, ht0, ht_mono, ⟨N, hN⟩, ht_cover⟩ :=
+    exists_monotone_Icc_subset_open_cover_Icc h hc₁ hc₂
+  refine ⟨N, fun k => t (k : ℕ), fun _ _ hij => ht_mono hij, ?_, ?_, fun i => ?_⟩
+  · simpa using ht0
+  · simpa using hN N le_rfl
+  · obtain ⟨j, hj⟩ := ht_cover i
+    exact ⟨j, by simpa [Fin.val_succ, Fin.val_castSucc] using hj⟩
 
-/-- Finite partition variant: Any open cover of the unit interval can be refined to a finite
-partition with strictly monotone partition points indexed by `Fin (n + 1)`. -/
-lemma exists_strictMono_Icc_subset_open_cover_unitInterval {ι} {c : ι → Set I}
+/-- Finite-`Fin` partition variant for the unit interval. -/
+lemma exists_monotone_partition_unitInterval {ι} {c : ι → Set I}
     (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
     ∃ (n : ℕ) (t : Fin (n + 1) → I),
-      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      Monotone t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
       ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
-  obtain ⟨n, t, ht_strict, ht0, htn, ht_cover⟩ :=
-    exists_strictMono_Icc_subset_open_cover_Icc zero_le_one hc₁ hc₂
-  refine ⟨n, t, ht_strict, ?_, ?_, ht_cover⟩
-  · ext; exact ht0
-  · ext; exact htn
+  obtain ⟨N, t, ht_mono, ht0, htN, ht_cover⟩ :=
+    exists_monotone_partition_Icc zero_le_one hc₁ hc₂
+  exact ⟨N, t, ht_mono, Subtype.ext ht0, Subtype.ext htN, ht_cover⟩
 
 end partition
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -383,6 +383,15 @@ when we reassociate a convex combination.
 -/
 abbrev convexCombo_assoc_coeff₂ (s t : unitInterval) : unitInterval := s * t
 
+private theorem one_sub_coe_ne_zero {t : unitInterval} (ht : (t : ℝ) ≠ 1) : (1 - t : ℝ) ≠ 0 := by
+  grind
+
+private theorem one_sub_mul_coe_ne_zero {s t : unitInterval}
+    (ht : (t : ℝ) ≠ 1) : (1 - s * t : ℝ) ≠ 0 := by
+  intro h
+  have : 1 ≤ (t : ℝ) := by nlinarith [s.2.2, t.2.1]
+  grind
+
 theorem convexCombo_assoc {a b : ℝ} (x y z : Icc a b) (s t : unitInterval) :
     convexCombo x (convexCombo y z t) s =
       convexCombo (convexCombo x y (convexCombo_assoc_coeff₁ s t)) z
@@ -392,15 +401,12 @@ theorem convexCombo_assoc {a b : ℝ} (x y z : Icc a b) (s t : unitInterval) :
   · simp only [hs]
     by_cases ht : (t : ℝ) = 1
     · simp [ht]
-    · have : (1 - t : ℝ) ≠ 0 := by grind
+    · have h1t : (1 - t : ℝ) ≠ 0 := one_sub_coe_ne_zero ht
       field_simp
       simp
   · by_cases ht : (t : ℝ) = 1
     · simp [ht]
-    · have : (1 - s * t : ℝ) ≠ 0 := by
-        intro h
-        have : 1 ≤ (t : ℝ) := by nlinarith [s.2.2, t.2.1]
-        grind
+    · have h1st : (1 - s * t : ℝ) ≠ 0 := one_sub_mul_coe_ne_zero ht
       field_simp
       ring_nf
 
@@ -467,17 +473,34 @@ end Set.Icc
 
 open scoped unitInterval
 
+private theorem mem_ball_addNSMul_of_mem_Icc {a b δ : ℝ} (h : a ≤ b) (δ_pos : 0 < δ)
+    (n : ℕ) {t : Icc a b}
+    (ht : t ∈ Icc (addNSMul h (δ / 2) n) (addNSMul h (δ / 2) (n + 1))) :
+    t ∈ Metric.ball (addNSMul h (δ / 2) n) δ := by
+  have hδ : 0 < δ / 2 := half_pos δ_pos
+  exact Metric.mem_ball.mpr <|
+    (abs_sub_addNSMul_le h hδ.le n ht).trans_lt <| half_lt_self δ_pos
+
+private theorem mem_ball_addNSMul_prod_of_mem_Icc {δ : ℝ} (δ_pos : 0 < δ)
+    (n m : ℕ) {t : I × I}
+    (ht₁ : t.1 ∈ Icc (addNSMul zero_le_one (δ / 2) n) (addNSMul zero_le_one (δ / 2) (n + 1)))
+    (ht₂ : t.2 ∈ Icc (addNSMul zero_le_one (δ / 2) m) (addNSMul zero_le_one (δ / 2) (m + 1))) :
+    t ∈ Metric.ball (addNSMul zero_le_one (δ / 2) n, addNSMul zero_le_one (δ / 2) m) δ := by
+  have hδ : 0 < δ / 2 := half_pos δ_pos
+  exact Metric.mem_ball.mpr <|
+    (max_le (abs_sub_addNSMul_le zero_le_one hδ.le n ht₁)
+      (abs_sub_addNSMul_le zero_le_one hδ.le m ht₂)).trans_lt <| half_lt_self δ_pos
+
 /-- Any open cover `c` of a closed interval `[a, b]` in ℝ
 can be refined to a finite partition into subintervals. -/
 lemma exists_monotone_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
     (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) : ∃ t : ℕ → Icc a b, t 0 = a ∧
       Monotone t ∧ (∃ m, ∀ n ≥ m, t n = b) ∧ ∀ n, ∃ i, Icc (t n) (t (n + 1)) ⊆ c i := by
   obtain ⟨δ, δ_pos, ball_subset⟩ := lebesgue_number_lemma_of_metric isCompact_univ hc₁ hc₂
-  have hδ := half_pos δ_pos
   refine ⟨addNSMul h (δ/2), addNSMul_zero h,
-    monotone_addNSMul h hδ.le, addNSMul_eq_right h hδ, fun n ↦ ?_⟩
+    monotone_addNSMul h (half_pos δ_pos).le, addNSMul_eq_right h (half_pos δ_pos), fun n ↦ ?_⟩
   obtain ⟨i, hsub⟩ := ball_subset (addNSMul h (δ / 2) n) trivial
-  exact ⟨i, fun t ht ↦ hsub ((abs_sub_addNSMul_le h hδ.le n ht).trans_lt <| half_lt_self δ_pos)⟩
+  exact ⟨i, fun t ht ↦ hsub <| mem_ball_addNSMul_of_mem_Icc h δ_pos n ht⟩
 
 /-- Any open cover of the unit interval can be refined to a finite partition into subintervals. -/
 lemma exists_monotone_Icc_subset_open_cover_unitInterval {ι} {c : ι → Set I}
@@ -491,14 +514,13 @@ lemma exists_monotone_Icc_subset_open_cover_unitInterval_prod_self {ι} {c : ι 
     ∃ t : ℕ → I, t 0 = 0 ∧ Monotone t ∧ (∃ n, ∀ m ≥ n, t m = 1) ∧
       ∀ n m, ∃ i, Icc (t n) (t (n + 1)) ×ˢ Icc (t m) (t (m + 1)) ⊆ c i := by
   obtain ⟨δ, δ_pos, ball_subset⟩ := lebesgue_number_lemma_of_metric isCompact_univ hc₁ hc₂
-  have hδ := half_pos δ_pos
   simp_rw [Subtype.ext_iff]
-  have h : (0 : ℝ) ≤ 1 := zero_le_one
-  refine ⟨addNSMul h (δ/2), addNSMul_zero h,
-    monotone_addNSMul h hδ.le, addNSMul_eq_right h hδ, fun n m ↦ ?_⟩
-  obtain ⟨i, hsub⟩ := ball_subset (addNSMul h (δ / 2) n, addNSMul h (δ / 2) m) trivial
-  exact ⟨i, fun t ht ↦ hsub (Metric.mem_ball.mpr <| (max_le (abs_sub_addNSMul_le h hδ.le n ht.1) <|
-    abs_sub_addNSMul_le h hδ.le m ht.2).trans_lt <| half_lt_self δ_pos)⟩
+  refine ⟨addNSMul zero_le_one (δ/2), addNSMul_zero zero_le_one,
+    monotone_addNSMul zero_le_one (half_pos δ_pos).le,
+    addNSMul_eq_right zero_le_one (half_pos δ_pos), fun n m ↦ ?_⟩
+  obtain ⟨i, hsub⟩ := ball_subset
+    (addNSMul zero_le_one (δ / 2) n, addNSMul zero_le_one (δ / 2) m) trivial
+  exact ⟨i, fun t ht ↦ hsub <| mem_ball_addNSMul_prod_of_mem_Icc δ_pos n m ht.1 ht.2⟩
 
 /-- Finite-`Fin` partition variant: Any open cover of `[a, b]` can be refined to a monotone
 partition indexed by `Fin (n + 1)`. -/
@@ -509,7 +531,7 @@ lemma exists_monotone_partition_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → S
       ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
   obtain ⟨t, ht0, ht_mono, ⟨N, hN⟩, ht_cover⟩ :=
     exists_monotone_Icc_subset_open_cover_Icc h hc₁ hc₂
-  refine ⟨N, fun k => t (k : ℕ), fun _ _ hij => ht_mono hij, ?_, ?_, fun i => ?_⟩
+  refine ⟨N, fun k ↦ t (k : ℕ), fun _ _ hij ↦ ht_mono hij, ?_, ?_, fun i ↦ ?_⟩
   · simpa using ht0
   · simpa using hN N le_rfl
   · obtain ⟨j, hj⟩ := ht_cover i

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -464,9 +464,8 @@ theorem eq_convexCombo {a b : ℝ} {x y z : Icc a b} (hxy : x ≤ y) (hyz : y �
     ring_nf
 
 theorem continuous_convexCombo {a b : ℝ} :
-    Continuous (fun (p : Icc a b × Icc a b × unitInterval) => convexCombo p.1 p.2.1 p.2.2) := by
-  apply Continuous.subtype_mk
-  fun_prop
+    Continuous (fun (p : Icc a b × Icc a b × unitInterval) => convexCombo p.1 p.2.1 p.2.2) :=
+  Continuous.subtype_mk (by fun_prop) _
 
 end Set.Icc
 
@@ -521,14 +520,14 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
     refine ⟨0, fun _ => ⟨a, by simp⟩, ?_, ?_, ?_, ?_⟩
     · -- StrictMono: vacuously true for Fin 1
       intro i j hij
-      exact absurd hij (by omega)
+      omega
     · -- t 0 = a
       rfl
     · -- t (Fin.last 0) = a = b
       rfl
     · -- Covering property: vacuously true for Fin 0
       intro i
-      exact absurd i.val.lt_succ_self (by omega)
+      exact i.elim0
   · -- Case a < b: pick n with (b - a) / n < δ
     have hab_pos : 0 < b - a := sub_pos.mpr (Ne.lt_of_le hab h)
     obtain ⟨n, hn_pos, hn_small⟩ : ∃ n : ℕ, 0 < n ∧ (b - a) / n < δ := by
@@ -602,8 +601,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
         have dist_bound : dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := by
           rw [dist_comm, Real.dist_eq]
           simp only [m, abs_sub_le_iff]
-          constructor
-          · linarith [hx_bounds.1, hx_bounds.2]
+          constructor <;>
           · linarith [hx_bounds.1, hx_bounds.2]
         -- Since (b-a)/n < δ, we have (b-a)/(2n) < δ/2 < δ
         calc dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := dist_bound

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -463,10 +463,6 @@ theorem eq_convexCombo {a b : ℝ} {x y z : Icc a b} (hxy : x ≤ y) (hyz : y �
   · field_simp
     ring_nf
 
-theorem continuous_convexCombo {a b : ℝ} :
-    Continuous (fun (p : Icc a b × Icc a b × unitInterval) => convexCombo p.1 p.2.1 p.2.2) :=
-  Continuous.subtype_mk (by fun_prop) _
-
 end Set.Icc
 
 open scoped unitInterval
@@ -517,17 +513,8 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
   by_cases hab : a = b
   · -- Case a = b: take n = 0 with single partition point
     subst hab
-    refine ⟨0, fun _ => ⟨a, by simp⟩, ?_, ?_, ?_, ?_⟩
-    · -- StrictMono: vacuously true for Fin 1
-      intro i j hij
-      omega
-    · -- t 0 = a
-      rfl
-    · -- t (Fin.last 0) = a = b
-      rfl
-    · -- Covering property: vacuously true for Fin 0
-      intro i
-      exact i.elim0
+    exact ⟨0, fun _ => ⟨a, by simp⟩, Subsingleton.strictMono (α := Fin 1) _, rfl, rfl,
+      fun i => i.elim0⟩
   · -- Case a < b: pick n with (b - a) / n < δ
     have hab_pos : 0 < b - a := sub_pos.mpr (Ne.lt_of_le hab h)
     obtain ⟨n, hn_pos, hn_small⟩ : ∃ n : ℕ, 0 < n ∧ (b - a) / n < δ := by
@@ -555,8 +542,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
               have : k * (b - a) ≤ n * (b - a) := by nlinarith
               linarith [div_le_div_of_nonneg_right this hn_pos'.le] }
           _ = b := by field_simp [hn_pos'.ne']; ring⟩
-    refine ⟨n, t, ?_, ?_, ?_, ?_⟩
-    · -- StrictMono
+    have ht_strict : StrictMono t := by
       intro i j hij
       change (t i : ℝ) < (t j : ℝ)
       simp only [t]
@@ -564,6 +550,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
       have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
       have : i * (b - a) < j * (b - a) := by nlinarith [hab_pos]
       linarith [div_lt_div_of_pos_right this hn_pos']
+    refine ⟨n, t, ht_strict, ?_, ?_, ?_⟩
     · -- t 0 = a
       simp [t]
     · -- t (Fin.last n) = b
@@ -573,15 +560,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
     · -- Covering property
       intro i
       -- Use StrictMono to get that t i.castSucc < t i.succ
-      have h_mono : (t i.castSucc : ℝ) < (t i.succ : ℝ) := by
-        simp only [t]
-        have hij : (i.castSucc : ℕ) < (i.succ : ℕ) := by
-          rw [Fin.val_castSucc]
-          simp
-        have hij' : (i.castSucc : ℝ) < (i.succ : ℝ) := Nat.cast_lt.mpr hij
-        have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
-        have : i.castSucc * (b - a) < i.succ * (b - a) := by nlinarith [hab_pos]
-        linarith [div_lt_div_of_pos_right this hn_pos']
+      have h_mono : (t i.castSucc : ℝ) < (t i.succ : ℝ) := ht_strict i.castSucc_lt_succ
       -- Define the midpoint
       let m : Icc a b := ⟨((t i.castSucc : ℝ) + (t i.succ : ℝ)) / 2, by
         constructor
@@ -591,7 +570,6 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
       have h_subset : Icc (t i.castSucc) (t i.succ) ⊆ Metric.ball m δ := by
         intro x hx
         simp only [Metric.ball, mem_setOf_eq]
-        -- The segment has length (b-a)/n, so max distance from midpoint is (b-a)/(2n)
         have segment_len : (t i.succ : ℝ) - (t i.castSucc : ℝ) = (b - a) / n := by
           simp [t]
           field_simp
@@ -602,7 +580,7 @@ lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b)
           rw [dist_comm, Real.dist_eq]
           simp only [m, abs_sub_le_iff]
           constructor <;>
-          · linarith [hx_bounds.1, hx_bounds.2]
+          · linarith [hx_bounds.1, hx_bounds.2, segment_len]
         -- Since (b-a)/n < δ, we have (b-a)/(2n) < δ/2 < δ
         calc dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := dist_bound
           _ < δ / 2 := by linarith [hn_small]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -463,6 +463,11 @@ theorem eq_convexCombo {a b : ℝ} {x y z : Icc a b} (hxy : x ≤ y) (hyz : y �
   · field_simp
     ring_nf
 
+theorem continuous_convexCombo {a b : ℝ} :
+    Continuous (fun (p : Icc a b × Icc a b × unitInterval) => convexCombo p.1 p.2.1 p.2.2) := by
+  apply Continuous.subtype_mk
+  fun_prop
+
 end Set.Icc
 
 open scoped unitInterval
@@ -499,6 +504,127 @@ lemma exists_monotone_Icc_subset_open_cover_unitInterval_prod_self {ι} {c : ι 
   obtain ⟨i, hsub⟩ := ball_subset (addNSMul h (δ / 2) n, addNSMul h (δ / 2) m) trivial
   exact ⟨i, fun t ht ↦ hsub (Metric.mem_ball.mpr <| (max_le (abs_sub_addNSMul_le h hδ.le n ht.1) <|
     abs_sub_addNSMul_le h hδ.le m ht.2).trans_lt <| half_lt_self δ_pos)⟩
+
+/-- Finite partition variant: Any open cover of `[a, b]` can be refined to a finite partition
+with strictly monotone partition points indexed by `Fin (n + 1)`. -/
+lemma exists_strictMono_Icc_subset_open_cover_Icc {ι} {a b : ℝ} (h : a ≤ b) {c : ι → Set (Icc a b)}
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → Icc a b),
+      StrictMono t ∧ t 0 = a ∧ t (Fin.last n) = b ∧
+      ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
+  -- Get Lebesgue number
+  obtain ⟨δ, δ_pos, hδ⟩ := lebesgue_number_lemma_of_metric isCompact_univ hc₁ hc₂
+  -- Pick n: if a = b then n = 0, otherwise pick n large enough so that (b - a) / n < δ
+  by_cases hab : a = b
+  · -- Case a = b: take n = 0 with single partition point
+    subst hab
+    refine ⟨0, fun _ => ⟨a, by simp⟩, ?_, ?_, ?_, ?_⟩
+    · -- StrictMono: vacuously true for Fin 1
+      intro i j hij
+      exact absurd hij (by omega)
+    · -- t 0 = a
+      rfl
+    · -- t (Fin.last 0) = a = b
+      rfl
+    · -- Covering property: vacuously true for Fin 0
+      intro i
+      exact absurd i.val.lt_succ_self (by omega)
+  · -- Case a < b: pick n with (b - a) / n < δ
+    have hab_pos : 0 < b - a := sub_pos.mpr (Ne.lt_of_le hab h)
+    obtain ⟨n, hn_pos, hn_small⟩ : ∃ n : ℕ, 0 < n ∧ (b - a) / n < δ := by
+      obtain ⟨n, hn⟩ := exists_nat_gt ((b - a) / δ)
+      have hn_pos : 0 < n := by
+        have h1 : 0 < (b - a) / δ := div_pos hab_pos δ_pos
+        have h2 : (0 : ℝ) < n := by linarith
+        exact Nat.cast_pos.mp h2
+      refine ⟨n, hn_pos, ?_⟩
+      have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+      -- From (b - a) / δ < n, multiply both sides by δ to get b - a < n * δ
+      have h_mul : b - a < n * δ := calc
+        b - a = (b - a) / δ * δ := by field_simp [δ_pos.ne']
+        _ < n * δ := by nlinarith [δ_pos]
+      calc (b - a) / n < (n * δ) / n := by gcongr
+        _ = δ := by field_simp
+    -- Define partition: t k = a + k * (b - a) / n
+    let t : Fin (n + 1) → Icc a b := fun k => ⟨a + k * (b - a) / n, by
+      constructor
+      · linarith [mul_nonneg (Nat.cast_nonneg (k : ℕ)) (sub_nonneg.mpr h),
+          div_nonneg (mul_nonneg (Nat.cast_nonneg (k : ℕ)) (sub_nonneg.mpr h)) (Nat.cast_nonneg n)]
+      · have hk : (k : ℝ) ≤ n := Nat.cast_le.mpr (Nat.lt_succ_iff.mp k.is_lt)
+        have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+        calc a + k * (b - a) / n ≤ a + n * (b - a) / n := by {
+              have : k * (b - a) ≤ n * (b - a) := by nlinarith
+              linarith [div_le_div_of_nonneg_right this hn_pos'.le] }
+          _ = b := by field_simp [hn_pos'.ne']; ring⟩
+    refine ⟨n, t, ?_, ?_, ?_, ?_⟩
+    · -- StrictMono
+      intro i j hij
+      change (t i : ℝ) < (t j : ℝ)
+      simp only [t]
+      have hij' : (i : ℝ) < (j : ℝ) := Nat.cast_lt.mpr hij
+      have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+      have : i * (b - a) < j * (b - a) := by nlinarith [hab_pos]
+      linarith [div_lt_div_of_pos_right this hn_pos']
+    · -- t 0 = a
+      simp [t]
+    · -- t (Fin.last n) = b
+      simp [t]
+      field_simp [Nat.cast_pos.mpr hn_pos]
+      ring
+    · -- Covering property
+      intro i
+      -- Use StrictMono to get that t i.castSucc < t i.succ
+      have h_mono : (t i.castSucc : ℝ) < (t i.succ : ℝ) := by
+        simp only [t]
+        have hij : (i.castSucc : ℕ) < (i.succ : ℕ) := by
+          rw [Fin.val_castSucc]
+          simp
+        have hij' : (i.castSucc : ℝ) < (i.succ : ℝ) := Nat.cast_lt.mpr hij
+        have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+        have : i.castSucc * (b - a) < i.succ * (b - a) := by nlinarith [hab_pos]
+        linarith [div_lt_div_of_pos_right this hn_pos']
+      -- Define the midpoint
+      let m : Icc a b := ⟨((t i.castSucc : ℝ) + (t i.succ : ℝ)) / 2, by
+        constructor
+        · linarith [(t i.castSucc).2.1, (t i.succ).2.1]
+        · linarith [(t i.castSucc).2.2, (t i.succ).2.2]⟩
+      -- The segment is contained in ball m δ
+      have h_subset : Icc (t i.castSucc) (t i.succ) ⊆ Metric.ball m δ := by
+        intro x hx
+        simp only [Metric.ball, mem_setOf_eq]
+        -- The segment has length (b-a)/n, so max distance from midpoint is (b-a)/(2n)
+        have segment_len : (t i.succ : ℝ) - (t i.castSucc : ℝ) = (b - a) / n := by
+          simp [t]
+          field_simp
+          ring
+        -- x is in the segment, so its distance from midpoint is at most (b-a)/(2n) < δ
+        have hx_bounds : (t i.castSucc : ℝ) ≤ (x : ℝ) ∧ (x : ℝ) ≤ (t i.succ : ℝ) := ⟨hx.1, hx.2⟩
+        have dist_bound : dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := by
+          rw [dist_comm, Real.dist_eq]
+          simp only [m, abs_sub_le_iff]
+          constructor
+          · linarith [hx_bounds.1, hx_bounds.2]
+          · linarith [hx_bounds.1, hx_bounds.2]
+        -- Since (b-a)/n < δ, we have (b-a)/(2n) < δ/2 < δ
+        calc dist (x : ℝ) (m : ℝ) ≤ ((b - a) / n) / 2 := dist_bound
+          _ < δ / 2 := by linarith [hn_small]
+          _ < δ := by linarith [δ_pos]
+      -- Apply Lebesgue number property to get the covering set
+      obtain ⟨j, hj⟩ := hδ m trivial
+      exact ⟨j, Subset.trans h_subset hj⟩
+
+/-- Finite partition variant: Any open cover of the unit interval can be refined to a finite
+partition with strictly monotone partition points indexed by `Fin (n + 1)`. -/
+lemma exists_strictMono_Icc_subset_open_cover_unitInterval {ι} {c : ι → Set I}
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : univ ⊆ ⋃ i, c i) :
+    ∃ (n : ℕ) (t : Fin (n + 1) → I),
+      StrictMono t ∧ t 0 = 0 ∧ t (Fin.last n) = 1 ∧
+      ∀ i : Fin n, ∃ j : ι, Icc (t i.castSucc) (t i.succ) ⊆ c j := by
+  obtain ⟨n, t, ht_strict, ht0, htn, ht_cover⟩ :=
+    exists_strictMono_Icc_subset_open_cover_Icc zero_le_one hc₁ hc₂
+  refine ⟨n, t, ht_strict, ?_, ?_, ht_cover⟩
+  · ext; exact ht0
+  · ext; exact htn
 
 end partition
 


### PR DESCRIPTION
This PR adds `Fin (n+1)`-indexed partition lemmas for open covers of intervals, and uses them to provide Lebesgue-partition theorems for paths.

**In `Mathlib/Topology/UnitInterval.lean`:**
- `exists_monotone_partition_Icc`: any open cover of a closed interval `[a, b]` can be refined to a monotone partition indexed by `Fin (n + 1)`.
- `exists_monotone_partition_unitInterval`: the unit interval version.

Both are thin wrappers around the existing `exists_monotone_Icc_subset_open_cover_*` lemmas, repackaging the output from `ℕ → Icc a b` (eventually-constant) to `Fin (n + 1) → Icc a b`.

**In `Mathlib/Topology/Path.lean`:**
- `Path.exists_partition_in_cover`: Lebesgue partition for paths — any open cover of a path's range can be refined to a finite partition.
- `Path.exists_partition_with_property`: neighborhood version — if every point on a path has a neighborhood with property `P`, get a partition with each segment in such a neighborhood.

Split out from #31576 to allow independent review.

🤖 Prepared with Claude Code