### PR TITLE
[Merged by Bors] - ci: bors runs should build tools from the commit under test

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -26,6 +26,9 @@ jobs:
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
       pr_branch_ref: ${{ github.sha }}
+      # bors runs should build the tools from their commit-under-test: after all, we are trying to
+      # test 'what would happen if this was merged', so we need to use the 'would-be-post-merge' tools
+      tools_branch_ref: ${{ github.sha }}
       # We don't wan't 'bors try' runs to compete with merge-candidates, so we pool trying with PR runs
       runs_on: ${{ github.ref_name == 'trying' && 'pr' || 'bors' }}
     secrets: inherit


### PR DESCRIPTION
bors runs should build the tools from their commit-under-test: after all, we are trying to test 'what would happen if this was merged', so we need to use the 'would-be-post-merge' tools.

Note that bors runs should have "trusted code" because after all some maintainer has to approve the bors run itself.