### PR TITLE
[Merged by Bors] - chore: use `to_dual` on `WellFoundedLT.toOrderBot`

### DIFF
--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -312,7 +312,7 @@ theorem WellFounded.induction_bot {α} {r : α → α → Prop} (hwf : WellFound
 end Induction
 
 /-- A nonempty linear order with well-founded `<` has a bottom element. -/
-@[to_dual (attr := implicit_reducible)
+@[to_dual (attr := instance_reducible)
 /-- A nonempty linear order with well-founded `>` has a top element. -/]
 noncomputable def WellFoundedLT.toOrderBot (α) [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
     OrderBot α where

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -312,17 +312,17 @@ theorem WellFounded.induction_bot {α} {r : α → α → Prop} (hwf : WellFound
 end Induction
 
 /-- A nonempty linear order with well-founded `<` has a bottom element. -/
-@[instance_reducible]
-noncomputable def WellFoundedLT.toOrderBot {α} [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
+@[implicit_reducible]
+noncomputable def WellFoundedLT.toOrderBot (α) [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
     OrderBot α where
   bot := h.wf.min _ Set.univ_nonempty
   bot_le a := h.wf.min_le (Set.mem_univ a)
 
 /-- A nonempty linear order with well-founded `>` has a top element. -/
 @[instance_reducible]
-noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
+noncomputable def WellFoundedGT.toOrderTop (α) [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
     OrderTop α :=
-  have := WellFoundedLT.toOrderBot (α := αᵒᵈ)
+  have := WellFoundedLT.toOrderBot (αᵒᵈ)
   inferInstanceAs (OrderTop αᵒᵈᵒᵈ)
 
 namespace ULift

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -312,25 +312,13 @@ theorem WellFounded.induction_bot {α} {r : α → α → Prop} (hwf : WellFound
 end Induction
 
 /-- A nonempty linear order with well-founded `<` has a bottom element. -/
-@[implicit_reducible]
+@[to_dual (attr := implicit_reducible)
+/-- A nonempty linear order with well-founded `>` has a top element. -/]
 noncomputable def WellFoundedLT.toOrderBot (α) [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
     OrderBot α where
   bot := h.wf.min _ Set.univ_nonempty
   bot_le a := h.wf.min_le (Set.mem_univ a)
 
-/-- A nonempty linear order with well-founded `>` has a top element. -/
-@[instance_reducible]
-noncomputable def WellFoundedGT.toOrderTop (α) [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
-    OrderTop α :=
-  have := WellFoundedLT.toOrderBot (αᵒᵈ)
-  inferInstanceAs (OrderTop αᵒᵈᵒᵈ)
-
-namespace ULift
-
+@[to_dual]
 instance [LT α] [h : WellFoundedLT α] : WellFoundedLT (ULift α) where
-  wf := InvImage.wf down h.wf
-
-instance [LT α] [WellFoundedGT α] : WellFoundedGT (ULift α) :=
-  inferInstanceAs (WellFoundedLT (ULift αᵒᵈ))
-
-end ULift
+  wf := InvImage.wf ULift.down h.wf


### PR DESCRIPTION
And also make the argument explicit, so it can be called as `let := WellFoundedLT.toOrderBot α`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
