### PR TITLE
[Merged by Bors] - doc(CategoryTheory/Bicategory/Kan): clarify Kan adjunction docstrings

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
@@ -154,7 +154,7 @@ def Adjunction.isAbsoluteLeftKanLift {f : a ⟶ b} {u : b ⟶ a} (adj : f ⊣ u)
         _ = _ := by
           rw [hτ]; dsimp only [StructuredArrow.homMk_right]
 
-/-- A left Kan lift of the identity along `u` that commutes with `u`, in the sense that
+/-- A left Kan lift `t` of the identity along `u` that commutes with `u`, in the sense that
 `t.whisker u` is a left Kan lift, is a left adjoint to `u`. The unit of this adjoint is given by
 the unit of the Kan lift. -/
 def LeftLift.IsKan.adjunction {u : b ⟶ a} {t : LeftLift u (𝟙 a)}

--- a/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
@@ -74,7 +74,7 @@ def Adjunction.isAbsoluteLeftKan {f : a ⟶ b} {u : b ⟶ a} (adj : f ⊣ u) :
       _ = _ := by
         rw [hτ]; dsimp only [StructuredArrow.homMk_right]
 
-/-- A left Kan extension of the identity along `f` that commutes with `f`, in the sense that
+/-- A left Kan extension `t` of the identity along `f` that commutes with `f`, in the sense that
 `t.whisker f` is a left Kan extension, is a right adjoint to `f`. The unit of this adjoint is
 given by the unit of the Kan extension. -/
 def LeftExtension.IsKan.adjunction {f : a ⟶ b} {t : LeftExtension f (𝟙 a)}

--- a/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/Adjunction.lean
@@ -74,8 +74,9 @@ def Adjunction.isAbsoluteLeftKan {f : a ⟶ b} {u : b ⟶ a} (adj : f ⊣ u) :
       _ = _ := by
         rw [hτ]; dsimp only [StructuredArrow.homMk_right]
 
-/-- A left Kan extension of the identity along `f` such that `f` commutes with is a right adjoint
-to `f`. The unit of this adjoint is given by the unit of the Kan extension. -/
+/-- A left Kan extension of the identity along `f` that commutes with `f`, in the sense that
+`t.whisker f` is a left Kan extension, is a right adjoint to `f`. The unit of this adjoint is
+given by the unit of the Kan extension. -/
 def LeftExtension.IsKan.adjunction {f : a ⟶ b} {t : LeftExtension f (𝟙 a)}
     (H : IsKan t) (H' : IsKan (t.whisker f)) :
       f ⊣ t.extension :=
@@ -98,8 +99,8 @@ def LeftExtension.IsKan.adjunction {f : a ⟶ b} {t : LeftExtension f (𝟙 a)}
         _ = _ := by
           rw [← leftZigzag, Hε]; bicategory }
 
-/-- For an adjunction `f ⊣ u`, `u` is a left Kan extension of the identity along `f`.
-The unit of this Kan extension is given by the unit of the adjunction. -/
+/-- An absolute left Kan extension of the identity along `f` is a right adjoint to `f`.
+The unit of this adjunction is given by the unit of the Kan extension. -/
 def LeftExtension.IsAbsKan.adjunction {f : a ⟶ b} (t : LeftExtension f (𝟙 a)) (H : IsAbsKan t) :
     f ⊣ t.extension :=
   H.isKan.adjunction (H f)
@@ -153,8 +154,9 @@ def Adjunction.isAbsoluteLeftKanLift {f : a ⟶ b} {u : b ⟶ a} (adj : f ⊣ u)
         _ = _ := by
           rw [hτ]; dsimp only [StructuredArrow.homMk_right]
 
-/-- A left Kan lift of the identity along `u` such that `u` commutes with is a left adjoint
-to `u`. The unit of this adjoint is given by the unit of the Kan lift. -/
+/-- A left Kan lift of the identity along `u` that commutes with `u`, in the sense that
+`t.whisker u` is a left Kan lift, is a left adjoint to `u`. The unit of this adjoint is given by
+the unit of the Kan lift. -/
 def LeftLift.IsKan.adjunction {u : b ⟶ a} {t : LeftLift u (𝟙 a)}
     (H : IsKan t) (H' : IsKan (t.whisker u)) :
       t.lift ⊣ u :=
@@ -177,8 +179,8 @@ def LeftLift.IsKan.adjunction {u : b ⟶ a} {t : LeftLift u (𝟙 a)}
           rw [← rightZigzag, Hε]; bicategory
     right_triangle := Hε }
 
-/-- For an adjunction `f ⊣ u`, `f` is a left Kan lift of the identity along `u`.
-The unit of this Kan lift is given by the unit of the adjunction. -/
+/-- An absolute left Kan lift of the identity along `u` is a left adjoint to `u`.
+The unit of this adjunction is given by the unit of the Kan lift. -/
 def LeftLift.IsAbsKan.adjunction {u : b ⟶ a} (t : LeftLift u (𝟙 a)) (H : IsAbsKan t) :
     t.lift ⊣ u :=
   H.isKan.adjunction (H u)

--- a/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
@@ -95,7 +95,7 @@ def lanUnit (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] : g ⟶ f ≫ 
 theorem lanLeftExtension_unit (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] :
     (lanLeftExtension f g).unit = lanUnit f g := rfl
 
-/-- Evidence that the `Lan.extension f g` is a Kan extension. -/
+/-- Evidence that `lan f g` is a Kan extension. -/
 def lanIsKan (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] : (lanLeftExtension f g).IsKan :=
   initialIsInitial
 
@@ -197,7 +197,7 @@ open LeftLift
 
 variable {f : b ⟶ a} {g : c ⟶ a}
 
-/-- The existence of a left kan lift of `g` along `f`. -/
+/-- The existence of a left Kan lift of `g` along `f`. -/
 class HasLeftKanLift (f : b ⟶ a) (g : c ⟶ a) : Prop where mk' ::
   hasInitial : HasInitial <| LeftLift f g
 
@@ -239,7 +239,7 @@ def lanLiftUnit (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] : g ⟶ f₊ g 
 theorem lanLiftLeftLift_unit (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] :
     (lanLiftLeftLift f g).unit = lanLiftUnit f g := rfl
 
-/-- Evidence that the `LanLift.lift f g` is a Kan lift. -/
+/-- Evidence that `lanLift f g` is a Kan lift. -/
 def lanLiftIsKan (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] : (lanLiftLeftLift f g).IsKan :=
   initialIsInitial
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
@@ -239,7 +239,7 @@ def lanLiftUnit (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] : g ⟶ f₊ g 
 theorem lanLiftLeftLift_unit (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] :
     (lanLiftLeftLift f g).unit = lanLiftUnit f g := rfl
 
-/-- Evidence that `lanLift f g` is a Kan lift. -/
+/-- Evidence that `lanLiftLeftLift f g` is a Kan lift. -/
 def lanLiftIsKan (f : b ⟶ a) (g : c ⟶ a) [HasLeftKanLift f g] : (lanLiftLeftLift f g).IsKan :=
   initialIsInitial
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
@@ -95,7 +95,7 @@ def lanUnit (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] : g ⟶ f ≫ 
 theorem lanLeftExtension_unit (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] :
     (lanLeftExtension f g).unit = lanUnit f g := rfl
 
-/-- Evidence that `lan f g` is a Kan extension. -/
+/-- Evidence that `lanLeftExtension f g` is a Kan extension. -/
 def lanIsKan (f : a ⟶ b) (g : a ⟶ c) [HasLeftKanExtension f g] : (lanLeftExtension f g).IsKan :=
   initialIsInitial
 

--- a/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/IsKan.lean
@@ -24,9 +24,9 @@ We also define left Kan lifts, right Kan extensions, and right Kan lifts.
 
 We use the Is-Has design pattern, which is used for the implementation of limits and colimits in
 the category theory library. This means that `IsKan t` is a structure containing the data of
-2-morphisms which ensure that `t` is a Kan extension, while `HasKan f g` defined in
-`CategoryTheory.Bicategory.Kan.HasKan` is a `Prop`-valued typeclass asserting that a Kan extension
-of `g` along `f` exists.
+2-morphisms which ensure that `t` is a Kan extension, while `HasLeftKanExtension f g`
+(and similarly for lifts) defined in `CategoryTheory.Bicategory.Kan.HasKan`
+is a `Prop`-valued typeclass asserting that a Kan extension of `g` along `f` exists.
 
 We define `LeftExtension.IsKan t` for an extension `t : LeftExtension f g` (which is an
 abbreviation of `t : StructuredArrow g (precomp _ f)`) to be an abbreviation for


### PR DESCRIPTION
* The two IsAbsKan.adjunction docstrings in Kan/Adjunction were corrected to match the actual definitions: they now describe deriving adjunctions from absolute left Kan (co)universal data, not from an input adjunction.
* Grammar and phrasing were cleaned up in the IsKan.adjunction docs (commutes with f/u).
* In Kan/HasKan and Kan/IsKan, stale/non-API names were replaced by the current identifiers (lan, lanLift, HasLeftKanExtension) and Kan capitalization was normalized.

---

The issues were identified and fixed by Codex.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
