### PR TITLE
[Merged by Bors] - ci: Enable telemetry pump for nightly-testing runs

### DIFF
--- a/.github/workflows/export_telemetry.yaml
+++ b/.github/workflows/export_telemetry.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: corentinmusard/otel-cicd-action@7e307f7baefcf4929d94d2844bc72d87566a75c3 # v3.0.0
         with:
           otlpEndpoint: ${{ vars.OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.OTLP_HEADERS_ALT }}
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
           otelServiceName: "mathlib-ci"
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           runId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/export_telemetry.yaml
+++ b/.github/workflows/export_telemetry.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   otel-export:
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: ${{ github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing' }}
     runs-on: ubuntu-latest
     steps:
       - name: Export workflow telemetry


### PR DESCRIPTION
Let's send these runs to telemetry. We can filter them out / analyze them separately based on some already-existing metadata, so we just need to modify this condition