### PR TITLE
[Merged by Bors] - chore(Topology): Generalised some of the instances for Function.locallyFinsuppWithin 

### DIFF
--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -294,17 +294,23 @@ protected lemma memAddSubgroup [AddGroup Y] (D : locallyFinsuppWithin U Y) :
 Assign a function with locally finite support within `U` to a function in the subgroup.
 -/
 @[simps]
-def mk_of_mem_addSubmonoid [AddMonoid Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
+def mk_of_mem_addSubmonoid [AddMonoid Y] (f : X → Y)
+    (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
+@[deprecated mk_of_mem_addSubmonoid (since := "2026-03-05")]
+def mk_of_mem [AddMonoid Y] (f : X → Y)
+    (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
+    locallyFinsuppWithin U Y := mk_of_mem_addSubmonoid f hf
+
 instance [AddMonoid Y] : Zero (locallyFinsuppWithin U Y) where
-  zero := mk_of_mem 0 <| zero_mem _
+  zero := mk_of_mem_addSubmonoid 0 <| zero_mem _
 
 instance [AddMonoid Y] : Add (locallyFinsuppWithin U Y) where
-  add D₁ D₂ := mk_of_mem (D₁ + D₂) <| add_mem D₁.memAddSubmonoid D₂.memAddSubmonoid
+  add D₁ D₂ := mk_of_mem_addSubmonoid (D₁ + D₂) <| add_mem D₁.memAddSubmonoid D₂.memAddSubmonoid
 
 instance [AddMonoid Y] : SMul ℕ (locallyFinsuppWithin U Y) where
-  smul n D := mk_of_mem (n • D) <| nsmul_mem D.memAddSubmonoid n
+  smul n D := mk_of_mem_addSubmonoid (n • D) <| nsmul_mem D.memAddSubmonoid n
 
 /--
 Assign a function with locally finite support within `U` to a function in the subgroup.
@@ -314,13 +320,13 @@ def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppW
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
-  neg D := mk_of_mem' (-D) <| neg_mem D.memAddSubgroup
+  neg D := mk_of_mem_addSubgroup (-D) <| neg_mem D.memAddSubgroup
 
 instance [AddGroup Y] : Sub (locallyFinsuppWithin U Y) where
-  sub D₁ D₂ := mk_of_mem' (D₁ - D₂) <| sub_mem D₁.memAddSubgroup D₂.memAddSubgroup
+  sub D₁ D₂ := mk_of_mem_addSubgroup (D₁ - D₂) <| sub_mem D₁.memAddSubgroup D₂.memAddSubgroup
 
 instance [AddGroup Y] : SMul ℤ (locallyFinsuppWithin U Y) where
-  smul n D := mk_of_mem' (n • D) <| zsmul_mem D.memAddSubgroup n
+  smul n D := mk_of_mem_addSubgroup (n • D) <| zsmul_mem D.memAddSubgroup n
 
 @[simp] lemma coe_zero [AddMonoid Y] :
     ((0 : locallyFinsuppWithin U Y) : X → Y) = 0 := rfl

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -298,14 +298,6 @@ def mk_of_mem_addSubmonoid [AddMonoid Y] (f : X → Y)
     (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-/--
-Deprecated spelling of `mk_of_mem_addSubmonoid`.
--/
-@[deprecated mk_of_mem_addSubmonoid (since := "2026-03-05")]
-def mk_of_mem [AddMonoid Y] (f : X → Y)
-    (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
-    locallyFinsuppWithin U Y := mk_of_mem_addSubmonoid f hf
-
 instance [AddMonoid Y] : Zero (locallyFinsuppWithin U Y) where
   zero := mk_of_mem_addSubmonoid 0 <| zero_mem _
 
@@ -321,6 +313,8 @@ Assign a function with locally finite support within `U` to a function in the su
 @[simps]
 def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
+
+@[deprecated] alias mk_of_mem := mk_of_mem_addSubgroup
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
   neg D := mk_of_mem_addSubgroup (-D) <| neg_mem D.memAddSubgroup

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -314,7 +314,7 @@ Assign a function with locally finite support within `U` to a function in the su
 def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-@[deprecated] alias mk_of_mem := mk_of_mem_addSubgroup
+@[deprecated (since := "2026-03-06")] alias mk_of_mem := mk_of_mem_addSubgroup
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
   neg D := mk_of_mem_addSubgroup (-D) <| neg_mem D.memAddSubgroup

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -298,6 +298,9 @@ def mk_of_mem_addSubmonoid [AddMonoid Y] (f : X → Y)
     (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
+/--
+Deprecated spelling of `mk_of_mem_addSubmonoid`.
+-/
 @[deprecated mk_of_mem_addSubmonoid (since := "2026-03-05")]
 def mk_of_mem [AddMonoid Y] (f : X → Y)
     (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -314,8 +314,7 @@ Assign a function with locally finite support within `U` to a function in the su
 def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-@[deprecated] alias mk_of_mem [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U)
-    := mk_of_mem_addSubgroup
+@[deprecated] alias mk_of_mem := mk_of_mem_addSubgroup
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
   neg D := mk_of_mem_addSubgroup (-D) <| neg_mem D.memAddSubgroup

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -294,7 +294,7 @@ protected lemma memAddSubgroup [AddGroup Y] (D : locallyFinsuppWithin U Y) :
 Assign a function with locally finite support within `U` to a function in the subgroup.
 -/
 @[simps]
-def mk_of_mem [AddMonoid Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
+def mk_of_mem_addSubmonoid [AddMonoid Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
 instance [AddMonoid Y] : Zero (locallyFinsuppWithin U Y) where

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -310,7 +310,7 @@ instance [AddMonoid Y] : SMul ℕ (locallyFinsuppWithin U Y) where
 Assign a function with locally finite support within `U` to a function in the subgroup.
 -/
 @[simps]
-def mk_of_mem' [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
+def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -112,7 +112,7 @@ lemma LocallyFiniteSupport.finite_inter_support_of_isCompact {W : Set X}
 
 lemma Function.locallyFinsupp.locallyFiniteSupport [Zero Y] (f : locallyFinsupp X Y) :
     LocallyFiniteSupport f.toFun :=
-  fun z ↦ f.supportLocallyFiniteWithinDomain' z (mem_of_subset_of_mem (fun _ a ↦ a) trivial)
+  (f.supportLocallyFiniteWithinDomain' · (by trivial))
 
 namespace Function.locallyFinsuppWithin
 

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -314,7 +314,8 @@ Assign a function with locally finite support within `U` to a function in the su
 def mk_of_mem_addSubgroup [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-@[deprecated] alias mk_of_mem := mk_of_mem_addSubgroup
+@[deprecated] alias mk_of_mem [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U)
+    := mk_of_mem_addSubgroup
 
 instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
   neg D := mk_of_mem_addSubgroup (-D) <| neg_mem D.memAddSubgroup

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -110,6 +110,10 @@ lemma LocallyFiniteSupport.finite_inter_support_of_isCompact {W : Set X}
   rw [← lem f.support W]
   exact Finite.image Subtype.val this
 
+lemma Function.locallyFinsupp.locallyFiniteSupport [Zero Y] (f : locallyFinsupp X Y) :
+    LocallyFiniteSupport f.toFun :=
+  fun z ↦ f.supportLocallyFiniteWithinDomain' z (mem_of_subset_of_mem (fun _ a ↦ a) trivial)
+
 namespace Function.locallyFinsuppWithin
 
 /--
@@ -246,7 +250,7 @@ variable (U) in
 /--
 Functions with locally finite support within `U` form an additive subgroup of functions X → Y.
 -/
-protected def addSubgroup [AddCommGroup Y] : AddSubgroup (X → Y) where
+protected def addSubmonoid [AddMonoid Y] : AddSubmonoid (X → Y) where
   carrier := {f | f.support ⊆ U ∧ ∀ z ∈ U, ∃ t ∈ 𝓝 z, Set.Finite (t ∩ f.support)}
   zero_mem' := by
     simp only [support_subset_iff, ne_eq, mem_setOf_eq, Pi.zero_apply, not_true_eq_false,
@@ -268,10 +272,21 @@ protected def addSubgroup [AddCommGroup Y] : AddSubgroup (X → Y) where
         mem_inter_iff, mem_support, Pi.add_apply, mem_union, true_and]
       by_contra! hCon
       simp_all
-  neg_mem' {f} hf := by
-    simp_all
 
-protected lemma memAddSubgroup [AddCommGroup Y] (D : locallyFinsuppWithin U Y) :
+protected lemma memAddSubmonoid [AddMonoid Y] (D : locallyFinsuppWithin U Y) :
+    (D : X → Y) ∈ locallyFinsuppWithin.addSubmonoid U :=
+  ⟨D.supportWithinDomain, D.supportLocallyFiniteWithinDomain⟩
+
+variable (U) in
+/--
+Functions with locally finite support within `U` form an additive subgroup of functions X → Y.
+-/
+protected def addSubgroup [AddGroup Y] : AddSubgroup (X → Y) where
+  carrier := {f | f.support ⊆ U ∧ ∀ z ∈ U, ∃ t ∈ 𝓝 z, Set.Finite (t ∩ f.support)}
+  __ := locallyFinsuppWithin.addSubmonoid U
+  neg_mem' {f} hf := by simp_all
+
+protected lemma memAddSubgroup [AddGroup Y] (D : locallyFinsuppWithin U Y) :
     (D : X → Y) ∈ locallyFinsuppWithin.addSubgroup U :=
   ⟨D.supportWithinDomain, D.supportLocallyFiniteWithinDomain⟩
 
@@ -279,39 +294,58 @@ protected lemma memAddSubgroup [AddCommGroup Y] (D : locallyFinsuppWithin U Y) :
 Assign a function with locally finite support within `U` to a function in the subgroup.
 -/
 @[simps]
-def mk_of_mem [AddCommGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
+def mk_of_mem [AddMonoid Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubmonoid U) :
     locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-instance [AddCommGroup Y] : Zero (locallyFinsuppWithin U Y) where
+instance [AddMonoid Y] : Zero (locallyFinsuppWithin U Y) where
   zero := mk_of_mem 0 <| zero_mem _
 
-instance [AddCommGroup Y] : Add (locallyFinsuppWithin U Y) where
-  add D₁ D₂ := mk_of_mem (D₁ + D₂) <| add_mem D₁.memAddSubgroup D₂.memAddSubgroup
+instance [AddMonoid Y] : Add (locallyFinsuppWithin U Y) where
+  add D₁ D₂ := mk_of_mem (D₁ + D₂) <| add_mem D₁.memAddSubmonoid D₂.memAddSubmonoid
 
-instance [AddCommGroup Y] : Neg (locallyFinsuppWithin U Y) where
-  neg D := mk_of_mem (-D) <| neg_mem D.memAddSubgroup
+instance [AddMonoid Y] : SMul ℕ (locallyFinsuppWithin U Y) where
+  smul n D := mk_of_mem (n • D) <| nsmul_mem D.memAddSubmonoid n
 
-instance [AddCommGroup Y] : Sub (locallyFinsuppWithin U Y) where
-  sub D₁ D₂ := mk_of_mem (D₁ - D₂) <| sub_mem D₁.memAddSubgroup D₂.memAddSubgroup
+/--
+Assign a function with locally finite support within `U` to a function in the subgroup.
+-/
+@[simps]
+def mk_of_mem' [AddGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.addSubgroup U) :
+    locallyFinsuppWithin U Y := ⟨f, hf.1, hf.2⟩
 
-instance [AddCommGroup Y] : SMul ℕ (locallyFinsuppWithin U Y) where
-  smul n D := mk_of_mem (n • D) <| nsmul_mem D.memAddSubgroup n
+instance [AddGroup Y] : Neg (locallyFinsuppWithin U Y) where
+  neg D := mk_of_mem' (-D) <| neg_mem D.memAddSubgroup
 
-instance [AddCommGroup Y] : SMul ℤ (locallyFinsuppWithin U Y) where
-  smul n D := mk_of_mem (n • D) <| zsmul_mem D.memAddSubgroup n
+instance [AddGroup Y] : Sub (locallyFinsuppWithin U Y) where
+  sub D₁ D₂ := mk_of_mem' (D₁ - D₂) <| sub_mem D₁.memAddSubgroup D₂.memAddSubgroup
 
-@[simp] lemma coe_zero [AddCommGroup Y] :
+instance [AddGroup Y] : SMul ℤ (locallyFinsuppWithin U Y) where
+  smul n D := mk_of_mem' (n • D) <| zsmul_mem D.memAddSubgroup n
+
+@[simp] lemma coe_zero [AddMonoid Y] :
     ((0 : locallyFinsuppWithin U Y) : X → Y) = 0 := rfl
-@[simp] lemma coe_add [AddCommGroup Y] (D₁ D₂ : locallyFinsuppWithin U Y) :
+@[simp] lemma coe_add [AddMonoid Y] (D₁ D₂ : locallyFinsuppWithin U Y) :
     (↑(D₁ + D₂) : X → Y) = D₁ + D₂ := rfl
-@[simp] lemma coe_neg [AddCommGroup Y] (D : locallyFinsuppWithin U Y) :
+@[simp] lemma coe_neg [AddGroup Y] (D : locallyFinsuppWithin U Y) :
     (↑(-D) : X → Y) = -(D : X → Y) := rfl
-@[simp] lemma coe_sub [AddCommGroup Y] (D₁ D₂ : locallyFinsuppWithin U Y) :
+@[simp] lemma coe_sub [AddGroup Y] (D₁ D₂ : locallyFinsuppWithin U Y) :
     (↑(D₁ - D₂) : X → Y) = D₁ - D₂ := rfl
-@[simp] lemma coe_nsmul [AddCommGroup Y] (D : locallyFinsuppWithin U Y) (n : ℕ) :
+@[simp] lemma coe_nsmul [AddMonoid Y] (D : locallyFinsuppWithin U Y) (n : ℕ) :
     (↑(n • D) : X → Y) = n • (D : X → Y) := rfl
-@[simp] lemma coe_zsmul [AddCommGroup Y] (D : locallyFinsuppWithin U Y) (n : ℤ) :
+@[simp] lemma coe_zsmul [AddGroup Y] (D : locallyFinsuppWithin U Y) (n : ℤ) :
     (↑(n • D) : X → Y) = n • (D : X → Y) := rfl
+
+instance [AddMonoid Y] : AddMonoid (locallyFinsuppWithin U Y) :=
+  Injective.addMonoid (M₁ := locallyFinsuppWithin U Y) (M₂ := X → Y)
+    _ coe_injective coe_zero coe_add coe_nsmul
+
+instance [AddCommMonoid Y] : AddCommMonoid (locallyFinsuppWithin U Y) :=
+  Injective.addCommMonoid (M₁ := locallyFinsuppWithin U Y) (M₂ := X → Y)
+    _ coe_injective coe_zero coe_add coe_nsmul
+
+instance [AddGroup Y] : AddGroup (locallyFinsuppWithin U Y) :=
+  Injective.addGroup (M₁ := locallyFinsuppWithin U Y) (M₂ := X → Y)
+    _ coe_injective coe_zero coe_add coe_neg coe_sub coe_nsmul coe_zsmul
 
 instance [AddCommGroup Y] : AddCommGroup (locallyFinsuppWithin U Y) :=
   Injective.addCommGroup (M₁ := locallyFinsuppWithin U Y) (M₂ := X → Y)

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -248,7 +248,7 @@ defined pointwise.
 
 variable (U) in
 /--
-Functions with locally finite support within `U` form an additive subgroup of functions X → Y.
+Functions with locally finite support within `U` form an additive submonoid of functions `X → Y`.
 -/
 protected def addSubmonoid [AddMonoid Y] : AddSubmonoid (X → Y) where
   carrier := {f | f.support ⊆ U ∧ ∀ z ∈ U, ∃ t ∈ 𝓝 z, Set.Finite (t ∩ f.support)}
@@ -279,7 +279,7 @@ protected lemma memAddSubmonoid [AddMonoid Y] (D : locallyFinsuppWithin U Y) :
 
 variable (U) in
 /--
-Functions with locally finite support within `U` form an additive subgroup of functions X → Y.
+Functions with locally finite support within `U` form an additive subgroup of functions `X → Y`.
 -/
 protected def addSubgroup [AddGroup Y] : AddSubgroup (X → Y) where
   carrier := {f | f.support ⊆ U ∧ ∀ z ∈ U, ∃ t ∈ 𝓝 z, Set.Finite (t ∩ f.support)}


### PR DESCRIPTION
In this PR, we generalised the various instances for locally fin supp functions. These changes were originally made on the PR #26304 about algebraic cycles, but it was decided that these changes are more appropriate in their own PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
