### PR TITLE
chore: rename ordered-cancel add monoid counterexample file

### DIFF
--- a/Counterexamples.lean
+++ b/Counterexamples.lean
@@ -16,7 +16,7 @@ import Counterexamples.MapFloor
 import Counterexamples.MonicNonRegular
 import Counterexamples.Motzkin
 import Counterexamples.NowhereDifferentiable
-import Counterexamples.OrderedCancelAddCommMonoidWithBounds
+import Counterexamples.IsOrderedCancelAddMonoidWithBounds
 import Counterexamples.PeanoCurve
 import Counterexamples.Phillips
 import Counterexamples.PolynomialIsDomain

--- a/Counterexamples.lean
+++ b/Counterexamples.lean
@@ -12,11 +12,11 @@ import Counterexamples.HeawoodUnitDistance
 import Counterexamples.HomogeneousPrimeNotPrime
 import Counterexamples.InvertibleModuleNotIdeal
 import Counterexamples.IrrationalPowerOfIrrational
+import Counterexamples.IsOrderedCancelAddMonoidWithBounds
 import Counterexamples.MapFloor
 import Counterexamples.MonicNonRegular
 import Counterexamples.Motzkin
 import Counterexamples.NowhereDifferentiable
-import Counterexamples.IsOrderedCancelAddMonoidWithBounds
 import Counterexamples.PeanoCurve
 import Counterexamples.Phillips
 import Counterexamples.PolynomialIsDomain

--- a/Counterexamples/IsOrderedCancelAddMonoidWithBounds.lean
+++ b/Counterexamples/IsOrderedCancelAddMonoidWithBounds.lean
@@ -7,10 +7,11 @@ import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Order.BoundedOrder.Lattice
 
 /-!
-# Do not combine OrderedCancelAddCommMonoid with BoundedOrder
+# Do not combine `IsOrderedCancelAddMonoid` with `BoundedOrder`
 
-This file shows that combining `OrderedCancelAddCommMonoid` with `BoundedOrder` is not a good idea,
-as such a structure must be trivial (`⊥ = x = ⊤` for all `x`).
+This file shows that combining `AddCommMonoid`, `PartialOrder`, `IsOrderedCancelAddMonoid`,
+and `BoundedOrder` is not a good idea, as such a structure must be trivial
+(`⊥ = x = ⊤` for all `x`).
 The same applies to any superclasses, e.g. combining `StrictOrderedSemiring` with `CompleteLattice`.
 -/
 


### PR DESCRIPTION
Closes #27812

Renames the counterexample module to match current class naming around `IsOrderedCancelAddMonoid`.
Renames the file and module usage accordingly.

Validation: targeted `lake build` and `lake exe runLinter --trace` passed for touched module(s).

Intelligent systems usage: tool=Codex; model=Codex 5.3; effort=extra high; workflow=ORP local-first gates (viability/overlap/naturality/targeted build+linter/draft CI); scope=drafting/refactoring/proof exploration including PR description drafting; final code choices and validation by me.
---
Happy to adjust naming, placement, or proof style based on maintainer preference.

