### PR TITLE
[Merged by Bors] - chore(CI): generate lean-pr-testing token just before use

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -50,14 +50,6 @@ jobs:
         shell: bash # there is no script body, so this is safe to "run" outside landrun.
         run: |
           # We just populate the env vars for this step to make them viewable in the logs
-      - name: Generate lean-pr-testing app token
-        id: lean-pr-testing-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MATHLIB_LEAN_PR_TESTING_APP_ID }}
-          private-key: ${{ secrets.MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY }}
-          owner: leanprover
-          repositories: lean4
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |
@@ -565,6 +557,17 @@ jobs:
             exit 1
           fi
 
+      # Generate a fresh token just before posting comments.
+      # GitHub App tokens expire after 1 hour, and the build can take longer than that.
+      - name: Generate lean-pr-testing app token
+        if: always()
+        id: lean-pr-testing-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.MATHLIB_LEAN_PR_TESTING_APP_ID }}
+          private-key: ${{ secrets.MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY }}
+          owner: leanprover
+          repositories: lean4
       # The create-github-app-token README states that this token is masked and will not be logged accidentally.
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
         if: always()


### PR DESCRIPTION
This PR moves the GitHub App token generation for posting comments on Lean PRs from the start of the build job to immediately before the comment posting step.

GitHub App installation tokens expire after 1 hour. When the mathlib build takes longer than that (which it often does for `lean-pr-testing-NNNN` branches), the token is stale by the time the "Post comments" step runs, causing failures like:

```
jq: error (at <stdin>:4): Cannot index string with string "name"
```

This error occurs because the expired token causes the GitHub API to return an error response instead of the expected labels array.

Example failure: https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/21728875282

🤖 Prepared with Claude Code