### PR TITLE
[Merged by Bors] - chore: golf using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -387,18 +387,7 @@ def Precoverage.toCoverage (J : Precoverage C) [J.HasPullbacks] [J.IsStableUnder
 lemma Precoverage.toGrothendieck_toCoverage {J : Precoverage C} [J.HasPullbacks]
     [J.IsStableUnderBaseChange] :
     J.toCoverage.toGrothendieck = J.toGrothendieck := by
-  refine le_antisymm ?_ ?_
-  · intro _ _ hS
-    induction hS with
-    | of _ _ hS => exact generate_mem_toGrothendieck hS
-    | top => exact J.toGrothendieck.top_mem _
-    | transitive _ _ _ _ _ ih1 ih2 => exact J.toGrothendieck.transitive ih1 _ ih2
-  · intro _ _ hS
-    induction hS with
-    | of _ _ hS => exact .of _ _ hS
-    | top => exact J.toCoverage.toGrothendieck.top_mem _
-    | pullback _ _ _ _ _ ih => exact J.toCoverage.toGrothendieck.pullback_stable _ ih
-    | transitive _ _ _ _ _ ih1 ih2 => exact J.toCoverage.toGrothendieck.transitive ih1 _ ih2
+  grind [toGrothendieck_eq_sInf, Coverage.toGrothendieck_eq_sInf]
 
 lemma Coverage.toGrothendieck_toPrecoverage (J : Coverage C) :
     J.toPrecoverage.toGrothendieck = J.toGrothendieck := by

--- a/Mathlib/Data/Int/Order/Basic.lean
+++ b/Mathlib/Data/Int/Order/Basic.lean
@@ -45,18 +45,7 @@ instance instLinearOrder : LinearOrder ℤ where
 protected alias ⟨eq_zero_or_eq_zero_of_mul_eq_zero, _⟩ := Int.mul_eq_zero
 
 theorem nonneg_or_nonpos_of_mul_nonneg : 0 ≤ a * b → 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 := by
-  intro h
-  by_cases! ha : 0 ≤ a <;> by_cases! hb : 0 ≤ b
-  · exact .inl ⟨ha, hb⟩
-  · refine .inr ⟨?_, le_of_lt hb⟩
-    obtain _ | _ := Int.mul_eq_zero.mp <|
-      le_antisymm (Int.mul_nonpos_of_nonneg_of_nonpos ha <| le_of_lt hb) h
-    all_goals lia
-  · refine .inr ⟨le_of_lt ha, ?_⟩
-    obtain _ | _ := Int.mul_eq_zero.mp <|
-      le_antisymm (Int.mul_nonpos_of_nonpos_of_nonneg (le_of_lt ha) hb) h
-    all_goals lia
-  · exact .inr ⟨le_of_lt ha, le_of_lt hb⟩
+  grind [Int.mul_comm, Int.mul_nonneg_iff_of_pos_right]
 
 theorem mul_nonneg_of_nonneg_or_nonpos : 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 → 0 ≤ a * b
   | .inl ⟨ha, hb⟩ => Int.mul_nonneg ha hb

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -127,16 +127,7 @@ theorem Separable.map {p : R[X]} (h : p.Separable) {f : R →+* S} : (p.map f).S
 
 theorem _root_.Associated.separable {f g : R[X]}
     (ha : Associated f g) (h : f.Separable) : g.Separable := by
-  obtain ⟨⟨u, v, h1, h2⟩, ha⟩ := ha
-  obtain ⟨a, b, h⟩ := h
-  refine ⟨a * v + b * derivative v, b * v, ?_⟩
-  replace h := congr($h * $(h1))
-  have h3 := congr(derivative $(h1))
-  simp only [← ha, derivative_mul, derivative_one] at h3 ⊢
-  calc
-    _ = (a * f + b * derivative f) * (u * v)
-      + (b * f) * (derivative u * v + u * derivative v) := by ring1
-    _ = 1 := by rw [h, h3]; ring1
+  grind [Separable.of_dvd, Associated.dvd']
 
 theorem _root_.Associated.separable_iff {f g : R[X]}
     (ha : Associated f g) : f.Separable ↔ g.Separable := ⟨ha.separable, ha.symm.separable⟩

--- a/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/InteriorBoundary.lean
@@ -460,24 +460,11 @@ lemma boundaryPoint_inr (x : M') (hx : I.IsBoundaryPoint x) :
 -- it had to be a boundary point, hence `p` were a boundary point also, contradiction.
 lemma isInteriorPoint_disjointUnion_left {p : M ⊕ M'} (hp : I.IsInteriorPoint p)
     (hleft : Sum.isLeft p) : I.IsInteriorPoint (Sum.getLeft p hleft) := by
-  by_contra h
-  set x := Sum.getLeft p hleft
-  rw [isInteriorPoint_iff_not_isBoundaryPoint x, not_not] at h
-  rw [isInteriorPoint_iff_not_isBoundaryPoint p] at hp
-  have := boundaryPoint_inl (M' := M') x (by tauto)
-  rw [← Sum.eq_left_getLeft_of_isLeft hleft] at this
-  exact hp this
+  grind [isInteriorPoint_iff_not_isBoundaryPoint, boundaryPoint_inl]
 
 lemma isInteriorPoint_disjointUnion_right {p : M ⊕ M'} (hp : I.IsInteriorPoint p)
     (hright : Sum.isRight p) : I.IsInteriorPoint (Sum.getRight p hright) := by
-  by_contra h
-  set x := Sum.getRight p hright
-  rw [← mem_empty_iff_false p, ← (disjoint_interior_boundary (I := I)).inter_eq]
-  constructor
-  · rw [ModelWithCorners.interior, mem_setOf]; exact hp
-  · rw [ModelWithCorners.boundary, mem_setOf, Sum.eq_right_getRight_of_isRight hright]
-    have := isInteriorPoint_or_isBoundaryPoint (I := I) x
-    exact boundaryPoint_inr (M' := M') x (by tauto)
+  grind [isInteriorPoint_iff_not_isBoundaryPoint, boundaryPoint_inr]
 
 lemma interior_disjointUnion :
     ModelWithCorners.interior (I := I) (M ⊕ M') =


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `CategoryTheory.Precoverage.toGrothendieck_toCoverage`: unchanged 🎉
* `Int.nonneg_or_nonpos_of_mul_nonneg`: unchanged 🎉
* `Associated.separable`: 113 ms before, 67 ms after  🎉
* `ModelWithCorners.isInteriorPoint_disjointUnion_left`: unchanged 🎉
* `ModelWithCorners.isInteriorPoint_disjointUnion_right`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
