### PR TITLE
[Merged by Bors] - feat: bounded variation functions have left and right limits, and limits at infinity

### DIFF
--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -9,6 +9,7 @@ public import Mathlib.Order.Interval.Set.ProjIcc
 public import Mathlib.Tactic.Finiteness
 public import Mathlib.Topology.UniformSpace.UniformConvergenceTopology
 public import Mathlib.Topology.Instances.ENNReal.Lemmas
+public import Mathlib.Topology.Order.LeftRightLim
 public import Mathlib.Topology.Semicontinuity.Defs
 
 /-!
@@ -47,8 +48,8 @@ that the sets one uses are nonempty and bounded above as these are only conditio
 @[expose] public section
 
 
-open scoped NNReal ENNReal Topology UniformConvergence
-open Set Filter
+open scoped NNReal ENNReal Topology UniformConvergence Topology
+open Set Filter OrderDual
 
 variable {α : Type*} [LinearOrder α] {E : Type*} [PseudoEMetricSpace E]
 
@@ -88,11 +89,11 @@ theorem eq_of_eqOn {f f' : α → E} {s : Set α} (h : EqOn f f' s) :
     eVariationOn f s = eVariationOn f' s :=
   eq_of_edist_zero_on fun x xs => by rw [h xs, edist_self]
 
-theorem sum_le (f : α → E) {s : Set α} (n : ℕ) {u : ℕ → α} (hu : Monotone u) (us : ∀ i, u i ∈ s) :
+theorem sum_le {f : α → E} {s : Set α} {n : ℕ} {u : ℕ → α} (hu : Monotone u) (us : ∀ i, u i ∈ s) :
     (∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))) ≤ eVariationOn f s :=
   le_iSup_of_le ⟨n, u, hu, us⟩ le_rfl
 
-theorem sum_le_of_monotoneOn_Icc (f : α → E) {s : Set α} {m n : ℕ} {u : ℕ → α}
+theorem sum_le_of_monotoneOn_Icc {f : α → E} {s : Set α} {m n : ℕ} {u : ℕ → α}
     (hu : MonotoneOn u (Icc m n)) (us : ∀ i ∈ Icc m n, u i ∈ s) :
     (∑ i ∈ Finset.Ico m n, edist (f (u (i + 1))) (f (u i))) ≤ eVariationOn f s := by
   rcases le_total n m with hnm | hmn
@@ -109,17 +110,53 @@ theorem sum_le_of_monotoneOn_Icc (f : α → E) {s : Set α} {m n : ℕ} {u : �
     _ ≤ ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) :=
       Finset.sum_mono_set _ (Nat.Iio_eq_range ▸ Finset.Ico_subset_Iio_self)
     _ ≤ eVariationOn f s :=
-      sum_le _ _ (fun i j h ↦ hu (π i).2 (π j).2 (monotone_projIcc hmn h)) fun i ↦ us _ (π i).2
+      sum_le (fun i j h ↦ hu (π i).2 (π j).2 (monotone_projIcc hmn h)) fun i ↦ us _ (π i).2
 
-theorem sum_le_of_monotoneOn_Iic (f : α → E) {s : Set α} {n : ℕ} {u : ℕ → α}
+theorem sum_le_of_monotoneOn_Iic {f : α → E} {s : Set α} {n : ℕ} {u : ℕ → α}
     (hu : MonotoneOn u (Iic n)) (us : ∀ i ≤ n, u i ∈ s) :
     (∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))) ≤ eVariationOn f s := by
-  simpa using sum_le_of_monotoneOn_Icc f (m := 0) (hu.mono Icc_subset_Iic_self) fun i hi ↦ us i hi.2
+  simpa using sum_le_of_monotoneOn_Icc (m := 0) (hu.mono Icc_subset_Iic_self) fun i hi ↦ us i hi.2
+
+/-- The variation can be expressed using strictly monotone functions. This formulation is
+often less convenient than the one with monotone functions as it involves dependent types, but
+it is sometimes handy. -/
+theorem eVariationOn_eq_strictMonoOn (f : α → E) (s : Set α) :
+    eVariationOn f s =
+      ⨆ p : (n : ℕ) × { u : ℕ → α // StrictMonoOn u (Iic n) ∧ ∀ i ∈ Iic n, u i ∈ s },
+        ∑ i ∈ Finset.range p.1, edist (f (p.2.1 (i + 1))) (f (p.2.1 i)) := by
+  apply le_antisymm
+  · apply iSup_le
+    rintro ⟨n, u, u_mono, u_mem⟩
+    have : ∃ p : (n : ℕ) × { u : ℕ → α // StrictMonoOn u (Iic n) ∧ ∀ i ∈ Iic n, u i ∈ s },
+        (p.2 : ℕ → α) p.1 = u n ∧
+        ∑ x ∈ Finset.range n, edist (f (u (x + 1))) (f (u x)) =
+        ∑ i ∈ Finset.range p.1, edist (f ((p.2 : ℕ → α) (i + 1))) (f ((p.2 : ℕ → α) i)) := by
+      induction n with
+      | zero => exact ⟨⟨0, ⟨u, by grind [StrictMonoOn], fun i hi ↦ u_mem _⟩⟩, by simp⟩
+      | succ n ih =>
+        rcases ih with ⟨⟨m, v, v_mono, v_mem⟩, hv, h'v⟩
+        simp only [Finset.sum_range_succ, Sigma.exists, Subtype.exists, mem_Iic, exists_and_left,
+          exists_prop]
+        rcases (u_mono (Nat.le_add_right n 1)).eq_or_lt with hn | hn
+        · simp only [← hn, edist_self, add_zero]
+          exact ⟨m, v, hv, ⟨v_mono, v_mem⟩, h'v⟩
+        · refine ⟨m + 1, fun i ↦ if i ≤ m then v i else u (n + 1), by simp,
+            by grind [StrictMonoOn], ?_⟩
+          simp only [h'v, ← hv, Order.add_one_le_iff, Finset.sum_range_succ, lt_self_iff_false,
+            ↓reduceIte, le_refl]
+          congr 1
+          exact Finset.sum_congr rfl (by grind)
+    rcases this with ⟨p, -, hp⟩
+    rw [hp]
+    apply le_iSup _ p
+  · apply iSup_le
+    rintro ⟨n, u, u_mono, u_mem⟩
+    apply sum_le_of_monotoneOn_Iic (by grind [MonotoneOn, StrictMonoOn]) (by grind)
 
 theorem mono (f : α → E) {s t : Set α} (hst : t ⊆ s) : eVariationOn f t ≤ eVariationOn f s := by
   apply iSup_le _
   rintro ⟨n, ⟨u, hu, ut⟩⟩
-  exact sum_le f n hu fun i => hst (ut i)
+  exact sum_le hu fun i => hst (ut i)
 
 theorem _root_.BoundedVariationOn.mono {f : α → E} {s : Set α} (h : BoundedVariationOn f s)
     {t : Set α} (ht : t ⊆ s) : BoundedVariationOn f t :=
@@ -141,7 +178,7 @@ theorem edist_le (f : α → E) {s : Set α} {x y : α} (hx : x ∈ s) (hy : y �
   have us : ∀ i, u i ∈ s := fun
   | 0 => hy
   | (_ + 1) => hx
-  simpa only [Finset.sum_range_one] using sum_le f 1 hu us
+  simpa only [Finset.sum_range_one] using sum_le (n := 1) hu us
 
 theorem eq_zero_iff (f : α → E) {s : Set α} :
     eVariationOn f s = 0 ↔ ∀ x ∈ s, ∀ y ∈ s, edist (f x) (f y) = 0 := by
@@ -177,7 +214,7 @@ theorem lowerSemicontinuous_aux {ι : Type*} {F : ι → α → E} {p : Filter �
       (𝓝 (∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i)))) := by
     apply tendsto_finset_sum
     exact fun i _ => Tendsto.edist (Ffs (u i.succ) (us i.succ)) (Ffs (u i) (us i))
-  exact (this.eventually_const_lt hlt).mono fun i h => h.trans_le (sum_le (F i) n um us)
+  exact (this.eventually_const_lt hlt).mono fun i h => h.trans_le (sum_le um us)
 
 /-- The map `(eVariationOn · s)` is lower semicontinuous for pointwise convergence *on `s`*.
 Pointwise convergence on `s` is encoded here as uniform convergence on the family consisting of the
@@ -323,7 +360,7 @@ theorem add_le_union (f : α → E) {s t : Set α} (h : ∀ x ∈ s, ∀ y ∈ t
       rw [← Finset.sum_union]
       · gcongr; grind
       · exact Finset.disjoint_left.2 (by grind)
-    _ ≤ eVariationOn f (s ∪ t) := sum_le f _ (by grind [Monotone]) (by grind)
+    _ ≤ eVariationOn f (s ∪ t) := sum_le (by grind [Monotone]) (by grind)
 
 /-- If a set `s` is to the left of a set `t`, and both contain the boundary point `x`, then
 the variation of `f` along `s ∪ t` is the sum of the variations. -/
@@ -348,7 +385,7 @@ theorem union (f : α → E) {s t : Set α} {x : α} (hs : IsGreatest s x) (ht :
       rw [Finset.range_eq_Ico, Finset.sum_Ico_consecutive _ (zero_le _) hN.le]
     _ ≤ eVariationOn f s + eVariationOn f t := by
       refine add_le_add ?_ ?_
-      · apply sum_le_of_monotoneOn_Icc _ (hv.monotoneOn _) fun i hi => ?_
+      · apply sum_le_of_monotoneOn_Icc (hv.monotoneOn _) fun i hi => ?_
         rcases vst i with (h | h); · exact h
         have : v i = x := by
           apply le_antisymm
@@ -356,7 +393,7 @@ theorem union (f : α → E) {s t : Set α} {x : α} (hs : IsGreatest s x) (ht :
           · exact ht.2 h
         rw [this]
         exact hs.1
-      · apply sum_le_of_monotoneOn_Icc _ (hv.monotoneOn _) fun i hi => ?_
+      · apply sum_le_of_monotoneOn_Icc (hv.monotoneOn _) fun i hi => ?_
         rcases vst i with (h | h); swap; · exact h
         have : v i = x := by
           apply le_antisymm
@@ -396,6 +433,423 @@ theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
   · simp only [right_eq_inter]
     gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
+
+private lemma eVariation_le_ofDual (f : α → E) (s : Set α) :
+    eVariationOn f s ≤ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by
+  apply iSup_le
+  rintro ⟨n, u, u_mono, u_mem⟩
+  let v (i : ℕ) := toDual (u (n - i))
+  have M : Monotone v := by
+    simp only [Monotone, toDual_le_toDual, v] at u_mono ⊢
+    grind
+  calc ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))
+  _ = ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) := by
+    simp only [toDual, v]
+    rw [← Finset.sum_range_reflect]
+    grind [Finset.sum_congr, edist_comm]
+  _ ≤ _ := sum_le M (fun i ↦ u_mem _)
+
+@[simp] lemma eVariationOn_ofDual (f : α → E) (s : Set α) :
+    eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) = eVariationOn f s :=
+  le_antisymm (eVariation_le_ofDual _ _) (eVariation_le_ofDual _ _)
+
+lemma _root_.BoundedVariationOn.ofDual {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+    BoundedVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by
+  simpa [BoundedVariationOn] using hf
+
+@[simp] lemma boundedVariation_ofDual {f : α → E} {s : Set α} :
+    BoundedVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ BoundedVariationOn f s :=
+  ⟨fun h ↦ h.ofDual, fun h ↦ h.ofDual⟩
+
+/-- If a function is continuous on the left at a point `a`, then its variations on `Iio a` and
+on `Iic a` coincide. We give a version relative to a set `s`. -/
+lemma eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt
+    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
+    (h : (𝓝[s ∩ Iio a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Iic a) a) :
+    eVariationOn f (s ∩ Iio a) = eVariationOn f (s ∩ Iic a) := by
+  apply le_antisymm (eVariationOn.mono _ (by grind))
+  rw [eVariationOn_eq_strictMonoOn]
+  apply iSup_le
+  rintro ⟨n, u, u_mono, u_mem⟩
+  have : u n ≤ a := (u_mem n (by simp)).2
+  rcases this.eq_or_lt with hn | hn; swap
+  · exact sum_le_of_monotoneOn_Iic u_mono.monotoneOn (by grind [StrictMonoOn])
+  cases n with
+  | zero => simp
+  | succ n =>
+    simp only [Finset.range_add_one, Finset.mem_range, lt_self_iff_false, not_false_eq_true,
+      Finset.sum_insert, ge_iff_le]
+    have : Tendsto (fun b ↦ edist (f b) (f (u n))
+        + ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))) (𝓝[s ∩ Iio a] a)
+      (𝓝 (edist (f (u (n + 1))) (f (u n))
+        + ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i)))) := by
+      apply Tendsto.add_const
+      apply Tendsto.edist _ tendsto_const_nhds
+      rw [hn]
+      apply h'.tendsto.mono_left
+      exact nhdsWithin_mono _ (by grind)
+    apply le_of_tendsto this
+    have : s ∩ Ioo (u n) (u (n + 1)) ∈ 𝓝[s ∩ Iio a] a := by
+      rw [hn]
+      apply inter_mem_nhdsWithin_inter self_mem_nhdsWithin
+      exact Ioo_mem_nhdsLT (by grind [StrictMonoOn])
+    filter_upwards [this] with b hb
+    let v i := if i ≤ n then u i else b
+    calc edist (f b) (f (u n)) + ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))
+    _ = ∑ i ∈ Finset.range (n + 1), edist (f (v (i + 1))) (f (v i)) := by
+      simp only [Finset.range_add_one, Finset.mem_range, lt_self_iff_false, not_false_eq_true,
+        Finset.sum_insert]
+      congr 1 <;> grind [Finset.sum_congr]
+    _ ≤ eVariationOn f (s ∩ Iio a) :=
+      sum_le_of_monotoneOn_Iic (by grind [MonotoneOn, StrictMonoOn]) (by grind [StrictMonoOn])
+
+/-- If a function is continuous on the right at a point `a`, then its variations on `Ioi a` and
+on `Ioc a` coincide. We give a version relative to a set `s`. -/
+lemma eVariationOn_inter_Ioi_eq_inter_Ici_of_continuousWithinAt
+    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
+    (h : (𝓝[s ∩ Ioi a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Ici a) a) :
+    eVariationOn f (s ∩ Ioi a) = eVariationOn f (s ∩ Ici a) := by
+  rw [← eVariationOn_ofDual f, ← eVariationOn_ofDual f]
+  exact eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt h h'
+
+lemma exists_lt_eVariationOn_inter_Icc {f : α → E} {ε : ℝ≥0∞} {s : Set α}
+    (h : ε < eVariationOn f s) : ∃ a ∈ s, ∃ b ∈ s, a < b ∧ ε < eVariationOn f (s ∩ Icc a b) := by
+  obtain ⟨n, u, ⟨u_mono, u_mem⟩, hu⟩ : ∃ n u, (Monotone u ∧ ∀ (i : ℕ), u i ∈ s) ∧
+      ε < ∑ x ∈ Finset.range n, edist (f (u (x + 1))) (f (u x)) := by
+    simpa [eVariationOn, lt_iSup_iff] using h
+  have A : ε < eVariationOn f (s ∩ Icc (u 0) (u n)) := by
+    apply hu.trans_le
+    simp only [Monotone] at u_mono
+    let v (i : ℕ) := min (u i) (u n)
+    calc ∑ x ∈ Finset.range n, edist (f (u (x + 1))) (f (u x))
+    _ = ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) := by grind [Finset.sum_congr]
+    _ ≤ eVariationOn f (s ∩ Icc (u 0) (u n)) :=
+      sum_le_of_monotoneOn_Iic (by grind [MonotoneOn]) (by grind)
+  refine ⟨u 0, u_mem _, u n, u_mem _, ?_, A⟩
+  by_contra!
+  have : Set.Subsingleton (s ∩ Icc (u 0) (u n)) := by
+    intro a ha b hb
+    simp only [mem_inter_iff, mem_Icc] at ha hb
+    order
+  simp [this] at A
+
+/-- If a function has bounded variation, then the variation on small closed-open
+intervals to the left of any point tends to `0`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
+    [TopologicalSpace α] [OrderTopology α]
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ico y x)) (𝓝[s] x) (𝓝 0) := by
+  /- The variation is monotone, therefore it converges. If the limit were positive, say `ε`,
+  then one would get variation `ε` between two points `x₀` and `x₁`. But also between two points
+  `x₁` and `x₂`, and so on. Adding up these variations would be arbitrarily large, contradicting
+  the finite variation of the function. -/
+  apply tendsto_order.2 ⟨by simp, fun ε εpos ↦ ?_⟩
+  obtain ⟨δ, δpos, hδ⟩ : ∃ δ, δ ∈ Ioo 0 ε := exists_between εpos
+  by_contra! H
+  have I {y} (hy : ε ≤ eVariationOn f (s ∩ Ico y x)) : y < x := by
+    contrapose! hy
+    have : Ico y x = ∅ := by grind
+    simpa [this] using εpos
+  have A (y) (hy : y ∈ s ∩ Iio x) : ∃ y', ε ≤ eVariationOn f (s ∩ Ico y' x) ∧ y' ∈ s ∩ Ioo y x := by
+    have : s ∩ Ioi y ∈ 𝓝[s] x := inter_mem_nhdsWithin _ (Ioi_mem_nhds hy.2)
+    obtain ⟨y', hy', h'y'⟩ : ∃ y', ε ≤ eVariationOn f (s ∩ Ico y' x) ∧ y' ∈ s ∩ Ioi y :=
+      (H.and_eventually this).exists
+    exact ⟨y', hy', h'y'.1, h'y'.2, I hy'⟩
+  have B (y) (hy : y ∈ s ∩ Iio x) : ∃ y' ∈ s ∩ Ioo y x, δ ≤ eVariationOn f (s ∩ Icc y y') := by
+    rcases A y hy with ⟨y', hy', y'_mem⟩
+    have : δ < eVariationOn f (s ∩ Ico y' x) := lt_of_lt_of_le hδ hy'
+    obtain ⟨a, ha, b, hb, hab, h⟩ : ∃ a ∈ s ∩ Ico y' x, ∃ b ∈ s ∩ Ico y' x, a < b ∧
+      δ < eVariationOn f ((s ∩ Ico y' x) ∩ Icc a b) := exists_lt_eVariationOn_inter_Icc this
+    refine ⟨b, ⟨hb.1, y'_mem.2.1.trans_le hb.2.1, hb.2.2⟩, h.le.trans (mono _ (by grind))⟩
+  choose! y y_mem le_y using B
+  obtain ⟨u, le_u, hu⟩ : ∃ u, ε ≤ eVariationOn f (s ∩ Ico u x) ∧ u ∈ s :=
+    (H.and_eventually self_mem_nhdsWithin).exists
+  let v (n : ℕ) := y^[n] u
+  have I n : v n ∈ s ∩ Iio x := by
+    induction n with
+    | zero => simpa [v] using ⟨hu, I le_u⟩
+    | succ n ih =>
+      simp only [Function.iterate_succ', Function.comp_apply, v]
+      have : s ∩ Ioo (y^[n] u) x ⊆ s ∩ Iio x := by grind
+      exact this (y_mem _ ih)
+  have J (n : ℕ) : n * δ ≤ eVariationOn f s := calc
+    n * δ
+    _ = ∑ i ∈ Finset.range n, δ := by simp
+    _ ≤ ∑ i ∈ Finset.range n, eVariationOn f (s ∩ Icc (v i) (v (i + 1))) := by
+      gcongr with i hi
+      simp only [Function.iterate_succ', Function.comp_apply, v]
+      grind
+    _ = eVariationOn f (s ∩ Icc (v 0) (v n)) := by
+      apply eVariationOn.sum
+      · apply monotone_nat_of_le_succ (fun n ↦ ?_)
+        simp only [Function.iterate_succ', Function.comp_apply, v]
+        exact (y_mem _ (I n)).2.1.le
+      · grind
+    _ ≤ eVariationOn f s := mono _ inter_subset_left
+  have : Tendsto (fun (n : ℕ) ↦ n * δ) atTop (𝓝 (∞ * δ)) :=
+    ENNReal.Tendsto.mul_const ENNReal.tendsto_nat_nhds_top (by simp)
+  rw [ENNReal.top_mul δpos.ne'] at this
+  have : ∞ ≤ eVariationOn f s := le_of_tendsto this (Eventually.of_forall J)
+  simp only [BoundedVariationOn] at hf
+  order
+
+/-- If a function has bounded variation, then the variation on small open-closed
+intervals to the right of any point tends to `0`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ioc_zero [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ioc x y)) (𝓝[s] x) (𝓝 0) := by
+  have : (fun y ↦ eVariationOn f (s ∩ Ioc x y)) =
+      (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Ico (toDual y) (toDual x))) := by
+    ext y
+    rw [Ico_toDual, ← preimage_inter, eVariationOn_ofDual]
+  rw [this]
+  exact hf.ofDual.tendsto_eVariationOn_Ico_zero (toDual x)
+
+/-- If a function has bounded variation and is left-continuous at a point, then the variation on
+small closed intervals to the left of this point tends to `0`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_left
+    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α}
+    (hf : BoundedVariationOn f s) {x : α} (h : ContinuousWithinAt f (s ∩ Iic x) x) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Icc y x)) (𝓝[s] x) (𝓝 0) := by
+  rcases eq_or_neBot (𝓝[s ∩ Iio x] x) with h' | h'
+  · apply tendsto_const_nhds.congr'
+    have : s = (s ∩ Iio x) ∪ (s ∩ Ici x) := by grind
+    nth_rewrite 1 [this]
+    simp only [nhdsWithin_union, h', bot_le, sup_of_le_right]
+    filter_upwards [self_mem_nhdsWithin] with y hy
+    apply (eVariationOn.subsingleton _ (by grind [Set.Subsingleton])).symm
+  apply (hf.tendsto_eVariationOn_Ico_zero x).congr (fun y ↦ ?_)
+  rcases le_or_gt x y with hy | hy
+  · rw [eVariationOn.subsingleton, eVariationOn.subsingleton] <;>
+      grind [Set.Subsingleton]
+  have W := eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt (f := f)
+    (s := s ∩ Icc y x) (a := x) ?_ ?_
+  · convert W using 2 <;> grind
+  · rwa [show s ∩ Icc y x ∩ Iio x = (s ∩ Iio x) ∩ Ici y by grind, nhdsWithin_inter_of_mem']
+    apply mem_nhdsWithin_of_mem_nhds
+    exact Ici_mem_nhds hy
+  · apply h.mono (by grind)
+
+/-- If a function has bounded variation and is right-continuous at a point, then the variation on
+small closed intervals to the right of this point tends to `0`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
+    [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α}
+    (hf : BoundedVariationOn f s) (x : α) (h : ContinuousWithinAt f (s ∩ Ici x) x) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Icc x y)) (𝓝[s] x) (𝓝 0) := by
+  have : (fun y ↦ eVariationOn f (s ∩ Icc x y)) =
+      (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Icc (toDual y) (toDual x))) := by
+    ext y
+    rw [Icc_toDual, ← preimage_inter, eVariationOn_ofDual]
+  rw [this]
+  exact hf.ofDual.tendsto_eVariationOn_Icc_zero_left h
+
+/-- A bounded variation function has a limit on its right within a set. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_right [CompleteSpace E] [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    ∃ l, Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l) := by
+  rcases Filter.eq_or_neBot (𝓝[s ∩ Ioi x] x) with h | h
+  · simp only [h, tendsto_bot, exists_const_iff, and_true]
+    exact ⟨f x⟩
+  apply CompleteSpace.complete
+  apply EMetric.cauchy_iff.2 ⟨by simp [neBot_iff.mp h], fun ε εpos ↦ ?_⟩
+  obtain ⟨y, hy, y_mem⟩ : ∃ y, eVariationOn f (s ∩ Ioc x y) < ε ∧ y ∈ s ∩ Ioi x := by
+    have := (hf.tendsto_eVariationOn_Ioc_zero x).mono_left
+      (nhdsWithin_mono (s := s ∩ Ioi x) _ inter_subset_left)
+    exact (((tendsto_order.1 this).2 ε εpos).and self_mem_nhdsWithin).exists
+  refine ⟨f '' (s ∩ Ioc x y), ?_, ?_⟩
+  · simp only [mem_map]
+    apply mem_of_superset ?_ (subset_preimage_image _ _)
+    exact inter_mem_nhdsWithin_inter self_mem_nhdsWithin (Ioc_mem_nhdsGT y_mem.2)
+  · rintro - ⟨a, ha, rfl⟩ - ⟨b, hb, rfl⟩
+    exact (eVariationOn.edist_le _ ha hb).trans_lt hy
+
+/-- A bounded variation function has a limit on its left within a set. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    ∃ l, Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l) :=
+  hf.ofDual.exists_tendsto_right (toDual x)
+
+/-- A bounded variation function tends to its left-limit on its left. -/
+theorem _root_.BoundedVariationOn.tendsto_leftLim [CompleteSpace E] [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} (hf : BoundedVariationOn f univ) (x : α) :
+    Tendsto f (𝓝[<] x) (𝓝 (f.leftLim x)) := by
+  apply tendsto_leftLim_of_tendsto
+  convert hf.exists_tendsto_left x
+  simp
+
+/-- A bounded variation function tends to its right-limit on its right. -/
+theorem _root_.BoundedVariationOn.tendsto_rightLim [CompleteSpace E] [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} (hf : BoundedVariationOn f univ) (x : α) :
+    Tendsto f (𝓝[>] x) (𝓝 (f.rightLim x)) :=
+  hf.ofDual.tendsto_leftLim x
+
+/-- If a function `g` is at each point `x` a limit of `f` to the left or to the right (or more
+generally a cluster point of the values of `f` around `x`) then the variation of `g` is bounded
+by that of `f`. -/
+lemma eVariationOn_le_of_mapClusterPt [TopologicalSpace α] [OrderTopology α] {f g : α → E}
+    {s : Set α} (hg : ∀ x, MapClusterPt (g x) (𝓝[s] x) f) :
+    eVariationOn g s ≤ eVariationOn f s := by
+  rw [eVariationOn_eq_strictMonoOn]
+  apply iSup_le
+  rintro ⟨n, u, u_mono, u_mem⟩
+  simp only
+  apply le_of_forall_lt (fun c hc ↦ ?_)
+  have : ∀ᶠ (b : ℕ → E) in 𝓝 (fun i ↦ g (u i)),
+      c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i) := by
+    have : Continuous (fun (v : ℕ → E) ↦ ∑ i ∈ Finset.range n, edist (v (i + 1)) (v i)) := by
+      fun_prop
+    exact (tendsto_order.1 (this.continuousAt (x := fun i ↦ g (u i))).tendsto).1 c hc
+  rw [nhds_pi] at this
+  obtain ⟨I, I_fin, t, t_mem, ht⟩ : ∃ (I : Set ℕ), I.Finite ∧ ∃ t, (∀ (i : ℕ), t i ∈ 𝓝 (g (u i))) ∧
+      I.pi t ⊆ {b : ℕ → E | c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i)} := mem_pi.1 this
+  have : ∀ᶠ b in 𝓝 u, ∀ i ∈ ((Finset.Iic n) ×ˢ (Finset.Iic n)).filter
+      (fun i ↦ i.1 < i.2), b i.1 < b i.2 := by
+    rw [Filter.eventually_all_finset]
+    intro i hi
+    apply IsOpen.mem_nhds ?_ (by grind [StrictMonoOn])
+    exact isOpen_lt (by fun_prop) (by fun_prop)
+  rw [nhds_pi] at this
+  obtain ⟨J, J_fin, k, k_mem, hk⟩ : ∃ (J : Set ℕ), J.Finite ∧ ∃ k, (∀ (i : ℕ), k i ∈ 𝓝 (u i)) ∧
+    J.pi k ⊆ _ := mem_pi.1 this
+  have A i : ∃ x, (f x ∈ t i ∧ x ∈ k i) ∧ x ∈ s :=
+    ((((mapClusterPt_iff_frequently.1 (hg (u i)) (t i) (t_mem i))).and_eventually
+      (mem_nhdsWithin_of_mem_nhds (k_mem i))).and_eventually self_mem_nhdsWithin).exists
+  choose v hv h'v using A
+  have : c < ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) := by
+    suffices H : f ∘ v ∈ I.pi t from ht H
+    grind
+  apply this.trans_le
+  have v_mono : StrictMonoOn v (Iic n) := by
+    suffices v ∈ J.pi k by
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_Iic, and_imp, Prod.forall] at hk
+      have W := hk this
+      grind [StrictMonoOn]
+    grind
+  exact sum_le_of_monotoneOn_Iic v_mono.monotoneOn (by grind)
+
+lemma eVariationOn_leftLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E} :
+    eVariationOn f.leftLim univ ≤ eVariationOn f univ := by
+  apply eVariationOn_le_of_mapClusterPt (fun x ↦ ?_)
+  apply (mapClusterPt_leftLim f x).mono (nhdsWithin_mono _ (subset_univ _))
+
+lemma eVariationOn_rightLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E} :
+    eVariationOn f.rightLim univ ≤ eVariationOn f univ := by
+  apply eVariationOn_le_of_mapClusterPt (fun x ↦ ?_)
+  apply (mapClusterPt_rightLim f x).mono (nhdsWithin_mono _ (subset_univ _))
+
+lemma _root_.BoundedVariationOn.leftLim [TopologicalSpace α] [OrderTopology α] {f : α → E}
+    (hf : BoundedVariationOn f univ) : BoundedVariationOn f.leftLim univ :=
+  (eVariationOn_leftLim_le.trans_lt hf.lt_top).ne
+
+lemma _root_.BoundedVariationOn.rightLim [TopologicalSpace α] [OrderTopology α] {f : α → E}
+    (hf : BoundedVariationOn f univ) : BoundedVariationOn f.rightLim univ :=
+  (eVariationOn_rightLim_le.trans_lt hf.lt_top).ne
+
+lemma _root_.BoundedVariationOn.continuousWithinAt_leftLim [TopologicalSpace α] [OrderTopology α]
+    [CompleteSpace E] [T3Space E] {f : α → E} (hf : BoundedVariationOn f univ) {x : α} :
+    ContinuousWithinAt f.leftLim (Iic x) x := by
+  have : Tendsto f.leftLim (𝓝[<] x) (𝓝 (f.leftLim.leftLim x)) := hf.leftLim.tendsto_leftLim x
+  rw [leftLim_leftLim (hf.tendsto_leftLim x)] at this
+  exact continuousWithinAt_Iio_iff_Iic.1 this
+
+lemma _root_.BoundedVariationOn.continuousWithinAt_rightLim [TopologicalSpace α] [OrderTopology α]
+    [CompleteSpace E] [T3Space E] {f : α → E} (hf : BoundedVariationOn f univ) {x : α} :
+    ContinuousWithinAt f.rightLim (Ici x) x :=
+  BoundedVariationOn.continuousWithinAt_leftLim hf.ofDual
+
+/-- If a function has bounded variation, then the variation on closed semi-infinite
+intervals tends to `0` at `+∞`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ici_zero
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ici y)) (𝓟 s ⊓ atTop) (𝓝 0) := by
+  /- The variation is monotone, therefore it converges. If the limit were positive, say `ε`,
+  then one would get variation `ε` between two points `x₀` and `x₁`. But also between two points
+  `x₁` and `x₂`, and so on. Adding up these variations would be arbitrarily large, contradicting
+  the finite variation of the function. -/
+  rcases isEmpty_or_nonempty α with hα | hα
+  · simp only [inf_bot_eq, tendsto_bot, filter_eq_bot_of_isEmpty atTop]
+  apply tendsto_order.2 ⟨by simp, fun ε εpos ↦ ?_⟩
+  obtain ⟨δ, δpos, hδ⟩ : ∃ δ, δ ∈ Ioo 0 ε := exists_between εpos
+  by_contra! H
+  have A (y) : ∃ y', ε ≤ eVariationOn f (s ∩ Ici y') ∧ y' ∈ s ∩ Ici y := by
+    have : s ∩ Ici y ∈ 𝓟 s ⊓ atTop := inter_mem_inf (by simp) (Ici_mem_atTop _)
+    exact (H.and_eventually this).exists
+  have B (y) : ∃ y' ∈ s ∩ Ici y, δ ≤ eVariationOn f (s ∩ Icc y y') := by
+    rcases A y with ⟨y', hy', y'_mem⟩
+    have : δ < eVariationOn f (s ∩ Ici y') := lt_of_lt_of_le hδ hy'
+    obtain ⟨a, ha, b, hb, hab, h⟩ : ∃ a ∈ s ∩ Ici y', ∃ b ∈ s ∩ Ici y', a < b ∧
+      δ < eVariationOn f ((s ∩ Ici y') ∩ Icc a b) := exists_lt_eVariationOn_inter_Icc this
+    exact ⟨b, by grind, h.le.trans (mono _ (by grind))⟩
+  choose! y y_mem le_y using B
+  let v (n : ℕ) := y^[n + 1] hα.some
+  have J (n : ℕ) : n * δ ≤ eVariationOn f s := calc
+    n * δ
+    _ = ∑ i ∈ Finset.range n, δ := by simp
+    _ ≤ ∑ i ∈ Finset.range n, eVariationOn f (s ∩ Icc (v i) (v (i + 1))) := by
+      gcongr with i hi
+      simp only [Function.iterate_succ', Function.comp_apply, v]
+      grind
+    _ = eVariationOn f (s ∩ Icc (v 0) (v n)) := by
+      apply eVariationOn.sum
+      · apply monotone_nat_of_le_succ (fun n ↦ ?_)
+        simp only [Function.iterate_succ', Function.comp_apply, v]
+        exact (y_mem _).2
+      · intro i hi h'i
+        simpa only [Function.iterate_succ', Function.comp_apply, v] using (y_mem _).1
+    _ ≤ eVariationOn f s := mono _ inter_subset_left
+  have : Tendsto (fun (n : ℕ) ↦ n * δ) atTop (𝓝 (∞ * δ)) :=
+    ENNReal.Tendsto.mul_const ENNReal.tendsto_nat_nhds_top (by simp)
+  rw [ENNReal.top_mul δpos.ne'] at this
+  have : ∞ ≤ eVariationOn f s := le_of_tendsto this (Eventually.of_forall J)
+  simp only [BoundedVariationOn] at hf
+  order
+
+/-- If a function has bounded variation, then the variation on semi-infinite closed
+intervals tends to `0` at `-∞`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Iic_zero
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Iic y)) (𝓟 s ⊓ atBot) (𝓝 0) := by
+  have : (fun y ↦ eVariationOn f (s ∩ Iic y)) =
+      (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Ici (toDual y))) := by
+    ext y
+    rw [Ici_toDual, ← preimage_inter, eVariationOn_ofDual]
+  rw [this]
+  exact hf.ofDual.tendsto_eVariationOn_Ici_zero
+
+/-- A bounded variation function has a limit at `+∞`. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_atTop [CompleteSpace E] [hE : Nonempty E]
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+    ∃ l, Tendsto f (𝓟 s ⊓ atTop) (𝓝 l) := by
+  rcases Filter.eq_or_neBot (𝓟 s ⊓ atTop) with h | h
+  · simp only [h, tendsto_bot, exists_const_iff, and_true]
+    exact ⟨hE.some⟩
+  apply CompleteSpace.complete
+  apply EMetric.cauchy_iff.2 ⟨by simp [neBot_iff.mp h], fun ε εpos ↦ ?_⟩
+  obtain ⟨y, hy, y_mem⟩ : ∃ y, eVariationOn f (s ∩ Ici y) < ε ∧ y ∈ s := by
+    have : s ∈ 𝓟 s ⊓ atTop := mem_inf_of_left (by simp)
+    exact (((tendsto_order.1 hf.tendsto_eVariationOn_Ici_zero).2 ε εpos).and this).exists
+  refine ⟨f '' (s ∩ Ici y), ?_, ?_⟩
+  · simp only [mem_map]
+    apply mem_of_superset ?_ (subset_preimage_image _ _)
+    exact inter_mem_inf (by simp) (Ici_mem_atTop _)
+  · rintro - ⟨a, ha, rfl⟩ - ⟨b, hb, rfl⟩
+    exact (eVariationOn.edist_le _ ha hb).trans_lt hy
+
+/-- A bounded variation function has a limit at `-∞`. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_atBot [CompleteSpace E] [hE : Nonempty E]
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
+    ∃ l, Tendsto f (𝓟 s ⊓ atBot) (𝓝 l) :=
+  hf.ofDual.exists_tendsto_atTop
+
+theorem _root_.BoundedVariationOn.tendsto_atTop_limUnder [CompleteSpace E] [hE : Nonempty E]
+    {f : α → E} (hf : BoundedVariationOn f univ) :
+    Tendsto f atTop (𝓝 (limUnder atTop f)) :=
+  tendsto_nhds_limUnder (by simpa using hf.exists_tendsto_atTop)
+
+theorem _root_.BoundedVariationOn.tendsto_atBot_limUnder [CompleteSpace E] [hE : Nonempty E]
+    {f : α → E} (hf : BoundedVariationOn f univ) :
+    Tendsto f atBot (𝓝 (limUnder atBot f)) :=
+  tendsto_nhds_limUnder (by simpa using hf.exists_tendsto_atBot)
 
 section Monotone
 
@@ -536,6 +990,15 @@ protected theorem nonpos_of_ge {a b : α} (h : b ≤ a) : variationOnFromTo f s 
   rw [variationOnFromTo.eq_neg_swap]
   exact neg_nonpos_of_nonneg (variationOnFromTo.nonneg_of_le f s h)
 
+variable {f s} in
+theorem abs_le_eVariationOn (hf : BoundedVariationOn f s) {a b : α} :
+    |variationOnFromTo f s a b| ≤ (eVariationOn f s).toReal := by
+  by_cases hab : a ≤ b
+  · simp only [variationOnFromTo, hab, ↓reduceIte, ENNReal.abs_toReal]
+    exact ENNReal.toReal_mono hf (eVariationOn.mono _ inter_subset_left)
+  · simp only [variationOnFromTo, hab, ↓reduceIte, abs_neg, ENNReal.abs_toReal]
+    exact ENNReal.toReal_mono hf (eVariationOn.mono _ inter_subset_left)
+
 protected theorem eq_of_le {a b : α} (h : a ≤ b) :
     variationOnFromTo f s a b = (eVariationOn f (s ∩ Icc a b)).toReal :=
   if_pos h
@@ -638,6 +1101,30 @@ protected theorem comp_eq_of_monotoneOn {β : Type*} [LinearOrder β] (f : α �
   · rw [variationOnFromTo.eq_of_ge _ _ h, variationOnFromTo.eq_of_ge _ _ (hφ hy hx h),
       eVariationOn.comp_inter_Icc_eq_of_monotoneOn f φ hφ hy hx]
 
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_Ici
+    [TopologicalSpace α] [OrderTopology α] (hf : BoundedVariationOn f univ) {a x : α}
+    (hx : ContinuousWithinAt f (Ici x) x) :
+    ContinuousWithinAt (variationOnFromTo f univ a) (Ici x) x := by
+  have : variationOnFromTo f univ a =
+      fun y ↦ variationOnFromTo f univ a x + variationOnFromTo f univ x y := by
+    ext y
+    rw [variationOnFromTo.add hf.locallyBoundedVariationOn (mem_univ _) (mem_univ _) (mem_univ _)]
+  rw [this]
+  apply continuousWithinAt_const.add
+  suffices H : ContinuousWithinAt (fun y ↦ (eVariationOn f (univ ∩ Icc x y)).toReal) (Ici x) x from
+    H.congr_of_mem (fun y hy ↦ by grind [variationOnFromTo]) self_mem_Iic
+  simp only [ContinuousWithinAt, Icc_self]
+  rw [eVariationOn.subsingleton _ (by grind [Set.Subsingleton])]
+  apply (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp
+  apply Tendsto.mono_left _ (nhdsWithin_mono _ (subset_univ _))
+  exact hf.tendsto_eVariationOn_Icc_zero_right _ (by simpa using hx)
+
+theorem _root_.BoundedVariationOn.continuousWithinAt_variationOnFromTo_rightLim_Ici
+    [TopologicalSpace α] [OrderTopology α] [T3Space E] [CompleteSpace E]
+    (hf : BoundedVariationOn f univ) {a x : α} :
+    ContinuousWithinAt (variationOnFromTo f.rightLim univ a) (Ici x) x :=
+  hf.rightLim.continuousWithinAt_variationOnFromTo_Ici hf.continuousWithinAt_rightLim
+
 end variationOnFromTo
 
 /-- If a real-valued function has bounded variation on a set, then it is a difference of monotone
@@ -667,7 +1154,7 @@ theorem LipschitzOnWith.comp_eVariationOn_le {f : E → F} {C : ℝ≥0} {t : Se
         ∑ i ∈ Finset.range n, C * edist (g (u (i + 1))) (g (u i)) :=
       Finset.sum_le_sum fun i _ => h (hg (us _)) (hg (us _))
     _ = C * ∑ i ∈ Finset.range n, edist (g (u (i + 1))) (g (u i)) := by rw [Finset.mul_sum]
-    _ ≤ C * eVariationOn g s := by grw [eVariationOn.sum_le _ _ hu us]
+    _ ≤ C * eVariationOn g s := by grw [eVariationOn.sum_le hu us]
 
 theorem LipschitzOnWith.comp_boundedVariationOn {f : E → F} {C : ℝ≥0} {t : Set E}
     (hf : LipschitzOnWith C f t) {g : α → E} {s : Set α} (hg : MapsTo g s t)

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -48,7 +48,7 @@ that the sets one uses are nonempty and bounded above as these are only conditio
 @[expose] public section
 
 
-open scoped NNReal ENNReal Topology UniformConvergence Topology
+open scoped NNReal ENNReal Topology UniformConvergence
 open Set Filter OrderDual
 
 variable {α : Type*} [LinearOrder α] {E : Type*} [PseudoEMetricSpace E]

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -434,7 +434,7 @@ theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
     gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
 
-private lemma eVariation_le_ofDual (f : α → E) (s : Set α) :
+private lemma eVariationOn_le_ofDual (f : α → E) (s : Set α) :
     eVariationOn f s ≤ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by
   apply iSup_le
   rintro ⟨n, u, u_mono, u_mem⟩
@@ -451,7 +451,7 @@ private lemma eVariation_le_ofDual (f : α → E) (s : Set α) :
 
 @[simp] lemma eVariationOn_ofDual (f : α → E) (s : Set α) :
     eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) = eVariationOn f s :=
-  le_antisymm (eVariation_le_ofDual _ _) (eVariation_le_ofDual _ _)
+  le_antisymm (eVariationOn_le_ofDual _ _) (eVariationOn_le_ofDual _ _)
 
 lemma _root_.BoundedVariationOn.ofDual {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
     BoundedVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -533,12 +533,15 @@ lemma exists_lt_eVariationOn_inter_Icc {f : α → E} {ε : ℝ≥0∞} {s : Set
     order
   simp [this] at A
 
-/-- If a function has bounded variation, then the variation on small closed-open
-intervals to the left of any point tends to `0`. -/
-theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
-    [TopologicalSpace α] [OrderTopology α]
-    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
-    Tendsto (fun y ↦ eVariationOn f (s ∩ Ico y x)) (𝓝[s] x) (𝓝 0) := by
+/-- If a function has bounded variation, then the variation on closed semi-infinite intervals
+tends to `0`. We give a version with a generic filter, that applies both to left-neighborhoods of
+points and to `atTop`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ici_zero_of_filter
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s)
+    (L : Filter α) (hL : ∀ y ∈ s, s ∩ Ici y ∈ L) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ici y)) L (𝓝 0) := by
+  rcases eq_empty_or_nonempty s with rfl | ⟨x₀, hx₀⟩
+  · simpa using tendsto_const_nhds
   /- The variation is monotone, therefore it converges. If the limit were positive, say `ε`,
   then one would get variation `ε` between two points `x₀` and `x₁`. But also between two points
   `x₁` and `x₂`, and so on. Adding up these variations would be arbitrarily large, contradicting
@@ -546,32 +549,24 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
   apply tendsto_order.2 ⟨by simp, fun ε εpos ↦ ?_⟩
   obtain ⟨δ, δpos, hδ⟩ : ∃ δ, δ ∈ Ioo 0 ε := exists_between εpos
   by_contra! H
-  have I {y} (hy : ε ≤ eVariationOn f (s ∩ Ico y x)) : y < x := by
-    contrapose! hy
-    have : Ico y x = ∅ := by grind
-    simpa [this] using εpos
-  have A (y) (hy : y ∈ s ∩ Iio x) : ∃ y', ε ≤ eVariationOn f (s ∩ Ico y' x) ∧ y' ∈ s ∩ Ioo y x := by
-    have : s ∩ Ioi y ∈ 𝓝[s] x := inter_mem_nhdsWithin _ (Ioi_mem_nhds hy.2)
-    obtain ⟨y', hy', h'y'⟩ : ∃ y', ε ≤ eVariationOn f (s ∩ Ico y' x) ∧ y' ∈ s ∩ Ioi y :=
-      (H.and_eventually this).exists
-    exact ⟨y', hy', h'y'.1, h'y'.2, I hy'⟩
-  have B (y) (hy : y ∈ s ∩ Iio x) : ∃ y' ∈ s ∩ Ioo y x, δ ≤ eVariationOn f (s ∩ Icc y y') := by
-    rcases A y hy with ⟨y', hy', y'_mem⟩
-    have : δ < eVariationOn f (s ∩ Ico y' x) := lt_of_lt_of_le hδ hy'
-    obtain ⟨a, ha, b, hb, hab, h⟩ : ∃ a ∈ s ∩ Ico y' x, ∃ b ∈ s ∩ Ico y' x, a < b ∧
-      δ < eVariationOn f ((s ∩ Ico y' x) ∩ Icc a b) := exists_lt_eVariationOn_inter_Icc this
-    refine ⟨b, ⟨hb.1, y'_mem.2.1.trans_le hb.2.1, hb.2.2⟩, h.le.trans (mono _ (by grind))⟩
+  have B (y) (hy : y ∈ s) : ∃ y' ∈ s ∩ Ici y, δ ≤ eVariationOn f (s ∩ Icc y y') := by
+    obtain ⟨y', hy', y'_mem⟩ : ∃ y', ε ≤ eVariationOn f (s ∩ Ici y') ∧ y' ∈ s ∩ Ici y :=
+      (H.and_eventually (hL y hy)).exists
+    obtain ⟨a, ha, b, hb, hab, h⟩ : ∃ a ∈ s ∩ Ici y', ∃ b ∈ s ∩ Ici y', a < b ∧
+      δ < eVariationOn f ((s ∩ Ici y') ∩ Icc a b) :=
+        exists_lt_eVariationOn_inter_Icc (hδ.trans_le hy')
+    refine ⟨b, ⟨hb.1, le_trans y'_mem.2 hb.2⟩, ?_⟩
+    have : Ici y' ∩ Icc a b = Icc a b := by grind
+    rw [inter_assoc, this] at h
+    exact h.le.trans (mono _ (by grind))
   choose! y y_mem le_y using B
-  obtain ⟨u, le_u, hu⟩ : ∃ u, ε ≤ eVariationOn f (s ∩ Ico u x) ∧ u ∈ s :=
-    (H.and_eventually self_mem_nhdsWithin).exists
-  let v (n : ℕ) := y^[n] u
-  have I n : v n ∈ s ∩ Iio x := by
+  let v (n : ℕ) := y^[n] x₀
+  have I n : v n ∈ s := by
     induction n with
-    | zero => simpa [v] using ⟨hu, I le_u⟩
+    | zero => simpa [v] using hx₀
     | succ n ih =>
       simp only [Function.iterate_succ', Function.comp_apply, v]
-      have : s ∩ Ioo (y^[n] u) x ⊆ s ∩ Iio x := by grind
-      exact this (y_mem _ ih)
+      exact (y_mem _ ih).1
   have J (n : ℕ) : n * δ ≤ eVariationOn f s := calc
     n * δ
     _ = ∑ i ∈ Finset.range n, δ := by simp
@@ -583,7 +578,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
       apply eVariationOn.sum
       · apply monotone_nat_of_le_succ (fun n ↦ ?_)
         simp only [Function.iterate_succ', Function.comp_apply, v]
-        exact (y_mem _ (I n)).2.1.le
+        exact (y_mem _ (I n)).2
       · grind
     _ ≤ eVariationOn f s := mono _ inter_subset_left
   have : Tendsto (fun (n : ℕ) ↦ n * δ) atTop (𝓝 (∞ * δ)) :=
@@ -592,6 +587,45 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
   have : ∞ ≤ eVariationOn f s := le_of_tendsto this (Eventually.of_forall J)
   simp only [BoundedVariationOn] at hf
   order
+
+/-- A bounded variation function has a limit on its left within a set. Version with a general
+filter, covering both left neighborhoods of points and `atTop`. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_left_of_filter [CompleteSpace E]
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s)
+    (L : Filter α) (hL : ∀ y ∈ s, s ∩ Ici y ∈ L) (hs : s.Nonempty) :
+    ∃ l, Tendsto f L (𝓝 l) := by
+  rcases hs with ⟨x₀, hx₀⟩
+  rcases Filter.eq_or_neBot L with h | h
+  · simp only [h, tendsto_bot, exists_const_iff, and_true]
+    exact ⟨f x₀⟩
+  apply CompleteSpace.complete
+  apply EMetric.cauchy_iff.2 ⟨by simp [neBot_iff.mp h], fun ε εpos ↦ ?_⟩
+  obtain ⟨y, y_mem, hy⟩ : ∃ y ∈ s, eVariationOn f (s ∩ Ici y) < ε := by
+    have W := hf.tendsto_eVariationOn_Ici_zero_of_filter L hL
+    rcases (((tendsto_order.1 W).2 ε εpos).and (hL x₀ hx₀)).exists with ⟨y, hy, h'y⟩
+    exact ⟨y, h'y.1, hy⟩
+  refine ⟨f '' (s ∩ Ici y), ?_, ?_⟩
+  · simp only [mem_map]
+    apply mem_of_superset (hL y y_mem) (subset_preimage_image _ _)
+  · rintro - ⟨a, ha, rfl⟩ - ⟨b, hb, rfl⟩
+    exact (eVariationOn.edist_le _ ha hb).trans_lt hy
+
+/-- If a function has bounded variation, then the variation on small closed-open
+intervals to the left of any point tends to `0`. -/
+theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ico_zero
+    [TopologicalSpace α] [OrderTopology α]
+    {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ico y x)) (𝓝[s] x) (𝓝 0) := by
+  have A : Tendsto (fun y ↦ eVariationOn f (s ∩ Ico y x)) (𝓝[s ∩ Iio x] x) (𝓝 0) := by
+    simp_rw [← Iio_inter_Ici, ← inter_assoc]
+    exact (hf.mono inter_subset_left).tendsto_eVariationOn_Ici_zero_of_filter (𝓝[s ∩ Iio x] x)
+      (fun y hy ↦ inter_mem_nhdsWithin _ (Ici_mem_nhds hy.2))
+  have B : Tendsto (fun y ↦ eVariationOn f (s ∩ Ico y x)) (𝓝[s ∩ Ici x] x) (𝓝 0) := by
+    apply tendsto_const_nhds.congr'
+    filter_upwards [self_mem_nhdsWithin] with a ha using by simp [show Ico a x = ∅ by grind]
+  nth_rewrite 2 [show s = (s ∩ Iio x) ∪ (s ∩ Ici x) by grind]
+  rw [nhdsWithin_union, tendsto_sup]
+  simp [A, B]
 
 /-- If a function has bounded variation, then the variation on small open-closed
 intervals to the right of any point tends to `0`. -/
@@ -642,6 +676,16 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
     rw [Icc_toDual, ← preimage_inter, eVariationOn_ofDual]
   rw [this]
   exact hf.ofDual.tendsto_eVariationOn_Icc_zero_left h
+
+/-- A bounded variation function has a limit on its left within a set. -/
+theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [TopologicalSpace α]
+    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
+    ∃ l, Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l) := by
+  rcases eq_empty_or_nonempty (s ∩ Iio x) with hs | hs
+  · simp only [hs, nhdsWithin_empty, tendsto_bot, exists_const_iff, and_true]
+    exact ⟨f x⟩
+  exact BoundedVariationOn.exists_tendsto_left_of_filter (s := s ∩ Iio x)
+    (hf.mono inter_subset_left) _ (fun y hy ↦ inter_mem_nhdsWithin _ (Ici_mem_nhds hy.2)) hs
 
 /-- A bounded variation function has a limit on its right within a set. -/
 theorem _root_.BoundedVariationOn.exists_tendsto_right [CompleteSpace E] [TopologicalSpace α]
@@ -761,48 +805,9 @@ lemma _root_.BoundedVariationOn.continuousWithinAt_rightLim [TopologicalSpace α
 intervals tends to `0` at `+∞`. -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ici_zero
     {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
-    Tendsto (fun y ↦ eVariationOn f (s ∩ Ici y)) (𝓟 s ⊓ atTop) (𝓝 0) := by
-  /- The variation is monotone, therefore it converges. If the limit were positive, say `ε`,
-  then one would get variation `ε` between two points `x₀` and `x₁`. But also between two points
-  `x₁` and `x₂`, and so on. Adding up these variations would be arbitrarily large, contradicting
-  the finite variation of the function. -/
-  rcases isEmpty_or_nonempty α with hα | hα
-  · simp only [inf_bot_eq, tendsto_bot, filter_eq_bot_of_isEmpty atTop]
-  apply tendsto_order.2 ⟨by simp, fun ε εpos ↦ ?_⟩
-  obtain ⟨δ, δpos, hδ⟩ : ∃ δ, δ ∈ Ioo 0 ε := exists_between εpos
-  by_contra! H
-  have A (y) : ∃ y', ε ≤ eVariationOn f (s ∩ Ici y') ∧ y' ∈ s ∩ Ici y := by
-    have : s ∩ Ici y ∈ 𝓟 s ⊓ atTop := inter_mem_inf (by simp) (Ici_mem_atTop _)
-    exact (H.and_eventually this).exists
-  have B (y) : ∃ y' ∈ s ∩ Ici y, δ ≤ eVariationOn f (s ∩ Icc y y') := by
-    rcases A y with ⟨y', hy', y'_mem⟩
-    have : δ < eVariationOn f (s ∩ Ici y') := lt_of_lt_of_le hδ hy'
-    obtain ⟨a, ha, b, hb, hab, h⟩ : ∃ a ∈ s ∩ Ici y', ∃ b ∈ s ∩ Ici y', a < b ∧
-      δ < eVariationOn f ((s ∩ Ici y') ∩ Icc a b) := exists_lt_eVariationOn_inter_Icc this
-    exact ⟨b, by grind, h.le.trans (mono _ (by grind))⟩
-  choose! y y_mem le_y using B
-  let v (n : ℕ) := y^[n + 1] hα.some
-  have J (n : ℕ) : n * δ ≤ eVariationOn f s := calc
-    n * δ
-    _ = ∑ i ∈ Finset.range n, δ := by simp
-    _ ≤ ∑ i ∈ Finset.range n, eVariationOn f (s ∩ Icc (v i) (v (i + 1))) := by
-      gcongr with i hi
-      simp only [Function.iterate_succ', Function.comp_apply, v]
-      grind
-    _ = eVariationOn f (s ∩ Icc (v 0) (v n)) := by
-      apply eVariationOn.sum
-      · apply monotone_nat_of_le_succ (fun n ↦ ?_)
-        simp only [Function.iterate_succ', Function.comp_apply, v]
-        exact (y_mem _).2
-      · intro i hi h'i
-        simpa only [Function.iterate_succ', Function.comp_apply, v] using (y_mem _).1
-    _ ≤ eVariationOn f s := mono _ inter_subset_left
-  have : Tendsto (fun (n : ℕ) ↦ n * δ) atTop (𝓝 (∞ * δ)) :=
-    ENNReal.Tendsto.mul_const ENNReal.tendsto_nat_nhds_top (by simp)
-  rw [ENNReal.top_mul δpos.ne'] at this
-  have : ∞ ≤ eVariationOn f s := le_of_tendsto this (Eventually.of_forall J)
-  simp only [BoundedVariationOn] at hf
-  order
+    Tendsto (fun y ↦ eVariationOn f (s ∩ Ici y)) (𝓟 s ⊓ atTop) (𝓝 0) :=
+  hf.tendsto_eVariationOn_Ici_zero_of_filter _
+    (fun y _ ↦ inter_mem_inf (mem_principal_self s) (Ici_mem_atTop y))
 
 /-- If a function has bounded variation, then the variation on semi-infinite closed
 intervals tends to `0` at `-∞`. -/

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -504,7 +504,7 @@ lemma eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt
       sum_le_of_monotoneOn_Iic (by grind [MonotoneOn, StrictMonoOn]) (by grind [StrictMonoOn])
 
 /-- If a function is continuous on the right at a point `a`, then its variations on `Ioi a` and
-on `Ioc a` coincide. We give a version relative to a set `s`. -/
+on `Ici a` coincide. We give a version relative to a set `s`. -/
 lemma eVariationOn_inter_Ioi_eq_inter_Ici_of_continuousWithinAt
     [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
     (h : (𝓝[s ∩ Ioi a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Ici a) a) :

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -690,28 +690,8 @@ theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [Topolog
 /-- A bounded variation function has a limit on its right within a set. -/
 theorem _root_.BoundedVariationOn.exists_tendsto_right [CompleteSpace E] [TopologicalSpace α]
     [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
-    ∃ l, Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l) := by
-  rcases Filter.eq_or_neBot (𝓝[s ∩ Ioi x] x) with h | h
-  · simp only [h, tendsto_bot, exists_const_iff, and_true]
-    exact ⟨f x⟩
-  apply CompleteSpace.complete
-  apply EMetric.cauchy_iff.2 ⟨by simp [neBot_iff.mp h], fun ε εpos ↦ ?_⟩
-  obtain ⟨y, hy, y_mem⟩ : ∃ y, eVariationOn f (s ∩ Ioc x y) < ε ∧ y ∈ s ∩ Ioi x := by
-    have := (hf.tendsto_eVariationOn_Ioc_zero x).mono_left
-      (nhdsWithin_mono (s := s ∩ Ioi x) _ inter_subset_left)
-    exact (((tendsto_order.1 this).2 ε εpos).and self_mem_nhdsWithin).exists
-  refine ⟨f '' (s ∩ Ioc x y), ?_, ?_⟩
-  · simp only [mem_map]
-    apply mem_of_superset ?_ (subset_preimage_image _ _)
-    exact inter_mem_nhdsWithin_inter self_mem_nhdsWithin (Ioc_mem_nhdsGT y_mem.2)
-  · rintro - ⟨a, ha, rfl⟩ - ⟨b, hb, rfl⟩
-    exact (eVariationOn.edist_le _ ha hb).trans_lt hy
-
-/-- A bounded variation function has a limit on its left within a set. -/
-theorem _root_.BoundedVariationOn.exists_tendsto_left [CompleteSpace E] [TopologicalSpace α]
-    [OrderTopology α] {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) (x : α) :
-    ∃ l, Tendsto f (𝓝[s ∩ Iio x] x) (𝓝 l) :=
-  hf.ofDual.exists_tendsto_right (toDual x)
+    ∃ l, Tendsto f (𝓝[s ∩ Ioi x] x) (𝓝 l) :=
+  hf.ofDual.exists_tendsto_left (toDual x)
 
 /-- A bounded variation function tends to its left-limit on its left. -/
 theorem _root_.BoundedVariationOn.tendsto_leftLim [CompleteSpace E] [TopologicalSpace α]
@@ -825,20 +805,10 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Iic_zero
 theorem _root_.BoundedVariationOn.exists_tendsto_atTop [CompleteSpace E] [hE : Nonempty E]
     {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
     ∃ l, Tendsto f (𝓟 s ⊓ atTop) (𝓝 l) := by
-  rcases Filter.eq_or_neBot (𝓟 s ⊓ atTop) with h | h
-  · simp only [h, tendsto_bot, exists_const_iff, and_true]
-    exact ⟨hE.some⟩
-  apply CompleteSpace.complete
-  apply EMetric.cauchy_iff.2 ⟨by simp [neBot_iff.mp h], fun ε εpos ↦ ?_⟩
-  obtain ⟨y, hy, y_mem⟩ : ∃ y, eVariationOn f (s ∩ Ici y) < ε ∧ y ∈ s := by
-    have : s ∈ 𝓟 s ⊓ atTop := mem_inf_of_left (by simp)
-    exact (((tendsto_order.1 hf.tendsto_eVariationOn_Ici_zero).2 ε εpos).and this).exists
-  refine ⟨f '' (s ∩ Ici y), ?_, ?_⟩
-  · simp only [mem_map]
-    apply mem_of_superset ?_ (subset_preimage_image _ _)
-    exact inter_mem_inf (by simp) (Ici_mem_atTop _)
-  · rintro - ⟨a, ha, rfl⟩ - ⟨b, hb, rfl⟩
-    exact (eVariationOn.edist_le _ ha hb).trans_lt hy
+  rcases eq_empty_or_nonempty s with rfl | hs
+  · simp
+  · exact hf.exists_tendsto_left_of_filter _
+      (fun y hy ↦ inter_mem_inf (mem_principal_self s) (Ici_mem_atTop _)) hs
 
 /-- A bounded variation function has a limit at `-∞`. -/
 theorem _root_.BoundedVariationOn.exists_tendsto_atBot [CompleteSpace E] [hE : Nonempty E]

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -434,24 +434,87 @@ theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
     gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
 
-private lemma eVariationOn_le_ofDual (f : α → E) (s : Set α) :
-    eVariationOn f s ≤ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by
-  apply iSup_le
-  rintro ⟨n, u, u_mono, u_mem⟩
-  let v (i : ℕ) := toDual (u (n - i))
-  have M : Monotone v := by
-    simp only [Monotone, toDual_le_toDual, v] at u_mono ⊢
-    grind
-  calc ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))
-  _ = ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) := by
-    simp only [toDual, v]
-    rw [← Finset.sum_range_reflect]
-    grind [Finset.sum_congr, edist_comm]
-  _ ≤ _ := sum_le M (fun i ↦ u_mem _)
+/-! # Composition of bounded variation functions with monotone functions -/
 
-@[simp] lemma eVariationOn_ofDual (f : α → E) (s : Set α) :
-    eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) = eVariationOn f s :=
-  le_antisymm (eVariationOn_le_ofDual _ _) (eVariationOn_le_ofDual _ _)
+section Monotone
+
+variable {β : Type*} [LinearOrder β]
+
+theorem comp_le_of_monotoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t)
+    (φst : MapsTo φ t s) : eVariationOn (f ∘ φ) t ≤ eVariationOn f s :=
+  iSup_le fun ⟨n, u, hu, ut⟩ =>
+    le_iSup_of_le ⟨n, φ ∘ u, fun x y xy => hφ (ut x) (ut y) (hu xy), fun i => φst (ut i)⟩ le_rfl
+
+theorem comp_le_of_antitoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β → α) (hφ : AntitoneOn φ t)
+    (φst : MapsTo φ t s) : eVariationOn (f ∘ φ) t ≤ eVariationOn f s := by
+  refine iSup_le ?_
+  rintro ⟨n, u, hu, ut⟩
+  rw [← Finset.sum_range_reflect]
+  refine (Finset.sum_congr rfl fun x hx => ?_).trans_le <| le_iSup_of_le
+    ⟨n, fun i => φ (u <| n - i), fun x y xy => hφ (ut _) (ut _) (hu <| Nat.sub_le_sub_left xy n),
+      fun i => φst (ut _)⟩
+    le_rfl
+  rw [Finset.mem_range] at hx
+  dsimp only [Subtype.coe_mk, Function.comp_apply]
+  rw [edist_comm]
+  congr 4 <;> lia
+
+theorem comp_eq_of_monotoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t) :
+    eVariationOn (f ∘ φ) t = eVariationOn f (φ '' t) := by
+  apply le_antisymm (comp_le_of_monotoneOn f φ hφ (mapsTo_image φ t))
+  cases isEmpty_or_nonempty β
+  · convert zero_le (_ : ℝ≥0∞)
+    exact eVariationOn.subsingleton f <|
+      (subsingleton_of_subsingleton.image _).anti (surjOn_image φ t)
+  let ψ := φ.invFunOn t
+  have ψφs : EqOn (φ ∘ ψ) id (φ '' t) := (surjOn_image φ t).rightInvOn_invFunOn
+  have ψts : MapsTo ψ (φ '' t) t := (surjOn_image φ t).mapsTo_invFunOn
+  have hψ : MonotoneOn ψ (φ '' t) := Function.monotoneOn_of_rightInvOn_of_mapsTo hφ ψφs ψts
+  change eVariationOn (f ∘ id) (φ '' t) ≤ eVariationOn (f ∘ φ) t
+  rw [← eq_of_eqOn (ψφs.comp_left : EqOn (f ∘ φ ∘ ψ) (f ∘ id) (φ '' t))]
+  exact comp_le_of_monotoneOn _ ψ hψ ψts
+
+theorem comp_inter_Icc_eq_of_monotoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t)
+    {x y : β} (hx : x ∈ t) (hy : y ∈ t) :
+    eVariationOn (f ∘ φ) (t ∩ Icc x y) = eVariationOn f (φ '' t ∩ Icc (φ x) (φ y)) := by
+  rcases le_total x y with (h | h)
+  · convert comp_eq_of_monotoneOn f φ (hφ.mono Set.inter_subset_left)
+    apply le_antisymm
+    · rintro _ ⟨⟨u, us, rfl⟩, vφx, vφy⟩
+      rcases le_total x u with (xu | ux)
+      · rcases le_total u y with (uy | yu)
+        · exact ⟨u, ⟨us, ⟨xu, uy⟩⟩, rfl⟩
+        · rw [le_antisymm vφy (hφ hy us yu)]
+          exact ⟨y, ⟨hy, ⟨h, le_rfl⟩⟩, rfl⟩
+      · rw [← le_antisymm vφx (hφ us hx ux)]
+        exact ⟨x, ⟨hx, ⟨le_rfl, h⟩⟩, rfl⟩
+    · rintro _ ⟨u, ⟨⟨hu, xu, uy⟩, rfl⟩⟩
+      exact ⟨⟨u, hu, rfl⟩, ⟨hφ hx hu xu, hφ hu hy uy⟩⟩
+  · rw [eVariationOn.subsingleton, eVariationOn.subsingleton]
+    exacts [(Set.subsingleton_Icc_of_ge (hφ hy hx h)).anti Set.inter_subset_right,
+      (Set.subsingleton_Icc_of_ge h).anti Set.inter_subset_right]
+
+theorem comp_eq_of_antitoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : AntitoneOn φ t) :
+    eVariationOn (f ∘ φ) t = eVariationOn f (φ '' t) := by
+  apply le_antisymm (comp_le_of_antitoneOn f φ hφ (mapsTo_image φ t))
+  cases isEmpty_or_nonempty β
+  · convert zero_le (_ : ℝ≥0∞)
+    exact eVariationOn.subsingleton f <| (subsingleton_of_subsingleton.image _).anti
+      (surjOn_image φ t)
+  let ψ := φ.invFunOn t
+  have ψφs : EqOn (φ ∘ ψ) id (φ '' t) := (surjOn_image φ t).rightInvOn_invFunOn
+  have ψts := (surjOn_image φ t).mapsTo_invFunOn
+  have hψ : AntitoneOn ψ (φ '' t) := Function.antitoneOn_of_rightInvOn_of_mapsTo hφ ψφs ψts
+  change eVariationOn (f ∘ id) (φ '' t) ≤ eVariationOn (f ∘ φ) t
+  rw [← eq_of_eqOn (ψφs.comp_left : EqOn (f ∘ φ ∘ ψ) (f ∘ id) (φ '' t))]
+  exact comp_le_of_antitoneOn _ ψ hψ ψts
+
+open OrderDual
+
+@[simp] theorem comp_ofDual (f : α → E) (s : Set α) :
+    eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) = eVariationOn f s := by
+  convert comp_eq_of_antitoneOn f ofDual fun _ _ _ _ => id
+  simp only [Equiv.image_preimage]
 
 lemma _root_.BoundedVariationOn.ofDual {f : α → E} {s : Set α} (hf : BoundedVariationOn f s) :
     BoundedVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) := by
@@ -460,6 +523,10 @@ lemma _root_.BoundedVariationOn.ofDual {f : α → E} {s : Set α} (hf : Bounded
 @[simp] lemma boundedVariation_ofDual {f : α → E} {s : Set α} :
     BoundedVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ BoundedVariationOn f s :=
   ⟨fun h ↦ h.ofDual, fun h ↦ h.ofDual⟩
+
+end Monotone
+
+/-! # Left and right limits of bounded variation functions -/
 
 /-- If a function is continuous on the left at a point `a`, then its variations on `Iio a` and
 on `Iic a` coincide. We give a version relative to a set `s`. -/
@@ -509,7 +576,7 @@ lemma eVariationOn_inter_Ioi_eq_inter_Ici_of_continuousWithinAt
     [TopologicalSpace α] [OrderTopology α] {f : α → E} {s : Set α} {a : α}
     (h : (𝓝[s ∩ Ioi a] a).NeBot) (h' : ContinuousWithinAt f (s ∩ Ici a) a) :
     eVariationOn f (s ∩ Ioi a) = eVariationOn f (s ∩ Ici a) := by
-  rw [← eVariationOn_ofDual f, ← eVariationOn_ofDual f]
+  rw [← comp_ofDual f, ← comp_ofDual f]
   exact eVariationOn_inter_Iio_eq_inter_Iic_of_continuousWithinAt h h'
 
 lemma exists_lt_eVariationOn_inter_Icc {f : α → E} {ε : ℝ≥0∞} {s : Set α}
@@ -635,7 +702,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ioc_zero [TopologicalSpac
   have : (fun y ↦ eVariationOn f (s ∩ Ioc x y)) =
       (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Ico (toDual y) (toDual x))) := by
     ext y
-    rw [Ico_toDual, ← preimage_inter, eVariationOn_ofDual]
+    rw [Ico_toDual, ← preimage_inter, comp_ofDual]
   rw [this]
   exact hf.ofDual.tendsto_eVariationOn_Ico_zero (toDual x)
 
@@ -673,7 +740,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Icc_zero_right
   have : (fun y ↦ eVariationOn f (s ∩ Icc x y)) =
       (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Icc (toDual y) (toDual x))) := by
     ext y
-    rw [Icc_toDual, ← preimage_inter, eVariationOn_ofDual]
+    rw [Icc_toDual, ← preimage_inter, comp_ofDual]
   rw [this]
   exact hf.ofDual.tendsto_eVariationOn_Icc_zero_left h
 
@@ -781,6 +848,8 @@ lemma _root_.BoundedVariationOn.continuousWithinAt_rightLim [TopologicalSpace α
     ContinuousWithinAt f.rightLim (Ici x) x :=
   BoundedVariationOn.continuousWithinAt_leftLim hf.ofDual
 
+/-! # Limits of bounded variation functions as `± ∞` -/
+
 /-- If a function has bounded variation, then the variation on closed semi-infinite
 intervals tends to `0` at `+∞`. -/
 theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Ici_zero
@@ -797,7 +866,7 @@ theorem _root_.BoundedVariationOn.tendsto_eVariationOn_Iic_zero
   have : (fun y ↦ eVariationOn f (s ∩ Iic y)) =
       (fun y ↦ eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s ∩ Ici (toDual y))) := by
     ext y
-    rw [Ici_toDual, ← preimage_inter, eVariationOn_ofDual]
+    rw [Ici_toDual, ← preimage_inter, comp_ofDual]
   rw [this]
   exact hf.ofDual.tendsto_eVariationOn_Ici_zero
 
@@ -826,91 +895,9 @@ theorem _root_.BoundedVariationOn.tendsto_atBot_limUnder [CompleteSpace E] [hE :
     Tendsto f atBot (𝓝 (limUnder atBot f)) :=
   tendsto_nhds_limUnder (by simpa using hf.exists_tendsto_atBot)
 
-section Monotone
-
-variable {β : Type*} [LinearOrder β]
-
-theorem comp_le_of_monotoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t)
-    (φst : MapsTo φ t s) : eVariationOn (f ∘ φ) t ≤ eVariationOn f s :=
-  iSup_le fun ⟨n, u, hu, ut⟩ =>
-    le_iSup_of_le ⟨n, φ ∘ u, fun x y xy => hφ (ut x) (ut y) (hu xy), fun i => φst (ut i)⟩ le_rfl
-
-theorem comp_le_of_antitoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β → α) (hφ : AntitoneOn φ t)
-    (φst : MapsTo φ t s) : eVariationOn (f ∘ φ) t ≤ eVariationOn f s := by
-  refine iSup_le ?_
-  rintro ⟨n, u, hu, ut⟩
-  rw [← Finset.sum_range_reflect]
-  refine (Finset.sum_congr rfl fun x hx => ?_).trans_le <| le_iSup_of_le
-    ⟨n, fun i => φ (u <| n - i), fun x y xy => hφ (ut _) (ut _) (hu <| Nat.sub_le_sub_left xy n),
-      fun i => φst (ut _)⟩
-    le_rfl
-  rw [Finset.mem_range] at hx
-  dsimp only [Subtype.coe_mk, Function.comp_apply]
-  rw [edist_comm]
-  congr 4 <;> lia
-
-theorem comp_eq_of_monotoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t) :
-    eVariationOn (f ∘ φ) t = eVariationOn f (φ '' t) := by
-  apply le_antisymm (comp_le_of_monotoneOn f φ hφ (mapsTo_image φ t))
-  cases isEmpty_or_nonempty β
-  · convert zero_le (_ : ℝ≥0∞)
-    exact eVariationOn.subsingleton f <|
-      (subsingleton_of_subsingleton.image _).anti (surjOn_image φ t)
-  let ψ := φ.invFunOn t
-  have ψφs : EqOn (φ ∘ ψ) id (φ '' t) := (surjOn_image φ t).rightInvOn_invFunOn
-  have ψts : MapsTo ψ (φ '' t) t := (surjOn_image φ t).mapsTo_invFunOn
-  have hψ : MonotoneOn ψ (φ '' t) := Function.monotoneOn_of_rightInvOn_of_mapsTo hφ ψφs ψts
-  change eVariationOn (f ∘ id) (φ '' t) ≤ eVariationOn (f ∘ φ) t
-  rw [← eq_of_eqOn (ψφs.comp_left : EqOn (f ∘ φ ∘ ψ) (f ∘ id) (φ '' t))]
-  exact comp_le_of_monotoneOn _ ψ hψ ψts
-
-theorem comp_inter_Icc_eq_of_monotoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t)
-    {x y : β} (hx : x ∈ t) (hy : y ∈ t) :
-    eVariationOn (f ∘ φ) (t ∩ Icc x y) = eVariationOn f (φ '' t ∩ Icc (φ x) (φ y)) := by
-  rcases le_total x y with (h | h)
-  · convert comp_eq_of_monotoneOn f φ (hφ.mono Set.inter_subset_left)
-    apply le_antisymm
-    · rintro _ ⟨⟨u, us, rfl⟩, vφx, vφy⟩
-      rcases le_total x u with (xu | ux)
-      · rcases le_total u y with (uy | yu)
-        · exact ⟨u, ⟨us, ⟨xu, uy⟩⟩, rfl⟩
-        · rw [le_antisymm vφy (hφ hy us yu)]
-          exact ⟨y, ⟨hy, ⟨h, le_rfl⟩⟩, rfl⟩
-      · rw [← le_antisymm vφx (hφ us hx ux)]
-        exact ⟨x, ⟨hx, ⟨le_rfl, h⟩⟩, rfl⟩
-    · rintro _ ⟨u, ⟨⟨hu, xu, uy⟩, rfl⟩⟩
-      exact ⟨⟨u, hu, rfl⟩, ⟨hφ hx hu xu, hφ hu hy uy⟩⟩
-  · rw [eVariationOn.subsingleton, eVariationOn.subsingleton]
-    exacts [(Set.subsingleton_Icc_of_ge (hφ hy hx h)).anti Set.inter_subset_right,
-      (Set.subsingleton_Icc_of_ge h).anti Set.inter_subset_right]
-
-theorem comp_eq_of_antitoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : AntitoneOn φ t) :
-    eVariationOn (f ∘ φ) t = eVariationOn f (φ '' t) := by
-  apply le_antisymm (comp_le_of_antitoneOn f φ hφ (mapsTo_image φ t))
-  cases isEmpty_or_nonempty β
-  · convert zero_le (_ : ℝ≥0∞)
-    exact eVariationOn.subsingleton f <| (subsingleton_of_subsingleton.image _).anti
-      (surjOn_image φ t)
-  let ψ := φ.invFunOn t
-  have ψφs : EqOn (φ ∘ ψ) id (φ '' t) := (surjOn_image φ t).rightInvOn_invFunOn
-  have ψts := (surjOn_image φ t).mapsTo_invFunOn
-  have hψ : AntitoneOn ψ (φ '' t) := Function.antitoneOn_of_rightInvOn_of_mapsTo hφ ψφs ψts
-  change eVariationOn (f ∘ id) (φ '' t) ≤ eVariationOn (f ∘ φ) t
-  rw [← eq_of_eqOn (ψφs.comp_left : EqOn (f ∘ φ ∘ ψ) (f ∘ id) (φ '' t))]
-  exact comp_le_of_antitoneOn _ ψ hψ ψts
-
-open OrderDual
-
-theorem comp_ofDual (f : α → E) (s : Set α) :
-    eVariationOn (f ∘ ofDual) (ofDual ⁻¹' s) = eVariationOn f s := by
-  convert comp_eq_of_antitoneOn f ofDual fun _ _ _ _ => id
-  simp only [Equiv.image_preimage]
-
-end Monotone
-
 end eVariationOn
 
-/-! ## Monotone functions and bounded variation -/
+/-! ## Variation of monotone functions -/
 
 theorem MonotoneOn.eVariationOn_le {f : α → ℝ} {s : Set α} (hf : MonotoneOn f s) {a b : α}
     (as : a ∈ s) (bs : b ∈ s) : eVariationOn f (s ∩ Icc a b) ≤ ENNReal.ofReal (f b - f a) := by

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -166,6 +166,9 @@ theorem _root_.BoundedVariationOn.locallyBoundedVariationOn {f : α → E} {s : 
     (h : BoundedVariationOn f s) : LocallyBoundedVariationOn f s := fun _ _ _ _ =>
   h.mono inter_subset_left
 
+theorem congr {f g : α → E} {s : Set α} (h : EqOn f g s) : eVariationOn f s = eVariationOn g s := by
+  grind [eVariationOn]
+
 theorem edist_le (f : α → E) {s : Set α} {x y : α} (hx : x ∈ s) (hy : y ∈ s) :
     edist (f x) (f y) ≤ eVariationOn f s := by
   wlog hxy : y ≤ x generalizing x y
@@ -777,13 +780,15 @@ theorem _root_.BoundedVariationOn.tendsto_rightLim [CompleteSpace E] [Topologica
 /-- If a function `g` is at each point `x` a limit of `f` to the left or to the right (or more
 generally a cluster point of the values of `f` around `x`) then the variation of `g` is bounded
 by that of `f`. -/
-lemma eVariationOn_le_of_mapClusterPt [TopologicalSpace α] [OrderTopology α] {f g : α → E}
-    {s : Set α} (hg : ∀ x, MapClusterPt (g x) (𝓝[s] x) f) :
+private lemma eVariationOn_le_of_mapClusterPt
+    [TopologicalSpace α] [OrderTopology α] {f g : α → E}
+    {s : Set α} (hg : ∀ x ∈ s, MapClusterPt (g x) (𝓝[s] x) f) :
     eVariationOn g s ≤ eVariationOn f s := by
   rw [eVariationOn_eq_strictMonoOn]
   apply iSup_le
   rintro ⟨n, u, u_mono, u_mem⟩
   simp only
+  have : Nonempty α := ⟨u 0⟩
   apply le_of_forall_lt (fun c hc ↦ ?_)
   have : ∀ᶠ (b : ℕ → E) in 𝓝 (fun i ↦ g (u i)),
       c < ∑ i ∈ Finset.range n, edist (b (i + 1)) (b i) := by
@@ -802,30 +807,37 @@ lemma eVariationOn_le_of_mapClusterPt [TopologicalSpace α] [OrderTopology α] {
   rw [nhds_pi] at this
   obtain ⟨J, J_fin, k, k_mem, hk⟩ : ∃ (J : Set ℕ), J.Finite ∧ ∃ k, (∀ (i : ℕ), k i ∈ 𝓝 (u i)) ∧
     J.pi k ⊆ _ := mem_pi.1 this
-  have A i : ∃ x, (f x ∈ t i ∧ x ∈ k i) ∧ x ∈ s :=
-    ((((mapClusterPt_iff_frequently.1 (hg (u i)) (t i) (t_mem i))).and_eventually
+  have A i (hi : i ∈ Iic n) : ∃ x, (f x ∈ t i ∧ x ∈ k i) ∧ x ∈ s :=
+    ((((mapClusterPt_iff_frequently.1 (hg (u i) (u_mem i hi)) (t i) (t_mem i))).and_eventually
       (mem_nhdsWithin_of_mem_nhds (k_mem i))).and_eventually self_mem_nhdsWithin).exists
-  choose v hv h'v using A
+  choose! v hv h'v using A
   have : c < ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) := by
-    suffices H : f ∘ v ∈ I.pi t from ht H
+    let f' i := if i ∈ Iic n then f (v i) else g (u i)
+    have : ∑ i ∈ Finset.range n, edist (f (v (i + 1))) (f (v i)) =
+        ∑ i ∈ Finset.range n, edist (f' (i + 1)) (f' i) :=
+      Finset.sum_congr rfl (fun i hi ↦ by grind)
+    rw [this]
+    suffices H : f' ∈ I.pi t from ht H
+    have A i : g (u i) ∈ t i := mem_of_mem_nhds (t_mem i)
     grind
   apply this.trans_le
   have v_mono : StrictMonoOn v (Iic n) := by
-    suffices v ∈ J.pi k by
+    let w i := if i ∈ Iic n then v i else u i
+    suffices w ∈ J.pi k by
       simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_Iic, and_imp, Prod.forall] at hk
-      have W := hk this
       grind [StrictMonoOn]
+    have A i : u i ∈ k i := mem_of_mem_nhds (k_mem i)
     grind
   exact sum_le_of_monotoneOn_Iic v_mono.monotoneOn (by grind)
 
 lemma eVariationOn_leftLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E} :
     eVariationOn f.leftLim univ ≤ eVariationOn f univ := by
-  apply eVariationOn_le_of_mapClusterPt (fun x ↦ ?_)
+  apply eVariationOn_le_of_mapClusterPt (fun x hx ↦ ?_)
   apply (mapClusterPt_leftLim f x).mono (nhdsWithin_mono _ (subset_univ _))
 
 lemma eVariationOn_rightLim_le [TopologicalSpace α] [OrderTopology α] {f : α → E} :
     eVariationOn f.rightLim univ ≤ eVariationOn f univ := by
-  apply eVariationOn_le_of_mapClusterPt (fun x ↦ ?_)
+  apply eVariationOn_le_of_mapClusterPt (fun x hx ↦ ?_)
   apply (mapClusterPt_rightLim f x).mono (nhdsWithin_mono _ (subset_univ _))
 
 lemma _root_.BoundedVariationOn.leftLim [TopologicalSpace α] [OrderTopology α] {f : α → E}

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -69,7 +69,7 @@ endpoints in `s`, then the function has finite variation on `s ∩ [a, b]`. -/
 def LocallyBoundedVariationOn (f : α → E) (s : Set α) :=
   ∀ a b, a ∈ s → b ∈ s → BoundedVariationOn f (s ∩ Icc a b)
 
-/-! ## Basic computations of variation -/
+/-! ### Basic computations of variation -/
 
 namespace eVariationOn
 
@@ -437,7 +437,7 @@ theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
     gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
 
-/-! # Composition of bounded variation functions with monotone functions -/
+/-! ### Composition of bounded variation functions with monotone functions -/
 
 section Monotone
 
@@ -529,7 +529,7 @@ lemma _root_.BoundedVariationOn.ofDual {f : α → E} {s : Set α} (hf : Bounded
 
 end Monotone
 
-/-! # Left and right limits of bounded variation functions -/
+/-! ### Left and right limits of bounded variation functions -/
 
 /-- If a function is continuous on the left at a point `a`, then its variations on `Iio a` and
 on `Iic a` coincide. We give a version relative to a set `s`. -/
@@ -860,7 +860,7 @@ lemma _root_.BoundedVariationOn.continuousWithinAt_rightLim [TopologicalSpace α
     ContinuousWithinAt f.rightLim (Ici x) x :=
   BoundedVariationOn.continuousWithinAt_leftLim hf.ofDual
 
-/-! # Limits of bounded variation functions as `± ∞` -/
+/-! ### Limits of bounded variation functions as `± ∞` -/
 
 /-- If a function has bounded variation, then the variation on closed semi-infinite
 intervals tends to `0` at `+∞`. -/
@@ -909,7 +909,7 @@ theorem _root_.BoundedVariationOn.tendsto_atBot_limUnder [CompleteSpace E] [hE :
 
 end eVariationOn
 
-/-! ## Variation of monotone functions -/
+/-! ### Variation of monotone functions -/
 
 theorem MonotoneOn.eVariationOn_le {f : α → ℝ} {s : Set α} (hf : MonotoneOn f s) {a b : α}
     (as : a ∈ s) (bs : b ∈ s) : eVariationOn f (s ∩ Icc a b) ≤ ENNReal.ofReal (f b - f a) := by
@@ -1112,7 +1112,7 @@ theorem LocallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn {f : α → �
   · exact ⟨_, _, variationOnFromTo.monotoneOn h cs, variationOnFromTo.sub_self_monotoneOn h cs,
       (sub_sub_cancel _ _).symm⟩
 
-/-! ## Lipschitz functions and bounded variation -/
+/-! ### Lipschitz functions and bounded variation -/
 
 section LipschitzOnWith
 


### PR DESCRIPTION
Needed for #34055.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Everything in the PR is on the same topic, which is why I have kept it as a single PR. I can split it into two parts if it's too long, though, just tell me!

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
