### PR TITLE
[Merged by Bors] - chore: fix naming in `WithVal`

### DIFF
--- a/Mathlib/NumberTheory/Padics/WithVal.lean
+++ b/Mathlib/NumberTheory/Padics/WithVal.lean
@@ -177,7 +177,7 @@ theorem withValUniformEquiv_norm_le_one_iff {p : ℕ} [Fact p.Prime]
       (Valued.isClopen_closedBall _ one_ne_zero)
     simpa [Metric.closedBall] using IsUltrametricDist.isClopen_closedBall (0 : ℚ_[p]) one_ne_zero
   | ih a =>
-    rw [Valued.valuedCompletion_apply, ← WithVal.apply_equiv, withValUniformEquiv_cast_apply]
+    rw [Valued.valuedCompletion_apply, ← WithVal.apply_ofVal, withValUniformEquiv_cast_apply]
     exact (norm_rat_le_one_iff_padicValuation_le_one p)
 
 end Padic

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1040,7 +1040,7 @@ theorem valuation_LaurentSeries_equal_extension :
     (LaurentSeriesPkg K).isDenseInducing.extend Valued.v = (Valued.v : K⸨X⸩ → ℤᵐ⁰) := by
   apply IsDenseInducing.extend_unique
   · intro x
-    rw [← WithVal.apply_equiv, valuation_eq_LaurentSeries_valuation K]
+    rw [← WithVal.apply_ofVal, valuation_eq_LaurentSeries_valuation K]
     rfl
   · exact Valued.continuous_valuation (K := K⸨X⸩)
 

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -155,8 +155,8 @@ def valuation : Valuation (WithVal v) Γ₀ := v.comap (equiv v)
 
 instance : Valued (WithVal v) Γ₀ := Valued.mk' (valuation v)
 
-theorem apply_equiv (r : WithVal v) : v r.ofVal = Valued.v r := rfl
-@[simp] theorem apply_symm_equiv (r : R) : Valued.v (toVal v r) = v r := rfl
+theorem apply_ofVal (r : WithVal v) : v r.ofVal = Valued.v r := rfl
+@[simp] theorem valued_toVal (r : R) : Valued.v (toVal v r) = v r := rfl
 
 instance [CharZero R] : CharZero (WithVal v) :=
   .of_addMonoidHom (equiv v).symm.toAddMonoidHom (by simp) (equiv v).symm.injective
@@ -381,7 +381,7 @@ theorem IsEquiv.uniformContinuous_congr
   intro γ
   obtain ⟨r, s, hr₀, hs₀, hr⟩ := hw γ
   use .mk0 (v r / v s) (by simp [h.eq_zero, hr₀.ne.symm, hs₀.ne.symm]), fun x hx ↦ ?_
-  rw [← hr, congr_apply, RingEquiv.refl_apply, Set.mem_setOf_eq, apply_symm_equiv, lt_div_iff₀ hs₀,
+  rw [← hr, congr_apply, RingEquiv.refl_apply, Set.mem_setOf_eq, valued_toVal, lt_div_iff₀ hs₀,
     ← map_mul, ← lt_def, ← ofVal_mul, ← h.orderRingIso_apply, ← h.orderRingIso.lt_symm_apply]
   simpa [lt_def, lt_div_iff₀ (h.pos_iff.2 hs₀)] using hx
 
@@ -407,7 +407,7 @@ theorem IsEquiv.uniformContinuous_equiv_symm [Valued R Γ₀'] (hv : Valued.v = 
   intro γ
   obtain ⟨r, s, hr₀, hs₀, hr⟩ := hw γ
   use .mk0 (w r / w s) (by simp [h.eq_zero, hr₀.ne.symm, hs₀.ne.symm]), fun x hx ↦ ?_
-  simp only [equiv_symm_apply, Set.mem_setOf_eq, apply_symm_equiv]
+  simp only [equiv_symm_apply, Set.mem_setOf_eq, valued_toVal]
   simp [hv] at hx
   rw [← hr, lt_div_iff₀ hs₀, ← map_mul, ← lt_def,
     ← h.orderRingIso_apply, ← h.orderRingIso.lt_symm_apply]
@@ -452,7 +452,7 @@ theorem IsEquiv.valuedCompletion_le_one_iff {K : Type*} [Field K] {v : Valuation
   | hp =>
     exact (mapEquiv (h.uniformEquiv _ _)).toHomeomorph.isClosed_setOf_iff
       (Valued.isClopen_closedBall _ one_ne_zero) (Valued.isClopen_closedBall _ one_ne_zero)
-  | ih a => simpa [Valued.valuedCompletion_apply, ← WithVal.apply_equiv] using h.le_one_iff_le_one
+  | ih a => simpa [Valued.valuedCompletion_apply, ← WithVal.apply_ofVal] using h.le_one_iff_le_one
 
 end Equivalence
 

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -158,6 +158,9 @@ instance : Valued (WithVal v) Γ₀ := Valued.mk' (valuation v)
 theorem apply_ofVal (r : WithVal v) : v r.ofVal = Valued.v r := rfl
 @[simp] theorem valued_toVal (r : R) : Valued.v (toVal v r) = v r := rfl
 
+@[deprecated (since := "2026-03-02")] alias apply_equiv := apply_ofVal
+@[deprecated (since := "2026-03-02")] alias apply_symm_equiv := valued_toVal
+
 instance [CharZero R] : CharZero (WithVal v) :=
   .of_addMonoidHom (equiv v).symm.toAddMonoidHom (by simp) (equiv v).symm.injective
 


### PR DESCRIPTION
Minor cleanup post #34049

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
