### PR TITLE
[Merged by Bors] - refactor(PiTensorProduct/{InjectiveNorm, ProjectiveNorm}): Golfs

### DIFF
--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
@@ -6,7 +6,7 @@ Authors: Sophie Morel
 module
 
 public import Mathlib.Analysis.Normed.Module.PiTensorProduct.ProjectiveSeminorm
-public import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.LinearAlgebra.Isomorphisms
 
 /-!
 # Injective seminorm on the tensor of a finite family of normed spaces.
@@ -93,30 +93,18 @@ section seminorm
 
 variable (F) in
 /-- The linear map from `⨂[𝕜] i, Eᵢ` to `ContinuousMultilinearMap 𝕜 E F →L[𝕜] F` sending
-`x` in `⨂[𝕜] i, Eᵢ` to the map `f ↦ f.lift x`.
--/
+`x` in `⨂[𝕜] i, Eᵢ` to the map `f ↦ f.lift x`. -/
 @[simps!]
 noncomputable def toDualContinuousMultilinearMap : (⨂[𝕜] i, E i) →ₗ[𝕜]
     ContinuousMultilinearMap 𝕜 E F →L[𝕜] F where
   toFun x := LinearMap.mkContinuous
-    ((LinearMap.flip (lift (R := 𝕜) (s := E) (E := F)).toLinearMap x) ∘ₗ
-    ContinuousMultilinearMap.toMultilinearMapLinear)
+    (lift.toLinearMap.flip x ∘ₗ ContinuousMultilinearMap.toMultilinearMapLinear)
     (projectiveSeminorm x)
-    (fun _ ↦ by simp only [LinearMap.coe_comp, Function.comp_apply,
-                  ContinuousMultilinearMap.toMultilinearMapLinear_apply, LinearMap.flip_apply,
-                  LinearEquiv.coe_coe]
-                exact norm_eval_le_projectiveSeminorm _ _ _)
+    (fun _ ↦ by simpa using norm_eval_le_projectiveSeminorm ..)
   map_add' x y := by
-    ext _
-    simp only [map_add, LinearMap.mkContinuous_apply, LinearMap.coe_comp, Function.comp_apply,
-      ContinuousMultilinearMap.toMultilinearMapLinear_apply, LinearMap.add_apply,
-      LinearMap.flip_apply, LinearEquiv.coe_coe, ContinuousLinearMap.add_apply]
+    ext; simp
   map_smul' a x := by
-    ext _
-    simp only [map_smul, LinearMap.mkContinuous_apply, LinearMap.coe_comp, Function.comp_apply,
-      ContinuousMultilinearMap.toMultilinearMapLinear_apply, LinearMap.smul_apply,
-      LinearMap.flip_apply, LinearEquiv.coe_coe, RingHom.id_apply, ContinuousLinearMap.coe_smul',
-      Pi.smul_apply]
+    ext; simp
 
 theorem toDualContinuousMultilinearMap_le_projectiveSeminorm (x : ⨂[𝕜] i, E i) :
     ‖toDualContinuousMultilinearMap F x‖ ≤ projectiveSeminorm x := by
@@ -137,14 +125,10 @@ lemma dualSeminorms_bounded : BddAbove {p | ∃ (G : Type (max uι u𝕜 uE))
     (_ : SeminormedAddCommGroup G) (_ : NormedSpace 𝕜 G),
     p = Seminorm.comp (normSeminorm 𝕜 (ContinuousMultilinearMap 𝕜 E G →L[𝕜] G))
     (toDualContinuousMultilinearMap G (𝕜 := 𝕜) (E := E))} := by
-  existsi projectiveSeminorm
-  rw [mem_upperBounds]
-  simp only [Set.mem_setOf_eq, forall_exists_index]
-  intro p G _ _ hp
-  rw [hp]
-  intro x
-  simp only [Seminorm.comp_apply, coe_normSeminorm]
-  exact toDualContinuousMultilinearMap_le_projectiveSeminorm _
+  use projectiveSeminorm
+  simp only [mem_upperBounds, Set.mem_setOf_eq, forall_exists_index]
+  intro p G _ _ hp x
+  simpa [hp] using toDualContinuousMultilinearMap_le_projectiveSeminorm _
 
 theorem injectiveSeminorm_apply (x : ⨂[𝕜] i, E i) :
     injectiveSeminorm x = ⨆ p : {p | ∃ (G : Type (max uι u𝕜 uE))
@@ -247,58 +231,42 @@ induced by `PiTensorProduct.lift`, for every normed space `F`.
 noncomputable def liftEquiv : ContinuousMultilinearMap 𝕜 E F ≃ₗ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F where
   toFun f := LinearMap.mkContinuous (lift f.toMultilinearMap) ‖f‖ fun x ↦
     norm_eval_le_injectiveSeminorm f x
-  map_add' f g := by ext _; simp only [ContinuousMultilinearMap.toMultilinearMap_add, map_add,
-    LinearMap.mkContinuous_apply, LinearMap.add_apply, ContinuousLinearMap.add_apply]
-  map_smul' a f := by ext _; simp only [ContinuousMultilinearMap.toMultilinearMap_smul, map_smul,
-    LinearMap.mkContinuous_apply, LinearMap.smul_apply, RingHom.id_apply,
-    ContinuousLinearMap.coe_smul', Pi.smul_apply]
-  invFun l := MultilinearMap.mkContinuous (lift.symm l.toLinearMap) ‖l‖ fun x ↦ by
-    simp only [lift_symm, LinearMap.compMultilinearMap_apply, ContinuousLinearMap.coe_coe]
-    exact ContinuousLinearMap.le_opNorm_of_le _ (injectiveSeminorm_tprod_le x)
-  left_inv f := by ext x; simp only [LinearMap.mkContinuous_coe, LinearEquiv.symm_apply_apply,
-      MultilinearMap.coe_mkContinuous, ContinuousMultilinearMap.coe_coe]
+  map_add' f g := by ext; simp
+  map_smul' a f := by ext; simp
+  invFun l := MultilinearMap.mkContinuous (lift.symm l.toLinearMap) ‖l‖ fun x ↦
+    ContinuousLinearMap.le_opNorm_of_le _ (injectiveSeminorm_tprod_le x)
+  left_inv f := by ext; simp
   right_inv l := by
     rw [← ContinuousLinearMap.coe_inj]
-    apply PiTensorProduct.ext; ext m
-    simp only [lift_symm, LinearMap.mkContinuous_coe, LinearMap.compMultilinearMap_apply,
-      lift.tprod, ContinuousMultilinearMap.coe_coe, MultilinearMap.coe_mkContinuous,
-      ContinuousLinearMap.coe_coe]
+    ext; simp
 
 /-- For a normed space `F`, we have constructed in `PiTensorProduct.liftEquiv` the canonical
 linear equivalence between `ContinuousMultilinearMap 𝕜 E F` and `(⨂[𝕜] i, Eᵢ) →L[𝕜] F`
 (induced by `PiTensorProduct.lift`). Here we give the upgrade of this equivalence to
-an isometric linear equivalence; in particular, it is a continuous linear equivalence.
--/
-noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F :=
-  { liftEquiv 𝕜 E F with
-    norm_map' := by
-      intro f
-      refine le_antisymm ?_ ?_
-      · simp only [liftEquiv_apply]
-        exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) _
-      · conv_lhs => rw [← (liftEquiv 𝕜 E F).symm_apply_apply f]
-        rw [liftEquiv_symm_apply]
-        exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg _) _ }
+an isometric linear equivalence; in particular, it is a continuous linear equivalence. -/
+noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F := by
+  refine LinearIsometryEquiv.ofBounds (liftEquiv 𝕜 E F) (fun f ↦ ?_) (fun f ↦ ?_)
+  · exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) (norm_eval_le_injectiveSeminorm f)
+  · rw [liftEquiv_symm_apply]
+    exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg f) _
 
 variable {𝕜 E F}
 
+-- API missing for `LinearIsometryEquiv.ofBounds`?
 @[simp]
 theorem liftIsometry_apply_apply (f : ContinuousMultilinearMap 𝕜 E F) (x : ⨂[𝕜] i, E i) :
     liftIsometry 𝕜 E F f x = lift f.toMultilinearMap x := by
-  simp only [liftIsometry, LinearIsometryEquiv.coe_mk, liftEquiv_apply,
-    LinearMap.mkContinuous_apply]
+  simp [LinearIsometryEquiv.ofBounds, liftIsometry]
 
 variable (𝕜) in
-/-- The canonical continuous multilinear map from `E = Πᵢ Eᵢ` to `⨂[𝕜] i, Eᵢ`.
--/
+/-- The canonical continuous multilinear map from `E = Πᵢ Eᵢ` to `⨂[𝕜] i, Eᵢ`. -/
 @[simps!]
 noncomputable def tprodL : ContinuousMultilinearMap 𝕜 E (⨂[𝕜] i, E i) :=
   (liftIsometry 𝕜 E _).symm (ContinuousLinearMap.id 𝕜 _)
 
 @[simp]
 theorem tprodL_coe : (tprodL 𝕜).toMultilinearMap = tprod 𝕜 (s := E) := by
-  ext m
-  simp only [ContinuousMultilinearMap.coe_coe, tprodL_toFun]
+  ext; simp
 
 @[simp]
 theorem liftIsometry_symm_apply (l : (⨂[𝕜] i, E i) →L[𝕜] F) :
@@ -308,9 +276,7 @@ theorem liftIsometry_symm_apply (l : (⨂[𝕜] i, E i) →L[𝕜] F) :
 @[simp]
 theorem liftIsometry_tprodL :
     liftIsometry 𝕜 E _ (tprodL 𝕜) = ContinuousLinearMap.id 𝕜 (⨂[𝕜] i, E i) := by
-  ext _
-  simp only [liftIsometry_apply_apply, tprodL_coe, lift_tprod, LinearMap.id_coe, id_eq,
-    ContinuousLinearMap.coe_id']
+  ext; simp
 
 end seminorm
 
@@ -321,21 +287,16 @@ variable [∀ i, SeminormedAddCommGroup (E' i)] [∀ i, NormedSpace 𝕜 (E' i)]
 variable [∀ i, SeminormedAddCommGroup (E'' i)] [∀ i, NormedSpace 𝕜 (E'' i)]
 variable (g : Π i, E' i →L[𝕜] E'' i) (f : Π i, E i →L[𝕜] E' i)
 
-/--
-Let `Eᵢ` and `E'ᵢ` be two families of normed `𝕜`-vector spaces.
+/-- Let `Eᵢ` and `E'ᵢ` be two families of normed `𝕜`-vector spaces.
 Let `f` be a family of continuous `𝕜`-linear maps between `Eᵢ` and `E'ᵢ`, i.e.
 `f : Πᵢ Eᵢ →L[𝕜] E'ᵢ`, then there is an induced continuous linear map
-`⨂ᵢ Eᵢ → ⨂ᵢ E'ᵢ` by `⨂ aᵢ ↦ ⨂ fᵢ aᵢ`.
--/
+`⨂ᵢ Eᵢ → ⨂ᵢ E'ᵢ` by `⨂ aᵢ ↦ ⨂ fᵢ aᵢ`. -/
 noncomputable def mapL : (⨂[𝕜] i, E i) →L[𝕜] ⨂[𝕜] i, E' i :=
   liftIsometry 𝕜 E _ <| (tprodL 𝕜).compContinuousLinearMap f
 
 @[simp]
 theorem mapL_coe : (mapL f).toLinearMap = map (fun i ↦ (f i).toLinearMap) := by
-  ext
-  simp only [mapL, LinearMap.compMultilinearMap_apply, ContinuousLinearMap.coe_coe,
-    liftIsometry_apply_apply, lift.tprod, ContinuousMultilinearMap.coe_coe,
-    ContinuousMultilinearMap.compContinuousLinearMap_apply, tprodL_toFun, map_tprod]
+  ext; simp [mapL]
 
 @[simp]
 theorem mapL_apply (x : ⨂[𝕜] i, E i) : mapL f x = map (fun i ↦ (f i).toLinearMap) x := by
@@ -343,33 +304,24 @@ theorem mapL_apply (x : ⨂[𝕜] i, E i) : mapL f x = map (fun i ↦ (f i).toLi
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Given submodules `pᵢ ⊆ Eᵢ`, this is the natural map: `⨂[𝕜] i, pᵢ → ⨂[𝕜] i, Eᵢ`.
-This is the continuous version of `PiTensorProduct.mapIncl`.
--/
+This is the continuous version of `PiTensorProduct.mapIncl`. -/
 @[simp]
 noncomputable def mapLIncl (p : Π i, Submodule 𝕜 (E i)) : (⨂[𝕜] i, p i) →L[𝕜] ⨂[𝕜] i, E i :=
   mapL fun (i : ι) ↦ (p i).subtypeL
 
 theorem mapL_comp : mapL (fun (i : ι) ↦ g i ∘L f i) = mapL g ∘L mapL f := by
   apply ContinuousLinearMap.coe_injective
-  ext
-  simp only [mapL_coe, ContinuousLinearMap.coe_comp, LinearMap.compMultilinearMap_apply, map_tprod,
-    LinearMap.coe_comp, ContinuousLinearMap.coe_coe, Function.comp_apply]
+  ext; simp
 
 theorem liftIsometry_comp_mapL (h : ContinuousMultilinearMap 𝕜 E' F) :
     liftIsometry 𝕜 E' F h ∘L mapL f = liftIsometry 𝕜 E F (h.compContinuousLinearMap f) := by
   apply ContinuousLinearMap.coe_injective
-  ext
-  simp only [ContinuousLinearMap.coe_comp, mapL_coe, LinearMap.compMultilinearMap_apply,
-    LinearMap.coe_comp, ContinuousLinearMap.coe_coe, Function.comp_apply, map_tprod,
-    liftIsometry_apply_apply, lift.tprod, ContinuousMultilinearMap.coe_coe,
-    ContinuousMultilinearMap.compContinuousLinearMap_apply]
+  ext; simp
 
 @[simp]
 theorem mapL_id : mapL (fun i ↦ ContinuousLinearMap.id 𝕜 (E i)) = ContinuousLinearMap.id _ _ := by
   apply ContinuousLinearMap.coe_injective
-  ext
-  simp only [mapL_coe, ContinuousLinearMap.coe_id, map_id, LinearMap.compMultilinearMap_apply,
-    LinearMap.id_coe, id_eq]
+  ext; simp
 
 @[simp]
 theorem mapL_one : mapL (fun (i : ι) ↦ (1 : E i →L[𝕜] E i)) = 1 :=
@@ -396,8 +348,7 @@ open Function in
 private theorem mapL_add_smul_aux {ι : Type uι}
     {E : ι → Type uE} [(i : ι) → SeminormedAddCommGroup (E i)] [(i : ι) → NormedSpace 𝕜 (E i)]
     {E' : ι → Type u_1} [(i : ι) → SeminormedAddCommGroup (E' i)] [(i : ι) → NormedSpace 𝕜 (E' i)]
-    (f : (i : ι) → E i →L[𝕜] E' i)
-    [DecidableEq ι] (i : ι) (u : E i →L[𝕜] E' i) :
+    (f : (i : ι) → E i →L[𝕜] E' i) [DecidableEq ι] (i : ι) (u : E i →L[𝕜] E' i) :
     (fun j ↦ (update f i u j).toLinearMap) =
       update (fun j ↦ (f j).toLinearMap) i u.toLinearMap := by
   grind
@@ -405,37 +356,27 @@ private theorem mapL_add_smul_aux {ι : Type uι}
 open Function in
 protected theorem mapL_add [DecidableEq ι] (i : ι) (u v : E i →L[𝕜] E' i) :
     mapL (update f i (u + v)) = mapL (update f i u) + mapL (update f i v) := by
-  ext x
-  simp only [mapL_apply, mapL_add_smul_aux, ContinuousLinearMap.coe_add,
-    PiTensorProduct.map_update_add, LinearMap.add_apply, ContinuousLinearMap.add_apply]
+  ext
+  simp [mapL_add_smul_aux, PiTensorProduct.map_update_add]
 
 open Function in
 protected theorem mapL_smul [DecidableEq ι] (i : ι) (c : 𝕜) (u : E i →L[𝕜] E' i) :
     mapL (update f i (c • u)) = c • mapL (update f i u) := by
-  ext x
-  simp only [mapL_apply, mapL_add_smul_aux, ContinuousLinearMap.coe_smul,
-    PiTensorProduct.map_update_smul, LinearMap.smul_apply, ContinuousLinearMap.coe_smul',
-    Pi.smul_apply]
+  ext
+  simp [mapL_add_smul_aux, PiTensorProduct.map_update_smul]
 
 theorem mapL_opNorm : ‖mapL f‖ ≤ ∏ i, ‖f i‖ := by
-  rw [ContinuousLinearMap.opNorm_le_iff (by positivity)]
-  intro x
-  rw [mapL, liftIsometry]
-  simp only [LinearIsometryEquiv.coe_mk, liftEquiv_apply, LinearMap.mkContinuous_apply]
-  refine le_trans (norm_eval_le_injectiveSeminorm _ _)
-    (mul_le_mul_of_nonneg_right ?_ (norm_nonneg x))
-  rw [ContinuousMultilinearMap.opNorm_le_iff (Finset.prod_nonneg (fun _ _ ↦ norm_nonneg _))]
-  intro m
-  simp only [ContinuousMultilinearMap.compContinuousLinearMap_apply]
-  refine le_trans (injectiveSeminorm_tprod_le (fun i ↦ (f i) (m i))) ?_
+  refine (ContinuousLinearMap.opNorm_le_iff (by positivity)).mpr fun x ↦ ?_
+  apply le_trans (norm_eval_le_injectiveSeminorm ..) (mul_le_mul_of_nonneg_right _ (norm_nonneg x))
+  refine (ContinuousMultilinearMap.opNorm_le_iff (by positivity)).mpr fun m ↦ ?_
+  apply le_trans (injectiveSeminorm_tprod_le fun i ↦ f i (m i))
   rw [← Finset.prod_mul_distrib]
   exact Finset.prod_le_prod (fun _ _ ↦ norm_nonneg _) (fun _ _ ↦ ContinuousLinearMap.le_opNorm _ _)
 
 variable (𝕜 E E')
 
 /-- The tensor of a family of linear maps from `Eᵢ` to `E'ᵢ`, as a continuous multilinear map of
-the family.
--/
+the family. -/
 @[simps!]
 noncomputable def mapLMultilinear : ContinuousMultilinearMap 𝕜 (fun (i : ι) ↦ E i →L[𝕜] E' i)
     ((⨂[𝕜] i, E i) →L[𝕜] ⨂[𝕜] i, E' i) :=

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/InjectiveSeminorm.lean
@@ -244,11 +244,12 @@ noncomputable def liftEquiv : ContinuousMultilinearMap 𝕜 E F ≃ₗ[𝕜] (�
 linear equivalence between `ContinuousMultilinearMap 𝕜 E F` and `(⨂[𝕜] i, Eᵢ) →L[𝕜] F`
 (induced by `PiTensorProduct.lift`). Here we give the upgrade of this equivalence to
 an isometric linear equivalence; in particular, it is a continuous linear equivalence. -/
-noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F := by
-  refine LinearIsometryEquiv.ofBounds (liftEquiv 𝕜 E F) (fun f ↦ ?_) (fun f ↦ ?_)
-  · exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) (norm_eval_le_injectiveSeminorm f)
-  · rw [liftEquiv_symm_apply]
-    exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg f) _
+noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F :=
+  LinearIsometryEquiv.ofBounds (liftEquiv 𝕜 E F)
+  (fun f ↦ LinearMap.mkContinuous_norm_le _ (norm_nonneg f) (norm_eval_le_injectiveSeminorm f))
+  (fun f ↦ by
+      rw [liftEquiv_symm_apply]
+      exact MultilinearMap.mkContinuous_norm_le _ (norm_nonneg f) _)
 
 variable {𝕜 E F}
 

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
@@ -11,7 +11,7 @@ public import Mathlib.LinearAlgebra.PiTensorProduct
 /-!
 # Projective seminorm on the tensor of a finite family of normed spaces.
 
-Let `𝕜` be a nontrivially normed field and `E` be a family of normed `𝕜`-vector spaces `Eᵢ`,
+Let `𝕜` be a normed field and `E` be a family of normed `𝕜`-vector spaces `Eᵢ`,
 indexed by a finite type `ι`. We define a seminorm on `⨂[𝕜] i, Eᵢ`, which we call the
 "projective seminorm". For `x` an element of `⨂[𝕜] i, Eᵢ`, its projective seminorm is the
 infimum over all expressions of `x` as `∑ j, ⨂ₜ[𝕜] mⱼ i` (with the `mⱼ` ∈ `Π i, Eᵢ`)
@@ -42,29 +42,28 @@ for every `m` in `Π i, Eᵢ` is bounded above by the projective seminorm.
 universe uι u𝕜 uE uF
 
 variable {ι : Type uι} [Fintype ι]
-variable {𝕜 : Type u𝕜} [NontriviallyNormedField 𝕜]
+variable {𝕜 : Type u𝕜}
 variable {E : ι → Type uE} [∀ i, SeminormedAddCommGroup (E i)]
 
 open scoped TensorProduct
 
 namespace PiTensorProduct
 
+section NormedField
+
+variable [NontriviallyNormedField 𝕜]
+
 /-- A lift of the projective seminorm to `FreeAddMonoid (𝕜 × Π i, Eᵢ)`, useful to prove the
-properties of `projectiveSeminorm`.
--/
+properties of `projectiveSeminorm`. -/
 def projectiveSeminormAux : FreeAddMonoid (𝕜 × Π i, E i) → ℝ :=
-  fun p => (p.toList.map (fun p ↦ ‖p.1‖ * ∏ i, ‖p.2 i‖)).sum
+  fun p ↦ (p.toList.map (fun p ↦ ‖p.1‖ * ∏ i, ‖p.2 i‖)).sum
 
 theorem projectiveSeminormAux_nonneg (p : FreeAddMonoid (𝕜 × Π i, E i)) :
     0 ≤ projectiveSeminormAux p := by
-  simp only [projectiveSeminormAux]
-  refine List.sum_nonneg ?_
-  intro a
-  simp only [List.mem_map, Prod.exists, forall_exists_index,
-    and_imp]
+  refine List.sum_nonneg fun a ↦ ?_
+  simp only [List.mem_map, Prod.exists, forall_exists_index, and_imp]
   intro x m _ h
-  rw [← h]
-  exact mul_nonneg (norm_nonneg _) (Finset.prod_nonneg (fun _ _ ↦ norm_nonneg _))
+  simpa [← h] using by positivity
 
 theorem projectiveSeminormAux_add_le (p q : FreeAddMonoid (𝕜 × Π i, E i)) :
     projectiveSeminormAux (p + q) ≤ projectiveSeminormAux p + projectiveSeminormAux q := by
@@ -78,66 +77,61 @@ theorem projectiveSeminormAux_smul (p : FreeAddMonoid (𝕜 × Π i, E i)) (a : 
 variable [∀ i, NormedSpace 𝕜 (E i)]
 
 theorem bddBelow_projectiveSemiNormAux (x : ⨂[𝕜] i, E i) :
-    BddBelow (Set.range (fun (p : lifts x) ↦ projectiveSeminormAux p.1)) := by
-  existsi 0
-  rw [mem_lowerBounds]
-  simp only [Set.mem_range, Subtype.exists, exists_prop, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂]
-  exact fun p _ ↦ projectiveSeminormAux_nonneg p
+    BddBelow (Set.range (fun (p : lifts x) ↦ projectiveSeminormAux p.1)) :=
+  ⟨0, by simp [mem_lowerBounds, projectiveSeminormAux_nonneg]⟩
+
+noncomputable def projectiveSeminormFun : (⨂[𝕜] i, E i) → ℝ :=
+  fun x ↦ iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.val)
+
+theorem projectiveSeminorm_zero : projectiveSeminormFun (0 : ⨂[𝕜] i, E i) = 0 :=
+  le_antisymm (ciInf_le (bddBelow_projectiveSemiNormAux _) ⟨0, lifts_zero⟩)
+    (le_ciInf (fun p ↦ projectiveSeminormAux_nonneg p.val))
+
+theorem projectiveSeminorm_add_le (x y : ⨂[𝕜] i, E i) :
+  projectiveSeminormFun (x+y) ≤ projectiveSeminormFun x + projectiveSeminormFun y :=
+  le_ciInf_add_ciInf (fun p q ↦ ciInf_le_of_le (bddBelow_projectiveSemiNormAux _)
+    ⟨p.1 + q.1, lifts_add p.2 q.2⟩ (projectiveSeminormAux_add_le p.1 q.1))
+
+theorem projectiveSeminorm_smul_le (a : 𝕜) (x : ⨂[𝕜] i, E i) :
+  projectiveSeminormFun (a • x) ≤ ‖a‖ * projectiveSeminormFun x := by
+  simp only [projectiveSeminormFun, Real.mul_iInf_of_nonneg (norm_nonneg _)]
+  refine le_ciInf fun p ↦ ?_
+  simpa [projectiveSeminormAux_smul] using
+    ciInf_le_of_le (bddBelow_projectiveSemiNormAux _) ⟨_, lifts_smul p.2 a⟩ (le_refl _)
 
 /-- The projective seminorm on `⨂[𝕜] i, Eᵢ`. It sends an element `x` of `⨂[𝕜] i, Eᵢ` to the
 infimum over all expressions of `x` as `∑ j, ⨂ₜ[𝕜] mⱼ i` (with the `mⱼ` ∈ `Π i, Eᵢ`)
-of `∑ j, Π i, ‖mⱼ i‖`.
--/
-noncomputable def projectiveSeminorm : Seminorm 𝕜 (⨂[𝕜] i, E i) := by
-  refine Seminorm.ofSMulLE (fun x ↦ iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.1)) ?_ ?_ ?_
-  · refine le_antisymm ?_ ?_
-    · refine ciInf_le_of_le (bddBelow_projectiveSemiNormAux (0 : ⨂[𝕜] i, E i)) ⟨0, lifts_zero⟩ ?_
-      rfl
-    · letI : Nonempty (lifts 0) := ⟨0, lifts_zero (R := 𝕜) (s := E)⟩
-      exact le_ciInf (fun p ↦ projectiveSeminormAux_nonneg p.1)
-  · intro x y
-    letI := nonempty_subtype.mpr (nonempty_lifts x); letI := nonempty_subtype.mpr (nonempty_lifts y)
-    exact le_ciInf_add_ciInf (fun p q ↦ ciInf_le_of_le (bddBelow_projectiveSemiNormAux _)
-      ⟨p.1 + q.1, lifts_add p.2 q.2⟩ (projectiveSeminormAux_add_le p.1 q.1))
-  · intro a x
-    letI := nonempty_subtype.mpr (nonempty_lifts x)
-    rw [Real.mul_iInf_of_nonneg (norm_nonneg _)]
-    refine le_ciInf ?_
-    intro p
-    rw [← projectiveSeminormAux_smul]
-    exact ciInf_le_of_le (bddBelow_projectiveSemiNormAux _)
-      ⟨(p.1.map (fun y ↦ (a * y.1, y.2))), lifts_smul p.2 a⟩ (le_refl _)
+of `∑ j, Π i, ‖mⱼ i‖`. -/
+noncomputable def projectiveSeminorm : Seminorm 𝕜 (⨂[𝕜] i, E i) := .ofSMulLE
+    _ projectiveSeminorm_zero projectiveSeminorm_add_le projectiveSeminorm_smul_le
 
 theorem projectiveSeminorm_apply (x : ⨂[𝕜] i, E i) :
     projectiveSeminorm x = iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.1) := rfl
 
 theorem projectiveSeminorm_tprod_le (m : Π i, E i) :
     projectiveSeminorm (⨂ₜ[𝕜] i, m i) ≤ ∏ i, ‖m i‖ := by
-  rw [projectiveSeminorm_apply]
   convert ciInf_le (bddBelow_projectiveSemiNormAux _) ⟨FreeAddMonoid.of ((1 : 𝕜), m), ?_⟩
   · simp [projectiveSeminormAux]
-  · rw [mem_lifts_iff, FreeAddMonoid.toList_of, List.map_singleton, List.sum_singleton, one_smul]
+  · simp [mem_lifts_iff]
+
+end NormedField
+
+section NontriviallyNormedField
+
+variable [NontriviallyNormedField 𝕜] [∀ i, NormedSpace 𝕜 (E i)]
 
 theorem norm_eval_le_projectiveSeminorm (x : ⨂[𝕜] i, E i) (G : Type*) [SeminormedAddCommGroup G]
     [NormedSpace 𝕜 G] (f : ContinuousMultilinearMap 𝕜 E G) :
     ‖lift f.toMultilinearMap x‖ ≤ projectiveSeminorm x * ‖f‖ := by
-  letI := nonempty_subtype.mpr (nonempty_lifts x)
   rw [projectiveSeminorm_apply, Real.iInf_mul_of_nonneg (norm_nonneg _)]
-  unfold projectiveSeminormAux
-  refine le_ciInf ?_
-  intro ⟨p, hp⟩
-  rw [mem_lifts_iff] at hp
-  conv_lhs => rw [← hp, ← List.sum_map_hom, ← Multiset.sum_coe]
-  refine le_trans (norm_multiset_sum_le _) ?_
-  simp only [Multiset.map_coe, List.map_map, Multiset.sum_coe]
-  rw [mul_comm, ← smul_eq_mul, List.smul_sum]
+  refine le_ciInf fun ⟨p, hp⟩ ↦ ?_
+  rw! [← ((mem_lifts_iff x p).mp hp), ← List.sum_map_hom, ← Multiset.sum_coe]
+  grw [norm_multiset_sum_le]
+  simp only [mul_comm, ← smul_eq_mul, List.smul_sum, projectiveSeminormAux]
   refine List.Forall₂.sum_le_sum ?_
-  simp only [smul_eq_mul, List.map_map, List.forall₂_map_right_iff, Function.comp_apply,
-    List.forall₂_map_left_iff, map_smul, lift.tprod, ContinuousMultilinearMap.coe_coe,
-    List.forall₂_same, Prod.forall]
-  intro a m _
-  rw [norm_smul, ← mul_assoc, mul_comm ‖f‖ _, mul_assoc]
-  exact mul_le_mul_of_nonneg_left (f.le_opNorm _) (norm_nonneg _)
+  simpa [norm_smul, ← mul_assoc, mul_comm ‖f‖ _] using
+    fun a m _ ↦ mul_le_mul_of_nonneg_left (f.le_opNorm _) (norm_nonneg _)
+
+end NontriviallyNormedField
 
 end PiTensorProduct

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
@@ -51,7 +51,7 @@ namespace PiTensorProduct
 
 section NormedField
 
-variable [NontriviallyNormedField 𝕜]
+variable [NormedField 𝕜]
 
 /-- A lift of the projective seminorm to `FreeAddMonoid (𝕜 × Π i, Eᵢ)`, useful to prove the
 properties of `projectiveSeminorm`. -/

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
@@ -80,6 +80,11 @@ theorem bddBelow_projectiveSemiNormAux (x : ⨂[𝕜] i, E i) :
     BddBelow (Set.range (fun (p : lifts x) ↦ projectiveSeminormAux p.1)) :=
   ⟨0, by simp [mem_lowerBounds, projectiveSeminormAux_nonneg]⟩
 
+-- This definition will be replaced by a `Norm` instance in a follow-up PR.
+/-- The projective seminorm on `⨂[𝕜] i, Eᵢ`. It sends an element `x` of `⨂[𝕜] i, Eᵢ` to the
+infimum over all expressions of `x` as `∑ j, ⨂ₜ[𝕜] mⱼ i` (with the `mⱼ` ∈ `Π i, Eᵢ`)
+of `∑ j, Π i, ‖mⱼ i‖`. See `PiTensorProduct.projectiveSeminorm` for a version bundled as a
+`Seminorm`. -/
 noncomputable def projectiveSeminormFun : (⨂[𝕜] i, E i) → ℝ :=
   fun x ↦ iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.val)
 

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -326,6 +326,8 @@ lemma nonempty_lifts (x : ⨂[R] i, s i) : Set.Nonempty (lifts x) := by
   existsi Quot.out x
   simp [lifts, ← AddCon.quot_mk_eq_coe]
 
+instance (x : ⨂[R] i, s i) : Nonempty ↑x.lifts := nonempty_subtype.mpr (nonempty_lifts x)
+
 /-- The empty list lifts the element `0` of `⨂[R] i, s i`.
 -/
 lemma lifts_zero : 0 ∈ lifts (0 : ⨂[R] i, s i) := by


### PR DESCRIPTION
This PR cleans up the proofs in

Analysis/Normed/Module/PiTensorProduct/{InjectiveSeminorm.lean, ProjectiveSeminorm.lean}

In addition, it performs the following minor structural changes:
* Weaken assumptions from `NontriviallyNormedField 𝕜` to `NormedField 𝕜` where possible
* The proofs showing that `projectiveSeminorm` actually defines a `Seminorm` are split off into separate lemmas. This mimics the idiom used e.g. in `Analysis.Normed.Modula.Operator.Basic` to define the operator norm. 
* Register a `Nonempty x.lifts` instance in PiTensorProduct.lean, to avoid creating a half-dozen local instances.

This is the first in a series of three PRs with the goal to [deprecate `PiTensorProuduct.injectiveSeminorm`](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/injectiveSeminorm/with/568798633). 

---

Co-authored-by: Davood H. T. Tehrani

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
