### PR TITLE
fix: make `Lean.levelZero` and `Lean.Level.ofNat` implicit_reducible

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -135,3 +135,7 @@ run_cmd liftTermElabM do
     let some cinfo := env.find? mlRes | throwError "{mlRes}: this code should be unreachable."
     if !cinfo.type.isAppOf ``Lean.Option then
       throwError "{.ofConstName mlRes} is not an option, it is a{indentD cinfo.type}"
+
+/- Local workaround until https://github.com/leanprover/lean4/pull/12719 lands -/
+set_option allowUnsafeReducibility true in
+attribute [implicit_reducible] Lean.levelZero Lean.Level.ofNat


### PR DESCRIPTION
This PR marks `Lean.levelZero` and `Lean.Level.ofNat` as `implicit_reducible`, so that `Level.ofNat 0 =?= Level.zero` succeeds at reducible transparency. Without this, coercions between structures with implicit `Level` parameters fail when `backward.isDefEq.respectTransparency` is enabled. This is a local workaround until https://github.com/leanprover/lean4/pull/12719 lands.

See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/576131374

🤖 Prepared with Claude Code