### PR TITLE
[Merged by Bors] - feat(SimpleGraph/Walks/Operations): `p.dropLast.support` lemmas

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -695,7 +695,6 @@ lemma concat_dropLast (p : G.Walk u v) (hp : G.Adj p.penultimate v) :
     u :: p.tail.support = p.support := by
   rw [← support_cons (p.adj_snd hp), cons_tail_eq _ hp]
 
-@[simp]
 theorem support_dropLast_concat {p : G.Walk u v} (hp : ¬p.Nil) :
     p.dropLast.support.concat v = p.support := by
   nth_rw 3 [← p.concat_dropLast <| adj_penultimate hp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -695,11 +695,13 @@ lemma concat_dropLast (p : G.Walk u v) (hp : G.Adj p.penultimate v) :
     u :: p.tail.support = p.support := by
   rw [← support_cons (p.adj_snd hp), cons_tail_eq _ hp]
 
+@[simp]
 theorem support_dropLast_concat {p : G.Walk u v} (hp : ¬p.Nil) :
     p.dropLast.support.concat v = p.support := by
   nth_rw 3 [← p.concat_dropLast <| adj_penultimate hp]
   rw [support_concat]
 
+@[simp]
 theorem support_dropLast {p : G.Walk u v} (hp : ¬p.Nil) :
     p.dropLast.support = p.support.dropLast := by
   simp [← support_dropLast_concat hp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -695,6 +695,15 @@ lemma concat_dropLast (p : G.Walk u v) (hp : G.Adj p.penultimate v) :
     u :: p.tail.support = p.support := by
   rw [← support_cons (p.adj_snd hp), cons_tail_eq _ hp]
 
+theorem support_dropLast_concat {p : G.Walk u v} (hp : ¬p.Nil) :
+    p.dropLast.support.concat v = p.support := by
+  nth_rw 3 [← p.concat_dropLast <| adj_penultimate hp]
+  rw [support_concat]
+
+theorem support_dropLast {p : G.Walk u v} (hp : ¬p.Nil) :
+    p.dropLast.support = p.support.dropLast := by
+  simp [← support_dropLast_concat hp]
+
 @[simp] lemma length_tail_add_one {p : G.Walk u v} (hp : ¬ p.Nil) :
     p.tail.length + 1 = p.length := by
   rw [← length_cons (p.adj_snd hp), cons_tail_eq _ hp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -696,8 +696,8 @@ lemma concat_dropLast (p : G.Walk u v) (hp : G.Adj p.penultimate v) :
   rw [← support_cons (p.adj_snd hp), cons_tail_eq _ hp]
 
 theorem support_dropLast_concat {p : G.Walk u v} (hp : ¬p.Nil) :
-    p.dropLast.support.concat v = p.support := by
-  rw [← support_concat _ <| adj_penultimate hp, concat_dropLast]
+    p.dropLast.support ++ [v] = p.support := by
+  rw [← List.concat_eq_append, ← support_concat _ <| adj_penultimate hp, concat_dropLast]
 
 @[simp]
 theorem support_dropLast {p : G.Walk u v} (hp : ¬p.Nil) :

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -697,8 +697,7 @@ lemma concat_dropLast (p : G.Walk u v) (hp : G.Adj p.penultimate v) :
 
 theorem support_dropLast_concat {p : G.Walk u v} (hp : ¬p.Nil) :
     p.dropLast.support.concat v = p.support := by
-  nth_rw 3 [← p.concat_dropLast <| adj_penultimate hp]
-  rw [support_concat]
+  rw [← support_concat _ <| adj_penultimate hp, concat_dropLast]
 
 @[simp]
 theorem support_dropLast {p : G.Walk u v} (hp : ¬p.Nil) :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
