### PR TITLE
feat(CategoryTheory/Monoidal): add definition of categorical groups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2890,6 +2890,7 @@ public import Mathlib.CategoryTheory.Monoidal.Cartesian.InfSemilattice
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mod_
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mon_
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
+public import Mathlib.CategoryTheory.Monoidal.CategoricalGroups.Basic
 public import Mathlib.CategoryTheory.Monoidal.Category
 public import Mathlib.CategoryTheory.Monoidal.Center
 public import Mathlib.CategoryTheory.Monoidal.Closed.Basic

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -84,6 +84,7 @@ def evaluationIso (X : C) : Xᘁ ⊗ X ≅ 𝟙_ C where
 /--
 The counit (coevaluation) isomorphism of a categorical group.
 -/
+@[simps!]
 def coevaluationIso (X : C) : 𝟙_ C ≅ X ⊗ Xᘁ where
   hom := η_ X Xᘁ
   inv := Groupoid.inv (η_ X Xᘁ)

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -113,9 +113,7 @@ lemma evaluation_coevaluation_iso (X : C) :
 
 instance ExactPairing.of_rightDual_self (X : C) : ExactPairing Xᘁ X where
   coevaluation' := (evaluationIso X).inv
-
   evaluation' := (coevaluationIso X).inv
-
   coevaluation_evaluation' := by
     have : whiskerLeftIso X (evaluationIso X).symm ≪≫
     (α_ X Xᘁ X).symm ≪≫ whiskerRightIso (coevaluationIso X).symm X

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -22,9 +22,8 @@ the unit and counit isomorphisms are natural.
 
 ## Implementation note
 
-
-We make `CategoricalGroup` as a typeclass with
-MonoidalCategory, Groupoid, and RightRigidCategory as subclasses with no additional conditions.
+A `CategoricalGroup` consists of
+MonoidalCategory, Groupoid, and RightRigidCategory typeclasses.
 Right rigidity gives the negator (right dual),
 the counit morphism (coevaluation), and the unit morphism (evaluation).
 With the groupoid structure, we can construct the unit and counit isomorphisms from the unit and
@@ -67,11 +66,6 @@ variable {C : Type u} [Groupoid.{v} C]
   [MonoidalCategory.{v} C] [RightRigidCategory C]
 
 /--
-Negator of an object in a categorical group is the right dual of the object.
--/
-def negatorObj (X : C) : C := Xᘁ
-
-/--
 The unit (evaluation) isomorphism of a categorical group.
 -/
 @[simps!]
@@ -111,52 +105,47 @@ lemma evaluation_coevaluation_iso (X : C) :
   simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom]
   exact ExactPairing.evaluation_coevaluation X Xᘁ
 
-
-
-instance ExactPairing.of_rightDual_self (X : C) : ExactPairing Xᘁ X where
+instance ExactPairing.ofRightDualSelf (X : C) : ExactPairing Xᘁ X where
   coevaluation' := (evaluationIso X).inv
   evaluation' := (coevaluationIso X).inv
   coevaluation_evaluation' := by
     have : whiskerLeftIso X (evaluationIso X).symm ≪≫
     (α_ X Xᘁ X).symm ≪≫ whiskerRightIso (coevaluationIso X).symm X
     = (ρ_ X) ≪≫ (λ_ X).symm := by
-      apply_fun (fun f => f.symm)
-      · simp only [Iso.trans_symm, whiskerRightIso_symm, Iso.symm_symm_eq, whiskerLeftIso_symm,
+      apply Iso.symm_bijective.injective
+      simp only [Iso.trans_symm, whiskerRightIso_symm, Iso.symm_symm_eq, whiskerLeftIso_symm,
         Iso.trans_assoc]
-        exact evaluation_coevaluation_iso X
-      · simp only [Iso.symm_bijective.injective]
-    apply_fun (fun f => f.hom) at this
-    simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom] at this
-    exact this
-
+      exact evaluation_coevaluation_iso X
+    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
+      congr($(this).hom)
 
   evaluation_coevaluation' := by
     have : whiskerRightIso (evaluationIso X).symm Xᘁ ≪≫
     (α_ Xᘁ X Xᘁ) ≪≫ whiskerLeftIso Xᘁ (coevaluationIso X).symm
     = (λ_ Xᘁ) ≪≫ (ρ_ Xᘁ).symm := by
-      apply_fun (fun f => f.symm)
-      · simp only [Iso.trans_symm, whiskerLeftIso_symm, Iso.symm_symm_eq, whiskerRightIso_symm,
+      apply Iso.symm_bijective.injective
+      simp only [Iso.trans_symm, whiskerLeftIso_symm, Iso.symm_symm_eq, whiskerRightIso_symm,
         Iso.trans_assoc]
-        exact coevaluation_evaluation_iso X
-      · simp only [Iso.symm_bijective.injective]
-    apply_fun (fun f => f.hom) at this
-    simp only [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] at this
-    exact this
+      exact coevaluation_evaluation_iso X
+    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
+      congr($(this).hom)
 
 /--
 In a categorical group, the right dual of an object is also its left dual.
 -/
 abbrev HasLeftDual.ofCategoricalGroup (X : C) : HasLeftDual X where
   leftDual := Xᘁ
-  exact := ExactPairing.of_rightDual_self X
+  exact := ExactPairing.ofRightDualSelf X
 
-instance LeftRigidCategory.of_CategoricalGroup : LeftRigidCategory C where
-  leftDual := fun X => HasLeftDual.of_CategoricalGroup X
+@[simps!]
+def isoLeftDual (X : C) [HasLeftDual X] : Xᘁ ≅ (ᘁX) :=
+  leftDualIso (ExactPairing.ofRightDualSelf X) HasLeftDual.exact
 
-instance RigidCategory.of_CategoricalGroup : RigidCategory C where
-  toRightRigidCategory := inferInstance
-  toLeftRigidCategory := LeftRigidCategory.of_CategoricalGroup
+abbrev LeftRigidCategory.ofCategoricalGroup : LeftRigidCategory C where
+  leftDual := HasLeftDual.ofCategoricalGroup
 
+abbrev RigidCategory.ofCategoricalGroup : RigidCategory C where
+  toLeftRigidCategory := LeftRigidCategory.ofCategoricalGroup
 
 end CategoricalGroup
 

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -146,7 +146,7 @@ instance ExactPairing.of_rightDual_self (X : C) : ExactPairing Xᘁ X where
 /--
 In a categorical group, the right dual of an object is also its left dual.
 -/
-instance HasLeftDual.of_CategoricalGroup (X : C) : HasLeftDual X where
+abbrev HasLeftDual.ofCategoricalGroup (X : C) : HasLeftDual X where
   leftDual := Xᘁ
   exact := ExactPairing.of_rightDual_self X
 

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -92,8 +92,8 @@ def coevaluationIso (X : C) : 𝟙_ C ≅ X ⊗ Xᘁ where
 /--
 The zig-zag axiom 1: Elevating the coevaluation-evaluation axiom to an equality of isomorphism.
 -/
-lemma coevaluation_evaluation_iso (X : C) : 
-    (whiskerLeftIso Xᘁ (coevaluationIso X)) ≪≫ (α_ Xᘁ X Xᘁ).symm ≪≫ 
+lemma coevaluation_evaluation_iso (X : C) :
+    (whiskerLeftIso Xᘁ (coevaluationIso X)) ≪≫ (α_ Xᘁ X Xᘁ).symm ≪≫
       whiskerRightIso (evaluationIso X) Xᘁ = ρ_ Xᘁ ≪≫ (λ_ Xᘁ).symm := by
   ext
   simp only [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom]
@@ -102,8 +102,8 @@ lemma coevaluation_evaluation_iso (X : C) :
 /--
 The zig-zag axiom 2: Elevating the evaluation-coevaluation axiom to an equality of isomorphism.
 -/
-lemma evaluation_coevaluation_iso (X : C) : 
-    (whiskerRightIso (coevaluationIso X) X) ≪≫ (α_ X Xᘁ X) ≪≫ 
+lemma evaluation_coevaluation_iso (X : C) :
+    (whiskerRightIso (coevaluationIso X) X) ≪≫ (α_ X Xᘁ X) ≪≫
       whiskerLeftIso X (evaluationIso X) = (λ_ X) ≪≫ (ρ_ X).symm := by
   ext
   simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom]

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -63,8 +63,6 @@ open Category MonoidalCategory CategoryTheory
 
 namespace CategoricalGroup
 
--- Since the categorical group class does not have any additional conditions,
---we just assume the following variables.
 variable {C : Type u} [Groupoid.{v} C]
   [MonoidalCategory.{v} C] [RightRigidCategory C]
 

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -102,11 +102,9 @@ lemma coevaluation_evaluation_iso (X : C) :
 /--
 The zig-zag axiom 2: Elevating the evaluation-coevaluation axiom to an equality of isomorphism.
 -/
-lemma evaluation_coevaluation_iso (X : C) : (whiskerRightIso (coevaluationIso X) X) ≪≫
-(α_ X Xᘁ X) ≪≫
-whiskerLeftIso X (evaluationIso X)
-=
-(λ_ X) ≪≫ (ρ_ X).symm := by
+lemma evaluation_coevaluation_iso (X : C) : 
+    (whiskerRightIso (coevaluationIso X) X) ≪≫ (α_ X Xᘁ X) ≪≫ 
+      whiskerLeftIso X (evaluationIso X) = (λ_ X) ≪≫ (ρ_ X).symm := by
   ext
   simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom]
   exact ExactPairing.evaluation_coevaluation X Xᘁ

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -92,11 +92,9 @@ def coevaluationIso (X : C) : 𝟙_ C ≅ X ⊗ Xᘁ where
 /--
 The zig-zag axiom 1: Elevating the coevaluation-evaluation axiom to an equality of isomorphism.
 -/
-lemma coevaluation_evaluation_iso (X : C) : (whiskerLeftIso Xᘁ (coevaluationIso X)) ≪≫
-(α_ Xᘁ X Xᘁ).symm ≪≫
-whiskerRightIso (evaluationIso X) Xᘁ
-=
-ρ_ Xᘁ ≪≫ (λ_ Xᘁ).symm := by
+lemma coevaluation_evaluation_iso (X : C) : 
+    (whiskerLeftIso Xᘁ (coevaluationIso X)) ≪≫ (α_ Xᘁ X Xᘁ).symm ≪≫ 
+      whiskerRightIso (evaluationIso X) Xᘁ = ρ_ Xᘁ ≪≫ (λ_ Xᘁ).symm := by
   ext
   simp only [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom]
   exact ExactPairing.coevaluation_evaluation X Xᘁ

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -74,6 +74,7 @@ def negatorObj (X : C) : C := Xᘁ
 /--
 The unit (evaluation) isomorphism of a categorical group.
 -/
+@[simps!]
 def evaluationIso (X : C) : Xᘁ ⊗ X ≅ 𝟙_ C where
   hom := ε_ X Xᘁ
   inv := Groupoid.inv (ε_ X Xᘁ)

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -137,13 +137,22 @@ abbrev HasLeftDual.ofCategoricalGroup (X : C) : HasLeftDual X where
   leftDual := Xᘁ
   exact := ExactPairing.ofRightDualSelf X
 
+/--
+For an object `X` with a left dual, the left dual of `X` is isomorphic to the right dual of `X`.
+-/
 @[simps!]
 def isoLeftDual (X : C) [HasLeftDual X] : Xᘁ ≅ (ᘁX) :=
   leftDualIso (ExactPairing.ofRightDualSelf X) HasLeftDual.exact
 
+/--
+A categorical group is a left rigid category.
+-/
 abbrev LeftRigidCategory.ofCategoricalGroup : LeftRigidCategory C where
   leftDual := HasLeftDual.ofCategoricalGroup
 
+/--
+A categorical group is a rigid category.
+-/
 abbrev RigidCategory.ofCategoricalGroup : RigidCategory C where
   toLeftRigidCategory := LeftRigidCategory.ofCategoricalGroup
 

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -61,13 +61,6 @@ namespace CategoryTheory
 
 open Category MonoidalCategory CategoryTheory
 
-
-/-- `CategoricalGroup` is a monoidal groupoid that is also a right rigid category.
-The negator is the right dual. -/
-class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C]
-[RightRigidCategory C]
-
-
 namespace CategoricalGroup
 
 -- Since the categorical group class does not have any additional conditions,

--- a/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CategoricalGroups/Basic.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 Amogh Parab. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Amogh Parab
+-/
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Discrete
+public import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
+
+/-!
+# Categorical Groups
+
+A categorical group is a monoidal category equipped with a negator,
+and cancellation isomorphisms called the unit and counit isomorphisms.
+The unit and counit isomorphisms must
+satisfy coherence axioms.
+
+With the coherence axioms, we can show that the negator extends to a functor and
+the unit and counit isomorphisms are natural.
+
+## Implementation note
+
+
+We make `CategoricalGroup` as a typeclass with
+MonoidalCategory, Groupoid, and RightRigidCategory as subclasses with no additional conditions.
+Right rigidity gives the negator (right dual),
+the counit morphism (coevaluation), and the unit morphism (evaluation).
+With the groupoid structure, we can construct the unit and counit isomorphisms from the unit and
+counit morphisms.
+
+From RightRigidity, we also get the coherence axioms of the unit and counit isomorphisms
+(evaluation-coevaluation and coevaluation-evaluation).
+Again, with the groupoid structure, we extend these to
+the coherence axioms of the unit and counit isomorphisms.
+
+For consistency, we will use the terms "evaluation" and "coevaluation"
+to refer to the unit and counit isomorphisms of a categorical group. This also avoids confusion
+with the unit object.
+
+## Future work
+
+* Extend `negatorObj` to a functor `negator : C ⥤ C` and
+unit and counit isomorphisms to natural isomorphisms.
+* Add basic lemmas.
+* Extend categorical groups to symmetric categorical groups by adding a braiding.
+
+## References
+
+* John C. Baez and Aaron D. Lauda. Higher-dimensional algebra V: 2-groups. Theory
+Appl. Categ., 12:423–491, 2004
+
+-/
+
+@[expose] public section
+
+universe u v
+
+namespace CategoryTheory
+
+open Category MonoidalCategory CategoryTheory
+
+
+/-- `CategoricalGroup` is a monoidal groupoid that is also a right rigid category.
+The negator is the right dual. -/
+class CategoricalGroup (C : Type u) [Groupoid.{v} C] [MonoidalCategory.{v} C]
+[RightRigidCategory C]
+
+
+namespace CategoricalGroup
+
+-- Since the categorical group class does not have any additional conditions,
+--we just assume the following variables.
+variable {C : Type u} [Groupoid.{v} C]
+  [MonoidalCategory.{v} C] [RightRigidCategory C]
+
+/--
+Negator of an object in a categorical group is the right dual of the object.
+-/
+def negatorObj (X : C) : C := Xᘁ
+
+/--
+The unit (evaluation) isomorphism of a categorical group.
+-/
+def evaluationIso (X : C) : Xᘁ ⊗ X ≅ 𝟙_ C where
+  hom := ε_ X Xᘁ
+  inv := Groupoid.inv (ε_ X Xᘁ)
+  hom_inv_id := Groupoid.comp_inv (ε_ X Xᘁ)
+  inv_hom_id := Groupoid.inv_comp (ε_ X Xᘁ)
+
+/--
+The counit (coevaluation) isomorphism of a categorical group.
+-/
+def coevaluationIso (X : C) : 𝟙_ C ≅ X ⊗ Xᘁ where
+  hom := η_ X Xᘁ
+  inv := Groupoid.inv (η_ X Xᘁ)
+  hom_inv_id := Groupoid.comp_inv (η_ X Xᘁ)
+  inv_hom_id := Groupoid.inv_comp (η_ X Xᘁ)
+
+/--
+The zig-zag axiom 1: Elevating the coevaluation-evaluation axiom to an equality of isomorphism.
+-/
+lemma coevaluation_evaluation_iso (X : C) : (whiskerLeftIso Xᘁ (coevaluationIso X)) ≪≫
+(α_ Xᘁ X Xᘁ).symm ≪≫
+whiskerRightIso (evaluationIso X) Xᘁ
+=
+ρ_ Xᘁ ≪≫ (λ_ Xᘁ).symm := by
+  ext
+  simp only [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom]
+  exact ExactPairing.coevaluation_evaluation X Xᘁ
+
+/--
+The zig-zag axiom 2: Elevating the evaluation-coevaluation axiom to an equality of isomorphism.
+-/
+lemma evaluation_coevaluation_iso (X : C) : (whiskerRightIso (coevaluationIso X) X) ≪≫
+(α_ X Xᘁ X) ≪≫
+whiskerLeftIso X (evaluationIso X)
+=
+(λ_ X) ≪≫ (ρ_ X).symm := by
+  ext
+  simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom]
+  exact ExactPairing.evaluation_coevaluation X Xᘁ
+
+
+
+instance ExactPairing.of_rightDual_self (X : C) : ExactPairing Xᘁ X where
+  coevaluation' := (evaluationIso X).inv
+
+  evaluation' := (coevaluationIso X).inv
+
+  coevaluation_evaluation' := by
+    have : whiskerLeftIso X (evaluationIso X).symm ≪≫
+    (α_ X Xᘁ X).symm ≪≫ whiskerRightIso (coevaluationIso X).symm X
+    = (ρ_ X) ≪≫ (λ_ X).symm := by
+      apply_fun (fun f => f.symm)
+      · simp only [Iso.trans_symm, whiskerRightIso_symm, Iso.symm_symm_eq, whiskerLeftIso_symm,
+        Iso.trans_assoc]
+        exact evaluation_coevaluation_iso X
+      · simp only [Iso.symm_bijective.injective]
+    apply_fun (fun f => f.hom) at this
+    simp only [Iso.trans_hom, whiskerRightIso_hom, Iso.symm_hom, whiskerLeftIso_hom] at this
+    exact this
+
+
+  evaluation_coevaluation' := by
+    have : whiskerRightIso (evaluationIso X).symm Xᘁ ≪≫
+    (α_ Xᘁ X Xᘁ) ≪≫ whiskerLeftIso Xᘁ (coevaluationIso X).symm
+    = (λ_ Xᘁ) ≪≫ (ρ_ Xᘁ).symm := by
+      apply_fun (fun f => f.symm)
+      · simp only [Iso.trans_symm, whiskerLeftIso_symm, Iso.symm_symm_eq, whiskerRightIso_symm,
+        Iso.trans_assoc]
+        exact coevaluation_evaluation_iso X
+      · simp only [Iso.symm_bijective.injective]
+    apply_fun (fun f => f.hom) at this
+    simp only [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] at this
+    exact this
+
+/--
+In a categorical group, the right dual of an object is also its left dual.
+-/
+instance HasLeftDual.of_CategoricalGroup (X : C) : HasLeftDual X where
+  leftDual := Xᘁ
+  exact := ExactPairing.of_rightDual_self X
+
+instance LeftRigidCategory.of_CategoricalGroup : LeftRigidCategory C where
+  leftDual := fun X => HasLeftDual.of_CategoricalGroup X
+
+instance RigidCategory.of_CategoricalGroup : RigidCategory C where
+  toRightRigidCategory := inferInstance
+  toLeftRigidCategory := LeftRigidCategory.of_CategoricalGroup
+
+
+end CategoricalGroup
+
+
+end CategoryTheory


### PR DESCRIPTION
This PR defines of categorical groups, also known as coherent 2-groups, in mathlib.

Motivation:
Categorical groups are well-studied structures in monoidal category theory, but are not currently available in mathlib. The definitions in this PR follow the existing design patterns used for Category, MonoidalCategory, and BraidedCategory.

This PR focuses on setting up the core structure and notation. Basic lemmas and further developments will be provided in a subsequent PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
