### PR TITLE
[Merged by Bors] - docs(CategoryTheory/Bicategory/Adjunction): fix typos and update docs

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Adj.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Adj.lean
@@ -191,7 +191,7 @@ def forget₁ : Adj B ⥤ᵖ B where
 -- TODO: define `forget₂` which sends an adjunction to its right adjoint functor
 
 /-- Given an isomorphism between two 1-morphisms in `Adj B`, this is the
-underlying isomorphisms between the left adjoints. -/
+underlying isomorphism between the left adjoints. -/
 @[simps]
 def lIso {a b : Adj B} {adj₁ adj₂ : a ⟶ b} (e : adj₁ ≅ adj₂) : adj₁.l ≅ adj₂.l where
   hom := e.hom.τl
@@ -200,7 +200,7 @@ def lIso {a b : Adj B} {adj₁ adj₂ : a ⟶ b} (e : adj₁ ≅ adj₂) : adj�
   inv_hom_id := by rw [← comp_τl, e.inv_hom_id, id_τl]
 
 /-- Given an isomorphism between two 1-morphisms in `Adj B`, this is the
-underlying isomorphisms between the right adjoints. -/
+underlying isomorphism between the right adjoints. -/
 @[simps]
 def rIso {a b : Adj B} {adj₁ adj₂ : a ⟶ b} (e : adj₁ ≅ adj₂) : adj₁.r ≅ adj₂.r where
   hom := e.inv.τr

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
@@ -19,12 +19,14 @@ identities. The 2-morphism `η` is called the unit and `ε` is called the counit
 
 * `Bicategory.Adjunction`: adjunctions between two 1-morphisms.
 * `Bicategory.Equivalence`: adjoint equivalences between two objects.
-* `Bicategory.mkOfAdjointifyCounit`: construct an adjoint equivalence from 2-isomorphisms
+* `Bicategory.Equivalence.mkOfAdjointifyCounit`: construct an adjoint equivalence from
+  2-isomorphisms
   `η : 𝟙 a ≅ f ≫ g` and `ε : g ≫ f ≅ 𝟙 b`, by upgrading `ε` to a counit.
 
 ## TODO
 
-* `Bicategory.mkOfAdjointifyUnit`: construct an adjoint equivalence from 2-isomorphisms
+* `Bicategory.Equivalence.mkOfAdjointifyUnit`: construct an adjoint equivalence from
+  2-isomorphisms
   `η : 𝟙 a ≅ f ≫ g` and `ε : g ≫ f ≅ 𝟙 b`, by upgrading `η` to a unit.
 -/
 
@@ -112,12 +114,12 @@ section Composition
 
 variable {f₁ : a ⟶ b} {g₁ : b ⟶ a} {f₂ : b ⟶ c} {g₂ : c ⟶ b}
 
-/-- Auxiliary definition for `adjunction.comp`. -/
+/-- Auxiliary definition for `Adjunction.comp`. -/
 @[simp]
 def compUnit (adj₁ : f₁ ⊣ g₁) (adj₂ : f₂ ⊣ g₂) : 𝟙 a ⟶ (f₁ ≫ f₂) ≫ g₂ ≫ g₁ :=
   adj₁.unit ⊗≫ f₁ ◁ adj₂.unit ▷ g₁ ⊗≫ 𝟙 _
 
-/-- Auxiliary definition for `adjunction.comp`. -/
+/-- Auxiliary definition for `Adjunction.comp`. -/
 @[simp]
 def compCounit (adj₁ : f₁ ⊣ g₁) (adj₂ : f₂ ⊣ g₂) : (g₂ ≫ g₁) ≫ f₁ ≫ f₂ ⟶ 𝟙 c :=
   𝟙 _ ⊗≫ g₂ ◁ adj₁.counit ▷ f₂ ⊗≫ adj₂.counit
@@ -304,7 +306,7 @@ def getRightAdjoint (f : a ⟶ b) [IsLeftAdjoint f] : RightAdjoint f :=
 def rightAdjoint (f : a ⟶ b) [IsLeftAdjoint f] : b ⟶ a :=
   (getRightAdjoint f).right
 
-/-- Evidence that `f⁺⁺` is a right adjoint of `f`. -/
+/-- Evidence that `rightAdjoint f` is a right adjoint of `f`. -/
 def Adjunction.ofIsLeftAdjoint (f : a ⟶ b) [IsLeftAdjoint f] : f ⊣ rightAdjoint f :=
   (getRightAdjoint f).adj
 
@@ -315,7 +317,7 @@ structure LeftAdjoint (right : b ⟶ a) where
   /-- The adjunction between `left` and `right`. -/
   adj : left ⊣ right
 
-/-- The existence of a left adjoint of `f`. -/
+/-- The existence of a left adjoint of `right`. -/
 class IsRightAdjoint (right : b ⟶ a) : Prop where mk' ::
   nonempty : Nonempty (LeftAdjoint right)
 
@@ -330,7 +332,7 @@ def getLeftAdjoint (f : b ⟶ a) [IsRightAdjoint f] : LeftAdjoint f :=
 def leftAdjoint (f : b ⟶ a) [IsRightAdjoint f] : a ⟶ b :=
   (getLeftAdjoint f).left
 
-/-- Evidence that `f⁺` is a left adjoint of `f`. -/
+/-- Evidence that `leftAdjoint f` is a left adjoint of `f`. -/
 def Adjunction.ofIsRightAdjoint (f : b ⟶ a) [IsRightAdjoint f] : leftAdjoint f ⊣ f :=
   (getLeftAdjoint f).adj
 

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Mate.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Mate.lean
@@ -139,7 +139,7 @@ Then we have a bijection between 2-morphisms `g ≫ l₂ ⟶ l₁ ≫ h` and
       c --→ d             c ←-- d
     g ↓  ↗  ↓ h         g ↓  ↘  ↓ h
       e --→ f             e ←-- f
-         L₂                  R₂
+         l₂                  r₂
 ```
 
 Note that if one of the 2-morphisms is an iso, it does not imply the other is an iso.
@@ -304,7 +304,7 @@ section leftAdjointSquare.comp
 variable (α : g₁ ≫ l₃ ⟶ l₁ ≫ h₁) (β : h₁ ≫ l₄ ⟶ l₂ ≫ k₁)
 variable (γ : g₂ ≫ l₅ ⟶ l₃ ≫ h₂) (δ : h₂ ≫ l₆ ⟶ l₄ ≫ k₂)
 
-/-- Squares of squares between left adjoints can be composed by iterating vertical and horizontal
+/-- A square of squares between left adjoints can be composed by iterating vertical and horizontal
 composition.
 -/
 def leftAdjointSquare.comp :
@@ -331,7 +331,7 @@ section rightAdjointSquare.comp
 variable (α : r₁ ≫ g₁ ⟶ h₁ ≫ r₃) (β : r₂ ≫ h₁ ⟶ k₁ ≫ r₄)
 variable (γ : r₃ ≫ g₂ ⟶ h₂ ≫ r₅) (δ : r₄ ≫ h₂ ⟶ k₂ ≫ r₆)
 
-/-- Squares of squares between right adjoints can be composed by iterating vertical and horizontal
+/-- A square of squares between right adjoints can be composed by iterating vertical and horizontal
 composition.
 -/
 def rightAdjointSquare.comp :
@@ -353,7 +353,7 @@ theorem rightAdjointSquare.comp_hvcomp :
 
 end rightAdjointSquare.comp
 
-/-- The mates equivalence commutes with composition of squares of squares. These results form the
+/-- The mates equivalence commutes with composition of a square of squares. These results form the
 basis for an isomorphism of double categories to be proven later.
 -/
 theorem mateEquiv_square
@@ -385,7 +385,7 @@ variable (adj₁ : l₁ ⊣ r₁) (adj₂ : l₂ ⊣ r₂)
 /-- Given two adjunctions `l₁ ⊣ r₁` and `l₂ ⊣ r₂` both between objects `c`, `d`, there is a
 bijection between 2-morphisms `l₂ ⟶ l₁` and 2-morphisms `r₁ ⟶ r₂`. This is
 defined as a special case of `mateEquiv`, where the two "vertical" 1-morphisms are identities.
-Corresponding 2-morphisms are called `conjugateEquiv`.
+This bijection is `conjugateEquiv`; the image of a 2-morphism under it is called its conjugate.
 
 Furthermore, this bijection preserves (and reflects) isomorphisms, i.e. a 2-morphism is an iso
 iff its image under the bijection is an iso.
@@ -583,7 +583,7 @@ instance conjugateEquiv_symm_iso (α : r₁ ⟶ r₂) [IsIso α] :
       ⟨conjugateEquiv_symm_comm _ _ (by simp), conjugateEquiv_symm_comm _ _ (by simp)⟩⟩⟩
 
 /-- If `α` is a 2-morphism between left adjoints whose conjugate 2-morphism
-is an isomorphism, then `α` is an isomorphism. The converse is given in `Conjugate_iso`.
+is an isomorphism, then `α` is an isomorphism. The converse is given in `conjugateEquiv_iso`.
 -/
 theorem conjugateEquiv_of_iso (α : l₂ ⟶ l₁) [IsIso (conjugateEquiv adj₁ adj₂ α)] :
     IsIso α := by
@@ -636,9 +636,9 @@ variable (adj₁ : l₁ ⊣ r₁) (adj₂ : l₂ ⊣ r₂) (adj₃ : f₁ ⊣ u�
 /-- When all four morphisms in a square are left adjoints, the mates operation can be iterated:
 ```
          l₁                  r₁                  r₁
-      c --→ d             c ←-- d             c ←-- d
-   f₁ ↓  ↗  ↓  f₂      f₁ ↓  ↘  ↓ f₂       u₁ ↑  ↙  ↑ u₂
       a --→ b             a ←-- b             a ←-- b
+   f₁ ↓  ↗  ↓  f₂      f₁ ↓  ↘  ↓ f₂       u₁ ↑  ↙  ↑ u₂
+      c --→ d             c ←-- d             c ←-- d
          l₂                  r₂                  r₂
 ```
 In this case the iterated mate equals the conjugate of the original 2-morphism and is thus an
@@ -667,12 +667,12 @@ variable {g : a ⟶ c} {h : b ⟶ d}
 variable {l₁ : a ⟶ b} {r₁ : b ⟶ a} {l₂ : c ⟶ d} {r₂ : d ⟶ c} {l₃ : c ⟶ d} {r₃ : d ⟶ c}
 variable (adj₁ : l₁ ⊣ r₁) (adj₂ : l₂ ⊣ r₂) (adj₃ : l₃ ⊣ r₃)
 
-/-- Composition of a squares between left adjoints with a conjugate square. -/
+/-- Composition of a square between left adjoints with a conjugate square. -/
 def leftAdjointSquareConjugate.vcomp (α : g ≫ l₂ ⟶ l₁ ≫ h) (β : l₃ ⟶ l₂) :
     g ≫ l₃ ⟶ l₁ ≫ h :=
   g ◁ β ≫ α
 
-/-- Composition of a squares between right adjoints with a conjugate square. -/
+/-- Composition of a square between right adjoints with a conjugate square. -/
 def rightAdjointSquareConjugate.vcomp (α : r₁ ≫ g ⟶ h ≫ r₂) (β : r₂ ⟶ r₃) :
     r₁ ≫ g ⟶ h ≫ r₃ :=
   α ≫ h ◁ β
@@ -705,12 +705,12 @@ variable {g : a ⟶ c} {h : b ⟶ d}
 variable {l₁ : a ⟶ b} {r₁ : b ⟶ a} {l₂ : a ⟶ b} {r₂ : b ⟶ a} {l₃ : c ⟶ d} {r₃ : d ⟶ c}
 variable (adj₁ : l₁ ⊣ r₁) (adj₂ : l₂ ⊣ r₂) (adj₃ : l₃ ⊣ r₃)
 
-/-- Composition of a conjugate square with a squares between left adjoints. -/
+/-- Composition of a conjugate square with a square between left adjoints. -/
 def leftAdjointConjugateSquare.vcomp (α : l₂ ⟶ l₁) (β : g ≫ l₃ ⟶ l₂ ≫ h) :
     g ≫ l₃ ⟶ l₁ ≫ h :=
   β ≫ α ▷ h
 
-/-- Composition of a conjugate square with a squares between right adjoints. -/
+/-- Composition of a conjugate square with a square between right adjoints. -/
 def rightAdjointConjugateSquare.vcomp (α : r₁ ⟶ r₂) (β : r₂ ≫ g ⟶ h ≫ r₃) :
     r₁ ≫ g ⟶ h ≫ r₃ :=
   α ▷ g ≫ β


### PR DESCRIPTION
  Fix documentation issues across the `Bicategory/Adjunction` files:

  - **Adj.lean**: Fix plural ("isomorphisms" → "isomorphism") in `lIso`/`rIso` docstrings.
  - **Basic.lean**: Use correct fully qualified names (`Bicategory.Equivalence.mkOfAdjointifyCounit`, `Adjunction.comp`), replace stale `f⁺`/`f⁺⁺` notation with `leftAdjoint f`/`rightAdjoint f`, and fix a parameter name reference in
  `IsRightAdjoint`.
  - **Mate.lean**: Fix capitalisation of variable names in a diagram (`L₂`/`R₂` → `l₂`/`r₂`), correct a swapped diagram in `iteratedMateEquiv`, fix a dangling reference (`Conjugate_iso` → `conjugateEquiv_iso`), improve the `conjugateEquiv`
  docstring, and fix several grammar issues ("a squares" → "a square", "Squares of squares" → "A square of squares").

---

The issues were found and fixed by Codex.
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
