### PR TITLE
[Merged by Bors] - ci: Update the workflow so the chain doesn’t get skipped when upload_cache is skipped

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -655,6 +655,7 @@ jobs:
   post_steps:
     name: Post-Build Step
     needs: [build, upload_cache]
+    if: ${{ always() && needs.build.result == 'success' && (needs.upload_cache.result == 'success' || needs.upload_cache.result == 'skipped') }}
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
 

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -745,7 +745,8 @@ jobs:
 
   final:
     name: Post-CI job
-    if: ${{ inputs.run_post_ci }}
+    # ensure that this runs iff direct dependencies succeeded even if transitive dependencies  were skipped
+    if: ${{ always() && inputs.run_post_ci && needs.style_lint.result == 'success' && needs.build.result == 'success' && needs.post_steps.result == 'success' }}
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently some PRs sent to `bors` have ended up failing (#35330, #34667) because the upload_cache step was skipped, causing the required Post-Build and Post-CI jobs to get skipped as well. This PR adjusts the conditionals to ensure that those steps still run even if the cache upload gets skipped.