### PR TITLE
[Merged by Bors] - chore: replace `aesop` with `lia` where possible

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -239,7 +239,7 @@ lemma HasAffineProperty.affineAnd_iff (P : MorphismProperty Scheme.{u})
   simp_rw [isAffineHom_iff]
   refine ⟨fun h X Y f ↦ ?_, fun h ↦ ⟨affineAnd_isLocal hQi hQl hQs, ?_⟩⟩
   · rw [eq_targetAffineLocally P, targetAffineLocally_affineAnd_iff hQi]
-    aesop
+    lia
   · ext X Y f
     rw [targetAffineLocally_affineAnd_iff hQi, h f]
     aesop

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -253,9 +253,9 @@ theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_add {f₁ f₂ : 𝕜 �
     filter_upwards [meromorphicOrderAt_eq_top_iff.1 h₁f₁]
     simp
   -- General case
-  lift meromorphicOrderAt f₁ x to ℤ using (by aesop) with n₁ hn₁
+  lift meromorphicOrderAt f₁ x to ℤ using (by lia) with n₁ hn₁
   obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (meromorphicOrderAt_eq_int_iff hf₁).1 hn₁.symm
-  lift meromorphicOrderAt f₂ x to ℤ using (by aesop) with n₂ hn₂
+  lift meromorphicOrderAt f₂ x to ℤ using (by lia) with n₂ hn₂
   obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (meromorphicOrderAt_eq_int_iff hf₂).1 hn₂.symm
   rw [WithTop.coe_eq_coe, h₁g₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₁ h₃g₁,
     h₁g₂.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₂ h₃g₂] at *

--- a/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
@@ -200,7 +200,7 @@ theorem parallelPair_pullback_initial {X B : C} (π : X ⟶ B)
     have hi := Over.w i.hom
     have hj := Over.w j.hom
     dsimp at hi hj
-    let ij := PullbackCone.IsLimit.lift hc i.hom.left j.hom.left (by aesop)
+    let ij := PullbackCone.IsLimit.lift hc i.hom.left j.hom.left (by lia)
     refine ⟨Quiver.Hom.op (ObjectProperty.homMk (Over.homMk ij)), ?_, ?_⟩
     all_goals congr; aesop
 

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -305,7 +305,7 @@ lemma exists_isTutteViolator (h : ∀ (M : G.Subgraph), ¬M.IsPerfectMatching)
       rwa [edge_le_iff (v := a.1.1) (w := c), adj_comm, not_or])
     have hcnex : c ≠ x.val.val := by rintro rfl; exact hc.2 hxa
     obtain ⟨Mcon, hMcon⟩ := tutte_exists_isPerfectMatching_of_near_matchings hxa
-      hxb hnadjxb (fun hadj ↦ hc.2 hadj.symm) (by aesop) hcnex.symm hc.1 hbnec hG1 hG2
+      hxb hnadjxb (fun hadj ↦ hc.2 hadj.symm) (by lia) hcnex.symm hc.1 hbnec hG1 hG2
     exact hMatchingFree Mcon hMcon
 
 /-- **Tutte's theorem**

--- a/Mathlib/GroupTheory/Perm/Centralizer.lean
+++ b/Mathlib/GroupTheory/Perm/Centralizer.lean
@@ -379,7 +379,7 @@ theorem ofPermHom_support :
       rw [← notMem_support]
       have := g.cycleFactorsFinset_pairwise_disjoint c.prop d.prop
       rw [disjoint_iff_disjoint_support, Finset.disjoint_left] at this
-      exact this (by aesop) hc
+      exact this (by lia) hc
     · simpa only [H, iff_false, not_not] using ⟨c, H, mem_support.mp hc⟩
 
 theorem card_ofPermHom_support :

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -393,7 +393,7 @@ theorem isCoatom_stabilizer_of_ncard_lt_ncard_compl
   have hB_not_le_sc (B : Set α) (hB : IsBlock G B) (hBsc : B ⊆ sᶜ) :
       B.Subsingleton :=
     -- uses Step 1
-    hB.subsingleton_of_ssubset_of_stabilizer_Perm_le (hBsc.ssubset_of_ne (by aesop)) hG'.le
+    hB.subsingleton_of_ssubset_of_stabilizer_Perm_le (hBsc.ssubset_of_ne (by lia)) hG'.le
   -- Step 3 : A block contained in `s` is a subsingleton
   have hB_not_le_s (B : Set α) (hB : IsBlock G B) (hBs : B ⊆ s) : B.Subsingleton :=
     have := isPreprimitive_stabilizer_subgroup hG.le

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -391,7 +391,7 @@ theorem ker_noncommProd_eq_of_supIndep_ker [FiniteDimensional K V] {ι : Type*} 
       ker_comp_eq_of_commute_of_disjoint_ker]
     · simp_rw [Finset.mem_insert_coe, iSup_insert, Finset.mem_coe, ih]
     · exact s.noncommProd_commute _ _ _ fun j hj ↦
-        comm (s.mem_insert_self i) (Finset.mem_insert_of_mem hj) (by aesop)
+        comm (s.mem_insert_self i) (Finset.mem_insert_of_mem hj) (by lia)
     · replace h := Finset.supIndep_iff_disjoint_erase.mp h i (s.mem_insert_self i)
       simpa [ih, hi, Finset.sup_eq_iSup] using h
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -521,7 +521,7 @@ theorem LinearIndependent.of_pairwise_dual_eq_zero_one (v : ι → M) (f : ι �
     LinearIndependent R v := by
   refine linearIndependent_iff'.mpr fun s g hrel i hi ↦ ?_
   have aux (j : ι) (hjs : j ∈ s) (hji : j ≠ i) : g j * (f i) (v j) = 0 := by simp [h1 hji.symm]
-  simpa [s.sum_eq_single i aux (by aesop), h2 i] using congr_arg (f i) hrel
+  simpa [s.sum_eq_single i aux (by lia), h2 i] using congr_arg (f i) hrel
 
 end Module
 

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -261,7 +261,7 @@ lemma sub_notMem_range_root
   let f : ι → ℤ := fun k ↦ if k = i then 1 else if k = j then -1 else 0
   have hf : ∑ k ∈ b.support, f k • P.root k = P.root i - P.root j := by
     have : {i, j} ⊆ b.support := by aesop (add simp Finset.insert_subset_iff)
-    rw [← Finset.sum_subset (s₁ := {i, j}) (s₂ := b.support) (by aesop) (by aesop),
+    rw [← Finset.sum_subset (s₁ := {i, j}) (s₂ := b.support) (by lia) (by aesop),
       Finset.sum_insert (by aesop), Finset.sum_singleton]
     simp [f, hij, sub_eq_add_neg]
   intro contra

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/MeanValue.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/MeanValue.lean
@@ -54,7 +54,7 @@ theorem exists_eq_const_mul_intervalIntegral_of_ae_nonneg
   wlog hab : a < b generalizing a b
   · simp only [not_lt] at hab
     obtain ⟨c, c_in_uIcc, that⟩ :=
-      this (by rwa [uIcc_comm]) hg.symm (by rwa [uIoc_comm]) (by aesop) (lt_of_le_of_ne' hab h)
+      this (by rwa [uIcc_comm]) hg.symm (by rwa [uIoc_comm]) (by lia) (lt_of_le_of_ne' hab h)
     exact ⟨c, by rwa [uIcc_comm], by simpa [integral_symm b a]⟩
   let s := Ι a b
   have hs : s = Ioc a b := uIoc_of_le hab.le

--- a/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
+++ b/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
@@ -77,7 +77,7 @@ lemma coinvariantsKer_leftRegular_eq_ker :
   refine le_antisymm (Submodule.span_le.2 ?_) fun x hx => ?_
   · rintro x ⟨⟨g, y⟩, rfl⟩
     simpa [linearCombination, sub_eq_zero, sum_fintype]
-      using Finset.sum_bijective _ (Group.mulLeft_bijective g⁻¹) (by aesop) (by aesop)
+      using Finset.sum_bijective _ (Group.mulLeft_bijective g⁻¹) (by aesop) (by lia)
   · have : x = x.sum (fun g r => single g r - single 1 r) := by
       ext g
       by_cases hg : g = 1

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -924,12 +924,12 @@ lemma veq_zero_iff : 0 =ᵥ a ↔ 0 = a := by
   rw [veq_comm, eq_comm, zero_veq_iff]
 
 lemma vle_div_iff (hc : c ≠ 0) : a ≤ᵥ b / c ↔ a * c ≤ᵥ b := by
-  rw [← mul_vle_mul_iff_left (by simpa), div_mul_cancel₀ _ (by aesop)]
+  rw [← mul_vle_mul_iff_left (by simpa), div_mul_cancel₀ _ (by lia)]
 
 @[deprecated (since := "2025-12-20")] alias rel_div_iff := vle_div_iff
 
 lemma div_vle_iff (hc : c ≠ 0) : a / c ≤ᵥ b ↔ a ≤ᵥ b * c := by
-  rw [← mul_vle_mul_iff_left (by simpa), div_mul_cancel₀ _ (by aesop)]
+  rw [← mul_vle_mul_iff_left (by simpa), div_mul_cancel₀ _ (by lia)]
 
 @[deprecated (since := "2025-12-20")] alias div_rel_iff := div_vle_iff
 

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -270,7 +270,7 @@ lemma exists_leadingCoeff_pow_smul_mem_radical_conductor
     | zero =>
       obtain hi' | hi' := lt_or_ge p.natDegree i
       · simp [coeff_eq_zero_of_natDegree_lt hi']
-      · simpa [← coeff_natDegree, hpn, show i = 0 by aesop] using this _ hp
+      · simpa [← coeff_natDegree, hpn, show i = 0 by lia] using this _ hp
     | succ n =>
       obtain hi' | hi' := eq_or_ne i p.natDegree
       · simpa [hi'] using this _ hp
@@ -279,7 +279,7 @@ lemma exists_leadingCoeff_pow_smul_mem_radical_conductor
           map_pow, sub_mul, mul_right_comm _ _ t, ← Algebra.smul_def _ t]
         exact sub_mem hp (Ideal.mul_mem_right _ _ (this _ hp))
       simpa [eraseLead_coeff, hi'] using
-        IH _ ((eraseLead_natDegree_le _).trans_lt (by aesop)) _ this rfl
+        IH _ ((eraseLead_natDegree_le _).trans_lt (by lia)) _ this rfl
   obtain ⟨n, hn⟩ := hp
   obtain ⟨k, hk⟩ := exists_leadingCoeff_pow_smul_mem_conductor φ  (t ^ n) (p ^ n) hRS hφ
     (by simpa [mul_pow] using hn)

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -281,7 +281,7 @@ private lemma RelCWComplex.subset_of_eq_union_iUnion [RelCWComplex C D] (I J : �
       (subset_iUnion_of_subset n (subset_iUnion_of_subset ⟨i, hi⟩ (subset_refl (openCell n i)))) D
   have h' : Disjoint (openCell n i) (D ∪ ⋃ n, ⋃ (j : J n), openCell (C := C) n j) := by
     simp_rw [disjoint_union_right, disjoint_iUnion_right]
-    exact ⟨disjointBase n i, fun m j ↦ disjoint_openCell_of_ne (by aesop)⟩
+    exact ⟨disjointBase n i, fun m j ↦ disjoint_openCell_of_ne (by lia)⟩
   rw [disjoint_of_subset_iff_left_eq_empty h] at h'
   exact notMem_empty _ (h' ▸ map_zero_mem_openCell n i)
 

--- a/Mathlib/Topology/CWComplex/Classical/Subcomplex.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Subcomplex.lean
@@ -70,7 +70,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma RelCWComplex.Subcomplex.disjoint_openCell_subcomplex_of_not_mem [RelCWComplex C D]
     (E : Subcomplex C) {n : ℕ} {i : cell C n} (h : i ∉ E.I n) : Disjoint (openCell n i) E := by
   simp_rw [← union, disjoint_union_right, disjoint_iUnion_right]
-  exact ⟨disjointBase n i , fun _ _ ↦ disjoint_openCell_of_ne (by aesop)⟩
+  exact ⟨disjointBase n i , fun _ _ ↦ disjoint_openCell_of_ne (by lia)⟩
 
 open Classical in
 /-- A subcomplex is again a CW complex. -/


### PR DESCRIPTION
`lia` makes the proof intent explicit and is typically faster (often significantly so in the cases below).

Trace profiling results (differences <30 ms considered measurement noise):
* `AlgebraicGeometry.HasAffineProperty.affineAnd_iff`: 563 ms before, 449 ms after  🎉
* `MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_add`: 976 ms before, 935 ms after  🎉
* `CategoryTheory.regularTopology.parallelPair_pullback_initial`: 334 ms before, 281 ms after  🎉
* `SimpleGraph.exists_isTutteViolator`: 3299 ms before, 2637 ms after  🎉
* `Equiv.Perm.Basis.ofPermHom_support`: 520 ms before, 87 ms after  🎉
* `Equiv.Perm.isCoatom_stabilizer_of_ncard_lt_ncard_compl`: unchanged 🎉
* `LinearMap.ker_noncommProd_eq_of_supIndep_ker`: 372 ms before, 197 ms after  🎉
* `LinearIndependent.of_pairwise_dual_eq_zero_one`: unchanged 🎉
* `RootPairing.Base.sub_notMem_range_root`: unchanged 🎉
* `exists_eq_const_mul_intervalIntegral_of_ae_nonneg`: 587 ms before, 232 ms after  🎉
* `Representation.FiniteCyclicGroup.coinvariantsKer_leftRegular_eq_ker`: unchanged 🎉
* `ValuativeRel.one_vle_div_iff`: unchanged 🎉
* `ValuativeRel.vle_div_iff`: unchanged 🎉
* `exists_leadingCoeff_pow_smul_mem_radical_conductor`: 547 ms before, 377 ms after  🎉
* `subset_of_eq_union_iUnion`: 1297 ms before, 75 ms after  🎉
* `Topology.RelCWComplex.Subcomplex.disjoint_openCell_subcomplex_of_not_mem`: 75 ms before, 32 ms after  🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
