### PR TITLE
[Merged by Bors] - chore: move OrderDual to its own file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5721,6 +5721,7 @@ public import Mathlib.Order.Notation
 public import Mathlib.Order.Nucleus
 public import Mathlib.Order.OmegaCompletePartialOrder
 public import Mathlib.Order.OrdContinuous
+public import Mathlib.Order.OrderDual
 public import Mathlib.Order.OrderIsoNat
 public import Mathlib.Order.PFilter
 public import Mathlib.Order.Part

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -20,10 +20,6 @@ public import Mathlib.Tactic.GCongr.Core
 This file proves basic results about orders, provides extensive dot notation, defines useful order
 classes and allows to transfer order instances.
 
-## Type synonyms
-
-* `OrderDual α` : A type synonym reversing the meaning of all inequalities, with notation `αᵒᵈ`.
-
 ### Transferring orders
 
 - `Order.Preimage`, `Preorder.lift`: Transfers a (pre)order on `β` to an order on `α`

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -499,89 +499,6 @@ lemma LinearOrder.ext {A B : LinearOrder α} (H : ∀ x y : α, (haveI := A; x �
 lemma LinearOrder.ext_lt {A B : LinearOrder α} (H : ∀ x y : α, (haveI := A; x < y) ↔ x < y) :
     A = B := LinearOrder.toPartialOrder_injective (PartialOrder.ext_lt H)
 
-/-! ### Order dual -/
-
-/-- Type synonym to equip a type with the dual order: `≤` means `≥` and `<` means `>`. `αᵒᵈ` is
-notation for `OrderDual α`. -/
-def OrderDual (α : Type*) : Type _ :=
-  α
-
-@[inherit_doc]
-notation:max α "ᵒᵈ" => OrderDual α
-
-namespace OrderDual
-
-instance (α : Type*) [h : Nonempty α] : Nonempty αᵒᵈ :=
-  h
-
-instance (α : Type*) [h : Subsingleton α] : Subsingleton αᵒᵈ :=
-  h
-
-instance (α : Type*) [LE α] : LE αᵒᵈ :=
-  ⟨fun x y : α ↦ y ≤ x⟩
-
-instance (α : Type*) [LT α] : LT αᵒᵈ :=
-  ⟨fun x y : α ↦ y < x⟩
-
-instance instOrd (α : Type*) [Ord α] : Ord αᵒᵈ where
-  compare := fun (a b : α) ↦ compare b a
-
-@[to_dual]
-instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
-  ⟨((· ⊓ ·) : α → α → α)⟩
-
-instance instIsTransLE [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
-  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
-
-instance instIsTransLT [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
-  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
-
-instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
-  le_refl := fun _ ↦ le_refl _
-  le_trans := fun _ _ _ hab hbc ↦ hbc.trans hab
-  lt_iff_le_not_ge := fun _ _ ↦ lt_iff_le_not_ge
-
-instance instPartialOrder (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
-  __ := inferInstanceAs (Preorder αᵒᵈ)
-  le_antisymm := fun a b hab hba ↦ @le_antisymm α _ a b hba hab
-
-instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
-  __ := inferInstanceAs (PartialOrder αᵒᵈ)
-  __ := inferInstanceAs (Ord αᵒᵈ)
-  le_total := fun a b : α ↦ le_total b a
-  max := fun a b ↦ (min a b : α)
-  min := fun a b ↦ (max a b : α)
-  min_def := fun a b ↦ show (max .. : α) = _ by rw [max_comm, max_def]; rfl
-  max_def := fun a b ↦ show (min .. : α) = _ by rw [min_comm, min_def]; rfl
-  toDecidableLE := (inferInstance : DecidableRel (fun a b : α ↦ b ≤ a))
-  toDecidableLT := (inferInstance : DecidableRel (fun a b : α ↦ b < a))
-  toDecidableEq := (inferInstance : DecidableEq α)
-  compare_eq_compareOfLessAndEq a b := by
-    simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
-    rfl
-
-/-- The opposite linear order to a given linear order -/
-def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α :=
-  inferInstanceAs <| LinearOrder (OrderDual α)
-
-instance : ∀ [Inhabited α], Inhabited αᵒᵈ := fun [x : Inhabited α] => x
-
-theorem Ord.dual_dual (α : Type*) [H : Ord α] : OrderDual.instOrd αᵒᵈ = H :=
-  rfl
-
-theorem Preorder.dual_dual (α : Type*) [H : Preorder α] : OrderDual.instPreorder αᵒᵈ = H :=
-  rfl
-
-theorem instPartialOrder.dual_dual (α : Type*) [H : PartialOrder α] :
-    OrderDual.instPartialOrder αᵒᵈ = H :=
-  rfl
-
-theorem instLinearOrder.dual_dual (α : Type*) [H : LinearOrder α] :
-    OrderDual.instLinearOrder αᵒᵈ = H :=
-  rfl
-
-end OrderDual
-
 /-! ### `Compl` -/
 
 
@@ -1059,13 +976,6 @@ theorem DenselyOrdered.dense' [LT α] [DenselyOrdered α] :
 theorem exists_between [LT α] [DenselyOrdered α] {a₁ a₂ : α} : a₁ < a₂ → ∃ a, a₁ < a ∧ a < a₂ :=
   DenselyOrdered.dense _ _
 
-instance OrderDual.denselyOrdered (α : Type*) [LT α] [h : DenselyOrdered α] :
-    DenselyOrdered αᵒᵈ :=
-  ⟨fun _ _ ha ↦ (@exists_between α _ h _ _ ha).imp fun _ ↦ And.symm⟩
-
-@[simp]
-theorem denselyOrdered_orderDual [LT α] : DenselyOrdered αᵒᵈ ↔ DenselyOrdered α :=
-  ⟨by convert @OrderDual.denselyOrdered αᵒᵈ _, @OrderDual.denselyOrdered α _⟩
 
 /-- Any ordered subsingleton is densely ordered. Not an instance to avoid a heavy subsingleton
 typeclass search. -/

--- a/Mathlib/Order/Monotone/Defs.lean
+++ b/Mathlib/Order/Monotone/Defs.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Data.Set.Operations
 public import Mathlib.Logic.Function.Iterate
-public import Mathlib.Order.Basic
+public import Mathlib.Order.OrderDual
 public import Mathlib.Tactic.Coe
 
 /-!

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Mario Carneiro
+-/
+module
+
+public import Mathlib.Order.Basic
+
+/-!
+# Order dual
+
+This file defines `OrderDual α`, a type synonym reversing the meaning of all inequalities,
+with notation `αᵒᵈ`.
+
+## Notation
+
+`αᵒᵈ` is notation for `OrderDual α`.
+
+## Implementation notes
+
+One should not abuse definitional equality between `α` and `αᵒᵈ`. Instead, explicit
+coercions should be inserted:
+* `OrderDual.toDual : α → αᵒᵈ` and `OrderDual.ofDual : αᵒᵈ → α`
+-/
+
+@[expose] public section
+
+
+variable {α : Type*}
+
+/-- Type synonym to equip a type with the dual order: `≤` means `≥` and `<` means `>`. `αᵒᵈ` is
+notation for `OrderDual α`. -/
+def OrderDual (α : Type*) : Type _ :=
+  α
+
+@[inherit_doc]
+notation:max α "ᵒᵈ" => OrderDual α
+
+namespace OrderDual
+
+instance (α : Type*) [h : Nonempty α] : Nonempty αᵒᵈ :=
+  h
+
+instance (α : Type*) [h : Subsingleton α] : Subsingleton αᵒᵈ :=
+  h
+
+instance (α : Type*) [LE α] : LE αᵒᵈ :=
+  ⟨fun x y : α ↦ y ≤ x⟩
+
+instance (α : Type*) [LT α] : LT αᵒᵈ :=
+  ⟨fun x y : α ↦ y < x⟩
+
+instance instOrd (α : Type*) [Ord α] : Ord αᵒᵈ where
+  compare := fun (a b : α) ↦ compare b a
+
+@[to_dual]
+instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
+  ⟨((· ⊓ ·) : α → α → α)⟩
+
+instance instIsTransLE [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
+  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+
+instance instIsTransLT [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
+  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+
+instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
+  le_refl := fun _ ↦ le_refl _
+  le_trans := fun _ _ _ hab hbc ↦ hbc.trans hab
+  lt_iff_le_not_ge := fun _ _ ↦ lt_iff_le_not_ge
+
+instance instPartialOrder (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
+  __ := inferInstanceAs (Preorder αᵒᵈ)
+  le_antisymm := fun a b hab hba ↦ @le_antisymm α _ a b hba hab
+
+instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
+  __ := inferInstanceAs (PartialOrder αᵒᵈ)
+  __ := inferInstanceAs (Ord αᵒᵈ)
+  le_total := fun a b : α ↦ le_total b a
+  max := fun a b ↦ (min a b : α)
+  min := fun a b ↦ (max a b : α)
+  min_def := fun a b ↦ show (max .. : α) = _ by rw [max_comm, max_def]; rfl
+  max_def := fun a b ↦ show (min .. : α) = _ by rw [min_comm, min_def]; rfl
+  toDecidableLE := (inferInstance : DecidableRel (fun a b : α ↦ b ≤ a))
+  toDecidableLT := (inferInstance : DecidableRel (fun a b : α ↦ b < a))
+  toDecidableEq := (inferInstance : DecidableEq α)
+  compare_eq_compareOfLessAndEq a b := by
+    simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
+    rfl
+
+/-- The opposite linear order to a given linear order -/
+def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α :=
+  inferInstanceAs <| LinearOrder (OrderDual α)
+
+instance : ∀ [Inhabited α], Inhabited αᵒᵈ := fun [x : Inhabited α] => x
+
+theorem Ord.dual_dual (α : Type*) [H : Ord α] : OrderDual.instOrd αᵒᵈ = H :=
+  rfl
+
+theorem Preorder.dual_dual (α : Type*) [H : Preorder α] : OrderDual.instPreorder αᵒᵈ = H :=
+  rfl
+
+theorem instPartialOrder.dual_dual (α : Type*) [H : PartialOrder α] :
+    OrderDual.instPartialOrder αᵒᵈ = H :=
+  rfl
+
+theorem instLinearOrder.dual_dual (α : Type*) [H : LinearOrder α] :
+    OrderDual.instLinearOrder αᵒᵈ = H :=
+  rfl
+
+end OrderDual
+
+/-! ### `DenselyOrdered` for `OrderDual` -/
+
+instance OrderDual.denselyOrdered (α : Type*) [LT α] [h : DenselyOrdered α] :
+    DenselyOrdered αᵒᵈ :=
+  ⟨fun _ _ ha ↦ (@exists_between α _ h _ _ ha).imp fun _ ↦ And.symm⟩
+
+@[simp]
+theorem denselyOrdered_orderDual [LT α] : DenselyOrdered αᵒᵈ ↔ DenselyOrdered α :=
+  ⟨by convert @OrderDual.denselyOrdered αᵒᵈ _, @OrderDual.denselyOrdered α _⟩

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad, Mario Carneiro, Yury Kudryashov
 module
 
 public import Mathlib.Logic.IsEmpty
-public import Mathlib.Order.Basic
+public import Mathlib.Order.OrderDual
 public import Mathlib.Tactic.MkIffOfInductiveProp
 
 /-!

--- a/Mathlib/Order/Synonym.lean
+++ b/Mathlib/Order/Synonym.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Logic.Equiv.Defs
 public import Mathlib.Logic.Nontrivial.Defs
-public import Mathlib.Order.Basic
+public import Mathlib.Order.OrderDual
 
 /-!
 # Type synonyms

--- a/Mathlib/Order/Synonym.lean
+++ b/Mathlib/Order/Synonym.lean
@@ -12,9 +12,8 @@ public import Mathlib.Order.OrderDual
 /-!
 # Type synonyms
 
-This file provides three type synonyms for order theory:
+This file provides two type synonyms for order theory:
 
-* `OrderDual α`: Type synonym of `α` to equip it with the dual order (`a ≤ b` becomes `b ≤ a`).
 * `Lex α`: Type synonym of `α` to equip it with its lexicographic order. The precise meaning depends
   on the type we take the lex of. Examples include `Prod`, `Sigma`, `List`, `Finset`.
 * `Colex α`: Type synonym of `α` to equip it with its colexicographic order. The precise meaning


### PR DESCRIPTION
This PR moves `OrderDual` and its order instances from `Order.Basic` to a new file `Order.OrderDual`, in preparation for changing `OrderDual` from a type alias to a one-field structure to prevent defeq abuse.

The new file imports `Order.Basic` and gives more flexibility with imports for the subsequent structure change.

🤖 Prepared with Claude Code