### PR TITLE
[Merged by Bors] - chore: fix delaborators for `[Comm][Semi]RingCat` and some more

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -36,6 +36,17 @@ structure SemiRingCat where
   carrier : Type u
   [semiring : Semiring carrier]
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `SemiRingCat.of R` being printed as `{ carrier := R, semiring := ... }` by
+`delabStructureInstance`. -/
+@[app_delab SemiRingCat.of]
+meta def SemiRingCat.delabOf : Delab := delabApp
+
+end Notation
+
 attribute [instance] SemiRingCat.semiring
 
 initialize_simps_projections SemiRingCat (-semiring)
@@ -193,6 +204,17 @@ structure RingCat where
   /-- The underlying type. -/
   carrier : Type u
   [ring : Ring carrier]
+
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `RingCat.of R` being printed as `{ carrier := R, ring := ... }` by
+`delabStructureInstance`. -/
+@[app_delab RingCat.of]
+meta def RingCat.delabOf : Delab := delabApp
+
+end Notation
 
 attribute [instance] RingCat.ring
 
@@ -361,6 +383,17 @@ structure CommSemiRingCat where
   carrier : Type u
   [commSemiring : CommSemiring carrier]
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `CommSemiRingCat.of R` being printed as `{ carrier := R, commSemiring := ... }` by
+`delabStructureInstance`. -/
+@[app_delab CommSemiRingCat.of]
+meta def CommSemiRingCat.delabOf : Delab := delabApp
+
+end Notation
+
 attribute [instance] CommSemiRingCat.commSemiring
 
 initialize_simps_projections CommSemiRingCat (-commSemiring)
@@ -525,6 +558,17 @@ structure CommRingCat where
   /-- The underlying type. -/
   carrier : Type u
   [commRing : CommRing carrier]
+
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `CommRingCat.of R` being printed as `{ carrier := R, commRing := ... }` by
+`delabStructureInstance`. -/
+@[app_delab CommRingCat.of]
+meta def CommRingCat.delabOf : Delab := delabApp
+
+end Notation
 
 attribute [instance] CommRingCat.commRing
 

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -35,6 +35,17 @@ structure FintypeCat where
   carrier : Type*
   [str : Fintype carrier]
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `FintypeCat.of X` being printed as `{ carrier := X, str := ... }` by
+`delabStructureInstance`. -/
+@[app_delab FintypeCat.of]
+meta def FintypeCat.delabOf : Delab := delabApp
+
+end Notation
+
 attribute [instance] FintypeCat.str
 
 namespace FintypeCat

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -35,6 +35,17 @@ structure TopCat where
   carrier : Type u
   [str : TopologicalSpace carrier]
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `TopCat.of X` being printed as `{ carrier := X, str := ... }` by
+`delabStructureInstance`. -/
+@[app_delab TopCat.of]
+meta def TopCat.delabOf : Delab := delabApp
+
+end Notation
+
 attribute [instance] TopCat.str
 
 initialize_simps_projections TopCat (-str)

--- a/Mathlib/Topology/Category/TopCommRingCat.lean
+++ b/Mathlib/Topology/Category/TopCommRingCat.lean
@@ -35,6 +35,17 @@ structure TopCommRingCat where
   [isTopologicalSpace : TopologicalSpace α]
   [isTopologicalRing : IsTopologicalRing α]
 
+section Notation
+
+open Lean.PrettyPrinter.Delaborator
+
+/-- This prevents `TopCommRingCat.of R` being printed as `{ α := R, ... }` by
+`delabStructureInstance`. -/
+@[app_delab TopCommRingCat.of]
+meta def TopCommRingCat.delabOf : Delab := delabApp
+
+end Notation
+
 namespace TopCommRingCat
 
 instance : Inhabited TopCommRingCat :=

--- a/MathlibTest/Delab/ConcreteCategories.lean
+++ b/MathlibTest/Delab/ConcreteCategories.lean
@@ -1,0 +1,43 @@
+import Mathlib
+
+universe u
+
+variable (R : Type u) [Semiring R]
+/-- info: SemiRingCat.of R : SemiRingCat -/
+#guard_msgs in
+#check SemiRingCat.of R
+
+variable (R : Type u) [CommSemiring R]
+/-- info: CommSemiRingCat.of R : CommSemiRingCat -/
+#guard_msgs in
+#check CommSemiRingCat.of R
+
+variable (R : Type u) [Ring R] in
+/-- info: RingCat.of R : RingCat -/
+#guard_msgs in
+#check RingCat.of R
+
+variable (R : Type u) [CommRing R] in
+/-- info: CommRingCat.of R : CommRingCat -/
+#guard_msgs in
+#check CommRingCat.of R
+
+variable (X : Type u) [TopologicalSpace X] in
+/-- info: TopCat.of X : TopCat -/
+#guard_msgs in
+#check TopCat.of X
+
+variable (X : Type u) [TopologicalSpace X] in
+/-- info: TopCat.of X : TopCat -/
+#guard_msgs in
+#check TopCat.of X
+
+variable (X : Type u) [Fintype X] in
+/-- info: FintypeCat.of X : FintypeCat -/
+#guard_msgs in
+#check FintypeCat.of X
+
+variable (R : Type u) [TopologicalSpace R] [CommRing R] [IsTopologicalRing R] in
+/-- info: TopCommRingCat.of R : TopCommRingCat -/
+#guard_msgs in
+#check TopCommRingCat.of R


### PR DESCRIPTION
Since #31622 terms of type `CommRingCat` are pretty printed as `{ carrier := R, commRing := inst }`. We make it pretty print as `CommRingCat.of R` again, which was the previous behaviour.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
