### PR TITLE
[Merged by Bors] - fix(translate): mark translated definitions with `meta`

### DIFF
--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -1,6 +1,10 @@
-import Mathlib.Order.Defs.PartialOrder
-import Mathlib.Order.Notation
-import Mathlib.Tactic.ToAdditive
+module
+
+public import Mathlib.Order.Defs.PartialOrder
+public import Mathlib.Order.Notation
+public import Mathlib.Tactic.ToAdditive
+
+@[expose] public section
 
 variable {α : Type} [PartialOrder α] (a b c : α)
 
@@ -243,7 +247,7 @@ info: theorem Cov.Ioc_def : ∀ {α : Type} [inst : PartialOrder α] {a b x : α
           forall_congr fun {b} =>
             forall_congr fun {x} =>
               congr (congrArg Iff (congrArg (And (x ≤ a ∧ ∀ ⦃c : α⦄, c < a → ¬x < c)) (CovBy._to_dual_cast_4 x b)))
-                (Eq.trans (Cov.Ico._to_dual_cast_3 a b x)
+                (Eq.trans (Cov.Ico._to_dual_cast_4 a b x)
                   (congr (congrArg And (WCovBy._to_dual_cast_4 a x)) (CovBy._to_dual_cast_4 x b)))))
   (@Eq.mp
     (∀ {α : Type} [inst : PartialOrder α] {a b x : α},
@@ -262,3 +266,11 @@ info: theorem Cov.Ioc_def : ∀ {α : Type} [inst : PartialOrder α] {a b x : α
 -/
 #guard_msgs in
 #print Cov.Ioc_def
+
+/-! Test that translated autoparams are marked with `meta`. -/
+
+@[to_dual]
+def Top.autoParamTest {a b : α} (h : a ≤ b := by grind) : a ≤ b := h
+
+open Lean
+run_meta guard <| isDeclMeta (← getEnv) ``Bot.autoParamTest._auto_1


### PR DESCRIPTION
This PR lets translations in `to_dual`/`to_additive` be marked with `meta` if the original was as well. This is necessary when dealing with autoparams, because they are marked with `meta`, and we need their translation to also be marked with `meta`.

I've added a test for this in `MathlibTest.ToDual`. This needs to be run in a `module` to actually test something relevant, so I've make the test file into a `module`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
