### PR TITLE
[Merged by Bors] - feat(Topology/Homotopy/Basic): maps homotopic rel S agree on S

### DIFF
--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -632,6 +632,11 @@ variable {S : Set X}
 protected theorem homotopic {f₀ f₁ : C(X, Y)} (h : HomotopicRel f₀ f₁ S) : Homotopic f₀ f₁ :=
   h.map fun F ↦ F.1
 
+/-- If two maps are homotopic relative to a set, then they agree on it. -/
+theorem fst_eq_snd ⦃f₀ f₁ : C(X, Y)⦄ (h : HomotopicRel f₀ f₁ S) {x : X} (hx : x ∈ S) :
+    f₀ x = f₁ x :=
+  Nonempty.elim h (HomotopyRel.fst_eq_snd · hx)
+
 theorem refl (f : C(X, Y)) : HomotopicRel f f S :=
   ⟨HomotopyRel.refl f S⟩
 


### PR DESCRIPTION
---

This adds an easy lemma showing maps that are `HomotopicRel` a set agree on it.