### PR TITLE
[Merged by Bors] - feat(GroupTheory/Nilpotent): remove `[IsNilpotent]` assumption from some theorems

### DIFF
--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -718,23 +718,29 @@ lemma upperCentralSeries.eq_top [IsNilpotent G] {a b : ℕ} (ab : a < b)
   grind only [IsNilpotent.nilpotent', IsNilpotent.nilpotent,
     upperCentralSeries_eq_top_iff_nilpotencyClass_le, eq_ge_of_eq_gt]
 
-lemma nilpotencyClass_le_of_upperCentralSeries_eq [IsNilpotent G] {a b : ℕ} (ab : a < b)
+lemma nilpotencyClass_le_of_upperCentralSeries_eq {a b : ℕ} (ab : a < b)
     (hn : upperCentralSeries G a = upperCentralSeries G b) :
     nilpotencyClass G ≤ a := by
-  grind only [IsNilpotent.nilpotent', IsNilpotent.nilpotent, upperCentralSeries.eq_top,
-    upperCentralSeries_eq_top_iff_nilpotencyClass_le]
+  by_cases hG : IsNilpotent G
+  · grind only [IsNilpotent.nilpotent', IsNilpotent.nilpotent, upperCentralSeries.eq_top,
+      upperCentralSeries_eq_top_iff_nilpotencyClass_le]
+  · rw [nilpotencyClass_of_not_nilpotent hG]
+    apply Nat.zero_le
 
 variable (G) in
-lemma upperCentralSeries.StrictMonoOn [IsNilpotent G] :
+lemma upperCentralSeries.StrictMonoOn :
     StrictMonoOn (upperCentralSeries G) (Set.Iic (nilpotencyClass G)) := by
-  intros a ha b hb ab
-  simp only [Set.mem_Iic] at ha hb
-  apply lt_of_le_of_ne
-  · exact upperCentralSeries_mono _ ab.le
-  · grind only [IsNilpotent.nilpotent', IsNilpotent.nilpotent, eq_top,
-      upperCentralSeries_eq_top_iff_nilpotencyClass_le]
+  by_cases hG : IsNilpotent G
+  · intros a ha b hb ab
+    simp only [Set.mem_Iic] at ha hb
+    apply lt_of_le_of_ne
+    · exact upperCentralSeries_mono _ ab.le
+    · grind only [IsNilpotent.nilpotent', IsNilpotent.nilpotent, eq_top,
+        upperCentralSeries_eq_top_iff_nilpotencyClass_le]
+  · rw [nilpotencyClass_of_not_nilpotent hG, ← Nat.bot_eq_zero, Set.Iic_bot]
+    apply Set.strictMonoOn_singleton
 
-lemma upperCentralSeries.card_image_eq_of_le_nilpotencyClass [IsNilpotent G] {a : ℕ}
+lemma upperCentralSeries.card_image_eq_of_le_nilpotencyClass {a : ℕ}
     (h2 : a ≤ nilpotencyClass G) :
     (upperCentralSeries G '' (Set.Iic a)).ncard = a + 1 := by
   refine Set.ncard_eq_of_bijective (fun _ => upperCentralSeries G ·) ?_ ?_ ?_


### PR DESCRIPTION
This PR uses the junk value of `nilpotencyClass` to remove `[IsNilpotent]` assumption from some theorems.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
