### PR TITLE
[Merged by Bors] - feat: equivalent conditions for `p ≤ q` for projections in a C⋆-algebra

### DIFF
--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Algebra.Defs
 public import Mathlib.Algebra.Algebra.NonUnitalHom
 public import Mathlib.Algebra.Star.Module
+public import Mathlib.Algebra.Star.StarProjection
 public import Mathlib.Algebra.Star.NonUnitalSubalgebra
 public import Mathlib.LinearAlgebra.Prod
 public import Mathlib.Tactic.Abel
@@ -847,5 +848,13 @@ lemma isIdempotentElem_inr_iff (R : Type*) {A : Type*} [MulZeroClass R]
   simp only [IsIdempotentElem, ← inr_mul, inr_injective.eq_iff]
 
 alias ⟨_, IsIdempotentElem.inr⟩ := isIdempotentElem_inr_iff
+
+lemma isStarProjection_inr_iff {R A : Type*} [Semiring R] [StarRing R] [NonUnitalSemiring A]
+    [StarRing A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A] {p : A} :
+    IsStarProjection (p : Unitization R A) ↔ IsStarProjection p := by
+  simp [isStarProjection_iff]
+
+protected alias ⟨_root_.IsStarProjection.of_inr, _root_.IsStarProjection.inr⟩ :=
+  isStarProjection_inr_iff
 
 end Unitization

--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -849,6 +849,7 @@ lemma isIdempotentElem_inr_iff (R : Type*) {A : Type*} [MulZeroClass R]
 
 alias ⟨_, IsIdempotentElem.inr⟩ := isIdempotentElem_inr_iff
 
+@[grind =]
 lemma isStarProjection_inr_iff {R A : Type*} [Semiring R] [StarRing R] [NonUnitalSemiring A]
     [StarRing A] [Module R A] {p : A} :
     IsStarProjection (p : Unitization R A) ↔ IsStarProjection p := by

--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -850,7 +850,7 @@ lemma isIdempotentElem_inr_iff (R : Type*) {A : Type*} [MulZeroClass R]
 alias ⟨_, IsIdempotentElem.inr⟩ := isIdempotentElem_inr_iff
 
 lemma isStarProjection_inr_iff {R A : Type*} [Semiring R] [StarRing R] [NonUnitalSemiring A]
-    [StarRing A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A] {p : A} :
+    [StarRing A] [Module R A] {p : A} :
     IsStarProjection (p : Unitization R A) ↔ IsStarProjection p := by
   simp [isStarProjection_iff]
 

--- a/Mathlib/Analysis/CStarAlgebra/Projection.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Projection.lean
@@ -71,7 +71,7 @@ lemma le_tfae (hp : IsStarProjection p) (hq : IsStarProjection q) :
       refine le_antisymm ?_ <| by
         simpa [hp.isIdempotentElem.eq] using conjugate_le_conjugate_of_nonneg h hp.nonneg
       have := by simpa [hp.inr.isIdempotentElem.eq, ← Unitization.inr_mul]
-        using conjugate_le_conjugate_of_nonneg hq.inr.le_one hp.inr.nonneg
+        using conjugate_le_conjugate_of_nonneg hq.inr.le_one (hp.inr (R := ℂ)).nonneg
       rwa [← Unitization.inr_le_iff (p * q * p) p ?_ hp.isSelfAdjoint]
       exact hp.isSelfAdjoint.conjugate_nonneg hq.nonneg |>.isSelfAdjoint
     rw [← norm_eq_zero, hp.isSelfAdjoint.norm_mul_mul_self_of_nonneg _ (by simpa),

--- a/Mathlib/Analysis/CStarAlgebra/Projection.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Projection.lean
@@ -12,10 +12,18 @@ public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpo
 
 # Projections in C⋆-algebras
 
-To show that an element is a star projection in a non-unital C⋆-algebra,
-it is enough to show that it is idempotent and normal,
-because self-adjointedness and normality are equivalent for idempotent
-elements in non-unital C⋆-algebras.
+Here we collect results about projections specific to C⋆-algebras.
+
+## Main results
+
++ `isStarProjection_iff_isIdempotentElem_and_isStarNormal`: star projections are precisely
+  idempotent normal elements.
++ `IsStarProjection.le_tfae`: for star projections `p` and `q`, the following are equivalent:
+  - `p ≤ q`
+  - `q * p = p`
+  - `p * q = p`
+  - `q - p` is a star projection
+  - `q - p` is an idempotent element
 
 -/
 
@@ -47,14 +55,7 @@ end Normal
 
 namespace IsStarProjection
 
-variable {A : Type*} [NonUnitalCStarAlgebra A]
-
-lemma inr_iff {p : A} : IsStarProjection p ↔ IsStarProjection (p : A⁺¹) := by
-  simp [isStarProjection_iff]
-
-protected alias ⟨inr, of_inr⟩ := inr_iff
-
-variable [PartialOrder A] [StarOrderedRing A] {p q : A}
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A] {p q : A}
 
 open CFC in
 lemma le_tfae (hp : IsStarProjection p) (hq : IsStarProjection q) :

--- a/Mathlib/Analysis/CStarAlgebra/Projection.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Projection.lean
@@ -1,11 +1,12 @@
 /-
 Copyright (c) 2025 Monica Omar. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Monica Omar
+Authors: Monica Omar, Jireh Loreaux
 -/
 module
 
-public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
+public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Isometric
 
 /-!
 
@@ -19,6 +20,10 @@ elements in non-unital C⋆-algebras.
 -/
 
 public section
+
+open scoped CStarAlgebra
+
+section Normal
 
 variable {A : Type*} [TopologicalSpace A]
   [NonUnitalRing A] [StarRing A] [Module ℂ A] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
@@ -37,3 +42,66 @@ if and only if it is idempotent and normal. -/
 theorem isStarProjection_iff_isIdempotentElem_and_isStarNormal {p : A} :
     IsStarProjection p ↔ IsIdempotentElem p ∧ IsStarNormal p :=
   (isStarProjection_iff p).eq ▸ and_congr_right_iff.eq ▸ fun h => h.isSelfAdjoint_iff_isStarNormal
+
+end Normal
+
+namespace IsStarProjection
+
+variable {A : Type*} [NonUnitalCStarAlgebra A]
+
+lemma inr_iff {p : A} : IsStarProjection p ↔ IsStarProjection (p : A⁺¹) := by
+  simp [isStarProjection_iff]
+
+protected alias ⟨inr, of_inr⟩ := inr_iff
+
+variable [PartialOrder A] [StarOrderedRing A] {p q : A}
+
+open CFC in
+lemma le_tfae (hp : IsStarProjection p) (hq : IsStarProjection q) :
+  List.TFAE
+    [p ≤ q,
+    q * p = p,
+    p * q = p,
+    IsStarProjection (q - p),
+    IsIdempotentElem (q - p)] := by
+  tfae_have 1 → 2 := fun h ↦ by
+    have key : p * (q - p) * p = 0 := by
+      simp only [sub_mul, mul_sub, hp.isIdempotentElem.eq, sub_eq_zero]
+      refine le_antisymm ?_ <| by
+        simpa [hp.isIdempotentElem.eq] using conjugate_le_conjugate_of_nonneg h hp.nonneg
+      have := by simpa [hp.inr.isIdempotentElem.eq, ← Unitization.inr_mul]
+        using conjugate_le_conjugate_of_nonneg hq.inr.le_one hp.inr.nonneg
+      rwa [← Unitization.inr_le_iff (p * q * p) p ?_ hp.isSelfAdjoint]
+      exact hp.isSelfAdjoint.conjugate_nonneg hq.nonneg |>.isSelfAdjoint
+    rw [← norm_eq_zero, hp.isSelfAdjoint.norm_mul_mul_self_of_nonneg _ (by simpa),
+      sq_eq_zero_iff, norm_eq_zero] at key
+    simpa [← mul_assoc, CFC.sqrt_mul_sqrt_self (q - p) (by simpa),
+      sub_mul, sub_eq_zero, hp.isIdempotentElem.eq] using congr(CFC.sqrt (q - p) * $key)
+  tfae_have 2 → 3 := fun h ↦ by
+    simpa [hp.isSelfAdjoint.star_eq, hq.isSelfAdjoint.star_eq] using congr(star $h)
+  tfae_have 3 → 4 := hp.sub_of_mul_eq_left hq
+  tfae_have 4 → 1 := fun h ↦ by simpa using h.nonneg
+  tfae_have 4 ↔ 5 := by simp [isStarProjection_iff, hq.isSelfAdjoint.sub hp.isSelfAdjoint]
+  tfae_finish
+
+lemma le_iff_mul_eq_right (hp : IsStarProjection p) (hq : IsStarProjection q) :
+    p ≤ q ↔ q * p = p :=
+  hp.le_tfae hq |>.out 0 1
+
+lemma le_iff_mul_eq_left (hp : IsStarProjection p) (hq : IsStarProjection q) :
+    p ≤ q ↔ p * q = p :=
+  hp.le_tfae hq |>.out 0 2
+
+lemma le_iff_sub (hp : IsStarProjection p) (hq : IsStarProjection q) :
+    p ≤ q ↔ IsStarProjection (q - p) :=
+  hp.le_tfae hq |>.out 0 3
+
+lemma le_iff_idempotent_sub (hp : IsStarProjection p) (hq : IsStarProjection q) :
+    p ≤ q ↔ IsIdempotentElem (q - p) :=
+  hp.le_tfae hq |>.out 0 4
+
+lemma commute_of_le (hp : IsStarProjection p) (hq : IsStarProjection q) (h : p ≤ q) :
+    Commute p q := by
+  rw [commute_iff_eq, hp.le_iff_mul_eq_right hq |>.mp h, hp.le_iff_mul_eq_left hq |>.mp h]
+
+end IsStarProjection

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
@@ -86,4 +86,32 @@ lemma continuousOn_rpow [ContinuousStar A] [CompleteSpace A] (r : ℝ) :
 
 end unital
 
+section cstar
+
+variable {A : Type*} [PartialOrder A] [NonUnitalNormedRing A] [StarRing A] [CStarRing A]
+    [NormedSpace ℝ A] [SMulCommClass ℝ A A] [IsScalarTower ℝ A A] [StarOrderedRing A]
+    [NonUnitalContinuousFunctionalCalculus ℝ A IsSelfAdjoint] [NonnegSpectrumClass ℝ A]
+
+lemma norm_star_mul_mul_self_of_nonneg {a : A} (b : A) (ha : 0 ≤ a := by cfc_tac) :
+    ‖star b * a * b‖ = ‖CFC.sqrt a * b‖ ^ 2 := by
+  rw [sq, ← CStarRing.norm_star_mul_self, star_mul, (CFC.sqrt_nonneg a).star_eq,
+    ← mul_assoc _ (CFC.sqrt a), mul_assoc _ _ (CFC.sqrt a), CFC.sqrt_mul_sqrt_self a]
+
+lemma IsSelfAdjoint.norm_mul_mul_self_of_nonneg {a : A} (b : A)
+    (hb : IsSelfAdjoint b := by cfc_tac) (ha : 0 ≤ a := by cfc_tac) :
+    ‖b * a * b‖ = ‖CFC.sqrt a * b‖ ^ 2 := by
+  simpa [hb.star_eq] using norm_star_mul_mul_self_of_nonneg b ha
+
+lemma norm_mul_mul_star_self_of_nonneg {a : A} (b : A) (ha : 0 ≤ a := by cfc_tac) :
+    ‖b * a * star b‖ = ‖b * CFC.sqrt a‖ ^ 2 := by
+  conv_rhs => rw [← (CFC.sqrt_nonneg a).star_eq, ← star_star b, ← star_mul, norm_star,
+    ← norm_star_mul_mul_self_of_nonneg _ ha, star_star]
+
+lemma IsSelfAdjoint.norm_mul_mul_self_of_nonneg' {a : A} (b : A)
+    (hb : IsSelfAdjoint b := by cfc_tac) (ha : 0 ≤ a := by cfc_tac) :
+    ‖b * a * b‖ = ‖b * CFC.sqrt a‖ ^ 2 := by
+  simpa [hb.star_eq] using norm_mul_mul_star_self_of_nonneg b ha
+
+end cstar
+
 end CFC


### PR DESCRIPTION
The follow are equivalent for star projections (i.e., selfadjoint idempotent elements) `p` and `q` in a C⋆-algebra `A`.

1. `p ≤ q`
2. `p * q = p`
3. `q * p = p`
4. `q - p` is a star projection
5. `q - p` is idempotent

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
