### PR TITLE
[Merged by Bors] - chore: migrate dependent-issues workflow to GitHub App

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -21,10 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.MATHLIB_DEPENDENT_ISSUES_APP_ID }}
+          private-key: ${{ secrets.MATHLIB_DEPENDENT_ISSUES_PRIVATE_KEY }}
+      # The create-github-app-token README states that this token is masked and will not be logged accidentally.
       - uses: z0al/dependent-issues@75d554cd9494b6e1766bc9d08a81c26444ad5c5a
         env:
           # (Required) The token to use to make API calls to GitHub.
-          GITHUB_TOKEN: ${{ secrets.DEPENDENT_ISSUES_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           # (Optional) The label to use to mark dependent issues
           label: blocked-by-other-PR


### PR DESCRIPTION
This PR migrates the `dependent-issues.yml` workflow from using a personal access token (`DEPENDENT_ISSUES_TOKEN` from `mathlib-dependent-issues-bot`) to using a GitHub App.

🤖 Prepared with Claude Code