### PR TITLE
feat(Tactic/AssumptionQuestion): add `assumption?` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6817,6 +6817,7 @@ public import Mathlib.Tactic.ApplyFun
 public import Mathlib.Tactic.ApplyWith
 public import Mathlib.Tactic.ArithMult
 public import Mathlib.Tactic.ArithMult.Init
+public import Mathlib.Tactic.AssumptionQuestion
 public import Mathlib.Tactic.Attr.Core
 public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Tactic.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Tactic.ApplyFun
 public import Mathlib.Tactic.ApplyWith
 public import Mathlib.Tactic.ArithMult
 public import Mathlib.Tactic.ArithMult.Init
+public import Mathlib.Tactic.AssumptionQuestion
 public import Mathlib.Tactic.Attr.Core
 public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Tactic.Basic

--- a/Mathlib/Tactic/AssumptionQuestion.lean
+++ b/Mathlib/Tactic/AssumptionQuestion.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 Pavel Grigorenko. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pavel Grigorenko
+-/
+module
+
+public import Mathlib.Init
+
+/-! # `assumption?` tactic -/
+
+meta section
+
+namespace Mathlib.Tactic.AssumptionQuestion
+
+open Lean.Elab.Tactic
+open Lean.Meta
+open Lean.Meta.Tactic.TryThis (addExactSuggestion)
+
+/--
+* TODO
+-/
+tactic_extension Lean.Parser.Tactic.assumption
+
+@[tactic_alt Lean.Parser.Tactic.assumption]
+macro (name := assumption?) "assumption?" : tactic => `(tactic| { show_term { assumption } })
+
+end Mathlib.Tactic.AssumptionQuestion

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -33,6 +33,7 @@ public import Mathlib.Tactic.ApplyCongr
 -- import Mathlib.Tactic.ApplyFun
 public import Mathlib.Tactic.ApplyAt
 public import Mathlib.Tactic.ApplyWith
+public import Mathlib.Tactic.AssumptionQuestion
 public import Mathlib.Tactic.Basic
 public import Mathlib.Tactic.ByCases
 public import Mathlib.Tactic.ByContra

--- a/MathlibTest/AssumptionQuestion.lean
+++ b/MathlibTest/AssumptionQuestion.lean
@@ -1,0 +1,53 @@
+import Mathlib.Tactic.AssumptionQuestion
+
+/--
+info: Try this:
+  [apply] exact h
+-/
+#guard_msgs in
+example (h : 1 = 1) : 1 = 1 := by
+  assumption?
+
+/--
+info: Try this:
+  [apply] exact this
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  have : 1 = 1 := by rfl
+  assumption?
+
+/--
+info: Try this:
+  [apply] exact this
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  let : 1 = 1 := by rfl
+  assumption?
+
+/--
+info: Try this:
+  [apply] exact h
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  have h : 1 = 1 := by rfl
+  assumption?
+
+/--
+info: Try this:
+  [apply] exact h
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  let h : 1 = 1 := by rfl
+  assumption?
+
+/--
+info: Try this:
+  [apply] (expose_names; exact inst_1)
+-/
+#guard_msgs in
+example [Nonempty a] [Decidable a] : Decidable a := by
+  assumption?

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -67,6 +67,7 @@
   "Mathlib.Tactic.ApplyWith",
   "Mathlib.Tactic.Attr.Core",
   "Mathlib.Tactic.Attr.Register",
+  "Mathlib.Tactic.AssumptionQuestion",
   "Mathlib.Tactic.Basic",
   "Mathlib.Tactic.Bound.Attribute",
   "Mathlib.Tactic.ByCases",


### PR DESCRIPTION

---

As requested in #10361

TODO: maybe add some tests?

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
