### PR TITLE
refactor(CategoryTheory): FinallySmallFiltered

### DIFF
--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -10,9 +10,10 @@ public import Mathlib.CategoryTheory.Limits.FinallySmall
 /-!
 # Finally small filtered categories
 
-In this file, we show that if `C` is a filtered finally small category
-that is locally small, there exists a final functor `D ⥤ C` from
-a small filtered category. The dual result is also obtained.
+We introduce a typeclass `FinallySmallFiltered.{w} C` saying that
+there exists a final functor `S ⥤ C` where `S` is a `w`-small filtered category.
+We show that if `C` is a filtered finally small category that is locally small,
+then it satisfies `FinallySmallFiltered.{w} C`. The dual result is also obtained.
 
 -/
 
@@ -22,7 +23,97 @@ universe w v u
 
 namespace CategoryTheory
 
+open Functor
+
+/-- A category is `FinallySmallFiltered.{w}` if there is a final functor
+from a filtered `w`-small category. -/
+class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
+  /-- There is a final functor from a small filtered category. -/
+  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+    (_ : IsFiltered S) (F : S ⥤ C), F.Final
+
+/-- A category is `InitiallySmallCofiltered.{w}` if there is an initial functor
+from a cofiltered `w`-small category. -/
+class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
+  /-- There is an initial functor from a small cofiltered category. -/
+  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+    (_ : IsCofiltered S) (F : S ⥤ C), F.Initial
+
 variable (C : Type u) [Category.{v} C]
+
+section
+
+variable [FinallySmallFiltered.{w} C]
+
+/-- If a category `C` satisfies `FinallySmallFiltered.{w} C`, this is
+a `w`-small filtered category equipped with a final functor
+`fromFilteredFinalModel C`. -/
+def FilteredFinalModel : Type w :=
+  (FinallySmallFiltered.final_smallCategory C).choose
+
+noncomputable instance : SmallCategory (FilteredFinalModel.{w} C) :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose
+
+noncomputable instance : IsFiltered (FilteredFinalModel.{w} C) :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose
+
+/-- If a category `C` satisfies `FinallySmallFiltered.{w} C`, this is
+a final functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
+noncomputable def fromFilteredFinalModel : FilteredFinalModel.{w} C ⥤ C :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+
+instance : (fromFilteredFinalModel.{w} C).Final :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+
+instance : FinallySmall.{w} C :=
+  finallySmall_of_final_of_essentiallySmall (fromFilteredFinalModel.{w} C)
+
+@[deprecated (since := "2026-02-21")]
+alias FinallySmall.FilteredFinalModel := FilteredFinalModel
+@[deprecated (since := "2026-02-21")]
+alias FinallySmall.fromFilteredFinalModel := fromFilteredFinalModel
+
+end
+
+section
+
+variable [InitiallySmallCofiltered.{w} C]
+
+/-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
+a `w`-small cofiltered category equipped with an initial functor
+`fromCofilteredInitialModel C`. -/
+def CofilteredInitialModel : Type w :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose
+
+noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose
+
+noncomputable instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose
+
+/-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
+an initial functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
+noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+
+instance : (fromCofilteredInitialModel.{w} C).Initial :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+
+instance : InitiallySmall.{w} C :=
+  initiallySmall_of_initial_of_essentiallySmall (fromCofilteredInitialModel.{w} C)
+
+@[deprecated (since := "2026-02-21")]
+alias InitiallySmall.CofilteredInitialModel := CofilteredInitialModel
+@[deprecated (since := "2026-02-21")]
+alias InitiallySmall.fromCofilteredInitialModel := fromCofilteredInitialModel
+
+end
+
+instance [InitiallySmallCofiltered.{w} C] :
+    FinallySmallFiltered.{w} Cᵒᵖ := sorry
+
+instance [FinallySmallFiltered.{w} C] :
+    InitiallySmallCofiltered.{w} Cᵒᵖ := sorry
 
 namespace FinallySmall
 
@@ -82,24 +173,8 @@ lemma exists_of_isFiltered :
     (of_equivalence e) (finallySmall_of_final_of_finallySmall e.functor)
   exact ⟨D, inferInstance, inferInstance, F ⋙ e.inverse, inferInstance⟩
 
-/-- If `C` is a locally small filtered finally small category,
-this is a small filtered category, equipped with a final functor to `C`
-(see `fromFilteredFinalModel`). -/
-def FilteredFinalModel : Type w := (exists_of_isFiltered.{w} C).choose
-
-noncomputable instance : Category (FilteredFinalModel.{w} C) :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose
-
-instance : IsFiltered (FilteredFinalModel.{w} C) :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose
-
-/-- If `C` is a locally small filtered finally small category,
-this is a final functor from a small filtered category. -/
-noncomputable def fromFilteredFinalModel : FilteredFinalModel.{w} C ⥤ C :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose_spec.choose
-
-instance : (fromFilteredFinalModel.{w} C).Final :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose_spec.choose_spec
+instance : FinallySmallFiltered.{w} C where
+  final_smallCategory := exists_of_isFiltered C
 
 end FinallySmall
 
@@ -112,24 +187,8 @@ lemma exists_of_isCofiltered :
   obtain ⟨D, _, _, F, _⟩ := FinallySmall.exists_of_isFiltered.{w} Cᵒᵖ
   exact ⟨Dᵒᵖ, inferInstance, inferInstance, F.leftOp, inferInstance⟩
 
-/-- If `C` is a locally small cofiltered initially small category,
-this is a small cofiltered category, equipped with an initial functor to `C`
-(see `fromCofilteredInitialModel`). -/
-def CofilteredInitialModel : Type w := (exists_of_isCofiltered.{w} C).choose
-
-noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose
-
-instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose
-
-/-- If `C` is a locally small cofiltered initially small category,
-this is an initial functor from a small cofiltered category. -/
-noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose_spec.choose
-
-instance : (fromCofilteredInitialModel.{w} C).Initial :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose_spec.choose_spec
+instance : InitiallySmallCofiltered.{w} C where
+  final_smallCategory := exists_of_isCofiltered C
 
 end InitiallySmall
 

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -27,6 +27,7 @@ open Functor
 
 /-- A category is `FinallySmallFiltered.{w}` if there is a final functor
 from a filtered `w`-small category. -/
+@[pp_with_univ]
 class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is a final functor from a small filtered category. -/
   final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
@@ -34,6 +35,7 @@ class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
 
 /-- A category is `InitiallySmallCofiltered.{w}` if there is an initial functor
 from a cofiltered `w`-small category. -/
+@[pp_with_univ]
 class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is an initial functor from a small cofiltered category. -/
   initial_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
@@ -124,7 +126,6 @@ lemma initiallySmallCofiltered_of_initial {C₀ : Type*} [Category* C₀] (F : C
   initial_smallCategory :=
     ⟨_, inferInstance, IsCofiltered.of_equivalence (equivSmallModel.{w} C₀),
       (equivSmallModel.{w} C₀).inverse ⋙ F, inferInstance⟩
-
 
 instance [InitiallySmallCofiltered.{w} C] :
     FinallySmallFiltered.{w} Cᵒᵖ :=

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -19,7 +19,7 @@ then it satisfies `FinallySmallFiltered.{w} C`. The dual result is also obtained
 
 @[expose] public section
 
-universe w v u
+universe w v' u' v u
 
 namespace CategoryTheory
 
@@ -36,7 +36,7 @@ class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
 from a cofiltered `w`-small category. -/
 class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is an initial functor from a small cofiltered category. -/
-  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+  initial_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
     (_ : IsCofiltered S) (F : S ⥤ C), F.Initial
 
 variable (C : Type u) [Category.{v} C]
@@ -83,21 +83,21 @@ variable [InitiallySmallCofiltered.{w} C]
 a `w`-small cofiltered category equipped with an initial functor
 `fromCofilteredInitialModel C`. -/
 def CofilteredInitialModel : Type w :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose
 
 noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose
 
 noncomputable instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose
 
 /-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
 an initial functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
 noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose_spec.choose
 
 instance : (fromCofilteredInitialModel.{w} C).Initial :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
 
 instance : InitiallySmall.{w} C :=
   initiallySmall_of_initial_of_essentiallySmall (fromCofilteredInitialModel.{w} C)
@@ -109,11 +109,30 @@ alias InitiallySmall.fromCofilteredInitialModel := fromCofilteredInitialModel
 
 end
 
+variable {C} in
+lemma finallySmallFiltered_of_final {C₀ : Type*} [Category* C₀] (F : C₀ ⥤ C)
+    [IsFiltered C₀] [EssentiallySmall.{w} C₀] [F.Final] :
+    FinallySmallFiltered.{w} C where
+  final_smallCategory :=
+    ⟨_, inferInstance, IsFiltered.of_equivalence (equivSmallModel.{w} C₀),
+      (equivSmallModel.{w} C₀).inverse ⋙ F, inferInstance⟩
+
+variable {C} in
+lemma initiallySmallCofiltered_of_initial {C₀ : Type*} [Category* C₀] (F : C₀ ⥤ C)
+    [IsCofiltered C₀] [EssentiallySmall.{w} C₀] [F.Initial] :
+    InitiallySmallCofiltered.{w} C where
+  initial_smallCategory :=
+    ⟨_, inferInstance, IsCofiltered.of_equivalence (equivSmallModel.{w} C₀),
+      (equivSmallModel.{w} C₀).inverse ⋙ F, inferInstance⟩
+
+
 instance [InitiallySmallCofiltered.{w} C] :
-    FinallySmallFiltered.{w} Cᵒᵖ := sorry
+    FinallySmallFiltered.{w} Cᵒᵖ :=
+  finallySmallFiltered_of_final (fromCofilteredInitialModel.{w} C).op
 
 instance [FinallySmallFiltered.{w} C] :
-    InitiallySmallCofiltered.{w} Cᵒᵖ := sorry
+    InitiallySmallCofiltered.{w} Cᵒᵖ :=
+  initiallySmallCofiltered_of_initial (fromFilteredFinalModel.{w} C).op
 
 namespace FinallySmall
 

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -207,7 +207,7 @@ lemma exists_of_isCofiltered :
   exact ⟨Dᵒᵖ, inferInstance, inferInstance, F.leftOp, inferInstance⟩
 
 instance : InitiallySmallCofiltered.{w} C where
-  final_smallCategory := exists_of_isCofiltered C
+  initial_smallCategory := exists_of_isCofiltered C
 
 end InitiallySmall
 

--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -88,7 +88,7 @@ instance : HasColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
 instance [LocallySmall.{w} C] [AB5OfSize.{w, w} A] [HasFiniteLimits A] :
     HasExactColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
   hasExactColimitsOfShape_of_final _
-    (FinallySmall.fromFilteredFinalModel Φ.fiber.Elementsᵒᵖ)
+    (fromFilteredFinalModel Φ.fiber.Elementsᵒᵖ)
 
 /-- The fiber functor on categories of presheaves that is given by a point of a site. -/
 noncomputable def presheafFiber : (Cᵒᵖ ⥤ A) ⥤ A :=
@@ -162,7 +162,7 @@ variable {P Q : Cᵒᵖ ⥤ A}
 variable [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C]
 
 instance : PreservesColimitsOfShape Φ.fiber.Elementsᵒᵖ (forget A) :=
-  Functor.Final.preservesColimitsOfShape_of_final (FinallySmall.fromFilteredFinalModel.{w} _) _
+  Functor.Final.preservesColimitsOfShape_of_final (fromFilteredFinalModel.{w} _) _
 
 lemma toPresheafFiber_jointly_surjective (p : ToType (Φ.presheafFiber.obj P)) :
     ∃ (X : C) (x : Φ.fiber.obj X) (z : ToType (P.obj (op X))),
@@ -298,7 +298,7 @@ noncomputable def presheafFiberCompIso :
     (Functor.whiskeringRight _ _ _).obj F ⋙ Φ.presheafFiber ≅
       Φ.presheafFiber ⋙ F :=
   haveI := Functor.Final.preservesColimitsOfShape_of_final
-    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+    (fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
   Functor.isoWhiskerLeft
     ((Functor.whiskeringLeft _ _ _).obj _) (preservesColimitNatIso F).symm
 
@@ -308,7 +308,7 @@ lemma toPresheafFiber_presheafFiberCompIso_hom_app
     Φ.toPresheafFiber X x (P ⋙ F) ≫ (Φ.presheafFiberCompIso F).hom.app P =
       F.map (Φ.toPresheafFiber X x P) := by
   haveI := Functor.Final.preservesColimitsOfShape_of_final
-    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+    (fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
   simp only [presheafFiberCompIso]
   exact ι_preservesColimitIso_inv F ((CategoryOfElements.π Φ.fiber).op ⋙ P) _
 


### PR DESCRIPTION
This PR introduces a typeclass `FinallySmallFiltered.{w} C` saying that there exists a final functor `S ⥤ C` with `S` `w`-small and filtered. The dual notion is also added.
This shall be used in a future PR in order to weaken the assumptions in the definition of points of Grothendieck sites (replacing `InitiallySmall` and `IsCofiltered` by `InitiallySmallCofiltered`, because in the case of the smooth étale site, the relevant category of elements will satisfy `InitiallySmallCofiltered` but not `IsCofiltered`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
