### PR TITLE
[Merged by Bors] - chore: update mathlib-ci ref to include merge-lean-testing-pr fixes

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -23,7 +23,7 @@ on:
       mathlib_ci_ref:
         type: string
         required: false
-        default: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        default: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
 
 env:
   # Disable Lake's automatic fetching of cloud builds.

--- a/.github/workflows/commit_verification.yml
+++ b/.github/workflows/commit_verification.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/latest_import.yml
+++ b/.github/workflows/latest_import.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/long_file_report.yml
+++ b/.github/workflows/long_file_report.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -180,7 +180,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/nightly-regression-report.yml
+++ b/.github/workflows/nightly-regression-report.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/nightly_bump_and_merge.yml
+++ b/.github/workflows/nightly_bump_and_merge.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 
@@ -332,7 +332,7 @@ jobs:
             MESSAGE+="- [lean-pr-testing-${PR_NUMBER}](${GITHUB_DIFF}) (adaptations for lean#${PR_NUMBER})"$'\n\n'
             MESSAGE+=$'```bash\n'
             MESSAGE+=$'tmp=$(mktemp)\n'
-            MESSAGE+=$'wget -qO "$tmp" https://raw.githubusercontent.com/leanprover-community/mathlib-ci/7c2dcf950607e48029aec2a614e840f2a14ae7e1/scripts/nightly/merge-lean-testing-pr.sh\n'
+            MESSAGE+=$'wget -qO "$tmp" https://raw.githubusercontent.com/leanprover-community/mathlib-ci/7355aeb4f32cb2a181d02abd7a9d6ab4fe033286/scripts/nightly/merge-lean-testing-pr.sh\n'
             MESSAGE+=$'chmod +x "$tmp"\n'
             MESSAGE+="\"\$tmp\" ${PR_NUMBER}"$'\n'
             MESSAGE+=$'```\n\n'

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 env:
-  MATHLIB_CI_REF: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+  MATHLIB_CI_REF: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
 
 jobs:
   handle_failure:

--- a/.github/workflows/technical_debt_metrics.yml
+++ b/.github/workflows/technical_debt_metrics.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -77,7 +77,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: leanprover-community/mathlib-ci
-          ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+          ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
           fetch-depth: 1
           path: ci-tools
 

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: leanprover-community/mathlib-ci
-        ref: 7c2dcf950607e48029aec2a614e840f2a14ae7e1
+        ref: 7355aeb4f32cb2a181d02abd7a9d6ab4fe033286
         fetch-depth: 1
         path: ci-tools
 


### PR DESCRIPTION
This PR updates the pinned `mathlib-ci` SHA in all workflow files from `7c2dcf95` to `7355aeb4`, picking up:
- mathlib-ci#2 / mathlib-ci#4: fix `merge-lean-testing-pr.sh` to detect the nightly-testing remote dynamically (instead of hardcoding remote names)
- mathlib-ci#1: fail early if needed branches are checked out in other worktrees

🤖 Prepared with Claude Code