### PR TITLE
[Merged by Bors] - feat(Algebra/Order): multiplicative versions of lemmas on (pre)images of intervals under group operations

### DIFF
--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -152,7 +152,7 @@ lemma Icc_mul_Icc (hab : a ≤ b) (hcd : c ≤ d) : Icc a b * Icc c d = Icc (a *
 end LinearOrderedCommMonoid
 
 section OrderedCommGroup
-variable [CommGroup α] [PartialOrder α] [IsOrderedMonoid α]
+variable [CommGroup α] [PartialOrder α] [IsOrderedMonoid α] (a b c : α)
 
 @[to_additive (attr := simp)] lemma inv_Ici (a : α) : (Ici a)⁻¹ = Iic a⁻¹ := ext fun _x ↦ le_inv'
 @[to_additive (attr := simp)] lemma inv_Iic (a : α) : (Iic a)⁻¹ = Ici a⁻¹ := ext fun _x ↦ inv_le'
@@ -173,291 +173,310 @@ lemma inv_Ioc (a b : α) : (Ioc a b)⁻¹ = Ico b⁻¹ a⁻¹ := by
 @[to_additive (attr := simp)]
 lemma inv_Ioo (a b : α) : (Ioo a b)⁻¹ = Ioo b⁻¹ a⁻¹ := by simp [← Ioi_inter_Iio, inter_comm]
 
-end OrderedCommGroup
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Ici (a b : α) : (fun x => a * x) ⁻¹' Ici b = Ici (b / a) :=
+  ext fun _x => by simp; grind
 
-section OrderedAddCommGroup
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Ioi (a b : α) : (fun x => a * x) ⁻¹' Ioi b = Ioi (b / a) :=
+  ext fun _x => div_lt_iff_lt_mul'.symm
 
-variable [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α] (a b c : α)
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Iic (a b : α) : (fun x => a * x) ⁻¹' Iic b = Iic (b / a) :=
+  ext fun _x => le_div_iff_mul_le'.symm
 
-/-!
-### Preimages under `x ↦ a + x`
--/
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Iio (a b : α) : (fun x => a * x) ⁻¹' Iio b = Iio (b / a) :=
+  ext fun _x => lt_div_iff_mul_lt'.symm
 
-
-@[simp]
-theorem preimage_const_add_Ici : (fun x => a + x) ⁻¹' Ici b = Ici (b - a) :=
-  ext fun _x => sub_le_iff_le_add'.symm
-
-@[simp]
-theorem preimage_const_add_Ioi : (fun x => a + x) ⁻¹' Ioi b = Ioi (b - a) :=
-  ext fun _x => sub_lt_iff_lt_add'.symm
-
-@[simp]
-theorem preimage_const_add_Iic : (fun x => a + x) ⁻¹' Iic b = Iic (b - a) :=
-  ext fun _x => le_sub_iff_add_le'.symm
-
-@[simp]
-theorem preimage_const_add_Iio : (fun x => a + x) ⁻¹' Iio b = Iio (b - a) :=
-  ext fun _x => lt_sub_iff_add_lt'.symm
-
-@[simp]
-theorem preimage_const_add_Icc : (fun x => a + x) ⁻¹' Icc b c = Icc (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Icc (a b c : α) :
+    (fun x => a * x) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
   simp [← Ici_inter_Iic]
 
-@[simp]
-theorem preimage_const_add_Ico : (fun x => a + x) ⁻¹' Ico b c = Ico (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Ico (a b c : α) :
+    (fun x => a * x) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
   simp [← Ici_inter_Iio]
 
-@[simp]
-theorem preimage_const_add_Ioc : (fun x => a + x) ⁻¹' Ioc b c = Ioc (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Ioc (a b c : α) :
+    (fun x => a * x) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
   simp [← Ioi_inter_Iic]
 
-@[simp]
-theorem preimage_const_add_Ioo : (fun x => a + x) ⁻¹' Ioo b c = Ioo (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_mul_Ioo (a b c : α) :
+    (fun x => a * x) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
   simp [← Ioi_inter_Iio]
 
 /-!
-### Preimages under `x ↦ x + a`
+### Preimages under `x ↦ x * a`
 -/
 
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Ici (a b : α) : (fun x => x * a) ⁻¹' Ici b = Ici (b / a) :=
+  ext fun _x => div_le_iff_le_mul.symm
 
-@[simp]
-theorem preimage_add_const_Ici : (fun x => x + a) ⁻¹' Ici b = Ici (b - a) :=
-  ext fun _x => sub_le_iff_le_add.symm
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Ioi (a b : α) : (fun x => x * a) ⁻¹' Ioi b = Ioi (b / a) :=
+  ext fun _x => div_lt_iff_lt_mul.symm
 
-@[simp]
-theorem preimage_add_const_Ioi : (fun x => x + a) ⁻¹' Ioi b = Ioi (b - a) :=
-  ext fun _x => sub_lt_iff_lt_add.symm
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Iic (a b : α) : (fun x => x * a) ⁻¹' Iic b = Iic (b / a) :=
+  ext fun _x => le_div_iff_mul_le.symm
 
-@[simp]
-theorem preimage_add_const_Iic : (fun x => x + a) ⁻¹' Iic b = Iic (b - a) :=
-  ext fun _x => le_sub_iff_add_le.symm
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Iio (a b : α) : (fun x => x * a) ⁻¹' Iio b = Iio (b / a) :=
+  ext fun _x => lt_div_iff_mul_lt.symm
 
-@[simp]
-theorem preimage_add_const_Iio : (fun x => x + a) ⁻¹' Iio b = Iio (b - a) :=
-  ext fun _x => lt_sub_iff_add_lt.symm
-
-@[simp]
-theorem preimage_add_const_Icc : (fun x => x + a) ⁻¹' Icc b c = Icc (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Icc (a b c : α) :
+    (fun x => x * a) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
   simp [← Ici_inter_Iic]
 
-@[simp]
-theorem preimage_add_const_Ico : (fun x => x + a) ⁻¹' Ico b c = Ico (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Ico (a b c : α) :
+    (fun x => x * a) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
   simp [← Ici_inter_Iio]
 
-@[simp]
-theorem preimage_add_const_Ioc : (fun x => x + a) ⁻¹' Ioc b c = Ioc (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Ioc (a b c : α) :
+    (fun x => x * a) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
   simp [← Ioi_inter_Iic]
 
-@[simp]
-theorem preimage_add_const_Ioo : (fun x => x + a) ⁻¹' Ioo b c = Ioo (b - a) (c - a) := by
+@[to_additive (attr := simp)]
+theorem preimage_mul_const_Ioo (a b c : α) :
+    (fun x => x * a) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
   simp [← Ioi_inter_Iio]
 
 /-!
-### Preimages under `x ↦ x - a`
+### Preimages under `x ↦ x / a`
 -/
 
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Ici (a b : α) : (fun x => x / a) ⁻¹' Ici b = Ici (b * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Ici : (fun x => x - a) ⁻¹' Ici b = Ici (b + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Ioi (a b : α) : (fun x => x / a) ⁻¹' Ioi b = Ioi (b * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Ioi : (fun x => x - a) ⁻¹' Ioi b = Ioi (b + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Iic (a b : α) : (fun x => x / a) ⁻¹' Iic b = Iic (b * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Iic : (fun x => x - a) ⁻¹' Iic b = Iic (b + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Iio (a b : α) : (fun x => x / a) ⁻¹' Iio b = Iio (b * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Iio : (fun x => x - a) ⁻¹' Iio b = Iio (b + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Icc (a b c : α) :
+    (fun x => x / a) ⁻¹' Icc b c = Icc (b * a) (c * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Icc : (fun x => x - a) ⁻¹' Icc b c = Icc (b + a) (c + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Ico (a b c : α) :
+    (fun x => x / a) ⁻¹' Ico b c = Ico (b * a) (c * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Ico : (fun x => x - a) ⁻¹' Ico b c = Ico (b + a) (c + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Ioc (a b c : α) :
+    (fun x => x / a) ⁻¹' Ioc b c = Ioc (b * a) (c * a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem preimage_sub_const_Ioc : (fun x => x - a) ⁻¹' Ioc b c = Ioc (b + a) (c + a) := by
-  simp [sub_eq_add_neg]
-
-@[simp]
-theorem preimage_sub_const_Ioo : (fun x => x - a) ⁻¹' Ioo b c = Ioo (b + a) (c + a) := by
-  simp [sub_eq_add_neg]
+@[to_additive (attr := simp)]
+theorem preimage_div_const_Ioo (a b c : α) :
+    (fun x => x / a) ⁻¹' Ioo b c = Ioo (b * a) (c * a) := by
+  simp [div_eq_mul_inv]
 
 /-!
-### Preimages under `x ↦ a - x`
+### Preimages under `x ↦ a / x`
 -/
 
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Ici (a b : α) : (fun x => a / x) ⁻¹' Ici b = Iic (a / b) :=
+  ext fun _x => le_div_comm
 
-@[simp]
-theorem preimage_const_sub_Ici : (fun x => a - x) ⁻¹' Ici b = Iic (a - b) :=
-  ext fun _x => le_sub_comm
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Iic (a b : α) : (fun x => a / x) ⁻¹' Iic b = Ici (a / b) :=
+  ext fun _x => div_le_comm
 
-@[simp]
-theorem preimage_const_sub_Iic : (fun x => a - x) ⁻¹' Iic b = Ici (a - b) :=
-  ext fun _x => sub_le_comm
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Ioi (a b : α) : (fun x => a / x) ⁻¹' Ioi b = Iio (a / b) :=
+  ext fun _x => lt_div_comm
 
-@[simp]
-theorem preimage_const_sub_Ioi : (fun x => a - x) ⁻¹' Ioi b = Iio (a - b) :=
-  ext fun _x => lt_sub_comm
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Iio (a b : α) : (fun x => a / x) ⁻¹' Iio b = Ioi (a / b) :=
+  ext fun _x => div_lt_comm
 
-@[simp]
-theorem preimage_const_sub_Iio : (fun x => a - x) ⁻¹' Iio b = Ioi (a - b) :=
-  ext fun _x => sub_lt_comm
-
-@[simp]
-theorem preimage_const_sub_Icc : (fun x => a - x) ⁻¹' Icc b c = Icc (a - c) (a - b) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Icc (a b c : α) :
+    (fun x => a / x) ⁻¹' Icc b c = Icc (a / c) (a / b) := by
   simp [← Ici_inter_Iic, inter_comm]
 
-@[simp]
-theorem preimage_const_sub_Ico : (fun x => a - x) ⁻¹' Ico b c = Ioc (a - c) (a - b) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Ico (a b c : α) :
+    (fun x => a / x) ⁻¹' Ico b c = Ioc (a / c) (a / b) := by
   simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
 
-@[simp]
-theorem preimage_const_sub_Ioc : (fun x => a - x) ⁻¹' Ioc b c = Ico (a - c) (a - b) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Ioc (a b c : α) :
+    (fun x => a / x) ⁻¹' Ioc b c = Ico (a / c) (a / b) := by
   simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
 
-@[simp]
-theorem preimage_const_sub_Ioo : (fun x => a - x) ⁻¹' Ioo b c = Ioo (a - c) (a - b) := by
+@[to_additive (attr := simp)]
+theorem preimage_const_div_Ioo (a b c : α) :
+    (fun x => a / x) ⁻¹' Ioo b c = Ioo (a / c) (a / b) := by
   simp [← Ioi_inter_Iio, inter_comm]
 
 /-!
-### Images under `x ↦ a + x`
+### Images under `x ↦ a * x`
 -/
 
+-- simp can prove this modulo `mul_comm`
+@[to_additive]
+theorem image_const_mul_Iic (a b : α) :
+    (fun x => a * x) '' Iic b = Iic (a * b) := by simp [mul_comm]
 
--- simp can prove this modulo `add_comm`
-theorem image_const_add_Iic : (fun x => a + x) '' Iic b = Iic (a + b) := by simp [add_comm]
-
--- simp can prove this modulo `add_comm`
-theorem image_const_add_Iio : (fun x => a + x) '' Iio b = Iio (a + b) := by simp [add_comm]
+-- simp can prove this modulo `mul_comm`
+@[to_additive]
+theorem image_const_mul_Iio (a b : α) :
+    (fun x => a * x) '' Iio b = Iio (a * b) := by simp [mul_comm]
 
 /-!
-### Images under `x ↦ x + a`
+### Images under `x ↦ x * a`
 -/
 
+@[to_additive]
+theorem image_mul_const_Iic (a b : α) : (fun x => x * a) '' Iic b = Iic (b * a) := by simp
 
-theorem image_add_const_Iic : (fun x => x + a) '' Iic b = Iic (b + a) := by simp
+@[to_additive]
+theorem image_mul_const_Iio (a b : α) : (fun x => x * a) '' Iio b = Iio (b * a) := by simp
 
-theorem image_add_const_Iio : (fun x => x + a) '' Iio b = Iio (b + a) := by simp
 
 /-!
-### Images under `x ↦ -x`
+### Images under `x ↦ x⁻¹`
 -/
 
+@[to_additive]
+theorem image_inv_Ici : Inv.inv '' Ici a = Iic (a⁻¹) := by simp
 
-theorem image_neg_Ici : Neg.neg '' Ici a = Iic (-a) := by simp
+@[to_additive]
+theorem image_inv_Iic : Inv.inv '' Iic a = Ici (a⁻¹) := by simp
 
-theorem image_neg_Iic : Neg.neg '' Iic a = Ici (-a) := by simp
+@[to_additive]
+theorem image_inv_Ioi : Inv.inv '' Ioi a = Iio (a⁻¹) := by simp
 
-theorem image_neg_Ioi : Neg.neg '' Ioi a = Iio (-a) := by simp
+@[to_additive]
+theorem image_inv_Iio : Inv.inv '' Iio a = Ioi (a⁻¹) := by simp
 
-theorem image_neg_Iio : Neg.neg '' Iio a = Ioi (-a) := by simp
+@[to_additive]
+theorem image_inv_Icc : Inv.inv '' Icc a b = Icc (b⁻¹) (a⁻¹) := by simp
 
-theorem image_neg_Icc : Neg.neg '' Icc a b = Icc (-b) (-a) := by simp
+@[to_additive]
+theorem image_inv_Ico : Inv.inv '' Ico a b = Ioc (b⁻¹) (a⁻¹) := by simp
 
-theorem image_neg_Ico : Neg.neg '' Ico a b = Ioc (-b) (-a) := by simp
+@[to_additive]
+theorem image_inv_Ioc : Inv.inv '' Ioc a b = Ico (b⁻¹) (a⁻¹) := by simp
 
-theorem image_neg_Ioc : Neg.neg '' Ioc a b = Ico (-b) (-a) := by simp
+@[to_additive]
+theorem image_inv_Ioo : Inv.inv '' Ioo a b = Ioo (b⁻¹) (a⁻¹) := by simp
 
-theorem image_neg_Ioo : Neg.neg '' Ioo a b = Ioo (-b) (-a) := by simp
+
 
 /-!
-### Images under `x ↦ a - x`
+### Images under `x ↦ a / x`
 -/
 
+@[to_additive (attr := simp)]
+theorem image_const_div_Ici (a b : α) : (fun x => a / x) '' Ici b = Iic (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Ici : (fun x => a - x) '' Ici b = Iic (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Iic (a b : α) : (fun x => a / x) '' Iic b = Ici (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Iic : (fun x => a - x) '' Iic b = Ici (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Ioi (a b : α) : (fun x => a / x) '' Ioi b = Iio (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Ioi : (fun x => a - x) '' Ioi b = Iio (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Iio (a b : α) : (fun x => a / x) '' Iio b = Ioi (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Iio : (fun x => a - x) '' Iio b = Ioi (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Icc (a b c : α) : (fun x => a / x) '' Icc b c = Icc (a / c) (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Icc : (fun x => a - x) '' Icc b c = Icc (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Ico (a b c : α) : (fun x => a / x) '' Ico b c = Ioc (a / c) (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Ico : (fun x => a - x) '' Ico b c = Ioc (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Ioc (a b c : α) : (fun x => a / x) '' Ioc b c = Ico (a / c) (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
-@[simp]
-theorem image_const_sub_Ioc : (fun x => a - x) '' Ioc b c = Ico (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
-
-@[simp]
-theorem image_const_sub_Ioo : (fun x => a - x) '' Ioo b c = Ioo (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp_def] at this
-  simp [sub_eq_add_neg, this, add_comm]
+@[to_additive (attr := simp)]
+theorem image_const_div_Ioo (a b c : α) : (fun x => a / x) '' Ioo b c = Ioo (a / c) (a / b) := by
+  have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
+  simp [div_eq_mul_inv, this, mul_comm]
 
 /-!
-### Images under `x ↦ x - a`
+### Images under `x ↦ x / a`
 -/
 
+@[to_additive (attr := simp)]
+theorem image_div_const_Ici (a b : α) :
+    (fun x => x / a) '' Ici b = Ici (b / a) := by simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Ici : (fun x => x - a) '' Ici b = Ici (b - a) := by simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Iic (a b : α) :
+    (fun x => x / a) '' Iic b = Iic (b / a) := by simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Iic : (fun x => x - a) '' Iic b = Iic (b - a) := by simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Ioi (a b : α) :
+    (fun x => x / a) '' Ioi b = Ioi (b / a) := by simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Ioi : (fun x => x - a) '' Ioi b = Ioi (b - a) := by simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Iio (a b : α) :
+    (fun x => x / a) '' Iio b = Iio (b / a) := by simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Iio : (fun x => x - a) '' Iio b = Iio (b - a) := by simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Icc (a b c : α) : (fun x => x / a) '' Icc b c = Icc (b / a) (c / a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Icc : (fun x => x - a) '' Icc b c = Icc (b - a) (c - a) := by
-  simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Ico (a b c : α) : (fun x => x / a) '' Ico b c = Ico (b / a) (c / a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Ico : (fun x => x - a) '' Ico b c = Ico (b - a) (c - a) := by
-  simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Ioc (a b c : α) : (fun x => x / a) '' Ioc b c = Ioc (b / a) (c / a) := by
+  simp [div_eq_mul_inv]
 
-@[simp]
-theorem image_sub_const_Ioc : (fun x => x - a) '' Ioc b c = Ioc (b - a) (c - a) := by
-  simp [sub_eq_neg_add]
-
-@[simp]
-theorem image_sub_const_Ioo : (fun x => x - a) '' Ioo b c = Ioo (b - a) (c - a) := by
-  simp [sub_eq_neg_add]
+@[to_additive (attr := simp)]
+theorem image_div_const_Ioo (a b c : α) : (fun x => x / a) '' Ioo b c = Ioo (b / a) (c / a) := by
+  simp [div_eq_mul_inv]
 
 /-!
 ### Bijections
 -/
 
+@[to_additive]
+theorem Iic_mul_bij : BijOn (· * a) (Iic b) (Iic (b * a)) :=
+  image_mul_const_Iic a b ▸ (mul_left_injective _).injOn.bijOn_image
 
-theorem Iic_add_bij : BijOn (· + a) (Iic b) (Iic (b + a)) :=
-  image_add_const_Iic a b ▸ (add_left_injective _).injOn.bijOn_image
+@[to_additive]
+theorem Iio_mul_bij : BijOn (· * a) (Iio b) (Iio (b * a)) :=
+  image_mul_const_Iio a b ▸ (mul_left_injective _).injOn.bijOn_image
 
-theorem Iio_add_bij : BijOn (· + a) (Iio b) (Iio (b + a)) :=
-  image_add_const_Iio a b ▸ (add_left_injective _).injOn.bijOn_image
-
-end OrderedAddCommGroup
+end OrderedCommGroup
 
 section LinearOrderedCommGroup
 variable [CommGroup α] [LinearOrder α] [IsOrderedMonoid α]
@@ -533,35 +552,35 @@ section MulPos
 variable {G₀ : Type*} [GroupWithZero G₀] [PartialOrder G₀] [MulPosReflectLT G₀] {a b c : G₀}
 
 @[simp]
-theorem preimage_mul_const_Iic (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Iic a = Iic (a / c) := by
+theorem preimage_mul_const_Iic₀ (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Iic a = Iic (a / c) := by
   simpa only [division_def] using (OrderIso.mulRight₀ c h).preimage_Iic a
 
 @[simp]
-theorem preimage_mul_const_Ici (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Ici a = Ici (a / c) := by
+theorem preimage_mul_const_Ici₀ (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Ici a = Ici (a / c) := by
   simpa only [division_def] using (OrderIso.mulRight₀ c h).preimage_Ici a
 
 @[simp]
-theorem preimage_mul_const_Ioi (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Ioi a = Ioi (a / c) := by
+theorem preimage_mul_const_Ioi₀ (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Ioi a = Ioi (a / c) := by
   simpa only [division_def] using (OrderIso.mulRight₀ c h).preimage_Ioi a
 
 @[simp]
-theorem preimage_mul_const_Iio (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Iio a = Iio (a / c) := by
+theorem preimage_mul_const_Iio₀ (a : G₀) (h : 0 < c) : (· * c) ⁻¹' Iio a = Iio (a / c) := by
   simpa only [division_def] using (OrderIso.mulRight₀ c h).preimage_Iio a
 
 @[simp]
-theorem preimage_mul_const_Icc (a b : G₀) (h : 0 < c) :
+theorem preimage_mul_const_Icc₀ (a b : G₀) (h : 0 < c) :
     (· * c) ⁻¹' Icc a b = Icc (a / c) (b / c) := by simp [← Ici_inter_Iic, h]
 
 @[simp]
-theorem preimage_mul_const_Ioo (a b : G₀) (h : 0 < c) :
+theorem preimage_mul_const_Ioo₀ (a b : G₀) (h : 0 < c) :
     (fun x => x * c) ⁻¹' Ioo a b = Ioo (a / c) (b / c) := by simp [← Ioi_inter_Iio, h]
 
 @[simp]
-theorem preimage_mul_const_Ioc (a b : G₀) (h : 0 < c) :
+theorem preimage_mul_const_Ioc₀ (a b : G₀) (h : 0 < c) :
     (fun x => x * c) ⁻¹' Ioc a b = Ioc (a / c) (b / c) := by simp [← Ioi_inter_Iic, h]
 
 @[simp]
-theorem preimage_mul_const_Ico (a b : G₀) (h : 0 < c) :
+theorem preimage_mul_const_Ico₀ (a b : G₀) (h : 0 < c) :
     (fun x => x * c) ⁻¹' Ico a b = Ico (a / c) (b / c) := by simp [← Ici_inter_Iio, h]
 
 theorem image_mul_right_Icc' (a b : G₀) (h : 0 < c) :
@@ -661,35 +680,35 @@ section CommGroupWithZero
 variable {G₀ : Type*} [CommGroupWithZero G₀] [PartialOrder G₀] [PosMulReflectLT G₀] {a b c : G₀}
 
 @[simp]
-theorem preimage_const_mul_Iic (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Iic a = Iic (a / c) :=
+theorem preimage_const_mul_Iic₀ (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Iic a = Iic (a / c) :=
   ext fun _x => (le_div_iff₀' h).symm
 
 @[simp]
-theorem preimage_const_mul_Ici (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Ici a = Ici (a / c) :=
+theorem preimage_const_mul_Ici₀ (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Ici a = Ici (a / c) :=
   ext fun _x => (div_le_iff₀' h).symm
 
 @[simp]
-theorem preimage_const_mul_Icc (a b : G₀) {c : G₀} (h : 0 < c) :
+theorem preimage_const_mul_Icc₀ (a b : G₀) {c : G₀} (h : 0 < c) :
     (c * ·) ⁻¹' Icc a b = Icc (a / c) (b / c) := by simp [← Ici_inter_Iic, h]
 
 @[simp]
-theorem preimage_const_mul_Iio (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Iio a = Iio (a / c) :=
+theorem preimage_const_mul_Iio₀ (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Iio a = Iio (a / c) :=
   ext fun _x => (lt_div_iff₀' h).symm
 
 @[simp]
-theorem preimage_const_mul_Ioi (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Ioi a = Ioi (a / c) :=
+theorem preimage_const_mul_Ioi₀ (a : G₀) (h : 0 < c) : (c * ·) ⁻¹' Ioi a = Ioi (a / c) :=
   ext fun _x => (div_lt_iff₀' h).symm
 
 @[simp]
-theorem preimage_const_mul_Ioo (a b : G₀) (h : 0 < c) :
+theorem preimage_const_mul_Ioo₀ (a b : G₀) (h : 0 < c) :
     (c * ·) ⁻¹' Ioo a b = Ioo (a / c) (b / c) := by simp [← Ioi_inter_Iio, h]
 
 @[simp]
-theorem preimage_const_mul_Ioc (a b : G₀) (h : 0 < c) :
+theorem preimage_const_mul_Ioc₀ (a b : G₀) (h : 0 < c) :
     (c * ·) ⁻¹' Ioc a b = Ioc (a / c) (b / c) := by simp [← Ioi_inter_Iic, h]
 
 @[simp]
-theorem preimage_const_mul_Ico (a b : G₀) (h : 0 < c) :
+theorem preimage_const_mul_Ico₀ (a b : G₀) (h : 0 < c) :
     (c * ·) ⁻¹' Ico a b = Ico (a / c) (b / c) := by simp [← Ici_inter_Iio, h]
 
 end CommGroupWithZero
@@ -845,9 +864,9 @@ lemma preimage_const_mul_Ioi_or_Iio (hb : a ≠ 0) {U V : Set α}
   use a⁻¹ * aU <;>
   rcases lt_or_gt_of_ne hb with (hb | hb)
   · right; rw [Set.preimage_const_mul_Ioi_of_neg _ hb, div_eq_inv_mul]
-  · left; rw [Set.preimage_const_mul_Ioi _ hb, div_eq_inv_mul]
+  · left; rw [Set.preimage_const_mul_Ioi₀ _ hb, div_eq_inv_mul]
   · left; rw [Set.preimage_const_mul_Iio_of_neg _ hb, div_eq_inv_mul]
-  · right; rw [Set.preimage_const_mul_Iio _ hb, div_eq_inv_mul]
+  · right; rw [Set.preimage_const_mul_Iio₀ _ hb, div_eq_inv_mul]
 
 @[simp]
 theorem image_mul_const_uIcc (a b c : α) : (· * a) '' [[b, c]] = [[b * a, c * a]] :=

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -419,20 +419,16 @@ theorem image_const_div_Ioo : (fun x => a / x) '' Ioo b c = Ioo (a / c) (a / b) 
 -/
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ici :
-    (fun x => x / a) '' Ici b = Ici (b / a) := by simp [div_eq_mul_inv]
+theorem image_div_const_Ici : (fun x => x / a) '' Ici b = Ici (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Iic :
-    (fun x => x / a) '' Iic b = Iic (b / a) := by simp [div_eq_mul_inv]
+theorem image_div_const_Iic : (fun x => x / a) '' Iic b = Iic (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ioi :
-    (fun x => x / a) '' Ioi b = Ioi (b / a) := by simp [div_eq_mul_inv]
+theorem image_div_const_Ioi : (fun x => x / a) '' Ioi b = Ioi (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Iio :
-    (fun x => x / a) '' Iio b = Iio (b / a) := by simp [div_eq_mul_inv]
+theorem image_div_const_Iio : (fun x => x / a) '' Iio b = Iio (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
 theorem image_div_const_Icc : (fun x => x / a) '' Icc b c = Icc (b / a) (c / a) := by

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -178,39 +178,35 @@ lemma inv_Ioo (a b : α) : (Ioo a b)⁻¹ = Ioo b⁻¹ a⁻¹ := by simp [← Io
 -/
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Ici (a b : α) : (fun x => a * x) ⁻¹' Ici b = Ici (b / a) :=
+theorem preimage_const_mul_Ici : (fun x => a * x) ⁻¹' Ici b = Ici (b / a) :=
   ext fun _x => (div_le_iff_le_mul').symm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Ioi (a b : α) : (fun x => a * x) ⁻¹' Ioi b = Ioi (b / a) :=
+theorem preimage_const_mul_Ioi : (fun x => a * x) ⁻¹' Ioi b = Ioi (b / a) :=
   ext fun _x => div_lt_iff_lt_mul'.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Iic (a b : α) : (fun x => a * x) ⁻¹' Iic b = Iic (b / a) :=
+theorem preimage_const_mul_Iic : (fun x => a * x) ⁻¹' Iic b = Iic (b / a) :=
   ext fun _x => le_div_iff_mul_le'.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Iio (a b : α) : (fun x => a * x) ⁻¹' Iio b = Iio (b / a) :=
+theorem preimage_const_mul_Iio : (fun x => a * x) ⁻¹' Iio b = Iio (b / a) :=
   ext fun _x => lt_div_iff_mul_lt'.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Icc (a b c : α) :
-    (fun x => a * x) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
+theorem preimage_const_mul_Icc : (fun x => a * x) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
   simp [← Ici_inter_Iic]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Ico (a b c : α) :
-    (fun x => a * x) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
+theorem preimage_const_mul_Ico : (fun x => a * x) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
   simp [← Ici_inter_Iio]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Ioc (a b c : α) :
-    (fun x => a * x) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
+theorem preimage_const_mul_Ioc : (fun x => a * x) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
   simp [← Ioi_inter_Iic]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_mul_Ioo (a b c : α) :
-    (fun x => a * x) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
+theorem preimage_const_mul_Ioo : (fun x => a * x) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
   simp [← Ioi_inter_Iio]
 
 /-!
@@ -218,39 +214,35 @@ theorem preimage_const_mul_Ioo (a b c : α) :
 -/
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Ici (a b : α) : (fun x => x * a) ⁻¹' Ici b = Ici (b / a) :=
+theorem preimage_mul_const_Ici : (fun x => x * a) ⁻¹' Ici b = Ici (b / a) :=
   ext fun _x => div_le_iff_le_mul.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Ioi (a b : α) : (fun x => x * a) ⁻¹' Ioi b = Ioi (b / a) :=
+theorem preimage_mul_const_Ioi : (fun x => x * a) ⁻¹' Ioi b = Ioi (b / a) :=
   ext fun _x => div_lt_iff_lt_mul.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Iic (a b : α) : (fun x => x * a) ⁻¹' Iic b = Iic (b / a) :=
+theorem preimage_mul_const_Iic : (fun x => x * a) ⁻¹' Iic b = Iic (b / a) :=
   ext fun _x => le_div_iff_mul_le.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Iio (a b : α) : (fun x => x * a) ⁻¹' Iio b = Iio (b / a) :=
+theorem preimage_mul_const_Iio : (fun x => x * a) ⁻¹' Iio b = Iio (b / a) :=
   ext fun _x => lt_div_iff_mul_lt.symm
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Icc (a b c : α) :
-    (fun x => x * a) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
+theorem preimage_mul_const_Icc : (fun x => x * a) ⁻¹' Icc b c = Icc (b / a) (c / a) := by
   simp [← Ici_inter_Iic]
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Ico (a b c : α) :
-    (fun x => x * a) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
+theorem preimage_mul_const_Ico : (fun x => x * a) ⁻¹' Ico b c = Ico (b / a) (c / a) := by
   simp [← Ici_inter_Iio]
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Ioc (a b c : α) :
-    (fun x => x * a) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
+theorem preimage_mul_const_Ioc : (fun x => x * a) ⁻¹' Ioc b c = Ioc (b / a) (c / a) := by
   simp [← Ioi_inter_Iic]
 
 @[to_additive (attr := simp)]
-theorem preimage_mul_const_Ioo (a b c : α) :
-    (fun x => x * a) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
+theorem preimage_mul_const_Ioo : (fun x => x * a) ⁻¹' Ioo b c = Ioo (b / a) (c / a) := by
   simp [← Ioi_inter_Iio]
 
 /-!
@@ -258,39 +250,35 @@ theorem preimage_mul_const_Ioo (a b c : α) :
 -/
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Ici (a b : α) : (fun x => x / a) ⁻¹' Ici b = Ici (b * a) := by
+theorem preimage_div_const_Ici : (fun x => x / a) ⁻¹' Ici b = Ici (b * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Ioi (a b : α) : (fun x => x / a) ⁻¹' Ioi b = Ioi (b * a) := by
+theorem preimage_div_const_Ioi : (fun x => x / a) ⁻¹' Ioi b = Ioi (b * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Iic (a b : α) : (fun x => x / a) ⁻¹' Iic b = Iic (b * a) := by
+theorem preimage_div_const_Iic : (fun x => x / a) ⁻¹' Iic b = Iic (b * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Iio (a b : α) : (fun x => x / a) ⁻¹' Iio b = Iio (b * a) := by
+theorem preimage_div_const_Iio : (fun x => x / a) ⁻¹' Iio b = Iio (b * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Icc (a b c : α) :
-    (fun x => x / a) ⁻¹' Icc b c = Icc (b * a) (c * a) := by
+theorem preimage_div_const_Icc : (fun x => x / a) ⁻¹' Icc b c = Icc (b * a) (c * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Ico (a b c : α) :
-    (fun x => x / a) ⁻¹' Ico b c = Ico (b * a) (c * a) := by
+theorem preimage_div_const_Ico : (fun x => x / a) ⁻¹' Ico b c = Ico (b * a) (c * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Ioc (a b c : α) :
-    (fun x => x / a) ⁻¹' Ioc b c = Ioc (b * a) (c * a) := by
+theorem preimage_div_const_Ioc : (fun x => x / a) ⁻¹' Ioc b c = Ioc (b * a) (c * a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem preimage_div_const_Ioo (a b c : α) :
-    (fun x => x / a) ⁻¹' Ioo b c = Ioo (b * a) (c * a) := by
+theorem preimage_div_const_Ioo : (fun x => x / a) ⁻¹' Ioo b c = Ioo (b * a) (c * a) := by
   simp [div_eq_mul_inv]
 
 /-!
@@ -298,39 +286,35 @@ theorem preimage_div_const_Ioo (a b c : α) :
 -/
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Ici (a b : α) : (fun x => a / x) ⁻¹' Ici b = Iic (a / b) :=
+theorem preimage_const_div_Ici : (fun x => a / x) ⁻¹' Ici b = Iic (a / b) :=
   ext fun _x => le_div_comm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Iic (a b : α) : (fun x => a / x) ⁻¹' Iic b = Ici (a / b) :=
+theorem preimage_const_div_Iic : (fun x => a / x) ⁻¹' Iic b = Ici (a / b) :=
   ext fun _x => div_le_comm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Ioi (a b : α) : (fun x => a / x) ⁻¹' Ioi b = Iio (a / b) :=
+theorem preimage_const_div_Ioi : (fun x => a / x) ⁻¹' Ioi b = Iio (a / b) :=
   ext fun _x => lt_div_comm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Iio (a b : α) : (fun x => a / x) ⁻¹' Iio b = Ioi (a / b) :=
+theorem preimage_const_div_Iio : (fun x => a / x) ⁻¹' Iio b = Ioi (a / b) :=
   ext fun _x => div_lt_comm
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Icc (a b c : α) :
-    (fun x => a / x) ⁻¹' Icc b c = Icc (a / c) (a / b) := by
+theorem preimage_const_div_Icc : (fun x => a / x) ⁻¹' Icc b c = Icc (a / c) (a / b) := by
   simp [← Ici_inter_Iic, inter_comm]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Ico (a b c : α) :
-    (fun x => a / x) ⁻¹' Ico b c = Ioc (a / c) (a / b) := by
+theorem preimage_const_div_Ico : (fun x => a / x) ⁻¹' Ico b c = Ioc (a / c) (a / b) := by
   simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Ioc (a b c : α) :
-    (fun x => a / x) ⁻¹' Ioc b c = Ico (a / c) (a / b) := by
+theorem preimage_const_div_Ioc : (fun x => a / x) ⁻¹' Ioc b c = Ico (a / c) (a / b) := by
   simp [← Ioi_inter_Iic, ← Ici_inter_Iio, inter_comm]
 
 @[to_additive (attr := simp)]
-theorem preimage_const_div_Ioo (a b c : α) :
-    (fun x => a / x) ⁻¹' Ioo b c = Ioo (a / c) (a / b) := by
+theorem preimage_const_div_Ioo : (fun x => a / x) ⁻¹' Ioo b c = Ioo (a / c) (a / b) := by
   simp [← Ioi_inter_Iio, inter_comm]
 
 /-!
@@ -339,23 +323,21 @@ theorem preimage_const_div_Ioo (a b c : α) :
 
 -- simp can prove this modulo `mul_comm`
 @[to_additive]
-theorem image_const_mul_Iic (a b : α) :
-    (fun x => a * x) '' Iic b = Iic (a * b) := by simp [mul_comm]
+theorem image_const_mul_Iic : (fun x => a * x) '' Iic b = Iic (a * b) := by simp [mul_comm]
 
 -- simp can prove this modulo `mul_comm`
 @[to_additive]
-theorem image_const_mul_Iio (a b : α) :
-    (fun x => a * x) '' Iio b = Iio (a * b) := by simp [mul_comm]
+theorem image_const_mul_Iio : (fun x => a * x) '' Iio b = Iio (a * b) := by simp [mul_comm]
 
 /-!
 ### Images under `x ↦ x * a`
 -/
 
 @[to_additive]
-theorem image_mul_const_Iic (a b : α) : (fun x => x * a) '' Iic b = Iic (b * a) := by simp
+theorem image_mul_const_Iic : (fun x => x * a) '' Iic b = Iic (b * a) := by simp
 
 @[to_additive]
-theorem image_mul_const_Iio (a b : α) : (fun x => x * a) '' Iio b = Iio (b * a) := by simp
+theorem image_mul_const_Iio : (fun x => x * a) '' Iio b = Iio (b * a) := by simp
 
 
 /-!
@@ -393,42 +375,42 @@ theorem image_inv_Ioo : Inv.inv '' Ioo a b = Ioo (b⁻¹) (a⁻¹) := by simp
 -/
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Ici (a b : α) : (fun x => a / x) '' Ici b = Iic (a / b) := by
+theorem image_const_div_Ici : (fun x => a / x) '' Ici b = Iic (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Iic (a b : α) : (fun x => a / x) '' Iic b = Ici (a / b) := by
+theorem image_const_div_Iic : (fun x => a / x) '' Iic b = Ici (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Ioi (a b : α) : (fun x => a / x) '' Ioi b = Iio (a / b) := by
+theorem image_const_div_Ioi : (fun x => a / x) '' Ioi b = Iio (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Iio (a b : α) : (fun x => a / x) '' Iio b = Ioi (a / b) := by
+theorem image_const_div_Iio : (fun x => a / x) '' Iio b = Ioi (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Icc (a b c : α) : (fun x => a / x) '' Icc b c = Icc (a / c) (a / b) := by
+theorem image_const_div_Icc : (fun x => a / x) '' Icc b c = Icc (a / c) (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Ico (a b c : α) : (fun x => a / x) '' Ico b c = Ioc (a / c) (a / b) := by
+theorem image_const_div_Ico : (fun x => a / x) '' Ico b c = Ioc (a / c) (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Ioc (a b c : α) : (fun x => a / x) '' Ioc b c = Ico (a / c) (a / b) := by
+theorem image_const_div_Ioc : (fun x => a / x) '' Ioc b c = Ico (a / c) (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
 @[to_additive (attr := simp)]
-theorem image_const_div_Ioo (a b c : α) : (fun x => a / x) '' Ioo b c = Ioo (a / c) (a / b) := by
+theorem image_const_div_Ioo : (fun x => a / x) '' Ioo b c = Ioo (a / c) (a / b) := by
   have := image_comp (fun x => a * x) fun x => x⁻¹; dsimp [Function.comp_def] at this
   simp [div_eq_mul_inv, this, mul_comm]
 
@@ -437,35 +419,35 @@ theorem image_const_div_Ioo (a b c : α) : (fun x => a / x) '' Ioo b c = Ioo (a 
 -/
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ici (a b : α) :
+theorem image_div_const_Ici :
     (fun x => x / a) '' Ici b = Ici (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Iic (a b : α) :
+theorem image_div_const_Iic :
     (fun x => x / a) '' Iic b = Iic (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ioi (a b : α) :
+theorem image_div_const_Ioi :
     (fun x => x / a) '' Ioi b = Ioi (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Iio (a b : α) :
+theorem image_div_const_Iio :
     (fun x => x / a) '' Iio b = Iio (b / a) := by simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Icc (a b c : α) : (fun x => x / a) '' Icc b c = Icc (b / a) (c / a) := by
+theorem image_div_const_Icc : (fun x => x / a) '' Icc b c = Icc (b / a) (c / a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ico (a b c : α) : (fun x => x / a) '' Ico b c = Ico (b / a) (c / a) := by
+theorem image_div_const_Ico : (fun x => x / a) '' Ico b c = Ico (b / a) (c / a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ioc (a b c : α) : (fun x => x / a) '' Ioc b c = Ioc (b / a) (c / a) := by
+theorem image_div_const_Ioc : (fun x => x / a) '' Ioc b c = Ioc (b / a) (c / a) := by
   simp [div_eq_mul_inv]
 
 @[to_additive (attr := simp)]
-theorem image_div_const_Ioo (a b c : α) : (fun x => x / a) '' Ioo b c = Ioo (b / a) (c / a) := by
+theorem image_div_const_Ioo : (fun x => x / a) '' Ioo b c = Ioo (b / a) (c / a) := by
   simp [div_eq_mul_inv]
 
 /-!

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -173,9 +173,13 @@ lemma inv_Ioc (a b : α) : (Ioc a b)⁻¹ = Ico b⁻¹ a⁻¹ := by
 @[to_additive (attr := simp)]
 lemma inv_Ioo (a b : α) : (Ioo a b)⁻¹ = Ioo b⁻¹ a⁻¹ := by simp [← Ioi_inter_Iio, inter_comm]
 
+/-!
+### Preimages under `x ↦ a * x`
+-/
+
 @[to_additive (attr := simp)]
 theorem preimage_const_mul_Ici (a b : α) : (fun x => a * x) ⁻¹' Ici b = Ici (b / a) :=
-  ext fun _x => by simp; grind
+  ext fun _x => (div_le_iff_le_mul').symm
 
 @[to_additive (attr := simp)]
 theorem preimage_const_mul_Ioi (a b : α) : (fun x => a * x) ⁻¹' Ioi b = Ioi (b / a) :=

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -420,7 +420,7 @@ theorem doublingGamma_log_convex_Ioi : ConvexOn ℝ (Ioi (0 : ℝ)) (log ∘ dou
   · convert
       convexOn_log_Gamma.comp_affineMap (DistribSMul.toLinearMap ℝ ℝ (1 / 2 : ℝ)).toAffineMap
       using 1
-    · simpa only [zero_div] using (preimage_const_mul_Ioi (0 : ℝ) one_half_pos).symm
+    · simpa only [zero_div] using (preimage_const_mul_Ioi₀ (0 : ℝ) one_half_pos).symm
     · ext1 x
       simp only [LinearMap.coe_toAffineMap, Function.comp_apply, DistribSMul.toLinearMap_apply]
       rw [smul_eq_mul, mul_comm, mul_one_div]
@@ -431,7 +431,7 @@ theorem doublingGamma_log_convex_Ioi : ConvexOn ℝ (Ioi (0 : ℝ)) (log ∘ dou
           AffineMap.const ℝ ℝ (1 / 2 : ℝ)) using 1
     · change Ioi (-1 : ℝ) = ((fun x : ℝ => x + 1 / 2) ∘ fun x : ℝ => (1 / 2 : ℝ) * x) ⁻¹' Ioi 0
       rw [preimage_comp, preimage_add_const_Ioi, zero_sub,
-        preimage_const_mul_Ioi (_ : ℝ) one_half_pos, neg_div, div_self (@one_half_pos ℝ _).ne']
+        preimage_const_mul_Ioi₀ (_ : ℝ) one_half_pos, neg_div, div_self (@one_half_pos ℝ _).ne']
     · ext1 x
       change log (Gamma (x / 2 + 1 / 2)) = log (Gamma ((1 / 2 : ℝ) • x + 1 / 2))
       rw [smul_eq_mul, mul_comm, mul_one_div]

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -1087,7 +1087,7 @@ theorem integral_comp_mul_left_Ioi (g : ℝ → E) (a : ℝ) {b : ℝ} (hb : 0 <
     ← abs_of_pos (inv_pos.mpr hb), ← Measure.integral_comp_mul_left]
   congr
   ext1 x
-  rw [← indicator_comp_right, preimage_const_mul_Ioi _ hb, mul_div_cancel_left₀ _ hb.ne',
+  rw [← indicator_comp_right, preimage_const_mul_Ioi₀ _ hb, mul_div_cancel_left₀ _ hb.ne',
     Function.comp_def]
 
 theorem integral_comp_mul_right_Ioi (g : ℝ → E) (a : ℝ) {b : ℝ} (hb : 0 < b) :
@@ -1142,7 +1142,7 @@ theorem integrableOn_Ioi_comp_mul_left_iff (f : ℝ → E) (c : ℝ) {a : ℝ} (
   rw [← integrable_indicator_iff (measurableSet_Ioi : MeasurableSet <| Ioi <| a * c)]
   convert integrable_comp_mul_left_iff ((Ioi (a * c)).indicator f) ha.ne' using 2
   ext1 x
-  rw [← indicator_comp_right, preimage_const_mul_Ioi _ ha, mul_comm a c,
+  rw [← indicator_comp_right, preimage_const_mul_Ioi₀ _ ha, mul_comm a c,
     mul_div_cancel_right₀ _ ha.ne', Function.comp_def]
 
 theorem integrableOn_Ioi_comp_mul_right_iff (f : ℝ → E) (c : ℝ) {a : ℝ} (ha : 0 < a) :

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -312,7 +312,7 @@ theorem smul_map_volume_mul_left {a : ℝ} (h : a ≠ 0) :
       preimage_const_mul_Ioo_of_neg _ _ h, abs_of_neg h, mul_sub, smul_eq_mul,
       mul_div_cancel₀ _ (ne_of_lt h)]
   · simp only [Real.volume_Ioo, Measure.smul_apply, ← ENNReal.ofReal_mul (le_of_lt h),
-      Measure.map_apply (measurable_const_mul a) measurableSet_Ioo, preimage_const_mul_Ioo _ _ h,
+      Measure.map_apply (measurable_const_mul a) measurableSet_Ioo, preimage_const_mul_Ioo₀ _ _ h,
       abs_of_pos h, mul_sub, mul_div_cancel₀ _ (ne_of_gt h), smul_eq_mul]
 
 theorem map_volume_mul_left {a : ℝ} (h : a ≠ 0) :

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -297,7 +297,7 @@ instance (priority := 100) IsStrictOrderedRing.toIsTopologicalDivisionRing :
 
 -- TODO: generalize to a `GroupWithZero`
 theorem comap_mulLeft_nhdsGT_zero {x : 𝕜} (hx : 0 < x) : comap (x * ·) (𝓝[>] 0) = 𝓝[>] 0 := by
-  rw [nhdsWithin, comap_inf, comap_principal, preimage_const_mul_Ioi _ hx, zero_div]
+  rw [nhdsWithin, comap_inf, comap_principal, preimage_const_mul_Ioi₀ _ hx, zero_div]
   congr 1
   refine ((Homeomorph.mulLeft₀ x hx.ne').comap_nhds_eq _).trans ?_
   simp


### PR DESCRIPTION
Currently, `Mathlib/Algebra/Order/Group/Pointwise/Interval.lean` contains lemmas about (pre)images of intervals under group operations only for additive groups. This PR adds multiplicative versions and derives the additive ones via `to_additive`.

It also renames lemmas about `GroupWithZero` (e.g. `preimage_const_mul_Ico` → `preimage_const_mul_Ico₀`) to avoid name collisions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
