### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): refactor `structureSheaf`

### DIFF
--- a/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
@@ -296,8 +296,7 @@ instance forget₂SemiRing_preservesFilteredColimits :
             (F ⋙ forget₂ RingCat SemiRingCat.{u})) }
 
 instance : Limits.PreservesFilteredColimits (forget₂ RingCat AddCommGrpCat.{u}) where
-  preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
+  preserves_filtered_colimits _ :=
     { preservesColimit := fun {F} =>
         Limits.preservesColimit_of_preserves_colimit_cocone
           (RingCat.FilteredColimits.colimitCoconeIsColimit.{u, u} F)

--- a/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
@@ -295,6 +295,15 @@ instance forget₂SemiRing_preservesFilteredColimits :
           (SemiRingCat.FilteredColimits.colimitCoconeIsColimit
             (F ⋙ forget₂ RingCat SemiRingCat.{u})) }
 
+instance : Limits.PreservesFilteredColimits (forget₂ RingCat AddCommGrpCat.{u}) where
+  preserves_filtered_colimits {J hJ1 _} :=
+    letI : Category J := hJ1
+    { preservesColimit := fun {F} =>
+        Limits.preservesColimit_of_preserves_colimit_cocone
+          (RingCat.FilteredColimits.colimitCoconeIsColimit.{u, u} F)
+          (AddCommGrpCat.FilteredColimits.colimitCoconeIsColimit
+            (F ⋙ forget₂ RingCat AddCommGrpCat.{u})) }
+
 instance forget_preservesFilteredColimits : PreservesFilteredColimits (forget RingCat.{u}) :=
   Limits.comp_preservesFilteredColimits (forget₂ RingCat SemiRingCat) (forget SemiRingCat.{u})
 

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -622,7 +622,7 @@ theorem exists_basicOpen_le {V : X.Opens} (x : V) (h : ↑x ∈ U) :
 
 noncomputable
 instance {R : CommRingCat} {U} : Algebra R Γ(Spec R, U) :=
-  ((Scheme.ΓSpecIso R).inv ≫ (Spec R).presheaf.map (homOfLE le_top).op).hom.toAlgebra
+  inferInstanceAs (Algebra R ((Spec.structureSheaf R).presheaf.obj _))
 
 @[simp]
 lemma algebraMap_Spec_obj {R : CommRingCat} {U} : algebraMap R Γ(Spec R, U) =
@@ -653,13 +653,13 @@ theorem isLocalization_basicOpen :
     (IsLocalization.isLocalization_iff_of_ringEquiv (Submonoid.powers f)
       (asIso <| basicOpenSectionsToAffine hU f).commRingCatIsoToRingEquiv).mpr
   convert StructureSheaf.IsLocalization.to_basicOpen _ f using 1
-  -- Porting note: more hand holding is required here, the next 3 lines were not necessary
+  apply Algebra.algebra_ext
+  intro _
   congr 1
   dsimp [CommRingCat.ofHom, RingHom.algebraMap_toAlgebra, ← CommRingCat.hom_comp,
     basicOpenSectionsToAffine]
   rw [hU.fromSpec.naturality_assoc, hU.fromSpec_app_self]
-  simp only [Category.assoc, ← Functor.map_comp, ← op_comp]
-  exact CommRingCat.hom_ext_iff.mp (StructureSheaf.toOpen_res _ _ _ _)
+  rfl
 
 instance _root_.AlgebraicGeometry.isLocalization_away_of_isAffine
     [IsAffine X] (r : Γ(X, ⊤)) :
@@ -1219,13 +1219,35 @@ end Factorization
 
 section Stalks
 
+variable {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) (x : PrimeSpectrum R)
+
+variable (R) (x : PrimeSpectrum R) in
+/-- The stalk of `Spec R` at `x` is isomorphic to `Rₚ`,
+where `p` is the prime corresponding to `x`. -/
+noncomputable
+def Spec.stalkIso : (Spec R).presheaf.stalk x ≅ .of (Localization.AtPrime x.asIdeal) :=
+  (StructureSheaf.stalkIso ..).toCommRingCatIso.symm
+
+@[reassoc (attr := simp)]
+lemma Spec.algebraMap_stalkIso_inv :
+    CommRingCat.ofHom (algebraMap R _) ≫ (stalkIso R x).inv =
+      (Scheme.ΓSpecIso R).inv ≫ (Spec R).presheaf.germ ⊤ x trivial := by
+  ext s : 2
+  exact (IsLocalization.algEquiv _ ((structureSheaf R).presheaf.stalk _) _).symm.commutes s
+
+@[reassoc (attr := simp)]
+lemma Spec.germ_stalkMapIso_hom :
+    (Spec R).presheaf.germ ⊤ _ trivial ≫ (stalkIso R x).hom =
+      (Scheme.ΓSpecIso R).hom ≫ CommRingCat.ofHom (algebraMap R _) := by
+  simp [← Iso.inv_comp_eq, ← Spec.algebraMap_stalkIso_inv_assoc]
+
 /-- Variant of `AlgebraicGeometry.localRingHom_comp_stalkIso` for `Spec.map`. -/
 @[elementwise]
 lemma Scheme.localRingHom_comp_stalkIso {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
-    (StructureSheaf.stalkIso R (PrimeSpectrum.comap f.hom p)).hom ≫
+    (Spec.stalkIso R (p.comap f.hom)).hom ≫
       (CommRingCat.ofHom <| Localization.localRingHom
         (PrimeSpectrum.comap f.hom p).asIdeal p.asIdeal f.hom rfl) ≫
-      (StructureSheaf.stalkIso S p).inv = (Spec.map f).stalkMap p :=
+      (Spec.stalkIso S p).inv = (Spec.map f).stalkMap p :=
   AlgebraicGeometry.localRingHom_comp_stalkIso f p
 
 /-- Given a morphism of rings `f : R ⟶ S`, the stalk map of `Spec S ⟶ Spec R` at
@@ -1233,8 +1255,8 @@ a prime of `S` is isomorphic to the localized ring homomorphism. -/
 def Scheme.arrowStalkMapSpecIso {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
     Arrow.mk ((Spec.map f).stalkMap p) ≅ Arrow.mk (CommRingCat.ofHom <| Localization.localRingHom
       (p.comap f.hom).asIdeal p.asIdeal f.hom rfl) := Arrow.isoMk
-  (StructureSheaf.stalkIso R (PrimeSpectrum.comap f.hom p))
-  (StructureSheaf.stalkIso S p) <| by
+  (Spec.stalkIso R (p.comap f.hom))
+  (Spec.stalkIso S p) <| by
     rw [← Scheme.localRingHom_comp_stalkIso]
     simp
 

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -165,7 +165,9 @@ def toΓSpecCBasicOpens :
   naturality r s f := by
     apply (StructureSheaf.to_basicOpen_epi (Γ.obj (op X)) r.unop).1
     simp only [← Category.assoc]
-    erw [X.toΓSpecCApp_spec r.unop]
+    rw [show algebraMap (Γ.obj (op X)) ((structureSheaf (Γ.obj (op X))).val.obj _) = algebraMap _
+      ((structureSheafInType (Γ.obj (op X)) (Γ.obj (op X))).val.obj _) from rfl,
+      X.toΓSpecCApp_spec r.unop]
     convert X.toΓSpecCApp_spec s.unop
     symm
     apply X.presheaf.map_comp

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -466,20 +466,6 @@ lemma Scheme.toSpecΓ_preimage_basicOpen (X : Scheme.{u}) (r : Γ(X, ⊤)) :
   rw [Scheme.toSpecΓ_appTop]
   exact Iso.inv_hom_id_apply (C := CommRingCat) _ _
 
--- -- Warning: this LHS of this lemma breaks the structure-sheaf abstraction.
--- @[reassoc (attr := simp)]
--- theorem toOpen_toSpecΓ_app {X : Scheme.{u}} (U) :
---     CommRingCat.ofHom (algebraMap _ ((Spec.structureSheaf _).presheaf.obj _)) ≫ X.toSpecΓ.app U =
---       X.presheaf.map (homOfLE (le_top)).op := by
---   sorry
---   rw [← StructureSheaf.toOpen_res _ _ _ (homOfLE le_top), Category.assoc,
---     NatTrans.naturality _ (homOfLE (le_top (a := U))).op]
---   change (ΓSpec.adjunction.counit.app (Scheme.Γ.rightOp.obj X)).unop ≫
---     (Scheme.Γ.rightOp.map (ΓSpec.adjunction.unit.app X)).unop ≫ _ = _
---   rw [← Category.assoc, ← unop_comp, ΓSpec.adjunction.left_triangle_components]
---   dsimp
---   exact Category.id_comp _
-
 lemma ΓSpecIso_inv_ΓSpec_adjunction_homEquiv {X : Scheme.{u}} {B : CommRingCat} (φ : B ⟶ Γ(X, ⊤)) :
     (Scheme.ΓSpecIso B).inv ≫ ((ΓSpec.adjunction.homEquiv X (op B)) φ.op).appTop = φ := by
   simp only [Adjunction.homEquiv_apply, Scheme.Spec_map, Opens.map_top, Scheme.Hom.comp_app]

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -140,7 +140,8 @@ theorem toΓSpecCApp_iff
     (f :
       (structureSheaf <| Γ.obj <| op X).val.obj (op <| basicOpen r) ⟶
         X.presheaf.obj (op <| X.toΓSpecMapBasicOpen r)) :
-    toOpen _ (basicOpen r) ≫ f = X.toToΓSpecMapBasicOpen r ↔ f = X.toΓSpecCApp r := by
+    CommRingCat.ofHom (algebraMap (Γ.obj (op X)) _) ≫ f = X.toToΓSpecMapBasicOpen r ↔
+      f = X.toΓSpecCApp r := by
   have loc_inst := IsLocalization.to_basicOpen (Γ.obj (op X)) r
   refine ConcreteCategory.ext_iff.trans ?_
   rw [← @IsLocalization.Away.lift_comp _ _ _ _ _ _ _ r loc_inst _
@@ -151,7 +152,8 @@ theorem toΓSpecCApp_iff
     exact IsLocalization.ringHom_ext (Submonoid.powers r) h
   apply congr_arg
 
-theorem toΓSpecCApp_spec : toOpen _ (basicOpen r) ≫ X.toΓSpecCApp r = X.toToΓSpecMapBasicOpen r :=
+theorem toΓSpecCApp_spec :
+    CommRingCat.ofHom (algebraMap (Γ.obj (op X)) _) ≫ X.toΓSpecCApp r = X.toToΓSpecMapBasicOpen r :=
   (X.toΓSpecCApp_iff r _).2 rfl
 
 /-- The sheaf hom on all basic opens, commuting with restrictions. -/
@@ -163,7 +165,7 @@ def toΓSpecCBasicOpens :
   naturality r s f := by
     apply (StructureSheaf.to_basicOpen_epi (Γ.obj (op X)) r.unop).1
     simp only [← Category.assoc]
-    rw [X.toΓSpecCApp_spec r.unop]
+    erw [X.toΓSpecCApp_spec r.unop]
     convert X.toΓSpecCApp_spec s.unop
     symm
     apply X.presheaf.map_comp
@@ -182,7 +184,8 @@ theorem toΓSpecSheafedSpace_app_eq :
   apply TopCat.Sheaf.extend_hom_app _ _ _
 
 @[reassoc] theorem toΓSpecSheafedSpace_app_spec (r : Γ.obj (op X)) :
-    toOpen (Γ.obj (op X)) (basicOpen r) ≫ X.toΓSpecSheafedSpace.hom.c.app (op (basicOpen r)) =
+    CommRingCat.ofHom (algebraMap (Γ.obj (op X)) _) ≫
+        X.toΓSpecSheafedSpace.hom.c.app (op (basicOpen r)) =
       X.toToΓSpecMapBasicOpen r :=
   (X.toΓSpecSheafedSpace_app_eq r).symm ▸ X.toΓSpecCApp_spec r
 
@@ -191,8 +194,8 @@ stalks (in `Spec Γ(X)` and in `X`). -/
 theorem toStalk_stalkMap_toΓSpec (x : X) :
     toStalk _ _ ≫ X.toΓSpecSheafedSpace.hom.stalkMap x = X.presheaf.Γgerm x := by
   rw [PresheafedSpace.Hom.stalkMap,
-    ← toOpen_germ _ (basicOpen (1 : Γ.obj (op X))) _ (by rw [basicOpen_one]; trivial),
-    ← Category.assoc, Category.assoc (toOpen _ _), stalkFunctor_map_germ, ← Category.assoc,
+    ← algebraMap_germ (basicOpen (1 : Γ.obj (op X))) _ (by rw [basicOpen_one]; trivial),
+    ← Category.assoc, Category.assoc (CommRingCat.ofHom _), stalkFunctor_map_germ, ← Category.assoc,
     X.toΓSpecSheafedSpace_app_eq, X.toΓSpecCApp_spec, Γgerm]
   erw [← stalkPushforward_germ _ _ X.presheaf ⊤]
   congr 1
@@ -244,7 +247,7 @@ theorem comp_ring_hom_ext {X : LocallyRingedSpace.{u}} {R : CommRingCat.{u}} {f 
     (h :
       ∀ r : R,
         f ≫ X.presheaf.map (homOfLE le_top : (Opens.map β.base).obj (basicOpen r) ⟶ _).op =
-          toOpen R (basicOpen r) ≫ β.c.app (op (basicOpen r))) :
+          CommRingCat.ofHom (algebraMap _ _) ≫ β.c.app (op (basicOpen r))) :
     X.toΓSpec ≫ Spec.locallyRingedSpaceMap f = β := by
   refine LocallyRingedSpace.forgetToSheafedSpace.map_injective
     (Spec.basicOpen_hom_ext w ?_)
@@ -258,10 +261,11 @@ theorem comp_ring_hom_ext {X : LocallyRingedSpace.{u}} {R : CommRingCat.{u}} {f 
 /-- `toSpecΓ _` is an isomorphism so these are mutually two-sided inverses. -/
 theorem Γ_Spec_left_triangle : toSpecΓ (Γ.obj (op X)) ≫ X.toΓSpec.c.app (op ⊤) = 𝟙 _ := by
   unfold toSpecΓ
-  rw [← toOpen_res _ (basicOpen (1 : Γ.obj (op X))) ⊤ (eqToHom basicOpen_one.symm),
-    Category.assoc, NatTrans.naturality, ← Category.assoc]
-  erw [X.toΓSpecSheafedSpace_app_spec 1, ← Functor.map_comp]
-  convert eqToHom_map X.presheaf _; rfl
+  have := X.toΓSpecSheafedSpace_app_spec 1
+  unfold toToΓSpecMapBasicOpen toΓSpecMapBasicOpen at this
+  rw! [basicOpen_one] at this
+  convert this
+  exact (X.presheaf.map_id ..).symm
 
 end LocallyRingedSpace
 
@@ -303,7 +307,7 @@ theorem right_triangle (R : CommRingCat) :
     rw [← IsLocalization.AtPrime.to_map_mem_maximal_iff ((structureSheaf R).presheaf.stalk p)
         p.asIdeal x]
     rfl
-  · intro r; apply toOpen_res
+  · intro r; rfl
 
 /-- The adjunction `Γ ⊣ Spec` from `CommRingᵒᵖ` to `LocallyRingedSpace`. -/
 @[simps]
@@ -323,23 +327,26 @@ def locallyRingedSpaceAdjunction : Γ.rightOp ⊣ Spec.toLocallyRingedSpace.{u} 
       Spec.toLocallyRingedSpace_map, Quiver.Hom.unop_op]
     exact right_triangle R.unop
 
-/-- `@[simp]`-normal form of `locallyRingedSpaceAdjunction_counit_app`. -/
-@[simp]
+
 lemma toSpecΓ_unop (R : CommRingCatᵒᵖ) :
-    AlgebraicGeometry.toSpecΓ (Opposite.unop R) = toOpen R.unop ⊤ := rfl
+    AlgebraicGeometry.toSpecΓ (Opposite.unop R) = CommRingCat.ofHom (algebraMap _ _) := rfl
 
 /-- `@[simp]`-normal form of `locallyRingedSpaceAdjunction_counit_app'`. -/
 @[simp]
 lemma toSpecΓ_of (R : Type u) [CommRing R] :
-    AlgebraicGeometry.toSpecΓ (CommRingCat.of R) = toOpen R ⊤ := rfl
+    AlgebraicGeometry.toSpecΓ (CommRingCat.of R) = CommRingCat.ofHom (algebraMap _ _) := rfl
 
 lemma locallyRingedSpaceAdjunction_counit_app (R : CommRingCatᵒᵖ) :
     locallyRingedSpaceAdjunction.counit.app R =
-      (toOpen R.unop ⊤).op := rfl
+      (CommRingCat.ofHom (algebraMap _ _)).op := rfl
 
 lemma locallyRingedSpaceAdjunction_counit_app' (R : Type u) [CommRing R] :
     locallyRingedSpaceAdjunction.counit.app (op <| CommRingCat.of R) =
-      (toOpen R ⊤).op := rfl
+      (CommRingCat.ofHom (algebraMap _ _)).op := rfl
+
+lemma unop_locallyRingedSpaceAdjunction_counit_app' (R : Type u) [CommRing R] :
+    (locallyRingedSpaceAdjunction.counit.app (op <| CommRingCat.of R)).unop =
+      (CommRingCat.ofHom (algebraMap _ _)) := rfl
 
 lemma locallyRingedSpaceAdjunction_homEquiv_apply
     {X : LocallyRingedSpace} {R : CommRingCatᵒᵖ}
@@ -356,16 +363,16 @@ lemma locallyRingedSpaceAdjunction_homEquiv_apply'
 lemma toOpen_comp_locallyRingedSpaceAdjunction_homEquiv_app
     {X : LocallyRingedSpace} {R : Type u} [CommRing R]
     (f : Γ.rightOp.obj X ⟶ op (CommRingCat.of R)) (U) :
-    StructureSheaf.toOpen R U.unop ≫
+    CommRingCat.ofHom (algebraMap R _) ≫
       (locallyRingedSpaceAdjunction.homEquiv X (op <| CommRingCat.of R) f).c.app U =
     f.unop ≫ X.presheaf.map (homOfLE le_top).op := by
-  rw [← StructureSheaf.toOpen_res _ _ _ (homOfLE le_top), Category.assoc,
+  dsimp
+  rw [← StructureSheaf.algebraMap_self_map _ U _ (homOfLE le_top).op, Category.assoc,
     NatTrans.naturality _ (homOfLE (le_top (a := U.unop))).op,
-    show (toOpen R ⊤) = (toOpen R ⊤).op.unop from rfl,
-    ← locallyRingedSpaceAdjunction_counit_app']
+    ← unop_locallyRingedSpaceAdjunction_counit_app']
   simp_rw [← Γ_map_op]
-  rw [← Γ.rightOp_map_unop, ← Category.assoc, ← unop_comp, ← Adjunction.homEquiv_counit,
-    Equiv.symm_apply_apply]
+  rw [← Γ.rightOp_map_unop, ← Category.assoc, ← unop_comp]
+  erw [← Adjunction.homEquiv_counit, Equiv.symm_apply_apply]
   rfl
 
 /-- The adjunction `Γ ⊣ Spec` from `CommRingᵒᵖ` to `Scheme`. -/
@@ -459,18 +466,19 @@ lemma Scheme.toSpecΓ_preimage_basicOpen (X : Scheme.{u}) (r : Γ(X, ⊤)) :
   rw [Scheme.toSpecΓ_appTop]
   exact Iso.inv_hom_id_apply (C := CommRingCat) _ _
 
--- Warning: this LHS of this lemma breaks the structure-sheaf abstraction.
-@[reassoc (attr := simp)]
-theorem toOpen_toSpecΓ_app {X : Scheme.{u}} (U) :
-    StructureSheaf.toOpen _ _ ≫ X.toSpecΓ.app U =
-      X.presheaf.map (homOfLE (by exact le_top)).op := by
-  rw [← StructureSheaf.toOpen_res _ _ _ (homOfLE le_top), Category.assoc,
-    NatTrans.naturality _ (homOfLE (le_top (a := U))).op]
-  change (ΓSpec.adjunction.counit.app (Scheme.Γ.rightOp.obj X)).unop ≫
-    (Scheme.Γ.rightOp.map (ΓSpec.adjunction.unit.app X)).unop ≫ _ = _
-  rw [← Category.assoc, ← unop_comp, ΓSpec.adjunction.left_triangle_components]
-  dsimp
-  exact Category.id_comp _
+-- -- Warning: this LHS of this lemma breaks the structure-sheaf abstraction.
+-- @[reassoc (attr := simp)]
+-- theorem toOpen_toSpecΓ_app {X : Scheme.{u}} (U) :
+--     CommRingCat.ofHom (algebraMap _ ((Spec.structureSheaf _).presheaf.obj _)) ≫ X.toSpecΓ.app U =
+--       X.presheaf.map (homOfLE (le_top)).op := by
+--   sorry
+--   rw [← StructureSheaf.toOpen_res _ _ _ (homOfLE le_top), Category.assoc,
+--     NatTrans.naturality _ (homOfLE (le_top (a := U))).op]
+--   change (ΓSpec.adjunction.counit.app (Scheme.Γ.rightOp.obj X)).unop ≫
+--     (Scheme.Γ.rightOp.map (ΓSpec.adjunction.unit.app X)).unop ≫ _ = _
+--   rw [← Category.assoc, ← unop_comp, ΓSpec.adjunction.left_triangle_components]
+--   dsimp
+--   exact Category.id_comp _
 
 lemma ΓSpecIso_inv_ΓSpec_adjunction_homEquiv {X : Scheme.{u}} {B : CommRingCat} (φ : B ⟶ Γ(X, ⊤)) :
     (Scheme.ΓSpecIso B).inv ≫ ((ΓSpec.adjunction.homEquiv X (op B)) φ.op).appTop = φ := by

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
@@ -42,6 +42,7 @@ variable {X : Scheme.{u}}
 variable (I : IdealSheafData X)
 
 /-- `Spec (𝒪ₓ(U)/I(U))`, the object to be glued into the closed subscheme. -/
+noncomputable
 def glueDataObj (U : X.affineOpens) : Scheme :=
   Spec <| .of <| Γ(X, U) ⧸ I.ideal U
 

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -1,7 +1,8 @@
 /-
 Copyright (c) 2024 Weihong Xu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin Buzzard, Johan Commelin, Amelia Livingston, Sophie Morel, Jujian Zhang, Weihong Xu
+Authors: Kevin Buzzard, Johan Commelin, Amelia Livingston, Sophie Morel, Jujian Zhang, Weihong Xu,
+  Andrew Yang
 -/
 module
 
@@ -20,18 +21,7 @@ Given any commutative ring `R` and `R`-module `M`, we construct the sheaf `M^~` 
 such that `M^~(U)` is the set of dependent functions that are locally fractions.
 
 ## Main definitions
-
-* `ModuleCat.tildeInType` : `M^~` as a sheaf of types groups.
 * `ModuleCat.tilde` : `M^~` as a sheaf of `𝒪_{Spec R}`-modules.
-* `ModuleCat.tilde.stalkIso`: The isomorphism of `R`-modules from the stalk of `M^~` at `x` to
-  the localization of `M` at the prime ideal corresponding to `x`.
-
-## Technical note
-
-To get the `R`-module structure on the stalks on `M^~`, we had to define
-`ModuleCat.tildeInModuleCat`, which is `M^~` seen as sheaf of `R`-modules. We get it by
-applying a forgetful functor to `ModuleCat.tilde M`.
-
 -/
 
 @[expose] public section
@@ -44,152 +34,20 @@ variable {R : Type u} [CommRing R] (M : ModuleCat.{u} R)
 
 namespace ModuleCat
 
-namespace Tilde
-
-/-- For an `R`-module `M` and a point `P` in `Spec R`, `Localizations P` is the localized module
-`M` at the prime ideal `P`. -/
-abbrev Localizations (P : PrimeSpectrum.Top R) :=
-LocalizedModule P.asIdeal.primeCompl M
-
-/-- For any open subset `U ⊆ Spec R`, `IsFraction` is the predicate expressing that a function
-`f : ∏_{x ∈ U}, Mₓ` is such that for any `𝔭 ∈ U`, `f 𝔭 = m / s` for some `m : M` and `s ∉ 𝔭`.
-In short `f` is a fraction on `U`. -/
-def isFraction {U : Opens (PrimeSpectrum R)} (f : ∀ 𝔭 : U, Localizations M 𝔭.1) : Prop :=
-  ∃ (m : M) (s : R),
-    ∀ x : U, s ∉ x.1.asIdeal ∧ s • f x = LocalizedModule.mkLinearMap x.1.asIdeal.primeCompl M m
-
-/--
-The property of a function `f : ∏_{x ∈ U}, Mₓ` being a fraction is stable under restriction.
--/
-def isFractionPrelocal : PrelocalPredicate (Localizations M) where
-  pred {_} f := isFraction M f
-  res := by rintro V U i f ⟨m, s, w⟩; exact ⟨m, s, fun x => w (i x)⟩
-
-/--
-For any open subset `U ⊆ Spec R`, `IsLocallyFraction` is the predicate expressing that a function
-`f : ∏_{x ∈ U}, Mₓ` is such that for any `𝔭 ∈ U`, there exists an open neighbourhood `V ∋ 𝔭`, such
-that for any `𝔮 ∈ V`, `f 𝔮 = m / s` for some `m : M` and `s ∉ 𝔮`.
-In short `f` is locally a fraction on `U`.
--/
-def isLocallyFraction : LocalPredicate (Localizations M) := (isFractionPrelocal M).sheafify
-
-@[simp]
-theorem isLocallyFraction_pred {U : Opens (PrimeSpectrum.Top R)}
-    (f : ∀ x : U, Localizations M x) :
-    (isLocallyFraction M).pred f =
-      ∀ y : U,
-        ∃ (V : _) (_ : y.1 ∈ V) (i : V ⟶ U),
-          ∃ (m : M) (s : R), ∀ x : V, s ∉ x.1.asIdeal ∧ s • f (i x) =
-            LocalizedModule.mkLinearMap x.1.asIdeal.primeCompl M m :=
-  rfl
-
-/- M_x is an O_SpecR(U)-module when x is in U -/
-noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
-    Module ((Spec.structureSheaf R).val.obj U) (Localizations M x) :=
-  Module.compHom (R := (Localization.AtPrime x.1.asIdeal)) _
-    ((StructureSheaf.openToLocalization R U.unop x x.2).hom)
-
-instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
-    IsScalarTower R (Localization.AtPrime x.1.asIdeal) (Localizations M x) :=
-  OreLocalization.instIsScalarTower_1 ..
-
-instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
-    IsScalarTower R ((Spec.structureSheaf R).val.obj U) (Localizations M x) :=
-  .of_algebraMap_smul fun r m ↦
-    IsScalarTower.algebraMap_smul (Localization.AtPrime x.1.asIdeal) r m
-
-@[simp]
-lemma sections_smul_localizations_def
-    {U : (Opens (PrimeSpectrum.Top R))ᵒᵖ} (x : U.unop)
-    (r : (Spec.structureSheaf R).val.obj U)
-    (m : Localizations M ↑x) :
-    r • m = (by exact r.1 x : Localization.AtPrime x.1.asIdeal) • m :=
-  rfl
-
-/--
-For any `R`-module `M` and any open subset `U ⊆ Spec R`, `M^~(U)` is an `𝒪_{Spec R}(U)`-submodule
-of `∏_{𝔭 ∈ U} M_𝔭`. -/
-noncomputable def sectionsSubmodule (U : (Opens (PrimeSpectrum R))ᵒᵖ) :
-    Submodule ((Spec.structureSheaf R).1.obj U) (∀ x : U.unop, Localizations M x.1) where
-  carrier := { f | (isLocallyFraction M).pred f }
-  zero_mem' x := ⟨unop U, x.2, 𝟙 _, 0, 1, fun y =>
-    ⟨Ideal.ne_top_iff_one _ |>.1 y.1.isPrime.1, by simp⟩⟩
-  add_mem' := by
-    intro a b ha hb x
-    rcases ha x with ⟨Va, ma, ia, ra, sa, wa⟩
-    rcases hb x with ⟨Vb, mb, ib, rb, sb, wb⟩
-    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, sb • ra + sa • rb, sa * sb, ?_⟩
-    intro y
-    rcases wa (Opens.infLELeft _ _ y : Va) with ⟨nma, wa⟩
-    rcases wb (Opens.infLERight _ _ y : Vb) with ⟨nmb, wb⟩
-    fconstructor
-    · intro H; cases y.1.isPrime.mem_or_mem H <;> contradiction
-    · simp only [LocalizedModule.mkLinearMap_apply, Opens.comp_apply, Pi.add_apply, smul_add,
-        map_add, map_smul] at wa wb ⊢
-      rw [← wa, ← wb, ← mul_smul, ← mul_smul]
-      congr 2
-      simp [mul_comm]
-  smul_mem' := by
-    intro r a ha x
-    rcases ha x with ⟨Va, ma, ia, ra, sa, wa⟩
-    rcases r.2 x with ⟨Vr, mr, ir, rr, sr, wr⟩
-    refine ⟨Va ⊓ Vr, ⟨ma, mr⟩, Opens.infLELeft _ _ ≫ ia, rr • ra, sr * sa, ?_⟩
-    intro y
-    rcases wa (Opens.infLELeft _ _ y : Va) with ⟨nma, wa⟩
-    rcases wr (Opens.infLERight _ _ y) with ⟨nmr, wr⟩
-    fconstructor
-    · intro H; cases y.1.isPrime.mem_or_mem H <;> contradiction
-    · simp only [Pi.smul_apply, LinearMapClass.map_smul, Opens.apply_def] at wa wr ⊢
-      rw [mul_comm, ← Algebra.smul_def] at wr
-      rw [sections_smul_localizations_def, ← wa, ← mul_smul, ← smul_assoc, mul_comm sr, mul_smul,
-        wr, mul_comm rr, Algebra.smul_def,
-        ← IsScalarTower.algebraMap_smul (R := R) (Localization.AtPrime y.1.asIdeal), map_mul]
-      rfl
-
-end Tilde
-
-/--
-For any `R`-module `M`, `TildeInType R M` is the sheaf of set on `Spec R` whose sections on `U` are
-the dependent functions that are locally fractions. This is often denoted by `M^~`.
-
-See also `Tilde.isLocallyFraction`.
--/
-def tildeInType : Sheaf (Type u) (PrimeSpectrum.Top R) :=
-  subsheafToTypes (Tilde.isLocallyFraction M)
-
-noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
-    AddCommGroup (M.tildeInType.1.obj U) :=
-  inferInstanceAs <| AddCommGroup (Tilde.sectionsSubmodule M U)
-
-noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
-    Module ((Spec <| .of R).ringCatSheaf.1.obj U) (M.tildeInType.1.obj U) :=
-  inferInstanceAs <| Module _ (Tilde.sectionsSubmodule M U)
-
 /--
 `M^~` as a sheaf of `𝒪_{Spec R}`-modules
 -/
 noncomputable def tilde : (Spec <| .of R).Modules where
-  val :=
-    { obj := fun U ↦ ModuleCat.of _ (M.tildeInType.val.obj U)
-      map := fun {U V} i ↦ ofHom
-        -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(Y := ...)`
-        -- This suggests `restrictScalars` needs to be redesigned.
-        (Y := (restrictScalars ((Spec <| .of R).ringCatSheaf.val.map i).hom).obj
-          (of ((Spec <| .of R).ringCatSheaf.val.obj V) (M.tildeInType.val.obj V)))
-        { toFun := M.tildeInType.val.map i
-          map_smul' := by intros; rfl
-          map_add' := by intros; rfl } }
+  val := moduleStructurePresheaf R M
   isSheaf := (TopCat.Presheaf.isSheaf_iff_isSheaf_comp (forget AddCommGrpCat) _).2
-    M.tildeInType.2
+    (structureSheafInType R M).2
 
 /--
 This is `M^~` as a sheaf of `R`-modules.
 -/
 noncomputable def tildeInModuleCat :
     TopCat.Presheaf (ModuleCat R) (PrimeSpectrum.Top R) :=
-  (PresheafOfModules.forgetToPresheafModuleCat (op ⊤) <|
-    Limits.initialOpOfTerminal Limits.isTerminalTop).obj (tilde M).1 ⋙
-  ModuleCat.restrictScalars (StructureSheaf.globalSectionsIso R).hom.hom
+  structurePresheafInModuleCat R M
 
 namespace Tilde
 
@@ -201,8 +59,7 @@ theorem res_apply (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U)
 
 lemma smul_section_apply (r : R) (U : Opens (PrimeSpectrum.Top R))
     (s : (tildeInModuleCat M).obj (op U)) (x : U) :
-    (r • s).1 x = r • (s.1 x) :=
-  IsScalarTower.algebraMap_smul ((Spec.structureSheaf R).val.obj (op U)) r (s.1 x)
+    (r • s).1 x = r • (s.1 x) := rfl
 
 lemma smul_stalk_no_nonzero_divisor {x : PrimeSpectrum R}
     (r : x.asIdeal.primeCompl) (st : (tildeInModuleCat M).stalk x) (hst : r.1 • st = 0) :
@@ -218,219 +75,29 @@ If `U` is an open subset of `Spec R`, this is the morphism of `R`-modules from `
 -/
 noncomputable def toOpen (U : Opens (PrimeSpectrum.Top R)) :
     ModuleCat.of R M ⟶ (tildeInModuleCat M).obj (op U) :=
-  -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(Y := ...)`
-  -- This suggests `restrictScalars` needs to be redesigned.
-  ModuleCat.ofHom (Y := (tildeInModuleCat M).obj (op U))
-  { toFun := fun f =>
-    ⟨fun x ↦ LocalizedModule.mkLinearMap _ _ f, fun x ↦
-      ⟨U, x.2, 𝟙 _, f, 1, fun y ↦ ⟨(Ideal.ne_top_iff_one _).1 y.1.2.1, by simp⟩⟩⟩
-    map_add' := fun f g => Subtype.ext <| funext fun x ↦ map_add _ _ _
-    map_smul' := fun r m => by
-      apply Subtype.val_injective
-      ext x
-      simp only [isLocallyFraction_pred, LocalizedModule.mkLinearMap_apply, LinearMapClass.map_smul,
-        RingHom.id_apply, smul_section_apply] }
+  ModuleCat.ofHom (StructureSheaf.toOpenₗ R M U)
+
 
 @[simp]
 theorem toOpen_res (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U) :
     toOpen M U ≫ (tildeInModuleCat M).map i.op = toOpen M V :=
   rfl
 
+noncomputable
+instance (x : PrimeSpectrum.Top R) : Module R ↑(TopCat.Presheaf.stalk M.tilde.presheaf x) :=
+  inferInstanceAs (Module R ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x))
+
 /--
 If `x` is a point of `Spec R`, this is the morphism of `R`-modules from `M` to the stalk of
 `M^~` at `x`.
 -/
 noncomputable def toStalk (x : PrimeSpectrum.Top R) :
-    ModuleCat.of R M ⟶ TopCat.Presheaf.stalk (tildeInModuleCat M) x :=
-  (toOpen M ⊤ ≫ TopCat.Presheaf.germ (tildeInModuleCat M) ⊤ x (by trivial))
-
-open LocalizedModule TopCat.Presheaf in
-lemma isUnit_toStalk (x : PrimeSpectrum.Top R) (r : x.asIdeal.primeCompl) :
-    IsUnit ((algebraMap R (Module.End R ((tildeInModuleCat M).stalk x))) r) := by
-  rw [Module.End.isUnit_iff]
-  refine ⟨LinearMap.ker_eq_bot.1 <| eq_bot_iff.2 fun st (h : r.1 • st = 0) ↦
-    smul_stalk_no_nonzero_divisor M r st h, fun st ↦ ?_⟩
-  obtain ⟨U, mem, s, rfl⟩ := germ_exist (F := M.tildeInModuleCat) x st
-  let O := U ⊓ (PrimeSpectrum.basicOpen r)
-  refine ⟨germ M.tildeInModuleCat O x ⟨mem, r.2⟩
-    ⟨fun q ↦ (Localization.mk 1 ⟨r, q.2.2⟩ : Localization.AtPrime q.1.asIdeal) • s.1
-      ⟨q.1, q.2.1⟩, fun q ↦ ?_⟩, by
-        simpa only [Module.algebraMap_end_apply, ← map_smul] using
-          germ_ext (C := ModuleCat R) (W := O) (hxW := ⟨mem, r.2⟩) (iWU := 𝟙 _)
-            (iWV := homOfLE inf_le_left) _ <|
-          Subtype.ext <| funext fun y ↦ by
-            simp [smul_section_apply, ← smul_assoc, Localization.smul_mk]; rfl⟩
-  obtain ⟨V, mem_V, iV, num, den, hV⟩ := s.2 ⟨q.1, q.2.1⟩
-  refine ⟨V ⊓ O, ⟨mem_V, q.2⟩, homOfLE inf_le_right, num, r * den, fun y ↦ ?_⟩
-  obtain ⟨h1, h2⟩ := hV ⟨y, y.2.1⟩
-  refine ⟨y.1.asIdeal.primeCompl.mul_mem y.2.2.2 h1, ?_⟩
-  simp only [Opens.apply_def, isLocallyFraction_pred, mkLinearMap_apply,
-    smul_eq_iff_of_mem (S := y.1.1.primeCompl) (hr := h1), mk_smul_mk, one_smul, mul_one] at h2 ⊢
-  simpa only [h2, mk_smul_mk, one_smul, smul'_mk, mk_eq] using ⟨1, by simp only [one_smul]; rfl⟩
-
-/--
-The morphism of `R`-modules from the localization of `M` at the prime ideal corresponding to `x`
-to the stalk of `M^~` at `x`.
--/
-noncomputable def localizationToStalk (x : PrimeSpectrum.Top R) :
-    ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M) ⟶
-    (TopCat.Presheaf.stalk (tildeInModuleCat M) x) :=
-  ModuleCat.ofHom <| LocalizedModule.lift _ (toStalk M x).hom <| isUnit_toStalk M x
-
-
-/-- The ring homomorphism that takes a section of the structure sheaf of `R` on the open set `U`,
-implemented as a subtype of dependent functions to localizations at prime ideals, and evaluates
-the section on the point corresponding to a given prime ideal. -/
-noncomputable def openToLocalization
-    (U : Opens (PrimeSpectrum R)) (x : PrimeSpectrum R) (hx : x ∈ U) :
-    (tildeInModuleCat M).obj (op U) ⟶
-    ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M) :=
-  -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(X := ...)` and `(Y := ...)`
-  -- This suggests `restrictScalars` needs to be redesigned.
-  ModuleCat.ofHom
-    (X := (tildeInModuleCat M).obj (op U))
-    (Y := ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M))
-  { toFun := fun s => (s.1 ⟨x, hx⟩ :)
-    map_add' := fun _ _ => rfl
-    map_smul' := fun _ _ => by simp [smul_section_apply] }
-
-/--
-The morphism of `R`-modules from the stalk of `M^~` at `x` to the localization of `M` at the
-prime ideal of `R` corresponding to `x`.
--/
-noncomputable def stalkToFiberLinearMap (x : PrimeSpectrum.Top R) :
-    (tildeInModuleCat M).stalk x ⟶
-    ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M) :=
-  Limits.colimit.desc ((OpenNhds.inclusion x).op ⋙ (tildeInModuleCat M))
-    { pt := _
-      ι :=
-      { app := fun U => openToLocalization M ((OpenNhds.inclusion _).obj U.unop) x U.unop.2 } }
-
-@[simp]
-theorem germ_comp_stalkToFiberLinearMap (U : Opens (PrimeSpectrum.Top R)) (x) (hx : x ∈ U) :
-    (tildeInModuleCat M).germ U x hx ≫ stalkToFiberLinearMap M x =
-    openToLocalization M U x hx :=
-  Limits.colimit.ι_desc _ _
-
-@[simp]
-theorem stalkToFiberLinearMap_germ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R)
-    (hx : x ∈ U) (s : (tildeInModuleCat M).obj (op U)) :
-    (stalkToFiberLinearMap M x).hom
-      (TopCat.Presheaf.germ (tildeInModuleCat M) U x hx s) = (s.1 ⟨x, hx⟩ :) :=
-  DFunLike.ext_iff.1 (ModuleCat.hom_ext_iff.mp (germ_comp_stalkToFiberLinearMap M U x hx)) s
-
-@[reassoc (attr := simp), elementwise (attr := simp)]
-theorem toOpen_germ (U : Opens (PrimeSpectrum.Top R)) (x) (hx : x ∈ U) :
-    toOpen M U ≫ M.tildeInModuleCat.germ U x hx = toStalk M x := by
-  rw [← toOpen_res M ⊤ U (homOfLE le_top : U ⟶ ⊤), Category.assoc, Presheaf.germ_res]; rfl
-
-@[reassoc (attr := simp)]
-theorem toStalk_comp_stalkToFiberLinearMap (x : PrimeSpectrum.Top R) :
-    toStalk M x ≫ stalkToFiberLinearMap M x =
-    ofHom (LocalizedModule.mkLinearMap x.asIdeal.primeCompl M) := by
-  rw [toStalk, Category.assoc, germ_comp_stalkToFiberLinearMap]; rfl
-
-theorem stalkToFiberLinearMap_toStalk (x : PrimeSpectrum.Top R) (m : M) :
-    (stalkToFiberLinearMap M x).hom (toStalk M x m) =
-    LocalizedModule.mk m 1 :=
-  LinearMap.ext_iff.1 (ModuleCat.hom_ext_iff.mp (toStalk_comp_stalkToFiberLinearMap M x)) _
-
-/--
-If `U` is an open subset of `Spec R`, `m` is an element of `M` and `r` is an element of `R`
-that is invertible on `U` (i.e. does not belong to any prime ideal corresponding to a point
-in `U`), this is `m / r` seen as a section of `M^~` over `U`.
--/
-def const (m : M) (r : R) (U : Opens (PrimeSpectrum.Top R))
-    (hu : ∀ x ∈ U, r ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) :
-    (tildeInModuleCat M).obj (op U) :=
-  ⟨fun x => LocalizedModule.mk m ⟨r, hu x x.2⟩, fun x =>
-    ⟨U, x.2, 𝟙 _, m, r, fun y => ⟨hu _ y.2, by
-      simpa only [LocalizedModule.mkLinearMap_apply, LocalizedModule.smul'_mk,
-        LocalizedModule.mk_eq] using ⟨1, by simp⟩⟩⟩⟩
-
-@[simp]
-theorem const_apply (m : M) (r : R) (U : Opens (PrimeSpectrum.Top R))
-    (hu : ∀ x ∈ U, r ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) (x : U) :
-    (const M m r U hu).1 x = LocalizedModule.mk m ⟨r, hu x x.2⟩ :=
-  rfl
-
-theorem exists_const (U) (s : (tildeInModuleCat M).obj (op U)) (x : PrimeSpectrum.Top R)
-    (hx : x ∈ U) :
-    ∃ (V : Opens (PrimeSpectrum.Top R)) (_ : x ∈ V) (i : V ⟶ U) (f : M) (g : R) (hg : _),
-      const M f g V hg = (tildeInModuleCat M).map i.op s :=
-  let ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩
-  ⟨V, hxV, iVU, f, g, fun y hyV => (hfg ⟨y, hyV⟩).1, Subtype.ext <| funext fun y => by
-    obtain ⟨h1, (h2 : g • s.1 ⟨y, _⟩ = LocalizedModule.mk f 1)⟩ := hfg y
-    exact show LocalizedModule.mk f ⟨g, by exact h1⟩ = s.1 (iVU y) by
-      set x := s.1 (iVU y); change g • x = _ at h2; clear_value x
-      induction x using LocalizedModule.induction_on with
-      | h a b =>
-        rw [LocalizedModule.smul'_mk, LocalizedModule.mk_eq] at h2
-        obtain ⟨c, hc⟩ := h2
-        exact LocalizedModule.mk_eq.mpr ⟨c, by simpa using hc.symm⟩⟩
-
-@[simp]
-theorem res_const (f : M) (g : R) (U hu V hv i) :
-    (tildeInModuleCat M).map i (const M f g U hu) = const M f g V hv :=
-  rfl
-
-@[simp]
-theorem localizationToStalk_mk (x : PrimeSpectrum.Top R) (f : M) (s : x.asIdeal.primeCompl) :
-    (localizationToStalk M x).hom (LocalizedModule.mk f s) =
-      (tildeInModuleCat M).germ (PrimeSpectrum.basicOpen (s : R)) x s.2
-        (const M f s (PrimeSpectrum.basicOpen s) fun _ => id) :=
-  (Module.End.isUnit_iff _ |>.1 (isUnit_toStalk M x s)).injective <| by
-  erw [← Module.End.mul_apply]
-  simp only [IsUnit.mul_val_inv, Module.End.one_apply, Module.algebraMap_end_apply]
-  change (M.tildeInModuleCat.germ ⊤ x ⟨⟩) ((toOpen M ⊤) f) = _
-  rw [← map_smul]
-  fapply TopCat.Presheaf.germ_ext (W := PrimeSpectrum.basicOpen s.1) (hxW := s.2)
-    (F := M.tildeInModuleCat)
-  · exact homOfLE le_top
-  · exact 𝟙 _
-  refine Subtype.ext <| funext fun y => show LocalizedModule.mk f 1 = _ from ?_
-  dsimp
-  simp only [CategoryTheory.Functor.map_id, hom_id, map_smul, LinearMap.id_coe, id_eq,
-    smul_section_apply, isLocallyFraction_pred, Opens.val_apply, LocalizedModule.mkLinearMap_apply,
-    const_apply, LocalizedModule.smul'_mk]
-  exact (LocalizedModule.mk_cancel ⟨s.1, _⟩ f).symm
-
-/--
-The isomorphism of `R`-modules from the stalk of `M^~` at `x` to the localization of `M` at the
-prime ideal corresponding to `x`.
--/
-@[simps]
-noncomputable def stalkIso (x : PrimeSpectrum.Top R) :
-    TopCat.Presheaf.stalk (tildeInModuleCat M) x ≅
-    ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M) where
-  hom := stalkToFiberLinearMap M x
-  inv := localizationToStalk M x
-  hom_inv_id := TopCat.Presheaf.stalk_hom_ext _ fun U hxU ↦ ModuleCat.hom_ext <|
-      LinearMap.ext fun s ↦ by
-    change localizationToStalk M x (stalkToFiberLinearMap M x (M.tildeInModuleCat.germ U x hxU s)) =
-      M.tildeInModuleCat.germ U x hxU s
-    rw [stalkToFiberLinearMap_germ]
-    obtain ⟨V, hxV, iVU, f, g, (hg : V ≤ PrimeSpectrum.basicOpen _), hs⟩ :=
-      exists_const _ _ s x hxU
-    have := res_apply M U V iVU s ⟨x, hxV⟩
-    dsimp only [isLocallyFraction_pred, Opens.val_apply, LocalizedModule.mkLinearMap_apply,
-      Opens.apply_mk] at this
-    rw [← this, ← hs, const_apply, localizationToStalk_mk]
-    exact (tildeInModuleCat M).germ_ext V hxV (homOfLE hg) iVU <| hs ▸ rfl
-  inv_hom_id := by ext x; exact x.induction_on (fun _ _ => by
-    simp only [hom_comp, LinearMap.coe_comp, Function.comp_apply, hom_id, LinearMap.id_coe, id_eq]
-    rw [localizationToStalk_mk, stalkToFiberLinearMap_germ]
-    simp)
+    ModuleCat.of R M ⟶ ModuleCat.of R ↑(TopCat.Presheaf.stalk M.tilde.presheaf x) :=
+  ModuleCat.ofHom (StructureSheaf.toStalkₗ ..)
 
 instance (x : PrimeSpectrum.Top R) :
-    IsLocalizedModule x.asIdeal.primeCompl (toStalk M x).hom := by
-  convert IsLocalizedModule.of_linearEquiv
-    (hf := localizedModuleIsLocalizedModule (M := M) x.asIdeal.primeCompl)
-    (e := (stalkIso M x).symm.toLinearEquiv)
-  ext
-  simp only [of_coe,
-    show (stalkIso M x).symm.toLinearEquiv.toLinearMap = (stalkIso M x).inv.hom by rfl]
-  erw [LocalizedModule.lift_comp]
+    IsLocalizedModule x.asIdeal.primeCompl (toStalk M x).hom :=
+  inferInstanceAs (IsLocalizedModule x.asIdeal.primeCompl (StructureSheaf.toStalkₗ ..))
 
 end Tilde
 

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -99,6 +99,9 @@ instance (x : PrimeSpectrum.Top R) :
     IsLocalizedModule x.asIdeal.primeCompl (toStalk M x).hom :=
   inferInstanceAs (IsLocalizedModule x.asIdeal.primeCompl (StructureSheaf.toStalkₗ ..))
 
+instance (f : R) : IsLocalizedModule (.powers f) (toOpen M (PrimeSpectrum.basicOpen f)).hom :=
+  inferInstanceAs (IsLocalizedModule (.powers f) (StructureSheaf.toOpenₗ ..))
+
 end Tilde
 
 end ModuleCat

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -693,18 +693,18 @@ lemma toSpec_preimage_basicOpen {f}
 
 @[reassoc]
 lemma toOpen_toSpec_val_c_app (f) (U) :
-    StructureSheaf.toOpen (A⁰_ f) U.unop ≫ (toSpec 𝒜 f).c.app U =
+    (Scheme.ΓSpecIso _).inv ≫ (Spec A⁰_ f).presheaf.map (homOfLE le_top).op ≫
+      (toSpec 𝒜 f).c.app U =
       awayToΓ 𝒜 f ≫ (Proj| pbo f).presheaf.map (homOfLE le_top).op :=
-  Eq.trans (by congr) <| ΓSpec.toOpen_comp_locallyRingedSpaceAdjunction_homEquiv_app _ U
+  Eq.trans (by rfl) <| ΓSpec.toOpen_comp_locallyRingedSpaceAdjunction_homEquiv_app _ U
 
 @[reassoc]
 lemma toStalk_stalkMap_toSpec (f) (x) :
-    StructureSheaf.toStalk _ _ ≫ (toSpec 𝒜 f).stalkMap x =
-      awayToΓ 𝒜 f ≫ (Proj| pbo f).presheaf.Γgerm x := by
-  rw [StructureSheaf.toStalk, Category.assoc]
-  simp_rw [← Spec.locallyRingedSpaceObj_presheaf']
-  rw [LocallyRingedSpace.stalkMap_germ (toSpec 𝒜 f),
-    toOpen_toSpec_val_c_app_assoc, Presheaf.germ_res]
+    (Scheme.ΓSpecIso _).inv ≫ (Spec A⁰_ f).presheaf.germ _ _ (by simp) ≫
+      (toSpec 𝒜 f).stalkMap x = awayToΓ 𝒜 f ≫ (Proj| pbo f).presheaf.Γgerm x := by
+  dsimp
+  erw [LocallyRingedSpace.stalkMap_germ (toSpec 𝒜 f) ⊤ x (by simp)]
+  erw [toOpen_toSpec_val_c_app_assoc]
   rfl
 
 /--
@@ -798,13 +798,13 @@ lemma toStalk_specStalkEquiv (f) (x : pbo f) {m} (f_deg : f ∈ 𝒜 m) (hm : 0 
 lemma stalkMap_toSpec (f) (x : pbo f) {m} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) :
     (toSpec 𝒜 f).stalkMap x =
       (specStalkEquiv 𝒜 f x f_deg hm).hom ≫ (Proj.stalkIso' 𝒜 x.1).toCommRingCatIso.inv ≫
-      ((Proj.toLocallyRingedSpace 𝒜).restrictStalkIso (Opens.isOpenEmbedding _) x).inv :=
-  CommRingCat.hom_ext <|
+      ((Proj.toLocallyRingedSpace 𝒜).restrictStalkIso (Opens.isOpenEmbedding _) x).inv := by
+  refine CommRingCat.hom_ext <|
     IsLocalization.ringHom_ext (R := A⁰_ f) ((toSpec 𝒜 f).base x).asIdeal.primeCompl
-      (S := (Spec.structureSheaf (A⁰_ f)).presheaf.stalk ((toSpec 𝒜 f).base x)) <|
-      CommRingCat.hom_ext_iff.mp <|
-        (toStalk_stalkMap_toSpec _ _ _).trans <| by
-        rw [awayToΓ_ΓToStalk, ← toStalk_specStalkEquiv, Category.assoc]; rfl
+      (S := (Spec.structureSheaf (A⁰_ f)).presheaf.stalk ((toSpec 𝒜 f).base x)) <| ?_
+  ext a
+  refine congr($(toStalk_stalkMap_toSpec 𝒜 f x) _).trans ?_
+  rw [awayToΓ_ΓToStalk, ← toStalk_specStalkEquiv, Category.assoc]; rfl
 
 lemma isIso_toSpec (f) {m} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) :
     IsIso (toSpec 𝒜 f) := by

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -98,8 +98,8 @@ instance {R : CommRingCat.{u}} [H : _root_.IsReduced R] : IsReduced (Spec R) := 
   intro x; dsimp
   have : _root_.IsReduced (CommRingCat.of <| Localization.AtPrime (PrimeSpectrum.asIdeal x)) := by
     dsimp; infer_instance
-  exact isReduced_of_injective (StructureSheaf.stalkIso R x).hom.hom
-    (StructureSheaf.stalkIso R x).commRingCatIsoToRingEquiv.injective
+  exact isReduced_of_injective (Spec.stalkIso R x).hom.hom
+    (Spec.stalkIso R x).commRingCatIsoToRingEquiv.injective
 
 theorem affine_isReduced_iff (R : CommRingCat) :
     IsReduced (Spec R) ↔ _root_.IsReduced R := by

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -590,9 +590,7 @@ The counit (`SpecΓIdentity.inv.op`) of the adjunction `Γ ⊣ Spec` as a natura
 This is almost never needed in practical use cases. Use `ΓSpecIso` instead.
 -/
 def SpecΓIdentity : Scheme.Spec.rightOp ⋙ Scheme.Γ ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents.{u, u, u + 1, u + 1}
-    (fun R => asIso (StructureSheaf.toOpen R ⊤))
-    (fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f)
+  LocallyRingedSpace.SpecΓIdentity
 
 variable (R : CommRingCat.{u})
 
@@ -614,10 +612,10 @@ lemma ΓSpecIso_inv_naturality {R S : CommRingCat.{u}} (f : R ⟶ S) :
     f ≫ (ΓSpecIso S).inv = (ΓSpecIso R).inv ≫ (Spec.map f).appTop := SpecΓIdentity.inv.naturality f
 
 -- This is not marked simp to respect the abstraction
-lemma ΓSpecIso_inv : (ΓSpecIso R).inv = StructureSheaf.toOpen R ⊤ := rfl
+lemma ΓSpecIso_inv : (ΓSpecIso R).inv = CommRingCat.ofHom (algebraMap _ _) := rfl
 
 lemma toOpen_eq (U) :
-    StructureSheaf.toOpen R U =
+    CommRingCat.ofHom (algebraMap R <| (Spec.structureSheaf R).presheaf.obj (.op U)) =
     (ΓSpecIso R).inv ≫ (Spec R).presheaf.map (homOfLE le_top).op := rfl
 
 instance {K} [Field K] : Unique <| Spec <| .of K :=
@@ -821,9 +819,9 @@ theorem basicOpen_eq_of_affine {R : CommRingCat} (f : R) :
     (Spec R).basicOpen ((Scheme.ΓSpecIso R).inv f) = PrimeSpectrum.basicOpen f := by
   ext x
   simp only [SetLike.mem_coe, Scheme.mem_basicOpen_top]
-  suffices IsUnit (StructureSheaf.toStalk R x f) ↔ f ∉ PrimeSpectrum.asIdeal x by exact this
-  rw [← isUnit_map_iff (StructureSheaf.stalkToFiberRingHom R x).hom,
-    StructureSheaf.stalkToFiberRingHom_toStalk]
+  suffices IsUnit (algebraMap _ ((structurePresheafInCommRingCat ↑R).stalk x) f) ↔
+    f ∉ PrimeSpectrum.asIdeal x by exact this
+  rw [← isUnit_map_iff (StructureSheaf.stalkIso R x).symm, AlgEquiv.commutes]
   exact IsLocalization.AtPrime.isUnit_to_map_iff _ (PrimeSpectrum.asIdeal x) f
 
 @[simp]

--- a/Mathlib/AlgebraicGeometry/Sites/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Etale.lean
@@ -59,6 +59,7 @@ instance {S : Scheme.{u}} (𝒰 : S.Cover (precoverage @Etale)) (i : 𝒰.I₀) 
 
 /-- A separably closed field `Ω` defines a point on the étale topology by the fiber
 functor `X ↦ Hom(Spec Ω, X)`. -/
+noncomputable
 def geometricFiber (Ω : Type u) [Field Ω] [IsSepClosed Ω] : etaleTopology.Point where
   fiber := coyoneda.obj ⟨Spec (.of Ω)⟩
   jointly_surjective {S} R hR (f : Spec (.of Ω) ⟶ S) := by

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -162,8 +162,9 @@ theorem Spec.basicOpen_hom_ext {X : RingedSpace.{u}} {R : CommRingCat.{u}}
     {α β : X ⟶ Spec.sheafedSpaceObj R} (w : α.hom.base = β.hom.base)
     (h : ∀ r : R,
       let U := PrimeSpectrum.basicOpen r
-      (toOpen R U ≫ α.hom.c.app (op U)) ≫ X.presheaf.map (eqToHom (by rw [w])) =
-        toOpen R U ≫ β.hom.c.app (op U)) :
+      ((CommRingCat.ofHom (algebraMap R _)) ≫ α.hom.c.app (op U)) ≫
+        X.presheaf.map (eqToHom (by rw [w])) =
+        CommRingCat.ofHom (algebraMap _ _) ≫ β.hom.c.app (op U)) :
     α = β := by
   ext : 1
   · exact w
@@ -177,11 +178,9 @@ theorem Spec.basicOpen_hom_ext {X : RingedSpace.{u}} {R : CommRingCat.{u}}
 -- if more is needed, add them here
 /-- The spectrum of a commutative ring, as a `LocallyRingedSpace`. -/
 @[simps! toSheafedSpace presheaf]
-def Spec.locallyRingedSpaceObj (R : CommRingCat.{u}) : LocallyRingedSpace :=
-  { Spec.sheafedSpaceObj R with
-    isLocalRing := fun x =>
-      RingEquiv.isLocalRing (A := Localization.AtPrime x.asIdeal)
-        (Iso.commRingCatIsoToRingEquiv <| stalkIso R x).symm }
+def Spec.locallyRingedSpaceObj (R : CommRingCat.{u}) : LocallyRingedSpace where
+  __ := Spec.sheafedSpaceObj R
+  isLocalRing x := (stalkIso R x).toRingEquiv.isLocalRing
 
 lemma Spec.locallyRingedSpaceObj_sheaf (R : CommRingCat.{u}) :
     (Spec.locallyRingedSpaceObj R).sheaf = structureSheaf R := rfl
@@ -204,7 +203,7 @@ lemma Spec.locallyRingedSpaceObj_presheaf_map' (R : Type u) [CommRing R] {U V} (
 theorem stalkMap_toStalk {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
     toStalk R (PrimeSpectrum.comap f.hom p) ≫ (Spec.sheafedSpaceMap f).hom.stalkMap p =
       f ≫ toStalk S p := by
-  rw [← toOpen_germ S ⊤ p trivial, ← toOpen_germ R ⊤ (PrimeSpectrum.comap f.hom p) trivial,
+  rw [← algebraMap_germ ⊤ p trivial, ← algebraMap_germ ⊤ (PrimeSpectrum.comap f.hom p) trivial,
     Category.assoc]
   erw [PresheafedSpace.stalkMap_germ (Spec.sheafedSpaceMap f).hom ⊤ p trivial]
   rw [Spec.sheafedSpaceMap_hom_c_app]
@@ -216,24 +215,17 @@ to the induced local ring homomorphism `Localization.localRingHom`.
 -/
 @[elementwise]
 theorem localRingHom_comp_stalkIso {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
-    (stalkIso R (PrimeSpectrum.comap f.hom p)).hom ≫
+    CommRingCat.ofHom (stalkIso R (PrimeSpectrum.comap f.hom p)).symm.toRingHom ≫
       (CommRingCat.ofHom (Localization.localRingHom (PrimeSpectrum.comap f.hom p).asIdeal p.asIdeal
           f.hom rfl)) ≫
-        (stalkIso S p).inv =
+        CommRingCat.ofHom (stalkIso S p).toRingHom =
       (Spec.sheafedSpaceMap f).hom.stalkMap p :=
-  (stalkIso R (PrimeSpectrum.comap f.hom p)).eq_inv_comp.mp <|
-    (stalkIso S p).comp_inv_eq.mpr <| CommRingCat.hom_ext <|
+  (stalkIso R (PrimeSpectrum.comap f.hom p)).toCommRingCatIso.symm.eq_inv_comp.mp <|
+    (stalkIso S p).toCommRingCatIso.symm.comp_inv_eq.mpr <| CommRingCat.hom_ext <|
       Localization.localRingHom_unique _ _ _ (PrimeSpectrum.comap_asIdeal _ _) fun x => by
-        rw [stalkIso_hom, stalkIso_inv, CommRingCat.comp_apply, CommRingCat.comp_apply,
-            localizationToStalk_of, stalkMap_toStalk_apply f p x, stalkToFiberRingHom_toStalk]
-
-/-- Version of `localRingHom_comp_stalkIso_apply` using `CommRingCat.Hom.hom` -/
-theorem localRingHom_comp_stalkIso_apply' {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S)
-    (x) :
-    (stalkIso S p).inv ((Localization.localRingHom (PrimeSpectrum.comap f.hom p).asIdeal p.asIdeal
-          f.hom rfl) ((stalkIso R (PrimeSpectrum.comap f.hom p)).hom x)) =
-      (Spec.sheafedSpaceMap f).hom.stalkMap p x :=
-  localRingHom_comp_stalkIso_apply _ _ _
+  dsimp
+  simp only [AlgEquiv.commutes, RingEquiv.symm_apply_eq, AlgEquiv.coe_ringEquiv]
+  exact stalkMap_toStalk_apply f p x
 
 /--
 The induced map of a ring homomorphism on the prime spectra, as a morphism of locally ringed spaces.
@@ -243,16 +235,11 @@ def Spec.locallyRingedSpaceMap {R S : CommRingCat.{u}} (f : R ⟶ S) :
     Spec.locallyRingedSpaceObj S ⟶ Spec.locallyRingedSpaceObj R :=
   LocallyRingedSpace.Hom.mk (Spec.sheafedSpaceMap f).hom fun p =>
     IsLocalHom.mk fun a ha => by
-      -- Here, we are showing that the map on prime spectra induced by `f` is really a morphism of
-      -- *locally* ringed spaces, i.e. that the induced map on the stalks is a local ring
-      -- homomorphism.
-      erw [← localRingHom_comp_stalkIso_apply' f p a] at ha
-      have : IsLocalHom (stalkIso (↑S) p).inv.hom := isLocalHom_of_isIso _
-      replace ha := (isUnit_map_iff (stalkIso S p).inv.hom _).mp ha
-      replace ha := IsLocalHom.map_nonunit
-        ((stalkIso R ((PrimeSpectrum.comap f.hom) p)).hom a) ha
-      convert RingHom.isUnit_map (stalkIso R (PrimeSpectrum.comap f.hom p)).inv.hom ha
-      rw [← CommRingCat.comp_apply, Iso.hom_inv_id, CommRingCat.id_apply]
+    rw [← localRingHom_comp_stalkIso] at ha
+    dsimp at ha
+    have : IsLocalHom (stalkIso S p) := isLocalHom_equiv _
+    have : IsLocalHom (stalkIso R (p.comap f.hom)).symm := isLocalHom_equiv _
+    exact ((ha.of_map (stalkIso S p)).of_map _).of_map (stalkIso R (p.comap f.hom)).symm
 
 @[simp]
 theorem Spec.locallyRingedSpaceMap_id (R : CommRingCat.{u}) :
@@ -281,10 +268,10 @@ open AlgebraicGeometry.LocallyRingedSpace
 
 /-- The counit morphism `R ⟶ Γ(Spec R)` given by `AlgebraicGeometry.StructureSheaf.toOpen`. -/
 def toSpecΓ (R : CommRingCat.{u}) : R ⟶ Γ.obj (op (Spec.toLocallyRingedSpace.obj (op R))) :=
-  StructureSheaf.toOpen R ⊤
+  CommRingCat.ofHom (algebraMap _ _)
 
-instance isIso_toSpecΓ (R : CommRingCat.{u}) : IsIso (toSpecΓ R) := by
-  cases R; apply StructureSheaf.isIso_to_global
+instance isIso_toSpecΓ (R : CommRingCat.{u}) : IsIso (toSpecΓ R) :=
+  (ConcreteCategory.isIso_iff_bijective _).mpr algebraMap_obj_top_bijective
 
 @[reassoc]
 theorem Spec_Γ_naturality {R S : CommRingCat.{u}} (f : R ⟶ S) :
@@ -292,14 +279,14 @@ theorem Spec_Γ_naturality {R S : CommRingCat.{u}} (f : R ⟶ S) :
   -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` failed to pick up one of the three lemmas
   ext : 2
   refine Subtype.ext <| funext fun x' => ?_; symm
+  erw [comap_apply]
   apply Localization.localRingHom_to_map
 
 /-- The counit (`SpecΓIdentity.inv.op`) of the adjunction `Γ ⊣ Spec` is an isomorphism. -/
 @[simps! hom_app inv_app]
 def LocallyRingedSpace.SpecΓIdentity : Spec.toLocallyRingedSpace.rightOp ⋙ Γ ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents.{u, u, u + 1, u + 1} (fun R =>
-    letI : IsIso (toSpecΓ R) := StructureSheaf.isIso_to_global _
-    asIso (toSpecΓ R)) fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f
+  Iso.symm <| NatIso.ofComponents.{u, u, u + 1, u + 1} (fun R ↦ asIso (toSpecΓ R):)
+    fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f
 
 end SpecΓ
 
@@ -310,12 +297,14 @@ theorem isIso_SpecMap_stakMap_localization (R : CommRingCat.{u}) (M : Submonoid 
       ((Spec.toPresheafedSpace.map
         (CommRingCat.ofHom (algebraMap R (Localization M))).op).stalkMap x) := by
   dsimp only [Spec.toPresheafedSpace_map, Quiver.Hom.unop_op]
-  rw [← localRingHom_comp_stalkIso]
-  refine IsIso.comp_isIso' inferInstance (IsIso.comp_isIso' ?_ inferInstance)
-  /- I do not know why this is defeq to the goal, but I'm happy to accept that it is. -/
-  change
+  rw [← localRingHom_comp_stalkIso, ConcreteCategory.isIso_iff_bijective]
+  dsimp
+  simp only [EquivLike.bijective_comp]
+  refine (stalkIso (Localization M) x).bijective.comp ?_
+  suffices
     IsIso (IsLocalization.localizationLocalizationAtPrimeIsoLocalization M
-      x.asIdeal).toRingEquiv.toCommRingCatIso.hom
+        x.asIdeal).toRingEquiv.toCommRingCatIso.hom by
+    rwa [ConcreteCategory.isIso_iff_bijective] at this
   infer_instance
 
 @[deprecated (since := "2025-10-11")]
@@ -329,7 +318,7 @@ variable {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum R)
 This is shown to be the localization at `p` in `isLocalizedModule_toPushforwardStalkAlgHom`.
 -/
 def toPushforwardStalk : S ⟶ (Spec.topMap f _* (structureSheaf S).1).stalk p :=
-  StructureSheaf.toOpen S ⊤ ≫
+  CommRingCat.ofHom (algebraMap _ _) ≫
     @TopCat.Presheaf.germ _ _ _ _ (Spec.topMap f _* (structureSheaf S).1) ⊤ p trivial
 
 @[reassoc]
@@ -413,8 +402,7 @@ instance isLocalizedModule_toPushforwardStalkAlgHom :
     apply_fun (Spec.topMap (CommRingCat.ofHom (algebraMap R S)) _* (structureSheaf S).1).map
         (homOfLE hrU).op at e
     simp only [map_zero] at e
-    have : toOpen S (PrimeSpectrum.basicOpen <| algebraMap R S r) x = 0 := by
-      refine Eq.trans ?_ e; rfl
+    have : algebraMap S ((structureSheaf S).presheaf.obj _) x = 0 := e
     have :=
       (@IsLocalization.mk'_one _ _ _ _ _ _
             (StructureSheaf.IsLocalization.to_basicOpen S <| algebraMap R S r) x).trans

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -171,7 +171,7 @@ theorem Spec.basicOpen_hom_ext {X : RingedSpace.{u}} {R : CommRingCat.{u}}
   · apply ((TopCat.Sheaf.pushforward _ β.hom.base).obj X.sheaf).hom_ext _
       PrimeSpectrum.isBasis_basic_opens
     intro r
-    apply (StructureSheaf.to_basicOpen_epi r).1
+    apply (StructureSheaf.to_basicOpen_epi R r).1
     simpa using h r
 
 -- `simps!` generates some garbage lemmas, so choose manually,
@@ -367,7 +367,7 @@ theorem isLocalizedModule_toPushforwardStalkAlgHom_aux (y) :
   clear_value s'; clear! U
   obtain ⟨⟨s, ⟨_, n, rfl⟩⟩, hsn⟩ :=
     @IsLocalization.surj _ _ _ _ _ _
-      (StructureSheaf.IsLocalization.to_basicOpen <| algebraMap R S r) s'
+      (StructureSheaf.IsLocalization.to_basicOpen S <| algebraMap R S r) s'
   refine ⟨⟨s, ⟨r, hpr⟩ ^ n⟩, ?_⟩
   rw [Submonoid.smul_def, Algebra.smul_def, algebraMap_pushforward_stalk, toPushforwardStalk,
     CommRingCat.comp_apply, CommRingCat.comp_apply]
@@ -405,7 +405,7 @@ instance isLocalizedModule_toPushforwardStalkAlgHom :
     have : algebraMap S ((structureSheaf S).presheaf.obj _) x = 0 := e
     have :=
       (@IsLocalization.mk'_one _ _ _ _ _ _
-            (StructureSheaf.IsLocalization.to_basicOpen <| algebraMap R S r) x).trans
+            (StructureSheaf.IsLocalization.to_basicOpen S <| algebraMap R S r) x).trans
         this
     obtain ⟨⟨_, n, rfl⟩, e⟩ := (IsLocalization.mk'_eq_zero_iff _ _).mp this
     refine ⟨⟨r, hpr⟩ ^ n, ?_⟩

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -171,7 +171,7 @@ theorem Spec.basicOpen_hom_ext {X : RingedSpace.{u}} {R : CommRingCat.{u}}
   · apply ((TopCat.Sheaf.pushforward _ β.hom.base).obj X.sheaf).hom_ext _
       PrimeSpectrum.isBasis_basic_opens
     intro r
-    apply (StructureSheaf.to_basicOpen_epi R r).1
+    apply (StructureSheaf.to_basicOpen_epi r).1
     simpa using h r
 
 -- `simps!` generates some garbage lemmas, so choose manually,
@@ -367,7 +367,7 @@ theorem isLocalizedModule_toPushforwardStalkAlgHom_aux (y) :
   clear_value s'; clear! U
   obtain ⟨⟨s, ⟨_, n, rfl⟩⟩, hsn⟩ :=
     @IsLocalization.surj _ _ _ _ _ _
-      (StructureSheaf.IsLocalization.to_basicOpen S <| algebraMap R S r) s'
+      (StructureSheaf.IsLocalization.to_basicOpen <| algebraMap R S r) s'
   refine ⟨⟨s, ⟨r, hpr⟩ ^ n⟩, ?_⟩
   rw [Submonoid.smul_def, Algebra.smul_def, algebraMap_pushforward_stalk, toPushforwardStalk,
     CommRingCat.comp_apply, CommRingCat.comp_apply]
@@ -405,7 +405,7 @@ instance isLocalizedModule_toPushforwardStalkAlgHom :
     have : algebraMap S ((structureSheaf S).presheaf.obj _) x = 0 := e
     have :=
       (@IsLocalization.mk'_one _ _ _ _ _ _
-            (StructureSheaf.IsLocalization.to_basicOpen S <| algebraMap R S r) x).trans
+            (StructureSheaf.IsLocalization.to_basicOpen <| algebraMap R S r) x).trans
         this
     obtain ⟨⟨_, n, rfl⟩, e⟩ := (IsLocalization.mk'_eq_zero_iff _ _).mp this
     refine ⟨⟨r, hpr⟩ ^ n, ?_⟩

--- a/Mathlib/AlgebraicGeometry/SpreadingOut.lean
+++ b/Mathlib/AlgebraicGeometry/SpreadingOut.lean
@@ -143,11 +143,11 @@ lemma Scheme.IsGermInjective.Spec
   obtain ⟨x, s, rfl⟩ := IsLocalization.exists_mk'_eq
     (S := ((Spec.structureSheaf R).val.obj (.op <| PrimeSpectrum.basicOpen f))) (.powers f) x
   rw [← RingHom.mem_ker, IsLocalization.mk'_eq_mul_mk'_one, Ideal.mul_unit_mem_iff_mem,
-    RingHom.mem_ker, RingHom.algebraMap_toAlgebra] at hx
+    RingHom.mem_ker] at hx
   swap; · exact @isUnit_of_invertible _ _ _ (@IsLocalization.invertible_mk'_one ..)
   -- There is an `Opposite.unop (Opposite.op _)` in `hx` which doesn't seem removable using
   -- `simp`/`rw`.
-  erw [StructureSheaf.germ_toOpen] at hx
+  erw [elementwise_of% StructureSheaf.algebraMap_germ] at hx
   obtain ⟨⟨y, hy⟩, hy'⟩ := (IsLocalization.map_eq_zero_iff p.asIdeal.primeCompl
     ((Spec.structureSheaf R).presheaf.stalk p) _).mp hx
   obtain ⟨n, hn⟩ := H x y hy' hy

--- a/Mathlib/AlgebraicGeometry/Stalk.lean
+++ b/Mathlib/AlgebraicGeometry/Stalk.lean
@@ -213,25 +213,6 @@ section Spec
 
 variable (R : CommRingCat) (x)
 
-/-- The stalk of `Spec R` at `x` is isomorphic to `Rₚ`,
-where `p` is the prime corresponding to `x`. -/
-noncomputable
-def Spec.stalkIso : (Spec R).presheaf.stalk x ≅ .of (Localization.AtPrime x.asIdeal) :=
-  StructureSheaf.stalkIso ..
-
-@[reassoc (attr := simp)]
-lemma Spec.algebraMap_stalkIso_inv :
-    CommRingCat.ofHom (algebraMap R _) ≫ (stalkIso R x).inv =
-      (Scheme.ΓSpecIso R).inv ≫ (Spec R).presheaf.germ ⊤ x trivial := by
-  ext s : 2
-  exact (IsLocalization.algEquiv _ ((structureSheaf R).presheaf.stalk _) _).symm.commutes s
-
-@[reassoc (attr := simp)]
-lemma Spec.germ_stalkMapIso_hom :
-    (Spec R).presheaf.germ ⊤ _ trivial ≫ (stalkIso R x).hom =
-      (Scheme.ΓSpecIso R).hom ≫ CommRingCat.ofHom (algebraMap R _) := by
-  simp [← Iso.inv_comp_eq, ← Spec.algebraMap_stalkIso_inv_assoc]
-
 lemma Spec.fromSpecStalk_eq :
     (Spec R).fromSpecStalk x =
       Spec.map ((Scheme.ΓSpecIso R).inv ≫ (Spec R).presheaf.germ ⊤ x trivial) := by
@@ -260,13 +241,13 @@ this is the isomorphism between the stalk of `Spec R` at `𝔪` and `R`. -/
 noncomputable
 def stalkClosedPointIso :
     (Spec R).presheaf.stalk (closedPoint R) ≅ R :=
-  StructureSheaf.stalkIso _ _ ≪≫ (IsLocalization.atUnits R
+  Spec.stalkIso _ _ ≪≫ (IsLocalization.atUnits R
       (closedPoint R).asIdeal.primeCompl fun _ ↦ not_not.mp).toRingEquiv.toCommRingCatIso.symm
 
 lemma stalkClosedPointIso_inv :
     (stalkClosedPointIso R).inv = StructureSheaf.toStalk R _ := by
   ext x
-  exact StructureSheaf.localizationToStalk_of _ _ _
+  exact (StructureSheaf.stalkIso _ _).commutes _
 
 lemma ΓSpecIso_hom_stalkClosedPointIso_inv :
     (Scheme.ΓSpecIso R).hom ≫ (stalkClosedPointIso R).inv =

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -14,10 +14,10 @@ public import Mathlib.Topology.Sheaves.LocalPredicate
 /-!
 # The structure sheaf on `PrimeSpectrum R`.
 
-We define the structure sheaf on `TopCat.of (PrimeSpectrum R)`, for a commutative ring `R` and prove
+We define the structure sheaf on `TopCat.of (PrimeSpectrum R)`, for an `R`-module `M` and prove
 basic properties about it. We define this as a subsheaf of the sheaf of dependent functions into the
-localizations, cut out by the condition that the function must be locally equal to a ratio of
-elements of `R`.
+localizations, cut out by the condition that the function must be locally equal to a quotient of
+an element of `M` by an element of `R`.
 
 Because the condition "is equal to a fraction" passes to smaller open subsets,
 the subset of functions satisfying this condition is automatically a subpresheaf.
@@ -29,14 +29,16 @@ where we show that dependent functions into any type family form a sheaf,
 and also `Mathlib/Topology/Sheaves/LocalPredicate.lean`, where we characterise the predicates
 which pick out sub-presheaves and sub-sheaves of these sheaves.)
 
-We also set up the ring structure, obtaining
+When `M = R`, the structure sheaf is furthermore a sheaf of commutative rings, which we bundle as
 `structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R)`.
 
-We then construct two basic isomorphisms, relating the structure sheaf to the underlying ring `R`.
-First, `StructureSheaf.stalkIso` gives an isomorphism between the stalk of the structure sheaf
-at a point `p` and the localization of `R` at the prime ideal `p`. Second,
-`StructureSheaf.basicOpenIso` gives an isomorphism between the structure sheaf on `basicOpen f`
-and the localization of `R` at the submonoid of powers of `f`.
+We then obtain two key descriptions of the structure sheaf. We show that the stalks `Mₓ` is the
+localization of `M` at the prime corresponding to `x`, and we show that the sections `Γ(M, D(f))`
+is the localization of `M` away from `f`.
+
+Note that the results of this file are packaged into schemes and sheaf of modules in later files,
+and one usually should not directly use the results in this file to respect the abstraction
+boundaries.
 
 ## References
 
@@ -223,17 +225,18 @@ def structurePresheafInCommRingCat : Presheaf CommRingCat (PrimeSpectrum.Top R) 
       map_one' := rfl
       map_zero' := rfl }
 
-instance (U : _) :
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     Module ((structureSheafInType R R).val.obj U) ((structureSheafInType R M).val.obj U) :=
   inferInstanceAs (Module (sectionsSubalgebra R _) (sectionsSubalgebraSubmodule M _))
 
-instance (U : _) :
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     IsScalarTower R ((structureSheafInType R R).val.obj U) ((structureSheafInType R M).val.obj U) :=
   .of_algebraMap_smul fun r m ↦ Subtype.ext <| funext fun x ↦
     IsScalarTower.algebraMap_smul (Localizations R x.1) r (m.1 x)
 
 variable (R M) in
-/-- The structure sheaf of a module as a presheaf of modules on `Spec R`. -/
+/-- The structure sheaf of a module as a presheaf of modules on `Spec R`.
+We will later package this into a `Scheme.Modules` in `Tilde.lean`. -/
 def moduleStructurePresheaf : PresheafOfModules (structurePresheafInCommRingCat R ⋙ forget₂ _ _) :=
   letI (X : (Opens ↑(PrimeSpectrum.Top R))ᵒᵖ) :
     Module ↑((structurePresheafInCommRingCat R ⋙ forget₂ CommRingCat RingCat).obj X)

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -1,16 +1,14 @@
 /-
 Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johan Commelin, Kim Morrison
+Authors: Johan Commelin, Kim Morrison, Andrew Yang
 -/
 module
 
-public import Mathlib.Algebra.Category.Ring.Colimits
-public import Mathlib.Algebra.Category.Ring.Instances
+public import Mathlib.Algebra.Category.ModuleCat.Stalk
 public import Mathlib.Algebra.Category.Ring.Limits
-public import Mathlib.Algebra.Ring.Subring.Basic
-public import Mathlib.RingTheory.Localization.AtPrime.Basic
 public import Mathlib.RingTheory.Spectrum.Prime.Topology
+public import Mathlib.Tactic.DepRewrite
 public import Mathlib.Topology.Sheaves.LocalPredicate
 
 /-!
@@ -47,82 +45,50 @@ and the localization of `R` at the submonoid of powers of `f`.
 
 -/
 
-@[expose] public section
-
 
 universe u
 
 noncomputable section
 
-variable (R : Type u) [CommRing R]
+variable {R M A : Type u} [CommRing R] [AddCommGroup M] [Module R M] [CommRing A] [Algebra R A]
 
 open TopCat
 
-open TopologicalSpace
+open TopologicalSpace CategoryTheory Opposite
 
-open CategoryTheory
-
-open Opposite
+open PrimeSpectrum (basicOpen)
 
 namespace AlgebraicGeometry
 
-/-- The prime spectrum, just as a topological space.
--/
-def PrimeSpectrum.Top : TopCat :=
-  TopCat.of (PrimeSpectrum R)
+@[expose] public section Public
+
+variable (R) in
+/-- The prime spectrum as an object of `TopCat`. -/
+@[expose] public def PrimeSpectrum.Top : TopCat := TopCat.of (PrimeSpectrum R)
 
 namespace StructureSheaf
 
-/-- The type family over `PrimeSpectrum R` consisting of the localization over each point.
--/
-def Localizations (P : PrimeSpectrum.Top R) : Type u :=
-  Localization.AtPrime P.asIdeal
+variable {P : PrimeSpectrum.Top R}
 
-instance commRingLocalizations (P : PrimeSpectrum.Top R) : CommRing <| Localizations R P :=
-  inferInstanceAs <| CommRing <| Localization.AtPrime P.asIdeal
-
-instance localRingLocalizations (P : PrimeSpectrum.Top R) : IsLocalRing <| Localizations R P :=
-  inferInstanceAs <| IsLocalRing <| Localization.AtPrime P.asIdeal
-
-instance (P : PrimeSpectrum.Top R) : Inhabited (Localizations R P) :=
-  ⟨1⟩
-
-instance (U : Opens (PrimeSpectrum.Top R)) (x : U) : Algebra R (Localizations R x) :=
-  inferInstanceAs <| Algebra R (Localization.AtPrime x.1.asIdeal)
-
-instance (U : Opens (PrimeSpectrum.Top R)) (x : U) :
-    IsLocalization.AtPrime (Localizations R x) (x : PrimeSpectrum.Top R).asIdeal :=
-  Localization.isLocalization
-
-variable {R}
+variable (M P) in
+/-- The type family over `PrimeSpectrum R` consisting of the localization over each point. -/
+abbrev Localizations : Type u := LocalizedModule P.asIdeal.primeCompl M
 
 /-- The predicate saying that a dependent function on an open `U` is realised as a fixed fraction
 `r / s` in each of the stalks (which are localizations at various prime ideals).
 -/
-def IsFraction {U : Opens (PrimeSpectrum.Top R)} (f : ∀ x : U, Localizations R x) : Prop :=
-  ∃ r s : R, ∀ x : U, s ∉ x.1.asIdeal ∧ f x * algebraMap _ _ s = algebraMap _ _ r
+def IsFraction {U : Opens (PrimeSpectrum.Top R)} (f : Π x : U, Localizations M x.1) : Prop :=
+  ∃ r s, ∀ x : U, ∃ hs : s ∉ x.1.asIdeal, f x = LocalizedModule.mk r ⟨s, hs⟩
 
-theorem IsFraction.eq_mk' {U : Opens (PrimeSpectrum.Top R)} {f : ∀ x : U, Localizations R x}
-    (hf : IsFraction f) :
-    ∃ r s : R,
-      ∀ x : U,
-        ∃ hs : s ∉ x.1.asIdeal,
-          f x =
-            IsLocalization.mk' (Localization.AtPrime _) r
-              (⟨s, hs⟩ : (x : PrimeSpectrum.Top R).asIdeal.primeCompl) := by
-  rcases hf with ⟨r, s, h⟩
-  refine ⟨r, s, fun x => ⟨(h x).1, (IsLocalization.mk'_eq_iff_eq_mul.mpr ?_).symm⟩⟩
-  exact (h x).2.symm
-
-variable (R)
-
+variable (R M) in
 /-- The predicate `IsFraction` is "prelocal",
 in the sense that if it holds on `U` it holds on any open subset `V` of `U`.
 -/
-def isFractionPrelocal : PrelocalPredicate (Localizations R) where
+def isFractionPrelocal : PrelocalPredicate (Localizations (R := R) M) where
   pred {_} f := IsFraction f
   res := by rintro V U i f ⟨r, s, w⟩; exact ⟨r, s, fun x => w (i x)⟩
 
+variable (R M) in
 /-- We will define the structure sheaf as
 the subsheaf of all dependent functions in `Π x : U, Localizations R x`
 consisting of those functions which can locally be expressed as a ratio of
@@ -141,697 +107,794 @@ Now Hartshorne had the disadvantage of not knowing about dependent functions,
 so we replace his circumlocution about functions into a disjoint union with
 `Π x : U, Localizations x`.
 -/
-def isLocallyFraction : LocalPredicate (Localizations R) :=
-  (isFractionPrelocal R).sheafify
+def isLocallyFraction : LocalPredicate (Localizations (R := R) M) :=
+  (isFractionPrelocal R M).sheafify
 
-@[simp]
-theorem isLocallyFraction_pred {U : Opens (PrimeSpectrum.Top R)} (f : ∀ x : U, Localizations R x) :
-    (isLocallyFraction R).pred f =
-      ∀ x : U,
-        ∃ (V : _) (_ : x.1 ∈ V) (i : V ⟶ U),
-          ∃ r s : R,
-            ∀ y : V, s ∉ y.1.asIdeal ∧ f (i y : U) * algebraMap _ _ s = algebraMap _ _ r :=
-  rfl
+variable (M) in
+/-- The functions satisfying `isLocallyFraction` form a submodule. -/
+def sectionsSubmodule (U : (Opens (PrimeSpectrum.Top R))) :
+    Submodule R (Π x : U, Localizations M x.1) where
+  carrier := { f | (isLocallyFraction R M).pred f }
+  add_mem' {a b} ha hb x := by
+    obtain ⟨Va, ma, ia, ra, sa, wa⟩ := ha x
+    obtain ⟨Vb, mb, ib, rb, sb, wb⟩ := hb x
+    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, sb • ra + sa • rb, sa * sb, fun x ↦ ?_⟩
+    obtain ⟨hsax, hsa⟩ := wa ⟨x.1, x.2.1⟩
+    obtain ⟨hsbx, hsb⟩ := wb ⟨x.1, x.2.2⟩
+    exact ⟨x.1.asIdeal.primeCompl.mul_mem hsax hsbx,
+      congr($hsa + $hsb).trans (LocalizedModule.mk_add_mk ..)⟩
+  zero_mem' x := ⟨U, x.2, 𝟙 _, 0, 1, fun y ↦ by simp [Ideal.IsPrime.one_notMem]⟩
+  smul_mem' r {a} ha x := by
+    obtain ⟨V, m, i, ra, sa, wa⟩ := ha x
+    exact ⟨V, m, i, r • ra, sa, fun x ↦ ⟨(wa x).1,
+      congr(r • $((wa x).2)).trans (LocalizedModule.smul'_mk ..)⟩⟩
 
-/-- The functions satisfying `isLocallyFraction` form a subring.
--/
-def sectionsSubring (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
-    Subring (∀ x : U.unop, Localizations R x) where
-  carrier := { f | (isLocallyFraction R).pred f }
-  zero_mem' := by
-    refine fun x => ⟨unop U, x.2, 𝟙 _, 0, 1, fun y => ⟨?_, ?_⟩⟩
-    · rw [← Ideal.ne_top_iff_one]; exact y.1.isPrime.1
-    · simp
-  one_mem' := by
-    refine fun x => ⟨unop U, x.2, 𝟙 _, 1, 1, fun y => ⟨?_, ?_⟩⟩
-    · rw [← Ideal.ne_top_iff_one]; exact y.1.isPrime.1
-    · simp
-  add_mem' := by
-    intro a b ha hb x
-    rcases ha x with ⟨Va, ma, ia, ra, sa, wa⟩
-    rcases hb x with ⟨Vb, mb, ib, rb, sb, wb⟩
-    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, ra * sb + rb * sa, sa * sb, ?_⟩
-    intro ⟨y, hy⟩
-    rcases wa (Opens.infLELeft _ _ ⟨y, hy⟩) with ⟨nma, wa⟩
-    rcases wb (Opens.infLERight _ _ ⟨y, hy⟩) with ⟨nmb, wb⟩
-    fconstructor
-    · intro H; cases y.isPrime.mem_or_mem H <;> contradiction
-    · simp only [Opens.apply_mk, Pi.add_apply, map_mul, add_mul, map_add] at wa wb ⊢
-      grind
-  neg_mem' := by
-    intro a ha x
-    rcases ha x with ⟨V, m, i, r, s, w⟩
-    refine ⟨V, m, i, -r, s, ?_⟩
-    intro y
-    rcases w y with ⟨nm, w⟩
-    fconstructor
-    · exact nm
-    · simp only [map_neg, Pi.neg_apply]
-      rw [← w]
-      simp only [neg_mul]
-  mul_mem' := by
-    intro a b ha hb x
-    rcases ha x with ⟨Va, ma, ia, ra, sa, wa⟩
-    rcases hb x with ⟨Vb, mb, ib, rb, sb, wb⟩
-    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, ra * rb, sa * sb, ?_⟩
-    intro ⟨y, hy⟩
-    rcases wa (Opens.infLELeft _ _ ⟨y, hy⟩) with ⟨nma, wa⟩
-    rcases wb (Opens.infLERight _ _ ⟨y, hy⟩) with ⟨nmb, wb⟩
-    fconstructor
-    · intro H; cases y.isPrime.mem_or_mem H <;> contradiction
-    · simp only [Opens.apply_mk, Pi.mul_apply, map_mul] at wa wb ⊢
-      rw [← wa, ← wb]
-      simp only [mul_left_comm, mul_assoc, mul_comm]
+variable (A) in
+/-- The functions satisfying `isLocallyFraction` form a subalgebra. -/
+def sectionsSubalgebra (U : (Opens (PrimeSpectrum.Top R))) :
+    Subalgebra R (Π x : U, Localizations A x.1) where
+  __ := sectionsSubmodule A U
+  mul_mem' {a b} ha hb x := by
+    obtain ⟨Va, ma, ia, ra, sa, wa⟩ := ha x
+    obtain ⟨Vb, mb, ib, rb, sb, wb⟩ := hb x
+    refine ⟨Va ⊓ Vb, ⟨ma, mb⟩, Opens.infLELeft _ _ ≫ ia, ra * rb, sa * sb, fun x ↦ ?_⟩
+    obtain ⟨hsax, hsa⟩ := wa ⟨x.1, x.2.1⟩
+    obtain ⟨hsbx, hsb⟩ := wb ⟨x.1, x.2.2⟩
+    exact ⟨x.1.asIdeal.primeCompl.mul_mem hsax hsbx,
+      congr($hsa * $hsb).trans (LocalizedModule.mk_mul_mk ..)⟩
+  algebraMap_mem' r x :=
+    ⟨U, x.2, 𝟙 _, algebraMap R A r, 1, fun y ↦ ⟨by simp [Ideal.IsPrime.one_notMem], rfl⟩⟩
+
+variable (M) in
+/-- The functions satisfying `isLocallyFraction` form a submodule. -/
+def sectionsSubalgebraSubmodule (U : (Opens (PrimeSpectrum.Top R))) :
+    Submodule (sectionsSubalgebra R U) (Π x : U, Localizations M x.1) where
+  __ := sectionsSubmodule M U
+  smul_mem' r {a} ha x := by
+    obtain ⟨V, hxV, hVU, rx, rs, hr⟩ := r.2 x
+    obtain ⟨W, hxW, hWU, ax, as, ha⟩ := ha x
+    refine ⟨V ⊓ W, ⟨hxV, hxW⟩, homOfLE (inf_le_left.trans hVU.le), rx • ax, as * rs, fun y ↦ ?_⟩
+    obtain ⟨hrsy, hry⟩ := hr ⟨y.1, y.2.1⟩
+    obtain ⟨hasy, hay⟩ := ha ⟨y.1, y.2.2⟩
+    exact ⟨y.1.asIdeal.primeCompl.mul_mem hasy hrsy, congr($hry • $hay)⟩
 
 end StructureSheaf
 
 open StructureSheaf
 
+variable (R M) in
 /-- The structure sheaf (valued in `Type`, not yet `CommRingCat`) is the subsheaf consisting of
-functions satisfying `isLocallyFraction`.
--/
+functions satisfying `isLocallyFraction`. -/
 def structureSheafInType : Sheaf (Type u) (PrimeSpectrum.Top R) :=
-  subsheafToTypes (isLocallyFraction R)
+  subsheafToTypes (isLocallyFraction R M)
 
-instance commRingStructureSheafInTypeObj (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
-    CommRing ((structureSheafInType R).1.obj U) :=
-  (sectionsSubring R U).toCommRing
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
+    AddCommGroup ((structureSheafInType R M).val.obj U) :=
+  (sectionsSubmodule M U.unop).toAddSubgroup.toAddCommGroup
 
-open PrimeSpectrum
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
+    Module R ((structureSheafInType R M).val.obj U) :=
+  (sectionsSubmodule M U.unop).module
 
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
+    CommRing ((structureSheafInType R A).val.obj U) :=
+  (sectionsSubalgebra A U.unop).toCommRing
+
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
+    Algebra R ((structureSheafInType R A).val.obj U) :=
+  (sectionsSubalgebra A U.unop).algebra
+
+local notation "Γ("M", "U")" => (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
+
+@[simp]
+lemma structureSheafInType.add_apply {U : Opens (PrimeSpectrum.Top R)} (s t : Γ(M, U)) (x : U) :
+  (s + t).1 x = s.1 x + t.1 x := rfl
+
+@[simp]
+lemma structureSheafInType.mul_apply {U : Opens (PrimeSpectrum.Top R)} (s t : Γ(A, U)) (x : U) :
+  (s * t).1 x = s.1 x * t.1 x := rfl
+
+@[simp]
+lemma structureSheafInType.smul_apply {U : Opens (PrimeSpectrum.Top R)}
+    (r : R) (s : Γ(M, U)) (x : U) :
+  (r • s).1 x = r • s.1 x := rfl
+
+variable (R M) in
 /-- The structure presheaf, valued in `CommRingCat`, constructed by dressing up the `Type`-valued
-structure presheaf.
--/
+structure presheaf. -/
 @[simps obj_carrier]
-def structurePresheafInCommRing : Presheaf CommRingCat (PrimeSpectrum.Top R) where
-  obj U := CommRingCat.of ((structureSheafInType R).1.obj U)
-  map {_ _} i := CommRingCat.ofHom
-    { toFun := (structureSheafInType R).1.map i
-      map_zero' := rfl
-      map_add' := fun _ _ => rfl
-      map_one' := rfl
-      map_mul' := fun _ _ => rfl }
+def structurePresheafInModuleCat : Presheaf (ModuleCat R) (PrimeSpectrum.Top R) where
+  obj U := ModuleCat.of R ((structureSheafInType R M).1.obj U)
+  map i := ModuleCat.ofHom
+    { toFun := (structureSheafInType R M).1.map i
+      map_add' _ _ := rfl
+      map_smul' _ _ := rfl }
 
+variable (R) in
+/-- The structure presheaf, valued in `CommRingCat`, constructed by dressing up the `Type`-valued
+structure presheaf. -/
+@[simps obj_carrier]
+def structurePresheafInCommRingCat : Presheaf CommRingCat (PrimeSpectrum.Top R) where
+  obj U := .of ((structureSheafInType R R).1.obj U)
+  map i := CommRingCat.ofHom
+    { toFun := (structureSheafInType R R).1.map i
+      map_add' _ _ := rfl
+      map_mul' _ _ := rfl
+      map_one' := rfl
+      map_zero' := rfl }
+
+instance (U : _) :
+    Module ((structureSheafInType R R).val.obj U) ((structureSheafInType R M).val.obj U) :=
+  inferInstanceAs (Module (sectionsSubalgebra R _) (sectionsSubalgebraSubmodule M _))
+
+instance (U : _) :
+    IsScalarTower R ((structureSheafInType R R).val.obj U) ((structureSheafInType R M).val.obj U) :=
+  .of_algebraMap_smul fun r m ↦ Subtype.ext <| funext fun x ↦
+    IsScalarTower.algebraMap_smul (Localizations R x.1) r (m.1 x)
+
+variable (R M) in
+/-- The structure sheaf of a module as a presheaf of modules on `Spec R`. -/
+def moduleStructurePresheaf : PresheafOfModules (structurePresheafInCommRingCat R ⋙ forget₂ _ _) :=
+  letI (X : (Opens ↑(PrimeSpectrum.Top R))ᵒᵖ) :
+    Module ↑((structurePresheafInCommRingCat R ⋙ forget₂ CommRingCat RingCat).obj X)
+      ↑((structurePresheafInModuleCat R M ⋙ forget₂ (ModuleCat R) Ab).obj X) := by
+    dsimp; infer_instance
+  .ofPresheaf (structurePresheafInModuleCat R M ⋙ forget₂ _ _) fun X Y f r m ↦ rfl
+
+variable (R) in
 /-- Some glue, verifying that the structure presheaf valued in `CommRingCat` agrees
 with the `Type`-valued structure presheaf.
 -/
 def structurePresheafCompForget :
-    structurePresheafInCommRing R ⋙ forget CommRingCat ≅ (structureSheafInType R).1 :=
+    structurePresheafInCommRingCat R ⋙ forget CommRingCat ≅ (structureSheafInType R R).1 :=
   NatIso.ofComponents fun _ => Iso.refl _
 
 open TopCat.Presheaf
 
-/-- The structure sheaf on $Spec R$, valued in `CommRingCat`.
+open PrimeSpectrum
 
-This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
--/
-def Spec.structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R) :=
-  ⟨structurePresheafInCommRing R,
-    (-- We check the sheaf condition under `forget CommRingCat`.
-          isSheaf_iff_isSheaf_comp
-          _ _).mpr
-      (isSheaf_of_iso (structurePresheafCompForget R).symm (structureSheafInType R).cond)⟩
-
-open Spec (structureSheaf)
+open TopCat.Presheaf
 
 namespace StructureSheaf
 
 @[simp]
 theorem res_apply (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U)
-    (s : (structureSheaf R).1.obj (op U)) (x : V) :
-    ((structureSheaf R).1.map i.op s).1 x = (s.1 (i x) :) :=
+    (s : Γ(M, U)) (x : V) : ((structureSheafInType R M).1.map i.op s).1 x = s.1 (i x) :=
   rfl
 
-/-
-
-Notation in this comment
-
-X = Spec R
-OX = structure sheaf
-
-In the following we construct an isomorphism between OX_p and R_p given any point p corresponding
-to a prime ideal in R.
-
-We do this via 8 steps:
-
-1. def const (f g : R) (V) (hv : V ≤ D_g) : OX(V) [for api]
-2. def toOpen (U) : R ⟶ OX(U)
-3. [2] def toStalk (p : Spec R) : R ⟶ OX_p
-4. [2] def toBasicOpen (f : R) : R_f ⟶ OX(D_f)
-5. [3] def localizationToStalk (p : Spec R) : R_p ⟶ OX_p
-6. def openToLocalization (U) (p) (hp : p ∈ U) : OX(U) ⟶ R_p
-7. [6] def stalkToFiberRingHom (p : Spec R) : OX_p ⟶ R_p
-8. [5,7] def stalkIso (p : Spec R) : OX_p ≅ R_p
-
-In the square brackets we list the dependencies of a construction on the previous steps.
-
--/
 /-- The section of `structureSheaf R` on an open `U` sending each `x ∈ U` to the element
 `f/g` in the localization of `R` at `x`. -/
-def const (f g : R) (U : Opens (PrimeSpectrum.Top R))
-    (hu : ∀ x ∈ U, g ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) :
-    (structureSheaf R).1.obj (op U) :=
-  ⟨fun x => IsLocalization.mk' _ f ⟨g, hu x x.2⟩, fun x =>
-    ⟨U, x.2, 𝟙 _, f, g, fun y => ⟨hu y y.2, IsLocalization.mk'_spec _ _ _⟩⟩⟩
+def const (f : M) (g : R) (U : Opens (PrimeSpectrum.Top R))
+    (hu : U ≤ basicOpen g) :
+    Γ(M, U) :=
+  ⟨fun x => .mk f ⟨g, hu x.2⟩, fun x ↦ ⟨U, x.2, 𝟙 _, f, g, fun y ↦ ⟨hu y.2, rfl⟩⟩⟩
 
 @[simp]
-theorem const_apply (f g : R) (U : Opens (PrimeSpectrum.Top R))
+theorem const_apply (f : M) (g : R) (U : Opens (PrimeSpectrum.Top R))
     (hu : ∀ x ∈ U, g ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) (x : U) :
-    (const R f g U hu).1 x =
-      IsLocalization.mk' (Localization.AtPrime x.1.asIdeal) f ⟨g, hu x x.2⟩ :=
+    (const f g U hu).1 x = .mk f ⟨g, hu x x.2⟩ :=
   rfl
 
-theorem const_apply' (f g : R) (U : Opens (PrimeSpectrum.Top R))
-    (hu : ∀ x ∈ U, g ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) (x : U)
-    (hx : g ∈ (x : PrimeSpectrum.Top R).asIdeal.primeCompl) :
-    (const R f g U hu).1 x = IsLocalization.mk' _ f ⟨g, hx⟩ :=
-  rfl
-
-theorem exists_const (U) (s : (structureSheaf R).1.obj (op U)) (x : PrimeSpectrum.Top R)
+theorem exists_const (U) (s : Γ(M, U)) (x : PrimeSpectrum.Top R)
     (hx : x ∈ U) :
-    ∃ (V : Opens (PrimeSpectrum.Top R)) (_ : x ∈ V) (i : V ⟶ U) (f g : R) (hg : _),
-      const R f g V hg = (structureSheaf R).1.map i.op s :=
-  let ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩
-  ⟨V, hxV, iVU, f, g, fun y hyV => (hfg ⟨y, hyV⟩).1,
-    Subtype.ext <| funext fun y => IsLocalization.mk'_eq_iff_eq_mul.2 <| Eq.symm <| (hfg y).2⟩
+    ∃ (g : R) (_ : x ∈ basicOpen g) (i : basicOpen g ≤ U) (f : M),
+      const f g _ le_rfl = (structureSheafInType R M).1.map i.hom.op s := by
+  obtain ⟨V, hxV, iVU, f, g, hfg⟩ := s.2 ⟨x, hx⟩
+  obtain ⟨_, ⟨_, ⟨g', rfl⟩, rfl⟩, hxg', hg'U⟩ :=
+    PrimeSpectrum.isBasis_basic_opens.exists_subset_of_mem_open hxV V.2
+  refine ⟨g' * g, ?_, ?_, g' • f, Subtype.ext <| funext fun ⟨y, hy⟩ ↦ ?_⟩ <;>
+    simp only [PrimeSpectrum.basicOpen_mul]
+  · exact ⟨hxg', (hfg ⟨x, hxV⟩).1⟩
+  · exact inf_le_left.trans (hg'U.trans iVU.le)
+  · rw [PrimeSpectrum.basicOpen_mul] at hy
+    obtain ⟨hgy, H⟩ := hfg ⟨y, hg'U hy.1⟩
+    refine (LocalizedModule.mk_eq.mpr ⟨1, ?_⟩).trans H.symm
+    simp [Submonoid.smul_def, ← smul_assoc]; ring_nf
 
 @[simp]
-theorem res_const (f g : R) (U hu V hv i) :
-    (structureSheaf R).1.map i (const R f g U hu) = const R f g V hv :=
+theorem res_const (f : M) (g : R) (U hu V hv i) :
+    (structureSheafInType R M).1.map i (const f g U hu) = const f g V hv :=
   rfl
 
-theorem res_const' (f g : R) (V hv) :
-    (structureSheaf R).1.map (homOfLE hv).op (const R f g (PrimeSpectrum.basicOpen g) fun _ => id) =
-      const R f g V hv :=
-  rfl
+@[simp]
+theorem const_zero (f : R) (U hu) : const (0 : M) f U hu = 0 :=
+  Subtype.ext <| funext fun x ↦ by simp; rfl
 
-theorem const_zero (f : R) (U hu) : const R 0 f U hu = 0 :=
-  Subtype.ext <| funext fun x => IsLocalization.mk'_eq_iff_eq_mul.2 <| by
-    rw [map_zero]
-    exact (mul_eq_zero_of_left rfl ((algebraMap R (Localizations R x)) _)).symm
+@[simp]
+theorem const_algebraMap (f : R) (U hu) : const (algebraMap R A f) f U hu = 1 :=
+  Subtype.ext <| funext fun _ ↦ (LocalizedModule.mk_eq.mpr
+      ⟨1, by simp [Algebra.smul_def, Submonoid.smul_def]⟩).trans
+    OreLocalization.one_def.symm
 
-theorem const_self (f : R) (U hu) : const R f f U hu = 1 :=
-  Subtype.ext <| funext fun _ => IsLocalization.mk'_self _ _
+@[simp]
+theorem const_self (f : R) (U hu) : const f f U hu = 1 :=
+  const_algebraMap ..
 
-theorem const_one (U) : (const R 1 1 U fun _ _ => Submonoid.one_mem _) = 1 :=
-  const_self R 1 U _
+@[simp]
+theorem const_one (U) : const (1 : A) (1 : R) U (by simp) = 1 := by
+  simpa using const_algebraMap 1 (A := A) U
 
-theorem const_add (f₁ f₂ g₁ g₂ : R) (U hu₁ hu₂) :
-    const R f₁ g₁ U hu₁ + const R f₂ g₂ U hu₂ =
-      const R (f₁ * g₂ + f₂ * g₁) (g₁ * g₂) U fun x hx =>
-        Submonoid.mul_mem _ (hu₁ x hx) (hu₂ x hx) :=
-  Subtype.ext <| funext fun x => Eq.symm <| IsLocalization.mk'_add _ _
-    ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
+theorem const_add (f₁ f₂ : M) (g₁ g₂ : R) (U hu₁ hu₂) :
+    const f₁ g₁ U hu₁ + const f₂ g₂ U hu₂ =
+      const (g₂ • f₁ + g₁ • f₂) (g₁ * g₂) U (by simp [*, PrimeSpectrum.basicOpen_mul]) :=
+  Subtype.ext <| funext fun _ ↦ LocalizedModule.mk_add_mk
 
-theorem const_mul (f₁ f₂ g₁ g₂ : R) (U hu₁ hu₂) :
-    const R f₁ g₁ U hu₁ * const R f₂ g₂ U hu₂ =
-      const R (f₁ * f₂) (g₁ * g₂) U fun x hx => Submonoid.mul_mem _ (hu₁ x hx) (hu₂ x hx) :=
-  Subtype.ext <|
-    funext fun x =>
-      Eq.symm <| IsLocalization.mk'_mul _ f₁ f₂ ⟨g₁, hu₁ x x.2⟩ ⟨g₂, hu₂ x x.2⟩
+theorem smul_const (f : M) (r g : R) (U hu) :
+    r • const f g U hu = const (r • f) g U hu :=
+  Subtype.ext <| funext fun _ ↦ LocalizedModule.smul'_mk _ _ _
 
-theorem const_ext {f₁ f₂ g₁ g₂ : R} {U hu₁ hu₂} (h : f₁ * g₂ = f₂ * g₁) :
-    const R f₁ g₁ U hu₁ = const R f₂ g₂ U hu₂ :=
-  Subtype.ext <|
-    funext fun x =>
-      IsLocalization.mk'_eq_of_eq (by rw [mul_comm, Subtype.coe_mk, ← h, mul_comm, Subtype.coe_mk])
+theorem const_mul (f₁ f₂ : A) (g₁ g₂ : R) (U hu₁ hu₂) :
+    const f₁ g₁ U hu₁ * const f₂ g₂ U hu₂ =
+      const (f₁ * f₂) (g₁ * g₂) U (by simp [*, PrimeSpectrum.basicOpen_mul]) :=
+  Subtype.ext <| funext fun _ ↦ LocalizedModule.mk_mul_mk
 
-theorem const_congr {f₁ f₂ g₁ g₂ : R} {U hu} (hf : f₁ = f₂) (hg : g₁ = g₂) :
-    const R f₁ g₁ U hu = const R f₂ g₂ U (hg ▸ hu) := by substs hf hg; rfl
+theorem const_ext {f₁ f₂ : M} {g₁ g₂ : R} {U hu₁ hu₂} (h : g₂ • f₁ = g₁ • f₂) :
+    const f₁ g₁ U hu₁ = const f₂ g₂ U hu₂ :=
+  Subtype.ext <| funext fun x ↦ LocalizedModule.mk_eq.mpr (by simp [h, Submonoid.smul_def])
 
-theorem const_mul_rev (f g : R) (U hu₁ hu₂) : const R f g U hu₁ * const R g f U hu₂ = 1 := by
-  rw [const_mul, const_congr R rfl (mul_comm g f), const_self]
+theorem const_congr {f₁ f₂ : M} {g₁ g₂ : R} {U hu} (hf : f₁ = f₂) (hg : g₁ = g₂) :
+    const f₁ g₁ U hu = const f₂ g₂ U (hg ▸ hu) := by substs hf hg; rfl
+
+theorem const_mul_rev (f g : R) (U hu₁ hu₂) : const f g U hu₁ * const g f U hu₂ = 1 := by
+  rw [const_mul, const_congr rfl (mul_comm g f), const_self]
 
 theorem const_mul_cancel (f g₁ g₂ : R) (U hu₁ hu₂) :
-    const R f g₁ U hu₁ * const R g₁ g₂ U hu₂ = const R f g₂ U hu₂ := by
-  rw [const_mul, const_ext]; rw [mul_assoc]
+    const f g₁ U hu₁ * const g₁ g₂ U hu₂ = const f g₂ U hu₂ := by
+  rw [const_mul, const_ext]; simp; ring
 
 theorem const_mul_cancel' (f g₁ g₂ : R) (U hu₁ hu₂) :
-    const R g₁ g₂ U hu₂ * const R f g₁ U hu₁ = const R f g₂ U hu₂ := by
+    const g₁ g₂ U hu₂ * const f g₁ U hu₁ = const f g₂ U hu₂ := by
   rw [mul_comm, const_mul_cancel]
 
-/-- The canonical ring homomorphism interpreting an element of `R` as
+theorem const_eq_const_of_smul_eq_smul (f₁ f₂ : M) (g₁ g₂ : R) (U hu₁ hu₂) (H : g₁ • f₂ = g₂ • f₁) :
+    const f₁ g₁ U hu₁ = const f₂ g₂ U hu₂ :=
+  Subtype.ext (funext fun x ↦ by
+    simp [LocalizedModule.mk_eq, Localizations, Submonoid.smul_def, H])
+
+variable (R M) in
+/-- The canonical linear map interpreting an element of `M` as
 a section of the structure sheaf. -/
-def toOpen (U : Opens (PrimeSpectrum.Top R)) :
-    CommRingCat.of R ⟶ (structureSheaf R).1.obj (op U) := CommRingCat.ofHom
-  { toFun f :=
-      ⟨fun _ => algebraMap R _ f, fun x =>
-        ⟨U, x.2, 𝟙 _, f, 1, fun y =>
-          ⟨(Ideal.ne_top_iff_one _).1 y.1.2.1, by simp [map_one, mul_one]⟩⟩⟩
-    map_one' := Subtype.ext <| funext fun _ => map_one _
-    map_mul' _ _ := Subtype.ext <| funext fun _ => map_mul _ _ _
-    map_zero' := Subtype.ext <| funext fun _ => map_zero _
-    map_add' _ _ := Subtype.ext <| funext fun _ => map_add _ _ _ }
+def toOpenₗ (U : Opens (PrimeSpectrum.Top R)) :
+    M →ₗ[R] Γ(M, U) where
+  toFun m := const m 1 U (by simp)
+  map_add' _ _ := by simp [const_add]
+  map_smul' _ _ := by simp [smul_const]
 
-@[simp]
-theorem toOpen_res (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U) :
-    toOpen R U ≫ (structureSheaf R).1.map i.op = toOpen R V :=
-  rfl
+theorem toOpenₗ_eq_const (U : Opens (PrimeSpectrum.Top R)) (f : M) :
+    toOpenₗ R M U f = const f 1 U (by simp) := rfl
 
-@[simp]
-theorem toOpen_apply (U : Opens (PrimeSpectrum.Top R)) (f : R) (x : U) :
-    (toOpen R U f).1 x = algebraMap _ _ f :=
-  rfl
+end StructureSheaf
 
-theorem toOpen_eq_const (U : Opens (PrimeSpectrum.Top R)) (f : R) :
-    toOpen R U f = const R f 1 U fun x _ => (Ideal.ne_top_iff_one _).1 x.2.1 :=
-  Subtype.ext <| funext fun _ => Eq.symm <| IsLocalization.mk'_one _ f
+end Public
 
-/-- The canonical ring homomorphism interpreting an element of `R` as an element of
-the stalk of `structureSheaf R` at `x`. -/
-def toStalk (x : PrimeSpectrum.Top R) : CommRingCat.of R ⟶ (structureSheaf R).presheaf.stalk x :=
-  (toOpen R ⊤ ≫ (structureSheaf R).presheaf.germ _ x (by trivial))
+local notation "Γ("M", "U")" => (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
 
-@[simp]
-theorem toOpen_germ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
-    toOpen R U ≫ (structureSheaf R).presheaf.germ U x hx = toStalk R x := by
-  rw [← toOpen_res R ⊤ U (homOfLE le_top : U ⟶ ⊤), Category.assoc, Presheaf.germ_res]; rfl
+namespace StructureSheaf
 
-@[simp]
-theorem germ_toOpen
-    (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) (f : R) :
-    (structureSheaf R).presheaf.germ U x hx (toOpen R U f) = toStalk R x f := by
-  rw [← toOpen_germ]; rfl
+section basicOpen
 
-theorem toOpen_Γgerm_apply (x : PrimeSpectrum.Top R) (f : R) :
-    (structureSheaf R).presheaf.Γgerm x (toOpen R ⊤ f) = toStalk R x f :=
-  rfl
+lemma isUnit_toBasicOpen (f : R) :
+    IsUnit ((algebraMap R Γ(R, basicOpen f)) f) :=
+  isUnit_iff_exists_inv.mpr ⟨const 1 f _ le_rfl, const_mul_rev _ _ _ (by simp) _⟩
 
-theorem isUnit_to_basicOpen_self (f : R) : IsUnit (toOpen R (PrimeSpectrum.basicOpen f) f) :=
-  .of_mul_eq_one (const R 1 f (PrimeSpectrum.basicOpen f) fun _ => id) <| by
-    rw [toOpen_eq_const, const_mul_rev]
+lemma isUnit_toBasicOpen_end (f : R) :
+    IsUnit ((algebraMap R (Module.End R Γ(M, basicOpen f))) f) := by
+  have := (isUnit_toBasicOpen f).map
+    (algebraMap _ (Module.End Γ(R, basicOpen f) Γ(M, basicOpen f)))
+  rw [Module.End.isUnit_iff] at this ⊢
+  convert this
+  ext a
+  simp
 
-theorem isUnit_toStalk (x : PrimeSpectrum.Top R) (f : x.asIdeal.primeCompl) :
-    IsUnit (toStalk R x (f : R)) := by
-  rw [← germ_toOpen R (PrimeSpectrum.basicOpen (f : R)) x f.2 (f : R)]
-  exact RingHom.isUnit_map _ (isUnit_to_basicOpen_self R f)
-
-/-- The canonical ring homomorphism from the localization of `R` at `p` to the stalk
-of the structure sheaf at the point `p`. -/
-def localizationToStalk (x : PrimeSpectrum.Top R) :
-    CommRingCat.of (Localization.AtPrime x.asIdeal) ⟶ (structureSheaf R).presheaf.stalk x :=
-  CommRingCat.ofHom <|
-    show Localization.AtPrime x.asIdeal →+* _ from IsLocalization.lift (isUnit_toStalk R x)
-
-@[simp]
-theorem localizationToStalk_of (x : PrimeSpectrum.Top R) (f : R) :
-    localizationToStalk R x (algebraMap _ (Localization _) f) = toStalk R x f :=
-  IsLocalization.lift_eq (S := Localization x.asIdeal.primeCompl) _ f
-
-@[simp]
-theorem localizationToStalk_mk' (x : PrimeSpectrum.Top R) (f : R) (s : x.asIdeal.primeCompl) :
-    localizationToStalk R x (IsLocalization.mk' (Localization.AtPrime x.asIdeal) f s) =
-      (structureSheaf R).presheaf.germ (PrimeSpectrum.basicOpen (s : R)) x s.2
-        (const R f s (PrimeSpectrum.basicOpen s) fun _ => id) :=
-  (IsLocalization.lift_mk'_spec (S := Localization.AtPrime x.asIdeal) _ _ _ _).2 <| by
-    rw [← germ_toOpen R (PrimeSpectrum.basicOpen s) x s.2,
-      ← germ_toOpen R (PrimeSpectrum.basicOpen s) x s.2, ← map_mul, toOpen_eq_const,
-      toOpen_eq_const, const_mul_cancel']
-
-/-- The ring homomorphism that takes a section of the structure sheaf of `R` on the open set `U`,
-implemented as a subtype of dependent functions to localizations at prime ideals, and evaluates
-the section on the point corresponding to a given prime ideal. -/
-def openToLocalization (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
-    (structureSheaf R).1.obj (op U) ⟶ CommRingCat.of (Localization.AtPrime x.asIdeal) :=
-  CommRingCat.ofHom
-  { toFun s := (s.1 ⟨x, hx⟩ :)
-    map_one' := rfl
-    map_mul' _ _ := rfl
-    map_zero' := rfl
-    map_add' _ _ := rfl }
-
-@[simp]
-theorem coe_openToLocalization (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R)
-    (hx : x ∈ U) :
-    (openToLocalization R U x hx :
-        (structureSheaf R).1.obj (op U) → Localization.AtPrime x.asIdeal) =
-      fun s => s.1 ⟨x, hx⟩ :=
-  rfl
-
-theorem openToLocalization_apply (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R)
-    (hx : x ∈ U) (s : (structureSheaf R).1.obj (op U)) :
-    openToLocalization R U x hx s = s.1 ⟨x, hx⟩ :=
-  rfl
-
-/-- The ring homomorphism from the stalk of the structure sheaf of `R` at a point corresponding to
-a prime ideal `p` to the localization of `R` at `p`,
-formed by gluing the `openToLocalization` maps. -/
-def stalkToFiberRingHom (x : PrimeSpectrum.Top R) :
-    (structureSheaf R).presheaf.stalk x ⟶ CommRingCat.of (Localization.AtPrime x.asIdeal) :=
-  Limits.colimit.desc ((OpenNhds.inclusion x).op ⋙ (structureSheaf R).1)
-    { pt := _
-      ι := { app := fun U =>
-        openToLocalization R ((OpenNhds.inclusion _).obj (unop U)) x (unop U).2 } }
-
-@[simp]
-theorem germ_comp_stalkToFiberRingHom
-    (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
-    (structureSheaf R).presheaf.germ U x hx ≫ stalkToFiberRingHom R x =
-      openToLocalization R U x hx :=
-  Limits.colimit.ι_desc _ _
-
-@[simp]
-theorem stalkToFiberRingHom_germ (U : Opens (PrimeSpectrum.Top R))
-    (x : PrimeSpectrum.Top R) (hx : x ∈ U) (s : (structureSheaf R).1.obj (op U)) :
-    stalkToFiberRingHom R x ((structureSheaf R).presheaf.germ U x hx s) = s.1 ⟨x, hx⟩ :=
-  RingHom.ext_iff.mp (CommRingCat.hom_ext_iff.mp (germ_comp_stalkToFiberRingHom R U x hx)) s
-
-@[simp]
-theorem toStalk_comp_stalkToFiberRingHom (x : PrimeSpectrum.Top R) :
-    toStalk R x ≫ stalkToFiberRingHom R x = CommRingCat.ofHom (algebraMap _ _) := by
-  rw [toStalk, Category.assoc, germ_comp_stalkToFiberRingHom]; rfl
-
-@[simp]
-theorem stalkToFiberRingHom_toStalk (x : PrimeSpectrum.Top R) (f : R) :
-    stalkToFiberRingHom R x (toStalk R x f) = algebraMap _ _ f :=
-  RingHom.ext_iff.1 (CommRingCat.hom_ext_iff.mp (toStalk_comp_stalkToFiberRingHom R x)) _
-
-/-- The ring isomorphism between the stalk of the structure sheaf of `R` at a point `p`
-corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
-@[simps]
-def stalkIso (x : PrimeSpectrum.Top R) :
-    (structureSheaf R).presheaf.stalk x ≅ CommRingCat.of (Localization.AtPrime x.asIdeal) where
-  hom := stalkToFiberRingHom R x
-  inv := localizationToStalk R x
-  hom_inv_id := by
-    apply stalk_hom_ext
-    intro U hxU
-    ext s
-    dsimp only [CommRingCat.hom_comp, RingHom.coe_comp, Function.comp_apply, CommRingCat.hom_id,
-      RingHom.coe_id, id_eq]
-    rw [stalkToFiberRingHom_germ]
-    obtain ⟨V, hxV, iVU, f, g, (hg : V ≤ PrimeSpectrum.basicOpen _), hs⟩ :=
-      exists_const _ _ s x hxU
-    have := res_apply R U V iVU s ⟨x, hxV⟩
-    dsimp only [isLocallyFraction_pred, Opens.apply_mk] at this
-    rw [← this, ← hs, const_apply, localizationToStalk_mk']
-    refine (structureSheaf R).presheaf.germ_ext V hxV (homOfLE hg) iVU ?_
-    rw [← hs, res_const']
-  inv_hom_id := CommRingCat.hom_ext <| IsLocalization.ringHom_ext x.asIdeal.primeCompl <| by
-    ext f
-    rw [CommRingCat.hom_comp, CommRingCat.hom_id,
-      RingHom.comp_apply, RingHom.comp_apply, localizationToStalk_of,
-      stalkToFiberRingHom_toStalk, RingHom.comp_apply, RingHom.id_apply]
-
-instance (x : PrimeSpectrum R) : IsIso (stalkToFiberRingHom R x) :=
-  (stalkIso R x).isIso_hom
-
-instance (x : PrimeSpectrum R) : IsLocalHom (stalkToFiberRingHom R x).hom :=
-  isLocalHom_of_isIso _
-
-instance (x : PrimeSpectrum R) : IsIso (localizationToStalk R x) :=
-  (stalkIso R x).isIso_inv
-
-instance (x : PrimeSpectrum R) : IsLocalHom (localizationToStalk R x).hom :=
-  isLocalHom_of_isIso _
-
-@[simp, reassoc]
-theorem stalkToFiberRingHom_localizationToStalk (x : PrimeSpectrum.Top R) :
-    stalkToFiberRingHom R x ≫ localizationToStalk R x = 𝟙 _ :=
-  (stalkIso R x).hom_inv_id
-
-@[simp, reassoc]
-theorem localizationToStalk_stalkToFiberRingHom (x : PrimeSpectrum.Top R) :
-    localizationToStalk R x ≫ stalkToFiberRingHom R x = 𝟙 _ :=
-  (stalkIso R x).inv_hom_id
-
+variable (R M) in
 /-- The canonical ring homomorphism interpreting `s ∈ R_f` as a section of the structure sheaf
 on the basic open defined by `f ∈ R`. -/
-def toBasicOpen (f : R) :
-    Localization.Away f →+* (structureSheaf R).1.obj (op <| PrimeSpectrum.basicOpen f) :=
-  IsLocalization.Away.lift f (isUnit_to_basicOpen_self R f)
+def toBasicOpenₗ (f : R) :
+    LocalizedModule (.powers f) M →ₗ[R] Γ(M, PrimeSpectrum.basicOpen f) :=
+  IsLocalizedModule.lift (.powers f) (LocalizedModule.mkLinearMap ..) (toOpenₗ R M _) <| by
+    simp only [Subtype.forall]
+    exact Submonoid.powers_le (P := (IsUnit.submonoid _).comap (algebraMap R _)).mpr
+      (isUnit_toBasicOpen_end ..)
+
+-- move me
+lemma PrimeSpectrum.le_basicOpen_pow (r : R) (n : ℕ) : basicOpen r ≤ basicOpen (r ^ n) := by
+  cases n <;> simp
 
 @[simp]
-theorem toBasicOpen_mk' (s f : R) (g : Submonoid.powers s) :
-    toBasicOpen R s (IsLocalization.mk' (Localization.Away s) f g) =
-      const R f g (PrimeSpectrum.basicOpen s) fun _ hx => Submonoid.powers_le.2 hx g.2 :=
-  (IsLocalization.lift_mk'_spec _ _ _ _).2 <| by
-    rw [toOpen_eq_const, toOpen_eq_const, const_mul_cancel']
+theorem toBasicOpenₗ_mk (s : R) (f : M) (g : Submonoid.powers s) :
+    toBasicOpenₗ R M s (.mk f g) = const f g.1 (basicOpen s) (by
+    have := PrimeSpectrum.le_basicOpen_pow s; aesop (add simp [Submonoid.mem_powers_iff])) := by
+  obtain ⟨_, n, rfl⟩ := g
+  apply ((Module.End.isUnit_iff _).mp ((isUnit_toBasicOpen_end ..).pow n)).1 ?_
+  rw [← map_pow]
+  dsimp [toBasicOpenₗ]
+  rw [← map_smul, LocalizedModule.smul'_mk, ← Submonoid.mk_smul (S := .powers s) _ ⟨n, rfl⟩,
+    LocalizedModule.mk_cancel, ← LocalizedModule.mkLinearMap_apply, IsLocalizedModule.lift_apply,
+    smul_const]
+  dsimp [toOpenₗ]
+  exact const_eq_const_of_smul_eq_smul (H := by simp) ..
 
-@[simp]
-theorem localization_toBasicOpen (f : R) :
-    RingHom.comp (toBasicOpen R f) (algebraMap R (Localization.Away f)) =
-    (toOpen R (PrimeSpectrum.basicOpen f)).hom :=
-  RingHom.ext fun g => by
-    rw [toBasicOpen, IsLocalization.Away.lift, RingHom.comp_apply, IsLocalization.lift_eq]
-
-@[simp]
-theorem toBasicOpen_to_map (s f : R) :
-    toBasicOpen R s (algebraMap R (Localization.Away s) f) =
-      const R f 1 (PrimeSpectrum.basicOpen s) fun _ _ => Submonoid.one_mem _ :=
-  (IsLocalization.lift_eq _ _).trans <| toOpen_eq_const _ _ _
-
--- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.
-theorem toBasicOpen_injective (f : R) : Function.Injective (toBasicOpen R f) := by
+theorem toBasicOpenₗ_injective (f : R) : Function.Injective (toBasicOpenₗ R M f) := by
   intro s t h_eq
-  obtain ⟨a, ⟨b, hb⟩, rfl⟩ := IsLocalization.exists_mk'_eq (Submonoid.powers f) s
-  obtain ⟨c, ⟨d, hd⟩, rfl⟩ := IsLocalization.exists_mk'_eq (Submonoid.powers f) t
-  simp only [toBasicOpen_mk'] at h_eq
-  rw [IsLocalization.eq]
-  -- We know that the fractions `a/b` and `c/d` are equal as sections of the structure sheaf on
-  -- `basicOpen f`. We need to show that they agree as elements in the localization of `R` at `f`.
-  -- This amounts showing that `r * (d * a) = r * (b * c)`, for some power `r = f ^ n` of `f`.
-  -- We define `I` as the ideal of *all* elements `r` satisfying the above equation.
-  let I : Ideal R :=
-    { carrier := { r : R | r * (d * a) = r * (b * c) }
-      zero_mem' := by simp only [Set.mem_setOf_eq, zero_mul]
-      add_mem' := fun {r₁ r₂} hr₁ hr₂ => by dsimp at hr₁ hr₂ ⊢; simp only [add_mul, hr₁, hr₂]
-      smul_mem' := fun {r₁ r₂} hr₂ => by dsimp at hr₂ ⊢; simp only [mul_assoc, hr₂] }
-  -- Our claim now reduces to showing that `f` is contained in the radical of `I`
-  suffices f ∈ I.radical by
+  induction s using LocalizedModule.induction_on with | h a b =>
+  induction t using LocalizedModule.induction_on with | h c d =>
+  suffices f ∈ ((⊥ : Submodule R M).colon {d • a - b • c}).radical by
+    rw [LocalizedModule.mk_eq]
     obtain ⟨n, hn⟩ := this
-    exact ⟨⟨f ^ n, n, rfl⟩, hn⟩
+    exact ⟨⟨f ^ n, n, rfl⟩, by simpa [sub_eq_zero, smul_sub] using Submodule.mem_colon.mp hn _ rfl⟩
+  simp only [toBasicOpenₗ_mk] at h_eq
   rw [← PrimeSpectrum.vanishingIdeal_zeroLocus_eq_radical, PrimeSpectrum.mem_vanishingIdeal]
   intro p hfp
   contrapose hfp
+  obtain ⟨u, hu⟩ := LocalizedModule.mk_eq.mp congr(($h_eq).1 ⟨p, hfp⟩)
   rw [PrimeSpectrum.mem_zeroLocus, Set.not_subset]
-  have := congr_fun (congr_arg Subtype.val h_eq) ⟨p, hfp⟩
-  dsimp at this
-  rw [IsLocalization.eq (S := Localization.AtPrime p.asIdeal)] at this
-  obtain ⟨r, hr⟩ := this
-  exact ⟨r.1, hr, r.2⟩
-
-/-
-Auxiliary lemma for surjectivity of `toBasicOpen`.
-Every section can locally be represented on basic opens `basicOpen g` as a fraction `f/g`
--/
-theorem locally_const_basicOpen (U : Opens (PrimeSpectrum.Top R))
-    (s : (structureSheaf R).1.obj (op U)) (x : U) :
-    ∃ (f g : R) (i : PrimeSpectrum.basicOpen g ⟶ U), x.1 ∈ PrimeSpectrum.basicOpen g ∧
-      (const R f g (PrimeSpectrum.basicOpen g) fun _ hy => hy) =
-      (structureSheaf R).1.map i.op s := by
-  -- First, any section `s` can be represented as a fraction `f/g` on some open neighborhood of `x`
-  -- and we may pass to a `basicOpen h`, since these form a basis
-  obtain ⟨V, hxV : x.1 ∈ V.1, iVU, f, g, hVDg : V ≤ PrimeSpectrum.basicOpen g, s_eq⟩ :=
-    exists_const R U s x.1 x.2
-  obtain ⟨_, ⟨h, rfl⟩, hxDh, hDhV : PrimeSpectrum.basicOpen h ≤ V⟩ :=
-    PrimeSpectrum.isTopologicalBasis_basic_opens.exists_subset_of_mem_open hxV V.2
-  -- The problem is of course, that `g` and `h` don't need to coincide.
-  -- But, since `basicOpen h ≤ basicOpen g`, some power of `h` must be a multiple of `g`
-  obtain ⟨n, hn⟩ := (PrimeSpectrum.basicOpen_le_basicOpen_iff h g).mp (Set.Subset.trans hDhV hVDg)
-  -- Actually, we will need a *nonzero* power of `h`.
-  -- This is because we will need the equality `basicOpen (h ^ n) = basicOpen h`, which only
-  -- holds for a nonzero power `n`. We therefore artificially increase `n` by one.
-  replace hn := Ideal.mul_mem_right h (Ideal.span {g}) hn
-  rw [← pow_succ, Ideal.mem_span_singleton'] at hn
-  obtain ⟨c, hc⟩ := hn
-  have basic_opens_eq := PrimeSpectrum.basicOpen_pow h (n + 1) (by lia)
-  have i_basic_open := eqToHom basic_opens_eq ≫ homOfLE hDhV
-  -- We claim that `(f * c) / h ^ (n + 1)` is our desired representation
-  use f * c, h ^ (n + 1), i_basic_open ≫ iVU, (basic_opens_eq.symm.le :) hxDh
-  rw [op_comp, Functor.map_comp, ConcreteCategory.comp_apply, ← s_eq, res_const]
-  -- Note that the last rewrite here generated an additional goal, which was a parameter
-  -- of `res_const`. We prove this goal first
-  swap
-  · intro y hy
-    rw [basic_opens_eq] at hy
-    exact (Set.Subset.trans hDhV hVDg :) hy
-  -- All that is left is a simple calculation
-  apply const_ext
-  rw [mul_assoc f c g, hc]
+  exact ⟨u.1, by simpa [sub_eq_zero, smul_sub], u.2⟩
 
 /-
 Auxiliary lemma for surjectivity of `toBasicOpen`.
 A local representation of a section `s` as fractions `a i / h i` on finitely many basic opens
 `basicOpen (h i)` can be "normalized" in such a way that `a i * h j = h i * a j` for all `i, j`
 -/
-theorem normalize_finite_fraction_representation (U : Opens (PrimeSpectrum.Top R))
-    (s : (structureSheaf R).1.obj (op U)) {ι : Type*} (t : Finset ι) (a h : ι → R)
-    (iDh : ∀ i : ι, PrimeSpectrum.basicOpen (h i) ⟶ U)
-    (h_cover : U ≤ ⨆ i ∈ t, PrimeSpectrum.basicOpen (h i))
-    (hs :
-      ∀ i : ι,
-        (const R (a i) (h i) (PrimeSpectrum.basicOpen (h i)) fun _ hy => hy) =
-          (structureSheaf R).1.map (iDh i).op s) :
-    ∃ (a' h' : ι → R) (iDh' : ∀ i : ι, PrimeSpectrum.basicOpen (h' i) ⟶ U),
-      (U ≤ ⨆ i ∈ t, PrimeSpectrum.basicOpen (h' i)) ∧
-        (∀ (i) (_ : i ∈ t) (j) (_ : j ∈ t), a' i * h' j = h' i * a' j) ∧
-          ∀ i ∈ t,
-            (structureSheaf R).1.map (iDh' i).op s =
-              const R (a' i) (h' i) (PrimeSpectrum.basicOpen (h' i)) fun _ hy => hy := by
-  -- First we show that the fractions `(a i * h j) / (h i * h j)` and `(h i * a j) / (h i * h j)`
-  -- coincide in the localization of `R` at `h i * h j`
-  have fractions_eq :
-    ∀ i j : ι,
-      IsLocalization.mk' (Localization.Away (h i * h j))
-        (a i * h j) ⟨h i * h j, Submonoid.mem_powers _⟩ =
-      IsLocalization.mk' _ (h i * a j) ⟨h i * h j, Submonoid.mem_powers _⟩ := by
-    intro i j
-    let D := PrimeSpectrum.basicOpen (h i * h j)
-    let iDi : D ⟶ PrimeSpectrum.basicOpen (h i) := homOfLE (PrimeSpectrum.basicOpen_mul_le_left _ _)
-    let iDj : D ⟶ PrimeSpectrum.basicOpen (h j) :=
-      homOfLE (PrimeSpectrum.basicOpen_mul_le_right _ _)
-    -- Crucially, we need injectivity of `toBasicOpen`
-    apply toBasicOpen_injective R (h i * h j)
-    rw [toBasicOpen_mk', toBasicOpen_mk']
-    simp only []
-    -- Here, both sides of the equation are equal to a restriction of `s`
-    trans
-    on_goal 1 =>
-      convert congr_arg ((structureSheaf R).1.map iDj.op) (hs j).symm using 1
-      convert congr_arg ((structureSheaf R).1.map iDi.op) (hs i) using 1
-    all_goals rw [res_const]; apply const_ext; ring
-    -- The remaining two goals were generated during the rewrite of `res_const`
-    -- These can be solved immediately
-    exacts [PrimeSpectrum.basicOpen_mul_le_left _ _, PrimeSpectrum.basicOpen_mul_le_right _ _]
-  -- From the equality in the localization, we obtain for each `(i,j)` some power `(h i * h j) ^ n`
-  -- which equalizes `a i * h j` and `h i * a j`
-  have exists_power :
-    ∀ i j : ι, ∃ n : ℕ, a i * h j * (h i * h j) ^ n = h i * a j * (h i * h j) ^ n := by
-    intro i j
-    obtain ⟨⟨c, n, rfl⟩, hc⟩ := IsLocalization.eq.mp (fractions_eq i j)
-    use n + 1
-    rw [pow_succ]
-    dsimp at hc
-    convert hc using 1 <;> ring
-  let n := fun p : ι × ι => (exists_power p.1 p.2).choose
-  have n_spec := fun p : ι × ι => (exists_power p.fst p.snd).choose_spec
-  -- We need one power `(h i * h j) ^ N` that works for *all* pairs `(i,j)`
-  -- Since there are only finitely many indices involved, we can pick the supremum.
-  let N := (t ×ˢ t).sup n
-  have basic_opens_eq : ∀ i : ι, PrimeSpectrum.basicOpen (h i ^ (N + 1)) =
-    PrimeSpectrum.basicOpen (h i) := fun i => PrimeSpectrum.basicOpen_pow _ _ (by lia)
-  -- Expanding the fraction `a i / h i` by the power `(h i) ^ n` gives the desired normalization
-  refine
-    ⟨fun i => a i * h i ^ N, fun i => h i ^ (N + 1), fun i => eqToHom (basic_opens_eq i) ≫ iDh i,
-      ?_, ?_, ?_⟩
-  · simpa only [basic_opens_eq] using h_cover
-  · intro i hi j hj
-    -- Here we need to show that our new fractions `a i / h i` satisfy the normalization condition
-    -- Of course, the power `N` we used to expand the fractions might be bigger than the power
-    -- `n (i, j)` which was originally chosen. We denote their difference by `k`
-    have n_le_N : n (i, j) ≤ N := Finset.le_sup (Finset.mem_product.mpr ⟨hi, hj⟩)
-    obtain ⟨k, hk⟩ := Nat.le.dest n_le_N
-    simp only [← hk, pow_add, pow_one]
-    -- To accommodate for the difference `k`, we multiply both sides of the equation `n_spec (i, j)`
-    -- by `(h i * h j) ^ k`
-    convert congr_arg (fun z => z * (h i * h j) ^ k) (n_spec (i, j)) using 1 <;>
-      · simp only [n, mul_pow]; ring
-  -- Lastly, we need to show that the new fractions still represent our original `s`
-  intro i _
-  rw [op_comp, Functor.map_comp, ConcreteCategory.comp_apply, ← hs, res_const]
-  -- additional goal spit out by `res_const`
-  swap
-  · exact (basic_opens_eq i).le
-  apply const_ext
-  dsimp
-  rw [pow_succ]
-  ring
+theorem exists_le_iSup_basicOpen_and_smul_eq_smul_and_eq_const
+    (U : Opens (PrimeSpectrum.Top R)) (hU : IsCompact (U : Set (PrimeSpectrum.Top R)))
+    (s : Γ(M, U)) :
+    ∃ (ι : Type u) (_ : Fintype ι) (a : ι → M) (b : ι → R) (ibU : ∀ i, basicOpen (b i) ≤ U),
+      (U ≤ ⨆ i, basicOpen (b i)) ∧ (∀ i j, b j • a i = b i • a j) ∧
+          ∀ i, (structureSheafInType R M).presheaf.map (ibU i).hom.op s =
+              const (a i) (b i) _ le_rfl := by
+  choose g hxg igU f H using fun x : U ↦ exists_const U s x.1 x.2
+  have (i j : _) : LocalizedModule.mk (g i • f j) ⟨g i * g j, Submonoid.mem_powers _⟩ =
+      LocalizedModule.mk (g j • f i) ⟨g i * g j, Submonoid.mem_powers _⟩ := by
+    refine toBasicOpenₗ_injective (g i * g j) ?_
+    simp only [toBasicOpenₗ_mk]
+    have := H i
+    trans (structureSheafInType R M).val.map (homOfLE ?_).op s
+    · refine .trans (Subtype.ext <| funext fun a ↦ ?_) congr((structureSheafInType R M).val.map
+        (homOfLE ((PrimeSpectrum.basicOpen_mul (g i) (g j)).trans_le inf_le_right)).op $(H j))
+      exact LocalizedModule.mk_eq.mpr ⟨1, by simp [Submonoid.smul_def, ← smul_assoc]; ring_nf⟩
+    · refine congr((structureSheafInType R M).val.map (homOfLE ((PrimeSpectrum.basicOpen_mul (g i)
+        (g j)).trans_le inf_le_left)).op $(H i)).symm.trans (Subtype.ext <| funext fun a ↦ ?_)
+      exact LocalizedModule.mk_eq.mpr ⟨1, by simp [Submonoid.smul_def, ← smul_assoc]⟩
+    · exact ((PrimeSpectrum.basicOpen_mul (g i) (g j)).trans_le inf_le_right).trans (igU _)
+  simp only [LocalizedModule.mk_eq, Submonoid.smul_def, Subtype.exists, Submonoid.mem_powers_iff,
+    exists_prop, exists_exists_eq_and, ← mul_smul, ← pow_succ, ← mul_assoc _ (_ * _)] at this
+  choose n hn using this
+  obtain ⟨t, ht⟩ := hU.elim_finite_subcover (fun i ↦ (basicOpen (g i) : Set (PrimeSpectrum R)))
+    (fun _ ↦ (basicOpen _).2) (fun x hx ↦ Set.mem_iUnion_of_mem ⟨x, hx⟩ (hxg _))
+  let N := (t ×ˢ t).sup fun x ↦ n x.1 x.2 + 1
+  refine ⟨t, inferInstance, fun i ↦ g i ^ N • f i, fun i ↦ (g i) ^ (N + 1),
+    fun x ↦ by simpa using igU x.1, fun x hx ↦ by simpa using ht hx, fun i j ↦ ?_, fun i ↦ ?_⟩
+  · dsimp
+    convert_to (g i * g ↑j) ^ N • g j • f i = (g i * g ↑j) ^ N • g i • f j
+    · module
+    · module
+    have : n i j + 1 ≤ N := (t ×ˢ t).le_sup (f := fun x ↦ n x.1 x.2 + 1) (b := ⟨_, _⟩) (by simp)
+    rw [← Nat.sub_add_cancel this, pow_add, mul_smul, mul_smul]
+    congr 1
+    convert (hn i j).symm using 1 <;> module
+  · convert congr((structureSheafInType R M).presheaf.map (homOfLE ?_).op $((H i).symm)) using 1
+    · refine Subtype.ext <| funext fun x ↦ LocalizedModule.mk_eq.mpr ⟨1, ?_⟩
+      simp [Submonoid.smul_def, pow_succ', mul_smul]
+    · simp
 
--- The proof here follows the argument in Hartshorne's Algebraic Geometry, Proposition II.2.2.
-theorem toBasicOpen_surjective (f : R) : Function.Surjective (toBasicOpen R f) := by
+theorem toBasicOpenₗ_surjective (f : R) : Function.Surjective (toBasicOpenₗ R M f) := by
   intro s
-  -- In this proof, `basicOpen f` will play two distinct roles: Firstly, it is an open set in the
-  -- prime spectrum. Secondly, it is used as an indexing type for various families of objects
-  -- (open sets, ring elements, ...). In order to make the distinction clear, we introduce a type
-  -- alias `ι` that is used whenever we want think of it as an indexing type.
-  let ι : Type u := PrimeSpectrum.basicOpen f
-  -- First, we pick some cover of basic opens, on which we can represent `s` as a fraction
-  choose a' h' iDh' hxDh' s_eq' using locally_const_basicOpen R (PrimeSpectrum.basicOpen f) s
-  -- Since basic opens are compact, we can pass to a finite subcover
-  obtain ⟨t, ht_cover'⟩ :=
-    (PrimeSpectrum.isCompact_basicOpen f).elim_finite_subcover
-      (fun i : ι => PrimeSpectrum.basicOpen (h' i)) (fun i => PrimeSpectrum.isOpen_basicOpen)
-      -- Here, we need to show that our basic opens actually form a cover of `basicOpen f`
-      fun x hx => by rw [Set.mem_iUnion]; exact ⟨⟨x, hx⟩, hxDh' ⟨x, hx⟩⟩
-  simp only [← Opens.coe_iSup, SetLike.coe_subset_coe] at ht_cover'
-  -- We use the normalization lemma from above to obtain the relation `a i * h j = h i * a j`
-  obtain ⟨a, h, iDh, ht_cover, ah_ha, s_eq⟩ :=
-    normalize_finite_fraction_representation R (PrimeSpectrum.basicOpen f)
-      s t a' h' iDh' ht_cover' s_eq'
-  clear s_eq' iDh' hxDh' ht_cover' a' h'
-  simp only [← SetLike.coe_subset_coe, Opens.coe_iSup] at ht_cover
-  replace ht_cover : (PrimeSpectrum.basicOpen f : Set <| PrimeSpectrum R) ⊆
-      ⋃ (i : ι) (x : i ∈ t), (PrimeSpectrum.basicOpen (h i) : Set _) := ht_cover
-  -- Next we show that some power of `f` is a linear combination of the `h i`
-  obtain ⟨n, hn⟩ : f ∈ (Ideal.span (h '' ↑t)).radical := by
-    rw [← PrimeSpectrum.vanishingIdeal_zeroLocus_eq_radical, PrimeSpectrum.zeroLocus_span]
-    simp only [PrimeSpectrum.basicOpen_eq_zeroLocus_compl] at ht_cover
-    replace ht_cover : (PrimeSpectrum.zeroLocus {f})ᶜ ⊆
-        ⋃ (i : ι) (x : i ∈ t), (PrimeSpectrum.zeroLocus {h i})ᶜ := ht_cover
-    rw [Set.compl_subset_comm] at ht_cover
-    -- Why doesn't `simp_rw` do this?
-    simp_rw [Set.compl_iUnion, compl_compl, ← PrimeSpectrum.zeroLocus_iUnion,
-      ← Finset.set_biUnion_coe, ← Set.image_eq_iUnion] at ht_cover
-    apply PrimeSpectrum.vanishingIdeal_anti_mono ht_cover
-    exact PrimeSpectrum.subset_vanishingIdeal_zeroLocus {f} (Set.mem_singleton f)
+  obtain ⟨ι, _, a, b, ibU, iU, hab, H⟩ := exists_le_iSup_basicOpen_and_smul_eq_smul_and_eq_const _
+    (PrimeSpectrum.isCompact_basicOpen _) s
+  obtain ⟨n, hn⟩ : f ∈ (Ideal.span (Set.range b)).radical := by
+    have : PrimeSpectrum.zeroLocus (Set.range b) ⊆ PrimeSpectrum.zeroLocus {f} := by
+      simpa [← SetLike.coe_subset_coe, ← Set.compl_iInter,
+        ← PrimeSpectrum.zeroLocus_iUnion, PrimeSpectrum.Top] using iU
+    rw [← PrimeSpectrum.vanishingIdeal_zeroLocus_eq_radical, PrimeSpectrum.zeroLocus_span,
+      PrimeSpectrum.mem_vanishingIdeal]
+    exact fun x hx ↦ by simpa using this hx
   replace hn := Ideal.mul_mem_right f _ hn
-  rw [← pow_succ, Ideal.span, Finsupp.mem_span_image_iff_linearCombination] at hn
-  rcases hn with ⟨b, b_supp, hb⟩
-  rw [Finsupp.linearCombination_apply_of_mem_supported R b_supp] at hb
-  dsimp at hb
-  -- Finally, we have all the ingredients.
-  -- We claim that our preimage is given by `(∑ (i : ι) ∈ t, b i * a i) / f ^ (n + 1)`
-  use
-    IsLocalization.mk' (Localization.Away f) (∑ i ∈ t, b i * a i)
-      (⟨f ^ (n + 1), n + 1, rfl⟩ : Submonoid.powers _)
-  rw [toBasicOpen_mk']
-  -- Since the structure sheaf is a sheaf, we can show the desired equality locally.
-  -- Annoyingly, `Sheaf.eq_of_locally_eq'` requires an open cover indexed by a *type*, so we need to
-  -- coerce our finset `t` to a type first.
-  let tt := ((t : Set (PrimeSpectrum.basicOpen f)) : Type u)
-  apply
-    (structureSheaf R).eq_of_locally_eq' (fun i : tt => PrimeSpectrum.basicOpen (h i))
-      (PrimeSpectrum.basicOpen f) fun i : tt => iDh i
-  · -- This feels a little redundant, since already have `ht_cover` as a hypothesis
-    -- Unfortunately, `ht_cover` uses a bounded union over the set `t`, while here we have the
-    -- Union indexed by the type `tt`, so we need some boilerplate to translate one to the other
-    intro x hx
-    rw [TopologicalSpace.Opens.mem_iSup]
-    have := ht_cover hx
-    rw [← Finset.set_biUnion_coe, Set.mem_iUnion₂] at this
-    rcases this with ⟨i, i_mem, x_mem⟩
-    exact ⟨⟨i, i_mem⟩, x_mem⟩
-  rintro ⟨i, hi⟩
-  dsimp
-  change (structureSheaf R).1.map (iDh i).op _ = (structureSheaf R).1.map (iDh i).op _
-  rw [s_eq i hi, res_const]
-  -- Again, `res_const` spits out an additional goal
-  swap
-  · intro y hy
-    change y ∈ PrimeSpectrum.basicOpen (f ^ (n + 1))
-    rw [PrimeSpectrum.basicOpen_pow f (n + 1) (by lia)]
-    exact (leOfHom (iDh i) :) hy
-  -- The rest of the proof is just computation
-  apply const_ext
-  rw [← hb, Finset.sum_mul, Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro j hj
-  rw [mul_assoc, ah_ha j hj i hi]
-  ring
+  rw [← pow_succ, Ideal.span, Finsupp.mem_span_range_iff_exists_finsupp] at hn
+  obtain ⟨c, hc⟩ := hn
+  rw [Finsupp.sum_fintype _ _ (by simp)] at hc
+  refine ⟨LocalizedModule.mk (∑ i, c i • a i) ⟨f ^ (n + 1), _, rfl⟩, ?_⟩
+  refine (structureSheafInType R M).eq_of_locally_eq' (fun i ↦ basicOpen (b i)) _
+    (fun i ↦ (ibU _).hom) iU _ _ fun i ↦ (Subtype.ext (funext fun x ↦ ?_)).trans (H _).symm
+  rw [toBasicOpenₗ_mk]
+  refine LocalizedModule.mk_eq.mpr ⟨1, ?_⟩
+  simp_rw [one_smul, Finset.smul_sum, Submonoid.smul_def, smul_comm (b i), hab _ i, ← smul_assoc,
+    ← Finset.sum_smul, hc]
+
+public instance (f : R) : IsLocalizedModule (.powers f) (toOpenₗ R M (basicOpen f)) := by
+  convert IsLocalizedModule.of_linearEquiv (.powers f) (LocalizedModule.mkLinearMap (.powers f) M)
+    (.ofBijective _ ⟨toBasicOpenₗ_injective _, toBasicOpenₗ_surjective _⟩)
+  ext x
+  simp [toOpenₗ]
 
 instance isIso_toBasicOpen (f : R) :
-    IsIso (CommRingCat.ofHom (toBasicOpen R f)) :=
-  haveI : IsIso ((forget CommRingCat).map (CommRingCat.ofHom (toBasicOpen R f))) :=
-    (isIso_iff_bijective _).mpr ⟨toBasicOpen_injective R f, toBasicOpen_surjective R f⟩
-  isIso_of_reflects_iso _ (forget CommRingCat)
+    IsIso (ModuleCat.ofHom (toBasicOpenₗ R M f)) :=
+  (ConcreteCategory.isIso_iff_bijective _).mpr ⟨toBasicOpenₗ_injective _, toBasicOpenₗ_surjective _⟩
 
-/-- The ring isomorphism between the structure sheaf on `basicOpen f` and the localization of `R`
-at the submonoid of powers of `f`. -/
-def basicOpenIso (f : R) :
-    (structureSheaf R).1.obj (op (PrimeSpectrum.basicOpen f)) ≅
-    CommRingCat.of (Localization.Away f) :=
-  (asIso (CommRingCat.ofHom (toBasicOpen R f))).symm
+public lemma toOpenₗ_top_bijective : Function.Bijective (toOpenₗ R M ⊤) := by
+  have : IsLocalizedModule ⊥ (toOpenₗ R M ⊤) := by
+    convert inferInstanceAs (IsLocalizedModule (.powers 1) (toOpenₗ R M (basicOpen 1)))
+    rw [PrimeSpectrum.basicOpen_one, Submonoid.powers_one]
+  refine ⟨fun x y e ↦ by simpa using (IsLocalizedModule.eq_iff_exists ⊥ _).mp e, fun x ↦ ?_⟩
+  obtain ⟨⟨x, _, rfl⟩, rfl⟩ := IsLocalizedModule.mk'_surjective ⊥ (toOpenₗ R M ⊤) x
+  exact ⟨x, (IsLocalizedModule.mk'_one ..).symm⟩
+
+public lemma algebraMap_obj_top_bijective :
+    Function.Bijective (algebraMap R Γ(R, (⊤ : Opens (PrimeSpectrum.Top R)))) :=
+  toOpenₗ_top_bijective
+
+public instance (f : R) : IsLocalization.Away f Γ(R, basicOpen f) :=
+  (isLocalizedModule_iff_isLocalization' _ _).mp <|
+    inferInstanceAs (IsLocalizedModule (.powers f) (toOpenₗ R R (basicOpen f)))
+
+end basicOpen
+
+section Stalk
+
+variable (R) in
+/-- The canonical ring homomorphism interpreting an element of `R` as an element of
+the stalk of `structureSheaf R` at `x`. -/
+@[expose] public def toStalk (x : PrimeSpectrum.Top R) :
+    CommRingCat.of R ⟶ (structurePresheafInCommRingCat R).stalk x :=
+  CommRingCat.ofHom (algebraMap _ _) ≫ (structurePresheafInCommRingCat R).germ ⊤ x trivial
+
+@[elementwise, reassoc]
+public lemma algebraMap_germ
+    (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hxU : x ∈ U) :
+    CommRingCat.ofHom (algebraMap R Γ(R, U)) ≫ (structurePresheafInCommRingCat R).germ U x hxU =
+      toStalk R x := by
+  dsimp [toStalk]
+  rw [← (structurePresheafInCommRingCat R).germ_res (homOfLE (le_top : U ≤ ⊤)) _ hxU]
+  rfl
+
+@[deprecated (since := "2026-02-10")] public alias toOpen_germ := algebraMap_germ
+
+@[expose] public
+instance (x : PrimeSpectrum.Top R) : Algebra R ((structurePresheafInCommRingCat R).stalk x) :=
+  (toStalk R x).hom.toAlgebra
+
+@[expose] public
+instance (x : PrimeSpectrum.Top R) :
+    Module R ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x) :=
+  .compHom _ (toStalk R x).hom
+
+variable (M) in
+def germₗ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hxU : x ∈ U) :
+    Γ(M, U) →ₗ[R] ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x) where
+  __ := (TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf U x hxU).hom
+  map_smul' r m := by
+    change _ = toStalk R x _ • TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf _ _ _ _
+    rw [← algebraMap_germ_apply U x hxU]
+    refine .trans ?_ (PresheafOfModules.germ_smul ..)
+    congr 1
+    exact (IsScalarTower.algebraMap_smul Γ(R, U) r m).symm
+
+public
+instance (x : PrimeSpectrum.Top R) :
+    IsScalarTower R ((structurePresheafInCommRingCat R).stalk x)
+      ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x) :=
+  .of_algebraMap_smul fun _ _ ↦ rfl
+
+variable (R M) in
+def modulePresheafStalkIso (x : PrimeSpectrum.Top R) :
+    ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x) ≃ₗ[R]
+      (structurePresheafInModuleCat R M).stalk x where
+  __ := (Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves (forget₂ (ModuleCat R) Ab)
+    (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+      structurePresheafInModuleCat R M))⟩:).addCommGroupIsoToAddEquiv
+  map_smul' r m := by
+    let α : TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x ≅
+      (forget₂ _ _).obj ((structurePresheafInModuleCat R M).stalk x) :=
+      Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves (forget₂ (ModuleCat R) Ab)
+      (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+        structurePresheafInModuleCat R M))⟩
+    obtain ⟨U, hxU, s, rfl⟩ := TopCat.Presheaf.germ_exist _ _ m
+    have : TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf U x hxU ≫ α.hom =
+        (forget₂ _ _).map ((structurePresheafInModuleCat R M).germ U x hxU) :=
+      Limits.colimit.isoColimitCocone_ι_hom (C := Ab) ..
+    have (m : _) : α.hom (TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf U x hxU m) =
+        (structurePresheafInModuleCat R M).germ U x hxU m := congr($this m)
+    change α.hom (r • germₗ M U x hxU _) =
+      r • (show (structurePresheafInModuleCat R M).stalk x from _)
+    rw [← map_smul]
+    refine (this _).trans ?_
+    dsimp [toStalk]
+    erw [this]
+    exact ((structurePresheafInModuleCat R M).germ U x hxU).hom.map_smul _ _
+
+instance (x : PrimeSpectrum.Top R) :
+    Module ((structurePresheafInCommRingCat R).stalk x)
+      ((structurePresheafInModuleCat R M).stalk x) :=
+  (modulePresheafStalkIso R M x).toAddEquiv.symm.module _
+
+lemma toStalk_smul (x : PrimeSpectrum.Top R) (r : R)
+    (m : (structurePresheafInModuleCat R M).stalk x) :
+    toStalk R x r • m = r • m := by
+  change modulePresheafStalkIso R M x (toStalk R x r • (modulePresheafStalkIso R M x).symm m) = _
+  rw [← (modulePresheafStalkIso R M x).eq_symm_apply, map_smul]
+  rfl
+
+variable (R M) in
+/-- The canonical ring homomorphism interpreting an element of `R` as an element of
+the stalk of `structureSheaf R` at `x`. -/
+def toStalkₗ' (x : PrimeSpectrum.Top R) :
+    ModuleCat.of R M ⟶ (structurePresheafInModuleCat R M).stalk x :=
+  ModuleCat.ofHom (toOpenₗ R M ⊤) ≫ (structurePresheafInModuleCat R M).germ _ x trivial
+
+@[simp]
+theorem toOpenₗ_germ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
+    ModuleCat.ofHom (toOpenₗ R M U) ≫
+      (structurePresheafInModuleCat R M).germ U x hx = toStalkₗ' R M x := by
+  rw [toStalkₗ', ← Presheaf.germ_res _ (homOfLE le_top) _ hx, ← Category.assoc]
+  rfl
+
+theorem isUnit_toStalk (x : PrimeSpectrum.Top R) (f : R) (hf : x ∈ basicOpen f) :
+    IsUnit (toStalk R x f) := by
+  convert (isUnit_toBasicOpen f).map ((structurePresheafInCommRingCat R).germ _ x hf).hom
+  exact ((structurePresheafInCommRingCat R).germ_res_apply (homOfLE (le_top : basicOpen f ≤ ⊤))
+    x hf (algebraMap R Γ(R, ⊤) f)).symm
+
+theorem isUnit_toStalkₗ' (x : PrimeSpectrum.Top R) (f : R) (hf : x ∈ basicOpen f) :
+    IsUnit (algebraMap R (Module.End R ((structurePresheafInModuleCat R M).stalk x)) f) := by
+  have := (isUnit_toStalk x f hf).map (algebraMap _
+    (Module.End ((structurePresheafInCommRingCat R).stalk x)
+      ((structurePresheafInModuleCat R M).stalk x)))
+  rw [Module.End.isUnit_iff] at this ⊢
+  convert this
+  ext a
+  simp only [Module.algebraMap_end_apply]
+  rw [toStalk_smul]
+
+variable (R M) in
+/-- The canonical ring homomorphism from the localization of `R` at `p` to the stalk
+of the structure sheaf at the point `p`. -/
+def localizationtoStalkₗ (x : PrimeSpectrum.Top R) :
+    ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M) ⟶
+      (structurePresheafInModuleCat R M).stalk x :=
+  ModuleCat.ofHom (IsLocalizedModule.lift x.asIdeal.primeCompl
+    (LocalizedModule.mkLinearMap x.asIdeal.primeCompl M)
+    (toStalkₗ' R M x).hom fun f ↦ isUnit_toStalkₗ' x f.1 f.2:)
+
+@[simp]
+theorem localizationtoStalkₗ_mk (x : PrimeSpectrum.Top R) (f : M) (s) :
+    localizationtoStalkₗ R M x (.mk f s) = (structurePresheafInModuleCat R M).germ
+      (PrimeSpectrum.basicOpen (s : R)) x s.2 (const f (s : R) _ fun _ ↦ id) := by
+  apply ((Module.End.isUnit_iff _).mp (isUnit_toStalkₗ' _ s.1 s.2)).1 ?_
+  dsimp [localizationtoStalkₗ]
+  rw [← map_smul, LocalizedModule.smul'_mk, ← Submonoid.smul_def, LocalizedModule.mk_cancel,
+    ← LocalizedModule.mkLinearMap_apply, IsLocalizedModule.lift_apply, ← map_smul,
+    ← toOpenₗ_germ (basicOpen ↑s) _ s.2, smul_const]
+  dsimp [toOpenₗ]
+  congr 1
+  exact const_eq_const_of_smul_eq_smul (H := by simp) ..
+
+variable (R M) in
+/-- The ring homomorphism that takes a section of the structure sheaf of `R` on the open set `U`,
+implemented as a subtype of dependent functions to localizations at prime ideals, and evaluates
+the section on the point corresponding to a given prime ideal. -/
+def openToLocalizationₗ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
+    (structurePresheafInModuleCat R M).obj (op U) ⟶
+      .of R (LocalizedModule x.asIdeal.primeCompl M) :=
+  ModuleCat.ofHom
+  { toFun s := s.1 ⟨x, hx⟩
+    map_smul' _ _ := rfl
+    map_add' _ _ := rfl }
+
+variable (R M) in
+/-- The ring homomorphism from the stalk of the structure sheaf of `R` at a point corresponding to
+a prime ideal `p` to the localization of `R` at `p`,
+formed by gluing the `openToLocalization` maps. -/
+def stalkToLocalizationₗ (x : PrimeSpectrum.Top R) :
+    (structurePresheafInModuleCat R M).stalk x ⟶ .of R (LocalizedModule x.asIdeal.primeCompl M) :=
+  Limits.colimit.desc ((OpenNhds.inclusion x).op ⋙ structurePresheafInModuleCat R M)
+    { pt := _
+      ι.app U := openToLocalizationₗ R M ((OpenNhds.inclusion _).obj (unop U)) x (unop U).2 }
+
+@[reassoc (attr := simp)]
+theorem germ_stalkToLocalizationₗ
+    (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top R) (hx : x ∈ U) :
+    (structurePresheafInModuleCat R M).germ U x hx ≫ stalkToLocalizationₗ R M x =
+      openToLocalizationₗ R M U x hx :=
+  Limits.colimit.ι_desc _ _
+
+@[simp]
+theorem toStalkₗ'_stalkToFiberRingHom (x : PrimeSpectrum.Top R) :
+    toStalkₗ' R M x ≫ stalkToLocalizationₗ R M x =
+      ModuleCat.ofHom (LocalizedModule.mkLinearMap _ _) := by
+  rw [toStalkₗ', Category.assoc, germ_stalkToLocalizationₗ]; rfl
+
+open TopCat.Presheaf
+
+variable (R M) in
+/-- The ring isomorphism between the stalk of the structure sheaf of `R` at a point `p`
+corresponding to a prime ideal in `R` and the localization of `R` at `p`. -/
+@[simps]
+def stalkIsoₗ (x : PrimeSpectrum.Top R) :
+    (structurePresheafInModuleCat R M).stalk x ≅
+      .of R (LocalizedModule x.asIdeal.primeCompl M) where
+  hom := stalkToLocalizationₗ R M x
+  inv := localizationtoStalkₗ R M x
+  hom_inv_id := by
+    apply stalk_hom_ext
+    intro U hxU
+    ext s
+    obtain ⟨g, hxg, igU, f, hs⟩ :=
+      exists_const _ s x hxU
+    rw [germ_stalkToLocalizationₗ_assoc, Category.comp_id, ← germ_res_apply _ igU.hom _ hxg]
+    refine congr(localizationtoStalkₗ R M x (openToLocalizationₗ R M _ x hxg $hs)).symm.trans ?_
+    refine (localizationtoStalkₗ_mk ..).trans
+      congr((structurePresheafInModuleCat R M).germ _ x hxg $hs)
+  inv_hom_id := by
+    ext1
+    refine IsLocalizedModule.ext x.asIdeal.primeCompl (LocalizedModule.mkLinearMap ..)
+      (IsLocalizedModule.map_units (LocalizedModule.mkLinearMap ..)) ?_
+    ext
+    dsimp [localizationtoStalkₗ]
+    rw [← LocalizedModule.mkLinearMap_apply, IsLocalizedModule.lift_apply,
+      elementwise_of% toStalkₗ'_stalkToFiberRingHom (M := M) x]
+    simp
+
+instance (x : PrimeSpectrum R) : IsIso (stalkToLocalizationₗ R M x) :=
+  (stalkIsoₗ R M x).isIso_hom
+
+instance (x : PrimeSpectrum R) : IsIso (localizationtoStalkₗ R M x) :=
+  (stalkIsoₗ R M x).isIso_inv
+
+@[simp, reassoc]
+theorem stalkToFiberRingHom_localizationToStalk (x : PrimeSpectrum.Top R) :
+    stalkToLocalizationₗ R M x ≫ localizationtoStalkₗ R M x = 𝟙 _ :=
+  (stalkIsoₗ R M x).hom_inv_id
+
+@[simp, reassoc]
+theorem localizationToStalk_stalkToFiberRingHom (x : PrimeSpectrum.Top R) :
+    localizationtoStalkₗ R M x ≫ stalkToLocalizationₗ R M x = 𝟙 _ :=
+  (stalkIsoₗ R M x).inv_hom_id
+
+instance (x : PrimeSpectrum.Top R) :
+    IsLocalizedModule x.asIdeal.primeCompl (toStalkₗ' R M x).hom := by
+  convert IsLocalizedModule.of_linearEquiv x.asIdeal.primeCompl
+    (LocalizedModule.mkLinearMap x.asIdeal.primeCompl M) (stalkIsoₗ R M x).toLinearEquiv.symm
+  ext m
+  refine .trans ?_ (localizationtoStalkₗ_mk ..).symm
+  dsimp [toStalkₗ', toOpenₗ]
+  rw! [PrimeSpectrum.basicOpen_one]
+  rfl
+
+variable (R M) in
+/-- The canonical ring homomorphism interpreting an element of `R` as an element of
+the stalk of `structureSheaf R` at `x`. -/
+@[expose] public
+def toStalkₗ (x : PrimeSpectrum.Top R) :
+    M →ₗ[R] ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x) where
+  toFun m :=
+    TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf ⊤ x (by simp) (toOpenₗ R M ⊤ m)
+  map_add' := by simp
+  map_smul' r m := by
+    change _ = toStalk R x r • TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf _ _ _ _
+    rw [map_smul]
+    refine .trans ?_ ((moduleStructurePresheaf R M).germ_smul ..)
+    congr 1
+    exact (IsScalarTower.algebraMap_smul Γ(R, _) (M := Γ(M, _)) _ _).symm
+
+public
+instance (x : PrimeSpectrum.Top R) : IsLocalizedModule x.asIdeal.primeCompl (toStalkₗ R M x) := by
+  convert IsLocalizedModule.of_linearEquiv x.asIdeal.primeCompl
+    (toStalkₗ' R M x).hom (modulePresheafStalkIso R M x).symm
+  ext m
+  let α : TopCat.Presheaf.stalk (moduleStructurePresheaf R M).presheaf x ≅
+    (forget₂ _ _).obj ((structurePresheafInModuleCat R M).stalk x) :=
+    Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves (forget₂ (ModuleCat R) Ab)
+    (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+      structurePresheafInModuleCat R M))⟩
+  refine α.addCommGroupIsoToAddEquiv.eq_symm_apply.mpr ?_
+  change α.hom _ = _
+  have : TopCat.Presheaf.germ (moduleStructurePresheaf R M).presheaf ⊤ x (by simp) ≫ α.hom =
+      (forget₂ _ _).map ((structurePresheafInModuleCat R M).germ ⊤ x (by simp)) :=
+    Limits.colimit.isoColimitCocone_ι_hom (C := Ab) ..
+  exact congr($this _)
+
+-- move me
+public instance forget₂SemiRing_preservesFilteredColimits :
+    Limits.PreservesFilteredColimits (forget₂ RingCat AddCommGrpCat.{u}) where
+  preserves_filtered_colimits {J hJ1 _} :=
+    letI : Category J := hJ1
+    { preservesColimit := fun {F} =>
+        Limits.preservesColimit_of_preserves_colimit_cocone
+          (RingCat.FilteredColimits.colimitCoconeIsColimit.{u, u} F)
+          (AddCommGrpCat.FilteredColimits.colimitCoconeIsColimit
+            (F ⋙ forget₂ RingCat AddCommGrpCat.{u})) }
+
+variable (R) in
+/-- The stalk of `Spec R` at `x` is isomorphic to the stalk of `R^~` at `x`. -/
+@[expose] public
+def commRingCatStalkEquivModuleStalk (x : PrimeSpectrum.Top R) :
+    ↑(TopCat.Presheaf.stalk (moduleStructurePresheaf R R).presheaf x) ≃ₗ[R]
+      (structurePresheafInCommRingCat R).stalk x where
+  __ := (Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves
+      (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat)
+    (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+      structurePresheafInCommRingCat R))⟩).addCommGroupIsoToAddEquiv
+  map_smul' r m := by
+    let α : TopCat.Presheaf.stalk (moduleStructurePresheaf R R).presheaf x ≅
+      (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat).obj
+        ((structurePresheafInCommRingCat R).stalk x) :=
+      (Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves
+      (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat)
+      (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+        structurePresheafInCommRingCat R))⟩)
+    obtain ⟨U, hxU, s, rfl⟩ := TopCat.Presheaf.germ_exist _ _ m
+    have : (TopCat.Presheaf.germ (moduleStructurePresheaf R R).presheaf U x hxU) ≫ α.hom =
+        (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat).map
+          ((structurePresheafInCommRingCat R).germ U x hxU) :=
+      Limits.colimit.isoColimitCocone_ι_hom ..
+    change α.hom (r • germₗ R U x hxU _) = toStalk R _ _ * _
+    rw [← map_smul, Algebra.smul_def]
+    refine congr($this _).trans ?_
+    refine (((structurePresheafInCommRingCat R).germ U x hxU).hom.map_mul _ _).trans ?_
+    congr 1
+    · dsimp [toStalk]
+      erw [← (structurePresheafInCommRingCat R).germ_res_apply (homOfLE (le_top : U ≤ ⊤)) _ hxU]
+      rfl
+    · exact congr($this _).symm
+
+public instance (x : PrimeSpectrum.Top R) :
+    IsLocalization.AtPrime ((structurePresheafInCommRingCat R).stalk x) x.asIdeal := by
+  refine (isLocalizedModule_iff_isLocalization' _ _).mp ?_
+  convert IsLocalizedModule.of_linearEquiv x.asIdeal.primeCompl (toStalkₗ R R x)
+    (commRingCatStalkEquivModuleStalk R x)
+  let α : TopCat.Presheaf.stalk (moduleStructurePresheaf R R).presheaf x ≅
+    (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat).obj
+      ((structurePresheafInCommRingCat R).stalk x) :=
+    (Limits.colimit.isoColimitCocone ⟨_, Limits.isColimitOfPreserves
+    (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat)
+    (Limits.colimit.isColimit ((OpenNhds.inclusion x).op ⋙
+      structurePresheafInCommRingCat R))⟩)
+  have : (TopCat.Presheaf.germ (moduleStructurePresheaf R R).presheaf ⊤ x (by simp)) ≫ α.hom =
+      (forget₂ CommRingCat RingCat ⋙ forget₂ RingCat AddCommGrpCat).map
+        ((structurePresheafInCommRingCat R).germ ⊤ x (by simp)) :=
+    Limits.colimit.isoColimitCocone_ι_hom ..
+  ext
+  dsimp [toStalkₗ]
+  simp only [map_one]
+  refine .trans ?_ congr($this _).symm
+  exact (((structurePresheafInCommRingCat R).germ ⊤ x (by simp)).hom.comp
+    (algebraMap R Γ(R, _))).map_one.symm
+
+variable (R) in
+/-- The stalk of `Spec R` at `x` is isomorphic to `Rₚ`,
+where `p` is the prime corresponding to `x`. -/
+public abbrev stalkIso (x : PrimeSpectrum R) :
+    Localization.AtPrime x.asIdeal ≃ₐ[R] (structurePresheafInCommRingCat R).stalk x :=
+  IsLocalization.algEquiv x.asIdeal.primeCompl _ _
+
+end Stalk
+
+@[expose] public section StructureSheaf
+
+variable (R) in
+/-- The structure sheaf on $Spec R$, valued in `CommRingCat`.
+
+This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
+-/
+def Spec.structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R) :=
+  ⟨structurePresheafInCommRingCat R,
+    (TopCat.Presheaf.isSheaf_iff_isSheaf_comp _ _).mpr (TopCat.Presheaf.isSheaf_of_iso
+      (structurePresheafCompForget R).symm (structureSheafInType R R).cond)⟩
+
+open Spec (structureSheaf)
+
+/-- The canonical ring homomorphism interpreting an element of `R` as
+a section of the structure sheaf. -/
+@[deprecated "algebraMap" (since := "2026-02-10")]
+def toOpen (U : Opens (PrimeSpectrum.Top R)) :
+    CommRingCat.of R ⟶ (structureSheaf R).1.obj (op U) := CommRingCat.ofHom (algebraMap _ _)
+
+@[simp]
+theorem algebraMap_self_map (U V : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (i : V ⟶ U) :
+    CommRingCat.ofHom (algebraMap R _) ≫ (Spec.structureSheaf R).1.map i =
+      CommRingCat.ofHom (algebraMap R _) :=
+  rfl
+
+@[deprecated (since := "2026-02-10")] alias toOpen_res := algebraMap_self_map
 
 instance stalkAlgebra (p : PrimeSpectrum R) : Algebra R ((structureSheaf R).presheaf.stalk p) :=
   (toStalk R p).hom.toAlgebra
@@ -843,100 +906,83 @@ theorem stalkAlgebra_map (p : PrimeSpectrum R) (r : R) :
 
 /-- Stalk of the structure sheaf at a prime p as localization of R -/
 instance IsLocalization.to_stalk (p : PrimeSpectrum R) :
-    IsLocalization.AtPrime ((structureSheaf R).presheaf.stalk p) p.asIdeal := by
-  convert (IsLocalization.isLocalization_iff_of_ringEquiv (S := Localization.AtPrime p.asIdeal) _
-          (stalkIso R p).symm.commRingCatIsoToRingEquiv).mp
-      Localization.isLocalization
-  apply Algebra.algebra_ext
-  intro
-  rw [stalkAlgebra_map]
-  congr 2
-  change toStalk R p = _ ≫ (stalkIso R p).inv
-  rw [Iso.eq_comp_inv]
-  exact toStalk_comp_stalkToFiberRingHom R p
+    IsLocalization.AtPrime ((structureSheaf R).presheaf.stalk p) p.asIdeal :=
+  inferInstanceAs (IsLocalization.AtPrime ((structurePresheafInCommRingCat R).stalk p) p.asIdeal)
 
 instance openAlgebra (U : (Opens (PrimeSpectrum R))ᵒᵖ) : Algebra R ((structureSheaf R).val.obj U) :=
-  (toOpen R (unop U)).hom.toAlgebra
-
-@[simp]
-theorem openAlgebra_map (U : (Opens (PrimeSpectrum R))ᵒᵖ) (r : R) :
-    algebraMap R ((structureSheaf R).val.obj U) r = toOpen R (unop U) r :=
-  rfl
+  inferInstanceAs (Algebra R ((structureSheafInType R R).presheaf.obj _))
 
 /-- Sections of the structure sheaf of Spec R on a basic open as localization of R -/
 instance IsLocalization.to_basicOpen (r : R) :
-    IsLocalization.Away r ((structureSheaf R).val.obj (op <| PrimeSpectrum.basicOpen r)) := by
-  convert (IsLocalization.isLocalization_iff_of_ringEquiv (S := Localization.Away r) _
-      (basicOpenIso R r).symm.commRingCatIsoToRingEquiv).mp
-      Localization.isLocalization
-  apply Algebra.algebra_ext
-  intro x
-  congr 1
-  exact (localization_toBasicOpen R r).symm
+    IsLocalization.Away r ((structureSheaf R).val.obj (op <| basicOpen r)) :=
+  inferInstanceAs (IsLocalization.Away r Γ(R, basicOpen r))
 
-instance to_basicOpen_epi (r : R) : Epi (toOpen R (PrimeSpectrum.basicOpen r)) :=
+instance to_basicOpen_epi (r : R) :
+    Epi (CommRingCat.ofHom <|
+      algebraMap R ((structureSheaf R).val.obj (op <| basicOpen r))) :=
   ⟨fun _ _ h => CommRingCat.hom_ext (IsLocalization.ringHom_ext (Submonoid.powers r)
     (CommRingCat.hom_ext_iff.mp h))⟩
 
-@[elementwise]
-theorem to_global_factors :
-    toOpen R ⊤ =
-      CommRingCat.ofHom (algebraMap R (Localization.Away (1 : R))) ≫
-        CommRingCat.ofHom (toBasicOpen R (1 : R)) ≫
-        (structureSheaf R).1.map (eqToHom PrimeSpectrum.basicOpen_one.symm).op := by
-  rw [← Category.assoc]
-  change toOpen R ⊤ =
-    (CommRingCat.ofHom <| (toBasicOpen R 1).comp (algebraMap R (Localization.Away 1))) ≫
-    (structureSheaf R).1.map (eqToHom _).op
-  rw [localization_toBasicOpen R, CommRingCat.ofHom_hom, toOpen_res]
-
-instance isIso_to_global : IsIso (toOpen R ⊤) := by
-  let hom := CommRingCat.ofHom (algebraMap R (Localization.Away (1 : R)))
-  haveI : IsIso hom :=
-    (IsLocalization.atOne R (Localization.Away (1 : R))).toRingEquiv.toCommRingCatIso.isIso_hom
-  rw [to_global_factors R]
-  infer_instance
-
+variable (R) in
 /-- The ring isomorphism between the ring `R` and the global sections `Γ(X, 𝒪ₓ)`. -/
 @[simps! inv]
 def globalSectionsIso : CommRingCat.of R ≅ (structureSheaf R).1.obj (op ⊤) :=
-  asIso (toOpen R ⊤)
+  RingEquiv.toCommRingCatIso (.ofBijective _ algebraMap_obj_top_bijective)
 
-@[simp]
-theorem globalSectionsIso_hom (R : CommRingCat) : (globalSectionsIso R).hom = toOpen R ⊤ :=
+theorem globalSectionsIso_hom (R : CommRingCat) :
+    (globalSectionsIso R).hom = CommRingCat.ofHom (algebraMap _ _) :=
   rfl
 
 @[simp, reassoc, elementwise nosimp]
 theorem toStalk_stalkSpecializes {R : Type*} [CommRing R] {x y : PrimeSpectrum R} (h : x ⤳ y) :
     toStalk R y ≫ (structureSheaf R).presheaf.stalkSpecializes h = toStalk R x := by
-  dsimp [toStalk]; simp [-toOpen_germ]
+  dsimp [toStalk]
+  simp [structureSheaf]
 
-@[simp, reassoc, elementwise nosimp]
-theorem localizationToStalk_stalkSpecializes {R : Type*} [CommRing R] {x y : PrimeSpectrum R}
-    (h : x ⤳ y) :
-    StructureSheaf.localizationToStalk R y ≫ (structureSheaf R).presheaf.stalkSpecializes h =
-      CommRingCat.ofHom (PrimeSpectrum.localizationMapOfSpecializes h) ≫
-        StructureSheaf.localizationToStalk R x := by
-  ext : 1
-  apply IsLocalization.ringHom_ext (S := Localization.AtPrime y.asIdeal) y.asIdeal.primeCompl
-  rw [CommRingCat.hom_comp, RingHom.comp_assoc, CommRingCat.hom_comp, RingHom.comp_assoc]
-  dsimp [localizationToStalk, PrimeSpectrum.localizationMapOfSpecializes]
-  rw [IsLocalization.lift_comp, IsLocalization.lift_comp, IsLocalization.lift_comp]
-  exact CommRingCat.hom_ext_iff.mp (toStalk_stalkSpecializes h)
+end StructureSheaf
 
-@[simp, reassoc, elementwise nosimp]
-theorem stalkSpecializes_stalk_to_fiber {R : Type*} [CommRing R] {x y : PrimeSpectrum R}
-    (h : x ⤳ y) :
-    (structureSheaf R).presheaf.stalkSpecializes h ≫ StructureSheaf.stalkToFiberRingHom R x =
-      StructureSheaf.stalkToFiberRingHom R y ≫
-      (CommRingCat.ofHom (PrimeSpectrum.localizationMapOfSpecializes h)) := by
-  change _ ≫ (StructureSheaf.stalkIso R x).hom = (StructureSheaf.stalkIso R y).hom ≫ _
-  rw [← Iso.eq_comp_inv, Category.assoc, ← Iso.inv_comp_eq]
-  exact localizationToStalk_stalkSpecializes h
+@[expose] public section Comap
 
-section Comap
+variable {S : Type u} [CommRing S] {N : Type u} [AddCommGroup N] [Module S N]
+  {σ : R →+* S} (f : M →ₛₗ[σ] N)
 
-variable {R} {S : Type u} [CommRing S] {P : Type u} [CommRing P]
+/-- The map `M_{f y} ⟶ N_{y}` used to build maps between structure sheaves. -/
+def Localizations.comapFun (y : PrimeSpectrum.Top S) :
+    Localizations M (y.comap σ) →ₛₗ[σ] Localizations N y :=
+  letI := Module.compHom N σ
+  letI := σ.toAlgebra
+  haveI : IsScalarTower R S N := .of_algebraMap_smul fun _ _ ↦ rfl
+  letI f' : M →ₗ[R] N := { __ := f }
+  letI g : LocalizedModule (y.comap σ).asIdeal.primeCompl M →ₗ[R]
+      LocalizedModule y.asIdeal.primeCompl N :=
+    IsLocalizedModule.lift (y.comap σ).asIdeal.primeCompl (LocalizedModule.mkLinearMap _ _)
+      ((LocalizedModule.mkLinearMap _ _).restrictScalars R ∘ₗ f') (by
+      intro x
+      have := IsLocalizedModule.map_units (S := y.asIdeal.primeCompl)
+        (LocalizedModule.mkLinearMap y.asIdeal.primeCompl N) ⟨σ x, x.2⟩
+      rw [Module.End.isUnit_iff] at this ⊢
+      convert this using 2 with a
+      exact (IsScalarTower.algebraMap_smul ..).symm)
+  { __ := g,
+    map_smul' r x := by simpa [Localizations] using (IsScalarTower.algebraMap_smul ..).symm }
+
+@[simp]
+lemma Localizations.comapFun_mk (y : PrimeSpectrum.Top S)
+    (a : M) (b : (y.comap σ).asIdeal.primeCompl) :
+    Localizations.comapFun f y (.mk a b) = .mk (f a) ⟨σ b.1, b.2⟩ := by
+  letI := Module.compHom N σ
+  letI := σ.toAlgebra
+  haveI : IsScalarTower R S N := .of_algebraMap_smul fun _ _ ↦ rfl
+  apply ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units (S := y.asIdeal.primeCompl)
+    (LocalizedModule.mkLinearMap y.asIdeal.primeCompl N) ⟨σ b, b.2⟩)).1
+  dsimp
+  rw [← (comapFun f y).map_smulₛₗ, LocalizedModule.smul'_mk, ← Submonoid.smul_def,
+    LocalizedModule.mk_cancel, ← LocalizedModule.mkLinearMap_apply]
+  dsimp [comapFun, Localizations]
+  refine (IsLocalizedModule.lift_apply ..).trans ?_
+  dsimp
+  rw [← LocalizedModule.mk_cancel ⟨σ b.1, b.2⟩, LocalizedModule.smul'_mk]
+  rfl
 
 /--
 Given a ring homomorphism `f : R →+* S`, an open set `U` of the prime spectrum of `R` and an open
@@ -949,31 +995,73 @@ At the moment, we work with arbitrary dependent functions `s : Π x : U, Localiz
 we prove the predicate `isLocallyFraction` is preserved by this map, hence it can be extended to
 a morphism between the structure sheaves of `R` and `S`.
 -/
-def comapFun (f : R →+* S) (U : Opens (PrimeSpectrum.Top R)) (V : Opens (PrimeSpectrum.Top S))
-    (hUV : V.1 ⊆ PrimeSpectrum.comap f ⁻¹' U.1) (s : ∀ x : U, Localizations R x) (y : V) :
-    Localizations S y :=
-  Localization.localRingHom (PrimeSpectrum.comap f y.1).asIdeal _ f rfl
-    (s ⟨PrimeSpectrum.comap f y.1, hUV y.2⟩ :)
+def comapFun (U : Opens (PrimeSpectrum.Top R)) (V : Opens (PrimeSpectrum.Top S))
+    (hUV : V.1 ⊆ PrimeSpectrum.comap σ ⁻¹' U.1) (s : ∀ x : U, Localizations M x.1) (y : V) :
+    Localizations N y.1 :=
+  Localizations.comapFun f _ (s ⟨y.1.comap σ, hUV y.2⟩)
 
-theorem comapFunIsLocallyFraction (f : R →+* S) (U : Opens (PrimeSpectrum.Top R))
-    (V : Opens (PrimeSpectrum.Top S)) (hUV : V.1 ⊆ PrimeSpectrum.comap f ⁻¹' U.1)
-    (s : ∀ x : U, Localizations R x) (hs : (isLocallyFraction R).toPrelocalPredicate.pred s) :
-    (isLocallyFraction S).toPrelocalPredicate.pred (comapFun f U V hUV s) := by
+theorem isLocallyFraction_comapFun (U : Opens (PrimeSpectrum.Top R))
+    (V : Opens (PrimeSpectrum.Top S)) (hUV : V.1 ⊆ PrimeSpectrum.comap σ ⁻¹' U.1)
+    (s : ∀ x : U, Localizations M x.1) (hs : (isLocallyFraction R M).toPrelocalPredicate.pred s) :
+    (isLocallyFraction S N).toPrelocalPredicate.pred (comapFun f U V hUV s) := by
+  letI := Module.compHom N σ
+  letI := σ.toAlgebra
+  haveI : IsScalarTower R S N := .of_algebraMap_smul fun _ _ ↦ rfl
   rintro ⟨p, hpV⟩
-  -- Since `s` is locally fraction, we can find a neighborhood `W` of `PrimeSpectrum.comap f p`
-  -- in `U`, such that `s = a / b` on `W`, for some ring elements `a, b : R`.
-  rcases hs ⟨PrimeSpectrum.comap f p, hUV hpV⟩ with ⟨W, m, iWU, a, b, h_frac⟩
-  -- We claim that we can write our new section as the fraction `f a / f b` on the neighborhood
-  -- `(comap f) ⁻¹ W ⊓ V` of `p`.
-  refine ⟨⟨_, (PrimeSpectrum.continuous_comap f).isOpen_preimage _ W.2⟩ ⊓ V,
-    ⟨m, hpV⟩, Opens.infLERight _ _, f a, f b, ?_⟩
+  obtain ⟨W, m, iWU, a, b, h_frac⟩ := hs ⟨PrimeSpectrum.comap σ p, hUV hpV⟩
+  refine ⟨⟨_, (PrimeSpectrum.continuous_comap σ).isOpen_preimage _ W.2⟩ ⊓ V,
+    ⟨m, hpV⟩, Opens.infLERight _ _, f a, σ b, ?_⟩
   rintro ⟨q, ⟨hqW, hqV⟩⟩
-  specialize h_frac ⟨PrimeSpectrum.comap f q, hqW⟩
-  refine ⟨h_frac.1, ?_⟩
-  dsimp only [comapFun]
-  erw [← Localization.localRingHom_to_map (PrimeSpectrum.comap f q).asIdeal _ _ rfl,
-    ← map_mul, h_frac.2, Localization.localRingHom_to_map]
-  rfl
+  obtain ⟨hs, H⟩ := h_frac ⟨PrimeSpectrum.comap σ q, hqW⟩
+  refine ⟨hs, ?_⟩
+  dsimp [comapFun] at H ⊢
+  erw [H]
+  simp
+
+/-- For a ring homomorphism `f : R →+* S` and open sets `U` and `V` of the prime spectra of `R` and
+`S` such that `V ⊆ (comap f) ⁻¹ U`, the induced ring homomorphism from the structure sheaf of `R`
+at `U` to the structure sheaf of `S` at `V`.
+
+Explicitly, this map is given as follows: For a point `p : V`, if the section `s` evaluates on `p`
+to the fraction `a / b`, its image on `V` evaluates on `p` to the fraction `f(a) / f(b)`.
+-/
+def comapₗ (U : Opens (PrimeSpectrum.Top R)) (V : Opens (PrimeSpectrum.Top S))
+    (hUV : V.1 ⊆ PrimeSpectrum.comap σ ⁻¹' U.1) :
+    Γ(M, U) →ₛₗ[σ] Γ(N, V) where
+  toFun s := ⟨comapFun f U V hUV s.1, isLocallyFraction_comapFun f U V hUV s.1 s.2⟩
+  map_add' s t := Subtype.ext <| funext fun _ ↦ by dsimp [comapFun]; rw [map_add]
+  map_smul' r m := Subtype.ext <| funext fun _ ↦ by
+    dsimp [comapFun]
+    rw [map_smulₛₗ, ← IsScalarTower.algebraMap_smul S]
+
+theorem comapₗ_const (U : Opens (PrimeSpectrum.Top R)) (V : Opens (PrimeSpectrum.Top S))
+    (hUV : V.1 ⊆ PrimeSpectrum.comap σ ⁻¹' U.1) (a : M) (b : R) (hb : U ≤ basicOpen b) :
+    comapₗ f U V hUV (const a b U hb) = const (f a) (σ b) V (hUV.trans (Set.preimage_mono hb)) :=
+  Subtype.ext <| funext fun _ ↦ by simp [comapₗ, comapFun]
+
+section Ring
+
+open Spec (structureSheaf)
+
+variable {S : Type u} [CommRing S] {P : Type u} [CommRing P]
+
+@[simp]
+theorem comapₗ_eq_localRingHom (f : R →+* S) (U : Opens (PrimeSpectrum.Top R))
+    (V : Opens (PrimeSpectrum.Top S)) (hUV : V.1 ⊆ PrimeSpectrum.comap f ⁻¹' U.1)
+    (s : (structureSheaf R).1.obj (op U)) (p : V) :
+    (comapₗ f.toSemilinearMap U V hUV s).1 p =
+      Localization.localRingHom (PrimeSpectrum.comap f p.1).asIdeal _ f rfl
+        (s.1 ⟨PrimeSpectrum.comap f p.1, hUV p.2⟩) := by
+  dsimp [comapₗ, comapFun]
+  suffices ⇑(Localizations.comapFun f.toSemilinearMap p.1) =
+      ⇑(Localization.localRingHom (PrimeSpectrum.comap f p.1).asIdeal _ f rfl) from
+    congr($this _)
+  ext m
+  induction m using LocalizedModule.induction_on with | h m s =>
+  trans LocalizedModule.mk (f m) ⟨f ↑s, s.2⟩
+  · simp
+  convert_to Localization.mk _ _ = Localization.localRingHom _ _ _ _ (Localization.mk _ _)
+  simp [Localization.mk_eq_mk']
 
 /-- For a ring homomorphism `f : R →+* S` and open sets `U` and `V` of the prime spectra of `R` and
 `S` such that `V ⊆ (comap f) ⁻¹ U`, the induced ring homomorphism from the structure sheaf of `R`
@@ -985,31 +1073,20 @@ to the fraction `a / b`, its image on `V` evaluates on `p` to the fraction `f(a)
 def comap (f : R →+* S) (U : Opens (PrimeSpectrum.Top R)) (V : Opens (PrimeSpectrum.Top S))
     (hUV : V.1 ⊆ PrimeSpectrum.comap f ⁻¹' U.1) :
     (structureSheaf R).1.obj (op U) →+* (structureSheaf S).1.obj (op V) where
-  toFun s := ⟨comapFun f U V hUV s.1, comapFunIsLocallyFraction f U V hUV s.1 s.2⟩
-  map_one' :=
-    Subtype.ext <|
-      funext fun p => by
-        dsimp
-        rw [comapFun, (sectionsSubring R (op U)).coe_one, Pi.one_apply, map_one]
-        rfl
-  map_zero' :=
-    Subtype.ext <|
-      funext fun p => by
-        dsimp
-        rw [comapFun, (sectionsSubring R (op U)).coe_zero, Pi.zero_apply, map_zero]
-        rfl
-  map_add' s t :=
-    Subtype.ext <|
-      funext fun p => by
-        dsimp
-        rw [comapFun, (sectionsSubring R (op U)).coe_add, Pi.add_apply, map_add]
-        rfl
-  map_mul' s t :=
-    Subtype.ext <|
-      funext fun p => by
-        dsimp
-        rw [comapFun, (sectionsSubring R (op U)).coe_mul, Pi.mul_apply, map_mul]
-        rfl
+  __ := comapₗ f.toSemilinearMap U V hUV
+  map_one' := Subtype.ext <| funext fun _ ↦ by
+    dsimp
+    simp only [comapₗ_eq_localRingHom, PrimeSpectrum.comap_asIdeal]
+    exact (Localization.localRingHom ..).map_one
+  map_mul' r s := Subtype.ext <| funext fun p ↦ by
+    dsimp
+    change _ = (comapₗ f.toSemilinearMap U V hUV r).1 p * (comapₗ f.toSemilinearMap U V hUV s).1 p
+    simp only [comapₗ_eq_localRingHom, PrimeSpectrum.comap_asIdeal]
+    exact (Localization.localRingHom ..).map_mul _ _
+  map_zero' := Subtype.ext <| funext fun _ ↦ by
+    dsimp
+    simp only [comapₗ_eq_localRingHom, PrimeSpectrum.comap_asIdeal]
+    exact (Localization.localRingHom ..).map_zero
 
 @[simp]
 theorem comap_apply (f : R →+* S) (U : Opens (PrimeSpectrum.Top R))
@@ -1017,17 +1094,18 @@ theorem comap_apply (f : R →+* S) (U : Opens (PrimeSpectrum.Top R))
     (s : (structureSheaf R).1.obj (op U)) (p : V) :
     (comap f U V hUV s).1 p =
       Localization.localRingHom (PrimeSpectrum.comap f p.1).asIdeal _ f rfl
-        (s.1 ⟨PrimeSpectrum.comap f p.1, hUV p.2⟩ :) :=
-  rfl
+        (s.1 ⟨PrimeSpectrum.comap f p.1, hUV p.2⟩) :=
+  comapₗ_eq_localRingHom ..
 
 theorem comap_const (f : R →+* S) (U : Opens (PrimeSpectrum.Top R))
     (V : Opens (PrimeSpectrum.Top S)) (hUV : V.1 ⊆ PrimeSpectrum.comap f ⁻¹' U.1) (a b : R)
     (hb : ∀ x : PrimeSpectrum R, x ∈ U → b ∈ x.asIdeal.primeCompl) :
-    comap f U V hUV (const R a b U hb) =
-      const S (f a) (f b) V fun p hpV => hb (PrimeSpectrum.comap f p) (hUV hpV) :=
-  Subtype.ext <|
-    funext fun p => by
-      rw [comap_apply, const_apply, const_apply, Localization.localRingHom_mk']
+    comap f U V hUV (const a b U hb) =
+      const (f a) (f b) V fun p hpV => hb (PrimeSpectrum.comap f p) (hUV hpV) :=
+  Subtype.ext <| funext fun p => by
+    rw [comap_apply, const_apply, const_apply]
+    convert_to Localization.localRingHom _ _ _ _ (Localization.mk _ _) = Localization.mk _ _
+    simp [Localization.mk_eq_mk']
 
 /-- For an inclusion `i : V ⟶ U` between open sets of the prime spectrum of `R`, the comap of the
 identity from OO_X(U) to OO_X(V) equals as the restriction map of the structure sheaf.
@@ -1040,18 +1118,7 @@ theorem comap_id_eq_map (U V : Opens (PrimeSpectrum.Top R)) (iVU : V ⟶ U) :
       ((structureSheaf R).1.map iVU.op).hom :=
   RingHom.ext fun s => Subtype.ext <| funext fun p => by
     rw [comap_apply]
-    -- Unfortunately, we cannot use `Localization.localRingHom_id` here, because
-    -- `PrimeSpectrum.comap (RingHom.id R) p` is not *definitionally* equal to `p`. Instead, we use
-    -- that we can write `s` as a fraction `a/b` in a small neighborhood around `p`. Since
-    -- `PrimeSpectrum.comap (RingHom.id R) p` equals `p`, it is also contained in the same
-    -- neighborhood, hence `s` equals `a/b` there too.
-    obtain ⟨W, hpW, iWU, h⟩ := s.2 (iVU p)
-    obtain ⟨a, b, h'⟩ := h.eq_mk'
-    obtain ⟨hb₁, s_eq₁⟩ := h' ⟨p, hpW⟩
-    obtain ⟨hb₂, s_eq₂⟩ :=
-      h' ⟨PrimeSpectrum.comap (RingHom.id _) p.1, hpW⟩
-    dsimp only at s_eq₁ s_eq₂
-    erw [s_eq₂, Localization.localRingHom_mk', ← s_eq₁, ← res_apply _ _ _ iVU]
+    exact congr($(Localization.localRingHom_id ..) _)
 
 /--
 The comap of the identity is the identity. In this variant of the lemma, two open subsets `U` and
@@ -1081,11 +1148,14 @@ theorem comap_comp (f : R →+* S) (g : S →+* P) (U : Opens (PrimeSpectrum.Top
 
 @[elementwise, reassoc]
 theorem toOpen_comp_comap (f : R →+* S) (U : Opens (PrimeSpectrum.Top R)) :
-    (toOpen R U ≫ CommRingCat.ofHom (comap f U (Opens.comap ⟨_, PrimeSpectrum.continuous_comap f⟩ U)
-        fun _ => id)) =
-      CommRingCat.ofHom f ≫ toOpen S _ :=
-  CommRingCat.hom_ext <| RingHom.ext fun _ => Subtype.ext <| funext fun _ =>
-    Localization.localRingHom_to_map _ _ _ _ _
+    CommRingCat.ofHom (algebraMap _ _) ≫
+      CommRingCat.ofHom (comap f U (Opens.comap ⟨_, PrimeSpectrum.continuous_comap f⟩ U)
+        fun _ ↦ id) =
+      CommRingCat.ofHom f ≫ CommRingCat.ofHom (algebraMap _ _) :=
+  CommRingCat.hom_ext <| RingHom.ext fun _ ↦ Subtype.ext <| funext fun x ↦ by
+    dsimp
+    rw [comap_apply]
+    exact Localization.localRingHom_to_map _ _ _ _ _
 
 lemma comap_basicOpen (f : R →+* S) (x : R) :
     comap f (PrimeSpectrum.basicOpen x) (PrimeSpectrum.basicOpen (f x))
@@ -1094,6 +1164,8 @@ lemma comap_basicOpen (f : R →+* S) (x : R) :
         (Submonoid.powers_le.mpr (Submonoid.mem_powers _)) :=
   IsLocalization.ringHom_ext (.powers x) <| by
     simpa [CommRingCat.hom_ext_iff] using toOpen_comp_comap f _
+
+end Ring
 
 end Comap
 

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -875,7 +875,7 @@ variable (R) in
 
 This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
 -/
-def Spec.structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R) :=
+def _root_.AlgebraicGeometry.Spec.structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R) :=
   ⟨structurePresheafInCommRingCat R,
     (TopCat.Presheaf.isSheaf_iff_isSheaf_comp _ _).mpr (TopCat.Presheaf.isSheaf_of_iso
       (structurePresheafCompForget R).symm (structureSheafInType R R).cond)⟩

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -66,7 +66,7 @@ namespace AlgebraicGeometry
 
 variable (R) in
 /-- The prime spectrum as an object of `TopCat`. -/
-@[expose] public def PrimeSpectrum.Top : TopCat := TopCat.of (PrimeSpectrum R)
+public def PrimeSpectrum.Top : TopCat := TopCat.of (PrimeSpectrum R)
 
 namespace StructureSheaf
 
@@ -202,7 +202,7 @@ lemma structureSheafInType.smul_apply {U : Opens (PrimeSpectrum.Top R)}
   (r • s).1 x = r • s.1 x := rfl
 
 variable (R M) in
-/-- The structure presheaf, valued in `CommRingCat`, constructed by dressing up the `Type`-valued
+/-- The structure presheaf, valued in `ModuleCat`, constructed by dressing up the `Type`-valued
 structure presheaf. -/
 @[simps obj_carrier]
 def structurePresheafInModuleCat : Presheaf (ModuleCat R) (PrimeSpectrum.Top R) where
@@ -246,8 +246,7 @@ def moduleStructurePresheaf : PresheafOfModules (structurePresheafInCommRingCat 
 
 variable (R) in
 /-- Some glue, verifying that the structure presheaf valued in `CommRingCat` agrees
-with the `Type`-valued structure presheaf.
--/
+with the `Type`-valued structure presheaf. -/
 def structurePresheafCompForget :
     structurePresheafInCommRingCat R ⋙ forget CommRingCat ≅ (structureSheafInType R R).1 :=
   NatIso.ofComponents fun _ => Iso.refl _
@@ -376,13 +375,13 @@ namespace StructureSheaf
 
 section basicOpen
 
-lemma isUnit_toBasicOpen (f : R) :
+lemma isUnit_basicOpen (f : R) :
     IsUnit ((algebraMap R Γ(R, basicOpen f)) f) :=
   isUnit_iff_exists_inv.mpr ⟨const 1 f _ le_rfl, const_mul_rev _ _ _ (by simp) _⟩
 
-lemma isUnit_toBasicOpen_end (f : R) :
+lemma isUnit_basicOpen_end (f : R) :
     IsUnit ((algebraMap R (Module.End R Γ(M, basicOpen f))) f) := by
-  have := (isUnit_toBasicOpen f).map
+  have := (isUnit_basicOpen f).map
     (algebraMap _ (Module.End Γ(R, basicOpen f) Γ(M, basicOpen f)))
   rw [Module.End.isUnit_iff] at this ⊢
   convert this
@@ -390,25 +389,21 @@ lemma isUnit_toBasicOpen_end (f : R) :
   simp
 
 variable (R M) in
-/-- The canonical ring homomorphism interpreting `s ∈ R_f` as a section of the structure sheaf
+/-- The canonical linear map interpreting `s ∈ M_f` as a section of the structure sheaf
 on the basic open defined by `f ∈ R`. -/
 def toBasicOpenₗ (f : R) :
     LocalizedModule (.powers f) M →ₗ[R] Γ(M, PrimeSpectrum.basicOpen f) :=
   IsLocalizedModule.lift (.powers f) (LocalizedModule.mkLinearMap ..) (toOpenₗ R M _) <| by
     simp only [Subtype.forall]
     exact Submonoid.powers_le (P := (IsUnit.submonoid _).comap (algebraMap R _)).mpr
-      (isUnit_toBasicOpen_end ..)
-
--- move me
-lemma PrimeSpectrum.le_basicOpen_pow (r : R) (n : ℕ) : basicOpen r ≤ basicOpen (r ^ n) := by
-  cases n <;> simp
+      (isUnit_basicOpen_end ..)
 
 @[simp]
 theorem toBasicOpenₗ_mk (s : R) (f : M) (g : Submonoid.powers s) :
     toBasicOpenₗ R M s (.mk f g) = const f g.1 (basicOpen s) (by
     have := PrimeSpectrum.le_basicOpen_pow s; aesop (add simp [Submonoid.mem_powers_iff])) := by
   obtain ⟨_, n, rfl⟩ := g
-  apply ((Module.End.isUnit_iff _).mp ((isUnit_toBasicOpen_end ..).pow n)).1 ?_
+  apply ((Module.End.isUnit_iff _).mp ((isUnit_basicOpen_end ..).pow n)).1 ?_
   rw [← map_pow]
   dsimp [toBasicOpenₗ]
   rw [← map_smul, LocalizedModule.smul'_mk, ← Submonoid.mk_smul (S := .powers s) _ ⟨n, rfl⟩,
@@ -509,7 +504,7 @@ public instance (f : R) : IsLocalizedModule (.powers f) (toOpenₗ R M (basicOpe
   ext x
   simp [toOpenₗ]
 
-instance isIso_toBasicOpen (f : R) :
+instance isIso_toBasicOpenₗ (f : R) :
     IsIso (ModuleCat.ofHom (toBasicOpenₗ R M f)) :=
   (ConcreteCategory.isIso_iff_bijective _).mpr ⟨toBasicOpenₗ_injective _, toBasicOpenₗ_surjective _⟩
 
@@ -632,7 +627,7 @@ theorem toOpenₗ_germ (U : Opens (PrimeSpectrum.Top R)) (x : PrimeSpectrum.Top 
 
 theorem isUnit_toStalk (x : PrimeSpectrum.Top R) (f : R) (hf : x ∈ basicOpen f) :
     IsUnit (toStalk R x f) := by
-  convert (isUnit_toBasicOpen f).map ((structurePresheafInCommRingCat R).germ _ x hf).hom
+  convert (isUnit_basicOpen f).map ((structurePresheafInCommRingCat R).germ _ x hf).hom
   exact ((structurePresheafInCommRingCat R).germ_res_apply (homOfLE (le_top : basicOpen f ≤ ⊤))
     x hf (algebraMap R Γ(R, ⊤) f)).symm
 
@@ -795,17 +790,6 @@ instance (x : PrimeSpectrum.Top R) : IsLocalizedModule x.asIdeal.primeCompl (toS
     Limits.colimit.isoColimitCocone_ι_hom (C := Ab) ..
   exact congr($this _)
 
--- move me
-public instance forget₂SemiRing_preservesFilteredColimits :
-    Limits.PreservesFilteredColimits (forget₂ RingCat AddCommGrpCat.{u}) where
-  preserves_filtered_colimits {J hJ1 _} :=
-    letI : Category J := hJ1
-    { preservesColimit := fun {F} =>
-        Limits.preservesColimit_of_preserves_colimit_cocone
-          (RingCat.FilteredColimits.colimitCoconeIsColimit.{u, u} F)
-          (AddCommGrpCat.FilteredColimits.colimitCoconeIsColimit
-            (F ⋙ forget₂ RingCat AddCommGrpCat.{u})) }
-
 variable (R) in
 /-- The stalk of `Spec R` at `x` is isomorphic to the stalk of `R^~` at `x`. -/
 @[expose] public
@@ -877,8 +861,7 @@ variable (R)
 
 /-- The structure sheaf on $Spec R$, valued in `CommRingCat`.
 
-This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
--/
+This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later. -/
 def _root_.AlgebraicGeometry.Spec.structureSheaf : Sheaf CommRingCat (PrimeSpectrum.Top R) :=
   ⟨structurePresheafInCommRingCat R,
     (TopCat.Presheaf.isSheaf_iff_isSheaf_comp _ _).mpr (TopCat.Presheaf.isSheaf_of_iso

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -870,7 +870,8 @@ end Stalk
 
 @[expose] public section StructureSheaf
 
-variable (R) in
+variable (R)
+
 /-- The structure sheaf on $Spec R$, valued in `CommRingCat`.
 
 This is provided as a bundled `SheafedSpace` as `Spec.SheafedSpace R` later.
@@ -923,7 +924,6 @@ instance to_basicOpen_epi (r : R) :
   ⟨fun _ _ h => CommRingCat.hom_ext (IsLocalization.ringHom_ext (Submonoid.powers r)
     (CommRingCat.hom_ext_iff.mp h))⟩
 
-variable (R) in
 /-- The ring isomorphism between the ring `R` and the global sections `Γ(X, 𝒪ₓ)`. -/
 @[simps! inv]
 def globalSectionsIso : CommRingCat.of R ≅ (structureSheaf R).1.obj (op ⊤) :=

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -1001,7 +1001,7 @@ theorem isLocallyFraction_comapFun (U : Opens (PrimeSpectrum.Top R))
   obtain ⟨hs, H⟩ := h_frac ⟨PrimeSpectrum.comap σ q, hqW⟩
   refine ⟨hs, ?_⟩
   dsimp [comapFun] at H ⊢
-  erw [H]
+  rw [H]
   simp
 
 /-- For a ring homomorphism `f : R →+* S` and open sets `U` and `V` of the prime spectra of `R` and

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -561,6 +561,9 @@ theorem basicOpen_mul_le_right (f g : R) : basicOpen (f * g) ≤ basicOpen g := 
 theorem basicOpen_pow (f : R) (n : ℕ) (hn : 0 < n) : basicOpen (f ^ n) = basicOpen f :=
   TopologicalSpace.Opens.ext <| by simpa using zeroLocus_singleton_pow f n hn
 
+lemma le_basicOpen_pow (r : R) (n : ℕ) : basicOpen r ≤ basicOpen (r ^ n) := by
+  cases n <;> simp
+
 theorem isTopologicalBasis_basic_opens :
     TopologicalSpace.IsTopologicalBasis
       (Set.range fun r : R => (basicOpen r : Set (PrimeSpectrum R))) := by


### PR DESCRIPTION
We redefine `structureSheaf` to unify its construction with `tilde`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
