### PR TITLE
[Merged by Bors] - fix(Valuation/RankOne): replace abstract completion `RankOne` instance with concrete instances

### DIFF
--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -136,12 +136,7 @@ noncomputable def FinitePlace.embedding : WithVal (v.valuation K) →+* adicComp
 theorem FinitePlace.embedding_apply (x : K) : embedding v x = ↑x := rfl
 
 noncomputable instance : (v.valuation K).RankOne where
-  hom := {
-    toFun := toNNReal (absNorm_ne_zero v)
-    map_zero' := rfl
-    map_one' := rfl
-    map_mul' := map_mul (toNNReal (absNorm_ne_zero v))
-  }
+  hom := toNNReal (absNorm_ne_zero v)
   strictMono' := toNNReal_strictMono (one_lt_absNorm_nnreal v)
   exists_val_nontrivial := by
     rcases Submodule.exists_mem_ne_zero_of_ne_bot v.ne_bot with ⟨x, hx1, hx2⟩
@@ -149,9 +144,15 @@ noncomputable instance : (v.valuation K).RankOne where
     rw [valuation_of_algebraMap]
     exact ⟨v.intValuation_ne_zero _ hx2, ((intValuation_lt_one_iff_mem _ _).2 hx1).ne⟩
 
-@[deprecated Valuation.instRankOneCompletion (since := "2026-01-05")]
 noncomputable instance instRankOneValuedAdicCompletion :
-    Valuation.RankOne (Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰) := inferInstance
+    Valuation.RankOne (Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰) where
+  hom := toNNReal (absNorm_ne_zero v)
+  strictMono' := toNNReal_strictMono (one_lt_absNorm_nnreal v)
+  exists_val_nontrivial := by
+    rcases Submodule.exists_mem_ne_zero_of_ne_bot v.ne_bot with ⟨x, hx1, hx2⟩
+    use x
+    rw [valuedAdicCompletion_eq_valuation' v (x : K)]
+    simpa [valuation_of_algebraMap] using ⟨v.intValuation_ne_zero _ hx2, hx1⟩
 
 /-- The `v`-adic completion of `K` is a normed field. -/
 noncomputable instance instNormedFieldValuedAdicCompletion : NormedField (adicCompletion K v) :=

--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -114,16 +114,6 @@ instance [RankOne v] : IsNontrivial v where
 
 end RankOne
 
-instance instRankOneCompletion {K : Type*} [Field K] {Γ : Type*}
-    [LinearOrderedCommGroupWithZero Γ] (v : Valuation K Γ) [h : v.RankOne] :
-    (Valued.v : Valuation v.Completion Γ).RankOne where
-  hom := Valuation.RankOne.hom v
-  strictMono' := Valuation.RankOne.strictMono v
-  exists_val_nontrivial := by
-    rcases h.exists_val_nontrivial with ⟨x, hx1, hx2⟩
-    use (WithVal.equiv v).symm x
-    simp_all
-
 end Valuation
 
 section ValuativeRel


### PR DESCRIPTION
#26872 fixes the definition of `Valuation.RankOne` so that its order embedding into `NNReal` is a map from the range of the value group (the type `MonoidWithZeroHom.ValueGroup₀`). 

This causes problems with the instance `instRankOneCompletion` (PR'd recently #33594) because the value group of the completion no longer type checks as the value group of the base ring. This abstract instance was only introduced to combine the proofs of `(v.valuation K).RankOne` and its completion `Valued.v.RankOne`. So we separate them here as concrete separate instances to help with the `RankOne` refactor. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
