### PR TITLE
[Merged by Bors] - feat: inv lemmas for uniform convergence, missing `to_fun` attributes

### DIFF
--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -144,47 +144,91 @@ section UniformConvergence
 
 variable {ι : Type*} {l : Filter ι} {l' : Filter β} {f f' : ι → β → α} {g g' : β → α} {s : Set β}
 
-@[to_additive]
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOnFilter.mul (hf : TendstoUniformlyOnFilter f g l l')
     (hf' : TendstoUniformlyOnFilter f' g' l l') : TendstoUniformlyOnFilter (f * f') (g * g') l l' :=
   fun u hu =>
   ((uniformContinuous_mul.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diag_of_prod_left
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformlyOnFilter.fun_mul
+
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOnFilter.div (hf : TendstoUniformlyOnFilter f g l l')
     (hf' : TendstoUniformlyOnFilter f' g' l l') : TendstoUniformlyOnFilter (f / f') (g / g') l l' :=
   fun u hu =>
   ((uniformContinuous_div.comp_tendstoUniformlyOnFilter (hf.prodMk hf')) u hu).diag_of_prod_left
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformlyOnFilter.fun_div
+
+@[to_additive (attr := to_fun)]
+theorem TendstoUniformlyOnFilter.inv (hf : TendstoUniformlyOnFilter f g l l') :
+    TendstoUniformlyOnFilter (f⁻¹) (g⁻¹) l l' :=
+  fun u hu ↦ uniformContinuous_inv.comp_tendstoUniformlyOnFilter hf u hu
+
+attribute [to_additive existing] TendstoUniformlyOnFilter.fun_inv
+
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOn.mul (hf : TendstoUniformlyOn f g l s)
     (hf' : TendstoUniformlyOn f' g' l s) : TendstoUniformlyOn (f * f') (g * g') l s := fun u hu =>
   ((uniformContinuous_mul.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diag_of_prod
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformlyOn.fun_mul
+
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformlyOn.div (hf : TendstoUniformlyOn f g l s)
     (hf' : TendstoUniformlyOn f' g' l s) : TendstoUniformlyOn (f / f') (g / g') l s := fun u hu =>
   ((uniformContinuous_div.comp_tendstoUniformlyOn (hf.prodMk hf')) u hu).diag_of_prod
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformlyOn.fun_div
+
+@[to_additive (attr := to_fun)]
+theorem TendstoUniformlyOn.inv (hf : TendstoUniformlyOn f g l s) :
+    TendstoUniformlyOn (f⁻¹) (g⁻¹) l s :=
+  fun u hu ↦ uniformContinuous_inv.comp_tendstoUniformlyOn hf u hu
+
+attribute [to_additive existing] TendstoUniformlyOn.fun_inv
+
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformly.mul (hf : TendstoUniformly f g l) (hf' : TendstoUniformly f' g' l) :
     TendstoUniformly (f * f') (g * g') l := fun u hu =>
   ((uniformContinuous_mul.comp_tendstoUniformly (hf.prodMk hf')) u hu).diag_of_prod
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformly.fun_mul
+
+@[to_additive (attr := to_fun)]
 theorem TendstoUniformly.div (hf : TendstoUniformly f g l) (hf' : TendstoUniformly f' g' l) :
     TendstoUniformly (f / f') (g / g') l := fun u hu =>
   ((uniformContinuous_div.comp_tendstoUniformly (hf.prodMk hf')) u hu).diag_of_prod
 
-@[to_additive]
+attribute [to_additive existing] TendstoUniformly.fun_div
+
+@[to_additive (attr := to_fun)]
+theorem TendstoUniformly.inv (hf : TendstoUniformly f g l) :
+    TendstoUniformly (f⁻¹) (g⁻¹) l :=
+  fun u hu ↦ uniformContinuous_inv.comp_tendstoUniformly hf u hu
+
+attribute [to_additive existing] TendstoUniformly.fun_inv
+
+@[to_additive (attr := to_fun)]
 theorem UniformCauchySeqOn.mul (hf : UniformCauchySeqOn f l s) (hf' : UniformCauchySeqOn f' l s) :
     UniformCauchySeqOn (f * f') l s := fun u hu => by
   simpa using (uniformContinuous_mul.comp_uniformCauchySeqOn (hf.prod' hf')) u hu
 
-@[to_additive]
+attribute [to_additive existing] UniformCauchySeqOn.fun_mul
+
+@[to_additive (attr := to_fun)]
 theorem UniformCauchySeqOn.div (hf : UniformCauchySeqOn f l s) (hf' : UniformCauchySeqOn f' l s) :
     UniformCauchySeqOn (f / f') l s := fun u hu => by
   simpa using (uniformContinuous_div.comp_uniformCauchySeqOn (hf.prod' hf')) u hu
+
+attribute [to_additive existing] UniformCauchySeqOn.fun_div
+
+@[to_additive (attr := to_fun)]
+theorem UniformCauchySeqOn.inv (hf : UniformCauchySeqOn f l s) :
+    UniformCauchySeqOn (f⁻¹) l s :=
+  fun u hu ↦ by simpa using (uniformContinuous_inv.comp_uniformCauchySeqOn hf u hu)
+
+attribute [to_additive existing] UniformCauchySeqOn.fun_inv
 
 end UniformConvergence
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
