### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/Veblen): add `recommended_spelling` for epsilon and gamma functions

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Veblen.lean
+++ b/Mathlib/SetTheory/Ordinal/Veblen.lean
@@ -534,40 +534,54 @@ This is an abbreviation for `veblen 1`. -/
 abbrev epsilon := veblen 1
 
 @[inherit_doc] scoped notation "ε_ " => epsilon
+recommended_spelling "epsilon" for "ε_ " in [epsilon, «termε_»]
 
 /-- `ε₀` is the first fixed point of `ω ^ ⬝`, i.e. the supremum of `ω`, `ω ^ ω`, `ω ^ ω ^ ω`, … -/
 scoped notation "ε₀" => ε_ 0
+recommended_spelling "epsilon_zero" for "ε₀" in [«termε₀»]
 
 theorem epsilon_eq_deriv (o : Ordinal) : ε_ o = deriv (fun a ↦ ω ^ a) o := by
   rw [epsilon, ← succ_zero, veblen_succ, veblen_zero]
 
-theorem epsilon0_eq_nfp : ε₀ = nfp (fun a ↦ ω ^ a) 0 := by
+theorem epsilon_zero_eq_nfp : ε₀ = nfp (fun a ↦ ω ^ a) 0 := by
   rw [epsilon_eq_deriv, deriv_zero_right]
+
+@[deprecated (since := "2026-02-02")]
+alias epsilon0_eq_nfp := epsilon_zero_eq_nfp
 
 theorem epsilon_succ_eq_nfp (o : Ordinal) : ε_ (succ o) = nfp (fun a ↦ ω ^ a) (succ (ε_ o)) := by
   rw [epsilon_eq_deriv, epsilon_eq_deriv, deriv_succ]
 
-theorem epsilon0_le_of_omega0_opow_le (h : ω ^ o ≤ o) : ε₀ ≤ o := by
-  rw [epsilon0_eq_nfp]
+theorem epsilon_zero_le_of_omega0_opow_le (h : ω ^ o ≤ o) : ε₀ ≤ o := by
+  rw [epsilon_zero_eq_nfp]
   exact nfp_le_fp (fun _ _ ↦ (opow_le_opow_iff_right one_lt_omega0).2) (zero_le o) h
+
+@[deprecated (since := "2026-02-02")]
+alias epsilon0_le_of_omega0_opow_le := epsilon_zero_le_of_omega0_opow_le
 
 @[simp]
 theorem omega0_opow_epsilon (o : Ordinal) : ω ^ ε_ o = ε_ o := by
   rw [epsilon_eq_deriv, deriv_fp (isNormal_opow one_lt_omega0)]
 
 /-- `ε₀` is the limit of `0`, `ω ^ 0`, `ω ^ ω ^ 0`, … -/
-theorem lt_epsilon0 : o < ε₀ ↔ ∃ n : ℕ, o < (fun a ↦ ω ^ a)^[n] 0 := by
-  rw [epsilon0_eq_nfp, lt_nfp_iff]
+theorem lt_epsilon_zero : o < ε₀ ↔ ∃ n : ℕ, o < (fun a ↦ ω ^ a)^[n] 0 := by
+  rw [epsilon_zero_eq_nfp, lt_nfp_iff]
+
+@[deprecated (since := "2026-02-02")]
+alias lt_epsilon0 := lt_epsilon_zero
 
 /-- `ω ^ ω ^ … ^ 0 < ε₀` -/
-theorem iterate_omega0_opow_lt_epsilon0 (n : ℕ) : (fun a ↦ ω ^ a)^[n] 0 < ε₀ := by
-  rw [epsilon0_eq_nfp]
+theorem iterate_omega0_opow_lt_epsilon_zero (n : ℕ) : (fun a ↦ ω ^ a)^[n] 0 < ε₀ := by
+  rw [epsilon_zero_eq_nfp]
   apply iterate_lt_nfp (isNormal_opow one_lt_omega0).strictMono
   simp
 
+@[deprecated (since := "2026-02-02")]
+alias iterate_omega0_opow_lt_epsilon0 := iterate_omega0_opow_lt_epsilon_zero
+
 theorem omega0_lt_epsilon (o : Ordinal) : ω < ε_ o := by
   apply lt_of_lt_of_le _ <| (veblen_right_strictMono _).monotone (zero_le o)
-  simpa using iterate_omega0_opow_lt_epsilon0 2
+  simpa using iterate_omega0_opow_lt_epsilon_zero 2
 
 theorem natCast_lt_epsilon (n : ℕ) (o : Ordinal) : n < ε_ o :=
   (nat_lt_omega0 n).trans <| omega0_lt_epsilon o
@@ -589,12 +603,13 @@ Of particular importance is `Γ₀ = gamma 0`, the Feferman-Schütte ordinal. -/
 def gamma : Ordinal → Ordinal :=
   deriv (veblen · 0)
 
-@[inherit_doc]
-scoped notation "Γ_ " => gamma
+@[inherit_doc] scoped notation "Γ_ " => gamma
+recommended_spelling "gamma" for "Γ_ " in [gamma, «termΓ_»]
 
 /-- The Feferman-Schütte ordinal `Γ₀` is the smallest fixed point of `veblen · 0`, i.e. the supremum
 of `veblen ε₀ 0`, `veblen (veblen ε₀ 0) 0`, etc. -/
 scoped notation "Γ₀" => Γ_ 0
+recommended_spelling "gamma_zero" for "Γ₀" in [«termΓ₀»]
 
 theorem isNormal_gamma : IsNormal gamma :=
   isNormal_deriv _
@@ -624,32 +639,47 @@ theorem gamma_inj : Γ_ a = Γ_ b ↔ a = b :=
 theorem veblen_gamma_zero (o : Ordinal) : veblen (Γ_ o) 0 = Γ_ o :=
   deriv_fp isNormal_veblen_zero o
 
-theorem gamma0_eq_nfp : Γ₀ = nfp (veblen · 0) 0 :=
+theorem gamma_zero_eq_nfp : Γ₀ = nfp (veblen · 0) 0 :=
   deriv_zero_right _
+
+@[deprecated (since := "2026-02-02")]
+alias gamma0_eq_nfp := gamma_zero_eq_nfp
 
 theorem gamma_succ_eq_nfp (o : Ordinal) : Γ_ (succ o) = nfp (veblen · 0) (succ (Γ_ o)) :=
   deriv_succ _ _
 
-theorem gamma0_le_of_veblen_le (h : veblen o 0 ≤ o) : Γ₀ ≤ o := by
-  rw [gamma0_eq_nfp]
+theorem gamma_zero_le_of_veblen_le (h : veblen o 0 ≤ o) : Γ₀ ≤ o := by
+  rw [gamma_zero_eq_nfp]
   exact nfp_le_fp (veblen_left_monotone 0) (zero_le o) h
 
+@[deprecated (since := "2026-02-02")]
+alias gamma0_le_of_veblen_le := gamma_zero_le_of_veblen_le
+
 /-- `Γ₀` is the limit of `0`, `veblen 0 0`, `veblen (veblen 0 0) 0`, … -/
-theorem lt_gamma0 : o < Γ₀ ↔ ∃ n : ℕ, o < (fun a ↦ veblen a 0)^[n] 0 := by
-  rw [gamma0_eq_nfp, lt_nfp_iff]
+theorem lt_gamma_zero : o < Γ₀ ↔ ∃ n : ℕ, o < (fun a ↦ veblen a 0)^[n] 0 := by
+  rw [gamma_zero_eq_nfp, lt_nfp_iff]
+
+@[deprecated (since := "2026-02-02")]
+alias lt_gamma0 := lt_gamma_zero
 
 /-- `veblen (veblen … (veblen 0 0) … 0) 0 < Γ₀` -/
-theorem iterate_veblen_lt_gamma0 (n : ℕ) : (fun a ↦ veblen a 0)^[n] 0 < Γ₀ := by
-  rw [gamma0_eq_nfp]
+theorem iterate_veblen_lt_gamma_zero (n : ℕ) : (fun a ↦ veblen a 0)^[n] 0 < Γ₀ := by
+  rw [gamma_zero_eq_nfp]
   apply iterate_lt_nfp veblen_zero_strictMono
   simp
 
-theorem epsilon0_lt_gamma (o : Ordinal) : ε₀ < Γ_ o := by
-  apply lt_of_lt_of_le _ <| (gamma_le_gamma.2 (zero_le _))
-  simpa using iterate_veblen_lt_gamma0 2
+@[deprecated (since := "2026-02-02")]
+alias iterate_veblen_lt_gamma0 := iterate_veblen_lt_gamma_zero
+
+theorem epsilon_zero_lt_gamma (o : Ordinal) : ε₀ < Γ_ o := by
+  apply (gamma_le_gamma.2 (zero_le _)).trans_lt'
+  simpa using iterate_veblen_lt_gamma_zero 2
+
+@[deprecated (since := "2026-02-02")]
+alias epsilon0_lt_gamma := epsilon_zero_lt_gamma
 
 theorem omega0_lt_gamma (o : Ordinal) : ω < Γ_ o :=
-  (omega0_lt_epsilon 0).trans (epsilon0_lt_gamma o)
+  (omega0_lt_epsilon 0).trans (epsilon_zero_lt_gamma o)
 
 theorem natCast_lt_gamma (n : ℕ) : n < Γ_ o :=
   (nat_lt_omega0 n).trans (omega0_lt_gamma o)


### PR DESCRIPTION
We also rename theorems from `epsilon0` → `epsilon_zero` and `gamma0` → `gamma_zero`, matching what we previously did with `aleph1` → `aleph_one` in #33198.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
