### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): more API for dense subsites

### DIFF
--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -433,6 +433,37 @@ noncomputable def restrictHomEquivHom : (G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) ≃
   left_inv := sheafHom_restrict_eq
   right_inv := sheafHom_eq _
 
+@[reassoc]
+lemma restrictHomEquivHom_naturality_right_symm
+    (f : ℱ ⟶ ℱ'.val) {𝒢'} (g : ℱ' ⟶ 𝒢') :
+    (restrictHomEquivHom (G := G)).symm (f ≫ g.val) =
+      restrictHomEquivHom.symm f ≫ whiskerLeft _ g.val := rfl
+
+@[reassoc]
+lemma restrictHomEquivHom_naturality_right
+    (f : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) {𝒢'} (g : ℱ' ⟶ 𝒢') :
+    restrictHomEquivHom (f ≫ whiskerLeft G.op g.val) =
+      restrictHomEquivHom f ≫ g.val := by
+  apply (restrictHomEquivHom (G := G)).symm.injective
+  simpa only [Equiv.symm_apply_apply] using
+    (restrictHomEquivHom_naturality_right_symm (G := G) (restrictHomEquivHom f) g).symm
+
+@[reassoc]
+lemma restrictHomEquivHom_naturality_left_symm
+    {𝒢} (f : 𝒢 ⟶ ℱ) (g : ℱ ⟶ ℱ'.val) :
+    (restrictHomEquivHom (G := G)).symm (f ≫ g) =
+      whiskerLeft G.op f ≫ restrictHomEquivHom.symm g := rfl
+
+@[reassoc]
+lemma restrictHomEquivHom_naturality_left
+    {𝒢} (f : 𝒢 ⟶ ℱ) (g : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
+    restrictHomEquivHom (whiskerLeft _ f ≫ g) =
+      f ≫ restrictHomEquivHom g := by
+  apply (restrictHomEquivHom (G := G)).symm.injective
+  simpa only [Equiv.symm_apply_apply] using
+    (restrictHomEquivHom_naturality_left_symm (G := G) (f := f)
+      (g := restrictHomEquivHom g)).symm
+
 /-- Given a locally-full and cover-dense functor `G` and a natural transformation of sheaves
 `α : ℱ ⟶ ℱ'`, if the pullback of `α` along `G` is iso, then `α` is also iso.
 -/
@@ -545,6 +576,84 @@ lemma equalizer_mem {U V} (f₁ f₂ : U ⟶ V) (e : G.map f₁ = G.map f₂) :
     Sieve.equalizer f₁ f₂ ∈ J _ :=
   letI := IsDenseSubsite.isLocallyFaithful J K G
   IsDenseSubsite.functorPushforward_mem_iff.mp (G.functorPushforward_equalizer_mem K f₁ f₂ e)
+
+variable {J} (F : Sheaf J A)
+
+lemma map_eq_of_eq {X Y : C} (f₁ f₂ : X ⟶ Y)
+    (h : G.map f₁ = G.map f₂) :
+    F.val.map f₁.op = F.val.map f₂.op :=
+  Presheaf.IsSheaf.hom_ext F.cond
+    ⟨_, IsDenseSubsite.equalizer_mem J K G _ _ h⟩ _ _ (by
+      rintro ⟨W₀, a, ha⟩
+      dsimp at ha ⊢
+      simp only [← Functor.map_comp, ← op_comp, ha])
+
+/-- If `G : C ⥤ D` is a dense subsite and `F` a sheaf on `C`, this is the morphism
+`F.val.obj (op Y) ⟶ F.val.obj (op X)` induced by a morphism
+`G.obj X ⟶ G.obj Y` in the category `D`. -/
+noncomputable def mapPreimage {X Y : C} (f : G.obj X ⟶ G.obj Y) :
+    F.val.obj (op Y) ⟶ F.val.obj (op X) :=
+  F.cond.amalgamate
+    ⟨_, imageSieve_mem J K G f⟩ (fun ⟨W₀, a, ha⟩ ↦ F.val.map ha.choose.op) (by
+      rintro ⟨W₀, a, ha⟩ ⟨W₀', a', ha'⟩ ⟨T₀, p₁, p₂, fac⟩
+      rw [← Functor.map_comp, ← Functor.map_comp, ← op_comp, ← op_comp]
+      apply map_eq_of_eq K G
+      rw [Functor.map_comp, Functor.map_comp, ha.choose_spec, ha'.choose_spec,
+        ← Functor.map_comp_assoc, ← Functor.map_comp_assoc, fac])
+
+lemma mapPreimage_map_of_fac {X Y Z : C} (f : G.obj X ⟶ G.obj Y)
+    (p : Z ⟶ X) (g : Z ⟶ Y) (fac : G.map p ≫ f = G.map g) :
+    mapPreimage K G F f ≫ F.val.map p.op = F.val.map g.op :=
+  Presheaf.IsSheaf.hom_ext F.cond
+    ⟨_, J.pullback_stable p (imageSieve_mem J K G f)⟩ _ _ (by
+      rintro ⟨W₀, a, ha⟩
+      dsimp at ha ⊢
+      rw [Category.assoc, ← Functor.map_comp, ← op_comp, mapPreimage]
+      rw [F.2.amalgamate_map ⟨_, imageSieve_mem J K G f⟩
+        (fun ⟨W₀, a, ha⟩ ↦ F.val.map ha.choose.op) _ ⟨W₀, a ≫ p, ha⟩,
+        ← Functor.map_comp, ← op_comp]
+      apply map_eq_of_eq K G
+      rw [ha.choose_spec, Functor.map_comp_assoc, Functor.map_comp, fac])
+
+lemma mapPreimage_of_eq {X Y : C} (f : G.obj X ⟶ G.obj Y)
+    (g : X ⟶ Y) (h : G.map g = f) :
+    mapPreimage K G F f = F.val.map g.op := by
+  simpa using mapPreimage_map_of_fac K G F f (𝟙 _) g (by simpa using h.symm)
+
+@[simp]
+lemma mapPreimage_map {X Y : C} (f : X ⟶ Y) :
+    mapPreimage K G F (G.map f) = F.val.map f.op :=
+  mapPreimage_of_eq K G F (G.map f) f rfl
+
+@[simp]
+lemma mapPreimage_id (X : C) :
+    mapPreimage K G F (𝟙 (G.obj X)) = 𝟙 _ := by
+  rw [← G.map_id, mapPreimage_map, op_id, map_id]
+
+@[reassoc]
+lemma mapPreimage_comp {X Y Z : C} (f : G.obj X ⟶ G.obj Y)
+    (g : G.obj Y ⟶ G.obj Z) :
+    mapPreimage K G F (f ≫ g) = mapPreimage K G F g ≫ mapPreimage K G F f :=
+  Presheaf.IsSheaf.hom_ext F.cond
+    ⟨_, imageSieve_mem J K G f⟩ _ _ (by
+      rintro ⟨T₀, a, ⟨b, fac₁⟩⟩
+      apply Presheaf.IsSheaf.hom_ext F.cond
+        ⟨_, J.pullback_stable b (imageSieve_mem J K G g)⟩
+      rintro ⟨U₀, c, ⟨d, fac₂⟩⟩
+      dsimp
+      simp only [Category.assoc, ← Functor.map_comp, ← op_comp]
+      rw [mapPreimage_map_of_fac K G F (f ≫ g) (c ≫ a) d,
+        mapPreimage_map_of_fac K G F f (c ≫ a) (c ≫ b),
+        mapPreimage_map_of_fac K G F g (c ≫ b) d]
+      all_goals
+        simp only [Functor.map_comp, Category.assoc, fac₁, fac₂])
+
+@[reassoc]
+lemma mapPreimage_comp_map {X Y Z : C} (f : G.obj X ⟶ G.obj Y)
+    (g : Z ⟶ X) :
+    mapPreimage K G F f ≫ F.val.map g.op =
+      mapPreimage K G F (G.map g ≫ f) := by
+  rw [mapPreimage_comp, mapPreimage_map]
 
 end IsDenseSubsite
 


### PR DESCRIPTION
Compatibility lemmas are added for `restrictHomEquivHom`. If `G : C ⥤ D` is a dense subsite and `F` is a sheaf on `C`, we introduce a definition `mapPreimage` which allows to define `F.val.obj (op Y) ⟶ F.val.obj (op X)` for any morphism `G.obj X ⟶ G.obj Y` in `D` between objects in the image of the functor `G`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
