### PR TITLE
[Merged by Bors] - refactor: `exist_roots` → `exists_root`

### DIFF
--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -40,7 +40,7 @@ algebraic closure, algebraically closed
 - `IsAlgClosure.of_splits`: if `K / k` is algebraic, and every monic irreducible polynomial over
   `k` splits in `K`, then `K` is algebraically closed (in fact an algebraic closure of `k`).
   For the stronger fact that only requires every such polynomial has a root in `K`,
-  see `IsAlgClosure.of_exist_roots`.
+  see `IsAlgClosure.of_exists_root`.
 
   Reference: <https://kconrad.math.uconn.edu/blurbs/galoistheory/algclosure.pdf>, Theorem 2
 

--- a/Mathlib/FieldTheory/Isaacs.lean
+++ b/Mathlib/FieldTheory/Isaacs.lean
@@ -14,12 +14,12 @@ public import Mathlib.GroupTheory.CosetCover
 
 ## Main results
 
-`Field.nonempty_algHom_of_exist_roots` says if `E/F` and `K/F` are field extensions
+`Field.nonempty_algHom_of_exists_root` says if `E/F` and `K/F` are field extensions
 with `E/F` algebraic, and if the minimal polynomial of every element of `E` over `F` has a root
 in `K`, then there exists an `F`-embedding of `E` into `K`. If `E/F` and `K/F` have the same
 set of minimal polynomials, then `E` and `K` are isomorphic as `F`-algebras. As a corollary:
 
-`IsAlgClosure.of_exist_roots`: if `E/F` is algebraic and every monic irreducible polynomial
+`IsAlgClosure.of_exists_root`: if `E/F` is algebraic and every monic irreducible polynomial
 in `F[X]` has a root in `E`, then `E` is an algebraic closure of `F`.
 
 ## Reference
@@ -38,7 +38,7 @@ open Polynomial IntermediateField
 variable {F E K : Type*} [Field F] [Field E] [Field K] [Algebra F E] [Algebra F K]
 variable [alg : Algebra.IsAlgebraic F E]
 
-theorem nonempty_algHom_of_exist_roots (h : ∀ x : E, ∃ y : K, aeval y (minpoly F x) = 0) :
+theorem nonempty_algHom_of_exists_root (h : ∀ x : E, ∃ y : K, aeval y (minpoly F x) = 0) :
     Nonempty (E →ₐ[F] K) := by
   refine Lifts.nonempty_algHom_of_exist_lifts_finset fun S ↦ ⟨⟨adjoin F S, ?_⟩, subset_adjoin _ _⟩
   let p := (S.prod <| fun x ↦ (minpoly F x).map (algebraMap F K))
@@ -74,10 +74,13 @@ theorem nonempty_algHom_of_exist_roots (h : ∀ x : E, ∃ y : K, aeval y (minpo
   exact ((botEquiv K K').toAlgHom.restrictScalars F).comp
     (ω.choose.codRestrict K₀.toSubalgebra fun x ↦ ω.choose_spec trivial)
 
+@[deprecated (since := "2026-01-31")]
+alias nonempty_algHom_of_exist_roots := nonempty_algHom_of_exists_root
+
 theorem nonempty_algHom_of_minpoly_eq
     (h : ∀ x : E, ∃ y : K, minpoly F x = minpoly F y) :
     Nonempty (E →ₐ[F] K) :=
-  nonempty_algHom_of_exist_roots fun x ↦ have ⟨y, hy⟩ := h x; ⟨y, by rw [hy, minpoly.aeval]⟩
+  nonempty_algHom_of_exists_root fun x ↦ have ⟨y, hy⟩ := h x; ⟨y, by rw [hy, minpoly.aeval]⟩
 
 theorem nonempty_algHom_of_range_minpoly_subset
     (h : Set.range (@minpoly F E _ _ _) ⊆ Set.range (@minpoly F K _ _ _)) :
@@ -110,13 +113,16 @@ theorem nonempty_algEquiv_of_aeval_eq_zero_eq [Algebra.IsAlgebraic F K]
   have ⟨τ⟩ := nonempty_algHom_of_aeval_eq_zero_subset h.ge
   ⟨.ofBijective _ (Algebra.IsAlgebraic.algHom_bijective₂ σ τ).1⟩
 
-theorem _root_.IsAlgClosure.of_exist_roots
+theorem _root_.IsAlgClosure.of_exists_root
     (h : ∀ p : F[X], p.Monic → Irreducible p → ∃ x : E, aeval x p = 0) :
     IsAlgClosure F E :=
   .of_splits fun p _ _ ↦
-    have ⟨σ⟩ := nonempty_algHom_of_exist_roots fun x : p.SplittingField ↦
+    have ⟨σ⟩ := nonempty_algHom_of_exists_root fun x : p.SplittingField ↦
       have := Algebra.IsAlgebraic.isIntegral (K := F).1 x
       h _ (minpoly.monic this) (minpoly.irreducible this)
     Splits.of_algHom (SplittingField.splits _) σ
+
+@[deprecated (since := "2026-01-31")]
+alias _root_.IsAlgClosure.of_exist_roots := IsAlgClosure.of_exists_root
 
 end Field


### PR DESCRIPTION
This matches [`IsAlgClosed.exists_root`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/IsAlgClosed/Basic.html#IsAlgClosed.exists_root) and [`IsAlgClosed.of_exists_root`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/IsAlgClosed/Basic.html#IsAlgClosed.of_exists_root). Besides, `exists` is quite more common as a spelling for ∃ than `exist`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
