### PR TITLE
fix(Topology/Defs/Basic): preserve noncanonical topology instances in delaboration

### DIFF
--- a/Mathlib/Topology/Defs/Basic.lean
+++ b/Mathlib/Topology/Defs/Basic.lean
@@ -248,16 +248,28 @@ private meta def isCanonicalTopologyInst (inst : Expr) : DelabM Bool := do
 
 /--
 Delaborate `@Continuous _ _ t₁ t₂` as `Continuous[t₁, t₂]`
-when either topology is noncanonical.
+when at least one topology is noncanonical, using `_` for canonical arguments.
 -/
 @[app_delab Continuous] meta def delabContinuousOf : Delab :=
   whenNotPPOption getPPExplicit <|
   whenPPOption getPPNotation <|
   withOverApp 4 do
     let #[_, _, t₁, t₂] := (← getExpr).getAppArgs | failure
-    if (← isCanonicalTopologyInst t₁) && (← isCanonicalTopologyInst t₂) then
-      failure
-    `(Continuous[$(← withNaryArg 2 delab), $(← withNaryArg 3 delab)])
+    let c₁ ← isCanonicalTopologyInst t₁
+    if c₁ then
+      let c₂ ← isCanonicalTopologyInst t₂
+      if c₂ then
+        failure
+      else
+        let hole ← `(term| _)
+        `(Continuous[$hole, $(← withNaryArg 3 delab)])
+    else
+      let c₂ ← isCanonicalTopologyInst t₂
+      if c₂ then
+        let hole ← `(term| _)
+        `(Continuous[$(← withNaryArg 2 delab), $hole])
+      else
+        `(Continuous[$(← withNaryArg 2 delab), $(← withNaryArg 3 delab)])
 
 end Topology
 

--- a/Mathlib/Topology/Defs/Basic.lean
+++ b/Mathlib/Topology/Defs/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Tactic.Continuity
 public import Mathlib.Tactic.FunProp
 public import Mathlib.Tactic.MkIffOfInductiveProp
 public import Mathlib.Data.Nat.Notation
+public import Lean.PrettyPrinter.Delaborator
 
 /-!
 # Basic definitions about topological spaces
@@ -197,6 +198,68 @@ scoped[Topology] notation (name := closure_of) "closure[" t "]" => @closure _ t
 /-- Notation for `Continuous` with respect to a non-standard topologies. -/
 scoped[Topology] notation (name := Continuous_of) "Continuous[" t₁ ", " t₂ "]" =>
   @Continuous _ _ t₁ t₂
+
+namespace Topology
+
+open Lean Meta PrettyPrinter.Delaborator SubExpr
+open scoped Topology
+
+/-- Return `true` if `inst` is definitionally equal to the instance synthesized for its type. -/
+private meta def isCanonicalTopologyInst (inst : Expr) : DelabM Bool := do
+  try
+    withNewMCtxDepth do
+      -- Delaboration currently does not reliably preserve local instances, so restore them here
+      -- before checking whether the instance can be re-synthesized canonically.
+      withLocalInstances (← getLCtx).decls.toList.reduceOption do
+        let some inst' ← synthInstance? (← inferType inst) | return false
+        isDefEq inst inst'
+  catch _ =>
+    return false
+
+/-- Delaborate `@IsOpen _ t` as `IsOpen[t]` when `t` is not the canonical topology instance. -/
+@[app_delab IsOpen] meta def delabIsOpenOf : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 2 do
+    let #[_, t] := (← getExpr).getAppArgs | failure
+    if ← isCanonicalTopologyInst t then
+      failure
+    `(IsOpen[$(← withNaryArg 1 delab)])
+
+/-- Delaborate `@IsClosed _ t` as `IsClosed[t]` when `t` is not the canonical topology instance. -/
+@[app_delab IsClosed] meta def delabIsClosedOf : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 2 do
+    let #[_, t] := (← getExpr).getAppArgs | failure
+    if ← isCanonicalTopologyInst t then
+      failure
+    `(IsClosed[$(← withNaryArg 1 delab)])
+
+/-- Delaborate `@closure _ t` as `closure[t]` when `t` is not the canonical topology instance. -/
+@[app_delab closure] meta def delabClosureOf : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 2 do
+    let #[_, t] := (← getExpr).getAppArgs | failure
+    if ← isCanonicalTopologyInst t then
+      failure
+    `(closure[$(← withNaryArg 1 delab)])
+
+/--
+Delaborate `@Continuous _ _ t₁ t₂` as `Continuous[t₁, t₂]`
+when either topology is noncanonical.
+-/
+@[app_delab Continuous] meta def delabContinuousOf : Delab :=
+  whenNotPPOption getPPExplicit <|
+  whenPPOption getPPNotation <|
+  withOverApp 4 do
+    let #[_, _, t₁, t₂] := (← getExpr).getAppArgs | failure
+    if (← isCanonicalTopologyInst t₁) && (← isCanonicalTopologyInst t₂) then
+      failure
+    `(Continuous[$(← withNaryArg 2 delab), $(← withNaryArg 3 delab)])
+
+end Topology
 
 /-- The property `BaireSpace α` means that the topological space `α` has the Baire property:
 any countable intersection of open dense subsets is dense.

--- a/MathlibTest/TopologyNonstandardNotation.lean
+++ b/MathlibTest/TopologyNonstandardNotation.lean
@@ -11,11 +11,39 @@ section
   #guard_msgs in
   #check (@Continuous Nat Nat (by infer_instance) (by infer_instance) (fun x : Nat => x))
 
+  /-- info: IsOpen Set.univ : Prop -/
+  #guard_msgs in
+  #check (@IsOpen Nat (by infer_instance) (Set.univ : Set Nat))
+
+  /-- info: IsOpen : Set ℕ → Prop -/
+  #guard_msgs in
+  #check (@IsOpen Nat (by infer_instance))
+
+  /-- info: IsClosed Set.univ : Prop -/
+  #guard_msgs in
+  #check (@IsClosed Nat (by infer_instance) (Set.univ : Set Nat))
+
+  /-- info: closure {0} : Set ℕ -/
+  #guard_msgs in
+  #check (@closure Nat (by infer_instance) ({0} : Set Nat))
+
+  /-- info: closure : Set ℕ → Set ℕ -/
+  #guard_msgs in
+  #check (@closure Nat (by infer_instance))
+
 end
 
 section
 
   local instance : TopologicalSpace Nat := ⊥
+
+  /-- info: Continuous[_, tNat] fun x => x : Prop -/
+  #guard_msgs in
+  #check (@Continuous Nat Nat (by infer_instance) tNat (fun x : Nat => x))
+
+  /-- info: Continuous[tNat, _] fun x => x : Prop -/
+  #guard_msgs in
+  #check (@Continuous Nat Nat tNat (by infer_instance) (fun x : Nat => x))
 
   /-- info: Continuous[tNat, tNat] fun x => x : Prop -/
   #guard_msgs in
@@ -42,7 +70,3 @@ end
 /-- info: closure[tNat] : Set ℕ → Set ℕ -/
 #guard_msgs in
 #check (@closure Nat tNat)
-
-/-- info: Continuous[tNat, tNat] fun x => x : Prop -/
-#guard_msgs in
-#check (@Continuous Nat Nat tNat tNat (fun x : Nat => x))

--- a/MathlibTest/TopologyNonstandardNotation.lean
+++ b/MathlibTest/TopologyNonstandardNotation.lean
@@ -1,0 +1,48 @@
+import Mathlib.Topology.Order
+import Mathlib.Topology.Instances.Nat
+
+def tNat : TopologicalSpace Nat := ⊤
+
+section
+
+  local instance : TopologicalSpace Nat := tNat
+
+  /-- info: Continuous fun x => x : Prop -/
+  #guard_msgs in
+  #check (@Continuous Nat Nat (by infer_instance) (by infer_instance) (fun x : Nat => x))
+
+end
+
+section
+
+  local instance : TopologicalSpace Nat := ⊥
+
+  /-- info: Continuous[tNat, tNat] fun x => x : Prop -/
+  #guard_msgs in
+  #check (@Continuous Nat Nat tNat tNat (fun x : Nat => x))
+
+end
+
+/-- info: IsOpen[tNat] Set.univ : Prop -/
+#guard_msgs in
+#check (@IsOpen Nat tNat (Set.univ : Set Nat))
+
+/-- info: IsOpen[tNat] : Set ℕ → Prop -/
+#guard_msgs in
+#check (@IsOpen Nat tNat)
+
+/-- info: IsClosed[tNat] Set.univ : Prop -/
+#guard_msgs in
+#check (@IsClosed Nat tNat (Set.univ : Set Nat))
+
+/-- info: closure[tNat] {0} : Set ℕ -/
+#guard_msgs in
+#check (@closure Nat tNat ({0} : Set Nat))
+
+/-- info: closure[tNat] : Set ℕ → Set ℕ -/
+#guard_msgs in
+#check (@closure Nat tNat)
+
+/-- info: Continuous[tNat, tNat] fun x => x : Prop -/
+#guard_msgs in
+#check (@Continuous Nat Nat tNat tNat (fun x : Nat => x))


### PR DESCRIPTION
Preserve noncanonical topology instances in delaboration.

Restore local instances before checking whether topology arguments can be omitted during delaboration, and print `IsOpen[t]`, `IsClosed[t]`, `closure[t]`, and `Continuous[t₁, t₂]` when the topology instances are not canonical in the current local-instance context.

Previously, pretty-printing could silently drop noncanonical topology arguments, so declarations such as `LinearMap.mem_span_iff_continuous_of_finite` were rendered as if they used the default topology.

Closes #33238