### PR TITLE
[Merged by Bors] - feat(SimpleGraph): `IsAcyclic` iff not 2-edge-reachable

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -639,18 +639,18 @@ lemma IsAcyclic.chromaticNumber_le_two (hG : G.IsAcyclic) : G.chromaticNumber �
 lemma IsTree.chromaticNumber_le_two (hG : G.IsTree) : G.chromaticNumber ≤ 2 :=
   hG.colorable_two.chromaticNumber_le
 
-lemma exists_isCycle_of_isEdgeReachable_two {u v : V} (huv : u ≠ v)
-    (h : G.IsEdgeReachable 2 u v) : ∃ w : G.Walk u u, w.IsCycle := by
+lemma exists_isCycle_of_two_le_isEdgeReachable {u v : V} (huv : u ≠ v) {n : ℕ} (hn : 2 ≤ n)
+    (h : G.IsEdgeReachable n u v) : ∃ w : G.Walk u u, w.IsCycle := by
   classical
-  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv h
+  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti hn)
   have := @h {s(u, w)} (by simp; norm_cast)
   obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
-  exact ⟨p.rotate (p.fst_mem_support_of_mem_edges hp₂), IsCycle.rotate hp₁ _⟩
+  exact ⟨p.rotate _ (p.fst_mem_support_of_mem_edges hp₂), IsCycle.rotate hp₁ _⟩
 
 lemma isAcyclic_iff_pairwise_not_isEdgeReachable_two :
     G.IsAcyclic ↔ Pairwise (¬G.IsEdgeReachable 2 · ·) := by
   refine ⟨fun h _ _ hne he ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨w, hw⟩ := exists_isCycle_of_isEdgeReachable_two hne he
+  · obtain ⟨w, hw⟩ := exists_isCycle_of_two_le_isEdgeReachable hne le_rfl he
     exact h w hw
   · refine isAcyclic_iff_forall_adj_isBridge.mpr fun _ _ hadj ↦ ?_
     exact isBridge_iff_adj_and_not_isEdgeConnected_two.mpr ⟨hadj, h hadj.ne⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -643,7 +643,7 @@ lemma exists_isCycle_of_isEdgeReachable_two {u v : V} (huv : u ≠ v)
     (h : G.IsEdgeReachable 2 u v) : ∃ w : G.Walk u u, w.IsCycle := by
   classical
   obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv h
-  have := @h {s(u, w)} (by simp)
+  have := @h {s(u, w)} (by simp; norm_cast)
   obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
   exact ⟨p.rotate (p.fst_mem_support_of_mem_edges hp₂), IsCycle.rotate hp₁ _⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -649,10 +649,10 @@ lemma exists_isCycle_of_isEdgeReachable_two {u v : V} (huv : u ≠ v)
 
 lemma isAcyclic_iff_pairwise_not_isEdgeReachable_two :
     G.IsAcyclic ↔ Pairwise (¬G.IsEdgeReachable 2 · ·) := by
-  refine ⟨fun h u v hne he ↦ ?_, fun h ↦ ?_⟩
+  refine ⟨fun h _ _ hne he ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨w, hw⟩ := exists_isCycle_of_isEdgeReachable_two hne he
     exact h w hw
-  · refine isAcyclic_iff_forall_adj_isBridge.mpr fun u v huv ↦ ?_
-    exact isBridge_iff_adj_and_not_isEdgeConnected_two.mpr ⟨huv, h huv.ne⟩
+  · refine isAcyclic_iff_forall_adj_isBridge.mpr fun _ _ hadj ↦ ?_
+    exact isBridge_iff_adj_and_not_isEdgeConnected_two.mpr ⟨hadj, h hadj.ne⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Combinatorics.SimpleGraph.Bipartite
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
+public import Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
 public import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 public import Mathlib.Combinatorics.SimpleGraph.Metric
 
@@ -637,5 +638,21 @@ lemma IsAcyclic.chromaticNumber_le_two (hG : G.IsAcyclic) : G.chromaticNumber �
 /-- The chromatic number of a tree is at most 2. -/
 lemma IsTree.chromaticNumber_le_two (hG : G.IsTree) : G.chromaticNumber ≤ 2 :=
   hG.colorable_two.chromaticNumber_le
+
+lemma exists_isCycle_of_isEdgeReachable_two {u v : V} (huv : u ≠ v)
+    (h : G.IsEdgeReachable 2 u v) : ∃ w : G.Walk u u, w.IsCycle := by
+  classical
+  obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv h
+  have := @h {s(u, w)} (by simp)
+  obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
+  exact ⟨p.rotate (p.fst_mem_support_of_mem_edges hp₂), IsCycle.rotate hp₁ _⟩
+
+lemma isAcyclic_iff_pairwise_not_isEdgeReachable_two :
+    G.IsAcyclic ↔ Pairwise (¬G.IsEdgeReachable 2 · ·) := by
+  refine ⟨fun h u v hne he ↦ ?_, fun h ↦ ?_⟩
+  · obtain ⟨w, hw⟩ := exists_isCycle_of_isEdgeReachable_two hne he
+    exact h w hw
+  · refine isAcyclic_iff_forall_adj_isBridge.mpr fun u v huv ↦ ?_
+    exact isBridge_iff_adj_and_not_isEdgeConnected_two.mpr ⟨huv, h huv.ne⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -145,7 +145,7 @@ lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e
 lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
   simp [isEdgeConnected_add_one]
 
-lemma exists_adj_isEdgeReachable_two (huv : u ≠ v) (h : G.IsEdgeReachable 2 u v) :
+lemma exists_adj_isEdgeReachable_two (hne : u ≠ v) (h : G.IsEdgeReachable 2 u v) :
     ∃ w : V, G.Adj u w ∧ G.IsEdgeReachable 2 u w := by
   obtain ⟨w, hw⟩ := h.reachable (by simp) |>.exists_isPath
   have : G.Adj u w.snd := Walk.adj_snd (by grind [Walk.not_nil_of_ne])
@@ -155,8 +155,7 @@ lemma exists_adj_isEdgeReachable_two (huv : u ≠ v) (h : G.IsEdgeReachable 2 u 
     refine Reachable.trans (h hs) <| w.tail.toDeleteEdge _ (fun hh ↦ ?_) |>.reachable.symm
     have := hw.tail.eq_snd_of_mem_edges (Sym2.eq_swap ▸ hh)
     simp only [Walk.getVert_tail, Nat.reduceAdd] at this
-    have := hw.getVert_eq_start_iff_of_not_nil (Walk.not_nil_of_ne huv) |>.mp this.symm
-    simp at this
+    simpa using hw.getVert_eq_start_iff_of_not_nil (Walk.not_nil_of_ne hne) |>.mp this.symm
   · refine Walk.reachable <| Walk.cons (deleteEdges_adj.mpr ⟨this, ?_⟩) Walk.nil
     contrapose! h'
     refine (Set.subsingleton_iff_singleton h').mp ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -145,6 +145,23 @@ lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e
 lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
   simp [isEdgeConnected_add_one]
 
+lemma exists_adj_isEdgeReachable_two (huv : u ≠ v) (h : G.IsEdgeReachable 2 u v) :
+    ∃ w : V, G.Adj u w ∧ G.IsEdgeReachable 2 u w := by
+  obtain ⟨w, hw⟩ := h.reachable (by simp) |>.exists_isPath
+  have : G.Adj u w.snd := Walk.adj_snd (by grind [Walk.not_nil_of_ne])
+  refine ⟨w.snd, this, fun s hs ↦ ?_⟩
+  by_cases! h' : s = {s(u, w.snd)}
+  · subst h'
+    refine Reachable.trans (h hs) <| w.tail.toDeleteEdge _ (fun hh ↦ ?_) |>.reachable.symm
+    have := hw.tail.eq_snd_of_mem_edges (Sym2.eq_swap ▸ hh)
+    simp only [Walk.getVert_tail, Nat.reduceAdd] at this
+    have := hw.getVert_eq_start_iff_of_not_nil (Walk.not_nil_of_ne huv) |>.mp this.symm
+    simp at this
+  · refine Walk.reachable <| Walk.cons (deleteEdges_adj.mpr ⟨this, ?_⟩) Walk.nil
+    contrapose! h'
+    refine (Set.subsingleton_iff_singleton h').mp ?_
+    exact Set.encard_le_one_iff_subsingleton.mp (Order.le_of_lt_succ hs)
+
 /-!
 ### 2-reachability
 

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -409,14 +409,21 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
         (by lia : (m - 1) ≤ p.length) hnm
       lia
 
-lemma IsPath.getVert_eq_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+lemma IsPath.getVert_eq_start_iff_of_not_nil {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (h : ¬p.Nil) :
     p.getVert i = u ↔ i = 0 := by
-  refine ⟨?_, by simp_all⟩
-  intro h
-  by_cases hi : i = 0
-  · exact hi
+  refine ⟨fun h ↦ ?_, by simp_all⟩
+  by_cases h' : i ≤ p.length
   · apply hp.getVert_injOn (by rw [Set.mem_setOf]; lia) (by rw [Set.mem_setOf]; lia)
     simp [h]
+  · rw [p.getVert_of_length_le (le_of_not_ge h')] at h
+    subst h
+    simp_all
+
+lemma IsPath.getVert_eq_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
+    p.getVert i = u ↔ i = 0 := by
+  by_cases h' : p.Nil
+  · simp_all [nil_iff_length_eq.mp h']
+  · exact hp.getVert_eq_start_iff_of_not_nil h'
 
 lemma IsPath.getVert_eq_end_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
     p.getVert i = w ↔ i = p.length := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
