### PR TITLE
[Merged by Bors] - feat: ab < ac and b ≤ c implies 0 < a

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -723,6 +723,22 @@ lemma eq_zero_of_mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
     (h : a * a + b * b = 0) : a = 0 :=
   (mul_self_add_mul_self_eq_zero.mp h).left
 
+theorem pos_of_right_mul_lt_le [ExistsAddOfLE R] [PosMulMono R]
+    [AddRightMono R] [AddRightReflectLE R]
+    (h : a * b < a * c) (hbc : b ≤ c) :
+    0 < a := by
+  by_cases! ha : 0 < a
+  · exact ha
+  · grind [mul_le_mul_of_nonpos_left hbc ha]
+
+theorem pos_of_left_mul_lt_le [ExistsAddOfLE R] [MulPosMono R]
+    [AddLeftMono R] [AddRightReflectLE R]
+    (h : b * a < c * a) (hbc : b ≤ c) :
+    0 < a := by
+  by_cases! ha : 0 < a
+  · exact ha
+  · grind [mul_le_mul_of_nonpos_right hbc ha]
+
 end LinearOrderedSemiring
 
 section LinearOrderedCommSemiring


### PR DESCRIPTION
[#Is there code for X? > a &#42; b < a &#42; c and b < c implies 0 < a](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/a.20*.20b.20.3C.20a.20*.20c.20and.20b.20.3C.20c.20implies.200.20.3C.20a/with/573860260)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
