### PR TITLE
[Merged by Bors] - chore: deduplicate `attribute [simp]`s

### DIFF
--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -27,9 +27,6 @@ open Nat
 namespace Int
 variable {a b c d m n : ℤ}
 
--- TODO: Tag in Lean
-attribute [simp] natAbs_pos
-
 attribute [gcongr] ofNat_le
 
 instance instNontrivial : Nontrivial ℤ := ⟨⟨0, 1, Int.zero_ne_one⟩⟩

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -15,8 +15,6 @@ namespace List
 
 variable {α : Type*} (p : α → Bool) (xs : List α) (ls : List (List α))
 
-attribute [simp] splitAt_eq
-
 @[simp]
 theorem splitOn_nil [BEq α] (a : α) : [].splitOn a = [[]] :=
   rfl

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -127,8 +127,6 @@ theorem testBit_land : ∀ m n k, testBit (m &&& n) k = (testBit m k && testBit 
 theorem testBit_ldiff : ∀ m n k, testBit (ldiff m n) k = (testBit m k && not (testBit n k)) :=
   testBit_bitwise rfl
 
-attribute [simp] testBit_xor
-
 end
 
 /-- An alternative for `bitwise_bit` which replaces the `f false false = false` assumption

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -102,10 +102,6 @@ theorem lift_binop_eq (f : ℚ → ℚ → ℚ) (f₁ : ℤ → ℤ → ℤ → 
   exact (divInt_eq_divInt_iff (f0 d₁0 d₂0) (f0 b0 d0)).2
     (H ((divInt_eq_divInt_iff b0 d₁0).1 ha) ((divInt_eq_divInt_iff d0 d₂0).1 hc))
 
-attribute [simp] divInt_add_divInt
-
-attribute [simp] neg_divInt
-
 lemma neg_def (q : ℚ) : -q = -q.num /. q.den := by rw [← neg_divInt, num_divInt_den]
 
 @[simp] lemma divInt_neg (n d : ℤ) : n /. -d = -n /. d := divInt_neg' ..

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -189,7 +189,6 @@ classical ones, as these may cause instance mismatch errors later.
 -/
 
 export Classical (not_not)
-attribute [simp] not_not
 
 variable {a b : Prop}
 
@@ -391,9 +390,6 @@ alias Ne.trans_eq := ne_of_ne_of_eq
 
 theorem eq_equivalence {α : Sort*} : Equivalence (@Eq α) :=
   ⟨Eq.refl, @Eq.symm _, @Eq.trans _⟩
-
--- These were migrated to Batteries but the `@[simp]` attributes were (mysteriously?) removed.
-attribute [simp] eq_mp_eq_cast eq_mpr_eq_cast
 
 -- @[simp] -- FIXME simp ignores proof rewrites
 theorem congr_refl_left {α β : Sort*} (f : α → β) {a b : α} (h : a = b) :

--- a/Mathlib/Tactic/Attr/Core.lean
+++ b/Mathlib/Tactic/Attr/Core.lean
@@ -17,7 +17,6 @@ from the core library and the `Batteries` library with these attributes in this 
 
 public meta section
 
-attribute [simp] id_map'
 attribute [functor_norm, monad_norm] seq_assoc pure_seq pure_bind bind_assoc bind_pure map_pure
 attribute [monad_norm] seq_eq_bind_map
 


### PR DESCRIPTION
This PR removes `attribute [simp]`s which are already simp-lemmas.

---

For reviewers: In `Mathlib.Logic.Basic`, `attribute [simp]` comes after `export` as following:
```
export Classical (not_not)
attribute [simp] not_not
```
This gives the impression that `simp?` suggests `Classical.not_not` without `attribute [simp]`, but `simp?` can suggests `not_not` without this.


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
