### PR TITLE
[Merged by Bors] - perf(to_dual): first try translating without inserting casts

### DIFF
--- a/Mathlib/Tactic/Translate/UnfoldBoundary.lean
+++ b/Mathlib/Tactic/Translate/UnfoldBoundary.lean
@@ -123,7 +123,7 @@ def mkAppWithCast (b : UnfoldBoundaries) (f a : Expr) : SimpM Expr :=
     return f.app (← mkCast b a d)
 
 /-- Modify `e` so that it has type `expectedType` if the constants in `b` cannot be unfolded. -/
-def UnfoldBoundaries.cast (b : UnfoldBoundaries) (e expectedType : Expr) (attr : Name) :
+public def UnfoldBoundaries.cast (b : UnfoldBoundaries) (e expectedType : Expr) (attr : Name) :
     MetaM Expr :=
   run b <|
   try
@@ -137,7 +137,7 @@ def UnfoldBoundaries.cast (b : UnfoldBoundaries) (e expectedType : Expr) (attr :
 Note: it may be that `e` contains some constant whose type is not well typed in this setting.
 We don't make an effort to replace such constants.
 It seems that this approximation works well enough. -/
-def UnfoldBoundaries.insertBoundaries (b : UnfoldBoundaries) (e : Expr) (attr : Name) :
+public def UnfoldBoundaries.insertBoundaries (b : UnfoldBoundaries) (e : Expr) (attr : Name) :
     MetaM Expr :=
   run b <| Meta.transform e (post := fun e ↦ e.withApp fun f args =>
     try
@@ -147,7 +147,7 @@ def UnfoldBoundaries.insertBoundaries (b : UnfoldBoundaries) (e : Expr) (attr : 
         well typed\n\n{ex.toMessageData}")
 
 /-- Unfold all of the auxiliary functions that were inserted as unfold boundaries. -/
-def UnfoldBoundaries.unfoldInsertions (e : Expr) (b : UnfoldBoundaries) : CoreM Expr :=
+public def UnfoldBoundaries.unfoldInsertions (e : Expr) (b : UnfoldBoundaries) : CoreM Expr :=
   -- This is the same as `Meta.deltaExpand`, but with an extra beta reduction.
   Core.transform e fun e => do
     if let some e ← delta? e b.insertionFuns.contains then
@@ -181,20 +181,5 @@ public def registerUnfoldBoundaryExt : IO UnfoldBoundaryExt := do
     addEntryFn := UnfoldBoundaries.insert
     addImportedFn as := as.foldl (Array.foldl (·.insert ·)) {}
   }
-
-@[inherit_doc UnfoldBoundaries.cast]
-public def UnfoldBoundaryExt.cast (b : UnfoldBoundaryExt) (e expectedType : Expr) (attr : Name) :
-    MetaM Expr := do
-  (b.getState (← getEnv)).cast e expectedType attr
-
-@[inherit_doc UnfoldBoundaries.insertBoundaries]
-public def UnfoldBoundaryExt.insertBoundaries (b : UnfoldBoundaryExt) (e : Expr) (attr : Name) :
-    MetaM Expr := do
-  (b.getState (← getEnv)).insertBoundaries e attr
-
-@[inherit_doc UnfoldBoundaries.unfoldInsertions]
-public def UnfoldBoundaryExt.unfoldInsertions (e : Expr) (b : UnfoldBoundaryExt) : CoreM Expr := do
-  (b.getState (← getEnv)).unfoldInsertions e
-
 
 end Mathlib.Tactic.UnfoldBoundary

--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -32,8 +32,9 @@ attribute [to_dual existing] Lattice.toSemilatticeInf
 
 -- we still cannot reorder arguments of arguments, so `SemilatticeInf.mk` is not translatable
 /--
-error: @[to_dual] failed. The translated value is not type correct. For help, see the docstring of `to_additive`, section `Troubleshooting`. Failed to add declaration
-instSemilatticeSupOfForallLeForallMax:
+error: @[to_dual] failed to add declaration `instSemilatticeSupOfForallLeForallMax`.
+  The translated value is not type correct.
+  For help, see the docstring of `to_additive`, section `Troubleshooting`.
 Application type mismatch: The argument
   le_inf
 has type


### PR DESCRIPTION
This PR addresses the performance regression introduced by #32438. The problem is that deciding where casts need to be inserted is an expensive operation (similarly expensive to kernel type checking). I expect that in category theory this will be particularly significant.

Most uses of `to_dual` don't need any casts to be inserted at all. So, it is more efficient to simply first try translating without inserting casts. And if that fails, we insert casts and then try again.

So after this PR, in the failure case, `to_dual` will check the term 4 times:
- first try the translation without casts
- then determine where casts should go
- then try the translation of this
- then use `Meta.check` to get a nicer error message.

This is OK, since the failure case is not the performance critical case.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
