### PR TITLE
[Merged by Bors] - perf(Linter/Whitespace): revert #26240

### DIFF
--- a/Mathlib/Tactic/Linter/Whitespace.lean
+++ b/Mathlib/Tactic/Linter/Whitespace.lean
@@ -118,10 +118,10 @@ Produces a `FormatError` from the input data.  It expects
 In particular, it extracts the position information within the string, both as number of characters
 and as `String.Pos`.
 -/
-def mkFormatError (ls ms : String.Slice) (msg : String) (length : Nat := 1) : FormatError where
-  srcNat := ls.positions.count
+def mkFormatError (ls ms : String) (msg : String) (length : Nat := 1) : FormatError where
+  srcNat := ls.length
   srcEndPos := ls.rawEndPos
-  fmtPos := ms.positions.count
+  fmtPos := ms.length
   msg := msg
   length := length
   srcStartPos := ls.rawEndPos
@@ -148,7 +148,7 @@ flagging some line-breaking changes.
 (The pretty-printer does not always produce desirably formatted code.)
 -/
 partial
-def parallelScanAux (as : Array FormatError) (L M : String.Slice) : Array FormatError :=
+def parallelScanAux (as : Array FormatError) (L M : String) : Array FormatError :=
   if M.trimAscii.isEmpty then as else
   -- We try as hard as possible to scan the strings one character at a time.
   -- However, single line comments introduced with `--` pretty-print differently than `/--`.
@@ -161,48 +161,48 @@ def parallelScanAux (as : Array FormatError) (L M : String.Slice) : Array Format
   -- original syntax, and for the same amount of characters in the pretty-printed one, since the
   -- pretty-printer *erases* the line break at the end of a single line comment.
   if L.take 3 == "/--".toSlice && M.take 3 == "/--".toSlice then
-    parallelScanAux as (L.drop 3) (M.drop 3) else
+    parallelScanAux as (L.drop 3).copy (M.drop 3).copy else
   if L.take 2 == "--".toSlice then
     let newL := L.dropWhile (· != '\n')
-    let diff := L.positions.count - newL.positions.count
+    let diff := L.length - newL.copy.length
     -- Assumption: if `L` contains an embedded inline comment, so does `M`
     -- (modulo additional whitespace).
     -- This holds because we call this function with `M` being a pretty-printed version of `L`.
     -- If the pretty-printer changes in the future, this code may need to be adjusted.
     let newM := M.dropWhile (· != '-') |>.drop diff
-    parallelScanAux as newL.trimAsciiStart newM.trimAsciiStart else
+    parallelScanAux as newL.trimAsciiStart.copy newM.trimAsciiStart.copy else
   if L.take 2 == "-/".toSlice then
     let newL := L.drop 2 |>.trimAsciiStart
     let newM := M.drop 2 |>.trimAsciiStart
-    parallelScanAux as newL newM else
+    parallelScanAux as newL.copy newM.copy else
   let ls := L.drop 1
   let ms := M.drop 1
   match L.front, M.front with
   | ' ', m =>
     if m.isWhitespace then
-      parallelScanAux as ls ms.trimAsciiStart
+      parallelScanAux as ls.copy ms.trimAsciiStart.copy
     else
-      parallelScanAux (pushFormatError as (mkFormatError L M "extra space")) ls M
+      parallelScanAux (pushFormatError as (mkFormatError L M "extra space")) ls.copy M
   | '\n', m =>
     if m.isWhitespace then
-      parallelScanAux as ls.trimAsciiStart ms.trimAsciiStart
+      parallelScanAux as ls.trimAsciiStart.copy ms.trimAsciiStart.copy
     else
       parallelScanAux
-        (pushFormatError as (mkFormatError L M "remove line break")) ls.trimAsciiStart M
+        (pushFormatError as (mkFormatError L M "remove line break")) ls.trimAsciiStart.copy M
   | l, m => -- `l` is not whitespace
     if l == m then
-      parallelScanAux as ls ms
+      parallelScanAux as ls.copy ms.copy
     else
       if m.isWhitespace then
         parallelScanAux
-          (pushFormatError as (mkFormatError L M "missing space")) L ms.trimAsciiStart
+          (pushFormatError as (mkFormatError L M "missing space")) L ms.trimAsciiStart.copy
     else
       -- If this code is reached, then `L` and `M` differ by something other than whitespace.
       -- This should not happen in practice.
-      pushFormatError as (mkFormatError ls ms "Oh no! (Unreachable?)")
+      pushFormatError as (mkFormatError ls.copy ms.copy "Oh no! (Unreachable?)")
 
 @[inherit_doc parallelScanAux]
-def parallelScan (src fmt : String.Slice) : Array FormatError :=
+def parallelScan (src fmt : String) : Array FormatError :=
   parallelScanAux ∅ src fmt
 
 namespace Style.Whitespace
@@ -298,7 +298,7 @@ to avoid cutting into "words".
 
 *Note*. `start` is the number of characters *from the right* where our focus is!
 -/
-public def mkWindow (orig : String.Slice) (start ctx : Nat) : String.Slice :=
+public def mkWindow (orig : String) (start ctx : Nat) : String :=
   let head := orig.dropEnd (start + 1) -- `orig`, up to one character before the discrepancy
   let middle := orig.takeEnd (start + 1)
   let headCtx := head.takeEndWhile (!·.isWhitespace)


### PR DESCRIPTION
This causes significant regressions to code with many violations, see e.g. https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.60linear_combination.60.20performance.20regression.20in.20v4.2E28.2E0-rc1.

Going from srcNat := ls.length to srcNat := ls.positions.count causes a regression, as this could go through the string linearly. Let us revert this change instead; it is not forward-compatible with #30658 anyway.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
