### PR TITLE
[Merged by Bors] - feat(Analysis/LocallyConvex/WeakDual): Weak Representation Theorem

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -31,6 +31,10 @@ convex and we explicitly give a neighborhood basis in terms of the family of sem
 * `LinearMap.toSeminormFamily.withSeminorms`: the topology of a weak space is induced by the
   family of seminorms `B.toSeminormFamily`.
 * `WeakBilin.locallyConvexSpace`: a space endowed with a weak topology is locally convex.
+* `LinearMap.rightDualEquiv`: When `B` is right-separating, `F` is linearly equivalent to the
+  strong dual of `E` with the weak topology.
+* `LinearMap.leftDualEquiv`: When `B` is left-separating, `E` is linearly equivalent to the
+  strong dual of `F` with the weak topology.
 
 ## References
 
@@ -83,6 +87,11 @@ def toSeminormFamily (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) : SeminormFamily �
 @[simp]
 theorem toSeminormFamily_apply {B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜} {x y} : (B.toSeminormFamily y) x = ‖B x y‖ :=
   rfl
+
+lemma dualEmbedding_injective_of_separatingRight (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) (hr : B.SeparatingRight) :
+    Function.Injective (WeakBilin.eval B) :=
+  (injective_iff_map_eq_zero _).mpr (fun f hf ↦
+    (separatingRight_iff_linear_flip_nontrivial.mp hr) f (ContinuousLinearMap.coe_inj.mpr hf))
 
 variable {ι 𝕜 E F : Type*}
 
@@ -172,18 +181,14 @@ variable [AddCommGroup F] [Module 𝕜 F]
 
 variable (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜)
 
-lemma dualEmbedding_surjective : Function.Surjective (WeakBilin.eval B) := fun f ↦ by
+/-- The Weak Representation Theorem: Every continuous linear functional on `E` endowed with
+the `σ(E, F; B)` topology is of the form `x ↦ B(x, y)` for some `y : F`. -/
+theorem dualEmbedding_surjective : Function.Surjective (WeakBilin.eval B) := fun f ↦ by
   have : f.toLinearMap ∈ Submodule.span 𝕜 ((fun x ↦ ↑(WeakBilin.eval B x)) '' Set.univ) := by
     simpa [mem_span_iff_continuous, continuous_iff_le_induced, ← induced_to_pi] using
       f.continuous.le_induced
   obtain ⟨t, -, c, h⟩ := (Submodule.mem_span_image_iff_exists_fun 𝕜).mp this
-  exact ⟨∑ v, c v • v, by simp_all [← ContinuousLinearMap.coe_inj]⟩
-
-lemma dualEmbedding_injective_of_separatingRight {E F : Type*} [AddCommGroup E] [AddCommGroup F]
-    [Module 𝕜 E] [Module 𝕜 F] (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) (hr : B.SeparatingRight) :
-    Function.Injective (WeakBilin.eval B) :=
-  (injective_iff_map_eq_zero _).mpr (fun f hf ↦
-    (separatingRight_iff_linear_flip_nontrivial.mp hr) f (ContinuousLinearMap.coe_inj.mpr hf))
+  exact ⟨∑ v, c v • v, by simpa [← ContinuousLinearMap.coe_inj]⟩
 
 /-- When `B` is right-separating, `F` is linearly equivalent to the strong dual of `E` with the
 weak topology. -/

--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -177,9 +177,7 @@ theorem mem_span_iff_bound {f : ι → E →ₗ[𝕜] 𝕜} (φ : E →ₗ[𝕜]
     exact ⟨s, C, hC⟩
   · exact Seminorm.cont_withSeminorms_normedSpace _ this _ H
 
-variable [AddCommGroup F] [Module 𝕜 F]
-
-variable (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜)
+variable [AddCommGroup F] [Module 𝕜 F] (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜)
 
 /-- The Weak Representation Theorem: Every continuous functional on `E` endowed with
 the `σ(E, F; B)`-topology is of the form `x ↦ B(x, y)` for some `y : F`. -/

--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -168,6 +168,34 @@ theorem mem_span_iff_bound {f : ι → E →ₗ[𝕜] 𝕜} (φ : E →ₗ[𝕜]
     exact ⟨s, C, hC⟩
   · exact Seminorm.cont_withSeminorms_normedSpace _ this _ H
 
+variable [AddCommGroup F] [Module 𝕜 F]
+
+variable (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜)
+
+lemma dualEmbedding_surjective : Function.Surjective (WeakBilin.eval B) := fun f ↦ by
+  have : f.toLinearMap ∈ Submodule.span 𝕜 ((fun x ↦ ↑(WeakBilin.eval B x)) '' Set.univ) := by
+    simpa [mem_span_iff_continuous, continuous_iff_le_induced, ← induced_to_pi] using
+      f.continuous.le_induced
+  obtain ⟨t, -, c, h⟩ := (Submodule.mem_span_image_iff_exists_fun 𝕜).mp this
+  exact ⟨∑ v, c v • v, by simp_all [← ContinuousLinearMap.coe_inj]⟩
+
+lemma dualEmbedding_injective_of_separatingRight {E F : Type*} [AddCommGroup E] [AddCommGroup F]
+    [Module 𝕜 E] [Module 𝕜 F] (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) (hr : B.SeparatingRight) :
+    Function.Injective (WeakBilin.eval B) :=
+  (injective_iff_map_eq_zero _).mpr (fun f hf ↦
+    (separatingRight_iff_linear_flip_nontrivial.mp hr) f (ContinuousLinearMap.coe_inj.mpr hf))
+
+/-- When `B` is right-separating, `F` is linearly equivalent to the strong dual of `E` with the
+weak topology. -/
+noncomputable def rightDualEquiv (hr : B.SeparatingRight) : F ≃ₗ[𝕜] StrongDual 𝕜 (WeakBilin B) :=
+  LinearEquiv.ofBijective (WeakBilin.eval B)
+    ⟨dualEmbedding_injective_of_separatingRight B hr, dualEmbedding_surjective B⟩
+
+/-- When `B` is left-separating, `E` is linearly equivalent to the strong dual of `F` with the
+weak topology. -/
+noncomputable def leftDualEquiv (hl : B.SeparatingLeft) : E ≃ₗ[𝕜] StrongDual 𝕜 (WeakBilin B.flip) :=
+  rightDualEquiv _ (LinearMap.flip_separatingRight.mpr hl)
+
 end NontriviallyNormedField
 
 end

--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -181,14 +181,14 @@ variable [AddCommGroup F] [Module 𝕜 F]
 
 variable (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜)
 
-/-- The Weak Representation Theorem: Every continuous linear functional on `E` endowed with
-the `σ(E, F; B)` topology is of the form `x ↦ B(x, y)` for some `y : F`. -/
+/-- The Weak Representation Theorem: Every continuous functional on `E` endowed with
+the `σ(E, F; B)`-topology is of the form `x ↦ B(x, y)` for some `y : F`. -/
 theorem dualEmbedding_surjective : Function.Surjective (WeakBilin.eval B) := fun f ↦ by
-  have : f.toLinearMap ∈ Submodule.span 𝕜 ((fun x ↦ ↑(WeakBilin.eval B x)) '' Set.univ) := by
-    simpa [mem_span_iff_continuous, continuous_iff_le_induced, ← induced_to_pi] using
+  have : f.toLinearMap ∈
+      Submodule.span 𝕜 (ContinuousLinearMap.coeLM 𝕜 ∘ₗ WeakBilin.eval B).range := by
+    simpa [coe_range, mem_span_iff_continuous, continuous_iff_le_induced, ← induced_to_pi] using
       f.continuous.le_induced
-  obtain ⟨t, -, c, h⟩ := (Submodule.mem_span_image_iff_exists_fun 𝕜).mp this
-  exact ⟨∑ v, c v • v, by simpa [← ContinuousLinearMap.coe_inj]⟩
+  simpa
 
 /-- When `B` is right-separating, `F` is linearly equivalent to the strong dual of `E` with the
 weak topology. -/


### PR DESCRIPTION
This PR uses the material in Topology/Algebra/Module/WeakBilin.lean from the unfinished PR #26345 by @mans0954.

Given a bilinear form `B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜`, every continuous functional on `E` endowed with the `σ(E, F; B)`-topology is of the form `x ↦ B(x, y)` for some `y : F`.

The result doesn't generally seem to be named, but Narici-Beckenstein's "Topological Vector Spaces" calls it the "weak representation theorem", a term we have used for the docstring. 

---

Changes compared to  #26345:

* We have moved the material to `Analysis/LocallyConvex/WeakDual`, as this is where the supporting result `mem_span_iff_continuous` ended up. (C.f. PR #27316)
* `dualEmbedding_surjective` is now much shorter and should no longer rely on defeqs.

Co-authored-by: Christopher Hoskin <mans0954>