### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/Lifts): Add `mem_lifts_and_support_eq`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -141,9 +141,9 @@ theorem monomial_mem_lifts_and_degree_eq {s : S} {n : ℕ} (hl : monomial n s �
   rw [degree_monomial, degree_monomial n h]
   exact mt (fun ha ↦ ha ▸ map_zero f) h
 
-/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same degree. -/
-theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
-    ∃ q : R[X], map f q = p ∧ q.degree = p.degree := by
+/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same support. -/
+theorem mem_lifts_and_support_eq {p : S[X]} (hlifts : p ∈ lifts f) :
+    ∃ q : R[X], map f q = p ∧ q.support = p.support := by
   rw [lifts_iff_coeff_lifts] at hlifts
   let g : ℕ → R := fun k ↦ (hlifts k).choose
   have hg : ∀ k, f (g k) = p.coeff k := fun k ↦ (hlifts k).choose_spec
@@ -153,6 +153,12 @@ theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     simp_rw [Finset.ext_iff, mem_support_iff, q, finset_sum_coeff, coeff_monomial,
       Finset.sum_ite_eq', ite_ne_right_iff, mem_support_iff, and_iff_left_iff_imp, not_imp_not]
     exact fun k h ↦ by rw [← hg, h, map_zero]
+  exact ⟨q, hq, hq'⟩
+
+/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same degree. -/
+theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
+    ∃ q : R[X], map f q = p ∧ q.degree = p.degree := by
+  obtain ⟨q, hq, hq'⟩ := mem_lifts_and_support_eq hlifts
   exact ⟨q, hq, congrArg Finset.max hq'⟩
 
 end LiftDeg

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -141,7 +141,7 @@ theorem monomial_mem_lifts_and_degree_eq {s : S} {n : ℕ} (hl : monomial n s �
   rw [degree_monomial, degree_monomial n h]
   exact mt (fun ha ↦ ha ▸ map_zero f) h
 
-/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same support. -/
+/-- A polynomial that lifts can be lifted to a polynomial of the same support. -/
 theorem mem_lifts_and_support_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     ∃ q : R[X], map f q = p ∧ q.support = p.support := by
   rw [lifts_iff_coeff_lifts] at hlifts
@@ -155,7 +155,7 @@ theorem mem_lifts_and_support_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     exact fun k h ↦ by rw [← hg, h, map_zero]
   exact ⟨q, hq, hq'⟩
 
-/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same degree. -/
+/-- A polynomial that lifts can be lifted to a polynomial of the same degree. -/
 theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     ∃ q : R[X], map f q = p ∧ q.degree = p.degree := by
   obtain ⟨q, hq, hq'⟩ := mem_lifts_and_support_eq hlifts

--- a/Mathlib/Algebra/Polynomial/Lifts.lean
+++ b/Mathlib/Algebra/Polynomial/Lifts.lean
@@ -142,7 +142,7 @@ theorem monomial_mem_lifts_and_degree_eq {s : S} {n : ℕ} (hl : monomial n s �
   exact mt (fun ha ↦ ha ▸ map_zero f) h
 
 /-- A polynomial that lifts can be lifted to a polynomial of the same support. -/
-theorem mem_lifts_and_support_eq {p : S[X]} (hlifts : p ∈ lifts f) :
+theorem exists_support_eq_of_mem_lifts {p : S[X]} (hlifts : p ∈ lifts f) :
     ∃ q : R[X], map f q = p ∧ q.support = p.support := by
   rw [lifts_iff_coeff_lifts] at hlifts
   let g : ℕ → R := fun k ↦ (hlifts k).choose
@@ -155,11 +155,14 @@ theorem mem_lifts_and_support_eq {p : S[X]} (hlifts : p ∈ lifts f) :
     exact fun k h ↦ by rw [← hg, h, map_zero]
   exact ⟨q, hq, hq'⟩
 
-/-- A polynomial that lifts can be lifted to a polynomial of the same degree. -/
-theorem mem_lifts_and_degree_eq {p : S[X]} (hlifts : p ∈ lifts f) :
+/-- A polynomial lifts if and only if it can be lifted to a polynomial of the same degree. -/
+theorem exists_degree_eq_of_mem_lifts {p : S[X]} (hlifts : p ∈ lifts f) :
     ∃ q : R[X], map f q = p ∧ q.degree = p.degree := by
-  obtain ⟨q, hq, hq'⟩ := mem_lifts_and_support_eq hlifts
+  obtain ⟨q, hq, hq'⟩ := exists_support_eq_of_mem_lifts hlifts
   exact ⟨q, hq, congrArg Finset.max hq'⟩
+
+@[deprecated (since := "2026-02-11")]
+alias mem_lifts_and_degree_eq := exists_degree_eq_of_mem_lifts
 
 end LiftDeg
 

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -573,9 +573,9 @@ nonrec lemma resultant_mul_right (f g₁ g₂ : R[X]) (m : ℕ) (hm : f.natDegre
     rw [← Polynomial.map_mul] at this
     simpa only [resultant_map_map, ← map_mul, natDegree_map_eq_of_injective hφ] using this
   | surjective R S φ hφ f IH =>
-    obtain ⟨f', hf', e⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ f)
-    obtain ⟨g₁', hg₁, e₁⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ g₁)
-    obtain ⟨g₂', hg₂, e₂⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ g₂)
+    obtain ⟨f', hf', e⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ f)
+    obtain ⟨g₁', hg₁, e₁⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ g₁)
+    obtain ⟨g₂', hg₂, e₂⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ g₂)
     rw [← hg₁, ← hg₂, ← hf', ← Polynomial.map_mul]
     simp_rw [resultant_map_map, hg₁, hg₂, hf', ← natDegree_eq_natDegree e₁,
       ← natDegree_eq_natDegree e₂, ← natDegree_eq_natDegree e, IH, map_mul]
@@ -600,7 +600,7 @@ lemma resultant_mul_left (f₁ f₂ g : R[X]) (n : ℕ) (hn : g.natDegree ≤ n)
     apply hφ
     simpa only [resultant_map_map, natDegree_map_eq_of_injective hφ, map_zero, map_pow] using IH
   | surjective R S φ hφ f IH =>
-    obtain ⟨f', hf', e⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ f)
+    obtain ⟨f', hf', e⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ f)
     rw [← hf', resultant_map_map, hf', ← natDegree_eq_natDegree e, IH f', map_pow, map_zero]
 
 lemma resultant_self_eq_zero (f : R[X]) (h : f.natDegree ≠ 0) :
@@ -719,8 +719,8 @@ nonrec lemma resultant_scaleRoots (f g : R[X]) (r : R) :
     · simpa [natDegree_map_eq_of_injective hφ] using this
     all_goals simpa [map_eq_zero_iff _ hφ]
   | surjective R S φ hφ f IH =>
-    obtain ⟨f', hf', ef⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ f)
-    obtain ⟨g', hg', eg⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ g)
+    obtain ⟨f', hf', ef⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ f)
+    obtain ⟨g', hg', eg⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ g)
     obtain ⟨r, rfl⟩ := hφ r
     have hfl : f.leadingCoeff = φ f'.leadingCoeff := by
       simp_rw [← coeff_natDegree, ← natDegree_eq_natDegree ef, ← hf', coeff_map]
@@ -743,8 +743,8 @@ lemma resultant_integralNormalization (f g : R[X]) (hg : g.natDegree ≠ 0) :
     let S := MvPolynomial R ℤ
     let φ : S →+* R := MvPolynomial.eval₂Hom (algebraMap _ _) id
     have hφ : Function.Surjective φ := fun x ↦ ⟨.X x, by simp [φ, MvPolynomial.eval₂Hom]⟩
-    obtain ⟨f', hf', ef⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ f)
-    obtain ⟨g', hg', eg⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ g)
+    obtain ⟨f', hf', ef⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ f)
+    obtain ⟨g', hg', eg⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ g)
     have hfl : f.leadingCoeff = φ f'.leadingCoeff := by
       simp_rw [← coeff_natDegree, ← natDegree_eq_natDegree ef, ← hf', coeff_map]
     have hgl : g.leadingCoeff = φ g'.leadingCoeff := by
@@ -786,8 +786,8 @@ nonrec lemma resultant_taylor (f g : R[X]) (r : R) :
     rw [← map_taylor, ← map_taylor] at this
     simpa [natDegree_map_eq_of_injective hφ] using this
   | surjective R S φ hφ f IH =>
-    obtain ⟨f', hf', ef⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ f)
-    obtain ⟨g', hg', eg⟩ := Polynomial.mem_lifts_and_degree_eq (Polynomial.map_surjective φ hφ g)
+    obtain ⟨f', hf', ef⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ f)
+    obtain ⟨g', hg', eg⟩ := exists_degree_eq_of_mem_lifts (Polynomial.map_surjective φ hφ g)
     obtain ⟨r, rfl⟩ := hφ r
     have hfl : f.leadingCoeff = φ f'.leadingCoeff := by
       simp_rw [← coeff_natDegree, ← natDegree_eq_natDegree ef, ← hf', coeff_map]


### PR DESCRIPTION
`mem_lifts_and_degree_eq` was already proving the more general statement, so I extracted the proof. I need this for #34877.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
