### PR TITLE
[Merged by Bors] - feat(Order/Interval/Set/Basic): use `to_dual`

### DIFF
--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -66,7 +66,20 @@ instance decidableMemIco [Decidable (a ≤ x ∧ x < b)] : Decidable (x ∈ Ico 
 
 instance decidableMemIcc [Decidable (a ≤ x ∧ x ≤ b)] : Decidable (x ∈ Icc a b) := by assumption
 
-instance decidableMemIoc [Decidable (a < x ∧ x ≤ b)] : Decidable (x ∈ Ioc a b) := by assumption
+@[to_dual self (reorder := a b, 6 7)]
+instance decidableMemIoo [Decidable (a < x)] [Decidable (x < b)] : Decidable (x ∈ Ioo a b) :=
+  instDecidableAnd
+
+instance decidableMemIco [Decidable (a ≤ x)] [Decidable (x < b)] : Decidable (x ∈ Ico a b) :=
+  instDecidableAnd
+
+@[to_dual self (reorder := a b, 6 7)]
+instance decidableMemIcc [Decidable (a ≤ x)] [Decidable (x ≤ b)] : Decidable (x ∈ Icc a b) :=
+  instDecidableAnd
+
+@[to_dual existing (reorder := a b, 6 7)]
+instance decidableMemIoc [Decidable (a < x)] [Decidable (x ≤ b)] : Decidable (x ∈ Ioc a b) :=
+  instDecidableAnd
 
 @[to_dual] theorem self_notMem_Iio : a ∉ Iio a := by simp
 @[to_dual] theorem self_mem_Iic : a ∈ Iic a := by simp

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -71,11 +71,11 @@ instance decidableMemIoc [Decidable (a < x ∧ x ≤ b)] : Decidable (x ∈ Ioc 
 @[to_dual] theorem self_notMem_Iio : a ∉ Iio a := by simp
 @[to_dual] theorem self_mem_Iic : a ∈ Iic a := by simp
 
-@[to_dual (reorder := a b) right_notMem_Ioo]
-theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
+@[to_dual right_notMem_Ioo]
+theorem left_notMem_Ioo : a ∉ Ioo a b := by simp
 
-@[to_dual (reorder := a b) right_notMem_Ico]
-theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
+@[to_dual right_notMem_Ico]
+theorem left_notMem_Ioc : a ∉ Ioc a b := by simp
 
 @[deprecated left_notMem_Ioo (since := "2025-12-26")]
 theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -59,6 +59,7 @@ instance decidableMemIio [Decidable (x < b)] : Decidable (x ∈ Iio b) := by ass
 @[to_dual]
 instance decidableMemIic [Decidable (x ≤ b)] : Decidable (x ∈ Iic b) := by assumption
 
+-- TODO: these instances are awkward for `to_dual`
 instance decidableMemIoo [Decidable (a < x ∧ x < b)] : Decidable (x ∈ Ioo a b) := by assumption
 
 instance decidableMemIco [Decidable (a ≤ x ∧ x < b)] : Decidable (x ∈ Ico a b) := by assumption
@@ -70,8 +71,8 @@ instance decidableMemIoc [Decidable (a < x ∧ x ≤ b)] : Decidable (x ∈ Ioc 
 @[to_dual] theorem self_notMem_Iio : a ∉ Iio a := by simp
 @[to_dual] theorem self_mem_Iic : a ∈ Iic a := by simp
 
-theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
-theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
+@[to_dual right_notMem_Ioo] theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
+@[to_dual right_notMem_Ico] theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
 
 @[deprecated left_notMem_Ioo (since := "2025-12-26")]
 theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp
@@ -79,24 +80,17 @@ theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp
 @[deprecated left_notMem_Ioc (since := "2025-12-26")]
 theorem left_mem_Ioc : a ∈ Ioc a b ↔ False := by simp
 
-theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp
-theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp
+@[to_dual right_mem_Ioc] theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp
+@[to_dual right_mem_Icc] theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp
 
 @[deprecated (since := "2025-12-26")]
 alias left_mem_Ici := self_mem_Ici
-
-theorem right_notMem_Ioo : b ∉ Ioo a b := by simp
-theorem right_notMem_Ico : b ∉ Ico a b := by simp
 
 @[deprecated right_notMem_Ioo (since := "2025-12-26")]
 theorem right_mem_Ioo : b ∈ Ioo a b ↔ False := by simp
 
 @[deprecated right_notMem_Ico (since := "2025-12-26")]
 theorem right_mem_Ico : b ∈ Ico a b ↔ False := by simp
-
-theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp
-theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp
-
 
 @[deprecated (since := "2025-12-26")]
 alias right_mem_Iic := self_mem_Iic
@@ -109,19 +103,15 @@ theorem Iio_toDual : Iio (toDual a) = ofDual ⁻¹' Ioi a :=
 theorem Iic_toDual : Iic (toDual a) = ofDual ⁻¹' Ici a :=
   rfl
 
-@[simp]
+@[simp, to_dual self]
 theorem Icc_toDual : Icc (toDual a) (toDual b) = ofDual ⁻¹' Icc b a :=
   Set.ext fun _ => and_comm
 
-@[simp]
-theorem Ioc_toDual : Ioc (toDual a) (toDual b) = ofDual ⁻¹' Ico b a :=
-  Set.ext fun _ => and_comm
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ico_toDual : Ico (toDual a) (toDual b) = ofDual ⁻¹' Ioc b a :=
   Set.ext fun _ => and_comm
 
-@[simp]
+@[simp, to_dual self]
 theorem Ioo_toDual : Ioo (toDual a) (toDual b) = ofDual ⁻¹' Ioo b a :=
   Set.ext fun _ => and_comm
 
@@ -133,19 +123,15 @@ theorem Iio_ofDual {x : αᵒᵈ} : Iio (ofDual x) = toDual ⁻¹' Ioi x :=
 theorem Iic_ofDual {x : αᵒᵈ} : Iic (ofDual x) = toDual ⁻¹' Ici x :=
   rfl
 
-@[simp]
+@[simp, to_dual self]
 theorem Icc_ofDual {x y : αᵒᵈ} : Icc (ofDual y) (ofDual x) = toDual ⁻¹' Icc x y :=
   Set.ext fun _ => and_comm
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ico_ofDual {x y : αᵒᵈ} : Ico (ofDual y) (ofDual x) = toDual ⁻¹' Ioc x y :=
   Set.ext fun _ => and_comm
 
-@[simp]
-theorem Ioc_ofDual {x y : αᵒᵈ} : Ioc (ofDual y) (ofDual x) = toDual ⁻¹' Ico x y :=
-  Set.ext fun _ => and_comm
-
-@[simp]
+@[simp, to_dual self]
 theorem Ioo_ofDual {x y : αᵒᵈ} : Ioo (ofDual y) (ofDual x) = toDual ⁻¹' Ioo x y :=
   Set.ext fun _ => and_comm
 
@@ -157,19 +143,16 @@ theorem nonempty_Iio [NoMinOrder α] : (Iio a).Nonempty :=
 theorem nonempty_Iic : (Iic a).Nonempty :=
   ⟨a, self_mem_Iic⟩
 
-@[simp]
+@[simp, to_dual self]
 theorem nonempty_Icc : (Icc a b).Nonempty ↔ a ≤ b :=
   ⟨fun ⟨_, hx⟩ => hx.1.trans hx.2, fun h => ⟨a, left_mem_Icc.2 h⟩⟩
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem nonempty_Ico : (Ico a b).Nonempty ↔ a < b :=
   ⟨fun ⟨_, hx⟩ => hx.1.trans_lt hx.2, fun h => ⟨a, left_mem_Ico.2 h⟩⟩
 
-@[simp]
-theorem nonempty_Ioc : (Ioc a b).Nonempty ↔ a < b :=
-  ⟨fun ⟨_, hx⟩ => hx.1.trans_le hx.2, fun h => ⟨b, right_mem_Ioc.2 h⟩⟩
 
-@[simp]
+@[simp, to_dual self]
 theorem nonempty_Ioo [DenselyOrdered α] : (Ioo a b).Nonempty ↔ a < b :=
   ⟨fun ⟨_, ha, hb⟩ => ha.trans hb, exists_between⟩
 
@@ -183,15 +166,15 @@ instance nonempty_Iio_subtype [NoMinOrder α] : Nonempty (Iio a) :=
 instance nonempty_Iic_subtype : Nonempty (Iic a) :=
   Nonempty.to_subtype nonempty_Iic
 
+@[to_dual self]
 theorem nonempty_Icc_subtype (h : a ≤ b) : Nonempty (Icc a b) :=
   Nonempty.to_subtype (nonempty_Icc.mpr h)
 
-theorem nonempty_Ico_subtype (h : a < b) : Nonempty (Ico a b) :=
-  Nonempty.to_subtype (nonempty_Ico.mpr h)
-
+@[to_dual]
 theorem nonempty_Ioc_subtype (h : a < b) : Nonempty (Ioc a b) :=
   Nonempty.to_subtype (nonempty_Ioc.mpr h)
 
+@[to_dual self]
 theorem nonempty_Ioo_subtype [DenselyOrdered α] (h : a < b) : Nonempty (Ioo a b) :=
   Nonempty.to_subtype (nonempty_Ioo.mpr h)
 
@@ -207,46 +190,51 @@ instance [NoMinOrder α] : NoMinOrder (Iic a) :=
     let ⟨b, hb⟩ := exists_lt (a : α)
     ⟨⟨b, hb.le.trans a.2⟩, hb⟩⟩
 
-@[simp]
+@[simp, to_dual self]
 theorem Icc_eq_empty (h : ¬a ≤ b) : Icc a b = ∅ :=
   eq_empty_iff_forall_notMem.2 fun _ ⟨ha, hb⟩ => h (ha.trans hb)
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ico_eq_empty (h : ¬a < b) : Ico a b = ∅ :=
-  eq_empty_iff_forall_notMem.2 fun _ ⟨ha, hb⟩ => h (ha.trans_lt hb)
+  eq_empty_iff_forall_notMem.2 fun _ hab => h (hab.1.trans_lt hab.2)
 
-@[simp]
-theorem Ioc_eq_empty (h : ¬a < b) : Ioc a b = ∅ :=
-  eq_empty_iff_forall_notMem.2 fun _ ⟨ha, hb⟩ => h (ha.trans_le hb)
-
-@[simp]
+@[simp, to_dual self]
 theorem Ioo_eq_empty (h : ¬a < b) : Ioo a b = ∅ :=
   eq_empty_iff_forall_notMem.2 fun _ ⟨ha, hb⟩ => h (ha.trans hb)
 
-@[simp]
+@[simp, to_dual self]
 theorem Icc_eq_empty_of_lt (h : b < a) : Icc a b = ∅ :=
   Icc_eq_empty h.not_ge
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ico_eq_empty_of_le (h : b ≤ a) : Ico a b = ∅ :=
   Ico_eq_empty h.not_gt
 
-@[simp]
-theorem Ioc_eq_empty_of_le (h : b ≤ a) : Ioc a b = ∅ :=
-  Ioc_eq_empty h.not_gt
-
-@[simp]
+@[simp, to_dual self]
 theorem Ioo_eq_empty_of_le (h : b ≤ a) : Ioo a b = ∅ :=
   Ioo_eq_empty h.not_gt
 
+@[to_dual]
 theorem Ico_self (a : α) : Ico a a = ∅ :=
   Ico_eq_empty <| lt_irrefl _
 
-theorem Ioc_self (a : α) : Ioc a a = ∅ :=
-  Ioc_eq_empty <| lt_irrefl _
-
 theorem Ioo_self (a : α) : Ioo a a = ∅ :=
   Ioo_eq_empty <| lt_irrefl _
+
+/-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Iio_subset_Iio_iff`. -/
+@[to_dual (attr := gcongr)
+/-- If `a ≤ b`, then `(b, +∞) ⊆ (a, +∞)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Ioi_subset_Ioi_iff`. -/]
+theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := fun _ hx => lt_of_lt_of_le hx h
+
+/-- If `a < b`, then `(-∞, a) ⊂ (-∞, b)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Iio_ssubset_Iio_iff`. -/
+@[to_dual (attr := gcongr)
+/-- If `a < b`, then `(b, +∞) ⊂ (a, +∞)`. In preorders, this is just an implication. If you need
+the equivalence in linear orders, use `Ioi_ssubset_Ioi_iff`. -/]
+theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b :=
+  (ssubset_iff_of_subset (Iio_subset_Iio h.le)).mpr ⟨a, h, lt_irrefl a⟩
 
 @[to_dual (attr := simp, gcongr)]
 theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b :=
@@ -264,143 +252,8 @@ theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b where
 theorem Iic_subset_Iio : Iic a ⊆ Iio b ↔ a < b :=
   ⟨fun h => h self_mem_Iic, fun h _ hx => lt_of_le_of_lt hx h⟩
 
-@[gcongr]
-theorem Ioo_subset_Ioo (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) : Ioo a₁ b₁ ⊆ Ioo a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
-  ⟨h₁.trans_lt hx₁, hx₂.trans_le h₂⟩
-
-theorem Ioo_subset_Ioo_left (h : a₁ ≤ a₂) : Ioo a₂ b ⊆ Ioo a₁ b :=
-  Ioo_subset_Ioo h le_rfl
-
-theorem Ioo_subset_Ioo_right (h : b₁ ≤ b₂) : Ioo a b₁ ⊆ Ioo a b₂ :=
-  Ioo_subset_Ioo le_rfl h
-
-@[gcongr]
-theorem Ico_subset_Ico (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) : Ico a₁ b₁ ⊆ Ico a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
-  ⟨h₁.trans hx₁, hx₂.trans_le h₂⟩
-
-theorem Ico_subset_Ico_left (h : a₁ ≤ a₂) : Ico a₂ b ⊆ Ico a₁ b :=
-  Ico_subset_Ico h le_rfl
-
-theorem Ico_subset_Ico_right (h : b₁ ≤ b₂) : Ico a b₁ ⊆ Ico a b₂ :=
-  Ico_subset_Ico le_rfl h
-
-@[gcongr]
-theorem Icc_subset_Icc (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) : Icc a₁ b₁ ⊆ Icc a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
-  ⟨h₁.trans hx₁, le_trans hx₂ h₂⟩
-
-theorem Icc_subset_Icc_left (h : a₁ ≤ a₂) : Icc a₂ b ⊆ Icc a₁ b :=
-  Icc_subset_Icc h le_rfl
-
-theorem Icc_subset_Icc_right (h : b₁ ≤ b₂) : Icc a b₁ ⊆ Icc a b₂ :=
-  Icc_subset_Icc le_rfl h
-
-theorem Icc_subset_Ioo (ha : a₂ < a₁) (hb : b₁ < b₂) : Icc a₁ b₁ ⊆ Ioo a₂ b₂ := fun _ hx =>
-  ⟨ha.trans_le hx.1, hx.2.trans_lt hb⟩
-
-theorem Icc_subset_Ici_self : Icc a b ⊆ Ici a := fun _ => And.left
-
-theorem Icc_subset_Iic_self : Icc a b ⊆ Iic b := fun _ => And.right
-
-theorem Ioc_subset_Iic_self : Ioc a b ⊆ Iic b := fun _ => And.right
-
-@[gcongr]
-theorem Ioc_subset_Ioc (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) : Ioc a₁ b₁ ⊆ Ioc a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
-  ⟨h₁.trans_lt hx₁, hx₂.trans h₂⟩
-
-theorem Ioc_subset_Ioc_left (h : a₁ ≤ a₂) : Ioc a₂ b ⊆ Ioc a₁ b :=
-  Ioc_subset_Ioc h le_rfl
-
-theorem Ioc_subset_Ioc_right (h : b₁ ≤ b₂) : Ioc a b₁ ⊆ Ioc a b₂ :=
-  Ioc_subset_Ioc le_rfl h
-
-theorem Ico_subset_Ioo_left (h₁ : a₁ < a₂) : Ico a₂ b ⊆ Ioo a₁ b := fun _ =>
-  And.imp_left h₁.trans_le
-
-theorem Ioc_subset_Ioo_right (h : b₁ < b₂) : Ioc a b₁ ⊆ Ioo a b₂ := fun _ =>
-  And.imp_right fun h' => h'.trans_lt h
-
-theorem Icc_subset_Ico_right (h₁ : b₁ < b₂) : Icc a b₁ ⊆ Ico a b₂ := fun _ =>
-  And.imp_right fun h₂ => h₂.trans_lt h₁
-
-theorem Ioo_subset_Ico_self : Ioo a b ⊆ Ico a b := fun _ => And.imp_left le_of_lt
-
-theorem Ioo_subset_Ioc_self : Ioo a b ⊆ Ioc a b := fun _ => And.imp_right le_of_lt
-
-theorem Ico_subset_Icc_self : Ico a b ⊆ Icc a b := fun _ => And.imp_right le_of_lt
-
-theorem Ioc_subset_Icc_self : Ioc a b ⊆ Icc a b := fun _ => And.imp_left le_of_lt
-
-theorem Ioo_subset_Icc_self : Ioo a b ⊆ Icc a b :=
-  Subset.trans Ioo_subset_Ico_self Ico_subset_Icc_self
-
-theorem Ico_subset_Iio_self : Ico a b ⊆ Iio b := fun _ => And.right
-
-theorem Ioo_subset_Iio_self : Ioo a b ⊆ Iio b := fun _ => And.right
-
-theorem Ioc_subset_Ioi_self : Ioc a b ⊆ Ioi a := fun _ => And.left
-
-theorem Ioo_subset_Ioi_self : Ioo a b ⊆ Ioi a := fun _ => And.left
-
 @[to_dual]
 theorem Iio_subset_Iic_self : Iio a ⊆ Iic a := fun _ hx => le_of_lt hx
-
-theorem Ico_subset_Ici_self : Ico a b ⊆ Ici a := fun _ => And.left
-
-@[to_dual]
-theorem Iio_ssubset_Iic_self : Iio a ⊂ Iic a :=
-  ⟨Iio_subset_Iic_self, fun h => lt_irrefl a (h le_rfl)⟩
-
-theorem Icc_subset_Icc_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Icc a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
-  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ ⟨hx, hx'⟩ =>
-    ⟨h.trans hx, hx'.trans h'⟩⟩
-
-theorem Icc_subset_Ioo_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioo a₂ b₂ ↔ a₂ < a₁ ∧ b₁ < b₂ :=
-  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ ⟨hx, hx'⟩ =>
-    ⟨h.trans_le hx, hx'.trans_lt h'⟩⟩
-
-theorem Icc_subset_Ico_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ < b₂ :=
-  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ ⟨hx, hx'⟩ =>
-    ⟨h.trans hx, hx'.trans_lt h'⟩⟩
-
-theorem Icc_subset_Ioc_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ a₂ < a₁ ∧ b₁ ≤ b₂ :=
-  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ ⟨hx, hx'⟩ =>
-    ⟨h.trans_le hx, hx'.trans h'⟩⟩
-
-theorem Icc_subset_Iio_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Iio b₂ ↔ b₁ < b₂ :=
-  ⟨fun h => h ⟨h₁, le_rfl⟩, fun h _ ⟨_, hx'⟩ => hx'.trans_lt h⟩
-
-theorem Icc_subset_Ioi_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioi a₂ ↔ a₂ < a₁ :=
-  ⟨fun h => h ⟨le_rfl, h₁⟩, fun h _ ⟨hx, _⟩ => h.trans_le hx⟩
-
-theorem Icc_subset_Iic_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Iic b₂ ↔ b₁ ≤ b₂ :=
-  ⟨fun h => h ⟨h₁, le_rfl⟩, fun h _ ⟨_, hx'⟩ => hx'.trans h⟩
-
-theorem Icc_subset_Ici_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ici a₂ ↔ a₂ ≤ a₁ :=
-  ⟨fun h => h ⟨le_rfl, h₁⟩, fun h _ ⟨hx, _⟩ => h.trans hx⟩
-
-theorem Icc_ssubset_Icc_left (hI : a₂ ≤ b₂) (ha : a₂ < a₁) (hb : b₁ ≤ b₂) : Icc a₁ b₁ ⊂ Icc a₂ b₂ :=
-  (ssubset_iff_of_subset (Icc_subset_Icc (le_of_lt ha) hb)).mpr
-    ⟨a₂, left_mem_Icc.mpr hI, not_and.mpr fun f _ => lt_irrefl a₂ (ha.trans_le f)⟩
-
-theorem Icc_ssubset_Icc_right (hI : a₂ ≤ b₂) (ha : a₂ ≤ a₁) (hb : b₁ < b₂) :
-    Icc a₁ b₁ ⊂ Icc a₂ b₂ :=
-  (ssubset_iff_of_subset (Icc_subset_Icc ha (le_of_lt hb))).mpr
-    ⟨b₂, right_mem_Icc.mpr hI, fun f => lt_irrefl b₁ (hb.trans_le f.2)⟩
-
-/-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b)`. In preorders, this is just an implication. If you need
-the equivalence in linear orders, use `Iio_subset_Iio_iff`. -/
-@[to_dual (attr := gcongr)
-/-- If `a ≤ b`, then `(b, +∞) ⊆ (a, +∞)`. In preorders, this is just an implication. If you need
-the equivalence in linear orders, use `Ioi_subset_Ioi_iff`. -/]
-theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := fun _ hx => lt_of_lt_of_le hx h
-
-/-- If `a < b`, then `(-∞, a) ⊂ (-∞, b)`. In preorders, this is just an implication. If you need
-the equivalence in linear orders, use `Iio_ssubset_Iio_iff`. -/
-@[to_dual (attr := gcongr)
-/-- If `a < b`, then `(b, +∞) ⊂ (a, +∞)`. In preorders, this is just an implication. If you need
-the equivalence in linear orders, use `Ioi_ssubset_Ioi_iff`. -/]
-theorem Iio_ssubset_Iio (h : a < b) : Iio a ⊂ Iio b :=
-  (ssubset_iff_of_subset (Iio_subset_Iio h.le)).mpr ⟨a, h, lt_irrefl a⟩
 
 /-- If `a ≤ b`, then `(-∞, a) ⊆ (-∞, b]`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Iio_subset_Iic_iff`. -/
@@ -408,64 +261,126 @@ the equivalence in dense linear orders, use `Iio_subset_Iic_iff`. -/
 /-- If `a ≤ b`, then `(b, +∞) ⊆ [a, +∞)`. In preorders, this is just an implication. If you need
 the equivalence in dense linear orders, use `Ioi_subset_Ici_iff`. -/]
 theorem Iio_subset_Iic (h : a ≤ b) : Iio a ⊆ Iic b :=
-  Subset.trans (Iio_subset_Iio h) Iio_subset_Iic_self
+  (Iio_subset_Iio h).trans Iio_subset_Iic_self
 
-theorem Ici_inter_Iic : Ici a ∩ Iic b = Icc a b :=
-  rfl
+@[to_dual]
+theorem Iio_ssubset_Iic_self : Iio a ⊂ Iic a :=
+  ⟨Iio_subset_Iic_self, fun h => (h le_rfl).false⟩
 
-theorem Ici_inter_Iio : Ici a ∩ Iio b = Ico a b :=
-  rfl
+@[gcongr, to_dual self (reorder := a₁ b₁, a₂ b₂, ha hb)]
+theorem Ioo_subset_Ioo (ha : a₂ ≤ a₁) (hb : b₁ ≤ b₂) : Ioo a₁ b₁ ⊆ Ioo a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
+  ⟨ha.trans_lt hx₁, hx₂.trans_le hb⟩
 
-theorem Ioi_inter_Iic : Ioi a ∩ Iic b = Ioc a b :=
-  rfl
+@[to_dual Ioo_subset_Ioo_right]
+theorem Ioo_subset_Ioo_left (h : a₁ ≤ a₂) : Ioo a₂ b ⊆ Ioo a₁ b :=
+  Ioo_subset_Ioo h le_rfl
 
-theorem Ioi_inter_Iio : Ioi a ∩ Iio b = Ioo a b :=
-  rfl
+@[to_dual (attr := gcongr) (reorder := ha hb)]
+theorem Ico_subset_Ico (ha : a₂ ≤ a₁) (hb : b₁ ≤ b₂) : Ico a₁ b₁ ⊆ Ico a₂ b₂ := fun _ hx =>
+  ⟨ha.trans hx.1, hx.2.trans_le hb⟩
 
-theorem Iic_inter_Ici : Iic a ∩ Ici b = Icc b a :=
-  inter_comm _ _
+@[to_dual Ioc_subset_Ioc_right]
+theorem Ico_subset_Ico_left (h : a₁ ≤ a₂) : Ico a₂ b ⊆ Ico a₁ b :=
+  Ico_subset_Ico h le_rfl
 
-theorem Iio_inter_Ici : Iio a ∩ Ici b = Ico b a :=
-  inter_comm _ _
+@[to_dual Ico_subset_Ico_right]
+theorem Ioc_subset_Ioc_left (h : a₁ ≤ a₂) : Ioc a₂ b ⊆ Ioc a₁ b :=
+  Ioc_subset_Ioc h le_rfl
 
-theorem Iic_inter_Ioi : Iic a ∩ Ioi b = Ioc b a :=
-  inter_comm _ _
+@[gcongr, to_dual self (reorder := a₁ b₁, a₂ b₂, ha hb)]
+theorem Icc_subset_Icc (ha : a₂ ≤ a₁) (hb : b₁ ≤ b₂) : Icc a₁ b₁ ⊆ Icc a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
+  ⟨ha.trans hx₁, le_trans hx₂ hb⟩
 
-theorem Iio_inter_Ioi : Iio a ∩ Ioi b = Ioo b a :=
-  inter_comm _ _
+@[to_dual Icc_subset_Icc_right]
+theorem Icc_subset_Icc_left (h : a₁ ≤ a₂) : Icc a₂ b ⊆ Icc a₁ b :=
+  Icc_subset_Icc h le_rfl
 
-theorem mem_Icc_of_Ioo (h : x ∈ Ioo a b) : x ∈ Icc a b :=
-  Ioo_subset_Icc_self h
+@[to_dual (reorder := ha hb) Icc_ssubset_Icc_right]
+theorem Icc_ssubset_Icc_left (h₂ : a₂ ≤ b₂) (ha : a₂ < a₁) (hb : b₁ ≤ b₂) : Icc a₁ b₁ ⊂ Icc a₂ b₂ :=
+  (ssubset_iff_of_subset (Icc_subset_Icc (le_of_lt ha) hb)).mpr
+    ⟨a₂, left_mem_Icc.mpr h₂, not_and.mpr fun f _ => lt_irrefl a₂ (ha.trans_le f)⟩
 
-theorem mem_Ico_of_Ioo (h : x ∈ Ioo a b) : x ∈ Ico a b :=
-  Ioo_subset_Ico_self h
+@[to_dual (reorder := ha hb)]
+theorem Ico_subset_Ioo (ha : a₂ < a₁) (hb : b₁ ≤ b₂) : Ico a₁ b₁ ⊆ Ioo a₂ b₂ := fun _ hx ↦
+  ⟨ha.trans_le hx.1, hx.2.trans_le hb⟩
 
-theorem mem_Ioc_of_Ioo (h : x ∈ Ioo a b) : x ∈ Ioc a b :=
-  Ioo_subset_Ioc_self h
+@[to_dual Ioc_subset_Ioo_right]
+theorem Ico_subset_Ioo_left (h : a₁ < a₂) : Ico a₂ b ⊆ Ioo a₁ b :=
+  Ico_subset_Ioo h le_rfl
 
-theorem mem_Icc_of_Ico (h : x ∈ Ico a b) : x ∈ Icc a b :=
-  Ico_subset_Icc_self h
+@[to_dual (reorder := ha hb)]
+theorem Icc_subset_Ioc (ha : a₂ < a₁) (hb : b₁ ≤ b₂) : Icc a₁ b₁ ⊆ Ioc a₂ b₂ := fun _ hx ↦
+  ⟨ha.trans_le hx.1, hx.2.trans hb⟩
 
-theorem mem_Icc_of_Ioc (h : x ∈ Ioc a b) : x ∈ Icc a b :=
-  Ioc_subset_Icc_self h
+@[to_dual Icc_subset_Ico_right]
+theorem Icc_subset_Ioc_left (h : a₁ < a₂) : Icc a₂ b ⊆ Ioc a₁ b :=
+  Icc_subset_Ioc h le_rfl
 
-theorem mem_Ici_of_Ioi (h : x ∈ Ioi a) : x ∈ Ici a :=
-  Ioi_subset_Ici_self h
+@[to_dual self (reorder := a₁ b₁, a₂ b₂, ha hb)]
+theorem Icc_subset_Ioo (ha : a₂ < a₁) (hb : b₁ < b₂) : Icc a₁ b₁ ⊆ Ioo a₂ b₂ :=
+  (Icc_subset_Ioc_left ha).trans (Ioc_subset_Ioo_right hb)
 
-theorem mem_Iic_of_Iio (h : x ∈ Iio a) : x ∈ Iic a :=
-  Iio_subset_Iic_self h
+@[to_dual] theorem Ico_subset_Iio_self : Ico a b ⊆ Iio b := fun _ => And.right
+@[to_dual] theorem Ioo_subset_Iio_self : Ioo a b ⊆ Iio b := fun _ => And.right
+@[to_dual] theorem Ioc_subset_Iic_self : Ioc a b ⊆ Iic b := fun _ => And.right
+@[to_dual] theorem Icc_subset_Iic_self : Icc a b ⊆ Iic b := fun _ => And.right
 
+@[to_dual] theorem Ioo_subset_Ico_self : Ioo a b ⊆ Ico a b := fun _ => And.imp_left le_of_lt
+@[to_dual] theorem Ioc_subset_Icc_self : Ioc a b ⊆ Icc a b := fun _ => And.imp_left le_of_lt
+
+@[to_dual self]
+theorem Ioo_subset_Icc_self : Ioo a b ⊆ Icc a b :=
+  Ioo_subset_Ico_self.trans Ico_subset_Icc_self
+
+@[to_dual none]
+theorem Icc_subset_Icc_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Icc a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ ≤ b₂ :=
+  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ hx =>
+    ⟨h.trans hx.1, hx.2.trans h'⟩⟩
+
+@[to_dual none]
+theorem Icc_subset_Ioo_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioo a₂ b₂ ↔ a₂ < a₁ ∧ b₁ < b₂ :=
+  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ hx =>
+    ⟨h.trans_le hx.1, hx.2.trans_lt h'⟩⟩
+
+@[to_dual none]
+theorem Icc_subset_Ico_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ico a₂ b₂ ↔ a₂ ≤ a₁ ∧ b₁ < b₂ :=
+  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ hx =>
+    ⟨h.trans hx.1, hx.2.trans_lt h'⟩⟩
+
+@[to_dual none]
+theorem Icc_subset_Ioc_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioc a₂ b₂ ↔ a₂ < a₁ ∧ b₁ ≤ b₂ :=
+  ⟨fun h => ⟨(h ⟨le_rfl, h₁⟩).1, (h ⟨h₁, le_rfl⟩).2⟩, fun ⟨h, h'⟩ _ hx =>
+    ⟨h.trans_le hx.1, hx.2.trans h'⟩⟩
+
+@[to_dual]
+theorem Icc_subset_Ioi_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ioi a₂ ↔ a₂ < a₁ :=
+  ⟨fun h => h ⟨le_rfl, h₁⟩, fun h _ hx => h.trans_le hx.1⟩
+
+@[to_dual]
+theorem Icc_subset_Ici_iff (h₁ : a₁ ≤ b₁) : Icc a₁ b₁ ⊆ Ici a₂ ↔ a₂ ≤ a₁ :=
+  ⟨fun h => h ⟨le_rfl, h₁⟩, fun h _ hx => h.trans hx.1⟩
+
+@[to_dual] theorem Ici_inter_Iic : Ici a ∩ Iic b = Icc a b := rfl
+@[to_dual] theorem Ici_inter_Iio : Ici a ∩ Iio b = Ico a b := rfl
+@[to_dual] theorem Ioi_inter_Iic : Ioi a ∩ Iic b = Ioc a b := rfl
+@[to_dual] theorem Ioi_inter_Iio : Ioi a ∩ Iio b = Ioo a b := rfl
+
+@[to_dual self] theorem mem_Icc_of_Ioo (h : x ∈ Ioo a b) : x ∈ Icc a b := Ioo_subset_Icc_self h
+@[to_dual] theorem mem_Ico_of_Ioo (h : x ∈ Ioo a b) : x ∈ Ico a b := Ioo_subset_Ico_self h
+@[to_dual] theorem mem_Icc_of_Ioc (h : x ∈ Ioc a b) : x ∈ Icc a b := Ioc_subset_Icc_self h
+@[to_dual] theorem mem_Iic_of_Iio (h : x ∈ Iio a) : x ∈ Iic a := Iio_subset_Iic_self h
+
+@[to_dual self]
 theorem Icc_eq_empty_iff : Icc a b = ∅ ↔ ¬a ≤ b := by
-  rw [← not_nonempty_iff_eq_empty, not_iff_not, nonempty_Icc]
+  contrapose!; exact nonempty_Icc
 
+@[to_dual]
 theorem Ico_eq_empty_iff : Ico a b = ∅ ↔ ¬a < b := by
-  rw [← not_nonempty_iff_eq_empty, not_iff_not, nonempty_Ico]
+  contrapose!; exact nonempty_Ico
 
-theorem Ioc_eq_empty_iff : Ioc a b = ∅ ↔ ¬a < b := by
-  rw [← not_nonempty_iff_eq_empty, not_iff_not, nonempty_Ioc]
-
+@[to_dual self]
 theorem Ioo_eq_empty_iff [DenselyOrdered α] : Ioo a b = ∅ ↔ ¬a < b := by
-  rw [← not_nonempty_iff_eq_empty, not_iff_not, nonempty_Ioo]
+  contrapose!; exact nonempty_Ioo
 
 @[to_dual]
 theorem _root_.IsTop.Iic_eq (h : IsTop a) : Iic a = univ :=
@@ -480,74 +395,52 @@ theorem Iio_eq_empty_iff : Iio a = ∅ ↔ IsMin a := by
 @[to_dual (attr := simp)]
 lemma Iio_nonempty : (Iio a).Nonempty ↔ ¬ IsMin a := by simp [nonempty_iff_ne_empty]
 
+@[to_dual]
 theorem Iic_inter_Ioc_of_le (h : a ≤ c) : Iic a ∩ Ioc b c = Ioc b a :=
   ext fun _ => ⟨fun H => ⟨H.2.1, H.1⟩, fun H => ⟨H.2, H.1, H.2.trans h⟩⟩
 
+@[to_dual notMem_Icc_of_gt]
 theorem notMem_Icc_of_lt (ha : c < a) : c ∉ Icc a b := fun h => ha.not_ge h.1
 
-theorem notMem_Icc_of_gt (hb : b < c) : c ∉ Icc a b := fun h => hb.not_ge h.2
-
+@[to_dual notMem_Ioc_of_gt]
 theorem notMem_Ico_of_lt (ha : c < a) : c ∉ Ico a b := fun h => ha.not_ge h.1
-
-theorem notMem_Ioc_of_gt (hb : b < c) : c ∉ Ioc a b := fun h => hb.not_ge h.2
 
 @[deprecated (since := "2026-02-10")] alias notMem_Ioi_self := self_notMem_Ioi
 
 @[deprecated (since := "2026-02-10")] alias notMem_Iio_self := self_notMem_Iio
 
+@[to_dual notMem_Ico_of_ge]
 theorem notMem_Ioc_of_le (ha : c ≤ a) : c ∉ Ioc a b := fun h => lt_irrefl _ <| h.1.trans_le ha
 
-theorem notMem_Ico_of_ge (hb : b ≤ c) : c ∉ Ico a b := fun h => lt_irrefl _ <| h.2.trans_le hb
-
+@[to_dual notMem_Ioo_of_ge]
 theorem notMem_Ioo_of_le (ha : c ≤ a) : c ∉ Ioo a b := fun h => lt_irrefl _ <| h.1.trans_le ha
-
-theorem notMem_Ioo_of_ge (hb : b ≤ c) : c ∉ Ioo a b := fun h => lt_irrefl _ <| h.2.trans_le hb
 
 section matched_intervals
 
-@[simp] theorem Icc_eq_Ioc_same_iff : Icc a b = Ioc a b ↔ ¬a ≤ b where
+@[to_dual (attr := simp)] theorem Icc_eq_Ioc_same_iff : Icc a b = Ioc a b ↔ ¬a ≤ b where
   mp h := by simpa using Set.ext_iff.mp h a
   mpr h := by rw [Icc_eq_empty h, Ioc_eq_empty (mt le_of_lt h)]
 
-@[simp] theorem Icc_eq_Ico_same_iff : Icc a b = Ico a b ↔ ¬a ≤ b where
-  mp h := by simpa using Set.ext_iff.mp h b
-  mpr h := by rw [Icc_eq_empty h, Ico_eq_empty (mt le_of_lt h)]
+@[to_dual (attr := simp)] theorem Ioc_eq_Icc_same_iff : Ioc a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioc_same_iff
 
-@[simp] theorem Icc_eq_Ioo_same_iff : Icc a b = Ioo a b ↔ ¬a ≤ b where
+@[simp, to_dual self] theorem Icc_eq_Ioo_same_iff : Icc a b = Ioo a b ↔ ¬a ≤ b where
   mp h := by simpa using Set.ext_iff.mp h b
   mpr h := by rw [Icc_eq_empty h, Ioo_eq_empty (mt le_of_lt h)]
 
-@[simp] theorem Ioc_eq_Ico_same_iff : Ioc a b = Ico a b ↔ ¬a < b where
+@[simp, to_dual self] theorem Ioo_eq_Icc_same_iff : Ioo a b = Icc a b ↔ ¬a ≤ b :=
+  eq_comm.trans Icc_eq_Ioo_same_iff
+
+@[to_dual (attr := simp)] theorem Ioc_eq_Ico_same_iff : Ioc a b = Ico a b ↔ ¬a < b where
   mp h := by simpa using Set.ext_iff.mp h a
   mpr h := by rw [Ioc_eq_empty h, Ico_eq_empty h]
 
-@[simp] theorem Ioo_eq_Ioc_same_iff : Ioo a b = Ioc a b ↔ ¬a < b where
+@[to_dual (attr := simp)] theorem Ioo_eq_Ioc_same_iff : Ioo a b = Ioc a b ↔ ¬a < b where
   mp h := by simpa using Set.ext_iff.mp h b
   mpr h := by rw [Ioo_eq_empty h, Ioc_eq_empty h]
 
-@[simp] theorem Ioo_eq_Ico_same_iff : Ioo a b = Ico a b ↔ ¬a < b where
-  mp h := by simpa using Set.ext_iff.mp h a
-  mpr h := by rw [Ioo_eq_empty h, Ico_eq_empty h]
-
--- Mirrored versions of the above for `simp`.
-
-@[simp] theorem Ioc_eq_Icc_same_iff : Ioc a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ioc_same_iff
-
-@[simp] theorem Ico_eq_Icc_same_iff : Ico a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ico_same_iff
-
-@[simp] theorem Ioo_eq_Icc_same_iff : Ioo a b = Icc a b ↔ ¬a ≤ b :=
-  eq_comm.trans Icc_eq_Ioo_same_iff
-
-@[simp] theorem Ico_eq_Ioc_same_iff : Ico a b = Ioc a b ↔ ¬a < b :=
-  eq_comm.trans Ioc_eq_Ico_same_iff
-
-@[simp] theorem Ioc_eq_Ioo_same_iff : Ioc a b = Ioo a b ↔ ¬a < b :=
+@[to_dual (attr := simp)] theorem Ioc_eq_Ioo_same_iff : Ioc a b = Ioo a b ↔ ¬a < b :=
   eq_comm.trans Ioo_eq_Ioc_same_iff
-
-@[simp] theorem Ico_eq_Ioo_same_iff : Ico a b = Ioo a b ↔ ¬a < b :=
-  eq_comm.trans Ioo_eq_Ico_same_iff
 
 end matched_intervals
 
@@ -565,7 +458,7 @@ instance instIccUnique : Unique (Set.Icc a a) where
   default := ⟨a, by simp⟩
   uniq y := Subtype.ext <| by simpa using y.2
 
-@[simp]
+@[simp, to_dual none]
 theorem Icc_eq_singleton_iff : Icc a b = {c} ↔ a = c ∧ b = c := by
   refine ⟨fun h => ?_, ?_⟩
   · have hab : a ≤ b := nonempty_Icc.1 (h.symm.subst <| singleton_nonempty c)
@@ -575,33 +468,27 @@ theorem Icc_eq_singleton_iff : Icc a b = {c} ↔ a = c ∧ b = c := by
   · rintro ⟨rfl, rfl⟩
     exact Icc_self _
 
+@[to_dual self]
 lemma subsingleton_Icc_of_ge (hba : b ≤ a) : Set.Subsingleton (Icc a b) :=
   fun _x ⟨hax, hxb⟩ _y ⟨hay, hyb⟩ ↦ le_antisymm
     (le_imp_le_of_le_of_le hxb hay hba) (le_imp_le_of_le_of_le hyb hax hba)
 
-@[simp] lemma subsingleton_Icc_iff {α : Type*} [LinearOrder α] {a b : α} :
+@[simp, to_dual self]
+lemma subsingleton_Icc_iff {α : Type*} [LinearOrder α] {a b : α} :
     Set.Subsingleton (Icc a b) ↔ b ≤ a := by
   refine ⟨fun h ↦ ?_, subsingleton_Icc_of_ge⟩
   contrapose! h
   exact ⟨a, ⟨le_refl _, h.le⟩, b, ⟨h.le, le_refl _⟩, h.ne⟩
 
-@[simp]
+@[to_dual (attr := simp) Icc_diff_right]
 theorem Icc_diff_left : Icc a b \ {a} = Ioc a b :=
   ext fun x => by simp [lt_iff_le_and_ne, eq_comm, and_right_comm]
 
-@[simp]
-theorem Icc_diff_right : Icc a b \ {b} = Ico a b :=
-  ext fun x => by simp [lt_iff_le_and_ne, and_assoc]
-
-@[simp]
+@[to_dual (attr := simp) Ioc_diff_right]
 theorem Ico_diff_left : Ico a b \ {a} = Ioo a b :=
   ext fun x => by simp [and_right_comm, ← lt_iff_le_and_ne, eq_comm]
 
-@[simp]
-theorem Ioc_diff_right : Ioc a b \ {b} = Ioo a b :=
-  ext fun x => by simp [and_assoc, ← lt_iff_le_and_ne]
-
-@[simp]
+@[simp, to_dual none]
 theorem Icc_diff_both : Icc a b \ {a, b} = Ioo a b := by
   rw [insert_eq, ← diff_diff, Icc_diff_left, Ioc_diff_right]
 
@@ -609,23 +496,15 @@ theorem Icc_diff_both : Icc a b \ {a, b} = Ioo a b := by
 theorem Iic_diff_right : Iic a \ {a} = Iio a :=
   ext fun x => by simp [lt_iff_le_and_ne]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ico_diff_Ioo_same (h : a < b) : Ico a b \ Ioo a b = {a} := by
   rw [← Ico_diff_left, diff_diff_cancel_left (singleton_subset_iff.2 <| left_mem_Ico.2 h)]
 
-@[simp]
-theorem Ioc_diff_Ioo_same (h : a < b) : Ioc a b \ Ioo a b = {b} := by
-  rw [← Ioc_diff_right, diff_diff_cancel_left (singleton_subset_iff.2 <| right_mem_Ioc.2 h)]
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem Icc_diff_Ico_same (h : a ≤ b) : Icc a b \ Ico a b = {b} := by
   rw [← Icc_diff_right, diff_diff_cancel_left (singleton_subset_iff.2 <| right_mem_Icc.2 h)]
 
-@[simp]
-theorem Icc_diff_Ioc_same (h : a ≤ b) : Icc a b \ Ioc a b = {a} := by
-  rw [← Icc_diff_left, diff_diff_cancel_left (singleton_subset_iff.2 <| left_mem_Icc.2 h)]
-
-@[simp]
+@[simp, to_dual none]
 theorem Icc_diff_Ioo_same (h : a ≤ b) : Icc a b \ Ioo a b = {a, b} := by
   rw [← Icc_diff_both, diff_diff_cancel_left]
   simp [insert_subset_iff, h]
@@ -638,41 +517,30 @@ theorem Iic_diff_Iio_same : Iic a \ Iio a = {a} := by
 theorem Iio_union_right : Iio a ∪ {a} = Iic a :=
   ext fun _ => le_iff_lt_or_eq.symm
 
+@[to_dual Ioo_union_right]
 theorem Ioo_union_left (hab : a < b) : Ioo a b ∪ {a} = Ico a b := by
   rw [← Ico_diff_left, diff_union_self,
     union_eq_self_of_subset_right (singleton_subset_iff.2 <| left_mem_Ico.2 hab)]
 
-theorem Ioo_union_right (hab : a < b) : Ioo a b ∪ {b} = Ioc a b := by
-  simpa only [Ioo_toDual, Ico_toDual] using Ioo_union_left hab.dual
-
+@[to_dual none]
 theorem Ioo_union_both (h : a ≤ b) : Ioo a b ∪ {a, b} = Icc a b := by
   have : (Icc a b \ {a, b}) ∪ {a, b} = Icc a b := diff_union_of_subset fun
     | x, .inl rfl => left_mem_Icc.mpr h
     | x, .inr rfl => right_mem_Icc.mpr h
   rw [← this, Icc_diff_both]
 
+@[to_dual Ico_union_right]
 theorem Ioc_union_left (hab : a ≤ b) : Ioc a b ∪ {a} = Icc a b := by
   rw [← Icc_diff_left, diff_union_self,
     union_eq_self_of_subset_right (singleton_subset_iff.2 <| left_mem_Icc.2 hab)]
 
-theorem Ico_union_right (hab : a ≤ b) : Ico a b ∪ {b} = Icc a b := by
-  simpa only [Ioc_toDual, Icc_toDual] using Ioc_union_left hab.dual
-
-@[simp]
+@[to_dual (attr := simp) Ioc_insert_left]
 theorem Ico_insert_right (h : a ≤ b) : insert b (Ico a b) = Icc a b := by
   rw [insert_eq, union_comm, Ico_union_right h]
 
-@[simp]
-theorem Ioc_insert_left (h : a ≤ b) : insert a (Ioc a b) = Icc a b := by
-  rw [insert_eq, union_comm, Ioc_union_left h]
-
-@[simp]
+@[to_dual (attr := simp) Ioo_insert_right]
 theorem Ioo_insert_left (h : a < b) : insert a (Ioo a b) = Ico a b := by
   rw [insert_eq, union_comm, Ioo_union_left h]
-
-@[simp]
-theorem Ioo_insert_right (h : a < b) : insert b (Ioo a b) = Ioc a b := by
-  rw [insert_eq, union_comm, Ioo_union_right h]
 
 @[to_dual (attr := simp)]
 theorem Iio_insert : insert a (Iio a) = Iic a :=
@@ -706,12 +574,11 @@ theorem mem_Icc_Ico_Ioc_Ioo_of_subset_of_subset {s : Set α} (ho : Ioo a b ⊆ s
       rw [← Ico_diff_left, ← Icc_diff_right]
       apply_rules [subset_diff_singleton]
 
+@[to_dual eq_right_or_mem_Ioo_of_mem_Ioc]
 theorem eq_left_or_mem_Ioo_of_mem_Ico {x : α} (hmem : x ∈ Ico a b) : x = a ∨ x ∈ Ioo a b :=
   hmem.1.eq_or_lt'.imp_right fun h => ⟨h, hmem.2⟩
 
-theorem eq_right_or_mem_Ioo_of_mem_Ioc {x : α} (hmem : x ∈ Ioc a b) : x = b ∨ x ∈ Ioo a b :=
-  hmem.2.eq_or_lt.imp_right <| And.intro hmem.1
-
+@[to_dual none]
 theorem eq_endpoints_or_mem_Ioo_of_mem_Icc {x : α} (hmem : x ∈ Icc a b) :
     x = a ∨ x = b ∨ x ∈ Ioo a b :=
   hmem.1.eq_or_lt'.imp_right fun h => eq_right_or_mem_Ioo_of_mem_Ioc ⟨h, hmem.2⟩
@@ -728,11 +595,12 @@ theorem Iic_injective : Injective (Iic : α → Set α) := fun _ _ =>
 theorem Iic_inj : Iic a = Iic b ↔ a = b :=
   Iic_injective.eq_iff
 
-@[simp]
+@[simp, to_dual none]
 theorem Icc_inter_Icc_eq_singleton (hab : a ≤ b) (hbc : b ≤ c) : Icc a b ∩ Icc b c = {b} := by
   rw [← Ici_inter_Iic, ← Iic_inter_Ici, inter_inter_inter_comm, Iic_inter_Ici]
   simp [hab, hbc]
 
+@[to_dual none]
 lemma Icc_eq_Icc_iff {d : α} (h : a ≤ b) :
     Icc a b = Icc c d ↔ a = c ∧ b = d := by
   refine ⟨fun heq ↦ ?_, by rintro ⟨rfl, rfl⟩; rfl⟩
@@ -767,25 +635,13 @@ theorem Ioi_top : Ioi (⊤ : α) = ∅ :=
 theorem Iic_top : Iic (⊤ : α) = univ :=
   isTop_top.Iic_eq
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Icc_top : Icc a ⊤ = Ici a := by simp [← Ici_inter_Iic]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ioc_top : Ioc a ⊤ = Ioi a := by simp [← Ioi_inter_Iic]
 
 end OrderTop
-
-section OrderBot
-
-variable [Preorder α] [OrderBot α] {a : α}
-
-@[simp]
-theorem Icc_bot : Icc ⊥ a = Iic a := by simp [← Ici_inter_Iic]
-
-@[simp]
-theorem Ico_bot : Ico ⊥ a = Iio a := by simp [← Ici_inter_Iio]
-
-end OrderBot
 
 theorem Icc_bot_top [Preorder α] [BoundedOrder α] : Icc (⊥ : α) ⊤ = univ := by simp
 
@@ -800,30 +656,17 @@ theorem Iic_inter_Iic {a b : α} : Iic a ∩ Iic b = Iic (a ⊓ b) := by
   ext x
   simp [Iic]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem Ioc_inter_Iic (a b c : α) : Ioc a b ∩ Iic c = Ioc a (b ⊓ c) := by
   rw [← Ioi_inter_Iic, ← Ioi_inter_Iic, inter_assoc, Iic_inter_Iic]
 
 end Inf
 
-section Sup
-
-variable [SemilatticeSup α]
-
-@[simp]
-theorem Ico_inter_Ici (a b c : α) : Ico a b ∩ Ici c = Ico (a ⊔ c) b := by
-  rw [← Ici_inter_Iio, ← Ici_inter_Iio, ← Ici_inter_Ici, inter_right_comm]
-
-end Sup
-
-section Both
-
 variable [Lattice α] {a b c a₁ a₂ b₁ b₂ : α}
 
+@[to_dual self]
 theorem Icc_inter_Icc : Icc a₁ b₁ ∩ Icc a₂ b₂ = Icc (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
   simp only [Ici_inter_Iic.symm, Ici_inter_Ici.symm, Iic_inter_Iic.symm]; ac_rfl
-
-end Both
 
 end Lattice
 
@@ -841,16 +684,15 @@ theorem Iic_prod_Iic (a : α) (b : β) : Iic a ×ˢ Iic b = Iic (a, b) :=
 theorem Iic_prod_eq (a : α × β) : Iic a = Iic a.1 ×ˢ Iic a.2 :=
   rfl
 
-@[simp]
+@[simp, to_dual self]
 theorem Icc_prod_Icc (a₁ a₂ : α) (b₁ b₂ : β) : Icc a₁ a₂ ×ˢ Icc b₁ b₂ = Icc (a₁, b₁) (a₂, b₂) := by
   ext ⟨x, y⟩
   simp [and_assoc, and_left_comm]
 
+@[to_dual self]
 theorem Icc_prod_eq (a b : α × β) : Icc a b = Icc a.1 b.1 ×ˢ Icc a.2 b.2 := by simp
 
 end Prod
-
-end Set
 
 /-! ### Lemmas about intervals in dense orders -/
 
@@ -858,41 +700,27 @@ section Dense
 
 variable (α) [Preorder α] [DenselyOrdered α] {x y : α}
 
+@[to_dual] -- TODO: `to_dual` only works with the `mem_Ioo.mpr` in the proof.
 instance : NoMinOrder (Set.Ioo x y) :=
-  ⟨fun ⟨a, ha₁, ha₂⟩ => by
-    rcases exists_between ha₁ with ⟨b, hb₁, hb₂⟩
-    exact ⟨⟨b, hb₁, hb₂.trans ha₂⟩, hb₂⟩⟩
+  ⟨fun ⟨a, ha⟩ => by
+    rcases exists_between ha.1 with ⟨b, hb₁, hb₂⟩
+    exact ⟨⟨b, mem_Ioo.mpr ⟨hb₁, hb₂.trans ha.2⟩⟩, hb₂⟩⟩
 
+@[to_dual] -- TODO: `to_dual` only works with the `mem_Ioc.mpr` in the proof.
 instance : NoMinOrder (Set.Ioc x y) :=
-  ⟨fun ⟨a, ha₁, ha₂⟩ => by
-    rcases exists_between ha₁ with ⟨b, hb₁, hb₂⟩
-    exact ⟨⟨b, hb₁, hb₂.le.trans ha₂⟩, hb₂⟩⟩
+  ⟨fun ⟨a, ha⟩ => by
+    rcases exists_between ha.1 with ⟨b, hb₁, hb₂⟩
+    exact ⟨⟨b, mem_Ioc.mpr ⟨hb₁, hb₂.le.trans ha.2⟩⟩, hb₂⟩⟩
 
+@[to_dual]
 instance : NoMinOrder (Set.Ioi x) :=
   ⟨fun ⟨a, ha⟩ => by
     rcases exists_between ha with ⟨b, hb₁, hb₂⟩
     exact ⟨⟨b, hb₁⟩, hb₂⟩⟩
 
-instance : NoMaxOrder (Set.Ioo x y) :=
-  ⟨fun ⟨a, ha₁, ha₂⟩ => by
-    rcases exists_between ha₂ with ⟨b, hb₁, hb₂⟩
-    exact ⟨⟨b, ha₁.trans hb₁, hb₂⟩, hb₁⟩⟩
-
-instance : NoMaxOrder (Set.Ico x y) :=
-  ⟨fun ⟨a, ha₁, ha₂⟩ => by
-    rcases exists_between ha₂ with ⟨b, hb₁, hb₂⟩
-    exact ⟨⟨b, ha₁.trans hb₁.le, hb₂⟩, hb₁⟩⟩
-
-instance : NoMaxOrder (Set.Iio x) :=
-  ⟨fun ⟨a, ha⟩ => by
-    rcases exists_between ha with ⟨b, hb₁, hb₂⟩
-    exact ⟨⟨b, hb₂⟩, hb₁⟩⟩
-
 end Dense
 
 /-! ### Intervals in `Prop` -/
-
-namespace Set
 
 @[simp] lemma Iic_False : Iic False = {False} := by aesop
 @[simp] lemma Iic_True : Iic True = univ := by aesop

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -71,8 +71,11 @@ instance decidableMemIoc [Decidable (a < x ∧ x ≤ b)] : Decidable (x ∈ Ioc 
 @[to_dual] theorem self_notMem_Iio : a ∉ Iio a := by simp
 @[to_dual] theorem self_mem_Iic : a ∈ Iic a := by simp
 
-@[to_dual right_notMem_Ioo] theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
-@[to_dual right_notMem_Ico] theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
+@[to_dual (reorder := a b) right_notMem_Ioo]
+theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
+
+@[to_dual (reorder := a b) right_notMem_Ico]
+theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
 
 @[deprecated left_notMem_Ioo (since := "2025-12-26")]
 theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp
@@ -656,7 +659,7 @@ theorem Iic_inter_Iic {a b : α} : Iic a ∩ Iic b = Iic (a ⊓ b) := by
   ext x
   simp [Iic]
 
-@[to_dual (attr := simp)]
+@[to_dual (reorder := a b) (attr := simp)]
 theorem Ioc_inter_Iic (a b c : α) : Ioc a b ∩ Iic c = Ioc a (b ⊓ c) := by
   rw [← Ioi_inter_Iic, ← Ioi_inter_Iic, inter_assoc, Iic_inter_Iic]
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -457,7 +457,7 @@ variable [PartialOrder α] {a b c : α}
 theorem Icc_self (a : α) : Icc a a = {a} :=
   Set.ext <| by simp [Icc, le_antisymm_iff, and_comm]
 
-instance instIccUnique : Unique (Set.Icc a a) where
+instance instIccUnique : Unique (Icc a a) where
   default := ⟨a, by simp⟩
   uniq y := Subtype.ext <| by simpa using y.2
 
@@ -704,19 +704,19 @@ section Dense
 variable (α) [Preorder α] [DenselyOrdered α] {x y : α}
 
 @[to_dual] -- TODO: `to_dual` only works with the `mem_Ioo.mpr` in the proof.
-instance : NoMinOrder (Set.Ioo x y) :=
+instance : NoMinOrder (Ioo x y) :=
   ⟨fun ⟨a, ha⟩ => by
     rcases exists_between ha.1 with ⟨b, hb₁, hb₂⟩
     exact ⟨⟨b, mem_Ioo.mpr ⟨hb₁, hb₂.trans ha.2⟩⟩, hb₂⟩⟩
 
 @[to_dual] -- TODO: `to_dual` only works with the `mem_Ioc.mpr` in the proof.
-instance : NoMinOrder (Set.Ioc x y) :=
+instance : NoMinOrder (Ioc x y) :=
   ⟨fun ⟨a, ha⟩ => by
     rcases exists_between ha.1 with ⟨b, hb₁, hb₂⟩
     exact ⟨⟨b, mem_Ioc.mpr ⟨hb₁, hb₂.le.trans ha.2⟩⟩, hb₂⟩⟩
 
 @[to_dual]
-instance : NoMinOrder (Set.Ioi x) :=
+instance : NoMinOrder (Ioi x) :=
   ⟨fun ⟨a, ha⟩ => by
     rcases exists_between ha with ⟨b, hb₁, hb₂⟩
     exact ⟨⟨b, hb₁⟩, hb₂⟩⟩

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -59,13 +59,6 @@ instance decidableMemIio [Decidable (x < b)] : Decidable (x ∈ Iio b) := by ass
 @[to_dual]
 instance decidableMemIic [Decidable (x ≤ b)] : Decidable (x ∈ Iic b) := by assumption
 
--- TODO: these instances are awkward for `to_dual`
-instance decidableMemIoo [Decidable (a < x ∧ x < b)] : Decidable (x ∈ Ioo a b) := by assumption
-
-instance decidableMemIco [Decidable (a ≤ x ∧ x < b)] : Decidable (x ∈ Ico a b) := by assumption
-
-instance decidableMemIcc [Decidable (a ≤ x ∧ x ≤ b)] : Decidable (x ∈ Icc a b) := by assumption
-
 @[to_dual self (reorder := a b, 6 7)]
 instance decidableMemIoo [Decidable (a < x)] [Decidable (x < b)] : Decidable (x ∈ Ioo a b) :=
   instDecidableAnd

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -753,7 +753,7 @@ partial def transformDeclRec (t : TranslateData) (ref : Syntax) (pre tgt_pre src
   if isProtected (← getEnv) src then
     modifyEnv (addProtected · tgt)
   if defeqAttr.hasTag (← getEnv) src then
-    defeqAttr.setTag tgt
+    MetaM.run' <| inferDefEqAttr tgt
   if let some matcherInfo ← getMatcherInfo? src then
     Match.addMatcherInfo tgt matcherInfo
   -- necessary so that e.g. match equations can be generated for `tgt`

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -753,6 +753,8 @@ partial def transformDeclRec (t : TranslateData) (ref : Syntax) (pre tgt_pre src
   if isProtected (← getEnv) src then
     modifyEnv (addProtected · tgt)
   if defeqAttr.hasTag (← getEnv) src then
+    /- It can be that `src` holds reflexively but `tgt` doesn't, so we need to use `inferDefEqAttr`.
+    For example in `Ici_inter_Iic : Ici a ∩ Iic b = Icc a b := rfl`. -/
     MetaM.run' <| inferDefEqAttr tgt
   if let some matcherInfo ← getMatcherInfo? src then
     Match.addMatcherInfo tgt matcherInfo


### PR DESCRIPTION
This PR tags basic theorems about `Ioo`, `Ioc`, `Ico` and `Icc` with `to_dual`. This is the other half of #33964.

Notes:
- I decided to add the theorems `Ico_subset_Ioo` and `Icc_subset_Ioc`, because they were missing.
- For some proofs, the cast insertion heuristic failed, and I had to modify the proof slightly in order to make it work with `to_dual`. The two kinds of fixes were replacing `fun ⟨hx₁, hx₁⟩ ↦` with `fun hx ↦` and then using `hx.1` and `hx.2`, and inserting an explicit rewrite using `mem_Ioo` in order to eliminate the defEq abuse. I should investigate how to fix this, but that shouldn't block this PR.
- There were some theorems that hold by `rfl`, but their dual does not. This confused the `@[defEq]` attribute, because we were erroneously setting it for these dual theorems. I've modified it so that it will first check if the attribute is applicable.
- `left_notMem_Ioc` and `left_notMem_Ioo` used to have explicit arguments. I made these implicit which lines up with their dual version, and their `Finset` counterparts.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
