### PR TITLE
[Merged by Bors] - chore(scripts): make rm_set_option cache opt-in via --resume

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -123,7 +123,7 @@ behaviour. They share a common DAG traversal library that parallelises work in i
   **backward** (leaves first) so removing an option from an upstream file doesn't invalidate
   cached builds of downstream files. Tries removing all occurrences at once; if that fails,
   falls back to one-at-a-time removal.
-  Usage: `python3 scripts/rm_set_option.py [--option NAME] [--dry-run] [--max-workers N] [--files FILE ...]`
+  Usage: `python3 scripts/rm_set_option.py [--option NAME] [--dry-run] [--max-workers N] [--files FILE ...] [--resume]`
 
 **CI workflow**
 - `lake-build-with-retry.sh`

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -338,9 +338,9 @@ def main():
         help="Skip the initial lake build (assumes .oleans are already fresh)",
     )
     parser.add_argument(
-        "--no-resume",
+        "--resume",
         action="store_true",
-        help="Ignore progress from a previous interrupted run",
+        help="Resume a previous interrupted run, skipping already-processed modules",
     )
     args = parser.parse_args()
 
@@ -374,7 +374,7 @@ def main():
 
     # Step 3b: filter out modules completed in a previous run
     resumed = 0
-    if not args.no_resume:
+    if args.resume:
         progress = load_progress()
         if progress:
             to_skip = []


### PR DESCRIPTION
This PR changes `scripts/rm_set_option.py` so the progress cache is only used when explicitly requested via `--resume`, rather than being on by default (with `--no-resume` to disable).

The previous default was unsafe: the cache only checks that the target module's own SHA256 is unchanged, so edits to upstream modules between runs would be silently ignored, causing the script to skip modules that should be reprocessed.

🤖 Prepared with Claude Code