### PR TITLE
[Merged by Bors] - ci: Remove unused OTEL endpoint

### DIFF
--- a/.github/workflows/export_telemetry.yaml
+++ b/.github/workflows/export_telemetry.yaml
@@ -21,14 +21,6 @@ jobs:
       - name: Export workflow telemetry
         uses: corentinmusard/otel-cicd-action@7e307f7baefcf4929d94d2844bc72d87566a75c3 # v3.0.0
         with:
-          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          runId: ${{ github.event.workflow_run.id }}
-
-      - name: Export workflow telemetry (alt endpoint)
-        uses: corentinmusard/otel-cicd-action@7e307f7baefcf4929d94d2844bc72d87566a75c3 # v3.0.0
-        with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT_ALT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS_ALT }}
           otelServiceName: "mathlib-ci"


### PR DESCRIPTION
After experimenting, let's keep only one endpoint (Honeycomb)