### PR TITLE
[Merged by Bors] - chore(Topology/MetricSpace/MetricSeparated): doctrings

### DIFF
--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -14,8 +14,8 @@ public import Mathlib.Topology.EMetricSpace.Defs
 This file defines a few notions of separations of sets in a metric space.
 
 
-The first notion (`Metric.IsSeparated`) is quantitative and about a single set: A set `s` is
-`ε`-separated if its elements are pairwise at distance at least `ε` from each other.
+The first notion (`Metric.IsSeparated`) is quantitative and describes a single set: a set `s` is
+`ε`-separated if the distance between any two distinct elements is strictly greater than `ε`
 
 The second notion (`Metric.AreSeparated`) is qualitative and about two sets: Two sets `s` and `t`
 are separated if the distance between `x ∈ s` and `y ∈ t` is bounded from below by a positive
@@ -38,8 +38,8 @@ variable {X : Type*} [PseudoEMetricSpace X] {s t : Set X} {ε δ : ℝ≥0∞} {
 In this section we define the predicate `Metric.IsSeparated` for `ε`-separated sets.
 -/
 
-/-- A set `s` is `ε`-separated if its elements are pairwise at distance at least `ε` from each
-other. -/
+/-- A set `s` is `ε`-separated if the extended distance between any two distinct
+elements is strictly greater than `ε`. -/
 def IsSeparated (ε : ℝ≥0∞) (s : Set X) : Prop := s.Pairwise (ε < edist · ·)
 
 lemma isSeparated_iff_setRelIsSeparated :


### PR DESCRIPTION
Adapt the meaning of the docstring to the code ("strictly greater" versus "at least")

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
