### PR TITLE
[Merged by Bors] - feat(FieldTheory/KrullTopology): stabilizers are open for the Krull topology

### DIFF
--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -38,8 +38,11 @@ all intermediate fields `E` with `E/K` finite dimensional.
 - `krullTopology_t2 K L`. For an integral field extension `L/K`, the topology `krullTopology K L`
   is Hausdorff.
 
-- `krullTopology_totallyDisconnected K L`. For an integral field extension `L/K`, the topology
-  `krullTopology K L` is totally disconnected.
+- `stabilizer_isOpen_of_isIntegral`: For an integral field extension `L/K`, the stabilizer
+  in `Gal(L/K)` of any element in `L` is open for the Krull topology.
+
+- `krullTopology_isTotallySeparated K L`. For an integral field extension `L/K`, the topology
+  `krullTopology K L` is totally separated.
 
 - `IntermediateField.finrank_eq_fixingSubgroup_index`: given a Galois extension `K/k` and an
   intermediate field `L`, the `[L : k]` as a natural number is equal to the index of the
@@ -218,6 +221,23 @@ theorem krullTopology_t2 {K L : Type*} [Field K] [Field L] [Algebra K L]
 
 end KrullT2
 
+section MulAction
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
+
+/-- If `L/K` is an algebraic field extension, then the stabilizer
+in `Gal(L/K)` of any element in `L` is open for the Krull topology. -/
+theorem stabilizer_isOpen_of_isIntegral [Algebra.IsIntegral K L] (x : L) :
+    IsOpen (MulAction.stabilizer Gal(L/K) x : Set Gal(L/K)) := by
+  open IntermediateField in
+  let E := adjoin K {x}
+  have hL : FiniteDimensional K E := adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
+  convert fixingSubgroup_isOpen E
+  ext g
+  simpa using (forall_mem_adjoin_smul_eq_self_iff K (S := {x}) g).symm
+
+end MulAction
+
 section TotallySeparated
 
 instance {K L : Type*} [Field K] [Field L] [Algebra K L] [Algebra.IsIntegral K L] :
@@ -237,7 +257,7 @@ instance {K L : Type*} [Field K] [Field L] [Algebra K L] [Algebra.IsIntegral K L
   exact ⟨x, IntermediateField.mem_adjoin_simple_self K x, hx⟩
 
 /-- If `L/K` is an algebraic field extension, then the Krull topology on `Gal(L/K)` is
-  totally disconnected. -/
+  totally separated. -/
 theorem krullTopology_isTotallySeparated {K L : Type*} [Field K] [Field L] [Algebra K L]
     [Algebra.IsIntegral K L] : IsTotallySeparated (Set.univ : Set Gal(L/K)) :=
   (totallySeparatedSpace_iff _).mp inferInstance

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -38,11 +38,11 @@ all intermediate fields `E` with `E/K` finite dimensional.
 - `krullTopology_t2 K L`. For an integral field extension `L/K`, the topology `krullTopology K L`
   is Hausdorff.
 
-- `stabilizer_isOpen_of_isIntegral`: For an integral field extension `L/K`, the stabilizer
-  in `Gal(L/K)` of any element in `L` is open for the Krull topology.
-
 - `krullTopology_isTotallySeparated K L`. For an integral field extension `L/K`, the topology
   `krullTopology K L` is totally separated.
+
+- `stabilizer_isOpen_of_isIntegral`: For an integral field extension `L/K`, the stabilizer
+  in `Gal(L/K)` of any element in `L` is open for the Krull topology.
 
 - `IntermediateField.finrank_eq_fixingSubgroup_index`: given a Galois extension `K/k` and an
   intermediate field `L`, the `[L : k]` as a natural number is equal to the index of the
@@ -221,23 +221,6 @@ theorem krullTopology_t2 {K L : Type*} [Field K] [Field L] [Algebra K L]
 
 end KrullT2
 
-section MulAction
-
-variable {K L : Type*} [Field K] [Field L] [Algebra K L]
-
-/-- If `L/K` is an algebraic field extension, then the stabilizer
-in `Gal(L/K)` of any element in `L` is open for the Krull topology. -/
-theorem stabilizer_isOpen_of_isIntegral [Algebra.IsIntegral K L] (x : L) :
-    IsOpen (MulAction.stabilizer Gal(L/K) x : Set Gal(L/K)) := by
-  open IntermediateField in
-  let E := adjoin K {x}
-  have hL : FiniteDimensional K E := adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
-  convert fixingSubgroup_isOpen E
-  ext g
-  simpa using (forall_mem_adjoin_smul_eq_self_iff K (S := {x}) g).symm
-
-end MulAction
-
 section TotallySeparated
 
 instance {K L : Type*} [Field K] [Field L] [Algebra K L] [Algebra.IsIntegral K L] :
@@ -270,6 +253,23 @@ instance krullTopology_discreteTopology_of_finiteDimensional (K L : Type*) [Fiel
   change IsOpen ((⊥ : Subgroup Gal(L/K)) : Set Gal(L/K))
   rw [← IntermediateField.fixingSubgroup_top]
   exact IntermediateField.fixingSubgroup_isOpen ⊤
+
+section MulAction
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
+
+/-- If `L/K` is an algebraic field extension, then the stabilizer
+in `Gal(L/K)` of any element in `L` is open for the Krull topology. -/
+theorem stabilizer_isOpen_of_isIntegral [Algebra.IsIntegral K L] (x : L) :
+    IsOpen (MulAction.stabilizer Gal(L/K) x : Set Gal(L/K)) := by
+  open IntermediateField in
+  let E := adjoin K {x}
+  have hL : FiniteDimensional K E := adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
+  convert fixingSubgroup_isOpen E
+  ext g
+  simpa using (forall_mem_adjoin_smul_eq_self_iff K (S := {x}) g).symm
+
+end MulAction
 
 namespace IntermediateField
 


### PR DESCRIPTION
`stabilizer_isOpen_of_isIntegral`: For an algebraic field extension `L/K`, the stabilizer in `Gal(L/K)` of any element in `L` is open for the Krull topology.

Also fix typo in docstrings for `krullTopology_isTotallySeparated`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
