### PR TITLE
[Merged by Bors] - chore(Order): fix indentation in markdown lists

### DIFF
--- a/Mathlib/Order/BourbakiWitt.lean
+++ b/Mathlib/Order/BourbakiWitt.lean
@@ -23,7 +23,7 @@ This file proves the Bourbaki-Witt Theorem.
 ## Main statements
 
 - `nonempty_fixedPoints_of_inflationary` : The Bourbaki-Witt Theorem : If $X$ is a chain complete
-partial order and $f : X → X$ is inflationary (i.e. ∀ x, x ≤ f x), then $f$ has a fixed point
+  partial order and $f : X → X$ is inflationary (i.e. ∀ x, x ≤ f x), then $f$ has a fixed point
 
 ## References
 

--- a/Mathlib/Order/GameAdd.lean
+++ b/Mathlib/Order/GameAdd.lean
@@ -26,7 +26,7 @@ We also define `Sym2.GameAdd`, which is the unordered pair analog of `Prod.GameA
 
 - `Sym2.GameAdd`: the game addition relation on unordered pairs.
 - `WellFounded.sym2_gameAdd`: formalizes induction on unordered pairs, where exactly one entry
-decreases at a time.
+  decreases at a time.
 -/
 
 @[expose] public section

--- a/Mathlib/Order/Interval/Finset/Gaps.lean
+++ b/Mathlib/Order/Interval/Finset/Gaps.lean
@@ -27,16 +27,16 @@ Technically, the definition `F.intervalGapsWithin a b` does not require `F` to b
 or endpoints to be within `[a, b]` or even require that `a ≤ b`, but it makes the most sense if
 they are actually satisfied. If they are actually satisfied, then we show that
 * `Finset.intervalGapsWithin_mapsTo`, `Finset.intervalGapsWithin_injective`,
-`Finset.intervalGapsWithin_surjOn`:
-`(fun j ↦ ((F.intervalGapsWithin h a b j.castSucc).2, (F.intervalGapsWithin h a b j.succ).1))` is
-a bijection between `Set.Iio k` and `F`.
+  `Finset.intervalGapsWithin_surjOn`:
+  `(fun j ↦ ((F.intervalGapsWithin h a b j.castSucc).2, (F.intervalGapsWithin h a b j.succ).1))` is
+  a bijection between `Set.Iio k` and `F`.
 * `Finset.intervalGapsWithin_le_fst`, `Finset.intervalGapsWithin_snd_le`,
-`Finset.intervalGapsWithin_fst_le_snd`:
-`[(F.intervalGapsWithin h a b j).1, (F.intervalGapsWithin h a b j).2]` is indeed a subinterval of
-`[a, b]` when `j < k`.
+  `Finset.intervalGapsWithin_fst_le_snd`:
+  `[(F.intervalGapsWithin h a b j).1, (F.intervalGapsWithin h a b j).2]` is indeed a subinterval of
+  `[a, b]` when `j < k`.
 * `Finset.intervalGapsWithin_pairwiseDisjoint_Ioc`: the half-closed intervals
-`[(F.intervalGapsWithin h a b j).1, (F.intervalGapsWithin h a b j).2)` are pairwise disjoint
-for `j < k + 1`.
+  `[(F.intervalGapsWithin h a b j).1, (F.intervalGapsWithin h a b j).2)` are pairwise disjoint
+  for `j < k + 1`.
 -/
 
 @[expose] public section

--- a/Mathlib/Order/PrimeSeparator.lean
+++ b/Mathlib/Order/PrimeSeparator.lean
@@ -23,7 +23,7 @@ ideal, filter, prime, distributive lattice
 ## References
 
 * [M. H. Stone, Topological representations of distributive lattices and Brouwerian logics
-(1938)][Sto1938]
+  (1938)][Sto1938]
 -/
 
 public section


### PR DESCRIPTION
Make sure to also indent subsequent lines of an item: this is required by the markdown specification (though not doc-gen), it expresses intent more clearly, and makes it easier to catch accidental misindentations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
