### PR TITLE
[Merged by Bors] - fix(GroupTheory/Complement): avoid DecidableEq diamond in Function.update proofs

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -276,8 +276,7 @@ lemma exists_isComplement_left (H : Subgroup G) (g : G) : ∃ S, IsComplement S 
     QuotientGroup.mk g, Function.update_self (Quotient.mk'' g) g Quotient.out⟩
   by_cases hq : q = Quotient.mk'' g
   · exact hq.symm ▸ congr_arg _ (Function.update_self (Quotient.mk'' g) g Quotient.out)
-  · show ↑(Function.update Quotient.out (Quotient.mk'' g) g q) = q
-    simp [Function.update, dif_neg hq, q.out_eq']
+  · simp [Function.update, dif_neg hq, q.out_eq']
 
 @[to_additive]
 lemma exists_isComplement_right (H : Subgroup G) (g : G) :
@@ -287,8 +286,7 @@ lemma exists_isComplement_right (H : Subgroup G) (g : G) :
     Quotient.mk'' g, Function.update_self (Quotient.mk'' g) g Quotient.out⟩
   by_cases hq : q = Quotient.mk'' g
   · exact hq.symm ▸ congr_arg _ (Function.update_self (Quotient.mk'' g) g Quotient.out)
-  · show Quotient.mk'' (Function.update Quotient.out (Quotient.mk'' g) g q) = q
-    simp [Function.update, dif_neg hq, q.out_eq']
+  · simp [Function.update, dif_neg hq, q.out_eq']
 
 /-- Given two subgroups `H' ⊆ H`, there exists a left transversal to `H'` inside `H`. -/
 @[to_additive /-- Given two subgroups `H' ⊆ H`, there exists a transversal to `H'` inside `H` -/]

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -276,8 +276,8 @@ lemma exists_isComplement_left (H : Subgroup G) (g : G) : ∃ S, IsComplement S 
     QuotientGroup.mk g, Function.update_self (Quotient.mk'' g) g Quotient.out⟩
   by_cases hq : q = Quotient.mk'' g
   · exact hq.symm ▸ congr_arg _ (Function.update_self (Quotient.mk'' g) g Quotient.out)
-  · refine Function.update_of_ne ?_ g Quotient.out ▸ q.out_eq'
-    exact hq
+  · show ↑(Function.update Quotient.out (Quotient.mk'' g) g q) = q
+    simp [Function.update, dif_neg hq, q.out_eq']
 
 @[to_additive]
 lemma exists_isComplement_right (H : Subgroup G) (g : G) :
@@ -287,8 +287,8 @@ lemma exists_isComplement_right (H : Subgroup G) (g : G) :
     Quotient.mk'' g, Function.update_self (Quotient.mk'' g) g Quotient.out⟩
   by_cases hq : q = Quotient.mk'' g
   · exact hq.symm ▸ congr_arg _ (Function.update_self (Quotient.mk'' g) g Quotient.out)
-  · refine Function.update_of_ne ?_ g Quotient.out ▸ q.out_eq'
-    exact hq
+  · show Quotient.mk'' (Function.update Quotient.out (Quotient.mk'' g) g q) = q
+    simp [Function.update, dif_neg hq, q.out_eq']
 
 /-- Given two subgroups `H' ⊆ H`, there exists a left transversal to `H'` inside `H`. -/
 @[to_additive /-- Given two subgroups `H' ⊆ H`, there exists a transversal to `H'` inside `H` -/]


### PR DESCRIPTION
This PR fixes fragile proofs in `exists_isComplement_left` and `exists_isComplement_right` that used the antipattern:
```lean
refine Function.update_of_ne ?_ g Quotient.out ▸ q.out_eq'
exact hq
```
Here the `refine`/`exact` split guides elaboration in a way that isn't evident from the source: `Function.update_of_ne` picks up a `DecidableEq` instance (from `QuotientGroup.instDecidableEq`) that can differ from the one used by `Function.update` in the goal (the `classical` instance), causing the `▸` to fail when these instances become distinguishable (as happens with https://github.com/leanprover/lean4/pull/12368).

The replacement proofs unfold `Function.update` directly via `simp`. I make no claim that these are particularly good proofs, only that they are robust enough to survive nightly-testing. Better proofs in a follow-up PR would be welcome.

See discussion on Zulip about the `refine`/`exact` antipattern: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/linter.20requests/near/572903100

🤖 Prepared with Claude Code