### PR TITLE
[Merged by Bors] - feat: better error message in T% elaborator

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -172,7 +172,11 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
               some <$> mkLambdaFVars #[x] body
             else return none
           | _ => return none
-        return f?.getD e.headBeta
+        match f? with
+        | some e => return e.headBeta
+        | none =>
+          throwError "error: `{e}` is a dependent function into `{V}`, but could not find a
+          `FiberBundle` instance on `{V}`: you may be missing suitable typeclass assumptions"
       | tgt =>
         trace[Elab.DiffGeo.TotalSpaceMk] "Section of a trivial bundle as a non-dependent function"
         -- TODO: can `tgt` depend on `x` in a way that is not a function application?

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -175,8 +175,11 @@ def totalSpaceMk (e : Expr) : MetaM Expr := do
         match f? with
         | some e => return e.headBeta
         | none =>
-          throwError "error: `{e}` is a dependent function into `{V}`, but could not find a
-          `FiberBundle` instance on `{V}`: you may be missing suitable typeclass assumptions"
+          -- future: special-case `Bundle.TotalSpace` for V;
+          -- if so, say "there is no need to apply T% twice"
+          throwError "could not find a `FiberBundle` instance on `{V}`:\n\
+          `{e}` is a function into `{V}`\n\n\
+          hint: you may be missing suitable typeclass assumptions"
       | tgt =>
         trace[Elab.DiffGeo.TotalSpaceMk] "Section of a trivial bundle as a non-dependent function"
         -- TODO: can `tgt` depend on `x` in a way that is not a function application?

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -159,7 +159,7 @@ hint: you may be missing suitable typeclass assumptions
 #check (T% (T% X)) x
 
 -- Error message when missing typeclass assumptions for sections of a fiber bundle.
--- This used to silently do nothing; no there is a helpful error.
+-- This used to silently do nothing; now there is a helpful error.
 section
 
 variable {B F Z : Type*} [TopologicalSpace B] [TopologicalSpace F]

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -139,12 +139,22 @@ example : (fun m ↦ (X m : TangentBundle I M)) = (fun m ↦ TotalSpace.mk' E m 
 #guard_msgs in
 #check T% (fun x ↦ X x) x
 
--- Applying the same elaborator twice is fine (and idempotent).
-/-- info: fun m ↦ TotalSpace.mk' E m (X m) : M → TotalSpace E (TangentSpace I) -/
+-- Applying the same elaborator twice errors.
+/--
+error: could not find a `FiberBundle` instance on `TotalSpace E`:
+`fun m ↦ TotalSpace.mk' E m (X m)` is a function into `TotalSpace E`
+
+hint: you may be missing suitable typeclass assumptions
+-/
 #guard_msgs in
 #check (T% (T% X))
 
-/-- info: (fun m ↦ TotalSpace.mk' E m (X m)) x : TotalSpace E (TangentSpace I) -/
+/--
+error: could not find a `FiberBundle` instance on `TotalSpace E`:
+`fun m ↦ TotalSpace.mk' E m (X m)` is a function into `TotalSpace E`
+
+hint: you may be missing suitable typeclass assumptions
+-/
 #guard_msgs in
 #check (T% (T% X)) x
 

--- a/MathlibTest/DifferentialGeometry/Notation/Basic.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Basic.lean
@@ -158,6 +158,31 @@ hint: you may be missing suitable typeclass assumptions
 #guard_msgs in
 #check (T% (T% X)) x
 
+-- Error message when missing typeclass assumptions for sections of a fiber bundle.
+-- This used to silently do nothing; no there is a helpful error.
+section
+
+variable {B F Z : Type*} [TopologicalSpace B] [TopologicalSpace F]
+  {E : B → Type*} [TopologicalSpace (TotalSpace F E)]
+  (e : Trivialization F (π F E)) [(x : B) → Zero (E x)]
+
+variable (σ : (b : B) → E b) in
+/--
+error: could not find a `FiberBundle` instance on `E`:
+`σ` is a function into `E`
+
+hint: you may be missing suitable typeclass assumptions
+-/
+#guard_msgs in
+#check T% σ
+
+/-- info: fun b ↦ TotalSpace.mk' F b (σ b) : B → TotalSpace F E -/
+#guard_msgs in
+variable [(b : B) → TopologicalSpace (E b)] [FiberBundle F E] (σ : (b : B) → E b) in
+#check T% σ
+
+end
+
 end TotalSpace
 
 /-! Tests for the elaborators for `MDifferentiable{WithinAt,At,On}`. -/


### PR DESCRIPTION
When applying the `T%` elaborator to sections of a fibre bundle, previously in the case of missing typeclass assumptions the elaborator would silently do nothing. Now it errors about this case.

Thanks to Patrick Massot for reporting this bug in person.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
