### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace): small lemmas about lineMap and homothety

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -119,6 +119,12 @@ theorem AffineMap.lineMap_mem {k V P : Type*} [Ring k] [AddCommGroup V] [Module 
   rw [AffineMap.lineMap_apply]
   exact Q.smul_vsub_vadd_mem c h₁ h₀ h₀
 
+theorem AffineMap.homothety_mem {k V P : Type*} [CommRing k] [AddCommGroup V] [Module k V]
+    [AddTorsor V P] {s : AffineSubspace k P} {c : P} (hc : c ∈ s) (r : k) {p : P} (hp : p ∈ s) :
+    AffineMap.homothety c r p ∈ s := by
+  rw [AffineMap.homothety_eq_lineMap]
+  exact lineMap_mem r hc hp
+
 namespace AffineSubspace
 
 variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k V]

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -596,6 +596,14 @@ lemma affineCombination_apply_eq_lineMap_sum [DecidableEq ι] (w : ι → k) (p 
     simp [hp₁ i hi]
   · exact (hp₂ i hi).symm
 
+/-- Applying `AffineMap.lineMap` on two `Finset.affineCombination` over the same set of points
+is equivalent to applying `AffineMap.lineMap` to the weights. -/
+theorem lineMap_affineCombination (w₁ : ι → k) (w₂ : ι → k) (r : k) (p : ι → P) :
+    AffineMap.lineMap (s.affineCombination k p w₁) (s.affineCombination k p w₂) r =
+    s.affineCombination k p (AffineMap.lineMap w₁ w₂ r) := by
+  simp_rw [Finset.affineCombination_apply, ← AffineMap.lineMap_vadd, AffineMap.lineMap_apply_module,
+    map_add, map_smul]
+
 variable (k)
 
 /-- Weights for expressing a single point as an affine combination. -/
@@ -705,6 +713,17 @@ theorem affineCombination_affineCombinationLineMapWeights [DecidableEq ι] (p : 
   rw [affineCombinationLineMapWeights, ← weightedVSub_vadd_affineCombination,
     weightedVSub_const_smul, s.affineCombination_affineCombinationSingleWeights k p hi,
     s.weightedVSub_weightedVSubVSubWeights k p hj hi, AffineMap.lineMap_apply]
+
+/-- Applying `AffineMap.homothety` on `Finset.affineCombination` towards one of the weighted points
+  is equivalent to moving the weights towards `Finset.affineCombinationSingleWeights`. -/
+-- Redeclaring all variables because `AffineMap.homothety` requires `[CommRing k]`
+theorem homothety_affineCombination {k V P : Type*} [CommRing k] [AddCommGroup V] [Module k V]
+    [AffineSpace V P] {ι : Type*} [DecidableEq ι] (s : Finset ι) (p : ι → P) (w : ι → k) {i : ι}
+    (hi : i ∈ s) (r : k) :
+    AffineMap.homothety (p i) r (s.affineCombination k p w) = s.affineCombination k p
+      (AffineMap.lineMap (Finset.affineCombinationSingleWeights k i) w r) := by
+  rw [AffineMap.homothety_eq_lineMap, ← Finset.lineMap_affineCombination,
+    Finset.affineCombination_affineCombinationSingleWeights _ _ _ hi]
 
 end Finset
 


### PR DESCRIPTION
Three lemmas about their interaction with AffineSubspace, and AffineCombination. Building towards #34826

`AffineMap.homothety_mem` is mostly just restating `AffineMap.lineMap_mem`, but since they are affine map with different names, putting it here can give better discovery

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
