### PR TITLE
[Merged by Bors] - feat: Add Function.Injective.addTorsor Function.Injective.normedAddTo…

### DIFF
--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -229,23 +229,21 @@ lemma pointReflection_eq_subLeft {G : Type*} [AddCommGroup G] (x : G) :
 end Equiv
 
 /-- Pullback of an add torsor along an injective map. -/
-abbrev Function.Injective.addTorsor
-    {M : Type*} {α : Type*} {β : Type*}
-    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β] [Nonempty β] (f : β → α)
+abbrev Function.Injective.addTorsor {G P Q : Type*}
+    [AddGroup G] [AddTorsor G P] [VAdd G Q] [VSub G Q] [Nonempty Q] (f : Q → P)
     (hf : Function.Injective f)
-    (vadd : ∀ (c : M) (x : β), f (c +ᵥ x) = c +ᵥ f x)
-    (vsub : ∀ (x y : β), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
+    (vadd : ∀ (c : G) (x : Q), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : Q), x -ᵥ y = f x -ᵥ f y) : AddTorsor G Q where
   __ := hf.addAction f vadd
   vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
   vadd_vsub' c x := by simp [vsub, vadd]
 
 /-- Pushforward of an add torsor along a surjective map. -/
-abbrev Function.Surjective.addTorsor
-    {M : Type*} {α : Type*} {β : Type*}
-    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β]
-    (f : α → β) (hf : Surjective f)
-    (vadd : ∀ (c : M) (x : α), f (c +ᵥ x) = c +ᵥ f x)
-    (vsub : ∀ (x y : α), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
+abbrev Function.Surjective.addTorsor {G P Q : Type*}
+    [AddGroup G] [AddTorsor G P] [VAdd G Q] [VSub G Q]
+    (f : P → Q) (hf : Surjective f)
+    (vadd : ∀ (c : G) (x : P), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : P), x -ᵥ y = f x -ᵥ f y) : AddTorsor G Q where
   __ := hf.addAction f vadd
   nonempty := AddTorsor.nonempty.map f
   vsub_vadd' := by simp [hf.forall, ← vadd, ← vsub]

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -247,6 +247,6 @@ abbrev Function.Surjective.addTorsor
     (vadd : ∀ (c : M) (x : α), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : α), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
   __ := hf.addAction f vadd
-  nonempty := ⟨f (Classical.choice (α := α) AddTorsor.nonempty)⟩
+  nonempty := AddTorsor.nonempty.map f
   vsub_vadd' := by simp [hf.forall, ← vadd, ← vsub]
   vadd_vsub' := by simp [hf.forall, ← vadd, ← vsub]

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -235,19 +235,18 @@ abbrev Function.Injective.addTorsor
     (hf : Function.Injective f)
     (vadd : ∀ (c : M) (x : β), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : β), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
-  add_vadd := (hf.addAction f vadd).add_vadd
-  zero_vadd := (hf.addAction f vadd).zero_vadd
+  __ := hf.addAction f vadd
   vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
   vadd_vsub' c x := by simp [vsub, vadd]
 
 /-- Pushforward of an add torsor along a surjective map. -/
 abbrev Function.Surjective.addTorsor
     {M : Type*} {α : Type*} {β : Type*}
-    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β] [Nonempty β]
+    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β]
     (f : α → β) (hf : Surjective f)
     (vadd : ∀ (c : M) (x : α), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : α), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
-  add_vadd := (hf.addAction f vadd).add_vadd
-  zero_vadd := (hf.addAction f vadd).zero_vadd
+  __ := hf.addAction f vadd
+  nonempty := ⟨f (Classical.choice (α := α) AddTorsor.nonempty)⟩
   vsub_vadd' := by simp [hf.forall, ← vadd, ← vsub]
   vadd_vsub' := by simp [hf.forall, ← vadd, ← vsub]

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -240,7 +240,7 @@ abbrev Function.Injective.addTorsor
   vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
   vadd_vsub' c x := by simp [vsub, vadd]
 
-/-- Pullforward of an add torsor along a surjective map. -/
+/-- Pushforward of an add torsor along a surjective map. -/
 abbrev Function.Surjective.addTorsor
     {M : Type*} {α : Type*} {β : Type*}
     [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β] [Nonempty β]

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -227,3 +227,15 @@ lemma pointReflection_eq_subLeft {G : Type*} [AddCommGroup G] (x : G) :
   ext; simp [pointReflection, sub_add_eq_add_sub, two_nsmul]
 
 end Equiv
+
+/-- Pullback of an add torsor along an injective map. -/
+abbrev Function.Injective.addTorsor
+    {M : Type*} {α : Type*} {β : Type*}
+    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β] [Nonempty β] (f : β → α)
+    (hf : Function.Injective f)
+    (vadd : ∀ (c : M) (x : β), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : β), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
+  add_vadd x y c := hf <| by simp only [vadd, add_vadd]
+  zero_vadd x := hf <| by simp only [vadd, zero_vadd]
+  vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
+  vadd_vsub' c x := by simp [vsub, vadd]

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -235,7 +235,19 @@ abbrev Function.Injective.addTorsor
     (hf : Function.Injective f)
     (vadd : ∀ (c : M) (x : β), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : β), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
-  add_vadd x y c := hf <| by simp only [vadd, add_vadd]
-  zero_vadd x := hf <| by simp only [vadd, zero_vadd]
+  add_vadd := (hf.addAction f vadd).add_vadd
+  zero_vadd := (hf.addAction f vadd).zero_vadd
   vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
   vadd_vsub' c x := by simp [vsub, vadd]
+
+/-- Pullforward of an add torsor along a surjective map. -/
+abbrev Function.Surjective.addTorsor
+    {M : Type*} {α : Type*} {β : Type*}
+    [AddGroup M] [AddTorsor M α] [VAdd M β] [VSub M β] [Nonempty β]
+    (f : α → β) (hf : Surjective f)
+    (vadd : ∀ (c : M) (x : α), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : α), x -ᵥ y = f x -ᵥ f y) : AddTorsor M β where
+  add_vadd := (hf.addAction f vadd).add_vadd
+  zero_vadd := (hf.addAction f vadd).zero_vadd
+  vsub_vadd' := by simp [hf.forall, ← vadd, ← vsub]
+  vadd_vsub' := by simp [hf.forall, ← vadd, ← vsub]

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -236,10 +236,7 @@ abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
     (vadd : ∀ (c : V) (x : Q), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : Q), x -ᵥ y = f x -ᵥ f y)
     (norm : ∀ (x y : Q), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
-  add_vadd := (hf.addTorsor f vadd vsub).add_vadd
-  zero_vadd := (hf.addTorsor f vadd vsub).zero_vadd
-  vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
-  vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
+  __ := hf.addTorsor f vadd vsub
   dist_eq_norm' x y := by simp [norm, NormedAddTorsor.dist_eq_norm', vsub]
 
 /-- Pushforward of a normed add torsor along a surjective map. -/
@@ -249,8 +246,5 @@ abbrev Function.Surjective.normedAddTorsor
     (vadd : ∀ (c : V) (x : P), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : P), x -ᵥ y = f x -ᵥ f y)
     (norm : ∀ (x y : P), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
-  add_vadd := (hf.addTorsor f vadd vsub).add_vadd
-  zero_vadd := (hf.addTorsor f vadd vsub).zero_vadd
-  vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
-  vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
+  __ := hf.addTorsor f vadd vsub
   dist_eq_norm' := by simp [hf.forall, ← norm, NormedAddTorsor.dist_eq_norm', ← vsub]

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -236,8 +236,8 @@ abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
     (vadd : ∀ (c : V) (x : Q), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : Q), x -ᵥ y = f x -ᵥ f y)
     (norm : ∀ (x y : Q), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
-  add_vadd := (hf.addAction f vadd).add_vadd
-  zero_vadd := (hf.addAction f vadd).zero_vadd
+  add_vadd := (hf.addTorsor f vadd vsub).add_vadd
+  zero_vadd := (hf.addTorsor f vadd vsub).zero_vadd
   vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
   vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
   dist_eq_norm' x y := by simp [norm, NormedAddTorsor.dist_eq_norm', vsub]
@@ -249,8 +249,8 @@ abbrev Function.Surjective.normedAddTorsor
     (vadd : ∀ (c : V) (x : P), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : P), x -ᵥ y = f x -ᵥ f y)
     (norm : ∀ (x y : P), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
-  add_vadd := (hf.addAction f vadd).add_vadd
-  zero_vadd := (hf.addAction f vadd).zero_vadd
+  add_vadd := (hf.addTorsor f vadd vsub).add_vadd
+  zero_vadd := (hf.addTorsor f vadd vsub).zero_vadd
   vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
   vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
   dist_eq_norm' := by simp [hf.forall, ← norm, NormedAddTorsor.dist_eq_norm', ← vsub]

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -236,8 +236,21 @@ abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
     (vadd : ∀ (c : V) (x : Q), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : Q), x -ᵥ y = f x -ᵥ f y)
     (norm : ∀ (x y : Q), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
-  add_vadd x y c := hf <| by simp only [vadd, add_vadd]
-  zero_vadd x := hf <| by simp only [vadd, zero_vadd]
-  vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
-  vadd_vsub' c x := by simp [vsub, vadd]
+  add_vadd := (hf.addAction f vadd).add_vadd
+  zero_vadd := (hf.addAction f vadd).zero_vadd
+  vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
+  vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
   dist_eq_norm' x y := by simp [norm, NormedAddTorsor.dist_eq_norm', vsub]
+
+/-- Pullforward of a normed add torsor along a surjective map. -/
+abbrev Function.Surjective.normedAddTorsor
+    {Q : Type*} [VAdd V Q] [VSub V Q] [Nonempty Q] [PseudoMetricSpace Q]
+    (f : P → Q) (hf : Surjective f)
+    (vadd : ∀ (c : V) (x : P), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : P), x -ᵥ y = f x -ᵥ f y)
+    (norm : ∀ (x y : P), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
+  add_vadd := (hf.addAction f vadd).add_vadd
+  zero_vadd := (hf.addAction f vadd).zero_vadd
+  vsub_vadd' := (hf.addTorsor f vadd vsub).vsub_vadd'
+  vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
+  dist_eq_norm' := by simp [hf.forall, ← norm, NormedAddTorsor.dist_eq_norm', ← vsub]

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -241,7 +241,7 @@ abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
 
 /-- Pushforward of a normed add torsor along a surjective map. -/
 abbrev Function.Surjective.normedAddTorsor
-    {Q : Type*} [VAdd V Q] [VSub V Q] [Nonempty Q] [PseudoMetricSpace Q]
+    {Q : Type*} [VAdd V Q] [VSub V Q] [PseudoMetricSpace Q]
     (f : P → Q) (hf : Surjective f)
     (vadd : ∀ (c : V) (x : P), f (c +ᵥ x) = c +ᵥ f x)
     (vsub : ∀ (x y : P), x -ᵥ y = f x -ᵥ f y)

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -229,3 +229,15 @@ theorem uniformContinuous_vsub : UniformContinuous fun x : P × P => x.1 -ᵥ x.
 instance : IsTopologicalAddTorsor P where
   continuous_vadd := uniformContinuous_vadd.continuous
   continuous_vsub := uniformContinuous_vsub.continuous
+
+/-- Pullback of a normed add torsor along an injective map. -/
+abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
+    [Nonempty Q] [PseudoMetricSpace Q] (f : Q → P) (hf : Function.Injective f)
+    (vadd : ∀ (c : V) (x : Q), f (c +ᵥ x) = c +ᵥ f x)
+    (vsub : ∀ (x y : Q), x -ᵥ y = f x -ᵥ f y)
+    (norm : ∀ (x y : Q), dist x y = dist (f x) (f y)) : NormedAddTorsor V Q where
+  add_vadd x y c := hf <| by simp only [vadd, add_vadd]
+  zero_vadd x := hf <| by simp only [vadd, zero_vadd]
+  vsub_vadd' x y := hf <| by simp only [vsub, vadd, vsub_vadd]
+  vadd_vsub' c x := by simp [vsub, vadd]
+  dist_eq_norm' x y := by simp [norm, NormedAddTorsor.dist_eq_norm', vsub]

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -242,7 +242,7 @@ abbrev Function.Injective.normedAddTorsor {Q : Type*} [VAdd V Q] [VSub V Q]
   vadd_vsub' := (hf.addTorsor f vadd vsub).vadd_vsub'
   dist_eq_norm' x y := by simp [norm, NormedAddTorsor.dist_eq_norm', vsub]
 
-/-- Pullforward of a normed add torsor along a surjective map. -/
+/-- Pushforward of a normed add torsor along a surjective map. -/
 abbrev Function.Surjective.normedAddTorsor
     {Q : Type*} [VAdd V Q] [VSub V Q] [Nonempty Q] [PseudoMetricSpace Q]
     (f : P → Q) (hf : Surjective f)


### PR DESCRIPTION
Adds 
- `Function.Injective.addTorsor`
- `Function.Injective.normedAddTorsor`

pulling back the proofs for `AddTorsor` and `NormedAddTorsor` along an injection. 

Related to this conversation on the Lean zulip: 
https://leanprover.zulipchat.com/#narrow/channel/479953-PhysLean/topic/Space.20vs.20EuclideanSpace/with/575938877


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
