### PR TITLE
[Merged by Bors] - chore(Tactic): improve `contrapose` tactic documentation

### DIFF
--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -44,10 +44,45 @@ lemma contrapose_iff₃ {p q : Prop} : (¬ p ↔ q) → (p ↔ ¬ q) := (not_iff
 lemma contrapose_iff₄ {p q : Prop} : (p ↔ q) → (¬ p ↔ ¬ q) := fun ⟨h₁, h₂⟩ ↦ ⟨mt h₂, mt h₁⟩
 
 /--
-Transforms the goal into its contrapositive.
-* `contrapose` turns a goal `P → Q` into `¬ Q → ¬ P` and it turns a goal `P ↔ Q` into `¬ P ↔ ¬ Q`
-* `contrapose h` first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
-* `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis
+`contrapose` transforms the main goal into its contrapositive. If the goal has the form `⊢ P → Q`,
+then `contrapose turns it into `⊢ ¬ Q → ¬ P`. If the goal has the form `⊢ P ↔ Q`, then `contrapose`
+turns it into `⊢ ¬ P ↔ ¬ Q`.
+
+* `contrapose h` on a goal of the form `h : P ⊢ Q` turns the goal into `h : ¬ Q ⊢ ¬ P`. This is
+  equivalent to `revert h; contrapose; intro h`.
+* `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis. This is equivalent
+  to `revert h; contrapose; intro new_h`.
+* `contrapose!`, `contrapose! h` and `contrapose! h with new_h` push negation deeper into the goal
+  after contraposing (but before introducing the new hypothesis). See the `push_neg` tactic for more
+  details on the pushing algorithm.
+* `contrapose! (config := cfg)` controls the options for negation pushing. All options for
+  `Mathlib.Tactic.Push.Config` are supported:
+  * `contrapose! +distrib` rewrites `¬ (p ∧ q)` into `¬ p ∨ ¬ q` instead of `p → ¬ q`.
+
+Examples:
+```lean4
+variables (P Q R : Prop)
+
+example (H : ¬ Q → ¬ P) : P → Q := by
+  contrapose
+  exact H
+
+example (H : ¬ P ↔ ¬ Q) : P ↔ Q := by
+  contrapose
+  exact H
+
+example (H : ¬ Q → ¬ P) (h : P) : Q := by
+  contrapose h
+  exact H h
+
+example (H : ¬ R → P → ¬ Q) : (P ∧ Q) → R := by
+  contrapose!
+  exact H
+
+example (H : ¬ R → ¬ P ∨ ¬ Q) : (P ∧ Q) → R := by
+  contrapose! +distrib
+  exact H
+```
 -/
 syntax (name := contrapose) "contrapose" (ppSpace colGt ident (" with " ident)?)? : tactic
 macro_rules
@@ -86,10 +121,7 @@ elab_rules : tactic
   | _ =>
     throwTacticEx `contrapose g m!"the goal `{target}` is not of the form `_ → _` or `_ ↔ _`"
 
-/--
-Transforms the goal into its contrapositive and pushes negations in the result.
-Usage matches `contrapose`
--/
+@[tactic_alt contrapose]
 syntax (name := contrapose!)
   "contrapose!" optConfig (ppSpace colGt ident (" with " ident)?)? : tactic
 


### PR DESCRIPTION
This PR (re)writes the docstrings for the `contrapose` and `contrapose!` tactics to consistently match the official style guide, to make sure they are complete while not getting too long.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
