### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): pullback comparison map of `Scheme.forgetToTop` is an epi

### DIFF
--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -402,6 +402,14 @@ lemma pullbackComparison_forget_surjective {X Y S : Scheme.{u}} (f : X ⟶ S) (g
 @[deprecated (since := "2025-10-06")]
 alias Pullback.forget_comparison_surjective := pullbackComparison_forget_surjective
 
+instance {X Y S : Scheme.{u}} (f : X ⟶ S) (g : Y ⟶ S) :
+    Epi (pullbackComparison Scheme.forgetToTop f g) := by
+  refine (CategoryTheory.forget TopCat).epi_of_epi_map ?_
+  rw [← CategoryTheory.epi_comp_iff_of_isIso _
+    (pullbackComparison (CategoryTheory.forget TopCat) (forgetToTop.map f) (forgetToTop.map g)),
+    ← _root_.CategoryTheory.Limits.pullbackComparison_comp, epi_iff_surjective]
+  apply Scheme.pullbackComparison_forget_surjective _ _
+
 lemma exists_preimage_of_isPullback {P X Y Z : Scheme.{u}} {fst : P ⟶ X} {snd : P ⟶ Y}
     {f : X ⟶ Z} {g : Y ⟶ Z} (h : IsPullback fst snd f g) (x : X) (y : Y)
     (hxy : f.base x = g.base y) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -434,6 +434,19 @@ theorem map_lift_pullbackComparison (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g
       pullback.lift (G.map h) (G.map k) (by simp only [← G.map_comp, w]) := by
   ext <;> simp [← G.map_comp]
 
+@[reassoc]
+lemma pullbackComparison_comp {E : Type*} [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X Y S : C}
+    (f : X ⟶ S) (g : Y ⟶ S) [HasPullback f g] [HasPullback (F.map f) (F.map g)]
+    [HasPullback (G.map (F.map f)) (G.map (F.map g))]
+    [HasPullback ((F ⋙ G).map f) ((F ⋙ G).map g)] :
+    pullbackComparison (F ⋙ G) f g = G.map (pullbackComparison F f g) ≫
+      pullbackComparison G (F.map f) (F.map g) := by
+  ext
+  · rw [pullbackComparison_comp_fst]
+    simp [← Functor.map_comp]
+  · rw [pullbackComparison_comp_snd]
+    simp [← Functor.map_comp]
+
 /-- The comparison morphism for the pushout of `f,g`.
 This is an isomorphism iff `G` preserves the pushout of `f,g`; see
 `Mathlib/CategoryTheory/Limits/Preserves/Shapes/Pullbacks.lean`


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
