### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -68,10 +68,7 @@ theorem ae_differentiableWithinAt_of_mem {f : ℝ → V} {s : Set ℝ}
   let A := (Module.Basis.ofVectorSpace ℝ V).equivFun.toContinuousLinearEquiv
   suffices H : ∀ᵐ x, x ∈ s → DifferentiableWithinAt ℝ (A ∘ f) s x by
     filter_upwards [H] with x hx xs
-    have : f = (A.symm ∘ A) ∘ f := by
-      simp only [ContinuousLinearEquiv.symm_comp_self, Function.id_comp]
-    rw [this]
-    exact A.symm.differentiableAt.comp_differentiableWithinAt x (hx xs)
+    exact (ContinuousLinearEquiv.comp_differentiableWithinAt_iff _).mp (hx xs)
   apply ae_differentiableWithinAt_of_mem_pi
   exact A.lipschitz.comp_locallyBoundedVariationOn h
 

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -94,11 +94,7 @@ theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionSemiring 𝕜] [To
     refine tendsto_const_nhds.div (tendsto_const_nhds.add ?_) (by simp)
     simp_rw [div_eq_mul_inv]
     refine tendsto_const_nhds.mul ?_
-    have := ((continuous_algebraMap ℚ≥0 𝕜).tendsto _).comp tendsto_inv_atTop_nhds_zero_nat
-    rw [map_zero, Filter.tendsto_atTop'] at this
-    refine Iff.mpr tendsto_atTop' ?_
-    intros
-    simp_all only [comp_apply, map_inv₀, map_natCast]
+    exact tendsto_inv_atTop_nhds_zero_nat
 
 theorem tendsto_add_mul_div_add_mul_atTop_nhds {𝕜 : Type*} [Semifield 𝕜] [CharZero 𝕜]
     [TopologicalSpace 𝕜] [ContinuousSMul ℚ≥0 𝕜] [IsTopologicalSemiring 𝕜] [ContinuousInv₀ 𝕜]

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -93,8 +93,7 @@ theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionSemiring 𝕜] [To
     rw [this]
     refine tendsto_const_nhds.div (tendsto_const_nhds.add ?_) (by simp)
     simp_rw [div_eq_mul_inv]
-    refine tendsto_const_nhds.mul ?_
-    exact tendsto_inv_atTop_nhds_zero_nat
+    exact tendsto_const_nhds.mul tendsto_inv_atTop_nhds_zero_nat
 
 theorem tendsto_add_mul_div_add_mul_atTop_nhds {𝕜 : Type*} [Semifield 𝕜] [CharZero 𝕜]
     [TopologicalSpace 𝕜] [ContinuousSMul ℚ≥0 𝕜] [IsTopologicalSemiring 𝕜] [ContinuousInv₀ 𝕜]

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -83,10 +83,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       have : N - 1 < N := Nat.pred_lt Npos.ne'
       simpa only [not_lt] using Nat.find_min exN this
     have IcN : (c N : ℝ) ≤ (1 + ε) * c (N - 1) := by
-      have A : a ≤ N - 1 := by
-        apply @Nat.le_of_add_le_add_right a 1 (N - 1)
-        rw [Nat.sub_add_cancel Npos]
-        exact aN
+      have A : a ≤ N - 1 := (Nat.le_sub_one_iff_lt Npos).mpr aN
       have B : N - 1 + 1 = N := Nat.succ_pred_eq_of_pos Npos
       have := (ha _ A).1
       rwa [B] at this
@@ -133,10 +130,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
         exact mem_range.2 h
       exact lt_irrefl _ ((cNM.trans hn).trans_lt ncN)
     have Npos : 0 < N := lt_of_lt_of_le Nat.succ_pos' aN
-    have aN' : a ≤ N - 1 := by
-      apply @Nat.le_of_add_le_add_right a 1 (N - 1)
-      rw [Nat.sub_add_cancel Npos]
-      exact aN
+    have aN' : a ≤ N - 1 := (Nat.le_sub_one_iff_lt Npos).mpr aN
     have cNn : c (N - 1) ≤ n := by
       have : N - 1 < N := Nat.pred_lt Npos.ne'
       simpa only [not_lt] using Nat.find_min exN this

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
@@ -102,8 +102,7 @@ theorem Presieve.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ Type w) :
       · ext b
         cases b
       · simp only [eq_iff_true_of_subsingleton]
-    · refine ⟨Fin n, inferInstance, Z, (fun i ↦ Sigma.ι Z i), rfl, ?_⟩
-      exact instIsIsoDescι
+    · exact ⟨Fin n, inferInstance, Z, (fun i ↦ Sigma.ι Z i), rfl, instIsIsoDescι⟩
   · rw [extensiveTopology, Presieve.isSheaf_coverage]
     intro X R ⟨Y, α, Z, π, hR, hi⟩
     have : IsIso (Sigma.desc (Cofan.inj (Cofan.mk X π))) := hi

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
@@ -103,9 +103,7 @@ theorem Presieve.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ Type w) :
         cases b
       · simp only [eq_iff_true_of_subsingleton]
     · refine ⟨Fin n, inferInstance, Z, (fun i ↦ Sigma.ι Z i), rfl, ?_⟩
-      suffices Sigma.desc (fun i ↦ Sigma.ι Z i) = 𝟙 _ by rw [this]; infer_instance
-      ext
-      simp
+      exact instIsIsoDescι
   · rw [extensiveTopology, Presieve.isSheaf_coverage]
     intro X R ⟨Y, α, Z, π, hR, hi⟩
     have : IsIso (Sigma.desc (Cofan.inj (Cofan.mk X π))) := hi

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -274,11 +274,7 @@ lemma mor₁_eq_zero_iff_epi₃ : T.mor₁ = 0 ↔ Epi T.mor₃ := by
   have h := mor₃_eq_zero_iff_epi₂ _ (rot_of_distTriang _ hT)
   dsimp at h
   rw [← h, neg_eq_zero]
-  constructor
-  · intro h
-    simp only [h, Functor.map_zero]
-  · intro h
-    rw [← (CategoryTheory.shiftFunctor C (1 : ℤ)).map_eq_zero_iff, h]
+  exact (Functor.map_eq_zero_iff (CategoryTheory.shiftFunctor C 1)).symm
 
 lemma mor₃_eq_zero_of_epi₂ (h : Epi T.mor₂) : T.mor₃ = 0 := (T.mor₃_eq_zero_iff_epi₂ hT).2 h
 lemma mor₂_eq_zero_of_epi₁ (h : Epi T.mor₁) : T.mor₂ = 0 := (T.mor₂_eq_zero_iff_epi₁ hT).2 h
@@ -305,11 +301,7 @@ lemma mor₃_eq_zero_iff_mono₁ : T.mor₃ = 0 ↔ Mono T.mor₁ := by
   have h := mor₁_eq_zero_iff_mono₂ _ (inv_rot_of_distTriang _ hT)
   dsimp at h
   rw [← h, neg_eq_zero, IsIso.comp_right_eq_zero]
-  constructor
-  · intro h
-    simp only [h, Functor.map_zero]
-  · intro h
-    rw [← (CategoryTheory.shiftFunctor C (-1 : ℤ)).map_eq_zero_iff, h]
+  exact (Functor.map_eq_zero_iff (CategoryTheory.shiftFunctor C (-1))).symm
 
 lemma mor₁_eq_zero_of_mono₂ (h : Mono T.mor₂) : T.mor₁ = 0 := (T.mor₁_eq_zero_iff_mono₂ hT).2 h
 lemma mor₂_eq_zero_of_mono₃ (h : Mono T.mor₃) : T.mor₂ = 0 := (T.mor₂_eq_zero_iff_mono₃ hT).2 h

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -575,11 +575,7 @@ theorem IsChain.cons_of_le [LinearOrder α] {a : α} {as m : List α}
       refine lt_of_le_of_lt ?_ ha.1
       rw [le_iff_lt_or_eq] at hmas
       rcases hmas with hmas | hmas
-      · by_contra! hh
-        rw [← not_le] at hmas
-        apply hmas
-        apply le_of_lt
-        exact (List.lt_iff_lex_lt _ _).mp (List.Lex.rel hh)
+      · exact head_le_of_lt hmas
       · simp_all only [List.cons.injEq, le_refl]
 
 @[deprecated (since := "2025-09-24")] alias Chain'.cons_of_le := IsChain.cons_of_le

--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -56,10 +56,7 @@ theorem Perm.inter_append {l t₁ t₂ : List α} (h : Disjoint t₁ t₂) :
     by_cases h₂ : x ∈ t₂
     · simp only [*, inter_cons_of_notMem, false_or, mem_append, inter_cons_of_mem,
         not_false_iff]
-      refine Perm.trans (Perm.cons _ l_ih) ?_
-      change [x] ++ xs ∩ t₁ ++ xs ∩ t₂ ~ xs ∩ t₁ ++ ([x] ++ xs ∩ t₂)
-      rw [← List.append_assoc]
-      solve_by_elim [Perm.append_right, perm_append_comm]
+      exact perm_cons_append_cons _ l_ih
     · simp [*]
 
 theorem Perm.take_inter {xs ys : List α} (n : ℕ) (h : xs ~ ys)

--- a/Mathlib/Data/Seq/Defs.lean
+++ b/Mathlib/Data/Seq/Defs.lean
@@ -208,9 +208,7 @@ theorem destruct_cons (a : α) : ∀ s, destruct (cons a s) = some (a, s)
 theorem destruct_eq_none {s : Seq α} : destruct s = none → s = nil := by
   dsimp [destruct]
   rcases f0 : get? s 0 <;> intro h
-  · apply Subtype.ext
-    funext n
-    induction n with | zero => exact f0 | succ n IH => exact s.2 IH
+  · exact get?_zero_eq_none.mp f0
   · contradiction
 
 theorem destruct_eq_cons {s : Seq α} {a s'} : destruct s = some (a, s') → s = cons a s' := by

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -246,13 +246,7 @@ lemma subsingleton_of_ssubset_of_stabilizer_le
       toFun := Subtype.val
       map_smul' _ _ := rfl }
     exact hB.preimage f'
-  let φ : stabilizer M (s : Set α) → Perm (s : Set α) := MulAction.toPerm
-  let f : (s : Set α) →ₑ[φ] (s : Set α) := {
-    toFun := id
-    map_smul' _ _ := rfl }
-  have hf : Function.Bijective f := Function.bijective_id
-  rw [isPreprimitive_congr hG hf]
-  infer_instance
+  exact isPreprimitive_stabilizer_of_surjective _ hG
 
 @[deprecated (since := "2025-12-16")]
 alias _root_.IsBlock.subsingleton_of_ssubset_compl_of_stabilizer_le :=

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -623,12 +623,7 @@ theorem prime_card : (Nat.card α).Prime := by
     · simp only [Nat.coprime_iff_gcd_eq_one]
       have hgn : g ∈ Subgroup.zpowers (g ^ n) := by simp_all only [ne_eq, orderOf_eq_one_iff,
         Subgroup.mem_top]
-      have hgn_int : g ∈ Subgroup.zpowers (g ^ (n : ℤ)) := by simpa [zpow_natCast]
-      have hgcd_int :
-          (n : ℤ).gcd (↑(orderOf g) : ℤ) = 1 :=
-        (mem_zpowers_zpow_iff (g := g) (k := (n : ℤ))).1 hgn_int
-      simp_all only [ne_eq, orderOf_eq_one_iff, Subgroup.mem_top, zpow_natCast,
-        Int.gcd_natCast_natCast]
+      exact mem_zpowers_pow_iff.mp hgn
   apply Nat.prime_of_coprime
   · refine Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨?_, hα⟩
     contrapose! h

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -66,7 +66,7 @@ lemma coxeterWeightIn_le_four (S : Type*)
   have cs : 4 * lij ^ 2 ≤ 4 * (li * lj) := by
     rw [mul_le_mul_iff_right₀ four_pos]
     refine (P.posRootForm S).posForm.apply_sq_le_of_symm ?_ (P.posRootForm S).isSymm_posForm ri rj
-    exact fun _ ↦ zero_le_posForm _ _ _
+    exact (zero_le_posForm _ _ ·)
   have key : 4 • lij ^ 2 = P.coxeterWeightIn S i j • (li * lj) := by
     apply algebraMap_injective S R
     simpa [map_ofNat, lij, posRootForm, ri, rj, li, lj] using

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -65,8 +65,8 @@ lemma coxeterWeightIn_le_four (S : Type*)
   rw [hsj'] at hsj
   have cs : 4 * lij ^ 2 ≤ 4 * (li * lj) := by
     rw [mul_le_mul_iff_right₀ four_pos]
-    refine (P.posRootForm S).posForm.apply_sq_le_of_symm ?_ (P.posRootForm S).isSymm_posForm ri rj
-    exact (zero_le_posForm _ _ ·)
+    exact (P.posRootForm S).posForm.apply_sq_le_of_symm (zero_le_posForm _ _ ·)
+      (P.posRootForm S).isSymm_posForm ri rj
   have key : 4 • lij ^ 2 = P.coxeterWeightIn S i j • (li * lj) := by
     apply algebraMap_injective S R
     simpa [map_ofNat, lij, posRootForm, ri, rj, li, lj] using

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -66,11 +66,7 @@ lemma coxeterWeightIn_le_four (S : Type*)
   have cs : 4 * lij ^ 2 ≤ 4 * (li * lj) := by
     rw [mul_le_mul_iff_right₀ four_pos]
     refine (P.posRootForm S).posForm.apply_sq_le_of_symm ?_ (P.posRootForm S).isSymm_posForm ri rj
-    intro x
-    obtain ⟨s, hs, hs'⟩ := P.exists_ge_zero_eq_rootForm S x x.property
-    change _ = (P.posRootForm S).form x x at hs'
-    rw [(P.posRootForm S).algebraMap_apply_eq_form_iff] at hs'
-    rwa [← hs']
+    exact fun _ ↦ zero_le_posForm _ _ _
   have key : 4 • lij ^ 2 = P.coxeterWeightIn S i j • (li * lj) := by
     apply algebraMap_injective S R
     simpa [map_ofNat, lij, posRootForm, ri, rj, li, lj] using

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -881,11 +881,7 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
       refine le_intro fun B hB _ ↦ ?_
       rw [withDensity_apply _ hB]
       exact hξle B hB
-    have : IsFiniteMeasure (ν.withDensity ξ) := by
-      refine isFiniteMeasure_withDensity ?_
-      have hle' := hle univ
-      rw [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ] at hle'
-      exact ne_top_of_le_ne_top (measure_ne_top _ _) hle'
+    have : IsFiniteMeasure (ν.withDensity ξ) := isFiniteMeasure_of_le _ hle
     -- `ξ` is the `f` in the theorem statement and we set `μ₁` to be `μ - ν.withDensity ξ`
     -- since we need `μ₁ + ν.withDensity ξ = μ`
     set μ₁ := μ - ν.withDensity ξ with hμ₁

--- a/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
@@ -295,11 +295,7 @@ theorem IsFundamentalDomain.QuotientMeasureEqMeasurePreimage_smulHaarMeasure {�
     QuotientMeasureEqMeasurePreimage ν
       ((ν ((π ⁻¹' (K : Set (G ⧸ Γ))) ∩ 𝓕)) • haarMeasure K) := by
   set c := ν ((π ⁻¹' (K : Set (G ⧸ Γ))) ∩ 𝓕)
-  have c_ne_top : c ≠ ∞ := by
-    contrapose! h𝓕_finite
-    have : c ≤ ν 𝓕 := measure_mono (Set.inter_subset_right)
-    rw [h𝓕_finite] at this
-    exact top_unique this
+  have c_ne_top : c ≠ ∞ := measure_inter_ne_top_of_right_ne_top h𝓕_finite
   set μ := c • haarMeasure K
   have hμK : μ K = c := by simp [μ, haarMeasure_self]
   haveI : SigmaFinite μ := by

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -872,10 +872,7 @@ lemma isMulLeftInvariant_eq_smul_of_regular [LocallyCompactSpace G]
     congr! 4 with K _KU K_comp
     exact measure_isMulLeftInvariant_eq_smul_of_ne_top μ' μ K_comp.measure_lt_top.ne
       K_comp.measure_lt_top.ne
-  ext s _hs
-  rw [s.measure_eq_iInf_isOpen, s.measure_eq_iInf_isOpen]
-  congr! 4 with U _sU U_open
-  exact A U U_open
+  exact OuterRegular.ext_isOpen A
 
 /-- **Uniqueness of left-invariant measures**:
 Two Haar measures coincide up to a multiplicative constant in a second countable group. -/

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
@@ -324,9 +324,7 @@ theorem exists_subset_restrict_nonpos (hi : s i < 0) :
   obtain ⟨k, hk₁, hk₂⟩ := this
   have hA' : A ⊆ i \ ⋃ l ≤ k, restrictNonposSeq s i l := by
     apply Set.diff_subset_diff_right
-    intro x; simp only [Set.mem_iUnion]
-    rintro ⟨n, _, hn₂⟩
-    exact ⟨n, hn₂⟩
+    exact Set.iUnion₂_subset_iUnion _ _
   refine
     findExistsOneDivLT_min (hn' k) (Nat.sub_lt hk₁ Nat.zero_lt_one)
       ⟨E, Set.Subset.trans hE₂ hA', hE₁, ?_⟩

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
@@ -322,9 +322,8 @@ theorem exists_subset_restrict_nonpos (hi : s i < 0) :
       rw [one_div] at this ⊢
       exact inv_lt_of_inv_lt₀ hE₃ this
   obtain ⟨k, hk₁, hk₂⟩ := this
-  have hA' : A ⊆ i \ ⋃ l ≤ k, restrictNonposSeq s i l := by
-    apply Set.diff_subset_diff_right
-    exact Set.iUnion₂_subset_iUnion _ _
+  have hA' : A ⊆ i \ ⋃ l ≤ k, restrictNonposSeq s i l :=
+    Set.diff_subset_diff_right (Set.iUnion₂_subset_iUnion _ _)
   refine
     findExistsOneDivLT_min (hn' k) (Nat.sub_lt hk₁ Nat.zero_lt_one)
       ⟨E, Set.Subset.trans hE₂ hA', hE₁, ?_⟩

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -402,12 +402,7 @@ theorem coe_toHom {f : M ↪[L] N} : (f.toHom : M → N) = f :=
   rfl
 
 theorem coe_injective : @Function.Injective (M ↪[L] N) (M → N) (↑)
-  | f, g, h => by
-    cases f
-    cases g
-    congr
-    ext x
-    exact funext_iff.1 h x
+  | _, _, h => DFunLike.ext'_iff.mpr h
 
 @[ext]
 theorem ext ⦃f g : M ↪[L] N⦄ (h : ∀ x, f x = g x) : f = g :=

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -183,11 +183,8 @@ theorem norm_extends (x : PadicAlgCl p) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
 theorem nnnorm_extends (x : PadicAlgCl p) : ‖(x : ℂ_[p])‖₊ = ‖x‖₊ := by ext; exact norm_extends p x
 
 /-- The norm on `ℂ_[p]` is nonarchimedean. -/
-theorem isNonarchimedean : IsNonarchimedean (Norm.norm : ℂ_[p] → ℝ) := fun x y ↦ by
-  refine UniformSpace.Completion.induction_on₂ x y
-    (isClosed_le (continuous_norm.comp continuous_add) (by fun_prop)) (fun a b ↦ ?_)
-  rw [← UniformSpace.Completion.coe_add, norm_extends, norm_extends, norm_extends]
-  exact PadicAlgCl.isNonarchimedean p a b
+theorem isNonarchimedean : IsNonarchimedean (Norm.norm : ℂ_[p] → ℝ) :=
+  IsUltrametricDist.norm_add_le_max
 
 end PadicComplex
 

--- a/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
@@ -141,10 +141,7 @@ lemma setLIntegral_stieltjesOfMeasurableRat [IsFiniteKernel κ] (hf : IsRatCondK
     rw [← Monotone.measure_iInter]
     · congr with y : 1
       simp only [mem_Iic, mem_iInter, Subtype.forall]
-      refine ⟨fun h a ha ↦ h.trans ?_, fun h ↦ ?_⟩
-      · exact mod_cast ha.le
-      · refine le_of_forall_lt_rat_imp_le fun q hq ↦ h q ?_
-        exact mod_cast hq
+      exact le_iff_forall_lt_rat_imp_le
     · exact fun r r' hrr' ↦ Iic_subset_Iic.mpr <| mod_cast hrr'
     · exact fun _ ↦ nullMeasurableSet_Iic
     · obtain ⟨q, hq⟩ := exists_rat_gt x
@@ -298,11 +295,7 @@ lemma IsRatCondKernelCDFAux.tendsto_atBot_zero (hf : IsRatCondKernelCDFAux f κ 
     ∀ᵐ t ∂(ν a), Tendsto (f (a, t)) atBot (𝓝 0) := by
   suffices ∀ᵐ t ∂(ν a), Tendsto (fun q : ℚ ↦ f (a, t) (-q)) atTop (𝓝 0) by
     filter_upwards [this] with t ht
-    have h_eq_neg : f (a, t) = fun q : ℚ ↦ f (a, t) (- -q) := by
-      simp_rw [neg_neg]
-    rw [h_eq_neg]
-    convert ht.comp tendsto_neg_atBot_atTop
-    simp
+    exact tendsto_comp_neg_atTop_iff.mp ht
   suffices ∀ᵐ t ∂(ν a), Tendsto (fun (n : ℕ) ↦ f (a, t) (-n)) atTop (𝓝 0) by
     filter_upwards [this, hf.mono a] with t ht h_mono
     have h_anti : Antitone (fun q ↦ f (a, t) (-q)) := h_mono.comp_antitone monotone_id.neg
@@ -604,14 +597,8 @@ lemma lintegral_toKernel_mem [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ ν)
       simp only [preimage_iUnion, implies_true]
     simp_rw [h_eq]
     have h_disj : ∀ a, Pairwise (Disjoint on fun i ↦ Prod.mk a ⁻¹' f' i) := by
-      intro a i j hij
-      have h_disj := hf_disj hij
-      rw [Function.onFun, disjoint_iff_inter_eq_empty] at h_disj ⊢
-      ext1 x
-      simp only [mem_inter_iff, mem_empty_iff_false, iff_false]
-      intro h_mem_both
-      suffices (a, x) ∈ ∅ by rwa [mem_empty_iff_false] at this
-      rwa [← h_disj, mem_inter_iff]
+      intro _ _ _ hij
+      exact Disjoint.preimage _ (hf_disj hij)
     calc ∫⁻ b, hf.toKernel f (a, b) (⋃ i, Prod.mk b ⁻¹' f' i) ∂(ν a)
       = ∫⁻ b, ∑' i, hf.toKernel f (a, b) (Prod.mk b ⁻¹' f' i) ∂(ν a) := by
           congr with x : 1

--- a/Mathlib/Probability/Kernel/Disintegration/CondCDF.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CondCDF.lean
@@ -100,10 +100,7 @@ theorem tendsto_IicSnd_atBot [IsFiniteMeasure ρ] {s : Set α} (hs : MeasurableS
       · rw [neg_neg] at h'; exact h'.2
       · exact h'.2
     rw [h_inter_eq] at h_neg
-    have h_fun_eq : (fun r : ℚ ↦ ρ (s ×ˢ Iic (r : ℝ))) = fun r : ℚ ↦ ρ (s ×ˢ Iic ↑(- -r)) := by
-      simp_rw [neg_neg]
-    rw [h_fun_eq]
-    exact h_neg.comp tendsto_neg_atBot_atTop
+    exact tendsto_comp_neg_atTop_iff.mp h_neg
   refine tendsto_measure_iInter_atTop (fun q ↦ (hs.prod measurableSet_Iic).nullMeasurableSet)
     ?_ ⟨0, measure_ne_top ρ _⟩
   refine fun q r hqr ↦ Set.prod_mono subset_rfl fun x hx ↦ ?_

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -54,9 +54,7 @@ theorem eq_condKernel_of_measure_eq_compProd' (κ : Kernel α Ω) [IsSFiniteKern
   refine ae_eq_of_forall_setLIntegral_eq_of_sigmaFinite
     (Kernel.measurable_coe κ hs) (Kernel.measurable_coe ρ.condKernel hs) (fun t ht _ ↦ ?_)
   conv_rhs => rw [Measure.setLIntegral_condKernel_eq_measure_prod ht hs, hκ]
-  simp only [Measure.compProd_apply (ht.prod hs), ← lintegral_indicator ht]
-  congr with x
-  by_cases hx : x ∈ t <;> simp [hx]
+  exact (Measure.compProd_apply_prod ht hs).symm
 
 /-- Auxiliary lemma for `eq_condKernel_of_measure_eq_compProd`.
 Uniqueness of the disintegration kernel on ℝ. -/

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -91,8 +91,7 @@ theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
     intro n; refine StronglyMeasurable.indicator ?_ (measurableSet_kernel_integrable hf)
     have : ∀ x, ((s' n x).range.filter fun x => x ≠ 0) ⊆ (s n).range := by
       intro
-      refine Finset.Subset.trans (Finset.filter_subset _ _) ?_
-      exact SimpleFunc.range_comp_subset_range _ _
+      exact Finset.Subset.trans (Finset.filter_subset _ _) (SimpleFunc.range_comp_subset_range _ _)
     simp only [SimpleFunc.integral_eq_sum_of_subset (this _)]
     refine Finset.stronglyMeasurable_fun_sum _ fun x _ => ?_
     refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -90,8 +90,9 @@ theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
   have hf' : ∀ n, StronglyMeasurable (f' n) := by
     intro n; refine StronglyMeasurable.indicator ?_ (measurableSet_kernel_integrable hf)
     have : ∀ x, ((s' n x).range.filter fun x => x ≠ 0) ⊆ (s n).range := by
-      intro x; refine Finset.Subset.trans (Finset.filter_subset _ _) ?_; intro y
-      simp_rw [SimpleFunc.mem_range]; rintro ⟨z, rfl⟩; exact ⟨(x, z), rfl⟩
+      intro
+      refine Finset.Subset.trans (Finset.filter_subset _ _) ?_
+      exact SimpleFunc.range_comp_subset_range _ _
     simp only [SimpleFunc.integral_eq_sum_of_subset (this _)]
     refine Finset.stronglyMeasurable_fun_sum _ fun x _ => ?_
     refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -219,13 +219,8 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : Kernel α β) [IsFin
     exact ⟨min_eq_left ((h_le a b n hn).trans (le_add_of_nonneg_right zero_le_one)),
       min_eq_left (h_le a b n hn)⟩
   have hf_eq_tsum : f = ∑' n, fs n := by
-    have h_sum_a : ∀ a, Summable fun n => fs n a := by
-      refine fun a => Pi.summable.mpr fun b => ?_
-      suffices ∀ n, n ∉ Finset.range ⌈(f a b).toReal⌉₊ → fs n a b = 0 from
-        summable_of_ne_finset_zero this
-      intro n hn_notMem
-      rw [Finset.mem_range, not_lt] at hn_notMem
-      exact h_zero a b n hn_notMem
+    have h_sum_a : ∀ a, Summable fun n => fs n a :=
+      fun _ => Pi.summable.mpr fun _ => ENNReal.summable
     ext a b : 2
     rw [tsum_apply (Pi.summable.mpr h_sum_a), tsum_apply (h_sum_a a),
       ENNReal.tsum_eq_liminf_sum_nat]

--- a/Mathlib/Probability/Process/Adapted.lean
+++ b/Mathlib/Probability/Process/Adapted.lean
@@ -248,10 +248,7 @@ theorem progMeasurable_of_tendsto' {γ} [MeasurableSpace ι] [PseudoMetrizableSp
   apply @stronglyMeasurable_of_tendsto (Set.Iic i × Ω) β γ
     (MeasurableSpace.prod _ (f i)) _ _ fltr _ _ _ _ fun l => h l i
   rw [tendsto_pi_nhds] at h_tendsto ⊢
-  intro x
-  specialize h_tendsto x.fst
-  rw [tendsto_nhds] at h_tendsto ⊢
-  exact fun s hs h_mem => h_tendsto {g | g x.snd ∈ s} (hs.preimage (continuous_apply x.snd)) h_mem
+  exact fun _ ↦ Tendsto.apply_nhds (h_tendsto _) _
 
 theorem progMeasurable_of_tendsto [MeasurableSpace ι] [PseudoMetrizableSpace β] {U : ℕ → ι → Ω → β}
     (h : ∀ l, ProgMeasurable f (U l)) (h_tendsto : Tendsto U atTop (𝓝 u)) : ProgMeasurable f u :=

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -530,11 +530,7 @@ lemma infinitePi_map_piCurry_symm :
     ← Finset.sigma_image_fst_preimage_mk s, coe_piCurry_symm, Finset.coe_sigma,
     Set.uncurry_preimage_sigma_pi, infinitePi_pi, Finset.prod_sigma]
   · apply Finset.prod_congr rfl
-    simp only [Finset.mem_image, Sigma.exists, exists_and_right, exists_eq_right,
-      forall_exists_index]
-    intro i j hij
-    rw [infinitePi_pi]
-    simp [ht]
+    exact fun _ _ ↦ infinitePi_pi _ fun _ _ ↦ ht _
   · simp only [mem_image, Sigma.exists, exists_and_right, exists_eq_right, forall_exists_index]
     exact fun i j hij ↦ MeasurableSet.pi (countable_toSet _) fun k hk ↦ by simp_all
 

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -529,8 +529,7 @@ lemma infinitePi_map_piCurry_symm :
   rw [map_apply (by fun_prop) (.pi (countable_toSet _) fun _ _ ↦ ht _),
     ← Finset.sigma_image_fst_preimage_mk s, coe_piCurry_symm, Finset.coe_sigma,
     Set.uncurry_preimage_sigma_pi, infinitePi_pi, Finset.prod_sigma]
-  · apply Finset.prod_congr rfl
-    exact fun _ _ ↦ infinitePi_pi _ fun _ _ ↦ ht _
+  · exact Finset.prod_congr rfl (fun _ _ ↦ infinitePi_pi _ fun _ _ ↦ ht _)
   · simp only [mem_image, Sigma.exists, exists_and_right, exists_eq_right, forall_exists_index]
     exact fun i j hij ↦ MeasurableSet.pi (countable_toSet _) fun k hk ↦ by simp_all
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -281,12 +281,7 @@ theorem add_smul [AddCommMonoid R] [SMulWithZero R V] {x y : R⟦Γ⟧}
     rw [coeff_smul_left hwf Set.subset_union_right,
       coeff_smul_left hwf Set.subset_union_left]
     simp only [sum_add_distrib]
-  · intro b
-    simp_all only [Set.isPWO_union, HahnSeries.isPWO_support, and_self, HahnSeries.mem_support,
-      HahnSeries.coeff_add, ne_eq, Set.mem_union]
-    contrapose!
-    intro h
-    rw [h.1, h.2, add_zero]
+  · exact support_add_subset _ _
 
 theorem coeff_single_smul_vadd [MulZeroClass R] [SMulWithZero R V] {r : R} {x : HahnModule Γ' R V}
     {a : Γ'} {b : Γ} :

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Localization.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Localization.lean
@@ -53,14 +53,8 @@ lemma mem_associatedPrimes_of_comap_mem_associatedPrimes_of_isLocalizedModule
       IsLocalizedModule.mk'_smul_mk', mul_one, IsLocalizedModule.mk'_eq_zero']
     refine ⟨fun h ↦ ?_, fun ⟨t, ht⟩ ↦ ?_⟩
     · use 1
-      simp only [← mem_colon_singleton, one_smul, ← mem_bot R, ← hx, Ideal.mem_comap]
-      have : (algebraMap R R') r =
-        IsLocalization.mk' R' r s * IsLocalization.mk' R' s.1 (1 : S) := by
-        rw [← IsLocalization.mk'_one (M := S) R', ← sub_eq_zero, ← IsLocalization.mk'_mul,
-          ← IsLocalization.mk'_sub]
-        simp
-      rw [this]
-      exact Ideal.IsTwoSided.mul_mem_of_left _ h
+      simp only [← mem_colon_singleton, one_smul, ← mem_bot R, ← hx]
+      exact IsLocalization.mk'_mem_iff.mp h
     · have : t • r • x = (t.1 * r) • x := smul_smul t.1 r x
       rw [this, ← mem_bot R, ← mem_colon_singleton, ← hx, Ideal.mem_comap,
         ← IsLocalization.mk'_one (M := S) R'] at ht

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -55,11 +55,7 @@ theorem comap_eq_of_scalar_tower_quotient [Algebra R S] [Algebra (R ⧸ p) (S �
   ext x
   rw [mem_comap, ← Quotient.eq_zero_iff_mem, ← Quotient.eq_zero_iff_mem, Quotient.mk_algebraMap,
     IsScalarTower.algebraMap_apply R (R ⧸ p) (S ⧸ P), Quotient.algebraMap_eq]
-  constructor
-  · intro hx
-    exact (injective_iff_map_eq_zero (algebraMap (R ⧸ p) (S ⧸ P))).mp h _ hx
-  · intro hx
-    rw [hx, map_zero]
+  exact map_eq_zero_iff _ h
 
 variable [Algebra R S]
 


### PR DESCRIPTION
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `LocallyBoundedVariationOn.ae_differentiableWithinAt_of_mem`: 199 ms before, 162 ms after  🎉
* `tendsto_natCast_div_add_atTop`: 247 ms before, 136 ms after  🎉
* `tendsto_div_of_monotone_of_exists_subseq_tendsto_div`: 2757 ms before, 2376 ms after  🎉
* `CategoryTheory.Presieve.isSheaf_iff_preservesFiniteProducts`: 219 ms before, 198 ms after  🎉
* `CategoryTheory.Pretriangulated.Triangle.mor₁_eq_zero_iff_epi₃`: 15 ms before, 13 ms after  🎉
* `CategoryTheory.Pretriangulated.Triangle.mor₃_eq_zero_iff_mono₁`: 23 ms before, 15 ms after  🎉
* `List.IsChain.cons_of_le`: 22 ms before, 17 ms after  🎉
* `List.Perm.inter_append`: 194 ms before, 19 ms after  🎉
* `Equivalence.quot_mk_eq_iff`: <10 ms before, <10 ms after  🎉
* `Stream'.Seq.destruct_eq_none`: <10 ms before, <10 ms after  🎉
* `MulAction.IsBlock.subsingleton_of_ssubset_of_stabilizer_le`: 169 ms before, 105 ms after  🎉
* `IsSimpleGroup.prime_card`: 60 ms before, 48 ms after  🎉
* `RootPairing.coxeterWeightIn_le_four`: 1236 ms before, 1126 ms after  🎉
* `MeasureTheory.Measure.haveLebesgueDecomposition_of_finiteMeasure`: 659 ms before, 584 ms after  🎉
* `IsFundamentalDomain.QuotientMeasureEqMeasurePreimage_smulHaarMeasure`: 85 ms before, 80 ms after  🎉
* `MeasureTheory.Measure.isMulLeftInvariant_eq_smul_of_regular`: 58 ms before, 50 ms after  🎉
* `MeasureTheory.SignedMeasure.exists_subset_restrict_nonpos`: 413 ms before, 325 ms after  🎉
* `FirstOrder.Language.Embedding.coe_injective`: <10 ms before, <10 ms after  🎉
* `ProbabilityTheory.setLIntegral_stieltjesOfMeasurableRat`: 343 ms before, 310 ms after  🎉
* `ProbabilityTheory.IsRatCondKernelCDFAux.tendsto_atBot_zero`: 116 ms before, 75 ms after  🎉
* `ProbabilityTheory.lintegral_toKernel_mem`: 173 ms before, 172 ms after  🎉
* `MeasureTheory.Measure.tendsto_IicSnd_atBot`: 70 ms before, 63 ms after  🎉
* `ProbabilityTheory.eq_condKernel_of_measure_eq_compProd'`: 46 ms before, 30 ms after  🎉
* `MeasureTheory.StronglyMeasurable.integral_kernel_prod_right`: 1298 ms before, 1142 ms after  🎉
* `ProbabilityTheory.Kernel.isSFiniteKernel_withDensity_of_isFiniteKernel`: 433 ms before, 429 ms after  🎉
* `MeasureTheory.progMeasurable_of_tendsto'`: 20 ms before, <10 ms after  🎉
* `MeasureTheory.Measure.infinitePi_map_piCurry_symm`: 1319 ms before, 1291 ms after  🎉
* `HahnModule.add_smul`: 111 ms before, 75 ms after  🎉
* `Module.associatedPrimes.mem_associatedPrimes_of_comap_mem_associatedPrimes_of_isLocalizedModule`: 215 ms before, 198 ms after  🎉
* `Ideal.comap_eq_of_scalar_tower_quotient`: 97 ms before, 56 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
