### PR TITLE
[Merged by Bors] - feat(CategoryTheory): Being equifibered is closed under limits

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2729,6 +2729,7 @@ public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Connected
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Cospan
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Equalizer
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Equifibered
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.EquifiberedLimits
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Basic
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.BicartesianSq

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -286,6 +286,11 @@ instance forget_reflects_iso : (forget X).ReflectsIsomorphisms where
 noncomputable def mkIdTerminal : Limits.IsTerminal (mk (𝟙 X)) :=
   CostructuredArrow.mkIdTerminal
 
+-- We could make this defeq if we care.
+@[simp] lemma mkIdTerminal_from_left (Y : Over X) : (mkIdTerminal.from Y).left = Y.hom := by
+  rw [mkIdTerminal.hom_ext (mkIdTerminal.from Y) (homMk Y.hom)]
+  rfl
+
 instance forget_faithful : (forget X).Faithful where
 
 -- TODO: Show the converse holds if `T` has binary products.
@@ -779,6 +784,11 @@ instance forget_reflects_iso : (forget X).ReflectsIsomorphisms where
 /-- The identity under `X` is initial. -/
 noncomputable def mkIdInitial : Limits.IsInitial (mk (𝟙 X)) :=
   StructuredArrow.mkIdInitial
+
+-- We could make this defeq if we care.
+@[simp] lemma mkIdInitial_to_right (Y : Under X) : (mkIdInitial.to Y).right = Y.hom := by
+  rw [mkIdInitial.hom_ext (mkIdInitial.to Y) (homMk Y.hom)]
+  rfl
 
 instance forget_faithful : (forget X).Faithful where
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
@@ -155,4 +155,3 @@ end Opposite
 end NatTrans
 
 end CategoryTheory
-#min_imports

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
@@ -5,16 +5,8 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.CategoryTheory.Limits.Shapes.Products
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Basic
 public import Mathlib.CategoryTheory.MorphismProperty.Composition
-public import Mathlib.CategoryTheory.ObjectProperty.ColimitsOfShape
-
-import Mathlib.CategoryTheory.Adjunction.Evaluation
-import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
-import Mathlib.CategoryTheory.Limits.Preserves.Opposites
-import Mathlib.CategoryTheory.Limits.Shapes.Opposites.Products
-import Mathlib.CategoryTheory.WithTerminal.Cone
 
 /-!
 
@@ -90,39 +82,6 @@ alias _root_.CategoryTheory.mapPair_equifibered := Equifibered.of_discrete
 
 @[deprecated (since := "2026-01-23")] alias equifibered_of_discrete := Equifibered.of_discrete
 
-instance (F : C ⥤ D) [∀ a b : C, HasCoproductsOfShape (a ⟶ b) D] :
-    ObjectProperty.IsClosedUnderLimitsOfShape (fun f : Over F ↦ f.hom.Equifibered) J := by
-  wlog hJ : IsConnected J generalizing J
-  · refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ U V f ↦ ?_⟩
-    have hα (i j) (f : i ⟶ j) : α.app i ≫ c.map f = α.app j := by simp [← NatTrans.naturality]
-    have hc' := WithTerminal.isLimitEquiv.symm hc
-    have inst : IsConnected (WithTerminal J) := isConnected_of_hasTerminal _
-    exact (this (J := WithTerminal J) inst).1 G ⟨⟨WithTerminal.liftToTerminal c Over.mkIdTerminal,
-      { app i := i.casesOn α.app (Over.mkIdTerminal.from _) }, isLimitOfReflects (Over.forget _) (by
-      refine IsLimit.equivOfNatIsoOfIso ?_ _ _ ?_ (WithTerminal.isLimitEquiv.symm hc)
-      · exact NatIso.ofComponents (fun i ↦ i.casesOn (fun _ ↦ .refl _) (.refl _)) <| by
-          rintro (i | _) (j | _) <;> (try rintro ⟨⟩) <;> simp
-      · exact Cones.ext (.refl _) (by rintro ⟨⟩ <;> simp))⟩, fun i ↦
-        i.casesOn H (.of_isIso (𝟙 F))⟩ f
-  refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ i j f ↦ ⟨⟨by simp⟩, ⟨Limits.PullbackCone.isLimitAux' _ fun s ↦ ?_⟩⟩⟩
-  let hcᵢ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj i) hc
-  let hcⱼ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj j) hc
-  dsimp at s
-  let l : s.pt ⟶ G.left.obj i := hcᵢ.lift ⟨_, fun k ↦ (H k f).lift (s.fst ≫ (α.app k).left.app j)
-    s.snd (by simp [← s.condition, ← NatTrans.comp_app]), fun k₁ k₂ fk₁k₂ ↦ (H _ f).hom_ext
-    (by simp [← NatTrans.naturality, ← NatTrans.comp_app, ← Over.comp_left])
-    (by simp [← NatTrans.comp_app])⟩
-  refine ⟨l, hcⱼ.hom_ext fun k ↦ ?_, ?_, fun {m} hm₁ hm₂ ↦ hcᵢ.hom_ext
-    fun k ↦ ((H k f).hom_ext ?_ ?_).trans (hcᵢ.fac ⟨_, _⟩ k).symm⟩
-  · simpa [Category.assoc, NatTrans.naturality] using (hcᵢ.fac_assoc _ _ _).trans (by simp)
-  · dsimp
-    obtain ⟨k⟩ : Nonempty J := inferInstance
-    rw [show G.hom.app i = (α.app k).left.app i ≫ (c.obj k).hom.app i by simp [← comp_app]]
-    exact (hcᵢ.fac_assoc ..).trans (by simp)
-  · dsimp at *
-    simp [← NatTrans.naturality, reassoc_of% hm₁]
-  · simpa [← NatTrans.comp_app]
-
 /-- A natural transformation is co-equifibered if every commutative square of the following form is
 a pushout.
 ```
@@ -193,21 +152,7 @@ theorem equifibered_unop_iff {F G : Jᵒᵖ ⥤ Cᵒᵖ} {α : F ⟶ G} :
 
 end Opposite
 
-open Over in
-instance (F : C ⥤ D) [∀ a b : C, HasProductsOfShape (a ⟶ b) D] :
-    ObjectProperty.IsClosedUnderColimitsOfShape (fun f : Under F ↦ f.hom.Coequifibered) J := by
-  have : ObjectProperty.IsClosedUnderIsomorphisms fun f : Under F ↦ f.hom.Coequifibered :=
-    ⟨fun {X Y} e ↦ by rw [← Under.w e.hom, Coequifibered.cancel_right_of_respectsIso]; simp⟩
-  have (a b : Cᵒᵖ) : HasCoproductsOfShape (a ⟶ b) Dᵒᵖ :=
-    hasColimitsOfShape_of_equivalence (Discrete.equivalence Quiver.Hom.opEquiv)
-  let e : Over F.op ≌ (Under F)ᵒᵖ := (postEquiv _ (opUnopEquiv _ _)).symm.trans (opEquivOpUnder F)
-  rw [ObjectProperty.isClosedUnderColimitsOfShape_iff_op,
-    ← IsClosedUnderLimitsOfShape.inverseImage_iff _ e]
-  convert (inferInstanceAs <| ObjectProperty.IsClosedUnderLimitsOfShape
-    (fun f : Over F.op ↦ f.hom.Equifibered) Jᵒᵖ) with f
-  simp [e, MorphismProperty.cancel_left_of_respectsIso, ← coequifibered_unop_iff]
-  rfl
-
 end NatTrans
 
 end CategoryTheory
+#min_imports

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equifibered.lean
@@ -5,7 +5,16 @@ Authors: Andrew Yang
 -/
 module
 
+public import Mathlib.CategoryTheory.Limits.Shapes.Products
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Basic
+public import Mathlib.CategoryTheory.MorphismProperty.Composition
+public import Mathlib.CategoryTheory.ObjectProperty.ColimitsOfShape
+
+import Mathlib.CategoryTheory.Adjunction.Evaluation
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
+import Mathlib.CategoryTheory.Limits.Preserves.Opposites
+import Mathlib.CategoryTheory.Limits.Shapes.Opposites.Products
+import Mathlib.CategoryTheory.WithTerminal.Cone
 
 /-!
 
@@ -43,15 +52,24 @@ F(X) → F(Y)
 G(X) → G(Y)
 ```
 -/
-def Equifibered {F G : J ⥤ C} (α : F ⟶ G) : Prop :=
-  ∀ ⦃i j : J⦄ (f : i ⟶ j), IsPullback (F.map f) (α.app i) (α.app j) (G.map f)
+def Equifibered : MorphismProperty (J ⥤ C) :=
+  fun {F G} α ↦ ∀ ⦃i j : J⦄ (f : i ⟶ j), IsPullback (F.map f) (α.app i) (α.app j) (G.map f)
 
-theorem equifibered_of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : Equifibered α :=
+theorem Equifibered.of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : Equifibered α :=
   fun _ _ f => IsPullback.of_vert_isIso ⟨naturality _ f⟩
+
+@[deprecated (since := "2026-02-01")] alias equifibered_of_isIso := Equifibered.of_isIso
 
 theorem Equifibered.comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} (hα : Equifibered α)
     (hβ : Equifibered β) : Equifibered (α ≫ β) :=
   fun _ _ f => (hα f).paste_vert (hβ f)
+
+instance : (Equifibered (J := J) (C := C)).IsMultiplicative where
+  id_mem _ := .of_isIso _
+  comp_mem _ _ := .comp
+
+instance : (Equifibered (J := J) (C := C)).RespectsIso :=
+  MorphismProperty.respectsIso_of_isStableUnderComposition fun _ _ ↦ .of_isIso
 
 theorem Equifibered.whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : Equifibered α)
     (H : C ⥤ D) [∀ (i j : J) (f : j ⟶ i), PreservesLimit (cospan (α.app i) (G.map f)) H] :
@@ -72,6 +90,39 @@ alias _root_.CategoryTheory.mapPair_equifibered := Equifibered.of_discrete
 
 @[deprecated (since := "2026-01-23")] alias equifibered_of_discrete := Equifibered.of_discrete
 
+instance (F : C ⥤ D) [∀ a b : C, HasCoproductsOfShape (a ⟶ b) D] :
+    ObjectProperty.IsClosedUnderLimitsOfShape (fun f : Over F ↦ f.hom.Equifibered) J := by
+  wlog hJ : IsConnected J generalizing J
+  · refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ U V f ↦ ?_⟩
+    have hα (i j) (f : i ⟶ j) : α.app i ≫ c.map f = α.app j := by simp [← NatTrans.naturality]
+    have hc' := WithTerminal.isLimitEquiv.symm hc
+    have inst : IsConnected (WithTerminal J) := isConnected_of_hasTerminal _
+    exact (this (J := WithTerminal J) inst).1 G ⟨⟨WithTerminal.liftToTerminal c Over.mkIdTerminal,
+      { app i := i.casesOn α.app (Over.mkIdTerminal.from _) }, isLimitOfReflects (Over.forget _) (by
+      refine IsLimit.equivOfNatIsoOfIso ?_ _ _ ?_ (WithTerminal.isLimitEquiv.symm hc)
+      · exact NatIso.ofComponents (fun i ↦ i.casesOn (fun _ ↦ .refl _) (.refl _)) <| by
+          rintro (i | _) (j | _) <;> (try rintro ⟨⟩) <;> simp
+      · exact Cones.ext (.refl _) (by rintro ⟨⟩ <;> simp))⟩, fun i ↦
+        i.casesOn H (.of_isIso (𝟙 F))⟩ f
+  refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ i j f ↦ ⟨⟨by simp⟩, ⟨Limits.PullbackCone.isLimitAux' _ fun s ↦ ?_⟩⟩⟩
+  let hcᵢ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj i) hc
+  let hcⱼ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj j) hc
+  dsimp at s
+  let l : s.pt ⟶ G.left.obj i := hcᵢ.lift ⟨_, fun k ↦ (H k f).lift (s.fst ≫ (α.app k).left.app j)
+    s.snd (by simp [← s.condition, ← NatTrans.comp_app]), fun k₁ k₂ fk₁k₂ ↦ (H _ f).hom_ext
+    (by simp [← NatTrans.naturality, ← NatTrans.comp_app, ← Over.comp_left])
+    (by simp [← NatTrans.comp_app])⟩
+  refine ⟨l, hcⱼ.hom_ext fun k ↦ ?_, ?_, fun {m} hm₁ hm₂ ↦ hcᵢ.hom_ext
+    fun k ↦ ((H k f).hom_ext ?_ ?_).trans (hcᵢ.fac ⟨_, _⟩ k).symm⟩
+  · simpa [Category.assoc, NatTrans.naturality] using (hcᵢ.fac_assoc _ _ _).trans (by simp)
+  · dsimp
+    obtain ⟨k⟩ : Nonempty J := inferInstance
+    rw [show G.hom.app i = (α.app k).left.app i ≫ (c.obj k).hom.app i by simp [← comp_app]]
+    exact (hcᵢ.fac_assoc ..).trans (by simp)
+  · dsimp at *
+    simp [← NatTrans.naturality, reassoc_of% hm₁]
+  · simpa [← NatTrans.comp_app]
+
 /-- A natural transformation is co-equifibered if every commutative square of the following form is
 a pushout.
 ```
@@ -80,15 +131,24 @@ F(X) → F(Y)
 G(X) → G(Y)
 ```
 -/
-def Coequifibered {F G : J ⥤ C} (α : F ⟶ G) : Prop :=
-  ∀ ⦃i j : J⦄ (f : i ⟶ j), IsPushout (F.map f) (α.app i) (α.app j) (G.map f)
+def Coequifibered : MorphismProperty (J ⥤ C) :=
+  fun {F G} α ↦ ∀ ⦃i j : J⦄ (f : i ⟶ j), IsPushout (F.map f) (α.app i) (α.app j) (G.map f)
 
-theorem Coequifibered_of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : Coequifibered α :=
+theorem Coequifibered.of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : Coequifibered α :=
   fun _ _ f => .of_vert_isIso ⟨naturality _ f⟩
+
+@[deprecated (since := "2026-02-01")] alias Coequifibered_of_isIso := Coequifibered.of_isIso
 
 theorem Coequifibered.comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} (hα : Coequifibered α)
     (hβ : Coequifibered β) : Coequifibered (α ≫ β) :=
   fun _ _ f => (hα f).paste_vert (hβ f)
+
+instance : (Coequifibered (J := J) (C := C)).IsMultiplicative where
+  id_mem _ := .of_isIso _
+  comp_mem _ _ := .comp
+
+instance : (Coequifibered (J := J) (C := C)).RespectsIso :=
+  MorphismProperty.respectsIso_of_isStableUnderComposition fun _ _ ↦ .of_isIso
 
 theorem Coequifibered.whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : Coequifibered α)
     (H : C ⥤ D) [∀ (i j : J) (f : j ⟶ i), PreservesColimit (span (F.map f) (α.app j)) H] :
@@ -119,7 +179,34 @@ theorem Coequifibered.unop {F G : Jᵒᵖ ⥤ Cᵒᵖ} {α : F ⟶ G} (hα : Coe
 theorem Equifibered.unop {F G : Jᵒᵖ ⥤ Cᵒᵖ} {α : F ⟶ G} (hα : Equifibered α) :
     Coequifibered (NatTrans.unop α) := fun _ _ f ↦ (hα f.op).unop
 
+theorem coequifibered_op_iff {F G : J ⥤ C} {α : F ⟶ G} :
+    Coequifibered (NatTrans.op α) ↔ Equifibered α := ⟨Coequifibered.unop, Equifibered.op⟩
+
+theorem equifibered_op_iff {F G : J ⥤ C} {α : F ⟶ G} :
+    Equifibered (NatTrans.op α) ↔ Coequifibered α := ⟨Equifibered.unop, Coequifibered.op⟩
+
+theorem coequifibered_unop_iff {F G : Jᵒᵖ ⥤ Cᵒᵖ} {α : F ⟶ G} :
+    Coequifibered (NatTrans.unop α) ↔ Equifibered α := ⟨Coequifibered.op, Equifibered.unop⟩
+
+theorem equifibered_unop_iff {F G : Jᵒᵖ ⥤ Cᵒᵖ} {α : F ⟶ G} :
+    Equifibered (NatTrans.unop α) ↔ Coequifibered α := ⟨Equifibered.op, Coequifibered.unop⟩
+
 end Opposite
+
+open Over in
+instance (F : C ⥤ D) [∀ a b : C, HasProductsOfShape (a ⟶ b) D] :
+    ObjectProperty.IsClosedUnderColimitsOfShape (fun f : Under F ↦ f.hom.Coequifibered) J := by
+  have : ObjectProperty.IsClosedUnderIsomorphisms fun f : Under F ↦ f.hom.Coequifibered :=
+    ⟨fun {X Y} e ↦ by rw [← Under.w e.hom, Coequifibered.cancel_right_of_respectsIso]; simp⟩
+  have (a b : Cᵒᵖ) : HasCoproductsOfShape (a ⟶ b) Dᵒᵖ :=
+    hasColimitsOfShape_of_equivalence (Discrete.equivalence Quiver.Hom.opEquiv)
+  let e : Over F.op ≌ (Under F)ᵒᵖ := (postEquiv _ (opUnopEquiv _ _)).symm.trans (opEquivOpUnder F)
+  rw [ObjectProperty.isClosedUnderColimitsOfShape_iff_op,
+    ← IsClosedUnderLimitsOfShape.inverseImage_iff _ e]
+  convert (inferInstanceAs <| ObjectProperty.IsClosedUnderLimitsOfShape
+    (fun f : Over F.op ↦ f.hom.Equifibered) Jᵒᵖ) with f
+  simp [e, MorphismProperty.cancel_left_of_respectsIso, ← coequifibered_unop_iff]
+  rfl
 
 end NatTrans
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/EquifiberedLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/EquifiberedLimits.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.Products
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Equifibered
+public import Mathlib.CategoryTheory.ObjectProperty.ColimitsOfShape
+
+import Mathlib.CategoryTheory.Adjunction.Evaluation
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
+import Mathlib.CategoryTheory.Limits.Preserves.Opposites
+import Mathlib.CategoryTheory.Limits.Shapes.Opposites.Products
+import Mathlib.CategoryTheory.WithTerminal.Cone
+
+/-! # Functors equifibered over a fixed functor is closed under limits -/
+
+@[expose] public section
+
+namespace CategoryTheory.NatTrans
+
+open Limits Functor ObjectProperty
+
+variable {J K C D ι : Type*} [Category* J] [Category* C] [Category* K] [Category* D]
+
+instance (F : C ⥤ D) [∀ a b : C, HasCoproductsOfShape (a ⟶ b) D] :
+    IsClosedUnderLimitsOfShape (fun f : Over F ↦ f.hom.Equifibered) J := by
+  wlog hJ : IsConnected J generalizing J
+  · refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ U V f ↦ ?_⟩
+    have hα (i j) (f : i ⟶ j) : α.app i ≫ c.map f = α.app j := by simp [← NatTrans.naturality]
+    have hc' := WithTerminal.isLimitEquiv.symm hc
+    have inst : IsConnected (WithTerminal J) := isConnected_of_hasTerminal _
+    exact (this (J := WithTerminal J) inst).1 G ⟨⟨WithTerminal.liftToTerminal c Over.mkIdTerminal,
+      { app i := i.casesOn α.app (Over.mkIdTerminal.from _) }, isLimitOfReflects (Over.forget _) (by
+      refine IsLimit.equivOfNatIsoOfIso ?_ _ _ ?_ (WithTerminal.isLimitEquiv.symm hc)
+      · exact NatIso.ofComponents (fun i ↦ i.casesOn (fun _ ↦ .refl _) (.refl _)) <| by
+          rintro (i | _) (j | _) <;> (try rintro ⟨⟩) <;> simp
+      · exact Cones.ext (.refl _) (by rintro ⟨⟩ <;> simp))⟩, fun i ↦
+        i.casesOn H (.of_isIso (𝟙 F))⟩ f
+  refine ⟨fun G ⟨⟨c, α, hc⟩, H⟩ i j f ↦ ⟨⟨by simp⟩, ⟨Limits.PullbackCone.isLimitAux' _ fun s ↦ ?_⟩⟩⟩
+  let hcᵢ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj i) hc
+  let hcⱼ := isLimitOfPreserves (Over.forget _ ⋙ (evaluation _ _).obj j) hc
+  dsimp at s
+  let l : s.pt ⟶ G.left.obj i := hcᵢ.lift ⟨_, fun k ↦ (H k f).lift (s.fst ≫ (α.app k).left.app j)
+    s.snd (by simp [← s.condition, ← NatTrans.comp_app]), fun k₁ k₂ fk₁k₂ ↦ (H _ f).hom_ext
+    (by simp [← NatTrans.naturality, ← NatTrans.comp_app, ← Over.comp_left])
+    (by simp [← NatTrans.comp_app])⟩
+  refine ⟨l, hcⱼ.hom_ext fun k ↦ ?_, ?_, fun {m} hm₁ hm₂ ↦ hcᵢ.hom_ext
+    fun k ↦ ((H k f).hom_ext ?_ ?_).trans (hcᵢ.fac ⟨_, _⟩ k).symm⟩
+  · simpa [Category.assoc, NatTrans.naturality] using (hcᵢ.fac_assoc _ _ _).trans (by simp)
+  · dsimp
+    obtain ⟨k⟩ : Nonempty J := inferInstance
+    rw [show G.hom.app i = (α.app k).left.app i ≫ (c.obj k).hom.app i by simp [← comp_app]]
+    exact (hcᵢ.fac_assoc ..).trans (by simp)
+  · dsimp at *
+    simp [← NatTrans.naturality, reassoc_of% hm₁]
+  · simpa [← NatTrans.comp_app]
+
+open Over in
+instance (F : C ⥤ D) [∀ a b : C, HasProductsOfShape (a ⟶ b) D] :
+    IsClosedUnderColimitsOfShape (fun f : Under F ↦ f.hom.Coequifibered) J := by
+  have : IsClosedUnderIsomorphisms fun f : Under F ↦ f.hom.Coequifibered :=
+    ⟨fun {X Y} e ↦ by rw [← Under.w e.hom, Coequifibered.cancel_right_of_respectsIso]; simp⟩
+  have (a b : Cᵒᵖ) : HasCoproductsOfShape (a ⟶ b) Dᵒᵖ :=
+    hasColimitsOfShape_of_equivalence (Discrete.equivalence Quiver.Hom.opEquiv)
+  let e : Over F.op ≌ (Under F)ᵒᵖ := (postEquiv _ (opUnopEquiv _ _)).symm.trans (opEquivOpUnder F)
+  rw [isClosedUnderColimitsOfShape_iff_op, ← isClosedUnderLimitsOfShape_inverseImage_iff _ _ e]
+  convert (inferInstanceAs <| IsClosedUnderLimitsOfShape
+    (fun f : Over F.op ↦ f.hom.Equifibered) Jᵒᵖ) with f
+  simp [e, MorphismProperty.cancel_left_of_respectsIso, ← coequifibered_unop_iff]
+  rfl
+
+end CategoryTheory.NatTrans

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -67,7 +67,7 @@ theorem IsVanKampenColimit.isUniversal {F : J ⥤ C} {c : Cocone F} (H : IsVanKa
 noncomputable def IsUniversalColimit.isColimit {F : J ⥤ C} {c : Cocone F}
     (h : IsUniversalColimit c) : IsColimit c := by
   refine ((h c (𝟙 F) (𝟙 c.pt :) (by rw [Functor.map_id, Category.comp_id, Category.id_comp])
-    (NatTrans.equifibered_of_isIso _)) fun j => ?_).some
+    (.of_isIso _)) fun j => ?_).some
   haveI : IsIso (𝟙 c.pt) := inferInstance
   exact IsPullback.of_vert_isIso ⟨by simp⟩
 
@@ -115,8 +115,7 @@ theorem IsVanKampenColimit.precompose_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIs
     {c : Cocone G} (hc : IsVanKampenColimit c) :
     IsVanKampenColimit ((Cocones.precompose α).obj c) := by
   intro F' c' α' f e hα
-  refine (hc c' (α' ≫ α) f ((Category.assoc _ _ _).trans e)
-    (hα.comp (NatTrans.equifibered_of_isIso _))).trans ?_
+  refine (hc c' (α' ≫ α) f ((Category.assoc _ _ _).trans e) (hα.comp (.of_isIso _))).trans ?_
   apply forall_congr'
   intro j
   simp only [Functor.const_obj_obj, NatTrans.comp_app,
@@ -130,8 +129,7 @@ theorem IsUniversalColimit.precompose_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIs
     {c : Cocone G} (hc : IsUniversalColimit c) :
     IsUniversalColimit ((Cocones.precompose α).obj c) := by
   intro F' c' α' f e hα H
-  apply (hc c' (α' ≫ α) f ((Category.assoc _ _ _).trans e)
-    (hα.comp (NatTrans.equifibered_of_isIso _)))
+  apply (hc c' (α' ≫ α) f ((Category.assoc _ _ _).trans e) (hα.comp (.of_isIso _)))
   intro j
   simp only [Functor.const_obj_obj, NatTrans.comp_app]
   rw [← Category.comp_id f]
@@ -178,7 +176,7 @@ theorem IsUniversalColimit.whiskerEquivalence {K : Type*} [Category* K] (e : J �
     IsUniversalColimit (c.whisker e.functor) := by
   intro F' c' α f e' hα H
   convert hc (c'.whisker e.inverse) (whiskerLeft e.inverse α ≫ (e.invFunIdAssoc F).hom) f ?_
-    ((hα.whiskerLeft _).comp (NatTrans.equifibered_of_isIso _)) ?_ using 1
+    ((hα.whiskerLeft _).comp (.of_isIso _)) ?_ using 1
   · exact (IsColimit.whiskerEquivalenceEquiv e.symm).nonempty_congr
   · convert congr_arg (whiskerLeft e.inverse) e'
     ext
@@ -199,7 +197,7 @@ theorem IsVanKampenColimit.whiskerEquivalence {K : Type*} [Category* K] (e : J �
     IsVanKampenColimit (c.whisker e.functor) := by
   intro F' c' α f e' hα
   convert hc (c'.whisker e.inverse) (whiskerLeft e.inverse α ≫ (e.invFunIdAssoc F).hom) f ?_
-    ((hα.whiskerLeft _).comp (NatTrans.equifibered_of_isIso _)) using 1
+    ((hα.whiskerLeft _).comp (.of_isIso _)) using 1
   · exact (IsColimit.whiskerEquivalenceEquiv e.symm).nonempty_congr
   · simp only [Functor.const_obj_obj, Functor.comp_obj, Cocone.whisker_pt, Cocone.whisker_ι,
       whiskerLeft_app, NatTrans.comp_app, Equivalence.invFunIdAssoc_hom_app, Functor.id_obj]
@@ -262,7 +260,7 @@ theorem IsUniversalColimit.map_reflective
     ⟨⟨_, isLimitPullbackConeMapOfIsLimit _ pullback.condition
       (IsPullback.of_hasPullback _ _).isLimit⟩⟩
   let α' := α ≫ (Functor.associator _ _ _).hom ≫ whiskerLeft F adj.counit ≫ F.rightUnitor.hom
-  have hα' : NatTrans.Equifibered α' := hα.comp (NatTrans.equifibered_of_isIso _)
+  have hα' : NatTrans.Equifibered α' := hα.comp (.of_isIso _)
   have hadj : ∀ X, Gl.map (adj.unit.app X) = inv (adj.counit.app _) := by
     intro X
     apply IsIso.eq_inv_of_inv_hom_id
@@ -358,7 +356,7 @@ theorem IsVanKampenColimit.map_reflective [HasColimitsOfShape J C]
   refine ⟨?_, H.isUniversal.map_reflective adj c' α f h hα⟩
   intro ⟨hc'⟩ j
   let α' := α ≫ (Functor.associator _ _ _).hom ≫ whiskerLeft F adj.counit ≫ F.rightUnitor.hom
-  have hα' : NatTrans.Equifibered α' := hα.comp (NatTrans.equifibered_of_isIso _)
+  have hα' : NatTrans.Equifibered α' := hα.comp (.of_isIso _)
   have hα'' : ∀ j, Gl.map (Gr.map <| α'.app j) = adj.counit.app _ ≫ α.app j := by
     intro j
     rw [← cancel_mono (adj.counit.app <| F.obj j)]

--- a/Mathlib/CategoryTheory/ObjectProperty/ColimitsOfShape.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/ColimitsOfShape.lean
@@ -10,6 +10,8 @@ public import Mathlib.CategoryTheory.ObjectProperty.LimitsOfShape
 public import Mathlib.CategoryTheory.ObjectProperty.Retract
 public import Mathlib.CategoryTheory.Limits.Presentation
 
+import Mathlib.CategoryTheory.Adjunction.Limits
+
 /-!
 # Objects that are colimits of objects satisfying a certain property
 
@@ -52,7 +54,7 @@ namespace CategoryTheory.ObjectProperty
 
 open Limits
 
-variable {C : Type*} [Category* C] (P : ObjectProperty C)
+variable {C D : Type*} [Category* C] [Category* D] (P : ObjectProperty C)
   (J : Type u') [Category.{v'} J]
   {J' : Type u''} [Category.{v''} J']
 
@@ -230,6 +232,21 @@ lemma IsClosedUnderColimitsOfShape.of_equivalence (e : J ≌ J')
     [P.IsClosedUnderColimitsOfShape J] :
     P.IsClosedUnderColimitsOfShape J' := by
   rwa [← P.isClosedUnderColimitsOfShape_iff_of_equivalence e]
+
+instance IsClosedUnderColimitsOfShape.inverseImage
+    (P : ObjectProperty D) (F : C ⥤ D) [P.IsClosedUnderColimitsOfShape J]
+    [PreservesColimitsOfShape J F] : (P.inverseImage F).IsClosedUnderColimitsOfShape J :=
+  ⟨fun _ ⟨c, H⟩ ↦ ColimitOfShape.prop (P := P) ⟨c.map F, H⟩⟩
+
+lemma isClosedUnderColimitsOfShape_inverseImage_iff (P : ObjectProperty D)
+    [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
+    (P.inverseImage e.functor).IsClosedUnderColimitsOfShape J ↔
+      P.IsClosedUnderColimitsOfShape J := by
+  refine ⟨fun H ↦ ?_, fun _ ↦ inferInstance⟩
+  convert inferInstanceAs
+    (((P.inverseImage e.functor).inverseImage e.inverse).IsClosedUnderColimitsOfShape J)
+  ext X
+  simpa using P.prop_iff_of_iso (e.counitIso.app X).symm
 
 lemma colimitsOfShape_eq_unop_limitsOfShape :
     P.colimitsOfShape J = (P.op.limitsOfShape Jᵒᵖ).unop := by

--- a/Mathlib/CategoryTheory/ObjectProperty/LimitsOfShape.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/LimitsOfShape.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.CategoryTheory.ObjectProperty.Small
 public import Mathlib.CategoryTheory.Limits.Presentation
 
+import Mathlib.CategoryTheory.Adjunction.Limits
+
 /-!
 # Objects that are limits of objects satisfying a certain property
 
@@ -45,7 +47,7 @@ namespace CategoryTheory.ObjectProperty
 
 open Limits
 
-variable {C : Type*} [Category* C] (P : ObjectProperty C)
+variable {C D : Type*} [Category* C] [Category* D] (P : ObjectProperty C)
   (J : Type u') [Category.{v'} J]
   {J' : Type u''} [Category.{v''} J']
 
@@ -228,6 +230,20 @@ lemma IsClosedUnderLimitsOfShape.of_equivalence (e : J ≌ J')
     [P.IsClosedUnderLimitsOfShape J] :
     P.IsClosedUnderLimitsOfShape J' := by
   rwa [← P.isClosedUnderLimitsOfShape_iff_of_equivalence e]
+
+instance IsClosedUnderLimitsOfShape.inverseImage
+    (P : ObjectProperty D) (F : C ⥤ D) [P.IsClosedUnderLimitsOfShape J]
+    [PreservesLimitsOfShape J F] : (P.inverseImage F).IsClosedUnderLimitsOfShape J :=
+  ⟨fun _ ⟨c, H⟩ ↦ ObjectProperty.LimitOfShape.prop (P := P) ⟨c.map F, H⟩⟩
+
+lemma isClosedUnderLimitsOfShape_inverseImage_iff (P : ObjectProperty D)
+    [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
+    (P.inverseImage e.functor).IsClosedUnderLimitsOfShape J ↔ P.IsClosedUnderLimitsOfShape J := by
+  refine ⟨fun H ↦ ?_, fun _ ↦ inferInstance⟩
+  convert inferInstanceAs
+    (((P.inverseImage e.functor).inverseImage e.inverse).IsClosedUnderLimitsOfShape J)
+  ext X
+  simpa using P.prop_iff_of_iso (e.counitIso.app X).symm
 
 end ObjectProperty
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
