### PR TITLE
feat(CategoryTheory/Monoidal): evaluation coevaluation isomorphisms

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -124,46 +124,26 @@ lemma evaluation_coevaluation'' :
     η_ X Y ▷ X ⊗≫ X ◁ ε_ X Y = ⊗𝟙.hom := by
   convert evaluation_coevaluation X Y <;> simp [monoidalComp]
 
-lemma coevaluation_evaluation_iso [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
-Y ◁ᵢ (asIso (η_ X Y)) ≪≫ (α_ Y X Y).symm ≪≫
-(asIso (ε_ X Y)) ▷ᵢ Y = ρ_ Y ≪≫ (λ_ Y).symm := by
-    ext
-    simp only [Iso.trans_hom, whiskerLeftIso_hom, asIso_hom, Iso.symm_hom, whiskerRightIso_hom,
-      coevaluation_evaluation]
-
-lemma evaluation_coevaluation_iso [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : (asIso (η_ X Y)) ▷ᵢ X ≪≫
-(α_ X Y X) ≪≫ X ◁ᵢ (asIso (ε_ X Y)) = (λ_ X) ≪≫ (ρ_ X).symm := by
-  ext
-  simp only [Iso.trans_hom, whiskerRightIso_hom, asIso_hom, whiskerLeftIso_hom,
-    evaluation_coevaluation, Iso.symm_hom]
-
-/-- Swapped exact pairing, provided isomorphic evaluation and coevaluation. -/
-def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
-ExactPairing Y X where
+/--
+Swap the terms of an exact pairing, provided that the evaluation and coevaluation are isomorphisms.
+-/
+def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : ExactPairing Y X where
   coevaluation' := inv (ε_ X Y)
   evaluation' := inv (η_ X Y)
-
   coevaluation_evaluation' := by
-    have : X ◁ᵢ (asIso (ε_ X Y)).symm ≪≫
-      (α_ X Y X).symm ≪≫ (asIso (η_ X Y)).symm ▷ᵢ X
-      = (ρ_ X) ≪≫ (λ_ X).symm := by
-        apply Iso.symm_bijective.injective
-        simp only [Iso.trans_symm, whiskerRightIso_symm, Iso.symm_symm_eq, whiskerLeftIso_symm,
-          Iso.trans_assoc]
-        exact evaluation_coevaluation_iso X Y
-    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
-        congr($(this).hom)
-
-  evaluation_coevaluation' := by
-    have : (asIso (ε_ X Y)).symm ▷ᵢ Y ≪≫
-    (α_ Y X Y) ≪≫ Y ◁ᵢ (asIso (η_ X Y)).symm
-    = (λ_ Y) ≪≫ (ρ_ Y).symm := by
+    have : X ◁ᵢ (asIso (ε_ X Y)).symm ≪≫ (α_ X Y X).symm ≪≫ (asIso (η_ X Y)).symm ▷ᵢ X =
+        (ρ_ X) ≪≫ (λ_ X).symm := by
       apply Iso.symm_bijective.injective
-      simp only [Iso.trans_symm, whiskerLeftIso_symm, Iso.symm_symm_eq, whiskerRightIso_symm,
-        Iso.trans_assoc]
-      exact coevaluation_evaluation_iso X Y
-    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
-      congr($(this).hom)
+      ext
+      simp [evaluation_coevaluation]
+    simpa [Iso.ext_iff] using this
+  evaluation_coevaluation' := by
+    have : (asIso (ε_ X Y)).symm ▷ᵢ Y ≪≫ (α_ Y X Y) ≪≫ Y ◁ᵢ (asIso (η_ X Y)).symm =
+        (λ_ Y) ≪≫ (ρ_ Y).symm := by
+      apply Iso.symm_bijective.injective
+      ext
+      simp [coevaluation_evaluation]
+    simpa [Iso.ext_iff] using this
 
 end ExactPairing
 

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -124,6 +124,46 @@ lemma evaluation_coevaluation'' :
     η_ X Y ▷ X ⊗≫ X ◁ ε_ X Y = ⊗𝟙.hom := by
   convert evaluation_coevaluation X Y <;> simp [monoidalComp]
 
+lemma coevaluation_evaluation_iso [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
+Y ◁ᵢ (asIso (η_ X Y)) ≪≫ (α_ Y X Y).symm ≪≫
+(asIso (ε_ X Y)) ▷ᵢ Y = ρ_ Y ≪≫ (λ_ Y).symm := by
+    ext
+    simp only [Iso.trans_hom, whiskerLeftIso_hom, asIso_hom, Iso.symm_hom, whiskerRightIso_hom,
+      coevaluation_evaluation]
+
+lemma evaluation_coevaluation_iso [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : (asIso (η_ X Y)) ▷ᵢ X ≪≫
+(α_ X Y X) ≪≫ X ◁ᵢ (asIso (ε_ X Y)) = (λ_ X) ≪≫ (ρ_ X).symm := by
+  ext
+  simp only [Iso.trans_hom, whiskerRightIso_hom, asIso_hom, whiskerLeftIso_hom,
+    evaluation_coevaluation, Iso.symm_hom]
+
+def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
+ExactPairing Y X where
+  coevaluation' := inv (ε_ X Y)
+  evaluation' := inv (η_ X Y)
+
+  coevaluation_evaluation' := by
+    have : X ◁ᵢ (asIso (ε_ X Y)).symm ≪≫
+      (α_ X Y X).symm ≪≫ (asIso (η_ X Y)).symm ▷ᵢ X
+      = (ρ_ X) ≪≫ (λ_ X).symm := by
+        apply Iso.symm_bijective.injective
+        simp only [Iso.trans_symm, whiskerRightIso_symm, Iso.symm_symm_eq, whiskerLeftIso_symm,
+          Iso.trans_assoc]
+        exact evaluation_coevaluation_iso X Y
+    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
+        congr($(this).hom)
+
+  evaluation_coevaluation' := by
+    have : (asIso (ε_ X Y)).symm ▷ᵢ Y ≪≫
+    (α_ Y X Y) ≪≫ Y ◁ᵢ (asIso (η_ X Y)).symm
+    = (λ_ Y) ≪≫ (ρ_ Y).symm := by
+      apply Iso.symm_bijective.injective
+      simp only [Iso.trans_symm, whiskerLeftIso_symm, Iso.symm_symm_eq, whiskerRightIso_symm,
+        Iso.trans_assoc]
+      exact coevaluation_evaluation_iso X Y
+    simpa [Iso.trans_hom, whiskerLeftIso_hom, Iso.symm_hom, whiskerRightIso_hom] using
+      congr($(this).hom)
+
 end ExactPairing
 
 attribute [reassoc (attr := simp)] ExactPairing.coevaluation_evaluation
@@ -179,6 +219,16 @@ theorem leftDual_rightDual {X : C} [HasRightDual X] : ᘁXᘁ = X :=
 @[simp]
 theorem rightDual_leftDual {X : C} [HasLeftDual X] : (ᘁX)ᘁ = X :=
   rfl
+
+def hasLeftDual_of_hasRightDual {X : C} [HasRightDual X] [IsIso (ε_ X (Xᘁ))] [IsIso (η_ X (Xᘁ))]
+: HasLeftDual X where
+  leftDual := Xᘁ
+  exact := ExactPairing.Symm X (Xᘁ)
+
+def hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X] [IsIso (ε_ (ᘁX) X)] [IsIso (η_ (ᘁX) X)]
+: HasRightDual X where
+  rightDual := ᘁX
+  exact := ExactPairing.Symm (ᘁX) X
 
 /-- The right adjoint mate `fᘁ : Xᘁ ⟶ Yᘁ` of a morphism `f : X ⟶ Y`. -/
 def rightAdjointMate {X Y : C} [HasRightDual X] [HasRightDual Y] (f : X ⟶ Y) : Yᘁ ⟶ Xᘁ :=

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -137,6 +137,7 @@ lemma evaluation_coevaluation_iso [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : (asIso (
   simp only [Iso.trans_hom, whiskerRightIso_hom, asIso_hom, whiskerLeftIso_hom,
     evaluation_coevaluation, Iso.symm_hom]
 
+/-- Swapped exact pairing, provided isomorphic evaluation and coevaluation. -/
 def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
 ExactPairing Y X where
   coevaluation' := inv (ε_ X Y)
@@ -220,12 +221,14 @@ theorem leftDual_rightDual {X : C} [HasRightDual X] : ᘁXᘁ = X :=
 theorem rightDual_leftDual {X : C} [HasLeftDual X] : (ᘁX)ᘁ = X :=
   rfl
 
-def hasLeftDual_of_hasRightDual {X : C} [HasRightDual X] [IsIso (ε_ X (Xᘁ))] [IsIso (η_ X (Xᘁ))]
+/-- The left dual treated as right dual provided isomorphic evaluation and coevaluation. -/
+abbrev hasLeftDual_of_hasRightDual {X : C} [HasRightDual X] [IsIso (ε_ X (Xᘁ))] [IsIso (η_ X (Xᘁ))]
 : HasLeftDual X where
   leftDual := Xᘁ
   exact := ExactPairing.Symm X (Xᘁ)
 
-def hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X] [IsIso (ε_ (ᘁX) X)] [IsIso (η_ (ᘁX) X)]
+/-- The right dual treated as left dual provided isomorphic evaluation and coevaluation. -/
+abbrev hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X] [IsIso (ε_ (ᘁX) X)] [IsIso (η_ (ᘁX) X)]
 : HasRightDual X where
   rightDual := ᘁX
   exact := ExactPairing.Symm (ᘁX) X
@@ -628,6 +631,18 @@ theorem rightDualIso_id {X Y : C} (p : ExactPairing X Y) : rightDualIso p p = Is
 theorem leftDualIso_id {X Y : C} (p : ExactPairing X Y) : leftDualIso p p = Iso.refl X := by
   ext
   simp only [leftDualIso, Iso.refl_hom, @leftAdjointMate_id]
+
+/-- Left dual and right dual are isomorphic provided left dual has isomorphic evaluation and
+coevaluation. -/
+def LeftDualRightDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X) [IsIso (ε_ Xₗ X)] [IsIso (η_ Xₗ X)]
+(q : ExactPairing X Xᵣ) : Xₗ ≅ Xᵣ :=
+  rightDualIso (p.Symm) (q)
+
+/-- Left dual and right dual are isomorphic provided right dual has isomorphic evaluation and
+coevaluation. -/
+def RightDualLeftDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X)
+(q : ExactPairing X Xᵣ) [IsIso (ε_ X Xᵣ)] [IsIso (η_ X Xᵣ)] : Xₗ ≅ Xᵣ :=
+  leftDualIso p (q.Symm)
 
 /-- A right rigid monoidal category is one in which every object has a right dual. -/
 class RightRigidCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -228,7 +228,7 @@ abbrev hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X]
   rightDual := ᘁX
   exact := ExactPairing.symm ᘁX X
 
-/-- The right adjoint mate `fᘁ : Xᘁ ⟶ Yᘁ` of a morphism `f : X ⟶ Y`. -/
+/-- The right adjoint mate `fᘁ : Yᘁ ⟶ Xᘁ` of a morphism `f : X ⟶ Y`. -/
 def rightAdjointMate {X Y : C} [HasRightDual X] [HasRightDual Y] (f : X ⟶ Y) : Yᘁ ⟶ Xᘁ :=
   (ρ_ _).inv ≫ _ ◁ η_ _ _ ≫ _ ◁ f ▷ _ ≫ (α_ _ _ _).inv ≫ ε_ _ _ ▷ _ ≫ (λ_ _).hom
 
@@ -645,7 +645,7 @@ def ExactPairing.rightDualLeftDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X
 class RightRigidCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where
   [rightDual : ∀ X : C, HasRightDual X]
 
-/-- A left rigid monoidal category is one in which every object has a right dual. -/
+/-- A left rigid monoidal category is one in which every object has a left dual. -/
 class LeftRigidCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where
   [leftDual : ∀ X : C, HasLeftDual X]
 

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -127,7 +127,8 @@ lemma evaluation_coevaluation'' :
 /--
 Swap the terms of an exact pairing, provided that the evaluation and coevaluation are isomorphisms.
 -/
-def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : ExactPairing Y X where
+@[reducible]
+def symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : ExactPairing Y X where
   coevaluation' := inv (ε_ X Y)
   evaluation' := inv (η_ X Y)
   coevaluation_evaluation' := by
@@ -144,6 +145,18 @@ def Symm [IsIso (ε_ X Y)] [IsIso (η_ X Y)] : ExactPairing Y X where
       ext
       simp [coevaluation_evaluation]
     simpa [Iso.ext_iff] using this
+
+@[simp]
+lemma symm_evaluation [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
+    letI : ExactPairing Y X := symm X Y
+    η_ Y X = inv (ε_ X Y) :=
+  rfl
+
+@[simp]
+lemma symm_coevaluation [IsIso (ε_ X Y)] [IsIso (η_ X Y)] :
+    letI : ExactPairing Y X := symm X Y
+    ε_ Y X = inv (η_ X Y) :=
+  rfl
 
 end ExactPairing
 
@@ -202,16 +215,18 @@ theorem rightDual_leftDual {X : C} [HasLeftDual X] : (ᘁX)ᘁ = X :=
   rfl
 
 /-- The left dual treated as right dual provided isomorphic evaluation and coevaluation. -/
-abbrev hasLeftDual_of_hasRightDual {X : C} [HasRightDual X] [IsIso (ε_ X (Xᘁ))] [IsIso (η_ X (Xᘁ))]
-: HasLeftDual X where
+abbrev hasLeftDual_of_hasRightDual {X : C} [HasRightDual X]
+    [IsIso (ε_ X (Xᘁ))] [IsIso (η_ X (Xᘁ))] :
+    HasLeftDual X where
   leftDual := Xᘁ
-  exact := ExactPairing.Symm X (Xᘁ)
+  exact := ExactPairing.symm X Xᘁ
 
 /-- The right dual treated as left dual provided isomorphic evaluation and coevaluation. -/
-abbrev hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X] [IsIso (ε_ (ᘁX) X)] [IsIso (η_ (ᘁX) X)]
-: HasRightDual X where
+abbrev hasRightDual_of_hasLeftDual {X : C} [HasLeftDual X]
+    [IsIso (ε_ (ᘁX) X)] [IsIso (η_ (ᘁX) X)] :
+    HasRightDual X where
   rightDual := ᘁX
-  exact := ExactPairing.Symm (ᘁX) X
+  exact := ExactPairing.symm ᘁX X
 
 /-- The right adjoint mate `fᘁ : Xᘁ ⟶ Yᘁ` of a morphism `f : X ⟶ Y`. -/
 def rightAdjointMate {X Y : C} [HasRightDual X] [HasRightDual Y] (f : X ⟶ Y) : Yᘁ ⟶ Xᘁ :=
@@ -614,15 +629,17 @@ theorem leftDualIso_id {X Y : C} (p : ExactPairing X Y) : leftDualIso p p = Iso.
 
 /-- Left dual and right dual are isomorphic provided left dual has isomorphic evaluation and
 coevaluation. -/
-def LeftDualRightDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X) [IsIso (ε_ Xₗ X)] [IsIso (η_ Xₗ X)]
-(q : ExactPairing X Xᵣ) : Xₗ ≅ Xᵣ :=
-  rightDualIso (p.Symm) (q)
+@[simps!]
+def ExactPairing.leftDualRightDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X)
+    [IsIso (ε_ Xₗ X)] [IsIso (η_ Xₗ X)] (q : ExactPairing X Xᵣ) : Xₗ ≅ Xᵣ :=
+  rightDualIso p.symm q
 
 /-- Left dual and right dual are isomorphic provided right dual has isomorphic evaluation and
 coevaluation. -/
-def RightDualLeftDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X)
-(q : ExactPairing X Xᵣ) [IsIso (ε_ X Xᵣ)] [IsIso (η_ X Xᵣ)] : Xₗ ≅ Xᵣ :=
-  leftDualIso p (q.Symm)
+@[simps!]
+def ExactPairing.rightDualLeftDualIso {Xₗ X Xᵣ : C} (p : ExactPairing Xₗ X)
+    (q : ExactPairing X Xᵣ) [IsIso (ε_ X Xᵣ)] [IsIso (η_ X Xᵣ)] : Xₗ ≅ Xᵣ :=
+  leftDualIso p q.symm
 
 /-- A right rigid monoidal category is one in which every object has a right dual. -/
 class RightRigidCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] where


### PR DESCRIPTION
This PR adds four features to rigid categories:

1. `coevaluation_evaluation` and `evaluation_coevaluation` as isomorphism equalities:  Using `IsIso` instances for the `evaluation` and `coevaluation` morphisms, we promote the morphism equalities to isomorphism equalities.
2. `ExactPairing Y X` from `ExactPairing X Y`: Using an exact pairing and `IsIso` instances for both `evaluation` and `coevaluation`, we swap the exact pairing by inverting the evaluation and coevaluation morphisms. Any suggestions for the definition name are welcome. Right now it is `ExactPairing.Symm`. The second choice was `ExactPairing.Swap`.
3. `HasLeftDual X` from `HasRightDual X`: Using a `HasRightDual X` instance and relevant `IsIso` instances, we construct a left dual. Similar construction for the other way.
4. `LeftDual` isomorphic to `RightDual`: Using relevant `IsIso` instances, we provide the isomorphism from the left dual of an object to the right dual. This can be achieved in two ways: either by using `leftDualIso` or using `rightDualIso`. We will prove in a subsequent PR that both these isomorphisms are equal.

Motivation: This is part of an effort to formalize CategoricalGroups, which can be defined as right rigid groupoids. The approach is motivated by the discussion in [#34830](https://github.com/leanprover-community/mathlib4/pull/34830). 

Any comments or suggestions are welcome, especially about the naming.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
