### PR TITLE
[Merged by Bors] - chore: forbid prime (') in filenames, rename LinearCombination'

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7078,7 +7078,7 @@ public import Mathlib.Tactic.Linarith.Parsing
 public import Mathlib.Tactic.Linarith.Preprocessing
 public import Mathlib.Tactic.Linarith.Verification
 public import Mathlib.Tactic.LinearCombination
-public import Mathlib.Tactic.LinearCombination'
+public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.LinearCombination.Lemmas
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.CommandRanges

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7078,8 +7078,8 @@ public import Mathlib.Tactic.Linarith.Parsing
 public import Mathlib.Tactic.Linarith.Preprocessing
 public import Mathlib.Tactic.Linarith.Verification
 public import Mathlib.Tactic.LinearCombination
-public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.LinearCombination.Lemmas
+public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.CommandRanges
 public import Mathlib.Tactic.Linter.CommandStart

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -155,7 +155,7 @@ public import Mathlib.Tactic.Linarith.Parsing
 public import Mathlib.Tactic.Linarith.Preprocessing
 public import Mathlib.Tactic.Linarith.Verification
 public import Mathlib.Tactic.LinearCombination
-public import Mathlib.Tactic.LinearCombination'
+public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.LinearCombination.Lemmas
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.CommandRanges

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -155,8 +155,8 @@ public import Mathlib.Tactic.Linarith.Parsing
 public import Mathlib.Tactic.Linarith.Preprocessing
 public import Mathlib.Tactic.Linarith.Verification
 public import Mathlib.Tactic.LinearCombination
-public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.LinearCombination.Lemmas
+public import Mathlib.Tactic.LinearCombinationPrime
 public import Mathlib.Tactic.Linter
 public import Mathlib.Tactic.Linter.CommandRanges
 public import Mathlib.Tactic.Linter.CommandStart

--- a/Mathlib/Tactic/LinearCombinationPrime.lean
+++ b/Mathlib/Tactic/LinearCombinationPrime.lean
@@ -39,7 +39,7 @@ implementation, but this version is provided for backward-compatibility.
 
 public meta section
 
-namespace Mathlib.Tactic.LinearCombination'
+namespace Mathlib.Tactic.LinearCombinationPrime
 open Lean
 open Elab Meta Term
 
@@ -264,4 +264,4 @@ elab_rules : tactic
   | `(tactic| linear_combination2%$tk $[(norm := $tac)]? $(e)?) =>
     elabLinearCombination' tk tac none e true
 
-end Mathlib.Tactic.LinearCombination'
+end Mathlib.Tactic.LinearCombinationPrime

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -590,7 +590,8 @@ COM6, COM7, COM8, COM9, COM¹, COM², COM³, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6,
 LPT¹, LPT² or LPT³ in its filename, as these are forbidden on Windows.
 
 Also verify that module names contain no forbidden characters such as `*`, `?` (Windows),
-`!` (forbidden on Nix OS) or `.` (might result from confusion with a module name).
+`!` (forbidden on Nix OS), `.` (might result from confusion with a module name)
+or `'` (causes shell escaping issues in scripts).
 
 Source: https://learn.microsoft.com/en-gb/windows/win32/fileio/naming-a-file.
 Return the number of module names violating this rule. -/
@@ -622,6 +623,10 @@ public def modulesOSForbidden (opts : LinterOptions) (modules : Array Lean.Name)
         else if s.contains '.' then
           isBad := true
           IO.eprintln s!"error: module name '{name}' contains forbidden character '.'"
+        else if s.contains '\'' then
+          isBad := true
+          IO.eprintln s!"error: module name '{name}' contains a prime ('), \
+            which causes shell escaping issues"
         else if s.contains ' ' || s.contains '\t' || s.contains '\n' then
           isBad := true
           IO.eprintln s!"error: module name '{name}' contains a whitespace character"

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -103,7 +103,7 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
     `Batteries.Tactic.seq_focus,
     `Mathlib.Tactic.Hint.registerHintStx,
     `Mathlib.Tactic.LinearCombination.linearCombination,
-    `Mathlib.Tactic.LinearCombination'.linearCombination',
+    `Mathlib.Tactic.LinearCombinationPrime.linearCombination',
     `Aesop.Frontend.Parser.addRules,
     `Aesop.Frontend.Parser.aesopTactic,
     `Aesop.Frontend.Parser.aesopTactic?,

--- a/MathlibTest/linear_combination_prime.lean
+++ b/MathlibTest/linear_combination_prime.lean
@@ -1,5 +1,5 @@
 module
-import Mathlib.Tactic.LinearCombination'
+import Mathlib.Tactic.LinearCombinationPrime
 import Mathlib.Tactic.Linarith
 
 
@@ -208,7 +208,7 @@ has type
 but is expected to have type
   ℤ
 in the application
-  Mathlib.Tactic.LinearCombination'.c_mul_pf h2 0
+  Mathlib.Tactic.LinearCombinationPrime.c_mul_pf h2 0
 -/
 #guard_msgs in
 example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y + 2 * x = 1 := by


### PR DESCRIPTION
This PR renames `Mathlib/Tactic/LinearCombination'.lean` to `LinearCombinationPrime.lean` (and the corresponding test file), and adds a lint check to `modulesOSForbidden` to prevent future files with prime/apostrophe characters in their names.

The `'` character in filenames causes shell escaping issues in scripts (any `find ... -name '*.lean'` or similar pattern needs careful quoting to handle these files correctly).

🤖 Prepared with Claude Code