### PR TITLE
chore: disable whitespace linter due to performance regression

### DIFF
--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -77,8 +77,6 @@ instance instAddCommSemigroup : AddCommSemigroup ℕ := by infer_instance
 instance instAddSemigroup     : AddSemigroup ℕ     := by infer_instance
 instance instOne              : One ℕ              := inferInstance
 
-set_option linter.style.whitespace true
-
 /-! ### Miscellaneous lemmas -/
 
 -- We set the simp priority slightly lower than default; later more general lemmas will replace it.

--- a/Mathlib/Algebra/Ring/Int/Defs.lean
+++ b/Mathlib/Algebra/Ring/Int/Defs.lean
@@ -88,6 +88,4 @@ instance instSemiring     : Semiring ℤ     := inferInstance
 instance instRing         : Ring ℤ         := inferInstance
 instance instDistrib      : Distrib ℤ      := inferInstance
 
-set_option linter.style.whitespace true
-
 end Int


### PR DESCRIPTION
This PR disables the whitespace linter which has a performance regression causing O(n²) behavior on files with many formatting violations.

See Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.60linear_combination.60.20performance.20regression.20in.20v4.2E28.2E0-rc1

🤖 Prepared with Claude Code