### PR TITLE
[Merged by Bors] - fix(Linter/TextBased): don't flag "see adaptation note" comments

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -231,8 +231,14 @@ def adaptationNoteLinter : TextbasedLinter := fun opts lines ↦ Id.run do
 
   let mut errors := Array.mkEmpty 0
   for h : idx in [:lines.size] do
-    -- We make this shorter to catch "Adaptation note", "adaptation note" and a missing colon.
-    if lines[idx].containsSubstr "daptation note" then
+    let line := lines[idx]
+    -- Flag lines that look like a hand-written adaptation note comment
+    -- (e.g. "-- Adaptation note:" or "-- adaptation note:"), but not lines that
+    -- merely reference the concept (e.g. "-- see adaptation note") or that
+    -- use the correct #adaptation_note command.
+    if line.containsSubstr "daptation note" &&
+        !line.containsSubstr "#adaptation_note" &&
+        !line.containsSubstr "see adaptation note" then
       errors := errors.push (StyleError.adaptationNote, idx + 1)
   return (errors, none)
 


### PR DESCRIPTION
This PR fixes the `adaptationNoteLinter` which was matching any line containing the substring `"daptation note"`, causing false positives on lines like:

```lean
#adaptation_note /-- The maxHeartbeats bump is required after leanprover/lean4#12564. -/
set_option maxHeartbeats 400000 in -- see adaptation note
```

The linter now excludes lines containing `#adaptation_note` (correct usage) and `see adaptation note` (cross-references to a nearby `#adaptation_note` command).

See https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/22289522784/job/64474181031 for all 8 false positives, all of this form.

🤖 Prepared with Claude Code