### PR TITLE
[Merged by Bors] - chore: fix whitespace

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Stalk.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Stalk.lean
@@ -144,7 +144,7 @@ lemma IsColimit.ι_smul {cR : Cocone R} (hcR : IsColimit cR) {cM : Cocone M}
     (β := AddCommGrpCat.FilteredColimits.colimit M)
     ((cR.ι.app i ≫ β.hom) r) ((cM.ι.app i ≫ α.hom) m))
   simp only [Functor.const_obj_obj, comp_coconePointUniqueUpToIso_hom, α, β]
-  obtain ⟨s, α, H⟩ :=  IsFilteredOrEmpty.cocone_maps (leftToMax i i) (rightToMax i i)
+  obtain ⟨s, α, H⟩ := IsFilteredOrEmpty.cocone_maps (leftToMax i i) (rightToMax i i)
   refine Functor.ιColimitType_eq_of_map_eq_map _ _ _ (leftToMax _ _ ≫ α) α ?_
   dsimp
   simp only [← ConcreteCategory.comp_apply, ← Functor.map_comp, *]

--- a/Mathlib/Algebra/Homology/SpectralSequence/Basic.lean
+++ b/Mathlib/Algebra/Homology/SpectralSequence/Basic.lean
@@ -68,7 +68,7 @@ attribute [reassoc (attr := simp)] Hom.comm
 @[simps! id_hom comp_hom]
 instance : Category (SpectralSequence C c r₀) where
   Hom := Hom
-  id _ := { hom _ _ := 𝟙 _}
+  id _ := { hom _ _ := 𝟙 _ }
   comp f g :=
     { hom r hr := f.hom r ≫ g.hom r
       comm r r' hrr' pq hr := by

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -71,7 +71,7 @@ def toProdl : (K ⋊⁅ψ⁆ L) ≃ₗ[R] K × L :=
     map_smul' _ _ := rfl }
 
 instance : Bracket (K ⋊⁅ψ⁆ L) (K ⋊⁅ψ⁆ L) where
-  bracket x y :=  ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
+  bracket x y := ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
 
 @[simp] lemma zero_eq_mk : (0 : K ⋊⁅ψ⁆ L) = ⟨0, 0⟩ := rfl
 @[simp] lemma add_eq_mk (x y : K ⋊⁅ψ⁆ L) : x + y = ⟨x.left + y.left, x.right + y.right⟩ := rfl
@@ -84,7 +84,7 @@ instance : Bracket (K ⋊⁅ψ⁆ L) (K ⋊⁅ψ⁆ L) where
 
 instance : LieRing (K ⋊⁅ψ⁆ L) where
   add_lie _ _ _ := by simp; abel
-  lie_add _ _ _:= by simp; abel
+  lie_add _ _ _ := by simp; abel
   lie_self _ := by simp
   leibniz_lie _ _ _ := by simp; grind [lie_skew]
 

--- a/Mathlib/Algebra/Module/SpanRank.lean
+++ b/Mathlib/Algebra/Module/SpanRank.lean
@@ -308,7 +308,7 @@ lemma le_spanRank_restrictScalars (N : Submodule S M) :
     N.spanRank ≤ (N.restrictScalars R).spanRank := by
   obtain ⟨s, hs, e⟩ := (N.restrictScalars R).exists_span_set_card_eq_spanRank
   obtain rfl : span S s = N :=
-    le_antisymm (span_le.mpr (span_le.mp e.le:)) (e.ge.trans (span_le_restrictScalars R S s))
+    le_antisymm (span_le.mpr (span_le.mp e.le :)) (e.ge.trans (span_le_restrictScalars R S s))
   grw [← hs, spanRank_span_le_card]
 
 lemma spanRank_restrictScalars_eq (H : Function.Surjective (algebraMap R S))

--- a/Mathlib/AlgebraicGeometry/ColimitsOver.lean
+++ b/Mathlib/AlgebraicGeometry/ColimitsOver.lean
@@ -289,7 +289,7 @@ lemma hasColimit_of_locallyDirected
   let d : ColimitGluingData D 𝒰 :=
     { cocone _ := colimit.cocone _
       isColimit _ := colimit.isColimit _
-      prop_trans := H  }
+      prop_trans := H }
   ⟨d.gluedCocone, d.isColimitGluedCocone⟩
 
 end AlgebraicGeometry.Scheme.Cover

--- a/Mathlib/AlgebraicGeometry/Group/Abelian.lean
+++ b/Mathlib/AlgebraicGeometry/Group/Abelian.lean
@@ -117,12 +117,12 @@ theorem isCommMonObj_of_isProper_of_isIntegral_tensorObj_of_isAlgClosed [IsAlgCl
         simp [Set.range_comp, Scheme.Pullback.range_map, x]
       · exact ⟨y, subset_closure (by simp), rfl⟩
       · refine ⟨xe, subset_closure ?_, ?_⟩
-        · simp [xe, ← Scheme.Hom.comp_apply, - Scheme.Hom.comp_base]
+        · simp [xe, ← Scheme.Hom.comp_apply, -Scheme.Hom.comp_base]
         · simp only [xe, γ, ← Scheme.Hom.comp_apply, ← Over.comp_left]
           congr 6; ext <;> simp
     convert congr((snd G G).left $this) using 1
     · simp [γ, ← Scheme.Hom.comp_apply]
-    · simp [xe, ← Scheme.Hom.comp_apply, - Scheme.Hom.comp_base]
+    · simp [xe, ← Scheme.Hom.comp_apply, -Scheme.Hom.comp_base]
   · simp
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiFinite.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiFinite.lean
@@ -307,7 +307,7 @@ nonrec lemma LocallyQuasiFinite.of_finite_preimage_singleton
   obtain ⟨R, rfl⟩ := hY
   wlog hX : ∃ S, X = Spec S
   · exact (IsZariskiLocalAtSource.iff_of_openCover X.affineCover).mpr fun i ↦ this _ _
-      (fun x ↦ ((hf x).preimage (X.affineCover.f _).isOpenEmbedding.injective.injOn:)) ⟨_, rfl⟩
+      (fun x ↦ ((hf x).preimage (X.affineCover.f _).isOpenEmbedding.injective.injOn :)) ⟨_, rfl⟩
   obtain ⟨S, rfl⟩ := hX
   obtain ⟨φ, rfl⟩ := Spec.map_surjective f
   simp only [HasRingHomProperty.Spec_iff, id_eq] at *

--- a/Mathlib/AlgebraicGeometry/Normalization.lean
+++ b/Mathlib/AlgebraicGeometry/Normalization.lean
@@ -616,7 +616,7 @@ instance [Smooth g] : IsIso (f.normalizationPullback g) := by
       ← Scheme.Hom.preimage_inf, inf_eq_right.mpr hVU]) hU hV (f.isCompact_preimage hU.isCompact)
     (f.isQuasiSeparated_preimage hU.isQuasiSeparated)
   let e₀ := (CommRingCat.isPushout_tensorProduct ..).flip.isoPushout ≪≫
-    (pushout.congrHom f.app_eq_appLE rfl ≪≫ @asIso _ _ _ _ _ this:)
+    (pushout.congrHom f.app_eq_appLE rfl ≪≫ @asIso _ _ _ _ _ this :)
   let e : Γ(Y, V) ⊗[Γ(S, U)] Γ(X, f ⁻¹ᵁ U) ≃ₐ[Γ(Y, V)] Γ(pullback f g, pullback.snd f g ⁻¹ᵁ V) :=
     { toRingEquiv := e₀.commRingCatIsoToRingEquiv,
       commutes' r := by

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -806,7 +806,7 @@ lemma Scheme.Hom.isPullback_resLE
     IsPullback (g.resLE UX UY (by simp [*])) (iY.resLE UT UY (by simp [*]))
       (iX.resLE US UX hUSX) (f.resLE US UT hUST) := by
   refine .paste_horiz (v₁₂ := iY.resLE _ _
-    ((g.preimage_mono hUSX).trans_eq congr(($H.w) ⁻¹ᵁ US):)) ?_ ?_
+    ((g.preimage_mono hUSX).trans_eq congr(($H.w) ⁻¹ᵁ US) :)) ?_ ?_
   · refine (IsOpenImmersion.isPullback _ _ _ _ (by simp) ?_).flip
     simp only [Scheme.opensRange_homOfLE, ← Scheme.Hom.comp_preimage, Scheme.Hom.resLE_comp_ι]
     rw [Scheme.Hom.comp_preimage, ← (g ⁻¹ᵁ UX).ι.image_injective.eq_iff]

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -290,7 +290,7 @@ theorem Spec_Γ_naturality {R S : CommRingCat.{u}} (f : R ⟶ S) :
 /-- The counit (`SpecΓIdentity.inv.op`) of the adjunction `Γ ⊣ Spec` is an isomorphism. -/
 @[simps! hom_app inv_app]
 def LocallyRingedSpace.SpecΓIdentity : Spec.toLocallyRingedSpace.rightOp ⋙ Γ ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents.{u, u, u + 1, u + 1} (fun R ↦ asIso (toSpecΓ R):)
+  Iso.symm <| NatIso.ofComponents.{u, u, u + 1, u + 1} (fun R ↦ asIso (toSpecΓ R) :)
     fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f
 
 end SpecΓ

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -188,7 +188,8 @@ instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     Algebra R ((structureSheafInType R A).val.obj U) :=
   (sectionsSubalgebra A U.unop).algebra
 
-local notation "Γ("M", "U")" => (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
+local notation "Γ(" M ", " U ")" =>
+  (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
 
 @[simp]
 lemma structureSheafInType.add_apply {U : Opens (PrimeSpectrum.Top R)} (s t : Γ(M, U)) (x : U) :
@@ -378,7 +379,8 @@ end StructureSheaf
 
 end Public
 
-local notation "Γ("M", "U")" => (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
+local notation "Γ(" M ", " U ")" =>
+  (Functor.obj (Sheaf.val (structureSheafInType _ M))) (Opposite.op U)
 
 namespace StructureSheaf
 
@@ -666,7 +668,7 @@ def localizationtoStalkₗ (x : PrimeSpectrum.Top R) :
       (structurePresheafInModuleCat R M).stalk x :=
   ModuleCat.ofHom (IsLocalizedModule.lift x.asIdeal.primeCompl
     (LocalizedModule.mkLinearMap x.asIdeal.primeCompl M)
-    (toStalkₗ' R M x).hom fun f ↦ isUnit_toStalkₗ' x f.1 f.2:)
+    (toStalkₗ' R M x).hom fun f ↦ isUnit_toStalkₗ' x f.1 f.2 :)
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]

--- a/Mathlib/AlgebraicGeometry/ZariskisMainTheorem.lean
+++ b/Mathlib/AlgebraicGeometry/ZariskisMainTheorem.lean
@@ -109,7 +109,7 @@ theorem exists_etale_isCompl_of_quasiFiniteAt [IsSeparated f]
   · exact ⟨⟨P', ‹_›⟩, heP', rfl⟩
   · simp [isCompl_iff, disjoint_iff, codisjoint_iff, W₂, SetLike.ext'_iff]
   · trans hV.fromSpec ⟨P'.comap Algebra.TensorProduct.includeRight.toRingHom, inferInstance⟩
-    · simp [← Scheme.Hom.comp_apply, - Scheme.Hom.comp_base, g, reassoc_of% he₁]; rfl
+    · simp [← Scheme.Hom.comp_apply, -Scheme.Hom.comp_base, g, reassoc_of% he₁]; rfl
     convert hV.fromSpec_primeIdealOf ⟨x, hxV⟩
 
 variable {X Y S : Scheme.{u}} (f : X ⟶ Y)

--- a/Mathlib/AlgebraicTopology/ModelCategory/BifibrantObjectHomotopy.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/BifibrantObjectHomotopy.lean
@@ -286,7 +286,7 @@ noncomputable def bifibrantResolutionMap {X₁ X₂ : CofibrantObject C} (f : X�
 
 @[reassoc (attr := simp)]
 lemma bifibrantResolutionMap_fac {X₁ X₂ : CofibrantObject C} (f : X₁ ⟶ X₂) :
-    iBifibrantResolutionObj X₁ ≫ homMk (bifibrantResolutionMap f).hom  =
+    iBifibrantResolutionObj X₁ ≫ homMk (bifibrantResolutionMap f).hom =
       f ≫ iBifibrantResolutionObj X₂ :=
   (exists_bifibrant_map f).choose_spec
 
@@ -390,7 +390,7 @@ noncomputable def HoCat.adjCounit' :
           (bifibrantResolutionMap_fac (CofibrantObject.homMk f.hom)).symm
         ext : 1
         dsimp
-        exact this ) }
+        exact this) }
 
 lemma HoCat.adjCounit'_app (X : BifibrantObject C) :
     HoCat.adjCounit'.app (BifibrantObject.toHoCat.obj X) =

--- a/Mathlib/AlgebraicTopology/ModelCategory/FibrantObjectHomotopy.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/FibrantObjectHomotopy.lean
@@ -217,9 +217,9 @@ a natural transformation `toHoCat ⟶ ι ⋙ HoCat.resolution`. -/
 @[simps]
 noncomputable def HoCat.ιCompResolutionNatTrans : toHoCat ⟶ ι ⋙ HoCat.resolution (C := C) where
   app X := toHoCat.map { hom := (HoCat.iResolutionObj (ι.obj X)) }
-  naturality _ _ f :=  toHoCat.congr_map (by
+  naturality _ _ f := toHoCat.congr_map (by
     ext : 1
-    exact (HoCat.resolutionMap_fac f.hom).symm )
+    exact (HoCat.resolutionMap_fac f.hom).symm)
 
 set_option backward.isDefEq.respectTransparency false in
 instance (X : FibrantObject C) :

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -175,7 +175,7 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculusIsClosedEmbedding :
   isClosedEmbedding a ha := by
     apply isometry_inr (𝕜 := 𝕜) (A := A) |>.isClosedEmbedding |>.of_comp_iff.mp
     convert isClosedEmbedding_cfcₙAux hp₁ a ha
-    congrm(⇑$(inrNonUnitalStarAlgHom_comp_cfcₙHom_eq_cfcₙAux hp₁ a ha))
+    congrm (⇑$(inrNonUnitalStarAlgHom_comp_cfcₙHom_eq_cfcₙAux hp₁ a ha))
 
 end RCLike
 

--- a/Mathlib/Analysis/Complex/Periodic.lean
+++ b/Mathlib/Analysis/Complex/Periodic.lean
@@ -274,7 +274,7 @@ lemma cuspFunction_add {h} {f g : ℂ → ℂ} (hfcts : ContinuousAt (cuspFuncti
   ext y
   obtain hy | rfl := ne_or_eq y 0
   · simp [hy]
-  ·  simpa using (tendsto_nhds_limUnder ⟨_, tendsto_nhds_zero hfcts⟩).add
+  · simpa using (tendsto_nhds_limUnder ⟨_, tendsto_nhds_zero hfcts⟩).add
       (tendsto_nhds_limUnder ⟨_, tendsto_nhds_zero hgcts⟩) |>.limUnder_eq
 
 lemma cuspFunction_sub {h} {f g : ℂ → ℂ} (hfcts : ContinuousAt (cuspFunction h f) 0)

--- a/Mathlib/Analysis/Complex/Poisson.lean
+++ b/Mathlib/Analysis/Complex/Poisson.lean
@@ -73,7 +73,8 @@ private lemma re_herglotzRieszKernel_le_aux (φ θ r R : ℝ) (h₁ : 0 < r) (h�
   rw [div_eq_mul_inv]
   have h_cos : (R ^ 2 + r ^ 2 - 2 * R * r * Real.cos (θ - φ)) ≥ (R - r) ^ 2 := by
     nlinarith [mul_pos h₁ (sub_pos.mpr h₂), Real.cos_le_one (θ - φ)]
-  have h_subst : (R^2 - r^2) / (R^2 + r^2 - 2 * R * r * Real.cos (θ - φ)) ≤ (R + r) / (R - r) := by
+  have h_subst :
+      (R ^ 2 - r ^ 2) / (R ^ 2 + r ^ 2 - 2 * R * r * Real.cos (θ - φ)) ≤ (R + r) / (R - r) := by
     rw [div_le_div_iff₀] <;> nlinarith [mul_pos h₁ (sub_pos.mpr h₂)]
   convert h_subst using 1
   rw [← div_eq_mul_inv, poissonKernel_eq_re_herglotzRieszKernel_aux]
@@ -133,7 +134,7 @@ theorem le_re_herglotzRieszKernel {c z : ℂ} (hz : z ∈ sphere c R) (hw : w �
 -- Trigonometric identity used in the computation of
 -- `DiffContOnCl.circleAverage_re_smul_on_ball_zero`.
 private lemma circleAverage_re_smul_on_ball_zero_aux {φ θ : ℝ} {r : ℝ} :
-    (R * exp (θ * I)) / (R * exp (θ * I)  - r * exp (φ * I)) - (r * exp (θ * I))
+    (R * exp (θ * I)) / (R * exp (θ * I) - r * exp (φ * I)) - (r * exp (θ * I))
       / (r * exp (θ * I) - R * exp (φ * I))
       = ((R * exp (θ * I) + r * exp (φ * I)) / (R * exp (θ * I) - r * exp (φ * I))).re := by
   simp only [Complex.ext_iff, exp_ofReal_mul_I, add_re, sub_re, mul_re, div_re, ofReal_re,

--- a/Mathlib/Analysis/Convex/Approximation.lean
+++ b/Mathlib/Analysis/Convex/Approximation.lean
@@ -40,17 +40,17 @@ variable {𝕜 E F : Type*} {s : Set E} {φ : E → ℝ} [RCLike 𝕜]
 theorem convex_re_epigraph [AddCommMonoid E] [Module ℝ E] (hφcv : ConvexOn ℝ s φ) :
     Convex ℝ { p : E × 𝕜 | p.1 ∈ s ∧ φ p.1 ≤ re p.2 } := by
   have lem : { p : E × 𝕜 | p.1 ∈ s ∧ φ p.1 ≤ re p.2 } =
-    ((LinearMap.id : E →ₗ[ℝ] E).prodMap reLm)⁻¹' { p : E × ℝ | p.1 ∈ s ∧ φ p.1 ≤ p.2 } := by simp
+    ((LinearMap.id : E →ₗ[ℝ] E).prodMap reLm) ⁻¹' { p : E × ℝ | p.1 ∈ s ∧ φ p.1 ≤ p.2 } := by simp
   exact lem ▸ hφcv.convex_epigraph.linear_preimage _
 
 variable [TopologicalSpace E]
 
 theorem _root_.LowerSemicontinuousOn.isClosed_re_epigraph (hsc : IsClosed s)
     (hφ_cont : LowerSemicontinuousOn φ s) :
-    IsClosed  { p : E × 𝕜 | p.1 ∈ s ∧ φ p.1 ≤ re p.2 } := by
+    IsClosed { p : E × 𝕜 | p.1 ∈ s ∧ φ p.1 ≤ re p.2 } := by
   let A := { p : E × EReal | p.1 ∈ s ∧ φ p.1 ≤ p.2 }
   have hC : { p : E × 𝕜 | p.1 ∈ s ∧ φ p.1 ≤ re p.2 }
-    = (Prod.map id ((Real.toEReal ∘ re) : 𝕜 → EReal))⁻¹' A := by simp [A]
+    = (Prod.map id ((Real.toEReal ∘ re) : 𝕜 → EReal)) ⁻¹' A := by simp [A]
   refine hC.symm ▸ IsClosed.preimage ?_ ?_
   · exact continuous_id.prodMap <| continuous_coe_real_ereal.comp reCLM.cont
   · exact (lowerSemicontinuousOn_iff_isClosed_epigraph hsc).1
@@ -202,7 +202,7 @@ theorem univ_sSup_of_nat_affine_eq [HereditarilyLindelofSpace E]
     ∃ (l : ℕ → E →L[𝕜] 𝕜) (c : ℕ → ℝ), ⨆ i, re ∘ (l i) + const E (c i) = φ := by
   obtain ⟨𝓕', h𝓕'⟩ := hφcv.univ_sSup_of_countable_affine_eq (𝕜 := 𝕜) hφc
   by_cases! he : 𝓕'.Nonempty
-  · obtain ⟨f, hf⟩ := h𝓕'.1.exists_eq_range  he
+  · obtain ⟨f, hf⟩ := h𝓕'.1.exists_eq_range he
     have (i : ℕ) : ∃ (l : E →L[𝕜] 𝕜) (c : ℝ), f i = re ∘ l + const E c := by simp_all
     choose l c hlc using this
     refine ⟨l, c, ?_⟩

--- a/Mathlib/Analysis/InnerProductSpace/Harmonic/HarmonicContOnCl.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Harmonic/HarmonicContOnCl.lean
@@ -83,7 +83,7 @@ theorem mono {t : Set E} (h : HarmonicContOnCl f s) (ht : t ⊆ s) :
   HarmonicContOnCl ((fun _ ↦ c) + f) s := harmonicContOnCl_const.add hf
 
 @[to_fun] theorem neg (hf : HarmonicContOnCl f s) :
-    HarmonicContOnCl  (-f) s := ⟨hf.1.neg, hf.2.neg⟩
+    HarmonicContOnCl (-f) s := ⟨hf.1.neg, hf.2.neg⟩
 
 @[to_fun] theorem sub (hf₁ : HarmonicContOnCl f₁ s) (hf₂ : HarmonicContOnCl f₂ s) :
     HarmonicContOnCl (f₁ - f₂) s := ⟨hf₁.1.sub hf₂.1, hf₁.2.sub hf₂.2⟩

--- a/Mathlib/Analysis/Normed/Group/Bounded.lean
+++ b/Mathlib/Analysis/Normed/Group/Bounded.lean
@@ -90,7 +90,7 @@ lemma Bornology.IsBounded.exists_pos_norm_lt' (hs : IsBounded s) : ∃ R > 0, �
 
 @[to_additive]
 lemma NormedCommGroup.cauchySeq_iff [Nonempty α] [SemilatticeSup α] {u : α → E} :
-    CauchySeq u ↔ ∀ ε > 0, ∃ N, ∀ m, N ≤ m → ∀ n, N ≤ n → ‖(u m) ⁻¹ * u n‖ < ε := by
+    CauchySeq u ↔ ∀ ε > 0, ∃ N, ∀ m, N ≤ m → ∀ n, N ≤ n → ‖(u m)⁻¹ * u n‖ < ε := by
   simp [Metric.cauchySeq_iff, dist_eq_norm_inv_mul]
 
 @[to_additive IsCompact.exists_bound_of_continuousOn]

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -416,8 +416,7 @@ noncomputable def leftInverse_of_injective_of_isClosed_range
     simp only [dist_zero_right, map_zero] at aux
     convert aux
     exact f.rangeRestrict.leftInverse_apply_of_inj
-      (by rw [ker_codRestrict]; exact LinearMap.ker_eq_bot.mpr hf) x
-  )
+      (by rw [ker_codRestrict]; exact LinearMap.ker_eq_bot.mpr hf) x)
 
 end
 

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -914,7 +914,7 @@ noncomputable def toNormedRing {R : Type*} [Ring R] (v : AbsoluteValue R ℝ) : 
   dist_eq _ _ := rfl
   dist_self x := by simp
   dist_comm x y := by rw [add_comm (-x), add_comm (-y), ← sub_eq_add_neg, v.map_sub, sub_eq_add_neg]
-  dist_triangle x y z := by simpa [neg_add_eq_sub, add_comm ( v (y - x))] using v.sub_le z y x
+  dist_triangle x y z := by simpa [neg_add_eq_sub, add_comm (v (y - x))] using v.sub_le z y x
   edist_dist x y := rfl
   norm_mul_le x y := (v.map_mul x y).le
   eq_of_dist_eq_zero := by

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/BinaryBiproducts.lean
@@ -43,11 +43,11 @@ def pointwiseBinaryBicone.isBilimit : (pointwiseBinaryBicone F G).IsBilimit wher
   isLimit := evaluationJointlyReflectsLimits _ fun d => by
     refine IsLimit.equivOfNatIsoOfIso ?_ _ _ ?_ (BinaryBiproduct.isLimit (F.obj d) (G.obj d))
     · exact (pairComp F G ((evaluation D C).obj d)).symm
-    · exact Cones.ext (Iso.refl _) <| by rintro (_ | _ | _)<;> cat_disch
+    · exact Cones.ext (Iso.refl _) <| by rintro (_ | _ | _) <;> cat_disch
   isColimit := evaluationJointlyReflectsColimits _ fun d => by
     refine IsColimit.equivOfNatIsoOfIso ?_ _ _ ?_ (BinaryBiproduct.isColimit (F.obj d) (G.obj d))
     · exact (pairComp F G ((evaluation D C).obj d)).symm
-    · exact Cocones.ext (Iso.refl _) <| by rintro (_ | _ | _)<;> cat_disch
+    · exact Cocones.ext (Iso.refl _) <| by rintro (_ | _ | _) <;> cat_disch
 
 /-- Construction of the binary biproduct data for functors `F` and `G` -/
 @[simps]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -440,11 +440,11 @@ def adj (adj₂ : F ⊣₂ G) (X₁ : Arrow C₁) [HasPullbacks C₂] [HasPushou
       w := by
         apply pullback.hom_ext
         · simp [← homEquiv_naturality_one, ← homEquiv_naturality_two, pushout.condition]
-        · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]}
+        · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three] }
     naturality _ _ _ := by
       ext
       · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]
-      · apply pullback.hom_ext <;> simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]}
+      · apply pullback.hom_ext <;> simp [← homEquiv_naturality_two, ← homEquiv_naturality_three] }
   counit := {
     app X₃ := {
       left := pushout.desc (adj₂.homEquiv.symm (𝟙 _)) (adj₂.homEquiv.symm (pullback.fst ..))
@@ -454,12 +454,12 @@ def adj (adj₂ : F ⊣₂ G) (X₁ : Arrow C₁) [HasPullbacks C₂] [HasPushou
         apply pushout.hom_ext
         · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three]
         · simp [← homEquiv_symm_naturality_one, ← homEquiv_symm_naturality_three,
-            pullback.condition]}
+            pullback.condition] }
     naturality _ _ _ := by
       ext
       · apply pushout.hom_ext <;> simp [← homEquiv_symm_naturality_two,
           ← homEquiv_symm_naturality_three]
-      · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three]}
+      · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three] }
   left_triangle_components _ := by
     ext
     · apply pushout.hom_ext <;> simp [← homEquiv_symm_naturality_two, ofHasPushout_pt]

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -199,7 +199,7 @@ see `CategoryTheory.GrpObj.lift_commutator_eq_mul_mul_inv_inv`.
 This morphism is constant with value `1` if and only if `G` is commutative
 (see `CategoryTheory.isCommMonObj_iff_commutator_eq_toUnit_η`). -/
 def GrpObj.commutator (G : C) [GrpObj G] : G ⊗ G ⟶ G :=
-  fst _ _ * snd _ _ * (fst _ _) ⁻¹ * (snd _ _) ⁻¹
+  fst _ _ * snd _ _ * (fst _ _)⁻¹ * (snd _ _)⁻¹
 
 @[reassoc (attr := simp)]
 lemma GrpObj.lift_commutator_eq_mul_mul_inv_inv {X G : C} [GrpObj G] (f₁ f₂ : X ⟶ G) :

--- a/Mathlib/CategoryTheory/RegularCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/RegularCategory/Basic.lean
@@ -196,7 +196,7 @@ lemma frobeniusMorphism_isPullback :
   apply IsPullback.of_right (t := (inf_isPullback ((«exists» f).obj A') B').flip)
     (p := by simp [frobeniusMorphism])
   simpa [frobeniusMorphism, IsPullback.lift_fst, ← imageFactorisation_F_m,
-    (isPullback f B').paste_horiz_iff ] using
+    (isPullback f B').paste_horiz_iff] using
     (inf_isPullback A' ((Subobject.pullback f).obj B')).flip
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/OneHypercoverDense.lean
@@ -106,7 +106,7 @@ def multicospanMap {P Q : C₀ᵒᵖ ⥤ A} (f : P ⟶ Q) :
     | WalkingMulticospan.left i => f.app _
     | WalkingMulticospan.right j => f.app _
   naturality := by
-    rintro (i₁|j₁) (i₂|j₂) (_|_)
+    rintro (i₁ | j₁) (i₂ | j₂) (_ | _)
     all_goals simp
 
 /-- The natural isomorphism between the diagrams attached to `data : F.PreOneHypercoverDenseData X`
@@ -403,7 +403,7 @@ end
 /-- Auxiliary definition for the lemma `OneHypercoverDenseData.isSheaf_iff`. -/
 noncomputable def isLimit : IsLimit (S.multifork G) :=
   Multifork.IsLimit.mk _
-    (lift hG₀ hG ) (fac hG₀ hG) (fun s _ hm ↦
+    (lift hG₀ hG) (fac hG₀ hG) (fun s _ hm ↦
       hom_ext hG₀ hG (fun a ↦ (hm a).trans (fac hG₀ hG s a).symm))
 
 end isSheaf_iff

--- a/Mathlib/CategoryTheory/Sites/Descent/DescentDataPrime.lean
+++ b/Mathlib/CategoryTheory/Sites/Descent/DescentDataPrime.lean
@@ -233,9 +233,9 @@ lemma comm {D₁ D₂ : F.DescentData' sq sq₃} (φ : D₁ ⟶ D₂)
     (hf₁ : f₁ ≫ f i₁ = q := by cat_disch) (hf₂ : f₂ ≫ f i₂ = q := by cat_disch) :
     (F.map f₁.op.toLoc).toFunctor.map (φ.hom i₁) ≫ pullHom' D₂.hom q f₁ f₂ hf₁ hf₂ =
       pullHom' D₁.hom q f₁ f₂ hf₁ hf₂ ≫ (F.map f₂.op.toLoc).toFunctor.map (φ.hom i₂) := by
-  obtain ⟨p, _, _⟩  := (sq i₁ i₂).isPullback.exists_lift f₁ f₂ (by cat_disch)
-  rw [← pullHom_pullHom' D₂.hom p (sq i₁ i₂).p q  (sq i₁ i₂).p₁ (sq i₁ i₂).p₂ f₁ f₂,
-    ← pullHom_pullHom' D₁.hom p (sq i₁ i₂).p q  (sq i₁ i₂).p₁ (sq i₁ i₂).p₂ f₁ f₂,
+  obtain ⟨p, _, _⟩ := (sq i₁ i₂).isPullback.exists_lift f₁ f₂ (by cat_disch)
+  rw [← pullHom_pullHom' D₂.hom p (sq i₁ i₂).p q (sq i₁ i₂).p₁ (sq i₁ i₂).p₂ f₁ f₂,
+    ← pullHom_pullHom' D₁.hom p (sq i₁ i₂).p q (sq i₁ i₂).p₁ (sq i₁ i₂).p₂ f₁ f₂,
     pullHom'_p₁_p₂, pullHom'_p₁_p₂]
   dsimp only [pullHom]
   rw [NatTrans.naturality_assoc]

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/AbelianSubcategory.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/AbelianSubcategory.lean
@@ -148,7 +148,7 @@ lemma exists_lift_ιK {B : A} (x₁ : B ⟶ X₁) (hx₁ : x₁ ≫ f₁ = 0) :
 
 /-- `ιK` is a kernel. -/
 noncomputable def isLimitKernelFork : IsLimit (KernelFork.ofι _ (ιK_mor₁ hT α)) :=
-  KernelFork.IsLimit.ofι _ _  _
+  KernelFork.IsLimit.ofι _ _ _
     (fun x₁ hx₁ ↦ (exists_lift_ιK hι hT hT' x₁ hx₁).choose_spec)
     (fun x₁ hx₁ m hm ↦ by
       have := mono_ιK hι hT hT'

--- a/Mathlib/Geometry/Manifold/IsManifold/ExtChartAt.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/ExtChartAt.lean
@@ -410,7 +410,7 @@ lemma isInvertible_fderivWithin_extendCoordChange (hn : n ≠ 0)
   · rw [← φ.left_inv hx, φ.right_inv (φ.map_source hx), ← fderivWithin_comp,
       fderivWithin_congr' φ.rightInvOn.eqOn (φ.map_source hx), fderivWithin_id]
     · exact I.uniqueDiffOn_extendCoordChange_source _ (φ.map_source hx)
-    · exact (φ.left_inv hx ▸ ((hφ _ hx).differentiableWithinAt hn):)
+    · exact (φ.left_inv hx ▸ ((hφ _ hx).differentiableWithinAt hn) :)
     · exact (hφ' _ (φ.map_source hx)).differentiableWithinAt hn
     · exact φ.symm_mapsTo
     · exact I.uniqueDiffOn_extendCoordChange_source _ (φ.map_source hx)

--- a/Mathlib/GroupTheory/Focal.lean
+++ b/Mathlib/GroupTheory/Focal.lean
@@ -186,7 +186,7 @@ lemma ker_transferFocal_inf_eq_focalSubgroup : P.transferFocal.ker ⊓ P = P.foc
 For a Sylow p-subgroup P of a finite group G, `P ∩ G' = P*`,
 where `P*` is the focal subgroup of `P`.
 -/
-theorem commutator_inf_eq_focalSubgroup :  _root_.commutator G ⊓ P = P.focalSubgroup := by
+theorem commutator_inf_eq_focalSubgroup : _root_.commutator G ⊓ P = P.focalSubgroup := by
   apply le_antisymm
   · apply le_trans ?_ (ker_transferFocal_inf_eq_focalSubgroup P).le
     exact inf_le_inf_right _ (Abelianization.commutator_subset_ker P.transferFocal)

--- a/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/OfQuotient.lean
@@ -59,7 +59,7 @@ open scoped FixedPoints
 
 variable {α : Type*} [Group α] [MulDistribMulAction G α]
 
-instance : MulDistribMulAction (G ⧸ H) (α ^* H) :=
+instance : MulDistribMulAction (G ⧸ H) (α^*H) :=
   inferInstanceAs (MulDistribMulAction (G ⧸ H) (FixedPoints.submonoid H α))
 
 end MulDistribMulAction

--- a/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
+++ b/Mathlib/InformationTheory/Coding/KraftMcMillan.lean
@@ -70,7 +70,7 @@ private lemma sum_pow_length_filter_eq_le_card_mul [Fintype α] [Nonempty α]
     (∑ x ∈ T.filter (fun x => x.length = s), (1 / (Fintype.card α : ℝ)) ^ x.length)
       ≤ ((Fintype.card α) ^ s) * (1 / Fintype.card α) ^ s := by
   calc
-    _  = ∑ x ∈ T.filter (fun x => x.length = s), (1 / (Fintype.card α : ℝ)) ^ s :=
+    _ = ∑ x ∈ T.filter (fun x => x.length = s), (1 / (Fintype.card α : ℝ)) ^ s :=
       Finset.sum_congr rfl fun x hx ↦ by simp [Finset.mem_filter.mp hx]
     _ = (T.filter fun x => x.length = s).card * (1 / Fintype.card α) ^ s := by
       simp only [Finset.sum_const, nsmul_eq_mul]

--- a/Mathlib/LinearAlgebra/Matrix/Stochastic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Stochastic.lean
@@ -53,7 +53,7 @@ def rowStochastic (R n : Type*) [Fintype n] [DecidableEq n] [Semiring R] [Partia
     simp [zero_le_one_elem]
 
 lemma mem_rowStochastic :
-    M ∈ rowStochastic R n ↔ (∀ i j, 0 ≤ M i j) ∧  M *ᵥ 1 = 1 :=
+    M ∈ rowStochastic R n ↔ (∀ i j, 0 ≤ M i j) ∧ M *ᵥ 1 = 1 :=
   Iff.rfl
 
 /-- A square matrix is row stochastic if each element is non-negative and row sums to one. -/

--- a/Mathlib/MeasureTheory/Function/ConditionalLExpectation.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalLExpectation.lean
@@ -124,7 +124,7 @@ theorem measurable_condLExp (mΩ : MeasurableSpace Ω) (P : Measure[mΩ₀] Ω) 
 theorem measurable_condLExp' (mΩ : MeasurableSpace Ω) (P : Measure[mΩ₀] Ω) (X : Ω → ℝ≥0∞) :
     Measurable[mΩ₀] P⁻[X|mΩ] := by
   by_cases hm : mΩ ≤ mΩ₀
-  · exact (measurable_condLExp _ _ _).mono  hm (le_refl _)
+  · exact (measurable_condLExp _ _ _).mono hm (le_refl _)
   · simp [condLExp_of_not_le hm, measurable_zero]
 
 variable (hm : mΩ ≤ mΩ₀)

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/LpNorm.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/LpNorm.lean
@@ -217,7 +217,7 @@ lemma lpNorm_sum_le {ι : Type*} {s : Finset ι} {f : ι → α → E} (hf : ∀
 -- TODO: Golf using `eLpNorm_expect_le` once it exists
 lemma lpNorm_expect_le [Module ℚ≥0 E] [NormedSpace ℝ E] {ι : Type*} {s : Finset ι}
     {f : ι → α → E} (hf : ∀ i ∈ s, MemLp (f i) p μ) (hp : 1 ≤ p) :
-    lpNorm (𝔼 i ∈ s, f i) p μ ≤ 𝔼 i ∈ s, lpNorm (f i) p μ  :=  by
+    lpNorm (𝔼 i ∈ s, f i) p μ ≤ 𝔼 i ∈ s, lpNorm (f i) p μ := by
   obtain rfl | hs := s.eq_empty_or_nonempty
   · simp
   refine (le_inv_smul_iff_of_pos <| by positivity).2 ?_

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/AbsolutelyContinuousFun.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/AbsolutelyContinuousFun.lean
@@ -187,7 +187,7 @@ theorem AbsolutelyContinuousOnInterval.const_of_ae_hasDerivAt_zero {f : ℝ → 
   · simp [hr.le]
   replace hf₀ : ∀ᵐ x, x ∈ Ioo d b → HasDerivAt f 0 x := by
     filter_upwards [hf₀] with x _ _ using by grind
-  have hfdb': 0 < r / (b - d) := by apply div_pos <;> linarith
+  have hfdb' : 0 < r / (b - d) := by apply div_pos <;> linarith
   have ⟨u, hu₁, hu₂, hu₃⟩ :=
     exists_dist_slope_lt_pairwiseDisjoint_hasSum hd.right hf₀ hfdb'
   let g := fun (z : u) ↦ dist (f z.val.1) (f z.val.2)

--- a/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
@@ -231,7 +231,7 @@ theorem vectorMeasure_Ioi (hf : BoundedVariationOn f univ) (a : α) :
 theorem vectorMeasure_Iic (hf : BoundedVariationOn f univ) (a : α) :
     hf.vectorMeasure (Iic a) = f.rightLim a - limUnder atBot f := by
   have : Nonempty α := ⟨a⟩
-  have hlim : Tendsto f atBot (𝓝 (limUnder atBot f)) :=  hf.tendsto_atBot_limUnder
+  have hlim : Tendsto f atBot (𝓝 (limUnder atBot f)) := hf.tendsto_atBot_limUnder
   obtain ⟨u, u_anti, hu⟩ : ∃ u, Antitone u ∧ Tendsto u atTop atBot :=
     Filter.exists_seq_antitone_tendsto_atTop_atBot α
   have A : Tendsto (fun n ↦ hf.vectorMeasure (Icc (u n) a)) atTop

--- a/Mathlib/NumberTheory/ModularForms/DedekindEta.lean
+++ b/Mathlib/NumberTheory/ModularForms/DedekindEta.lean
@@ -153,7 +153,7 @@ lemma logDeriv_eta_eq_E2 (z : ℍ) : logDeriv eta z = (π * I / 12) * E2 z := by
     (differentiableAt_eta_tprod z.2)]
   have HG := logDeriv_tprod_eq_tsum isOpen_upperHalfPlaneSet z.2
     (one_sub_eta_q_ne_zero · z.2) (by fun_prop) (summable_logDeriv_one_sub_eta_q z.2)
-    (multipliableLocallyUniformlyOn_eta ) (eta_tprod_ne_zero z.2)
+    multipliableLocallyUniformlyOn_eta (eta_tprod_ne_zero z.2)
   simp only [logDeriv_qParam 24 z, HG, tsum_logDeriv_eta_q z, E2, one_div,
     mul_inv_rev, Pi.smul_apply, smul_eq_mul]
   rw [G2_eq_tsum_cexp, riemannZeta_two, ← tsum_pow_div_one_sub_eq_tsum_sigma

--- a/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/HilbertTheory.lean
@@ -43,7 +43,7 @@ class IsDecompositionField [MulSemiringAction Gal(L/K) B] extends
     IsGaloisGroup (stabilizer Gal(L/K) P) D L
 
 instance [MulSemiringAction Gal(L/K) B] [h : IsGaloisGroup (stabilizer Gal(L/K) P) D L] :
-    IsDecompositionField K L P D :=  { toIsGaloisGroup := h }
+    IsDecompositionField K L P D := { toIsGaloisGroup := h }
 
 variable (E : Type*) [Field E] [Algebra E L]
 
@@ -57,7 +57,7 @@ class IsInertiaField [MulSemiringAction Gal(L/K) B] extends
     IsGaloisGroup (inertia Gal(L/K) P) E L
 
 instance [MulSemiringAction Gal(L/K) B] [h : IsGaloisGroup (inertia Gal(L/K) P) D L] :
-    IsInertiaField K L P D :=  { toIsGaloisGroup := h }
+    IsInertiaField K L P D := { toIsGaloisGroup := h }
 
 variable [MulSemiringAction Gal(L/K) B]
 

--- a/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
@@ -90,7 +90,7 @@ protected lemma DirectedOn.csSup_le (hd : DirectedOn (· ≤ ·) s) (h_non : s.N
 @[to_dual ciInf_le]
 protected lemma Directed.le_ciSup (hf : Directed (· ≤ ·) f)
     (hf_bdd : BddAbove (Set.range f)) (i : ι) : f i ≤ ⨆ j, f j :=
-  hf.directedOn_range.le_csSup  hf_bdd <| Set.mem_range_self _
+  hf.directedOn_range.le_csSup hf_bdd <| Set.mem_range_self _
 
 @[to_dual le_ciInf]
 protected lemma Directed.ciSup_le [Nonempty ι] (hf : Directed (· ≤ ·) f)

--- a/Mathlib/Order/ScottContinuity.lean
+++ b/Mathlib/Order/ScottContinuity.lean
@@ -101,7 +101,7 @@ theorem ScottContinuousOn.image_comp {g : β → γ}
     (hg : ScottContinuousOn ((f '' ·) '' D) g)
     (hf : ScottContinuousOn D f) :
     ScottContinuousOn D (g ∘ f) :=
-  ScottContinuousOn.comp hD (Set.mapsTo_image  (f '' ·) D) hg hf
+  ScottContinuousOn.comp hD (Set.mapsTo_image (f '' ·) D) hg hf
 
 @[fun_prop]
 lemma ScottContinuousOn.prodMk {g : α → γ} (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D)

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -76,7 +76,7 @@ instance : AddMonoid OrderType.{u} where
   nsmul := nsmulRec
 
 instance (priority := low) : HMul OrderType.{u} OrderType.{v} OrderType.{max u v} where
-  hMul o₁ o₂ :=  OrderType.liftOn₂ o₁ o₂ (fun r _ s _ ↦ type (s ×ₗ r))
+  hMul o₁ o₂ := OrderType.liftOn₂ o₁ o₂ (fun r _ s _ ↦ type (s ×ₗ r))
     fun _ _ _ _ _ _ _ _ ha hb ↦ Prod.Lex.prodLexCongr (Classical.choice <| type_eq_type.mp hb)
       (Classical.choice <| type_eq_type.mp ha) |> type_congr
 
@@ -107,7 +107,7 @@ instance (n : Nat) : OfNat OrderType n where
 instance : LeftDistribClass OrderType where
   left_distrib a b c := by
     refine inductionOn₃ a b c (fun _ _ _ _ _ _ ↦ ?_)
-    simp only [← type_lex_prod,← type_lex_sum]
+    simp only [← type_lex_prod, ← type_lex_sum]
     exact (Prod.Lex.sumLexProdLexDistrib _ _ _).type_congr
 
 /-- The order type of the rational numbers. -/

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -167,7 +167,7 @@ def liftOn₂ (o₁ o₂ : OrderType) (f : ∀ (α) [LinearOrder α] (β) [Linea
     (c : ∀ (α₁) [LinearOrder α₁] (β₁) [LinearOrder β₁] (α₂) [LinearOrder α₂] (β₂) [LinearOrder β₂],
       type α₁ = type α₂ → type β₁ = type β₂ → f α₁ β₁ = f α₂ β₂) : δ :=
   Quotient.liftOn₂ o₁ o₂ (fun w v ↦ f w v)
-    fun w₁ w₂ v₁ v₂ hw hv ↦  c w₁ w₂ v₁ v₂ (Quotient.sound hw) (Quotient.sound hv)
+    fun w₁ w₂ v₁ v₂ hw hv ↦ c w₁ w₂ v₁ v₂ (Quotient.sound hw) (Quotient.sound hv)
 
 @[simp]
 theorem liftOn_type (f : ∀ (α) [LinearOrder α], δ)

--- a/Mathlib/RepresentationTheory/Irreducible.lean
+++ b/Mathlib/RepresentationTheory/Irreducible.lean
@@ -73,7 +73,7 @@ theorem algebraMap_intertwiningMap_bijective_of_isAlgClosed :
     Bijective (algebraMap k (IntertwiningMap ρ ρ)) := by
   have : Bijective (algebraMap k (Module.End k[G] ρ.asModule)) :=
     IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k
-  exact (Bijective.of_comp_iff' (IntertwiningMap.equivAlgEnd (ρ:=ρ)).bijective _).1 this
+  exact (Bijective.of_comp_iff' (IntertwiningMap.equivAlgEnd (ρ := ρ)).bijective _).1 this
 
 set_option backward.isDefEq.respectTransparency false in
 include ρ in

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -197,7 +197,7 @@ lemma Algebra.exists_notMem_and_isIntegral_forall_mem_of_ne_of_liesOver
     rw [IsLocalization.map_mk', ← e.symm.commutes, ← map_mul,
       IsScalarTower.algebraMap_eq _ S _] at this
     replace this : e.symm ((algebraMap _ (Localization.Away s₂.1)) s₃) ∈ q's := by
-      simpa [-map_mul, -map_pow, - AlgEquiv.commutes] using this
+      simpa [-map_mul, -map_pow, -AlgEquiv.commutes] using this
     replace this : s₃ ∈ q' := by simpa [← Ideal.mem_comap, ← q's.over_def q'] using this
     exact H (Ideal.mul_mem_left _ (s₂ ^ m) this)
   · rw [map_pow]; exact Ideal.notMem_of_isUnit _ (.pow _ (IsLocalization.Away.algebraMap_isUnit _))
@@ -347,7 +347,7 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq_aux₂
         (Ideal.notMem_of_isUnit (m.comap Algebra.TensorProduct.includeRight)
         (IsLocalization.Away.algebraMap_isUnit _))
     rw [← hP'q]
-    exact this.le ((Ideal.span_singleton_le_iff_mem _).mp hm:))
+    exact this.le ((Ideal.span_singleton_le_iff_mem _).mp hm :))
   rw [he₀e] at hf
   refine ⟨f, hfP, ?_⟩
   let φ : R' ⊗[R] S →ₐ[R'] Localization.Away f ⊗[R] S :=
@@ -370,7 +370,7 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq_aux₂
   refine RingHom.finite_algebraMap.mp ?_
   convert equiv.symm.toRingEquiv.finite.comp hf
   apply IsLocalization.ringHom_ext (.powers f)
-  dsimp [- AlgEquiv.symm_toRingEquiv,
+  dsimp [-AlgEquiv.symm_toRingEquiv,
     ← AlgEquiv.toAlgHom_toRingHom, -AlgHomClass.toRingHom_toAlgHom]
   simp only [← IsScalarTower.algebraMap_eq, RingHom.comp_assoc, AlgHom.comp_algebraMap_of_tower,
     Algebra.ofId_apply]

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Basic.lean
@@ -94,7 +94,7 @@ variable {R : Type*} [CommSemiring R] (I J : Ideal R) (M : Type*) [AddCommMonoid
 /-- `IsAssociatedPrime I M` if the prime ideal `I` is the radical of the annihilator
 of some `x : M`. -/
 def IsAssociatedPrime : Prop :=
-  (⊥: Submodule R M).IsAssociatedPrime I
+  (⊥ : Submodule R M).IsAssociatedPrime I
 
 variable (R) in
 /-- The set of associated primes of a module. -/

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -307,7 +307,7 @@ lemma localRingHom_bijective_of_saturated_inf_eq_top
   · suffices ∀ y, ∀ z ∉ P, ∃ y' ∈ s, ∃ z' ∉ P, z' ∈ s ∧ ∃ t ∉ P, t * (z * y') = t * (z' * y) by
       simpa [(IsLocalization.mk'_surjective p.primeCompl).exists,
         (IsLocalization.mk'_surjective P.primeCompl).forall, P.over_def p,
-        Localization.localRingHom_mk', IsLocalization.mk'_eq_iff_eq, - map_mul,
+        Localization.localRingHom_mk', IsLocalization.mk'_eq_iff_eq, -map_mul,
         IsLocalization.eq_iff_exists P.primeCompl, Function.Surjective] using this
     intro y z hzP
     obtain ⟨a, ⟨haP, has⟩, ha⟩ := H.ge (Set.mem_univ y)

--- a/Mathlib/RingTheory/QuasiFinite/Weakly.lean
+++ b/Mathlib/RingTheory/QuasiFinite/Weakly.lean
@@ -213,7 +213,7 @@ lemma of_restrictScalars [Algebra S T] [IsScalarTower R S T]
     .of_restrictScalars R _ _
   have H : (q.under R).map (algebraMap R T) ≤ (q.under S).map (algebraMap S T) := by
     simpa [Ideal.under, IsScalarTower.algebraMap_eq R S T, ← Ideal.map_map,
-      ← Ideal.comap_comap, - Ideal.under_under] using Ideal.map_mono Ideal.map_comap_le
+      ← Ideal.comap_comap, -Ideal.under_under] using Ideal.map_mono Ideal.map_comap_le
   delta WeaklyQuasiFiniteAt
   refine .of_surjectiveOnStalks (q.map (Ideal.Quotient.mk ((q.under R).map (algebraMap R T))))
     (Ideal.quotientMapₐ _ (.id _ _) (by exact H)) (RingHom.surjectiveOnStalks_of_surjective

--- a/Mathlib/RingTheory/Smooth/IntegralClosure.lean
+++ b/Mathlib/RingTheory/Smooth/IntegralClosure.lean
@@ -394,4 +394,4 @@ theorem TensorProduct.toIntegralClosure_bijective_of_smooth [Algebra.Smooth R S]
     (s := Set.range f) (B := B) ?_ (Localization.Away ·.1) (Set.forall_subtype_range_iff.mpr hf)
   by_contra H
   obtain ⟨m, hm, e⟩ := Ideal.exists_le_maximal _ H
-  exact hfm ⟨m, inferInstance⟩ (e (Ideal.subset_span (Set.mem_range_self ⟨m, inferInstance⟩)):)
+  exact hfm ⟨m, inferInstance⟩ (e (Ideal.subset_span (Set.mem_range_self ⟨m, inferInstance⟩)) :)

--- a/Mathlib/RingTheory/TensorProduct/IncludeLeftSubRight.lean
+++ b/Mathlib/RingTheory/TensorProduct/IncludeLeftSubRight.lean
@@ -133,7 +133,7 @@ lemma of_isEffective_tensorProduct_of_faithfullyFlat
       (TensorProduct.rid R R T).toAddMonoidHom (AddMonoidHom.id (T ⊗[R] S))
       (TensorProduct.AlgebraTensorModule.distribBaseChange R T S S).toAddMonoidHom ?_ ?_
       (TensorProduct.rid R R T).surjective Function.bijective_id
-      ((TensorProduct.AlgebraTensorModule.distribBaseChange R T S S).injective)|>.mpr ‹_›
+      ((TensorProduct.AlgebraTensorModule.distribBaseChange R T S S).injective) |>.mpr ‹_›
   · ext
     simp [← Algebra.TensorProduct.linearMap_comp_rid]
   · ext

--- a/Mathlib/RingTheory/Unramified/LocalStructure.lean
+++ b/Mathlib/RingTheory/Unramified/LocalStructure.lean
@@ -235,7 +235,7 @@ lemma exists_notMem_forall_ne_mem_and_adjoin_eq_top
     let φ' : p.Fiber S →ₐ[p.ResidueField] Q'.ResidueField := Algebra.TensorProduct.lift
         (Algebra.ofId _ _) (IsScalarTower.toAlgHom _ _ _) fun _ _ ↦ .all _ _
     have H : φ' r = 0 := (hr (α ⟨Q', ⟨‹_›, ‹_›⟩⟩).asIdeal inferInstance (by
-        rwa [ne_eq, ← PrimeSpectrum.ext_iff, EmbeddingLike.apply_eq_iff_eq, Subtype.mk.injEq]):)
+        rwa [ne_eq, ← PrimeSpectrum.ext_iff, EmbeddingLike.apply_eq_iff_eq, Subtype.mk.injEq]) :)
     rw [← Ideal.algebraMap_residueField_eq_zero]
     trans φ' (1 ⊗ₜ t)
     · simp [φ']
@@ -329,7 +329,7 @@ lemma exists_hasStandardEtaleSurjectionOn
     |>.exists_fg_and_exists_notMem_and_awayMap_bijective
   have : Module.Finite R S' := ⟨(Submodule.fg_top _).mpr hS'⟩
   have : Algebra.FormallyUnramified R (Localization.Away r) :=
-    .of_equiv (AlgEquiv.ofBijective (Localization.awayMapₐ S'.val r) hr:).symm
+    .of_equiv (AlgEquiv.ofBijective (Localization.awayMapₐ S'.val r) hr :).symm
   have : IsUnramifiedAt R (Ideal.under (↥S') Q) := by
     rw [← Algebra.basicOpen_subset_unramifiedLocus_iff] at this
     exact @this ⟨Q.under S', inferInstance⟩ hrQ

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -170,7 +170,7 @@ lemma isIntegral_of_isIntegralElem_of_monic_of_natDegree_lt
     rw [AlgHom.toRingHom_eq_coe, eval₂_map, ← map_zero (algebraMap S St), ← hq',
       hom_eval₂]
     congr 1
-    ext <;> simp [- Polynomial.algebraMap_apply, ← algebraMap_eq, ← IsScalarTower.algebraMap_apply]
+    ext <;> simp [-Polynomial.algebraMap_apply, ← algebraMap_eq, ← IsScalarTower.algebraMap_apply]
   simpa using IsLocalization.Away.isIntegral_of_isIntegral_map t
     (isIntegral_of_isIntegral_adjoin_of_mul_eq_one _ _ ht't this)
 
@@ -200,7 +200,7 @@ lemma exists_isIntegral_leadingCoeff_pow_smul_sub_of_isIntegralElem_of_mul_mem_r
   have ha : IsUnit (algebraMap R R' a) := IsLocalization.Away.algebraMap_isUnit a
   have H : (aeval ((algebraMap S S') (φ X))).toRingHom.comp (mapRingHom (algebraMap R R')) =
     (algebraMap S S').comp φ := by ext <;>
-      simp [- Polynomial.algebraMap_apply, ← Polynomial.algebraMap_eq, ← algebraMap_apply]
+      simp [-Polynomial.algebraMap_apply, ← Polynomial.algebraMap_eq, ← algebraMap_apply]
   obtain ⟨q, hq⟩ := exists_isIntegral_sub_of_isIntegralElem_of_mul_mem_range (R := R')
     (aeval (algebraMap S S' (φ X))) (algebraMap S S' t) (C ha.unit⁻¹.1 * p.map (algebraMap _ _)) (by
       obtain ⟨q, hqm, hq⟩ := ht
@@ -281,13 +281,13 @@ lemma exists_leadingCoeff_pow_smul_mem_radical_conductor
       simpa [eraseLead_coeff, hi'] using
         IH _ ((eraseLead_natDegree_le _).trans_lt (by aesop)) _ this rfl
   obtain ⟨n, hn⟩ := hp
-  obtain ⟨k, hk⟩ := exists_leadingCoeff_pow_smul_mem_conductor φ  (t ^ n) (p ^ n) hRS hφ
+  obtain ⟨k, hk⟩ := exists_leadingCoeff_pow_smul_mem_conductor φ (t ^ n) (p ^ n) hRS hφ
     (by simpa [mul_pow] using hn)
   by_cases hpn : p.leadingCoeff ^ n = 0
   · use n; simp [_root_.smul_pow, hpn, hi]
   rw [leadingCoeff_pow' hpn, ← pow_mul] at hk
   refine ⟨n * k + n, ?_⟩
-  rw [_root_.smul_pow,  pow_add, add_comm, pow_add, mul_smul_mul_comm, hi]
+  rw [_root_.smul_pow, pow_add, add_comm, pow_add, mul_smul_mul_comm, hi]
   exact Ideal.mul_mem_right _ _ hk
 
 set_option backward.isDefEq.respectTransparency false in
@@ -514,7 +514,7 @@ private lemma ZariskisMainProperty.of_algHom_polynomial
       OreLocalization.instAlgebra
     have inst : Algebra.WeaklyQuasiFiniteAt (integralClosure R S) p :=
       .of_restrictScalars R (integralClosure R S) _
-    refine .restrictScalars (this p (aeval (f X)) ?_  (integralClosure_idem (R := R)))
+    refine .restrictScalars (this p (aeval (f X)) ?_ (integralClosure_idem (R := R)))
     refine RingHom.Finite.of_comp_finite (f := mapRingHom (algebraMap R _)) ?_
     convert (show f.toRingHom.Finite from hf)
     ext <;> simp [show ∀ x, f (C x) = algebraMap _ _ x from f.commutes]

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -849,7 +849,7 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
   congr 1
   · have αd : ω ∣ α' :=
       dvd_add (dvd_mul_of_dvd_left (by simpa using opow_dvd_opow ω (one_le_iff_ne_zero.2 e0)) _) d
-    have α0: ¬IsMin α' := by
+    have α0 : ¬IsMin α' := by
       rw [isMin_iff_eq_bot]
       exact α0.ne'
     rw [mul_add (ω0 ^ (k : Ordinal)), add_assoc, ← mul_assoc, ← opow_succ,

--- a/Mathlib/Tactic/CategoryTheory/Coherence/Datatypes.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence/Datatypes.lean
@@ -416,7 +416,7 @@ inductive NormalizedHom : Type
 /-- The underlying expression of a normalized 1-morphism. -/
 def NormalizedHom.e : NormalizedHom → Mor₁
   | NormalizedHom.nil e _ => e
-  | NormalizedHom.cons e _ _  => e
+  | NormalizedHom.cons e _ _ => e
 
 /-- The domain of a normalized 1-morphism. -/
 def NormalizedHom.src : NormalizedHom → Obj

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -462,7 +462,7 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     -- lift from original semiring of scalars (say `R₀`) to `R₀ ⊗ S`
     let ⟨u, R, iR, iRM, ⟨l, pf_l⟩, _, ⟨s, pf_r⟩⟩ ← qNF.matchRings iRM₀ i₁ i₂ l₀ [] s₀ y
     -- build the new list and proof
-    pure ⟨u, R, iR, iRM, l.onScalar q(HMul.hMul $s), (q(NF.smul_eq_eval $pf₀ $pf_l $pf_r):)⟩
+    pure ⟨u, R, iR, iRM, l.onScalar q(HMul.hMul $s), (q(NF.smul_eq_eval $pf₀ $pf_l $pf_r) :)⟩
   /- parse a `(0:M)` -/
   | ~q(0) =>
     pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommMonoid.toNatModule), [], q(NF.zero_eq_eval $M)⟩

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -368,7 +368,7 @@ lemma mapEquiv_sup_eq (f : M ≃L[R] N) {s t : ClosedSubmodule R M} :
     Submodule.coe_closure, Set.mem_image]
   have : f = f.toLinearEquiv.toLinearMap := by
     exact LinearMap.ext (congrFun rfl)
-  rw [← this, ← Submodule.coe_closure, ← Submodule.map_sup,  Submodule.map_coe]
+  rw [← this, ← Submodule.coe_closure, ← Submodule.map_sup, Submodule.map_coe]
   simp only [Submodule.coe_closure, ContinuousLinearMap.coe_coe, ContinuousLinearEquiv.coe_coe,
     ← ContinuousLinearEquiv.image_closure, Set.mem_image]
 

--- a/Mathlib/Topology/Algebra/Monoid/Defs.lean
+++ b/Mathlib/Topology/Algebra/Monoid/Defs.lean
@@ -131,7 +131,7 @@ theorem continuous_mul_const (m : M) : Continuous (· * m) :=
 @[to_additive]
 theorem Filter.Tendsto.const_mul {α : Type*} {f : α → M} {x : Filter α} {a : M}
     (b : M) (hf : Tendsto f x (𝓝 a)) : Tendsto (b * f ·) x (𝓝 (b * a)) :=
-  continuous_const_mul  b |>.tendsto _ |>.comp hf
+  continuous_const_mul b |>.tendsto _ |>.comp hf
 
 @[to_additive]
 theorem Filter.Tendsto.mul_const {α : Type*} {f : α → M} {x : Filter α} {a : M}

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -573,7 +573,7 @@ lemma mulSingle_pow [∀ i, Monoid (G i)] [∀ i, SubmonoidClass (S i) (G i)]
 @[to_additive]
 lemma mulSingle_zpow [∀ i, Group (G i)] [∀ i, SubgroupClass (S i) (G i)]
     (i : ι) (r : G i) (n : ℤ) :
-    mulSingle A i (r  ^ n) = mulSingle A i r ^ n := by
+    mulSingle A i (r ^ n) = mulSingle A i r ^ n := by
   ext; simp [Pi.mulSingle_zpow, RestrictedProduct.zpow_apply]
 
 end single

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Units.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Units.lean
@@ -58,7 +58,7 @@ theorem eventualy_isUnit_of_isUnit {x : Πʳ i, [R i, B i]_[𝓕]} (hx : IsUnit 
     fun i hx hb ↦ ⟨hx, ⟨b i, hb⟩, by simp_all [← SetLike.coe_eq_coe]⟩⟩
 
 theorem isUnit_iff {x : Πʳ i, [R i, B i]_[𝓕]} :
-    IsUnit x ↔ (∀ i, IsUnit (x i)) ∧ ∀ᶠ i in 𝓕, ∃ (h : x i ∈ B i), IsUnit (⟨x i, h⟩ : B i)  :=
+    IsUnit x ↔ (∀ i, IsUnit (x i)) ∧ ∀ᶠ i in 𝓕, ∃ (h : x i ∈ B i), IsUnit (⟨x i, h⟩ : B i) :=
   ⟨eventualy_isUnit_of_isUnit, fun h ↦ isUnit_of_eventually_isUnit h.1 h.2⟩
 
 /-- The homomorphism from the units of a restricted product to the regular product of unit. -/

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -132,7 +132,7 @@ theorem postcomp_injective (g : C(Y, R)₀) (hg : Injective g) :
   fun _ _ h ↦ ext fun x ↦ hg congr($h x)
 
 @[fun_prop]
-theorem continuous_postcomp (g : C(Y, R)₀) : Continuous (g.comp  : C(X, Y)₀ → C(X, R)₀) := by
+theorem continuous_postcomp (g : C(Y, R)₀) : Continuous (g.comp : C(X, Y)₀ → C(X, R)₀) := by
   rw [ContinuousMapZero.isEmbedding_toContinuousMap.continuous_iff]
   exact g.toContinuousMap.continuous_postcomp |>.comp <|
     ContinuousMapZero.isEmbedding_toContinuousMap.continuous

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -413,7 +413,7 @@ lemma IsIrreducible.preimage (ht : IsIrreducible t) {f : Y → X}
 
 lemma preimage_mem_irreducibleComponents_of_isPreirreducible_fiber
     (ht : t ∈ irreducibleComponents X) {f : Y → X} (hf₁ : Continuous f) (hf₂ : IsOpenMap f)
-    (hf₃ : ∀ x, IsPreirreducible (f ⁻¹'{x})) (h : (t ∩ range f).Nonempty) :
+    (hf₃ : ∀ x, IsPreirreducible (f ⁻¹' {x})) (h : (t ∩ range f).Nonempty) :
     f ⁻¹' t ∈ irreducibleComponents Y := by
   refine ⟨ht.1.preimage_of_isPreirreducible_fiber f hf₂ hf₃ h, fun u hu htu ↦ image_subset_iff.mp
     (subset_closure.trans (ht.2 (hu.image f hf₁.continuousOn).closure ?_))⟩

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -145,9 +145,9 @@ Is analogy to `Finsupp.single`, this definition presents the indicator function
 of a single point as a function with locally finite support.
 -/
 noncomputable def single [DecidableEq X] [Zero Y] (x : X) (y : Y) : locallyFinsupp X Y where
-  toFun :=  Pi.single x y
+  toFun := Pi.single x y
   supportWithinDomain' z hz := by tauto
-  supportLocallyFiniteWithinDomain' _ _:=
+  supportLocallyFiniteWithinDomain' _ _ :=
     ⟨Set.univ, univ_mem, by simpa using (finite_singleton x).subset Pi.support_single_subset⟩
 
 /--


### PR DESCRIPTION
Found by extending the whitespace linter to proof bodies in #30658.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
