### PR TITLE
[Merged by Bors] - feat(NumberTheory/Height): formula for logHeight₁

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -391,6 +391,8 @@ protected theorem _root_.Finsupp.log_prod {α β : Type*} [Zero β] (f : α →�
     (hg : ∀ a, g a (f a) = 0 → f a = 0) : log (f.prod g) = f.sum fun a b ↦ log (g a b) :=
   log_prod fun _x hx h₀ ↦ Finsupp.mem_support_iff.1 hx <| hg _ h₀
 
+-- Note: This is wrong assuming only `f a ≠ 0` (as in `Real.log_prod`).
+-- E.g., `f = (2, -1, -1, ...)` (with infinitely many `-1`s).
 lemma log_finprod {α : Type*} {f : α → ℝ} (h : ∀ a, 0 < f a) :
     log (∏ᶠ a, f a) = ∑ᶠ a, log (f a) := by
   classical

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -391,6 +391,13 @@ protected theorem _root_.Finsupp.log_prod {α β : Type*} [Zero β] (f : α →�
     (hg : ∀ a, g a (f a) = 0 → f a = 0) : log (f.prod g) = f.sum fun a b ↦ log (g a b) :=
   log_prod fun _x hx h₀ ↦ Finsupp.mem_support_iff.1 hx <| hg _ h₀
 
+lemma log_finprod {α : Type*} {f : α → ℝ} (h : ∀ a, 0 < f a) :
+    log (∏ᶠ a, f a) = ∑ᶠ a, log (f a) := by
+  classical
+  simp only [finprod_def, finsum_def, show (fun i ↦ log (f i)).support = f.mulSupport by
+    grind [mem_mulSupport, mem_support, log_eq_zero]]
+  grind [log_prod, log_eq_zero]
+
 theorem log_nat_eq_sum_factorization (n : ℕ) :
     log n = n.factorization.sum fun p t => t * log p := by
   rcases eq_or_ne n 0 with (rfl | hn)

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -5,7 +5,7 @@ Authors: Michael Stoll
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.Log.Basic
+public import Mathlib.Analysis.SpecialFunctions.Log.PosLog
 public import Mathlib.Tactic.Positivity.Core
 
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
@@ -154,6 +154,23 @@ lemma logHeight₁_one : logHeight₁ (1 : K) = 0 := by
 
 lemma zero_le_logHeight₁ (x : K) : 0 ≤ logHeight₁ x :=
   Real.log_nonneg <| one_le_mulHeight₁ x
+
+/-- The logarithmic height of a field element can be expressed as a sum over the positive parts
+of the logarithms of its various absolute values. -/
+lemma logHeight₁_eq (x : K) :
+    logHeight₁ x =
+      (archAbsVal.map fun v ↦ log⁺ (v x)).sum + ∑ᶠ v : nonarchAbsVal, log⁺ (v.val x) := by
+  simp only [logHeight₁_eq_log_mulHeight₁, mulHeight₁_eq]
+  have H : mulHeight₁ x ≠ 0 := mulHeight₁_ne_zero x
+  rw [mulHeight₁_eq] at H
+  have : ∀ a ∈ archAbsVal.map (fun v ↦ max (v x) 1), a ≠ 0 := by
+    intro a ha
+    contrapose! ha
+    rw [ha]
+    exact Multiset.prod_eq_zero_iff.not.mp <| left_ne_zero_of_mul H
+  rw [log_mul (left_ne_zero_of_mul H) (right_ne_zero_of_mul H), log_multiset_prod this,
+    Multiset.map_map, log_finprod (fun _ ↦ by positivity)]
+  congr 2 <;> simp [max_comm, posLog_eq_log_max_one]
 
 end Height
 

--- a/Mathlib/NumberTheory/Height/NumberField.lean
+++ b/Mathlib/NumberTheory/Height/NumberField.lean
@@ -77,9 +77,8 @@ lemma sum_archAbsVal_eq {M : Type*} [AddCommMonoid M] (f : AbsoluteValue K ℝ �
     (archAbsVal.map f).sum = ∑ v : InfinitePlace K, v.mult • f v.val := by
   classical
   rw [sum_multiset_map_count]
-  exact sum_bij' (fun w hw ↦ ⟨w, mem_multisetInfinitePlace.mp <| mem_dedup.mp hw⟩)
-    (fun v _ ↦ v.val) (fun _ _ ↦ mem_univ _) (fun v _ ↦ by simp [v.isInfinitePlace, archAbsVal])
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  exact sum_bij' (⟨·, mem_multisetInfinitePlace.mp <| mem_dedup.mp ·⟩)
+    _ (by simp) (by simp [InfinitePlace.isInfinitePlace, archAbsVal]) (by simp) (fun _ _ ↦ rfl)
     fun w hw ↦ by
       simp only [archAbsVal, mem_toFinset, mem_multisetInfinitePlace] at hw ⊢
       simp [count_multisetInfinitePlace_eq_mult ⟨w, hw⟩]

--- a/Mathlib/NumberTheory/Height/NumberField.lean
+++ b/Mathlib/NumberTheory/Height/NumberField.lean
@@ -72,12 +72,38 @@ lemma prod_nonarchAbsVal_eq {M : Type*} [CommMonoid M] (f : AbsoluteValue K ℝ 
     (∏ᶠ v : nonarchAbsVal, f v.val) = ∏ᶠ v : FinitePlace K, f v.val :=
   rfl
 
+open Finset Multiset in
+lemma sum_archAbsVal_eq {M : Type*} [AddCommMonoid M] (f : AbsoluteValue K ℝ → M) :
+    (archAbsVal.map f).sum = ∑ v : InfinitePlace K, v.mult • f v.val := by
+  classical
+  rw [sum_multiset_map_count]
+  exact sum_bij' (fun w hw ↦ ⟨w, mem_multisetInfinitePlace.mp <| mem_dedup.mp hw⟩)
+    (fun v _ ↦ v.val) (fun _ _ ↦ mem_univ _) (fun v _ ↦ by simp [v.isInfinitePlace, archAbsVal])
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    fun w hw ↦ by
+      simp only [archAbsVal, mem_toFinset, mem_multisetInfinitePlace] at hw ⊢
+      simp [count_multisetInfinitePlace_eq_mult ⟨w, hw⟩]
+
+lemma sum_nonarchAbsVal_eq {M : Type*} [AddCommMonoid M] (f : AbsoluteValue K ℝ → M) :
+    (∑ᶠ v : nonarchAbsVal, f v.val) = ∑ᶠ v : FinitePlace K, f v.val :=
+  rfl
+
+
 /-- This is the familiar definition of the multiplicative height on a number field. -/
 lemma mulHeight₁_eq (x : K) :
     mulHeight₁ x =
       (∏ v : InfinitePlace K, max (v x) 1 ^ v.mult) * ∏ᶠ v : FinitePlace K, max (v x) 1 := by
   simp only [FinitePlace.coe_apply, InfinitePlace.coe_apply, Height.mulHeight₁_eq,
     prod_archAbsVal_eq, prod_nonarchAbsVal_eq fun v ↦ max (v x) 1]
+
+open Real in
+-- For the next PR
+/-- This is the familiar definition of the logarithmic height on a number field. -/
+lemma logHeight₁_eq (x : K) :
+    logHeight₁ x =
+      (∑ v : InfinitePlace K, v.mult * log⁺ (v x)) + ∑ᶠ v : FinitePlace K, log⁺ (v x) := by
+  simp only [← nsmul_eq_mul, FinitePlace.coe_apply, InfinitePlace.coe_apply, Height.logHeight₁_eq,
+    sum_archAbsVal_eq, sum_nonarchAbsVal_eq fun v ↦ log⁺ (v x)]
 
 /-- This is the familiar definition of the multiplicative height on (nonzero) tuples
 of number field elements. -/

--- a/Mathlib/NumberTheory/Height/NumberField.lean
+++ b/Mathlib/NumberTheory/Height/NumberField.lean
@@ -97,7 +97,6 @@ lemma mulHeight₁_eq (x : K) :
     prod_archAbsVal_eq, prod_nonarchAbsVal_eq fun v ↦ max (v x) 1]
 
 open Real in
--- For the next PR
 /-- This is the familiar definition of the logarithmic height on a number field. -/
 lemma logHeight₁_eq (x : K) :
     logHeight₁ x =


### PR DESCRIPTION
This adds the formula for the logarithmic height of a field element as the sum of the positive parts of the logaithms of its various absolute values, plus a version specific for number fields.

We also add an API lemma `Real.log_finprod` that is needed for this.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
