### PR TITLE
[Merged by Bors] - feat(RestrictedProduct/Basic): `RestrictedProduct.mulSingle` and additive version

### DIFF
--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -482,11 +482,11 @@ lemma mulSingle_injective : (mulSingle A i).Injective :=
 lemma mulSingle_inj {x y : G i} : mulSingle A i x = mulSingle A i y ↔ x = y :=
   (mulSingle_injective A i).eq_iff
 
-@[to_additive (attr := simp)]
+@[to_additive]
 lemma mulSingle_eq_of_ne {i j : ι} (r : G i) (h : j ≠ i) : mulSingle A i r j = 1 :=
   Pi.mulSingle_eq_of_ne h r
 
-@[to_additive (attr := simp)]
+@[to_additive]
 lemma mulSingle_eq_of_ne' {i j : ι} (r : G i) (h : i ≠ j) : mulSingle A i r j = 1 :=
   Pi.mulSingle_eq_of_ne' h r
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -503,8 +503,6 @@ lemma mulSingle_ne_one_iff {x : G i} : mulSingle A i x ≠ 1 ↔ x ≠ 1 :=
 
 end one
 
-section mul
-
 @[to_additive]
 lemma mulSingle_mul [∀ i, MulOneClass (G i)] [∀ i, OneMemClass (S i) (G i)]
     [∀ i, MulMemClass (S i) (G i)] (i : ι) (r s : G i) :
@@ -527,7 +525,29 @@ lemma single_mul [∀ i, MulZeroClass (G i)] [∀ i, ZeroMemClass (S i) (G i)]
   rcases eq_or_ne i j with rfl | hne; · simp
   simp [single_eq_of_ne' A _ hne]
 
-end mul
+@[to_additive]
+lemma mulSingle_inv [∀ i, Group (G i)] [∀ i, SubgroupClass (S i) (G i)]
+    (i : ι) (r : G i) :
+    mulSingle A i r⁻¹ = (mulSingle A i r)⁻¹ := by
+  ext; simp [Pi.mulSingle_inv]
+
+@[to_additive]
+lemma mulSingle_div [∀ i, Group (G i)] [∀ i, SubgroupClass (S i) (G i)]
+    (i : ι) (r s : G i) :
+    mulSingle A i (r / s) = mulSingle A i r / mulSingle A i s := by
+  ext; simp [Pi.mulSingle_div]
+
+@[to_additive]
+lemma mulSingle_pow [∀ i, Monoid (G i)] [∀ i, SubmonoidClass (S i) (G i)]
+    (i : ι) (r : G i) (n : ℕ) :
+    mulSingle A i (r ^ n) = mulSingle A i r ^ n := by
+  ext; simp [Pi.mulSingle_pow, RestrictedProduct.pow_apply]
+
+@[to_additive]
+lemma mulSingle_zpow [∀ i, Group (G i)] [∀ i, SubgroupClass (S i) (G i)]
+    (i : ι) (r : G i) (n : ℤ) :
+    mulSingle A i (r  ^ n) = mulSingle A i r ^ n := by
+  ext; simp [Pi.mulSingle_zpow, RestrictedProduct.zpow_apply]
 
 end single
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -452,4 +452,83 @@ end ring
 
 end map
 
+section single
+
+variable {S : ι → Type*} {G : ι → Type*} [Π i, SetLike (S i) (G i)] (A : (i : ι) → (S i))
+  [DecidableEq ι]
+
+section one
+
+variable [∀ i, One (G i)] [∀ i, OneMemClass (S i) (G i)] (i : ι)
+
+/-- The function supported at `i`, with value `x` there, and `1` elsewhere. -/
+@[to_additive
+/-- The function supported at `i`, with value `x` there, and `0` elsewhere. -/]
+def mulSingle (x : G i) : Πʳ i, [G i, A i] where
+  val := Pi.mulSingle i x
+  property := by
+    filter_upwards [show {i}ᶜ ∈ Filter.cofinite by simp]
+    simp_all
+
+@[to_additive (attr := simp)]
+lemma coe_mulSingle_apply (x : G i) (j : ι) : mulSingle A i x j = Pi.mulSingle i x j := rfl
+@[to_additive] lemma comp_mulSingle : (↑) ∘ mulSingle A i = Pi.mulSingle (M := G) i := by ext; simp
+
+@[to_additive]
+lemma mulSingle_injective : (mulSingle A i).Injective :=
+  (comp_mulSingle A _ ▸ Pi.mulSingle_injective i).of_comp
+
+@[to_additive]
+lemma mulSingle_inj {x y : G i} : mulSingle A i x = mulSingle A i y ↔ x = y :=
+  (mulSingle_injective A i).eq_iff
+
+@[to_additive (attr := simp)]
+lemma mulSingle_eq_of_ne {i j : ι} (r : G i) (h : j ≠ i) : mulSingle A i r j = 1 :=
+  Pi.mulSingle_eq_of_ne h r
+
+@[to_additive (attr := simp)]
+lemma mulSingle_eq_of_ne' {i j : ι} (r : G i) (h : i ≠ j) : mulSingle A i r j = 1 :=
+  Pi.mulSingle_eq_of_ne' h r
+
+@[to_additive (attr := simp)]
+lemma mulSingle_one : mulSingle A i 1 = 1 := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma mulSingle_eq_one_iff {x : G i} : mulSingle A i x = 1 ↔ x = 1 :=
+  Subtype.ext_iff.trans Pi.mulSingle_eq_one_iff
+
+@[to_additive]
+lemma mulSingle_ne_one_iff {x : G i} : mulSingle A i x ≠ 1 ↔ x ≠ 1 :=
+  Subtype.coe_ne_coe.symm.trans Pi.mulSingle_ne_one_iff
+
+end one
+
+section mul
+
+@[to_additive]
+lemma mulSingle_mul [∀ i, MulOneClass (G i)] [∀ i, OneMemClass (S i) (G i)]
+    [∀ i, MulMemClass (S i) (G i)] (i : ι) (r s : G i) :
+    mulSingle A i (r * s) = mulSingle A i r * mulSingle A i s := by
+  ext; simp [Pi.mulSingle_mul]
+
+@[simp]
+lemma mul_single [∀ i, MulZeroClass (G i)] [∀ i, ZeroMemClass (S i) (G i)]
+    [∀ i, MulMemClass (S i) (G i)] (i : ι) (r : G i) (x : Πʳ i, [G i, A i]) :
+    single A i (x i * r) = x * single A i r := by
+  ext j
+  rcases eq_or_ne i j with rfl | hne; · simp
+  simp [single_eq_of_ne' A _ hne]
+
+@[simp]
+lemma single_mul [∀ i, MulZeroClass (G i)] [∀ i, ZeroMemClass (S i) (G i)]
+    [∀ i, MulMemClass (S i) (G i)] (i : ι) (r : G i) (x : Πʳ i, [G i, A i]) :
+    single A i (r * x i) = single A i r * x := by
+  ext j
+  rcases eq_or_ne i j with rfl | hne; · simp
+  simp [single_eq_of_ne' A _ hne]
+
+end mul
+
+end single
+
 end RestrictedProduct


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
