### PR TITLE
[Merged by Bors] - feat: closed subgroup of profinite group is intersection of open subgroups containing it

### DIFF
--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Nailin Guan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nailin Guan, Yi Song, Xuchun Li
+Authors: Nailin Guan, Yi Song, Xuchun Li, Bryan Wang
 -/
 module
 
@@ -16,6 +16,9 @@ public import Mathlib.Topology.Separation.Connected
 This file proves the lemma `IsTopologicalGroup.exist_openNormalSubgroup_sub_clopen_nhds_of_one`,
 which states that in a compact topological group, for any clopen neighborhood of 1,
 there exists an open normal subgroup contained within it.
+
+We then apply this lemma to show `ProfiniteGrp.closedSubgroup_eq_sInf_open`:
+any closed subgroup of a profinite group is the intersection of the open subgroups containing it.
 
 This file is split out from the file `OpenSubgroup` because it needs more imports.
 -/
@@ -37,12 +40,42 @@ end IsTopologicalGroup
 
 namespace ProfiniteGrp
 
-theorem exist_openNormalSubgroup_sub_open_nhds_of_one {G : Type*} [Group G] [TopologicalSpace G]
-    [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G] {U : Set G}
-    (UOpen : IsOpen U) (einU : 1 ∈ U) : ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ U := by
+variable {G : Type*} [Group G] [TopologicalSpace G]
+    [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G]
+
+theorem exist_openNormalSubgroup_sub_open_nhds_of_one
+    {U : Set G} (UOpen : IsOpen U) (einU : 1 ∈ U) :
+    ∃ H : OpenNormalSubgroup G, (H : Set G) ⊆ U := by
   rcases ((Filter.HasBasis.mem_iff' ((nhds_basis_clopen (1 : G))) U).mp <|
     mem_nhds_iff.mpr (by use U)) with ⟨W, hW, h⟩
   rcases IsTopologicalGroup.exist_openNormalSubgroup_sub_clopen_nhds_of_one hW.2 hW.1 with ⟨H, hH⟩
   exact ⟨H, fun _ a ↦ h (hH a)⟩
+
+/--
+Any closed subgroup of a profinite group is the intersection of the open subgroups containing it.
+See https://math.stackexchange.com/questions/5023433/closed-subgroups-of-a-compact-topological-group.
+-/
+theorem closedSubgroup_eq_sInf_open (H : ClosedSubgroup G) :
+    H = sInf {N : Subgroup G | IsOpen (N : Set G) ∧ H ≤ N} := by
+  open scoped Pointwise in
+  apply le_antisymm
+  · exact le_sInf fun N hN ↦ hN.2
+  · intro g hg; by_contra hg_not
+    let U : Set G := (g • H)ᶜ
+    have UOpen : IsOpen U :=
+      ((Homeomorph.mulLeft g).isClosedMap _ H.isClosed').isOpen_compl
+    have einU : 1 ∈ U := by
+      refine Set.mem_compl (fun ⟨l, hl, (hgl : g * l = 1)⟩ ↦ ?_)
+      rw [← inv_eq_iff_mul_eq_one] at hgl
+      exact hg_not <| inv_mem_iff.mp (hgl ▸ hl)
+    obtain ⟨N, hN⟩ := exist_openNormalSubgroup_sub_open_nhds_of_one UOpen einU
+    let NH : Subgroup G := N ⊔ H
+    have hg_not' : g ∉ NH := by
+      by_contra hg'
+      rcases Subgroup.mem_sup_of_normal_left.mp hg' with ⟨y, hy, z, hz, hyz⟩
+      rw [← eq_mul_inv_iff_mul_eq] at hyz
+      exact hN (hyz ▸ hy) <| mem_leftCoset g (inv_mem_iff.mpr hz)
+    exact hg_not' <|
+      Subgroup.mem_sInf.mp hg _ ⟨Subgroup.isOpen_mono le_sup_left N.isOpen, le_sup_right⟩
 
 end ProfiniteGrp

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -60,7 +60,8 @@ theorem closedSubgroup_eq_sInf_open (H : ClosedSubgroup G) :
   open scoped Pointwise in
   apply le_antisymm
   · exact le_sInf fun N hN ↦ hN.2
-  · intro g hg; by_contra hg_not
+  · intro g hg
+    by_contra hg_not
     let U : Set G := (g • H)ᶜ
     have UOpen : IsOpen U :=
       ((Homeomorph.mulLeft g).isClosedMap _ H.isClosed').isOpen_compl

--- a/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
+++ b/Mathlib/Topology/Algebra/ClopenNhdofOne.lean
@@ -51,13 +51,13 @@ theorem exist_openNormalSubgroup_sub_open_nhds_of_one
   rcases IsTopologicalGroup.exist_openNormalSubgroup_sub_clopen_nhds_of_one hW.2 hW.1 with ⟨H, hH⟩
   exact ⟨H, fun _ a ↦ h (hH a)⟩
 
+open scoped Pointwise in
 /--
 Any closed subgroup of a profinite group is the intersection of the open subgroups containing it.
 See https://math.stackexchange.com/questions/5023433/closed-subgroups-of-a-compact-topological-group.
 -/
 theorem closedSubgroup_eq_sInf_open (H : ClosedSubgroup G) :
     H = sInf {N : Subgroup G | IsOpen (N : Set G) ∧ H ≤ N} := by
-  open scoped Pointwise in
   apply le_antisymm
   · exact le_sInf fun N hN ↦ hN.2
   · intro g hg


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
