### PR TITLE
[Merged by Bors] - ci: add daily master tags

### DIFF
--- a/.github/workflows/daily-master-tag.yml
+++ b/.github/workflows/daily-master-tag.yml
@@ -1,0 +1,32 @@
+name: Daily master tag
+
+on:
+  schedule:
+    # Run daily at 10:00 UTC (after nightly-testing has settled)
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Create daily tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="master-$(date -u +%Y-%m-%d)"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created tag $TAG"
+          fi

--- a/.github/workflows/daily-master-tag.yml
+++ b/.github/workflows/daily-master-tag.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that creates a `master-YYYY-MM-DD` tag from master each day at 10:00 UTC.

Downstream repos that depend on mathlib can pin to these tags instead of waiting for the monthly toolchain release tags.

The workflow is idempotent (skips if the tag already exists) and can also be triggered manually via workflow_dispatch.

🤖 Prepared with Claude Code