### PR TITLE
chore: scope AddCommGroup.toIntModule

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -31,6 +31,8 @@ We use parameters `a` and `b` instead of `1` to accommodate for two use cases:
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Finset
 
 open Function Set

--- a/Mathlib/Algebra/AffineMonoid/Embedding.lean
+++ b/Mathlib/Algebra/AffineMonoid/Embedding.lean
@@ -25,6 +25,8 @@ This file proves that finitely generated cancellative torsion-free commutative m
 
 public section
 
+open scoped AddCommGroup
+
 open Algebra AddLocalization Function
 
 variable {M : Type*} [AddCancelCommMonoid M] [AddMonoid.FG M] [IsAddTorsionFree M]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -23,6 +23,8 @@ In this file we define `NonUnitalSubalgebra`s and the usual operations on them (
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe u u' v v' w w'
 
 section NonUnitalSubalgebraClass

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -47,6 +47,8 @@ this map to be injective it suffices that the range omits `1`. In this setting w
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 /-! ## Subalgebras -/
 
 namespace Unitization

--- a/Mathlib/Algebra/Algebra/ZMod.lean
+++ b/Mathlib/Algebra/Algebra/ZMod.lean
@@ -14,6 +14,8 @@ public import Mathlib.Data.ZMod.Basic
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists TwoSidedIdeal
 
 namespace ZMod

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -26,6 +26,8 @@ in `Mathlib/Algebra/Category/Grp/EnoughInjectives.lean`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open CategoryTheory
 
 open Pointwise

--- a/Mathlib/Algebra/Category/Grp/LargeColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/LargeColimits.lean
@@ -20,6 +20,8 @@ by the relations given by the morphisms in the diagram) is `w`-small.
 
 public section
 
+open scoped AddCommGroup
+
 universe w u v
 
 open CategoryTheory Limits

--- a/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
+++ b/Mathlib/Algebra/Category/Grp/ZModuleEquivalence.lean
@@ -18,6 +18,8 @@ or, having constructed that monoidal structure directly, show this functor is mo
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -29,6 +29,8 @@ of scalars of `M.obj Y` via `R.map f`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe v v₁ u₁ u
 
 open CategoryTheory LinearMap Opposite

--- a/Mathlib/Algebra/CharZero/Quotient.lean
+++ b/Mathlib/Algebra/CharZero/Quotient.lean
@@ -17,6 +17,7 @@ public import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
 
 public section
 
+open scoped AddCommGroup
 
 variable {R : Type*} [DivisionRing R] [CharZero R] {p : R}
 

--- a/Mathlib/Algebra/FreeAbelianGroup/Finsupp.lean
+++ b/Mathlib/Algebra/FreeAbelianGroup/Finsupp.lean
@@ -24,6 +24,8 @@ We use this to transport the notion of `support` from `Finsupp` to `FreeAbelianG
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Cardinal Module.Basis
 
 noncomputable section

--- a/Mathlib/Algebra/Group/ForwardDiff.lean
+++ b/Mathlib/Algebra/Group/ForwardDiff.lean
@@ -35,6 +35,8 @@ We also prove some auxiliary results about iterated forward differences of the f
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Finset Nat Function Polynomial
 
 variable {M G : Type*} [AddCommMonoid M] [AddCommGroup G] (h : M)

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -51,6 +51,7 @@ lie bracket, jacobi identity, lie ring, lie algebra, lie module
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe u v w w₁ w₂
 

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -40,6 +40,8 @@ as `- [b, D a]`. Within Lie algebras, skew symmetry restores the expected defini
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 /-- A Lie derivation `D` from the Lie `R`-algebra `L` to the `L`-module `M` is an `R`-linear map
 that satisfies the Leibniz rule `D [a, b] = [a, D b] - [b, D a]`. -/
 structure LieDerivation (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -33,6 +33,8 @@ lie algebra, lower central series, nilpotent, max nilpotent ideal
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe u v w w₁ w₂
 
 section NilpotentModules

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -57,6 +57,7 @@ Develop the theory of two-sided ideals, which have type `Submodule (R ⊗[ℕ] R
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open TensorProduct
 

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -31,6 +31,8 @@ an `R`-linear map `l : M ⟶ N` induces an `R`-linear map `l⋆ : f ↦ f ∘ l`
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open CategoryTheory
 
 universe uR uA uB

--- a/Mathlib/Algebra/Module/End.lean
+++ b/Mathlib/Algebra/Module/End.lean
@@ -17,6 +17,8 @@ We use this to prove some results on scalar multiplication by integers.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists RelIso Multiset Set.indicator Pi.single_smul₀ Field
 
 open Function Set

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -22,6 +22,8 @@ public import Mathlib.Algebra.Module.Prod
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function
 
 variable {R : Type*} {R₂ : Type*}

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -38,6 +38,8 @@ public import Mathlib.RingTheory.Ideal.Defs
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists ModuleCat
 
 noncomputable section

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -54,6 +54,7 @@ linear map
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 assert_not_exists TrivialStar DomMulAct Pi.module WCovBy.image Field
 

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -25,6 +25,8 @@ including the action of `Module.End` on the module we are considering endomorphi
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe u v
 
 /-- Linear endomorphisms of a module, with associated ring structure

--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -72,13 +72,15 @@ section AddCommGroup
 
 variable (M) [AddCommGroup M]
 
-instance AddCommGroup.toIntModule : Module ℤ M where
+scoped instance AddCommGroup.toIntModule : Module ℤ M where
   one_smul := one_zsmul
   mul_smul m n a := mul_zsmul a m n
   smul_add n a b := zsmul_add a b n
   smul_zero := zsmul_zero
   zero_smul := zero_zsmul
   add_smul r s x := add_zsmul x r s
+
+open scoped AddCommGroup
 
 theorem DistribSMul.toAddMonoidHom_eq_zsmulAddGroupHom :
     toAddMonoidHom M = zsmulAddGroupHom := rfl

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -31,6 +31,8 @@ linear algebra, vector space, module
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function
 
 open Pointwise

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -32,6 +32,8 @@ to unify the APIs where possible.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe v
 
 variable {R S M : Type*}

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -28,6 +28,8 @@ submodule, subspace, linear map, pushforward, pullback
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Pointwise Set
 
 variable {R : Type*} {R₁ : Type*} {R₂ : Type*} {R₃ : Type*}

--- a/Mathlib/Algebra/Module/Submodule/Range.lean
+++ b/Mathlib/Algebra/Module/Submodule/Range.lean
@@ -31,6 +31,8 @@ linear algebra, vector space, module, range
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function
 
 variable {R : Type*} {R₂ : Type*} {R₃ : Type*}

--- a/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
+++ b/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
@@ -24,6 +24,8 @@ this restriction of scalars for submodules.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 namespace Submodule
 
 variable (S : Type*) {R M : Type*} [Semiring R] [AddCommMonoid M] [Semiring S]

--- a/Mathlib/Algebra/Module/Submodule/Union.lean
+++ b/Mathlib/Algebra/Module/Submodule/Union.lean
@@ -26,6 +26,8 @@ a proper subset, provided the coefficients are a sufficiently large field.
 
 public section
 
+open scoped AddCommGroup
+
 open Function Set
 
 variable {ι K M : Type*} [Field K] [AddCommGroup M] [Module K M]

--- a/Mathlib/Algebra/Module/Torsion/Basic.lean
+++ b/Mathlib/Algebra/Module/Torsion/Basic.lean
@@ -72,6 +72,8 @@ Torsion, submodule, module, quotient
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module
 
 namespace Ideal

--- a/Mathlib/Algebra/Module/Torsion/Free.lean
+++ b/Mathlib/Algebra/Module/Torsion/Free.lean
@@ -25,6 +25,8 @@ If furthermore the base ring is a domain, this is equivalent to the naïve
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module
 
 variable {R S M N : Type*}

--- a/Mathlib/Algebra/Module/ZLattice/Basic.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Basic.lean
@@ -55,6 +55,7 @@ consistent with the `ZSpan` construction of `ℤ`-lattices.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/Algebra/Module/ZLattice/Covolume.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Covolume.lean
@@ -56,6 +56,8 @@ general case, we had two primes, e.g. `covolume.tendsto_card_div_pow''`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 namespace ZLattice

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -25,6 +25,8 @@ We show that `∑ z ∈ L, ‖z - x‖ʳ` is convergent for `r < -d`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open Module

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -32,6 +32,8 @@ interval.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists TwoSidedIdeal
 
 noncomputable section

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -47,6 +47,8 @@ centroid
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Field
 
 open Function

--- a/Mathlib/Algebra/Star/CHSH.lean
+++ b/Mathlib/Algebra/Star/CHSH.lean
@@ -76,6 +76,7 @@ There is a CHSH tuple in 4-by-4 matrices such that
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe u
 

--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -36,6 +36,7 @@ when `A` is an abelian category.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open CategoryTheory CategoryTheory.Limits CategoryTheory.Subobject
 

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -24,6 +24,8 @@ Uniformize API between analytic and meromorphic functions
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Filter Set
 open scoped Topology
 

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -56,6 +56,7 @@ separately.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open NNReal ENNReal ContinuousLinearMap MulOpposite
 

--- a/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -12,6 +12,8 @@ public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 
 public section
 
+open scoped AddCommGroup
+
 variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
 namespace CStarAlgebra

--- a/Mathlib/Analysis/Calculus/DifferentialForm/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/VectorField.lean
@@ -36,6 +36,8 @@ For this reason, we have `-` before the sum in our formal statement.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Filter ContinuousAlternatingMap Finset VectorField
 open scoped Topology
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -64,6 +64,7 @@ rectangle are contained in `s` by convexity. The general case follows by lineari
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open Asymptotics Set Filter
 

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -49,6 +49,7 @@ Taylor polynomial, Taylor's theorem
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open scoped Interval Topology Nat
 

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -96,6 +96,7 @@ uniform convergence, limits of derivatives
 
 public section
 
+open scoped AddCommGroup
 
 open Filter
 

--- a/Mathlib/Analysis/Convex/Join.lean
+++ b/Mathlib/Analysis/Convex/Join.lean
@@ -17,6 +17,7 @@ convex hulls of finite sets.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open Set
 

--- a/Mathlib/Analysis/Convex/Side.lean
+++ b/Mathlib/Analysis/Convex/Side.lean
@@ -29,6 +29,7 @@ This file defines notions of two points being on the same or opposite sides of a
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 variable {R V V' P P' : Type*}
 

--- a/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
+++ b/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
@@ -79,6 +79,8 @@ distributions
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open TopologicalSpace SeminormFamily Set Function Seminorm UniformSpace
 open scoped BoundedContinuousFunction Topology NNReal ContDiff
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
@@ -60,6 +60,8 @@ Schwartz space, tempered distributions
 
 @[expose] public noncomputable section
 
+open scoped AddCommGroup
+
 open scoped Nat NNReal ContDiff
 
 variable {ι 𝕜 𝕜' D E F G H V : Type*}

--- a/Mathlib/Analysis/Distribution/TestFunction.lean
+++ b/Mathlib/Analysis/Distribution/TestFunction.lean
@@ -54,6 +54,8 @@ distributions, test function
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Seminorm SeminormFamily Set TopologicalSpace UniformSpace
 open scoped BoundedContinuousFunction NNReal Topology
 

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -63,6 +63,7 @@ converges to `f` in the uniform-convergence topology of `C(AddCircle T, ℂ)`.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -45,6 +45,8 @@ equivalence to an inner-product space.
 
 public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open MeasureTheory Filter Complex Set Module

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -56,6 +56,7 @@ inner product space, Hilbert space, norm
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open RCLike
 

--- a/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
@@ -39,6 +39,7 @@ A slightly more elaborate corollary is that if `E` is complete and `T` is a comp
 
 public section
 
+open scoped AddCommGroup
 
 variable {𝕜 : Type*} [RCLike 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -22,6 +22,7 @@ about these definitions.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 variable {𝕜 𝕜' E F α : Type*}
 

--- a/Mathlib/Analysis/Normed/Module/Connected.lean
+++ b/Mathlib/Analysis/Normed/Module/Connected.lean
@@ -28,6 +28,8 @@ Statements with connectedness instead of path-connectedness are also given.
 
 public section
 
+open scoped AddCommGroup
+
 assert_not_exists Subgroup.index Nat.divisors
 -- TODO assert_not_exists Cardinal
 

--- a/Mathlib/CategoryTheory/Linear/Basic.lean
+++ b/Mathlib/CategoryTheory/Linear/Basic.lean
@@ -35,6 +35,8 @@ a category enriched in `Module R`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe w v u
 
 open CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Preadditive/EilenbergMoore.lean
+++ b/Mathlib/CategoryTheory/Preadditive/EilenbergMoore.lean
@@ -19,6 +19,7 @@ preadditive. Dually, if `U` is an additive comonad on `C` then `Coalgebra U` is 
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe v₁ u₁
 

--- a/Mathlib/CategoryTheory/Preadditive/EndoFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/EndoFunctor.lean
@@ -18,6 +18,7 @@ also preadditive. Dually, the category `Coalgebra F` is also preadditive.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe v₁ u₁
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -55,6 +55,7 @@ inequalities this can be changed.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe w v₁ v₂ v₃ u₁ u₂ u₃
 

--- a/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
+++ b/Mathlib/Combinatorics/Enumerative/InclusionExclusion.lean
@@ -45,6 +45,8 @@ See also `MeasureTheory.integral_biUnion_eq_sum_powerset` for the version with i
 
 public section
 
+open scoped AddCommGroup
+
 assert_not_exists Field
 
 namespace Finset

--- a/Mathlib/Data/Int/AbsoluteValue.lean
+++ b/Mathlib/Data/Int/AbsoluteValue.lean
@@ -20,6 +20,8 @@ This file contains some results on absolute values applied to integers.
 
 public section
 
+open scoped AddCommGroup
+
 variable {R S : Type*} [Ring R] [CommRing S] [LinearOrder S] [IsStrictOrderedRing S]
 
 @[simp]

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -24,6 +24,7 @@ This file provides embedding of any archimedean groups into reals.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 variable {M : Type*}
 variable [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M] [One M]

--- a/Mathlib/Data/ZMod/IntUnitsPower.lean
+++ b/Mathlib/Data/ZMod/IntUnitsPower.lean
@@ -27,6 +27,8 @@ by using `Module R (Additive M)` in its place, especially since this already has
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Ideal TwoSidedIdeal
 
 instance : SMul (ZMod 2) (Additive ℤˣ) where

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -32,6 +32,7 @@ This file contains proofs of ergodicity for maps of the additive circle.
 
 public section
 
+open scoped AddCommGroup
 
 open Set Function MeasureTheory MeasureTheory.Measure Filter Metric
 

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
@@ -23,6 +23,7 @@ This file defines oriented angles in Euclidean affine spaces.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
@@ -32,6 +32,7 @@ modulo `2 * π` as equalities of `(2 : ℤ) • θ`.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Rotation.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Rotation.lean
@@ -21,6 +21,7 @@ This file defines rotations by oriented angles in real inner product spaces.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -16,6 +16,8 @@ import Mathlib.Geometry.Euclidean.Triangle
 This file contains the proof that angles obey the triangle inequality.
 -/
 
+open scoped AddCommGroup
+
 open InnerProductGeometry
 open NormedSpace
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Power.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Power.lean
@@ -29,6 +29,7 @@ secants) in spheres in real inner product spaces and Euclidean affine spaces.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open Real
 

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -39,6 +39,8 @@ unnecessarily.
 
 public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open scoped CharZero Real RealInnerProductSpace

--- a/Mathlib/GroupTheory/DivisibleHull.lean
+++ b/Mathlib/GroupTheory/DivisibleHull.lean
@@ -40,6 +40,8 @@ it.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 variable {M : Type*} [AddCommMonoid M]
 
 local notation "↑ⁿ" => PNat.equivNonZeroDivisorsNat

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -68,6 +68,8 @@ are about `FreeAbelianGroup.map`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Cardinal Multiset
 
 universe u v

--- a/Mathlib/GroupTheory/FreeGroup/GeneratorEquiv.lean
+++ b/Mathlib/GroupTheory/FreeGroup/GeneratorEquiv.lean
@@ -16,6 +16,8 @@ public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 variable {α β G H : Type*}

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -47,6 +47,8 @@ topology are defined elsewhere; see `Analysis.Normed.Affine.AddTorsor` and
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Affine Module
 
 /-- An `AffineMap k P1 P2` (notation: `P1 →ᵃ[k] P2`) is a map from `P1` to `P2` that

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -44,6 +44,8 @@ using `map_swap` as a definition, and does not require `Neg N`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module
 
 -- semiring / add_comm_monoid

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -22,6 +22,8 @@ taking values in the tensor product of the codomains of the original maps.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open TensorProduct
 
 variable {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]

--- a/Mathlib/LinearAlgebra/Alternating/Uncurry/Fin.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Uncurry/Fin.lean
@@ -45,6 +45,8 @@ will be used to prove that the second exterior derivative of a differential form
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Fin Function
 
 namespace AlternatingMap

--- a/Mathlib/LinearAlgebra/Basis/Submodule.lean
+++ b/Mathlib/LinearAlgebra/Basis/Submodule.lean
@@ -14,6 +14,8 @@ public import Mathlib.LinearAlgebra.Basis.Basic
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Set Submodule Finsupp Module
 
 assert_not_exists Ordinal

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -46,6 +46,7 @@ This file is almost identical to `Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.le
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 variable {R : Type*} [CommRing R]
 variable {M : Type*} [AddCommGroup M] [Module R M]

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -39,6 +39,8 @@ function with finite support, module, linear algebra
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module
 
 variable {ι ι' : Type*} {R : Type*} {S : Type*} {M : ι → Type*} {N : Type*}

--- a/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
@@ -24,6 +24,7 @@ This file contains results on the `R`-module structure on functions of finite su
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/CardQuotient.lean
@@ -22,6 +22,8 @@ public import Mathlib.LinearAlgebra.FreeModule.Finite.Quotient
 
 public section
 
+open scoped AddCommGroup
+
 open Module Submodule
 
 section Submodule

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -23,6 +23,7 @@ We provide some instances for finite and free modules involving matrices.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 universe u u' v w
 

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
@@ -22,6 +22,8 @@ public import Mathlib.LinearAlgebra.Quotient.Pi
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module
 open scoped DirectSum
 

--- a/Mathlib/LinearAlgebra/FreeModule/Int.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Int.lean
@@ -19,6 +19,7 @@ index.
 
 public section
 
+open scoped AddCommGroup
 
 variable {ι R M : Type*} {n : ℕ} [CommRing R] [AddCommGroup M]
 

--- a/Mathlib/LinearAlgebra/FreeModule/ModN.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/ModN.lean
@@ -17,6 +17,8 @@ If `G` is a rank `d` free `ℤ`-module, then `G/nG` is a finite group of cardina
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Finsupp Function Module
 
 variable {G H M : Type*} [AddCommGroup G] {n : ℕ}

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -53,6 +53,7 @@ linearly dependent, linear dependence, linearly independent, linear independence
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 assert_not_exists Cardinal
 

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -71,6 +71,8 @@ and so the equality can just be substituted.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Fin Function Finset Set
 
 universe uR uS uι v v' v₁ v₁' v₁'' v₂ v₃ v₄

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -79,6 +79,8 @@ quadratic map, homogeneous polynomial, quadratic polynomial
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe u v w
 
 variable {S T : Type*}

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -21,6 +21,8 @@ public import Mathlib.Tactic.LinearCombination
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe uR uA uM₁ uM₂ uN₁ uN₂
 
 variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂} {N₁ : Type uN₁} {N₂ : Type uN₂}

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -30,6 +30,8 @@ This file defines rays in modules.
 
 @[expose] public noncomputable section
 
+open scoped AddCommGroup
+
 open Module
 
 section StrictOrderedCommSemiring

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -53,6 +53,8 @@ should connect (or unify) these definitions with `Module.reflection` defined her
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Set
 open Module
 open Submodule (span)

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -49,6 +49,8 @@ is too strong.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open Function Set Submodule

--- a/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
@@ -38,6 +38,8 @@ to yield slightly more general results.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function IsAddIndecomposable Module Set Submodule
 
 namespace RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -29,6 +29,8 @@ length, `p + q` is at most 3.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open FaithfulSMul Function Set Submodule

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -61,6 +61,8 @@ require that it is compatible with reflections and coreflections.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Set Function
 open Module hiding reflection
 open Submodule (span span_image)

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -46,6 +46,8 @@ Once sufficient API for `RootPairing.Base` has been developed:
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open FaithfulSMul Function Set Submodule

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -31,6 +31,8 @@ root pairings.
 
 public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open Function Set

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -15,6 +15,8 @@ public import Mathlib.LinearAlgebra.RootSystem.Finite.G2
 
 public section
 
+open scoped AddCommGroup
+
 open Set
 open FaithfulSMul (algebraMap_injective)
 

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -34,6 +34,8 @@ of this theory is the theory of crystallographic root systems, where `S = ℤ`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Set Function
 open Submodule (span)
 open Module

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -34,6 +34,8 @@ solely on `RootPairing.pairingIn` and `RootPairing.coxeterWeightIn`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Module Set Function
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -32,6 +32,8 @@ import Mathlib.Algebra.Module.Torsion.Field
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 variable {R R₂ K M M₂ V S : Type*}
 
 namespace Submodule

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -23,6 +23,8 @@ public import Mathlib.Algebra.Group.Pointwise.Set.Basic
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Field
 
 variable {R R₂ K M M₂ V S : Type*}

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -41,6 +41,7 @@ modulo the additional relations making the inclusion of `M` into an `R`-linear m
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 variable (R : Type*) [CommSemiring R]
 variable (M : Type*) [AddCommMonoid M] [Module R M]

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -40,6 +40,8 @@ bilinear, tensor, tensor product
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 set_option linter.style.longFile 1700
 
 section Semiring

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -47,7 +47,7 @@ multiplication follows trivially from this after some point-free nonsense.
 
 @[expose] public section
 
-open scoped TensorProduct DirectSum
+open scoped AddCommGroup TensorProduct DirectSum
 
 variable {R ι : Type*}
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -46,6 +46,7 @@ vector measure, signed measure, complex measure
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Moebius.lean
@@ -36,6 +36,8 @@ arithmetic functions, dirichlet convolution, divisors
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Finset Nat
 
 variable {R : Type*}

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -59,6 +59,7 @@ See the sections *Main theorems on weak FE-pairs* and
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 /- TODO: Consider extending the results to allow functional equations of the form
 `f (N / x) = (const) • x ^ k • g x` for a real parameter `0 < N`. This could be done either by

--- a/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
@@ -39,6 +39,8 @@ number field, units, Dirichlet unit theorem
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 noncomputable section
 
 open Module NumberField NumberField.InfinitePlace NumberField.Units

--- a/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
@@ -35,6 +35,8 @@ number field, units, regulator
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open scoped NumberField
 
 noncomputable section

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -43,6 +43,8 @@ Bojanic
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Finset IsUltrametricDist NNReal Filter
 
 open scoped fwdDiff ZeroAtInfty Topology

--- a/Mathlib/Probability/Distributions/Gaussian/IsGaussianProcess/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/IsGaussianProcess/Basic.lean
@@ -32,6 +32,8 @@ Gaussian process
 
 public section
 
+open scoped AddCommGroup
+
 open MeasureTheory Finset
 
 namespace ProbabilityTheory.IsGaussianProcess

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -37,6 +37,8 @@ module can be accessed via `ρ.asModule`. Conversely, given a `k[G]`-module `M`,
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open MonoidAlgebra (lift of)
 open LinearMap Module
 open scoped MonoidAlgebra

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -47,6 +47,8 @@ We show that when the representation on `A` is trivial, `H₁(G, A) ≃+ Gᵃᵇ
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 universe v u
 
 noncomputable section

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -31,6 +31,8 @@ We verify that `Rep k G` is a `k`-linear abelian symmetric monoidal category wit
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 suppress_compilation
 
 open CategoryTheory Limits

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -67,6 +67,8 @@ Further results in Elliot's paper:
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Polynomial
 
 /-- A binomial ring is a ring for which ascending Pochhammer evaluations are uniquely divisible by

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -35,6 +35,8 @@ and `RingTheory.Derivation.ToSquareZero` for
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Algebra
 
 /-- `D : Derivation R A M` is an `R`-linear map from `A` to `M` that satisfies the `leibniz`

--- a/Mathlib/RingTheory/Finiteness/Cardinality.lean
+++ b/Mathlib/RingTheory/Finiteness/Cardinality.lean
@@ -21,6 +21,8 @@ This file relates `Module.Finite` and `_root_.Finite`.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function (Surjective)
 open Finsupp
 

--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -28,6 +28,8 @@ In this file we define a notion of finiteness that is common in commutative alge
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Module.Basis Ideal.radical Matrix Subalgebra
 
 open Function (Surjective)

--- a/Mathlib/RingTheory/Finiteness/Finsupp.lean
+++ b/Mathlib/RingTheory/Finiteness/Finsupp.lean
@@ -19,6 +19,8 @@ public import Mathlib.Algebra.Exact
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function (Surjective)
 open Finsupp
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -87,6 +87,9 @@ type with a zero. They are denoted `R⸨X⸩`.
 -/
 
 @[expose] public section
+
+open scoped AddCommGroup
+
 universe u
 
 open scoped PowerSeries

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -20,6 +20,8 @@ The `Monoid` and `DistribMulAction` instances and additive versions are provided
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Subgroup
 
 universe u

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -32,6 +32,8 @@ This file provides results about maps between tensor products of `R`-algebras.
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists Equiv.Perm.cycleType
 
 open scoped TensorProduct

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -27,6 +27,7 @@ for `ContinuousLinearMap R E F`.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 /-- A continuous map of affine spaces -/
 structure ContinuousAffineMap (R : Type*) {V W : Type*} (P Q : Type*) [Ring R] [AddCommGroup V]

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -28,6 +28,8 @@ multilinear map, alternating map, continuous
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 open Function Matrix
 
 /-- A continuous alternating map from `ι → M` to `N`, denoted `M [⋀^ι]→L[R] N`,

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -24,6 +24,8 @@ Plain linear maps are denoted by `M →L[R] M₂` and star-linear maps by `M →
 
 @[expose] public section
 
+open scoped AddCommGroup
+
 assert_not_exists TrivialStar
 
 open LinearMap (ker range)

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -36,6 +36,7 @@ especially when defining iterated derivatives.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 open Function Fin Set
 

--- a/Mathlib/Topology/Instances/ZMultiples.lean
+++ b/Mathlib/Topology/Instances/ZMultiples.lean
@@ -18,6 +18,7 @@ intersection with compact sets is finite.
 
 @[expose] public section
 
+open scoped AddCommGroup
 
 noncomputable section
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
