### PR TITLE
chore(LinearAlgebra/AffineSpace): Redefine AffineSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4556,6 +4556,7 @@ public import Mathlib.LinearAlgebra.AffineSpace.AffineEquiv
 public import Mathlib.LinearAlgebra.AffineSpace.AffineMap
 public import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
 public import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs
+public import Mathlib.LinearAlgebra.AffineSpace.Basic
 public import Mathlib.LinearAlgebra.AffineSpace.Basis
 public import Mathlib.LinearAlgebra.AffineSpace.Centroid
 public import Mathlib.LinearAlgebra.AffineSpace.Ceva

--- a/Mathlib/LinearAlgebra/AffineSpace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basic.lean
@@ -1,0 +1,105 @@
+module
+
+public import Mathlib.LinearAlgebra.ConvexSpace
+
+public section
+
+noncomputable section
+
+/--
+A finitely supported weighting over elements of `M` with coefficients in `R`. The weights sum to 1.
+-/
+structure AffineWeights (R : Type*) [AddCommMonoid R] [One R] (M : Type*)
+    extends weights : M →₀ R where
+  /-- The weights sum to 1. -/
+  total : weights.sum (fun _ r => r) = 1
+
+attribute [simp] AffineWeights.total
+grind_pattern AffineWeights.total => self.weights
+
+namespace AffineWeights
+
+variable {R : Type*} [AddCommMonoid R] [One R] {M : Type*}
+
+@[ext]
+theorem ext {f g : AffineWeights R M} (h : f.weights = g.weights) : f = g := by
+  cases f; cases g; simp_all
+
+/-- The weighting that puts all weight on `x`. -/
+def single (x : M) : AffineWeights R M where
+  weights := Finsupp.single x 1
+  total := by simp
+
+@[simp]
+theorem mk_single (x : M) {total} :
+    (AffineWeights.mk (Finsupp.single x (1 : R)) total) = single x := by simp [single]
+
+/-- A weighting with weight `s` on `x` and weight `t` on `y`. -/
+def duple (x y : M) {s t : R} (h : s + t = 1) : AffineWeights R M where
+  weights := Finsupp.single x s + Finsupp.single y t
+  total := by
+    classical
+    rw [Finsupp.sum_add_index] <;> simp [h]
+
+/--
+Map a function over the support of an affine weighting.
+For each n : N, the weight is the sum of weights of all m : M with g m = n.
+-/
+def map {M : Type*} {N : Type*} (g : M → N) (f : AffineWeights R M) : AffineWeights R N where
+  weights := f.weights.mapDomain g
+  total := by simp [Finsupp.sum_mapDomain_index]
+
+/--
+Join operation for affine weightings (monadic join).
+Given a weighting of a weighting, flattens it to a single weighting.
+-/
+def join {R : Type*} [Semiring R] {M : Type*} (f : AffineWeights R (AffineWeights R M)) :
+    AffineWeights R M where
+  weights := f.weights.sum (fun d r => r • d.weights)
+  total := by
+    rw [Finsupp.sum_sum_index (fun _ ↦ rfl) (fun _ _ _ ↦ rfl)]
+    convert f.total
+    rw [Finsupp.sum_smul_index (fun _ ↦ rfl), ← Finsupp.mul_sum, AffineWeights.total, mul_one]
+
+end AffineWeights
+
+/--
+A set equipped with an operation of finite affine combinations, where the coefficients sum to 1.
+-/
+class AffineSpace (R : Type*) (M : Type*) [Semiring R] where
+  /-- Take a affine combination with the given weighting. -/
+  affineCombination (f : AffineWeights R M) : M
+  /-- Associativity of affine combination (monadic join law). -/
+  assoc (f : AffineWeights R (AffineWeights R M)) :
+    affineCombination (f.map affineCombination) = affineCombination f.join
+  /-- A affine combination of a single point is that point. -/
+  single (x : M) : affineCombination (.single x) = x
+
+namespace AffineSpace
+
+section ConvexSpace
+
+variable {R : Type*} {M : Type*} [LE R] [Semiring R] in
+-- its probably nicer to redefine StdSimplex to extend AffineWeights?
+instance : Coe (StdSimplex R M) (AffineWeights R M) where
+  coe f := ⟨f.weights, f.total⟩
+
+variable {R : Type*} {M : Type*} [PartialOrder R] [Semiring R] [IsStrictOrderedRing R]
+
+instance : Coe (StdSimplex R (StdSimplex R M)) (AffineWeights R (AffineWeights R M)) where
+  coe f := f.map (Coe.coe (β := (AffineWeights R M)))
+
+instance [af : AffineSpace R M] : ConvexSpace R M where
+  convexCombination (f : StdSimplex R M) := af.affineCombination f
+  assoc (f : StdSimplex R (StdSimplex R M)) := by
+    convert af.assoc f
+    · simp only [StdSimplex.map, AffineWeights.map, ← Finsupp.mapDomain_comp]; rfl
+    · simp only [StdSimplex.join, AffineWeights.join, StdSimplex.map]
+      rw [Finsupp.sum_mapDomain_index] <;> simp [add_smul]
+  single (x : M) := by convert af.single x
+
+end ConvexSpace
+
+end AffineSpace
+
+end

--- a/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
@@ -5,7 +5,6 @@ Authors: Joseph Myers
 -/
 module
 
-public import Mathlib.LinearAlgebra.ConvexSpace
 public import Mathlib.Algebra.AddTorsor.Defs
 
 /-!
@@ -42,104 +41,6 @@ Some key definitions are not yet present.
 
 public section
 
+assert_not_exists MonoidWithZero
+
 @[inherit_doc] scoped[Affine] notation "AffineSpace" => AddTorsor
-
-noncomputable section
-
-/--
-A finitely supported weighting over elements of `M` with coefficients in `R`. The weights sum to 1.
--/
-structure AffineWeights (R : Type*) [AddCommMonoid R] [One R] (M : Type*)
-    extends weights : M →₀ R where
-  /-- The weights sum to 1. -/
-  total : weights.sum (fun _ r => r) = 1
-
-attribute [simp] AffineWeights.total
-grind_pattern AffineWeights.total => self.weights
-
-namespace AffineWeights
-
-variable {R : Type*} [AddCommMonoid R] [One R] {M : Type*}
-
-@[ext]
-theorem ext {f g : AffineWeights R M} (h : f.weights = g.weights) : f = g := by
-  cases f; cases g; simp_all
-
-/-- The weighting that puts all weight on `x`. -/
-def single (x : M) : AffineWeights R M where
-  weights := Finsupp.single x 1
-  total := by simp
-
-@[simp]
-theorem mk_single (x : M) {total} :
-    (AffineWeights.mk (Finsupp.single x (1 : R)) total) = single x := by simp [single]
-
-/-- A weighting with weight `s` on `x` and weight `t` on `y`. -/
-def duple (x y : M) {s t : R} (h : s + t = 1) : AffineWeights R M where
-  weights := Finsupp.single x s + Finsupp.single y t
-  total := by
-    classical
-    rw [Finsupp.sum_add_index] <;> simp [h]
-
-/--
-Map a function over the support of an affine weighting.
-For each n : N, the weight is the sum of weights of all m : M with g m = n.
--/
-def map {M : Type*} {N : Type*} (g : M → N) (f : AffineWeights R M) : AffineWeights R N where
-  weights := f.weights.mapDomain g
-  total := by simp [Finsupp.sum_mapDomain_index]
-
-/--
-Join operation for affine weightings (monadic join).
-Given a weighting of a weighting, flattens it to a single weighting.
--/
-def join {R : Type*} [Semiring R] {M : Type*} (f : AffineWeights R (AffineWeights R M)) :
-    AffineWeights R M where
-  weights := f.weights.sum (fun d r => r • d.weights)
-  total := by
-    rw [Finsupp.sum_sum_index (fun _ ↦ rfl) (fun _ _ _ ↦ rfl)]
-    convert f.total
-    rw [Finsupp.sum_smul_index (fun _ ↦ rfl), ← Finsupp.mul_sum, AffineWeights.total, mul_one]
-
-end AffineWeights
-
-/--
-A set equipped with an operation of finite affine combinations, where the coefficients sum to 1.
--/
-class AffineSpace (R : Type*) (M : Type*) [Semiring R] where
-  /-- Take a affine combination with the given weighting. -/
-  affineCombination (f : AffineWeights R M) : M
-  /-- Associativity of affine combination (monadic join law). -/
-  assoc (f : AffineWeights R (AffineWeights R M)) :
-    affineCombination (f.map affineCombination) = affineCombination f.join
-  /-- A affine combination of a single point is that point. -/
-  single (x : M) : affineCombination (.single x) = x
-
-namespace AffineSpace
-
-section ConvexSpace
-
-variable {R : Type*} {M : Type*} [LE R] [Semiring R] in
--- its probably nicer to redefine StdSimplex to extend AffineWeights?
-instance : Coe (StdSimplex R M) (AffineWeights R M) where
-  coe f := ⟨f.weights, f.total⟩
-
-variable {R : Type*} {M : Type*} [PartialOrder R] [Semiring R] [IsStrictOrderedRing R]
-
-instance : Coe (StdSimplex R (StdSimplex R M)) (AffineWeights R (AffineWeights R M)) where
-  coe f := f.map (Coe.coe (β := (AffineWeights R M)))
-
-instance [af : AffineSpace R M] : ConvexSpace R M where
-  convexCombination (f : StdSimplex R M) := af.affineCombination f
-  assoc (f : StdSimplex R (StdSimplex R M)) := by
-    convert af.assoc f
-    · simp only [StdSimplex.map, AffineWeights.map, ← Finsupp.mapDomain_comp]; rfl
-    · simp only [StdSimplex.join, AffineWeights.join, StdSimplex.map]
-      rw [Finsupp.sum_mapDomain_index] <;> simp [add_smul]
-  single (x : M) := by convert af.single x
-
-end ConvexSpace
-
-end AffineSpace
-
-end

--- a/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Defs.lean
@@ -5,6 +5,7 @@ Authors: Joseph Myers
 -/
 module
 
+public import Mathlib.LinearAlgebra.ConvexSpace
 public import Mathlib.Algebra.AddTorsor.Defs
 
 /-!
@@ -41,6 +42,104 @@ Some key definitions are not yet present.
 
 public section
 
-assert_not_exists MonoidWithZero
-
 @[inherit_doc] scoped[Affine] notation "AffineSpace" => AddTorsor
+
+noncomputable section
+
+/--
+A finitely supported weighting over elements of `M` with coefficients in `R`. The weights sum to 1.
+-/
+structure AffineWeights (R : Type*) [AddCommMonoid R] [One R] (M : Type*)
+    extends weights : M →₀ R where
+  /-- The weights sum to 1. -/
+  total : weights.sum (fun _ r => r) = 1
+
+attribute [simp] AffineWeights.total
+grind_pattern AffineWeights.total => self.weights
+
+namespace AffineWeights
+
+variable {R : Type*} [AddCommMonoid R] [One R] {M : Type*}
+
+@[ext]
+theorem ext {f g : AffineWeights R M} (h : f.weights = g.weights) : f = g := by
+  cases f; cases g; simp_all
+
+/-- The weighting that puts all weight on `x`. -/
+def single (x : M) : AffineWeights R M where
+  weights := Finsupp.single x 1
+  total := by simp
+
+@[simp]
+theorem mk_single (x : M) {total} :
+    (AffineWeights.mk (Finsupp.single x (1 : R)) total) = single x := by simp [single]
+
+/-- A weighting with weight `s` on `x` and weight `t` on `y`. -/
+def duple (x y : M) {s t : R} (h : s + t = 1) : AffineWeights R M where
+  weights := Finsupp.single x s + Finsupp.single y t
+  total := by
+    classical
+    rw [Finsupp.sum_add_index] <;> simp [h]
+
+/--
+Map a function over the support of an affine weighting.
+For each n : N, the weight is the sum of weights of all m : M with g m = n.
+-/
+def map {M : Type*} {N : Type*} (g : M → N) (f : AffineWeights R M) : AffineWeights R N where
+  weights := f.weights.mapDomain g
+  total := by simp [Finsupp.sum_mapDomain_index]
+
+/--
+Join operation for affine weightings (monadic join).
+Given a weighting of a weighting, flattens it to a single weighting.
+-/
+def join {R : Type*} [Semiring R] {M : Type*} (f : AffineWeights R (AffineWeights R M)) :
+    AffineWeights R M where
+  weights := f.weights.sum (fun d r => r • d.weights)
+  total := by
+    rw [Finsupp.sum_sum_index (fun _ ↦ rfl) (fun _ _ _ ↦ rfl)]
+    convert f.total
+    rw [Finsupp.sum_smul_index (fun _ ↦ rfl), ← Finsupp.mul_sum, AffineWeights.total, mul_one]
+
+end AffineWeights
+
+/--
+A set equipped with an operation of finite affine combinations, where the coefficients sum to 1.
+-/
+class AffineSpace (R : Type*) (M : Type*) [Semiring R] where
+  /-- Take a affine combination with the given weighting. -/
+  affineCombination (f : AffineWeights R M) : M
+  /-- Associativity of affine combination (monadic join law). -/
+  assoc (f : AffineWeights R (AffineWeights R M)) :
+    affineCombination (f.map affineCombination) = affineCombination f.join
+  /-- A affine combination of a single point is that point. -/
+  single (x : M) : affineCombination (.single x) = x
+
+namespace AffineSpace
+
+section ConvexSpace
+
+variable {R : Type*} {M : Type*} [LE R] [Semiring R] in
+-- its probably nicer to redefine StdSimplex to extend AffineWeights?
+instance : Coe (StdSimplex R M) (AffineWeights R M) where
+  coe f := ⟨f.weights, f.total⟩
+
+variable {R : Type*} {M : Type*} [PartialOrder R] [Semiring R] [IsStrictOrderedRing R]
+
+instance : Coe (StdSimplex R (StdSimplex R M)) (AffineWeights R (AffineWeights R M)) where
+  coe f := f.map (Coe.coe (β := (AffineWeights R M)))
+
+instance [af : AffineSpace R M] : ConvexSpace R M where
+  convexCombination (f : StdSimplex R M) := af.affineCombination f
+  assoc (f : StdSimplex R (StdSimplex R M)) := by
+    convert af.assoc f
+    · simp only [StdSimplex.map, AffineWeights.map, ← Finsupp.mapDomain_comp]; rfl
+    · simp only [StdSimplex.join, AffineWeights.join, StdSimplex.map]
+      rw [Finsupp.sum_mapDomain_index] <;> simp [add_smul]
+  single (x : M) := by convert af.single x
+
+end ConvexSpace
+
+end AffineSpace
+
+end


### PR DESCRIPTION
Definition of `AffineSpace` following that of `ConvexSpace`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
