### PR TITLE
[Merged by Bors] - feat(Algebra/Group/End): use `to_additive`

### DIFF
--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -638,8 +638,6 @@ end Equiv
 abbrev MulAut (M : Type*) [Mul M] :=
   M ≃* M
 
-attribute [to_additive_dont_translate] MulAut MulEquiv
-
 namespace MulAut
 
 variable (M) [Mul M]
@@ -647,10 +645,6 @@ variable (M) [Mul M]
 /-- The group operation on multiplicative automorphisms is defined by `g h => MulEquiv.trans h g`.
 This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
 -/
-@[to_additive instGroup
-/-- The group operation on additive automorphisms is defined by `g h => AddEquiv.trans h g`.
-This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
--/]
 instance : Group (MulAut M) where
   mul g h := MulEquiv.trans h g
   one := MulEquiv.refl _
@@ -660,62 +654,54 @@ instance : Group (MulAut M) where
   mul_one _ := rfl
   inv_mul_cancel := MulEquiv.self_trans_symm
 
-@[to_additive]
 instance : Inhabited (MulAut M) :=
   ⟨1⟩
 
-@[to_additive (attr := simp) coe_mul]
+@[simp]
 theorem coe_mul (e₁ e₂ : MulAut M) : ⇑(e₁ * e₂) = e₁ ∘ e₂ :=
   rfl
 
-@[to_additive (attr := simp) coe_one]
+@[simp]
 theorem coe_one : ⇑(1 : MulAut M) = id :=
   rfl
 
-@[to_additive (attr := simp) coe_inv]
+@[simp]
 theorem coe_inv (e : MulAut M) : ⇑e⁻¹ = e.symm := rfl
 
-@[to_additive mul_def]
 theorem mul_def (e₁ e₂ : MulAut M) : e₁ * e₂ = e₂.trans e₁ :=
   rfl
 
-@[to_additive one_def]
 theorem one_def : (1 : MulAut M) = MulEquiv.refl _ :=
   rfl
 
-@[to_additive inv_def]
 theorem inv_def (e₁ : MulAut M) : e₁⁻¹ = e₁.symm :=
   rfl
 
-@[to_additive (attr := simp) inv_symm]
+@[simp]
 theorem inv_symm (e : MulAut M) : e⁻¹.symm = e := rfl
 
-@[to_additive (attr := simp) symm_inv]
+@[simp]
 theorem symm_inv (e : MulAut M) : (e.symm)⁻¹ = e := rfl
 
-@[to_additive (attr := simp) inv_apply]
+@[simp]
 theorem inv_apply (e : MulAut M) (m : M) : e⁻¹ m = e.symm m := by
   rw [inv_def]
 
-@[to_additive (attr := simp) mul_apply]
+@[simp]
 theorem mul_apply (e₁ e₂ : MulAut M) (m : M) : (e₁ * e₂) m = e₁ (e₂ m) :=
   rfl
 
-@[to_additive (attr := simp) one_apply]
+@[simp]
 theorem one_apply (m : M) : (1 : MulAut M) m = m :=
   rfl
 
-@[to_additive apply_inv_self]
 theorem apply_inv_self (e : MulAut M) (m : M) : e (e⁻¹ m) = m :=
   MulEquiv.apply_symm_apply _ _
 
-@[to_additive inv_apply_self]
 theorem inv_apply_self (e : MulAut M) (m : M) : e⁻¹ (e m) = m :=
   MulEquiv.apply_symm_apply _ _
 
 /-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
-@[to_additive
-/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/]
 def toPerm : MulAut M →* Equiv.Perm M where
   toFun := MulEquiv.toEquiv
   map_one' := rfl
@@ -750,8 +736,7 @@ theorem conj_inv_apply [Group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g :=
   rfl
 
 /-- Isomorphic groups have isomorphic automorphism groups. -/
-@[to_additive (attr := simps)
-/-- Isomorphic additive groups have isomorphic automorphism groups. -/]
+@[simps]
 def congr [Group G] {H : Type*} [Group H] (ϕ : G ≃* H) :
     MulAut G ≃* MulAut H where
   toFun f := ϕ.symm.trans (f.trans ϕ)
@@ -765,6 +750,70 @@ end MulAut
 namespace AddAut
 
 variable (A) [Add A]
+
+/-- The group operation on additive automorphisms is defined by `g h => AddEquiv.trans h g`.
+This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
+-/
+instance : Group (AddAut A) where
+  mul g h := AddEquiv.trans h g
+  one := AddEquiv.refl _
+  inv := AddEquiv.symm
+  mul_assoc _ _ _ := rfl
+  one_mul _ := rfl
+  mul_one _ := rfl
+  inv_mul_cancel := AddEquiv.self_trans_symm
+
+instance : Inhabited (AddAut A) :=
+  ⟨1⟩
+
+@[simp]
+theorem coe_mul (e₁ e₂ : AddAut A) : ⇑(e₁ * e₂) = e₁ ∘ e₂ :=
+  rfl
+
+@[simp]
+theorem coe_one : ⇑(1 : AddAut A) = id :=
+  rfl
+
+@[simp]
+theorem coe_inv (e : AddAut A) : ⇑e⁻¹ = e.symm := rfl
+
+theorem mul_def (e₁ e₂ : AddAut A) : e₁ * e₂ = e₂.trans e₁ :=
+  rfl
+
+theorem one_def : (1 : AddAut A) = AddEquiv.refl _ :=
+  rfl
+
+theorem inv_def (e₁ : AddAut A) : e₁⁻¹ = e₁.symm :=
+  rfl
+
+@[simp]
+theorem mul_apply (e₁ e₂ : AddAut A) (a : A) : (e₁ * e₂) a = e₁ (e₂ a) :=
+  rfl
+
+@[simp]
+theorem one_apply (a : A) : (1 : AddAut A) a = a :=
+  rfl
+
+@[simp]
+theorem inv_symm (e : AddAut A) : e⁻¹.symm = e := rfl
+
+@[simp]
+theorem symm_inv (e : AddAut A) : e.symm⁻¹ = e := rfl
+
+@[simp]
+theorem inv_apply (e : AddAut A) (a : A) : e⁻¹ a = e.symm a := rfl
+
+theorem inv_apply_self (e : AddAut A) (a : A) : e⁻¹ (e a) = a :=
+  AddEquiv.apply_symm_apply _ _
+
+theorem apply_inv_self (e : AddAut A) (a : A) : e (e⁻¹ a) = a :=
+  AddEquiv.apply_symm_apply _ _
+
+/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
+def toPerm : AddAut A →* Equiv.Perm A where
+  toFun := AddEquiv.toEquiv
+  map_one' := rfl
+  map_mul' _ _ := rfl
 
 /-- Additive group conjugation, `AddAut.conj g h = g + h - g`, as an additive monoid
 homomorphism mapping addition in `G` into multiplication in the automorphism group `AddAut G`
@@ -802,6 +851,16 @@ theorem conj_inv_apply [AddGroup G] (g h : G) : (conj g).toMul⁻¹ h = -g + h +
 
 theorem neg_conj_apply [AddGroup G] (g h : G) : (-conj g).toMul h = -g + h + g := by
   simp
+
+/-- Isomorphic additive groups have isomorphic automorphism groups. -/
+@[simps]
+def congr [AddGroup G] {H : Type*} [AddGroup H] (ϕ : G ≃+ H) :
+    AddAut G ≃* AddAut H where
+  toFun f := ϕ.symm.trans (f.trans ϕ)
+  invFun f := ϕ.trans (f.trans ϕ.symm)
+  left_inv _ := by simp [DFunLike.ext_iff]
+  right_inv _ := by simp [DFunLike.ext_iff]
+  map_mul' := by simp [DFunLike.ext_iff]
 
 end AddAut
 

--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -61,6 +61,8 @@ instance : Inhabited (Function.End α) := ⟨1⟩
 
 namespace Equiv.Perm
 
+attribute [to_additive_dont_translate] Perm Equiv
+
 instance instOne : One (Perm α) where one := Equiv.refl _
 instance instMul : Mul (Perm α) where mul f g := Equiv.trans g f
 instance instInv : Inv (Perm α) where inv := Equiv.symm
@@ -587,69 +589,44 @@ theorem swap_mul_swap_mul_swap {x y z : α} (hxy : x ≠ y) (hxz : x ≠ z) :
 
 end Swap
 
-section AddGroup
-variable [AddGroup α] (a b : α)
-
--- we can't use `to_additive`, because it tries to translate `1` into `0`
-
-@[simp] lemma addLeft_zero : Equiv.addLeft (0 : α) = 1 := ext zero_add
-
-@[simp] lemma addRight_zero : Equiv.addRight (0 : α) = 1 := ext add_zero
-
-@[simp] lemma addLeft_add : Equiv.addLeft (a + b) = Equiv.addLeft a * Equiv.addLeft b :=
-  ext <| add_assoc _ _
-
-@[simp] lemma addRight_add : Equiv.addRight (a + b) = Equiv.addRight b * Equiv.addRight a :=
-  ext fun _ ↦ (add_assoc _ _ _).symm
-
-@[simp] lemma inv_addLeft : (Equiv.addLeft a)⁻¹ = Equiv.addLeft (-a) := Equiv.coe_inj.1 rfl
-
-@[simp] lemma inv_addRight : (Equiv.addRight a)⁻¹ = Equiv.addRight (-a) := Equiv.coe_inj.1 rfl
-
-@[simp] lemma pow_addLeft (n : ℕ) : Equiv.addLeft a ^ n = Equiv.addLeft (n • a) := by
-  ext; simp [Perm.coe_pow]
-
-@[simp] lemma pow_addRight (n : ℕ) : Equiv.addRight a ^ n = Equiv.addRight (n • a) := by
-  ext; simp [Perm.coe_pow]
-
-@[simp] lemma zpow_addLeft (n : ℤ) : Equiv.addLeft a ^ n = Equiv.addLeft (n • a) :=
-  (map_zsmul ({ toFun := Equiv.addLeft, map_zero' := addLeft_zero, map_add' := addLeft_add } :
-    α →+ Additive (Perm α)) _ _).symm
-
-@[simp] lemma zpow_addRight : ∀ (n : ℤ), Equiv.addRight a ^ n = Equiv.addRight (n • a)
-  | Int.ofNat n => by simp
-  | Int.negSucc n => by simp
-
-end AddGroup
-
 section Group
 variable [Group α] (a b : α)
 
-@[simp] lemma mulLeft_one : Equiv.mulLeft (1 : α) = 1 := ext one_mul
+@[to_additive (attr := simp)]
+lemma mulLeft_one : Equiv.mulLeft (1 : α) = 1 := ext one_mul
 
-@[simp] lemma mulRight_one : Equiv.mulRight (1 : α) = 1 := ext mul_one
+@[to_additive (attr := simp)]
+lemma mulRight_one : Equiv.mulRight (1 : α) = 1 := ext mul_one
 
-@[simp] lemma mulLeft_mul : Equiv.mulLeft (a * b) = Equiv.mulLeft a * Equiv.mulLeft b :=
+@[to_additive (attr := simp)]
+lemma mulLeft_mul : Equiv.mulLeft (a * b) = Equiv.mulLeft a * Equiv.mulLeft b :=
   ext <| mul_assoc _ _
 
-@[simp] lemma mulRight_mul : Equiv.mulRight (a * b) = Equiv.mulRight b * Equiv.mulRight a :=
+@[to_additive (attr := simp)]
+lemma mulRight_mul : Equiv.mulRight (a * b) = Equiv.mulRight b * Equiv.mulRight a :=
   ext fun _ ↦ (mul_assoc _ _ _).symm
 
-@[simp] lemma inv_mulLeft : (Equiv.mulLeft a)⁻¹ = Equiv.mulLeft a⁻¹ := Equiv.coe_inj.1 rfl
+@[to_additive (attr := simp)]
+lemma inv_mulLeft : (Equiv.mulLeft a)⁻¹ = Equiv.mulLeft a⁻¹ := Equiv.coe_inj.1 rfl
 
-@[simp] lemma inv_mulRight : (Equiv.mulRight a)⁻¹ = Equiv.mulRight a⁻¹ := Equiv.coe_inj.1 rfl
+@[to_additive (attr := simp)]
+lemma inv_mulRight : (Equiv.mulRight a)⁻¹ = Equiv.mulRight a⁻¹ := Equiv.coe_inj.1 rfl
 
-@[simp] lemma pow_mulLeft (n : ℕ) : Equiv.mulLeft a ^ n = Equiv.mulLeft (a ^ n) := by
+@[to_additive (attr := simp)]
+lemma pow_mulLeft (n : ℕ) : Equiv.mulLeft a ^ n = Equiv.mulLeft (a ^ n) := by
   ext; simp [Perm.coe_pow]
 
-@[simp] lemma pow_mulRight (n : ℕ) : Equiv.mulRight a ^ n = Equiv.mulRight (a ^ n) := by
+@[to_additive (attr := simp)]
+lemma pow_mulRight (n : ℕ) : Equiv.mulRight a ^ n = Equiv.mulRight (a ^ n) := by
   ext; simp [Perm.coe_pow]
 
-@[simp] lemma zpow_mulLeft (n : ℤ) : Equiv.mulLeft a ^ n = Equiv.mulLeft (a ^ n) :=
-  (map_zpow ({ toFun := Equiv.mulLeft, map_one' := mulLeft_one, map_mul' := mulLeft_mul } :
-              α →* Perm α) _ _).symm
+@[to_additive (attr := simp)]
+lemma zpow_mulLeft : ∀ n : ℤ, Equiv.mulLeft a ^ n = Equiv.mulLeft (a ^ n)
+  | Int.ofNat n => by simp
+  | Int.negSucc n => by simp
 
-@[simp] lemma zpow_mulRight : ∀ n : ℤ, Equiv.mulRight a ^ n = Equiv.mulRight (a ^ n)
+@[to_additive (attr := simp)]
+lemma zpow_mulRight : ∀ n : ℤ, Equiv.mulRight a ^ n = Equiv.mulRight (a ^ n)
   | Int.ofNat n => by simp
   | Int.negSucc n => by simp
 
@@ -657,13 +634,11 @@ end Group
 end Equiv
 
 /-- The group of multiplicative automorphisms. -/
-@[reducible, to_additive /-- The group of additive automorphisms. -/]
-def MulAut (M : Type*) [Mul M] :=
+@[to_additive /-- The group of additive automorphisms. -/]
+abbrev MulAut (M : Type*) [Mul M] :=
   M ≃* M
 
--- Note that `(attr := reducible)` in `to_additive` currently doesn't work,
--- so we add the reducible attribute manually.
-attribute [reducible] AddAut
+attribute [to_additive_dont_translate] MulAut MulEquiv
 
 namespace MulAut
 
@@ -672,6 +647,10 @@ variable (M) [Mul M]
 /-- The group operation on multiplicative automorphisms is defined by `g h => MulEquiv.trans h g`.
 This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
 -/
+@[to_additive instGroup
+/-- The group operation on additive automorphisms is defined by `g h => AddEquiv.trans h g`.
+This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
+-/]
 instance : Group (MulAut M) where
   mul g h := MulEquiv.trans h g
   one := MulEquiv.refl _
@@ -681,60 +660,67 @@ instance : Group (MulAut M) where
   mul_one _ := rfl
   inv_mul_cancel := MulEquiv.self_trans_symm
 
+@[to_additive]
 instance : Inhabited (MulAut M) :=
   ⟨1⟩
 
-@[simp]
+@[to_additive (attr := simp) coe_mul]
 theorem coe_mul (e₁ e₂ : MulAut M) : ⇑(e₁ * e₂) = e₁ ∘ e₂ :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp) coe_one]
 theorem coe_one : ⇑(1 : MulAut M) = id :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp) coe_inv]
 theorem coe_inv (e : MulAut M) : ⇑e⁻¹ = e.symm := rfl
 
+@[to_additive mul_def]
 theorem mul_def (e₁ e₂ : MulAut M) : e₁ * e₂ = e₂.trans e₁ :=
   rfl
 
+@[to_additive one_def]
 theorem one_def : (1 : MulAut M) = MulEquiv.refl _ :=
   rfl
 
+@[to_additive inv_def]
 theorem inv_def (e₁ : MulAut M) : e₁⁻¹ = e₁.symm :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp) inv_symm]
 theorem inv_symm (e : MulAut M) : e⁻¹.symm = e := rfl
 
-@[simp]
+@[to_additive (attr := simp) symm_inv]
 theorem symm_inv (e : MulAut M) : (e.symm)⁻¹ = e := rfl
 
-@[simp]
+@[to_additive (attr := simp) inv_apply]
 theorem inv_apply (e : MulAut M) (m : M) : e⁻¹ m = e.symm m := by
   rw [inv_def]
 
-@[simp]
+@[to_additive (attr := simp) mul_apply]
 theorem mul_apply (e₁ e₂ : MulAut M) (m : M) : (e₁ * e₂) m = e₁ (e₂ m) :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp) one_apply]
 theorem one_apply (m : M) : (1 : MulAut M) m = m :=
   rfl
 
+@[to_additive apply_inv_self]
 theorem apply_inv_self (e : MulAut M) (m : M) : e (e⁻¹ m) = m :=
   MulEquiv.apply_symm_apply _ _
 
+@[to_additive inv_apply_self]
 theorem inv_apply_self (e : MulAut M) (m : M) : e⁻¹ (e m) = m :=
   MulEquiv.apply_symm_apply _ _
 
 /-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
+@[to_additive
+/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/]
 def toPerm : MulAut M →* Equiv.Perm M where
   toFun := MulEquiv.toEquiv
   map_one' := rfl
   map_mul' _ _ := rfl
 
-set_option backward.proofsInPublic true in
 /-- Group conjugation, `MulAut.conj g h = g * h * g⁻¹`, as a monoid homomorphism
 mapping multiplication in `G` into multiplication in the automorphism group `MulAut G`.
 See also the type `ConjAct G` for any group `G`, which has a `MulAction (ConjAct G) G` instance
@@ -764,7 +750,8 @@ theorem conj_inv_apply [Group G] (g h : G) : (conj g)⁻¹ h = g⁻¹ * h * g :=
   rfl
 
 /-- Isomorphic groups have isomorphic automorphism groups. -/
-@[simps]
+@[to_additive (attr := simps)
+/-- Isomorphic additive groups have isomorphic automorphism groups. -/]
 def congr [Group G] {H : Type*} [Group H] (ϕ : G ≃* H) :
     MulAut G ≃* MulAut H where
   toFun f := ϕ.symm.trans (f.trans ϕ)
@@ -778,72 +765,6 @@ end MulAut
 namespace AddAut
 
 variable (A) [Add A]
-
-/-- The group operation on additive automorphisms is defined by `g h => AddEquiv.trans h g`.
-This means that multiplication agrees with composition, `(g*h)(x) = g (h x)`.
--/
-instance group : Group (AddAut A) where
-  mul g h := AddEquiv.trans h g
-  one := AddEquiv.refl _
-  inv := AddEquiv.symm
-  mul_assoc _ _ _ := rfl
-  one_mul _ := rfl
-  mul_one _ := rfl
-  inv_mul_cancel := AddEquiv.self_trans_symm
-
-attribute [to_additive AddAut.instGroup] MulAut.instGroup
-
-instance : Inhabited (AddAut A) :=
-  ⟨1⟩
-
-@[simp]
-theorem coe_mul (e₁ e₂ : AddAut A) : ⇑(e₁ * e₂) = e₁ ∘ e₂ :=
-  rfl
-
-@[simp]
-theorem coe_one : ⇑(1 : AddAut A) = id :=
-  rfl
-
-@[simp]
-theorem coe_inv (e : AddAut A) : ⇑e⁻¹ = e.symm := rfl
-
-theorem mul_def (e₁ e₂ : AddAut A) : e₁ * e₂ = e₂.trans e₁ :=
-  rfl
-
-theorem one_def : (1 : AddAut A) = AddEquiv.refl _ :=
-  rfl
-
-theorem inv_def (e₁ : AddAut A) : e₁⁻¹ = e₁.symm :=
-  rfl
-
-@[simp]
-theorem mul_apply (e₁ e₂ : AddAut A) (a : A) : (e₁ * e₂) a = e₁ (e₂ a) :=
-  rfl
-
-@[simp]
-theorem one_apply (a : A) : (1 : AddAut A) a = a :=
-  rfl
-
-@[simp]
-theorem inv_symm (e : AddAut A) : e⁻¹.symm = e := rfl
-
-@[simp]
-theorem symm_inv (e : AddAut A) : e.symm⁻¹ = e := rfl
-
-@[simp]
-theorem inv_apply (e : AddAut A) (a : A) : e⁻¹ a = e.symm a := rfl
-
-theorem apply_inv_self (e : AddAut A) (a : A) : e⁻¹ (e a) = a :=
-  AddEquiv.apply_symm_apply _ _
-
-theorem inv_apply_self (e : AddAut A) (a : A) : e (e⁻¹ a) = a :=
-  AddEquiv.apply_symm_apply _ _
-
-/-- Monoid hom from the group of multiplicative automorphisms to the group of permutations. -/
-def toPerm : AddAut A →* Equiv.Perm A where
-  toFun := AddEquiv.toEquiv
-  map_one' := rfl
-  map_mul' _ _ := rfl
 
 /-- Additive group conjugation, `AddAut.conj g h = g + h - g`, as an additive monoid
 homomorphism mapping addition in `G` into multiplication in the automorphism group `AddAut G`
@@ -881,16 +802,6 @@ theorem conj_inv_apply [AddGroup G] (g h : G) : (conj g).toMul⁻¹ h = -g + h +
 
 theorem neg_conj_apply [AddGroup G] (g h : G) : (-conj g).toMul h = -g + h + g := by
   simp
-
-/-- Isomorphic additive groups have isomorphic automorphism groups. -/
-@[simps]
-def congr [AddGroup G] {H : Type*} [AddGroup H] (ϕ : G ≃+ H) :
-    AddAut G ≃* AddAut H where
-  toFun f := ϕ.symm.trans (f.trans ϕ)
-  invFun f := ϕ.trans (f.trans ϕ.symm)
-  left_inv _ := by simp [DFunLike.ext_iff]
-  right_inv _ := by simp [DFunLike.ext_iff]
-  map_mul' := by simp [DFunLike.ext_iff]
 
 end AddAut
 

--- a/Mathlib/Data/ZMod/Aut.lean
+++ b/Mathlib/Data/ZMod/Aut.lean
@@ -25,7 +25,7 @@ variable (n : ℕ)
 def AddAutEquivUnits : AddAut (ZMod n) ≃* (ZMod n)ˣ :=
   have h (f : AddAut (ZMod n)) (x : ZMod n) : f 1 * x = f x := by
     rw [mul_comm, ← x.intCast_zmod_cast, ← zsmul_eq_mul, ← map_zsmul, zsmul_one]
-  { toFun := fun f ↦ Units.mkOfMulEqOne (f 1) (f⁻¹ 1) ((h f _).trans (f.inv_apply_self _ _))
+  { toFun := fun f ↦ Units.mkOfMulEqOne (f 1) (f⁻¹ 1) ((h f _).trans (f.apply_inv_self _ _))
     invFun := AddAut.mulLeft
     left_inv := fun f ↦ by simp [DFunLike.ext_iff, Units.smul_def, h]
     right_inv := fun x ↦ by simp [Units.ext_iff, Units.smul_def]

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
@@ -214,7 +214,7 @@ section FixingSubgroupConj
 variable {s t : Set α} {g : M}
 
 /-
-FIXME: The following use of `to_additive` is a horrible mess.
+FIXME: The use of `to_additive` in this section is a horrible mess.
 It requires translating `MulAut.instGroup` to `AddAut.instAddGroup` instead of `AddAut.instGroup`,
 and `MulAut.conj` shouldn't be able to translate to `AddAut.conj`, but somehow it works out.
 -/

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
@@ -12,6 +12,8 @@ public import Mathlib.GroupTheory.GroupAction.Transitive
 public import Mathlib.GroupTheory.GroupAction.Primitive
 public import Mathlib.Tactic.Group
 
+import all Mathlib.Algebra.Group.End -- TODO: needed for `to_additive`
+
 /-!
 # SubMulActions on complements of invariant subsets
 
@@ -210,6 +212,13 @@ end FixingSubgroupInsert
 section FixingSubgroupConj
 
 variable {s t : Set α} {g : M}
+
+/-
+FIXME: The following use of `to_additive` is a horrible mess.
+It requires translating `MulAut.instGroup` to `AddAut.instAddGroup` instead of `AddAut.instGroup`,
+and `MulAut.conj` shouldn't be able to translate to `AddAut.conj`, but somehow it works out.
+-/
+attribute [to_additive] MulAut.instGroup
 
 @[to_additive]
 theorem _root_.Set.conj_mem_fixingSubgroup (hg : g • t = s) {k : M} (hk : k ∈ fixingSubgroup M t) :


### PR DESCRIPTION
This PR uses `to_additive` on some lemmas about the instance `Group (Perm α)`.

This PR also exposes some technical debt in the form of `to_additive` being used where it should not.

It also swaps the names of  `AddAut.inv_apply_self` and `AddAut.apply_inv_self`, because they were the wrong way around.

This PR revives my old PR #29145

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
