### PR TITLE
[Merged by Bors] - chore: fix and re-enable differential geometry elaborators test

### DIFF
--- a/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
+++ b/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
@@ -369,22 +369,20 @@ Hint: failures to find a model with corners can be debugged with the command `se
 -- TODO: the error message could be more helpful.
 variable {E'''' : Type*} [NormedAddCommGroup E''''] [NormedSpace ℝ E''''] (σ : ℝ →+* ℝ) [RingHomIsometric σ]
 
--- FIXME: the error message is non-deterministic because of different universe levels,
--- normalise this somehow and re-enable this test!
 variable {f : M → E'' →SL[σ] E''''} in
-/-
+/--
 error: Application type mismatch: The argument
   𝓘(ℝ, E'' →SL[σ] E'''')
 has type
   ModelWithCorners.{0, max u_11 u_13, max u_11 u_13} ℝ (E'' →SL[σ] E'''') (E'' →SL[σ] E'''')
 but is expected to have type
-  ModelWithCorners.{u_1, ?u.235761, ?u.235762} 𝕜 ?E' ?H'
+  ModelWithCorners.{u_1, _, _} 𝕜 ?_ ?_
 in the application
-  @ContMDiff 𝕜 inst✝³⁰ E inst✝²⁹ inst✝²⁸ H inst✝²⁷ I ?M ?inst✝ ?inst✝¹ ?E' ?inst✝² ?inst✝³ ?H' ?inst✝⁴
-    𝓘(ℝ, E'' →SL[σ] E'''')
+  @ContMDiff 𝕜 inst✝³⁰ E inst✝²⁹ inst✝²⁸ H inst✝²⁷ I ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ 𝓘(ℝ, E'' →SL[σ] E'''')
 -/
---#guard_msgs in
---#check CMDiff 2 f
+#guard_msgs in
+set_option pp.mvars false in
+#check CMDiff 2 f
 
 end
 

--- a/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
+++ b/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
@@ -376,12 +376,13 @@ error: Application type mismatch: The argument
 has type
   ModelWithCorners.{0, max u_11 u_13, max u_11 u_13} ℝ (E'' →SL[σ] E'''') (E'' →SL[σ] E'''')
 but is expected to have type
-  ModelWithCorners.{u_1, _, _} 𝕜 ?_ ?_
+  ModelWithCorners.{u_1, _, _} 𝕜 ?E' ?H'
 in the application
-  @ContMDiff 𝕜 inst✝³⁰ E inst✝²⁹ inst✝²⁸ H inst✝²⁷ I ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ 𝓘(ℝ, E'' →SL[σ] E'''')
+  @ContMDiff 𝕜 inst✝³⁰ E inst✝²⁹ inst✝²⁸ H inst✝²⁷ I ?M ?inst✝ ?inst✝¹ ?E' ?inst✝² ?inst✝³ ?H' ?inst✝⁴
+    𝓘(ℝ, E'' →SL[σ] E'''')
 -/
 #guard_msgs in
-set_option pp.mvars false in
+set_option pp.mvars.anonymous false in
 #check CMDiff 2 f
 
 end


### PR DESCRIPTION
`set_option pp.mvars false` normalises the universe levels, making the output sufficiently deterministic.
Follow-up to #30744.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
