### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Order): add lemma Finsupp.single_le_sum

### DIFF
--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -109,6 +109,14 @@ lemma mapDomain_mono : Monotone (mapDomain f : (ι →₀ α) → (κ →₀ α)
 lemma mapDomain_nonneg (hg : 0 ≤ g) : 0 ≤ g.mapDomain f := by simpa using mapDomain_mono hg
 lemma mapDomain_nonpos (hg : g ≤ 0) : g.mapDomain f ≤ 0 := by simpa using mapDomain_mono hg
 
+lemma single_le_sum {α M N : Type*} [Zero M] [AddCommMonoid N] [PartialOrder N]
+    [IsOrderedAddMonoid N] (f : α →₀ M) {g : M → N} (hg : g 0 = 0) (h : ∀ m, 0 ≤ g m) (a : α) :
+    g (f a) ≤ f.sum fun _ m ↦ g m := by
+  rcases eq_or_ne (f a) 0 with H | H
+  · rw [H, hg]
+    exact sum_nonneg' fun _ ↦ h _
+  · exact Finset.single_le_sum (fun a _ ↦ h (f a)) <| mem_support_iff.mpr H
+
 end OrderedAddCommMonoid
 
 instance isOrderedCancelAddMonoid [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α] :

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -109,13 +109,22 @@ lemma mapDomain_mono : Monotone (mapDomain f : (ι →₀ α) → (κ →₀ α)
 lemma mapDomain_nonneg (hg : 0 ≤ g) : 0 ≤ g.mapDomain f := by simpa using mapDomain_mono hg
 lemma mapDomain_nonpos (hg : g ≤ 0) : g.mapDomain f ≤ 0 := by simpa using mapDomain_mono hg
 
-lemma single_le_sum {α M N : Type*} [Zero M] [AddCommMonoid N] [PartialOrder N]
-    [IsOrderedAddMonoid N] (f : α →₀ M) {g : M → N} (hg : g 0 = 0) (h : ∀ m, 0 ≤ g m) (a : α) :
-    g (f a) ≤ f.sum fun _ m ↦ g m := by
+theorem single_le_sum {α M N : Type*} [Zero M] [AddCommMonoid N]
+    [PartialOrder N] [IsOrderedAddMonoid N] (f : α →₀ M) {g : α → M → N}
+    (h : 0 ≤ (g · ·)) (a : α) :
+    ((single a (f a)).sum g) ≤ f.sum g := by
   rcases eq_or_ne (f a) 0 with H | H
-  · rw [H, hg]
-    exact sum_nonneg' fun _ ↦ h _
-  · exact Finset.single_le_sum (fun a _ ↦ h (f a)) <| mem_support_iff.mpr H
+  · rw [H, single_zero, sum_zero_index]
+    exact sum_nonneg' (fun i ↦ h i (f i))
+  · rw [sum, support_single_ne_zero _ H, sum_singleton, single_eq_same]
+    apply Finset.single_le_sum (fun i hi ↦ h i (f i))
+    simpa [mem_support_iff, ne_eq] using H
+
+lemma single_eval_le_sum {α M N : Type*} [Zero M] [AddCommMonoid N] [PartialOrder N]
+    [IsOrderedAddMonoid N] (f : α →₀ M) {g : M → N} (hg : g 0 = 0) (h : 0 ≤ (g ·)) (a : α) :
+    g (f a) ≤ f.sum fun _ m ↦ g m := by
+  simp only [← sum_single_index (h := fun (_ : α) m ↦ g m) (a := a) (b := f a) hg]
+  apply single_le_sum _ (fun _ m ↦ h m)
 
 end OrderedAddCommMonoid
 


### PR DESCRIPTION
This adds an API lemma for `Finsupp` that turned out to be useful in [Heights](github.com/MichaelStollBayreuth/Heights).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
