### PR TITLE
[Merged by Bors] - feat: measurable union of a family of measurable sets

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
@@ -341,7 +341,7 @@ private lemma exists_ae_subset_biUnion_countable_of_isFiniteMeasure [IsFiniteMea
   · rw [hD, show s ∪ ⋃₀ D = ⋃₀ (D ∪ {s}) by simp]
     apply le_biSup (f := fun D ↦ μ (⋃₀ D))
     simp [D_mem.2, insert_subset_iff, hs, D_mem.1]
-  · exact MeasurableSet.nullMeasurableSet (MeasurableSet.sUnion D_mem.2 (by grind))
+  · exact (MeasurableSet.sUnion D_mem.2 (by grind)).nullMeasurableSet
   · simp
 
 variable (μ) in
@@ -358,7 +358,7 @@ lemma exists_ae_subset_biUnion_countable [SFinite μ]
   choose D DC D_count hD using A
   refine ⟨⋃ n, D n, by simp [DC], by simp [D_count], fun s hs ↦ ?_⟩
   rw [← sum_sfiniteSeq μ]
-  apply Measure.ae_sum_iff.2 (fun n ↦ EventuallyLE.trans (hD n s hs) ?_)
+  apply ae_sum_iff.2 (fun n ↦ (hD n s hs).trans ?_)
   exact HasSubset.Subset.eventuallyLE (fun x hx ↦ by simp at hx ⊢; grind)
 
 /-- If a measure `μ` is the sum of a countable family `mₙ`, and a set `t` has finite measure for

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean
@@ -22,6 +22,7 @@ We introduce the following typeclasses for measures:
 namespace MeasureTheory
 
 open Set Filter Function Measure MeasurableSpace NNReal ENNReal
+open scoped Topology
 
 variable {α β ι : Type*} {m0 : MeasurableSpace α} [MeasurableSpace β] {μ ν : Measure α}
   {s t : Set α} {a : α}
@@ -315,6 +316,50 @@ theorem countable_meas_level_set_pos {α β : Type*} {_ : MeasurableSpace α} {�
     [SFinite μ] [MeasurableSpace β] [MeasurableSingletonClass β] {g : α → β}
     (g_mble : Measurable g) : Set.Countable { t : β | 0 < μ { a : α | g a = t } } :=
   countable_meas_level_set_pos₀ g_mble.nullMeasurable
+
+private lemma exists_ae_subset_biUnion_countable_of_isFiniteMeasure [IsFiniteMeasure μ]
+    {C : Set (Set α)} (hC : ∀ s ∈ C, MeasurableSet s) :
+    ∃ D ⊆ C, D.Countable ∧ ∀ s ∈ C, s ≤ᵐ[μ] (⋃₀ D) := by
+  let m := ⨆ D ∈ {D : Set (Set α) | D ⊆ C ∧ D.Countable}, μ (⋃₀ D)
+  obtain ⟨D, D_mem, hD⟩ : ∃ D ∈ {D : Set (Set α) | D ⊆ C ∧ D.Countable}, μ (⋃₀ D) = m := by
+    rcases eq_bot_or_bot_lt m with hm | hm
+    · exact ⟨∅, by simp, by simp [hm]⟩
+    obtain ⟨u, -, u_mem, u_lim⟩ :
+        ∃ u : ℕ → ℝ≥0∞, StrictMono u ∧ (∀ n, u n ∈ Ioo 0 m) ∧ Tendsto u atTop (𝓝 m) :=
+      exists_seq_strictMono_tendsto' hm
+    have A n : ∃ D ∈ {D : Set (Set α) | D ⊆ C ∧ D.Countable}, u n < μ (⋃₀ D) :=
+      lt_biSup_iff.1 (u_mem n).2
+    choose! D D_mem huD using A
+    have hD : ⋃ n, D n ∈ {D | D ⊆ C ∧ D.Countable} := by simp; grind
+    refine ⟨⋃ n, D n, hD, ?_⟩
+    apply le_antisymm (le_biSup (f := fun D ↦ μ (⋃₀ D)) hD)
+    apply le_of_tendsto' u_lim (fun n ↦ (huD n).le.trans ?_)
+    exact measure_mono (fun x hx ↦ by simp at hx ⊢; grind)
+  refine ⟨D, by grind, by grind, fun s hs ↦ union_ae_eq_right_iff_ae_subset.mp ?_⟩
+  symm
+  apply ae_eq_of_ae_subset_of_measure_ge subset_union_right.eventuallyLE
+  · rw [hD, show s ∪ ⋃₀ D = ⋃₀ (D ∪ {s}) by simp]
+    apply le_biSup (f := fun D ↦ μ (⋃₀ D))
+    simp [D_mem.2, insert_subset_iff, hs, D_mem.1]
+  · exact MeasurableSet.nullMeasurableSet (MeasurableSet.sUnion D_mem.2 (by grind))
+  · simp
+
+variable (μ) in
+/-- Given a family of measurable sets, its measurable union is its union modulo sets of measure
+zero. It is well defined up to measure 0. For instance, the measurable union of all the singleton
+sets in `ℝ` is empty (while the usual union would be the whole space).
+This lemma shows the existence of a measurable union, writing it as the union of a countable
+subfamily. -/
+lemma exists_ae_subset_biUnion_countable [SFinite μ]
+    {C : Set (Set α)} (hC : ∀ s ∈ C, MeasurableSet s) :
+    ∃ D ⊆ C, D.Countable ∧ ∀ s ∈ C, s ≤ᵐ[μ] (⋃₀ D) := by
+  have A n : ∃ D ⊆ C, D.Countable ∧ ∀ s ∈ C, s ≤ᵐ[sfiniteSeq μ n] (⋃₀ D) :=
+    exists_ae_subset_biUnion_countable_of_isFiniteMeasure hC
+  choose D DC D_count hD using A
+  refine ⟨⋃ n, D n, by simp [DC], by simp [D_count], fun s hs ↦ ?_⟩
+  rw [← sum_sfiniteSeq μ]
+  apply Measure.ae_sum_iff.2 (fun n ↦ EventuallyLE.trans (hD n s hs) ?_)
+  exact HasSubset.Subset.eventuallyLE (fun x hx ↦ by simp at hx ⊢; grind)
 
 /-- If a measure `μ` is the sum of a countable family `mₙ`, and a set `t` has finite measure for
 each `mₙ`, then its measurable superset `toMeasurable μ t` (which has the same measure as `t`)


### PR DESCRIPTION
Needed for #34055

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
