### PR TITLE
[Merged by Bors] - ci: Use variable instead of secret for OTLP_ENDPOINT

### DIFF
--- a/.github/workflows/export_telemetry.yaml
+++ b/.github/workflows/export_telemetry.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Export workflow telemetry
         uses: corentinmusard/otel-cicd-action@7e307f7baefcf4929d94d2844bc72d87566a75c3 # v3.0.0
         with:
-          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT_ALT }}
+          otlpEndpoint: ${{ vars.OTLP_ENDPOINT }}
           otlpHeaders: ${{ secrets.OTLP_HEADERS_ALT }}
           otelServiceName: "mathlib-ci"
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This value is not a secret, we can use a variable instead