### PR TITLE
add reindexing, fibers pseudofunctor, internal categories, and single-morphism descent

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2524,6 +2524,8 @@ public import Mathlib.CategoryTheory.FiberedCategory.Fibered
 public import Mathlib.CategoryTheory.FiberedCategory.Grothendieck
 public import Mathlib.CategoryTheory.FiberedCategory.HasFibers
 public import Mathlib.CategoryTheory.FiberedCategory.HomLift
+public import Mathlib.CategoryTheory.FiberedCategory.PseudofunctorOfFibers
+public import Mathlib.CategoryTheory.FiberedCategory.Reindexing
 public import Mathlib.CategoryTheory.Filtered.Basic
 public import Mathlib.CategoryTheory.Filtered.Connected
 public import Mathlib.CategoryTheory.Filtered.CostructuredArrow
@@ -2619,6 +2621,7 @@ public import Mathlib.CategoryTheory.Idempotents.Karoubi
 public import Mathlib.CategoryTheory.Idempotents.KaroubiKaroubi
 public import Mathlib.CategoryTheory.Idempotents.SimplicialObject
 public import Mathlib.CategoryTheory.InducedCategory
+public import Mathlib.CategoryTheory.InternalCategory.Basic
 public import Mathlib.CategoryTheory.IsConnected
 public import Mathlib.CategoryTheory.Iso
 public import Mathlib.CategoryTheory.IsomorphismClasses
@@ -3149,6 +3152,7 @@ public import Mathlib.CategoryTheory.Sites.Descent.DescentDataPrime
 public import Mathlib.CategoryTheory.Sites.Descent.IsPrestack
 public import Mathlib.CategoryTheory.Sites.Descent.IsStack
 public import Mathlib.CategoryTheory.Sites.Descent.Precoverage
+public import Mathlib.CategoryTheory.Sites.Descent.SingleMorphism
 public import Mathlib.CategoryTheory.Sites.EffectiveEpimorphic
 public import Mathlib.CategoryTheory.Sites.EpiMono
 public import Mathlib.CategoryTheory.Sites.EqualizerSheafCondition

--- a/Mathlib/CategoryTheory/FiberedCategory/PseudofunctorOfFibers.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/PseudofunctorOfFibers.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 Elias Judin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Elias Judin
+-/
+
+module
+
+public import Mathlib.CategoryTheory.FiberedCategory.Reindexing
+public import Mathlib.CategoryTheory.Bicategory.Functor.LocallyDiscrete
+
+/-!
+# The pseudofunctor of fibers of a fibered category
+
+Let `pA : 𝒜 ⥤ C` be a fibered functor. For each `S : C`, we have the fiber category
+`Fiber pA S`, and for each morphism `f : R ⟶ S`, reindexing gives a functor
+`f^* : Fiber pA S ⥤ Fiber pA R`.
+
+This file packages the reindexing data into a pseudofunctor
+`LocallyDiscrete Cᵒᵖ ⥤ᵖ Cat`.
+
+Note: coherence constraints are discharged by
+`CategoryTheory.pseudofunctorOfIsLocallyDiscrete` via its default `by cat_disch` obligations.
+-/
+
+open CategoryTheory
+open CategoryTheory.Functor
+open Opposite
+
+@[expose] public section
+
+namespace CategoryTheory
+
+namespace FiberedCategory
+
+universe u v w
+
+variable {C : Type u} [Category.{v} C]
+variable {𝒜 : Type w} [Category.{v} 𝒜]
+
+noncomputable section
+
+/-- Fiber category object part for the pseudofunctor of fibers. -/
+abbrev fibers_obj (pA : 𝒜 ⥤ C) (X : LocallyDiscrete Cᵒᵖ) : Cat.{v, w} :=
+  Cat.of (Fiber pA (unop X.as))
+
+/-- Reindexing functor as the morphism part for the pseudofunctor of fibers. -/
+abbrev fibers_map (pA : 𝒜 ⥤ C) [pA.IsFibered] {X Y : LocallyDiscrete Cᵒᵖ}
+    (f : X ⟶ Y) : fibers_obj (pA := pA) X ⟶ fibers_obj (pA := pA) Y :=
+  (reindex (pA := pA) f.as.unop).toCatHom
+
+/-- Identity coherence for the morphism part of the pseudofunctor of fibers. -/
+abbrev fibers_mapId (pA : 𝒜 ⥤ C) [pA.IsFibered] (X : LocallyDiscrete Cᵒᵖ) :
+    fibers_map (pA := pA) (𝟙 X) ≅ 𝟙 (fibers_obj (pA := pA) X) :=
+  CategoryTheory.Cat.Hom.isoMk (by
+    simpa using (reindex_id_iso_nat_iso (pA := pA) (S := unop X.as)))
+
+/-- Composition coherence for the morphism part of the pseudofunctor of fibers. -/
+abbrev fibers_mapComp (pA : 𝒜 ⥤ C) [pA.IsFibered]
+    {X Y Z : LocallyDiscrete Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    fibers_map (pA := pA) (f ≫ g) ≅ fibers_map (pA := pA) f ≫ fibers_map (pA := pA) g :=
+  CategoryTheory.Cat.Hom.isoMk (by
+    simpa using (reindex_comp_iso (pA := pA) (g := g.as.unop) (f := f.as.unop)))
+
+/-- Associator coherence for the pseudofunctor of fibers. -/
+lemma fibers_map₂_associator (pA : 𝒜 ⥤ C) [pA.IsFibered] :
+    ∀ {X Y Z W : LocallyDiscrete Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ W),
+      (fibers_mapComp (pA := pA) (f ≫ g) h).hom ≫
+          Bicategory.whiskerRight (fibers_mapComp (pA := pA) f g).hom (fibers_map (pA := pA) h) ≫
+            (Bicategory.associator (fibers_map (pA := pA) f) (fibers_map (pA := pA) g)
+              (fibers_map (pA := pA) h)).hom ≫
+              Bicategory.whiskerLeft (fibers_map (pA := pA) f)
+                (fibers_mapComp (pA := pA) g h).inv ≫
+                (fibers_mapComp (pA := pA) f (g ≫ h)).inv =
+        eqToHom (by simp [fibers_map]) := by
+  intro X Y Z W f g h
+  ext a
+  apply Fiber.hom_ext
+  let φ : (reindexObj (pA := pA) ((h.as.unop ≫ g.as.unop) ≫ f.as.unop) a).1 ⟶ a.1 :=
+    IsPreFibered.pullbackMap (p := pA) a.2 ((h.as.unop ≫ g.as.unop) ≫ f.as.unop)
+  haveI : IsCartesian pA ((h.as.unop ≫ g.as.unop) ≫ f.as.unop) φ := by
+    dsimp [φ]
+    infer_instance
+  apply IsCartesian.ext (p := pA) (f := ((h.as.unop ≫ g.as.unop) ≫ f.as.unop)) (φ := φ)
+  trans IsPreFibered.pullbackMap (p := pA) a.2 (h.as.unop ≫ (g.as.unop ≫ f.as.unop))
+  · change
+      Fiber.fiberInclusion.map
+          (((fibers_mapComp (pA := pA) (f ≫ g) h).hom ≫
+                  Bicategory.whiskerRight (fibers_mapComp (pA := pA) f g).hom
+                    (fibers_map (pA := pA) h) ≫
+                (Bicategory.associator (fibers_map (pA := pA) f) (fibers_map (pA := pA) g)
+                  (fibers_map (pA := pA) h)).hom ≫
+              Bicategory.whiskerLeft (fibers_map (pA := pA) f)
+                (fibers_mapComp (pA := pA) g h).inv ≫
+            (fibers_mapComp (pA := pA) f (g ≫ h)).inv).toNatTrans.app a) ≫
+        φ =
+        IsPreFibered.pullbackMap (p := pA) a.2 (h.as.unop ≫ g.as.unop ≫ f.as.unop)
+    simp only [Cat.of_α, toCatHom_toFunctor, LocallyDiscrete.comp_as, unop_comp,
+      Cat.Hom.isoMk_hom, id_eq, Cat.Hom.isoMk_inv, Cat.Hom.toNatTrans_comp,
+      Cat.Hom.comp_toFunctor, NatTrans.toCatHom₂_toNatTrans, Cat.whiskerRight_toNatTrans,
+      Cat.associator_hom_toNatTrans, Cat.whiskerLeft_toNatTrans, NatTrans.comp_app, comp_obj,
+      reindex_comp_iso_hom_app, whiskerRight_app, associator_hom_app, whiskerLeft_app,
+      reindex_comp_iso_inv_app, Fiber.fiberInclusion, Category.id_comp, map_comp, Category.assoc]
+    change
+      (reindex_comp_iso_obj (pA := pA) h.as.unop (g.as.unop ≫ f.as.unop) a).hom.1 ≫
+        (((reindex (pA := pA) h.as.unop).map
+              (reindex_comp_iso_obj (pA := pA) g.as.unop f.as.unop a).hom).1 ≫
+            (reindex_comp_iso_obj (pA := pA) h.as.unop g.as.unop
+                ((reindex (pA := pA) f.as.unop).obj a)).inv.1 ≫
+            (reindex_comp_iso_obj (pA := pA) (h.as.unop ≫ g.as.unop) f.as.unop a).inv.1) ≫
+          IsPreFibered.pullbackMap (p := pA) a.2 ((h.as.unop ≫ g.as.unop) ≫ f.as.unop) =
+        IsPreFibered.pullbackMap (p := pA) a.2 (h.as.unop ≫ (g.as.unop ≫ f.as.unop))
+    simp only [Category.assoc]
+    rw [reindex_comp_iso_obj_inv_comp_pullback (pA := pA)
+      (g := h.as.unop ≫ g.as.unop) (f := f.as.unop) a]
+    rw [CategoryTheory.FiberedCategory.reindex_comp_iso_obj_inv_comp_pullback_assoc
+      (pA := pA) (g := h.as.unop) (f := g.as.unop)
+      (a := (reindex (pA := pA) f.as.unop).obj a)]
+    rw [reindex_map_comp_pullback_assoc (pA := pA) (f := h.as.unop)
+      (φ := (reindex_comp_iso_obj (pA := pA) g.as.unop f.as.unop a).hom)]
+    rw [reindex_comp_iso_obj_hom_comp_pullback (pA := pA) (g := g.as.unop) (f := f.as.unop) a]
+    exact
+      reindex_comp_iso_obj_hom_comp_pullback (pA := pA) (g := h.as.unop)
+        (f := g.as.unop ≫ f.as.unop) a
+  simpa only [φ, Fiber.fiberInclusion, Cat.Hom₂.eqToHom_toNatTrans, eqToHom_app,
+    reindex_obj_iso_of_eq_hom_eq_to_hom, Category.assoc] using
+    (reindex_obj_iso_of_eq_hom_comp_pullback (pA := pA)
+      (f := h.as.unop ≫ (g.as.unop ≫ f.as.unop))
+      (g := (h.as.unop ≫ g.as.unop) ≫ f.as.unop)
+      (h := by simp only [Category.assoc]) a).symm
+
+/-- Left unitor coherence for the pseudofunctor of fibers. -/
+lemma fibers_map₂_left_unitor (pA : 𝒜 ⥤ C) [pA.IsFibered] :
+    ∀ {X Y : LocallyDiscrete Cᵒᵖ} (f : X ⟶ Y),
+      (fibers_mapComp (pA := pA) (𝟙 X) f).hom ≫
+          Bicategory.whiskerRight (fibers_mapId (pA := pA) X).hom (fibers_map (pA := pA) f) ≫
+            (Bicategory.leftUnitor (fibers_map (pA := pA) f)).hom =
+        eqToHom (by simp [fibers_map]) := by
+  intro X Y f
+  ext a
+  apply Fiber.hom_ext
+  let φ : (reindexObj (pA := pA) f.as.unop a).1 ⟶ a.1 :=
+    IsPreFibered.pullbackMap (p := pA) a.2 f.as.unop
+  haveI : IsCartesian pA f.as.unop φ := by
+    dsimp [φ]
+    infer_instance
+  apply IsCartesian.ext (p := pA) (f := f.as.unop) (φ := φ)
+  simp [φ, fibers_map, fibers_mapComp, fibers_mapId, Fiber.fiberInclusion, reindex_id_iso_hom_eq,
+    reindex_comp_iso_obj_hom_comp_pullback, Category.assoc]
+  simpa [reindex, reindex_id_iso, fiber_iso, Category.assoc] using
+    (reindex_obj_iso_of_eq_hom_comp_pullback (pA := pA)
+      (f := f.as.unop ≫ 𝟙 (unop X.as))
+      (g := f.as.unop)
+      (h := by simp) a).symm
+
+/-- Right unitor coherence for the pseudofunctor of fibers. -/
+lemma fibers_map₂_right_unitor (pA : 𝒜 ⥤ C) [pA.IsFibered] :
+    ∀ {X Y : LocallyDiscrete Cᵒᵖ} (f : X ⟶ Y),
+      (fibers_mapComp (pA := pA) f (𝟙 Y)).hom ≫
+          Bicategory.whiskerLeft (fibers_map (pA := pA) f) (fibers_mapId (pA := pA) Y).hom ≫
+            (Bicategory.rightUnitor (fibers_map (pA := pA) f)).hom =
+        eqToHom (by simp [fibers_map]) := by
+  intro X Y f
+  ext a
+  apply Fiber.hom_ext
+  let φ : (reindexObj (pA := pA) f.as.unop a).1 ⟶ a.1 :=
+    IsPreFibered.pullbackMap (p := pA) a.2 f.as.unop
+  haveI : IsCartesian pA f.as.unop φ := by
+    dsimp [φ]
+    infer_instance
+  apply IsCartesian.ext (p := pA) (f := f.as.unop) (φ := φ)
+  simp [φ, fibers_map, fibers_mapComp, fibers_mapId, Fiber.fiberInclusion, reindex_id_iso_hom_eq,
+    reindex_comp_iso_obj_hom_comp_pullback, Category.assoc]
+  simpa [Category.assoc] using
+    (reindex_obj_iso_of_eq_hom_comp_pullback (pA := pA)
+      (f := 𝟙 (unop Y.as) ≫ f.as.unop)
+      (g := f.as.unop)
+      (h := by simp) a).symm
+
+/-- The pseudofunctor of fibers associated to a fibered functor `pA : 𝒜 ⥤ C`. -/
+noncomputable def pseudofunctor_of_fibers (pA : 𝒜 ⥤ C) [pA.IsFibered] :
+    Pseudofunctor (LocallyDiscrete Cᵒᵖ) Cat.{v, w} :=
+  CategoryTheory.pseudofunctorOfIsLocallyDiscrete
+    (B := LocallyDiscrete Cᵒᵖ) (C := Cat.{v, w})
+    (obj := fibers_obj (pA := pA))
+    (map := fun f => fibers_map (pA := pA) f)
+    (mapId := fibers_mapId (pA := pA))
+    (mapComp := fun f g => fibers_mapComp (pA := pA) f g)
+    (map₂_associator := fibers_map₂_associator (pA := pA))
+    (map₂_left_unitor := fibers_map₂_left_unitor (pA := pA))
+    (map₂_right_unitor := fibers_map₂_right_unitor (pA := pA))
+
+@[simp]
+lemma pseudofunctor_of_fibers_obj (pA : 𝒜 ⥤ C) [pA.IsFibered] (S : C) :
+    (pseudofunctor_of_fibers (pA := pA)).obj (.mk (op S)) = Cat.of (Fiber pA S) :=
+  rfl
+
+@[simp]
+lemma pseudofunctor_of_fibers_map {pA : 𝒜 ⥤ C} [pA.IsFibered]
+    {R S : C} (f : R ⟶ S) :
+    (pseudofunctor_of_fibers (pA := pA)).map f.op.toLoc =
+      (reindex (pA := pA) f).toCatHom := by
+  rfl
+
+end
+
+end FiberedCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/FiberedCategory/Reindexing.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Reindexing.lean
@@ -1,0 +1,383 @@
+/-
+Copyright (c) 2024 Elias Judin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Elias Judin
+-/
+
+module
+
+public import Mathlib.CategoryTheory.FiberedCategory.HasFibers
+
+/-!
+# Reindexing on fibers of a fibered category
+
+Defines reindexing functors `f^* : Fiber p S ⥤ Fiber p R` for a fibered functor `p : 𝒜 ⥤ C`,
+together with the basic coherence isomorphisms for composition and identity.
+
+This file is intended as an upstream candidate: it lives in the namespace
+`CategoryTheory.FiberedCategory`. The `Descent` library re-exports this API.
+-/
+
+open CategoryTheory
+open CategoryTheory.Functor
+
+@[expose] public section
+
+namespace CategoryTheory
+
+namespace FiberedCategory
+
+universe u v w
+
+variable {C : Type u} [Category.{v} C]
+variable {𝒜 : Type w} [Category.{v} 𝒜] (pA : 𝒜 ⥤ C) [pA.IsFibered]
+
+noncomputable section
+
+/-!
+## Reindexing on standard fibers
+-/
+
+/-- Reindexing (pullback) functor on the standard fibers of a fibered category. -/
+def reindex {R S : C} (f : R ⟶ S) : Fiber pA S ⥤ Fiber pA R where
+  obj a :=
+    ⟨IsPreFibered.pullbackObj (p := pA) a.2 f,
+      IsPreFibered.pullbackObj_proj (p := pA) a.2 f⟩
+  map {a b} φ := by
+    haveI : pA.IsHomLift (𝟙 S) φ.1 := φ.2
+    haveI : pA.IsHomLift f (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1) := by
+      simpa using
+        (inferInstance :
+          pA.IsHomLift (f ≫ 𝟙 S) (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1))
+    refine
+      ⟨IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) b.2 f)
+          (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1),
+        inferInstance⟩
+  map_id a := by
+    apply Fiber.hom_ext
+    change
+        IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) a.2 f)
+            (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ (𝟙 a.1))
+          = 𝟙 (IsPreFibered.pullbackObj (p := pA) a.2 f)
+    simp
+  map_comp {a b c} φ ψ := by
+    apply Fiber.hom_ext
+    haveI : pA.IsHomLift (𝟙 S) φ.1 := φ.2
+    haveI : pA.IsHomLift (𝟙 S) ψ.1 := ψ.2
+    haveI : pA.IsHomLift f (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1) := by
+      simpa using
+        (inferInstance :
+          pA.IsHomLift (f ≫ 𝟙 S) (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1))
+    haveI : pA.IsHomLift f (IsPreFibered.pullbackMap (p := pA) b.2 f ≫ ψ.1) := by
+      simpa using
+        (inferInstance :
+          pA.IsHomLift (f ≫ 𝟙 S) (IsPreFibered.pullbackMap (p := pA) b.2 f ≫ ψ.1))
+    haveI : pA.IsHomLift (𝟙 S) (φ.1 ≫ ψ.1) := by
+      simpa using (inferInstance : pA.IsHomLift (𝟙 S ≫ 𝟙 S) (φ.1 ≫ ψ.1))
+    haveI : pA.IsHomLift f (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ (φ.1 ≫ ψ.1)) := by
+      simpa [Category.assoc] using
+        (inferInstance :
+          pA.IsHomLift (f ≫ 𝟙 S) (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ (φ.1 ≫ ψ.1)))
+    change
+        IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) c.2 f)
+            (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ (φ.1 ≫ ψ.1))
+          =
+          IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) b.2 f)
+              (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1)
+            ≫
+            IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) c.2 f)
+              (IsPreFibered.pullbackMap (p := pA) b.2 f ≫ ψ.1)
+    let θ :=
+      IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) b.2 f)
+          (IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1)
+        ≫
+        IsCartesian.map pA f (IsPreFibered.pullbackMap (p := pA) c.2 f)
+          (IsPreFibered.pullbackMap (p := pA) b.2 f ≫ ψ.1)
+    haveI : pA.IsHomLift (𝟙 R) θ := by
+      dsimp [θ]
+      infer_instance
+    symm
+    apply
+      (IsCartesian.map_uniq (p := pA) (f := f)
+        (φ := IsPreFibered.pullbackMap (p := pA) c.2 f)
+        (φ' := IsPreFibered.pullbackMap (p := pA) a.2 f ≫ (φ.1 ≫ ψ.1)) θ)
+    dsimp [θ]
+    simp [Category.assoc]
+
+/-- The object part of `reindex`. -/
+abbrev reindexObj {R S : C} (f : R ⟶ S) (a : Fiber pA S) : Fiber pA R :=
+  (reindex (pA := pA) f).obj a
+
+@[simp, reassoc]
+lemma reindex_map_comp_pullback {R S : C} (f : R ⟶ S) {a b : Fiber pA S} (φ : a ⟶ b) :
+    ((reindex (pA := pA) f).map φ).1 ≫ IsPreFibered.pullbackMap (p := pA) b.2 f =
+      IsPreFibered.pullbackMap (p := pA) a.2 f ≫ φ.1 := by
+  dsimp [reindex]
+  simp
+
+/-!
+## Auxiliary isomorphisms
+-/
+
+/-- Lift an isomorphism in the total category to an isomorphism in a fiber. -/
+def fiber_iso {S : C} {a b : Fiber pA S} (i : a.1 ≅ b.1)
+    (hi : pA.IsHomLift (𝟙 S) i.hom) : a ≅ b where
+  hom := ⟨i.hom, hi⟩
+  inv :=
+    ⟨i.inv, by
+      haveI : pA.IsHomLift (𝟙 S) i.hom := hi
+      infer_instance⟩
+  hom_inv_id := by
+    apply Fiber.hom_ext
+    change i.hom ≫ i.inv = 𝟙 a.1
+    exact i.hom_inv_id
+  inv_hom_id := by
+    apply Fiber.hom_ext
+    change i.inv ≫ i.hom = 𝟙 b.1
+    exact i.inv_hom_id
+
+/-- If `f = g`, then `f^* a ≅ g^* a`. -/
+def reindex_obj_iso_of_eq {R S : C} {f g : R ⟶ S} (h : f = g) (a : Fiber pA S) :
+    reindexObj (pA := pA) f a ≅ reindexObj (pA := pA) g a := by
+  subst h
+  exact Iso.refl _
+
+@[simp]
+lemma reindex_obj_iso_of_eq_hom_eq_to_hom {R S : C} {f g : R ⟶ S} (h : f = g) (a : Fiber pA S) :
+    (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h a).hom =
+      eqToHom (by
+        cases h
+        rfl) := by
+  cases h
+  rfl
+
+@[simp]
+lemma reindex_obj_iso_of_eq_inv_eq_to_hom {R S : C} {f g : R ⟶ S} (h : f = g) (a : Fiber pA S) :
+    (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h a).inv =
+      eqToHom (by
+        cases h
+        rfl) := by
+  cases h
+  rfl
+
+lemma reindex_obj_iso_of_eq_hom_naturality {R S : C} {f g : R ⟶ S} (h : f = g)
+    {a b : Fiber pA S} (φ : a ⟶ b) :
+    (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h a).hom ≫
+        (reindex (pA := pA) g).map φ =
+      (reindex (pA := pA) f).map φ ≫
+        (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h b).hom := by
+  subst h
+  simp [reindex_obj_iso_of_eq]
+
+lemma reindex_obj_iso_of_eq_inv_naturality {R S : C} {f g : R ⟶ S} (h : f = g)
+    {a b : Fiber pA S} (φ : a ⟶ b) :
+    (reindex (pA := pA) g).map φ ≫
+        (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h b).inv =
+      (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h a).inv ≫
+        (reindex (pA := pA) f).map φ := by
+  subst h
+  simp [reindex_obj_iso_of_eq]
+
+/-- Compatibility of `reindex_obj_iso_of_eq` with the chosen pullback maps. -/
+@[reassoc]
+lemma reindex_obj_iso_of_eq_hom_comp_pullback {R S : C} {f g : R ⟶ S} (h : f = g)
+    (a : Fiber pA S) :
+    (reindex_obj_iso_of_eq (pA := pA) (f := f) (g := g) h a).hom.1 ≫
+        IsPreFibered.pullbackMap (p := pA) a.2 g =
+      IsPreFibered.pullbackMap (p := pA) a.2 f := by
+  subst h
+  change (𝟙 (IsPreFibered.pullbackObj (p := pA) a.2 f)) ≫
+      IsPreFibered.pullbackMap (p := pA) a.2 f =
+    IsPreFibered.pullbackMap (p := pA) a.2 f
+  simp
+
+/-- The canonical isomorphism `(g ≫ f)^* a ≅ g^* (f^* a)`. -/
+def reindex_comp_iso_obj {T R S : C} (g : T ⟶ R) (f : R ⟶ S) (a : Fiber pA S) :
+    reindexObj (pA := pA) (g ≫ f) a ≅
+      reindexObj (pA := pA) g (reindexObj (pA := pA) f a) := by
+  refine
+    fiber_iso (pA := pA) (S := T)
+      (Functor.IsFibered.pullbackPullbackIso (p := pA) a.2 f g) ?_
+  dsimp [Functor.IsFibered.pullbackPullbackIso]
+  infer_instance
+
+/-- A simp-lemma characterizing the defining property of `pullbackPullbackIso`. -/
+@[simp, reassoc]
+lemma pullback_pullback_iso_hom_comp {R S T : C} {a : 𝒜} (ha : pA.obj a = S) (f : R ⟶ S)
+    (g : T ⟶ R) :
+    (Functor.IsFibered.pullbackPullbackIso (p := pA) ha f g).hom ≫
+        IsPreFibered.pullbackMap (p := pA) (IsPreFibered.pullbackObj_proj (p := pA) ha f) g ≫
+          IsPreFibered.pullbackMap (p := pA) ha f =
+      IsPreFibered.pullbackMap (p := pA) ha (g ≫ f) := by
+  dsimp [Functor.IsFibered.pullbackPullbackIso, IsCartesian.domainUniqueUpToIso]
+  simp
+
+/-- A simp-lemma characterizing the defining property of the inverse of `pullbackPullbackIso`. -/
+@[simp, reassoc]
+lemma pullback_pullback_iso_inv_comp {R S T : C} {a : 𝒜} (ha : pA.obj a = S) (f : R ⟶ S)
+    (g : T ⟶ R) :
+    (Functor.IsFibered.pullbackPullbackIso (p := pA) ha f g).inv ≫
+        IsPreFibered.pullbackMap (p := pA) ha (g ≫ f) =
+      IsPreFibered.pullbackMap (p := pA) (IsPreFibered.pullbackObj_proj (p := pA) ha f) g ≫
+        IsPreFibered.pullbackMap (p := pA) ha f := by
+  dsimp [Functor.IsFibered.pullbackPullbackIso, IsCartesian.domainUniqueUpToIso]
+  simp
+
+/-- Naturality of `reindex_comp_iso_obj` with respect to morphisms in the fiber. -/
+lemma reindex_comp_iso_obj_hom_naturality {T R S : C} (g : T ⟶ R) (f : R ⟶ S)
+    {a b : Fiber pA S} (φ : a ⟶ b) :
+    (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a).hom ≫
+        (reindex (pA := pA) g).map ((reindex (pA := pA) f).map φ) =
+      (reindex (pA := pA) (g ≫ f)).map φ ≫
+        (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) b).hom := by
+  apply Fiber.hom_ext
+  let φb :
+      (reindexObj (pA := pA) g (reindexObj (pA := pA) f b)).1 ⟶ b.1 :=
+    IsPreFibered.pullbackMap (p := pA) (IsPreFibered.pullbackObj_proj (p := pA) b.2 f) g ≫
+      IsPreFibered.pullbackMap (p := pA) b.2 f
+  haveI : IsCartesian pA (g ≫ f) φb := by
+    dsimp [φb]
+    infer_instance
+  apply IsCartesian.ext (p := pA) (f := g ≫ f) (φ := φb)
+  dsimp [φb, reindex, reindex_comp_iso_obj, fiber_iso, Functor.IsFibered.pullbackPullbackIso]
+  simp [Fiber.fiberInclusion, Category.assoc]
+  simpa [Category.assoc] using
+    (IsCartesian.fac_assoc (p := pA) (f := g ≫ f)
+        (φ :=
+          IsPreFibered.pullbackMap (p := pA) (IsPreFibered.pullbackObj_proj (p := pA) a.2 f) g ≫
+            IsPreFibered.pullbackMap (p := pA) a.2 f)
+        (φ' := IsPreFibered.pullbackMap (p := pA) a.2 (g ≫ f)) (h := φ.1))
+
+/-- Naturality of the inverse of `reindex_comp_iso_obj`. -/
+lemma reindex_comp_iso_obj_inv_naturality {T R S : C} (g : T ⟶ R) (f : R ⟶ S)
+    {a b : Fiber pA S} (φ : a ⟶ b) :
+    (reindex (pA := pA) g).map ((reindex (pA := pA) f).map φ) ≫
+        (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) b).inv =
+      (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a).inv ≫
+        (reindex (pA := pA) (g ≫ f)).map φ := by
+  simpa [Category.assoc] using
+    congrArg (fun k => (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a).inv ≫ k ≫
+        (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) b).inv)
+      (reindex_comp_iso_obj_hom_naturality (pA := pA) (g := g) (f := f) (a := a) (b := b) φ)
+
+/-- The canonical isomorphism `((𝟙 S)^* a) ≅ a`. -/
+def reindex_id_iso {S : C} (a : Fiber pA S) : reindexObj (pA := pA) (𝟙 S) a ≅ a := by
+  haveI : IsIso (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S)) := by
+    haveI : pA.IsStronglyCartesian (𝟙 S) (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S)) := by
+      infer_instance
+    exact
+      IsStronglyCartesian.isIso_of_base_isIso (p := pA) (f := 𝟙 S)
+        (φ := IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S))
+  refine
+    fiber_iso (pA := pA) (S := S)
+      (a := reindexObj (pA := pA) (𝟙 S) a)
+      (b := a)
+      (asIso (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S))) ?_
+  change pA.IsHomLift (𝟙 S) (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S))
+  infer_instance
+
+/-- The natural isomorphism `reindex (𝟙 S) ≅ 𝟭 _`. -/
+def reindex_id_iso_nat_iso {S : C} :
+    reindex (pA := pA) (𝟙 S) ≅ 𝟭 (Fiber pA S) := by
+  refine NatIso.ofComponents (fun a => reindex_id_iso (pA := pA) a) fun {a b} φ ↦ ?_
+  haveI : pA.IsHomLift (𝟙 S) φ.1 := φ.2
+  haveI :
+      pA.IsHomLift (𝟙 S)
+        (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S) ≫ φ.1) := by
+    simpa using
+      (inferInstance :
+        pA.IsHomLift (𝟙 S ≫ 𝟙 S)
+          (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S) ≫ φ.1))
+  apply Fiber.hom_ext
+  change
+      (IsCartesian.map pA (𝟙 S) (IsPreFibered.pullbackMap (p := pA) b.2 (𝟙 S))
+          (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S) ≫ φ.1)) ≫
+        (IsPreFibered.pullbackMap (p := pA) b.2 (𝟙 S)) =
+      (IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S)) ≫ φ.1
+  simp
+
+/-- The natural isomorphism `(g ≫ f)^* ≅ f^* ⋙ g^*` on fibers. -/
+def reindex_comp_iso {T R S : C} (g : T ⟶ R) (f : R ⟶ S) :
+    reindex (pA := pA) (g ≫ f) ≅ (reindex (pA := pA) f) ⋙ (reindex (pA := pA) g) := by
+  refine
+    NatIso.ofComponents
+      (fun a ↦ reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a)
+      (fun {a b} φ ↦
+        (reindex_comp_iso_obj_hom_naturality (pA := pA) (g := g) (f := f)
+            (a := a) (b := b) φ).symm)
+
+@[simp]
+lemma reindex_id_iso_nat_iso_hom_app {S : C} (a : Fiber pA S) :
+    (reindex_id_iso_nat_iso (pA := pA) (S := S)).hom.app a =
+      (reindex_id_iso (pA := pA) a).hom := rfl
+
+@[simp]
+lemma reindex_id_iso_nat_iso_inv_app {S : C} (a : Fiber pA S) :
+    (reindex_id_iso_nat_iso (pA := pA) (S := S)).inv.app a =
+      (reindex_id_iso (pA := pA) a).inv := rfl
+
+@[simp]
+lemma reindex_comp_iso_hom_app {T R S : C} (g : T ⟶ R) (f : R ⟶ S) (a : Fiber pA S) :
+    (reindex_comp_iso (pA := pA) (g := g) (f := f)).hom.app a =
+      (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a).hom := rfl
+
+@[simp]
+lemma reindex_comp_iso_inv_app {T R S : C} (g : T ⟶ R) (f : R ⟶ S) (a : Fiber pA S) :
+    (reindex_comp_iso (pA := pA) (g := g) (f := f)).inv.app a =
+      (reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a).inv := rfl
+
+/-!
+## Coherence laws
+
+We record the standard coherence conventions for reindexing on fibers and
+their interaction with the chosen Cartesian lifts.
+-/
+
+/-- Explicit statement of the reindexing convention: `(g ≫ f)^*` is naturally isomorphic
+to `f^* ⋙ g^*` (note: `f^*` first, then `g^*`). -/
+def reindex_comp_iso_comp_reindex {T R S : C} (g : T ⟶ R) (f : R ⟶ S) :
+    ∀ a : Fiber pA S,
+      reindexObj (pA := pA) (g ≫ f) a ≅
+        reindexObj (pA := pA) g (reindexObj (pA := pA) f a) :=
+  fun a => reindex_comp_iso_obj (pA := pA) (g := g) (f := f) a
+
+/-- The composition coherence isomorphism factors through the underlying Cartesian lifts.
+
+This lemma characterizes `reindex_comp_iso_obj` in terms of the universal property:
+the hom component, when composed with the iterated Cartesian lifts, equals the
+Cartesian lift for the composed morphism. -/
+@[simp, reassoc]
+lemma reindex_comp_iso_obj_hom_comp_pullback {T R S : C} (g : T ⟶ R) (f : R ⟶ S)
+    (a : Fiber pA S) :
+    (reindex_comp_iso_obj (pA := pA) g f a).hom.1 ≫
+      IsPreFibered.pullbackMap (p := pA)
+          (IsPreFibered.pullbackObj_proj (p := pA) a.2 f) g ≫
+        IsPreFibered.pullbackMap (p := pA) a.2 f =
+    IsPreFibered.pullbackMap (p := pA) a.2 (g ≫ f) := by
+  simp [reindex_comp_iso_obj, fiber_iso, reindexObj,
+    Functor.IsFibered.pullbackPullbackIso, IsCartesian.domainUniqueUpToIso]
+
+/-- The inverse of the composition coherence isomorphism. -/
+@[simp, reassoc]
+lemma reindex_comp_iso_obj_inv_comp_pullback {T R S : C} (g : T ⟶ R) (f : R ⟶ S)
+    (a : Fiber pA S) :
+    (reindex_comp_iso_obj (pA := pA) g f a).inv.1 ≫
+      IsPreFibered.pullbackMap (p := pA) a.2 (g ≫ f) =
+    IsPreFibered.pullbackMap (p := pA)
+        (IsPreFibered.pullbackObj_proj (p := pA) a.2 f) g ≫
+      IsPreFibered.pullbackMap (p := pA) a.2 f := by
+  simp [reindex_comp_iso_obj, fiber_iso, reindexObj,
+    Functor.IsFibered.pullbackPullbackIso, IsCartesian.domainUniqueUpToIso]
+
+/-- The identity coherence `reindex_id_iso` sends the chosen pullback along `𝟙 S` to the identity.
+
+Specifically, `(reindex_id_iso a).hom.1` is the Cartesian lift along `𝟙 S`. -/
+lemma reindex_id_iso_hom_eq {S : C} (a : Fiber pA S) :
+    (reindex_id_iso (pA := pA) a).hom.1 = IsPreFibered.pullbackMap (p := pA) a.2 (𝟙 S) := by
+  simp [reindex_id_iso, fiber_iso]
+
+end
+
+end FiberedCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/InternalCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/InternalCategory/Basic.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 Elias Judin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Elias Judin
+-/
+
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+
+/-!
+# Internal categories
+
+This file provides a small, standalone record for an **internal category** in a category `C` with
+pullbacks.
+
+Mathlib does not currently provide a general internal-category theory (in the sense of “category
+objects”). Since *Facets of Descent, II* uses internal categories prominently, we introduce this
+minimal structure locally, designed to be upstreamable.
+
+## Convention
+
+We use the pullback `pullback dom cod` as the object of composable pairs. In this convention, an
+element of `pullback dom cod` should be thought of as a pair `(f, g)` with `dom f = cod g`, and
+`comp` returns the composite `g ≫ f`.
+-/
+
+open CategoryTheory
+
+@[expose] public section
+
+namespace CategoryTheory
+
+universe u v
+
+variable {C : Type u} [Category.{v} C] [Limits.HasPullbacks C]
+
+noncomputable section
+
+/-- An internal category in a category with pullbacks. -/
+structure InternalCategory where
+  /-- The object of objects. -/
+  obj : C
+  /-- The object of morphisms. -/
+  hom : C
+  /-- The domain map `hom ⟶ obj`. -/
+  dom : hom ⟶ obj
+  /-- The codomain map `hom ⟶ obj`. -/
+  cod : hom ⟶ obj
+  /-- The identity-assigning map `obj ⟶ hom`. -/
+  id : obj ⟶ hom
+  /-- The composition map on composable pairs. -/
+  comp : Limits.pullback dom cod ⟶ hom
+  /-- `dom (id x) = x`. -/
+  id_comp_dom : id ≫ dom = 𝟙 obj
+  /-- `cod (id x) = x`. -/
+  id_comp_cod : id ≫ cod = 𝟙 obj
+  /-- `dom (g ≫ f) = dom g`. -/
+  comp_comp_dom : comp ≫ dom = Limits.pullback.snd dom cod ≫ dom
+  /-- `cod (g ≫ f) = cod f`. -/
+  comp_comp_cod : comp ≫ cod = Limits.pullback.fst dom cod ≫ cod
+  /-- Right identity: `f ≫ id (cod f) = f`. -/
+  comp_id :
+      Limits.pullback.lift (cod ≫ id) (𝟙 hom) (by
+          simp [Category.assoc, id_comp_dom]) ≫
+        comp =
+      𝟙 hom
+  /-- Left identity: `id (dom f) ≫ f = f`. -/
+  id_comp :
+      Limits.pullback.lift (𝟙 hom) (dom ≫ id) (by
+          simp [Category.assoc, id_comp_cod]) ≫
+        comp =
+      𝟙 hom
+  /-- Associativity of composition. -/
+  assoc :
+      let compObj := Limits.pullback dom cod
+      let assocObj :=
+        Limits.pullback (Limits.pullback.snd dom cod) (Limits.pullback.fst dom cod)
+      let π12 : assocObj ⟶ compObj := Limits.pullback.fst _ _
+      let π23 : assocObj ⟶ compObj := Limits.pullback.snd _ _
+      let assocLeft : assocObj ⟶ compObj :=
+        Limits.pullback.lift (π12 ≫ comp) (π23 ≫ Limits.pullback.snd dom cod) (by
+          have h_assoc :
+              π12 ≫ Limits.pullback.snd dom cod =
+                π23 ≫ Limits.pullback.fst dom cod := by
+            simpa [Category.assoc] using
+              (Limits.pullback.condition (f := Limits.pullback.snd dom cod)
+                (g := Limits.pullback.fst dom cod))
+          have h_comp :
+              Limits.pullback.fst dom cod ≫ dom =
+                Limits.pullback.snd dom cod ≫ cod := by
+            simpa using (Limits.pullback.condition (f := dom) (g := cod))
+          calc
+            (π12 ≫ comp) ≫ dom = (π12 ≫ Limits.pullback.snd dom cod) ≫ dom := by
+              simpa [Category.assoc] using congrArg (fun k => π12 ≫ k) comp_comp_dom
+            _ = (π23 ≫ Limits.pullback.fst dom cod) ≫ dom := by
+              simpa [Category.assoc] using congrArg (fun k => k ≫ dom) h_assoc
+            _ = (π23 ≫ Limits.pullback.snd dom cod) ≫ cod := by
+              simpa [Category.assoc] using congrArg (fun k => π23 ≫ k) h_comp)
+      let assocRight : assocObj ⟶ compObj :=
+        Limits.pullback.lift (π12 ≫ Limits.pullback.fst dom cod) (π23 ≫ comp) (by
+          calc
+            (π12 ≫ Limits.pullback.fst dom cod) ≫ dom =
+                (π12 ≫ Limits.pullback.snd dom cod) ≫ cod := by
+              simpa [Category.assoc] using
+                congrArg (fun k => π12 ≫ k) (Limits.pullback.condition (f := dom) (g := cod))
+            _ = (π23 ≫ Limits.pullback.fst dom cod) ≫ cod := by
+              simpa [Category.assoc] using
+                congrArg (fun k => k ≫ cod)
+                  (Limits.pullback.condition (f := Limits.pullback.snd dom cod)
+                    (g := Limits.pullback.fst dom cod))
+            _ = (π23 ≫ comp) ≫ cod := by
+              simpa [Category.assoc] using congrArg (fun k => π23 ≫ k) comp_comp_cod.symm)
+      assocLeft ≫ comp = assocRight ≫ comp
+
+namespace InternalCategory
+
+attribute [simp, reassoc] id_comp_dom id_comp_cod comp_comp_dom comp_comp_cod
+
+end InternalCategory
+
+end
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Descent/SingleMorphism.lean
+++ b/Mathlib/CategoryTheory/Sites/Descent/SingleMorphism.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 Elias Judin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Elias Judin
+-/
+
+module
+
+public import Mathlib.CategoryTheory.Sites.Descent.DescentData
+
+/-!
+# Descent data along a single morphism (Mathlib singleton family)
+
+Mathlib’s descent theory is formulated for families of morphisms `f i : X i ⟶ S` via the
+category `CategoryTheory.Pseudofunctor.DescentData F f` and the comparison functor
+`CategoryTheory.Pseudofunctor.toDescentData F f`.
+
+For a single morphism `p : E ⟶ B`, the relevant family is the singleton family
+`fun _ : PUnit => p`. This file provides abbreviations for this special case, together with the
+associated “descent” and “effective descent” predicates.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+open Opposite
+
+namespace Pseudofunctor
+
+universe t v' v u' u
+
+variable {C : Type u} [Category.{v} C]
+variable (F : Pseudofunctor (LocallyDiscrete Cᵒᵖ) Cat.{v', u'})
+
+section
+
+variable {E B : C} (p : E ⟶ B)
+
+/-- The category of descent data for a single morphism `p : E ⟶ B`,
+as `F.DescentData` for the singleton family `fun _ : PUnit => p`. -/
+abbrev SingleMorphismDescentData : Type _ :=
+  F.DescentData (f := fun _ : PUnit.{1} ↦ p)
+
+/-- The comparison functor for descent data along `p : E ⟶ B`,
+i.e. `F.toDescentData` for the singleton family. -/
+abbrev singleMorphismComparisonFunctor :
+    F.obj (.mk (op B)) ⥤ F.DescentData (f := fun _ : PUnit.{1} ↦ p) :=
+  F.toDescentData (f := fun _ : PUnit.{1} ↦ p)
+
+/-- `p` is a descent morphism for `F` if the comparison functor is fully faithful. -/
+abbrev IsDescentMorphism : Prop :=
+  Nonempty (singleMorphismComparisonFunctor (F := F) p).FullyFaithful
+
+/-- `p` is an effective descent morphism for `F` if the comparison functor is an equivalence. -/
+abbrev IsEffectiveDescentMorphism : Prop :=
+  (singleMorphismComparisonFunctor (F := F) p).IsEquivalence
+
+end
+
+end Pseudofunctor
+
+end CategoryTheory


### PR DESCRIPTION
## Summary

- **FiberedCategory**: `PseudofunctorOfFibers.lean` (pseudofunctor of fibers for a fibered category), `Reindexing.lean` (reindexing functors and coherence isos)
- **InternalCategory**: `Basic.lean` (minimal internal category structure over a category with pullbacks)
- **Sites/Descent**: `SingleMorphism.lean` (descent data and comparison functor for a single morphism; `IsDescentMorphism` / `IsEffectiveDescentMorphism`)
- **Mathlib.lean**: import updates

Naming follows mathlib convention (e.g. `singleMorphismComparisonFunctor` in lowerCamelCase for definitions).