### PR TITLE
[Merged by Bors] - chore(NumberTheory/ModularForms): golf using custom elaborators

### DIFF
--- a/Mathlib/NumberTheory/ModularForms/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/Basic.lean
@@ -63,9 +63,9 @@ open ModularForm
 
 /-- The weight `k` slash action of `GL(2, ℝ)⁺` preserves holomorphic functions. This is private,
 since it is a step towards the proof of `MDifferentiable.slash` which is more general. -/
-private lemma MDifferentiable.slash_of_pos {f : ℍ → ℂ} (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f)
+private lemma MDifferentiable.slash_of_pos {f : ℍ → ℂ} (hf : MDiff f)
     (k : ℤ) {g : GL (Fin 2) ℝ} (hg : 0 < g.det.val) :
-    MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (f ∣[k] g) := by
+    MDiff (f ∣[k] g) := by
   refine .mul (.mul ?_ mdifferentiable_const) (mdifferentiable_denom_zpow g _)
   simpa only [σ, hg, ↓reduceIte] using hf.comp (mdifferentiable_smul hg)
 
@@ -76,8 +76,8 @@ private lemma slash_J (f : ℍ → ℂ) (k : ℤ) :
 
 /-- The weight `k` slash action of the negative-determinant matrix `J` preserves holomorphic
 functions. -/
-private lemma MDifferentiable.slashJ {f : ℍ → ℂ} (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f) (k : ℤ) :
-    MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (f ∣[k] J) := by
+private lemma MDifferentiable.slashJ {f : ℍ → ℂ} (hf : MDiff f) (k : ℤ) :
+    MDiff (f ∣[k] J) := by
   simp only [mdifferentiable_iff, slash_J, Function.comp_def] at hf ⊢
   have : {z | 0 < z.im}.EqOn (fun x ↦ conj (f <| ofComplex <| -conj ↑(ofComplex x)))
       (fun x ↦ conj (f <| ofComplex <| -conj x)) := fun z h ↦ by simp [ofComplex_apply_of_im_pos h]
@@ -88,8 +88,8 @@ private lemma MDifferentiable.slashJ {f : ℍ → ℂ} (hf : MDifferentiable �
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The weight `k` slash action of `GL(2, ℝ)` preserves holomorphic functions. -/
-lemma MDifferentiable.slash {f : ℍ → ℂ} (hf : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) f)
-    (k : ℤ) (g : GL (Fin 2) ℝ) : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (f ∣[k] g) := by
+lemma MDifferentiable.slash {f : ℍ → ℂ} (hf : MDiff f)
+    (k : ℤ) (g : GL (Fin 2) ℝ) : MDiff (f ∣[k] g) := by
   refine g.det_ne_zero.lt_or_gt.elim (fun hg ↦ ?_) (hf.slash_of_pos k)
   rw [show g = J * (J * g) by simp [← mul_assoc, ← sq], SlashAction.slash_mul]
   exact (hf.slashJ k).slash_of_pos _ (by simpa using hg)
@@ -100,7 +100,7 @@ open scoped ModularForm
 
 /-- These are `SlashInvariantForm`'s that are holomorphic and bounded at infinity. -/
 structure ModularForm extends SlashInvariantForm Γ k where
-  holo' : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (toSlashInvariantForm : ℍ → ℂ)
+  holo' : MDiff (toSlashInvariantForm : ℍ → ℂ)
   bdd_at_cusps' {c : OnePoint ℝ} (hc : IsCusp c Γ) : c.IsBoundedAt toFun k
 
 /-- The `SlashInvariantForm` associated to a `ModularForm`. -/
@@ -108,7 +108,7 @@ add_decl_doc ModularForm.toSlashInvariantForm
 
 /-- These are `SlashInvariantForm`s that are holomorphic and zero at infinity. -/
 structure CuspForm extends SlashInvariantForm Γ k where
-  holo' : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (toSlashInvariantForm : ℍ → ℂ)
+  holo' : MDiff (toSlashInvariantForm : ℍ → ℂ)
   zero_at_cusps' {c : OnePoint ℝ} (hc : IsCusp c Γ) : c.IsZeroAt toFun k
 
 /-- The `SlashInvariantForm` associated to a `CuspForm`. -/
@@ -119,7 +119,7 @@ add_decl_doc CuspForm.toSlashInvariantForm
 at all cusps. -/
 class ModularFormClass (F : Type*) (Γ : outParam <| Subgroup (GL (Fin 2) ℝ)) (k : outParam ℤ)
     [FunLike F ℍ ℂ] : Prop extends SlashInvariantFormClass F Γ k where
-  holo : ∀ f : F, MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (f : ℍ → ℂ)
+  holo : ∀ f : F, MDiff (f : ℍ → ℂ)
   bdd_at_cusps (f : F) {c : OnePoint ℝ} (hc : IsCusp c Γ) : c.IsBoundedAt f k
 
 /-- `CuspFormClass F Γ k` says that `F` is a type of bundled functions that extend
@@ -127,7 +127,7 @@ class ModularFormClass (F : Type*) (Γ : outParam <| Subgroup (GL (Fin 2) ℝ)) 
 at all cusps. -/
 class CuspFormClass (F : Type*) (Γ : outParam <| Subgroup (GL (Fin 2) ℝ)) (k : outParam ℤ)
     [FunLike F ℍ ℂ] : Prop extends SlashInvariantFormClass F Γ k where
-  holo : ∀ f : F, MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (f : ℍ → ℂ)
+  holo : ∀ f : F, MDiff (f : ℍ → ℂ)
   zero_at_cusps (f : F) {c : OnePoint ℝ} (hc : IsCusp c Γ) : c.IsZeroAt f k
 
 instance (priority := 100) ModularForm.funLike :

--- a/Mathlib/NumberTheory/ModularForms/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/Basic.lean
@@ -11,6 +11,7 @@ public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
 public import Mathlib.NumberTheory.ModularForms.BoundedAtCusp
 public import Mathlib.NumberTheory.ModularForms.SlashInvariantForms
+import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # Modular forms

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
@@ -9,6 +9,7 @@ public import Mathlib.NumberTheory.ModularForms.EisensteinSeries.UniformConverge
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Analysis.Complex.LocallyUniformLimit
 public import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
+import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # Holomorphicity of Eisenstein series

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
@@ -50,7 +50,7 @@ lemma eisSummand_extension_differentiableOn (k : ℤ) (a : Fin 2 → ℤ) :
 
 /-- Eisenstein series are MDifferentiable (i.e. holomorphic functions from `ℍ → ℂ`). -/
 theorem eisensteinSeriesSIF_mdifferentiable {k : ℤ} {N : ℕ} (hk : 3 ≤ k) (a : Fin 2 → ZMod N) :
-    MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (eisensteinSeriesSIF a k) := by
+    MDiff (eisensteinSeriesSIF a k) := by
   intro τ
   suffices DifferentiableAt ℂ (↑ₕeisensteinSeriesSIF a k) τ.1 by
     convert MDifferentiableAt.comp τ (DifferentiableAt.mdifferentiableAt this) τ.mdifferentiable_coe

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/Manifold.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/Manifold.lean
@@ -25,5 +25,5 @@ public section
 
 open scoped UpperHalfPlane Manifold
 
-theorem mdifferentiable_jacobiTheta : MDifferentiable 𝓘(ℂ) 𝓘(ℂ) (jacobiTheta ∘ (↑) : ℍ → ℂ) :=
+theorem mdifferentiable_jacobiTheta : MDiff (jacobiTheta ∘ (↑) : ℍ → ℂ) :=
   fun τ => (differentiableAt_jacobiTheta τ.2).mdifferentiableAt.comp τ τ.mdifferentiable_coe


### PR DESCRIPTION
The differential geometry directory gained some custom elaborators, which allow omitting the model with corners in many cases. For example, instead of writing `MDifferentiable I J f`, you can now write `MDiff f` (and I and J are usually inferred from the domain and co-domain of f --- if not, an error message will tell you why not).

Use these elaborators to shorten differentiability statements.

---

Split out from #30357.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
