### PR TITLE
chore: tidy various files

### DIFF
--- a/Mathlib/Algebra/Group/Int/Defs.lean
+++ b/Mathlib/Algebra/Group/Int/Defs.lean
@@ -42,8 +42,7 @@ instance instAddCommGroup : AddCommGroup ℤ where
   neg_add_cancel := Int.add_left_neg
   nsmul := (· * ·)
   nsmul_zero := Int.zero_mul
-  nsmul_succ n x :=
-    show (n + 1 : ℤ) * x = n * x + x by rw [Int.add_mul, Int.one_mul]
+  nsmul_succ n x := by rw [natCast_add, ofNat_one, Int.add_mul, Int.one_mul]
   zsmul := (· * ·)
   zsmul_zero' := Int.zero_mul
   zsmul_succ' m n := by

--- a/Mathlib/Algebra/LinearRecurrence.lean
+++ b/Mathlib/Algebra/LinearRecurrence.lean
@@ -112,14 +112,12 @@ theorem eq_mk_of_is_sol_of_eq_init' {u : ℕ → R} {init : Fin E.order → R} (
     (heq : ∀ n : Fin E.order, u n = init n) : u = E.mkSol init :=
   funext (E.eq_mk_of_is_sol_of_eq_init h heq)
 
--- TODO: there's a non-terminal simp here
-set_option linter.flexible false in
 /-- The space of solutions of `E`, as a `Submodule` over `R` of the module `ℕ → R`. -/
 def solSpace : Submodule R (ℕ → R) where
   carrier := { u | E.IsSolution u }
   zero_mem' n := by simp
   add_mem' {u v} hu hv n := by simp [mul_add, sum_add_distrib, hu n, hv n]
-  smul_mem' a u hu n := by simp [hu n, mul_sum]; congr; ext; ac_rfl
+  smul_mem' a u hu n := by simp [hu n, mul_sum]; grind
 
 /-- Defining property of the solution space : `u` is a solution
   iff it belongs to the solution space. -/
@@ -137,7 +135,7 @@ def toInit : E.solSpace ≃ₗ[R] Fin E.order → R where
     ext
     simp
   invFun u := ⟨E.mkSol u, E.is_sol_mkSol u⟩
-  left_inv u := by ext n; symm; apply E.eq_mk_of_is_sol_of_eq_init u.2; intro k; rfl
+  left_inv u := by ext n; exact E.eq_mk_of_is_sol_of_eq_init u.2 (fun _ => rfl) _ |>.symm
   right_inv u := funext_iff.mpr fun n ↦ E.mkSol_eq_init u n
 
 /-- Two solutions are equal iff they are equal on `range E.order`. -/
@@ -148,7 +146,7 @@ theorem sol_eq_of_eq_init (u v : ℕ → R) (hu : E.IsSolution u) (hv : E.IsSolu
   set u' : ↥E.solSpace := ⟨u, hu⟩
   set v' : ↥E.solSpace := ⟨v, hv⟩
   change u'.val = v'.val
-  suffices h' : u' = v' from h' ▸ rfl
+  congr
   rw [← E.toInit.toEquiv.apply_eq_iff_eq, LinearEquiv.coe_toEquiv]
   ext x
   exact mod_cast h (mem_range.mpr x.2)

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -14,6 +14,7 @@ public import Mathlib.Algebra.Order.Monoid.NatCast
 public import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
 public import Mathlib.Algebra.Ring.Defs
 public import Mathlib.Tactic.Tauto
+import Mathlib.Tactic.ByContra
 
 /-!
 # Basic facts for ordered rings and semirings
@@ -727,17 +728,15 @@ theorem pos_of_right_mul_lt_le [ExistsAddOfLE R] [PosMulMono R]
     [AddRightMono R] [AddRightReflectLE R]
     (h : a * b < a * c) (hbc : b ≤ c) :
     0 < a := by
-  by_cases! ha : 0 < a
-  · exact ha
-  · grind [mul_le_mul_of_nonpos_left hbc ha]
+  by_contra! ha
+  grind [mul_le_mul_of_nonpos_left hbc ha]
 
 theorem pos_of_left_mul_lt_le [ExistsAddOfLE R] [MulPosMono R]
     [AddLeftMono R] [AddRightReflectLE R]
     (h : b * a < c * a) (hbc : b ≤ c) :
     0 < a := by
-  by_cases! ha : 0 < a
-  · exact ha
-  · grind [mul_le_mul_of_nonpos_right hbc ha]
+  by_contra! ha
+  grind [mul_le_mul_of_nonpos_right hbc ha]
 
 end LinearOrderedSemiring
 

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -778,7 +778,7 @@ theorem primeIdealOf_eq_map_closedPoint (x : U) :
   hU.isoSpec_hom_apply _
 
 lemma comap_primeIdealOf_appLE {f : X ⟶ Y} {x : X} (U : Y.Opens)
-      (hU : IsAffineOpen U) (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U) (hx : x ∈ V) :
+    (hU : IsAffineOpen U) (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U) (hx : x ∈ V) :
     (hV.primeIdealOf ⟨x, hx⟩).comap (f.appLE U V hVU).hom = hU.primeIdealOf ⟨f x, hVU hx⟩ := by
   change Spec.map (f.appLE U V hVU) (hV.primeIdealOf ⟨x, hx⟩) = (hU.primeIdealOf ⟨f x, hVU hx⟩)
   simp only [IsAffineOpen.primeIdealOf, ← Scheme.Hom.comp_apply, IsAffineOpen.isoSpec_hom,
@@ -865,9 +865,8 @@ lemma ideal_ext_iff {I J : Ideal Γ(X, U)} :
 
 /-- Given affine opens `x ∈ V ⊆ f⁻¹(U)`, the stalk map of `f` at `x` is isomorphic to
 `Localization.localRingHom` of `f.appLE U V`. -/
-def arrowStalkMapIso (f : X ⟶ Y) {x : X} (U : Y.Opens)
-      (hU : IsAffineOpen U) (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U)
-      (hx : x ∈ V) :
+def arrowStalkMapIso (f : X ⟶ Y) {x : X} (U : Y.Opens) (hU : IsAffineOpen U)
+    (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U) (hx : x ∈ V) :
     Arrow.mk (f.stalkMap x) ≅ Arrow.mk (CommRingCat.ofHom <|
       Localization.localRingHom _ _ (f.appLE U V hVU).hom
         congr($(IsAffineOpen.comap_primeIdealOf_appLE U hU V hV hVU hx).1).symm) := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Smooth.lean
@@ -240,9 +240,8 @@ instance (priority := 100) [hf : Smooth f] : LocallyOfFinitePresentation f := by
   rw [HasRingHomProperty.eq_affineLocally @Smooth] at hf
   exact affineLocally_le (fun hf ↦ hf.finitePresentation) f hf
 
-lemma formallySmooth_stalkMap_iff {f : X ⟶ Y} {x : X} (U : Y.Opens)
-      (hU : IsAffineOpen U) (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U)
-      (hx : x ∈ V) :
+lemma formallySmooth_stalkMap_iff {f : X ⟶ Y} {x : X} (U : Y.Opens) (hU : IsAffineOpen U)
+    (V : X.Opens) (hV : IsAffineOpen V) (hVU : V ≤ f ⁻¹ᵁ U) (hx : x ∈ V) :
     letI := (f.appLE U V hVU).hom.toAlgebra
     (f.stalkMap x).hom.FormallySmooth ↔
       hV.primeIdealOf ⟨x, hx⟩ ∈ Algebra.smoothLocus Γ(Y, U) Γ(X, V) := by
@@ -333,9 +332,8 @@ lemma Scheme.Hom.preimage_smoothLocus_eq {U : Scheme.{u}}
     (f : U ⟶ X) (g : X ⟶ Y) [IsOpenImmersion f] [LocallyOfFinitePresentation g] :
     f ⁻¹ᵁ g.smoothLocus = (f ≫ g).smoothLocus := by
   ext x
-  refine (RingHom.FormallySmooth.respectsIso.cancel_right_isIso _ (f.stalkMap x)).symm.trans ?_
-  rw [← CommRingCat.hom_comp, ← stalkMap_comp]
-  rfl
+  simp [smoothLocus, ← RingHom.FormallySmooth.respectsIso.cancel_right_isIso _ (f.stalkMap x),
+    ← CommRingCat.hom_comp, ← stalkMap_comp]
 
 set_option backward.isDefEq.respectTransparency false in
 lemma Scheme.Hom.genericPoint_mem_smoothLocus_of_perfectField

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -99,7 +99,7 @@ theorem isReduced_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [IsOpenImmersi
     (asIso <| f.app (f ''ᵁ U) : Γ(Y, f ''ᵁ U) ≅ _).symm.commRingCatIsoToRingEquiv.injective
 
 instance {X : Scheme} {U : X.Opens} [IsReduced X] : IsReduced U :=
-    isReduced_of_isOpenImmersion U.ι
+  isReduced_of_isOpenImmersion U.ι
 
 instance {R : CommRingCat.{u}} [H : _root_.IsReduced R] : IsReduced (Spec R) := by
   apply +allowSynthFailures isReduced_of_isReduced_stalk

--- a/Mathlib/AlgebraicGeometry/ZariskisMainTheorem.lean
+++ b/Mathlib/AlgebraicGeometry/ZariskisMainTheorem.lean
@@ -43,7 +43,7 @@ variable {X Y S : Scheme.{u}} (f : X ⟶ S) [LocallyOfFiniteType f]
 
 set_option backward.isDefEq.respectTransparency false in
 open TensorProduct in
--- Note: This is weaker than stacks#02LN but is enough to proof Zariski's main.
+-- Note: This is weaker than stacks#02LN but is enough to prove Zariski's main.
 -- TODO: generalize this.
 theorem exists_etale_isCompl_of_quasiFiniteAt [IsSeparated f]
     {x : X} {s : S} (h : f x = s) (hx : f.QuasiFiniteAt x) :

--- a/Mathlib/Analysis/Complex/CoveringMap.lean
+++ b/Mathlib/Analysis/Complex/CoveringMap.lean
@@ -63,17 +63,18 @@ theorem Polynomial.isCoveringMapOn_eval (p : 𝕜[X]) :
 
 theorem isCoveringMapOn_npow (n : ℕ) (hn : (n : 𝕜) ≠ 0) :
     IsCoveringMapOn (fun x : 𝕜 ↦ x ^ n) {0}ᶜ := by
-  convert (X ^ n).isCoveringMapOn_eval.mono fun x' h ↦ _ with x
+  convert (X ^ n : 𝕜[X]).isCoveringMapOn_eval.mono fun x' h ↦ _ with x
   · simp
-  · assumption
-  · simpa [derivative_X_pow, hn, show n ≠ 0 by aesop] using fun _ ↦ Ne.symm h
+  · simp only [Set.mem_compl_iff, Set.mem_singleton_iff, ← ne_eq] at h
+    simp [derivative_X_pow, hn, show n ≠ 0 by aesop, h.symm]
 
 /-- `(· ^ n) : 𝕜 \ {0} → 𝕜 \ {0}` is a covering map (if `n ≠ 0` in `𝕜`). -/
 theorem isCoveringMap_npow (n : ℕ) (hn : (n : 𝕜) ≠ 0) :
     IsCoveringMap fun x : {x : 𝕜 // x ≠ 0} ↦ (⟨x ^ n, pow_ne_zero n x.2⟩ : {x : 𝕜 // x ≠ 0}) := by
-  convert (isCoveringMapOn_npow n hn).isCoveringMap_restrictPreimage.comp_homeomorph (.setCongr _)
-    using 1
-  ext; simp [show n ≠ 0 by aesop]; rfl
+  convert (isCoveringMapOn_npow n hn).isCoveringMap_restrictPreimage.comp_homeomorph
+    (.setCongr (s := {0}ᶜ) _)
+    using 0
+  ext; simp [show n ≠ 0 by aesop]
 
 /-- `(· ^ n) : 𝕜 \ {0} → 𝕜 \ {0}` is a covering map (if `n ≠ 0` in `𝕜`). -/
 theorem isCoveringMap_zpow (n : ℤ) (hn : (n : 𝕜) ≠ 0) :
@@ -104,9 +105,9 @@ theorem isQuotientCoveringMap_npow (n : ℕ) (hn : (n : 𝕜) ≠ 0)
     (by fun_prop) (.restrictPreimage _ surj)
   have : IsQuotientMap fun x : 𝕜ˣ ↦ x ^ n := by
     let e := unitsHomeomorphNeZero (G₀ := 𝕜)
-    convert (e.symm.isQuotientMap.comp this).comp (e.trans (.setCongr _)).isQuotientMap
+    convert (e.symm.isQuotientMap.comp this).comp (e.trans (.setCongr (s := {0}ᶜ) ?_)).isQuotientMap
     · exact (e.left_inv _).symm
-    · ext; simp [NeZero.ne]; rfl
+    · ext; simp [NeZero.ne]
   refine this.isQuotientCoveringMap_of_subgroup _
     (Set.Finite.isDiscrete <| inferInstanceAs (Finite (rootsOfUnity ..))) ?_
   simp [mul_pow, mul_inv_eq_one, eq_comm]

--- a/Mathlib/Analysis/Complex/MeanValue.lean
+++ b/Mathlib/Analysis/Complex/MeanValue.lean
@@ -45,7 +45,7 @@ theorem circleAverage_sub_sub_inv_smul_of_differentiable_on_off_countable (hs : 
     circleAverage (fun z ↦ ((z - c) / (z - w)) • f z) c R = f w := by
   rw [← circleAverage_abs_radius]
   rcases le_or_gt |R| 0 with hR | hR
-  · simp_all [(ball_eq_empty).2 hR]
+  · simp [ball_eq_empty.2 hR] at hw
   calc circleAverage (fun z ↦ ((z - c) * (z - w)⁻¹) • f z) c |R|
   _ = (2 * π * I)⁻¹ • (∮ z in C(c, |R|), (z - w)⁻¹ • f z) := by
     simp only [circleAverage_eq_circleIntegral hR.ne', mul_inv_rev, inv_I, neg_mul, neg_smul,
@@ -71,7 +71,7 @@ theorem DiffContOnCl.circleAverage_smul_div (hf : DiffContOnCl ℂ f (ball c |R|
     (hw : w ∈ ball c |R|) :
     circleAverage (fun z ↦ ((z - c) / (z - w)) • f z) c R = f w := by
   by_cases hR : |R| ≤ 0
-  · simp_all [(ball_eq_empty).2 hR]
+  · simp [ball_eq_empty.2 hR] at hw
   apply circleAverage_sub_sub_inv_smul_of_differentiable_on_off_countable countable_empty _ _ hw
   · simpa [← closure_ball _ (ne_of_not_ge hR).symm] using hf.2
   · intro z hz

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -54,8 +54,8 @@ variable {X : T}
 
 @[ext]
 theorem OverMorphism.ext {X : T} {U V : Over X} {f g : U ⟶ V} (h : f.left = g.left) : f = g := by
-  let ⟨_,b,_⟩ := f
-  let ⟨_,e,_⟩ := g
+  let ⟨_, b, _⟩ := f
+  let ⟨_, e, _⟩ := g
   congr
   simp only [eq_iff_true_of_subsingleton]
 

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -120,8 +120,7 @@ section Set
 
 @[simp, norm_cast] lemma bddAbove_range_natCast_iff {ι : Sort*} (f : ι → ℕ) :
     BddAbove (Set.range (f ·) : Set NNReal) ↔ BddAbove (Set.range f) := by
-  rw [← bddAbove_natCast_image_iff, ← Set.range_comp]
-  rfl
+  rw [← bddAbove_natCast_image_iff, ← Set.range_comp, Function.comp_def]
 
 end Set
 

--- a/Mathlib/Data/Set/Dissipate.lean
+++ b/Mathlib/Data/Set/Dissipate.lean
@@ -37,7 +37,7 @@ theorem dissipate_subset [LE α] {x y : α} (hy : y ≤ x) : dissipate s x ⊆ s
 
 theorem iInter_subset_dissipate [LE α] (x : α) : ⋂ i, s i ⊆ dissipate s x := by
   simp only [dissipate, subset_iInter_iff]
-  exact fun x h ↦ iInter_subset_of_subset x fun ⦃a⦄ a ↦ a
+  exact fun x h ↦ iInter_subset_of_subset x .rfl
 
 theorem antitone_dissipate [Preorder α] : Antitone (dissipate s) :=
   fun _ _ hab ↦ biInter_subset_biInter_left fun _ hz => le_trans hz hab

--- a/Mathlib/Data/Set/PowersetCard.lean
+++ b/Mathlib/Data/Set/PowersetCard.lean
@@ -84,9 +84,7 @@ theorem exists_mem_notMem (hn : 1 ≤ n) (hα : n < ENat.card α) {a b : α} (ha
       by simpa using has, by simpa using has'⟩
 
 theorem exists_mem_notMem_iff_ne (s t : Set.powersetCard α n) : s ≠ t ↔ ∃ a ∈ s, a ∉ t := by
-  contrapose!
-  rw [eq_iff_subset]
-  rfl
+  simp [eq_iff_subset, Finset.subset_iff, mem_coe_iff]
 
 section map
 
@@ -94,13 +92,12 @@ variable (n) {β : Type*}
 
 /-- The map `powersetCard α n → powersetCard β n` induced by embedding `f : α ↪ β`. -/
 def map (f : α ↪ β) (s : powersetCard α n) : powersetCard β n :=
-    ⟨Finset.map f s, by rw [mem_iff, card_map, s.prop]⟩
+  ⟨Finset.map f s, by rw [mem_iff, card_map, s.prop]⟩
 
 set_option backward.isDefEq.respectTransparency false in
 lemma mem_map_iff_mem_range (f : α ↪ β) (s : powersetCard α n) (b : β) :
     b ∈ map n f s ↔ b ∈ f '' s := by
-  simp [map]
-  rfl
+  simp [map, mem_coe_iff]
 
 @[simp]
 lemma coe_map (f : α ↪ β) (s : powersetCard α n) : SetLike.coe (map n f s) = f '' s := by

--- a/Mathlib/Geometry/Euclidean/Angle/Bisector.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Bisector.lean
@@ -201,7 +201,7 @@ lemma dist_orthogonalProjection_eq_iff_oangle_eq {p p' : P} {s₁ s₂ : AffineS
     (dist p (orthogonalProjection s₁ p) = dist p (orthogonalProjection s₂ p) ↔
       ∡ (orthogonalProjection s₁ p : P) p' p = ∡ p p' (orthogonalProjection s₂ p)) :=
   fun hne hp₁ hp₂ ↦ ⟨oangle_eq_of_dist_orthogonalProjection_eq hp'₁ hp'₂ hne,
-   dist_orthogonalProjection_eq_of_oangle_eq hp'₁ hp'₂ hp₁ hp₂⟩
+    dist_orthogonalProjection_eq_of_oangle_eq hp'₁ hp'₂ hp₁ hp₂⟩
 
 /-- A point `p` is equidistant to two affine subspaces (typically lines, for this version of the
 lemma) if twice the oriented angles at a point `p'` in their intersection between `p` and its

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -194,8 +194,8 @@ lemma finsuppScalarRight_symm_apply_single (i : ι) (m : M) :
   simp [finsuppScalarRight, finsuppRight_symm_apply_single]
 
 theorem finsuppScalarRight_smul (s : S) (t) :
-    finsuppScalarRight R S M ι (s • t) = s • finsuppScalarRight R S M ι t := by
-  simp
+    finsuppScalarRight R S M ι (s • t) = s • finsuppScalarRight R S M ι t :=
+  map_smul _ _ _
 
 @[deprecated (since := "2026-01-01")] alias finsuppScalarRight' := finsuppScalarRight
 

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -95,7 +95,7 @@ theorem isNilpotent_isSemisimple_unique [PerfectField K]
   have hsf : Commute s (n₁ + s₁) := heq ▸ hc.symm.add_right (Commute.refl s)
   have hnf : Commute n (n₁ + s₁) := heq ▸ (Commute.refl n).add_right hc
   have hnil : IsNilpotent (s - s₀) := by
-    rw [show s - s₀ = n₀ - n from by grind]
+    rw [show s - s₀ = n₀ - n by grind]
     exact (commute_of_mem_adjoin_singleton_of_commute hn₀ hnf).symm.isNilpotent_sub hn₀_nil hn
   have hss : (s - s₀).IsSemisimple :=
     hs.sub_of_commute (commute_of_mem_adjoin_singleton_of_commute hs₀ hsf) hs₀_ss

--- a/Mathlib/MeasureTheory/Measure/PreVariation.lean
+++ b/Mathlib/MeasureTheory/Measure/PreVariation.lean
@@ -32,7 +32,7 @@ measure.
 
 variable {X : Type*} [MeasurableSpace X]
 
-open MeasureTheory BigOperators NNReal ENNReal Function
+open NNReal ENNReal Function
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Measure/SubFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/SubFinite.lean
@@ -15,9 +15,9 @@ public import Mathlib.MeasureTheory.Measure.WithDensity
 /-!
 # Results about subtraction of finite measures
 
-The content of this file is not placed in `MeasureTheory.Measure.Sub` because it uses tools that are
-not imported in the other file: the Hahn decomposition of finite measures and measures built with
-`withDensity`.
+The content of this file is not placed in `Mathlib/MeasureTheory/Measure/Sub.lean` because it uses
+tools that are not imported in the other file: the Hahn decomposition of finite measures and
+measures built with `withDensity`.
 
 ## Main statements
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Variation/Defs.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Variation/Defs.lean
@@ -34,7 +34,7 @@ not less than this function. It turns out that this function is a measure.
 
 variable {X : Type*} [MeasurableSpace X]
 
-open MeasureTheory BigOperators NNReal ENNReal Function
+open ENNReal
 
 namespace MeasureTheory.VectorMeasure
 

--- a/Mathlib/Order/ConditionallyCompletePartialOrder/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompletePartialOrder/Indexed.lean
@@ -113,11 +113,7 @@ theorem cbiSup_eq_of_forall {p : ι → Prop} {f : Subtype p → α} (hp : ∀ i
   simp only [hp, ciSup_unique]
   simp only [iSup]
   congr
-  apply Subset.antisymm
-  · rintro - ⟨i, rfl⟩
-    simp
-  · rintro - ⟨i, rfl⟩
-    simp
+  grind
 
 /-- Introduction rule to prove that `b` is the supremum of `f`: it suffices to check that `b`
 is larger than `f i` for all `i`, and that this is not the case of any `w<b`.

--- a/Mathlib/Probability/Distributions/Cauchy.lean
+++ b/Mathlib/Probability/Distributions/Cauchy.lean
@@ -68,7 +68,7 @@ lemma cauchyPDF_scale_zero (x₀ : ℝ) : cauchyPDF x₀ 0 = 0 := by
   simp [cauchyPDF]
 
 lemma cauchyPDF_def (x₀ : ℝ) (γ : ℝ≥0) (x : ℝ) :
-  cauchyPDF x₀ γ x = ENNReal.ofReal (cauchyPDFReal x₀ γ x) := by rfl
+    cauchyPDF x₀ γ x = ENNReal.ofReal (cauchyPDFReal x₀ γ x) := by rfl
 
 @[fun_prop]
 lemma measurable_cauchyPDFReal (x₀ : ℝ) (γ : ℝ≥0) : Measurable (cauchyPDFReal x₀ γ) := by

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -250,7 +250,7 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq_aux
   let e : R' ⊗[R] S := aeval s' (c * a')
   let φ := Algebra.TensorProduct.map (.id R' R') (integralClosure R S).val
   have he₀e : φ e₀ = e := by
-    simp only [e₀, ← aeval_algHom_apply]; rfl
+    simp only [e₀, ← aeval_algHom_apply]; simp [e, s', φ, s₀]
   have he : IsIdempotentElem e := he₀e ▸ he₀.map _
   let P' := (Ideal.fiberIsoOfBijectiveResidueField hP).symm ⟨q, ‹_›, ‹_›⟩
   have hP'q : P'.1.comap Algebra.TensorProduct.includeRight.toRingHom = q :=

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -156,7 +156,7 @@ theorem inertia_le_stabilizer {R : Type*} [Ring R] (P : Ideal R) [MulSemiringAct
     ← P.add_mem_iff_left (a := x) ((inv_mem hσ) x), add_sub_cancel]
 
 instance {R : Type*} [Ring R] (P : Ideal R) [MulSemiringAction M R] :
-  ((inertia M P).subgroupOf (MulAction.stabilizer M P)).Normal := by
+    ((inertia M P).subgroupOf (MulAction.stabilizer M P)).Normal := by
   refine (Subgroup.normal_subgroupOf_iff (inertia_le_stabilizer P)).mpr fun g s hg hs x ↦ ?_
   rw [Submodule.mem_toAddSubgroup, ← Ideal.smul_mem_pointwise_smul_iff (a := s⁻¹), smul_sub,
     smul_smul, ← mul_assoc, inv_mul_cancel_left, mul_smul, Subgroup.inv_mem _ hs]

--- a/Mathlib/RingTheory/Polynomial/Subring.lean
+++ b/Mathlib/RingTheory/Polynomial/Subring.lean
@@ -44,12 +44,7 @@ variable (hp : (↑p.coeffs : Set R) ⊆ T)
 @[simp]
 theorem coeff_toSubring {n : ℕ} : ↑(coeff (toSubring p T hp) n) = coeff p n := by
   classical
-  simp only [toSubring, coeff_monomial, finset_sum_coeff, mem_support_iff, Finset.sum_ite_eq',
-    Ne, ite_not]
-  split_ifs with h
-  · rw [h]
-    rfl
-  · rfl
+  simp +contextual [toSubring, coeff_monomial, apply_ite Subtype.val]
 
 theorem coeff_toSubring' {n : ℕ} : (coeff (toSubring p T hp) n).1 = coeff p n := by
   simp
@@ -57,9 +52,7 @@ theorem coeff_toSubring' {n : ℕ} : (coeff (toSubring p T hp) n).1 = coeff p n 
 @[simp]
 theorem support_toSubring : support (toSubring p T hp) = support p := by
   ext i
-  simp only [mem_support_iff, not_iff_not, Ne]
-  conv_rhs => rw [← coeff_toSubring p T hp]
-  exact ⟨fun H => by rw [H, ZeroMemClass.coe_zero], fun H => Subtype.coe_injective H⟩
+  simp [← ZeroMemClass.coe_eq_zero, coeff_toSubring p T hp]
 
 @[simp]
 theorem degree_toSubring : (toSubring p T hp).degree = p.degree := by simp [degree]
@@ -69,8 +62,8 @@ theorem natDegree_toSubring : (toSubring p T hp).natDegree = p.natDegree := by s
 
 @[simp]
 theorem monic_toSubring : Monic (toSubring p T hp) ↔ Monic p := by
-  simp_rw [Monic, leadingCoeff, natDegree_toSubring, ← coeff_toSubring p T hp]
-  exact ⟨fun H => by rw [H, OneMemClass.coe_one], fun H => Subtype.coe_injective H⟩
+  simp_rw [Monic, leadingCoeff, natDegree_toSubring, ← coeff_toSubring p T hp,
+    OneMemClass.coe_eq_one]
 
 @[simp]
 theorem toSubring_zero : toSubring (0 : R[X]) T (by simp [coeffs]) = 0 := by
@@ -81,10 +74,9 @@ theorem toSubring_zero : toSubring (0 : R[X]) T (by simp [coeffs]) = 0 := by
 theorem toSubring_one :
     toSubring (1 : R[X]) T
         (Set.Subset.trans coeffs_one <| Finset.singleton_subset_set_iff.2 T.one_mem) =
-      1 :=
-  ext fun i => Subtype.ext <| by
-    rw [coeff_toSubring', coeff_one, coeff_one, apply_ite Subtype.val, ZeroMemClass.coe_zero,
-      OneMemClass.coe_one]
+      1 := by
+  ext i
+  simp [coeff_one, apply_ite Subtype.val]
 
 @[simp]
 theorem map_toSubring : (p.toSubring T hp).map (Subring.subtype T) = p := by
@@ -99,17 +91,13 @@ noncomputable def ofSubring (p : T[X]) : R[X] :=
   ∑ i ∈ p.support, monomial i (p.coeff i : R)
 
 theorem coeff_ofSubring (p : T[X]) (n : ℕ) : coeff (ofSubring T p) n = (coeff p n : T) := by
-  simp only [ofSubring, coeff_monomial, finset_sum_coeff, mem_support_iff, Finset.sum_ite_eq',
-    Ne, Classical.not_not, ite_eq_left_iff]
-  intro h
-  rw [h, ZeroMemClass.coe_zero]
+  simp +contextual [ofSubring, coeff_monomial, finset_sum_coeff]
 
 @[simp]
 theorem coeffs_ofSubring {p : T[X]} : (↑(p.ofSubring T).coeffs : Set R) ⊆ T := by
   classical
   intro i hi
-  simp only [coeffs, Set.mem_image, mem_support_iff, Ne, Finset.mem_coe,
-    (Finset.coe_image)] at hi
+  simp only [coeffs, Set.mem_image, mem_support_iff, Ne, Finset.mem_coe, Finset.coe_image] at hi
   rcases hi with ⟨n, _, h'n⟩
   rw [← h'n, coeff_ofSubring]
   exact Subtype.mem (coeff p n : T)

--- a/Mathlib/RingTheory/Smooth/IntegralClosure.lean
+++ b/Mathlib/RingTheory/Smooth/IntegralClosure.lean
@@ -326,7 +326,7 @@ theorem mem_adjoin_map_integralClosure_of_isStandardEtale [Algebra.IsStandardEta
       simp [StandardEtalePresentation.baseChange, 𝓟']
     rw [← e.eq_symm_apply]
     simp [e, StandardEtalePair.equivAwayAdjoinRoot, ← aeval_def, ← aeval_algHom_apply]
-    rfl
+    simp [𝓟', StandardEtalePresentation.baseChange]
   -- And `gᵏ • a` is still `R`-integral for `k` large enough.
   obtain ⟨k, hk⟩ : ∃ k, IsIntegral R (AdjoinRoot.mk 𝓟'.f 𝓟'.g ^ k * a) := by
     have H : ∀ k, e (1 ⊗ₜ (aeval 𝓟.x 𝓟.g ^ k)) = algebraMap _ _ (AdjoinRoot.mk 𝓟'.f 𝓟'.g ^ k) := by

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/ClassGroup.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/ClassGroup.lean
@@ -34,8 +34,7 @@ namespace NormalizedGCDMonoid
 lemma isPrincipal_of_exists_mul_ne_zero_isPrincipal
     {J : Ideal R} (hJ : ∃ K : Ideal R, J * K ≠ 0 ∧ (J * K).IsPrincipal) :
     J.IsPrincipal := by
-  letI : NormalizedGCDMonoid R :=
-    Classical.choice (inferInstance : Nonempty (NormalizedGCDMonoid R))
+  letI : NormalizedGCDMonoid R := Nonempty.some inferInstance
   obtain ⟨K, hJK0, hK⟩ := hJ
   rcases hK.principal with ⟨x, hJK⟩
   have hxmemJK : x ∈ J * K := by simp [hJK, mem_span_singleton_self]
@@ -66,8 +65,8 @@ lemma isPrincipal_of_exists_mul_ne_zero_isPrincipal
       rw [hx0, mul_zero]
   -- Show `J * (g) ≤ (x)` by proving `x ∣ b * g` for all `b ∈ J`.
   refine le_antisymm
-      (mul_le.mpr fun b hb z hz ↦ ?_)
-      ((span_singleton_le_iff_mem _).mpr hxJg)
+    (mul_le.mpr fun b hb z hz ↦ ?_)
+    ((span_singleton_le_iff_mem _).mpr hxJg)
   obtain ⟨z, rfl⟩ := mem_span_singleton.mp hz
   rw [mem_span_singleton, ← mul_assoc]
   apply dvd_mul_of_dvd_left
@@ -86,20 +85,14 @@ private theorem isPrincipal_of_isUnit_fractionalIdeal (I : Ideal R)
     (hI : IsUnit (I : FractionalIdeal R⁰ (FractionRing R))) :
     I.IsPrincipal := by
   obtain ⟨a, K, ha0, h⟩ := exists_eq_spanSingleton_mul (I : FractionalIdeal R⁰ (FractionRing R))⁻¹
-  have hIK : I * K = Ideal.span ({a} : Set R) :=
-    (coeIdeal_inj (K := FractionRing R)).mp <| by
-      rw [coeIdeal_mul, coeIdeal_span_singleton]
-      rw [← mul_inv_cancel_iff_isUnit] at hI
-      have ha0' := spanSingleton_mul_inv (R₁ := R) (FractionRing R)
-        (IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors
-          (mem_nonZeroDivisors_iff_ne_zero.mpr ha0))
-      replace h :=
-        congrArg
-          (fun t =>
-            spanSingleton R⁰ ((algebraMap R (FractionRing R)) a) * I * t)
-          h.symm
-      dsimp only at h
-      rwa [mul_mul_mul_comm, ← spanSingleton_inv, ha0', one_mul, mul_assoc, hI, mul_one] at h
+  have hIK : I * K = Ideal.span ({a} : Set R) := by
+    rw [← coeIdeal_inj (K := FractionRing R), coeIdeal_mul, coeIdeal_span_singleton]
+    rw [← mul_inv_cancel_iff_isUnit] at hI
+    have ha0' := spanSingleton_mul_inv (R₁ := R) (FractionRing R)
+      (IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors
+        (mem_nonZeroDivisors_iff_ne_zero.mpr ha0))
+    replace h := congr(spanSingleton R⁰ ((algebraMap R (FractionRing R)) a) * I * $h.symm)
+    rwa [mul_mul_mul_comm, ← spanSingleton_inv, ha0', one_mul, mul_assoc, hI, mul_one] at h
   refine isPrincipal_of_exists_mul_ne_zero_isPrincipal (J := I) ?_
   refine ⟨K, ?_, ?_⟩
   · simp [hIK, ha0]

--- a/Mathlib/RingTheory/Unramified/LocalStructure.lean
+++ b/Mathlib/RingTheory/Unramified/LocalStructure.lean
@@ -265,8 +265,7 @@ lemma exists_primesOver_under_adjoin_eq_singleton_and_residueField_bijective
     have : Q'.LiesOver p := .trans _ (Q.under (adjoin R {t})) _
     exact htQ (SetLike.le_def.mp (Q'.over_def (Q.under (adjoin R {t}))).ge
       (x := ⟨t, self_mem_adjoin_singleton _ _⟩) (htQ' Q' ⟨‹_›, ‹_›⟩ H))
-  · change Function.Surjective (IsScalarTower.toAlgHom p.ResidueField _ _)
-    rw [← AlgHom.range_eq_top, ← top_le_iff, ← ht]
+  · rw [← IsScalarTower.coe_toAlgHom' p.ResidueField, ← AlgHom.range_eq_top, ← top_le_iff, ← ht]
     refine adjoin_singleton_le ?_
     use algebraMap (adjoin R {t}) _ ⟨t, self_mem_adjoin_singleton _ _⟩
     rw [AlgHom.toRingHom_eq_coe, IsScalarTower.coe_toAlgHom, ← IsScalarTower.algebraMap_apply]

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -317,7 +317,7 @@ private lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt_of_isIntegrall
     [FaithfulSMul R S] [IsIntegrallyClosed R] [IsDomain S]
     {x : S} (hx' : (aeval (R := R) x).Finite)
     (P : Ideal S) [P.IsPrime] [Algebra.WeaklyQuasiFiniteAt R P] :
-      ¬ IsStronglyTranscendental R x := by
+    ¬ IsStronglyTranscendental R x := by
   intro hx
   have : IsDomain R := (FaithfulSMul.algebraMap_injective R S).isDomain
   have hf' : Function.Injective (aeval (R := R) x) := (injective_iff_map_eq_zero _).mpr
@@ -401,7 +401,7 @@ private lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt_of_isDomain_au
     (RingHom.surjectiveOnStalks_of_surjective hf₁) rfl
 
 set_option backward.isDefEq.respectTransparency false in
-nonrec lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt [IsReduced S]
+lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt [IsReduced S]
     {x : S} (hx' : (aeval (R := R) x).toRingHom.Finite)
     (P : Ideal S) [P.IsPrime] [Algebra.WeaklyQuasiFiniteAt R P] :
     ¬ IsStronglyTranscendental R x := by
@@ -445,7 +445,7 @@ nonrec lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt [IsReduced S]
   exact not_isStronglyTranscendental_of_weaklyQuasiFiniteAt_of_isDomain_aux K L f hf rfl hx' P
 
 @[stacks 00Q2]
-nonrec lemma not_isStronglyTranscendental_of_quasiFiniteAt [IsReduced S]
+lemma not_isStronglyTranscendental_of_quasiFiniteAt [IsReduced S]
     {x : S} (hx' : (aeval (R := R) x).toRingHom.Finite)
     (P : Ideal S) [P.IsPrime] [Algebra.QuasiFiniteAt R P] :
     ¬ IsStronglyTranscendental R x :=

--- a/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Corecursion.lean
+++ b/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Corecursion.lean
@@ -88,7 +88,7 @@ local instance : CompleteSpace (Seq α) := by
     (Metric.ball_mem_nhds _ (by positivity))
   simp only [Metric.ball, Set.mem_setOf_eq] at hts
   rw [← PiNat.apply_eq_of_dist_lt hts (by simp)] at hn
-  rw [← PiNat.apply_eq_of_dist_lt hts (by rfl)]
+  rw [← PiNat.apply_eq_of_dist_lt hts le_rfl]
   exact ht hn
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Majorized.lean
+++ b/Mathlib/Tactic/ComputeAsymptotics/Multiseries/Majorized.lean
@@ -121,8 +121,8 @@ theorem mul_bounded {f g basis_hd : ℝ → ℝ} {exp : ℝ} (hf : Majorized f b
     Majorized (f * g) basis_hd exp := by
   intro exp h_exp
   convert IsLittleO.mul_isBigO (hf _ h_exp) hg using 1
+  ext
   simp
-  rfl
 
 end Majorized
 

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -646,10 +646,10 @@ commutative additive groups (see `isUniformAddGroup_of_addCommGroup`) and for co
 additive groups (see `IsUniformAddGroup.of_compactSpace`). -/]
 def IsTopologicalGroup.leftUniformSpace : UniformSpace G where
   uniformity := comap (fun p : G × G => p.1⁻¹ * p.2) (𝓝 1)
-  symm :=
+  symm := by
     have : Tendsto (fun p : G × G ↦ (p.1⁻¹ * p.2)⁻¹) (comap (fun p : G × G ↦ p.1⁻¹ * p.2) (𝓝 1))
       (𝓝 1⁻¹) := tendsto_id.inv.comp tendsto_comap
-    by simpa [tendsto_comap_iff]
+    simpa [tendsto_comap_iff]
   comp := Tendsto.le_comap fun U H ↦ by
     rcases exists_nhds_one_split H with ⟨V, V_nhds, V_mul⟩
     refine mem_map.2 (mem_of_superset (mem_lift' <| preimage_mem_comap V_nhds) ?_)

--- a/Mathlib/Topology/Algebra/MulAction.lean
+++ b/Mathlib/Topology/Algebra/MulAction.lean
@@ -247,11 +247,11 @@ theorem continuousSMul_iff_stabilizer_isOpen [DiscreteTopology X] :
   intro x
   let U := {m' : M | m' • y = x}
   have hU : IsOpen U := by
-    by_cases hU' : U ≠ ∅
-    · obtain ⟨m, (hm : m • y = x)⟩ := Set.nonempty_iff_empty_ne.mpr hU'.symm
-      convert (h x).preimage (by fun_prop : Continuous fun m' : M ↦ m' * m⁻¹)
-      ext; simp [← smul_smul, U, eq_inv_smul_iff.mpr hm]
-    simp_all
+    by_cases! hU' : U = ∅
+    · simp [hU']
+    obtain ⟨m, hm : m • y = x⟩ := hU'
+    convert (h x).preimage (by fun_prop : Continuous fun m' : M ↦ m' * m⁻¹)
+    ext; simp [← smul_smul, U, eq_inv_smul_iff.mpr hm]
   simpa using hU
 
 end IsTopologicalGroup


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

As usual, `simp`s didn't seem slow.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
