### PR TITLE
[Merged by Bors] - ci: Skip build_fork workflow when changes are made only to workflow files

### DIFF
--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -9,7 +9,7 @@ on:
       - 'staging*.tmp'
       - 'nolints'
     paths-ignore:
-      # pull_request_target uses the workflow from the base branch:
+      # pull_request_target uses the workflow from the target branch:
       # PR changes under this directory won't affect this run, so
       # running it is just wasteful
       - '.github/workflows/**'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -8,6 +8,11 @@ on:
       - 'trying.tmp*'
       - 'staging*.tmp'
       - 'nolints'
+    paths-ignore:
+      # pull_request_target uses the workflow from the base branch:
+      # PR changes under this directory won't affect this run, so
+      # running it is just wasteful
+      - '.github/workflows/**'
 
 concurrency:
   # label each workflow run; only the latest with each label will run


### PR DESCRIPTION
`pull_request_target` uses the workflow files from the target branch: PR changes under this directory won't affect this run, so running it is just wasting resources. The files should be validated eventually by `bors try` or `bors r+`