### PR TITLE
[Merged by Bors] - chore(Geometry): fix markdown lists

### DIFF
--- a/Mathlib/Geometry/Diffeology/Basic.lean
+++ b/Mathlib/Geometry/Diffeology/Basic.lean
@@ -22,6 +22,7 @@ Concretely, this means that for our purposes a diffeological space is a type `X`
 * For every plot p : ℝⁿ → X and smooth map f : ℝᵐ → ℝⁿ, p ∘ f is a plot.
 * Every map p : ℝⁿ → X that is locally smooth is a plot, where by locally smooth we mean that ℝⁿ can
   be covered by open sets U such that p ∘ f is a plot for every smooth f : ℝᵐ → U.
+
 Every normed space, smooth manifold etc. is then naturally a diffeological space by simply taking
 the plots to be those maps ℝⁿ → X that are smooth in the traditional sense. A map `f : X → Y`
 between diffeological spaces is furthermore called smooth if postcomposition with it sends plots of

--- a/Mathlib/Geometry/Euclidean/Sphere/Ptolemy.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Ptolemy.lean
@@ -36,6 +36,7 @@ An API needs to be built around that concept, which would include:
 - a point P where the diagonals of a cyclic polygon cross exists (and is unique) with weak/strict
   betweenness depending on weak/strict cyclicity,
 - four points on a sphere with such a point P are cyclic in the appropriate order,
+
 and so on.
 -/
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -16,7 +16,7 @@ This file contains results about smoothness of standard maps associated to produ
 - the component projections from a product of manifolds are smooth.
 - functions into a product (*pi type*) are `C^n` iff their components are
 - if `M` and `N` are manifolds modelled over the same space, `Sum.inl` and `Sum.inr` are
-`C^n`, as are `Sum.elim`, `Sum.map` and `Sum.swap`.
+  `C^n`, as are `Sum.elim`, `Sum.map` and `Sum.swap`.
 
 -/
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -16,11 +16,11 @@ public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
 ## Main results
 
 * `exists_isMIntegralCurveAt_of_contMDiffAt_boundaryless`: Existence of local integral curves for a
-$C^1$ vector field. This follows from the existence theorem for solutions to ODEs
-(`exists_forall_hasDerivAt_Ioo_eq_of_contDiffAt`).
+  $C^1$ vector field. This follows from the existence theorem for solutions to ODEs
+  (`exists_forall_hasDerivAt_Ioo_eq_of_contDiffAt`).
 * `isMIntegralCurveOn_Ioo_eqOn_of_contMDiff_boundaryless`: Uniqueness of local integral curves for a
-$C^1$ vector field. This follows from the uniqueness theorem for solutions to ODEs
-(`ODE_solution_unique_of_mem_set_Ioo`). This requires the manifold to be Hausdorff (`T2Space`).
+  $C^1$ vector field. This follows from the uniqueness theorem for solutions to ODEs
+  (`ODE_solution_unique_of_mem_set_Ioo`). This requires the manifold to be Hausdorff (`T2Space`).
 
 ## Implementation notes
 

--- a/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
@@ -26,7 +26,7 @@ Define the interior and boundary of a manifold.
 - `ModelWithCorners.interior_boundary_disjoint`: interior and boundary of `M` are disjoint
 - `BoundarylessManifold.isInteriorPoint`: if `M` is boundaryless, every point is an interior point
 - `ModelWithCorners.Boundaryless.boundary_eq_empty` and `of_boundary_eq_empty`:
-`M` is boundaryless if and only if its boundary is empty
+  `M` is boundaryless if and only if its boundary is empty
 
 - `isInteriorPoint_iff_of_mem_atlas`: a point is an interior point iff any given chart around it
   sends it to the interior of the model; that is, the notion of interior is independent of choices
@@ -41,7 +41,7 @@ Define the interior and boundary of a manifold.
 - `ModelWithCorners.BoundarylessManifold.open`: if `M` is boundaryless, so is `u : Opens M`
 
 - `ModelWithCorners.interior_prod`: the interior of `M × N` is the product of the interiors
-of `M` and `N`.
+  of `M` and `N`.
 - `ModelWithCorners.boundary_prod`: the boundary of `M × N` is `∂M × N ∪ (M × ∂N)`.
 - `ModelWithCorners.BoundarylessManifold.prod`: if `M` and `N` are boundaryless, so is `M × N`
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
@@ -46,9 +46,9 @@ Let `f` be a map between manifolds. The following definitions follow the `fderiv
 Various related results are proven in separate files: see
 - `Basic.lean` for basic properties of the `mfderiv`, mimicking the API of the Fréchet derivative,
 - `FDeriv.lean` for the equivalence of the manifold notions with the usual Fréchet derivative
-for functions between vector spaces,
+  for functions between vector spaces,
 - `SpecificFunctions.lean` for results on the differential of the identity, constant functions,
-products and arithmetic operators (like addition or scalar multiplication),
+  products and arithmetic operators (like addition or scalar multiplication),
 - `Atlas.lean` for differentiability of charts, models with corners and extended charts,
 - `UniqueDifferential.lean` for various properties of unique differentiability sets in manifolds.
 


### PR DESCRIPTION
We make sure to also indent subsequent lines of an item: this is required by the markdown specification (though not doc-gen), it expresses intent more clearly, and makes it easier to catch accidental misindentations.

Furthermore, we split some text out of the ultimate item of some markdown lists, where the text was accidentally attached to it.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
