### PR TITLE
[Merged by Bors] - chore: remove no-longer-needed backwards compatibility options

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -797,7 +797,6 @@ theorem prod_span_singleton {ι : Type*} (s : Finset ι) (x : ι → A) :
 
 variable (R A)
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- R-submodules of the R-algebra A are a module over `Set A`. -/
 noncomputable instance moduleSet : Module (SetSemiring A) (Submodule R A) where

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -152,7 +152,6 @@ theorem sum_Ico_reflect {δ : Type*} [AddCommMonoid δ] (f : ℕ → δ) (k : �
     (h : m ≤ n + 1) : (∑ j ∈ Ico k m, f (n - j)) = ∑ j ∈ Ico (n + 1 - m) (n + 1 - k), f j :=
   @prod_Ico_reflect (Multiplicative δ) _ f k m n h
 
-set_option backward.isDefEq.respectTransparency false in
 theorem prod_range_reflect (f : ℕ → M) (n : ℕ) :
     (∏ j ∈ range n, f (n - 1 - j)) = ∏ j ∈ range n, f j := by
   cases n

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -252,7 +252,6 @@ namespace Free
 
 section
 
-set_option backward.whnf.reducibleClassField false in
 instance : Preadditive (Free R C) where
   homGroup _ _ := Finsupp.instAddCommGroup
   add_comp X Y Z f f' g := by
@@ -264,7 +263,6 @@ instance : Preadditive (Free R C) where
     congr; ext r h
     rw [Finsupp.sum_add_index'] <;> · simp [mul_add]
 
-set_option backward.whnf.reducibleClassField false in
 instance : Linear R (Free R C) where
   homModule _ _ := Finsupp.module _ R
   smul_comp X Y Z r f g := by
@@ -276,7 +274,6 @@ instance : Linear R (Free R C) where
     congr; ext h s
     rw [Finsupp.sum_smul_index] <;> simp [mul_left_comm]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 theorem single_comp_single {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (r s : R) :
     (single f r ≫ single g s : Free.of R X ⟶ Free.of R Z) = single (f ≫ g) (r * s) := by
@@ -303,7 +300,6 @@ variable {C} {D : Type u} [Category.{v} D] [Preadditive D] [Linear R D]
 
 open Preadditive Linear
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- A functor to an `R`-linear category lifts to a functor from its `R`-linear completion.
 -/

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -223,7 +223,6 @@ instance instDistrib : Distrib (FreeAlgebra R X) where
     rintro ⟨⟩ ⟨⟩ ⟨⟩
     exact Quot.sound Rel.right_distrib
 
-set_option backward.whnf.reducibleClassField false in
 instance instAddCommMonoid : AddCommMonoid (FreeAlgebra R X) where
   add_assoc := by
     rintro ⟨⟩ ⟨⟩ ⟨⟩

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -884,7 +884,6 @@ instance uniqueNormalizationMonoidOfUniqueUnits : Unique (NormalizationMonoid α
   default := .ofUniqueUnits
   uniq := fun ⟨u, _, _, _⟩ => by congr; simp [eq_iff_true_of_subsingleton]
 
-set_option backward.whnf.reducibleClassField false in
 instance subsingleton_gcdMonoid_of_unique_units : Subsingleton (GCDMonoid α) :=
   ⟨fun g₁ g₂ => by
     have hgcd : g₁.gcd = g₂.gcd := by

--- a/Mathlib/Algebra/Group/Action/Hom.lean
+++ b/Mathlib/Algebra/Group/Action/Hom.lean
@@ -40,7 +40,6 @@ namespace MulAction
 
 variable (α)
 
-set_option backward.whnf.reducibleClassField false in
 /-- A multiplicative action of `M` on `α` and a monoid homomorphism `N → M` induce
 a multiplicative action of `N` on `α`.
 

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -408,7 +408,6 @@ theorem mk_mem_nonZeroDivisors_associates : Associates.mk a ∈ (Associates M₀
   · refine fun ⟨b, hb₁, hb₂⟩ ↦ ⟨Associates.mk b, ?_, by rwa [Associates.mk_ne_zero]⟩
     rw [Associates.mk_mul_mk, hb₁, Associates.mk_zero]
 
-set_option backward.whnf.reducibleClassField false in
 /-- The non-zero divisors of associates of a monoid with zero `M₀` are isomorphic to the associates
 of the non-zero divisors of `M₀` under the map `⟨⟦a⟧, _⟩ ↦ ⟦⟨a, _⟩⟧`. -/
 def associatesNonZeroDivisorsEquiv : (Associates M₀)⁰ ≃* Associates M₀⁰ where

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -541,7 +541,6 @@ lemma traceForm_eq_zero_of_mem_ker_of_mem_span_coroot {α : Weight K H L} {x y :
         root_apply_coroot hβ]
     · simp [root_apply_coroot hα]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma exists_isSl2Triple_of_weight_isNonZero {α : Weight K H L} (hα : α.IsNonZero) :
     ∃ h e f : L, IsSl2Triple h e f ∧ e ∈ rootSpace H α ∧ f ∈ rootSpace H (-α) := by
   obtain ⟨e, heα : e ∈ rootSpace H α, he₀ : e ≠ 0⟩ := α.exists_ne_zero

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -258,7 +258,6 @@ lemma chainLength_of_eq_zsmul_add (β' : Weight K H L) (n : ℤ) (hβ' : (β' : 
       chainBotCoeff_of_eq_zsmul_add α β hα β' n hβ', sub_eq_add_neg, add_add_add_comm,
       neg_add_cancel, add_zero]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma chainTopCoeff_zero_right [Nontrivial L] (hα : α.IsNonZero) :
     chainTopCoeff α (0 : Weight K H L) = 1 := by
   symm

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -167,7 +167,6 @@ theorem exists_smul_eq_zero_and_mk_eq {z : M} (hz : Module.IsTorsionBy R M (p ^ 
 
 open Finset Multiset
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 omit dec in
 /-- A finitely generated `p ^ ∞`-torsion module over a PID is isomorphic to a direct sum of some

--- a/Mathlib/Algebra/Order/Nonneg/Lattice.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Lattice.lean
@@ -53,7 +53,6 @@ protected noncomputable abbrev conditionallyCompleteLinearOrder [ConditionallyCo
     {a : α} : ConditionallyCompleteLinearOrder { x : α // a ≤ x } :=
   { @ordConnectedSubsetConditionallyCompleteLinearOrder α (Set.Ici a) _ ⟨⟨a, le_rfl⟩⟩ _ with }
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If `sSup ∅ ≤ a` then `{x : α // a ≤ x}` is a `ConditionallyCompleteLinearOrderBot`.
 

--- a/Mathlib/Algebra/Order/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Order/Ring/Idempotent.lean
@@ -67,7 +67,6 @@ instance : SemilatticeSup {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
       (IsIdempotentElem.of_mul_add b.2.1 b.2.2).1.eq, ← mul_add, a.2.2, mul_one]
   sup_le a b c hac hbc := by simp_rw [(· ≤ ·), add_mul, mul_assoc]; rw [hac, hbc]
 
-set_option backward.whnf.reducibleClassField false in
 instance : BooleanAlgebra {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
   inf a b := (aᶜ ⊔ bᶜ)ᶜ
   inf_le_left a b := by simp_rw [(· ≤ ·), (· ⊔ ·), (·ᶜ), SemilatticeSup.sup,

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -118,7 +118,6 @@ instance instPreorder : Preorder ℚ := inferInstance
 instance : AddLeftMono ℚ where
   elim := fun _ _ _ h => Rat.add_le_add_left.2 h
 
-set_option backward.whnf.reducibleClassField false in
 @[simp] lemma num_nonpos {a : ℚ} : a.num ≤ 0 ↔ a ≤ 0 := by
   simp +instances [Int.le_iff_lt_or_eq, instLE, Rat.blt]
 @[simp] lemma num_pos {a : ℚ} : 0 < a.num ↔ 0 < a := lt_iff_lt_of_le_iff_le num_nonpos

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -664,7 +664,6 @@ lemma dvd_comp_C_mul_X_add_C_iff (p q : R[X]) (a b : R) [Invertible a] :
   convert map_dvd_iff <| algEquivCMulXAddC a b using 2
   simp [← comp_eq_aeval, comp_assoc, ← mul_assoc, ← C_mul]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma dvd_comp_X_sub_C_iff (p q : R[X]) (a : R) :
     p ∣ q.comp (X - C a) ↔ p.comp (X + C a) ∣ q := by
   let _ := invertibleOne (α := R)
@@ -674,7 +673,6 @@ lemma dvd_comp_X_add_C_iff (p q : R[X]) (a : R) :
     p ∣ q.comp (X + C a) ↔ p.comp (X - C a) ∣ q := by
   simpa using dvd_comp_X_sub_C_iff p q (-a)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma dvd_comp_neg_X_iff (p q : R[X]) : p ∣ q.comp (-X) ↔ p.comp (-X) ∣ q := by
   let _ := invertibleOne (α := R)
   let _ := invertibleNeg (R := R) 1

--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -592,7 +592,6 @@ theorem dvd_C_mul (ha : a ≠ 0) : p ∣ Polynomial.C a * q ↔ p ∣ q :=
         one_mul]⟩,
     fun h => dvd_trans h (dvd_mul_left _ _)⟩
 
-set_option backward.isDefEq.respectTransparency false in
 theorem coe_normUnit_of_ne_zero [DecidableEq R] (hp : p ≠ 0) :
     (normUnit p : R[X]) = C p.leadingCoeff⁻¹ := by
   have : p.leadingCoeff ≠ 0 := mt leadingCoeff_eq_zero.mp hp
@@ -694,7 +693,6 @@ theorem irreducible_iff_lt_natDegree_lt {p : R[X]} (hp0 : p ≠ 0) (hpu : ¬ IsU
   simp only [IsUnit.dvd_mul_right
     (isUnit_C.mpr (IsUnit.mk0 (leadingCoeff p)⁻¹ (inv_ne_zero (leadingCoeff_ne_zero.mpr hp0))))]
 
-set_option backward.isDefEq.respectTransparency false in
 open UniqueFactorizationMonoid in
 /--
 The normalized factors of a polynomial over a field times its leading coefficient give

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -173,7 +173,6 @@ instance : NatCast (RingQuot r) :=
 @[no_expose] instance : Mul (RingQuot r) :=
   ⟨fun ⟨a⟩ ⟨b⟩ ↦ ⟨Quot.map₂ (· * ·) Rel.mul_right Rel.mul_left a b⟩⟩
 
-set_option backward.whnf.reducibleClassField false in
 @[no_expose] instance : NatPow (RingQuot r) :=
   ⟨fun ⟨a⟩ n ↦ ⟨Quot.lift (fun a ↦ Quot.mk (RingQuot.Rel r) (a ^ n))
     (fun a b (h : Rel r a b) ↦ by
@@ -281,7 +280,6 @@ instance instMonoidWithZero (r : R → R → Prop) : MonoidWithZero (RingQuot r)
     rintro n ⟨⟨⟩⟩
     simp only [pow_quot, mul_quot, pow_succ]
 
-set_option backward.whnf.reducibleClassField false in
 instance instSemiring (r : R → R → Prop) : Semiring (RingQuot r) where
   natCast_zero := by simp +instances [instNatCast, natCast, ← zero_quot]
   natCast_succ := by simp +instances [instNatCast, natCast, ← one_quot, add_quot]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -394,7 +394,6 @@ def toShortNFOfCharThree : VariableChange R :=
   letI : Invertible (2 : R) := ⟨2, h, h⟩
   W.toCharNeTwoNF
 
-set_option backward.whnf.reducibleClassField false in
 lemma toShortNFOfCharThree_a₂ : (W.toShortNFOfCharThree • W).a₂ = W.b₂ := by
   simp_rw [toShortNFOfCharThree, toCharNeTwoNF, variableChange_a₂, inv_one, Units.val_one, b₂]
   linear_combination (-W.a₂ - W.a₁ ^ 2) * CharP.cast_eq_zero R 3

--- a/Mathlib/Analysis/CStarAlgebra/Classes.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Classes.lean
@@ -60,7 +60,6 @@ noncomputable instance StarSubalgebra.commCStarAlgebra {S A : Type*} [CommCStarA
   norm_mul_self_le x := CStarRing.norm_star_mul_self (x := (x : A)) |>.symm.le
   mul_comm _ _ := Subtype.ext <| mul_comm _ _
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance NonUnitalStarSubalgebra.nonUnitalCStarAlgebra {S A : Type*}
     [NonUnitalCStarAlgebra A] [SetLike S A] [NonUnitalSubringClass S A] [SMulMemClass S ℂ A]
     [StarMemClass S A] (s : S) [h_closed : IsClosed (s : Set A)] : NonUnitalCStarAlgebra s where

--- a/Mathlib/Analysis/CStarAlgebra/CompletelyPositiveMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CompletelyPositiveMap.lean
@@ -90,7 +90,6 @@ instance instCoeToCompletelyPositiveMap [CompletelyPositiveMapClass F A₁ A₂]
     CoeHead F (A₁ →CP A₂) where
   coe f := toCompletelyPositiveLinearMap f
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 open CStarMatrix in
 /-- Linear maps which are completely positive are order homomorphisms (i.e., positive maps). -/
@@ -132,7 +131,6 @@ instance : LinearMapClass (A₁ →CP A₂) ℂ A₁ A₂ where
 instance : CompletelyPositiveMapClass (A₁ →CP A₂) A₁ A₂ where
   map_cstarMatrix_nonneg' f := f.map_cstarMatrix_nonneg'
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 open CStarMatrix in
 lemma map_cstarMatrix_nonneg {n : Type*} [Fintype n] (φ : A₁ →CP A₂) (M : CStarMatrix n n A₁)

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -407,7 +407,6 @@ def CStarAlgebra.spectralOrder : PartialOrder A where
       quasispectrumRestricts_iff_spectrumRestricts_inr' ℂ] at hxy hyz ⊢
     exact ⟨by simpa using hyz.1.add hxy.1, by simpa using hyz.2.nnreal_add hyz.1 hxy.1 hxy.2⟩
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 variable (A) in
 /-- The `CStarAlgebra.spectralOrder` on a C⋆-algebra is a `StarOrderedRing`. -/

--- a/Mathlib/Analysis/CStarAlgebra/GelfandNaimarkSegal.lean
+++ b/Mathlib/Analysis/CStarAlgebra/GelfandNaimarkSegal.lean
@@ -131,7 +131,6 @@ lemma leftMulMapPreGNS_mul_eq_comp (a b : A) :
     f.leftMulMapPreGNS (a * b) = f.leftMulMapPreGNS a ∘L f.leftMulMapPreGNS b := by
   ext c; simp [mul_assoc]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /--
 The non-unital ⋆-homomorphism/⋆-representation of `A` into the algebra of bounded operators on
@@ -172,7 +171,6 @@ set_option backward.isDefEq.respectTransparency false in
 lemma gnsNonUnitalStarAlgHom_apply {a : A} :
     f.gnsNonUnitalStarAlgHom a = (f.leftMulMapPreGNS a).completion := rfl
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma gnsNonUnitalStarAlgHom_apply_coe {a : A} {b : f.PreGNS} :
     f.gnsNonUnitalStarAlgHom a b = f.leftMulMapPreGNS a b := by

--- a/Mathlib/Analysis/CStarAlgebra/Hom.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Hom.lean
@@ -19,7 +19,6 @@ Here we collect properties of C⋆-algebra homomorphisms.
 
 public section
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 open CStarAlgebra in
 lemma IsSelfAdjoint.map_spectrum_real {F A B : Type*} [CStarAlgebra A] [CStarAlgebra B]

--- a/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
@@ -135,7 +135,6 @@ noncomputable def Unitary.argSelfAdjoint (u : unitary A) : selfAdjoint A :=
 
 @[deprecated (since := "2025-10-29")] alias unitary.argSelfAdjoint := Unitary.argSelfAdjoint
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma selfAdjoint.norm_sq_expUnitary_sub_one {x : selfAdjoint A} (hx : ‖x‖ ≤ π) :
     ‖(expUnitary x - 1 : A)‖ ^ 2 = 2 * (1 - Real.cos ‖x‖) := by
@@ -154,7 +153,6 @@ lemma selfAdjoint.norm_sq_expUnitary_sub_one {x : selfAdjoint A} (hx : ‖x‖ �
     exact Real.cos_abs y ▸ Real.cos_le_cos_of_nonneg_of_le_pi (by positivity) hx <|
       spectrum.norm_le_norm_of_mem hy
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma argSelfAdjoint_expUnitary {x : selfAdjoint A} (hx : ‖x‖ < π) :
     argSelfAdjoint (expUnitary x) = x := by
@@ -272,7 +270,6 @@ lemma Unitary.continuousOn_argSelfAdjoint :
 @[deprecated (since := "2025-10-29")] alias unitary.continuousOn_argSelfAdjoint :=
   Unitary.continuousOn_argSelfAdjoint
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- the maps `unitary.argSelfAdjoint` and `selfAdjoint.expUnitary` form a partial
 homeomorphism between `ball (1 : unitary A) 2` and `ball (0 : selfAdjoint A) π`. -/
@@ -306,7 +303,6 @@ noncomputable def Unitary.openPartialHomeomorph :
   continuousOn_toFun := by fun_prop
   continuousOn_invFun := by fun_prop
 
-set_option backward.whnf.reducibleClassField false in
 @[deprecated (since := "2025-10-29")] alias unitary.openPartialHomeomorph :=
   Unitary.openPartialHomeomorph
 
@@ -324,7 +320,6 @@ lemma Unitary.expUnitary_eq_mul_inv (u v : unitary A) (huv : ‖(u - v : A)‖ <
 @[deprecated (since := "2025-10-29")] alias unitary.expUnitary_eq_mul_inv :=
   Unitary.expUnitary_eq_mul_inv
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- For a selfadjoint element `x` in a C⋆-algebra, this is the path from `1` to `expUnitary x`
 given by `t ↦ expUnitary (t • x)`. -/

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -202,7 +202,6 @@ end PosRealAction
 
 section RealAddAction
 
-set_option backward.whnf.reducibleClassField false in
 instance : AddAction ℝ ℍ where
   vadd x z := mk (x + z) <| by simpa using z.im_pos
   zero_vadd _ := by simp [HVAdd.hVAdd]

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -916,7 +916,6 @@ local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 since `𝕜` does not appear in the return type `Inner ℝ E`. -/
 def Inner.rclikeToReal : Inner ℝ E where inner x y := re ⟪x, y⟫
 
-set_option backward.whnf.reducibleClassField false in
 /-- A general inner product space structure implies a real inner product structure.
 
 This is not registered as an instance since

--- a/Mathlib/Analysis/InnerProductSpace/Coalgebra.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Coalgebra.lean
@@ -109,7 +109,6 @@ lemma AlgebraOfCoalgebra.mul_def (x y : E) :
 
 attribute [local simp] AlgebraOfCoalgebra.mul_def
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 attribute [local instance] InnerProductSpace.mulOfCoalgebra in
 /-- A finite-dimensional inner product space with a coalgebra structure induces a ring structure,

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -399,7 +399,6 @@ instance instFunLike : FunLike (HilbertBasis ι 𝕜 E) ι E where
     ext
     exact congr_fun h i
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 protected theorem repr_symm_single [DecidableEq ι] (b : HilbertBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (lp.single 2 i (1 : 𝕜)) = b i := by

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -490,7 +490,6 @@ theorem meromorphicOrderAt_add_of_top_right
     meromorphicOrderAt (f₁ + f₂) x = meromorphicOrderAt f₁ x := by
   rw [add_comm, meromorphicOrderAt_add_of_top_left hf₂]
 
-set_option backward.isDefEq.respectTransparency false in
 /--
 The order of a sum is at least the minimum of the orders of the summands.
 -/

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -227,7 +227,6 @@ def TransportEnrichment.ofOrdinaryEnrichedCategoryEquiv : TransportEnrichment F 
 
 open EnrichedCategory
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If for a lax monoidal functor `F : V ⥤ W` the canonical function
 `(𝟙_ V ⟶ v) → (𝟙_ W ⟶ F.obj v)` is bijective, and `C` is an enriched ordinary category on `V`,

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -616,7 +616,6 @@ variable
     {F₀ : C ⥤ H} {F₁ : D ⥤ H} {F₂ : D' ⥤ H}
     (α : F₀ ⟶ L ⋙ F₁)
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If the right extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
 then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
@@ -661,7 +660,6 @@ def LeftExtension.isUniversalPrecomp₂
     simp [← a_w_t, hb_fac_app, u, hα_fac_app]
   apply IsInitial.ofUnique
 
-set_option backward.whnf.reducibleClassField false in
 /-- If the left extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
 then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
 `b : L'.LeftExtension F₁` is such that the "pasted" extension

--- a/Mathlib/CategoryTheory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid.lean
@@ -80,7 +80,6 @@ theorem Groupoid.inv_eq_inv (f : X ⟶ Y) : Groupoid.inv f = CategoryTheory.inv 
 def Groupoid.invEquiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
   ⟨Groupoid.inv, Groupoid.inv, fun f => by simp, fun f => by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 instance (priority := 100) groupoidHasInvolutiveReverse : Quiver.HasInvolutiveReverse C where
   reverse' f := Groupoid.inv f
   inv' f := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -165,7 +165,6 @@ theorem eq_zero_of_src {X Y : C} (o : IsZero X) (f : X ⟶ Y) : f = 0 :=
 theorem eq_zero_of_tgt {X Y : C} (o : IsZero Y) (f : X ⟶ Y) : f = 0 :=
   o.eq_of_tgt _ _
 
-set_option backward.whnf.reducibleClassField false in
 theorem iff_id_eq_zero (X : C) : IsZero X ↔ 𝟙 X = 0 :=
   ⟨fun h => h.eq_of_src _ _, fun h =>
     ⟨fun Y => ⟨⟨⟨0⟩, fun f => by

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -70,7 +70,6 @@ lemma homMap_comp (f : L₁.obj X ⟶ L₁.obj Y) (g : L₁.obj Y ⟶ L₁.obj Z
     Φ.homMap L₁ L₂ (f ≫ g) = Φ.homMap L₁ L₂ f ≫ Φ.homMap L₁ L₂ g := by
   simp [homMap]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma homMap_apply (G : D₁ ⥤ D₂) (e : Φ.functor ⋙ L₂ ≅ L₁ ⋙ G) (f : L₁.obj X ⟶ L₁.obj Y) :

--- a/Mathlib/CategoryTheory/Localization/Monoidal/Basic.lean
+++ b/Mathlib/CategoryTheory/Localization/Monoidal/Basic.lean
@@ -208,7 +208,6 @@ lemma μ_inv_natural_right (X : C) {Y₁ Y₂ : C} (g : Y₁ ⟶ Y₂) :
       (L').map (X ◁ g) ≫ (μ L W ε X Y₂).inv := by
   simp [Iso.eq_comp_inv]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma leftUnitor_hom_app (Y : C) :
     (λ_ ((L').obj Y)).hom =
@@ -220,7 +219,6 @@ lemma leftUnitor_hom_app (Y : C) :
   change _ ≫ (μ L W ε _ _).hom ≫ _ ≫ 𝟙 _ ≫ 𝟙 _ = _
   simp only [comp_id]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma rightUnitor_hom_app (X : C) :
     (ρ_ ((L').obj X)).hom =
@@ -233,7 +231,6 @@ lemma rightUnitor_hom_app (X : C) :
   change _ ≫ (μ L W ε _ _).hom ≫ _ ≫ 𝟙 _ ≫ 𝟙 _ = _
   simp only [comp_id]
 
-set_option backward.whnf.reducibleClassField false in
 lemma associator_hom_app (X₁ X₂ X₃ : C) :
     (α_ ((L').obj X₁) ((L').obj X₂) ((L').obj X₃)).hom =
       ((μ L W ε _ _).hom ⊗ₘ 𝟙 _) ≫ (μ L W ε _ _).hom ≫ (L').map (α_ X₁ X₂ X₃).hom ≫
@@ -243,24 +240,20 @@ lemma associator_hom_app (X₁ X₂ X₃ : C) :
   rw [Localization.associator_hom_app_app_app]
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 lemma id_tensorHom (X : LocalizedMonoidal L W ε) {Y₁ Y₂ : LocalizedMonoidal L W ε} (f : Y₁ ⟶ Y₂) :
     𝟙 X ⊗ₘ f = X ◁ f := by
   simp +instances [monoidalCategoryStruct]
 
-set_option backward.whnf.reducibleClassField false in
 lemma tensorHom_id {X₁ X₂ : LocalizedMonoidal L W ε} (f : X₁ ⟶ X₂) (Y : LocalizedMonoidal L W ε) :
     f ⊗ₘ 𝟙 Y = f ▷ Y := by
   simp +instances [monoidalCategoryStruct]
 
-set_option backward.whnf.reducibleClassField false in
 @[reassoc]
 lemma tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : LocalizedMonoidal L W ε}
     (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
     (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) = (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) := by
   simp +instances [monoidalCategoryStruct]
 
-set_option backward.whnf.reducibleClassField false in
 lemma id_tensorHom_id (X₁ X₂ : LocalizedMonoidal L W ε) : 𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by
   simp +instances [monoidalCategoryStruct]
 
@@ -276,12 +269,10 @@ theorem whiskerRight_comp (Q : LocalizedMonoidal L W ε) {X Y Z : LocalizedMonoi
     (f ≫ g) ▷ Q = f ▷ Q ≫ g ▷ Q := by
   simp only [← tensorHom_id, ← tensor_comp, comp_id]
 
-set_option backward.whnf.reducibleClassField false in
 lemma whiskerLeft_id (X Y : LocalizedMonoidal L W ε) :
     X ◁ (𝟙 Y) = 𝟙 _ := by
   simp +instances [monoidalCategoryStruct]
 
-set_option backward.whnf.reducibleClassField false in
 lemma whiskerRight_id (X Y : LocalizedMonoidal L W ε) :
     (𝟙 X) ▷ Y = 𝟙 _ := by
   simp +instances [monoidalCategoryStruct]
@@ -291,7 +282,6 @@ lemma whisker_exchange {Q X Y Z : LocalizedMonoidal L W ε} (f : Q ⟶ X) (g : Y
     Q ◁ g ≫ f ▷ Z = f ▷ Y ≫ X ◁ g := by
   simp only [← id_tensorHom, ← tensorHom_id, ← tensor_comp, id_comp, comp_id]
 
-set_option backward.whnf.reducibleClassField false in
 @[reassoc]
 lemma associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : LocalizedMonoidal L W ε}
     (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃) :
@@ -379,7 +369,6 @@ lemma pentagon (Y₁ Y₂ Y₃ Y₄ : LocalizedMonoidal L W ε) :
     Iso.inv_hom_id, whiskerRight_id, ← whiskerLeft_comp,
     whiskerLeft_id]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma leftUnitor_naturality {X Y : LocalizedMonoidal L W ε} (f : X ⟶ Y) :
     𝟙_ (LocalizedMonoidal L W ε) ◁ f ≫ (λ_ Y).hom = (λ_ X).hom ≫ f := by
@@ -447,7 +436,6 @@ lemma triangle (X Y : LocalizedMonoidal L W ε) :
   · exact triangle_aux₂ _ _ _ e₁ e₂
   · exact triangle_aux₃ _ _ _ e₁ e₂
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 noncomputable instance :
     MonoidalCategory (LocalizedMonoidal L W ε) where

--- a/Mathlib/CategoryTheory/LocallyCartesianClosed/ExponentiableMorphism.lean
+++ b/Mathlib/CategoryTheory/LocallyCartesianClosed/ExponentiableMorphism.lean
@@ -152,7 +152,6 @@ section
 def id (I : C) [ChosenPullbacksAlong (𝟙 I)] : ExponentiableMorphism (𝟙 I) :=
   ⟨𝟭 _, ofNatIsoLeft (F := 𝟭 _) Adjunction.id (pullbackId I).symm⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem id_pushforward (I : C) [ChosenPullbacksAlong (𝟙 I)] :
     (id I).pushforward = 𝟭 (Over I) := by
   dsimp +instances only [id]
@@ -186,7 +185,6 @@ def comp {I J K : C} (f : I ⟶ J) (g : J ⟶ K)
     ofNatIsoLeft (pullbackPushforwardAdj g |>.comp <| pullbackPushforwardAdj f)
     (pullbackComp f g).symm⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem comp_pushforward {I J K : C} (f : I ⟶ J) (g : J ⟶ K)
     [ChosenPullbacksAlong f] [ChosenPullbacksAlong g] [ChosenPullbacksAlong (f ≫ g)]
     [ExponentiableMorphism f] [ExponentiableMorphism g] :

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -533,7 +533,6 @@ def SymmetricCategory.ofFaithful {C D : Type*} [Category* C] [Category* D] [Mono
     [F.Faithful] : SymmetricCategory C where
   symmetry X Y := F.map_injective (by simp)
 
-set_option backward.whnf.reducibleClassField false in
 /-- Pull back a symmetric braiding along a fully faithful monoidal functor. -/
 noncomputable def SymmetricCategory.ofFullyFaithful {C D : Type*} [Category* C] [Category* D]
     [MonoidalCategory C] [MonoidalCategory D] (F : C ⥤ D) [F.Monoidal] [F.Full]
@@ -872,7 +871,6 @@ lemma SymmetricCategory.reverseBraiding_eq (C : Type u₁) [Category.{v₁} C]
   funext X Y
   exact Iso.ext (braiding_swap_eq_inv_braiding Y X).symm
 
-set_option backward.whnf.reducibleClassField false in
 /-- The identity functor from `C` to `C`, where the codomain is given the
 reversed braiding, upgraded to a braided functor. -/
 def SymmetricCategory.equivReverseBraiding (C : Type u₁) [Category.{v₁} C]

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Transport.lean
@@ -26,7 +26,6 @@ namespace CategoryTheory.Monoidal
 
 open Functor.LaxMonoidal Functor.OplaxMonoidal
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 instance Transported.instBraidedCategory (e : C ≌ D) [MonoidalCategory C] [BraidedCategory C] :
     BraidedCategory (Transported e) :=
@@ -35,7 +34,6 @@ instance Transported.instBraidedCategory (e : C ≌ D) [MonoidalCategory C] [Bra
 
 local notation "e'" e => equivalenceTransported e
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 instance (e : C ≌ D) [MonoidalCategory C] [BraidedCategory C] :
     (e' e).inverse.Braided where

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Comon_.lean
@@ -28,7 +28,6 @@ variable (C : Type u) [Category.{v} C] [CartesianMonoidalCategory C]
 
 attribute [local simp] leftUnitor_hom rightUnitor_hom
 
-set_option backward.whnf.reducibleClassField false in
 /--
 The functor from a Cartesian monoidal category to comonoids in that category,
 equipping every object with the diagonal map as a comultiplication.

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -1163,7 +1163,6 @@ lemma tensorHom_id {x x' : D} (f : x ⟶ x') (y : D) :
     f ⊗ₘ (𝟙 y) = f ▷ y :=
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma ι_map_tensorHom_eq {d₁ d₁' d₂ d₂' : D} (f : d₁ ⟶ d₂) (f' : d₁' ⟶ d₂') :
     letI := mkMonoidalCategoryStruct C V D

--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -186,7 +186,6 @@ theorem inv_comp_inv (A : C) [GrpObj A] : ι ≫ ι = 𝟙 A := by
   apply lift_left_mul_ext ι[A]
   rw [right_inv, ← comp_toUnit_assoc ι, ← left_inv, comp_lift_assoc, Category.comp_id]
 
-set_option backward.whnf.reducibleClassField false in
 /-- Transfer `GrpObj` along an isomorphism. -/
 -- Note: The simps lemmas are not tagged simp because their `#discr_tree_simp_key` are too generic.
 @[simps! -isSimp]

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
@@ -44,7 +44,6 @@ noncomputable def functor : Mon (Type u) ⥤ MonCat.{u} where
       map_one' := congr_fun (IsMonHom.one_hom f.hom) PUnit.unit
       map_mul' x y := congr_fun (IsMonHom.mul_hom f.hom) (x, y) }
 
-set_option backward.whnf.reducibleClassField false in
 /-- Converting a bundled monoid to a monoid object in `Type`.
 -/
 noncomputable def inverse : MonCat.{u} ⥤ Mon (Type u) where

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -565,13 +565,11 @@ def leftDualIso {X₁ X₂ Y : C} (p₁ : ExactPairing X₁ Y) (p₂ : ExactPair
     rw [← @comp_leftAdjointMate C, Category.comp_id, @leftAdjointMate_id]
     rfl
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem rightDualIso_id {X Y : C} (p : ExactPairing X Y) : rightDualIso p p = Iso.refl Y := by
   ext
   simp only [rightDualIso, Iso.refl_hom, @rightAdjointMate_id]
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem leftDualIso_id {X Y : C} (p : ExactPairing X Y) : leftDualIso p p = Iso.refl X := by
   ext

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -155,7 +155,6 @@ def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
 the fields `whiskerList_eq` and following were all filled by the `cat_disch` auto_param. -/
 attribute [local simp] transportStruct in
 set_option backward.isDefEq.respectTransparency false in
-set_option backward.whnf.reducibleClassField false in
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=

--- a/Mathlib/CategoryTheory/Shift/Localization.lean
+++ b/Mathlib/CategoryTheory/Shift/Localization.lean
@@ -279,7 +279,6 @@ noncomputable def commShift : G.CommShift M := by
   letI : Localization.Lifting L₁ W₁ (Φ.functor ⋙ L₂) G := ⟨e.symm⟩
   exact Functor.commShiftOfLocalization L₁ W₁ M (Φ.functor ⋙ L₂) G
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma commShift_iso_hom_app (m : M) (X : C₁) :
@@ -291,7 +290,6 @@ lemma commShift_iso_hom_app (m : M) (X : C₁) :
   simp [Functor.commShiftOfLocalization_iso_hom_app,
     Functor.commShiftIso_comp_hom_app]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma commShift_iso_inv_app (m : M) (X : C₁) :

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
@@ -78,7 +78,6 @@ instance extensiveTopology.subcanonical : (extensiveTopology C).Subcanonical :=
 
 variable [FinitaryExtensive C]
 
-set_option backward.isDefEq.respectTransparency false in
 /--
 A presheaf of sets on a category which is `FinitaryExtensive` is a sheaf iff it preserves finite
 products.

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -220,7 +220,6 @@ instance [HasReverse V] : HasReverse (Quiver.Push σ) where
   reverse' := fun
               | PushQuiver.arrow f => PushQuiver.arrow (reverse f)
 
-set_option backward.whnf.reducibleClassField false in
 instance [h : HasInvolutiveReverse V] :
     HasInvolutiveReverse (Push σ) where
   reverse' := fun

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -170,7 +170,6 @@ theorem IsAntichain.disjoint_slice_shadow_falling {m n : ℕ}
     rintro rfl
     exact notMem_erase _ _ (hst ha)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A bound on any top part of the sum in LYM in terms of the size of `falling k 𝒜`. -/
 theorem le_card_falling_div_choose [Fintype α] (hk : k ≤ Fintype.card α)
     (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset α))) :

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -181,7 +181,6 @@ lemma not_adj_iff_part_eq [DecidableEq V] :
   change t ∈ fp.part s ↔ fp.part s = fp.part t
   rw [fp.mem_part_iff_part_eq_part (mem_univ t) (mem_univ s), eq_comm]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma degree_eq_card_sub_part_card [DecidableEq V] :
     G.degree s = card V - #(h.finpartition.part s) :=

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -340,7 +340,6 @@ protected theorem liftOn₂_eq {φ} (p q : Set ℕ) (f : Set ℕ → Set ℕ →
     (of p).liftOn₂ (of q) f h = f p q :=
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem of_eq_of {p : α → Prop} {q : β → Prop} : of p = of q ↔ ManyOneEquiv p q := by

--- a/Mathlib/Data/ENat/Pow.lean
+++ b/Mathlib/Data/ENat/Pow.lean
@@ -68,7 +68,6 @@ lemma epow_zero : x ^ (0 : ℕ∞) = 1 := by
 lemma epow_one : x ^ (1 : ℕ∞) = x := by
   rw [← coe_one, epow_natCast, pow_one]
 
-set_option backward.whnf.reducibleClassField false in
 lemma epow_top (h : 1 < x) : x ^ (⊤ : ℕ∞) = ⊤ := by
   simp +instances only [instHPow, instPow, (zero_le_one.trans_lt h).ne.symm, ↓reduceIte, h.ne.symm]
 

--- a/Mathlib/Data/Finset/Interval.lean
+++ b/Mathlib/Data/Finset/Interval.lean
@@ -71,7 +71,6 @@ theorem Iio_eq_ssubsets : Iio s = s.ssubsets := by ext; simp
 
 variable {s t}
 
-set_option backward.whnf.reducibleClassField false in
 theorem Icc_eq_image_powerset (h : s ⊆ t) : Icc s t = (t \ s).powerset.image (s ∪ ·) := by
   unfold Finset.Icc instLocallyFiniteOrder LocallyFiniteOrder.ofIcc
   ext
@@ -86,7 +85,6 @@ theorem Ico_eq_image_ssubsets (h : s ⊆ t) : Ico s t = (t \ s).ssubsets.image (
   · rintro ⟨v, hv, rfl⟩
     exact ⟨le_sup_left, sup_lt_of_lt_sdiff_left hv h⟩
 
-set_option backward.whnf.reducibleClassField false in
 /-- Cardinality of a non-empty `Icc` of finsets. -/
 theorem card_Icc_finset (h : s ⊆ t) : (Icc s t).card = 2 ^ (t.card - s.card) := by
   unfold Finset.Icc instLocallyFiniteOrder LocallyFiniteOrder.ofIcc

--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -199,7 +199,6 @@ lemma restrict_preimage [DecidableEq ι] {I : Set ι}
       Set.pi (s.image Subtype.val) (fun i ↦ if h : i ∈ I then u ⟨i, h⟩ else .univ) := by
   grind
 
-set_option backward.isDefEq.respectTransparency false in
 lemma restrict₂_preimage [DecidablePred (· ∈ s)] (hst : s ⊆ t) (u : (i : s) → Set (π i)) :
     (restrict₂ hst) ⁻¹' (Set.univ.pi u) =
       (@Set.univ t).pi (fun j ↦ if h : j.1 ∈ s then u ⟨j.1, h⟩ else Set.univ) := by

--- a/Mathlib/Data/Multiset/Interval.lean
+++ b/Mathlib/Data/Multiset/Interval.lean
@@ -77,7 +77,6 @@ theorem card_uIcc :
   simp_rw [uIcc_eq, Finset.card_map, DFinsupp.card_uIcc, Nat.card_uIcc, Multiset.toDFinsupp_apply,
     toDFinsupp_support]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem card_Iic : (Finset.Iic s).card = ∏ i ∈ s.toFinset, (s.count i + 1) := by
   simp_rw [Iic_eq_Icc, card_Icc, bot_eq_zero, toFinset_zero, empty_union, count_zero, tsub_zero]
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -329,7 +329,6 @@ theorem even_xor {m n : ℕ} : Even (m ^^^ n) ↔ (Even m ↔ Even n) := by
   simp only [even_iff, xor_mod_two_eq]
   lia
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem xor_one_of_even {n : ℕ} (h : Even n) : n ^^^ 1 = n + 1 := by
   cases n with
@@ -338,7 +337,6 @@ theorem xor_one_of_even {n : ℕ} (h : Even n) : n ^^^ 1 = n + 1 := by
     simp +instances [HXor.hXor, instXorOp, xor, bitwise, even_iff.mp h, ← mul_two,
       div_two_mul_two_of_even h]
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem xor_one_of_odd {n : ℕ} (h : Odd n) : n ^^^ 1 = n - 1 := by
   cases n with

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -196,11 +196,9 @@ theorem top_def : ⇑(⊤ : Setoid α) = ⊤ :=
 theorem bot_def : ⇑(⊥ : Setoid α) = (· = ·) :=
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 @[simp] lemma mk_eq_top {r : α → α → Prop} (iseqv) : mk r iseqv = ⊤ ↔ r = ⊤ := by
   simp [eq_iff_rel_eq]
 
-set_option backward.whnf.reducibleClassField false in
 @[simp] lemma mk_eq_bot {r : α → α → Prop} (iseqv) : mk r iseqv = ⊥ ↔ r = (· = ·) := by
   simp [eq_iff_rel_eq]
 

--- a/Mathlib/Data/String/Basic.lean
+++ b/Mathlib/Data/String/Basic.lean
@@ -35,7 +35,6 @@ def ltb (s₁ s₂ : Legacy.Iterator) : Bool :=
 instance LT' : LT String :=
   ⟨fun s₁ s₂ ↦ ltb (String.Legacy.iter s₁) (String.Legacy.iter s₂)⟩
 
-set_option backward.whnf.reducibleClassField false in
 /-- This instance has a prime to avoid the name of the corresponding instance in core Lean. -/
 instance decidableLT' : DecidableLT String := by
   simp +instances only [DecidableLT, LT']
@@ -125,7 +124,6 @@ theorem lt_iff_toList_lt : ∀ {s₁ s₂ : String}, s₁ < s₂ ↔ s₁.toList
 instance LE : LE String :=
   ⟨fun s₁ s₂ ↦ ¬s₂ < s₁⟩
 
-set_option backward.whnf.reducibleClassField false in
 instance decidableLE : DecidableLE String := by
   simp +instances only [DecidableLE, LE]
   infer_instance -- short-circuit type class inference
@@ -154,7 +152,6 @@ theorem toList_nonempty :
 theorem head_empty : "".toList.head! = default :=
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 instance : LinearOrder String where
   le_refl _ := le_iff_toList_le.mpr le_rfl
   le_trans a b c := by

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -48,7 +48,6 @@ def mkMulHom (c : Con M) : MulHom M c.Quotient where
   toFun := (↑)
   map_mul' _ _ := rfl
 
-set_option backward.whnf.reducibleClassField false in
 /-- The kernel of a multiplicative homomorphism as a congruence relation. -/
 @[to_additive /-- The kernel of an additive homomorphism as an additive congruence relation. -/]
 def ker (f : F) : Con M where

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -471,7 +471,6 @@ theorem equivPair_head {i : ι} {w : Word M} :
     · subst hi; simp
     · simp [hi, Ne.symm hi]
 
-set_option backward.whnf.reducibleClassField false in
 instance summandAction (i) : MulAction (M i) (Word M) where
   smul m w := rcons { equivPair i w with head := m * (equivPair i w).head }
   one_smul w := by

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -954,7 +954,6 @@ theorem mul_bind (f : α → FreeGroup β) (x y : FreeGroup α) : x * y >>= f = 
 theorem inv_bind (f : α → FreeGroup β) (x : FreeGroup α) : x⁻¹ >>= f = (x >>= f)⁻¹ :=
   (lift f).map_inv _
 
-set_option backward.whnf.reducibleClassField false in
 @[to_additive]
 instance : LawfulMonad FreeGroup.{u} := LawfulMonad.mk'
   (id_map := fun x =>

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -288,7 +288,6 @@ variable {G α}
 theorem orbitRel_apply {a b : α} : orbitRel G α a b ↔ a ∈ orbit G b :=
   Iff.rfl
 
-set_option backward.whnf.reducibleClassField false in
 /-- When you take a set `U` in `α`, push it down to the quotient, and pull back, you get the union
 of the orbit of `U` under `G`. -/
 @[to_additive

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -254,7 +254,6 @@ def ofGroup (g : G) : NormalWord d :=
 
 instance : Inhabited (NormalWord d) := ⟨empty⟩
 
-set_option backward.whnf.reducibleClassField false in
 instance : MulAction G (NormalWord d) :=
   { smul := fun g w => { w with head := g * w.head }
     one_smul := by simp +instances [instHSMul]
@@ -501,17 +500,14 @@ theorem prod_group_smul (g : G) (w : NormalWord d) :
     (g • w).prod φ = of g * (w.prod φ) := by
   simp [ReducedWord.prod, mul_assoc]
 
-set_option backward.whnf.reducibleClassField false in
 theorem of_smul_eq_smul (g : G) (w : NormalWord d) :
     (of g : HNNExtension G A B φ) • w = g • w := by
   simp +instances [instHSMul, SMul.smul, MulAction.toEndHom]
 
-set_option backward.whnf.reducibleClassField false in
 theorem t_smul_eq_unitsSMul (w : NormalWord d) :
     (t : HNNExtension G A B φ) • w = unitsSMul φ 1 w := by
   simp +instances [instHSMul, SMul.smul, MulAction.toEndHom]
 
-set_option backward.whnf.reducibleClassField false in
 theorem t_pow_smul_eq_unitsSMul (u : ℤˣ) (w : NormalWord d) :
     (t ^ (u : ℤ) : HNNExtension G A B φ) • w = unitsSMul φ u w := by
   rcases Int.units_eq_one_or u with (rfl | rfl) <;>

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -187,7 +187,6 @@ theorem r_eq_r' : r S = r' S :=
 
 variable {S}
 
-set_option backward.whnf.reducibleClassField false in
 @[to_additive]
 theorem r_iff_exists {x y : M × S} : r S x y ↔ ∃ c : S, ↑c * (↑y.2 * x.1) = c * (x.2 * y.1) := by
   simp only [r_eq_r' S, r', Con.rel_mk]
@@ -220,7 +219,6 @@ class of `(x, y)` in the localization of `M` at `S`. -/
 the equivalence class of `(x, y)` in the localization of `M` at `S`. -/]
 def mk (x : M) (y : S) : Localization S := x /ₒ y
 
-set_option backward.whnf.reducibleClassField false in
 @[to_additive]
 theorem mk_eq_mk_iff {a c : M} {b d : S} : mk a b = mk c d ↔ r S ⟨a, b⟩ ⟨c, d⟩ := by
   simp +instances only [mk, OreLocalization.oreDiv_eq_iff, r_iff_oreEqv_r, OreLocalization.oreEqv]

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -284,7 +284,6 @@ theorem ext {w₁ w₂ : NormalWord d} (hhead : w₁.head = w₂.head)
 
 open Subgroup.IsComplement
 
-set_option backward.whnf.reducibleClassField false in
 instance baseAction : MulAction H (NormalWord d) :=
   { smul := fun h w => { w with head := h * w.head },
     one_smul := by simp +instances [instHSMul]
@@ -439,7 +438,6 @@ noncomputable def equivPair (i) : NormalWord d ≃ Pair d i :=
     left_inv := leftInv
     right_inv := fun _ => rcons_injective (leftInv _) }
 
-set_option backward.whnf.reducibleClassField false in
 noncomputable instance summandAction (i : ι) : MulAction (G i) (NormalWord d) :=
   { smul := fun g w => (equivPair i).symm
       { equivPair i w with

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -66,7 +66,6 @@ private def inv : DihedralGroup n → DihedralGroup n
   | r i => r (-i)
   | sr i => sr i
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
@@ -85,7 +85,6 @@ private def inv : QuaternionGroup n → QuaternionGroup n
   | a i => a (-i)
   | xa i => xa (n + i)
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -133,7 +133,6 @@ abbrev closureCommGroupOfComm {k : Set G} (hcomm : ∀ x ∈ k, ∀ y ∈ k, x *
       have := closure_le_centralizer_centralizer k
       Subtype.ext <| Set.centralizer_centralizer_comm_of_comm hcomm _ (this h₁) _ (this h₂) }
 
-set_option backward.whnf.reducibleClassField false in
 /-- The conjugation action of N(H) on H. -/
 @[simps]
 instance : MulDistribMulAction H.normalizer H where

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -272,7 +272,6 @@ theorem finrank_add_finrank_orthogonal' (W : Submodule K V) :
       add_comm, ← add_assoc, add_comm (finrank K (LinearMap.ker (B.domRestrict W))),
       LinearMap.finrank_range_add_finrank_ker]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem finrank_add_finrank_orthogonal (b₁ : B.IsRefl) (W : Submodule K V) :
     finrank K W + finrank K (B.orthogonal W) =
       finrank K V + finrank K (W ⊓ B.orthogonal ⊤ : Subspace K V) := by

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -296,7 +296,6 @@ section
 
 open Finset
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If a finset has cardinality larger than the rank of a module,
 then there is a nontrivial linear relation amongst its elements. -/
 theorem Module.exists_nontrivial_relation_of_finrank_lt_card {t : Finset M}

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -200,7 +200,6 @@ def transposePath {i j : n} (p : @Quiver.Path n A.toQuiver i j) :
     exact (@Quiver.Path.comp n (toQuiver Aᵀ) c b i (@Quiver.Hom.toPath n (toQuiver Aᵀ) c b
       (PLift.up eT)) ih)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Irreducibility is invariant under transpose. -/
 theorem IsIrreducible.transpose (hA : IsIrreducible A) : IsIrreducible Aᵀ := by
   have hA_T_nonneg : ∀ i j, 0 ≤ Aᵀ i j := fun i j => by

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -81,7 +81,6 @@ def invertibleOfDetInvertible [Invertible A.det] : Invertible A where
   invOf_mul_self := by
     rw [smul_mul_assoc, adjugate_mul, smul_smul, invOf_mul_self, one_smul]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_eq [Invertible A.det] [Invertible A] : ⅟A = ⅟A.det • A.adjugate := by
   letI := invertibleOfDetInvertible A
   convert (rfl : ⅟A = _)
@@ -102,7 +101,6 @@ def detInvertibleOfRightInverse (h : A * B = 1) : Invertible A.det where
 def detInvertibleOfInvertible [Invertible A] : Invertible A.det :=
   detInvertibleOfLeftInverse A (⅟A) (invOf_mul_self _)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem det_invOf [Invertible A] [Invertible A.det] : (⅟A).det = ⅟A.det := by
   letI := detInvertibleOfInvertible A
   convert (rfl : _ = ⅟A.det)
@@ -175,14 +173,12 @@ theorem nonsing_inv_apply_not_isUnit (h : ¬IsUnit A.det) : A⁻¹ = 0 := by
 theorem nonsing_inv_apply (h : IsUnit A.det) : A⁻¹ = (↑h.unit⁻¹ : α) • A.adjugate := by
   rw [inv_def, ← Ring.inverse_unit h.unit, IsUnit.unit_spec]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The nonsingular inverse is the same as `invOf` when `A` is invertible. -/
 @[simp]
 theorem invOf_eq_nonsing_inv [Invertible A] : ⅟A = A⁻¹ := by
   letI := detInvertibleOfInvertible A
   rw [inv_def, Ring.inverse_invertible, invOf_eq]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Coercing the result of `Units.instInv` is the same as coercing first and applying the
 nonsingular inverse. -/
 @[simp, norm_cast]
@@ -190,7 +186,6 @@ theorem coe_units_inv (A : (Matrix n n α)ˣ) : ↑A⁻¹ = (A⁻¹ : Matrix n n
   letI := A.invertible
   rw [← invOf_eq_nonsing_inv, invOf_units]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The nonsingular inverse is the same as the general `Ring.inverse`. -/
 theorem nonsing_inv_eq_ringInverse : A⁻¹ = Ring.inverse A := by
   by_cases h_det : IsUnit A.det
@@ -222,7 +217,6 @@ instance [Invertible A] : Invertible A⁻¹ := by
   rw [← invOf_eq_nonsing_inv]
   infer_instance
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem inv_inv_of_invertible [Invertible A] : A⁻¹⁻¹ = A := by
   simp only [← invOf_eq_nonsing_inv, invOf_invOf]
@@ -413,7 +407,6 @@ theorem nonsing_inv_cancel_or_zero : A⁻¹ * A = 1 ∧ A * A⁻¹ = 1 ∨ A⁻�
 theorem det_nonsing_inv_mul_det (h : IsUnit A.det) : A⁻¹.det * A.det = 1 := by
   rw [← det_mul, A.nonsing_inv_mul h, det_one]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem det_nonsing_inv : A⁻¹.det = Ring.inverse A.det := by
   by_cases h : IsUnit A.det
@@ -529,7 +522,6 @@ def diagonalInvertible {α} [NonAssocSemiring α] (v : n → α) [Invertible v] 
     Invertible (diagonal v) :=
   Invertible.map (diagonalRingHom n α) v
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_diagonal_eq {α} [Semiring α] (v : n → α) [Invertible v] [Invertible (diagonal v)] :
     ⅟(diagonal v) = diagonal (⅟v) := by
   rw [@Invertible.congr _ _ _ _ _ (diagonalInvertible v) rfl]
@@ -568,7 +560,6 @@ theorem isUnit_diagonal {v : n → α} : IsUnit (diagonal v) ↔ IsUnit v := by
   simp only [← nonempty_invertible_iff_isUnit,
     (diagonalInvertibleEquivInvertible v).nonempty_congr]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem inv_diagonal (v : n → α) : (diagonal v)⁻¹ = diagonal (Ring.inverse v) := by
   rw [nonsing_inv_eq_ringInverse]
   by_cases h : IsUnit v
@@ -699,7 +690,6 @@ def invertibleOfSubmatrixEquivInvertible (A : Matrix m m α) (e₁ e₂ : n ≃ 
       rw [this]
     rw [Matrix.submatrix_mul_equiv, mul_invOf_self, submatrix_one_equiv]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_submatrix_equiv_eq (A : Matrix m m α) (e₁ e₂ : n ≃ m) [Invertible A]
     [Invertible (A.submatrix e₁ e₂)] : ⅟(A.submatrix e₁ e₂) = (⅟A).submatrix e₂ e₁ := by
   rw [@Invertible.congr _ _ _ _ _ (submatrixEquivInvertible A e₁ e₂) rfl]

--- a/Mathlib/LinearAlgebra/Matrix/SchurComplement.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SchurComplement.lean
@@ -91,14 +91,12 @@ def fromBlocksZero₁₂Invertible (A : Matrix m m α) (C : Matrix n m α) (D : 
       Matrix.neg_mul, invOf_mul_self, Matrix.invOf_mul_cancel_right, neg_add_cancel,
       fromBlocks_one]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_fromBlocks_zero₂₁_eq (A : Matrix m m α) (B : Matrix m n α) (D : Matrix n n α)
     [Invertible A] [Invertible D] [Invertible (fromBlocks A B 0 D)] :
     ⅟(fromBlocks A B 0 D) = fromBlocks (⅟A) (-(⅟A * B * ⅟D)) 0 (⅟D) := by
   letI := fromBlocksZero₂₁Invertible A B D
   convert (rfl : ⅟(fromBlocks A B 0 D) = _)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_fromBlocks_zero₁₂_eq (A : Matrix m m α) (C : Matrix n m α) (D : Matrix n n α)
     [Invertible A] [Invertible D] [Invertible (fromBlocks A 0 C D)] :
     ⅟(fromBlocks A 0 C D) = fromBlocks (⅟A) 0 (-(⅟D * C * ⅟A)) (⅟D) := by
@@ -270,7 +268,6 @@ def fromBlocks₁₁Invertible (A : Matrix m m α) (B : Matrix m n α) (C : Matr
       (fromBlocks_submatrix_sum_swap_sum_swap _ _ _ _).symm
       (fromBlocks_submatrix_sum_swap_sum_swap _ _ _ _).symm
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_fromBlocks₂₂_eq (A : Matrix m m α) (B : Matrix m n α) (C : Matrix n m α)
     (D : Matrix n n α) [Invertible D] [Invertible (A - B * ⅟D * C)]
     [Invertible (fromBlocks A B C D)] :
@@ -280,7 +277,6 @@ theorem invOf_fromBlocks₂₂_eq (A : Matrix m m α) (B : Matrix m n α) (C : M
   letI := fromBlocks₂₂Invertible A B C D
   convert (rfl : ⅟(fromBlocks A B C D) = _)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem invOf_fromBlocks₁₁_eq (A : Matrix m m α) (B : Matrix m n α) (C : Matrix n m α)
     (D : Matrix n n α) [Invertible A] [Invertible (D - C * ⅟A * B)]
     [Invertible (fromBlocks A B C D)] :
@@ -369,7 +365,6 @@ theorem det_fromBlocks₁₁ (A : Matrix m m α) (B : Matrix m n α) (C : Matrix
   rw [fromBlocks_eq_of_invertible₁₁ (A := A), det_mul, det_mul, det_fromBlocks_zero₂₁,
     det_fromBlocks_zero₂₁, det_fromBlocks_zero₁₂, det_one, det_one, one_mul, one_mul, mul_one]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem det_fromBlocks_one₁₁ (B : Matrix m n α) (C : Matrix n m α) (D : Matrix n n α) :
     (Matrix.fromBlocks 1 B C D).det = det (D - C * B) := by
@@ -387,7 +382,6 @@ theorem det_fromBlocks₂₂ (A : Matrix m m α) (B : Matrix m n α) (C : Matrix
     cases i <;> cases j <;> rfl
   rw [this, det_submatrix_equiv_self, det_fromBlocks₁₁]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem det_fromBlocks_one₂₂ (A : Matrix m m α) (B : Matrix m n α) (C : Matrix n m α) :
     (Matrix.fromBlocks A B C 1).det = det (A - B * C) := by

--- a/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
@@ -176,7 +176,6 @@ def weightedSumSquaresCongr (h : w = w') :
   __ := LinearEquiv.refl R (ι → R)
   map_app' := by simp [h]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The isometry between two weighted sum of squares, give that each weight is scaled by the square
 of a unit. -/
 def isometryEquivWeightedSumSquaresWeightedSumSquares (u : ι → Sˣ) (h : ∀ i, w' i * u i ^ 2 = w i) :

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -93,7 +93,6 @@ instance : Unique (Σ n, Language.order.Relations n) :=
       match n, R with
       | 2, .le => rfl⟩
 
-set_option backward.whnf.reducibleClassField false in
 instance : Unique Language.order.Symbols := ⟨⟨Sum.inr default⟩, by
   have : IsEmpty (Σ n, Language.order.Functions n) := isEmpty_sigma.2 inferInstance
   simp only [Symbols, Sum.forall, reduceCtorEq, Sum.inr.injEq, IsEmpty.forall_iff, true_and]

--- a/Mathlib/ModelTheory/Ultraproducts.lean
+++ b/Mathlib/ModelTheory/Ultraproducts.lean
@@ -46,7 +46,6 @@ variable {L : Language.{u, v}} [∀ a, L.Structure (M a)]
 
 namespace Ultraproduct
 
-set_option backward.whnf.reducibleClassField false in
 instance setoidPrestructure : L.Prestructure ((u : Filter α).productSetoid M) :=
   { (u : Filter α).productSetoid M with
     toStructure :=

--- a/Mathlib/NumberTheory/Chebyshev.lean
+++ b/Mathlib/NumberTheory/Chebyshev.lean
@@ -300,7 +300,6 @@ theorem integrableOn_theta_div_id_mul_log_sq (x : ℝ) :
   have : x * log x ^ 2 ≠ 0 := mul_ne_zero this <| by simp; grind
   fun_prop (disch := assumption)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Expresses the prime counting function `π` in terms of `θ` by using Abel summation. -/
 theorem primeCounting_eq_theta_div_log_add_integral {x : ℝ} (hx : 2 ≤ x) :
     π ⌊x⌋₊ = θ x / log x + ∫ t in 2..x, θ t / (t * log t ^ 2) := by

--- a/Mathlib/NumberTheory/MahlerMeasure.lean
+++ b/Mathlib/NumberTheory/MahlerMeasure.lean
@@ -54,7 +54,6 @@ variable (n : ℕ) (B₁ B₂ : Fin (n + 1) → ℝ)
 construction is used as part of our proof of Northcott's theorem. -/
 def boxPoly : Set ℤ[X] := {p : ℤ[X] | p.natDegree ≤ n ∧ ∀ i, B₁ i ≤ p.coeff i ∧ p.coeff i ≤ B₂ i}
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_boxPoly : (boxPoly n B₁ B₂).ncard = ∏ i, (⌊B₂ i⌋ - ⌈B₁ i⌉ + 1).toNat := by
   trans Set.ncard (α := Fin (n + 1) → ℤ) (Finset.Icc (⌈B₁ ·⌉) (⌊B₂ ·⌋))
   · refine Set.ncard_congr' ⟨fun p ↦ ⟨toFn (n + 1) p, ?_⟩, fun p ↦ ⟨ofFn (n + 1) p, ?_⟩, ?_, ?_⟩

--- a/Mathlib/NumberTheory/NumberField/CMField.lean
+++ b/Mathlib/NumberTheory/NumberField/CMField.lean
@@ -205,7 +205,6 @@ theorem complexConj_eq_self_iff (x : K) :
   · rw [IsGalois.fixedField_top, IntermediateField.mem_bot]
     aesop
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 protected theorem RingOfIntegers.complexConj_eq_self_iff (x : 𝓞 K) :
     complexConj K x = x ↔ ∃ y : 𝓞 K⁺, algebraMap (𝓞 K⁺) K y = x := by
@@ -459,7 +458,6 @@ namespace CMExtension
 variable (F K : Type*) [Field F] [IsTotallyReal F] [Field K] [CharZero K] [Algebra.IsIntegral ℚ K]
   [IsTotallyComplex K] [Algebra F K] [IsQuadraticExtension F K]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 theorem eq_maximalRealSubfield (E : Subfield K) [IsTotallyReal E] [IsQuadraticExtension E K] :
     E = maximalRealSubfield K := by
@@ -520,7 +518,6 @@ theorem ofCMExtension :
   is_quadratic := ⟨(IsQuadraticExtension.finrank_eq_two F K) ▸ finrank_eq_of_equiv_equiv
       (CMExtension.equivMaximalRealSubfield F K).symm (RingEquiv.refl K) (by ext; simp)⟩
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 open IntermediateField in
 /--

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -182,8 +182,6 @@ lemma isFinitePlace_iff (v : AbsoluteValue K ℝ) :
     IsFinitePlace v ↔ ∃ w : FinitePlace K, w.val = v :=
   ⟨fun H ↦ ⟨⟨v, H⟩, rfl⟩, fun ⟨w, hw⟩ ↦ hw ▸ w.isFinitePlace⟩
 
-set_option backward.whnf.reducibleClassField false in
-set_option backward.isDefEq.respectTransparency false in
 /-- The norm of the image after the embedding associated to `v` is equal to the `v`-adic absolute
 value. -/
 theorem FinitePlace.norm_def (x : WithVal (v.valuation K)) : ‖embedding v x‖ = adicAbv v x := by

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -133,7 +133,6 @@ private theorem c_nonneg : 0 ≤ c K := by
   rw [c]
   positivity
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -80,7 +80,6 @@ theorem exponent_eq_sInf : exponent θ = sInf {d : ℕ | 0 < d ∧ (d : 𝓞 K) 
 
 variable [NumberField K] {θ : 𝓞 K} {p : ℕ} [Fact p.Prime]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /--
 If `p` doesn't divide the exponent of `θ`, then `(ℤ / pℤ)[X] / (minpoly θ) ≃+* 𝓞 K / p(𝓞 K)`.
@@ -94,7 +93,6 @@ def ZModXQuotSpanEquivQuotSpan (hp : ¬ p ∣ exponent θ) :
         (quotientEquivAlgOfEq ℤ (by simp [map_span])).toRingEquiv))
 
 set_option backward.isDefEq.respectTransparency false in
-set_option backward.whnf.reducibleClassField false in
 theorem ZModXQuotSpanEquivQuotSpan_mk_apply (hp : ¬ p ∣ exponent θ) (Q : ℤ[X]) :
     (ZModXQuotSpanEquivQuotSpan hp)
       (Ideal.Quotient.mk (span {map (Int.castRingHom (ZMod p)) (minpoly ℤ θ)})

--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -24,7 +24,6 @@ universe u
 
 variable {α : Type u}
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a top order
 with possibly different definitional equalities. -/
 def OrderTop.copy {h : LE α} {h' : LE α} (c : @OrderTop α h')
@@ -32,7 +31,6 @@ def OrderTop.copy {h : LE α} {h' : LE α} (c : @OrderTop α h')
     (le_eq : ∀ x y : α, (@LE.le α h) x y ↔ x ≤ y) : @OrderTop α h :=
   @OrderTop.mk α h { top := top } fun _ ↦ by simp [eq_top, le_eq]
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a bottom order
 with possibly different definitional equalities. -/
 def OrderBot.copy {h : LE α} {h' : LE α} (c : @OrderBot α h')
@@ -40,7 +38,6 @@ def OrderBot.copy {h : LE α} {h' : LE α} (c : @OrderBot α h')
     (le_eq : ∀ x y : α, (@LE.le α h) x y ↔ x ≤ y) : @OrderBot α h :=
   @OrderBot.mk α h { bot := bot } fun _ ↦ by simp [eq_bot, le_eq]
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a bounded order
 with possibly different definitional equalities. -/
 def BoundedOrder.copy {h : LE α} {h' : LE α} (c : @BoundedOrder α h')

--- a/Mathlib/Order/Lattice/Congruence.lean
+++ b/Mathlib/Order/Lattice/Congruence.lean
@@ -114,7 +114,6 @@ variable [FunLike F α β]
 
 open Function
 
-set_option backward.whnf.reducibleClassField false in
 /-- The kernel of a lattice homomorphism as a lattice congruence. -/
 @[simps!]
 def ker [LatticeHomClass F α β] (f : F) : LatticeCon α where

--- a/Mathlib/Probability/Distributions/Gaussian/HasGaussianLaw/Independence.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/HasGaussianLaw/Independence.lean
@@ -233,7 +233,6 @@ end InnerProductSpace
 
 section Real
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If $((X_{i,j})_{j \in \kappa_i})_{i \in \iota}$ are jointly Gaussian, then they are independent
 if for all $i_1 \ne i_2 \in \iota$ and for all $j_1 \in \kappa_{i_1}, j_2 \in \kappa_{i_2}$,
@@ -281,7 +280,6 @@ variable {E F : Type*}
     [NormedAddCommGroup F] [MeasurableSpace F]
     [CompleteSpace F] [BorelSpace F] [SecondCountableTopology F]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- Independent Gaussian random variables are jointly Gaussian. -/
 lemma IndepFun.hasGaussianLaw [NormedSpace ℝ E] [NormedSpace ℝ F] {X : Ω → E} {Y : Ω → F}
@@ -340,7 +338,6 @@ lemma HasGaussianLaw.indepFun_of_covariance_inner [InnerProductSpace ℝ E] [Inn
   hXY.indepFun_of_covariance_strongDual fun L₁ L₂ ↦ by
     simpa using h ((toDual ℝ E).symm L₁) ((toDual ℝ F).symm L₂)
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If $((X_i)_{i \in \iota}, (Y_j)_{j \in \kappa})$ is Gaussian, then $(X_i)_{i \in \iota}$ and
 $(Y_j)_{j \in \kappa}$ are independent if for all $i \in \iota, j \in \kappa$,

--- a/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
@@ -542,7 +542,6 @@ lemma setLIntegral_toKernel_prod [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ 
     · exact fun i ↦
         ((Kernel.measurable_coe _ (hf_meas i)).comp measurable_prodMk_left).aemeasurable.restrict
 
-set_option backward.isDefEq.respectTransparency false in
 open scoped Function in -- required for scoped `on` notation
 lemma lintegral_toKernel_mem [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ ν)
     (a : α) {s : Set (β × ℝ)} (hs : MeasurableSet s) :

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -273,7 +273,6 @@ lemma measurable_singularPart_fun_right (κ η : Kernel α γ) (a : α) :
     - ENNReal.ofReal (1 - rnDerivAux κ (κ + η) a b) * rnDeriv κ η a b) ∘ (fun b ↦ (a, b)))
   exact (measurable_singularPart_fun κ η).comp measurable_prodMk_left
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 lemma singularPart_compl_mutuallySingularSetSlice (κ η : Kernel α γ) [IsSFiniteKernel κ]
     [IsSFiniteKernel η] (a : α) :

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -484,7 +484,6 @@ lemma integrable_exp_add_compProd {η : Kernel (Ω' × Ω) Ω''} [IsZeroOrMarkov
     rwa [ENNReal.coe_ofNat, Measure.comp_compProd_comm, Measure.snd,
       memLp_map_measure_iff h.1 measurable_snd.aemeasurable] at h
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- For `ν : Measure Ω'`, `κ : Kernel Ω' Ω` and `η : (Ω' × Ω) Ω''`, if a random variable `X : Ω → ℝ`
 has a sub-Gaussian mgf with respect to `κ` and `ν` and another random variable `Y : Ω'' → ℝ` has

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -591,7 +591,6 @@ theorem strong_law_aux7 :
 
 end StrongLawNonneg
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- **Strong law of large numbers**, almost sure version: if `X n` is a sequence of independent
 identically distributed integrable real-valued random variables, then `∑ i ∈ range n, X i / n`

--- a/Mathlib/RingTheory/AdicCompletion/Topology.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Topology.lean
@@ -26,7 +26,6 @@ section TopologicalSpace
 
 variable {R : Type*} [CommRing R] [TopologicalSpace R] {I : Ideal R} (hI : IsAdic I)
 
-set_option backward.whnf.reducibleClassField false in
 include hI in
 /-- `IsHausdorff I R` is equivalent to being Hausdorff in the adic topology. -/
 protected lemma IsAdic.isHausdorff_iff : IsHausdorff I R ↔ T2Space R := by

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -269,7 +269,6 @@ theorem comul_comp_snd :
 
 @[simp] theorem counit_comp_inl : counit ∘ₗ inl R A B = counit := by ext; simp
 
-set_option backward.whnf.reducibleClassField false in
 instance instCoalgebra : Coalgebra R (A × B) where
   rTensor_counit_comp_comul := by
     ext : 1
@@ -557,7 +556,6 @@ abbrev coalgebraStruct [AddCommMonoid B] [Module R B] [CoalgebraStruct R B] (e :
         comul ∘ₗ (e.linearEquiv R).toLinearMap
     counit := counit ∘ₗ (e.linearEquiv R).toLinearMap }
 
-set_option backward.whnf.reducibleClassField false in
 variable (R) in
 /-- Transfer `Coalgebra` across an `Equiv`. -/
 abbrev coalgebra [AddCommMonoid B] [Module R B] [Coalgebra R B] (e : A ≃ B) :

--- a/Mathlib/RingTheory/Ideal/Prod.lean
+++ b/Mathlib/RingTheory/Ideal/Prod.lean
@@ -85,7 +85,6 @@ theorem map_snd_prod (I : Ideal R) (J : Ideal S) : map (RingHom.snd R S) (prod I
       rintro ⟨x, ⟨h, rfl⟩⟩
       exact h.2, fun h => ⟨⟨0, x⟩, ⟨⟨Ideal.zero_mem _, h⟩, rfl⟩⟩⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem map_prodComm_prod :
     map ((RingEquiv.prodComm : R × S ≃+* S × R) : R × S →+* S × R) (prod I J) = prod J I := by

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
@@ -58,7 +58,6 @@ lemma Ideal.ResidueField.exists_smul_eq_tmul_one
     ← IsLocalRing.ResidueField.algebraMap_eq, ← algebraMap.coe_smul,
     ← IsScalarTower.algebraMap_apply] using congr(t • $e)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The fiber of a prime `p` of `R` in an `R`-algebra `S`, defined to be `κ(p) ⊗ S`.
 
 See `PrimeSpectrum.preimageHomeomorphFiber` for the homeomorphism between the spectrum of it

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
@@ -138,7 +138,6 @@ lemma Ideal.algebraMap_residueField_surjective (I : Ideal R) [I.IsMaximal] :
   rw [IsScalarTower.algebraMap_eq R (R ⧸ I) _]
   exact I.bijective_algebraMap_quotient_residueField.surjective.comp Ideal.Quotient.mk_surjective
 
-set_option backward.isDefEq.respectTransparency false in
 instance (I : Ideal R) [I.IsMaximal] : Module.Finite R I.ResidueField :=
   .of_surjective (Algebra.linearMap _ _) I.algebraMap_residueField_surjective
 

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -159,7 +159,6 @@ lemma Algebra.isPushout_of_isLocalization [IsLocalization (Algebra.algebraMapSub
     Algebra.IsPushout R T A B :=
   (Algebra.isLocalization_iff_isPushout S _).mp inferInstance
 
-set_option backward.isDefEq.respectTransparency false in
 variable (R M) in
 open TensorProduct in
 instance {α} [IsLocalizedModule S f] :

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -314,7 +314,6 @@ lemma IsLocalization.Away.exists_isIntegral_mul_of_isIntegral_mk'
   convert (hr.pow n).algebraMap.mul hx
   exact (mk'_spec'_mk ..).symm
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If `t` is integral over `R[1/t]`, then it is integral over `R`. -/
 lemma isIntegral_of_isIntegral_adjoin_of_mul_eq_one

--- a/Mathlib/RingTheory/QuasiFinite/Basic.lean
+++ b/Mathlib/RingTheory/QuasiFinite/Basic.lean
@@ -280,7 +280,6 @@ lemma eq_of_le_of_under_eq [QuasiFinite R S] (P Q : Ideal S) [P.IsPrime] [Q.IsPr
     (a := ⟨P, ‹_›⟩) (b := ⟨Q, ‹_›⟩) (by simpa [← PrimeSpectrum.le_iff_specializes]) rfl
     (PrimeSpectrum.ext h₂.symm)).1)
 
-set_option backward.isDefEq.respectTransparency false in
 instance [QuasiFinite R S] (P : Ideal R) [P.IsPrime] (Q : Ideal S) [Q.IsPrime] [Q.LiesOver P] :
     Module.Finite P.ResidueField Q.ResidueField :=
   have : QuasiFinite P.ResidueField Q.ResidueField := .of_restrictScalars R _ _

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -198,7 +198,6 @@ lemma sigmaToPi_bijective {ι : Type*} (R : ι → Type*) [∀ i, CommRing (R i)
   obtain ⟨i, q, rfl⟩ := exists_comap_evalRingHom_eq q
   exact ⟨⟨i, q⟩, rfl⟩
 
-set_option backward.isDefEq.respectTransparency false in
 lemma iUnion_range_comap_comp_evalRingHom
     {ι : Type*} {R : ι → Type*} [∀ i, CommRing (R i)] [Finite ι]
     {S : Type*} [CommRing S] (f : S →+* Π i, R i) :

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -598,7 +598,6 @@ theorem moduleAux_apply (a : A) (b : B) (m : M) : moduleAux (a ⊗ₜ[R] b) m = 
 
 variable [SMulCommClass A B M]
 
-set_option backward.whnf.reducibleClassField false in
 /-- If `M` is a representation of two different `R`-algebras `A` and `B` whose actions commute,
 then it is a representation the `R`-algebra `A ⊗[R] B`.
 

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -167,7 +167,6 @@ def mk' (carrier : Set R)
         rw [show a + c - (b + d) = (a - b) + (c - d) by abel]
         exact add_mem h1 h2 }
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 lemma mem_mk' (carrier : Set R) (zero_mem add_mem neg_mem mul_mem_left mul_mem_right) (x : R) :
     x ∈ mk' carrier zero_mem add_mem neg_mem mul_mem_left mul_mem_right ↔ x ∈ carrier := by

--- a/Mathlib/RingTheory/Unramified/LocalRing.lean
+++ b/Mathlib/RingTheory/Unramified/LocalRing.lean
@@ -149,7 +149,6 @@ lemma isUnramifiedAt_iff_map_eq :
 instance [Algebra.IsUnramifiedAt R q] : Algebra.IsSeparable p.ResidueField q.ResidueField :=
   ((Algebra.isUnramifiedAt_iff_map_eq _ _ _).mp inferInstance).1
 
-set_option backward.isDefEq.respectTransparency false in
 instance [Algebra.IsUnramifiedAt R q] : Module.Finite p.ResidueField q.ResidueField :=
   Algebra.FormallyUnramified.finite_of_free _ _
 

--- a/Mathlib/Tactic/FieldSimp/Lemmas.lean
+++ b/Mathlib/Tactic/FieldSimp/Lemmas.lean
@@ -313,7 +313,6 @@ theorem cons_zero_eq_div_of_eq_div [CommGroupWithZero M] (e : M) {t t_n t_d : NF
 instance : Inv (NF M) where
   inv l := l.map fun (a, x) ↦ (-a, x)
 
-set_option backward.whnf.reducibleClassField false in
 theorem eval_inv [CommGroupWithZero M] (l : NF M) : (l⁻¹).eval = l.eval⁻¹ := by
   simp +instances only [NF.eval, List.map_map, NF.instInv, List.prod_inv]
   congr! 2

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -138,7 +138,6 @@ theorem sub_eq_eval {R₁ R₂ S₁ S₂ : Type*} [AddCommGroup M] [Ring R] [Mod
 instance [Neg R] : Neg (NF R M) where
   neg l := l.map fun (a, x) ↦ (-a, x)
 
-set_option backward.whnf.reducibleClassField false in
 theorem eval_neg [AddCommGroup M] [Ring R] [Module R M] (l : NF R M) : (-l).eval = - l.eval := by
   simp +instances only [NF.eval, List.map_map, List.sum_neg, NF.instNeg]
   congr

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -88,12 +88,10 @@ theorem isInt_ratCast {R : Type*} [DivisionRing R] : {q : ℚ} → {n : ℤ} →
     IsInt q n → IsInt (q : R) n
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem isNNRat_ratCast {R : Type*} [DivisionRing R] [CharZero R] : {q : ℚ} → {n : ℕ} → {d : ℕ} →
     IsNNRat q n d → IsNNRat (q : R) n d
   | _, _, _, ⟨⟨qi,_,_⟩, rfl⟩ => ⟨⟨qi, by norm_cast, by norm_cast⟩, by simp only; norm_cast⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem isRat_ratCast {R : Type*} [DivisionRing R] [CharZero R] : {q : ℚ} → {n : ℤ} → {d : ℕ} →
     IsRat q n d → IsRat (q : R) n d
   | _, _, _, ⟨⟨qi,_,_⟩, rfl⟩ => ⟨⟨qi, by norm_cast, by norm_cast⟩, by simp only; norm_cast⟩

--- a/Mathlib/Tactic/NormNum/Irrational.lean
+++ b/Mathlib/Tactic/NormNum/Irrational.lean
@@ -222,7 +222,6 @@ private theorem irrational_rpow_nat_rat {x y : ℝ} {x_num y_num y_den k : ℕ}
     Irrational (x ^ y) :=
   irrational_rpow_rat_rat_of_num hx_isNat.to_isNNRat hy_isNNRat (by simp) hy_coprime hn1 hn2
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem irrational_sqrt_rat_of_num {x : ℝ} {num den num_k : ℕ}
     (hx_isNNRat : IsNNRat x num den)
     (hx_coprime : Nat.Coprime num den)
@@ -234,7 +233,6 @@ private theorem irrational_sqrt_rat_of_num {x : ℝ} {num den num_k : ℕ}
     hn1 hn2
   exact ⟨Invertible.mk (1/2) (by simp) (by simp), by simp⟩
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem irrational_sqrt_rat_of_den {x : ℝ} {num den den_k : ℕ}
     (hx_isNNRat : IsNNRat x num den)
     (hx_coprime : Nat.Coprime num den)

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -244,7 +244,6 @@ theorem IsNNRat.to_isNat {α} [Semiring α] : ∀ {a : α} {n}, IsNNRat a (n) (n
 theorem IsRat.to_isNNRat {α} [Ring α] : ∀ {a : α} {n d}, IsRat a (.ofNat n) (d) → IsNNRat a n d
   | _, _, _, ⟨inv, rfl⟩ => ⟨inv, by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem IsNat.to_isNNRat {α} [Semiring α] : ∀ {a : α} {n}, IsNat a n → IsNNRat a (n) (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 
@@ -254,7 +253,6 @@ theorem IsNNRat.to_isRat {α} [Ring α] : ∀ {a : α} {n d}, IsNNRat a n d → 
 theorem IsRat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsRat a n (nat_lit 1) → IsInt a n
   | _, _, ⟨inv, rfl⟩ => have := @invertibleOne α _; ⟨by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem IsInt.to_isRat {α} [Ring α] : ∀ {a : α} {n}, IsInt a n → IsRat a n (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -222,7 +222,6 @@ abbrev replaceEDist : PseudoEMetricSpace X where
 
 lemma replaceEDist_eq : m.replaceEDist d hd = m := by ext : 2; exact hd
 
-set_option backward.whnf.reducibleClassField false in
 -- Check uniformity is unchanged
 example : (replaceEDist m d hd).toUniformSpace = m.toUniformSpace := by
   dsimp +instances [replaceEDist]
@@ -249,12 +248,10 @@ abbrev replaceDist : PseudoMetricSpace X where
 
 lemma replaceDist_eq : m.replaceDist d hd = m := by ext : 2; exact hd
 
-set_option backward.whnf.reducibleClassField false in
 -- Check uniformity is unchanged
 example : (replaceDist m d hd).toUniformSpace = m.toUniformSpace := by
   dsimp +instances [replaceDist]
 
-set_option backward.whnf.reducibleClassField false in
 -- Check Bornology is unchanged
 example : (replaceDist m d hd).toBornology = m.toBornology := by
   dsimp +instances [replaceDist]

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -180,7 +180,6 @@ lemma topology_eq [IsScottHausdorff α D] : ‹_› = scottHausdorff α D := top
 
 variable {α D}
 
-set_option backward.whnf.reducibleClassField false in
 lemma isOpen_iff [IsScottHausdorff α D] :
     IsOpen s ↔ ∀ ⦃d : Set α⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a : α⦄, IsLUB d a →
       a ∈ s → ∃ b ∈ d, Ici b ∩ d ⊆ s := by


### PR DESCRIPTION
The default value for `backward.whnf.reducibleClassField` of `true` now works fine as of today.