### PR TITLE
[Merged by Bors] - chore: migrate nightly-testing workflows to GitHub App

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -13,17 +13,25 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4-nightly-testing'
 
     steps:
+    - name: Generate app token
+      id: app-token
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      with:
+        app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}
+        private-key: ${{ secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY }}
+
+    # The create-github-app-token README states that this token is masked and will not be logged accidentally.
     - name: Checkout mathlib4 repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: nightly-testing
         fetch-depth: 0  # Fetch all branches
-        token: ${{ secrets.NIGHTLY_TESTING }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Set up Git
       run: |
-        git config --global user.name "leanprover-community-mathlib4-bot"
-        git config --global user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+        git config --global user.name "mathlib-nightly-testing[bot]"
+        git config --global user.email "mathlib-nightly-testing[bot]@users.noreply.github.com"
 
     - name: Configure Lean
       uses: leanprover/lean-action@c544e89643240c6b398f14a431bcdc6309e36b3e # v1.4.0

--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -13,11 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4-nightly-testing'
     steps:
+    - name: Generate app token
+      id: app-token
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      with:
+        app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}
+        private-key: ${{ secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY }}
+
+    # The create-github-app-token README states that this token is masked and will not be logged accidentally.
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: nightly-testing # checkout nightly-testing branch
-        token: ${{ secrets.NIGHTLY_TESTING }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Get latest release tag from leanprover/lean4-nightly
       id: get-latest-release
@@ -31,8 +39,8 @@ jobs:
 
     - name: Commit and push changes
       run: |
-        git config user.name "leanprover-community-mathlib4-bot"
-        git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+        git config user.name "mathlib-nightly-testing[bot]"
+        git config user.email "mathlib-nightly-testing[bot]@users.noreply.github.com"
         git add lean-toolchain
         # Don't fail if there's nothing to commit
         git commit -m "chore: bump to ${RELEASE_TAG}" || true

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -35,12 +35,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate app token
+      id: app-token
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      with:
+        app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}
+        private-key: ${{ secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY }}
+
+    # The create-github-app-token README states that this token is masked and will not be logged accidentally.
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: nightly-testing # checkout nightly-testing branch
         fetch-depth: 0 # checkout all branches so that we can push from `nightly-testing` to `nightly-testing-YYYY-MM-DD`
-        token: ${{ secrets.NIGHTLY_TESTING }}
+        token: ${{ steps.app-token.outputs.token }}
     - name: Update the nightly-testing-green branch
       continue-on-error: true
       run: |
@@ -313,7 +321,7 @@ jobs:
       with:
         ref: nightly-testing # checkout nightly-testing branch (shouldn't matter which)
         fetch-depth: 0 # checkout all branches
-        token: ${{ secrets.NIGHTLY_TESTING }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Attempt automatic PR creation
       id: auto_pr
@@ -323,7 +331,7 @@ jobs:
         BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
         BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
         SHA: ${{ env.SHA }}
-        GH_TOKEN: ${{ secrets.NIGHTLY_TESTING }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
       run: |
         echo "Current version: ${NIGHTLY}"

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -12,13 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.MATHLIB_NIGHTLY_TESTING_APP_ID }}
+          private-key: ${{ secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY }}
+          repositories: mathlib4,mathlib4-nightly-testing
+
+      # The create-github-app-token README states that this token is masked and will not be logged accidentally.
       - name: Checkout nightly-testing from fork
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib4-nightly-testing
           ref: nightly-testing
           path: nightly-testing
-          token: ${{ secrets.NIGHTLY_TESTING }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Configure Lean
@@ -32,8 +41,8 @@ jobs:
       - name: Configure Git User
         run: |
           cd nightly-testing
-          git config user.name "leanprover-community-mathlib4-bot"
-          git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+          git config user.name "mathlib-nightly-testing[bot]"
+          git config user.email "mathlib-nightly-testing[bot]@users.noreply.github.com"
 
       - name: Merge master to nightly favoring nightly changes
         run: |


### PR DESCRIPTION
This PR migrates the nightly-testing workflows from using a personal access token (`NIGHTLY_TESTING` from `leanprover-community-mathlib4-bot`) to using a GitHub App.

Affects: `nightly_merge_master.yml`, `nightly_bump_toolchain.yml`, `discover-lean-pr-testing.yml`, `nightly_detect_failure.yml`

**Note:** The app must be installed on both `mathlib4` AND `mathlib4-nightly-testing`, and secrets must be added to both repos.

🤖 Prepared with Claude Code