### PR TITLE
feat(Topology/Algebra/Order): piecewise linear interpolation on regular grids

### DIFF
--- a/Mathlib/Topology/Algebra/Order/Floor.lean
+++ b/Mathlib/Topology/Algebra/Order/Floor.lean
@@ -233,3 +233,54 @@ theorem ContinuousOn.comp_fract'' {f : α → β} (h : ContinuousOn f I) (hf : f
     Continuous (f ∘ fract) :=
   ContinuousOn.comp_fract (h.comp continuousOn_snd fun _x hx => (mem_prod.mp hx).2) continuous_id
     fun _ => hf
+
+/-!
+## Regular grids and `Nat.floor`
+
+These results relate `⌊(t - a) / h⌋₊` to membership in a regular grid of intervals
+`[a + n * h, a + (n + 1) * h)` with step size `h > 0`. They are used, for example,
+to construct piecewise linear interpolations and prove their continuity.
+-/
+
+section RegularGrid
+
+variable {K : Type*} [Field K] [LinearOrder K] [FloorSemiring K] [IsStrictOrderedRing K]
+
+/-- If `t ∈ [a + n * h, a + (n + 1) * h)` and `0 < h`, then `⌊(t - a) / h⌋₊ = n`. -/
+theorem Nat.floor_div_eq_of_mem_Ico {h : K} (hh : 0 < h) {a : K}
+    {n : ℕ} {t : K} (ht : t ∈ Ico (a + n * h) (a + (n + 1) * h)) :
+    ⌊(t - a) / h⌋₊ = n := by
+  refine Nat.floor_eq_on_Ico n _ ⟨?_, ?_⟩ <;>
+    (first | rw [le_div_iff₀ hh] | rw [div_lt_iff₀ hh]) <;> linarith [ht.1, ht.2]
+
+/-- If `0 < h` and `a ≤ t`, then `t` lies in the floor interval
+`[a + ⌊(t - a) / h⌋₊ * h, a + (⌊(t - a) / h⌋₊ + 1) * h)`. -/
+theorem mem_Ico_Nat_floor_div {h : K} (hh : 0 < h) {a t : K} (hat : a ≤ t) :
+    t ∈ Ico (a + ⌊(t - a) / h⌋₊ * h) (a + (↑⌊(t - a) / h⌋₊ + 1) * h) := by
+  constructor <;> nlinarith [Nat.floor_le (div_nonneg (sub_nonneg.mpr hat) hh.le),
+    Nat.lt_floor_add_one ((t - a) / h), mul_div_cancel₀ (t - a) hh.ne']
+
+variable [TopologicalSpace K] [OrderTopology K]
+
+/-- The regular grid of closed intervals `[a + n * h, a + (n + 1) * h]` is locally finite. -/
+theorem locallyFinite_Icc_grid {h : K} (hh : 0 < h) (a : K) :
+    LocallyFinite fun n : ℕ => Icc (a + n * h) (a + (↑n + 1) * h) := by
+  intro x
+  refine ⟨Ioo (x - h) (x + h), Ioo_mem_nhds (by linarith) (by linarith),
+    (finite_Icc (⌊(x - h - a) / h⌋₊) (⌈(x + h - a) / h⌉₊)).subset ?_⟩
+  rintro n ⟨z, ⟨hz1, hz2⟩, hz3, hz4⟩
+  refine ⟨Nat.lt_add_one_iff.mp ((Nat.floor_lt' (by linarith)).mpr ?_),
+    Nat.cast_le.mp ((?_ : (n : K) ≤ _).trans (Nat.le_ceil _))⟩ <;>
+    (first | rw [div_lt_iff₀ hh] | rw [le_div_iff₀ hh]) <;> push_cast <;> nlinarith
+
+/-- A function continuous on each cell `[a + n * h, a + (n + 1) * h]` is continuous
+on `[a, ∞)`. -/
+theorem ContinuousOn.of_Icc_grid {E : Type*} [TopologicalSpace E]
+    {f : K → E} {h : K} (hh : 0 < h) {a : K}
+    (hf : ∀ n : ℕ, ContinuousOn f (Icc (a + n * h) (a + (n + 1) * h))) :
+    ContinuousOn f (Ici a) :=
+  ((locallyFinite_Icc_grid hh a).continuousOn_iUnion (fun _ => isClosed_Icc) (hf ·)).mono
+    fun t (hat : a ≤ t) =>
+      mem_iUnion.mpr ⟨_, Ico_subset_Icc_self (mem_Ico_Nat_floor_div hh hat)⟩
+
+end RegularGrid

--- a/Mathlib/Topology/Algebra/Order/PiecewiseLinear.lean
+++ b/Mathlib/Topology/Algebra/Order/PiecewiseLinear.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2025 Vasily Ilin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vasily Ilin
+-/
+import Mathlib.Topology.Algebra.Order.Floor
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Mul
+
+/-!
+# Piecewise linear and constant interpolation on regular grids
+
+Given a sequence of values `y` and slopes `c` on a regular grid with step size `h > 0`
+starting at `a`, this file defines:
+
+* `piecewiseLinear y c h a t`: the piecewise linear interpolation, equal to
+  `y n + (t - (a + n * h)) • c n` on `[a + n * h, a + (n + 1) * h)`.
+* `piecewiseConst c h a t`: the piecewise constant function taking value `c n` on
+  `[a + n * h, a + (n + 1) * h)`.
+
+## Main results
+
+* `piecewiseConst_eq_on_Ico`: `piecewiseConst c h a t = c n` on the `n`-th cell.
+* `piecewiseLinear_apply_grid`: `piecewiseLinear y c h a (a + n * h) = y n`.
+* `piecewiseLinear_eq_on_Ico`: evaluation on the `n`-th cell.
+* `piecewiseLinear_continuousOn`: continuity on `[a, ∞)` when `y (n+1) = y n + h • c n`.
+* `piecewiseLinear_hasDerivWithinAt`: the right derivative of the piecewise linear function
+  is the piecewise constant slope.
+
+## References
+
+* [Vilin97/forward_euler](https://github.com/Vilin97/forward_euler) — a formal proof of
+  convergence of the forward Euler method, where these definitions are used.
+-/
+
+open Set
+
+variable {α : Type*} [Field α] [LinearOrder α] [FloorSemiring α] [IsStrictOrderedRing α]
+
+/-- The piecewise linear interpolation of a sequence `y` with slopes `c` on a regular grid
+with step size `h` starting at `a`. On `[a + n * h, a + (n + 1) * h)`, the value is
+`y n + (t - (a + n * h)) • c n`. -/
+noncomputable def piecewiseLinear {E : Type*} [AddCommGroup E] [Module α E]
+    (y : ℕ → E) (c : ℕ → E) (h : α) (a : α) (t : α) : E :=
+  let n := ⌊(t - a) / h⌋₊
+  y n + (t - (a + n * h)) • c n
+
+/-- The piecewise constant function taking value `c n` on `[a + n * h, a + (n + 1) * h)`. -/
+noncomputable def piecewiseConst {E : Type*} (c : ℕ → E) (h : α) (a : α) (t : α) : E :=
+  c ⌊(t - a) / h⌋₊
+
+/-- The piecewise constant function equals `c n` on `[a + n * h, a + (n + 1) * h)`. -/
+theorem piecewiseConst_eq_on_Ico {E : Type*} {c : ℕ → E} {h : α} {a : α}
+    (hh : 0 < h) {n : ℕ} {t : α}
+    (ht : t ∈ Ico (a + n * h) (a + (n + 1) * h)) :
+    piecewiseConst c h a t = c n := by
+  simp [piecewiseConst, Nat.floor_div_eq_of_mem_Ico hh ht]
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {y : ℕ → E} {c : ℕ → E} {h : ℝ} {a : ℝ}
+
+/-- The piecewise linear interpolation at a grid point `a + n * h` equals `y n`. -/
+theorem piecewiseLinear_apply_grid (hh : 0 < h) (a : ℝ) (n : ℕ) :
+    piecewiseLinear y c h a (a + n * h) = y n := by
+  simp [piecewiseLinear, hh.ne']
+
+/-- The piecewise linear interpolation equals `y n + (t - (a + n * h)) • c n`
+on `[a + n * h, a + (n + 1) * h)`. -/
+theorem piecewiseLinear_eq_on_Ico (hh : 0 < h) {n : ℕ} {t : ℝ}
+    (ht : t ∈ Ico (a + n * h) (a + (n + 1) * h)) :
+    piecewiseLinear y c h a t = y n + (t - (a + n * h)) • c n := by
+  simp [piecewiseLinear, Nat.floor_div_eq_of_mem_Ico hh ht]
+
+/-- A piecewise linear function whose grid values satisfy `y (n + 1) = y n + h • c n`
+is continuous on `[a, ∞)`. -/
+theorem piecewiseLinear_continuousOn (hh : 0 < h)
+    (hstep : ∀ n, y (n + 1) = y n + h • c n) :
+    ContinuousOn (piecewiseLinear y c h a) (Ici a) := by
+  apply ContinuousOn.of_Icc_grid hh; intro n
+  apply (show ContinuousOn (fun t => y n + (t - (a + n * h)) • c n) _ by fun_prop).congr
+  intro t ht; rcases eq_or_lt_of_le ht.2 with rfl | h_lt
+  · norm_cast
+    rw [piecewiseLinear_apply_grid hh a (n + 1), hstep]
+    module
+  · exact piecewiseLinear_eq_on_Ico hh ⟨ht.1, h_lt⟩
+
+/-- The right derivative of a piecewise linear function is the piecewise constant slope. -/
+theorem piecewiseLinear_hasDerivWithinAt (hh : 0 < h) {t : ℝ} (hat : a ≤ t) :
+    HasDerivWithinAt (piecewiseLinear y c h a)
+      (piecewiseConst c h a t) (Ici t) t := by
+  set n := ⌊(t - a) / h⌋₊; set tn := a + n * h
+  obtain ⟨h1, h2⟩ := mem_Ico_Nat_floor_div hh hat
+  simp only [piecewiseConst]
+  exact hasDerivWithinAt_Ioi_iff_Ici.mp
+    (((hasDerivAt_id t |>.sub_const tn |>.smul_const (c n)
+      |>.const_add (y n)).hasDerivWithinAt.congr_of_eventuallyEq (by
+        filter_upwards [Ioo_mem_nhdsGT h2] with x hx
+        exact piecewiseLinear_eq_on_Ico hh ⟨h1.trans hx.1.le, hx.2⟩)
+      (by simp [piecewiseLinear, n, tn])).congr_deriv (one_smul _ _))


### PR DESCRIPTION
## Summary
- Add `piecewiseLinear` and `piecewiseConst` definitions for interpolation on regular grids `[a + n*h, a + (n+1)*h)`.
- Prove evaluation lemmas (`piecewiseConst_eq_on_Ico`, `piecewiseLinear_apply_grid`, `piecewiseLinear_eq_on_Ico`), continuity (`piecewiseLinear_continuousOn`), and the right derivative (`piecewiseLinear_hasDerivWithinAt`).
- Definitions are generic over `Field α` with `FloorSemiring`; continuity/derivative results are for `ℝ`-normed spaces.

## Motivation
These are used in the [forward Euler convergence proof](https://github.com/Vilin97/forward_euler) to construct the piecewise linear Euler path and prove it has the expected derivative. They provide general-purpose piecewise interpolation infrastructure.

Depends on #35753.

## Test plan
- [x] `lake env lean Mathlib/Topology/Algebra/Order/PiecewiseLinear.lean` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)