### PR TITLE
[Merged by Bors] - ci: Change display names to avoid on-cancellation quirk

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -19,11 +19,11 @@ permissions:
 
 jobs:
   build:
+    name: build (staging)
     if: ${{ github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
       pr_branch_ref: ${{ github.sha }}
-      job_name_suffix: ""
       runs_on: bors
     secrets: inherit

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    name: build (staging)
+    name: ci (staging)
     if: ${{ github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   build:
+    name: build (upstream)
     if: ${{ github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    name: build (upstream)
+    name: ci
     if: ${{ github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,5 @@ jobs:
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/master' && github.run_id) || '' }}
       pr_branch_ref: ${{ github.sha }}
-      job_name_suffix: ""
       runs_on: pr
     secrets: inherit

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   build:
-    name: build (forks)
+    name: ci (fork)
     if: ${{ github.event.pull_request.head.repo.fork && github.repository != 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -24,11 +24,11 @@ permissions:
 
 jobs:
   build:
+    name: build (forks)
     if: ${{ github.event.pull_request.head.repo.fork && github.repository != 'leanprover-community/mathlib4-nightly-testing' }}
     uses: ./.github/workflows/build_template.yml
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       pr_branch_ref: ${{ github.event.pull_request.head.sha }}
-      job_name_suffix: ' (fork)'
       runs_on: pr
     secrets: inherit

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -9,10 +9,6 @@ on:
       pr_branch_ref:
         type: string
         required: true
-      job_name_suffix:
-        type: string
-        required: false
-        default: ""
       runs_on:
         type: string
         required: true
@@ -27,7 +23,7 @@ env:
 
 jobs:
   build:
-    name: Build${{ inputs.job_name_suffix }}
+    name: Build
     runs-on: ${{ inputs.runs_on }}
     outputs:
       build-outcome: ${{ steps.build.outcome }}
@@ -599,7 +595,7 @@ jobs:
           master-branch/scripts/lean-pr-testing-comments.sh batteries
 
   post_steps:
-    name: Post-Build Step${{ inputs.job_name_suffix }}
+    name: Post-Build Step
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -678,7 +674,7 @@ jobs:
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `daily.yml`.
   style_lint:
-    name: Lint style${{ inputs.job_name_suffix }}
+    name: Lint style
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@a7e7428fa44f9635d6eb8e01919d16fd498d387a # 2025-08-18
@@ -688,7 +684,7 @@ jobs:
           ref: ${{ inputs.pr_branch_ref }}
 
   final:
-    name: Post-CI job${{ inputs.job_name_suffix }}
+    name: Post-CI job
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
-status = ["ci (staging) / Build", "ci (staging) / Lint style", "ci (staging) / Post-Build Step"]
+status = ["ci (staging) / Build", "ci (staging) / Lint style", "ci (staging) / Post-Build Step", "ci (staging) / Post-CI job"]
 use_squash_merge = true
 timeout_sec = 7200
 block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]


### PR DESCRIPTION
It seems like cancelled jobs are not resolving the suffix correctly, so let's push the disambiguation to the upper UI layer