### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
@@ -180,7 +180,6 @@ theorem compExactValue_correctness_of_stream_eq_some :
       have tmp_calc' :=
         compExactValue_correctness_of_stream_eq_some_aux_comp pB ppB ifp_succ_n_fr_ne_zero
       let f := Int.fract (1 / ifp_n.fr)
-      have f_ne_zero : f ≠ 0 := by simpa [f] using ifp_succ_n_fr_ne_zero
       -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
       dsimp only [conts, pconts, ppconts]
       have hfr : (IntFractPair.of (1 / ifp_n.fr)).fr = f := rfl

--- a/Mathlib/Algebra/Homology/ExactSequenceFour.lean
+++ b/Mathlib/Algebra/Homology/ExactSequenceFour.lean
@@ -113,7 +113,6 @@ lemma epi_cokerToKer' (hS' : (S.sc hS (k + 1)).Exact) :
     Epi (hS.cokerToKer' k hk cc kf hcc hkf) := by
   have := hS'.hasZeroObject
   have := hS'.hasHomology
-  have : Epi cc.π := ⟨fun _ _ => Cofork.IsColimit.hom_ext hcc⟩
   let h := hS'.leftHomologyDataOfIsLimitKernelFork kf hkf
   have := h.exact_iff_epi_f'.1 hS'
   have fac : cc.π ≫ hS.cokerToKer' k hk cc kf hcc hkf = h.f' := by
@@ -126,7 +125,6 @@ lemma mono_cokerToKer' (hS' : (S.sc hS k).Exact) :
     Mono (hS.cokerToKer' k hk cc kf hcc hkf) := by
   have := hS'.hasZeroObject
   have := hS'.hasHomology
-  have : Mono kf.ι := ⟨fun _ _ => Fork.IsLimit.hom_ext hkf⟩
   let h := hS'.rightHomologyDataOfIsColimitCokernelCofork cc hcc
   have := h.exact_iff_mono_g'.1 hS'
   have fac : hS.cokerToKer' k hk cc kf hcc hkf ≫ kf.ι = h.g' := by

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -260,7 +260,6 @@ lemma ComplexShape.quotient_isLocalization :
 lemma ComplexShape.QFactorsThroughHomotopy_of_exists_prev [CategoryWithHomology C] :
     c.QFactorsThroughHomotopy C where
   areEqualizedByLocalization {K L f g} h := by
-    have : DecidableRel c.Rel := by classical infer_instance
     exact h.map_eq_of_inverts_homotopyEquivalences hc _
       (MorphismProperty.IsInvertedBy.of_le _ _ _
         (Localization.inverts _ (HomologicalComplex.quasiIso C _))

--- a/Mathlib/AlgebraicGeometry/FunctionField.lean
+++ b/Mathlib/AlgebraicGeometry/FunctionField.lean
@@ -128,7 +128,6 @@ theorem IsAffineOpen.primeIdealOf_genericPoint {X : Scheme} [IsIntegral X] {U : 
         ⟨genericPoint X,
           ((genericPoint_spec X).mem_open_set_iff U.isOpen).mpr (by simpa using h)⟩ =
       genericPoint (Spec Γ(X, U)) := by
-  haveI : IsAffine _ := hU
   delta IsAffineOpen.primeIdealOf
   convert
     genericPoint_eq_of_isOpenImmersion
@@ -141,10 +140,6 @@ set_option backward.isDefEq.respectTransparency false in
 theorem functionField_isFractionRing_of_isAffineOpen [IsIntegral X] (U : X.Opens)
     (hU : IsAffineOpen U) [Nonempty U] :
     IsFractionRing Γ(X, U) X.functionField := by
-  haveI : IsAffine _ := hU
-  haveI : IsIntegral U :=
-    @isIntegral_of_isAffine_of_isDomain _ _ _ (by rw [Scheme.Opens.toScheme_presheaf_obj,
-      U.ι.image_top_eq_opensRange, U.opensRange_ι]; infer_instance)
   delta IsFractionRing Scheme.functionField
   convert hU.isLocalization_stalk ⟨genericPoint X,
     (((genericPoint_spec X).mem_open_set_iff U.isOpen).mpr (by simpa using ‹Nonempty U›))⟩ using 1

--- a/Mathlib/AlgebraicGeometry/Group/Smooth.lean
+++ b/Mathlib/AlgebraicGeometry/Group/Smooth.lean
@@ -55,7 +55,6 @@ lemma smooth_of_grpObj_of_isAlgClosed : Smooth f := by
     simp [comp_lift_assoc]
   have hα' : α.hom.left x = y := by
     simpa [x', y', pointEquivClosedPoint] using congr(($hα).left (IsLocalRing.closedPoint K))
-  have hαf : α.hom.left ≫ f = f := α.hom.w
   rw! [← hα', ← α.hom.left.mem_preimage, Scheme.Hom.preimage_smoothLocus_eq,
     show α.hom.left ≫ f = f from α.hom.w] at hy
   exact hx hy

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -817,8 +817,6 @@ lemma Hom.iUnion_support_ker_openCover_map_comp
 lemma ker_morphismRestrict_ideal (f : X.Hom Y) [QuasiCompact f]
     (U : Y.Opens) (V : U.toScheme.affineOpens) :
     (f ∣_ U).ker.ideal V = f.ker.ideal ⟨U.ι ''ᵁ V, V.2.image_of_isOpenImmersion _⟩ := by
-  have inst : QuasiCompact (f ∣_ U) := MorphismProperty.of_isPullback
-      (isPullback_morphismRestrict _ _).flip inferInstance
   ext x
   simpa [Scheme.Hom.appLE] using map_eq_zero_iff _
     (ConcreteCategory.bijective_of_isIso

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
@@ -109,7 +109,6 @@ lemma isLocalization_away {U V : X.affineOpens}
       letI := (Ideal.quotientMap _ _ (I.ideal_le_comap_ideal h)).toAlgebra
       IsLocalization.Away (Ideal.Quotient.mk (I.ideal V) f) (Γ(X, U) ⧸ (I.ideal U)) := by
   letI := (Ideal.quotientMap _ _ (I.ideal_le_comap_ideal h)).toAlgebra
-  let f' : Γ(X, V) ⧸ I.ideal V := Ideal.Quotient.mk _ f
   letI := (X.presheaf.map (homOfLE (X := X.Opens) h).op).hom.toAlgebra
   have : IsLocalization.Away f Γ(X, U) := by
     subst hU; exact V.2.isLocalization_of_eq_basicOpen _ _ rfl

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -78,7 +78,6 @@ lemma affineAnd_isLocal (hPi : RingHom.RespectsIso Q) (hQl : RingHom.Localizatio
       rw [(isAffineOpen_top Y).app_basicOpen_eq_away_map f (isAffineOpen_top X),
         CommRingCat.hom_comp, hPi.cancel_right_isIso, ← Scheme.Hom.appTop]
       dsimp only [Opens.map_top]
-      haveI := (isAffineOpen_top X).isLocalization_basicOpen (f.appTop r)
       apply hQl
       exact hf
   of_basicOpenCover {X Y _} f s hs hf := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -542,7 +542,6 @@ theorem of_iSup_eq_top
   intro V
   induction V using of_affine_open_cover U hU with
   | basicOpen U r h =>
-    haveI : IsAffine _ := U.2
     have := AffineTargetMorphismProperty.IsLocal.to_basicOpen (f ∣_ U.1) (U.1.topIso.inv r) h
     exact (Q.arrow_mk_iso_iff
       (morphismRestrictRestrictBasicOpen f _ r)).mp this
@@ -578,8 +577,6 @@ theorem iff_of_openCover (𝒰 : Y.OpenCover) [∀ i, IsAffine (𝒰.X i)] :
 
 theorem iff_of_isAffine [IsAffine Y] : P f ↔ Q f := by
   letI := isLocal_affineProperty P
-  haveI : ∀ i, IsAffine ((Scheme.coverOfIsIso (P := @IsOpenImmersion) (𝟙 Y)).X i) := fun i => by
-    dsimp; infer_instance
   rw [iff_of_openCover (P := P) (Scheme.coverOfIsIso.{0} (𝟙 Y))]
   trans Q (pullback.snd f (𝟙 _))
   · exact ⟨fun H => H PUnit.unit, fun H _ => H⟩

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -245,7 +245,6 @@ set_option backward.isDefEq.respectTransparency false in
 lemma isDominant_of_of_appTop_injective [CompactSpace X]
     (hfinj : Function.Injective (f.appTop)) :
     IsDominant f := by
-  have : QuasiCompact f := HasAffineProperty.iff_of_isAffine.mpr ‹_›
   have : f.ker = ⊥ := Scheme.IdealSheafData.ext_of_isAffine
     (by simpa [f.ker_apply ⟨⊤, isAffineOpen_top Y⟩, ← RingHom.injective_iff_ker_eq_bot])
   exact ⟨by simpa only [Scheme.Hom.support_ker, Scheme.IdealSheafData.support_bot,

--- a/Mathlib/AlgebraicGeometry/Morphisms/Preimmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Preimmersion.lean
@@ -80,9 +80,6 @@ theorem comp_iff {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) [IsPreimmersion g]
 lemma SpecMap_iff {R S : CommRingCat.{u}} (f : R ⟶ S) :
     IsPreimmersion (Spec.map f) ↔ IsEmbedding (PrimeSpectrum.comap f.hom) ∧
       f.hom.SurjectiveOnStalks := by
-  haveI : (RingHom.toMorphismProperty <| fun f ↦ Function.Surjective f).RespectsIso := by
-    rw [← RingHom.toMorphismProperty_respectsIso_iff]
-    exact RingHom.surjective_respectsIso
   rw [← HasRingHomProperty.Spec_iff (P := @SurjectiveOnStalks), isPreimmersion_iff, and_comm]
   rfl
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -93,8 +93,6 @@ theorem quasiCompact_affineProperty_iff_quasiSeparatedSpace [IsAffine Y] (f : X 
   rw [quasiSeparatedSpace_iff_forall_affineOpens]
   constructor
   · intro H U V
-    haveI : IsAffine _ := U.2
-    haveI : IsAffine _ := V.2
     let g : pullback U.1.ι V.1.ι ⟶ X := pullback.fst _ _ ≫ U.1.ι
     have e := g.isOpenEmbedding.isEmbedding.toHomeomorph
     rw [IsOpenImmersion.range_pullback_to_base_of_left] at e


### PR DESCRIPTION
This PR removes unused `have`/`haveI`/`let`/`letI` calls.

The goal of this PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `GenContFract.compExactValue_correctness_of_stream_eq_some`: unchanged 🎉
* `Finset.disjoint_range_addLeftEmbedding`: unchanged 🎉
* `CategoryTheory.ComposableArrows.IsComplex.epi_cokerToKer'`: unchanged 🎉
* `CategoryTheory.ComposableArrows.IsComplex.mono_cokerToKer'`: unchanged 🎉
* `ComplexShape.QFactorsThroughHomotopy_of_exists_prev`: unchanged 🎉
* `AlgebraicGeometry.IsAffineOpen.primeIdealOf_genericPoint`: unchanged 🎉
* `AlgebraicGeometry.functionField_isFractionRing_of_isAffineOpen`: unchanged 🎉
* `AlgebraicGeometry.smooth_of_grpObj_of_isAlgClosed`: 266 ms before, 232 ms after  🎉
* `AlgebraicGeometry.Scheme.ker_morphismRestrict_ideal`: 570 ms before, 538 ms after  🎉
* `AlgebraicGeometry.Scheme.IdealSheafData.isLocalization_away`: unchanged 🎉
* `AlgebraicGeometry.affineAnd_isLocal`: unchanged 🎉
* `AlgebraicGeometry.IsZariskiLocalAtTarget.of_iSup_eq_top`: unchanged 🎉
* `AlgebraicGeometry.HasAffineProperty.iff_of_isAffine`: unchanged 🎉
* `AlgebraicGeometry.isDominant_of_of_appTop_injective`: unchanged 🎉
* `AlgebraicGeometry.IsPreimmersion.SpecMap_iff`: unchanged 🎉
* `AlgebraicGeometry.quasiCompact_affineProperty_iff_quasiSeparatedSpace`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
