### PR TITLE
chore: Fix non-defeq diamonds on OrderDual

### DIFF
--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Field.Defs
 public import Mathlib.Algebra.Ring.GrindInstances
 public import Mathlib.Algebra.Ring.Commute
 public import Mathlib.Algebra.Ring.Invertible
+public import Mathlib.Algebra.Order.Ring.Synonym
 public import Mathlib.Order.Synonym
 
 import Mathlib.Tactic.Tauto
@@ -296,11 +297,27 @@ end Function.Injective
 
 namespace OrderDual
 
-instance instRatCast [RatCast K] : RatCast Kᵒᵈ := ‹_›
-instance instDivisionSemiring [DivisionSemiring K] : DivisionSemiring Kᵒᵈ := ‹_›
-instance instDivisionRing [DivisionRing K] : DivisionRing Kᵒᵈ := ‹_›
-instance instSemifield [Semifield K] : Semifield Kᵒᵈ := ‹_›
-instance instField [Field K] : Field Kᵒᵈ := ‹_›
+instance instRatCast [RatCast K] : RatCast Kᵒᵈ where
+  ratCast x := toDual x
+instance instDivisionSemiring [h : DivisionSemiring K] : DivisionSemiring Kᵒᵈ where
+  inv_zero := h.inv_zero
+  mul_inv_cancel := h.mul_inv_cancel
+  nnqsmul x y := toDual <| x • y.ofDual
+  nnqsmul_def := h.nnqsmul_def
+  nnratCast_def := h.nnratCast_def
+instance instDivisionRing [h : DivisionRing K] : DivisionRing Kᵒᵈ where
+  inv_zero := h.inv_zero
+  mul_inv_cancel := h.mul_inv_cancel
+  nnqsmul x y := toDual <| x • y.ofDual
+  nnqsmul_def := h.nnqsmul_def
+  nnratCast_def := h.nnratCast_def
+  qsmul x y := toDual <| x • y.ofDual
+  ratCast_def := h.ratCast_def
+  qsmul_def := h.qsmul_def
+
+instance instSemifield [h : Semifield K] : Semifield Kᵒᵈ where
+  mul_comm := h.mul_comm
+instance instField [Field K] : Field Kᵒᵈ where
 
 end OrderDual
 

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -111,8 +111,9 @@ theorem sup_support_mul_le {degb : A → B} (degbm : ∀ a b, degb (a + b) ≤ d
 
 theorem le_inf_support_mul {degt : A → T} (degtm : ∀ a b, degt a + degt b ≤ degt (a + b))
     (f g : R[A]) :
-    f.support.inf degt + g.support.inf degt ≤ (f * g).support.inf degt :=
-  sup_support_mul_le (B := Tᵒᵈ) degtm f g
+    f.support.inf degt + g.support.inf degt ≤ (f * g).support.inf degt := by
+  refine sup_support_mul_le (B := Tᵒᵈ) ?_ f g
+  exact degtm
 
 end AddOnly
 
@@ -151,8 +152,8 @@ theorem sup_support_pow_le (degb0 : degb 0 ≤ 0) (degbm : ∀ a b, degb (a + b)
 
 theorem le_inf_support_pow (degt0 : 0 ≤ degt 0) (degtm : ∀ a b, degt a + degt b ≤ degt (a + b))
     (n : ℕ) (f : R[A]) : n • f.support.inf degt ≤ (f ^ n).support.inf degt := by
-  refine OrderDual.ofDual_le_ofDual.mpr <| sup_support_pow_le (OrderDual.ofDual_le_ofDual.mp ?_)
-      (fun a b => OrderDual.ofDual_le_ofDual.mp ?_) n f
+  refine OrderDual.ofDual_le_ofDual.mpr <| sup_support_pow_le (B := Tᵒᵈ)
+    (OrderDual.ofDual_le_ofDual.mp ?_) (fun a b => OrderDual.ofDual_le_ofDual.mp ?_) n f
   · exact degt0
   · exact degtm _ _
 

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -25,28 +25,44 @@ variable {α β : Type*}
 
 
 @[to_additive]
-instance [h : One α] : One αᵒᵈ := h
+instance [One α] : One αᵒᵈ where one := toDual 1
 
 @[to_additive]
-instance [h : Mul α] : Mul αᵒᵈ := h
+instance [h : Mul α] : Mul αᵒᵈ where mul x y := toDual <| ofDual x * ofDual y
 
 @[to_additive]
-instance [h : Inv α] : Inv αᵒᵈ := h
+instance [h : Inv α] : Inv αᵒᵈ where inv x := toDual (ofDual x)⁻¹
 
 @[to_additive]
-instance [h : Div α] : Div αᵒᵈ := h
-
-@[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul]
-instance OrderDual.instPow [h : Pow α β] : Pow αᵒᵈ β := h
-
-@[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul']
-instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ := h
+instance [h : Div α] : Div αᵒᵈ where div x y := toDual <| ofDual x / ofDual y
 
 @[to_additive]
-instance [h : Semigroup α] : Semigroup αᵒᵈ := h
+instance OrderDual.instSMul [h : SMul α β] : SMul α βᵒᵈ where smul x y := toDual <| x • y.ofDual
 
 @[to_additive]
-instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ := h
+instance OrderDual.instSMul' [h : SMul α β] : SMul αᵒᵈ β where smul x y := x.ofDual • y
+
+@[to_additive existing OrderDual.instSMul]
+instance OrderDual.instPow [h : Pow α β] : Pow αᵒᵈ β where pow x y := toDual <| x.ofDual ^ y
+
+@[to_additive existing OrderDual.instSMul']
+instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ where pow x y := x ^ y.ofDual
+
+-- verify there is no diamond at `instance` transparency
+example [SMul α β] : instSMul (α := αᵒᵈ) (β := β) = instSMul' := by
+  with_reducible_and_instances rfl
+
+-- verify there is no diamond at `instance` transparency
+example [Pow α β] : instPow (α := α) (β := βᵒᵈ) = instPow' := by
+  with_reducible_and_instances rfl
+
+@[to_additive]
+instance [h : Semigroup α] : Semigroup αᵒᵈ where
+  mul_assoc := h.mul_assoc
+
+@[to_additive]
+instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ where
+  mul_comm := h.mul_comm
 
 @[to_additive]
 instance [Mul α] [h : IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ := h
@@ -58,49 +74,63 @@ instance [Mul α] [h : IsRightCancelMul α] : IsRightCancelMul αᵒᵈ := h
 instance [Mul α] [h : IsCancelMul α] : IsCancelMul αᵒᵈ := h
 
 @[to_additive]
-instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ := h
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ where
 
 @[to_additive]
-instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ := h
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ where
 
 @[to_additive]
-instance [h : MulOneClass α] : MulOneClass αᵒᵈ := h
+instance [h : MulOneClass α] : MulOneClass αᵒᵈ where
+  one_mul := h.one_mul
+  mul_one := h.mul_one
 
 @[to_additive]
-instance [h : Monoid α] : Monoid αᵒᵈ := h
+instance [h : Monoid α] : Monoid αᵒᵈ where
+  npow n x := toDual <| x.ofDual ^ n
+  npow_zero := h.npow_zero
+  npow_succ := h.npow_succ
 
 @[to_additive]
-instance OrderDual.instCommMonoid [h : CommMonoid α] : CommMonoid αᵒᵈ := h
+instance OrderDual.instCommMonoid [h : CommMonoid α] : CommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ := h
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ := h
+instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ := h
+instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ := h
+instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : InvolutiveInv α] : InvolutiveInv αᵒᵈ := h
+instance [h : InvolutiveInv α] : InvolutiveInv αᵒᵈ where
+  inv_inv := h.inv_inv
 
 @[to_additive]
-instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ := h
+instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ where
+  div_eq_mul_inv := h.div_eq_mul_inv
+  zpow n x := toDual <| x.ofDual ^ n
+  zpow_zero' := h.zpow_zero'
+  zpow_succ' := h.zpow_succ'
+  zpow_neg' := h.zpow_neg'
 
 @[to_additive]
-instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ := h
+instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ where
+  mul_inv_rev := h.mul_inv_rev
+  inv_eq_of_mul := h.inv_eq_of_mul
 
 @[to_additive]
-instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ := h
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ where
 
 @[to_additive]
-instance OrderDual.instGroup [h : Group α] : Group αᵒᵈ := h
+instance OrderDual.instGroup [h : Group α] : Group αᵒᵈ where
+  inv_mul_cancel := h.inv_mul_cancel
 
 @[to_additive]
-instance [h : CommGroup α] : CommGroup αᵒᵈ := h
+instance [h : CommGroup α] : CommGroup αᵒᵈ where
 
 @[to_additive (attr := simp)]
 theorem toDual_one [One α] : toDual (1 : α) = 1 := rfl

--- a/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
@@ -27,29 +27,49 @@ variable {G₀ M₀ : Type*}
 
 namespace OrderDual
 
-instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ :=
-  ‹SMulWithZero G₀ M₀›
+instance instSMulWithZero [Zero G₀] [Zero M₀] [h : SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
 
-instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ :=
-  ‹SMulWithZero G₀ M₀›
+instance instSMulWithZero' [Zero G₀] [Zero M₀] [h : SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
 
-instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ :=
-  ‹DistribSMul G₀ M₀›
+instance instDistribSMul [AddZeroClass M₀] [h : DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
 
-instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ :=
-  ‹DistribSMul G₀ M₀›
+instance instDistribSMul' [AddZeroClass M₀] [h : DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
 
-instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ᵒᵈ M₀ := ‹DistribMulAction G₀ M₀›
+instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [h : DistribMulAction G₀ M₀] :
+    DistribMulAction G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
+  one_smul := h.one_smul
+  mul_smul := h.mul_smul
 
-instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ M₀ᵒᵈ := ‹DistribMulAction G₀ M₀›
+instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [h : DistribMulAction G₀ M₀] :
+    DistribMulAction G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
+  one_smul := h.one_smul
+  mul_smul := h.mul_smul
 
-instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ᵒᵈ M₀ := ‹MulActionWithZero G₀ M₀›
+instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [h : MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
+  one_smul := h.one_smul
+  mul_smul := h.mul_smul
 
-instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ M₀ᵒᵈ := ‹MulActionWithZero G₀ M₀›
+instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [h : MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
+  one_smul := h.one_smul
+  mul_smul := h.mul_smul
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
@@ -27,25 +27,29 @@ variable {α : Type*}
 
 open OrderDual
 
-instance [h : MulZeroClass α] : MulZeroClass αᵒᵈ := h
+instance [h : MulZeroClass α] : MulZeroClass αᵒᵈ where
+  zero_mul := h.zero_mul
+  mul_zero := h.mul_zero
 
-instance [h : MulZeroOneClass α] : MulZeroOneClass αᵒᵈ := h
+instance [h : MulZeroOneClass α] : MulZeroOneClass αᵒᵈ where
 
 instance [Mul α] [Zero α] [h : NoZeroDivisors α] : NoZeroDivisors αᵒᵈ := h
 
-instance [h : SemigroupWithZero α] : SemigroupWithZero αᵒᵈ := h
+instance [h : SemigroupWithZero α] : SemigroupWithZero αᵒᵈ where
 
-instance [h : MonoidWithZero α] : MonoidWithZero αᵒᵈ := h
+instance [h : MonoidWithZero α] : MonoidWithZero αᵒᵈ where
 
 instance [Mul α] [Zero α] [h : IsLeftCancelMulZero α] : IsLeftCancelMulZero αᵒᵈ := h
 instance [Mul α] [Zero α] [h : IsRightCancelMulZero α] : IsRightCancelMulZero αᵒᵈ := h
 instance [Mul α] [Zero α] [h : IsCancelMulZero α] : IsCancelMulZero αᵒᵈ := h
 
-instance [h : CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ := h
+instance [h : CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ where
 
-instance [h : GroupWithZero α] : GroupWithZero αᵒᵈ := h
+instance [h : GroupWithZero α] : GroupWithZero αᵒᵈ where
+  inv_zero := h.inv_zero
+  mul_inv_cancel := h.mul_inv_cancel
 
-instance [h : CommGroupWithZero α] : CommGroupWithZero αᵒᵈ := h
+instance [h : CommGroupWithZero α] : CommGroupWithZero αᵒᵈ where
 
 /-! ### Lexicographic order -/
 

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -848,13 +848,17 @@ section Left
 variable [Preorder α] [Preorder β] [SMul α β] [Zero α]
 
 instance instPosSMulMono [PosSMulMono α β] : PosSMulMono α βᵒᵈ where
-  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb := smul_le_smul_of_nonneg_left (β := β) hb ha
+  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb :=
+    smul_le_smul_of_nonneg_left (α := α) (β := β) hb ha
 instance instPosSMulStrictMono [PosSMulStrictMono α β] : PosSMulStrictMono α βᵒᵈ where
-  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb := smul_lt_smul_of_pos_left (β := β) hb ha
+  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb :=
+    smul_lt_smul_of_pos_left (α := α) (β := β) hb ha
 instance instPosSMulReflectLT [PosSMulReflectLT α β] : PosSMulReflectLT α βᵒᵈ where
-  lt_of_smul_lt_smul_left _a ha _b₁ _b₂ h := lt_of_smul_lt_smul_of_nonneg_left (β := β) h ha
+  lt_of_smul_lt_smul_left _a ha _b₁ _b₂ h :=
+    lt_of_smul_lt_smul_of_nonneg_left (α := α) (β := β) h ha
 instance instPosSMulReflectLE [PosSMulReflectLE α β] : PosSMulReflectLE α βᵒᵈ where
-  le_of_smul_le_smul_left _a ha _b₁ _b₂ h := le_of_smul_le_smul_of_pos_left (β := β) h ha
+  le_of_smul_le_smul_left _a ha _b₁ _b₂ h :=
+    le_of_smul_le_smul_of_pos_left (α := α) (β := β) h ha
 
 end Left
 
@@ -865,22 +869,22 @@ variable [Preorder α] [Monoid α] [AddCommGroup β] [PartialOrder β] [IsOrdere
 instance instSMulPosMono [SMulPosMono α β] : SMulPosMono α βᵒᵈ where
   smul_le_smul_of_nonneg_right _b hb a₁ a₂ ha := by
     rw [← neg_le_neg_iff, ← smul_neg, ← smul_neg]
-    exact smul_le_smul_of_nonneg_right (β := β) ha <| neg_nonneg.2 hb
+    exact smul_le_smul_of_nonneg_right (α := α) (β := β) ha <| neg_nonneg.2 hb
 
 instance instSMulPosStrictMono [SMulPosStrictMono α β] : SMulPosStrictMono α βᵒᵈ where
   smul_lt_smul_of_pos_right _b hb a₁ a₂ ha := by
     rw [← neg_lt_neg_iff, ← smul_neg, ← smul_neg]
-    exact smul_lt_smul_of_pos_right (β := β) ha <| neg_pos.2 hb
+    exact smul_lt_smul_of_pos_right (α := α) (β := β) ha <| neg_pos.2 hb
 
 instance instSMulPosReflectLT [SMulPosReflectLT α β] : SMulPosReflectLT α βᵒᵈ where
   lt_of_smul_lt_smul_right _b hb a₁ a₂ h := by
     rw [← neg_lt_neg_iff, ← smul_neg, ← smul_neg] at h
-    exact lt_of_smul_lt_smul_right (β := β) h <| neg_nonneg.2 hb
+    exact lt_of_smul_lt_smul_right (α := α) (β := β) h <| neg_nonneg.2 hb
 
 instance instSMulPosReflectLE [SMulPosReflectLE α β] : SMulPosReflectLE α βᵒᵈ where
   le_of_smul_le_smul_right _b hb a₁ a₂ h := by
     rw [← neg_le_neg_iff, ← smul_neg, ← smul_neg] at h
-    exact le_of_smul_le_smul_right (β := β) h <| neg_pos.2 hb
+    exact le_of_smul_le_smul_right (α := α) (β := β) h <| neg_pos.2 hb
 
 end Right
 

--- a/Mathlib/Algebra/Order/Module/Synonym.lean
+++ b/Mathlib/Algebra/Order/Module/Synonym.lean
@@ -28,14 +28,13 @@ variable {α β : Type*}
 
 namespace OrderDual
 
-set_option backward.isDefEq.respectTransparency false in
-instance instModule [Semiring α] [AddCommMonoid β] [Module α β] : Module αᵒᵈ β where
-  add_smul := add_smul (R := α)
-  zero_smul := zero_smul _
+instance instModule [Semiring α] [AddCommMonoid β] [h : Module α β] : Module αᵒᵈ β where
+  add_smul := h.add_smul
+  zero_smul := h.zero_smul
 
-instance instModule' [Semiring α] [AddCommMonoid β] [Module α β] : Module α βᵒᵈ where
-  add_smul := add_smul (M := β)
-  zero_smul := zero_smul _
+instance instModule' [Semiring α] [AddCommMonoid β] [h : Module α β] : Module α βᵒᵈ where
+  add_smul := h.add_smul
+  zero_smul := h.zero_smul
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Order.Group.Abs
 public import Mathlib.Algebra.Order.Ring.Int
 public import Mathlib.Data.Nat.Cast.Order.Ring
+public import Mathlib.Data.Nat.Cast.Synonym
 
 /-!
 # Order properties of cast of integers
@@ -115,9 +116,12 @@ open OrderDual
 
 namespace OrderDual
 
-instance instIntCast [IntCast R] : IntCast Rᵒᵈ := ‹_›
-instance instAddGroupWithOne [AddGroupWithOne R] : AddGroupWithOne Rᵒᵈ := ‹_›
-instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵒᵈ := ‹_›
+instance instIntCast [IntCast R] : IntCast Rᵒᵈ where
+  intCast n := toDual n
+instance instAddGroupWithOne [h : AddGroupWithOne R] : AddGroupWithOne Rᵒᵈ where
+  intCast_ofNat := h.intCast_ofNat
+  intCast_negSucc := h.intCast_negSucc
+instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵒᵈ where
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Ring/Synonym.lean
+++ b/Mathlib/Algebra/Order/Ring/Synonym.lean
@@ -5,8 +5,9 @@ Authors: Yury Kudryashov, Yaël Dillies
 -/
 module
 
-public import Mathlib.Algebra.Order.Group.Synonym
+public import Mathlib.Algebra.Order.GroupWithZero.Synonym
 public import Mathlib.Algebra.Ring.Defs
+public import Mathlib.Data.Nat.Cast.Synonym
 
 /-!
 # Ring structure on the order type synonyms
@@ -22,39 +23,50 @@ variable {R : Type*}
 /-! ### Order dual -/
 
 
-instance [h : Distrib R] : Distrib Rᵒᵈ := h
+instance [h : Distrib R] : Distrib Rᵒᵈ where
+  left_distrib := h.left_distrib
+  right_distrib := h.right_distrib
 
 instance [Mul R] [Add R] [h : LeftDistribClass R] : LeftDistribClass Rᵒᵈ := h
 
 instance [Mul R] [Add R] [h : RightDistribClass R] : RightDistribClass Rᵒᵈ := h
 
-instance [h : NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ := h
+instance [h : NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ where
+  zero_mul := h.zero_mul
+  mul_zero := h.mul_zero
 
-instance [h : NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ := h
+instance [h : NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ where
 
-instance [h : NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ := h
+instance [h : NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ where
 
-instance [h : Semiring R] : Semiring Rᵒᵈ := h
+instance [h : Semiring R] : Semiring Rᵒᵈ where
 
-instance [h : NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ := h
+instance [h : NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ where
 
-instance [h : CommSemiring R] : CommSemiring Rᵒᵈ := h
+instance [h : CommSemiring R] : CommSemiring Rᵒᵈ where
 
-instance [Mul R] [h : HasDistribNeg R] : HasDistribNeg Rᵒᵈ := h
+instance [Mul R] [h : HasDistribNeg R] : HasDistribNeg Rᵒᵈ where
+  neg_mul := h.neg_mul
+  mul_neg := h.mul_neg
 
-instance [h : NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ := h
+instance [h : NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ where
 
-instance [h : NonUnitalRing R] : NonUnitalRing Rᵒᵈ := h
+instance [h : NonUnitalRing R] : NonUnitalRing Rᵒᵈ where
 
-instance [h : NonAssocRing R] : NonAssocRing Rᵒᵈ := h
+instance [h : NonAssocRing R] : NonAssocRing Rᵒᵈ where
+  intCast n := .toDual n
+  intCast_ofNat := h.intCast_ofNat
+  intCast_negSucc := h.intCast_negSucc
 
-instance [h : Ring R] : Ring Rᵒᵈ := h
+instance [h : Ring R] : Ring Rᵒᵈ where
 
-instance [h : NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ := h
+instance [h : NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ where
 
-instance [h : CommRing R] : CommRing Rᵒᵈ := h
+instance [h : CommRing R] : CommRing Rᵒᵈ where
 
-instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ := h
+instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ where
+  mul_left_cancel_of_ne_zero := h.mul_left_cancel_of_ne_zero
+  mul_right_cancel_of_ne_zero := h.mul_right_cancel_of_ne_zero
 
 /-! ### Lexicographical order -/
 

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -125,6 +125,8 @@ theorem DirectedOn.convex_sUnion {c : Set (Set E)} (hdir : DirectedOn (· ⊆ ·
 theorem Convex.setOf_const_imp {P : Prop} (hs : Convex 𝕜 s) : Convex 𝕜 {x | P → x ∈ s} := by
   by_cases hP : P <;> simp [hP, hs, convex_univ]
 
+theorem Convex.dual (hc : Convex 𝕜 s) : Convex 𝕜 (OrderDual.ofDual ⁻¹' s) := hc
+
 end SMul
 
 section Module
@@ -347,11 +349,11 @@ theorem MonotoneOn.convex_lt (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β)
 
 theorem MonotoneOn.convex_ge (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | r ≤ f x }) :=
-  MonotoneOn.convex_le (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual hs r
+  MonotoneOn.convex_le hf.dual hs.dual r
 
 theorem MonotoneOn.convex_gt (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | r < f x }) :=
-  MonotoneOn.convex_lt (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual hs r
+  MonotoneOn.convex_lt hf.dual hs.dual r
 
 theorem AntitoneOn.convex_le (hf : AntitoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | f x ≤ r }) :=

--- a/Mathlib/Analysis/Normed/Group/Constructions.lean
+++ b/Mathlib/Analysis/Normed/Group/Constructions.lean
@@ -204,22 +204,24 @@ namespace OrderDual
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) seminormedGroup [SeminormedGroup E] : SeminormedGroup Eᵒᵈ :=
-  ‹SeminormedGroup E›
+instance (priority := 100) seminormedGroup [h : SeminormedGroup E] : SeminormedGroup Eᵒᵈ where
+  dist_eq := h.dist_eq
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) seminormedCommGroup [SeminormedCommGroup E] : SeminormedCommGroup Eᵒᵈ :=
-  ‹SeminormedCommGroup E›
+instance (priority := 100) seminormedCommGroup [h : SeminormedCommGroup E] :
+    SeminormedCommGroup Eᵒᵈ where
+  dist_eq := h.dist_eq
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) normedGroup [NormedGroup E] : NormedGroup Eᵒᵈ := ‹NormedGroup E›
+instance (priority := 100) normedGroup [h : NormedGroup E] : NormedGroup Eᵒᵈ where
+  dist_eq := h.dist_eq
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) normedCommGroup [NormedCommGroup E] : NormedCommGroup Eᵒᵈ :=
-  ‹NormedCommGroup E›
+instance (priority := 100) normedCommGroup [h : NormedCommGroup E] : NormedCommGroup Eᵒᵈ  where
+  dist_eq := h.dist_eq
 
 end OrderDual
 end OrderDual

--- a/Mathlib/Data/Nat/Cast/Synonym.lean
+++ b/Mathlib/Data/Nat/Cast/Synonym.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Data.Nat.Cast.Defs
 public import Mathlib.Order.Synonym
+public import Mathlib.Algebra.Order.Group.Synonym
 
 /-!
 # Cast of natural numbers (additional theorems)
@@ -24,14 +25,15 @@ variable {α : Type*}
 
 open OrderDual
 
-instance [h : NatCast α] : NatCast αᵒᵈ :=
-  h
+instance [h : NatCast α] : NatCast αᵒᵈ where
+  natCast n := toDual n
 
-instance [h : AddMonoidWithOne α] : AddMonoidWithOne αᵒᵈ :=
-  h
+instance [h : AddMonoidWithOne α] : AddMonoidWithOne αᵒᵈ where
+  natCast_zero := h.natCast_zero
+  natCast_succ := h.natCast_succ
 
-instance [h : AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵒᵈ :=
-  h
+instance [h : AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵒᵈ where
+  add_comm := h.add_comm
 
 @[simp]
 theorem toDual_natCast [NatCast α] (n : ℕ) : toDual (n : α) = n :=

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -334,14 +334,14 @@ theorem SemilatticeInf.ext {α} {A B : SemilatticeInf α}
 
 -- `to_dual` cannot yet reorder arguments of arguments
 instance OrderDual.instSemilatticeSup (α) [SemilatticeInf α] : SemilatticeSup αᵒᵈ where
-  sup := @SemilatticeInf.inf α _
+  sup a b := @SemilatticeInf.inf α _ a b
   le_sup_left := @SemilatticeInf.inf_le_left α _
   le_sup_right := @SemilatticeInf.inf_le_right α _
   sup_le := fun _ _ _ hca hcb => @SemilatticeInf.le_inf α _ _ _ _ hca hcb
 
 @[to_dual existing]
 instance OrderDual.instSemilatticeInf (α) [SemilatticeSup α] : SemilatticeInf αᵒᵈ where
-  inf := @SemilatticeSup.sup α _
+  inf a b := @SemilatticeSup.sup α _ a b
   inf_le_left := @le_sup_left α _
   inf_le_right := @le_sup_right α _
   le_inf := fun _ _ _ hca hcb => @sup_le α _ _ _ _ hca hcb


### PR DESCRIPTION
This only makes changes to fix the diamonds, rather than the general defeq abuse with `OrderDual`.

---

- [x] depends on: #35995

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
