### PR TITLE
perf: let `simp_rw` use pre simp lemmas

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -657,7 +657,7 @@ lemma Scheme.exists_hom_comp_eq_comp_of_locallyOfFiniteType
   simp only [Precoverage.ZeroHypercover.pullback₁_toPreZeroHypercover,
     PreZeroHypercover.pullback₁_X, PreZeroHypercover.pullback₁_f, Functor.map_comp, Category.assoc]
     at heq ⊢
-  simp_rw [← D.map_comp_assoc, reassoc_of% this o u, D.map_comp_assoc]
+  simp_rw [← D.map_comp_assoc, this o u, D.map_comp_assoc]
   rw [← reassoc_of% hF, ← reassoc_of% hF, heq]
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -301,9 +301,6 @@ def fourierCoeff (f : AddCircle T → E) (n : ℤ) : E :=
 over `[a, a + T]`, for any real `a`. -/
 theorem fourierCoeff_eq_intervalIntegral (f : AddCircle T → E) (n : ℤ) (a : ℝ) :
     fourierCoeff f n = (1 / T) • ∫ x in a..a + T, @fourier T (-n) x • f x := by
-  have : ∀ x : ℝ, @fourier T (-n) x • f x = (fun z : AddCircle T => @fourier T (-n) z • f z) x := by
-    intro x; rfl
-  simp_rw +singlePass [this]
   rw [fourierCoeff, AddCircle.intervalIntegral_preimage T a (fun z => _ • _),
     volume_eq_smul_haarAddCircle, integral_smul_measure, ENNReal.toReal_ofReal hT.out.le,
     ← smul_assoc, smul_eq_mul, one_div_mul_cancel hT.out.ne', one_smul]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -41,7 +41,8 @@ theorem tendsto_rpow_atTop {y : ℝ} (hy : 0 < y) : Tendsto (fun x : ℝ => x ^ 
 
 theorem tendsto_rpow_neg_nhdsGT_zero {y : ℝ} (hr : y < 0) :
     Tendsto (fun (x : ℝ) ↦ x ^ y) (𝓝[>] 0) atTop := by
-  simp_rw +singlePass [← neg_neg y, Real.rpow_neg_eq_inv_rpow]
+  rw [← neg_neg y]
+  conv => enter [1, x]; rw [Real.rpow_neg_eq_inv_rpow]
   exact (tendsto_rpow_atTop <| neg_pos.mpr hr).comp tendsto_inv_nhdsGT_zero
 
 /-- The function `x ^ (-y)` tends to `0` at `+∞` for any positive real `y`. -/

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -365,7 +365,7 @@ theorem hasStrictFDerivAt_rpow_of_neg (p : ℝ × ℝ) (hp : p.1 < 0) :
   refine HasStrictFDerivAt.congr_of_eventuallyEq ?_ this.symm
   convert ((hasStrictFDerivAt_fst.log hp.ne).fun_mul hasStrictFDerivAt_snd).exp.fun_mul
     (hasStrictFDerivAt_snd.mul_const π).cos using 1
-  simp_rw [rpow_sub_one hp.ne, smul_add, ← add_assoc, smul_smul, ← add_smul, ← mul_assoc,
+  simp_rw [rpow_sub_one hp.ne, smul_add, ← add_assoc, smul_smul, ← add_smul,
     mul_comm (cos _), ← rpow_def_of_neg hp]
   rw [div_eq_mul_inv, add_comm]; congr 2 <;> ring
 

--- a/Mathlib/FieldTheory/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PerfectClosure.lean
@@ -349,8 +349,7 @@ theorem mk_pow (x : ℕ × K) (n : ℕ) : mk K p x ^ n = mk K p (x.1, x.2 ^ n) :
     exact ⟨0, by simp_rw [← coe_iterateFrobenius, map_one]⟩
   | succ n ih =>
     rw [pow_succ, pow_succ, ih, mk_mul_mk, mk_eq_iff]
-    exact ⟨0, by simp_rw [iterate_frobenius, add_zero, mul_pow, ← pow_mul,
-      ← pow_add, mul_assoc, ← pow_add]⟩
+    exact ⟨0, by simp_rw [iterate_frobenius, add_zero, mul_pow, ← pow_mul, ← pow_add]⟩
 
 theorem natCast (n x : ℕ) : (x : PerfectClosure K p) = mk K p (n, x) := by
   induction n with

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -306,7 +306,8 @@ instance Pi.measurableDiv₂ {ι : Type*} {α : ι → Type*} [∀ i, Div (α i)
 instance {E} [MeasurableSpace E] [AddGroup E] [MeasurableSingletonClass E] [MeasurableSub₂ E] :
     MeasurableEq E := by
   constructor
-  simp_rw +singlePass [Set.diagonal, ← sub_eq_zero]
+  rw [Set.diagonal]
+  conv => enter [1, 1, p]; rw [← sub_eq_zero]
   measurability
 
 instance {β : Type*} [AddCommMonoid β] [PartialOrder β]

--- a/Mathlib/MeasureTheory/Integral/CircleTransform.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleTransform.lean
@@ -57,7 +57,7 @@ theorem circleTransformDeriv_periodic (f : ℂ → E) :
 theorem circleTransformDeriv_eq (f : ℂ → E) : circleTransformDeriv R z w f =
     fun θ => (circleMap z R θ - w)⁻¹ • circleTransform R z w f θ := by
   ext
-  simp_rw [circleTransformDeriv, circleTransform, ← mul_smul, ← mul_assoc]
+  simp_rw [circleTransformDeriv, circleTransform, ← mul_smul]
   ring_nf
   rw [inv_pow]
   congr

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -637,7 +637,7 @@ lemma differentiableAt_hurwitzZetaEven_sub_one_div (a : UnitAddCircle) :
     rw [hurwitzZetaEven, Function.update_of_ne hx]
   simp_rw [← sub_div, div_eq_mul_inv _ (Gammaℝ _)]
   refine DifferentiableAt.mul ?_ differentiable_Gammaℝ_inv.differentiableAt
-  simp_rw [completedHurwitzZetaEven_eq, sub_sub, add_assoc]
+  simp_rw [completedHurwitzZetaEven_eq, sub_sub]
   conv => enter [2, s, 2]; rw [← neg_sub, div_neg, neg_add_cancel, add_zero]
   exact (differentiable_completedHurwitzZetaEven₀ a _).sub
     <| (differentiableAt_const _).div differentiableAt_id one_ne_zero

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -103,8 +103,8 @@ theorem cosZeta_two_mul_nat' (hk : k ≠ 0) (hx : x ∈ Icc (0 : ℝ) 1) :
   have : (2 * k)! = (2 * k) * Complex.Gamma (2 * k) := by
     rw [(by { norm_cast; lia } : 2 * (k : ℂ) = ↑(2 * k - 1) + 1), Complex.Gamma_nat_eq_factorial,
       ← Nat.cast_add_one, ← Nat.cast_mul, ← Nat.factorial_succ, Nat.sub_add_cancel (by lia)]
-  simp_rw [this, Gammaℂ, cpow_neg, ← div_div, div_inv_eq_mul, div_mul_eq_mul_div, div_div,
-    mul_right_comm (2 : ℂ) (k : ℂ)]
+  simp_rw [this, Gammaℂ, cpow_neg]
+  field_simp
   norm_cast
 
 /-- Reformulation of `sinZeta_two_mul_nat_add_one` using `Gammaℂ`. -/

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -1046,8 +1046,9 @@ theorem iUnion_negAt_plusPart_union :
   rw [Set.mem_union, Set.mem_inter_iff, Set.mem_iUnion, Set.mem_iUnion]
   refine ⟨?_, fun h ↦ ?_⟩
   · rintro (⟨s, ⟨x, ⟨hx, _⟩, rfl⟩⟩ | h)
-    · simp_rw +singlePass [hA, negAt_apply_norm_isReal, negAt_apply_snd]
-      rwa [← hA]
+    · rw [hA]
+      simp_rw [negAt_apply_norm_isReal]
+      rwa [negAt_apply_snd, ← hA]
     · exact h.left
   · obtain hx | hx := exists_or_forall_not (fun w ↦ x.1 w = 0)
     · exact Or.inr ⟨h, hx⟩

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -221,13 +221,13 @@ variable {A B : Type*} [PartialOrder A] [SetLike A B] [IsConcreteLE A B]
 
 theorem isAtom_iff [OrderBot A] {K : A} :
     IsAtom K ↔ K ≠ ⊥ ∧ ∀ H g, H ≤ K → g ∉ H → g ∈ K → H = ⊥ := by
-  simp_rw [IsAtom, lt_iff_le_not_ge, SetLike.not_le_iff_exists,
-    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+  simp_rw [IsAtom, lt_iff_le_not_ge, SetLike.not_le_iff_exists]
+  grind only
 
 theorem isCoatom_iff [OrderTop A] {K : A} :
     IsCoatom K ↔ K ≠ ⊤ ∧ ∀ H g, K ≤ H → g ∉ K → g ∈ H → H = ⊤ := by
-  simp_rw [IsCoatom, lt_iff_le_not_ge, SetLike.not_le_iff_exists,
-    and_comm (a := _ ≤ _), and_imp, exists_imp, ← and_imp, and_comm]
+  simp_rw [IsCoatom, lt_iff_le_not_ge, SetLike.not_le_iff_exists]
+  grind only
 
 theorem covBy_iff {K L : A} :
     K ⋖ L ↔ K < L ∧ ∀ H g, K ≤ H → H ≤ L → g ∉ K → g ∈ H → H = L := by

--- a/Mathlib/Probability/Kernel/Posterior.lean
+++ b/Mathlib/Probability/Kernel/Posterior.lean
@@ -197,9 +197,7 @@ lemma posterior_comp {η : Kernel 𝓧 𝓨} [IsFiniteKernel η] :
     rw [parallelProd_posterior_comp_copy_comp]
   _ = (Kernel.swap _ _) ∘ₘ (Kernel.id ∥ₖ η) ∘ₘ (Kernel.id ∥ₖ κ) ∘ₘ Kernel.copy Ω ∘ₘ μ := by
     simp_rw [Measure.comp_assoc]
-    conv_rhs => rw [← Kernel.comp_assoc]
-    rw [Kernel.swap_parallelComp, Kernel.comp_assoc, ← Kernel.comp_assoc (Kernel.swap Ω 𝓧),
-      Kernel.swap_parallelComp, Kernel.comp_assoc, Kernel.swap_copy]
+    grind [Kernel.comp_assoc, Kernel.swap_parallelComp, Kernel.swap_copy]
 
 end StandardBorelSpace
 

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -286,11 +286,11 @@ instance instCoalgebra : Coalgebra R (A × B) where
     dsimp +instances only [instCoalgebraStruct]
     ext x : 2 <;> dsimp only [comp_apply, LinearEquiv.coe_coe, coe_inl, coe_inr, coprod_apply]
     · simp only [map_zero, add_zero]
-      simp_rw [← comp_apply, ← comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inl,
+      simp_rw [← comp_apply, rTensor_comp_map, lTensor_comp_map, coprod_inl,
         ← map_comp_rTensor, ← map_comp_lTensor, comp_assoc, ← coassoc, ← comp_assoc,
         TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
     · simp only [map_zero, zero_add]
-      simp_rw [← comp_apply, ← comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inr,
+      simp_rw [← comp_apply, rTensor_comp_map, lTensor_comp_map, coprod_inr,
         ← map_comp_rTensor, ← map_comp_lTensor, comp_assoc, ← coassoc, ← comp_assoc,
         TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
 

--- a/Mathlib/RingTheory/Extension/Presentation/Submersive.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Submersive.lean
@@ -454,7 +454,7 @@ lemma jacobian_reindex (P : PreSubmersivePresentation R S ι σ)
     Matrix.reindex_apply, Equiv.symm_symm, Generators.algebraMap_apply, Generators.reindex_val]
   simp_rw [← MvPolynomial.aeval_rename,
     ← AlgHom.mapMatrix_apply, ← Matrix.det_submatrix_equiv_self f, AlgHom.map_det,
-    AlgHom.mapMatrix_apply, Matrix.map_map]
+    AlgHom.mapMatrix_apply, Matrix.map_map, Function.comp_assoc]
   simp [← AlgHom.coe_comp, rename_comp_rename, rename_id]
 
 section

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -119,7 +119,7 @@ lemma eval_zero_comp_det :
     eval 0 (comp m m n n R[X] <| (cornerAddX M k).map f.polyToMatrix).det =
       (comp m m n n R <| M.map f).det := by
   simp_rw [← coe_evalRingHom, RingHom.map_det, ← compRingEquiv_apply, ← RingEquiv.coe_toRingHom,
-    ← RingHom.mapMatrix_apply, ← RingHom.comp_apply, ← RingHom.comp_assoc,
+    ← RingHom.mapMatrix_apply, ← RingHom.comp_apply,
     evalRingHom_mapMatrix_comp_compRingEquiv, RingHom.comp_assoc, RingHom.mapMatrix_comp,
     evalRingHom_mapMatrix_comp_polyToMatrix, ← RingHom.mapMatrix_comp, RingHom.comp_apply]
   congr with i j

--- a/Mathlib/Tactic/SimpRw.lean
+++ b/Mathlib/Tactic/SimpRw.lean
@@ -70,8 +70,8 @@ elab s:"simp_rw " cfg:optConfig rws:rwRuleSeq g:(location)? : tactic => focus do
     evalTactic (← match term with
     | `(term| $e:term) =>
       if symm then
-        `(tactic| simp%$e $cfg only [← $e:term] $g ?)
+        `(tactic| simp%$e $cfg only [↓← $e:term] $g ?)
       else
-        `(tactic| simp%$e $cfg only [$e:term] $g ?))
+        `(tactic| simp%$e $cfg only [↓$e:term] $g ?))
 
 end Mathlib.Tactic

--- a/Mathlib/Topology/AlexandrovDiscrete.lean
+++ b/Mathlib/Topology/AlexandrovDiscrete.lean
@@ -46,9 +46,8 @@ variable [TopologicalSpace α] [TopologicalSpace β]
 
 lemma alexandrovDiscrete_iff_isClosed :
     AlexandrovDiscrete α ↔ ∀ S : Set (Set α), (∀ s ∈ S, IsClosed s) → IsClosed (⋃₀ S) := by
-  conv_lhs => tactic =>
-    simp_rw +singlePass [alexandrovDiscrete_iff, compl_surjective.image_surjective.forall,
-      forall_mem_image, ← compl_sUnion, isOpen_compl_iff]
+  rw [alexandrovDiscrete_iff, compl_surjective.image_surjective.forall]
+  simp_rw [forall_mem_image, ← compl_sUnion, isOpen_compl_iff]
 
 instance DiscreteTopology.toAlexandrovDiscrete [DiscreteTopology α] : AlexandrovDiscrete α where
   isOpen_sInter _ _ := isOpen_discrete _

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -246,8 +246,8 @@ theorem exists_pos_forall_lt_edist (hs : IsCompact s) (ht : IsClosed t) (hst : D
 
 theorem infEDist_prod (x : α × β) (s : Set α) (t : Set β) :
     infEDist x (s ×ˢ t) = max (infEDist x.1 s) (infEDist x.2 t) := by
-  simp_rw +singlePass [infEDist, Prod.edist_eq, iInf_prod, Set.mem_prod, iInf_and, iInf_sup_eq,
-    sup_iInf_eq, iInf_sup_eq, sup_iInf_eq]
+  simp_rw [infEDist, Prod.edist_eq, iInf_prod, Set.mem_prod, iInf_and, iInf_comm (ι := β),
+    iInf_sup_eq, sup_iInf_eq]
 
 end InfEDist
 

--- a/Mathlib/Topology/Separation/CompletelyRegular.lean
+++ b/Mathlib/Topology/Separation/CompletelyRegular.lean
@@ -72,9 +72,9 @@ class CompletelyRegularSpace (X : Type u) [TopologicalSpace X] : Prop where
 lemma completelyRegularSpace_iff_isOpen : CompletelyRegularSpace X ↔
     ∀ (x : X), ∀ K : Set X, IsOpen K → x ∈ K →
       ∃ f : X → I, Continuous f ∧ f x = 0 ∧ EqOn f 1 Kᶜ := by
-  conv_lhs => tactic =>
-    simp_rw +singlePass [completelyRegularSpace_iff, compl_surjective.forall, isClosed_compl_iff,
-      mem_compl_iff, not_not]
+  rw [completelyRegularSpace_iff]
+  conv_lhs => enter [x]; rw [compl_surjective.forall]
+  simp
 
 lemma CompletelyRegularSpace.completely_regular_isOpen [CompletelyRegularSpace X] :
     ∀ (x : X), ∀ K : Set X, IsOpen K → x ∈ K →

--- a/Mathlib/Topology/Sets/VietorisTopology.lean
+++ b/Mathlib/Topology/Sets/VietorisTopology.lean
@@ -70,7 +70,8 @@ theorem _root_.IsClosed.powerset_vietoris {F : Set α} (h : IsClosed F) :
 
 theorem isClosed_inter_nonempty_of_isClosed {F : Set α} (h : IsClosed F) :
     IsClosed {s | (s ∩ F).Nonempty} := by
-  simp_rw +singlePass [← compl_compl F, inter_compl_nonempty_iff, ← compl_setOf]
+  rw [← compl_compl F]
+  simp_rw [inter_compl_nonempty_iff, ← compl_setOf]
   exact h.isOpen_compl.powerset_vietoris.isClosed_compl
 
 theorem isClopen_singleton_empty : IsClopen {(∅ : Set α)} := by
@@ -159,7 +160,8 @@ theorem isClosed_subsets_of_isClosed {F : Set α} (h : IsClosed F) :
 
 theorem isClosed_inter_nonempty_of_isClosed {F : Set α} (h : IsClosed F) :
     IsClosed {K : Compacts α | (↑K ∩ F).Nonempty} := by
-  simp_rw +singlePass [← compl_compl F, Set.inter_compl_nonempty_iff, ← Set.compl_setOf]
+  rw [← compl_compl F]
+  simp_rw [Set.inter_compl_nonempty_iff, ← Set.compl_setOf]
   exact (isOpen_subsets_of_isOpen h.isOpen_compl).isClosed_compl
 
 theorem isClopen_singleton_bot : IsClopen {(⊥ : Compacts α)} := by

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -588,8 +588,8 @@ theorem app_surjective_of_injective_of_locally_surjective {F G : Sheaf C X} (f :
   apply hinj z ((iVU x).le ((inf_le_left : V x ⊓ V y ≤ V x) hz))
   dsimp only
   rw [stalkFunctor_map_germ_apply, stalkFunctor_map_germ_apply]
-  simp_rw [← ConcreteCategory.comp_apply, f.1.naturality, ConcreteCategory.comp_apply, heq,
-    ← ConcreteCategory.comp_apply, ← G.1.map_comp]
+  simp_rw [← ConcreteCategory.comp_apply, reassoc_of% f.1.naturality, ConcreteCategory.comp_apply,
+    heq, ← ConcreteCategory.comp_apply, ← reassoc_of% G.1.map_comp]
   rfl
 
 theorem app_surjective_of_stalkFunctor_map_bijective {F G : Sheaf C X} (f : F ⟶ G) (U : Opens X)

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -228,7 +228,9 @@ theorem isUniformInducing_closure : IsUniformInducing (closure (X := α)) := by
   · grw [subset_closure (s := t), hts, closure_subset_image hV s, ← hVU, SetRel.image_comp]
 
 theorem nhds_closure (s : Set α) : 𝓝 (closure s) = 𝓝 s := by
-  simp_rw +singlePass [isUniformInducing_closure.isInducing.nhds_eq_comap, closure_closure]
+  nth_rw 2 [isUniformInducing_closure.isInducing.nhds_eq_comap]
+  nth_rw 1 [isUniformInducing_closure.isInducing.nhds_eq_comap]
+  rw [closure_closure]
 
 instance [DiscreteUniformity α] : DiscreteUniformity (Set α) := by
   rw [discreteUniformity_iff_setRelId_mem_uniformity]

--- a/Mathlib/Topology/UniformSpace/Dini.lean
+++ b/Mathlib/Topology/UniformSpace/Dini.lean
@@ -61,8 +61,9 @@ lemma tendstoLocallyUniformly_of_forall_tendsto
     exact hF_mono hnm x
   simp_rw [Metric.tendstoLocallyUniformly_iff, dist_eq_norm']
   intro ε ε_pos x
-  simp_rw +singlePass [tendsto_iff_norm_sub_tendsto_zero] at h_tendsto
-  obtain ⟨n, hn⟩ := (h_tendsto x).eventually (eventually_lt_nhds ε_pos) |>.exists
+  specialize h_tendsto x
+  rw [tendsto_iff_norm_sub_tendsto_zero] at h_tendsto
+  obtain ⟨n, hn⟩ := h_tendsto.eventually (eventually_lt_nhds ε_pos) |>.exists
   refine ⟨{y | ‖F n y - f y‖ < ε}, ⟨isOpen_lt (by fun_prop) continuous_const |>.mem_nhds hn, ?_⟩⟩
   filter_upwards [eventually_ge_atTop n] with m hnm z hz
   refine norm_le_norm_of_abs_le_abs ?_ |>.trans_lt hz


### PR DESCRIPTION
This PR tests the effect of making `simp_rw` use pre simp lemmas, rather than post simp lemmas, for improved performance.

One disadvantage of this is that `simp_rw +singlePass` now doesn't work anymore. (Though `simp only +singlePass` still works instead). I expect that this will not be an issue anymore once the new rewrite tactic exists.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
