### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): `Semiring` structure on ideal sheaves

### DIFF
--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -325,6 +325,9 @@ lemma coe_support_eq_eq_iInter_zeroLocus :
     (I.support : Set X) = ⋂ U, X.zeroLocus (U := U.1) (I.ideal U) :=
   I.supportSet_eq_iInter_zeroLocus
 
+@[simp] lemma mem_supportSet_iff_mem_support {I : IdealSheafData X} {x} :
+    x ∈ I.supportSet ↔ x ∈ I.support := .rfl
+
 lemma mem_support_iff {I : IdealSheafData X} {x} :
     x ∈ I.support ↔ ∀ U, x ∈ X.zeroLocus (U := U.1) (I.ideal U) :=
   (Set.ext_iff.mp I.supportSet_eq_iInter_zeroLocus _).trans Set.mem_iInter
@@ -397,38 +400,21 @@ instance : One X.IdealSheafData where one := ⊤
 instance : Add X.IdealSheafData where add := (· ⊔ ·)
 
 instance : Mul X.IdealSheafData where
-  mul I J :=
-  { ideal := I.ideal * J.ideal
-    map_ideal_basicOpen U f := by simp [Ideal.map_mul, map_ideal_basicOpen]
-    supportSet := I.supportSet ∪ J.supportSet
-    supportSet_eq_iInter_zeroLocus := by
-      simp only [Pi.mul_apply, Set.iInter_coe_set, zeroLocus_mul]
-      apply subset_antisymm
-      · simp only [Set.subset_iInter_iff, Set.union_subset_iff]
-        exact fun U hU ↦ ⟨Set.subset_union_of_subset_left (I.supportSet_subset_zeroLocus ..) _,
-          Set.subset_union_of_subset_right (J.supportSet_subset_zeroLocus ..) _⟩
-      · simp only [Set.subset_def, Set.mem_iInter, Set.mem_union]
-        intro x hx
-        obtain ⟨_, ⟨U, hU, rfl⟩, hxU, -⟩ :=
-          X.isBasis_affineOpens.exists_subset_of_mem_open (Set.mem_univ x) isOpen_univ
-        refine (hx U hU).imp (mem_support_iff_of_mem (U := ⟨U, hU⟩) hxU).mpr
-          (mem_support_iff_of_mem (U := ⟨U, hU⟩) hxU).mpr }
+  mul I J := mkOfMemSupportIff (I.ideal * J.ideal) (by simp [Ideal.map_mul, map_ideal_basicOpen])
+    (I.supportSet ∪ J.supportSet) fun U x hxU ↦ by
+    simp [-mem_zeroLocus_iff, zeroLocus_mul, mem_support_iff_of_mem hxU]
 
 instance : Pow X.IdealSheafData ℕ where
-  pow I n :=
-  { ideal := I.ideal ^ n
-    map_ideal_basicOpen := by simp [Ideal.map_pow, map_ideal_basicOpen]
-    supportSet := n.casesOn ∅ fun _ ↦ I.supportSet
-    supportSet_eq_iInter_zeroLocus := by
-      induction n with
-      | zero => convert (⊤ : X.IdealSheafData).supportSet_eq_iInter_zeroLocus; ext; simp
-      | succ n IH =>
-        let J : X.IdealSheafData := ⟨_, by simp [Ideal.map_pow, map_ideal_basicOpen], _, IH⟩
-        exact (Set.union_eq_right.mpr (by cases n <;> simp [J])).symm.trans
-          (J * I).supportSet_eq_iInter_zeroLocus }
+  pow I n := mkOfMemSupportIff (I.ideal ^ n) (by simp [Ideal.map_pow, map_ideal_basicOpen])
+    (if n = 0 then ∅ else I.supportSet) fun U x hxU ↦ .symm <| by
+    induction n <;> simp_all [-mem_zeroLocus_iff, zeroLocus_mul,
+      pow_succ, mem_support_iff_of_mem hxU]
 
 @[simp] lemma ideal_mul : (I * J).ideal = I.ideal * J.ideal := rfl
 @[simp] lemma support_mul : (I * J).support = I.support ⊔ J.support := rfl
+@[simp] lemma ideal_pow (n : ℕ) : (I ^ n).ideal = I.ideal ^ n := rfl
+@[simp] lemma support_pow_succ (n : ℕ) : (I ^ (n + 1)).support = I.support := rfl
+lemma support_pow (n : ℕ) (hn : n ≠ 0) : (I ^ n).support = I.support := by cases n <;> simp_all
 
 @[simp] lemma top_mul : ⊤ * I = I := by ext; simp
 @[simp] lemma mul_top : I * ⊤ = I := by ext; simp

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -475,7 +475,6 @@ lemma ext_of_isAffine [IsAffine X] {I J : IdealSheafData X}
   (le_of_isAffine H.le).antisymm (le_of_isAffine H.ge)
 
 /-- Over affine schemes, ideal sheaves are in bijection with ideals of the global sections. -/
-@[simps]
 def equivOfIsAffine [IsAffine X] : IdealSheafData X ≃+*o Ideal Γ(X, ⊤) where
   toFun := (ideal · ⟨⊤, isAffineOpen_top X⟩)
   invFun := ofIdealTop
@@ -484,6 +483,14 @@ def equivOfIsAffine [IsAffine X] : IdealSheafData X ≃+*o Ideal Γ(X, ⊤) wher
   map_mul' := by simp
   map_add' := by simp
   map_le_map_iff' := ⟨le_of_isAffine, (· _)⟩
+
+@[simp]
+lemma equivOfIsAffine_apply [IsAffine X] (I : IdealSheafData X) :
+    equivOfIsAffine I = I.ideal ⟨⊤, isAffineOpen_top X⟩ := rfl
+
+@[simp]
+lemma equivOfIsAffine_symm_apply [IsAffine X] (I : Ideal Γ(X, ⊤)) :
+    equivOfIsAffine.symm I = ofIdealTop I := rfl
 
 end IsAffine
 

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -388,6 +388,82 @@ lemma support_eq_bot_iff : support I = ⊥ ↔ I = ⊤ := by
 
 end support
 
+section Semiring
+
+variable (I J K : X.IdealSheafData)
+
+instance : Zero X.IdealSheafData where zero := ⊥
+instance : One X.IdealSheafData where one := ⊤
+instance : Add X.IdealSheafData where add := (· ⊔ ·)
+
+instance : Mul X.IdealSheafData where
+  mul I J :=
+  { ideal := I.ideal * J.ideal
+    map_ideal_basicOpen U f := by simp [Ideal.map_mul, map_ideal_basicOpen]
+    supportSet := I.supportSet ∪ J.supportSet
+    supportSet_eq_iInter_zeroLocus := by
+      simp only [Pi.mul_apply, Set.iInter_coe_set, zeroLocus_mul]
+      apply subset_antisymm
+      · simp only [Set.subset_iInter_iff, Set.union_subset_iff]
+        exact fun U hU ↦ ⟨Set.subset_union_of_subset_left (I.supportSet_subset_zeroLocus ..) _,
+          Set.subset_union_of_subset_right (J.supportSet_subset_zeroLocus ..) _⟩
+      · simp only [Set.subset_def, Set.mem_iInter, Set.mem_union]
+        intro x hx
+        obtain ⟨_, ⟨U, hU, rfl⟩, hxU, -⟩ :=
+          X.isBasis_affineOpens.exists_subset_of_mem_open (Set.mem_univ x) isOpen_univ
+        refine (hx U hU).imp (mem_support_iff_of_mem (U := ⟨U, hU⟩) hxU).mpr
+          (mem_support_iff_of_mem (U := ⟨U, hU⟩) hxU).mpr }
+
+instance : Pow X.IdealSheafData ℕ where
+  pow I n :=
+  { ideal := I.ideal ^ n
+    map_ideal_basicOpen := by simp [Ideal.map_pow, map_ideal_basicOpen]
+    supportSet := n.casesOn ∅ fun _ ↦ I.supportSet
+    supportSet_eq_iInter_zeroLocus := by
+      induction n with
+      | zero => convert (⊤ : X.IdealSheafData).supportSet_eq_iInter_zeroLocus; ext; simp
+      | succ n IH =>
+        let J : X.IdealSheafData := ⟨_, by simp [Ideal.map_pow, map_ideal_basicOpen], _, IH⟩
+        exact (Set.union_eq_right.mpr (by cases n <;> simp [J])).symm.trans
+          (J * I).supportSet_eq_iInter_zeroLocus }
+
+@[simp] lemma ideal_mul : (I * J).ideal = I.ideal * J.ideal := rfl
+@[simp] lemma support_mul : (I * J).support = I.support ⊔ J.support := rfl
+
+@[simp] lemma top_mul : ⊤ * I = I := by ext; simp
+@[simp] lemma mul_top : I * ⊤ = I := by ext; simp
+@[simp] lemma bot_mul : ⊥ * I = ⊥ := by ext; simp
+@[simp] lemma mul_bot : I * ⊥ = ⊥ := by ext; simp
+lemma mul_inf : I * (J ⊔ K) = I * J ⊔ I * K := by ext U : 2; exact mul_add _ _ _
+lemma inf_mul : (I ⊔ J) * K = I * K ⊔ J * K := by ext U : 2; exact add_mul _ _ _
+
+instance : IdemCommSemiring X.IdealSheafData where
+  add_assoc := sup_assoc
+  zero_add := bot_sup_eq
+  add_zero := sup_bot_eq
+  add_comm := sup_comm
+  mul_assoc _ _ _ := IdealSheafData.ext (mul_assoc _ _ _)
+  mul_comm _ _ := IdealSheafData.ext (mul_comm _ _)
+  zero_mul := bot_mul
+  mul_zero := mul_bot
+  one_mul := top_mul
+  mul_one := mul_top
+  nsmul := nsmulRec
+  left_distrib := mul_inf
+  right_distrib := inf_mul
+  npow_zero _ := by ext; rfl
+  npow_succ _ _ := by ext; rfl
+  bot_le _ := bot_le
+
+instance : IsOrderedRing X.IdealSheafData where
+
+/-! We follow `Ideal` and set the simp normal form to be `⊥` and `⊤` and `⊔`. -/
+@[simp] lemma zero_eq_bot : (0 : X.IdealSheafData) = ⊥ := rfl
+@[simp] lemma one_eq_top : (1 : X.IdealSheafData) = ⊤ := rfl
+@[simp] lemma add_eq_sup : I + J = I ⊔ J := rfl
+
+end Semiring
+
 section IsAffine
 
 /-- The ideal sheaf induced by an ideal of the global sections. -/
@@ -414,12 +490,14 @@ lemma ext_of_isAffine [IsAffine X] {I J : IdealSheafData X}
 
 /-- Over affine schemes, ideal sheaves are in bijection with ideals of the global sections. -/
 @[simps]
-def equivOfIsAffine [IsAffine X] : IdealSheafData X ≃o Ideal Γ(X, ⊤) where
+def equivOfIsAffine [IsAffine X] : IdealSheafData X ≃+*o Ideal Γ(X, ⊤) where
   toFun := (ideal · ⟨⊤, isAffineOpen_top X⟩)
   invFun := ofIdealTop
   left_inv I := ext_of_isAffine (by simp)
   right_inv I := by simp
-  map_rel_iff' {I J} := ⟨le_of_isAffine, (· _)⟩
+  map_mul' := by simp
+  map_add' := by simp
+  map_le_map_iff' := ⟨le_of_isAffine, (· _)⟩
 
 end IsAffine
 
@@ -470,9 +548,15 @@ lemma radical_sup {I J : IdealSheafData X} :
 
 @[simp]
 lemma radical_inf {I J : IdealSheafData X} :
-    radical (I ⊓ J) = (radical I ⊓ radical J) := by
+    radical (I ⊓ J) = radical I ⊓ radical J := by
   ext U : 2
   simp only [radical_ideal, ideal_inf, Pi.inf_apply, Ideal.radical_inf]
+
+@[simp]
+lemma radical_mul {I J : IdealSheafData X} :
+    radical (I * J) = radical I ⊓ radical J := by
+  ext U : 2
+  simp only [radical_ideal, ideal_mul, Pi.mul_apply, Ideal.radical_mul, ideal_inf, Pi.inf_apply]
 
 /-- The vanishing ideal sheaf of a closed set,
 which is the largest ideal sheaf whose support is equal to it.

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -771,6 +771,18 @@ lemma zeroLocus_span {U : X.Opens} (s : Set Γ(X, U)) :
   · exact fun a b _ _ ha hb H ↦ (X.basicOpen_add_le a b H).elim ha hb
   · simp +contextual
 
+open scoped Pointwise in
+lemma zeroLocus_setMul {U : X.Opens} (s t : Set Γ(X, U)) :
+    X.zeroLocus (s * t) = X.zeroLocus s ∪ X.zeroLocus t := by
+  simp only [← Set.image2_mul, zeroLocus_def, Set.biInter_image2]
+  simp [Set.compl_inter, ← Set.union_iInter₂, ← Set.iInter₂_union]
+
+open scoped Pointwise in
+lemma zeroLocus_mul {U : X.Opens} (I J : Ideal Γ(X, U)) :
+    X.zeroLocus (U := U) ↑(I * J) = X.zeroLocus (U := U) I ∪ X.zeroLocus (U := U) J := by
+  rw [← X.zeroLocus_setMul, ← X.zeroLocus_span (U := U) (↑I * ↑J), ← Ideal.span_mul_span]
+  simp
+
 lemma zeroLocus_map {U V : X.Opens} (i : U ≤ V) (s : Set Γ(X, V)) :
     X.zeroLocus ((X.presheaf.map (homOfLE i).op).hom '' s) = X.zeroLocus s ∪ Uᶜ := by
   ext x


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
