### PR TITLE
[Merged by Bors] - perf: try lowering prio for A(0) instances, A a graded object

### DIFF
--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -400,7 +400,7 @@ theorem of_zero_smul {i} (a : A 0) (b : A i) : of _ _ (a • b) = of _ _ a * of 
 theorem of_zero_mul (a b : A 0) : of _ 0 (a * b) = of _ 0 a * of _ 0 b :=
   of_zero_smul A a b
 
-instance GradeZero.nonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring (A 0) :=
+instance (priority := 900) GradeZero.nonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring (A 0) :=
   Function.Injective.nonUnitalNonAssocSemiring (of A 0) DFinsupp.single_injective (of A 0).map_zero
     (of A 0).map_add (of_zero_mul A) (map_nsmul _)
 
@@ -421,7 +421,7 @@ theorem of_zero_pow (a : A 0) : ∀ n : ℕ, of A 0 (a ^ n) = of A 0 a ^ n
   -- Porting note: Lean doesn't think this terminates if we only use `of_zero_pow` alone
   | n + 1 => by rw [pow_succ, pow_succ, of_zero_mul, of_zero_pow _ n]
 
-instance : NatCast (A 0) :=
+instance (priority := 900) : NatCast (A 0) :=
   ⟨GSemiring.natCast⟩
 
 
@@ -436,7 +436,7 @@ theorem of_zero_ofNat (n : ℕ) [n.AtLeastTwo] : of A 0 ofNat(n) = ofNat(n) :=
   of_natCast A n
 
 /-- The `Semiring` structure derived from `GSemiring A`. -/
-instance GradeZero.semiring : Semiring (A 0) :=
+instance (priority := 900) GradeZero.semiring : Semiring (A 0) :=
   Function.Injective.semiring (of A 0) DFinsupp.single_injective (of A 0).map_zero (of_zero_one A)
     (of A 0).map_add (of_zero_mul A) (fun _ _ ↦ (of A 0).map_nsmul _ _)
     (fun _ _ => of_zero_pow _ _ _) (of_natCast A)
@@ -461,7 +461,7 @@ section CommSemiring
 variable [∀ i, AddCommMonoid (A i)] [AddCommMonoid ι] [GCommSemiring A]
 
 /-- The `CommSemiring` structure derived from `GCommSemiring A`. -/
-instance GradeZero.commSemiring : CommSemiring (A 0) :=
+instance (priority := 900) GradeZero.commSemiring : CommSemiring (A 0) :=
   Function.Injective.commSemiring (of A 0) DFinsupp.single_injective (of A 0).map_zero
     (of_zero_one A) (of A 0).map_add (of_zero_mul A) (fun _ _ ↦ map_nsmul _ _ _)
     (fun _ _ => of_zero_pow _ _ _) (of_natCast A)
@@ -473,7 +473,7 @@ section Ring
 variable [∀ i, AddCommGroup (A i)] [AddZeroClass ι] [GNonUnitalNonAssocSemiring A]
 
 /-- The `NonUnitalNonAssocRing` derived from `GNonUnitalNonAssocSemiring A`. -/
-instance GradeZero.nonUnitalNonAssocRing : NonUnitalNonAssocRing (A 0) :=
+instance (priority := 900) GradeZero.nonUnitalNonAssocRing : NonUnitalNonAssocRing (A 0) :=
   Function.Injective.nonUnitalNonAssocRing (of A 0) DFinsupp.single_injective (of A 0).map_zero
     (of A 0).map_add (of_zero_mul A) (of A 0).map_neg (of A 0).map_sub (fun _ _ ↦ map_nsmul _ _ _)
     (fun _ _ ↦ map_zsmul _ _ _)
@@ -484,7 +484,7 @@ section Ring
 
 variable [∀ i, AddCommGroup (A i)] [AddMonoid ι] [GRing A]
 
-instance : IntCast (A 0) :=
+instance (priority := 900) : IntCast (A 0) :=
   ⟨GRing.intCast⟩
 
 @[simp]
@@ -492,7 +492,7 @@ theorem of_intCast (n : ℤ) : of A 0 n = n := by
   rfl
 
 /-- The `Ring` derived from `GSemiring A`. -/
-instance GradeZero.ring : Ring (A 0) :=
+instance (priority := 900) GradeZero.ring : Ring (A 0) :=
   Function.Injective.ring (of A 0) DFinsupp.single_injective (of A 0).map_zero (of_zero_one A)
     (of A 0).map_add (of_zero_mul A) (of A 0).map_neg (of A 0).map_sub (fun _ _ ↦ map_nsmul _ _ _)
     (fun _ _ ↦ map_zsmul _ _ _) (fun _ _ => of_zero_pow _ _ _) (of_natCast A) (of_intCast A)
@@ -504,7 +504,7 @@ section CommRing
 variable [∀ i, AddCommGroup (A i)] [AddCommMonoid ι] [GCommRing A]
 
 /-- The `CommRing` derived from `GCommSemiring A`. -/
-instance GradeZero.commRing : CommRing (A 0) :=
+instance (priority := 900) GradeZero.commRing : CommRing (A 0) :=
   Function.Injective.commRing (of A 0) DFinsupp.single_injective (of A 0).map_zero (of_zero_one A)
     (of A 0).map_add (of_zero_mul A) (of A 0).map_neg (of A 0).map_sub (fun _ _ ↦ map_nsmul _ _ _)
     (fun _ _ ↦ map_zsmul _ _ _) (fun _ _ => of_zero_pow _ _ _) (of_natCast A) (of_intCast A)

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -540,12 +540,12 @@ def submonoid : Submonoid R where
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/
-instance (priority := 900) instMonoid : Monoid (A 0) :=
+instance instMonoid : Monoid (A 0) :=
   inferInstanceAs <| Monoid (GradeZero.submonoid A)
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The commutative monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/
-instance (priority := 900) instCommMonoid
+instance instCommMonoid
     {R S : Type*} [SetLike S R] [CommMonoid R]
     {A : ι → S} [SetLike.GradedMonoid A] :
     CommMonoid (A 0) :=

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -280,7 +280,7 @@ variable [Zero ι] [GOne A]
 
 /-- `1 : A 0` is the value provided in `GOne.one`. -/
 @[nolint unusedArguments]
-instance GradeZero.one : One (A 0) :=
+instance (priority := 900) GradeZero.one : One (A 0) :=
   ⟨GOne.one⟩
 
 end One
@@ -298,7 +298,7 @@ instance GradeZero.smul (i : ι) : SMul (A 0) (A i) where
 /-- `(*) : A 0 → A 0 → A 0` is the value provided in `GradedMonoid.GMul.mul`, composed with
 an `Eq.rec` to turn `A (0 + 0)` into `A 0`.
 -/
-instance GradeZero.mul : Mul (A 0) where mul := (· • ·)
+instance (priority := 900) GradeZero.mul : Mul (A 0) where mul := (· • ·)
 
 variable {A}
 
@@ -325,7 +325,7 @@ theorem mk_zero_pow (a : A 0) (n : ℕ) : mk _ (a ^ n) = mk _ a ^ n :=
   Sigma.ext (nsmul_zero n).symm <| eqRec_heq _ _
 
 /-- The `Monoid` structure derived from `GMonoid A`. -/
-instance GradeZero.monoid : Monoid (A 0) :=
+instance (priority := 900) GradeZero.monoid : Monoid (A 0) :=
   Function.Injective.monoid (mk 0) sigma_mk_injective rfl mk_zero_smul mk_zero_pow
 
 end Monoid
@@ -335,7 +335,7 @@ section Monoid
 variable [AddCommMonoid ι] [GCommMonoid A]
 
 /-- The `CommMonoid` structure derived from `GCommMonoid A`. -/
-instance GradeZero.commMonoid : CommMonoid (A 0) :=
+instance (priority := 900) GradeZero.commMonoid : CommMonoid (A 0) :=
   Function.Injective.commMonoid (mk 0) sigma_mk_injective rfl mk_zero_smul mk_zero_pow
 
 end Monoid
@@ -540,11 +540,11 @@ def submonoid : Submonoid R where
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/
-instance instMonoid : Monoid (A 0) := inferInstanceAs <| Monoid (GradeZero.submonoid A)
+instance (priority := 900) instMonoid : Monoid (A 0) := inferInstanceAs <| Monoid (GradeZero.submonoid A)
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The commutative monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/
-instance instCommMonoid
+instance (priority := 900) instCommMonoid
     {R S : Type*} [SetLike S R] [CommMonoid R]
     {A : ι → S} [SetLike.GradedMonoid A] :
     CommMonoid (A 0) :=

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -540,7 +540,8 @@ def submonoid : Submonoid R where
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/
-instance (priority := 900) instMonoid : Monoid (A 0) := inferInstanceAs <| Monoid (GradeZero.submonoid A)
+instance (priority := 900) instMonoid : Monoid (A 0) :=
+  inferInstanceAs <| Monoid (GradeZero.submonoid A)
 
 -- TODO: it might be expensive to unify `A` in this instance in practice
 /-- The commutative monoid `A 0` inherited from `R` in the presence of `SetLike.GradedMonoid A`. -/


### PR DESCRIPTION
If Lean is looking for `Mul X` where `X` is coincidentally of the form `A 0` then the first thing it tries is `GradedMonoid.GradeZero.mul` which, if wrong, can take a long time to fail. In this PR I steer typeclass inference away from "A(0)-instances" by lowering their priority. Benchmarking is 100% green indicating that this decision is not hurting us. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

See [#mathlib4 > Typeclass Synthesis Regression @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Typeclass.20Synthesis.20Regression/near/564417997)

I initiated a new discussion about this PR here [#mathlib4 > priority hacks @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/priority.20hacks/near/574353616)