### PR TITLE
[Merged by Bors] - chore: fix printf error in nightly bump Zulip message

### DIFF
--- a/.github/workflows/nightly_bump_and_merge.yml
+++ b/.github/workflows/nightly_bump_and_merge.yml
@@ -295,7 +295,7 @@ jobs:
           MESSAGE+=$'### Successfully merged branches into \'nightly-testing\':\n\n'
           for MERGE_INFO in $SUCCESSFUL_MERGES; do
             IFS='|' read -r PR_NUMBER GITHUB_DIFF _ <<< "$MERGE_INFO"
-            MESSAGE+=$(printf -- '- [lean-pr-testing-%s](%s) (adaptations for lean#%s)' "$PR_NUMBER" "$GITHUB_DIFF" "$PR_NUMBER")$'\n\n'
+            MESSAGE+="- [lean-pr-testing-${PR_NUMBER}](${GITHUB_DIFF}) (adaptations for lean#${PR_NUMBER})"$'\n\n'
           done
           MESSAGE+=$'\n'
         else
@@ -307,9 +307,9 @@ jobs:
           MESSAGE+=$'### Failed merges:\n\nThe following branches need to be merged manually into \'nightly-testing\':\n\n'
           for MERGE_INFO in $FAILED_MERGES; do
             IFS='|' read -r PR_NUMBER GITHUB_DIFF _ <<< "$MERGE_INFO"
-            MESSAGE+=$(printf '- [lean-pr-testing-%s](%s) (adaptations for lean#%s)' "$PR_NUMBER" "$GITHUB_DIFF" "$PR_NUMBER")$'\n\n'
+            MESSAGE+="- [lean-pr-testing-${PR_NUMBER}](${GITHUB_DIFF}) (adaptations for lean#${PR_NUMBER})"$'\n\n'
             MESSAGE+=$'```bash\n'
-            MESSAGE+=$(printf 'scripts/merge-lean-testing-pr.sh %s' "$PR_NUMBER")$'\n'
+            MESSAGE+="scripts/merge-lean-testing-pr.sh ${PR_NUMBER}"$'\n'
             MESSAGE+=$'```\n\n'
           done
         else


### PR DESCRIPTION
This PR fixes a bug in the nightly bump workflow where bash's builtin `printf` interprets a leading `-` in the format string as an option flag, causing `printf: - : invalid option`.

See the [failed run](https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/22084056453/job/63817494622) — the toolchain bump and push succeeded, but the Zulip notification step crashed.

The fix replaces `printf` subshells with direct string interpolation, which is simpler and avoids the issue.

🤖 Prepared with Claude Code