### PR TITLE
[Merged by Bors] - feat(MeasureTheory): add `continuousWithinAt_Ici/Iic_primitive_Ioi/Iio` and `continuousOn_Ici/Iic_primitive_Ioi/Iio/Ici/Iic`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -677,6 +677,9 @@ theorem integral_Ioc_eq_integral_Ioo : ∫ t in Ioc x y, f t ∂μ = ∫ t in Io
 theorem integral_Ico_eq_integral_Ioo : ∫ t in Ico x y, f t ∂μ = ∫ t in Ioo x y, f t ∂μ :=
   integral_Ico_eq_integral_Ioo' <| measure_singleton x
 
+theorem integral_Ico_eq_integral_Ioc : ∫ t in Ico x y, f t ∂μ = ∫ t in Ioc x y, f t ∂μ := by
+  rw [integral_Ico_eq_integral_Ioo, integral_Ioc_eq_integral_Ioo]
+
 theorem integral_Icc_eq_integral_Ioo : ∫ t in Icc x y, f t ∂μ = ∫ t in Ioo x y, f t ∂μ := by
   rw [integral_Icc_eq_integral_Ico, integral_Ico_eq_integral_Ioo]
 

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -787,6 +787,32 @@ theorem IntegrableOn.continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ}
 
 end PrimitiveIio
 
+section PrimitiveIci
+
+theorem IntegrableOn.continuousOn_primitive_Ici [NoAtoms μ] {a : ℝ}
+    (hf : IntegrableOn f (Ici a) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a) := by
+  conv =>
+    arg 1
+    ext b
+    rw [integral_Ici_eq_integral_Ioi]
+  exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_primitive_Ioi
+
+end PrimitiveIci
+
+section PrimitiveIci
+
+theorem IntegrableOn.continuousOn_primitive_Iic [NoAtoms μ] {a : ℝ}
+    (hf : IntegrableOn f (Iic a) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a) := by
+  conv =>
+    arg 1
+    ext b
+    rw [integral_Iic_eq_integral_Iio]
+  exact (hf.mono_set Iio_subset_Iic_self).continuousOn_primitive_Iio
+
+end PrimitiveIci
+
 end MeasureTheory
 
 end DominatedConvergenceTheorem

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -714,6 +714,79 @@ theorem IntegrableOn.continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ}
 
 end PrimitiveIoi
 
+section PrimitiveIio
+
+theorem IntegrableOn.tendsto_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
+    (hb₀ : b₀ ≤ a) :
+    Tendsto (fun b ↦ ∫ x in Iio b, f x ∂μ) (𝓝[≤] b₀) (𝓝 (∫ x in Iio b₀, f x ∂μ)) := by
+  simp_rw [← integral_indicator measurableSet_Iio]
+  apply tendsto_integral_filter_of_dominated_convergence
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    rw [aestronglyMeasurable_indicator_iff measurableSet_Iio]
+    apply Integrable.aestronglyMeasurable
+    exact hf.mono_set (Iio_subset_Iio (hb.trans hb₀))
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    apply ae_of_all
+    intro x
+    rw [norm_indicator_eq_indicator_norm]
+    apply indicator_le_indicator_of_subset (Iio_subset_Iio (hb.trans hb₀))
+    intro _
+    exact norm_nonneg _
+  · simpa [integrable_indicator_iff measurableSet_Iio] using hf.norm
+  · apply ae_of_all
+    intro x
+    rw [indicator_apply]
+    by_cases hx : x < b₀
+    · simp only [mem_Iio, hx, if_true]
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with b (hb : x < b)
+      simp [hb]
+    · simp only [mem_Iio, hx, if_false]
+      simp at hx
+      apply tendsto_const_nhds.congr'
+      filter_upwards [self_mem_nhdsWithin] with b hb
+      simp [hb.trans hx]
+
+theorem IntegrableOn.continuousWithinAt_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
+    (hb₀ : b₀ ≤ a) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ :=
+  hf.tendsto_primitive_Iio hb₀
+
+theorem IntegrableOn.continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ}
+    (hf : IntegrableOn f (Iio a) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a) := by
+  intro b₀ hb₀
+  rw [mem_Iic] at hb₀
+  simp_rw [← integral_indicator measurableSet_Iio]
+  apply tendsto_integral_filter_of_dominated_convergence
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    rw [aestronglyMeasurable_indicator_iff measurableSet_Iio]
+    apply Integrable.aestronglyMeasurable
+    exact hf.mono_set (Iio_subset_Iio hb)
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    apply ae_of_all
+    intro x
+    rw [norm_indicator_eq_indicator_norm]
+    apply indicator_le_indicator_of_subset (Iio_subset_Iio hb)
+    intro _
+    exact norm_nonneg _
+  · simpa [integrable_indicator_iff measurableSet_Iio] using hf.norm
+  · have hne : ∀ᵐ x ∂μ, x ≠ b₀ := by simp [ae_iff]
+    filter_upwards [hne] with x hx
+    rw [indicator_apply]
+    by_cases hxb : x < b₀
+    · simp only [mem_Iio, hxb, if_true]
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hxb)] with b (hb : x < b)
+      simp [hb]
+    · simp only [mem_Iio, hxb, if_false]
+      have hxb' : b₀ < x := lt_of_le_of_ne (not_lt.mp hxb) (Ne.symm hx)
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hxb')] with b (hb : b < x)
+      simp [hb.le]
+
+end PrimitiveIio
+
 end MeasureTheory
 
 end DominatedConvergenceTheorem

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -637,4 +637,50 @@ end ContinuousPrimitive
 
 end intervalIntegral
 
+namespace MeasureTheory
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {μ : Measure ℝ} {f : ℝ → E}
+
+section PrimitiveIoi
+
+theorem IntegrableOn.tendsto_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
+    (hb₀ : a ≤ b₀) :
+    Tendsto (fun b ↦ ∫ x in Ioi b, f x ∂μ) (𝓝[≥] b₀) (𝓝 (∫ x in Ioi b₀, f x ∂μ)) := by
+  simp_rw [← integral_indicator measurableSet_Ioi]
+  apply tendsto_integral_filter_of_dominated_convergence
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    rw [aestronglyMeasurable_indicator_iff measurableSet_Ioi]
+    apply Integrable.aestronglyMeasurable
+    exact hf.mono_set (Ioi_subset_Ioi (hb₀.trans hb))
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    apply ae_of_all
+    intro x
+    rw [norm_indicator_eq_indicator_norm]
+    apply indicator_le_indicator_of_subset (Ioi_subset_Ioi (hb₀.trans hb))
+    intro _
+    exact norm_nonneg _
+  · simpa [integrable_indicator_iff measurableSet_Ioi] using hf.norm
+  · apply ae_of_all
+    intro x
+    rw [indicator_apply]
+    by_cases hx : b₀ < x
+    · simp only [mem_Ioi, hx, if_true]
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with b (hb : b < x)
+      simp [hb]
+    · simp only [mem_Ioi, hx, if_false]
+      simp at hx
+      apply tendsto_const_nhds.congr'
+      filter_upwards [self_mem_nhdsWithin] with b hb
+      simp [hx.trans hb]
+
+theorem IntegrableOn.continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
+    (hb₀ : a ≤ b₀) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ :=
+  hf.tendsto_primitive_Ioi hb₀
+
+end PrimitiveIoi
+
+end MeasureTheory
+
 end DominatedConvergenceTheorem

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -679,6 +679,39 @@ theorem IntegrableOn.continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : Integ
     ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ :=
   hf.tendsto_primitive_Ioi hb₀
 
+theorem IntegrableOn.continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ}
+    (hf : IntegrableOn f (Ioi a) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a) := by
+  intro b₀ hb₀
+  rw [mem_Ici] at hb₀
+  simp_rw [← integral_indicator measurableSet_Ioi]
+  apply tendsto_integral_filter_of_dominated_convergence
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    rw [aestronglyMeasurable_indicator_iff measurableSet_Ioi]
+    apply Integrable.aestronglyMeasurable
+    exact hf.mono_set (Ioi_subset_Ioi hb)
+  · filter_upwards [self_mem_nhdsWithin] with b hb
+    apply ae_of_all
+    intro x
+    rw [norm_indicator_eq_indicator_norm]
+    apply indicator_le_indicator_of_subset (Ioi_subset_Ioi hb)
+    intro _
+    exact norm_nonneg _
+  · simpa [integrable_indicator_iff measurableSet_Ioi] using hf.norm
+  · have hne : ∀ᵐ x ∂μ, x ≠ b₀ := by simp [ae_iff]
+    filter_upwards [hne] with x hx
+    rw [indicator_apply]
+    by_cases hxb : b₀ < x
+    · simp only [mem_Ioi, hxb, if_true]
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hxb)] with b (hb : b < x)
+      simp [hb]
+    · simp only [mem_Ioi, hxb, if_false]
+      have hxb' : x < b₀ := lt_of_le_of_ne (not_lt.mp hxb) hx
+      apply tendsto_const_nhds.congr'
+      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hxb')] with b (hb : x < b)
+      simp [hb.le]
+
 end PrimitiveIoi
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -792,10 +792,7 @@ section PrimitiveIci
 theorem IntegrableOn.continuousOn_primitive_Ici [NoAtoms μ] {a : ℝ}
     (hf : IntegrableOn f (Ici a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a) := by
-  conv =>
-    arg 1
-    ext b
-    rw [integral_Ici_eq_integral_Ioi]
+  simp_rw [integral_Ici_eq_integral_Ioi]
   exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_primitive_Ioi
 
 end PrimitiveIci
@@ -805,10 +802,7 @@ section PrimitiveIci
 theorem IntegrableOn.continuousOn_primitive_Iic [NoAtoms μ] {a : ℝ}
     (hf : IntegrableOn f (Iic a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a) := by
-  conv =>
-    arg 1
-    ext b
-    rw [integral_Iic_eq_integral_Iio]
+  simp_rw [integral_Iic_eq_integral_Iio]
   exact (hf.mono_set Iio_subset_Iic_self).continuousOn_primitive_Iio
 
 end PrimitiveIci

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Zhouhang Zhou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Zhouhang Zhou, Yury Kudryashov, Patrick Massot
+Authors: Zhouhang Zhou, Yury Kudryashov, Patrick Massot, Louis (Yiyang) Liu
 -/
 module
 

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -645,8 +645,8 @@ open intervalIntegral
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {μ : Measure ℝ} {f : ℝ → E}
 
-theorem continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ) (hb₀ : a ≤ b₀) :
-    ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ := by
+theorem continuousWithinAt_Ici_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
+    (hb₀ : a ≤ b₀) : ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ := by
   simp_rw [← integral_indicator measurableSet_Ioi]
   refine tendsto_integral_filter_of_dominated_convergence ((Ioi a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
   · filter_upwards [self_mem_nhdsWithin] with b hb
@@ -663,7 +663,7 @@ theorem continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Io
     · filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with b hb using by grind
     · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
 
-theorem continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ioi a) μ) :
+theorem continuousOn_Ici_primitive_Ioi [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ioi a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a) := by
   intro b₀ hb₀
   rw [mem_Ici] at hb₀
@@ -680,10 +680,10 @@ theorem continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (
     have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a..b, f x ∂μ) (Icc a b₀) b₀ :=
       continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
     exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split b₀ (right_mem_Icc.2 hb₀))
-  · simpa [hb₀] using hf.continuousWithinAt_primitive_Ioi hb₀
+  · simpa [hb₀] using hf.continuousWithinAt_Ici_primitive_Ioi hb₀
 
-theorem continuousWithinAt_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ) (hb₀ : b₀ ≤ a) :
-    ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ := by
+theorem continuousWithinAt_Iic_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
+    (hb₀ : b₀ ≤ a) : ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ := by
   simp_rw [← integral_indicator measurableSet_Iio]
   refine tendsto_integral_filter_of_dominated_convergence ((Iio a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
   · filter_upwards [self_mem_nhdsWithin] with b hb
@@ -700,13 +700,13 @@ theorem continuousWithinAt_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Ii
     · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with b hb using by grind
     · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
 
-theorem continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iio a) μ) :
+theorem continuousOn_Iic_primitive_Iio [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iio a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a) := by
   intro b₀ hb₀
   rw [mem_Iic] at hb₀
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
-  · simpa [hb₀] using hf.continuousWithinAt_primitive_Iio hb₀
+  · simpa [hb₀] using hf.continuousWithinAt_Iic_primitive_Iio hb₀
   · rw [Iic_inter_Ici]
     have h_int : IntervalIntegrable f μ b₀ a := by
       rw [intervalIntegrable_iff_integrableOn_Ico_of_le hb₀]
@@ -719,15 +719,15 @@ theorem continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (
       exact continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
     apply (continuousWithinAt_const.add h_cwa).congr h_split (h_split b₀ (left_mem_Icc.2 hb₀))
 
-theorem continuousOn_primitive_Ici [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ici a) μ) :
+theorem continuousOn_Ici_primitive_Ici [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ici a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a) := by
   simp_rw [integral_Ici_eq_integral_Ioi]
-  exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_primitive_Ioi
+  exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_Ici_primitive_Ioi
 
-theorem continuousOn_primitive_Iic [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iic a) μ) :
+theorem continuousOn_Iic_primitive_Iic [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iic a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a) := by
   simp_rw [integral_Iic_eq_integral_Iio]
-  exact (hf.mono_set Iio_subset_Iic_self).continuousOn_primitive_Iio
+  exact (hf.mono_set Iio_subset_Iic_self).continuousOn_Iic_primitive_Iio
 
 end IntegrableOn
 

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -639,173 +639,97 @@ end intervalIntegral
 
 namespace MeasureTheory
 
+namespace IntegrableOn
+
+open intervalIntegral
+
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {μ : Measure ℝ} {f : ℝ → E}
 
-section PrimitiveIoi
-
-theorem IntegrableOn.tendsto_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
-    (hb₀ : a ≤ b₀) :
-    Tendsto (fun b ↦ ∫ x in Ioi b, f x ∂μ) (𝓝[≥] b₀) (𝓝 (∫ x in Ioi b₀, f x ∂μ)) := by
+theorem continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ) (hb₀ : a ≤ b₀) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ := by
   simp_rw [← integral_indicator measurableSet_Ioi]
-  apply tendsto_integral_filter_of_dominated_convergence
+  refine tendsto_integral_filter_of_dominated_convergence ((Ioi a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
   · filter_upwards [self_mem_nhdsWithin] with b hb
     rw [aestronglyMeasurable_indicator_iff measurableSet_Ioi]
-    apply Integrable.aestronglyMeasurable
-    exact hf.mono_set (Ioi_subset_Ioi (hb₀.trans hb))
+    exact (hf.mono_set (Ioi_subset_Ioi (hb₀.trans hb))).aestronglyMeasurable
   · filter_upwards [self_mem_nhdsWithin] with b hb
-    apply ae_of_all
-    intro x
+    refine ae_of_all _ fun x ↦ ?_
     rw [norm_indicator_eq_indicator_norm]
-    apply indicator_le_indicator_of_subset (Ioi_subset_Ioi (hb₀.trans hb))
-    intro _
-    exact norm_nonneg _
+    apply indicator_le_indicator_of_subset (Ioi_subset_Ioi (by grind)) (fun a ↦ norm_nonneg (f a))
   · simpa [integrable_indicator_iff measurableSet_Ioi] using hf.norm
-  · apply ae_of_all
-    intro x
-    rw [indicator_apply]
-    by_cases hx : b₀ < x
-    · simp only [mem_Ioi, hx, if_true]
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with b (hb : b < x)
-      simp [hb]
-    · simp only [mem_Ioi, hx, if_false]
-      simp at hx
-      apply tendsto_const_nhds.congr'
-      filter_upwards [self_mem_nhdsWithin] with b hb
-      simp [hx.trans hb]
+  · refine ae_of_all _ fun x ↦ ?_
+    simp only [indicator_apply, mem_Ioi]
+    by_cases hx : b₀ < x <;> apply tendsto_const_nhds.congr'
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with b hb using by grind
+    · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
 
-theorem IntegrableOn.continuousWithinAt_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
-    (hb₀ : a ≤ b₀) :
-    ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ :=
-  hf.tendsto_primitive_Ioi hb₀
-
-theorem IntegrableOn.continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ}
-    (hf : IntegrableOn f (Ioi a) μ) :
+theorem continuousOn_primitive_Ioi [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ioi a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a) := by
   intro b₀ hb₀
   rw [mem_Ici] at hb₀
-  simp_rw [← integral_indicator measurableSet_Ioi]
-  apply tendsto_integral_filter_of_dominated_convergence
-  · filter_upwards [self_mem_nhdsWithin] with b hb
-    rw [aestronglyMeasurable_indicator_iff measurableSet_Ioi]
-    apply Integrable.aestronglyMeasurable
-    exact hf.mono_set (Ioi_subset_Ioi hb)
-  · filter_upwards [self_mem_nhdsWithin] with b hb
-    apply ae_of_all
-    intro x
-    rw [norm_indicator_eq_indicator_norm]
-    apply indicator_le_indicator_of_subset (Ioi_subset_Ioi hb)
-    intro _
-    exact norm_nonneg _
-  · simpa [integrable_indicator_iff measurableSet_Ioi] using hf.norm
-  · have hne : ∀ᵐ x ∂μ, x ≠ b₀ := by simp [ae_iff]
-    filter_upwards [hne] with x hx
-    rw [indicator_apply]
-    by_cases hxb : b₀ < x
-    · simp only [mem_Ioi, hxb, if_true]
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hxb)] with b (hb : b < x)
-      simp [hb]
-    · simp only [mem_Ioi, hxb, if_false]
-      have hxb' : x < b₀ := lt_of_le_of_ne (not_lt.mp hxb) hx
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hxb')] with b (hb : x < b)
-      simp [hb.le]
+  rw [continuousWithinAt_iff_continuous_left_right]
+  constructor
+  · rw [Ici_inter_Iic]
+    have h_int : IntervalIntegrable f μ a b₀ := by
+      rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hb₀]
+      exact hf.mono_set Ioc_subset_Ioi_self
+    have h_split : ∀ b ∈ Icc a b₀, ∫ x in Ioi b, f x ∂μ =
+        (∫ x in Ioi a, f x ∂μ) - ∫ x in a..b, f x ∂μ := by
+      intro b hb
+      simp [← integral_Ioi_sub_Ioi hf hb.1]
+    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a..b, f x ∂μ) (Icc a b₀) b₀ :=
+      continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
+    exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split b₀ (right_mem_Icc.2 hb₀))
+  · simpa [hb₀] using hf.continuousWithinAt_primitive_Ioi hb₀
 
-end PrimitiveIoi
-
-section PrimitiveIio
-
-theorem IntegrableOn.tendsto_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
-    (hb₀ : b₀ ≤ a) :
-    Tendsto (fun b ↦ ∫ x in Iio b, f x ∂μ) (𝓝[≤] b₀) (𝓝 (∫ x in Iio b₀, f x ∂μ)) := by
+theorem continuousWithinAt_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ) (hb₀ : b₀ ≤ a) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ := by
   simp_rw [← integral_indicator measurableSet_Iio]
-  apply tendsto_integral_filter_of_dominated_convergence
+  refine tendsto_integral_filter_of_dominated_convergence ((Iio a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
   · filter_upwards [self_mem_nhdsWithin] with b hb
     rw [aestronglyMeasurable_indicator_iff measurableSet_Iio]
-    apply Integrable.aestronglyMeasurable
-    exact hf.mono_set (Iio_subset_Iio (hb.trans hb₀))
+    exact (hf.mono_set (Iio_subset_Iio (hb.trans hb₀))).aestronglyMeasurable
   · filter_upwards [self_mem_nhdsWithin] with b hb
-    apply ae_of_all
-    intro x
+    refine ae_of_all _ fun x ↦ ?_
     rw [norm_indicator_eq_indicator_norm]
-    apply indicator_le_indicator_of_subset (Iio_subset_Iio (hb.trans hb₀))
-    intro _
-    exact norm_nonneg _
+    apply indicator_le_indicator_of_subset (Iio_subset_Iio (by grind)) (fun a ↦ norm_nonneg (f a))
   · simpa [integrable_indicator_iff measurableSet_Iio] using hf.norm
-  · apply ae_of_all
-    intro x
-    rw [indicator_apply]
-    by_cases hx : x < b₀
-    · simp only [mem_Iio, hx, if_true]
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with b (hb : x < b)
-      simp [hb]
-    · simp only [mem_Iio, hx, if_false]
-      simp at hx
-      apply tendsto_const_nhds.congr'
-      filter_upwards [self_mem_nhdsWithin] with b hb
-      simp [hb.trans hx]
+  · refine ae_of_all _ fun x ↦ ?_
+    simp only [indicator_apply, mem_Iio]
+    by_cases hx : x < b₀ <;> apply tendsto_const_nhds.congr'
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with b hb using by grind
+    · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
 
-theorem IntegrableOn.continuousWithinAt_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
-    (hb₀ : b₀ ≤ a) :
-    ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ :=
-  hf.tendsto_primitive_Iio hb₀
-
-theorem IntegrableOn.continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ}
-    (hf : IntegrableOn f (Iio a) μ) :
+theorem continuousOn_primitive_Iio [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iio a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a) := by
   intro b₀ hb₀
   rw [mem_Iic] at hb₀
-  simp_rw [← integral_indicator measurableSet_Iio]
-  apply tendsto_integral_filter_of_dominated_convergence
-  · filter_upwards [self_mem_nhdsWithin] with b hb
-    rw [aestronglyMeasurable_indicator_iff measurableSet_Iio]
-    apply Integrable.aestronglyMeasurable
-    exact hf.mono_set (Iio_subset_Iio hb)
-  · filter_upwards [self_mem_nhdsWithin] with b hb
-    apply ae_of_all
-    intro x
-    rw [norm_indicator_eq_indicator_norm]
-    apply indicator_le_indicator_of_subset (Iio_subset_Iio hb)
-    intro _
-    exact norm_nonneg _
-  · simpa [integrable_indicator_iff measurableSet_Iio] using hf.norm
-  · have hne : ∀ᵐ x ∂μ, x ≠ b₀ := by simp [ae_iff]
-    filter_upwards [hne] with x hx
-    rw [indicator_apply]
-    by_cases hxb : x < b₀
-    · simp only [mem_Iio, hxb, if_true]
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hxb)] with b (hb : x < b)
-      simp [hb]
-    · simp only [mem_Iio, hxb, if_false]
-      have hxb' : b₀ < x := lt_of_le_of_ne (not_lt.mp hxb) (Ne.symm hx)
-      apply tendsto_const_nhds.congr'
-      filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hxb')] with b (hb : b < x)
-      simp [hb.le]
+  rw [continuousWithinAt_iff_continuous_left_right]
+  constructor
+  · simpa [hb₀] using hf.continuousWithinAt_primitive_Iio hb₀
+  · rw [Iic_inter_Ici]
+    have h_int : IntervalIntegrable f μ b₀ a := by
+      rw [intervalIntegrable_iff_integrableOn_Ico_of_le hb₀]
+      exact hf.mono_set Ico_subset_Iio_self
+    have h_split : ∀ b ∈ Icc b₀ a, ∫ x in Iio b, f x ∂μ =
+        (∫ x in Iio a, f x ∂μ) + ∫ x in a..b, f x ∂μ := by
+      intro b hb
+      simp [integral_symm b a, ← integral_Iio_sub_Iio hf hb.2]
+    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a..b, f x ∂μ) (Icc b₀ a) b₀ := by
+      exact continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
+    apply (continuousWithinAt_const.add h_cwa).congr h_split (h_split b₀ (left_mem_Icc.2 hb₀))
 
-end PrimitiveIio
-
-section PrimitiveIci
-
-theorem IntegrableOn.continuousOn_primitive_Ici [NoAtoms μ] {a : ℝ}
-    (hf : IntegrableOn f (Ici a) μ) :
+theorem continuousOn_primitive_Ici [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ici a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a) := by
   simp_rw [integral_Ici_eq_integral_Ioi]
   exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_primitive_Ioi
 
-end PrimitiveIci
-
-section PrimitiveIci
-
-theorem IntegrableOn.continuousOn_primitive_Iic [NoAtoms μ] {a : ℝ}
-    (hf : IntegrableOn f (Iic a) μ) :
+theorem continuousOn_primitive_Iic [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iic a) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a) := by
   simp_rw [integral_Iic_eq_integral_Iio]
   exact (hf.mono_set Iio_subset_Iic_self).continuousOn_primitive_Iio
 
-end PrimitiveIci
+end IntegrableOn
 
 end MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -472,8 +472,7 @@ theorem continuousOn_primitive (h_int : IntegrableOn f (Icc a b) μ) :
     rw [continuousOn_congr this]
     intro x₀ _
     refine continuousWithinAt_primitive (measure_singleton x₀) ?_
-    simp only [intervalIntegrable_iff_integrableOn_Ioc_of_le, max_eq_right, h,
-      min_self]
+    simp only [intervalIntegrable_iff_integrableOn_Ioc_of_le, max_eq_right, h, min_self]
     exact h_int.mono Ioc_subset_Icc_self le_rfl
   · rw [Icc_eq_empty h]
     exact continuousOn_empty _
@@ -645,8 +644,8 @@ open intervalIntegral
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {μ : Measure ℝ} {f : ℝ → E}
 
-theorem continuousWithinAt_Ici_primitive_Ioi {a₀ : ℝ} (hf : IntegrableOn f (Ioi a₀) μ)
-    : ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a₀) a₀ := by
+theorem continuousWithinAt_Ici_primitive_Ioi {a₀ : ℝ} (hf : IntegrableOn f (Ioi a₀) μ) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a₀) a₀ := by
   simp_rw [← integral_indicator measurableSet_Ioi]
   apply tendsto_integral_filter_of_dominated_convergence ((Ioi a₀).indicator (norm ∘ f))
   · filter_upwards [self_mem_nhdsWithin] with a ha
@@ -665,14 +664,12 @@ theorem continuousWithinAt_Ici_primitive_Ioi {a₀ : ℝ} (hf : IntegrableOn f (
 
 theorem continuousOn_Ici_primitive_Ioi [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Ioi a₀) μ) :
     ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a₀) := by
-  intro a ha
-  rw [mem_Ici] at ha
+  intro a (ha : a₀ ≤ a)
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
   · rw [Ici_inter_Iic]
-    have h_int : IntervalIntegrable f μ a₀ a := by
-      rw [intervalIntegrable_iff_integrableOn_Ioc_of_le ha]
-      exact hf.mono_set Ioc_subset_Ioi_self
+    have h_int : IntervalIntegrable f μ a₀ a :=
+      (intervalIntegrable_iff_integrableOn_Ioc_of_le ha).2 <| hf.mono_set Ioc_subset_Ioi_self
     have h_split : ∀ b ∈ Icc a₀ a, ∫ x in Ioi b, f x ∂μ =
         (∫ x in Ioi a₀, f x ∂μ) - ∫ x in a₀..b, f x ∂μ := by
       intro b hb
@@ -682,8 +679,8 @@ theorem continuousOn_Ici_primitive_Ioi [NoAtoms μ] {a₀ : ℝ} (hf : Integrabl
     exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split a (right_mem_Icc.2 ha))
   · simpa [ha] using (hf.mono_set (Ioi_subset_Ioi ha)).continuousWithinAt_Ici_primitive_Ioi
 
-theorem continuousWithinAt_Iic_primitive_Iio {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ)
-    : ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) a₀ := by
+theorem continuousWithinAt_Iic_primitive_Iio {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ) :
+    ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) a₀ := by
   simp_rw [← integral_indicator measurableSet_Iio]
   apply tendsto_integral_filter_of_dominated_convergence ((Iio a₀).indicator (norm ∘ f))
   · filter_upwards [self_mem_nhdsWithin] with a ha
@@ -702,21 +699,19 @@ theorem continuousWithinAt_Iic_primitive_Iio {a₀ : ℝ} (hf : IntegrableOn f (
 
 theorem continuousOn_Iic_primitive_Iio [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ) :
     ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) := by
-  intro a ha
-  rw [mem_Iic] at ha
+  intro a (ha : a ≤ a₀)
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
   · simpa [ha] using (hf.mono_set (Iio_subset_Iio ha)).continuousWithinAt_Iic_primitive_Iio
   · rw [Iic_inter_Ici]
-    have h_int : IntervalIntegrable f μ a a₀ := by
-      rw [intervalIntegrable_iff_integrableOn_Ico_of_le ha]
-      exact hf.mono_set Ico_subset_Iio_self
+    have h_int : IntervalIntegrable f μ a a₀ :=
+      (intervalIntegrable_iff_integrableOn_Ico_of_le ha).2 <| hf.mono_set Ico_subset_Iio_self
     have h_split : ∀ b ∈ Icc a a₀, ∫ x in Iio b, f x ∂μ =
         (∫ x in Iio a₀, f x ∂μ) + ∫ x in a₀..b, f x ∂μ := by
       intro b hb
       simp [integral_symm b a₀, ← integral_Iio_sub_Iio' hf (hf.mono_set (Iio_subset_Iio hb.2))]
-    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a a₀) a := by
-      exact continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
+    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a a₀) a :=
+      continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
     exact (continuousWithinAt_const.add h_cwa).congr h_split (h_split a (left_mem_Icc.2 ha))
 
 theorem continuousOn_Ici_primitive_Ici [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Ici a₀) μ) :

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -645,87 +645,87 @@ open intervalIntegral
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {μ : Measure ℝ} {f : ℝ → E}
 
-theorem continuousWithinAt_Ici_primitive_Ioi {a b₀ : ℝ} (hf : IntegrableOn f (Ioi a) μ)
-    (hb₀ : a ≤ b₀) : ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici b₀) b₀ := by
+theorem continuousWithinAt_Ici_primitive_Ioi {a₀ : ℝ} (hf : IntegrableOn f (Ioi a₀) μ)
+    : ContinuousWithinAt (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a₀) a₀ := by
   simp_rw [← integral_indicator measurableSet_Ioi]
-  refine tendsto_integral_filter_of_dominated_convergence ((Ioi a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
-  · filter_upwards [self_mem_nhdsWithin] with b hb
+  apply tendsto_integral_filter_of_dominated_convergence ((Ioi a₀).indicator (norm ∘ f))
+  · filter_upwards [self_mem_nhdsWithin] with a ha
     rw [aestronglyMeasurable_indicator_iff measurableSet_Ioi]
-    exact (hf.mono_set (Ioi_subset_Ioi (hb₀.trans hb))).aestronglyMeasurable
-  · filter_upwards [self_mem_nhdsWithin] with b hb
+    exact (hf.mono_set (Ioi_subset_Ioi ha)).aestronglyMeasurable
+  · filter_upwards [self_mem_nhdsWithin] with a ha
     refine ae_of_all _ fun x ↦ ?_
     rw [norm_indicator_eq_indicator_norm]
     apply indicator_le_indicator_of_subset (Ioi_subset_Ioi (by grind)) (fun a ↦ norm_nonneg (f a))
   · simpa [integrable_indicator_iff measurableSet_Ioi] using hf.norm
   · refine ae_of_all _ fun x ↦ ?_
     simp only [indicator_apply, mem_Ioi]
-    by_cases hx : b₀ < x <;> apply tendsto_const_nhds.congr'
-    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with b hb using by grind
-    · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
+    by_cases hx : a₀ < x <;> apply tendsto_const_nhds.congr'
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds hx)] with a ha using by grind
+    · filter_upwards [self_mem_nhdsWithin] with a ha using by grind
 
-theorem continuousOn_Ici_primitive_Ioi [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ioi a) μ) :
-    ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a) := by
-  intro b₀ hb₀
-  rw [mem_Ici] at hb₀
+theorem continuousOn_Ici_primitive_Ioi [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Ioi a₀) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Ioi b, f x ∂μ) (Ici a₀) := by
+  intro a ha
+  rw [mem_Ici] at ha
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
   · rw [Ici_inter_Iic]
-    have h_int : IntervalIntegrable f μ a b₀ := by
-      rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hb₀]
+    have h_int : IntervalIntegrable f μ a₀ a := by
+      rw [intervalIntegrable_iff_integrableOn_Ioc_of_le ha]
       exact hf.mono_set Ioc_subset_Ioi_self
-    have h_split : ∀ b ∈ Icc a b₀, ∫ x in Ioi b, f x ∂μ =
-        (∫ x in Ioi a, f x ∂μ) - ∫ x in a..b, f x ∂μ := by
+    have h_split : ∀ b ∈ Icc a₀ a, ∫ x in Ioi b, f x ∂μ =
+        (∫ x in Ioi a₀, f x ∂μ) - ∫ x in a₀..b, f x ∂μ := by
       intro b hb
       simp [← integral_Ioi_sub_Ioi hf hb.1]
-    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a..b, f x ∂μ) (Icc a b₀) b₀ :=
-      continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
-    exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split b₀ (right_mem_Icc.2 hb₀))
-  · simpa [hb₀] using hf.continuousWithinAt_Ici_primitive_Ioi hb₀
+    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a₀ a) a :=
+      continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
+    exact (continuousWithinAt_const.sub h_cwa).congr h_split (h_split a (right_mem_Icc.2 ha))
+  · simpa [ha] using (hf.mono_set (Ioi_subset_Ioi ha)).continuousWithinAt_Ici_primitive_Ioi
 
-theorem continuousWithinAt_Iic_primitive_Iio {a b₀ : ℝ} (hf : IntegrableOn f (Iio a) μ)
-    (hb₀ : b₀ ≤ a) : ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic b₀) b₀ := by
+theorem continuousWithinAt_Iic_primitive_Iio {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ)
+    : ContinuousWithinAt (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) a₀ := by
   simp_rw [← integral_indicator measurableSet_Iio]
-  refine tendsto_integral_filter_of_dominated_convergence ((Iio a).indicator (norm ∘ f)) ?_ ?_ ?_ ?_
-  · filter_upwards [self_mem_nhdsWithin] with b hb
+  apply tendsto_integral_filter_of_dominated_convergence ((Iio a₀).indicator (norm ∘ f))
+  · filter_upwards [self_mem_nhdsWithin] with a ha
     rw [aestronglyMeasurable_indicator_iff measurableSet_Iio]
-    exact (hf.mono_set (Iio_subset_Iio (hb.trans hb₀))).aestronglyMeasurable
-  · filter_upwards [self_mem_nhdsWithin] with b hb
+    exact (hf.mono_set (Iio_subset_Iio ha)).aestronglyMeasurable
+  · filter_upwards [self_mem_nhdsWithin] with a ha
     refine ae_of_all _ fun x ↦ ?_
     rw [norm_indicator_eq_indicator_norm]
     apply indicator_le_indicator_of_subset (Iio_subset_Iio (by grind)) (fun a ↦ norm_nonneg (f a))
   · simpa [integrable_indicator_iff measurableSet_Iio] using hf.norm
   · refine ae_of_all _ fun x ↦ ?_
     simp only [indicator_apply, mem_Iio]
-    by_cases hx : x < b₀ <;> apply tendsto_const_nhds.congr'
-    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with b hb using by grind
-    · filter_upwards [self_mem_nhdsWithin] with b hb using by grind
+    by_cases hx : x < a₀ <;> apply tendsto_const_nhds.congr'
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hx)] with a ha using by grind
+    · filter_upwards [self_mem_nhdsWithin] with a ha using by grind
 
-theorem continuousOn_Iic_primitive_Iio [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iio a) μ) :
-    ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a) := by
-  intro b₀ hb₀
-  rw [mem_Iic] at hb₀
+theorem continuousOn_Iic_primitive_Iio [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Iio a₀) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Iio b, f x ∂μ) (Iic a₀) := by
+  intro a ha
+  rw [mem_Iic] at ha
   rw [continuousWithinAt_iff_continuous_left_right]
   constructor
-  · simpa [hb₀] using hf.continuousWithinAt_Iic_primitive_Iio hb₀
+  · simpa [ha] using (hf.mono_set (Iio_subset_Iio ha)).continuousWithinAt_Iic_primitive_Iio
   · rw [Iic_inter_Ici]
-    have h_int : IntervalIntegrable f μ b₀ a := by
-      rw [intervalIntegrable_iff_integrableOn_Ico_of_le hb₀]
+    have h_int : IntervalIntegrable f μ a a₀ := by
+      rw [intervalIntegrable_iff_integrableOn_Ico_of_le ha]
       exact hf.mono_set Ico_subset_Iio_self
-    have h_split : ∀ b ∈ Icc b₀ a, ∫ x in Iio b, f x ∂μ =
-        (∫ x in Iio a, f x ∂μ) + ∫ x in a..b, f x ∂μ := by
+    have h_split : ∀ b ∈ Icc a a₀, ∫ x in Iio b, f x ∂μ =
+        (∫ x in Iio a₀, f x ∂μ) + ∫ x in a₀..b, f x ∂μ := by
       intro b hb
-      simp [integral_symm b a, ← integral_Iio_sub_Iio hf hb.2]
-    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a..b, f x ∂μ) (Icc b₀ a) b₀ := by
-      exact continuousWithinAt_primitive (measure_singleton b₀) (by simpa [hb₀])
-    apply (continuousWithinAt_const.add h_cwa).congr h_split (h_split b₀ (left_mem_Icc.2 hb₀))
+      simp [integral_symm b a₀, ← integral_Iio_sub_Iio' hf (hf.mono_set (Iio_subset_Iio hb.2))]
+    have h_cwa : ContinuousWithinAt (fun b ↦ ∫ x in a₀..b, f x ∂μ) (Icc a a₀) a := by
+      exact continuousWithinAt_primitive (measure_singleton a) (by simpa [ha])
+    exact (continuousWithinAt_const.add h_cwa).congr h_split (h_split a (left_mem_Icc.2 ha))
 
-theorem continuousOn_Ici_primitive_Ici [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Ici a) μ) :
-    ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a) := by
+theorem continuousOn_Ici_primitive_Ici [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Ici a₀) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Ici b, f x ∂μ) (Ici a₀) := by
   simp_rw [integral_Ici_eq_integral_Ioi]
   exact (hf.mono_set Ioi_subset_Ici_self).continuousOn_Ici_primitive_Ioi
 
-theorem continuousOn_Iic_primitive_Iic [NoAtoms μ] {a : ℝ} (hf : IntegrableOn f (Iic a) μ) :
-    ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a) := by
+theorem continuousOn_Iic_primitive_Iic [NoAtoms μ] {a₀ : ℝ} (hf : IntegrableOn f (Iic a₀) μ) :
+    ContinuousOn (fun b ↦ ∫ x in Iic b, f x ∂μ) (Iic a₀) := by
   simp_rw [integral_Iic_eq_integral_Iio]
   exact (hf.mono_set Iio_subset_Iic_self).continuousOn_Iic_primitive_Iio
 

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -630,6 +630,12 @@ theorem IntegrableOn.tendsto_integral_Ioi {ι E : Type*} [NormedAddCommGroup E] 
     Tendsto (fun i ↦ ∫ x in Ioi (b i), f x) l (𝓝 (∫ x in Ioi a, f x)) :=
   (hf.tendsto_primitive_Ioi le_rfl).comp hb
 
+theorem IntegrableOn.tendsto_integral_Iio {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iio a)) {b : ι → ℝ} {l : Filter ι}
+    (hb : Tendsto b l (𝓝[≤] a)) :
+    Tendsto (fun i ↦ ∫ x in Iio (b i), f x) l (𝓝 (∫ x in Iio a, f x)) :=
+  (hf.tendsto_primitive_Iio le_rfl).comp hb
+
 open Real
 
 open scoped Interval

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -624,32 +624,6 @@ theorem intervalIntegral_tendsto_integral_Ioi (a : ℝ) (hfi : IntegrableOn f (I
 
 end IntegralOfIntervalIntegral
 
-theorem IntegrableOn.tendsto_integral_Ioi {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi a)) {b : ι → ℝ} {l : Filter ι}
-    (hb : Tendsto b l (𝓝[≥] a)) :
-    Tendsto (fun i ↦ ∫ x in Ioi (b i), f x) l (𝓝 (∫ x in Ioi a, f x)) :=
-  (hf.tendsto_primitive_Ioi le_rfl).comp hb
-
-theorem IntegrableOn.tendsto_integral_Iio {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iio a)) {b : ι → ℝ} {l : Filter ι}
-    (hb : Tendsto b l (𝓝[≤] a)) :
-    Tendsto (fun i ↦ ∫ x in Iio (b i), f x) l (𝓝 (∫ x in Iio a, f x)) :=
-  (hf.tendsto_primitive_Iio le_rfl).comp hb
-
-theorem IntegrableOn.tendsto_integral_Ici {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {μ : Measure ℝ} [NoAtoms μ] {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ici a) μ)
-    {b : ι → ℝ} {l : Filter ι} (hb : Tendsto b l (𝓝[≥] a)) :
-    Tendsto (fun i ↦ ∫ x in Ici (b i), f x ∂μ) l (𝓝 (∫ x in Ici a, f x ∂μ)) := by
-  simp_rw [integral_Ici_eq_integral_Ioi]
-  exact ((hf.mono_set Ioi_subset_Ici_self).tendsto_primitive_Ioi le_rfl).comp hb
-
-theorem IntegrableOn.tendsto_integral_Iic {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {μ : Measure ℝ} [NoAtoms μ] {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iic a) μ)
-    {b : ι → ℝ} {l : Filter ι} (hb : Tendsto b l (𝓝[≤] a)) :
-    Tendsto (fun i ↦ ∫ x in Iic (b i), f x ∂μ) l (𝓝 (∫ x in Iic a, f x ∂μ)) := by
-  simp_rw [integral_Iic_eq_integral_Iio]
-  exact ((hf.mono_set Iio_subset_Iic_self).tendsto_primitive_Iio le_rfl).comp hb
-
 open Real
 
 open scoped Interval

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -636,6 +636,20 @@ theorem IntegrableOn.tendsto_integral_Iio {ι E : Type*} [NormedAddCommGroup E] 
     Tendsto (fun i ↦ ∫ x in Iio (b i), f x) l (𝓝 (∫ x in Iio a, f x)) :=
   (hf.tendsto_primitive_Iio le_rfl).comp hb
 
+theorem IntegrableOn.tendsto_integral_Ici {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {μ : Measure ℝ} [NoAtoms μ] {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ici a) μ)
+    {b : ι → ℝ} {l : Filter ι} (hb : Tendsto b l (𝓝[≥] a)) :
+    Tendsto (fun i ↦ ∫ x in Ici (b i), f x ∂μ) l (𝓝 (∫ x in Ici a, f x ∂μ)) := by
+  simp_rw [integral_Ici_eq_integral_Ioi]
+  exact ((hf.mono_set Ioi_subset_Ici_self).tendsto_primitive_Ioi le_rfl).comp hb
+
+theorem IntegrableOn.tendsto_integral_Iic {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {μ : Measure ℝ} [NoAtoms μ] {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Iic a) μ)
+    {b : ι → ℝ} {l : Filter ι} (hb : Tendsto b l (𝓝[≤] a)) :
+    Tendsto (fun i ↦ ∫ x in Iic (b i), f x ∂μ) l (𝓝 (∫ x in Iic a, f x ∂μ)) := by
+  simp_rw [integral_Iic_eq_integral_Iio]
+  exact ((hf.mono_set Iio_subset_Iic_self).tendsto_primitive_Iio le_rfl).comp hb
+
 open Real
 
 open scoped Interval

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -623,6 +623,32 @@ theorem intervalIntegral_tendsto_integral_Ioi (a : ℝ) (hfi : IntegrableOn f (I
 
 end IntegralOfIntervalIntegral
 
+theorem IntegrableOn.tendsto_integral_Ioi {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi a)) {b : ι → ℝ} {l : Filter ι}
+    (hb : Tendsto b l (𝓝[≥] a)) :
+    Tendsto (fun i ↦ ∫ x in Ioi (b i), f x) l (𝓝 (∫ x in Ioi a, f x)) := by
+  have hf' : IntervalIntegrable f volume a (a + 1) := by
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by linarith)]
+    exact hf.mono_set Ioc_subset_Ioi_self
+  have h_lim_zero : Tendsto (fun ε ↦ ∫ x in a..ε, f x) (𝓝[≥] a) (𝓝 0) := by
+    have hcont : ContinuousWithinAt (fun ε ↦ ∫ x in a..ε, f x) (Icc a (a + 1)) a :=
+      intervalIntegral.continuousWithinAt_primitive (by simp) (by simpa using hf')
+    simpa [ContinuousWithinAt] using hcont
+  have hε_split (ε : ℝ) (hε : a ≤ ε) :
+      ∫ x in Ioi ε, f x = (∫ x in Ioi a, f x) - ∫ x in a..ε, f x := by
+    calc
+      _ = ∫ x in Ioi a \ Ioc a ε, f x := by simp [hε]
+      _ = (∫ x in Ioi a, f x) - ∫ x in Ioc a ε, f x :=
+        integral_diff measurableSet_Ioc hf Ioc_subset_Ioi_self
+      _ = _ := by rw [intervalIntegral.integral_of_le hε]
+  have hev_eq : (fun i ↦ ∫ x in Ioi (b i), f x) =ᶠ[l]
+      (fun i ↦ (∫ x in Ioi a, f x) - ∫ x in a..b i, f x) := by
+    apply (hb.eventually self_mem_nhdsWithin).mono
+    intro i hi
+    exact hε_split (b i) hi
+  rw [tendsto_congr' hev_eq]
+  simpa using tendsto_const_nhds.sub (h_lim_zero.comp hb)
+
 open Real
 
 open scoped Interval

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -11,6 +11,7 @@ public import Mathlib.MeasureTheory.Function.JacobianOneDim
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 public import Mathlib.MeasureTheory.Measure.Haar.Unique
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # Links between an integral and its "improper" version
@@ -626,28 +627,8 @@ end IntegralOfIntervalIntegral
 theorem IntegrableOn.tendsto_integral_Ioi {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {a : ℝ} {f : ℝ → E} (hf : IntegrableOn f (Ioi a)) {b : ι → ℝ} {l : Filter ι}
     (hb : Tendsto b l (𝓝[≥] a)) :
-    Tendsto (fun i ↦ ∫ x in Ioi (b i), f x) l (𝓝 (∫ x in Ioi a, f x)) := by
-  have hf' : IntervalIntegrable f volume a (a + 1) := by
-    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by linarith)]
-    exact hf.mono_set Ioc_subset_Ioi_self
-  have h_lim_zero : Tendsto (fun ε ↦ ∫ x in a..ε, f x) (𝓝[≥] a) (𝓝 0) := by
-    have hcont : ContinuousWithinAt (fun ε ↦ ∫ x in a..ε, f x) (Icc a (a + 1)) a :=
-      intervalIntegral.continuousWithinAt_primitive (by simp) (by simpa using hf')
-    simpa [ContinuousWithinAt] using hcont
-  have hε_split (ε : ℝ) (hε : a ≤ ε) :
-      ∫ x in Ioi ε, f x = (∫ x in Ioi a, f x) - ∫ x in a..ε, f x := by
-    calc
-      _ = ∫ x in Ioi a \ Ioc a ε, f x := by simp [hε]
-      _ = (∫ x in Ioi a, f x) - ∫ x in Ioc a ε, f x :=
-        integral_diff measurableSet_Ioc hf Ioc_subset_Ioi_self
-      _ = _ := by rw [intervalIntegral.integral_of_le hε]
-  have hev_eq : (fun i ↦ ∫ x in Ioi (b i), f x) =ᶠ[l]
-      (fun i ↦ (∫ x in Ioi a, f x) - ∫ x in a..b i, f x) := by
-    apply (hb.eventually self_mem_nhdsWithin).mono
-    intro i hi
-    exact hε_split (b i) hi
-  rw [tendsto_congr' hev_eq]
-  simpa using tendsto_const_nhds.sub (h_lim_zero.comp hb)
+    Tendsto (fun i ↦ ∫ x in Ioi (b i), f x) l (𝓝 (∫ x in Ioi a, f x)) :=
+  (hf.tendsto_primitive_Ioi le_rfl).comp hb
 
 open Real
 

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -11,7 +11,6 @@ public import Mathlib.MeasureTheory.Function.JacobianOneDim
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 public import Mathlib.MeasureTheory.Measure.Haar.Unique
-public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # Links between an integral and its "improper" version

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -1106,6 +1106,30 @@ theorem integral_interval_add_Ioi' (ha : IntervalIntegrable f μ a b)
       ((intervalIntegrable_iff_integrableOn_Ioc_of_le h).1 ha) hb
   · exact hb.mono_set <| Ioi_subset_Ioi h.le
 
+theorem integral_Ioi_sub_Ioi (hf : IntegrableOn f (Ioi a) μ) (hab : a ≤ b) :
+    ∫ x in Ioi a, f x ∂μ - ∫ x in Ioi b, f x ∂μ = ∫ x in a..b, f x ∂μ :=
+  sub_eq_of_eq_add (integral_interval_add_Ioi hf (hf.mono_set (Ioi_subset_Ioi hab))).symm
+
+theorem integral_Ioi_sub_Ioi' (hf : IntegrableOn f (Ioi a) μ) (hg : IntegrableOn f (Ioi b) μ) :
+    ∫ x in Ioi a, f x ∂μ - ∫ x in Ioi b, f x ∂μ = ∫ x in a..b, f x ∂μ := by
+  wlog! hab : a ≤ b generalizing a b
+  · rw [integral_symm, ← this hg hf hab.le, neg_sub]
+  exact integral_Ioi_sub_Ioi hf hab
+
+theorem integral_Iio_sub_Iio [NoAtoms μ] (hf : IntegrableOn f (Iio b) μ) (hab : a ≤ b) :
+    ∫ x in Iio b, f x ∂μ - ∫ x in Iio a, f x ∂μ = ∫ x in a..b, f x ∂μ := by
+  simp_rw [setIntegral_congr_set Iio_ae_eq_Iic]
+  have hb : IntegrableOn f (Iic b) μ := by rwa [integrableOn_Iic_iff_integrableOn_Iio]
+  have ha : IntegrableOn f (Iic a) μ := hb.mono_set (Iic_subset_Iic.2 hab)
+  exact integral_Iic_sub_Iic ha hb
+
+theorem integral_Iio_sub_Iio' [NoAtoms μ] (hf : IntegrableOn f (Iio b) μ)
+    (hg : IntegrableOn f (Iio a) μ) :
+    ∫ x in Iio b, f x ∂μ - ∫ x in Iio a, f x ∂μ = ∫ x in a..b, f x ∂μ := by
+  wlog! hab : a ≤ b generalizing a b
+  · rw [integral_symm, ← this hg hf hab.le, neg_sub]
+  exact integral_Iio_sub_Iio hf hab
+
 theorem integral_Iic_add_Ioi (h_left : IntegrableOn f (Iic b) μ)
     (h_right : IntegrableOn f (Ioi b) μ) :
     (∫ x in Iic b, f x ∂μ) + (∫ x in Ioi b, f x ∂μ) = ∫ (x : ℝ), f x ∂μ := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -1116,19 +1116,19 @@ theorem integral_Ioi_sub_Ioi' (hf : IntegrableOn f (Ioi a) μ) (hg : IntegrableO
   · rw [integral_symm, ← this hg hf hab.le, neg_sub]
   exact integral_Ioi_sub_Ioi hf hab
 
-theorem integral_Iio_sub_Iio [NoAtoms μ] (hf : IntegrableOn f (Iio b) μ) (hab : a ≤ b) :
-    ∫ x in Iio b, f x ∂μ - ∫ x in Iio a, f x ∂μ = ∫ x in a..b, f x ∂μ := by
-  simp_rw [setIntegral_congr_set Iio_ae_eq_Iic]
-  have hb : IntegrableOn f (Iic b) μ := by rwa [integrableOn_Iic_iff_integrableOn_Iio]
-  have ha : IntegrableOn f (Iic a) μ := hb.mono_set (Iic_subset_Iic.2 hab)
-  exact integral_Iic_sub_Iic ha hb
+theorem integral_Iio_sub_Iio (hf : IntegrableOn f (Iio b) μ) (hab : a ≤ b) :
+    ∫ x in Iio b, f x ∂μ - ∫ x in Iio a, f x ∂μ = ∫ x in Ico a b, f x ∂μ := by
+  have ha : IntegrableOn f (Iio a) μ := hf.mono_set (Iio_subset_Iio hab)
+  have h : IntegrableOn f (Ico a b) μ := hf.mono_set Ico_subset_Iio_self
+  rw [sub_eq_iff_eq_add', ← setIntegral_union (by grind) measurableSet_Ico ha h,
+      Iio_union_Ico_eq_Iio hab]
 
 theorem integral_Iio_sub_Iio' [NoAtoms μ] (hf : IntegrableOn f (Iio b) μ)
     (hg : IntegrableOn f (Iio a) μ) :
     ∫ x in Iio b, f x ∂μ - ∫ x in Iio a, f x ∂μ = ∫ x in a..b, f x ∂μ := by
   wlog! hab : a ≤ b generalizing a b
   · rw [integral_symm, ← this hg hf hab.le, neg_sub]
-  exact integral_Iio_sub_Iio hf hab
+  rw [integral_Iio_sub_Iio hf hab, integral_of_le hab, integral_Ico_eq_integral_Ioc]
 
 theorem integral_Iic_add_Ioi (h_left : IntegrableOn f (Iic b) μ)
     (h_right : IntegrableOn f (Ioi b) μ) :

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -559,6 +559,10 @@ theorem compl_Ioc : (Ioc a b)ᶜ = Iic a ∪ Ioi b := by
 theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
   grind
 
+@[simp]
+theorem Ioi_diff_Ioc : Ioi a \ Ioc a b = Ioi (max a b) := by
+  simp [diff_eq, compl_Ioc, inter_union_distrib_left, Ioi_inter_Iic, Ioi_inter_Ioi]
+
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
   grind
 

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -561,7 +561,7 @@ theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
 
 @[simp]
 theorem Ioi_diff_Ioc : Ioi a \ Ioc a b = Ioi (max a b) := by
-  simp [diff_eq, compl_Ioc, inter_union_distrib_left, Ioi_inter_Iic, Ioi_inter_Ioi]
+  grind
 
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
   grind


### PR DESCRIPTION
This PR proves:

- `continuousWithinAt_Ici/Iic_primitive_Ioi/Iio`
- `continuousOn_Ici/Iic_primitive_Ioi/Iio/Ici/Iic`
- `integral_Ioi_sub_Ioi`, `integral_Ioi_sub_Ioi'`, `integral_Iio_sub_Iio`, `integral_Iio_sub_Iio'`
- `Ioi_diff_Ioc`

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
