### PR TITLE
[Merged by Bors] - feat(RingTheory): `Algebra.TensorProduct.map f g` is flat if `f` and `g` are

### DIFF
--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -664,6 +664,43 @@ lemma IsPushout.cancelBaseChange_symm_tmul (s : S) (m : M) :
     (IsPushout.cancelBaseChange R S A B M).symm (s ⊗ₜ m) = algebraMap S B s ⊗ₜ m :=
   IsPushout.cancelBaseChangeAux_symm_tmul R S A B M s m
 
+variable (C : Type*) [CommRing C] [Algebra R C] [Algebra A C] [IsScalarTower R A C]
+
+/-- Algebra version of `IsPushout.cancelBaseChange`. -/
+noncomputable def IsPushout.cancelBaseChangeAlg : B ⊗[A] C ≃ₐ[S] S ⊗[R] C := by
+  refine AlgEquiv.symm
+    (AlgEquiv.ofLinearEquiv (IsPushout.cancelBaseChange R S A B C).symm ?_ ?_)
+  · simp [TensorProduct.one_def]
+  · apply LinearMap.map_mul_of_map_mul_tmul
+    simp
+
+@[simp]
+lemma IsPushout.toLinearEquiv_cancelBaseChangeAlg :
+    (IsPushout.cancelBaseChangeAlg R S A B C).toLinearEquiv =
+      IsPushout.cancelBaseChange R S A B C := by
+  rfl
+
+@[simp]
+lemma IsPushout.cancelBaseChangeAlg_tmul (c : C) :
+    IsPushout.cancelBaseChangeAlg R S A B C (1 ⊗ₜ c) = 1 ⊗ₜ c := by
+  simp [cancelBaseChangeAlg]
+
+@[simp]
+lemma IsPushout.cancelBaseChangeAlg_symm_tmul (s : S) (c : C) :
+    (IsPushout.cancelBaseChangeAlg R S A B C).symm (s ⊗ₜ c) = algebraMap S B s ⊗ₜ c := by
+  simp [cancelBaseChangeAlg]
+
+variable (S : Type*) [CommRing S] [Algebra R S] [Algebra S B] [IsScalarTower R S B]
+  [Algebra.IsPushout R S A B]
+
+attribute [local instance] TensorProduct.rightAlgebra in
+lemma IsPushout.cancelBaseChange_symm_comp_lTensor :
+    AlgHom.comp (IsPushout.cancelBaseChangeAlg R S A (S ⊗[R] A) C).symm.toAlgHom
+      (TensorProduct.lTensor _ (IsScalarTower.toAlgHom R A C)) =
+      TensorProduct.includeLeft := by
+  ext
+  simp [← TensorProduct.one_def, ← TensorProduct.tmul_one_eq_one_tmul, RingHom.algebraMap_toAlgebra]
+
 end Algebra
 
 end IsBaseChange

--- a/Mathlib/RingTheory/RingHom/Flat.lean
+++ b/Mathlib/RingTheory/RingHom/Flat.lean
@@ -197,7 +197,3 @@ lemma CommRingCat.inl_injective_of_flat
     |>.injective.comp (Algebra.TensorProduct.includeLeft_injective (S := R) (A := S) hg)
 
 end
-
-namespace Algebra
-
-end Algebra

--- a/Mathlib/RingTheory/RingHom/Flat.lean
+++ b/Mathlib/RingTheory/RingHom/Flat.lean
@@ -133,6 +133,45 @@ lemma of_isField (hR : IsField R) (f : R →+* S) : f.Flat := by
   rw [← f.algebraMap_toAlgebra, RingHom.flat_algebraMap_iff]
   infer_instance
 
+section
+
+variable [Algebra R S]
+variable (A : Type*) {B C D : Type*} [CommRing A] [Algebra R A] [Algebra S A]
+  [IsScalarTower R S A] [CommRing B] [Algebra R B] [CommRing C] [Algebra R C] [Algebra S C]
+  [IsScalarTower R S C] [CommRing D] [Algebra R D]
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra in
+lemma lTensor {f : B →ₐ[R] D} (hf : f.Flat) :
+    (Algebra.TensorProduct.lTensor (S := S) A f).Flat := by
+  algebraize [f.toRingHom, (Algebra.TensorProduct.lTensor (S := A) A f).toRingHom]
+  let e : A ⊗[R] D ≃ₐ[A ⊗[R] B] (A ⊗[R] B) ⊗[B] D :=
+    { __ := (Algebra.IsPushout.cancelBaseChangeAlg _ _ _ _ _).symm,
+      commutes' x := congr($(Algebra.IsPushout.cancelBaseChange_symm_comp_lTensor R B D A) x) }
+  exact .of_linearEquiv e.toLinearEquiv
+
+variable {A} in
+lemma tensorProductMap {f : A →ₐ[S] C} {g : B →ₐ[R] D} (hf : f.Flat) (hg : g.Flat) :
+    (Algebra.TensorProduct.map f g).Flat := by
+  have heq : Algebra.TensorProduct.map f g =
+      (Algebra.TensorProduct.map f (.id R D)).comp (Algebra.TensorProduct.map (.id _ _) g) := by
+    ext <;> simp
+  rw [heq]
+  refine RingHom.Flat.comp ?_ ?_
+  · exact hg.lTensor _
+  · have : (Algebra.TensorProduct.map f (AlgHom.id R D)).restrictScalars R =
+        (Algebra.TensorProduct.comm _ _ _).toAlgHom.comp
+          ((Algebra.TensorProduct.lTensor _ (f.restrictScalars R)).comp
+            (Algebra.TensorProduct.comm _ _ _).toAlgHom) := by
+      ext <;> simp
+    change ((Algebra.TensorProduct.map f (AlgHom.id R D)).restrictScalars R).Flat
+    rw [this]
+    refine RingHom.Flat.comp ?_ (.of_bijective <| AlgEquiv.bijective _)
+    change RingHom.Flat (RingHom.comp (Algebra.TensorProduct.lTensor D
+      (AlgHom.restrictScalars R f)).toRingHom _)
+    exact RingHom.Flat.comp (.of_bijective <| (TensorProduct.comm R A D).bijective) (lTensor D hf)
+
+end
+
 end RingHom.Flat
 
 section
@@ -158,3 +197,7 @@ lemma CommRingCat.inl_injective_of_flat
     |>.injective.comp (Algebra.TensorProduct.includeLeft_injective (S := R) (A := S) hg)
 
 end
+
+namespace Algebra
+
+end Algebra


### PR DESCRIPTION
From Proetale.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
