### PR TITLE
[Merged by Bors] - chore: replace `aesop` with `simp`/`simp_all` where applicable

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
@@ -51,7 +51,7 @@ lemma prod_Ico_int_div (b : ℕ) {α : Type*} [CommGroup α] (f : ℤ → α) :
   | zero => simp
   | succ b ihb =>
     simp only [Nat.cast_add_one, Ico_succ_succ]
-    rw [prod_union (by aesop), prod_insert (by grind), prod_singleton, ihb, ← mul_assoc, mul_div]
+    rw [prod_union (by simp), prod_insert (by grind), prod_singleton, ihb, ← mul_assoc, mul_div]
     simp [mul_comm, mul_div, ← mul_assoc]
 
 end Finset

--- a/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Indecomposable.lean
@@ -220,7 +220,7 @@ lemma Submonoid.apply_ne_one_of_mem_or_inv_mem_closure
     simpa [hv_inv] using this v f s hf i⁻¹ (by simpa [hv_inv]) (by simp [hv_inv])
       (by left; simpa [hv_inv]) (by simpa [hv_inv])
   suffices v i ≠ 1 → 1 < f (v i) from (this hv_one).ne'
-  refine closure_induction (by aesop) (by simp) (fun x y _ _ hx hy _ ↦ ?_) hi
+  refine closure_induction (by simp_all) (by simp) (fun x y _ _ hx hy _ ↦ ?_) hi
   rcases eq_or_ne x 1 with rfl | hx'; · grind
   rcases eq_or_ne y 1 with rfl | hy'; · grind
   simpa using lt_mul_of_lt_of_one_lt (hx hx') (hy hy')

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -534,7 +534,7 @@ theorem iterate_derivative_mul_X_pow (n m : ℕ) (p : R[X]) :
     norm_cast
     ring
   rw [hsum]
-  refine sum_congr_of_eq_on_inter (fun k hk hk' ↦ ?_) (by aesop) (by simp)
+  refine sum_congr_of_eq_on_inter (fun k hk hk' ↦ ?_) (by simp_all) (by simp)
   rcases le_or_gt k m with hkm | hkm
   · replace hk' : n < k := by simpa [hkm] using hk'
     simp [Nat.choose_eq_zero_of_lt hk']

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -484,7 +484,7 @@ theorem splits_mul_iff (hf₀ : f ≠ 0) (hg₀ : g ≠ 0) :
 
 theorem Splits.of_dvd (hg : Splits g) (hg₀ : g ≠ 0) (hfg : f ∣ g) : Splits f := by
   obtain ⟨g, rfl⟩ := hfg
-  exact ((splits_mul_iff (by aesop) (by aesop)).mp hg).1
+  exact ((splits_mul_iff (by simp_all) (by simp_all)).mp hg).1
 
 @[deprecated (since := "2025-11-27")]
 alias Splits.splits_of_dvd := Splits.of_dvd
@@ -527,7 +527,7 @@ variable [DivisionSemiring R]
 theorem Splits.of_natDegree_le_one {f : R[X]} (hf : natDegree f ≤ 1) : Splits f := by
   obtain ⟨a, b, rfl⟩ := exists_eq_X_add_C_of_natDegree_le_one hf
   by_cases ha : a = 0
-  · aesop
+  · simp_all
   · rw [← mul_inv_cancel_left₀ ha b, C_mul, ← mul_add]
     exact (X_add_C (a⁻¹ * b)).C_mul a
 

--- a/Mathlib/AlgebraicGeometry/Cover/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/QuasiCompact.lean
@@ -51,7 +51,7 @@ lemma isCompactOpenCovered_of_isCompact [QuasiCompactCover 𝒰]
     {U : S.Opens} (hU : IsCompact (U : Set S)) :
     IsCompactOpenCovered (𝒰.f ·) (U : Set S) := by
   obtain ⟨Us, hUs, hUf, hUc⟩ := S.isBasis_affineOpens.exists_finite_of_isCompact hU
-  refine .of_biUnion_eq_of_finite (SetLike.coe '' Us) (by aesop) (hUf.image _) ?_
+  refine .of_biUnion_eq_of_finite (SetLike.coe '' Us) (by simp_all) (hUf.image _) ?_
   simpa using fun t ht ↦ IsAffineOpen.isCompactOpenCovered 𝒰 (hUs ht)
 
 variable {𝒰 : PreZeroHypercover.{v} S} {K : Precoverage Scheme.{u}}

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -299,7 +299,7 @@ lemma mono_pushoutSection_of_iSup_eq {ι : Type*} [Finite ι] (VX : ι → X.Ope
   · have H₁ : e.inv.hom.comp Algebra.TensorProduct.includeLeftRingHom =
         (pushout.inr (C := CommRingCat) _ _).hom :=
       congr($((CommRingCat.isPushout_tensorProduct _ _ _).flip.inr_isoPushout_hom).hom)
-    have H₂ (x j) : φ (x ⊗ₜ[↑Γ(S, US)] 1) j = pushoutSection H hUST (UX := VX j) (by aesop) rfl
+    have H₂ (x j) : φ (x ⊗ₜ[↑Γ(S, US)] 1) j = pushoutSection H hUST (UX := VX j) (by simp_all) rfl
         (pushout.inr (C := CommRingCat) _ _ x) := congr(pushoutSection H hUST (UX := VX j) _ rfl
         ($((CommRingCat.isPushout_tensorProduct ↑Γ(S, US)
           ↑Γ(T, UT) ↑Γ(X, VX j)).flip.inr_isoPushout_hom) x))
@@ -309,7 +309,7 @@ lemma mono_pushoutSection_of_iSup_eq {ι : Type*} [Finite ι] (VX : ι → X.Ope
   · have H₁ : e.inv.hom.comp Algebra.TensorProduct.includeRight.toRingHom =
         (pushout.inl (C := CommRingCat) _ _).hom :=
       congr($((CommRingCat.isPushout_tensorProduct _ _ _).flip.inl_isoPushout_hom).hom)
-    have H₂ (x j) : φ (1 ⊗ₜ[↑Γ(S, US)] x) j = pushoutSection H hUST (UX := VX j) (by aesop) rfl
+    have H₂ (x j) : φ (1 ⊗ₜ[↑Γ(S, US)] x) j = pushoutSection H hUST (UX := VX j) (by simp_all) rfl
         (pushout.inl (C := CommRingCat) _ _ (x j)) := congr(pushoutSection H hUST (UX := VX j) _ rfl
         ($((CommRingCat.isPushout_tensorProduct ↑Γ(S, US)
           ↑Γ(T, UT) ↑Γ(X, VX j)).flip.inl_isoPushout_hom) (x j)))

--- a/Mathlib/AlgebraicTopology/SimplicialObject/II.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/II.lean
@@ -114,7 +114,7 @@ lemma map'_zero (f : Fin (n + 1) →o Fin (m + 1)) :
 lemma map'_id (x : Fin (n + 2)) : map' OrderHom.id x = x := by
   obtain ⟨x, rfl⟩ | rfl := Fin.eq_castSucc_or_eq_last x
   · rw [map'_eq_castSucc_iff]
-    aesop
+    simp
   · simp
 
 lemma map'_map' {p : ℕ} (f : Fin (n + 1) →o Fin (m + 1))

--- a/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
@@ -85,7 +85,7 @@ lemma Unitary.norm_sub_one_sq_eq {u : A} (hu : u ∈ unitary A) {x : ℝ}
     have : Antitone (fun y : ℝ ↦ 2 * (1 - y)) := by intro _ _ _; simp only; gcongr
     simpa [Set.image_image] using this.map_isLeast hz
   have h₃ : IsGreatest ((‖· - 1‖ ^ 2) '' spectrum ℂ u) (‖cfc (· - 1 : ℂ → ℂ) u‖ ^ 2) := by
-    have := pow_left_monotoneOn (n := 2) |>.mono (s₂ := ((‖· - 1‖) '' spectrum ℂ u)) (by aesop)
+    have := pow_left_monotoneOn (n := 2) |>.mono (s₂ := ((‖· - 1‖) '' spectrum ℂ u)) (by simp)
     simpa [Set.image_image] using this.map_isGreatest (IsGreatest.norm_cfc (fun z : ℂ ↦ z - 1) u)
   exact h₃.unique (h_eqOn.image_eq ▸ h₂)
 

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -238,7 +238,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
     _ = g₂.right := by
       symm
       apply hc.uniq (c.extend _)
-      aesop
+      simp
   -- Finally, since `fᵢ` factors through `F(gᵢ)`, the result follows.
   calc
     f₁ = 𝟙 _ ≫ f₁ := by simp

--- a/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
@@ -307,7 +307,7 @@ lemma comp_mk₀_id {X Y : C} [HasSmallLocalizedShiftedHom.{w} W M X Y]
     [HasSmallLocalizedShiftedHom.{w} W M Y Y]
     [W.IsCompatibleWithShift M] {m : M}
     (α : SmallShiftedHom.{w} W X Y m) (m₀ : M) (hm₀ : m₀ = 0) :
-    α.comp (mk₀ W m₀ hm₀ (𝟙 Y)) (by aesop) = α :=
+    α.comp (mk₀ W m₀ hm₀ (𝟙 Y)) (by simp_all) = α :=
   (equiv W W.Q).injective (by simp [equiv_comp])
 
 variable {W} in
@@ -317,7 +317,7 @@ lemma mk₀_id_comp {X Y : C} [HasSmallLocalizedShiftedHom.{w} W M X Y]
     [HasSmallLocalizedShiftedHom.{w} W M Y Y]
     [W.IsCompatibleWithShift M] {m : M}
     (α : SmallShiftedHom.{w} W X Y m) (m₀ : M) (hm₀ : m₀ = 0) :
-    (mk₀ W m₀ hm₀ (𝟙 X)).comp α (by aesop) = α :=
+    (mk₀ W m₀ hm₀ (𝟙 X)).comp α (by simp_all) = α :=
   (equiv W W.Q).injective (by simp [equiv_comp])
 
 variable {W} in

--- a/Mathlib/Combinatorics/Matroid/Closure.lean
+++ b/Mathlib/Combinatorics/Matroid/Closure.lean
@@ -629,7 +629,7 @@ lemma Indep.indep_insert_diff_of_mem_closure (hI : M.Indep I) (hfI : f ∈ M.clo
   · exact hI.subset (by simp)
   rw [Indep.insert_diff_indep_iff (hI.subset (diff_subset ..)) heI]
   refine .inl ⟨mem_ground_of_mem_closure hfI, fun h ↦ hI.notMem_closure_diff_of_mem heI ?_⟩
-  exact closure_insert_eq_of_mem_closure h ▸ M.closure_subset_closure (by intro; aesop) he
+  exact closure_insert_eq_of_mem_closure h ▸ M.closure_subset_closure (by intro; simp_all) he
 
 lemma IsBasis.isBasis_insert_diff_of_mem_closure (hB : M.IsBasis B X)
     (he : e ∈ M.closure (insert f B \ {e})) (heB : e ∈ insert f B) (hfX : f ∈ X) :

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -356,7 +356,7 @@ theorem mapsTo_digitsAppend {b : ℕ} (hb : 1 < b) (l : ℕ) :
 
 theorem injOn_ofDigits {b : ℕ} (hb : 1 < b) (l : ℕ) :
     Set.InjOn (ofDigits b) {L : List ℕ | L.length = l ∧ ∀ x ∈ L, x < b} :=
-  fun _ _ _ _ h ↦ ofDigits_inj_of_len_eq hb (by aesop) (by aesop) (by aesop) h
+  fun _ _ _ _ h ↦ ofDigits_inj_of_len_eq hb (by simp_all) (by simp_all) (by simp_all) h
 
 theorem setInvOn_digitsAppend_ofDigits {b : ℕ} (hb : 1 < b) (l : ℕ) :
     Set.InvOn (digitsAppend b l) (ofDigits b) {L : List ℕ | L.length = l ∧ ∀ x ∈ L, x < b}

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -277,7 +277,7 @@ lemma subsingleton_of_stabilizer_lt_of_subset {B : Set α}
       rw [← inter_eq_self_of_subset_right hBs, ← Subtype.image_preimage_val]
       apply Set.Subsingleton.image hB'
     · -- `Subtype.val ⁻¹' B = s`
-      have hBs' : B = s := Set.Subset.antisymm hBs (by aesop)
+      have hBs' : B = s := Set.Subset.antisymm hBs (by simp_all)
       subst hBs'
       obtain ⟨g', hg', hg's⟩ := SetLike.exists_of_lt hG
       have h := (isBlock_iff_smul_eq_or_disjoint.mp hB ⟨g', hg'⟩).resolve_left hg's

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -104,7 +104,7 @@ lemma IsIrreducible.exists_pos [Nontrivial n]
   have ⟨v, p₁, p₂, _hp_eq, hp₁_len⟩ := p.exists_eq_comp_of_le_length (n := 1) h_le
   have hlen_ne : p₁.length ≠ 0 := by simp [hp₁_len]
   obtain ⟨c, p', e, rfl⟩ := (Quiver.Path.length_ne_zero_iff_eq_cons (p := p₁)).1 (by lia)
-  obtain ⟨rfl⟩ : i = c := Quiver.Path.eq_of_length_zero p' (by aesop)
+  obtain ⟨rfl⟩ : i = c := Quiver.Path.eq_of_length_zero p' (by simp_all)
   exact (no_out _).false e
 
 /--

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -111,7 +111,7 @@ lemma root_ne_neg_of_ne [Nontrivial R] {i j : ι}
 lemma linearIndependent_pair_of_ne {i j : b.support} (hij : i ≠ j) :
     LinearIndependent R ![P.root i, P.root j] := by
   have : ({(j : ι), (i : ι)} : Set ι) ⊆ b.support := by simp [pair_subset_iff]
-  rw [← linearIndepOn_id_range_iff (by aesop)]
+  rw [← linearIndepOn_id_range_iff (by simp_all)]
   simpa [image_pair] using LinearIndepOn.id_image <| b.linearIndepOn_root.mono this
 
 lemma root_mem_span_int (i : ι) :

--- a/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseExists.lean
@@ -193,7 +193,7 @@ lemma eq_baseOf_iff (s : Set ι) (f : M →+ ℚ)
   refine ⟨?_, fun ⟨hli, sp⟩ ↦ P.eq_baseOf_of_linearIndepOn_of_mem_or_neg_mem_closure s hli sp f hf⟩
   rintro rfl
   exact ⟨P.linearIndepOn_root_baseOf f hf', fun i ↦
-    mem_or_neg_mem_closure_baseOf P.root f i (by aesop) (by simp)⟩
+    mem_or_neg_mem_closure_baseOf P.root f i (by simp_all) (by simp)⟩
 
 variable [P.IsReduced]
 
@@ -294,7 +294,7 @@ lemma coroot_mem_or_neg_mem_closure_of_root (s : Set ι)
   obtain ⟨f, hf'⟩ := exists_dual_forall_apply_eq_one (hli.restrict_scalars' ℚ)
   have hf := P.eq_baseOf_of_linearIndepOn_of_mem_or_neg_mem_closure s hli hsp f hf'
   have hf₀ (i : ι) : f (P.root i) ≠ 0 :=
-    AddSubmonoid.apply_ne_zero_of_mem_or_neg_mem_closure P.root (f : M →+ ℚ) s (by aesop) i
+    AddSubmonoid.apply_ne_zero_of_mem_or_neg_mem_closure P.root (f : M →+ ℚ) s (by simp_all) i
       (P.ne_zero i) (by simp) (hsp i)
   have aux (i : ι) : ∃ q : ℚ, 0 < q ∧ q = 2 / P.RootForm (P.root i) (P.root i) := by
     refine ⟨2 / P.RootFormIn ℚ (P.rootSpanMem ℚ i) (P.rootSpanMem ℚ i), ?_, ?_⟩

--- a/Mathlib/Order/SuccPred/IntervalSucc.lean
+++ b/Mathlib/Order/SuccPred/IntervalSucc.lean
@@ -43,7 +43,7 @@ theorem biUnion_Ici_Ico_map_succ [SuccOrder α] [IsSuccArchimedean α] [LinearOr
   contrapose! h2f
   use b
   simp only [upperBounds, mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
-  exact Succ.rec (P := fun i _ ↦ f i ≤ b) hb (by aesop)
+  exact Succ.rec (P := fun i _ ↦ f i ≤ b) hb (by simp_all)
 
 /-- Union formula for `Set.Ioc (f i) (f (Order.succ i))` over `i ∈ Ici a`. See also
 `iUnion_Ioc_map_succ_eq_Ioi` for the specialization `a = ⊥`. -/
@@ -55,7 +55,7 @@ theorem biUnion_Ici_Ioc_map_succ [SuccOrder α] [IsSuccArchimedean α] [LinearOr
   intro b hb
   contrapose! h2f
   suffices ∀ i, a ≤ i → f i < b from ⟨b, by aesop (add simp [upperBounds, le_of_lt])⟩
-  exact Succ.rec (P := fun i _ ↦ f i < b) hb (by aesop)
+  exact Succ.rec (P := fun i _ ↦ f i < b) hb (by simp_all)
 
 /-- Special case `a = ⊥` of `biUnion_Ici_Ico_map_succ`. -/
 theorem iUnion_Ico_map_succ_eq_Ici [OrderBot α] [SuccOrder α] [IsSuccArchimedean α] [LinearOrder β]

--- a/Mathlib/RingTheory/MvPolynomial/IrreducibleQuadratic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/IrreducibleQuadratic.lean
@@ -165,7 +165,7 @@ theorem coeff_sumSMulX (i : n) :
   · simp
   intro j hj hji
   rw [coeff_smul, coeff_X', if_neg]
-  · aesop
+  · simp
   · rwa [Finsupp.single_left_inj Nat.one_ne_zero]
 
 theorem irreducible_sumSMulX [IsDomain R]

--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -314,7 +314,7 @@ theorem Multipliable.hasProd (ha : Multipliable f L) : HasProd f (∏'[L] b, f b
     · simp only [Set.inter_eq_left.mpr (show ↑h.2.toFinset ⊆ L.support by simp)]
       simp only [Set.Finite.coe_toFinset, Finset.toFinset_coe]
       rw [finprod_eq_prod_of_mulSupport_subset (s := h.2.toFinset)]
-      · exact Finset.prod_congr rfl (by aesop)
+      · exact Finset.prod_congr rfl (by simp_all)
       · simp
     · grind [Set.Finite.mem_toFinset, mem_mulSupport]
     · exact h.1

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -333,7 +333,7 @@ theorem IsClosed.mem_of_ge_of_forall_exists_lt {a b : α} {s : Set α} (hs : IsC
   suffices OrderDual.toDual a ∈ ofDual ⁻¹' s by aesop
   have : IsClosed (OrderDual.ofDual ⁻¹' (s ∩ Icc a b)) := hs
   rw [preimage_inter, ← Icc_toDual] at this
-  apply this.mem_of_ge_of_forall_exists_gt (by aesop) (by aesop) (fun x hx ↦ ?_)
+  apply this.mem_of_ge_of_forall_exists_gt (by simp_all) (by simp_all) (fun x hx ↦ ?_)
   rw [Ico_toDual, ← preimage_inter, ← Equiv.image_symm_eq_preimage, mem_image] at hx
   aesop
 


### PR DESCRIPTION
Since `aesop` runs `simp_all` by default, it is preferable to use `simp` directly when it suffices to close the goal. This makes the proof intent more explicit and is typically faster (often significantly so in the cases below).

Trace profiling results (differences <30 ms considered measurement noise):
* `Finset.prod_Ico_int_div`: 122 ms before, 86 ms after  🎉
* `Submonoid.apply_ne_one_of_mem_or_inv_mem_closure`: 3985 ms before, 3818 ms after  🎉
* `Polynomial.iterate_derivative_mul_X_pow`: 937 ms before, 730 ms after  🎉
* `Polynomial.Splits.of_dvd`: 1141 ms before, 32 ms after  🎉
* `Polynomial.Splits.of_natDegree_le_one`: 156 ms before, 85 ms after  🎉
* `AlgebraicGeometry.QuasiCompactCover.isCompactOpenCovered_of_isCompact`: unchanged 🎉
* `AlgebraicGeometry.mono_pushoutSection_of_iSup_eq`: 7303 ms before, 3748 ms after  🎉
* `SimplexCategory.II.map'_id`: 90 ms before, <30 ms after  🎉
* `Unitary.norm_sub_one_sq_eq`: 477 ms before, 399 ms after  🎉
* `CategoryTheory.PreservesFiniteLimitsOfFlat.uniq`: unchanged 🎉
* `CategoryTheory.Localization.SmallShiftedHom.comp_mk₀_id`: unchanged 🎉
* `CategoryTheory.Localization.SmallShiftedHom.mk₀_id_comp`: unchanged 🎉
* `Matroid.Indep.indep_insert_diff_of_mem_closure`: 1094 ms before, 58 ms after  🎉
* `Nat.injOn_ofDigits`: 515 ms before, 103 ms after  🎉
* `MulAction.IsBlock.subsingleton_of_stabilizer_lt_of_subset`: 628 ms before, 268 ms after  🎉
* `Matrix.IsIrreducible.exists_pos`: 319 ms before, 230 ms after  🎉
* `RootPairing.Base.linearIndependent_pair_of_ne`: unchanged 🎉
* `RootPairing.eq_baseOf_iff`: 1286 ms before, 194 ms after  🎉
* `RootPairing.coroot_mem_or_neg_mem_closure_of_root`: 2974 ms before, 1117 ms after  🎉
* `biUnion_Ici_Ico_map_succ`: 613 ms before, 429 ms after  🎉
* `biUnion_Ici_Ioc_map_succ`: 1327 ms before, 1033 ms after  🎉
* `MvPolynomial.coeff_sumSMulX`: 794 ms before, 205 ms after  🎉
* `Multipliable.hasProd`: 202 ms before, 115 ms after  🎉
* `IsClosed.mem_of_ge_of_forall_exists_lt`: 2396 ms before, 2187 ms after  🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
