### PR TITLE
[Merged by Bors] - feat(Order/Filter/Pointwise): `((∀ᶠ|∃ᶠ) x in op f, p x) ↔ ((∀ᶠ|∃ᶠ) x in f, p (op x))`

### DIFF
--- a/Mathlib/Order/Filter/Map.lean
+++ b/Mathlib/Order/Filter/Map.lean
@@ -146,6 +146,10 @@ theorem eventually_pure {a : α} {p : α → Prop} : (∀ᶠ x in pure a, p x) �
   Iff.rfl
 
 @[simp]
+theorem frequently_pure {a : α} {p : α → Prop} : (∃ᶠ x in pure a, p x) ↔ p a := by
+  simp [Filter.Frequently]
+
+@[simp]
 theorem principal_singleton (a : α) : 𝓟 {a} = pure a :=
   Filter.ext fun s => by simp only [mem_pure, mem_principal, singleton_subset_iff]
 

--- a/Mathlib/Order/Filter/Pointwise.lean
+++ b/Mathlib/Order/Filter/Pointwise.lean
@@ -130,6 +130,10 @@ theorem eventually_one {p : α → Prop} : (∀ᶠ x in 1, p x) ↔ p 1 :=
   eventually_pure
 
 @[to_additive (attr := simp)]
+theorem frequently_one {p : α → Prop} : (∃ᶠ x in 1, p x) ↔ p 1 :=
+  frequently_pure
+
+@[to_additive (attr := simp)]
 theorem tendsto_one {a : Filter β} {f : β → α} : Tendsto f a 1 ↔ ∀ᶠ x in a, f x = 1 :=
   tendsto_pure
 
@@ -203,6 +207,14 @@ protected theorem NeBot.inv : f.NeBot → f⁻¹.NeBot := fun h => h.map _
 lemma inv.instNeBot [NeBot f] : NeBot f⁻¹ := .inv ‹_›
 
 scoped[Pointwise] attribute [instance] inv.instNeBot neg.instNeBot
+
+@[to_additive (attr := simp)]
+lemma eventually_inv {p : α → Prop} : (∀ᶠ x in f⁻¹, p x) ↔ (∀ᶠ x in f, p x⁻¹) :=
+  eventually_map
+
+@[to_additive (attr := simp)]
+lemma frequently_inv {p : α → Prop} : (∃ᶠ x in f⁻¹, p x) ↔ (∃ᶠ x in f, p x⁻¹) :=
+  frequently_map
 
 end Inv
 
@@ -994,6 +1006,14 @@ theorem NeBot.of_smul_filter : (a • f).NeBot → f.NeBot :=
 lemma smul_filter.instNeBot [NeBot f] : NeBot (a • f) := .smul_filter ‹_›
 
 scoped[Pointwise] attribute [instance] smul_filter.instNeBot vadd_filter.instNeBot
+
+@[to_additive (attr := simp)]
+lemma eventually_smul_filter {p : β → Prop} : (∀ᶠ y in a • f, p y) ↔ (∀ᶠ x in f, p (a • x)) :=
+  eventually_map
+
+@[to_additive (attr := simp)]
+lemma frequently_inv_filter {p : β → Prop} : (∃ᶠ y in a • f, p y) ↔ (∃ᶠ x in f, p (a • x)) :=
+  frequently_map
 
 @[to_additive (attr := gcongr)]
 theorem smul_filter_le_smul_filter (hf : f₁ ≤ f₂) : a • f₁ ≤ a • f₂ :=


### PR DESCRIPTION
This lemma is required when I prove that $z \mapsto \sin^{-1} z^{-1}$ is not meromorphic at $0$:

```lean4
@[simp]
lemma Filter.frequently_inv {α : Type*} [Inv α] {f : Filter α} {p : α → Prop} :
    (∃ᶠ a in f⁻¹, p a) ↔ (∃ᶠ a in f, p a⁻¹) :=
  frequently_map

example : ¬(∀ᶠ z in 𝓝[≠] (0 : ℂ), sin⁻¹ z⁻¹ = 0) ↔ (∃ᶠ z in cobounded ℂ, sin z ≠ 0) := by
  simp [← inv_cobounded₀]
```

So I added the simp lemmas of `(∀ᶠ|∃ᶠ) x in op f, p x` for unary operations `op` (`-f`, `f⁻¹` & `a • f`).

While I was at it, I also added the simp lemmas of `∃ᶠ x in pure a, p x` & `∃ᶠ x in (0|1), p x`, which previously existed only for the `∀ᶠ` versions.

Binary operation versions will be added if necessary.

<details>
<summary>Appendix: Full proof of that $z \mapsto \sin^{-1} z^{-1}$ is not meromorphic at $0$</summary>

```lean4
module
import Mathlib.Analysis.Meromorphic.Basic
import Mathlib.Analysis.SpecialFunctions.Trigonometric.Complex
import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
import Mathlib.Analysis.SpecificLimits.RCLike

open Complex Filter Bornology
open scoped Real Topology Pointwise

@[simp]
lemma Filter.frequently_inv {α : Type*} [Inv α] {f : Filter α} {p : α → Prop} :
    (∃ᶠ a in f⁻¹, p a) ↔ (∃ᶠ a in f, p a⁻¹) :=
  frequently_map

example : ¬MeromorphicAt (fun z => sin⁻¹ z⁻¹) 0 := by
  apply mt MeromorphicAt.eventually_eq_zero_or_eventually_ne_zero
  conv => equals (∃ᶠ z in cobounded ℂ, sin z ≠ 0) ∧ (∃ᶠ z in cobounded ℂ, sin z = 0) =>
    simp [← inv_cobounded₀]
  constructor
  case left =>
    have ht : Tendsto (fun x : ℝ ↦ ↑x * I) (cobounded ℝ) (cobounded ℂ) := by
      have ht₁ : Tendsto ((↑) : ℝ → ℂ) (cobounded ℝ) (cobounded ℂ) :=
        RCLike.tendsto_ofReal_cobounded_cobounded ℂ
      have ht₂ : Tendsto (fun z : ℂ ↦ z * I) (cobounded ℂ) (cobounded ℂ) :=
        tendsto_mul_right_cobounded (by simp)
      exact ht₂.comp ht₁
    refine ht.frequently_map _ (fun x ↦ mt ?_) (eventually_ne_cobounded 0).frequently
    rw [sin_eq_zero_iff]
    rintro ⟨n, hn⟩
    simpa using congr_arg im hn
  case right =>
    suffices ht : Tendsto (fun n : ℤ ↦ (↑n * ↑π : ℂ)) atTop (cobounded ℂ) by
      apply ht.frequently; simp [sin_int_mul_pi, atTop_neBot]
    have ht₁ : Tendsto ((↑) : ℤ → ℝ) atTop (cobounded ℝ) := tendsto_intCast_atTop_cobounded
    have ht₂ : Tendsto ((↑) : ℝ → ℂ) (cobounded ℝ) (cobounded ℂ) :=
      RCLike.tendsto_ofReal_cobounded_cobounded ℂ
    have ht₃ : Tendsto (fun z : ℂ ↦ z * ↑π) (cobounded ℂ) (cobounded ℂ) :=
      tendsto_mul_right_cobounded (by simp)
    exact ht₃.comp <| ht₂.comp ht₁
```

</details>


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
