### PR TITLE
chore: add GitHub Apps validation script and config

### DIFF
--- a/.github/github-apps.yml
+++ b/.github/github-apps.yml
@@ -1,0 +1,222 @@
+# GitHub Apps used by mathlib4 and related repositories
+#
+# This file documents all GitHub Apps, their secrets, and which workflows use them.
+# Run `.github/scripts/validate-github-apps.sh` to verify this configuration.
+#
+# To add a new app:
+# 1. Create the app at https://github.com/organizations/{org}/settings/apps
+# 2. Note the App ID from the app settings page
+# 3. Generate a private key and add both secrets to the repository
+# 4. Add the app configuration below
+# 5. Run the validation script to verify
+
+apps:
+  # ============================================================================
+  # mathlib-merge-conflicts
+  # Labels PRs with `merge-conflict` and posts a reminder comment
+  # ============================================================================
+  mathlib-merge-conflicts:
+    id: 2784000
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-merge-conflicts
+    description: Labels mathlib4 PRs that have merge conflicts and posts a reminder comment
+    permissions:
+      pull_requests: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_MERGE_CONFLICTS_APP_ID
+        private_key: MATHLIB_MERGE_CONFLICTS_PRIVATE_KEY
+      - repo: leanprover-community/batteries
+        app_id: MATHLIB_MERGE_CONFLICTS_APP_ID
+        private_key: MATHLIB_MERGE_CONFLICTS_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [merge_conflicts.yml]
+      - repo: leanprover-community/batteries
+        files: [merge_conflicts.yml]
+
+  # ============================================================================
+  # mathlib-dependent-issues
+  # Tracks `- [ ] depends on:` syntax and adds `blocked-by-other-PR` label
+  # ============================================================================
+  mathlib-dependent-issues:
+    id: 2784145
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-dependent-issues
+    description: "Tracks PR dependencies using - [ ] depends on: syntax and adds the blocked-by-other-PR label"
+    permissions:
+      pull_requests: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_DEPENDENT_ISSUES_APP_ID
+        private_key: MATHLIB_DEPENDENT_ISSUES_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [dependent-issues.yml]
+
+  # ============================================================================
+  # mathlib-nolints
+  # Weekly nolints.json updates and deprecated declaration removal
+  # ============================================================================
+  mathlib-nolints:
+    id: 2784168
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-nolints
+    description: Weekly updates to nolints.json
+    permissions:
+      contents: write
+      pull_requests: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_NOLINTS_APP_ID
+        private_key: MATHLIB_NOLINTS_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [nolints.yml, remove_deprecated_decls.yml]
+
+  # ============================================================================
+  # mathlib-update-dependencies
+  # Hourly dependency updates
+  # ============================================================================
+  mathlib-update-dependencies:
+    id: 2784189
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-update-dependencies
+    description: Hourly dependency updates via lake update
+    permissions:
+      contents: write
+      pull_requests: write
+      issues: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_UPDATE_DEPENDENCIES_APP_ID
+        private_key: MATHLIB_UPDATE_DEPENDENCIES_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [update_dependencies.yml, update_dependencies_zulip.yml]
+
+  # ============================================================================
+  # mathlib-nightly-testing
+  # Nightly toolchain bumps, merge master to nightly, Lean PR testing
+  # Note: Installed as "Any account" to allow cross-org installation on cslib
+  # ============================================================================
+  mathlib-nightly-testing:
+    id: 2784211
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-nightly-testing
+    description: Nightly toolchain bumps and master merges for mathlib4-nightly-testing
+    installation: any_account  # Allows cross-org installation
+    permissions:
+      contents: write
+      pull_requests: write
+      workflows: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_NIGHTLY_TESTING_APP_ID
+        private_key: MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY
+      - repo: leanprover-community/batteries
+        app_id: MATHLIB_NIGHTLY_TESTING_APP_ID
+        private_key: MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY
+      - repo: leanprover/cslib
+        app_id: MATHLIB_NIGHTLY_TESTING_APP_ID
+        private_key: MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files:
+          - discover-lean-pr-testing.yml
+          - nightly_bump_toolchain.yml
+          - nightly_detect_failure.yml
+          - nightly_merge_master.yml
+      - repo: leanprover-community/batteries
+        files:
+          - nightly_bump_toolchain.yml
+          - nightly_detect_failure.yml
+          - nightly_merge_master.yml
+      - repo: leanprover/cslib
+        files:
+          - bump_toolchain_nightly-testing.yml
+          - merge_main_into_nightly-testing.yml
+          - report_failures_nightly-testing.yml
+
+  # ============================================================================
+  # mathlib-triage
+  # Label management for bors commands (ready-to-merge, delegated)
+  # ============================================================================
+  mathlib-triage:
+    id: 2784271
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-triage
+    description: Adds the maintainer-merge label when mathlib reviewers use maintainer merge commands
+    permissions:
+      pull_requests: write
+      issues: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_TRIAGE_APP_ID
+        private_key: MATHLIB_TRIAGE_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files:
+          - maintainer_bors.yml
+          - maintainer_bors_wf_run.yml
+          - maintainer_merge.yml
+          - maintainer_merge_wf_run.yml
+
+  # ============================================================================
+  # mathlib-auto-merge
+  # Posts "bors merge" comment after CI passes for PRs with auto-merge label
+  # ============================================================================
+  mathlib-auto-merge:
+    id: 2784285
+    org: leanprover-community
+    settings_url: https://github.com/organizations/leanprover-community/settings/apps/mathlib-auto-merge
+    description: Posts bors merge comment after CI passes on auto-merge labeled PRs
+    permissions:
+      pull_requests: write
+      issues: write
+
+    secrets:
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_AUTO_MERGE_APP_ID
+        private_key: MATHLIB_AUTO_MERGE_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [build_template.yml]
+
+  # ============================================================================
+  # mathlib-lean-pr-testing
+  # Posts comments to Lean PRs about mathlib compatibility
+  # Note: This app is in the leanprover org, NOT leanprover-community
+  # ============================================================================
+  mathlib-lean-pr-testing:
+    id: 2785182
+    org: leanprover  # Different org!
+    settings_url: https://github.com/organizations/leanprover/settings/apps/mathlib-lean-pr-testing
+    description: Posts comments to Lean PRs about mathlib test results and pushes lean-pr-testing branches
+    installed_on: [leanprover/lean4]
+    permissions:
+      contents: write
+      pull_requests: write
+
+    secrets:
+      # Secrets are in mathlib4, but app is installed on lean4
+      - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_LEAN_PR_TESTING_APP_ID
+        private_key: MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY
+
+    workflows:
+      - repo: leanprover-community/mathlib4
+        files: [build_template.yml, nightly_detect_failure.yml]

--- a/.github/github-apps.yml
+++ b/.github/github-apps.yml
@@ -1,7 +1,7 @@
 # GitHub Apps used by mathlib4 and related repositories
 #
 # This file documents all GitHub Apps, their secrets, and which workflows use them.
-# Run `.github/scripts/validate-github-apps.sh` to verify this configuration.
+# Run `scripts/validate-github-apps.sh` to verify this configuration.
 #
 # To add a new app:
 # 1. Create the app at https://github.com/organizations/{org}/settings/apps
@@ -9,6 +9,16 @@
 # 3. Generate a private key and add both secrets to the repository
 # 4. Add the app configuration below
 # 5. Run the validation script to verify
+
+# MATHLIB_* secrets that are NOT GitHub App secrets.
+# These are excluded from the exhaustivity check.
+excepted_secrets:
+  - name: MATHLIB_CACHE_S3_TOKEN
+    purpose: S3 credentials for mathlib build cache
+  - name: MATHLIB_CACHE_SAS
+    purpose: Azure SAS token for mathlib build cache
+  - name: MATHLIB_REVIEWERS_TEAM_KEY
+    purpose: PAT with read:org scope for checking mathlib-reviewers team membership
 
 apps:
   # ============================================================================

--- a/.github/github-apps.yml
+++ b/.github/github-apps.yml
@@ -149,6 +149,7 @@ apps:
           - nightly_merge_master.yml
       - repo: leanprover-community/batteries
         files:
+          - discover-lean-pr-testing.yml
           - nightly_bump_toolchain.yml
           - nightly_detect_failure.yml
           - nightly_merge_master.yml

--- a/.github/github-apps.yml
+++ b/.github/github-apps.yml
@@ -201,9 +201,14 @@ apps:
       - repo: leanprover-community/mathlib4
         app_id: MATHLIB_AUTO_MERGE_APP_ID
         private_key: MATHLIB_AUTO_MERGE_PRIVATE_KEY
+      - repo: leanprover-community/mathlib4-nightly-testing
+        app_id: MATHLIB_AUTO_MERGE_APP_ID
+        private_key: MATHLIB_AUTO_MERGE_PRIVATE_KEY
 
     workflows:
       - repo: leanprover-community/mathlib4
+        files: [build_template.yml]
+      - repo: leanprover-community/mathlib4-nightly-testing
         files: [build_template.yml]
 
   # ============================================================================
@@ -222,11 +227,16 @@ apps:
       pull_requests: write
 
     secrets:
-      # Secrets are in mathlib4, but app is installed on lean4
+      # Secrets are in mathlib4 and mathlib4-nightly-testing, but app is installed on lean4
       - repo: leanprover-community/mathlib4
+        app_id: MATHLIB_LEAN_PR_TESTING_APP_ID
+        private_key: MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY
+      - repo: leanprover-community/mathlib4-nightly-testing
         app_id: MATHLIB_LEAN_PR_TESTING_APP_ID
         private_key: MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY
 
     workflows:
       - repo: leanprover-community/mathlib4
+        files: [build_template.yml, nightly_detect_failure.yml]
+      - repo: leanprover-community/mathlib4-nightly-testing
         files: [build_template.yml, nightly_detect_failure.yml]

--- a/.github/workflows/validate-github-apps.yml
+++ b/.github/workflows/validate-github-apps.yml
@@ -1,0 +1,39 @@
+# Validates GitHub Apps configuration weekly
+#
+# This workflow runs the validate-github-apps.sh script to ensure:
+# - All documented GitHub Apps exist and have correct IDs
+# - Apps are installed and not suspended
+# - Required secrets exist in each repository
+# - Workflow files reference the correct secrets
+#
+# The workflow runs weekly and can be triggered manually.
+
+name: Validate GitHub Apps
+
+on:
+  schedule:
+    # Run every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies
+        run: |
+          # yq is pre-installed on GitHub runners, but ensure latest
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          # jq is pre-installed on GitHub runners
+
+      - name: Validate GitHub Apps configuration
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/validate-github-apps.sh
+          ./scripts/validate-github-apps.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -145,6 +145,14 @@ to learn about it as well!
 **Version tag verification**
 - `verify_version_tags.py` verifies that Mathlib version tags are correctly published across git, GitHub, elan toolchains, and build cache.
 
+**GitHub App management**
+- `validate-github-apps.sh`
+  Validates the GitHub Apps configuration in `.github/github-apps.yml` against actual GitHub state.
+  Checks that apps exist with expected IDs, are installed and not suspended, required secrets exist
+  in each repository, and workflow files reference the correct secrets. Also warns about any
+  undocumented `MATHLIB_*` secrets. Run manually or via the weekly `validate-github-apps.yml` workflow.
+  Requires `gh`, `yq`, and `jq` installed.
+
 **Managing and tracking technical debt**
 - `technical-debt-metrics.sh`
   Prints information on certain kind of technical debt in Mathlib.

--- a/scripts/validate-github-apps.sh
+++ b/scripts/validate-github-apps.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Validates GitHub Apps configuration against actual GitHub state.
+#
+# This script checks that:
+# - Apps exist with expected IDs and descriptions
+# - Apps are installed and not suspended
+# - Required secrets exist in each repository
+# - Workflow files reference the correct secrets
+# - No undocumented MATHLIB_* secrets exist (warning only)
+#
+# Usage: ./scripts/validate-github-apps.sh
+#
+# Requirements:
+# - gh (GitHub CLI) installed and authenticated
+# - yq (YAML processor) installed
+# - jq (JSON processor) installed
+#
+# Exit codes:
+# - 0: All validations passed (warnings are OK)
+# - 1: One or more validations failed
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Counters
+ERRORS=0
+WARNINGS=0
+APPS_VALIDATED=0
+
+# Config file location (relative to repo root)
+CONFIG_FILE=".github/github-apps.yml"
+
+# Find repo root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+CONFIG_PATH="${REPO_ROOT}/${CONFIG_FILE}"
+
+# Check dependencies
+check_dependencies() {
+    local missing=()
+    command -v gh &>/dev/null || missing+=("gh")
+    command -v yq &>/dev/null || missing+=("yq")
+    command -v jq &>/dev/null || missing+=("jq")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo -e "${RED}Missing required dependencies: ${missing[*]}${NC}"
+        echo "Install with:"
+        echo "  brew install gh yq jq  # macOS"
+        echo "  apt install gh yq jq   # Debian/Ubuntu"
+        exit 1
+    fi
+
+    # Check gh is authenticated
+    if ! gh auth status &>/dev/null; then
+        echo -e "${RED}GitHub CLI not authenticated. Run 'gh auth login' first.${NC}"
+        exit 1
+    fi
+}
+
+# Print status messages
+ok() { echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1"; ((ERRORS++)) || true; }
+warn() { echo -e "  ${YELLOW}⚠${NC} $1"; ((WARNINGS++)) || true; }
+info() { echo -e "  ${BLUE}ℹ${NC} $1"; }
+
+# Get list of app slugs from config
+get_app_slugs() {
+    yq -r '.apps | keys | .[]' "$CONFIG_PATH"
+}
+
+# Get app property
+get_app_prop() {
+    local slug="$1" prop="$2"
+    yq -r ".apps[\"$slug\"].$prop // \"\"" "$CONFIG_PATH"
+}
+
+# Get array property as newline-separated values
+get_app_array() {
+    local slug="$1" prop="$2"
+    yq -r ".apps[\"$slug\"].$prop[]? // \"\"" "$CONFIG_PATH"
+}
+
+# Validate a single app
+validate_app() {
+    local slug="$1"
+    local expected_id expected_org expected_desc
+
+    expected_id=$(get_app_prop "$slug" "id")
+    expected_org=$(get_app_prop "$slug" "org")
+    expected_desc=$(get_app_prop "$slug" "description")
+
+    echo -e "\n${BLUE}[$slug]${NC}"
+
+    # Check app exists and get metadata
+    local app_data
+    if ! app_data=$(gh api "/apps/$slug" 2>/dev/null); then
+        fail "App does not exist at /apps/$slug"
+        return
+    fi
+
+    # Verify app ID
+    local actual_id
+    actual_id=$(echo "$app_data" | jq -r '.id')
+    if [[ "$actual_id" == "$expected_id" ]]; then
+        ok "App exists (id: $actual_id)"
+    else
+        fail "App ID mismatch: expected $expected_id, got $actual_id"
+    fi
+
+    # Verify description contains expected text (substring match)
+    local actual_desc
+    actual_desc=$(echo "$app_data" | jq -r '.description // ""')
+    if [[ "$actual_desc" == *"$expected_desc"* ]] || [[ "$expected_desc" == *"$actual_desc"* ]]; then
+        ok "Description matches"
+    else
+        warn "Description mismatch: expected '$expected_desc', got '$actual_desc'"
+    fi
+
+    # Check app is installed on org
+    local installations
+    if installations=$(gh api "/orgs/$expected_org/installations" 2>/dev/null); then
+        local installed suspended
+        installed=$(echo "$installations" | jq -r ".installations[] | select(.app_slug == \"$slug\") | .id" | head -1)
+        if [[ -n "$installed" ]]; then
+            ok "App installed on $expected_org"
+
+            # Check if suspended
+            suspended=$(echo "$installations" | jq -r ".installations[] | select(.app_slug == \"$slug\") | .suspended_at // empty" | head -1)
+            if [[ -z "$suspended" ]]; then
+                ok "App not suspended"
+            else
+                fail "App is suspended!"
+            fi
+        else
+            fail "App not installed on $expected_org"
+        fi
+    else
+        warn "Could not check installations on $expected_org (may lack permissions)"
+    fi
+
+    # Validate secrets for each repo
+    validate_app_secrets "$slug"
+
+    # Validate workflow references
+    validate_app_workflows "$slug"
+
+    ((APPS_VALIDATED++)) || true
+}
+
+# Validate secrets exist for an app
+validate_app_secrets() {
+    local slug="$1"
+    local secrets_json
+
+    # Get secrets configuration as JSON for easier parsing
+    secrets_json=$(yq -o=json ".apps[\"$slug\"].secrets // []" "$CONFIG_PATH")
+    local num_secrets
+    num_secrets=$(echo "$secrets_json" | jq 'length')
+
+    for ((i=0; i<num_secrets; i++)); do
+        local repo app_id_secret private_key_secret
+        repo=$(echo "$secrets_json" | jq -r ".[$i].repo")
+        app_id_secret=$(echo "$secrets_json" | jq -r ".[$i].app_id")
+        private_key_secret=$(echo "$secrets_json" | jq -r ".[$i].private_key")
+
+        # Get secrets list for repo
+        local repo_secrets
+        if ! repo_secrets=$(gh secret list --repo "$repo" 2>/dev/null); then
+            warn "Could not list secrets for $repo (may lack permissions)"
+            continue
+        fi
+
+        # Check APP_ID secret exists
+        if echo "$repo_secrets" | grep -q "^${app_id_secret}"; then
+            ok "Secret $app_id_secret exists in $repo"
+        else
+            fail "Secret $app_id_secret missing in $repo"
+        fi
+
+        # Check PRIVATE_KEY secret exists
+        if echo "$repo_secrets" | grep -q "^${private_key_secret}"; then
+            ok "Secret $private_key_secret exists in $repo"
+        else
+            fail "Secret $private_key_secret missing in $repo"
+        fi
+    done
+}
+
+# Validate workflow files reference correct secrets
+validate_app_workflows() {
+    local slug="$1"
+    local workflows_json
+
+    workflows_json=$(yq -o=json ".apps[\"$slug\"].workflows // []" "$CONFIG_PATH")
+    local num_workflows
+    num_workflows=$(echo "$workflows_json" | jq 'length')
+
+    for ((i=0; i<num_workflows; i++)); do
+        local repo files_json
+        repo=$(echo "$workflows_json" | jq -r ".[$i].repo")
+        files_json=$(echo "$workflows_json" | jq -r ".[$i].files")
+
+        # Get expected secret name pattern for this app
+        local secret_pattern
+        secret_pattern=$(yq -r ".apps[\"$slug\"].secrets[0].app_id // \"\"" "$CONFIG_PATH")
+
+        local num_files
+        num_files=$(echo "$files_json" | jq 'length')
+
+        for ((j=0; j<num_files; j++)); do
+            local file
+            file=$(echo "$files_json" | jq -r ".[$j]")
+
+            # For mathlib4, check local files; for others, use API
+            if [[ "$repo" == "leanprover-community/mathlib4" ]]; then
+                local workflow_path="${REPO_ROOT}/.github/workflows/${file}"
+                if [[ -f "$workflow_path" ]]; then
+                    ok "Workflow $file exists"
+
+                    # Check it references the expected secrets
+                    if grep -q "$secret_pattern" "$workflow_path" 2>/dev/null; then
+                        ok "Workflow $file references $secret_pattern"
+                    else
+                        fail "Workflow $file does not reference $secret_pattern"
+                    fi
+                else
+                    fail "Workflow $file does not exist"
+                fi
+            else
+                # For other repos, just check file exists via API
+                if gh api "repos/$repo/contents/.github/workflows/$file" &>/dev/null; then
+                    ok "Workflow $file exists in $repo"
+                else
+                    fail "Workflow $file does not exist in $repo"
+                fi
+            fi
+        done
+    done
+}
+
+# Check for undocumented MATHLIB_* secrets (exhaustivity)
+check_exhaustivity() {
+    echo -e "\n${BLUE}[Exhaustivity Check]${NC}"
+
+    # Get all documented secret names
+    local documented_secrets
+    documented_secrets=$(yq -r '.apps[].secrets[].app_id, .apps[].secrets[].private_key' "$CONFIG_PATH" | sort -u)
+
+    # Get all MATHLIB_* secrets from mathlib4
+    local actual_secrets
+    if ! actual_secrets=$(gh secret list --repo leanprover-community/mathlib4 2>/dev/null | awk '{print $1}' | grep "^MATHLIB_"); then
+        warn "Could not list secrets for exhaustivity check"
+        return
+    fi
+
+    # Find undocumented secrets
+    local undocumented=()
+    while IFS= read -r secret; do
+        if ! echo "$documented_secrets" | grep -q "^${secret}$"; then
+            undocumented+=("$secret")
+        fi
+    done <<< "$actual_secrets"
+
+    if [[ ${#undocumented[@]} -eq 0 ]]; then
+        ok "All MATHLIB_* secrets are documented"
+    else
+        for secret in "${undocumented[@]}"; do
+            warn "Secret $secret in mathlib4 not documented in config"
+        done
+    fi
+}
+
+# Main
+main() {
+    echo "Validating GitHub Apps configuration..."
+    echo "Config file: $CONFIG_PATH"
+
+    check_dependencies
+
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+        echo -e "${RED}Config file not found: $CONFIG_PATH${NC}"
+        exit 1
+    fi
+
+    # Validate each app
+    for slug in $(get_app_slugs); do
+        validate_app "$slug"
+    done
+
+    # Exhaustivity check
+    check_exhaustivity
+
+    # Summary
+    echo -e "\n${BLUE}────────────────────────────────────────${NC}"
+    echo -e "Summary: ${GREEN}$APPS_VALIDATED apps validated${NC}"
+    if [[ $ERRORS -gt 0 ]]; then
+        echo -e "         ${RED}$ERRORS errors${NC}"
+    fi
+    if [[ $WARNINGS -gt 0 ]]; then
+        echo -e "         ${YELLOW}$WARNINGS warnings${NC}"
+    fi
+
+    if [[ $ERRORS -gt 0 ]]; then
+        echo -e "\n${RED}Validation failed!${NC}"
+        exit 1
+    else
+        echo -e "\n${GREEN}Validation passed!${NC}"
+        exit 0
+    fi
+}
+
+main "$@"

--- a/scripts/validate-github-apps.sh
+++ b/scripts/validate-github-apps.sh
@@ -165,11 +165,16 @@ validate_app_repo_installations() {
     local slug="$1"
     local installation_id="$2"
     local org="$3"
+    local secrets_json
 
     # Note: We cannot reliably check per-repo installations without app-level authentication.
     # The /repos/{repo}/installation endpoint requires the app's JWT, not user auth.
-    # Instead, we just remind the user to verify manually for "selected" installations.
-    info "App uses 'selected' repos - verify installation includes all repos at: https://github.com/organizations/$org/settings/installations/$installation_id"
+    # List which repos need this app and remind user to verify.
+    secrets_json=$(yq -o=json ".apps[\"$slug\"].secrets // []" "$CONFIG_PATH")
+    local repos
+    repos=$(echo "$secrets_json" | jq -r '.[].repo' | sort -u | tr '\n' ', ' | sed 's/,$//')
+
+    warn "App uses 'selected' repos. Verify $repos are included at: https://github.com/organizations/$org/settings/installations/$installation_id"
 }
 
 # Validate secrets exist for an app

--- a/scripts/validate-github-apps.sh
+++ b/scripts/validate-github-apps.sh
@@ -124,10 +124,11 @@ validate_app() {
     # Check app is installed on org
     local installations
     if installations=$(gh api "/orgs/$expected_org/installations" 2>/dev/null); then
-        local installed suspended
+        local installed suspended repo_selection installation_id
         installed=$(echo "$installations" | jq -r ".installations[] | select(.app_slug == \"$slug\") | .id" | head -1)
         if [[ -n "$installed" ]]; then
             ok "App installed on $expected_org"
+            installation_id="$installed"
 
             # Check if suspended
             suspended=$(echo "$installations" | jq -r ".installations[] | select(.app_slug == \"$slug\") | .suspended_at // empty" | head -1)
@@ -135,6 +136,13 @@ validate_app() {
                 ok "App not suspended"
             else
                 fail "App is suspended!"
+            fi
+
+            # Check repository selection - if "selected", we need to verify each repo
+            repo_selection=$(echo "$installations" | jq -r ".installations[] | select(.app_slug == \"$slug\") | .repository_selection" | head -1)
+            if [[ "$repo_selection" == "selected" ]]; then
+                # App is installed on selected repos only - verify each secret repo has the app
+                validate_app_repo_installations "$slug" "$installation_id" "$expected_org"
             fi
         else
             fail "App not installed on $expected_org"
@@ -150,6 +158,18 @@ validate_app() {
     validate_app_workflows "$slug"
 
     ((APPS_VALIDATED++)) || true
+}
+
+# Validate app is installed on each repo that needs secrets (for "selected" repo installations)
+validate_app_repo_installations() {
+    local slug="$1"
+    local installation_id="$2"
+    local org="$3"
+
+    # Note: We cannot reliably check per-repo installations without app-level authentication.
+    # The /repos/{repo}/installation endpoint requires the app's JWT, not user auth.
+    # Instead, we just remind the user to verify manually for "selected" installations.
+    info "App uses 'selected' repos - verify installation includes all repos at: https://github.com/organizations/$org/settings/installations/$installation_id"
 }
 
 # Validate secrets exist for an app

--- a/scripts/validate-github-apps.sh
+++ b/scripts/validate-github-apps.sh
@@ -247,9 +247,13 @@ validate_app_workflows() {
 check_exhaustivity() {
     echo -e "\n${BLUE}[Exhaustivity Check]${NC}"
 
-    # Get all documented secret names
+    # Get all documented secret names (from apps)
     local documented_secrets
     documented_secrets=$(yq -r '.apps[].secrets[].app_id, .apps[].secrets[].private_key' "$CONFIG_PATH" | sort -u)
+
+    # Get excepted secrets (non-app secrets that are known and intentional)
+    local excepted_secrets
+    excepted_secrets=$(yq -r '.excepted_secrets[].name // ""' "$CONFIG_PATH" | sort -u)
 
     # Get all MATHLIB_* secrets from mathlib4
     local actual_secrets
@@ -261,13 +265,19 @@ check_exhaustivity() {
     # Find undocumented secrets
     local undocumented=()
     while IFS= read -r secret; do
-        if ! echo "$documented_secrets" | grep -q "^${secret}$"; then
-            undocumented+=("$secret")
+        # Skip if documented as app secret
+        if echo "$documented_secrets" | grep -q "^${secret}$"; then
+            continue
         fi
+        # Skip if in excepted list
+        if echo "$excepted_secrets" | grep -q "^${secret}$"; then
+            continue
+        fi
+        undocumented+=("$secret")
     done <<< "$actual_secrets"
 
     if [[ ${#undocumented[@]} -eq 0 ]]; then
-        ok "All MATHLIB_* secrets are documented"
+        ok "All MATHLIB_* secrets are documented or excepted"
     else
         for secret in "${undocumented[@]}"; do
             warn "Secret $secret in mathlib4 not documented in config"


### PR DESCRIPTION
This PR adds tooling to validate the GitHub Apps configuration after the recent bot account migration.

**New files:**
- `.github/github-apps.yml` - Documents all 8 GitHub Apps with their IDs, secrets, and workflow usage
- `scripts/validate-github-apps.sh` - Validates apps exist, secrets are present, and workflows reference correct secrets
- `.github/workflows/validate-github-apps.yml` - Weekly CI to run validation

**Validation checks:**
- App exists with expected ID via GitHub API
- App is installed and not suspended
- Required secrets exist in each repository
- Workflow files reference the correct secrets
- Warns about undocumented `MATHLIB_*` secrets

**Issue found:** The validation script discovered that `MATHLIB_AUTO_MERGE_APP_ID` and `MATHLIB_AUTO_MERGE_PRIVATE_KEY` secrets are missing. These need to be added for the `mathlib-auto-merge` app (ID: 2784285).

**Requirements:** `gh`, `yq`, and `jq` must be installed to run the script locally.

🤖 Prepared with Claude Code