### PR TITLE
feat(SimpleGraph): redefine `IsBridge` via `deleteEdges`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -158,17 +158,15 @@ theorem IsTree.coe_subgraphOfAdj {u v : V} (h : G.Adj u v) : G.subgraphOfAdj h |
 
 theorem isAcyclic_iff_forall_adj_isBridge :
     G.IsAcyclic ↔ ∀ ⦃v w : V⦄, G.Adj v w → G.IsBridge s(v, w) := by
-  simp_rw [isBridge_iff_adj_and_forall_cycle_notMem]
   constructor
   · intro ha v w hvw
-    apply And.intro hvw
-    intro u p hp
-    cases ha p hp
+    refine (isBridge_iff_adj_and_forall_cycle_notMem hvw).2 ?_
+    intro u p hp hmem
+    exact (ha p hp).elim
   · rintro hb v (_ | ⟨ha, p⟩) hp
     · exact hp.not_of_nil
-    · apply (hb ha).2 _ hp
-      rw [Walk.edges_cons]
-      apply List.mem_cons_self
+    · exact (hb ha).forall_cycle_notMem _ hp <| by
+        simp [Walk.edges_cons]
 
 theorem isAcyclic_iff_forall_edge_isBridge :
     G.IsAcyclic ↔ ∀ ⦃e⦄, e ∈ (G.edgeSet) → G.IsBridge e := by
@@ -187,7 +185,7 @@ theorem IsAcyclic.path_unique {G : SimpleGraph V} (h : G.IsAcyclic) {v w : V} (p
     rw [isAcyclic_iff_forall_adj_isBridge] at h
     specialize h ph
     rw [isBridge_iff_adj_and_forall_walk_mem_edges] at h
-    replace h := h.2 (q.append p.reverse)
+    replace h := h (q.append p.reverse)
     simp only [Walk.edges_append, Walk.edges_reverse, List.mem_append, List.mem_reverse] at h
     rcases h with h | h
     · cases q with
@@ -379,8 +377,8 @@ theorem isAcyclic_sup_fromEdgeSet_iff {u v : V} :
   refine ⟨?_, fun ⟨hacyc, hreach⟩ ↦ hacyc.isAcyclic_sup_fromEdgeSet_of_not_reachable <| by grind⟩
   refine fun hacyc ↦ ⟨hacyc.anti le_sup_left, fun hreach ↦ False.elim ?_⟩
   have := isAcyclic_iff_forall_edge_isBridge.mp (e := s(u, v)) hacyc <| by simp [huv]
-  refine isBridge_iff.mp this |>.right <| hreach.mono <| Eq.le <| Eq.symm ?_
-  rw [sup_sdiff_right_self]
+  refine isBridge_iff.mp this <| hreach.mono <| Eq.le <| Eq.symm ?_
+  rw [deleteEdges, sup_sdiff_right_self]
   exact deleteEdges_eq_self.mpr <| Set.disjoint_singleton_right.mpr hadj
 
 /--
@@ -414,8 +412,11 @@ theorem maximal_isAcyclic_iff_reachable_eq {F : SimpleGraph V} (hle : F ≤ G) (
     exact hH.anti <| sup_le_iff.mpr ⟨hFH.le, H.fromEdgeSet_le.mpr <| by grind⟩
   have : (F ⊔ fromEdgeSet {e}) \ fromEdgeSet {e} = F := by simpa using heF
   cases e
-  rw [isBridge_iff, this, h] at h_bridge
-  exact h_bridge.right <| hHG heH |>.reachable
+  rename_i x y
+  have hdelete : (F ⊔ fromEdgeSet {s(x, y)}).deleteEdges {s(x, y)} = F := by
+    simpa [deleteEdges] using this
+  rw [isBridge_iff, hdelete, h] at h_bridge
+  exact h_bridge <| hHG heH |>.reachable
 
 /-- A subgraph of a connected graph is maximal acyclic iff it is a tree. -/
 theorem Connected.maximal_le_isAcyclic_iff_isTree {T : SimpleGraph V} (hG : G.Connected)

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -28,11 +28,6 @@ public import Mathlib.Combinatorics.SimpleGraph.Subgraph
 * `SimpleGraph.isBridge_iff_mem_and_forall_cycle_notMem` characterizes bridge edges in terms of
   there being no cycle containing them.
 
-## TODO
-
-`IsBridge` is unpractical: we shouldn't require the edge to be present.
-See https://github.com/leanprover-community/mathlib4/issues/31690.
-
 ## Tags
 trails, paths, cycles, bridge edges
 -/
@@ -732,11 +727,10 @@ section BridgeEdges
 /-- An edge of a graph is a *bridge* if, after removing it, its incident vertices
 are no longer reachable from one another. -/
 def IsBridge (G : SimpleGraph V) (e : Sym2 V) : Prop :=
-  e ∈ G.edgeSet ∧
-    Sym2.lift ⟨fun v w => ¬(G \ fromEdgeSet {e}).Reachable v w, by simp [reachable_comm]⟩ e
+  Sym2.lift ⟨fun v w => ¬(G.deleteEdges {e}).Reachable v w, by simp [reachable_comm]⟩ e
 
 theorem isBridge_iff {u v : V} :
-    G.IsBridge s(u, v) ↔ G.Adj u v ∧ ¬(G \ fromEdgeSet {s(u, v)}).Reachable u v := Iff.rfl
+    G.IsBridge s(u, v) ↔ ¬(G.deleteEdges {s(u, v)}).Reachable u v := Iff.rfl
 
 set_option backward.isDefEq.respectTransparency false in
 theorem reachable_delete_edges_iff_exists_walk {v w v' w' : V} :
@@ -753,9 +747,8 @@ theorem reachable_delete_edges_iff_exists_walk {v w v' w' : V} :
     exact ⟨p.edges_subset_edgeSet ep, fun h' => h (h' ▸ ep)⟩
 
 theorem isBridge_iff_adj_and_forall_walk_mem_edges {v w : V} :
-    G.IsBridge s(v, w) ↔ G.Adj v w ∧ ∀ p : G.Walk v w, s(v, w) ∈ p.edges := by
-  rw [isBridge_iff, and_congr_right']
-  rw [reachable_delete_edges_iff_exists_walk, not_exists_not]
+    G.IsBridge s(v, w) ↔ ∀ p : G.Walk v w, s(v, w) ∈ p.edges := by
+  rw [isBridge_iff, deleteEdges, reachable_delete_edges_iff_exists_walk, not_exists_not]
 
 theorem reachable_deleteEdges_iff_exists_cycle.aux [DecidableEq V] {u v w : V}
     (hb : ∀ p : G.Walk v w, s(v, w) ∈ p.edges) (c : G.Walk u u) (hc : c.IsTrail)
@@ -807,24 +800,38 @@ theorem adj_and_reachable_delete_edges_iff_exists_cycle {v w : V} :
       ?_ (Walk.start_mem_support _)
     rwa [(Walk.rotate_edges c hvc).mem_iff, Sym2.eq_swap]
 
-theorem isBridge_iff_adj_and_forall_cycle_notMem {v w : V} : G.IsBridge s(v, w) ↔
-    G.Adj v w ∧ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → s(v, w) ∉ p.edges := by
-  rw [isBridge_iff, and_congr_right_iff]
-  intro h
-  contrapose!
-  rw [← adj_and_reachable_delete_edges_iff_exists_cycle]
-  simp only [h, true_and]
+theorem IsBridge.forall_cycle_notMem {v w : V} (hvw : G.IsBridge s(v, w)) :
+    ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → s(v, w) ∉ p.edges := by
+  intro _ p hp hpe
+  exact hvw <| by
+    simpa [deleteEdges] using
+      (adj_and_reachable_delete_edges_iff_exists_cycle (G := G) (v := v) (w := w)).mpr
+        ⟨_, p, hp, hpe⟩ |>.2
 
-theorem isBridge_iff_mem_and_forall_cycle_notMem {e : Sym2 V} :
-    G.IsBridge e ↔ e ∈ G.edgeSet ∧ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → e ∉ p.edges :=
-  Sym2.ind (fun _ _ => isBridge_iff_adj_and_forall_cycle_notMem) e
+theorem isBridge_iff_adj_and_forall_cycle_notMem {v w : V} (hvw : G.Adj v w) :
+    G.IsBridge s(v, w) ↔ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → s(v, w) ∉ p.edges := by
+  refine ⟨fun h ↦ h.forall_cycle_notMem, ?_⟩
+  intro h
+  rw [isBridge_iff]
+  intro hreach
+  obtain ⟨u, p, hp, hpe⟩ :=
+    (adj_and_reachable_delete_edges_iff_exists_cycle (G := G) (v := v) (w := w)).1
+      ⟨hvw, by simpa [deleteEdges] using hreach⟩
+  exact h p hp hpe
+
+theorem isBridge_iff_mem_and_forall_cycle_notMem {e : Sym2 V} (he : e ∈ G.edgeSet) :
+    G.IsBridge e ↔ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → e ∉ p.edges := by
+  refine Sym2.ind ?_ e he
+  intro v w hvw
+  have hvw' : G.Adj v w := by simpa [mem_edgeSet] using hvw
+  simpa using (isBridge_iff_adj_and_forall_cycle_notMem (G := G) (v := v) (w := w) hvw')
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Deleting a non-bridge edge from a connected graph preserves connectedness. -/
 lemma Connected.connected_delete_edge_of_not_isBridge (hG : G.Connected) {x y : V}
     (h : ¬ G.IsBridge s(x, y)) : (G.deleteEdges {s(x, y)}).Connected := by
   classical
-  simp only [isBridge_iff, not_and, not_not] at h
+  simp only [isBridge_iff, not_not] at h
   obtain hxy | hxy := em' <| G.Adj x y
   · rwa [deleteEdges, Disjoint.sdiff_eq_left (by simpa)]
   refine (connected_iff_exists_forall_reachable _).2 ⟨x, fun w ↦ ?_⟩
@@ -835,28 +842,33 @@ lemma Connected.connected_delete_edge_of_not_isBridge (hG : G.Connected) {x y : 
   let P₁ := P.takeUntil y hyP
   have hxP₁ := Walk.endpoint_notMem_support_takeUntil hP hyP hxy.ne
   have heP₁ : s(x, y) ∉ P₁.edges := fun h ↦ hxP₁ <| P₁.fst_mem_support_of_mem_edges h
-  exact (h hxy).trans (Reachable.symm ⟨P₁.toDeleteEdges {s(x, y)} (by aesop)⟩)
+  exact h.trans (Reachable.symm ⟨P₁.toDeleteEdges {s(x, y)} (by aesop)⟩)
 
 /-- If `e` is an edge in `G` and is a bridge in a larger graph `G'`, then it's a bridge in `G`. -/
 theorem IsBridge.anti_of_mem_edgeSet {G' : SimpleGraph V} {e : Sym2 V} (hle : G ≤ G')
     (h : e ∈ G.edgeSet) (h' : G'.IsBridge e) : G.IsBridge e :=
-  isBridge_iff_mem_and_forall_cycle_notMem.mpr ⟨h, fun _ p hp hpe ↦
-    isBridge_iff_mem_and_forall_cycle_notMem.mp h' |>.right
-      (p.mapLe hle) (Walk.IsCycle.mapLe hle hp) (p.edges_mapLe_eq_edges hle ▸ hpe)⟩
+  (isBridge_iff_mem_and_forall_cycle_notMem (G := G) h).2 <| by
+    intro _ p hp hpe
+    exact (isBridge_iff_mem_and_forall_cycle_notMem (G := G') (edgeSet_mono hle h)).1 h'
+      (p.mapLe hle) (Walk.IsCycle.mapLe hle hp) (p.edges_mapLe_eq_edges hle ▸ hpe)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Connecting two unreachable vertices by an edge creates a bridge. -/
 theorem IsBridge.sup_fromEdgeSet_of_not_reachable {u v : V} (h : ¬G.Reachable u v) :
     (G ⊔ fromEdgeSet {s(u, v)}).IsBridge s(u, v) := by
-  refine isBridge_iff.mpr ⟨.inr ⟨Set.mem_singleton _, mt (· ▸ .rfl) h⟩, ?_⟩
-  exact fun h' ↦ h <| .mono (sdiff_le_iff'.mpr <| refl _) h'
+  rw [isBridge_iff]
+  intro h'
+  exact h <| .mono (sdiff_le_iff'.mpr <| refl _) <| by
+    simpa [deleteEdges] using h'
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Connecting two unreachable vertices by an edge preserves existing bridges. -/
 theorem IsBridge.sup_fromEdgeSet_of_not_reachable_of_isBridge {u v : V} {e : Sym2 V}
-    (h : ¬G.Reachable u v) (h' : G.IsBridge e) : (G ⊔ fromEdgeSet {s(u, v)}).IsBridge e := by
-  refine isBridge_iff_mem_and_forall_cycle_notMem.mpr ⟨edgeSet_mono le_sup_left h'.left, ?_⟩
-  refine fun _ p hp hpe ↦ isBridge_iff_mem_and_forall_cycle_notMem.mp h' |>.right
+    (h : ¬G.Reachable u v) (he : e ∈ G.edgeSet) (h' : G.IsBridge e) :
+    (G ⊔ fromEdgeSet {s(u, v)}).IsBridge e := by
+  refine (isBridge_iff_mem_and_forall_cycle_notMem (G := G ⊔ fromEdgeSet {s(u, v)})
+    (edgeSet_mono le_sup_left he)).2 ?_
+  refine fun _ p hp hpe ↦ (isBridge_iff_mem_and_forall_cycle_notMem (G := G) he).1 h'
     (p.transfer G fun e' he' ↦ ?_) (hp.transfer _) (Walk.edges_transfer p _ ▸ hpe)
   refine edgeSet_sup .. ▸ Walk.edges_subset_edgeSet _ he' |>.elim id fun h' ↦ h ?_ |>.elim
   exact .mono (sdiff_le_iff'.mpr <| refl _) <|

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -102,11 +102,11 @@ lemma isEdgeConnected_add_one (hk : k ≠ 0) :
 
 set_option backward.isDefEq.respectTransparency false in
 /-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
-lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
-    G.IsBridge s(u, v) ↔ G.Adj u v ∧ ¬G.IsEdgeReachable 2 u v := by
-  refine ⟨fun h ↦ ⟨h.left, fun hc ↦ ?_⟩, fun ⟨hadj, hc⟩ ↦ ?_⟩
-  · exact isBridge_iff.mp h |>.right <| hc <| Set.encard_singleton _ |>.trans_lt Nat.one_lt_ofNat
-  · refine isBridge_iff.mpr ⟨hadj, fun hr ↦ hc fun s hs₂ ↦ ?_⟩
+lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} (hadj : G.Adj u v) :
+    G.IsBridge s(u, v) ↔ ¬G.IsEdgeReachable 2 u v := by
+  refine ⟨fun h hc ↦ ?_, fun hc ↦ ?_⟩
+  · exact isBridge_iff.mp h <| hc <| Set.encard_singleton _ |>.trans_lt Nat.one_lt_ofNat
+  · refine isBridge_iff.mpr <| fun hr ↦ hc fun s hs₂ ↦ ?_
     by_cases! hs₁ : s.encard ≠ (1 : ℕ)
     · apply G.isEdgeReachable_one.mpr hadj.reachable
       exact lt_of_le_of_ne (ENat.lt_coe_add_one_iff.mp hs₂) hs₁

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -235,18 +235,21 @@ theorem not_isHamiltonian_of_isBridge (G : SimpleGraph V)
   classical
   refine Sym2.ind (fun x y hbr => ?_) e he
   intro hHam
-  have hxne : x ≠ y :=
-    ((SimpleGraph.isBridge_iff_adj_and_forall_walk_mem_edges.mp hbr).1).ne
+  have hxne : x ≠ y := by
+    intro hxy
+    subst hxy
+    exact (SimpleGraph.isBridge_iff.mp hbr)
+      (SimpleGraph.Reachable.refl (G := G.deleteEdges {s(x, x)}) x)
   haveI : Nontrivial V := ⟨⟨x, y, hxne⟩⟩
   have hne : Fintype.card V ≠ 1 := by
     have : 1 < Fintype.card V := by omega
     exact ne_of_gt this
   obtain ⟨u, c, hcHam⟩ := hHam hne
   have he_not_in_cycle : s(x, y) ∉ c.edges :=
-    (SimpleGraph.isBridge_iff_adj_and_forall_cycle_notMem.mp hbr).2 c hcHam.isCycle
+    hbr.forall_cycle_notMem c hcHam.isCycle
   have hWalkAllMem :
       ∀ p : G.Walk x y, s(x, y) ∈ p.edges :=
-    (SimpleGraph.isBridge_iff_adj_and_forall_walk_mem_edges.mp hbr).2
+    (SimpleGraph.isBridge_iff_adj_and_forall_walk_mem_edges.mp hbr)
   let cX := c.rotate (hcHam.mem_support x)
   have hcycleX : cX.IsCycle := hcHam.isCycle.rotate (hcHam.mem_support x)
   have he_not_in_cX : s(x, y) ∉ cX.edges :=


### PR DESCRIPTION
Closes #31690

Redefines `SimpleGraph.IsBridge` via deletion-only connectivity, without embedding edge membership into the definition.
Updates bridge definition and supporting lemmas.

Validation: targeted `lake build` and `lake exe runLinter --trace` passed for touched module(s).

Intelligent systems usage: tool=Codex; model=Codex 5.3; effort=extra high; workflow=ORP local-first gates (viability/overlap/naturality/targeted build+linter/draft CI); scope=drafting/refactoring/proof exploration including PR description drafting; final code choices and validation by me.
---
Happy to adjust naming, placement, or proof style based on maintainer preference.

