### PR TITLE
[Merged by Bors] - chore: add missing `namespace`s

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/CategoryStar.lean
+++ b/Mathlib/Tactic/CategoryTheory/CategoryStar.lean
@@ -57,3 +57,5 @@ elab "Category*" ppSpace C:term:arg : term => commitIfNoEx <| withoutErrToSorry 
   let us := (collectLevelParams (collectLevelParams {} cExpr) tpCExpr).params
   let v ← mkFreshLevelParam `v (insertAfterLevels us)
   return .app (.const `CategoryTheory.Category [v, u]) cExpr
+
+end Mathlib.Tactic.CategoryStar

--- a/Mathlib/Tactic/CategoryTheory/CategoryStar.lean
+++ b/Mathlib/Tactic/CategoryTheory/CategoryStar.lean
@@ -34,6 +34,7 @@ variable (C : Type*) [Category* C]
 ```
 -/
 
+namespace Mathlib.Tactic.CategoryStar
 open Lean Meta Elab Term
 
 /--

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -38,7 +38,7 @@ public meta section
 open Lean Meta Elab Tactic
 open Mathlib.Tactic
 
-namespace Tactic.Elementwise
+namespace Mathlib.Tactic.Elementwise
 open CategoryTheory
 
 section theorems

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -38,8 +38,8 @@ public meta section
 open Lean Meta Elab Tactic
 open Mathlib.Tactic
 
-namespace Mathlib.Tactic.Elementwise
 open CategoryTheory
+namespace Mathlib.Tactic.Elementwise
 
 section theorems
 
@@ -257,4 +257,4 @@ elab "elementwise_of% " t:term : term => do
   let (pf, _) ← elementwiseExpr .anonymous e (simpSides := false)
   return pf
 
-end Tactic.Elementwise
+end Mathlib.Tactic.Elementwise

--- a/Mathlib/Tactic/CategoryTheory/Slice.lean
+++ b/Mathlib/Tactic/CategoryTheory/Slice.lean
@@ -83,3 +83,4 @@ macro_rules
 --     declNames := [`tactic.interactive.sliceLHS, `tactic.interactive.sliceRHS]
 --     tags := ["category theory"] }
 --
+end Mathlib.Tactic.Slice

--- a/Mathlib/Tactic/CategoryTheory/Slice.lean
+++ b/Mathlib/Tactic/CategoryTheory/Slice.lean
@@ -17,6 +17,7 @@ of `Category.comp`.
 
 public meta section
 
+namespace Mathlib.Tactic.Slice
 open CategoryTheory
 open Lean Parser.Tactic Elab Command Elab.Tactic Meta
 

--- a/Mathlib/Tactic/CategoryTheory/ToApp.lean
+++ b/Mathlib/Tactic/CategoryTheory/ToApp.lean
@@ -34,7 +34,7 @@ public meta section
 open Lean Meta Elab Tactic
 open Mathlib.Tactic
 
-namespace CategoryTheory
+namespace Mathlib.Tactic.CategoryTheory.ToApp
 
 /-- Simplify an expression in `Cat` using basic properties of `NatTrans.app`. -/
 def catAppSimp (e : Expr) : MetaM Simp.Result :=

--- a/Mathlib/Tactic/CategoryTheory/ToApp.lean
+++ b/Mathlib/Tactic/CategoryTheory/ToApp.lean
@@ -32,8 +32,7 @@ There is also a term elaborator `to_app_of% t` for use within proofs.
 public meta section
 
 open Lean Meta Elab Tactic
-open Mathlib.Tactic
-
+open CategoryTheory
 namespace Mathlib.Tactic.CategoryTheory.ToApp
 
 /-- Simplify an expression in `Cat` using basic properties of `NatTrans.app`. -/
@@ -161,4 +160,4 @@ it suitably using basic lemmas about `NatTrans.app`.
 elab "to_app_of% " t:term : term => do
   toAppExpr (← elabTerm t none)
 
-end CategoryTheory
+end Mathlib.Tactic.CategoryTheory.ToApp


### PR DESCRIPTION
I noticed that there is a global definition called `slice`, which causes ambiguity with `Finset.slice`. This PR improved the `namespace`dness of some tactic files.

Really, we should have a linter against definitions in the root namespace in the `Mathlib.Tactic` and `Mathlib.Meta` folders.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
