### PR TITLE
[Merged by Bors] - fix: `#find_syntax` under the module system

### DIFF
--- a/Mathlib/Tactic/FindSyntax.lean
+++ b/Mathlib/Tactic/FindSyntax.lean
@@ -15,7 +15,7 @@ The `#find_syntax` command takes as input a string `str` and retrieves from the 
 all the candidates for `syntax` terms that contain the string `str`.
 
 It also makes a very crude effort at regenerating what the syntax looks like, by inspecting the
-`Expr`ession tree of the corresponding parser.
+`ParserDescr`iptor of the corresponding parser.
 -/
 
 public meta section
@@ -25,35 +25,22 @@ namespace Mathlib.FindSyntax
 open Lean Elab Command
 
 /--
-`extractSymbols expr` takes as input an `Expr`ession `expr`, assuming that it is the `value`
-of a "parser".
-It returns the array of all subterms of `expr` that are the `Expr.lit` argument to
-`Lean.ParserDescr.symbol` and `Lean.ParserDescr.nonReservedSymbol` applications.
+`extractSymbols descr acc` takes as input a `ParserDescr`iptor `descr` and an accumulator array
+`acc`. It accumulates all symbols in `descr` corresponding to `Lean.ParserDescr.symbol`,
+`Lean.ParserDescr.nonReservedSymbol` or `Lean.ParserDescr.unicodeSymbol`.
 
 The output array serves as a way of regenerating what the syntax tree of the input parser is.
 -/
-def extractSymbols : Expr → Array Expr
-  | .app a b =>
-    let rest := extractSymbols a ++ extractSymbols b
-    match a.constName with
-      | ``Lean.ParserDescr.symbol | ``Lean.ParserDescr.nonReservedSymbol => rest.push b
-      | _ => rest
-  | .letE _ a b c _ => extractSymbols a ++ extractSymbols b ++ extractSymbols c
-  | .lam _ a b _ => extractSymbols a ++ extractSymbols b
-  | .forallE _ a b _ => extractSymbols a ++ extractSymbols b
-  | .mdata _ a => extractSymbols a
-  | .proj _ _ a => extractSymbols a
-  | _ => #[]
-
-/--
-`litToString expr` converts the input `Expr`ession `expr` into the "natural" string that
-it corresponds to, in case `expr` is a `String`/`Nat`-literal, returning the empty string `""`
-otherwise.
--/
-def litToString : Expr → String
-  | .lit (.natVal v) => s!"{v}"
-  | .lit (.strVal v) => v
-  | _ => ""
+def extractSymbols : ParserDescr → Array String → Array String
+  | .symbol s, acc => acc.push s
+  | .nonReservedSymbol s _, acc => acc.push s
+  | .unicodeSymbol s _ _, acc => acc.push s
+  | .parser _, acc | .const _, acc | .cat _ _, acc => acc
+  | .node _ _ descr, acc | .trailingNode _ _ _ descr, acc | .nodeWithAntiquot _ _ descr, acc
+  | .unary _ descr, acc => extractSymbols descr acc
+  | .binary _ l r, acc => extractSymbols r (extractSymbols l acc)
+  | .sepBy p _ psep _, acc | .sepBy1 p _ psep _, acc =>
+    extractSymbols psep (extractSymbols p acc)
 
 /--
 The `#find_syntax` command takes as input a string `str` and retrieves from the environment
@@ -69,17 +56,18 @@ declarations, it returns its round-down to the previous multiple of 100.
 -/
 elab "#find_syntax " id:str d:(&" approx")? : command => do
   let prsr : Array Expr := #[.const ``ParserDescr [], .const ``TrailingParserDescr []]
-  let mut symbs : Std.HashSet (Name × Array Expr) := {}
+  let mut symbs : Std.HashSet (Name × List String) := {}
   -- We scan the environment in search of "parsers" whose name is not internal and that
   -- contain some `symbol` information and we store them in `symbs`
   for (declName, cinfo) in (← getEnv).constants do
-    if prsr.contains cinfo.type && cinfo.hasValue then
-      let ls := extractSymbols cinfo.value!
-      if !declName.isInternal && !ls.isEmpty then symbs := symbs.insert (declName, ls)
+    if prsr.contains cinfo.type then
+      let descr ← unsafe evalConst ParserDescr declName
+      let ls := extractSymbols descr #[]
+      if !declName.isInternal && !ls.isEmpty then symbs := symbs.insert (declName, ls.toList)
   -- From among the parsers in `symbs`, we extract the ones whose `symbols` contain the input `str`
   let mut match_results : NameMap (Array (Name × String)) := {}
   for (nm, ar) in symbs.toList do
-    let rem : String := " _ ".intercalate (ar.map litToString).toList
+    let rem : String := " _ ".intercalate ar
     -- If either the name of the parser or the regenerated syntax stub contains the input string,
     -- then we include an entry into the final message.
     if 2 ≤ (nm.toString.splitOn id.getString).length || 2 ≤ (rem.splitOn id.getString).length then

--- a/Mathlib/Tactic/FindSyntax.lean
+++ b/Mathlib/Tactic/FindSyntax.lean
@@ -32,13 +32,17 @@ open Lean Elab Command
 The output array serves as a way of regenerating what the syntax tree of the input parser is.
 -/
 def extractSymbols : ParserDescr → Array String → Array String
-  | .symbol s, acc => acc.push s
-  | .nonReservedSymbol s _, acc => acc.push s
-  | .unicodeSymbol s _ _, acc => acc.push s
-  | .parser _, acc | .const _, acc | .cat _ _, acc => acc
-  | .node _ _ descr, acc | .trailingNode _ _ _ descr, acc | .nodeWithAntiquot _ _ descr, acc
-  | .unary _ descr, acc => extractSymbols descr acc
-  | .binary _ l r, acc => extractSymbols r (extractSymbols l acc)
+  | .symbol s, acc | .nonReservedSymbol s _, acc | .unicodeSymbol s _ _, acc =>
+    acc.push s
+  | .parser _, acc | .const _, acc | .cat _ _, acc =>
+    acc
+  | .node _ _ descr, acc
+  | .trailingNode _ _ _ descr, acc
+  | .nodeWithAntiquot _ _ descr, acc
+  | .unary _ descr, acc =>
+    extractSymbols descr acc
+  | .binary _ l r, acc =>
+    extractSymbols r (extractSymbols l acc)
   | .sepBy p _ psep _, acc | .sepBy1 p _ psep _, acc =>
     extractSymbols psep (extractSymbols p acc)
 
@@ -60,10 +64,10 @@ elab "#find_syntax " id:str d:(&" approx")? : command => do
   -- We scan the environment in search of "parsers" whose name is not internal and that
   -- contain some `symbol` information and we store them in `symbs`
   for (declName, cinfo) in (← getEnv).constants do
-    if prsr.contains cinfo.type then
+    if prsr.contains cinfo.type && !declName.isInternal then
       let descr ← unsafe evalConst ParserDescr declName
       let ls := extractSymbols descr #[]
-      if !declName.isInternal && !ls.isEmpty then symbs := symbs.insert (declName, ls.toList)
+      if !ls.isEmpty then symbs := symbs.insert (declName, ls.toList)
   -- From among the parsers in `symbs`, we extract the ones whose `symbols` contain the input `str`
   let mut match_results : NameMap (Array (Name × String)) := {}
   for (nm, ar) in symbs.toList do

--- a/Mathlib/Tactic/FindSyntax.lean
+++ b/Mathlib/Tactic/FindSyntax.lean
@@ -67,7 +67,8 @@ elab "#find_syntax " id:str d:(&" approx")? : command => do
     if prsr.contains cinfo.type && !declName.isInternal then
       let descr ← unsafe evalConst ParserDescr declName
       let ls := extractSymbols descr #[]
-      if !ls.isEmpty then symbs := symbs.insert (declName, ls.toList)
+      unless ls.isEmpty do
+        symbs := symbs.insert (declName, ls.toList)
   -- From among the parsers in `symbs`, we extract the ones whose `symbols` contain the input `str`
   let mut match_results : NameMap (Array (Name × String)) := {}
   for (nm, ar) in symbs.toList do

--- a/MathlibTest/FindSyntax.lean
+++ b/MathlibTest/FindSyntax.lean
@@ -1,4 +1,5 @@
-import Mathlib.Tactic.FindSyntax
+module
+public import Mathlib.Tactic.FindSyntax
 
 infix:65 " #find_syntax_add " => Nat.add
 
@@ -47,26 +48,13 @@ In `Init.Notation`:
 #find_syntax "~~~" approx  -- a `prefix`
 
 /--
-info: Found 16 uses among over 800 syntax declarations
+info: Found 5 uses among over 800 syntax declarations
 In `Init.Tactics`:
   Lean.Parser.Tactic.mrefineMacro: 'mrefine'
   Lean.Parser.Tactic.refine: 'refine'
   Lean.Parser.Tactic.refine': 'refine''
   Lean.Parser.Tactic.tacticRefine_lift'_: 'refine_lift''
   Lean.Parser.Tactic.tacticRefine_lift_: 'refine_lift'
-
-In `Std.Tactic.Do.Syntax`:
-  Lean.Parser.Tactic.mrefine: 'mrefine'
-  Lean.Parser.Tactic.mrefineError: 'mrefine'
-  Lean.Parser.Tactic.«mrefinePat#_»: '#'
-  Lean.Parser.Tactic.«mrefinePat%_»: '%'
-  Lean.Parser.Tactic.«mrefinePat(_)»: '( _ )'
-  Lean.Parser.Tactic.mrefinePat?_: '?'
-  Lean.Parser.Tactic.mrefinePats: ','
-  Lean.Parser.Tactic.«mrefinePat⌜_⌝»: '⌜ _ ⌝'
-  Lean.Parser.Tactic.«mrefinePat□_»: '□'
-  Lean.Parser.Tactic.«mrefinePat⟨_⟩»: '⟨ _ ⟩'
-  Lean.Parser.Tactic.mrefinePat.quot: '`(mrefinePat|  _ )'
 -/
 #guard_msgs in
 #find_syntax "refine" approx  -- a `nonReservedSymbol`


### PR DESCRIPTION
Instead of using the value, we now use `evalConst` and inspect the resulting `ParserDescr`.

---

[Zulip topic](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.23find_syntax.20is.20broken.20by.20the.20module.20system/with/573726049)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
