### PR TITLE
[Merged by Bors] - chore: use custom docker image for codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,6 @@
-FROM mcr.microsoft.com/devcontainers/base:jammy
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 USER vscode
 WORKDIR /home/vscode
 
 RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
-
-ENV PATH="/home/vscode/.elan/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,20 @@
 {
   "name": "Mathlib4 dev container",
 
-  "image": "ghcr.io/leanprover-community/mathlib4/gitpod",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
 
   "onCreateCommand": "lake exe cache get!",
 
   "hostRequirements": {
-     "cpus": 4
+    "cpus": 4,
+    "memory": "8gb"
   },
 
   "customizations": {
-    "vscode" : {
-      "extensions" : [ "leanprover.lean4" ]
+    "vscode": {
+      "extensions": ["leanprover.lean4"]
     }
   }
 }


### PR DESCRIPTION
After a lot of experimentation with the help of @b-mehta, this is my best guess as to why codespaces sometimes failed:

Codespaces uses the [pre-built gitpod docker image](https://github.com/leanprover-community/mathlib4/pkgs/container/mathlib4%2Fgitpod). This image is updated daily and includes not just elan but also a copy of the toolchain currently used by mathlib master, to speed up codespace initialization time.

The default tier of codespaces runners are limited to 32 GiB of storage space. While a fully initialized codespace has more than enough free space, there is a lot less space available during initialization of the codespace (I don't know why).

When opening a codespace for a different toolchain than the one used by mathlib master, the second toolchain combined with the data downloaded and unpacked by `lake exe cache get` takes up more space than is left in the codespace. This causes initialization to fail and the codespace to switch to a rescue image. The rescue image is usually alpine-based, where lean won't work, resulting in a broken codespace after a considerable amount of waiting.

Simply setting `hostRequirements.storage` to a higher value in `devcontainer.json` won't work, since GitHub will say that no runner machines with this configuration are available. Maybe paying for codespaces unlocks more powerful runners, but that's an unreasonable hurdle for the average person who just wants to experiment with lean/mathlib a bit.

This PR hopes to solve the problem by switching back to the custom devcontainer docker image that doesn't include a default toolchain. This increases the codespace initialization time a bit: A gitpod docker image based codespace takes about **4 minutes** to finish initializing, but breaks if the toolchain doesn't match mathlib master. A custom docker image based codespace takes about **5 minutes** to finish initializing (the extra time mostly due to installing the lean toolchain; bulding the custom image is pretty quick), but should work with any toolchain.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
