### PR TITLE
[Merged by Bors] - fix: non-defeq projections in `WithAbs`

### DIFF
--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -354,6 +354,7 @@ end SubfieldClass
 namespace AbsoluteValue
 
 /-- A real absolute value on a field determines a `NormedField` structure. -/
+@[implicit_reducible]
 noncomputable def toNormedField {K : Type*} [Field K] (v : AbsoluteValue K ℝ) : NormedField K where
   toField := inferInstanceAs (Field K)
   __ := v.toNormedRing

--- a/Mathlib/Analysis/Normed/Field/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Field/WithAbs.lean
@@ -141,8 +141,6 @@ abbrev Completion := UniformSpace.Completion (WithAbs v)
 
 namespace Completion
 
-/-- This is a `CoeTail` so that it does not apply to the defeq `(WithAbs v`) and replace the
-already existing `Coe (WithAbs v) v.Completion` from `UniformSpace.Completion.instCoe`. -/
 noncomputable instance : Coe K v.Completion where
   coe k : v.Completion := ↑(toAbs v k)
 

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -908,6 +908,7 @@ end SubringClass
 namespace AbsoluteValue
 
 /-- A real absolute value on a ring determines a `NormedRing` structure. -/
+@[implicit_reducible]
 noncomputable def toNormedRing {R : Type*} [Ring R] (v : AbsoluteValue R ℝ) : NormedRing R where
   norm := v
   dist x y := v (-x + y)

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -180,7 +180,7 @@ instance (v : AbsoluteValue R S) : Ring (WithAbs v) := fast_instance% (equiv v).
 set_option backward.isDefEq.respectTransparency false in
 noncomputable instance normedRing (v : AbsoluteValue R ℝ) : NormedRing (WithAbs v) :=
   letI := v.toNormedRing
-  fast_instance% (equiv v).normedRing
+  (equiv v).normedRing
 
 lemma norm_eq_apply_ofAbs (v : AbsoluteValue R ℝ) (x : WithAbs v) : ‖x‖ = v x.ofAbs := rfl
 lemma norm_toAbs_eq (v : AbsoluteValue R ℝ) (x : R) : ‖toAbs v x‖ = v x := rfl

--- a/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
+++ b/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
@@ -1,0 +1,5 @@
+import Mathlib.Analysis.Normed.Field.WithAbs
+
+example (v : AbsoluteValue R ℝ) :
+    (normedField v).toNormedCommRing.toNormedRing = (normedRing v) := by
+  with_reducible_and_instances rfl

--- a/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
+++ b/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
@@ -1,5 +1,5 @@
-import Mathlib.Analysis.Normed.Field.WithAbs
+import Mathlib
 
 example (v : AbsoluteValue R ℝ) :
-    (normedField v).toNormedCommRing.toNormedRing = (normedRing v) := by
+    (normedField v).toNormedCommRing.toNormedRing = normedRing v := by
   with_reducible_and_instances rfl

--- a/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
+++ b/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
@@ -1,5 +1,5 @@
 import Mathlib
 
-example (v : AbsoluteValue R ℝ) :
+example {R : Type*} [Field R] (v : AbsoluteValue R ℝ) :
     (normedField v).toNormedCommRing.toNormedRing = normedRing v := by
   with_reducible_and_instances rfl

--- a/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
+++ b/MathlibTest/instance_diamonds/Analysis/Normed/Field/WithAbs.lean
@@ -1,5 +1,5 @@
 import Mathlib
 
 example {R : Type*} [Field R] (v : AbsoluteValue R ℝ) :
-    (normedField v).toNormedCommRing.toNormedRing = normedRing v := by
+    (WithAbs.normedField v).toNormedCommRing.toNormedRing = WithAbs.normedRing v := by
   with_reducible_and_instances rfl


### PR DESCRIPTION
Previously the following fails
```lean
example (v : AbsoluteValue R ℝ) : (normedField v).toNormedCommRing.toNormedRing = (normedRing v) := by
  with_reducible_and_instances rfl
```

Fix requires removing `fast_instance%` from `normedRing` and adding `@[implicit_reducible]` to `AbsoluteValue.toNormedField`. 

Also remove out-of-date docstring.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
