### PR TITLE
[Merged by Bors] - perf(Cache): skip decompression for already-unpacked files

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -390,13 +390,94 @@ def getLocalCacheSet : IO <| Std.TreeSet String compare := do
 def isFromMathlib (mod : Name) : Bool :=
   mod.getRoot == `Mathlib
 
+/-- Parse a single hex digit character to its numeric value. -/
+def hexDigitToNat (c : Char) : Option Nat :=
+  if '0' ≤ c ∧ c ≤ '9' then some (c.toNat - '0'.toNat)
+  else if 'a' ≤ c ∧ c ≤ 'f' then some (c.toNat - 'a'.toNat + 10)
+  else if 'A' ≤ c ∧ c ≤ 'F' then some (c.toNat - 'A'.toNat + 10)
+  else none
+
+/-- Parse a hex string (like "4bd6700ff435e8d0") to a UInt64. -/
+def parseHexString (s : String) : IO (Option UInt64) := do
+  if s.length != 16 then return none
+  let mut result : UInt64 := 0
+  for c in s.toList do
+    let some digit := hexDigitToNat c | return none
+    result := (result <<< 4) ||| digit.toUInt64
+  return some result
+
+/-- Get the trace file path for a module. -/
+def getTracePath (mod : Name) : CacheM FilePath := do
+  let sp := (← read).srcSearchPath
+  let packageDir ← getSrcDir sp mod
+  let path := (System.mkFilePath <| mod.components.map toString)
+  return packageDir / LIBDIR / path.withExtension "trace"
+
+/-- Read the `depHash` from a trace file, if it exists and is valid.
+    Returns the hash as a UInt64. -/
+def readTraceHash (tracePath : FilePath) : IO (Option UInt64) := do
+  let some contents ← try (some <$> IO.FS.readFile tracePath)
+                       catch _ => pure none | return none
+  -- Try to parse as JSON and extract depHash
+  let some json := Lean.Json.parse contents |>.toOption | return none
+  let some depHashStr := json.getObjValAs? String "depHash" |>.toOption | return none
+  -- Parse hex string to UInt64
+  parseHexString depHashStr
+
+/-- Read the Lake depHash from an ltar file header.
+    The ltar format is: 4-byte magic (LTAR/LTR2/LTR3) + 8-byte little-endian u64 hash. -/
+def readLtarHash (ltarPath : FilePath) : IO (Option UInt64) := do
+  let some handle ← try
+      some <$> IO.FS.Handle.mk ltarPath .read
+    catch _ => pure none | return none
+  -- Read 12 bytes: 4 magic + 8 hash
+  let bytes ← handle.read 12
+  if bytes.size < 12 then return none
+  -- Verify magic (LTAR, LTR2, or LTR3)
+  let magic := String.fromUTF8! (bytes.extract 0 4)
+  if magic != "LTAR" && magic != "LTR2" && magic != "LTR3" then return none
+  -- Read little-endian u64 hash
+  let mut hash : UInt64 := 0
+  for i in [0:8] do
+    hash := hash ||| ((bytes.get! (4 + i)).toUInt64 <<< (i * 8).toUInt64)
+  return some hash
+
+/-- Check if a module's trace file indicates it is already unpacked with the correct hash.
+    The hash to compare comes from the ltar file header, not the mathlib cache hash.
+    Returns `true` if the module needs decompression, `false` if it can be skipped. -/
+def needsDecompression (mod : Name) (mathlibHash : UInt64) : CacheM Bool := do
+  -- Read the Lake depHash from the ltar file header
+  let ltarPath := CACHEDIR / mathlibHash.asLTar
+  let some ltarHash ← readLtarHash ltarPath | return true
+  -- Read the trace file hash
+  let tracePath ← getTracePath mod
+  let some traceHash ← readTraceHash tracePath | return true
+  -- They should match if the file is already unpacked
+  return ltarHash != traceHash
+
+/-- Filter the hashmap to only include modules that need decompression.
+    A module needs decompression if its trace file doesn't exist or has a different hash. -/
+def ModuleHashMap.filterNeedsDecompression (hashMap : ModuleHashMap) : CacheM ModuleHashMap :=
+  hashMap.foldM (init := ∅) fun acc mod hash => do
+    if ← needsDecompression mod hash then
+      return acc.insert mod hash
+    else
+      return acc
+
 /-- Decompresses build files into their respective folders -/
 def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true
+  let totalCached := hashMap.size
+  -- Unless force is set, filter to only modules that actually need decompression
+  let hashMap ← if force then pure hashMap else hashMap.filterNeedsDecompression
   let size := hashMap.size
+  let skipped := totalCached - size
   if size > 0 then
     let now ← IO.monoMsNow
-    IO.println s!"Decompressing {size} file(s)"
+    if skipped > 0 then
+      IO.println s!"Decompressing {size} file(s) ({skipped} already unpacked)"
+    else
+      IO.println s!"Decompressing {size} file(s)"
     let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
@@ -429,7 +510,10 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
     IO.println s!"Unpacked in {(← IO.monoMsNow) - now} ms"
     IO.println "Completed successfully!"
-  else IO.println "No cache files to decompress"
+  else if totalCached > 0 then
+    IO.println s!"Already unpacked ({totalCached} file(s))"
+  else
+    IO.println "No cache files to decompress"
 
 instance : Ord FilePath where
   compare x y := compare x.toString y.toString

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -390,22 +390,6 @@ def getLocalCacheSet : IO <| Std.TreeSet String compare := do
 def isFromMathlib (mod : Name) : Bool :=
   mod.getRoot == `Mathlib
 
-/-- Parse a single hex digit character to its numeric value. -/
-def hexDigitToNat (c : Char) : Option Nat :=
-  if '0' ≤ c ∧ c ≤ '9' then some (c.toNat - '0'.toNat)
-  else if 'a' ≤ c ∧ c ≤ 'f' then some (c.toNat - 'a'.toNat + 10)
-  else if 'A' ≤ c ∧ c ≤ 'F' then some (c.toNat - 'A'.toNat + 10)
-  else none
-
-/-- Parse a hex string (like "4bd6700ff435e8d0") to a UInt64. -/
-def parseHexString (s : String) : IO (Option UInt64) := do
-  if s.length != 16 then return none
-  let mut result : UInt64 := 0
-  for c in s.toList do
-    let some digit := hexDigitToNat c | return none
-    result := (result <<< 4) ||| digit.toUInt64
-  return some result
-
 /-- Get the trace file path for a module. -/
 def getTracePath (mod : Name) : CacheM FilePath := do
   let sp := (← read).srcSearchPath
@@ -422,7 +406,7 @@ def readTraceHash (tracePath : FilePath) : IO (Option UInt64) := do
   let some json := Lean.Json.parse contents |>.toOption | return none
   let some depHashStr := json.getObjValAs? String "depHash" |>.toOption | return none
   -- Parse hex string to UInt64
-  parseHexString depHashStr
+  return depHashStr.parseHexToUInt64?
 
 /-- Read the Lake depHash from an ltar file header.
     The ltar format is: 4-byte magic (LTAR/LTR2/LTR3) + 8-byte little-endian u64 hash. -/
@@ -442,7 +426,7 @@ def readLtarHash (ltarPath : FilePath) : IO (Option UInt64) := do
     hash := hash ||| ((bytes.get! (4 + i)).toUInt64 <<< (i * 8).toUInt64)
   return some hash
 
-/-- Check if a module's trace file indicates it is already unpacked with the correct hash.
+/-- Check if a module's trace file indicates it is already decompressed with the correct hash.
     The hash to compare comes from the ltar file header, not the mathlib cache hash.
     Returns `true` if the module needs decompression, `false` if it can be skipped. -/
 def needsDecompression (mod : Name) (mathlibHash : UInt64) : CacheM Bool := do
@@ -452,7 +436,7 @@ def needsDecompression (mod : Name) (mathlibHash : UInt64) : CacheM Bool := do
   -- Read the trace file hash
   let tracePath ← getTracePath mod
   let some traceHash ← readTraceHash tracePath | return true
-  -- They should match if the file is already unpacked
+  -- They should match if the file is already decompressed
   return ltarHash != traceHash
 
 /-- Filter the hashmap to only include modules that need decompression.
@@ -475,7 +459,7 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   if size > 0 then
     let now ← IO.monoMsNow
     if skipped > 0 then
-      IO.println s!"Decompressing {size} file(s) ({skipped} already unpacked)"
+      IO.println s!"Decompressing {size} file(s) ({skipped} already decompressed)"
     else
       IO.println s!"Decompressing {size} file(s)"
     let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
@@ -508,10 +492,10 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
     stdin.putStr <| Lean.Json.compress <| .arr config
     let exitCode ← child.wait
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
-    IO.println s!"Unpacked in {(← IO.monoMsNow) - now} ms"
+    IO.println s!"Decompressed in {(← IO.monoMsNow) - now} ms"
     IO.println "Completed successfully!"
   else if totalCached > 0 then
-    IO.println s!"Already unpacked ({totalCached} file(s))"
+    IO.println s!"Already decompressed {totalCached} file(s)"
   else
     IO.println "No cache files to decompress"
 

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -400,8 +400,8 @@ def getTracePath (mod : Name) : CacheM FilePath := do
 /-- Read the `depHash` from a trace file, if it exists and is valid.
     Returns the hash as a UInt64. -/
 def readTraceHash (tracePath : FilePath) : IO (Option UInt64) := do
-  let some contents ← try (some <$> IO.FS.readFile tracePath)
-                       catch _ => pure none | return none
+  let contents ← try IO.FS.readFile tracePath
+                  catch _ => return none
   -- Try to parse as JSON and extract depHash
   let some json := Lean.Json.parse contents |>.toOption | return none
   let some depHashStr := json.getObjValAs? String "depHash" |>.toOption | return none

--- a/Cache/Lean.lean
+++ b/Cache/Lean.lean
@@ -28,6 +28,22 @@ def Nat.toHexDigits (n : Nat) : Nat → (res : String := "") → String
 def UInt64.asLTar (n : UInt64) : String :=
   s!"{Nat.toHexDigits n.toNat 8}.ltar"
 
+/-- Parse a single hex digit character to its numeric value. -/
+def Char.hexDigitToNat? (c : Char) : Option Nat :=
+  if '0' ≤ c ∧ c ≤ '9' then some (c.toNat - '0'.toNat)
+  else if 'a' ≤ c ∧ c ≤ 'f' then some (c.toNat - 'a'.toNat + 10)
+  else if 'A' ≤ c ∧ c ≤ 'F' then some (c.toNat - 'A'.toNat + 10)
+  else none
+
+/-- Parse a 16-character hex string (like "4bd6700ff435e8d0") to a UInt64. -/
+def String.parseHexToUInt64? (s : String) : Option UInt64 := do
+  if s.length != 16 then failure
+  let mut result : UInt64 := 0
+  for c in s.toList do
+    let digit ← c.hexDigitToNat?
+    result := (result <<< 4) ||| digit.toUInt64
+  return result
+
 -- copied from Mathlib
 /-- Create a `Name` from a list of components. -/
 def Lean.Name.fromComponents : List Name → Name := go .anonymous where


### PR DESCRIPTION
This PR adds pre-filtering to `lake exe cache get`: before calling leantar, we check if each module's trace file exists and has a matching Lake depHash. Modules that are already correctly unpacked are skipped entirely.

**Performance (tested on Mac Studio with SSD, ~7900 cached files):**

| Scenario | Before | After |
|----------|--------|-------|
| All files already unpacked | ~25s | ~5s |
| Partial decompression needed | ~25s | ~5s + decompression time |

**Timing breakdown (after this PR):**
- Hash computation: ~2.8s
- Filter to existing ltar files: ~0.06s  
- Read ltar headers + trace files, compare hashes: ~2.5s
- leantar (if needed): 0s when all files match

**What changed:**
Before calling leantar, we now read the Lake depHash from each ltar file header (first 12 bytes) and compare with the trace file's `depHash` field. Files with matching hashes are filtered out.

Note: The mathlib cache hash (ltar filename) is different from the Lake depHash (stored in ltar header and trace file). This PR compares the Lake depHashes, which is what leantar uses internally.

Fixes https://leanprover.zulipchat.com/#narrow/channel/536994-ecosystem-infrastructure/topic/lake.20exe.20cache.20get.20always.20decompresses

🤖 Prepared with Claude Code