### PR TITLE
feat(Combinatorics/Enumerative/DoubleCounting): add weighted bipartite lower bound

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -88,6 +88,28 @@ theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (
     (∑ a ∈ s, #(t.bipartiteAbove r a)) = ∑ b ∈ t, #(s.bipartiteBelow r b) := by
   simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
+/-- **Weighted double counting** lower bound.
+
+If each `a ∈ s` is related to at least `m a` elements of `t`, then the weighted incidence sum on
+`t` is at least `∑ a∈s, m a * w a`. -/
+theorem sum_mul_le_sum_sum_bipartiteBelow_of_le_card_bipartiteAbove
+    [∀ a b, Decidable (r a b)] (w m : α → ℕ)
+    (hm : ∀ a ∈ s, m a ≤ #(t.bipartiteAbove r a)) :
+    (∑ a ∈ s, m a * w a) ≤ ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
+  have hswap :
+      (∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a) =
+        ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
+    simpa using
+      (sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
+        (r := r) (s := s) (t := t) (f := fun a _ => w a))
+  calc
+    (∑ a ∈ s, m a * w a) ≤ ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a := by
+      refine sum_le_sum fun a ha => ?_
+      have hmul : m a * w a ≤ #(t.bipartiteAbove r a) * w a :=
+        Nat.mul_le_mul_right (w a) (hm a ha)
+      simpa [sum_const, Nat.mul_comm] using hmul
+    _ = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := hswap
+
 section OrderedSemiring
 variable [Semiring R] [PartialOrder R] [IsOrderedRing R] {m n : R}
 

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -95,15 +95,13 @@ If each `a ∈ s` is related to at least `m a` elements of `t`, then the weighte
 theorem sum_mul_le_sum_sum_bipartiteBelow_of_le_card_bipartiteAbove
     [∀ a b, Decidable (r a b)] (w m : α → ℕ)
     (hm : ∀ a ∈ s, m a ≤ #(t.bipartiteAbove r a)) :
-    (∑ a ∈ s, m a * w a) ≤ ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
+    (∑ a ∈ s, m a * w a) ≤ ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a :=
   calc
-    (∑ a ∈ s, m a * w a) ≤ ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a := by
-      refine sum_le_sum <| fun a ha => ?_
-      simpa [sum_const, Nat.mul_comm] using Nat.mul_le_mul_right (w a) (hm a ha)
-    _ = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
-      simpa using
-        (sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
-          (r := r) (s := s) (t := t) (f := fun a _ => w a))
+    _ ≤ ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a :=
+      sum_le_sum fun a ha ↦ by
+        simpa using Nat.mul_le_mul_right (w a) (hm a ha)
+    _ = _ := by
+      simpa using sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow (r := r) (f := fun a _ ↦ w a)
 
 section OrderedSemiring
 variable [Semiring R] [PartialOrder R] [IsOrderedRing R] {m n : R}

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -96,19 +96,14 @@ theorem sum_mul_le_sum_sum_bipartiteBelow_of_le_card_bipartiteAbove
     [∀ a b, Decidable (r a b)] (w m : α → ℕ)
     (hm : ∀ a ∈ s, m a ≤ #(t.bipartiteAbove r a)) :
     (∑ a ∈ s, m a * w a) ≤ ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
-  have hswap :
-      (∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a) =
-        ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
-    simpa using
-      (sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
-        (r := r) (s := s) (t := t) (f := fun a _ => w a))
   calc
     (∑ a ∈ s, m a * w a) ≤ ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, w a := by
-      refine sum_le_sum fun a ha => ?_
-      have hmul : m a * w a ≤ #(t.bipartiteAbove r a) * w a :=
-        Nat.mul_le_mul_right (w a) (hm a ha)
-      simpa [sum_const, Nat.mul_comm] using hmul
-    _ = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := hswap
+      refine sum_le_sum <| fun a ha => ?_
+      simpa [sum_const, Nat.mul_comm] using Nat.mul_le_mul_right (w a) (hm a ha)
+    _ = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, w a := by
+      simpa using
+        (sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
+          (r := r) (s := s) (t := t) (f := fun a _ => w a))
 
 section OrderedSemiring
 variable [Semiring R] [PartialOrder R] [IsOrderedRing R] {m n : R}


### PR DESCRIPTION
Adds a weighted bipartite lower-bound theorem in `Mathlib.Combinatorics.Enumerative.DoubleCounting`.
Adds `Finset.sum_mul_le_sum_sum_bipartiteBelow_of_le_card_bipartiteAbove`.

Validation: targeted `lake build` and `lake exe runLinter --trace` passed for touched module(s).

Intelligent systems usage: tool=Codex; model=Codex 5.3; effort=extra high; workflow=ORP local-first gates (viability/overlap/naturality/targeted build+linter/draft CI); scope=drafting/refactoring/proof exploration including PR description drafting; final code choices and validation by me.
---
Happy to adjust naming, placement, or proof style based on maintainer preference.

