### PR TITLE
[Merged by Bors] - feat: `DenseRange.eq_zero_of_inner_left` and generalize `Dense.eq_zero_of_inner_right`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Continuous.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Continuous.lean
@@ -91,3 +91,39 @@ theorem Continuous.inner (hf : Continuous f) (hg : Continuous g) : Continuous fu
   continuous_iff_continuousAt.2 fun _x => by fun_prop
 
 end Continuous
+
+open Submodule
+
+variable {𝕜 E F ι : Type*} [RCLike 𝕜]
+variable [NormedAddCommGroup E] [NormedAddCommGroup F]
+variable [InnerProductSpace 𝕜 E] [InnerProductSpace ℝ F]
+variable {x y : E} {S : Set E} {f : ι → E}
+
+local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
+
+variable (𝕜) in
+theorem Dense.eq_zero_of_inner_left (hS : Dense S) (h : ∀ v ∈ S, ⟪x, v⟫ = 0) : x = 0 := by
+  let K := span 𝕜 S
+  have hK : Dense (K : Set E) := hS.mono subset_span
+  have : (⟪x, ·⟫) = 0 := (continuous_const.inner continuous_id).ext_on
+    hK continuous_const fun v ↦ Submodule.span_induction h (by simp)
+      (by simp +contextual [inner_add_right]) (by simp +contextual [inner_smul_right])
+  simpa using congr_fun this x
+
+variable (𝕜) in
+theorem Dense.eq_zero_of_inner_right (hS : Dense S) (h : ∀ v ∈ S, ⟪v, x⟫ = 0) : x = 0 :=
+  hS.eq_zero_of_inner_left 𝕜 fun v hv ↦ by rw! [← inner_conj_symm]; simp [-inner_conj_symm, h, hv]
+
+variable (𝕜) in
+theorem Dense.eq_of_inner_left (hS : Dense S) (h : ∀ v ∈ S, ⟪x, v⟫ = ⟪y, v⟫) : x = y := by
+  rw [← sub_eq_zero]; exact hS.eq_zero_of_inner_left 𝕜 (by simpa [inner_sub_left, sub_eq_zero])
+
+variable (𝕜) in
+theorem Dense.eq_of_inner_right (hS : Dense S) (h : ∀ v ∈ S, ⟪v, x⟫ = ⟪v, y⟫) : x = y := by
+  rw [← sub_eq_zero]; exact hS.eq_zero_of_inner_right 𝕜 (by simpa [inner_sub_right, sub_eq_zero])
+
+nonrec theorem DenseRange.eq_zero_of_inner_left (hf : DenseRange f) (h : ∀ i, ⟪x, f i⟫ = 0) :
+    x = 0 := hf.eq_zero_of_inner_left 𝕜 (by simpa)
+
+nonrec theorem DenseRange.eq_zero_of_inner_right (hf : DenseRange f) (h : ∀ i, ⟪f i, x⟫ = 0) :
+    x = 0 := hf.eq_zero_of_inner_right 𝕜 (by simpa)

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -129,13 +129,13 @@ the assumption that `T.domain` is dense. -/
 def adjointAux : T.adjointDomain →ₗ[𝕜] E where
   toFun y := (InnerProductSpace.toDual 𝕜 E).symm (adjointDomainMkCLMExtend T y)
   map_add' x y :=
-    hT.eq_of_inner_left fun _ => by
-      simp only [inner_add_left, Submodule.coe_add, InnerProductSpace.toDual_symm_apply,
-        adjointDomainMkCLMExtend_apply hT]
+    hT.eq_of_inner_left 𝕜 fun z zin => by
+      simp [InnerProductSpace.toDual_symm_apply, inner_add_left,
+        adjointDomainMkCLMExtend_apply hT _ ⟨z, zin⟩, inner_add_left]
   map_smul' _ _ :=
-    hT.eq_of_inner_left fun _ => by
-      simp only [inner_smul_left, Submodule.coe_smul_of_tower, RingHom.id_apply,
-        InnerProductSpace.toDual_symm_apply, adjointDomainMkCLMExtend_apply hT]
+    hT.eq_of_inner_left 𝕜 fun z zin => by
+      simp [inner_smul_left, RingHom.id_apply,
+        InnerProductSpace.toDual_symm_apply, adjointDomainMkCLMExtend_apply hT _ ⟨z, zin⟩]
 
 theorem adjointAux_inner (y : T.adjointDomain) (x : T.domain) :
     ⟪adjointAux hT y, x⟫ = ⟪(y : F), T x⟫ := by
@@ -143,7 +143,7 @@ theorem adjointAux_inner (y : T.adjointDomain) (x : T.domain) :
 
 theorem adjointAux_unique (y : T.adjointDomain) {x₀ : E}
     (hx₀ : ∀ x : T.domain, ⟪x₀, x⟫ = ⟪(y : F), T x⟫) : adjointAux hT y = x₀ :=
-  hT.eq_of_inner_left fun v => (adjointAux_inner hT _ _).trans (hx₀ v).symm
+  hT.eq_of_inner_left 𝕜 fun v vin => (adjointAux_inner hT _ _).trans (hx₀ ⟨v, vin⟩).symm
 
 variable (T)
 
@@ -304,8 +304,8 @@ theorem _root_.LinearPMap.adjoint_graph_eq_graph_adjoint (hT : Dense (T.domain :
       rintro ⟨a, ha⟩
       rw [← inner_conj_symm, ← h a ha, inner_conj_symm]
     use hx
-    apply hT.eq_of_inner_right
-    rintro ⟨a, ha⟩
+    apply hT.eq_of_inner_right 𝕜
+    rintro a ha
     rw [← h a ha, (adjoint_isFormalAdjoint hT).symm ⟨a, ha⟩ ⟨x.fst, hx⟩]
 
 @[simp]
@@ -317,9 +317,8 @@ theorem _root_.LinearPMap.graph_adjoint_toLinearPMap_eq_adjoint (hT : Dense (T.d
   intro x hx hx'
   simp only [mem_adjoint_iff, mem_graph_iff, Subtype.exists, exists_and_left, exists_eq_left, hx',
     inner_zero_right, zero_sub, neg_eq_zero, forall_exists_index, forall_apply_eq_imp_iff] at hx
-  apply hT.eq_zero_of_inner_right
-  rintro ⟨a, ha⟩
-  exact hx a ha
+  apply hT.eq_zero_of_inner_right 𝕜
+  exact fun a ha ↦ hx a ha
 
 end Submodule
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
@@ -207,27 +207,12 @@ open Submodule
 
 variable {K} {x y : E}
 
-theorem eq_zero_of_inner_left (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪x, v⟫ = 0) : x = 0 := by
-  have : (⟪x, ·⟫) = 0 := (continuous_const.inner continuous_id).ext_on
-    hK continuous_const (Subtype.forall.1 h)
-  simpa using congr_fun this x
-
 theorem eq_zero_of_mem_orthogonal (hK : Dense (K : Set E)) (h : x ∈ Kᗮ) : x = 0 :=
-  eq_zero_of_inner_left hK fun v ↦ (mem_orthogonal' _ _).1 h _ v.2
+  eq_zero_of_inner_left 𝕜 hK fun _ ↦ (mem_orthogonal' _ _).1 h _
 
 /-- If `S` is dense and `x - y ∈ Kᗮ`, then `x = y`. -/
 theorem eq_of_sub_mem_orthogonal (hK : Dense (K : Set E)) (h : x - y ∈ Kᗮ) : x = y :=
   sub_eq_zero.1 <| eq_zero_of_mem_orthogonal hK h
-
-theorem eq_of_inner_left (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
-  hK.eq_of_sub_mem_orthogonal (Submodule.sub_mem_orthogonal_of_inner_left h)
-
-theorem eq_of_inner_right (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪(v : E), x⟫ = ⟪(v : E), y⟫) :
-    x = y :=
-  hK.eq_of_sub_mem_orthogonal (Submodule.sub_mem_orthogonal_of_inner_right h)
-
-theorem eq_zero_of_inner_right (hK : Dense (K : Set E)) (h : ∀ v : K, ⟪(v : E), x⟫ = 0) : x = 0 :=
-  hK.eq_of_inner_right fun v => by rw [inner_zero_right, h v]
 
 end Dense
 


### PR DESCRIPTION
Generalize
- `DenseRange.eq_zero_of_inner_left`
- `DenseRange.eq_zero_of_inner_right`
- `Dense.eq_of_inner_left`
- `Dense.eq_of_inner_right`
to work with arbitrary sets. Also add
- `DenseRange.eq_zero_of_inner_left`
- `DenseRange.eq_zero_of_inner_right`