### PR TITLE
[Merged by Bors] - chore: golf using `simp`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Tower.lean
@@ -143,10 +143,6 @@ theorem adjoin_range_toAlgHom (t : Set A) :
       (Algebra.adjoin S t).restrictScalars R :=
   Subalgebra.ext fun z ↦
     show z ∈ Subsemiring.closure (Set.range (algebraMap (toAlgHom R S A).range A) ∪ t : Set A) ↔
-         z ∈ Subsemiring.closure (Set.range (algebraMap S A) ∪ t : Set A) by
-      suffices Set.range (algebraMap (toAlgHom R S A).range A) = Set.range (algebraMap S A) by
-        rw [this]
-      ext z
-      exact ⟨fun ⟨⟨_, y, h1⟩, h2⟩ ↦ ⟨y, h2 ▸ h1⟩, fun ⟨y, hy⟩ ↦ ⟨⟨z, y, hy⟩, rfl⟩⟩
+         z ∈ Subsemiring.closure (Set.range (algebraMap S A) ∪ t : Set A) by simp
 
 end IsScalarTower

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -724,9 +724,7 @@ lemma mkAux_eq_shortComplex_mk_d_comp_d (n : ℕ) :
       ShortComplex.mk _ _ ((mk X₀ X₁ X₂ d₀ d₁ s succ).d_comp_d (n + 2) (n + 1) n) := by
   change ShortComplex.mk _ _ (mkAux X₀ X₁ X₂ d₀ d₁ s succ n).zero = _
   dsimp [mk, of, mkAux]
-  congr
-  · rw [if_pos (by rfl), id_comp]
-  · simp
+  simp
 
 /-- The isomorphism from `(mk X₀ X₁ X₂ d₀ d₁ s succ).X (n + 3)` that is given by
 the inductive construction. -/

--- a/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
@@ -518,10 +518,7 @@ theorem algebraMap_dvd_iff {r : R} {z : QuadraticAlgebra R a b} :
 theorem algebraMap_dvd_iff_dvd {z w : R} :
     algebraMap R (QuadraticAlgebra R a b) z ∣ algebraMap R (QuadraticAlgebra R a b) w ↔ z ∣ w := by
   rw [algebraMap_dvd_iff]
-  constructor
-  · rintro ⟨hx, -⟩
-    simpa using hx
-  · simp [← C_eq_algebraMap]
+  simp
 
 @[deprecated (since := "2025-12-15")] alias coe_dvd_iff_dvd := algebraMap_dvd_iff_dvd
 

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -277,10 +277,7 @@ theorem orthonormal_fourier : Orthonormal ℂ (@fourierLp T _ 2 _) := by
   rw [ContinuousMap.inner_toLp (@haarAddCircle T hT) (fourier i) (fourier j)]
   simp_rw [← fourier_neg, ← fourier_add]
   split_ifs with h
-  · simp_rw [h, add_neg_cancel]
-    have : ⇑(@fourier T 0) = (fun _ => 1 : AddCircle T → ℂ) := by ext1; exact fourier_zero
-    rw [this, integral_const, probReal_univ, Complex.real_smul,
-      Complex.ofReal_one, mul_one]
+  · simp [h]
   have hij : j + -i ≠ 0 := by
     exact sub_ne_zero.mpr (Ne.symm h)
   convert integral_eq_zero_of_add_right_eq_neg (μ := haarAddCircle)

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -303,9 +303,7 @@ theorem _root_.Real.tendsto_euler_sin_prod (x : ℝ) :
       (∏ j ∈ Finset.range n, (1 - x ^ 2 / (j + 1) ^ 2) : ℂ) =
         (∏ j ∈ Finset.range n, (1 - x ^ 2 / (j + 1) ^ 2) : ℝ) by
       rw [this, Complex.ofReal_re]
-    rw [Complex.ofReal_prod]
-    refine Finset.prod_congr (by rfl) fun n _ => ?_
-    norm_cast
+    simp
   · rw [← Complex.ofReal_mul, ← Complex.ofReal_sin, Complex.ofReal_re]
 
 end EulerSine

--- a/Mathlib/CategoryTheory/CatCommSq.lean
+++ b/Mathlib/CategoryTheory/CatCommSq.lean
@@ -165,11 +165,6 @@ lemma vInv_vInv (h : CatCommSq T L.functor R.functor B) :
     Functor.id_obj, assoc, Iso.inv_hom_id_app_assoc, Iso.inv_hom_id_app, comp_id]
   rw [← B.map_comp, L.counit_app_functor, ← L.functor.map_comp, ← NatTrans.comp_app,
     Iso.inv_hom_id, NatTrans.id_app, L.functor.map_id]
-  simp only [Functor.comp_obj]
-  rw [B.map_id]
-  rw [comp_id, R.counit_app_functor,
-    ← R.functor.map_comp_assoc, ← R.functor.map_comp_assoc, assoc, ← NatTrans.comp_app,
-    Iso.hom_inv_id, NatTrans.id_app]
   simp
 
 /-- In a square of categories, when the left and right functors are part

--- a/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
@@ -100,10 +100,7 @@ theorem ι_colimitLimitToLimitColimit_π_apply [Small.{v} J] [Small.{v} K] (F : 
         (colimitLimitToLimitColimit F (colimit.ι (curry.obj (Prod.swap K J ⋙ F) ⋙ lim) k f)) =
       colimit.ι ((curry.obj F).obj j) k (limit.π ((curry.obj (Prod.swap K J ⋙ F)).obj k) j f) := by
   dsimp [colimitLimitToLimitColimit]
-  rw [Types.Limit.lift_π_apply]
-  dsimp only
-  rw [Types.Colimit.ι_desc_apply]
-  dsimp
+  simp
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The map `colimit_limit_to_limit_colimit` realized as a map of cones. -/

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -295,8 +295,6 @@ lemma one_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
   slice_lhs 2 3 => rw [associator_naturality]
   slice_rhs 1 2 => rw [← Category.id_comp η, ← tensorHom_comp_tensorHom]
   slice_lhs 1 2 => rw [tensorHom_id, ← leftUnitor_tensor_inv]
-  rw [← cancel_epi (λ_ (𝟙_ C)).inv]
-  slice_lhs 1 2 => rw [leftUnitor_inv_naturality]
   simp
 
 lemma one_leftUnitor {M : C} [MonObj M] :

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -321,9 +321,6 @@ theorem Colorable.chromaticNumber_le {n : ℕ} (hc : G.Colorable n) : G.chromati
 
 theorem chromaticNumber_ne_top_iff_exists : G.chromaticNumber ≠ ⊤ ↔ ∃ n, G.Colorable n := by
   rw [chromaticNumber]
-  convert_to ⨅ n : {m | G.Colorable m}, (n : ℕ∞) ≠ ⊤ ↔ _
-  · rw [iInf_subtype]
-  rw [← lt_top_iff_ne_top, ENat.iInf_coe_lt_top]
   simp
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -72,12 +72,7 @@ theorem antidiagonal_cons (a : α) (s) :
   Quotient.inductionOn s fun l ↦ by
     simp only [revzip, reverse_append, quot_mk_to_coe, coe_eq_coe, powersetAux'_cons, cons_coe,
       map_coe, antidiagonal_coe', coe_add]
-    rw [← zip_map, ← zip_map, zip_append, (_ : _ ++ _ = _)]
-    · congr
-      · simp only [List.map_id]
-      · rw [map_reverse]
-      · simp
-    · simp
+    rw [← zip_map, ← zip_map, zip_append, (_ : _ ++ _ = _)] <;> simp
 
 theorem antidiagonal_eq_map_powerset [DecidableEq α] (s : Multiset α) :
     s.antidiagonal = s.powerset.map fun t ↦ (s - t, t) := by

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -81,10 +81,7 @@ theorem getLast_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
   · cases m
     · cases hm rfl
     · simp
-  · cases m
-    · cases hm rfl
-    simp only [zero_add, digits_one, List.getLast_replicate_succ]
-    exact Nat.one_ne_zero
+  · simp
   revert hm
   induction m using Nat.strongRecOn with | ind n IH => ?_
   intro hn

--- a/Mathlib/Data/QPF/Univariate/Basic.lean
+++ b/Mathlib/Data/QPF/Univariate/Basic.lean
@@ -633,8 +633,7 @@ theorem suppPreservation_iff_liftpPreservation : q.SuppPreservation ↔ q.LiftpP
     rw [suppPreservation_iff_uniform] at h'
     dsimp only [SuppPreservation, supp] at h
     rw [liftp_iff_of_isUniform h', supp_eq_of_isUniform h', PFunctor.liftp_iff']
-    simp only [image_univ, mem_range, exists_imp]
-    constructor <;> intros <;> subst_vars <;> solve_by_elim
+    simp
   · rintro α ⟨a, f⟩
     simp only [LiftpPreservation] at h
     simp only [supp, h]

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -292,11 +292,7 @@ theorem last_def {v : Vector α (n + 1)} : v.last = v.get (Fin.last n) :=
 theorem reverse_get_zero {v : Vector α (n + 1)} : v.reverse.head = v.last := by
   rw [← get_zero, last_def, get_eq_get_toList, get_eq_get_toList]
   simp_rw [toList_reverse]
-  rw [List.get_eq_getElem, List.get_eq_getElem, ← Option.some_inj, Fin.cast, Fin.cast,
-    ← List.getElem?_eq_getElem, ← List.getElem?_eq_getElem, List.getElem?_reverse]
-  · congr
-    simp
-  · simp
+  simp
 
 section Scan
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -982,10 +982,7 @@ set_option backward.isDefEq.respectTransparency false in
 theorem neg_eq_self_iff {n : ℕ} (a : ZMod n) : -a = a ↔ a = 0 ∨ 2 * a.val = n := by
   rw [neg_eq_iff_add_eq_zero, ← two_mul]
   cases n
-  · rw [@mul_eq_zero ℤ, @mul_eq_zero ℕ, val_eq_zero]
-    exact
-      ⟨fun h => h.elim (by simp) Or.inl, fun h =>
-        Or.inr (h.elim id fun h => h.elim (by simp) id)⟩
+  · simp
   conv_lhs =>
     rw [← a.natCast_zmod_val, ← Nat.cast_two, ← Nat.cast_mul, natCast_eq_zero_iff]
   constructor

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/KleinFour.lean
@@ -225,10 +225,7 @@ theorem kleinFour_eq_commutator (hα4 : Nat.card α = 4) :
         Subgroup.map fc.toMonoidHom (⊤ : Subgroup (alternatingGroup α)) by
         rw [this, ← Subgroup.map_commutator]
         refine Subgroup.mem_map_of_mem _ hk
-      apply symm
-      rw [← MonoidHom.range_eq_map]
-      rw [MonoidHom.range_eq_top]
-      exact MulEquiv.surjective _
+      simp
   have hk2 := comm_le hk
   rw [← SetLike.mem_coe, coe_kleinFour_of_card_eq_four hα4,
     Set.mem_union, Set.mem_singleton_iff, Set.mem_setOf_eq] at hk2

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -780,11 +780,7 @@ theorem det_succ_row {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (i : Fin
   rw [← det_permute, det_succ_row_zero]
   refine Finset.sum_congr rfl fun j _ => ?_
   rw [mul_assoc, Matrix.submatrix_apply, submatrix_submatrix, id_comp, Function.comp_def, id]
-  congr 3
-  · rw [Equiv.Perm.inv_def, Fin.cycleRange_symm_zero]
-  · ext i' j'
-    rw [Equiv.Perm.inv_def, Matrix.submatrix_apply, Matrix.submatrix_apply,
-      Fin.cycleRange_symm_succ]
+  simp
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column `j`. -/
 theorem det_succ_column {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (j : Fin n.succ) :

--- a/Mathlib/LinearAlgebra/TensorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Basic.lean
@@ -162,9 +162,6 @@ theorem mul_one {n} (a : ⨂[R]^n M) : cast R M (add_zero _) (a ₜ* ₜ1) = a :
   | smul_tprod r a =>
     rw [← TensorProduct.smul_tmul', map_smul, map_smul, ← gMul_def, tprod_mul_tprod R a _,
       cast_tprod]
-    congr 2 with i
-    rw [Fin.append_elim0]
-    refine congr_arg a (Fin.ext ?_)
     simp
   | add x y hx hy =>
     rw [TensorProduct.add_tmul, map_add, map_add, hx, hy]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -298,11 +298,7 @@ theorem convexBodySumFun_eq_zero_iff (x : mixedSpace K) :
     convexBodySumFun x = 0 ↔ x = 0 := by
   rw [← forall_normAtPlace_eq_zero_iff, convexBodySumFun, Finset.sum_eq_zero_iff_of_nonneg
     fun _ _ ↦ mul_nonneg (Nat.cast_pos.mpr mult_pos).le (normAtPlace_nonneg _ _)]
-  conv =>
-    enter [1, w, hw]
-    rw [mul_left_mem_nonZeroDivisors_eq_zero_iff
-      (mem_nonZeroDivisors_iff_ne_zero.mpr mult_coe_ne_zero)]
-  simp_rw [Finset.mem_univ, true_implies]
+  simp
 
 open scoped Classical in
 theorem norm_le_convexBodySumFun (x : mixedSpace K) : ‖x‖ ≤ convexBodySumFun x := by

--- a/Mathlib/NumberTheory/Real/GoldenRatio.lean
+++ b/Mathlib/NumberTheory/Real/GoldenRatio.lean
@@ -230,11 +230,7 @@ theorem coe_fib_eq' :
   rw [fibRec.sol_eq_of_eq_init]
   · intro i hi
     norm_cast at hi
-    fin_cases hi
-    · simp
-    · simp only [goldenRatio, goldenConj]
-      ring_nf
-      rw [mul_inv_cancel₀]; norm_num
+    fin_cases hi <;> simp
   · exact fib_isSol_fibRec
   · suffices LinearRecurrence.IsSolution fibRec
         ((fun n ↦ (√5)⁻¹ * φ ^ n) - (fun n ↦ (√5)⁻¹ * ψ ^ n)) by

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -347,11 +347,7 @@ theorem intCast_dvd (z : ℤ) (a : ℤ√d) : ↑z ∣ a ↔ z ∣ a.re ∧ z �
 @[simp, norm_cast]
 theorem intCast_dvd_intCast (a b : ℤ) : (a : ℤ√d) ∣ b ↔ a ∣ b := by
   rw [intCast_dvd]
-  constructor
-  · rintro ⟨hre, -⟩
-    rwa [re_intCast] at hre
-  · rw [re_intCast, im_intCast]
-    exact fun hc => ⟨hc, dvd_zero a⟩
+  simp
 
 protected theorem eq_of_smul_eq_smul_left {a : ℤ} {b c : ℤ√d} (ha : a ≠ 0) (h : ↑a * b = a * c) :
     b = c := by

--- a/Mathlib/Probability/Distributions/Gaussian/Real.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Real.lean
@@ -304,12 +304,7 @@ lemma gaussianReal_map_const_mul (c : ℝ) :
   · simp only [hv, mul_zero, gaussianReal_zero_var]
     exact Measure.map_dirac (measurable_id'.const_mul c) μ
   by_cases hc : c = 0
-  · simp only [hc, zero_mul]
-    rw [Measure.map_const]
-    simp only [measure_univ, one_smul]
-    convert (gaussianReal_zero_var 0).symm
-    simp only [ne_eq, zero_pow, mul_eq_zero, hv, or_false, not_false_eq_true, reduceCtorEq,
-      NNReal.mk_zero]
+  · simp [hc, zero_mul]
   let e : ℝ ≃ᵐ ℝ := (Homeomorph.mulLeft₀ c hc).symm.toMeasurableEquiv
   have he' : ∀ x, HasDerivAt e ((fun _ ↦ c⁻¹) x) x := by
     suffices ∀ x, HasDerivAt (fun x => c⁻¹ * x) (c⁻¹ * 1) x by rwa [mul_one] at this
@@ -571,10 +566,7 @@ variable {μ : ℝ} {v : ℝ≥0}
 
 lemma gaussianReal_map_linearMap (L : ℝ →ₗ[ℝ] ℝ) :
     (gaussianReal μ v).map L = gaussianReal (L μ) ((L 1 ^ 2).toNNReal * v) := by
-  have : (L : ℝ → ℝ) = fun x ↦ L 1 * x := by
-    ext x
-    have : x = x • 1 := by simp
-    conv_lhs => rw [this, L.map_smul, smul_eq_mul, mul_comm]
+  have : (L : ℝ → ℝ) = fun x ↦ L 1 * x := by simp
   rw [this, gaussianReal_map_const_mul]
   congr
   simp only [mul_one, left_eq_sup]

--- a/Mathlib/RingTheory/Fintype.lean
+++ b/Mathlib/RingTheory/Fintype.lean
@@ -36,9 +36,7 @@ lemma Finset.univ_of_card_le_three (h : Fintype.card R ≤ 3) :
   rcases lt_or_eq_of_le h with h | h
   · apply card_le_card
     rw [Finset.univ_of_card_le_two (Nat.lt_succ_iff.1 h)]
-    intro a ha
-    simp only [mem_insert, mem_singleton] at ha
-    rcases ha with rfl | rfl <;> simp
+    simp
   · have : Nontrivial R := by
       refine Fintype.one_lt_card_iff_nontrivial.1 ?_
       rw [h]
@@ -52,11 +50,7 @@ lemma Finset.univ_of_card_le_three (h : Fintype.card R ≤ 3) :
       replace H : ((2 : ℕ) : ZMod 3) = 0 := H
       rw [natCast_eq_zero_iff] at H
       norm_num at H
-    · intro h
-      simp only [mem_insert, mem_singleton, zero_eq_neg] at h
-      rcases h with (h | h)
-      · exact zero_ne_one h
-      · exact zero_ne_one h.symm
+    · simp
 
 end Ring
 

--- a/Mathlib/RingTheory/Localization/NumDen.lean
+++ b/Mathlib/RingTheory/Localization/NumDen.lean
@@ -114,9 +114,7 @@ theorem isUnit_den_iff (x : K) : IsUnit (den A x : A) ↔ IsLocalization.IsInteg
     · simp only [map_mul, h]
       rw [mul_comm, ← div_eq_iff]
       · simp only [mk'_num_den']
-      intro h
-      replace h : algebraMap A K (den A x : A) = algebraMap A K 0 := by convert h; simp
-      exact nonZeroDivisors.coe_ne_zero _ <| FaithfulSMul.algebraMap_injective A K h
+      simp
     exact FaithfulSMul.algebraMap_injective A K
 
 theorem isUnit_den_zero : IsUnit (den A (0 : K) : A) := by

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -183,9 +183,7 @@ theorem right_inv (M : Matrix n n A) : (toFunAlgHom n R A) (invFun n R A M) = M 
   simp only [invFun, map_sum, toFunAlgHom_apply]
   convert Finset.sum_product (β := Matrix n n A) ..
   conv_lhs => rw [matrix_eq_sum_single M]
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => Matrix.ext fun a b => ?_
-  dsimp [single]
-  split_ifs <;> aesop
+  simp
 
 theorem left_inv (M : A ⊗[R] Matrix n n R) : invFun n R A (toFunAlgHom n R A M) = M := by
   induction M with

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -88,9 +88,7 @@ theorem norm_algebraMap_of_basis [Fintype ι] (b : Basis ι R S) (x : R) :
     norm R (algebraMap R S x) = x ^ Fintype.card ι := by
   haveI := Classical.decEq ι
   rw [norm_apply, ← det_toMatrix b, lmul_algebraMap]
-  convert @det_diagonal _ _ _ _ _ fun _ : ι => x
-  · ext (i j); rw [toMatrix_lsmul]
-  · rw [Finset.prod_const, Finset.card_univ]
+  simp
 
 /-- If `x` is in the base field `K`, then the norm is `x ^ [L : K]`.
 

--- a/Mathlib/RingTheory/Polynomial/Content.lean
+++ b/Mathlib/RingTheory/Polynomial/Content.lean
@@ -127,11 +127,7 @@ theorem content_X_mul {p : R[X]} : content (X * p) = content p := by
       rw [← Nat.succ_injective h2]
       apply h1
   rw [h]
-  simp only [Finset.map_val, Function.comp_apply, Function.Embedding.coeFn_mk, Multiset.map_map]
-  refine congr (congr rfl ?_) rfl
-  ext a
-  rw [mul_comm]
-  simp [coeff_mul_X]
+  simp
 
 @[simp]
 theorem content_X_pow {k : ℕ} : content ((X : R[X]) ^ k) = 1 := by

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -454,19 +454,12 @@ theorem deriv_add_eq_mul_omega0_add (a b : Ordinal.{u}) : deriv (a + ·) b = a *
 @[simp]
 theorem nfp_mul_one {a : Ordinal} (ha : 0 < a) : nfp (a * ·) 1 = a ^ ω := by
   rw [← iSup_iterate_eq_nfp, ← iSup_pow_natCast ha]
-  congr
-  funext n
-  induction n with
-  | zero => rw [pow_zero, iterate_zero_apply]
-  | succ n hn => rw [iterate_succ_apply', Nat.add_comm, pow_add, pow_one, hn]
+  simp
 
 @[simp]
 theorem nfp_mul_zero (a : Ordinal) : nfp (a * ·) 0 = 0 := by
   rw [← nonpos_iff_eq_zero, nfp_le_iff]
-  intro n
-  induction n with
-  | zero => rfl
-  | succ n hn => dsimp only; rwa [iterate_succ_apply, mul_zero]
+  simp
 
 theorem nfp_mul_eq_opow_omega0 {a b : Ordinal} (hb : 0 < b) (hba : b ≤ a ^ ω) :
     nfp (a * ·) b = a ^ ω := by

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -131,10 +131,7 @@ theorem unique_topology_of_t2 {t : TopologicalSpace 𝕜} (h₁ : @IsTopological
           map id (@nhds 𝕜 hnorm.toUniformSpace.toTopologicalSpace 0) :=
         map_id.symm
       _ = map (fun x => id x • (1 : 𝕜)) (@nhds 𝕜 hnorm.toUniformSpace.toTopologicalSpace 0) := by
-        conv_rhs =>
-          congr
-          ext
-          rw [smul_eq_mul, mul_one]
+        simp
       _ ≤ @nhds 𝕜 t ((0 : 𝕜) • (1 : 𝕜)) :=
         (@Tendsto.smul_const _ _ _ hnorm.toUniformSpace.toTopologicalSpace t _ _ _ _ _
           tendsto_id (1 : 𝕜))

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -309,9 +309,7 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat} (c : BinaryCofan X Y) :
             exact h₂.isOpen_range
       · intro T f g
         ext x
-        dsimp
-        rw [dif_pos ⟨x, rfl⟩]
-        conv_lhs => rw [Equiv.ofInjective_symm_apply]
+        simp
       · intro T f g
         ext x
         dsimp

--- a/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
@@ -161,10 +161,7 @@ theorem sup_mem_closed_subalgebra (A : Subalgebra ℝ C(X, ℝ)) (h : IsClosed (
     (f g : A) : (f : C(X, ℝ)) ⊔ (g : C(X, ℝ)) ∈ A := by
   convert sup_mem_subalgebra_closure A f g
   apply SetLike.ext'
-  symm
-  dsimp
-  rw [closure_eq_iff_isClosed]
-  exact h
+  simp
 
 open scoped Topology
 

--- a/Mathlib/Topology/OpenPartialHomeomorph/Constructions.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph/Constructions.lean
@@ -326,10 +326,7 @@ theorem subtypeRestr_symm_eqOn_of_le {U V : Opens X} (hU : Nonempty U) (hV : Non
     rw [Opens.openPartialHomeomorphSubtypeCoe_target] at hy ⊢
     exact hUV hy.2
   refine (V.openPartialHomeomorphSubtypeCoe hV).injOn ?_ trivial ?_
-  · rw [← OpenPartialHomeomorph.symm_target]
-    apply OpenPartialHomeomorph.map_source
-    rw [OpenPartialHomeomorph.symm_source]
-    exact hyV
+  · simp
   · rw [(V.openPartialHomeomorphSubtypeCoe hV).right_inv hyV]
     change _ = U.openPartialHomeomorphSubtypeCoe hU _
     rw [(U.openPartialHomeomorphSubtypeCoe hU).right_inv hy.2]


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `IsScalarTower.adjoin_range_toAlgHom`: 106 ms before, 41 ms after  🎉
* `ChainComplex.mkAux_eq_shortComplex_mk_d_comp_d`: unchanged 🎉
* `QuadraticAlgebra.algebraMap_dvd_iff_dvd`: 91 ms before, 34 ms after  🎉
* `orthonormal_fourier`: unchanged 🎉
* `Real.tendsto_euler_sin_prod`: 712 ms before, 96 ms after  🎉
* `CategoryTheory.CatCommSq.vInv_vInv`: 224 ms before, 120 ms after  🎉
* `CategoryTheory.Limits.ι_colimitLimitToLimitColimit_π_apply`: unchanged 🎉
* `CategoryTheory.MonObj.one_associator`: 96 ms before, 54 ms after  🎉
* `SimpleGraph.chromaticNumber_ne_top_iff_exists`: unchanged 🎉
* `Multiset.antidiagonal_cons`: 104 ms before, <30 ms after  🎉
* `Nat.getLast_digit_ne_zero`: 153 ms before, 89 ms after  🎉
* `QPF.suppPreservation_iff_liftpPreservation`: unchanged 🎉
* `List.Vector.reverse_get_zero`: 128 ms before, 46 ms after  🎉
* `ZMod.neg_eq_self_iff`: 166 ms before, 93 ms after  🎉
* `alternatingGroup.kleinFour_eq_commutator`: unchanged 🎉
* `Matrix.det_succ_row`: 647 ms before, 328 ms after  🎉
* `TensorPower.mul_one`: 483 ms before, 298 ms after  🎉
* `NumberField.mixedEmbedding.convexBodySumFun_eq_zero_iff`: unchanged 🎉
* `Real.coe_fib_eq'`: 233 ms before, 159 ms after  🎉
* `Zsqrtd.intCast_dvd_intCast`: unchanged 🎉
* `ProbabilityTheory.gaussianReal_map_const_mul`: 583 ms before, 198 ms after  🎉
* `ProbabilityTheory.gaussianReal_map_linearMap`: unchanged 🎉
* `Finset.univ_of_card_le_three`: 194 ms before, 151 ms after  🎉
* `IsFractionRing.isUnit_den_iff`: 400 ms before, 137 ms after  🎉
* `MatrixEquivTensor.right_inv`: 329 ms before, 259 ms after  🎉
* `Algebra.norm_algebraMap_of_basis`: unchanged 🎉
* `Polynomial.content_X_mul`: unchanged 🎉
* `Ordinal.nfp_mul_one`: unchanged 🎉
* `Ordinal.nfp_mul_zero`: unchanged 🎉
* `unique_topology_of_t2`: unchanged 🎉
* `TopCat.binaryCofan_isColimit_iff`: 3138 ms before, 1214 ms after  🎉
* `ContinuousMap.sup_mem_closed_subalgebra`: unchanged 🎉
* `OpenPartialHomeomorph.subtypeRestr_symm_eqOn_of_le`: 108 ms before, 45 ms after  🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
