### PR TITLE
[Merged by Bors] - feat(SimpleGraph): `IsEdgeReachable` lemmas

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -89,18 +89,15 @@ lemma IsEdgeConnected.connected [Nonempty V] (hk : k ≠ 0) (h : G.IsEdgeConnect
     G.Connected where
   preconnected := h.preconnected hk
 
-lemma IsEdgeReachable.le_degree [G.LocallyFinite] (h : G.IsEdgeReachable k u v) (huv : u ≠ v) :
-    k ≤ G.degree u := by
+lemma IsEdgeReachable.le_degree [Fintype (G.neighborSet u)] (h : G.IsEdgeReachable k u v)
+    (huv : u ≠ v) : k ≤ G.degree u := by
   classical
   by_contra! hh
   obtain ⟨w, _⟩ := @h (G.incidenceSet u) (by simpa [← Set.coe_fintypeCard]) |>.exists_isPath
-  have : 1 < w.support.length := by
-    by_contra! hh
-    exact huv <| Walk.eq_of_length_eq_zero (by simpa using hh)
-  simpa using w.isChain_adj_support.getElem 0 this
+  simpa using w.adj_snd <| by grind [Walk.nil_iff_length_eq, Walk.eq_of_length_eq_zero]
 
-lemma IsEdgeConnected.le_degree [G.LocallyFinite] [Nontrivial V] (h : G.IsEdgeConnected k) :
-    k ≤ G.degree u := by
+lemma IsEdgeConnected.le_degree [Fintype (G.neighborSet u)] [Nontrivial V]
+    (h : G.IsEdgeConnected k) : k ≤ G.degree u := by
   obtain ⟨v, hv⟩ := exists_ne u
   exact (h u v).le_degree hv.symm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -76,11 +76,11 @@ lemma isEdgeConnected_one : G.IsEdgeConnected 1 ↔ G.Preconnected := by
 lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
   isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
 
-lemma IsEdgeReachable.subsingleton [Subsingleton V] : G.IsEdgeReachable k u v :=
-  fun _ _ ↦ Reachable.of_subsingleton
+lemma IsEdgeReachable.of_subsingleton [Subsingleton V] : G.IsEdgeReachable k u v :=
+  fun _ _ ↦ .of_subsingleton
 
-lemma IsEdgeConnected.subsingleton [Subsingleton V] : G.IsEdgeConnected k :=
-  fun _ _ ↦ IsEdgeReachable.subsingleton
+lemma IsEdgeConnected.of_subsingleton [Subsingleton V] : G.IsEdgeConnected k :=
+  fun _ _ ↦ .of_subsingleton
 
 lemma IsEdgeConnected.preconnected (hk : k ≠ 0) (h : G.IsEdgeConnected k) : G.Preconnected :=
   fun u v ↦ (h u v).reachable hk
@@ -93,7 +93,8 @@ lemma IsEdgeReachable.le_degree [Fintype (G.neighborSet u)] (h : G.IsEdgeReachab
     (huv : u ≠ v) : k ≤ G.degree u := by
   classical
   by_contra! hh
-  obtain ⟨w, _⟩ := @h (G.incidenceSet u) (by simpa [← Set.coe_fintypeCard]) |>.exists_isPath
+  obtain ⟨w, _⟩ :=
+    @h (G.incidenceSet u) (by simpa [← Set.coe_fintypeCard, ENat.coe_lt_coe]) |>.exists_isPath
   simpa using w.adj_snd <| by grind [Walk.nil_iff_length_eq, Walk.eq_of_length_eq_zero]
 
 lemma IsEdgeConnected.le_degree [Fintype (G.neighborSet u)] [Nontrivial V]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -76,12 +76,33 @@ lemma isEdgeConnected_one : G.IsEdgeConnected 1 ↔ G.Preconnected := by
 lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
   isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
 
+lemma IsEdgeReachable.subsingleton [Subsingleton V] : G.IsEdgeReachable k u v :=
+  fun _ _ ↦ Reachable.of_subsingleton
+
+lemma IsEdgeConnected.subsingleton [Subsingleton V] : G.IsEdgeConnected k :=
+  fun _ _ ↦ IsEdgeReachable.subsingleton
+
 lemma IsEdgeConnected.preconnected (hk : k ≠ 0) (h : G.IsEdgeConnected k) : G.Preconnected :=
   fun u v ↦ (h u v).reachable hk
 
 lemma IsEdgeConnected.connected [Nonempty V] (hk : k ≠ 0) (h : G.IsEdgeConnected k) :
     G.Connected where
   preconnected := h.preconnected hk
+
+lemma IsEdgeReachable.le_degree [G.LocallyFinite] (h : G.IsEdgeReachable k u v) (huv : u ≠ v) :
+    k ≤ G.degree u := by
+  classical
+  by_contra! hh
+  obtain ⟨w, _⟩ := @h (G.incidenceSet u) (by simpa [← Set.coe_fintypeCard]) |>.exists_isPath
+  have : 1 < w.support.length := by
+    by_contra! hh
+    exact huv <| Walk.eq_of_length_eq_zero (by simpa using hh)
+  simpa using w.isChain_adj_support.getElem 0 this
+
+lemma IsEdgeConnected.le_degree [G.LocallyFinite] [Nontrivial V] (h : G.IsEdgeConnected k) :
+    k ≤ G.degree u := by
+  obtain ⟨v, hv⟩ := exists_ne u
+  exact (h u v).le_degree hv.symm
 
 lemma isEdgeReachable_add_one (hk : k ≠ 0) :
     G.IsEdgeReachable (k + 1) u v ↔ ∀ e, (G.deleteEdges {e}).IsEdgeReachable k u v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -76,9 +76,11 @@ lemma isEdgeConnected_one : G.IsEdgeConnected 1 ↔ G.Preconnected := by
 lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
   isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
 
+@[nontriviality]
 lemma IsEdgeReachable.of_subsingleton [Subsingleton V] : G.IsEdgeReachable k u v :=
   fun _ _ ↦ .of_subsingleton
 
+@[nontriviality]
 lemma IsEdgeConnected.of_subsingleton [Subsingleton V] : G.IsEdgeConnected k :=
   fun _ _ ↦ .of_subsingleton
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
