### PR TITLE
refactor(Combinatorics): move `Walk` from `SimpleGraph` to `HasAdj` (and refactor)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3306,6 +3306,7 @@ public import Mathlib.Combinatorics.HalesJewett
 public import Mathlib.Combinatorics.Hall.Basic
 public import Mathlib.Combinatorics.Hall.Finite
 public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Combinatorics.HasAdj.Walk
 public import Mathlib.Combinatorics.Hindman
 public import Mathlib.Combinatorics.KatonaCircle
 public import Mathlib.Combinatorics.Matroid.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3306,6 +3306,7 @@ public import Mathlib.Combinatorics.HalesJewett
 public import Mathlib.Combinatorics.Hall.Basic
 public import Mathlib.Combinatorics.Hall.Finite
 public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Combinatorics.HasAdj.Dart
 public import Mathlib.Combinatorics.Hindman
 public import Mathlib.Combinatorics.KatonaCircle
 public import Mathlib.Combinatorics.Matroid.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3285,6 +3285,7 @@ public import Mathlib.Combinatorics.Derangements.Basic
 public import Mathlib.Combinatorics.Derangements.Exponential
 public import Mathlib.Combinatorics.Derangements.Finite
 public import Mathlib.Combinatorics.Digraph.Basic
+public import Mathlib.Combinatorics.Digraph.HasAdj
 public import Mathlib.Combinatorics.Digraph.Orientation
 public import Mathlib.Combinatorics.Enumerative.Bell
 public import Mathlib.Combinatorics.Enumerative.Catalan
@@ -3304,6 +3305,7 @@ public import Mathlib.Combinatorics.Graph.Basic
 public import Mathlib.Combinatorics.HalesJewett
 public import Mathlib.Combinatorics.Hall.Basic
 public import Mathlib.Combinatorics.Hall.Finite
+public import Mathlib.Combinatorics.HasAdj.Basic
 public import Mathlib.Combinatorics.Hindman
 public import Mathlib.Combinatorics.KatonaCircle
 public import Mathlib.Combinatorics.Matroid.Basic
@@ -3386,6 +3388,7 @@ public import Mathlib.Combinatorics.SimpleGraph.FiveWheelLike
 public import Mathlib.Combinatorics.SimpleGraph.Girth
 public import Mathlib.Combinatorics.SimpleGraph.Hall
 public import Mathlib.Combinatorics.SimpleGraph.Hamiltonian
+public import Mathlib.Combinatorics.SimpleGraph.HasAdj
 public import Mathlib.Combinatorics.SimpleGraph.Hasse
 public import Mathlib.Combinatorics.SimpleGraph.IncMatrix
 public import Mathlib.Combinatorics.SimpleGraph.Init

--- a/Mathlib/Combinatorics/Digraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/Digraph/HasAdj.lean
@@ -17,7 +17,7 @@ In this file we make `Digraph` an instance of `HasAdj`.
 variable {α : Type*}
 
 instance : HasAdj α (Digraph α) where
-  vertexSet _ := Set.univ
+  verts _ := Set.univ
   Adj G := G.Adj
-  left_mem_vertexSet_of_adj _ := Set.mem_univ _
-  right_mem_vertexSet_of_adj _ := Set.mem_univ _
+  left_mem_verts_of_adj _ := Set.mem_univ _
+  right_mem_verts_of_adj _ := Set.mem_univ _

--- a/Mathlib/Combinatorics/Digraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/Digraph/HasAdj.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 Iván Renison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison
+-/
+module
+
+public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Combinatorics.Digraph.Basic
+
+/-!
+In this file we make `Digraph` an instance of `HasAdj`.
+-/
+
+@[expose] public section
+
+variable {α : Type*}
+
+instance : HasAdj α (Digraph α) where
+  vertexSet _ := Set.univ
+  Adj G := G.Adj

--- a/Mathlib/Combinatorics/Digraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/Digraph/HasAdj.lean
@@ -19,3 +19,5 @@ variable {α : Type*}
 instance : HasAdj α (Digraph α) where
   vertexSet _ := Set.univ
   Adj G := G.Adj
+  left_mem_vertexSet_of_adj _ := Set.mem_univ _
+  right_mem_vertexSet_of_adj _ := Set.mem_univ _

--- a/Mathlib/Combinatorics/HasAdj/Basic.lean
+++ b/Mathlib/Combinatorics/HasAdj/Basic.lean
@@ -16,7 +16,7 @@ This module defines the typeclass `HasAdj` for capturing the common structure of
 
 ## Main definitions
 
-* `HasAdj`: is the main typeclass in question. The field `vertexSet` gives the set of vertices of a
+* `HasAdj`: is the main typeclass in question. The field `verts` gives the set of vertices of a
   graph, and the field `Adj` gives the adjacency relation between vertices.
 
 ## TODO
@@ -29,24 +29,24 @@ This module defines the typeclass `HasAdj` for capturing the common structure of
 /-- Typeclass for (simple) graphs. -/
 class HasAdj (α : outParam Type*) (Gr : Type*) where
   /-- The set of vertices of the graph. -/
-  vertexSet (G : Gr) : Set α
+  verts (G : Gr) : Set α
   /-- The adjacency relation of the graph. -/
   Adj (G : Gr) : α → α → Prop
   /-- There is no edge of the graph outside of it vertices. -/
-  left_mem_vertexSet_of_adj {G : Gr} {v w : α} (h : Adj G v w) : v ∈ vertexSet G
+  left_mem_verts_of_adj {G : Gr} {v w : α} (h : Adj G v w) : v ∈ verts G
   /-- There is no edge of the graph outside of it vertices. -/
-  right_mem_vertexSet_of_adj {G : Gr} {v w : α} (h : Adj G v w) : w ∈ vertexSet G
+  right_mem_verts_of_adj {G : Gr} {v w : α} (h : Adj G v w) : w ∈ verts G
 
 namespace HasAdj
 
 variable {Gr : Type*} {α : Type*} [HasAdj α Gr]
 
-/-- Dot notation for `left_mem_vertexSet_of_adj`. -/
-lemma Adj.left_mem_vertexSet {G : Gr} {v w : α} (h : Adj G v w) : v ∈ vertexSet G :=
-  left_mem_vertexSet_of_adj h
+/-- Dot notation for `left_mem_verts_of_adj`. -/
+lemma Adj.left_mem_verts {G : Gr} {v w : α} (h : Adj G v w) : v ∈ verts G :=
+  left_mem_verts_of_adj h
 
-/-- Dot notation for `right_mem_vertexSet_of_adj`. -/
-lemma Adj.right_mem_vertexSet {G : Gr} {v w : α} (h : Adj G v w) : w ∈ vertexSet G :=
-  right_mem_vertexSet_of_adj h
+/-- Dot notation for `right_mem_verts_of_adj`. -/
+lemma Adj.right_mem_verts {G : Gr} {v w : α} (h : Adj G v w) : w ∈ verts G :=
+  right_mem_verts_of_adj h
 
 end HasAdj

--- a/Mathlib/Combinatorics/HasAdj/Basic.lean
+++ b/Mathlib/Combinatorics/HasAdj/Basic.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Iván Renison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison
+-/
+module
+
+public import Batteries.Data.List.Basic
+public import Mathlib.Data.Rel
+
+/-!
+# Typeclass for different kinds of (simple) graphs
+
+This module defines the typeclass `HasAdj` for capturing the common structure of different kinds of
+(simple) graphs.
+
+## Main definitions
+
+* `HasAdj`: is the main typeclass in question. The field `vertexSet` gives the set of vertices of a
+  graph, and the field `Adj` gives the adjacency relation between vertices.
+
+## TODO
+* Migrate from `SimpleGraph` all the results that only depend on the adjacency relation.
+
+-/
+
+@[expose] public section
+
+/-- Typeclass for (simple) graphs. -/
+class HasAdj (α : outParam Type*) (Gr : Type*) where
+  /-- The set of vertices of the graph. -/
+  vertexSet (G : Gr) : Set α
+  /-- The adjacency relation of the graph. -/
+  Adj (G : Gr) : α → α → Prop
+  /-- There is no edge of the graph outside of it vertices. -/
+  left_mem_vertexSet_of_adj {G : Gr} {v w : α} (h : Adj G v w) : v ∈ vertexSet G
+  /-- There is no edge of the graph outside of it vertices. -/
+  right_mem_vertexSet_of_adj {G : Gr} {v w : α} (h : Adj G v w) : w ∈ vertexSet G
+
+namespace HasAdj
+
+variable {Gr : Type*} {α : Type*} [HasAdj α Gr]
+
+/-- Dot notation for `left_mem_vertexSet_of_adj`. -/
+lemma Adj.left_mem_vertexSet {G : Gr} {v w : α} (h : Adj G v w) : v ∈ vertexSet G :=
+  left_mem_vertexSet_of_adj h
+
+/-- Dot notation for `right_mem_vertexSet_of_adj`. -/
+lemma Adj.right_mem_vertexSet {G : Gr} {v w : α} (h : Adj G v w) : w ∈ vertexSet G :=
+  right_mem_vertexSet_of_adj h
+
+end HasAdj

--- a/Mathlib/Combinatorics/HasAdj/Dart.lean
+++ b/Mathlib/Combinatorics/HasAdj/Dart.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Iván Renison, Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison, Kyle Miller
+-/
+module
+
+public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Data.Fintype.Sets
+public import Mathlib.Data.Fintype.Sigma
+
+/-!
+# Darts in graphs
+
+A `Dart` or half-edge or bond in a graph is an ordered pair of adjacent vertices, regarded as an
+oriented edge. This file defines darts and proves some of their basic properties.
+-/
+
+@[expose] public section
+
+namespace HasAdj
+
+variable {α : Type*} {Gr : Type*} [HasAdj α Gr]
+
+/-- A `Dart` is an oriented edge, implemented as an ordered pair of adjacent vertices.
+This terminology comes from combinatorial maps, and they are also known as "half-edges"
+or "bonds." -/
+structure Dart (G : Gr) extends α × α where
+  adj : Adj G fst snd
+
+initialize_simps_projections Dart (+toProd, -fst, -snd)
+
+attribute [simp] Dart.adj
+
+variable {G : Gr}
+
+theorem Dart.ext_iff (d₁ d₂ : Dart G) : d₁ = d₂ ↔ d₁.toProd = d₂.toProd := by
+  cases d₁; cases d₂; simp
+
+@[ext]
+theorem Dart.ext (d₁ d₂ : Dart G) (h : d₁.toProd = d₂.toProd) : d₁ = d₂ :=
+  (Dart.ext_iff d₁ d₂).mpr h
+
+theorem Dart.toProd_injective : Function.Injective (Dart.toProd : Dart G → α × α) :=
+  Dart.ext
+
+instance [DecidableEq α] (G : Gr) : DecidableEq (Dart G) :=
+  Dart.toProd_injective.decidableEq
+
+instance Dart.fintype [Fintype α] [DecidableRel (Adj G)] : Fintype (Dart G) :=
+  Fintype.ofEquiv (Σ v, { w | Adj G v w })
+    { toFun := fun s => ⟨(s.fst, s.snd), s.snd.property⟩
+      invFun := fun d => ⟨d.fst, d.snd, d.adj⟩ }
+
+variable (G)
+
+/-- Two darts are said to be adjacent if they could be consecutive
+darts in a walk -- that is, the first dart's second vertex is equal to
+the second dart's first vertex. -/
+def DartAdj (d d' : Dart G) : Prop :=
+  d.snd = d'.fst
+
+end HasAdj

--- a/Mathlib/Combinatorics/HasAdj/Walk.lean
+++ b/Mathlib/Combinatorics/HasAdj/Walk.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 Iván Renison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison
+-/
+module
+
+public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Data.List.Chain
+
+/-!
+
+-/
+
+@[expose] public section
+
+
+namespace HasAdj
+
+variable {α : Type*} {Gr : Type*} [HasAdj α Gr]
+
+structure Walk (G : Gr) where
+  support : List α
+  support_verts (u : α) (hu : u ∈ support) : u ∈ verts G := by aesop
+  non_empty_support : support ≠ [] := by aesop
+  chainAdj : support.IsChain (Adj G) := by aesop
+
+namespace Walk
+
+variable {G : Gr}
+
+lemma ext_iff {p q : Walk G} : p = q ↔ p.support = q.support := by
+  cases p
+  cases q
+  simp
+
+lemma length_support_pos (p : Walk G) : 0 < p.support.length := by
+  rw [← List.ne_nil_iff_length_pos]
+  exact p.non_empty_support
+
+/-- The head of a walk is the first vertex in its support. -/
+def head (p : Walk G) : α := p.support.head p.non_empty_support
+
+lemma head_mem_verts (p : Walk G) : p.head ∈ verts G := by
+  simp [head, p.support_verts]
+
+lemma head_mem_support (p : Walk G) : p.head ∈ p.support :=
+  List.head_mem p.non_empty_support
+
+lemma support_nonempty (p : Walk G) : { u | u ∈ p.support }.Nonempty :=
+  ⟨p.head, p.head_mem_support⟩
+
+/-- The last vertex of a walk is the last vertex in its support. -/
+def last (p : Walk G) : α := p.support.getLast p.non_empty_support
+
+lemma last_mem_verts (p : Walk G) : p.last ∈ verts G := by
+  simp [last, p.support_verts]
+
+lemma last_mem_support (p : Walk G) : p.last ∈ p.support :=
+  List.getLast_mem p.non_empty_support
+
+/-- The empty walk consisting of a single vertex. -/
+def nil {u : α} (hu : u ∈ verts G) : Walk G where
+  support := [u]
+
+lemma head_nil {u : α} (hu : u ∈ verts G) : (nil hu).head = u := by simp [nil, head]
+
+lemma last_nil {u : α} (hu : u ∈ verts G) : (nil hu).last = u := by simp [nil, last]
+
+lemma support_nil {u : α} (hu : u ∈ verts G) : (nil hu).support = [u] := rfl
+
+lemma mem_support_nil_iff {u : α} (hu : u ∈ verts G) (v : α) : v ∈ (nil hu).support ↔ v = u := by
+  simp [support_nil]
+
+/- Wether a walk is a "nil" walk, i.e. consists of a single vertex. -/
+def IsNil (p : Walk G) : Prop := p.support = [p.head]
+
+lemma isNil_nil {u : α} (hu : u ∈ verts G) : IsNil (nil hu) := by
+  simp [IsNil, head_nil, support_nil]
+
+lemma IsNil.exist_nil {p : Walk G} (hp : IsNil p) : ∃ (u : α) (hu : u ∈ verts G), p = nil hu := by
+  use p.head, p.head_mem_verts
+  rw [ext_iff, hp, support_nil]
+
+lemma IsNil.head_eq_last {p : Walk G} (hp : IsNil p) : p.head = p.last := by
+  unfold IsNil at hp
+  unfold head last
+  simp [hp]
+
+lemma IsNil.support_eq_head {p : Walk G} (hp : IsNil p) : p.support = [p.head] := hp
+
+lemma IsNil.support_eq_last {p : Walk G} (hp : IsNil p) : p.support = [p.last] :=
+  hp.head_eq_last ▸ hp.support_eq_head
+
+lemma IsNil.mem_support_iff_eq_head {p : Walk G} (hp : IsNil p) (u : α) :
+    u ∈ p.support ↔ u = p.head := by
+  simp [hp.support_eq_head]
+
+lemma IsNil.mem_support_iff_eq_last {p : Walk G} (hp : IsNil p) (u : α) :
+    u ∈ p.support ↔ u = p.last := by
+  simp [hp.support_eq_last]
+
+/-- Prepend a vertex to a walk, given an adjacency relation between the new vertex and the head of
+  the walk. -/
+def cons {u : α} {p : Walk G} (h : Adj G u p.head) : Walk G where
+  support := u :: p.support
+  support_verts x hx := by
+    rcases List.mem_cons.mp hx with rfl | hx
+    · exact h.left_mem_verts
+    · exact p.support_verts x hx
+  chainAdj := by
+    rw [List.isChain_cons]
+    refine ⟨?_, p.chainAdj⟩
+    intro x hx
+    rw [List.head?_eq_some_head p.non_empty_support, Option.mem_def, Option.some.injEq,
+      ← head] at hx
+    exact hx ▸ h
+
+lemma head_cons {u : α} {p : Walk G} (h : Adj G u p.head) : (p.cons h).head = u := by
+  simp [cons, head]
+
+lemma last_cons {u : α} {p : Walk G} (h : Adj G u p.head) : (p.cons h).last = p.last := by
+  simp [cons, last, List.getLast_cons p.non_empty_support]
+
+lemma support_cons {u : α} {p : Walk G} (h : Adj G u p.head) :
+    (p.cons h).support = u :: p.support := rfl
+
+lemma support_subset_support_cons {u : α} {p : Walk G} (h : Adj G u p.head) :
+    p.support ⊆ (p.cons h).support := by
+  rw [support_cons]
+  exact p.support.subset_cons_self u
+
+/-- Induction principle for walks.
+
+To prove a property holds for all walks, it suffices to prove:
+- It holds for the empty walk `nil hu` for any vertex `u`
+- If it holds for a walk `p`, it also holds for `cons h` where `h : Adj G u p.head`
+-/
+@[elab_as_elim, induction_eliminator]
+theorem ind {motive : Walk G → Prop}
+    (nil : ∀ (u : α) (hu : u ∈ verts G), motive (nil hu))
+    (cons : ∀ (u : α) (p : Walk G) (h : Adj G u p.head), motive p → motive (p.cons h))
+    (p : Walk G) : motive p := by
+  -- Proof using induction in the support
+  have : ∀ (l : List α) (hnonempty : l ≠ []) (hverts : ∀ u ∈ l, u ∈ verts G)
+    (hchain : l.IsChain (Adj G)), motive ⟨l, hverts, hnonempty, hchain⟩ := by
+    intro l
+    induction l with
+    | nil =>
+      intro h
+      exact (h rfl).elim
+    | cons u l ihl =>
+      intro _ hverts hchain
+      by_cases h : l = []
+      · subst h
+        have hu : u ∈ verts G := hverts u (List.mem_singleton_self u)
+        have : (⟨[u], hverts, List.cons_ne_nil u _, hchain⟩ : Walk G) = Walk.nil hu := by
+          rw [ext_iff]
+          rfl
+        rw [this]
+        exact nil u hu
+      · have hverts' :  ∀ (u : α), u ∈ l → u ∈ verts G :=
+          fun x hx ↦ hverts x (List.mem_cons_of_mem u hx)
+        have hchain' : l.IsChain (Adj G) := (List.isChain_cons.mp hchain).right
+        let p' : Walk G := ⟨l, hverts', h, hchain'⟩
+        have hadj : Adj G u p'.head :=
+          (List.isChain_cons.mp hchain).left (l.head h) (List.head_mem_head? h)
+        have : (⟨u :: l, hverts, by simp, hchain⟩ : Walk G) = Walk.cons hadj := by
+          rw [ext_iff]
+          rfl
+        rw [this]
+        apply cons _ p' _ (ihl h hverts' hchain')
+  exact this p.support p.non_empty_support p.support_verts p.chainAdj
+
+theorem exists_eq_cons_of_not_nil {p : Walk G} (hp : ¬p.IsNil) :
+    ∃ (u : α) (p' : Walk G) (h : Adj G u p'.head), p = cons h := by
+  obtain ⟨u, l, hul⟩ := List.ne_nil_iff_exists_cons.mp p.non_empty_support
+  let p' : Walk G := {
+    support := l
+    support_verts x hx := (hul ▸ p.support_verts x) (List.mem_cons_of_mem u hx)
+    non_empty_support := by
+      simp only [IsNil, head, hul, List.head_cons, List.cons.injEq, true_and] at hp
+      exact hp
+    chainAdj := (hul ▸ p.chainAdj).of_cons
+  }
+  have hadj : Adj G u p'.head := by
+    simp only [head, p']
+    exact (List.isChain_cons.mp (hul ▸ p.chainAdj)).left (l.head p'.non_empty_support)
+      (List.head_mem_head? p'.non_empty_support)
+  use u, p', hadj
+  rw [ext_iff, hul, support_cons]
+
+/-- The one-edge walk associated to a pair of adjacent vertices. -/
+@[match_pattern, reducible]
+def _root_.HasAdj.Adj.toWalk {G : Gr} {u v : α} (h : Adj G u v) : Walk G :=
+  (nil h.right_mem_verts).cons h
+
+lemma _root_.HasAdj.Adj.head_toWalk {G : Gr} {u v : α} (h : Adj G u v) : (h.toWalk).head = u := by
+  simp [Adj.toWalk, head_cons]
+
+lemma _root_.HasAdj.Adj.last_toWalk {G : Gr} {u v : α} (h : Adj G u v) : (h.toWalk).last = v := by
+  simp [Adj.toWalk, last_cons, last_nil]
+
+lemma _root_.HasAdj.Adj.support_toWalk {G : Gr} {u v : α} (h : Adj G u v) :
+    (h.toWalk).support = [u, v] := by
+  simp [Adj.toWalk, support_cons, support_nil]
+
+lemma _root_.HasAdj.Adj.adj_toWalk_head_last {G : Gr} {u v : α} (h : Adj G u v) :
+    Adj G (h.toWalk).head (h.toWalk).last := h
+
+/-- The length of a walk is the number of edges/darts along it. -/
+def length (p : Walk G) : ℕ := p.support.length - 1
+
+lemma length_nil {u : α} (hu : u ∈ verts G) : (nil hu).length = 0 := by
+  simp [nil, length]
+
+lemma length_cons {u : α} {p : Walk G} (h : Adj G u p.head) : (p.cons h).length = p.length + 1 := by
+  simp only [length, cons, List.length_cons, Nat.add_one_sub_one]
+  exact (Nat.sub_add_cancel (Nat.one_le_of_lt p.length_support_pos)).symm
+
+lemma _root_.HasAdj.Adj.length_toWalk {G : Gr} {u v : α} (h : Adj G u v) : h.toWalk.length = 1 := by
+  simp [Adj.toWalk, length_cons, length_nil]
+
+example (l : List α) (h : l ≠ []) (h' : l.length = 1) : l = [l.head h] := by
+  rw [List.head_eq_getElem_zero]
+  exact List.eq_getElem_of_length_eq_one l h'
+
+lemma length_eq_zero_iff_isNil {p : Walk G} : p.length = 0 ↔ IsNil p := by
+  rw [IsNil, length]
+  constructor
+  · intro h
+    rw [head, List.head_eq_getElem_zero]
+    rw [Nat.sub_eq_iff_eq_add' p.length_support_pos] at h
+    exact p.support.eq_getElem_of_length_eq_one h
+  · intro h
+    simp [h]
+
+lemma length_eq_zero_iff_support_eq_singleton {p : Walk G} :
+    p.length = 0 ↔ p.support = [p.head] := by
+  rw [length_eq_zero_iff_isNil, IsNil]
+
+lemma head_eq_last_of_length_eq_zero {p : Walk G} (hp : p.length = 0) : p.head = p.last :=
+  (length_eq_zero_iff_isNil.mp hp).head_eq_last
+
+lemma length_pos_ifff_not_nil {p : Walk G} : 0 < p.length ↔ ¬p.IsNil := by
+  grind [length_eq_zero_iff_isNil]
+
+lemma length_eq_one_iff_support_eq_head_last {p : Walk G} :
+    p.length = 1 ↔ p.support = [p.head, p.last] := by
+  unfold length head last
+  simp only [Nat.pred_eq_succ_iff, Nat.zero_add]
+  rw [List.length_eq_two']
+
+lemma adj_head_last_of_length_eq_one {p : Walk G} (h : p.length = 1) : Adj G p.head p.last := by
+  have := length_eq_one_iff_support_eq_head_last.mp h ▸ p.chainAdj
+  simp only [List.isChain_cons_cons, List.IsChain.singleton, and_true] at this
+  exact this
+
+end Walk
+
+end HasAdj

--- a/Mathlib/Combinatorics/HasAdj/Walk.lean
+++ b/Mathlib/Combinatorics/HasAdj/Walk.lean
@@ -13,6 +13,9 @@ public import Mathlib.Data.List.Chain
 
 This file defines walks for a general `HasAdj` structure.
 
+We say that a walk *visits* the vertices it contains.  The set of vertices a
+walk visits is `HasAdj.Walk.support`.
+
 -/
 
 @[expose] public section
@@ -24,6 +27,7 @@ variable {α : Type*} {Gr : Type*} [HasAdj α Gr]
 
 /-- A walk is a sequence of adjacent vertices. -/
 structure Walk (G : Gr) where
+  /-- The `support` of a walk is the list of vertices it visits in order. -/
   support : List α
   support_verts (u : α) (hu : u ∈ support) : u ∈ verts G := by aesop
   non_empty_support : support ≠ [] := by aesop
@@ -76,7 +80,7 @@ lemma support_nil {u : α} (hu : u ∈ verts G) : (nil hu).support = [u] := rfl
 lemma mem_support_nil_iff {u : α} (hu : u ∈ verts G) (v : α) : v ∈ (nil hu).support ↔ v = u := by
   simp [support_nil]
 
-/- Wether a walk is a "nil" walk, i.e. consists of a single vertex. -/
+/-- Wether a walk is a "nil" walk, i.e. consists of a single vertex. -/
 def IsNil (p : Walk G) : Prop := p.support = [p.head]
 
 lemma isNil_nil {u : α} (hu : u ∈ verts G) : IsNil (nil hu) := by
@@ -259,6 +263,10 @@ lemma adj_head_last_of_length_eq_one {p : Walk G} (h : p.length = 1) : Adj G p.h
   have := length_eq_one_iff_support_eq_head_last.mp h ▸ p.chainAdj
   simp only [List.isChain_cons_cons, List.IsChain.singleton, and_true] at this
   exact this
+
+theorem isChain_adj_cons_support {u : α} {p : Walk G} (h : Adj G u p.head) :
+    (u :: p.support).IsChain (Adj G) :=
+  p.chainAdj.cons_of_ne_nil p.non_empty_support h
 
 end Walk
 

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -47,6 +47,7 @@ acyclic graphs, trees
 namespace SimpleGraph
 
 open Walk
+open HasAdj
 
 variable {V V' : Type*} (G : SimpleGraph V) (G' : SimpleGraph V')
 

--- a/Mathlib/Combinatorics/SimpleGraph/Dart.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Dart.lean
@@ -5,72 +5,35 @@ Authors: Kyle Miller
 -/
 module
 
-public import Mathlib.Combinatorics.SimpleGraph.Basic
-public import Mathlib.Data.Fintype.Sigma
+public import Mathlib.Combinatorics.HasAdj.Dart
+public import Mathlib.Combinatorics.SimpleGraph.HasAdj
 
 /-!
-# Darts in graphs
+# Darts in simple graphs
 
-A `Dart` or half-edge or bond in a graph is an ordered pair of adjacent vertices, regarded as an
-oriented edge. This file defines darts and proves some of their basic properties.
+This files gives simple-graph-specific properties of darts.
 -/
 
 @[expose] public section
 
-namespace SimpleGraph
+namespace HasAdj
 
-variable {V : Type*} (G : SimpleGraph V)
-
-/-- A `Dart` is an oriented edge, implemented as an ordered pair of adjacent vertices.
-This terminology comes from combinatorial maps, and they are also known as "half-edges"
-or "bonds." -/
-structure Dart extends V × V where
-  adj : G.Adj fst snd
-  deriving DecidableEq
-
-initialize_simps_projections Dart (+toProd, -fst, -snd)
-
-attribute [simp] Dart.adj
-
-variable {G}
-
-theorem Dart.ext_iff (d₁ d₂ : G.Dart) : d₁ = d₂ ↔ d₁.toProd = d₂.toProd := by
-  cases d₁; cases d₂; simp
-
-@[ext]
-theorem Dart.ext (d₁ d₂ : G.Dart) (h : d₁.toProd = d₂.toProd) : d₁ = d₂ :=
-  (Dart.ext_iff d₁ d₂).mpr h
-
-@[simp]
-theorem Dart.fst_ne_snd (d : G.Dart) : d.fst ≠ d.snd :=
-  fun h ↦ G.irrefl (h ▸ d.adj)
-
-@[simp]
-theorem Dart.snd_ne_fst (d : G.Dart) : d.snd ≠ d.fst :=
-  fun h ↦ G.irrefl (h ▸ d.adj)
-
-theorem Dart.toProd_injective : Function.Injective (Dart.toProd : G.Dart → V × V) :=
-  Dart.ext
-
-instance Dart.fintype [Fintype V] [DecidableRel G.Adj] : Fintype G.Dart :=
-  Fintype.ofEquiv (Σ v, G.neighborSet v)
-    { toFun := fun s => ⟨(s.fst, s.snd), s.snd.property⟩
-      invFun := fun d => ⟨d.fst, d.snd, d.adj⟩ }
+variable {V : Type*} {G : SimpleGraph V}
 
 /-- The edge associated to the dart. -/
-def Dart.edge (d : G.Dart) : Sym2 V := s(d.fst, d.snd)
+def Dart.edge (d : Dart G) : Sym2 V := s(d.fst, d.snd)
 
 @[simp]
 theorem Dart.edge_mk {p : V × V} (h : G.Adj p.1 p.2) : (Dart.mk p h).edge = s(p.1, p.2) :=
   rfl
 
 @[simp]
-theorem Dart.edge_mem (d : G.Dart) : d.edge ∈ G.edgeSet :=
+theorem Dart.edge_mem (d : Dart G) : d.edge ∈ G.edgeSet :=
   d.adj
 
 /-- The dart with reversed orientation from a given dart. -/
 @[simps]
-def Dart.symm (d : G.Dart) : G.Dart :=
+def Dart.symm (d : Dart G) : Dart G :=
   ⟨d.toProd.swap, G.symm d.adj⟩
 
 @[simp]
@@ -78,35 +41,35 @@ theorem Dart.symm_mk {p : V × V} (h : G.Adj p.1 p.2) : (Dart.mk p h).symm = Dar
   rfl
 
 @[simp]
-theorem Dart.edge_symm (d : G.Dart) : d.symm.edge = d.edge :=
+theorem Dart.edge_symm (d : Dart G) : d.symm.edge = d.edge :=
   Sym2.eq_swap
 
 @[simp]
-theorem Dart.edge_comp_symm : Dart.edge ∘ Dart.symm = (Dart.edge : G.Dart → Sym2 V) :=
+theorem Dart.edge_comp_symm : Dart.edge ∘ Dart.symm = (Dart.edge : Dart G → Sym2 V) :=
   funext Dart.edge_symm
 
 @[simp]
-theorem Dart.symm_symm (d : G.Dart) : d.symm.symm = d :=
+theorem Dart.symm_symm (d : Dart G) : d.symm.symm = d :=
   Dart.ext _ _ <| Prod.swap_swap _
 
 @[simp]
-theorem Dart.symm_involutive : Function.Involutive (Dart.symm : G.Dart → G.Dart) :=
+theorem Dart.symm_involutive : Function.Involutive (Dart.symm : Dart G → Dart G) :=
   Dart.symm_symm
 
-theorem Dart.symm_ne (d : G.Dart) : d.symm ≠ d :=
+theorem Dart.symm_ne (d : Dart G) : d.symm ≠ d :=
   ne_of_apply_ne (Prod.snd ∘ Dart.toProd) d.adj.ne
 
-theorem dart_edge_eq_iff : ∀ d₁ d₂ : G.Dart, d₁.edge = d₂.edge ↔ d₁ = d₂ ∨ d₁ = d₂.symm := by
+theorem dart_edge_eq_iff : ∀ d₁ d₂ : Dart G, d₁.edge = d₂.edge ↔ d₁ = d₂ ∨ d₁ = d₂.symm := by
   rintro ⟨p, hp⟩ ⟨q, hq⟩
   simp
 
 theorem dart_edge_eq_mk'_iff :
-    ∀ {d : G.Dart} {u v : V}, d.edge = s(u, v) ↔ d.toProd = (u, v) ∨ d.toProd = (v, u) := by
+    ∀ {d : Dart G} {u v : V}, d.edge = s(u, v) ↔ d.toProd = (u, v) ∨ d.toProd = (v, u) := by
   rintro ⟨p, h⟩ _ _
   simp
 
 theorem dart_edge_eq_mk'_iff' :
-    ∀ {d : G.Dart} {u v : V},
+    ∀ {d : Dart G} {u v : V},
       d.edge = s(u, v) ↔ d.fst = u ∧ d.snd = v ∨ d.fst = v ∧ d.snd = u := by
   rintro ⟨⟨a, b⟩, h⟩ u v
   rw [dart_edge_eq_mk'_iff]
@@ -114,26 +77,20 @@ theorem dart_edge_eq_mk'_iff' :
 
 variable (G)
 
-/-- Two darts are said to be adjacent if they could be consecutive
-darts in a walk -- that is, the first dart's second vertex is equal to
-the second dart's first vertex. -/
-def DartAdj (d d' : G.Dart) : Prop :=
-  d.snd = d'.fst
-
 /-- For a given vertex `v`, this is the bijective map from the neighbor set at `v`
 to the darts `d` with `d.fst = v`. -/
 @[simps]
-def dartOfNeighborSet (v : V) (w : G.neighborSet v) : G.Dart :=
+def dartOfNeighborSet (v : V) (w : G.neighborSet v) : Dart G :=
   ⟨(v, w), w.property⟩
 
-theorem dartOfNeighborSet_injective (v : V) : Function.Injective (G.dartOfNeighborSet v) :=
+theorem dartOfNeighborSet_injective (v : V) : Function.Injective (dartOfNeighborSet G v) :=
   fun e₁ e₂ h =>
   Subtype.ext <| by
     injection h with h'
     convert congr_arg Prod.snd h'
 
-instance nonempty_dart_top [Nontrivial V] : Nonempty (⊤ : SimpleGraph V).Dart := by
+instance nonempty_dart_top [Nontrivial V] : Nonempty (Dart (⊤ : SimpleGraph V)) := by
   obtain ⟨v, w, h⟩ := exists_pair_ne V
   exact ⟨⟨(v, w), h⟩⟩
 
-end SimpleGraph
+end HasAdj

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -42,6 +42,7 @@ public section
 assert_not_exists Field TwoSidedIdeal
 
 open Finset
+open HasAdj
 
 namespace SimpleGraph
 
@@ -53,8 +54,8 @@ section DegreeSum
 
 variable [Fintype V] [DecidableRel G.Adj]
 
-theorem dart_fst_fiber [DecidableEq V] (v : V) :
-    ({d : G.Dart | d.fst = v} : Finset _) = univ.image (G.dartOfNeighborSet v) := by
+theorem dart_fst_fiber [DecidableEq V] [DecidableEq (Dart G)] (v : V) :
+    ({d : Dart G | d.fst = v} : Finset _) = univ.image (dartOfNeighborSet G v) := by
   ext d
   simp only [mem_image, true_and, mem_filter, SetCoe.exists, mem_univ]
   constructor
@@ -64,30 +65,30 @@ theorem dart_fst_fiber [DecidableEq V] (v : V) :
     rfl
 
 theorem dart_fst_fiber_card_eq_degree [DecidableEq V] (v : V) :
-    #{d : G.Dart | d.fst = v} = G.degree v := by
+    #{d : Dart G | d.fst = v} = G.degree v := by
   simpa only [dart_fst_fiber, Finset.card_univ, card_neighborSet_eq_degree] using
-    card_image_of_injective univ (G.dartOfNeighborSet_injective v)
+    card_image_of_injective univ (dartOfNeighborSet_injective G v)
 
-theorem dart_card_eq_sum_degrees : Fintype.card G.Dart = ∑ v, G.degree v := by
+theorem dart_card_eq_sum_degrees : Fintype.card (Dart G) = ∑ v, G.degree v := by
   haveI := Classical.decEq V
   simp only [← card_univ, ← dart_fst_fiber_card_eq_degree]
   exact card_eq_sum_card_fiberwise (by simp)
 
 variable {G} in
-theorem Dart.edge_fiber [DecidableEq V] (d : G.Dart) :
-    ({d' : G.Dart | d'.edge = d.edge} : Finset _) = {d, d.symm} :=
+theorem _root_.HasAdj.Dart.edge_fiber [DecidableEq V] (d : Dart G) :
+    ({d' : Dart G | d'.edge = d.edge} : Finset _) = {d, d.symm} :=
   Finset.ext fun d' => by simpa using dart_edge_eq_iff d' d
 
 theorem dart_edge_fiber_card [DecidableEq V] (e : Sym2 V) (h : e ∈ G.edgeSet) :
-    #{d : G.Dart | d.edge = e} = 2 := by
+    #{d : Dart G | d.edge = e} = 2 := by
   obtain ⟨v, w⟩ := e
-  let d : G.Dart := ⟨(v, w), h⟩
+  let d : Dart G := ⟨(v, w), h⟩
   convert congr_arg card d.edge_fiber
   rw [card_insert_of_notMem, card_singleton]
   rw [mem_singleton]
   exact d.symm_ne.symm
 
-theorem dart_card_eq_twice_card_edges : Fintype.card G.Dart = 2 * #G.edgeFinset := by
+theorem dart_card_eq_twice_card_edges : Fintype.card (Dart G) = 2 * #G.edgeFinset := by
   classical
   rw [← card_univ]
   rw [@card_eq_sum_card_fiberwise _ _ _ Dart.edge _ G.edgeFinset fun d _h =>
@@ -104,8 +105,10 @@ theorem sum_degrees_eq_twice_card_edges : ∑ v, G.degree v = 2 * #G.edgeFinset 
 
 lemma two_mul_card_edgeFinset : 2 * #G.edgeFinset = #(univ.filter fun (x, y) ↦ G.Adj x y) := by
   rw [← dart_card_eq_twice_card_edges, ← card_univ]
-  refine card_bij' (fun d _ ↦ (d.fst, d.snd)) (fun xy h ↦ ⟨xy, (mem_filter.1 h).2⟩) ?_ ?_ ?_ ?_
-    <;> simp
+  refine card_bij' (fun d _ ↦ (d.fst, d.snd)) (fun xy h ↦ ⟨xy, (mem_filter.1 h).2⟩) ?_
+      ?_ ?_ ?_
+    <;> simp only [mem_univ, Prod.mk.eta, mem_filter, true_and, forall_const, implies_true]
+  exact Dart.adj
 
 /-- The degree-sum formula only counting over the vertices that form edges.
 

--- a/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 Iván Renison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison
+-/
+module
+
+public import Mathlib.Combinatorics.HasAdj.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Basic
+
+/-!
+In this file we make `SimpleGraph` an instance of `HasAdj`.
+-/
+
+@[expose] public section
+
+variable {α : Type*}
+
+instance : HasAdj α (SimpleGraph α) where
+  vertexSet _ := Set.univ
+  Adj G := G.Adj

--- a/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
@@ -19,3 +19,5 @@ variable {α : Type*}
 instance : HasAdj α (SimpleGraph α) where
   vertexSet _ := Set.univ
   Adj G := G.Adj
+  left_mem_vertexSet_of_adj _ := Set.mem_univ _
+  right_mem_vertexSet_of_adj _ := Set.mem_univ _

--- a/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/HasAdj.lean
@@ -17,7 +17,7 @@ In this file we make `SimpleGraph` an instance of `HasAdj`.
 variable {α : Type*}
 
 instance : HasAdj α (SimpleGraph α) where
-  vertexSet _ := Set.univ
+  verts _ := Set.univ
   Adj G := G.Adj
-  left_mem_vertexSet_of_adj _ := Set.mem_univ _
-  right_mem_vertexSet_of_adj _ := Set.mem_univ _
+  left_mem_verts_of_adj _ := Set.mem_univ _
+  right_mem_verts_of_adj _ := Set.mem_univ _

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -42,6 +42,7 @@ abbreviations as well.
 
 
 open Function
+open HasAdj
 
 namespace SimpleGraph
 
@@ -304,11 +305,11 @@ def mapNeighborSet (v : V) (w : G.neighborSet v) : G'.neighborSet (f v) :=
   ⟨f w, f.apply_mem_neighborSet w.property⟩
 
 /-- The map between darts induced by a homomorphism. -/
-def mapDart (d : G.Dart) : G'.Dart :=
+def mapDart (d : Dart G) : Dart G' :=
   ⟨d.1.map f f, f.map_adj d.2⟩
 
 @[simp]
-theorem mapDart_apply (d : G.Dart) : f.mapDart d = ⟨d.1.map f f, f.map_adj d.2⟩ :=
+theorem mapDart_apply (d : Dart G) : f.mapDart d = ⟨d.1.map f f, f.map_adj d.2⟩ :=
   rfl
 
 /-- The graph homomorphism from a smaller graph to a bigger one. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
@@ -39,6 +39,7 @@ walks
 @[expose] public section
 
 namespace SimpleGraph
+open HasAdj
 
 universe u
 variable {V : Type u} (G : SimpleGraph V) {u v w : V}
@@ -123,7 +124,7 @@ def support {u v : V} : G.Walk u v → List V
   | cons _ p => u :: p.support
 
 /-- The `darts` of a walk is the list of darts it visits in order. -/
-def darts {u v : V} : G.Walk u v → List G.Dart
+def darts {u v : V} : G.Walk u v → List (Dart G)
   | nil => []
   | cons h p => ⟨(u, _), h⟩ :: p.darts
 
@@ -193,13 +194,13 @@ theorem isChain_adj_support {u v : V} : ∀ (p : G.Walk u v), List.IsChain G.Adj
 
 @[deprecated (since := "2025-09-24")] alias chain'_adj_support := isChain_adj_support
 
-theorem isChain_dartAdj_cons_darts {d : G.Dart} {v w : V} (h : d.snd = v) (p : G.Walk v w) :
-    List.IsChain G.DartAdj (d :: p.darts) := by
+theorem isChain_dartAdj_cons_darts {d : Dart G} {v w : V} (h : d.snd = v) (p : G.Walk v w) :
+    List.IsChain (DartAdj G) (d :: p.darts) := by
   induction p generalizing d with
   | nil => exact .singleton _
   | cons h' p ih => exact .cons_cons h (ih rfl)
 
-theorem isChain_dartAdj_darts {u v : V} : ∀ (p : G.Walk u v), List.IsChain G.DartAdj p.darts
+theorem isChain_dartAdj_darts {u v : V} : ∀ (p : G.Walk u v), List.IsChain (DartAdj G) p.darts
   | nil => .nil
   -- Porting note: needed to defer `rfl` to help elaboration
   | cons h p => isChain_dartAdj_cons_darts (by rfl) p
@@ -284,12 +285,12 @@ theorem mem_darts_iff_infix_support {u' v'} {p : G.Walk u v} (h : G.Adj u' v') :
     convert p.darts.getElem_mem (n := i) (by grind)
       <;> grind [fst_darts_getElem, snd_darts_getElem]
 
-theorem mem_darts_iff_fst_snd_infix_support {p : G.Walk u v} {d : G.Dart} :
+theorem mem_darts_iff_fst_snd_infix_support {p : G.Walk u v} {d : Dart G} :
     d ∈ p.darts ↔ [d.fst, d.snd] <:+: p.support :=
   mem_darts_iff_infix_support ..
 
 theorem dart_fst_mem_support_of_mem_darts {u v : V} :
-    ∀ (p : G.Walk u v) {d : G.Dart}, d ∈ p.darts → d.fst ∈ p.support
+    ∀ (p : G.Walk u v) {d : Dart G}, d ∈ p.darts → d.fst ∈ p.support
   | cons h p', d, hd => by
     simp only [support_cons, darts_cons, List.mem_cons] at hd ⊢
     rcases hd with rfl | hd
@@ -323,7 +324,7 @@ theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v 
     obtain ⟨rfl, h₃⟩ : v = v' ∧ w₁.edges = w₂.edges := by simpa [h₁, h₃] using h
     rw [edges_injective h₃]
 
-theorem darts_injective {u v : V} : Function.Injective (Walk.darts : G.Walk u v → List G.Dart) :=
+theorem darts_injective {u v : V} : Function.Injective (Walk.darts : G.Walk u v → List (Dart G)) :=
   edges_injective.of_comp
 
 /-- The `Set` of edges of a walk. -/
@@ -422,7 +423,7 @@ theorem mem_support_iff_exists_mem_edges_of_not_nil {u v w : V} {p : G.Walk u v}
 /-- Given a set `S` and a walk `w` from `u` to `v` such that `u ∈ S` but `v ∉ S`,
 there exists a dart in the walk whose start is in `S` but whose end is not. -/
 theorem exists_boundary_dart {u v : V} (p : G.Walk u v) (S : Set V) (uS : u ∈ S) (vS : v ∉ S) :
-    ∃ d : G.Dart, d ∈ p.darts ∧ d.fst ∈ S ∧ d.snd ∉ S := by
+    ∃ d : (Dart G), d ∈ p.darts ∧ d.fst ∈ S ∧ d.snd ∉ S := by
   induction p with
   | nil => cases vS uS
   | cons a p' ih =>

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
@@ -32,6 +32,7 @@ walks
 @[expose] public section
 
 namespace SimpleGraph
+open HasAdj
 
 namespace Walk
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -33,6 +33,7 @@ walks
 open Function
 
 namespace SimpleGraph
+open HasAdj
 
 namespace Walk
 
@@ -355,8 +356,8 @@ theorem support_eq_concat {u v : V} (p : G.Walk u v) : p.support = p.support.dro
 
 lemma ext_support {u v} {p q : G.Walk u v} (h : p.support = q.support) : p = q := by
   refine darts_injective (Dart.toProd_injective.list_map (List.rightInverse_unzip_zip.injective ?_))
-  have : Prod.fst ∘ Dart.toProd = fun d : G.Dart ↦ d.fst := rfl
-  have : Prod.snd ∘ Dart.toProd = fun d : G.Dart ↦ d.snd := rfl
+  have : Prod.fst ∘ Dart.toProd = fun d : Dart G ↦ d.fst := rfl
+  have : Prod.snd ∘ Dart.toProd = fun d : Dart G ↦ d.snd := rfl
   grind [map_fst_darts, map_snd_darts]
 
 @[simp]
@@ -417,7 +418,7 @@ theorem darts_reverse {u v : V} (p : G.Walk u v) :
     p.reverse.darts = (p.darts.map Dart.symm).reverse := by
   induction p <;> simp [*]
 
-theorem mem_darts_reverse {u v : V} {d : G.Dart} {p : G.Walk u v} :
+theorem mem_darts_reverse {u v : V} {d : Dart G} {p : G.Walk u v} :
     d ∈ p.reverse.darts ↔ d.symm ∈ p.darts := by simp
 
 @[simp]
@@ -438,7 +439,7 @@ theorem edges_append {u v w : V} (p : G.Walk u v) (p' : G.Walk v w) :
 theorem edges_reverse {u v : V} (p : G.Walk u v) : p.reverse.edges = p.edges.reverse := by
   simp [edges]
 
-theorem dart_snd_mem_support_of_mem_darts {u v : V} (p : G.Walk u v) {d : G.Dart}
+theorem dart_snd_mem_support_of_mem_darts {u v : V} (p : G.Walk u v) {d : Dart G}
     (h : d ∈ p.darts) : d.snd ∈ p.support := by
   simpa using p.reverse.dart_fst_mem_support_of_mem_darts (by simp [h] : d.symm ∈ p.reverse.darts)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Subwalks.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Subwalks.lean
@@ -25,6 +25,8 @@ walks, subwalks
 
 @[expose] public section
 
+open HasAdj
+
 namespace SimpleGraph
 
 namespace Walk
@@ -147,7 +149,7 @@ theorem isSubwalk_toWalk_iff_mem_darts (p : G.Walk u v) (h : G.Adj u' v') :
     h.toWalk.IsSubwalk p ↔ ⟨⟨u', v'⟩, h⟩ ∈ p.darts := by
   simp [isSubwalk_iff_darts_isInfix, List.singleton_infix_iff]
 
-theorem isSubwalk_toWalk_adj_iff_mem_darts {d : G.Dart} (p : G.Walk u v) :
+theorem isSubwalk_toWalk_adj_iff_mem_darts {d : Dart G} (p : G.Walk u v) :
     d.adj.toWalk.IsSubwalk p ↔ d ∈ p.darts :=
   isSubwalk_toWalk_iff_mem_darts ..
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
@@ -29,6 +29,7 @@ walks
 @[expose] public section
 
 namespace SimpleGraph
+open HasAdj
 
 namespace Walk
 
@@ -196,14 +197,14 @@ lemma support_getElem_length_sub_one_eq_penultimate {p : G.Walk u v} :
 
 /-- The first dart of a walk. -/
 @[simps]
-def firstDart (p : G.Walk v w) (hp : ¬ p.Nil) : G.Dart where
+def firstDart (p : G.Walk v w) (hp : ¬ p.Nil) : Dart G where
   fst := v
   snd := p.snd
   adj := p.adj_snd hp
 
 /-- The last dart of a walk. -/
 @[simps]
-def lastDart (p : G.Walk v w) (hp : ¬ p.Nil) : G.Dart where
+def lastDart (p : G.Walk v w) (hp : ¬ p.Nil) : Dart G where
   fst := p.penultimate
   snd := w
   adj := p.adj_penultimate hp

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -120,6 +120,15 @@ lemma length_injective [Subsingleton α] : Injective (length : List α → ℕ) 
 theorem length_eq_two {l : List α} : l.length = 2 ↔ ∃ a b, l = [a, b] :=
   ⟨fun _ => let [a, b] := l; ⟨a, b, rfl⟩, fun ⟨_, _, e⟩ => e ▸ rfl⟩
 
+theorem length_eq_two' {l : List α} (h : l ≠ []) : l.length = 2 ↔ l = [l.head h, l.getLast h] := by
+  constructor
+  · intro h
+    obtain ⟨a, b, rfl⟩ := List.length_eq_two.mp h
+    rfl
+  · intro h
+    rw [h]
+    rfl
+
 theorem length_eq_three {l : List α} : l.length = 3 ↔ ∃ a b c, l = [a, b, c] :=
   ⟨fun _ => let [a, b, c] := l; ⟨a, b, c, rfl⟩, fun ⟨_, _, _, e⟩ => e ▸ rfl⟩
 


### PR DESCRIPTION
The idea for the `Walk` structure comes from https://github.com/Shreyas4991/mathlib4/pull/1 as suggested in Zulip

---
Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/252551-graph-theory/topic/HasAdj/with/575843445

- [ ] depends on: #35775
- [ ] depends on: #35776
- [ ] depends on: #35783

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
