### PR TITLE
[Merged by Bors] - feat(RingTheory): isomorphism between perfection of R and perfection of R/I

### DIFF
--- a/Mathlib/LinearAlgebra/SModEq/Basic.lean
+++ b/Mathlib/LinearAlgebra/SModEq/Basic.lean
@@ -60,7 +60,7 @@ lemma of_toAddSubgroup_le {U : Submodule R M} {V : Submodule S M}
   simp only [SModEq, Submodule.Quotient.eq] at hxy ⊢
   exact h hxy
 
-@[refl]
+@[refl, simp]
 protected theorem refl (x : M) : x ≡ x [SMOD U] :=
   @rfl _ _
 

--- a/Mathlib/RingTheory/AdicCompletion/Algebra.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Algebra.lean
@@ -190,7 +190,7 @@ lemma evalOneₐ_surjective : Function.Surjective (evalOneₐ I) := by
 /-- `AdicCauchySequence I R` is an `R`-subalgebra of `ℕ → R`. -/
 def AdicCauchySequence.subalgebra : Subalgebra R (ℕ → R) :=
   Submodule.toSubalgebra (AdicCauchySequence.submodule I R)
-    (fun {m n} _ ↦ by simp; rfl)
+    (fun {m n} _ ↦ by simp)
     (fun x y hx hy {m n} hmn ↦ by
       simp only [Pi.mul_apply]
       exact SModEq.mul (hx hmn) (hy hmn))

--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -126,6 +126,16 @@ theorem coeffMonoidHom_pow_p_pow (f : Perfection M p) (m n : ℕ) :
     coeffMonoidHom M p (m + n) (f ^ p ^ n) = coeffMonoidHom M p m f :=
   n.recOn (by simp) fun n ih ↦ by rw [pow_succ, pow_mul, Nat.add_succ, coeffMonoidHom_pow_p, ih]
 
+@[simp]
+theorem coeffMonoidHom_pow_p_pow' (f : Perfection M p) (m n : ℕ) :
+    coeffMonoidHom M p (m + n) f ^ p ^ n = coeffMonoidHom M p m f := by
+  rw [← map_pow, coeffMonoidHom_pow_p_pow]
+
+@[simp]
+theorem coeffMonoidHom_pow_p_pow_self (f : Perfection M p) (n : ℕ) :
+    coeffMonoidHom M p n f ^ p ^ n = coeffMonoidHom M p 0 f := by
+  rw [← coeffMonoidHom_pow_p_pow' _ 0 n, zero_add]
+
 theorem coeffMonoidHom_powMonoidHom (f : Perfection M p) (n : ℕ) :
     coeffMonoidHom M p (n + 1) (powMonoidHom p f) = coeffMonoidHom M p n f :=
   coeffMonoidHom_pow_p f n
@@ -141,7 +151,7 @@ theorem coeffMonoidHom_iterate_powMonoidHom' (f : Perfection M p) (n m : ℕ) (h
 
 /-- Given monoids `M` and `N`, with `M` being perfect,
 any homomorphism `M →+* N` can be lifted uniquely to a homomorphism `M →* Perfection N p`. -/
-@[simps]
+@[simps! symm_apply]
 noncomputable def liftMonoidHom (p : ℕ) (M : Type*) [CommMonoid M] [PerfectRing M p]
     (N : Type*) [CommMonoid N] : (M →* N) ≃* (M →* Perfection N p) where
   toFun f :=
@@ -158,6 +168,10 @@ noncomputable def liftMonoidHom (p : ℕ) (M : Type*) [CommMonoid M] [PerfectRin
       coeffMonoidHom_mk]
     rw [← coeffMonoidHom_pow_p_pow _ 0 n, ← map_pow, powMulEquiv_symm_pow_p, zero_add]
   map_mul' _ _ := by ext; simp
+
+@[simp] lemma coeffMonoidHom_zero_liftMonoidHom
+    (p : ℕ) {M N : Type*} [CommMonoid M] [PerfectRing M p] [CommMonoid N] (e : M →* N) (x : M) :
+    coeffMonoidHom N p 0 (liftMonoidHom p M N e x) = e x := by simp [liftMonoidHom]
 
 /-- A monoid homomorphism `M →* N` induces `Perfection M p →* Perfection N p`. -/
 @[simps!]
@@ -370,6 +384,14 @@ instance : CommRing (Perfection R p) :=
   (subring R p).toCommRing
 
 end CommRing
+
+section CommMonoid_CommRing
+
+@[simp] theorem coeff_mapMonoidHom {p : ℕ} [Fact p.Prime] {M N : Type*} [CommMonoid M] [CommRing N]
+    [CharP N p] (e : M →* N) (n : ℕ) (x : Perfection M p) :
+    coeff N p n (mapMonoidHom p e x) = e (coeffMonoidHom M p n x) := rfl
+
+end CommMonoid_CommRing
 
 end Perfection
 

--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -174,7 +174,6 @@ noncomputable def liftMonoidHom (p : ℕ) (M : Type*) [CommMonoid M] [PerfectRin
     coeffMonoidHom N p 0 (liftMonoidHom p M N e x) = e x := by simp [liftMonoidHom]
 
 /-- A monoid homomorphism `M →* N` induces `Perfection M p →* Perfection N p`. -/
-@[simps!]
 def mapMonoidHom (p : ℕ) {M N : Type*} [CommMonoid M] [CommMonoid N] (φ : M →* N) :
     Perfection M p →* Perfection N p where
   toFun f := ⟨fun n ↦ φ (f.coeffMonoidHom M p n), fun n ↦ by rw [← map_pow, coeffMonoidHom_pow_p']⟩
@@ -353,13 +352,12 @@ theorem hom_ext {R : Type u₁} [CommSemiring R] [CharP R p] [PerfectRing R p] {
 variable {R} {S : Type u₂} [CommSemiring S] [CharP S p]
 
 /-- A ring homomorphism `R →+* S` induces `Perfection R p →+* Perfection S p`. -/
-@[simps!]
 def map (φ : R →+* S) : Perfection R p →+* Perfection S p where
   __ := mapMonoidHom p (φ : R →* S)
   map_zero' := Subtype.ext <| funext fun _ => φ.map_zero
   map_add' _ _ := Subtype.ext <| funext fun _ => φ.map_add _ _
 
-theorem coeff_map (φ : R →+* S) (f : Perfection R p) (n : ℕ) :
+@[simp] theorem coeff_map (φ : R →+* S) (f : Perfection R p) (n : ℕ) :
     coeff S p n (map p φ f) = φ (coeff R p n f) := rfl
 
 end CommSemiring

--- a/Mathlib/RingTheory/Teichmuller.lean
+++ b/Mathlib/RingTheory/Teichmuller.lean
@@ -189,6 +189,11 @@ theorem mk_comp_teichmuller' :
   funext mk_teichmuller
 
 set_option backward.isDefEq.respectTransparency false in
+/-- If `R` is `I`-adically complete and `R ⧸ I` has characteristic `p`, then
+`Perfection R p` and `Perfection (R ⧸ I) p` are isomorphic as monoids.
+
+Note that `Perfection R p` is generally not a ring, and the forward map is induced by
+the quotient map, and the backwards map is constructed using the Teichmüller map. -/
 noncomputable def quotientMulEquiv (p : ℕ) [Fact p.Prime]
     {R : Type*} [CommRing R] (I : Ideal R) [CharP (R ⧸ I) p] [IsAdicComplete I R] :
     Perfection R p ≃* Perfection (R ⧸ I) p := MonoidHom.toMulEquiv

--- a/Mathlib/RingTheory/Teichmuller.lean
+++ b/Mathlib/RingTheory/Teichmuller.lean
@@ -100,7 +100,7 @@ limit of `p^n`-th powers of arbitrary lifts in `R` of the `n`-th component from 
 The simp NF is `teichmuller₀`. -/
 noncomputable def teichmuller : Perfection (R ⧸ I) p →* R where
   toFun := teichmullerFun
-  map_one' := teichmullerFun_spec fun _ ↦ ⟨1, by simp; rfl⟩
+  map_one' := teichmullerFun_spec fun _ ↦ ⟨1, by simp⟩
   map_mul' x y := by
     refine teichmullerFun_spec fun n ↦ ?_
     refine ⟨(coeff _ p n x).out * (coeff _ p n y).out, by simp, ?_⟩
@@ -125,7 +125,7 @@ theorem teichmuller_spec {x : Perfection (R ⧸ I) p} {y : R}
 
 theorem teichmuller_zero : teichmuller p I 0 = 0 :=
   have : p ≠ 0 := Nat.Prime.ne_zero Fact.out
-  teichmuller_spec fun n ↦ ⟨0, by simp [zero_pow (pow_ne_zero n this)]; rfl⟩
+  teichmuller_spec fun n ↦ ⟨0, by simp [zero_pow (pow_ne_zero n this)]⟩
 
 variable (p I) in
 /-- `teichmuller` as a `MonoidWithZeroHom`. This is the simp NF. -/
@@ -158,11 +158,18 @@ theorem teichmuller₀_spec {x : Perfection (R ⧸ I) p} {y : R}
     teichmuller₀ p I x = y :=
   teichmullerFun_spec h
 
+@[simp] theorem teichmuller₀_mapMonoidHom_idealQuotientMk {x : Perfection R p} :
+    teichmuller₀ p I (mapMonoidHom p (Ideal.Quotient.mk I) x) = coeffMonoidHom R p 0 x :=
+  teichmuller₀_spec fun n ↦ ⟨coeffMonoidHom R p n x, by simp⟩
+
 theorem mk_teichmuller (x : Perfection (R ⧸ I) p) :
     Ideal.Quotient.mk I (teichmuller p I x) = coeff _ p 0 x := by
   have := teichmuller_sModEq <| Ideal.Quotient.mk_out <| coeff _ p 0 x
   simp_rw [zero_add, pow_one] at this
   simpa [SModEq.idealQuotientMk] using this
+
+@[simp] theorem mk_teichmuller₀ (x : Perfection (R ⧸ I) p) :
+    Ideal.Quotient.mk I (teichmuller₀ p I x) = coeff _ p 0 x := mk_teichmuller _
 
 variable (p I) in
 theorem mk_comp_teichmuller :
@@ -180,5 +187,20 @@ variable (p I) in
 theorem mk_comp_teichmuller' :
     Ideal.Quotient.mk I ∘ (teichmuller p I) = coeff (R ⧸ I) p 0 :=
   funext mk_teichmuller
+
+set_option backward.isDefEq.respectTransparency false in
+noncomputable def quotientMulEquiv : Perfection R p ≃* Perfection (R ⧸ I) p := MonoidHom.toMulEquiv
+  (mapMonoidHom _ <| Ideal.Quotient.mk I)
+  (liftMonoidHom p _ _ <| teichmuller p I)
+  ((liftMonoidHom p _ _).symm.injective <| by ext; simp)
+  ((liftMonoidHom p _ _).symm.injective <| by ext; simp)
+
+@[simp] theorem coeff_quotientMulEquiv (x : Perfection R p) (n : ℕ) :
+    coeff (R ⧸ I) p n (quotientMulEquiv x) = Ideal.Quotient.mk I (coeffMonoidHom R p n x) := rfl
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp] theorem coeff_zero_symm_quotientMulEquiv (x : Perfection (R ⧸ I) p) :
+    coeffMonoidHom R p 0 (quotientMulEquiv.symm x) = teichmuller₀ p I x := by
+  simp [quotientMulEquiv]
 
 end Perfection

--- a/Mathlib/RingTheory/Teichmuller.lean
+++ b/Mathlib/RingTheory/Teichmuller.lean
@@ -189,7 +189,7 @@ theorem mk_comp_teichmuller' :
   funext mk_teichmuller
 
 set_option backward.isDefEq.respectTransparency false in
-noncomputable def quotientMulEquiv (p : ℕ) [Fact (Nat.Prime p)]
+noncomputable def quotientMulEquiv (p : ℕ) [Fact p.Prime]
     {R : Type*} [CommRing R] (I : Ideal R) [CharP (R ⧸ I) p] [IsAdicComplete I R] :
     Perfection R p ≃* Perfection (R ⧸ I) p := MonoidHom.toMulEquiv
   (mapMonoidHom _ <| Ideal.Quotient.mk I)

--- a/Mathlib/RingTheory/Teichmuller.lean
+++ b/Mathlib/RingTheory/Teichmuller.lean
@@ -189,18 +189,20 @@ theorem mk_comp_teichmuller' :
   funext mk_teichmuller
 
 set_option backward.isDefEq.respectTransparency false in
-noncomputable def quotientMulEquiv : Perfection R p ≃* Perfection (R ⧸ I) p := MonoidHom.toMulEquiv
+noncomputable def quotientMulEquiv (p : ℕ) [Fact (Nat.Prime p)]
+    {R : Type*} [CommRing R] (I : Ideal R) [CharP (R ⧸ I) p] [IsAdicComplete I R] :
+    Perfection R p ≃* Perfection (R ⧸ I) p := MonoidHom.toMulEquiv
   (mapMonoidHom _ <| Ideal.Quotient.mk I)
   (liftMonoidHom p _ _ <| teichmuller p I)
   ((liftMonoidHom p _ _).symm.injective <| by ext; simp)
   ((liftMonoidHom p _ _).symm.injective <| by ext; simp)
 
 @[simp] theorem coeff_quotientMulEquiv (x : Perfection R p) (n : ℕ) :
-    coeff (R ⧸ I) p n (quotientMulEquiv x) = Ideal.Quotient.mk I (coeffMonoidHom R p n x) := rfl
+    coeff (R ⧸ I) p n (quotientMulEquiv p I x) = Ideal.Quotient.mk I (coeffMonoidHom R p n x) := rfl
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp] theorem coeff_zero_symm_quotientMulEquiv (x : Perfection (R ⧸ I) p) :
-    coeffMonoidHom R p 0 (quotientMulEquiv.symm x) = teichmuller₀ p I x := by
+    coeffMonoidHom R p 0 (quotientMulEquiv p I |>.symm x) = teichmuller₀ p I x := by
   simp [quotientMulEquiv]
 
 end Perfection


### PR DESCRIPTION
We construct the following isomorphism:
```lean
def Perfection.quotientMulEquiv (p : ℕ) [Fact (Nat.Prime p)]
    {R : Type*} [CommRing R] (I : Ideal R) [CharP (R ⧸ I) p] [IsAdicComplete I R] :
    Perfection R p ≃* Perfection (R ⧸ I) p
```

I also removed simp lemmas which expose the raw definition and instead prioritised lemmas which talk about the intended constructors, i.e. for `x : Perfection R p` we don't want `x.1 n` and instead want `x.coeff R p n`, and when `M` is perfect then maps `M -> Perfection N p` is determined by the zeroth coefficients.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This was requested in a [comment](https://github.com/leanprover-community/mathlib4/pull/30989#pullrequestreview-3386123609) by erdOne on Oct 28, 2025 .

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
