### PR TITLE
[Merged by Bors] - fix(Geometry/Manifold/Notation): better error message if the expected type contains metavariables

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -687,9 +687,13 @@ partial def findModel (e : Expr) (baseInfo : Option (Expr × Expr) := none) : Te
   if let some { model .. } ← go e baseInfo then
     return model
   else
-    let hint := if (← isTracingEnabledFor `Elab.DiffGeo.MDiff) then m!"" else
-      .hint' "failures to find a model with corners can be debugged with the \
-        command `set_option trace.Elab.DiffGeo.MDiff true`."
+    let tracing := (← isTracingEnabledFor `Elab.DiffGeo.MDiff)
+    let hint : MessageData := if e.hasExprMVar then
+      .hint' "the expected type contains metavariables, \
+        maybe you need to provide an implicit argument"
+      else if tracing then m!"" else
+        .hint' "failures to find a model with corners can be debugged with the \
+          command `set_option trace.Elab.DiffGeo.MDiff true`."
     throwError "Could not find a model with corners for `{e}`.{hint}"
 where
   go (e : Expr) (baseInfo : Option (Expr × Expr)) : TermElabM (Option FindModelResult) := do

--- a/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
+++ b/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
@@ -46,11 +46,10 @@ def proj : TangentBundle 𝓘(𝕜, 𝕜) 𝕜 → 𝕜 := fun x ↦ x.2
 
 open ContDiff
 
--- TODO: the error message could be more helpful, by saying "the goal has metavariables; maybe there is an implicit argument missing"
 /--
 error: Could not find a model with corners for `TangentBundle 𝓘(?_, ?_) ?_`.
 
-Hint: failures to find a model with corners can be debugged with the command `set_option trace.Elab.DiffGeo.MDiff true`.
+Hint: the expected type contains metavariables, maybe you need to provide an implicit argument
 -/
 #guard_msgs in
 set_option pp.mvars.anonymous false in


### PR DESCRIPTION
---

- [x] depends on: #35176
- [x] depends on: #30463

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
