### PR TITLE
[Merged by Bors] - feat(Data/Multiset/Powerset): show injectivity and monotonicity of powerset

### DIFF
--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -56,19 +56,18 @@ lemma subperm_iff : l₁ <+~ l₂ ↔ ∃ l, l ~ l₂ ∧ l₁ <+ l := by
 
 lemma subperm_cons_self : l <+~ a :: l := ⟨l, Perm.refl _, sublist_cons_self _ _⟩
 
+protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
+
 theorem Subperm.append {l₁ l₂ r₁ r₂ : List α} :
     l₁ <+~ l₂ → r₁ <+~ r₂ → (l₁ ++ r₁) <+~ (l₂ ++ r₂)
   | ⟨l, hl_perm, hl_sub⟩, ⟨r, hr_perm, hr_sub⟩ =>
     ⟨l ++ r, hl_perm.append hr_perm, hl_sub.append hr_sub⟩
 
-theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β) :
-    l₁ <+~ l₂ → (l₁.map f) <+~ (l₂.map f)
-  | ⟨l, hl_perm, hl_sub⟩ =>
-    ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
-
 theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} {f : α → β} (hf : Function.Injective f) :
     (l₁.map f) <+~ (l₂.map f) ↔ l₁ <+~ l₂ where
-  mpr a := Subperm.map f a
+  mpr a := by
+    obtain ⟨l, hl_perm, hl_sub⟩ := a
+    exact ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
   mp a := by
     obtain ⟨w, ⟨perm, sublist⟩⟩ := a
     obtain ⟨x, ⟨sublistₓ, mapₓ⟩⟩ := sublist_map_iff.mp sublist
@@ -78,7 +77,7 @@ theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} {f : α → β} (hf : 
       exact (map_perm_map_iff hf).mp perm
     · exact sublistₓ
 
-protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
+alias ⟨_, Subperm.map⟩ := map_subperm_map_iff
 
 protected theorem Nodup.subperm (d : Nodup l₁) (H : l₁ ⊆ l₂) : l₁ <+~ l₂ :=
   subperm_of_subset d H

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -8,6 +8,7 @@ module
 public import Batteries.Data.List.Perm
 public import Mathlib.Data.List.Basic
 public import Batteries.Tactic.Trans
+public import Mathlib.Data.List.Perm.Basic
 
 /-!
 # List Sub-permutations
@@ -64,6 +65,18 @@ theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β) :
     l₁ <+~ l₂ → (l₁.map f) <+~ (l₂.map f)
   | ⟨l, hl_perm, hl_sub⟩ =>
     ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
+
+theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} (f : α → β) (hf : Function.Injective f) :
+    (l₁.map f) <+~ (l₂.map f) ↔ l₁ <+~ l₂ where
+  mpr a := Subperm.map f a
+  mp a := by
+    obtain ⟨w, ⟨perm, sublist⟩⟩ := a
+    obtain ⟨x, ⟨sublistₓ, mapₓ⟩⟩ := List.sublist_map_iff.mp sublist
+    use x
+    constructor
+    · rw [mapₓ] at perm
+      exact (map_perm_map_iff hf).mp perm
+    · exact sublistₓ
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -55,18 +55,15 @@ lemma subperm_iff : l₁ <+~ l₂ ↔ ∃ l, l ~ l₂ ∧ l₁ <+ l := by
 
 lemma subperm_cons_self : l <+~ a :: l := ⟨l, Perm.refl _, sublist_cons_self _ _⟩
 
-theorem Subperm.append {l₁ l₂ r₁ r₂ : List α}
-    (hl : l₁.Subperm l₂) (hr : r₁.Subperm r₂) :
-    (l₁ ++ r₁).Subperm (l₂ ++ r₂) := by
-  obtain ⟨l, hl_perm, hl_sub⟩ := hl
-  obtain ⟨r, hr_perm, hr_sub⟩ := hr
-  exact ⟨l ++ r, hl_perm.append hr_perm, hl_sub.append hr_sub⟩
+theorem Subperm.append {l₁ l₂ r₁ r₂ : List α} :
+    l₁ <+~ l₂ → r₁ <+~ r₂ → (l₁ ++ r₁) <+~ (l₂ ++ r₂)
+  | ⟨l, hl_perm, hl_sub⟩, ⟨r, hr_perm, hr_sub⟩ =>
+    ⟨l ++ r, hl_perm.append hr_perm, hl_sub.append hr_sub⟩
 
-theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β)
-    (h : l₁.Subperm l₂) :
-    (l₁.map f).Subperm (l₂.map f) := by
-  obtain ⟨l, hl_perm, hl_sub⟩ := h
-  exact ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
+theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β) :
+    l₁ <+~ l₂ → (l₁.map f) <+~ (l₂.map f)
+  | ⟨l, hl_perm, hl_sub⟩ =>
+    ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -71,7 +71,7 @@ theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} {f : α → β} (hf : 
   mpr a := Subperm.map f a
   mp a := by
     obtain ⟨w, ⟨perm, sublist⟩⟩ := a
-    obtain ⟨x, ⟨sublistₓ, mapₓ⟩⟩ := List.sublist_map_iff.mp sublist
+    obtain ⟨x, ⟨sublistₓ, mapₓ⟩⟩ := sublist_map_iff.mp sublist
     use x
     constructor
     · rw [mapₓ] at perm

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -66,7 +66,7 @@ theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β) :
   | ⟨l, hl_perm, hl_sub⟩ =>
     ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
 
-theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} (f : α → β) (hf : Function.Injective f) :
+theorem map_subperm_map_iff {α β} {l₁ l₂ : List α} {f : α → β} (hf : Function.Injective f) :
     (l₁.map f) <+~ (l₂.map f) ↔ l₁ <+~ l₂ where
   mpr a := Subperm.map f a
   mp a := by

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -8,6 +8,7 @@ module
 public import Batteries.Data.List.Perm
 public import Mathlib.Data.List.Basic
 public import Batteries.Tactic.Trans
+public import Mathlib.Data.List.Sublists
 
 /-!
 # List Sub-permutations
@@ -54,6 +55,31 @@ lemma subperm_iff : l₁ <+~ l₂ ↔ ∃ l, l ~ l₂ ∧ l₁ <+ l := by
     exacts [nil_subperm, Subperm.refl _]
 
 lemma subperm_cons_self : l <+~ a :: l := ⟨l, Perm.refl _, sublist_cons_self _ _⟩
+
+theorem Subperm.append {l₁ l₂ r₁ r₂ : List α}
+    (hl : l₁.Subperm l₂) (hr : r₁.Subperm r₂) :
+    (l₁ ++ r₁).Subperm (l₂ ++ r₂) := by
+  obtain ⟨l, hl_perm, hl_sub⟩ := hl
+  obtain ⟨r, hr_perm, hr_sub⟩ := hr
+  exact ⟨l ++ r, hl_perm.append hr_perm, hl_sub.append hr_sub⟩
+
+theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β)
+    (h : l₁.Subperm l₂) :
+    (l₁.map f).Subperm (l₂.map f) := by
+  obtain ⟨l, hl_perm, hl_sub⟩ := h
+  exact ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
+
+lemma subperm_sublists'_sublists' {l₁ l₂ : List α}
+    (sublist : l₁.Sublist l₂) :
+    l₁.sublists'.Subperm l₂.sublists' := by
+  induction sublist with
+  | slnil => exact .refl _
+  | cons a _ ih =>
+    rw [sublists'_cons]
+    exact ih.trans (List.sublist_append_left ..).subperm
+  | cons₂ a _ ih =>
+    rw [List.sublists'_cons, List.sublists'_cons]
+    exact ih.append (ih.map _)
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -8,7 +8,6 @@ module
 public import Batteries.Data.List.Perm
 public import Mathlib.Data.List.Basic
 public import Batteries.Tactic.Trans
-public import Mathlib.Data.List.Sublists
 
 /-!
 # List Sub-permutations
@@ -68,18 +67,6 @@ theorem Subperm.map {α β} {l₁ l₂ : List α} (f : α → β)
     (l₁.map f).Subperm (l₂.map f) := by
   obtain ⟨l, hl_perm, hl_sub⟩ := h
   exact ⟨l.map f, hl_perm.map f, hl_sub.map f⟩
-
-lemma subperm_sublists'_sublists' {l₁ l₂ : List α}
-    (sublist : l₁.Sublist l₂) :
-    l₁.sublists'.Subperm l₂.sublists' := by
-  induction sublist with
-  | slnil => exact .refl _
-  | cons a _ ih =>
-    rw [sublists'_cons]
-    exact ih.trans (List.sublist_append_left ..).subperm
-  | cons₂ a _ ih =>
-    rw [List.sublists'_cons, List.sublists'_cons]
-    exact ih.append (ih.map _)
 
 protected alias ⟨subperm.of_cons, subperm.cons⟩ := subperm_cons
 

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -367,10 +367,15 @@ theorem Sublist.sublists' {l₁ l₂ : List α}
     rw [sublists'_cons, sublists'_cons]
     exact ih.append (ih.map _)
 
-theorem sublists'_sublist_sublists'_iff_sublist {l₁ l₂ : List α} :
+@[simp]
+theorem sublists'_sublist_sublists'_iff {l₁ l₂ : List α} :
     l₁.sublists' <+ l₂.sublists' ↔ l₁ <+ l₂ where
   mpr := Sublist.sublists'
-  mp sublist := mem_sublists'.mp <| sublist.subset <| mem_sublists'.mpr <| List.Sublist.refl _
+  mp sublist := mem_sublists'.mp <| sublist.subset <| mem_sublists'.mpr <| .refl _
+
+theorem subperm_of_sublists'_subperm_sublists' {l₁ l₂ : List α}
+    (subperm : l₁.sublists' <+~ l₂.sublists') : l₁ <+~ l₂ :=
+  Sublist.subperm <| mem_sublists'.mp <| subperm.subset <| mem_sublists'.mpr <| .refl _
 
 theorem sublists_cons_perm_append (a : α) (l : List α) :
     sublists (a :: l) ~ sublists l ++ map (cons a) (sublists l) :=

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -355,14 +355,14 @@ theorem sublists_perm_sublists' (l : List α) : sublists l ~ sublists' l := by
   · exact nodup_sublists.mpr (nodup_finRange _)
   · exact (nodup_sublists'.mpr (nodup_finRange _))
 
-theorem sublists'_subperm_sublists' {l₁ l₂ : List α}
-    (sublist : l₁.Sublist l₂) :
-    l₁.sublists'.Subperm l₂.sublists' := by
+theorem Sublist.sublists' {l₁ l₂ : List α}
+    (sublist : l₁ <+ l₂) :
+    l₁.sublists' <+ l₂.sublists' := by
   induction sublist with
   | slnil => exact .refl _
   | cons a _ ih =>
     rw [sublists'_cons]
-    exact ih.trans (List.sublist_append_left ..).subperm
+    exact ih.trans (List.sublist_append_left ..)
   | cons₂ a _ ih =>
     rw [sublists'_cons, sublists'_cons]
     exact ih.append (ih.map _)

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Data.Nat.Choose.Basic
 public import Mathlib.Data.List.Perm.Basic
+public import Mathlib.Data.List.Perm.Subperm
 public import Mathlib.Data.List.Lex
 public import Mathlib.Data.List.Induction
 public import Mathlib.Data.List.Nodup
@@ -353,6 +354,18 @@ theorem sublists_perm_sublists' (l : List α) : sublists l ~ sublists' l := by
   · simp
   · exact nodup_sublists.mpr (nodup_finRange _)
   · exact (nodup_sublists'.mpr (nodup_finRange _))
+
+theorem sublists'_subperm_sublists' {l₁ l₂ : List α}
+    (sublist : l₁.Sublist l₂) :
+    l₁.sublists'.Subperm l₂.sublists' := by
+  induction sublist with
+  | slnil => exact .refl _
+  | cons a _ ih =>
+    rw [sublists'_cons]
+    exact ih.trans (List.sublist_append_left ..).subperm
+  | cons₂ a _ ih =>
+    rw [sublists'_cons, sublists'_cons]
+    exact ih.append (ih.map _)
 
 theorem sublists_cons_perm_append (a : α) (l : List α) :
     sublists (a :: l) ~ sublists l ++ map (cons a) (sublists l) :=

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -367,6 +367,11 @@ theorem Sublist.sublists' {l₁ l₂ : List α}
     rw [sublists'_cons, sublists'_cons]
     exact ih.append (ih.map _)
 
+theorem sublist_sublists'_iff_sublist {l₁ l₂ : List α} :
+    l₁.sublists' <+ l₂.sublists' ↔ l₁ <+ l₂ where
+  mpr := Sublist.sublists'
+  mp sublist := mem_sublists'.mp (sublist.subset (mem_sublists'.mpr (List.Sublist.refl _)))
+
 theorem sublists_cons_perm_append (a : α) (l : List α) :
     sublists (a :: l) ~ sublists l ++ map (cons a) (sublists l) :=
   Perm.trans (sublists_perm_sublists' _) <| by

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -367,10 +367,10 @@ theorem Sublist.sublists' {l₁ l₂ : List α}
     rw [sublists'_cons, sublists'_cons]
     exact ih.append (ih.map _)
 
-theorem sublist_sublists'_iff_sublist {l₁ l₂ : List α} :
+theorem sublists'_sublist_sublists'_iff_sublist {l₁ l₂ : List α} :
     l₁.sublists' <+ l₂.sublists' ↔ l₁ <+ l₂ where
   mpr := Sublist.sublists'
-  mp sublist := mem_sublists'.mp (sublist.subset (mem_sublists'.mpr (List.Sublist.refl _)))
+  mp sublist := mem_sublists'.mp <| sublist.subset <| mem_sublists'.mpr <| List.Sublist.refl _
 
 theorem sublists_cons_perm_append (a : α) (l : List α) :
     sublists (a :: l) ~ sublists l ++ map (cons a) (sublists l) :=

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -115,9 +115,9 @@ theorem card_powerset (s : Multiset α) : card (powerset s) = 2 ^ card s :=
   Quotient.inductionOn s <| by simp
 
 @[simp]
-theorem powerset_eq_singleton_zero_iff (s) : @powerset α s = {0} ↔ s = 0 where
+theorem powerset_eq_singleton_zero_iff (s : Multiset α) : powerset s = {0} ↔ s = 0 where
   mpr := by
-    rintro rfl
+    intro rfl
     exact powerset_zero
   mp powerset := by
     simpa using congr(card $powerset)
@@ -164,19 +164,20 @@ theorem powerset_le_powerset_iff_le {s t : Multiset α} :
     s.powerset ≤ t.powerset ↔ s ≤ t where
   mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
   mpr le :=
-    Multiset.leInductionOn le fun {l₁ l₂} hsub => by
-      rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
-      exact Sublist.subperm <| (Sublist.sublists' hsub).map Multiset.ofList
+    Multiset.leInductionOn le fun hsub => by
+      rw [powerset_coe', powerset_coe', coe_le]
+      apply Sublist.subperm
+      apply Sublist.map
+      exact Sublist.sublists' hsub
 
 lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
-  unfold Function.Injective
   intro a₁ a₂ a
   exact le_antisymm
     (powerset_le_powerset_iff_le.mp (le_of_eq a))
     (powerset_le_powerset_iff_le.mp (le_of_eq a.symm))
 
 lemma powerset_strictMono : StrictMono (@Multiset.powerset α) :=
-  strictMono_of_le_iff_le (fun _ _ ↦ Iff.symm powerset_le_powerset_iff_le)
+  strictMono_of_le_iff_le (fun _ _ ↦ powerset_le_powerset_iff_le.symm)
 
 lemma powerset_mono : Monotone (@Multiset.powerset α) :=
   powerset_strictMono.monotone

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -160,6 +160,7 @@ theorem revzip_powersetAux_perm {l₁ l₂ : List α} (p : l₁ ~ l₂) :
   simp only [fun l : List α => revzip_powersetAux_lemma l revzip_powersetAux, coe_eq_coe.2 p]
   exact (powersetAux_perm p).map _
 
+@[simp]
 theorem powerset_le_powerset_iff_le {s t : Multiset α} :
     s.powerset ≤ t.powerset ↔ s ≤ t where
   mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -164,7 +164,7 @@ theorem powerset_le_powerset_iff_le {s t : Multiset α} :
     s.powerset ≤ t.powerset ↔ s ≤ t where
   mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
   mpr le :=
-    Multiset.leInductionOn le fun hsub => by
+    leInductionOn le fun hsub => by
       rw [powerset_coe', powerset_coe', coe_le]
       apply Sublist.subperm
       apply Sublist.map

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -5,6 +5,8 @@ Authors: Mario Carneiro
 -/
 module
 
+public import Mathlib.Algebra.Ring.Nat
+public import Mathlib.Data.List.Perm.Subperm
 public import Mathlib.Data.List.Sublists
 public import Mathlib.Data.List.Zip
 public import Mathlib.Data.Multiset.Bind
@@ -104,9 +106,23 @@ theorem map_single_le_powerset (s : Multiset α) : s.map singleton ≤ powerset 
     rw [← List.map_map]
     exact ((map_pure_sublist_sublists _).map _).subperm
 
+theorem zero_mem_powerset (s) : 0 ∈ @powerset α s :=
+  Multiset.mem_powerset.mpr s.zero_le
+
+theorem self_mem_powerset (s) : s ∈ @powerset α s :=
+  Multiset.mem_powerset.mpr le_rfl
+
 @[simp]
 theorem card_powerset (s : Multiset α) : card (powerset s) = 2 ^ card s :=
   Quotient.inductionOn s <| by simp
+
+
+theorem powerset_eq_singleton_empty_iff (s) : @powerset α s = {0} ↔ s = 0 where
+  mpr := by
+    rintro rfl
+    exact powerset_zero
+  mp powerset := by
+    simpa using congr(card $powerset)
 
 theorem revzip_powersetAux {l : List α} ⦃x⦄ (h : x ∈ revzip (powersetAux l)) : x.1 + x.2 = ↑l := by
   rw [revzip, powersetAux_eq_map_coe, ← map_reverse, zip_map, ← revzip, List.mem_map] at h
@@ -289,5 +305,28 @@ alias ⟨Nodup.ofPowerset, Nodup.powerset⟩ := nodup_powerset
 protected theorem Nodup.powersetCard {n : ℕ} {s : Multiset α} (h : Nodup s) :
     Nodup (powersetCard n s) :=
   nodup_of_le (powersetCard_le_powerset _ _) (nodup_powerset.2 h)
+
+theorem le_powerset_iff_le {s t} :
+    @powerset α s ≤ @powerset α t ↔ s ≤ t where
+  mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
+  mpr le :=
+    Multiset.leInductionOn le fun {l₁ l₂} hsub => by
+      rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
+      exact (subperm_sublists'_sublists' hsub).map Multiset.ofList
+
+lemma powerset_mono : Monotone (@Multiset.powerset α) := by
+  unfold Monotone
+  intro a₁ a₂ a
+  exact le_powerset_iff_le.mpr a
+
+lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
+  unfold Function.Injective
+  intro a₁ a₂ a
+  exact le_antisymm
+    (le_powerset_iff_le.mp (le_of_eq a))
+    (le_powerset_iff_le.mp (le_of_eq a.symm))
+
+lemma powerset_strictMono : StrictMono (@Multiset.powerset α) := by
+  exact Monotone.strictMono_of_injective powerset_mono powerset_injective
 
 end Multiset

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -5,8 +5,6 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Mathlib.Algebra.Ring.Nat
-public import Mathlib.Data.List.Perm.Subperm
 public import Mathlib.Data.List.Sublists
 public import Mathlib.Data.List.Zip
 public import Mathlib.Data.Multiset.Bind
@@ -116,7 +114,6 @@ theorem self_mem_powerset (s) : s ∈ @powerset α s :=
 theorem card_powerset (s : Multiset α) : card (powerset s) = 2 ^ card s :=
   Quotient.inductionOn s <| by simp
 
-
 theorem powerset_eq_singleton_empty_iff (s) : @powerset α s = {0} ↔ s = 0 where
   mpr := by
     rintro rfl
@@ -161,6 +158,29 @@ theorem revzip_powersetAux_perm {l₁ l₂ : List α} (p : l₁ ~ l₂) :
   haveI := Classical.decEq α
   simp only [fun l : List α => revzip_powersetAux_lemma l revzip_powersetAux, coe_eq_coe.2 p]
   exact (powersetAux_perm p).map _
+
+theorem le_powerset_iff_le {s t} :
+    @powerset α s ≤ @powerset α t ↔ s ≤ t where
+  mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
+  mpr le :=
+    Multiset.leInductionOn le fun {l₁ l₂} hsub => by
+      rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
+      exact (sublists'_subperm_sublists' hsub).map Multiset.ofList
+
+lemma powerset_mono : Monotone (@Multiset.powerset α) := by
+  unfold Monotone
+  intro a₁ a₂ a
+  exact le_powerset_iff_le.mpr a
+
+lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
+  unfold Function.Injective
+  intro a₁ a₂ a
+  exact le_antisymm
+    (le_powerset_iff_le.mp (le_of_eq a))
+    (le_powerset_iff_le.mp (le_of_eq a.symm))
+
+lemma powerset_strictMono : StrictMono (@Multiset.powerset α) := by
+  exact Monotone.strictMono_of_injective powerset_mono powerset_injective
 
 /-! ### powersetCard -/
 
@@ -305,28 +325,5 @@ alias ⟨Nodup.ofPowerset, Nodup.powerset⟩ := nodup_powerset
 protected theorem Nodup.powersetCard {n : ℕ} {s : Multiset α} (h : Nodup s) :
     Nodup (powersetCard n s) :=
   nodup_of_le (powersetCard_le_powerset _ _) (nodup_powerset.2 h)
-
-theorem le_powerset_iff_le {s t} :
-    @powerset α s ≤ @powerset α t ↔ s ≤ t where
-  mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
-  mpr le :=
-    Multiset.leInductionOn le fun {l₁ l₂} hsub => by
-      rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
-      exact (subperm_sublists'_sublists' hsub).map Multiset.ofList
-
-lemma powerset_mono : Monotone (@Multiset.powerset α) := by
-  unfold Monotone
-  intro a₁ a₂ a
-  exact le_powerset_iff_le.mpr a
-
-lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
-  unfold Function.Injective
-  intro a₁ a₂ a
-  exact le_antisymm
-    (le_powerset_iff_le.mp (le_of_eq a))
-    (le_powerset_iff_le.mp (le_of_eq a.symm))
-
-lemma powerset_strictMono : StrictMono (@Multiset.powerset α) := by
-  exact Monotone.strictMono_of_injective powerset_mono powerset_injective
 
 end Multiset

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -168,11 +168,6 @@ theorem powerset_le_powerset_iff_le {s t : Multiset α} :
       rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
       exact Sublist.subperm <| (Sublist.sublists' hsub).map Multiset.ofList
 
-lemma powerset_mono : Monotone (@Multiset.powerset α) := by
-  unfold Monotone
-  intro a₁ a₂ a
-  exact powerset_le_powerset_iff_le.mpr a
-
 lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
   unfold Function.Injective
   intro a₁ a₂ a
@@ -182,6 +177,9 @@ lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
 
 lemma powerset_strictMono : StrictMono (@Multiset.powerset α) :=
   strictMono_of_le_iff_le (fun _ _ ↦ Iff.symm powerset_le_powerset_iff_le)
+
+lemma powerset_mono : Monotone (@Multiset.powerset α) :=
+  powerset_strictMono.monotone
 
 /-! ### powersetCard -/
 

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -104,17 +104,18 @@ theorem map_single_le_powerset (s : Multiset α) : s.map singleton ≤ powerset 
     rw [← List.map_map]
     exact ((map_pure_sublist_sublists _).map _).subperm
 
-theorem zero_mem_powerset (s) : 0 ∈ @powerset α s :=
+theorem zero_mem_powerset (s : Multiset α) : 0 ∈ s.powerset :=
   Multiset.mem_powerset.mpr s.zero_le
 
-theorem self_mem_powerset (s) : s ∈ @powerset α s :=
+theorem self_mem_powerset (s : Multiset α) : s ∈ s.powerset :=
   Multiset.mem_powerset.mpr le_rfl
 
 @[simp]
 theorem card_powerset (s : Multiset α) : card (powerset s) = 2 ^ card s :=
   Quotient.inductionOn s <| by simp
 
-theorem powerset_eq_singleton_empty_iff (s) : @powerset α s = {0} ↔ s = 0 where
+@[simp]
+theorem powerset_eq_singleton_zero_iff (s) : @powerset α s = {0} ↔ s = 0 where
   mpr := by
     rintro rfl
     exact powerset_zero
@@ -159,28 +160,28 @@ theorem revzip_powersetAux_perm {l₁ l₂ : List α} (p : l₁ ~ l₂) :
   simp only [fun l : List α => revzip_powersetAux_lemma l revzip_powersetAux, coe_eq_coe.2 p]
   exact (powersetAux_perm p).map _
 
-theorem le_powerset_iff_le {s t} :
-    @powerset α s ≤ @powerset α t ↔ s ≤ t where
+theorem powerset_le_powerset_iff_le {s t : Multiset α} :
+    s.powerset ≤ t.powerset ↔ s ≤ t where
   mp powerset := Multiset.mem_powerset.mp <| Multiset.mem_of_le powerset (self_mem_powerset s)
   mpr le :=
     Multiset.leInductionOn le fun {l₁ l₂} hsub => by
       rw [Multiset.powerset_coe', Multiset.powerset_coe', Multiset.coe_le]
-      exact (sublists'_subperm_sublists' hsub).map Multiset.ofList
+      exact Sublist.subperm <| (Sublist.sublists' hsub).map Multiset.ofList
 
 lemma powerset_mono : Monotone (@Multiset.powerset α) := by
   unfold Monotone
   intro a₁ a₂ a
-  exact le_powerset_iff_le.mpr a
+  exact powerset_le_powerset_iff_le.mpr a
 
 lemma powerset_injective : Function.Injective (@Multiset.powerset α) := by
   unfold Function.Injective
   intro a₁ a₂ a
   exact le_antisymm
-    (le_powerset_iff_le.mp (le_of_eq a))
-    (le_powerset_iff_le.mp (le_of_eq a.symm))
+    (powerset_le_powerset_iff_le.mp (le_of_eq a))
+    (powerset_le_powerset_iff_le.mp (le_of_eq a.symm))
 
-lemma powerset_strictMono : StrictMono (@Multiset.powerset α) := by
-  exact Monotone.strictMono_of_injective powerset_mono powerset_injective
+lemma powerset_strictMono : StrictMono (@Multiset.powerset α) :=
+  strictMono_of_le_iff_le (fun _ _ ↦ Iff.symm powerset_le_powerset_iff_le)
 
 /-! ### powersetCard -/
 


### PR DESCRIPTION
Add Injective, Monotone, and StrictMono proofs for `Multiset.powerset`. Also, add a theorem showing that the sizes of two powersets are bidirectionally related to the sizes of the underlying Multisets (`powerset_le_powerset_iff_le`), a couple of other small `Multiset.powerset` lemmas, and theorems for append and map for `List.Subperm`.

Also, thanks to Ruben Van de Velde for looking this over on the Zulip!

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
