### PR TITLE
 feat(CategoryTheory/Monoidal): add the definition of categorical groups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2863,6 +2863,7 @@ public import Mathlib.CategoryTheory.Monoidal.Cartesian.InfSemilattice
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mod_
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mon_
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
+public import Mathlib.CategoryTheory.Monoidal.CategoricalGroups.Basic
 public import Mathlib.CategoryTheory.Monoidal.Category
 public import Mathlib.CategoryTheory.Monoidal.Center
 public import Mathlib.CategoryTheory.Monoidal.Closed.Basic

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -47,7 +47,6 @@ namespace CategoryTheory
 open Category MonoidalCategory
 
 
-<<<<<<< HEAD
 /-- Auxiliary structure to carry only the data fields of (and provide notation for)
 `CategoricalGroup`. -/
 class CategoricalGroupStruct (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
@@ -110,45 +109,9 @@ extends CategoricalGroupStruct C where
       ≫ (α_ (X′) X (X′)).inv ≫ (ε_ X).hom ▷ (X′) =
       (ρ_ (X′)).hom  ≫
       (λ_ (X′)).inv := by cat_disch
-=======
 
 
-/-- A braided monoidal category is a monoidal category equipped with a braiding isomorphism
-`β_ X Y : X ⊗ Y ≅ Y ⊗ X`
-which is natural in both arguments,
-and also satisfies the two hexagon identities.
--/
-class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
-  /-- The negator functor -/
-  negator : C ⥤  C
-  /-- Left cancellation isomorphism, usually denoted by ε -/
-  cancel_left : ∀ X : C, negator.obj X ⊗ X ≅ 𝟙_ C
-  /-- Right cancellation isomorphism, usually denoted by η -/
-  cancel_right : ∀ X : C, 𝟙_ C ≅ X ⊗ negator.obj X
-  cancel_naturality_left :
-    ∀  {X Y : C} (f : X ⟶ Y),
-      (negator.map f) ▷ X ≫ (negator.obj Y) ◁ f ≫ (cancel_left Y).hom = (cancel_left X).hom  := by
-    cat_disch
-  cancel_naturality_right :
-    ∀ {X Y : C} (f : X ⟶ Y),
-      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).inv)
-        = (cancel_right X).inv := by
-    cat_disch
->>>>>>> 1382fcff18 (The definition is complete)
 
-  cancellation_right :
-    ∀ X : C,
-      (λ_ X).inv ≫ (cancel_right X).hom ▷ X ≫ (α_ X (negator.obj X) X).hom ≫
-        X ◁ (cancel_left X).hom ≫ (ρ_ X).hom = 𝟙 X  := by cat_disch
-
-  cancellation_left :
-    ∀ X : C,
-      (ρ_ (negator.obj X)).inv ≫ (negator.obj X) ◁ (cancel_right X).hom
-      ≫ (α_ (negator.obj X) X (negator.obj X)).inv ≫ (cancel_left X).hom ▷ (negator.obj X) ≫
-      (λ_ (negator.obj X)).hom = 𝟙 (negator.obj X) := by cat_disch
-
-
-<<<<<<< HEAD
 attribute [reassoc (attr := simp)]
   CategoricalGroup.zigzag_1
 attribute [reassoc (attr := simp)]
@@ -159,23 +122,6 @@ namespace CategoricalGroup
 
 variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup C]
 
-=======
-
-attribute [reassoc (attr := simp)]
-  CategoricalGroup.cancellation_right
-  CategoricalGroup.cancellation_left
--- attribute [reassoc] CategoricalGroup.cancellation_left CategoricalGroup.cancellation_right
-
-open CategoricalGroup
-
-@[inherit_doc]
-notation "η_" => CategoricalGroup.cancel_right
-notation "ε_" => CategoricalGroup.cancel_left
-
-namespace CategoricalGroup
-
-variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup.{v} C]
->>>>>>> 1382fcff18 (The definition is complete)
 
 /-- The negator on morphisms -/
 def negatorHom {X Y : C} (f : X ⟶ Y) : X′ ⟶ Y′ :=

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2025 Amogh Parab. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Amogh Parab
+-/
+import Mathlib.CategoryTheory.Monoidal.Discrete
+import Mathlib.CategoryTheory.Monoidal.NaturalTransformation
+import Mathlib.CategoryTheory.Monoidal.Opposite
+import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
+import Mathlib.CategoryTheory.CommSq
+
+/-!
+# Categorical Groups
+
+The basic definitions of categorical groups, symmetric categorical groups, and
+categorical group functors.
+
+## Implementation note
+
+We make `BraidedCategory` another typeclass, but then have `SymmetricCategory` extend this.
+The rationale is that we are not carrying any additional data, just requiring a property.
+
+## Future work
+
+* Construct the Drinfeld center of a monoidal category as a braided monoidal category.
+* Say something about pseudo-natural transformations.
+
+## References
+
+* [Pavel Etingof, Shlomo Gelaki, Dmitri Nikshych, Victor Ostrik, *Tensor categories*][egno15]
+
+-/
+
+
+
+universe v v₁ v₂ v₃ u u₁ u₂ u₃
+
+namespace CategoryTheory
+
+open Category MonoidalCategory Functor.LaxMonoidal Functor.OplaxMonoidal Functor.Monoidal
+
+/-- A braided monoidal category is a monoidal category equipped with a braiding isomorphism
+`β_ X Y : X ⊗ Y ≅ Y ⊗ X`
+which is natural in both arguments,
+and also satisfies the two hexagon identities.
+-/
+class CategoricalGroup (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where
+  /-- The negator functor -/
+  negator : C ⥤  C
+  /-- Left cancellation isomorphism -/
+  cancel_left : ∀ X : C, negator.obj X ⊗ X ≅ 𝟙_ C
+  /-- Right cancellation isomorphism -/
+  cancel_right : ∀ X : C, X ⊗ negator.obj X ≅ 𝟙_ C
+  cancel_naturality_left :
+    ∀  {X Y : C} (f : X ⟶ Y),
+      (negator.map f) ▷ X ≫ (negator.obj Y) ◁ f ≫ (cancel_left Y).hom = (cancel_left X).hom  := by
+    cat_disch
+  cancel_naturality_right :
+    ∀ {X Y : C} (f : X ⟶ Y),
+      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).hom) = (cancel_right X).hom := by
+    cat_disch
+
+
+
+
+  /-- The first hexagon identity. -/
+  hexagon_forward :
+    ∀ X Y Z : C,
+      (α_ X Y Z).hom ≫ (braiding X (Y ⊗ Z)).hom ≫ (α_ Y Z X).hom =
+        ((braiding X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫ (Y ◁ (braiding X Z).hom) := by
+    cat_disch
+  /-- The second hexagon identity. -/
+  hexagon_reverse :
+    ∀ X Y Z : C,
+      (α_ X Y Z).inv ≫ (braiding (X ⊗ Y) Z).hom ≫ (α_ Z X Y).inv =
+        (X ◁ (braiding Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((braiding X Z).hom ▷ Y) := by
+    cat_disch
+
+attribute [reassoc (attr := simp)]
+  BraidedCategory.braiding_naturality_left
+  BraidedCategory.braiding_naturality_right
+attribute [reassoc] BraidedCategory.hexagon_forward BraidedCategory.hexagon_reverse
+
+open BraidedCategory
+
+@[inherit_doc]
+notation "β_" => BraidedCategory.braiding
+
+namespace BraidedCategory
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+
+@[simp, reassoc]
+theorem braiding_tensor_left_hom (X Y Z : C) :
+    (β_ (X ⊗ Y) Z).hom  =
+      (α_ X Y Z).hom ≫ X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫
+        (β_ X Z).hom ▷ Y ≫ (α_ Z X Y).hom := by
+  apply (cancel_epi (α_ X Y Z).inv).1
+  apply (cancel_mono (α_ Z X Y).inv).1
+  simp [hexagon_reverse]
+
+@[deprecated (since := "2025-06-24")] alias braiding_tensor_left := braiding_tensor_left_hom
+
+@[simp, reassoc]
+theorem braiding_tensor_right_hom (X Y Z : C) :
+    (β_ X (Y ⊗ Z)).hom  =
+      (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
+        Y ◁ (β_ X Z).hom ≫ (α_ Y Z X).inv := by
+  apply (cancel_epi (α_ X Y Z).hom).1
+  apply (cancel_mono (α_ Y Z X).hom).1
+  simp [hexagon_forward]
+
+@[deprecated (since := "2025-06-24")] alias braiding_tensor_right := braiding_tensor_right_hom
+
+@[simp, reassoc]
+theorem braiding_tensor_left_inv (X Y Z : C) :
+    (β_ (X ⊗ Y) Z).inv  =
+      (α_ Z X Y).inv ≫ (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫
+        X ◁ (β_ Y Z).inv ≫ (α_ X Y Z).inv :=
+  eq_of_inv_eq_inv (by simp)
+
+@[deprecated (since := "2025-06-24")] alias braiding_inv_tensor_left := braiding_tensor_left_inv
+
+@[simp, reassoc]
+theorem braiding_tensor_right_inv (X Y Z : C) :
+    (β_ X (Y ⊗ Z)).inv  =
+      (α_ Y Z X).hom ≫ Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫
+        (β_ X Y).inv ▷ Z ≫ (α_ X Y Z).hom :=
+  eq_of_inv_eq_inv (by simp)
+
+@[deprecated (since := "2025-06-24")] alias braiding_inv_tensor_right := braiding_tensor_right_inv
+
+@[reassoc (attr := simp)]
+theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
+    (f ⊗ₘ g) ≫ (braiding Y Y').hom = (braiding X X').hom ≫ (g ⊗ₘ f) := by
+  rw [tensorHom_def' f g, tensorHom_def g f]
+  simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
+
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality_right (X : C) {Y Z : C} (f : Y ⟶ Z) :
+    X ◁ f ≫ (β_ Z X).inv = (β_ Y X).inv ≫ f ▷ X :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_left f X
+
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality_left {X Y : C} (f : X ⟶ Y) (Z : C) :
+    f ▷ Z ≫ (β_ Z Y).inv = (β_ Z X).inv ≫ Z ◁ f :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_right Z f
+
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
+    (f ⊗ₘ g) ≫ (β_ Y' Y).inv = (β_ X' X).inv ≫ (g ⊗ₘ f) :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality g f
+
+/-- In a braided monoidal category, the functors `tensorLeft X` and
+`tensorRight X` are isomorphic. -/
+@[simps]
+def tensorLeftIsoTensorRight (X : C) :
+    tensorLeft X ≅ tensorRight X where
+  hom := { app Y := (β_ X Y).hom }
+  inv := { app Y := (β_ X Y).inv }
+
+@[reassoc]
+theorem yang_baxter (X Y Z : C) :
+    (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
+    Y ◁ (β_ X Z).hom ≫ (α_ Y Z X).inv ≫ (β_ Y Z).hom ▷ X ≫ (α_ Z Y X).hom =
+      X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫ (β_ X Z).hom ▷ Y ≫
+      (α_ Z X Y).hom ≫ Z ◁ (β_ X Y).hom := by
+  rw [← braiding_tensor_right_hom_assoc X Y Z, ← cancel_mono (α_ Z Y X).inv]
+  repeat rw [assoc]
+  rw [Iso.hom_inv_id, comp_id, ← braiding_naturality_right, braiding_tensor_right_hom]
+
+theorem yang_baxter' (X Y Z : C) :
+    (β_ X Y).hom ▷ Z ⊗≫ Y ◁ (β_ X Z).hom ⊗≫ (β_ Y Z).hom ▷ X =
+      𝟙 _ ⊗≫ (X ◁ (β_ Y Z).hom ⊗≫ (β_ X Z).hom ▷ Y ⊗≫ Z ◁ (β_ X Y).hom) ⊗≫ 𝟙 _ := by
+  rw [← cancel_epi (α_ X Y Z).inv, ← cancel_mono (α_ Z Y X).hom]
+  convert yang_baxter X Y Z using 1
+  all_goals monoidal
+
+theorem yang_baxter_iso (X Y Z : C) :
+    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫
+    whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm ≪≫
+    whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X) =
+      whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫
+      whiskerRightIso (β_ X Z) Y ≪≫ α_ Z X Y ≪≫
+      whiskerLeftIso Z (β_ X Y) := Iso.ext (yang_baxter X Y Z)
+
+theorem hexagon_forward_iso (X Y Z : C) :
+    α_ X Y Z ≪≫ β_ X (Y ⊗ Z) ≪≫ α_ Y Z X =
+      whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫ whiskerLeftIso Y (β_ X Z) :=
+  Iso.ext (hexagon_forward X Y Z)
+
+theorem hexagon_reverse_iso (X Y Z : C) :
+    (α_ X Y Z).symm ≪≫ β_ (X ⊗ Y) Z ≪≫ (α_ Z X Y).symm =
+      whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫ whiskerRightIso (β_ X Z) Y :=
+  Iso.ext (hexagon_reverse X Y Z)
+
+@[reassoc]
+theorem hexagon_forward_inv (X Y Z : C) :
+    (α_ Y Z X).inv ≫ (β_ X (Y ⊗ Z)).inv ≫ (α_ X Y Z).inv =
+      Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫ (β_ X Y).inv ▷ Z := by
+  simp
+
+@[reassoc]
+theorem hexagon_reverse_inv (X Y Z : C) :
+    (α_ Z X Y).hom ≫ (β_ (X ⊗ Y) Z).inv ≫ (α_ X Y Z).hom =
+      (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫ X ◁ (β_ Y Z).inv := by
+  simp
+
+end BraidedCategory
+
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Amogh Parab. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amogh Parab
 -/
-import Mathlib.CategoryTheory.Monoidal.Discrete
-import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Discrete
+public import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
 
 /-!
 # Categorical Groups
@@ -38,7 +40,7 @@ Appl. Categ., 12:423–491, 2004
 
 -/
 
-
+@[expose] public section
 
 universe u v
 

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -47,6 +47,7 @@ namespace CategoryTheory
 open Category MonoidalCategory
 
 
+<<<<<<< HEAD
 /-- Auxiliary structure to carry only the data fields of (and provide notation for)
 `CategoricalGroup`. -/
 class CategoricalGroupStruct (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
@@ -109,9 +110,45 @@ extends CategoricalGroupStruct C where
       ≫ (α_ (X′) X (X′)).inv ≫ (ε_ X).hom ▷ (X′) =
       (ρ_ (X′)).hom  ≫
       (λ_ (X′)).inv := by cat_disch
+=======
 
 
+/-- A braided monoidal category is a monoidal category equipped with a braiding isomorphism
+`β_ X Y : X ⊗ Y ≅ Y ⊗ X`
+which is natural in both arguments,
+and also satisfies the two hexagon identities.
+-/
+class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
+  /-- The negator functor -/
+  negator : C ⥤  C
+  /-- Left cancellation isomorphism, usually denoted by ε -/
+  cancel_left : ∀ X : C, negator.obj X ⊗ X ≅ 𝟙_ C
+  /-- Right cancellation isomorphism, usually denoted by η -/
+  cancel_right : ∀ X : C, 𝟙_ C ≅ X ⊗ negator.obj X
+  cancel_naturality_left :
+    ∀  {X Y : C} (f : X ⟶ Y),
+      (negator.map f) ▷ X ≫ (negator.obj Y) ◁ f ≫ (cancel_left Y).hom = (cancel_left X).hom  := by
+    cat_disch
+  cancel_naturality_right :
+    ∀ {X Y : C} (f : X ⟶ Y),
+      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).inv)
+        = (cancel_right X).inv := by
+    cat_disch
+>>>>>>> 1382fcff18 (The definition is complete)
 
+  cancellation_right :
+    ∀ X : C,
+      (λ_ X).inv ≫ (cancel_right X).hom ▷ X ≫ (α_ X (negator.obj X) X).hom ≫
+        X ◁ (cancel_left X).hom ≫ (ρ_ X).hom = 𝟙 X  := by cat_disch
+
+  cancellation_left :
+    ∀ X : C,
+      (ρ_ (negator.obj X)).inv ≫ (negator.obj X) ◁ (cancel_right X).hom
+      ≫ (α_ (negator.obj X) X (negator.obj X)).inv ≫ (cancel_left X).hom ▷ (negator.obj X) ≫
+      (λ_ (negator.obj X)).hom = 𝟙 (negator.obj X) := by cat_disch
+
+
+<<<<<<< HEAD
 attribute [reassoc (attr := simp)]
   CategoricalGroup.zigzag_1
 attribute [reassoc (attr := simp)]
@@ -122,6 +159,23 @@ namespace CategoricalGroup
 
 variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup C]
 
+=======
+
+attribute [reassoc (attr := simp)]
+  CategoricalGroup.cancellation_right
+  CategoricalGroup.cancellation_left
+-- attribute [reassoc] CategoricalGroup.cancellation_left CategoricalGroup.cancellation_right
+
+open CategoricalGroup
+
+@[inherit_doc]
+notation "η_" => CategoricalGroup.cancel_right
+notation "ε_" => CategoricalGroup.cancel_left
+
+namespace CategoricalGroup
+
+variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup.{v} C]
+>>>>>>> 1382fcff18 (The definition is complete)
 
 /-- The negator on morphisms -/
 def negatorHom {X Y : C} (f : X ⟶ Y) : X′ ⟶ Y′ :=

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -39,56 +39,58 @@ namespace CategoryTheory
 
 open Category MonoidalCategory Functor.LaxMonoidal Functor.OplaxMonoidal Functor.Monoidal
 
+
+
+
 /-- A braided monoidal category is a monoidal category equipped with a braiding isomorphism
 `β_ X Y : X ⊗ Y ≅ Y ⊗ X`
 which is natural in both arguments,
 and also satisfies the two hexagon identities.
 -/
-class CategoricalGroup (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where
+class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
   /-- The negator functor -/
   negator : C ⥤  C
-  /-- Left cancellation isomorphism -/
+  /-- Left cancellation isomorphism, usually denoted by ε -/
   cancel_left : ∀ X : C, negator.obj X ⊗ X ≅ 𝟙_ C
-  /-- Right cancellation isomorphism -/
-  cancel_right : ∀ X : C, X ⊗ negator.obj X ≅ 𝟙_ C
+  /-- Right cancellation isomorphism, usually denoted by η -/
+  cancel_right : ∀ X : C, 𝟙_ C ≅ X ⊗ negator.obj X
   cancel_naturality_left :
     ∀  {X Y : C} (f : X ⟶ Y),
       (negator.map f) ▷ X ≫ (negator.obj Y) ◁ f ≫ (cancel_left Y).hom = (cancel_left X).hom  := by
     cat_disch
   cancel_naturality_right :
     ∀ {X Y : C} (f : X ⟶ Y),
-      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).hom) = (cancel_right X).hom := by
+      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).inv)
+        = (cancel_right X).inv := by
     cat_disch
 
+  cancellation_right :
+    ∀ X : C,
+      (λ_ X).inv ≫ (cancel_right X).hom ▷ X ≫ (α_ X (negator.obj X) X).hom ≫
+        X ◁ (cancel_left X).hom ≫ (ρ_ X).hom = 𝟙 X  := by cat_disch
+
+  cancellation_left :
+    ∀ X : C,
+      (ρ_ (negator.obj X)).inv ≫ (negator.obj X) ◁ (cancel_right X).hom
+      ≫ (α_ (negator.obj X) X (negator.obj X)).inv ≫ (cancel_left X).hom ▷ (negator.obj X) ≫
+      (λ_ (negator.obj X)).hom = 𝟙 (negator.obj X) := by cat_disch
 
 
-
-  /-- The first hexagon identity. -/
-  hexagon_forward :
-    ∀ X Y Z : C,
-      (α_ X Y Z).hom ≫ (braiding X (Y ⊗ Z)).hom ≫ (α_ Y Z X).hom =
-        ((braiding X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫ (Y ◁ (braiding X Z).hom) := by
-    cat_disch
-  /-- The second hexagon identity. -/
-  hexagon_reverse :
-    ∀ X Y Z : C,
-      (α_ X Y Z).inv ≫ (braiding (X ⊗ Y) Z).hom ≫ (α_ Z X Y).inv =
-        (X ◁ (braiding Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((braiding X Z).hom ▷ Y) := by
-    cat_disch
 
 attribute [reassoc (attr := simp)]
-  BraidedCategory.braiding_naturality_left
-  BraidedCategory.braiding_naturality_right
-attribute [reassoc] BraidedCategory.hexagon_forward BraidedCategory.hexagon_reverse
+  CategoricalGroup.cancellation_right
+  CategoricalGroup.cancellation_left
+-- attribute [reassoc] CategoricalGroup.cancellation_left CategoricalGroup.cancellation_right
 
-open BraidedCategory
+open CategoricalGroup
 
 @[inherit_doc]
-notation "β_" => BraidedCategory.braiding
+notation "η_" => CategoricalGroup.cancel_right
+notation "ε_" => CategoricalGroup.cancel_left
 
-namespace BraidedCategory
+namespace CategoricalGroup
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup.{v} C]
 
 @[simp, reassoc]
 theorem braiding_tensor_left_hom (X Y Z : C) :

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -1,214 +1,133 @@
 /-
-Copyright (c) 2025 Amogh Parab. All rights reserved.
+Copyright (c) 2026 Amogh Parab. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amogh Parab
 -/
 import Mathlib.CategoryTheory.Monoidal.Discrete
-import Mathlib.CategoryTheory.Monoidal.NaturalTransformation
-import Mathlib.CategoryTheory.Monoidal.Opposite
 import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
-import Mathlib.CategoryTheory.CommSq
 
 /-!
 # Categorical Groups
 
-The basic definitions of categorical groups, symmetric categorical groups, and
-categorical group functors.
+A categorical group is a monoidal category equipped with a negator, and cancellation isomorphisms.
+In the definition, we provide the negator as a function
+* `negatorObj : C ⟶ C`
+on objects. We use the notation `X′` for `negatorObj X`.
+The unit and counit isomorphisms are provided componentwise. The unit and counit isomorphisms must
+satisfy coherence conditions called the zigzag identities.
+
+With the zigzag identities, we can show that the negator extends to a functor and
+the unit and counit isomorphisms are natural.
 
 ## Implementation note
 
-We make `BraidedCategory` another typeclass, but then have `SymmetricCategory` extend this.
-The rationale is that we are not carrying any additional data, just requiring a property.
+We make `CategoricalGroupStruct` as a typeclass to carry
+only the data fields, but then have `CategoricalGroup` extend this.
 
 ## Future work
 
-* Construct the Drinfeld center of a monoidal category as a braided monoidal category.
-* Say something about pseudo-natural transformations.
+* Extend `negatorObj` to a functor `negator : C ⥤ C` and
+unit and counit isomorphisms to natural isomorphisms.
+* Add basic lemmas.
+* Extend categorical groups to symmetric categorical groups by adding a braiding.
 
 ## References
 
-* [Pavel Etingof, Shlomo Gelaki, Dmitri Nikshych, Victor Ostrik, *Tensor categories*][egno15]
+* John C. Baez and Aaron D. Lauda. Higher-dimensional algebra V: 2-groups. Theory
+Appl. Categ., 12:423–491, 2004
 
 -/
 
 
 
-universe v v₁ v₂ v₃ u u₁ u₂ u₃
+universe u v
 
 namespace CategoryTheory
 
-open Category MonoidalCategory Functor.LaxMonoidal Functor.OplaxMonoidal Functor.Monoidal
+open Category MonoidalCategory
 
 
+/-- Auxiliary structure to carry only the data fields of (and provide notation for)
+`CategoricalGroup`. -/
+class CategoricalGroupStruct (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
+  /-- The negator of objects -/
+  negatorObj : C → C
+  /-- The counit isomorphism, usually denoted by ε -/
+  counit : ∀ X : C, negatorObj X ⊗ X ≅ 𝟙_ C
+  /-- The unit isomorphism, usually denoted by η -/
+  unit : ∀ X : C, 𝟙_ C ≅ X ⊗ negatorObj X
+
+namespace CategoricalGroup
+
+export CategoricalGroupStruct (negatorObj counit unit)
+
+end CategoricalGroup
 
 
-/-- A braided monoidal category is a monoidal category equipped with a braiding isomorphism
-`β_ X Y : X ⊗ Y ≅ Y ⊗ X`
-which is natural in both arguments,
-and also satisfies the two hexagon identities.
+namespace CategoricalGroup
+
+/-- Notation for `negatorObj`, the negator on objects in a categorical group -/
+scoped postfix:70 "′" => CategoricalGroup.negatorObj
+
+
+/-- Notation for the `unit` : `𝟙 ≅ X ⊗ X'` -/
+scoped notation "η_ " => CategoricalGroup.unit
+
+/-- Notation for the `counit` : `X' ⊗ X ≅ 𝟙` -/
+scoped notation "ε_ " => CategoricalGroup.counit
+
+
+end CategoricalGroup
+
+
+open CategoricalGroup
+
+/-- A categorical group is a monoidal category equipped with a negator function `(-)′ : C → C`, and
+cancellation natural isomorphisms
+`η_ X : 𝟙 ≅ X ⊗ X'`
+`ε_ X : X' ⊗ X ≅ 𝟙`,
+and also satisfies the cancellation identities.
 -/
-class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C] where
-  /-- The negator functor -/
-  negator : C ⥤  C
-  /-- Left cancellation isomorphism, usually denoted by ε -/
-  cancel_left : ∀ X : C, negator.obj X ⊗ X ≅ 𝟙_ C
-  /-- Right cancellation isomorphism, usually denoted by η -/
-  cancel_right : ∀ X : C, 𝟙_ C ≅ X ⊗ negator.obj X
-  cancel_naturality_left :
-    ∀  {X Y : C} (f : X ⟶ Y),
-      (negator.map f) ▷ X ≫ (negator.obj Y) ◁ f ≫ (cancel_left Y).hom = (cancel_left X).hom  := by
-    cat_disch
-  cancel_naturality_right :
-    ∀ {X Y : C} (f : X ⟶ Y),
-      (X ◁ (negator.map f)) ≫ (f ▷ (negator.obj Y)) ≫ ((cancel_right Y).inv)
-        = (cancel_right X).inv := by
-    cat_disch
-
-  cancellation_right :
+class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C]
+extends CategoricalGroupStruct C where
+  /--
+  The zigzag identity relating the isomorphisms between
+  `𝟙 ⊗ X` and `X ⊗ 𝟙`
+  -/
+  zigzag_1 :
     ∀ X : C,
-      (λ_ X).inv ≫ (cancel_right X).hom ▷ X ≫ (α_ X (negator.obj X) X).hom ≫
-        X ◁ (cancel_left X).hom ≫ (ρ_ X).hom = 𝟙 X  := by cat_disch
+      (η_ X).hom ▷ X ≫ (α_ X (X′) X).hom ≫
+        X ◁ (ε_ X).hom = (λ_ X).hom ≫ (ρ_ X).inv  := by cat_disch
 
-  cancellation_left :
+  /--
+  The zigzag identity relating the isomorphisms between
+  `X′ ⊗ 𝟙` and `𝟙 ⊗ X′`
+  -/
+  zigzag_2 :
     ∀ X : C,
-      (ρ_ (negator.obj X)).inv ≫ (negator.obj X) ◁ (cancel_right X).hom
-      ≫ (α_ (negator.obj X) X (negator.obj X)).inv ≫ (cancel_left X).hom ▷ (negator.obj X) ≫
-      (λ_ (negator.obj X)).hom = 𝟙 (negator.obj X) := by cat_disch
+      (X′) ◁ (η_ X).hom
+      ≫ (α_ (X′) X (X′)).inv ≫ (ε_ X).hom ▷ (X′) =
+      (ρ_ (X′)).hom  ≫
+      (λ_ (X′)).inv := by cat_disch
 
 
 
 attribute [reassoc (attr := simp)]
-  CategoricalGroup.cancellation_right
-  CategoricalGroup.cancellation_left
--- attribute [reassoc] CategoricalGroup.cancellation_left CategoricalGroup.cancellation_right
+  CategoricalGroup.zigzag_1
+attribute [reassoc (attr := simp)]
+  CategoricalGroup.zigzag_2
 
-open CategoricalGroup
-
-@[inherit_doc]
-notation "η_" => CategoricalGroup.cancel_right
-notation "ε_" => CategoricalGroup.cancel_left
 
 namespace CategoricalGroup
 
-variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup.{v} C]
+variable {C : Type u} [Groupoid.{v} C] [MonoidalCategory.{v} C] [CategoricalGroup C]
 
-@[simp, reassoc]
-theorem braiding_tensor_left_hom (X Y Z : C) :
-    (β_ (X ⊗ Y) Z).hom  =
-      (α_ X Y Z).hom ≫ X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫
-        (β_ X Z).hom ▷ Y ≫ (α_ Z X Y).hom := by
-  apply (cancel_epi (α_ X Y Z).inv).1
-  apply (cancel_mono (α_ Z X Y).inv).1
-  simp [hexagon_reverse]
 
-@[deprecated (since := "2025-06-24")] alias braiding_tensor_left := braiding_tensor_left_hom
+/-- The negator on morphisms -/
+def negatorHom {X Y : C} (f : X ⟶ Y) : X′ ⟶ Y′ :=
+  (ρ_ (X′)).inv ≫ (X′) ◁ (η_ Y).hom ≫ (α_ (X′) Y (Y′)).inv ≫ ((X′) ◁ (Groupoid.inv f)) ▷ (Y′) ≫
+    (ε_ X).hom ▷ (Y′) ≫ (λ_ (Y′)).hom
 
-@[simp, reassoc]
-theorem braiding_tensor_right_hom (X Y Z : C) :
-    (β_ X (Y ⊗ Z)).hom  =
-      (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
-        Y ◁ (β_ X Z).hom ≫ (α_ Y Z X).inv := by
-  apply (cancel_epi (α_ X Y Z).hom).1
-  apply (cancel_mono (α_ Y Z X).hom).1
-  simp [hexagon_forward]
-
-@[deprecated (since := "2025-06-24")] alias braiding_tensor_right := braiding_tensor_right_hom
-
-@[simp, reassoc]
-theorem braiding_tensor_left_inv (X Y Z : C) :
-    (β_ (X ⊗ Y) Z).inv  =
-      (α_ Z X Y).inv ≫ (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫
-        X ◁ (β_ Y Z).inv ≫ (α_ X Y Z).inv :=
-  eq_of_inv_eq_inv (by simp)
-
-@[deprecated (since := "2025-06-24")] alias braiding_inv_tensor_left := braiding_tensor_left_inv
-
-@[simp, reassoc]
-theorem braiding_tensor_right_inv (X Y Z : C) :
-    (β_ X (Y ⊗ Z)).inv  =
-      (α_ Y Z X).hom ≫ Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫
-        (β_ X Y).inv ▷ Z ≫ (α_ X Y Z).hom :=
-  eq_of_inv_eq_inv (by simp)
-
-@[deprecated (since := "2025-06-24")] alias braiding_inv_tensor_right := braiding_tensor_right_inv
-
-@[reassoc (attr := simp)]
-theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
-    (f ⊗ₘ g) ≫ (braiding Y Y').hom = (braiding X X').hom ≫ (g ⊗ₘ f) := by
-  rw [tensorHom_def' f g, tensorHom_def g f]
-  simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
-
-@[reassoc (attr := simp)]
-theorem braiding_inv_naturality_right (X : C) {Y Z : C} (f : Y ⟶ Z) :
-    X ◁ f ≫ (β_ Z X).inv = (β_ Y X).inv ≫ f ▷ X :=
-  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_left f X
-
-@[reassoc (attr := simp)]
-theorem braiding_inv_naturality_left {X Y : C} (f : X ⟶ Y) (Z : C) :
-    f ▷ Z ≫ (β_ Z Y).inv = (β_ Z X).inv ≫ Z ◁ f :=
-  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_right Z f
-
-@[reassoc (attr := simp)]
-theorem braiding_inv_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
-    (f ⊗ₘ g) ≫ (β_ Y' Y).inv = (β_ X' X).inv ≫ (g ⊗ₘ f) :=
-  CommSq.w <| .vert_inv <| .mk <| braiding_naturality g f
-
-/-- In a braided monoidal category, the functors `tensorLeft X` and
-`tensorRight X` are isomorphic. -/
-@[simps]
-def tensorLeftIsoTensorRight (X : C) :
-    tensorLeft X ≅ tensorRight X where
-  hom := { app Y := (β_ X Y).hom }
-  inv := { app Y := (β_ X Y).inv }
-
-@[reassoc]
-theorem yang_baxter (X Y Z : C) :
-    (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
-    Y ◁ (β_ X Z).hom ≫ (α_ Y Z X).inv ≫ (β_ Y Z).hom ▷ X ≫ (α_ Z Y X).hom =
-      X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫ (β_ X Z).hom ▷ Y ≫
-      (α_ Z X Y).hom ≫ Z ◁ (β_ X Y).hom := by
-  rw [← braiding_tensor_right_hom_assoc X Y Z, ← cancel_mono (α_ Z Y X).inv]
-  repeat rw [assoc]
-  rw [Iso.hom_inv_id, comp_id, ← braiding_naturality_right, braiding_tensor_right_hom]
-
-theorem yang_baxter' (X Y Z : C) :
-    (β_ X Y).hom ▷ Z ⊗≫ Y ◁ (β_ X Z).hom ⊗≫ (β_ Y Z).hom ▷ X =
-      𝟙 _ ⊗≫ (X ◁ (β_ Y Z).hom ⊗≫ (β_ X Z).hom ▷ Y ⊗≫ Z ◁ (β_ X Y).hom) ⊗≫ 𝟙 _ := by
-  rw [← cancel_epi (α_ X Y Z).inv, ← cancel_mono (α_ Z Y X).hom]
-  convert yang_baxter X Y Z using 1
-  all_goals monoidal
-
-theorem yang_baxter_iso (X Y Z : C) :
-    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫
-    whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm ≪≫
-    whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X) =
-      whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫
-      whiskerRightIso (β_ X Z) Y ≪≫ α_ Z X Y ≪≫
-      whiskerLeftIso Z (β_ X Y) := Iso.ext (yang_baxter X Y Z)
-
-theorem hexagon_forward_iso (X Y Z : C) :
-    α_ X Y Z ≪≫ β_ X (Y ⊗ Z) ≪≫ α_ Y Z X =
-      whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫ whiskerLeftIso Y (β_ X Z) :=
-  Iso.ext (hexagon_forward X Y Z)
-
-theorem hexagon_reverse_iso (X Y Z : C) :
-    (α_ X Y Z).symm ≪≫ β_ (X ⊗ Y) Z ≪≫ (α_ Z X Y).symm =
-      whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫ whiskerRightIso (β_ X Z) Y :=
-  Iso.ext (hexagon_reverse X Y Z)
-
-@[reassoc]
-theorem hexagon_forward_inv (X Y Z : C) :
-    (α_ Y Z X).inv ≫ (β_ X (Y ⊗ Z)).inv ≫ (α_ X Y Z).inv =
-      Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫ (β_ X Y).inv ▷ Z := by
-  simp
-
-@[reassoc]
-theorem hexagon_reverse_inv (X Y Z : C) :
-    (α_ Z X Y).hom ≫ (β_ (X ⊗ Y) Z).inv ≫ (α_ X Y Z).hom =
-      (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫ X ◁ (β_ Y Z).inv := by
-  simp
-
-end BraidedCategory
-
+end CategoricalGroup
 
 end CategoryTheory


### PR DESCRIPTION
This PR defines of categorical groups, also known as coherent 2-groups, in mathlib.

Motivation:
Categorical groups are well-studied structures in monoidal category theory, but are not currently available in mathlib. The definitions in this PR follow the existing design patterns used for Category, MonoidalCategory, and BraidedCategory.

This PR focuses on setting up the core structure and notation. Basic lemmas and further developments will be provided in a subsequent PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
