### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction): `MulDistribMulAction` of G⧸H on fixedPoints H A

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
@@ -10,10 +10,10 @@ public import Mathlib.GroupTheory.GroupAction.SubMulAction
 public import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
-# MulAction of quotient group on fixed points
+# MulAction and MulDistribMulAction of quotient group on fixed points
 
-Given a `MulAction` of a group `G` on `A` and a normal subgroup `H` of `G`,
-there is a `MulAction` of the quotient group `G ⧸ H` on `fixedPoints H A`.
+Given a `MulAction`/`MulDistribMulAction` of a group `G` on `A` and a normal subgroup `H` of `G`,
+there is a `MulAction`/`MulDistribMulAction` of the quotient group `G ⧸ H` on `fixedPoints H A`.
 
 -/
 
@@ -41,3 +41,32 @@ lemma quotient_out_smul_fixedPoints (g : G ⧸ H) (a : fixedPoints H A) :
   rfl
 
 end MulAction
+
+namespace MulDistribMulAction
+
+open MulAction
+
+variable {G : Type*} [Group G] {A : Type*} [Monoid A] [MulDistribMulAction G A]
+
+variable {H : Subgroup G} [H.Normal]
+
+instance : MulDistribMulAction (G ⧸ H) (FixedPoints.submonoid H A) where
+  __ := instQuotientSubgroupElemFixedPointsSubtypeMem
+  smul_mul _ _ _ := by
+    ext
+    repeat
+      rw [← quotient_out_smul_fixedPoints]
+    simp [-quotient_out_smul_fixedPoints]
+    rfl
+  smul_one _ := by
+    ext; rw [← quotient_out_smul_fixedPoints]
+    simp [-quotient_out_smul_fixedPoints]
+
+open scoped FixedPoints
+
+variable {α : Type*} [Group α] [MulDistribMulAction G α]
+
+instance : MulDistribMulAction (G ⧸ H) (α ^* H) :=
+  instQuotientSubgroupSubtypeMemSubmonoidSubmonoid
+
+end MulDistribMulAction

--- a/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
@@ -51,7 +51,7 @@ variable {G : Type*} [Group G] {A : Type*} [Monoid A] [MulDistribMulAction G A]
 variable {H : Subgroup G} [H.Normal]
 
 instance : MulDistribMulAction (G ⧸ H) (FixedPoints.submonoid H A) where
-  __ := instQuotientSubgroupElemFixedPointsSubtypeMem
+  __ := inferInstanceAs (MulAction (G ⧸ H) (fixedPoints H A))
   smul_mul g a b := g.induction_on fun g ↦ Subtype.ext (smul_mul g a.1 b.1)
   smul_one g := g.induction_on fun g ↦ Subtype.ext (smul_one g)
 

--- a/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
@@ -67,6 +67,6 @@ open scoped FixedPoints
 variable {α : Type*} [Group α] [MulDistribMulAction G α]
 
 instance : MulDistribMulAction (G ⧸ H) (α ^* H) :=
-  instQuotientSubgroupSubtypeMemSubmonoidSubmonoid
+  inferInstanceAs (MulDistribMulAction (G ⧸ H) (FixedPoints.submonoid H α))
 
 end MulDistribMulAction

--- a/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
@@ -52,15 +52,8 @@ variable {H : Subgroup G} [H.Normal]
 
 instance : MulDistribMulAction (G ⧸ H) (FixedPoints.submonoid H A) where
   __ := instQuotientSubgroupElemFixedPointsSubtypeMem
-  smul_mul _ _ _ := by
-    ext
-    repeat
-      rw [← quotient_out_smul_fixedPoints]
-    simp [-quotient_out_smul_fixedPoints]
-    rfl
-  smul_one _ := by
-    ext; rw [← quotient_out_smul_fixedPoints]
-    simp [-quotient_out_smul_fixedPoints]
+  smul_mul g a b := g.induction_on fun g ↦ Subtype.ext (smul_mul g a.1 b.1)
+  smul_one g := g.induction_on fun g ↦ Subtype.ext (smul_one g)
 
 open scoped FixedPoints
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
