### PR TITLE
[Merged by Bors] - chore: migrate merge-conflicts workflow to GitHub App

### DIFF
--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -10,9 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MATHLIB_MERGE_CONFLICTS_APP_ID }}
+          private-key: ${{ secrets.MATHLIB_MERGE_CONFLICTS_PRIVATE_KEY }}
       - name: check if prs are dirty
         uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           dirtyLabel: "merge-conflict"
           commentOnDirty: "This pull request has conflicts, please merge `master` and resolve them."
-          repoToken: "${{ secrets.MERGE_CONFLICTS_TOKEN }}"
+          repoToken: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.MATHLIB_MERGE_CONFLICTS_APP_ID }}
           private-key: ${{ secrets.MATHLIB_MERGE_CONFLICTS_PRIVATE_KEY }}

--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -21,4 +21,5 @@ jobs:
         with:
           dirtyLabel: "merge-conflict"
           commentOnDirty: "This pull request has conflicts, please merge `master` and resolve them."
+          # The create-github-app-token README states that this token is masked and will not be logged accidentally.
           repoToken: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This PR migrates the `merge_conflicts.yml` workflow from using a personal access token (`MERGE_CONFLICTS_TOKEN` from `mathlib-merge-conflicts-bot`) to using a GitHub App.


🤖 Prepared with Claude Code