### PR TITLE
[Merged by Bors] - fix: rename `uniformlyContinuous` -> `uniformContinuous` in lemma names

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -147,8 +147,11 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
-lemma uniformlyContinuous_re : UniformContinuous re :=
+lemma uniformContinuous_re : UniformContinuous re :=
   reCLM.uniformContinuous
+
+@[deprecated (since := "2026-02-03")] alias uniformlyContinuous_re :=
+  uniformContinuous_re
 
 @[simp]
 theorem reCLM_coe : (reCLM : ℂ →ₗ[ℝ] ℝ) = reLm :=
@@ -166,8 +169,11 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
-lemma uniformlyContinuous_im : UniformContinuous im :=
+lemma uniformContinuous_im : UniformContinuous im :=
   imCLM.uniformContinuous
+
+@[deprecated (since := "2026-02-03")] alias uniformlyContinuous_im :=
+  uniformContinuous_im
 
 @[simp]
 theorem imCLM_coe : (imCLM : ℂ →ₗ[ℝ] ℝ) = imLm :=

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -186,21 +186,21 @@ variable {α ι : Type*}
 protected lemma TendstoUniformlyOn.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).re) (fun y => (g y).re) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinuous_re hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformContinuous_re hf
 
 protected lemma TendstoUniformly.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).re) (fun y => (g y).re) p := by
-  apply UniformContinuous.comp_tendstoUniformly uniformlyContinuous_re hf
+  apply UniformContinuous.comp_tendstoUniformly uniformContinuous_re hf
 
 protected lemma TendstoUniformlyOn.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).im) (fun y => (g y).im) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinuous_im hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformContinuous_im hf
 
 protected lemma TendstoUniformly.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).im) (fun y => (g y).im) p := by
-  apply UniformContinuous.comp_tendstoUniformly uniformlyContinuous_im hf
+  apply UniformContinuous.comp_tendstoUniformly uniformContinuous_im hf
 
 end continuity

--- a/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
@@ -34,7 +34,7 @@ We use the filter version to prove that absolutely continuous functions are clos
 * multiplication - `AbsolutelyContinuousOnInterval.smul`,
 `AbsolutelyContinuousOnInterval.mul`;
 and that absolutely continuous implies uniformly continuous in
-`AbsolutelyContinuousOnInterval.uniformlyContinuousOn`
+`AbsolutelyContinuousOnInterval.uniformContinuousOn`
 
 We use the `ε`-`δ` definition to prove that
 * Lipschitz continuous functions are absolutely continuous -
@@ -225,7 +225,7 @@ lemma uniformity_eq_comap_totalLengthFilter :
 
 /-- If `f` is absolutely continuous on `uIcc a b`, then `f` is uniformly continuous on `uIcc a b`.
 -/
-theorem uniformlyContinuousOn (hf : AbsolutelyContinuousOnInterval f a b) :
+theorem uniformContinuousOn (hf : AbsolutelyContinuousOnInterval f a b) :
     UniformContinuousOn f (uIcc a b) := by
   simp only [UniformContinuousOn, Filter.tendsto_iff_comap, uniformity_eq_comap_totalLengthFilter]
   simp only [AbsolutelyContinuousOnInterval, Filter.tendsto_iff_comap] at hf
@@ -238,10 +238,13 @@ theorem uniformlyContinuousOn (hf : AbsolutelyContinuousOnInterval f a b) :
     simp
   · simp [totalLengthFilter, comap_comap, Function.comp_def]
 
+@[deprecated (since := "2026-02-03")] alias uniformlyContinuousOn :=
+  uniformContinuousOn
+
 /-- If `f` is absolutely continuous on `uIcc a b`, then `f` is continuous on `uIcc a b`. -/
 theorem continuousOn (hf : AbsolutelyContinuousOnInterval f a b) :
     ContinuousOn f (uIcc a b) :=
-  hf.uniformlyContinuousOn.continuousOn
+  hf.uniformContinuousOn.continuousOn
 
 /-- If `f` is absolutely continuous on `uIcc a b`, then `f` is bounded on `uIcc a b`. -/
 theorem exists_bound (hf : AbsolutelyContinuousOnInterval f a b) :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
