### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): schemes are universally open over fields

### DIFF
--- a/Mathlib/AlgebraicGeometry/Geometrically/Irreducible.lean
+++ b/Mathlib/AlgebraicGeometry/Geometrically/Irreducible.lean
@@ -102,7 +102,7 @@ lemma GeometricallyIrreducible.irreducibleSpace_of_subsingleton
 then `X ×ₛ Y` is irreducible.
 
 The universally open assumption in particular holds when it is flat and locally of finite
-presentation, e.g. when `S` is a field and `X` is locally of finite type over `S`. -/
+presentation, or when `S` is a field. -/
 instance [GeometricallyIrreducible f] [UniversallyOpen f] [IrreducibleSpace Y] :
     IrreducibleSpace ↥(pullback f g) :=
   GeometricallyIrreducible.irreducibleSpace (pullback.snd _ _) (pullback.snd f g).isOpenMap

--- a/Mathlib/AlgebraicGeometry/Morphisms/UniversallyOpen.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UniversallyOpen.lean
@@ -145,4 +145,30 @@ instance (priority := low) UniversallyOpen.of_flat [Flat f] [LocallyOfFinitePres
     UniversallyOpen f :=
   ⟨universally_mk' _ _ fun _ _ ↦ isOpenMap_of_generalizingMap _ (Flat.generalizingMap _)⟩
 
+nonrec instance (priority := low) [IsIntegral Y] [Subsingleton Y] :
+    UniversallyOpen f := by
+  wlog hX : ∃ S, X = Spec S generalizing X
+  · refine (IsZariskiLocalAtSource.iff_of_openCover X.affineCover).mpr fun i ↦ this _ ⟨_, rfl⟩
+  obtain ⟨S, rfl⟩ := hX
+  wlog hY : ∃ K, Y = Spec K ∧ IsField K generalizing Y
+  · have inst : Subsingleton (Spec Γ(Y, ⊤)) := Y.isoSpec.inv.homeomorph.subsingleton
+    exact (MorphismProperty.cancel_right_of_respectsIso _ _ Y.isoSpec.hom).mp
+      (this _ ⟨_, rfl, isField_of_isIntegral_of_subsingleton _⟩)
+  obtain ⟨K, rfl, hK⟩ := hY
+  obtain ⟨φ, rfl⟩ := Spec.map_surjective f
+  refine ⟨universally_mk' _ _ fun {T} g _ ↦ ?_⟩
+  wlog hT : ∃ R, T = Spec R generalizing T
+  · refine (IsZariskiLocalAtTarget.iff_of_openCover T.affineCover).mpr fun i ↦ ?_
+    refine (MorphismProperty.cancel_left_of_respectsIso _
+      ((pullbackRightPullbackFstIso ..).inv ≫ (pullbackSymmetry ..).hom) _).mp ?_
+    simpa [Scheme.Cover.pullbackHom] using this _ _ ⟨_, rfl⟩
+  obtain ⟨R, rfl⟩ := hT
+  obtain ⟨ψ, rfl⟩ := Spec.map_surjective g
+  algebraize [φ.hom, ψ.hom]
+  refine (MorphismProperty.cancel_left_of_respectsIso _ (pullbackSpecIso K R S).inv _).mp ?_
+  convert_to topologically _ (Spec.map <| CommRingCat.ofHom (algebraMap R (TensorProduct K R S)))
+  · exact pullbackSpecIso_inv_fst ..
+  let := hK.toField
+  exact PrimeSpectrum.isOpenMap_comap_algebraMap_tensorProduct_of_field
+
 end AlgebraicGeometry

--- a/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 module
 
+public import Mathlib.RingTheory.FiniteStability
 public import Mathlib.RingTheory.Ideal.GoingDown
 public import Mathlib.RingTheory.Spectrum.Prime.ChevalleyComplexity
 
@@ -65,5 +66,38 @@ lemma isOpenMap_comap_of_hasGoingDown_of_finitePresentation
       (Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap.mp ‹_›))
     (isConstructible_comap_image (RingHom.finitePresentation_algebraMap.mpr ‹_›)
       isConstructible_basicOpen)
+
+open TensorProduct in
+@[stacks 037G]
+theorem isOpenMap_comap_algebraMap_tensorProduct_of_field
+    {K A B : Type*} [Field K] [CommRing A] [CommRing B] [Algebra K A] [Algebra K B] :
+    IsOpenMap (PrimeSpectrum.comap (algebraMap A (A ⊗[K] B))) := by
+  intro U hU
+  wlog hU' : ∃ f, U = SetLike.coe (basicOpen f) generalizing U
+  · rw [eq_biUnion_of_isOpen hU, Set.image_iUnion₂]
+    exact isOpen_iUnion fun _ ↦ isOpen_iUnion fun _ ↦ this _ (basicOpen _).isOpen ⟨_, rfl⟩
+  obtain ⟨f, rfl⟩ := hU'
+  obtain ⟨B', hB, f, rfl⟩ := exists_fg_and_mem_baseChange f
+  have : Algebra.FinitePresentation K B' :=
+    Algebra.FinitePresentation.of_finiteType.mp ⟨B'.fg_top.mpr hB⟩
+  convert isOpenMap_comap_of_hasGoingDown_of_finitePresentation (R := A) (S := A ⊗[K] B') _
+    (basicOpen f).isOpen using 1
+  ext x
+  rw [PrimeSpectrum.mem_image_comap_basicOpen, PrimeSpectrum.mem_image_comap_basicOpen,
+    not_iff_not]
+  let ψ := Algebra.TensorProduct.map
+    (Algebra.TensorProduct.map (.id A A) B'.val) (.id A x.asIdeal.ResidueField)
+  have hψeq : ψ = (Algebra.TensorProduct.comm _ _ _ |>.toAlgHom.comp <|
+    Algebra.TensorProduct.cancelBaseChange K A A _ B |>.symm.toAlgHom.comp <|
+    Algebra.TensorProduct.map (.id _ _) B'.val |>.comp <|
+    Algebra.TensorProduct.cancelBaseChange K A A _ B' |>.toAlgHom.comp <|
+    (Algebra.TensorProduct.comm _ _ _).toAlgHom) := by ext; simp [ψ]
+  have hψ : Function.Injective ψ := by
+    rw [hψeq]
+    dsimp
+    simp_rw [EmbeddingLike.comp_injective, ← Function.comp_assoc, EquivLike.injective_comp]
+    exact Module.Flat.lTensor_preserves_injective_linearMap _ Subtype.val_injective
+  rw [← IsNilpotent.map_iff hψ]
+  rfl
 
 end PrimeSpectrum


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
