### PR TITLE
[Merged by Bors] - perf(to_additive): hard code `OfNat` and `OfNat.ofNat` for numeral translation

### DIFF
--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -18,8 +18,6 @@ set_option linter.privateModule false
 attribute [to_additive_do_translate] Empty PEmpty Unit PUnit
 attribute [to_additive_ignore_args 2] Subtype
 
-attribute [translate_change_numeral 2] OfNat OfNat.ofNat
-
 attribute [to_additive] One
 attribute [to_additive existing Zero.toOfNat0] One.toOfNat1
 attribute [to_additive existing Zero.ofOfNat0] One.ofOfNat1


### PR DESCRIPTION
This PR removes the environment extension used by `to_additive` to determine which numerals to translate. The only two entries in this environment extension are `OfNat` and `OfNat.ofNat`, and I don't see why this would change.

See [#mathlib4 > Performance cost of environment extensions](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Performance.20cost.20of.20environment.20extensions/with/571319366)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
