### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Preserves/FunctorCategory): add `ReflectsLimitsOfShape` instance for `whiskeringRight`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
@@ -130,6 +130,12 @@ instance whiskeringRight_preservesLimitsOfShape {C : Type*} [Category* C] {D : T
       change IsLimit (((evaluation _ _).obj k ⋙ F).mapCone c)
       exact isLimitOfPreserves _ hc⟩⟩⟩
 
+instance whiskeringRight_reflectsLimitsOfShape {C : Type*} [Category* C] {D : Type*}
+    [Category* D] {E : Type*} [Category* E] {J : Type*} [Category* J]
+    [HasLimitsOfShape J D] (F : D ⥤ E) [F.ReflectsIsomorphisms] [PreservesLimitsOfShape J F] :
+    ReflectsLimitsOfShape J ((whiskeringRight C D E).obj F) :=
+  reflectsLimitsOfShape_of_reflectsIsomorphisms
+
 /-- Whiskering right and then taking a limit is the same as taking the limit and applying the
 functor. -/
 def limitCompWhiskeringRightIsoLimitComp {C : Type*} [Category* C] {D : Type*}

--- a/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
@@ -130,7 +130,7 @@ instance whiskeringRight_preservesLimitsOfShape {C : Type*} [Category* C] {D : T
       change IsLimit (((evaluation _ _).obj k ⋙ F).mapCone c)
       exact isLimitOfPreserves _ hc⟩⟩⟩
 
-instance whiskeringRight_reflectsLimitsOfShape {C : Type*} [Category* C] {D : Type*}
+instance {C : Type*} [Category* C] {D : Type*}
     [Category* D] {E : Type*} [Category* E] {J : Type*} [Category* J]
     [HasLimitsOfShape J D] (F : D ⥤ E) [F.ReflectsIsomorphisms] [PreservesLimitsOfShape J F] :
     ReflectsLimitsOfShape J ((whiskeringRight C D E).obj F) :=

--- a/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
@@ -136,6 +136,15 @@ instance {C : Type*} [Category* C] {D : Type*}
     ReflectsLimitsOfShape J ((whiskeringRight C D E).obj F) :=
   reflectsLimitsOfShape_of_reflectsIsomorphisms
 
+instance {C : Type*} [Category* C] {D : Type*}
+    [Category* D] {E : Type*} [Category* E] {J : Type*} [Category* J]
+    [HasLimitsOfShape J E] (F : D ⥤ E) [ReflectsLimitsOfShape J F] :
+    ReflectsLimitsOfShape J ((whiskeringRight C D E).obj F) :=
+  ⟨fun {K} ↦ ⟨fun {c} hc ↦ ⟨by
+    apply evaluationJointlyReflectsLimits _ (fun k ↦ ?_)
+    apply isLimitOfReflects F
+    exact isLimitOfPreserves ((evaluation C E).obj k) hc⟩⟩⟩
+
 /-- Whiskering right and then taking a limit is the same as taking the limit and applying the
 functor. -/
 def limitCompWhiskeringRightIsoLimitComp {C : Type*} [Category* C] {D : Type*}


### PR DESCRIPTION
This PR adds an `ReflectsLimitsOfShape` instance for `whiskeringRight`, analogous to the existing `PreservesLimitsOfShape` instance.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
