### PR TITLE
[Merged by Bors] - fix(Tactic): make `eta_expand` idempotent

### DIFF
--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -256,6 +256,7 @@ where
     if f.etaExpandedStrict?.isSome then
       expandSubterms (f.beta args)
     else
+      -- We use `expandSubterms` for `f` to avoid creating a beta-redex
       return mkAppN (← expandSubterms f) (← args.mapM etaExpandAll)
   | .mdata d e =>
     return .mdata d (← etaExpandAll e)

--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -227,12 +227,11 @@ As a side-effect, beta reduces any pre-existing instances of eta expanded terms.
 partial def etaExpandAll (e : Expr) : MetaM Expr := do
   let betaOrApp (f : Expr) (args : Array Expr) : Expr :=
     if f.etaExpanded?.isSome then f.beta args else mkAppN f args
-  let expand (e : Expr) : MetaM Expr := do
-    if e.isLambda then
-      return e
-    else
-      forallTelescopeReducing (← inferType e) fun xs _ => do
-        mkLambdaFVars xs (betaOrApp e xs)
+  let rec expand (e : Expr) : MetaM Expr := do
+    forallTelescopeReducing (← inferType e) fun xs _ => do
+      mkLambdaFVars xs (betaOrApp e (← xs.mapM expand))
+  let expandIfNotLambda (e : Expr) : MetaM Expr := do
+    if e.isLambda then return e else expand e
   transform e
     (pre := fun node => do
       if node.isApp then
@@ -241,7 +240,7 @@ partial def etaExpandAll (e : Expr) : MetaM Expr := do
         .done <$> expand (betaOrApp f args)
       else
         pure .continue)
-    (post := (.done <$> expand ·))
+    (post := (.done <$> expandIfNotLambda ·))
 
 /--
 `eta_expand at loc` eta expands all sub-expressions at the given location.

--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -225,22 +225,43 @@ elab "eta_reduce" : conv => runDefEqConvTactic etaReduceAll
 
 As a side-effect, beta reduces any pre-existing instances of eta expanded terms. -/
 partial def etaExpandAll (e : Expr) : MetaM Expr := do
-  let betaOrApp (f : Expr) (args : Array Expr) : Expr :=
-    if f.etaExpanded?.isSome then f.beta args else mkAppN f args
-  let rec expand (e : Expr) : MetaM Expr := do
+  if e.isLambda then
+    expandSubterms e
+  else
     forallTelescopeReducing (← inferType e) fun xs _ => do
-      mkLambdaFVars xs (betaOrApp e (← xs.mapM expand))
-  let expandIfNotLambda (e : Expr) : MetaM Expr := do
-    if e.isLambda then return e else expand e
-  transform e
-    (pre := fun node => do
-      if node.isApp then
-        let f ← etaExpandAll node.getAppFn
-        let args ← node.getAppArgs.mapM etaExpandAll
-        .done <$> expand (betaOrApp f args)
-      else
-        pure .continue)
-    (post := (.done <$> expandIfNotLambda ·))
+      let e := mkAppN (e.instantiate xs) xs
+      mkLambdaFVars xs (← expandSubterms e)
+where
+  expandSubterms
+  | .forallE n t b bi =>
+    return .forallE n
+      (← etaExpandAll t)
+      (← withLocalDecl n bi t fun x => (·.abstract #[x]) <$> etaExpandAll (b.instantiate1 x))
+      bi
+  | .lam n t b bi =>
+    return .lam n
+      (← etaExpandAll t)
+      (← withLocalDecl n bi t fun x => (·.abstract #[x]) <$> etaExpandAll (b.instantiate1 x))
+      bi
+  | .letE n t v b ndep =>
+    return .letE n
+      (← etaExpandAll t)
+      (← etaExpandAll v)
+      (← withLetDecl n t v (nondep := ndep) fun x =>
+        (·.abstract #[x]) <$> etaExpandAll (b.instantiate1 x))
+      ndep
+  | e@(.app ..) =>
+    let f := e.getAppFn
+    let args := e.getAppArgs
+    if f.etaExpandedStrict?.isSome then
+      expandSubterms (f.beta args)
+    else
+      return mkAppN (← expandSubterms f) (← args.mapM etaExpandAll)
+  | .mdata d e =>
+    return .mdata d (← etaExpandAll e)
+  | .proj n i e =>
+    return .proj n i (← etaExpandAll e)
+  | e => return e
 
 /--
 `eta_expand at loc` eta expands all sub-expressions at the given location.

--- a/MathlibTest/DefEqTransformations.lean
+++ b/MathlibTest/DefEqTransformations.lean
@@ -105,6 +105,16 @@ example : (fun (a : Nat) => 1 + a) 2 = (1 + ·) 2 := by
   guard_target =ₛ 1 + 2 = 1 + 2
   rfl
 
+example (f : ((Nat → Nat) → Nat) → Nat) : f = fun _ => 0 := by
+  eta_expand
+  guard_target =ₛ (fun x : (Nat → Nat) → Nat => f (fun y => x fun z => y z)) = fun _ => 0
+  exact test_sorry
+
+example : @id (Nat → Nat) = fun x => x := by
+  eta_expand
+  guard_target =ₛ (fun (x : Nat → Nat) y => id (fun z => x z) y) = fun x y => x y
+  rfl
+
 example (p : Nat × Nat) : (p.1, p.2) = (p.2, p.1) := by
   eta_struct
   guard_target =ₛ p = (p.2, p.1)

--- a/MathlibTest/DefEqTransformations.lean
+++ b/MathlibTest/DefEqTransformations.lean
@@ -105,12 +105,23 @@ example : (fun (a : Nat) => 1 + a) 2 = (1 + ·) 2 := by
   guard_target =ₛ 1 + 2 = 1 + 2
   rfl
 
+example (f : (Nat → Nat) → Nat) : f = fun _ => 0 := by
+  eta_expand
+  guard_target =ₛ (fun x : Nat → Nat => f (fun y => x y)) = fun _ => 0
+  eta_expand
+  guard_target =ₛ (fun x : Nat → Nat => f (fun y => x y)) = fun _ => 0
+  exact test_sorry
+
 example (f : ((Nat → Nat) → Nat) → Nat) : f = fun _ => 0 := by
+  eta_expand
+  guard_target =ₛ (fun x : (Nat → Nat) → Nat => f (fun y => x fun z => y z)) = fun _ => 0
   eta_expand
   guard_target =ₛ (fun x : (Nat → Nat) → Nat => f (fun y => x fun z => y z)) = fun _ => 0
   exact test_sorry
 
 example : @id (Nat → Nat) = fun x => x := by
+  eta_expand
+  guard_target =ₛ (fun (x : Nat → Nat) y => id (fun z => x z) y) = fun x y => x y
   eta_expand
   guard_target =ₛ (fun (x : Nat → Nat) y => id (fun z => x z) y) = fun x y => x y
   rfl


### PR DESCRIPTION
The docstring of `eta_expand` says that it puts terms into a normal form, implying that it is idempontent, however, this is not the case in some tricky cases. This PR changes `eta_expand` so that it gives the normal form in one step.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
