### PR TITLE
[Merged by Bors] - fix(Cache): Do not treat 201 Created as an error code

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -333,7 +333,8 @@ def monitorCurl (args : Array String) (size : Nat)
       match Lean.Json.parse line.copy with
       | .ok result =>
         match result.getObjValAs? Nat "http_code" with
-        | .ok 200 =>
+        | .ok 200
+        | .ok 201 =>
           if let .ok fn := result.getObjValAs? String "filename_effective" then
             if (← System.FilePath.pathExists fn) && fn.endsWith ".part" then
               IO.FS.rename fn (fn.dropEnd 5).copy


### PR DESCRIPTION
`201 Created` is a success in the cache `PUT` operation: we are getting the failure log lines in every build (see [example](https://github.com/leanprover-community/mathlib4/actions/runs/21996999056/job/63559518669#step:25:39) but this happens every time):

```
Transfer failed (error code: 201)
```

because creating new blobs comes back with `201`.