### PR TITLE
[Merged by Bors] - feat(Algebra/Ring/NegOnePow): add negOnePow ↔ natAbs bridge lemmas

### DIFF
--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -116,6 +116,7 @@ lemma cast_negOnePow_natCast (R : Type*) [Ring R] (n : ℕ) : negOnePow n = (-1 
 lemma coe_negOnePow_natCast (n : ℕ) : negOnePow n = (-1 : ℤ) ^ n := cast_negOnePow_natCast ..
 
 /-- The cast of `negOnePow n` to a ring equals `(-1) ^ n.natAbs`. -/
+@[simp]
 lemma cast_negOnePow_eq_neg_one_pow_natAbs (R : Type*) [Ring R] (n : ℤ) :
     (n.negOnePow : R) = (-1 : R) ^ n.natAbs := by
   cases n with
@@ -123,6 +124,7 @@ lemma cast_negOnePow_eq_neg_one_pow_natAbs (R : Type*) [Ring R] (n : ℤ) :
   | negSucc n => simp [negOnePow_def, Units.val_pow_eq_pow_val]
 
 /-- Specialization of `cast_negOnePow_eq_neg_one_pow_natAbs` to `ℤ`. -/
+@[simp]
 lemma coe_negOnePow_eq_neg_one_pow_natAbs (n : ℤ) :
     (n.negOnePow : ℤ) = (-1 : ℤ) ^ n.natAbs :=
   cast_negOnePow_eq_neg_one_pow_natAbs ..

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -123,7 +123,7 @@ lemma coe_negOnePow (R : Type*) [Ring R] (n : ℤ) :
 
 /-- Specialization of `cast_negOnePow_eq_neg_one_pow_natAbs` to `ℤ`. -/
 @[simp]
-lemma coe_negOnePow_eq_neg_one_pow_natAbs (n : ℤ) :
+lemma coe_int_negOnePow (n : ℤ) :
     (n.negOnePow : ℤ) = (-1 : ℤ) ^ n.natAbs :=
   cast_negOnePow_eq_neg_one_pow_natAbs ..
 

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -78,7 +78,6 @@ lemma negOnePow_eq_neg_one_iff (n : ℤ) : n.negOnePow = -1 ↔ Odd n := by
     contradiction
   · exact negOnePow_odd n
 
-@[simp]
 theorem abs_negOnePow (n : ℤ) : |(n.negOnePow : ℤ)| = 1 := by
   rw [abs_eq_natAbs, Int.units_natAbs, Nat.cast_one]
 
@@ -116,7 +115,6 @@ lemma cast_negOnePow_natCast (R : Type*) [Ring R] (n : ℕ) : negOnePow n = (-1 
 lemma coe_negOnePow_natCast (n : ℕ) : negOnePow n = (-1 : ℤ) ^ n := cast_negOnePow_natCast ..
 
 /-- The cast of `negOnePow n` to a ring equals `(-1) ^ n.natAbs`. -/
-@[simp]
 lemma cast_negOnePow_eq_neg_one_pow_natAbs (R : Type*) [Ring R] (n : ℤ) :
     (n.negOnePow : R) = (-1 : R) ^ n.natAbs := by
   cases n with

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -115,16 +115,11 @@ lemma cast_negOnePow_natCast (R : Type*) [Ring R] (n : ℕ) : negOnePow n = (-1 
 lemma coe_negOnePow_natCast (n : ℕ) : negOnePow n = (-1 : ℤ) ^ n := cast_negOnePow_natCast ..
 
 /-- The cast of `negOnePow n` to a ring equals `(-1) ^ n.natAbs`. -/
+@[simp]
 lemma coe_negOnePow (R : Type*) [Ring R] (n : ℤ) :
     (n.negOnePow : R) = (-1 : R) ^ n.natAbs := by
   cases n with
   | ofNat n => exact cast_negOnePow_natCast R n
   | negSucc n => simp [negOnePow_def, Units.val_pow_eq_pow_val]
-
-/-- Specialization of `cast_negOnePow_eq_neg_one_pow_natAbs` to `ℤ`. -/
-@[simp]
-lemma coe_int_negOnePow (n : ℤ) :
-    (n.negOnePow : ℤ) = (-1 : ℤ) ^ n.natAbs :=
-  cast_negOnePow_eq_neg_one_pow_natAbs ..
 
 end Int

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -115,7 +115,7 @@ lemma cast_negOnePow_natCast (R : Type*) [Ring R] (n : ℕ) : negOnePow n = (-1 
 lemma coe_negOnePow_natCast (n : ℕ) : negOnePow n = (-1 : ℤ) ^ n := cast_negOnePow_natCast ..
 
 /-- The cast of `negOnePow n` to a ring equals `(-1) ^ n.natAbs`. -/
-lemma cast_negOnePow_eq_neg_one_pow_natAbs (R : Type*) [Ring R] (n : ℤ) :
+lemma coe_negOnePow (R : Type*) [Ring R] (n : ℤ) :
     (n.negOnePow : R) = (-1 : R) ^ n.natAbs := by
   cases n with
   | ofNat n => exact cast_negOnePow_natCast R n

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -115,4 +115,16 @@ lemma cast_negOnePow_natCast (R : Type*) [Ring R] (n : ℕ) : negOnePow n = (-1 
 
 lemma coe_negOnePow_natCast (n : ℕ) : negOnePow n = (-1 : ℤ) ^ n := cast_negOnePow_natCast ..
 
+/-- The cast of `negOnePow n` to a ring equals `(-1) ^ n.natAbs`. -/
+lemma cast_negOnePow_eq_neg_one_pow_natAbs (R : Type*) [Ring R] (n : ℤ) :
+    (n.negOnePow : R) = (-1 : R) ^ n.natAbs := by
+  cases n with
+  | ofNat n => exact cast_negOnePow_natCast R n
+  | negSucc n => simp [negOnePow_def, Units.val_pow_eq_pow_val]
+
+/-- Specialization of `cast_negOnePow_eq_neg_one_pow_natAbs` to `ℤ`. -/
+lemma coe_negOnePow_eq_neg_one_pow_natAbs (n : ℤ) :
+    (n.negOnePow : ℤ) = (-1 : ℤ) ^ n.natAbs :=
+  cast_negOnePow_eq_neg_one_pow_natAbs ..
+
 end Int

--- a/Mathlib/Analysis/Analytic/Binomial.lean
+++ b/Mathlib/Analysis/Analytic/Binomial.lean
@@ -163,7 +163,7 @@ theorem one_div_one_sub_cpow_hasFPowerSeriesOnBall_zero (a : ℂ) :
   have H : ((binomialSeries ℂ (-a)).compContinuousLinearMap (-1)) =
       .ofScalars ℂ fun n ↦ Ring.choose (a + n - 1) n := by
     ext n; simp [FormalMultilinearSeries.compContinuousLinearMap, binomialSeries, Ring.choose_neg,
-      Units.smul_def, Int.coe_negOnePow_natCast, ← pow_add, ← mul_assoc]
+      Units.smul_def, ← pow_add, ← mul_assoc]
   have : HasFPowerSeriesOnBall (fun x ↦ (1 + x) ^ (-a)) (binomialSeries ℂ (-a : ℂ)) (-0) 1 := by
     simpa using one_add_cpow_hasFPowerSeriesOnBall_zero
   simpa [cpow_neg, Function.comp_def, ← sub_eq_add_neg, H] using


### PR DESCRIPTION
Adds `Int.cast_negOnePow_eq_neg_one_pow_natAbs` (for any `Ring R`) and its `ℤ` specialization `Int.coe_negOnePow_eq_neg_one_pow_natAbs`, relating `negOnePow n` to `(-1) ^ n.natAbs`.

The file already has [`cast_negOnePow_natCast`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Ring/NegOnePow.html#Int.cast_negOnePow_natCast) for `n : ℕ` but nothing for general integers via `natAbs`.