### PR TITLE
[Merged by Bors] - feat(Order): Add simp lemma for `IsRelUpperSet` and `IsRelLowerSet`

### DIFF
--- a/Mathlib/Order/UpperLower/Relative.lean
+++ b/Mathlib/Order/UpperLower/Relative.lean
@@ -28,11 +28,11 @@ variable [LE α]
 
 @[simp] lemma isRelUpperSet_true_iff_isUpperSet :
     IsRelUpperSet s (fun _ ↦ True) ↔ IsUpperSet s := by
-  simp [IsUpperSet, IsRelUpperSet]; grind
+  grind [IsUpperSet, IsRelUpperSet]
 
 @[simp] lemma isRelLowerSet_true_iff_isLowerSet :
     IsRelLowerSet s (fun _ ↦ True) ↔ IsLowerSet s := by
-  simp [IsLowerSet, IsRelLowerSet]; grind
+  grind [IsLowerSet, IsRelLowerSet]
 
 variable (P) in
 lemma IsUpperSet.isRelUpperSet_sep (hs : IsUpperSet s) : IsRelUpperSet {x ∈ s | P x} P :=

--- a/Mathlib/Order/UpperLower/Relative.lean
+++ b/Mathlib/Order/UpperLower/Relative.lean
@@ -26,6 +26,14 @@ section LE
 
 variable [LE α]
 
+@[simp] lemma isRelUpperSet_true_iff_isUpperSet :
+    IsRelUpperSet s (fun _ ↦ True) ↔ IsUpperSet s := by
+  simp [IsUpperSet, IsRelUpperSet]; grind
+
+@[simp] lemma isRelLowerSet_true_iff_isLowerSet :
+    IsRelLowerSet s (fun _ ↦ True) ↔ IsLowerSet s := by
+  simp [IsLowerSet, IsRelLowerSet]; grind
+
 variable (P) in
 lemma IsUpperSet.isRelUpperSet_sep (hs : IsUpperSet s) : IsRelUpperSet {x ∈ s | P x} P :=
   fun _ h => ⟨h.2, fun _ ht hp => ⟨hs ht h.1, hp⟩⟩


### PR DESCRIPTION
This is useful in scenarios when `simp` can simplify the relation to true. 