### PR TITLE
[Merged by Bors] - feat(Combinatorics/SetFamily/Intersecting): L-intersecting families

### DIFF
--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -20,6 +20,8 @@ This file defines intersecting families and proves their basic properties.
 * `Set.Intersecting.card_le`: An intersecting family can only take up to half the elements, because
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
+* `Set.IsIntersectingWith`: Predicate stating that a family of finsets is `ℓ`-intersecting, i.e.,
+  every pair of members intersects in at least `ℓ` elements.
 
 ## References
 
@@ -188,5 +190,63 @@ theorem Intersecting.exists_card_eq (hs : (s : Set α).Intersecting) :
   refine (ih ?_ (_root_.ssubset_iff_subset_ne.2 hst) ht).imp fun u => And.imp_left hst.1.trans
   rw [Nat.le_div_iff_mul_le Nat.two_pos, Nat.mul_comm]
   exact ht.card_le
+
+/-!
+### `ℓ`-intersecting families
+
+This section defines `ℓ`-intersecting families and establishes their basic properties.
+-/
+
+variable {ℓ : ℕ}
+variable {α : Type*} [DecidableEq α]
+variable {𝒜 ℬ : Set (Finset α)}
+
+/--
+A family `𝒜` of finite subsets of `α` is `ℓ`-intersecting if every pair of members
+intersects in at least `ℓ` elements.
+
+That is, for all `s, t ∈ 𝒜`, we have `ℓ ≤ |s ∩ t|`.
+-/
+def IsIntersectingWith (ℓ : ℕ) (𝒜 : Set (Finset α)) : Prop :=
+  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → ℓ ≤ (s ∩ t).card
+
+namespace IsIntersectingWith
+
+/--
+An `ℓ`-intersecting family remains `ℓ`-intersecting under restriction to any subfamily.
+-/
+@[gcongr]
+theorem mono (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingWith ℓ 𝒜) : IsIntersectingWith ℓ ℬ := by
+  grind [IsIntersectingWith]
+
+/--
+Every family of finite sets is `0`-intersecting.
+-/
+theorem zero : IsIntersectingWith 0 𝒜 := by
+  simp [IsIntersectingWith]
+
+/--
+The empty family of finite sets is `ℓ`-intersecting, vacuously, because it contains no pairs of
+sets.
+-/
+theorem empty : IsIntersectingWith ℓ (∅ : Set (Finset α)) := by
+  simp [IsIntersectingWith]
+
+/--
+Every member of an `ℓ`-intersecting family has cardinality at least `ℓ`.
+-/
+theorem card_le (h𝒜 : IsIntersectingWith ℓ 𝒜) : ∀ s ∈ 𝒜, ℓ ≤ s.card := by
+  grind [IsIntersectingWith]
+
+/--
+If `ℓ ≠ 0`, an `ℓ`-intersecting family is intersecting in the usual sense, meaning that every pair
+of members has a nonempty intersection.
+-/
+theorem intersecting (hℓ : ℓ ≠ 0) (h𝒜 : IsIntersectingWith ℓ 𝒜) : Intersecting 𝒜 := by
+  intro a ha b hb
+  have : ℓ ≤ (a ∩ b).card := h𝒜 ha hb
+  grind [Finset.disjoint_iff_inter_eq_empty]
+
+end IsIntersectingWith
 
 end Set

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -21,7 +21,7 @@ This file defines intersecting families and proves their basic properties.
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
 * `Set.IsIntersectingOf`: Predicate stating that a family `𝒜` of finsets is `L`-intersecting, i.e.,
-  meaning that for all `s, t ∈ 𝒜`, `(s ∩ t).card ∈ L`.
+  meaning that for all `s, t ∈ 𝒜`, `#(s ∩ t) ∈ L`.
 
 ## References
 
@@ -34,11 +34,11 @@ assert_not_exists Monoid
 
 open Finset
 
-variable {α : Type*}
-
 namespace Set
 
 section SemilatticeInf
+
+variable {α : Type*}
 
 variable [SemilatticeInf α] [OrderBot α] {s t : Set α} {a b c : α}
 
@@ -124,6 +124,10 @@ theorem Intersecting.isUpperSet' {s : Finset α} (hs : (s : Set α).Intersecting
 
 end SemilatticeInf
 
+section
+
+variable {α : Type*}
+
 theorem Intersecting.exists_mem_set {𝒜 : Set (Set α)} (h𝒜 : 𝒜.Intersecting) {s t : Set α}
     (hs : s ∈ 𝒜) (ht : t ∈ 𝒜) : ∃ a, a ∈ s ∧ a ∈ t :=
   not_disjoint_iff.1 <| h𝒜 hs ht
@@ -191,6 +195,8 @@ theorem Intersecting.exists_card_eq (hs : (s : Set α).Intersecting) :
   rw [Nat.le_div_iff_mul_le Nat.two_pos, Nat.mul_comm]
   exact ht.card_le
 
+end
+
 /-!
 ### `L`-intersecting families
 
@@ -208,7 +214,7 @@ members of `𝒜` belong to `L ⊆ ℕ`.
 That is, for all `s, t ∈ 𝒜`, we have `|(s ∩ t)| ∈ L`.
 -/
 def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop :=
-  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → (s ∩ t).card ∈ L
+  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → #(s ∩ t) ∈ L
 
 namespace IsIntersectingOf
 
@@ -242,7 +248,7 @@ protected theorem univ : IsIntersectingOf univ 𝒜 := by simp [IsIntersectingOf
 /--
 Every member of an `L`-intersecting family has cardinality in `L`.
 -/
-theorem card_mem (h𝒜 : IsIntersectingOf L 𝒜) : ∀ s ∈ 𝒜, s.card ∈ L := by grind [IsIntersectingOf]
+theorem card_mem (h𝒜 : IsIntersectingOf L 𝒜) : ∀ s ∈ 𝒜, #s ∈ L := by grind [IsIntersectingOf]
 
 /--
 If `0 ∉ L`, then any `L`-intersecting family is intersecting in the usual sense: every pair of

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -20,8 +20,8 @@ This file defines intersecting families and proves their basic properties.
 * `Set.Intersecting.card_le`: An intersecting family can only take up to half the elements, because
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
-* `Set.IsIntersectingWith`: Predicate stating that a family of finsets is `ℓ`-intersecting, i.e.,
-  every pair of members intersects in at least `ℓ` elements.
+* `Set.IsIntersectingOf`: Predicate stating that a family `𝒜` of finsets is `L`-intersecting, i.e.,
+  meaning that for all `s, t ∈ 𝒜`, `(s ∩ t).card ∈ L`.
 
 ## References
 
@@ -192,61 +192,74 @@ theorem Intersecting.exists_card_eq (hs : (s : Set α).Intersecting) :
   exact ht.card_le
 
 /-!
-### `ℓ`-intersecting families
+### `L`-intersecting families
 
-This section defines `ℓ`-intersecting families and establishes their basic properties.
+This section defines `L`-intersecting families and establishes their basic properties.
 -/
 
-variable {ℓ : ℕ}
+variable {L L' : Set ℕ}
 variable {α : Type*} [DecidableEq α]
 variable {𝒜 ℬ : Set (Finset α)}
 
 /--
-A family `𝒜` of finite subsets of `α` is `ℓ`-intersecting if every pair of members
-intersects in at least `ℓ` elements.
+A family `𝒜` of finite subsets of `α` is `L`-intersecting if all pairwise intersection sizes of
+members of `𝒜` belong to `L ⊆ ℕ`.
 
-That is, for all `s, t ∈ 𝒜`, we have `ℓ ≤ |s ∩ t|`.
+That is, for all `s, t ∈ 𝒜`, we have `|(s ∩ t)| ∈ L`.
 -/
-def IsIntersectingWith (ℓ : ℕ) (𝒜 : Set (Finset α)) : Prop :=
-  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → ℓ ≤ (s ∩ t).card
+def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop :=
+  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → (s ∩ t).card ∈ L
 
-namespace IsIntersectingWith
+namespace IsIntersectingOf
 
 /--
-An `ℓ`-intersecting family remains `ℓ`-intersecting under restriction to any subfamily.
+An `L`-intersecting family is also `L'`-intersecting whenever `L ⊆ L'`.
 -/
 @[gcongr]
-theorem mono (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingWith ℓ 𝒜) : IsIntersectingWith ℓ ℬ := by
-  grind [IsIntersectingWith]
+theorem mono (h : L ⊆ L') (hL : IsIntersectingOf L 𝒜) : IsIntersectingOf L' 𝒜 := by
+  grind [IsIntersectingOf]
 
 /--
-Every family of finite sets is `0`-intersecting.
+An `L`-intersecting family remains `L`-intersecting under restriction to any subfamily.
 -/
-theorem zero : IsIntersectingWith 0 𝒜 := by
-  simp [IsIntersectingWith]
+@[gcongr]
+theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ := by
+  grind [IsIntersectingOf]
 
 /--
-The empty family of finite sets is `ℓ`-intersecting, vacuously, because it contains no pairs of
+The empty family of finite sets is `L`-intersecting, vacuously, because it contains no pairs of
 sets.
 -/
-theorem empty : IsIntersectingWith ℓ (∅ : Set (Finset α)) := by
-  simp [IsIntersectingWith]
+@[simp]
+protected theorem empty : IsIntersectingOf L (∅ : Set (Finset α)) := by simp [IsIntersectingOf]
 
 /--
-Every member of an `ℓ`-intersecting family has cardinality at least `ℓ`.
+Every family of finite sets is `univ`-intersecting.
 -/
-theorem card_le (h𝒜 : IsIntersectingWith ℓ 𝒜) : ∀ s ∈ 𝒜, ℓ ≤ s.card := by
-  grind [IsIntersectingWith]
+@[simp]
+protected theorem univ : IsIntersectingOf univ 𝒜 := by simp [IsIntersectingOf]
 
 /--
-If `ℓ ≠ 0`, an `ℓ`-intersecting family is intersecting in the usual sense, meaning that every pair
-of members has a nonempty intersection.
+Every member of an `L`-intersecting family has cardinality in `L`.
 -/
-theorem intersecting (hℓ : ℓ ≠ 0) (h𝒜 : IsIntersectingWith ℓ 𝒜) : Intersecting 𝒜 := by
-  intro a ha b hb
-  have : ℓ ≤ (a ∩ b).card := h𝒜 ha hb
-  grind [Finset.disjoint_iff_inter_eq_empty]
+theorem card_mem (h𝒜 : IsIntersectingOf L 𝒜) : ∀ s ∈ 𝒜, s.card ∈ L := by grind [IsIntersectingOf]
 
-end IsIntersectingWith
+/--
+If `0 ∉ L`, then any `L`-intersecting family is intersecting in the usual sense: every pair of
+members has a nonempty intersection.
+-/
+theorem intersecting (hL : 0 ∉ L) (h𝒜 : IsIntersectingOf L 𝒜) : Intersecting 𝒜 := by
+  intro s hs t ht
+  grind [h𝒜 hs ht, card_inter, card_union_eq_card_add_card]
+
+/--
+A family `𝒜` of finite subsets of `α` is `{0}ᶜ`-intersecting if and only if it is intersecting in in
+the usual sense.
+-/
+@[simp]
+theorem isIntersectingOf_singleton_compl : IsIntersectingOf {0}ᶜ 𝒜 ↔ Intersecting 𝒜 := by
+  simp [IsIntersectingOf, Intersecting, disjoint_iff]
+
+end IsIntersectingOf
 
 end Set

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -21,7 +21,7 @@ This file defines intersecting families and proves their basic properties.
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
 * `Set.IsIntersectingOf`: Predicate stating that a family `𝒜` of finsets is `L`-intersecting, i.e.,
-  meaning that for all `s, t ∈ 𝒜`, `#(s ∩ t) ∈ L`.
+  meaning the intersection size of every pair of distinct members of `𝒜` belongs to `L ⊆ ℕ`.
 
 ## References
 
@@ -208,13 +208,12 @@ variable {α : Type*} [DecidableEq α]
 variable {𝒜 ℬ : Set (Finset α)}
 
 /--
-A family `𝒜` of finite subsets of `α` is `L`-intersecting if all pairwise intersection sizes of
-members of `𝒜` belong to `L ⊆ ℕ`.
+A family `𝒜` of finite subsets of `α` is `L`-intersecting if the intersection size of every pair of
+distinct members of `𝒜` belongs to `L ⊆ ℕ`.
 
-That is, for all `s, t ∈ 𝒜`, we have `|(s ∩ t)| ∈ L`.
+That is, for all `s, t ∈ 𝒜` with `s ≠ t`, we have `|(s ∩ t)| ∈ L`.
 -/
-def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop :=
-  ∀ ⦃s⦄, s ∈ 𝒜 → ∀ ⦃t⦄, t ∈ 𝒜 → #(s ∩ t) ∈ L
+def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop := 𝒜.Pairwise fun s t ↦ #(s ∩ t) ∈ L
 
 namespace IsIntersectingOf
 
@@ -222,49 +221,26 @@ namespace IsIntersectingOf
 An `L`-intersecting family is also `L'`-intersecting whenever `L ⊆ L'`.
 -/
 @[gcongr]
-theorem mono (h : L ⊆ L') (hL : IsIntersectingOf L 𝒜) : IsIntersectingOf L' 𝒜 := by
-  grind [IsIntersectingOf]
+theorem mono (h : L ⊆ L') (hL : IsIntersectingOf L 𝒜) : IsIntersectingOf L' 𝒜 := by tauto
 
 /--
 An `L`-intersecting family remains `L`-intersecting under restriction to any subfamily.
 -/
 @[gcongr]
-theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ := by
-  grind [IsIntersectingOf]
+theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ := Pairwise.mono h h𝒜
 
 /--
 The empty family of finite sets is `L`-intersecting, vacuously, because it contains no pairs of
 sets.
 -/
 @[simp]
-protected theorem empty : IsIntersectingOf L (∅ : Set (Finset α)) := by simp [IsIntersectingOf]
+protected theorem empty : IsIntersectingOf L (∅ : Set (Finset α)) := by tauto
 
 /--
 Every family of finite sets is `univ`-intersecting.
 -/
 @[simp]
-protected theorem univ : IsIntersectingOf univ 𝒜 := by simp [IsIntersectingOf]
-
-/--
-Every member of an `L`-intersecting family has cardinality in `L`.
--/
-theorem card_mem (h𝒜 : IsIntersectingOf L 𝒜) : ∀ s ∈ 𝒜, #s ∈ L := by grind [IsIntersectingOf]
-
-/--
-If `0 ∉ L`, then any `L`-intersecting family is intersecting in the usual sense: every pair of
-members has a nonempty intersection.
--/
-theorem intersecting (hL : 0 ∉ L) (h𝒜 : IsIntersectingOf L 𝒜) : Intersecting 𝒜 := by
-  intro s hs t ht
-  grind [h𝒜 hs ht, card_inter, card_union_eq_card_add_card]
-
-/--
-A family `𝒜` of finite subsets of `α` is `{0}ᶜ`-intersecting if and only if it is intersecting in in
-the usual sense.
--/
-@[simp]
-theorem isIntersectingOf_singleton_compl : IsIntersectingOf {0}ᶜ 𝒜 ↔ Intersecting 𝒜 := by
-  simp [IsIntersectingOf, Intersecting, disjoint_iff]
+protected theorem univ : IsIntersectingOf univ 𝒜 := 𝒜.pairwise_of_forall _ fun _ _ ↦ trivial
 
 end IsIntersectingOf
 

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -21,7 +21,8 @@ This file defines intersecting families and proves their basic properties.
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
 * `Set.IsIntersectingOf`: Predicate stating that a family `𝒜` of finsets is `L`-intersecting, i.e.,
-  meaning the intersection size of every pair of distinct members of `𝒜` belongs to `L ⊆ ℕ`.
+  meaning the intersection size of every pair of distinct members of `𝒜` satisfies some predicate
+  `L`.
 
 ## References
 
@@ -203,31 +204,33 @@ end
 This section defines `L`-intersecting families and establishes their basic properties.
 -/
 
-variable {L L' : Set ℕ}
+variable {L L' : ℕ → Prop}
 variable {α : Type*} [DecidableEq α]
 variable {𝒜 ℬ : Set (Finset α)}
 
 /--
 A family `𝒜` of finite subsets of `α` is `L`-intersecting if the intersection size of every pair of
-distinct members of `𝒜` belongs to `L ⊆ ℕ`.
+distinct members of `𝒜` satisfies some predicate `L`.
 
-That is, for all `s, t ∈ 𝒜` with `s ≠ t`, we have `|(s ∩ t)| ∈ L`.
+That is, for all `s, t ∈ 𝒜` with `s ≠ t`, we have `L #(s ∩ t)`.
 -/
-def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop := 𝒜.Pairwise fun s t ↦ #(s ∩ t) ∈ L
+def IsIntersectingOf (L : ℕ → Prop) (𝒜 : Set (Finset α)) : Prop := 𝒜.Pairwise fun s t ↦ L #(s ∩ t)
 
 namespace IsIntersectingOf
 
 /--
-An `L`-intersecting family is also `L'`-intersecting whenever `L ⊆ L'`.
+An `L`-intersecting family is also `L'`-intersecting whenever `L` implies `L'`.
 -/
 @[gcongr]
-theorem mono (h : L ⊆ L') (hL : IsIntersectingOf L 𝒜) : IsIntersectingOf L' 𝒜 := by tauto
+protected theorem mono (h : ∀ n, L n → L' n) (hL : IsIntersectingOf L 𝒜) :
+    IsIntersectingOf L' 𝒜 := by tauto
 
 /--
 An `L`-intersecting family remains `L`-intersecting under restriction to any subfamily.
 -/
 @[gcongr]
-theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ := Pairwise.mono h h𝒜
+protected theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ :=
+  Pairwise.mono h h𝒜
 
 /--
 The empty family of finite sets is `L`-intersecting, vacuously, because it contains no pairs of
@@ -237,10 +240,10 @@ sets.
 protected theorem empty : IsIntersectingOf L (∅ : Set (Finset α)) := by tauto
 
 /--
-Every family of finite sets is `univ`-intersecting.
+Every family of finite sets is `True`-intersecting.
 -/
 @[simp]
-protected theorem univ : IsIntersectingOf univ 𝒜 := 𝒜.pairwise_of_forall _ fun _ _ ↦ trivial
+protected theorem true : IsIntersectingOf (fun _ : ℕ ↦ True) 𝒜 := by tauto
 
 end IsIntersectingOf
 

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -21,8 +21,7 @@ This file defines intersecting families and proves their basic properties.
   `a` and `aᶜ` cannot simultaneously be in it.
 * `Set.Intersecting.is_max_iff_card_eq`: Any maximal intersecting family takes up half the elements.
 * `Set.IsIntersectingOf`: Predicate stating that a family `𝒜` of finsets is `L`-intersecting, i.e.,
-  meaning the intersection size of every pair of distinct members of `𝒜` satisfies some predicate
-  `L`.
+  meaning the intersection size of every pair of distinct members of `𝒜` belongs to `L ⊆ ℕ`.
 
 ## References
 
@@ -204,33 +203,31 @@ end
 This section defines `L`-intersecting families and establishes their basic properties.
 -/
 
-variable {L L' : ℕ → Prop}
+variable {L L' : Set ℕ}
 variable {α : Type*} [DecidableEq α]
 variable {𝒜 ℬ : Set (Finset α)}
 
 /--
 A family `𝒜` of finite subsets of `α` is `L`-intersecting if the intersection size of every pair of
-distinct members of `𝒜` satisfies some predicate `L`.
+distinct members of `𝒜` belongs to `L ⊆ ℕ`.
 
-That is, for all `s, t ∈ 𝒜` with `s ≠ t`, we have `L #(s ∩ t)`.
+That is, for all `s, t ∈ 𝒜` with `s ≠ t`, we have `|(s ∩ t)| ∈ L`.
 -/
-def IsIntersectingOf (L : ℕ → Prop) (𝒜 : Set (Finset α)) : Prop := 𝒜.Pairwise fun s t ↦ L #(s ∩ t)
+def IsIntersectingOf (L : Set ℕ) (𝒜 : Set (Finset α)) : Prop := 𝒜.Pairwise fun s t ↦ #(s ∩ t) ∈ L
 
 namespace IsIntersectingOf
 
 /--
-An `L`-intersecting family is also `L'`-intersecting whenever `L` implies `L'`.
+An `L`-intersecting family is also `L'`-intersecting whenever `L ⊆ L'`.
 -/
 @[gcongr]
-protected theorem mono (h : ∀ n, L n → L' n) (hL : IsIntersectingOf L 𝒜) :
-    IsIntersectingOf L' 𝒜 := by tauto
+theorem mono (h : L ⊆ L') (hL : IsIntersectingOf L 𝒜) : IsIntersectingOf L' 𝒜 := by tauto
 
 /--
 An `L`-intersecting family remains `L`-intersecting under restriction to any subfamily.
 -/
 @[gcongr]
-protected theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ :=
-  Pairwise.mono h h𝒜
+theorem anti (h : ℬ ⊆ 𝒜) (h𝒜 : IsIntersectingOf L 𝒜) : IsIntersectingOf L ℬ := Pairwise.mono h h𝒜
 
 /--
 The empty family of finite sets is `L`-intersecting, vacuously, because it contains no pairs of
@@ -240,10 +237,10 @@ sets.
 protected theorem empty : IsIntersectingOf L (∅ : Set (Finset α)) := by tauto
 
 /--
-Every family of finite sets is `True`-intersecting.
+Every family of finite sets is `univ`-intersecting.
 -/
 @[simp]
-protected theorem true : IsIntersectingOf (fun _ : ℕ ↦ True) 𝒜 := by tauto
+protected theorem univ : IsIntersectingOf univ 𝒜 := 𝒜.pairwise_of_forall _ fun _ _ ↦ trivial
 
 end IsIntersectingOf
 


### PR DESCRIPTION
Define L-intersecting families and establish their basic properties.

A family 𝒜 of finsets is L-intersecting if all pairwise intersection sizes of distinct members of 𝒜 belong to L ⊆ ℕ.

From LeanCamCombi.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
