### PR TITLE
[Merged by Bors] - chore(Data/Nat/Choose): add grind annotations

### DIFF
--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -51,13 +51,14 @@ def choose : ℕ → ℕ → ℕ
   | 0, _ + 1 => 0
   | n + 1, k + 1 => choose n k + choose n (k + 1)
 
-@[simp]
+@[simp, grind =]
 theorem choose_zero_right (n : ℕ) : choose n 0 = 1 := by cases n <;> rfl
 
-@[simp]
+@[simp, grind =]
 theorem choose_zero_succ (k : ℕ) : choose 0 (succ k) = 0 :=
   rfl
 
+@[grind =]
 theorem choose_succ_succ (n k : ℕ) : choose (succ n) (succ k) = choose n k + choose n (succ k) :=
   rfl
 
@@ -79,6 +80,7 @@ theorem choose_eq_choose_pred_add {n k : ℕ} (hn : 0 < n) (hk : 0 < k) :
   obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
   rw [choose_succ_right _ _ hn, Nat.add_one_sub_one]
 
+@[grind <=]
 theorem choose_eq_zero_of_lt : ∀ {n k}, n < k → choose n k = 0
   | _, 0, hk => absurd hk (Nat.not_lt_zero _)
   | 0, _ + 1, _ => choose_zero_succ _
@@ -89,7 +91,7 @@ theorem choose_eq_zero_of_lt : ∀ {n k}, n < k → choose n k = 0
 
 @[simp]
 theorem choose_self (n : ℕ) : choose n n = 1 := by
-  induction n <;> simp [*, choose, choose_eq_zero_of_lt (lt_succ_self _)]
+  induction n <;> grind
 
 @[simp]
 theorem choose_succ_self (n : ℕ) : choose n (succ n) = 0 :=
@@ -160,7 +162,7 @@ theorem choose_mul_factorial_mul_factorial : ∀ {n k}, k ≤ n → choose n k *
 theorem choose_mul {n k s : ℕ} (hsk : s ≤ k) :
     n.choose k * k.choose s = n.choose s * (n - s).choose (k - s) := by
   obtain hnk | hkn := lt_or_ge n k
-  · grind [Nat.choose_eq_zero_of_lt]
+  · grind
   have h : 0 < (n - k)! * (k - s)! * s ! := by apply_rules [factorial_pos, Nat.mul_pos]
   apply Nat.mul_right_cancel h
   calc
@@ -213,7 +215,7 @@ theorem choose_succ_right_eq (n k : ℕ) : choose n (k + 1) * (k + 1) = choose n
     rw [← Nat.add_mul, Nat.add_comm (choose _ _), ← choose_succ_succ, add_one_mul_choose_eq]
   rw [← Nat.sub_eq_of_eq_add e, Nat.mul_comm, ← Nat.mul_sub_left_distrib, Nat.add_sub_add_right]
 
-@[simp]
+@[simp, grind =]
 theorem choose_succ_self_right : ∀ n : ℕ, (n + 1).choose n = n + 1
   | 0 => rfl
   | n + 1 => by rw [choose_succ_succ, choose_succ_self_right n, choose_self]
@@ -341,7 +343,7 @@ theorem choose_le_middle (r n : ℕ) : choose n r ≤ choose n (n / 2) := by
 
 
 theorem choose_le_succ (a c : ℕ) : choose a c ≤ choose a.succ c := by
-  cases c <;> simp [Nat.choose_succ_succ]
+  cases c <;> grind
 
 theorem choose_le_add (a b c : ℕ) : choose a c ≤ choose (a + b) c := by
   induction b with
@@ -356,11 +358,9 @@ theorem choose_mono (b : ℕ) : Monotone fun a => choose a b := fun _ _ => choos
 
 theorem choose_eq_one_iff {n k : ℕ} : n.choose k = 1 ↔ k = 0 ∨ n = k := by
   rcases lt_trichotomy k n with hk | rfl | hk
-  · have := k.choose_succ_self_right.symm.trans_le (k.choose_mono hk)
-    have := n.choose_zero_right
-    grind
+  · grind [k.choose_mono hk]
   · simp
-  · simp [choose_eq_zero_of_lt hk, hk.ne, Nat.ne_zero_of_lt hk]
+  · grind
 
 /-! #### Multichoose
 


### PR DESCRIPTION

While doing some work for Numina, I noticed that there was a point at which I wanted to have `Nat.choose_eq_zero_of_lt` applied as a `grind <=` lemma. This PR adds a grind annotation here, as well as a few other grind annotations to the file, and tries to golf using these where appropriate.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
