### PR TITLE
feat(SimpleGraph): the cycle graph and complete graph are Hamiltonian

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -299,7 +299,7 @@ theorem isContained_iff_exists_iso_subgraph :
 theorem isContained_completeGraph_of_card_le_card [Fintype V] [Fintype W]
     (h : Fintype.card V ≤ Fintype.card W) : G ⊑ completeGraph W := by
   obtain ⟨f, hf⟩ := Function.Embedding.nonempty_of_card_le h
-  exact ⟨⟨f, by grind [top_adj, SimpleGraph.irrefl] ⟩, hf⟩
+  exact ⟨⟨f, by grind [top_adj, SimpleGraph.irrefl]⟩, hf⟩
 
 alias ⟨IsContained.exists_iso_subgraph, IsContained.of_exists_iso_subgraph⟩ :=
   isContained_iff_exists_iso_subgraph

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -296,6 +296,11 @@ theorem isContained_iff_exists_iso_subgraph :
   mp := fun ⟨f⟩ ↦ ⟨.map f.toHom ⊤, ⟨f.isoToSubgraph⟩⟩
   mpr := fun ⟨B', ⟨e⟩⟩ ↦ B'.coe_isContained.trans' ⟨e.toCopy⟩
 
+theorem isContained_completeGraph_of_card_le_card [Fintype V] [Fintype W]
+    (h : Fintype.card V ≤ Fintype.card W) : G ⊑ completeGraph W := by
+  obtain ⟨f, hf⟩ := Function.Embedding.nonempty_of_card_le h
+  exact ⟨⟨f, by grind [top_adj, SimpleGraph.irrefl] ⟩, hf⟩
+
 alias ⟨IsContained.exists_iso_subgraph, IsContained.of_exists_iso_subgraph⟩ :=
   isContained_iff_exists_iso_subgraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.GroupWithZero.Nat
 public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.Circulant
 
 /-!
 # Hamiltonian Graphs
@@ -158,6 +159,10 @@ lemma IsHamiltonianCycle.support_count_of_ne (hp : p.IsHamiltonianCycle) (h : a 
     p.support.count b = 1 := by
   rw [← cons_support_tail p hp.1.not_nil, List.count_cons_of_ne h, hp.isHamiltonian_tail]
 
+theorem cycleGraph_EulerianCircuit_isHamiltonianCycle {n : ℕ} :
+    (cycleGraph_EulerianCircuit n).IsHamiltonianCycle :=
+  isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨cycleGraph_EulerianCircuit_isCycle, by simp⟩
+
 end Walk
 
 variable [Fintype α]
@@ -188,6 +193,25 @@ lemma IsHamiltonian.of_card_eq_one (h : Fintype.card α = 1) : G.IsHamiltonian :
 
 lemma IsHamiltonian.of_unique [Unique α] : G.IsHamiltonian :=
   of_card_eq_one <| Fintype.card_unique
+
+theorem isHamiltonian_iff_cycleGraph_isContained (h : 2 < Fintype.card α) :
+    G.IsHamiltonian ↔ cycleGraph (Fintype.card α) ⊑ G := by
+  refine ⟨fun h' ↦ ?_, fun h' ↦ ?_⟩
+  · obtain ⟨a, p, hp⟩ := h' (by grind)
+    exact cycleGraph_isContained_iff h |>.mpr ⟨a, p, hp.isCycle, hp.length_eq⟩
+  · obtain ⟨a, p, hp₁, hp₂⟩ := cycleGraph_isContained_iff h |>.mp h'
+    exact fun _ ↦ ⟨a, p, Walk.isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨hp₁, hp₂⟩⟩
+
+@[simp]
+theorem isHamiltonian_cycleGraph (n : ℕ) (hn : 2 < n) : (cycleGraph n).IsHamiltonian := by
+  apply isHamiltonian_iff_cycleGraph_isContained (by simp [hn]) |>.mpr
+  rw [Fintype.card_fin]
+  exact IsContained.rfl
+
+@[simp]
+theorem isHamiltonian_top (h : 2 < Fintype.card α) : (completeGraph α).IsHamiltonian :=
+  isHamiltonian_iff_cycleGraph_isContained h |>.mpr <|
+    isContained_completeGraph_of_card_le_card (by simp)
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -219,8 +219,7 @@ lemma isHamiltonianCycle_rotate (hv : v ∈ p.support) :
 protected alias ⟨IsHamiltonianCycle.of_rotate, IsHamiltonianCycle.rotate⟩ :=
   isHamiltonianCycle_rotate
 
-theorem cycleGraph_EulerianCircuit_isHamiltonianCycle {n : ℕ} :
-    (cycleGraph.cycle n).IsHamiltonianCycle :=
+lemma isHamiltonianCycle_cycleGraph {n : ℕ} : (cycleGraph.cycle n).IsHamiltonianCycle :=
   isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨cycleGraph.isCycle_cycle, by simp⟩
 
 end Walk
@@ -295,9 +294,9 @@ theorem isHamiltonian_iff_cycleGraph_isContained (h : 2 < Fintype.card α) :
     exact fun _ ↦ ⟨a, p, Walk.isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨hp₁, hp₂⟩⟩
 
 @[simp]
-theorem isHamiltonian_cycleGraph (n : ℕ) (hn : 2 < n) : (cycleGraph n).IsHamiltonian := by
-  apply isHamiltonian_iff_cycleGraph_isContained (by simp [hn]) |>.mpr
-  exact Fintype.card_fin _ ▸ IsContained.rfl
+theorem isHamiltonian_cycleGraph {n : ℕ} (hn : 2 < n) : (cycleGraph n).IsHamiltonian :=
+  isHamiltonian_iff_cycleGraph_isContained (by simp [hn]) |>.mpr <|
+    Fintype.card_fin _ ▸ IsContained.rfl
 
 @[simp]
 theorem isHamiltonian_top (h : 2 < Fintype.card α) : (completeGraph α).IsHamiltonian :=

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.GroupWithZero.Nat
 public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.CycleGraph
 
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
 
@@ -218,6 +219,10 @@ lemma isHamiltonianCycle_rotate (hv : v ∈ p.support) :
 protected alias ⟨IsHamiltonianCycle.of_rotate, IsHamiltonianCycle.rotate⟩ :=
   isHamiltonianCycle_rotate
 
+theorem cycleGraph_EulerianCircuit_isHamiltonianCycle {n : ℕ} :
+    (cycleGraph.cycle n).IsHamiltonianCycle :=
+  isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨cycleGraph.isCycle_cycle, by simp⟩
+
 end Walk
 
 variable [Fintype α]
@@ -280,5 +285,23 @@ theorem IsBridge.not_isHamiltonian {e : Sym2 α} (he : G.IsBridge e) : ¬G.IsHam
   refine hp.isHamiltonian_tail.isPath.isTrail.not_mem_support_of_not_reachable
     (fun huv ↦ he <| .trans ?_ huv) he (hp.isHamiltonian_tail.mem_support v)
   apply hp.isTrail.isEdgeReachable_two <;> simp
+
+theorem isHamiltonian_iff_cycleGraph_isContained (h : 2 < Fintype.card α) :
+    G.IsHamiltonian ↔ cycleGraph (Fintype.card α) ⊑ G := by
+  refine ⟨fun h' ↦ ?_, fun h' ↦ ?_⟩
+  · obtain ⟨a, p, hp⟩ := h' (by grind)
+    exact cycleGraph_isContained_iff h |>.mpr ⟨a, p, hp.isCycle, hp.length_eq⟩
+  · obtain ⟨a, p, hp₁, hp₂⟩ := cycleGraph_isContained_iff h |>.mp h'
+    exact fun _ ↦ ⟨a, p, Walk.isHamiltonianCycle_iff_isCycle_and_length_eq.mpr ⟨hp₁, hp₂⟩⟩
+
+@[simp]
+theorem isHamiltonian_cycleGraph (n : ℕ) (hn : 2 < n) : (cycleGraph n).IsHamiltonian := by
+  apply isHamiltonian_iff_cycleGraph_isContained (by simp [hn]) |>.mpr
+  exact Fintype.card_fin _ ▸ IsContained.rfl
+
+@[simp]
+theorem isHamiltonian_top (h : 2 < Fintype.card α) : (completeGraph α).IsHamiltonian :=
+  isHamiltonian_iff_cycleGraph_isContained h |>.mpr <|
+    isContained_top_iff.mpr <| Function.Embedding.nonempty_of_card_le (by simp)
 
 end SimpleGraph


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #34797 
- [ ] depends on: #35255
- [ ] depends on: #37930

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)