### PR TITLE
feat(Tactic/Linter): add unicode linter for unicode variant-selectors

### DIFF
--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -23,14 +23,14 @@ such as splittings and equivalences.
 
 ```text
 For multiplicative groups:
-      ↗︎ E  ↘
+      ↗ E  ↘
 1 → N   ↓    G → 1
-      ↘︎ E' ↗︎️
+      ↘ E' ↗
 
 For additive groups:
-      ↗︎ E  ↘
+      ↗ E  ↘
 0 → N   ↓    G → 0
-      ↘︎ E' ↗︎️
+      ↘ E' ↗
 ```
 
 - `(Add?)GroupExtension.Section S`: structure for right inverses to `rightHom` of a group extension

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -88,7 +88,7 @@ def suggestion (tac : TSyntax `tactic) (trees : PersistentArray InfoTree) : Tact
   We use emojis for now instead.
   -/
   -- let style? := if goals.isEmpty then some .success else none
-  let preInfo? := if goals.isEmpty then some "🎉 " else none
+  let preInfo? := if goals.isEmpty then some "🎉️ " else none
   let suggestions := collectTryThisSuggestions trees
   let suggestion := match suggestions[0]? with
   | some s => s.suggestion

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -60,7 +60,12 @@ inductive StyleError where
   | semicolon
   /-- A unicode character was used that isn't allowed -/
   | unwantedUnicode (c : Char)
-deriving BEq, Inhabited
+  /-- Unicode variant selectors are used in a bad way.
+  * `s` is the string containing the unicode character and any unicode variant selector following it
+  * `selector` is the desired selector, or `none` if `c` should not be followed by any selector.
+  -/
+  | unicodeVariant (s : String) (selector: Option Char)
+deriving BEq, Inhabited, Repr
 
 /-- How to format style errors -/
 public inductive ErrorFormat
@@ -74,6 +79,7 @@ public inductive ErrorFormat
   | github : ErrorFormat
   deriving BEq
 
+open UnicodeLinter in
 /-- Create the underlying error message for a given `StyleError`. -/
 def StyleError.errorMessage (err : StyleError) : String := match err with
   | StyleError.adaptationNote =>
@@ -83,7 +89,30 @@ def StyleError.errorMessage (err : StyleError) : String := match err with
   | trailingWhitespace => "This line ends with some whitespace: please remove this"
   | semicolon => "This line contains a space before a semicolon"
   | StyleError.unwantedUnicode c => s!"This line contains a bad unicode character \
-    '{c}' ({UnicodeLinter.printCodepointHex c})."
+    '{c}' ({c.printCodepointHex})."
+  | StyleError.unicodeVariant s selector =>
+    let variantText := if selector == UnicodeVariant.emoji then
+      "emoji"
+    else if selector == UnicodeVariant.text then
+      "text"
+    else
+      "default"
+    let oldHex := s.printCodepointHex
+    match s.toList, selector with
+    | c₀ :: [], some sel =>
+      let newC : String := String.ofList [c₀, sel]
+      let newHex := newC.printCodepointHex
+      s!"Missing unicode variant selector: \"{s}\" ({oldHex}). \
+        Please use the {variantText} variant: \"{newC}\" ({newHex})!"
+    | c₀ :: _ :: [], some sel =>
+      -- by assumption, the second character is a variant selector
+      let newC : String := String.ofList [c₀, sel]
+      let newHex := newC.printCodepointHex
+      s!"Wrong unicode variant selector: \"{s}\" ({oldHex}). \
+        Please use the {variantText} variant: \"{newC}\" ({newHex})!"
+    | _, _ =>
+      s!"Unexpected unicode variant selector: \"{s}\" ({oldHex}). \
+        Consider deleting it."
 
 /-- The error code for a given style error. Keep this in sync with `parse?_errorContext` below! -/
 -- FUTURE: we're matching the old codes in `lint-style.py` for compatibility;
@@ -94,7 +123,7 @@ def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.trailingWhitespace => "ERR_TWS"
   | StyleError.semicolon => "ERR_SEM"
   | StyleError.unwantedUnicode _ => "ERR_UNICODE"
-
+  | StyleError.unicodeVariant _ _ => "ERR_UNICODE_VARIANT"
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
 and the path to the file. -/
@@ -158,6 +187,11 @@ def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
     -- Print for humans: clickable file name and omit the error code
     s!"error: {errctx.path}:{errctx.lineNumber}: {errorMessage}"
 
+
+/-- Removes quotation marks '"' at front and back of string. -/
+def removeQuotations (s : String) : String :=
+  ((s.dropPrefix "\"").toString.dropSuffix "\"").toString
+
 /-- Try parsing an `ErrorContext` from a string: return `some` if successful, `none` otherwise.
 Used for, e.g., parsing the "exceptions" file.
 
@@ -188,6 +222,19 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
           let str ← errorMessage[7]?
           let c ← String.Pos.Raw.get? str ⟨1⟩ -- take middle character of expected three
           StyleError.unwantedUnicode c
+        | "ERR_UNICODE_VARIANT" => do
+          match (← errorMessage[0]?).toLower with
+          | "wrong" | "missing" =>
+            let offending := removeQuotations (← errorMessage[4]?)
+            let selector := match ← errorMessage[9]? with
+            | "emoji" => UnicodeLinter.UnicodeVariant.emoji
+            | "text" => UnicodeLinter.UnicodeVariant.text
+            | _ => none
+            StyleError.unicodeVariant offending selector
+          | "unexpected" =>
+            let offending := removeQuotations (← errorMessage[4]?)
+            StyleError.unicodeVariant offending none
+          | _ => none
         | _ => none
       match String.toNat? lineNumber with
       | some n => err.map fun e ↦ (ErrorContext.mk e n path)
@@ -304,6 +351,33 @@ termination_by pos.remainingBytes
 def findBadUnicode (s : String) : Array StyleError :=
   findBadUnicodeAux s s.startPos
 
+/-- Looks at two consecutive characters in a string.
+Decides if variant selector rules are violated -/
+def findBadUnicodeVariantSelectorsAux (c₁ c₂ : Char) : Option StyleError :=
+  if c₂ == UnicodeVariant.emoji && !(emojis.contains c₁) then
+      -- bad: emoji variant selector following a non-emoji.
+      some (.unicodeVariant (String.ofList [c₁, c₂]) none)
+  else if c₂ == UnicodeVariant.text && !(nonEmojis.contains c₁) then
+      -- bad: text variant selector following non-text.
+      some (.unicodeVariant (String.ofList [c₁, c₂]) none)
+  else if c₂ != UnicodeVariant.emoji && emojis.contains c₁ then
+      -- bad: missing emoji variant selector.
+      some (.unicodeVariant c₁.toString UnicodeVariant.emoji)
+  else if c₂ != UnicodeVariant.text && nonEmojis.contains c₁ then
+      -- bad: missing text variant selector.
+      some (.unicodeVariant c₁.toString UnicodeVariant.text)
+  else none
+
+/-- Iterate over all consecutive pairs of characters of a `String` -/
+def pairwiseMap {α : Type} (s : String) (f : Char → Char → α) : Array α :=
+  let arr := s.toList.toArray
+  arr.zipWith f (arr.drop 1)
+
+/-- Creates `StyleError`s for bad usage of unicode characters. -/
+@[inline]
+def findBadUnicodeVariantSelectors (s : String) : Array StyleError :=
+  (pairwiseMap s findBadUnicodeVariantSelectorsAux).reduceOption
+
 end UnicodeLinter
 
 /-- Lint a collection of input strings for disallowed unicode characters. -/
@@ -335,12 +409,43 @@ def unicodeLinter : TextbasedLinter := fun opts lines ↦ Id.run do
     lineNumber := lineNumber + 1
   return (errors, if (changed == lines) then none else some changed)
 
+/-- Lint a collection of input strings for incorrect use of unicode variant selectors. -/
+public register_option linter.variantSelectorLinter : Bool := { defValue := true }
+
+@[inherit_doc linter.unicodeLinter]
+def variantSelectorLinter : TextbasedLinter := fun opts lines ↦ Id.run do
+  unless getLinterValue linter.variantSelectorLinter opts do return (#[], none)
+
+  let mut changed : Array String := #[]
+  let mut errors : Array (StyleError × ℕ) := Array.mkEmpty 0
+  let mut lineNumber := 1 -- one-based line numbers!
+  for line in lines do
+    let err := UnicodeLinter.findBadUnicodeVariantSelectors line
+
+    -- try to auto-fix the style error
+    let mut newLine := line
+    for e in err.reverse do -- reversing is a cheap fix to prevent shifting indices
+      match e with
+      | .unicodeVariant s sel =>
+        let replacement : String := match sel, s.startPos.get? with
+        | none, some c => c.toString
+        | some v, some c => String.ofList [c, v]
+        | _, none => unreachable!
+        newLine := newLine.replace s replacement
+      | _ => unreachable!
+
+    changed := changed.push newLine
+    errors := errors.append (err.map (fun e => (e, lineNumber)))
+    lineNumber := lineNumber + 1
+  return (errors, if (changed == lines) then none else some changed)
+
 /-- All text-based linters registered in this file. -/
 def allLinters : Array TextbasedLinter := #[
     adaptationNoteLinter,
     semicolonLinter,
     trailingWhitespaceLinter,
     unicodeLinter,
+    variantSelectorLinter
   ]
 
 /-- Read a file and apply all text-based linters.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -487,7 +487,7 @@ def lintFile (opts : LinterOptions) (path : FilePath) (exceptions : Array ErrorC
         -- check if any exception applies:
         if new_errors.any fun (e, idx) ↦
           (idx - 1 == lineIdx) -- Subtract 1 since linter's line numbers are one-based
-          ∧ (ErrorContext.find?_comparable ⟨e, lineIdx, path⟩ exceptions).isSome
+          ∧ (ErrorContext.find?_comparable ⟨e, lineIdx, path⟩ exceptions).isNone
         then
           c[lineIdx]! -- no exception applies. Assign linter's suggestion.
         else

--- a/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
@@ -43,7 +43,7 @@ public def String.printCodepointHex (s : String) : String :=
 public def isAllowedCharacter (c : Char) : Bool :=
   !#['\u00A0'].contains c -- non-breaking space
 
-/-- Provide default replacement (`String`) for a blocklisted character, or `none` if not defined -/
+/-- Provide default replacement (`String`) for a blocklisted character, or `none` if not defined -/
 public def replaceDisallowed : Char → Option String
 | '\u00a0' => " " -- replace non-breaking space with normal whitespace
 | _ => none

--- a/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
@@ -20,20 +20,52 @@ This file defines the blocklist and other tools used by the linter.
 
 namespace Mathlib.Linter.TextBased.UnicodeLinter
 
+/-- Following any unicode character, this indicates that the emoji variant should be displayed -/
+public def UnicodeVariant.emoji := '\uFE0F'
+
+/-- Following any unicode character, this indicates that the text variant should be displayed -/
+public def UnicodeVariant.text := '\uFE0E'
+
 /-- Prints a unicode character's codepoint in hexadecimal with prefix 'U+'.
 E.g., 'a' is "U+0061". -/
-public def printCodepointHex (c : Char) : String :=
+public def Char.printCodepointHex (c : Char) : String :=
   let digits := Nat.toDigits 16 c.val.toNat
   -- print at least 4 (could be more) hex characters using leading zeros
   ("U+".append <| "0000".drop digits.length |>.toString).append <| String.ofList digits
 
-/-- Blocklist: If `false`, the character is not allowed in Mathlib. -/
+/-- Prints all characters in a string in hexadecimal with prefix 'U+'.
+E.g., "ab" is "U+0061;U+0062". -/
+public def String.printCodepointHex (s : String) : String :=
+  -- note: must not contain spaces because of the error message parsing below!
+  ";".intercalate <| s.toList.map Char.printCodepointHex
+
+/-- If `false`, the character is not allowed in Mathlib. -/
 public def isAllowedCharacter (c : Char) : Bool :=
   !#['\u00A0'].contains c -- non-breaking space
 
-/-- Provide default replacement (`String`) for a blocklisted character, or `none` if none defined -/
+/-- Provide default replacement (`String`) for a blocklisted character, or `none` if not defined -/
 public def replaceDisallowed : Char → Option String
 | '\u00a0' => " " -- replace non-breaking space with normal whitespace
 | _ => none
+
+/-- A unicode character is in this list
+if and only if it should always be followed by the emoji variant selector. -/
+public def emojis := #[
+'\u2705',        -- ✅️
+'\u274C',        -- ❌️
+ -- Note: cannot write these as e.g. '\u1F4A5' due to error: "missing end of character literal"
+.ofNat 0x1F4A5,  -- 💥️
+.ofNat 0x1F7E1,  -- 🟡️
+.ofNat 0x1F4A1,  -- 💡️
+.ofNat 0x1F419,  -- 🐙️
+.ofNat 0x1F50D,  -- 🔍️
+.ofNat 0x1F389,  -- 🎉️
+'\u23F3',        -- ⏳️
+.ofNat 0x1F3C1,  -- 🏁️
+]
+
+/-- A unicode character is in this list
+if and only if it should always be followed by the text variant selector. -/
+public def nonEmojis : Array Char := #[]
 
 end Mathlib.Linter.TextBased.UnicodeLinter

--- a/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
@@ -36,14 +36,14 @@ public def Char.printCodepointHex (c : Char) : String :=
 /-- Prints all characters in a string in hexadecimal with prefix 'U+'.
 E.g., "ab" is "U+0061;U+0062". -/
 public def String.printCodepointHex (s : String) : String :=
-  -- note: must not contain spaces because of the error message parsing below!
+  -- note: Output must not contain spaces because of the error message parsing!
   ";".intercalate <| s.toList.map Char.printCodepointHex
 
 /-- If `false`, the character is not allowed in Mathlib. -/
 public def isAllowedCharacter (c : Char) : Bool :=
   !#['\u00A0'].contains c -- non-breaking space
 
-/-- Provide default replacement (`String`) for a blocklisted character, or `none` if not defined -/
+/-- Provide default replacement (`String`) for a blocklisted character, or `none` if not defined -/
 public def replaceDisallowed : Char → Option String
 | '\u00a0' => " " -- replace non-breaking space with normal whitespace
 | _ => none

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -124,7 +124,7 @@ def suggestSteps (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr) (par
 @[server_rpc_method]
 def CalcPanel.rpc := mkSelectionPanelRPC suggestSteps
   "Please select subterms using Shift-click."
-  "Calc 🔍"
+  "Calc 🔍️"
 
 /-- The calc widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/CongrM.lean
+++ b/Mathlib/Tactic/Widget/CongrM.lean
@@ -45,7 +45,7 @@ def makeCongrMString (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
 @[server_rpc_method]
 def CongrMSelectionPanel.rpc := mkSelectionPanelRPC makeCongrMString
   "Use shift-click to select sub-expressions in the goal that should become holes in congrm."
-  "CongrM 🔍"
+  "CongrM 🔍️"
 
 /-- The congrm widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/Conv.lean
+++ b/Mathlib/Tactic/Widget/Conv.lean
@@ -258,7 +258,7 @@ public protected def SelectionPanel.rpc :=
   mkSelectionPanelRPC insertEnter
     "Use shift-click to select one sub-expression in the goal or local context that you want to \
     zoom in on."
-    "Conv 🔍" (onlyGoal := false) (onlyOne := true)
+    "Conv 🔍️" (onlyGoal := false) (onlyOne := true)
 
 /-- The conv widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/GCongr.lean
+++ b/Mathlib/Tactic/Widget/GCongr.lean
@@ -45,7 +45,7 @@ return (res, res, none)
 @[server_rpc_method]
 def GCongrSelectionPanel.rpc := mkSelectionPanelRPC makeGCongrString
   "Use shift-click to select sub-expressions in the goal that should become holes in gcongr."
-  "GCongr 🔍"
+  "GCongr 🔍️"
 
 /-- The gcongr widget. -/
 @[widget_module]

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -1,5 +1,5 @@
 module
-
+import Batteries.Data.List.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic.Linter.Style
 import Mathlib.Order.SetNotation
@@ -655,6 +655,100 @@ private theorem disallowed_of_replaceable (c : Char) (creplaced : replaceDisallo
   simp [isAllowedCharacter, Array.contains] at creplaced
   repeat obtain ⟨_, creplaced⟩ := creplaced
   simp [replaceDisallowed]
+
+
+/- Ensure each character can only be listed in either selector-list.
+Linter logic would need to change in order to allow this. -/
+#guard UnicodeLinter.emojis.toList ∩ UnicodeLinter.nonEmojis.toList = ∅
+
+/-!
+Ensure parsing back error messages in `parse?_errorContext` works.
+-/
+
+-- These test guard against changes in the error message.
+-- Changes to the error message mean the indices in `parse?_errorContext`
+-- need to be adjusted
+
+/-- info: some "'X'" -/
+#guard_msgs in
+#eval (StyleError.errorMessage (.unwantedUnicode 'X') |>.splitToList (· == ' '))[7]?
+
+/-- info: some "Missing" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "A" (some emoji))).splitToList (· == ' '))[0]?
+
+/-- info: some "Wrong" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "A\uFE0F" (some emoji))).splitToList (· == ' '))[0]?
+
+/-- info: some "Unexpected" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "A\uFE0F" none)).splitToList (· == ' '))[0]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[4]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[4]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" none)).splitToList (· == ' '))[4]?
+
+/-- info: some "emoji" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[9]?
+
+/-- info: some "emoji" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[9]?
+
+/-- info: none -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" none)).splitToList (· == ' '))[9]?
+
+
+-- "missing" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d" UnicodeVariant.emoji,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d" UnicodeVariant.text,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+
+-- "wrong" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0E" UnicodeVariant.emoji,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0F" UnicodeVariant.text,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+-- "unexpected" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0E" none,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0F" none,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
 
 end unicodeLinter
 


### PR DESCRIPTION
_(adapted from [joneugster](https://github.com/joneugster)'s [original PR message](https://github.com/leanprover-community/mathlib4/pull/17129#issue-2547635963))_ 

* add a new unicode linter ensuring variant-selectors only appear on specified characters and also ensuring these       characters always have the correct variant selector to avoid confusions.
* fix a bug from https://github.com/leanprover-community/mathlib4/pull/34022 which broke autofixing
    * add `String.printCodepointHex` analog to the existing `printCodepointHex` which has been renamed to `Char.printCodepointHex`
    * add some `ToString` instances to the test file to help debugging. (I really needed them badly...)
* automatic fixes flagged by this linter

* tracking PR: [feat(Tactic/Linter): lint unwanted unicode #16215](https://github.com/leanprover-community/mathlib4/pull/16215)

Unicode characters can be followed by one of the two "variant-selectors" `\FE0E` (text) or `\FE0F` (emoji). These appear to the user as a single unicode character and they might copy them by accident. For example `✝️` (`\u271d\uFE0F`), `✝` (`\u271d`) and `✝︎` (`\u271d\uFE0E`) are three variants of the "same" unicode character. The one without variant-selector might display as either emoji or not, depending on the user's device and font. (e.g. for me it is an emoji while editing this message, but a text when previewing). This linter ensures that specific variant selectors are used consistently for certain unicode characters.

Everything flagged by this linter can be fixed fully automatically with `lake exe lint-style --fix` or by commenting `bot fix style` on the PR.


## Testing:
First, drop the last commit from this PR (which includes only the autofixed style issues)
Then call `lake exe lint-style`. You should see 13 new style errors.
Next, add the following line to `nolints-style.txt`:
```
Mathlib/GroupTheory/GroupExtension/Defs.lean : line 26 : ERR_UNICODE_VARIANT : Unexpected unicode variant selector: "↗︎" (U+2197;U+fe0e). Consider deleting it.
```
now `lake exe lint-style` should only display 9 style errors. These can be applied with `lake exe lint-style --fix`.
Next, remove the changes from `nolints-style.txt`. You should then see another 2 errors which can be fixed again.
## Zulip discussions:
* https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Whitelist.20for.20Unicode.3F
* https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.20specific.20font

## Related PRs:
* [RFC: Use emoji variant selector for unicode characters leanprover/lean4#5015](https://github.com/leanprover/lean4/issues/5015) added some emoji-variant selectors to Emojis used in `Lean` itself.
* replacement of https://github.com/leanprover-community/mathlib4/pull/17129 (due to PRs being made from forks now)
    tracking PR: https://github.com/leanprover-community/mathlib4/pull/16215
