### PR TITLE
[Merged by Bors] - chore(CI): use nightly-testing-green for tools in mathlib4-nightly-testing

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -85,8 +85,9 @@ jobs:
         with:
           # Recall that on the `leanprover-community/mathlib4-nightly-testing` repository,
           # we don't maintain a `master` branch at all.
-          # For PRs and pushes to this repository, we will use `nightly-testing` instead.
-          ref: ${{ github.repository == 'leanprover-community/mathlib4-nightly-testing' && 'nightly-testing' || 'master' }}
+          # For PRs and pushes to this repository, we will use `nightly-testing-green` instead,
+          # so that even when `nightly-testing` is broken, we can still build tools from a known good state.
+          ref: ${{ github.repository == 'leanprover-community/mathlib4-nightly-testing' && 'nightly-testing-green' || 'master' }}
           path: master-branch
 
       # Checkout the PR branch into a subdirectory


### PR DESCRIPTION
This PR changes the "background" branch used to build tools (like `cache`) during CI
on the `mathlib4-nightly-testing` repository from `nightly-testing` to `nightly-testing-green`.

When `nightly-testing` is broken (e.g., due to a Lean nightly regression), all PR testing
currently fails even for PRs that have nothing to do with the breakage, because we can't
build the tools needed to fetch the cache.

By using `nightly-testing-green` instead (which is only updated when CI passes), we ensure
that we can always build tools from a known good state.

🤖 Prepared with Claude Code