### PR TITLE
[Merged by Bors] - refactor(Algebra/*): generalize `of_ringEquiv` lemmas

### DIFF
--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -175,29 +175,32 @@ theorem Projective.of_split [Module.Projective R M]
   rw [LinearMap.comp_apply, ← LinearMap.comp_apply, hg,
     ← LinearMap.comp_apply, H, LinearMap.id_apply]
 
-theorem Projective.of_equiv [Module.Projective R M]
+theorem Projective.of_equiv {R S} [Semiring R] [Semiring S] {M N}
+    [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module S N]
+    {σ : R →+* S} {σ' : S →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
+    (e₂ : M ≃ₛₗ[σ] N)
+    [Projective R M] : Projective S N := by
+  let e₁ : R ≃+* S := RingHomInvPair.toRingEquiv σ σ'
+  obtain ⟨f, hf⟩ := ‹Projective R M›
+  let g : N →ₗ[S] N →₀ S :=
+  { toFun := fun x ↦ (equivCongrLeft e₂ (f (e₂.symm x))).mapRange e₁ e₁.map_zero
+    map_add' := fun x y ↦ by ext; simp
+    map_smul' := fun r v ↦ by ext i; simp [e₁, e₂.symm.map_smulₛₗ] }
+  refine ⟨⟨g, fun x ↦ ?_⟩⟩
+  replace hf := congr(e₂ $(hf (e₂.symm x)))
+  simpa [linearCombination_apply, sum_mapRange_index, g, map_finsuppSum, e₂.map_smulₛₗ] using hf
+
+theorem Projective.of_equiv' [Module.Projective R M]
     (e : M ≃ₗ[R] P) : Module.Projective R P :=
-  Projective.of_split e.symm e.toLinearMap (by simp)
+  .of_equiv e
+
+@[deprecated (since := "2026-02-14")] alias Projective.of_ringEquiv := Projective.of_equiv
 
 /-- A quotient of a projective module is projective iff it is a direct summand. -/
 theorem Projective.iff_split_of_projective [Module.Projective R M] (s : M →ₗ[R] P)
     (hs : Function.Surjective s) :
     Module.Projective R P ↔ ∃ i, s ∘ₗ i = LinearMap.id :=
   ⟨fun _ ↦ projective_lifting_property _ _ hs, fun ⟨i, H⟩ ↦ Projective.of_split i s H⟩
-
-attribute [local instance] RingHomInvPair.of_ringEquiv in
-theorem Projective.of_ringEquiv {R S} [Semiring R] [Semiring S] {M N}
-    [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module S N]
-    (e₁ : R ≃+* S) (e₂ : M ≃ₛₗ[RingHomClass.toRingHom e₁] N)
-    [Projective R M] : Projective S N := by
-  obtain ⟨f, hf⟩ := ‹Projective R M›
-  let g : N →ₗ[S] N →₀ S :=
-  { toFun := fun x ↦ (equivCongrLeft e₂ (f (e₂.symm x))).mapRange e₁ e₁.map_zero
-    map_add' := fun x y ↦ by ext; simp
-    map_smul' := fun r v ↦ by ext i; simp [e₂.symm.map_smulₛₗ] }
-  refine ⟨⟨g, fun x ↦ ?_⟩⟩
-  replace hf := congr(e₂ $(hf (e₂.symm x)))
-  simpa [linearCombination_apply, sum_mapRange_index, g, map_finsuppSum, e₂.map_smulₛₗ] using hf
 
 end Semiring
 

--- a/Mathlib/Algebra/Ring/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Ring/CompTypeclasses.lean
@@ -111,13 +111,29 @@ instance triples₂ {σ₂₁ : R₂ →+* R₁} [RingHomInvPair σ₁₂ σ₂�
     RingHomCompTriple σ₂₁ σ₁₂ (RingHom.id R₂) :=
   ⟨by simp only [comp_eq₂]⟩
 
+variable (σ σ') in
+/-- The ring equivalence defined by a pair of ring homomorphisms satisfying `RingHomInvPair`. -/
+@[simps!]
+def toRingEquiv : R₁ ≃+* R₂ := .ofRingHom σ σ' comp_eq₂ comp_eq
+
 /-- Construct a `RingHomInvPair` from both directions of a ring equiv.
 
 This is not an instance, as for equivalences that are involutions, a better instance
-would be `RingHomInvPair e e`. Indeed, this declaration is not currently used in mathlib.
+would be `RingHomInvPair e e`.
+
+This declaration should not be used as an instance to state a theorem,
+but it may be useful sometimes in the middle of a proof.
 -/
 theorem of_ringEquiv (e : R₁ ≃+* R₂) : RingHomInvPair (↑e : R₁ →+* R₂) ↑e.symm :=
   ⟨e.symm_toRingHom_comp_toRingHom, e.symm.symm_toRingHom_comp_toRingHom⟩
+
+/-- Construct a `RingHomInvPair` from both directions of a ring equiv.
+
+This is not an instance, as for equivalences that are involutions, a better instance
+would be `RingHomInvPair e e`.
+-/
+theorem of_ringEquiv_symm (e : R₁ ≃+* R₂) : RingHomInvPair (↑e.symm : R₂ →+* R₁) ↑e :=
+  of_ringEquiv e.symm
 
 /--
 Swap the direction of a `RingHomInvPair`. This is not an instance as it would loop, and better

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -120,8 +120,20 @@ instance [Module.Free R M] [Nontrivial M] : FaithfulSMul R M :=
 
 variable {R M N}
 
-theorem of_equiv (e : M ≃ₗ[R] N) : Module.Free R N :=
-  of_basis <| (chooseBasis R M).map e
+lemma of_equiv {R R' M M' : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+    [Semiring R'] [AddCommMonoid M'] [Module R' M']
+    {σ : R →+* R'} {σ' : R' →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
+    (e₂ : M ≃ₛₗ[σ] M') [Module.Free R M] :
+    Module.Free R' M' := by
+  let e₁ : R ≃+* R' := RingHomInvPair.toRingEquiv σ σ'
+  let I := Module.Free.ChooseBasisIndex R M
+  obtain ⟨e₃ : M ≃ₗ[R] I →₀ R⟩ := Module.Free.chooseBasis R M
+  let e : M' ≃+ (I →₀ R') :=
+    (e₂.symm.trans e₃).toAddEquiv.trans (Finsupp.mapRange.addEquiv (ι := I) e₁.toAddEquiv)
+  have he (x) : e x = Finsupp.mapRange.addEquiv (ι := I) e₁.toAddEquiv (e₃ (e₂.symm x)) := rfl
+  let e' : M' ≃ₗ[R'] (I →₀ R') :=
+    { __ := e, map_smul' := fun m x ↦ Finsupp.ext fun i ↦ by simp [e₁, he, map_smulₛₗ] }
+  exact of_basis (.ofRepr e')
 
 /-- A variation of `of_equiv`: the assumption `Module.Free R P` here is explicit rather than an
 instance. -/
@@ -129,29 +141,18 @@ theorem of_equiv' {P : Type v} [AddCommMonoid P] [Module R P] (_ : Module.Free R
     (e : P ≃ₗ[R] N) : Module.Free R N :=
   of_equiv e
 
+lemma iff_of_equiv {R R' M M'} [Semiring R] [AddCommMonoid M] [Module R M]
+    [Semiring R'] [AddCommMonoid M'] [Module R' M']
+    {σ : R →+* R'} {σ' : R' →+* R} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
+    (e₂ : M ≃ₛₗ[σ] M') :
+    Module.Free R M ↔ Module.Free R' M' :=
+  ⟨fun _ ↦ of_equiv e₂, fun _ ↦ of_equiv e₂.symm⟩
+
+@[deprecated (since := "2026-02-14")] alias of_ringEquiv := of_equiv
+@[deprecated (since := "2026-02-14")] alias iff_of_ringEquiv := iff_of_equiv
+
 instance Module.free_shrink [Module.Free R M] [Small.{w} M] : Module.Free R (Shrink.{w} M) :=
   Module.Free.of_equiv (Shrink.linearEquiv R M).symm
-
-attribute [local instance] RingHomInvPair.of_ringEquiv in
-lemma of_ringEquiv {R R' M M'} [Semiring R] [AddCommMonoid M] [Module R M]
-    [Semiring R'] [AddCommMonoid M'] [Module R' M']
-    (e₁ : R ≃+* R') (e₂ : M ≃ₛₗ[RingHomClass.toRingHom e₁] M') [Module.Free R M] :
-    Module.Free R' M' := by
-  let I := Module.Free.ChooseBasisIndex R M
-  obtain ⟨e₃ : M ≃ₗ[R] I →₀ R⟩ := Module.Free.chooseBasis R M
-  let e : M' ≃+ (I →₀ R') :=
-    (e₂.symm.trans e₃).toAddEquiv.trans (Finsupp.mapRange.addEquiv (ι := I) e₁.toAddEquiv)
-  have he (x) : e x = Finsupp.mapRange.addEquiv (ι := I) e₁.toAddEquiv (e₃ (e₂.symm x)) := rfl
-  let e' : M' ≃ₗ[R'] (I →₀ R') :=
-    { __ := e, map_smul' := fun m x ↦ Finsupp.ext fun i ↦ by simp [he, map_smulₛₗ] }
-  exact of_basis (.ofRepr e')
-
-attribute [local instance] RingHomInvPair.of_ringEquiv in
-lemma iff_of_ringEquiv {R R' M M'} [Semiring R] [AddCommMonoid M] [Module R M]
-    [Semiring R'] [AddCommMonoid M'] [Module R' M']
-    (e₁ : R ≃+* R') (e₂ : M ≃ₛₗ[RingHomClass.toRingHom e₁] M') :
-    Module.Free R M ↔ Module.Free R' M' :=
-  ⟨fun _ ↦ of_ringEquiv e₁ e₂, fun _ ↦ of_ringEquiv e₁.symm e₂.symm⟩
 
 variable (R M N)
 

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -151,7 +151,7 @@ variable
   (f : ∀ (P : Ideal R) [P.IsMaximal], M →ₗ[R] Mₚ P)
   [inst : ∀ (P : Ideal R) [P.IsMaximal], IsLocalizedModule P.primeCompl (f P)]
 
-attribute [local instance] RingHomInvPair.of_ringEquiv in
+attribute [local instance] RingHomInvPair.of_ringEquiv RingHomInvPair.of_ringEquiv_symm in
 include f in
 /--
 A variant of `Module.projective_of_localization_maximal` that accepts `IsLocalizedModule`.
@@ -161,8 +161,9 @@ theorem Module.projective_of_localization_maximal'
     [Module.FinitePresentation R M] : Module.Projective R M := by
   apply Module.projective_of_localization_maximal
   intro P hP
-  refine Module.Projective.of_ringEquiv (M := Mₚ P)
-    (IsLocalization.algEquiv P.primeCompl (Rₚ P) (Localization.AtPrime P)).toRingEquiv
+  set e := (IsLocalization.algEquiv P.primeCompl (Rₚ P) (Localization.AtPrime P)).toRingEquiv
+  refine Module.Projective.of_equiv (M := Mₚ P) (R := Rₚ P)
+    (σ := e)
     { __ := IsLocalizedModule.linearEquiv P.primeCompl (f P)
         (LocalizedModule.mkLinearMap P.primeCompl M)
       map_smul' := ?_ }
@@ -170,6 +171,6 @@ theorem Module.projective_of_localization_maximal'
     obtain ⟨r, s, rfl⟩ := IsLocalization.exists_mk'_eq P.primeCompl r
     apply ((Module.End.isUnit_iff _).mp
       (IsLocalizedModule.map_units (LocalizedModule.mkLinearMap P.primeCompl M) s)).1
-    dsimp
+    dsimp [e]
     simp only [← map_smul, ← smul_assoc, IsLocalization.smul_mk'_self, algebraMap_smul,
       IsLocalization.map_id_mk']

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -60,13 +60,14 @@ lemma mem_freeLocus_of_isLocalization (p : PrimeSpectrum R)
     [AddCommGroup Mₚ] [Module R Mₚ] (f : M →ₗ[R] Mₚ) [IsLocalizedModule p.asIdeal.primeCompl f]
     [Module Rₚ Mₚ] [IsScalarTower R Rₚ Mₚ] :
     p ∈ freeLocus R M ↔ Module.Free Rₚ Mₚ := by
-  apply Module.Free.iff_of_ringEquiv (IsLocalization.algEquiv p.asIdeal.primeCompl
+  set e := (IsLocalization.algEquiv p.asIdeal.primeCompl
       (Localization.AtPrime p.asIdeal) Rₚ).toRingEquiv
+  apply Module.Free.iff_of_equiv (σ := e)
   refine { __ := IsLocalizedModule.iso p.asIdeal.primeCompl f, map_smul' := ?_ }
   intro r x
   obtain ⟨r, s, rfl⟩ := IsLocalization.exists_mk'_eq p.asIdeal.primeCompl r
   apply ((Module.End.isUnit_iff _).mp (IsLocalizedModule.map_units f s)).1
-  simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe,
+  simp only [e, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearEquiv.coe_coe,
     algebraMap_end_apply, AlgEquiv.toRingEquiv_eq_coe,
     AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_coe, IsLocalization.algEquiv_apply,
     IsLocalization.map_id_mk']


### PR DESCRIPTION
Some lemmas assumed that two modules over different rings
admit a semilinear equivalence with respect to a `RingEquiv`.
While this is mathematically equivalent
to the definition we use everywhere else
(a pair of `RingHom`s with `RingHomInvPair` assumptions),
it does not directly apply neither to the linear case,
nor to the `starRingEnd` case.

This PR drops `of_ringEquiv` theorems
and generalizes `of_equiv` theorems
to semilinear equivalences instead.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

<!-- Message of single commit: -->