### PR TITLE
[Merged by Bors] - feat(Analysis/PSeries): add version of Cauchy condensation with weaker assumptions

### DIFF
--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -235,6 +235,22 @@ theorem summable_condensed_iff_of_nonneg {f : ℕ → ℝ} (h_nonneg : ∀ n, 0 
     (pow_right_strictMono₀ one_lt_two) two_ne_zero h_succ_diff
   simp [pow_succ, mul_two]
 
+/-- Cauchy condensation test for eventually antitone and nonnegative series of real numbers. -/
+theorem summable_condensed_iff_of_nonneg' {f : ℕ → ℝ} (h_nonneg : 0 ≤ᶠ[Filter.atTop] f)
+    (h_mono : ∃ k : ℕ, AntitoneOn f (Set.Ici k)) :
+    (Summable fun k : ℕ => (2 : ℝ) ^ k * f (2 ^ k)) ↔ Summable f := by
+  rw [Filter.EventuallyLE, Filter.eventually_atTop] at h_nonneg
+  rcases h_nonneg with ⟨n,hn⟩
+  rcases h_mono with ⟨m,hm⟩
+  convert summable_condensed_iff_of_nonneg (f := fun k ↦ f (max k (n + m))) _ _ using 1
+  · rw [summable_congr_atTop]
+    have h_pow := tendsto_pow_atTop_atTop_of_one_lt (r := 2) (by simp)
+    filter_upwards [h_pow.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
+  · rw [summable_congr_atTop]
+    filter_upwards [Filter.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
+  · exact fun _ ↦ by apply hn; simp
+  · exact fun _ _ _ _ ↦ hm (by simp) (by simp) (by bound)
+
 section p_series
 
 /-!

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -240,8 +240,8 @@ theorem summable_condensed_iff_of_nonneg' {f : ℕ → ℝ} (h_nonneg : 0 ≤ᶠ
     (h_mono : ∃ k : ℕ, AntitoneOn f (Set.Ici k)) :
     (Summable fun k : ℕ => (2 : ℝ) ^ k * f (2 ^ k)) ↔ Summable f := by
   rw [Filter.EventuallyLE, Filter.eventually_atTop] at h_nonneg
-  rcases h_nonneg with ⟨n,hn⟩
-  rcases h_mono with ⟨m,hm⟩
+  rcases h_nonneg with ⟨n, hn⟩
+  rcases h_mono with ⟨m, hm⟩
   convert summable_condensed_iff_of_nonneg (f := fun k ↦ f (max k (n + m))) _ _ using 1
   · rw [summable_congr_atTop]
     have h_pow := tendsto_pow_atTop_atTop_of_one_lt (r := 2) (by simp)

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -236,10 +236,11 @@ theorem summable_condensed_iff_of_nonneg {f : ℕ → ℝ} (h_nonneg : ∀ n, 0 
   simp [pow_succ, mul_two]
 
 /-- Cauchy condensation test for eventually antitone and nonnegative series of real numbers. -/
-theorem summable_condensed_iff_of_nonneg' {f : ℕ → ℝ} (h_nonneg : 0 ≤ᶠ[Filter.atTop] f)
-    (h_mono : ∃ k : ℕ, AntitoneOn f (Set.Ici k)) :
+theorem summable_condensed_iff_of_eventually_nonneg {f : ℕ → ℝ} (h_nonneg : 0 ≤ᶠ[Filter.atTop] f)
+    (h_mono : ∀ᶠ k in Filter.atTop, f (k + 1) ≤ f k) :
     (Summable fun k : ℕ => (2 : ℝ) ^ k * f (2 ^ k)) ↔ Summable f := by
   rw [Filter.EventuallyLE, Filter.eventually_atTop] at h_nonneg
+  rw [Filter.eventually_atTop] at h_mono
   rcases h_nonneg with ⟨n, hn⟩
   rcases h_mono with ⟨m, hm⟩
   convert summable_condensed_iff_of_nonneg (f := fun k ↦ f (max k (n + m))) _ _ using 1
@@ -248,8 +249,10 @@ theorem summable_condensed_iff_of_nonneg' {f : ℕ → ℝ} (h_nonneg : 0 ≤ᶠ
     filter_upwards [h_pow.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
   · rw [summable_congr_atTop]
     filter_upwards [Filter.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
-  · exact fun _ ↦ by apply hn; simp
-  · exact fun _ _ _ _ ↦ hm (by simp) (by simp) (by bound)
+  · simpa [hn] using by bound
+  · intro _ _ _ _
+    apply antitoneOn_nat_Ici_of_succ_le (k := n + m) _ (by aesop) (by aesop) (by bound)
+    simpa [hn] using by bound
 
 section p_series
 


### PR DESCRIPTION
Add a version of `summable_condensed_iff_of_nonneg` which only requires that f is eventually positive and antitone.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
