### PR TITLE
feat(CategoryTheory/Endofunctor/Algebra): Adamek's Initial Algebra Theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2504,6 +2504,9 @@ public import Mathlib.CategoryTheory.EffectiveEpi.RegularEpi
 public import Mathlib.CategoryTheory.Elements
 public import Mathlib.CategoryTheory.Elementwise
 public import Mathlib.CategoryTheory.Endofunctor.Algebra
+public import Mathlib.CategoryTheory.Endofunctor.Algebra.Adamek
+public import Mathlib.CategoryTheory.Endofunctor.Algebra.ChainShift
+public import Mathlib.CategoryTheory.Endofunctor.Algebra.InitialChain
 public import Mathlib.CategoryTheory.Endomorphism
 public import Mathlib.CategoryTheory.Enriched.Basic
 public import Mathlib.CategoryTheory.Enriched.EnrichedCat

--- a/Mathlib/CategoryTheory/Endofunctor/Algebra/Adamek.lean
+++ b/Mathlib/CategoryTheory/Endofunctor/Algebra/Adamek.lean
@@ -1,0 +1,262 @@
+/-
+Copyright (c) 2026 Larsen Close. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Larsen Close
+-/
+module
+
+public import Mathlib.CategoryTheory.Endofunctor.Algebra.ChainShift
+public import Mathlib.CategoryTheory.Endofunctor.Algebra
+
+/-!
+# Adamek's initial algebra theorem
+
+Given an endofunctor `F : C ⥤ C` on a category with an initial object,
+if the initial chain `⊥ → F(⊥) → F²(⊥) → ⋯` has a colimit `L` and `F`
+preserves this colimit, then `L` carries the structure of an initial
+`F`-algebra. The algebra structure map `F(L) → L` is an isomorphism
+(by Lambek's lemma applied to the initial algebra).
+
+## Main definitions
+
+- `CategoryTheory.Endofunctor.Algebra.adamek` : the `F`-algebra on the colimit `L`
+- `CategoryTheory.Endofunctor.Algebra.adamekHom` : the unique algebra homomorphism from the
+  Adamek algebra to any other algebra
+- `CategoryTheory.Endofunctor.Algebra.adamekFromInitial` : the Adamek algebra constructed from
+  `HasColimit` and `PreservesColimit` instances
+- `CategoryTheory.Endofunctor.Algebra.adamekStructureIso` : the isomorphism `F(L) ≅ L`
+  (Lambek's lemma)
+- `CategoryTheory.Endofunctor.Algebra.adamekFixedPoint` : the colimit as a fixed point of `F`
+
+## Main results
+
+- `CategoryTheory.Endofunctor.Algebra.adamek_isInitial` : the Adamek algebra is initial in
+  `Endofunctor.Algebra F`
+- `CategoryTheory.Endofunctor.Algebra.adamekFromInitial_isInitial` : initiality from
+  `HasColimit` and `PreservesColimit` instances
+
+## References
+
+- [J. Adamek, *Free algebras and automata realizations in the language of categories and
+  functors*][adamek1974]
+-/
+
+@[expose] public section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace CategoryTheory.Endofunctor
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+variable (F : C ⥤ C) [HasInitial C]
+
+/-! ### Algebra structure on the colimit -/
+
+section AlgebraConstruction
+
+variable {c : Cocone (initialChain F)} (hc : IsColimit c)
+variable [PreservesColimit (initialChain F) F]
+
+/-- The colimit of `F` applied to the initial chain is a colimit (by preservation). -/
+noncomputable def preservedColimit :
+    IsColimit (F.mapCocone c) :=
+  isColimitOfPreserves F hc
+
+/-- The algebra structure map `F(L) → L` for the Adamek algebra. -/
+noncomputable def adamekStr : F.obj c.pt ⟶ c.pt :=
+  (preservedColimit F hc).desc (shiftCocone F c)
+
+/-- The structure map commutes with the colimit inclusions:
+`F.map (ι_n) ≫ adamekStr = ι_{n+1}`. -/
+@[reassoc]
+lemma adamekStr_fac (n : ℕ) :
+    F.map (c.ι.app n) ≫ adamekStr F hc = c.ι.app (n + 1) :=
+  (preservedColimit F hc).fac (shiftCocone F c) n
+
+end AlgebraConstruction
+
+namespace Algebra
+
+section AlgebraDefinition
+
+variable (c : Cocone (initialChain F)) (hc : IsColimit c)
+variable [PreservesColimit (initialChain F) F]
+
+/-- The Adamek algebra: the colimit of the initial chain, equipped with the
+algebra structure map `F(L) → L` obtained from the preserved colimit. -/
+noncomputable def adamek : Endofunctor.Algebra F where
+  a := c.pt
+  str := adamekStr F hc
+
+@[simp]
+lemma adamek_a : (adamek F c hc).a = c.pt := rfl
+
+@[simp]
+lemma adamek_str : (adamek F c hc).str = adamekStr F hc := rfl
+
+end AlgebraDefinition
+
+/-! ### Algebra cocone and initiality -/
+
+section AlgebraCoconeApp
+
+/-- The `n`-th leg of the algebra cocone: the unique map `F^n(⊥) → B.a`. -/
+noncomputable def algebraCoconeApp (B : Endofunctor.Algebra F) :
+    (n : ℕ) → iterateObj F n ⟶ B.a
+  | 0 => initial.to B.a
+  | n + 1 => F.map (algebraCoconeApp B n) ≫ B.str
+
+@[simp]
+lemma algebraCoconeApp_zero (B : Endofunctor.Algebra F) :
+    algebraCoconeApp F B 0 = initial.to B.a := rfl
+
+@[simp]
+lemma algebraCoconeApp_succ (B : Endofunctor.Algebra F) (n : ℕ) :
+    algebraCoconeApp F B (n + 1) =
+    F.map (algebraCoconeApp F B n) ≫ B.str := rfl
+
+/-- The successor map of the chain composes with the next algebra cocone leg
+to give the current one: `iterateMap k ≫ f_{k+1} = f_k`. -/
+lemma iterateMap_comp_algebraCoconeApp (B : Endofunctor.Algebra F) (k : ℕ) :
+    iterateMap F k ≫ algebraCoconeApp F B (k + 1) = algebraCoconeApp F B k := by
+  induction k with
+  | zero => exact initial.hom_ext _ _
+  | succ k ih =>
+    change F.map (iterateMap F k) ≫ (F.map (algebraCoconeApp F B (k + 1)) ≫ B.str) =
+      F.map (algebraCoconeApp F B k) ≫ B.str
+    rw [← Category.assoc, ← F.map_comp, ih]
+
+end AlgebraCoconeApp
+
+section Initiality
+
+variable {c : Cocone (initialChain F)} (hc : IsColimit c)
+variable [PreservesColimit (initialChain F) F]
+
+/-- Given an `F`-algebra `(B, β)`, define the cocone over the initial chain with point `B`. -/
+noncomputable def algebraCocone (B : Endofunctor.Algebra F) :
+    Cocone (initialChain F) where
+  pt := B.a
+  ι :=
+  { app := fun n => algebraCoconeApp F B n
+    naturality := by
+      intro m n α
+      simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id]
+      have hle := leOfHom α
+      rw [show (initialChain F).map α = (initialChain F).map (homOfLE hle) from
+        congr_arg _ (Subsingleton.elim _ _)]
+      induction hle with
+      | refl =>
+        rw [show (homOfLE (le_refl m) : (m : ℕ) ⟶ m) = 𝟙 _ from Subsingleton.elim _ _]
+        rw [Functor.map_id, Category.id_comp]
+      | @step k hle' ih =>
+        rw [show (homOfLE (Nat.le.step hle') : (m : ℕ) ⟶ (k + 1)) =
+          (homOfLE hle' : (m : ℕ) ⟶ k) ≫
+          (homOfLE (Nat.le_add_right k 1) : (k : ℕ) ⟶ (k + 1)) from
+          Subsingleton.elim _ _]
+        simp only [Functor.map_comp, Category.assoc, initialChain_map_succ]
+        -- Goal: ... ≫ iterateMap F k ≫ algebraCoconeApp F B k.succ = ...
+        erw [iterateMap_comp_algebraCoconeApp F B k]
+        exact ih (homOfLE hle') }
+
+omit [PreservesColimit (initialChain F) F] in
+@[simp]
+lemma algebraCocone_ι_app (B : Endofunctor.Algebra F) (n : ℕ) :
+    (algebraCocone F B).ι.app n = algebraCoconeApp F B n := rfl
+
+/-- The unique algebra homomorphism from the Adamek algebra to any other algebra. -/
+noncomputable def adamekHom (B : Endofunctor.Algebra F) :
+    adamek F _ hc ⟶ B where
+  f := hc.desc (algebraCocone F B)
+  h := by
+    apply (preservedColimit F hc).hom_ext
+    intro n
+    simp only [Functor.mapCocone_pt, Functor.mapCocone_ι_app]
+    -- Goal: F.map (c.ι.app n) ≫ F.map (desc) ≫ B.str =
+    --       F.map (c.ι.app n) ≫ (adamek ...).str ≫ desc
+    -- Both sides equal algebraCoconeApp F B (n + 1)
+    -- LHS: reassociate and fold F.map_comp
+    conv_lhs => erw [← Category.assoc, ← F.map_comp, hc.fac (algebraCocone F B) n]
+    -- RHS: unfold adamek str and use fac
+    conv_rhs => erw [adamek_str, ← Category.assoc, adamekStr_fac F hc n,
+      hc.fac (algebraCocone F B) (n + 1)]
+    rfl
+
+@[simp]
+lemma adamekHom_f (B : Endofunctor.Algebra F) :
+    (adamekHom F hc B).f = hc.desc (algebraCocone F B) := rfl
+
+/-- Any algebra homomorphism from the Adamek algebra equals the canonical one. -/
+lemma adamekHom_unique (B : Endofunctor.Algebra F)
+    (g : adamek F _ hc ⟶ B) :
+    g = adamekHom F hc B := by
+  ext
+  apply hc.uniq (algebraCocone F B)
+  intro n
+  induction n with
+  | zero => exact initial.hom_ext _ _
+  | succ n ih =>
+    rw [show c.ι.app (n + 1) = F.map (c.ι.app n) ≫ adamekStr F hc from
+      (adamekStr_fac F hc n).symm]
+    erw [Category.assoc]
+    have hg : adamekStr F hc ≫ g.f = F.map g.f ≫ B.str := by
+      have := g.h; simp only [adamek_str] at this; exact this.symm
+    erw [hg]
+    conv_lhs => erw [← Category.assoc, ← F.map_comp, ih]
+    rfl
+
+/-- **Adamek's Initial Algebra Theorem.** The colimit of the initial chain,
+equipped with the algebra structure from the preserved colimit,
+is an initial object in the category of `F`-algebras. -/
+noncomputable def adamek_isInitial :
+    IsInitial (adamek F _ hc) :=
+  IsInitial.ofUniqueHom
+    (fun B => adamekHom F hc B)
+    (fun B g => adamekHom_unique F hc B g)
+
+end Initiality
+
+/-! ### Convenience API from `HasColimit` and `PreservesColimit` -/
+
+section Connection
+
+variable [HasColimit (initialChain F)]
+variable [PreservesColimit (initialChain F) F]
+
+/-- The standard colimit cocone for the initial chain. -/
+noncomputable def standardCocone : Cocone (initialChain F) :=
+  colimit.cocone (initialChain F)
+
+/-- The standard colimit is indeed a colimit. -/
+noncomputable def standardIsColimit : IsColimit (standardCocone F) :=
+  colimit.isColimit (initialChain F)
+
+/-- The Adamek initial algebra constructed from `HasColimit` and `PreservesColimit` instances. -/
+noncomputable def adamekFromInitial : Endofunctor.Algebra F :=
+  adamek F (standardCocone F) (standardIsColimit F)
+
+/-- The Adamek algebra constructed from instances is initial. -/
+noncomputable def adamekFromInitial_isInitial :
+    IsInitial (adamekFromInitial F) :=
+  adamek_isInitial F (standardIsColimit F)
+
+/-- The structure map of the initial algebra is an isomorphism: `F(L) ≅ L`.
+This is Lambek's lemma applied to the Adamek initial algebra. -/
+noncomputable def adamekStructureIso :
+    F.obj (adamekFromInitial F).a ≅ (adamekFromInitial F).a := by
+  haveI : IsIso (adamekFromInitial F).str :=
+    Endofunctor.Algebra.Initial.str_isIso (adamekFromInitial_isInitial F)
+  exact asIso (adamekFromInitial F).str
+
+/-- The colimit of the initial chain is a fixed point of `F`: `F(L) ≅ L`. -/
+noncomputable def adamekFixedPoint :
+    F.obj (colimit (initialChain F)) ≅ colimit (initialChain F) :=
+  adamekStructureIso F
+
+end Connection
+
+end Algebra
+
+end CategoryTheory.Endofunctor

--- a/Mathlib/CategoryTheory/Endofunctor/Algebra/ChainShift.lean
+++ b/Mathlib/CategoryTheory/Endofunctor/Algebra/ChainShift.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Larsen Close. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Larsen Close
+-/
+module
+
+public import Mathlib.CategoryTheory.Endofunctor.Algebra.InitialChain
+public import Mathlib.CategoryTheory.Limits.HasLimits
+public import Mathlib.CategoryTheory.Limits.Preserves.Basic
+
+/-!
+# Shifted chain colimit equivalence
+
+Given a cocone over the initial chain `⊥ → F(⊥) → F²(⊥) → ⋯` with colimit `L`,
+we construct a cocone over the "shifted" chain `F(⊥) → F²(⊥) → F³(⊥) → ⋯`
+(equivalently, the composite functor `initialChain F ⋙ F`) with the same point `L`.
+
+The key result is that if the original cocone is a colimit, then the shifted cocone
+is also a colimit. This is the foundation for constructing the Adamek algebra.
+
+## Main definitions
+
+- `CategoryTheory.Endofunctor.shiftCocone` : shifted cocone from a cocone over the initial chain
+- `CategoryTheory.Endofunctor.extendCocone` : extend a cocone over the shifted chain to the full
+  chain
+
+## Main results
+
+- `CategoryTheory.Endofunctor.shiftCoconeIsColimit` : the shifted cocone is a colimit when the
+  original is
+
+## References
+
+- [J. Adamek, *Free algebras and automata realizations in the language of categories and
+  functors*][adamek1974]
+-/
+
+@[expose] public section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace CategoryTheory.Endofunctor
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+variable (F : C ⥤ C) [HasInitial C]
+
+/-- Given a cocone over the initial chain with point `L`, construct a cocone
+over `initialChain F ⋙ F` (the shifted chain) with the same point `L`.
+The legs are the original cocone legs shifted by one: `ι_{n+1}` for each `n`. -/
+noncomputable def shiftCocone (c : Cocone (initialChain F)) :
+    Cocone (initialChain F ⋙ F) where
+  pt := c.pt
+  ι :=
+  { app := fun n => c.ι.app (n + 1)
+    naturality := by
+      intro m n α
+      simp only [Functor.comp_obj, Functor.comp_map, Functor.const_obj_obj,
+        Functor.const_obj_map, Category.comp_id]
+      have hle := leOfHom α
+      rw [show (initialChain F).map α = (initialChain F).map (homOfLE hle) from
+        congr_arg _ (Subsingleton.elim _ _)]
+      rw [← initialChain_map_succ_eq F hle]
+      exact c.w (homOfLE (Nat.succ_le_succ hle)) }
+
+@[simp]
+lemma shiftCocone_ι_app (c : Cocone (initialChain F)) (n : ℕ) :
+    (shiftCocone F c).ι.app n = c.ι.app (n + 1) := rfl
+
+/-- Extend a cocone over the shifted chain to one over the full initial chain,
+by adding `initial.to` as the zeroth leg. -/
+noncomputable def extendCocone (s : Cocone (initialChain F ⋙ F)) :
+    Cocone (initialChain F) where
+  pt := s.pt
+  ι :=
+  { app := fun n =>
+      match n with
+      | 0 => initial.to s.pt
+      | n + 1 => s.ι.app n
+    naturality := by
+      intro m n α
+      simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id]
+      match m, n with
+      | 0, 0 =>
+        rw [show α = 𝟙 _ from Subsingleton.elim _ _, Functor.map_id, Category.id_comp]
+      | 0, (n + 1) =>
+        exact initial.hom_ext _ _
+      | (m + 1), (n + 1) =>
+        have hle := Nat.le_of_succ_le_succ (leOfHom α)
+        rw [show (initialChain F).map α =
+          (initialChain F).map (homOfLE (Nat.succ_le_succ hle)) from
+          congr_arg _ (Subsingleton.elim _ _)]
+        rw [initialChain_map_succ_eq F hle]
+        have := s.w (homOfLE hle)
+        simp only [Functor.comp_obj, Functor.comp_map, Functor.const_obj_obj] at this
+        exact this }
+
+/-- If `c` is a colimit cocone for the initial chain, then `shiftCocone F c` is a
+colimit cocone for `initialChain F ⋙ F`. -/
+noncomputable def shiftCoconeIsColimit (c : Cocone (initialChain F))
+    (hc : IsColimit c) : IsColimit (shiftCocone F c) where
+  desc s := hc.desc (extendCocone F s)
+  fac s n := by
+    simp only [shiftCocone_ι_app]
+    exact hc.fac (extendCocone F s) (n + 1)
+  uniq s g hg := by
+    apply hc.uniq (extendCocone F s)
+    intro n
+    match n with
+    | 0 => exact initial.hom_ext _ _
+    | n + 1 => exact hg n
+
+end CategoryTheory.Endofunctor

--- a/Mathlib/CategoryTheory/Endofunctor/Algebra/InitialChain.lean
+++ b/Mathlib/CategoryTheory/Endofunctor/Algebra/InitialChain.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 Larsen Close. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Larsen Close
+-/
+module
+
+public import Mathlib.CategoryTheory.Functor.OfSequence
+public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+
+/-!
+# The initial chain of an endofunctor
+
+Given a category `C` with an initial object and an endofunctor `F : C ⥤ C`,
+the *initial chain* is the sequence `⊥ → F(⊥) → F²(⊥) → ⋯` viewed as
+a functor from `ℕ` (as a preorder category) to `C`.
+
+## Main definitions
+
+- `CategoryTheory.Endofunctor.iterateObj F n` : the `n`-th iterate `F^n(⊥)`
+- `CategoryTheory.Endofunctor.iterateMap F n` : the successor map `F^n(⊥) → F^{n+1}(⊥)`
+- `CategoryTheory.Endofunctor.initialChain F` : the functor `ℕ ⥤ C`
+
+## Main results
+
+- `CategoryTheory.Endofunctor.initialChain_obj` : `(initialChain F).obj n = iterateObj F n`
+- `CategoryTheory.Endofunctor.initialChain_map_succ` : the map for `n ≤ n+1` is `iterateMap F n`
+- `CategoryTheory.Endofunctor.initialChain_map_succ_eq` : the chain map at successor indices
+  equals `F` applied to the chain map
+
+## References
+
+- [J. Adamek, *Free algebras and automata realizations in the language of categories and
+  functors*][adamek1974]
+-/
+
+@[expose] public section
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace CategoryTheory.Endofunctor
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+
+section Definitions
+
+variable (F : C ⥤ C) [HasInitial C]
+
+/-- The `n`-th iterate of `F` applied to the initial object: `F^n(⊥)`. -/
+noncomputable def iterateObj : ℕ → C
+  | 0 => ⊥_ C
+  | n + 1 => F.obj (iterateObj n)
+
+/-- The successor map `F^n(!) : F^n(⊥) → F^{n+1}(⊥)`, defined by applying `F` to the
+unique map from the initial object. -/
+noncomputable def iterateMap : (n : ℕ) → iterateObj F n ⟶ iterateObj F (n + 1)
+  | 0 => initial.to _
+  | n + 1 => F.map (iterateMap n)
+
+end Definitions
+
+section Functor
+
+variable (F : C ⥤ C) [HasInitial C]
+
+/-- The initial chain: the functor `ℕ ⥤ C` sending `n` to `F^n(⊥)`,
+constructed via `Functor.ofSequence` from the successor maps. -/
+noncomputable def initialChain : ℕ ⥤ C :=
+  Functor.ofSequence (X := iterateObj F) (iterateMap F)
+
+@[simp]
+lemma initialChain_obj (n : ℕ) :
+    (initialChain F).obj n = iterateObj F n := rfl
+
+@[simp]
+lemma initialChain_map_succ (n : ℕ) :
+    (initialChain F).map (homOfLE (Nat.le_add_right n 1)) = iterateMap F n :=
+  Functor.ofSequence_map_homOfLE_succ (iterateMap F) n
+
+/-- The chain map at successor indices equals `F` applied to the chain map.
+This is the key structural property: the `(m+1)`-to-`(n+1)` map in the chain
+is `F` applied to the `m`-to-`n` map. -/
+lemma initialChain_map_succ_eq {m n : ℕ} (h : m ≤ n) :
+    (initialChain F).map (homOfLE (Nat.succ_le_succ h)) =
+    F.map ((initialChain F).map (homOfLE h)) := by
+  induction h with
+  | refl =>
+    have h1 : (homOfLE (Nat.succ_le_succ (le_refl m)) : (m+1 : ℕ) ⟶ (m+1 : ℕ)) = 𝟙 _ :=
+      Subsingleton.elim _ _
+    have h2 : (homOfLE (le_refl m) : (m : ℕ) ⟶ (m : ℕ)) = 𝟙 _ :=
+      Subsingleton.elim _ _
+    rw [h1, h2, Functor.map_id, Functor.map_id, F.map_id]
+    rfl
+  | @step k h' ih =>
+    have decomp_lhs :
+        (homOfLE (Nat.succ_le_succ (Nat.le.step h')) : (m+1 : ℕ) ⟶ (k+2 : ℕ)) =
+        (homOfLE (Nat.succ_le_succ h') : (m+1 : ℕ) ⟶ (k+1 : ℕ)) ≫
+        (homOfLE (Nat.le_add_right (k+1) 1) : (k+1 : ℕ) ⟶ (k+2 : ℕ)) :=
+      Subsingleton.elim _ _
+    have decomp_rhs :
+        (homOfLE (Nat.le.step h') : (m : ℕ) ⟶ (k+1 : ℕ)) =
+        (homOfLE h' : (m : ℕ) ⟶ (k : ℕ)) ≫
+        (homOfLE (Nat.le_add_right k 1) : (k : ℕ) ⟶ (k+1 : ℕ)) :=
+      Subsingleton.elim _ _
+    rw [decomp_lhs, Functor.map_comp, ih, decomp_rhs, Functor.map_comp, F.map_comp]
+    congr 1
+    rw [initialChain_map_succ, initialChain_map_succ]
+    rfl
+
+end Functor
+
+end CategoryTheory.Endofunctor


### PR DESCRIPTION
## Summary

This PR adds a fully proved formalisation of **Adamek's Initial Algebra Theorem** in the `CategoryTheory.Endofunctor.Algebra` namespace. There are 0 `sorry`s.

### What is proved

Given an endofunctor `F : C ⥤ C` on a category `C` with an initial object `⊥`:

1. **Initial chain** (`InitialChain.lean`): the sequence `⊥ → F(⊥) → F²(⊥) → ⋯` is packaged as a functor `initialChain F : ℕ ⥤ C` via `Functor.ofSequence`, with `iterateObj F n = Fⁿ(⊥)` and `iterateMap F n : Fⁿ(⊥) → Fⁿ⁺¹(⊥)`.

2. **Chain shift** (`ChainShift.lean`): given a cocone `c` over `initialChain F` with point `L`, constructs `shiftCocone F c : Cocone (initialChain F ⋙ F)` with legs `ι_{n+1}`. The key lemma `shiftCoconeIsColimit` shows that if `c` is a colimit, the shifted cocone is too.

3. **Adamek's theorem** (`Adamek.lean`): given `hc : IsColimit c` and `[PreservesColimit (initialChain F) F]`, constructs the initial `F`-algebra on `L`:
   - `Algebra.adamek F c hc : Endofunctor.Algebra F` — the algebra structure
   - `Algebra.adamek_isInitial : IsInitial (adamek F _ hc)` — **the main theorem**
   - `Algebra.adamekFromInitial` / `adamekFromInitial_isInitial` — convenience API from typeclass instances
   - `Algebra.adamekStructureIso : F.obj L ≅ L` — Lambek's lemma (the structure map of the initial algebra is an iso)
   - `Algebra.adamekFixedPoint : F.obj (colimit (initialChain F)) ≅ colimit (initialChain F)`

### Mathematical context

Adamek's theorem (1974) gives a constructive proof that initial algebras exist: if `F` preserves the colimit of the chain `⊥ → F(⊥) → ⋯`, then that colimit is the carrier of the initial algebra. The algebra structure map is `F(L) → L` obtained from the universal property of the preserved colimit. Initiality follows because any algebra `(B, β)` admits a unique cocone leg `L → B` (by initiality of `⊥` in each fiber), and the homomorphism condition is verified by colimit extensionality.

### New declarations

| Declaration | Type |
|---|---|
| `Endofunctor.iterateObj` | `(C ⥤ C) → ℕ → C` |
| `Endofunctor.iterateMap` | `∀ n, Fⁿ(⊥) → Fⁿ⁺¹(⊥)` |
| `Endofunctor.initialChain` | `(C ⥤ C) → (ℕ ⥤ C)` |
| `Endofunctor.shiftCocone` | cocone over shifted chain |
| `Endofunctor.shiftCoconeIsColimit` | colimit preservation for shift |
| `Endofunctor.Algebra.adamek` | the Adamek algebra |
| `Endofunctor.Algebra.adamek_isInitial` | **Adamek's theorem** |
| `Endofunctor.Algebra.adamekStructureIso` | Lambek's lemma |
| `Endofunctor.Algebra.adamekFixedPoint` | fixed-point iso |

### References

- J. Adamek, *Free algebras and automata realizations in the language of categories and functors* (1974) [`adamek1974`]
- Adamek–Rosický, *Locally Presentable and Accessible Categories*, Cambridge University Press

### Checklist

- [x] 0 `sorry`
- [x] `lake exe lint-style` passes on all three files
- [x] Module docstrings present on all files
- [x] `@[simp]` lemmas for projections and key equalities
- [x] `@[reassoc]` on `adamekStr_fac`
- [x] Entries added to `Mathlib.lean`