### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): limits of degreewise eventually constant projective systems

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -602,6 +602,7 @@ public import Mathlib.Algebra.Homology.HomologicalComplex
 public import Mathlib.Algebra.Homology.HomologicalComplexAbelian
 public import Mathlib.Algebra.Homology.HomologicalComplexBiprod
 public import Mathlib.Algebra.Homology.HomologicalComplexLimits
+public import Mathlib.Algebra.Homology.HomologicalComplexLimitsEventuallyConstant
 public import Mathlib.Algebra.Homology.HomologySequence
 public import Mathlib.Algebra.Homology.HomologySequenceLemmas
 public import Mathlib.Algebra.Homology.Homotopy

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimitsEventuallyConstant.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimitsEventuallyConstant.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Constructions.EventuallyConstant
+public import Mathlib.Algebra.Homology.HomologicalComplexLimits
+public import Mathlib.Algebra.Homology.QuasiIso
+
+/-!
+# Limits of eventually constant systems
+
+Let `F : J ⥤ HomologicalComplex C c` be a functor from a cofiltered category
+such that for any degree `q`, the functor `F ⋙ eval C c q : J ⥤ C` is
+eventually constant. Let `cF` be a limit cone for `F`. For a given degree `q`,
+we show that for suitable `j : J`, the map `(cF.π.app j).f q` is an
+isomorphism, and that `cf.π.app j` is a quasi-isomorphism in degree `q`.
+
+-/
+
+@[expose] public section
+
+open CategoryTheory Category Limits
+
+variable {C J ι : Type*} [Category C] [Category J]
+   {c : ComplexShape ι} [IsCofiltered J]
+
+namespace HomologicalComplex
+
+variable [HasZeroMorphisms C] (F : J ⥤ HomologicalComplex C c)
+  [∀ (j : ι), HasLimit (F ⋙ eval C c j)]
+  {cF : Cone F} (hcF : IsLimit cF)
+
+include hcF
+
+lemma isIso_π_f_of_isLimit_of_isEventuallyConstantTo
+    (q : ι) (j : J) (hq : (F ⋙ eval C c q).IsEventuallyConstantTo j) :
+    IsIso ((cF.π.app j).f q) :=
+  hq.isIso_π_of_isLimit (isLimitOfPreserves (eval C c q) hcF)
+
+lemma quasiIsoAt_π_of_isLimit_of_isEventuallyConstantTo
+    [CategoryWithHomology C] (q₀ q₁ q₂ : ι)
+    (h₀ : c.prev q₁ = q₀) (h₂ : c.next q₁ = q₂) (j : J)
+    (hq₀ : (F ⋙ eval C c q₀).IsEventuallyConstantTo j)
+    (hq₁ : (F ⋙ eval C c q₁).IsEventuallyConstantTo j)
+    (hq₂ : (F ⋙ eval C c q₂).IsEventuallyConstantTo j) :
+    QuasiIsoAt (cF.π.app j) q₁ := by
+  rw [quasiIsoAt_iff' _ q₀ q₁ q₂ h₀ h₂]
+  let φ := (shortComplexFunctor' C c q₀ q₁ q₂).map (cF.π.app j)
+  have : IsIso φ.τ₁ := isIso_π_f_of_isLimit_of_isEventuallyConstantTo F hcF _ _ hq₀
+  have : IsIso φ.τ₂ := isIso_π_f_of_isLimit_of_isEventuallyConstantTo F hcF _ _ hq₁
+  have : IsIso φ.τ₃ := isIso_π_f_of_isLimit_of_isEventuallyConstantTo F hcF _ _ hq₂
+  apply ShortComplex.quasiIso_of_epi_of_isIso_of_mono
+
+end HomologicalComplex

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimitsEventuallyConstant.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimitsEventuallyConstant.lean
@@ -10,7 +10,7 @@ public import Mathlib.Algebra.Homology.HomologicalComplexLimits
 public import Mathlib.Algebra.Homology.QuasiIso
 
 /-!
-# Limits of eventually constant systems
+# Limits of degreewise eventually constant systems
 
 Let `F : J ⥤ HomologicalComplex C c` be a functor from a cofiltered category
 such that for any degree `q`, the functor `F ⋙ eval C c q : J ⥤ C` is


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
