### PR TITLE
[Merged by Bors] - chore: remove stray comment about backward.isDefEq.respectTransparency

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -44,9 +44,6 @@ abbrev mathlibLeanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
     ⟨`autoImplicit, false⟩,
     ⟨`maxSynthPendingDepth, .ofNat 3⟩,
-    -- This feature is broken, see
-    -- https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/574421640.
-    -- We disable it here to avoid tripping over new contributors.
   ] ++ -- options that are used in `lake build`
     mathlibOnlyLinters.map fun s ↦ { s with name := `weak ++ s.name }
 


### PR DESCRIPTION
This PR removes a stray comment in `lakefile.lean` that referred to the `backward.isDefEq.respectTransparency` option. The option itself was already removed, but the comment was left behind.

See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/576953838

🤖 Prepared with Claude Code