### PR TITLE
[Merged by Bors] - chore(Polynomial/Div): deprecate noncomputable `Decidable` non-instance

### DIFF
--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -478,9 +478,9 @@ theorem not_isField : ¬IsField R[X] := by
 section multiplicity
 
 /-- An algorithm for deciding polynomial divisibility.
-The algorithm is "compute `p %ₘ q` and compare to `0`".
-See `Polynomial.modByMonic` for the algorithm that computes `%ₘ`.
+Prefer `Classical.dec`, as the algorithm relies on `%ₘ` and so is `noncomputable`.
 -/
+@[deprecated Classical.dec (since := "2026-02-07")]
 def decidableDvdMonic [DecidableEq R] (p : R[X]) (hq : Monic q) : Decidable (q ∣ p) :=
   decidable_of_iff (p %ₘ q = 0) (modByMonic_eq_zero_iff_dvd hq)
 
@@ -492,27 +492,13 @@ theorem finiteMultiplicity_X_sub_C (a : R) (h0 : p ≠ 0) : FiniteMultiplicity (
 
 /- TODO: stripping out classical for decidability instance parameter might
 make for better ergonomics -/
-/-- The largest power of `X - C a` which divides `p`.
-This *could be* computable via the divisibility algorithm `Polynomial.decidableDvdMonic`,
-as shown by `Polynomial.rootMultiplicity_eq_nat_find_of_nonzero` which has a computable RHS. -/
+/-- The largest power of `X - C a` which divides `p`. -/
 def rootMultiplicity (a : R) (p : R[X]) : ℕ :=
   letI := Classical.decEq R
   if h0 : p = 0 then 0
   else
-    let _ : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := fun n =>
-      have := decidableDvdMonic p ((monic_X_sub_C a).pow (n + 1))
-      inferInstanceAs (Decidable ¬_)
+    let _ : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := Classical.decPred _
     Nat.find (finiteMultiplicity_X_sub_C a h0)
-
-theorem rootMultiplicity_eq_nat_find_of_nonzero [DecidableEq R] {p : R[X]} (p0 : p ≠ 0) {a : R} :
-    -- `decidableDvdMonic` can't be an instance, so we inline it here.
-    letI : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := fun n =>
-      have := decidableDvdMonic p ((monic_X_sub_C a).pow (n + 1))
-      inferInstanceAs (Decidable ¬_)
-    rootMultiplicity a p = Nat.find (finiteMultiplicity_X_sub_C a p0) := by
-  dsimp [rootMultiplicity]
-  cases Subsingleton.elim ‹DecidableEq R› (Classical.decEq R)
-  rw [dif_neg p0]
 
 theorem rootMultiplicity_eq_multiplicity [DecidableEq R]
     (p : R[X]) (a : R) :
@@ -525,6 +511,13 @@ theorem rootMultiplicity_eq_multiplicity [DecidableEq R]
   simp only [finiteMultiplicity_X_sub_C a h, ↓reduceDIte]
   rw [← ENat.some_eq_coe, WithTop.untopD_coe]
   congr
+
+@[deprecated rootMultiplicity_eq_multiplicity (since := "2026-02-07")]
+theorem rootMultiplicity_eq_nat_find_of_nonzero {p : R[X]} (p0 : p ≠ 0) {a : R} :
+    letI : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := Classical.decPred _
+    rootMultiplicity a p = Nat.find (finiteMultiplicity_X_sub_C a p0) := by
+  dsimp [rootMultiplicity]
+  rw [dif_neg p0]
 
 @[simp]
 theorem rootMultiplicity_zero {x : R} : rootMultiplicity x 0 = 0 :=
@@ -716,7 +709,7 @@ lemma eval_divByMonic_eq_trailingCoeff_comp {p : R[X]} {t : R} :
 lemma le_rootMultiplicity_iff (p0 : p ≠ 0) {a : R} {n : ℕ} :
     n ≤ rootMultiplicity a p ↔ (X - C a) ^ n ∣ p := by
   classical
-  simp_rw [rootMultiplicity_eq_nat_find_of_nonzero p0, @Nat.le_find_iff _ (_), Classical.not_not]
+  simp_rw [rootMultiplicity, dif_neg p0, Nat.le_find_iff, not_not]
   refine ⟨fun h => ?_, fun h m hm => (pow_dvd_pow _ hm).trans h⟩
   rcases n with - | n
   · rw [pow_zero]

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -500,6 +500,16 @@ def rootMultiplicity (a : R) (p : R[X]) : ℕ :=
     let _ : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := Classical.decPred _
     Nat.find (finiteMultiplicity_X_sub_C a h0)
 
+theorem rootMultiplicity_eq_natFind_of_ne_zero {p : R[X]} (p0 : p ≠ 0) {a : R}
+    [DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p] :
+    rootMultiplicity a p = Nat.find (finiteMultiplicity_X_sub_C a p0) := by
+  dsimp [rootMultiplicity]
+  rw [dif_neg p0]
+  congr
+
+@[deprecated (since := "2026-02-12")]
+alias rootMultiplicity_eq_nat_find_of_nonzero := rootMultiplicity_eq_natFind_of_ne_zero
+
 theorem rootMultiplicity_eq_multiplicity [DecidableEq R]
     (p : R[X]) (a : R) :
     rootMultiplicity a p =
@@ -511,13 +521,6 @@ theorem rootMultiplicity_eq_multiplicity [DecidableEq R]
   simp only [finiteMultiplicity_X_sub_C a h, ↓reduceDIte]
   rw [← ENat.some_eq_coe, WithTop.untopD_coe]
   congr
-
-@[deprecated rootMultiplicity_eq_multiplicity (since := "2026-02-07")]
-theorem rootMultiplicity_eq_nat_find_of_nonzero {p : R[X]} (p0 : p ≠ 0) {a : R} :
-    letI : DecidablePred fun n : ℕ => ¬(X - C a) ^ (n + 1) ∣ p := Classical.decPred _
-    rootMultiplicity a p = Nat.find (finiteMultiplicity_X_sub_C a p0) := by
-  dsimp [rootMultiplicity]
-  rw [dif_neg p0]
 
 @[simp]
 theorem rootMultiplicity_zero {x : R} : rootMultiplicity x 0 = 0 :=


### PR DESCRIPTION
Deprecate `decidableDvdMonic`, which is a noncomputable `Decidable` non-instance and so inferior to `Classical.dec`. This is a leftover from before leanprover-community/mathlib3#1391, in which polynomials were made to use classical logic.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
