### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/ConvexSpace): show AffineSpace is a ConvexSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4602,6 +4602,7 @@ public import Mathlib.LinearAlgebra.Complex.Module
 public import Mathlib.LinearAlgebra.Complex.Orientation
 public import Mathlib.LinearAlgebra.Contraction
 public import Mathlib.LinearAlgebra.ConvexSpace
+public import Mathlib.LinearAlgebra.ConvexSpace.AffineSpace
 public import Mathlib.LinearAlgebra.Countable
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.DFinsupp

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -6,7 +6,8 @@ Authors: Kim Morrison
 module
 
 public import Mathlib.LinearAlgebra.ConvexSpace
-import Mathlib.LinearAlgebra.AffineSpace.Combination
+public import Mathlib.LinearAlgebra.AffineSpace.Combination
+public import Mathlib.LinearAlgebra.AffineSpace.AffineMap
 
 /-!
 # Affine spaces are convex spaces
@@ -16,6 +17,9 @@ This file shows that every affine space is a convex space.
 ## Main results
 
 * `AddTorsor.instConvexSpace`: An affine space over a module is a convex space.
+* `AddTorsor.convexCombination_eq_affineCombination`: The convex combination equals the affine
+  combination.
+* `AddTorsor.convexComboPair_eq_lineMap`: Binary convex combinations are given by `lineMap`.
 -/
 
 noncomputable section
@@ -32,14 +36,14 @@ namespace AddTorsor
 public def convexCombination (s : StdSimplex R P) : P :=
   s.weights.support.affineCombination R id s.weights
 
-theorem convexCombination_single (x : P) :
+public theorem convexCombination_single (x : P) :
     convexCombination (StdSimplex.single x : StdSimplex R P) = x := by
   simp only [convexCombination, StdSimplex.single]
   rw [Finsupp.support_single_ne_zero _ one_ne_zero]
   exact ({x} : Finset P).affineCombination_of_eq_one_of_eq_zero _ _
     (Finset.mem_singleton_self x) Finsupp.single_eq_same fun j _ hne => Finsupp.single_eq_of_ne hne
 
-theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
+public theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
     convexCombination (f.map convexCombination) = convexCombination f.join := by
   classical
   -- Choose a base point
@@ -91,12 +95,42 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
       simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, hp', mul_zero,
         not_true_eq_false] at hp
 
-instance instConvexSpace : ConvexSpace R P where
+public instance instConvexSpace : ConvexSpace R P where
   convexCombination := convexCombination
   single := convexCombination_single
   assoc := convexCombination_assoc
 
--- TODO: we still need a public theorem stating how `ConvexSpace.convexCombination`
--- is defined in terms of the affine structure.
+/-- `ConvexSpace.convexCombination` in an affine space is the affine combination. -/
+public theorem convexCombination_eq_affineCombination (s : StdSimplex R P) :
+    @ConvexSpace.convexCombination R P _ _ _ instConvexSpace s =
+      s.weights.support.affineCombination R id s.weights := by
+  rfl
+
+/-- `convexComboPair` in an affine space is the affine line map. -/
+public theorem convexComboPair_eq_lineMap (s t : R) (hs : 0 ≤ s) (ht : 0 ≤ t)
+    (h : s + t = 1) (x y : P) :
+    convexComboPair s t hs ht h x y = AffineMap.lineMap y x s := by
+  simp only [convexComboPair, convexCombination_eq_affineCombination, StdSimplex.duple,
+    AffineMap.lineMap_apply]
+  classical
+  -- Use weighted subtraction with base point y
+  rw [Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ id (b := y)]
+  swap
+  · -- Prove sum of weights equals 1
+    trans (Finsupp.single x s + Finsupp.single y t).sum fun _ r => r
+    · apply Finset.sum_congr rfl
+      intro i _
+      simp only [Finsupp.coe_add, Pi.add_apply]
+    · rw [Finsupp.sum_add_index (by simp) (by simp), Finsupp.sum_single_index (by simp),
+        Finsupp.sum_single_index (by simp), h]
+  -- Now simplify the weighted subtraction
+  congr 1
+  rw [Finset.weightedVSubOfPoint_apply]
+  simp only [id]
+  -- Convert to Finsupp.sum
+  change (Finsupp.single x s + Finsupp.single y t).sum (fun p w => w • (p -ᵥ y)) = _
+  rw [Finsupp.sum_add_index (by simp) (fun _ a b => by simp [add_smul]),
+    Finsupp.sum_single_index (by simp), Finsupp.sum_single_index (by simp)]
+  simp [vsub_self]
 
 end AddTorsor

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.LinearAlgebra.ConvexSpace
+module
+
+public import Mathlib.LinearAlgebra.ConvexSpace
 import Mathlib.LinearAlgebra.AffineSpace.Combination
 
 /-!
@@ -27,17 +29,15 @@ variable [AddCommGroup V] [Module R V] [AddTorsor V P]
 namespace AddTorsor
 
 /-- The convex combination of points in an affine space, given a probability distribution. -/
-def convexCombination (s : StdSimplex R P) : P :=
+public def convexCombination (s : StdSimplex R P) : P :=
   s.weights.support.affineCombination R id s.weights
 
 theorem convexCombination_single (x : P) :
     convexCombination (StdSimplex.single x : StdSimplex R P) = x := by
   simp only [convexCombination, StdSimplex.single]
   rw [Finsupp.support_single_ne_zero _ one_ne_zero]
-  refine ({x} : Finset P).affineCombination_of_eq_one_of_eq_zero _ _
-    (Finset.mem_singleton_self x) Finsupp.single_eq_same ?_
-  intro j _ hne
-  exact Finsupp.single_eq_of_ne hne
+  exact ({x} : Finset P).affineCombination_of_eq_one_of_eq_zero _ _
+    (Finset.mem_singleton_self x) Finsupp.single_eq_same fun j _ hne => Finsupp.single_eq_of_ne hne
 
 theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
     convexCombination (f.map convexCombination) = convexCombination f.join := by
@@ -45,11 +45,11 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
   -- Choose a base point
   obtain ⟨b⟩ : Nonempty P := inferInstance
   -- Express both sides using weightedVSubOfPoint with base point b
-  have hL := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one R V P _ _ _ _
-    P (f.map convexCombination).weights.support (f.map convexCombination).weights id
+  have hL := Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one
+    (f.map convexCombination).weights.support (f.map convexCombination).weights id
     (f.map convexCombination).total b
-  have hR := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one R V P _ _ _ _
-    P f.join.weights.support f.join.weights id f.join.total b
+  have hR := Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one
+    f.join.weights.support f.join.weights id f.join.total b
   simp only [convexCombination, hL, hR]
   congr 1
   -- Now show the weighted vector sums are equal

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -96,4 +96,7 @@ instance instConvexSpace : ConvexSpace R P where
   single := convexCombination_single
   assoc := convexCombination_assoc
 
+-- TODO: we still need a public theorem stating how `ConvexSpace.convexCombination`
+-- is defined in terms of the affine structure.
+
 end AddTorsor

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.LinearAlgebra.ConvexSpace
+import Mathlib.LinearAlgebra.AffineSpace.Combination
+
+/-!
+# Affine spaces are convex spaces
+
+This file shows that every affine space is a convex space.
+
+## Main results
+
+* `AddTorsor.instConvexSpace`: An affine space over a module is a convex space.
+-/
+
+noncomputable section
+
+open scoped Affine
+
+variable {R : Type*} {V : Type*} {P : Type*}
+variable [Ring R] [PartialOrder R] [IsStrictOrderedRing R]
+variable [AddCommGroup V] [Module R V] [AddTorsor V P]
+
+namespace StdSimplex
+
+omit [IsStrictOrderedRing R] in
+/-- The sum of weights over the support equals 1. -/
+theorem support_sum (s : StdSimplex R P) : ∑ p ∈ s.weights.support, s.weights p = 1 :=
+  s.total
+
+end StdSimplex
+
+namespace AddTorsor
+
+/-- The convex combination of points in an affine space, given a probability distribution. -/
+def convexCombination (s : StdSimplex R P) : P :=
+  s.weights.support.affineCombination R id s.weights
+
+theorem convexCombination_single (x : P) :
+    convexCombination (StdSimplex.single x : StdSimplex R P) = x := by
+  simp only [convexCombination, StdSimplex.single]
+  rw [Finsupp.support_single_ne_zero _ one_ne_zero]
+  refine ({x} : Finset P).affineCombination_of_eq_one_of_eq_zero _ _
+    (Finset.mem_singleton_self x) Finsupp.single_eq_same ?_
+  intro j _ hne
+  exact Finsupp.single_eq_of_ne hne
+
+theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
+    convexCombination (f.map convexCombination) = convexCombination f.join := by
+  classical
+  -- Choose a base point
+  obtain ⟨b⟩ : Nonempty P := inferInstance
+  -- Express both sides using weightedVSubOfPoint with base point b
+  have hL := (f.map convexCombination).total
+  have hR := f.join.total
+  have eqL := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one
+    R V P _ _ _ _ P (f.map convexCombination).weights.support
+    (f.map convexCombination).weights id hL b
+  rw [convexCombination, eqL]
+  rw [convexCombination,
+    f.join.weights.support.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ hR b]
+  congr 1
+  -- Now show the weighted vector sums are equal
+  simp only [Finset.weightedVSubOfPoint_apply, StdSimplex.map, StdSimplex.join, id]
+  -- Rewrite LHS using sum_mapDomain_index
+  conv_lhs =>
+    rw [show ∑ x ∈ (Finsupp.mapDomain convexCombination f.weights).support,
+            (Finsupp.mapDomain convexCombination f.weights) x • (x -ᵥ b) =
+          (Finsupp.mapDomain convexCombination f.weights).sum
+            (fun x w => w • (x -ᵥ b)) from rfl]
+  rw [Finsupp.sum_mapDomain_index (fun _ => by simp) (fun _ _ _ => by simp [add_smul])]
+  -- LHS: f.weights.sum (fun d _ => f.weights d • (cc d -ᵥ b))
+  simp only [Finsupp.sum, convexCombination]
+  -- Expand cc d -ᵥ b
+  conv_lhs =>
+    congr; · skip
+    ext d
+    rw [d.weights.support.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one
+        _ _ d.total b, vadd_vsub, Finset.weightedVSubOfPoint_apply]
+    simp only [id]
+  simp_rw [Finset.smul_sum, smul_smul]
+  -- LHS: ∑_{d ∈ f.support} ∑_{p ∈ d.support} (f.weights d * d.weights p) • (p -ᵥ b)
+  -- RHS: ∑ x ∈ (∑ d ∈ f.support, f.weights d • d.weights).support, ... • (x -ᵥ b)
+  -- First expand RHS using sum_finset_sum_index
+  let h : P → R → V := fun x w => w • (x -ᵥ b)
+  have h_rhs : (∑ d ∈ f.weights.support, f.weights d • d.weights).sum h
+      = ∑ d ∈ f.weights.support, (f.weights d • d.weights).sum h :=
+    (Finsupp.sum_finset_sum_index (h := h) (fun _ => zero_smul _ _)
+      (fun _ _ _ => add_smul _ _ _)).symm
+  simp only [Finsupp.sum] at h_rhs ⊢
+  rw [h_rhs]
+  -- Now both sides are ∑_{d ∈ f.support} ∑_{p ∈ ...} ...
+  congr 1
+  ext d
+  simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul]
+  -- Need to show the inner sums match
+  -- LHS inner: ∑_{p ∈ d.support} (f.weights d * d.weights p) • (p -ᵥ b)
+  -- RHS inner: ∑_{p ∈ (f.weights d • d.weights).support} (f.weights d * d.weights p) • (p -ᵥ b)
+  -- The supports match when f.weights d ≠ 0 (which is the case in the outer sum)
+  by_cases hd : f.weights d = 0
+  · simp [hd]
+  · refine Finset.sum_congr ?_ (fun _ _ => rfl)
+    ext p
+    simp only [Finsupp.mem_support_iff, ne_eq]
+    constructor
+    · intro hp
+      -- Both f.weights d and d.weights p are non-negative and nonzero, hence positive
+      have hd_pos := (f.nonneg d).lt_of_ne' hd
+      have hp_pos := (d.nonneg p).lt_of_ne' hp
+      exact (mul_pos hd_pos hp_pos).ne'
+    · intro hp hp'
+      simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, hp', mul_zero,
+        not_true_eq_false] at hp
+
+instance instConvexSpace : ConvexSpace R P where
+  convexCombination := convexCombination
+  single := convexCombination_single
+  assoc := convexCombination_assoc
+
+end AddTorsor

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -24,15 +24,6 @@ variable {R : Type*} {V : Type*} {P : Type*}
 variable [Ring R] [PartialOrder R] [IsStrictOrderedRing R]
 variable [AddCommGroup V] [Module R V] [AddTorsor V P]
 
-namespace StdSimplex
-
-omit [IsStrictOrderedRing R] in
-/-- The sum of weights over the support equals 1. -/
-theorem support_sum (s : StdSimplex R P) : ∑ p ∈ s.weights.support, s.weights p = 1 :=
-  s.total
-
-end StdSimplex
-
 namespace AddTorsor
 
 /-- The convex combination of points in an affine space, given a probability distribution. -/
@@ -54,27 +45,20 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
   -- Choose a base point
   obtain ⟨b⟩ : Nonempty P := inferInstance
   -- Express both sides using weightedVSubOfPoint with base point b
-  have hL := (f.map convexCombination).total
-  have hR := f.join.total
-  have eqL := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one
-    R V P _ _ _ _ P (f.map convexCombination).weights.support
-    (f.map convexCombination).weights id hL b
-  rw [convexCombination, eqL]
-  rw [convexCombination,
-    f.join.weights.support.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ hR b]
+  have hL := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one R V P _ _ _ _
+    P (f.map convexCombination).weights.support (f.map convexCombination).weights id
+    (f.map convexCombination).total b
+  have hR := @Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one R V P _ _ _ _
+    P f.join.weights.support f.join.weights id f.join.total b
+  simp only [convexCombination, hL, hR]
   congr 1
   -- Now show the weighted vector sums are equal
   simp only [Finset.weightedVSubOfPoint_apply, StdSimplex.map, StdSimplex.join, id]
   -- Rewrite LHS using sum_mapDomain_index
-  conv_lhs =>
-    rw [show ∑ x ∈ (Finsupp.mapDomain convexCombination f.weights).support,
-            (Finsupp.mapDomain convexCombination f.weights) x • (x -ᵥ b) =
-          (Finsupp.mapDomain convexCombination f.weights).sum
-            (fun x w => w • (x -ᵥ b)) from rfl]
+  change (Finsupp.mapDomain convexCombination f.weights).sum (fun x w => w • (x -ᵥ b)) = _
   rw [Finsupp.sum_mapDomain_index (fun _ => by simp) (fun _ _ _ => by simp [add_smul])]
-  -- LHS: f.weights.sum (fun d _ => f.weights d • (cc d -ᵥ b))
   simp only [Finsupp.sum, convexCombination]
-  -- Expand cc d -ᵥ b
+  -- Expand convexCombination d using base point b
   conv_lhs =>
     congr; · skip
     ext d
@@ -82,9 +66,7 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
         _ _ d.total b, vadd_vsub, Finset.weightedVSubOfPoint_apply]
     simp only [id]
   simp_rw [Finset.smul_sum, smul_smul]
-  -- LHS: ∑_{d ∈ f.support} ∑_{p ∈ d.support} (f.weights d * d.weights p) • (p -ᵥ b)
-  -- RHS: ∑ x ∈ (∑ d ∈ f.support, f.weights d • d.weights).support, ... • (x -ᵥ b)
-  -- First expand RHS using sum_finset_sum_index
+  -- Expand RHS using sum_finset_sum_index
   let h : P → R → V := fun x w => w • (x -ᵥ b)
   have h_rhs : (∑ d ∈ f.weights.support, f.weights d • d.weights).sum h
       = ∑ d ∈ f.weights.support, (f.weights d • d.weights).sum h :=
@@ -92,14 +74,11 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
       (fun _ _ _ => add_smul _ _ _)).symm
   simp only [Finsupp.sum] at h_rhs ⊢
   rw [h_rhs]
-  -- Now both sides are ∑_{d ∈ f.support} ∑_{p ∈ ...} ...
+  -- Both sides are now double sums; show the inner sums match
   congr 1
   ext d
   simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul]
-  -- Need to show the inner sums match
-  -- LHS inner: ∑_{p ∈ d.support} (f.weights d * d.weights p) • (p -ᵥ b)
-  -- RHS inner: ∑_{p ∈ (f.weights d • d.weights).support} (f.weights d * d.weights p) • (p -ᵥ b)
-  -- The supports match when f.weights d ≠ 0 (which is the case in the outer sum)
+  -- Show that d.support = (f.weights d • d.weights).support
   by_cases hd : f.weights d = 0
   · simp [hd]
   · refine Finset.sum_congr ?_ (fun _ _ => rfl)
@@ -107,10 +86,7 @@ theorem convexCombination_assoc (f : StdSimplex R (StdSimplex R P)) :
     simp only [Finsupp.mem_support_iff, ne_eq]
     constructor
     · intro hp
-      -- Both f.weights d and d.weights p are non-negative and nonzero, hence positive
-      have hd_pos := (f.nonneg d).lt_of_ne' hd
-      have hp_pos := (d.nonneg p).lt_of_ne' hp
-      exact (mul_pos hd_pos hp_pos).ne'
+      exact (mul_pos ((f.nonneg d).lt_of_ne' hd) ((d.nonneg p).lt_of_ne' hp)).ne'
     · intro hp hp'
       simp only [Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul, hp', mul_zero,
         not_true_eq_false] at hp

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -102,8 +102,8 @@ public instance instConvexSpace : ConvexSpace R P where
 
 /-- `ConvexSpace.convexCombination` in an affine space is the affine combination. -/
 public theorem convexCombination_eq_affineCombination (s : StdSimplex R P) :
-    @ConvexSpace.convexCombination R P _ _ _ instConvexSpace s =
-      s.weights.support.affineCombination R id s.weights := by
+    letI : ConvexSpace R P := instConvexSpace
+    ConvexSpace.convexCombination s = s.weights.support.affineCombination R id s.weights := by
   rfl
 
 /-- `convexComboPair` in an affine space is the affine line map. -/


### PR DESCRIPTION
This PR shows that every affine space is a convex space, resolving a TODO item in `Mathlib.LinearAlgebra.ConvexSpace`.

The key components are:
- `AddTorsor.convexCombination`: convex combination using `affineCombination`
- `convexCombination_single`: unit law for convex combinations
- `convexCombination_assoc`: associativity law (monadic join)
- `AddTorsor.instConvexSpace`: the `ConvexSpace R P` instance

🤖 Prepared with Claude Code