### PR TITLE
[Merged by Bors] - fix(PowerSeries/WeierstrassPreparation): avoid simp_rw [HasEquiv.Equiv]

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/WeierstrassPreparation.lean
+++ b/Mathlib/RingTheory/PowerSeries/WeierstrassPreparation.lean
@@ -409,7 +409,8 @@ theorem mod_zero [IsAdicComplete I A] : H.mod 0 = 0 := by
 `A⟦X⟧ / (g) →ₗ[A] A[X]`. -/
 noncomputable def mod' [IsAdicComplete I A] : A⟦X⟧ ⧸ Ideal.span {g} →ₗ[A] A[X] where
   toFun := Quotient.lift (fun f ↦ H.mod f) fun f f' hf ↦ by
-    simp_rw [HasEquiv.Equiv, Submodule.quotientRel_def, Ideal.mem_span_singleton'] at hf
+    have hf := (Submodule.quotientRel_def (p := Ideal.span {g})).mp hf
+    rw [Ideal.mem_span_singleton'] at hf
     obtain ⟨a, ha⟩ := hf
     obtain ⟨hf1, hf2⟩ := H.isWeierstrassDivisionAt_div_mod f
     obtain ⟨hf'1, hf'2⟩ := H.isWeierstrassDivisionAt_div_mod f'


### PR DESCRIPTION
This PR fixes a proof in `IsWeierstrassDivisorAt.mod'` that used `simp_rw [HasEquiv.Equiv, Submodule.quotientRel_def, Ideal.mem_span_singleton']` to rewrite a `Quotient.lift` proof obligation. This breaks when `HasEquiv.Equiv` becomes `@[reducible]` (as in https://github.com/leanprover/lean4/pull/12368), since the first rewrite step then makes no progress.

Replace with `have hf := (Submodule.quotientRel_def (p := Ideal.span {g})).mp hf` which works regardless of `HasEquiv.Equiv`'s reducibility.

See also the related `refine`/`exact` antipattern fix in https://github.com/leanprover-community/mathlib4/pull/35059.

I'll note that we may yet revert some or all of the changes in leanprover/lean4#12386, but nevertheless having this robustness in Mathlib makes life easier for us to experiment / get things right!

🤖 Prepared with Claude Code