### PR TITLE
feat(NumberTheory/Divisors): Add `infinite_setOf_divisors_iff`

### DIFF
--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -259,7 +259,8 @@ lemma nonempty_divisors : (divisors n).Nonempty ↔ n ≠ 0 :=
   ⟨fun ⟨m, hm⟩ hn ↦ by simp [hn] at hm, fun hn ↦ ⟨1, one_mem_divisors.2 hn⟩⟩
 
 /-- A natural number has infinitely many divisors if and only if it is zero. -/
-lemma infinite_setOf_divisors (n : ℕ) : { m | m ∣ n }.Infinite ↔ n = 0 := by
+@[simp]
+lemma infinite_setOf_divisors_iff (n : ℕ) : { m | m ∣ n }.Infinite ↔ n = 0 := by
   cases n
   case zero => simp [Set.infinite_univ]
   case succ n =>

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -258,6 +258,15 @@ theorem properDivisors_zero : properDivisors 0 = ∅ := by
 lemma nonempty_divisors : (divisors n).Nonempty ↔ n ≠ 0 :=
   ⟨fun ⟨m, hm⟩ hn ↦ by simp [hn] at hm, fun hn ↦ ⟨1, one_mem_divisors.2 hn⟩⟩
 
+/-- A natural number has infinitely many divisors if and only if it is zero. -/
+lemma infinite_setOf_divisors (n : ℕ) : { m | m ∣ n }.Infinite ↔ n = 0 := by
+  cases n
+  case zero => simp [Set.infinite_univ]
+  case succ n =>
+    have h : {m : ℕ | m ∣ n + 1}.Finite :=
+      Set.finite_iff_bddAbove.2 ⟨ _, fun m hm => Nat.le_of_dvd ( Nat.succ_pos _ ) hm ⟩
+    simp [h]
+
 @[simp]
 lemma divisors_eq_empty : divisors n = ∅ ↔ n = 0 := by
   contrapose!; exact nonempty_divisors


### PR DESCRIPTION
This proves that the set of divisors `{ m | m | n }` of a natural number `n` is infinite if and only if `n` is zero. The first proof draft was by @Aristotle-Harmonic.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
