### PR TITLE
feat: `FiniteUnion`

### DIFF
--- a/Mathlib/Data/Set/Constructions.lean
+++ b/Mathlib/Data/Set/Constructions.lean
@@ -20,7 +20,7 @@ We define `finiteInterClosure` which, given a set `S` of subsets of `α`, is the
 set of subsets of `α` which is closed under finite intersections.
 
 `finiteInterClosure S` is endowed with a term of type `FiniteInter` using
-`finiteInterClosure_finiteInter`.
+`finiteInter_finiteInterClosure`.
 
 -/
 
@@ -36,6 +36,17 @@ structure FiniteInter : Prop where
   /-- `inter_mem` states that any two intersections of sets in `S` is also in `S`. -/
   inter_mem : ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∩ t ∈ S
 
+attribute [grind .] FiniteInter.univ_mem
+
+/-- A structure encapsulating the fact that a set of sets is closed under finite union. -/
+structure FiniteUnion : Prop where
+  /-- `empty_mem` states that `∅` is in `S`. -/
+  empty_mem : ∅ ∈ S
+  /-- `union_mem` states that any two unions of sets in `S` is also in `S`. -/
+  union_mem : ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∪ t ∈ S
+
+attribute [grind .] FiniteUnion.empty_mem
+
 namespace FiniteInter
 
 /-- The smallest set of sets containing `S` which is closed under finite intersections. -/
@@ -44,51 +55,102 @@ inductive finiteInterClosure : Set (Set α)
   | univ : finiteInterClosure Set.univ
   | inter {s t} : finiteInterClosure s → finiteInterClosure t → finiteInterClosure (s ∩ t)
 
-theorem finiteInterClosure_finiteInter : FiniteInter (finiteInterClosure S) :=
+theorem finiteInter_finiteInterClosure : FiniteInter (finiteInterClosure S) :=
   { univ_mem := finiteInterClosure.univ
     inter_mem := fun _ h _ => finiteInterClosure.inter h }
 
+@[deprecated (since := "2026-03-04")] alias finiteInterClosure_finiteInter :=
+  finiteInter_finiteInterClosure
+
 variable {S}
 
-theorem finiteInter_mem (cond : FiniteInter S) (F : Finset (Set α)) :
-    ↑F ⊆ S → ⋂₀ (↑F : Set (Set α)) ∈ S := by
+theorem sInter_finset_mem (cond : FiniteInter S) (F : Finset (Set α)) (hF : ↑F ⊆ S) :
+    ⋂₀ (F : Set (Set α)) ∈ S := by
+  revert hF
   classical
     refine Finset.induction_on F (fun _ => ?_) ?_
     · simp [cond.univ_mem]
     · intro a s _ h1 h2
       suffices a ∩ ⋂₀ ↑s ∈ S by simpa
-      exact
-        cond.inter_mem (h2 (Finset.mem_insert_self a s))
-          (h1 fun x hx => h2 <| Finset.mem_insert_of_mem hx)
+      exact cond.inter_mem (h2 (Finset.mem_insert_self a s))
+        (h1 fun x hx => h2 <| Finset.mem_insert_of_mem hx)
+
+@[deprecated (since := "2026-03-04")] alias finiteInter_mem := sInter_finset_mem
 
 theorem finiteInterClosure_insert {A : Set α} (cond : FiniteInter S) (P)
-    (H : P ∈ finiteInterClosure (insert A S)) : P ∈ S ∨ ∃ Q ∈ S, P = A ∩ Q := by
+    (H : P ∈ finiteInterClosure (insert A S)) :
+    P ∈ S ∨ ∃ Q ∈ S, P = A ∩ Q := by
   induction H with
   | basic h =>
     cases h
     · exact Or.inr ⟨Set.univ, cond.univ_mem, by simpa⟩
     · exact Or.inl (by assumption)
-  | univ => exact Or.inl cond.univ_mem
+  | univ => grind
   | @inter T1 T2 _ _ h1 h2 =>
     rcases h1 with (h | ⟨Q, hQ, rfl⟩) <;> rcases h2 with (i | ⟨R, hR, rfl⟩)
-    · exact Or.inl (cond.inter_mem h i)
-    · exact
-        Or.inr ⟨T1 ∩ R, cond.inter_mem h hR, by simp only [← Set.inter_assoc, Set.inter_comm _ A]⟩
+    · exact .inl (cond.inter_mem h i)
+    · exact .inr ⟨T1 ∩ R, cond.inter_mem h hR, by simp only [← Set.inter_assoc, Set.inter_comm _ A]⟩
     · exact Or.inr ⟨Q ∩ T2, cond.inter_mem hQ i, by simp only [Set.inter_assoc]⟩
-    · exact
-        Or.inr
-          ⟨Q ∩ R, cond.inter_mem hQ hR, by
-            ext x
-            constructor <;> simp +contextual⟩
+    · exact Or.inr ⟨Q ∩ R, cond.inter_mem hQ hR, by ext; simp; grind⟩
 
 open Set
 
 theorem mk₂ (h : ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∩ t ∈ S) :
     FiniteInter (insert (univ : Set α) S) where
-  univ_mem := Set.mem_insert Set.univ S
+  univ_mem := by simp
   inter_mem s hs t ht := by aesop
 
 end FiniteInter
+
+namespace FiniteUnion
+
+/-- The smallest set of sets containing `S` which is closed under finite unions. -/
+inductive finiteUnionClosure : Set (Set α)
+  | basic {s} : s ∈ S → finiteUnionClosure s
+  | empty : finiteUnionClosure ∅
+  | union {s t} : finiteUnionClosure s → finiteUnionClosure t → finiteUnionClosure (s ∪ t)
+
+theorem finiteUnion_finiteUnionClosure : FiniteUnion (finiteUnionClosure S) :=
+  { empty_mem := finiteUnionClosure.empty
+    union_mem := fun _ h _ => finiteUnionClosure.union h }
+
+variable {S}
+
+theorem sUnion_finset_mem (cond : FiniteUnion S) (F : Finset (Set α)) (hF : ↑F ⊆ S) :
+    ⋃₀ (F : Set (Set α)) ∈ S := by
+  revert hF
+  classical
+    refine Finset.induction_on F (fun _ => ?_) ?_
+    · simp [cond.empty_mem]
+    · intro a s _ h1 h2
+      suffices a ∪ ⋃₀ ↑s ∈ S by simpa
+      exact cond.union_mem (h2 (Finset.mem_insert_self a s))
+        (h1 fun x hx => h2 <| Finset.mem_insert_of_mem hx)
+
+theorem finiteUnionClosure_insert {A : Set α} (cond : FiniteUnion S) (P)
+    (H : P ∈ finiteUnionClosure (insert A S)) :
+    P ∈ S ∨ ∃ Q ∈ S, P = A ∪ Q := by
+  induction H with
+  | basic h =>
+    cases h
+    · exact Or.inr ⟨∅, cond.empty_mem, by simpa⟩
+    · exact Or.inl (by assumption)
+  | empty => grind
+  | @union T1 T2 _ _ h1 h2 =>
+    rcases h1 with (h | ⟨Q, hQ, rfl⟩) <;> rcases h2 with (i | ⟨R, hR, rfl⟩)
+    · exact .inl (cond.union_mem h i)
+    · exact .inr ⟨T1 ∪ R, cond.union_mem h hR, by simp only [← Set.union_assoc, Set.union_comm _ A]⟩
+    · exact Or.inr ⟨Q ∪ T2, cond.union_mem hQ i, by simp only [Set.union_assoc]⟩
+    · exact Or.inr ⟨Q ∪ R, cond.union_mem hQ hR, by ext; simp; grind⟩
+
+open Set
+
+theorem mk₂ (h : ∀ ⦃s⦄, s ∈ S → ∀ ⦃t⦄, t ∈ S → s ∪ t ∈ S) :
+    FiniteUnion (insert (∅ : Set α) S) where
+  empty_mem := by simp
+  union_mem s hs t ht := by aesop
+
+end FiniteUnion
 
 /-- This is a hybrid of `Set.biUnion_empty` and `Finset.biUnion_empty` (the index set on the LHS is
 the empty finset, but `s` is a family of sets, not finsets). -/

--- a/Mathlib/Data/Set/Constructions.lean
+++ b/Mathlib/Data/Set/Constructions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Adam Topaz
+Authors: Adam Topaz, Rémy Degenne
 -/
 module
 
@@ -11,16 +11,18 @@ public import Mathlib.Data.Set.Lattice
 /-!
 # Constructions involving sets of sets.
 
-## Finite Intersections
+## Finite Intersections and unions
 
 We define a structure `FiniteInter` which asserts that a set `S` of subsets of `α` is
-closed under finite intersections.
+closed under finite intersections. Similarly, we define `FiniteUnion` for finite unions.
 
 We define `finiteInterClosure` which, given a set `S` of subsets of `α`, is the smallest
 set of subsets of `α` which is closed under finite intersections.
 
 `finiteInterClosure S` is endowed with a term of type `FiniteInter` using
 `finiteInter_finiteInterClosure`.
+
+Similarly, we define `finiteUnionClosure` and `finiteUnion_finiteUnionClosure`.
 
 -/
 

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -98,7 +98,7 @@ theorem isTopologicalBasis_of_subbasis_of_finiteInter {s : Set (Set α)} (hsg : 
   refine le_antisymm (fun t ht ↦ ⟨{t}, by simpa using ht⟩) ?_
   rintro _ ⟨g, ⟨hg, hgs⟩, rfl⟩
   lift g to Finset (Set α) using hg
-  exact hsi.finiteInter_mem g hgs
+  exact hsi.sInter_finset_mem g hgs
 
 theorem isTopologicalBasis_of_subbasis_of_inter {r : Set (Set α)} (hsg : t = generateFrom r)
     (hsi : ∀ ⦃s⦄, s ∈ r → ∀ ⦃t⦄, t ∈ r → s ∩ t ∈ r) : IsTopologicalBasis (insert univ r) :=

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -241,7 +241,7 @@ private theorem cl_cl {X : Compactum} (A : Set X) : cl (cl A) ⊆ cl A := by
     rw [join_distrib, this]
     exact ⟨h1 (Or.inl rfl), rfl⟩
   -- C2 is closed under finite intersections (by construction!).
-  have claim4 := finiteInterClosure_finiteInter C1
+  have claim4 := finiteInter_finiteInterClosure C1
   -- C0 is closed under finite intersections by claim1.
   have claim5 : FiniteInter C0 := ⟨⟨_, univ_mem, Set.preimage_univ⟩, claim1⟩
   -- Every element of C2 is nonempty.
@@ -258,7 +258,7 @@ private theorem cl_cl {X : Compactum} (A : Set X) : cl (cl A) ⊆ cl A := by
   -- Suffices to show that the intersection of the T's is contained in C2.
   suffices ⋂₀ ι T ∈ C2 by exact claim6 _ this
   -- Finish
-  apply claim4.finiteInter_mem T
+  apply claim4.sInter_finset_mem T
   intro t ht
   exact finiteInterClosure.basic (@hT t ht)
 
@@ -335,7 +335,7 @@ theorem str_eq_of_le_nhds {X : Compactum} (F : Ultrafilter X) (x : X) : ↑F ≤
     simp [← c1, c2]
   -- Finish...
   intro T hT
-  refine claim6 _ (finiteInter_mem (.finiteInterClosure_finiteInter _) _ ?_)
+  refine claim6 _ (sInter_finset_mem (.finiteInter_finiteInterClosure _) _ ?_)
   intro t ht
   exact finiteInterClosure.basic (@hT t ht)
 


### PR DESCRIPTION
Add the property for a set of sets to be closed by finite unions. This is the analogue of the existing `FiniteInter` for unions. It will be used with compact systems in the proof of Kolmogorov's extension theorem.

- add the new definition
- rename some of the intersection lemmas
- golf a few existing proofs slightly

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
