### PR TITLE
[Merged by Bors] - ci: refactor commit_verification so it works on PRs from forks

### DIFF
--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -3,7 +3,7 @@
 #
 # - Transient commits (prefix: "transient: ") must have zero net effect
 # - Automated commits (prefix: "x: <command>") must match command output
-# - Posts a summary comment categorizing commits for reviewers
+# - Uploads a workflow artifact with verification status and a comment to be posted on the PR
 
 name: Commit Verification
 
@@ -18,7 +18,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   TRANSIENT_PREFIX: "transient: "
@@ -100,26 +99,24 @@ jobs:
           # Save to file (GitHub Actions has issues with multiline outputs)
           echo "$COMMENT" > comment_body.md
 
-      - name: Find existing comment
+      - name: Prepare bridge outputs
         if: steps.check.outputs.has_special == 'true'
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'Commit Verification Summary'
-
-      - name: Post or update comment
-        if: steps.check.outputs.has_special == 'true'
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v4
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: comment_body.md
-          edit-mode: replace
-
-      - name: Set job status
-        if: steps.check.outputs.has_special == 'true' && steps.verify.outputs.success == 'false'
         run: |
-          echo "::error::Commit verification failed. See PR comment for details."
-          exit 1
+          jq -n \
+            --arg has_special "${{ steps.check.outputs.has_special }}" \
+            --arg success "${{ steps.verify.outputs.success }}" \
+            '{
+              has_special: $has_special,
+              success: $success,
+            }' > bridge-outputs.json
+
+      - name: Emit bridge artifact
+        if: steps.check.outputs.has_special == 'true'
+        uses: leanprover-community/privilege-escalation-bridge/emit@v1
+        with:
+          artifact: workflow-data
+          outputs_file: bridge-outputs.json
+          include_event: minimal
+          files: |
+            comment_body.md
+          retention_days: 5

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Emit bridge artifact
         if: steps.check.outputs.has_special == 'true'
-        uses: leanprover-community/privilege-escalation-bridge/emit@v1
+        uses: leanprover-community/privilege-escalation-bridge/emit@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           outputs_file: bridge-outputs.json

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -100,7 +100,6 @@ jobs:
           echo "$COMMENT" > comment_body.md
 
       - name: Prepare bridge outputs
-        if: steps.check.outputs.has_special == 'true'
         run: |
           jq -n \
             --arg has_special "${{ steps.check.outputs.has_special }}" \

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -66,6 +66,7 @@ jobs:
           else
             echo "has_special=false" >> "$GITHUB_OUTPUT"
             echo "No transient or automated commits found"
+            echo "No transient or automated commits found; this comment should never be posted" > comment_body.md
           fi
 
       - name: Verify commits

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -111,7 +111,6 @@ jobs:
             }' > bridge-outputs.json
 
       - name: Emit bridge artifact
-        if: steps.check.outputs.has_special == 'true'
         uses: leanprover-community/privilege-escalation-bridge/emit@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data

--- a/.github/workflows/commit_verification_wf_run.yml
+++ b/.github/workflows/commit_verification_wf_run.yml
@@ -1,0 +1,67 @@
+# Commit Verification CI (workflow run)
+# Verifies transient and automated commits in PRs
+#
+# - Downloads the workflow artifact uploaded by commit_verification.yml
+# - Posts a summary comment categorizing commits for reviewers
+
+name: Commit Verification (workflow_run)
+
+on:
+  workflow_run:
+    workflows: ["Commit Verification"]
+    types:
+      - completed
+
+# Cancel in-progress runs for the same PR
+concurrency:
+  group: commit-verification-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify:
+    name: Verify Transient and Automated Commits
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Consume bridge artifact
+        id: bridge
+        uses: leanprover-community/privilege-escalation-bridge/consume@v1
+        with:
+          artifact: workflow-data
+          source_workflow: Commit Verification
+          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
+          require_event: pull_request
+          fail_on_missing: false
+          extract: |
+            pr_number=meta.pr_number
+            has_special=outputs.has_special
+            success=outputs.success
+
+      - name: Find existing comment
+        if: steps.bridge.outputs.has_special == 'true'
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        id: find-comment
+        with:
+          issue-number: ${{ steps.bridge.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Commit Verification Summary'
+
+      - name: Post or update comment
+        if: steps.bridge.outputs.has_special == 'true'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.bridge.outputs.pr_number }}
+          body-path: .bridge/comment_body.md
+          edit-mode: replace
+
+      - name: Set job status
+        if: steps.bridge.outputs.has_special == 'true' && steps.bridge.outputs.success == 'false'
+        run: |
+          echo "::error::Commit verification failed. See PR comment for details."
+          exit 1

--- a/.github/workflows/commit_verification_wf_run.yml
+++ b/.github/workflows/commit_verification_wf_run.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           artifact: workflow-data
           source_workflow: Commit Verification
-          expected_head_sha: ${{ github.event.workflow_run.head_sha }}
           require_event: pull_request
           fail_on_missing: false
           extract: |

--- a/.github/workflows/commit_verification_wf_run.yml
+++ b/.github/workflows/commit_verification_wf_run.yml
@@ -27,6 +27,7 @@ jobs:
         id: bridge
         uses: leanprover-community/privilege-escalation-bridge/consume@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
+          token: ${{ github.token }}
           artifact: workflow-data
           source_workflow: Commit Verification
           require_event: pull_request

--- a/.github/workflows/commit_verification_wf_run.yml
+++ b/.github/workflows/commit_verification_wf_run.yml
@@ -12,11 +12,6 @@ on:
     types:
       - completed
 
-# Cancel in-progress runs for the same PR
-concurrency:
-  group: commit-verification-${{ github.event.workflow_run.pull_requests[0].number }}
-  cancel-in-progress: true
-
 permissions:
   actions: read
   contents: read
@@ -30,7 +25,7 @@ jobs:
     steps:
       - name: Consume bridge artifact
         id: bridge
-        uses: leanprover-community/privilege-escalation-bridge/consume@v1
+        uses: leanprover-community/privilege-escalation-bridge/consume@d3bd99c50a4cf8c5350a211e8e3ba07ac19067d8 # v1.1.0
         with:
           artifact: workflow-data
           source_workflow: Commit Verification


### PR DESCRIPTION
Currently the commit verification workflow fails when run on a PR from a fork because it tries to post a comment, but its GITHUB_TOKEN is read-only. [Example failure](https://github.com/leanprover-community/mathlib4/actions/runs/21796757425/job/62885536927?pr=34973)

This PR refactors the commit verification workflow using the new [leanprover-community/privilege-escalation-bridge](https://github.com/leanprover-community/privilege-escalation-bridge), splitting it into two workflows where the second one (triggered by `workflow_run` has access to a GITHUB_TOKEN that can post comments).

We also make the workflow run the commit verification scripts from `master` rather than the PR branch to close a small security issue where someone could spoof verification / get the workflow to post arbitrary comments by modifying the scripts in their branch.

Prepared with codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
