### PR TITLE
[Merged by Bors] - feat(SimpleGraph): the adjacency matrix of empty and complete graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -159,6 +159,17 @@ theorem adjMatrix_apply (v w : V) [Zero α] [One α] :
   rfl
 
 @[simp]
+theorem bot_adjMatrix_eq [Zero α] [One α] :
+    (⊥ : SimpleGraph V).adjMatrix α = 0 := by
+  ext; simp
+
+@[simp]
+theorem top_adjMatrix_eq [DecidableEq V] [Ring α] :
+    (⊤ : SimpleGraph V).adjMatrix α = (Matrix.of fun _ _ ↦ 1) - 1 := by
+  ext i j
+  cases eq_or_ne i j <;> simp [‹_›]
+
+@[simp]
 theorem transpose_adjMatrix [Zero α] [One α] : (G.adjMatrix α)ᵀ = G.adjMatrix α := by
   ext
   simp [adj_comm]

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -164,7 +164,7 @@ theorem adjMatrix_bot [Zero α] [One α] :
   ext; simp
 
 @[simp]
-theorem adjMatrix_top_eq [DecidableEq V] [Ring α] :
+theorem adjMatrix_top [DecidableEq V] [Ring α] :
     (⊤ : SimpleGraph V).adjMatrix α = .of (fun i j ↦ if i = j then 0 else 1) := by
   ext i j
   cases eq_or_ne i j <;> simp [‹_›]

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -159,13 +159,13 @@ theorem adjMatrix_apply (v w : V) [Zero α] [One α] :
   rfl
 
 @[simp]
-theorem adjMatrix_bot_eq [Zero α] [One α] :
+theorem adjMatrix_bot [Zero α] [One α] :
     (⊥ : SimpleGraph V).adjMatrix α = 0 := by
   ext; simp
 
 @[simp]
 theorem adjMatrix_top_eq [DecidableEq V] [Ring α] :
-    (⊤ : SimpleGraph V).adjMatrix α = (Matrix.of fun _ _ ↦ 1) - 1 := by
+    (⊤ : SimpleGraph V).adjMatrix α = .of (fun i j ↦ if i = j then 0 else 1) := by
   ext i j
   cases eq_or_ne i j <;> simp [‹_›]
 

--- a/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/AdjMatrix.lean
@@ -159,12 +159,12 @@ theorem adjMatrix_apply (v w : V) [Zero α] [One α] :
   rfl
 
 @[simp]
-theorem bot_adjMatrix_eq [Zero α] [One α] :
+theorem adjMatrix_bot_eq [Zero α] [One α] :
     (⊥ : SimpleGraph V).adjMatrix α = 0 := by
   ext; simp
 
 @[simp]
-theorem top_adjMatrix_eq [DecidableEq V] [Ring α] :
+theorem adjMatrix_top_eq [DecidableEq V] [Ring α] :
     (⊤ : SimpleGraph V).adjMatrix α = (Matrix.of fun _ _ ↦ 1) - 1 := by
   ext i j
   cases eq_or_ne i j <;> simp [‹_›]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
