### PR TITLE
[Merged by Bors] - chore: golf using `grind`

### DIFF
--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -886,20 +886,11 @@ theorem chain_of_pairwise : (∀ a ∈ s, ∀ b ∈ s, r a b) → Chain r s := b
   rw [Cycle.chain_coe_cons]
   apply Pairwise.isChain
   rw [pairwise_cons]
-  refine
-    ⟨fun b hb => ?_,
+  exact
+    ⟨fun b hb => by grind,
       pairwise_append.2
         ⟨pairwise_of_forall_mem_list fun b hb c hc => hs b (Hl hb) c (Hl hc),
-          pairwise_singleton r a, fun b hb c hc => ?_⟩⟩
-  · rw [mem_append] at hb
-    rcases hb with hb | hb
-    · exact hs a Ha b (Hl hb)
-    · rw [mem_singleton] at hb
-      rw [hb]
-      exact hs a Ha a Ha
-  · rw [mem_singleton] at hc
-    rw [hc]
-    exact hs b (Hl hb) a Ha
+          pairwise_singleton r a, fun b hb c hc => by grind⟩⟩
 
 theorem chain_iff_pairwise [IsTrans α r] : Chain r s ↔ ∀ a ∈ s, ∀ b ∈ s, r a b :=
   ⟨by

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -177,10 +177,7 @@ theorem argmax_cons (f : α → β) (a : α) (l : List α) :
     · simp
     dsimp
     rw [← apply_ite, ← apply_ite]
-    dsimp
-    split_ifs <;> try rfl
-    · exact absurd (lt_trans ‹f a < f m› ‹_›) ‹_›
-    · cases (‹f a < f tl›.gt_or_lt _).elim ‹_› ‹_›
+    grind
 
 theorem argmin_cons (f : α → β) (a : α) (l : List α) :
     argmin f (a :: l) =

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -217,13 +217,7 @@ theorem ciSup_subtype [Nonempty ι] {p : ι → Prop} [Nonempty (Subtype p)] {f 
     refine le_ciSup (f := (fun i : ι ↦ ⨆ (h : p i), f ⟨i, h⟩)) ?_ i
     simp_rw [ciSup_eq_ite]
     refine (hf.union (bddAbove_singleton (a := sSup ∅))).mono ?_
-    intro
-    simp only [Set.mem_range, Set.union_singleton, Set.mem_insert_iff, Subtype.exists,
-      forall_exists_index]
-    intro b hb
-    split_ifs at hb
-    · exact Or.inr ⟨_, _, hb⟩
-    · simp_all
+    grind
   · refine ciSup_le fun i ↦ ?_
     simp_rw [ciSup_eq_ite]
     split_ifs

--- a/Mathlib/Order/KonigLemma.lean
+++ b/Mathlib/Order/KonigLemma.lean
@@ -116,10 +116,7 @@ theorem exists_seq_forall_proj_of_forall_finite {α : ℕ → Type*} [Finite (α
     le := fun a b ↦ ∃ h, π h b.2 = a.2
     le_refl := fun a ↦ ⟨rfl.le, π_refl _⟩
     le_trans := fun _ _ c h h' ↦ ⟨h.1.trans h'.1, by rw [← π_trans h.1 h'.1 c.2, h'.2, h.2]⟩
-    le_antisymm := by
-      rintro ⟨i, a⟩ ⟨j, b⟩ ⟨hij : i ≤ j, hab : π hij b = a⟩ ⟨hji : j ≤ i, hba : π hji a = b⟩
-      obtain rfl := hij.antisymm hji
-      rw [show a = b by rwa [π_refl] at hba] }
+    le_antisymm := by grind }
   have hcovby : ∀ {a b : αs}, a ⋖ b ↔ a ≤ b ∧ a.1 + 1 = b.1 := by
     simp only [αs, covBy_iff_lt_and_eq_or_eq, lt_iff_le_and_ne, ne_eq, Sigma.forall, and_assoc,
       and_congr_right_iff, or_iff_not_imp_left]

--- a/Mathlib/RingTheory/Polynomial/SmallDegreeVieta.lean
+++ b/Mathlib/RingTheory/Polynomial/SmallDegreeVieta.lean
@@ -97,9 +97,7 @@ lemma roots_quadratic_eq_pair_iff_of_ne_zero' [Field R] {a b c x1 x2 : R} (ha : 
     (C a * X ^ 2 + C b * X + C c).roots = {x1, x2} ↔
       x1 + x2 = -b / a ∧ x1 * x2 = c / a := by
   rw [roots_quadratic_eq_pair_iff_of_ne_zero ha]
-  field_simp
-  exact and_congr ⟨fun h => by linear_combination h, fun h => by linear_combination h⟩
-    ⟨fun h => by linear_combination -h, fun h => by linear_combination -h⟩
+  grind
 
 /-- **Vieta's formula** for quadratics as an iff (`aroots, Field` version). -/
 lemma aroots_quadratic_eq_pair_iff_of_ne_zero' [CommRing T] [Field S] [Algebra T S] {a b c : T}


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly (replacing calls to lemmas with calls to tactics). Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `Cycle.chain_of_pairwise`: unchanged 🎉
* `List.argmax_cons`: 387 ms before, 94 ms after  🎉
* `ciSup_subtype`: 118 ms before, 77 ms after  🎉
* `exists_seq_forall_proj_of_forall_finite`: unchanged 🎉
* `Polynomial.roots_quadratic_eq_pair_iff_of_ne_zero'`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
