### PR TITLE
[Merged by Bors] - fix: `linarith` `splitNe` skips hypotheses without `LinearOrder`

### DIFF
--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -363,12 +363,13 @@ end nlinarith
 section removeNe
 /--
 `removeNe_aux` case splits on any proof `h : a ≠ b` in the input,
-turning it into `a < b ∨ a > b`.
+turning it into `a < b ∨ a > b`, provided the type has a `LinearOrder` instance.
 This produces `2^n` branches when there are `n` such hypotheses in the input.
 -/
 partial def removeNe_aux : MVarId → List Expr → MetaM (List Branch) := fun g hs => do
   let some (e, α, a, b) ← hs.findSomeM? (fun e : Expr => do
     let some (α, a, b) := (← instantiateMVars (← inferType e)).ne?' | return none
+    unless (← synthInstance? (← mkAppM ``LinearOrder #[α])).isSome do return none
     return some (e, α, a, b)) | return [(g, hs)]
   let [ng1, ng2] ← g.apply (← mkAppOptM ``Or.elim #[none, none, ← g.getType,
       ← mkAppOptM ``lt_or_gt_of_ne #[α, none, a, b, e]]) | failure
@@ -381,7 +382,7 @@ partial def removeNe_aux : MVarId → List Expr → MetaM (List Branch) := fun g
 
 /--
 `removeNe` case splits on any proof `h : a ≠ b` in the input, turning it into `a < b ∨ a > b`,
-by calling `linarith.removeNe_aux`.
+by calling `linarith.removeNe_aux`, provided the type has a `LinearOrder` instance.
 This produces `2^n` branches when there are `n` such hypotheses in the input.
 -/
 def removeNe : GlobalBranchingPreprocessor where

--- a/MathlibTest/Linarith/Basic.lean
+++ b/MathlibTest/Linarith/Basic.lean
@@ -549,6 +549,11 @@ example (r : ℚ) (h' : 1 = r * 2) : 1 = 0 ∨ r = 1 / 2 := by
   by_contra! h''
   linarith +splitNe
 
+/-- https://github.com/leanprover-community/mathlib4/issues/29963 -/
+example {V : Type*} [AddCommGroup V] {x : V} (hx : x ≠ 0) {a b : ℚ} (hab : a ≠ b) (hab' : a = b) :
+    False := by
+  linarith +splitNe
+
 example (x y : ℚ) (h₁ : 0 ≤ y) (h₂ : y ≤ x) : y * x ≤ x * x := by nlinarith
 
 example (x y : ℚ) (h₁ : 0 ≤ y) (h₂ : y ≤ x) : y * x ≤ x ^ 2 := by nlinarith


### PR DESCRIPTION
When using `linarith` with `splitNe := true`, the tactic would fail with "failed to synthesize LinearOrder V" if any `≠` hypothesis existed on a type without a `LinearOrder` instance (like `AddCommGroup`). With this PR it just skips those hypotheses and processes only the ones it can actually split.

Fixes #29963