### PR TITLE
[Merged by Bors] - feat: generalize IsStoppingTime.add

### DIFF
--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -311,51 +311,36 @@ theorem add_const [AddGroup ι] [Preorder ι] [AddRightMono ι]
   rw [h_eq]
   exact f.mono (sub_le_self j hi) _ (hτ (j - i))
 
-theorem add_const_nat {f : Filtration ℕ m} {τ : Ω → WithTop ℕ} (hτ : IsStoppingTime f τ) {i : ℕ} :
+theorem add_const' [Add ι] [LinearOrder ι] [CanonicallyOrderedAdd ι] [Countable ι]
+    [TopologicalSpace ι] [OrderTopology ι]
+    {f : Filtration ι m} {τ : Ω → WithTop ι}
+    (hτ : IsStoppingTime f τ) (i : ι) :
     IsStoppingTime f fun ω => τ ω + i := by
-  refine isStoppingTime_of_measurableSet_eq fun j => ?_
-  by_cases! hij : i ≤ j
-  · simp only [ENat.some_eq_coe]
-    have h_eq : {ω | τ ω + i = j} = {ω | τ ω = (j - i : ℕ)} := by
-      ext ω
-      simp only [Set.mem_setOf_eq]
-      cases τ ω with
-      | top => simp
-      | coe a =>
-        simp only [ENat.some_eq_coe, Nat.cast_inj]
-        norm_cast
-        simp_rw [eq_comm, ← Nat.sub_eq_iff_eq_add hij, eq_comm]
-    rw [h_eq]
-    exact f.mono (j.sub_le i) _ (hτ.measurableSet_eq (j - i))
-  · convert @MeasurableSet.empty _ (f.1 j)
+  intro j
+  have h : {ω | τ ω + i ≤ j} = ⋃ k : {k | k + i ≤ j}, {ω | τ ω = k} := by
     ext ω
-    simp only [Set.mem_empty_iff_false, iff_false, Set.mem_setOf]
+    simp only [Set.mem_setOf_eq, Set.mem_iUnion]
     cases τ ω with
     | top => simp
-    | coe a => simp only [ENat.some_eq_coe]; norm_cast; lia
+    | coe a => simp; norm_cast
+  exact h ▸ MeasurableSet.iUnion fun k => hτ.measurableSet_eq_le (le_of_add_le_left k.2)
 
--- generalize to certain countable type?
-theorem add {f : Filtration ℕ m} {τ π : Ω → WithTop ℕ}
+theorem add [Add ι] [LinearOrder ι] [CanonicallyOrderedAdd ι] [Countable ι]
+    [TopologicalSpace ι] [OrderTopology ι]
+    {f : Filtration ι m} {τ π : Ω → WithTop ι}
     (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π) :
     IsStoppingTime f (τ + π) := by
-  intro i
-  simp only [ENat.some_eq_coe]
-  have h : {ω | (τ + π) ω ≤ i} = ⋃ k ≤ i, {ω | π ω = k} ∩ {ω | τ ω + k ≤ i} := by
+  intro j
+  have h : {ω | (τ + π) ω ≤ j} = ⋃ k : Set.Iic j, {ω | π ω = k} ∩ {ω | τ ω + k ≤ j} := by
     ext ω
-    simp only [Pi.add_apply, Set.mem_setOf_eq, Set.mem_iUnion, Set.mem_inter_iff, exists_and_left,
-      exists_prop]
+    simp only [Pi.add_apply, Set.mem_setOf_eq, Set.mem_iUnion, Set.mem_inter_iff]
     cases τ ω with
     | top => simp
     | coe a =>
       cases π ω with
       | top => simp
-      | coe b =>
-        simp only [ENat.some_eq_coe, Nat.cast_inj, exists_eq_left', iff_and_self]
-        norm_cast
-        lia
-  rw [h]
-  exact MeasurableSet.iUnion fun k =>
-    MeasurableSet.iUnion fun hk => (hπ.measurableSet_eq_le hk).inter (hτ.add_const_nat i)
+      | coe b => norm_cast; simpa using le_of_add_le_right
+  exact h ▸ MeasurableSet.iUnion fun k => (hπ.measurableSet_eq_le k.2).inter (hτ.add_const' k.1 j)
 
 section Preorder
 


### PR DESCRIPTION
`IsStoppingTime.add` is originally proved only for `ℕ`. This PR proves the same theorem for a countable linearly ordered set `ι` that is CanonicallyOrderedAdd and equppied with the order topology.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
