### PR TITLE
chore(Data/Finsupp/Defs): make `Finsupp.onFinset` computable

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -138,8 +138,9 @@ result of `onFinset` is the same as multiplying it over the original `Finset`. -
 @[to_additive
       /-- If `g` maps a second argument of 0 to 0, summing it over the
       result of `onFinset` is the same as summing it over the original `Finset`. -/]
-theorem onFinset_prod {s : Finset α} {f : α → M} {g : α → M → N} (hf : ∀ a, f a ≠ 0 → a ∈ s)
-    (hg : ∀ a, g a 0 = 1) : (onFinset s f hf).prod g = ∏ a ∈ s, g a (f a) :=
+theorem onFinset_prod [DecidableEq M] {s : Finset α} {f : α → M} {g : α → M → N}
+    (hf : ∀ a, f a ≠ 0 → a ∈ s) (hg : ∀ a, g a 0 = 1) :
+    (onFinset s f hf).prod g = ∏ a ∈ s, g a (f a) :=
   Finset.prod_subset support_onFinset_subset <| by simp +contextual [*]
 
 /-- Taking a product over `f : α →₀ M` is the same as multiplying the value on a single element

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -21,9 +21,6 @@ public import Mathlib.GroupTheory.GroupAction.Ring
 
 @[expose] public section
 
-
-noncomputable section
-
 open Finset
 
 open Polynomial
@@ -43,7 +40,7 @@ section Semiring
 variable [Semiring R]
 
 /-- `derivative p` is the formal derivative of the polynomial `p` -/
-def derivative : R[X] →ₗ[R] R[X] where
+noncomputable def derivative : R[X] →ₗ[R] R[X] where
   toFun p := p.sum fun n a => C (a * n) * X ^ (n - 1)
   map_add' p q := by
     rw [sum_add_index] <;>
@@ -395,9 +392,11 @@ theorem iterate_derivative_mul {n} (p q : R[X]) :
 Iterated derivatives as a finite support function.
 -/
 @[simps! apply_apply]
-noncomputable def derivativeFinsupp [DecidableEq R[X]] : R[X] →ₗ[R] ℕ →₀ R[X] where
-  toFun p := .onFinset (range (p.natDegree + 1)) (derivative^[·] p) fun i ↦ by
-    contrapose; simp_all [iterate_derivative_eq_zero]
+noncomputable def derivativeFinsupp : R[X] →ₗ[R] ℕ →₀ R[X] where
+  toFun p :=
+    haveI := Classical.decEq R[X]
+    .onFinset (range (p.natDegree + 1)) (derivative^[·] p) fun i ↦ by
+      contrapose; simp_all [iterate_derivative_eq_zero]
   map_add' _ _ := by ext; simp
   map_smul' _ _ := by ext; simp
 
@@ -405,39 +404,37 @@ noncomputable def derivativeFinsupp [DecidableEq R[X]] : R[X] →ₗ[R] ℕ →�
 alias derivativeFinsupp_apply_toFun := derivativeFinsupp_apply_apply
 
 @[simp]
-theorem support_derivativeFinsupp_subset_range [DecidableEq R[X]] {p : R[X]} {n : ℕ}
-    (h : p.natDegree < n) : (derivativeFinsupp p).support ⊆ range n := by
+theorem support_derivativeFinsupp_subset_range {p : R[X]} {n : ℕ} (h : p.natDegree < n) :
+    (derivativeFinsupp p).support ⊆ range n := by
+  letI := Classical.decEq R[X]
   dsimp [derivativeFinsupp]
   exact Finsupp.support_onFinset_subset.trans (Finset.range_subset_range.mpr h)
 
 @[simp]
-theorem derivativeFinsupp_C [DecidableEq R[X]] (r : R) :
-    derivativeFinsupp (C r : R[X]) = .single 0 (C r) := by
+theorem derivativeFinsupp_C (r : R) : derivativeFinsupp (C r : R[X]) = .single 0 (C r) := by
   ext i : 1
   match i with
   | 0 => simp
   | i + 1 => simp
 
 @[simp]
-theorem derivativeFinsupp_one [DecidableEq R[X]] : derivativeFinsupp (1 : R[X]) = .single 0 1 := by
+theorem derivativeFinsupp_one : derivativeFinsupp (1 : R[X]) = .single 0 1 := by
   simpa using derivativeFinsupp_C (1 : R)
 
 @[simp]
-theorem derivativeFinsupp_X [DecidableEq R[X]] :
-    derivativeFinsupp (X : R[X]) = .single 0 X + .single 1 1 := by
+theorem derivativeFinsupp_X : derivativeFinsupp (X : R[X]) = .single 0 X + .single 1 1 := by
   ext i : 1
   match i with
   | 0 => simp
   | 1 => simp
   | (n + 2) => simp
 
-theorem derivativeFinsupp_map [DecidableEq R[X]] [Semiring S] [DecidableEq S[X]] (p : R[X])
-    (f : R →+* S) :
+theorem derivativeFinsupp_map [Semiring S] (p : R[X]) (f : R →+* S) :
     derivativeFinsupp (p.map f) = (derivativeFinsupp p).mapRange (·.map f) (by simp) := by
   ext i : 1
   simp
 
-theorem derivativeFinsupp_derivative [DecidableEq R[X]] (p : R[X]) :
+theorem derivativeFinsupp_derivative (p : R[X]) :
     derivativeFinsupp (derivative p) =
       (derivativeFinsupp p).comapDomain Nat.succ Nat.succ_injective.injOn := by
   ext i : 1

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -395,7 +395,7 @@ theorem iterate_derivative_mul {n} (p q : R[X]) :
 Iterated derivatives as a finite support function.
 -/
 @[simps! apply_apply]
-noncomputable def derivativeFinsupp : R[X] →ₗ[R] ℕ →₀ R[X] where
+noncomputable def derivativeFinsupp [DecidableEq R[X]] : R[X] →ₗ[R] ℕ →₀ R[X] where
   toFun p := .onFinset (range (p.natDegree + 1)) (derivative^[·] p) fun i ↦ by
     contrapose; simp_all [iterate_derivative_eq_zero]
   map_add' _ _ := by ext; simp
@@ -405,36 +405,39 @@ noncomputable def derivativeFinsupp : R[X] →ₗ[R] ℕ →₀ R[X] where
 alias derivativeFinsupp_apply_toFun := derivativeFinsupp_apply_apply
 
 @[simp]
-theorem support_derivativeFinsupp_subset_range {p : R[X]} {n : ℕ} (h : p.natDegree < n) :
-    (derivativeFinsupp p).support ⊆ range n := by
+theorem support_derivativeFinsupp_subset_range [DecidableEq R[X]] {p : R[X]} {n : ℕ}
+    (h : p.natDegree < n) : (derivativeFinsupp p).support ⊆ range n := by
   dsimp [derivativeFinsupp]
   exact Finsupp.support_onFinset_subset.trans (Finset.range_subset_range.mpr h)
 
 @[simp]
-theorem derivativeFinsupp_C (r : R) : derivativeFinsupp (C r : R[X]) = .single 0 (C r) := by
+theorem derivativeFinsupp_C [DecidableEq R[X]] (r : R) :
+    derivativeFinsupp (C r : R[X]) = .single 0 (C r) := by
   ext i : 1
   match i with
   | 0 => simp
   | i + 1 => simp
 
 @[simp]
-theorem derivativeFinsupp_one : derivativeFinsupp (1 : R[X]) = .single 0 1 := by
+theorem derivativeFinsupp_one [DecidableEq R[X]] : derivativeFinsupp (1 : R[X]) = .single 0 1 := by
   simpa using derivativeFinsupp_C (1 : R)
 
 @[simp]
-theorem derivativeFinsupp_X : derivativeFinsupp (X : R[X]) = .single 0 X + .single 1 1 := by
+theorem derivativeFinsupp_X [DecidableEq R[X]] :
+    derivativeFinsupp (X : R[X]) = .single 0 X + .single 1 1 := by
   ext i : 1
   match i with
   | 0 => simp
   | 1 => simp
   | (n + 2) => simp
 
-theorem derivativeFinsupp_map [Semiring S] (p : R[X]) (f : R →+* S) :
+theorem derivativeFinsupp_map [DecidableEq R[X]] [Semiring S] [DecidableEq S[X]] (p : R[X])
+    (f : R →+* S) :
     derivativeFinsupp (p.map f) = (derivativeFinsupp p).mapRange (·.map f) (by simp) := by
   ext i : 1
   simp
 
-theorem derivativeFinsupp_derivative (p : R[X]) :
+theorem derivativeFinsupp_derivative [DecidableEq R[X]] (p : R[X]) :
     derivativeFinsupp (derivative p) =
       (derivativeFinsupp p).comapDomain Nat.succ Nat.succ_injective.injOn := by
   ext i : 1

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1278,6 +1278,7 @@ This is the `Finsupp` version of `Equiv.Pi_curry`. -/
 noncomputable def sigmaFinsuppEquivPiFinsupp : ((Σ j, ιs j) →₀ α) ≃ ∀ j, ιs j →₀ α where
   toFun := split
   invFun f :=
+    haveI := Classical.decEq α
     onFinset (Finset.univ.sigma fun j => (f j).support) (fun ji => f ji.1 ji.2) fun _ hg =>
       Finset.mem_sigma.mpr ⟨Finset.mem_univ _, mem_support_iff.mpr hg⟩
   left_inv f := by

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -64,7 +64,7 @@ We also use the following convention for `Type*` variables in this file
 
 ## Implementation notes
 
-This file is a `noncomputable theory` and uses classical logic throughout.
+This file contains `noncomputable` definitions and uses classical logic throughout.
 
 ## TODO
 
@@ -75,8 +75,6 @@ This file is a `noncomputable theory` and uses classical logic throughout.
 @[expose] public section
 
 assert_not_exists CompleteLattice Monoid
-
-noncomputable section
 
 open Finset Function
 
@@ -200,7 +198,7 @@ theorem support_subset_iff {s : Set α} {f : α →₀ M} :
 /-- Given `Finite α`, `equivFunOnFinite` is the `Equiv` between `α →₀ β` and `α → β`.
   (All functions on a finite type are finitely supported.) -/
 @[simps]
-def equivFunOnFinite [Finite α] : (α →₀ M) ≃ (α → M) where
+noncomputable def equivFunOnFinite [Finite α] : (α →₀ M) ≃ (α → M) where
   toFun := (⇑)
   invFun f := mk (Function.support f).toFinite.toFinset f fun _a => Set.Finite.mem_toFinset _
 
@@ -232,39 +230,42 @@ section OnFinset
 variable [Zero M]
 
 /-- The (not exposed) support of `Finsupp.onFinset`. -/
-@[no_expose] def onFinset_support (s : Finset α) (f : α → M) : Finset α :=
-  haveI := Classical.decEq M
+@[no_expose] def onFinset_support [DecidableEq M] (s : Finset α) (f : α → M) : Finset α :=
   {a ∈ s | f a ≠ 0}
 
 /-- `Finsupp.onFinset s f hf` is the finsupp function representing `f` restricted to the finset `s`.
 The function must be `0` outside of `s`. Use this when the set needs to be filtered anyways,
 otherwise a better set representation is often available. -/
-def onFinset (s : Finset α) (f : α → M) (hf : ∀ a, f a ≠ 0 → a ∈ s) : α →₀ M where
+def onFinset [DecidableEq M] (s : Finset α) (f : α → M) (hf : ∀ a, f a ≠ 0 → a ∈ s) :
+    α →₀ M where
   support := onFinset_support s f
   toFun := f
   mem_support_toFun := by simpa [onFinset_support]
 
-@[simp, norm_cast] lemma coe_onFinset (s : Finset α) (f : α → M) (hf) : onFinset s f hf = f := rfl
+@[simp, norm_cast] lemma coe_onFinset [DecidableEq M] (s : Finset α) (f : α → M) (hf) :
+    onFinset s f hf = f :=
+  rfl
 
 @[simp, grind =]
-theorem onFinset_apply {s : Finset α} {f : α → M} {hf a} : (onFinset s f hf : α →₀ M) a = f a :=
+theorem onFinset_apply [DecidableEq M] {s : Finset α} {f : α → M} {hf a} :
+    (onFinset s f hf : α →₀ M) a = f a :=
   rfl
 
 theorem support_onFinset [DecidableEq M] {s : Finset α} {f : α → M}
-    (hf : ∀ a : α, f a ≠ 0 → a ∈ s) :
-    (Finsupp.onFinset s f hf).support = {a ∈ s | f a ≠ 0} := by
-  dsimp [onFinset]; rw [onFinset_support]; congr
+    (hf : ∀ a : α, f a ≠ 0 → a ∈ s) : (onFinset s f hf).support = {a ∈ s | f a ≠ 0} := by
+  dsimp [onFinset]
+  rw [onFinset_support]
 
 @[simp]
-theorem support_onFinset_subset {s : Finset α} {f : α → M} {hf} :
+theorem support_onFinset_subset [DecidableEq M] {s : Finset α} {f : α → M} {hf} :
     (onFinset s f hf).support ⊆ s := by
   grind
 
 grind_pattern support_onFinset_subset => onFinset s f hf
 
-theorem mem_support_onFinset {s : Finset α} {f : α → M} (hf : ∀ a : α, f a ≠ 0 → a ∈ s) {a : α} :
-    a ∈ (Finsupp.onFinset s f hf).support ↔ f a ≠ 0 := by
-  rw [Finsupp.mem_support_iff, Finsupp.onFinset_apply]
+theorem mem_support_onFinset [DecidableEq M] {s : Finset α} {f : α → M}
+    (hf : ∀ a : α, f a ≠ 0 → a ∈ s) {a : α} : a ∈ (onFinset s f hf).support ↔ f a ≠ 0 := by
+  rw [mem_support_iff, onFinset_apply]
 
 end OnFinset
 
@@ -311,7 +312,8 @@ bundled (defined in `Mathlib/Data/Finsupp/Basic.lean`):
 * `Finsupp.mapRange.linearMap`
 * `Finsupp.mapRange.linearEquiv`
 -/
-def mapRange (f : M → N) (hf : f 0 = 0) (g : α →₀ M) : α →₀ N :=
+noncomputable def mapRange (f : M → N) (hf : f 0 = 0) (g : α →₀ M) : α →₀ N :=
+  haveI := Classical.decEq N
   onFinset g.support (f ∘ g) fun a => by
     rw [mem_support_iff, not_imp_not]; exact fun H => (congr_arg f H).trans hf
 
@@ -342,8 +344,9 @@ lemma mapRange_mapRange (e₁ : N → O) (e₂ : M → N) (he₁ he₂) (f : α 
     mapRange e₁ he₁ (mapRange e₂ he₂ f) = mapRange (e₁ ∘ e₂) (by simp [*]) f := ext fun _ ↦ rfl
 
 theorem support_mapRange {f : M → N} {hf : f 0 = 0} {g : α →₀ M} :
-    (mapRange f hf g).support ⊆ g.support :=
-  support_onFinset_subset
+    (mapRange f hf g).support ⊆ g.support := by
+  classical
+  exact support_onFinset_subset
 
 theorem support_mapRange_of_injective {e : M → N} (he0 : e 0 = 0) (f : ι →₀ M)
     (he : Function.Injective e) : (Finsupp.mapRange e he0 f).support = f.support := by grind
@@ -380,7 +383,7 @@ variable [Zero M] [Zero N] [Zero O]
 
 /-- `Finsupp.mapRange` as an equiv. -/
 @[simps (attr := grind =) apply]
-def mapRange.equiv (e : M ≃ N) (hf : e 0 = 0) : (ι →₀ M) ≃ (ι →₀ N) where
+noncomputable def mapRange.equiv (e : M ≃ N) (hf : e 0 = 0) : (ι →₀ M) ≃ (ι →₀ N) where
   toFun := mapRange e hf
   invFun := mapRange e.symm <| by simp [← hf]
   left_inv x := by ext; simp
@@ -408,7 +411,7 @@ variable [Zero M] [Zero N]
 /-- Given `f : α ↪ β` and `v : α →₀ M`, `Finsupp.embDomain f v : β →₀ M`
 is the finitely supported function whose value at `f a : β` is `v a`.
 For a `b : β` outside the range of `f`, it is zero. -/
-def embDomain (f : α ↪ β) (v : α →₀ M) : β →₀ M where
+noncomputable def embDomain (f : α ↪ β) (v : α →₀ M) : β →₀ M where
   support := v.support.map f
   toFun a₂ :=
     haveI := Classical.decEq β
@@ -482,7 +485,8 @@ variable [Zero M] [Zero N] [Zero O]
 /-- Given finitely supported functions `g₁ : α →₀ M` and `g₂ : α →₀ N` and function `f : M → N → O`,
 `Finsupp.zipWith f hf g₁ g₂` is the finitely supported function `α →₀ O` satisfying
 `zipWith f hf g₁ g₂ a = f (g₁ a) (g₂ a)`, which is well-defined when `f 0 0 = 0`. -/
-def zipWith (f : M → N → O) (hf : f 0 0 = 0) (g₁ : α →₀ M) (g₂ : α →₀ N) : α →₀ O :=
+noncomputable def zipWith (f : M → N → O) (hf : f 0 0 = 0) (g₁ : α →₀ M) (g₂ : α →₀ N) : α →₀ O :=
+  haveI := Classical.decEq O
   onFinset
     (haveI := Classical.decEq α; g₁.support ∪ g₂.support)
     (fun a => f (g₁ a) (g₂ a))

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -258,6 +258,7 @@ def sigmaFinsuppEquivDFinsupp [Zero N] : ((Σ i, η i) →₀ N) ≃ Π₀ i, η
           exact (em _).symm⟩⟩
   invFun f := by
     haveI := Classical.decEq ι
+    haveI := Classical.decEq N
     haveI := fun i => Classical.decEq (η i →₀ N)
     refine
       onFinset (Finset.sigma f.support fun j => (f j).support) (fun ji => f ji.1 ji.2) fun g hg =>

--- a/Mathlib/Data/Sym/Sym2/Finsupp.lean
+++ b/Mathlib/Data/Sym/Sym2/Finsupp.lean
@@ -34,9 +34,12 @@ lemma mem_sym2_support_of_mul_ne_zero (p : Sym2 α) (hp : mul (p.map f) ≠ 0) :
 
 /-- The composition of a `Finsupp` with `Sym2.mul` as a `Finsupp`. -/
 noncomputable def sym2Mul (f : α →₀ M₀) : Sym2 α →₀ M₀ :=
+  haveI := Classical.decEq M₀
   .onFinset f.support.sym2 (fun p ↦ mul (p.map f)) mem_sym2_support_of_mul_ne_zero
 
-lemma support_sym2Mul_subset : f.sym2Mul.support ⊆ f.support.sym2 := support_onFinset_subset
+lemma support_sym2Mul_subset : f.sym2Mul.support ⊆ f.support.sym2 := by
+  classical
+  exact support_onFinset_subset
 
 @[simp, norm_cast] lemma coe_sym2Mul (f : α →₀ M₀) : f.sym2Mul = mul ∘ map f := rfl
 

--- a/Mathlib/FieldTheory/PurelyInseparable/Tower.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Tower.lean
@@ -65,6 +65,7 @@ then it is also `E`-linearly independent. -/
 theorem LinearIndependent.map_of_isPurelyInseparable_of_isSeparable [IsPurelyInseparable F E]
     {ι : Type*} {v : ι → K} (hsep : ∀ i : ι, IsSeparable F (v i))
     (h : LinearIndependent F v) : LinearIndependent E v := by
+  classical
   obtain ⟨q, _⟩ := ExpChar.exists F
   haveI := expChar_of_injective_algebraMap (algebraMap F K).injective q
   refine linearIndependent_iff.mpr fun l hl ↦ Finsupp.ext fun i ↦ ?_

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -265,10 +265,9 @@ theorem linearCombination_comapDomain (f : α → α') (l : α' →₀ R)
       (l.support.preimage f hf).sum fun i => l (f i) • v i := by
   rw [linearCombination_apply]; rfl
 
-theorem linearCombination_onFinset {s : Finset α} {f : α → R} (g : α → M)
+theorem linearCombination_onFinset [DecidableEq R] {s : Finset α} {f : α → R} (g : α → M)
     (hf : ∀ a, f a ≠ 0 → a ∈ s) :
     linearCombination R g (Finsupp.onFinset s f hf) = Finset.sum s fun x : α => f x • g x := by
-  classical
   simp only [linearCombination_apply, Finsupp.sum, Finsupp.onFinset_apply, Finsupp.support_onFinset]
   rw [Finset.sum_filter_of_ne]
   intro x _ h


### PR DESCRIPTION
Delete the `noncomputable section` to let every `def` choose whether it's computable, and replace the use of `Classical.decEq` in `onFinset_support` and `onFinset` with a `[DecidableEq M]` assumption.

---
[Zulip](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Finsupp.20noncomputability/with/576412101)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
