### PR TITLE
[Merged by Bors] - feat: add dist_center_midpoint_lt_radius for spheres

### DIFF
--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -400,21 +400,13 @@ with distinct endpoints `A` and `C` is strictly less than the radius. -/
 theorem Sphere.dist_center_midpoint_lt_radius {A C : P} {s : Sphere P}
     (hA : A ∈ s) (hC : C ∈ s) (hAC : A ≠ C) :
     dist s.center (midpoint ℝ A C) < s.radius := by
-  set M := midpoint ℝ A C
-  have hperp : ⟪s.center -ᵥ M, M -ᵥ A⟫ = 0 := by
-    rw [show M -ᵥ A = (2⁻¹ : ℝ) • (C -ᵥ A) from by rw [midpoint_vsub_left, invOf_eq_inv],
-        inner_smul_right, Sphere.inner_vsub_center_midpoint_vsub hA hC, mul_zero]
-  have hradius : ‖s.center -ᵥ A‖ = s.radius := by
-    rw [← dist_eq_norm_vsub']; exact mem_sphere.mp hA
-  have hpyth : s.radius ^ 2 = ‖s.center -ᵥ M‖ ^ 2 + ‖M -ᵥ A‖ ^ 2 := by
-    rw [← hradius, ← vsub_add_vsub_cancel s.center M A, norm_add_sq_real,
-        hperp, mul_zero, add_zero]
-  rw [dist_eq_norm_vsub]
-  have hMA_ne : M -ᵥ A ≠ (0 : V) :=
-    vsub_ne_zero.mpr (fun h => hAC ((midpoint_eq_left_iff ℝ).mp h))
-  exact (abs_lt_of_sq_lt_sq'
-    (by nlinarith [sq_pos_of_pos (norm_pos_iff.mpr hMA_ne)])
-    (by linarith [norm_nonneg (s.center -ᵥ A)])).2
+  have hA' : ‖A -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hA
+  have hC' : ‖C -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hC
+  rw [dist_comm, dist_eq_norm_vsub, ← midpoint_self ℝ s.center, midpoint_vsub_midpoint, ← hA']
+  convert (norm_midpoint_lt_iff (hA'.trans hC'.symm)).mpr
+    (fun h => hAC (vsub_left_cancel h)) using 2
+  simp only [midpoint, AffineMap.lineMap_apply, invOf_eq_inv, vsub_eq_sub, vadd_eq_add, one_div]
+  module
 
 /-- Two spheres intersect in at most two points in a two-dimensional subspace containing their
 centers; this is a version of `eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two` for bundled

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -388,25 +388,48 @@ theorem inner_vsub_vsub_of_mem_sphere_of_mem_sphere {p₁ p₂ : P} {s₁ s₂ :
 
 /-- The vector from the midpoint of a chord to the center of the sphere is
 orthogonal to the chord. -/
-theorem Sphere.inner_vsub_center_midpoint_vsub {A C : P} {s : Sphere P}
-    (hA : A ∈ s) (hC : C ∈ s) :
-    ⟪s.center -ᵥ midpoint ℝ A C, C -ᵥ A⟫ = 0 :=
+theorem Sphere.inner_vsub_center_midpoint_vsub {p₁ p₂ : P} {s : Sphere P}
+    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) :
+    ⟪s.center -ᵥ midpoint ℝ p₁ p₂, p₂ -ᵥ p₁⟫ = 0 :=
   inner_vsub_vsub_of_dist_eq_of_dist_eq
-    (dist_left_midpoint_eq_dist_right_midpoint A C)
-    (dist_center_eq_dist_center_of_mem_sphere hA hC)
+    (dist_left_midpoint_eq_dist_right_midpoint p₁ p₂)
+    (dist_center_eq_dist_center_of_mem_sphere hp₁ hp₂)
+
+/-- The distance from the center of a sphere to any point strictly between
+two points on the sphere is strictly less than the radius. -/
+theorem Sphere.dist_center_lt_radius_of_sbtw {p₁ p₂ p : P} {s : Sphere P}
+    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp : Sbtw ℝ p₁ p p₂) :
+    dist s.center p < s.radius := by
+  set o := s.center
+  obtain ⟨⟨t, ⟨ht₀, ht₁⟩, hpt⟩, hne₁, hne₂⟩ := hp
+  have ht₀' : 0 < t := lt_of_le_of_ne ht₀ fun h => hne₁ <| by
+    rw [← hpt, ← h, AffineMap.lineMap_apply_zero]
+  have ht₁' : t < 1 := lt_of_le_of_ne ht₁ fun h => hne₂ <| by
+    rw [← hpt, h, AffineMap.lineMap_apply_one]
+  set u := p₁ -ᵥ o; set v := p₂ -ᵥ o
+  have hu : ‖u‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hp₁
+  have hv : ‖v‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hp₂
+  have huv : u ≠ v := fun h => hne₁ <| by
+    rw [← hpt, vsub_left_cancel h, AffineMap.lineMap_same, AffineMap.const_apply]
+  have hpo : p -ᵥ o = (1 - t) • u + t • v := by
+    rw [show p = (AffineMap.lineMap p₁ p₂) t from hpt.symm, AffineMap.lineMap_apply,
+      vadd_vsub_assoc, show (p₂ -ᵥ p₁ : V) = v - u from
+      (vsub_sub_vsub_cancel_right p₂ p₁ o).symm]
+    module
+  rw [dist_comm, dist_eq_norm_vsub, hpo]
+  have hmem := (strictConvex_closedBall ℝ (0 : V) s.radius)
+    (by simp [Metric.mem_closedBall, hu]) (by simp [Metric.mem_closedBall, hv])
+    huv (sub_pos.mpr ht₁') ht₀' (sub_add_cancel 1 t)
+  rwa [interior_closedBall _ (fun h : s.radius = 0 => huv <|
+      (norm_eq_zero.mp (hu.trans h)).trans (norm_eq_zero.mp (hv.trans h)).symm),
+    Metric.mem_ball, dist_zero_right] at hmem
 
 /-- The distance from the center of a sphere to the midpoint of a chord
-with distinct endpoints `A` and `C` is strictly less than the radius. -/
-theorem Sphere.dist_center_midpoint_lt_radius {A C : P} {s : Sphere P}
-    (hA : A ∈ s) (hC : C ∈ s) (hAC : A ≠ C) :
-    dist s.center (midpoint ℝ A C) < s.radius := by
-  have hA' : ‖A -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hA
-  have hC' : ‖C -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub]; exact mem_sphere.mp hC
-  rw [dist_comm, dist_eq_norm_vsub, ← midpoint_self ℝ s.center, midpoint_vsub_midpoint, ← hA']
-  convert (norm_midpoint_lt_iff (hA'.trans hC'.symm)).mpr
-    (fun h => hAC (vsub_left_cancel h)) using 2
-  simp only [midpoint, AffineMap.lineMap_apply, invOf_eq_inv, vsub_eq_sub, vadd_eq_add, one_div]
-  module
+with distinct endpoints is strictly less than the radius. -/
+theorem Sphere.dist_center_midpoint_lt_radius {p₁ p₂ : P} {s : Sphere P}
+    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₁p₂ : p₁ ≠ p₂) :
+    dist s.center (midpoint ℝ p₁ p₂) < s.radius :=
+  s.dist_center_lt_radius_of_sbtw hp₁ hp₂ (sbtw_midpoint_of_ne ℝ hp₁p₂)
 
 /-- Two spheres intersect in at most two points in a two-dimensional subspace containing their
 centers; this is a version of `eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two` for bundled

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -386,6 +386,15 @@ theorem inner_vsub_vsub_of_mem_sphere_of_mem_sphere {p₁ p₂ : P} {s₁ s₂ :
   inner_vsub_vsub_of_dist_eq_of_dist_eq (dist_center_eq_dist_center_of_mem_sphere hp₁s₁ hp₂s₁)
     (dist_center_eq_dist_center_of_mem_sphere hp₁s₂ hp₂s₂)
 
+/-- The vector from the midpoint of a chord to the center of the sphere is
+orthogonal to the chord. -/
+theorem Sphere.inner_vsub_center_midpoint_vsub {A C : P} {s : Sphere P}
+    (hA : A ∈ s) (hC : C ∈ s) :
+    ⟪s.center -ᵥ midpoint ℝ A C, C -ᵥ A⟫ = 0 :=
+  inner_vsub_vsub_of_dist_eq_of_dist_eq
+    (dist_left_midpoint_eq_dist_right_midpoint A C)
+    (dist_center_eq_dist_center_of_mem_sphere hA hC)
+
 /-- Two spheres intersect in at most two points in a two-dimensional subspace containing their
 centers; this is a version of `eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two` for bundled
 spheres. -/

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -395,6 +395,27 @@ theorem Sphere.inner_vsub_center_midpoint_vsub {A C : P} {s : Sphere P}
     (dist_left_midpoint_eq_dist_right_midpoint A C)
     (dist_center_eq_dist_center_of_mem_sphere hA hC)
 
+/-- The distance from the center of a sphere to the midpoint of a chord
+with distinct endpoints `A` and `C` is strictly less than the radius. -/
+theorem Sphere.dist_center_midpoint_lt_radius {A C : P} {s : Sphere P}
+    (hA : A ∈ s) (hC : C ∈ s) (hAC : A ≠ C) :
+    dist s.center (midpoint ℝ A C) < s.radius := by
+  set M := midpoint ℝ A C
+  have hperp : ⟪s.center -ᵥ M, M -ᵥ A⟫ = 0 := by
+    rw [show M -ᵥ A = (2⁻¹ : ℝ) • (C -ᵥ A) from by rw [midpoint_vsub_left, invOf_eq_inv],
+        inner_smul_right, Sphere.inner_vsub_center_midpoint_vsub hA hC, mul_zero]
+  have hradius : ‖s.center -ᵥ A‖ = s.radius := by
+    rw [← dist_eq_norm_vsub']; exact mem_sphere.mp hA
+  have hpyth : s.radius ^ 2 = ‖s.center -ᵥ M‖ ^ 2 + ‖M -ᵥ A‖ ^ 2 := by
+    rw [← hradius, ← vsub_add_vsub_cancel s.center M A, norm_add_sq_real,
+        hperp, mul_zero, add_zero]
+  rw [dist_eq_norm_vsub]
+  have hMA_ne : M -ᵥ A ≠ (0 : V) :=
+    vsub_ne_zero.mpr (fun h => hAC ((midpoint_eq_left_iff ℝ).mp h))
+  exact (abs_lt_of_sq_lt_sq'
+    (by nlinarith [sq_pos_of_pos (norm_pos_iff.mpr hMA_ne)])
+    (by linarith [norm_nonneg (s.center -ᵥ A)])).2
+
 /-- Two spheres intersect in at most two points in a two-dimensional subspace containing their
 centers; this is a version of `eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two` for bundled
 spheres. -/


### PR DESCRIPTION
Adds two results about chords of spheres in Euclidean affine spaces:

- `Sphere.inner_vsub_center_midpoint_vsub`: the vector from the center
  of a sphere to the midpoint of a chord is orthogonal to the chord.

- `Sphere.dist_center_midpoint_lt_radius`: the distance from the center
  to the midpoint of a chord with distinct endpoints is strictly less
  than the radius. This follows by applying the Pythagorean theorem to
  the right triangle formed by the center, the midpoint, and an endpoint,
  using the orthogonality result above.