### PR TITLE
[Merged by Bors] - chore: fix overlapping instances in meta files

### DIFF
--- a/Mathlib/Deprecated/MLList/BestFirst.lean
+++ b/Mathlib/Deprecated/MLList/BestFirst.lean
@@ -106,19 +106,19 @@ variable {ω α : Type} {prio : α → Thunk ω} {ε : α → Type} [LinearOrder
 /-- Calculate the current best lower bound for the priority of a node. -/
 def BestFirstNode.estimate (n : BestFirstNode prio ε) : ω := bound (prio n.key) n.estimator
 
-instance [Ord ω] [Ord α] : Ord (BestFirstNode prio ε) where
+instance [Ord α] : Ord (BestFirstNode prio ε) where
   compare :=
     compareLex
       (compareOn BestFirstNode.estimate)
       (compareOn BestFirstNode.key)
 
 set_option linter.unusedVariables false in
-variable (prio ε m β) [Ord ω] [Ord α] in
+variable (prio ε m β) [Ord α] in
 /-- A queue of `MLList m β`s, lazily prioritized by lower bounds. -/
 @[nolint unusedArguments]
 def BestFirstQueue (maxSize : Option Nat) := TreeMap (BestFirstNode prio ε) (MLList m β) compare
 
-variable [Ord ω] [Ord α] {maxSize : Option Nat}
+variable [Ord α] {maxSize : Option Nat}
 
 namespace BestFirstQueue
 
@@ -234,7 +234,7 @@ end BestFirstQueue
 
 open MLList
 
-variable {m : Type → Type} [Monad m] [Alternative m] [∀ a, Bot (ε a)] (prio ε)
+variable {m : Type → Type} [AlternativeMonad m] [∀ a, Bot (ε a)] (prio ε)
 
 /--
 Core implementation of `bestFirstSearch`, that works by iteratively updating an internal state,
@@ -311,7 +311,7 @@ def bestFirstSearchCore (f : α → MLList m α) (a : α)
 
 end
 
-variable {m : Type → Type} {α : Type} [Monad m] [Alternative m] [LinearOrder α]
+variable {m : Type → Type} {α : Type} [AlternativeMonad m] [LinearOrder α]
 
 /-- A local instance that enables using "the actual value" as a priority estimator,
 for simple use cases. -/

--- a/Mathlib/Lean/LocalContext.lean
+++ b/Mathlib/Lean/LocalContext.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Init
 public import Lean.LocalContext
+public import Batteries.Control.AlternativeMonad
 
 /-!
 # Additional methods about `LocalContext`
@@ -17,7 +18,7 @@ public section
 namespace Lean.LocalContext
 
 universe u v
-variable {m : Type u → Type v} [Monad m] [Alternative m]
+variable {m : Type u → Type v} [AlternativeMonad m]
 variable {β : Type u}
 
 /-- Return the result of `f` on the first local declaration on which `f` succeeds. -/

--- a/Mathlib/Tactic/Linter/DirectoryDependency.lean
+++ b/Mathlib/Tactic/Linter/DirectoryDependency.lean
@@ -187,7 +187,7 @@ def allowedImportDirs : NamePrefixRel := .ofArray #[
   (`Mathlib.Lean, `Batteries.Data.Fin),
   (`Mathlib.Lean, `Batteries.Data.List),
   (`Mathlib.Lean, `Batteries.Lean),
-  (`Mathlib.Lean, `Batteries.Control.ForInStep),
+  (`Mathlib.Lean, `Batteries.Control),
   (`Mathlib.Lean, `Batteries.Tactic.Alias),
   (`Mathlib.Lean, `Batteries.Util.ProofWanted),
 

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -203,10 +203,9 @@ def catchNone {e : Q($α)} (t : MetaM (Strictness zα pα e)) : MetaM (Strictnes
 variable {zα pα} in
 /-- Converts a `MetaM Strictness` which can return `.none`
 into one which never returns `.none` but fails instead. -/
-def throwNone {m : Type → Type*} {e : Q($α)} [Monad m] [Alternative m]
-    (t : m (Strictness zα pα e)) : m (Strictness zα pα e) := do
+def throwNone {e : Q($α)} (t : MetaM (Strictness zα pα e)) : MetaM (Strictness zα pα e) := do
   match ← t with
-  | .none => failure
+  | .none => throwError "Strictness result was `{.ofConstName ``Strictness.none}`."
   | r => pure r
 
 /-- Attempts to prove a `Strictness` result when `e` evaluates to a literal number. -/


### PR DESCRIPTION
This PR is intended to satisfy the upcoming overlapping instances linter. It replaces `[Monad m] [Alternative m]` with `[AlternativeMonad m]` , which avoids overlapping on the data-carrying `Applicative` projection, or specializes appropriate monads like `MetaM` where possible.

It also fixes some other duplicated instance projections in `Mathlib.Deprecated.MLList.BestFirst`, even though this file is deprecated.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
