### PR TITLE
[Merged by Bors] - feat: restrict normal function to `Iio` intervals

### DIFF
--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -107,6 +107,12 @@ theorem comp (hg : IsNormal g) (hf : IsNormal f) : IsNormal (g ∘ f) := by
   simpa [hg.le_iff_forall_le (hf.map_isSuccLimit ha), hf.lt_iff_exists_lt ha] using
     fun c d hd hc ↦ (hg.strictMono hc).le.trans (hb hd)
 
+theorem to_Iio (hf : IsNormal f) (a : α) :
+    IsNormal (β := Iio (f a)) fun x : Iio a ↦ ⟨f x.1, hf.strictMono x.2⟩ := by
+  rw [isNormal_iff]
+  refine ⟨fun x y h ↦ hf.strictMono h, fun b hb c hc ↦ hf.2 (hb.subtype (isLowerSet_Iio _)) ?_⟩
+  simpa [upperBounds] using fun d hd ↦ hc ⟨d, hd.trans b.2⟩ hd
+
 section WellFoundedLT
 variable [WellFoundedLT α] [SuccOrder α]
 

--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -110,7 +110,7 @@ theorem comp (hg : IsNormal g) (hf : IsNormal f) : IsNormal (g ∘ f) := by
 theorem to_Iio (hf : IsNormal f) (a : α) :
     IsNormal (β := Iio (f a)) fun x : Iio a ↦ ⟨f x.1, hf.strictMono x.2⟩ := by
   rw [isNormal_iff]
-  refine ⟨fun x y h ↦ hf.strictMono h, fun b hb c hc ↦ hf.2 (hb.subtype (isLowerSet_Iio _)) ?_⟩
+  refine ⟨fun x y h ↦ hf.strictMono h, fun b hb c hc ↦ hf.2 (hb.subtypeVal (isLowerSet_Iio _)) ?_⟩
   simpa [upperBounds] using fun d hd ↦ hc ⟨d, hd.trans b.2⟩ hd
 
 section WellFoundedLT

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -141,7 +141,7 @@ theorem not_isSuccLimit_iff : ¬ IsSuccLimit a ↔ IsMin a ∨ ¬ IsSuccPrelimit
   rw [IsSuccLimit, not_and_or, not_not]
 
 @[to_dual]
-theorem IsSuccPrelimit.subtype {s : Set α} (hs : IsLowerSet s) {a : s}
+theorem IsSuccPrelimit.subtypeVal {s : Set α} (hs : IsLowerSet s) {a : s}
     (ha : IsSuccPrelimit a) : IsSuccPrelimit a.1 := by
   intro b hb
   have := ha ⟨b, hs hb.le a.2⟩
@@ -151,9 +151,9 @@ theorem IsSuccPrelimit.subtype {s : Set α} (hs : IsLowerSet s) {a : s}
   · exact hb.lt
 
 @[to_dual]
-theorem IsSuccLimit.subtype {s : Set α} (hs : IsLowerSet s) {a : s}
+theorem IsSuccLimit.subtypeVal {s : Set α} (hs : IsLowerSet s) {a : s}
     (ha : IsSuccLimit a) : IsSuccLimit a.1 := by
-  refine ⟨?_, ha.isSuccPrelimit.subtype hs⟩
+  refine ⟨?_, ha.isSuccPrelimit.subtypeVal hs⟩
   have := ha.1
   rw [not_isMin_iff] at ⊢ this
   obtain ⟨b, hb⟩ := this

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -140,6 +140,25 @@ theorem IsSuccLimit.ne_bot [OrderBot α] (h : IsSuccLimit a) : a ≠ ⊥ := by
 theorem not_isSuccLimit_iff : ¬ IsSuccLimit a ↔ IsMin a ∨ ¬ IsSuccPrelimit a := by
   rw [IsSuccLimit, not_and_or, not_not]
 
+@[to_dual]
+theorem IsSuccPrelimit.subtype {s : Set α} (hs : IsLowerSet s) {a : s}
+    (ha : IsSuccPrelimit a) : IsSuccPrelimit a.1 := by
+  intro b hb
+  have := ha ⟨b, hs hb.le a.2⟩
+  rw [not_covBy_iff] at this
+  · obtain ⟨c, hc, hc'⟩ := this
+    exact hb.2 hc hc'
+  · exact hb.lt
+
+@[to_dual]
+theorem IsSuccLimit.subtype {s : Set α} (hs : IsLowerSet s) {a : s}
+    (ha : IsSuccLimit a) : IsSuccLimit a.1 := by
+  refine ⟨?_, ha.isSuccPrelimit.subtype hs⟩
+  have := ha.1
+  rw [not_isMin_iff] at ⊢ this
+  obtain ⟨b, hb⟩ := this
+  exact ⟨b, hb⟩
+
 variable [SuccOrder α]
 
 @[to_dual]


### PR DESCRIPTION
To be used in some future results about cofinalities.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
