### PR TITLE
[Merged by Bors] - chore(CategoryTheory): deprecate adjunction opposite nat iso helpers

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -6,6 +6,7 @@ Authors: Bhavik Mehta, Thomas Read, Andrew Yang
 module
 
 public import Mathlib.CategoryTheory.Adjunction.Basic
+public import Mathlib.CategoryTheory.Adjunction.Unique
 public import Mathlib.CategoryTheory.Yoneda
 public import Mathlib.CategoryTheory.Opposites
 
@@ -83,26 +84,18 @@ def leftAdjointsCoyonedaEquiv {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (a
     NatIso.ofComponents fun Y =>
       ((adj1.homEquiv X.unop Y).trans (adj2.homEquiv X.unop Y).symm).toIso
 
-/-- Given two adjunctions, if the right adjoints are naturally isomorphic, then so are the left
-adjoints.
-
-Note: it is generally better to use `Adjunction.natIsoEquiv`, see the file `Adjunction.Unique`.
-The reason this definition still exists is that apparently `CategoryTheory.extendAlongYonedaYoneda`
-uses its definitional properties (TODO: figure out a way to avoid this).
--/
+/-- Deprecated: prefer `Adjunction.leftAdjointUniq`. -/
+@[deprecated "Use `Adjunction.leftAdjointUniq`." (since := "2026-01-29")]
 def natIsoOfRightAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (r : G ≅ G') : F ≅ F' :=
   NatIso.removeOp ((Coyoneda.fullyFaithful.whiskeringRight _).isoEquiv.symm
     (leftAdjointsCoyonedaEquiv adj2 (adj1.ofNatIsoRight r)))
 
-/-- Given two adjunctions, if the left adjoints are naturally isomorphic, then so are the right
-adjoints.
-
-Note: it is generally better to use `Adjunction.natIsoEquiv`, see the file `Adjunction.Unique`.
--/
+/-- Deprecated: prefer `Adjunction.rightAdjointUniq`. -/
+@[deprecated "Use `Adjunction.rightAdjointUniq`." (since := "2026-01-29")]
 def natIsoOfLeftAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (l : F ≅ F') : G ≅ G' :=
-  NatIso.removeOp (natIsoOfRightAdjointNatIso (op adj2) (op adj1) (NatIso.op l))
+  Adjunction.rightAdjointUniq adj1 (adj2.ofNatIsoLeft l.symm)
 
 end Adjunction
 

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -6,7 +6,6 @@ Authors: Bhavik Mehta, Thomas Read, Andrew Yang
 module
 
 public import Mathlib.CategoryTheory.Adjunction.Basic
-public import Mathlib.CategoryTheory.Adjunction.Unique
 public import Mathlib.CategoryTheory.Yoneda
 public import Mathlib.CategoryTheory.Opposites
 
@@ -85,17 +84,20 @@ def leftAdjointsCoyonedaEquiv {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (a
       ((adj1.homEquiv X.unop Y).trans (adj2.homEquiv X.unop Y).symm).toIso
 
 /-- Deprecated: prefer `Adjunction.leftAdjointUniq`. -/
-@[deprecated "Use `Adjunction.leftAdjointUniq`." (since := "2026-01-29")]
+@[deprecated "Use `Adjunction.leftAdjointUniq` \
+  (requires `import Mathlib.CategoryTheory.Adjunction.Unique`)." (since := "2026-01-31")]
 def natIsoOfRightAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (r : G ≅ G') : F ≅ F' :=
   NatIso.removeOp ((Coyoneda.fullyFaithful.whiskeringRight _).isoEquiv.symm
     (leftAdjointsCoyonedaEquiv adj2 (adj1.ofNatIsoRight r)))
 
+set_option linter.deprecated false in
 /-- Deprecated: prefer `Adjunction.rightAdjointUniq`. -/
-@[deprecated "Use `Adjunction.rightAdjointUniq`." (since := "2026-01-29")]
+@[deprecated "Use `Adjunction.rightAdjointUniq` \
+  (requires `import Mathlib.CategoryTheory.Adjunction.Unique`)." (since := "2026-01-31")]
 def natIsoOfLeftAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (l : F ≅ F') : G ≅ G' :=
-  Adjunction.rightAdjointUniq adj1 (adj2.ofNatIsoLeft l.symm)
+  NatIso.removeOp (natIsoOfRightAdjointNatIso (op adj2) (op adj1) (NatIso.op l))
 
 end Adjunction
 

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -83,18 +83,18 @@ def leftAdjointsCoyonedaEquiv {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (a
     NatIso.ofComponents fun Y =>
       ((adj1.homEquiv X.unop Y).trans (adj2.homEquiv X.unop Y).symm).toIso
 
-/-- Deprecated: prefer `Adjunction.leftAdjointUniq`. -/
-@[deprecated "Use `Adjunction.leftAdjointUniq` \
-  (requires `import Mathlib.CategoryTheory.Adjunction.Unique`)." (since := "2026-01-31")]
+/-- Deprecated: prefer `(Adjunction.conjugateIsoEquiv adj1 adj2).symm`. -/
+@[deprecated "Use `(Adjunction.conjugateIsoEquiv adj1 adj2).symm` \
+  (requires `import Mathlib.CategoryTheory.Adjunction.Mates`)." (since := "2026-01-31")]
 def natIsoOfRightAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (r : G ≅ G') : F ≅ F' :=
   NatIso.removeOp ((Coyoneda.fullyFaithful.whiskeringRight _).isoEquiv.symm
     (leftAdjointsCoyonedaEquiv adj2 (adj1.ofNatIsoRight r)))
 
 set_option linter.deprecated false in
-/-- Deprecated: prefer `Adjunction.rightAdjointUniq`. -/
-@[deprecated "Use `Adjunction.rightAdjointUniq` \
-  (requires `import Mathlib.CategoryTheory.Adjunction.Unique`)." (since := "2026-01-31")]
+/-- Deprecated: prefer `Adjunction.conjugateIsoEquiv adj1 adj2`. -/
+@[deprecated "Use `Adjunction.conjugateIsoEquiv adj1 adj2` \
+  (requires `import Mathlib.CategoryTheory.Adjunction.Mates`)." (since := "2026-01-31")]
 def natIsoOfLeftAdjointNatIso {F F' : C ⥤ D} {G G' : D ⥤ C}
     (adj1 : F ⊣ G) (adj2 : F' ⊣ G') (l : F ≅ F') : G ≅ G' :=
   NatIso.removeOp (natIsoOfRightAdjointNatIso (op adj2) (op adj1) (NatIso.op l))


### PR DESCRIPTION
We deprecate two definitions that have been unused in Mathlib since #10425 (July 2024), which removed `extendAlongYonedaYoneda` - the only code that needed their definitional properties.

---

As requested by @dagurtomas in https://github.com/leanprover-community/mathlib4/pull/34520#discussion_r2742367827

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
