### PR TITLE
[Merged by Bors] - chore(Computability/Partrec): remove `linter.flexible` exceptions

### DIFF
--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -219,11 +219,8 @@ theorem ppred : Nat.Partrec fun n => ppred n :=
       (_root_.Primrec.const 0) (_root_.Primrec.const 1)).to₂
   (of_primrec (Primrec₂.unpaired'.2 this)).rfind.of_eq fun n => by
     cases n
-    · apply eq_none_iff.2
-      simp
-    · apply eq_some_iff.2
-      simp
-      lia
+    · exact eq_none_iff.2 (by simp)
+    · exact eq_some_iff.2 (by simp; lia)
 
 end Partrec
 

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -412,15 +412,13 @@ theorem map {f : α →. β} {g : α → β → σ} (hf : Partrec f) (hg : Compu
 theorem to₂ {f : α × β →. σ} (hf : Partrec f) : Partrec₂ fun a b => f (a, b) :=
   hf.of_eq fun ⟨_, _⟩ => rfl
 
-set_option linter.flexible false in -- TODO: revisit this after #13791 is merged
 theorem nat_rec {f : α → ℕ} {g : α →. σ} {h : α → ℕ × σ →. σ} (hf : Computable f) (hg : Partrec g)
     (hh : Partrec₂ h) : Partrec fun a => (f a).rec (g a) fun y IH => IH.bind fun i => h a (y, i) :=
   (Nat.Partrec.prec' hf hg hh).of_eq fun n => by
-    rcases e : decode (α := α) n with - | a <;> simp [e]
-    induction f a with simp | succ m IH
-    rw [IH, Part.bind_map]
-    congr; funext s
-    simp [encodek]
+    rcases e : decode (α := α) n with - | a
+    · simp
+    · simp only [coe_some, PFun.coe_val, bind_some]
+      induction f a <;> simp_all
 
 nonrec theorem comp {f : β →. σ} {g : α → β} (hf : Partrec f) (hg : Computable g) :
     Partrec fun a => f (g a) :=

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -277,7 +277,7 @@ theorem const (s : σ) : Computable fun _ : α => s :=
 theorem ofOption {f : α → Option β} (hf : Computable f) : Partrec fun a => (f a : Part β) :=
   (Nat.Partrec.ppred.comp hf).of_eq fun n => by
     rcases decode (α := α) n with - | a <;> simp
-    cases (f a) <;> simp
+    cases f a <;> simp
 
 theorem to₂ {f : α × β → σ} (hf : Computable f) : Computable₂ fun a b => f (a, b) :=
   hf.of_eq fun ⟨_, _⟩ => rfl
@@ -403,7 +403,7 @@ theorem const' (s : Part σ) : Partrec fun _ : α => s :=
 protected theorem bind {f : α →. β} {g : α → β →. σ} (hf : Partrec f) (hg : Partrec₂ g) :
     Partrec fun a => (f a).bind (g a) :=
   (hg.comp (Nat.Partrec.some.pair hf)).of_eq fun n => by
-    rcases e : decode (α := α) n with - | a <;> simp [Seq.seq, e, encodek]
+    rcases e : decode (α := α) n <;> simp [Seq.seq, e, encodek]
 
 theorem map {f : α →. β} {g : α → β → σ} (hf : Partrec f) (hg : Computable₂ g) :
     Partrec fun a => (f a).map (g a) := by

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -497,7 +497,7 @@ theorem rfind {p : α → ℕ →. Bool} (hp : Partrec₂ p) : Partrec fun a => 
   (Nat.Partrec.rfind <|
         hp.map ((Primrec.dom_bool fun b => cond b 0 1).comp Primrec.snd).to₂.to_comp).of_eq
     fun n => by
-    rcases e : decode (α := α) n with - | a <;> simp [e, Nat.rfind_zero_none, map_map, map_id']
+    rcases e : decode (α := α) n <;> simp [e, Nat.rfind_zero_none, map_map, map_id']
 
 theorem rfindOpt {f : α → ℕ → Option σ} (hf : Computable₂ f) :
     Partrec fun a => Nat.rfindOpt (f a) :=
@@ -507,10 +507,9 @@ theorem nat_casesOn_right {f : α → ℕ} {g : α → σ} {h : α → ℕ →. 
     (hg : Computable g) (hh : Partrec₂ h) : Partrec fun a => (f a).casesOn (some (g a)) (h a) :=
   (nat_rec hf hg (hh.comp fst (pred.comp <| hf.comp fst)).to₂).of_eq fun a => by
     simp only [PFun.coe_val, Nat.pred_eq_sub_one]
-    cases f a with
-    | zero => simp
-    | succ n =>
-      refine ext fun b => ⟨fun H => ?_, fun H => ?_⟩
+    rcases f a with - | n
+    · simp
+    · refine ext fun b => ⟨fun H => ?_, fun H => ?_⟩
       · rcases mem_bind_iff.1 H with ⟨c, _, h₂⟩
         exact h₂
       · have : ∀ m, (Nat.rec (motive := fun _ => Part σ)


### PR DESCRIPTION
This removes all `set_option linter.flexible false` from this module. Some proofs simply required moving around the usage of `simp`. For others I used `grind`, which is permitted to follow flexible tactics. In all cases I prioritized leaving the structure of the proof either mostly as-is or slightly improving readability.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
