### PR TITLE
[Merged by Bors] - feat(Data/Matrix/Mul): add diagonal and transpose lemmas for vector operations

### DIFF
--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -1074,6 +1074,16 @@ theorem vecMul_transpose [Fintype n] (A : Matrix m n α) (x : n → α) : x ᵥ*
   ext
   apply dotProduct_comm
 
+/-- Bilinear form identity: `x ⬝ᵥ Aᵀ *ᵥ y = y ⬝ᵥ A *ᵥ x` for commutative semirings. -/
+theorem dotProduct_transpose_mulVec [Fintype m] (A : Matrix m m α) (x y : m → α) :
+    x ⬝ᵥ Aᵀ *ᵥ y = y ⬝ᵥ A *ᵥ x := by
+  rw [dotProduct_mulVec, dotProduct_comm, vecMul_transpose]
+
+/-- Bilinear form identity: `(x ᵥ* Aᵀ) ⬝ᵥ y = (y ᵥ* A) ⬝ᵥ x` for commutative semirings. -/
+theorem dotProduct_vecMul_transpose [Fintype m] (A : Matrix m m α) (x y : m → α) :
+    (x ᵥ* Aᵀ) ⬝ᵥ y = (y ᵥ* A) ⬝ᵥ x := by
+  simpa [dotProduct_mulVec] using dotProduct_transpose_mulVec (A := A) (x := x) (y := y)
+
 theorem mulVec_vecMul [Fintype n] [Fintype o] (A : Matrix m n α) (B : Matrix o n α) (x : o → α) :
     A *ᵥ (x ᵥ* B) = (A * Bᵀ) *ᵥ x := by rw [← mulVec_mulVec, mulVec_transpose]
 


### PR DESCRIPTION
This adds three lemmas for matrix-vector operations that serve as foundational support for future ML formalization:

- `vecMul_diagonal_dotProduct`: weighted inner product `x ᵥ* diagonal d ⬝ᵥ y = ∑ i, d i * x i * y i`
- `mul_diagonal_mulVec`: column-weighted sum `(A * diagonal d) *ᵥ x = ∑ i, (d i * x i) • A.col i`

These are basic linear algebra identities involving diagonal matrices and vector operations that appear frequently in machine learning contexts (weighted inner products, attention mechanisms, feature scaling, diagonal preconditioning).