### PR TITLE
[Merged by Bors] - chore: exhaustively replace `measurability`/`continuity` → `fun_prop`, `simp_all` → `simp` where possible

### DIFF
--- a/Mathlib/Analysis/Fourier/Convolution.lean
+++ b/Mathlib/Analysis/Fourier/Convolution.lean
@@ -47,12 +47,12 @@ theorem integrable_prod_sub (B : F₁ →L[𝕜] F₂ →L[𝕜] F₃) {f₁ : E
     (hf₁ : Integrable f₁) (hf₂ : Integrable f₂) (hf₁' : Continuous f₁) (hf₂' : Continuous f₂) :
     Integrable (fun (p : E × E) ↦ ‖B‖ * (‖f₁ (p.1 - p.2)‖ * ‖f₂ p.2‖)) (volume.prod volume) := by
   apply Integrable.const_mul
-  rw [integrable_prod_iff' (by measurability)]
+  rw [integrable_prod_iff' (by fun_prop)]
   constructor
   · filter_upwards with x
     exact (hf₁.comp_sub_right x).norm.mul_const _
   have : Integrable (fun x ↦ ((∫ y, ‖f₁ y‖) * ‖f₂ x‖)) := by
-    apply hf₂.norm.bdd_mul (by measurability) (c := ‖(∫ y, ‖f₁ y‖)‖)
+    apply hf₂.norm.bdd_mul (by fun_prop) (c := ‖(∫ y, ‖f₁ y‖)‖)
     filter_upwards with; rfl
   convert this using 1
   ext x
@@ -124,7 +124,7 @@ theorem fourier_bilin_convolution_eq (B : F₁ →L[ℂ] F₂ →L[ℂ] F₃) {f
     · simp
     have : MeasureTheory.Integrable (fun x ↦ ‖B‖ * ‖f₁ x‖) MeasureTheory.volume :=
       hf₁.norm.const_mul _
-    apply this.mono (by measurability)
+    apply this.mono (by fun_prop)
     filter_upwards with x
     simpa [← Circle.smul_def] using le_opNorm B (f₁ x)
   _ = B (∫ x, 𝐞 (-inner ℝ x ξ) • f₁ x) (∫ y, 𝐞 (-inner ℝ y ξ) • f₂ y) := by

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -275,7 +275,7 @@ lemma weierstrassPExcept_add (l₀ : L.lattice) (z : ℂ) :
   rw [weierstrassPExcept, ← Summable.tsum_add]
   · congr with w; split_ifs <;> simp only [zero_add, add_zero, *]
   · exact ⟨_, L.hasSum_weierstrassPExcept _ _⟩
-  · exact summable_of_hasFiniteSupport ((Set.finite_singleton l₀).subset (by simp_all))
+  · exact summable_of_hasFiniteSupport ((Set.finite_singleton l₀).subset (by simp))
 
 lemma weierstrassPExcept_def (l₀ : L.lattice) (z : ℂ) :
     ℘[L - l₀] z = ℘[L] z + (1 / l₀.1 ^ 2 - 1 / (z - l₀.1) ^ 2) := by
@@ -529,7 +529,7 @@ lemma derivWeierstrassPExcept_sub (l₀ : L.lattice) (z : ℂ) :
   rw [derivWeierstrassP, derivWeierstrassPExcept, ← Summable.tsum_add, ← tsum_neg]
   · congr with w; split_ifs <;> simp only [zero_add, add_zero, *, neg_div]
   · exact ⟨_, L.hasSum_derivWeierstrassPExcept _ _⟩
-  · exact summable_of_hasFiniteSupport ((Set.finite_singleton l₀).subset (by simp_all))
+  · exact summable_of_hasFiniteSupport ((Set.finite_singleton l₀).subset (by simp))
 
 lemma derivWeierstrassPExcept_def (l₀ : L.lattice) (z : ℂ) :
     ℘'[L - l₀] z = ℘'[L] z + 2 / (z - l₀) ^ 3 := by
@@ -647,7 +647,7 @@ lemma coeff_weierstrassPExceptSeries (l₀ x : ℂ) (i : ℕ) :
           split_ifs with e
           · simp only [e, zpow_natCast, sub_self, mul_zero]
           · dsimp; norm_cast; ring
-        · exact summable_of_hasFiniteSupport ((Set.finite_singleton ⟨l₀, hl₀⟩).subset (by simp_all))
+        · exact summable_of_hasFiniteSupport ((Set.finite_singleton ⟨l₀, hl₀⟩).subset (by simp))
     · have h₁ (l : L.lattice) : l.1 ≠ l₀ := fun e ↦ hl₀ (e ▸ l.2)
       simp [h₁, tsum_mul_left, sumInvPow, add_assoc,
         one_add_one_eq_two, ← zpow_natCast, -neg_add_rev]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Orthogonality.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Orthogonality.lean
@@ -52,7 +52,7 @@ theorem integral_measureT (f : ℝ → ℝ) :
     ∫ x, f x ∂measureT = ∫ x in -1..1, f x * √(1 - x ^ 2)⁻¹ := by
   rw [integral_of_le (by norm_num), measureT,
     restrict_withDensity (by measurability),
-    integral_withDensity_eq_integral_smul (by measurability)]
+    integral_withDensity_eq_integral_smul (by fun_prop)]
   congr! 2 with x hx
   simp [NNReal.smul_def, mul_comm]
 
@@ -68,7 +68,7 @@ theorem integrable_measureT {f : ℝ → ℝ} (hf : ContinuousOn f (Set.Icc (-1)
   have := intervalIntegrable_sqrt_one_sub_sq_inv.continuousOn_mul hf
   rw [intervalIntegrable_iff, Set.uIoc_of_le (by norm_num)] at this
   rw [measureT, restrict_withDensity (by measurability),
-    integrable_withDensity_iff (by measurability) (by simp)]
+    integrable_withDensity_iff (by fun_prop) (by simp)]
   unfold IntegrableOn at this
   convert this
 

--- a/Mathlib/LinearAlgebra/Finsupp/Pi.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Pi.lean
@@ -108,7 +108,7 @@ def prodOfFinsuppNat : (ℕ →₀ P) →ₗ[R] P × M :=
 
 theorem fst_prodOfFinsuppNat (x : ℕ →₀ P) : (prodOfFinsuppNat f x).1 = x 0 := by
   simp_rw [prodOfFinsuppNat, coe_lsum, sum, Prod.fst_sum]
-  rw [Finset.sum_eq_single 0 (fun n _ hn ↦ ?_) (by simp_all)]
+  rw [Finset.sum_eq_single 0 (fun n _ hn ↦ ?_) (by simp)]
   · simp
   obtain ⟨n, rfl⟩ := n.exists_eq_succ_of_ne_zero hn
   simp [pow_succ']

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -532,7 +532,7 @@ lemma leftRegular_norm_apply :
       linearCombination _ (fun _ => 1) := by
   ext i : 2
   simpa [Representation.norm] using Finset.sum_bijective _
-    (Group.mulRight_bijective i) (by simp_all) (by simp_all)
+    (Group.mulRight_bijective i) (by simp) (by simp)
 
 lemma leftRegular_norm_eq_zero_iff (x : G →₀ k) :
     (leftRegular k G).norm x = 0 ↔ x.linearCombination k (fun _ => (1 : k)) = 0 := by

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Trivial.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Trivial.lean
@@ -80,7 +80,7 @@ lemma isDiscrete_trivialRel [ValuativeRel R] [Valuation.Compatible (1 : Valuatio
   refine ⟨⟨0, zero_lt_one, fun x ↦ ?_⟩⟩
   have := subsingleton_units_valueGroupWithZero_of_trivialRel R Γ
   rcases GroupWithZero.eq_zero_or_unit x with rfl | ⟨u, rfl⟩
-  · simp_all
+  · simp
   · rw [← Units.val_one, Units.val_lt_val]
     simp
 


### PR DESCRIPTION
The goal of this PR is to exhaustively replace `measurability`/`continuity` and `simp_all` with the preferred `fun_prop` and `simp` where possible.

Trace profiling results (differences <30 ms considered measurement noise):
* `PeriodPair.weierstrassPExcept_add`: unchanged 🎉
* `PeriodPair.derivWeierstrassPExcept_sub`: unchanged 🎉
* `PeriodPair.coeff_weierstrassPExceptSeries`: 353 ms before, 320 ms after  🎉
* `Polynomial.Chebyshev.integral_measureT`: unchanged 🎉
* `Polynomial.Chebyshev.integrable_measureT`: 513 ms before, 338 ms after  🎉
* `LinearMap.fst_prodOfFinsuppNat`: unchanged 🎉
* `Representation.leftRegular_norm_apply`: unchanged 🎉
* `ValuativeRel.isDiscrete_trivialRel`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
