### PR TITLE
feat(SimpleGraph/Matching): add maximal and maximum matching defs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -66,6 +66,33 @@ We say that the vertices in `M.support` are *matched* or *saturated*.
 -/
 def IsMatching (M : Subgraph G) : Prop := ∀ ⦃v⦄, v ∈ M.verts → ∃! w, M.Adj v w
 
+/--
+The subgraph `M` of `G` is a maximal matching if it is a matching and cannot be extended by adding
+more edges.
+-/
+def IsMaximalMatching (M : Subgraph G) : Prop :=
+  Maximal IsMatching M
+
+/--
+The subgraph `M` of `G` is a maximum matching if it is a matching and has the largest possible
+number of edges.
+-/
+def IsMaximumMatching (M : Subgraph G) : Prop :=
+  MaximalFor IsMatching (fun M ↦ Cardinal.mk M.edgeSet) M
+
+theorem isMaximalMatching_iff :
+    M.IsMaximalMatching ↔ M.IsMatching ∧ ∀ M' : Subgraph G, M'.IsMatching → M ≤ M' → M' ≤ M :=
+  Iff.rfl
+
+theorem isMaximumMatching_iff :
+    M.IsMaximumMatching ↔ M.IsMatching ∧
+      ∀ M' : Subgraph G, M'.IsMatching → Cardinal.mk M'.edgeSet ≤ Cardinal.mk M.edgeSet := by
+  constructor
+  · intro h
+    exact ⟨h.prop, fun M' hM' ↦ h.le hM'⟩
+  · rintro ⟨hM, hmax⟩
+    exact ⟨hM, fun M' hM' _ ↦ hmax M' hM'⟩
+
 /-- Given a vertex, returns the unique edge of the matching it is incident to. -/
 noncomputable def IsMatching.toEdge (h : M.IsMatching) (v : M.verts) : M.edgeSet :=
   ⟨s(v, (h v.property).choose), (h v.property).choose_spec.1⟩


### PR DESCRIPTION
Closes #34957.

This is a focused pass on the issue request:
- add `Subgraph.IsMaximalMatching` as `Maximal IsMatching`
- add `Subgraph.IsMaximumMatching` as `MaximalFor IsMatching (fun M ↦ Cardinal.mk M.edgeSet)`
- add small wrapper lemmas:
  - `Subgraph.isMaximalMatching_iff`
  - `Subgraph.isMaximumMatching_iff`

Build:
- `~/.elan/bin/lake build Mathlib/Combinatorics/SimpleGraph/Matching.lean`
- `~/.elan/bin/lake build`

Context:
- There is already broader work in #32555; this PR intentionally keeps scope narrow to land the core defs/API from this issue.
