### PR TITLE
[Merged by Bors] - ci: create GitHub releases from version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ contains(github.ref, 'rc') }}
+          make_latest: ${{ !contains(github.ref, 'rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           prerelease: ${{ contains(github.ref, 'rc') }}
           make_latest: ${{ !contains(github.ref, 'rc') }}


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically creates GitHub releases when version tags are pushed.

Currently mathlib4 only has tags (no GitHub releases), which makes it harder to programmatically discover the latest release version. This mirrors the existing functionality in batteries' `docs-release.yml`, but without building/attaching docs.

See also https://github.com/leanprover/cslib/pull/340

Closes https://github.com/leanprover-community/mathlib4/issues/11292

🤖 Prepared with Claude Code