### PR TITLE
[Merged by Bors] - feat(Analysis/Complex): weaken hypothesis in Borel-Caratheodory theorem

### DIFF
--- a/Mathlib/Analysis/Complex/BorelCaratheodory.lean
+++ b/Mathlib/Analysis/Complex/BorelCaratheodory.lean
@@ -54,18 +54,18 @@ lemma norm_two_mul_div_one_add_le (hM : 0 < M) (hw : ‖w‖ < 1) :
   gcongr; · linarith
   rw [← norm_one (α := ℂ)]; exact norm_sub_le_norm_add 1 w
 
-/-- If `z.re < M`, then `‖z‖ < ‖2M - z‖`. This shows that the Schwarz transform
+/-- If `z.re ≤ M`, then `‖z‖ ≤ ‖2M - z‖`. This shows that the Schwarz transform
 `z ↦ z / (2M - z)` has numerator smaller than denominator when the real part is bounded by M -/
-lemma norm_lt_norm_two_mul_sub (_ : 0 < M) (_ : z.re < M) : ‖z‖ < ‖2 * M - z‖ := by
-  rw [← sq_lt_sq₀ (by positivity) (by positivity)]
-  suffices z.re * z.re < (2 * M - z.re) * (2 * M - z.re) by simpa [Complex.sq_norm, normSq_apply]
+lemma norm_le_norm_two_mul_sub (_ : 0 < M) (_ : z.re ≤ M) : ‖z‖ ≤ ‖2 * M - z‖ := by
+  rw [← sq_le_sq₀ (by positivity) (by positivity)]
+  suffices z.re * z.re ≤ (2 * M - z.re) * (2 * M - z.re) by simpa [Complex.sq_norm, normSq_apply]
   nlinarith
 
 /-- Application of the Schwarz lemma to the transformed function. If `f` is differentiable on
-the ball, maps into `{z | z.re < M}`, and satisfies `f 0 = 0`, then the Schwarz transform
+the ball, maps into `{z | z.re ≤ M}`, and satisfies `f 0 = 0`, then the Schwarz transform
 satisfies the bound from the Schwarz lemma. -/
 lemma schwarz_applied (hM : 0 < M) (hf : DifferentiableOn ℂ f (ball 0 R))
-    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re < M}) (hz : z ∈ ball 0 R) (hf₂ : f 0 = 0) :
+    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re ≤ M}) (hz : z ∈ ball 0 R) (hf₂ : f 0 = 0) :
     ‖f z / (2 * M - f z)‖ ≤ (1 / R) * ‖z‖ := by
   rw [← dist_zero_right, ← dist_zero_right]
   nth_rw 1 [← zero_div (2 * M - f 0), ← hf₂]
@@ -74,7 +74,7 @@ lemma schwarz_applied (hM : 0 < M) (hf : DifferentiableOn ℂ f (ball 0 R))
     have := sub_eq_zero.mp h ▸ hf₁ hx
     aesop
   · simpa [hf₂] using
-      div_le_one_of_le₀ (norm_lt_norm_two_mul_sub hM (hf₁ hx)).le (by positivity)
+      div_le_one_of_le₀ (norm_le_norm_two_mul_sub hM (hf₁ hx)) (by positivity)
 
 end SchwarzTransform
 
@@ -82,10 +82,10 @@ section BorelCaratheodory
 
 /-- **Borel-Carathéodory theorem** for functions vanishing at the origin.
 
-If `f` is analytic on the open ball `‖z‖ < R`, satisfies `(f z).re < M` for all such `z`,
+If `f` is analytic on the open ball `‖z‖ < R`, satisfies `(f z).re ≤ M` for all such `z`,
 and `f 0 = 0`, then `‖f z‖ ≤ 2 * M * ‖z‖ / (R - ‖z‖)` for all `‖z‖ < R`. -/
 public theorem borelCaratheodory_zero (hM : 0 < M) (hf : DifferentiableOn ℂ f (ball 0 R))
-    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re < M}) (hR : 0 < R) (hz : z ∈ ball 0 R)
+    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re ≤ M}) (hR : 0 < R) (hz : z ∈ ball 0 R)
     (hf₂ : f 0 = 0) : ‖f z‖ ≤ 2 * M * ‖z‖ / (R - ‖z‖) := by
   set w := f z / (2 * M - f z)
   have hzR : ‖z‖ < R := mem_ball_zero_iff.mp hz
@@ -105,16 +105,16 @@ public theorem borelCaratheodory_zero (hM : 0 < M) (hf : DifferentiableOn ℂ f 
 
 /-- **Borel-Carathéodory theorem**.
 
-If `f` is analytic on the open ball `‖z‖ < R` and satisfies `(f z).re < M` for all such `z`,
+If `f` is analytic on the open ball `‖z‖ < R` and satisfies `(f z).re ≤ M` for all such `z`,
 then `‖f z‖ ≤ 2 * M * ‖z‖ / (R - ‖z‖) + ‖f 0‖ * (R + ‖z‖) / (R - ‖z‖)` for all `‖z‖ < R`. -/
 public theorem borelCaratheodory (hM : 0 < M) (hf : DifferentiableOn ℂ f (ball 0 R))
-    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re < M}) (hR : 0 < R) (hz : z ∈ ball 0 R) :
+    (hf₁ : Set.MapsTo f (ball 0 R) {z | z.re ≤ M}) (hR : 0 < R) (hz : z ∈ ball 0 R) :
     ‖f z‖ ≤ 2 * M * ‖z‖ / (R - ‖z‖) + ‖f 0‖ * (R + ‖z‖) / (R - ‖z‖) := by
   have hfz : ‖f z - f 0‖ ≤ 2 * (M + ‖f 0‖) * ‖z‖ / (R - ‖z‖) := by
     apply borelCaratheodory_zero (by positivity) (by fun_prop) ?_ hR hz (by simp)
     intro x hx
     simp only [Set.mem_setOf_eq, sub_re]
-    calc (f x).re - (f 0).re < M - (f 0).re := by gcongr; exact hf₁ hx
+    calc (f x).re - (f 0).re ≤ M - (f 0).re := by gcongr; exact hf₁ hx
       _ ≤ M + ‖f 0‖ := by linarith [neg_le_abs (f 0).re, abs_re_le_norm (f 0)]
   have h_denom_ne : R - ‖z‖ ≠ 0 := by linarith [mem_ball_zero_iff.mp hz]
   calc ‖f z‖ ≤ ‖f z - f 0‖ + ‖f 0‖ := norm_le_norm_sub_add _ _

--- a/Mathlib/Analysis/Complex/BorelCaratheodory.lean
+++ b/Mathlib/Analysis/Complex/BorelCaratheodory.lean
@@ -22,8 +22,8 @@ open ball `|z| < R` such that `Re(f z) < M` for all `|z| < R`, we have
 
 ## Implementation Notes
 
-The proof applies the Schwarz lemma to the transformed function `fun z ↦ f z / (2 * M - f z)`,
-which maps the ball `|z| < R` into the unit disk provided that `(f z).re < M` for all `|z| < R`.
+The proof applies the Schwarz lemma to the transformed function `w z := f z / (2 * M - f z)`,
+which maps the ball `|z| < R` into the unit disk provided that `(f z).re ≤ M` for all `|z| < R`.
 After obtaining bounds on `w`, we invert the transformation to recover bounds on `f`.
 
 ## Tags


### PR DESCRIPTION
Replace the hypothesis Re z < m with Re z <= m which is sufficient for the proof. The conclusions are unchanged. The non-strict inequality is used in the PNT project, somehow it had been made strict when upstreaming the result.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
