### PR TITLE
[Merged by Bors] - chore(ENNReal/Inv): lemma variants for `norm_cast`

### DIFF
--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -67,12 +67,18 @@ theorem coe_inv_le : (↑r⁻¹ : ℝ≥0∞) ≤ (↑r)⁻¹ :=
 theorem coe_inv (hr : r ≠ 0) : (↑r⁻¹ : ℝ≥0∞) = (↑r)⁻¹ :=
   coe_inv_le.antisymm <| sInf_le <| mem_setOf.2 <| by rw [← coe_mul, mul_inv_cancel₀ hr, coe_one]
 
+@[simp, norm_cast]
+theorem coe_inv' [NeZero r] : (↑r⁻¹ : ℝ≥0∞) = (↑r)⁻¹ := coe_inv (NeZero.ne r)
+
 @[norm_cast]
 theorem coe_inv_two : ((2⁻¹ : ℝ≥0) : ℝ≥0∞) = 2⁻¹ := by rw [coe_inv _root_.two_ne_zero, coe_two]
 
 @[simp, norm_cast]
 theorem coe_div (hr : r ≠ 0) : (↑(p / r) : ℝ≥0∞) = p / r := by
   rw [div_eq_mul_inv, div_eq_mul_inv, coe_mul, coe_inv hr]
+
+@[simp, norm_cast]
+theorem coe_div' [NeZero r] : (↑(p / r) : ℝ≥0∞) = p / r := coe_div (NeZero.ne r)
 
 lemma coe_div_le : ↑(p / r) ≤ (p / r : ℝ≥0∞) := by
   simpa only [div_eq_mul_inv, coe_mul] using _root_.mul_le_mul_right coe_inv_le _

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -207,13 +207,12 @@ lemma mutuallySingular_of_disjoint (h : Disjoint μ ν) : μ ⟂ₘ ν := by
   have h' (n : ℕ) : ∃ s, μ s = 0 ∧ ν sᶜ ≤ (1 / 2) ^ n := by
     convert exists_null_set_measure_lt_of_disjoint h (ε := (1 / 2) ^ (n + 1))
       <| pow_pos (by simp) (n + 1)
-    push_cast
-    rw [pow_succ, ← mul_assoc, mul_comm, ← mul_assoc]
+    conv =>
+      -- this tweak is needed due to the known issue of `norm_cast` with numeric fractions
+      enter [1, 1]
+      equals ((1:ℝ≥0) / (2:ℝ≥0)) => rfl
     norm_cast
-    rw [div_mul_cancel₀, one_mul]
-    · push_cast
-      simp
-    · simp
+    ring
   choose s hs₂ hs₃ using h'
   refine Measure.MutuallySingular.mk (t := (⋃ n, s n)ᶜ) (measure_iUnion_null hs₂) ?_ ?_
   · rw [compl_iUnion]

--- a/MathlibTest/norm_cast.lean
+++ b/MathlibTest/norm_cast.lean
@@ -134,6 +134,9 @@ lemma half_lt_self_bis {a : ℝ≥0∞} (hz : a ≠ 0) (ht : a ≠ ⊤) : a / 2 
   norm_cast at hz
   exact NNReal.half_lt_self hz
 
+example (x : NNReal) : (x:ENNReal) / 3 = ↑(x / 3) := by
+  norm_cast
+
 end ENNReal
 
 lemma b (_h g : true) : true ∧ true := by

--- a/MathlibTest/norm_cast.lean
+++ b/MathlibTest/norm_cast.lean
@@ -134,7 +134,7 @@ lemma half_lt_self_bis {a : ℝ≥0∞} (hz : a ≠ 0) (ht : a ≠ ⊤) : a / 2 
   norm_cast at hz
   exact NNReal.half_lt_self hz
 
-example (x : NNReal) : (x:ENNReal) / 3 = ↑(x / 3) := by
+example (x : NNReal) : (x : ENNReal) / 3 = ↑(x / 3) := by
   norm_cast
 
 end ENNReal


### PR DESCRIPTION
The `norm_cast` lemma intertwining division with the `NNReal`-to-`ENNReal` cast has a side condition that the denominator be nonzero. (Otherwise it fails, because division by zero is different in those two types.) So `norm_cast` currently works in this setting only if it can find a suitable nonzeroness hypothesis.

We add a variant of the lemma in which the side condition is made instance-implicit, by phrasing it using `NeZero`. This in particular allows `norm_cast` to work for this cast when the denominator is a numeral. For example, this now works, for `↑` the cast from `NNReal` to `ENNReal`:
```lean
example (x : NNReal) : (↑x) / 3 = ↑(x / 3) := by norm_cast
```

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
