### PR TITLE
[Merged by Bors] - doc: capitalize the proper name Kan

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Kan/HasKan.lean
@@ -197,7 +197,7 @@ open LeftLift
 
 variable {f : b ⟶ a} {g : c ⟶ a}
 
-/-- The existence of a left kan lift of `g` along `f`. -/
+/-- The existence of a left Kan lift of `g` along `f`. -/
 class HasLeftKanLift (f : b ⟶ a) (g : c ⟶ a) : Prop where mk' ::
   hasInitial : HasInitial <| LeftLift f g
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -396,7 +396,7 @@ class DayConvolutionUnit (F : C ⥤ V) where
   /-- A "canonical" structure map `𝟙_ V ⟶ F.obj (𝟙_ C)` that defines a natural transformation
   `fromPUnit (𝟙_ V) ⟶ fromPUnit (𝟙_ C) ⋙ F`. -/
   can : 𝟙_ V ⟶ F.obj (𝟙_ C)
-  /-- The canonical map `𝟙_ V ⟶ F.obj (𝟙_ C)` exhibits `F` as a pointwise left kan extension
+  /-- The canonical map `𝟙_ V ⟶ F.obj (𝟙_ C)` exhibits `F` as a pointwise left Kan extension
   of `fromPUnit.{0} 𝟙_ V` along `fromPUnit.{0} 𝟙_ C`. -/
   isPointwiseLeftKanExtensionCan : Functor.LeftExtension.mk F
     ({ app _ := can } : Functor.fromPUnit.{0} (𝟙_ V) ⟶

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct/KanExtension.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct/KanExtension.lean
@@ -15,7 +15,7 @@ public import Mathlib.CategoryTheory.Limits.Final
 We prove that if a functor `H' : D' ⥤ V` is a pointwise left Kan extension of
 `H : D ⥤ V` along `L : D ⥤ D'`, and if `K : E ⥤ V` is any functor such that
 for any `e : E`, the functor `tensorRight (K.obj e)` commutes with colimits of
-shape `CostructuredArrow L d`, then the functor `H' ⊠ K` is a pointwise left kan extension
+shape `CostructuredArrow L d`, then the functor `H' ⊠ K` is a pointwise left Kan extension
 of `H ⊠ K` along `L.prod (𝟭 E)`.
 
 We also prove a similar criterion to establish that `K ⊠ H'` is a pointwise left Kan

--- a/Mathlib/Topology/Sheaves/Alexandrov.lean
+++ b/Mathlib/Topology/Sheaves/Alexandrov.lean
@@ -69,7 +69,7 @@ lemma exists_le_of_le_sup {ι : Type v} {x : X}
     ∃ i : ι, principalOpen x ≤ Us i := by
   grind [principalOpen_le_iff, Opens.mem_iSup]
 
-/-- The right kan extension of `F` along `X ⥤ (Opens X)ᵒᵖ`. -/
+/-- The right Kan extension of `F` along `X ⥤ (Opens X)ᵒᵖ`. -/
 abbrev principalsKanExtension : (Opens X)ᵒᵖ ⥤ C :=
   (principals X).pointwiseRightKanExtension F
 


### PR DESCRIPTION
We capitalize the surname of Daniel Kan.

This makes our spelling consistent with the one used by nLab and Wikipedia:
- [nLab - Kan extension](https://ncatlab.org/nlab/show/Kan+extension)
- [nLab - Kan lift](https://ncatlab.org/nlab/show/Kan+lift)
- https://en.wikipedia.org/wiki/Kan_extension

---

This PR is exhaustive.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
