### PR TITLE
refactor: avoid OrderDual defeq abuse in RelHomClass.map_sup

### DIFF
--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -38,7 +38,7 @@ theorem map_inf [SemilatticeInf α] [LinearOrder β] [FunLike F β α]
 theorem map_sup [SemilatticeSup α] [LinearOrder β] [FunLike F β α]
     [RelHomClass F (· > ·) (· > ·)] (a : F) (m n : β) :
     a (m ⊔ n) = a m ⊔ a n :=
-  map_inf (α := αᵒᵈ) (β := βᵒᵈ) _ _ _
+  (StrictMono.monotone fun _ _ => map_rel a).map_sup m n
 
 theorem directed [FunLike F α β] [RelHomClass F r s] {ι : Sort*} {a : ι → α} {f : F}
     (ha : Directed r a) : Directed s (f ∘ a) :=


### PR DESCRIPTION
This PR proves `RelHomClass.map_sup` directly via `StrictMono.monotone` instead of reducing to `map_inf` on `OrderDual`. This is a backwards compatible change needed to deal with https://github.com/leanprover/lean4/pull/12286, instead of relying on `OrderDual` defeq abuse.

🤖 Prepared with Claude Code