### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Types): epimorphisms are stable under base change

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3247,6 +3247,7 @@ public import Mathlib.CategoryTheory.Triangulated.TriangleShift
 public import Mathlib.CategoryTheory.Triangulated.Triangulated
 public import Mathlib.CategoryTheory.Triangulated.Yoneda
 public import Mathlib.CategoryTheory.Types.Basic
+public import Mathlib.CategoryTheory.Types.Epimorphisms
 public import Mathlib.CategoryTheory.Types.Monomorphisms
 public import Mathlib.CategoryTheory.Types.Set
 public import Mathlib.CategoryTheory.UnivLE

--- a/Mathlib/CategoryTheory/Types/Epimorphisms.lean
+++ b/Mathlib/CategoryTheory/Types/Epimorphisms.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Limits
+public import Mathlib.CategoryTheory.Limits.Types.Pullbacks
+
+/-!
+# Stability properties of epimorphisms in `Type`
+
+In this file, we show that in the category `Type u`, epimorphisms
+are stable under base change.
+
+-/
+
+@[expose] public section
+
+universe u
+
+namespace CategoryTheory.Types
+
+open MorphismProperty Limits
+
+instance : (epimorphisms (Type u)).IsStableUnderBaseChange where
+  of_isPullback {_ _ _ _} b r t l sq hr := by
+    simp only [epimorphisms.iff, epi_iff_surjective] at hr ⊢
+    intro x
+    obtain ⟨y, hy⟩ := hr (b x)
+    obtain ⟨z, _, hz⟩ := Types.exists_of_isPullback sq _ _ hy
+    exact ⟨z, hz⟩
+
+end CategoryTheory.Types


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
