### PR TITLE
[Merged by Bors] - chore: use authenticated gh api in nightly bump workflow

### DIFF
--- a/.github/workflows/nightly_bump_and_merge.yml
+++ b/.github/workflows/nightly_bump_and_merge.yml
@@ -59,8 +59,15 @@ jobs:
 
     - name: Get latest release tag from leanprover/lean4-nightly
       id: get-latest-release
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
-        RELEASE_TAG="$(curl -s "https://api.github.com/repos/leanprover/lean4-nightly/releases" | jq -r '.[0].tag_name')"
+        RELEASE_TAG=$(gh api repos/leanprover/lean4-nightly/releases \
+          -f per_page=1 --jq '.[0].tag_name')
+        if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+          echo "::error::Could not determine latest lean4-nightly release"
+          exit 1
+        fi
         echo "RELEASE_TAG=$RELEASE_TAG"
         echo "RELEASE_TAG=$RELEASE_TAG" >> "${GITHUB_ENV}"
         echo "new=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
@@ -88,6 +95,8 @@ jobs:
     - name: Clone lean4-nightly and get PRs
       id: get-prs
       if: steps.commit-bump.outputs.bumped == 'true'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         OLD="${{ steps.old-toolchain.outputs.old }}"
         NEW="${{ steps.get-latest-release.outputs.new }}"
@@ -121,9 +130,11 @@ jobs:
           echo "Checking commit $commit_sha for associated PRs..."
 
           # Query GitHub API for PRs associated with this commit
-          pr_numbers=$(curl -s -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/leanprover/lean4/commits/$commit_sha/pulls" | \
-            jq -r '.[] | select(.merged_at != null) | .number | tostring' 2>/dev/null || echo "")
+          pr_numbers=$(gh api "repos/leanprover/lean4/commits/$commit_sha/pulls" \
+            --jq '[.[] | select(.merged_at != null) | .number] | .[] | tostring' 2>/dev/null) || {
+            echo "::warning::Failed to fetch PRs for commit $commit_sha, skipping"
+            continue
+          }
 
           # Add each PR number to our list (duplicates will be handled later)
           for pr_num in $pr_numbers; do


### PR DESCRIPTION
This PR replaces unauthenticated `curl` calls to the GitHub API with `gh api` in the nightly bump workflow. The `gh api` command automatically uses the app token already generated in the workflow, avoiding transient failures from the unauthenticated rate limit (60 req/hour).

The [first attempt of this run](https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/22084056453/job/63814863096) failed because the API returned a rate-limit error object instead of the expected array, and `jq` crashed trying to index it.

Corresponding PRs:
- https://github.com/leanprover-community/batteries/pull/1678
- https://github.com/leanprover/cslib/pull/341

🤖 Prepared with Claude Code