### PR TITLE
[Merged by Bors] - feat: add generalizations of some padicVal{Nat,Int} lemmas

### DIFF
--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -451,23 +451,23 @@ theorem pow_padicValNat_dvd {n : ℕ} : p ^ padicValNat p n ∣ n := by
   rw [padicValNat_def'] <;> assumption
 
 set_option backward.isDefEq.respectTransparency false in
-theorem padicValNat_dvd_iff_le' {p : ℕ} (hp : p ≠ 1) {a n : ℕ} (ha : a ≠ 0) :
+theorem padicValNat_dvd_iff_le_of_ne_one {p : ℕ} (hp : p ≠ 1) {a n : ℕ} (ha : a ≠ 0) :
     p ^ n ∣ a ↔ n ≤ padicValNat p a := by
-  rw [pow_dvd_iff_le_emultiplicity, ← padicValNat_eq_emultiplicity' hp ha, Nat.cast_le]
+  rw [pow_dvd_iff_le_emultiplicity, ← padicValNat_eq_emultiplicity_of_ne_one hp ha, Nat.cast_le]
 
 theorem padicValNat_dvd_iff_le [hp : Fact p.Prime] {a n : ℕ} (ha : a ≠ 0) :
     p ^ n ∣ a ↔ n ≤ padicValNat p a :=
-  padicValNat_dvd_iff_le' hp.out.ne_one ha
+  padicValNat_dvd_iff_le_of_ne_one hp.out.ne_one ha
 
-theorem padicValNat_dvd_iff' {p : ℕ} (hp : p ≠ 1) (n a : ℕ) :
+theorem padicValNat_dvd_iff_of_ne_one {p : ℕ} (hp : p ≠ 1) (n a : ℕ) :
     p ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValNat p a := by
   rcases eq_or_ne a 0 with (rfl | ha)
   · exact iff_of_true (dvd_zero _) (Or.inl rfl)
-  · rw [padicValNat_dvd_iff_le' hp ha, or_iff_right ha]
+  · rw [padicValNat_dvd_iff_le_of_ne_one hp ha, or_iff_right ha]
 
 theorem padicValNat_dvd_iff (n : ℕ) [hp : Fact p.Prime] (a : ℕ) :
     p ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValNat p a :=
-  padicValNat_dvd_iff' hp.out.ne_one n a
+  padicValNat_dvd_iff_of_ne_one hp.out.ne_one n a
 
 theorem pow_succ_padicValNat_not_dvd {n : ℕ} [hp : Fact p.Prime] (hn : n ≠ 0) :
     ¬p ^ (padicValNat p n + 1) ∣ n := by
@@ -697,19 +697,19 @@ section padicValInt
 
 variable {p : ℕ}
 
-theorem padicValInt_dvd_iff' (hp : p ≠ 1) (n : ℕ) (a : ℤ) :
+theorem padicValInt_dvd_iff_of_ne_one (hp : p ≠ 1) (n : ℕ) (a : ℤ) :
     (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a := by
-  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff' hp, ← Int.natCast_dvd,
+  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff_of_ne_one hp, ← Int.natCast_dvd,
     Int.natCast_pow]
 
 theorem padicValInt_dvd_iff [hp : Fact p.Prime] (n : ℕ) (a : ℤ) :
     (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a :=
-  padicValInt_dvd_iff' hp.out.ne_one n a
+  padicValInt_dvd_iff_of_ne_one hp.out.ne_one n a
 
 theorem padicValInt_dvd (a : ℤ) : (p : ℤ) ^ padicValInt p a ∣ a := by
   by_cases hp : p = 1
   · rw [hp, Nat.cast_one, one_pow]; exact one_dvd _
-  rw [padicValInt_dvd_iff' hp]
+  rw [padicValInt_dvd_iff_of_ne_one hp]
   exact Or.inr le_rfl
 
 theorem padicValInt_self [hp : Fact p.Prime] : padicValInt p p = 1 :=

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -451,16 +451,23 @@ theorem pow_padicValNat_dvd {n : ℕ} : p ^ padicValNat p n ∣ n := by
   rw [padicValNat_def'] <;> assumption
 
 set_option backward.isDefEq.respectTransparency false in
-theorem padicValNat_dvd_iff_le [hp : Fact p.Prime] {a n : ℕ} (ha : a ≠ 0) :
+theorem padicValNat_dvd_iff_le' {p : ℕ} (hp : p ≠ 1) {a n : ℕ} (ha : a ≠ 0) :
     p ^ n ∣ a ↔ n ≤ padicValNat p a := by
-  rw [pow_dvd_iff_le_emultiplicity, ← padicValNat_eq_emultiplicity ha,
-    Nat.cast_le]
+  rw [pow_dvd_iff_le_emultiplicity, ← padicValNat_eq_emultiplicity' hp ha, Nat.cast_le]
 
-theorem padicValNat_dvd_iff (n : ℕ) [hp : Fact p.Prime] (a : ℕ) :
+theorem padicValNat_dvd_iff_le [hp : Fact p.Prime] {a n : ℕ} (ha : a ≠ 0) :
+    p ^ n ∣ a ↔ n ≤ padicValNat p a :=
+  padicValNat_dvd_iff_le' hp.out.ne_one ha
+
+theorem padicValNat_dvd_iff' {p : ℕ} (hp : p ≠ 1) (n a : ℕ) :
     p ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValNat p a := by
   rcases eq_or_ne a 0 with (rfl | ha)
   · exact iff_of_true (dvd_zero _) (Or.inl rfl)
-  · rw [padicValNat_dvd_iff_le ha, or_iff_right ha]
+  · rw [padicValNat_dvd_iff_le' hp ha, or_iff_right ha]
+
+theorem padicValNat_dvd_iff (n : ℕ) [hp : Fact p.Prime] (a : ℕ) :
+    p ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValNat p a :=
+  padicValNat_dvd_iff' hp.out.ne_one n a
 
 theorem pow_succ_padicValNat_not_dvd {n : ℕ} [hp : Fact p.Prime] (hn : n ≠ 0) :
     ¬p ^ (padicValNat p n + 1) ∣ n := by
@@ -688,24 +695,32 @@ end padicValNat
 
 section padicValInt
 
-variable {p : ℕ} [hp : Fact p.Prime]
+variable {p : ℕ}
 
-theorem padicValInt_dvd_iff (n : ℕ) (a : ℤ) : (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a := by
-  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff, ← Int.natCast_dvd, Int.natCast_pow]
+theorem padicValInt_dvd_iff' (hp : p ≠ 1) (n : ℕ) (a : ℤ) :
+    (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a := by
+  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff' hp, ← Int.natCast_dvd,
+    Int.natCast_pow]
+
+theorem padicValInt_dvd_iff [hp : Fact p.Prime] (n : ℕ) (a : ℤ) :
+    (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a :=
+  padicValInt_dvd_iff' hp.out.ne_one n a
 
 theorem padicValInt_dvd (a : ℤ) : (p : ℤ) ^ padicValInt p a ∣ a := by
-  rw [padicValInt_dvd_iff]
+  by_cases hp : p = 1
+  · rw [hp, Nat.cast_one, one_pow]; exact one_dvd _
+  rw [padicValInt_dvd_iff' hp]
   exact Or.inr le_rfl
 
-theorem padicValInt_self : padicValInt p p = 1 :=
+theorem padicValInt_self [hp : Fact p.Prime] : padicValInt p p = 1 :=
   padicValInt.self hp.out.one_lt
 
-theorem padicValInt.mul {a b : ℤ} (ha : a ≠ 0) (hb : b ≠ 0) :
+theorem padicValInt.mul [hp : Fact p.Prime] {a b : ℤ} (ha : a ≠ 0) (hb : b ≠ 0) :
     padicValInt p (a * b) = padicValInt p a + padicValInt p b := by
   simp_rw [padicValInt]
   rw [Int.natAbs_mul, padicValNat.mul] <;> rwa [Int.natAbs_ne_zero]
 
-theorem padicValInt_mul_eq_succ (a : ℤ) (ha : a ≠ 0) :
+theorem padicValInt_mul_eq_succ [hp : Fact p.Prime] (a : ℤ) (ha : a ≠ 0) :
     padicValInt p (a * p) = padicValInt p a + 1 := by
   rw [padicValInt.mul ha (Int.natCast_ne_zero.mpr hp.out.ne_zero)]
   simp only [padicValInt.of_nat, padicValNat_self]

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -51,13 +51,16 @@ theorem padicValNat_def [hp : Fact p.Prime] {n : ℕ} (hn : n ≠ 0) :
   padicValNat_def' hp.out.ne_one hn
 
 set_option backward.isDefEq.respectTransparency false in
+theorem padicValNat_eq_emultiplicity' (hp : p ≠ 1) {n : ℕ} (hn : n ≠ 0) :
+    padicValNat p n = emultiplicity p n := by
+  rw [padicValNat_def' hp hn,
+    (finiteMultiplicity_iff.2 ⟨hp, Nat.pos_of_ne_zero hn⟩).emultiplicity_eq_multiplicity]
+
 /-- A simplification of `padicValNat` when one input is prime, by analogy with
 `padicValRat_def`. -/
 theorem padicValNat_eq_emultiplicity [hp : Fact p.Prime] {n : ℕ} (hn : n ≠ 0) :
-    padicValNat p n = emultiplicity p n := by
-  rw [(finiteMultiplicity_iff.2
-    ⟨hp.out.ne_one, Nat.pos_iff_ne_zero.mpr hn⟩).emultiplicity_eq_multiplicity]
-  exact_mod_cast padicValNat_def hn
+    padicValNat p n = emultiplicity p n :=
+  padicValNat_eq_emultiplicity' hp.out.ne_one hn
 
 namespace padicValNat
 

--- a/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Defs.lean
@@ -51,7 +51,7 @@ theorem padicValNat_def [hp : Fact p.Prime] {n : ℕ} (hn : n ≠ 0) :
   padicValNat_def' hp.out.ne_one hn
 
 set_option backward.isDefEq.respectTransparency false in
-theorem padicValNat_eq_emultiplicity' (hp : p ≠ 1) {n : ℕ} (hn : n ≠ 0) :
+theorem padicValNat_eq_emultiplicity_of_ne_one (hp : p ≠ 1) {n : ℕ} (hn : n ≠ 0) :
     padicValNat p n = emultiplicity p n := by
   rw [padicValNat_def' hp hn,
     (finiteMultiplicity_iff.2 ⟨hp, Nat.pos_of_ne_zero hn⟩).emultiplicity_eq_multiplicity]
@@ -60,7 +60,7 @@ theorem padicValNat_eq_emultiplicity' (hp : p ≠ 1) {n : ℕ} (hn : n ≠ 0) :
 `padicValRat_def`. -/
 theorem padicValNat_eq_emultiplicity [hp : Fact p.Prime] {n : ℕ} (hn : n ≠ 0) :
     padicValNat p n = emultiplicity p n :=
-  padicValNat_eq_emultiplicity' hp.out.ne_one hn
+  padicValNat_eq_emultiplicity_of_ne_one hp.out.ne_one hn
 
 namespace padicValNat
 


### PR DESCRIPTION
Also drop the unnecessary primality condition from padicValInt_dvd.

From flt-regular.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
