### PR TITLE
[Merged by Bors] - feat: decomposition of `ContinuousAffineMap` as an `Equiv`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -128,12 +128,12 @@ theorem fst_decompLinearIsometryEquiv (f : V →ᴬ[𝕜] W) :
 
 @[simp]
 theorem snd_decompLinearIsometryEquiv (f : V →ᴬ[𝕜] W) :
-    (decompLinearIsometryEquiv 𝕜 R V W f).2 = f.linear :=
+    (decompLinearIsometryEquiv 𝕜 R V W f).2 = f.contLinear :=
   rfl
 
 @[simp]
 theorem decompLinearIsometryEquiv_symm_apply (p : W × (V →L[𝕜] W)) (x : V) :
-    (decompLinearIsometryEquiv 𝕜 R V W).symm p x = p.2 x +ᵥ p.1 :=
+    (decompLinearIsometryEquiv 𝕜 R V W).symm p x = p.2 x + p.1 :=
   rfl
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -40,7 +40,7 @@ submultiplicative: for a composition of maps, we have only `‖f.comp g‖ ≤ �
 
 namespace ContinuousAffineMap
 
-variable {𝕜 V W W₂ : Type*}
+variable {𝕜 R V W W₂ : Type*}
 variable [NormedAddCommGroup V] [NormedAddCommGroup W] [NormedAddCommGroup W₂]
 variable [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 V] [NormedSpace 𝕜 W] [NormedSpace 𝕜 W₂]
 
@@ -112,29 +112,48 @@ theorem norm_comp_le (g : W₂ →ᴬ[𝕜] V) : ‖f.comp g‖ ≤ ‖f‖ * �
       _ ≤ ‖f‖ * ‖g‖ := by grw [f.norm_contLinear_le, g.norm_contLinear_le]
       _ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by rw [le_add_iff_nonneg_right]; apply norm_nonneg
 
-variable (𝕜 V W)
+variable (𝕜 R V W) [Ring R] [Module R W] [ContinuousConstSMul R W] [SMulCommClass 𝕜 R W]
 
 /-- The space of affine maps between two normed spaces is linearly isometric to the product of the
 codomain with the space of linear maps, by taking the value of the affine map at `(0 : V)` and the
 linear part. -/
-noncomputable def toConstProdContinuousLinearMap : (V →ᴬ[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W) where
-  toFun f := ⟨f 0, f.contLinear⟩
-  invFun p := p.2.toContinuousAffineMap + const 𝕜 V p.1
-  left_inv f := by
-    ext
-    rw [f.decomp]
-    simp only [coe_add, ContinuousLinearMap.coe_toContinuousAffineMap, Pi.add_apply, coe_const]
-  right_inv := by rintro ⟨v, f⟩; ext <;> simp
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
+def decompLinearIsometryEquiv : (V →ᴬ[𝕜] W) ≃ₗᵢ[R] W × (V →L[𝕜] W) where
+  __ := decompLinearEquiv 𝕜 R V W
   norm_map' _ := rfl
 
 @[simp]
+theorem fst_decompLinearIsometryEquiv (f : V →ᴬ[𝕜] W) :
+    (decompLinearIsometryEquiv 𝕜 R V W f).1 = f 0 :=
+  rfl
+
+@[simp]
+theorem snd_decompLinearIsometryEquiv (f : V →ᴬ[𝕜] W) :
+    (decompLinearIsometryEquiv 𝕜 R V W f).2 = f.linear :=
+  rfl
+
+@[simp]
+theorem decompLinearIsometryEquiv_symm_apply (p : W × (V →L[𝕜] W)) (x : V) :
+    (decompLinearIsometryEquiv 𝕜 R V W).symm p x = p.2 x +ᵥ p.1 :=
+  rfl
+
+@[simp]
+theorem decompLinearIsometryEquiv_symm_contLinear (p : W × (V →L[𝕜] W)) :
+    ((decompLinearIsometryEquiv 𝕜 R V W).symm p).contLinear = p.2 := by
+  rw [decompLinearIsometryEquiv, ← LinearIsometryEquiv.coe_symm_toLinearEquiv,
+    decompLinearEquiv_symm_contLinear]
+
+@[deprecated decompLinearIsometryEquiv (since := "2026-03-03"),
+  inherit_doc decompLinearIsometryEquiv]
+abbrev toConstProdContinuousLinearMap := decompLinearIsometryEquiv 𝕜 𝕜 V W
+
+set_option linter.deprecated false in
+@[deprecated fst_decompLinearIsometryEquiv (since := "2026-03-03")]
 theorem toConstProdContinuousLinearMap_fst (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).fst = f 0 :=
   rfl
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated snd_decompLinearIsometryEquiv (since := "2026-03-03")]
 theorem toConstProdContinuousLinearMap_snd (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).snd = f.contLinear :=
   rfl

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -514,7 +514,7 @@ theorem fst_decompEquiv (f : V →ᴬ[R] Q) :
 
 @[simp]
 theorem snd_decompEquiv (f : V →ᴬ[R] Q) :
-    (decompEquiv R V Q f).2 = f.linear :=
+    (decompEquiv R V Q f).2 = f.contLinear :=
   rfl
 
 @[simp]
@@ -523,7 +523,7 @@ theorem decompEquiv_symm_apply (p : Q × (V →L[R] W)) (x : V) :
   rfl
 
 @[simp]
-theorem decompEquiv_symm_linear (p : Q × (V →L[R] W)) :
+theorem decompEquiv_symm_contLinear (p : Q × (V →L[R] W)) :
     ((decompEquiv R V Q).symm p).contLinear = p.2 := by
   haveI := IsTopologicalAddTorsor.to_isTopologicalAddGroup W Q
   ext; simp [decompEquiv]
@@ -549,12 +549,12 @@ theorem fst_decompLinearEquiv (f : V →ᴬ[R] W) :
 
 @[simp]
 theorem snd_decompLinearEquiv (f : V →ᴬ[R] W) :
-    (decompLinearEquiv R S V W f).2 = f.linear :=
+    (decompLinearEquiv R S V W f).2 = f.contLinear :=
   rfl
 
 @[simp]
 theorem decompLinearEquiv_symm_apply (p : W × (V →L[R] W)) (x : V) :
-    (decompLinearEquiv R S V W).symm p x = p.2 x +ᵥ p.1 :=
+    (decompLinearEquiv R S V W).symm p x = p.2 x + p.1 :=
   rfl
 
 @[simp]
@@ -584,7 +584,7 @@ theorem fst_decompAffineEquiv (f : V →ᴬ[R] Q) :
 
 @[simp]
 theorem snd_decompAffineEquiv (f : V →ᴬ[R] Q) :
-    (decompAffineEquiv R S V Q f).2 = f.linear :=
+    (decompAffineEquiv R S V Q f).2 = f.contLinear :=
   rfl
 
 @[simp]
@@ -593,9 +593,9 @@ theorem decompAffineEquiv_symm_apply (p : Q × (V →L[R] W)) (x : V) :
   rfl
 
 @[simp]
-theorem decompAffineEquiv_symm_contLinear (p : W × (V →L[R] W)) :
-    ((decompAffineEquiv R S V W).symm p).contLinear = p.2 := by
-  rw [decompAffineEquiv, ← AffineEquiv.coe_symm_toEquiv, decompEquiv_symm_linear]
+theorem decompAffineEquiv_symm_contLinear (p : Q × (V →L[R] W)) :
+    ((decompAffineEquiv R S V Q).symm p).contLinear = p.2 := by
+  rw [decompAffineEquiv, ← AffineEquiv.coe_symm_toEquiv, decompEquiv_symm_contLinear]
 
 end
 

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -478,3 +478,125 @@ theorem _root_.ContinuousAffineMap.decomp (f : V →ᴬ[R] W) :
     Pi.add_apply, LinearMap.map_zero, zero_add, ← Function.const_def]
 
 end ContinuousLinearMap
+
+namespace ContinuousAffineMap
+
+variable (R S V : Type*) {W : Type*} (Q : Type*) [Ring S] [Ring R]
+variable [AddCommGroup V] [Module R V] [TopologicalSpace V] [IsTopologicalAddGroup V]
+variable [AddCommGroup W] [Module R W] [TopologicalSpace W]
+variable [Module S W] [SMulCommClass R S W] [ContinuousConstSMul S W]
+variable [AddTorsor W Q] [TopologicalSpace Q]
+
+section
+
+variable [IsTopologicalAddTorsor Q]
+
+/-- The space of continuous affine maps from a topological vector space to a topological affine
+space is in bijection with the product of the codomain with the space of linear maps, by taking the
+value of the affine map at `(0 : V)` and the linear part. -/
+def decompEquiv : (V →ᴬ[R] Q) ≃ Q × (V →L[R] W) where
+  toFun f := ⟨f 0, f.contLinear⟩
+  invFun p :=
+    haveI := IsTopologicalAddTorsor.to_isTopologicalAddGroup W Q
+    p.2.toContinuousAffineMap +ᵥ const R V p.1
+  left_inv f := by
+    ext x
+    simp_rw [vadd_apply, f.contLinear.coe_toContinuousAffineMap, coe_const, Function.const_apply,
+      ← f.map_vadd, vadd_eq_add, add_zero]
+  right_inv := by
+    haveI := IsTopologicalAddTorsor.to_isTopologicalAddGroup W Q
+    rintro ⟨v, f⟩; ext <;> simp
+
+@[simp]
+theorem fst_decompEquiv (f : V →ᴬ[R] Q) :
+    (decompEquiv R V Q f).1 = f 0 :=
+  rfl
+
+@[simp]
+theorem snd_decompEquiv (f : V →ᴬ[R] Q) :
+    (decompEquiv R V Q f).2 = f.linear :=
+  rfl
+
+@[simp]
+theorem decompEquiv_symm_apply (p : Q × (V →L[R] W)) (x : V) :
+    (decompEquiv R V Q).symm p x = p.2 x +ᵥ p.1 :=
+  rfl
+
+@[simp]
+theorem decompEquiv_symm_linear (p : Q × (V →L[R] W)) :
+    ((decompEquiv R V Q).symm p).contLinear = p.2 := by
+  haveI := IsTopologicalAddTorsor.to_isTopologicalAddGroup W Q
+  ext; simp [decompEquiv]
+
+end
+
+section
+
+variable (W) [IsTopologicalAddGroup W]
+
+/-- The space of continuous affine maps between topological vector spaces is linearly isomorphic to
+the product of the codomain with the space of linear maps, by taking the value of the affine map at
+`(0 : V)` and the linear part. -/
+def decompLinearEquiv : (V →ᴬ[R] W) ≃ₗ[S] W × (V →L[R] W) where
+  __ := decompEquiv R V W
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+@[simp]
+theorem fst_decompLinearEquiv (f : V →ᴬ[R] W) :
+    (decompLinearEquiv R S V W f).1 = f 0 :=
+  rfl
+
+@[simp]
+theorem snd_decompLinearEquiv (f : V →ᴬ[R] W) :
+    (decompLinearEquiv R S V W f).2 = f.linear :=
+  rfl
+
+@[simp]
+theorem decompLinearEquiv_symm_apply (p : W × (V →L[R] W)) (x : V) :
+    (decompLinearEquiv R S V W).symm p x = p.2 x +ᵥ p.1 :=
+  rfl
+
+@[simp]
+theorem decompLinearEquiv_symm_contLinear (p : W × (V →L[R] W)) :
+    ((decompLinearEquiv R S V W).symm p).contLinear = p.2 := by
+  ext; simp [decompLinearEquiv]
+
+end
+
+section
+
+variable [IsTopologicalAddGroup W] [IsTopologicalAddTorsor Q]
+
+/-- The space of continuous affine maps from a topological vector space to a topological affine
+space is affinely isomorphic to the product of the codomain with the space of linear maps, by taking
+the value of the affine map at `(0 : V)` and the linear part. -/
+@[simps linear]
+def decompAffineEquiv : (V →ᴬ[R] Q) ≃ᵃ[S] Q × (V →L[R] W) where
+  __ := decompEquiv R V Q
+  linear := decompLinearEquiv R S V W
+  map_vadd' _ _ := rfl
+
+@[simp]
+theorem fst_decompAffineEquiv (f : V →ᴬ[R] Q) :
+    (decompAffineEquiv R S V Q f).1 = f 0 :=
+  rfl
+
+@[simp]
+theorem snd_decompAffineEquiv (f : V →ᴬ[R] Q) :
+    (decompAffineEquiv R S V Q f).2 = f.linear :=
+  rfl
+
+@[simp]
+theorem decompAffineEquiv_symm_apply (p : Q × (V →L[R] W)) (x : V) :
+    (decompAffineEquiv R S V Q).symm p x = p.2 x +ᵥ p.1 :=
+  rfl
+
+@[simp]
+theorem decompAffineEquiv_symm_contLinear (p : W × (V →L[R] W)) :
+    ((decompAffineEquiv R S V W).symm p).contLinear = p.2 := by
+  rw [decompAffineEquiv, ← AffineEquiv.coe_symm_toEquiv, decompEquiv_symm_linear]
+
+end
+
+end ContinuousAffineMap


### PR DESCRIPTION
This PR defines an equivalence `(V →ᴬ[R] Q) ≃ Q × (V →L[R] W)`, plus `LinearEquiv` and `AffineEquiv` variants. To match the names of the new equivalences, `ContinuousAffineMap.toConstProdLinearMap` is also renamed.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
