### PR TITLE
[Merged by Bors] - ci: adapt auto-merge check for GitHub apps bots

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -774,7 +774,10 @@ jobs:
           echo "username=$USERNAME" >> "$GITHUB_OUTPUT"
           echo "Found label actor: $USERNAME"
 
-      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+      - if: >- # bot usernames will cause this step to error with "Could not resolve to a User..."
+          contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') &&
+          steps.get-label-actor.outputs.username != 'mathlib-nolints' &&
+          steps.get-label-actor.outputs.username != 'mathlib-update-dependencies'
         name: check team membership
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: actorTeams
@@ -784,11 +787,18 @@ jobs:
           username: ${{ steps.get-label-actor.outputs.username }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      # The create-github-app-token README states that this token is masked and will not be logged accidentally.
-      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams, 'bot-users')) }}
+      - if: >-
+          contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') &&
+          (
+            steps.get-label-actor.outputs.username == 'mathlib-nolints' ||
+            steps.get-label-actor.outputs.username == 'mathlib-update-dependencies' ||
+            contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') ||
+            contains(steps.actorTeams.outputs.teams, 'bot-users')
+          )
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:
+          # The create-github-app-token README states that this token is masked and will not be logged accidentally.
           token: ${{ steps.auto-merge-app-token.outputs.token }}
           issue-number: ${{ steps.PR.outputs.number }}
           body: |


### PR DESCRIPTION
The steps in our build workflow which determine whether to act on the `auto-merge-after-CI` label are [failing](https://github.com/leanprover-community/mathlib4/actions/runs/21793023184/job/62877678664?pr=34967#step:8:11) when one of our new GitHub apps bots has applied the label, since the username no longer corresponds to a user. 

We fix that by whitelisting the bot usernames. ([Usernames must be unique across both bots and users](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app#registering-a-github-app) so it should be impossible for someone to pose as one of them.)

Noticed in [#nightly-testing > Mathlib &#96;lake update&#96; failure @ 💬](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Mathlib.20.60lake.20update.60.20failure/near/572616935).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
