### PR TITLE
[Merged by Bors] - feat: ring where elements are bounded by naturals is a floor ring

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -227,17 +227,14 @@ theorem exists_int_lt (x : R) : ∃ n : ℤ, (n : R) < x :=
   let ⟨n, h⟩ := exists_int_gt (-x)
   ⟨-n, by rw [Int.cast_neg]; exact neg_lt.1 h⟩
 
+/-- See `exists_floor'` for a more general version which only assumes the element is bounded by
+two integers. -/
 theorem exists_floor (x : R) : ∃ fl : ℤ, ∀ z : ℤ, z ≤ fl ↔ (z : R) ≤ x := by
-  classical
-  have : ∃ ub : ℤ, (ub : R) ≤ x ∧ ∀ z : ℤ, (z : R) ≤ x → z ≤ ub :=
-    Int.exists_greatest_of_bdd
-      (let ⟨n, hn⟩ := exists_int_gt x
-      ⟨n, fun z h' => Int.cast_le.1 <| le_trans h' <| le_of_lt hn⟩)
-      (let ⟨n, hn⟩ := exists_int_lt x
-      ⟨n, le_of_lt hn⟩)
-  refine this.imp fun fl h z => ?_
-  obtain ⟨h₁, h₂⟩ := h
-  exact ⟨fun h => le_trans (Int.cast_le.2 h) h₁, h₂ z⟩
+  apply exists_floor'
+  · obtain ⟨n, hn⟩ := exists_int_lt x
+    exact ⟨n, hn.le⟩
+  · obtain ⟨n, hn⟩ := exists_int_gt x
+    exact ⟨n, hn.le⟩
 
 end StrictOrderedRing
 
@@ -531,8 +528,7 @@ instance : MulArchimedean NNRat := Nonneg.instMulArchimedean
 cases we have a computable `floor` function. -/
 noncomputable def Archimedean.floorRing (R) [Ring R] [LinearOrder R] [IsStrictOrderedRing R]
     [Archimedean R] : FloorRing R :=
-  .ofFloor R (fun a => Classical.choose (exists_floor a)) fun z a =>
-    (Classical.choose_spec (exists_floor a) z).symm
+  .ofBounded _ exists_nat_ge
 
 -- see Note [lower instance priority]
 /-- A linear ordered field that is a floor ring is archimedean. -/

--- a/Mathlib/Algebra/Order/Floor/Defs.lean
+++ b/Mathlib/Algebra/Order/Floor/Defs.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Algebra.Order.Ring.Cast
 public import Mathlib.Data.Nat.Cast.Basic
 
+import Mathlib.Data.Int.LeastGreatest
+
 /-!
 # Floor and ceil
 
@@ -176,6 +178,38 @@ def FloorRing.ofCeil (α) [Ring α] [LinearOrder α] [IsStrictOrderedRing α] (c
     gc_coe_floor := fun a z => by rw [le_neg, gc_ceil_coe, Int.cast_neg, neg_le_neg_iff]
     gc_ceil_coe }
 
+open Classical in
+private noncomputable def floorAux {α} [Ring α] [PartialOrder α] [IsStrictOrderedRing α] {x : α}
+    (below : ∃ n : ℤ, n ≤ x) (above : ∃ n : ℤ, x ≤ n) :
+    {n : ℤ // n ≤ x ∧ ∀ m : ℤ, m ≤ x → m ≤ n} := by
+  let n := Classical.indefiniteDescription _ above
+  refine Int.greatestOfBdd (P := (· ≤ x)) n.1 (fun m hm ↦ ?_) below
+  rw [← Int.cast_le (R := α)]
+  exact hm.trans n.2
+
+/-- See `exists_floor` for a variant which instead assumes an `Archimedean` ring. -/
+theorem exists_floor' {α} [Ring α] [PartialOrder α] [IsStrictOrderedRing α] (x : α)
+    (below : ∃ n : ℤ, n ≤ x) (above : ∃ n : ℤ, x ≤ n) :
+    ∃ fl : ℤ, ∀ z : ℤ, z ≤ fl ↔ (z : α) ≤ x := by
+  refine ⟨_, fun n ↦ ⟨?_, (floorAux below above).2.2 _⟩⟩
+  rw [← Int.cast_le (R := α)]
+  exact le_trans' (floorAux below above).2.1
+
+/-- Construct a `FloorRing` instance noncomputably, from the hypothesis that every element is
+bounded above by a natural number. -/
+@[no_expose]
+noncomputable def FloorRing.ofBounded (α) [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
+    (bounded : ∀ x : α, ∃ n : ℕ, x ≤ n) : FloorRing α :=
+  have below (x : α) : ∃ n : ℤ, n ≤ x := by
+    obtain ⟨n, hn⟩ := bounded (-x)
+    use -n
+    simpa [neg_le]
+  have above (x : α) : ∃ n : ℤ, x ≤ n := by
+    obtain ⟨n, hn⟩ := bounded x
+    use n
+    exact_mod_cast hn
+  .ofFloor _ _ fun n x ↦ (Classical.choose_spec (exists_floor' x (below x) (above x)) n).symm
+
 namespace Int
 
 variable [Ring α] [LinearOrder α] [FloorRing α] {z : ℤ} {a b : α}
@@ -270,7 +304,6 @@ section FloorRingToSemiring
 variable [Ring α] [LinearOrder α] [IsStrictOrderedRing α] [FloorRing α]
 
 /-! #### A floor ring as a floor semiring -/
-
 
 -- see Note [lower instance priority]
 instance (priority := 100) FloorRing.toFloorSemiring : FloorSemiring α where

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -11,6 +11,7 @@ public import Mathlib.Data.Real.Archimedean
 public import Mathlib.Order.Quotient
 public import Mathlib.RingTheory.Valuation.ValuationSubring
 
+import Mathlib.Data.Int.ConditionallyCompleteOrder
 import Mathlib.Data.Real.CompleteField
 
 /-!
@@ -127,6 +128,19 @@ instance : RatCast (FiniteElement K) where
   ratCast q := .mk q (mk_ratCast_nonneg q)
 
 @[simp] theorem mk_ratCast (q : ℚ) : FiniteElement.mk (q : K) (mk_ratCast_nonneg q) = q := rfl
+
+@[no_expose]
+noncomputable instance : FloorRing (FiniteElement K) :=
+  .ofFloor _ (fun x ↦ sSup {n | n ≤ x}) fun n x ↦ by
+    obtain ⟨m, hm⟩ := x.2
+    simp only [ArchimedeanOrder.val_of, abs_one, nsmul_eq_mul, mul_one] at hm
+    have H : BddAbove {n : ℤ | n ≤ x} := by
+      refine ⟨m, fun k hk ↦ ?_⟩
+      simpa [← Int.cast_le (R := FiniteElement K)] using hk.trans (le_of_abs_le hm)
+    refine ⟨le_csSup H, ?_⟩
+    rw [← Int.cast_le (R := FiniteElement K)]
+    refine le_trans' (Int.csSup_mem ⟨-m, ?_⟩ H)
+    simpa using neg_le_of_abs_le hm
 
 end FiniteElement
 

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -11,7 +11,6 @@ public import Mathlib.Data.Real.Archimedean
 public import Mathlib.Order.Quotient
 public import Mathlib.RingTheory.Valuation.ValuationSubring
 
-import Mathlib.Data.Int.ConditionallyCompleteOrder
 import Mathlib.Data.Real.CompleteField
 
 /-!
@@ -131,16 +130,10 @@ instance : RatCast (FiniteElement K) where
 
 @[no_expose]
 noncomputable instance : FloorRing (FiniteElement K) :=
-  .ofFloor _ (fun x ↦ sSup {n | n ≤ x}) fun n x ↦ by
-    obtain ⟨m, hm⟩ := x.2
-    simp only [ArchimedeanOrder.val_of, abs_one, nsmul_eq_mul, mul_one] at hm
-    have H : BddAbove {n : ℤ | n ≤ x} := by
-      refine ⟨m, fun k hk ↦ ?_⟩
-      simpa [← Int.cast_le (R := FiniteElement K)] using hk.trans (le_of_abs_le hm)
-    refine ⟨le_csSup H, ?_⟩
-    rw [← Int.cast_le (R := FiniteElement K)]
-    refine le_trans' (Int.csSup_mem ⟨-m, ?_⟩ H)
-    simpa using neg_le_of_abs_le hm
+  .ofBounded _ fun x ↦ by
+    obtain ⟨n, hn⟩ := x.2
+    refine ⟨n, (le_abs_self x).trans ?_⟩
+    simpa using hn
 
 end FiniteElement
 


### PR DESCRIPTION
Used in the CGT repo.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
