### PR TITLE
[Merged by Bors] - feat: definition of equivalence of representations

### DIFF
--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -204,4 +204,53 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
 
 end IntertwiningMap
 
+
+@[ext]
+structure Equivalence extends IntertwiningMap ρ σ, V ≃+ W
+
+namespace Equivalence
+
+variable {ρ σ} (φ : Equivalence ρ σ)
+
+def EquivalencetoLinearEquiv : V ≃ₗ[A] W :=
+  AddEquiv.toLinearEquiv φ.toAddEquiv φ.toLinearMap.map_smul
+
+@[simp]
+theorem toLinearEquiv_toLinearMap_eq_toIntertwiningMap_toLinearMap :
+  LinearEquiv.toLinearMap φ.EquivalencetoLinearEquiv = φ.toIntertwiningMap.toLinearMap := rfl
+
+@[simp]
+theorem equivalencetoLinearEquiv_apply (v : V) :
+  (EquivalencetoLinearEquiv φ) v = φ.toIntertwiningMap v := rfl
+
+theorem conj (g : G) : σ g = (EquivalencetoLinearEquiv φ).conj (ρ g) := by
+  rw [LinearMap.ext_iff]
+  intro w
+  simp only [LinearEquiv.conj_apply_apply, equivalencetoLinearEquiv_apply,
+    φ.toIntertwiningMap.isIntertwining]
+  rw [← equivalencetoLinearEquiv_apply, LinearEquiv.apply_symm_apply]
+
+end Equivalence
+
+end
+
+namespace Equivalence
+
+variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [AddCommGroup W]
+    [Module k W] [FiniteDimensional k V] [FiniteDimensional k W]
+    (ρ : Representation k G V) (σ : Representation k G W)
+
+noncomputable def dualTensorHom_equivalence : Equivalence (tprod ρ.dual σ) (linHom ρ σ) where
+  toAddEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
+      (b := Module.Free.chooseBasis k V)
+  map_smul' := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
+      (b := Module.Free.chooseBasis k V).map_smul
+  isIntertwining' g v := by
+    simpa [tprod_apply] using
+      (congrArg (fun f => f v)
+        (dualTensorHom_comm (ρV := ρ) (ρW := σ) (k := k) (V := V) (W := W) g))
+
+
+end Equivalence
+
 end Representation

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -250,7 +250,7 @@ variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [Ad
     [Module k W] [FiniteDimensional k V] [FiniteDimensional k W]
     (ρ : Representation k G V) (σ : Representation k G W)
 
-/-- Promotes dualTensorHom to an equivalence of representations. -/
+/-- dualTensorHom as an equivalence of representations. -/
 noncomputable def dualTensorHom_equivalence : Equivalence (tprod ρ.dual σ) (linHom ρ σ) where
   toAddEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
       (b := Module.Free.chooseBasis k V)

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -242,6 +242,7 @@ variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [Ad
     [Module k W] [FiniteDimensional k V] [FiniteDimensional k W]
     (ρ : Representation k G V) (σ : Representation k G W)
 
+/-- Promotes dualTensorHom to an equivalence of representations. -/
 noncomputable def dualTensorHom_equivalence : Equivalence (tprod ρ.dual σ) (linHom ρ σ) where
   toAddEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
       (b := Module.Free.chooseBasis k V)

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -207,6 +207,7 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
 end IntertwiningMap
 
 
+/-- Equivalence between representation is a bijective intertwining map. -/
 @[ext]
 structure Equivalence extends IntertwiningMap ρ σ, V ≃+ W
 
@@ -214,6 +215,7 @@ namespace Equivalence
 
 variable {ρ σ} (φ : Equivalence ρ σ)
 
+/-- Underlying linear isomorphism of an equivalence of representations. -/
 def EquivalencetoLinearEquiv : V ≃ₗ[A] W :=
   AddEquiv.toLinearEquiv φ.toAddEquiv φ.toLinearMap.map_smul
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -20,6 +20,8 @@ open scoped MonoidAlgebra
 
 namespace Representation
 
+section
+
 variable {A G V W U : Type*} [CommRing A] [Monoid G] [AddCommMonoid V] [AddCommMonoid W]
   [AddCommMonoid U] [Module A V] [Module A W] [Module A U] (ρ : Representation A G V)
   (σ : Representation A G W) (τ : Representation A G U) (f : V →ₗ[A] W)

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -207,7 +207,7 @@ def centralMul (g : G) (hg : g ∈ Submonoid.center G) : IntertwiningMap ρ ρ w
 end IntertwiningMap
 
 
-/-- Equivalence between representation is a bijective intertwining map. -/
+/-- Equivalence between representations is a bijective intertwining map. -/
 @[ext]
 structure Equivalence extends IntertwiningMap ρ σ, V ≃+ W
 
@@ -222,23 +222,23 @@ namespace Equivalence
 variable {ρ σ} (φ : Equivalence ρ σ)
 
 /-- Underlying linear isomorphism of an equivalence of representations. -/
-def EquivalencetoLinearEquiv : V ≃ₗ[A] W :=
+def toLinearEquiv : V ≃ₗ[A] W :=
   AddEquiv.toLinearEquiv φ.toAddEquiv φ.toLinearMap.map_smul
 
 @[simp]
 theorem toLinearEquiv_toLinearMap_eq_toIntertwiningMap_toLinearMap :
-  LinearEquiv.toLinearMap φ.EquivalencetoLinearEquiv = φ.toIntertwiningMap.toLinearMap := rfl
+  LinearEquiv.toLinearMap φ.toLinearEquiv = φ.toIntertwiningMap.toLinearMap := rfl
 
 @[simp]
-theorem equivalencetoLinearEquiv_apply (v : V) :
-  (EquivalencetoLinearEquiv φ) v = φ.toIntertwiningMap v := rfl
+theorem toLinearEquiv_apply (v : V) :
+  (toLinearEquiv φ) v = φ.toIntertwiningMap v := rfl
 
-theorem conj (g : G) : σ g = (EquivalencetoLinearEquiv φ).conj (ρ g) := by
+theorem conj (g : G) : σ g = (toLinearEquiv φ).conj (ρ g) := by
   rw [LinearMap.ext_iff]
   intro w
-  simp only [LinearEquiv.conj_apply_apply, equivalencetoLinearEquiv_apply,
+  simp only [LinearEquiv.conj_apply_apply, toLinearEquiv_apply,
     φ.toIntertwiningMap.isIntertwining]
-  rw [← equivalencetoLinearEquiv_apply, LinearEquiv.apply_symm_apply]
+  rw [← toLinearEquiv_apply, LinearEquiv.apply_symm_apply]
 
 end Equivalence
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -211,6 +211,12 @@ end IntertwiningMap
 @[ext]
 structure Equivalence extends IntertwiningMap ρ σ, V ≃+ W
 
+/-- The additive equivalence of types underlying an equivalence of representations. -/
+add_decl_doc Equivalence.toAddEquiv
+
+/-- The intertwining map underlying an equivalence of representations. -/
+add_decl_doc Equivalence.toIntertwiningMap
+
 namespace Equivalence
 
 variable {ρ σ} (φ : Equivalence ρ σ)

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -230,11 +230,7 @@ instance : EquivLike (Equiv ρ σ) V W where
 
 @[simp] lemma coe_toIntertwiningMap : ⇑φ.toIntertwiningMap = ⇑φ := rfl
 
-@[simp] lemma coe_toLinearEquiv : ⇑φ.toLinearEquiv = ⇑φ := rfl
-
-@[simp] lemma coe_toAddEquiv : ⇑φ.toAddEquiv = ⇑φ := rfl
-
-@[simp] lemma coe_toEquiv : ⇑φ.toEquiv = ⇑φ := rfl
+@[simp] lemma coe_toLinearMap : ⇑φ.toLinearMap = ⇑φ := rfl
 
 @[simp] lemma coe_invFun : φ.invFun = EquivLike.inv φ := rfl
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -20,7 +20,7 @@ open scoped MonoidAlgebra
 
 namespace Representation
 
-section
+section Monoid
 
 variable {A G V W U : Type*} [CommRing A] [Monoid G] [AddCommMonoid V] [AddCommMonoid W]
   [AddCommMonoid U] [Module A V] [Module A W] [Module A U] (ρ : Representation A G V)
@@ -246,9 +246,11 @@ theorem conj_apply_self (g : G) : φ.conj (ρ g) = σ g := by ext; simp [φ.isIn
 
 end Equiv
 
-end
+end Monoid
 
 namespace Equiv
+
+section Group
 
 variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [AddCommGroup W]
     [Module k W] [FiniteDimensional k V] [FiniteDimensional k W]
@@ -263,6 +265,7 @@ noncomputable def dualTensorHom_equivalence : Equiv (tprod ρ.dual σ) (linHom �
       (congrArg (fun f => f v)
         (dualTensorHom_comm (ρV := ρ) (ρW := σ) (k := k) (V := V) (W := W) g))
 
+end Group
 
 end Equiv
 

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -209,10 +209,10 @@ end IntertwiningMap
 
 /-- Equivalence between representations is a bijective intertwining map. -/
 @[ext]
-structure Equiv extends IntertwiningMap ρ σ, V ≃ W
+structure Equiv extends IntertwiningMap ρ σ, V ≃ₗ[A] W
 
-/-- The additive equivalence of types underlying an equivalence of representations. -/
-add_decl_doc Equiv.toEquiv
+/-- Underlying linear isomorphism of an equivalence of representations. -/
+add_decl_doc Equiv.toLinearEquiv
 
 /-- The intertwining map underlying an equivalence of representations. -/
 add_decl_doc Equiv.toIntertwiningMap
@@ -228,29 +228,25 @@ instance : EquivLike (Equiv ρ σ) V W where
   right_inv e := e.right_inv
   coe_injective' _ _ := Equiv.ext
 
-/-- The additive equivalence of types underlying an equivalence of representations. -/
-def toAddEquiv : V ≃+ W := { __ := φ }
+@[simp] lemma coe_toIntertwiningMap : ⇑φ.toIntertwiningMap = ⇑φ := rfl
+
+@[simp] lemma coe_toLinearEquiv : ⇑φ.toLinearEquiv = ⇑φ := rfl
 
 @[simp] lemma coe_toAddEquiv : ⇑φ.toAddEquiv = ⇑φ := rfl
 
-/-- Underlying linear isomorphism of an equivalence of representations. -/
-def toLinearEquiv : V ≃ₗ[A] W :=
-  AddEquiv.toLinearEquiv φ.toAddEquiv φ.toLinearMap.map_smul
+@[simp] lemma coe_toEquiv : ⇑φ.toEquiv = ⇑φ := rfl
+
+@[simp] lemma coe_invFun : φ.invFun = EquivLike.inv φ := rfl
 
 @[simp]
-theorem toLinearEquiv_toLinearMap_eq_toIntertwiningMap_toLinearMap :
+theorem toLinearEquiv_toLinearMap :
   LinearEquiv.toLinearMap φ.toLinearEquiv = φ.toIntertwiningMap.toLinearMap := rfl
 
 @[simp]
 theorem toLinearEquiv_apply (v : V) :
-  (toLinearEquiv φ) v = φ.toIntertwiningMap v := rfl
+  φ.toLinearEquiv v = φ.toIntertwiningMap v := rfl
 
-theorem conj (g : G) : σ g = (toLinearEquiv φ).conj (ρ g) := by
-  rw [LinearMap.ext_iff]
-  intro w
-  simp only [LinearEquiv.conj_apply_apply, toLinearEquiv_apply,
-    φ.toIntertwiningMap.isIntertwining]
-  rw [← toLinearEquiv_apply, LinearEquiv.apply_symm_apply]
+theorem conj_apply_self (g : G) : φ.conj (ρ g) = σ g := by ext; simp [φ.isIntertwining]
 
 end Equiv
 
@@ -264,12 +260,8 @@ variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [Ad
 
 /-- dualTensorHom as an equivalence of representations. -/
 noncomputable def dualTensorHom_equivalence : Equiv (tprod ρ.dual σ) (linHom ρ σ) where
-  toEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
+  toLinearEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
       (b := Module.Free.chooseBasis k V)
-  map_add' := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
-      (b := Module.Free.chooseBasis k V).map_add
-  map_smul' := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
-      (b := Module.Free.chooseBasis k V).map_smul
   isIntertwining' g v := by
     simpa [tprod_apply] using
       (congrArg (fun f => f v)

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -209,17 +209,29 @@ end IntertwiningMap
 
 /-- Equivalence between representations is a bijective intertwining map. -/
 @[ext]
-structure Equivalence extends IntertwiningMap ρ σ, V ≃+ W
+structure Equiv extends IntertwiningMap ρ σ, V ≃ W
 
 /-- The additive equivalence of types underlying an equivalence of representations. -/
-add_decl_doc Equivalence.toAddEquiv
+add_decl_doc Equiv.toEquiv
 
 /-- The intertwining map underlying an equivalence of representations. -/
-add_decl_doc Equivalence.toIntertwiningMap
+add_decl_doc Equiv.toIntertwiningMap
 
-namespace Equivalence
+namespace Equiv
 
-variable {ρ σ} (φ : Equivalence ρ σ)
+variable {ρ σ} (φ : Equiv ρ σ)
+
+instance : EquivLike (Equiv ρ σ) V W where
+  coe φ := φ.toFun
+  inv φ := φ.invFun
+  left_inv e := e.left_inv
+  right_inv e := e.right_inv
+  coe_injective' _ _ := Equiv.ext
+
+/-- The additive equivalence of types underlying an equivalence of representations. -/
+def toAddEquiv : V ≃+ W := { __ := φ }
+
+@[simp] lemma coe_toAddEquiv : ⇑φ.toAddEquiv = ⇑φ := rfl
 
 /-- Underlying linear isomorphism of an equivalence of representations. -/
 def toLinearEquiv : V ≃ₗ[A] W :=
@@ -240,20 +252,22 @@ theorem conj (g : G) : σ g = (toLinearEquiv φ).conj (ρ g) := by
     φ.toIntertwiningMap.isIntertwining]
   rw [← toLinearEquiv_apply, LinearEquiv.apply_symm_apply]
 
-end Equivalence
+end Equiv
 
 end
 
-namespace Equivalence
+namespace Equiv
 
 variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [AddCommGroup W]
     [Module k W] [FiniteDimensional k V] [FiniteDimensional k W]
     (ρ : Representation k G V) (σ : Representation k G W)
 
 /-- dualTensorHom as an equivalence of representations. -/
-noncomputable def dualTensorHom_equivalence : Equivalence (tprod ρ.dual σ) (linHom ρ σ) where
-  toAddEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
+noncomputable def dualTensorHom_equivalence : Equiv (tprod ρ.dual σ) (linHom ρ σ) where
+  toEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
       (b := Module.Free.chooseBasis k V)
+  map_add' := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
+      (b := Module.Free.chooseBasis k V).map_add
   map_smul' := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
       (b := Module.Free.chooseBasis k V).map_smul
   isIntertwining' g v := by
@@ -262,6 +276,6 @@ noncomputable def dualTensorHom_equivalence : Equivalence (tprod ρ.dual σ) (li
         (dualTensorHom_comm (ρV := ρ) (ρW := σ) (k := k) (V := V) (W := W) g))
 
 
-end Equivalence
+end Equiv
 
 end Representation

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -257,9 +257,8 @@ variable {G k V W : Type*} [Group G] [Field k] [AddCommGroup V] [Module k V] [Ad
     (ρ : Representation k G V) (σ : Representation k G W)
 
 /-- dualTensorHom as an equivalence of representations. -/
-noncomputable def dualTensorHom_equivalence : Equiv (tprod ρ.dual σ) (linHom ρ σ) where
-  toLinearEquiv := dualTensorHomEquivOfBasis (R := k) (M := V) (N := W)
-      (b := Module.Free.chooseBasis k V)
+@[simps!] noncomputable def dualTensorHom : Equiv (tprod ρ.dual σ) (linHom ρ σ) where
+  toLinearEquiv := dualTensorHomEquiv (R := k) (M := V) (N := W)
   isIntertwining' g v := by
     simpa [tprod_apply] using
       (congrArg (fun f => f v)


### PR DESCRIPTION
Defines equivalence of representations, and defines an equivalence between $$\mathrm{Hom}(V, W)$$ and $$V^* \otimes W$$ as representations. This is a missing piece to respell all of the results in Character.lean without using category-theoretic notions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
