### PR TITLE
[Merged by Bors] - chore: remove redundant `Aesop` imports

### DIFF
--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Group.Equiv.Defs
 public import Mathlib.Algebra.Group.InjSurj
-public import Aesop
 
 /-!
 # `ULift` instances for groups and monoids

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Group.Defs
 public import Mathlib.Logic.Equiv.Defs
-public import Aesop
 public import Batteries.Tactic.Lint.Simp
 
 /-!

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -6,7 +6,6 @@ Authors: Anne Baanen, Eric Wieser
 module
 
 public import Mathlib.Data.Fin.Tuple.Basic
-public import Aesop
 
 /-!
 # Matrix and vector notation

--- a/Mathlib/Data/List/GetD.lean
+++ b/Mathlib/Data/List/GetD.lean
@@ -7,7 +7,6 @@ Mario Carneiro
 module
 
 public import Mathlib.Data.List.Defs
-public import Aesop
 public import Mathlib.Logic.Basic
 
 /-! # getD and getI

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 -/
 module
 
+public import Aesop
 public import Mathlib.Data.Set.Disjoint
 public import Mathlib.Tactic.Simproc.ExistsAndEq
 

--- a/Mathlib/Order/BooleanAlgebra/Defs.lean
+++ b/Mathlib/Order/BooleanAlgebra/Defs.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Bryan Gin-ge Chen
 -/
 module
 
+public import Aesop
 public import Mathlib.Order.Heyting.Basic
 
 /-!

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl
 -/
 module
 
-public import Aesop
 public import Mathlib.Order.BoundedOrder.Lattice
 
 /-!

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -9,7 +9,6 @@ public import Mathlib.Data.Set.Insert
 public import Mathlib.Order.SetNotation
 public import Mathlib.Order.BooleanAlgebra.Set
 public import Mathlib.Order.Bounds.Defs
-public import Aesop
 
 /-!
 # Definitions about filters

--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -6,7 +6,6 @@ Authors: Keeley Hoek, Patrick Massot, Kim Morrison
 module
 
 public meta import Mathlib.Lean.Expr.Basic
-public import Aesop
 public import Mathlib.Order.Hom.Basic
 public meta import Mathlib.Tactic.ToDual
 

--- a/Mathlib/Tactic/CategoryTheory/Coherence/Basic.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence/Basic.lean
@@ -6,7 +6,6 @@ Authors: Yuma Mizuno
 module
 
 public meta import Mathlib.Tactic.CategoryTheory.Coherence.Normalize
-public import Aesop
 public import Mathlib.CategoryTheory.Category.Basic
 public import Mathlib.Tactic.CategoryTheory.Coherence.Normalize
 public import Mathlib.Tactic.CategoryTheory.Coherence.PureCoherence

--- a/Mathlib/Tactic/DeriveCountable.lean
+++ b/Mathlib/Tactic/DeriveCountable.lean
@@ -9,7 +9,6 @@ public meta import Lean.Meta.Transform
 public meta import Lean.Meta.Inductive
 public meta import Lean.Elab.Deriving.Basic
 public meta import Lean.Elab.Deriving.Util
-public import Aesop
 public import Mathlib.Data.Countable.Defs
 public import Mathlib.Data.Nat.Pairing
 public meta import Mathlib.Tactic.ToAdditive

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -6,7 +6,6 @@ Authors: Arthur Paulino, Damiano Testa
 module
 
 public meta import Mathlib.Lean.Meta
-public import Aesop
 public import Mathlib.Algebra.Group.Basic
 public import Mathlib.Order.Defs.LinearOrder
 public meta import Mathlib.Tactic.ToAdditive

--- a/Mathlib/Tactic/Order/CollectFacts.lean
+++ b/Mathlib/Tactic/Order/CollectFacts.lean
@@ -8,7 +8,6 @@ module
 public meta import Qq
 public import Mathlib.Order.BoundedOrder.Basic  -- shake: keep (Qq dependency)
 public import Mathlib.Order.Lattice  -- shake: keep (Qq dependency)
-public import Aesop
 public meta import Mathlib.Tactic.ToDual
 public import Mathlib.Util.AtomM
 

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -6,7 +6,6 @@ Authors: Lenny Taelman
 module
 
 public import Mathlib.Data.Set.SymmDiff  -- shake: keep (Qq dependency)
-public import Aesop
 public meta import Mathlib.Tactic.ToDual
 
 /-!

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -6,7 +6,6 @@ Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 module
 
 public meta import Mathlib.Tactic.Basic
-public import Aesop
 public import Mathlib.Data.Int.Cast.Basic
 public import Mathlib.Order.Basic
 public meta import Mathlib.Tactic.ToAdditive


### PR DESCRIPTION
This PR removes redundant imports of `Aesop`. Two transitive imports had to be restored.

These redundant imports can appear due to `grind` replacing `aesop`, and due to the new `shake` getting fussy about preserving public imports (I don't fully understand why shake adds these redundant imports).

This helps improve parallellism when building mathlib.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
