### PR TITLE
chore(Util/Qq): remove `meta`

### DIFF
--- a/Mathlib/Data/Multiset/Sort.lean
+++ b/Mathlib/Data/Multiset/Sort.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Data.List.Sort
 public import Mathlib.Data.Multiset.Range
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 public meta import Mathlib.Data.Multiset.Defs
 
 /-!

--- a/Mathlib/Tactic/FieldSimp/Lemmas.lean
+++ b/Mathlib/Tactic/FieldSimp/Lemmas.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.BigOperators.Group.List.Basic
 public import Mathlib.Algebra.Field.Power  -- shake: keep (Qq dependency)
 public import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 
 /-! # Lemmas for the field_simp tactic
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -8,7 +8,7 @@ module
 public meta import Mathlib.Lean.Expr.Rat
 public import Mathlib.Tactic.Hint
 public import Mathlib.Tactic.NormNum.Result
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 
 /-!
 ## `norm_num` core functionality

--- a/Mathlib/Tactic/Order/ToInt.lean
+++ b/Mathlib/Tactic/Order/ToInt.lean
@@ -9,7 +9,7 @@ public import Batteries.Data.List
 public import Batteries.Tactic.GeneralizeProofs
 public import Mathlib.Tactic.Order.CollectFacts
 public meta import Mathlib.Util.AtomM
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 
 /-!
 # Translating linear orders to ℤ

--- a/Mathlib/Tactic/Simproc/Divisors.lean
+++ b/Mathlib/Tactic/Simproc/Divisors.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.NumberTheory.Divisors
 public meta import Mathlib.Tactic.ToAdditive
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 
 /-! # Divisor Simprocs
 

--- a/Mathlib/Tactic/Simproc/FinsetInterval.lean
+++ b/Mathlib/Tactic/Simproc/FinsetInterval.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.Int.Interval
 public import Mathlib.Data.Int.SuccPred
 public import Mathlib.Order.Interval.Finset.Nat
 public meta import Mathlib.Tactic.ToAdditive
-public import Mathlib.Util.Qq
+public meta import Mathlib.Util.Qq
 
 /-!
 # Simproc for intervals of natural numbers

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -15,7 +15,7 @@ public import Qq.Typ
 This file contains some additional functions for using the quote4 library more conveniently.
 -/
 
-public meta section
+public section
 
 open Lean Elab Tactic Meta
 


### PR DESCRIPTION
These are wrappers of existing functions on `Expr`s which are also not marked `meta`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
