### PR TITLE
feat(CategoryTheory/Profunctor): Add profunctors and a basic API for them

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3082,6 +3082,7 @@ public import Mathlib.CategoryTheory.Products.Associator
 public import Mathlib.CategoryTheory.Products.Basic
 public import Mathlib.CategoryTheory.Products.Bifunctor
 public import Mathlib.CategoryTheory.Products.Unitor
+public import Mathlib.CategoryTheory.Profunctor
 public import Mathlib.CategoryTheory.Quotient
 public import Mathlib.CategoryTheory.Quotient.Linear
 public import Mathlib.CategoryTheory.Quotient.LocallySmall

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -25,11 +25,17 @@ namespace CategoryTheory
 
 universe w
 
+/-- A profunctor between two categories `C` and `D` is a functor from `Cᵒᵖ × D` to the category of
+types. We encode this data as a structure. -/
 structure Profunctor (C : Type*) [Category* C] (D : Type*) [Category* D] where
+  /-- Apply a profunctor to a pair of objects. -/
   obj : D → C → Type w
+  /-- Apply a profunctor to a pair of maps. -/
   map {X X' : D} {Y Y' : C} (f : X' ⟶ X) (g : Y ⟶ Y') :
     obj X Y → obj X' Y'
+  /-- Identity law for profunctors. -/
   map_id (X : D) (Y : C) (e : obj X Y) : map (𝟙 _) (𝟙 _) e = e
+  /-- Composition law for profunctors. -/
   map_comp {X X' X'' : D} {Y Y' Y'' : C}
     (f' : X'' ⟶ X') (f : X' ⟶ X)
     (g : Y ⟶ Y') (g' : Y' ⟶ Y'')
@@ -85,11 +91,13 @@ theorem map_eq_mapR_mapL (H : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
     H.map f g e = H.mapL f (H.mapR g e) := by
   simp only [mapL, mapR, ← H.map_comp, Category.comp_id]
 
-def mpRight (H : Profunctor.{w} C D) {a b c} (p : b = c) (f : H.obj a b) : H.obj a c :=
-  H.mapR (eqToHom p) f
-
+/-- Transport a profunctor along an equality on the left. -/
 def mpLeft (H : Profunctor.{w} C D) {a b c} (p : a = b) (f : H.obj b c) : H.obj a c :=
   H.mapL (eqToHom p) f
+
+/-- Transport a profunctor along an equality on the right. -/
+def mpRight (H : Profunctor.{w} C D) {a b c} (p : b = c) (f : H.obj a b) : H.obj a c :=
+  H.mapR (eqToHom p) f
 
 /-- A natural transformation between profunctors `H` and `K`. -/
 structure NatTrans (H K : Profunctor.{w} C D) where

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Adrian Marti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adrian Marti, Aristotle
+-/
+module
+
+public import Mathlib.CategoryTheory.Category.Basic
+public import Mathlib.CategoryTheory.EqToHom
+public import Mathlib.Tactic.CategoryTheory.CategoryStar
+
+/-!
+# Profunctors and Natural Transformations
+
+In this file we define profunctors between two categories and natural transformations between profunctors.
+
+Profunctors are defined as a structure with a mapping operation `map` that lets us map on both sides of the profunctor at once. We also provide operations `mapL` and `mapR` to map only on one side.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+universe w
+
+structure Profunctor (C : Type*) [Category* C] (D : Type*) [Category* D] where
+  obj : D → C → Type w
+  map {X X' : D} {Y Y' : C} (f : X' ⟶ X) (g : Y ⟶ Y') :
+    obj X Y → obj X' Y'
+  map_id (X : D) (Y : C) (e : obj X Y) : map (𝟙 _) (𝟙 _) e = e
+  map_comp {X X' X'' : D} {Y Y' Y'' : C}
+    (f' : X'' ⟶ X') (f : X' ⟶ X)
+    (g : Y ⟶ Y') (g' : Y' ⟶ Y'')
+    (e : obj X Y) :
+    map (f' ≫ f) (g ≫ g') e = map f' g' (map f g e)
+
+
+variable {C : Type*} [Category C] {D : Type*} [Category D]
+
+namespace Profunctor
+
+/-! ### Left and right mapping -/
+
+/-- Apply a profunctor to a morphism on the left (contravariant) side,
+    keeping the right (covariant) side fixed. -/
+def mapL (h : Profunctor.{w} C D) {X X' : D} (f : X ⟶ X') {Y : C} :
+    h.obj X' Y → h.obj X Y :=
+  h.map f (𝟙 Y)
+
+/-- Apply a profunctor to a morphism on the right (covariant) side,
+    keeping the left (contravariant) side fixed. -/
+def mapR (h : Profunctor.{w} C D) {X : D} {Y Y' : C} (g : Y ⟶ Y') :
+    h.obj X Y → h.obj X Y' :=
+  h.map (𝟙 X) g
+
+@[simp]
+theorem mapL_id (h : Profunctor.{w} C D) (X : D) (Y : C) (e : h.obj X Y) :
+    h.mapL (𝟙 X) e = e :=
+  h.map_id X Y e
+
+@[simp]
+theorem mapR_id (h : Profunctor.{w} C D) (X : D) (Y : C) (e : h.obj X Y) :
+    h.mapR (𝟙 Y) e = e :=
+  h.map_id X Y e
+
+theorem mapL_comp (h : Profunctor.{w} C D) {X X' X'' : D} (f : X ⟶ X') (f' : X' ⟶ X'')
+    {Y : C} (e : h.obj X'' Y) :
+    h.mapL (f ≫ f') e = h.mapL f (h.mapL f' e) := by
+  simp only [mapL, ← h.map_comp, Category.comp_id]
+
+theorem mapR_comp (h : Profunctor.{w} C D) {X : D} {Y Y' Y'' : C} (g : Y ⟶ Y') (g' : Y' ⟶ Y'')
+    (e : h.obj X Y) :
+    h.mapR (g ≫ g') e = h.mapR g' (h.mapR g e) := by
+  simp only [mapR, ← h.map_comp, Category.comp_id]
+
+theorem map_eq_mapL_mapR (h : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
+    (f : X ⟶ X') (g : Y ⟶ Y') (e : h.obj X' Y) :
+    h.map f g e = h.mapR g (h.mapL f e) := by
+  simp only [mapL, mapR, ← h.map_comp, Category.id_comp]
+
+theorem map_eq_mapR_mapL (h : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
+    (f : X ⟶ X') (g : Y ⟶ Y') (e : h.obj X' Y) :
+    h.map f g e = h.mapL f (h.mapR g e) := by
+  simp only [mapL, mapR, ← h.map_comp, Category.comp_id]
+
+def mpRight (h : Profunctor.{w} C D) {a b c} (p : b = c) (f : h.obj a b) : h.obj a c :=
+  h.mapR (eqToHom p) f
+
+def mpLeft (h : Profunctor.{w} C D) {a b c} (p : a = b) (f : h.obj b c) : h.obj a c :=
+  h.mapL (eqToHom p) f
+
+/-- A natural transformation between profunctors `h` and `k`. -/
+structure NatTrans (h k : Profunctor.{w} C D) where
+  /-- The component of the natural transformation at each pair of objects. -/
+  app (X : D) (Y : C) : h.obj X Y → k.obj X Y
+  /-- Naturality: the transformation commutes with `map`. -/
+  naturality {X X' : D} {Y Y' : C} (f : X' ⟶ X) (g : Y ⟶ Y') (e : h.obj X Y) :
+    app X' Y' (h.map f g e) = k.map f g (app X Y e)
+
+namespace NatTrans
+
+/-- The identity natural transformation. -/
+@[simps]
+def id (h : Profunctor.{w} C D) : NatTrans h h where
+  app _ _ e := e
+  naturality _ _ _ := rfl
+
+/-- Composition of natural transformations between profunctors. -/
+@[simps]
+def comp {h k R : Profunctor.{w} C D} (β : NatTrans k R) (α : NatTrans h k) :
+    NatTrans h R where
+  app X Y e := β.app X Y (α.app X Y e)
+  naturality f g e := by rw [α.naturality, β.naturality]
+
+@[ext]
+theorem ext {h k : Profunctor.{w} C D} {α β : NatTrans h k}
+    (h : ∀ (X : D) (Y : C) (e : h.obj X Y), α.app X Y e = β.app X Y e) :
+    α = β := by
+  cases α
+  cases β
+  congr
+  funext X Y e
+  exact h X Y e
+
+@[simp]
+theorem id_comp {h k : Profunctor.{w} C D} (α : NatTrans h k) :
+    (NatTrans.id k).comp α = α := by
+  ext
+  simp [comp, id]
+
+@[simp]
+theorem comp_id {h k : Profunctor.{w} C D} (α : NatTrans h k) :
+    α.comp (NatTrans.id h) = α := by
+  ext
+  simp [comp, id]
+
+theorem comp_assoc {h k R S : Profunctor.{w} C D}
+    (γ : NatTrans R S) (β : NatTrans k R) (α : NatTrans h k) :
+    (γ.comp β).comp α = γ.comp (β.comp α) :=
+  rfl
+
+/-- Naturality with respect to `mapL`. -/
+theorem naturality_mapL {h k : Profunctor.{w} C D} (α : NatTrans h k)
+    {X X' : D} (f : X ⟶ X') {Y : C} (e : h.obj X' Y) :
+    α.app X Y (h.mapL f e) = k.mapL f (α.app X' Y e) := by
+  simp only [mapL]
+  exact α.naturality f (𝟙 Y) e
+
+/-- Naturality with respect to `mapR`. -/
+theorem naturality_mapR {h k : Profunctor.{w} C D} (α : NatTrans h k)
+    {X : D} {Y Y' : C} (g : Y ⟶ Y') (e : h.obj X Y) :
+    α.app X Y' (h.mapR g e) = k.mapR g (α.app X Y e) := by
+  simp only [mapR]
+  exact α.naturality (𝟙 X) g e
+
+end NatTrans
+
+/-! ### Category instance for profunctors -/
+
+/-- The category of profunctors from `D` to `C`, with natural transformations as morphisms. -/
+instance instCategory : Category (Profunctor.{w} C D) where
+  Hom h k := NatTrans h k
+  id h := NatTrans.id h
+  comp α β := β.comp α
+  id_comp := NatTrans.comp_id
+  comp_id := NatTrans.id_comp
+  assoc _ _ _ := (NatTrans.comp_assoc _ _ _).symm
+
+end Profunctor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -25,7 +25,7 @@ namespace CategoryTheory
 
 universe w
 
-/-- A profunctor between two categories `C` and `D` is a functor from `Cᵒᵖ × D` to the category of
+/-- A profunctor between two categories `C` and `D` is a functor from `Dᵒᵖ × C` to the category of
 types. We encode this data as a structure. -/
 structure Profunctor (C : Type*) [Category* C] (D : Type*) [Category* D] where
   /-- Apply a profunctor to a pair of objects. -/

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -43,113 +43,113 @@ namespace Profunctor
 
 /-- Apply a profunctor to a morphism on the left (contravariant) side,
     keeping the right (covariant) side fixed. -/
-def mapL (h : Profunctor.{w} C D) {X X' : D} (f : X ⟶ X') {Y : C} :
-    h.obj X' Y → h.obj X Y :=
-  h.map f (𝟙 Y)
+def mapL (H : Profunctor.{w} C D) {X X' : D} (f : X ⟶ X') {Y : C} :
+    H.obj X' Y → H.obj X Y :=
+  H.map f (𝟙 Y)
 
 /-- Apply a profunctor to a morphism on the right (covariant) side,
     keeping the left (contravariant) side fixed. -/
-def mapR (h : Profunctor.{w} C D) {X : D} {Y Y' : C} (g : Y ⟶ Y') :
-    h.obj X Y → h.obj X Y' :=
-  h.map (𝟙 X) g
+def mapR (H : Profunctor.{w} C D) {X : D} {Y Y' : C} (g : Y ⟶ Y') :
+    H.obj X Y → H.obj X Y' :=
+  H.map (𝟙 X) g
 
 @[simp]
-theorem mapL_id (h : Profunctor.{w} C D) (X : D) (Y : C) (e : h.obj X Y) :
-    h.mapL (𝟙 X) e = e :=
-  h.map_id X Y e
+theorem mapL_id (H : Profunctor.{w} C D) (X : D) (Y : C) (e : H.obj X Y) :
+    H.mapL (𝟙 X) e = e :=
+  H.map_id X Y e
 
 @[simp]
-theorem mapR_id (h : Profunctor.{w} C D) (X : D) (Y : C) (e : h.obj X Y) :
-    h.mapR (𝟙 Y) e = e :=
-  h.map_id X Y e
+theorem mapR_id (H : Profunctor.{w} C D) (X : D) (Y : C) (e : H.obj X Y) :
+    H.mapR (𝟙 Y) e = e :=
+  H.map_id X Y e
 
-theorem mapL_comp (h : Profunctor.{w} C D) {X X' X'' : D} (f : X ⟶ X') (f' : X' ⟶ X'')
-    {Y : C} (e : h.obj X'' Y) :
-    h.mapL (f ≫ f') e = h.mapL f (h.mapL f' e) := by
-  simp only [mapL, ← h.map_comp, Category.comp_id]
+theorem mapL_comp (H : Profunctor.{w} C D) {X X' X'' : D} (f : X ⟶ X') (f' : X' ⟶ X'')
+    {Y : C} (e : H.obj X'' Y) :
+    H.mapL (f ≫ f') e = H.mapL f (H.mapL f' e) := by
+  simp only [mapL, ← H.map_comp, Category.comp_id]
 
-theorem mapR_comp (h : Profunctor.{w} C D) {X : D} {Y Y' Y'' : C} (g : Y ⟶ Y') (g' : Y' ⟶ Y'')
-    (e : h.obj X Y) :
-    h.mapR (g ≫ g') e = h.mapR g' (h.mapR g e) := by
-  simp only [mapR, ← h.map_comp, Category.comp_id]
+theorem mapR_comp (H : Profunctor.{w} C D) {X : D} {Y Y' Y'' : C} (g : Y ⟶ Y') (g' : Y' ⟶ Y'')
+    (e : H.obj X Y) :
+    H.mapR (g ≫ g') e = H.mapR g' (H.mapR g e) := by
+  simp only [mapR, ← H.map_comp, Category.comp_id]
 
-theorem map_eq_mapL_mapR (h : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
-    (f : X ⟶ X') (g : Y ⟶ Y') (e : h.obj X' Y) :
-    h.map f g e = h.mapR g (h.mapL f e) := by
-  simp only [mapL, mapR, ← h.map_comp, Category.id_comp]
+theorem map_eq_mapL_mapR (H : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
+    (f : X ⟶ X') (g : Y ⟶ Y') (e : H.obj X' Y) :
+    H.map f g e = H.mapR g (H.mapL f e) := by
+  simp only [mapL, mapR, ← H.map_comp, Category.id_comp]
 
-theorem map_eq_mapR_mapL (h : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
-    (f : X ⟶ X') (g : Y ⟶ Y') (e : h.obj X' Y) :
-    h.map f g e = h.mapL f (h.mapR g e) := by
-  simp only [mapL, mapR, ← h.map_comp, Category.comp_id]
+theorem map_eq_mapR_mapL (H : Profunctor.{w} C D) {X X' : D} {Y Y' : C}
+    (f : X ⟶ X') (g : Y ⟶ Y') (e : H.obj X' Y) :
+    H.map f g e = H.mapL f (H.mapR g e) := by
+  simp only [mapL, mapR, ← H.map_comp, Category.comp_id]
 
-def mpRight (h : Profunctor.{w} C D) {a b c} (p : b = c) (f : h.obj a b) : h.obj a c :=
-  h.mapR (eqToHom p) f
+def mpRight (H : Profunctor.{w} C D) {a b c} (p : b = c) (f : H.obj a b) : H.obj a c :=
+  H.mapR (eqToHom p) f
 
-def mpLeft (h : Profunctor.{w} C D) {a b c} (p : a = b) (f : h.obj b c) : h.obj a c :=
-  h.mapL (eqToHom p) f
+def mpLeft (H : Profunctor.{w} C D) {a b c} (p : a = b) (f : H.obj b c) : H.obj a c :=
+  H.mapL (eqToHom p) f
 
-/-- A natural transformation between profunctors `h` and `k`. -/
-structure NatTrans (h k : Profunctor.{w} C D) where
+/-- A natural transformation between profunctors `H` and `K`. -/
+structure NatTrans (H K : Profunctor.{w} C D) where
   /-- The component of the natural transformation at each pair of objects. -/
-  app (X : D) (Y : C) : h.obj X Y → k.obj X Y
+  app (X : D) (Y : C) : H.obj X Y → K.obj X Y
   /-- Naturality: the transformation commutes with `map`. -/
-  naturality {X X' : D} {Y Y' : C} (f : X' ⟶ X) (g : Y ⟶ Y') (e : h.obj X Y) :
-    app X' Y' (h.map f g e) = k.map f g (app X Y e)
+  naturality {X X' : D} {Y Y' : C} (f : X' ⟶ X) (g : Y ⟶ Y') (e : H.obj X Y) :
+    app X' Y' (H.map f g e) = K.map f g (app X Y e)
 
 namespace NatTrans
 
 /-- The identity natural transformation. -/
 @[simps]
-def id (h : Profunctor.{w} C D) : NatTrans h h where
+def id (H : Profunctor.{w} C D) : NatTrans H H where
   app _ _ e := e
   naturality _ _ _ := rfl
 
 /-- Composition of natural transformations between profunctors. -/
 @[simps]
-def comp {h k R : Profunctor.{w} C D} (β : NatTrans k R) (α : NatTrans h k) :
-    NatTrans h R where
+def comp {H K R : Profunctor.{w} C D} (β : NatTrans K R) (α : NatTrans H K) :
+    NatTrans H R where
   app X Y e := β.app X Y (α.app X Y e)
   naturality f g e := by rw [α.naturality, β.naturality]
 
 @[ext]
-theorem ext {h k : Profunctor.{w} C D} {α β : NatTrans h k}
-    (h : ∀ (X : D) (Y : C) (e : h.obj X Y), α.app X Y e = β.app X Y e) :
+theorem ext {H K : Profunctor.{w} C D} {α β : NatTrans H K}
+    (H : ∀ (X : D) (Y : C) (e : H.obj X Y), α.app X Y e = β.app X Y e) :
     α = β := by
   cases α
   cases β
   congr
   funext X Y e
-  exact h X Y e
+  exact H X Y e
 
 @[simp]
-theorem id_comp {h k : Profunctor.{w} C D} (α : NatTrans h k) :
-    (NatTrans.id k).comp α = α := by
+theorem id_comp {H K : Profunctor.{w} C D} (α : NatTrans H K) :
+    (NatTrans.id K).comp α = α := by
   ext
   simp [comp, id]
 
 @[simp]
-theorem comp_id {h k : Profunctor.{w} C D} (α : NatTrans h k) :
-    α.comp (NatTrans.id h) = α := by
+theorem comp_id {H K : Profunctor.{w} C D} (α : NatTrans H K) :
+    α.comp (NatTrans.id H) = α := by
   ext
   simp [comp, id]
 
-theorem comp_assoc {h k R S : Profunctor.{w} C D}
-    (γ : NatTrans R S) (β : NatTrans k R) (α : NatTrans h k) :
+theorem comp_assoc {H K L M : Profunctor.{w} C D}
+    (γ : NatTrans R S) (β : NatTrans K R) (α : NatTrans H K) :
     (γ.comp β).comp α = γ.comp (β.comp α) :=
   rfl
 
 /-- Naturality with respect to `mapL`. -/
-theorem naturality_mapL {h k : Profunctor.{w} C D} (α : NatTrans h k)
-    {X X' : D} (f : X ⟶ X') {Y : C} (e : h.obj X' Y) :
-    α.app X Y (h.mapL f e) = k.mapL f (α.app X' Y e) := by
+theorem naturality_mapL {H K : Profunctor.{w} C D} (α : NatTrans H K)
+    {X X' : D} (f : X ⟶ X') {Y : C} (e : H.obj X' Y) :
+    α.app X Y (H.mapL f e) = K.mapL f (α.app X' Y e) := by
   simp only [mapL]
   exact α.naturality f (𝟙 Y) e
 
 /-- Naturality with respect to `mapR`. -/
-theorem naturality_mapR {h k : Profunctor.{w} C D} (α : NatTrans h k)
-    {X : D} {Y Y' : C} (g : Y ⟶ Y') (e : h.obj X Y) :
-    α.app X Y' (h.mapR g e) = k.mapR g (α.app X Y e) := by
+theorem naturality_mapR {H K : Profunctor.{w} C D} (α : NatTrans H K)
+    {X : D} {Y Y' : C} (g : Y ⟶ Y') (e : H.obj X Y) :
+    α.app X Y' (H.mapR g e) = K.mapR g (α.app X Y e) := by
   simp only [mapR]
   exact α.naturality (𝟙 X) g e
 
@@ -159,8 +159,8 @@ end NatTrans
 
 /-- The category of profunctors from `D` to `C`, with natural transformations as morphisms. -/
 instance instCategory : Category (Profunctor.{w} C D) where
-  Hom h k := NatTrans h k
-  id h := NatTrans.id h
+  Hom H K := NatTrans H K
+  id H := NatTrans.id H
   comp α β := β.comp α
   id_comp := NatTrans.comp_id
   comp_id := NatTrans.id_comp

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -12,9 +12,11 @@ public import Mathlib.Tactic.CategoryTheory.CategoryStar
 /-!
 # Profunctors and Natural Transformations
 
-In this file we define profunctors between two categories and natural transformations between profunctors.
+In this file we define profunctors between two categories and natural transformations between
+profunctors.
 
-Profunctors are defined as a structure with a mapping operation `map` that lets us map on both sides of the profunctor at once. We also provide operations `mapL` and `mapR` to map only on one side.
+Profunctors are defined as a structure with a mapping operation `map` that lets us map on both sides
+of the profunctor at once. We also provide operations `mapL` and `mapR` to map only on one side.
 -/
 
 @[expose] public section

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -42,6 +42,9 @@ structure Profunctor (C : Type*) [Category* C] (D : Type*) [Category* D] where
     (e : obj X Y) :
     map (f' ≫ f) (g ≫ g') e = map f' g' (map f g e)
 
+attribute [simp] Profunctor.map_id Profunctor.map_comp
+attribute [grind =] Profunctor.map_id
+attribute [grind _=_] Profunctor.map_comp
 
 variable {C : Type*} [Category* C] {D : Type*} [Category* D]
 

--- a/Mathlib/CategoryTheory/Profunctor.lean
+++ b/Mathlib/CategoryTheory/Profunctor.lean
@@ -35,7 +35,7 @@ structure Profunctor (C : Type*) [Category* C] (D : Type*) [Category* D] where
     map (f' ≫ f) (g ≫ g') e = map f' g' (map f g e)
 
 
-variable {C : Type*} [Category C] {D : Type*} [Category D]
+variable {C : Type*} [Category* C] {D : Type*} [Category* D]
 
 namespace Profunctor
 
@@ -135,7 +135,7 @@ theorem comp_id {H K : Profunctor.{w} C D} (α : NatTrans H K) :
   simp [comp, id]
 
 theorem comp_assoc {H K L M : Profunctor.{w} C D}
-    (γ : NatTrans R S) (β : NatTrans K R) (α : NatTrans H K) :
+    (γ : NatTrans L M) (β : NatTrans K L) (α : NatTrans H K) :
     (γ.comp β).comp α = γ.comp (β.comp α) :=
   rfl
 


### PR DESCRIPTION
This adds a definition of a profunctor and the definition of a natural transformation between two profunctors. Profunctors are defined as a structure, as suggested by @adamtopaz [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Operads.20Formalization/with/566160316).

Using this as a base, I wrote a basic API for profunctors. This will be needed for a future formalization of operads.

A lot of the API was first drafted by @Aristotle-Harmonic. 


Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
