### PR TITLE
[Merged by Bors] - feat(List): permutations preserve maximum

### DIFF
--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -448,14 +448,13 @@ theorem minimum_of_length_pos_le_getElem {i : ℕ} (w : i < l.length) (h := (Nat
 
 theorem Perm.maximum_eq {l l' : List α} (h : l ~ l') :
     l.maximum = l'.maximum := by
-  by_cases he : l = []
+  by_cases he : l' = []
   · simp_all
-  have hm : ∃ m : α, l.maximum = m := Option.ne_none_iff_exists'.mp <| maximum_ne_bot_of_ne_nil he
+  have hm : ∃ m : α, l'.maximum = m := Option.ne_none_iff_exists'.mp <| maximum_ne_bot_of_ne_nil he
   obtain ⟨m, hm⟩ := hm
-  symm
   rw [hm, maximum_eq_coe_iff]
   rw [maximum_eq_coe_iff] at hm
-  exact ⟨(mem_iff h).mp hm.1, fun _ ha ↦ hm.2 _ <| (mem_iff h.symm).mp ha⟩
+  exact ⟨(mem_iff h).mpr hm.1, fun _ ha ↦ hm.2 _ <| (mem_iff h).mp ha⟩
 
 theorem Perm.minimum_eq {l l' : List α} (h : l ~ l') :
     l.minimum = l'.minimum :=

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -448,17 +448,11 @@ theorem minimum_of_length_pos_le_getElem {i : ℕ} (w : i < l.length) (h := (Nat
 
 theorem Perm.maximum_eq {l l' : List α} (h : l ~ l') :
     l.maximum = l'.maximum := by
-  by_cases he : l' = []
-  · simp_all
-  have hm : ∃ m : α, l'.maximum = m := Option.ne_none_iff_exists'.mp <| maximum_ne_bot_of_ne_nil he
-  obtain ⟨m, hm⟩ := hm
-  rw [hm, maximum_eq_coe_iff]
-  rw [maximum_eq_coe_iff] at hm
-  exact ⟨(mem_iff h).mpr hm.1, fun _ ha ↦ hm.2 _ <| (mem_iff h).mp ha⟩
+  induction h with grind [maximum_cons]
 
 theorem Perm.minimum_eq {l l' : List α} (h : l ~ l') :
-    l.minimum = l'.minimum :=
-  @Perm.maximum_eq αᵒᵈ _ _ _ h
+    l.minimum = l'.minimum := by
+  induction h with grind [minimum_cons]
 
 #adaptation_note
 /-- 2025-08-14: We should stop using `max?_eq_some_iff_legacy` below, by connecting up Mathlib's

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -446,6 +446,21 @@ theorem minimum_of_length_pos_le_getElem {i : ℕ} (w : i < l.length) (h := (Nat
     l.minimum_of_length_pos h ≤ l[i] :=
   getElem_le_maximum_of_length_pos (α := αᵒᵈ) w
 
+theorem Perm.maximum_eq {l l' : List α} (h : l ~ l') :
+    l.maximum = l'.maximum := by
+  by_cases he : l = []
+  · simp_all
+  have hm : ∃ m : α, l.maximum = m := Option.ne_none_iff_exists'.mp <| maximum_ne_bot_of_ne_nil he
+  obtain ⟨m, hm⟩ := hm
+  symm
+  rw [hm, maximum_eq_coe_iff]
+  rw [maximum_eq_coe_iff] at hm
+  exact ⟨(mem_iff h).mp hm.1, fun _ ha ↦ hm.2 _ <| (mem_iff h.symm).mp ha⟩
+
+theorem Perm.minimum_eq {l l' : List α} (h : l ~ l') :
+    l.minimum = l'.minimum :=
+  @Perm.maximum_eq αᵒᵈ _ _ _ h
+
 #adaptation_note
 /-- 2025-08-14: We should stop using `max?_eq_some_iff_legacy` below, by connecting up Mathlib's
 order typeclasses with the new classes in Lean. -/


### PR DESCRIPTION
and minimum.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
