### PR TITLE
[Merged by Bors] - chore: replace uses of `aesop` with `simp`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -470,7 +470,7 @@ theorem splits_mul_iff (hf₀ : f ≠ 0) (hg₀ : g ≠ 0) :
     rw [← hp, natDegree_mul hf₀ hg₀, Nat.add_eq_zero_iff] at hn
     exact ⟨splits_of_natDegree_eq_zero hn.1, splits_of_natDegree_eq_zero hn.2⟩
   | succ n ih =>
-    obtain ⟨a, ha⟩ := Splits.exists_eval_eq_zero h (degree_ne_of_natDegree_ne <| hn ▸ by aesop)
+    obtain ⟨a, ha⟩ := Splits.exists_eval_eq_zero h (degree_ne_of_natDegree_ne <| hn ▸ by simp)
     have := dvd_iff_isRoot.mpr ha
     rw [← hp, (prime_X_sub_C a).dvd_mul] at this
     wlog hf : X - C a ∣ f with hf2

--- a/Mathlib/AlgebraicGeometry/Noetherian.lean
+++ b/Mathlib/AlgebraicGeometry/Noetherian.lean
@@ -344,7 +344,7 @@ instance {R} [CommRing R] [IsNoetherianRing R] :
   assumption
 
 instance [IsLocallyNoetherian X] {x : X} : IsNoetherianRing (X.presheaf.stalk x) := by
-  obtain ⟨U, hU, hU2, hU3⟩ := exists_isAffineOpen_mem_and_subset (U := ⊤) (x := x) (by aesop)
+  obtain ⟨U, hU, hU2, hU3⟩ := exists_isAffineOpen_mem_and_subset (U := ⊤) (x := x) (by simp)
   have := AlgebraicGeometry.IsAffineOpen.isLocalization_stalk hU ⟨x, hU2⟩
   exact @IsLocalization.isNoetherianRing _ _ (hU.primeIdealOf ⟨x, hU2⟩).asIdeal.primeCompl
         (X.presheaf.stalk x) _ (X.presheaf.algebra_section_stalk ⟨x, hU2⟩)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -255,7 +255,7 @@ def faceRepresentableBy {n : ℕ} (S : Finset (Fin (n + 1)))
     { toFun f := ⟨objMk ((OrderHom.Subtype.val (· ∈ S)).comp
           (e.toOrderEmbedding.toOrderHom.comp f.toOrderHom)), fun _ ↦ by aesop⟩
       invFun := fun ⟨x, hx⟩ ↦ SimplexCategory.Hom.mk
-        { toFun i := e.symm ⟨(objEquiv x).toOrderHom i, hx (by aesop)⟩
+        { toFun i := e.symm ⟨(objEquiv x).toOrderHom i, hx (by simp)⟩
           monotone' i₁ i₂ h := e.symm.monotone (by
             simp only [Subtype.mk_le_mk]
             exact OrderHom.monotone _ h) }

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -249,9 +249,9 @@ theorem summable_condensed_iff_of_eventually_nonneg {f : ℕ → ℝ} (h_nonneg 
     filter_upwards [h_pow.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
   · rw [summable_congr_atTop]
     filter_upwards [Filter.eventually_ge_atTop (n + m)] with _ hk using by simp [max_eq_left hk]
-  · bound
+  · simp_all
   · intro _ _ _ _
-    exact antitoneOn_nat_Ici_of_succ_le (k := n + m) (by bound) (by aesop) (by aesop) (by bound)
+    exact antitoneOn_nat_Ici_of_succ_le (k := n + m) (by grind) (by simp) (by simp) (by grind)
 
 section p_series
 

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -232,7 +232,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
   have : g₁.right = g₂.right := calc
     g₁.right = hc.lift (c.extend g₁.right) := by
       apply hc.uniq (c.extend _)
-      aesop
+      simp
     _ = hc.lift (c.extend g₂.right) := by
       congr
     _ = g₂.right := by

--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -239,8 +239,8 @@ def currySum (f : MultilinearMap R N M₂) :
     MultilinearMap R (fun i : ι ↦ N (.inl i)) (MultilinearMap R (fun i : ι' ↦ N (.inr i)) M₂) where
   toFun u :=
     { toFun v := f (Sum.rec u v)
-      map_update_add' := by letI := Classical.decEq ι; aesop
-      map_update_smul' := by letI := Classical.decEq ι; aesop }
+      map_update_add' := by letI := Classical.decEq ι; simp
+      map_update_smul' := by letI := Classical.decEq ι; simp }
   map_update_add' u i x y :=
     ext fun _ ↦ by letI := Classical.decEq ι'; simp
   map_update_smul' u i c x :=

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -211,7 +211,7 @@ theorem union_of_isPrimitiveRoot [hB : IsCyclotomicExtension S A B] {r : B}
   by_cases hn : n = 0
   · rwa [hn, eq_self_sdiff_zero, Set.union_diff_right, ← eq_self_sdiff_zero]
   rw [iff_adjoin_eq_top]
-  refine ⟨fun m hm₁ hm₂ ↦ ?_, le_antisymm (by aesop) ?_⟩
+  refine ⟨fun m hm₁ hm₂ ↦ ?_, le_antisymm (by simp) ?_⟩
   · obtain hm₁ | rfl := hm₁
     · exact exists_isPrimitiveRoot A B hm₁ hm₂
     · use r

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
@@ -221,7 +221,7 @@ def expMap_single (w : InfinitePlace K) : OpenPartialHomeomorph ℝ ℝ where
   left_inv' _ _ := by simp only [Real.log_exp, mul_inv_cancel_left₀ mult_coe_ne_zero]
   right_inv' _ h := by simp only [inv_mul_cancel_left₀ mult_coe_ne_zero, Real.exp_log h]
   continuousOn_toFun := (continuousOn_const.mul continuousOn_id).rexp
-  continuousOn_invFun := continuousOn_const.mul (Real.continuousOn_log.mono (by aesop))
+  continuousOn_invFun := continuousOn_const.mul (Real.continuousOn_log.mono (by simp))
 
 /--
 The derivative of `expMap_single`, see `hasDerivAt_expMap_single`.

--- a/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
+++ b/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
@@ -77,7 +77,7 @@ lemma coinvariantsKer_leftRegular_eq_ker :
   refine le_antisymm (Submodule.span_le.2 ?_) fun x hx => ?_
   · rintro x ⟨⟨g, y⟩, rfl⟩
     simpa [linearCombination, sub_eq_zero, sum_fintype]
-      using Finset.sum_bijective _ (Group.mulLeft_bijective g⁻¹) (by aesop) (by lia)
+      using Finset.sum_bijective _ (Group.mulLeft_bijective g⁻¹) (by simp) (by lia)
   · have : x = x.sum (fun g r => single g r - single 1 r) := by
       ext g
       by_cases hg : g = 1

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/FiniteCyclic.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/FiniteCyclic.lean
@@ -63,7 +63,7 @@ noncomputable def coinvariantsTensorResolutionIso (hg : ∀ x, x ∈ Subgroup.zp
     · simpa [hj, whiskerLeft_def, coinvariantsTensorMk,
         tensorObj_carrier, ofCoinvariantsTprodLeftRegular, Representation.norm,
         ← Module.End.mul_apply, ← map_mul, mul_comm g⁻¹]
-        using Finset.sum_bijective _ (MulEquiv.inv G).bijective (by aesop) (by aesop)
+        using Finset.sum_bijective _ (MulEquiv.inv G).bijective (by simp) (by simp)
     · simp [hj, whiskerLeft_def, coinvariantsTensorMk, tensorObj_carrier,
         ← Module.End.mul_apply, ← map_mul, mul_comm g⁻¹]))
 
@@ -86,7 +86,7 @@ noncomputable def groupHomologyIsoEven
     groupHomology A i ≅ (subCompNormHom A g).homology :=
   groupHomologyIso A i (resolution k g⁻¹ <| (@Subgroup.zpowers_inv G ..).symm ▸ hg) ≪≫
   (HomologicalComplex.homologyMapIso (coinvariantsTensorResolutionIso A g hg) i) ≪≫
-  HomologicalComplex.alternatingConstHomologyIsoEven A.V (by ext; simp) (by ext; simp) _ (by aesop)
+  HomologicalComplex.alternatingConstHomologyIsoEven A.V (by ext; simp) (by ext; simp) _ (by simp)
     (by induction i generalizing h₀ with | zero => exact (NeZero.ne 0 rfl).elim | succ n _ => simp)
     hi
 

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -705,7 +705,7 @@ lemma shortComplexH0_exact : (shortComplexH0 A).Exact := by
 
 /-- The 0-cycles of the complex of inhomogeneous chains of `A` are isomorphic to `A`. -/
 def cyclesIso₀ : cycles A 0 ≅ A.V :=
-  (inhomogeneousChains A).iCyclesIso _ 0 (by aesop) (by aesop) ≪≫ chainsIso₀ A
+  (inhomogeneousChains A).iCyclesIso _ 0 (by simp) (by simp) ≪≫ chainsIso₀ A
 
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp), elementwise (attr := simp)]

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
@@ -51,7 +51,7 @@ def linearMapRightBaseChangeHom (ε : N →ₗ[R] P) :
   toAddHom := (TensorProduct.lift {
     toFun s := s • (LinearMap.compRight R ε (M := M))
     map_add' x y := by ext; simp [add_smul]
-    map_smul' r s := by aesop }).toAddHom
+    map_smul' r s := by simp }).toAddHom
   map_smul' s x := by
     simp only [AddHom.toFun_eq_coe, coe_toAddHom, RingHom.id_apply]
     induction x using TensorProduct.induction_on with

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -474,7 +474,7 @@ private lemma ZariskisMainProperty.of_adjoin_eq_top
       top_le_iff.mp fun x _ ↦ (Subalgebra.mem_restrictScalars _).mp (this trivial)
     refine hx.ge.trans ?_
     rw [Algebra.restrictScalars_adjoin]
-    exact Algebra.adjoin_mono (by aesop)
+    exact Algebra.adjoin_mono (by simp)
   have H₀ : Function.Surjective (aeval (R := R) x) := by
     rwa [← AlgHom.range_eq_top, ← Algebra.adjoin_singleton_eq_range_aeval]
   have ⟨f, (hf : aeval x f = 0), hfp⟩ := SetLike.not_le_iff_exists.mp


### PR DESCRIPTION
Since `aesop` runs `simp_all` by default, it is preferable to call `simp` directly when it suffices to close the goal. This makes the proof intent more explicit and is typically faster (sometimes significantly so in the cases below).

Trace profiling results (differences <30 ms considered measurement noise):
* `Polynomial.splits_mul_iff`: 998 ms before, 807 ms after  🎉
* `summable_condensed_iff_of_eventually_nonneg`: 927 ms before, 835 ms after  🎉
* `CategoryTheory.PreservesFiniteLimitsOfFlat.uniq`: 1476 ms before, 1327 ms after  🎉
* `IsCyclotomicExtension.union_of_isPrimitiveRoot`: 528 ms before, 306 ms after  🎉
* `Representation.FiniteCyclicGroup.coinvariantsKer_leftRegular_eq_ker`: 324 ms before, 292 ms after  🎉
* `of_adjoin_eq_top`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
