### PR TITLE
feat(SimpleGraph/VertexCover): add minimal/minimum cover defs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/VertexCover.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/VertexCover.lean
@@ -36,6 +36,28 @@ section IsVertexCover
 def IsVertexCover (G : SimpleGraph V) (c : Set V) : Prop :=
   ∀ ⦃v w : V⦄, G.Adj v w → v ∈ c ∨ w ∈ c
 
+/-- A minimal vertex cover is a vertex cover with no strictly smaller vertex cover. -/
+def IsMinimalCover (G : SimpleGraph V) (c : Set V) : Prop :=
+  Minimal G.IsVertexCover c
+
+/-- A minimum vertex cover is a vertex cover with minimal cardinality among all vertex covers. -/
+def IsMinimumCover (G : SimpleGraph V) (c : Set V) : Prop :=
+  MinimalFor G.IsVertexCover (fun c ↦ Cardinal.mk c) c
+
+theorem isMinimalCover_iff {c : Set V} :
+    G.IsMinimalCover c ↔ G.IsVertexCover c ∧
+      ∀ d : Set V, G.IsVertexCover d → d ⊆ c → c ⊆ d :=
+  Iff.rfl
+
+theorem isMinimumCover_iff {c : Set V} :
+    G.IsMinimumCover c ↔ G.IsVertexCover c ∧
+      ∀ d : Set V, G.IsVertexCover d → Cardinal.mk c ≤ Cardinal.mk d := by
+  constructor
+  · intro h
+    exact ⟨h.prop, fun d hd ↦ h.le hd⟩
+  · rintro ⟨hc, hmin⟩
+    exact ⟨hc, fun d hd _ ↦ hmin d hd⟩
+
 @[simp]
 theorem isVertexCover_empty : IsVertexCover G ∅ ↔ G = ⊥ := by
   simp [IsVertexCover, eq_bot_iff_forall_not_adj]


### PR DESCRIPTION
Closes #34958

Adds focused core definitions for minimal and minimum vertex covers.
Adds `SimpleGraph.IsMinimalCover`.

Validation: targeted `lake build` and `lake exe runLinter --trace` passed for touched module(s).

Intelligent systems usage: tool=Codex; model=Codex 5.3; effort=extra high; workflow=ORP local-first gates (viability/overlap/naturality/targeted build+linter/draft CI); scope=drafting/refactoring/proof exploration including PR description drafting; final code choices and validation by me.
---
Happy to adjust naming, placement, or proof style based on maintainer preference.

