### PR TITLE
fix: align Vector.insertIdx argument order

### DIFF
--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -529,15 +529,15 @@ section InsertIdx
 
 variable {a : α}
 
-/-- `v.insertIdx a i` inserts `a` into the vector `v` at position `i`
+/-- `v.insertIdx i a` inserts `a` into the vector `v` at position `i`
 (and shifting later components to the right). -/
-def insertIdx (a : α) (i : Fin (n + 1)) (v : Vector α n) : Vector α (n + 1) :=
+def insertIdx (v : Vector α n) (i : Fin (n + 1)) (a : α) : Vector α (n + 1) :=
   ⟨v.1.insertIdx i a, by
     rw [List.length_insertIdx, v.2]
     split <;> lia⟩
 
 theorem insertIdx_val {i : Fin (n + 1)} {v : Vector α n} :
-    (v.insertIdx a i).val = v.val.insertIdx i.1 a :=
+    (v.insertIdx i a).val = v.val.insertIdx i.1 a :=
   rfl
 
 @[simp]
@@ -545,14 +545,14 @@ theorem eraseIdx_val {i : Fin n} : ∀ {v : Vector α n}, (eraseIdx i v).val = v
   | _ => rfl
 
 theorem eraseIdx_insertIdx_self {v : Vector α n} {i : Fin (n + 1)} :
-    eraseIdx i (insertIdx a i v) = v :=
+    eraseIdx i (insertIdx v i a) = v :=
   Subtype.ext (List.eraseIdx_insertIdx_self ..)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Erasing an element after inserting an element, at different indices. -/
 theorem eraseIdx_insertIdx' {v : Vector α (n + 1)} :
     ∀ {i : Fin (n + 1)} {j : Fin (n + 2)},
-      eraseIdx (j.succAbove i) (insertIdx a j v) = insertIdx a (i.predAbove j) (eraseIdx i v)
+      eraseIdx (j.succAbove i) (insertIdx v j a) = insertIdx (eraseIdx i v) (i.predAbove j) a
   | ⟨i, hi⟩, ⟨j, hj⟩ => by
     dsimp [insertIdx, eraseIdx, Fin.succAbove, Fin.predAbove]
     rw [Subtype.mk_eq_mk]
@@ -572,7 +572,7 @@ theorem eraseIdx_insertIdx' {v : Vector α (n + 1)} :
 
 theorem insertIdx_comm (a b : α) (i j : Fin (n + 1)) (h : i ≤ j) :
     ∀ v : Vector α n,
-      (v.insertIdx a i).insertIdx b j.succ = (v.insertIdx b j).insertIdx a (Fin.castSucc i)
+      (v.insertIdx i a).insertIdx j.succ b = (v.insertIdx j b).insertIdx (Fin.castSucc i) a
   | ⟨l, hl⟩ => by
     refine Subtype.ext ?_
     simp only [insertIdx_val, Fin.val_succ, Fin.castSucc, Fin.val_castAdd]

--- a/Mathlib/Topology/List.lean
+++ b/Mathlib/Topology/List.lean
@@ -184,8 +184,8 @@ theorem tendsto_cons {n : ℕ} {a : α} {l : Vector α n} :
 set_option backward.isDefEq.respectTransparency false in
 theorem tendsto_insertIdx {n : ℕ} {i : Fin (n + 1)} {a : α} :
     ∀ {l : Vector α n},
-      Tendsto (fun p : α × Vector α n => insertIdx p.1 i p.2) (𝓝 a ×ˢ 𝓝 l)
-        (𝓝 (insertIdx a i l))
+      Tendsto (fun p : α × Vector α n => insertIdx p.2 i p.1) (𝓝 a ×ˢ 𝓝 l)
+        (𝓝 (insertIdx l i a))
   | ⟨l, hl⟩ => by
     rw [insertIdx, tendsto_subtype_rng]
     simp only [insertIdx_val]
@@ -193,12 +193,12 @@ theorem tendsto_insertIdx {n : ℕ} {i : Fin (n + 1)} {a : α} :
 
 /-- Continuity of `Vector.insertIdx`. -/
 theorem continuous_insertIdx' {n : ℕ} {i : Fin (n + 1)} :
-    Continuous fun p : α × Vector α n => Vector.insertIdx p.1 i p.2 :=
+    Continuous fun p : α × Vector α n => Vector.insertIdx p.2 i p.1 :=
   continuous_iff_continuousAt.mpr fun ⟨a, l⟩ => by
     rw [ContinuousAt, nhds_prod_eq]; exact tendsto_insertIdx
 
 theorem continuous_insertIdx {n : ℕ} {i : Fin (n + 1)} {f : β → α} {g : β → Vector α n}
-    (hf : Continuous f) (hg : Continuous g) : Continuous fun b => Vector.insertIdx (f b) i (g b) :=
+    (hf : Continuous f) (hg : Continuous g) : Continuous fun b => Vector.insertIdx (g b) i (f b) :=
   continuous_insertIdx'.comp (hf.prodMk hg)
 
 set_option backward.isDefEq.respectTransparency false in


### PR DESCRIPTION
Closes #32394

Aligns `Vector.insertIdx` argument order with `List.insertIdx`.
Updates `Mathlib/Data/Vector/Basic.lean` definitions and related lemmas.

Validation: targeted `lake build` and `lake exe runLinter --trace` passed for touched module(s).

Intelligent systems usage: tool=Codex; model=Codex 5.3; effort=extra high; workflow=ORP local-first gates (viability/overlap/naturality/targeted build+linter/draft CI); scope=drafting/refactoring/proof exploration including PR description drafting; final code choices and validation by me.
---
Happy to adjust naming, placement, or proof style based on maintainer preference.

