### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian/Preradical): introduce basic definition of preradicals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2298,6 +2298,7 @@ public import Mathlib.CategoryTheory.Abelian.LeftDerived
 public import Mathlib.CategoryTheory.Abelian.Monomorphisms
 public import Mathlib.CategoryTheory.Abelian.NonPreadditive
 public import Mathlib.CategoryTheory.Abelian.Opposite
+public import Mathlib.CategoryTheory.Abelian.Preradical.Basic
 public import Mathlib.CategoryTheory.Abelian.Projective.Basic
 public import Mathlib.CategoryTheory.Abelian.Projective.Dimension
 public import Mathlib.CategoryTheory.Abelian.Projective.Ext

--- a/Mathlib/CategoryTheory/Abelian/Preradical/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Preradical/Basic.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Blake Farman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Blake Farman
+-/
+module
+public import Mathlib.CategoryTheory.Abelian.Basic
+public import Mathlib.CategoryTheory.Subobject.MonoOver
+public import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
+
+/-!
+# Preradicals
+
+A **preradical** on an abelian category `C` is a monomorphism in the functor category `C ⥤ C`
+with codomain `𝟭 C`, i.e. an element of `MonoOver (𝟭 C)`.
+
+## Main definitions
+
+* `Preradical C`: The type of preradicals on `C`.
+* `Preradical.r`: The underlying endofunctor of a `Preradical`.
+* `Preradical.ι`: The structure morphism of a `Preradical`.
+* `Preradical.IsIdempotent`: The predicate expressing idempotence.
+
+## References
+
+* [Bo Stenström, *Rings and Modules of Quotients*][stenstrom1971]
+* [Bo Stenström, *Rings of Quotients*][stenstrom1975]
+
+## Tags
+
+category theory, preradical, torsion theory
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory.Abelian
+
+variable {C : Type u} [Category.{v} C] [Abelian C]
+
+variable (C) in
+/-- A preradical on an abelian category `C` is a monomorphism in `C ⥤ C` with codomain `𝟭 C`. -/
+abbrev Preradical := MonoOver (𝟭 C)
+
+namespace Preradical
+
+variable (Φ : Preradical C)
+
+/-- The underlying endofunctor `r : C ⥤ C` of a preradical `Φ`. -/
+abbrev r : C ⥤ C := Φ.obj.left
+
+/-- The structure morphism `Φ.r ⟶ 𝟭 C` of a preradical `Φ`. -/
+abbrev ι : Φ.r ⟶ 𝟭 C := Φ.obj.hom
+
+@[simp, reassoc]
+lemma r_map_ι_app (X : C) : Φ.r.map (Φ.ι.app X) = Φ.ι.app (Φ.r.obj X) := by
+  rw [← cancel_mono (Φ.ι.app X)]
+  exact Φ.ι.naturality (Φ.ι.app X)
+
+/-- A preradical `Φ` is idempotent if `Φ.r ⋙ Φ.r ≅ Φ.r`. -/
+class IsIdempotent : Prop where
+  isIso_whiskerLeft_r_ι : IsIso (Functor.whiskerLeft Φ.r Φ.ι)
+
+attribute [instance] IsIdempotent.isIso_whiskerLeft_r_ι
+
+instance [Φ.IsIdempotent] (X : C) :
+    IsIso (Φ.ι.app (Φ.r.obj X)) :=
+  inferInstanceAs (IsIso ((Functor.whiskerLeft Φ.r Φ.ι).app X))
+
+instance [Φ.IsIdempotent] (X : C) :
+    IsIso (Φ.r.map (Φ.ι.app X)) := by
+  rw [r_map_ι_app]
+  infer_instance
+
+end Preradical
+
+end CategoryTheory.Abelian

--- a/Mathlib/CategoryTheory/Abelian/Preradical/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Preradical/Basic.lean
@@ -53,7 +53,7 @@ abbrev r : C ⥤ C := Φ.obj.left
 /-- The structure morphism `Φ.r ⟶ 𝟭 C` of a preradical `Φ`. -/
 abbrev ι : Φ.r ⟶ 𝟭 C := Φ.obj.hom
 
-@[simp, reassoc]
+@[simp]
 lemma r_map_ι_app (X : C) : Φ.r.map (Φ.ι.app X) = Φ.ι.app (Φ.r.obj X) := by
   rw [← cancel_mono (Φ.ι.app X)]
   exact Φ.ι.naturality (Φ.ι.app X)


### PR DESCRIPTION
A **preradical** on an abelian category `C` is a monomorphism in the functor category `C ⥤ C`
with codomain `𝟭 C`, i.e. an element of `MonoOver (𝟭 C)`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
