### PR TITLE
feat(Tactic): add inferInstanceAs% to fix type leakage

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6919,6 +6919,7 @@ public import Mathlib.Tactic.HaveI
 public import Mathlib.Tactic.HigherOrder
 public import Mathlib.Tactic.Hint
 public import Mathlib.Tactic.ITauto
+public import Mathlib.Tactic.InferInstanceAsPercent
 public import Mathlib.Tactic.InferParam
 public import Mathlib.Tactic.Inhabit
 public import Mathlib.Tactic.IntervalCases

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -12,6 +12,7 @@ public import Mathlib.Order.Quotient
 public import Mathlib.RingTheory.Valuation.ValuationSubring
 
 import Mathlib.Data.Real.CompleteField
+import Mathlib.Tactic.InferInstanceAsPercent
 
 /-!
 # Standard part function
@@ -145,7 +146,7 @@ def FiniteResidueField : Type _ :=
 namespace FiniteResidueField
 
 noncomputable instance : Field (FiniteResidueField K) :=
-  inferInstanceAs (Field (IsLocalRing.ResidueField _))
+  inferInstanceAs% (Field (IsLocalRing.ResidueField _))
 
 private theorem ordConnected_preimage_mk' : ∀ x, Set.OrdConnected <| Quotient.mk
     (Submodule.quotientRel (IsLocalRing.maximalIdeal (FiniteElement K))) ⁻¹' {x} := by
@@ -198,12 +199,6 @@ theorem mk_lt_mk {x y : FiniteElement K} : mk x < mk y ↔ x < y ∧ mk x ≠ mk
 theorem lt_of_mk_lt_mk {x y : FiniteElement K} (h : mk x < mk y) : x < y :=
   (mk_lt_mk.1 h).1
 
-#adaptation_note /-- Upon bumping to v4.29.0-rc3, this was previously proved by
-`grind [mul_le_mul_of_nonneg_left]`, but `grind` fails due to `inferInstanceAs` leakage in the
-`Field (FiniteResidueField K)` instance causing a defeq mismatch between
-`DivisionMonoid.toDivInvOneMonoid.toInvOneClass.toInv` and `Field.toGrindField.toInv`.
-See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/576520256
--/
 private theorem mul_le_mul_of_nonneg_left' {x y z : FiniteResidueField K} (h : x ≤ y) (hz : 0 ≤ z) :
     z * x ≤ z * y := by
   induction x with | mk x
@@ -212,11 +207,7 @@ private theorem mul_le_mul_of_nonneg_left' {x y z : FiniteResidueField K} (h : x
   rw [← map_mul, ← map_mul]
   rw [← map_zero mk] at hz
   rw [mk_le_mk] at h hz ⊢
-  rcases h with h | h
-  · rcases hz with hz | hz
-    · simp [mul_le_mul_of_nonneg_left h hz]
-    · simp [← hz]
-  · simp [h]
+  grind [mul_le_mul_of_nonneg_left]
 
 instance : IsOrderedRing (FiniteResidueField K) where
   zero_le_one := mk.monotone' zero_le_one

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -38,6 +38,8 @@ public import ImportGraph.Tools
 public import Mathlib.Tactic.Linter.Lint
 -- This import makes the `#min_imports in` command available globally.
 public import Mathlib.Tactic.MinImports
+-- This import makes the `inferInstanceAs%` term elaborator avaliable globally.
+public import Mathlib.Tactic.InferInstanceAsPercent
 
 /-!
 This is the root file in Mathlib: it is imported by virtually *all* Mathlib files.

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -130,6 +130,7 @@ public import Mathlib.Tactic.HaveI
 public import Mathlib.Tactic.HigherOrder
 public import Mathlib.Tactic.Hint
 public import Mathlib.Tactic.ITauto
+public import Mathlib.Tactic.InferInstanceAsPercent
 public import Mathlib.Tactic.InferParam
 public import Mathlib.Tactic.Inhabit
 public import Mathlib.Tactic.IntervalCases

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -65,17 +65,6 @@ private def unfoldChain (e : Expr) (skipHead : Bool := false) :
     cur := nxt
   return out
 
-/-- Add all unfoldings of `e` to `acc` as replacement sources mapping to `target`.
-If `skipHead` is true, the first element (i.e. `e` itself) is not added. -/
-private def addUnfoldings (acc : Array (Expr × Expr)) (e target : Expr)
-    (skipHead : Bool := false) : MetaM (Array (Expr × Expr)) := do
-  let chain ← unfoldChain e (skipHead := skipHead)
-  let mut acc := acc
-  for form in chain do
-    if !acc.any (·.1 == form) then
-      acc := acc.push (form, target)
-  return acc
-
 /-- Check whether two expressions have the same head constant name (ignoring universe levels). -/
 private def sameHeadConstName (a b : Expr) : Bool :=
   match a.getAppFn, b.getAppFn with
@@ -115,19 +104,17 @@ private def alignHeads (sourceType expectedType : Expr) :
     does not match expected type head{indentExpr expectedType.getAppFn}"
 
 /-- Build the replacement table for differing arguments between `sourceType` and
-`expectedType`. For each differing argument position, all unfoldings of both the
-source and expected arguments are mapped to the expected argument. -/
+`expectedType`. For each differing argument position, the source argument is mapped
+to the expected argument. Since `matchesAnyDefeq` uses `isDefEq` at `default`
+transparency, intermediate unfoldings are handled automatically. -/
 private def buildReplacements (sourceType expectedType : Expr) :
-    MetaM (Array (Expr × Expr)) := do
+    Array (Expr × Expr) := Id.run do
   let sourceArgs := sourceType.getAppArgs
   let expectedArgs := expectedType.getAppArgs
   let mut replacements : Array (Expr × Expr) := #[]
   for sArg in sourceArgs, eArg in expectedArgs do
     if sArg != eArg then
-      -- Unfoldings of the expected (target) carrier, skipping the target itself
-      replacements ← addUnfoldings replacements eArg eArg (skipHead := true)
-      -- Unfoldings of the source carrier (including itself)
-      replacements ← addUnfoldings replacements sArg eArg
+      replacements := replacements.push (sArg, eArg)
   return replacements
 
 /-- Check whether `e` is defeq (at `default` transparency) to any source expression
@@ -160,9 +147,9 @@ private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × 
     return .lam name ty' (← replaceLamDomains body replacements) bi
   | _ => return e
 
-/-- WHNF `e` at default transparency and return the constructor info, universe levels,
-and arguments, or `none` if `e` doesn't reduce to a constructor application. -/
-private def getCtorApp? (e : Expr) :
+/-- Like `Lean.Meta.constructorApp?`, but also returns the universe levels
+(needed to reconstruct the constructor application after patching arguments). -/
+private def constructorAppWithUniverses? (e : Expr) :
     MetaM (Option (ConstructorVal × List Level × Array Expr)) := do
   let e' ← withDefault <| whnf e
   let .const c us := e'.getAppFn | return none
@@ -179,6 +166,37 @@ private def getFieldInfo (ci : ConstructorVal) : MetaM (Array (Bool × Bool)) :=
       return (isInst, isProof)
 
 mutual
+
+/-- At the top level, try to find a pre-existing clean sub-instance via `trySynthInstance`.
+If synthesis succeeds and the result is already clean (e.g. defined with `inferInstanceAs%`),
+use it to avoid diamonds with canonical instances.
+If the synthesized instance is leaky, warn and use the mechanically patched version instead. -/
+private partial def processInstFieldWithSynth (arg : Expr)
+    (replacements : Array (Expr × Expr))
+    (warnings : IO.Ref (Array MessageData)) : MetaM Expr := do
+  let fieldType ← inferType arg
+  let targetFieldType ← replaceCarriersInType fieldType replacements
+  let .some synthInst ← trySynthInstance targetFieldType
+    | normalizeInstance arg replacements warnings (trySynth := false)
+  -- Check if the synthesized version is already clean
+  let synthWarnings ← IO.mkRef #[]
+  let normalizedSynth ←
+    normalizeInstance synthInst replacements synthWarnings (trySynth := false)
+  if ← withReducibleAndInstances <| withNewMCtxDepth <|
+      isDefEq normalizedSynth synthInst then
+    -- synthInst is already clean; prefer it to avoid diamonds
+    return synthInst
+  -- synthInst is leaky: warn and use mechanically patched version
+  warnings.modify (·.push
+    m!"inferInstanceAs%: the synthesized instance for \
+      {targetFieldType} has carrier type leakage \
+      (it uses the source carrier type internally instead of the \
+      target). `inferInstanceAs%` will patch the sub-instance \
+      inline, but consider defining it separately with \
+      `inferInstanceAs%` for cleaner results.{indentD
+      "To suppress this warning: \
+      `set_option inferInstanceAsPercent.leakySubInstWarning false`"}")
+  normalizeInstance arg replacements warnings (trySynth := false)
 
 /-- Process each constructor argument: replace carrier type parameters, recursively
 normalize instance-implicit fields, and patch lambda binder domains in other fields.
@@ -199,49 +217,16 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
       args := args.set! i r
   -- Process each field
   for i in ci.numParams...args.size do
-    if let some (isInst, isProof) := fieldInfo[i]? then
-      if isProof then
-        pure ()
-      else if isInst then
+    let some (isInst, isProof) := fieldInfo[i]? | continue
+    if isProof then continue
+    if isInst then
+      args := args.set! i (←
         if trySynth then
-          -- At the top level: try to find a pre-existing clean sub-instance
-          let fieldType ← inferType args[i]!
-          let targetFieldType ← replaceCarriersInType fieldType replacements
-          match ← trySynthInstance targetFieldType with
-          | .some synthInst =>
-            -- Check if the synthesized version is clean by normalizing it
-            -- (with trySynth := false to keep this cheap) and comparing
-            let synthWarnings ← IO.mkRef #[]
-            let normalizedSynth ←
-              normalizeInstance synthInst replacements synthWarnings (trySynth := false)
-            if ← withReducibleAndInstances <| withNewMCtxDepth <|
-                isDefEq normalizedSynth synthInst then
-              -- synthInst is already clean (e.g. defined with inferInstanceAs%);
-              -- prefer it to avoid diamonds with the canonical instance
-              args := args.set! i synthInst
-            else
-              -- synthInst is leaky: warn and use mechanically patched version
-              let patched ←
-                normalizeInstance args[i]! replacements warnings (trySynth := false)
-              warnings.modify (·.push
-                m!"inferInstanceAs%: the synthesized instance for \
-                  {targetFieldType} has carrier type leakage \
-                  (it uses the source carrier type internally instead of the \
-                  target). `inferInstanceAs%` will patch the sub-instance \
-                  inline, but consider defining it separately with \
-                  `inferInstanceAs%` for cleaner results.{indentD
-                  "To suppress this warning: \
-                  `set_option inferInstanceAsPercent.leakySubInstWarning false`"}")
-              args := args.set! i patched
-          | _ =>
-            args := args.set! i
-              (← normalizeInstance args[i]! replacements warnings (trySynth := false))
+          processInstFieldWithSynth args[i]! replacements warnings
         else
-          -- Recursive calls: just normalize mechanically (no synthesis)
-          args := args.set! i
-            (← normalizeInstance args[i]! replacements warnings (trySynth := false))
-      else
-        args := args.set! i (← replaceLamDomains args[i]! replacements)
+          normalizeInstance args[i]! replacements warnings (trySynth := false))
+    else
+      args := args.set! i (← replaceLamDomains args[i]! replacements)
   return mkAppN (.const ci.name us) args
 
 /-- Recursively normalize a class instance expression:
@@ -254,7 +239,7 @@ private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × 
   let ty ← inferType e
   let some _className ← isClass? ty | return e
   if ← Meta.isProp ty then return e
-  let some (ci, us, args) ← getCtorApp? e | return e
+  let some (ci, us, args) ← constructorAppWithUniverses? e | return e
   let fieldInfo ← getFieldInfo ci
   normalizeCtorArgs ci us args fieldInfo replacements warnings (trySynth := trySynth)
 
@@ -291,7 +276,7 @@ elab "inferInstanceAs% " source:term : term <= expectedType => do
   -- This handles universe mismatches and type abbreviations like DecidableLT vs DecidableRel.
   let (sourceType, expectedType) ← alignHeads sourceType expectedType
   -- Build replacement table from differing carrier type arguments
-  let replacements ← buildReplacements sourceType expectedType
+  let replacements := buildReplacements sourceType expectedType
   if replacements.isEmpty then return inst
   let warnLeaky := inferInstanceAsPercent.leakySubInstWarning.get (← getOptions)
   let warnings ← IO.mkRef #[]

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -126,7 +126,7 @@ mutual
 normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
 private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
     (args : Array Expr) (fieldInfo : Array (Bool × Bool))
-    (replacements : Array (Expr × Expr)) (fuel : Nat) : MetaM Expr := do
+    (replacements : Array (Expr × Expr)) : MetaM Expr := do
   let mut args := args
   -- Replace carrier type in constructor parameters
   for i in *...ci.numParams do
@@ -138,7 +138,7 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
       if isProof then
         pure ()
       else if isInst then
-        args := args.set! i (← normalizeInstance args[i]! replacements (fuel - 1))
+        args := args.set! i (← normalizeInstance args[i]! replacements)
       else
         args := args.set! i (← replaceLamDomains args[i]! replacements)
   return mkAppN (.const ci.name us) args
@@ -148,15 +148,14 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
 2. Replace the carrier type parameter(s) in the constructor.
 3. For each instance-implicit, non-proof field: recurse.
 4. For each non-instance function field: replace lambda binder domains only. -/
-private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
-    (fuel : Nat := 50) : MetaM Expr := do
-  if fuel == 0 then return e
+private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr)) :
+    MetaM Expr := do
   let ty ← inferType e
   let some _className ← isClass? ty | return e
   if ← Meta.isProp ty then return e
   let some (ci, us, args) ← getCtorApp? e | return e
   let fieldInfo ← getFieldInfo ci
-  normalizeCtorArgs ci us args fieldInfo replacements fuel
+  normalizeCtorArgs ci us args fieldInfo replacements
 
 end
 

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -44,7 +44,7 @@ public meta section
 open Lean Meta Elab Term
 
 /-- Compute the chain of delta-unfoldings starting from `e` at default transparency.
-    Returns all intermediate forms including `e` itself (unless `skipHead` is true). -/
+Returns all intermediate forms including `e` itself (unless `skipHead` is true). -/
 private def unfoldChain (e : Expr) (skipHead : Bool := false) :
     MetaM (Array Expr) := do
   let mut out : Array Expr := #[]
@@ -57,7 +57,7 @@ private def unfoldChain (e : Expr) (skipHead : Bool := false) :
   return out
 
 /-- Add all unfoldings of `e` to `acc` as replacement sources mapping to `target`.
-    If `skipHead` is true, the first element (i.e. `e` itself) is not added. -/
+If `skipHead` is true, the first element (i.e. `e` itself) is not added. -/
 private def addUnfoldings (acc : Array (Expr × Expr)) (e target : Expr)
     (skipHead : Bool := false) : MetaM (Array (Expr × Expr)) := do
   let chain ← unfoldChain e (skipHead := skipHead)
@@ -68,8 +68,8 @@ private def addUnfoldings (acc : Array (Expr × Expr)) (e target : Expr)
   return acc
 
 /-- Build the replacement table for differing arguments between `sourceType` and
-    `expectedType`. For each differing argument position, all unfoldings of both the
-    source and expected arguments are mapped to the expected argument. -/
+`expectedType`. For each differing argument position, all unfoldings of both the
+source and expected arguments are mapped to the expected argument. -/
 private def buildReplacements (sourceType expectedType : Expr) :
     MetaM (Array (Expr × Expr)) := do
   let sourceArgs := sourceType.getAppArgs
@@ -84,7 +84,7 @@ private def buildReplacements (sourceType expectedType : Expr) :
   return replacements
 
 /-- Check whether `e` is defeq (at `default` transparency) to any source expression
-    in `replacements`. Returns the target if found. -/
+in `replacements`. Returns the target if found. -/
 private def matchesAnyDefeq (e : Expr) (replacements : Array (Expr × Expr)) :
     MetaM (Option Expr) := do
   for (from_, to_) in replacements do
@@ -93,7 +93,7 @@ private def matchesAnyDefeq (e : Expr) (replacements : Array (Expr × Expr)) :
   return none
 
 /-- Replace binder domains in a chain of lambdas, stopping at the body.
-    Only replaces domains that are defeq to entries in `replacements`. -/
+Only replaces domains that are defeq to entries in `replacements`. -/
 private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × Expr)) :
     MetaM Expr := do
   match e with
@@ -103,7 +103,7 @@ private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × 
   | _ => return e
 
 /-- WHNF `e` at default transparency and return the constructor info, universe levels,
-    and arguments, or `none` if `e` doesn't reduce to a constructor application. -/
+and arguments, or `none` if `e` doesn't reduce to a constructor application. -/
 private def getCtorApp? (e : Expr) :
     MetaM (Option (ConstructorVal × List Level × Array Expr)) := do
   let e' ← withDefault <| whnf e
@@ -112,7 +112,7 @@ private def getCtorApp? (e : Expr) :
   return some (ci, us, e'.getAppArgs)
 
 /-- For each constructor parameter, determine whether it is instance-implicit and
-    whether it is a proof. -/
+whether it is a proof. -/
 private def getFieldInfo (ci : ConstructorVal) : MetaM (Array (Bool × Bool)) :=
   withDefault <| forallTelescopeReducing ci.type fun ctorArgs _ =>
     ctorArgs.mapM fun arg => do
@@ -123,7 +123,7 @@ private def getFieldInfo (ci : ConstructorVal) : MetaM (Array (Bool × Bool)) :=
 mutual
 
 /-- Process each constructor argument: replace carrier type parameters, recursively
-    normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
+normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
 private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
     (args : Array Expr) (fieldInfo : Array (Bool × Bool))
     (replacements : Array (Expr × Expr)) (fuel : Nat) : MetaM Expr := do
@@ -144,10 +144,10 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
   return mkAppN (.const ci.name us) args
 
 /-- Recursively normalize a class instance expression:
-    1. WHNF at `default` transparency to expose the constructor.
-    2. Replace the carrier type parameter(s) in the constructor.
-    3. For each instance-implicit, non-proof field: recurse.
-    4. For each non-instance function field: replace lambda binder domains only. -/
+1. WHNF at `default` transparency to expose the constructor.
+2. Replace the carrier type parameter(s) in the constructor.
+3. For each instance-implicit, non-proof field: recurse.
+4. For each non-instance function field: replace lambda binder domains only. -/
 private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
     (fuel : Nat := 50) : MetaM Expr := do
   if fuel == 0 then return e
@@ -161,21 +161,21 @@ private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × 
 end
 
 /-- `inferInstanceAs%` — like `inferInstanceAs`, but rewrites internal sub-expressions
-    (e.g. lambda binder domains) to use the expected carrier type instead of
-    intermediate unfoldings that leaked during instance synthesis.
+(e.g. lambda binder domains) to use the expected carrier type instead of
+intermediate unfoldings that leaked during instance synthesis.
 
-    When `inferInstanceAs (SomeClass A)` is used to define `SomeClass B` (where
-    `B` is a non-reducible alias for `A`), the synthesized instance may contain
-    sub-expressions referring to `A` or its unfoldings instead of `B`. This
-    causes `isDefEq` failures at `reducibleAndInstances` transparency.
-    `inferInstanceAs%` fixes this by recursively normalizing the constructor
-    tree, patching carrier types and lambda binder domains.
+When `inferInstanceAs (SomeClass A)` is used to define `SomeClass B` (where
+`B` is a non-reducible alias for `A`), the synthesized instance may contain
+sub-expressions referring to `A` or its unfoldings instead of `B`. This
+causes `isDefEq` failures at `reducibleAndInstances` transparency.
+`inferInstanceAs%` fixes this by recursively normalizing the constructor
+tree, patching carrier types and lambda binder domains.
 
-    Example:
-    ```
-    noncomputable instance : Field (FiniteResidueField K) :=
-      inferInstanceAs% (Field (IsLocalRing.ResidueField _))
-    ```
+Example:
+```
+noncomputable instance : Field (FiniteResidueField K) :=
+  inferInstanceAs% (Field (IsLocalRing.ResidueField _))
+```
 -/
 elab "inferInstanceAs% " source:term : term <= expectedType => do
   let sourceType ← elabType source

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+public import Mathlib.Init
+public meta import Lean.Elab.Term
+
+/-!
+# `inferInstanceAs%` term elaborator
+
+`inferInstanceAs%` is a drop-in replacement for `inferInstanceAs` that prevents
+"type leakage" in synthesized instances.
+
+## The problem
+
+When `inferInstanceAs` synthesizes an instance for a type alias, the resulting
+expression may contain lambda binder domains (and other sub-expressions) that
+refer to an unfolded form of the carrier type rather than the declared alias.
+For example, defining
+
+```
+def B := A
+instance : SomeClass B := inferInstanceAs (SomeClass A)
+```
+
+may produce an instance whose internal lambdas have domain `A` (or even deeper
+unfoldings) instead of `B`. This is invisible at `default` transparency (where
+`A` and `B` are defeq), but causes `isDefEq` failures at `reducibleAndInstances`
+transparency — which is the level used by `grind`'s `checkInst`.
+
+## The fix
+
+`inferInstanceAs%` synthesizes the instance, then recursively normalizes its
+constructor tree: for each class-valued structure, it WHNFs to expose the
+constructor, patches the carrier type parameter, and recursively processes
+instance-implicit fields. Lambda binder domains matching the source carrier
+are replaced with the target carrier.
+-/
+
+public meta section
+
+open Lean Meta Elab Term
+
+/-- Compute the chain of delta-unfoldings starting from `e` at default transparency.
+    Returns all intermediate forms including `e` itself. -/
+private partial def unfoldChain (e : Expr) (fuel : Nat := 100) : MetaM (Array Expr) := do
+  if fuel == 0 then return #[e]
+  let some e' ← withDefault <| unfoldDefinition? e | return #[e]
+  return #[e] ++ (← unfoldChain e' (fuel - 1))
+
+/-- Check whether `e` is defeq (at `default` transparency) to any source expression
+    in `replacements`. Returns the target if found. -/
+private def matchesAnyDefeq (e : Expr) (replacements : Array (Expr × Expr)) :
+    MetaM (Option Expr) := do
+  for (from_, to_) in replacements do
+    if ← withDefault <| withNewMCtxDepth <| isDefEq e from_ then
+      return some to_
+  return none
+
+/-- Replace binder domains in a chain of lambdas, stopping at the body.
+    Only replaces domains that are defeq to entries in `replacements`. -/
+private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × Expr)) :
+    MetaM Expr := do
+  match e with
+  | .lam name ty body bi =>
+    let ty' ← do
+      match ← matchesAnyDefeq ty replacements with
+      | some r => pure r
+      | none => pure ty
+    return .lam name ty' (← replaceLamDomains body replacements) bi
+  | _ => return e
+
+/-- Recursively normalize a class instance expression:
+    1. WHNF at `default` transparency to expose the constructor.
+    2. Replace the carrier type parameter(s) in the constructor.
+    3. For each instance-implicit, non-proof field: recurse.
+    4. For each non-instance function field: replace lambda binder domains only. -/
+private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
+    (fuel : Nat := 50) : MetaM Expr := do
+  if fuel == 0 then return e
+  let ty ← inferType e
+  -- Only process class instances
+  let some _className ← isClass? ty | return e
+  -- Skip proofs
+  if ← withDefault <| Meta.isProp ty then return e
+  -- WHNF to expose constructor
+  let e' ← withDefault <| whnf e
+  let .const c .. := e'.getAppFn | return e
+  let some (.ctorInfo ci) := (← getEnv).find? c | return e
+  -- Identify which constructor fields are instance-implicit and non-proof
+  let params ← withDefault <| forallTelescopeReducing ci.type fun ctorArgs _ =>
+    ctorArgs.mapM fun arg => do
+      let isInst := (← arg.fvarId!.getBinderInfo).isInstImplicit
+      let isProof ← Meta.isProof arg
+      return (isInst, isProof)
+  let mut args := e'.getAppArgs
+  -- Replace carrier type in constructor parameters (using defeq matching)
+  for i in [:ci.numParams] do
+    if let some r ← matchesAnyDefeq args[i]! replacements then
+      args := args.set! i r
+  -- Process each field
+  for i in [ci.numParams:args.size] do
+    if h : i < params.size then
+      let (isInst, isProof) := params[i]
+      if isProof then
+        -- Skip proofs (proof irrelevance)
+        pure ()
+      else if isInst then
+        -- Instance-implicit field: recursively normalize
+        args := args.set! i (← normalizeInstance args[i]! replacements (fuel - 1))
+      else
+        -- Non-instance field (e.g., function): replace lambda binder domains only
+        args := args.set! i (← replaceLamDomains args[i]! replacements)
+  return mkAppN e'.getAppFn args
+
+/-- `inferInstanceAs%` — like `inferInstanceAs`, but rewrites internal sub-expressions
+    (e.g. lambda binder domains) to use the expected carrier type instead of
+    intermediate unfoldings that leaked during instance synthesis.
+
+    When `inferInstanceAs (SomeClass A)` is used to define `SomeClass B` (where
+    `B` is a non-reducible alias for `A`), the synthesized instance may contain
+    sub-expressions referring to `A` or its unfoldings instead of `B`. This
+    causes `isDefEq` failures at `reducibleAndInstances` transparency.
+    `inferInstanceAs%` fixes this by recursively normalizing the constructor
+    tree, patching carrier types and lambda binder domains.
+
+    Example:
+    ```
+    noncomputable instance : Field (FiniteResidueField K) :=
+      inferInstanceAs% (Field (IsLocalRing.ResidueField _))
+    ```
+-/
+elab "inferInstanceAs% " source:term : term <= expectedType => do
+  let sourceType ← elabType source
+  -- Unify source with expected type to resolve metavariables (e.g., _ placeholders)
+  discard <| withDefault <| isDefEq sourceType expectedType
+  let sourceType ← instantiateMVars sourceType
+  let inst ← synthInstance sourceType
+  let inst ← instantiateMVars inst
+  let expectedType ← instantiateMVars expectedType
+  -- Compare arguments to find differing carrier types
+  let sourceArgs := sourceType.getAppArgs
+  let expectedArgs := expectedType.getAppArgs
+  let mut replacements : Array (Expr × Expr) := #[]
+  for i in [:sourceArgs.size.min expectedArgs.size] do
+    let sArg := sourceArgs[i]!
+    let eArg := expectedArgs[i]!
+    if sArg != eArg then
+      -- Compute unfolding chain from the expected (target) carrier
+      let chain ← unfoldChain eArg
+      -- All forms except the first (target) are candidates for replacement
+      for j in [1:chain.size] do
+        replacements := replacements.push (chain[j]!, eArg)
+      -- Also compute unfolding chain from the source carrier
+      let sourceChain ← unfoldChain sArg
+      for j in [:sourceChain.size] do
+        if !replacements.any (·.1 == sourceChain[j]!) then
+          replacements := replacements.push (sourceChain[j]!, eArg)
+  if replacements.isEmpty then return inst
+  normalizeInstance inst replacements

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -44,11 +44,47 @@ public meta section
 open Lean Meta Elab Term
 
 /-- Compute the chain of delta-unfoldings starting from `e` at default transparency.
-    Returns all intermediate forms including `e` itself. -/
-private partial def unfoldChain (e : Expr) (fuel : Nat := 100) : MetaM (Array Expr) := do
-  if fuel == 0 then return #[e]
-  let some e' ← withDefault <| unfoldDefinition? e | return #[e]
-  return #[e] ++ (← unfoldChain e' (fuel - 1))
+    Returns all intermediate forms including `e` itself (unless `skipHead` is true). -/
+private def unfoldChain (e : Expr) (fuel : Nat := 100) (skipHead : Bool := false) :
+    MetaM (Array Expr) := do
+  let mut out : Array Expr := #[]
+  let mut cur := e
+  if !skipHead then out := out.push cur
+  for _ in [:fuel] do
+    let some nxt ← withDefault <| unfoldDefinition? cur | break
+    if out.any (· == nxt) then break
+    out := out.push nxt
+    cur := nxt
+  return out
+
+/-- Add all unfoldings of `e` to `acc` as replacement sources mapping to `target`.
+    If `skipHead` is true, the first element (i.e. `e` itself) is not added. -/
+private def addUnfoldings (acc : Array (Expr × Expr)) (e target : Expr)
+    (skipHead : Bool := false) : MetaM (Array (Expr × Expr)) := do
+  let chain ← unfoldChain e (skipHead := skipHead)
+  let mut acc := acc
+  for form in chain do
+    if !acc.any (·.1 == form) then
+      acc := acc.push (form, target)
+  return acc
+
+/-- Build the replacement table for differing arguments between `sourceType` and
+    `expectedType`. For each differing argument position, all unfoldings of both the
+    source and expected arguments are mapped to the expected argument. -/
+private def buildReplacements (sourceType expectedType : Expr) :
+    MetaM (Array (Expr × Expr)) := do
+  let sourceArgs := sourceType.getAppArgs
+  let expectedArgs := expectedType.getAppArgs
+  let mut replacements : Array (Expr × Expr) := #[]
+  for i in [:sourceArgs.size.min expectedArgs.size] do
+    let sArg := sourceArgs[i]!
+    let eArg := expectedArgs[i]!
+    if sArg != eArg then
+      -- Unfoldings of the expected (target) carrier, skipping the target itself
+      replacements ← addUnfoldings replacements eArg eArg (skipHead := true)
+      -- Unfoldings of the source carrier (including itself)
+      replacements ← addUnfoldings replacements sArg eArg
+  return replacements
 
 /-- Check whether `e` is defeq (at `default` transparency) to any source expression
     in `replacements`. Returns the target if found. -/
@@ -72,6 +108,48 @@ private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × 
     return .lam name ty' (← replaceLamDomains body replacements) bi
   | _ => return e
 
+/-- WHNF `e` at default transparency and return the constructor info, universe levels,
+    and arguments, or `none` if `e` doesn't reduce to a constructor application. -/
+private def getCtorApp? (e : Expr) :
+    MetaM (Option (ConstructorVal × List Level × Array Expr)) := do
+  let e' ← withDefault <| whnf e
+  let .const c us := e'.getAppFn | return none
+  let some (.ctorInfo ci) := (← getEnv).find? c | return none
+  return some (ci, us, e'.getAppArgs)
+
+/-- For each constructor parameter, determine whether it is instance-implicit and
+    whether it is a proof. -/
+private def getFieldInfo (ci : ConstructorVal) : MetaM (Array (Bool × Bool)) :=
+  withDefault <| forallTelescopeReducing ci.type fun ctorArgs _ =>
+    ctorArgs.mapM fun arg => do
+      let isInst := (← arg.fvarId!.getBinderInfo).isInstImplicit
+      let isProof ← Meta.isProof arg
+      return (isInst, isProof)
+
+mutual
+
+/-- Process each constructor argument: replace carrier type parameters, recursively
+    normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
+private partial def normalizeCtorArgs (ci : ConstructorVal) (args : Array Expr)
+    (fieldInfo : Array (Bool × Bool)) (replacements : Array (Expr × Expr))
+    (fuel : Nat) : MetaM (Array Expr) := do
+  let mut args := args
+  -- Replace carrier type in constructor parameters
+  for i in [:ci.numParams] do
+    if let some r ← matchesAnyDefeq args[i]! replacements then
+      args := args.set! i r
+  -- Process each field
+  for i in [ci.numParams:args.size] do
+    if h : i < fieldInfo.size then
+      let (isInst, isProof) := fieldInfo[i]
+      if isProof then
+        pure ()
+      else if isInst then
+        args := args.set! i (← normalizeInstance args[i]! replacements (fuel - 1))
+      else
+        args := args.set! i (← replaceLamDomains args[i]! replacements)
+  return args
+
 /-- Recursively normalize a class instance expression:
     1. WHNF at `default` transparency to expose the constructor.
     2. Replace the carrier type parameter(s) in the constructor.
@@ -81,39 +159,14 @@ private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × 
     (fuel : Nat := 50) : MetaM Expr := do
   if fuel == 0 then return e
   let ty ← inferType e
-  -- Only process class instances
   let some _className ← isClass? ty | return e
-  -- Skip proofs
   if ← withDefault <| Meta.isProp ty then return e
-  -- WHNF to expose constructor
-  let e' ← withDefault <| whnf e
-  let .const c .. := e'.getAppFn | return e
-  let some (.ctorInfo ci) := (← getEnv).find? c | return e
-  -- Identify which constructor fields are instance-implicit and non-proof
-  let params ← withDefault <| forallTelescopeReducing ci.type fun ctorArgs _ =>
-    ctorArgs.mapM fun arg => do
-      let isInst := (← arg.fvarId!.getBinderInfo).isInstImplicit
-      let isProof ← Meta.isProof arg
-      return (isInst, isProof)
-  let mut args := e'.getAppArgs
-  -- Replace carrier type in constructor parameters (using defeq matching)
-  for i in [:ci.numParams] do
-    if let some r ← matchesAnyDefeq args[i]! replacements then
-      args := args.set! i r
-  -- Process each field
-  for i in [ci.numParams:args.size] do
-    if h : i < params.size then
-      let (isInst, isProof) := params[i]
-      if isProof then
-        -- Skip proofs (proof irrelevance)
-        pure ()
-      else if isInst then
-        -- Instance-implicit field: recursively normalize
-        args := args.set! i (← normalizeInstance args[i]! replacements (fuel - 1))
-      else
-        -- Non-instance field (e.g., function): replace lambda binder domains only
-        args := args.set! i (← replaceLamDomains args[i]! replacements)
-  return mkAppN e'.getAppFn args
+  let some (ci, us, args) ← getCtorApp? e | return e
+  let fieldInfo ← getFieldInfo ci
+  let args ← normalizeCtorArgs ci args fieldInfo replacements fuel
+  return mkAppN (.const ci.name us) args
+
+end
 
 /-- `inferInstanceAs%` — like `inferInstanceAs`, but rewrites internal sub-expressions
     (e.g. lambda binder domains) to use the expected carrier type instead of
@@ -140,23 +193,7 @@ elab "inferInstanceAs% " source:term : term <= expectedType => do
   let inst ← synthInstance sourceType
   let inst ← instantiateMVars inst
   let expectedType ← instantiateMVars expectedType
-  -- Compare arguments to find differing carrier types
-  let sourceArgs := sourceType.getAppArgs
-  let expectedArgs := expectedType.getAppArgs
-  let mut replacements : Array (Expr × Expr) := #[]
-  for i in [:sourceArgs.size.min expectedArgs.size] do
-    let sArg := sourceArgs[i]!
-    let eArg := expectedArgs[i]!
-    if sArg != eArg then
-      -- Compute unfolding chain from the expected (target) carrier
-      let chain ← unfoldChain eArg
-      -- All forms except the first (target) are candidates for replacement
-      for j in [1:chain.size] do
-        replacements := replacements.push (chain[j]!, eArg)
-      -- Also compute unfolding chain from the source carrier
-      let sourceChain ← unfoldChain sArg
-      for j in [:sourceChain.size] do
-        if !replacements.any (·.1 == sourceChain[j]!) then
-          replacements := replacements.push (sourceChain[j]!, eArg)
+  -- Build replacement table from differing carrier type arguments
+  let replacements ← buildReplacements sourceType expectedType
   if replacements.isEmpty then return inst
   normalizeInstance inst replacements

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -78,7 +78,7 @@ This handles two cases:
   (same constant name, different universe levels)
 - Type abbreviations: e.g. `DecidableLT α` vs `DecidableRel (· < ·)`
   (different constants that unfold to a common head) -/
-private def alignHeads (sourceType expectedType : Expr) :
+def alignHeads (sourceType expectedType : Expr) :
     MetaM (Expr × Expr) := do
   -- Fast path: same head constant name (handles universe mismatches)
   if sameHeadConstName sourceType expectedType then
@@ -106,7 +106,7 @@ private def alignHeads (sourceType expectedType : Expr) :
 `expectedType`. For each differing argument position, the source argument is mapped
 to the expected argument. Since `matchesAnyDefeq` uses `isDefEq` at `default`
 transparency, intermediate unfoldings are handled automatically. -/
-private def buildReplacements (sourceType expectedType : Expr) :
+def buildReplacements (sourceType expectedType : Expr) :
     Array (Expr × Expr) := Id.run do
   let sourceArgs := sourceType.getAppArgs
   let expectedArgs := expectedType.getAppArgs
@@ -233,7 +233,7 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
 2. Replace the carrier type parameter(s) in the constructor.
 3. For each instance-implicit, non-proof field: try synthesis (if `trySynth`), else recurse.
 4. For each non-instance function field: replace lambda binder domains only. -/
-private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
+partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
     (warnings : IO.Ref (Array MessageData)) (trySynth : Bool := true) : MetaM Expr := do
   let ty ← inferType e
   let some _className ← isClass? ty | return e

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -182,13 +182,16 @@ mutual
 
 /-- Process each constructor argument: replace carrier type parameters, recursively
 normalize instance-implicit fields, and patch lambda binder domains in other fields.
-For each instance-implicit field, first tries to find a clean synthesized sub-instance
-for the target carrier type; if found, uses it instead of the patched constructor tree.
-If synthesis finds a leaky sub-instance, records a warning. -/
+
+When `trySynth` is `true` (used only at the top level), for each instance-implicit field
+we first try to find a pre-existing clean sub-instance via `trySynthInstance`. This avoids
+diamonds with canonical instances. Recursive calls use `trySynth := false` to avoid
+expensive synthesis at every level of the class hierarchy. -/
 private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
     (args : Array Expr) (fieldInfo : Array (Bool × Bool))
     (replacements : Array (Expr × Expr))
-    (warnings : IO.Ref (Array MessageData)) : MetaM Expr := do
+    (warnings : IO.Ref (Array MessageData))
+    (trySynth : Bool := true) : MetaM Expr := do
   let mut args := args
   -- Replace carrier type in constructor parameters
   for i in *...ci.numParams do
@@ -200,32 +203,26 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
       if isProof then
         pure ()
       else if isInst then
-        -- Always compute the patched version (needed as fallback and for comparison)
-        let patched ← normalizeInstance args[i]! replacements warnings
-        -- Try to find a synthesized sub-instance for the target carrier type
-        let fieldType ← inferType args[i]!
-        let targetFieldType ← replaceCarriersInType fieldType replacements
-        match ← trySynthInstance targetFieldType with
-        | .some synthInst =>
-          -- Check if the synthesized version is clean (defeq to patched at instances)
-          if ← withReducibleAndInstances <| withNewMCtxDepth <| isDefEq synthInst patched then
-            args := args.set! i synthInst
-          else
-            -- synthInst and patched differ. Check if synthInst is itself clean
-            -- (i.e. normalizing it doesn't change it). This handles the case where
-            -- the sub-instance was already defined with `inferInstanceAs%` — in that case
-            -- it's already clean, and the mismatch with `patched` is just because the
-            -- sub-instance inside the parent hierarchy was constructed differently.
+        if trySynth then
+          -- At the top level: try to find a pre-existing clean sub-instance
+          let fieldType ← inferType args[i]!
+          let targetFieldType ← replaceCarriersInType fieldType replacements
+          match ← trySynthInstance targetFieldType with
+          | .some synthInst =>
+            -- Check if the synthesized version is clean by normalizing it
+            -- (with trySynth := false to keep this cheap) and comparing
             let synthWarnings ← IO.mkRef #[]
             let normalizedSynth ←
-              normalizeInstance synthInst replacements synthWarnings
+              normalizeInstance synthInst replacements synthWarnings (trySynth := false)
             if ← withReducibleAndInstances <| withNewMCtxDepth <|
                 isDefEq normalizedSynth synthInst then
               -- synthInst is already clean (e.g. defined with inferInstanceAs%);
-              -- prefer it over patched to avoid diamonds with the canonical instance
+              -- prefer it to avoid diamonds with the canonical instance
               args := args.set! i synthInst
             else
-              -- synthInst is leaky: warn and use patched version
+              -- synthInst is leaky: warn and use mechanically patched version
+              let patched ←
+                normalizeInstance args[i]! replacements warnings (trySynth := false)
               warnings.modify (·.push
                 m!"inferInstanceAs%: the synthesized instance for \
                   {targetFieldType} has carrier type leakage \
@@ -236,8 +233,13 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
                   "To suppress this warning: \
                   `set_option inferInstanceAsPercent.leakySubInstWarning false`"}")
               args := args.set! i patched
-        | _ =>
-          args := args.set! i patched
+          | _ =>
+            args := args.set! i
+              (← normalizeInstance args[i]! replacements warnings (trySynth := false))
+        else
+          -- Recursive calls: just normalize mechanically (no synthesis)
+          args := args.set! i
+            (← normalizeInstance args[i]! replacements warnings (trySynth := false))
       else
         args := args.set! i (← replaceLamDomains args[i]! replacements)
   return mkAppN (.const ci.name us) args
@@ -245,16 +247,16 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
 /-- Recursively normalize a class instance expression:
 1. WHNF at `default` transparency to expose the constructor.
 2. Replace the carrier type parameter(s) in the constructor.
-3. For each instance-implicit, non-proof field: try synthesis, else recurse.
+3. For each instance-implicit, non-proof field: try synthesis (if `trySynth`), else recurse.
 4. For each non-instance function field: replace lambda binder domains only. -/
 private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
-    (warnings : IO.Ref (Array MessageData)) : MetaM Expr := do
+    (warnings : IO.Ref (Array MessageData)) (trySynth : Bool := true) : MetaM Expr := do
   let ty ← inferType e
   let some _className ← isClass? ty | return e
   if ← Meta.isProp ty then return e
   let some (ci, us, args) ← getCtorApp? e | return e
   let fieldInfo ← getFieldInfo ci
-  normalizeCtorArgs ci us args fieldInfo replacements warnings
+  normalizeCtorArgs ci us args fieldInfo replacements warnings (trySynth := trySynth)
 
 end
 

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -98,10 +98,7 @@ private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × 
     MetaM Expr := do
   match e with
   | .lam name ty body bi =>
-    let ty' ← do
-      match ← matchesAnyDefeq ty replacements with
-      | some r => pure r
-      | none => pure ty
+    let ty' := (← matchesAnyDefeq ty replacements).getD ty
     return .lam name ty' (← replaceLamDomains body replacements) bi
   | _ => return e
 
@@ -127,9 +124,9 @@ mutual
 
 /-- Process each constructor argument: replace carrier type parameters, recursively
     normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
-private partial def normalizeCtorArgs (ci : ConstructorVal) (args : Array Expr)
-    (fieldInfo : Array (Bool × Bool)) (replacements : Array (Expr × Expr))
-    (fuel : Nat) : MetaM (Array Expr) := do
+private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
+    (args : Array Expr) (fieldInfo : Array (Bool × Bool))
+    (replacements : Array (Expr × Expr)) (fuel : Nat) : MetaM Expr := do
   let mut args := args
   -- Replace carrier type in constructor parameters
   for i in *...ci.numParams do
@@ -144,7 +141,7 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (args : Array Expr)
         args := args.set! i (← normalizeInstance args[i]! replacements (fuel - 1))
       else
         args := args.set! i (← replaceLamDomains args[i]! replacements)
-  return args
+  return mkAppN (.const ci.name us) args
 
 /-- Recursively normalize a class instance expression:
     1. WHNF at `default` transparency to expose the constructor.
@@ -156,11 +153,10 @@ private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × 
   if fuel == 0 then return e
   let ty ← inferType e
   let some _className ← isClass? ty | return e
-  if ← withDefault <| Meta.isProp ty then return e
+  if ← Meta.isProp ty then return e
   let some (ci, us, args) ← getCtorApp? e | return e
   let fieldInfo ← getFieldInfo ci
-  let args ← normalizeCtorArgs ci args fieldInfo replacements fuel
-  return mkAppN (.const ci.name us) args
+  normalizeCtorArgs ci us args fieldInfo replacements fuel
 
 end
 

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 module
-public import Mathlib.Init
 public meta import Lean.Elab.Term
 
 /-!

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -45,14 +45,13 @@ open Lean Meta Elab Term
 
 /-- Compute the chain of delta-unfoldings starting from `e` at default transparency.
     Returns all intermediate forms including `e` itself (unless `skipHead` is true). -/
-private def unfoldChain (e : Expr) (fuel : Nat := 100) (skipHead : Bool := false) :
+private def unfoldChain (e : Expr) (skipHead : Bool := false) :
     MetaM (Array Expr) := do
   let mut out : Array Expr := #[]
   let mut cur := e
   if !skipHead then out := out.push cur
-  for _ in [:fuel] do
+  repeat do
     let some nxt ← withDefault <| unfoldDefinition? cur | break
-    if out.any (· == nxt) then break
     out := out.push nxt
     cur := nxt
   return out
@@ -76,9 +75,7 @@ private def buildReplacements (sourceType expectedType : Expr) :
   let sourceArgs := sourceType.getAppArgs
   let expectedArgs := expectedType.getAppArgs
   let mut replacements : Array (Expr × Expr) := #[]
-  for i in [:sourceArgs.size.min expectedArgs.size] do
-    let sArg := sourceArgs[i]!
-    let eArg := expectedArgs[i]!
+  for sArg in sourceArgs, eArg in expectedArgs do
     if sArg != eArg then
       -- Unfoldings of the expected (target) carrier, skipping the target itself
       replacements ← addUnfoldings replacements eArg eArg (skipHead := true)
@@ -135,13 +132,12 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (args : Array Expr)
     (fuel : Nat) : MetaM (Array Expr) := do
   let mut args := args
   -- Replace carrier type in constructor parameters
-  for i in [:ci.numParams] do
+  for i in *...ci.numParams do
     if let some r ← matchesAnyDefeq args[i]! replacements then
       args := args.set! i r
   -- Process each field
-  for i in [ci.numParams:args.size] do
-    if h : i < fieldInfo.size then
-      let (isInst, isProof) := fieldInfo[i]
+  for i in ci.numParams...args.size do
+    if let some (isInst, isProof) := fieldInfo[i]? then
       if isProof then
         pure ()
       else if isInst then

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -173,13 +173,31 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
           if ← withReducibleAndInstances <| withNewMCtxDepth <| isDefEq synthInst patched then
             args := args.set! i synthInst
           else
-            -- Leaky: warn the user
-            warnings.modify (·.push
-              m!"inferInstanceAs%: synthesized sub-instance for \
-                {targetFieldType} is not defeq to the patched version at \
-                `reducibleAndInstances` transparency. Consider defining it \
-                separately with `inferInstanceAs%`.")
-            args := args.set! i patched
+            -- synthInst and patched differ. Check if synthInst is itself clean
+            -- (i.e. normalizing it doesn't change it). This handles the case where
+            -- the sub-instance was already defined with `inferInstanceAs%` — in that case
+            -- it's already clean, and the mismatch with `patched` is just because the
+            -- sub-instance inside the parent hierarchy was constructed differently.
+            let synthWarnings ← IO.mkRef #[]
+            let normalizedSynth ←
+              normalizeInstance synthInst replacements synthWarnings
+            if ← withReducibleAndInstances <| withNewMCtxDepth <|
+                isDefEq normalizedSynth synthInst then
+              -- synthInst is already clean (e.g. defined with inferInstanceAs%);
+              -- prefer it over patched to avoid diamonds with the canonical instance
+              args := args.set! i synthInst
+            else
+              -- synthInst is leaky: warn and use patched version
+              warnings.modify (·.push
+                m!"inferInstanceAs%: the synthesized instance for \
+                  {targetFieldType} has carrier type leakage \
+                  (it uses the source carrier type internally instead of the \
+                  target). `inferInstanceAs%` will patch the sub-instance \
+                  inline, but consider defining it separately with \
+                  `inferInstanceAs%` for cleaner results.{indentD
+                  "To suppress this warning: \
+                  `set_option inferInstanceAsPercent.leakySubInstWarning false`"}")
+              args := args.set! i patched
         | _ =>
           args := args.set! i patched
       else

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -180,11 +180,17 @@ noncomputable instance : Field (FiniteResidueField K) :=
 elab "inferInstanceAs% " source:term : term <= expectedType => do
   let sourceType ← elabType source
   -- Unify source with expected type to resolve metavariables (e.g., _ placeholders)
-  discard <| withDefault <| isDefEq sourceType expectedType
+  unless ← withDefault <| isDefEq sourceType expectedType do
+    throwError "inferInstanceAs%: source type{indentExpr sourceType}\n\
+      is not defeq to expected type{indentExpr expectedType}"
   let sourceType ← instantiateMVars sourceType
   let inst ← synthInstance sourceType
   let inst ← instantiateMVars inst
   let expectedType ← instantiateMVars expectedType
+  -- Check that the class heads match before comparing arguments pairwise
+  unless sourceType.getAppFn == expectedType.getAppFn do
+    throwError "inferInstanceAs%: source type head{indentExpr sourceType.getAppFn}\n\
+      does not match expected type head{indentExpr expectedType.getAppFn}"
   -- Build replacement table from differing carrier type arguments
   let replacements ← buildReplacements sourceType expectedType
   if replacements.isEmpty then return inst

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -76,6 +76,44 @@ private def addUnfoldings (acc : Array (Expr × Expr)) (e target : Expr)
       acc := acc.push (form, target)
   return acc
 
+/-- Check whether two expressions have the same head constant name (ignoring universe levels). -/
+private def sameHeadConstName (a b : Expr) : Bool :=
+  match a.getAppFn, b.getAppFn with
+  | .const n₁ _, .const n₂ _ => n₁ == n₂
+  | _, _ => false
+
+/-- Try to unfold `sourceType` and `expectedType` until they share a common head constant.
+Returns the aligned pair, or throws an error if no common head is found.
+
+This handles two cases:
+- Universe-polymorphic aliases: e.g. `DecidableEq.{max 0 u}` vs `DecidableEq.{u}`
+  (same constant name, different universe levels)
+- Type abbreviations: e.g. `DecidableLT α` vs `DecidableRel (· < ·)`
+  (different constants that unfold to a common head) -/
+private def alignHeads (sourceType expectedType : Expr) :
+    MetaM (Expr × Expr) := do
+  -- Fast path: same head constant name (handles universe mismatches)
+  if sameHeadConstName sourceType expectedType then
+    return (sourceType, expectedType)
+  -- Try unfolding both to find a common head
+  let sourceChain ← unfoldChain sourceType (skipHead := true)
+  let expectedChain ← unfoldChain expectedType (skipHead := true)
+  -- Try unfolding source only
+  for s in sourceChain do
+    if sameHeadConstName s expectedType then
+      return (s, expectedType)
+  -- Try unfolding expected only
+  for e in expectedChain do
+    if sameHeadConstName sourceType e then
+      return (sourceType, e)
+  -- Try unfolding both
+  for s in sourceChain do
+    for e in expectedChain do
+      if sameHeadConstName s e then
+        return (s, e)
+  throwError "inferInstanceAs%: source type head{indentExpr sourceType.getAppFn}\n\
+    does not match expected type head{indentExpr expectedType.getAppFn}"
+
 /-- Build the replacement table for differing arguments between `sourceType` and
 `expectedType`. For each differing argument position, all unfoldings of both the
 source and expected arguments are mapped to the expected argument. -/
@@ -247,10 +285,9 @@ elab "inferInstanceAs% " source:term : term <= expectedType => do
   let inst ← synthInstance sourceType
   let inst ← instantiateMVars inst
   let expectedType ← instantiateMVars expectedType
-  -- Check that the class heads match before comparing arguments pairwise
-  unless sourceType.getAppFn == expectedType.getAppFn do
-    throwError "inferInstanceAs%: source type head{indentExpr sourceType.getAppFn}\n\
-      does not match expected type head{indentExpr expectedType.getAppFn}"
+  -- Align heads: unfold both types until they share a common head constant.
+  -- This handles universe mismatches and type abbreviations like DecidableLT vs DecidableRel.
+  let (sourceType, expectedType) ← alignHeads sourceType expectedType
   -- Build replacement table from differing carrier type arguments
   let replacements ← buildReplacements sourceType expectedType
   if replacements.isEmpty then return inst

--- a/Mathlib/Tactic/InferInstanceAsPercent.lean
+++ b/Mathlib/Tactic/InferInstanceAsPercent.lean
@@ -43,6 +43,15 @@ public meta section
 
 open Lean Meta Elab Term
 
+/-- When `true` (the default), `inferInstanceAs%` warns about sub-instances that are
+synthesizable for the target carrier type but leaky at `reducibleAndInstances` transparency.
+These warnings suggest defining intermediate instances with `inferInstanceAs%` to produce
+smaller, more modular instance terms. -/
+register_option inferInstanceAsPercent.leakySubInstWarning : Bool := {
+  defValue := true
+  descr := "warn about leaky sub-instances in inferInstanceAs%"
+}
+
 /-- Compute the chain of delta-unfoldings starting from `e` at default transparency.
 Returns all intermediate forms including `e` itself (unless `skipHead` is true). -/
 private def unfoldChain (e : Expr) (skipHead : Bool := false) :
@@ -92,6 +101,17 @@ private def matchesAnyDefeq (e : Expr) (replacements : Array (Expr × Expr)) :
       return some to_
   return none
 
+/-- Replace carrier type arguments in a class type expression using the replacement table.
+For example, transforms `TestDivInvMonoid Nat` into `TestDivInvMonoid TestNat`. -/
+private def replaceCarriersInType (ty : Expr) (replacements : Array (Expr × Expr)) :
+    MetaM Expr := do
+  let args := ty.getAppArgs
+  let mut args' := args
+  for i in [:args.size] do
+    if let some r ← matchesAnyDefeq args[i]! replacements then
+      args' := args'.set! i r
+  return mkAppN ty.getAppFn args'
+
 /-- Replace binder domains in a chain of lambdas, stopping at the body.
 Only replaces domains that are defeq to entries in `replacements`. -/
 private partial def replaceLamDomains (e : Expr) (replacements : Array (Expr × Expr)) :
@@ -123,10 +143,14 @@ private def getFieldInfo (ci : ConstructorVal) : MetaM (Array (Bool × Bool)) :=
 mutual
 
 /-- Process each constructor argument: replace carrier type parameters, recursively
-normalize instance-implicit fields, and patch lambda binder domains in other fields. -/
+normalize instance-implicit fields, and patch lambda binder domains in other fields.
+For each instance-implicit field, first tries to find a clean synthesized sub-instance
+for the target carrier type; if found, uses it instead of the patched constructor tree.
+If synthesis finds a leaky sub-instance, records a warning. -/
 private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
     (args : Array Expr) (fieldInfo : Array (Bool × Bool))
-    (replacements : Array (Expr × Expr)) : MetaM Expr := do
+    (replacements : Array (Expr × Expr))
+    (warnings : IO.Ref (Array MessageData)) : MetaM Expr := do
   let mut args := args
   -- Replace carrier type in constructor parameters
   for i in *...ci.numParams do
@@ -138,7 +162,26 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
       if isProof then
         pure ()
       else if isInst then
-        args := args.set! i (← normalizeInstance args[i]! replacements)
+        -- Always compute the patched version (needed as fallback and for comparison)
+        let patched ← normalizeInstance args[i]! replacements warnings
+        -- Try to find a synthesized sub-instance for the target carrier type
+        let fieldType ← inferType args[i]!
+        let targetFieldType ← replaceCarriersInType fieldType replacements
+        match ← trySynthInstance targetFieldType with
+        | .some synthInst =>
+          -- Check if the synthesized version is clean (defeq to patched at instances)
+          if ← withReducibleAndInstances <| withNewMCtxDepth <| isDefEq synthInst patched then
+            args := args.set! i synthInst
+          else
+            -- Leaky: warn the user
+            warnings.modify (·.push
+              m!"inferInstanceAs%: synthesized sub-instance for \
+                {targetFieldType} is not defeq to the patched version at \
+                `reducibleAndInstances` transparency. Consider defining it \
+                separately with `inferInstanceAs%`.")
+            args := args.set! i patched
+        | _ =>
+          args := args.set! i patched
       else
         args := args.set! i (← replaceLamDomains args[i]! replacements)
   return mkAppN (.const ci.name us) args
@@ -146,16 +189,16 @@ private partial def normalizeCtorArgs (ci : ConstructorVal) (us : List Level)
 /-- Recursively normalize a class instance expression:
 1. WHNF at `default` transparency to expose the constructor.
 2. Replace the carrier type parameter(s) in the constructor.
-3. For each instance-implicit, non-proof field: recurse.
+3. For each instance-implicit, non-proof field: try synthesis, else recurse.
 4. For each non-instance function field: replace lambda binder domains only. -/
-private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr)) :
-    MetaM Expr := do
+private partial def normalizeInstance (e : Expr) (replacements : Array (Expr × Expr))
+    (warnings : IO.Ref (Array MessageData)) : MetaM Expr := do
   let ty ← inferType e
   let some _className ← isClass? ty | return e
   if ← Meta.isProp ty then return e
   let some (ci, us, args) ← getCtorApp? e | return e
   let fieldInfo ← getFieldInfo ci
-  normalizeCtorArgs ci us args fieldInfo replacements
+  normalizeCtorArgs ci us args fieldInfo replacements warnings
 
 end
 
@@ -193,4 +236,10 @@ elab "inferInstanceAs% " source:term : term <= expectedType => do
   -- Build replacement table from differing carrier type arguments
   let replacements ← buildReplacements sourceType expectedType
   if replacements.isEmpty then return inst
-  normalizeInstance inst replacements
+  let warnLeaky := inferInstanceAsPercent.leakySubInstWarning.get (← getOptions)
+  let warnings ← IO.mkRef #[]
+  let result ← normalizeInstance inst replacements warnings
+  if warnLeaky then
+    for w in ← warnings.get do
+      logWarning w
+  return result

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -96,11 +96,13 @@ instance testField_leaky : TestField TestNat := inferInstanceAs (TestField Nat)
 -- Fixed: inferInstanceAs% patches lambda domains to use TestNat
 -- (warns about leaky sub-instances that could be defined separately)
 /--
-warning: inferInstanceAs%: synthesized sub-instance for TestInv
-  TestNat is not defeq to the patched version at `reducibleAndInstances` transparency. Consider defining it separately with `inferInstanceAs%`.
+warning: inferInstanceAs%: the synthesized instance for TestInv
+  TestNat has carrier type leakage (it uses the source carrier type internally instead of the target). `inferInstanceAs%` will patch the sub-instance inline, but consider defining it separately with `inferInstanceAs%` for cleaner results.
+  To suppress this warning: `set_option inferInstanceAsPercent.leakySubInstWarning false`
 ---
-warning: inferInstanceAs%: synthesized sub-instance for TestDivInvMonoid
-  TestNat is not defeq to the patched version at `reducibleAndInstances` transparency. Consider defining it separately with `inferInstanceAs%`.
+warning: inferInstanceAs%: the synthesized instance for TestDivInvMonoid
+  TestNat has carrier type leakage (it uses the source carrier type internally instead of the target). `inferInstanceAs%` will patch the sub-instance inline, but consider defining it separately with `inferInstanceAs%` for cleaner results.
+  To suppress this warning: `set_option inferInstanceAsPercent.leakySubInstWarning false`
 -/
 #guard_msgs in
 instance testField_fixed : TestField TestNat := inferInstanceAs% (TestField Nat)
@@ -131,3 +133,28 @@ example : testField_leaky = testField_direct := by with_reducible_and_instances 
 
 -- The fixed instance IS defeq at `instances` transparency.
 example : testField_fixed = testField_direct := by with_reducible_and_instances rfl
+
+/-! ## Sub-instances already defined with `inferInstanceAs%`
+
+When a sub-instance has already been defined with `inferInstanceAs%`,
+defining a parent instance with `inferInstanceAs%` should NOT warn about
+leaky sub-instances — the sub-instance is already clean.
+
+This was reported by Sébastien Gouëzel: when `AddMonoid SGNNReal` is defined
+with `inferInstanceAs%`, defining `AddCancelCommMonoid SGNNReal` with
+`inferInstanceAs%` should not warn about `AddMonoid` being leaky.
+
+The warning only fires when `trySynthInstance` finds a pre-existing instance for
+the sub-class. So we test this by first defining a clean `TestInv` instance,
+then a leaky parent (so synthesis can find sub-instances through projection),
+and finally verifying that `inferInstanceAs%` suppresses the `TestInv` warning.
+-/
+
+-- Define a clean sub-instance for TestInv
+instance testInv_clean : TestInv TestNat := inferInstanceAs% (TestInv Nat)
+
+-- Now `testInv_clean` provides a clean `TestInv TestNat`, and
+-- `testField_direct`/`testField_fixed` provide clean `TestDivInvMonoid TestNat`
+-- through projection. So no warnings should fire:
+#guard_msgs in
+instance testField_with_clean_inv : TestField TestNat := inferInstanceAs% (TestField Nat)

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -94,7 +94,21 @@ instance testField_direct : TestField TestNat where
 instance testField_leaky : TestField TestNat := inferInstanceAs (TestField Nat)
 
 -- Fixed: inferInstanceAs% patches lambda domains to use TestNat
+-- (warns about leaky sub-instances that could be defined separately)
+/--
+warning: inferInstanceAs%: synthesized sub-instance for TestInv
+  TestNat is not defeq to the patched version at `reducibleAndInstances` transparency. Consider defining it separately with `inferInstanceAs%`.
+---
+warning: inferInstanceAs%: synthesized sub-instance for TestDivInvMonoid
+  TestNat is not defeq to the patched version at `reducibleAndInstances` transparency. Consider defining it separately with `inferInstanceAs%`.
+-/
+#guard_msgs in
 instance testField_fixed : TestField TestNat := inferInstanceAs% (TestField Nat)
+
+-- The warning can be disabled:
+#guard_msgs in
+set_option inferInstanceAsPercent.leakySubInstWarning false in
+instance testField_fixed' : TestField TestNat := inferInstanceAs% (TestField Nat)
 
 -- All three are defeq at default transparency (Nat = TestNat at this level).
 example : testField_leaky = testField_direct := rfl

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -94,12 +94,8 @@ instance testField_direct : TestField TestNat where
 instance testField_leaky : TestField TestNat := inferInstanceAs (TestField Nat)
 
 -- Fixed: inferInstanceAs% patches lambda domains to use TestNat
--- (warns about leaky sub-instances that could be defined separately)
+-- (warns about leaky direct sub-instances that could be defined separately)
 /--
-warning: inferInstanceAs%: the synthesized instance for TestInv
-  TestNat has carrier type leakage (it uses the source carrier type internally instead of the target). `inferInstanceAs%` will patch the sub-instance inline, but consider defining it separately with `inferInstanceAs%` for cleaner results.
-  To suppress this warning: `set_option inferInstanceAsPercent.leakySubInstWarning false`
----
 warning: inferInstanceAs%: the synthesized instance for TestDivInvMonoid
   TestNat has carrier type leakage (it uses the source carrier type internally instead of the target). `inferInstanceAs%` will patch the sub-instance inline, but consider defining it separately with `inferInstanceAs%` for cleaner results.
   To suppress this warning: `set_option inferInstanceAsPercent.leakySubInstWarning false`

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -158,3 +158,35 @@ instance testInv_clean : TestInv TestNat := inferInstanceAs% (TestInv Nat)
 -- through projection. So no warnings should fire:
 #guard_msgs in
 instance testField_with_clean_inv : TestField TestNat := inferInstanceAs% (TestField Nat)
+
+/-! ## Head alignment: universe mismatches and type abbreviations
+
+`inferInstanceAs%` should handle cases where the source and expected types have
+different head expressions due to:
+1. Universe-level differences (same constant name, different universe levels)
+2. Type abbreviations (different constant names that unfold to a common head)
+
+These are reproductions of failures reported by Sébastien Gouëzel.
+-/
+
+-- Universe mismatch: `MyVec α n` is a `def` with type `Type u`, but its body
+-- `{l : List α // l.length = n}` has type `Sort (max 1 (u+1))`.
+-- This causes `DecidableEq` to be elaborated at `DecidableEq.{u+1}` for the expected
+-- type vs `DecidableEq.{max 1 (u+1)}` for the source — structurally different but equal.
+def MyVec (α : Type u) (n : Nat) := {l : List α // l.length = n}
+
+#guard_msgs in
+instance [DecidableEq α] : DecidableEq (MyVec α n) :=
+  inferInstanceAs% (DecidableEq {l : List α // l.length = n})
+
+-- Abbreviation head mismatch: `TestAbbrevRel` unfolds to `TestBaseRel`
+class TestBaseRel (r : Nat → Nat → Prop) where
+  decide : Nat → Nat → Bool
+
+abbrev TestAbbrevRel := TestBaseRel (· < ·)
+
+instance : TestBaseRel (· < ·) where
+  decide := (· < ·)
+
+#guard_msgs in
+instance : TestAbbrevRel := inferInstanceAs% (TestBaseRel (· < ·))

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -51,3 +51,69 @@ set_option pp.all true in
 
 -- Both instances should compute the same thing
 example : myNatInv_leaky.myInv (α := MyNat) (5 : Nat) = myNatInv_fixed.myInv (5 : Nat) := rfl
+
+/-! ## Deeper hierarchy: reproducing the grind failure pattern
+
+The original failure involved `Field (FiniteResidueField K)` defined via
+`inferInstanceAs (Field (IsLocalRing.ResidueField _))`. Deeply nested sub-instances
+(e.g. `DivisionMonoid.toDivInvOneMonoid.toInvOneClass.toInv`) had lambda domains
+referring to `IsLocalRing.ResidueField _` instead of `FiniteResidueField K`.
+This caused `isDefEq` failures at `instances` transparency — the level used by
+grind's `checkInst`.
+
+We reproduce the pattern with a smaller 3-level hierarchy and verify the
+transparency-level failure directly.
+-/
+
+class TestInv (α : Type) where
+  inv : α → α
+
+class TestDivInvMonoid (α : Type) extends TestInv α where
+  mul : α → α → α
+
+class TestField (α : Type) extends TestDivInvMonoid α where
+  add : α → α → α
+  neg : α → α
+
+instance : TestField Nat where
+  inv n := n
+  mul := Nat.mul
+  add := Nat.add
+  neg n := n
+
+def TestNat := Nat
+
+-- Direct instance: all lambda domains correctly use TestNat
+instance testField_direct : TestField TestNat where
+  inv n := n
+  mul := Nat.mul
+  add := Nat.add
+  neg n := n
+
+-- Leaky: internal lambda domains use Nat instead of TestNat
+instance testField_leaky : TestField TestNat := inferInstanceAs (TestField Nat)
+
+-- Fixed: inferInstanceAs% patches lambda domains to use TestNat
+instance testField_fixed : TestField TestNat := inferInstanceAs% (TestField Nat)
+
+-- All three are defeq at default transparency (Nat = TestNat at this level).
+example : testField_leaky = testField_direct := rfl
+example : testField_fixed = testField_direct := rfl
+
+-- At `instances` transparency (the level grind's `checkInst` uses):
+-- the leaky instance is NOT defeq to a directly-defined instance,
+-- because lambda domains say `Nat` instead of `TestNat` and
+-- `TestNat := Nat` is not unfolded at this transparency.
+/--
+error: Tactic `rfl` failed: The left-hand side
+  testField_leaky
+is not definitionally equal to the right-hand side
+  testField_direct
+
+⊢ testField_leaky = testField_direct
+-/
+#guard_msgs in
+example : testField_leaky = testField_direct := by with_reducible_and_instances rfl
+
+-- The fixed instance IS defeq at `instances` transparency.
+example : testField_fixed = testField_direct := by with_reducible_and_instances rfl

--- a/MathlibTest/InferInstanceAsPercent.lean
+++ b/MathlibTest/InferInstanceAsPercent.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Tactic.InferInstanceAsPercent
+
+/-!
+# Tests for `inferInstanceAs%`
+
+Demonstrates that `inferInstanceAs%` fixes type leakage in synthesized instances:
+when defining a typeclass instance for a type alias, the lambda binder domains
+use the alias type (not an internal unfolding).
+-/
+
+class MyInv (α : Type) where
+  myInv : α → α
+
+instance : MyInv Nat where
+  myInv n := n + 1
+
+def MyNat : Type := Nat
+
+-- `inferInstanceAs` leaks the source type `Nat` as the carrier
+instance myNatInv_leaky : MyInv MyNat :=
+  inferInstanceAs (MyInv Nat)
+
+-- `inferInstanceAs%` fixes this — the carrier and lambda domain are `MyNat`
+instance myNatInv_fixed : MyInv MyNat :=
+  inferInstanceAs% (MyInv Nat)
+
+-- Verify the leaky instance: carrier is `Nat`, not `MyNat`
+/--
+info: @[implicit_reducible] def myNatInv_leaky : MyInv MyNat :=
+@inferInstanceAs.{1} (MyInv Nat) instMyInvNat
+-/
+#guard_msgs in
+set_option pp.all true in
+#print myNatInv_leaky
+
+-- Verify the fixed instance: carrier and lambda domain are `MyNat`
+/--
+info: @[implicit_reducible] def myNatInv_fixed : MyInv MyNat :=
+@MyInv.mk MyNat fun (n : MyNat) =>
+  @HAdd.hAdd.{0, 0, 0} Nat Nat Nat (@instHAdd.{0} Nat instAddNat) n
+    (@OfNat.ofNat.{0} Nat (nat_lit 1) (instOfNatNat (nat_lit 1)))
+-/
+#guard_msgs in
+set_option pp.all true in
+#print myNatInv_fixed
+
+-- Both instances should compute the same thing
+example : myNatInv_leaky.myInv (α := MyNat) (5 : Nat) = myNatInv_fixed.myInv (5 : Nat) := rfl


### PR DESCRIPTION
This PR adds `inferInstanceAs%`, a drop-in replacement for `inferInstanceAs` that prevents "type leakage" in synthesized instances.

When `inferInstanceAs (SomeClass A)` is used to define `SomeClass B` (where `B` is a non-reducible alias for `A`), the synthesized instance may contain lambda binder domains (and other sub-expressions) referring to `A` or deeper unfoldings instead of `B`. This is invisible at `default` transparency but causes `isDefEq` failures at `reducibleAndInstances` transparency — which is the level used by `grind`'s `checkInst`.

`inferInstanceAs%` fixes this by recursively normalizing the constructor tree: it WHNFs to expose the constructor, patches carrier type parameters via `isDefEq` matching against the unfolding chain, recursively processes instance-implicit fields, and replaces lambda binder domains in function fields.

As a demonstration, this fixes the `grind` failure in `FiniteResidueField` that was worked around with `#adaptation_note` and a manual proof on `nightly-testing`.

🤖 Prepared with Claude Code