### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift): naturality lemmas for ShiftedHom.map

### DIFF
--- a/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
@@ -192,6 +192,7 @@ lemma map_naturality {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (τ : F ⟶ 
   rw [comp_mk₀, mk₀_comp, map, map, Category.assoc, ← τ.naturality_assoc,
     τ.shift_app_comm a]
 
+@[simp]
 lemma map_naturality_1
     {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (e : F ≅ G)
     [F.CommShift M] [G.CommShift M] [NatTrans.CommShift e.hom M] :

--- a/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
@@ -200,6 +200,7 @@ lemma map_naturality_1
       (mk₀ 0 rfl (e.hom.app Y)) (zero_add _)) (add_zero _) = f.map G := by
   simp [map_naturality]
 
+@[simp]
 lemma map_naturality_2
     {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (e : F ≅ G)
     [F.CommShift M] [G.CommShift M] [NatTrans.CommShift e.hom M] :

--- a/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
@@ -185,6 +185,27 @@ lemma comp_map {a : M} (f : ShiftedHom X Y a) (F : C ⥤ D) [F.CommShift M]
     (G : D ⥤ E) [G.CommShift M] : f.map (F ⋙ G) = (f.map F).map G := by
   simp [map, Functor.commShiftIso_comp_hom_app]
 
+lemma map_naturality {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (τ : F ⟶ G)
+    [F.CommShift M] [G.CommShift M] [NatTrans.CommShift τ M] :
+    (f.map F).comp (mk₀ 0 rfl (τ.app Y)) (zero_add _) =
+      (mk₀ 0 rfl (τ.app X)).comp (f.map G) (add_zero _) := by
+  rw [comp_mk₀, mk₀_comp, map, map, Category.assoc, ← τ.naturality_assoc,
+    τ.shift_app_comm a]
+
+lemma map_naturality_1
+    {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (e : F ≅ G)
+    [F.CommShift M] [G.CommShift M] [NatTrans.CommShift e.hom M] :
+    (mk₀ 0 rfl (e.inv.app X)).comp ((f.map F).comp
+      (mk₀ 0 rfl (e.hom.app Y)) (zero_add _)) (add_zero _) = f.map G := by
+  simp [map_naturality]
+
+lemma map_naturality_2
+    {a : M} (f : ShiftedHom X Y a) {F G : C ⥤ D} (e : F ≅ G)
+    [F.CommShift M] [G.CommShift M] [NatTrans.CommShift e.hom M] :
+    (mk₀ 0 rfl (e.hom.app X)).comp ((f.map G).comp
+      (mk₀ 0 rfl (e.inv.app Y)) (zero_add _)) (add_zero _) = f.map F :=
+  map_naturality_1 f e.symm
+
 set_option backward.isDefEq.respectTransparency false in
 lemma map_comp {a b c : M} (f : ShiftedHom X Y a) (g : ShiftedHom Y Z b)
     (h : b + a = c) (F : C ⥤ D) [F.CommShift M] :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
