### PR TITLE
[Merged by Bors] - chore(Order/Hom/Basic): remove unused OrderDual instances

### DIFF
--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -540,11 +540,6 @@ theorem uliftRightMap_uliftLeftMap_eq (f : α →o β) : f.uliftRightMap.uliftLe
 
 end OrderHom
 
--- See note [lower instance priority]
-instance (priority := 90) OrderHomClass.toOrderHomClassOrderDual [LE α] [LE β]
-    [FunLike F α β] [OrderHomClass F α β] : OrderHomClass F αᵒᵈ βᵒᵈ where
-  map_rel f := map_rel f
-
 /-- Embeddings of partial orders that preserve `<` also preserve `≤`. -/
 def RelEmbedding.orderEmbeddingOfLTEmbedding [PartialOrder α] [PartialOrder β]
     (f : ((· < ·) : α → α → Prop) ↪r ((· < ·) : β → β → Prop)) : α ↪o β :=
@@ -1210,11 +1205,6 @@ theorem OrderIso.complementedLattice_iff (f : α ≃o β) :
 end BoundedOrder
 
 end LatticeIsos
-
--- See note [lower instance priority]
-instance (priority := 90) OrderIsoClass.toOrderIsoClassOrderDual [LE α] [LE β]
-    [EquivLike F α β] [OrderIsoClass F α β] : OrderIsoClass F αᵒᵈ βᵒᵈ where
-  map_le_map_iff f := map_le_map_iff f
 
 section DenselyOrdered
 


### PR DESCRIPTION
This PR removes `OrderHomClass.toOrderHomClassOrderDual` and `OrderIsoClass.toOrderIsoClassOrderDual`. These instances are unused throughout mathlib.

These instances also require hacky local instances to work under https://github.com/leanprover/lean4/pull/12286. If they are both unused and unwanted, it is simpler to delete them on master rather than working around the issue.

🤖 Prepared with Claude Code