### PR TITLE
[Merged by Bors] - feat(QuotientGroup): add `QuotientGroup.liftEquiv`

### DIFF
--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -428,10 +428,8 @@ instance of_fixedField_normal_subgroup [IsGalois K L]
 noncomputable def normalAutEquivQuotient [FiniteDimensional K L] [IsGalois K L]
     (H : Subgroup Gal(L/K)) [Subgroup.Normal H] :
     Gal(L/K) ⧸ H ≃* Gal(fixedField H/K) :=
-  (QuotientGroup.quotientMulEquivOfEq ((fixingSubgroup_fixedField H).symm.trans
-  (fixedField H).restrictNormalHom_ker.symm)).trans <|
-  QuotientGroup.quotientKerEquivOfSurjective (restrictNormalHom (fixedField H)) <|
-  restrictNormalHom_surjective L
+  QuotientGroup.liftEquiv _ (restrictNormalHom_surjective L) <|
+    (fixingSubgroup_fixedField H).symm.trans (fixedField H).restrictNormalHom_ker.symm
 
 lemma normalAutEquivQuotient_apply [FiniteDimensional K L] [IsGalois K L]
     (H : Subgroup Gal(L/K)) [Subgroup.Normal H] (σ : Gal(L/K)) :

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -226,9 +226,8 @@ then `Gal(fixedField H / k)` is isomorphic to `Gal(K / k) ⧸ H`. -/
 noncomputable def normalAutEquivQuotient [IsGalois k K]
     (H : ClosedSubgroup Gal(K/k)) [H.Normal] :
     Gal(K/k) ⧸ H.1 ≃* Gal(fixedField H.1/k) :=
-  (QuotientGroup.quotientMulEquivOfEq ((fixingSubgroup_fixedField H).symm.trans
-    (fixedField H.1).restrictNormalHom_ker.symm)).trans <|
-      QuotientGroup.quotientKerEquivOfSurjective _ <| restrictNormalHom_surjective K
+  QuotientGroup.liftEquiv _ (restrictNormalHom_surjective K)
+    ((fixingSubgroup_fixedField H).symm.trans (fixedField H.1).restrictNormalHom_ker.symm)
 
 open IntermediateField in
 lemma normalAutEquivQuotient_apply [IsGalois k K]

--- a/Mathlib/GroupTheory/GroupExtension/Basic.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Basic.lean
@@ -34,8 +34,7 @@ noncomputable def quotientKerRightHomEquivRight : E ⧸ S.rightHom.ker ≃* G :=
 /-- The isomorphism `E ⧸ S.inl.range ≃* G` induced by `S.rightHom` -/
 @[to_additive /-- The isomorphism `E ⧸ S.inl.range ≃+ G` induced by `S.rightHom` -/]
 noncomputable def quotientRangeInlEquivRight : E ⧸ S.inl.range ≃* G :=
-  (QuotientGroup.quotientMulEquivOfEq S.range_inl_eq_ker_rightHom).trans
-    S.quotientKerRightHomEquivRight
+  QuotientGroup.liftEquiv _ S.rightHom_surjective S.range_inl_eq_ker_rightHom
 
 /-- An arbitrarily chosen section -/
 @[to_additive surjInvRightHom /-- An arbitrarily chosen section -/]

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -246,7 +246,7 @@ lemma con_mono {N M : Subgroup G} [hN : N.Normal] [hM : M.Normal] (h : N ≤ M) 
 /-- A group homomorphism `φ : G →* M` with `N ⊆ ker(φ)` descends (i.e. `lift`s) to a
 group homomorphism `G/N →* M`. -/
 @[to_additive /-- An `AddGroup` homomorphism `φ : G →+ M` with `N ⊆ ker(φ)` descends (i.e. `lift`s)
-to a group homomorphism `G/N →* M`. -/]
+to an `AddGroup` homomorphism `G/N →+ M`. -/]
 def lift (φ : G →* M) (HN : N ≤ φ.ker) : Q →* M :=
   (QuotientGroup.con N).lift φ <| con_ker_eq_conKer φ ▸ con_mono HN
 
@@ -273,6 +273,25 @@ theorem lift_quot_mk {φ : G →* M} (HN : N ≤ φ.ker) (g : G) :
 theorem lift_surjective_of_surjective (φ : G →* M) (hφ : Function.Surjective φ) (HN : N ≤ φ.ker) :
     Function.Surjective (QuotientGroup.lift N φ HN) :=
   Quotient.lift_surjective _ _ hφ
+
+/-- A surjective group homomorphism `φ : G →* H` with `N = ker(φ)` descends (i.e. `lift`s) to a
+group isomorphism `G/N ≃* H`. -/
+@[to_additive /-- A surjecitve `AddGroup` homomorphism `φ : G →+ H` with `N = ker(φ)` descends
+(i.e. `lift`s) to an `AddGroup` isomorphism `G/N ≃+ H`. -/]
+noncomputable def liftEquiv {φ : G →* H} (hφ : Function.Surjective φ)
+    (HN : N = φ.ker) : G ⧸ N ≃* H :=
+  MulEquiv.ofBijective (QuotientGroup.lift N φ HN.le)
+    ⟨fun x y ↦ Quotient.inductionOn₂' x y fun a b (h : φ a = φ b) ↦ Quotient.sound' <|
+      by rw [leftRel_apply, HN, MonoidHom.mem_ker, φ.map_mul, ← h, φ.map_inv, inv_mul_cancel],
+    lift_surjective_of_surjective N φ hφ HN.le⟩
+
+@[to_additive (attr := simp)]
+theorem liftEquiv_mk {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
+    liftEquiv N hφ HN (g : Q) = φ g := rfl
+
+@[to_additive (attr := simp)]
+theorem liftEquiv_mk' {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
+    liftEquiv N hφ HN (mk g : Q) = φ g := rfl
 
 @[to_additive]
 theorem ker_lift (φ : G →* M) (HN : N ≤ φ.ker) :

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -291,11 +291,11 @@ noncomputable def liftEquiv {φ : G →* H} (hφ : Function.Surjective φ)
       lift_surjective_of_surjective N φ hφ HN.le⟩
 
 @[to_additive (attr := simp)]
-theorem liftEquiv_mk {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
+theorem liftEquiv_coe {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
     liftEquiv N hφ HN (g : Q) = φ g := rfl
 
 @[to_additive (attr := simp)]
-theorem liftEquiv_mk' {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
+theorem liftEquiv_mk {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
     liftEquiv N hφ HN (mk g : Q) = φ g := rfl
 
 /-- A group homomorphism `f : G →* H` induces a map `G/N →* H/M` if `N ⊆ f⁻¹(M)`. -/

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -274,6 +274,12 @@ theorem lift_surjective_of_surjective (φ : G →* M) (hφ : Function.Surjective
     Function.Surjective (QuotientGroup.lift N φ HN) :=
   Quotient.lift_surjective _ _ hφ
 
+@[to_additive]
+theorem ker_lift (φ : G →* M) (HN : N ≤ φ.ker) :
+    (QuotientGroup.lift N φ HN).ker = Subgroup.map (QuotientGroup.mk' N) φ.ker := by
+  rw [← congrArg MonoidHom.ker (lift_comp_mk' N φ HN), ← MonoidHom.comap_ker,
+    Subgroup.map_comap_eq_self_of_surjective (mk'_surjective N)]
+
 /-- A surjective group homomorphism `φ : G →* H` with `N = ker(φ)` descends (i.e. `lift`s) to a
 group isomorphism `G/N ≃* H`. -/
 @[to_additive /-- A surjective `AddGroup` homomorphism `φ : G →+ H` with `N = ker(φ)` descends
@@ -281,9 +287,8 @@ group isomorphism `G/N ≃* H`. -/
 noncomputable def liftEquiv {φ : G →* H} (hφ : Function.Surjective φ)
     (HN : N = φ.ker) : G ⧸ N ≃* H :=
   MulEquiv.ofBijective (QuotientGroup.lift N φ HN.le)
-    ⟨fun x y ↦ Quotient.inductionOn₂' x y fun a b (h : φ a = φ b) ↦ Quotient.sound' <|
-      by rw [leftRel_apply, HN, MonoidHom.mem_ker, φ.map_mul, ← h, φ.map_inv, inv_mul_cancel],
-    lift_surjective_of_surjective N φ hφ HN.le⟩
+    ⟨by rw [← MonoidHom.ker_eq_bot_iff, ker_lift, ← HN, QuotientGroup.map_mk'_self],
+      lift_surjective_of_surjective N φ hφ HN.le⟩
 
 @[to_additive (attr := simp)]
 theorem liftEquiv_mk {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
@@ -292,12 +297,6 @@ theorem liftEquiv_mk {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ
 @[to_additive (attr := simp)]
 theorem liftEquiv_mk' {φ : G →* H} (hφ : Function.Surjective φ) (HN : N = φ.ker) (g : G) :
     liftEquiv N hφ HN (mk g : Q) = φ g := rfl
-
-@[to_additive]
-theorem ker_lift (φ : G →* M) (HN : N ≤ φ.ker) :
-    (QuotientGroup.lift N φ HN).ker = Subgroup.map (QuotientGroup.mk' N) φ.ker := by
-  rw [← congrArg MonoidHom.ker (lift_comp_mk' N φ HN), ← MonoidHom.comap_ker,
-    Subgroup.map_comap_eq_self_of_surjective (mk'_surjective N)]
 
 /-- A group homomorphism `f : G →* H` induces a map `G/N →* H/M` if `N ⊆ f⁻¹(M)`. -/
 @[to_additive

--- a/Mathlib/GroupTheory/QuotientGroup/Defs.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Defs.lean
@@ -276,7 +276,7 @@ theorem lift_surjective_of_surjective (φ : G →* M) (hφ : Function.Surjective
 
 /-- A surjective group homomorphism `φ : G →* H` with `N = ker(φ)` descends (i.e. `lift`s) to a
 group isomorphism `G/N ≃* H`. -/
-@[to_additive /-- A surjecitve `AddGroup` homomorphism `φ : G →+ H` with `N = ker(φ)` descends
+@[to_additive /-- A surjective `AddGroup` homomorphism `φ : G →+ H` with `N = ker(φ)` descends
 (i.e. `lift`s) to an `AddGroup` isomorphism `G/N ≃+ H`. -/]
 noncomputable def liftEquiv {φ : G →* H} (hφ : Function.Surjective φ)
     (HN : N = φ.ker) : G ⧸ N ≃* H :=

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -785,14 +785,13 @@ noncomputable def zmodAddCyclicAddEquiv [AddGroup G] (h : IsAddCyclic G) :
     ZMod (Nat.card G) ≃+ G := by
   let n := Nat.card G
   let ⟨g, surj⟩ := Classical.indefiniteDescription _ h.exists_generator
-  have kereq : ((zmultiplesHom G) g).ker = zmultiples ↑(Nat.card G) := by
+  have kereq : zmultiples ↑(Nat.card G) = ((zmultiplesHom G) g).ker := by
     rw [zmultiplesHom_ker_eq]
     congr
     rw [← Nat.card_zmultiples]
-    exact Nat.card_congr (Equiv.subtypeUnivEquiv surj)
-  exact Int.quotientZMultiplesNatEquivZMod n
-    |>.symm.trans <| QuotientAddGroup.quotientAddEquivOfEq kereq
-    |>.symm.trans <| QuotientAddGroup.quotientKerEquivOfSurjective (zmultiplesHom G g) surj
+    exact Nat.card_congr (Equiv.subtypeUnivEquiv surj).symm
+  exact Int.quotientZMultiplesNatEquivZMod n |>.symm.trans <|
+    QuotientAddGroup.liftEquiv _ (φ := zmultiplesHom G g) surj kereq
 
 /-- A commutative simple group is isomorphic to `ZMod p` from some prime `p`. -/
 theorem exists_prime_addEquiv_ZMod [CommGroup G] [IsSimpleGroup G] :

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -706,8 +706,8 @@ theorem surjective_unitGroupToResidueFieldUnits :
 the units of the residue field of `A`. -/
 def unitsModPrincipalUnitsEquivResidueFieldUnits :
     A.unitGroup ⧸ A.principalUnitGroup.comap A.unitGroup.subtype ≃* (IsLocalRing.ResidueField A)ˣ :=
-  (QuotientGroup.quotientMulEquivOfEq A.ker_unitGroupToResidueFieldUnits.symm).trans
-    (QuotientGroup.quotientKerEquivOfSurjective _ A.surjective_unitGroupToResidueFieldUnits)
+  QuotientGroup.liftEquiv _ A.surjective_unitGroupToResidueFieldUnits
+    A.ker_unitGroupToResidueFieldUnits.symm
 
 theorem unitsModPrincipalUnitsEquivResidueFieldUnits_comp_quotientGroup_mk :
     (A.unitsModPrincipalUnitsEquivResidueFieldUnits : _ ⧸ Subgroup.comap _ _ →* _).comp


### PR DESCRIPTION
Construct a group isomorphism `G/N ≃* H` from a surjective group homomorphism `φ : G →* H` with `N = ker(φ)`.

Golf some proofs using the new construction and also fix a typo in the docstring of `QuotientGroup.lift`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
