### PR TITLE
[Merged by Bors] - feat(GroupTheory): explicit isomorphism between infinite cyclic groups and Z

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -828,6 +828,58 @@ noncomputable def mulEquivOfPrimeCardEq {p : ℕ} [Group G] [Group G']
   apply mulEquivOfCyclicCardEq
   exact hG.trans hH.symm
 
+lemma zpowersHom_bijective {G : Type*} [Group G] [Infinite G] {g : G}
+    (hg : zpowers g = ⊤) : Function.Bijective (zpowersHom G g) := by
+  refine ⟨(MonoidHom.ker_eq_bot_iff _).mp ?_, MonoidHom.range_eq_top.mp hg⟩
+  simp [zpowersHom_ker_eq, ← infinite_zpowers, hg, Set.infinite_univ]
+
+/-- The isomorphism between `Multiplicative ℤ` and the infinite cyclic group `G` sending
+`Multiplicative.ofAdd 1` to the generator `g : G`. -/
+@[simps! apply]
+noncomputable def intCyclicMulEquiv {G : Type*} [Group G] [Infinite G] (g : G)
+    (hg : zpowers g = ⊤) : Multiplicative ℤ ≃* G :=
+  .ofBijective (zpowersHom G g) (zpowersHom_bijective hg)
+
+@[simp]
+lemma intCyclicMulEquiv_symm_self {G : Type*} [Group G] [Infinite G] {g : G}
+    (hg : zpowers g = ⊤) :
+    (intCyclicMulEquiv g hg).symm g = Multiplicative.ofAdd 1 := by
+  simp [MulEquiv.symm_apply_eq]
+
+lemma mulIntCyclicMulEquiv_symm_apply_zpow {G : Type*} [Group G] [Infinite G] {g : G}
+    (hg : zpowers g = ⊤) (k : ℤ) :
+    (intCyclicMulEquiv g hg).symm (g ^ k) = Multiplicative.ofAdd k := by
+  simp [← ofAdd_zsmul]
+
+lemma mulIntCyclicMulEquiv_strictMono {G : Type*} [CommGroup G] [PartialOrder G] [Infinite G]
+    [Nontrivial G] [IsOrderedMonoid G] {g : G} (hg : zpowers g = ⊤) (hg1 : 1 < g) :
+    StrictMono (intCyclicMulEquiv g hg) := by
+  intro x y hxy
+  simp only [intCyclicMulEquiv, MulEquiv.ofBijective_apply, zpowersHom_apply]
+  exact zpow_lt_zpow_right hg1 hxy
+
+lemma zmultiplesHom_bijective {G : Type*} [AddGroup G] [Infinite G] {g : G}
+    (hg : zmultiples g = ⊤) : Function.Bijective (zmultiplesHom G g) := by
+  refine ⟨(AddMonoidHom.ker_eq_bot_iff _).mp ?_, AddMonoidHom.range_eq_top.mp hg⟩
+  simp [zmultiplesHom_ker_eq, ← infinite_zmultiples, hg, Set.infinite_univ]
+
+/-- The isomorphism between `ℤ` and the infinite cyclic group `G` sending
+`1` to the generator `g : G`. -/
+@[simps! apply]
+noncomputable def intCyclicAddEquiv {G : Type*} [AddGroup G] [Infinite G] (g : G)
+    (hg : zmultiples g = ⊤) : ℤ ≃+ G :=
+  .ofBijective (zmultiplesHom G g) (zmultiplesHom_bijective hg)
+
+@[simp]
+lemma intCyclicAddEquiv_symm_self {G : Type*} [AddGroup G] [Infinite G] (g : G)
+    (hg : zmultiples g = ⊤) :
+    (intCyclicAddEquiv g hg).symm g = 1 := by
+  simp [AddEquiv.symm_apply_eq]
+
+lemma intCyclicAddEquiv_symm_apply_zsmul {G : Type*} [AddGroup G] [Infinite G] {g : G}
+    (hg : zmultiples g = ⊤) (k : ℤ) : (intCyclicAddEquiv g hg).symm (k • g) = k := by
+  simp
+
 variable (G) in
 /-- The automorphism group of a cyclic group is isomorphic to the multiplicative group of ZMod. -/
 @[simps!]

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -828,7 +828,11 @@ noncomputable def mulEquivOfPrimeCardEq {p : ℕ} [Group G] [Group G']
   apply mulEquivOfCyclicCardEq
   exact hG.trans hH.symm
 
-lemma zpowersHom_bijective {G : Type*} [Group G] [Infinite G] {g : G}
+section Infinite
+
+variable [Infinite G]
+
+lemma zpowersHom_bijective [Group G] {g : G}
     (hg : zpowers g = ⊤) : Function.Bijective (zpowersHom G g) := by
   refine ⟨(MonoidHom.ker_eq_bot_iff _).mp ?_, MonoidHom.range_eq_top.mp hg⟩
   simp [zpowersHom_ker_eq, ← infinite_zpowers, hg, Set.infinite_univ]
@@ -836,29 +840,36 @@ lemma zpowersHom_bijective {G : Type*} [Group G] [Infinite G] {g : G}
 /-- The isomorphism between `Multiplicative ℤ` and the infinite cyclic group `G` sending
 `Multiplicative.ofAdd 1` to the generator `g : G`. -/
 @[simps! apply]
-noncomputable def intCyclicMulEquiv {G : Type*} [Group G] [Infinite G] (g : G)
+noncomputable def intCyclicMulEquiv [Group G] (g : G)
     (hg : zpowers g = ⊤) : Multiplicative ℤ ≃* G :=
   .ofBijective (zpowersHom G g) (zpowersHom_bijective hg)
 
 @[simp]
-lemma intCyclicMulEquiv_symm_self {G : Type*} [Group G] [Infinite G] {g : G}
+lemma intCyclicMulEquiv_symm_self [Group G] {g : G}
     (hg : zpowers g = ⊤) :
     (intCyclicMulEquiv g hg).symm g = Multiplicative.ofAdd 1 := by
   simp [MulEquiv.symm_apply_eq]
 
-lemma mulIntCyclicMulEquiv_symm_apply_zpow {G : Type*} [Group G] [Infinite G] {g : G}
+lemma mulIntCyclicMulEquiv_symm_apply_zpow [Group G] {g : G}
     (hg : zpowers g = ⊤) (k : ℤ) :
     (intCyclicMulEquiv g hg).symm (g ^ k) = Multiplicative.ofAdd k := by
   simp [← ofAdd_zsmul]
 
-lemma mulIntCyclicMulEquiv_strictMono {G : Type*} [CommGroup G] [PartialOrder G] [Infinite G]
-    [Nontrivial G] [IsOrderedMonoid G] {g : G} (hg : zpowers g = ⊤) (hg1 : 1 < g) :
+lemma mulIntCyclicMulEquiv_strictMono [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
+    {g : G} (hg : zpowers g = ⊤) (hg1 : 1 < g) :
     StrictMono (intCyclicMulEquiv g hg) := by
   intro x y hxy
   simp only [intCyclicMulEquiv, MulEquiv.ofBijective_apply, zpowersHom_apply]
   exact zpow_lt_zpow_right hg1 hxy
 
-lemma zmultiplesHom_bijective {G : Type*} [AddGroup G] [Infinite G] {g : G}
+lemma mulIntCyclicMulEquiv_strictAnti [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
+    {g : G} (hg : zpowers g = ⊤) (hg1 : g < 1) :
+    StrictAnti (intCyclicMulEquiv g hg) := by
+  intro x y hxy
+  simp only [intCyclicMulEquiv, MulEquiv.ofBijective_apply, zpowersHom_apply]
+  exact zpow_right_strictAnti hg1 hxy
+
+lemma zmultiplesHom_bijective [AddGroup G] {g : G}
     (hg : zmultiples g = ⊤) : Function.Bijective (zmultiplesHom G g) := by
   refine ⟨(AddMonoidHom.ker_eq_bot_iff _).mp ?_, AddMonoidHom.range_eq_top.mp hg⟩
   simp [zmultiplesHom_ker_eq, ← infinite_zmultiples, hg, Set.infinite_univ]
@@ -866,19 +877,21 @@ lemma zmultiplesHom_bijective {G : Type*} [AddGroup G] [Infinite G] {g : G}
 /-- The isomorphism between `ℤ` and the infinite cyclic group `G` sending
 `1` to the generator `g : G`. -/
 @[simps! apply]
-noncomputable def intCyclicAddEquiv {G : Type*} [AddGroup G] [Infinite G] (g : G)
+noncomputable def intCyclicAddEquiv [AddGroup G] (g : G)
     (hg : zmultiples g = ⊤) : ℤ ≃+ G :=
   .ofBijective (zmultiplesHom G g) (zmultiplesHom_bijective hg)
 
 @[simp]
-lemma intCyclicAddEquiv_symm_self {G : Type*} [AddGroup G] [Infinite G] (g : G)
+lemma intCyclicAddEquiv_symm_self [AddGroup G] (g : G)
     (hg : zmultiples g = ⊤) :
     (intCyclicAddEquiv g hg).symm g = 1 := by
   simp [AddEquiv.symm_apply_eq]
 
-lemma intCyclicAddEquiv_symm_apply_zsmul {G : Type*} [AddGroup G] [Infinite G] {g : G}
+lemma intCyclicAddEquiv_symm_apply_zsmul [AddGroup G] {g : G}
     (hg : zmultiples g = ⊤) (k : ℤ) : (intCyclicAddEquiv g hg).symm (k • g) = k := by
   simp
+
+end Infinite
 
 variable (G) in
 /-- The automorphism group of a cyclic group is isomorphic to the multiplicative group of ZMod. -/

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -832,64 +832,71 @@ section Infinite
 
 variable [Infinite G]
 
-lemma zpowersHom_bijective [Group G] {g : G}
-    (hg : zpowers g = ⊤) : Function.Bijective (zpowersHom G g) := by
+lemma zpowersHom_bijective [Group G] {g : G} (hg : zpowers g = ⊤) :
+    Function.Bijective (zpowersHom G g) := by
   refine ⟨(MonoidHom.ker_eq_bot_iff _).mp ?_, MonoidHom.range_eq_top.mp hg⟩
   simp [zpowersHom_ker_eq, ← infinite_zpowers, hg, Set.infinite_univ]
 
 /-- The isomorphism between `Multiplicative ℤ` and the infinite cyclic group `G` sending
 `Multiplicative.ofAdd 1` to the generator `g : G`. -/
 @[simps! apply]
-noncomputable def intCyclicMulEquiv [Group G] (g : G)
-    (hg : zpowers g = ⊤) : Multiplicative ℤ ≃* G :=
+noncomputable def intEquivOfZPowersEqTop [Group G] (g : G) (hg : zpowers g = ⊤) :
+    Multiplicative ℤ ≃* G :=
   .ofBijective (zpowersHom G g) (zpowersHom_bijective hg)
 
 @[simp]
-lemma intCyclicMulEquiv_symm_self [Group G] {g : G}
-    (hg : zpowers g = ⊤) :
-    (intCyclicMulEquiv g hg).symm g = Multiplicative.ofAdd 1 := by
+lemma intEquivOfZPowersEqTop_symm_self [Group G] {g : G} (hg : zpowers g = ⊤) :
+    (intEquivOfZPowersEqTop g hg).symm g = Multiplicative.ofAdd 1 := by
   simp [MulEquiv.symm_apply_eq]
 
-lemma mulIntCyclicMulEquiv_symm_apply_zpow [Group G] {g : G}
-    (hg : zpowers g = ⊤) (k : ℤ) :
-    (intCyclicMulEquiv g hg).symm (g ^ k) = Multiplicative.ofAdd k := by
+lemma mulintEquivOfZPowersEqTop_symm_apply_zpow [Group G] {g : G} (hg : zpowers g = ⊤) (k : ℤ) :
+    (intEquivOfZPowersEqTop g hg).symm (g ^ k) = Multiplicative.ofAdd k := by
   simp [← ofAdd_zsmul]
 
-lemma mulIntCyclicMulEquiv_strictMono [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
+lemma mulintEquivOfZPowersEqTop_strictMono [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
     {g : G} (hg : zpowers g = ⊤) (hg1 : 1 < g) :
-    StrictMono (intCyclicMulEquiv g hg) := by
+    StrictMono (intEquivOfZPowersEqTop g hg) := by
   intro x y hxy
-  simp only [intCyclicMulEquiv, MulEquiv.ofBijective_apply, zpowersHom_apply]
+  simp only [intEquivOfZPowersEqTop, MulEquiv.ofBijective_apply, zpowersHom_apply]
   exact zpow_lt_zpow_right hg1 hxy
 
-lemma mulIntCyclicMulEquiv_strictAnti [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
+lemma mulintEquivOfZPowersEqTop_strictAnti [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
     {g : G} (hg : zpowers g = ⊤) (hg1 : g < 1) :
-    StrictAnti (intCyclicMulEquiv g hg) := by
+    StrictAnti (intEquivOfZPowersEqTop g hg) := by
   intro x y hxy
-  simp only [intCyclicMulEquiv, MulEquiv.ofBijective_apply, zpowersHom_apply]
+  simp only [intEquivOfZPowersEqTop, MulEquiv.ofBijective_apply, zpowersHom_apply]
   exact zpow_right_strictAnti hg1 hxy
 
-lemma zmultiplesHom_bijective [AddGroup G] {g : G}
-    (hg : zmultiples g = ⊤) : Function.Bijective (zmultiplesHom G g) := by
+/-- An infinite cyclic group is isomorphic to `Multiplicative ℤ`. -/
+noncomputable
+abbrev intCyclicMulEquiv [Group G] [IsCyclic G] : Multiplicative ℤ ≃* G :=
+  intEquivOfZPowersEqTop _ (isCyclic_iff_exists_zpowers_eq_top.mp ‹IsCyclic G›).choose_spec
+
+lemma zmultiplesHom_bijective [AddGroup G] {g : G} (hg : zmultiples g = ⊤) :
+    Function.Bijective (zmultiplesHom G g) := by
   refine ⟨(AddMonoidHom.ker_eq_bot_iff _).mp ?_, AddMonoidHom.range_eq_top.mp hg⟩
   simp [zmultiplesHom_ker_eq, ← infinite_zmultiples, hg, Set.infinite_univ]
 
 /-- The isomorphism between `ℤ` and the infinite cyclic group `G` sending
 `1` to the generator `g : G`. -/
 @[simps! apply]
-noncomputable def intCyclicAddEquiv [AddGroup G] (g : G)
-    (hg : zmultiples g = ⊤) : ℤ ≃+ G :=
+noncomputable def intEquivOfZMultiplesEqTop [AddGroup G] (g : G) (hg : zmultiples g = ⊤) : ℤ ≃+ G :=
   .ofBijective (zmultiplesHom G g) (zmultiplesHom_bijective hg)
 
 @[simp]
-lemma intCyclicAddEquiv_symm_self [AddGroup G] (g : G)
-    (hg : zmultiples g = ⊤) :
-    (intCyclicAddEquiv g hg).symm g = 1 := by
+lemma intEquivOfZMultiplesEqTop_symm_self [AddGroup G] (g : G) (hg : zmultiples g = ⊤) :
+    (intEquivOfZMultiplesEqTop g hg).symm g = 1 := by
   simp [AddEquiv.symm_apply_eq]
 
-lemma intCyclicAddEquiv_symm_apply_zsmul [AddGroup G] {g : G}
-    (hg : zmultiples g = ⊤) (k : ℤ) : (intCyclicAddEquiv g hg).symm (k • g) = k := by
+lemma intEquivOfZMultiplesEqTop_symm_apply_zsmul [AddGroup G]
+    {g : G} (hg : zmultiples g = ⊤) (k : ℤ) :
+    (intEquivOfZMultiplesEqTop g hg).symm (k • g) = k := by
   simp
+
+/-- An infinite cyclic additive group is isomorphic to `ℤ`. -/
+noncomputable
+abbrev intCyclicAddEquiv [AddGroup G] [IsAddCyclic G] : ℤ ≃+ G :=
+  intEquivOfZMultiplesEqTop _ (isAddCyclic_iff_exists_zmultiples_eq_top.mp ‹_›).choose_spec
 
 end Infinite
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
