### PR TITLE
fix(GCongr): robustness against @[reducible] HasSSubset.SSubset

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -244,7 +244,11 @@ def makeGCongrLemma (hyps : Array Expr) (target : Expr) (declName : Name) (prio 
     @[gcongr] attribute only applies to lemmas proving f x₁ ... xₙ ∼ f x₁' ... xₙ'.\n \
     {m} in {target}"
   -- verify that conclusion of the lemma is of the form `f x₁ ... xₙ ∼ f x₁' ... xₙ'`
-  let some (relName, lhs, rhs) := getRel (← whnf target) | fail "No relation found"
+  -- Try `getRel` on the syntactic target first, before `whnf`. This avoids unfolding
+  -- `@[reducible]` class projections (like `HasSSubset.SSubset`) that would destroy the
+  -- relation structure.
+  let some (relName, lhs, rhs) := getRel target <|> getRel (← whnf target)
+    | fail "No relation found"
   let lhs := lhs.headBeta; let rhs := rhs.headBeta -- this is required for `Monotone fun x => ⋯`
   let some (head, lhsArgs) := getCongrAppFnArgs lhs | fail "LHS is not suitable for congruence"
   let some (head', rhsArgs) := getCongrAppFnArgs rhs | fail "RHS is not suitable for congruence"


### PR DESCRIPTION
This PR makes the `gcongr` tactic robust against `HasSSubset.SSubset` (and similar relations) being marked `@[reducible]`. When `whnf` at reducible transparency unfolds `⊂` away, `getRel` can no longer parse the result, breaking both `@[gcongr]` attribute registration and the tactic itself.

The fix is to try `getRel` on the unreduced type first, falling back to the `whnf`'d form only when needed. This is applied in four locations: `makeGCongrLemma` (attribute registration), `MVarId.gcongr` (tactic core), and the `gcongr`/`rel` elaborators.

This is forward-ported from `nightly-testing`, where it's needed for lean4#12368.

🤖 Prepared with Claude Code