### PR TITLE
[Merged by Bors] - feat(SimpleGraph): relate `takeUntil`/`dropUntil` to `take`/`drop`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
@@ -57,6 +57,24 @@ lemma takeUntil_first (p : G.Walk u v) :
 lemma nil_takeUntil (p : G.Walk u v) (hwp : w ∈ p.support) :
     (p.takeUntil w hwp).Nil ↔ u = w := ⟨Nil.eq, (by cases ·; simp)⟩
 
+lemma takeUntil_eq_take (p : G.Walk u v) (h : w ∈ p.support) :
+    p.takeUntil w h = (p.take <| p.support.idxOf w).copy rfl (p.getVert_support_idxOf h) := by
+  apply ext_support
+  induction p with
+  | nil =>
+    simp only [takeUntil, eq_mpr_eq_cast, support_nil, getVert_nil, take, support_copy]
+    grind [mem_support_nil_iff, support_nil]
+  | @cons a _ _ _ p ih =>
+    by_cases! h' : w = a
+    · grind [List.idxOf_cons_self, take_zero, copy_rfl_rfl, support_nil, takeUntil_first]
+    · rw [take_cons_eq _ _ _ (by grind), takeUntil_cons (List.mem_of_ne_of_mem h' h) h'.symm,
+        support_cons, support_copy, ih (by grind)]
+      grind
+
+lemma length_takeUntil (p : G.Walk u v) (h : w ∈ p.support) :
+    (p.takeUntil w h).length = p.support.idxOf w := by
+  simp [takeUntil_eq_take, Nat.le_iff_lt_add_one, ← length_support, List.idxOf_lt_length_of_mem h]
+
 /-- Given a vertex in the support of a path, give the path from (and including) that vertex to
 the end. In other words, drop vertices from the front of a path until (and not including)
 that vertex. -/
@@ -84,6 +102,29 @@ theorem take_spec {u v w : V} (p : G.Walk v w) (h : u ∈ p.support) :
     · simp!
     · simp! only
       split_ifs with h' <;> subst_vars <;> simp [*]
+
+@[simp]
+lemma dropUntil_first (p : G.Walk u v) (h : u ∈ p.support) : p.dropUntil u h = p := by
+  unfold dropUntil
+  split <;> simp
+
+lemma dropUntil_eq_drop (p : G.Walk u v) (h : w ∈ p.support) :
+    p.dropUntil w h = (p.drop <| p.support.idxOf w).copy (p.getVert_support_idxOf h) rfl := by
+  apply ext_support
+  induction p with
+  | nil =>
+    simp only [dropUntil, eq_mpr_eq_cast, support_nil, getVert_nil, drop, support_copy]
+    grind [mem_support_nil_iff, support_nil]
+  | @cons a _ _ _ p ih =>
+    by_cases! h' : w = a
+    · subst h'
+      simp [dropUntil_first, drop_support_eq_support_drop_min]
+    · rw [drop_cons_eq _ _ _ (by grind), support_copy, dropUntil]
+      grind
+
+lemma length_dropUntil (p : G.Walk u v) (h : w ∈ p.support) :
+    (p.dropUntil w h).length = p.length - p.support.idxOf w := by
+  simp [dropUntil_eq_drop]
 
 theorem isSubwalk_takeUntil (p : G.Walk u v) (h : w ∈ p.support) : (p.takeUntil w h).IsSubwalk p :=
   ⟨nil, p.dropUntil w h, by simp⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -524,6 +524,13 @@ lemma drop_add_eq (p : G.Walk u v) (n m : ℕ) :
 lemma nil_drop_iff (p : G.Walk u v) (n : ℕ) : (p.drop n).Nil ↔ p.length ≤ n := by
   induction p generalizing n <;> cases n <;> simp [*, drop]
 
+lemma drop_cons_eq (h : G.Adj u v) (p : G.Walk v w) (n : ℕ) (hn : n ≠ 0) :
+    (cons h p).drop n = (p.drop (n - 1)).copy (p.getVert_cons h hn).symm rfl := by
+  apply ext_support
+  obtain ⟨_, rfl⟩ := Nat.exists_add_one_eq.mpr (Nat.ne_zero_iff_zero_lt.mp hn)
+  conv_lhs => unfold drop
+  simp
+
 lemma darts_drop (p : G.Walk u v) (n : ℕ) : (p.drop n).darts = p.darts.drop n := by
   induction p generalizing n <;> cases n <;> simp [*, drop]
 
@@ -575,6 +582,11 @@ lemma take_of_length_le {u v n} {p : G.Walk u v} (h : p.length ≤ n) :
     · simp [take]
     rw [length_cons, Nat.add_le_add_iff_right] at h
     simp [take, ih h]
+
+lemma take_cons_eq (h : G.Adj u v) (p : G.Walk v w) (n : ℕ) (hn : n ≠ 0) :
+    (cons h p).take n = cons h ((p.take <| n - 1).copy rfl (p.getVert_cons h hn).symm) := by
+  apply ext_support
+  grind [support_copy, take_support_eq_support_take_succ]
 
 lemma darts_take (p : G.Walk u v) (n : ℕ) : (p.take n).darts = p.darts.take n := by
   induction p generalizing n <;> cases n <;> simp [*, take]

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
@@ -110,6 +110,11 @@ lemma getVert_eq_getD_support {u v : V} (p : G.Walk u v) (n : ℕ) :
   · simp [← getVert_eq_support_getElem? p h]
   grind [getVert_of_length_le, length_support]
 
+@[simp]
+lemma getVert_support_idxOf [DecidableEq V] (p : G.Walk u v) (h : w ∈ p.support) :
+    p.getVert (p.support.idxOf w) = w := by
+  grind [getVert_eq_support_getElem]
+
 theorem getVert_comp_val_eq_get_support {u v : V} (p : G.Walk u v) :
     p.getVert ∘ Fin.val = p.support.get := by
   grind [getVert_eq_support_getElem, length_support]


### PR DESCRIPTION
Add lemmas to allow going from takeUntil/dropUntil to a take/drop in terms of an explicit index `p.support.idxOf w`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
