### PR TITLE
[Merged by Bors] - feat(LinearAlgebra): dimension of `P →ᵃ[R] W`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
@@ -697,6 +697,45 @@ end arrowCongr
 
 end CommRing
 
+section congrLeft
+
+variable (R W : Type*) [Ring R] [AddCommGroup W] [Module k W] [Module R W] [SMulCommClass k R W]
+  (e : P₁ ≃ᵃ[k] P₂)
+
+/-- An affine isomorphism between the domains of affine spaces induces a linear isomorphism over
+another ring between the two function spaces. -/
+def congrLeftₗ : (P₁ →ᵃ[k] W) ≃ₗ[R] (P₂ →ᵃ[k] W) where
+  __ := e.arrowCongrEquiv (.refl k W)
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+
+@[simp]
+theorem congrLeftₗ_apply (f : P₁ →ᵃ[k] W) (x : P₂) : e.congrLeftₗ R W f x = f (e.symm x) :=
+  rfl
+
+@[simp]
+theorem congrLeftₗ_symm_apply (f : P₂ →ᵃ[k] W) (x : P₁) : (e.congrLeftₗ R W).symm f x = f (e x) :=
+  rfl
+
+variable {W} (Q : Type*) [AddTorsor W Q]
+
+/-- An affine isomorphism between the domains of affine spaces induces an affine isomorphism over
+another ring between the two function spaces. -/
+def congrLeft : (P₁ →ᵃ[k] Q) ≃ᵃ[R] (P₂ →ᵃ[k] Q) where
+  __ := e.arrowCongrEquiv (.refl k Q)
+  linear := e.congrLeftₗ R W
+  map_vadd' _ _ := by ext; simp
+
+@[simp]
+theorem congrLeft_apply (f : P₁ →ᵃ[k] Q) (x : P₂) : e.congrLeft R Q f x = f (e.symm x) :=
+  rfl
+
+@[simp]
+theorem congrLeft_symm_apply (f : P₂ →ᵃ[k] Q) (x : P₁) : (e.congrLeft R Q).symm f x = f (e x) :=
+  rfl
+
+end congrLeft
+
 end AffineEquiv
 
 namespace AffineMap

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
@@ -613,6 +613,90 @@ theorem ofLinearEquiv_trans_ofLinearEquiv (A B : V ≃ₗ[k] V) (p₀ p₁ p₂ 
 
 end ofLinearEquiv
 
+section arrowCongrEquiv
+
+variable (e₁ : P₁ ≃ᵃ[k] P₂) (e₂ : P₃ ≃ᵃ[k] P₄)
+
+/-- Affine isomorphisms between the domains and codomains of two spaces of affine maps give a
+bijection between the two function spaces.
+
+See `AffineEquiv.arrowCongr` and `AffineEquiv.arrowCongrₗ` for the affine and linear versions of
+this bijection. -/
+def arrowCongrEquiv : (P₁ →ᵃ[k] P₃) ≃ (P₂ →ᵃ[k] P₄) where
+  toFun f := e₂.toAffineMap.comp <| f.comp e₁.symm.toAffineMap
+  invFun f := e₂.symm.toAffineMap.comp <| f.comp e₁.toAffineMap
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
+@[simp]
+theorem arrowCongrEquiv_apply (f : P₁ →ᵃ[k] P₃) (x : P₂) :
+    e₁.arrowCongrEquiv e₂ f x = e₂ (f (e₁.symm x)) :=
+  rfl
+
+@[simp]
+theorem arrowCongrEquiv_symm_apply (f : P₂ →ᵃ[k] P₄) (x : P₁) :
+    (e₁.arrowCongrEquiv e₂).symm f x = e₂.symm (f (e₁ x)) :=
+  rfl
+
+end arrowCongrEquiv
+
+section CommRing
+
+variable {R : Type*} [CommRing R] [Module R V₁] [Module R V₂] [Module R V₃] [Module R V₄]
+
+section arrowCongrₗ
+
+variable (e₁ : P₁ ≃ᵃ[R] P₂) (e₂ : V₃ ≃ₗ[R] V₄)
+
+/-- An affine isomorphism between the domains and a linear isomorphism between the codomains of two
+spaces of affine maps give a linear isomorphism between the two function spaces.
+
+See also `AffineEquiv.arrowCongrEquiv` and `AffineEquiv.arrowCongr`. -/
+def arrowCongrₗ : (P₁ →ᵃ[R] V₃) ≃ₗ[R] (P₂ →ᵃ[R] V₄) where
+  __ := e₁.arrowCongrEquiv e₂.toAffineEquiv
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+
+@[simp]
+theorem arrowCongrₗ_apply (f : P₁ →ᵃ[R] V₃) (x : P₂) :
+    e₁.arrowCongrₗ e₂ f x = e₂ (f (e₁.symm x)) :=
+  rfl
+
+@[simp]
+theorem arrowCongrₗ_symm_apply (f : P₂ →ᵃ[R] V₄) (x : P₁) :
+    (e₁.arrowCongrₗ e₂).symm f x = e₂.symm (f (e₁ x)) :=
+  rfl
+
+end arrowCongrₗ
+
+section arrowCongr
+
+variable (e₁ : P₁ ≃ᵃ[R] P₂) (e₂ : P₃ ≃ᵃ[R] P₄)
+
+/-- Affine isomorphisms between the domains and codomains of two spaces of affine maps give an
+affine isomorphism between the two function spaces.
+
+See also `AffineEquiv.arrowCongrEquiv` and `AffineEquiv.arrowCongrₗ`. -/
+@[simps linear]
+def arrowCongr : (P₁ →ᵃ[R] P₃) ≃ᵃ[R] (P₂ →ᵃ[R] P₄) where
+  __ := e₁.arrowCongrEquiv e₂
+  linear := e₁.arrowCongrₗ e₂.linear
+  map_vadd' _ _ := by ext; simp
+
+@[simp]
+theorem arrowCongr_apply (f : P₁ →ᵃ[R] P₃) (x : P₂) :
+    e₁.arrowCongr e₂ f x = e₂ (f (e₁.symm x)) :=
+  rfl
+
+@[simp]
+theorem arrowCongr_symm_apply (f : P₂ →ᵃ[R] P₄) (x : P₁) :
+    (e₁.arrowCongr e₂).symm f x = e₂.symm (f (e₁ x)) :=
+  rfl
+
+end arrowCongr
+
+end CommRing
+
 end AffineEquiv
 
 namespace AffineMap

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -12,6 +12,9 @@ public import Mathlib.LinearAlgebra.AffineSpace.Simplex.Centroid
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.Dimension.OrzechProperty
 
+import Mathlib.LinearAlgebra.Matrix.FiniteDimensional
+import Mathlib.RingTheory.Finiteness.Prod
+
 /-!
 # Finite-dimensional subspaces of affine spaces.
 
@@ -847,3 +850,26 @@ theorem exists_affineBasis_of_finiteDimensional [Fintype ι] [FiniteDimensional 
 end DivisionRing
 
 end AffineBasis
+
+namespace AffineMap
+
+variable {R S V W P : Type*} [Ring R] [Ring S]
+  [AddCommGroup V] [Module R V] [Module.Finite R V] [Module.Free R V] [AddTorsor V P]
+  [AddCommGroup W] [Module R W] [Module S W] [Module.Finite S W] [SMulCommClass R S W]
+
+instance : Module.Finite S (P →ᵃ[R] W) :=
+  have ⟨p⟩ : Nonempty P := inferInstance
+  .equiv <| (AffineMap.toConstProdLinearMap S).symm ≪≫ₗ (AffineEquiv.vaddConst R p).congrLeftₗ S W
+
+theorem finrank_eq [Module.Free S W] [StrongRankCondition R] [StrongRankCondition S] :
+    Module.finrank S (P →ᵃ[R] W) = (Module.finrank R V + 1) * Module.finrank S W :=
+  calc
+    _ = Module.finrank S (V →ᵃ[R] W) :=
+      have ⟨p⟩ : Nonempty P := inferInstance
+      AffineEquiv.vaddConst R p |>.symm.congrLeftₗ S W |>.finrank_eq
+    _ = Module.finrank S (W × (V →ₗ[R] W)) := (AffineMap.toConstProdLinearMap S).finrank_eq
+    _ = (Module.finrank R V + 1) * Module.finrank S W := by
+      rw [Module.finrank_prod, Module.finrank_linearMap]
+      ring
+
+end AffineMap


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #35998 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
