### PR TITLE
[Merged by Bors] - feat(Order/Minimal): uncompose `MinimalFor`/`MaximalFor` with a strictly monotonic function

### DIFF
--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -47,7 +47,7 @@ assert_not_exists CompleteLattice
 
 open Set OrderDual
 
-variable {ι α : Type*}
+variable {ι α β : Type*}
 
 section LE
 variable [LE α] {f : ι → α} {i j : ι}
@@ -180,7 +180,7 @@ end LE
 
 section Preorder
 
-variable [Preorder α] {Q : ι → Prop} {f : ι → α} {i j : ι}
+variable [Preorder α] [Preorder β] {Q : ι → Prop} {f : ι → α} {g : α → β} {i j : ι}
 
 theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → ¬ P y := by
   simp [Minimal, lt_iff_le_not_ge, imp.swap]
@@ -239,6 +239,30 @@ theorem not_maximal_iff_exists_gt (hx : P x) : ¬ Maximal P x ↔ ∃ y, x < y �
   not_minimal_iff_exists_lt (α := αᵒᵈ) hx
 
 alias ⟨exists_gt_of_not_maximal, _⟩ := not_maximal_iff_exists_gt
+
+theorem MinimalFor.of_strictMonoOn_comp (hg : StrictMonoOn g (f '' setOf Q))
+    (h : MinimalFor Q (g ∘ f) i) : MinimalFor Q f i := by
+  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
+  by_contra
+  exact h.not_lt hj <| hg ⟨j, hj, rfl⟩ ⟨i, h.prop, rfl⟩ <| lt_of_le_not_ge hle this
+
+theorem MaximalFor.of_strictMonoOn_comp (hg : StrictMonoOn g (f '' setOf Q))
+    (h : MaximalFor Q (g ∘ f) i) : MaximalFor Q f i := by
+  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
+  by_contra
+  exact h.not_gt hj <| hg ⟨i, h.prop, rfl⟩ ⟨j, hj, rfl⟩ <| lt_of_le_not_ge hle this
+
+theorem MinimalFor.maximalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' setOf Q))
+    (h : MinimalFor Q (g ∘ f) i) : MaximalFor Q f i := by
+  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
+  by_contra
+  exact h.not_lt hj <| hg ⟨i, h.prop, rfl⟩ ⟨j, hj, rfl⟩ <| lt_of_le_not_ge hle this
+
+theorem MaximalFor.minimalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' setOf Q))
+    (h : MaximalFor Q (g ∘ f) i) : MinimalFor Q f i := by
+  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
+  by_contra
+  exact h.not_gt hj <| hg ⟨j, hj, rfl⟩ ⟨i, h.prop, rfl⟩ <| lt_of_le_not_ge hle this
 
 section WellFoundedLT
 variable [WellFoundedLT α]
@@ -476,7 +500,7 @@ end Set
 
 section Image
 
-variable [Preorder α] {β : Type*} [Preorder β] {s : Set α} {t : Set β}
+variable [Preorder α] [Preorder β] {s : Set α} {t : Set β}
 section Function
 
 variable {f : α → β}

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -252,6 +252,14 @@ theorem MaximalFor.of_strictMonoOn_comp (hg : StrictMonoOn g (f '' setOf Q))
   by_contra
   exact h.not_gt hj <| hg ⟨i, h.prop, rfl⟩ ⟨j, hj, rfl⟩ <| lt_of_le_not_ge hle this
 
+theorem MinimalFor.minimal_of_strictMonoOn (hg : StrictMonoOn g (setOf P)) (h : MinimalFor P g x) :
+    Minimal P x :=
+  minimalFor_id.mp <| .of_strictMonoOn_comp (Set.image_id _ ▸ hg) h
+
+theorem MaximalFor.maximal_of_strictMonoOn (hg : StrictMonoOn g (setOf P)) (h : MaximalFor P g x) :
+    Maximal P x :=
+  maximalFor_id.mp <| .of_strictMonoOn_comp (Set.image_id _ ▸ hg) h
+
 theorem MinimalFor.maximalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' setOf Q))
     (h : MinimalFor Q (g ∘ f) i) : MaximalFor Q f i := by
   refine ⟨h.prop, fun j hj hle ↦ ?_⟩
@@ -263,6 +271,14 @@ theorem MaximalFor.minimalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' se
   refine ⟨h.prop, fun j hj hle ↦ ?_⟩
   by_contra
   exact h.not_gt hj <| hg ⟨j, hj, rfl⟩ ⟨i, h.prop, rfl⟩ <| lt_of_le_not_ge hle this
+
+theorem MinimalFor.maximal_of_strictAntiOn (hg : StrictAntiOn g (setOf P)) (h : MinimalFor P g x) :
+    Maximal P x :=
+  maximalFor_id.mp <| MinimalFor.maximalFor_of_strictAntiOn_comp (Set.image_id _ ▸ hg) h
+
+theorem MaximalFor.minimal_of_strictAntiOn (hg : StrictAntiOn g (setOf P)) (h : MaximalFor P g x) :
+    Minimal P x :=
+  minimalFor_id.mp <| MaximalFor.minimalFor_of_strictAntiOn_comp (Set.image_id _ ▸ hg) h
 
 section WellFoundedLT
 variable [WellFoundedLT α]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
