### PR TITLE
[Merged by Bors] - fix(Dynamics/BirkhoffSum): birkhoffAverage_of_comp_eq only needs AddCommMonoid

### DIFF
--- a/Mathlib/Dynamics/BirkhoffSum/Average.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/Average.lean
@@ -83,6 +83,14 @@ lemma birkhoffAverage_add {f : α → α} {g g' : α → M} :
   funext _ x
   simp [birkhoffAverage, birkhoffSum, sum_add_distrib, smul_add]
 
+/-- If a function `g` is invariant under a function `f` (i.e., `g ∘ f = g`), then the Birkhoff
+average of `g` over `f` for `n` iterations is equal to `g`. Requires that `0 < n`. -/
+theorem birkhoffAverage_of_comp_eq [CharZero R] {f : α → α} {g : α → M} (h : g ∘ f = g)
+    {n : ℕ} (hn : n ≠ 0) : birkhoffAverage R f g n = g := by
+  funext x
+  suffices (n : R)⁻¹ • n • g x = g x by simpa [birkhoffAverage, birkhoffSum_of_comp_eq h]
+  rw [← Nat.cast_smul_eq_nsmul (R := R), ← mul_smul, inv_mul_cancel₀ (by norm_cast), one_smul]
+
 end birkhoffAverage
 
 section AddCommGroup
@@ -106,13 +114,5 @@ theorem birkhoffAverage_apply_sub_birkhoffAverage (f : α → α) (g : α → M)
     birkhoffAverage R f g n (f x) - birkhoffAverage R f g n x =
       (n : R)⁻¹ • (g (f^[n] x) - g x) := by
   simp only [birkhoffAverage, birkhoffSum_apply_sub_birkhoffSum, ← smul_sub]
-
-/-- If a function `g` is invariant under a function `f` (i.e., `g ∘ f = g`), then the Birkhoff
-average of `g` over `f` for `n` iterations is equal to `g`. Requires that `0 < n`. -/
-theorem birkhoffAverage_of_comp_eq [CharZero R] {f : α → α} {g : α → M} (h : g ∘ f = g)
-    {n : ℕ} (hn : n ≠ 0) : birkhoffAverage R f g n = g := by
-  funext x
-  suffices (n : R)⁻¹ • n • g x = g x by simpa [birkhoffAverage, birkhoffSum_of_comp_eq h]
-  rw [← Nat.cast_smul_eq_nsmul (R := R), ← mul_smul, inv_mul_cancel₀ (by norm_cast), one_smul]
 
 end AddCommGroup

--- a/Mathlib/Dynamics/BirkhoffSum/Average.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/Average.lean
@@ -85,8 +85,8 @@ lemma birkhoffAverage_add {f : α → α} {g g' : α → M} :
 
 /-- If a function `g` is invariant under a function `f` (i.e., `g ∘ f = g`), then the Birkhoff
 average of `g` over `f` for `n` iterations is equal to `g`. Requires that `0 < n`. -/
-theorem birkhoffAverage_of_comp_eq [CharZero R] {f : α → α} {g : α → M} (h : g ∘ f = g)
-    {n : ℕ} (hn : n ≠ 0) : birkhoffAverage R f g n = g := by
+theorem birkhoffAverage_of_comp_eq {f : α → α} {g : α → M} (h : g ∘ f = g)
+    {n : ℕ} (hn : (n : R) ≠ 0) : birkhoffAverage R f g n = g := by
   funext x
   suffices (n : R)⁻¹ • n • g x = g x by simpa [birkhoffAverage, birkhoffSum_of_comp_eq h]
   rw [← Nat.cast_smul_eq_nsmul (R := R), ← mul_smul, inv_mul_cancel₀ (by norm_cast), one_smul]

--- a/Mathlib/Dynamics/BirkhoffSum/Average.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/Average.lean
@@ -89,7 +89,7 @@ theorem birkhoffAverage_of_comp_eq {f : α → α} {g : α → M} (h : g ∘ f =
     {n : ℕ} (hn : (n : R) ≠ 0) : birkhoffAverage R f g n = g := by
   funext x
   suffices (n : R)⁻¹ • n • g x = g x by simpa [birkhoffAverage, birkhoffSum_of_comp_eq h]
-  rw [← Nat.cast_smul_eq_nsmul (R := R), ← mul_smul, inv_mul_cancel₀ (by norm_cast), one_smul]
+  rw [← Nat.cast_smul_eq_nsmul (R := R), ← mul_smul, inv_mul_cancel₀ hn, one_smul]
 
 end birkhoffAverage
 

--- a/Mathlib/Dynamics/BirkhoffSum/Average.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/Average.lean
@@ -73,10 +73,9 @@ theorem birkhoffAverage_congr_ring' (S : Type*) [DivisionSemiring S] [Module S M
     birkhoffAverage (α := α) (M := M) R = birkhoffAverage S := by
   ext; apply birkhoffAverage_congr_ring
 
-theorem Function.IsFixedPt.birkhoffAverage_eq [CharZero R] {f : α → α} {x : α} (h : IsFixedPt f x)
-    (g : α → M) {n : ℕ} (hn : n ≠ 0) : birkhoffAverage R f g n x = g x := by
-  rw [birkhoffAverage, h.birkhoffSum_eq, ← Nat.cast_smul_eq_nsmul R, inv_smul_smul₀]
-  rwa [Nat.cast_ne_zero]
+theorem Function.IsFixedPt.birkhoffAverage_eq {f : α → α} {x : α} (h : IsFixedPt f x)
+    (g : α → M) {n : ℕ} (hn : (n : R) ≠ 0) : birkhoffAverage R f g n x = g x := by
+  rw [birkhoffAverage, h.birkhoffSum_eq, ← Nat.cast_smul_eq_nsmul R, inv_smul_smul₀ hn]
 
 lemma birkhoffAverage_add {f : α → α} {g g' : α → M} :
     birkhoffAverage R f (g + g') = birkhoffAverage R f g + birkhoffAverage R f g' := by

--- a/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
@@ -39,7 +39,7 @@ theorem Function.IsFixedPt.tendsto_birkhoffAverage
     {f : α → α} {x : α} (h : f.IsFixedPt x) (g : α → E) :
     Tendsto (birkhoffAverage R f g · x) atTop (𝓝 (g x)) :=
   tendsto_const_nhds.congr' <| (eventually_ne_atTop 0).mono fun _n hn ↦
-    (h.birkhoffAverage_eq R g hn).symm
+    (h.birkhoffAverage_eq R g (Nat.cast_ne_zero.mpr hn)).symm
 
 variable [NormedAddCommGroup E]
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
