### PR TITLE
feat(Logic.Equiv.BijectiveBase2): add bijective base-2 numeration

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4952,7 +4952,6 @@ public import Mathlib.Logic.Encodable.Lattice
 public import Mathlib.Logic.Encodable.Pi
 public import Mathlib.Logic.Equiv.Array
 public import Mathlib.Logic.Equiv.Basic
-public import Mathlib.Logic.Equiv.BijectiveBase2
 public import Mathlib.Logic.Equiv.Bool
 public import Mathlib.Logic.Equiv.Defs
 public import Mathlib.Logic.Equiv.Embedding
@@ -4962,6 +4961,7 @@ public import Mathlib.Logic.Equiv.Finset
 public import Mathlib.Logic.Equiv.Fintype
 public import Mathlib.Logic.Equiv.Functor
 public import Mathlib.Logic.Equiv.List
+public import Mathlib.Logic.Equiv.ListNatBijective
 public import Mathlib.Logic.Equiv.Multiset
 public import Mathlib.Logic.Equiv.Nat
 public import Mathlib.Logic.Equiv.Option

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4952,6 +4952,7 @@ public import Mathlib.Logic.Encodable.Lattice
 public import Mathlib.Logic.Encodable.Pi
 public import Mathlib.Logic.Equiv.Array
 public import Mathlib.Logic.Equiv.Basic
+public import Mathlib.Logic.Equiv.BijectiveBase2
 public import Mathlib.Logic.Equiv.Bool
 public import Mathlib.Logic.Equiv.Defs
 public import Mathlib.Logic.Equiv.Embedding

--- a/Mathlib/Logic/Equiv/BijectiveBase2.lean
+++ b/Mathlib/Logic/Equiv/BijectiveBase2.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Alexey Milovanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alexey Milovanov
+-/
+import Mathlib.Data.List.Basic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Logic.Equiv.Basic
+
+/-!
+# Bijective Base-2 Numeration
+
+This module formalizes a bijective base-2 numeration system.
+Unlike standard binary representation, bijective base-2 numeration avoids the
+"leading zeros" problem, providing a strict bijection `ℕ ≃ List Bool`.
+-/
+
+namespace Equiv.BijectiveBase2
+
+/-- Encodes a natural number into a list of booleans using bijective base-2. -/
+def toBits (n : ℕ) : List Bool :=
+  if h : n = 0 then []
+  else ((n - 1) % 2 == 1) :: toBits ((n - 1) / 2)
+termination_by n
+decreasing_by omega
+
+@[simp] lemma toBits_zero : toBits 0 = [] := by rw [toBits]; simp
+
+/-- Decodes a list of booleans into a natural number using bijective base-2.
+    [] ↦ 0, [false] ↦ 1, [true] ↦ 2, [false, false] ↦ 3. -/
+def ofBits : List Bool → ℕ
+  | [] => 0
+  | false :: bs => 1 + 2 * ofBits bs
+  | true :: bs => 2 + 2 * ofBits bs
+
+@[simp] lemma ofBits_nil : ofBits [] = 0 := rfl
+
+/-- Proves that decoding the encoded bijective base-2 bits of a natural number
+returns the original number. -/
+@[simp]
+theorem ofBits_toBits (n : ℕ) : ofBits (toBits n) = n := by
+  rw [toBits]
+  split_ifs with h
+  · subst h; rfl
+  · have ih := ofBits_toBits ((n - 1) / 2)
+    have h_mod : (n - 1) % 2 = 0 ∨ (n - 1) % 2 = 1 := by omega
+    rcases h_mod with h0 | h1
+    · simp [h0, ofBits, ih]
+      omega
+    · simp [h1, ofBits, ih]
+      omega
+termination_by n
+decreasing_by omega
+
+/-- Proves that encoding the decoded natural number of bijective base-2 bits
+returns the original bits. -/
+@[simp]
+theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
+  induction bs with
+  | nil => simp
+  | cons b bs ih =>
+    cases b
+    · change toBits (1 + 2 * ofBits bs) = false :: bs
+      rw [toBits]
+      split_ifs with h
+      · omega
+      · have h_math : 1 + 2 * ofBits bs - 1 = 2 * ofBits bs := by omega
+        have h_div : (2 * ofBits bs) / 2 = ofBits bs := by omega
+        have h_mod : (2 * ofBits bs) % 2 = 0 := by omega
+        simp [h_math, h_div, h_mod, ih]
+    · change toBits (2 + 2 * ofBits bs) = true :: bs
+      rw [toBits]
+      split_ifs with h
+      · omega
+      · have h_math : 2 + 2 * ofBits bs - 1 = 1 + 2 * ofBits bs := by omega
+        have h_div : (1 + 2 * ofBits bs) / 2 = ofBits bs := by omega
+        have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by omega
+        simp [h_math, h_div, h_mod, ih]
+
+end Equiv.BijectiveBase2
+
+/-- The formal mathematical bijection between Natural Numbers and Boolean Lists
+using bijective base-2 numeration. -/
+def equivBijectiveBase2 : ℕ ≃ List Bool where
+  toFun := Equiv.BijectiveBase2.toBits
+  invFun := Equiv.BijectiveBase2.ofBits
+  left_inv := Equiv.BijectiveBase2.ofBits_toBits
+  right_inv := Equiv.BijectiveBase2.toBits_ofBits

--- a/Mathlib/Logic/Equiv/ListNatBijective.lean
+++ b/Mathlib/Logic/Equiv/ListNatBijective.lean
@@ -26,7 +26,7 @@ def toBits (n : ℕ) : List Bool :=
   if h : n = 0 then []
   else ((n - 1) % 2 == 1) :: toBits ((n - 1) / 2)
 termination_by n
-decreasing_by omega
+decreasing_by lia
 
 @[simp] lemma toBits_zero : toBits 0 = [] := by rw [toBits]; simp
 
@@ -47,14 +47,14 @@ theorem ofBits_toBits (n : ℕ) : ofBits (toBits n) = n := by
   split_ifs with h
   · subst h; rfl
   · have ih := ofBits_toBits ((n - 1) / 2)
-    have h_mod : (n - 1) % 2 = 0 ∨ (n - 1) % 2 = 1 := by omega
+    have h_mod : (n - 1) % 2 = 0 ∨ (n - 1) % 2 = 1 := by lia
     rcases h_mod with h0 | h1
     · simp [h0, ofBits, ih]
-      omega
+      lia
     · simp [h1, ofBits, ih]
-      omega
+      lia
 termination_by n
-decreasing_by omega
+decreasing_by lia
 
 /-- Proves that encoding the decoded natural number of bijective base-2 bits
 returns the original bits. -/
@@ -67,18 +67,18 @@ theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
     · change toBits (1 + 2 * ofBits bs) = false :: bs
       rw [toBits]
       split_ifs with h
-      · omega
-      · have h_math : 1 + 2 * ofBits bs - 1 = 2 * ofBits bs := by omega
-        have h_div : (2 * ofBits bs) / 2 = ofBits bs := by omega
-        have h_mod : (2 * ofBits bs) % 2 = 0 := by omega
+      · lia
+      · have h_math : 1 + 2 * ofBits bs - 1 = 2 * ofBits bs := by lia
+        have h_div : (2 * ofBits bs) / 2 = ofBits bs := by lia
+        have h_mod : (2 * ofBits bs) % 2 = 0 := by lia
         simp [h_math, h_div, h_mod, ih]
     · change toBits (2 + 2 * ofBits bs) = true :: bs
       rw [toBits]
       split_ifs with h
-      · omega
-      · have h_math : 2 + 2 * ofBits bs - 1 = 1 + 2 * ofBits bs := by omega
-        have h_div : (1 + 2 * ofBits bs) / 2 = ofBits bs := by omega
-        have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by omega
+      · lia
+      · have h_math : 2 + 2 * ofBits bs - 1 = 1 + 2 * ofBits bs := by lia
+        have h_div : (1 + 2 * ofBits bs) / 2 = ofBits bs := by lia
+        have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by lia
         simp [h_math, h_div, h_mod, ih]
 
 end BijectiveNumeration

--- a/Mathlib/Logic/Equiv/ListNatBijective.lean
+++ b/Mathlib/Logic/Equiv/ListNatBijective.lean
@@ -3,9 +3,11 @@ Copyright (c) 2026 Alexey Milovanov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexey Milovanov
 -/
-import Mathlib.Data.List.Basic
-import Mathlib.Data.Nat.Basic
-import Mathlib.Logic.Equiv.Basic
+module
+
+public import Mathlib.Data.List.Basic
+public import Mathlib.Data.Nat.Basic
+public import Mathlib.Logic.Equiv.Basic
 
 /-!
 # Bijective Base-2 Numeration
@@ -15,7 +17,9 @@ Unlike standard binary representation, bijective base-2 numeration avoids the
 "leading zeros" problem, providing a strict bijection `ℕ ≃ List Bool`.
 -/
 
-namespace Equiv.BijectiveBase2
+@[expose] public section
+
+namespace BijectiveNumeration
 
 /-- Encodes a natural number into a list of booleans using bijective base-2. -/
 def toBits (n : ℕ) : List Bool :=
@@ -77,12 +81,14 @@ theorem toBits_ofBits (bs : List Bool) : toBits (ofBits bs) = bs := by
         have h_mod : (1 + 2 * ofBits bs) % 2 = 1 := by omega
         simp [h_math, h_div, h_mod, ih]
 
-end Equiv.BijectiveBase2
+end BijectiveNumeration
 
 /-- The formal mathematical bijection between Natural Numbers and Boolean Lists
 using bijective base-2 numeration. -/
-def equivBijectiveBase2 : ℕ ≃ List Bool where
-  toFun := Equiv.BijectiveBase2.toBits
-  invFun := Equiv.BijectiveBase2.ofBits
-  left_inv := Equiv.BijectiveBase2.ofBits_toBits
-  right_inv := Equiv.BijectiveBase2.toBits_ofBits
+def listNatBijectiveEquiv : ℕ ≃ List Bool where
+  toFun := BijectiveNumeration.toBits
+  invFun := BijectiveNumeration.ofBits
+  left_inv := BijectiveNumeration.ofBits_toBits
+  right_inv := BijectiveNumeration.toBits_ofBits
+
+end


### PR DESCRIPTION
This PR introduces a formalization of the bijective base-2 numeration system. 

Unlike standard binary representation, bijective base-2 avoids the "leading zeros" problem, providing a strict mathematical bijection between natural numbers (`ℕ`) and lists of booleans (`List Bool`).

**Main additions:**
* `Equiv.BijectiveBase2.toBits`: Encodes `ℕ` to `List Bool`.
* `Equiv.BijectiveBase2.ofBits`: Decodes `List Bool` to `ℕ`.
* `equivBijectiveBase2`: The formal `ℕ ≃ List Bool` equivalence.

---

Zulip: [#PR reviews > PR #35857: Bijective Base-2 Numeration](https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/PR.20.2335857.3A.20Bijective.20Base-2.20Numeration/with/576336540)
Zulip: [#batteries > Upstreaming Nat.Bits](https://leanprover.zulipchat.com/#narrow/channel/348111-batteries/topic/Upstreaming.20Nat.2EBits/with/580736051)

*(Note: This replaces my previously closed PR to avoid the terminology clash between "Dyadic" and dyadic rationals. The namespace and definitions have been updated accordingly).*

*(Note: Used AI to assist with standardizing proof structures).*