### PR TITLE
[Merged by Bors] - feat: add (m)differentiableAt_of_(m)fderiv_injective

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Const.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Const.lean
@@ -332,12 +332,8 @@ lemma differentiableWithinAt_of_fderivWithin_injective (hf : Injective (fderivWi
   by_cases h: Subsingleton E
   · exact (differentiable_of_subsingleton x).differentiableWithinAt
   · by_contra h'
-    replace hf : LinearMap.ker (fderivWithin 𝕜 f s x).toLinearMap = ⊥ := by
-      rw [LinearMap.ker_eq_bot]; exact hf
-    have : (⊥ : Submodule 𝕜 E) = ⊤ := by
-      simp [fderivWithin_zero_of_not_differentiableWithinAt h', ← hf]
-    have : Subsingleton (Submodule 𝕜 E) := subsingleton_of_bot_eq_top this
-    simp_all only [Submodule.subsingleton_iff]
+    rw [fderivWithin_zero_of_not_differentiableWithinAt h'] at hf
+    exact h { allEq a b := hf rfl }
 
 /-- If `f : E → F` has injective differential at `x`, it is differentiable at `x`. -/
 lemma differentiableAt_of_fderiv_injective (hf : Injective (fderiv 𝕜 f x)) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Const.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Const.lean
@@ -295,21 +295,27 @@ theorem hasFDerivWithinAt_singleton (f : E → F) (x : E) :
   rw [accPt_iff_clusterPt, inf_principal]
   simp [ClusterPt]
 
-@[fun_prop]
+@[fun_prop, nontriviality]
 theorem hasFDerivWithinAt_of_subsingleton [h : Subsingleton E] (f : E → F) (s : Set E) (x : E) :
     HasFDerivWithinAt f (0 : E →L[𝕜] F) s x := by
   obtain rfl | ⟨a, rfl⟩ := s.eq_empty_or_singleton_of_subsingleton
   · simp
   · exact HasFDerivWithinAt.singleton
 
-@[fun_prop]
+@[fun_prop, nontriviality]
 theorem hasFDerivAt_of_subsingleton [h : Subsingleton E] (f : E → F) (x : E) :
     HasFDerivAt f (0 : E →L[𝕜] F) x := by
   rw [← hasFDerivWithinAt_univ, subsingleton_univ.eq_singleton_of_mem (mem_univ x)]
   exact hasFDerivWithinAt_singleton f x
 
+@[nontriviality]
 theorem differentiable_of_subsingleton [Subsingleton E] {f : E → F} : Differentiable 𝕜 f :=
   fun x ↦ (hasFDerivAt_of_subsingleton f x (𝕜 := 𝕜)).differentiableAt
+
+@[nontriviality]
+theorem differentiableWithinAt_of_subsingleton [Subsingleton E] :
+    DifferentiableWithinAt 𝕜 f s x :=
+  (differentiable_of_subsingleton x).differentiableWithinAt
 
 @[fun_prop]
 theorem differentiableOn_singleton : DifferentiableOn 𝕜 f {x} :=
@@ -329,11 +335,10 @@ end Const
 it is differentiable within `s` at `x`. -/
 lemma differentiableWithinAt_of_fderivWithin_injective (hf : Injective (fderivWithin 𝕜 f s x)) :
     DifferentiableWithinAt 𝕜 f s x := by
-  by_cases h: Subsingleton E
-  · exact (differentiable_of_subsingleton x).differentiableWithinAt
-  · by_contra h'
-    rw [fderivWithin_zero_of_not_differentiableWithinAt h'] at hf
-    exact h { allEq a b := hf rfl }
+  nontriviality E
+  contrapose! hf
+  rw [fderivWithin_zero_of_not_differentiableWithinAt hf]
+  exact not_injective_const
 
 /-- If `f : E → F` has injective differential at `x`, it is differentiable at `x`. -/
 lemma differentiableAt_of_fderiv_injective (hf : Injective (fderiv 𝕜 f x)) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Const.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Const.lean
@@ -325,18 +325,33 @@ theorem hasFDerivAt_zero_of_eventually_const (c : F) (hf : f =ᶠ[𝓝 x] fun _ 
 
 end Const
 
+/-- If `f : E → F` has injective differential within `s` at `x`,
+it is differentiable within `s` at `x`. -/
+lemma differentiableWithinAt_of_fderivWithin_injective (hf : Injective (fderivWithin 𝕜 f s x)) :
+    DifferentiableWithinAt 𝕜 f s x := by
+  by_cases h: Subsingleton E
+  · exact (differentiable_of_subsingleton x).differentiableWithinAt
+  · by_contra h'
+    replace hf : LinearMap.ker (fderivWithin 𝕜 f s x).toLinearMap = ⊥ := by
+      rw [LinearMap.ker_eq_bot]; exact hf
+    have : (⊥ : Submodule 𝕜 E) = ⊤ := by
+      simp [fderivWithin_zero_of_not_differentiableWithinAt h', ← hf]
+    have : Subsingleton (Submodule 𝕜 E) := subsingleton_of_bot_eq_top this
+    simp_all only [Submodule.subsingleton_iff]
+
+/-- If `f : E → F` has injective differential at `x`, it is differentiable at `x`. -/
+lemma differentiableAt_of_fderiv_injective (hf : Injective (fderiv 𝕜 f x)) :
+    DifferentiableAt 𝕜 f x := by
+  simp only [← differentiableWithinAt_univ, ← fderivWithin_univ] at hf ⊢
+  exact differentiableWithinAt_of_fderivWithin_injective hf
+
 theorem differentiableWithinAt_of_isInvertible_fderivWithin
-    (hf : (fderivWithin 𝕜 f s x).IsInvertible) : DifferentiableWithinAt 𝕜 f s x := by
-  contrapose hf
-  rw [fderivWithin_zero_of_not_differentiableWithinAt hf]
-  contrapose! hf
-  rcases ContinuousLinearMap.isInvertible_zero_iff.1 hf with ⟨hE, hF⟩
-  exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
+    (hf : (fderivWithin 𝕜 f s x).IsInvertible) : DifferentiableWithinAt 𝕜 f s x :=
+  differentiableWithinAt_of_fderivWithin_injective hf.injective
 
 theorem differentiableAt_of_isInvertible_fderiv
-    (hf : (fderiv 𝕜 f x).IsInvertible) : DifferentiableAt 𝕜 f x := by
-  simp only [← differentiableWithinAt_univ, ← fderivWithin_univ] at hf ⊢
-  exact differentiableWithinAt_of_isInvertible_fderivWithin hf
+    (hf : (fderiv 𝕜 f x).IsInvertible) : DifferentiableAt 𝕜 f x :=
+  differentiableAt_of_fderiv_injective hf.injective
 
 /-! ### Support of derivatives -/
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -558,12 +558,8 @@ lemma mdifferentiableWithinAt_of_mfderivWithin_injective
   by_cases h: Subsingleton E
   · exact (mdifferentiable_of_subsingleton x).mdifferentiableWithinAt
   · by_contra h'
-    replace hf : LinearMap.ker (mfderivWithin I I' f s x).toLinearMap = ⊥ := by
-      rw [LinearMap.ker_eq_bot]; exact hf
-    have : (⊥ : Submodule 𝕜 (TangentSpace I x)) = ⊤ := by
-      simp [mfderivWithin_zero_of_not_mdifferentiableWithinAt h', ← hf]
-    have : Subsingleton (Submodule 𝕜 E) := subsingleton_of_bot_eq_top this
-    simp_all only [Submodule.subsingleton_iff]
+    rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt h'] at hf
+    exact h { allEq a b := hf rfl }
 
 /-- If `f : M → M'` has injective differential at `x`, it is `MDifferentiable` at `x`. -/
 lemma mdifferentiableAt_of_mfderiv_injective {f : M → M'} (hf : Injective (mfderiv I I' f x)) :

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -543,6 +543,7 @@ theorem mfderivWithin_zero_of_not_mdifferentiableWithinAt
 theorem mfderiv_zero_of_not_mdifferentiableAt (h : ¬MDifferentiableAt I I' f x) :
     mfderiv I I' f x = 0 := by simp only [mfderiv, h, if_neg, not_false_iff]
 
+@[nontriviality]
 theorem mdifferentiable_of_subsingleton [Subsingleton E] : MDifferentiable I I' f := by
   intro x
   have : Subsingleton H := I.injective.subsingleton
@@ -550,16 +551,20 @@ theorem mdifferentiable_of_subsingleton [Subsingleton E] : MDifferentiable I I' 
   simp only [mdifferentiableAt_iff, continuous_of_discreteTopology.continuousAt, true_and]
   exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
 
+@[nontriviality]
+theorem mdifferentiableWithinAt_of_subsingleton [Subsingleton E] :
+    MDifferentiableWithinAt I I' f s x :=
+  (mdifferentiable_of_subsingleton x).mdifferentiableWithinAt
+
 /-- If `f : M → M'` has injective differential at `x` within `s`,
 it is `MDifferentiable` at `x` within `s`. -/
 lemma mdifferentiableWithinAt_of_mfderivWithin_injective
     (hf : Injective (mfderivWithin I I' f s x)) :
     MDifferentiableWithinAt I I' f s x := by
-  by_cases h: Subsingleton E
-  · exact (mdifferentiable_of_subsingleton x).mdifferentiableWithinAt
-  · by_contra h'
-    rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt h'] at hf
-    exact h { allEq a b := hf rfl }
+  nontriviality E
+  contrapose! hf
+  rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt hf]
+  exact not_injective_const
 
 /-- If `f : M → M'` has injective differential at `x`, it is `MDifferentiable` at `x`. -/
 lemma mdifferentiableAt_of_mfderiv_injective {f : M → M'} (hf : Injective (mfderiv I I' f x)) :

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -30,7 +30,7 @@ noncomputable section
 assert_not_exists tangentBundleCore
 
 open scoped Topology Manifold
-open Set Bundle ChartedSpace
+open Function Set Bundle ChartedSpace
 
 section DerivativesProperties
 
@@ -550,19 +550,34 @@ theorem mdifferentiable_of_subsingleton [Subsingleton E] : MDifferentiable I I' 
   simp only [mdifferentiableAt_iff, continuous_of_discreteTopology.continuousAt, true_and]
   exact (hasFDerivAt_of_subsingleton _ _).differentiableAt.differentiableWithinAt
 
+/-- If `f : M → M'` has injective differential at `x` within `s`,
+it is `MDifferentiable` at `x` within `s`. -/
+lemma mdifferentiableWithinAt_of_mfderivWithin_injective
+    (hf : Injective (mfderivWithin I I' f s x)) :
+    MDifferentiableWithinAt I I' f s x := by
+  by_cases h: Subsingleton E
+  · exact (mdifferentiable_of_subsingleton x).mdifferentiableWithinAt
+  · by_contra h'
+    replace hf : LinearMap.ker (mfderivWithin I I' f s x).toLinearMap = ⊥ := by
+      rw [LinearMap.ker_eq_bot]; exact hf
+    have : (⊥ : Submodule 𝕜 (TangentSpace I x)) = ⊤ := by
+      simp [mfderivWithin_zero_of_not_mdifferentiableWithinAt h', ← hf]
+    have : Subsingleton (Submodule 𝕜 E) := subsingleton_of_bot_eq_top this
+    simp_all only [Submodule.subsingleton_iff]
+
+/-- If `f : M → M'` has injective differential at `x`, it is `MDifferentiable` at `x`. -/
+lemma mdifferentiableAt_of_mfderiv_injective {f : M → M'} (hf : Injective (mfderiv I I' f x)) :
+    MDifferentiableAt I I' f x := by
+  simp only [← mdifferentiableWithinAt_univ, ← mfderivWithin_univ] at hf ⊢
+  exact mdifferentiableWithinAt_of_mfderivWithin_injective hf
+
 theorem mdifferentiableWithinAt_of_isInvertible_mfderivWithin
-    (hf : (mfderivWithin I I' f s x).IsInvertible) : MDifferentiableWithinAt I I' f s x := by
-  contrapose hf
-  rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt hf]
-  contrapose! hf
-  rcases ContinuousLinearMap.isInvertible_zero_iff.1 hf with ⟨hE, hF⟩
-  have : Subsingleton E := hE
-  exact mdifferentiable_of_subsingleton.mdifferentiableAt.mdifferentiableWithinAt
+    (hf : (mfderivWithin I I' f s x).IsInvertible) : MDifferentiableWithinAt I I' f s x :=
+  mdifferentiableWithinAt_of_mfderivWithin_injective hf.injective
 
 theorem mdifferentiableAt_of_isInvertible_mfderiv
-    (hf : (mfderiv I I' f x).IsInvertible) : MDifferentiableAt I I' f x := by
-  simp only [← mdifferentiableWithinAt_univ, ← mfderivWithin_univ] at hf ⊢
-  exact mdifferentiableWithinAt_of_isInvertible_mfderivWithin hf
+    (hf : (mfderiv I I' f x).IsInvertible) : MDifferentiableAt I I' f x :=
+  mdifferentiableAt_of_mfderiv_injective hf.injective
 
 theorem HasMFDerivWithinAt.mono (h : HasMFDerivWithinAt I I' f t x f') (hst : s ⊆ t) :
     HasMFDerivWithinAt I I' f s x f' :=

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -562,6 +562,7 @@ lemma mdifferentiableWithinAt_of_mfderivWithin_injective
     (hf : Injective (mfderivWithin I I' f s x)) :
     MDifferentiableWithinAt I I' f s x := by
   nontriviality E
+  have : Nontrivial (TangentSpace I x) := inferInstanceAs (Nontrivial E)
   contrapose! hf
   rw [mfderivWithin_zero_of_not_mdifferentiableWithinAt hf]
   exact not_injective_const

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -81,6 +81,12 @@ protected theorem Bijective.surjective {f : α → β} (hf : Bijective f) : Surj
 theorem not_injective_iff : ¬ Injective f ↔ ∃ a b, f a = f b ∧ a ≠ b := by
   simp only [Injective, not_forall, exists_prop]
 
+@[simp] lemma not_injective_const {α β : Type*} [Nontrivial α] {b : β} :
+    ¬ Injective (fun _ : α ↦ b) := by
+  rw [not_injective_iff]
+  obtain ⟨a₁, a₂, h⟩ := exists_pair_ne α
+  exact ⟨a₁, a₂, rfl, h⟩
+
 /-- If the co-domain `β` of an injective function `f : α → β` has decidable equality, then
 the domain `α` also has decidable equality. -/
 protected def Injective.decidableEq [DecidableEq β] (I : Injective f) : DecidableEq α :=


### PR DESCRIPTION
and versions for `(m)fderivWithin` versions. This generalises the existing lemmas `(m)differentiableAt_of_isInvertible_(m)fderiv` and friends.

Extracted from #35078; from the path to immersions, embeddings and submanifolds.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
