### PR TITLE
feat(SimpleGraph): `bypass` lemmas

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -753,7 +753,7 @@ lemma bypass_cons_nil (hadj : G.Adj u v) : (cons hadj nil).bypass = cons hadj ni
 lemma bypass_eq_nil (p : G.Walk u u) : p.bypass = nil := by
   grind [p.bypass_isPath, isPath_iff_eq_nil]
 
-lemma bypass_eq_of_isPath (p : G.Walk u v) (h : p.IsPath) : p.bypass = p := by
+lemma bypass_eq_of_isPath {p : G.Walk u v} (h : p.IsPath) : p.bypass = p := by
   induction p <;> grind [cons_isPath_iff, bypass]
 
 /-- Given a walk, produces a path with the same endpoints using `SimpleGraph.Walk.bypass`. -/
@@ -815,11 +815,11 @@ lemma edges_cycleBypass_subset : ∀ {w : G.Walk v v}, w.cycleBypass.edges ⊆ w
     gcongr
     exact edges_bypass_subset _
 
-lemma cycleBypass_eq_of_isCycle (p : G.Walk u u) (h : p.IsCycle) : p.cycleBypass = p := by
+lemma cycleBypass_eq_of_isCycle {p : G.Walk u u} (h : p.IsCycle) : p.cycleBypass = p := by
   cases p
   · simp
   · simp only [cycleBypass, cons.injEq, heq_eq_eq, true_and]
-    exact bypass_eq_of_isPath _ (by simpa using h.isPath_tail)
+    exact bypass_eq_of_isPath (by simpa using h.isPath_tail)
 
 lemma IsTrail.isCycle_cycleBypass : ∀ {w : G.Walk v v}, w ≠ .nil → w.IsTrail → w.cycleBypass.IsCycle
   | .cons (v := v') hvv' w, _, hw => by

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -745,6 +745,17 @@ lemma bypass_eq_self_of_length_le (p : G.Walk u v) (h : p.length ≤ p.bypass.le
         Nat.add_le_add_iff_right] at h
       rw [ih h]
 
+@[simp]
+lemma bypass_cons_nil (hadj : G.Adj u v) : (cons hadj nil).bypass = cons hadj nil := by
+  grind [bypass, support_nil, SimpleGraph.irrefl]
+
+@[simp]
+lemma bypass_eq_nil (p : G.Walk u u) : p.bypass = nil := by
+  grind [p.bypass_isPath, isPath_iff_eq_nil]
+
+lemma bypass_eq_of_isPath (p : G.Walk u v) (h : p.IsPath) : p.bypass = p := by
+  induction p <;> grind [cons_isPath_iff, bypass]
+
 /-- Given a walk, produces a path with the same endpoints using `SimpleGraph.Walk.bypass`. -/
 def toPath (p : G.Walk u v) : G.Path u v :=
   ⟨p.bypass, p.bypass_isPath⟩
@@ -803,6 +814,12 @@ lemma edges_cycleBypass_subset : ∀ {w : G.Walk v v}, w.cycleBypass.edges ⊆ w
     dsimp only [cycleBypass, edges_cons]
     gcongr
     exact edges_bypass_subset _
+
+lemma cycleBypass_eq_of_isCycle (p : G.Walk u u) (h : p.IsCycle) : p.cycleBypass = p := by
+  cases p
+  · simp
+  · simp only [cycleBypass, cons.injEq, heq_eq_eq, true_and]
+    exact bypass_eq_of_isPath _ (by simpa using h.isPath_tail)
 
 lemma IsTrail.isCycle_cycleBypass : ∀ {w : G.Walk v v}, w ≠ .nil → w.IsTrail → w.cycleBypass.IsCycle
   | .cons (v := v') hvv' w, _, hw => by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
