### PR TITLE
[Merged by Bors] - chore(Translate): use `Term.applyAttributes`

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1226,30 +1226,13 @@ partial def applyAttributes (t : TranslateData) (cfg : Config) (src tgt : Name) 
   if attrs.size > 0 then
     trace[translate_detail] "Applying attributes {attrs.map (·.stx)} to {allDecls}"
   for attr in attrs do
-    withRef attr.stx do withLogging do
     if attr.name == `simps then
-      translateLemmas t allDecls reorder relevantArg "simps lemmas" cfg.ref
-        (simpsTacFromSyntax · attr.stx)
-      return
-    let env ← getEnv
-    match getAttributeImpl env attr.name with
-    | Except.error errMsg => throwError errMsg
-    | Except.ok attrImpl =>
-      let runAttr := do
-        for decl in allDecls do
-          attrImpl.add decl attr.stx attr.kind
-      -- not truly an elaborator, but a sensible target for go-to-definition
-      let elaborator := attrImpl.ref
-      if (← getInfoState).enabled && (← getEnv).contains elaborator then
-        withInfoContext (mkInfo := return .ofCommandInfo { elaborator, stx := attr.stx }) do
-          try runAttr
-          finally if attr.stx[0].isIdent || attr.stx[0].isAtom then
-            -- Add an additional node over the leading identifier if there is one
-            -- to make it look more function-like.
-            -- Do this last because we want user-created infos to take precedence
-            pushInfoLeaf <| .ofCommandInfo { elaborator, stx := attr.stx[0] }
-      else
-        runAttr
+      withRef attr.stx do withLogging do
+        translateLemmas t allDecls reorder relevantArg "simps lemmas" cfg.ref
+          (simpsTacFromSyntax · attr.stx)
+    else
+      for decl in allDecls do
+        Term.applyAttributes decl #[attr]
   return nestedDecls
 
 /--


### PR DESCRIPTION
This PR uses the function `Term.applyAttributes` in `to_additive`/`to_dual` for applying attributes. Previously, the code that was there was a copy-paste of `Term.applyAttributes` (and this was outdated due to changes from the module system).

One advantage of the original implementation was the fact that it only calls `pushInfoLeaf` once, and in the new implementation this will typically be done twice for the same syntax. However, I think that this is not a good enough reason for duplicating so much code.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
