### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace): a linear map composed with its adjoint is symmetric

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -592,6 +592,10 @@ theorem isAdjointPair_inner (A : E →ₗ[𝕜] F) :
   intro x y
   simp [adjoint_inner_left]
 
+/- This next batch of lemmas is based on theorems like `LinearMap.IsPositive.conj_adjoint`, which
+are in a downstream file but historically existed before these lemmas. We can't put them in the file
+where `LinearMap.IsSymmetric` is defined because they depend on the adjoint. -/
+
 @[aesop safe apply]
 theorem IsSymmetric.conj_adjoint {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (S : E →ₗ[𝕜] F) :
     (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := by
@@ -608,11 +612,12 @@ theorem IsSymmetric.adjoint_conj {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (S 
     (S.adjoint ∘ₗ T ∘ₗ S).IsSymmetric := by
   simpa using hT.conj_adjoint S.adjoint
 
--- LinearMap.isSymmetric_adjoint_mul_self but domain and range can be different
+/-- Like `LinearMap.isSymmetric_adjoint_mul_self` but domain and range can be different -/
 theorem isSymmetric_adjoint_comp_self (T : E →ₗ[𝕜] F) : (adjoint T ∘ₗ T).IsSymmetric := by
   simpa using LinearMap.IsSymmetric.id.adjoint_conj T
 
-/-- The Gram operator T†T is symmetric. -/
+/-- The Gram operator T†T is symmetric. See `LinearMap.isSymmetric_adjoint_comp_self` for a version
+where the domain and codomain are distinct. -/
 theorem isSymmetric_adjoint_mul_self (T : E →ₗ[𝕜] E) : IsSymmetric (T.adjoint * T) := by
   intro x y
   simp [adjoint_inner_left, adjoint_inner_right]

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -598,11 +598,7 @@ where `LinearMap.IsSymmetric` is defined because they depend on the adjoint. -/
 
 @[aesop safe apply]
 theorem IsSymmetric.conj_adjoint {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (S : E →ₗ[𝕜] F) :
-    (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := by
-  rw [LinearMap.IsSymmetric]
-  intro x y
-  rw [← adjoint_inner_right (S ∘ₗ T ∘ₗ S.adjoint)]
-  simp [hT.adjoint_eq]
+    (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := fun _ _ ↦ by simp [← adjoint_inner_right, hT]
 
 theorem isSymmetric_self_comp_adjoint (T : E →ₗ[𝕜] F) : (T ∘ₗ adjoint T).IsSymmetric := by
   simpa using LinearMap.IsSymmetric.id.conj_adjoint T

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -593,25 +593,23 @@ theorem isAdjointPair_inner (A : E →ₗ[𝕜] F) :
   simp [adjoint_inner_left]
 
 @[aesop safe apply]
-theorem IsSymmetric.conj_adjoint {T : E →ₗ[𝕜] E}
-    (hT : T.IsSymmetric) (S : E →ₗ[𝕜] F) : (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := by
+theorem IsSymmetric.conj_adjoint {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (S : E →ₗ[𝕜] F) :
+    (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := by
   rw [LinearMap.IsSymmetric]
   intro x y
   rw [← adjoint_inner_right (S ∘ₗ T ∘ₗ S.adjoint)]
   simp [hT.adjoint_eq]
 
-theorem isSymmetric_self_comp_adjoint (T : E →ₗ[𝕜] F) :
-    (T ∘ₗ adjoint T).IsSymmetric := by
+theorem isSymmetric_self_comp_adjoint (T : E →ₗ[𝕜] F) : (T ∘ₗ adjoint T).IsSymmetric := by
   simpa using LinearMap.IsSymmetric.id.conj_adjoint T
 
 @[aesop safe apply]
-theorem IsSymmetric.adjoint_conj {T : E →ₗ[𝕜] E}
-    (hT : T.IsSymmetric) (S : F →ₗ[𝕜] E) : (S.adjoint ∘ₗ T ∘ₗ S).IsSymmetric := by
+theorem IsSymmetric.adjoint_conj {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (S : F →ₗ[𝕜] E) :
+    (S.adjoint ∘ₗ T ∘ₗ S).IsSymmetric := by
   simpa using hT.conj_adjoint S.adjoint
 
 -- LinearMap.isSymmetric_adjoint_mul_self but domain and range can be different
-theorem isSymmetric_adjoint_comp_self (T : E →ₗ[𝕜] F) :
-    (adjoint T ∘ₗ T).IsSymmetric := by
+theorem isSymmetric_adjoint_comp_self (T : E →ₗ[𝕜] F) : (adjoint T ∘ₗ T).IsSymmetric := by
   simpa using LinearMap.IsSymmetric.id.adjoint_conj T
 
 /-- The Gram operator T†T is symmetric. -/

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -592,6 +592,28 @@ theorem isAdjointPair_inner (A : E →ₗ[𝕜] F) :
   intro x y
   simp [adjoint_inner_left]
 
+@[aesop safe apply]
+theorem IsSymmetric.conj_adjoint {T : E →ₗ[𝕜] E}
+    (hT : T.IsSymmetric) (S : E →ₗ[𝕜] F) : (S ∘ₗ T ∘ₗ S.adjoint).IsSymmetric := by
+  rw [LinearMap.IsSymmetric]
+  intro x y
+  rw [← adjoint_inner_right (S ∘ₗ T ∘ₗ S.adjoint)]
+  simp [hT.adjoint_eq]
+
+theorem isSymmetric_self_comp_adjoint (T : E →ₗ[𝕜] F) :
+    (T ∘ₗ adjoint T).IsSymmetric := by
+  simpa using LinearMap.IsSymmetric.id.conj_adjoint T
+
+@[aesop safe apply]
+theorem IsSymmetric.adjoint_conj {T : E →ₗ[𝕜] E}
+    (hT : T.IsSymmetric) (S : F →ₗ[𝕜] E) : (S.adjoint ∘ₗ T ∘ₗ S).IsSymmetric := by
+  simpa using hT.conj_adjoint S.adjoint
+
+-- LinearMap.isSymmetric_adjoint_mul_self but domain and range can be different
+theorem isSymmetric_adjoint_comp_self (T : E →ₗ[𝕜] F) :
+    (adjoint T ∘ₗ T).IsSymmetric := by
+  simpa using LinearMap.IsSymmetric.id.adjoint_conj T
+
 /-- The Gram operator T†T is symmetric. -/
 theorem isSymmetric_adjoint_mul_self (T : E →ₗ[𝕜] E) : IsSymmetric (T.adjoint * T) := by
   intro x y


### PR DESCRIPTION
Add theorems about `LinearMap.IsSymmetric` that match some theorems for `LinearMap.IsPositive`.
Mathlib contains stronger versions of some of these, like `LinearMap.IsPositive.self_comp_adjoint`, but having a dedicated version for `LinearMap.IsSymmetric` is advantageous, especially when used with `LinearMap.IsSymmetric.eigenvalues`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

One thing that I am uncertain about is if I should add similar lemmas for `ContinuousLinearMap` to even better match the `IsPositive` API, and if so, whether these theorems should be stated in terms of `IsSymmetric` or `IsSelfAdjoint`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
