### PR TITLE
feat: add a LE version of previous div_lt_div_iff_mul_lt_mul theorem

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -123,12 +123,28 @@ instance : AddLeftMono ℚ where
 @[simp] lemma num_pos {a : ℚ} : 0 < a.num ↔ 0 < a := lt_iff_lt_of_le_iff_le num_nonpos
 @[simp] lemma num_neg {a : ℚ} : a.num < 0 ↔ a < 0 := lt_iff_lt_of_le_iff_le num_nonneg
 
+theorem div_le_div_iff_mul_le_mul {a b c d : ℤ} (b_pos : 0 < b) (d_pos : 0 < d) :
+    (a : ℚ) / b ≤ c / d ↔ a * d ≤ c * b := by
+  apply Iff.intro <;> simp [div_def', Rat.divInt_le_divInt b_pos d_pos]
+
 theorem div_lt_div_iff_mul_lt_mul {a b c d : ℤ} (b_pos : 0 < b) (d_pos : 0 < d) :
     (a : ℚ) / b < c / d ↔ a * d < c * b := by
   simp only [lt_iff_le_not_ge]
   apply and_congr
   · simp [div_def', Rat.divInt_le_divInt b_pos d_pos]
   · simp [div_def', Rat.divInt_le_divInt d_pos b_pos]
+
+theorem div_le_div_iff_num_le_num {a b c : ℤ} (c_pos : 0 < c) :
+    (a : ℚ) / c ≤ b / c ↔ a ≤ b := by
+  apply Iff.intro
+  · intro h; exact (Int.mul_le_mul_right c_pos).mp ((div_le_div_iff_mul_le_mul c_pos c_pos).mp h)
+  · intro h; exact (div_le_div_iff_mul_le_mul c_pos c_pos).mpr ((Int.mul_le_mul_right c_pos).mpr h)
+
+theorem div_lt_div_iff_num_lt_num {a b c : ℤ} (c_pos : 0 < c) :
+    (a : ℚ) / c < b / c ↔ a < b := by
+  apply Iff.intro
+  · intro h; exact (Int.mul_lt_mul_right c_pos).mp ((div_lt_div_iff_mul_lt_mul c_pos c_pos).mp h)
+  · intro h; exact (div_lt_div_iff_mul_lt_mul c_pos c_pos).mpr ((Int.mul_lt_mul_right c_pos).mpr h)
 
 theorem num_le_denom_iff {q : ℚ} : q.num ≤ q.den ↔ q ≤ 1 := by simp [Rat.le_iff]
 


### PR DESCRIPTION
The following is more useful due to the partial order application of LE in comparison to LT.

Additionally, add specialized cases of equal denominators as simpler syntactic sugar.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
