### PR TITLE
[Merged by Bors] - ci(emojibot): enable Zulip emoji reactions for mathlib4-nightly-testing

### DIFF
--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   update_ci_emoji:
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' ||
+        github.repository == 'leanprover-community/mathlib4-nightly-testing'
     steps:
     - name: Determine PR number
       id: pr
@@ -75,7 +76,7 @@ jobs:
       if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: master
+        ref: ${{ github.event.repository.default_branch }}
         sparse-checkout: |
           scripts/zulip_emoji_reactions.py
 

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -20,7 +20,8 @@ jobs:
 
     name: Add closed-pr emoji in Zulip
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' ||
+        github.repository == 'leanprover-community/mathlib4-nightly-testing'
     steps:
       - name: Debugging information
         run: |
@@ -48,7 +49,7 @@ jobs:
                 github.event_name == 'reopened' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
             scripts/zulip_emoji_reactions.py
 

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -12,13 +12,14 @@ jobs:
   # add resp. remove the matching emoji reaction from zulip messages.
   set_pr_emoji:
     if: (github.event.label.name == 'awaiting-author' || github.event.label.name == 'maintainer-merge') &&
-        github.repository == 'leanprover-community/mathlib4'
+        (github.repository == 'leanprover-community/mathlib4' ||
+         github.repository == 'leanprover-community/mathlib4-nightly-testing')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout mathlib repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
             scripts/zulip_emoji_reactions.py
 

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - master
+      - nightly-testing
       - bump/*
 
 jobs:
   zulip-emoji-merged:
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' ||
+        github.repository == 'leanprover-community/mathlib4-nightly-testing'
 
     steps:
     - name: Checkout mathlib repository

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import zulip
+import os
 import re
 import json
 
@@ -87,7 +88,8 @@ print(f"reviewers_response:{reviewers_response}")
 messages = (public_response['messages']) + (reviewers_response['messages'])
 
 hashPR = re.compile(f'#{PR_NUMBER}')
-urlPR = re.compile(f'https://github.com/leanprover-community/mathlib4/pull/{PR_NUMBER}')
+GITHUB_REPO = os.environ.get('GITHUB_REPOSITORY', 'leanprover-community/mathlib4')
+urlPR = re.compile(f'https://github.com/{re.escape(GITHUB_REPO)}/pull/{PR_NUMBER}')
 
 print(f"Searching for: '{urlPR}'")
 


### PR DESCRIPTION
This PR enables the Zulip emojibot (CI status, merge/close, label reactions) for PRs in the `mathlib4-nightly-testing` repository.

Changes:
- Add `mathlib4-nightly-testing` to repository guards in all 4 emoji workflow files
- Update hardcoded `ref: master` checkout refs to use `github.event.repository.default_branch`
- Add `nightly-testing` branch to the merge-delegate workflow's push trigger
- Extend the URL regex in `zulip_emoji_reactions.py` to match `mathlib4-nightly-testing` PR URLs

The `ZULIP_API_KEY` secret is already configured in the nightly-testing repo.

🤖 Prepared with Claude Code