### PR TITLE
[Merged by Bors] - chore(FieldTheory/Galois/NormalBasis): don't expose file

### DIFF
--- a/Mathlib/FieldTheory/Galois/NormalBasis.lean
+++ b/Mathlib/FieldTheory/Galois/NormalBasis.lean
@@ -23,13 +23,11 @@ The proof follows [ConradLinearChar] Keith Conrad, *Linear Independence of Chara
 
 -/
 
-@[expose] public section
-
 variable (K L : Type*) [Field K] [Field L] [Algebra K L]
 
 open Polynomial FiniteField Module Submodule LinearMap in
 -- [ConradLinearChar] Theorem 3.7.
-private theorem exists_linearIndependent_algEquiv_apply_of_finite [Finite L] :
+theorem exists_linearIndependent_algEquiv_apply_of_finite [Finite L] :
     ∃ x : L, LinearIndependent K fun σ : Gal(L/K) ↦ σ x := by
   have := Finite.of_injective _ (algebraMap K L).injective
   have := Fintype.ofFinite K
@@ -59,7 +57,7 @@ private theorem exists_linearIndependent_algEquiv_apply_of_finite [Finite L] :
 variable [FiniteDimensional K L]
 
 -- [ConradLinearChar] Theorem 3.6.
-private theorem exists_linearIndependent_algEquiv_apply_of_infinite [Infinite K] :
+theorem exists_linearIndependent_algEquiv_apply_of_infinite [Infinite K] :
     ∃ x : L, LinearIndependent K fun σ : Gal(L/K) ↦ σ x := by
   classical
   /- Choose a basis `e` of `L` over `K` and form the matrix `M` with entries
@@ -105,7 +103,7 @@ private theorem exists_linearIndependent_algEquiv_apply_of_infinite [Infinite K]
   simp_rw [M, Pi.zero_apply, map_zero, ← ha]
   simp [Algebra.smul_def, Matrix.mulVec_eq_sum, mul_comm]
 
-theorem exists_linearIndependent_algEquiv_apply :
+public theorem exists_linearIndependent_algEquiv_apply :
     ∃ x : L, LinearIndependent K fun σ : Gal(L/K) ↦ σ x := by
   obtain h | h := finite_or_infinite K
   · have := Module.finite_of_finite K (M := L)
@@ -118,14 +116,14 @@ variable [IsGalois K L]
 
 /-- Given a finite Galois extension `L/K`, `normalBasis K L` is a basis of `L` over `K`
 that is an orbit under the Galois group action. -/
-noncomputable def normalBasis : Module.Basis Gal(L/K) K L :=
+public noncomputable def normalBasis : Module.Basis Gal(L/K) K L :=
   basisOfLinearIndependentOfCardEqFinrank
     (exists_linearIndependent_algEquiv_apply K L).choose_spec
     (Fintype.card_eq_nat_card.trans <| card_aut_eq_finrank K L)
 
 variable {K L}
 
-theorem normalBasis_apply (e : Gal(L/K)) : normalBasis K L e = e (normalBasis K L 1) := by
+public theorem normalBasis_apply (e : Gal(L/K)) : normalBasis K L e = e (normalBasis K L 1) := by
   rw [normalBasis, coe_basisOfLinearIndependentOfCardEqFinrank, AlgEquiv.one_apply]
 
 end IsGalois


### PR DESCRIPTION
Remove the `@[expose] public section` at the top of the file, instead marking each public theorem individually. `normalBasis` is completely characterized by `normalBasis_apply`, and has no interesting defeqs, so it is not exposed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
