### PR TITLE
chore(Algebra/Quaternion): make `Quaternion` instance_reducible

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -750,6 +750,7 @@ end QuaternionAlgebra
 
 /-- Space of quaternions over a type, denoted as `ℍ[R]`.
 Implemented as a structure with four fields: `re`, `im_i`, `im_j`, and `im_k`. -/
+@[instance_reducible]
 def Quaternion (R : Type*) [Zero R] [One R] [Neg R] :=
   QuaternionAlgebra R (-1) (0) (-1)
 

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -41,18 +41,15 @@ open scoped RealInnerProductSpace
 
 namespace Quaternion
 
-set_option backward.isDefEq.respectTransparency false in
 instance : Inner ℝ ℍ :=
   ⟨fun a b => (a * star b).re⟩
 
 theorem inner_self (a : ℍ) : ⟪a, a⟫ = normSq a :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 theorem inner_def (a b : ℍ) : ⟪a, b⟫ = (a * star b).re :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance : NormedAddCommGroup ℍ :=
   @InnerProductSpace.Core.toNormedAddCommGroup ℝ ℍ _ _ _
     { toInner := inferInstance
@@ -60,9 +57,8 @@ noncomputable instance : NormedAddCommGroup ℍ :=
       re_inner_nonneg := fun _ => normSq_nonneg
       definite := fun _ => normSq_eq_zero.1
       add_left := fun x y z => by simp only [inner_def, add_mul, re_add]
-      smul_left := fun x y r => by simp [inner_def] }
+      smul_left := fun x y r => by simp [inner_def, mul_add] }
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance : InnerProductSpace ℝ ℍ :=
   InnerProductSpace.ofCore _
 
@@ -79,7 +75,6 @@ set_option backward.isDefEq.respectTransparency false in
 theorem norm_coe (a : ℝ) : ‖(a : ℍ)‖ = ‖a‖ := by
   rw [norm_eq_sqrt_real_inner, inner_self, normSq_coe, Real.sqrt_sq_eq_abs, Real.norm_eq_abs]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp, norm_cast]
 theorem nnnorm_coe (a : ℝ) : ‖(a : ℍ)‖₊ = ‖a‖₊ :=
   Subtype.ext <| norm_coe a
@@ -89,7 +84,6 @@ set_option backward.isDefEq.respectTransparency false in
 theorem norm_star (a : ℍ) : ‖star a‖ = ‖a‖ := by
   simp_rw [norm_eq_sqrt_real_inner, inner_self, normSq_star]
 
-set_option backward.isDefEq.respectTransparency false in
 -- This does not need to be `@[simp]`, as it is a consequence of later simp lemmas.
 theorem nnnorm_star (a : ℍ) : ‖star a‖₊ = ‖a‖₊ :=
   Subtype.ext <| norm_star a
@@ -99,11 +93,11 @@ noncomputable instance : NormedDivisionRing ℍ where
   dist_eq _ _ := rfl
   norm_mul _ _ := by simp_rw [norm_eq_sqrt_real_inner, inner_self]; simp
 
+set_option backward.isDefEq.respectTransparency false in
 noncomputable instance : NormedAlgebra ℝ ℍ where
   norm_smul_le := norm_smul_le
   toAlgebra := Quaternion.algebra
 
-set_option backward.isDefEq.respectTransparency false in
 instance : CStarRing ℍ where
   norm_mul_self_le x :=
     le_of_eq <| Eq.symm <| (norm_mul _ _).trans <| congr_arg (· * ‖x‖) (norm_star x)
@@ -154,7 +148,6 @@ theorem coeComplex_one : ((1 : ℂ) : ℍ) = 1 :=
 @[simp, norm_cast]
 theorem coe_real_complex_mul (r : ℝ) (z : ℂ) : (r • z : ℍ) = ↑r * ↑z := by ext <;> simp
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp, norm_cast]
 theorem coeComplex_coe (r : ℝ) : ((r : ℂ) : ℍ) = r :=
   rfl


### PR DESCRIPTION
This PR marks `Quaternion` as `@[instance_reducible]`, removing 7 (net) `set_option backward.isDefEq.respectTransparency false` workarounds from `Analysis/Quaternion.lean`.

The `smul_left` proof in the `NormedAddCommGroup` instance needs a small adjustment (`simp [inner_def]` → `simp [inner_def, mul_add]`) since `@[instance_reducible]` changes how `simp` normalizes through the type alias.

🤖 Prepared with Claude Code