### PR TITLE
[Merged by Bors] - chore(scripts): add new technical debt counters

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -77,9 +77,6 @@ tdc () {
 # See also the comment on the `read` line in the for-loop that follows the definition of this array.
 titlesPathsAndRegexes=(
   "porting notes"                  "*"      "Porting note"
-  "backwards compatibility flags"  "*"      "set_option.*backward"
-  "proofsInPublic flags"           "*"      "set_option backward.proofsInPublic"
-  "privateInPublic flags"          "*"      "set_option backward.privateInPublic"
   "flexible linter exceptions"     ":^MathlibTest"      "set_option linter.flexible"
   "adaptation notes"               ":^Mathlib/Tactic/AdaptationNote.lean :^Mathlib/Tactic/Linter"
                                             "^[· ]*#adaptation_note"
@@ -105,6 +102,24 @@ for i in ${!titlesPathsAndRegexes[@]}; do
     printf '%s|%s\n' "$(git grep "${fl}" "${regex}" -- ":^scripts" "${pathspec[@]}" | wc -l)" "${title}"
   fi
 done
+
+# Dynamic breakdown of backwards compatibility flags by individual option
+for flag in $({ git grep -oh -e 'set_option backward\.[A-Za-z0-9_]*' -- ':^scripts' || true; } |
+               sed 's/set_option //' | sort -u); do
+  printf '%s|%s\n' \
+    "$({ git grep -Fc -e "set_option ${flag}" -- ':^scripts' || true; } |
+      awk -F: 'BEGIN{s=0}{s+=$2} END{print s}')" \
+    "${flag}"
+done
+
+# count simp +instances and dsimp +instances
+# we use grep -v 'dsimp' to avoid counting dsimp lines in the simp total
+simpPlusInstances="$({ git grep -e 'simp.*[+]instances' -- ':^scripts' || true; } |
+  grep -v 'dsimp' | wc -l)"
+dsimpPlusInstances="$({ git grep -c -e 'dsimp.*[+]instances' -- ':^scripts' || true; } |
+  awk -F: 'BEGIN{s=0}{s+=$2} END{print s}')"
+printf '%s|simp +instances\n' "${simpPlusInstances}"
+printf '%s|dsimp +instances\n' "${dsimpPlusInstances}"
 
 # count total number of `set_option linter.deprecated false` outside of `Mathlib/Deprecated`
 deprecs="$(git grep -c -- "set_option linter.deprecated false" -- ":^Mathlib/Deprecated" |

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -114,9 +114,9 @@ done
 
 # count simp +instances and dsimp +instances
 # we use grep -v 'dsimp' to avoid counting dsimp lines in the simp total
-simpPlusInstances="$({ git grep -e 'simp.*[+]instances' -- ':^scripts' || true; } |
+simpPlusInstances="$({ git grep -e 'simp \([+-][^ ]* *\)*+instances' -- ':^scripts' || true; } |
   grep -v 'dsimp' | wc -l)"
-dsimpPlusInstances="$({ git grep -c -e 'dsimp.*[+]instances' -- ':^scripts' || true; } |
+dsimpPlusInstances="$({ git grep -c -e 'dsimp \([+-][^ ]* *\)*+instances' -- ':^scripts' || true; } |
   awk -F: 'BEGIN{s=0}{s+=$2} END{print s}')"
 printf '%s|simp +instances\n' "${simpPlusInstances}"
 printf '%s|dsimp +instances\n' "${dsimpPlusInstances}"


### PR DESCRIPTION
This PR updates `scripts/technical-debt-metrics.sh` to:

- Dynamically enumerate `backward.*` compatibility flags instead of maintaining a static list. New flags are automatically picked up.
- Add counters for `simp +instances` and `dsimp +instances` (careful not to double-count, since `dsimp` contains `simp`).

🤖 Prepared with Claude Code