### PR TITLE
feat: limit the use of Classical.choice

### DIFF
--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -48,9 +48,11 @@ theorem dedup_cons' (a : α) (l : List α) :
 @[simp]
 theorem mem_dedup {a : α} {l : List α} : a ∈ dedup l ↔ a ∈ l := by
   have := not_congr (@forall_mem_pwFilter α (· ≠ ·) _ ?_ a l)
-  · simpa only [dedup, forall_mem_ne, not_not] using this
+  · simpa only [dedup, forall_mem_ne, Decidable.not_not] using this
   · intro x y z xz
-    exact not_and_or.1 <| mt (fun h ↦ h.1.trans h.2) xz
+    by_cases hxy : x = y
+    · simp_all
+    · simp [hxy]
 
 @[simp]
 theorem dedup_cons_of_mem {a : α} {l : List α} (h : a ∈ l) : dedup (a :: l) = dedup l :=

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -226,8 +226,8 @@ theorem nodup_attach {l : List α} : Nodup (attach l) ↔ Nodup l :=
 protected alias ⟨Nodup.of_attach, Nodup.attach⟩ := nodup_attach
 
 theorem Nodup.pmap {p : α → Prop} {f : ∀ a, p a → β} {l : List α} {H}
-    (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) := by
-  grind
+    (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) :=
+  Pairwise.pmap h H fun _ _ _ _ hxy hEq ↦ hxy (hf _ _ _ _ hEq)
 
 theorem Nodup.filter (p : α → Bool) {l} : Nodup l → Nodup (filter p l) := by
   simpa using Pairwise.filter p

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -140,8 +140,14 @@ theorem nodup_iff_count_le_one [BEq α] [LawfulBEq α] {l : List α} : Nodup l �
       have : replicate 2 a <+ l ↔ 1 < count a l := replicate_sublist_iff ..
       (not_congr this).trans Nat.not_lt
 
-theorem nodup_iff_count_eq_one [BEq α] [LawfulBEq α] : Nodup l ↔ ∀ a ∈ l, count a l = 1 :=
-  nodup_iff_count_le_one.trans <| forall_congr' fun x => by rw [← count_pos_iff]; grind
+theorem nodup_iff_count_eq_one [BEq α] [LawfulBEq α] : Nodup l ↔ ∀ a ∈ l, count a l = 1 := by
+  refine nodup_iff_count_le_one.trans <| forall_congr' fun x => ?_
+  rw [← count_pos_iff]
+  refine ⟨fun _ _ ↦ by omega, fun h ↦ ?_⟩
+  simp only [count_pos_iff] at h
+  by_cases hx : x ∈ l
+  · simp_all
+  · simp_all [count_eq_zero_of_not_mem hx]
 
 theorem get_bijective_iff [BEq α] [LawfulBEq α] : l.get.Bijective ↔ ∀ a, l.count a = 1 :=
   ⟨fun h a ↦ (nodup_iff_count_eq_one.mp <| nodup_iff_injective_get.mpr h.injective)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,7 +6,7 @@ open Lake DSL
 ## Mathlib dependencies on upstream projects
 -/
 
-require "leanprover-community" / "batteries" @ git "main"
+require "leanprover-community" / "batteries" @ git "riccardo/less_choice"
 require "leanprover-community" / "Qq" @ git "master"
 require "leanprover-community" / "aesop" @ git "master"
 require "leanprover-community" / "proofwidgets" @ git "v0.0.88" -- ProofWidgets should always be pinned to a specific version

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0-rc1
+leanprover/lean4-pr-releases:pr-release-12637-5718b14

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-12637-1091212
+leanprover/lean4-pr-releases:pr-release-12637-b58546e

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-12637-5718b14
+leanprover/lean4-pr-releases:pr-release-12637-1091212


### PR DESCRIPTION
A version of `mathlib` that try to limit the use of the axiom of choice. It uses the toolchain of [lean4#12637](https://github.com/leanprover/lean4/pull/12637) and `batteries` from [batteries#1690](https://github.com/leanprover-community/batteries/pull/1690).