### PR TITLE
[Merged by Bors] - chore(Algebra): make `TensorProduct.equivOfCompatibleSMul` more linear

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -114,6 +114,15 @@ def lidOfCompatibleSMul : A ⊗[R] M ≃ₗ[A] M :=
 
 theorem lidOfCompatibleSMul_tmul (a m) : lidOfCompatibleSMul R A M (a ⊗ₜ[R] m) = a • m := rfl
 
+variable {R} in
+lemma CompatibleSMul.of_algebraMap_surjective {A : Type*} [CommSemiring A] [Algebra R A]
+    [Module A M] [IsScalarTower R A M] [Module A N] [IsScalarTower R A N]
+    (h : Function.Surjective (algebraMap R A)) :
+    CompatibleSMul R A M N where
+  smul_tmul a m n := by
+    obtain ⟨r, rfl⟩ := h a
+    simp [smul_tmul]
+
 end CompatibleSMul
 
 open LinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -110,7 +110,7 @@ variable (R A M N) [CommSemiring A] [Module A M] [Module A N]
 /-- If the R- and A- action on A and M satisfy `CompatibleSMul` both ways,
 then `A ⊗[R] M` is canonically isomorphic to `M`. -/
 def lidOfCompatibleSMul : A ⊗[R] M ≃ₗ[A] M :=
-  (equivOfCompatibleSMul R A A M).symm ≪≫ₗ TensorProduct.lid _ _
+  (equivOfCompatibleSMul R A A A M).symm ≪≫ₗ TensorProduct.lid _ _
 
 theorem lidOfCompatibleSMul_tmul (a m) : lidOfCompatibleSMul R A M (a ⊗ₜ[R] m) = a • m := rfl
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -339,7 +339,7 @@ alias mapOfCompatibleSMul' := mapOfCompatibleSMul
 
 /-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,
 then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N` as `S`-modules,
-where `S` is another ring whose actions on `M` and `N` commute with the `A`-actions. -/
+where `S` is any other ring acting on `M` and whose action commutes with the `A` and `R`-actions. -/
 def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[S] M ⊗[R] N where
   __ := mapOfCompatibleSMul R A S M N
   invFun := mapOfCompatibleSMul A R S M N

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -310,7 +310,7 @@ variable (R) (A S M N : Type*) [AddCommMonoid M] [AddCommMonoid N] [Module R M]
 /-- If M and N are both R- and A-modules and their actions on them commute,
 and if the A-action on `M ⊗[R] N` can switch between the two factors, then there is a
 canonical S-linear map from `M ⊗[A] N` to `M ⊗[R] N`,
-where `S` is another ring whose actions on `M` and `N` commute with the `A`-actions. -/
+where `S` is any other ring acting on `M` and whose action commute with the `A` and `R`-actions. -/
 def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
   __ :=
     lift (σ₁₂ := RingHom.id A)

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -310,7 +310,7 @@ variable (R) (A S M N : Type*) [AddCommMonoid M] [AddCommMonoid N] [Module R M]
 /-- If M and N are both R- and A-modules and their actions on them commute,
 and if the A-action on `M ⊗[R] N` can switch between the two factors, then there is a
 canonical S-linear map from `M ⊗[A] N` to `M ⊗[R] N`,
-where `S` is any other ring acting on `M` and whose action commute with the `A` and `R`-actions. -/
+where `S` is any other ring acting on `M` and whose action commutes with the `A` and `R`-actions. -/
 def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
   __ :=
     lift (σ₁₂ := RingHom.id A)

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -302,40 +302,46 @@ end
 
 section CompatibleSMul
 
-variable (R A M N) [CommSemiring A] [Module A M] [Module A N] [SMulCommClass R A M]
+variable (R) (A : Type*) (S : Type*) (M : Type*) (N : Type*)
+  [AddCommMonoid M] [AddCommMonoid N] [Module R M]
+  [Module R N] [CommSemiring A] [Module A M] [Module A N] [SMulCommClass R A M]
+  [CommSemiring S] [Module S M] [SMulCommClass R S M] [SMulCommClass A S M]
   [CompatibleSMul R A M N]
 
 /-- If M and N are both R- and A-modules and their actions on them commute,
 and if the A-action on `M ⊗[R] N` can switch between the two factors, then there is a
-canonical A-linear map from `M ⊗[A] N` to `M ⊗[R] N`. -/
-def mapOfCompatibleSMul : M ⊗[A] N →ₗ[A] M ⊗[R] N :=
-  lift
-  { toFun := fun m ↦
-    { __ := mk R M N m
-      map_smul' := fun _ _ ↦ (smul_tmul _ _ _).symm }
-    map_add' := fun _ _ ↦ LinearMap.ext <| by simp
-    map_smul' := fun _ _ ↦ rfl }
+canonical S-linear map from `M ⊗[A] N` to `M ⊗[R] N`. -/
+def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
+  __ :=
+    lift (σ₁₂ := RingHom.id A)
+    { toFun := fun m ↦
+      { __ := mk R M N m
+        map_smul' := fun _ _ ↦ (smul_tmul _ _ _).symm }
+      map_add' := fun _ _ ↦ LinearMap.ext <| by simp
+      map_smul' := fun _ _ ↦ rfl }
+  map_smul' s x := by
+    induction x with
+    | zero => simp
+    | add x y _ _ => simp_all
+    | tmul x y => simp [smul_tmul']
 
-@[simp] theorem mapOfCompatibleSMul_tmul (m n) : mapOfCompatibleSMul R A M N (m ⊗ₜ n) = m ⊗ₜ n :=
+@[simp] theorem mapOfCompatibleSMul_tmul (m n) : mapOfCompatibleSMul R A S M N (m ⊗ₜ n) = m ⊗ₜ n :=
   rfl
 
-theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R A M N) :=
+theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R A S M N) :=
   fun x ↦ x.induction_on (⟨0, map_zero _⟩) (fun m n ↦ ⟨_, mapOfCompatibleSMul_tmul ..⟩)
     fun _ _ ⟨x, hx⟩ ⟨y, hy⟩ ↦ ⟨x + y, by simpa using congr($hx + $hy)⟩
 
 attribute [local instance] SMulCommClass.symm
 
-/-- `mapOfCompatibleSMul R A M N` is also R-linear. -/
-def mapOfCompatibleSMul' : M ⊗[A] N →ₗ[R] M ⊗[R] N where
-  __ := mapOfCompatibleSMul R A M N
-  map_smul' _ x := x.induction_on (map_zero _) (fun _ _ ↦ by simp [smul_tmul'])
-    fun _ _ h h' ↦ by simpa using congr($h + $h')
+@[deprecated (since := "2026-02-21")]
+alias mapOfCompatibleSMul':= mapOfCompatibleSMul
 
 /-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,
 then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N`. -/
-def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[A] M ⊗[R] N where
-  __ := mapOfCompatibleSMul R A M N
-  invFun := mapOfCompatibleSMul A R M N
+def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[S] M ⊗[R] N where
+  __ := mapOfCompatibleSMul R A S M N
+  invFun := mapOfCompatibleSMul A R S M N
   left_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)
     fun _ _ h h' ↦ by simpa using congr($h + $h')
   right_inv x := x.induction_on (map_zero _) (fun _ _ ↦ rfl)

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -302,8 +302,7 @@ end
 
 section CompatibleSMul
 
-variable (R) (A : Type*) (S : Type*) (M : Type*) (N : Type*)
-  [AddCommMonoid M] [AddCommMonoid N] [Module R M]
+variable (R) (A S M N : Type*) [AddCommMonoid M] [AddCommMonoid N] [Module R M]
   [Module R N] [CommSemiring A] [Module A M] [Module A N] [SMulCommClass R A M]
   [CommSemiring S] [Module S M] [SMulCommClass R S M] [SMulCommClass A S M]
   [CompatibleSMul R A M N]

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -334,7 +334,7 @@ theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMu
 attribute [local instance] SMulCommClass.symm
 
 @[deprecated (since := "2026-02-21")]
-alias mapOfCompatibleSMul':= mapOfCompatibleSMul
+alias mapOfCompatibleSMul' := mapOfCompatibleSMul
 
 /-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,
 then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N`. -/

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -309,7 +309,8 @@ variable (R) (A S M N : Type*) [AddCommMonoid M] [AddCommMonoid N] [Module R M]
 
 /-- If M and N are both R- and A-modules and their actions on them commute,
 and if the A-action on `M ⊗[R] N` can switch between the two factors, then there is a
-canonical S-linear map from `M ⊗[A] N` to `M ⊗[R] N`. -/
+canonical S-linear map from `M ⊗[A] N` to `M ⊗[R] N`,
+where `S` is another ring whose actions on `M` and `N` commute with the `A`-actions. -/
 def mapOfCompatibleSMul : M ⊗[A] N →ₗ[S] M ⊗[R] N where
   __ :=
     lift (σ₁₂ := RingHom.id A)

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -333,7 +333,7 @@ theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMu
 
 attribute [local instance] SMulCommClass.symm
 
-@[deprecated (since := "2026-02-21")]
+@[deprecated "with (S := R)" (since := "2026-02-21")]
 alias mapOfCompatibleSMul' := mapOfCompatibleSMul
 
 /-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -338,7 +338,8 @@ attribute [local instance] SMulCommClass.symm
 alias mapOfCompatibleSMul' := mapOfCompatibleSMul
 
 /-- If the R- and A-actions on M and N satisfy `CompatibleSMul` both ways,
-then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N`. -/
+then `M ⊗[A] N` is canonically isomorphic to `M ⊗[R] N` as `S`-modules,
+where `S` is another ring whose actions on `M` and `N` commute with the `A`-actions. -/
 def equivOfCompatibleSMul [CompatibleSMul A R M N] : M ⊗[A] N ≃ₗ[S] M ⊗[R] N where
   __ := mapOfCompatibleSMul R A S M N
   invFun := mapOfCompatibleSMul A R S M N

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -101,8 +101,8 @@ private lemma coassoc :
         (AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _ _ _)
   let F' : A ⊗[S] (A ⊗[S] A) ⊗[R] (B ⊗[R] (B ⊗[R] B)) →ₗ[S]
       A ⊗[R] B ⊗[S] (A ⊗[R] B ⊗[S] (A ⊗[R] B)) :=
-    TensorProduct.mapOfCompatibleSMul _ _ _ _ _ ∘ₗ
-        TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _ _) ∘ₗ F.toLinearMap
+    TensorProduct.mapOfCompatibleSMul .. ∘ₗ
+        TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul ..) ∘ₗ F.toLinearMap
   convert congr(F ($(Coalgebra.coassoc_apply x) ⊗ₜ[R] $(Coalgebra.coassoc_apply y))) using 1
   · dsimp
     hopf_tensor_induction comul (R := S) x with x₁ x₂

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -101,8 +101,8 @@ private lemma coassoc :
         (AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _ _ _)
   let F' : A ⊗[S] (A ⊗[S] A) ⊗[R] (B ⊗[R] (B ⊗[R] B)) →ₗ[S]
       A ⊗[R] B ⊗[S] (A ⊗[R] B ⊗[S] (A ⊗[R] B)) :=
-    TensorProduct.mapOfCompatibleSMul _ _ _ _ ∘ₗ
-        TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _) ∘ₗ F.toLinearMap
+    TensorProduct.mapOfCompatibleSMul _ _ _ _ _ ∘ₗ
+        TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _ _) ∘ₗ F.toLinearMap
   convert congr(F ($(Coalgebra.coassoc_apply x) ⊗ₜ[R] $(Coalgebra.coassoc_apply y))) using 1
   · dsimp
     hopf_tensor_induction comul (R := S) x with x₁ x₂

--- a/Mathlib/RingTheory/LinearDisjoint.lean
+++ b/Mathlib/RingTheory/LinearDisjoint.lean
@@ -678,7 +678,7 @@ theorem _root_.Algebra.TensorProduct.not_isField_of_transcendental
   replace htb : Function.Injective gb := transcendental_iff_injective.1 htb
   have htab : Function.Injective gab := hfa.comp hta
   algebraize_only [ga.toRingHom, gb.toRingHom]
-  let f := Algebra.TensorProduct.mapOfCompatibleSMul R[X] R A B
+  let f := Algebra.TensorProduct.mapOfCompatibleSMul R[X] R R A B
   haveI := Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_isDomain R[X] A B hta htb
   have hf : Function.Injective f := RingHom.injective _
   have key2 : gab.range ≤ fa.range ⊓ fb.range := by

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -120,18 +120,18 @@ instance (N N') [AddCommMonoid N] [Module R N] [AddCommMonoid N'] [Module R N'] 
 tensoring them over `R`. -/
 noncomputable def moduleTensorEquiv : M₁ ⊗[A] M₂ ≃ₗ[A] M₁ ⊗[R] M₂ :=
   have := tensorProduct_compatibleSMul S A M₁ M₂
-  equivOfCompatibleSMul R A M₁ M₂
+  equivOfCompatibleSMul R A A M₁ M₂
 
 /-- If `A` is a localization of `R`, tensoring an `A`-module with `A` over `R` does nothing. -/
 noncomputable def moduleLid : A ⊗[R] M₁ ≃ₗ[A] M₁ :=
   have := tensorProduct_compatibleSMul S A A M₁
-  (equivOfCompatibleSMul R A A M₁).symm ≪≫ₗ TensorProduct.lid _ _
+  (equivOfCompatibleSMul R A A A M₁).symm ≪≫ₗ TensorProduct.lid _ _
 
 /-- If `A` is a localization of `R`, tensoring two `A`-algebras over `A` is the same as
 tensoring them over `R`. -/
 noncomputable def algebraTensorEquiv : B ⊗[A] C ≃ₐ[A] B ⊗[R] C :=
   have := tensorProduct_compatibleSMul S A B C
-  Algebra.TensorProduct.equivOfCompatibleSMul R A B C
+  Algebra.TensorProduct.equivOfCompatibleSMul R A A B C
 
 /-- If `A` is a localization of `R`, tensoring an `A`-algebra with `A` over `R` does nothing. -/
 noncomputable def algebraLid : A ⊗[R] B ≃ₐ[A] B :=

--- a/Mathlib/RingTheory/Smooth/Fiber.lean
+++ b/Mathlib/RingTheory/Smooth/Fiber.lean
@@ -227,7 +227,7 @@ lemma IsSmoothAt.of_formallySmooth_fiber
       ((TensorProduct.comm _ _ _).restrictScalars R).trans <|
       ((TensorProduct.congr (.refl (R := S)) e).restrictScalars R).trans <|
       ((TensorProduct.cancelBaseChange _ _ S _ _).restrictScalars R).trans <|
-      (TensorProduct.comm _ _ _).trans (TensorProduct.equivOfCompatibleSMul _ _ _ _ _)
+      (TensorProduct.comm _ _ _).trans (TensorProduct.equivOfCompatibleSMul ..)
     have : e'.toAlgHom.comp (IsScalarTower.toAlgHom R p.ResidueField _) =
         IsScalarTower.toAlgHom _ _ _ := by ext
     let e'' : (𝓀[Rp] ⊗[R] S) ⊗[S] Sq ≃ₐ[𝓀[Rp]] 𝓀[Rp] ⊗[Rp] Sq :=

--- a/Mathlib/RingTheory/Smooth/Fiber.lean
+++ b/Mathlib/RingTheory/Smooth/Fiber.lean
@@ -227,7 +227,7 @@ lemma IsSmoothAt.of_formallySmooth_fiber
       ((TensorProduct.comm _ _ _).restrictScalars R).trans <|
       ((TensorProduct.congr (.refl (R := S)) e).restrictScalars R).trans <|
       ((TensorProduct.cancelBaseChange _ _ S _ _).restrictScalars R).trans <|
-      (TensorProduct.comm _ _ _).trans (TensorProduct.equivOfCompatibleSMul _ _ _ _)
+      (TensorProduct.comm _ _ _).trans (TensorProduct.equivOfCompatibleSMul _ _ _ _ _)
     have : e'.toAlgHom.comp (IsScalarTower.toAlgHom R p.ResidueField _) =
         IsScalarTower.toAlgHom _ _ _ := by ext
     let e'' : (𝓀[Rp] ⊗[R] S) ⊗[S] Sq ≃ₐ[𝓀[Rp]] 𝓀[Rp] ⊗[Rp] Sq :=

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -278,7 +278,7 @@ variable [SMulCommClass R S A] [CompatibleSMul R S A B]
 /-- If A and B are both R- and S-algebras and their actions on them commute,
 and if the S-action on `A ⊗[R] B` can switch between the two factors, then there is a
 canonical T-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`,
-where `T` is another ring whose actions on `A` and `B` commute with the `S`-actions. -/
+where `T` is any other ring acting on `A` and whose action commutes with the `R` and `S`-actions. -/
 def mapOfCompatibleSMul : A ⊗[S] B →ₐ[T] A ⊗[R] B :=
   .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul R S T A B) rfl fun x ↦
     x.induction_on (by simp) (fun _ _ y ↦ y.induction_on (by simp) (by simp)

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -667,7 +667,7 @@ def lmul'' : S ⊗[R] S →ₐ[S] S :=
     (fun a₁ a₂ b₁ b₂ => by simp [mul_mul_mul_comm]) <| by simp
 
 theorem lmul''_eq_lid_comp_mapOfCompatibleSMul :
-    lmul'' R = (TensorProduct.lid S S).toAlgHom.comp (mapOfCompatibleSMul _ _ _ _ _) := by
+    lmul'' R = (TensorProduct.lid S S).toAlgHom.comp (mapOfCompatibleSMul ..) := by
   ext; rfl
 
 /-- `LinearMap.mul'` as an `AlgHom` over the base ring. -/

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -269,38 +269,39 @@ theorem rid_symm_apply (a : A) : (TensorProduct.rid R S A).symm a = a ⊗ₜ 1 :
 
 section CompatibleSMul
 
-variable (R S A B : Type*) [CommSemiring R] [CommSemiring S] [Semiring A] [Semiring B]
+variable (R S T A B : Type*) [CommSemiring R] [CommSemiring S] [CommSemiring T] [Semiring A]
+  [Semiring B]
 variable [Algebra R A] [Algebra R B] [Algebra S A] [Algebra S B]
+variable [Algebra R T] [Algebra T A] [IsScalarTower R T A]
+variable [Algebra S T] [IsScalarTower S T A]
 variable [SMulCommClass R S A] [CompatibleSMul R S A B]
 
 /-- If A and B are both R- and S-algebras and their actions on them commute,
 and if the S-action on `A ⊗[R] B` can switch between the two factors, then there is a
-canonical S-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`. -/
-def mapOfCompatibleSMul : A ⊗[S] B →ₐ[S] A ⊗[R] B :=
-  .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul R S A B) rfl fun x ↦
+canonical T-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`. -/
+def mapOfCompatibleSMul : A ⊗[S] B →ₐ[T] A ⊗[R] B :=
+  .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul R S T A B) rfl fun x ↦
     x.induction_on (by simp) (fun _ _ y ↦ y.induction_on (by simp) (by simp)
       fun _ _ h h' ↦ by simp only [mul_add, map_add, h, h'])
       fun _ _ h h' _ ↦ by simp only [add_mul, map_add, h, h']
 
-@[simp] theorem mapOfCompatibleSMul_tmul (m n) : mapOfCompatibleSMul R S A B (m ⊗ₜ n) = m ⊗ₜ n :=
+@[simp] theorem mapOfCompatibleSMul_tmul (m n) : mapOfCompatibleSMul R S T A B (m ⊗ₜ n) = m ⊗ₜ n :=
   rfl
 
-theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R S A B) :=
-  _root_.TensorProduct.mapOfCompatibleSMul_surjective R S A B
+theorem mapOfCompatibleSMul_surjective : Function.Surjective (mapOfCompatibleSMul R S T A B) :=
+  _root_.TensorProduct.mapOfCompatibleSMul_surjective R S T A B
 
 attribute [local instance] SMulCommClass.symm
 
-/-- `mapOfCompatibleSMul R S A B` is also A-linear. -/
-def mapOfCompatibleSMul' : A ⊗[S] B →ₐ[R] A ⊗[R] B :=
-  .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul' R S A B) rfl
-    (map_mul <| mapOfCompatibleSMul R S A B)
+@[deprecated (since := "2026-02-21")]
+alias mapOfCompatibleSMul' := mapOfCompatibleSMul
 
 /-- If the R- and S-actions on A and B satisfy `CompatibleSMul` both ways,
 then `A ⊗[S] B` is canonically isomorphic to `A ⊗[R] B`. -/
-def equivOfCompatibleSMul [CompatibleSMul S R A B] : A ⊗[S] B ≃ₐ[S] A ⊗[R] B where
-  __ := mapOfCompatibleSMul R S A B
-  invFun := mapOfCompatibleSMul S R A B
-  __ := _root_.TensorProduct.equivOfCompatibleSMul R S A B
+def equivOfCompatibleSMul [CompatibleSMul S R A B] : A ⊗[S] B ≃ₐ[T] A ⊗[R] B where
+  __ := mapOfCompatibleSMul R S T A B
+  invFun := mapOfCompatibleSMul S R T A B
+  __ := _root_.TensorProduct.equivOfCompatibleSMul R S T A B
 
 variable [Algebra R S] [CompatibleSMul R S S A] [CompatibleSMul S R S A]
 omit [SMulCommClass R S A]
@@ -308,7 +309,7 @@ omit [SMulCommClass R S A]
 /-- If the R- and S- action on S and A satisfy `CompatibleSMul` both ways,
 then `S ⊗[R] A` is canonically isomorphic to `A`. -/
 def lidOfCompatibleSMul : S ⊗[R] A ≃ₐ[S] A :=
-  (equivOfCompatibleSMul R S S A).symm.trans (TensorProduct.lid _ _)
+  (equivOfCompatibleSMul R S S S A).symm.trans (TensorProduct.lid _ _)
 
 theorem lidOfCompatibleSMul_tmul (s a) : lidOfCompatibleSMul R S A (s ⊗ₜ[R] a) = s • a := rfl
 
@@ -666,7 +667,7 @@ def lmul'' : S ⊗[R] S →ₐ[S] S :=
     (fun a₁ a₂ b₁ b₂ => by simp [mul_mul_mul_comm]) <| by simp
 
 theorem lmul''_eq_lid_comp_mapOfCompatibleSMul :
-    lmul'' R = (TensorProduct.lid S S).toAlgHom.comp (mapOfCompatibleSMul' _ _ _ _) := by
+    lmul'' R = (TensorProduct.lid S S).toAlgHom.comp (mapOfCompatibleSMul _ _ _ _ _) := by
   ext; rfl
 
 /-- `LinearMap.mul'` as an `AlgHom` over the base ring. -/

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -272,8 +272,7 @@ section CompatibleSMul
 variable (R S T A B : Type*) [CommSemiring R] [CommSemiring S] [CommSemiring T] [Semiring A]
   [Semiring B]
 variable [Algebra R A] [Algebra R B] [Algebra S A] [Algebra S B]
-variable [Algebra R T] [Algebra T A] [IsScalarTower R T A]
-variable [Algebra S T] [IsScalarTower S T A]
+variable [Algebra T A] [SMulCommClass R T A] [SMulCommClass S T A]
 variable [SMulCommClass R S A] [CompatibleSMul R S A B]
 
 /-- If A and B are both R- and S-algebras and their actions on them commute,

--- a/Mathlib/RingTheory/TensorProduct/Maps.lean
+++ b/Mathlib/RingTheory/TensorProduct/Maps.lean
@@ -277,7 +277,8 @@ variable [SMulCommClass R S A] [CompatibleSMul R S A B]
 
 /-- If A and B are both R- and S-algebras and their actions on them commute,
 and if the S-action on `A ⊗[R] B` can switch between the two factors, then there is a
-canonical T-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`. -/
+canonical T-algebra homomorphism from `A ⊗[S] B` to `A ⊗[R] B`,
+where `T` is another ring whose actions on `A` and `B` commute with the `S`-actions. -/
 def mapOfCompatibleSMul : A ⊗[S] B →ₐ[T] A ⊗[R] B :=
   .ofLinearMap (_root_.TensorProduct.mapOfCompatibleSMul R S T A B) rfl fun x ↦
     x.induction_on (by simp) (fun _ _ y ↦ y.induction_on (by simp) (by simp)

--- a/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
+++ b/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
@@ -40,7 +40,7 @@ theorem nontrivial_of_algebraMap_injective_of_isDomain
     ((IsFractionRing.injective B FB).comp hb)
   algebraize_only [fa.toRingHom, fb.toRingHom]
   letI : CompatibleSMul FR R FA FB := CompatibleSMul.isScalarTower
-  exact Algebra.TensorProduct.mapOfCompatibleSMul FR R FA FB |>.comp
+  exact Algebra.TensorProduct.mapOfCompatibleSMul FR R R FA FB |>.comp
     (Algebra.TensorProduct.map (IsScalarTower.toAlgHom R A FA) (IsScalarTower.toAlgHom R B FB))
     |>.toRingHom.domain_nontrivial
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
