### PR TITLE
[Merged by Bors] - chore(Geometry/Manifold/Algebra): golf using custom elaborators

### DIFF
--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -149,11 +149,11 @@ theorem ContMDiffAt.inv {f : M → G} {x₀ : M} (hf : CMDiffAt n f x₀) :
 
 @[to_additive]
 theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : CMDiff[s] n f) :
-    CMDiff[s] n (fun x => (f x)⁻¹) := fun x hx ↦ (hf x hx).inv
+    CMDiff[s] n (fun x ↦ (f x)⁻¹) := fun x hx ↦ (hf x hx).inv
 
 @[to_additive]
-theorem ContMDiff.inv {f : M → G} (hf : CMDiff n f) : CMDiff n fun x => (f x)⁻¹ :=
-  fun x => (hf x).inv
+theorem ContMDiff.inv {f : M → G} (hf : CMDiff n f) : CMDiff n fun x ↦ (f x)⁻¹ :=
+  fun x ↦ (hf x).inv
 
 @[to_additive]
 theorem ContMDiffWithinAt.div {f g : M → G} {s : Set M} {x₀ : M}
@@ -270,8 +270,8 @@ theorem continuousInv₀_of_contMDiffInv₀ : ContinuousInv₀ G :=
 @[deprecated (since := "2025-09-01")] alias hasContinuousInv₀_of_hasContMDiffInv₀ :=
   continuousInv₀_of_contMDiffInv₀
 
-theorem contMDiffOn_inv₀ : CMDiff[{0}ᶜ] n (Inv.inv : G → G) := fun _x hx =>
-  (contMDiffAt_inv₀ hx).contMDiffWithinAt
+theorem contMDiffOn_inv₀ : CMDiff[{0}ᶜ] n (Inv.inv : G → G) :=
+  fun _x hx ↦ (contMDiffAt_inv₀ hx).contMDiffWithinAt
 
 variable {s : Set M} {a : M}
 
@@ -287,7 +287,7 @@ theorem ContMDiff.inv₀ (hf : CMDiff n f) (h0 : ∀ x, f x ≠ 0) :
   fun x ↦ ContMDiffAt.inv₀ (hf x) (h0 x)
 
 theorem ContMDiffOn.inv₀ (hf : CMDiff[s] n f) (h0 : ∀ x ∈ s, f x ≠ 0) :
-    CMDiff[s] n (fun x => (f x)⁻¹) :=
+    CMDiff[s] n (fun x ↦ (f x)⁻¹) :=
   fun x hx ↦ ContMDiffWithinAt.inv₀ (hf x hx) (h0 x hx)
 
 end ContMDiffInv₀

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -64,7 +64,7 @@ class LieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Top
     (n : WithTop ℕ∞) (G : Type*)
     [AddGroup G] [TopologicalSpace G] [ChartedSpace H G] : Prop extends ContMDiffAdd I n G where
   /-- Negation is smooth in an additive Lie group. -/
-  contMDiff_neg : CMDiff n fun a : G => -a
+  contMDiff_neg : CMDiff n fun a : G ↦ -a
 
 -- See note [Design choices about smooth algebraic structures]
 /-- A (multiplicative) Lie group is a group and a `C^n` manifold at the same time in which
@@ -75,7 +75,7 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
     (n : WithTop ℕ∞) (G : Type*)
     [Group G] [TopologicalSpace G] [ChartedSpace H G] : Prop extends ContMDiffMul I n G where
   /-- Inversion is smooth in a Lie group. -/
-  contMDiff_inv : CMDiff n fun a : G => a⁻¹
+  contMDiff_inv : CMDiff n fun a : G ↦ a⁻¹
 
 /-!
   ### Smoothness of inversion, negation, division and subtraction
@@ -124,7 +124,7 @@ variable (I n)
 
 /-- In a Lie group, inversion is `C^n`. -/
 @[to_additive /-- In an additive Lie group, inversion is a smooth map. -/]
-theorem contMDiff_inv : CMDiff n fun x : G => x⁻¹ :=
+theorem contMDiff_inv : CMDiff n fun x : G ↦ x⁻¹ :=
   LieGroup.contMDiff_inv
 
 include I n in
@@ -139,17 +139,17 @@ end
 
 @[to_additive]
 theorem ContMDiffWithinAt.inv {f : M → G} {s : Set M} {x₀ : M}
-    (hf : CMDiffAt[s] n f x₀) : CMDiffAt[s] n (fun x => (f x)⁻¹) x₀ :=
+    (hf : CMDiffAt[s] n f x₀) : CMDiffAt[s] n (fun x ↦ (f x)⁻¹) x₀ :=
   (contMDiff_inv I n).contMDiffAt.contMDiffWithinAt.comp x₀ hf <| Set.mapsTo_univ _ _
 
 @[to_additive]
 theorem ContMDiffAt.inv {f : M → G} {x₀ : M} (hf : CMDiffAt n f x₀) :
-    CMDiffAt n (fun x => (f x)⁻¹) x₀ :=
+    CMDiffAt n (fun x ↦ (f x)⁻¹) x₀ :=
   (contMDiff_inv I n).contMDiffAt.comp x₀ hf
 
 @[to_additive]
 theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : CMDiff[s] n f) :
-    CMDiff[s] n (fun x => (f x)⁻¹) := fun x hx => (hf x hx).inv
+    CMDiff[s] n (fun x => (f x)⁻¹) := fun x hx ↦ (hf x hx).inv
 
 @[to_additive]
 theorem ContMDiff.inv {f : M → G} (hf : CMDiff n f) : CMDiff n fun x => (f x)⁻¹ :=
@@ -158,22 +158,22 @@ theorem ContMDiff.inv {f : M → G} (hf : CMDiff n f) : CMDiff n fun x => (f x)�
 @[to_additive]
 theorem ContMDiffWithinAt.div {f g : M → G} {s : Set M} {x₀ : M}
     (hf : CMDiffAt[s] n f x₀) (hg : CMDiffAt[s] n g x₀) :
-    CMDiffAt[s] n (fun x => f x / g x) x₀ := by
+    CMDiffAt[s] n (fun x ↦ f x / g x) x₀ := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
 theorem ContMDiffAt.div {f g : M → G} {x₀ : M} (hf : CMDiffAt n f x₀)
-    (hg : CMDiffAt n g x₀) : CMDiffAt n (fun x => f x / g x) x₀ := by
+    (hg : CMDiffAt n g x₀) : CMDiffAt n (fun x ↦ f x / g x) x₀ := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
 theorem ContMDiffOn.div {f g : M → G} {s : Set M} (hf : CMDiff[s] n f)
-    (hg : CMDiff[s] n g) : CMDiff[s] n (fun x => f x / g x) := by
+    (hg : CMDiff[s] n g) : CMDiff[s] n (fun x ↦ f x / g x) := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
 theorem ContMDiff.div {f g : M → G} (hf : CMDiff n f) (hg : CMDiff n g) :
-    CMDiff n fun x => f x / g x := by simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
+    CMDiff n fun x ↦ f x / g x := by simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 end PointwiseDivision
 
@@ -276,7 +276,7 @@ theorem contMDiffOn_inv₀ : CMDiff[{0}ᶜ] n (Inv.inv : G → G) := fun _x hx =
 variable {s : Set M} {a : M}
 
 theorem ContMDiffWithinAt.inv₀ (hf : CMDiffAt[s] n f a) (ha : f a ≠ 0) :
-    CMDiffAt[s] n (fun x => (f x)⁻¹) a :=
+    CMDiffAt[s] n (fun x ↦ (f x)⁻¹) a :=
   (contMDiffAt_inv₀ ha).comp_contMDiffWithinAt a hf
 
 theorem ContMDiffAt.inv₀ (hf : CMDiffAt n f a) (ha : f a ≠ 0) : CMDiffAt n (fun x ↦ (f x)⁻¹) a :=

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -6,6 +6,7 @@ Authors: Nicolò Cavalleri
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.Monoid
+import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # Lie groups
@@ -63,7 +64,7 @@ class LieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Top
     (n : WithTop ℕ∞) (G : Type*)
     [AddGroup G] [TopologicalSpace G] [ChartedSpace H G] : Prop extends ContMDiffAdd I n G where
   /-- Negation is smooth in an additive Lie group. -/
-  contMDiff_neg : ContMDiff I I n fun a : G => -a
+  contMDiff_neg : CMDiff n fun a : G => -a
 
 -- See note [Design choices about smooth algebraic structures]
 /-- A (multiplicative) Lie group is a group and a `C^n` manifold at the same time in which
@@ -74,7 +75,7 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
     (n : WithTop ℕ∞) (G : Type*)
     [Group G] [TopologicalSpace G] [ChartedSpace H G] : Prop extends ContMDiffMul I n G where
   /-- Inversion is smooth in a Lie group. -/
-  contMDiff_inv : ContMDiff I I n fun a : G => a⁻¹
+  contMDiff_inv : CMDiff n fun a : G => a⁻¹
 
 /-!
   ### Smoothness of inversion, negation, division and subtraction
@@ -123,7 +124,7 @@ variable (I n)
 
 /-- In a Lie group, inversion is `C^n`. -/
 @[to_additive /-- In an additive Lie group, inversion is a smooth map. -/]
-theorem contMDiff_inv : ContMDiff I I n fun x : G => x⁻¹ :=
+theorem contMDiff_inv : CMDiff n fun x : G => x⁻¹ :=
   LieGroup.contMDiff_inv
 
 include I n in
@@ -138,41 +139,41 @@ end
 
 @[to_additive]
 theorem ContMDiffWithinAt.inv {f : M → G} {s : Set M} {x₀ : M}
-    (hf : ContMDiffWithinAt I' I n f s x₀) : ContMDiffWithinAt I' I n (fun x => (f x)⁻¹) s x₀ :=
+    (hf : CMDiffAt[s] n f x₀) : CMDiffAt[s] n (fun x => (f x)⁻¹) x₀ :=
   (contMDiff_inv I n).contMDiffAt.contMDiffWithinAt.comp x₀ hf <| Set.mapsTo_univ _ _
 
 @[to_additive]
-theorem ContMDiffAt.inv {f : M → G} {x₀ : M} (hf : ContMDiffAt I' I n f x₀) :
-    ContMDiffAt I' I n (fun x => (f x)⁻¹) x₀ :=
+theorem ContMDiffAt.inv {f : M → G} {x₀ : M} (hf : CMDiffAt n f x₀) :
+    CMDiffAt n (fun x => (f x)⁻¹) x₀ :=
   (contMDiff_inv I n).contMDiffAt.comp x₀ hf
 
 @[to_additive]
-theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : ContMDiffOn I' I n f s) :
-    ContMDiffOn I' I n (fun x => (f x)⁻¹) s := fun x hx => (hf x hx).inv
+theorem ContMDiffOn.inv {f : M → G} {s : Set M} (hf : CMDiff[s] n f) :
+    CMDiff[s] n (fun x => (f x)⁻¹) := fun x hx => (hf x hx).inv
 
 @[to_additive]
-theorem ContMDiff.inv {f : M → G} (hf : ContMDiff I' I n f) : ContMDiff I' I n fun x => (f x)⁻¹ :=
+theorem ContMDiff.inv {f : M → G} (hf : CMDiff n f) : CMDiff n fun x => (f x)⁻¹ :=
   fun x => (hf x).inv
 
 @[to_additive]
 theorem ContMDiffWithinAt.div {f g : M → G} {s : Set M} {x₀ : M}
-    (hf : ContMDiffWithinAt I' I n f s x₀) (hg : ContMDiffWithinAt I' I n g s x₀) :
-    ContMDiffWithinAt I' I n (fun x => f x / g x) s x₀ := by
+    (hf : CMDiffAt[s] n f x₀) (hg : CMDiffAt[s] n g x₀) :
+    CMDiffAt[s] n (fun x => f x / g x) x₀ := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
-theorem ContMDiffAt.div {f g : M → G} {x₀ : M} (hf : ContMDiffAt I' I n f x₀)
-    (hg : ContMDiffAt I' I n g x₀) : ContMDiffAt I' I n (fun x => f x / g x) x₀ := by
+theorem ContMDiffAt.div {f g : M → G} {x₀ : M} (hf : CMDiffAt n f x₀)
+    (hg : CMDiffAt n g x₀) : CMDiffAt n (fun x => f x / g x) x₀ := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
-theorem ContMDiffOn.div {f g : M → G} {s : Set M} (hf : ContMDiffOn I' I n f s)
-    (hg : ContMDiffOn I' I n g s) : ContMDiffOn I' I n (fun x => f x / g x) s := by
+theorem ContMDiffOn.div {f g : M → G} {s : Set M} (hf : CMDiff[s] n f)
+    (hg : CMDiff[s] n g) : CMDiff[s] n (fun x => f x / g x) := by
   simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 @[to_additive]
-theorem ContMDiff.div {f g : M → G} (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) :
-    ContMDiff I' I n fun x => f x / g x := by simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
+theorem ContMDiff.div {f g : M → G} (hf : CMDiff n f) (hg : CMDiff n g) :
+    CMDiff n fun x => f x / g x := by simp_rw [div_eq_mul_inv]; exact hf.mul hg.inv
 
 end PointwiseDivision
 
@@ -213,7 +214,7 @@ class ContMDiffInv₀ {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} 
     (n : WithTop ℕ∞) (G : Type*)
     [Inv G] [Zero G] [TopologicalSpace G] [ChartedSpace H G] : Prop where
   /-- Inversion is `C^n` away from `0`. -/
-  contMDiffAt_inv₀ : ∀ ⦃x : G⦄, x ≠ 0 → ContMDiffAt I I n (fun y ↦ y⁻¹) x
+  contMDiffAt_inv₀ : ∀ ⦃x : G⦄, x ≠ 0 → CMDiffAt n (fun (y : G) ↦ y⁻¹) x
 
 instance {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞} : ContMDiffInv₀ 𝓘(𝕜) n 𝕜 where
   contMDiffAt_inv₀ x hx := by
@@ -243,7 +244,7 @@ instance {a : WithTop ℕ∞} [ContMDiffInv₀ I ω G] : ContMDiffInv₀ I a G :
 instance [ContinuousInv₀ G] : ContMDiffInv₀ I 0 G := by
   have : T1Space G := I.t1Space G
   constructor
-  have A : ContMDiffOn I I 0 (fun (x : G) ↦ x⁻¹) {0}ᶜ := by
+  have A : CMDiff[{0}ᶜ] 0 (fun (x : G) ↦ x⁻¹) := by
     rw [contMDiffOn_zero_iff]
     exact continuousOn_inv₀
   intro x hx
@@ -269,25 +270,24 @@ theorem continuousInv₀_of_contMDiffInv₀ : ContinuousInv₀ G :=
 @[deprecated (since := "2025-09-01")] alias hasContinuousInv₀_of_hasContMDiffInv₀ :=
   continuousInv₀_of_contMDiffInv₀
 
-theorem contMDiffOn_inv₀ : ContMDiffOn I I n (Inv.inv : G → G) {0}ᶜ := fun _x hx =>
+theorem contMDiffOn_inv₀ : CMDiff[{0}ᶜ] n (Inv.inv : G → G) := fun _x hx =>
   (contMDiffAt_inv₀ hx).contMDiffWithinAt
 
 variable {s : Set M} {a : M}
 
-theorem ContMDiffWithinAt.inv₀ (hf : ContMDiffWithinAt I' I n f s a) (ha : f a ≠ 0) :
-    ContMDiffWithinAt I' I n (fun x => (f x)⁻¹) s a :=
+theorem ContMDiffWithinAt.inv₀ (hf : CMDiffAt[s] n f a) (ha : f a ≠ 0) :
+    CMDiffAt[s] n (fun x => (f x)⁻¹) a :=
   (contMDiffAt_inv₀ ha).comp_contMDiffWithinAt a hf
 
-theorem ContMDiffAt.inv₀ (hf : ContMDiffAt I' I n f a) (ha : f a ≠ 0) :
-    ContMDiffAt I' I n (fun x ↦ (f x)⁻¹) a :=
+theorem ContMDiffAt.inv₀ (hf : CMDiffAt n f a) (ha : f a ≠ 0) : CMDiffAt n (fun x ↦ (f x)⁻¹) a :=
   (contMDiffAt_inv₀ ha).comp a hf
 
-theorem ContMDiff.inv₀ (hf : ContMDiff I' I n f) (h0 : ∀ x, f x ≠ 0) :
-    ContMDiff I' I n (fun x ↦ (f x)⁻¹) :=
+theorem ContMDiff.inv₀ (hf : CMDiff n f) (h0 : ∀ x, f x ≠ 0) :
+    CMDiff n (fun x ↦ (f x)⁻¹) :=
   fun x ↦ ContMDiffAt.inv₀ (hf x) (h0 x)
 
-theorem ContMDiffOn.inv₀ (hf : ContMDiffOn I' I n f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
-    ContMDiffOn I' I n (fun x => (f x)⁻¹) s :=
+theorem ContMDiffOn.inv₀ (hf : CMDiff[s] n f) (h0 : ∀ x ∈ s, f x ≠ 0) :
+    CMDiff[s] n (fun x => (f x)⁻¹) :=
   fun x hx ↦ ContMDiffWithinAt.inv₀ (hf x hx) (h0 x hx)
 
 end ContMDiffInv₀
@@ -310,19 +310,18 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞}
   {f g : M → G} {s : Set M} {a : M}
 
 theorem ContMDiffWithinAt.div₀
-    (hf : ContMDiffWithinAt I' I n f s a) (hg : ContMDiffWithinAt I' I n g s a) (h₀ : g a ≠ 0) :
-    ContMDiffWithinAt I' I n (f / g) s a := by
+    (hf : CMDiffAt[s] n f a) (hg : CMDiffAt[s] n g a) (h₀ : g a ≠ 0) : CMDiffAt[s] n (f / g) a := by
   simpa [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
 
-theorem ContMDiffOn.div₀ (hf : ContMDiffOn I' I n f s) (hg : ContMDiffOn I' I n g s)
-    (h₀ : ∀ x ∈ s, g x ≠ 0) : ContMDiffOn I' I n (f / g) s := by
+theorem ContMDiffOn.div₀ (hf : CMDiff[s] n f) (hg : CMDiff[s] n g)
+    (h₀ : ∀ x ∈ s, g x ≠ 0) : CMDiff[s] n (f / g) := by
   simpa [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
 
-theorem ContMDiffAt.div₀ (hf : ContMDiffAt I' I n f a) (hg : ContMDiffAt I' I n g a)
-    (h₀ : g a ≠ 0) : ContMDiffAt I' I n (f / g) a := by
+theorem ContMDiffAt.div₀ (hf : CMDiffAt n f a) (hg : CMDiffAt n g a)
+    (h₀ : g a ≠ 0) : CMDiffAt n (f / g) a := by
   simpa [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
 
-theorem ContMDiff.div₀ (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) (h₀ : ∀ x, g x ≠ 0) :
-    ContMDiff I' I n (f / g) := by simpa only [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
+theorem ContMDiff.div₀ (hf : CMDiff n f) (hg : CMDiff n g) (h₀ : ∀ x, g x ≠ 0) :
+    CMDiff n (f / g) := by simpa only [div_eq_mul_inv] using hf.mul (hg.inv₀ h₀)
 
 end Div

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -50,7 +50,7 @@ class ContMDiffAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
     (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞)
     (G : Type*) [Add G] [TopologicalSpace G] [ChartedSpace H G] : Prop
     extends IsManifold I n G where
-  contMDiff_add : CMDiff n fun p : G × G => p.1 + p.2
+  contMDiff_add : CMDiff n fun p : G × G ↦ p.1 + p.2
 
 -- See note [Design choices about smooth algebraic structures]
 /-- Basic hypothesis to talk about a `C^n` (Lie) monoid or a `C^n` semigroup.
@@ -62,7 +62,7 @@ class ContMDiffMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
     (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞)
     (G : Type*) [Mul G] [TopologicalSpace G] [ChartedSpace H G] : Prop
     extends IsManifold I n G where
-  contMDiff_mul : CMDiff n fun p : G × G => p.1 * p.2
+  contMDiff_mul : CMDiff n fun p : G × G ↦ p.1 * p.2
 
 section ContMDiffMul
 
@@ -102,7 +102,7 @@ section
 variable (I n)
 
 @[to_additive]
-theorem contMDiff_mul [ContMDiffMul I n G] : CMDiff n fun p : G × G => p.1 * p.2 :=
+theorem contMDiff_mul [ContMDiffMul I n G] : CMDiff n fun p : G × G ↦ p.1 * p.2 :=
   ContMDiffMul.contMDiff_mul
 
 include I n in
@@ -259,7 +259,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞}
   {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G'] [ContMDiffMul I' n G']
 
 @[to_additive]
-theorem contMDiff_pow : ∀ i : ℕ, CMDiff n fun a : G => a ^ i
+theorem contMDiff_pow : ∀ i : ℕ, CMDiff n fun a : G ↦ a ^ i
   | 0 => by simp only [pow_zero, contMDiff_const]
   | k + 1 => by simpa [pow_succ] using (contMDiff_pow _).mul contMDiff_id
 
@@ -379,13 +379,13 @@ theorem contMDiffOn_finprod
 
 @[to_additive]
 theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, CMDiff[s] n (f i)) :
-    CMDiff[s] n (∏ i ∈ t, f i) := fun x hx =>
-  contMDiffWithinAt_finset_prod' fun i hi => h i hi x hx
+    CMDiff[s] n (∏ i ∈ t, f i) :=
+  fun x hx ↦ contMDiffWithinAt_finset_prod' fun i hi ↦ h i hi x hx
 
 @[to_additive]
 theorem contMDiffOn_finset_prod (h : ∀ i ∈ t, CMDiff[s] n (f i)) :
-    CMDiff[s] n (fun x => ∏ i ∈ t, f i x) := fun x hx =>
-  contMDiffWithinAt_finset_prod fun i hi => h i hi x hx
+    CMDiff[s] n (fun x ↦ ∏ i ∈ t, f i x) :=
+  fun x hx ↦ contMDiffWithinAt_finset_prod fun i hi ↦ h i hi x hx
 
 @[to_additive]
 theorem ContMDiff.prod (h : ∀ i ∈ t, CMDiff n (f i)) :
@@ -394,12 +394,12 @@ theorem ContMDiff.prod (h : ∀ i ∈ t, CMDiff n (f i)) :
 
 @[to_additive]
 theorem contMDiff_finset_prod' (h : ∀ i ∈ t, CMDiff n (f i)) :
-    CMDiff n (∏ i ∈ t, f i) := fun x ↦ contMDiffAt_finset_prod' fun i hi => h i hi x
+    CMDiff n (∏ i ∈ t, f i) := fun x ↦ contMDiffAt_finset_prod' fun i hi ↦ h i hi x
 
 @[to_additive]
 theorem contMDiff_finset_prod (h : ∀ i ∈ t, CMDiff n (f i)) :
-    CMDiff n fun x => ∏ i ∈ t, f i x := fun x =>
-  contMDiffAt_finset_prod fun i hi => h i hi x
+    CMDiff n fun x ↦ ∏ i ∈ t, f i x :=
+  fun x ↦ contMDiffAt_finset_prod fun i hi ↦ h i hi x
 
 @[to_additive]
 theorem contMDiff_finprod (h : ∀ i, CMDiff n (f i))
@@ -408,10 +408,10 @@ theorem contMDiff_finprod (h : ∀ i, CMDiff n (f i))
 
 @[to_additive]
 theorem contMDiff_finprod_cond (hc : ∀ i, p i → CMDiff n (f i))
-    (hf : LocallyFinite fun i => mulSupport (f i)) :
+    (hf : LocallyFinite fun i ↦ mulSupport (f i)) :
     CMDiff n fun x ↦ ∏ᶠ (i) (_ : p i), f i x := by
   simp only [← finprod_subtype_eq_finprod_cond]
-  exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
+  exact contMDiff_finprod (fun i ↦ hc i i.2) (hf.comp_injective Subtype.coe_injective)
 
 variable {g : M → G}
 

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -340,12 +340,12 @@ theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ mulSupport <| f 
 @[to_additive]
 theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, CMDiffAt[s] n (f i) x) :
     CMDiffAt[s] n (∏ i ∈ t, f i) x :=
-  Finset.prod_induction f (fun f => CMDiffAt[s] n f x) (fun _ _ hf hg => hf.mul hg)
+  Finset.prod_induction f (fun f ↦ CMDiffAt[s] n f x) (fun _ _ hf hg ↦ hf.mul hg)
     (contMDiffWithinAt_const (c := 1)) h
 
 @[to_additive]
 theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, CMDiffAt[s] n (f i) x) :
-    CMDiffAt[s] n (fun x => ∏ i ∈ t, f i x) x := by
+    CMDiffAt[s] n (fun x ↦ ∏ i ∈ t, f i x) x := by
   simp only [← Finset.prod_apply]
   exact contMDiffWithinAt_finset_prod' h
 
@@ -368,7 +368,7 @@ theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, CMDiffAt n (f i) x) :
 
 @[to_additive]
 theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, CMDiffAt n (f i) x) :
-    CMDiffAt n (fun x => ∏ i ∈ t, f i x) x :=
+    CMDiffAt n (fun x ↦ ∏ i ∈ t, f i x) x :=
   contMDiffWithinAt_finset_prod h
 
 @[to_additive]
@@ -394,7 +394,7 @@ theorem ContMDiff.prod (h : ∀ i ∈ t, CMDiff n (f i)) :
 
 @[to_additive]
 theorem contMDiff_finset_prod' (h : ∀ i ∈ t, CMDiff n (f i)) :
-    CMDiff n (∏ i ∈ t, f i) := fun x => contMDiffAt_finset_prod' fun i hi => h i hi x
+    CMDiff n (∏ i ∈ t, f i) := fun x ↦ contMDiffAt_finset_prod' fun i hi => h i hi x
 
 @[to_additive]
 theorem contMDiff_finset_prod (h : ∀ i ∈ t, CMDiff n (f i)) :
@@ -403,13 +403,13 @@ theorem contMDiff_finset_prod (h : ∀ i ∈ t, CMDiff n (f i)) :
 
 @[to_additive]
 theorem contMDiff_finprod (h : ∀ i, CMDiff n (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : CMDiff n fun x => ∏ᶠ i, f i x :=
+    (hfin : LocallyFinite fun i ↦ mulSupport (f i)) : CMDiff n fun x ↦ ∏ᶠ i, f i x :=
   fun x ↦ contMDiffAt_finprod hfin fun i ↦ h i x
 
 @[to_additive]
 theorem contMDiff_finprod_cond (hc : ∀ i, p i → CMDiff n (f i))
     (hf : LocallyFinite fun i => mulSupport (f i)) :
-    CMDiff n fun x => ∏ᶠ (i) (_ : p i), f i x := by
+    CMDiff n fun x ↦ ∏ᶠ (i) (_ : p i), f i x := by
   simp only [← finprod_subtype_eq_finprod_cond]
   exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
 
@@ -473,10 +473,10 @@ nonrec theorem ContMDiffAt.div_const (hf : CMDiffAt n f x) :
 
 @[to_additive]
 theorem ContMDiffOn.div_const (hf : CMDiff[s] n f) :
-    CMDiff[s] n (fun x ↦ f x / c) := fun x hx => (hf x hx).div_const c
+    CMDiff[s] n (fun x ↦ f x / c) := fun x hx ↦ (hf x hx).div_const c
 
 @[to_additive]
 theorem ContMDiff.div_const (hf : CMDiff n f) :
-    CMDiff n (fun x ↦ f x / c) := fun x => (hf x).div_const c
+    CMDiff n (fun x ↦ f x / c) := fun x ↦ (hf x).div_const c
 
 end DivConst

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -6,6 +6,7 @@ Authors: Nicolò Cavalleri
 module
 
 public import Mathlib.Geometry.Manifold.ContMDiffMap
+import Mathlib.Geometry.Manifold.Notation
 public import Mathlib.Geometry.Manifold.MFDeriv.Basic
 
 /-!
@@ -49,7 +50,7 @@ class ContMDiffAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
     (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞)
     (G : Type*) [Add G] [TopologicalSpace G] [ChartedSpace H G] : Prop
     extends IsManifold I n G where
-  contMDiff_add : ContMDiff (I.prod I) I n fun p : G × G => p.1 + p.2
+  contMDiff_add : CMDiff n fun p : G × G => p.1 + p.2
 
 -- See note [Design choices about smooth algebraic structures]
 /-- Basic hypothesis to talk about a `C^n` (Lie) monoid or a `C^n` semigroup.
@@ -61,7 +62,7 @@ class ContMDiffMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
     (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞)
     (G : Type*) [Mul G] [TopologicalSpace G] [ChartedSpace H G] : Prop
     extends IsManifold I n G where
-  contMDiff_mul : ContMDiff (I.prod I) I n fun p : G × G => p.1 * p.2
+  contMDiff_mul : CMDiff n fun p : G × G => p.1 * p.2
 
 section ContMDiffMul
 
@@ -101,7 +102,7 @@ section
 variable (I n)
 
 @[to_additive]
-theorem contMDiff_mul [ContMDiffMul I n G] : ContMDiff (I.prod I) I n fun p : G × G => p.1 * p.2 :=
+theorem contMDiff_mul [ContMDiffMul I n G] : CMDiff n fun p : G × G => p.1 * p.2 :=
   ContMDiffMul.contMDiff_mul
 
 include I n in
@@ -119,37 +120,36 @@ section
 variable [ContMDiffMul I n G] {f g : M → G} {s : Set M} {x : M}
 
 @[to_additive]
-theorem ContMDiffWithinAt.mul (hf : ContMDiffWithinAt I' I n f s x)
-    (hg : ContMDiffWithinAt I' I n g s x) : ContMDiffWithinAt I' I n (f * g) s x :=
+theorem ContMDiffWithinAt.mul (hf : CMDiffAt[s] n f x) (hg : CMDiffAt[s] n g x) :
+    CMDiffAt[s] n (f * g) x :=
   (contMDiff_mul I n).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
 
 @[to_additive]
-nonrec theorem ContMDiffAt.mul (hf : ContMDiffAt I' I n f x) (hg : ContMDiffAt I' I n g x) :
-    ContMDiffAt I' I n (f * g) x :=
+nonrec theorem ContMDiffAt.mul (hf : CMDiffAt n f x) (hg : CMDiffAt n g x) : CMDiffAt n (f * g) x :=
   hf.mul hg
 
 @[to_additive]
-theorem ContMDiffOn.mul (hf : ContMDiffOn I' I n f s) (hg : ContMDiffOn I' I n g s) :
-    ContMDiffOn I' I n (f * g) s := fun x hx => (hf x hx).mul (hg x hx)
+theorem ContMDiffOn.mul (hf : CMDiff[s] n f) (hg : CMDiff[s] n g) : CMDiff[s] n (f * g) :=
+  fun x hx ↦ (hf x hx).mul (hg x hx)
 
 @[to_additive]
-theorem ContMDiff.mul (hf : ContMDiff I' I n f) (hg : ContMDiff I' I n g) :
-    ContMDiff I' I n (f * g) := fun x => (hf x).mul (hg x)
+theorem ContMDiff.mul (hf : CMDiff n f) (hg : CMDiff n g) : CMDiff n (f * g) :=
+  fun x ↦ (hf x).mul (hg x)
 
 @[to_additive]
-theorem contMDiff_mul_left {a : G} : ContMDiff I I n (a * ·) :=
+theorem contMDiff_mul_left {a : G} : CMDiff n (a * ·) :=
   contMDiff_const.mul contMDiff_id
 
 @[to_additive]
-theorem contMDiffAt_mul_left {a b : G} : ContMDiffAt I I n (a * ·) b :=
+theorem contMDiffAt_mul_left {a b : G} : CMDiffAt n (a * ·) b :=
   contMDiff_mul_left.contMDiffAt
 
 @[to_additive]
-theorem contMDiff_mul_right {a : G} : ContMDiff I I n (· * a) :=
+theorem contMDiff_mul_right {a : G} : CMDiff n (· * a) :=
   contMDiff_id.mul contMDiff_const
 
 @[to_additive]
-theorem contMDiffAt_mul_right {a b : G} : ContMDiffAt I I n (· * a) b :=
+theorem contMDiffAt_mul_right {a b : G} : CMDiffAt n (· * a) b :=
   contMDiff_mul_right.contMDiffAt
 
 end
@@ -159,21 +159,19 @@ section
 variable [ContMDiffMul I 1 G]
 
 @[to_additive]
-theorem mdifferentiable_mul_left {a : G} : MDifferentiable I I (a * ·) :=
+theorem mdifferentiable_mul_left {a : G} : MDiff (a * ·) :=
   contMDiff_mul_left.mdifferentiable one_ne_zero
 
 @[to_additive]
-theorem mdifferentiableAt_mul_left {a b : G} :
-    MDifferentiableAt I I (a * ·) b :=
+theorem mdifferentiableAt_mul_left {a b : G} : MDiffAt (a * ·) b :=
   contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
 
 @[to_additive]
-theorem mdifferentiable_mul_right {a : G} : MDifferentiable I I (· * a) :=
+theorem mdifferentiable_mul_right {a : G} : MDiff (· * a) :=
   contMDiff_mul_right.mdifferentiable one_ne_zero
 
 @[to_additive]
-theorem mdifferentiableAt_mul_right {a b : G} :
-    MDifferentiableAt I I (· * a) b :=
+theorem mdifferentiableAt_mul_right {a b : G} : MDiffAt (· * a) b :=
   contMDiffAt_mul_right.mdifferentiableAt one_ne_zero
 
 end
@@ -261,7 +259,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞}
   {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G'] [ContMDiffMul I' n G']
 
 @[to_additive]
-theorem contMDiff_pow : ∀ i : ℕ, ContMDiff I I n fun a : G => a ^ i
+theorem contMDiff_pow : ∀ i : ℕ, CMDiff n fun a : G => a ^ i
   | 0 => by simp only [pow_zero, contMDiff_const]
   | k + 1 => by simpa [pow_succ] using (contMDiff_pow _).mul contMDiff_id
 
@@ -270,7 +268,7 @@ structure ContMDiffAddMonoidMorphism (I : ModelWithCorners 𝕜 E H) (I' : Model
     (n : WithTop ℕ∞) (G : Type*) [TopologicalSpace G] [ChartedSpace H G] [AddMonoid G]
     (G' : Type*) [TopologicalSpace G'] [ChartedSpace H' G'] [AddMonoid G']
     extends G →+ G' where
-  contMDiff_toFun : ContMDiff I I' n toFun
+  contMDiff_toFun : CMDiff n toFun
 
 /-- Morphism of `C^n` monoids. -/
 @[to_additive]
@@ -278,7 +276,7 @@ structure ContMDiffMonoidMorphism (I : ModelWithCorners 𝕜 E H) (I' : ModelWit
     (n : WithTop ℕ∞) (G : Type*) [TopologicalSpace G] [ChartedSpace H G] [Monoid G] (G' : Type*)
     [TopologicalSpace G'] [ChartedSpace H' G'] [Monoid G'] extends
     G →* G' where
-  contMDiff_toFun : ContMDiff I I' n toFun
+  contMDiff_toFun : CMDiff n toFun
 
 @[to_additive]
 instance : One (ContMDiffMonoidMorphism I I' n G G') :=
@@ -322,8 +320,8 @@ variable {ι 𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞} {
   {s : Set M} {x x₀ : M} {t : Finset ι} {f : ι → M → G} {p : ι → Prop}
 
 @[to_additive]
-theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x₀) :
-    ContMDiffWithinAt I' I n (fun x ↦ ∏ i ∈ t, f i x) s x₀ := by
+theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, CMDiffAt[s] n (f i) x₀) :
+    CMDiffAt[s] n (fun x ↦ ∏ i ∈ t, f i x) x₀ := by
   classical
   induction t using Finset.induction_on with
   | empty => simp [contMDiffWithinAt_const]
@@ -333,108 +331,108 @@ theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) 
 
 @[to_additive]
 theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ mulSupport <| f i) {x₀ : M}
-    (h : ∀ i, ContMDiffWithinAt I' I n (f i) s x₀) :
-    ContMDiffWithinAt I' I n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
+    (h : ∀ i, CMDiffAt[s] n (f i) x₀) :
+    CMDiffAt[s] n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
   let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
   (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
     (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
 
 @[to_additive]
-theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
-    ContMDiffWithinAt I' I n (∏ i ∈ t, f i) s x :=
-  Finset.prod_induction f (fun f => ContMDiffWithinAt I' I n f s x) (fun _ _ hf hg => hf.mul hg)
+theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, CMDiffAt[s] n (f i) x) :
+    CMDiffAt[s] n (∏ i ∈ t, f i) x :=
+  Finset.prod_induction f (fun f => CMDiffAt[s] n f x) (fun _ _ hf hg => hf.mul hg)
     (contMDiffWithinAt_const (c := 1)) h
 
 @[to_additive]
-theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
-    ContMDiffWithinAt I' I n (fun x => ∏ i ∈ t, f i x) s x := by
+theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, CMDiffAt[s] n (f i) x) :
+    CMDiffAt[s] n (fun x => ∏ i ∈ t, f i x) x := by
   simp only [← Finset.prod_apply]
   exact contMDiffWithinAt_finset_prod' h
 
 @[to_additive]
-theorem ContMDiffAt.prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x₀) :
-    ContMDiffAt I' I n (fun x ↦ ∏ i ∈ t, f i x) x₀ := by
+theorem ContMDiffAt.prod (h : ∀ i ∈ t, CMDiffAt n (f i) x₀) :
+    CMDiffAt n (fun x ↦ ∏ i ∈ t, f i x) x₀ := by
   simp only [← contMDiffWithinAt_univ] at *
   exact ContMDiffWithinAt.prod h
 
 @[to_additive]
 theorem contMDiffAt_finprod
-    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
-    ContMDiffAt I' I n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, CMDiffAt n (f i) x₀) :
+    CMDiffAt n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
   contMDiffWithinAt_finprod lf h
 
 @[to_additive]
-theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
-    ContMDiffAt I' I n (∏ i ∈ t, f i) x :=
+theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, CMDiffAt n (f i) x) :
+    CMDiffAt n (∏ i ∈ t, f i) x :=
   contMDiffWithinAt_finset_prod' h
 
 @[to_additive]
-theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
-    ContMDiffAt I' I n (fun x => ∏ i ∈ t, f i x) x :=
+theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, CMDiffAt n (f i) x) :
+    CMDiffAt n (fun x => ∏ i ∈ t, f i x) x :=
   contMDiffWithinAt_finset_prod h
 
 @[to_additive]
 theorem contMDiffOn_finprod
-    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffOn I' I n (f i) s) :
-    ContMDiffOn I' I n (fun x ↦ ∏ᶠ i, f i x) s := fun x hx ↦
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, CMDiff[s] n (f i)) :
+    CMDiff[s] n (fun x ↦ ∏ᶠ i, f i x) := fun x hx ↦
   contMDiffWithinAt_finprod lf fun i ↦ h i x hx
 
 @[to_additive]
-theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
-    ContMDiffOn I' I n (∏ i ∈ t, f i) s := fun x hx =>
+theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, CMDiff[s] n (f i)) :
+    CMDiff[s] n (∏ i ∈ t, f i) := fun x hx =>
   contMDiffWithinAt_finset_prod' fun i hi => h i hi x hx
 
 @[to_additive]
-theorem contMDiffOn_finset_prod (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
-    ContMDiffOn I' I n (fun x => ∏ i ∈ t, f i x) s := fun x hx =>
+theorem contMDiffOn_finset_prod (h : ∀ i ∈ t, CMDiff[s] n (f i)) :
+    CMDiff[s] n (fun x => ∏ i ∈ t, f i x) := fun x hx =>
   contMDiffWithinAt_finset_prod fun i hi => h i hi x hx
 
 @[to_additive]
-theorem ContMDiff.prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
-    ContMDiff I' I n fun x ↦ ∏ i ∈ t, f i x :=
+theorem ContMDiff.prod (h : ∀ i ∈ t, CMDiff n (f i)) :
+    CMDiff n fun x ↦ ∏ i ∈ t, f i x :=
   fun x ↦ ContMDiffAt.prod fun j hj ↦ h j hj x
 
 @[to_additive]
-theorem contMDiff_finset_prod' (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
-    ContMDiff I' I n (∏ i ∈ t, f i) := fun x => contMDiffAt_finset_prod' fun i hi => h i hi x
+theorem contMDiff_finset_prod' (h : ∀ i ∈ t, CMDiff n (f i)) :
+    CMDiff n (∏ i ∈ t, f i) := fun x => contMDiffAt_finset_prod' fun i hi => h i hi x
 
 @[to_additive]
-theorem contMDiff_finset_prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
-    ContMDiff I' I n fun x => ∏ i ∈ t, f i x := fun x =>
+theorem contMDiff_finset_prod (h : ∀ i ∈ t, CMDiff n (f i)) :
+    CMDiff n fun x => ∏ i ∈ t, f i x := fun x =>
   contMDiffAt_finset_prod fun i hi => h i hi x
 
 @[to_additive]
-theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x :=
+theorem contMDiff_finprod (h : ∀ i, CMDiff n (f i))
+    (hfin : LocallyFinite fun i => mulSupport (f i)) : CMDiff n fun x => ∏ᶠ i, f i x :=
   fun x ↦ contMDiffAt_finprod hfin fun i ↦ h i x
 
 @[to_additive]
-theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
+theorem contMDiff_finprod_cond (hc : ∀ i, p i → CMDiff n (f i))
     (hf : LocallyFinite fun i => mulSupport (f i)) :
-    ContMDiff I' I n fun x => ∏ᶠ (i) (_ : p i), f i x := by
+    CMDiff n fun x => ∏ᶠ (i) (_ : p i), f i x := by
   simp only [← finprod_subtype_eq_finprod_cond]
   exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
 
 variable {g : M → G}
 
 @[to_additive]
-theorem ContMDiffWithinAt.pow (hg : ContMDiffWithinAt I' I n g s x) (m : ℕ) :
-    ContMDiffWithinAt I' I n (fun x ↦ g x ^ m) s x :=
+theorem ContMDiffWithinAt.pow (hg : CMDiffAt[s] n g x) (m : ℕ) :
+    CMDiffAt[s] n (fun x ↦ g x ^ m) x :=
   (contMDiff_pow m).contMDiffAt.comp_contMDiffWithinAt x hg
 
 @[to_additive]
-nonrec theorem ContMDiffAt.pow (hg : ContMDiffAt I' I n g x) (m : ℕ) :
-    ContMDiffAt I' I n (fun x ↦ g x ^ m) x :=
+nonrec theorem ContMDiffAt.pow (hg : CMDiffAt n g x) (m : ℕ) :
+    CMDiffAt n (fun x ↦ g x ^ m) x :=
   hg.pow m
 
 @[to_additive]
-theorem ContMDiffOn.pow (hg : ContMDiffOn I' I n g s) (m : ℕ) :
-    ContMDiffOn I' I n (fun x ↦ g x ^ m) s :=
+theorem ContMDiffOn.pow (hg : CMDiff[s] n g) (m : ℕ) :
+    CMDiff[s] n (fun x ↦ g x ^ m) :=
   fun x hx ↦ (hg x hx).pow m
 
 @[to_additive]
-theorem ContMDiff.pow (hg : ContMDiff I' I n g) (m : ℕ) :
-    ContMDiff I' I n (fun x ↦ g x ^ m) :=
+theorem ContMDiff.pow (hg : CMDiff n g) (m : ℕ) :
+    CMDiff n (fun x ↦ g x ^ m) :=
   fun x ↦ (hg x).pow m
 
 end CommMonoid
@@ -464,21 +462,21 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞}
 variable {f : M → G} {s : Set M} {x : M} (c : G)
 
 @[to_additive]
-theorem ContMDiffWithinAt.div_const (hf : ContMDiffWithinAt I' I n f s x) :
-    ContMDiffWithinAt I' I n (fun x ↦ f x / c) s x := by
+theorem ContMDiffWithinAt.div_const (hf : CMDiffAt[s] n f x) :
+    CMDiffAt[s] n (fun x ↦ f x / c) x := by
   simpa only [div_eq_mul_inv] using hf.mul contMDiffWithinAt_const
 
 @[to_additive]
-nonrec theorem ContMDiffAt.div_const (hf : ContMDiffAt I' I n f x) :
-    ContMDiffAt I' I n (fun x ↦ f x / c) x :=
+nonrec theorem ContMDiffAt.div_const (hf : CMDiffAt n f x) :
+    CMDiffAt n (fun x ↦ f x / c) x :=
   hf.div_const c
 
 @[to_additive]
-theorem ContMDiffOn.div_const (hf : ContMDiffOn I' I n f s) :
-    ContMDiffOn I' I n (fun x ↦ f x / c) s := fun x hx => (hf x hx).div_const c
+theorem ContMDiffOn.div_const (hf : CMDiff[s] n f) :
+    CMDiff[s] n (fun x ↦ f x / c) := fun x hx => (hf x hx).div_const c
 
 @[to_additive]
-theorem ContMDiff.div_const (hf : ContMDiff I' I n f) :
-    ContMDiff I' I n (fun x ↦ f x / c) := fun x => (hf x).div_const c
+theorem ContMDiff.div_const (hf : CMDiff n f) :
+    CMDiff n (fun x ↦ f x / c) := fun x => (hf x).div_const c
 
 end DivConst

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -110,7 +110,7 @@ variable (I N)
 `C^n⟮I, N; I'', G''⟯`. -/]
 def compLeftMonoidHom {G' : Type*} [Monoid G'] [TopologicalSpace G'] [ChartedSpace H' G']
     [ContMDiffMul I' n G'] {G'' : Type*} [Monoid G''] [TopologicalSpace G''] [ChartedSpace H'' G'']
-    [ContMDiffMul I'' n G''] (φ : G' →* G'') (hφ : ContMDiff I' I'' n φ) :
+    [ContMDiffMul I'' n G''] (φ : G' →* G'') (hφ : CMDiff n φ) :
     C^n⟮I, N; I', G'⟯ →* C^n⟮I, N; I'', G''⟯ where
   toFun f := ⟨φ ∘ f, hφ.comp f.contMDiff⟩
   map_one' := by ext; change φ 1 = 1; simp
@@ -195,7 +195,7 @@ variable (I N)
 'left-composition-by-`φ`' ring homomorphism from `C^n⟮I, N; I', R'⟯` to `C^n⟮I, N; I'', R''⟯`. -/
 def compLeftRingHom {R' : Type*} [Ring R'] [TopologicalSpace R'] [ChartedSpace H' R']
     [ContMDiffRing I' n R'] {R'' : Type*} [Ring R''] [TopologicalSpace R''] [ChartedSpace H'' R'']
-    [ContMDiffRing I'' n R''] (φ : R' →+* R'') (hφ : ContMDiff I' I'' n φ) :
+    [ContMDiffRing I'' n R''] (φ : R' →+* R'') (hφ : CMDiff n φ) :
     C^n⟮I, N; I', R'⟯ →+* C^n⟮I, N; I'', R''⟯ :=
   { ContMDiffMap.compLeftMonoidHom I N φ.toMonoidHom hφ,
     ContMDiffMap.compLeftAddMonoidHom I N φ.toAddMonoidHom hφ with

--- a/Mathlib/Geometry/Manifold/Algebra/Structures.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Structures.lean
@@ -6,6 +6,7 @@ Authors: Nicolò Cavalleri
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # `C^n` structures
@@ -30,7 +31,7 @@ If `R` is a ring, then negation is automatically `C^n`, as it is multiplication 
 class ContMDiffRing (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞)
     (R : Type*) [Semiring R] [TopologicalSpace R] [ChartedSpace H R] : Prop
     extends ContMDiffAdd I n R where
-  contMDiff_mul : ContMDiff (I.prod I) I n fun p : R × R => p.1 * p.2
+  contMDiff_mul : CMDiff n fun p : R × R => p.1 * p.2
 
 -- see Note [lower instance priority]
 instance (priority := 100) ContMDiffRing.toContMDiffMul (I : ModelWithCorners 𝕜 E H) (R : Type*)


### PR DESCRIPTION
---

Split out from #30357.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
