### PR TITLE
[Merged by Bors] - chore(Algebra/Module): golf proofs

### DIFF
--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -402,11 +402,7 @@ lemma Module.FinitePresentation.exists_lift_of_isLocalizedModule
   obtain ⟨x, rfl⟩ := hπ x
   rw [← LinearMap.comp_apply, ← LinearMap.comp_apply, mul_smul, LinearMap.smul_comp, ← hi,
     ← LinearMap.comp_smul, LinearMap.comp_assoc, LinearMap.comp_assoc]
-  congr 2
-  convert Submodule.liftQ_mkQ _ _ this using 2
-  ext x
-  apply (LinearMap.quotKerEquivOfSurjective _ hπ).injective
-  simp [LinearMap.quotKerEquivOfSurjective]
+  simp
 
 lemma Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule
     [hM : Module.Finite R M] (g₁ g₂ : M →ₗ[R] N) (h : f.comp g₁ = f.comp g₂) :

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -110,23 +110,11 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
     simp [hd, hr'.ne]
   replace hd : 1 ≤ d := by rwa [Nat.one_le_iff_ne_zero]
   have hs0 : s 0 = {0} := by ext; simp [s, funext_iff]
-  have hs {a b : ℕ} (ha : a ≤ b) : s a ⊆ s b := by
-    intros x hx
-    simp only [Fintype.mem_piFinset, s] at hx ⊢
-    exact fun i ↦ Icc_subset_Icc (by simpa) (by simpa) (hx i)
+  have hs {a b : ℕ} (ha : a ≤ b) : s a ⊆ s b := by grind
   have (k : ℕ) : #(s (k + 1) \ s k) ≤ 2 * d * (2 * k + 3) ^ (d - 1) := by
-    -- We do not yet replace `omega` with `lia` here, as it is measurably slower.
-    trans (2 * k + 3) ^ d - (2 * k + 1) ^ d
-    · simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s]
-      simp only [Fintype.card_piFinset, Int.card_Icc, sub_neg_eq_add, prod_const, card_univ]
-      gcongr <;> norm_cast <;> omega
-    · have := abs_pow_sub_pow_le (α := ℤ) ↑(2 * k + 3) ↑(2 * k + 1) d
-      norm_num at this
-      zify
-      convert this using 3
-      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; lia)), Nat.cast_sub (by gcongr; lia)]
-        simp
-      · rw [max_eq_left (by gcongr; lia), abs_eq_self.mpr (by positivity)]
+    simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s]
+    simp only [Fintype.card_piFinset, Int.card_Icc, prod_const]
+    grind [abs_pow_sub_pow_le (α := ℤ) (2 * k + 3) (2 * k + 1) d]
   let ε := normBound b
   have hε : 0 < ε := normBound_pos b
   calc ∑ p ∈ s n, ‖∑ i, p i • b i‖ ^ r

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -112,8 +112,8 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
   have hs0 : s 0 = {0} := by ext; simp [s, funext_iff]
   have hs {a b : ℕ} (ha : a ≤ b) : s a ⊆ s b := by grind
   have (k : ℕ) : #(s (k + 1) \ s k) ≤ 2 * d * (2 * k + 3) ^ (d - 1) := by
-    simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s]
-    simp only [Fintype.card_piFinset, Int.card_Icc, prod_const]
+    simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s, Fintype.card_piFinset,
+      Int.card_Icc, prod_const]
     grind [abs_pow_sub_pow_le (α := ℤ) (2 * k + 3) (2 * k + 1) d]
   let ε := normBound b
   have hε : 0 < ε := normBound_pos b


### PR DESCRIPTION
---
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `Module.FinitePresentation.exists_lift_of_isLocalizedModule`: 1283 ms before, 856 ms after  🎉
* `ZLattice.sum_piFinset_Icc_rpow_le`: 4789 ms before, 4052 ms after  🎉
 after

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
