### PR TITLE
[Merged by Bors] - chore(NumberTheory/Height/Basic): fix names, add `to_fun`, more API

### DIFF
--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -140,7 +140,7 @@ lemma mulHeight₁_pos (x : K) : 0 < mulHeight₁ x :=
 lemma mulHeight₁_ne_zero (x : K) : mulHeight₁ x ≠ 0 :=
   (mulHeight₁_pos x).ne'
 
-lemma zero_le_mulHeight₁ (x : K) : 0 ≤ mulHeight₁ x :=
+lemma mulHeight₁_nonneg (x : K) : 0 ≤ mulHeight₁ x :=
   (mulHeight₁_pos x).le
 
 /-- The logarithmic height of an element of `K`. -/
@@ -221,11 +221,11 @@ lemma mulHeight_eq {x : ι → K} (hx : x ≠ 0) :
       (archAbsVal.map fun v ↦ ⨆ i, v (x i)).prod * ∏ᶠ v : nonarchAbsVal, ⨆ i, v.val (x i) := by
   simp [mulHeight, hx]
 
-@[simp]
+@[to_fun (attr := simp)]
 lemma mulHeight_zero : mulHeight (0 : ι → K) = 1 := by
   simp [mulHeight]
 
-@[simp]
+@[to_fun (attr := simp)]
 lemma mulHeight_one : mulHeight (1 : ι → K) = 1 := by
   rcases isEmpty_or_nonempty ι with hι | hι
   · rw [show (1 : ι → K) = 0 from Subsingleton.elim ..]
@@ -253,6 +253,14 @@ lemma mulHeight_swap (x y : K) : mulHeight ![x, y] = mulHeight ![y, x] := by
 def logHeight (x : ι → K) : ℝ := log (mulHeight x)
 
 lemma logHeight_eq_log_mulHeight (x : ι → K) : logHeight x = log (mulHeight x) := rfl
+
+@[to_fun (attr := simp)]
+lemma logHeight_zero {ι : Type*} : logHeight (0 : ι → K) = 0 := by
+  simp [logHeight_eq_log_mulHeight]
+
+@[to_fun (attr := simp)]
+lemma logHeight_one {ι : Type*} : logHeight (1 : ι → K) = 0 := by
+  simp [logHeight_eq_log_mulHeight]
 
 variable {α : Type*}
 
@@ -325,10 +333,10 @@ lemma one_le_mulHeight (x : ι → K) : 1 ≤ mulHeight x := by
 lemma mulHeight_pos (x : ι → K) : 0 < mulHeight x :=
   zero_lt_one.trans_le <| one_le_mulHeight x
 
-lemma mulHeight.ne_zero (x : ι → K) : mulHeight x ≠ 0 :=
+lemma mulHeight_ne_zero (x : ι → K) : mulHeight x ≠ 0 :=
   (mulHeight_pos x).ne'
 
-lemma zero_le_logHeight (x : ι → K) : 0 ≤ logHeight x :=
+lemma logHeight_nonneg (x : ι → K) : 0 ≤ logHeight x :=
   log_nonneg <| one_le_mulHeight x
 
 end Height
@@ -363,7 +371,7 @@ meta def evalLogHeight : PositivityExt where eval {u α} _ _ e := do
     match ← trySynthInstanceQ q(Finite $ι) with
     | .some _instFinite =>
       assertInstancesCommute
-      return .nonnegative q(zero_le_logHeight $a)
+      return .nonnegative q(logHeight_nonneg $a)
     | _ => throwError "index type in Height.logHeight not known to be finite"
   | _, _, _ => throwError "not Height.logHeight"
 


### PR DESCRIPTION
This PR does some house-keeping:
* change two names from `zero_le_xxx` to `xxx_nonneg` as per the naming convention
* add `to_fun` to `mulHeight_{zero|one}`
* add the two parallel API lemmas `logHeight_{zero|one}` (with `to_fun` attribute)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
