### PR TITLE
[Merged by Bors] - chore: Rename ncard_image_of_injOn

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
@@ -64,7 +64,7 @@ lemma ncard_inter (hrep : Represents s C) (h : c ∈ C) : (s ∩ c.supp).ncard =
   exact exists_inter_eq_singleton hrep h
 
 lemma ncard_eq (hrep : Represents s C) : s.ncard = C.ncard :=
-  hrep.image_eq ▸ (Set.ncard_image_of_injOn hrep.injOn).symm
+  hrep.image_eq ▸ (Set.InjOn.ncard_image hrep.injOn).symm
 
 lemma ncard_sdiff_of_mem (hrep : Represents s C) (h : c ∈ C) :
     (c.supp \ s).ncard = c.supp.ncard - 1 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
@@ -64,7 +64,7 @@ lemma ncard_inter (hrep : Represents s C) (h : c ∈ C) : (s ∩ c.supp).ncard =
   exact exists_inter_eq_singleton hrep h
 
 lemma ncard_eq (hrep : Represents s C) : s.ncard = C.ncard :=
-  hrep.image_eq ▸ (Set.InjOn.ncard_image hrep.injOn).symm
+  hrep.image_eq ▸ (hrep.injOn.ncard_image).symm
 
 lemma ncard_sdiff_of_mem (hrep : Represents s C) (h : c ∈ C) :
     (c.supp \ s).ncard = c.supp.ncard - 1 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Represents.lean
@@ -64,7 +64,7 @@ lemma ncard_inter (hrep : Represents s C) (h : c ∈ C) : (s ∩ c.supp).ncard =
   exact exists_inter_eq_singleton hrep h
 
 lemma ncard_eq (hrep : Represents s C) : s.ncard = C.ncard :=
-  hrep.image_eq ▸ (hrep.injOn.ncard_image).symm
+  hrep.image_eq ▸ hrep.injOn.ncard_image.symm
 
 lemma ncard_sdiff_of_mem (hrep : Represents s C) (h : c ∈ C) :
     (c.supp \ s).ncard = c.supp.ncard - 1 := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -743,8 +743,10 @@ variable {f : α → β}
 theorem ncard_image_le (hs : s.Finite := by toFinite_tac) : (f '' s).ncard ≤ s.ncard := by
   to_encard_tac; rw [hs.cast_ncard_eq, (hs.image _).cast_ncard_eq]; apply encard_image_le
 
-theorem ncard_image_of_injOn (H : Set.InjOn f s) : (f '' s).ncard = s.ncard :=
+theorem InjOn.ncard_image (H : Set.InjOn f s) : (f '' s).ncard = s.ncard :=
   congr_arg ENat.toNat <| H.encard_image
+
+@[deprecated (since := "2026-01-30")] alias ncard_image_of_injOn := InjOn.ncard_image
 
 theorem injOn_of_ncard_image_eq (h : (f '' s).ncard = s.ncard) (hs : s.Finite := by toFinite_tac) :
     Set.InjOn f s := by
@@ -753,10 +755,10 @@ theorem injOn_of_ncard_image_eq (h : (f '' s).ncard = s.ncard) (hs : s.Finite :=
 
 theorem ncard_image_iff (hs : s.Finite := by toFinite_tac) :
     (f '' s).ncard = s.ncard ↔ Set.InjOn f s :=
-  ⟨fun h ↦ injOn_of_ncard_image_eq h hs, ncard_image_of_injOn⟩
+  ⟨fun h ↦ injOn_of_ncard_image_eq h hs, InjOn.ncard_image⟩
 
 theorem ncard_image_of_injective (s : Set α) (H : f.Injective) : (f '' s).ncard = s.ncard :=
-  ncard_image_of_injOn fun _ _ _ _ h ↦ H h
+  InjOn.ncard_image fun _ _ _ _ h ↦ H h
 
 theorem ncard_preimage_of_injective_subset_range {s : Set β} (H : f.Injective)
     (hs : s ⊆ Set.range f) :
@@ -821,7 +823,7 @@ theorem ncard_eq_of_bijective {n : ℕ} (f : ∀ i, i < n → α)
   let f' : Fin n → α := fun i ↦ f i.val i.is_lt
   suffices himage : s = f' '' Set.univ by
     rw [← Fintype.card_fin n, ← Nat.card_eq_fintype_card, ← Set.ncard_univ, himage]
-    exact ncard_image_of_injOn <| fun i _hi j _hj h ↦ Fin.ext <| f_inj i.val j.val i.is_lt j.is_lt h
+    exact InjOn.ncard_image <| fun i _hi j _hj h ↦ Fin.ext <| f_inj i.val j.val i.is_lt j.is_lt h
   ext x
   simp only [image_univ, mem_range]
   refine ⟨fun hx ↦ ?_, fun ⟨⟨i, hi⟩, hx⟩ ↦ hx ▸ hf' i hi⟩
@@ -919,7 +921,7 @@ theorem ncard_coe {α : Type*} (s : Set α) :
     Set.ncard (Set.univ : Set (Set.Elem s)) = s.ncard := by simp
 
 @[simp] lemma ncard_graphOn (s : Set α) (f : α → β) : (s.graphOn f).ncard = s.ncard := by
-  rw [← ncard_image_of_injOn fst_injOn_graph, image_fst_graphOn]
+  rw [← InjOn.ncard_image fst_injOn_graph, image_fst_graphOn]
 
 section Lattice
 

--- a/Mathlib/RingTheory/PowerSeries/Ideal.lean
+++ b/Mathlib/RingTheory/PowerSeries/Ideal.lean
@@ -136,7 +136,7 @@ theorem exist_eq_span_eq_ncard_of_X_notMem (hI : X ∉ I) {S : Set R}
   obtain ⟨T, hTI, hinj, hT⟩ := this.exists_subset_injOn_image_eq
   refine ⟨T, eq_of_le_of_X_notMem_of_fg_of_isPrime (span_le.2  hTI) hI (Submodule.fg_def.2
     ⟨T, (hT ▸ hS).of_finite_image hinj, rfl⟩) ?_, Finite.of_injOn
-    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ (hinj.ncard_image).symm⟩
+    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ hinj.ncard_image.symm⟩
   rw [map_le_iff_le_comap]
   intro f hf
   rw [mem_comap, mem_map_iff_of_surjective _ constantCoeff_surj]

--- a/Mathlib/RingTheory/PowerSeries/Ideal.lean
+++ b/Mathlib/RingTheory/PowerSeries/Ideal.lean
@@ -136,7 +136,7 @@ theorem exist_eq_span_eq_ncard_of_X_notMem (hI : X ∉ I) {S : Set R}
   obtain ⟨T, hTI, hinj, hT⟩ := this.exists_subset_injOn_image_eq
   refine ⟨T, eq_of_le_of_X_notMem_of_fg_of_isPrime (span_le.2  hTI) hI (Submodule.fg_def.2
     ⟨T, (hT ▸ hS).of_finite_image hinj, rfl⟩) ?_, Finite.of_injOn
-    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ (InjOn.ncard_image hinj).symm⟩
+    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ (hinj.ncard_image).symm⟩
   rw [map_le_iff_le_comap]
   intro f hf
   rw [mem_comap, mem_map_iff_of_surjective _ constantCoeff_surj]

--- a/Mathlib/RingTheory/PowerSeries/Ideal.lean
+++ b/Mathlib/RingTheory/PowerSeries/Ideal.lean
@@ -136,7 +136,7 @@ theorem exist_eq_span_eq_ncard_of_X_notMem (hI : X ∉ I) {S : Set R}
   obtain ⟨T, hTI, hinj, hT⟩ := this.exists_subset_injOn_image_eq
   refine ⟨T, eq_of_le_of_X_notMem_of_fg_of_isPrime (span_le.2  hTI) hI (Submodule.fg_def.2
     ⟨T, (hT ▸ hS).of_finite_image hinj, rfl⟩) ?_, Finite.of_injOn
-    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ (ncard_image_of_injOn hinj).symm⟩
+    (fun f hf ↦ hT ▸ Set.mem_image_of_mem _ hf) hinj hS, hT ▸ (InjOn.ncard_image hinj).symm⟩
   rw [map_le_iff_le_comap]
   intro f hf
   rw [mem_comap, mem_map_iff_of_surjective _ constantCoeff_surj]


### PR DESCRIPTION
See [zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Consistent.20naming.20scheme.20in.20Data.2FSet.2FCard/with/570464688), there are inconsistent namings.

