### PR TITLE
[Merged by Bors] - ci: More information for new contributors

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -2,7 +2,7 @@ name: Label New Contributors
 
 # Written with ChatGPT: https://chat.openai.com/share/3777ceb1-d722-4705-bacd-ba3f04b387be
 
-on: 
+on:
   pull_request_target:
     types:
       - opened
@@ -50,7 +50,7 @@ jobs:
               totalIssuesChecked += response.data.length;
 
               // Filter this page for PRs with "[Merged by Bors] -" in the title
-              const pageMatches = response.data.filter(item => 
+              const pageMatches = response.data.filter(item =>
                 item.pull_request && item.title.startsWith('[Merged by Bors] -')
               );
 
@@ -76,6 +76,14 @@ jobs:
                 owner,
                 repo,
                 labels: ['new-contributor']
+              });
+
+              console.log('Posting welcome comment for new contributor...');
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner,
+                repo,
+                body: '## Welcome new contributor!\nThank you for contributing to Mathlib! If you haven't done so already, please do review our [contribution guidelines](https://leanprover-community.github.io/contribute/index.html). In particular, we use a [review queue](https://leanprover-community.github.io/queueboard/review_dashboard.html) to manage reviews. If your PR does not appear there, it is probably because it is not successfully building (i.e., it doesn't have a green checkmark), has the `awaiting-author` tag, or another reason described in the [Lifecycle of a PR](https://leanprover-community.github.io/contribute/index.html#lifecycle-of-a-pr).\nIf you haven't already done so, please come to [https://leanprover.zulipchat.com/](https://leanprover.zulipchat.com/), introduce yourself, and mention your new PR.\nThank you again for joining our community.'
               });
             }
 

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -79,19 +79,27 @@ jobs:
               });
 
               // Check if we already posted a welcome comment (idempotency)
-              const comments = await github.rest.issues.listComments({
-                issue_number: context.issue.number,
-                owner,
-                repo,
-              });
-              const alreadyWelcomed = comments.data.some(c =>
-                c.user.login === 'github-actions[bot]' &&
-                c.body.includes('Welcome new contributor')
-              );
+              const WELCOME_MARKER = '<!-- mathlib-welcome-comment -->';
+              let alreadyWelcomed = false;
+              for await (const response of github.paginate.iterator(
+                github.rest.issues.listComments,
+                {
+                  issue_number: context.issue.number,
+                  owner,
+                  repo,
+                  per_page: 100,
+                }
+              )) {
+                if (response.data.some(c => c.body.includes(WELCOME_MARKER))) {
+                  alreadyWelcomed = true;
+                  break;
+                }
+              }
 
               if (!alreadyWelcomed) {
                 console.log('Posting welcome comment for new contributor...');
                 const body = [
+                  WELCOME_MARKER,
                   '## Welcome new contributor!',
                   'Thank you for contributing to Mathlib! If you haven\'t done so already, please review our [contribution guidelines](https://leanprover-community.github.io/contribute/index.html), as well as the [style guide](https://leanprover-community.github.io/contribute/style.html) and [naming conventions](https://leanprover-community.github.io/contribute/naming.html).',
                   '',

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -78,13 +78,38 @@ jobs:
                 labels: ['new-contributor']
               });
 
-              console.log('Posting welcome comment for new contributor...');
-              await github.rest.issues.createComment({
+              // Check if we already posted a welcome comment (idempotency)
+              const comments = await github.rest.issues.listComments({
                 issue_number: context.issue.number,
                 owner,
                 repo,
-                body: '## Welcome new contributor!\nThank you for contributing to Mathlib! If you haven't done so already, please do review our [contribution guidelines](https://leanprover-community.github.io/contribute/index.html). In particular, we use a [review queue](https://leanprover-community.github.io/queueboard/review_dashboard.html) to manage reviews. If your PR does not appear there, it is probably because it is not successfully building (i.e., it doesn't have a green checkmark), has the `awaiting-author` tag, or another reason described in the [Lifecycle of a PR](https://leanprover-community.github.io/contribute/index.html#lifecycle-of-a-pr).\nIf you haven't already done so, please come to [https://leanprover.zulipchat.com/](https://leanprover.zulipchat.com/), introduce yourself, and mention your new PR.\nThank you again for joining our community.'
               });
+              const alreadyWelcomed = comments.data.some(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.includes('Welcome new contributor')
+              );
+
+              if (!alreadyWelcomed) {
+                console.log('Posting welcome comment for new contributor...');
+                const body = [
+                  '## Welcome new contributor!',
+                  'Thank you for contributing to Mathlib! If you haven\'t done so already, please review our [contribution guidelines](https://leanprover-community.github.io/contribute/index.html), as well as the [style guide](https://leanprover-community.github.io/contribute/style.html) and [naming conventions](https://leanprover-community.github.io/contribute/naming.html).',
+                  '',
+                  'We use a [review queue](https://leanprover-community.github.io/queueboard/review_dashboard.html) to manage reviews. If your PR does not appear there, it is probably because it is not successfully building (i.e., it doesn\'t have a green checkmark), has the `awaiting-author` tag, or another reason described in the [Lifecycle of a PR](https://leanprover-community.github.io/contribute/index.html#lifecycle-of-a-pr).',
+                  '',
+                  'If you haven\'t already done so, please come to [https://leanprover.zulipchat.com/](https://leanprover.zulipchat.com/), introduce yourself, and mention your new PR.',
+                  '',
+                  'Thank you again for joining our community.',
+                ].join('\n');
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner,
+                  repo,
+                  body,
+                });
+              } else {
+                console.log('Welcome comment already exists, skipping.');
+              }
             }
 
             console.log('Creating check run with a message about the PR count by this author...');


### PR DESCRIPTION
Currently, mathlib adds a "new-contributor" tag to PRs from folks with fewer than 5 PRs merged. However, this is more of a flag to reviewers and doesn't directly provide information to the new contributors.

This PR introduces a flow where when the "new-contributor" tag is added to a PR, a comment is also added reminding the new contributor to read the Lifecycle of a PR document and notes some common pitfalls (in particular, that tag management is performed via PR comments).

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)