### PR TITLE
feat(Logic.Equiv.Dyadic): add dyadic (bijective base-2) numeration

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4952,9 +4952,9 @@ public import Mathlib.Logic.Encodable.Lattice
 public import Mathlib.Logic.Encodable.Pi
 public import Mathlib.Logic.Equiv.Array
 public import Mathlib.Logic.Equiv.Basic
+public import Mathlib.Logic.Equiv.BijectiveBase2
 public import Mathlib.Logic.Equiv.Bool
 public import Mathlib.Logic.Equiv.Defs
-public import Mathlib.Logic.Equiv.Dyadic
 public import Mathlib.Logic.Equiv.Embedding
 public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Logic.Equiv.Fin.Rotate

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4954,6 +4954,7 @@ public import Mathlib.Logic.Equiv.Array
 public import Mathlib.Logic.Equiv.Basic
 public import Mathlib.Logic.Equiv.Bool
 public import Mathlib.Logic.Equiv.Defs
+public import Mathlib.Logic.Equiv.Dyadic
 public import Mathlib.Logic.Equiv.Embedding
 public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Logic.Equiv.Fin.Rotate

--- a/Mathlib/Logic/Equiv/BijectiveBase2.lean
+++ b/Mathlib/Logic/Equiv/BijectiveBase2.lean
@@ -8,14 +8,14 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Equiv.Basic
 
 /-!
-# Dyadic Numeration (Bijective Base-2)
+# Bijective Base-2 Numeration
 
 This module formalizes a bijective base-2 numeration system.
-Unlike standard binary representation, dyadic numeration avoids the "leading zeros"
-problem, providing a strict bijection `ℕ ≃ List Bool`.
+Unlike standard binary representation, bijective base-2 numeration avoids the
+"leading zeros" problem, providing a strict bijection `ℕ ≃ List Bool`.
 -/
 
-namespace Equiv.Dyadic
+namespace Equiv.BijectiveBase2
 
 /-- Encodes a natural number into a list of booleans using bijective base-2. -/
 def toBits (n : ℕ) : List Bool :=
@@ -35,7 +35,8 @@ def ofBits : List Bool → ℕ
 
 @[simp] lemma ofBits_nil : ofBits [] = 0 := rfl
 
-/-- Proves that decoding the encoded dyadic bits of a natural number returns the original number. -/
+/-- Proves that decoding the encoded bijective base-2 bits of a natural number
+returns the original number. -/
 @[simp]
 theorem ofBits_toBits (n : ℕ) : ofBits (toBits n) = n := by
   rw [toBits]
@@ -51,7 +52,8 @@ theorem ofBits_toBits (n : ℕ) : ofBits (toBits n) = n := by
 termination_by n
 decreasing_by omega
 
-/-- Proves that encoding the decoded natural number of dyadic bits returns the original bits. -/
+/-- Proves that encoding the decoded natural number of bijective base-2 bits
+returns the original bits. -/
 @[simp]
 theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
   induction bs with
@@ -75,12 +77,12 @@ theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
         have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by omega
         simp [h_math, h_div, h_mod, ih]
 
-end Equiv.Dyadic
+end Equiv.BijectiveBase2
 
 /-- The formal mathematical bijection between Natural Numbers and Boolean Lists
-using bijective base-2 (dyadic) numeration. -/
-def equivDyadic : ℕ ≃ List Bool where
-  toFun := Equiv.Dyadic.toBits
-  invFun := Equiv.Dyadic.ofBits
-  left_inv := Equiv.Dyadic.ofBits_toBits
-  right_inv := Equiv.Dyadic.toBits_ofBits
+using bijective base-2 numeration. -/
+def equivBijectiveBase2 : ℕ ≃ List Bool where
+  toFun := Equiv.BijectiveBase2.toBits
+  invFun := Equiv.BijectiveBase2.ofBits
+  left_inv := Equiv.BijectiveBase2.ofBits_toBits
+  right_inv := Equiv.BijectiveBase2.toBits_ofBits

--- a/Mathlib/Logic/Equiv/Dyadic.lean
+++ b/Mathlib/Logic/Equiv/Dyadic.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Alexey Milovanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alexey Milovanov
+-/
+import Mathlib.Data.List.Basic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Logic.Equiv.Basic
+
+/-!
+# Dyadic Numeration (Bijective Base-2)
+
+This module formalizes a bijective base-2 numeration system.
+Unlike standard binary representation, dyadic numeration avoids the "leading zeros"
+problem, providing a strict bijection `ℕ ≃ List Bool`.
+-/
+
+namespace Equiv.Dyadic
+
+/-- Encodes a natural number into a list of booleans using bijective base-2. -/
+def toBits (n : ℕ) : List Bool :=
+  if h : n = 0 then []
+  else ((n - 1) % 2 == 1) :: toBits ((n - 1) / 2)
+termination_by n
+decreasing_by omega
+
+@[simp] lemma toBits_zero : toBits 0 = [] := by rw [toBits]; simp
+
+/-- Decodes a list of booleans into a natural number using bijective base-2.
+    [] ↦ 0, [false] ↦ 1, [true] ↦ 2, [false, false] ↦ 3. -/
+def ofBits : List Bool → ℕ
+  | [] => 0
+  | false :: bs => 1 + 2 * ofBits bs
+  | true :: bs => 2 + 2 * ofBits bs
+
+@[simp] lemma ofBits_nil : ofBits [] = 0 := rfl
+
+/-- Proves that decoding the encoded dyadic bits of a natural number returns the original number. -/
+@[simp]
+theorem ofBits_toBits (n : ℕ) : ofBits (toBits n) = n := by
+  rw [toBits]
+  split_ifs with h
+  · subst h; rfl
+  · have ih := ofBits_toBits ((n - 1) / 2)
+    have h_mod : (n - 1) % 2 = 0 ∨ (n - 1) % 2 = 1 := by omega
+    rcases h_mod with h0 | h1
+    · simp [h0, ofBits, ih]
+      omega
+    · simp [h1, ofBits, ih]
+      omega
+termination_by n
+decreasing_by omega
+
+/-- Proves that encoding the decoded natural number of dyadic bits returns the original bits. -/
+@[simp]
+theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
+  induction bs with
+  | nil => simp
+  | cons b bs ih =>
+    cases b
+    · change toBits (1 + 2 * ofBits bs) = false :: bs
+      rw [toBits]
+      split_ifs with h
+      · omega
+      · have h_math : 1 + 2 * ofBits bs - 1 = 2 * ofBits bs := by omega
+        have h_div : (2 * ofBits bs) / 2 = ofBits bs := by omega
+        have h_mod : (2 * ofBits bs) % 2 = 0 := by omega
+        simp [h_math, h_div, h_mod, ih]
+    · change toBits (2 + 2 * ofBits bs) = true :: bs
+      rw [toBits]
+      split_ifs with h
+      · omega
+      · have h_math : 2 + 2 * ofBits bs - 1 = 1 + 2 * ofBits bs := by omega
+        have h_div : (1 + 2 * ofBits bs) / 2 = ofBits bs := by omega
+        have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by omega
+        simp [h_math, h_div, h_mod, ih]
+
+end Equiv.Dyadic
+
+/-- The formal mathematical bijection between Natural Numbers and Boolean Lists
+using bijective base-2 (dyadic) numeration. -/
+def equivDyadic : ℕ ≃ List Bool where
+  toFun := Equiv.Dyadic.toBits
+  invFun := Equiv.Dyadic.ofBits
+  left_inv := Equiv.Dyadic.ofBits_toBits
+  right_inv := Equiv.Dyadic.toBits_ofBits


### PR DESCRIPTION
This PR introduces dyadic numeration (bijective base-2), providing a strict bijection between `ℕ` and `List Bool`.

**Motivation:**
While `Mathlib` already has `Denumerable (List Bool)` via Cantor pairing, that default bijection drastically distorts lengths (a short list can map to an exponentially huge number). Standard binary representation (e.g. `Nat.digits 2`), on the other hand, is not injective over `List Bool` due to the "leading zeros" problem (`[]`, `[false]`, and `[false, false]` all map to `0`).

Dyadic numeration natively solves both problems:
1. It provides a strict mathematical equivalence `ℕ ≃ List Bool`.
2. It mathematically preserves lengths logarithmically (the specific length-bound lemmas and computability proofs will follow in subsequent PRs to keep this initial PR small).

**Applications:**
This equivalence is foundational for Algorithmic Information Theory (e.g., formalizing Kolmogorov Complexity) and coding theory. It provides a natural way to embed arbitrary bitstrings into `ℕ` without needing a separate channel to store the string's length.

*(Note: Used AI to assist with standardizing proof structures).*