### PR TITLE
[Merged by Bors] - feat(RingTheory/UniqueFactorizationDomain/Basic): associated elements have the same number of factors

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -110,6 +110,18 @@ theorem factors_unique {f g : Multiset α} (hf : ∀ x ∈ f, Irreducible x)
   prime_factors_unique (fun x hx => UniqueFactorizationMonoid.irreducible_iff_prime.mp (hf x hx))
     (fun x hx => UniqueFactorizationMonoid.irreducible_iff_prime.mp (hg x hx)) h
 
+theorem _root_.Associated.card_factors_eq {a b : α} (h : Associated a b) :
+    (factors a).card = (factors b).card := by
+  by_cases hb : b = 0
+  · rw [hb, associated_zero_iff_eq_zero] at h
+    rw [h, hb]
+  have ha : a ≠ 0 := h.ne_zero_iff.mpr hb
+  by_cases hb : b = 0
+  · simp [hb, ha] at h
+  apply Multiset.card_eq_card_of_rel
+  apply factors_unique irreducible_of_factor irreducible_of_factor
+  exact (factors_prod ha).trans <| h.trans (factors_prod hb).symm
+
 end UniqueFactorizationMonoid
 
 /-- If an irreducible has a prime factorization,

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -113,8 +113,7 @@ theorem factors_unique {f g : Multiset α} (hf : ∀ x ∈ f, Irreducible x)
 theorem _root_.Associated.card_factors_eq {a b : α} (h : Associated a b) :
     (factors a).card = (factors b).card := by
   by_cases hb : b = 0
-  · rw [hb, associated_zero_iff_eq_zero] at h
-    rw [h, hb]
+  · simp_all
   have ha : a ≠ 0 := h.ne_zero_iff.mpr hb
   by_cases hb : b = 0
   · simp [hb, ha] at h

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -115,8 +115,6 @@ theorem _root_.Associated.card_factors_eq {a b : α} (h : Associated a b) :
   by_cases hb : b = 0
   · simp_all
   have ha : a ≠ 0 := h.ne_zero_iff.mpr hb
-  by_cases hb : b = 0
-  · simp [hb, ha] at h
   apply Multiset.card_eq_card_of_rel
   apply factors_unique irreducible_of_factor irreducible_of_factor
   exact (factors_prod ha).trans <| h.trans (factors_prod hb).symm


### PR DESCRIPTION
This PR proves that associated elements have the same number of factors (this follows from the preceeding lemma `factors_unique`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
