### PR TITLE
feat(Mathlib/GroupTheory/PresentedGroup): every group has a presentation

### DIFF
--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -23,8 +23,7 @@ given by generators `x : α` and relations `r ∈ rels`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
 * `toGroup f`: the canonical group homomorphism `PresentedGroup rels → G`, given a function
   `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
-* `freeGroupProdKerEquiv G`: the canonical isomorphism from the quotient of `FreeGroup G` by the
-  normal closure of `ker (FreeGroup.prod : FreeGroup G →* G)` to `G`; equivalently,
+* `freeGroupProdKerEquiv G`: the canonical isomorphism
   `PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G`.
 * `exists_presentation G`: every group `G` is isomorphic to some
   `PresentedGroup rels`.
@@ -173,22 +172,21 @@ end ToGroup
 /-- The canonical isomorphism from a presented group to the underlying group,
 with the group elements as generators and relations given by
 `(FreeGroup.prod : FreeGroup G →* G).ker`. -/
-def freeGroupProdKerEquiv (G : Type u) [Group G] :
+def freeGroupProdKerEquiv (G : Type*) [Group G] :
   PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G := by
-  let F : FreeGroup G →* G := FreeGroup.prod
-  let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=
-    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of (by
-      intro g
-      simp [F])
-  let e₂ : FreeGroup G ⧸ MonoidHom.ker F ≃*
-      PresentedGroup (MonoidHom.ker F : Set (FreeGroup G)) :=
-    by
-      simpa [PresentedGroup] using
-        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
-          (M := MonoidHom.ker F)
-          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
-          (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm)
-  exact e₂.symm.trans e₁
+  let e : FreeGroup G ⧸ Subgroup.normalClosure
+      ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃*
+      FreeGroup G ⧸ (FreeGroup.prod : FreeGroup G →* G).ker :=
+    QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
+      (M := Subgroup.normalClosure ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)))
+      (N := (FreeGroup.prod : FreeGroup G →* G).ker)
+      (Subgroup.normalClosure_eq_self (MonoidHom.ker (FreeGroup.prod : FreeGroup G →* G)))
+  let e' : FreeGroup G ⧸ (FreeGroup.prod : FreeGroup G →* G).ker ≃* G := by
+    simpa using (QuotientGroup.quotientKerEquivOfRightInverse
+      (φ := (FreeGroup.prod : FreeGroup G →* G)) FreeGroup.of (by
+        intro g
+        simp))
+  simpa [PresentedGroup] using e.trans e'
 
 /-- Every group is isomorphic to some presented group. -/
 theorem exists_presentation (G : Type u) [Group G] :

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -23,6 +23,9 @@ given by generators `x : α` and relations `r ∈ rels`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
 * `toGroup f`: the canonical group homomorphism `PresentedGroup rels → G`, given a function
   `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
+* `freeGroupProdKerEquiv G`: the canonical isomorphism from the quotient of `FreeGroup G` by the
+  normal closure of `ker (FreeGroup.prod : FreeGroup G →* G)` to `G`; equivalently,
+  `PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G`.
 * `exists_presentation G`: every group `G` is isomorphic to some
   `PresentedGroup rels`.
 
@@ -167,27 +170,31 @@ theorem equivPresentedGroup_symm_apply_of (x : β) (rels : Set (FreeGroup α)) (
 
 end ToGroup
 
-/-- Every group is isomorphic to a presented group. -/
-theorem exists_presentation (G : Type u) [Group G] :
-    ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels) := by
-  let F : FreeGroup (ULift G) →* G := FreeGroup.lift ULift.down
-  have hF : Function.Surjective F := by
-    intro g
-    refine ⟨FreeGroup.of (ULift.up g), ?_⟩
-    simp [F]
-  refine ⟨ULift G, (MonoidHom.ker F : Set (FreeGroup (ULift G))), ?_⟩
-  refine ⟨?_⟩
-  let e₁ : FreeGroup (ULift G) ⧸ MonoidHom.ker F ≃* G :=
-    QuotientGroup.quotientKerEquivOfSurjective (φ := F) hF
-  let e₂ : FreeGroup (ULift G) ⧸ MonoidHom.ker F ≃*
-      PresentedGroup (MonoidHom.ker F : Set (FreeGroup (ULift G))) :=
+/-- The canonical isomorphism from a presented group to the underlying group,
+with the group elements as generators and relations given by
+`(FreeGroup.prod : FreeGroup G →* G).ker`. -/
+def freeGroupProdKerEquiv (G : Type u) [Group G] :
+  PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G := by
+  let F : FreeGroup G →* G := FreeGroup.prod
+  let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=
+    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of (by
+      intro g
+      simp [F])
+  let e₂ : FreeGroup G ⧸ MonoidHom.ker F ≃*
+      PresentedGroup (MonoidHom.ker F : Set (FreeGroup G)) :=
     by
       simpa [PresentedGroup] using
-        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup (ULift G))
+        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
           (M := MonoidHom.ker F)
-          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup (ULift G))))
+          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
           (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm)
-  exact e₁.symm.trans e₂
+  exact e₂.symm.trans e₁
+
+/-- Every group is isomorphic to some presented group. -/
+theorem exists_presentation (G : Type u) [Group G] :
+    ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels) := by
+  exact ⟨G, ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)),
+    ⟨(freeGroupProdKerEquiv G).symm⟩⟩
 
 instance (rels : Set (FreeGroup α)) : Inhabited (PresentedGroup rels) :=
   ⟨1⟩

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Algebra.Group.Subgroup.Basic
 public import Mathlib.GroupTheory.FreeGroup.Basic
 public import Mathlib.GroupTheory.QuotientGroup.Basic
-public import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
 # Defining a group given by generators and relations

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -182,7 +182,7 @@ def freeGroupProdKerEquiv (G : Type*) [Group G] :
       (Subgroup.normalClosure_eq_self (MonoidHom.ker f)).symm
   e₂.symm.trans e₁
 
-/-- Every group is isomorphic to some presented group. -/
+/-- There exists an isomorphism for every group to a presented group. -/
 theorem exists_presentation (G : Type u) [Group G] :
     ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels) := by
   let rels : Set (FreeGroup G) := ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G))

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -23,8 +23,7 @@ given by generators `x : α` and relations `r ∈ rels`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
 * `toGroup f`: the canonical group homomorphism `PresentedGroup rels → G`, given a function
   `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
-* `freeGroupProdKerEquiv G`: the canonical isomorphism from the quotient of `FreeGroup G` by the
-  normal closure of `ker (FreeGroup.prod : FreeGroup G →* G)` to `G`; equivalently,
+* `freeGroupProdKerEquiv G`: the canonical isomorphism
   `PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G`.
 * `exists_presentation G`: every group `G` is isomorphic to some
   `PresentedGroup rels`.
@@ -173,7 +172,7 @@ end ToGroup
 /-- The canonical isomorphism from a presented group to the underlying group,
 with the group elements as generators and relations given by
 `(FreeGroup.prod : FreeGroup G →* G).ker`. -/
-def freeGroupProdKerEquiv (G : Type u) [Group G] :
+def freeGroupProdKerEquiv (G : Type*) [Group G] :
   PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G := by
   let F : FreeGroup G →* G := FreeGroup.prod
   let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -171,23 +171,23 @@ with the group elements as free group generators and relations given by
 `(FreeGroup.prod : FreeGroup G →* G).ker`. -/
 def freeGroupProdKerEquiv (G : Type*) [Group G] :
   PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G :=
-  let F : FreeGroup G →* G := FreeGroup.prod
-  let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=
-    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of
+  let f : FreeGroup G →* G := FreeGroup.prod
+  let e₁ : FreeGroup G ⧸ MonoidHom.ker f ≃* G :=
+    QuotientGroup.quotientKerEquivOfRightInverse (φ := f) FreeGroup.of
       (fun g => FreeGroup.prod.of (x := g))
-  let e₂ : FreeGroup G ⧸ MonoidHom.ker F ≃*
-      PresentedGroup (MonoidHom.ker F : Set (FreeGroup G)) :=
+  let e₂ : FreeGroup G ⧸ MonoidHom.ker f ≃*
+      PresentedGroup (MonoidHom.ker f : Set (FreeGroup G)) :=
     QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
-      (M := MonoidHom.ker F)
-      (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
-      (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm
+      (M := MonoidHom.ker f)
+      (N := Subgroup.normalClosure (MonoidHom.ker f : Set (FreeGroup G)))
+      (Subgroup.normalClosure_eq_self (MonoidHom.ker f)).symm
   e₂.symm.trans e₁
 
 /-- Every group is isomorphic to some presented group. -/
 theorem exists_presentation (G : Type u) [Group G] :
     ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels) := by
-  exact ⟨G, ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)),
-    ⟨(freeGroupProdKerEquiv G).symm⟩⟩
+  let rels : Set (FreeGroup G) := ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G))
+  exact ⟨G, rels, ⟨(freeGroupProdKerEquiv G).symm⟩⟩
 
 instance (rels : Set (FreeGroup α)) : Inhabited (PresentedGroup rels) :=
   ⟨1⟩

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -23,7 +23,8 @@ given by generators `x : α` and relations `r ∈ rels`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
 * `toGroup f`: the canonical group homomorphism `PresentedGroup rels → G`, given a function
   `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
-* `IsPresented G`: a group `G` is isomorphic to some `PresentedGroup rels`.
+* `exists_presentation G`: every group `G` is isomorphic to some
+  `PresentedGroup rels`.
 
 ## Tags
 
@@ -166,12 +167,9 @@ theorem equivPresentedGroup_symm_apply_of (x : β) (rels : Set (FreeGroup α)) (
 
 end ToGroup
 
-/-- A group is presented if it admits an isomorphism to a presented group. -/
-def IsPresented (G : Type u) [Group G] : Prop :=
-  ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels)
-
 /-- Every group is isomorphic to a presented group. -/
-theorem isPresented (G : Type u) [Group G] : IsPresented G := by
+theorem exists_presentation (G : Type u) [Group G] :
+    ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels) := by
   let F : FreeGroup (ULift G) →* G := FreeGroup.lift ULift.down
   have hF : Function.Surjective F := by
     intro g

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Subgroup.Basic
 public import Mathlib.GroupTheory.FreeGroup.Basic
+public import Mathlib.GroupTheory.QuotientGroup.Basic
 public import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
@@ -22,6 +23,7 @@ given by generators `x : α` and relations `r ∈ rels`.
 * `of`: The canonical map from `α` to a presented group with generators `α`.
 * `toGroup f`: the canonical group homomorphism `PresentedGroup rels → G`, given a function
   `f : α → G` from a type `α` to a group `G` which satisfies the relations `rels`.
+* `IsPresented G`: a group `G` is isomorphic to some `PresentedGroup rels`.
 
 ## Tags
 
@@ -29,6 +31,8 @@ generators, relations, group presentations
 -/
 
 @[expose] public section
+
+universe u
 
 
 variable {α : Type*}
@@ -142,6 +146,8 @@ theorem ext {φ ψ : PresentedGroup rels →* G} (hx : ∀ (x : α), φ (.of x) 
 
 variable {β : Type*}
 
+
+
 /-- Presented groups of isomorphic types are isomorphic. -/
 def equivPresentedGroup (rels : Set (FreeGroup α)) (e : α ≃ β) :
     PresentedGroup rels ≃* PresentedGroup (FreeGroup.freeGroupCongr e '' rels) :=
@@ -159,6 +165,31 @@ theorem equivPresentedGroup_symm_apply_of (x : β) (rels : Set (FreeGroup α)) (
       PresentedGroup.of (rels := rels) (e.symm x) := rfl
 
 end ToGroup
+
+/-- A group is presented if it admits an isomorphism to a presented group. -/
+def IsPresented (G : Type u) [Group G] : Prop :=
+  ∃ (α : Type u) (rels : Set (FreeGroup α)), Nonempty (G ≃* PresentedGroup rels)
+
+/-- Every group is isomorphic to a presented group. -/
+theorem isPresented (G : Type u) [Group G] : IsPresented G := by
+  let F : FreeGroup (ULift G) →* G := FreeGroup.lift ULift.down
+  have hF : Function.Surjective F := by
+    intro g
+    refine ⟨FreeGroup.of (ULift.up g), ?_⟩
+    simp [F]
+  refine ⟨ULift G, (MonoidHom.ker F : Set (FreeGroup (ULift G))), ?_⟩
+  refine ⟨?_⟩
+  let e₁ : FreeGroup (ULift G) ⧸ MonoidHom.ker F ≃* G :=
+    QuotientGroup.quotientKerEquivOfSurjective (φ := F) hF
+  let e₂ : FreeGroup (ULift G) ⧸ MonoidHom.ker F ≃*
+      PresentedGroup (MonoidHom.ker F : Set (FreeGroup (ULift G))) :=
+    by
+      simpa [PresentedGroup] using
+        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup (ULift G))
+          (M := MonoidHom.ker F)
+          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup (ULift G))))
+          (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm)
+  exact e₁.symm.trans e₂
 
 instance (rels : Set (FreeGroup α)) : Inhabited (PresentedGroup rels) :=
   ⟨1⟩

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -170,24 +170,21 @@ theorem equivPresentedGroup_symm_apply_of (x : β) (rels : Set (FreeGroup α)) (
 end ToGroup
 
 /-- The canonical isomorphism from a presented group to the underlying group,
-with the group elements as generators and relations given by
+with the group elements as free group generators and relations given by
 `(FreeGroup.prod : FreeGroup G →* G).ker`. -/
 def freeGroupProdKerEquiv (G : Type*) [Group G] :
-  PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G := by
+  PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G :=
   let F : FreeGroup G →* G := FreeGroup.prod
   let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=
-    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of (by
-      intro g
-      simp [F])
+    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of
+      (fun g => FreeGroup.prod.of (x := g))
   let e₂ : FreeGroup G ⧸ MonoidHom.ker F ≃*
       PresentedGroup (MonoidHom.ker F : Set (FreeGroup G)) :=
-    by
-      simpa [PresentedGroup] using
-        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
-          (M := MonoidHom.ker F)
-          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
-          (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm)
-  exact e₂.symm.trans e₁
+    QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
+      (M := MonoidHom.ker F)
+      (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
+      (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm
+  e₂.symm.trans e₁
 
 /-- Every group is isomorphic to some presented group. -/
 theorem exists_presentation (G : Type u) [Group G] :

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -174,19 +174,20 @@ with the group elements as generators and relations given by
 `(FreeGroup.prod : FreeGroup G →* G).ker`. -/
 def freeGroupProdKerEquiv (G : Type*) [Group G] :
   PresentedGroup ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃* G := by
-  let e : FreeGroup G ⧸ Subgroup.normalClosure
-      ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)) ≃*
-      FreeGroup G ⧸ (FreeGroup.prod : FreeGroup G →* G).ker :=
-    QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
-      (M := Subgroup.normalClosure ((FreeGroup.prod : FreeGroup G →* G).ker : Set (FreeGroup G)))
-      (N := (FreeGroup.prod : FreeGroup G →* G).ker)
-      (Subgroup.normalClosure_eq_self (MonoidHom.ker (FreeGroup.prod : FreeGroup G →* G)))
-  let e' : FreeGroup G ⧸ (FreeGroup.prod : FreeGroup G →* G).ker ≃* G := by
-    simpa using (QuotientGroup.quotientKerEquivOfRightInverse
-      (φ := (FreeGroup.prod : FreeGroup G →* G)) FreeGroup.of (by
-        intro g
-        simp))
-  simpa [PresentedGroup] using e.trans e'
+  let F : FreeGroup G →* G := FreeGroup.prod
+  let e₁ : FreeGroup G ⧸ MonoidHom.ker F ≃* G :=
+    QuotientGroup.quotientKerEquivOfRightInverse (φ := F) FreeGroup.of (by
+      intro g
+      simp [F])
+  let e₂ : FreeGroup G ⧸ MonoidHom.ker F ≃*
+      PresentedGroup (MonoidHom.ker F : Set (FreeGroup G)) :=
+    by
+      simpa [PresentedGroup] using
+        (QuotientGroup.quotientMulEquivOfEq (G := FreeGroup G)
+          (M := MonoidHom.ker F)
+          (N := Subgroup.normalClosure (MonoidHom.ker F : Set (FreeGroup G)))
+          (Subgroup.normalClosure_eq_self (MonoidHom.ker F)).symm)
+  exact e₂.symm.trans e₁
 
 /-- Every group is isomorphic to some presented group. -/
 theorem exists_presentation (G : Type u) [Group G] :

--- a/Mathlib/GroupTheory/PresentedGroup.lean
+++ b/Mathlib/GroupTheory/PresentedGroup.lean
@@ -37,7 +37,6 @@ generators, relations, group presentations
 
 universe u
 
-
 variable {α : Type*}
 
 /-- Given a set of relations, `rels`, over a type `α`, `PresentedGroup` constructs the group with
@@ -148,8 +147,6 @@ theorem ext {φ ψ : PresentedGroup rels →* G} (hx : ∀ (x : α), φ (.of x) 
   apply hx
 
 variable {β : Type*}
-
-
 
 /-- Presented groups of isomorphic types are isomorphic. -/
 def equivPresentedGroup (rels : Set (FreeGroup α)) (e : α ≃ β) :


### PR DESCRIPTION
We show that every group has a presentation defined by taking the free group with all of the group elements as the generators, and defining the relations as the kernel of the induced subjective homomorphism from that free group to the group itself. 

Use of AI: This has been vibe-coded with GPT-Codex-5.3, was updated through review, and was double-checked by the author. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
