### PR TITLE
[Merged by Bors] - ci: refactor maintainer_*.yml workflows to use new helper actions

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -23,19 +23,10 @@ jobs:
       COMMENT_REVIEW: ${{ github.event.review.body }}
       PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
       HAS_DELEGATED_LABEL: ${{ contains(github.event.issue.labels.*.name, 'delegated') }}
-      HAS_TRIAGE_SECRET: ${{ secrets.MATHLIB_TRIAGE_APP_ID != '' }}
     name: Add ready-to-merge or delegated label
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
-      - name: Generate app token
-        if: ${{ env.HAS_TRIAGE_SECRET == 'true' }}
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MATHLIB_TRIAGE_APP_ID }}
-          private-key: ${{ secrets.MATHLIB_TRIAGE_PRIVATE_KEY }}
-
       - name: Find bors merge/delegate
         id: merge_or_delegate
         run: |
@@ -79,143 +70,24 @@ jobs:
             BOT='false'
           fi
 
-          # write an artifact with all data needed below if we don't have access to necessary secrets
-          if [[ -z '${{ secrets.MATHLIB_TRIAGE_APP_ID }}' ]]
-          then
-            printf 'No access to secrets, writing to file.\n'
-            jq -n \
-              --arg author "${AUTHOR}" \
-              --arg pr_number "${PR_NUMBER}" \
-              --arg comment "${COMMENT}" \
-              --arg bot "${BOT}" \
-              --arg remove_labels "${remove_labels}" \
-              --arg m_or_d "${m_or_d}" \
-              '{
-                author: $author,
-                pr_number: $pr_number,
-                comment: $comment,
-                bot: $bot,
-                remove_labels: $remove_labels,
-                m_or_d: $m_or_d,
-              }' > artifact-data.json
-            echo "Generated JSON artifact:"
-            cat artifact-data.json
-
-            printf 'secrets=' >> "${GITHUB_OUTPUT}"
-            exit 0
-          else
-            printf 'secrets=true\n' >> "${GITHUB_OUTPUT}"
-          fi
-
-      # upload artifact if we have no access to secrets
-      - if: ${{ steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '') }}
-        name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: workflow-data
-          path: artifact-data.json
-          retention-days: 5
-
-      # Run the following steps only if we have access to secrets / write perms on GITHUB_TOKEN
-      - name: Check whether user is a mathlib admin
-        id: user_permission
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '') }}
-        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
-        with:
-          require: 'admin'
-
-      - name: Add ready-to-merge or delegated label
-        id: add_label
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
-        with:
-          route: POST /repos/:repository/issues/:issue_number/labels
-          # Unexpected input warning from the following is expected:
-          # https://github.com/octokit/request-action?tab=readme-ov-file#warnings
-          repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
-          labels: '["${{ steps.merge_or_delegate.outputs.mOrD }}"]'
-        env:
-          # The create-github-app-token README states that this token is masked and will not be logged accidentally.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        id: remove_labels
-        name: Remove "awaiting-author" and "maintainer-merge"
-        # we use curl rather than octokit/request-action so that the job won't fail
-        # (and send an annoying email) if the labels don't exist
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '' }}
+        name: Prepare bridge outputs
         run: |
-          for label in awaiting-author maintainer-merge; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
-          done
+          jq -n \
+            --arg bot "${{ steps.merge_or_delegate.outputs.bot }}" \
+            --arg removeLabels "${{ steps.merge_or_delegate.outputs.removeLabels }}" \
+            --arg mOrD "${{ steps.merge_or_delegate.outputs.mOrD }}" \
+            '{
+              bot: $bot,
+              removeLabels: $removeLabels,
+              mOrD: $mOrD,
+            }' > bridge-outputs.json
 
-      - name: On bors r/d-, remove ready-to-merge or delegated label
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.removeLabels == '' &&
-          steps.user_permission.outputs.require-result == 'true') }}
-        # we use curl rather than octokit/request-action so that the job won't fail
-        # (and send an annoying email) if the labels don't exist
-        run: |
-          for label in ready-to-merge delegated; do
-            curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/${label}" \
-              --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
-          done
-
-      - name: Checkout local actions
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '' }}
+        name: Emit bridge artifact
+        uses: leanprover-community/privilege-escalation-bridge/emit@v1
         with:
-          ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
-          sparse-checkout: .github/actions
-          path: workflow-actions
-      - name: Get mathlib-ci
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        uses: ./workflow-actions/.github/actions/get-mathlib-ci
-
-      - name: Set up Python
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
-
-      - name: update zulip emoji reactions
-        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
-          (! steps.merge_or_delegate.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' )) }}
-        env:
-          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
-          ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
-          ZULIP_SITE: https://leanprover.zulipchat.com
-        run: |
-          python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
+          artifact: workflow-data
+          outputs_file: bridge-outputs.json
+          include_event: minimal
+          retention_days: 5

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -63,11 +63,9 @@ jobs:
           then
             printf $'bot=true\n'
             printf $'bot=true\n' >> "${GITHUB_OUTPUT}"
-            BOT='true'
           else
             printf $'bot=false\n'
             printf $'bot=false\n' >> "${GITHUB_OUTPUT}"
-            BOT='false'
           fi
 
       - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '' }}

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -83,7 +83,7 @@ jobs:
 
       - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '' }}
         name: Emit bridge artifact
-        uses: leanprover-community/privilege-escalation-bridge/emit@v1
+        uses: leanprover-community/privilege-escalation-bridge/emit@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           outputs_file: bridge-outputs.json

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  contents: read
+
 
 jobs:
   add_ready_to_merge_label:

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Consume bridge artifact
         id: bridge
-        uses: leanprover-community/privilege-escalation-bridge/consume@v1
+        uses: leanprover-community/privilege-escalation-bridge/consume@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           source_workflow: Add "ready-to-merge" and "delegated" label

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           artifact: workflow-data
           source_workflow: Add "ready-to-merge" and "delegated" label
-          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
           require_event: issue_comment,pull_request_review,pull_request_review_comment
           fail_on_missing: false
           extract: |

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -103,16 +103,23 @@ jobs:
             steps.bridge.outputs.bot == 'true' ) }}
         run: |
           python -m pip install --upgrade pip
-          pip install zulip
+          pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
 
-      - if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+      - name: Checkout local actions
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
             steps.bridge.outputs.bot == 'true' ) }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
-          sparse-checkout: |
-            scripts/zulip_emoji_reactions.py
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+          path: workflow-actions
+      - name: Get mathlib-ci
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.bridge.outputs.bot == 'true' ) }}
+        uses: ./workflow-actions/.github/actions/get-mathlib-ci
 
       - name: update zulip emoji reactions
         if: ${{ ! steps.bridge.outputs.mOrD == '' &&
@@ -123,4 +130,4 @@ jobs:
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.pr_number }}"
+          python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.pr_number }}"

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -20,79 +20,50 @@ jobs:
           app-id: ${{ secrets.MATHLIB_TRIAGE_APP_ID }}
           private-key: ${{ secrets.MATHLIB_TRIAGE_PRIVATE_KEY }}
 
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+      - name: Consume bridge artifact
+        id: bridge
+        uses: leanprover-community/privilege-escalation-bridge/consume@v1
         with:
-          workflow: maintainer_bors.yml
-          name: workflow-data
-          path: ./artifacts
-          if_no_artifact_found: ignore
-          # Use the workflow run that triggered this workflow
-          run_id: ${{ github.event.workflow_run.id }}
-
-      - if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
-        name: Extract data from JSON artifact
-        id: extract-data
-        run: |
-          # Read the JSON artifact file and extract data
-          if [ -f "./artifacts/artifact-data.json" ]; then
-            echo "JSON artifact found, extracting data..."
-            echo "Full JSON artifact content:"
-            cat ./artifacts/artifact-data.json
-
-            # Extract specific values using jq
-            author=$(jq -r '.author' ./artifacts/artifact-data.json)
-            pr_number=$(jq -r '.pr_number' ./artifacts/artifact-data.json)
-            comment=$(jq -r '.comment' ./artifacts/artifact-data.json)
-            bot=$(jq -r '.bot' ./artifacts/artifact-data.json)
-            remove_labels=$(jq -r '.remove_labels' ./artifacts/artifact-data.json)
-            m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
-
-            # Set as step outputs for use in later steps
-            {
-              echo "author=$author"
-              echo "pr_number=$pr_number"
-              echo "comment<<EOF"
-              echo "$comment"
-              echo "EOF"
-              echo "bot=$bot"
-              echo "removeLabels=$remove_labels"
-              echo "mOrD=$m_or_d"
-            } | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "JSON artifact file not found!"
-            exit 1
-          fi
+          artifact: workflow-data
+          source_workflow: Add "ready-to-merge" and "delegated" label
+          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
+          require_event: issue_comment,pull_request_review,pull_request_review_comment
+          fail_on_missing: false
+          extract: |
+            author=event.comment.user.login|event.review.user.login
+            pr_number=meta.pr_number
+            bot=outputs.bot
+            removeLabels=outputs.removeLabels
+            mOrD=outputs.mOrD
 
       - name: Check whether user is a mathlib admin
         id: user_permission
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' || ! steps.extract-data.outputs.removeLabels == '' }}
+        if: ${{ ! steps.bridge.outputs.mOrD == '' || ! steps.bridge.outputs.removeLabels == '' }}
         uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
-          username: ${{ steps.extract-data.outputs.author }}
+          username: ${{ steps.bridge.outputs.author }}
           require: 'admin'
 
       - name: Add ready-to-merge or delegated label
         id: add_label
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
+            steps.bridge.outputs.bot == 'true' ) }}
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
           # Unexpected input warning from the following is expected:
           # https://github.com/octokit/request-action?tab=readme-ov-file#warnings
           repository: ${{ github.repository }}
-          issue_number: ${{ steps.extract-data.outputs.pr_number }}
-          labels: '["${{ steps.extract-data.outputs.mOrD }}"]'
+          issue_number: ${{ steps.bridge.outputs.pr_number }}
+          labels: '["${{ steps.bridge.outputs.mOrD }}"]'
         env:
           # The create-github-app-token README states that this token is masked and will not be logged accidentally.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+      - if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
+            steps.bridge.outputs.bot == 'true' ) }}
         id: remove_labels
         name: Remove "awaiting-author" and "maintainer-merge"
         # we use curl rather than octokit/request-action so that the job won't fail
@@ -100,60 +71,53 @@ jobs:
         run: |
           for label in awaiting-author maintainer-merge; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.extract-data.outputs.pr_number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.bridge.outputs.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
           done
 
       - name: On bors r/d-, remove ready-to-merge or delegated label
-        if: ${{ ! steps.extract-data.outputs.removeLabels == '' && steps.user_permission.outputs.require-result == 'true' }}
+        if: ${{ ! steps.bridge.outputs.removeLabels == '' && steps.user_permission.outputs.require-result == 'true' }}
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
           for label in ready-to-merge delegated; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.extract-data.outputs.pr_number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.bridge.outputs.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
           done
 
-      - name: Checkout local actions
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
-          sparse-checkout: .github/actions
-          path: workflow-actions
-      - name: Get mathlib-ci
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
-        uses: ./workflow-actions/.github/actions/get-mathlib-ci
-
       - name: Set up Python
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
+            steps.bridge.outputs.bot == 'true' ) }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
+            steps.bridge.outputs.bot == 'true' ) }}
         run: |
           python -m pip install --upgrade pip
-          pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
+          pip install zulip
+
+      - if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.bridge.outputs.bot == 'true' ) }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          sparse-checkout: |
+            scripts/zulip_emoji_reactions.py
 
       - name: update zulip emoji reactions
-        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.extract-data.outputs.bot == 'true' ) }}
+            steps.bridge.outputs.bot == 'true' ) }}
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.extract-data.outputs.mOrD }}" "${{ steps.extract-data.outputs.mOrD }}" "${{ steps.extract-data.outputs.pr_number }}"
+          python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.pr_number }}"

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -27,24 +27,15 @@ jobs:
       PR_TITLE_PR: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.issue.html_url }}${{ github.event.pull_request.html_url }}
       EVENT_NAME: ${{ github.event_name }}
-      HAS_TRIAGE_SECRET: ${{ secrets.MATHLIB_TRIAGE_APP_ID != '' }}
     name: Ping maintainers on Zulip
     runs-on: ubuntu-latest
     if: >- # crude check to skip running this on most reviews / comments
-      github.repository == 'leanprover-community/mathlib4' &&
+      github.repository == 'leanprover-community/mathlib4' && 
       (
-        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') ||
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') || 
         contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer delegate')
       )
     steps:
-      - name: Generate app token
-        if: ${{ env.HAS_TRIAGE_SECRET == 'true' }}
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MATHLIB_TRIAGE_APP_ID }}
-          private-key: ${{ secrets.MATHLIB_TRIAGE_PRIVATE_KEY }}
-
       - name: Find maintainer merge/delegate
         id: merge_or_delegate
         run: |
@@ -66,121 +57,20 @@ jobs:
 
           printf $'mOrD=%s\n' "${m_or_d}" > "${GITHUB_OUTPUT}"
 
-          # write an artifact with all data needed below if we don't have access to necessary secrets
-          if [[ -z '${{ secrets.MATHLIB_TRIAGE_APP_ID }}' ]]
-          then
-            printf 'No access to secrets, writing to file.\n'
-            jq -n \
-              --arg author "${AUTHOR}" \
-              --arg pr_author "${PR_AUTHOR}" \
-              --arg pr_number "${PR_NUMBER}" \
-              --arg comment "${COMMENT}" \
-              --arg pr_title "${PR_TITLE_ISSUE}${PR_TITLE_PR}" \
-              --arg pr_url "${PR_URL}" \
-              --arg event_name "${EVENT_NAME}" \
-              --arg m_or_d "${m_or_d}" \
-              '{
-                author: $author,
-                pr_author: $pr_author,
-                pr_number: $pr_number,
-                comment: $comment,
-                pr_title: $pr_title,
-                pr_url: $pr_url,
-                event_name: $event_name,
-                m_or_d: $m_or_d,
-              }' > artifact-data.json
-            echo "Generated JSON artifact:"
-            cat artifact-data.json
-
-            printf 'secrets=' >> "${GITHUB_OUTPUT}"
-            exit 0
-          else
-            printf 'secrets=true\n' >> "${GITHUB_OUTPUT}"
-          fi
-
-      # upload artifact if we have no access to secrets
-      - if: ${{ steps.merge_or_delegate.outputs.secrets == '' && ! steps.merge_or_delegate.outputs.mOrD == '' }}
-        name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: workflow-data
-          path: artifact-data.json
-          retention-days: 5
-
-      # Run the following steps only if we have access to secrets / write perms on GITHUB_TOKEN
-      - if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' && ! steps.merge_or_delegate.outputs.mOrD == '' }}
-        name: Check whether user is part of mathlib-reviewers team
-        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
-        id: actorTeams
-        with:
-          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
-                  # Organization to get membership from.
-          team: 'mathlib-reviewers'
-          username: ${{ env.AUTHOR }}
-          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
-
-      - name: Checkout local actions
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
-          sparse-checkout: .github/actions
-          path: workflow-actions
-      - name: Get mathlib-ci
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: ./workflow-actions/.github/actions/get-mathlib-ci
-
-      - name: Determine Zulip topic
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        id: determine_topic
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        name: Prepare bridge outputs
         run: |
-          "${CI_SCRIPTS_DIR}/maintainer/get_tlabel.sh" "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          jq -n \
+            --arg mOrD "${{ steps.merge_or_delegate.outputs.mOrD }}" \
+            '{
+              mOrD: $mOrD,
+            }' > bridge-outputs.json
 
-      - name: Form the message
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        id: form_the_message
-        run: |
-          # for debugging, we print the available variables
-          echo "github.event.action: '${{ github.event.action }}'"
-
-          echo ""
-          message="$(
-            "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE_ISSUE}${PR_TITLE_PR}" "${COMMENT_EVENT}${COMMENT_REVIEW}" "${PR_AUTHOR}"
-          )"
-          printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
-
-      - name: Send message on Zulip
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        name: Emit bridge artifact
+        uses: leanprover-community/privilege-escalation-bridge/emit@v1
         with:
-          api-key: ${{ secrets.ZULIP_API_KEY }}
-          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
-          organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
-          type: 'stream'
-          topic: ${{ steps.determine_topic.outputs.topic }}
-          content: ${{ steps.form_the_message.outputs.title }}
-
-      - name: Add comment to PR
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
-        with:
-          # if a comment triggers the action, then `issue.number` is set
-          # if a review or review comment triggers the action, then `pull_request.number` is set
-          issue-number: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
-          body: |
-            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}.
-
-      - name: Add label to PR
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow
-          # The create-github-app-token README states that this token is masked and will not be logged accidentally.
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const { owner, repo, number: issue_number } = context.issue;
-            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });
+          artifact: workflow-data
+          outputs_file: bridge-outputs.json
+          include_event: minimal
+          retention_days: 5

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -30,9 +30,9 @@ jobs:
     name: Ping maintainers on Zulip
     runs-on: ubuntu-latest
     if: >- # crude check to skip running this on most reviews / comments
-      github.repository == 'leanprover-community/mathlib4' && 
+      github.repository == 'leanprover-community/mathlib4' &&
       (
-        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') || 
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') ||
         contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer delegate')
       )
     steps:
@@ -68,7 +68,7 @@ jobs:
 
       - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
         name: Emit bridge artifact
-        uses: leanprover-community/privilege-escalation-bridge/emit@v1
+        uses: leanprover-community/privilege-escalation-bridge/emit@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           outputs_file: bridge-outputs.json

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   ping_zulip:
     name: Ping maintainers on Zulip

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Consume bridge artifact
         id: bridge
-        uses: leanprover-community/privilege-escalation-bridge/consume@v1
+        uses: leanprover-community/privilege-escalation-bridge/consume@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           source_workflow: Maintainer merge

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -20,61 +20,26 @@ jobs:
           app-id: ${{ secrets.MATHLIB_TRIAGE_APP_ID }}
           private-key: ${{ secrets.MATHLIB_TRIAGE_PRIVATE_KEY }}
 
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+      - name: Consume bridge artifact
+        id: bridge
+        uses: leanprover-community/privilege-escalation-bridge/consume@v1
         with:
-          workflow: maintainer_merge.yml
-          name: workflow-data
-          path: ./artifacts
-          if_no_artifact_found: ignore
-          # Use the workflow run that triggered this workflow
-          run_id: ${{ github.event.workflow_run.id }}
+          artifact: workflow-data
+          source_workflow: Maintainer merge
+          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
+          require_event: issue_comment,pull_request_review,pull_request_review_comment
+          fail_on_missing: false
+          extract: |
+            author=event.comment.user.login|event.review.user.login
+            pr_author=event.issue.user.login|event.pull_request.user.login
+            pr_number=meta.pr_number
+            comment=event.comment.body|event.review.body
+            pr_title=event.issue.title|event.pull_request.title
+            pr_url=event.issue.html_url|event.pull_request.html_url
+            event_name=meta.event_name
+            mOrD=outputs.mOrD
 
-      - if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
-        name: Extract data from JSON artifact
-        id: extract-data
-        run: |
-          # Read the JSON artifact file and extract data
-          if [ -f "./artifacts/artifact-data.json" ]; then
-            echo "JSON artifact found, extracting data..."
-            echo "Full JSON artifact content:"
-            cat ./artifacts/artifact-data.json
-
-            # Extract specific values using jq
-            author=$(jq -r '.author' ./artifacts/artifact-data.json)
-            pr_author=$(jq -r '.pr_author' ./artifacts/artifact-data.json)
-            pr_number=$(jq -r '.pr_number' ./artifacts/artifact-data.json)
-            comment=$(jq -r '.comment' ./artifacts/artifact-data.json)
-            pr_title=$(jq -r '.pr_title' ./artifacts/artifact-data.json)
-            pr_url=$(jq -r '.pr_url' ./artifacts/artifact-data.json)
-            event_name=$(jq -r '.event_name' ./artifacts/artifact-data.json)
-            m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
-
-            # Set as step outputs for use in later steps
-            {
-              echo "author=$author"
-              echo "pr_author=$pr_author"
-              echo "pr_number=$pr_number"
-
-              echo "comment<<EOF"
-              echo "$comment"
-              echo "EOF"
-
-              echo "pr_title<<EOF"
-              echo "$pr_title"
-              echo "EOF"
-
-              echo "pr_url=$pr_url"
-              echo "event_name=$event_name"
-              echo "mOrD=$m_or_d"
-            } | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "JSON artifact file not found!"
-            exit 1
-          fi
-
-      - if: ${{ ! steps.extract-data.outputs.mOrD == '' }}
+      - if: ${{ ! steps.bridge.outputs.mOrD == '' }}
         name: Check whether user is part of mathlib-reviewers team
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: actorTeams
@@ -82,46 +47,43 @@ jobs:
           organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
                   # Organization to get membership from.
           team: 'mathlib-reviewers'
-          username: ${{ steps.extract-data.outputs.author }}
+          username: ${{ steps.bridge.outputs.author }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - name: Checkout local actions
+      - name: Checkout
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
-          sparse-checkout: .github/actions
-          path: workflow-actions
-      - name: Get mathlib-ci
-        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
-        uses: ./workflow-actions/.github/actions/get-mathlib-ci
+          ref: master
+          sparse-checkout: |
+            scripts/get_tlabel.py
+            scripts/maintainer_merge_message.py
 
       - name: Determine Zulip topic
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: determine_topic
         run: |
-          "${CI_SCRIPTS_DIR}/maintainer/get_tlabel.sh" "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          ./scripts/get_tlabel.sh "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PR_NUMBER: ${{ steps.extract-data.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
 
       - name: Form the message
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: form_the_message
         run: |
           message="$(
-            "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.extract-data.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
+            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.bridge.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
           )"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
         env:
-          AUTHOR: ${{ steps.extract-data.outputs.author }}
-          EVENT_NAME: ${{ steps.extract-data.outputs.event_name }}
-          PR_NUMBER: ${{ steps.extract-data.outputs.pr_number }}
-          PR_URL: ${{ steps.extract-data.outputs.pr_url }}
-          PR_TITLE: ${{ steps.extract-data.outputs.pr_title }}
-          COMMENT: ${{ steps.extract-data.outputs.comment }}
-          PR_AUTHOR: ${{ steps.extract-data.outputs.pr_author }}
+          AUTHOR: ${{ steps.bridge.outputs.author }}
+          EVENT_NAME: ${{ steps.bridge.outputs.event_name }}
+          PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
+          PR_URL: ${{ steps.bridge.outputs.pr_url }}
+          PR_TITLE: ${{ steps.bridge.outputs.pr_title }}
+          COMMENT: ${{ steps.bridge.outputs.comment }}
+          PR_AUTHOR: ${{ steps.bridge.outputs.pr_author }}
 
       - name: Send message on Zulip
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
@@ -141,9 +103,9 @@ jobs:
         with:
           # if a comment triggers the action, then `issue.number` is set
           # if a review or review comment triggers the action, then `pull_request.number` is set
-          issue-number: ${{ steps.extract-data.outputs.pr_number }}
+          issue-number: ${{ steps.bridge.outputs.pr_number }}
           body: |
-            🚀 Pull request has been placed on the maintainer queue by ${{ steps.extract-data.outputs.author }}.
+            🚀 Pull request has been placed on the maintainer queue by ${{ steps.bridge.outputs.author }}.
 
       - name: Add label to PR
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
@@ -154,5 +116,5 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = ${{ steps.extract-data.outputs.pr_number }};
+            const issue_number = ${{ steps.bridge.outputs.pr_number }};
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           artifact: workflow-data
           source_workflow: Maintainer merge
-          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
           require_event: issue_comment,pull_request_review,pull_request_review_comment
           fail_on_missing: false
           extract: |

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -53,20 +53,23 @@ jobs:
           username: ${{ steps.bridge.outputs.author }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - name: Checkout
+      - name: Checkout local actions
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
-          sparse-checkout: |
-            scripts/get_tlabel.py
-            scripts/maintainer_merge_message.py
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          sparse-checkout: .github/actions
+          path: workflow-actions
+      - name: Get mathlib-ci
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        uses: ./workflow-actions/.github/actions/get-mathlib-ci
 
       - name: Determine Zulip topic
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: determine_topic
         run: |
-          ./scripts/get_tlabel.sh "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          "${CI_SCRIPTS_DIR}/maintainer/get_tlabel.sh" "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
@@ -76,7 +79,7 @@ jobs:
         id: form_the_message
         run: |
           message="$(
-            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.bridge.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
+            "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.bridge.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
           )"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
The workflows `maintainer_{bors,merge}.yml` workflows were rewritten in #26288 so that they were split into two workflows. The first workflow is triggered by an issue comment, PR review, or PR review comment and does not have access to secrets. The second workflow is triggered by the successful completion of the first workflow and does the actual labeling of the PR using its access to secrets. Data about the PR and the triggering comment / review is passed between workflows by use of a workflow artifact. It turns out this is a fairly useful pattern, so I've created [leanprover-community/privilege-escalation-brdge](https://github.com/leanprover-community/privilege-escalation-bridge) with some helper actions that we will be able to use in more workflows.

This PR refactors the abovementioned PRs to use the new actions. There is a slight change in behavior: previously PRs which were opened from a branch in this repo (as opposed to a branch in a fork) would just be handled using some steps in the first workflow (since the workflow does get access to secrets for such PRs) and the second workflow would not be triggered. Now all PRs are treated equally -- they all go through both workflows. This will slow down labeling for the (rare) PRs which are still opened from branches in this repo, however, I think that's outweighed by the resulting simplification of the workflows. Other than this though the behavior should be unchanged.

Prepared with codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
