### PR TITLE
[Merged by Bors] - feat: `SeparatelyContinuousMul` class for multiplication which is continuous in each variable

### DIFF
--- a/Mathlib/Analysis/Calculus/Rademacher.lean
+++ b/Mathlib/Analysis/Calculus/Rademacher.lean
@@ -193,11 +193,11 @@ theorem integral_lineDeriv_mul_eq
   simp_rw [_root_.sub_mul, _root_.mul_sub]
   rw [integral_sub, integral_sub, S3]
   · apply Continuous.integrable_of_hasCompactSupport
-    · exact hf.continuous.mul (hg.continuous.comp (continuous_add_right _))
+    · exact hf.continuous.mul (hg.continuous.comp (continuous_add_const _))
     · exact (h'g.comp_homeomorph (Homeomorph.addRight (t • (-v)))).mul_left
   · exact (hf.continuous.mul hg.continuous).integrable_of_hasCompactSupport h'g.mul_left
   · apply Continuous.integrable_of_hasCompactSupport
-    · exact (hf.continuous.comp (continuous_add_right _)).mul hg.continuous
+    · exact (hf.continuous.comp (continuous_add_const _)).mul hg.continuous
     · exact h'g.mul_left
   · exact (hf.continuous.mul hg.continuous).integrable_of_hasCompactSupport h'g.mul_left
 

--- a/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
@@ -68,7 +68,7 @@ theorem tangentConeAt_mono_nhds (h : 𝓝[s] x ≤ 𝓝[t] x) :
   suffices Tendsto (x + ·) (𝓝[(x + ·) ⁻¹' s] 0) (𝓝[s] x) from
     this.mono_right h |> tendsto_nhdsWithin_iff.mp |>.2
   refine .inf ?_ (mapsTo_preimage _ _).tendsto
-  exact (continuous_add_left x).tendsto' 0 x (add_zero _)
+  exact (continuous_const_add x).tendsto' 0 x (add_zero _)
 
 /-- Tangent cone of `s` at `x` depends only on `𝓝[s] x`. -/
 theorem tangentConeAt_congr (h : 𝓝[s] x = 𝓝[t] x) : tangentConeAt 𝕜 s x = tangentConeAt 𝕜 t x :=

--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -211,7 +211,7 @@ theorem fourierChar_apply' (x : ℝ) : 𝐞 x = Circle.exp (2 * π * x) := rfl
 theorem fourierChar_apply (x : ℝ) : 𝐞 x = Complex.exp (↑(2 * π * x) * Complex.I) := rfl
 
 @[continuity, fun_prop]
-theorem continuous_fourierChar : Continuous 𝐞 := Circle.exp.continuous.comp (continuous_mul_left _)
+theorem continuous_fourierChar : Continuous 𝐞 := Circle.exp.continuous.comp (continuous_const_mul _)
 
 theorem fourierChar_ne_one : fourierChar ≠ 1 := by
   rw [DFunLike.ne_iff]

--- a/Mathlib/Analysis/Complex/HasPrimitives.lean
+++ b/Mathlib/Analysis/Complex/HasPrimitives.lean
@@ -203,7 +203,7 @@ private lemma hasDerivAt_wedgeIntegral_re_aux :
   let s : Set ℝ := Ioo (z.re - r₁) (z.re + r₁)
   have zRe_mem_s : z.re ∈ s := by simp [s, r₁_pos]
   have f_contOn : ContinuousOn (fun (x : ℝ) ↦ f (x + z.im * I)) s :=
-    f_cont.comp ((continuous_add_right _).comp continuous_ofReal).continuousOn <|
+    f_cont.comp ((continuous_add_const _).comp continuous_ofReal).continuousOn <|
       fun _ ↦ mem_ball_re_aux
   have int1 : IntervalIntegrable (fun (x : ℝ) ↦ f (x + z.im * I)) volume z.re z.re :=
     ContinuousOn.intervalIntegrable <| f_contOn.mono <| by simpa

--- a/Mathlib/Analysis/Convex/Strict.lean
+++ b/Mathlib/Analysis/Convex/Strict.lean
@@ -195,7 +195,7 @@ variable [AddCancelCommMonoid E] [ContinuousAdd E] [Module 𝕜 E] {s : Set E}
 theorem StrictConvex.preimage_add_right (hs : StrictConvex 𝕜 s) (z : E) :
     StrictConvex 𝕜 ((fun x => z + x) ⁻¹' s) := by
   intro x hx y hy hxy a b ha hb hab
-  refine preimage_interior_subset_interior_preimage (continuous_add_left _) ?_
+  refine preimage_interior_subset_interior_preimage (continuous_const_add _) ?_
   have h := hs hx hy ((add_right_injective _).ne hxy) ha hb hab
   rwa [smul_add, smul_add, add_add_add_comm, ← _root_.add_smul, hab, one_smul] at h
 

--- a/Mathlib/Analysis/InnerProductSpace/Completion.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Completion.lean
@@ -100,7 +100,7 @@ instance innerProductSpace : InnerProductSpace 𝕜 (Completion E) where
   smul_left x y c :=
     Completion.induction_on₂ x y
       (isClosed_eq (Continuous.inner (continuous_fst.const_smul c) continuous_snd)
-        ((continuous_mul_left _).comp (by fun_prop)))
+        ((continuous_const_mul _).comp (by fun_prop)))
       fun a b => by simp only [← coe_smul c a, inner_coe, inner_smul_left]
 
 end UniformSpace.Completion

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -317,7 +317,7 @@ lemma NormedField.completeSpace_iff_isComplete_closedBall {K : Type*} [NormedFie
     rw [div_le_one (kpos.trans_lt hx)]
     exact hx.le.trans' (hk (by simp))
   obtain ⟨a, -, ha'⟩ := cauchySeq_tendsto_of_isComplete h hb hu'
-  refine ⟨a * x, (((continuous_mul_right x).tendsto a).comp ha').congr ?_⟩
+  refine ⟨a * x, (((continuous_mul_const x).tendsto a).comp ha').congr ?_⟩
   have hx' : x ≠ 0 := by
     contrapose! hx
     simp [hx, kpos]

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -327,7 +327,7 @@ lemma not_continuousAt_weierstrassP (x : ℂ) (hx : x ∈ L.lattice) : ¬ Contin
     (((H.sub ((L.differentiableOn_weierstrassPExcept x).differentiableAt
       (L.compl_lattice_diff_singleton_mem_nhds x)).continuousAt).add
       (continuous_const (y := 1 / x ^ 2)).continuousAt).comp_of_eq
-      (continuous_const_addd x).continuousAt (add_zero _) :)
+      (continuous_const_add x).continuousAt (add_zero _) :)
 
 end weierstrassP
 

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -327,7 +327,7 @@ lemma not_continuousAt_weierstrassP (x : ℂ) (hx : x ∈ L.lattice) : ¬ Contin
     (((H.sub ((L.differentiableOn_weierstrassPExcept x).differentiableAt
       (L.compl_lattice_diff_singleton_mem_nhds x)).continuousAt).add
       (continuous_const (y := 1 / x ^ 2)).continuousAt).comp_of_eq
-      (continuous_add_left x).continuousAt (add_zero _) :)
+      (continuous_const_addd x).continuousAt (add_zero _) :)
 
 end weierstrassP
 

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -679,7 +679,7 @@ lemma summable_weierstrassPExceptSummand (l₀ z x : ℂ)
   -- We first find a `κ > 1`,
   -- such that the ball centered at `x` with radius `κ * ‖z - x‖` does not touch `L`.
   obtain ⟨κ, hκ, hκ'⟩ : ∃ κ : ℝ, 1 < κ ∧ ∀ l : L.lattice, l.1 ≠ l₀ → ‖z - x‖ * κ < ‖l - x‖ := by
-    obtain ⟨κ, hκ, hκ'⟩ := Metric.isOpen_iff.mp ((continuous_mul_right ‖z - x‖).isOpen_preimage _
+    obtain ⟨κ, hκ, hκ'⟩ := Metric.isOpen_iff.mp ((continuous_mul_const ‖z - x‖).isOpen_preimage _
       (isClosedMap_dist x _
       (L.isClosed_of_subset_lattice (Set.diff_subset (t := {l₀})))).upperClosure.isOpen_compl) 1
       (by simpa [Complex.dist_eq, @forall_comm ℝ, norm_sub_rev x] using hx)

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
@@ -113,7 +113,7 @@ theorem continuousAt_Gamma_one : ContinuousAt Gamma 1 :=
 theorem tendsto_self_mul_Gamma_nhds_zero : Tendsto (fun z : ℂ => z * Gamma z) (𝓝[≠] 0) (𝓝 1) := by
   rw [show 𝓝 (1 : ℂ) = 𝓝 (Gamma (0 + 1)) by simp only [zero_add, Complex.Gamma_one]]
   refine tendsto_nhdsWithin_congr Gamma_add_one (continuousAt_iff_punctured_nhds.mp ?_)
-  exact ContinuousAt.comp' (by simp [continuousAt_Gamma_one]) (continuous_add_right 1).continuousAt
+  exact ContinuousAt.comp' (by simp [continuousAt_Gamma_one]) (continuous_add_const 1).continuousAt
 
 theorem not_continuousAt_Gamma_zero : ¬ ContinuousAt Gamma 0 :=
   tendsto_self_mul_Gamma_nhds_zero.not_tendsto (by simp) ∘

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -108,7 +108,7 @@ lemma IsMIntegralCurveOn.comp_mul (hγ : IsMIntegralCurveOn γ v s) (a : ℝ) :
   rw [comp_apply, Pi.smul_apply, ← ContinuousLinearMap.one_apply (R₁ := ℝ) a,
     ← ContinuousLinearMap.smulRight_comp_smulRight]
   refine HasMFDerivWithinAt.comp t (hγ (t * a) ht)
-    ⟨(continuous_mul_right _).continuousWithinAt, ?_⟩ subset_rfl
+    ⟨(continuous_mul_const _).continuousWithinAt, ?_⟩ subset_rfl
   simp only [mfld_simps]
   exact HasFDerivWithinAt.mul_const' (hasFDerivWithinAt_id _ _) _
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -43,7 +43,7 @@ lemma IsMIntegralCurveOn.comp_add (hγ : IsMIntegralCurveOn γ v s) (dt : ℝ) :
   intro t ht
   rw [comp_apply, ← ContinuousLinearMap.comp_id (ContinuousLinearMap.smulRight 1 (v (γ (t + dt))))]
   apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ subset_rfl
-  refine ⟨(continuous_add_right _).continuousWithinAt, ?_⟩
+  refine ⟨(continuous_add_const _).continuousWithinAt, ?_⟩
   simp only [mfld_simps]
   exact (hasFDerivWithinAt_id _ _).add_const _
 

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -523,13 +523,13 @@ instance innerRegular_map_smul {α} [Monoid α] [MulAction α G] [ContinuousCons
 @[to_additive
 /-- The image of an inner regular measure under left addition is again inner regular. -/]
 instance innerRegular_map_mul_left [IsTopologicalGroup G] [InnerRegular μ] (g : G) :
-    InnerRegular (Measure.map (g * ·) μ) := InnerRegular.map_of_continuous (continuous_mul_left g)
+    InnerRegular (Measure.map (g * ·) μ) := InnerRegular.map_of_continuous (continuous_const_mul g)
 
 /-- The image of an inner regular measure under right multiplication is again inner regular. -/
 @[to_additive
 /-- The image of an inner regular measure under right addition is again inner regular. -/]
 instance innerRegular_map_mul_right [IsTopologicalGroup G] [InnerRegular μ] (g : G) :
-    InnerRegular (Measure.map (· * g) μ) := InnerRegular.map_of_continuous (continuous_mul_right g)
+    InnerRegular (Measure.map (· * g) μ) := InnerRegular.map_of_continuous (continuous_mul_const g)
 
 variable [IsTopologicalGroup G]
 

--- a/Mathlib/MeasureTheory/Group/ModularCharacter.lean
+++ b/Mathlib/MeasureTheory/Group/ModularCharacter.lean
@@ -64,7 +64,7 @@ lemma modularCharacterFun_eq_haarScalarFactor [MeasurableSpace G] [BorelSpace G]
   apply NNReal.coe_injective
   have t : (∫ x, f (x * g) ∂ν) = (∫ x, f (x * g) ∂(haarScalarFactor ν μ • μ)) := by
     refine integral_isMulLeftInvariant_eq_smul_of_hasCompactSupport ν μ ?_ ?_
-    · exact Continuous.comp' f_cont (continuous_mul_right g)
+    · exact Continuous.comp' f_cont (continuous_mul_const g)
     · have j : (fun x ↦ f (x * g)) = (f ∘ (Homeomorph.mulRight g)) := rfl
       rw [j]
       exact HasCompactSupport.comp_homeomorph f_comp _

--- a/Mathlib/MeasureTheory/Measure/Content.lean
+++ b/Mathlib/MeasureTheory/Measure/Content.lean
@@ -203,14 +203,14 @@ theorem innerContent_comap (f : G ≃ₜ G) (h : ∀ ⦃K : Compacts G⦄, μ (K
 
 @[to_additive]
 theorem is_mul_left_invariant_innerContent [Group G] [ContinuousMul G]
-    (h : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_mul_left g) = μ K) (g : G)
+    (h : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_const_mul g) = μ K) (g : G)
     (U : Opens G) :
     μ.innerContent (Opens.comap (Homeomorph.mulLeft g) U) = μ.innerContent U := by
   convert μ.innerContent_comap (Homeomorph.mulLeft g) (fun K => h g) U
 
 @[to_additive]
 theorem innerContent_pos_of_is_mul_left_invariant [Group G] [IsTopologicalGroup G]
-    (h3 : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_mul_left g) = μ K) (K : Compacts G)
+    (h3 : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_const_mul g) = μ K) (K : Compacts G)
     (hK : μ K ≠ 0) (U : Opens G) (hU : (U : Set G).Nonempty) : 0 < μ.innerContent U := by
   have : (interior (U : Set G)).Nonempty := by rwa [U.isOpen.interior_eq]
   rcases compact_covered_by_mul_left_translates K.2 this with ⟨s, hs⟩
@@ -292,7 +292,7 @@ theorem outerMeasure_lt_top_of_isCompact [WeaklyLocallyCompactSpace G]
 
 @[to_additive]
 theorem is_mul_left_invariant_outerMeasure [Group G] [ContinuousMul G]
-    (h : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_mul_left g) = μ K) (g : G)
+    (h : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_const_mul g) = μ K) (g : G)
     (A : Set G) : μ.outerMeasure ((g * ·) ⁻¹' A) = μ.outerMeasure A := by
   convert μ.outerMeasure_preimage (Homeomorph.mulLeft g) (fun K => h g) A
 
@@ -306,7 +306,7 @@ theorem outerMeasure_caratheodory (A : Set G) :
 
 @[to_additive]
 theorem outerMeasure_pos_of_is_mul_left_invariant [Group G] [IsTopologicalGroup G]
-    (h3 : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_mul_left g) = μ K) (K : Compacts G)
+    (h3 : ∀ (g : G) {K : Compacts G}, μ (K.map _ <| continuous_const_mul g) = μ K) (K : Compacts G)
     (hK : μ K ≠ 0) {U : Set G} (h1U : IsOpen U) (h2U : U.Nonempty) : 0 < μ.outerMeasure U := by
   convert μ.innerContent_pos_of_is_mul_left_invariant h3 K hK ⟨U, h1U⟩ h2U
   exact μ.outerMeasure_opens ⟨U, h1U⟩

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -252,7 +252,7 @@ theorem mul_left_index_le {K : Set G} (hK : IsCompact K) {V : Set G} (hV : (inte
 theorem is_left_invariant_index {K : Set G} (hK : IsCompact K) (g : G) {V : Set G}
     (hV : (interior V).Nonempty) : index ((fun h => g * h) '' K) V = index K V := by
   refine le_antisymm (mul_left_index_le hK hV g) ?_
-  convert mul_left_index_le (hK.image <| continuous_mul_left g) hV g⁻¹
+  convert mul_left_index_le (hK.image <| continuous_const_mul g) hV g⁻¹
   rw [image_image]; symm; convert image_id' _ with h; apply inv_mul_cancel_left
 
 /-!
@@ -307,7 +307,7 @@ theorem prehaar_sup_eq {K₀ : PositiveCompacts G} {U : Set G} {K₁ K₂ : Comp
 @[to_additive]
 theorem is_left_invariant_prehaar {K₀ : PositiveCompacts G} {U : Set G} (hU : (interior U).Nonempty)
     (g : G) (K : Compacts G) :
-    prehaar (K₀ : Set G) U (K.map _ <| continuous_mul_left g) = prehaar (K₀ : Set G) U K := by
+    prehaar (K₀ : Set G) U (K.map _ <| continuous_const_mul g) = prehaar (K₀ : Set G) U K := by
   simp only [prehaar, Compacts.coe_map, is_left_invariant_index K.isCompact _ hU]
 
 /-!
@@ -447,8 +447,8 @@ theorem chaar_sup_eq {K₀ : PositiveCompacts G}
 
 @[to_additive is_left_invariant_addCHaar]
 theorem is_left_invariant_chaar {K₀ : PositiveCompacts G} (g : G) (K : Compacts G) :
-    chaar K₀ (K.map _ <| continuous_mul_left g) = chaar K₀ K := by
-  let eval : (Compacts G → ℝ) → ℝ := fun f => f (K.map _ <| continuous_mul_left g) - f K
+    chaar K₀ (K.map _ <| continuous_const_mul g) = chaar K₀ K := by
+  let eval : (Compacts G → ℝ) → ℝ := fun f => f (K.map _ <| continuous_const_mul g) - f K
   have : Continuous eval := (continuous_apply (K.map _ _)).sub (continuous_apply K)
   rw [← sub_eq_zero]; change chaar K₀ ∈ eval ⁻¹' {(0 : ℝ)}
   apply mem_of_subset_of_mem _ (chaar_mem_clPrehaar K₀ ⊤)
@@ -484,7 +484,7 @@ theorem haarContent_self {K₀ : PositiveCompacts G} : haarContent K₀ K₀.toC
 /-- The variant of `is_left_invariant_chaar` for `haarContent` -/
 @[to_additive /-- The variant of `is_left_invariant_addCHaar` for `addHaarContent` -/]
 theorem is_left_invariant_haarContent {K₀ : PositiveCompacts G} (g : G) (K : Compacts G) :
-    haarContent K₀ (K.map _ <| continuous_mul_left g) = haarContent K₀ K := by
+    haarContent K₀ (K.map _ <| continuous_const_mul g) = haarContent K₀ K := by
   simpa only [ENNReal.coe_inj, ← NNReal.coe_inj, haarContent_apply] using
     is_left_invariant_chaar g K
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -835,7 +835,7 @@ theorem tendsto_addHaar_inter_smul_one_of_density_one (s : Set E) (x : E)
   congr 1
   apply measure_toMeasurable_inter_of_sFinite
   simp only [image_add_left, singleton_add]
-  apply (continuous_add_left (-x)).measurable (ht.const_smul₀ r)
+  apply (continuous_const_addd (-x)).measurable (ht.const_smul₀ r)
 
 /-- Consider a point `x` at which a set `s` has density one, with respect to closed balls (i.e.,
 a Lebesgue density point of `s`). Then `s` intersects the rescaled copies `{x} + r • t` of a given

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -835,7 +835,7 @@ theorem tendsto_addHaar_inter_smul_one_of_density_one (s : Set E) (x : E)
   congr 1
   apply measure_toMeasurable_inter_of_sFinite
   simp only [image_add_left, singleton_add]
-  apply (continuous_const_addd (-x)).measurable (ht.const_smul₀ r)
+  apply (continuous_const_add (-x)).measurable (ht.const_smul₀ r)
 
 /-- Consider a point `x` at which a set `s` has density one, with respect to closed balls (i.e.,
 a Lebesgue density point of `s`). Then `s` intersects the rescaled copies `{x} + r • t` of a given

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -145,7 +145,7 @@ instance : Algebra ℚ_[p] ℂ_[p] where
   algebraMap := (UniformSpace.Completion.coeRingHom).comp (algebraMap ℚ_[p] (PadicAlgCl p))
   commutes' r x := by rw [mul_comm]
   smul_def' r x := by
-    apply UniformSpace.Completion.ext' (continuous_const_smul r) (continuous_mul_left _)
+    apply UniformSpace.Completion.ext' (continuous_const_smul r) (continuous_const_mul _)
     intro a
     rw [RingHom.coe_comp, Function.comp_apply, Algebra.smul_def]
     rfl

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -164,8 +164,8 @@ lemma lintegral_exponentialPDF_eq_antiDeriv {r : ℝ} (hr : 0 < r) (x : ℝ) :
       · simp only [intervalIntegrable_iff, uIoc_of_le h]
         exact Integrable.const_mul (exp_neg_integrableOn_Ioc hr) _
       · have : Continuous (fun a ↦ rexp (-(r * a))) := by
-          simp only [← neg_mul]; exact (continuous_mul_left (-r)).rexp
-        exact Continuous.continuousOn (Continuous.comp' (continuous_mul_left (-1)) this)
+          simp only [← neg_mul]; exact (continuous_const_mul (-r)).rexp
+        exact Continuous.continuousOn (Continuous.comp' (continuous_const_mul (-1)) this)
       · simp only [neg_mul, one_mul]
         exact fun _ _ ↦ HasDerivAt.hasDerivWithinAt hasDerivAt_neg_exp_mul_exp
     · refine Integrable.aestronglyMeasurable (Integrable.const_mul ?_ _)

--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -477,7 +477,7 @@ instance : Algebra S (v.adicCompletion K) where
   commutes' r x := by
     induction x using Completion.induction_on with
     | hp =>
-      exact isClosed_eq (continuous_mul_left _) (continuous_mul_right _)
+      exact isClosed_eq (continuous_const_mul _) (continuous_mul_const _)
     | ih x =>
       change (↑(algebraMap S (WithVal <| v.valuation K) r) : v.adicCompletion K) * x
         = x * (↑(algebraMap S (WithVal <| v.valuation K) r) : v.adicCompletion K)
@@ -486,7 +486,7 @@ instance : Algebra S (v.adicCompletion K) where
   smul_def' r x := by
     induction x using Completion.induction_on with
     | hp =>
-      exact isClosed_eq (continuous_const_smul _) (continuous_mul_left _)
+      exact isClosed_eq (continuous_const_smul _) (continuous_const_mul _)
     | ih x =>
       change _ = (↑(algebraMap S (WithVal <| v.valuation K) r) : v.adicCompletion K) * x
       norm_cast

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -132,7 +132,7 @@ might print out
 ```
 Continuous
   continuous_add, args: [4,5], priority: 1000
-  continuous_const_addd, args: [5], priority: 1000
+  continuous_const_add, args: [5], priority: 1000
   continuous_add_const, args [4], priority: 1000
   ...
 Differentiable

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -132,8 +132,8 @@ might print out
 ```
 Continuous
   continuous_add, args: [4,5], priority: 1000
-  continuous_add_left, args: [5], priority: 1000
-  continuous_add_right, args [4], priority: 1000
+  continuous_const_addd, args: [5], priority: 1000
+  continuous_add_const, args [4], priority: 1000
   ...
 Differentiable
   Differentiable.add, args: [4,5], priority: 1000

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -47,7 +47,7 @@ variable {G : Type w} {H : Type x} {α : Type u} {β : Type v}
 
 /-- In a Hausdorff magma with continuous multiplication, the centralizer of any set is closed. -/
 lemma Set.isClosed_centralizer {M : Type*} (s : Set M) [Mul M] [TopologicalSpace M]
-    [ContinuousMul M] [T2Space M] : IsClosed (centralizer s) := by
+    [SeparatelyContinuousMul M] [T2Space M] : IsClosed (centralizer s) := by
   rw [centralizer, setOf_forall]
   refine isClosed_sInter ?_
   rintro - ⟨m, ht, rfl⟩
@@ -63,7 +63,7 @@ In this section we prove a few statements about groups with continuous `(*)`.
 -/
 
 
-variable [TopologicalSpace G] [Group G] [ContinuousMul G]
+variable [TopologicalSpace G] [Group G] [SeparatelyContinuousMul G]
 
 /-- Multiplication from the left in a topological group as a homeomorphism. -/
 @[to_additive /-- Addition from the left in a topological additive group as a homeomorphism. -/]
@@ -411,29 +411,30 @@ instance ConjAct.units_continuousConstSMul {M} [Monoid M] [TopologicalSpace M]
     [ContinuousMul M] : ContinuousConstSMul (ConjAct Mˣ) M :=
   ⟨fun _ => (continuous_const.mul continuous_id).mul continuous_const⟩
 
-variable [TopologicalSpace G] [Inv G] [Mul G] [ContinuousMul G]
+variable [TopologicalSpace G] [Inv G] [Mul G]
 
 /-- Conjugation is jointly continuous on `G × G` when both `mul` and `inv` are continuous. -/
 @[to_additive continuous_addConj_prod
   /-- Conjugation is jointly continuous on `G × G` when both `add` and `neg` are continuous. -/]
-theorem IsTopologicalGroup.continuous_conj_prod [ContinuousInv G] :
+theorem IsTopologicalGroup.continuous_conj_prod [ContinuousMul G] [ContinuousInv G] :
     Continuous fun g : G × G => g.fst * g.snd * g.fst⁻¹ :=
   continuous_mul.mul (continuous_inv.comp continuous_fst)
 
 /-- Conjugation by a fixed element is continuous when `mul` is continuous. -/
-@[to_additive (attr := continuity)
+@[to_additive (attr := continuity, fun_prop)
   /-- Conjugation by a fixed element is continuous when `add` is continuous. -/]
-theorem IsTopologicalGroup.continuous_conj (g : G) : Continuous fun h : G => g * h * g⁻¹ :=
-  (continuous_mul_right g⁻¹).comp (continuous_mul_left g)
+theorem IsTopologicalGroup.continuous_conj [SeparatelyContinuousMul G] (g : G) :
+    Continuous fun h : G => g * h * g⁻¹ :=
+  (continuous_mul_const g⁻¹).comp (continuous_const_mul g)
 
 /-- Conjugation acting on fixed element of the group is continuous when both `mul` and
 `inv` are continuous. -/
-@[to_additive (attr := continuity)
+@[to_additive (attr := continuity, fun_prop)
   /-- Conjugation acting on fixed element of the additive group is continuous when both
     `add` and `neg` are continuous. -/]
-theorem IsTopologicalGroup.continuous_conj' [ContinuousInv G] (h : G) :
+theorem IsTopologicalGroup.continuous_conj' [ContinuousMul G] [ContinuousInv G] (h : G) :
     Continuous fun g : G => g * h * g⁻¹ :=
-  (continuous_mul_right h).mul continuous_inv
+  (continuous_mul_const h).mul continuous_inv
 
 end Conj
 
@@ -700,7 +701,7 @@ theorem mul_mem_connectedComponent_one {G : Type*} [TopologicalSpace G] [MulOneC
     (hh : h ∈ connectedComponent (1 : G)) : g * h ∈ connectedComponent (1 : G) := by
   rw [connectedComponent_eq hg]
   have hmul : g ∈ connectedComponent (g * h) := by
-    apply Continuous.image_connectedComponent_subset (continuous_mul_left g)
+    apply Continuous.image_connectedComponent_subset (continuous_const_mul g)
     rw [← connectedComponent_eq hh]
     exact ⟨(1 : G), mem_connectedComponent, by simp only [mul_one]⟩
   simpa [← connectedComponent_eq hmul] using mem_connectedComponent

--- a/Mathlib/Topology/Algebra/Group/Pointwise.lean
+++ b/Mathlib/Topology/Algebra/Group/Pointwise.lean
@@ -294,7 +294,7 @@ theorem IsTopologicalGroup.t2Space_of_one_sep (H : ∀ x : G, x ≠ 1 → ∃ U 
   suffices T1Space G from inferInstance
   refine t1Space_iff_specializes_imp_eq.2 fun x y hspec ↦ by_contra fun hne ↦ ?_
   rcases H (x * y⁻¹) (by rwa [Ne, mul_inv_eq_one]) with ⟨U, hU₁, hU⟩
-  exact hU <| mem_of_mem_nhds <| hspec.map (continuous_mul_right y⁻¹) (by rwa [mul_inv_cancel])
+  exact hU <| mem_of_mem_nhds <| hspec.map (continuous_mul_const y⁻¹) (by rwa [mul_inv_cancel])
 
 /-- Given a neighborhood `U` of the identity, one may find a neighborhood `V` of the identity which
 is closed, symmetric, and satisfies `V * V ⊆ U`. -/

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -274,15 +274,15 @@ variable [TopologicalSpace α] [GroupWithZero α] [ContinuousMul α]
 is a homeomorphism of the underlying type. -/
 protected def mulLeft₀ (c : α) (hc : c ≠ 0) : α ≃ₜ α :=
   { Equiv.mulLeft₀ c hc with
-    continuous_toFun := continuous_mul_left _
-    continuous_invFun := continuous_mul_left _ }
+    continuous_toFun := continuous_const_mul _
+    continuous_invFun := continuous_const_mul _ }
 
 /-- Right multiplication by a nonzero element in a `GroupWithZero` with continuous multiplication
 is a homeomorphism of the underlying type. -/
 protected def mulRight₀ (c : α) (hc : c ≠ 0) : α ≃ₜ α :=
   { Equiv.mulRight₀ c hc with
-    continuous_toFun := continuous_mul_right _
-    continuous_invFun := continuous_mul_right _ }
+    continuous_toFun := continuous_mul_const _
+    continuous_invFun := continuous_mul_const _ }
 
 @[simp]
 theorem coe_mulLeft₀ (c : α) (hc : c ≠ 0) : ⇑(Homeomorph.mulLeft₀ c hc) = (c * ·) :=

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -35,6 +35,28 @@ variable {ι α M N X : Type*} [TopologicalSpace X]
 theorem continuous_one [TopologicalSpace M] [One M] : Continuous (1 : X → M) :=
   @continuous_const _ _ _ _ 1
 
+section SeparatelyContinuousMul
+
+variable [TopologicalSpace M] [Mul M] [SeparatelyContinuousMul M]
+
+@[to_additive]
+instance : SeparatelyContinuousMul Mᵒᵈ :=
+  ‹SeparatelyContinuousMul M›
+
+@[to_additive]
+instance : SeparatelyContinuousMul (ULift.{u} M) :=
+  ⟨continuous_uliftUp.comp (by fun_prop), continuous_uliftUp.comp (by fun_prop)⟩
+
+@[to_additive]
+instance SeparatelyContinuousMul.to_continuousSMul : ContinuousConstSMul M M :=
+  ⟨fun _ ↦ continuous_const_mul⟩
+
+@[to_additive]
+instance SeparatelyContinuousMul.to_continuousSMul_op : ContinuousConstSMul Mᵐᵒᵖ M :=
+  ⟨fun _ ↦ continuous_mul_const⟩
+
+end SeparatelyContinuousMul
+
 section ContinuousMul
 
 variable [TopologicalSpace M] [Mul M] [ContinuousMul M]
@@ -64,25 +86,16 @@ theorem ContinuousMul.induced {α : Type*} {β : Type*} {F : Type*} [FunLike F �
   simp only [Function.comp_def, map_mul]
   fun_prop
 
-@[to_additive (attr := continuity)]
-theorem continuous_mul_left (a : M) : Continuous fun b : M => a * b := by fun_prop
-
-@[to_additive (attr := continuity)]
-theorem continuous_mul_right (a : M) : Continuous fun b : M => b * a := by fun_prop
+@[deprecated (since := "2026-02-20")] alias continuous_add_left := continuous_const_add
+@[deprecated (since := "2026-02-20")] alias continuous_add_right := continuous_add_const
+@[to_additive existing, deprecated (since := "2026-02-20")]
+alias continuous_mul_left := continuous_const_mul
+@[to_additive existing, deprecated (since := "2026-02-20")]
+alias continuous_mul_right := continuous_mul_const
 
 @[to_additive]
 theorem tendsto_mul {a b : M} : Tendsto (fun p : M × M => p.fst * p.snd) (𝓝 (a, b)) (𝓝 (a * b)) :=
   continuous_iff_continuousAt.mp ContinuousMul.continuous_mul (a, b)
-
-@[to_additive]
-theorem Filter.Tendsto.const_mul (b : M) {c : M} {f : α → M} {l : Filter α}
-    (h : Tendsto (fun k : α => f k) l (𝓝 c)) : Tendsto (fun k : α => b * f k) l (𝓝 (b * c)) :=
-  tendsto_const_nhds.mul h
-
-@[to_additive]
-theorem Filter.Tendsto.mul_const (b : M) {c : M} {f : α → M} {l : Filter α}
-    (h : Tendsto (fun k : α => f k) l (𝓝 c)) : Tendsto (fun k : α => f k * b) l (𝓝 (c * b)) :=
-  h.mul tendsto_const_nhds
 
 @[to_additive]
 theorem le_nhds_mul (a b : M) : 𝓝 a * 𝓝 b ≤ 𝓝 (a * b) := by
@@ -110,7 +123,7 @@ theorem one_le_nhds_iff [T1Space X] [One X] {b : X} : 1 ≤ 𝓝 b ↔ 1 = b :=
 
 section tendsto_nhds
 
-variable {𝕜 : Type*} [Preorder 𝕜] [Zero 𝕜] [Mul 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜]
+variable {𝕜 : Type*} [Preorder 𝕜] [Zero 𝕜] [Mul 𝕜] [TopologicalSpace 𝕜] [SeparatelyContinuousMul 𝕜]
   {l : Filter α} {f : α → 𝕜} {b c : 𝕜} (hb : 0 < b)
 include hb
 
@@ -181,10 +194,24 @@ instance Prod.continuousMul [TopologicalSpace N] [Mul N] [ContinuousMul N] :
   ⟨by apply Continuous.prodMk <;> fun_prop⟩
 
 @[to_additive]
+instance Prod.separatelyContinuousMul {M N : Type*}
+    [TopologicalSpace M] [Mul M] [SeparatelyContinuousMul M]
+    [TopologicalSpace N] [Mul N] [SeparatelyContinuousMul N] :
+    SeparatelyContinuousMul (M × N) where
+  continuous_const_mul {_} := by apply Continuous.prodMk <;> fun_prop
+  continuous_mul_const {_} := by apply Continuous.prodMk <;> fun_prop
+
+@[to_additive]
 instance Pi.continuousMul {C : ι → Type*} [∀ i, TopologicalSpace (C i)] [∀ i, Mul (C i)]
     [∀ i, ContinuousMul (C i)] : ContinuousMul (∀ i, C i) where
   continuous_mul :=
     continuous_pi fun i => (continuous_apply i).fst'.mul (continuous_apply i).snd'
+
+@[to_additive]
+instance Pi.separatelyContinuousMul {C : ι → Type*} [∀ i, TopologicalSpace (C i)] [∀ i, Mul (C i)]
+    [∀ i, SeparatelyContinuousMul (C i)] : SeparatelyContinuousMul (∀ i, C i) where
+  continuous_mul_const {_} := continuous_pi fun i ↦ (continuous_apply i).mul_const _
+  continuous_const_mul {_} := continuous_pi fun i ↦ (continuous_apply i).const_mul _
 
 /-- A version of `Pi.continuousMul` for non-dependent functions. It is needed because sometimes
 Lean 3 fails to use `Pi.continuousMul` for non-dependent functions. -/
@@ -527,13 +554,28 @@ section ContinuousMul
 
 section Semigroup
 
-variable [TopologicalSpace M] [Semigroup M] [ContinuousMul M]
+-- Move to `Topology.Constructions.SumProd`
+/-- The hypotheses on `f` are slightly weaker here compared to `mem_map_closure₂`. That
+lemma requires `f` to be jointly continuous, whereas here we only require continuity in each
+variable separately. -/
+theorem map_mem_closure₂' {X Y Z : Type*}
+    [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
+    {f : X → Y → Z} {x : X} {y : Y} {s : Set X} {t : Set Y} {u : Set Z}
+    (hf₁ : ∀ x, Continuous (f x)) (hf₂ : ∀ y, Continuous (f · y))
+    (hx : x ∈ closure s) (hy : y ∈ closure t) (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) :
+    f x y ∈ closure u := by
+  rw [← isClosed_closure.closure_eq]
+  apply map_mem_closure (hf₁ x) hy fun b hb ↦ ?_
+  apply map_mem_closure (hf₂ b) hx fun a ha ↦ h a ha b hb
+
+variable [TopologicalSpace M] [Semigroup M] [SeparatelyContinuousMul M]
 
 @[to_additive]
 theorem Subsemigroup.top_closure_mul_self_subset (s : Subsemigroup M) :
     _root_.closure (s : Set M) * _root_.closure s ⊆ _root_.closure s :=
   image2_subset_iff.2 fun _ hx _ hy =>
-    map_mem_closure₂ continuous_mul hx hy fun _ ha _ hb => s.mul_mem ha hb
+    map_mem_closure₂' continuous_const_mul continuous_mul_const
+      hx hy fun _ ha _ hb => s.mul_mem ha hb
 
 /-- The (topological-space) closure of a subsemigroup of a space `M` with `ContinuousMul` is
 itself a subsemigroup. -/
@@ -574,23 +616,30 @@ abbrev Subsemigroup.commSemigroupTopologicalClosure [T2Space M] (s : Subsemigrou
       have : ∀ x ∈ s, ∀ y ∈ s, x * y = y * x := fun x hx y hy =>
         congr_arg Subtype.val (hs ⟨x, hx⟩ ⟨y, hy⟩)
       fun ⟨x, hx⟩ ⟨y, hy⟩ =>
-      Subtype.ext <|
-        eqOn_closure₂ this continuous_mul (continuous_snd.mul continuous_fst) x hx y hy }
+      Subtype.ext <| by
+        refine eqOn_closure₂' this ?_ ?_ ?_ ?_ x hx y hy
+        all_goals fun_prop }
 
 @[to_additive]
-theorem IsCompact.mul {s t : Set M} (hs : IsCompact s) (ht : IsCompact t) : IsCompact (s * t) := by
+theorem IsCompact.mul [TopologicalSpace N] [Mul N] [ContinuousMul N] {s t : Set N}
+    (hs : IsCompact s) (ht : IsCompact t) : IsCompact (s * t) := by
   rw [← image_mul_prod]
   exact (hs.prod ht).image continuous_mul
 
 end Semigroup
 
-variable [TopologicalSpace M] [Monoid M] [ContinuousMul M]
+variable [TopologicalSpace M] [Monoid M]
+
+section SeparatelyContinuousMul
+
+variable [SeparatelyContinuousMul M]
 
 @[to_additive]
 theorem Submonoid.top_closure_mul_self_subset (s : Submonoid M) :
     _root_.closure (s : Set M) * _root_.closure s ⊆ _root_.closure s :=
   image2_subset_iff.2 fun _ hx _ hy =>
-    map_mem_closure₂ continuous_mul hx hy fun _ ha _ hb => s.mul_mem ha hb
+    map_mem_closure₂' continuous_const_mul continuous_mul_const hx hy
+      fun _ ha _ hb ↦ s.mul_mem ha hb
 
 @[to_additive]
 theorem Submonoid.top_closure_mul_self_eq (s : Submonoid M) :
@@ -631,6 +680,27 @@ See note [reducible non-instances]. -/]
 abbrev Submonoid.commMonoidTopologicalClosure [T2Space M] (s : Submonoid M)
     (hs : ∀ x y : s, x * y = y * x) : CommMonoid s.topologicalClosure :=
   { s.topologicalClosure.toMonoid, s.toSubsemigroup.commSemigroupTopologicalClosure hs with }
+
+/-- Left-multiplication by a left-invertible element of a topological monoid is proper, i.e.,
+inverse images of compact sets are compact. -/
+theorem Filter.tendsto_cocompact_mul_left {a b : M} (ha : b * a = 1) :
+    Filter.Tendsto (fun x : M => a * x) (Filter.cocompact M) (Filter.cocompact M) := by
+  refine Filter.Tendsto.of_tendsto_comp ?_ (Filter.comap_cocompact_le (continuous_const_mul b))
+  convert Filter.tendsto_id
+  ext x
+  simp [← mul_assoc, ha]
+
+/-- Right-multiplication by a right-invertible element of a topological monoid is proper, i.e.,
+inverse images of compact sets are compact. -/
+theorem Filter.tendsto_cocompact_mul_right {a b : M} (ha : a * b = 1) :
+    Filter.Tendsto (fun x : M => x * a) (Filter.cocompact M) (Filter.cocompact M) := by
+  refine Filter.Tendsto.of_tendsto_comp ?_ (Filter.comap_cocompact_le (continuous_mul_const b))
+  simp only [comp_mul_right, ha, mul_one]
+  exact Filter.tendsto_id
+
+end SeparatelyContinuousMul
+
+variable [ContinuousMul M]
 
 @[to_additive exists_nhds_zero_quarter]
 theorem exists_nhds_one_split4 {u : Set M} (hu : u ∈ 𝓝 (1 : M)) :
@@ -725,23 +795,6 @@ theorem ContinuousAt.pow {f : X → M} {x : X} (hf : ContinuousAt f x) (n : ℕ)
 theorem ContinuousOn.pow {f : X → M} {s : Set X} (hf : ContinuousOn f s) (n : ℕ) :
     ContinuousOn (fun x => f x ^ n) s := fun x hx => (hf x hx).pow n
 
-/-- Left-multiplication by a left-invertible element of a topological monoid is proper, i.e.,
-inverse images of compact sets are compact. -/
-theorem Filter.tendsto_cocompact_mul_left {a b : M} (ha : b * a = 1) :
-    Filter.Tendsto (fun x : M => a * x) (Filter.cocompact M) (Filter.cocompact M) := by
-  refine Filter.Tendsto.of_tendsto_comp ?_ (Filter.comap_cocompact_le (continuous_mul_left b))
-  convert Filter.tendsto_id
-  ext x
-  simp [← mul_assoc, ha]
-
-/-- Right-multiplication by a right-invertible element of a topological monoid is proper, i.e.,
-inverse images of compact sets are compact. -/
-theorem Filter.tendsto_cocompact_mul_right {a b : M} (ha : a * b = 1) :
-    Filter.Tendsto (fun x : M => x * a) (Filter.cocompact M) (Filter.cocompact M) := by
-  refine Filter.Tendsto.of_tendsto_comp ?_ (Filter.comap_cocompact_le (continuous_mul_right b))
-  simp only [comp_mul_right, ha, mul_one]
-  exact Filter.tendsto_id
-
 /-- If `R` acts on `A` via `A`, then continuous multiplication implies continuous scalar
 multiplication by constants.
 
@@ -749,7 +802,8 @@ Notably, this instance applies when `R = A`, or when `[Algebra R A]` is availabl
 @[to_additive /-- If `R` acts on `A` via `A`, then continuous addition implies
 continuous affine addition by constants. -/]
 instance (priority := 100) IsScalarTower.continuousConstSMul {R A : Type*} [Monoid A] [SMul R A]
-    [IsScalarTower R A A] [TopologicalSpace A] [ContinuousMul A] : ContinuousConstSMul R A where
+    [IsScalarTower R A A] [TopologicalSpace A] [SeparatelyContinuousMul A] :
+    ContinuousConstSMul R A where
   continuous_const_smul q := by
     simp +singlePass only [← smul_one_mul q (_ : A)]
     fun_prop
@@ -763,7 +817,8 @@ continuous addition implies continuous affine addition by constants.
 
 Notably, this instance applies when `R = Aᵃᵒᵖ`. -/]
 instance (priority := 100) SMulCommClass.continuousConstSMul {R A : Type*} [Monoid A] [SMul R A]
-    [SMulCommClass R A A] [TopologicalSpace A] [ContinuousMul A] : ContinuousConstSMul R A where
+    [SMulCommClass R A A] [TopologicalSpace A] [SeparatelyContinuousMul A] :
+    ContinuousConstSMul R A where
   continuous_const_smul q := by
     simp +singlePass only [← mul_smul_one q (_ : A)]
     fun_prop
@@ -771,6 +826,13 @@ instance (priority := 100) SMulCommClass.continuousConstSMul {R A : Type*} [Mono
 end ContinuousMul
 
 namespace MulOpposite
+
+/-- If multiplication is separately continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
+@[to_additive /-- If addition is separately continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
+instance [TopologicalSpace α] [Mul α] [SeparatelyContinuousMul α] :
+    SeparatelyContinuousMul αᵐᵒᵖ where
+  continuous_mul_const := continuous_op.comp (continuous_unop.const_mul (unop _))
+  continuous_const_mul := continuous_op.comp (continuous_unop.mul_const (unop _))
 
 /-- If multiplication is continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
 @[to_additive /-- If addition is continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
@@ -898,6 +960,16 @@ instance [TopologicalSpace M] [Mul M] [ContinuousMul M] : ContinuousAdd (Additiv
 instance [TopologicalSpace M] [Add M] [ContinuousAdd M] : ContinuousMul (Multiplicative M) where
   continuous_mul := @continuous_add M _ _ _
 
+instance [TopologicalSpace M] [Mul M] [SeparatelyContinuousMul M] :
+    SeparatelyContinuousAdd (Additive M) where
+  continuous_const_add := @continuous_const_mul M _ _ _
+  continuous_add_const := @continuous_mul_const M _ _ _
+
+instance [TopologicalSpace M] [Add M] [SeparatelyContinuousAdd M] :
+    SeparatelyContinuousMul (Multiplicative M) where
+  continuous_const_mul := @continuous_const_add M _ _ _
+  continuous_mul_const := @continuous_add_const M _ _ _
+
 section LatticeOps
 
 variable {ι' : Sort*} [Mul M]
@@ -927,12 +999,12 @@ end LatticeOps
 
 namespace ContinuousMap
 
-variable [Mul X] [ContinuousMul X]
+variable [Mul X] [SeparatelyContinuousMul X]
 
 /-- The continuous map `fun y => y * x` -/
 @[to_additive /-- The continuous map `fun y => y + x` -/]
 protected def mulRight (x : X) : C(X, X) :=
-  mk _ (continuous_mul_right x)
+  mk _ (continuous_mul_const x)
 
 @[to_additive (attr := simp)]
 theorem coe_mulRight (x : X) : ⇑(ContinuousMap.mulRight x) = fun y => y * x :=
@@ -941,7 +1013,7 @@ theorem coe_mulRight (x : X) : ⇑(ContinuousMap.mulRight x) = fun y => y * x :=
 /-- The continuous map `fun y => x * y` -/
 @[to_additive /-- The continuous map `fun y => x + y` -/]
 protected def mulLeft (x : X) : C(X, X) :=
-  mk _ (continuous_mul_left x)
+  mk _ (continuous_const_mul x)
 
 @[to_additive (attr := simp)]
 theorem coe_mulLeft (x : X) : ⇑(ContinuousMap.mulLeft x) = fun y => x * y :=

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -35,6 +35,22 @@ variable {ι α M N X : Type*} [TopologicalSpace X]
 theorem continuous_one [TopologicalSpace M] [One M] : Continuous (1 : X → M) :=
   @continuous_const _ _ _ _ 1
 
+namespace MulOpposite
+
+/-- If multiplication is separately continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
+@[to_additive /-- If addition is separately continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
+instance [TopologicalSpace α] [Mul α] [SeparatelyContinuousMul α] :
+    SeparatelyContinuousMul αᵐᵒᵖ where
+  continuous_mul_const := continuous_op.comp (continuous_unop.const_mul (unop _))
+  continuous_const_mul := continuous_op.comp (continuous_unop.mul_const (unop _))
+
+/-- If multiplication is continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
+@[to_additive /-- If addition is continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
+instance [TopologicalSpace α] [Mul α] [ContinuousMul α] : ContinuousMul αᵐᵒᵖ :=
+  ⟨continuous_op.comp (continuous_unop.snd'.mul continuous_unop.fst')⟩
+
+end MulOpposite
+
 section SeparatelyContinuousMul
 
 variable [TopologicalSpace M] [Mul M] [SeparatelyContinuousMul M]
@@ -374,6 +390,34 @@ instance Submonoid.continuousMul [TopologicalSpace M] [Monoid M] [ContinuousMul 
     (S : Submonoid M) : ContinuousMul S :=
   S.toSubsemigroup.continuousMul
 
+open MulOpposite in
+@[to_additive]
+theorem Topology.IsInducing.separatelyContinuousMul {M N F : Type*} [Mul M] [Mul N] [FunLike F M N]
+    [MulHomClass F M N] [TopologicalSpace M] [TopologicalSpace N] [SeparatelyContinuousMul N]
+    (f : F) (hf : IsInducing f) : SeparatelyContinuousMul M where
+  continuous_const_mul := (hf.continuousConstSMul f (map_mul f _ _)).1 _
+  continuous_mul_const {m} :=
+    have := ((opHomeomorph.isInducing.comp hf).comp (opHomeomorph.symm.isInducing)
+      |>.continuousConstSMul (fun x ↦ op (f (unop x))) (by simp)).1 (op m)
+    continuous_unop.comp <| this.comp continuous_op
+
+@[to_additive]
+theorem separatelyContinuousMul_induced {M N F : Type*} [Mul M] [Mul N] [FunLike F M N]
+    [MulHomClass F M N] [TopologicalSpace N] [SeparatelyContinuousMul N] (f : F) :
+    @SeparatelyContinuousMul M (induced f ‹_›) _ :=
+  letI := induced f ‹_›
+  IsInducing.separatelyContinuousMul f ⟨rfl⟩
+
+@[to_additive]
+instance Subsemigroup.separatelyContinuousMul [TopologicalSpace M] [Semigroup M]
+    [SeparatelyContinuousMul M] (S : Subsemigroup M) : SeparatelyContinuousMul S :=
+  IsInducing.separatelyContinuousMul
+    ({ toFun := (↑), map_mul' := fun _ _ => rfl } : MulHom S M) ⟨rfl⟩
+
+@[to_additive]
+instance Submonoid.separatelyContinuousMul [TopologicalSpace M] [Monoid M]
+    [SeparatelyContinuousMul M] (S : Submonoid M) : SeparatelyContinuousMul S :=
+  S.toSubsemigroup.separatelyContinuousMul
 section MulZeroClass
 
 open Filter
@@ -553,20 +597,6 @@ end MulOneClass
 section ContinuousMul
 
 section Semigroup
-
--- Move to `Topology.Constructions.SumProd`
-/-- The hypotheses on `f` are slightly weaker here compared to `mem_map_closure₂`. That
-lemma requires `f` to be jointly continuous, whereas here we only require continuity in each
-variable separately. -/
-theorem map_mem_closure₂' {X Y Z : Type*}
-    [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
-    {f : X → Y → Z} {x : X} {y : Y} {s : Set X} {t : Set Y} {u : Set Z}
-    (hf₁ : ∀ x, Continuous (f x)) (hf₂ : ∀ y, Continuous (f · y))
-    (hx : x ∈ closure s) (hy : y ∈ closure t) (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) :
-    f x y ∈ closure u := by
-  rw [← isClosed_closure.closure_eq]
-  apply map_mem_closure (hf₁ x) hy fun b hb ↦ ?_
-  apply map_mem_closure (hf₂ b) hx fun a ha ↦ h a ha b hb
 
 variable [TopologicalSpace M] [Semigroup M] [SeparatelyContinuousMul M]
 
@@ -824,22 +854,6 @@ instance (priority := 100) SMulCommClass.continuousConstSMul {R A : Type*} [Mono
     fun_prop
 
 end ContinuousMul
-
-namespace MulOpposite
-
-/-- If multiplication is separately continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
-@[to_additive /-- If addition is separately continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
-instance [TopologicalSpace α] [Mul α] [SeparatelyContinuousMul α] :
-    SeparatelyContinuousMul αᵐᵒᵖ where
-  continuous_mul_const := continuous_op.comp (continuous_unop.const_mul (unop _))
-  continuous_const_mul := continuous_op.comp (continuous_unop.mul_const (unop _))
-
-/-- If multiplication is continuous in `α`, then it also is in `αᵐᵒᵖ`. -/
-@[to_additive /-- If addition is continuous in `α`, then it also is in `αᵃᵒᵖ`. -/]
-instance [TopologicalSpace α] [Mul α] [ContinuousMul α] : ContinuousMul αᵐᵒᵖ :=
-  ⟨continuous_op.comp (continuous_unop.snd'.mul continuous_unop.fst')⟩
-
-end MulOpposite
 
 namespace Units
 

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -11,10 +11,15 @@ public import Mathlib.Algebra.Group.Basic
 /-!
 # Topological monoids - definitions
 
-In this file we define two mixin typeclasses:
+In this file we define three mixin typeclasses:
 
 - `ContinuousMul M` says that the multiplication on `M` is continuous as a function on `M × M`;
 - `ContinuousAdd M` says that the addition on `M` is continuous as a function on `M × M`.
+- `ContinuousMulConst M` says that the multiplication on `M` is continuous in each argument
+  separately. This is strictly weaker than `ContinuousMul M`, but arises frequently in practice in
+  functional analysis where one often considers topologies weaker than the norm topology. In these
+  topologies it is frequently the case that the multiplication is not jointly continuous, but is
+  continuous in each argument separately.
 
 These classes are `Prop`-valued mixins,
 i.e., they take data (`TopologicalSpace`, `Mul`/`Add`) as arguments
@@ -40,11 +45,21 @@ class ContinuousAdd (M : Type*) [TopologicalSpace M] [Add M] : Prop where
 A topological monoid over `M`, for example, is obtained by requiring both the instances `Monoid M`
 and `ContinuousMul M`.
 
-Continuity in only the left/right argument can be stated using
+Continuity in each argument separately can be stated using `SeparatelyContinuousMul α`. If one wants
+only continuity in either the left or right argument, but not both one can use
 `ContinuousConstSMul α α`/`ContinuousConstSMul αᵐᵒᵖ α`. -/
 @[to_additive]
 class ContinuousMul (M : Type*) [TopologicalSpace M] [Mul M] : Prop where
   continuous_mul : Continuous fun p : M × M => p.1 * p.2
+
+class SeparatelyContinuousAdd (M : Type*) [TopologicalSpace M] [Add M] : Prop where
+  continuous_const_add {a} : Continuous fun b : M => a + b
+  continuous_add_const {a} : Continuous fun b : M => b + a
+
+@[to_additive]
+class SeparatelyContinuousMul (M : Type*) [TopologicalSpace M] [Mul M] : Prop where
+  continuous_const_mul {a} : Continuous fun b : M => a * b
+  continuous_mul_const {a} : Continuous fun b : M => b * a
 
 section ContinuousMul
 
@@ -88,3 +103,71 @@ theorem ContinuousOn.mul (hf : ContinuousOn f s) (hg : ContinuousOn g s) :
   (hf x hx).mul (hg x hx)
 
 end ContinuousMul
+
+section
+
+variable {M : Type*} [TopologicalSpace M] [Mul M]
+
+instance [ContinuousMul M] : SeparatelyContinuousMul M where
+  continuous_const_mul := continuous_const.mul continuous_id
+  continuous_mul_const := continuous_id.mul continuous_const
+
+variable [SeparatelyContinuousMul M]
+
+@[to_additive (attr := fun_prop)]
+theorem continuous_const_mul (m : M) : Continuous (m * ·) :=
+  SeparatelyContinuousMul.continuous_const_mul
+
+@[to_additive (attr := fun_prop)]
+theorem continuous_mul_const (m : M) : Continuous (· * m) :=
+  SeparatelyContinuousMul.continuous_mul_const
+
+@[to_additive]
+theorem Filter.Tendsto.const_mul {α : Type*} {f : α → M} {x : Filter α} {a : M}
+    (hf : Tendsto f x (𝓝 a)) (b : M) : Tendsto (b * f ·) x (𝓝 (b * a)) :=
+  continuous_const_mul  b |>.tendsto _ |>.comp hf
+
+@[to_additive]
+theorem Filter.Tendsto.mul_const {α : Type*} {f : α → M} {x : Filter α} {a : M}
+    (hf : Tendsto f x (𝓝 a)) (b : M) : Tendsto (f · * b) x (𝓝 (a * b)) :=
+  continuous_mul_const b |>.tendsto _ |>.comp hf
+
+variable {X : Type*} [TopologicalSpace X] {f g : X → M} {s : Set X} {x : X}
+
+@[to_additive (attr := fun_prop)]
+theorem Continuous.mul_const (hf : Continuous f) (b : M) : Continuous (f · * b) :=
+  continuous_mul_const b |>.comp hf
+
+@[to_additive (attr := fun_prop)]
+theorem Continuous.const_mul (hf : Continuous f) (b : M) : Continuous (b * f ·) :=
+  continuous_const_mul b |>.comp hf
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousWithinAt.mul_const (hf : ContinuousWithinAt f s x) (b : M) :
+    ContinuousWithinAt (f · * b) s x :=
+  Filter.Tendsto.mul_const hf b
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousWithinAt.const_mul (hf : ContinuousWithinAt f s x) (b : M) :
+    ContinuousWithinAt (b * f ·) s x :=
+  Filter.Tendsto.const_mul hf b
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousAt.mul_const (hf : ContinuousAt f x) (b : M) :
+    ContinuousAt (f · * b) x :=
+  Filter.Tendsto.mul_const hf b
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousAt.const_mul (hf : ContinuousAt f x) (b : M) :
+    ContinuousAt (b * f ·) x :=
+  Filter.Tendsto.const_mul hf b
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousOn.mul_const (hf : ContinuousOn f s) (b : M) :
+    ContinuousOn (f · * b) s :=
+  fun x hx ↦ (hf x hx).mul_const b
+
+@[to_additive (attr := fun_prop)]
+theorem ContinuousOn.const_mul (hf : ContinuousOn f s) (b : M) :
+    ContinuousOn (b * f ·) s :=
+  fun x hx ↦ (hf x hx).const_mul b

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -120,11 +120,11 @@ instance [ContinuousMul M] : SeparatelyContinuousMul M where
 
 variable [SeparatelyContinuousMul M]
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := continuity, fun_prop)]
 theorem continuous_const_mul (m : M) : Continuous (m * ·) :=
   SeparatelyContinuousMul.continuous_const_mul
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := continuity, fun_prop)]
 theorem continuous_mul_const (m : M) : Continuous (· * m) :=
   SeparatelyContinuousMul.continuous_mul_const
 
@@ -140,11 +140,11 @@ theorem Filter.Tendsto.mul_const {α : Type*} {f : α → M} {x : Filter α} {a 
 
 variable {X : Type*} [TopologicalSpace X] {f g : X → M} {s : Set X} {x : X}
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := continuity, fun_prop)]
 theorem Continuous.mul_const (hf : Continuous f) (b : M) : Continuous (f · * b) :=
   continuous_mul_const b |>.comp hf
 
-@[to_additive (attr := fun_prop)]
+@[to_additive (attr := continuity, fun_prop)]
 theorem Continuous.const_mul (hf : Continuous f) (b : M) : Continuous (b * f ·) :=
   continuous_const_mul b |>.comp hf
 

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -36,7 +36,8 @@ open scoped Topology
 semigroup. A topological additive monoid over `M`, for example, is obtained by requiring both the
 instances `AddMonoid M` and `ContinuousAdd M`.
 
-Continuity in only the left/right argument can be stated using
+Continuity in each argument separately can be stated using `SeparatelyContinuousAdd α`. If one wants
+only continuity in either the left or right argument, but not both one can use
 `ContinuousConstVAdd α α`/`ContinuousConstVAdd αᵐᵒᵖ α`. -/
 class ContinuousAdd (M : Type*) [TopologicalSpace M] [Add M] : Prop where
   continuous_add : Continuous fun p : M × M => p.1 + p.2
@@ -52,14 +53,18 @@ only continuity in either the left or right argument, but not both one can use
 class ContinuousMul (M : Type*) [TopologicalSpace M] [Mul M] : Prop where
   continuous_mul : Continuous fun p : M × M => p.1 * p.2
 
+/-- A type class encoding that addition is continuous in each argument. This is weaker than
+`ContinuousAdd`. -/
 class SeparatelyContinuousAdd (M : Type*) [TopologicalSpace M] [Add M] : Prop where
-  continuous_const_add {a} : Continuous fun b : M => a + b
-  continuous_add_const {a} : Continuous fun b : M => b + a
+  continuous_const_add {a : M} : Continuous (a + ·)
+  continuous_add_const {a : M} : Continuous (· + a)
 
+/-- A type class encoding that addition is continuous in each argument. This is weaker than
+`ContinuousMul`. -/
 @[to_additive]
 class SeparatelyContinuousMul (M : Type*) [TopologicalSpace M] [Mul M] : Prop where
-  continuous_const_mul {a} : Continuous fun b : M => a * b
-  continuous_mul_const {a} : Continuous fun b : M => b * a
+  continuous_const_mul {a : M} : Continuous (a * ·)
+  continuous_mul_const {a : M} : Continuous (· * a)
 
 section ContinuousMul
 

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -113,6 +113,7 @@ section
 
 variable {M : Type*} [TopologicalSpace M] [Mul M]
 
+@[to_additive]
 instance [ContinuousMul M] : SeparatelyContinuousMul M where
   continuous_const_mul := continuous_const.mul continuous_id
   continuous_mul_const := continuous_id.mul continuous_const
@@ -129,12 +130,12 @@ theorem continuous_mul_const (m : M) : Continuous (· * m) :=
 
 @[to_additive]
 theorem Filter.Tendsto.const_mul {α : Type*} {f : α → M} {x : Filter α} {a : M}
-    (hf : Tendsto f x (𝓝 a)) (b : M) : Tendsto (b * f ·) x (𝓝 (b * a)) :=
+    (b : M) (hf : Tendsto f x (𝓝 a)) : Tendsto (b * f ·) x (𝓝 (b * a)) :=
   continuous_const_mul  b |>.tendsto _ |>.comp hf
 
 @[to_additive]
 theorem Filter.Tendsto.mul_const {α : Type*} {f : α → M} {x : Filter α} {a : M}
-    (hf : Tendsto f x (𝓝 a)) (b : M) : Tendsto (f · * b) x (𝓝 (a * b)) :=
+    (b : M) (hf : Tendsto f x (𝓝 a)) : Tendsto (f · * b) x (𝓝 (a * b)) :=
   continuous_mul_const b |>.tendsto _ |>.comp hf
 
 variable {X : Type*} [TopologicalSpace X] {f g : X → M} {s : Set X} {x : X}
@@ -150,22 +151,22 @@ theorem Continuous.const_mul (hf : Continuous f) (b : M) : Continuous (b * f ·)
 @[to_additive (attr := fun_prop)]
 theorem ContinuousWithinAt.mul_const (hf : ContinuousWithinAt f s x) (b : M) :
     ContinuousWithinAt (f · * b) s x :=
-  Filter.Tendsto.mul_const hf b
+  Filter.Tendsto.mul_const b hf
 
 @[to_additive (attr := fun_prop)]
 theorem ContinuousWithinAt.const_mul (hf : ContinuousWithinAt f s x) (b : M) :
     ContinuousWithinAt (b * f ·) s x :=
-  Filter.Tendsto.const_mul hf b
+  Filter.Tendsto.const_mul b hf
 
 @[to_additive (attr := fun_prop)]
 theorem ContinuousAt.mul_const (hf : ContinuousAt f x) (b : M) :
     ContinuousAt (f · * b) x :=
-  Filter.Tendsto.mul_const hf b
+  Filter.Tendsto.mul_const b hf
 
 @[to_additive (attr := fun_prop)]
 theorem ContinuousAt.const_mul (hf : ContinuousAt f x) (b : M) :
     ContinuousAt (b * f ·) x :=
-  Filter.Tendsto.const_mul hf b
+  Filter.Tendsto.const_mul b hf
 
 @[to_additive (attr := fun_prop)]
 theorem ContinuousOn.mul_const (hf : ContinuousOn f s) (b : M) :

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -15,7 +15,7 @@ In this file we define three mixin typeclasses:
 
 - `ContinuousMul M` says that the multiplication on `M` is continuous as a function on `M × M`;
 - `ContinuousAdd M` says that the addition on `M` is continuous as a function on `M × M`.
-- `ContinuousMulConst M` says that the multiplication on `M` is continuous in each argument
+- `SeparatelyContinuousMul M` says that the multiplication on `M` is continuous in each argument
   separately. This is strictly weaker than `ContinuousMul M`, but arises frequently in practice in
   functional analysis where one often considers topologies weaker than the norm topology. In these
   topologies it is frequently the case that the multiplication is not jointly continuous, but is

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Basic.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Basic.lean
@@ -121,7 +121,7 @@ instance : NonarchimedeanRing (R × S) where
   subgroup `V` such that `r • V` is contained in `U`. -/
 theorem left_mul_subset (U : OpenAddSubgroup R) (r : R) :
     ∃ V : OpenAddSubgroup R, r • (V : Set R) ⊆ U :=
-  ⟨U.comap (AddMonoidHom.mulLeft r) (continuous_mul_left r), (U : Set R).image_preimage_subset _⟩
+  ⟨U.comap (AddMonoidHom.mulLeft r) (continuous_const_mul r), (U : Set R).image_preimage_subset _⟩
 
 /-- An open subgroup of a nonarchimedean ring contains the square of another one. -/
 theorem mul_subset (U : OpenAddSubgroup R) : ∃ V : OpenAddSubgroup R, (V : Set R) * V ⊆ U := by

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -165,7 +165,7 @@ lemma limsup_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (bdd_above : F.IsBoundedUnder (· ≤ ·) f) (cobdd : F.IsCoboundedUnder (· ≤ ·) f) :
     Filter.limsup (fun i ↦ c + f i) F = c + Filter.limsup f F :=
   (Monotone.map_limsSup_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ c + x)
-    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_left c).continuousAt bdd_above cobdd).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_const_add c).continuousAt bdd_above cobdd).symm
 
 /-- `limsup (xᵢ + c) = (limsup xᵢ) + c`. -/
 lemma limsup_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -173,7 +173,7 @@ lemma limsup_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (bdd_above : F.IsBoundedUnder (· ≤ ·) f) (cobdd : F.IsCoboundedUnder (· ≤ ·) f) :
     Filter.limsup (fun i ↦ f i + c) F = Filter.limsup f F + c :=
   (Monotone.map_limsSup_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ x + c)
-    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_right c).continuousAt bdd_above cobdd).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_const c).continuousAt bdd_above cobdd).symm
 
 /-- `liminf (c + xᵢ) = c + liminf xᵢ`. -/
 lemma liminf_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -181,7 +181,7 @@ lemma liminf_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (cobdd : F.IsCoboundedUnder (· ≥ ·) f) (bdd_below : F.IsBoundedUnder (· ≥ ·) f) :
     Filter.liminf (fun i ↦ c + f i) F = c + Filter.liminf f F :=
   (Monotone.map_limsInf_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ c + x)
-    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_left c).continuousAt cobdd bdd_below).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_const_add c).continuousAt cobdd bdd_below).symm
 
 /-- `liminf (xᵢ + c) = (liminf xᵢ) + c`. -/
 lemma liminf_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -189,7 +189,7 @@ lemma liminf_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (cobdd : F.IsCoboundedUnder (· ≥ ·) f) (bdd_below : F.IsBoundedUnder (· ≥ ·) f) :
     Filter.liminf (fun i ↦ f i + c) F = Filter.liminf f F + c :=
   (Monotone.map_limsInf_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ x + c)
-    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_right c).continuousAt cobdd bdd_below).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_const c).continuousAt cobdd bdd_below).symm
 
 /-- `limsup (c - xᵢ) = c - liminf xᵢ`. -/
 lemma limsup_const_sub (F : Filter ι) [AddCommSemigroup R] [Sub R] [ContinuousSub R] [OrderedSub R]

--- a/Mathlib/Topology/Algebra/Semigroup.lean
+++ b/Mathlib/Topology/Algebra/Semigroup.lean
@@ -27,7 +27,7 @@ an idempotent, i.e. an `m` such that `m * m = m`. -/
       contains an idempotent, i.e. an `m` such that `m + m = m` -/]
 theorem exists_idempotent_of_compact_t2_of_continuous_mul_left {M} [Nonempty M] [Semigroup M]
     [TopologicalSpace M] [CompactSpace M] [T2Space M]
-    (continuous_mul_left : ∀ r : M, Continuous (· * r)) : ∃ m : M, m * m = m := by
+    (continuous_const_mul : ∀ r : M, Continuous (· * r)) : ∃ m : M, m * m = m := by
   /- We apply Zorn's lemma to the poset of nonempty closed subsemigroups of `M`.
      It will turn out that any minimal element is `{m}` for an idempotent `m : M`. -/
   let S : Set (Set M) :=
@@ -39,7 +39,7 @@ theorem exists_idempotent_of_compact_t2_of_continuous_mul_left {M} [Nonempty M] 
     We first show that every element of `N` is of the form `m' + m`. -/
     have scaling_eq_self : (· * m) '' N = N := by
       apply hN.eq_of_subset
-      · refine ⟨(continuous_mul_left m).isClosedMap _ N_closed, ⟨_, ⟨m, hm, rfl⟩⟩, ?_⟩
+      · refine ⟨(continuous_const_mul m).isClosedMap _ N_closed, ⟨_, ⟨m, hm, rfl⟩⟩, ?_⟩
         rintro _ ⟨m'', hm'', rfl⟩ _ ⟨m', hm', rfl⟩
         exact ⟨m'' * m * m', N_mul _ (N_mul _ hm'' _ hm) _ hm', mul_assoc _ _ _⟩
       · rintro _ ⟨m', hm', rfl⟩
@@ -48,7 +48,7 @@ theorem exists_idempotent_of_compact_t2_of_continuous_mul_left {M} [Nonempty M] 
        to show that this holds for all `m' ∈ N`. -/
     have absorbing_eq_self : N ∩ { m' | m' * m = m } = N := by
       apply hN.eq_of_subset
-      · refine ⟨N_closed.inter ((T1Space.t1 m).preimage (continuous_mul_left m)), ?_, ?_⟩
+      · refine ⟨N_closed.inter ((T1Space.t1 m).preimage (continuous_const_mul m)), ?_, ?_⟩
         · rwa [← scaling_eq_self] at hm
         · rintro m'' ⟨mem'', eq'' : _ = m⟩ m' ⟨mem', eq' : _ = m⟩
           refine ⟨N_mul _ mem'' _ mem', ?_⟩
@@ -79,7 +79,7 @@ in some specified nonempty compact subsemigroup. -/
       `exists_idempotent_of_compact_t2_of_continuous_add_left` where the idempotent lies in
       some specified nonempty compact additive subsemigroup. -/]
 theorem exists_idempotent_in_compact_subsemigroup {M} [Semigroup M] [TopologicalSpace M] [T2Space M]
-    (continuous_mul_left : ∀ r : M, Continuous (· * r)) (s : Set M) (snemp : s.Nonempty)
+    (continuous_const_mul : ∀ r : M, Continuous (· * r)) (s : Set M) (snemp : s.Nonempty)
     (s_compact : IsCompact s) (s_add : ∀ᵉ (x ∈ s) (y ∈ s), x * y ∈ s) :
     ∃ m ∈ s, m * m = m := by
   let M' := { m // m ∈ s }
@@ -89,6 +89,6 @@ theorem exists_idempotent_in_compact_subsemigroup {M} [Semigroup M] [Topological
   haveI : CompactSpace M' := isCompact_iff_compactSpace.mp s_compact
   haveI : Nonempty M' := nonempty_subtype.mpr snemp
   have : ∀ p : M', Continuous (· * p) := fun p =>
-    ((continuous_mul_left p.1).comp continuous_subtype_val).subtype_mk _
+    ((continuous_const_mul p.1).comp continuous_subtype_val).subtype_mk _
   obtain ⟨⟨m, hm⟩, idem⟩ := exists_idempotent_of_compact_t2_of_continuous_mul_left this
   exact ⟨m, hm, Subtype.ext_iff.mp idem⟩

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -191,13 +191,13 @@ theorem map_smul_eq_mul_coe (r : R) :
     Completion.map (r • ·) = ((algebraMap R A r : Completion A) * ·) := by
   ext x
   refine Completion.induction_on x ?_ fun a => ?_
-  · exact isClosed_eq Completion.continuous_map (continuous_mul_left _)
+  · exact isClosed_eq Completion.continuous_map (continuous_const_mul _)
   · simp_rw [map_coe (uniformContinuous_const_smul r) a, Algebra.smul_def, coe_mul]
 
 instance algebra : Algebra R (Completion A) where
   algebraMap := (UniformSpace.Completion.coeRingHom : A →+* Completion A).comp (algebraMap R A)
   commutes' := fun r x =>
-    Completion.induction_on x (isClosed_eq (continuous_mul_left _) (continuous_mul_right _))
+    Completion.induction_on x (isClosed_eq (continuous_const_mul _) (continuous_mul_const _))
       fun a => by
       simpa only [coe_mul] using congr_arg ((↑) : A → Completion A) (Algebra.commutes r a)
   smul_def' := fun r x => congr_fun (map_smul_eq_mul_coe A R r) x

--- a/Mathlib/Topology/Constructions/SumProd.lean
+++ b/Mathlib/Topology/Constructions/SumProd.lean
@@ -520,6 +520,17 @@ theorem frontier_univ_prod_eq (s : Set Y) :
     frontier ((univ : Set X) ×ˢ s) = univ ×ˢ frontier s := by
   simp [frontier_prod_eq]
 
+/-- The hypotheses on `f` are slightly weaker here compared to `mem_map_closure₂`. That
+lemma requires `f` to be jointly continuous, whereas here we only require continuity in each
+variable separately. -/
+theorem map_mem_closure₂' {f : X → Y → Z} {x : X} {y : Y} {s : Set X} {t : Set Y} {u : Set Z}
+    (hf₁ : ∀ x, Continuous (f x)) (hf₂ : ∀ y, Continuous (f · y))
+    (hx : x ∈ closure s) (hy : y ∈ closure t) (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) :
+    f x y ∈ closure u := by
+  rw [← isClosed_closure.closure_eq]
+  apply map_mem_closure (hf₁ x) hy fun b hb ↦ ?_
+  apply map_mem_closure (hf₂ b) hx fun a ha ↦ h a ha b hb
+
 theorem map_mem_closure₂ {f : X → Y → Z} {x : X} {y : Y} {s : Set X} {t : Set Y} {u : Set Z}
     (hf : Continuous (uncurry f)) (hx : x ∈ closure s) (hy : y ∈ closure t)
     (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f x y ∈ closure u :=

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -479,8 +479,8 @@ variable [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [TopologicalSpace 𝕜] [
 /-- The rescaling homeomorphism between additive circles with different periods. -/
 def homeomorphAddCircle (hp : p ≠ 0) (hq : q ≠ 0) : AddCircle p ≃ₜ AddCircle q :=
   ⟨equivAddCircle p q hp hq,
-    (continuous_quotient_mk'.comp (continuous_mul_right (p⁻¹ * q))).quotient_lift _,
-    (continuous_quotient_mk'.comp (continuous_mul_right (q⁻¹ * p))).quotient_lift _⟩
+    (continuous_quotient_mk'.comp (continuous_mul_const (p⁻¹ * q))).quotient_lift _,
+    (continuous_quotient_mk'.comp (continuous_mul_const (q⁻¹ * p))).quotient_lift _⟩
 
 @[simp]
 theorem homeomorphAddCircle_apply_mk (hp : p ≠ 0) (hq : q ≠ 0) (x : 𝕜) :

--- a/MathlibTest/Monotonicity.lean
+++ b/MathlibTest/Monotonicity.lean
@@ -419,7 +419,7 @@ example {x y z w : ℕ} : true := by
 -- example : ∫ x in Icc 0 1, real.exp x ≤ ∫ x in Icc 0 1, real.exp (x+1) := by
 --   mono
 --   · exact real.continuous_exp.locally_integrable.integrable_on_is_compact is_compact_Icc
---   · exact (real.continuous_exp.comp <| continuous_add_right 1)
+--   · exact (real.continuous_exp.comp <| continuous_add_const 1)
 --       .locally_integrable.integrable_on_is_compact is_compact_Icc
 --   intro x
 --   dsimp only


### PR DESCRIPTION
In functional analysis, more specifically operator algebras, one often considers topologies weaker than the norm topology. There are a plethora of these, and virtually none of them satisfy docs#ContinuousMul because multiplication is not jointly continuous, but it *is* continuous in each variable separately. Sometimes multiplication is jointly continuous on bounded sets.

In fact, this separate continuity of multiplication is really the correct hypothesis for a bunch of places where we use `ContinuousMul`. E.g., it is the proper assumption for docs#Set.isClosed_centralizer, but it's also the correct one for working with topological subobjects. Of course, one way to spell this separate continuity is `ContinuousConstSMul α α` and `ContinuousConstSMul αᵐᵒᵖ α`, but this is painful because it means (a) you need to write down both classes whenever you want to prove something about it, and (b) all the generic lemmas are about `•` instead of `*`.

Consequently, in this PR we define classes `SeparatelyContinuousMul` (and `SeparatelyContinuousAdd` via `to_additive`) to encode this weaker form of continuity of multiplication.

---

I've only done a limited amount of generalization here for `Subsemigroup` and `Submonoid`, just to show that the basic material generalizes. In a follow-up PR I will do more generalization using this class.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
