### PR TITLE
[Merged by Bors] - ci: Relax cache upload gating to upload cache artifacts from non-success builds

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -400,7 +400,7 @@ jobs:
           # results of build at pr-branch/.lake/build_summary_Counterexamples.json
 
       - name: stage Mathlib cache files
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure' || steps.build.outcome == 'cancelled') }}
         shell: bash
         run: |
           rm -rf cache-staging
@@ -424,7 +424,7 @@ jobs:
 
       - name: check cache staging contents
         id: cache_staging_check
-        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure' || steps.build.outcome == 'cancelled') }}
         shell: bash
         run: |
           if find cache-staging -type f -name '*.ltar' -print -quit | grep -q .; then
@@ -434,7 +434,7 @@ jobs:
           fi
 
       - name: upload cache staging artifact
-        if: ${{ steps.cache_staging_check.outputs.has_files == 'true' }}
+        if: ${{ always() && steps.cache_staging_check.outputs.has_files == 'true' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cache-staging

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -399,17 +399,12 @@ jobs:
           ../tools-branch/scripts/lake-build-with-retry.sh Counterexamples
           # results of build at pr-branch/.lake/build_summary_Counterexamples.json
 
-      - name: prepare cache staging directory
-        if: ${{ steps.build.outcome == 'success' }}
+      - name: stage Mathlib cache files
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         shell: bash
         run: |
           rm -rf cache-staging
           mkdir -p cache-staging
-
-      - name: stage Mathlib cache files
-        if: ${{ steps.build.outcome == 'success' }}
-        shell: bash
-        run: |
           cd pr-branch
           lake env ../tools-branch/.lake/build/bin/cache --staging-dir="../cache-staging" stage
 
@@ -429,7 +424,7 @@ jobs:
 
       - name: check cache staging contents
         id: cache_staging_check
-        if: ${{ steps.build.outcome == 'success' }}
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         shell: bash
         run: |
           if find cache-staging -type f -name '*.ltar' -print -quit | grep -q .; then
@@ -609,7 +604,7 @@ jobs:
     # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
     # but not if any earlier step failed or was cancelled.
     # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
-    if: ${{ always() && needs.build.outputs.build-outcome == 'success' && needs.build.outputs.get-cache-outcome == 'success' && needs.build.outputs.cache-staging-has-files == 'true' }}
+    if: ${{ always() && needs.build.outputs.cache-staging-has-files == 'true' }}
     steps:
       - name: Checkout tools branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Fixing an issue caught by @bryangingechen. We want to upload the build artifacts on failure also, so we run the cache job iff we had some artifacts to stage (and try to stage stuff whenever we had 'some' build)