### PR TITLE
[Merged by Bors] - chore: remove 21 redundant set_option backward.whnf.reducibleClassField false

### DIFF
--- a/Mathlib/Algebra/Field/Equiv.lean
+++ b/Mathlib/Algebra/Field/Equiv.lean
@@ -19,6 +19,7 @@ public section
 
 variable {A B F : Type*} [Semiring A] [Semiring B]
 
+set_option backward.isDefEq.respectTransparency false in
 protected theorem IsLocalHom.isField [FunLike F A B] [MonoidWithZeroHomClass F A B] {f : F}
     [IsLocalHom f] (inj : Function.Injective f) (hB : IsField B) : IsField A where
   exists_pair_ne := have : Nontrivial B := ⟨hB.1⟩; (domain_nontrivial f (map_zero f) (map_one f)).1

--- a/Mathlib/Algebra/Field/Equiv.lean
+++ b/Mathlib/Algebra/Field/Equiv.lean
@@ -19,7 +19,6 @@ public section
 
 variable {A B F : Type*} [Semiring A] [Semiring B]
 
-set_option backward.isDefEq.respectTransparency false in
 protected theorem IsLocalHom.isField [FunLike F A B] [MonoidWithZeroHomClass F A B] {f : F}
     [IsLocalHom f] (inj : Function.Injective f) (hB : IsField B) : IsField A where
   exists_pair_ne := have : Nontrivial B := ⟨hB.1⟩; (domain_nontrivial f (map_zero f) (map_one f)).1

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -884,7 +884,6 @@ instance uniqueNormalizationMonoidOfUniqueUnits : Unique (NormalizationMonoid α
   default := .ofUniqueUnits
   uniq := fun ⟨u, _, _, _⟩ => by congr; simp [eq_iff_true_of_subsingleton]
 
-set_option backward.whnf.reducibleClassField false in
 instance subsingleton_gcdMonoid_of_unique_units : Subsingleton (GCDMonoid α) :=
   ⟨fun g₁ g₂ => by
     have hgcd : g₁.gcd = g₂.gcd := by

--- a/Mathlib/Algebra/Order/Nonneg/Lattice.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Lattice.lean
@@ -53,7 +53,6 @@ protected noncomputable abbrev conditionallyCompleteLinearOrder [ConditionallyCo
     {a : α} : ConditionallyCompleteLinearOrder { x : α // a ≤ x } :=
   { @ordConnectedSubsetConditionallyCompleteLinearOrder α (Set.Ici a) _ ⟨⟨a, le_rfl⟩⟩ _ with }
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If `sSup ∅ ≤ a` then `{x : α // a ≤ x}` is a `ConditionallyCompleteLinearOrderBot`.
 

--- a/Mathlib/Algebra/Order/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Order/Ring/Idempotent.lean
@@ -67,7 +67,6 @@ instance : SemilatticeSup {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
       (IsIdempotentElem.of_mul_add b.2.1 b.2.2).1.eq, ← mul_add, a.2.2, mul_one]
   sup_le a b c hac hbc := by simp_rw [(· ≤ ·), add_mul, mul_assoc]; rw [hac, hbc]
 
-set_option backward.whnf.reducibleClassField false in
 instance : BooleanAlgebra {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
   inf a b := (aᶜ ⊔ bᶜ)ᶜ
   inf_le_left a b := by simp_rw [(· ≤ ·), (· ⊔ ·), (·ᶜ), SemilatticeSup.sup,

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -616,7 +616,6 @@ variable
     {F₀ : C ⥤ H} {F₁ : D ⥤ H} {F₂ : D' ⥤ H}
     (α : F₀ ⟶ L ⋙ F₁)
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 /-- If the right extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
 then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
@@ -661,7 +660,6 @@ def LeftExtension.isUniversalPrecomp₂
     simp [← a_w_t, hb_fac_app, u, hα_fac_app]
   apply IsInitial.ofUnique
 
-set_option backward.whnf.reducibleClassField false in
 /-- If the left extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
 then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
 `b : L'.LeftExtension F₁` is such that the "pasted" extension

--- a/Mathlib/CategoryTheory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid.lean
@@ -80,7 +80,6 @@ theorem Groupoid.inv_eq_inv (f : X ⟶ Y) : Groupoid.inv f = CategoryTheory.inv 
 def Groupoid.invEquiv : (X ⟶ Y) ≃ (Y ⟶ X) :=
   ⟨Groupoid.inv, Groupoid.inv, fun f => by simp, fun f => by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 instance (priority := 100) groupoidHasInvolutiveReverse : Quiver.HasInvolutiveReverse C where
   reverse' f := Groupoid.inv f
   inv' f := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -165,7 +165,6 @@ theorem eq_zero_of_src {X Y : C} (o : IsZero X) (f : X ⟶ Y) : f = 0 :=
 theorem eq_zero_of_tgt {X Y : C} (o : IsZero Y) (f : X ⟶ Y) : f = 0 :=
   o.eq_of_tgt _ _
 
-set_option backward.whnf.reducibleClassField false in
 theorem iff_id_eq_zero (X : C) : IsZero X ↔ 𝟙 X = 0 :=
   ⟨fun h => h.eq_of_src _ _, fun h =>
     ⟨fun Y => ⟨⟨⟨0⟩, fun f => by

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -70,7 +70,6 @@ lemma homMap_comp (f : L₁.obj X ⟶ L₁.obj Y) (g : L₁.obj Y ⟶ L₁.obj Z
     Φ.homMap L₁ L₂ (f ≫ g) = Φ.homMap L₁ L₂ f ≫ Φ.homMap L₁ L₂ g := by
   simp [homMap]
 
-set_option backward.whnf.reducibleClassField false in
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma homMap_apply (G : D₁ ⥤ D₂) (e : Φ.functor ⋙ L₂ ≅ L₁ ⋙ G) (f : L₁.obj X ⟶ L₁.obj Y) :

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -220,7 +220,6 @@ instance [HasReverse V] : HasReverse (Quiver.Push σ) where
   reverse' := fun
               | PushQuiver.arrow f => PushQuiver.arrow (reverse f)
 
-set_option backward.whnf.reducibleClassField false in
 instance [h : HasInvolutiveReverse V] :
     HasInvolutiveReverse (Push σ) where
   reverse' := fun

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -329,7 +329,6 @@ theorem even_xor {m n : ℕ} : Even (m ^^^ n) ↔ (Even m ↔ Even n) := by
   simp only [even_iff, xor_mod_two_eq]
   lia
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem xor_one_of_even {n : ℕ} (h : Even n) : n ^^^ 1 = n + 1 := by
   cases n with
@@ -338,7 +337,6 @@ theorem xor_one_of_even {n : ℕ} (h : Even n) : n ^^^ 1 = n + 1 := by
     simp +instances [HXor.hXor, instXorOp, xor, bitwise, even_iff.mp h, ← mul_two,
       div_two_mul_two_of_even h]
 
-set_option backward.whnf.reducibleClassField false in
 @[simp]
 theorem xor_one_of_odd {n : ℕ} (h : Odd n) : n ^^^ 1 = n - 1 := by
   cases n with

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -196,11 +196,9 @@ theorem top_def : ⇑(⊤ : Setoid α) = ⊤ :=
 theorem bot_def : ⇑(⊥ : Setoid α) = (· = ·) :=
   rfl
 
-set_option backward.whnf.reducibleClassField false in
 @[simp] lemma mk_eq_top {r : α → α → Prop} (iseqv) : mk r iseqv = ⊤ ↔ r = ⊤ := by
   simp [eq_iff_rel_eq]
 
-set_option backward.whnf.reducibleClassField false in
 @[simp] lemma mk_eq_bot {r : α → α → Prop} (iseqv) : mk r iseqv = ⊥ ↔ r = (· = ·) := by
   simp [eq_iff_rel_eq]
 

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -48,7 +48,6 @@ def mkMulHom (c : Con M) : MulHom M c.Quotient where
   toFun := (↑)
   map_mul' _ _ := rfl
 
-set_option backward.whnf.reducibleClassField false in
 /-- The kernel of a multiplicative homomorphism as a congruence relation. -/
 @[to_additive /-- The kernel of an additive homomorphism as an additive congruence relation. -/]
 def ker (f : F) : Con M where

--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -24,7 +24,6 @@ universe u
 
 variable {α : Type u}
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a top order
 with possibly different definitional equalities. -/
 def OrderTop.copy {h : LE α} {h' : LE α} (c : @OrderTop α h')
@@ -32,7 +31,6 @@ def OrderTop.copy {h : LE α} {h' : LE α} (c : @OrderTop α h')
     (le_eq : ∀ x y : α, (@LE.le α h) x y ↔ x ≤ y) : @OrderTop α h :=
   @OrderTop.mk α h { top := top } fun _ ↦ by simp [eq_top, le_eq]
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a bottom order
 with possibly different definitional equalities. -/
 def OrderBot.copy {h : LE α} {h' : LE α} (c : @OrderBot α h')
@@ -40,7 +38,6 @@ def OrderBot.copy {h : LE α} {h' : LE α} (c : @OrderBot α h')
     (le_eq : ∀ x y : α, (@LE.le α h) x y ↔ x ≤ y) : @OrderBot α h :=
   @OrderBot.mk α h { bot := bot } fun _ ↦ by simp [eq_bot, le_eq]
 
-set_option backward.whnf.reducibleClassField false in
 /-- A function to create a provable equal copy of a bounded order
 with possibly different definitional equalities. -/
 def BoundedOrder.copy {h : LE α} {h' : LE α} (c : @BoundedOrder α h')

--- a/Mathlib/Order/Lattice/Congruence.lean
+++ b/Mathlib/Order/Lattice/Congruence.lean
@@ -114,7 +114,6 @@ variable [FunLike F α β]
 
 open Function
 
-set_option backward.whnf.reducibleClassField false in
 /-- The kernel of a lattice homomorphism as a lattice congruence. -/
 @[simps!]
 def ker [LatticeHomClass F α β] (f : F) : LatticeCon α where

--- a/Mathlib/Tactic/FieldSimp/Lemmas.lean
+++ b/Mathlib/Tactic/FieldSimp/Lemmas.lean
@@ -313,7 +313,6 @@ theorem cons_zero_eq_div_of_eq_div [CommGroupWithZero M] (e : M) {t t_n t_d : NF
 instance : Inv (NF M) where
   inv l := l.map fun (a, x) ↦ (-a, x)
 
-set_option backward.whnf.reducibleClassField false in
 theorem eval_inv [CommGroupWithZero M] (l : NF M) : (l⁻¹).eval = l.eval⁻¹ := by
   simp +instances only [NF.eval, List.map_map, NF.instInv, List.prod_inv]
   congr! 2

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -244,7 +244,6 @@ theorem IsNNRat.to_isNat {α} [Semiring α] : ∀ {a : α} {n}, IsNNRat a (n) (n
 theorem IsRat.to_isNNRat {α} [Ring α] : ∀ {a : α} {n d}, IsRat a (.ofNat n) (d) → IsNNRat a n d
   | _, _, _, ⟨inv, rfl⟩ => ⟨inv, by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem IsNat.to_isNNRat {α} [Semiring α] : ∀ {a : α} {n}, IsNat a n → IsNNRat a (n) (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 
@@ -254,7 +253,6 @@ theorem IsNNRat.to_isRat {α} [Ring α] : ∀ {a : α} {n d}, IsNNRat a n d → 
 theorem IsRat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsRat a n (nat_lit 1) → IsInt a n
   | _, _, ⟨inv, rfl⟩ => have := @invertibleOne α _; ⟨by simp⟩
 
-set_option backward.whnf.reducibleClassField false in
 theorem IsInt.to_isRat {α} [Ring α] : ∀ {a : α} {n}, IsInt a n → IsRat a n (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 


### PR DESCRIPTION
This PR removes 21 `set_option backward.whnf.reducibleClassField false` directives that are no longer needed.

🤖 Prepared with Claude Code