### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `field`/`field_simp` tactic documentation

### DIFF
--- a/Mathlib/Tactic/Field.lean
+++ b/Mathlib/Tactic/Field.lean
@@ -25,34 +25,44 @@ namespace Mathlib.Tactic.FieldSimp
 open Lean Elab Tactic Lean.Parser.Tactic
 
 /--
-The `field` tactic proves equality goals in (semi-)fields. For example:
-```
-example {x y : ℚ} (hx : x + y ≠ 0) : x / (x + y) + y / (x + y) = 1 := by
-  field
-example {a b : ℝ} (ha : a ≠ 0) : a / (a * b) - 1 / b = 0 := by field
-```
-The scope of the tactic is equality goals which are *universal*, in the sense that they are true in
-any field in which the appropriate denominators don't vanish. (That is, they are consequences purely
-of the field axioms.)
-
-Checking the nonvanishing of the necessary denominators is done using a variety of tricks -- in
-particular this part of the reasoning is non-universal, i.e. can be specific to the field at hand
-(order properties, explicit `≠ 0` hypotheses, `CharZero` if that is known, etc).  The user can also
-provide additional terms to help with the nonzeroness proofs. For example:
-```
-example {K : Type*} [Field K] (hK : ∀ x : K, x ^ 2 + 1 ≠ 0) (x : K) :
-    1 / (x ^ 2 + 1) + x ^ 2 / (x ^ 2 + 1) = 1 := by
-  field [hK]
-```
+`field` solves equality goals in (semi-)fields. The goal must be an equality which is *universal*,
+in the sense that it is true in any field in which the appropriate denominators don't vanish.
+(That is, it is a consequence purely of the field axioms.)
 
 The `field` tactic is built from the tactics `field_simp` (which clears the denominators) and `ring`
 (which proves equality goals universally true in commutative (semi-)rings). If `field` fails to
 prove your goal, you may still be able to prove your goal by running the `field_simp` and `ring_nf`
-normalizations in some order.  For example, this statement:
+normalizations in some order.
+
+The tactic will try discharge proofs of nonzeroness of denominators, and skip steps if discharging
+fails. These denominators are made out of denominators appearing in the input expression, by
+repeatedly taking products or divisors. The default discharger can be non-universal, i.e. can be
+specific to the field at hand (order properties, explicit `≠ 0` hypotheses, `CharZero` if that is
+known, etc). See `Mathlib.Tactic.FieldSimp.discharge` for full details of the default discharger
+algorithm.
+
+* `field (disch := tac)` uses the tactic sequence `tac` to discharge nonzeroness proofs.
+* `field [t₁, ..., tₙ]` provides terms `t₁`, ..., `tₙ` to the discharger for nonzeroness proofs.
+
+Examples:
 ```
-example {a b : ℚ} (H : b + a ≠ 0) : a / (a + b) + b / (b + a) = 1
+example {x y : ℚ} (hx : x + y ≠ 0) : x / (x + y) + y / (x + y) = 1 := by field
+example {a b : ℝ} (ha : a ≠ 0) : a / (a * b) - 1 / b = 0 := by field
+
+-- The user can also provide additional terms to help with nonzeroness proofs:
+example {K : Type*} [Field K] (hK : ∀ x : K, x ^ 2 + 1 ≠ 0) (x : K) :
+    1 / (x ^ 2 + 1) + x ^ 2 / (x ^ 2 + 1) = 1 := by
+  field [hK]
+
+example {a b : ℚ} (H : b + a ≠ 0) : a / (a + b) + b / (b + a) = 1 := by
+  -- `field` cannot prove this on its own.
+  fail_if_success field
+  -- But running `ring_nf` and `field_simp` in a different order works:
+  ring_nf at *
+  field
 ```
-is not proved by `field` but is proved by `ring_nf at *; field`. -/
+
+-/
 elab (name := field) "field" d:(ppSpace discharger)? args:(ppSpace simpArgs)? : tactic =>
     withMainContext do
   let disch ← parseDischarger d args

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -645,9 +645,9 @@ def reduceProp (disch : ∀ {u : Level} (type : Q(Sort u)), MetaM Q($type)) (t :
 
 open Elab Tactic Lean.Parser.Tactic
 
-/-- If the user provided a discharger, elaborate it. If not, we will use the `field_simp` default
-discharger, which (among other things) includes a simp-run for the specified argument list, so we
-elaborate those arguments. -/
+/-- If the user provided a discharger, elaborate it. If not, we will use the `field_simp_discharge`
+default discharger, which (among other things) includes a simp-run for the specified argument list,
+so we elaborate those arguments. -/
 def parseDischarger (d : Option (TSyntax ``discharger)) (args : Option (TSyntax ``simpArgs)) :
     TacticM (∀ {u : Level} (type : Q(Sort u)), MetaM Q($type)) := do
   match d with
@@ -665,37 +665,43 @@ def parseDischarger (d : Option (TSyntax ``discharger)) (args : Option (TSyntax 
     | _ => throwError "could not parse the provided discharger {d}"
 
 /--
-The goal of `field_simp` is to bring expressions in (semi-)fields over a common denominator, i.e. to
-reduce them to expressions of the form `n / d` where neither `n` nor `d` contains any division
-symbol. For example, `x / (1 - y) / (1 + y / (1 - y))` is reduced to `x / (1 - y + y)`:
-```
-example (x y z : ℚ) (hy : 1 - y ≠ 0) :
-    ⌊x / (1 - y) / (1 + y / (1 - y))⌋ < 3 := by
-  field_simp
-  -- new goal: `⊢ ⌊x / (1 - y + y)⌋ < 3`
-```
-
-The `field_simp` tactic will also clear denominators in field *(in)equalities*, by
-cross-multiplying. For example, `field_simp` will clear the `x` denominators in the following
-equation:
-```
-example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
-    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
-  field_simp
-  -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
-```
+`field_simp` normalizes expressions in (semi-)fields by rewriting them to a common denominator,
+i.e. to reduce them to expressions of the form `n / d` where neither `n` nor `d` contains any
+division symbol. The `field_simp` tactic will also clear denominators in field *(in)equalities*, by
+cross-multiplying.
 
 A very common pattern is `field_simp; ring` (clear denominators, then the resulting goal is
 solvable by the axioms of a commutative ring). The finishing tactic `field` is a shorthand for this
 pattern.
 
-Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
-side conditions. The `field_simp` tactic attempts to discharge these, and will omit such steps if it
-cannot discharge the corresponding side conditions. The discharger will try, among other things,
-`positivity` and `norm_num`, and will also use any nonzeroness/positivity proofs included explicitly
-(e.g. `field_simp [hx]`). If your expression is not completely reduced by `field_simp`, check the
-denominators of the resulting expression and provide proofs that they are nonzero/positive to enable
-further progress.
+The tactic will try discharge proofs of nonzeroness of denominators, and skip steps if discharging
+fails. These denominators are made out of denominators appearing in the input expression,
+by repeatedly taking products or divisors. The default discharger can be non-universal, i.e. can be
+specific to the field at hand (order properties, explicit `≠ 0` hypotheses, `CharZero` if that is
+known, etc). See `field_simp_discharge` for full details of the default discharger algorithm.
+
+* `field_simp at l1 l2 ...` can be used to normalize at the given locations.
+* `field_simp (disch := tac)` uses the tactic sequence `tac` to discharge nonzeroness/positivity
+  proofs.
+* `field_simp [t₁, ..., tₙ]` provides terms `t₁`, ..., `tₙ` to the discharger for
+  nonzeroness/positivity proofs.
+
+Examples:
+```
+-- `x / (1 - y) / (1 + y / (1 - y))` is reduced to `x / (1 - y + y)`
+example (x y z : ℚ) (hy : 1 - y ≠ 0) :
+    ⌊x / (1 - y) / (1 + y / (1 - y))⌋ < 3 := by
+  field_simp
+  -- new goal: `⊢ ⌊x / (1 - y + y)⌋ < 3`
+  sorry
+
+-- `field_simp` will clear the `x` denominators in the following equation
+example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
+    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
+  field_simp
+  -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
+  sorry
+```
 -/
 elab (name := fieldSimp) "field_simp" d:(discharger)? args:(simpArgs)? loc:(location)? :
     tactic => withMainContext do
@@ -708,28 +714,34 @@ elab (name := fieldSimp) "field_simp" d:(discharger)? args:(simpArgs)? loc:(loca
   transformAtLocation (m ·) "field_simp" (failIfUnchanged := true) (mayCloseGoalFromHyp := true) loc
 
 /--
-The goal of the `field_simp` conv tactic is to bring an expression in a (semi-)field over a common
-denominator, i.e. to reduce it to an expression of the form `n / d` where neither `n` nor `d`
-contains any division symbol. For example, `x / (1 - y) / (1 + y / (1 - y))` is reduced to
-`x / (1 - y + y)`:
+`field_simp` normalizes an expression in a (semi-)field by rewriting it to a common denominator,
+i.e. to reduce it to an expression of the form `n / d` where neither `n` nor `d` contains any
+division symbol.
+
+The `field_simp` conv tactic is a variant of the main (i.e., not conv) `field_simp` tactic. The
+latter operates recursively on subexpressions, bringing *every* field-expression encountered to the
+form `n / d`.
+
+The tactic will try discharge proofs of nonzeroness of denominators, and skip steps if discharging
+fails. These denominators are made out of denominators appearing in the input expression,
+by repeatedly taking products or divisors. The default discharger can be non-universal, i.e. can be
+specific to the field at hand (order properties, explicit `≠ 0` hypotheses, `CharZero` if that is
+known, etc). See `field_simp_discharge` for full details of the default discharger algorithm.
+
+* `field_simp (disch := tac)` uses the tactic sequence `tac` to discharge nonzeroness/positivity
+  proofs.
+* `field_simp [t₁, ..., tₙ]` provides terms `t₁`, ..., `tₙ` to the discharger for
+  nonzeroness/positivity proofs.
+
+Examples:
+
 ```
+-- `x / (1 - y) / (1 + y / (1 - y))` is reduced to `x / (1 - y + y)`:
 example (x y z : ℚ) (hy : 1 - y ≠ 0) :
     ⌊x / (1 - y) / (1 + y / (1 - y))⌋ < 3 := by
   conv => enter [1, 1]; field_simp
   -- new goal: `⊢ ⌊x / (1 - y + y)⌋ < 3`
 ```
-
-As in this example, cancelling and combining denominators will generally require checking
-"nonzeroness" side conditions. The `field_simp` tactic attempts to discharge these, and will omit
-such steps if it cannot discharge the corresponding side conditions. The discharger will try, among
-other things, `positivity` and `norm_num`, and will also use any nonzeroness proofs included
-explicitly (e.g. `field_simp [hx]`). If your expression is not completely reduced by `field_simp`,
-check the denominators of the resulting expression and provide proofs that they are nonzero to
-enable further progress.
-
-The `field_simp` conv tactic is a variant of the main (i.e., not conv) `field_simp` tactic. The
-latter operates recursively on subexpressions, bringing *every* field-expression encountered to the
-form `n / d`.
 -/
 elab "field_simp" d:(discharger)? args:(simpArgs)? : conv => do
   -- find the expression `x` to `conv` on
@@ -741,29 +753,29 @@ elab "field_simp" d:(discharger)? args:(simpArgs)? : conv => do
   Conv.applySimpResult r
 
 /--
-The goal of the simprocs grouped under the `field` attribute is to clear denominators in
-(semi-)field (in)equalities, by bringing LHS and RHS each over a common denominator and then
-cross-multiplying. For example, the `field` simproc will clear the `x` denominators in the following
-equation:
+`field` is a `simp` set that clears denominators in (semi-)field (in)equalities.
+
+The `field` simp set is a variant of the `field_simp` tactic. The latter operates recursively on
+subexpressions, bringing every field-expression encountered to the form `n / d`, and then attempts
+to clear the denominator. (For confluence reasons, the `field` simprocs also have a slightly
+different normal form from `field_simp`'s.)
+
+The tactic will try discharge proofs of nonzeroness of denominators, and skip steps if discharging
+fails. These denominators are made out of denominators appearing in the input expression,
+by repeatedly taking products or divisors. The discharger can be non-universal, i.e. can be specific
+to the field at hand (order properties, explicit `≠ 0` hypotheses, `CharZero` if that is known,
+etc). See `field_simp_discharge` for full details of the discharger algorithm.
+
+* `simp [field, t₁, ..., tₙ]` provides terms `t₁`, ..., `tₙ` to the discharger for
+  nonzeroness/positivity proofs.
+
+Examples:
 ```
 example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
     (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
   simp only [field]
   -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
 ```
-
-The `field` simproc-set's functionality is a variant of the more general `field_simp` tactic, which
-not only clears denominators in field (in)equalities but also brings isolated field expressions into
-the normal form `n / d` (where neither `n` nor `d` contains any division symbol). (For confluence
-reasons, the `field` simprocs also have a slightly different normal form from `field_simp`'s.)
-
-Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
-side conditions. The `field` simproc-set attempts to discharge these, and will omit such steps if it
-cannot discharge the corresponding side conditions. The discharger will try, among other things,
-`positivity` and `norm_num`, and will also use any nonzeroness/positivity proofs included explicitly
-in the simp call (e.g. `simp [field, hx]`). If your (in)equality is not completely reduced by the
-`field` simproc-set, check the denominators of the resulting (in)equality and provide proofs that
-they are nonzero/positive to enable further progress.
 -/
 def proc : Simp.Simproc := fun (t : Expr) ↦ do
   let ctx ← Simp.getContext

--- a/Mathlib/Tactic/FieldSimp/Discharger.lean
+++ b/Mathlib/Tactic/FieldSimp/Discharger.lean
@@ -50,7 +50,20 @@ private def dischargerTraceMessage {ε : Type*} (prop : Expr) :
 | .error _ | .ok none => return m!"{crossEmoji} discharge {prop}"
 | .ok (some _) => return m!"{checkEmoji} discharge {prop}"
 
-/-- Discharge strategy for the `field_simp` tactic. -/
+/-- Default discharge strategy for `field` and `field_simp`: try to solve the (in)equality `prop`,
+of the form `t = 0` or `t > 0`, by one of the following strategies:
+
+* Use an assumption from the context.
+* Use the `norm_num` tactic.
+* Use the `positivity` tactic.
+* Use the `simp` tactic with `discharge` as discharger and lemmas stating:
+  * `2 ≠ 0`, `3 ≠ 0`, `4 ≠ 0`
+  * `x ≠ 0 → y ≠ 0 → x * y ≠ 0`
+  * `a ≠ 0 → a ^ n ≠ 0` (for `n : ℕ` and `n : ℤ`)
+  * `↑n + 1 ≠ 0`, if `n : ℕ` and the field has characteristic 0.
+
+If none of the strategies finds a proof for `prop`, the result is `none`.
+-/
 partial def discharge (prop : Expr) : SimpM (Option Expr) :=
   withTraceNode `Tactic.field_simp (dischargerTraceMessage prop) do
     -- Discharge strategy 1: Use assumptions


### PR DESCRIPTION
This PR (re)writes the docstrings for the `field` and `field_simp` tactics, to consistently match the official style guide, to make sure they are complete while not getting too long.

In particular, this makes precise what goals are given to the default discharger and what it tries to do to discharge them; and structures the documentation into sections consistent with the style guide.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
