### PR TITLE
[Merged by Bors] - chore(bors.toml): only cut PR bodies from commit messages if `---` starts a line

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,5 +4,5 @@ timeout_sec = 7200
 block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
 delete_merged_branches = true
 update_base_for_deletes = true
-cut_body_after = "---"
+cut_body_after = "\n---"
 max_batch_size = 16


### PR DESCRIPTION
Currently bors cuts the rest of the PR body from the commit message if it contains `---` anywhere in the message, including in formatting markdown tables (cf. #33456 and commit fa0ba716743c7bb9db8ecdae0d8696764f00a153). Adding `\n` here should prevent bors from mangling such messages.


---

Note that the above message itself contains `---` so this PR is self-testing. See how the commit message of ea20b1e9d2ef6c487bf66c7879033c01a64c0561 isn't cut off.


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
