### PR TITLE
[Merged by Bors] - chore(CategoryTheory): improve Factorisation

### DIFF
--- a/Mathlib/CategoryTheory/Category/Factorisation.lean
+++ b/Mathlib/CategoryTheory/Category/Factorisation.lean
@@ -41,7 +41,7 @@ structure Factorisation {X Y : C} (f : X ⟶ Y) where
   /-- The factorisation condition. -/
   ι_π : ι ≫ π = f := by cat_disch
 
-attribute [simp] Factorisation.ι_π
+attribute [reassoc (attr := simp)] Factorisation.ι_π
 
 namespace Factorisation
 
@@ -58,25 +58,17 @@ protected structure Hom (d e : Factorisation f) : Type (max u v) where
   /-- The right commuting triangle of the factorization morphism. -/
   h_π : h ≫ e.π = d.π := by cat_disch
 
-attribute [simp] Factorisation.Hom.ι_h Factorisation.Hom.h_π
+attribute [reassoc (attr := simp)] Factorisation.Hom.ι_h Factorisation.Hom.h_π
 
-/-- The identity morphism of `Factorisation f`. -/
-@[simps]
-protected def Hom.id (d : Factorisation f) : Factorisation.Hom d d where
-  h := 𝟙 _
-
-/-- Composition of morphisms in `Factorisation f`. -/
-@[simps]
-protected def Hom.comp {d₁ d₂ d₃ : Factorisation f}
-    (f : Factorisation.Hom d₁ d₂) (g : Factorisation.Hom d₂ d₃) : Factorisation.Hom d₁ d₃ where
-  h := f.h ≫ g.h
-  ι_h := by rw [← Category.assoc, f.ι_h, g.ι_h]
-  h_π := by rw [Category.assoc, g.h_π, f.h_π]
-
-instance : Category.{max u v} (Factorisation f) where
+instance : Quiver (Factorisation f) where
   Hom d e := Factorisation.Hom d e
-  id d := Factorisation.Hom.id d
-  comp f g := Factorisation.Hom.comp f g
+
+@[simps]
+instance : Category.{max u v} (Factorisation f) where
+  id d := { h := 𝟙 _ }
+  comp f g := { h := f.h ≫ g.h }
+
+attribute [reassoc] comp_h
 
 variable (d : Factorisation f)
 


### PR DESCRIPTION
Some `reassoc` attributes are added so as to improve automation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
