### PR TITLE
feat: define Boolean circuits over abstract gate families

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3383,11 +3383,12 @@ public import Mathlib.Computability.AkraBazzi.AkraBazzi
 public import Mathlib.Computability.AkraBazzi.GrowsPolynomially
 public import Mathlib.Computability.AkraBazzi.SumTransform
 public import Mathlib.Computability.Circuit.Basic
-public import Mathlib.Computability.Circuit.Gate
 public import Mathlib.Computability.ContextFreeGrammar
 public import Mathlib.Computability.DFA
 public import Mathlib.Computability.Encoding
 public import Mathlib.Computability.EpsilonNFA
+public import Mathlib.Computability.Formula.Basic
+public import Mathlib.Computability.Gate
 public import Mathlib.Computability.Halting
 public import Mathlib.Computability.Language
 public import Mathlib.Computability.MyhillNerode

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3382,6 +3382,8 @@ public import Mathlib.Computability.AkraBazzi.AkraBazzi
 public import Mathlib.Computability.AkraBazzi.GrowsPolynomially
 public import Mathlib.Computability.AkraBazzi.SumTransform
 public import Mathlib.Computability.ContextFreeGrammar
+public import Mathlib.Computability.Circuit.Basic
+public import Mathlib.Computability.Circuit.Gate
 public import Mathlib.Computability.DFA
 public import Mathlib.Computability.Encoding
 public import Mathlib.Computability.EpsilonNFA

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3382,9 +3382,9 @@ public import Mathlib.Computability.Ackermann
 public import Mathlib.Computability.AkraBazzi.AkraBazzi
 public import Mathlib.Computability.AkraBazzi.GrowsPolynomially
 public import Mathlib.Computability.AkraBazzi.SumTransform
-public import Mathlib.Computability.ContextFreeGrammar
 public import Mathlib.Computability.Circuit.Basic
 public import Mathlib.Computability.Circuit.Gate
+public import Mathlib.Computability.ContextFreeGrammar
 public import Mathlib.Computability.DFA
 public import Mathlib.Computability.Encoding
 public import Mathlib.Computability.EpsilonNFA

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -15,6 +15,25 @@ This file defines a basic notion of Boolean circuits as *syntax trees* over an a
 
 The representation deliberately does not include explicit sharing (DAG circuits). It is intended as
 a minimal foundation for later definitions (size/depth measures, families, and non-uniform classes).
+
+## Main definitions
+
+* `Circuit G n`: Boolean circuit over gate family `G` with `n` input wires
+* `Circuit.eval`: evaluate a circuit on an input assignment
+* `Circuit.mapGate`: transform gate labels via a `GateHom`
+* `Circuit.mapInputs`: rename/reindex circuit inputs
+* `Circuit.subst`: substitute each input wire by a circuit
+
+## Main theorems
+
+* `Circuit.eval_mapGate`: evaluation commutes with gate mapping (given semantic compatibility)
+* `Circuit.eval_mapInputs`: evaluation commutes with input renaming
+* `Circuit.eval_subst`: evaluation commutes with substitution
+* `Circuit.mapGate_comp`, `Circuit.subst_comp`: composition laws
+
+## Tags
+
+circuit, Boolean, syntax tree, evaluation
 -/
 
 @[expose] public section
@@ -178,10 +197,7 @@ theorem mapGate_id (c : Circuit G n) :
   induction c with
   | input i => rfl
   | const b => rfl
-  | gate g f ih =>
-      simp only [mapGate_gate, GateHom.id_map, gate.injEq, heq_eq_eq, true_and]
-      funext i
-      simpa using ih i
+  | gate g f ih => simp [ih]
 
 theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c : Circuit G n) :
     mapGate (G := G) (n := n) (GateHom.comp g f) c =
@@ -189,10 +205,7 @@ theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c
   induction c with
   | input i => rfl
   | const b => rfl
-  | gate g₀ f₀ ih =>
-      simp only [mapGate_gate, GateHom.comp_map, gate.injEq, heq_eq_eq, true_and]
-      funext i
-      simpa using ih i
+  | gate g₀ f₀ ih => simp [ih]
 
 end Circuit
 

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -157,8 +157,9 @@ theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom 
   | gate g f ih =>
       simp [mapGate, eval, hφ, ih]
 
+@[simp]
 theorem mapInputs_id (c : Circuit G n) :
-    mapInputs (G := G) c (fun i => i) = c := by
+    mapInputs c id = c := by
   induction c with
   | input i => rfl
   | const b => rfl

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -193,8 +193,9 @@ theorem subst_comp {m ℓ n : Nat} (c : Circuit G n) (σ₁ : Fin n → Circuit 
   | gate g f ih =>
       simp [subst, ih]
 
-theorem mapGate_id (c : Circuit G n) :
-    mapGate (G := G) (n := n) (GateHom.id G) c = c := by
+@[simp]
+theorem mapGate_id {G : ℕ → Type} {n : Nat} (c : Circuit G n) :
+    mapGate (GateHom.id G) c = c := by
   induction c with
   | input i => rfl
   | const b => rfl

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -5,209 +5,435 @@ Authors: Dennj Osele
 -/
 module
 
-public import Mathlib.Computability.Circuit.Gate
+public import Mathlib.Computability.Gate
+public import Mathlib.Data.Fin.Tuple.Basic
+public import Mathlib.Data.Finset.Lattice.Fold
 
 /-!
-# Circuits (syntax trees)
+# Boolean circuits (DAGs with explicit sharing)
 
-This file defines a basic notion of Boolean circuits as *syntax trees* over an abstract gate family
-`G : Nat → Type` equipped with semantics `[GateEval G]`.
+This file defines Boolean circuits as *topologically indexed* DAGs.
 
-The representation deliberately does not include explicit sharing (DAG circuits). It is intended as
-a minimal foundation for later definitions (size/depth measures, families, and non-uniform classes).
+In circuit complexity, a **circuit** is a DAG where gates can have arbitrary fan-out (sharing).
+This contrasts with **formulas** (see `Formula` in `Formula/Basic.lean`) which are trees with
+fan-out 1.
+
+The key idea is to index nodes by natural numbers and require that a node at index `i` may only
+refer to predecessors `< i`. This gives acyclicity and enables evaluation by simple recursion over
+the prefix length. This representation is equivalent to a straight-line program.
 
 ## Main definitions
 
-* `Circuit G n`: Boolean circuit over gate family `G` with `n` input wires
-* `Circuit.eval`: evaluate a circuit on an input assignment
-* `Circuit.mapGate`: transform gate labels via a `GateHom`
-* `Circuit.mapInputs`: rename/reindex circuit inputs
-* `Circuit.subst`: substitute each input wire by a circuit
-
-## Main theorems
-
-* `Circuit.eval_mapGate`: evaluation commutes with gate mapping (given semantic compatibility)
-* `Circuit.eval_mapInputs`: evaluation commutes with input renaming
-* `Circuit.eval_subst`: evaluation commutes with substitution
-* `Circuit.mapGate_comp`, `Circuit.subst_comp`: composition laws
+* `CircuitNode G n i`: a node at index `i` (input, constant, or gate referencing earlier nodes)
+* `CircuitDAG G n`: the underlying DAG structure (nodes indexed 0 to N-1)
+* `Circuit G n`: a DAG circuit with a designated output node
 
 ## Tags
 
-circuit, Boolean, syntax tree, evaluation
+circuit, Boolean, DAG, sharing, straight-line program, circuit complexity
 -/
 
 @[expose] public section
 
 namespace Computability
 
-/-- A Boolean circuit over gate labels `G` with `n` input wires. -/
-inductive Circuit (G : Nat → Type) (n : Nat) : Type where
-  | input : Fin n → Circuit G n
-  | const : Bool → Circuit G n
-  | gate {k : Nat} : G k → (Fin k → Circuit G n) → Circuit G n
-
-namespace Circuit
+open Gate
 
 variable {G : Nat → Type} {n : Nat}
 
-/-- Map gate labels along a `GateHom`. -/
-def mapGate {H : Nat → Type} (φ : GateHom G H) : Circuit G n → Circuit H n
-  | input i => input i
-  | const b => const b
-  | gate g f => gate (φ.map g) (fun i => mapGate φ (f i))
+/-- A node at index `i` is either an input wire, a constant, or a gate whose children are indexed by
+`Fin i` (so they are strictly earlier). -/
+inductive CircuitNode (G : Nat → Type) (n : Nat) (i : Nat) : Type where
+  | input : Fin n → CircuitNode G n i
+  | const : Bool → CircuitNode G n i
+  | gate : {k : Nat} → G k → (Fin k → Fin i) → CircuitNode G n i
 
-@[simp] theorem mapGate_input {H : Nat → Type} (φ : GateHom G H) (i : Fin n) :
-    mapGate φ (input i) = input i :=
+namespace CircuitNode
+
+variable {i : Nat}
+
+section DecidableEq
+
+variable [∀ k, DecidableEq (G k)]
+
+/-- Decidable equality for circuit nodes, given decidable equality on gate labels. -/
+protected def decEq : (nd₁ nd₂ : CircuitNode G n i) → Decidable (nd₁ = nd₂)
+  | .input j₁, .input j₂ =>
+      if h : j₁ = j₂ then isTrue (h ▸ rfl) else isFalse fun h' => by cases h'; exact h rfl
+  | .const b₁, .const b₂ =>
+      if h : b₁ = b₂ then isTrue (h ▸ rfl) else isFalse fun h' => by cases h'; exact h rfl
+  | .gate (k := k₁) g₁ f₁, .gate (k := k₂) g₂ f₂ =>
+      if hk : k₁ = k₂ then
+        let g₂' : G k₁ := hk ▸ g₂
+        let f₂' : Fin k₁ → Fin i := fun j => f₂ (hk ▸ j)
+        if hg : g₁ = g₂' then
+          if hf : ∀ j, f₁ j = f₂' j then
+            isTrue (by subst hk hg; congr; funext j; exact hf j)
+          else isFalse fun h => by cases h; exact hf fun _ => rfl
+        else isFalse fun h => by cases h; exact hg rfl
+      else isFalse fun h => by cases h; exact hk rfl
+  | .input _, .const _ | .input _, .gate _ _ | .const _, .input _
+  | .const _, .gate _ _ | .gate _ _, .input _ | .gate _ _, .const _ => isFalse nofun
+
+instance [∀ k, DecidableEq (G k)] : DecidableEq (CircuitNode G n i) := CircuitNode.decEq
+
+end DecidableEq
+
+end CircuitNode
+
+/-- A circuit DAG is given by a number of nodes `N` and an assignment of a node-description to each
+index `i < N`. -/
+structure CircuitDAG (G : Nat → Type) (n : Nat) : Type where
+  /-- Number of nodes. -/
+  N : Nat
+  /-- Node-description at each index `i < N`. -/
+  node : ∀ i : Nat, i < N → CircuitNode G n i
+
+namespace CircuitDAG
+
+/-- The empty DAG (with no nodes). -/
+def empty (G : Nat → Type) (n : Nat) : CircuitDAG G n :=
+  ⟨0, fun i hi => (Nat.not_lt_zero i hi).elim⟩
+
+instance : Inhabited (CircuitDAG G n) :=
+  ⟨empty G n⟩
+
+/-- Append a new node at the end (at index `d.N`). -/
+def snoc (d : CircuitDAG G n) (nd : CircuitNode G n d.N) : CircuitDAG G n :=
+  ⟨d.N + 1, fun i hi =>
+    if h : i < d.N then d.node i h else Nat.eq_of_lt_succ_of_not_lt hi h ▸ nd⟩
+
+@[simp] theorem snoc_N (d : CircuitDAG G n) (nd : CircuitNode G n d.N) : (snoc d nd).N = d.N + 1 :=
   rfl
 
-@[simp] theorem mapGate_const {H : Nat → Type} (φ : GateHom G H) (b : Bool) :
-    mapGate φ (const (n := n) b) = const b :=
+@[simp] theorem snoc_node_lt (d : CircuitDAG G n) (nd : CircuitNode G n d.N) {i : Nat}
+    (hi : i < d.N) : (snoc d nd).node i (lt_trans hi (Nat.lt_succ_self _)) = d.node i hi := by
+  simp [snoc, hi]
+
+@[simp] theorem snoc_node_last (d : CircuitDAG G n) (nd : CircuitNode G n d.N) :
+    (snoc d nd).node d.N (Nat.lt_succ_self _) = nd := by
+  simp [snoc]
+
+/-- `d₀` is a prefix of `d₁` if `d₁` has at least as many nodes and agrees with `d₀` on all earlier
+nodes. -/
+structure Prefix (d₀ d₁ : CircuitDAG G n) : Prop where
+  le : d₀.N ≤ d₁.N
+  node_eq : ∀ i (hi : i < d₀.N), d₁.node i (lt_of_lt_of_le hi le) = d₀.node i hi
+
+namespace Prefix
+
+theorem refl (d : CircuitDAG G n) : Prefix d d :=
+  ⟨le_rfl, fun _ _ => rfl⟩
+
+theorem trans {d₀ d₁ d₂ : CircuitDAG G n} (h₀₁ : Prefix d₀ d₁) (h₁₂ : Prefix d₁ d₂) :
+    Prefix d₀ d₂ :=
+  ⟨le_trans h₀₁.le h₁₂.le,
+    fun i hi => by simpa [h₀₁.node_eq i hi] using h₁₂.node_eq i (lt_of_lt_of_le hi h₀₁.le)⟩
+
+theorem snoc (d : CircuitDAG G n) (nd : CircuitNode G n d.N) : Prefix d (CircuitDAG.snoc d nd) :=
+  ⟨Nat.le_succ _, fun i hi => by simpa using snoc_node_lt (d := d) (nd := nd) (hi := hi)⟩
+
+end Prefix
+
+/-- Rename inputs of a circuit DAG by applying `ρ` to input references. -/
+def mapInputs {m : Nat} (ρ : Fin n → Fin m) (d : CircuitDAG G n) : CircuitDAG G m :=
+  { N := d.N
+    node := fun i hi =>
+      match d.node i hi with
+      | .input j => .input (ρ j)
+      | .const b => .const b
+      | .gate g f => .gate g f }
+
+/-- Relabel gates of a circuit DAG using an arity-preserving map. -/
+def mapGate {H : Nat → Type} (φ : GateHom G H) (d : CircuitDAG G n) : CircuitDAG H n :=
+  { N := d.N
+    node := fun i hi =>
+      match d.node i hi with
+      | .input j => .input j
+      | .const b => .const b
+      | .gate g f => .gate (φ.map g) f }
+
+@[simp] theorem mapInputs_N {m : Nat} (ρ : Fin n → Fin m) (d : CircuitDAG G n) :
+    (mapInputs ρ d).N = d.N :=
   rfl
 
-@[simp] theorem mapGate_gate {H : Nat → Type} (φ : GateHom G H) {k : Nat} (g : G k)
-    (f : Fin k → Circuit G n) :
-    mapGate φ (gate g f) = gate (φ.map g) (fun i => mapGate φ (f i)) :=
+@[simp] theorem mapGate_N {H : Nat → Type} (φ : GateHom G H) (d : CircuitDAG G n) :
+    (d.mapGate φ).N = d.N :=
   rfl
+
+@[simp] theorem mapInputs_id (d : CircuitDAG G n) :
+    mapInputs id d = d := by
+  simp only [mapInputs, id_eq]
+  congr 1
+  funext i hi
+  cases d.node i hi <;> rfl
+
+theorem mapInputs_comp {m ℓ : Nat} (ρ₁ : Fin n → Fin m) (ρ₂ : Fin m → Fin ℓ)
+    (d : CircuitDAG G n) :
+    mapInputs ρ₂ (mapInputs ρ₁ d) = mapInputs (fun i => ρ₂ (ρ₁ i)) d := by
+  simp only [mapInputs]
+  congr 1
+  funext i hi
+  cases d.node i hi <;> rfl
+
+@[simp] theorem mapGate_id (d : CircuitDAG G n) :
+    d.mapGate (GateHom.id G) = d := by
+  simp only [mapGate]
+  congr 1
+  funext i hi
+  cases d.node i hi <;> rfl
+
+theorem mapGate_comp {H K : Nat → Type} (ψ : GateHom H K) (φ : GateHom G H) (d : CircuitDAG G n) :
+    (d.mapGate φ).mapGate ψ = d.mapGate (GateHom.comp ψ φ) := by
+  simp only [mapGate]
+  congr 1
+  funext i hi
+  cases d.node i hi <;> rfl
+
+section Eval
+
+variable [GateEval G]
+
+/-- Evaluate the first `m` nodes of a circuit DAG, producing a vector of Boolean values
+of length `m`. -/
+def evalVec (d : CircuitDAG G n) (x : Fin n → Bool) : (m : Nat) → (hm : m ≤ d.N) → Fin m → Bool
+  | 0, _ => Fin.elim0
+  | m + 1, hm =>
+      let vals := evalVec d x m (le_trans (Nat.le_succ m) hm)
+      let nd := d.node m (lt_of_lt_of_le (Nat.lt_succ_self m) hm)
+      let v : Bool :=
+        match nd with
+        | .input i => x i
+        | .const b => b
+        | .gate g f => GateEval.eval g fun j => vals (f j)
+      Fin.snoc vals v
+
+@[simp] theorem evalVec_zero (d : CircuitDAG G n) (x : Fin n → Bool) (hm : 0 ≤ d.N) :
+    d.evalVec x 0 hm = Fin.elim0 :=
+  rfl
+
+/-- Proof-irrelevance for the `m ≤ N` argument of `evalVec`. -/
+theorem evalVec_congr_hm (d : CircuitDAG G n) (x : Fin n → Bool) (m : Nat) {hm₁ hm₂ : m ≤ d.N} :
+    d.evalVec x m hm₁ = d.evalVec x m hm₂ := by
+  cases Subsingleton.elim hm₁ hm₂
+  rfl
+
+/-- Increasing the prefix length of `evalVec` does not change earlier entries. -/
+theorem evalVec_castLE (d : CircuitDAG G n) (x : Fin n → Bool) (m : Nat) (hm : m ≤ d.N) :
+    ∀ m' (hm' : m' ≤ d.N) (hmm' : m ≤ m') (i : Fin m),
+      d.evalVec x m' hm' (Fin.castLE hmm' i) = d.evalVec x m hm i := by
+  intro m' hm' hmm' i; induction m' with
+  | zero => exact (Nat.le_zero.mp hmm' ▸ i).elim0
+  | succ m' ih =>
+      rcases Nat.lt_or_eq_of_le hmm' with hlt | rfl
+      · have : Fin.castLE hmm' i = (Fin.castLE (Nat.lt_succ_iff.mp hlt) i).castSucc := by ext; simp
+        simp only [evalVec, this, Fin.snoc_castSucc, ih (Nat.le_of_succ_le hm')]
+      · simp
+
+/-- Evaluate a node at index `i`. -/
+def evalAt (d : CircuitDAG G n) (x : Fin n → Bool) (i : Nat) (hi : i < d.N) : Bool :=
+  d.evalVec x d.N le_rfl ⟨i, hi⟩
+
+/-- Unfold `evalAt` at a node by looking at the node label. -/
+theorem evalAt_eq_node (d : CircuitDAG G n) (x : Fin n → Bool) {i : Nat} (hi : i < d.N) :
+    d.evalAt x i hi =
+      match d.node i hi with
+      | .input j => x j
+      | .const b => b
+      | .gate g f =>
+          GateEval.eval g fun j =>
+            d.evalAt x (f j).1 (lt_trans (f j).2 hi) := by
+  have hm : i + 1 ≤ d.N := Nat.succ_le_of_lt hi
+  have hm' : i ≤ d.N := Nat.le_of_succ_le hm
+  have heq : d.evalVec x d.N le_rfl ⟨i, hi⟩ = d.evalVec x (i + 1) hm (Fin.last i) := by
+    simpa using d.evalVec_castLE x (i + 1) hm d.N le_rfl hm (Fin.last i)
+  have hchild : ∀ j : Fin i, d.evalVec x i hm' j = d.evalAt x j (lt_trans j.isLt hi) := fun j =>
+    by simpa using (d.evalVec_castLE x i hm' d.N le_rfl hm' j).symm
+  cases hnd : d.node i hi <;> simpa [evalAt, evalVec, hnd, hchild] using heq
+
+theorem evalAt_mapInputs {m : Nat} (ρ : Fin n → Fin m) (d : CircuitDAG G n) (x : Fin m → Bool)
+    (i : Nat) (hi : i < d.N) :
+    (mapInputs ρ d).evalAt x i hi = d.evalAt (fun j => x (ρ j)) i hi := by
+  revert hi; refine Nat.strong_induction_on i ?_; intro i ih hi
+  rw [evalAt_eq_node, evalAt_eq_node]
+  cases hnd : d.node i hi with
+  | input j => simp [CircuitDAG.mapInputs, hnd]
+  | const b => simp [CircuitDAG.mapInputs, hnd]
+  | gate g f =>
+      simp only [CircuitDAG.mapInputs, hnd]
+      congr 1; funext j; exact ih (f j).1 (f j).2 (lt_trans (f j).2 hi)
+
+/-- If `d₀` is a prefix of `d₁`, then evaluation on any prefix length `m ≤ d₀.N` agrees. -/
+theorem evalVec_eq_of_prefix {d₀ d₁ : CircuitDAG G n} (h : Prefix (G := G) (n := n) d₀ d₁)
+    (x : Fin n → Bool) :
+    ∀ m (hm : m ≤ d₀.N), d₁.evalVec x m (le_trans hm h.le) = d₀.evalVec x m hm := by
+  intro m hm; induction m with
+  | zero => rfl
+  | succ m ih =>
+      have hm0 : m ≤ d₀.N := Nat.le_of_succ_le hm
+      have hn0 : m < d₀.N := Nat.lt_of_succ_le hm
+      have hnode : d₁.node m (lt_of_lt_of_le hn0 h.le) = d₀.node m hn0 := by
+        simpa using h.node_eq m hn0
+      funext i; induction i using Fin.lastCases with
+      | cast j => simp only [evalVec, Fin.snoc_castSucc]; exact congrFun (ih hm0) j
+      | last => simp [evalVec, ih hm0, hnode]
+
+/-- If `d₀` is a prefix of `d₁`, then evaluation of earlier nodes agrees. -/
+theorem evalAt_eq_of_prefix {d₀ d₁ : CircuitDAG G n} (h : Prefix (G := G) (n := n) d₀ d₁)
+    (x : Fin n → Bool) {i : Nat} (hi : i < d₀.N) :
+    d₁.evalAt x i (lt_of_lt_of_le hi h.le) = d₀.evalAt x i hi := by
+  simp only [evalAt]
+  calc d₁.evalVec x d₁.N le_rfl ⟨i, _⟩
+      = d₁.evalVec x d₀.N h.le ⟨i, hi⟩ := by
+          simpa using d₁.evalVec_castLE x d₀.N h.le d₁.N le_rfl h.le ⟨i, hi⟩
+    _ = d₀.evalVec x d₀.N le_rfl ⟨i, hi⟩ := congrFun (evalVec_eq_of_prefix h x d₀.N le_rfl) _
+
+/-- Appending a node does not change the values of earlier nodes. -/
+theorem evalAt_snoc_of_lt (d : CircuitDAG G n) (nd : CircuitNode G n d.N) (x : Fin n → Bool)
+    {i : Nat} (hi : i < d.N) :
+    (snoc d nd).evalAt x i (lt_trans hi (Nat.lt_succ_self _)) = d.evalAt x i hi := by
+  simpa using evalAt_eq_of_prefix (Prefix.snoc d nd) x hi
+
+/-- The value of the newly appended node. -/
+theorem evalAt_snoc_last (d : CircuitDAG G n) (nd : CircuitNode G n d.N) (x : Fin n → Bool) :
+    (snoc d nd).evalAt x d.N (Nat.lt_succ_self _) =
+      match nd with
+      | .input i => x i
+      | .const b => b
+      | .gate g f => GateEval.eval g fun j => d.evalAt x (f j).1 (f j).2 := by
+  have hlast : (⟨d.N, Nat.lt_succ_self _⟩ : Fin (d.N + 1)) = Fin.last d.N := rfl
+  have hvals : ∀ nd', (snoc d nd').evalVec x d.N (Nat.le_succ d.N) = d.evalVec x d.N le_rfl := by
+    intro nd'; simpa using evalVec_eq_of_prefix (Prefix.snoc (nd := nd')) x d.N le_rfl
+  unfold evalAt
+  cases nd <;> simpa [hlast, evalAt] using (by simp [evalVec, CircuitDAG.snoc_node_last, hvals])
+
+end Eval
+
+end CircuitDAG
+
+/-- A Boolean circuit is a DAG together with a designated output node.
+
+In circuit complexity, circuits allow sharing (fan-out > 1), unlike formulas which are trees.
+The size of a circuit is the number of nodes (gates + inputs + constants). -/
+structure Circuit (G : Nat → Type) (n : Nat) : Type extends CircuitDAG G n where
+  /-- Output node. -/
+  out : Fin N
+
+namespace Circuit
+
+variable [GateEval G]
 
 /-- Evaluate a circuit on an input assignment. -/
-def eval [GateEval G] : Circuit G n → (Fin n → Bool) → Bool
-  | input i, x => x i
-  | const b, _ => b
-  | gate g f, x => GateEval.eval g fun i => eval (f i) x
+def eval (c : Circuit G n) (x : Fin n → Bool) : Bool :=
+  c.toCircuitDAG.evalAt x c.out.1 c.out.2
 
-@[simp] theorem eval_input [GateEval G] (i : Fin n) (x : Fin n → Bool) :
-    eval (input (G := G) i) x = x i :=
+@[simp] theorem eval_def (c : Circuit G n) (x : Fin n → Bool) :
+    c.eval x = c.toCircuitDAG.evalAt x c.out.1 c.out.2 :=
   rfl
 
-@[simp] theorem eval_const [GateEval G] (b : Bool) (x : Fin n → Bool) :
-    eval (const (G := G) (n := n) b) x = b :=
+/-- The size of a circuit is the number of nodes. -/
+def size (c : Circuit G n) : Nat :=
+  c.N
+
+omit [GateEval G] in
+@[simp] theorem size_eq_N (c : Circuit G n) : c.size = c.N :=
   rfl
 
-@[simp] theorem eval_gate [GateEval G] {k : Nat} (g : G k) (f : Fin k → Circuit G n)
-    (x : Fin n → Bool) :
-    eval (gate (G := G) (n := n) g f) x = GateEval.eval g (fun i => eval (f i) x) :=
+/-- Rename inputs of a circuit by applying `ρ` to input references. -/
+def mapInputs {m : Nat} (ρ : Fin n → Fin m) (c : Circuit G n) : Circuit G m :=
+  { N := c.N
+    node := (CircuitDAG.mapInputs ρ c.toCircuitDAG).node
+    out := c.out }
+
+omit [GateEval G] in
+@[simp] theorem mapInputs_size {m : Nat} (ρ : Fin n → Fin m) (c : Circuit G n) :
+    (mapInputs ρ c).size = c.size :=
   rfl
 
-/-- Rename/reindex circuit inputs. -/
-def mapInputs {m n : Nat} (c : Circuit G n) (ρ : Fin n → Fin m) : Circuit G m :=
-  match c with
-  | input i => input (ρ i)
-  | const b => const b
-  | gate g f => gate g (fun i => mapInputs (f i) ρ)
-
-@[simp] theorem mapInputs_input {m n : Nat} (ρ : Fin n → Fin m) (i : Fin n) :
-    mapInputs (G := G) (input i) ρ = input (ρ i) :=
+omit [GateEval G] in
+@[simp] theorem mapInputs_N {m : Nat} (ρ : Fin n → Fin m) (c : Circuit G n) :
+    (mapInputs ρ c).N = c.N :=
   rfl
 
-@[simp] theorem mapInputs_const {m n : Nat} (ρ : Fin n → Fin m) (b : Bool) :
-    mapInputs (G := G) (const (n := n) b) ρ = const (n := m) b :=
+omit [GateEval G] in
+@[simp] theorem mapInputs_out {m : Nat} (ρ : Fin n → Fin m) (c : Circuit G n) :
+    (mapInputs ρ c).out = c.out :=
   rfl
 
-@[simp] theorem mapInputs_gate {m n k : Nat} (ρ : Fin n → Fin m) (g : G k)
-    (f : Fin k → Circuit G n) :
-    mapInputs (G := G) (gate (n := n) g f) ρ = gate (n := m) g (fun i => mapInputs (f i) ρ) :=
-  rfl
+theorem eval_mapInputs {m : Nat} (ρ : Fin n → Fin m) (c : Circuit G n) (x : Fin m → Bool) :
+    (mapInputs ρ c).eval x = c.eval (fun i => x (ρ i)) := by
+  simpa [Circuit.mapInputs, Circuit.eval] using CircuitDAG.evalAt_mapInputs
+    (ρ := ρ) (d := c.toCircuitDAG) (x := x) (i := c.out.1) (hi := c.out.2)
 
-/-- Substitute each input wire by a circuit. -/
-def subst {m n : Nat} (c : Circuit G n) (σ : Fin n → Circuit G m) : Circuit G m :=
-  match c with
-  | input i => σ i
-  | const b => const b
-  | gate g f => gate g (fun i => subst (f i) σ)
+omit [GateEval G] in
+@[simp] theorem mapInputs_id (c : Circuit G n) :
+    mapInputs id c = c := by
+  obtain ⟨dag, out⟩ := c
+  simp only [mapInputs, CircuitDAG.mapInputs]; congr 2; funext i hi; cases dag.node i hi <;> rfl
 
-@[simp] theorem subst_input {m n : Nat} (σ : Fin n → Circuit G m) (i : Fin n) :
-    subst (G := G) (input i) σ = σ i :=
-  rfl
-
-@[simp] theorem subst_const {m n : Nat} (σ : Fin n → Circuit G m) (b : Bool) :
-    subst (G := G) (const (n := n) b) σ = const (n := m) b :=
-  rfl
-
-@[simp] theorem subst_gate {m n k : Nat} (σ : Fin n → Circuit G m) (g : G k)
-    (f : Fin k → Circuit G n) :
-    subst (G := G) (gate (n := n) g f) σ = gate (n := m) g (fun i => subst (f i) σ) :=
-  rfl
-
-theorem eval_mapInputs [GateEval G] {m n : Nat} (c : Circuit G n) (ρ : Fin n → Fin m)
-    (x : Fin m → Bool) :
-    eval (mapInputs (G := G) c ρ) x = eval c (fun i => x (ρ i)) := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [mapInputs, eval, ih]
-
-theorem eval_subst [GateEval G] {m n : Nat} (c : Circuit G n) (σ : Fin n → Circuit G m)
-    (x : Fin m → Bool) :
-    eval (subst (G := G) c σ) x = eval c (fun i => eval (σ i) x) := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [subst, eval, ih]
-
-theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom G H)
-    (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map g) x =
-      GateEval.eval (G := G) g x)
-    (c : Circuit G n) (x : Fin n → Bool) :
-    eval (mapGate φ c) x = eval c x := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp only [mapGate, eval, ih, hφ]
-
-@[simp]
-theorem mapInputs_id (c : Circuit G n) :
-    mapInputs c id = c := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [mapInputs, ih]
-
-theorem mapInputs_comp {m ℓ n : Nat} (c : Circuit G n) (ρ₁ : Fin n → Fin m) (ρ₂ : Fin m → Fin ℓ) :
-    mapInputs (G := G) (mapInputs (G := G) c ρ₁) ρ₂ =
-      mapInputs (G := G) c (fun i => ρ₂ (ρ₁ i)) := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [mapInputs, ih]
-
-theorem subst_id (c : Circuit G n) :
-    subst (G := G) c (fun i => input i) = c := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [subst, ih]
-
-theorem subst_comp {m ℓ n : Nat} (c : Circuit G n) (σ₁ : Fin n → Circuit G m)
-    (σ₂ : Fin m → Circuit G ℓ) :
-    subst (G := G) (subst (G := G) c σ₁) σ₂ =
-      subst (G := G) c (fun i => subst (G := G) (σ₁ i) σ₂) := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih =>
-      simp [subst, ih]
-
-@[simp]
-theorem mapGate_id {G : ℕ → Type} {n : Nat} (c : Circuit G n) :
-    mapGate (GateHom.id G) c = c := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g f ih => simp [ih]
-
-theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c : Circuit G n) :
-    mapGate (GateHom.comp g f) c = mapGate g (mapGate f c) := by
-  induction c with
-  | input i => rfl
-  | const b => rfl
-  | gate g₀ f₀ ih => simp [ih]
+omit [GateEval G] in
+theorem mapInputs_comp {m ℓ : Nat} (ρ₁ : Fin n → Fin m) (ρ₂ : Fin m → Fin ℓ) (c : Circuit G n) :
+    mapInputs ρ₂ (mapInputs ρ₁ c) = mapInputs (fun i => ρ₂ (ρ₁ i)) c := by
+  obtain ⟨dag, out⟩ := c
+  simp only [mapInputs, CircuitDAG.mapInputs]; congr 2; funext i hi; cases dag.node i hi <;> rfl
 
 end Circuit
+
+section MapGate
+
+variable {G H : Nat → Type} {n : Nat}
+
+/-- Relabel gates of a circuit using an arity-preserving map. -/
+def Circuit.mapGate (φ : GateHom G H) (c : Circuit G n) : Circuit H n :=
+  { N := c.N
+    node := (c.toCircuitDAG.mapGate φ).node
+    out := c.out }
+
+@[simp] theorem Circuit.mapGate_size (φ : GateHom G H) (c : Circuit G n) :
+    (c.mapGate φ).size = c.size :=
+  rfl
+
+@[simp] theorem Circuit.mapGate_N (φ : GateHom G H) (c : Circuit G n) :
+    (c.mapGate φ).N = c.N :=
+  rfl
+
+@[simp] theorem Circuit.mapGate_out (φ : GateHom G H) (c : Circuit G n) :
+    (c.mapGate φ).out = c.out :=
+  rfl
+
+@[simp] theorem Circuit.mapGate_id (c : Circuit G n) :
+    c.mapGate (GateHom.id G) = c := by
+  obtain ⟨dag, out⟩ := c
+  simp only [Circuit.mapGate, CircuitDAG.mapGate]; congr 2; funext i hi; cases dag.node i hi <;> rfl
+
+theorem Circuit.mapGate_comp {K : Nat → Type} (ψ : GateHom H K) (φ : GateHom G H)
+    (c : Circuit G n) :
+    (c.mapGate φ).mapGate ψ = c.mapGate (GateHom.comp ψ φ) := by
+  obtain ⟨dag, out⟩ := c
+  simp only [Circuit.mapGate, CircuitDAG.mapGate]; congr 2; funext i hi; cases dag.node i hi <;> rfl
+
+theorem CircuitDAG.evalAt_mapGate [GateEval G] [GateEval H] (φ : GateHom G H)
+    (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool),
+      GateEval.eval (G := H) (φ.map g) x = GateEval.eval (G := G) g x)
+    (d : CircuitDAG G n) (x : Fin n → Bool) (i : Nat) (hi : i < d.N) :
+    (d.mapGate φ).evalAt x i hi = d.evalAt x i hi := by
+  revert hi; refine Nat.strong_induction_on i ?_; intro i ih hi
+  rw [evalAt_eq_node, evalAt_eq_node]
+  cases hnd : d.node i hi with
+  | input j => simp [CircuitDAG.mapGate, hnd]
+  | const b => simp [CircuitDAG.mapGate, hnd]
+  | gate g f =>
+      simp only [CircuitDAG.mapGate, hnd, hφ]
+      congr 1; funext j; exact ih (f j).1 (f j).2 (lt_trans (f j).2 hi)
+
+theorem Circuit.eval_mapGate [GateEval G] [GateEval H] (φ : GateHom G H)
+    (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool),
+      GateEval.eval (G := H) (φ.map g) x = GateEval.eval (G := G) g x)
+    (c : Circuit G n) (x : Fin n → Bool) :
+    (c.mapGate φ).eval x = c.eval x := by
+  simp only [Circuit.eval, Circuit.mapGate]
+  exact CircuitDAG.evalAt_mapGate φ hφ c.toCircuitDAG x c.out.1 c.out.2
+
+end MapGate
 
 end Computability

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -54,7 +54,7 @@ variable {G : Nat → Type} {n : Nat}
 def mapGate {H : Nat → Type} (φ : GateHom G H) : Circuit G n → Circuit H n
   | input i => input i
   | const b => const b
-  | gate g f => gate (φ.map _ g) (fun i => mapGate φ (f i))
+  | gate g f => gate (φ.map g) (fun i => mapGate φ (f i))
 
 @[simp] theorem mapGate_input {H : Nat → Type} (φ : GateHom G H) (i : Fin n) :
     mapGate (G := G) (n := n) φ (input i) = input i :=
@@ -66,7 +66,7 @@ def mapGate {H : Nat → Type} (φ : GateHom G H) : Circuit G n → Circuit H n
 
 @[simp] theorem mapGate_gate {H : Nat → Type} (φ : GateHom G H) {k : Nat} (g : G k)
     (f : Fin k → Circuit G n) :
-    mapGate (G := G) (n := n) φ (gate g f) = gate (φ.map k g) (fun i => mapGate φ (f i)) :=
+    mapGate (G := G) (n := n) φ (gate g f) = gate (φ.map g) (fun i => mapGate φ (f i)) :=
   rfl
 
 /-- Evaluate a circuit on an input assignment. -/
@@ -147,7 +147,7 @@ theorem eval_subst [GateEval G] {m n : Nat} (c : Circuit G n) (σ : Fin n → Ci
       simp [subst, eval, ih]
 
 theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom G H)
-    (hφ : ∀ (k : Nat) (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map k g) x =
+    (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map g) x =
       GateEval.eval (G := G) g x)
     (c : Circuit G n) (x : Fin n → Bool) :
     eval (mapGate (G := G) (n := n) φ c) x = eval c x := by
@@ -155,7 +155,7 @@ theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom 
   | input i => rfl
   | const b => rfl
   | gate g f ih =>
-      simp [mapGate, eval, hφ, ih]
+      simp only [mapGate, eval, ih, hφ]
 
 @[simp]
 theorem mapInputs_id (c : Circuit G n) :

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Dennj Osele. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dennj Osele
+-/
+module
+
+public import Mathlib.Computability.Circuit.Gate
+
+/-!
+# Circuits (syntax trees)
+
+This file defines a basic notion of Boolean circuits as *syntax trees* over an abstract gate family
+`G : Nat → Type` equipped with semantics `[GateEval G]`.
+
+The representation deliberately does not include explicit sharing (DAG circuits). It is intended as
+a minimal foundation for later definitions (size/depth measures, families, and non-uniform classes).
+-/
+
+@[expose] public section
+
+namespace Computability
+
+/-- A Boolean circuit over gate labels `G` with `n` input wires. -/
+inductive Circuit (G : Nat → Type) (n : Nat) : Type where
+  | input : Fin n → Circuit G n
+  | const : Bool → Circuit G n
+  | gate : {k : Nat} → G k → (Fin k → Circuit G n) → Circuit G n
+
+namespace Circuit
+
+variable {G : Nat → Type} {n : Nat}
+
+/-- Map gate labels along a `GateHom`. -/
+def mapGate {H : Nat → Type} (φ : GateHom G H) : Circuit G n → Circuit H n
+  | input i => input i
+  | const b => const b
+  | gate g f => gate (φ.map _ g) (fun i => mapGate φ (f i))
+
+@[simp] theorem mapGate_input {H : Nat → Type} (φ : GateHom G H) (i : Fin n) :
+    mapGate (G := G) (n := n) φ (input i) = input i :=
+  rfl
+
+@[simp] theorem mapGate_const {H : Nat → Type} (φ : GateHom G H) (b : Bool) :
+    mapGate (G := G) (n := n) φ (const b) = const b :=
+  rfl
+
+@[simp] theorem mapGate_gate {H : Nat → Type} (φ : GateHom G H) {k : Nat} (g : G k)
+    (f : Fin k → Circuit G n) :
+    mapGate (G := G) (n := n) φ (gate g f) = gate (φ.map k g) (fun i => mapGate φ (f i)) :=
+  rfl
+
+/-- Evaluate a circuit on an input assignment. -/
+def eval [GateEval G] : Circuit G n → (Fin n → Bool) → Bool
+  | input i, x => x i
+  | const b, _ => b
+  | gate g f, x => GateEval.eval g fun i => eval (f i) x
+
+@[simp] theorem eval_input [GateEval G] (i : Fin n) (x : Fin n → Bool) :
+    eval (input (G := G) i) x = x i :=
+  rfl
+
+@[simp] theorem eval_const [GateEval G] (b : Bool) (x : Fin n → Bool) :
+    eval (const (G := G) (n := n) b) x = b :=
+  rfl
+
+@[simp] theorem eval_gate [GateEval G] {k : Nat} (g : G k) (f : Fin k → Circuit G n)
+    (x : Fin n → Bool) :
+    eval (gate (G := G) (n := n) g f) x = GateEval.eval g (fun i => eval (f i) x) :=
+  rfl
+
+/-- Rename/reindex circuit inputs. -/
+def mapInputs {m n : Nat} (c : Circuit G n) (ρ : Fin n → Fin m) : Circuit G m :=
+  match c with
+  | input i => input (ρ i)
+  | const b => const b
+  | gate g f => gate g (fun i => mapInputs (f i) ρ)
+
+@[simp] theorem mapInputs_input {m n : Nat} (ρ : Fin n → Fin m) (i : Fin n) :
+    mapInputs (G := G) (input i) ρ = input (ρ i) :=
+  rfl
+
+@[simp] theorem mapInputs_const {m n : Nat} (ρ : Fin n → Fin m) (b : Bool) :
+    mapInputs (G := G) (const (n := n) b) ρ = const (n := m) b :=
+  rfl
+
+@[simp] theorem mapInputs_gate {m n k : Nat} (ρ : Fin n → Fin m) (g : G k)
+    (f : Fin k → Circuit G n) :
+    mapInputs (G := G) (gate (n := n) g f) ρ = gate (n := m) g (fun i => mapInputs (f i) ρ) :=
+  rfl
+
+/-- Substitute each input wire by a circuit. -/
+def subst {m n : Nat} (c : Circuit G n) (σ : Fin n → Circuit G m) : Circuit G m :=
+  match c with
+  | input i => σ i
+  | const b => const b
+  | gate g f => gate g (fun i => subst (f i) σ)
+
+@[simp] theorem subst_input {m n : Nat} (σ : Fin n → Circuit G m) (i : Fin n) :
+    subst (G := G) (input i) σ = σ i :=
+  rfl
+
+@[simp] theorem subst_const {m n : Nat} (σ : Fin n → Circuit G m) (b : Bool) :
+    subst (G := G) (const (n := n) b) σ = const (n := m) b :=
+  rfl
+
+@[simp] theorem subst_gate {m n k : Nat} (σ : Fin n → Circuit G m) (g : G k)
+    (f : Fin k → Circuit G n) :
+    subst (G := G) (gate (n := n) g f) σ = gate (n := m) g (fun i => subst (f i) σ) :=
+  rfl
+
+theorem eval_mapInputs [GateEval G] {m n : Nat} (c : Circuit G n) (ρ : Fin n → Fin m)
+    (x : Fin m → Bool) :
+    eval (mapInputs (G := G) c ρ) x = eval c (fun i => x (ρ i)) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [mapInputs, eval, ih]
+
+theorem eval_subst [GateEval G] {m n : Nat} (c : Circuit G n) (σ : Fin n → Circuit G m)
+    (x : Fin m → Bool) :
+    eval (subst (G := G) c σ) x = eval c (fun i => eval (σ i) x) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [subst, eval, ih]
+
+theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom G H)
+    (hφ : ∀ (k : Nat) (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map k g) x =
+      GateEval.eval (G := G) g x)
+    (c : Circuit G n) (x : Fin n → Bool) :
+    eval (mapGate (G := G) (n := n) φ c) x = eval c x := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [mapGate, eval, hφ, ih]
+
+theorem mapInputs_id (c : Circuit G n) :
+    mapInputs (G := G) c (fun i => i) = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [mapInputs, ih]
+
+theorem mapInputs_comp {m ℓ n : Nat} (c : Circuit G n) (ρ₁ : Fin n → Fin m) (ρ₂ : Fin m → Fin ℓ) :
+    mapInputs (G := G) (mapInputs (G := G) c ρ₁) ρ₂ =
+      mapInputs (G := G) c (fun i => ρ₂ (ρ₁ i)) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [mapInputs, ih]
+
+theorem subst_id (c : Circuit G n) :
+    subst (G := G) c (fun i => input i) = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [subst, ih]
+
+theorem subst_comp {m ℓ n : Nat} (c : Circuit G n) (σ₁ : Fin n → Circuit G m)
+    (σ₂ : Fin m → Circuit G ℓ) :
+    subst (G := G) (subst (G := G) c σ₁) σ₂ =
+      subst (G := G) c (fun i => subst (G := G) (σ₁ i) σ₂) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [subst, ih]
+
+theorem mapGate_id (c : Circuit G n) :
+    mapGate (G := G) (n := n) (GateHom.id G) c = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp only [mapGate_gate, GateHom.id_map, gate.injEq, heq_eq_eq, true_and]
+      funext i
+      simpa using ih i
+
+theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c : Circuit G n) :
+    mapGate (G := G) (n := n) (GateHom.comp g f) c =
+      mapGate (G := H) (n := n) g (mapGate (G := G) (n := n) f c) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g₀ f₀ ih =>
+      simp only [mapGate_gate, GateHom.comp_map, gate.injEq, heq_eq_eq, true_and]
+      funext i
+      simpa using ih i
+
+end Circuit
+
+end Computability

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -57,16 +57,16 @@ def mapGate {H : Nat → Type} (φ : GateHom G H) : Circuit G n → Circuit H n
   | gate g f => gate (φ.map g) (fun i => mapGate φ (f i))
 
 @[simp] theorem mapGate_input {H : Nat → Type} (φ : GateHom G H) (i : Fin n) :
-    mapGate (G := G) (n := n) φ (input i) = input i :=
+    mapGate φ (input i) = input i :=
   rfl
 
 @[simp] theorem mapGate_const {H : Nat → Type} (φ : GateHom G H) (b : Bool) :
-    mapGate (G := G) (n := n) φ (const b) = const b :=
+    mapGate φ (const (n := n) b) = const b :=
   rfl
 
 @[simp] theorem mapGate_gate {H : Nat → Type} (φ : GateHom G H) {k : Nat} (g : G k)
     (f : Fin k → Circuit G n) :
-    mapGate (G := G) (n := n) φ (gate g f) = gate (φ.map g) (fun i => mapGate φ (f i)) :=
+    mapGate φ (gate g f) = gate (φ.map g) (fun i => mapGate φ (f i)) :=
   rfl
 
 /-- Evaluate a circuit on an input assignment. -/
@@ -150,7 +150,7 @@ theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom 
     (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map g) x =
       GateEval.eval (G := G) g x)
     (c : Circuit G n) (x : Fin n → Bool) :
-    eval (mapGate (G := G) (n := n) φ c) x = eval c x := by
+    eval (mapGate φ c) x = eval c x := by
   induction c with
   | input i => rfl
   | const b => rfl
@@ -202,8 +202,7 @@ theorem mapGate_id {G : ℕ → Type} {n : Nat} (c : Circuit G n) :
   | gate g f ih => simp [ih]
 
 theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c : Circuit G n) :
-    mapGate (G := G) (n := n) (GateHom.comp g f) c =
-      mapGate (G := H) (n := n) g (mapGate (G := G) (n := n) f c) := by
+    mapGate (GateHom.comp g f) c = mapGate g (mapGate f c) := by
   induction c with
   | input i => rfl
   | const b => rfl

--- a/Mathlib/Computability/Circuit/Basic.lean
+++ b/Mathlib/Computability/Circuit/Basic.lean
@@ -44,7 +44,7 @@ namespace Computability
 inductive Circuit (G : Nat → Type) (n : Nat) : Type where
   | input : Fin n → Circuit G n
   | const : Bool → Circuit G n
-  | gate : {k : Nat} → G k → (Fin k → Circuit G n) → Circuit G n
+  | gate {k : Nat} : G k → (Fin k → Circuit G n) → Circuit G n
 
 namespace Circuit
 

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -58,24 +58,24 @@ class GateEval (G : Nat → Type) : Type where
 with semantics is expressed separately when needed. -/
 structure GateHom (G H : Nat → Type) : Type where
   /-- Map a gate label of arity `n` to a gate label of arity `n`. -/
-  map : ∀ n : Nat, G n → H n
+  map : ∀ {n : Nat}, G n → H n
 
 namespace GateHom
 
 /-- Identity gate homomorphism. -/
 def id (G : Nat → Type) : GateHom G G :=
-  ⟨fun _ g => g⟩
+  ⟨fun g => g⟩
 
 /-- Composition of gate homomorphisms. -/
 def comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) : GateHom G K :=
-  ⟨fun n x => g.map n (f.map n x)⟩
+  ⟨fun x => g.map (f.map x)⟩
 
-@[simp] theorem id_map {G : Nat → Type} (n : Nat) (x : G n) : (id G).map n x = x :=
+@[simp] theorem id_map {G : Nat → Type} {n : Nat} (x : G n) : (id G).map x = x :=
   rfl
 
-@[simp] theorem map_comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (n : Nat)
+@[simp] theorem map_comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) {n : Nat}
     (x : G n) :
-    (comp g f).map n x = g.map n (f.map n x) :=
+    (comp g f).map x = g.map (f.map x) :=
   rfl
 
 @[simp] theorem comp_id {G H : Nat → Type} (f : GateHom G H) : comp f (id G) = f :=
@@ -242,27 +242,27 @@ namespace AC0Gate
 
 /-- The canonical injection of `AC0Gate` into `ACC0Gate m`. -/
 def toACC0Gate (m : Nat) : GateHom AC0Gate (ACC0Gate m) :=
-  ⟨fun n g => ACC0Gate.ac0 (m := m) (n := n) g⟩
+  ⟨fun g => ACC0Gate.ac0 g⟩
 
 /-- The canonical injection of `AC0Gate` into `TC0Gate`. -/
 def toTC0Gate : GateHom AC0Gate TC0Gate :=
-  ⟨fun n g => TC0Gate.ac0 (n := n) g⟩
+  ⟨fun g => TC0Gate.ac0 g⟩
 
-@[simp] theorem toACC0Gate_map (m : Nat) (n : Nat) (g : AC0Gate n) :
-    (toACC0Gate m).map n g = ACC0Gate.ac0 (m := m) (n := n) g :=
+@[simp] theorem toACC0Gate_map (m : Nat) {n : Nat} (g : AC0Gate n) :
+    (toACC0Gate m).map g = ACC0Gate.ac0 (m := m) g :=
   rfl
 
-@[simp] theorem toTC0Gate_map (n : Nat) (g : AC0Gate n) :
-    toTC0Gate.map n g = TC0Gate.ac0 (n := n) g :=
+@[simp] theorem toTC0Gate_map {n : Nat} (g : AC0Gate n) :
+    toTC0Gate.map g = TC0Gate.ac0 g :=
   rfl
 
-@[simp] theorem eval_toACC0Gate (m n : Nat) (g : AC0Gate n) (x : Fin n → Bool) :
-    GateEval.eval (G := ACC0Gate m) ((toACC0Gate m).map n g) x =
+@[simp] theorem eval_toACC0Gate (m : Nat) {n : Nat} (g : AC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := ACC0Gate m) ((toACC0Gate m).map g) x =
       GateEval.eval (G := AC0Gate) g x :=
   rfl
 
-@[simp] theorem eval_toTC0Gate (n : Nat) (g : AC0Gate n) (x : Fin n → Bool) :
-    GateEval.eval (G := TC0Gate) (toTC0Gate.map n g) x =
+@[simp] theorem eval_toTC0Gate {n : Nat} (g : AC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := TC0Gate) (toTC0Gate.map g) x =
       GateEval.eval (G := AC0Gate) g x :=
   rfl
 

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -73,7 +73,7 @@ def comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) : GateHom G 
 @[simp] theorem id_map {G : Nat → Type} (n : Nat) (x : G n) : (id G).map n x = x :=
   rfl
 
-@[simp] theorem comp_map {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (n : Nat)
+@[simp] theorem map_comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (n : Nat)
     (x : G n) :
     (comp g f).map n x = g.map n (f.map n x) :=
   rfl

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -70,7 +70,7 @@ def id (G : Nat → Type) : GateHom G G :=
 def comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) : GateHom G K :=
   ⟨fun x => g.map (f.map x)⟩
 
-@[simp] theorem id_map {G : Nat → Type} {n : Nat} (x : G n) : (id G).map x = x :=
+@[simp] theorem map_id {G : Nat → Type} {n : Nat} (x : G n) : (id G).map x = x :=
   rfl
 
 @[simp] theorem map_comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) {n : Nat}

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -81,7 +81,7 @@ def comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) : GateHom G 
 @[simp] theorem comp_id {G H : Nat → Type} (f : GateHom G H) : comp f (id G) = f :=
   rfl
 
-@[simp] theorem id_comp {G H : Nat → Type} (f : GateHom G H) : comp (id H) f = f :=
+@[simp] theorem comp_id' {G H : Nat → Type} (f : GateHom G H) : comp (id H) f = f :=
   rfl
 
 theorem comp_assoc {G H K L : Nat → Type} (h : GateHom K L) (g : GateHom H K) (f : GateHom G H) :

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -62,10 +62,6 @@ structure GateHom (G H : Nat → Type) : Type where
 
 namespace GateHom
 
-theorem map_mk {G H : Nat → Type} (f : ∀ n : Nat, G n → H n) (n : Nat) (g : G n) :
-    (GateHom.mk f).map n g = f n g :=
-  rfl
-
 /-- Identity gate homomorphism. -/
 def id (G : Nat → Type) : GateHom G G :=
   ⟨fun _ g => g⟩

--- a/Mathlib/Computability/Circuit/Gate.lean
+++ b/Mathlib/Computability/Circuit/Gate.lean
@@ -1,0 +1,322 @@
+/-
+Copyright (c) 2026 Dennj Osele. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dennj Osele
+-/
+module
+
+public import Mathlib.Data.Fintype.Basic
+public import Mathlib.Data.Fintype.Card
+public import Mathlib.Data.Fin.Tuple.Basic
+public import Mathlib.Data.Finset.Card
+
+/-!
+# Circuit gate labels
+
+This file defines a lightweight interface for *arity-indexed* gate labels and their Boolean
+semantics, together with standard bases used in circuit complexity (`AC0`, `ACC0`, `TC0`).
+
+The key design choice is to keep **syntax** (gate labels) separate from **semantics**
+(an evaluation function), so that later developments can swap representations without changing
+core APIs.
+-/
+
+@[expose] public section
+
+namespace Computability
+
+namespace Circuit
+
+/-- Semantics for an arity-indexed family of gate labels `G : Nat → Type`. -/
+class GateEval (G : Nat → Type) : Type where
+  /-- Evaluate a gate of arity `n` on an `n`-bit input vector. -/
+  eval : ∀ {n : Nat}, G n → (Fin n → Bool) → Bool
+
+/-- An arity-preserving map between gate label families. This is purely *syntactic*; compatibility
+with semantics is expressed separately when needed. -/
+structure GateHom (G H : Nat → Type) : Type where
+  /-- Map a gate label of arity `n` to a gate label of arity `n`. -/
+  map : ∀ n : Nat, G n → H n
+
+namespace GateHom
+
+@[simp] theorem map_mk {G H : Nat → Type} (f : ∀ n : Nat, G n → H n) (n : Nat) (g : G n) :
+    (GateHom.mk f).map n g = f n g :=
+  rfl
+
+/-- Identity gate homomorphism. -/
+def id (G : Nat → Type) : GateHom G G :=
+  ⟨fun _ g => g⟩
+
+/-- Composition of gate homomorphisms. -/
+def comp {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) : GateHom G K :=
+  ⟨fun n x => g.map n (f.map n x)⟩
+
+@[simp] theorem id_map {G : Nat → Type} (n : Nat) (x : G n) : (id G).map n x = x :=
+  rfl
+
+@[simp] theorem comp_map {G H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (n : Nat)
+    (x : G n) :
+    (comp g f).map n x = g.map n (f.map n x) :=
+  rfl
+
+end GateHom
+
+/-- Number of `true` inputs in a Boolean vector. -/
+def countTrue {n : Nat} (x : Fin n → Bool) : Nat :=
+  (Finset.univ.filter fun i : Fin n => x i = true).card
+
+@[simp] theorem countTrue_def {n : Nat} (x : Fin n → Bool) :
+    countTrue x = (Finset.univ.filter fun i : Fin n => x i = true).card :=
+  rfl
+
+theorem countTrue_le {n : Nat} (x : Fin n → Bool) : countTrue x ≤ n := by
+  simpa [countTrue] using card_finset_fin_le (Finset.univ.filter fun i : Fin n => x i = true)
+
+theorem countTrue_snoc {n : Nat} (x : Fin n → Bool) (b : Bool) :
+    countTrue (Fin.snoc x b) = countTrue x + (if b then 1 else 0) := by
+  classical
+  -- Split `Fin (n+1)` into the prefix `Fin.castSucc` and the last element `Fin.last n`.
+  let s0 : Finset (Fin (n + 1)) :=
+    Finset.image Fin.castSucc (Finset.univ.filter fun i : Fin n => x i = true)
+  let s1 : Finset (Fin (n + 1)) :=
+    if b then {Fin.last n} else ∅
+  have hs :
+      (Finset.univ.filter fun i : Fin (n + 1) =>
+          Fin.snoc (α := fun _ : Fin (n + 1) => Bool) x b i = true) =
+        s0 ∪ s1 := by
+    ext i
+    cases i using Fin.lastCases with
+    | cast j0 =>
+        constructor
+        · intro hj
+          refine Finset.mem_union.2 (Or.inl ?_)
+          refine Finset.mem_image.2 ?_
+          refine ⟨j0, ?_, rfl⟩
+          have : x j0 = true := by
+            simpa using hj
+          simp [this]
+        · intro hi
+          rcases Finset.mem_union.1 hi with hi | hi
+          · rcases Finset.mem_image.1 hi with ⟨j, hj, hjEq⟩
+            have hj' : j = j0 := by
+              exact Fin.castSucc_injective n hjEq
+            have : x j0 = true := by
+              have : x j = true := by
+                simpa using (Finset.mem_filter.1 hj).2
+              simpa [hj'] using this
+            simp [this]
+          · cases hb : b with
+            | false =>
+                have : False := by
+                  have hiff : ((Fin.castSucc j0 : Fin (n + 1)) ∈ s1) ↔ False := by
+                    simp [s1, hb]
+                  exact hiff.1 hi
+                exact this.elim
+            | true =>
+                -- `Fin.castSucc j ∉ {Fin.last n}`.
+                have hiEq : (Fin.castSucc j0 : Fin (n + 1)) = Fin.last n := by
+                  have hiff :
+                      ((Fin.castSucc j0 : Fin (n + 1)) ∈ s1) ↔
+                        (Fin.castSucc j0 : Fin (n + 1)) = Fin.last n := by
+                    simp [s1, hb]
+                  exact hiff.1 hi
+                have := congrArg Fin.val hiEq
+                exact (Nat.ne_of_lt j0.2) (by simpa using this) |>.elim
+    | last =>
+        constructor
+        · intro hl
+          have hb : b = true := by
+            simpa using hl
+          subst hb
+          refine Finset.mem_union.2 (Or.inr ?_)
+          simp [s1]
+        · intro hi
+          rcases Finset.mem_union.1 hi with hi | hi
+          · rcases Finset.mem_image.1 hi with ⟨j, hj, hjEq⟩
+            have := congrArg Fin.val hjEq
+            exact (Nat.ne_of_lt j.2) (by simpa using this) |>.elim
+          · cases hb : b with
+            | false =>
+                have : False := by
+                  have hiff : (Fin.last n ∈ s1) ↔ False := by
+                    simp [s1, hb]
+                  exact hiff.1 hi
+                exact this.elim
+            | true =>
+                -- `Fin.snoc x true (Fin.last n) = true`.
+                simp
+  have hs0_card : s0.card = (Finset.univ.filter fun i : Fin n => x i = true).card := by
+    -- `Fin.castSucc` is injective.
+    have hinj : Function.Injective (Fin.castSucc : Fin n → Fin (n + 1)) :=
+      Fin.castSucc_injective n
+    simpa [s0] using (Finset.card_image_of_injective _ hinj)
+  have hs1_card : s1.card = (if b then 1 else 0) := by
+    cases hb : b <;> simp [s1, hb]
+  have hdisj : Disjoint s0 s1 := by
+    cases hb : b with
+    | false =>
+        simp [s1, hb]
+    | true =>
+        refine Finset.disjoint_left.2 ?_
+        intro i hi0 hi1
+        have hi : i = Fin.last n := by
+          have hi' : i ∈ ({Fin.last n} : Finset (Fin (n + 1))) := by
+            simpa [s1, hb] using hi1
+          simpa using (Finset.mem_singleton.1 hi')
+        subst hi
+        rcases Finset.mem_image.1 hi0 with ⟨j, hj, hjEq⟩
+        have := congrArg Fin.val hjEq
+        exact (Nat.ne_of_lt j.2) (by simpa using this)
+  have hcard_union : (s0 ∪ s1).card = s0.card + s1.card := by
+    have hinter : (s0 ∩ s1) = (∅ : Finset (Fin (n + 1))) := by
+      ext i
+      constructor
+      · intro hi
+        rcases Finset.mem_inter.1 hi with ⟨hi0, hi1⟩
+        exact ((Finset.disjoint_left.1 hdisj) hi0 hi1).elim
+      · intro hi
+        simp at hi
+    have h := Finset.card_union_add_card_inter s0 s1
+    simpa [hinter] using h
+  calc
+    countTrue (Fin.snoc x b)
+        =
+          (Finset.univ.filter fun i : Fin (n + 1) =>
+              Fin.snoc (α := fun _ : Fin (n + 1) => Bool) x b i = true).card := rfl
+    _ = (s0 ∪ s1).card := by
+        simp [hs]
+    _ = s0.card + s1.card := hcard_union
+    _ = countTrue x + (if b then 1 else 0) := by
+        simp [countTrue, s0, s1, hs0_card, hs1_card]
+
+/-! ## Standard gate bases -/
+
+/-- A simple `AC0` gate basis: unbounded fan-in `AND` / `OR` and unary `NOT`. -/
+inductive AC0Gate : Nat → Type where
+  | and : {n : Nat} → AC0Gate n
+  | or : {n : Nat} → AC0Gate n
+  | not : AC0Gate 1
+  deriving DecidableEq
+
+/-- Boolean semantics of `AC0Gate`. -/
+def AC0Gate.eval : ∀ {n : Nat}, AC0Gate n → (Fin n → Bool) → Bool
+  | _, .and, x => decide (∀ i, x i = true)
+  | _, .or, x => decide (∃ i, x i = true)
+  | _, .not, x => !(x 0)
+
+instance (n : Nat) : Inhabited (AC0Gate n) :=
+  ⟨AC0Gate.and⟩
+
+instance : GateEval AC0Gate where
+  eval := AC0Gate.eval
+
+@[simp] theorem GateEval_eval_AC0Gate {n : Nat} (g : AC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := AC0Gate) g x = AC0Gate.eval g x :=
+  rfl
+
+@[simp] theorem AC0Gate_eval_and {n : Nat} (x : Fin n → Bool) :
+    AC0Gate.eval (n := n) AC0Gate.and x = decide (∀ i, x i = true) :=
+  rfl
+
+@[simp] theorem AC0Gate_eval_or {n : Nat} (x : Fin n → Bool) :
+    AC0Gate.eval (n := n) AC0Gate.or x = decide (∃ i, x i = true) :=
+  rfl
+
+@[simp] theorem AC0Gate_eval_not (x : Fin 1 → Bool) :
+    AC0Gate.eval (n := 1) AC0Gate.not x = !(x 0) :=
+  rfl
+
+/-- An `ACC0` gate basis: `AC0` plus a `MOD m` gate (unbounded fan-in). -/
+inductive ACC0Gate (m : Nat) : Nat → Type where
+  | ac0 : {n : Nat} → AC0Gate n → ACC0Gate m n
+  | mod : {n : Nat} → ACC0Gate m n
+  deriving DecidableEq
+
+/-- Boolean semantics of `ACC0Gate m`. The `mod` gate outputs `true` iff the number of `true`
+inputs is congruent to `0` modulo `m`.
+
+Note: in the usual complexity-theoretic definition of `ACC0[m]`, one assumes `2 ≤ m`. -/
+def ACC0Gate.eval (m : Nat) : ∀ {n : Nat}, ACC0Gate m n → (Fin n → Bool) → Bool
+  | _, .ac0 g, x => AC0Gate.eval g x
+  | _, .mod, x => decide (countTrue x % m = 0)
+
+instance (m n : Nat) : Inhabited (ACC0Gate m n) :=
+  ⟨ACC0Gate.mod⟩
+
+instance (m : Nat) : GateEval (ACC0Gate m) where
+  eval := ACC0Gate.eval m
+
+@[simp] theorem GateEval_eval_ACC0Gate (m : Nat) {n : Nat} (g : ACC0Gate m n) (x : Fin n → Bool) :
+    GateEval.eval (G := ACC0Gate m) g x = ACC0Gate.eval m g x :=
+  rfl
+
+@[simp] theorem ACC0Gate_eval_ac0 (m : Nat) {n : Nat} (g : AC0Gate n) (x : Fin n → Bool) :
+    ACC0Gate.eval m (ACC0Gate.ac0 (m := m) g) x = AC0Gate.eval g x :=
+  rfl
+
+@[simp] theorem ACC0Gate_eval_mod (m n : Nat) (x : Fin n → Bool) :
+    ACC0Gate.eval m (ACC0Gate.mod (m := m) (n := n)) x = decide (countTrue x % m = 0) :=
+  rfl
+
+/-- A `TC0` gate basis: `AC0` plus threshold gates (unbounded fan-in). -/
+inductive TC0Gate : Nat → Type where
+  | ac0 : {n : Nat} → AC0Gate n → TC0Gate n
+  /-- Threshold gate: outputs `true` iff at least `t` of the inputs are `true`. -/
+  | thr : {n : Nat} → Nat → TC0Gate n
+  deriving DecidableEq
+
+/-- Boolean semantics of `TC0Gate`. -/
+def TC0Gate.eval : ∀ {n : Nat}, TC0Gate n → (Fin n → Bool) → Bool
+  | _, .ac0 g, x => AC0Gate.eval g x
+  | _, .thr t, x => decide (t ≤ countTrue x)
+
+instance (n : Nat) : Inhabited (TC0Gate n) :=
+  ⟨TC0Gate.ac0 AC0Gate.and⟩
+
+instance : GateEval TC0Gate where
+  eval := TC0Gate.eval
+
+@[simp] theorem GateEval_eval_TC0Gate {n : Nat} (g : TC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := TC0Gate) g x = TC0Gate.eval g x :=
+  rfl
+
+@[simp] theorem TC0Gate_eval_ac0 {n : Nat} (g : AC0Gate n) (x : Fin n → Bool) :
+    TC0Gate.eval (n := n) (TC0Gate.ac0 g) x = AC0Gate.eval g x :=
+  rfl
+
+@[simp] theorem TC0Gate_eval_thr {n : Nat} (t : Nat) (x : Fin n → Bool) :
+    TC0Gate.eval (n := n) (TC0Gate.thr (n := n) t) x = decide (t ≤ countTrue x) :=
+  rfl
+
+namespace AC0Gate
+
+/-- The canonical injection of `AC0Gate` into `ACC0Gate m`. -/
+def toACC0Gate (m : Nat) : GateHom AC0Gate (ACC0Gate m) :=
+  ⟨fun n g => ACC0Gate.ac0 (m := m) (n := n) g⟩
+
+/-- The canonical injection of `AC0Gate` into `TC0Gate`. -/
+def toTC0Gate : GateHom AC0Gate TC0Gate :=
+  ⟨fun n g => TC0Gate.ac0 (n := n) g⟩
+
+@[simp] theorem toACC0Gate_map (m : Nat) (n : Nat) (g : AC0Gate n) :
+    (toACC0Gate m).map n g = ACC0Gate.ac0 (m := m) (n := n) g :=
+  rfl
+
+@[simp] theorem toTC0Gate_map (n : Nat) (g : AC0Gate n) :
+    toTC0Gate.map n g = TC0Gate.ac0 (n := n) g :=
+  rfl
+
+@[simp] theorem eval_toACC0Gate (m n : Nat) (g : AC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := ACC0Gate m) ((toACC0Gate m).map n g) x = GateEval.eval (G := AC0Gate) g x :=
+  rfl
+
+@[simp] theorem eval_toTC0Gate (n : Nat) (g : AC0Gate n) (x : Fin n → Bool) :
+    GateEval.eval (G := TC0Gate) (toTC0Gate.map n g) x = GateEval.eval (G := AC0Gate) g x :=
+  rfl
+
+end AC0Gate
+
+end Circuit
+
+end Computability

--- a/Mathlib/Computability/Formula/Basic.lean
+++ b/Mathlib/Computability/Formula/Basic.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2026 Dennj Osele. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dennj Osele
+-/
+module
+
+public import Mathlib.Computability.Gate
+
+/-!
+# Boolean formulas (syntax trees)
+
+This file defines Boolean formulas as *syntax trees* over an abstract gate family
+`G : Nat → Type` equipped with semantics `[GateEval G]`.
+
+In circuit complexity, a **formula** is a circuit where every gate has fan-out 1 (i.e., no sharing).
+This corresponds precisely to a tree structure. The term "circuit" is reserved for DAG
+representations with explicit sharing (see `Circuit` in `Circuit/Basic.lean`).
+
+## Main definitions
+
+* `Formula G n`: Boolean formula over gate family `G` with `n` input wires
+* `Formula.eval`: evaluate a formula on an input assignment
+* `Formula.mapGate`: transform gate labels via a `GateHom`
+* `Formula.mapInputs`: rename/reindex formula inputs
+* `Formula.subst`: substitute each input wire by a formula
+
+## Main theorems
+
+* `Formula.eval_mapGate`: evaluation commutes with gate mapping (given semantic compatibility)
+* `Formula.eval_mapInputs`: evaluation commutes with input renaming
+* `Formula.eval_subst`: evaluation commutes with substitution
+* `Formula.mapGate_comp`, `Formula.subst_comp`: composition laws
+
+## Tags
+
+formula, Boolean, syntax tree, evaluation, circuit complexity
+-/
+
+@[expose] public section
+
+namespace Computability
+
+open Gate
+
+/-- A Boolean formula over gate labels `G` with `n` input wires.
+
+In circuit complexity, a formula is a circuit with fan-out 1 (no sharing), which corresponds
+to a tree structure. For circuits with sharing (DAGs), see `Circuit` in `Circuit/Basic.lean`. -/
+inductive Formula (G : Nat → Type) (n : Nat) : Type where
+  | input : Fin n → Formula G n
+  | const : Bool → Formula G n
+  | gate {k : Nat} : G k → (Fin k → Formula G n) → Formula G n
+
+namespace Formula
+
+variable {G : Nat → Type} {n : Nat}
+
+/-- Map gate labels along a `GateHom`. -/
+def mapGate {H : Nat → Type} (φ : GateHom G H) : Formula G n → Formula H n
+  | input i => input i
+  | const b => const b
+  | gate g f => gate (φ.map g) (fun i => mapGate φ (f i))
+
+@[simp] theorem mapGate_input {H : Nat → Type} (φ : GateHom G H) (i : Fin n) :
+    mapGate φ (input i) = input i :=
+  rfl
+
+@[simp] theorem mapGate_const {H : Nat → Type} (φ : GateHom G H) (b : Bool) :
+    mapGate φ (const (n := n) b) = const b :=
+  rfl
+
+@[simp] theorem mapGate_gate {H : Nat → Type} (φ : GateHom G H) {k : Nat} (g : G k)
+    (f : Fin k → Formula G n) :
+    mapGate φ (gate g f) = gate (φ.map g) (fun i => mapGate φ (f i)) :=
+  rfl
+
+/-- Evaluate a formula on an input assignment. -/
+def eval [GateEval G] : Formula G n → (Fin n → Bool) → Bool
+  | input i, x => x i
+  | const b, _ => b
+  | gate g f, x => GateEval.eval g fun i => eval (f i) x
+
+@[simp] theorem eval_input [GateEval G] (i : Fin n) (x : Fin n → Bool) :
+    eval (input (G := G) i) x = x i :=
+  rfl
+
+@[simp] theorem eval_const [GateEval G] (b : Bool) (x : Fin n → Bool) :
+    eval (const (G := G) (n := n) b) x = b :=
+  rfl
+
+@[simp] theorem eval_gate [GateEval G] {k : Nat} (g : G k) (f : Fin k → Formula G n)
+    (x : Fin n → Bool) :
+    eval (gate (G := G) (n := n) g f) x = GateEval.eval g (fun i => eval (f i) x) :=
+  rfl
+
+/-- Rename/reindex formula inputs. -/
+def mapInputs {m n : Nat} (ρ : Fin n → Fin m) : Formula G n → Formula G m
+  | input i => input (ρ i)
+  | const b => const b
+  | gate g f => gate g (fun i => mapInputs ρ (f i))
+
+@[simp] theorem mapInputs_input {m n : Nat} (ρ : Fin n → Fin m) (i : Fin n) :
+    mapInputs (G := G) ρ (input i) = input (ρ i) :=
+  rfl
+
+@[simp] theorem mapInputs_const {m n : Nat} (ρ : Fin n → Fin m) (b : Bool) :
+    mapInputs (G := G) ρ (const (n := n) b) = const (n := m) b :=
+  rfl
+
+@[simp] theorem mapInputs_gate {m n k : Nat} (ρ : Fin n → Fin m) (g : G k)
+    (f : Fin k → Formula G n) :
+    mapInputs (G := G) ρ (gate (n := n) g f) = gate (n := m) g (fun i => mapInputs ρ (f i)) :=
+  rfl
+
+/-- Substitute each input wire by a formula. -/
+def subst {m n : Nat} (σ : Fin n → Formula G m) : Formula G n → Formula G m
+  | input i => σ i
+  | const b => const b
+  | gate g f => gate g (fun i => subst σ (f i))
+
+@[simp] theorem subst_input {m n : Nat} (σ : Fin n → Formula G m) (i : Fin n) :
+    subst (G := G) σ (input i) = σ i :=
+  rfl
+
+@[simp] theorem subst_const {m n : Nat} (σ : Fin n → Formula G m) (b : Bool) :
+    subst (G := G) σ (const (n := n) b) = const (n := m) b :=
+  rfl
+
+@[simp] theorem subst_gate {m n k : Nat} (σ : Fin n → Formula G m) (g : G k)
+    (f : Fin k → Formula G n) :
+    subst (G := G) σ (gate (n := n) g f) = gate (n := m) g (fun i => subst σ (f i)) :=
+  rfl
+
+theorem eval_mapInputs [GateEval G] {m n : Nat} (ρ : Fin n → Fin m) (c : Formula G n)
+    (x : Fin m → Bool) :
+    eval (mapInputs (G := G) ρ c) x = eval c (fun i => x (ρ i)) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [eval, ih]
+
+theorem eval_subst [GateEval G] {m n : Nat} (σ : Fin n → Formula G m) (c : Formula G n)
+    (x : Fin m → Bool) :
+    eval (subst (G := G) σ c) x = eval c (fun i => eval (σ i) x) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [eval, ih]
+
+theorem eval_mapGate {H : Nat → Type} [GateEval G] [GateEval H] (φ : GateHom G H)
+    (hφ : ∀ {k : Nat} (g : G k) (x : Fin k → Bool), GateEval.eval (G := H) (φ.map g) x =
+      GateEval.eval (G := G) g x)
+    (c : Formula G n) (x : Fin n → Bool) :
+    eval (mapGate φ c) x = eval c x := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp only [mapGate, eval, ih, hφ]
+
+@[simp]
+theorem mapInputs_id (c : Formula G n) :
+    mapInputs id c = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [ih]
+
+theorem mapInputs_comp {m ℓ n : Nat} (ρ₁ : Fin n → Fin m) (ρ₂ : Fin m → Fin ℓ) (c : Formula G n) :
+    mapInputs (G := G) ρ₂ (mapInputs (G := G) ρ₁ c) =
+      mapInputs (G := G) (fun i => ρ₂ (ρ₁ i)) c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [ih]
+
+@[simp]
+theorem subst_id (c : Formula G n) :
+    subst (G := G) (fun i => input i) c = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [ih]
+
+theorem subst_comp {m ℓ n : Nat} (σ₁ : Fin n → Formula G m) (σ₂ : Fin m → Formula G ℓ)
+    (c : Formula G n) :
+    subst (G := G) σ₂ (subst (G := G) σ₁ c) =
+      subst (G := G) (fun i => subst (G := G) σ₂ (σ₁ i)) c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih =>
+      simp [ih]
+
+@[simp]
+theorem mapGate_id {G : Nat → Type} {n : Nat} (c : Formula G n) :
+    mapGate (GateHom.id G) c = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g f ih => simp [ih]
+
+theorem mapGate_comp {H K : Nat → Type} (g : GateHom H K) (f : GateHom G H) (c : Formula G n) :
+    mapGate (GateHom.comp g f) c = mapGate g (mapGate f c) := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | gate g₀ f₀ ih => simp [ih]
+
+section DecidableEq
+
+variable {G : Nat → Type} {n : Nat} [∀ k, DecidableEq (G k)]
+
+/-- Decidable equality for formulas, given decidable equality on gate labels. -/
+protected def decEq : (f₁ f₂ : Formula G n) → Decidable (f₁ = f₂)
+  | .input i₁, .input i₂ => if h : i₁ = i₂ then isTrue (h ▸ rfl) else isFalse (h <| by cases ·; rfl)
+  | .const b₁, .const b₂ => if h : b₁ = b₂ then isTrue (h ▸ rfl) else isFalse (h <| by cases ·; rfl)
+  | .gate (k := k₁) g₁ f₁, .gate (k := k₂) g₂ f₂ =>
+      if hk : k₁ = k₂ then
+        let g₂' : G k₁ := hk ▸ g₂
+        let f₂' : Fin k₁ → Formula G n := fun i => f₂ (hk ▸ i)
+        if hg : g₁ = g₂' then
+          haveI : DecidableEq (Formula G n) := Formula.decEq
+          if hf : ∀ i, f₁ i = f₂' i then isTrue (by subst hk hg; congr; funext i; exact hf i)
+          else isFalse (hf <| by cases ·; exact fun _ => rfl)
+        else isFalse (hg <| by cases ·; rfl)
+      else isFalse (hk <| by cases ·; rfl)
+  | .input _, .const _ | .input _, .gate _ _ | .const _, .input _
+  | .const _, .gate _ _ | .gate _ _, .input _ | .gate _ _, .const _ => isFalse nofun
+
+instance [∀ k, DecidableEq (G k)] : DecidableEq (Formula G n) := Formula.decEq
+
+end DecidableEq
+
+end Formula
+
+end Computability


### PR DESCRIPTION
This PR introduces a foundation for Boolean circuits parameterized by abstract gate families.

## Main definitions

- `GateEval`: typeclass for gate families with Boolean semantics
- `GateHom`: arity-preserving maps between gate families
- `Circuit`: inductive type representing circuit syntax trees
- `AC0Gate`, `ACC0Gate`, `TC0Gate`: standard complexity-theoretic gate bases

## Design notes

The key design choice is to keep **syntax** (gate labels `G : Nat → Type`) separate from
**semantics** (`GateEval.eval`), allowing users to define custom gate families (e.g., MAJ, XOR,
arbitrary threshold gates) without modifying core definitions.

### Tree vs DAG representation

We evaluated two approaches for circuit representation:

1. **Tree-based** (this PR): Circuits as inductive syntax trees
2. **DAG-based**: Circuits as lists of gates with index-based references

We chose tree-based circuits because:

- **Compositionality**: Easy to build circuits via `gate g (fun i => subcircuit i)`
- **Type safety**: Arity-indexed gates (`G : Nat → Type`) catch errors at compile time
- **Manipulation**: Natural support for `mapGate`, `subst`, `mapInputs`
- **Mathlib philosophy**: Aligns with structural/compositional reasoning patterns

For use cases requiring explicit sharing (complexity analysis, evaluation efficiency),
a separate `DAG` type can be added later with proven equivalence via `Circuit.toDAG`.

The current representation serves as a minimal foundation for size/depth measures,
circuit families, and complexity classes (AC0, ACC0, TC0).

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
