### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -203,12 +203,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma restrict₂_preimage [DecidablePred (· ∈ s)] (hst : s ⊆ t) (u : (i : s) → Set (π i)) :
     (restrict₂ hst) ⁻¹' (Set.univ.pi u) =
       (@Set.univ t).pi (fun j ↦ if h : j.1 ∈ s then u ⟨j.1, h⟩ else Set.univ) := by
-  ext x
-  simp only [Set.mem_preimage, Set.mem_pi, Set.mem_univ, restrict₂, forall_const, Subtype.forall]
-  refine ⟨fun h i hi ↦ ?_, fun h i i_mem ↦ by simpa [i_mem] using h i (hst i_mem)⟩
-  split_ifs with i_mem
-  · exact h i i_mem
-  · exact Set.mem_univ _
+  grind [restrict₂]
 
 end Pi
 

--- a/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
@@ -834,23 +834,11 @@ theorem nondegenerate_toLinearMap₂'_iff_det_ne_zero :
 
 theorem separatingLeft_toLinearMap₂'_iff_det_ne_zero :
     (Matrix.toLinearMap₂' R M).SeparatingLeft (R := R) ↔ M.det ≠ 0 := by
-  constructor
-  · intro h hne
-    obtain ⟨w, hwne, hw⟩ := exists_vecMul_eq_zero_iff.mpr hne
-    refine hwne (h w fun y ↦ ?_)
-    simp [toLinearMap₂'_apply', dotProduct_mulVec, hw]
-  · rw [← nondegenerate_toLinearMap₂'_iff_det_ne_zero]
-    exact fun h ↦ h.1
+  simpa using separatingLeft_iff_det_ne_zero
 
 theorem separatingRight_toLinearMap₂'_iff_det_ne_zero :
     (Matrix.toLinearMap₂' R M).SeparatingRight (R := R) ↔ M.det ≠ 0 := by
-  constructor
-  · intro h hne
-    obtain ⟨w, hwne, hw⟩ := exists_mulVec_eq_zero_iff.mpr hne
-    refine hwne (h w fun y ↦ ?_)
-    simp [toLinearMap₂'_apply', hw]
-  · rw [← nondegenerate_toLinearMap₂'_iff_det_ne_zero]
-    exact fun h ↦ h.2
+  simpa using separatingRight_iff_det_ne_zero
 
 theorem separatingLeft_toLinearMap₂'_of_det_ne_zero' (h : M.det ≠ 0) :
     (Matrix.toLinearMap₂' R M).SeparatingLeft (R := R) :=

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -179,13 +179,8 @@ theorem IsLocalization.isMaximal_iff_isMaximal_disjoint [H : IsJacobsonRing R] (
         rwa [disjoint_powers_iff_notMem y hI.right.isPrime.isRadical]
       have : J ≤ I.map (algebraMap R S) := map_comap (Submonoid.powers y) S J ▸ map_mono hI.left
       exact absurd (h.1.2 _ (lt_of_le_of_ne this hJ)) hI_p.1
-  · refine fun h => ⟨⟨fun hJ => h.1.ne_top (eq_top_iff.2 ?_), fun I hI => ?_⟩⟩
-    · rwa [eq_top_iff, ← (IsLocalization.orderEmbedding (powers y) S).le_iff_le] at hJ
-    · have := congr_arg (Ideal.map (algebraMap R S)) (h.1.1.2 _ ⟨comap_mono (le_of_lt hI), ?_⟩)
-      · rwa [map_comap (powers y) S I, Ideal.map_top] at this
-      refine fun hI' => hI.right ?_
-      rw [← map_comap (powers y) S I, ← map_comap (powers y) S J]
-      exact map_mono hI'
+  · simp only [Ideal.mem_comap, and_imp]
+    exact (fun _ _ ↦ IsMaximal.of_isLocalization_of_disjoint (powers y))
 
 /-- If `R` is a Jacobson ring, then maximal ideals in the localization at `y`
 correspond to maximal ideals in the original ring `R` that don't contain `y`.

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -279,9 +279,8 @@ lemma pderiv_inr_universalFactorizationMap_X (i j) :
       Pi.single_apply, Fin.ext_iff, ← ite_and]
   · obtain h | h := lt_or_ge j.1 i.1
     · rw [Finset.sum_eq_zero, if_pos h]
-      simp only [Finset.mem_antidiagonal, Prod.forall]
-      intro a b hab
-      simp [show b ≠ i by lia]
+      simp only [Finset.mem_antidiagonal]
+      lia
     rw [Finset.sum_eq_single ⟨j.1 - i.1, i.1⟩, if_neg h.not_gt]
     · simp
     · simp only [Finset.mem_antidiagonal, ne_eq, ite_eq_right_iff, Prod.forall, Prod.mk.injEq]


### PR DESCRIPTION
The goal of this golfing PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `Finset.restrict₂_preimage`: unchanged 🎉
* `LinearMap.separatingLeft_toLinearMap₂'_iff_det_ne_zero`: unchanged 🎉
* `LinearMap.separatingRight_toLinearMap₂'_iff_det_ne_zero`: unchanged 🎉
* `IsLocalization.isMaximal_iff_isMaximal_disjoint`: 155 ms before, 123 ms after  🎉
* `MvPolynomial.pderiv_inr_universalFactorizationMap_X`: 2019 ms before, 1950 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
