### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Subobject): missing simp lemma on self equalizers

### DIFF
--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -82,7 +82,7 @@ theorem equalizerSubobject_arrow_comp :
   rw [← equalizerSubobject_arrow, Category.assoc, Category.assoc, equalizer.condition]
 
 @[reassoc (attr := simp)]
-theorem equalizerSubobject_of_self {X Y : C} (f : X ⟶ Y) : equalizerSubobject f f = ⊤ := by
+theorem equalizerSubobject_of_self : equalizerSubobject f f = ⊤ := by
   apply mk_eq_top_of_isIso
 
 theorem equalizerSubobject_factors {W : C} (h : W ⟶ X) (w : h ≫ f = h ≫ g) :

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -81,7 +81,7 @@ theorem equalizerSubobject_arrow_comp :
     (equalizerSubobject f g).arrow ≫ f = (equalizerSubobject f g).arrow ≫ g := by
   rw [← equalizerSubobject_arrow, Category.assoc, Category.assoc, equalizer.condition]
 
-@[reassoc (attr := simp)]
+@[simp]
 theorem equalizerSubobject_of_self : equalizerSubobject f f = ⊤ := by
   apply mk_eq_top_of_isIso
 

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -203,9 +203,7 @@ theorem kernelSubobjectIso_comp_kernel_map (sq : Arrow.mk f ⟶ Arrow.mk f') :
 
 end
 
-@[simp]
-theorem kernelSubobject_zero {A B : C} : kernelSubobject (0 : A ⟶ B) = ⊤ :=
-  (isIso_iff_mk_eq_top _).mp (by infer_instance)
+@[deprecated (since := "2026-02-12")] alias kernelSubobject_zero := equalizerSubobject_of_self
 
 instance isIso_kernelSubobject_zero_arrow : IsIso (kernelSubobject (0 : X ⟶ Y)).arrow :=
   (isIso_arrow_iff_eq_top _).mpr kernelSubobject_zero

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -203,7 +203,9 @@ theorem kernelSubobjectIso_comp_kernel_map (sq : Arrow.mk f ⟶ Arrow.mk f') :
 
 end
 
-@[deprecated (since := "2026-02-12")] alias kernelSubobject_zero := equalizerSubobject_of_self
+@[simp]
+theorem kernelSubobject_zero {A B : C} : kernelSubobject (0 : A ⟶ B) = ⊤ :=
+  equalizerSubobject_of_self 0
 
 instance isIso_kernelSubobject_zero_arrow : IsIso (kernelSubobject (0 : X ⟶ Y)).arrow :=
   (isIso_arrow_iff_eq_top _).mpr kernelSubobject_zero

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -203,12 +203,11 @@ theorem kernelSubobjectIso_comp_kernel_map (sq : Arrow.mk f ⟶ Arrow.mk f') :
 
 end
 
-@[simp]
-theorem kernelSubobject_zero {A B : C} : kernelSubobject (0 : A ⟶ B) = ⊤ :=
-  equalizerSubobject_of_self 0
+theorem kernelSubobject_zero {A B : C} : kernelSubobject (0 : A ⟶ B) = ⊤ := by
+  simp
 
 instance isIso_kernelSubobject_zero_arrow : IsIso (kernelSubobject (0 : X ⟶ Y)).arrow :=
-  (isIso_arrow_iff_eq_top _).mpr kernelSubobject_zero
+  (isIso_arrow_iff_eq_top _).mpr (by simp)
 
 theorem le_kernelSubobject (A : Subobject X) (h : A.arrow ≫ f = 0) : A ≤ kernelSubobject f :=
   Subobject.le_mk_of_comm (kernel.lift f A.arrow h) (by simp)

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -81,6 +81,10 @@ theorem equalizerSubobject_arrow_comp :
     (equalizerSubobject f g).arrow ≫ f = (equalizerSubobject f g).arrow ≫ g := by
   rw [← equalizerSubobject_arrow, Category.assoc, Category.assoc, equalizer.condition]
 
+@[reassoc (attr := simp)]
+theorem equalizerSubobject_of_self {X Y : C} (f : X ⟶ Y) : equalizerSubobject f f = ⊤ := by
+  apply mk_eq_top_of_isIso
+
 theorem equalizerSubobject_factors {W : C} (h : W ⟶ X) (w : h ≫ f = h ≫ g) :
     (equalizerSubobject f g).Factors h :=
   ⟨equalizer.lift h w, by simp⟩


### PR DESCRIPTION
Missing simp lemma on `equalizerSubobject f f = ⊤`.