### PR TITLE
[Merged by Bors] - perf: remove unnecessary `nsmul := (· • ·)`

### DIFF
--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -289,52 +289,40 @@ instance instSemiring (r : R → R → Prop) : Semiring (RingQuot r) where
   right_distrib := by
     rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩ ⟨⟨⟩⟩
     simp only [mul_quot, add_quot, right_distrib]
-  nsmul := (· • ·)
-  nsmul_zero := by
-    rintro ⟨⟨⟩⟩
-    simp only [zero_smul]
-  nsmul_succ := by
-    rintro n ⟨⟨⟩⟩
-    simp only [smul_quot, nsmul_eq_mul, Nat.cast_add, Nat.cast_one, add_mul, one_mul,
-               add_comm, add_quot]
-  __ := instAddCommMonoid r
-  __ := instMonoidWithZero r
 
 -- Has to be exposed, otherwise we get diamonds in ℤ-algebras.
 /-- The `intCast` function for `RingQuot`. -/
 def intCast {R : Type uR} [Ring R] (r : R → R → Prop) (z : ℤ) : RingQuot r :=
   ⟨Quot.mk _ z⟩
 
-instance instRing {R : Type uR} [Ring R] (r : R → R → Prop) : Ring (RingQuot r) :=
-  { RingQuot.instSemiring r with
-    neg_add_cancel := by
-      rintro ⟨⟨⟩⟩
-      simp [neg_quot, add_quot, ← zero_quot]
-    sub_eq_add_neg := by
-      rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩
-      simp [neg_quot, sub_quot, add_quot, sub_eq_add_neg]
-    zsmul := (· • ·)
-    zsmul_zero' := by
-      rintro ⟨⟨⟩⟩
-      simp [smul_quot, ← zero_quot]
-    zsmul_succ' := by
-      rintro n ⟨⟨⟩⟩
-      simp [smul_quot, add_quot, add_mul, add_comm]
-    zsmul_neg' := by
-      rintro n ⟨⟨⟩⟩
-      simp [smul_quot, neg_quot, add_mul]
-    intCast := intCast r
-    intCast_ofNat := fun n => congrArg RingQuot.mk <| by
-      exact congrArg (Quot.mk _) (Int.cast_natCast _)
-    intCast_negSucc := fun n => congrArg RingQuot.mk <| by
-      exact congrArg (Quot.mk _) (Int.cast_negSucc n) }
+instance instRing {R : Type uR} [Ring R] (r : R → R → Prop) : Ring (RingQuot r) where
+  neg_add_cancel := by
+    rintro ⟨⟨⟩⟩
+    simp [neg_quot, add_quot, ← zero_quot]
+  sub_eq_add_neg := by
+    rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩
+    simp [neg_quot, sub_quot, add_quot, sub_eq_add_neg]
+  zsmul := (· • ·)
+  zsmul_zero' := by
+    rintro ⟨⟨⟩⟩
+    simp [smul_quot, ← zero_quot]
+  zsmul_succ' := by
+    rintro n ⟨⟨⟩⟩
+    simp [smul_quot, add_quot, add_mul, add_comm]
+  zsmul_neg' := by
+    rintro n ⟨⟨⟩⟩
+    simp [smul_quot, neg_quot, add_mul]
+  intCast := intCast r
+  intCast_ofNat := fun n => congrArg RingQuot.mk <| by
+    exact congrArg (Quot.mk _) (Int.cast_natCast _)
+  intCast_negSucc := fun n => congrArg RingQuot.mk <| by
+    exact congrArg (Quot.mk _) (Int.cast_negSucc n)
 
 instance instCommSemiring {R : Type uR} [CommSemiring R] (r : R → R → Prop) :
-    CommSemiring (RingQuot r) :=
-  { RingQuot.instSemiring r with
-    mul_comm := by
-      rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩
-      simp [mul_quot, mul_comm] }
+    CommSemiring (RingQuot r) where
+  mul_comm := by
+    rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩
+    simp [mul_quot, mul_comm]
 
 instance {R : Type uR} [CommRing R] (r : R → R → Prop) : CommRing (RingQuot r) :=
   { RingQuot.instCommSemiring r, RingQuot.instRing r with }

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -841,9 +841,7 @@ instance sub : Sub (M →SL[σ₁₂] M₂) :=
   ⟨fun f g => ⟨f - g, f.2.sub g.2⟩⟩
 
 instance addCommGroup : AddCommGroup (M →SL[σ₁₂] M₂) where
-  __ := ContinuousLinearMap.addCommMonoid
   sub_eq_add_neg _ _ := by ext; apply sub_eq_add_neg
-  nsmul := (· • ·)
   zsmul := (· • ·)
   zsmul_zero' f := by ext; simp
   zsmul_succ' n f := by ext; simp [add_smul, add_comm]


### PR DESCRIPTION
This PR removes some unnecessary `nsmul := (· • ·)`. In particular the modified instance `AddCommGroup (M →SL[σ₁₂] M₂)` now has faster unification properties.

This is the same effect as we had in #30734

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
