### PR TITLE
chore: generalise local extensions to any local frame

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -32,8 +32,8 @@ complete field). In the planned file `Mathlib/Geometry/Manifold/VectorBundle/Ort
 metric. This includes bundles of finite rank, modelled on a Hilbert space or on a Banach space which
 has smooth partitions of unity.
 
-We will use this to construct local extensions of a vector to a section which is smooth on the
-trivialisation domain.
+We also use this to extend a vector in a single fiber `V x` to a section near `x` which is
+smooth on the trivialisation domain.
 
 ## Main definitions and results
 
@@ -568,3 +568,99 @@ lemma mdifferentiableAt_iff_localFrame_coeff (hx : x' ∈ e.baseSet) :
 end MDifferentiable
 
 end
+
+-- local extension of a vector field in a trivialisation's base set
+section extendLocally
+
+variable {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F}
+  {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
+  [MemTrivializationAtlas e] {x : M}
+
+open scoped Classical in
+-- TODO: add longer docs!
+-- a starting point (not fully updated any more) is this:
+/- Extend a vector `v ∈ V x` to a section of the bundle `V`, whose value at `x` is `v`.
+The details of the extension are mostly unspecified: for covariant derivatives, the value of
+`s` at points other than `x` will not matter (except for shorter proofs).
+Thus, we choose `s` to be somewhat nice: our chosen construction is linear in `v`.
+-/
+
+-- comment: need not be smooth (outside of e.baseSet), but this is a useful building block for
+-- global smooth extensions of vector fields
+-- the latter caps this with a smooth bump function, which need not exist if k=C
+-- In contrast, this definition makes sense over any field
+-- (for example, *locally* holomorphic sections always exist),
+
+/--
+Extend a vector `v ∈ V x` to a local section of `V`, w.r.t. a chosen local trivialisation.
+This construction uses a choice of local frame near `x`, w.r.t. to a basis `b` of `F` and a
+compatible local trivialisation `e` of `V` near `x`: the resulting extension has constant
+coefficients on `e.baseSet` w.r.t. this trivialisation (and is zero otherwise).
+
+In particular, our construction is smooth on `e.baseSet`, and linear in the input vector `v`.
+-/
+noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
+    (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
+    (x : M) (v : V x) : (x' : M) → V x' :=
+  fun x' ↦ if hx : x ∈ e.baseSet then
+    letI bV := b.localFrame_toBasis_at e hx; ∑ i, bV.repr v i • b.localFrame e i x'
+    else 0
+
+variable (b e) in
+@[simp]
+lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
+    ((localExtensionOn b e x v) x) = v := by
+  simp [localExtensionOn, hx]
+
+omit [IsManifold I 0 M] in
+/-- A local extension has constant frame coefficients within its defining trivialisation. -/
+lemma localExtensionOn_localFrame_coeff (b : Basis ι 𝕜 F) [ContMDiffVectorBundle 1 F V I]
+    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
+    [MemTrivializationAtlas e] {x : M} (hx : x ∈ e.baseSet) (v : V x) (i : ι)
+    {x' : M} (hx' : x' ∈ e.baseSet) :
+    b.localFrame_coeff I e i (localExtensionOn b e x v) x' =
+      b.localFrame_coeff I e i (localExtensionOn b e x v) x := by
+  simp [localExtensionOn, hx, hx']
+
+-- By construction, localExtensionOn is a linear map.
+
+variable (b e) in
+lemma localExtensionOn_add (v v' : V x) :
+    localExtensionOn b e x (v + v') = localExtensionOn b e x v + localExtensionOn b e x v' := by
+  ext x'
+  by_cases hx: x ∈ e.baseSet; swap
+  · simp [hx, localExtensionOn]
+  · simp [hx, localExtensionOn, add_smul, Finset.sum_add_distrib]
+
+variable (b e) in
+lemma localExtensionOn_zero :
+    localExtensionOn b e x 0 = 0 := by
+  ext x'
+  by_cases hx: x ∈ e.baseSet <;> simp [hx, localExtensionOn]
+
+variable (b e) in
+lemma localExtensionOn_smul (a : 𝕜) (v : V x) :
+    localExtensionOn b e x (a • v) = a • localExtensionOn b e x v := by
+  ext x'
+  by_cases hx: x ∈ e.baseSet; swap
+  · simp [hx, localExtensionOn]
+  · simp [hx, localExtensionOn, Finset.smul_sum]
+    set B := Basis.localFrame_toBasis_at e b hx
+    congr
+    ext i
+    rw [mul_smul a ((B.repr v) i)]
+
+variable (F) in
+omit [IsManifold I 0 M] in
+lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
+    {x : M} (hx : x ∈ e.baseSet) (v : V x) [ContMDiffVectorBundle ∞ F V I] :
+    CMDiff[e.baseSet] ∞ (T% (localExtensionOn b e x v)) := by
+  -- The local frame coefficients of `localExtensionOn` w.r.t. the frame induced by `e` are
+  -- constant, hence smoothness follows.
+  rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
+  intro i
+  apply (contMDiffOn_const (c := (b.localFrame_coeff I e i) (localExtensionOn b e x v) x)).congr
+  intro y hy
+  rw [localExtensionOn_localFrame_coeff b hx v i hy]
+
+end extendLocally

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -570,11 +570,11 @@ end MDifferentiable
 end
 
 -- local extension of a vector field in a trivialisation's base set
-section localExntensionOn
+section localExtensionOn
 
 variable {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F}
   {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
-  [MemTrivializationAtlas e] {x : M}
+  [MemTrivializationAtlas e] {x x' : M}
 
 open scoped Classical in
 
@@ -613,21 +613,20 @@ noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
     (x : M) (v : V x) : (x' : M) → V x' :=
   fun x' ↦ if hx : x ∈ e.baseSet then
-    letI bV := b.localFrame_toBasis_at e hx; ∑ i, bV.repr v i • b.localFrame e i x'
-    else 0
+    ∑ i, (b.localFrame_toBasis_at e hx).repr v i • b.localFrame e i x'
+  else 0
 
 variable (b e) in
 @[simp]
 lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
-    ((localExtensionOn b e x v) x) = v := by
+    (localExtensionOn b e x v) x = v := by
   simp [localExtensionOn, hx]
 
 omit [IsManifold I 0 M] in
+variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
-lemma localExtensionOn_localFrame_coeff (b : Basis ι 𝕜 F) [ContMDiffVectorBundle 1 F V I]
-    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
-    [MemTrivializationAtlas e] {x : M} (hx : x ∈ e.baseSet) (v : V x) (i : ι)
-    {x' : M} (hx' : x' ∈ e.baseSet) :
+lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
+    (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
     b.localFrame_coeff I e i (localExtensionOn b e x v) x' =
       b.localFrame_coeff I e i (localExtensionOn b e x v) x := by
   simp [localExtensionOn, hx, hx']
@@ -654,11 +653,10 @@ lemma localExtensionOn_smul (a : 𝕜) (v : V x) :
   ext x'
   by_cases hx: x ∈ e.baseSet; swap
   · simp [hx, localExtensionOn]
-  · simp [hx, localExtensionOn, Finset.smul_sum]
-    set B := Basis.localFrame_toBasis_at e b hx
-    congr
-    ext i
-    rw [mul_smul a ((B.repr v) i)]
+  · simp only [localExtensionOn, hx, ↓reduceDIte, map_smul, Finsupp.coe_smul, Pi.smul_apply,
+      smul_eq_mul, Finset.smul_sum]
+    congr with i
+    rw [mul_smul a (((b.localFrame_toBasis_at e hx).repr v) i)]
 
 variable (F) in
 omit [IsManifold I 0 M] in
@@ -671,6 +669,6 @@ lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace �
   intro i
   apply (contMDiffOn_const (c := (b.localFrame_coeff I e i) (localExtensionOn b e x v) x)).congr
   intro y hy
-  rw [localExtensionOn_localFrame_coeff b hx v i hy]
+  rw [localExtensionOn_localFrame_coeff b hx hy v i]
 
-end localExntensionOn
+end localExtensionOn

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -591,9 +591,9 @@ end
 -- local extension of a vector field in a trivialisation's base set
 section localExtensionOn
 
-variable {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F}
-  {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
-  [MemTrivializationAtlas e] {x x' : M}
+variable {e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)} [MemTrivializationAtlas e]
+  {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F} {x x' : M}
+  [VectorBundle 𝕜 F V]
 
 open scoped Classical in
 
@@ -616,8 +616,7 @@ constructions on covariant derivatives (and in this context, the value at `s` at
 noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
     {x : M} (v : V x) : (x' : M) → V x' :=
-  fun x' ↦ if hx : x ∈ e.baseSet then
-    ∑ i, (b.localFrame_toBasis_at e hx).repr v i • b.localFrame e i x'
+  fun x' ↦ if hx : x ∈ e.baseSet then ∑ i, (e.basisAt b hx).repr v i • e.localFrame b i x'
   else 0
 
 variable (b e) in
@@ -626,13 +625,12 @@ lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
     (localExtensionOn b e v) x = v := by
   simp [localExtensionOn, hx]
 
-omit [IsManifold I 0 M] in
 variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
-    b.localFrame_coeff I e i (localExtensionOn b e v) x' =
-      b.localFrame_coeff I e i (localExtensionOn b e v) x := by
+    e.localFrame_coeff I b i (localExtensionOn b e v) x' =
+      e.localFrame_coeff I b i (localExtensionOn b e v) x := by
   simp [localExtensionOn, hx, hx']
 
 -- By construction, localExtensionOn is a linear map.
@@ -659,10 +657,9 @@ lemma localExtensionOn_smul (a : 𝕜) (v : V x) :
   · simp only [localExtensionOn, hx, ↓reduceDIte, map_smul, Finsupp.coe_smul, Pi.smul_apply,
       smul_eq_mul, Finset.smul_sum]
     congr with i
-    rw [mul_smul a (((b.localFrame_toBasis_at e hx).repr v) i)]
+    rw [mul_smul a (((e.basisAt b hx).repr v) i)]
 
 variable (F) in
-omit [IsManifold I 0 M] in
 lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
     {x : M} (hx : x ∈ e.baseSet) (v : V x) [ContMDiffVectorBundle ∞ F V I] :
     CMDiff[e.baseSet] ∞ (T% (localExtensionOn b e v)) := by
@@ -670,7 +667,7 @@ lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace �
   -- constant, hence smoothness follows.
   rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
   intro i
-  apply (contMDiffOn_const (c := (b.localFrame_coeff I e i) (localExtensionOn b e v) x)).congr
+  apply (contMDiffOn_const (c := (e.localFrame_coeff I b i) (localExtensionOn b e v) x)).congr
   intro y hy
   rw [localExtensionOn_localFrame_coeff b hx hy v i]
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -597,7 +597,7 @@ variable {e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)} [MemTri
 
 open scoped Classical in
 
-/- Extend a vector `v ∈ V x` to a section `s` of the bundle `V` which is smooth near `x`,
+/-- Extend a vector `v ∈ V x` to a section `s` of the bundle `V` which is smooth near `x`,
 such that `s x = v` and this construction is linear in `v`.
 
 The details of this extension are unspecified (and could be subject to change).

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -591,11 +591,73 @@ end
 -- local extension of a vector field in a trivialisation's base set
 section localExtensionOn
 
-variable {e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)} [MemTrivializationAtlas e]
-  {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F} {x x' : M}
-  [VectorBundle 𝕜 F V]
+section
+
+variable {ι : Type*} [Fintype ι] {s : ι → (x : M) → V x} {u : Set M} {x x' : M} {n : WithTop ℕ∞}
+
 
 open scoped Classical in
+/-- Given a local frame `{sᵢ}` on `u ∋ x`, extend a vector `v ∈ V x` to a section `t` of the
+bundle `V` which is smooth near `x`, such that `t x = v` and this construction is linear in `v`.
+
+The details of this extension are unspecified (and could be subject to change).
+Our current construction has constant coefficients on `u` w.r.t. the local frame `{sᵢ}`, and is zero
+otherwise. In particular, it is smooth on `u`, and (globally) linear in `v`.
+
+We choose an extension with these particularly nice properties because this simplifies later
+constructions on covariant derivatives (and in this context, the value at `t` at points other than
+`x` does not matter, but constant frame coefficients are useful).
+-/
+noncomputable def IsLocalFrameOn.localExtension (hs : IsLocalFrameOn I F n s u) :
+    V x →ₗ[𝕜] ((x' : M) → V x') where
+  toFun v := open scoped Classical in
+    fun x' ↦ if hx : x ∈ u then ∑ i, (hs.toBasisAt hx).repr v i • s i x' else 0
+  map_add' v v' := by
+    ext x'
+    by_cases hx: x ∈ u; swap
+    · simp [hx]
+    · simp [hx, add_smul, Finset.sum_add_distrib]
+  map_smul' a v := by
+    ext x'
+    by_cases hx: x ∈ u; swap
+    · simp [hx]
+    · simp +contextual [hx, Finset.smul_sum, mul_smul a]
+
+@[simp]
+lemma IsLocalFrameOn.localExtension_apply_self (hs : IsLocalFrameOn I F n s u) (hx : x ∈ u) (v : V x) :
+    hs.localExtension v x = v := by
+  simp [IsLocalFrameOn.localExtension, hx]
+  sorry--apply?
+
+/-- A local extension has constant frame coefficients within its defining trivialisation. -/
+lemma IsLocalFrameOn.localExtension_localFrame_coeff
+    (hs : IsLocalFrameOn I F n s u) (hx : x ∈ u) (hx' : x' ∈ u) (v : V x) (i : ι) :
+    (hs.coeff i x') (hs.localExtension v x') = (hs.coeff i x) (hs.localExtension v x) := by
+  -- Combining these into one `simp` call makes these lemmas never fire.
+  rw [hs.coeff_apply_of_mem hx, hs.coeff_apply_of_mem hx']
+  simp [IsLocalFrameOn.localExtension, hx] --, hx']
+  sorry -- TODO!
+
+lemma IsLocalFrameOn.contMDiffOn_localExtension [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
+    (hs : IsLocalFrameOn I F n s u) [VectorBundle 𝕜 F V]
+    {x : M} (hx : x ∈ u) (v : V x) :
+    CMDiff[u] n (T% (hs.localExtension v)) := by
+  -- The local frame coefficients of `localExtension` w.r.t. the frame induced by `e` are
+  -- constant, hence smoothness follows.
+  apply hs.contMDiffOn_of_coeff
+  intro i
+  simp only [LinearMap.piApply_apply]
+  apply (contMDiffOn_const
+    (c := (hs.coeff i x) (hs.localExtension v x))).congr
+  intro y hy
+  rw [hs.localExtension_localFrame_coeff hx hy v i]
+
+end
+
+variable {n}
+
+open scoped Classical in
+variable (I) in -- necessary to infer `I` in `ContMDiffVectorBundle`...
 /-- Extend a vector `v ∈ V x` to a section `s` of the bundle `V` which is smooth near `x`,
 such that `s x = v` and this construction is linear in `v`.
 
@@ -610,52 +672,62 @@ We choose an extension with these particularly nice properties because this simp
 constructions on covariant derivatives (and in this context, the value at `s` at points other than
 `x` does not matter, but constant frame coefficients are useful).
 -/
--- XXX: we could generalise this definition to any local frame on `U ∋ x`, with smoothness on `U`.
--- Would this be useful? Should do this?
-noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
+noncomputable def localExtensionOn [VectorBundle 𝕜 F V] [ContMDiffVectorBundle 1 F V I]
+    {ι : Type*} [Fintype ι] (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
-    {x : M} : V x →ₗ[𝕜] ((x' : M) → V x') where
-  toFun v := open scoped Classical in
-    fun x' ↦ if hx : x ∈ e.baseSet then ∑ i, (e.basisAt b hx).repr v i • e.localFrame b i x' else 0
-  map_add' v v' := by
-    ext x'
-    by_cases hx: x ∈ e.baseSet; swap
-    · simp [hx]
-    · simp [hx, add_smul, Finset.sum_add_distrib]
-  map_smul' a v := by
-    ext x'
-    by_cases hx: x ∈ e.baseSet; swap
-    · simp [hx]
-    · simp +contextual [hx, Finset.smul_sum, mul_smul a (((e.basisAt b hx).repr v) _)]
+    {x : M} : V x →ₗ[𝕜] ((x' : M) → V x') :=
+  (e.isLocalFrameOn_localFrame_baseSet I 1 b).localExtension
+  -- where
+  -- toFun v := open scoped Classical in
+  --   fun x' ↦ if hx : x ∈ e.baseSet then ∑ i, (e.basisAt b hx).repr v i • e.localFrame b i x' else 0
+  -- map_add' v v' := by
+  --   ext x'
+  --   by_cases hx: x ∈ e.baseSet; swap
+  --   · simp [hx]
+  --   · simp [hx, add_smul, Finset.sum_add_distrib]
+  -- map_smul' a v := by
+  --   ext x'
+  --   by_cases hx: x ∈ e.baseSet; swap
+  --   · simp [hx]
+  --   · simp +contextual [hx, Finset.smul_sum, mul_smul a (((e.basisAt b hx).repr v) _)]
 
+variable {e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)} [MemTrivializationAtlas e]
+  {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F} {x x' : M}
+variable [VectorBundle 𝕜 F V] [ContMDiffVectorBundle 1 F V I]
 variable (b e) in
 @[simp]
 lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
-    (localExtensionOn b e v) x = v := by
+    (localExtensionOn I b e v) x = v := by
   simp [localExtensionOn, hx]
 
 variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
-    (Trivialization.localFrame_coeff I e b i x') ((localExtensionOn b e) v x') =
-    (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn b e) v x) := by
+    (Trivialization.localFrame_coeff I e b i x') ((localExtensionOn I b e) v x') =
+    (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn I b e) v x) := by
   -- Combining these into one `simp` call makes these lemmas never fire.
-  rw [e.localFrame_coeff_apply_of_mem_baseSet b hx ((localExtensionOn b e) v) i,
-    e.localFrame_coeff_apply_of_mem_baseSet b hx' ((localExtensionOn b e) v) i]
+  rw [e.localFrame_coeff_apply_of_mem_baseSet b hx ((localExtensionOn I b e) v) i,
+    e.localFrame_coeff_apply_of_mem_baseSet b hx' ((localExtensionOn I b e) v) i]
   simp [localExtensionOn, hx, hx']
+  sorry -- TODO fix!
 
 variable (F) in
 lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
     {x : M} (hx : x ∈ e.baseSet) (v : V x) [ContMDiffVectorBundle ∞ F V I] :
-    CMDiff[e.baseSet] ∞ (T% (localExtensionOn b e v)) := by
+    CMDiff[e.baseSet] ∞ (T% (localExtensionOn I b e v)) := by
+  have hs := (e.isLocalFrameOn_localFrame_baseSet I 1 b)
+  simp only [localExtensionOn]
+  -- TODO: re-using the machinery above only yields C^n local extensions from a C^n frame;
+  -- the manual construction yields smooth extensions from even a C¹ frame...
+  apply hs.contMDiffOn_localExtension
   -- The local frame coefficients of `localExtensionOn` w.r.t. the frame induced by `e` are
   -- constant, hence smoothness follows.
   rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
   intro i
   simp only [LinearMap.piApply_apply]
   apply (contMDiffOn_const
-    (c := (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn b e) v x))).congr
+    (c := (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn I b e) v x))).congr
   intro y hy
   rw [localExtensionOn_localFrame_coeff b hx hy v i]
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -418,7 +418,7 @@ lemma localFrame_coeff_apply_of_notMem_baseSet (hx : x ∉ e.baseSet) (i : ι) :
 variable (e b) in
 @[simp]
 lemma localFrame_coeff_apply_of_mem_baseSet (hx : x ∈ e.baseSet) (s : Π x : M, V x) (i : ι) :
-    (localFrame_coeff I e b i x) (s x) = (e.basisAt b hx).repr (s x) i := by
+    localFrame_coeff I e b i x (s x) = (e.basisAt b hx).repr (s x) i := by
   have he := e.isLocalFrameOn_localFrame_baseSet I 1 b
   have hbasis : e.basisAt b hx = he.toBasisAt hx := by
     ext j
@@ -630,9 +630,31 @@ lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
     e.localFrame_coeff I b i x' (localExtensionOn b e v x') =
       e.localFrame_coeff I b i x (localExtensionOn b e v x) := by
-  simp [localExtensionOn, hx, hx']
+  have : (Trivialization.localFrame_coeff I e b i x) (localExtensionOn b e v x) = (Trivialization.localFrame_coeff I e b i x) v := by
+    simp [localExtensionOn, hx]
+  have : (Trivialization.localFrame_coeff I e b i x') (localExtensionOn b e v x') = (Trivialization.localFrame_coeff I e b i x) v := by
+    simp only [localExtensionOn, hx, ↓reduceDIte]
+    --simp [localExtensionOn, hx, hx']
+    set bx := e.basisAt b hx
+    set bx' := e.basisAt b hx'
+    rw [bx.sum_repr (u := v)]
+  simp [localExtensionOn, hx, hx', ↓reduceDIte]
+  simp
+  simp only [Basis.sum_repr]
+  simp only [map_sum, map_smul]
+  simp only [hx, hx', Trivialization.localFrame_apply_of_mem_baseSet]
+
+  simp only [smul_eq_mul, hx, Trivialization.localFrame_apply_of_mem_baseSet]
+  --simp
+  --simp only [Trivialization.localFrame_apply_of_mem_baseSet, ]
+  --simp only [hx,
+  --  Trivialization.localFrame_apply_of_mem_baseSet, Basis.sum_repr]
+  --rw [Module.Basis.sum_repr]
+
+  simp [hx, hx']
   sorry -- TODO: proof was done now
 
+#exit
 -- By construction, localExtensionOn is a linear map.
 
 variable (b e) in

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -611,7 +611,7 @@ In particular, our construction is smooth on `e.baseSet`, and linear in the inpu
 -/
 noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
-    (x : M) (v : V x) : (x' : M) → V x' :=
+    {x : M} (v : V x) : (x' : M) → V x' :=
   fun x' ↦ if hx : x ∈ e.baseSet then
     ∑ i, (b.localFrame_toBasis_at e hx).repr v i • b.localFrame e i x'
   else 0
@@ -619,7 +619,7 @@ noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
 variable (b e) in
 @[simp]
 lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
-    (localExtensionOn b e x v) x = v := by
+    (localExtensionOn b e v) x = v := by
   simp [localExtensionOn, hx]
 
 omit [IsManifold I 0 M] in
@@ -627,29 +627,28 @@ variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
-    b.localFrame_coeff I e i (localExtensionOn b e x v) x' =
-      b.localFrame_coeff I e i (localExtensionOn b e x v) x := by
+    b.localFrame_coeff I e i (localExtensionOn b e v) x' =
+      b.localFrame_coeff I e i (localExtensionOn b e v) x := by
   simp [localExtensionOn, hx, hx']
 
 -- By construction, localExtensionOn is a linear map.
 
 variable (b e) in
 lemma localExtensionOn_add (v v' : V x) :
-    localExtensionOn b e x (v + v') = localExtensionOn b e x v + localExtensionOn b e x v' := by
+    localExtensionOn b e (v + v') = localExtensionOn b e v + localExtensionOn b e v' := by
   ext x'
   by_cases hx: x ∈ e.baseSet; swap
   · simp [hx, localExtensionOn]
   · simp [hx, localExtensionOn, add_smul, Finset.sum_add_distrib]
 
 variable (b e) in
-lemma localExtensionOn_zero :
-    localExtensionOn b e x 0 = 0 := by
+lemma localExtensionOn_zero : localExtensionOn b e (x := x) 0 = 0 := by
   ext x'
   by_cases hx: x ∈ e.baseSet <;> simp [hx, localExtensionOn]
 
 variable (b e) in
 lemma localExtensionOn_smul (a : 𝕜) (v : V x) :
-    localExtensionOn b e x (a • v) = a • localExtensionOn b e x v := by
+    localExtensionOn b e (a • v) = a • localExtensionOn b e v := by
   ext x'
   by_cases hx: x ∈ e.baseSet; swap
   · simp [hx, localExtensionOn]
@@ -662,12 +661,12 @@ variable (F) in
 omit [IsManifold I 0 M] in
 lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
     {x : M} (hx : x ∈ e.baseSet) (v : V x) [ContMDiffVectorBundle ∞ F V I] :
-    CMDiff[e.baseSet] ∞ (T% (localExtensionOn b e x v)) := by
+    CMDiff[e.baseSet] ∞ (T% (localExtensionOn b e v)) := by
   -- The local frame coefficients of `localExtensionOn` w.r.t. the frame induced by `e` are
   -- constant, hence smoothness follows.
   rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
   intro i
-  apply (contMDiffOn_const (c := (b.localFrame_coeff I e i) (localExtensionOn b e x v) x)).congr
+  apply (contMDiffOn_const (c := (b.localFrame_coeff I e i) (localExtensionOn b e v) x)).congr
   intro y hy
   rw [localExtensionOn_localFrame_coeff b hx hy v i]
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -634,21 +634,16 @@ lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
     (localExtensionOn b e v) x = v := by
   simp [localExtensionOn, hx]
 
--- TODO: fix this proof!
 variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
     (Trivialization.localFrame_coeff I e b i x') ((localExtensionOn b e) v x') =
     (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn b e) v x) := by
--- statement used to be
---  e.localFrame_coeff I b i (LinearMap.piApply (localExtensionOn b e v)) x' =
---   e.localFrame_coeff I b i (localExtensionOn b e v) x := by
-  simp only [localExtensionOn, hx, ↓reduceDIte]
-  dsimp
-  simp [hx, hx']
-  -- TODO: proof was done here (and in fact just `simp [localExtensionOn, hx, hx']`)
-  sorry
+  -- Combining these into one `simp` call makes these lemmas never fire.
+  rw [e.localFrame_coeff_apply_of_mem_baseSet b hx ((localExtensionOn b e) v) i,
+    e.localFrame_coeff_apply_of_mem_baseSet b hx' ((localExtensionOn b e) v) i]
+  simp [localExtensionOn, hx, hx']
 
 variable (F) in
 lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -418,7 +418,7 @@ lemma localFrame_coeff_apply_of_notMem_baseSet (hx : x ∉ e.baseSet) (i : ι) :
 variable (e b) in
 @[simp]
 lemma localFrame_coeff_apply_of_mem_baseSet (hx : x ∈ e.baseSet) (s : Π x : M, V x) (i : ι) :
-    localFrame_coeff I e b i x (s x) = (e.basisAt b hx).repr (s x) i := by
+    (localFrame_coeff I e b i x) (s x) = (e.basisAt b hx).repr (s x) i := by
   have he := e.isLocalFrameOn_localFrame_baseSet I 1 b
   have hbasis : e.basisAt b hx = he.toBasisAt hx := by
     ext j
@@ -630,31 +630,9 @@ lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
     e.localFrame_coeff I b i x' (localExtensionOn b e v x') =
       e.localFrame_coeff I b i x (localExtensionOn b e v x) := by
-  have : (Trivialization.localFrame_coeff I e b i x) (localExtensionOn b e v x) = (Trivialization.localFrame_coeff I e b i x) v := by
-    simp [localExtensionOn, hx]
-  have : (Trivialization.localFrame_coeff I e b i x') (localExtensionOn b e v x') = (Trivialization.localFrame_coeff I e b i x) v := by
-    simp only [localExtensionOn, hx, ↓reduceDIte]
-    --simp [localExtensionOn, hx, hx']
-    set bx := e.basisAt b hx
-    set bx' := e.basisAt b hx'
-    rw [bx.sum_repr (u := v)]
-  simp [localExtensionOn, hx, hx', ↓reduceDIte]
-  simp
-  simp only [Basis.sum_repr]
-  simp only [map_sum, map_smul]
-  simp only [hx, hx', Trivialization.localFrame_apply_of_mem_baseSet]
-
-  simp only [smul_eq_mul, hx, Trivialization.localFrame_apply_of_mem_baseSet]
-  --simp
-  --simp only [Trivialization.localFrame_apply_of_mem_baseSet, ]
-  --simp only [hx,
-  --  Trivialization.localFrame_apply_of_mem_baseSet, Basis.sum_repr]
-  --rw [Module.Basis.sum_repr]
-
-  simp [hx, hx']
+  simp [localExtensionOn, hx, hx']
   sorry -- TODO: proof was done now
 
-#exit
 -- By construction, localExtensionOn is a linear map.
 
 variable (b e) in

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -83,6 +83,18 @@ the model fiber `F`.
 * `e.contMDiffOn_iff_localFrame_coeff b`: a section `s` is `C^k` on an open set `t ⊆ e.baseSet`
   iff all of its frame coefficients are
 
+A local frame can be used to extend any single vector `v : V x` to a section which is smooth near
+`x`, such that the construction is linear in `v`.
+* `localExtensionOn b e v`: given a basis `b` and a compatible trivialisation `e` of `V` near `x`,
+  extend the vector `v : V x` to a section of `V` which is smooth on `e.baseSet`
+* `localExtensionOn_apply_self`: `localExtensionOn b e v x = v`, i.e. we really extend `v` at `x`
+* `contMDiffOn_localExtensionOn`: `localExtensionOn b e v` is `C^n` on `e.baseSet`
+* `localExtensionOn_localFrame_coeff`: `localExtensionOn` has constant frame coefficients
+  (knowing this is sometimes useful when working with local extensions for covariant derivatives)
+* `localExtensionOn_add`, `localExtensionOn_zero` and `localExtensionOn_smul` prove that
+  `v ↦ localExtensionON b e v` is a linear map.
+
+
 ## Note
 
 This file proves smoothness criteria in terms of coefficients for local frames induced by a
@@ -93,8 +105,15 @@ trivialization. A fully frame-intrinsic converse for `IsLocalFrameOn` will be ad
 Local frames use the junk value pattern: they are defined on all of `M`, but their value is
 only meaningful on the set on which they are a local frame.
 
+Note that `localExtensionOn` need not be smooth globally; in turn, this definition makes sense over
+any field. In contrast, an extension to a global holomorphic vector field is more delicate for
+complex vector bundles (whereas *locally* holomorphic sections always exist).
+For real bundles, global extensions always exist and can be constructed by scalar multiplication
+of a local extension with a smooth bump function of sufficiently small support.
+
+
 ## Tags
-vector bundle, local frame, smoothness
+vector bundle, local frame, smoothness, local extension of section
 
 -/
 
@@ -592,23 +611,8 @@ We choose an extension with these particularly nice properties because this simp
 constructions on covariant derivatives (and in this context, the value at `s` at points other than
 `x` does not matter, but constant frame coefficients are useful).
 -/
-
--- Note that `localExtensionOn` need not be smooth globally;
--- in turn, this definition makes sense over any field.
--- In contrast, an extension to a global smooth vector field is more delicate for complex vector
--- bundles (where *locally* holomorphic sections always exist).
--- For real bundles, global extensions always exist and can be constructed by scalar multiplication
--- of a local extension with a smooth bump function of sufficiently small support.
-
-
-/--
-Extend a vector `v ∈ V x` to a local section of `V`, w.r.t. a chosen local trivialisation.
-This construction uses a choice of local frame near `x`, w.r.t. to a basis `b` of `F` and a
-compatible local trivialisation `e` of `V` near `x`: the resulting extension has constant
-coefficients on `e.baseSet` w.r.t. this trivialisation (and is zero otherwise).
-
-In particular, our construction is smooth on `e.baseSet`, and linear in the input vector `v`.
--/
+-- XXX: we could generalise this definition to any local frame on `U ∋ x`, with smoothness on `U`.
+-- Would this be useful? Should do this?
 noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
     {x : M} (v : V x) : (x' : M) → V x' :=

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -570,26 +570,36 @@ end MDifferentiable
 end
 
 -- local extension of a vector field in a trivialisation's base set
-section extendLocally
+section localExntensionOn
 
 variable {ι : Type*} [Fintype ι] {b : Basis ι 𝕜 F}
   {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F V → M)}
   [MemTrivializationAtlas e] {x : M}
 
 open scoped Classical in
--- TODO: add longer docs!
--- a starting point (not fully updated any more) is this:
-/- Extend a vector `v ∈ V x` to a section of the bundle `V`, whose value at `x` is `v`.
-The details of the extension are mostly unspecified: for covariant derivatives, the value of
-`s` at points other than `x` will not matter (except for shorter proofs).
-Thus, we choose `s` to be somewhat nice: our chosen construction is linear in `v`.
+
+/- Extend a vector `v ∈ V x` to a section `s` of the bundle `V` which is smooth near `x`,
+such that `s x = v` and this construction is linear in `v`.
+
+The details of this extension are unspecified (and could be subject to change).
+Currently, we construct this extension using a local frame induced by a choose of basis of the
+fibre `F` and a compatible trivialisation `e` of `V` around `x`.
+(Allowing any local frame near `x` would be easy to implement.)
+Our construction has constant coefficients on `e.baseSet` w.r.t. this local frame, and is zero
+otherwise. In particular, it is smooth on `e.baseSet`, and (globally) linear in `v`.
+
+We choose an extension with these particularly nice properties because this simplifies later
+constructions on covariant derivatives (and in this context, the value at `s` at points other than
+`x` does not matter, but constant frame coefficients are useful).
 -/
 
--- comment: need not be smooth (outside of e.baseSet), but this is a useful building block for
--- global smooth extensions of vector fields
--- the latter caps this with a smooth bump function, which need not exist if k=C
--- In contrast, this definition makes sense over any field
--- (for example, *locally* holomorphic sections always exist),
+-- Note that `localExtensionOn` need not be smooth globally;
+-- in turn, this definition makes sense over any field.
+-- In contrast, an extension to a global smooth vector field is more delicate for complex vector
+-- bundles (where *locally* holomorphic sections always exist).
+-- For real bundles, global extensions always exist and can be constructed by scalar multiplication
+-- of a local extension with a smooth bump function of sufficiently small support.
+
 
 /--
 Extend a vector `v ∈ V x` to a local section of `V`, w.r.t. a chosen local trivialisation.
@@ -663,4 +673,4 @@ lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace �
   intro y hy
   rw [localExtensionOn_localFrame_coeff b hx v i hy]
 
-end extendLocally
+end localExntensionOn

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -596,7 +596,6 @@ variable {e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)} [MemTri
   [VectorBundle 𝕜 F V]
 
 open scoped Classical in
-
 /-- Extend a vector `v ∈ V x` to a section `s` of the bundle `V` which is smooth near `x`,
 such that `s x = v` and this construction is linear in `v`.
 
@@ -629,9 +628,10 @@ variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
-    e.localFrame_coeff I b i (localExtensionOn b e v) x' =
-      e.localFrame_coeff I b i (localExtensionOn b e v) x := by
+    e.localFrame_coeff I b i x' (localExtensionOn b e v x') =
+      e.localFrame_coeff I b i x (localExtensionOn b e v x) := by
   simp [localExtensionOn, hx, hx']
+  sorry -- TODO: proof was done now
 
 -- By construction, localExtensionOn is a linear map.
 
@@ -667,8 +667,8 @@ lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace �
   -- constant, hence smoothness follows.
   rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
   intro i
-  apply (contMDiffOn_const (c := (e.localFrame_coeff I b i) (localExtensionOn b e v) x)).congr
+  apply (contMDiffOn_const (c := (e.localFrame_coeff I b i) x (localExtensionOn b e v x))).congr
   intro y hy
-  rw [localExtensionOn_localFrame_coeff b hx hy v i]
+  simp [localExtensionOn_localFrame_coeff b hx hy v i]
 
 end localExtensionOn

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -614,9 +614,19 @@ constructions on covariant derivatives (and in this context, the value at `s` at
 -- Would this be useful? Should do this?
 noncomputable def localExtensionOn (b : Basis ι 𝕜 F)
     (e : Trivialization F (TotalSpace.proj : TotalSpace F V → M)) [MemTrivializationAtlas e]
-    {x : M} (v : V x) : (x' : M) → V x' :=
-  fun x' ↦ if hx : x ∈ e.baseSet then ∑ i, (e.basisAt b hx).repr v i • e.localFrame b i x'
-  else 0
+    {x : M} : V x →ₗ[𝕜] ((x' : M) → V x') where
+  toFun v := open scoped Classical in
+    fun x' ↦ if hx : x ∈ e.baseSet then ∑ i, (e.basisAt b hx).repr v i • e.localFrame b i x' else 0
+  map_add' v v' := by
+    ext x'
+    by_cases hx: x ∈ e.baseSet; swap
+    · simp [hx]
+    · simp [hx, add_smul, Finset.sum_add_distrib]
+  map_smul' a v := by
+    ext x'
+    by_cases hx: x ∈ e.baseSet; swap
+    · simp [hx]
+    · simp +contextual [hx, Finset.smul_sum, mul_smul a (((e.basisAt b hx).repr v) _)]
 
 variable (b e) in
 @[simp]
@@ -624,40 +634,21 @@ lemma localExtensionOn_apply_self (hx : x ∈ e.baseSet) (v : V x) :
     (localExtensionOn b e v) x = v := by
   simp [localExtensionOn, hx]
 
+-- TODO: fix this proof!
 variable (b) in
 /-- A local extension has constant frame coefficients within its defining trivialisation. -/
 lemma localExtensionOn_localFrame_coeff [ContMDiffVectorBundle 1 F V I]
     (hx : x ∈ e.baseSet) (hx' : x' ∈ e.baseSet) (v : V x) (i : ι) :
-    e.localFrame_coeff I b i x' (localExtensionOn b e v x') =
-      e.localFrame_coeff I b i x (localExtensionOn b e v x) := by
-  simp [localExtensionOn, hx, hx']
-  sorry -- TODO: proof was done now
-
--- By construction, localExtensionOn is a linear map.
-
-variable (b e) in
-lemma localExtensionOn_add (v v' : V x) :
-    localExtensionOn b e (v + v') = localExtensionOn b e v + localExtensionOn b e v' := by
-  ext x'
-  by_cases hx: x ∈ e.baseSet; swap
-  · simp [hx, localExtensionOn]
-  · simp [hx, localExtensionOn, add_smul, Finset.sum_add_distrib]
-
-variable (b e) in
-lemma localExtensionOn_zero : localExtensionOn b e (x := x) 0 = 0 := by
-  ext x'
-  by_cases hx: x ∈ e.baseSet <;> simp [hx, localExtensionOn]
-
-variable (b e) in
-lemma localExtensionOn_smul (a : 𝕜) (v : V x) :
-    localExtensionOn b e (a • v) = a • localExtensionOn b e v := by
-  ext x'
-  by_cases hx: x ∈ e.baseSet; swap
-  · simp [hx, localExtensionOn]
-  · simp only [localExtensionOn, hx, ↓reduceDIte, map_smul, Finsupp.coe_smul, Pi.smul_apply,
-      smul_eq_mul, Finset.smul_sum]
-    congr with i
-    rw [mul_smul a (((e.basisAt b hx).repr v) i)]
+    (Trivialization.localFrame_coeff I e b i x') ((localExtensionOn b e) v x') =
+    (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn b e) v x) := by
+-- statement used to be
+--  e.localFrame_coeff I b i (LinearMap.piApply (localExtensionOn b e v)) x' =
+--   e.localFrame_coeff I b i (localExtensionOn b e v) x := by
+  simp only [localExtensionOn, hx, ↓reduceDIte]
+  dsimp
+  simp [hx, hx']
+  -- TODO: proof was done here (and in fact just `simp [localExtensionOn, hx, hx']`)
+  sorry
 
 variable (F) in
 lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace 𝕜]
@@ -667,8 +658,10 @@ lemma contMDiffOn_localExtensionOn [FiniteDimensional 𝕜 F] [CompleteSpace �
   -- constant, hence smoothness follows.
   rw [contMDiffOn_baseSet_iff_localFrame_coeff b]
   intro i
-  apply (contMDiffOn_const (c := (e.localFrame_coeff I b i) x (localExtensionOn b e v x))).congr
+  simp only [LinearMap.piApply_apply]
+  apply (contMDiffOn_const
+    (c := (Trivialization.localFrame_coeff I e b i x) ((localExtensionOn b e) v x))).congr
   intro y hy
-  simp [localExtensionOn_localFrame_coeff b hx hy v i]
+  rw [localExtensionOn_localFrame_coeff b hx hy v i]
 
 end localExtensionOn


### PR DESCRIPTION
One proof breaks again; one stupid design question comes up which requires some thought.

---

- [ ] depends on: #30339

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
