### PR TITLE
[Merged by Bors] - chore: golf using `exact`/`simpa`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Cover/Directed.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Directed.lean
@@ -91,9 +91,7 @@ lemma exists_of_trans_eq_trans {i j k : 𝒰.I₀} (fi : i ⟶ k) (fj : j ⟶ k)
   have : 𝒰.f i xi = 𝒰.f j xj := by
     rw [← 𝒰.trans_map fi, ← 𝒰.trans_map fj, Hom.comp_base, Hom.comp_base,
       ConcreteCategory.comp_apply, h, ConcreteCategory.comp_apply]
-  obtain ⟨z, rfl, rfl⟩ := Scheme.Pullback.exists_preimage_pullback xi xj this
-  obtain ⟨l, gi, gj, y, rfl⟩ := 𝒰.exists_lift_trans_eq z
-  refine ⟨l, gi, gj, y, ?_, ?_⟩ <;> simp [← Scheme.Hom.comp_apply]
+  exact exists_of_f_eq_f _ _ _ this
 
 lemma property_trans {i j : 𝒰.I₀} (hij : i ⟶ j) : P (𝒰.trans hij) :=
   LocallyDirected.property_trans hij

--- a/Mathlib/AlgebraicGeometry/Cover/Directed.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Directed.lean
@@ -87,11 +87,9 @@ set_option backward.isDefEq.respectTransparency false in
 lemma exists_of_trans_eq_trans {i j k : 𝒰.I₀} (fi : i ⟶ k) (fj : j ⟶ k) (xi : 𝒰.X i)
     (xj : 𝒰.X j) (h : 𝒰.trans fi xi = 𝒰.trans fj xj) :
     ∃ (l : 𝒰.I₀) (fli : l ⟶ i) (flj : l ⟶ j) (x : 𝒰.X l),
-      𝒰.trans fli x = xi ∧ 𝒰.trans flj x = xj := by
-  have : 𝒰.f i xi = 𝒰.f j xj := by
-    rw [← 𝒰.trans_map fi, ← 𝒰.trans_map fj, Hom.comp_base, Hom.comp_base,
-      ConcreteCategory.comp_apply, h, ConcreteCategory.comp_apply]
-  exact exists_of_f_eq_f _ _ _ this
+      𝒰.trans fli x = xi ∧ 𝒰.trans flj x = xj := exists_of_f_eq_f _ _ _ <| by
+  rw [← 𝒰.trans_map fi, ← 𝒰.trans_map fj, Hom.comp_base, Hom.comp_base,
+    ConcreteCategory.comp_apply, h, ConcreteCategory.comp_apply]
 
 lemma property_trans {i j : 𝒰.I₀} (hij : i ⟶ j) : P (𝒰.trans hij) :=
   LocallyDirected.property_trans hij

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -207,11 +207,7 @@ lemma compactSpace_iff_exists :
     CompactSpace X ↔ ∃ R, ∃ f : Spec R ⟶ X, Function.Surjective f := by
   refine ⟨fun h ↦ ?_, fun ⟨R, f, hf⟩ ↦ ⟨hf.range_eq ▸ isCompact_range f.continuous⟩⟩
   let 𝒰 : X.OpenCover := X.affineCover.finiteSubcover
-  refine ⟨Γ(∐ 𝒰.X, ⊤), (∐ 𝒰.X).isoSpec.inv ≫ Sigma.desc 𝒰.f, ?_⟩
-  refine Function.Surjective.comp (g := Sigma.desc 𝒰.f)
-    (fun x ↦ ?_) (∐ 𝒰.X).isoSpec.inv.surjective
-  obtain ⟨y, hy⟩ := 𝒰.covers x
-  exact ⟨Sigma.ι 𝒰.X (𝒰.idx x) y, by rw [← Scheme.Hom.comp_apply, Sigma.ι_desc, hy]⟩
+  exact ⟨Γ(∐ 𝒰.X, ⊤), (∐ 𝒰.X).isoSpec.inv ≫ Sigma.desc 𝒰.f, Surjective.surj⟩
 
 lemma isCompact_iff_exists {U : X.Opens} :
     IsCompact (U : Set X) ↔ ∃ R, ∃ f : Spec R ⟶ X, Set.range f = U := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -204,10 +204,11 @@ instance (f : X ⟶ Z) (g : Y ⟶ Z) [QuasiCompact g] [CompactSpace X] : Compact
   QuasiCompact.compactSpace_of_compactSpace (pullback.fst _ _)
 
 lemma compactSpace_iff_exists :
-    CompactSpace X ↔ ∃ R, ∃ f : Spec R ⟶ X, Function.Surjective f := by
-  refine ⟨fun h ↦ ?_, fun ⟨R, f, hf⟩ ↦ ⟨hf.range_eq ▸ isCompact_range f.continuous⟩⟩
-  let 𝒰 : X.OpenCover := X.affineCover.finiteSubcover
-  exact ⟨Γ(∐ 𝒰.X, ⊤), (∐ 𝒰.X).isoSpec.inv ≫ Sigma.desc 𝒰.f, Surjective.surj⟩
+    CompactSpace X ↔ ∃ R, ∃ f : Spec R ⟶ X, Function.Surjective f where
+  mp _ := let 𝒰 : X.OpenCover := X.affineCover.finiteSubcover
+    ⟨Γ(∐ 𝒰.X, ⊤), (∐ 𝒰.X).isoSpec.inv ≫ Sigma.desc 𝒰.f, Surjective.surj⟩
+  mpr := fun ⟨_, f, hf⟩ ↦ ⟨hf.range_eq ▸ isCompact_range f.continuous⟩
+
 
 lemma isCompact_iff_exists {U : X.Opens} :
     IsCompact (U : Set X) ↔ ∃ R, ∃ f : Spec R ⟶ X, Set.range f = U := by

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -807,13 +807,12 @@ theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ �
   exact eq_comp_δ_of_not_surjective' θ i (not_exists.mp hi)
 
 theorem eq_id_of_mono {x : SimplexCategory} (i : x ⟶ x) [Mono i] : i = 𝟙 _ := by
-  suffices IsIso i by
-    apply eq_id_of_isIso
-  exact (isIso_iff_of_mono i).mpr rfl
+  have := (isIso_iff_of_mono i).mpr rfl
+  exact eq_id_of_isIso _
 
 theorem eq_id_of_epi {x : SimplexCategory} (i : x ⟶ x) [Epi i] : i = 𝟙 _ := by
-  suffices IsIso i from eq_id_of_isIso _
-  exact (isIso_iff_of_epi i).mpr rfl
+  have := (isIso_iff_of_epi i).mpr rfl
+  exact eq_id_of_isIso _
 
 theorem eq_σ_of_epi {n : ℕ} (θ : ⦋n + 1⦌ ⟶ ⦋n⦌) [Epi θ] : ∃ i : Fin (n + 1), θ = σ i := by
   obtain ⟨i, θ', h⟩ := eq_σ_comp_of_not_injective θ (by

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -809,19 +809,11 @@ theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ �
 theorem eq_id_of_mono {x : SimplexCategory} (i : x ⟶ x) [Mono i] : i = 𝟙 _ := by
   suffices IsIso i by
     apply eq_id_of_isIso
-  apply isIso_of_bijective
-  dsimp
-  rw [Fintype.bijective_iff_injective_and_card i.toOrderHom, ← mono_iff_injective,
-    eq_self_iff_true, and_true]
-  infer_instance
+  exact (isIso_iff_of_mono i).mpr rfl
 
 theorem eq_id_of_epi {x : SimplexCategory} (i : x ⟶ x) [Epi i] : i = 𝟙 _ := by
   suffices IsIso i from eq_id_of_isIso _
-  apply isIso_of_bijective
-  dsimp
-  rw [Fintype.bijective_iff_surjective_and_card i.toOrderHom, ← epi_iff_surjective,
-    eq_self_iff_true, and_true]
-  infer_instance
+  exact (isIso_iff_of_epi i).mpr rfl
 
 theorem eq_σ_of_epi {n : ℕ} (θ : ⦋n + 1⦌ ⟶ ⦋n⦌) [Epi θ] : ∃ i : Fin (n + 1), θ = σ i := by
   obtain ⟨i, θ', h⟩ := eq_σ_comp_of_not_injective θ (by

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -806,13 +806,13 @@ theorem eq_comp_δ_of_not_surjective {n : ℕ} {Δ : SimplexCategory} (θ : Δ �
   use i
   exact eq_comp_δ_of_not_surjective' θ i (not_exists.mp hi)
 
-theorem eq_id_of_mono {x : SimplexCategory} (i : x ⟶ x) [Mono i] : i = 𝟙 _ := by
+theorem eq_id_of_mono {x : SimplexCategory} (i : x ⟶ x) [Mono i] : i = 𝟙 _ :=
   have := (isIso_iff_of_mono i).mpr rfl
-  exact eq_id_of_isIso _
+  eq_id_of_isIso _
 
-theorem eq_id_of_epi {x : SimplexCategory} (i : x ⟶ x) [Epi i] : i = 𝟙 _ := by
+theorem eq_id_of_epi {x : SimplexCategory} (i : x ⟶ x) [Epi i] : i = 𝟙 _ :=
   have := (isIso_iff_of_epi i).mpr rfl
-  exact eq_id_of_isIso _
+  eq_id_of_isIso _
 
 theorem eq_σ_of_epi {n : ℕ} (θ : ⦋n + 1⦌ ⟶ ⦋n⦌) [Epi θ] : ∃ i : Fin (n + 1), θ = σ i := by
   obtain ⟨i, θ', h⟩ := eq_σ_comp_of_not_injective θ (by

--- a/Mathlib/CategoryTheory/Sites/Plus.lean
+++ b/Mathlib/CategoryTheory/Sites/Plus.lean
@@ -258,11 +258,7 @@ theorem isIso_toPlus_of_isSheaf (hP : Presheaf.IsSheaf J P) : IsIso (J.toPlus P)
   intro S T e
   have : S.unop.toMultiequalizer P ≫ (J.diagram P X.unop).map e = T.unop.toMultiequalizer P :=
     Multiequalizer.hom_ext _ _ _ (fun II => by simp)
-  have :
-    (J.diagram P X.unop).map e = inv (S.unop.toMultiequalizer P) ≫ T.unop.toMultiequalizer P := by
-    simp [← this]
-  rw [this]
-  infer_instance
+  exact IsIso.of_isIso_fac_left this
 
 /-- The natural isomorphism between `P` and `P⁺` when `P` is a sheaf. -/
 def isoToPlus (hP : Presheaf.IsSheaf J P) : P ≅ J.plusObj P :=

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -253,8 +253,7 @@ lemma isTriangulated_of_op [F.op.IsTriangulated] : F.IsTriangulated where
     rw [← this, Functor.comp_obj, ← mem_distTriang_op_iff, ← Functor.op_obj, ← Functor.comp_obj,
       distinguished_iff_of_iso ((mapTriangleOpCompTriangleOpEquivalenceFunctor F).app
       (Opposite.op T))]
-    apply F.op.map_distinguished
-    exact op_distinguished T dT
+    exact F.op.map_distinguished _ (op_distinguished _ dT)
 
 open Pretriangulated.Opposite in
 /-- `F` is triangulated if and only if `F.op` is triangulated.

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -254,10 +254,7 @@ lemma isTriangulated_of_op [F.op.IsTriangulated] : F.IsTriangulated where
       distinguished_iff_of_iso ((mapTriangleOpCompTriangleOpEquivalenceFunctor F).app
       (Opposite.op T))]
     apply F.op.map_distinguished
-    have := distinguished_iff_of_iso ((triangleOpEquivalence C).unitIso.app (Opposite.op T)).unop
-    rw [Functor.id_obj, Opposite.unop_op T] at this
-    rw [← this, Functor.comp_obj, ← mem_distTriang_op_iff] at dT
-    exact dT
+    exact op_distinguished T dT
 
 open Pretriangulated.Opposite in
 /-- `F` is triangulated if and only if `F.op` is triangulated.

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -457,10 +457,7 @@ theorem chromaticNumber_top [Fintype V] : (⊤ : SimpleGraph V).chromaticNumber 
   rw [chromaticNumber_eq_card_iff_forall_surjective (selfColoring _).colorable]
   intro C
   rw [← Finite.injective_iff_surjective]
-  intro v w
-  contrapose
-  intro h
-  exact C.valid h
+  exact Hom.injective_of_top_hom C
 
 theorem chromaticNumber_top_eq_top_of_infinite (V : Type*) [Infinite V] :
     (⊤ : SimpleGraph V).chromaticNumber = ⊤ := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -65,12 +65,8 @@ protected lemma Connected.preconnected {H : G.Subgraph} (h : H.Connected) : H.Pr
 protected lemma Connected.nonempty {H : G.Subgraph} (h : H.Connected) : H.verts.Nonempty := by
   rw [H.connected_iff] at h; exact h.2
 
-theorem singletonSubgraph_connected {v : V} : (G.singletonSubgraph v).Connected := by
-  refine ⟨⟨?_⟩⟩
-  rintro ⟨a, ha⟩ ⟨b, hb⟩
-  simp only [singletonSubgraph_verts, Set.mem_singleton_iff] at ha hb
-  subst_vars
-  rfl
+theorem singletonSubgraph_connected {v : V} : (G.singletonSubgraph v).Connected :=
+  ⟨⟨Preconnected.of_subsingleton⟩⟩
 
 @[simp]
 theorem subgraphOfAdj_connected {v w : V} (hvw : G.Adj v w) : (G.subgraphOfAdj hvw).Connected := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
@@ -107,7 +107,7 @@ theorem exists_length_eq_zero_iff {u v : V} : (∃ p : G.Walk u v, p.length = 0)
 
 @[simp]
 lemma exists_length_eq_one_iff {u v : V} : (∃ (p : G.Walk u v), p.length = 1) ↔ G.Adj u v :=
-  ⟨fun ⟨_, hp⟩ ↦ adj_of_length_eq_one hp, fun h ↦ ⟨h.toWalk, by simp⟩⟩
+  ⟨fun ⟨_, hp⟩ ↦ adj_of_length_eq_one hp, (⟨·.toWalk, by simp⟩)⟩
 
 @[simp]
 theorem length_eq_zero_iff {u : V} {p : G.Walk u u} : p.length = 0 ↔ p = nil := by cases p <;> simp

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
@@ -106,13 +106,8 @@ theorem exists_length_eq_zero_iff {u v : V} : (∃ p : G.Walk u v, p.length = 0)
   ⟨fun ⟨_, h⟩ ↦ (eq_of_length_eq_zero h), (· ▸ ⟨nil, rfl⟩)⟩
 
 @[simp]
-lemma exists_length_eq_one_iff {u v : V} : (∃ (p : G.Walk u v), p.length = 1) ↔ G.Adj u v := by
-  refine ⟨fun ⟨p, hp⟩ ↦ ?_, fun h ↦ ⟨h.toWalk, by simp⟩⟩
-  induction p with
-  | nil => simp at hp
-  | cons h p' =>
-    simp only [Walk.length_cons, add_eq_right] at hp
-    exact (p'.eq_of_length_eq_zero hp) ▸ h
+lemma exists_length_eq_one_iff {u v : V} : (∃ (p : G.Walk u v), p.length = 1) ↔ G.Adj u v :=
+  ⟨fun ⟨_, hp⟩ ↦ adj_of_length_eq_one hp, fun h ↦ ⟨h.toWalk, by simp⟩⟩
 
 @[simp]
 theorem length_eq_zero_iff {u : V} {p : G.Walk u u} : p.length = 0 ↔ p = nil := by cases p <;> simp

--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -101,11 +101,7 @@ theorem _root_.Module.natCard_eq_pow_finrank [Module.Finite K V] :
 /-- A module over a division ring is Noetherian if and only if it is finitely generated. -/
 theorem iff_fg : IsNoetherian K V ↔ Module.Finite K V := by
   constructor
-  · intro h
-    exact
-      ⟨⟨finsetBasisIndex K V, by
-          convert (finsetBasis K V).span_eq
-          simp⟩⟩
+  · exact fun _ ↦ IsNoetherian.finite K V
   · rintro ⟨s, hs⟩
     rw [IsNoetherian.iff_rank_lt_aleph0, ← rank_top, ← hs]
     exact lt_of_le_of_lt (rank_span_le _) s.finite_toSet.lt_aleph0

--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -99,11 +99,7 @@ theorem _root_.Module.natCard_eq_pow_finrank [Module.Finite K V] :
   rw [Nat.card_congr b.equivFun.toEquiv, Nat.card_fun, finrank_eq_nat_card_basis b]
 
 /-- A module over a division ring is Noetherian if and only if it is finitely generated. -/
-theorem iff_fg : IsNoetherian K V ↔ Module.Finite K V := by
-  constructor
-  · exact fun _ ↦ IsNoetherian.finite K V
-  · rintro ⟨s, hs⟩
-    rw [IsNoetherian.iff_rank_lt_aleph0, ← rank_top, ← hs]
-    exact lt_of_le_of_lt (rank_span_le _) s.finite_toSet.lt_aleph0
+theorem iff_fg : IsNoetherian K V ↔ Module.Finite K V :=
+  ⟨fun _ ↦ IsNoetherian.finite _ _, fun _ ↦ isNoetherian_of_isNoetherianRing_of_finite _ _⟩
 
 end IsNoetherian

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -385,10 +385,7 @@ theorem contMDiff_inclusion {n : WithTop ℕ∞} {U V : Opens M} (h : U ≤ V) :
     ContMDiff I I n (Opens.inclusion h : U → V) := by
   rintro ⟨x, hx : x ∈ U⟩
   apply (contDiffWithinAt_localInvariantProp n).liftProp_inclusion
-  intro y
-  dsimp only [ContDiffWithinAtProp, id_comp, preimage_univ]
-  rw [Set.univ_inter]
-  exact contDiffWithinAt_id.congr I.rightInvOn (congr_arg I (I.left_inv y))
+  exact (contDiffWithinAtProp_id ·)
 
 end Inclusion
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -384,8 +384,7 @@ theorem ContMDiff.extend_one [T2Space M] [One M'] {n : WithTop ℕ∞} {U : Open
 theorem contMDiff_inclusion {n : WithTop ℕ∞} {U V : Opens M} (h : U ≤ V) :
     ContMDiff I I n (Opens.inclusion h : U → V) := by
   rintro ⟨x, hx : x ∈ U⟩
-  apply (contDiffWithinAt_localInvariantProp n).liftProp_inclusion
-  exact (contDiffWithinAtProp_id ·)
+  exact (contDiffWithinAt_localInvariantProp n).liftProp_inclusion (contDiffWithinAtProp_id ·) _ _
 
 end Inclusion
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -382,9 +382,8 @@ theorem ContMDiff.extend_one [T2Space M] [One M'] {n : WithTop ℕ∞} {U : Open
   exact diff.contMDiffAt
 
 theorem contMDiff_inclusion {n : WithTop ℕ∞} {U V : Opens M} (h : U ≤ V) :
-    ContMDiff I I n (Opens.inclusion h : U → V) := by
-  rintro ⟨x, hx : x ∈ U⟩
-  exact (contDiffWithinAt_localInvariantProp n).liftProp_inclusion (contDiffWithinAtProp_id ·) _ _
+    ContMDiff I I n (Opens.inclusion h : U → V) := fun _ ↦
+  (contDiffWithinAt_localInvariantProp n).liftProp_inclusion (contDiffWithinAtProp_id ·) _ _
 
 end Inclusion
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -175,8 +175,7 @@ lemma FermatLastTheoremForThree_of_FermatLastTheoremThreeGen
   · rwa [← Ideal.norm_dvd_iff (hζ.prime_norm_toInteger_sub_one_of_prime_ne_two' (by decide)),
       hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)] at hdvd
   · exact dvd_trans hζ.toInteger_sub_one_dvd_prime' ⟨x, by simp [hx]⟩
-  · rw [show a = algebraMap _ (𝓞 K) a by simp, show b = algebraMap _ (𝓞 K) b by simp]
-    exact hcoprime.map _
+  · exact IsCoprime.intCast hcoprime
   · simp only [Units.val_one, one_mul]
     exact_mod_cast h
 
@@ -283,12 +282,8 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Given `S' : Solution'`, we have that `λ ^ 2` divides `S'.c`. -/
 lemma lambda_sq_dvd_c : λ ^ 2 ∣ S'.c := by
   have hm := S'.multiplicity_lambda_c_finite
-  suffices 2 ≤ multiplicity (hζ.toInteger - 1) S'.c by
-    obtain ⟨x, hx⟩ := pow_multiplicity_dvd (hζ.toInteger - 1) S'.c
-    refine ⟨λ ^ (multiplicity (hζ.toInteger - 1) S'.c - 2) * x, ?_⟩
-    rw [← mul_assoc, ← pow_add]
-    convert hx using 3
-    simp [this]
+  suffices 2 ≤ multiplicity (hζ.toInteger - 1) S'.c from
+    (FiniteMultiplicity.pow_dvd_iff_le_multiplicity hm).mpr this
   have := lambda_pow_four_dvd_c_cube S'
   rw [pow_dvd_iff_le_emultiplicity, emultiplicity_pow hζ.zeta_sub_one_prime',
     hm.emultiplicity_eq_multiplicity] at this

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -176,7 +176,7 @@ lemma FermatLastTheoremForThree_of_FermatLastTheoremThreeGen
       hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)] at hdvd
   · exact dvd_trans hζ.toInteger_sub_one_dvd_prime' ⟨x, by simp [hx]⟩
   · exact IsCoprime.intCast hcoprime
-  · simpa using by exact_mod_cast h
+  · simpa using mod_cast h
 
 namespace FermatLastTheoremForThreeGen
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -176,8 +176,7 @@ lemma FermatLastTheoremForThree_of_FermatLastTheoremThreeGen
       hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)] at hdvd
   · exact dvd_trans hζ.toInteger_sub_one_dvd_prime' ⟨x, by simp [hx]⟩
   · exact IsCoprime.intCast hcoprime
-  · simp only [Units.val_one, one_mul]
-    exact_mod_cast h
+  · simpa using by exact_mod_cast h
 
 namespace FermatLastTheoremForThreeGen
 
@@ -282,13 +281,11 @@ set_option backward.isDefEq.respectTransparency false in
 /-- Given `S' : Solution'`, we have that `λ ^ 2` divides `S'.c`. -/
 lemma lambda_sq_dvd_c : λ ^ 2 ∣ S'.c := by
   have hm := S'.multiplicity_lambda_c_finite
-  suffices 2 ≤ multiplicity (hζ.toInteger - 1) S'.c from
-    (FiniteMultiplicity.pow_dvd_iff_le_multiplicity hm).mpr this
   have := lambda_pow_four_dvd_c_cube S'
   rw [pow_dvd_iff_le_emultiplicity, emultiplicity_pow hζ.zeta_sub_one_prime',
     hm.emultiplicity_eq_multiplicity] at this
   norm_cast at this
-  lia
+  exact (FiniteMultiplicity.pow_dvd_iff_le_multiplicity hm).mpr (by lia)
 
 /-- Given `S' : Solution'`, we have that `2 ≤ S'.multiplicity`. -/
 lemma Solution'.two_le_multiplicity : 2 ≤ S'.multiplicity := by

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -684,7 +684,7 @@ theorem isGLB_sInf' {β : Type*} [ConditionallyCompleteLattice β] {s : Set (Wit
 theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
   by_cases hs : BddBelow s
   · exact isGLB_sInf' hs
-  · exact hs.elim (OrderBot.bddBelow _)
+  · exact isGLB_sInf' (OrderBot.bddBelow _)
 
 noncomputable instance : CompleteLinearOrder (WithTop α) where
   __ := linearOrder

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -684,9 +684,7 @@ theorem isGLB_sInf' {β : Type*} [ConditionallyCompleteLattice β] {s : Set (Wit
 theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
   by_cases hs : BddBelow s
   · exact isGLB_sInf' hs
-  · exfalso
-    apply hs
-    exact OrderBot.bddBelow _
+  · exact hs.elim (OrderBot.bddBelow _)
 
 noncomputable instance : CompleteLinearOrder (WithTop α) where
   __ := linearOrder

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -686,9 +686,7 @@ theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
   · exact isGLB_sInf' hs
   · exfalso
     apply hs
-    use ⊥
-    intro _ _
-    exact bot_le
+    exact OrderBot.bddBelow _
 
 noncomputable instance : CompleteLinearOrder (WithTop α) where
   __ := linearOrder

--- a/Mathlib/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Order/SuccPred/WithBot.lean
@@ -54,11 +54,7 @@ variable {α : Type*} [Nontrivial α] [LinearOrder α] [OrderBot α] [SuccOrder 
 theorem succ_eq_bot (a : WithBot α) : WithBot.succ a = ⊥ ↔ a = ⊥ := by
   cases a
   · simp
-  · simp only [WithBot.succ_coe, WithBot.coe_ne_bot, iff_false]
-    apply ne_of_gt
-    by_contra! h
-    have h₂ : _ = ⊥ := le_bot_iff.mp ((Order.le_succ _).trans h)
-    exact not_isMax_bot (h₂ ▸ Order.max_of_succ_le (h.trans bot_le))
+  · simpa [WithBot.succ_coe, WithBot.coe_ne_bot, iff_false] using Order.succ_ne_bot _
 
 end LinearOrder
 end WithBot
@@ -100,10 +96,7 @@ theorem pred_eq_top (a : WithTop α) : WithTop.pred a = ⊤ ↔ a = ⊤ := by
   cases a
   · simp
   · simp only [WithTop.pred_coe, WithTop.coe_ne_top, iff_false]
-    apply ne_of_lt
-    by_contra! h
-    have h₂ : _ = ⊤ := top_le_iff.mp (h.trans (Order.pred_le _))
-    exact not_isMin_top (h₂ ▸ Order.min_of_le_pred (le_top.trans h))
+    simpa [WithTop.pred_coe, WithTop.coe_ne_top, iff_false] using Order.pred_ne_top _
 
 end LinearOrder
 end WithTop

--- a/Mathlib/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Order/SuccPred/WithBot.lean
@@ -93,10 +93,7 @@ variable {α : Type*} [Nontrivial α] [LinearOrder α] [OrderTop α] [PredOrder 
 
 @[simp]
 theorem pred_eq_top (a : WithTop α) : WithTop.pred a = ⊤ ↔ a = ⊤ := by
-  cases a
-  · simp
-  · simp only [WithTop.pred_coe, WithTop.coe_ne_top, iff_false]
-    simpa [WithTop.pred_coe, WithTop.coe_ne_top, iff_false] using Order.pred_ne_top _
+  cases a <;> simp [Order.pred_ne_top]
 
 end LinearOrder
 end WithTop


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `AlgebraicGeometry.Scheme.Cover.exists_of_trans_eq_trans`: unchanged 🎉
* `AlgebraicGeometry.compactSpace_iff_exists`: unchanged 🎉
* `SimplexCategory.eq_id_of_mono`: unchanged 🎉
* `SimplexCategory.eq_id_of_epi`: unchanged 🎉
* `CategoryTheory.GrothendieckTopology.isIso_toPlus_of_isSheaf`: unchanged 🎉
* `CategoryTheory.Functor.isTriangulated_of_op`: unchanged 🎉
* `SimpleGraph.chromaticNumber_top`: unchanged 🎉
* `SimpleGraph.Subgraph.singletonSubgraph_connected`: unchanged 🎉
* `SimpleGraph.Walk.exists_length_eq_one_iff`: unchanged 🎉
* `Turing.TM2to1.addBottom_modifyNth`: unchanged 🎉
* `IsNoetherian.iff_fg`: unchanged 🎉
* `contMDiff_inclusion`: unchanged 🎉
* `FermatLastTheoremForThree_of_FermatLastTheoremThreeGen`: 146 ms before, 91 ms after  🎉
* `FermatLastTheoremForThreeGen.lambda_sq_dvd_c`: 313 ms before, 218 ms after  🎉
* `WithTop.isGLB_sInf`: unchanged 🎉
* `WithBot.succ_eq_bot`: 56 ms before, <30 ms after  🎉
* `WithTop.pred_eq_top`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
