### PR TITLE
[Merged by Bors] - fix(Tactic/ApplyWith): disambiguate parse to improve error messages

### DIFF
--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -20,6 +20,15 @@ public meta section
 namespace Mathlib.Tactic
 open Lean Parser Meta Elab Tactic Term
 
+/-- At least one configuration option for tactics.
+
+Use `declare_config_elab` to get a function turning this syntax into a concrete object.
+
+`optConfig` allows zero or more, `manyConfig` requires at least one.
+-/
+syntax manyConfig := (colGt configItem)+
+
+
 /-- Elaborator for the configuration in `apply (config := cfg)` syntax. -/
 declare_config_elab elabApplyConfig ApplyConfig
 
@@ -34,7 +43,8 @@ declare_config_elab elabApplyConfig ApplyConfig
 tactic_extension Lean.Parser.Tactic.apply
 
 @[tactic_alt Lean.Parser.Tactic.apply]
-elab (name := applyWith) "apply" cfg:optConfig ppSpace e:term : tactic => do
+-- We have to use `manyConfig` instead of `optConfig` to avoid ambiguous parses.
+elab (name := applyWith) "apply" cfg:manyConfig ppSpace e:term : tactic => do
   let cfg ← elabApplyConfig cfg
   evalApplyLikeTactic (·.apply · cfg) e
 

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -22,12 +22,33 @@ open Lean Parser Meta Elab Tactic Term
 
 /-- At least one configuration option for tactics.
 
-Use `declare_config_elab` to get a function turning this syntax into a concrete object.
+If a configuration elaborator is defined as `declare_config_elab elabMyConfig MyConfigStruct`,
+a `manyConfig` syntax item ```cfg : TSyntax ``manyConfig``` can be passed to it using
+`elabMyConfig (optConfigOf cfg)`.
 
-`optConfig` allows zero or more, `manyConfig` requires at least one.
+`optConfig` allows zero or more options, `manyConfig` requires at least one option.
 -/
 syntax manyConfig := (colGt configItem)+
 
+/--
+Extracts the items from a tactic configuration,
+either a `Mathlib.Tactic.manyConfig`, `Lean.Parser.Tactic.optConfig`, `Lean.Parser.Tactic.config`,
+or these wrapped in null nodes.
+-/
+def getManyConfigItems (c : Syntax) : TSyntaxArray ``configItem :=
+  if c.isOfKind nullKind then
+    c.getArgs.flatMap getConfigItems
+  else
+    match c with
+    | `(manyConfig| $items:configItem*) => items
+    | `(optConfig| $items:configItem*) => items
+    | `(config| (config := $_)) => #[⟨c⟩] -- handled by mkConfigItemViews
+    | _ => #[]
+
+/-- Convert `manyConfig`, `optConfig` or `config` syntax into `optConfig`,
+for use in a `declare_config_elab` elaborator. -/
+def optConfigOf (c : Syntax) : TSyntax ``optConfig :=
+  mkOptConfig (getManyConfigItems c)
 
 /-- Elaborator for the configuration in `apply (config := cfg)` syntax. -/
 declare_config_elab elabApplyConfig ApplyConfig
@@ -45,7 +66,7 @@ tactic_extension Lean.Parser.Tactic.apply
 @[tactic_alt Lean.Parser.Tactic.apply]
 -- We have to use `manyConfig` instead of `optConfig` to avoid ambiguous parses.
 elab (name := applyWith) "apply" cfg:manyConfig ppSpace e:term : tactic => do
-  let cfg ← elabApplyConfig cfg
+  let cfg ← elabApplyConfig (optConfigOf cfg)
   evalApplyLikeTactic (·.apply · cfg) e
 
 end Mathlib.Tactic

--- a/MathlibTest/apply_with.lean
+++ b/MathlibTest/apply_with.lean
@@ -29,3 +29,28 @@ example : Nat := by
   fail_if_success apply -allowSynthFailures takeImplicit
   apply +allowSynthFailures takeImplicit
   apply foo
+
+section
+
+/-! Making sure we have useful error reporting. -/
+
+def MyProp (n : Nat) : Prop := n = n
+
+theorem MyProp.mk (n : Nat) : MyProp n := by rw [MyProp]
+
+/--
+error: Application type mismatch: The argument
+  "foo"
+has type
+  String
+but is expected to have type
+  Nat
+in the application
+  MyProp.mk "foo"
+-/
+#guard_msgs in
+example : MyProp 1337 := by
+  apply MyProp.mk "foo"
+  exact "qed"
+
+end


### PR DESCRIPTION
This PR fixes that `apply` and `applyWith` have overlapping parses, which seems to cause bad error messages ("this declaration contains sorry" instead of "apply failed, type mismatch").

Zulip threads:
* https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Wall.20of.20warnings.20of.20.60unreachableTactic.60.2F.60unusedTactic.60
* https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/optConfig.20causes.20tactics.20to.20be.20ignored/with/571416569


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
