### PR TITLE
[Merged by Bors] - refactor(Computability): split RecursiveIn out of TuringDegree

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3415,6 +3415,7 @@ public import Mathlib.Computability.PostTuringMachine
 public import Mathlib.Computability.Primrec
 public import Mathlib.Computability.Primrec.Basic
 public import Mathlib.Computability.Primrec.List
+public import Mathlib.Computability.RecursiveIn
 public import Mathlib.Computability.Reduce
 public import Mathlib.Computability.RegularExpressions
 public import Mathlib.Computability.TMComputable

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2025 Tanner Duve. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tanner Duve, Elan Roth
+-/
+module
+
+public import Mathlib.Computability.Partrec
+
+/-!
+# Oracle computability
+
+This file defines oracle computability using partial recursive functions.
+
+## Main definitions
+
+- `RecursiveIn O f`: An inductive definition representing that a partial function `f` is partial
+  recursive given access to a set of oracles O.
+
+## Implementation notes
+
+The type of partial functions recursive in a set of oracles `O` is the smallest type containing
+the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
+and is closed under pairing, composition, primitive recursion, and μ-recursion.
+
+## References
+
+* [Odifreddi1989] Odifreddi, Piergiorgio.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
+  Vol. I*. Springer-Verlag, 1989.
+
+## Tags
+
+Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
+-/
+
+@[expose] public section
+
+open Primrec Nat.Partrec Part
+
+variable {f g h : ℕ →. ℕ}
+
+/--
+The type of partial functions recursive in a set of oracles `O` is the smallest type containing
+the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
+and is closed under pairing, composition, primitive recursion, and μ-recursion.
+-/
+inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
+  | zero : RecursiveIn O fun _ => 0
+  | succ : RecursiveIn O Nat.succ
+  | left : RecursiveIn O fun n => (Nat.unpair n).1
+  | right : RecursiveIn O fun n => (Nat.unpair n).2
+  | oracle : ∀ g ∈ O, RecursiveIn O g
+  | pair {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun n => (Nat.pair <$> f n <*> h n)
+  | comp {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun n => h n >>= f
+  | prec {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
+      RecursiveIn O fun p =>
+        let (a, n) := Nat.unpair p
+        n.rec (f a) fun y IH => do
+          let i ← IH
+          h (Nat.pair a (Nat.pair y i))
+  | rfind {f : ℕ →. ℕ} (hf : RecursiveIn O f) :
+      RecursiveIn O fun a =>
+        Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
+
+@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
+  mp fRecInNone := by
+    induction fRecInNone with repeat {constructor}
+    | oracle _ hg => simp at hg
+    | pair | comp | prec | rfind =>
+      repeat {constructor; assumption; try assumption}
+  mpr pF := by
+    induction pF with repeat {constructor}
+    | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+    | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+    | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+    | rfind _ ih => exact RecursiveIn.rfind ih

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -23,12 +23,6 @@ The type of partial functions recursive in a set of oracles `O` is the smallest 
 the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
 and is closed under pairing, composition, primitive recursion, and μ-recursion.
 
-## References
-
-* [Odifreddi1989] Odifreddi, Piergiorgio.
-  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
-  Vol. I*. Springer-Verlag, 1989.
-
 ## Tags
 
 Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -5,20 +5,17 @@ Authors: Tanner Duve, Elan Roth
 -/
 module
 
-public import Mathlib.Computability.Partrec
+public import Mathlib.Computability.RecursiveIn
 public import Mathlib.Order.Antisymmetrization
 
 /-!
-# Oracle computability and Turing degrees
+# Turing degrees
 
-This file defines a model of oracle computability using partial recursive functions. It introduces
-Turing reducibility and equivalence, proves that Turing equivalence is an equivalence relation, and
-defines Turing degrees as the quotient under this relation.
+This file defines Turing reducibility and equivalence, proves that Turing equivalence is an
+equivalence relation, and defines Turing degrees as the quotient under this relation.
 
 ## Main definitions
 
-- `RecursiveIn O f`: An inductive definition representing that a partial function `f` is partially
-  recursive given access to a set of oracles O.
 - `TuringReducible`: A relation defining Turing reducibility between partial functions.
 - `TuringEquivalent`: An equivalence relation defining Turing equivalence between partial functions.
 - `TuringDegree`: The type of Turing degrees, defined as the quotient of partial functions under
@@ -28,12 +25,6 @@ defines Turing degrees as the quotient under this relation.
 
 - `f ≤ᵀ g` : `f` is Turing reducible to `g`.
 - `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
-
-## Implementation notes
-
-The type of partial functions recursive in a set of oracles `O` is the smallest type containing
-the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
-and is closed under pairing, composition, primitive recursion, and μ-recursion.
 
 ## References
 
@@ -52,30 +43,6 @@ open Primrec Nat.Partrec Part
 
 variable {f g h : ℕ →. ℕ}
 
-/--
-The type of partial functions recursive in a set of oracles `O` is the smallest type containing
-the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
-and is closed under pairing, composition, primitive recursion, and μ-recursion.
--/
-inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
-  | zero : RecursiveIn O fun _ => 0
-  | succ : RecursiveIn O Nat.succ
-  | left : RecursiveIn O fun n => (Nat.unpair n).1
-  | right : RecursiveIn O fun n => (Nat.unpair n).2
-  | oracle : ∀ g ∈ O, RecursiveIn O g
-  | pair {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
-      RecursiveIn O fun n => (Nat.pair <$> f n <*> h n)
-  | comp {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
-      RecursiveIn O fun n => h n >>= f
-  | prec {f h : ℕ →. ℕ} (hf : RecursiveIn O f) (hh : RecursiveIn O h) :
-      RecursiveIn O fun p =>
-        let (a, n) := Nat.unpair p
-        n.rec (f a) fun y IH => do
-          let i ← IH
-          h (Nat.pair a (Nat.pair y i))
-  | rfind {f : ℕ →. ℕ} (hf : RecursiveIn O f) :
-      RecursiveIn O fun a =>
-        Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
 /--
 `f` is Turing reducible to `g` if `f` is partial recursive given access to the oracle `g`
 -/
@@ -163,16 +130,3 @@ private instance : Preorder (ℕ →. ℕ) where
 
 instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
   instPartialOrderAntisymmetrization
-
-@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
-  mp fRecInNone := by
-    induction fRecInNone with repeat {constructor}
-    | oracle _ hg => simp at hg
-    | pair | comp | prec | rfind =>
-      repeat {constructor; assumption; try assumption}
-  mpr pF := by
-    induction pF with repeat {constructor}
-    | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-    | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-    | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-    | rfind _ ih => exact RecursiveIn.rfind ih


### PR DESCRIPTION
Move-only refactor: extracts `RecursiveIn` into its own file. per @eric-wieser suggestion in #34899 . the `TuringDegree` header is also edited because it no longer contains definitions of oracle computability and recursive in

note: cursor agent was allowed to execute some git commands