### PR TITLE
[Merged by Bors] - fix(Translate): remap ConstantInfo.all during declaration translation

### DIFF
--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -143,6 +143,18 @@ def updateLevelParams (c : ConstantInfo) (levelParams : List Name) :
     ConstantInfo :=
   c.updateConstantVal {c.toConstantVal with levelParams}
 
+/--
+Update the mutual-block `all` field of a `ConstantInfo`.
+
+This applies to declaration kinds where `ConstantInfo.all` is stored directly.
+-/
+def updateAll : ConstantInfo → List Name → ConstantInfo
+  | .defnInfo info, all => .defnInfo {info with all}
+  | .thmInfo info, all => .thmInfo {info with all}
+  | .opaqueInfo info, all => .opaqueInfo {info with all}
+  | .inductInfo info, all => .inductInfo {info with all}
+  | ci, _ => ci
+
 /-- Update the value of a `ConstantInfo`, if it has one. -/
 def updateValue : ConstantInfo → Expr → ConstantInfo
   | defnInfo   info, v => defnInfo   {info with value := v}

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -614,6 +614,11 @@ def updateDecl (t : TranslateData) (tgt : Name) (srcDecl : ConstantInfo)
     (unfoldBoundaries? : Option UnfoldBoundary.UnfoldBoundaries) :
     MetaM (ConstantInfo × Option RelevantArg) := do
   let mut decl := srcDecl.updateName tgt
+  let env ← getEnv
+  let newAll := srcDecl.all.map fun n =>
+    if n == srcDecl.name then tgt
+    else (findTranslationName? env t n).getD n
+  decl := decl.updateAll newAll
   if reorder.any (·.contains 0) then
     decl := decl.updateLevelParams decl.levelParams.swapFirstTwo
   let mut value := decl.value! (allowOpaque := true)

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -613,12 +613,10 @@ def updateDecl (t : TranslateData) (tgt : Name) (srcDecl : ConstantInfo)
     (reorder : Reorder) (dont : List Nat)
     (unfoldBoundaries? : Option UnfoldBoundary.UnfoldBoundaries) :
     MetaM (ConstantInfo × Option RelevantArg) := do
+  unless srcDecl.all == [srcDecl.name] do
+    throwError "`{t.attrName}` does not support mutually recursive declarations."
   let mut decl := srcDecl.updateName tgt
-  let env ← getEnv
-  let newAll := srcDecl.all.map fun n =>
-    if n == srcDecl.name then tgt
-    else (findTranslationName? env t n).getD n
-  decl := decl.updateAll newAll
+  decl := decl.updateAll [tgt]
   if reorder.any (·.contains 0) then
     decl := decl.updateLevelParams decl.levelParams.swapFirstTwo
   let mut value := decl.value! (allowOpaque := true)

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -22,6 +22,25 @@ theorem bar0_works : bar0 3 4 = 7 := by decide
 
 run_meta guard <| (← getConstInfo `Test.bar0).all == [`Test.bar0]
 
+/--
+error: `to_additive` does not support mutually recursive declarations.
+-/
+#guard_msgs (error) in
+mutual
+
+@[to_additive bar0a]
+theorem foo0a {α} [Monoid α] (n : ℕ) : True := by
+  cases n with
+  | zero => trivial
+  | succ n => exact foo0b (α := α) n
+
+theorem foo0b {α} [Monoid α] (n : ℕ) : True := by
+  cases n with
+  | zero => trivial
+  | succ n => exact foo0a (α := α) n
+
+end
+
 class my_has_pow (α : Type u) (β : Type v) where
   pow : α → β → α
 

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -22,6 +22,23 @@ theorem bar0_works : bar0 3 4 = 7 := by decide
 
 run_meta guard <| (← getConstInfo `Test.bar0).all == [`Test.bar0]
 
+mutual
+
+@[to_additive bar0a]
+partial def foo0a {α} [Monoid α] (x : α) : ℕ → α
+  | 0 => 1
+  | n + 1 => foo0b x n
+
+@[to_additive bar0b]
+partial def foo0b {α} [Monoid α] (x : α) : ℕ → α
+  | 0 => 1
+  | n + 1 => foo0a x n
+
+end
+
+run_meta guard <| (← getConstInfo `Test.foo0b).all == [`Test.foo0a, `Test.foo0b]
+run_meta guard <| (← getConstInfo `Test.bar0b).all == [`Test.bar0a, `Test.bar0b]
+
 class my_has_pow (α : Type u) (β : Type v) where
   pow : α → β → α
 

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -20,6 +20,8 @@ def foo0 {α} [Mul α] [One α] (x y : α) : α := x * y * 1
 
 theorem bar0_works : bar0 3 4 = 7 := by decide
 
+run_meta guard <| (← getConstInfo `Test.bar0).all == [`Test.bar0]
+
 class my_has_pow (α : Type u) (β : Type v) where
   pow : α → β → α
 
@@ -138,6 +140,8 @@ example [Group α] (x : α) : foo17 x = x := by simp
 example [AddGroup α] (x : α) : bar17 x = 0 + x := by simp
 example [AddGroup α] (x : α) : bar17 x = x := by simp
 
+run_meta guard <| (← getConstInfo `Test.bar18).all == [`Test.bar18]
+
 /- Testing nested to_additive calls -/
 @[to_additive (attr := simp, to_additive baz19) bar19]
 def foo19 := 1
@@ -172,6 +176,7 @@ run_meta do
   -- some auxiliary definitions are also `abbrev` but not `reducible`
   guard <| (← getReducibilityStatus `Test.bar22.match_1) != .reducible
   guard <| (Compiler.getInlineAttribute? (← getEnv) `Test.bar22.match_1) == some .inline
+  guard <| (← getConstInfo `Test.bar22.match_1).all == [`Test.bar22.match_1]
 
 run_cmd do
   -- test that we cannot transport a declaration to itself

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -22,23 +22,6 @@ theorem bar0_works : bar0 3 4 = 7 := by decide
 
 run_meta guard <| (← getConstInfo `Test.bar0).all == [`Test.bar0]
 
-mutual
-
-@[to_additive bar0a]
-partial def foo0a {α} [Monoid α] (x : α) : ℕ → α
-  | 0 => 1
-  | n + 1 => foo0b x n
-
-@[to_additive bar0b]
-partial def foo0b {α} [Monoid α] (x : α) : ℕ → α
-  | 0 => 1
-  | n + 1 => foo0a x n
-
-end
-
-run_meta guard <| (← getConstInfo `Test.foo0b).all == [`Test.foo0a, `Test.foo0b]
-run_meta guard <| (← getConstInfo `Test.bar0b).all == [`Test.bar0a, `Test.bar0b]
-
 class my_has_pow (α : Type u) (β : Type v) where
   pow : α → β → α
 


### PR DESCRIPTION
It seems that the translation automation did not properly update the .all field of constant infos. When doing a traversal that requires knowledge about mutual blocks, it's convenient to use .all.

Here is an [example](https://live.lean-lang.org/#codez=JYWwDg9gTgLgBAWQIYwBYBtgCMBQOJgCmAdnADKFLF5QCuxA+iITEnACYQ5xzotwAPOIATCOAHMWAYQjEAzjACSxAGYQ4AA3UAFYADok7dtJAgA4lAi0w3cbSRR2cADwAfQfvTo4AXm9wA2po6+obGZhZWALpAA).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
