### PR TITLE
[Merged by Bors] - feat(Data/ENNReal/Basic): ∞ prettyprints as ∞

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -104,8 +104,10 @@ def ENNReal := WithTop ℝ≥0
 @[inherit_doc]
 scoped[ENNReal] notation "ℝ≥0∞" => ENNReal
 
+-- note: using notation3 rather than notation means that `∞` pretty-prints
+-- as `∞` rather than `top`. Despite this, we still use `top` in the names of lemmas.
 /-- Notation for infinity as an `ENNReal` number. -/
-scoped[ENNReal] notation "∞" => (⊤ : ENNReal)
+scoped[ENNReal] notation3 "∞" => (⊤ : ENNReal)
 
 namespace ENNReal
 


### PR DESCRIPTION
Right now we are consistently using `∞` in our lemma statements about `ℝ≥0∞` and they are consistently being pretty-printed as `⊤`. This changes makes them prettyprint as `∞`. Note however that they are still being referred to as `⊤` in lemma names, which might make this change controversial.

---

[Zulip topic](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/delaborator.20for.20.28.E2.88.9E.20.3A.20.E2.84.9D.E2.89.A50.E2.88.9E.29)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

My motivation is that I want to show mathematicians mathlib code corresponding to their work and say "look, it's your theorem in digitised form and you can kind of read it" but mathematicians typically don't know what `⊤` means.