### PR TITLE
[Merged by Bors] - chore(NumberTheory/Height): update module docstrings after file move

### DIFF
--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -50,6 +50,15 @@ We define the following variants.
   `Projectivization K (ι → K)` (with a `Fintype ι`). This is the height of a point
   on projective space (with fixed basis).
 
+## TODO
+
+* Add `Height.AdmissibleAbsValues` instances for
+  * Fields of rational functions in `n` variables and
+  * Finite extensions of fields with `Height.AdmissibleAbsValues`.
+
+* Prove upper and lower bounds on the height of the image of a tuple under a tuple
+  of homogeneous polynomial maps of the same degree.
+
 ## Tags
 
 Height, absolute value

--- a/Mathlib/NumberTheory/Height/NumberField.lean
+++ b/Mathlib/NumberTheory/Height/NumberField.lean
@@ -9,18 +9,10 @@ public import Mathlib.NumberTheory.NumberField.ProductFormula
 public import Mathlib.NumberTheory.Height.Basic
 
 /-!
-# Instances of AdmissibleAbsValues
+# Heights over number fields
 
-We provide instances of `Height.AdmissibleAbsValues` for
-
-* algebraic number fields.
-
-## TODO
-
-* Fields of rational functions in `n` variables.
-
-* Finite extensions of fields with `Height.AdmissibleAbsValues`.
-
+We provide an instance of `Height.AdmissibleAbsValues` for algebraic number fields
+and set up some API.
 -/
 
 @[expose] public section


### PR DESCRIPTION
This is a follow-up to [#34776](https://github.com/leanprover-community/mathlib4/pull/34776), which renamed `Mathlib.NumberTheory.Height.Instances` to `Mathlib.NumberTheory.Height.NumberField`. It updates the module docstrings of `Mathlib.NumberTheory.Height.NumberField` and `Mathlib.NumberTheory.Height.Basic` to reflect the change.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
