### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): relation between products and wide pullbacks

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2619,6 +2619,7 @@ public import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
 public import Mathlib.CategoryTheory.Limits.Constructions.Over.Products
 public import Mathlib.CategoryTheory.Limits.Constructions.Pullbacks
 public import Mathlib.CategoryTheory.Limits.Constructions.WeaklyInitial
+public import Mathlib.CategoryTheory.Limits.Constructions.WidePullbackOfTerminal
 public import Mathlib.CategoryTheory.Limits.Constructions.ZeroObjects
 public import Mathlib.CategoryTheory.Limits.Creates
 public import Mathlib.CategoryTheory.Limits.Elements

--- a/Mathlib/CategoryTheory/Limits/Constructions/WidePullbackOfTerminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/WidePullbackOfTerminal.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.WidePullbacks
+public import Mathlib.CategoryTheory.Limits.Shapes.Products
+public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+
+/-!
+# Existence of wide pullbacks when the target object is terminal
+
+In this file, we show that the wide pullback of a family of arrows `objs j ⟶ B`
+exists when `B` is terminal and the product of the objects `objs j` exists.
+
+-/
+
+@[expose] public section
+
+universe w v u
+
+namespace CategoryTheory.Limits
+
+variable {C : Type u} [Category.{v} C]
+  {ι : Type w} {B : C} {objs : ι → C}
+  (arrows : (j : ι) → objs j ⟶ B)
+
+namespace WidePullbackCone
+
+/-- The fan that is induced by a wide pullback cone. -/
+abbrev toFan (s : WidePullbackCone arrows) : Fan objs :=
+  Fan.mk _ s.π
+
+variable (c : Fan objs)
+
+/-- The wide pullback cone given by a fan, when the base object is terminal. -/
+abbrev ofFan (hB : IsTerminal B) : WidePullbackCone arrows :=
+  WidePullbackCone.mk (hB.from _) c.proj (fun _ ↦ hB.hom_ext _ _)
+
+variable {c} in
+/-- When the base object is terminal, a limit wide pullback cone can be obtained
+from a limit fan. -/
+def isLimitOfFan (hc : IsLimit c) (hB : IsTerminal B) :
+    IsLimit (ofFan arrows c hB) :=
+  IsLimit.mk _
+    (fun s ↦ hc.lift s.toFan)
+    (fun s ↦ hB.hom_ext _ _)
+    (fun s i ↦ hc.fac s.toFan (.mk i))
+    (fun s m _ hm ↦ hc.hom_ext (fun ⟨i⟩ ↦ by simpa using hm i))
+
+end WidePullbackCone
+
+lemma hasWidePullback_of_isTerminal
+    [HasProduct objs] (hB : IsTerminal B) :
+    HasWidePullback B objs arrows where
+  exists_limit :=
+    ⟨_, WidePullbackCone.isLimitOfFan (arrows := arrows) (limit.isLimit _) hB⟩
+
+end CategoryTheory.Limits


### PR DESCRIPTION
In this PR, we show that a wide pullback of arrows `objs j ⟶ B` exists when `B` is terminal and the product of the objects `obj j` exists.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
