### PR TITLE
[Merged by Bors] - chore(Order/Defs/LinearOrder): avoid `grind` in very fundamental lemmas

### DIFF
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -193,16 +193,14 @@ lemma lt_min (h₁ : a < b) (h₂ : a < c) : a < min b c := by
 section Ord
 
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  simp [apply_ite (· = Ordering.lt)]
-
-lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  simpa [apply_ite (· = Ordering.gt), ne_iff_lt_or_gt, and_or_left, - not_lt] using not_lt_of_gt
+  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq_eq_lt]
 
 lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
-  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  simp +contextual [apply_ite (· = Ordering.eq)]
+  rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq_eq_eq le_refl not_le]
+
+lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
+  rw [lt_iff_not_ge, Decidable.le_iff_lt_or_eq, ← compare_lt_iff_lt, ← compare_eq_iff_eq (a := a)]
+  cases compare a b <;> decide
 
 lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
   cases h : compare a b

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -164,15 +164,12 @@ lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
 @[to_dual]
-lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  apply eq_min
-  · apply le_trans (min_le_left ..) (min_le_left ..)
-  · apply le_min
-    · apply le_trans (min_le_left ..) (min_le_right ..)
-    · apply min_le_right
-  · intro d h₁ h₂; apply le_min
-    · apply le_min h₁; apply le_trans h₂; apply min_le_left
-    · apply le_trans h₂; apply min_le_right
+lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
+  eq_min
+    (le_trans (min_le_left ..) (min_le_left ..))
+    (le_min (le_trans (min_le_left ..) (min_le_right ..)) (min_le_right ..))
+    (fun h₁ h₂ ↦
+      le_min (le_min h₁ (le_trans h₂ (min_le_left ..))) (le_trans h₂ (min_le_right ..)))
 
 @[to_dual]
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -94,24 +94,21 @@ instance : Std.IsLinearOrder α where
 @[to_dual self] lemma le_of_not_ge : ¬a ≤ b → b ≤ a := (le_total a b).resolve_left
 @[to_dual self] lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 
-@[to_dual gt_trichotomy]
-lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
-  cases le_total a b with
-  | _ h =>
-    cases Decidable.lt_or_eq_of_le h with | _ h => simp [h]
-
-@[to_dual self]
-lemma le_of_not_gt (h : ¬b < a) : a ≤ b := by
-  obtain hlt | heq | hgt := lt_trichotomy a b
-  exacts [le_of_lt hlt, heq ▸ le_refl a, absurd hgt h]
-
 @[to_dual self] lemma lt_or_ge (a b : α) : a < b ∨ b ≤ a :=
   if hba : b ≤ a then Or.inr hba else Or.inl <| lt_of_not_ge hba
 
 @[to_dual self] lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
+@[to_dual gt_trichotomy]
+lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a :=
+  (lt_or_ge a b).imp_right (fun h ↦ (Decidable.lt_or_eq_of_le' h).symm)
+
+@[to_dual self]
+lemma le_of_not_gt (h : ¬b < a) : a ≤ b := (le_or_gt a b).resolve_right h
+
 @[to_dual gt_or_lt_of_ne]
-lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by simpa [h] using lt_trichotomy a b
+lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a :=
+  (lt_trichotomy a b).imp_right (fun h' ↦ h'.resolve_left h)
 
 @[to_dual ne_iff_gt_or_lt]
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
@@ -181,7 +178,7 @@ lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
   rw [← min_assoc, min_comm a, min_assoc]
 
-@[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by simp [min_def]
+@[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by rw [min_def, ite_id]
 
 @[to_dual]
 lemma min_eq_left (h : a ≤ b) : min a b = a := (eq_min le_rfl h (fun h _ ↦ h)).symm

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -199,8 +199,8 @@ lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq_eq_eq le_refl not_le]
 
 lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
-  rw [lt_iff_not_ge, Decidable.le_iff_lt_or_eq, ← compare_lt_iff_lt, ← compare_eq_iff_eq (a := a)]
-  cases compare a b <;> decide
+  rw [LinearOrder.compare_eq_compareOfLessAndEq,
+    compareOfLessAndEq_eq_gt le_antisymm le_total not_le]
 
 lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
   cases h : compare a b

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -101,11 +101,9 @@ lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
     cases Decidable.lt_or_eq_of_le h with | _ h => simp [h]
 
 @[to_dual self]
-lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
-  match lt_trichotomy a b with
-  | Or.inl hlt => le_of_lt hlt
-  | Or.inr (Or.inl HEq) => HEq ▸ le_refl a
-  | Or.inr (Or.inr hgt) => absurd hgt h
+lemma le_of_not_gt (h : ¬b < a) : a ≤ b := by
+  obtain hlt | heq | hgt := lt_trichotomy a b
+  exacts [le_of_lt hlt, heq ▸ le_refl a, absurd hgt h]
 
 @[to_dual self] lemma lt_or_ge (a b : α) : a < b ∨ b ≤ a :=
   if hba : b ≤ a then Or.inr hba else Or.inl <| lt_of_not_ge hba
@@ -139,13 +137,11 @@ lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max
 
 @[to_dual existing max_def]
 theorem min_def' (a b : α) : min a b = if b ≤ a then b else a := by
-  match lt_trichotomy a b with
-  | .inl h | .inr (.inl h) | .inr (.inr h) => simp [le_of_lt, not_le_of_gt, h, min_def]
+  obtain h | h | h := lt_trichotomy a b <;> simp [le_of_lt, not_le_of_gt, h, min_def]
 
 @[to_dual existing min_def]
 theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by
-  match lt_trichotomy a b with
-  | .inl h | .inr (.inl h) | .inr (.inr h) => simp [le_of_lt, not_le_of_gt, h, max_def]
+  obtain h | h | h := lt_trichotomy a b <;> simp [le_of_lt, not_le_of_gt, h, max_def]
 
 @[to_dual le_max_left]
 lemma min_le_left (a b : α) : min a b ≤ a := by

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -96,7 +96,7 @@ instance : Std.IsLinearOrder α where
 
 @[to_dual gt_trichotomy]
 lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
-  cases le_total (a := a) (b := b) with
+  cases le_total a b with
   | _ h =>
     cases Decidable.lt_or_eq_of_le h with | _ h => simp [h]
 

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -19,6 +19,9 @@ public import Mathlib.Order.Defs.PartialOrder
 # Orders
 
 Defines classes for linear orders and proves some basic lemmas about them.
+
+We intentionally avoid using `grind` in this fundamental file to keep the proofs understandable,
+rather than hiding the reasoning behind automation.
 -/
 
 @[expose] public section
@@ -144,38 +147,20 @@ theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by
   match lt_trichotomy a b with
   | .inl h | .inr (.inl h) | .inr (.inr h) => simp [le_of_lt, not_le_of_gt, h, max_def]
 
-@[to_dual le_min_iff]
-theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c := by
-  rw [max_def]
-  split_ifs with h
-  · simpa using le_trans h
-  · simpa using le_trans (le_of_not_ge h)
-
-instance : Std.LawfulOrderMin α where
-  min_eq_or a b := by
-    rw [min_def]
-    split_ifs <;> simp
-  le_min_iff _ _ _ := le_min_iff
-
-instance : Std.LawfulOrderMax α where
-  max_eq_or a b := by
-    rw [max_def]
-    split_ifs <;> simp
-  max_le_iff _ _ _ := max_le_iff
-
-theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c := Std.le_max
-
-@[to_dual existing le_max_iff]
-theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c := Std.min_le
-
 @[to_dual le_max_left]
-lemma min_le_left (a b : α) : min a b ≤ a := min_le_iff.mpr (.inl le_rfl)
+lemma min_le_left (a b : α) : min a b ≤ a := by
+  rw [min_def]
+  split_ifs with h <;> simp [h, le_of_not_ge]
 
 @[to_dual le_max_right]
-lemma min_le_right (a b : α) : min a b ≤ b := min_le_iff.mpr (.inr le_rfl)
+lemma min_le_right (a b : α) : min a b ≤ b := by
+  rw [min_def]
+  split_ifs with h <;> simp [h]
 
 @[to_dual max_le]
-lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := le_min_iff.mpr ⟨h₁, h₂⟩
+lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
+  rw [min_def]
+  split_ifs <;> assumption
 
 @[to_dual]
 lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) : c = min a b :=
@@ -187,7 +172,14 @@ lemma min_comm (a b : α) : min a b = min b a :=
 
 @[to_dual]
 lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  apply le_antisymm <;> simp [min_le_iff, le_min_iff]
+  apply eq_min
+  · apply le_trans (min_le_left ..) (min_le_left ..)
+  · apply le_min
+    · apply le_trans (min_le_left ..) (min_le_right ..)
+    · apply min_le_right
+  · intro d h₁ h₂; apply le_min
+    · apply le_min h₁; apply le_trans h₂; apply min_le_left
+    · apply le_trans h₂; apply min_le_right
 
 @[to_dual]
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -92,7 +92,10 @@ instance : Std.IsLinearOrder α where
 @[to_dual self] lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 
 @[to_dual gt_trichotomy]
-lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by grind
+lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
+  cases le_total (a := a) (b := b) with
+  | _ h =>
+    cases Decidable.lt_or_eq_of_le h with | _ h => simp [h]
 
 @[to_dual self]
 lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
@@ -107,7 +110,7 @@ lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
 @[to_dual self] lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
 @[to_dual gt_or_lt_of_ne]
-lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by grind
+lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by simpa [h] using lt_trichotomy a b
 
 @[to_dual ne_iff_gt_or_lt]
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
@@ -132,19 +135,47 @@ lemma min_def (a b : α) : min a b = if a ≤ b then a else b := LinearOrder.min
 lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max_def a b
 
 @[to_dual existing max_def]
-theorem min_def' (a b : α) : min a b = if b ≤ a then b else a := by grind
+theorem min_def' (a b : α) : min a b = if b ≤ a then b else a := by
+  match lt_trichotomy a b with
+  | .inl h | .inr (.inl h) | .inr (.inr h) => simp [le_of_lt, not_le_of_gt, h, min_def]
 
 @[to_dual existing min_def]
-theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by grind
+theorem max_def' (a b : α) : max a b = if b ≤ a then a else b := by
+  match lt_trichotomy a b with
+  | .inl h | .inr (.inl h) | .inr (.inr h) => simp [le_of_lt, not_le_of_gt, h, max_def]
+
+@[to_dual le_min_iff]
+theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c := by
+  rw [max_def]
+  split_ifs with h
+  · simpa using le_trans h
+  · simpa using le_trans (le_of_not_ge h)
+
+instance : Std.LawfulOrderMin α where
+  min_eq_or a b := by
+    rw [min_def]
+    split_ifs <;> simp
+  le_min_iff _ _ _ := le_min_iff
+
+instance : Std.LawfulOrderMax α where
+  max_eq_or a b := by
+    rw [max_def]
+    split_ifs <;> simp
+  max_le_iff _ _ _ := max_le_iff
+
+theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c := Std.le_max
+
+@[to_dual existing le_max_iff]
+theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c := Std.min_le
 
 @[to_dual le_max_left]
-lemma min_le_left (a b : α) : min a b ≤ a := by grind
+lemma min_le_left (a b : α) : min a b ≤ a := min_le_iff.mpr (.inl le_rfl)
 
 @[to_dual le_max_right]
-lemma min_le_right (a b : α) : min a b ≤ b := by grind
+lemma min_le_right (a b : α) : min a b ≤ b := min_le_iff.mpr (.inr le_rfl)
 
 @[to_dual max_le]
-lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by grind
+lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := le_min_iff.mpr ⟨h₁, h₂⟩
 
 @[to_dual]
 lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) : c = min a b :=
@@ -155,15 +186,17 @@ lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
 @[to_dual]
-lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by grind
+lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
+  apply le_antisymm <;> simp [min_le_iff, le_min_iff]
 
 @[to_dual]
-lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by grind
+lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
+  rw [← min_assoc, min_comm a, min_assoc]
 
-@[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by grind
+@[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by simp [min_def]
 
 @[to_dual]
-lemma min_eq_left (h : a ≤ b) : min a b = a := by grind
+lemma min_eq_left (h : a ≤ b) : min a b = a := (eq_min le_rfl h (fun h _ ↦ h)).symm
 
 @[to_dual]
 lemma min_eq_right (h : b ≤ a) : min a b = b := min_comm b a ▸ min_eq_left h
@@ -179,15 +212,15 @@ section Ord
 
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  grind
+  simp [apply_ite (· = Ordering.lt)]
 
 lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  grind
+  simpa [apply_ite (· = Ordering.gt), ne_iff_lt_or_gt, and_or_left, - not_lt] using not_lt_of_gt
 
 lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  grind
+  simp +contextual [apply_ite (· = Ordering.eq)]
 
 lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
   cases h : compare a b

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -30,24 +30,6 @@ section
 variable [LinearOrder α] [LinearOrder β] {f : α → β} {s : Set α} {a b c d : α}
 
 -- translate from lattices to linear orders (sup → max, inf → min)
-theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
-  le_inf_iff
-
-theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
-  le_sup_iff
-
-theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
-  inf_le_iff
-
-theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
-  sup_le_iff
-
-instance [LinearOrder α] : Std.LawfulOrderSup α where
-  max_le_iff _ _ _ := max_le_iff
-
-instance [LinearOrder α] : Std.LawfulOrderInf α where
-  le_min_iff _ _ _ := le_min_iff
-
 theorem lt_min_iff : a < min b c ↔ a < b ∧ a < c :=
   lt_inf_iff
 

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -30,6 +30,24 @@ section
 variable [LinearOrder α] [LinearOrder β] {f : α → β} {s : Set α} {a b c d : α}
 
 -- translate from lattices to linear orders (sup → max, inf → min)
+theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
+  le_inf_iff
+
+theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
+  le_sup_iff
+
+theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
+  inf_le_iff
+
+theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
+  sup_le_iff
+
+instance [LinearOrder α] : Std.LawfulOrderSup α where
+  max_le_iff _ _ _ := max_le_iff
+
+instance [LinearOrder α] : Std.LawfulOrderInf α where
+  le_min_iff _ _ _ := le_min_iff
+
 theorem lt_min_iff : a < min b c ↔ a < b ∧ a < c :=
   lt_inf_iff
 


### PR DESCRIPTION
Some lemmas can be optimized more elegantly, but it requires moving lemmas from other files, so I will do it in a subsequent PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2334013.20chore.3A.20golf.20with.20grind.20to.20reduce.20explicit.20lemma.20refer/near/570429476)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
