### PR TITLE
fix: writer monad should use an additive logging type

### DIFF
--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -189,20 +189,20 @@ instance [MonadCont m] [LawfulMonadCont m] : LawfulMonadCont (OptionT m) where
 def WriterT.mkLabel {α β ω} [EmptyCollection ω] : Label (α × ω) m β → Label α (WriterT ω m) β
   | ⟨f⟩ => ⟨fun a => monadLift <| f (a, ∅)⟩
 
-def WriterT.mkLabel' {α β ω} [Monoid ω] : Label (α × ω) m β → Label α (WriterT ω m) β
-  | ⟨f⟩ => ⟨fun a => monadLift <| f (a, 1)⟩
+def WriterT.mkLabel' {α β ω} [AddMonoid ω] : Label (α × ω) m β → Label α (WriterT ω m) β
+  | ⟨f⟩ => ⟨fun a => monadLift <| f (a, 0)⟩
 
 theorem WriterT.goto_mkLabel {α β ω : Type _} [EmptyCollection ω] (x : Label (α × ω) m β) (i : α) :
     goto (WriterT.mkLabel x) i = monadLift (goto x (i, ∅)) := by cases x; rfl
 
-theorem WriterT.goto_mkLabel' {α β ω : Type _} [Monoid ω] (x : Label (α × ω) m β) (i : α) :
-    goto (WriterT.mkLabel' x) i = monadLift (goto x (i, 1)) := by cases x; rfl
+theorem WriterT.goto_mkLabel' {α β ω : Type _} [AddMonoid ω] (x : Label (α × ω) m β) (i : α) :
+    goto (WriterT.mkLabel' x) i = monadLift (goto x (i, 0)) := by cases x; rfl
 
 nonrec def WriterT.callCC [MonadCont m] {α β ω : Type _} [EmptyCollection ω]
     (f : Label α (WriterT ω m) β → WriterT ω m α) : WriterT ω m α :=
   WriterT.mk <| callCC (WriterT.run ∘ f ∘ WriterT.mkLabel : Label (α × ω) m β → m (α × ω))
 
-def WriterT.callCC' [MonadCont m] {α β ω : Type _} [Monoid ω]
+def WriterT.callCC' [MonadCont m] {α β ω : Type _} [AddMonoid ω]
     (f : Label α (WriterT ω m) β → WriterT ω m α) : WriterT ω m α :=
   WriterT.mk <|
     MonadCont.callCC (WriterT.run ∘ f ∘ WriterT.mkLabel' : Label (α × ω) m β → m (α × ω))
@@ -212,7 +212,7 @@ end
 instance (ω) [Monad m] [EmptyCollection ω] [MonadCont m] : MonadCont (WriterT ω m) where
   callCC := WriterT.callCC
 
-instance (ω) [Monad m] [Monoid ω] [MonadCont m] : MonadCont (WriterT ω m) where
+instance (ω) [Monad m] [AddMonoid ω] [MonadCont m] : MonadCont (WriterT ω m) where
   callCC := WriterT.callCC'
 
 def StateT.mkLabel {α β σ : Type u} : Label (α × σ) m (β × σ) → Label α (StateT σ m) β

--- a/Mathlib/Control/Monad/Writer.lean
+++ b/Mathlib/Control/Monad/Writer.lean
@@ -94,15 +94,15 @@ protected def liftTell (empty : ω) : MonadLift M (WriterT ω M) where
 
 instance [EmptyCollection ω] [Append ω] : Monad (WriterT ω M) := monad ∅ (· ++ ·)
 instance [EmptyCollection ω] : MonadLift M (WriterT ω M) := WriterT.liftTell ∅
-instance [Monoid ω] : Monad (WriterT ω M) := monad 1 (· * ·)
-instance [Monoid ω] : MonadLift M (WriterT ω M) := WriterT.liftTell 1
+instance [AddMonoid ω] : Monad (WriterT ω M) := monad 0 (· + ·)
+instance [AddMonoid ω] : MonadLift M (WriterT ω M) := WriterT.liftTell 0
 
-instance [Monoid ω] [LawfulMonad M] : LawfulMonad (WriterT ω M) := LawfulMonad.mk'
+instance [AddMonoid ω] [LawfulMonad M] : LawfulMonad (WriterT ω M) := LawfulMonad.mk'
   (bind_pure_comp := by
     simp [Bind.bind, Functor.map, Pure.pure, WriterT.mk, bind_pure_comp])
   (id_map := by simp [Functor.map, WriterT.mk])
   (pure_bind := by simp [Bind.bind, Pure.pure, WriterT.mk])
-  (bind_assoc := by simp [Bind.bind, mul_assoc, WriterT.mk, ← bind_pure_comp])
+  (bind_assoc := by simp [Bind.bind, add_assoc, WriterT.mk, ← bind_pure_comp])
 
 instance : MonadWriter ω (WriterT ω M) where
   tell := fun w ↦ WriterT.mk <| pure (⟨⟩, w)


### PR DESCRIPTION
The Writer monad's w type is supposed to be additive, not multiplicative. This is how it is conceptually used in Haskell (as a logging type). Haskell uses `Monoid` because it doesn't make a distinction between `AddMonoid` and `Monoid`.

[#mathlib4 > Writer should use an additive monoid @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Writer.20should.20use.20an.20additive.20monoid/near/574990415)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
