### PR TITLE
[Merged by Bors] - feat: the normal closure of an empty set is the trivial subgroup

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -496,6 +496,13 @@ theorem normalClosure_le_normal {N : Subgroup G} [N.Normal] (h : s ⊆ N) : norm
   · exact mul_mem ihx ihy
   · exact inv_mem ihx
 
+/-- The normal closure of an empty set is the trivial subgroup. -/
+lemma normalClosure_empty :
+  normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
+apply le_antisymm
+· exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
+· exact bot_le
+
 theorem normalClosure_subset_iff {N : Subgroup G} [N.Normal] : s ⊆ N ↔ normalClosure s ≤ N :=
   ⟨normalClosure_le_normal, Set.Subset.trans subset_normalClosure⟩
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -497,6 +497,7 @@ theorem normalClosure_le_normal {N : Subgroup G} [N.Normal] (h : s ⊆ N) : norm
   · exact inv_mem ihx
 
 /-- The normal closure of an empty set is the trivial subgroup. -/
+@[simp]
 lemma normalClosure_empty :
   normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
 apply le_antisymm

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -498,11 +498,10 @@ theorem normalClosure_le_normal {N : Subgroup G} [N.Normal] (h : s ⊆ N) : norm
 
 /-- The normal closure of an empty set is the trivial subgroup. -/
 @[simp]
-lemma normalClosure_empty :
-  normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
-apply le_antisymm
-· exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
-· exact bot_le
+lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
+  apply le_antisymm
+  · exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
+  · exact bot_le
 
 theorem normalClosure_subset_iff {N : Subgroup G} [N.Normal] : s ⊆ N ↔ normalClosure s ≤ N :=
   ⟨normalClosure_le_normal, Set.Subset.trans subset_normalClosure⟩

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -496,12 +496,6 @@ theorem normalClosure_le_normal {N : Subgroup G} [N.Normal] (h : s ⊆ N) : norm
   · exact mul_mem ihx ihy
   · exact inv_mem ihx
 
-/-- The normal closure of an empty set is the trivial subgroup. -/
-@[simp]
-lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
-  rw [eq_bot_iff_forall]
-  exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
-
 theorem normalClosure_subset_iff {N : Subgroup G} [N.Normal] : s ⊆ N ↔ normalClosure s ≤ N :=
   ⟨normalClosure_le_normal, Set.Subset.trans subset_normalClosure⟩
 
@@ -529,6 +523,11 @@ theorem closure_le_normalClosure {s : Set G} : closure s ≤ normalClosure s := 
 theorem normalClosure_closure_eq_normalClosure {s : Set G} :
     normalClosure ↑(closure s) = normalClosure s :=
   le_antisymm (normalClosure_le_normal closure_le_normalClosure) (normalClosure_mono subset_closure)
+
+/-- The normal closure of an empty set is the trivial subgroup. -/
+@[simp]
+lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
+rw [← normalClosure_closure_eq_normalClosure, closure_empty, normalClosure_eq_self]
 
 /-- The normal core of a subgroup `H` is the largest normal subgroup of `G` contained in `H`,
 as shown by `Subgroup.normalCore_eq_iSup`. -/

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -527,7 +527,7 @@ theorem normalClosure_closure_eq_normalClosure {s : Set G} :
 /-- The normal closure of an empty set is the trivial subgroup. -/
 @[simp]
 lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
-rw [← normalClosure_closure_eq_normalClosure, closure_empty, normalClosure_eq_self]
+  rw [← normalClosure_closure_eq_normalClosure, closure_empty, normalClosure_eq_self]
 
 /-- The normal core of a subgroup `H` is the largest normal subgroup of `G` contained in `H`,
 as shown by `Subgroup.normalCore_eq_iSup`. -/

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -499,9 +499,8 @@ theorem normalClosure_le_normal {N : Subgroup G} [N.Normal] (h : s ⊆ N) : norm
 /-- The normal closure of an empty set is the trivial subgroup. -/
 @[simp]
 lemma normalClosure_empty : normalClosure (∅ : Set G) = (⊥ : Subgroup G) := by
-  apply le_antisymm
-  · exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
-  · exact bot_le
+  rw [eq_bot_iff_forall]
+  exact Subgroup.normalClosure_le_normal (N := (⊥ : Subgroup G)) (by simp)
 
 theorem normalClosure_subset_iff {N : Subgroup G} [N.Normal] : s ⊆ N ↔ normalClosure s ≤ N :=
   ⟨normalClosure_le_normal, Set.Subset.trans subset_normalClosure⟩


### PR DESCRIPTION
This is a dependency of a larger PR to formalize finitely presented groups (#34236).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
