### PR TITLE
[Merged by Bors] - feat(Topology): a continuous nonzero function does not change sign

### DIFF
--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -704,18 +704,13 @@ variable [SuccOrder β] [IsSuccArchimedean β]
 theorem IsPreconnected.iUnion_of_chain {s : β → Set α} (H : ∀ n, IsPreconnected (s n))
     (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsPreconnected (⋃ n, s n) :=
   IsPreconnected.iUnion_of_reflTransGen H fun _ _ =>
-    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
-      rw [inter_comm]
-      exact K i
+    reflTransGen_of_succ _ (fun i _ => K i) (by grind)
 
 /-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
   such that any two neighboring sets meet is connected. -/
 theorem IsConnected.iUnion_of_chain [Nonempty β] {s : β → Set α} (H : ∀ n, IsConnected (s n))
     (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n, s n) :=
-  IsConnected.iUnion_of_reflTransGen H fun _ _ =>
-    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
-      rw [inter_comm]
-      exact K i
+  IsConnected.iUnion_of_reflTransGen H fun _ _ => reflTransGen_of_succ _ (fun i _ => K i) (by grind)
 
 /-- The iUnion of preconnected sets indexed by a subset of a type with an archimedean successor
   (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -680,18 +680,18 @@ section OrderClosedTopology
 
 variable [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
 
-lemma IsPreconnected.subset_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
+lemma IsPreconnected.mapsTo_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
     (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) := by
   simpa [mapsTo_iff_image_subset] using
     (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
 
 lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
     (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x :=
-  (hs.subset_Ioi_or_Iio hf hfb).resolve_right (not_forall₂_of_exists₂_not (by grind)) hx
+  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_right (not_forall₂_of_exists₂_not (by grind)) hx
 
 lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
     (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b :=
-  (hs.subset_Ioi_or_Iio hf hfb).resolve_left (not_forall₂_of_exists₂_not (by grind)) hx
+  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_left (not_forall₂_of_exists₂_not (by grind)) hx
 
 end OrderClosedTopology
 

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -5,9 +5,8 @@ Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 module
 
-public import Mathlib.Data.Set.SymmDiff
 public import Mathlib.Order.SuccPred.Relation
-public import Mathlib.Topology.Irreducible
+public import Mathlib.Topology.Order.OrderClosed
 
 /-!
 # Connected subsets of topological spaces
@@ -200,56 +199,6 @@ theorem IsConnected.iUnion_of_reflTransGen {ι : Type*} [Nonempty ι] {s : ι �
     (K : ∀ i j, ReflTransGen (fun i j : ι => (s i ∩ s j).Nonempty) i j) : IsConnected (⋃ n, s n) :=
   ⟨nonempty_iUnion.2 <| Nonempty.elim ‹_› fun i : ι => ⟨i, (H _).nonempty⟩,
     IsPreconnected.iUnion_of_reflTransGen (fun i => (H i).isPreconnected) K⟩
-
-section SuccOrder
-
-open Order
-
-variable [LinearOrder β] [SuccOrder β] [IsSuccArchimedean β]
-
-/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
-  such that any two neighboring sets meet is preconnected. -/
-theorem IsPreconnected.iUnion_of_chain {s : β → Set α} (H : ∀ n, IsPreconnected (s n))
-    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsPreconnected (⋃ n, s n) :=
-  IsPreconnected.iUnion_of_reflTransGen H fun _ _ =>
-    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
-      rw [inter_comm]
-      exact K i
-
-/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
-  such that any two neighboring sets meet is connected. -/
-theorem IsConnected.iUnion_of_chain [Nonempty β] {s : β → Set α} (H : ∀ n, IsConnected (s n))
-    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n, s n) :=
-  IsConnected.iUnion_of_reflTransGen H fun _ _ =>
-    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
-      rw [inter_comm]
-      exact K i
-
-/-- The iUnion of preconnected sets indexed by a subset of a type with an archimedean successor
-  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
-theorem IsPreconnected.biUnion_of_chain {s : β → Set α} {t : Set β} (ht : OrdConnected t)
-    (H : ∀ n ∈ t, IsPreconnected (s n))
-    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) :
-    IsPreconnected (⋃ n ∈ t, s n) := by
-  have h1 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → k ∈ t := fun hi hj hk =>
-    ht.out hi hj (Ico_subset_Icc_self hk)
-  have h2 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → succ k ∈ t := fun hi hj hk =>
-    ht.out hi hj ⟨hk.1.trans <| le_succ _, succ_le_of_lt hk.2⟩
-  have h3 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → (s k ∩ s (succ k)).Nonempty :=
-    fun hi hj hk => K _ (h1 hi hj hk) (h2 hi hj hk)
-  refine IsPreconnected.biUnion_of_reflTransGen H fun i hi j hj => ?_
-  exact reflTransGen_of_succ _ (fun k hk => ⟨h3 hi hj hk, h1 hi hj hk⟩) fun k hk =>
-      ⟨by rw [inter_comm]; exact h3 hj hi hk, h2 hj hi hk⟩
-
-/-- The iUnion of connected sets indexed by a subset of a type with an archimedean successor
-  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
-theorem IsConnected.biUnion_of_chain {s : β → Set α} {t : Set β} (hnt : t.Nonempty)
-    (ht : OrdConnected t) (H : ∀ n ∈ t, IsConnected (s n))
-    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n ∈ t, s n) :=
-  ⟨nonempty_biUnion.2 <| ⟨hnt.some, hnt.some_mem, (H _ hnt.some_mem).nonempty⟩,
-    IsPreconnected.biUnion_of_chain ht (fun i hi => (H i hi).isPreconnected) K⟩
-
-end SuccOrder
 
 /-- Theorem of bark and tree: if a set is within a preconnected set and its closure, then it is
 preconnected as well. See also `IsConnected.subset_closure`. -/
@@ -720,5 +669,86 @@ theorem isPreconnected_iff_preconnectedSpace {s : Set α} : IsPreconnected s ↔
 theorem isConnected_iff_connectedSpace {s : Set α} : IsConnected s ↔ ConnectedSpace s :=
   ⟨Subtype.connectedSpace, fun h =>
     ⟨nonempty_subtype.mp h.2, isPreconnected_iff_preconnectedSpace.mpr h.1⟩⟩
+
+section Order
+
+open Order
+
+variable [LinearOrder β]
+
+section OrderClosedTopology
+
+variable [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
+
+lemma IsPreconnected.subset_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) : f '' s ⊆ Set.Ioi b ∨ f '' s ⊆ Set.Iio b :=
+  (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
+
+lemma IsPreconnected.lt_or_gt (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) : (∀ x ∈ s, b < f x) ∨ ∀ x ∈ s, f x < b := by
+  rcases hs.subset_Ioi_or_Iio hf hfb with (ha | hb)
+  all_goals simp_all; grind
+
+lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x := by
+  have := hs.lt_or_gt hf hfb
+  grind
+
+lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b := by
+  have := hs.lt_or_gt hf hfb
+  grind
+
+end OrderClosedTopology
+
+section SuccOrder
+
+variable [SuccOrder β] [IsSuccArchimedean β]
+
+/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
+  such that any two neighboring sets meet is preconnected. -/
+theorem IsPreconnected.iUnion_of_chain {s : β → Set α} (H : ∀ n, IsPreconnected (s n))
+    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsPreconnected (⋃ n, s n) :=
+  IsPreconnected.iUnion_of_reflTransGen H fun _ _ =>
+    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
+      rw [inter_comm]
+      exact K i
+
+/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
+  such that any two neighboring sets meet is connected. -/
+theorem IsConnected.iUnion_of_chain [Nonempty β] {s : β → Set α} (H : ∀ n, IsConnected (s n))
+    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n, s n) :=
+  IsConnected.iUnion_of_reflTransGen H fun _ _ =>
+    reflTransGen_of_succ _ (fun i _ => K i) fun i _ => by
+      rw [inter_comm]
+      exact K i
+
+/-- The iUnion of preconnected sets indexed by a subset of a type with an archimedean successor
+  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
+theorem IsPreconnected.biUnion_of_chain {s : β → Set α} {t : Set β} (ht : OrdConnected t)
+    (H : ∀ n ∈ t, IsPreconnected (s n))
+    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) :
+    IsPreconnected (⋃ n ∈ t, s n) := by
+  have h1 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → k ∈ t := fun hi hj hk =>
+    ht.out hi hj (Ico_subset_Icc_self hk)
+  have h2 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → succ k ∈ t := fun hi hj hk =>
+    ht.out hi hj ⟨hk.1.trans <| le_succ _, succ_le_of_lt hk.2⟩
+  have h3 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → (s k ∩ s (succ k)).Nonempty :=
+    fun hi hj hk => K _ (h1 hi hj hk) (h2 hi hj hk)
+  refine IsPreconnected.biUnion_of_reflTransGen H fun i hi j hj => ?_
+  exact reflTransGen_of_succ _ (fun k hk => ⟨h3 hi hj hk, h1 hi hj hk⟩) fun k hk =>
+      ⟨by rw [inter_comm]; exact h3 hj hi hk, h2 hj hi hk⟩
+
+/-- The iUnion of connected sets indexed by a subset of a type with an archimedean successor
+  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
+theorem IsConnected.biUnion_of_chain {s : β → Set α} {t : Set β} (hnt : t.Nonempty)
+    (ht : OrdConnected t) (H : ∀ n ∈ t, IsConnected (s n))
+    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n ∈ t, s n) :=
+  ⟨nonempty_biUnion.2 <| ⟨hnt.some, hnt.some_mem, (H _ hnt.some_mem).nonempty⟩,
+    IsPreconnected.biUnion_of_chain ht (fun i hi => (H i hi).isPreconnected) K⟩
+
+end SuccOrder
+
+end Order
 
 end Preconnected

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -686,16 +686,12 @@ lemma IsPreconnected.subset_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousO
     (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
 
 lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x := by
-  have := hs.subset_Ioi_or_Iio hf hfb
-  simp_all [MapsTo]
-  grind
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x :=
+  (hs.subset_Ioi_or_Iio hf hfb).resolve_right (not_forall₂_of_exists₂_not (by grind)) hx
 
 lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b := by
-  have := hs.subset_Ioi_or_Iio hf hfb
-  simp_all [MapsTo]
-  grind
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b :=
+  (hs.subset_Ioi_or_Iio hf hfb).resolve_left (not_forall₂_of_exists₂_not (by grind)) hx
 
 end OrderClosedTopology
 

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -681,22 +681,20 @@ section OrderClosedTopology
 variable [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
 
 lemma IsPreconnected.subset_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) :=
-  (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
-
-lemma IsPreconnected.lt_or_gt (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) : (∀ x ∈ s, b < f x) ∨ ∀ x ∈ s, f x < b := by
-  rcases hs.subset_Ioi_or_Iio hf hfb with (ha | hb)
-  all_goals simp_all; grind
+    (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) := by
+  simpa [mapsTo_iff_image_subset] using
+    (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
 
 lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
     (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x := by
-  have := hs.lt_or_gt hf hfb
+  have := hs.subset_Ioi_or_Iio hf hfb
+  simp_all [MapsTo]
   grind
 
 lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
     (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b := by
-  have := hs.lt_or_gt hf hfb
+  have := hs.subset_Ioi_or_Iio hf hfb
+  simp_all [MapsTo]
   grind
 
 end OrderClosedTopology

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -200,6 +200,51 @@ theorem IsConnected.iUnion_of_reflTransGen {ι : Type*} [Nonempty ι] {s : ι �
   ⟨nonempty_iUnion.2 <| Nonempty.elim ‹_› fun i : ι => ⟨i, (H _).nonempty⟩,
     IsPreconnected.iUnion_of_reflTransGen (fun i => (H i).isPreconnected) K⟩
 
+section SuccOrder
+
+open Order
+
+variable [LinearOrder β] [SuccOrder β] [IsSuccArchimedean β]
+
+/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
+  such that any two neighboring sets meet is preconnected. -/
+theorem IsPreconnected.iUnion_of_chain {s : β → Set α} (H : ∀ n, IsPreconnected (s n))
+    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsPreconnected (⋃ n, s n) :=
+  IsPreconnected.iUnion_of_reflTransGen H fun _ _ =>
+    reflTransGen_of_succ _ (fun i _ => K i) (by grind)
+
+/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
+  such that any two neighboring sets meet is connected. -/
+theorem IsConnected.iUnion_of_chain [Nonempty β] {s : β → Set α} (H : ∀ n, IsConnected (s n))
+    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n, s n) :=
+  IsConnected.iUnion_of_reflTransGen H fun _ _ => reflTransGen_of_succ _ (fun i _ => K i) (by grind)
+
+/-- The iUnion of preconnected sets indexed by a subset of a type with an archimedean successor
+  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
+theorem IsPreconnected.biUnion_of_chain {s : β → Set α} {t : Set β} (ht : OrdConnected t)
+    (H : ∀ n ∈ t, IsPreconnected (s n))
+    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) :
+    IsPreconnected (⋃ n ∈ t, s n) := by
+  have h1 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → k ∈ t := fun hi hj hk =>
+    ht.out hi hj (Ico_subset_Icc_self hk)
+  have h2 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → succ k ∈ t := fun hi hj hk =>
+    ht.out hi hj ⟨hk.1.trans <| le_succ _, succ_le_of_lt hk.2⟩
+  have h3 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → (s k ∩ s (succ k)).Nonempty :=
+    fun hi hj hk => K _ (h1 hi hj hk) (h2 hi hj hk)
+  refine IsPreconnected.biUnion_of_reflTransGen H fun i hi j hj => ?_
+  exact reflTransGen_of_succ _ (fun k hk => ⟨h3 hi hj hk, h1 hi hj hk⟩) fun k hk =>
+      ⟨by rw [inter_comm]; exact h3 hj hi hk, h2 hj hi hk⟩
+
+/-- The iUnion of connected sets indexed by a subset of a type with an archimedean successor
+  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
+theorem IsConnected.biUnion_of_chain {s : β → Set α} {t : Set β} (hnt : t.Nonempty)
+    (ht : OrdConnected t) (H : ∀ n ∈ t, IsConnected (s n))
+    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n ∈ t, s n) :=
+  ⟨nonempty_biUnion.2 <| ⟨hnt.some, hnt.some_mem, (H _ hnt.some_mem).nonempty⟩,
+    IsPreconnected.biUnion_of_chain ht (fun i hi => (H i hi).isPreconnected) K⟩
+
+end SuccOrder
+
 /-- Theorem of bark and tree: if a set is within a preconnected set and its closure, then it is
 preconnected as well. See also `IsConnected.subset_closure`. -/
 protected theorem IsPreconnected.subset_closure {s : Set α} {t : Set α} (H : IsPreconnected s)
@@ -329,6 +374,25 @@ theorem IsPreconnected.subset_or_subset (hu : IsOpen u) (hv : IsOpen v) (huv : D
     simp_rw [Set.not_nonempty_iff_eq_empty, ← Set.disjoint_iff_inter_eq_empty,
       disjoint_iff_inter_eq_empty.1 huv] at hs
     exact Or.inl ((hs s.disjoint_empty).subset_left_of_subset_union hsuv)
+
+section OrderClosedTopology
+
+variable [LinearOrder β] [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
+
+lemma IsPreconnected.mapsTo_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) := by
+  simpa [mapsTo_iff_image_subset] using
+    (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
+
+lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x :=
+  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_right (not_forall₂_of_exists₂_not (by grind)) hx
+
+lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
+    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b :=
+  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_left (not_forall₂_of_exists₂_not (by grind)) hx
+
+end OrderClosedTopology
 
 theorem IsPreconnected.subset_left_of_subset_union (hu : IsOpen u) (hv : IsOpen v)
     (huv : Disjoint u v) (hsuv : s ⊆ u ∪ v) (hsu : (s ∩ u).Nonempty) (hs : IsPreconnected s) :
@@ -669,75 +733,5 @@ theorem isPreconnected_iff_preconnectedSpace {s : Set α} : IsPreconnected s ↔
 theorem isConnected_iff_connectedSpace {s : Set α} : IsConnected s ↔ ConnectedSpace s :=
   ⟨Subtype.connectedSpace, fun h =>
     ⟨nonempty_subtype.mp h.2, isPreconnected_iff_preconnectedSpace.mpr h.1⟩⟩
-
-section Order
-
-open Order
-
-variable [LinearOrder β]
-
-section OrderClosedTopology
-
-variable [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
-
-lemma IsPreconnected.mapsTo_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) := by
-  simpa [mapsTo_iff_image_subset] using
-    (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
-
-lemma IsPreconnected.lt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, b < f x) {x : α} (hx : x ∈ s) : b < f x :=
-  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_right (not_forall₂_of_exists₂_not (by grind)) hx
-
-lemma IsPreconnected.gt_of_ne (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) (hfx : ∃ x ∈ s, f x < b) {x : α} (hx : x ∈ s) : f x < b :=
-  (hs.mapsTo_Ioi_or_Iio hf hfb).resolve_left (not_forall₂_of_exists₂_not (by grind)) hx
-
-end OrderClosedTopology
-
-section SuccOrder
-
-variable [SuccOrder β] [IsSuccArchimedean β]
-
-/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
-  such that any two neighboring sets meet is preconnected. -/
-theorem IsPreconnected.iUnion_of_chain {s : β → Set α} (H : ∀ n, IsPreconnected (s n))
-    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsPreconnected (⋃ n, s n) :=
-  IsPreconnected.iUnion_of_reflTransGen H fun _ _ =>
-    reflTransGen_of_succ _ (fun i _ => K i) (by grind)
-
-/-- The iUnion of connected sets indexed by a type with an archimedean successor (like `ℕ` or `ℤ`)
-  such that any two neighboring sets meet is connected. -/
-theorem IsConnected.iUnion_of_chain [Nonempty β] {s : β → Set α} (H : ∀ n, IsConnected (s n))
-    (K : ∀ n, (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n, s n) :=
-  IsConnected.iUnion_of_reflTransGen H fun _ _ => reflTransGen_of_succ _ (fun i _ => K i) (by grind)
-
-/-- The iUnion of preconnected sets indexed by a subset of a type with an archimedean successor
-  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
-theorem IsPreconnected.biUnion_of_chain {s : β → Set α} {t : Set β} (ht : OrdConnected t)
-    (H : ∀ n ∈ t, IsPreconnected (s n))
-    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) :
-    IsPreconnected (⋃ n ∈ t, s n) := by
-  have h1 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → k ∈ t := fun hi hj hk =>
-    ht.out hi hj (Ico_subset_Icc_self hk)
-  have h2 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → succ k ∈ t := fun hi hj hk =>
-    ht.out hi hj ⟨hk.1.trans <| le_succ _, succ_le_of_lt hk.2⟩
-  have h3 : ∀ {i j k : β}, i ∈ t → j ∈ t → k ∈ Ico i j → (s k ∩ s (succ k)).Nonempty :=
-    fun hi hj hk => K _ (h1 hi hj hk) (h2 hi hj hk)
-  refine IsPreconnected.biUnion_of_reflTransGen H fun i hi j hj => ?_
-  exact reflTransGen_of_succ _ (fun k hk => ⟨h3 hi hj hk, h1 hi hj hk⟩) fun k hk =>
-      ⟨by rw [inter_comm]; exact h3 hj hi hk, h2 hj hi hk⟩
-
-/-- The iUnion of connected sets indexed by a subset of a type with an archimedean successor
-  (like `ℕ` or `ℤ`) such that any two neighboring sets meet is preconnected. -/
-theorem IsConnected.biUnion_of_chain {s : β → Set α} {t : Set β} (hnt : t.Nonempty)
-    (ht : OrdConnected t) (H : ∀ n ∈ t, IsConnected (s n))
-    (K : ∀ n : β, n ∈ t → succ n ∈ t → (s n ∩ s (succ n)).Nonempty) : IsConnected (⋃ n ∈ t, s n) :=
-  ⟨nonempty_biUnion.2 <| ⟨hnt.some, hnt.some_mem, (H _ hnt.some_mem).nonempty⟩,
-    IsPreconnected.biUnion_of_chain ht (fun i hi => (H i hi).isPreconnected) K⟩
-
-end SuccOrder
-
-end Order
 
 end Preconnected

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -681,7 +681,7 @@ section OrderClosedTopology
 variable [TopologicalSpace β] [OrderClosedTopology β] {f : α → β} {b : β}
 
 lemma IsPreconnected.subset_Ioi_or_Iio (hs : IsPreconnected s) (hf : ContinuousOn f s)
-    (hfb : ∀ x ∈ s, f x ≠ b) : f '' s ⊆ Set.Ioi b ∨ f '' s ⊆ Set.Iio b :=
+    (hfb : ∀ x ∈ s, f x ≠ b) : Set.MapsTo f s (Set.Ioi b) ∨ Set.MapsTo f s (Set.Iio b) :=
   (hs.image f hf).subset_or_subset isOpen_Ioi isOpen_Iio (by grind) (by grind)
 
 lemma IsPreconnected.lt_or_gt (hs : IsPreconnected s) (hf : ContinuousOn f s)


### PR DESCRIPTION
The main theorem proved in this PR is `IsPreconnected.subset_Ioi_or_Iio`, which says that if a function `f : α → β` is continuous on a preconnected set `s` and `f` is never equal to `b`, then the range of `f` is a subset of `Ioi b` or `Iio b`. I proved this under the assumption that `β` is equipped with an order closed topology. A typical application of this lemma is that a nonzero real valued continuous function does not change sign.

I move the section SuccOrder to the bottom of the file in order to declare less variables. I also proved some variants/corollary of `IsPreconnected.subset_Ioi_or_Iio`. 

Zulip discusion: [#Is there code for X? > A nonzero function does not change sign](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/A.20nonzero.20function.20does.20not.20change.20sign/with/570871797)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
