### PR TITLE
refactor(CategoryTheory/Sites): weaken assumption for points

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2795,6 +2795,7 @@ public import Mathlib.CategoryTheory.Limits.Types.Colimits
 public import Mathlib.CategoryTheory.Limits.Types.Coproducts
 public import Mathlib.CategoryTheory.Limits.Types.Equalizers
 public import Mathlib.CategoryTheory.Limits.Types.Filtered
+public import Mathlib.CategoryTheory.Limits.Types.FinallySmallFiltered
 public import Mathlib.CategoryTheory.Limits.Types.Images
 public import Mathlib.CategoryTheory.Limits.Types.Limits
 public import Mathlib.CategoryTheory.Limits.Types.Multicoequalizer

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -10,9 +10,10 @@ public import Mathlib.CategoryTheory.Limits.FinallySmall
 /-!
 # Finally small filtered categories
 
-In this file, we show that if `C` is a filtered finally small category
-that is locally small, there exists a final functor `D ⥤ C` from
-a small filtered category. The dual result is also obtained.
+We introduce a typeclass `FinallySmallFiltered.{w} C` saying that
+there exists a final functor `S ⥤ C` where `S` is a `w`-small filtered category.
+We show that if `C` is a filtered finally small category that is locally small,
+then it satisfies `FinallySmallFiltered.{w} C`. The dual result is also obtained.
 
 -/
 
@@ -22,7 +23,97 @@ universe w v u
 
 namespace CategoryTheory
 
+open Functor
+
+/-- A category is `FinallySmallFiltered.{w}` if there is a final functor
+from a filtered `w`-small category. -/
+class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
+  /-- There is a final functor from a small filtered category. -/
+  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+    (_ : IsFiltered S) (F : S ⥤ C), F.Final
+
+/-- A category is `InitiallySmallCofiltered.{w}` if there is an initial functor
+from a cofiltered `w`-small category. -/
+class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
+  /-- There is an initial functor from a small cofiltered category. -/
+  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+    (_ : IsCofiltered S) (F : S ⥤ C), F.Initial
+
 variable (C : Type u) [Category.{v} C]
+
+section
+
+variable [FinallySmallFiltered.{w} C]
+
+/-- If a category `C` satisfies `FinallySmallFiltered.{w} C`, this is
+a `w`-small filtered category equipped with a final functor
+`fromFilteredFinalModel C`. -/
+def FilteredFinalModel : Type w :=
+  (FinallySmallFiltered.final_smallCategory C).choose
+
+noncomputable instance : SmallCategory (FilteredFinalModel.{w} C) :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose
+
+noncomputable instance : IsFiltered (FilteredFinalModel.{w} C) :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose
+
+/-- If a category `C` satisfies `FinallySmallFiltered.{w} C`, this is
+a final functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
+noncomputable def fromFilteredFinalModel : FilteredFinalModel.{w} C ⥤ C :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+
+instance : (fromFilteredFinalModel.{w} C).Final :=
+  (FinallySmallFiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+
+instance : FinallySmall.{w} C :=
+  finallySmall_of_final_of_essentiallySmall (fromFilteredFinalModel.{w} C)
+
+@[deprecated (since := "2026-02-21")]
+alias FinallySmall.FilteredFinalModel := FilteredFinalModel
+@[deprecated (since := "2026-02-21")]
+alias FinallySmall.fromFilteredFinalModel := fromFilteredFinalModel
+
+end
+
+section
+
+variable [InitiallySmallCofiltered.{w} C]
+
+/-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
+a `w`-small cofiltered category equipped with an initial functor
+`fromCofilteredInitialModel C`. -/
+def CofilteredInitialModel : Type w :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose
+
+noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose
+
+noncomputable instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose
+
+/-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
+an initial functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
+noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+
+instance : (fromCofilteredInitialModel.{w} C).Initial :=
+  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+
+instance : InitiallySmall.{w} C :=
+  initiallySmall_of_initial_of_essentiallySmall (fromCofilteredInitialModel.{w} C)
+
+@[deprecated (since := "2026-02-21")]
+alias InitiallySmall.CofilteredInitialModel := CofilteredInitialModel
+@[deprecated (since := "2026-02-21")]
+alias InitiallySmall.fromCofilteredInitialModel := fromCofilteredInitialModel
+
+end
+
+instance [InitiallySmallCofiltered.{w} C] :
+    FinallySmallFiltered.{w} Cᵒᵖ := sorry
+
+instance [FinallySmallFiltered.{w} C] :
+    InitiallySmallCofiltered.{w} Cᵒᵖ := sorry
 
 namespace FinallySmall
 
@@ -82,24 +173,8 @@ lemma exists_of_isFiltered :
     (of_equivalence e) (finallySmall_of_final_of_finallySmall e.functor)
   exact ⟨D, inferInstance, inferInstance, F ⋙ e.inverse, inferInstance⟩
 
-/-- If `C` is a locally small filtered finally small category,
-this is a small filtered category, equipped with a final functor to `C`
-(see `fromFilteredFinalModel`). -/
-def FilteredFinalModel : Type w := (exists_of_isFiltered.{w} C).choose
-
-noncomputable instance : Category (FilteredFinalModel.{w} C) :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose
-
-instance : IsFiltered (FilteredFinalModel.{w} C) :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose
-
-/-- If `C` is a locally small filtered finally small category,
-this is a final functor from a small filtered category. -/
-noncomputable def fromFilteredFinalModel : FilteredFinalModel.{w} C ⥤ C :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose_spec.choose
-
-instance : (fromFilteredFinalModel.{w} C).Final :=
-  (exists_of_isFiltered.{w} C).choose_spec.choose_spec.choose_spec.choose_spec
+instance : FinallySmallFiltered.{w} C where
+  final_smallCategory := exists_of_isFiltered C
 
 end FinallySmall
 
@@ -112,24 +187,8 @@ lemma exists_of_isCofiltered :
   obtain ⟨D, _, _, F, _⟩ := FinallySmall.exists_of_isFiltered.{w} Cᵒᵖ
   exact ⟨Dᵒᵖ, inferInstance, inferInstance, F.leftOp, inferInstance⟩
 
-/-- If `C` is a locally small cofiltered initially small category,
-this is a small cofiltered category, equipped with an initial functor to `C`
-(see `fromCofilteredInitialModel`). -/
-def CofilteredInitialModel : Type w := (exists_of_isCofiltered.{w} C).choose
-
-noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose
-
-instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose
-
-/-- If `C` is a locally small cofiltered initially small category,
-this is an initial functor from a small cofiltered category. -/
-noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose_spec.choose
-
-instance : (fromCofilteredInitialModel.{w} C).Initial :=
-  (exists_of_isCofiltered.{w} C).choose_spec.choose_spec.choose_spec.choose_spec
+instance : InitiallySmallCofiltered.{w} C where
+  final_smallCategory := exists_of_isCofiltered C
 
 end InitiallySmall
 

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -19,7 +19,7 @@ then it satisfies `FinallySmallFiltered.{w} C`. The dual result is also obtained
 
 @[expose] public section
 
-universe w v u
+universe w v' u' v u
 
 namespace CategoryTheory
 
@@ -36,7 +36,7 @@ class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
 from a cofiltered `w`-small category. -/
 class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is an initial functor from a small cofiltered category. -/
-  final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
+  initial_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
     (_ : IsCofiltered S) (F : S ⥤ C), F.Initial
 
 variable (C : Type u) [Category.{v} C]
@@ -83,21 +83,21 @@ variable [InitiallySmallCofiltered.{w} C]
 a `w`-small cofiltered category equipped with an initial functor
 `fromCofilteredInitialModel C`. -/
 def CofilteredInitialModel : Type w :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose
 
 noncomputable instance : Category (CofilteredInitialModel.{w} C) :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose
 
 noncomputable instance : IsCofiltered (CofilteredInitialModel.{w} C) :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose
 
 /-- If a category `C` satisfies `InitiallySmallCofiltered.{w} C`, this is
 an initial functor `FilteredFinalModel.{w} C ⥤ C` from a `w`-small filtered category. -/
 noncomputable def fromCofilteredInitialModel : CofilteredInitialModel.{w} C ⥤ C :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose_spec.choose
 
 instance : (fromCofilteredInitialModel.{w} C).Initial :=
-  (InitiallySmallCofiltered.final_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
+  (InitiallySmallCofiltered.initial_smallCategory C).choose_spec.choose_spec.choose_spec.choose_spec
 
 instance : InitiallySmall.{w} C :=
   initiallySmall_of_initial_of_essentiallySmall (fromCofilteredInitialModel.{w} C)
@@ -109,11 +109,30 @@ alias InitiallySmall.fromCofilteredInitialModel := fromCofilteredInitialModel
 
 end
 
+variable {C} in
+lemma finallySmallFiltered_of_final {C₀ : Type*} [Category* C₀] (F : C₀ ⥤ C)
+    [IsFiltered C₀] [EssentiallySmall.{w} C₀] [F.Final] :
+    FinallySmallFiltered.{w} C where
+  final_smallCategory :=
+    ⟨_, inferInstance, IsFiltered.of_equivalence (equivSmallModel.{w} C₀),
+      (equivSmallModel.{w} C₀).inverse ⋙ F, inferInstance⟩
+
+variable {C} in
+lemma initiallySmallCofiltered_of_initial {C₀ : Type*} [Category* C₀] (F : C₀ ⥤ C)
+    [IsCofiltered C₀] [EssentiallySmall.{w} C₀] [F.Initial] :
+    InitiallySmallCofiltered.{w} C where
+  initial_smallCategory :=
+    ⟨_, inferInstance, IsCofiltered.of_equivalence (equivSmallModel.{w} C₀),
+      (equivSmallModel.{w} C₀).inverse ⋙ F, inferInstance⟩
+
+
 instance [InitiallySmallCofiltered.{w} C] :
-    FinallySmallFiltered.{w} Cᵒᵖ := sorry
+    FinallySmallFiltered.{w} Cᵒᵖ :=
+  finallySmallFiltered_of_final (fromCofilteredInitialModel.{w} C).op
 
 instance [FinallySmallFiltered.{w} C] :
-    InitiallySmallCofiltered.{w} Cᵒᵖ := sorry
+    InitiallySmallCofiltered.{w} Cᵒᵖ :=
+  initiallySmallCofiltered_of_initial (fromFilteredFinalModel.{w} C).op
 
 namespace FinallySmall
 

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -27,6 +27,7 @@ open Functor
 
 /-- A category is `FinallySmallFiltered.{w}` if there is a final functor
 from a filtered `w`-small category. -/
+@[pp_with_univ]
 class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is a final functor from a small filtered category. -/
   final_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)
@@ -34,6 +35,7 @@ class FinallySmallFiltered (C : Type u) [Category.{v} C] : Prop where
 
 /-- A category is `InitiallySmallCofiltered.{w}` if there is an initial functor
 from a cofiltered `w`-small category. -/
+@[pp_with_univ]
 class InitiallySmallCofiltered (C : Type u) [Category.{v} C] : Prop where
   /-- There is an initial functor from a small cofiltered category. -/
   initial_smallCategory (C) : ∃ (S : Type w) (_ : SmallCategory S)

--- a/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
+++ b/Mathlib/CategoryTheory/Filtered/FinallySmall.lean
@@ -207,7 +207,7 @@ lemma exists_of_isCofiltered :
   exact ⟨Dᵒᵖ, inferInstance, inferInstance, F.leftOp, inferInstance⟩
 
 instance : InitiallySmallCofiltered.{w} C where
-  final_smallCategory := exists_of_isCofiltered C
+  initial_smallCategory := exists_of_isCofiltered C
 
 end InitiallySmall
 

--- a/Mathlib/CategoryTheory/Limits/Types/FinallySmallFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/FinallySmallFiltered.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Filtered.FinallySmall
+public import Mathlib.CategoryTheory.Limits.Types.Filtered
+
+/-!
+# Colimits of types indexed by finally small filtered categories
+
+We deduce properties of colimits of types indexed by finally small filtered
+categories from results about filtered colimits.
+
+-/
+
+@[expose] public section
+
+universe w t v' u' v u
+
+namespace CategoryTheory.FinallySmallFiltered
+
+open Limits
+
+variable {J : Type u} [Category.{v} J] [FinallySmallFiltered.{w} J]
+  {F : J ⥤ Type t} {c : Cocone F} (hc : IsColimit c)
+
+include hc
+
+lemma jointly_surjective₂_of_isColimit (z₁ z₂ : c.pt) :
+    ∃ (j : J) (x₁ x₂ : F.obj j), c.ι.app j x₁ = z₁ ∧ c.ι.app j x₂ = z₂ := by
+  obtain ⟨j₁, y₁, rfl⟩ := Types.jointly_surjective_of_isColimit hc z₁
+  obtain ⟨j₂, y₂, rfl⟩ := Types.jointly_surjective_of_isColimit hc z₂
+  let k₁ : StructuredArrow j₁ (fromFilteredFinalModel.{w} J) := Classical.arbitrary _
+  let k₂ : StructuredArrow j₂ (fromFilteredFinalModel.{w} J) := Classical.arbitrary _
+  exact ⟨(fromFilteredFinalModel.{w} J).obj (IsFiltered.max k₁.right k₂.right), _, _,
+    congr_fun (c.w (k₁.hom ≫ (fromFilteredFinalModel.{w} J).map
+      (IsFiltered.leftToMax k₁.right k₂.right))) y₁,
+    congr_fun (c.w (k₂.hom ≫ (fromFilteredFinalModel.{w} J).map
+      (IsFiltered.rightToMax k₁.right k₂.right))) y₂,⟩
+
+lemma eq_iff_of_isColimit {j : J} (x₁ x₂ : F.obj j) :
+    c.ι.app j x₁ = c.ι.app j x₂ ↔
+      ∃ (k : J) (f : j ⟶ k), F.map f x₁ = F.map f x₂ := by
+  refine ⟨fun h ↦ ?_, fun ⟨k, f, hf⟩ ↦ by simp [← congr_fun (c.w f), hf]⟩
+  let D := FilteredFinalModel.{w} J
+  let G := fromFilteredFinalModel.{w} J
+  wlog hj : ∃ i, G.obj i = j generalizing j
+  · let k : StructuredArrow j G := Classical.arbitrary _
+    obtain ⟨l, f, hl⟩ := this (F.map k.hom x₁) (F.map k.hom x₂) (by
+      have := congr_fun (c.w k.hom)
+      dsimp at this
+      simpa [this]) ⟨_, rfl⟩
+    exact ⟨l, k.hom ≫ f, by simpa⟩
+  obtain ⟨i, rfl⟩ := hj
+  obtain ⟨k, f, hk⟩ := (Types.FilteredColimit.isColimit_eq_iff'
+    ((Functor.Final.isColimitWhiskerEquiv G _).2 hc) (x := x₁) (y := x₂)).1 h
+  exact ⟨G.obj k, G.map f, hk⟩
+
+end CategoryTheory.FinallySmallFiltered

--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -88,7 +88,7 @@ instance : HasColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
 instance [LocallySmall.{w} C] [AB5OfSize.{w, w} A] [HasFiniteLimits A] :
     HasExactColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
   hasExactColimitsOfShape_of_final _
-    (FinallySmall.fromFilteredFinalModel Φ.fiber.Elementsᵒᵖ)
+    (fromFilteredFinalModel Φ.fiber.Elementsᵒᵖ)
 
 /-- The fiber functor on categories of presheaves that is given by a point of a site. -/
 noncomputable def presheafFiber : (Cᵒᵖ ⥤ A) ⥤ A :=
@@ -162,7 +162,7 @@ variable {P Q : Cᵒᵖ ⥤ A}
 variable [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C]
 
 instance : PreservesColimitsOfShape Φ.fiber.Elementsᵒᵖ (forget A) :=
-  Functor.Final.preservesColimitsOfShape_of_final (FinallySmall.fromFilteredFinalModel.{w} _) _
+  Functor.Final.preservesColimitsOfShape_of_final (fromFilteredFinalModel.{w} _) _
 
 lemma toPresheafFiber_jointly_surjective (p : ToType (Φ.presheafFiber.obj P)) :
     ∃ (X : C) (x : Φ.fiber.obj X) (z : ToType (P.obj (op X))),
@@ -298,7 +298,7 @@ noncomputable def presheafFiberCompIso :
     (Functor.whiskeringRight _ _ _).obj F ⋙ Φ.presheafFiber ≅
       Φ.presheafFiber ⋙ F :=
   haveI := Functor.Final.preservesColimitsOfShape_of_final
-    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+    (fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
   Functor.isoWhiskerLeft
     ((Functor.whiskeringLeft _ _ _).obj _) (preservesColimitNatIso F).symm
 
@@ -308,7 +308,7 @@ lemma toPresheafFiber_presheafFiberCompIso_hom_app
     Φ.toPresheafFiber X x (P ⋙ F) ≫ (Φ.presheafFiberCompIso F).hom.app P =
       F.map (Φ.toPresheafFiber X x P) := by
   haveI := Functor.Final.preservesColimitsOfShape_of_final
-    (FinallySmall.fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
+    (fromFilteredFinalModel.{w} (Φ.fiber.Elementsᵒᵖ)) F
   simp only [presheafFiberCompIso]
   exact ι_preservesColimitIso_inv F ((CategoryOfElements.π Φ.fiber).op ⋙ P) _
 

--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -328,21 +328,30 @@ noncomputable def sheafFiberCompIso [J.HasSheafCompose F] :
 
 section Comap
 
-variable {C D : Type*} [Category* C] [Category* D]
-  {J : GrothendieckTopology C} {K : GrothendieckTopology D}
+variable {D : Type*} [Category* D] {K : GrothendieckTopology D}
+    (F : D ⥤ C) (H : CoverPreserving K J F)
 
-/-- If `F : C ⥤ D` is a representably flat and cover preserving functor between sites, then
-any point on `D` induces a point on `C` by precomposing the fiber functor with `F`. -/
+/-- If `Φ` is a point of a site `(C, J)`, `F : D ⥤ C` is a cover preserving
+functor (with respect to a topology `K` on `D`), and the category of
+elements of `F ⋙ Φ.fiber` is initially small cofiltered, then this
+point on the site `(D, K)` given by the functor `F ⋙ Φ.fiber`.
+(Note that when `Φ.fiber.Elements` is cofiltered, and `F` is representably flat,
+then `(F ⋙ Φ.fiber).Elements` is automatically cofiltered.) -/
 @[simps]
-def comap (F : C ⥤ D) [RepresentablyFlat F] (H : CoverPreserving J K F) (Φ : Point.{w} K)
-    [InitiallySmallCofiltered.{w} (F ⋙ Φ.fiber).Elements] :
-    Point.{w} J where
+def comap [InitiallySmallCofiltered.{w} (F ⋙ Φ.fiber).Elements] :
+    Point.{w} K where
   fiber := F ⋙ Φ.fiber
   jointly_surjective {X} {R} hR x := by
     obtain ⟨Y, f, ⟨W, g, h, hg, rfl⟩, y, rfl⟩ :=
       Φ.jointly_surjective (Sieve.functorPushforward F R) (H.1 hR) x
     use W, g, hg, Φ.fiber.map h y
     simp
+
+instance [RepresentablyFlat F] [IsCofiltered Φ.fiber.Elements]
+    [LocallySmall.{w} D] [InitiallySmall.{w} (F ⋙ Φ.fiber).Elements] :
+  IsCofiltered (Φ.comap F H).fiber.Elements := by
+  dsimp
+  infer_instance
 
 end Comap
 

--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -20,7 +20,7 @@ Let `C` be a category equipped with a Grothendieck topology `J`. In this file,
 we define the notion of point of the site `(C, J)`, as a
 structure `GrothendieckTopology.Point`. Such a `Φ : J.Point` consists
 in a functor `Φ.fiber : C ⥤ Type w` such that the category `Φ.fiber.Elements`
-is cofiltered (and initially small) and such that if `x : Φ.fiber.obj X`
+is initially small cofiltered and such that if `x : Φ.fiber.obj X`
 and `R` is a covering sieve of `X`, then `x` belongs to the image
 of some `y : Φ.fiber.obj Y` by a morphism `f : Y ⟶ X` which belongs to `R`.
 (This definition is essentially the definition of a fiber functor on a site
@@ -63,8 +63,8 @@ variable (J : GrothendieckTopology C)
 
 /-- Given `J` a Grothendieck topology on a category `C`, a point of the site `(C, J)`
 consists of a functor `fiber : C ⥤ Type w` such that the category `fiber.Elements`
-is initially small (which allows defining the fiber functor on presheaves by
-taking colimits) and cofiltered (so that the fiber functor on presheaves is exact),
+is initially small cofiltered, which allows defining the fiber functor on presheaves by
+taking colimits and ensures that the fiber functor on presheaves is exact,
 and such that covering sieves induce jointly surjective maps on fibers (which
 allows to show that the fibers of a presheaf and its associated sheaf are isomorphic). -/
 structure Point where

--- a/Mathlib/CategoryTheory/Sites/Point/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Basic
 public import Mathlib.CategoryTheory.Filtered.FinallySmall
 public import Mathlib.CategoryTheory.Limits.Preserves.Filtered
+public import Mathlib.CategoryTheory.Limits.Types.FinallySmallFiltered
 public import Mathlib.CategoryTheory.Sites.CoverPreserving
 public import Mathlib.CategoryTheory.Sites.LocallyBijective
 public import Mathlib.CategoryTheory.Functor.Flat
@@ -69,14 +70,13 @@ allows to show that the fibers of a presheaf and its associated sheaf are isomor
 structure Point where
   /-- the fiber functor on the underlying category of the site -/
   fiber : C ⥤ Type w
-  isCofiltered : IsCofiltered fiber.Elements := by infer_instance
-  initiallySmall : InitiallySmall.{w} fiber.Elements := by infer_instance
+  initiallySmallCofiltered : InitiallySmallCofiltered.{w} fiber.Elements := by infer_instance
   jointly_surjective {X : C} (R : Sieve X) (h : R ∈ J X) (x : fiber.obj X) :
     ∃ (Y : C) (f : Y ⟶ X) (_ : R f) (y : fiber.obj Y), fiber.map f y = x
 
 namespace Point
 
-attribute [instance] initiallySmall isCofiltered
+attribute [instance] initiallySmallCofiltered
 
 variable {J} (Φ : Point.{w} J) {A : Type u'} [Category.{v'} A]
   {B : Type u''} [Category.{v''} B]
@@ -85,7 +85,7 @@ variable {J} (Φ : Point.{w} J) {A : Type u'} [Category.{v'} A]
 instance : HasColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
   hasColimitsOfShape_of_finallySmall _ _
 
-instance [LocallySmall.{w} C] [AB5OfSize.{w, w} A] [HasFiniteLimits A] :
+instance [AB5OfSize.{w, w} A] [HasFiniteLimits A] :
     HasExactColimitsOfShape Φ.fiber.Elementsᵒᵖ A :=
   hasExactColimitsOfShape_of_final _
     (fromFilteredFinalModel Φ.fiber.Elementsᵒᵖ)
@@ -130,6 +130,17 @@ lemma toPresheafFiber_naturality {P Q : Cᵒᵖ ⥤ A} (g : P ⟶ Q) (X : C) (x 
       g.app (op X) ≫ Φ.toPresheafFiber X x Q :=
   ((Φ.toPresheafFiberNatTrans X x).naturality g).symm
 
+/-- The (colimit) cocone which defines the fiber of a presheaf. -/
+noncomputable def presheafFiberCocone (P : Cᵒᵖ ⥤ A) :
+    Cocone ((CategoryOfElements.π Φ.fiber).op ⋙ P) where
+  pt := Φ.presheafFiber.obj P
+  ι.app x := Φ.toPresheafFiber x.unop.1 x.unop.2 P
+
+/-- The cocone `Φ.presheafFiberCocone P` is a colimit. -/
+noncomputable def isColimitPresheafFiberCocone (P : Cᵒᵖ ⥤ A) :
+    IsColimit (Φ.presheafFiberCocone P) :=
+  colimit.isColimit _
+
 section
 
 variable {P : Cᵒᵖ ⥤ A} {T : A}
@@ -159,7 +170,7 @@ section
 
 variable {P Q : Cᵒᵖ ⥤ A}
 
-variable [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C]
+variable [PreservesFilteredColimitsOfSize.{w, w} (forget A)]
 
 instance : PreservesColimitsOfShape Φ.fiber.Elementsᵒᵖ (forget A) :=
   Functor.Final.preservesColimitsOfShape_of_final (fromFilteredFinalModel.{w} _) _
@@ -175,23 +186,18 @@ lemma toPresheafFiber_jointly_surjective (p : ToType (Φ.presheafFiber.obj P)) :
 lemma toPresheafFiber_jointly_surjective₂ (p₁ p₂ : ToType (Φ.presheafFiber.obj P)) :
     ∃ (X : C) (x : Φ.fiber.obj X) (z₁ z₂ : ToType (P.obj (op X))),
       Φ.toPresheafFiber X x P z₁ = p₁ ∧ Φ.toPresheafFiber X x P z₂ = p₂ := by
-  obtain ⟨⟨X, x⟩, z₁, z₂, rfl, rfl⟩ := Types.FilteredColimit.jointly_surjective_of_isColimit₂
-    (isColimitOfPreserves (forget A)
-      (colimit.isColimit ((CategoryOfElements.π Φ.fiber).op ⋙ P))) p₁ p₂
-  exact ⟨X, x, z₁, z₂, rfl, rfl⟩
+  obtain ⟨j, y₁, y₂, rfl, rfl⟩ := FinallySmallFiltered.jointly_surjective₂_of_isColimit.{w}
+    (isColimitOfPreserves (forget A) (Φ.isColimitPresheafFiberCocone P)) p₁ p₂
+  exact ⟨_, _, _, _, rfl, rfl⟩
 
 lemma toPresheafFiber_eq_iff' (X : C) (x : Φ.fiber.obj X) (z₁ z₂ : ToType (P.obj (op X))) :
     Φ.toPresheafFiber X x P z₁ = Φ.toPresheafFiber X x P z₂ ↔
       ∃ (Y : C) (f : Y ⟶ X) (y : Φ.fiber.obj Y), Φ.fiber.map f y = x ∧
-        P.map f.op z₁ = P.map f.op z₂ := by
-  refine (Types.FilteredColimit.isColimit_eq_iff'
-    (ht := isColimitOfPreserves (forget A)
-      (colimit.isColimit ((CategoryOfElements.π Φ.fiber).op ⋙ P))) ..).trans ?_
-  constructor
-  · rintro ⟨⟨Y, y⟩, ⟨f, hf⟩, hf'⟩
-    exact ⟨Y, f, y, hf, hf'⟩
-  · rintro ⟨Y, f, y, hf, hf'⟩
-    exact ⟨⟨Y, y⟩, ⟨f, hf⟩, hf'⟩
+        P.map f.op z₁ = P.map f.op z₂ :=
+  (FinallySmallFiltered.eq_iff_of_isColimit
+    (isColimitOfPreserves (forget A) (Φ.isColimitPresheafFiberCocone P)) _ _).trans
+    ⟨fun ⟨⟨Y, y⟩, ⟨f, hf⟩, hf'⟩ ↦ ⟨Y, f, y, hf, hf'⟩,
+      fun ⟨Y, f, y, hf, hf'⟩ ↦ ⟨⟨Y, y⟩, ⟨f, hf⟩, hf'⟩⟩
 
 variable (f : P ⟶ Q)
 
@@ -236,7 +242,7 @@ noncomputable abbrev sheafFiber : Sheaf J A ⥤ A :=
   sheafToPresheaf J A ⋙ Φ.presheafFiber
 
 instance (P : Cᵒᵖ ⥤ A) [HasWeakSheafify J A]
-    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C]
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)]
     [J.WEqualsLocallyBijective A] [(forget A).ReflectsIsomorphisms] :
     IsIso (Φ.presheafFiber.map (CategoryTheory.toSheafify J P)) :=
   W_isInvertedBy_presheafFiber _ _ (W_toSheafify J P)
@@ -246,18 +252,18 @@ variable (A) in
 /-- The fiber functor on sheaves is obtained from the fiber functor on presheaves
 by localization with respect to the class of morphisms `J.W`. -/
 noncomputable def presheafToSheafCompSheafFiber [HasWeakSheafify J A]
-    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C]
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)]
     [J.WEqualsLocallyBijective A] [(forget A).ReflectsIsomorphisms] :
     presheafToSheaf J A ⋙ Φ.sheafFiber ≅ Φ.presheafFiber :=
   (NatIso.ofComponents
     (fun P ↦ asIso ((Φ.presheafFiber (A := A)).map (CategoryTheory.toSheafify J P) :))
       (by simp [← Functor.map_comp])).symm
 
-instance [LocallySmall.{w} C] [HasFiniteLimits A] [AB5OfSize.{w, w} A] :
+instance [HasFiniteLimits A] [AB5OfSize.{w, w} A] :
     PreservesFiniteLimits (Φ.presheafFiber (A := A)) :=
   comp_preservesFiniteLimits _ _
 
-instance [LocallySmall.{w} C] [HasFiniteLimits A] [AB5OfSize.{w, w} A] :
+instance [HasFiniteLimits A] [AB5OfSize.{w, w} A] :
     PreservesFiniteLimits (Φ.sheafFiber (A := A)) :=
   comp_preservesFiniteLimits _ _
 
@@ -268,7 +274,7 @@ instance : PreservesColimitsOfSize.{w, w} (Φ.presheafFiber (A := A)) where
 
 set_option backward.isDefEq.respectTransparency false in
 instance [HasSheafify J A] [J.WEqualsLocallyBijective A] [(forget A).ReflectsIsomorphisms]
-    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C] :
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] :
     PreservesColimitsOfSize.{w, w} (Φ.sheafFiber (A := A)) where
   preservesColimitsOfShape {K _} := ⟨fun {F} ↦
     preservesColimit_of_preserves_colimit_cocone
@@ -286,11 +292,11 @@ instance [HasSheafify J A] [J.WEqualsLocallyBijective A] [(forget A).ReflectsIso
             dsimp))⟩
 
 instance [HasSheafify J A] [J.WEqualsLocallyBijective A] [(forget A).ReflectsIsomorphisms]
-    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] [LocallySmall.{w} C] :
+    [PreservesFilteredColimitsOfSize.{w, w} (forget A)] :
     PreservesFiniteColimits (Φ.sheafFiber (A := A)) :=
   PreservesColimitsOfSize.preservesFiniteColimits _
 
-variable (F : A ⥤ B) [LocallySmall.{w} C] [PreservesFilteredColimitsOfSize.{w, w} F]
+variable (F : A ⥤ B) [PreservesFilteredColimitsOfSize.{w, w} F]
 
 /-- If `Φ` is a point of a site and `F : A ⥤ B` is a functor which preserves
 filtered colimits, then taking fibers of presheaves at `Φ` commutes with `F`. -/
@@ -329,7 +335,7 @@ variable {C D : Type*} [Category* C] [Category* D]
 any point on `D` induces a point on `C` by precomposing the fiber functor with `F`. -/
 @[simps]
 def comap (F : C ⥤ D) [RepresentablyFlat F] (H : CoverPreserving J K F) (Φ : Point.{w} K)
-    [InitiallySmall (F ⋙ Φ.fiber).Elements] :
+    [InitiallySmallCofiltered.{w} (F ⋙ Φ.fiber).Elements] :
     Point.{w} J where
   fiber := F ⋙ Φ.fiber
   jointly_surjective {X} {R} hR x := by

--- a/Mathlib/CategoryTheory/Sites/Point/Conservative.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Conservative.lean
@@ -54,7 +54,7 @@ structure IsConservativeFamilyOfPoints : Prop where
 namespace IsConservativeFamilyOfPoints
 
 variable {P} (hP : P.IsConservativeFamilyOfPoints)
-  (A : Type u') [Category.{v'} A] [LocallySmall.{w} C]
+  (A : Type u') [Category.{v'} A]
   [HasColimitsOfSize.{w, w} A]
   {FC : A → A → Type*} {CC : A → Type w}
   [∀ (X Y : A), FunLike (FC X Y) (CC X) (CC Y)]

--- a/Mathlib/CategoryTheory/Sites/Point/Over.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Over.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Filtered.FinallySmall
 public import Mathlib.CategoryTheory.Functor.TypeValuedFlat
+public import Mathlib.CategoryTheory.Comma.LocallySmall
 public import Mathlib.CategoryTheory.Comma.StructuredArrow.Small
 public import Mathlib.CategoryTheory.Sites.Over
 public import Mathlib.CategoryTheory.Sites.Point.Basic
@@ -26,7 +27,7 @@ universe w v u
 namespace CategoryTheory.GrothendieckTopology.Point
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
-  [LocallySmall.{w} C] (Φ : Point.{w} J) {X : C} (x : Φ.fiber.obj X)
+  (Φ : Point.{w} J) {X : C} (x : Φ.fiber.obj X)
 
 set_option backward.isDefEq.respectTransparency false in
 open InitiallySmall in
@@ -35,11 +36,13 @@ this is the point of the site `(Over X, J.over X)` such that the fiber of
 an object of `Over X` corresponding to a morphism `f : Y ⟶ X` identifies
 to subtype of `Φ.fiber.obj Y` consisting of elemnts `y` such
 that `Φ.fiber.map f y = x`. -/
-def over : Point.{w} (J.over X) where
+@[simps -isSimp]
+def over [InitiallySmallCofiltered.{w}
+    (FunctorToTypes.fromOverFunctor Φ.fiber x).Elements] : Point.{w} (J.over X) where
   fiber := FunctorToTypes.fromOverFunctor Φ.fiber x
-  initiallySmall :=
-    initiallySmall_of_initial_of_initiallySmall
-      (FunctorToTypes.fromOverFunctorElementsEquivalence Φ.fiber x).inverse
+  --initiallySmall :=
+  --  initiallySmall_of_initial_of_initiallySmall
+  --    (FunctorToTypes.fromOverFunctorElementsEquivalence Φ.fiber x).inverse
   jointly_surjective := by
     rintro U R hR ⟨u, hu⟩
     obtain ⟨R, rfl⟩ := (Sieve.overEquiv _).symm.surjective R
@@ -48,5 +51,20 @@ def over : Point.{w} (J.over X) where
     refine ⟨Over.mk (f ≫ U.hom), Over.homMk f, hf, ⟨v, ?_⟩, rfl⟩
     rw [FunctorToTypes.mem_fromOverSubfunctor_iff] at hu ⊢
     simpa
+
+section
+
+variable [LocallySmall.{w} C] [IsCofiltered Φ.fiber.Elements]
+
+instance :
+    InitiallySmall.{w} (FunctorToTypes.fromOverFunctor Φ.fiber x).Elements :=
+  initiallySmall_of_initial_of_initiallySmall
+    (FunctorToTypes.fromOverFunctorElementsEquivalence Φ.fiber x).inverse
+
+instance : IsCofiltered (Φ.over x).fiber.Elements := by
+  dsimp [over_fiber]
+  infer_instance
+
+end
 
 end CategoryTheory.GrothendieckTopology.Point


### PR DESCRIPTION
A point on a site `(C ,J)` is given a functor `fiber : C ⥤ Type w`. Instead of requiring that the category `fiber.Elements` is cofiltered and initially small, we now only assume that it is initially small cofiltered, i.e. there is an initial Functor `D ⥤ fiber.Elements` where `D` is small and cofiltered. For many sites, the stronger condition is satisfied, but it will not be the case for points on the site of smooth schemes over a base with the étale topology: this is the reason for this refactor.

---

- [ ] depends on: #35614

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
