### PR TITLE
[Merged by Bors] - feat(ci): add CI status emoji reactions to Zulip messages

### DIFF
--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -1,0 +1,92 @@
+name: Zulip emoji CI status
+
+on:
+  workflow_run:
+    workflows: ["continuous integration", "continuous integration (mathlib forks)"]
+    types: [requested, completed]
+
+# Limit permissions for GITHUB_TOKEN for the entire workflow
+permissions:
+  contents: read
+  pull-requests: read
+  # All other permissions are implicitly 'none'
+
+jobs:
+  update_ci_emoji:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+    - name: Determine PR number
+      id: pr
+      env:
+        GH_TOKEN: ${{ github.token }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      run: |
+        # Try to get PR number from the workflow_run event
+        PR_NUMBER=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
+        # For push-triggered CI (non-fork PRs), pull_requests may be empty;
+        # fall back to looking up the PR by branch name.
+        if [ -z "$PR_NUMBER" ]; then
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+        fi
+        if [ -z "$PR_NUMBER" ]; then
+          echo "No PR found for branch $HEAD_BRANCH, skipping"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Found PR #$PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Determine CI action
+      id: action
+      if: steps.pr.outputs.skip != 'true'
+      run: |
+        EVENT_ACTION="${{ github.event.action }}"
+        CONCLUSION="${{ github.event.workflow_run.conclusion }}"
+        echo "Event action: $EVENT_ACTION, conclusion: $CONCLUSION"
+        if [ "$EVENT_ACTION" = "requested" ]; then
+          echo "ci_action=ci-running" >> "$GITHUB_OUTPUT"
+        elif [ "$EVENT_ACTION" = "completed" ]; then
+          case "$CONCLUSION" in
+            success)
+              echo "ci_action=ci-success" >> "$GITHUB_OUTPUT"
+              ;;
+            cancelled)
+              # Don't update emoji for cancelled runs; a new run will follow.
+              echo "ci_action=skip" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ci_action=ci-failure" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+        fi
+
+    - name: Checkout mathlib repository
+      if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: master
+        sparse-checkout: |
+          scripts/zulip_emoji_reactions.py
+
+    - name: Set up Python
+      if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
+      run: |
+        python -m pip install --upgrade pip
+        pip install zulip
+
+    - name: Update CI emoji
+      if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
+      env:
+        ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+        ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
+        ZULIP_SITE: https://leanprover.zulipchat.com
+      run: |
+        python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.action.outputs.ci_action }}" "none" "${{ steps.pr.outputs.pr_number }}"

--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -21,16 +21,24 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
         # Try to get PR number from the workflow_run event
         PR_NUMBER=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
         # For push-triggered CI (non-fork PRs), pull_requests may be empty;
         # fall back to looking up the PR by branch name.
+        # Use owner:branch format to avoid matching the wrong PR when
+        # multiple forks use the same branch name.
         if [ -z "$PR_NUMBER" ]; then
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$HEAD_REPO_OWNER:$HEAD_BRANCH" --state open --json number,headRefOid --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number" 2>/dev/null || true)
+        fi
+        # If owner-qualified lookup failed, try without owner (for same-repo branches)
+        if [ -z "$PR_NUMBER" ]; then
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$HEAD_BRANCH" --state open --json number,headRefOid --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number" 2>/dev/null || true)
         fi
         if [ -z "$PR_NUMBER" ]; then
-          echo "No PR found for branch $HEAD_BRANCH, skipping"
+          echo "No PR found for branch $HEAD_REPO_OWNER:$HEAD_BRANCH at $HEAD_SHA, skipping"
           echo "skip=true" >> "$GITHUB_OUTPUT"
         else
           echo "Found PR #$PR_NUMBER"
@@ -53,8 +61,9 @@ jobs:
               echo "ci_action=ci-success" >> "$GITHUB_OUTPUT"
               ;;
             cancelled)
-              # Don't update emoji for cancelled runs; a new run will follow.
-              echo "ci_action=skip" >> "$GITHUB_OUTPUT"
+              # Clear the running emoji. A new run may or may not follow
+              # (manual cancel, branch deleted, etc.), so don't leave stale 🟡.
+              echo "ci_action=ci-cancelled" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "ci_action=ci-failure" >> "$GITHUB_OUTPUT"

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -27,7 +27,7 @@ ZULIP_SITE = sys.argv[3]
 #   command), it is 'ready-to-merge' or 'delegated'. On a bors merge-, bors r- or bors d- command,
 #   it is 'remove-label'. (This particular value is not used in this script.)
 #   Note that `bors d-` is *not* a bors command, so only has an effect on mathlib's PR labels.
-# - if CI status changed, it is 'ci-running', 'ci-success', or 'ci-failure'
+# - if CI status changed, it is 'ci-running', 'ci-success', 'ci-failure', or 'ci-cancelled'
 #   (see .github/workflows/zulip_emoji_ci_status.yaml)
 ACTION = sys.argv[4]
 # Name of the label that was applied or removed

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -27,6 +27,8 @@ ZULIP_SITE = sys.argv[3]
 #   command), it is 'ready-to-merge' or 'delegated'. On a bors merge-, bors r- or bors d- command,
 #   it is 'remove-label'. (This particular value is not used in this script.)
 #   Note that `bors d-` is *not* a bors command, so only has an effect on mathlib's PR labels.
+# - if CI status changed, it is 'ci-running', 'ci-success', or 'ci-failure'
+#   (see .github/workflows/zulip_emoji_ci_status.yaml)
 ACTION = sys.argv[4]
 # Name of the label that was applied or removed
 # (if applicable; is 'none' if a PR was closed, reopened or merged)
@@ -110,6 +112,9 @@ for message in messages:
     has_awaiting_author = has_reaction('writing')
     has_maintainer_merge = has_reaction('hammer')
     has_closed = has_reaction('closed-pr')
+    has_ci_running = has_reaction('yellow')
+    has_ci_success = has_reaction('check')
+    has_ci_failure = has_reaction('cross_mark')
     first_in_thread = hashPR.search(message['subject']) and message['display_recipient'] == 'PR reviews' and message['subject'] not in first_by_subject
     first_by_subject[message['subject']] = message['id']
     match = urlPR.search(content) or first_in_thread
@@ -138,6 +143,24 @@ for message in messages:
                 "message_id": message['id'],
                 "emoji_name": emoji_name
             })
+
+        # CI status emojis are mutually exclusive with each other
+        # but independent of PR status emojis.
+        if ACTION.startswith('ci-'):
+            if has_ci_running:
+                remove_reaction('ci-running', 'yellow', '')
+            if has_ci_success:
+                remove_reaction('ci-success', 'check', '')
+            if has_ci_failure:
+                remove_reaction('ci-failure', 'cross_mark', '')
+            match ACTION:
+                case 'ci-running':
+                    add_reaction('ci-running', 'yellow')
+                case 'ci-success':
+                    add_reaction('ci-success', 'check')
+                case 'ci-failure':
+                    add_reaction('ci-failure', 'cross_mark')
+            continue
 
         # The maintainer merge label is different from the others, as it is not mutually exclusive
         # with them: just add or remove it manually and leave the other emojis alone.


### PR DESCRIPTION
This PR extends the emojibot to show CI build status on Zulip messages that mention a PR:
- 🟡 CI running
- ✅ CI passed
- ❌ CI failed

These are independent of the existing PR status emojis (merged, delegated, awaiting-author, etc.) and can coexist with them.

The new `zulip_emoji_ci_status.yaml` workflow triggers on `workflow_run` events from both CI workflows. Cancelled runs are ignored (a new run will follow shortly).

🤖 Prepared with Claude Code