### PR TITLE
[Merged by Bors] - fix: `(f ⊔ g) i` isn't pretty-printed

### DIFF
--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -113,27 +113,33 @@ private meta def hasLinearOrder (u : Level) (α : Q(Type u)) (cls : Q(Type u →
 
 /-- Delaborate `max x y` into `x ⊔ y` if the type is not a linear order. -/
 @[delab app.Max.max]
-meta def delabSup : Delab := whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
-  let_expr f@Max.max α inst _ _ := ← getExpr | failure
-  have u := f.constLevels![0]!
-  if ← hasLinearOrder u α q(Max) q($(linearOrderToMax u)) inst then
-    failure -- use the default delaborator
-  let x ← withNaryArg 2 delab
-  let y ← withNaryArg 3 delab
-  let stx ← `($x ⊔ $y)
-  annotateGoToSyntaxDef stx
+meta def delabSup : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 4 do
+    let_expr f@Max.max α inst _ _ := ← getExpr | failure
+    have u := f.constLevels![0]!
+    if ← hasLinearOrder u α q(Max) q($(linearOrderToMax u)) inst then
+      failure -- use the default delaborator
+    let x ← withNaryArg 2 delab
+    let y ← withNaryArg 3 delab
+    let stx ← `($x ⊔ $y)
+    annotateGoToSyntaxDef stx
 
 /-- Delaborate `min x y` into `x ⊓ y` if the type is not a linear order. -/
 @[delab app.Min.min]
-meta def delabInf : Delab := whenNotPPOption getPPExplicit <| whenPPOption getPPNotation do
-  let_expr f@Min.min α inst _ _ := ← getExpr | failure
-  have u := f.constLevels![0]!
-  if ← hasLinearOrder u α q(Min) q($(linearOrderToMin u)) inst then
-    failure -- use the default delaborator
-  let x ← withNaryArg 2 delab
-  let y ← withNaryArg 3 delab
-  let stx ← `($x ⊓ $y)
-  annotateGoToSyntaxDef stx
+meta def delabInf : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 4 do
+    let_expr f@Min.min α inst _ _ := ← getExpr | failure
+    have u := f.constLevels![0]!
+    if ← hasLinearOrder u α q(Min) q($(linearOrderToMin u)) inst then
+      failure -- use the default delaborator
+    let x ← withNaryArg 2 delab
+    let y ← withNaryArg 3 delab
+    let stx ← `($x ⊓ $y)
+    annotateGoToSyntaxDef stx
 
 end Mathlib.Meta
 

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -1,5 +1,5 @@
-import Mathlib
-
+module
+import Mathlib.Data.Real.Archimedean
 
 /-- info: max 1 2 : ℕ -/
 #guard_msgs in
@@ -82,3 +82,17 @@ set_option pp.explicit true in
 #check min (max a b) c
 
 end
+
+section Apply
+
+variable {ι α : Type*} (f g : ι → α) (i : ι) variable [Lattice α]
+
+/-- info: (f ⊔ g) i : α -/
+#guard_msgs in
+#check (f ⊔ g) i
+
+/-- info: (f ⊔ g) i : α -/
+#guard_msgs in
+#check max f g i
+
+end Apply

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -95,4 +95,12 @@ variable {ι α : Type*} [Lattice α] (f g : ι → α) (i : ι)
 #guard_msgs in
 #check max f g i
 
+/-- info: (f ⊓ g) i : α -/
+#guard_msgs in
+#check (f ⊓ g) i
+
+/-- info: (f ⊓ g) i : α -/
+#guard_msgs in
+#check min f g i
+
 end Apply

--- a/MathlibTest/Delab/SupInf.lean
+++ b/MathlibTest/Delab/SupInf.lean
@@ -85,7 +85,7 @@ end
 
 section Apply
 
-variable {ι α : Type*} (f g : ι → α) (i : ι) variable [Lattice α]
+variable {ι α : Type*} [Lattice α] (f g : ι → α) (i : ι)
 
 /-- info: (f ⊔ g) i : α -/
 #guard_msgs in


### PR DESCRIPTION
To see; [`Pi.sup_apply`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Lattice.html#Pi.sup_apply)
This can be easily fixed by `withOverApp`. On the way, I minimized imports of the test.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
