### PR TITLE
chore(GroupAction/DomAct): mark DomMulAct as instance_reducible

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -548,7 +548,6 @@ See `LinearEquiv.conj` for the linear version of this isomorphism. -/
   __ := arrowCongrAddEquiv e e
   map_mul' _ _ := by ext; simp [arrowCongrAddEquiv]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A linear isomorphism between the domains and codomains of two spaces of linear maps gives a
 linear isomorphism with respect to an action on the domains. -/
 @[simps] def domMulActCongrRight [Semiring S] [Module S M₁]

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -46,16 +46,13 @@ instance instModule [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] :
   add_smul _ _ _ := ext fun _ => add_smul _ _ _
   zero_smul _ := ext fun _ => zero_smul _ _
 
-set_option backward.isDefEq.respectTransparency false in
 instance instDomMulActModule
     {S M M₂ : Type*} [Semiring S] [AddCommMonoid M] [AddCommMonoid M₂] [Module S M] :
     Module Sᵈᵐᵃ (M →+ M₂) where
   add_smul s s' f := AddMonoidHom.ext fun m ↦ by
     simp_rw [AddMonoidHom.add_apply, DomMulAct.smul_addMonoidHom_apply, ← map_add, ← add_smul]; rfl
   zero_smul _ := AddMonoidHom.ext fun _ ↦ by
-    rw [DomMulAct.smul_addMonoidHom_apply]
-    -- TODO there should be a simp lemma for `DomMulAct.mk.symm 0`
-    simp [DomMulAct.mk, MulOpposite.opEquiv]
+    simp [DomMulAct.smul_addMonoidHom_apply]
 
 end AddMonoidHom
 

--- a/Mathlib/Algebra/Module/LinearMap/Basic.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Basic.lean
@@ -106,12 +106,11 @@ variable [Semiring S] [Module S M] [Module S M'] [SMulCommClass R' S M']
 instance [Module.IsTorsionFree S M'] : Module.IsTorsionFree S (M →ₛₗ[σ₁₂] M') :=
   coe_injective.moduleIsTorsionFree _ coe_smul
 
-set_option backward.isDefEq.respectTransparency false in
 instance [SMulCommClass R S M] : Module Sᵈᵐᵃ (M →ₛₗ[σ₁₂] M') where
   add_smul _ _ _ := ext fun _ ↦ by
     simp_rw [add_apply, DomMulAct.smul_linearMap_apply, ← map_add, ← add_smul]; rfl
   zero_smul _ := ext fun _ ↦ by
-    simp [DomMulAct.smul_linearMap_apply, DomMulAct.mk, MulOpposite.opEquiv]
+    simp [DomMulAct.smul_linearMap_apply]
 
 end Module
 

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -91,9 +91,10 @@ open Function
 /-- If `M` multiplicatively acts on `α`, then `DomMulAct M` acts on `α → β` as well as some
 bundled maps from `α`. This is a type synonym for `MulOpposite M`, so this corresponds to a right
 action of `M`. -/
-@[to_additive /-- If `M` additively acts on `α`, then `DomAddAct M` acts on `α → β` as
-well as some bundled maps from `α`. This is a type synonym for `AddOpposite M`, so this corresponds
-to a right action of `M`. -/]
+@[instance_reducible,
+  to_additive /-- If `M` additively acts on `α`, then `DomAddAct M`
+  acts on `α → β` as well as some bundled maps from `α`. This is a type synonym for
+  `AddOpposite M`, so this corresponds to a right action of `M`. -/]
 def DomMulAct (M : Type*) := MulOpposite M
 
 @[inherit_doc] postfix:max "ᵈᵐᵃ" => DomMulAct
@@ -126,6 +127,15 @@ run_cmd
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsLeftCancelMul Mᵐᵒᵖ] : IsLeftCancelMul Mᵈᵐᵃ := ‹_›
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsRightCancelMul Mᵐᵒᵖ] : IsRightCancelMul Mᵈᵐᵃ := ‹_›
 @[to_additive] instance [Mul Mᵐᵒᵖ] [IsCancelMul Mᵐᵒᵖ] : IsCancelMul Mᵈᵐᵃ := ‹_›
+
+/-- `DomMulAct` inherits `Zero` from `MulOpposite` (needed for module scalar actions). -/
+instance instZero [Zero Mᵐᵒᵖ] : Zero Mᵈᵐᵃ := ‹_›
+
+@[simp]
+lemma mk_zero [Zero M] : mk (0 : M) = 0 := rfl
+
+@[simp]
+lemma symm_mk_zero [Zero M] : mk.symm (0 : Mᵈᵐᵃ) = 0 := rfl
 
 @[to_additive (attr := simp)]
 lemma mk_one [One M] : mk (1 : M) = 1 := rfl


### PR DESCRIPTION
This PR marks `DomMulAct` as `@[instance_reducible]` so that TC synthesis can see through the type alias, removing three `set_option backward.isDefEq.respectTransparency false` workarounds in downstream files.

Also adds a `Zero` instance for `Mᵈᵐᵃ` and `@[simp]` lemmas `mk_zero`/`symm_mk_zero`, resolving the TODO about a missing simp lemma for `DomMulAct.mk.symm 0`.

🤖 Prepared with Claude Code