### PR TITLE
[Merged by Bors] - chore(Analysis/Normed/Lp/SmoothApprox): shake public imports

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
+++ b/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Calculus.ContDiff.Defs
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+
 import Mathlib.Geometry.Manifold.SmoothApprox
 import Mathlib.MeasureTheory.Function.ContinuousMapDense
 

--- a/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
+++ b/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
@@ -5,8 +5,11 @@ Authors: Moritz Doll
 -/
 module
 
-public import Mathlib.Geometry.Manifold.SmoothApprox
-public import Mathlib.MeasureTheory.Function.ContinuousMapDense
+public import Mathlib.Analysis.Calculus.ContDiff.Defs
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+import Mathlib.Geometry.Manifold.SmoothApprox
+import Mathlib.MeasureTheory.Function.ContinuousMapDense
 
 /-!
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
@@ -11,6 +11,7 @@ public import Mathlib.NumberTheory.LSeries.Dirichlet
 public import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
 public import Mathlib.NumberTheory.ModularForms.EisensteinSeries.Basic
 public import Mathlib.NumberTheory.TsumDivisorsAntidiagonal
+import Mathlib.Topology.EMetricSpace.Paracompact
 
 /-!
 # Eisenstein series q-expansions


### PR DESCRIPTION
`lake shake --keep-implied --keep-prefix --fix --only Mathlib.Analysis.Normed.Lp.SmoothApprox`, using a dev version of `shake`