### PR TITLE
feat(Computability): semilattice instance on Turing degrees

### DIFF
--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -783,40 +783,29 @@ lemma kronecker_partrec : Nat.Partrec Partrec.kronecker := by
   exact (Partrec.nat_iff).1 (hcomp.partrec.of_eq fun p => by
     simp only [Partrec.kronecker]; exact congrArg Part.some (Bool.cond_decide _ _ _))
 
-def flip10 (m : ℕ) : ℕ := if m = 1 then 0 else 1
-
-lemma flip10_partrec : Nat.Partrec (fun m => Part.some (Partrec.flip10 m)) := by
-  have hc : Computable (fun m : ℕ => m == 1) :=
-    (Primrec.beq.comp Primrec.id (Primrec.const 1)).to_comp
-  have hcomp : Computable (fun m : ℕ => cond (m == 1) (0 : ℕ) 1) :=
-    Computable.cond hc (Computable.const 0) (Computable.const 1)
-  exact (Partrec.nat_iff).1 (hcomp.partrec.of_eq fun m => by
-    simp only [Partrec.flip10]
-    exact congrArg Part.some (Bool.cond_decide _ _ _))
-
 lemma kronecker_rfind_none :
     Nat.rfind (fun k => (fun m : ℕ => m = 0) <$>
-        Part.map Partrec.flip10
+        Part.map (1 - ·)
           (((Nat.pair <$> (Part.none : Part ℕ) <*> Part.some k) >>= Partrec.kronecker))) =
       Part.none :=
   Nat.rfind_zero_none
     (p := fun k => (fun m : ℕ => m = 0) <$>
-      Part.map Partrec.flip10
+      Part.map (1 - ·)
         (((Nat.pair <$> (Part.none : Part ℕ) <*> Part.some k) >>= Partrec.kronecker)))
     (by simp [Seq.seq])
 
 lemma kronecker_rfind_some (n : ℕ) :
     Nat.rfind (fun k => (fun m : ℕ => m = 0) <$>
-        Part.map Partrec.flip10
+        Part.map (1 - ·)
           (((Nat.pair <$> (Part.some n : Part ℕ) <*> Part.some k) >>= Partrec.kronecker))) =
       Part.some n := by
   refine Part.mem_right_unique (Nat.mem_rfind.2 ⟨?_, ?_⟩) (Part.mem_some n)
-  · simp [Partrec.kronecker, Partrec.flip10, Seq.seq]
-  · intro m hm; simp [Partrec.kronecker, Partrec.flip10, Seq.seq, Nat.ne_of_gt hm]
+  · simp [Partrec.kronecker, Seq.seq]
+  · intro m hm; simp [Partrec.kronecker, Seq.seq, Nat.ne_of_gt hm]
 
 lemma kronecker_rfind (v : Part ℕ) :
     Nat.rfind (fun k => (fun m : ℕ => m = 0) <$>
-        Part.map Partrec.flip10
+        Part.map (1 - ·)
           (((Nat.pair <$> v <*> Part.some k) >>= Partrec.kronecker))) = v := by
   refine Part.induction_on v ?_ ?_
   · simpa using kronecker_rfind_none

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -80,7 +80,7 @@ inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
         Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
 
 namespace Nat
-/-- The primitive recursive functions `ℕ → ℕ`. -/
+/-- The primitive recursive functions `ℕ → ℕ`, with respect to an oracle `O`. -/
 protected inductive PrimrecIn (O : Set (ℕ → ℕ)) : (ℕ → ℕ) → Prop
   | zero : Nat.PrimrecIn O fun _ => 0
   | protected succ : Nat.PrimrecIn O succ

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Antisymmetrization
 
 This file defines oracle computability using partial recursive functions with access to oracles.
 
-## Main Definitions
+## Main definitions
 
 * `RecursiveIn O f`: A partial function `f : ℕ →. ℕ` is partial recursive given access to oracles
   in the set `O`.
@@ -22,7 +22,7 @@ This file defines oracle computability using partial recursive functions with ac
 * `RecursiveIn' O f`: Lifts `RecursiveIn` to partial functions between `Primcodable` types.
 * `ComputableIn O f`: A total function `f : α → σ` is computable given access to oracles in `O`.
 
-## Main Results
+## Main results
 
 * `Nat.Partrec.recursiveIn`: Every partial recursive function is recursive in any oracle set.
 * `partrec_iff_forall_recursiveIn`: A function is partial recursive iff it is recursive in every
@@ -31,7 +31,7 @@ This file defines oracle computability using partial recursive functions with ac
   partial recursive.
 * `RecursiveIn.mono`: Monotonicity of `RecursiveIn` with respect to oracle sets.
 
-## Implementation Notes
+## Implementation notes
 
 The type of partial functions recursive in a set of oracles `O` is the smallest type containing
 the constant zero, the successor, left and right projections, each oracle `g ∈ O`,

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -9,7 +9,7 @@ public import Mathlib.Computability.Partrec
 public import Mathlib.Order.Antisymmetrization
 
 /-!
-# Oracle Computability
+# Oracle computability
 
 This file defines oracle computability using partial recursive functions with access to oracles.
 

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -3,25 +3,46 @@ Copyright (c) 2025 Tanner Duve. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tanner Duve, Elan Roth
 -/
+
 module
 
 public import Mathlib.Computability.Partrec
+public import Mathlib.Order.Antisymmetrization
 
 /-!
-# Oracle computability
+# Oracle Computability
 
-This file defines oracle computability using partial recursive functions.
+This file defines oracle computability using partial recursive functions with access to oracles.
 
-## Main definitions
+## Main Definitions
 
-- `RecursiveIn O f`: An inductive definition representing that a partial function `f` is partial
-  recursive given access to a set of oracles O.
+* `RecursiveIn O f`: A partial function `f : ℕ →. ℕ` is partial recursive given access to oracles
+  in the set `O`.
+* `Nat.PrimrecIn O f`: A total function `f : ℕ → ℕ` is primitive recursive relative to oracles
+  in the set `O`.
+* `RecursiveIn' O f`: Lifts `RecursiveIn` to partial functions between `Primcodable` types.
+* `ComputableIn O f`: A total function `f : α → σ` is computable given access to oracles in `O`.
 
-## Implementation notes
+## Main Results
+
+* `Nat.Partrec.recursiveIn`: Every partial recursive function is recursive in any oracle set.
+* `partrec_iff_forall_recursiveIn`: A function is partial recursive iff it is recursive in every
+  singleton oracle set.
+* `recursiveIn_empty_iff_partrec`: Being recursive in the empty set is equivalent to being
+  partial recursive.
+* `RecursiveIn.mono`: Monotonicity of `RecursiveIn` with respect to oracle sets.
+
+## Implementation Notes
 
 The type of partial functions recursive in a set of oracles `O` is the smallest type containing
 the constant zero, the successor, left and right projections, each oracle `g ∈ O`,
 and is closed under pairing, composition, primitive recursion, and μ-recursion.
+
+## References
+
+* [Odifreddi1989] Odifreddi, Piergiorgio.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
+  Vol. I*. Springer-Verlag, 1989.
 
 ## Tags
 
@@ -30,9 +51,9 @@ Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
 
 @[expose] public section
 
-open Primrec Nat.Partrec Part
+open Encodable Primrec Nat.Partrec Part
 
-variable {f g h : ℕ →. ℕ}
+variable {f g h : ℕ →. ℕ} {O : Set (ℕ →. ℕ)} {α β γ σ : Type*}
 
 /--
 The type of partial functions recursive in a set of oracles `O` is the smallest type containing
@@ -59,15 +80,352 @@ inductive RecursiveIn (O : Set (ℕ →. ℕ)) : (ℕ →. ℕ) → Prop
       RecursiveIn O fun a =>
         Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a n)
 
-@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
-  mp fRecInNone := by
-    induction fRecInNone with repeat {constructor}
-    | oracle _ hg => simp at hg
-    | pair | comp | prec | rfind =>
-      repeat {constructor; assumption; try assumption}
-  mpr pF := by
-    induction pF with repeat {constructor}
-    | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-    | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-    | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-    | rfind _ ih => exact RecursiveIn.rfind ih
+namespace Nat
+/-- The primitive recursive functions `ℕ → ℕ`. -/
+protected inductive PrimrecIn (O : Set (ℕ → ℕ)) : (ℕ → ℕ) → Prop
+  | zero : Nat.PrimrecIn O fun _ => 0
+  | protected succ : Nat.PrimrecIn O succ
+  | left : Nat.PrimrecIn O fun n => n.unpair.1
+  | right : Nat.PrimrecIn O fun n => n.unpair.2
+  | oracle : ∀ g ∈ O, Nat.PrimrecIn O g
+  | pair {f g} : Nat.PrimrecIn O f → Nat.PrimrecIn O g → Nat.PrimrecIn O fun n => pair (f n) (g n)
+  | comp {f g} : Nat.PrimrecIn O f → Nat.PrimrecIn O g → Nat.PrimrecIn O fun n => f (g n)
+  | prec {f g} :
+      Nat.PrimrecIn O f →
+        Nat.PrimrecIn O g →
+          Nat.PrimrecIn O (unpaired fun z n => n.rec (f z) fun y IH => g <| pair z <| pair y IH)
+end Nat
+
+/--
+Encode a partial function between `Primcodable` types as a partial function `ℕ →. ℕ`.
+-/
+def liftPrim {α σ} [Primcodable α] [Primcodable σ] (f : α →. σ) : ℕ →. ℕ :=
+  fun n => Part.bind (decode (α := α) n) fun a => (f a).map encode
+
+/--
+Encode a total function between `Primcodable` types as a total function `ℕ → ℕ`.
+If decoding fails, the output defaults to `0`.
+-/
+def liftPrimrec {α σ} [Primcodable α] [Primcodable σ] (f : α → σ) : ℕ → ℕ :=
+  fun n => (decode (α := α) n).map (fun a => encode (f a)) |>.getD 0
+
+/-- Lift `RecursiveIn` from `ℕ →. ℕ` to partial functions between `Primcodable` types. -/
+def RecursiveIn' {α σ} [Primcodable α] [Primcodable σ] (O : Set (ℕ →. ℕ)) (f : α →. σ) : Prop :=
+  RecursiveIn O (liftPrim f)
+
+/-- Relative primitive recursion between primcodable types -/
+def PrimrecIn' {α σ} [Primcodable α] [Primcodable σ] (O : Set (ℕ → ℕ)) (f : α → σ) : Prop :=
+  Nat.PrimrecIn O (liftPrimrec f)
+
+/-- A binary partial function is recursive in `O` if the curried form is. -/
+def RecursiveIn₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
+    (O : Set (ℕ →. ℕ)) (f : α → β →. σ) : Prop :=
+  RecursiveIn' O (fun p : α × β => f p.1 p.2)
+
+/-- A total function is computable in `O` if its constant lift is recursive in `O`. -/
+def ComputableIn {α σ} [Primcodable α] [Primcodable σ] (O : Set (ℕ →. ℕ)) (f : α → σ) : Prop :=
+  RecursiveIn' O (fun a => Part.some (f a))
+
+/-- A binary total function is computable in `O`. -/
+def ComputableIn₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
+    (O : Set (ℕ →. ℕ)) (f : α → β → σ) : Prop :=
+  ComputableIn O (fun p : α × β => f p.1 p.2)
+
+namespace RecursiveIn
+
+theorem of_eq {f g : ℕ →. ℕ} {O : Set (ℕ →. ℕ)} (hf : RecursiveIn O f) (H : ∀ n, f n = g n) :
+    RecursiveIn O g :=
+  (funext H : f = g) ▸ hf
+
+theorem of_eq_tot {f : ℕ →. ℕ} {g : ℕ → ℕ} {O : Set (ℕ →. ℕ)} (hf : RecursiveIn O f)
+    (H : ∀ n, g n ∈ f n) : RecursiveIn O g :=
+  of_eq hf fun n => eq_some_iff.2 (H n)
+
+end RecursiveIn
+/--
+If a function is partial recursive, then it is recursive in every partial function.
+-/
+lemma Nat.Partrec.recursiveIn {O : Set (ℕ →. ℕ)} (pF : Nat.Partrec f) : RecursiveIn O f := by
+  induction pF with
+  | zero | succ | left | right => constructor
+  | pair _ _ ih₁ ih₂ => exact .pair ih₁ ih₂
+  | comp _ _ ih₁ ih₂ => exact .comp ih₁ ih₂
+  | prec _ _ ih₁ ih₂ => exact .prec ih₁ ih₂
+  | rfind _ ih => exact .rfind ih
+
+/--
+If a function is computable, then it is computable in every oracle.
+-/
+theorem Computable.computableIn {f : α → β} [Primcodable α] [Primcodable β]
+    (hf : Computable f) : ComputableIn O f :=
+  Nat.Partrec.recursiveIn (by simpa [Computable] using hf)
+
+namespace RecursiveIn
+
+theorem of_primrec {O : Set (ℕ →. ℕ)} {f : ℕ → ℕ} (hf : Nat.Primrec f) :
+    RecursiveIn O (fun n => f n) :=
+  Nat.Partrec.recursiveIn (Nat.Partrec.of_primrec hf)
+
+protected theorem some {O : Set (ℕ →. ℕ)} : RecursiveIn O some :=
+  of_primrec (O := O) Nat.Primrec.id
+
+theorem none {O : Set (ℕ →. ℕ)} : RecursiveIn O (fun _ => none) :=
+  (of_primrec (O := O) (Nat.Primrec.const 1)).rfind.of_eq fun _ =>
+    eq_none_iff.2 fun _ ⟨h, _⟩ => by simp at h
+
+end RecursiveIn
+
+theorem Primrec.to_computableIn {α σ} [Primcodable α] [Primcodable σ]
+    {f : α → σ} (hf : Primrec f) (O : Set (ℕ →. ℕ)) :
+    ComputableIn O f := Computable.computableIn (Primrec.to_comp hf)
+
+nonrec theorem Primrec₂.to_computableIn₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
+    {f : α → β → σ} (hf : Primrec₂ f) (O : Set (ℕ →. ℕ)) :
+    ComputableIn₂ O f :=
+  Primrec.to_computableIn hf O
+
+protected theorem ComputableIn.recursiveIn' {α σ} [Primcodable α] [Primcodable σ]
+    {f : α → σ} {O} (hf : ComputableIn O f) :
+    RecursiveIn' O (fun a => Part.some (f a)) := hf
+
+protected theorem ComputableIn₂.recursiveIn₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
+    {f : α → β → σ} {O} (hf : ComputableIn₂ O f) :
+    RecursiveIn₂ O fun a => (f a : β →. σ) := hf
+
+variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable σ]
+
+theorem const_in (O : Set (ℕ →. ℕ)) (s : σ) : ComputableIn O (fun _ : α => s) :=
+  Primrec.to_computableIn (Primrec.const s) O
+
+theorem id_in (O : Set (ℕ →. ℕ)) : ComputableIn O (@id α) :=
+  Primrec.to_computableIn Primrec.id O
+
+theorem fst_in (O : Set (ℕ →. ℕ)) : ComputableIn O (@Prod.fst α β) :=
+  Primrec.to_computableIn Primrec.fst O
+
+theorem snd_in (O : Set (ℕ →. ℕ)) : ComputableIn O (@Prod.snd α β) :=
+  Primrec.to_computableIn Primrec.snd O
+
+theorem unpair_in (O : Set (ℕ →. ℕ)) : ComputableIn O Nat.unpair :=
+  Primrec.to_computableIn Primrec.unpair O
+
+theorem succ_in (O : Set (ℕ →. ℕ)) : ComputableIn O Nat.succ :=
+  Primrec.to_computableIn Primrec.succ O
+
+theorem sumInl_in (O : Set (ℕ →. ℕ)) : ComputableIn O (@Sum.inl α β) :=
+  Primrec.to_computableIn Primrec.sumInl O
+
+theorem sumInr_in (O : Set (ℕ →. ℕ)) : ComputableIn O (@Sum.inr α β) :=
+  Primrec.to_computableIn Primrec.sumInr O
+
+/--
+If every function in `O` is partial recursive,
+then a function which is RecursiveIn g is also partial recursive.
+-/
+theorem partrec_of_partrec_oracle (h₁ : ∀ g ∈ O, Nat.Partrec g) (h₂ : RecursiveIn O f) :
+  Nat.Partrec f := by
+  induction h₂ with
+  | zero | succ | left | right => constructor
+  | oracle g gIn => exact h₁ g gIn
+  | pair _ _ ih₁ ih₂ => exact .pair ih₁ ih₂
+  | comp _ _ ih₁ ih₂ => exact .comp ih₁ ih₂
+  | prec _ _ ih₁ ih₂ => exact .prec ih₁ ih₂
+  | rfind _ ih => exact .rfind ih
+
+/--
+If a function is recursive in the constant zero function,
+then it is partial recursive.
+-/
+lemma RecursiveIn.partrec_of_zero (fRecInZero : RecursiveIn {fun _ => Part.some 0} f) :
+    Nat.Partrec f :=
+  partrec_of_partrec_oracle
+    (fun _ gIn =>
+      (Set.mem_singleton_iff.mp gIn).symm ▸
+        (Nat.Partrec.zero.of_eq fun _ => rfl))
+    fRecInZero
+
+/--
+If a function is partial recursive in the constant none function,
+then it is partial recursive.
+-/
+lemma RecursiveIn.partrec_of_none (fRecInNone : RecursiveIn {fun _ => Part.none} f) :
+    Nat.Partrec f :=
+  partrec_of_partrec_oracle
+    (fun _ gIn =>
+      (Set.mem_singleton_iff.mp gIn).symm ▸
+        (Nat.Partrec.none.of_eq fun _ => rfl))
+    fRecInNone
+
+/--
+A partial function `f` is partial recursive if and only if it is recursive in
+every partial function `g`.
+-/
+theorem partrec_iff_forall_recursiveIn : Nat.Partrec f ↔ ∀ g, RecursiveIn {g} f :=
+  ⟨fun hf _ ↦ hf.recursiveIn, (· _ |>.partrec_of_zero)⟩
+
+@[simp]
+lemma recursiveIn_empty_iff_partrec : RecursiveIn ({} : Set (ℕ →. ℕ)) f ↔ Nat.Partrec f :=
+⟨
+  fun hf =>
+    partrec_of_partrec_oracle (O := ({} : Set (ℕ →. ℕ))) (f := f)
+      (fun g hg => ((Set.mem_empty_iff_false g).mp hg).elim)
+      hf,
+  fun hf =>
+    Nat.Partrec.recursiveIn (O := ({} : Set (ℕ →. ℕ))) hf
+⟩
+
+namespace RecursiveIn
+
+/-- If every element of O₁ is RecursiveIn O₂, then any function which is RecursiveIn O₁
+ is also RecursiveIn O₂ -/
+theorem subst {O O' : Set (ℕ →. ℕ)} {f : ℕ →. ℕ} (hf : RecursiveIn O f)
+    (hO : ∀ g, g ∈ O → RecursiveIn O' g) : RecursiveIn O' f := by
+  induction hf with
+  | zero | succ | left | right =>
+      constructor
+  | oracle g hg => exact hO g hg
+  | pair _ _ ihf ihg => exact .pair ihf ihg
+  | comp _ _ ihf ihg => exact .comp ihf ihg
+  | prec _ _ ihf ihg => exact .prec ihf ihg
+  | rfind _ ihf => exact .rfind ihf
+
+/-- Monotonicity of `RecursiveIn` with respect to oracle sets. -/
+theorem mono {O₁ O₂ : Set (ℕ →. ℕ)} (hsub : O₁ ⊆ O₂) {g : ℕ →. ℕ} :
+      RecursiveIn O₁ g → RecursiveIn O₂ g :=
+      fun gRecInO => .subst (gRecInO) (fun g' g'In => .oracle g' (hsub (g'In)))
+/--
+`RecursiveIn O` is closed under conditionals with a computable guard and a constant fallback.
+
+If `c n = true` we return `f n`, otherwise we return the
+constant value `k`.
+-/
+theorem cond_const {c : ℕ → Bool} {f : ℕ →. ℕ} (hc : Computable c)
+    (hf : RecursiveIn O f) (k : ℕ) :
+    RecursiveIn O (fun n => bif (c n) then f n else (Part.some k)) := by
+  have hid : RecursiveIn O (fun n : ℕ => n) := by
+    simpa using (RecursiveIn.of_primrec (O := O) Nat.Primrec.id)
+  have hcode : RecursiveIn O (fun n : ℕ => encode (c n)) := by
+    have hcomp : Computable (fun n : ℕ => encode (c n)) := (Computable.encode.comp hc)
+    exact Nat.Partrec.recursiveIn (O := O) ((Partrec.nat_iff).1 hcomp.partrec)
+  let pairFn : ℕ →. ℕ := fun n =>
+    Nat.pair <$> (show Part ℕ from n) <*> (show Part ℕ from encode (c n))
+  have hpair : RecursiveIn O pairFn := by
+    simpa [pairFn] using (RecursiveIn.pair hid hcode)
+  let base : ℕ →. ℕ := fun _ : ℕ => (k : ℕ)
+  have hbase : RecursiveIn O base := by
+    simpa [base] using (RecursiveIn.of_primrec (O := O) (Nat.Primrec.const k))
+  let step : ℕ →. ℕ := fun p : ℕ => (Nat.unpair p).1 >>= f
+  have hstep : RecursiveIn O step := by
+    simpa [step] using (RecursiveIn.comp hf RecursiveIn.left)
+  let precFn : ℕ →. ℕ :=
+    fun p : ℕ =>
+      let (a, n) := Nat.unpair p
+      n.rec (base a) (fun y IH => do
+        let i ← IH
+        step (Nat.pair a (Nat.pair y i)))
+  have hprec : RecursiveIn O precFn := by
+    simpa [precFn] using (RecursiveIn.prec hbase hstep)
+  let mainFn : ℕ →. ℕ := fun n => pairFn n >>= precFn
+  have hmain : RecursiveIn O mainFn := by
+    simpa [mainFn] using (RecursiveIn.comp hprec hpair)
+  have hEq : mainFn = (fun n => bif (c n) then f n else Part.some k) := by
+    funext n
+    cases h : c n <;>
+      simp [mainFn, pairFn, precFn, base, step, h, Seq.seq, Nat.unpair_pair]
+  simpa [hEq] using hmain
+
+/--
+Construct `cmp` so that a single `Nat.rfind` over `cmp` computes `cond (c n) (f n) (g n)`.
+-/
+theorem cond_core_rfind {c : ℕ → Bool} {f g : ℕ →. ℕ}
+    (hc : Computable c) (hf : RecursiveIn O f) (hg : RecursiveIn O g) :
+    ∃ cmp : ℕ →. ℕ,
+      RecursiveIn O cmp ∧
+        (fun n => Nat.rfind (fun k => (fun m => m = 0) <$> cmp (Nat.pair n k))) =
+          (fun n => cond (c n) (f n) (g n)) := by
+  have kronecker_recursiveIn : RecursiveIn O Partrec.kronecker :=
+    Nat.Partrec.recursiveIn (O := O) Partrec.kronecker_partrec
+  have flip10_recursiveIn : RecursiveIn O (fun m => Part.some (Partrec.flip10 m)) :=
+    Nat.Partrec.recursiveIn (O := O) Partrec.flip10_partrec
+  let eq (h : ℕ →. ℕ) : ℕ →. ℕ := fun p =>
+    ((Nat.pair <$>
+          ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
+          (fun n : ℕ => (Nat.unpair n).2) p) >>= Partrec.kronecker) >>=
+      fun m => Part.some (Partrec.flip10 m)
+  have heq {h : ℕ →. ℕ} (hh : RecursiveIn O h) : RecursiveIn O (eq h) := by
+    have hbase : RecursiveIn O (fun p =>
+        (Nat.pair <$> ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
+          (fun n : ℕ => (Nat.unpair n).2) p) >>= Partrec.kronecker) :=
+      RecursiveIn.comp kronecker_recursiveIn
+        (RecursiveIn.pair (RecursiveIn.comp hh RecursiveIn.left) RecursiveIn.right)
+    have : RecursiveIn O (fun p =>
+        ((Nat.pair <$> ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
+            (fun n : ℕ => (Nat.unpair n).2) p) >>= Partrec.kronecker) >>=
+          fun m => Part.some (Partrec.flip10 m)) :=
+      RecursiveIn.comp flip10_recursiveIn hbase
+    simpa [eq] using this
+  let c1 : ℕ → Bool := fun p => c (Nat.unpair p).1
+  let c2 : ℕ → Bool := fun p => !c (Nat.unpair p).1
+  have hc1 : Computable c1 := by
+    simpa [c1] using hc.comp (Computable.fst.comp Computable.unpair)
+  have hc2 : Computable c2 := by
+    have hnot : Computable not := Primrec.not.to_comp
+    simpa [c2] using hnot.comp hc1
+  let t1 : ℕ →. ℕ := fun p => bif c1 p then eq f p else Part.some 1
+  let t2 : ℕ →. ℕ := fun p => bif c2 p then eq g p else Part.some 1
+  have ht1 : RecursiveIn O t1 := by
+    simpa [t1] using (cond_const (O := O) (c := c1) (f := eq f) hc1 (heq hf) 1)
+  have ht2 : RecursiveIn O t2 := by
+    simpa [t2] using (cond_const (O := O) (c := c2) (f := eq g) hc2 (heq hg) 1)
+  let mulPair : ℕ →. ℕ := (Nat.unpaired (fun a b : ℕ => a * b) : ℕ → ℕ)
+  have hmul : RecursiveIn O mulPair := by
+    have hpart : Nat.Partrec (mulPair : ℕ →. ℕ) := by
+      simpa [mulPair] using (Nat.Partrec.of_primrec (Nat.Primrec.mul))
+    exact Nat.Partrec.recursiveIn (O := O) hpart
+  let cmp : ℕ →. ℕ := fun p => (Nat.pair <$> t1 p <*> t2 p) >>= mulPair
+  have hcmp : RecursiveIn O cmp := by
+    have hpair : RecursiveIn O (fun p => Nat.pair <$> t1 p <*> t2 p) :=
+      RecursiveIn.pair ht1 ht2
+    have : RecursiveIn O (fun p => (Nat.pair <$> t1 p <*> t2 p) >>= mulPair) :=
+      RecursiveIn.comp hmul hpair
+    simpa [cmp] using this
+  refine ⟨cmp, hcmp, ?_⟩
+  funext n
+  let φ : ℕ → Bool := fun m => decide (m = 0)
+  cases hn : c n with
+  | true =>
+      simp only [Part.map_eq_map, cond_true]
+      have hpred : (fun k => Part.map φ (cmp (Nat.pair n k))) =
+          fun k => Part.map φ (eq f (Nat.pair n k)) := by
+        funext k
+        simp [cmp, t1, t2, c1, c2, eq, mulPair, hn, Nat.unpair_pair, Nat.unpaired,
+          Seq.seq, Part.bind_assoc, Part.bind_some]
+      rw [hpred]
+      simpa [eq, Nat.unpair_pair, Seq.seq, Part.map_eq_map, Part.bind_some_eq_map, φ] using
+        (Partrec.kronecker_rfind (v := f n))
+  | false =>
+      simp only [Part.map_eq_map, cond_false]
+      have hpred : (fun k => Part.map φ (cmp (Nat.pair n k))) =
+          fun k => Part.map φ (eq g (Nat.pair n k)) := by
+        funext k
+        simp [cmp, t1, t2, c1, c2, eq, mulPair, hn, Nat.unpair_pair, Nat.unpaired,
+          Seq.seq, Part.bind_assoc, Part.bind_some]
+      rw [hpred]
+      simpa [eq, Nat.unpair_pair, Seq.seq, Part.map_eq_map, Part.bind_some_eq_map, φ] using
+        (Partrec.kronecker_rfind (v := g n))
+
+/--
+`RecursiveIn O` is closed under conditionals with a computable guard.
+-/
+theorem cond {c : ℕ → Bool} {f g : ℕ →. ℕ}
+    (hc : Computable c) (hf : RecursiveIn O f) (hg : RecursiveIn O g) :
+    RecursiveIn O (fun n => cond (c n) (f n) (g n)) := by
+  rcases cond_core_rfind (O := O) (c := c) (f := f) (g := g) hc hf hg with ⟨cmp, hcmp, hEq⟩
+  have hr : RecursiveIn O (fun n => Nat.rfind (fun k => (fun m => m = 0) <$>
+    cmp (Nat.pair n k))) := by
+    exact RecursiveIn.rfind hcmp
+  refine RecursiveIn.of_eq hr ?_
+  intro n
+  simpa using congrArg (fun h => h n) hEq
+
+end RecursiveIn

--- a/Mathlib/Computability/RecursiveIn.lean
+++ b/Mathlib/Computability/RecursiveIn.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Tanner Duve. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tanner Duve, Elan Roth
 -/
-
 module
 
 public import Mathlib.Computability.Partrec
@@ -345,13 +344,14 @@ theorem cond_core_rfind {c : ℕ → Bool} {f g : ℕ →. ℕ}
           (fun n => cond (c n) (f n) (g n)) := by
   have kronecker_recursiveIn : RecursiveIn O Partrec.kronecker :=
     Nat.Partrec.recursiveIn (O := O) Partrec.kronecker_partrec
-  have flip10_recursiveIn : RecursiveIn O (fun m => Part.some (Partrec.flip10 m)) :=
-    Nat.Partrec.recursiveIn (O := O) Partrec.flip10_partrec
+  have sub1_recursiveIn : RecursiveIn O (fun m => Part.some (1 - m)) :=
+    Nat.Partrec.recursiveIn (O := O)
+      ((Partrec.nat_iff).1 (Primrec.nat_sub.comp (Primrec.const 1) Primrec.id).to_comp)
   let eq (h : ℕ →. ℕ) : ℕ →. ℕ := fun p =>
     ((Nat.pair <$>
           ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
           (fun n : ℕ => (Nat.unpair n).2) p) >>= Partrec.kronecker) >>=
-      fun m => Part.some (Partrec.flip10 m)
+      fun m => Part.some (1 - m)
   have heq {h : ℕ →. ℕ} (hh : RecursiveIn O h) : RecursiveIn O (eq h) := by
     have hbase : RecursiveIn O (fun p =>
         (Nat.pair <$> ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
@@ -361,8 +361,8 @@ theorem cond_core_rfind {c : ℕ → Bool} {f g : ℕ →. ℕ}
     have : RecursiveIn O (fun p =>
         ((Nat.pair <$> ((fun n : ℕ => (Nat.unpair n).1) p >>= h) <*>
             (fun n : ℕ => (Nat.unpair n).2) p) >>= Partrec.kronecker) >>=
-          fun m => Part.some (Partrec.flip10 m)) :=
-      RecursiveIn.comp flip10_recursiveIn hbase
+          fun m => Part.some (1 - m)) :=
+      RecursiveIn.comp sub1_recursiveIn hbase
     simpa [eq] using this
   let c1 : ℕ → Bool := fun p => c (Nat.unpair p).1
   let c2 : ℕ → Bool := fun p => !c (Nat.unpair p).1

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -12,7 +12,7 @@ public import Mathlib.Computability.RecursiveIn
 import Aesop
 
 /-!
-# Turing Reducibility and Turing Degrees
+# Turing degrees
 
 This file defines Turing reducibility and equivalence, proves that Turing equivalence is an
 equivalence relation, and defines Turing degrees as the quotient under this relation.

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -3,45 +3,52 @@ Copyright (c) 2025 Tanner Duve. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tanner Duve, Elan Roth
 -/
+
 module
 
+public import Mathlib.Tactic.Cases
+public import Mathlib.Tactic.NormNum
+public import Aesop
 public import Mathlib.Computability.RecursiveIn
-public import Mathlib.Order.Antisymmetrization
 
 /-!
-# Turing degrees
+# Turing Reducibility and Turing Degrees
 
-This file defines Turing reducibility and equivalence, proves that Turing equivalence is an
-equivalence relation, and defines Turing degrees as the quotient under this relation.
+This file defines Turing reducibility and Turing equivalence in terms of oracle computability,
+as well as the notion of Turing degrees as equivalence classes under mutual reducibility.
 
-## Main definitions
+## Main Definitions
 
-- `TuringReducible`: A relation defining Turing reducibility between partial functions.
-- `TuringEquivalent`: An equivalence relation defining Turing equivalence between partial functions.
-- `TuringDegree`: The type of Turing degrees, defined as the quotient of partial functions under
-  `TuringEquivalent`.
+* `TuringReducible f g`:
+  The function `f` is Turing reducible to `g` if `f` is recursive in the singleton set `{g}`.
+* `TuringEquivalent f g`:
+  Functions `f` and `g` are Turing equivalent if they are mutually Turing reducible.
+* `TuringDegree`:
+  The type of Turing degrees, given by the quotient of `ℕ →. ℕ` under `TuringEquivalent`.
 
 ## Notation
 
-- `f ≤ᵀ g` : `f` is Turing reducible to `g`.
-- `f ≡ᵀ g` : `f` is Turing equivalent to `g`.
+* `f ≤ᵀ g`: `f` is Turing reducible to `g`.
+* `f ≡ᵀ g`: `f` is Turing equivalent to `g`.
+
+## Implementation Notes
+
+We define `TuringDegree` as the `Antisymmetrization` of the preorder of partial functions under
+Turing reducibility. This gives a concrete representation of degrees as equivalence classes.
 
 ## References
 
 * [Odifreddi1989] Odifreddi, Piergiorgio.
-  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers,
-  Vol. I*. Springer-Verlag, 1989.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.
 
 ## Tags
 
-Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
+Computability, Turing Degrees, Reducibility, Equivalence Relation
 -/
 
 @[expose] public section
 
-open Primrec Nat.Partrec Part
-
-variable {f g h : ℕ →. ℕ}
+open Std
 
 /--
 `f` is Turing reducible to `g` if `f` is partial recursive given access to the oracle `g`
@@ -60,46 +67,30 @@ abbrev TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
 
 open scoped Computability
 
-/--
-If a function is partial recursive, then it is recursive in every partial function.
--/
-lemma Nat.Partrec.turingReducible (pF : Nat.Partrec f) : f ≤ᵀ g := by
-  induction pF with repeat {constructor}
-  | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  | rfind _ ih => exact RecursiveIn.rfind ih
-
-/--
-If a function is recursive in the constant zero function,
-then it is partial recursive.
--/
-lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
-  induction fRecInZero with repeat {constructor}
-  | oracle _ hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
-  | pair | comp | prec | rfind => repeat {constructor; assumption; try assumption}
-
-/--
-A partial function `f` is partial recursive if and only if it is recursive in
-every partial function `g`.
--/
-theorem partrec_iff_forall_turingReducible : Nat.Partrec f ↔ ∀ g, f ≤ᵀ g :=
-  ⟨fun hf _ ↦ hf.turingReducible, (· _ |>.partrec_of_zero)⟩
+variable {f g h : ℕ →. ℕ}
 
 protected theorem TuringReducible.refl (f : ℕ →. ℕ) : f ≤ᵀ f := .oracle _ <| by simp
 protected theorem TuringReducible.rfl : f ≤ᵀ f := .refl _
 
+instance : Refl TuringReducible where refl _ := .rfl
+
 theorem TuringReducible.trans (hg : f ≤ᵀ g) (hh : g ≤ᵀ h) : f ≤ᵀ h := by
-  induction hg with repeat {constructor}
-  | oracle _ hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
-  | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  | rfind _ ih => exact RecursiveIn.rfind ih
+  induction hg with
+  | zero | succ | left | right => constructor
+  | oracle g' hg' =>
+    rw [Set.mem_singleton_iff] at hg'
+    rw [hg']
+    exact hh
+  | pair _ _ ih₁ ih₂ => exact .pair ih₁ ih₂
+  | comp _ _ ih₁ ih₂ => exact .comp ih₁ ih₂
+  | prec _ _ ih₁ ih₂ => exact .prec ih₁ ih₂
+  | rfind _ ih => exact .rfind ih
+
+instance : IsTrans (ℕ →. ℕ) TuringReducible :=
+  ⟨@TuringReducible.trans⟩
 
 instance : IsPreorder (ℕ →. ℕ) TuringReducible where
-  refl _ := .rfl
-  trans := @TuringReducible.trans
+  refl := .refl
 
 theorem TuringEquivalent.equivalence : Equivalence TuringEquivalent :=
   (AntisymmRel.setoid _ _).iseqv
@@ -117,6 +108,13 @@ theorem TuringEquivalent.trans (f g h : ℕ →. ℕ) (h₁ : f ≡ᵀ g) (h₂ 
   Equivalence.trans equivalence h₁ h₂
 
 /--
+Instance declaring that `RecursiveIn` is a preorder.
+-/
+instance : IsPreorder (ℕ →. ℕ) TuringReducible where
+  refl := TuringReducible.refl
+  trans := @TuringReducible.trans
+
+/--
 Turing degrees are the equivalence classes of partial functions under Turing equivalence.
 -/
 abbrev TuringDegree :=
@@ -130,3 +128,175 @@ private instance : Preorder (ℕ →. ℕ) where
 
 instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
   instPartialOrderAntisymmetrization
+
+open scoped Computability Partrec
+open Encodable Partrec
+
+/--
+`f` is Turing reducible to the join `f ⊕ g`.
+-/
+lemma left_le_join (f g : ℕ →. ℕ) : f ≤ᵀ (f ⊕ g) := by
+  set j : ℕ →. ℕ := f ⊕ g
+  have hj : RecursiveIn {j} j := RecursiveIn.oracle j (by simp)
+  have hdouble : RecursiveIn {j} (fun n : ℕ => (2 * n : ℕ)) := by
+    refine RecursiveIn.of_primrec (Primrec.nat_iff.1 ?_)
+    simpa using (Primrec.nat_mul.comp (Primrec.const 2) Primrec.id)
+  have hdiv2 : RecursiveIn {j} (fun n : ℕ => (Nat.div2 n : ℕ)) := by
+    refine RecursiveIn.of_primrec (Primrec.nat_iff.1 ?_)
+    simpa using (Primrec.nat_div2 : Primrec Nat.div2)
+  have hquery : RecursiveIn {j} (fun n => j (2 * n)) := by
+    refine RecursiveIn.of_eq (RecursiveIn.comp hj hdouble) ?_
+    intro n
+    simp [Part.bind_some]
+  have hdecode : RecursiveIn {j} (fun n => j (2 * n) >>= fun m => (Nat.div2 m : ℕ)) :=
+    RecursiveIn.comp hdiv2 hquery
+  have hf' : RecursiveIn {j} f := by
+    refine RecursiveIn.of_eq hdecode ?_
+    intro n
+    have hcomp : (Nat.div2 ∘ fun y : ℕ => 2 * y) = (fun y => y) := by
+      funext y
+      simp [Function.comp, Nat.div2_bit0]
+    simpa [j, join, Part.bind_some_eq_map, Part.map_map, Function.comp, hcomp] using
+      (Part.map_id' (f := fun y : ℕ => y) (fun y => rfl) (f n))
+  simpa [TuringReducible, j] using hf'
+
+/--
+`g` is Turing reducible to the join `f ⊕ g`.
+-/
+lemma right_le_join (f g : ℕ →. ℕ) : g ≤ᵀ (f ⊕ g) := by
+  set j : ℕ →. ℕ := f ⊕ g
+  have hj : RecursiveIn {j} j := RecursiveIn.oracle j (by simp)
+  have hdouble1 : RecursiveIn {j} (fun n : ℕ => (2 * n + 1 : ℕ)) := by
+    refine RecursiveIn.of_primrec (Primrec.nat_iff.1 ?_)
+    simpa using
+      (Primrec.nat_add.comp (Primrec.nat_mul.comp (Primrec.const 2) Primrec.id) (Primrec.const 1))
+  have hdiv2 : RecursiveIn {j} (fun n : ℕ => (Nat.div2 n : ℕ)) := by
+    refine RecursiveIn.of_primrec (Primrec.nat_iff.1 ?_)
+    simpa using Primrec.nat_div2
+  have hquery : RecursiveIn {j} (fun n => j (2 * n + 1)) := by
+    refine RecursiveIn.of_eq (RecursiveIn.comp hj hdouble1) ?_
+    intro n
+    simp [Part.bind_some]
+  have hdecode : RecursiveIn {j} (fun n => j (2 * n + 1) >>= fun m => (Nat.div2 m : ℕ)) :=
+    RecursiveIn.comp hdiv2 hquery
+  have hg' : RecursiveIn {j} g := by
+    refine RecursiveIn.of_eq hdecode ?_
+    intro n
+    have hcomp : (Nat.div2 ∘ fun y : ℕ => 2 * y + 1) = (fun y => y) := by
+      funext y
+      simp [Function.comp]
+    simpa [j, join, Part.bind_some_eq_map, Part.map_map, Function.comp, hcomp] using
+      (Part.map_id' (f := fun y : ℕ => y) (fun y => rfl) (g n))
+  simpa [TuringReducible, j] using hg'
+
+/--
+The join is recursive in the pair of oracles `{f, g}`.
+-/
+lemma join_recursiveIn_pair (f g : ℕ →. ℕ) : RecursiveIn ({f, g} : Set (ℕ →. ℕ)) (f ⊕ g) := by
+  let O : Set (ℕ →. ℕ) := ({f, g} : Set (ℕ →. ℕ))
+  have hpayload : RecursiveIn O (fun n : ℕ => (Nat.div2 n : ℕ)) := by
+    refine RecursiveIn.of_primrec (O := O) ?_
+    exact (Primrec.nat_iff.1 (by simpa using (Primrec.nat_div2 : Primrec Nat.div2)))
+  have hdbl : RecursiveIn O (fun n : ℕ => (2 * n : ℕ)) := by
+    refine RecursiveIn.of_primrec (O := O) ?_
+    exact (Primrec.nat_iff.1 (by
+      simpa using (Primrec.nat_mul.comp (Primrec.const 2) Primrec.id)))
+  have hdbl1 : RecursiveIn O (fun n : ℕ => (2 * n + 1 : ℕ)) := by
+    refine RecursiveIn.of_primrec (O := O) ?_
+    exact (Primrec.nat_iff.1 (by
+      simpa using
+        (Primrec.nat_add.comp (Primrec.nat_mul.comp (Primrec.const 2) Primrec.id)
+          (Primrec.const 1))))
+  have hfO : RecursiveIn O f := RecursiveIn.oracle f (by simp [O])
+  have hgO : RecursiveIn O g := RecursiveIn.oracle g (by simp [O])
+  let evenBranch : ℕ →. ℕ := fun n => (Nat.div2 n : ℕ) >>= f >>= fun y => (2 * y : ℕ)
+  let oddBranch : ℕ →. ℕ := fun n => (Nat.div2 n : ℕ) >>= g >>= fun y => (2 * y + 1 : ℕ)
+  have heven : RecursiveIn O evenBranch := by
+    simpa [evenBranch] using RecursiveIn.comp hdbl (RecursiveIn.comp hfO hpayload)
+  have hodd : RecursiveIn O oddBranch := by
+    simpa [oddBranch] using RecursiveIn.comp hdbl1 (RecursiveIn.comp hgO hpayload)
+  have hcond :
+      RecursiveIn O (fun n => cond (Nat.bodd n) (oddBranch n) (evenBranch n)) :=
+    RecursiveIn.cond (O := O) (c := Nat.bodd) (f := oddBranch) (g := evenBranch)
+      (Computable.nat_bodd) hodd heven
+  refine (RecursiveIn.of_eq (O := O) hcond ?_)
+  intro n
+  by_cases hbn : Nat.bodd n
+  · simp [join, evenBranch, oddBranch, hbn, Part.bind_some_eq_map]
+  · simp [join, evenBranch, oddBranch, hbn, Part.bind_some_eq_map]
+
+/--
+If `f` and `g` are both reducible to `h`, then their join is reducible to `h`.
+-/
+lemma join_le (f g h : ℕ →. ℕ) (hf : f ≤ᵀ h) (hg : g ≤ᵀ h) :
+(f ⊕ g) ≤ᵀ h := by
+  have hj : RecursiveIn ({f, g} : Set (ℕ →. ℕ)) (f ⊕ g) := join_recursiveIn_pair f g
+  have hO : ∀ k, k ∈ ({f, g} : Set (ℕ →. ℕ)) → RecursiveIn ({h} : Set (ℕ →. ℕ)) k := by
+    intro k hk
+    have hk' : k = f ∨ k = g := by
+      simpa [Set.mem_insert_iff, Set.mem_singleton_iff] using hk
+    cases hk' with
+    | inl hkf =>
+        simpa [hkf] using hf
+    | inr hkg =>
+        simpa [hkg] using hg
+  exact RecursiveIn.subst (O := ({f, g} : Set (ℕ →. ℕ))) (O' := ({h} : Set (ℕ →. ℕ)))
+    (f := (f ⊕ g)) hj hO
+
+namespace TuringDegree
+
+/-- The Turing join respects Turing reducibility: if `f ≤ᵀ f'` and `g ≤ᵀ g'`,
+then `f ⊕ g ≤ᵀ f' ⊕ g'`. -/
+theorem join_mono {f f' g g' : ℕ →. ℕ} (hf : f ≤ᵀ f') (hg : g ≤ᵀ g') :
+    (f ⊕ g) ≤ᵀ (f' ⊕ g') := by
+  have hf' : f ≤ᵀ (f' ⊕ g') := hf.trans (left_le_join f' g')
+  have hg' : g ≤ᵀ (f' ⊕ g') := hg.trans (right_le_join f' g')
+  exact join_le f g (f' ⊕ g') hf' hg'
+
+/-- The Turing join respects Turing equivalence. -/
+theorem join_congr {f f' g g' : ℕ →. ℕ} (hf : f ≡ᵀ f') (hg : g ≡ᵀ g') :
+    (f ⊕ g) ≡ᵀ (f' ⊕ g') :=
+  ⟨join_mono hf.1 hg.1, join_mono hf.2 hg.2⟩
+
+/-- The supremum operation on Turing degrees, induced by the Turing join. -/
+def sup : TuringDegree → TuringDegree → TuringDegree :=
+  Quotient.lift₂
+    (fun f g => toAntisymmetrization TuringReducible (f ⊕ g))
+    (fun _ _ _ _ hf hg => Quotient.sound (join_congr hf hg))
+
+/-- `sup` agrees with `⊕` on representatives. -/
+lemma sup_mk (f g : ℕ →. ℕ) :
+    TuringDegree.sup (toAntisymmetrization TuringReducible f)
+    (toAntisymmetrization TuringReducible g) =
+    toAntisymmetrization TuringReducible (f ⊕ g) := rfl
+
+/-- Left injection into `sup`: \(a \le a ⊔ b\). -/
+lemma le_sup_left (a b : TuringDegree) : a ≤ TuringDegree.sup a b := by
+  induction a using Quotient.inductionOn'
+  induction b using Quotient.inductionOn'
+  exact left_le_join _ _
+
+/-- Right injection into `sup`: \(b \le a ⊔ b\). -/
+lemma le_sup_right (a b : TuringDegree) : b ≤ TuringDegree.sup a b := by
+  induction a using Quotient.inductionOn'
+  induction b using Quotient.inductionOn'
+  exact right_le_join _ _
+
+/-- Supremum property: if `a ≤ c` and `b ≤ c` then `a ⊔ b ≤ c`. -/
+lemma sup_le {a b c : TuringDegree} (ha : a ≤ c) (hb : b ≤ c) :
+    TuringDegree.sup a b ≤ c := by
+  induction a using Quotient.inductionOn'
+  induction b using Quotient.inductionOn'
+  induction c using Quotient.inductionOn'
+  exact join_le _ _ _ ha hb
+
+instance instSemilatticeSup : SemilatticeSup TuringDegree :=
+  { sup := sup, le_sup_left, le_sup_right, sup_le := fun _ _ _ => sup_le }
+
+/-- The sup on Turing degrees agrees with the Turing join on representatives. -/
+@[simp]
+lemma sup_def (f g : ℕ →. ℕ) :
+    (toAntisymmetrization TuringReducible f) ⊔ (toAntisymmetrization TuringReducible g) =
+    toAntisymmetrization TuringReducible (f ⊕ g) := rfl
+
+end TuringDegree

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -31,7 +31,7 @@ as well as the notion of Turing degrees as equivalence classes under mutual redu
 * `f ≤ᵀ g`: `f` is Turing reducible to `g`.
 * `f ≡ᵀ g`: `f` is Turing equivalent to `g`.
 
-## Implementation Notes
+## Implementation notes
 
 We define `TuringDegree` as the `Antisymmetrization` of the preorder of partial functions under
 Turing reducibility. This gives a concrete representation of degrees as equivalence classes.

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -39,7 +39,8 @@ Turing reducibility. This gives a concrete representation of degrees as equivale
 ## References
 
 * [Odifreddi1989] Odifreddi, Piergiorgio.
-  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.
+* [Odifreddi, Piergiorgio.
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.][Odifreddi1989] 
 
 ## Tags
 

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -270,28 +270,21 @@ lemma sup_mk (f g : ℕ →. ℕ) :
     (toAntisymmetrization TuringReducible g) =
     toAntisymmetrization TuringReducible (f ⊕ g) := rfl
 
-/-- Left injection into `sup`: \(a \le a ⊔ b\). -/
-lemma le_sup_left (a b : TuringDegree) : a ≤ TuringDegree.sup a b := by
-  induction a using Quotient.inductionOn'
-  induction b using Quotient.inductionOn'
-  exact left_le_join _ _
-
-/-- Right injection into `sup`: \(b \le a ⊔ b\). -/
-lemma le_sup_right (a b : TuringDegree) : b ≤ TuringDegree.sup a b := by
-  induction a using Quotient.inductionOn'
-  induction b using Quotient.inductionOn'
-  exact right_le_join _ _
-
-/-- Supremum property: if `a ≤ c` and `b ≤ c` then `a ⊔ b ≤ c`. -/
-lemma sup_le {a b c : TuringDegree} (ha : a ≤ c) (hb : b ≤ c) :
-    TuringDegree.sup a b ≤ c := by
-  induction a using Quotient.inductionOn'
-  induction b using Quotient.inductionOn'
-  induction c using Quotient.inductionOn'
-  exact join_le _ _ _ ha hb
-
-instance instSemilatticeSup : SemilatticeSup TuringDegree :=
-  { sup := sup, le_sup_left, le_sup_right, sup_le := fun _ _ _ => sup_le }
+instance instSemilatticeSup : SemilatticeSup TuringDegree where
+  sup := sup
+  le_sup_left a b := by
+    induction a using Quotient.inductionOn'
+    induction b using Quotient.inductionOn'
+    exact left_le_join _ _
+  le_sup_right a b := by
+    induction a using Quotient.inductionOn'
+    induction b using Quotient.inductionOn'
+    exact right_le_join _ _
+  sup_le {a b c} ha hb := by
+    induction a using Quotient.inductionOn'
+    induction b using Quotient.inductionOn'
+    induction c using Quotient.inductionOn'
+    exact join_le _ _ _ ha hb
 
 /-- The sup on Turing degrees agrees with the Turing join on representatives. -/
 @[simp]

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -31,11 +31,6 @@ equivalence relation, and defines Turing degrees as the quotient under this rela
 * `f ≤ᵀ g`: `f` is Turing reducible to `g`.
 * `f ≡ᵀ g`: `f` is Turing equivalent to `g`.
 
-## Implementation notes
-
-We define `TuringDegree` as the `Antisymmetrization` of the preorder of partial functions under
-Turing reducibility. This gives a concrete representation of degrees as equivalence classes.
-
 ## References
 
 * [Odifreddi1989] Odifreddi, Piergiorgio.

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -40,7 +40,7 @@ Turing reducibility. This gives a concrete representation of degrees as equivale
 
 * [Odifreddi1989] Odifreddi, Piergiorgio.
 * [Odifreddi, Piergiorgio.
-  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.][Odifreddi1989] 
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.][Odifreddi1989]
 
 ## Tags
 

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -17,7 +17,7 @@ import Aesop
 This file defines Turing reducibility and Turing equivalence in terms of oracle computability,
 as well as the notion of Turing degrees as equivalence classes under mutual reducibility.
 
-## Main Definitions
+## Main definitions
 
 * `TuringReducible f g`:
   The function `f` is Turing reducible to `g` if `f` is recursive in the singleton set `{g}`.

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -8,8 +8,8 @@ module
 
 public import Mathlib.Tactic.Cases
 public import Mathlib.Tactic.NormNum
-public import Aesop
 public import Mathlib.Computability.RecursiveIn
+import Aesop
 
 /-!
 # Turing Reducibility and Turing Degrees

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -14,8 +14,8 @@ import Aesop
 /-!
 # Turing Reducibility and Turing Degrees
 
-This file defines Turing reducibility and Turing equivalence in terms of oracle computability,
-as well as the notion of Turing degrees as equivalence classes under mutual reducibility.
+This file defines Turing reducibility and equivalence, proves that Turing equivalence is an
+equivalence relation, and defines Turing degrees as the quotient under this relation.
 
 ## Main definitions
 
@@ -44,7 +44,7 @@ Turing reducibility. This gives a concrete representation of degrees as equivale
 
 ## Tags
 
-Computability, Turing Degrees, Reducibility, Equivalence Relation
+Computability, Oracle, Turing Degrees, Reducibility, Equivalence Relation
 -/
 
 @[expose] public section

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -33,9 +33,9 @@ equivalence relation, and defines Turing degrees as the quotient under this rela
 
 ## References
 
-* [Odifreddi1989] Odifreddi, Piergiorgio.
 * [Odifreddi, Piergiorgio.
-  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.][Odifreddi1989]
+  *Classical Recursion Theory: The Theory of Functions and Sets of Natural Numbers*, Vol. I.]
+  [Odifreddi1989]
 
 ## Tags
 


### PR DESCRIPTION
This PR equips `TuringDegree` with a `SemilatticeSup` structure by introducing the Turing join, proving usual least-upper-bound properties, and lifting these to degrees (quotients). In support of this, it extends the existing `RecursiveIn` API with some lemmas used in the degree theory.

The main contribution is the `SemilatticeSup` instance on `TuringDegree`. We define the Turing join as follows

```
turingJoin (f g) : ℕ → ℕ   -- notation: f ⊕ g
```

and prove it is a least upper bound:

* `left_le_join`, `right_le_join`
* `join_le`
* monotonicity and congruence lemmas (`join_mono`, `join_congr`)

We lift this to degrees in `TuringDegree.sup`, `TuringDegree.le_sup_left`, `TuringDegree.le_sup_right`, and `TuringDegree.sup_le`

```
instance : SemilatticeSup TuringDegree
```

**New additions to `RecursiveIn.lean`:**

-  `liftPrim`, `liftPrimrec`, `RecursiveIn'`, `ComputableIn`, `ComputableIn₂`: Encodes partial/total functions between `Primcodable` types as `ℕ →. ℕ`, analogous to `Partrec`/`Computable`.

- `of_eq`, `of_eq_tot`, `of_primrec`, `some`, `none`, `mono`, `subst`: Standard closure properties for `RecursiveIn`.

- `cond_const`, `cond_core_rfind`, `cond`, `ComputableIn.cond`: Shows `RecursiveIn` is closed under conditionals when the guard is absolutely computable

- `Nat.Partrec.recursiveIn`, `Computable.computableIn`: Every partrec/computable function is recursive in any oracle set.

Small addition to `Partrec`

we add to `Mathlib.Computability.Partrec` a small helper def (`Partrec.kronecker` and related `rfind` lemmas) representing the function that returns 1 if its two (unpaired) arguments are equal, and 0 otherwise, which is used in the proof of `cond`

## TODO
Some current `RecursiveIn` proofs such as `cond_core_rfind` still work directly with the inductive constructors and are thus very long. A follow up could add a combinator-style closure library by essentially relativizing all the results and lemmas in `Partrec`, and proofs could be golfed heavily as they are in `Partrec`

## Note: AI Usage

[Aleph prover](https://logicalintelligence.com/aleph-coding-ai/) was allowed to prove an earlier version of `cond_core_rfind`, which included stating and proving the lemma `cond_const` but the proofs have since been iterated on manually

Cursor was allowed to run git commands and edit docstrings/headers, and was used in setting up the module structure of the files