### PR TITLE
[Merged by Bors] - chore(*): fix unbalanced backticks in docstrings

### DIFF
--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -953,7 +953,7 @@ end LinearOrderedAddCommGroup
 
 In rings, we simplify `(m : ℤ) • x` to `↑m * x`, so we need to restate some lemmas
 using `↑m * x` instead of `m • x`. In some lemmas, `m` is a variable,
-in other lemmas `m = toIcoDiv _ _ _` or `m = `toIocDiv _ _ _`.
+in other lemmas `m = toIcoDiv _ _ _` or `m = toIocDiv _ _ _`.
 -/
 
 section Ring

--- a/Mathlib/Analysis/Normed/Group/Real.lean
+++ b/Mathlib/Analysis/Normed/Group/Real.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.Normed.Group.Basic
 /-!
 # Norms on `ℝ` and `ℝ≥0`
 
-We equip `ℝ`, `ℝ≥0`, and ``ℝ≥0∞` with their natural norms / enorms.
+We equip `ℝ`, `ℝ≥0`, and `ℝ≥0∞` with their natural norms / enorms.
 
 ## Tags
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -632,7 +632,7 @@ end
 
 section
 
-/-- `(Z ⨯ Y) ×[Y] X` ≅ Z ⨯ X` -/
+/-- `(Z ⨯ Y) ×[Y] X ≅ Z ⨯ X` -/
 noncomputable def pullbackProdSndIsoProd {X Y : C} (f : X ⟶ Y) (Z : C)
     [HasBinaryProduct Z Y] [HasBinaryProduct Z X] [HasPullback (prod.snd : Z ⨯ Y ⟶ Y) f] :
     pullback (prod.snd : Z ⨯ Y ⟶ Y) f ≅ Z ⨯ X where

--- a/Mathlib/CategoryTheory/LocallyCartesianClosed/Sections.lean
+++ b/Mathlib/CategoryTheory/LocallyCartesianClosed/Sections.lean
@@ -56,7 +56,7 @@ variable (I) [ChosenPullbacksAlong (curryRightUnitorHom I)]
 /-- The functor mapping an object `X : Over I` to the object of sections of `X` over `I`, defined
 by the following pullback diagram. The functor's mapping of morphisms is induced by `pullbackMap`,
 that is by the universal property of chosen pullbacks.
-`
+
 ```
  sections X -->  I ⟹ X
    |               |
@@ -119,7 +119,7 @@ open Adjunction
 variable (I)
 
 /-- An auxiliary definition which is used to define the adjunction between the star functor
-and the sections functor. See starSectionsAdjunction`. -/
+and the sections functor. See `starSectionsAdjunction`. -/
 @[simps homEquiv]
 def coreHomEquivToOverSections : CoreHomEquiv (toOver I) (sections I) where
   homEquiv A X :=

--- a/Mathlib/Data/List/OffDiag.lean
+++ b/Mathlib/Data/List/OffDiag.lean
@@ -27,7 +27,7 @@ namespace List
 
 variable {α : Type*} {l : List α}
 
-/-- List.offDiag l` is the product `l.product l` with the diagonal removed. -/
+/-- `List.offDiag l` is the product `l.product l` with the diagonal removed. -/
 def offDiag (l : List α) : List (α × α) :=
   l.zipIdx.flatMap fun (x, n) ↦ map (Prod.mk x) <| l.eraseIdx n
 

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -997,7 +997,7 @@ meta def evalNNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure (.nonnegative q(NNReal.coe_nonneg $a))
   | _, _, _ => throwError "not NNReal.toReal"
 
-/-- Extension for the `positivity` tactic: `Real.toNNReal`. -/
+/-- Extension for the `positivity` tactic: `Real.toNNReal` -/
 @[positivity Real.toNNReal _]
 meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with
@@ -1010,7 +1010,7 @@ meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
 
 alias ⟨_, nnabs_pos_of_pos⟩ := Real.nnabs_pos
 
-/-- Extension for the `positivity` tactic: `Real.nnabs`. -/
+/-- Extension for the `positivity` tactic: `Real.nnabs` -/
 @[positivity Real.nnabs _]
 meta def evalRealNNAbs : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -997,7 +997,7 @@ meta def evalNNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure (.nonnegative q(NNReal.coe_nonneg $a))
   | _, _, _ => throwError "not NNReal.toReal"
 
-/-- Extension for the `positivity` tactic: `Real.toNNReal. -/
+/-- Extension for the `positivity` tactic: `Real.toNNReal`. -/
 @[positivity Real.toNNReal _]
 meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with
@@ -1010,7 +1010,7 @@ meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
 
 alias ⟨_, nnabs_pos_of_pos⟩ := Real.nnabs_pos
 
-/-- Extension for the `positivity` tactic: `Real.nnabs. -/
+/-- Extension for the `positivity` tactic: `Real.nnabs`. -/
 @[positivity Real.nnabs _]
 meta def evalRealNNAbs : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -510,7 +510,7 @@ theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)
 
-/-- This lemma says that `⌈log (b ^ k) n⌉ = ⌈(⌈log b n⌉ / k)⌉, using operations on natural numbers
+/-- This lemma says that `⌈log (b ^ k) n⌉ = ⌈(⌈log b n⌉ / k)⌉`, using operations on natural numbers
 to express this equality.
 
 Since Lean has no dedicated function for the ceiling division,

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -725,7 +725,7 @@ def toConstProdLinearMap : (V1 →ᵃ[k] V2) ≃ₗ[R] V2 × (V1 →ₗ[k] V2) w
 
 end Module
 
-/-- Interpolating between affine maps with lineMap` commutes with evaluation. -/
+/-- Interpolating between affine maps with `lineMap` commutes with evaluation. -/
 @[simp]
 lemma lineMap_apply' [SMulCommClass k k V2] (f g : P1 →ᵃ[k] P2) (c : k)
     (p : P1) : lineMap f g c p = lineMap (f p) (g p) c := by

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -30,7 +30,7 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
 * `fintypeAffineCoords`: the `AffineSubspace` of `ι → k` (for `Fintype ι`) where coordinates sum
   to `1`.
-* `finsuppAffineCoords`: the `AffineSubspace of `ι →₀ k` where coordinates sum to `1`.
+* `finsuppAffineCoords`: the `AffineSubspace` of `ι →₀ k` where coordinates sum to `1`.
 * `AffineBasis`: a structure representing an affine basis of an affine space.
 * `AffineBasis.coord`: the map `P →ᵃ[k] k` corresponding to `i : ι`.
 * `AffineBasis.coord_apply_eq`: the behaviour of `AffineBasis.coord i` on `p i`.

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Defs.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Defs.lean
@@ -136,7 +136,7 @@ lemma eLpNorm_nnreal_pow_eq_lintegral {f : α → ε} {p : ℝ≥0} (hp : p ≠ 
   simp [eLpNorm_eq_eLpNorm' (by exact_mod_cast hp) ENNReal.coe_ne_top,
     lintegral_rpow_enorm_eq_rpow_eLpNorm' ((NNReal.coe_pos.trans pos_iff_ne_zero).mpr hp)]
 
-/-- Real-valued `ℒp` seminorm, equal to `0` for `p = 0`, to `(∫ ‖f a‖^p ∂μ) ^ p⁻¹` for `0 < p < ∞
+/-- Real-valued `ℒp` seminorm, equal to `0` for `p = 0`, to `(∫ ‖f a‖^p ∂μ) ^ p⁻¹` for `0 < p < ∞`
 and to `essSup ‖f‖ μ` for `p = ∞`.
 
 This is well-defined only if `MemLp f p μ`. Otherwise, it equals `0`. -/

--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -17,7 +17,7 @@ Let `R` have field of fractions `ℚ`. If `v : HeightOneSpectrum R`, then `v.adi
 the uniform space completion of `ℚ` with respect to the `v`-adic valuation.
 On the other hand, `ℚ_[p]` is the `p`-adic numbers, defined as the completion of `ℚ` with respect
 to the `p`-adic norm using the completion of Cauchy sequences. This file constructs continuous
-`ℚ`-algebra` isomorphisms between the two, as well as continuous `ℤ`-algebra isomorphisms for their
+`ℚ`-algebra isomorphisms between the two, as well as continuous `ℤ`-algebra isomorphisms for their
 respective rings of integers.
 
 Isomorphisms are provided in both directions, allowing traversal of the following diagram:

--- a/Mathlib/Order/SaddlePoint.lean
+++ b/Mathlib/Order/SaddlePoint.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.OmegaCompletePartialOrder
 * `IsSaddlePointOn`.
   Let `f : E × F → β` be a map, where `β` is preordered.
   A pair `(a,b)` in `E × F` is a *saddle point* of `f` on `X × Y`
-  if `f a y ≤ f x b` for all `x ∈ X` and all `y `in Y`.
+  if `f a y ≤ f x b` for all `x ∈ X` and all `y` in `Y`.
 
 * `isSaddlePointOn_iff`: if `β` is a complete linear order,
   then `(a, b) ∈ X × Y` is a saddle point on `X × Y` iff
@@ -40,9 +40,9 @@ theorem iSup₂_iInf₂_le_iInf₂_iSup₂ [CompleteLinearOrder β] :
 
 -- [Hiriart-Urruty, (4.1.4)]
 /-- The pair `(a, b)` is a saddle point of `f` on `X × Y`
-if `f a y ≤ f x b` for all `x ∈ X` and all `y `in Y`.
+if `f a y ≤ f x b` for all `x ∈ X` and all `y` in `Y`.
 
-Note: we do not require that a ∈ X and b ∈ Y. -/
+Note: we do not require that `a ∈ X` and `b ∈ Y`. -/
 def IsSaddlePointOn [Preorder β] (a : E) (b : F) : Prop :=
   ∀ x ∈ X, ∀ y ∈ Y, f a y ≤ f x b
 

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -302,7 +302,7 @@ def lifts : Type _ := Σ (s : Finset S), (MvPolynomial (Fin s.card) R) ⊗[R] M
 
 variable {S}
 
-/-- The lift of `f.toFun to the type `lifts` -/
+/-- The lift of `f.toFun` to the type `lifts` -/
 def φ (s : Finset S) : MvPolynomial (Fin s.card) R →ₐ[R] S :=
   aeval (R := R) (fun n ↦ (s.equivFin.symm n : S))
 
@@ -341,7 +341,7 @@ variable
     {B : Type u} [CommSemiring B] [Algebra R B] {ψ : B →ₐ[R] T} (q : B ⊗[R] M)
     (g : A →ₐ[R] B) (h : S →ₐ[R] T)
 
-/-- Compare the values of `PolynomialLaw.toFun' in a square diagram -/
+/-- Compare the values of `PolynomialLaw.toFun'` in a square diagram -/
 theorem toFun'_eq_of_diagram
     (h : S →ₐ[R] T) (h' : φ.range →ₐ[R] ψ.range)
     (hh' : ψ.range.val.comp h' = h.comp φ.range.val)
@@ -370,7 +370,7 @@ theorem toFun'_eq_of_diagram
     ← quotientKerEquivRangeₐ_comp_mkₐ, ← AlgHom.comp_assoc]
   simp
 
-/-- Compare the values of `PolynomialLaw.toFun' in a square diagram,
+/-- Compare the values of `PolynomialLaw.toFun'` in a square diagram,
   when one of the maps is a subalgebra inclusion. -/
 theorem toFun'_eq_of_inclusion {ψ : B →ₐ[R] S} (h : φ.range ≤ ψ.range)
     (hpq : ((Subalgebra.inclusion h).comp

--- a/Mathlib/Tactic/DeriveTraversable.lean
+++ b/Mathlib/Tactic/DeriveTraversable.lean
@@ -349,7 +349,7 @@ def traverseField (n : Name) (cl f v e : Expr) : TermElabM (Bool × Expr) := do
 /--
 For a sum type `inductive Foo (α : Type) | foo1 : List α → ℕ → Foo α | ...`
 ``traverseConstructor `foo1 `Foo applInst f `α `β [`(x : List α), `(y : ℕ)]``
-synthesizes `foo1 <$> traverse f x <*> pure y.` -/
+synthesizes `foo1 <$> traverse f x <*> pure y`. -/
 def traverseConstructor (c n : Name) (applInst f α β : Expr) (args₀ : List Expr)
     (args₁ : List (Bool × Expr)) (m : MVarId) : TermElabM Unit := do
   let ad ← getAuxDefOfDeclName

--- a/Mathlib/Tactic/Linter/Whitespace.lean
+++ b/Mathlib/Tactic/Linter/Whitespace.lean
@@ -40,7 +40,7 @@ public register_option linter.style.whitespace : Bool := {
   descr := "enable the whitespace linter"
 }
 
-/-- Deprecated in favour of `linter.style.whitespace -/
+/-- Deprecated in favour of `linter.style.whitespace` -/
 @[deprecated linter.style.whitespace (since := "2026-01-07")]
 public register_option linter.style.commandStart : Bool := {
   defValue := false


### PR DESCRIPTION
This PR fixes a lot of cases of unbalanced backticks (`` ` ``) in docstrings. These were detected automatically, by a linter I'm working on (in particular, if an even number of backticks is added or removed, the linter can't find the issue). This is part of preparing for Verso docstrings, which are much more strict about their syntax (whereas currently docstrings are written in Markdown where any sequence of Unicode codepoints is a valid Markdown document).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
