### PR TITLE
[Merged by Bors] - feat(Analysis): Eliminate a hypothesis on IsTheta.rpow

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -243,12 +243,10 @@ theorem IsBigO.rpow (hr : 0 ≤ r) (hg : 0 ≤ᶠ[l] g) (h : f =O[l] g) :
 theorem IsTheta.rpow (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h : f =Θ[l] g) :
     (fun x => f x ^ r) =Θ[l] fun x => g x ^ r := by
   wlog hr : r ≥ 0 with rpow_pos
-  · rw[← isTheta_inv]
-    calc
-      (fun x ↦ (f x ^ r)⁻¹) =ᶠ[l] fun x ↦ f x ^ (-r) :=
-        hf.mono fun x hfx => (Real.rpow_neg hfx _).symm
-      _ =Θ[l] fun x ↦ (g x ^ (-r)) := rpow_pos hf hg h (by linarith)
-      _ =ᶠ[l] fun x ↦ (g x ^ r)⁻¹ := hg.mono fun x hgx => Real.rpow_neg hgx _
+  · rw [← isTheta_inv]
+    grw [← EventuallyEq.isTheta <| hf.mono fun x hfx ↦ Real.rpow_neg hfx r]
+    grw [← EventuallyEq.isTheta <| hg.mono fun x hgx ↦ Real.rpow_neg hgx r]
+    exact rpow_pos hf hg h <| by linarith
   exact ⟨h.1.rpow hr hg, h.2.rpow hr hf⟩
 
 theorem IsLittleO.rpow (hr : 0 < r) (hg : 0 ≤ᶠ[l] g) (h : f =o[l] g) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -240,23 +240,16 @@ theorem IsBigO.rpow (hr : 0 ≤ r) (hg : 0 ≤ᶠ[l] g) (h : f =O[l] g) :
   let ⟨_, hc, h'⟩ := h.exists_nonneg
   (h'.rpow hc hr hg).isBigO
 
-theorem IsTheta.rpow (hr : 0 ≤ r) (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h : f =Θ[l] g) :
-    (fun x => f x ^ r) =Θ[l] fun x => g x ^ r :=
-  ⟨h.1.rpow hr hg, h.2.rpow hr hf⟩
-
-theorem IsTheta.rpow' (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h : f =Θ[l] g) :
+theorem IsTheta.rpow (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h : f =Θ[l] g) :
     (fun x => f x ^ r) =Θ[l] fun x => g x ^ r := by
   wlog hr : r ≥ 0 with rpow_pos
   · rw[← isTheta_inv]
     calc
-      (fun x ↦ (f x ^ r)⁻¹) =ᶠ[l] (fun x ↦ f x ^ (-r)) := by
-          filter_upwards [hf] with x hfx
-          exact (Real.rpow_neg hfx _).symm
+      (fun x ↦ (f x ^ r)⁻¹) =ᶠ[l] fun x ↦ f x ^ (-r) :=
+        hf.mono fun x hfx => (Real.rpow_neg hfx _).symm
       _ =Θ[l] fun x ↦ (g x ^ (-r)) := rpow_pos hf hg h (by linarith)
-      _ =ᶠ[l] fun x ↦ (g x ^ r)⁻¹ := by
-          filter_upwards [hg] with x hgx
-          exact Real.rpow_neg hgx _
-  exact IsTheta.rpow hr hf hg h
+      _ =ᶠ[l] fun x ↦ (g x ^ r)⁻¹ := hg.mono fun x hgx => Real.rpow_neg hgx _
+  exact ⟨h.1.rpow hr hg, h.2.rpow hr hf⟩
 
 theorem IsLittleO.rpow (hr : 0 < r) (hg : 0 ≤ᶠ[l] g) (h : f =o[l] g) :
     (fun x => f x ^ r) =o[l] fun x => g x ^ r := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -244,6 +244,20 @@ theorem IsTheta.rpow (hr : 0 ≤ r) (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h
     (fun x => f x ^ r) =Θ[l] fun x => g x ^ r :=
   ⟨h.1.rpow hr hg, h.2.rpow hr hf⟩
 
+theorem IsTheta.rpow' (hf : 0 ≤ᶠ[l] f) (hg : 0 ≤ᶠ[l] g) (h : f =Θ[l] g) :
+    (fun x => f x ^ r) =Θ[l] fun x => g x ^ r := by
+  wlog hr : r ≥ 0 with rpow_pos
+  · rw[← isTheta_inv]
+    calc
+      (fun x ↦ (f x ^ r)⁻¹) =ᶠ[l] (fun x ↦ f x ^ (-r)) := by
+          filter_upwards [hf] with x hfx
+          exact (Real.rpow_neg hfx _).symm
+      _ =Θ[l] fun x ↦ (g x ^ (-r)) := rpow_pos hf hg h (by linarith)
+      _ =ᶠ[l] fun x ↦ (g x ^ r)⁻¹ := by
+          filter_upwards [hg] with x hgx
+          exact Real.rpow_neg hgx _
+  exact IsTheta.rpow hr hf hg h
+
 theorem IsLittleO.rpow (hr : 0 < r) (hg : 0 ≤ᶠ[l] g) (h : f =o[l] g) :
     (fun x => f x ^ r) =o[l] fun x => g x ^ r := by
   refine .of_isBigOWith fun c hc ↦ ?_


### PR DESCRIPTION
A strengthened version of `IsTheta.rpow`: if $f$ and $g$ are eventually nonnegative functions with $f = \Theta(g)$ and $r \in \mathbb{R}$, then $f^r = \Theta(g^r)$.

The previous version had a hypothesis that $r \geq 0$. The present version proves by splitting into two cases; in the case $r < 0$, the lower and upper bounds must be used in reverse order.

Since `IsTheta.rpow` is not used elsewhere in Mathlib, this should be an easy one to merge.

(Claude AI was used to help in the golfing.)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
