### PR TITLE
[Merged by Bors] - chore: use `NameMapExtension.find?` API

### DIFF
--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -809,7 +809,7 @@ def getRawProjections (stx : Syntax) (str : Name) (traceIfExists : Bool := false
     CoreM (List Name × Array ProjectionData) := do
   withOptions (fun o => if trc then o.set `trace.simps.verbose true else o) do
   let env ← getEnv
-  if let some data := (structureExt.getState env).find? str then
+  if let some data := structureExt.find? env str then
     -- We always print the projections when they already exists and are called by
     -- `initialize_simps_projections`.
     withOptions (fun o => if traceIfExists then o.set `trace.simps.verbose true else o) do

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -194,7 +194,7 @@ attribute [inherit_doc GuessName.GuessNameData] TranslateData.guessNameData
 
 /-- Get the translation for the given name. -/
 def findTranslation? (env : Environment) (t : TranslateData) : Name → Option TranslationInfo :=
-  (t.translations.getState env).find?
+  t.translations.find? env
 
 /-- Get the translation name for the given name. -/
 def findTranslationName? (env : Environment) (t : TranslateData) (n : Name) : Option Name :=
@@ -240,7 +240,7 @@ def insertTranslation (t : TranslateData) (src tgt : Name) (reorder : Reorder)
 where
   /-- Insert only one direction of a translation. -/
   insertTranslationAux (src : Name) (t : TranslateData) (info : TranslationInfo) : CoreM Unit := do
-    if let some info' := (t.translations.getState (← getEnv)).find? src then
+    if let some info' := t.translations.find? (← getEnv) src then
       -- After `insert_to_additive_translation`, we may end up adding same translation again.
       -- So in that case, don't log a warning.
       if info.translation != info'.translation then

--- a/MathlibTest/Simps.lean
+++ b/MathlibTest/Simps.lean
@@ -29,7 +29,7 @@ initialize_simps_projections Foo1 (Projone → toNat, two → toBool, three → 
 
 run_cmd liftTermElabM do
   let env ← getEnv
-  let state := ((Simps.structureExt.getState env).find? `Foo1).get!
+  let state := (Simps.structureExt.find? env `Foo1).get!
   guard <| state.1 == []
   guard <| state.2.map (·.1) == #[`toNat, `toBool, `coe, `four, `five]
   liftMetaM <| guard (← isDefEq (state.2[0]!.2) (← elabTerm (← `(Foo1.Projone)) none))
@@ -60,7 +60,7 @@ initialize_simps_projections Foo2
 def Foo2.foo2 : Foo2 Nat := ⟨(0, 0)⟩
 
 -- run_cmd do
---   logInfo m!"{Simps.structureExt.getState (← getEnv) |>.find? `Foo2 |>.get!}"
+--   logInfo m!"{Simps.structureExt.find? (← getEnv) `Foo2 |>.get!}"
 
 structure Left (α : Type _) extends Foo2 α where
   moreData1 : Nat
@@ -75,7 +75,7 @@ initialize_simps_projections Right (elim → newProjection, -otherData, +toFoo2)
 
 run_cmd liftTermElabM do
   let env ← getEnv
-  let state := ((Simps.structureExt.getState env).find? `Right).get!
+  let state := (Simps.structureExt.find? env `Right).get!
   -- logInfo m!"{state}"
   guard <| state.1 == [`u, `v]
   guard <| state.2.map (·.1) == #[`toFoo2, `otherData, `newProjection]


### PR DESCRIPTION
This PR prepares a refactor of `NameMapExtension` by not relying on its definition.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
