### PR TITLE
[Merged by Bors] - feat(Data/Set/PowersetCard): definitions on `Set.powersetCard`

### DIFF
--- a/Mathlib/Data/Set/PowersetCard.lean
+++ b/Mathlib/Data/Set/PowersetCard.lean
@@ -115,6 +115,7 @@ section of
 /-- The coercion of a finite set to its corresponding element of `Set.powersetCard`. -/
 def ofCard {s : Finset α} (s_card : s.card = n) : powersetCard α n := ⟨s, mem_iff.mpr s_card⟩
 
+@[simp]
 lemma val_ofCard {s : Finset α} (s_card : s.card = n) : Subtype.val (ofCard s_card) = s := rfl
 
 /-- The equivalence sending `a : α` to the singleton `{a}`. -/
@@ -286,11 +287,13 @@ theorem nontrivial_iff [Finite α] :
 `Finset α`. -/
 def prodEquiv : (n : ℕ) × (powersetCard α n) ≃ Finset α where
   toFun x := x.2
-  invFun x := ⟨x.card, ⟨x, by rw [mem_iff]⟩⟩
+  invFun x := ⟨x.card, ⟨x, rfl⟩⟩
   left_inv x := by ext <;> simp
 
+@[simp]
 lemma prodEquiv_apply (x : (n : ℕ) × (powersetCard α n)) : prodEquiv x = x.2 := rfl
 
-lemma prodEquiv_symm_apply (s : Finset α) : prodEquiv.symm s = ⟨s.card, ⟨s, by rw [mem_iff]⟩⟩ := rfl
+@[simp]
+lemma prodEquiv_symm_apply (s : Finset α) : prodEquiv.symm s = ⟨s.card, ⟨s, rfl⟩⟩ := rfl
 
 end Set.powersetCard

--- a/Mathlib/Data/Set/PowersetCard.lean
+++ b/Mathlib/Data/Set/PowersetCard.lean
@@ -112,6 +112,11 @@ end map
 
 section of
 
+/-- The coercion of a finite set to its corresponding element of `Set.powersetCard`. -/
+def ofCard {s : Finset α} (s_card : s.card = n) : powersetCard α n := ⟨s, mem_iff.mpr s_card⟩
+
+lemma val_ofCard {s : Finset α} (s_card : s.card = n) : Subtype.val (ofCard s_card) = s := rfl
+
 /-- The equivalence sending `a : α` to the singleton `{a}`. -/
 noncomputable def ofSingleton : α ≃ powersetCard α 1 where
   toFun a := ⟨{a}, Finset.card_singleton a⟩
@@ -175,6 +180,25 @@ theorem mem_compl {s : powersetCard α n} {a : α} :
 theorem compl_symm : (compl hm).symm = compl ((n.add_comm m).trans hm) := rfl
 
 end compl
+
+section disjUnion
+
+variable {m : ℕ} {s : powersetCard α m} {t : powersetCard α n} (hst : Disjoint s.val t.val)
+
+/-- The disjoint union of two `powersetCard`s. -/
+def disjUnion : powersetCard α (m + n) :=
+  ⟨s.val.disjUnion t hst, by rw [mem_iff, Finset.card_disjUnion, card_eq s, card_eq t]⟩
+
+variable {hst}
+
+@[simp]
+theorem coe_disjUnion : (disjUnion hst : Finset α) = s.val.disjUnion t hst := rfl
+
+@[simp]
+theorem mem_disjUnion {a : α} : a ∈ disjUnion hst ↔ a ∈ s ∨ a ∈ t :=
+  Finset.mem_disjUnion (h := hst)
+
+end disjUnion
 
 variable (α n)
 
@@ -257,5 +281,16 @@ theorem nontrivial_iff [Finite α] :
   rw [← Finite.one_lt_card_iff_nontrivial, powersetCard.card, Nat.one_lt_iff_ne_zero_and_ne_one,
     ne_eq, Nat.choose_eq_zero_iff, ne_eq, Nat.choose_eq_one_iff]
   grind
+
+/-- The bijection between the product of `(n : ℕ)` and the finsets of `α` of cardinality `n` and
+`Finset α`. -/
+def prodEquiv : (n : ℕ) × (powersetCard α n) ≃ Finset α where
+  toFun x := x.2
+  invFun x := ⟨x.card, ⟨x, by rw [mem_iff]⟩⟩
+  left_inv x := by ext <;> simp
+
+lemma prodEquiv_apply (x : (n : ℕ) × (powersetCard α n)) : prodEquiv x = x.2 := rfl
+
+lemma prodEquiv_symm_apply (s : Finset α) : prodEquiv.symm s = ⟨s.card, ⟨s, by rw [mem_iff]⟩⟩ := rfl
 
 end Set.powersetCard


### PR DESCRIPTION
This PR adds three new definitions for `Set.powersetCard`:
* `ofCard`: casts a set of cardinality `n` to its corresponding element of `Set.powersetCard α n`
* `disjUnion`: the disjoint union of finite sets as a function on `Set.powersetCard`
* `prodEquiv`: the equivalence `(n : ℕ) × (Set.powersetCard α n) ≃ Finset α`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
