### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): golf sheaf isomorphisms using `FullyFaithful.preimageIso`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -286,17 +286,10 @@ Given a natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of typ
 where `G` is locally-full and cover-dense, and `ℱ, ℱ'` are sheaves,
 we may obtain a natural isomorphism between sheaves.
 -/
-@[simps]
+@[simps!]
 noncomputable def sheafIso {ℱ ℱ' : Sheaf K (Type v)} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
-    ℱ ≅ ℱ' where
-  hom := ⟨(presheafIso i).hom⟩
-  inv := ⟨(presheafIso i).inv⟩
-  hom_inv_id := by
-    ext1
-    apply (presheafIso i).hom_inv_id
-  inv_hom_id := by
-    ext1
-    apply (presheafIso i).inv_hom_id
+    ℱ ≅ ℱ' :=
+  (fullyFaithfulSheafToPresheaf _ _).preimageIso (presheafIso i)
 
 end Types
 
@@ -377,16 +370,9 @@ Given a natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of arb
 where `G` is locally-full and cover-dense, and `ℱ', ℱ` are sheaves,
 we may obtain a natural isomorphism between presheaves.
 -/
-@[simps]
-noncomputable def sheafIso {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) : ℱ ≅ ℱ' where
-  hom := ⟨(presheafIso i).hom⟩
-  inv := ⟨(presheafIso i).inv⟩
-  hom_inv_id := by
-    ext1
-    apply (presheafIso i).hom_inv_id
-  inv_hom_id := by
-    ext1
-    apply (presheafIso i).inv_hom_id
+@[simps!]
+noncomputable def sheafIso {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) : ℱ ≅ ℱ' :=
+  (fullyFaithfulSheafToPresheaf _ _).preimageIso (presheafIso i)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The constructed `sheafHom α` is equal to `α` when restricted onto `C`. -/

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -286,7 +286,7 @@ Given a natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of typ
 where `G` is locally-full and cover-dense, and `ℱ, ℱ'` are sheaves,
 we may obtain a natural isomorphism between sheaves.
 -/
-@[simps!]
+@[simps! hom_val inv_val]
 noncomputable def sheafIso {ℱ ℱ' : Sheaf K (Type v)} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) :
     ℱ ≅ ℱ' :=
   (fullyFaithfulSheafToPresheaf _ _).preimageIso (presheafIso i)
@@ -370,7 +370,7 @@ Given a natural isomorphism `G ⋙ ℱ ≅ G ⋙ ℱ'` between presheaves of arb
 where `G` is locally-full and cover-dense, and `ℱ', ℱ` are sheaves,
 we may obtain a natural isomorphism between presheaves.
 -/
-@[simps!]
+@[simps! hom_val inv_val]
 noncomputable def sheafIso {ℱ ℱ' : Sheaf K A} (i : G.op ⋙ ℱ.val ≅ G.op ⋙ ℱ'.val) : ℱ ≅ ℱ' :=
   (fullyFaithfulSheafToPresheaf _ _).preimageIso (presheafIso i)
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
