### PR TITLE
fix(Tactic/FunProp): do not unfold semireducible definitions in the presence of projections

### DIFF
--- a/Mathlib/Analysis/Matrix/Normed.lean
+++ b/Mathlib/Analysis/Matrix/Normed.lean
@@ -431,6 +431,7 @@ For a matrix over a field, the norm defined in this section agrees with the oper
 section
 variable [NontriviallyNormedField α] [NormedAlgebra ℝ α]
 
+set_option backward.isDefEq.respectTransparency.types false in
 lemma linfty_opNNNorm_eq_opNNNorm (A : Matrix m n α) :
     ‖A‖₊ = ‖ContinuousLinearMap.mk (Matrix.mulVecLin A)‖₊ := by
   rw [ContinuousLinearMap.opNNNorm_eq_of_bounds _ (linfty_opNNNorm_mulVec _) fun N hN => ?_]
@@ -449,6 +450,7 @@ lemma linfty_opNNNorm_eq_opNNNorm (A : Matrix m n α) :
     nnnorm_one, mul_one] at hN
   exact hN
 
+set_option backward.isDefEq.respectTransparency.types false in
 lemma linfty_opNorm_eq_opNorm (A : Matrix m n α) :
     ‖A‖ = ‖ContinuousLinearMap.mk (Matrix.mulVecLin A)‖ :=
   congr_arg NNReal.toReal (linfty_opNNNorm_eq_opNNNorm A)

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -562,11 +562,13 @@ def prodContinuousLinearEquiv : WithLp p (α × β) ≃L[𝕜] α × β where
 lemma prodContinuousLinearEquiv_symm_apply (x : α × β) :
     (prodContinuousLinearEquiv p 𝕜 α β).symm x = toLp p x := rfl
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `WithLp.fst` as a continuous linear map. -/
 @[simps! coe apply]
 def fstL : WithLp p (α × β) →L[𝕜] α where
   __ := fstₗ ..
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `WithLp.snd` as a continuous linear map. -/
 @[simps! coe apply]
 def sndL : WithLp p (α × β) →L[𝕜] β where

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -167,6 +167,7 @@ noncomputable def sequentialAdjunction :
     (Functor.FullyFaithful.id _) fullyFaithfulSequentialToTop
     (Iso.refl _) (Iso.refl _)
 
+set_option fun_prop.projDefaultTransparency true in
 /--
 The counit of the adjunction `lightCondSetToSequential ⊣ sequentialToLightCondSet`
 is a homeomorphism.

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -183,6 +183,7 @@ noncomputable def compactlyGeneratedAdjunction :
     (Functor.FullyFaithful.id _) fullyFaithfulCompactlyGeneratedToTop
     (Iso.refl _) (Iso.refl _)
 
+set_option fun_prop.projDefaultTransparency true in
 /--
 The counit of the adjunction `condensedSetToCompactlyGenerated ⊣ compactlyGeneratedToCondensedSet`
 is a homeomorphism.

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -612,7 +612,7 @@ lemma log_riemannZeta_add_log_sub_isBigO_ofReal :
     simp [log_riemannZeta_eq_neg_log_sub_add_ofReal hs]
   suffices DifferentiableAt ℝ (fun (s : ℝ) ↦ (riemannZeta₁ s).re.log) 1 by
     simpa using this.isBigO_sub
-  have : Differentiable ℝ riemannZeta₀ := by fun_prop
+  have : Differentiable ℝ riemannZeta₁ := by fun_prop
   fun_prop (disch := simp)
 
 lemma log_riemannZeta_add_log_sub_isLittleO_ofReal :

--- a/Mathlib/NumberTheory/ModularForms/Bounds.lean
+++ b/Mathlib/NumberTheory/ModularForms/Bounds.lean
@@ -107,6 +107,7 @@ lemma exists_bound_of_invariant_of_isBigO {f : ℍ → E} (hf_cont : Continuous 
     have : (1 : ℝ) ≤ g 1 0 ^ 2 := mod_cast (one_le_sq_iff_one_le_abs _).mpr (Int.one_le_abs hg)
     nlinarith
 
+set_option backward.isDefEq.respectTransparency.types false in
 /-- A function on `ℍ` which is invariant under a finite-index subgroup of `SL(2, ℤ)`, and satisfies
 an `O((im τ) ^ t)` bound at all cusps for some `0 ≤ t`, is in fact uniformly bounded by a multiple
 of `(max (im τ) (1 / im τ)) ^ t`. -/
@@ -122,7 +123,7 @@ lemma exists_bound_of_subgroup_invariant_of_isBigO
       exact ⟨g⁻¹ * h, hgh, (mul_inv_cancel_left g h).symm⟩
     simp [-sl_moeb, hj', mul_smul, hf_inv j⁻¹ (inv_mem hj)]
   have hf'_cont γ : Continuous (f' · γ) := QuotientGroup.induction_on γ fun g ↦ by
-    simp only [sl_moeb, f']
+    simp only [sl_moeb, f', Quotient.lift_mk]
     fun_prop
   have hf'_inv τ (g : SL(2, ℤ)) γ : f' (g • τ) (g • γ) = f' τ γ := by
     induction γ using QuotientGroup.induction_on

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -446,7 +446,7 @@ def getLocalTheorems (funPropDecl : FunPropDecl) (funOrigin : Origin)
       let some (decl, f) ← getFunProp? b | return none
       unless decl.funPropName = funPropDecl.funPropName do return none
 
-      let .data fData ← getFunctionData? f (← unfoldNamePred)
+      let .data fData ← getFunctionData? f (← getUnfoldPred)
         | return none
       unless (fData.getFnOrigin == funOrigin) do return none
 
@@ -679,7 +679,7 @@ mutual
     if f.isLet then
       return ← funProp (← mapLetTelescope f fun _ b => pure <| e.setArg funPropDecl.funArgId b)
 
-    match ← getFunctionData? f (← unfoldNamePred) with
+    match ← getFunctionData? f (← getUnfoldPred) with
     | .letE f =>
       trace[Debug.Meta.Tactic.fun_prop] "let case on {← ppExpr f}"
       let e := e.setArg funPropDecl.funArgId f -- update e with reduced f

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -122,21 +122,15 @@ def MaybeFunctionData.get (fData : MaybeFunctionData) : MetaM Expr :=
 
 /-- Get `FunctionData` for `f`. -/
 def getFunctionData? (f : Expr)
-    (unfoldPred : Name → Bool := fun _ => false) :
+    (unfoldPred : Meta.Config → ConstantInfo → CoreM Bool) :
     MetaM MaybeFunctionData := do
   withConfig (fun cfg => { cfg with zeta := false, zetaDelta := false }) do
-
-  let unfold := fun e : Expr => do
-    if let some n := e.getAppFn'.constName? then
-      pure ((unfoldPred n) || (← isReducible n))
-    else
-      pure false
-
   let .forallE xName xType _ _ ← instantiateMVars (← inferType f)
     | throwError m!"fun_prop bug: function expected, got `{f} : {← inferType f}, \
                     type ctor {(← inferType f).ctorName}"
   withLocalDeclD xName xType fun x => do
-    let fx' := (← Mor.whnfPred (f.beta #[x]).eta unfold) |> headBetaThroughLet
+    let fx' := (← withCanUnfoldPred unfoldPred <| Mor.whnf (f.beta #[x]).eta) |>
+      headBetaThroughLet
     let f' ← mkLambdaFVars #[x] fx'
     match fx' with
     | .letE .. => return .letE f'

--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -66,39 +66,36 @@ def isMorApp? (e : Expr) : MetaM (Option App) := do
   else
     return none
 
-/--
-Weak normal head form of an expression involving morphism applications. Additionally, `pred`
-can specify which when to unfold definitions.
+/-- Previously, `fun_prop` incorrectly switched to default transparency when reducing an
+expression if a projection was applied to it. Setting this option to true restores this
+behavior.
 
-For example calling this on `coe (f a) b` will put `f` in weak normal head form instead of `coe`.
--/
-partial def whnfPred (e : Expr) (pred : Expr → MetaM Bool) :
-    MetaM Expr := do
-  whnfEasyCases e fun e => do
-    let e ← whnfCore e
-
-    if let some ⟨coe,f,x⟩ ← isMorApp? e then
-      let f ← whnfPred f pred
-      if (← getConfig).zeta then
-        return (coe.app f).app x
-      else
-        return ← mapLetTelescope f fun _ f' => pure ((coe.app f').app x)
-
-    if (← pred e) then
-        match (← unfoldDefinition? e) with
-        | some e => whnfPred e pred
-        | none   => return e
-    else
-      return e
+Note that this option is only for backward compatibility and will be removed in the future. -/
+register_option fun_prop.projDefaultTransparency : Bool := {
+  descr := "Previously, `fun_prop` incorrectly switched to default transparency when reducing an \
+    expression if a projection was applied to it. Setting this option to true restores this \
+    behavior.\n\n\
+    Note that this option is only for backward compatibility and will be removed in the future."
+  defValue := false
+}
 
 /--
 Weak normal head form of an expression involving morphism applications.
 
 For example calling this on `coe (f a) b` will put `f` in weak normal head form instead of `coe`.
 -/
-def whnf (e : Expr) : MetaM Expr :=
-  whnfPred e (fun _ => return false)
-
+protected partial def whnf (e : Expr) : MetaM Expr := do
+  let e ← whnfR e
+  if ← fun_prop.projDefaultTransparency.getM then
+    let e' ← whnfCore e
+    if e != e' then
+      return ← Mor.whnf e'
+  let some ⟨coe,f,x⟩ ← isMorApp? e | return e
+  let f ← Mor.whnf f
+  if (← getConfig).zeta then
+    return (coe.app f).app x
+  else
+    return ← mapLetTelescope f fun _ f' => pure ((coe.app f').app x)
 
 /-- Argument of morphism application that stores corresponding coercion if necessary -/
 structure Arg where

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -327,7 +327,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
       | throwError "unrecognized function property `{← ppExpr b}`"
     let funPropName := decl.funPropName
     let fData? ←
-      withConfig (fun cfg => { cfg with zeta := false}) <| getFunctionData? f defaultUnfoldPred
+      withConfig (fun cfg => { cfg with zeta := false}) <| getFunctionData? f unfoldPred
     if let some thmArgs ← detectLambdaTheoremArgs (← fData?.get) xs then
       return .lam {
         funPropName := funPropName

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -149,14 +149,15 @@ structure Result where
   /-- -/
   proof : Expr
 
-/-- Default names to unfold -/
-def defaultUnfoldPred : Name → Bool :=
-  defaultNamesToUnfold.contains
+/-- Predicate for unfolding the constants that are considered reducible by `fun_prop`. -/
+def unfoldPred (toUnfold : NameSet := .ofArray defaultNamesToUnfold) (cfg : Meta.Config)
+    (info : ConstantInfo) : CoreM Bool :=
+  pure (toUnfold.contains info.name) <||> canUnfoldDefault cfg info
 
-/-- Get predicate on names indicating whether they should be unfolded. -/
-def unfoldNamePred : FunPropM (Name → Bool) := do
-  let toUnfold := (← read).constToUnfold
-  return fun n => toUnfold.contains n
+/-- Returns an unfolding predicate that also unfolds constants given with the `fun_prop [c]` syntax.
+-/
+def getUnfoldPred : FunPropM (Meta.Config → ConstantInfo → CoreM Bool) := do
+  return unfoldPred (← read).constToUnfold
 
 /-- Increase heartbeat, throws error when `maxSteps` was reached -/
 def increaseSteps : FunPropM Unit := do

--- a/Mathlib/Topology/Algebra/AffineSubspace.lean
+++ b/Mathlib/Topology/Algebra/AffineSubspace.lean
@@ -94,10 +94,10 @@ variable [TopologicalSpace V] [IsTopologicalAddTorsor P]
 
 instance {s : AffineSubspace R P} [Nonempty s] : IsTopologicalAddTorsor s where
   continuous_vadd := by
-    rw [Topology.IsEmbedding.subtypeVal.continuous_iff]
+    simp_rw [Topology.IsEmbedding.subtypeVal.continuous_iff, Function.comp_def, coe_vadd]
     fun_prop
   continuous_vsub := by
-    rw [Topology.IsEmbedding.subtypeVal.continuous_iff]
+    simp_rw [Topology.IsEmbedding.subtypeVal.continuous_iff, Function.comp_def, coe_vsub]
     fun_prop
 
 theorem isClosed_direction_iff [T1Space V] (s : AffineSubspace R P) :

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -237,6 +237,7 @@ theorem continuousAt_const_smul_iff (c : G) :
 theorem continuous_const_smul_iff (c : G) : (Continuous fun x => c • f x) ↔ Continuous f := by
   simp only [continuous_iff_continuousAt, continuousAt_const_smul_iff]
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The homeomorphism given by scalar multiplication by a given element of a group `Γ` acting on
   `T` is a homeomorphism from `T` to itself. -/
 @[to_additive (attr := simps!)]

--- a/Mathlib/Topology/Algebra/Constructions.lean
+++ b/Mathlib/Topology/Algebra/Constructions.lean
@@ -45,6 +45,7 @@ theorem continuous_unop : Continuous (unop : Mᵐᵒᵖ → M) :=
 theorem continuous_op : Continuous (op : M → Mᵐᵒᵖ) :=
   continuous_induced_rng.2 continuous_id
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `MulOpposite.op` as a homeomorphism. -/
 @[to_additive (attr := simps!) /-- `AddOpposite.op` as a homeomorphism. -/]
 def opHomeomorph : M ≃ₜ Mᵐᵒᵖ where

--- a/Mathlib/Topology/Algebra/ContinuousAffineEquiv.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineEquiv.lean
@@ -136,6 +136,7 @@ end Basic
 
 section ReflSymmTrans
 
+set_option fun_prop.projDefaultTransparency true in
 variable (k P₁) in
 /-- Identity map as a `ContinuousAffineEquiv`. -/
 def refl : P₁ ≃ᴬ[k] P₁ where

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -82,6 +82,7 @@ end Subfield
 
 section Units
 
+set_option fun_prop.projDefaultTransparency true in
 /-- In an ordered field, the units of the nonnegative elements are the positive elements. -/
 @[simps!]
 def Nonneg.unitsHomeomorphPos (R : Type*) [DivisionSemiring R] [PartialOrder R]

--- a/Mathlib/Topology/Algebra/Group/ContinuousDiv.lean
+++ b/Mathlib/Topology/Algebra/Group/ContinuousDiv.lean
@@ -69,6 +69,7 @@ lemma Filter.tendsto_const_div_iff' (b : G) {c : G} {f : α → G} {l : Filter �
 @[deprecated (since := "2026-02-03")]
 alias Filter.tendsto_const_div_iff := Filter.tendsto_const_div_iff'
 
+set_option backward.defeqAttrib.useBackward true in
 /-- A version of `Homeomorph.mulLeft a b⁻¹` that is defeq to `a / b`. -/
 @[to_additive (attr := simps! +simpRhs)
   /-- A version of `Homeomorph.addLeft a (-b)` that is defeq to `a - b`. -/]
@@ -87,6 +88,7 @@ theorem isOpenMap_div_left (a : G) : IsOpenMap (a / ·) :=
 theorem isClosedMap_div_left (a : G) : IsClosedMap (a / ·) :=
   (Homeomorph.divLeft _).isClosedMap
 
+set_option backward.defeqAttrib.useBackward true in
 /-- A version of `Homeomorph.mulRight a⁻¹ b` that is defeq to `b / a`. -/
 @[to_additive (attr := simps! +simpRhs)
   /-- A version of `Homeomorph.addRight (-a) b` that is defeq to `b - a`. -/]

--- a/Mathlib/Topology/Algebra/Group/ContinuousInv.lean
+++ b/Mathlib/Topology/Algebra/Group/ContinuousInv.lean
@@ -170,6 +170,7 @@ theorem IsCompact.inv (hs : IsCompact s) : IsCompact s⁻¹ := by
 
 variable (G)
 
+set_option backward.defeqAttrib.useBackward true in
 /-- Inversion in a topological group as a homeomorphism. -/
 @[to_additive /-- Negation in a topological group as a homeomorphism. -/]
 protected def Homeomorph.inv (G : Type*) [TopologicalSpace G] [InvolutiveInv G]

--- a/Mathlib/Topology/Algebra/Group/Matrix.lean
+++ b/Mathlib/Topology/Algebra/Group/Matrix.lean
@@ -59,7 +59,7 @@ lemma _root_.Topology.IsClosedEmbedding.generalLinearGroup_map [T0Space R]
 /-- The determinant is continuous as a map from the general linear group to the units. -/
 @[continuity, fun_prop] protected lemma continuous_det :
     Continuous (det : GL n R → Rˣ) := by
-  simp_rw [Units.continuous_iff, ← map_inv]
+  simp_rw [Units.continuous_iff, ← map_inv, Function.comp_def, val_det_apply]
   constructor <;> fun_prop
 
 @[continuity, fun_prop]
@@ -132,6 +132,7 @@ instance topologicalGroup : IsTopologicalGroup (SL n R) where
 -/
 section toGL
 
+set_option fun_prop.projDefaultTransparency true in
 /-- The natural map from `SL n A` to `GL n A` is continuous. -/
 @[fun_prop]
 lemma continuous_toGL : Continuous (toGL : SL n R → GL n R) := by

--- a/Mathlib/Topology/Algebra/Group/Torsor.lean
+++ b/Mathlib/Topology/Algebra/Group/Torsor.lean
@@ -100,6 +100,7 @@ theorem IsTopologicalTorsor.to_isTopologicalGroup : IsTopologicalGroup V where
 def Homeomorph.smulConst (p : P) : V ≃ₜ P where
   __ := Equiv.smulConst p
 
+set_option fun_prop.projDefaultTransparency true in
 /-- The map `p' ↦ p /ₛ p'` as a homeomorphism: `Equiv.constSDiv` as a homeomorphism -/
 @[to_additive (attr := simps!)
 /-- The map `p' ↦ p -ᵥ p'` as a homeomorphism: `Equiv.constVSub` as a homeomorphism -/]

--- a/Mathlib/Topology/Algebra/Group/Units.lean
+++ b/Mathlib/Topology/Algebra/Group/Units.lean
@@ -70,6 +70,7 @@ open Set Filter TopologicalSpace Function Topology MulOpposite Pointwise
 
 variable {G H α β : Type*}
 
+set_option backward.defeqAttrib.useBackward true in
 /-- If `G` is a group with topological `⁻¹`, then it is homeomorphic to its units. -/
 @[to_additive /-- If `G` is an additive group with topological negation, then it is homeomorphic to
 its additive units. -/]

--- a/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Positive.lean
+++ b/Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Positive.lean
@@ -124,6 +124,7 @@ lemma toContinuousLinearMap_inj (f g : E₁ →P[R] E₂) :
     f.toContinuousLinearMap = g.toContinuousLinearMap ↔ f = g :=
   toContinuousLinearMap_injective.eq_iff
 
+set_option fun_prop.projDefaultTransparency true in
 instance : Zero (E₁ →P[R] E₂) where
   zero := .mk (0 : E₁ →ₚ[R] E₂) <| by fun_prop
 

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -439,6 +439,7 @@ variable (R M₁ M₂ M₃ M₄ : Type*) [Semiring R]
   [Module R M₁] [Module R M₂] [Module R M₃] [Module R M₄]
   [TopologicalSpace M₁] [TopologicalSpace M₂] [TopologicalSpace M₃] [TopologicalSpace M₄]
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The product of topological modules is four-way commutative up to continuous linear isomorphism.
 This is `LinearEquiv.prodProdProdComm` prodAssoc as a continuous linear equivalence. -/
 def prodProdProdComm : ((M₁ × M₂) × M₃ × M₄) ≃L[R] (M₁ × M₃) × M₂ × M₄ where
@@ -704,6 +705,7 @@ variable {M₁} {R₄ : Type*} [Semiring R₄] [Module R₄ M₄] {σ₃₄ : R�
   [RingHomInvPair σ₃₄ σ₄₃] [RingHomInvPair σ₄₃ σ₃₄] {σ₂₄ : R₂ →+* R₄} {σ₁₄ : R₁ →+* R₄}
   [RingHomCompTriple σ₂₁ σ₁₄ σ₂₄] [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The continuous linear equivalence between `ULift M₁` and `M₁`.
 
 This is a continuous version of `ULift.moduleEquiv`. -/
@@ -1150,6 +1152,7 @@ theorem ofSubmodule'_symm_apply (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂
 
 end ContinuousLinearEquiv
 
+set_option fun_prop.projDefaultTransparency true in
 /-- The top submodule is continuous linearly equivalent to the module.
 This is the continuous version of `Submodule.topEquiv`. -/
 abbrev _root_.Submodule.topContEquiv {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]

--- a/Mathlib/Topology/Algebra/Module/IsWeak.lean
+++ b/Mathlib/Topology/Algebra/Module/IsWeak.lean
@@ -136,6 +136,7 @@ protected theorem congr [AddCommMonoid E'] [Module 𝕜 E']
     rw [f.toEquiv.iInf_congr]
     simp
 
+set_option fun_prop.projDefaultTransparency true in
 /-- Map `F` into the topological dual of `E` with the weak topology induced by `F` -/
 def eval [ContinuousAdd 𝕜] [ContinuousConstSMul 𝕜 𝕜] : F →ₗ[𝕜] StrongDual 𝕜 E where
   toFun f := ⟨B.flip f, by fun_prop⟩

--- a/Mathlib/Topology/Algebra/Module/Spaces/WeakBilin.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/WeakBilin.lean
@@ -135,6 +135,7 @@ instance instContinuousSMul [ContinuousSMul 𝕜 𝕜] : ContinuousSMul 𝕜 (We
   simp only [Function.comp_apply, Pi.smul_apply, map_smulₛₗ, RingHom.id_apply, LinearMap.smul_apply]
 
 set_option backward.isDefEq.respectTransparency false in
+set_option fun_prop.projDefaultTransparency true in
 /--
 Map `F` into the topological dual of `E` with the weak topology induced by `F`
 -/

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -141,6 +141,7 @@ theorem induced_of_isLimit :
 
 end IsLimit
 
+set_option fun_prop.projDefaultTransparency true in
 lemma nonempty_isLimit_iff_eq_induced {F : J ⥤ TopCat.{u}} (c : Cone F)
     (hc : IsLimit ((forget).mapCone c)) :
     Nonempty (IsLimit c) ↔ c.pt.str = ⨅ j, (F.obj j).str.induced (c.π.app j) := by
@@ -275,6 +276,7 @@ lemma continuous_iff_of_isColimit {X : Type u'} [TopologicalSpace X] (f : c.pt �
 
 end IsColimit
 
+set_option fun_prop.projDefaultTransparency true in
 lemma nonempty_isColimit_iff_eq_coinduced (c : Cocone F) (hc : IsColimit ((forget).mapCocone c)) :
     Nonempty (IsColimit c) ↔ c.pt.str = ⨆ j, (F.obj j).str.coinduced (c.ι.app j) := by
   refine ⟨fun ⟨hc⟩ ↦ coinduced_of_isColimit _ hc, fun h ↦ ⟨?_⟩⟩

--- a/Mathlib/Topology/Constructions/SumProd.lean
+++ b/Mathlib/Topology/Constructions/SumProd.lean
@@ -695,6 +695,7 @@ theorem prodComm_symm : (prodComm X Y).symm = prodComm Y X :=
 theorem coe_prodComm : ⇑(prodComm X Y) = Prod.swap :=
   rfl
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `(X × Y) × Z` is homeomorphic to `X × (Y × Z)`. -/
 def prodAssoc : (X × Y) × Z ≃ₜ X × Y × Z where
   toEquiv := Equiv.prodAssoc X Y Z
@@ -702,6 +703,7 @@ def prodAssoc : (X × Y) × Z ≃ₜ X × Y × Z where
 @[simp]
 lemma prodAssoc_toEquiv : (prodAssoc X Y Z).toEquiv = Equiv.prodAssoc X Y Z := rfl
 
+set_option backward.defeqAttrib.useBackward true in
 /-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
 def prodProdProdComm : (X × Y) × W × Z ≃ₜ (X × W) × Y × Z where
   toEquiv := Equiv.prodProdProdComm X Y W Z
@@ -710,6 +712,7 @@ def prodProdProdComm : (X × Y) × W × Z ≃ₜ (X × W) × Y × Z where
 theorem prodProdProdComm_symm : (prodProdProdComm X Y W Z).symm = prodProdProdComm X W Y Z :=
   rfl
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `X × {*}` is homeomorphic to `X`. -/
 @[simps! -fullyApplied apply]
 def prodPUnit : X × PUnit ≃ₜ X where
@@ -908,6 +911,7 @@ theorem sumCongr_trans {X'' Y'' : Type*} [TopologicalSpace X''] [TopologicalSpac
 
 variable (W X Y Z)
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `X ⊕ Y` is homeomorphic to `Y ⊕ X`. -/
 def sumComm : X ⊕ Y ≃ₜ Y ⊕ X where
   toEquiv := Equiv.sumComm X Y
@@ -946,6 +950,7 @@ lemma sumSumSumComm_toEquiv : (sumSumSumComm W X Y Z).toEquiv = (Equiv.sumSumSum
 @[simp]
 lemma sumSumSumComm_symm : (sumSumSumComm X Y W Z).symm = (sumSumSumComm X W Y Z) := rfl
 
+set_option fun_prop.projDefaultTransparency true in
 /-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
 @[simps! -fullyApplied apply]
 def sumEmpty [IsEmpty Y] : X ⊕ Y ≃ₜ X where

--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -589,6 +589,7 @@ instance module : Module R C(α, M) := fast_instance%
 
 variable (R)
 
+set_option fun_prop.projDefaultTransparency true in
 /-- Composition on the left by a continuous linear map, as a `ContinuousLinearMap`.
 Similar to `LinearMap.compLeft`. -/
 @[simps]

--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -269,6 +269,7 @@ def piCongr {ι₁ ι₂ : Type*} {Y₁ : ι₁ → Type*} {Y₂ : ι₂ → Typ
     (e : ι₁ ≃ ι₂) (F : ∀ i₁, Y₁ i₁ ≃ₜ Y₂ (e i₁)) : (∀ i₁, Y₁ i₁) ≃ₜ ∀ i₂, Y₂ i₂ :=
   (Homeomorph.piCongrRight F).trans (Homeomorph.piCongrLeft e)
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `ULift X` is homeomorphic to `X`. -/
 def ulift.{u, v} {X : Type v} [TopologicalSpace X] : ULift.{u, v} X ≃ₜ X where
   toEquiv := Equiv.ulift
@@ -298,6 +299,7 @@ theorem _root_.Fin.continuous_append (m n : ℕ) :
   rw [Fin.appendEquiv_eq_homeomorph]
   exact Homeomorph.continuous_toFun _
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `Fin (m + n) → X`.
 `Fin.appendEquiv` as a homeomorphism -/
 @[simps!]
@@ -329,6 +331,7 @@ set_option backward.defeqAttrib.useBackward true in
 def funUnique (ι X : Type*) [Unique ι] [TopologicalSpace X] : (ι → X) ≃ₜ X where
   toEquiv := Equiv.funUnique ι X
 
+set_option backward.defeqAttrib.useBackward true in
 /-- Homeomorphism between dependent functions `Π i : Fin 2, X i` and `X 0 × X 1`. -/
 @[simps! -fullyApplied]
 def piFinTwo.{u} (X : Fin 2 → Type u) [∀ i, TopologicalSpace (X i)] : (∀ i, X i) ≃ₜ X 0 × X 1 where
@@ -348,6 +351,7 @@ def image (e : X ≃ₜ Y) (s : Set X) : s ≃ₜ e '' s where
   continuous_invFun := (e.symm.continuous.comp continuous_subtype_val).codRestrict _
   toEquiv := e.toEquiv.image s
 
+set_option backward.defeqAttrib.useBackward true in
 /-- `Set.univ X` is homeomorphic to `X`. -/
 @[simps! -fullyApplied]
 def Set.univ (X : Type*) [TopologicalSpace X] : (univ : Set X) ≃ₜ X where
@@ -366,6 +370,7 @@ section
 
 variable {ι : Type*}
 
+set_option backward.defeqAttrib.useBackward true in
 /-- The topological space `Π i, Y i` can be split as a product by separating the indices in ι
   depending on whether they satisfy a predicate p or not. -/
 @[simps!]
@@ -379,6 +384,7 @@ def piEquivPiSubtypeProd (p : ι → Prop) (Y : ι → Type*) [∀ i, Topologica
 
 variable [DecidableEq ι] (i : ι)
 
+set_option backward.defeqAttrib.useBackward true in
 /-- A product of topological spaces can be split as the binary product of one of the spaces and
   the product of all the remaining spaces. -/
 @[simps!]

--- a/Mathlib/Topology/Semicontinuity/Michael.lean
+++ b/Mathlib/Topology/Semicontinuity/Michael.lean
@@ -129,7 +129,7 @@ theorem LowerHemicontinuous.exists_continuous_selection (hf : LowerHemicontinuou
     rw [← forall_and, ← forall_and]
     intro n
     induction n with
-    | zero => exact ⟨by fun_prop, hg_mem, (hF 0 g ⟨hg_cont, hg_mem⟩).2.2⟩
+    | zero => exact ⟨hg_cont, hg_mem, (hF 0 g ⟨hg_cont, hg_mem⟩).2.2⟩
     | succ n ih => simp [ih, P, hF, -singleton_add]
   -- Prove the sequence is uniformly cauchy. The (necessarily continuous) limit is a selection
   have hUnif : UniformCauchySeqOn h Filter.atTop univ := by

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -853,3 +853,33 @@ theorem Con_imp {p q : α → Prop} : Con (fun x => p x → q x) := silentSorry
 example {p : α → Prop} : Con (fun x => True → p x) := by fun_prop
 
 end DependentCompositionalForm
+
+section ProjTransparency
+
+def semireducibleFun (_ : Nat) := (1, 2)
+
+/--
+error: `fun_prop` was unable to prove `Con semireducibleFun`
+
+Issues:
+  No theorems found for `semireducibleFun` in order to prove `Con fun x => semireducibleFun x`
+-/
+#guard_msgs in
+example : Con semireducibleFun := by fun_prop
+
+-- This used to work because `semireducibleFun` was incorrectly unfolded
+
+/--
+error: `fun_prop` was unable to prove `Con fun x => (semireducibleFun x).fst`
+
+Issues:
+  No theorems found for `semireducibleFun` in order to prove `Con fun x => semireducibleFun x`
+-/
+#guard_msgs in
+example : Con (fun x => (semireducibleFun x).1) := by fun_prop
+
+-- Test that the backward compatibility option restores the incorrect behavior
+set_option fun_prop.projDefaultTransparency true in
+example : Con (fun x => (semireducibleFun x).1) := by fun_prop
+
+end ProjTransparency


### PR DESCRIPTION
Currently, `fun_prop` incorrectly unfolds semireducible definitions when a projection or recursor is applied. This PR fixes this by switching to `whnfR` together with `Lean.Meta.withCanUnfoldPred` for the custom unfolding logic.

Unfortunately, there are many proofs which rely on this bug. To avoid breaking proofs, the option `fun_prop.projDefaultTransparency` is added for locally restoring the previous behavior. Removing the uses of this option is left for future PRs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
