### PR TITLE
[Merged by Bors] - feat: Semi-direct sum of Lie algebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -693,6 +693,7 @@ public import Mathlib.Algebra.Lie.Normalizer
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.Algebra.Lie.Quotient
 public import Mathlib.Algebra.Lie.Rank
+public import Mathlib.Algebra.Lie.SemiDirect
 public import Mathlib.Algebra.Lie.Semisimple.Basic
 public import Mathlib.Algebra.Lie.Semisimple.Defs
 public import Mathlib.Algebra.Lie.Semisimple.Lemmas

--- a/Mathlib/Algebra/Lie/Ideal.lean
+++ b/Mathlib/Algebra/Lie/Ideal.lean
@@ -56,6 +56,10 @@ theorem lie_mem_left (I : LieIdeal R L) (x y : L) (h : x ∈ I) : ⁅x, y⁆ ∈
 def LieIdeal.toLieSubalgebra (I : LieIdeal R L) : LieSubalgebra R L :=
   { I.toSubmodule with lie_mem' := by intro x y _ hy; apply lie_mem_right; exact hy }
 
+@[simp] lemma LieIdeal.mem_toLieSubalgebra (I : LieIdeal R L) (x : L) :
+    x ∈ I.toLieSubalgebra ↔ x ∈ I :=
+  Iff.rfl
+
 instance : Coe (LieIdeal R L) (LieSubalgebra R L) :=
   ⟨LieIdeal.toLieSubalgebra R L⟩
 

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -34,6 +34,7 @@ namespace LieAlgebra
 The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie algebra homomorphism
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
+@[nolint unusedArguments]
 def SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
     (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
 
@@ -96,6 +97,7 @@ instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
       LieDerivation.coe_smul, Pi.smul_apply, Prod.smul_mk, Prod.mk.injEq, and_true]
     rw [← smul_add,← smul_sub]
 
+
 /-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
 def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
   toLinearMap := LinearMap.inl R H G
@@ -103,6 +105,7 @@ def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
     intros x y
     unfold SemiDirectSum
     simp [Bracket.bracket]
+
 
 /-- The canonical projection from the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
 def projection : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -35,7 +35,7 @@ The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie 
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
 def SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
-    (G : Type*) [LieRing G] [LieAlgebra R G] (_ψ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
+    (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
 
 @[inherit_doc]
 notation:35 H " ⋊⁅" ψ:35 "⁆ " G:35 => SemiDirectSum H G ψ
@@ -96,7 +96,7 @@ instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
       LieDerivation.coe_smul, Pi.smul_apply, Prod.smul_mk, Prod.mk.injEq, and_true]
     rw [← smul_add,← smul_sub]
 
-
+/-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
 def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
   toLinearMap := LinearMap.inl R H G
   map_lie' := by
@@ -104,7 +104,7 @@ def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
     unfold SemiDirectSum
     simp [Bracket.bracket]
 
-
+/-- The canonical projection from the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
 def projection : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
   toLinearMap := LinearMap.snd R H G
   map_lie' := by

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -35,10 +35,11 @@ The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie 
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
 def SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
-(G : Type*) [LieRing G] [LieAlgebra R G] (_ψ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
+    (G : Type*) [LieRing G] [LieAlgebra R G] (_ψ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
 
 @[inherit_doc]
-notation:35 H " ⋊[" φ:35 "] " G:35 => SemiDirectSum H G φ
+notation:35 H " ⋊⁅" ψ:35 "⁆ " G:35 => SemiDirectSum H G ψ
+
 
 namespace SemiDirectSum
 
@@ -48,18 +49,21 @@ variable {H : Type*} [LieRing H] [LieAlgebra R H]
 variable (ψ : G →ₗ⁅R⁆ (LieDerivation R H H))
 
 
-instance : AddCommGroup (SemiDirectSum H G ψ) := by
+instance : AddCommGroup (H ⋊⁅ψ⁆ G) := by
   unfold SemiDirectSum
   infer_instance
 
-instance : Module R (SemiDirectSum H G ψ) := by
+
+instance : Module R (H ⋊⁅ψ⁆ G) := by
   unfold SemiDirectSum
   infer_instance
 
-instance : Bracket (SemiDirectSum H G ψ) (SemiDirectSum H G ψ) where
-  bracket x y := (⁅x.1, y.1⁆ + (ψ x.2) y.1 - (ψ y.2) x.1 , ⁅x.2, y.2⁆)
 
-instance : LieRing (SemiDirectSum H G ψ) where
+instance : Bracket (H ⋊⁅ψ⁆ G) (H ⋊⁅ψ⁆ G) where
+  bracket x y := (⁅x.1, y.1⁆ + (ψ x.2) y.1 - (ψ y.2) x.1, ⁅x.2, y.2⁆)
+
+
+instance : LieRing (H ⋊⁅ψ⁆ G) where
   add_lie _ _ _ := by
     unfold SemiDirectSum
     simp [Bracket.bracket]
@@ -84,7 +88,8 @@ instance : LieRing (SemiDirectSum H G ψ) where
     rw [←lie_skew]
     abel_nf
 
-instance : LieAlgebra R (SemiDirectSum H G ψ) where
+
+instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
   lie_smul r x y := by
     unfold SemiDirectSum
     simp only [Bracket.bracket, Prod.smul_fst, lie_smul, map_smul, Prod.smul_snd,
@@ -92,7 +97,7 @@ instance : LieAlgebra R (SemiDirectSum H G ψ) where
     rw [← smul_add,← smul_sub]
 
 
-def inclusion : H →ₗ⁅R⁆ (SemiDirectSum H G ψ) where
+def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
   toLinearMap := LinearMap.inl R H G
   map_lie' := by
     intros x y
@@ -100,7 +105,7 @@ def inclusion : H →ₗ⁅R⁆ (SemiDirectSum H G ψ) where
     simp [Bracket.bracket]
 
 
-def projection : (SemiDirectSum H G ψ) →ₗ⁅R⁆ G where
+def projection : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
   toLinearMap := LinearMap.snd R H G
   map_lie' := by
     unfold SemiDirectSum

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Leonid Ryvkin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonid Ryvkin
+-/
+module
+
+public import Mathlib.Algebra.Lie.Derivation.Basic
+public import Mathlib.Algebra.Lie.Extension
+
+/-!
+# Semi-direct products
+
+This file defines the semi-direct sum of Lie algebras. These are the infinitesimal counterpart of
+semidirect products of (Lie) groups. Given two Lie algebras `H` and `G` over `R` as well as a Lie
+algebra homomorphism  `ψ : G → LieDerivation  R H H`, the underlying set of the semidirect sum is
+`H × G`, however the bracket is twisted by `ψ`. In this file we show that `SemiDirectSum H G ψ` is
+itself a Lie algebra and that it fits into an exact sequence `H → (SemiDirectSum H G ψ) → G`, i.e.
+forms an extension of `G`.
+
+
+## References
+
+* https://en.wikipedia.org/wiki/Lie_algebra_extension#By_semidirect_sum
+
+-/
+
+
+@[expose] public section
+
+namespace LieAlgebra
+
+/--
+The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie algebra homomorphism
+`ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
+-/
+def SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
+(G : Type*) [LieRing G] [LieAlgebra R G] (_ψ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
+
+@[inherit_doc]
+notation:35 H " ⋊[" φ:35 "] " G:35 => SemiDirectSum H G φ
+
+namespace SemiDirectSum
+
+variable {R : Type*} [CommRing R]
+variable {G : Type*} [LieRing G] [LieAlgebra R G]
+variable {H : Type*} [LieRing H] [LieAlgebra R H]
+variable (ψ : G →ₗ⁅R⁆ (LieDerivation R H H))
+
+
+instance : AddCommGroup (SemiDirectSum H G ψ) := by
+  unfold SemiDirectSum
+  infer_instance
+
+instance : Module R (SemiDirectSum H G ψ) := by
+  unfold SemiDirectSum
+  infer_instance
+
+instance : Bracket (SemiDirectSum H G ψ) (SemiDirectSum H G ψ) where
+  bracket x y := (⁅x.1, y.1⁆ + (ψ x.2) y.1 - (ψ y.2) x.1 , ⁅x.2, y.2⁆)
+
+instance : LieRing (SemiDirectSum H G ψ) where
+  add_lie _ _ _ := by
+    unfold SemiDirectSum
+    simp [Bracket.bracket]
+    grind
+  lie_add _ _ _:= by
+    unfold SemiDirectSum
+    simp [Bracket.bracket]
+    grind
+  lie_self _ := by
+    unfold SemiDirectSum
+    simp [Bracket.bracket]
+  leibniz_lie x y z:= by
+    unfold SemiDirectSum
+    simp only [Bracket.bracket, lie_sub, lie_add, map_sub, map_add, LieDerivation.apply_lie_eq_sub,
+      LieHom.map_lie, LieDerivation.coeFn_coe, Module.End.smul_def, LieDerivation.mk_coe,
+      LinearMap.coe_mk, AddHom.coe_mk, sub_lie, add_lie, lie_lie, Prod.mk_add_mk, sub_add_cancel,
+      Prod.mk.injEq, and_true]
+    apply sub_eq_zero.mp
+    abel_nf
+    rw [←lie_skew]
+    abel_nf
+    rw [←lie_skew]
+    abel_nf
+
+instance : LieAlgebra R (SemiDirectSum H G ψ) where
+  lie_smul r x y := by
+    unfold SemiDirectSum
+    simp only [Bracket.bracket, Prod.smul_fst, lie_smul, map_smul, Prod.smul_snd,
+      LieDerivation.coe_smul, Pi.smul_apply, Prod.smul_mk, Prod.mk.injEq, and_true]
+    rw [← smul_add,← smul_sub]
+
+
+def inclusion : H →ₗ⁅R⁆ (SemiDirectSum H G ψ) where
+  toLinearMap := LinearMap.inl R H G
+  map_lie' := by
+    intros x y
+    unfold SemiDirectSum
+    simp [Bracket.bracket]
+
+
+def projection : (SemiDirectSum H G ψ) →ₗ⁅R⁆ G where
+  toLinearMap := LinearMap.snd R H G
+  map_lie' := by
+    unfold SemiDirectSum
+    intros x y
+    simp [Bracket.bracket]
+
+
+instance : LieAlgebra.IsExtension (inclusion ψ) (projection ψ)  where
+  ker_eq_bot := by
+    simp only [LieHom.ker_eq_bot]
+    exact LinearMap.inl_injective
+  range_eq_top := by
+    simp only [LieHom.range_eq_top]
+    exact LinearMap.snd_surjective
+  exact := by
+    refine (LieHom.range_eq_ker_iff (inclusion ψ) (projection ψ)).mpr ?_
+    refine Function.Exact.of_comp_of_mem_range rfl ?_
+    refine fun x a ↦ ?_
+    use x.1
+    unfold inclusion
+    exact Prod.ext rfl (id (Eq.symm a))
+
+end SemiDirectSum
+
+end LieAlgebra
+
+end

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -136,23 +136,10 @@ lemma projr_inr_apply {x : G} : projr ψ (inr ψ x) = x := by simp
 lemma projr_surjective : Function.Surjective (projr ψ) :=
   fun x ↦ ⟨inr ψ x, by simp⟩
 
-instance : LieAlgebra.IsExtension (in_left ψ) (pr_right ψ) where
+instance : LieAlgebra.IsExtension (inl ψ) (projr ψ) where
   ker_eq_bot := by simp [LieHom.ker_eq_bot]
   range_eq_top := by simp [LieHom.range_eq_top]
-  exact := by
-    ext x
-    simp only [in_left, LieHom.mem_range, LieHom.coe_mk, LieIdeal.toLieSubalgebra, pr_right,
-      LieHom.ker_toSubmodule, LieSubalgebra.mem_mk_iff', LinearMap.mem_ker, LinearMap.coe_mk,
-      AddHom.coe_mk, Prod.snd_eq_iff]
-    constructor
-    case mp =>
-      intro hyp
-      obtain ⟨y, hy⟩ := hyp
-      simp [← hy]
-    case mpr =>
-      intro hyp
-      use (toProd x).1
-      simp [← hyp]
+  exact := by ext ⟨x, y⟩; aesop
 
 end SemiDirectSum
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -90,29 +90,10 @@ lemma toProd_lie (x y : H ⋊⁅ψ⁆ G) :
   simp [lie_def]
 
 instance : LieRing (H ⋊⁅ψ⁆ G) where
-  add_lie _ _ _ := by
-    unfold SemiDirectSum
-    simp [Bracket.bracket]
-    grind
-  lie_add _ _ _:= by
-    unfold SemiDirectSum
-    simp [Bracket.bracket]
-    grind
-  lie_self _ := by
-    unfold SemiDirectSum
-    simp [Bracket.bracket]
-  leibniz_lie x y z:= by
-    unfold SemiDirectSum
-    simp only [Bracket.bracket, lie_sub, lie_add, map_sub, map_add, LieDerivation.apply_lie_eq_sub,
-      LieHom.map_lie, LieDerivation.coeFn_coe, Module.End.smul_def, LieDerivation.mk_coe,
-      LinearMap.coe_mk, AddHom.coe_mk, sub_lie, add_lie, lie_lie, Prod.mk_add_mk, sub_add_cancel,
-      Prod.mk.injEq, and_true]
-    apply sub_eq_zero.mp
-    abel_nf
-    rw [←lie_skew]
-    abel_nf
-    rw [←lie_skew]
-    abel_nf
+  add_lie _ _ _ := toProd.injective <| by simp; abel
+  lie_add _ _ _:= toProd.injective <| by simp; abel
+  lie_self _ := toProd.injective <| by simp
+  leibniz_lie x y z:= toProd.injective <| by simp; grind [lie_skew]
 
 
 instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -101,11 +101,11 @@ instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
     simp [toProd_smul, smul_sub, smul_add]
 
 /-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
-def in_left : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
-  toFun x := toProd.symm (x ,0)
+def inl : H →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
+  toFun x := toProd.symm (x, 0)
   map_add' _ _ := toProd.injective <| by simp
   map_smul' _ _ := toProd.injective <| by simp
-  map_lie' {_ _}:= toProd.injective <| by simp
+  map_lie' := toProd.injective <| by simp
 
 @[simp]
 lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -73,62 +73,60 @@ instance : Module R (H ⋊⁅ψ⁆ G) := toProd.module R
 @[simp] lemma toProd_smul (t : R) (x : H ⋊⁅ψ⁆ G) : (t • x).toProd = t • x.toProd := rfl
 
 instance : Bracket (H ⋊⁅ψ⁆ G) (H ⋊⁅ψ⁆ G) where
-  bracket x y := toProd.symm
-    (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
-     ⁅x.toProd.2, y.toProd.2⁆)
-
-lemma lie_def (x y : H ⋊⁅ψ⁆ G) :
-    ⁅x, y⁆ = toProd.symm
-      (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
-       ⁅x.toProd.2, y.toProd.2⁆) :=
-  rfl
+  bracket x y :=  ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
 
 @[simp]
+lemma lie_def (x y : H ⋊⁅ψ⁆ G) :
+    ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
+  rfl
+
+@[simp] -- still needed?
 lemma toProd_lie (x y : H ⋊⁅ψ⁆ G) :
     toProd ⁅x, y⁆ =
-      (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
-       ⁅x.toProd.2, y.toProd.2⁆) := by
-  simp [lie_def]
+      (⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left,
+       ⁅x.right, y.right⁆) := by simp [toProd, lie_def]
 
-lemma zero_eq_mk : (0 : H ⋊⁅ψ⁆ G) = ⟨0, 0⟩ := rfl
-lemma add_eq_mk (x y : H ⋊⁅ψ⁆ G) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
-lemma sub_eq_mk (x y : H ⋊⁅ψ⁆ G) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl
-lemma neg_eq_mk (x : H ⋊⁅ψ⁆ G) : -x = ⟨-x.left, -x.right⟩ := rfl
-lemma smul_eq_mk (t : R) (x : H ⋊⁅ψ⁆ G) : t • x = ⟨t • x.left, t • x.right⟩ := rfl
-lemma lie_eq_mk (x y : H ⋊⁅ψ⁆ G) :
+@[simp] lemma zero_eq_mk : (0 : H ⋊⁅ψ⁆ G) = ⟨0, 0⟩ := rfl
+@[simp] lemma add_eq_mk (x y : H ⋊⁅ψ⁆ G) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
+@[simp] lemma sub_eq_mk (x y : H ⋊⁅ψ⁆ G) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl
+@[simp] lemma neg_eq_mk (x : H ⋊⁅ψ⁆ G) : -x = ⟨-x.left, -x.right⟩ := rfl
+@[simp] lemma smul_eq_mk (t : R) (x : H ⋊⁅ψ⁆ G) : t • x = ⟨t • x.left, t • x.right⟩ := rfl
+@[simp] lemma lie_eq_mk (x y : H ⋊⁅ψ⁆ G) :
     ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
   rfl
 
 instance : LieRing (H ⋊⁅ψ⁆ G) where
-  add_lie _ _ _ := toProd.injective <| by simp; abel
-  lie_add _ _ _:= toProd.injective <| by simp; abel
-  lie_self _ := toProd.injective <| by simp
-  leibniz_lie _ _ _ := toProd.injective <| by simp; grind [lie_skew]
+  add_lie _ _ _ := by simp; abel
+  lie_add _ _ _:= by simp; abel
+  lie_self _ := by simp
+  leibniz_lie _ _ _ := by simp; grind [lie_skew]
 
 instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
-  lie_smul _ _ _ := toProd.injective <| by
-    simp [toProd_smul, smul_sub, smul_add]
+  lie_smul _ _ _ := by simp [smul_sub, smul_add]
 
 /-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
 def inl : H →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
-  toFun x := toProd.symm (x, 0)
-  map_add' _ _ := toProd.injective <| by simp
-  map_smul' _ _ := toProd.injective <| by simp
-  map_lie' := toProd.injective <| by simp
+  toFun x := ⟨x, 0⟩
+  map_add' _ _ := by simp
+  map_smul' _ _ := by simp
+  map_lie' := by simp
 
 /-- The canonical inclusion of G into the semi-direct sum H ⋊⁅ψ⁆ G. -/
 def inr : G →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
-  toFun x := toProd.symm (0, x)
-  map_add' _ _ := toProd.injective <| by simp
-  map_smul' _ _ := toProd.injective <| by simp
-  map_lie' := toProd.injective <| by simp
+  toFun x := ⟨0, x⟩
+  map_add' _ _ := by simp
+  map_smul' _ _ := by simp
+  map_lie' := by simp
+
+@[simp] lemma inl_eq_mk (x : H) : inl ψ x = ⟨x, 0⟩ := rfl
+@[simp] lemma inr_eq_mk (x : G) : inr ψ x = ⟨0, x⟩ := rfl
 
 @[simp]
 lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]
 
 /-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
 def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
-  toFun x := x.toProd.snd
+  toFun x := x.right
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
   map_lie' := by simp
@@ -136,16 +134,13 @@ def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
 /-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G.
 It is not, in general, a Lie algebra homomorphism, just a linear map. -/
 def projl : H ⋊⁅ψ⁆ G →ₗ[R] H where
-  toFun x := x.toProd.fst
+  toFun x := x.left
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
 
-
-
-@[simp] lemma inl_eq_mk (x : H) : inl ψ x = ⟨x, 0⟩ := rfl
-@[simp] lemma inr_eq_mk (x : G) : inr ψ x = ⟨0, x⟩ := rfl
-
 @[simp] lemma projr_mk (x : H ⋊⁅ψ⁆ G) : projr ψ x = x.right := rfl
+@[simp] lemma projl_mk (x : H ⋊⁅ψ⁆ G) : projl ψ x = x.left := rfl
+
 lemma projr_inl_apply {x : H} : projr ψ (inl ψ x) = 0 := by simp
 lemma projr_inr_apply {x : G} : projr ψ (inr ψ x) = x := by simp
 

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -31,10 +31,9 @@ forms an extension of `G`.
 namespace LieAlgebra
 
 /--
-The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie algebra homomorphism
+The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to a Lie algebra homomorphism
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
-@[nolint unusedArguments]
 structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
     (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ LieDerivation R H H) where
   left : H
@@ -95,50 +94,50 @@ instance : LieRing (H ⋊⁅ψ⁆ G) where
   lie_self _ := toProd.injective <| by simp
   leibniz_lie x y z:= toProd.injective <| by simp; grind [lie_skew]
 
-
 instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
-  lie_smul r x y := by
-    unfold SemiDirectSum
-    simp only [Bracket.bracket, Prod.smul_fst, lie_smul, map_smul, Prod.smul_snd,
-      LieDerivation.coe_smul, Pi.smul_apply, Prod.smul_mk, Prod.mk.injEq, and_true]
-    rw [← smul_add,← smul_sub]
-
+  lie_smul r x y:= toProd.injective <| by
+    simp [toProd_smul, smul_sub, smul_add]
 
 /-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
-def inclusion : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
-  toLinearMap := LinearMap.inl R H G
-  map_lie' := by
-    intros x y
-    unfold SemiDirectSum
-    simp [Bracket.bracket]
+def in_left : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
+  toFun x := toProd.symm (x ,0)
+  map_add' _ _ := toProd.injective <| by simp
+  map_smul' _ _ := toProd.injective <| by simp
+  map_lie' {_ _}:= toProd.injective <| by simp
 
+@[simp]
+lemma in_left_injective :  (Function.Injective (in_left ψ)) := by intro _ _; simp [in_left]
 
-/-- The canonical projection from the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
-def projection : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
-  toLinearMap := LinearMap.snd R H G
-  map_lie' := by
-    unfold SemiDirectSum
-    intros x y
-    simp [Bracket.bracket]
+def pr_right : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
+  toFun x := (toProd x).2
+  map_add' _ _ := Prod.snd_eq_iff.mpr rfl
+  map_smul' _ _ := Prod.snd_eq_iff.mpr rfl
+  map_lie' {_ _}:= Prod.snd_eq_iff.mpr rfl
 
+@[simp]
+lemma pr_right_surjective :  (Function.Surjective (pr_right ψ)) := by
+  intro g
+  use (toProd.symm (0,g))
+  simp [pr_right]
 
-instance : LieAlgebra.IsExtension (inclusion ψ) (projection ψ)  where
-  ker_eq_bot := by
-    simp only [LieHom.ker_eq_bot]
-    exact LinearMap.inl_injective
-  range_eq_top := by
-    simp only [LieHom.range_eq_top]
-    exact LinearMap.snd_surjective
+instance : LieAlgebra.IsExtension (in_left ψ) (pr_right ψ) where
+  ker_eq_bot := by simp [LieHom.ker_eq_bot]
+  range_eq_top := by simp [LieHom.range_eq_top]
   exact := by
-    refine (LieHom.range_eq_ker_iff (inclusion ψ) (projection ψ)).mpr ?_
-    refine Function.Exact.of_comp_of_mem_range rfl ?_
-    refine fun x a ↦ ?_
-    use x.1
-    unfold inclusion
-    exact Prod.ext rfl (id (Eq.symm a))
+    ext x
+    simp only [in_left, LieHom.mem_range, LieHom.coe_mk, LieIdeal.toLieSubalgebra, pr_right,
+      LieHom.ker_toSubmodule, LieSubalgebra.mem_mk_iff', LinearMap.mem_ker, LinearMap.coe_mk,
+      AddHom.coe_mk, Prod.snd_eq_iff]
+    constructor
+    case mp =>
+      intro hyp
+      obtain ⟨y, hy⟩ := hyp
+      simp [← hy]
+    case mpr =>
+      intro hyp
+      use (toProd x).1
+      simp [← hyp]
 
 end SemiDirectSum
-
 end LieAlgebra
-
 end

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -94,10 +94,10 @@ instance : LieRing (H ⋊⁅ψ⁆ G) where
   add_lie _ _ _ := toProd.injective <| by simp; abel
   lie_add _ _ _:= toProd.injective <| by simp; abel
   lie_self _ := toProd.injective <| by simp
-  leibniz_lie x y z:= toProd.injective <| by simp; grind [lie_skew]
+  leibniz_lie _ _ _ := toProd.injective <| by simp; grind [lie_skew]
 
 instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
-  lie_smul r x y:= toProd.injective <| by
+  lie_smul _ _ _ := toProd.injective <| by
     simp [toProd_smul, smul_sub, smul_add]
 
 /-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -12,11 +12,11 @@ public import Mathlib.Algebra.Lie.Extension
 # Semi-direct products
 
 This file defines the semi-direct sum of Lie algebras. These are the infinitesimal counterpart of
-semidirect products of (Lie) groups. Given two Lie algebras `H` and `G` over `R` as well as a Lie
-algebra homomorphism  `ψ : G → LieDerivation  R H H`, the underlying set of the semidirect sum is
-`H × G`, however the bracket is twisted by `ψ`. In this file we show that `SemiDirectSum H G ψ` is
-itself a Lie algebra and that it fits into an exact sequence `H → (SemiDirectSum H G ψ) → G`, i.e.
-forms an extension of `G`.
+semidirect products of (Lie) groups. Given two Lie algebras `K` and `L` over `R` as well as a Lie
+algebra homomorphism  `ψ : L → LieDerivation  R K K`, the underlying set of the semidirect sum is
+`K × L`, however the bracket is twisted by `ψ`. In this file we show that `SemiDirectSum K L ψ` is
+itself a Lie algebra and that it fits into an exact sequence `H → (SemiDirectSum K L ψ) → L`, i.e.
+forms an extension of `L`.
 
 
 ## References
@@ -31,118 +31,110 @@ forms an extension of `G`.
 namespace LieAlgebra
 
 /--
-The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to a Lie algebra homomorphism
-`ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
+The semi-direct sum of two Lie algebras `K` and `L` over `R`, relative to a Lie algebra homomorphism
+`ψ: L → Liederivation R K K`. As a set it just `K × L`, however the Lie bracket is twisted by `ψ`.
 -/
-@[ext] structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
-    (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ LieDerivation R H H) where
-  /-- The element of H -/
-  left : H
-  /-- The element of G -/
-  right : G
+@[ext] structure SemiDirectSum {R : Type*} [CommRing R] (K : Type*) [LieRing K] [LieAlgebra R K]
+    (L : Type*) [LieRing L] [LieAlgebra R L] (_ : L →ₗ⁅R⁆ LieDerivation R K K) where
+  /-- The element of K -/
+  left : K
+  /-- The element of L -/
+  right : L
 
 @[inherit_doc]
-notation:35 H " ⋊⁅" ψ:35 "⁆ " G:35 => SemiDirectSum H G ψ
+notation:35 K " ⋊⁅" ψ:35 "⁆ " L:35 => SemiDirectSum K L ψ
 
 
 namespace SemiDirectSum
 
 variable {R : Type*} [CommRing R]
-variable {G : Type*} [LieRing G] [LieAlgebra R G]
-variable {H : Type*} [LieRing H] [LieAlgebra R H]
-variable (ψ : G →ₗ⁅R⁆ LieDerivation R H H)
+variable {K : Type*} [LieRing K] [LieAlgebra R K]
+variable {L : Type*} [LieRing L] [LieAlgebra R L]
+variable (ψ : L →ₗ⁅R⁆ LieDerivation R K K)
 
 variable {ψ} in
 /-- As raw types, the semidirect product is just a product. -/
-def toProd : H ⋊⁅ψ⁆ G ≃ H × G where
+def toProd : K ⋊⁅ψ⁆ L ≃ K × L where
   toFun x := ⟨x.left, x.right⟩
   invFun x := ⟨x.fst, x.snd⟩
   left_inv _ := rfl
   right_inv _ := rfl
 
+instance : AddCommGroup (K ⋊⁅ψ⁆ L) := toProd.addCommGroup
 
-instance : AddCommGroup (H ⋊⁅ψ⁆ G) := toProd.addCommGroup
+instance : Module R (K ⋊⁅ψ⁆ L) := toProd.module R
 
-@[simp] lemma toProd_zero : (0 : H ⋊⁅ψ⁆ G).toProd = 0 := rfl
-@[simp] lemma toProd_add (x y : H ⋊⁅ψ⁆ G) : (x + y).toProd = x.toProd + y.toProd := rfl
-@[simp] lemma toProd_sub (x y : H ⋊⁅ψ⁆ G) : (x - y).toProd = x.toProd - y.toProd := rfl
-@[simp] lemma toProd_neg (x : H ⋊⁅ψ⁆ G) : (-x).toProd = -x.toProd := rfl
+/-- `LieAlgebra.SemiDirectSum.toProd` as a linear equivalence. -/
+def toProdl : (K ⋊⁅ψ⁆ L) ≃ₗ[R] K × L :=
+  { __ := toProd
+    map_add' _ _ := rfl
+    map_smul' _ _ := rfl }
 
-instance : Module R (H ⋊⁅ψ⁆ G) := toProd.module R
-
-@[simp] lemma toProd_smul (t : R) (x : H ⋊⁅ψ⁆ G) : (t • x).toProd = t • x.toProd := rfl
-
-instance : Bracket (H ⋊⁅ψ⁆ G) (H ⋊⁅ψ⁆ G) where
+instance : Bracket (K ⋊⁅ψ⁆ L) (K ⋊⁅ψ⁆ L) where
   bracket x y :=  ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
 
 @[simp]
-lemma lie_def (x y : H ⋊⁅ψ⁆ G) :
+lemma lie_def (x y : K ⋊⁅ψ⁆ L) :
     ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
   rfl
 
-@[simp] -- still needed?
-lemma toProd_lie (x y : H ⋊⁅ψ⁆ G) :
-    toProd ⁅x, y⁆ =
-      (⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left,
-       ⁅x.right, y.right⁆) := by simp [toProd, lie_def]
-
-@[simp] lemma zero_eq_mk : (0 : H ⋊⁅ψ⁆ G) = ⟨0, 0⟩ := rfl
-@[simp] lemma add_eq_mk (x y : H ⋊⁅ψ⁆ G) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
-@[simp] lemma sub_eq_mk (x y : H ⋊⁅ψ⁆ G) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl
-@[simp] lemma neg_eq_mk (x : H ⋊⁅ψ⁆ G) : -x = ⟨-x.left, -x.right⟩ := rfl
-@[simp] lemma smul_eq_mk (t : R) (x : H ⋊⁅ψ⁆ G) : t • x = ⟨t • x.left, t • x.right⟩ := rfl
-@[simp] lemma lie_eq_mk (x y : H ⋊⁅ψ⁆ G) :
+@[simp] lemma zero_eq_mk : (0 : K ⋊⁅ψ⁆ L) = ⟨0, 0⟩ := rfl
+@[simp] lemma add_eq_mk (x y : K ⋊⁅ψ⁆ L) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
+@[simp] lemma sub_eq_mk (x y : K ⋊⁅ψ⁆ L) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl
+@[simp] lemma neg_eq_mk (x : K ⋊⁅ψ⁆ L) : -x = ⟨-x.left, -x.right⟩ := rfl
+@[simp] lemma smul_eq_mk (t : R) (x : K ⋊⁅ψ⁆ L) : t • x = ⟨t • x.left, t • x.right⟩ := rfl
+@[simp] lemma lie_eq_mk (x y : K ⋊⁅ψ⁆ L) :
     ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
   rfl
 
-instance : LieRing (H ⋊⁅ψ⁆ G) where
+instance : LieRing (K ⋊⁅ψ⁆ L) where
   add_lie _ _ _ := by simp; abel
   lie_add _ _ _:= by simp; abel
   lie_self _ := by simp
   leibniz_lie _ _ _ := by simp; grind [lie_skew]
 
-instance : LieAlgebra R (H ⋊⁅ψ⁆ G) where
+instance : LieAlgebra R (K ⋊⁅ψ⁆ L) where
   lie_smul _ _ _ := by simp [smul_sub, smul_add]
 
-/-- The canonical inclusion of H into the semi-direct sum H ⋊⁅ψ⁆ G. -/
-def inl : H →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
+/-- The canonical inclusion of K into the semi-direct sum K ⋊⁅ψ⁆ G. -/
+def inl : K →ₗ⁅R⁆ K ⋊⁅ψ⁆ L where
   toFun x := ⟨x, 0⟩
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
   map_lie' := by simp
 
-/-- The canonical inclusion of G into the semi-direct sum H ⋊⁅ψ⁆ G. -/
-def inr : G →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
+/-- The canonical inclusion of L into the semi-direct sum K ⋊⁅ψ⁆ G. -/
+def inr : L →ₗ⁅R⁆ K ⋊⁅ψ⁆ L where
   toFun x := ⟨0, x⟩
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
   map_lie' := by simp
 
-@[simp] lemma inl_eq_mk (x : H) : inl ψ x = ⟨x, 0⟩ := rfl
-@[simp] lemma inr_eq_mk (x : G) : inr ψ x = ⟨0, x⟩ := rfl
+@[simp] lemma inl_eq_mk (x : K) : inl ψ x = ⟨x, 0⟩ := rfl
+@[simp] lemma inr_eq_mk (x : L) : inr ψ x = ⟨0, x⟩ := rfl
 
 @[simp]
 lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]
 
-/-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
-def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
+/-- The canonical projection of the semi-direct sum K ⋊⁅ψ⁆ L to G. -/
+def projr : K ⋊⁅ψ⁆ L →ₗ⁅R⁆ L where
   toFun x := x.right
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
   map_lie' := by simp
 
-/-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G.
+/-- The canonical projection of the semi-direct sum K ⋊⁅ψ⁆ L to G.
 It is not, in general, a Lie algebra homomorphism, just a linear map. -/
-def projl : H ⋊⁅ψ⁆ G →ₗ[R] H where
+def projl : K ⋊⁅ψ⁆ L →ₗ[R] K where
   toFun x := x.left
   map_add' _ _ := by simp
   map_smul' _ _ := by simp
 
-@[simp] lemma projr_mk (x : H ⋊⁅ψ⁆ G) : projr ψ x = x.right := rfl
-@[simp] lemma projl_mk (x : H ⋊⁅ψ⁆ G) : projl ψ x = x.left := rfl
+@[simp] lemma projr_mk (x : K ⋊⁅ψ⁆ L) : projr ψ x = x.right := rfl
+@[simp] lemma projl_mk (x : K ⋊⁅ψ⁆ L) : projl ψ x = x.left := rfl
 
-lemma projr_inl_apply {x : H} : projr ψ (inl ψ x) = 0 := by simp
-lemma projr_inr_apply {x : G} : projr ψ (inr ψ x) = x := by simp
+lemma projr_inl_apply {x : K} : projr ψ (inl ψ x) = 0 := by simp
+lemma projr_inr_apply {x : L} : projr ψ (inr ψ x) = x := by simp
 
 @[simp]
 lemma projr_surjective : Function.Surjective (projr ψ) :=

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -116,6 +116,13 @@ def inl : H →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
   map_smul' _ _ := toProd.injective <| by simp
   map_lie' := toProd.injective <| by simp
 
+/-- The canonical inclusion of G into the semi-direct sum H ⋊⁅ψ⁆ G. -/
+def inr : G →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
+  toFun x := toProd.symm (0, x)
+  map_add' _ _ := toProd.injective <| by simp
+  map_smul' _ _ := toProd.injective <| by simp
+  map_lie' := toProd.injective <| by simp
+
 @[simp]
 lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]
 
@@ -126,8 +133,18 @@ def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
   map_smul' _ _ := by simp
   map_lie' := by simp
 
+/-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G.
+It is not, in general, a Lie algebra homomorphism, just a linear map. -/
+def projl : H ⋊⁅ψ⁆ G →ₗ[R] H where
+  toFun x := x.toProd.fst
+  map_add' _ _ := by simp
+  map_smul' _ _ := by simp
+
+
+
 @[simp] lemma inl_eq_mk (x : H) : inl ψ x = ⟨x, 0⟩ := rfl
 @[simp] lemma inr_eq_mk (x : G) : inr ψ x = ⟨0, x⟩ := rfl
+
 @[simp] lemma projr_mk (x : H ⋊⁅ψ⁆ G) : projr ψ x = x.right := rfl
 lemma projr_inl_apply {x : H} : projr ψ (inl ψ x) = 0 := by simp
 lemma projr_inr_apply {x : G} : projr ψ (inr ψ x) = x := by simp

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -50,7 +50,7 @@ namespace SemiDirectSum
 variable {R : Type*} [CommRing R]
 variable {G : Type*} [LieRing G] [LieAlgebra R G]
 variable {H : Type*} [LieRing H] [LieAlgebra R H]
-variable (ψ : G →ₗ⁅R⁆ (LieDerivation R H H))
+variable (ψ : G →ₗ⁅R⁆ LieDerivation R H H)
 
 variable {ψ} in
 /-- As raw types, the semidirect product is just a product. -/

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -35,8 +35,10 @@ The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to A Lie 
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
 @[nolint unusedArguments]
-def SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
-    (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ (LieDerivation R H H)) := H × G
+structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
+    (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ LieDerivation R H H) where
+  left : H
+  right : G
 
 @[inherit_doc]
 notation:35 H " ⋊⁅" ψ:35 "⁆ " G:35 => SemiDirectSum H G ψ

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -73,11 +73,6 @@ def toProdl : (K ⋊⁅ψ⁆ L) ≃ₗ[R] K × L :=
 instance : Bracket (K ⋊⁅ψ⁆ L) (K ⋊⁅ψ⁆ L) where
   bracket x y :=  ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
 
-@[simp]
-lemma lie_def (x y : K ⋊⁅ψ⁆ L) :
-    ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
-  rfl
-
 @[simp] lemma zero_eq_mk : (0 : K ⋊⁅ψ⁆ L) = ⟨0, 0⟩ := rfl
 @[simp] lemma add_eq_mk (x y : K ⋊⁅ψ⁆ L) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
 @[simp] lemma sub_eq_mk (x y : K ⋊⁅ψ⁆ L) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -51,6 +51,14 @@ variable {G : Type*} [LieRing G] [LieAlgebra R G]
 variable {H : Type*} [LieRing H] [LieAlgebra R H]
 variable (ψ : G →ₗ⁅R⁆ (LieDerivation R H H))
 
+variable {ψ} in
+/-- As raw types, the semidirect product is just a product. -/
+def toProd : H ⋊⁅ψ⁆ G ≃ H × G where
+  toFun x := ⟨x.left, x.right⟩
+  invFun x := ⟨x.fst, x.snd⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
 
 instance : AddCommGroup (H ⋊⁅ψ⁆ G) := by
   unfold SemiDirectSum

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -126,11 +126,15 @@ def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
   map_smul' _ _ := by simp
   map_lie' := by simp
 
+@[simp] lemma inl_eq_mk (x : H) : inl ψ x = ⟨x, 0⟩ := rfl
+@[simp] lemma inr_eq_mk (x : G) : inr ψ x = ⟨0, x⟩ := rfl
+@[simp] lemma projr_mk (x : H ⋊⁅ψ⁆ G) : projr ψ x = x.right := rfl
+lemma projr_inl_apply {x : H} : projr ψ (inl ψ x) = 0 := by simp
+lemma projr_inr_apply {x : G} : projr ψ (inr ψ x) = x := by simp
+
 @[simp]
-lemma pr_right_surjective :  (Function.Surjective (pr_right ψ)) := by
-  intro g
-  use (toProd.symm (0,g))
-  simp [pr_right]
+lemma projr_surjective : Function.Surjective (projr ψ) :=
+  fun x ↦ ⟨inr ψ x, by simp⟩
 
 instance : LieAlgebra.IsExtension (in_left ψ) (pr_right ψ) where
   ker_eq_bot := by simp [LieHom.ker_eq_bot]

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -67,14 +67,27 @@ instance : AddCommGroup (H ⋊⁅ψ⁆ G) := toProd.addCommGroup
 @[simp] lemma toProd_sub (x y : H ⋊⁅ψ⁆ G) : (x - y).toProd = x.toProd - y.toProd := rfl
 @[simp] lemma toProd_neg (x : H ⋊⁅ψ⁆ G) : (-x).toProd = -x.toProd := rfl
 
-instance : Module R (H ⋊⁅ψ⁆ G) := by
-  unfold SemiDirectSum
-  infer_instance
+instance : Module R (H ⋊⁅ψ⁆ G) := toProd.module R
 
+@[simp] lemma toProd_smul (t : R) (x : H ⋊⁅ψ⁆ G) : (t • x).toProd = t • x.toProd := rfl
 
 instance : Bracket (H ⋊⁅ψ⁆ G) (H ⋊⁅ψ⁆ G) where
-  bracket x y := (⁅x.1, y.1⁆ + (ψ x.2) y.1 - (ψ y.2) x.1, ⁅x.2, y.2⁆)
+  bracket x y := toProd.symm
+    (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
+     ⁅x.toProd.2, y.toProd.2⁆)
 
+lemma lie_def (x y : H ⋊⁅ψ⁆ G) :
+    ⁅x, y⁆ = toProd.symm
+      (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
+       ⁅x.toProd.2, y.toProd.2⁆) :=
+  rfl
+
+@[simp]
+lemma toProd_lie (x y : H ⋊⁅ψ⁆ G) :
+    toProd ⁅x, y⁆ =
+      (⁅x.toProd.1, y.toProd.1⁆ + ψ x.toProd.2 y.toProd.1 - ψ y.toProd.2 x.toProd.1,
+       ⁅x.toProd.2, y.toProd.2⁆) := by
+  simp [lie_def]
 
 instance : LieRing (H ⋊⁅ψ⁆ G) where
   add_lie _ _ _ := by

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -90,6 +90,15 @@ lemma toProd_lie (x y : H ⋊⁅ψ⁆ G) :
        ⁅x.toProd.2, y.toProd.2⁆) := by
   simp [lie_def]
 
+lemma zero_eq_mk : (0 : H ⋊⁅ψ⁆ G) = ⟨0, 0⟩ := rfl
+lemma add_eq_mk (x y : H ⋊⁅ψ⁆ G) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
+lemma sub_eq_mk (x y : H ⋊⁅ψ⁆ G) : x - y = ⟨x.left - y.left, x.right - y.right⟩ := rfl
+lemma neg_eq_mk (x : H ⋊⁅ψ⁆ G) : -x = ⟨-x.left, -x.right⟩ := rfl
+lemma smul_eq_mk (t : R) (x : H ⋊⁅ψ⁆ G) : t • x = ⟨t • x.left, t • x.right⟩ := rfl
+lemma lie_eq_mk (x y : H ⋊⁅ψ⁆ G) :
+    ⁅x, y⁆ = ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩ :=
+  rfl
+
 instance : LieRing (H ⋊⁅ψ⁆ G) where
   add_lie _ _ _ := toProd.injective <| by simp; abel
   lie_add _ _ _:= toProd.injective <| by simp; abel

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -111,11 +111,11 @@ def inl : H →ₗ⁅R⁆ H ⋊⁅ψ⁆ G where
 lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]
 
 /-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
-def pr_right : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
-  toFun x := (toProd x).2
-  map_add' _ _ := Prod.snd_eq_iff.mpr rfl
-  map_smul' _ _ := Prod.snd_eq_iff.mpr rfl
-  map_lie' {_ _}:= Prod.snd_eq_iff.mpr rfl
+def projr : H ⋊⁅ψ⁆ G →ₗ⁅R⁆ G where
+  toFun x := x.toProd.snd
+  map_add' _ _ := by simp
+  map_smul' _ _ := by simp
+  map_lie' := by simp
 
 @[simp]
 lemma pr_right_surjective :  (Function.Surjective (pr_right ψ)) := by

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -108,7 +108,7 @@ def in_left : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
   map_lie' {_ _}:= toProd.injective <| by simp
 
 @[simp]
-lemma in_left_injective :  (Function.Injective (in_left ψ)) := by intro _ _; simp [in_left]
+lemma inl_injective : Function.Injective (inl ψ) := by intro; simp [inl]
 
 /-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
 def pr_right : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -60,10 +60,12 @@ def toProd : H ⋊⁅ψ⁆ G ≃ H × G where
   right_inv _ := rfl
 
 
-instance : AddCommGroup (H ⋊⁅ψ⁆ G) := by
-  unfold SemiDirectSum
-  infer_instance
+instance : AddCommGroup (H ⋊⁅ψ⁆ G) := toProd.addCommGroup
 
+@[simp] lemma toProd_zero : (0 : H ⋊⁅ψ⁆ G).toProd = 0 := rfl
+@[simp] lemma toProd_add (x y : H ⋊⁅ψ⁆ G) : (x + y).toProd = x.toProd + y.toProd := rfl
+@[simp] lemma toProd_sub (x y : H ⋊⁅ψ⁆ G) : (x - y).toProd = x.toProd - y.toProd := rfl
+@[simp] lemma toProd_neg (x : H ⋊⁅ψ⁆ G) : (-x).toProd = -x.toProd := rfl
 
 instance : Module R (H ⋊⁅ψ⁆ G) := by
   unfold SemiDirectSum

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -36,7 +36,9 @@ The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to a Lie 
 -/
 structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
     (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ LieDerivation R H H) where
+  /-- The element of H -/
   left : H
+  /-- The element of G -/
   right : G
 
 @[inherit_doc]
@@ -108,6 +110,7 @@ def in_left : H →ₗ⁅R⁆ (H ⋊⁅ψ⁆ G) where
 @[simp]
 lemma in_left_injective :  (Function.Injective (in_left ψ)) := by intro _ _; simp [in_left]
 
+/-- The canonical projection of the semi-direct sum H ⋊⁅ψ⁆ G to G. -/
 def pr_right : (H ⋊⁅ψ⁆ G) →ₗ⁅R⁆ G where
   toFun x := (toProd x).2
   map_add' _ _ := Prod.snd_eq_iff.mpr rfl

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -34,7 +34,7 @@ namespace LieAlgebra
 The semi-direct sum of two Lie algebras `H` and `G` over `R`, relative to a Lie algebra homomorphism
 `ψ: G → Liederivation R H H `. As a set it just `H × G`, however the Lie bracket is twisted by `ψ`.
 -/
-structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
+@[ext] structure SemiDirectSum {R : Type*} [CommRing R] (H : Type*) [LieRing H] [LieAlgebra R H]
     (G : Type*) [LieRing G] [LieAlgebra R G] (_ : G →ₗ⁅R⁆ LieDerivation R H H) where
   /-- The element of H -/
   left : H

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -135,6 +135,8 @@ def projl : K ⋊⁅ψ⁆ L →ₗ[R] K where
 
 lemma projr_inl_apply {x : K} : projr ψ (inl ψ x) = 0 := by simp
 lemma projr_inr_apply {x : L} : projr ψ (inr ψ x) = x := by simp
+lemma projl_inr_apply {x : L} : projl ψ (inr ψ x) = 0 := by simp
+lemma projl_inl_apply {x : K} : projl ψ (inl ψ x) = x := by simp
 
 @[simp]
 lemma projr_surjective : Function.Surjective (projr ψ) :=


### PR DESCRIPTION
In this PR a construction of the [semi-direct sum of two Lie algebras](https://en.wikipedia.org/wiki/Lie_algebra_extension#By_semidirect_sum)  is added.
It is shown that the resulting object $K\rtimes L$ is a Lie algebra and that it fits into an exact sequence 
$K \to  K\rtimes L \to L$.

---

I was not sure about multiple things and would be very grateful for feedback:

- Currently the semidirect product is created via a def as a type synonym of $H\times G$ so one can define a new bracket on it, which need not coincide with the standard 'direct sum' bracket. This is analogous to e.g. `PointedContMDiffMap` in `Mathlib.Geometry.Manifold.DerivationBundle`. An alternative way would creating a structure with $H$ and $G$ as fields. This seems to be the way chosen in `Mathlib.GroupTheory.SemidirectProduct.lean`.

- Currently it is created as a separate file, but it could also be added to the `Mathlib.Algebra.Lie.Extension` file.

- I am not fully happy with some of the proofs, especially the `leibniz_lie` in the `LieRing` instance, but did not manage to get it more elegant.


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
