### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): commutation of fiber functors with functors which preserves filtered colimits

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -46,7 +46,7 @@ and with arbitrary colimits.
 
 @[expose] public section
 
-universe w' w v v' u u'
+universe w' w v v' v'' u u' u''
 
 namespace CategoryTheory
 
@@ -77,7 +77,8 @@ namespace Point
 attribute [instance] initiallySmall isCofiltered
 
 variable {J} (Φ : Point.{w} J) {A : Type u'} [Category.{v'} A]
-  [HasColimitsOfSize.{w, w} A]
+  {B : Type u''} [Category.{v''} B]
+  [HasColimitsOfSize.{w, w} A] [HasColimitsOfSize.{w, w} B]
 
 instance : HasColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
   hasColimitsOfShape_of_finallySmall _ _
@@ -278,6 +279,36 @@ instance [HasSheafify J A] [J.WEqualsLocallyBijective A] [(forget A).ReflectsIso
             dsimp
             rw [← Functor.map_comp, Sheaf.sheafifyCocone_ι_app_val]
             dsimp))⟩
+
+variable (F : A ⥤ B) [LocallySmall.{w} C] [PreservesFilteredColimitsOfSize.{w, w} F]
+
+/-- If `Φ` is a point of a site and `F : A ⥤ B` is a functor which preserves
+filtered colimits, then taking fibers of presheaves at `Φ` commutes with `F`. -/
+noncomputable def presheafFiberCompIso :
+  (Functor.whiskeringRight _ _ _).obj F ⋙ Φ.presheafFiber ≅
+    Φ.presheafFiber ⋙ F :=
+  haveI := Functor.Final.preservesColimitsOfShape_of_final
+    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+  Functor.isoWhiskerLeft
+    ((Functor.whiskeringLeft _ _ _).obj _) (preservesColimitNatIso F).symm
+
+@[reassoc]
+lemma toPresheafFiber_presheafFiberCompIso_hom_app
+    (X : C) (x : Φ.fiber.obj X) (P : Cᵒᵖ ⥤ A) :
+    Φ.toPresheafFiber X x (P ⋙ F) ≫ (Φ.presheafFiberCompIso F).hom.app P =
+      F.map (Φ.toPresheafFiber X x P) := by
+  haveI := Functor.Final.preservesColimitsOfShape_of_final
+    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+  simp only [presheafFiberCompIso]
+  exact ι_preservesColimitIso_inv F ((CategoryOfElements.π Φ.fiber).op ⋙ P) _
+
+/-- If `Φ` is a point of a site and `F : A ⥤ B` is a functor which preserves
+filtered colimits, then taking fibers of sheaves at `Φ` commutes with `F`. -/
+@[simps!]
+noncomputable def sheafFiberCompIso [J.HasSheafCompose F] :
+    sheafCompose J F ⋙ Φ.sheafFiber ≅ Φ.sheafFiber ⋙ F :=
+  Functor.isoWhiskerLeft (sheafToPresheaf J A) (Φ.presheafFiberCompIso F) ≪≫
+    (Functor.associator _ _ _).symm
 
 end Point
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
