### PR TITLE
[Merged by Bors] - fix(CI): add missing guards to nightly_detect_failure workflow

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -181,6 +181,7 @@ jobs:
         exit 0
 
     - name: Fetch latest bump branch name
+      if: steps.check_branch.outputs.result == 'false'
       id: latest_bump_branch
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
@@ -201,6 +202,7 @@ jobs:
           return latestBranch;
 
     - name: Fetch lean-toolchain from latest bump branch
+      if: steps.check_branch.outputs.result == 'false'
       id: bump_version
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
@@ -271,7 +273,7 @@ jobs:
           return match[1];
 
     - name: Send warning message on Zulip if pattern doesn't match
-      if: failure()
+      if: failure() && steps.bump_version.outcome == 'failure'
       uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
       with:
         api-key: ${{ secrets.ZULIP_API_KEY }}


### PR DESCRIPTION
This PR fixes two bugs in `nightly_detect_failure.yml` that caused a [misleading warning message](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Mathlib.20status.20updates/near/571796205) today.

**What happened:** An unrelated auth failure (checking out `leanprover/lean4`) caused `if: failure()` to trigger the "lean-toolchain doesn't match pattern" warning, even though the actual failure had nothing to do with toolchain validation. The warning showed empty values because the `bump_version` step never ran.

**Fixes:**
1. Add `if: steps.check_branch.outputs.result == 'false'` guards to `latest_bump_branch` and `bump_version` steps (matching the guards already present on later steps)
2. Change the warning step from `if: failure()` to `if: failure() && steps.bump_version.outcome == 'failure'` so it only fires for actual toolchain validation failures

🤖 Prepared with Claude Code