### PR TITLE
[Merged by Bors] - feat(RatFunc): add notation for RatFunc

### DIFF
--- a/Mathlib/FieldTheory/Laurent.lean
+++ b/Mathlib/FieldTheory/Laurent.lean
@@ -36,7 +36,7 @@ open Polynomial
 
 open scoped nonZeroDivisors
 
-variable {R : Type u} [CommRing R] (r s : R) (p q : R[X]) (f : RatFunc R)
+variable {R : Type u} [CommRing R] (r s : R) (p q : R[X]) (f : R⟮X⟯)
 
 theorem taylor_mem_nonZeroDivisors (hp : p ∈ R[X]⁰) : taylor r p ∈ R[X]⁰ := by
   rw [mem_nonZeroDivisors_iff_right]
@@ -48,7 +48,7 @@ theorem taylor_mem_nonZeroDivisors (hp : p ∈ R[X]⁰) : taylor r p ∈ R[X]⁰
 
 /-- The Laurent expansion of rational functions about a value.
 Auxiliary definition, usage when over integral domains should prefer `RatFunc.laurent`. -/
-def laurentAux : RatFunc R →+* RatFunc R :=
+def laurentAux : R⟮X⟯ →+* R⟮X⟯ :=
   RatFunc.mapRingHom
     ( { toFun := taylor r
         map_add' := map_add (taylor r)
@@ -75,7 +75,7 @@ theorem laurentAux_algebraMap : laurentAux r (algebraMap _ _ p) = algebraMap _ _
   rw [← mk_one, ← mk_one, mk_eq_div, laurentAux_div, mk_eq_div, taylor_one, map_one, map_one]
 
 /-- The Laurent expansion of rational functions about a value. -/
-def laurent : RatFunc R →ₐ[R] RatFunc R :=
+def laurent : R⟮X⟯ →ₐ[R] R⟮X⟯ :=
   RatFunc.mapAlgHom (.ofLinearMap (taylor r) (taylor_one _) (taylor_mul _))
     (taylor_mem_nonZeroDivisors _)
 

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -51,15 +51,15 @@ variable [CommRing K] [IsDomain K]
 def C : K →+* K⟮X⟯ := algebraMap _ _
 
 @[simp]
-theorem algebraMap_eq_C : algebraMap K (K⟮X⟯) = C :=
+theorem algebraMap_eq_C : algebraMap K K⟮X⟯ = C :=
   rfl
 
 @[simp]
-theorem algebraMap_C (a : K) : algebraMap K[X] (K⟮X⟯) (Polynomial.C a) = C a :=
+theorem algebraMap_C (a : K) : algebraMap K[X] K⟮X⟯ (Polynomial.C a) = C a :=
   rfl
 
 @[simp]
-theorem algebraMap_comp_C : (algebraMap K[X] (K⟮X⟯)).comp Polynomial.C = C :=
+theorem algebraMap_comp_C : (algebraMap K[X] K⟮X⟯).comp Polynomial.C = C :=
   rfl
 
 set_option backward.isDefEq.respectTransparency false in
@@ -72,21 +72,21 @@ theorem C_injective : Function.Injective (RatFunc.C (K := K)) := by
 
 /-- `RatFunc.X` is the polynomial variable (aka indeterminate). -/
 def X : K⟮X⟯ :=
-  algebraMap K[X] (K⟮X⟯) Polynomial.X
+  algebraMap K[X] K⟮X⟯ Polynomial.X
 
 @[simp]
-theorem algebraMap_X : algebraMap K[X] (K⟮X⟯) Polynomial.X = X :=
+theorem algebraMap_X : algebraMap K[X] K⟮X⟯ Polynomial.X = X :=
   rfl
 
 @[simp]
 theorem algebraMap_monomial (n : ℕ) (a : K) :
-    algebraMap K[X] (K⟮X⟯) (Polynomial.monomial n a) = C a * X ^ n := by
+    algebraMap K[X] K⟮X⟯ (Polynomial.monomial n a) = C a * X ^ n := by
   simp [← Polynomial.C_mul_X_pow_eq_monomial]
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem aeval_X_left_eq_algebraMap (p : K[X]) :
-    p.aeval (X : K⟮X⟯) = algebraMap K[X] (K⟮X⟯) p := by
+    p.aeval (X : K⟮X⟯) = algebraMap K[X] K⟮X⟯ p := by
   induction p using Polynomial.induction_on' <;> simp_all
 
 @[simp]
@@ -169,7 +169,7 @@ theorem eval_one : eval f a 1 = 1 := by simp [eval]
 @[simp]
 theorem eval_algebraMap {S : Type*} [CommSemiring S] [Algebra S K[X]] (p : S) :
     eval f a (algebraMap _ _ p) = (algebraMap _ K[X] p).eval₂ f a := by
-  simp [eval, IsScalarTower.algebraMap_apply S K[X] (K⟮X⟯)]
+  simp [eval, IsScalarTower.algebraMap_apply S K[X] K⟮X⟯]
 
 /-- `eval` is an additive homomorphism except when a denominator evaluates to `0`.
 
@@ -222,7 +222,7 @@ lemma transcendental_X : Transcendental K (X : K⟮X⟯) := by
   rw [← RatFunc.algebraMap_X, transcendental_algebraMap_iff (algebraMap_injective K)]
   exact Polynomial.transcendental_X K
 
-instance transcendental : Algebra.Transcendental K (K⟮X⟯) := ⟨X, transcendental_X⟩
+instance transcendental : Algebra.Transcendental K K⟮X⟯ := ⟨X, transcendental_X⟩
 
 end Algebra
 
@@ -253,7 +253,7 @@ theorem idealX_span : (idealX K).asIdeal = Ideal.span {X} := rfl
 
 @[simp]
 theorem valuation_X_eq_neg_one :
-    (idealX K).valuation (K⟮X⟯) RatFunc.X = exp (-1 : ℤ) := by
+    (idealX K).valuation K⟮X⟯ RatFunc.X = exp (-1 : ℤ) := by
   rw [← RatFunc.algebraMap_X, valuation_of_algebraMap, intValuation_singleton
       _ (Polynomial.X_ne_zero) (idealX_span K)]
 
@@ -296,7 +296,7 @@ theorem valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X (w : 
 
 end Algebra
 
-variable {v : Valuation (K⟮X⟯) Γ} (hv : ∀ a : K, a ≠ 0 → v (C a) = 1)
+variable {v : Valuation K⟮X⟯ Γ} (hv : ∀ a : K, a ≠ 0 → v (C a) = 1)
 
 open Valuation
 
@@ -314,11 +314,11 @@ lemma valuation_monomial_eq_valuation_X_pow (n : ℕ) {a : K} (ha : a ≠ 0) :
 Note: The condition `1 < v RatFunc.X` is typically satisfied by the valuation at infinity. -/
 theorem valuation_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X (hlt : 1 < v RatFunc.X)
     {p : K[X]} (hp : p ≠ 0) : v p = v RatFunc.X ^ p.natDegree := by
-  convert valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X K (K⟮X⟯) hv
+  convert valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X K K⟮X⟯ hv
     RatFunc.X hlt hp
   ext p
   nth_rw 1 [RatFunc.X, ← aeval_X_left_apply p (R := K)]
-  exact (aeval_algebraMap_apply (K⟮X⟯) X p).symm
+  exact (aeval_algebraMap_apply K⟮X⟯ X p).symm
 
 
 /-- If a valuation `v` is trivial on constants and `v RatFunc.X ≤ 1` then for every polynomial `p`,
@@ -349,7 +349,7 @@ open scoped WithZero
 
 open Polynomial
 
-instance : Valued (K⟮X⟯) ℤᵐ⁰ := Valued.mk' ((idealX K).valuation _)
+instance : Valued K⟮X⟯ ℤᵐ⁰ := Valued.mk' ((idealX K).valuation _)
 
 @[simp]
 theorem v_def {x : K⟮X⟯} :

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -234,6 +234,8 @@ variable (K : Type*) [Field K]
 
 namespace Polynomial
 
+open RatFunc
+
 section HeightOneSpectrum
 
 open IsDedekindDomain.HeightOneSpectrum WithZero

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -48,22 +48,22 @@ section Domain
 variable [CommRing K] [IsDomain K]
 
 /-- `RatFunc.C a` is the constant rational function `a`. -/
-def C : K →+* RatFunc K := algebraMap _ _
+def C : K →+* K⟮X⟯ := algebraMap _ _
 
 @[simp]
-theorem algebraMap_eq_C : algebraMap K (RatFunc K) = C :=
+theorem algebraMap_eq_C : algebraMap K (K⟮X⟯) = C :=
   rfl
 
 @[simp]
-theorem algebraMap_C (a : K) : algebraMap K[X] (RatFunc K) (Polynomial.C a) = C a :=
+theorem algebraMap_C (a : K) : algebraMap K[X] (K⟮X⟯) (Polynomial.C a) = C a :=
   rfl
 
 @[simp]
-theorem algebraMap_comp_C : (algebraMap K[X] (RatFunc K)).comp Polynomial.C = C :=
+theorem algebraMap_comp_C : (algebraMap K[X] (K⟮X⟯)).comp Polynomial.C = C :=
   rfl
 
 set_option backward.isDefEq.respectTransparency false in
-theorem smul_eq_C_mul (r : K) (x : RatFunc K) : r • x = C r * x := by
+theorem smul_eq_C_mul (r : K) (x : K⟮X⟯) : r • x = C r * x := by
   rw [Algebra.smul_def, algebraMap_eq_C]
 
 theorem C_injective : Function.Injective (RatFunc.C (K := K)) := by
@@ -71,22 +71,22 @@ theorem C_injective : Function.Injective (RatFunc.C (K := K)) := by
   exact Function.Injective.comp (algebraMap_injective K) (Polynomial.C_injective)
 
 /-- `RatFunc.X` is the polynomial variable (aka indeterminate). -/
-def X : RatFunc K :=
-  algebraMap K[X] (RatFunc K) Polynomial.X
+def X : K⟮X⟯ :=
+  algebraMap K[X] (K⟮X⟯) Polynomial.X
 
 @[simp]
-theorem algebraMap_X : algebraMap K[X] (RatFunc K) Polynomial.X = X :=
+theorem algebraMap_X : algebraMap K[X] (K⟮X⟯) Polynomial.X = X :=
   rfl
 
 @[simp]
 theorem algebraMap_monomial (n : ℕ) (a : K) :
-    algebraMap K[X] (RatFunc K) (Polynomial.monomial n a) = C a * X ^ n := by
+    algebraMap K[X] (K⟮X⟯) (Polynomial.monomial n a) = C a * X ^ n := by
   simp [← Polynomial.C_mul_X_pow_eq_monomial]
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem aeval_X_left_eq_algebraMap (p : K[X]) :
-    p.aeval (X : RatFunc K) = algebraMap K[X] (RatFunc K) p := by
+    p.aeval (X : K⟮X⟯) = algebraMap K[X] (K⟮X⟯) p := by
   induction p using Polynomial.induction_on' <;> simp_all
 
 @[simp]
@@ -114,17 +114,17 @@ theorem denom_C (c : K) : denom (C c) = 1 :=
   denom_algebraMap _
 
 @[simp]
-theorem num_X : num (X : RatFunc K) = Polynomial.X :=
+theorem num_X : num (X : K⟮X⟯) = Polynomial.X :=
   num_algebraMap _
 
 @[simp]
-theorem denom_X : denom (X : RatFunc K) = 1 :=
+theorem denom_X : denom (X : K⟮X⟯) = 1 :=
   denom_algebraMap _
 
-theorem X_ne_zero : (X : RatFunc K) ≠ 0 :=
+theorem X_ne_zero : (X : K⟮X⟯) ≠ 0 :=
   RatFunc.algebraMap_ne_zero Polynomial.X_ne_zero
 
-theorem eq_C_iff (f : RatFunc K) :
+theorem eq_C_iff (f : K⟮X⟯) :
     (∃ c, f = C c) ↔ f.num.natDegree = 0 ∧ f.denom.natDegree = 0 := by
   refine ⟨by rintro ⟨c, rfl⟩; simp, ?_⟩
   rw [Polynomial.natDegree_eq_zero, Polynomial.natDegree_eq_zero]
@@ -140,15 +140,15 @@ to the target and a value `x` for the variable in the target.
 Fractions are reduced by clearing common denominators before evaluating:
 `eval id 1 ((X^2 - 1) / (X - 1)) = eval id 1 (X + 1) = 2`, not `0 / 0 = 0`.
 -/
-def eval (f : K →+* L) (a : L) (p : RatFunc K) : L :=
+def eval (f : K →+* L) (a : L) (p : K⟮X⟯) : L :=
   (num p).eval₂ f a / (denom p).eval₂ f a
 
 variable {f : K →+* L} {a : L}
 
-theorem eval_eq_zero_of_eval₂_denom_eq_zero {x : RatFunc K}
+theorem eval_eq_zero_of_eval₂_denom_eq_zero {x : K⟮X⟯}
     (h : Polynomial.eval₂ f a (denom x) = 0) : eval f a x = 0 := by rw [eval, h, div_zero]
 
-theorem eval₂_denom_ne_zero {x : RatFunc K} (h : eval f a x ≠ 0) :
+theorem eval₂_denom_ne_zero {x : K⟮X⟯} (h : eval f a x ≠ 0) :
     Polynomial.eval₂ f a (denom x) ≠ 0 :=
   mt eval_eq_zero_of_eval₂_denom_eq_zero h
 
@@ -169,7 +169,7 @@ theorem eval_one : eval f a 1 = 1 := by simp [eval]
 @[simp]
 theorem eval_algebraMap {S : Type*} [CommSemiring S] [Algebra S K[X]] (p : S) :
     eval f a (algebraMap _ _ p) = (algebraMap _ K[X] p).eval₂ f a := by
-  simp [eval, IsScalarTower.algebraMap_apply S K[X] (RatFunc K)]
+  simp [eval, IsScalarTower.algebraMap_apply S K[X] (K⟮X⟯)]
 
 /-- `eval` is an additive homomorphism except when a denominator evaluates to `0`.
 
@@ -178,7 +178,7 @@ Counterexample: `eval _ 1 (X / (X-1)) + eval _ 1 (-1 / (X-1)) = 0`
 
 See also `RatFunc.eval₂_denom_ne_zero` to make the hypotheses simpler but less general.
 -/
-theorem eval_add {x y : RatFunc K} (hx : Polynomial.eval₂ f a (denom x) ≠ 0)
+theorem eval_add {x y : K⟮X⟯} (hx : Polynomial.eval₂ f a (denom x) ≠ 0)
     (hy : Polynomial.eval₂ f a (denom y) ≠ 0) : eval f a (x + y) = eval f a x + eval f a y := by
   unfold eval
   by_cases hxy : Polynomial.eval₂ f a (denom (x + y)) = 0
@@ -197,7 +197,7 @@ Counterexample: `eval _ 0 X * eval _ 0 (1/X) = 0 ≠ 1 = eval _ 0 1 = eval _ 0 (
 
 See also `RatFunc.eval₂_denom_ne_zero` to make the hypotheses simpler but less general.
 -/
-theorem eval_mul {x y : RatFunc K} (hx : Polynomial.eval₂ f a (denom x) ≠ 0)
+theorem eval_mul {x y : K⟮X⟯} (hx : Polynomial.eval₂ f a (denom x) ≠ 0)
     (hy : Polynomial.eval₂ f a (denom y) ≠ 0) : eval f a (x * y) = eval f a x * eval f a y := by
   unfold eval
   by_cases hxy : Polynomial.eval₂ f a (denom (x * y)) = 0
@@ -218,11 +218,11 @@ section Algebra
 
 variable [CommRing K] [IsDomain K]
 
-lemma transcendental_X : Transcendental K (X : RatFunc K) := by
+lemma transcendental_X : Transcendental K (X : K⟮X⟯) := by
   rw [← RatFunc.algebraMap_X, transcendental_algebraMap_iff (algebraMap_injective K)]
   exact Polynomial.transcendental_X K
 
-instance transcendental : Algebra.Transcendental K (RatFunc K) := ⟨X, transcendental_X⟩
+instance transcendental : Algebra.Transcendental K (K⟮X⟯) := ⟨X, transcendental_X⟩
 
 end Algebra
 
@@ -251,7 +251,7 @@ theorem idealX_span : (idealX K).asIdeal = Ideal.span {X} := rfl
 
 @[simp]
 theorem valuation_X_eq_neg_one :
-    (idealX K).valuation (RatFunc K) RatFunc.X = exp (-1 : ℤ) := by
+    (idealX K).valuation (K⟮X⟯) RatFunc.X = exp (-1 : ℤ) := by
   rw [← RatFunc.algebraMap_X, valuation_of_algebraMap, intValuation_singleton
       _ (Polynomial.X_ne_zero) (idealX_span K)]
 
@@ -294,7 +294,7 @@ theorem valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X (w : 
 
 end Algebra
 
-variable {v : Valuation (RatFunc K) Γ} (hv : ∀ a : K, a ≠ 0 → v (C a) = 1)
+variable {v : Valuation (K⟮X⟯) Γ} (hv : ∀ a : K, a ≠ 0 → v (C a) = 1)
 
 open Valuation
 
@@ -312,11 +312,11 @@ lemma valuation_monomial_eq_valuation_X_pow (n : ℕ) {a : K} (ha : a ≠ 0) :
 Note: The condition `1 < v RatFunc.X` is typically satisfied by the valuation at infinity. -/
 theorem valuation_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X (hlt : 1 < v RatFunc.X)
     {p : K[X]} (hp : p ≠ 0) : v p = v RatFunc.X ^ p.natDegree := by
-  convert valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X K (RatFunc K) hv
+  convert valuation_aeval_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X K (K⟮X⟯) hv
     RatFunc.X hlt hp
   ext p
   nth_rw 1 [RatFunc.X, ← aeval_X_left_apply p (R := K)]
-  exact (aeval_algebraMap_apply (RatFunc K) X p).symm
+  exact (aeval_algebraMap_apply (K⟮X⟯) X p).symm
 
 
 /-- If a valuation `v` is trivial on constants and `v RatFunc.X ≤ 1` then for every polynomial `p`,
@@ -347,10 +347,10 @@ open scoped WithZero
 
 open Polynomial
 
-instance : Valued (RatFunc K) ℤᵐ⁰ := Valued.mk' ((idealX K).valuation _)
+instance : Valued (K⟮X⟯) ℤᵐ⁰ := Valued.mk' ((idealX K).valuation _)
 
 @[simp]
-theorem v_def {x : RatFunc K} :
+theorem v_def {x : K⟮X⟯} :
     Valued.v x = (idealX K).valuation _ x := rfl
 
 end RatFunc

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -17,11 +17,11 @@ public import Mathlib.RingTheory.Algebraic.Integral
 Working with rational functions as polynomials:
 - `RatFunc.instField` provides a field structure
 You can use `IsFractionRing` API to treat `RatFunc` as the field of fractions of polynomials:
-* `algebraMap K[X] (K⟮X⟯)` maps polynomials to rational functions
+* `algebraMap K[X] K⟮X⟯` maps polynomials to rational functions
 * `IsFractionRing.algEquiv` maps other fields of fractions of `K[X]` to `K⟮X⟯`.
 
 In particular:
-* `FractionRing.algEquiv K[X] (K⟮X⟯)` maps the generic field of
+* `FractionRing.algEquiv K[X] K⟮X⟯` maps the generic field of
   fraction construction to `K⟮X⟯`. Combine this with `AlgEquiv.restrictScalars` to change
   the `FractionRing K[X] ≃ₐ[K[X]] K⟮X⟯` to `FractionRing K[X] ≃ₐ[K] K⟮X⟯`.
 
@@ -67,7 +67,7 @@ variable [CommRing K]
 protected irreducible_def zero : K⟮X⟯ :=
   ⟨0⟩
 
-instance : Zero (K⟮X⟯) :=
+instance : Zero K⟮X⟯ :=
   ⟨RatFunc.zero⟩
 
 theorem ofFractionRing_zero : (ofFractionRing 0 : K⟮X⟯) = 0 :=
@@ -77,7 +77,7 @@ theorem ofFractionRing_zero : (ofFractionRing 0 : K⟮X⟯) = 0 :=
 protected irreducible_def add : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p + q⟩
 
-instance : Add (K⟮X⟯) :=
+instance : Add K⟮X⟯ :=
   ⟨RatFunc.add⟩
 
 theorem ofFractionRing_add (p q : FractionRing K[X]) :
@@ -88,7 +88,7 @@ theorem ofFractionRing_add (p q : FractionRing K[X]) :
 protected irreducible_def sub : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p - q⟩
 
-instance : Sub (K⟮X⟯) :=
+instance : Sub K⟮X⟯ :=
   ⟨RatFunc.sub⟩
 
 theorem ofFractionRing_sub (p q : FractionRing K[X]) :
@@ -99,7 +99,7 @@ theorem ofFractionRing_sub (p q : FractionRing K[X]) :
 protected irreducible_def neg : K⟮X⟯ → K⟮X⟯
   | ⟨p⟩ => ⟨-p⟩
 
-instance : Neg (K⟮X⟯) :=
+instance : Neg K⟮X⟯ :=
   ⟨RatFunc.neg⟩
 
 theorem ofFractionRing_neg (p : FractionRing K[X]) :
@@ -110,7 +110,7 @@ theorem ofFractionRing_neg (p : FractionRing K[X]) :
 protected irreducible_def one : K⟮X⟯ :=
   ⟨1⟩
 
-instance : One (K⟮X⟯) :=
+instance : One K⟮X⟯ :=
   ⟨RatFunc.one⟩
 
 theorem ofFractionRing_one : (ofFractionRing 1 : K⟮X⟯) = 1 :=
@@ -120,7 +120,7 @@ theorem ofFractionRing_one : (ofFractionRing 1 : K⟮X⟯) = 1 :=
 protected irreducible_def mul : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p * q⟩
 
-instance : Mul (K⟮X⟯) :=
+instance : Mul K⟮X⟯ :=
   ⟨RatFunc.mul⟩
 
 theorem ofFractionRing_mul (p q : FractionRing K[X]) :
@@ -135,7 +135,7 @@ variable [IsDomain K]
 protected irreducible_def div : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p / q⟩
 
-instance : Div (K⟮X⟯) :=
+instance : Div K⟮X⟯ :=
   ⟨RatFunc.div⟩
 
 theorem ofFractionRing_div (p q : FractionRing K[X]) :
@@ -146,7 +146,7 @@ theorem ofFractionRing_div (p q : FractionRing K[X]) :
 protected irreducible_def inv : K⟮X⟯ → K⟮X⟯
   | ⟨p⟩ => ⟨p⁻¹⟩
 
-instance : Inv (K⟮X⟯) :=
+instance : Inv K⟮X⟯ :=
   ⟨RatFunc.inv⟩
 
 theorem ofFractionRing_inv (p : FractionRing K[X]) :
@@ -171,7 +171,7 @@ variable {R : Type*}
 protected irreducible_def smul [SMul R (FractionRing K[X])] : R → K⟮X⟯ → K⟮X⟯
   | r, ⟨p⟩ => ⟨r • p⟩
 
-instance [SMul R (FractionRing K[X])] : SMul R (K⟮X⟯) :=
+instance [SMul R (FractionRing K[X])] : SMul R K⟮X⟯ :=
   ⟨RatFunc.smul⟩
 
 theorem ofFractionRing_smul [SMul R (FractionRing K[X])] (c : R) (p : FractionRing K[X]) :
@@ -202,7 +202,7 @@ theorem mk_smul (c : R) (p q : K[X]) : RatFunc.mk (c • p) q = c • RatFunc.mk
   · rw [mk_eq_localization_mk _ hq, mk_eq_localization_mk _ hq, ← Localization.smul_mk, ←
       ofFractionRing_smul]
 
-instance : IsScalarTower R K[X] (K⟮X⟯) :=
+instance : IsScalarTower R K[X] K⟮X⟯ :=
   ⟨fun c p q => q.induction_on' fun q r _ => by rw [← mk_smul, smul_assoc, mk_smul, mk_smul]⟩
 
 end IsDomain
@@ -211,13 +211,13 @@ end SMul
 
 variable (K)
 
-instance [Subsingleton K] : Subsingleton (K⟮X⟯) :=
+instance [Subsingleton K] : Subsingleton K⟮X⟯ :=
   toFractionRing_injective.subsingleton
 
-instance : Inhabited (K⟮X⟯) :=
+instance : Inhabited K⟮X⟯ :=
   ⟨0⟩
 
-instance instNontrivial [Nontrivial K] : Nontrivial (K⟮X⟯) :=
+instance instNontrivial [Nontrivial K] : Nontrivial K⟮X⟯ :=
   ofFractionRing_injective.nontrivial
 
 /-- `K⟮X⟯` is isomorphic to the field of fractions of `K[X]`, as rings.
@@ -268,7 +268,7 @@ variable (K) [CommRing K]
 
 This is an intermediate step on the way to the full instance `RatFunc.instCommRing`.
 -/
-def instCommMonoid : CommMonoid (K⟮X⟯) where
+def instCommMonoid : CommMonoid K⟮X⟯ where
   mul_assoc := by frac_tac
   mul_comm := by frac_tac
   one_mul := by frac_tac
@@ -279,7 +279,7 @@ def instCommMonoid : CommMonoid (K⟮X⟯) where
 
 This is an intermediate step on the way to the full instance `RatFunc.instCommRing`.
 -/
-def instAddCommGroup : AddCommGroup (K⟮X⟯) where
+def instAddCommGroup : AddCommGroup K⟮X⟯ where
   add_assoc := by frac_tac
   add_comm := by frac_tac
   zero_add := by frac_tac
@@ -295,7 +295,7 @@ def instAddCommGroup : AddCommGroup (K⟮X⟯) where
   zsmul_neg' _ := by smul_tac
 
 set_option backward.isDefEq.respectTransparency false in
-instance instCommRing : CommRing (K⟮X⟯) :=
+instance instCommRing : CommRing K⟮X⟯ :=
   { instCommMonoid K, instAddCommGroup K with
     zero_mul := by frac_tac
     mul_zero := by frac_tac
@@ -479,7 +479,7 @@ variable (K)
 
 set_option backward.isDefEq.respectTransparency false in
 @[stacks 09FK]
-instance instField [IsDomain K] : Field (K⟮X⟯) where
+instance instField [IsDomain K] : Field K⟮X⟯ where
   inv_zero := by frac_tac
   div_eq_mul_inv := by frac_tac
   mul_inv_cancel _ := mul_inv_cancel
@@ -498,7 +498,7 @@ section IsDomain
 variable [IsDomain K]
 
 set_option backward.isDefEq.respectTransparency false in
-instance (R : Type*) [CommSemiring R] [Algebra R K[X]] : Algebra R (K⟮X⟯) where
+instance (R : Type*) [CommSemiring R] [Algebra R K[X]] : Algebra R K⟮X⟯ where
   algebraMap :=
   { toFun x := RatFunc.mk (algebraMap _ _ x) 1
     map_add' x y := by simp only [mk_one', map_add, ofFractionRing_add]
@@ -519,7 +519,7 @@ domain to its field of fractions -/
 @[coe]
 def coePolynomial (P : Polynomial K) : K⟮X⟯ := algebraMap _ _ P
 
-instance : Coe (Polynomial K) (K⟮X⟯) := ⟨coePolynomial⟩
+instance : Coe (Polynomial K) K⟮X⟯ := ⟨coePolynomial⟩
 
 theorem mk_one (x : K[X]) : RatFunc.mk x 1 = algebraMap _ _ x :=
   rfl
@@ -547,12 +547,12 @@ theorem mk_eq_div (p q : K[X]) : RatFunc.mk p q = algebraMap _ _ p / algebraMap 
 @[simp]
 theorem div_smul {R} [Monoid R] [DistribMulAction R K[X]] [IsScalarTower R K[X] K[X]] (c : R)
     (p q : K[X]) :
-    algebraMap _ (K⟮X⟯) (c • p) / algebraMap _ _ q =
+    algebraMap _ K⟮X⟯ (c • p) / algebraMap _ _ q =
       c • (algebraMap _ _ p / algebraMap _ _ q) := by
   rw [← mk_eq_div, mk_smul, mk_eq_div]
 
 theorem algebraMap_apply {R : Type*} [CommSemiring R] [Algebra R K[X]] (x : R) :
-    algebraMap R (K⟮X⟯) x = algebraMap _ _ (algebraMap R K[X] x) / algebraMap K[X] _ 1 := by
+    algebraMap R K⟮X⟯ x = algebraMap _ _ (algebraMap R K[X] x) / algebraMap K[X] _ 1 := by
   rw [← mk_eq_div]
   rfl
 
@@ -620,7 +620,7 @@ theorem ofFractionRing_comp_algebraMap :
     ofFractionRing ∘ algebraMap K[X] (FractionRing K[X]) = algebraMap _ _ :=
   funext ofFractionRing_algebraMap
 
-theorem algebraMap_injective : Function.Injective (algebraMap K[X] (K⟮X⟯)) := by
+theorem algebraMap_injective : Function.Injective (algebraMap K[X] K⟮X⟯) := by
   rw [← ofFractionRing_comp_algebraMap]
   exact ofFractionRing_injective.comp (IsFractionRing.injective _ _)
 
@@ -677,7 +677,7 @@ variable (K)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- `K⟮X⟯` is the field of fractions of the polynomials over `K`. -/
-instance : IsFractionRing K[X] (K⟮X⟯) where
+instance : IsFractionRing K[X] K⟮X⟯ where
   map_units y := by
     rw [← ofFractionRing_algebraMap]
     exact (toFractionRingRingEquiv K).symm.toRingHom.isUnit_map (IsLocalization.map_units _ y)
@@ -693,7 +693,7 @@ instance : IsFractionRing K[X] (K⟮X⟯) where
 variable {K}
 
 set_option backward.isDefEq.respectTransparency false in
-theorem algebraMap_ne_zero {x : K[X]} (hx : x ≠ 0) : algebraMap K[X] (K⟮X⟯) x ≠ 0 := by
+theorem algebraMap_ne_zero {x : K[X]} (hx : x ≠ 0) : algebraMap K[X] K⟮X⟯ x ≠ 0 := by
   simpa
 
 @[simp]
@@ -701,13 +701,13 @@ theorem liftOn_div {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀
     (H' : ∀ {p q p' q'} (_hq : q ≠ 0) (_hq' : q' ≠ 0), q' * p = q * p' → f p q = f p' q')
     (H : ∀ {p q p' q'} (_hq : q ∈ K[X]⁰) (_hq' : q' ∈ K[X]⁰), q' * p = q * p' → f p q = f p' q' :=
       fun {_ _ _ _} hq hq' h => H' (nonZeroDivisors.ne_zero hq) (nonZeroDivisors.ne_zero hq') h) :
-    (RatFunc.liftOn (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) f @H = f p q := by
+    (RatFunc.liftOn (algebraMap _ K⟮X⟯ p / algebraMap _ _ q)) f @H = f p q := by
   rw [← mk_eq_div, liftOn_mk _ _ f f0 @H']
 
 @[simp]
 theorem liftOn'_div {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀ p, f p 0 = f 0 1)
     (H) :
-    (RatFunc.liftOn' (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) f @H = f p q := by
+    (RatFunc.liftOn' (algebraMap _ K⟮X⟯ p / algebraMap _ _ q)) f @H = f p q := by
   rw [RatFunc.liftOn', liftOn_div _ _ _ f0]
   apply liftOn_condition_of_liftOn'_condition H
 
@@ -717,16 +717,16 @@ then `P` holds on all elements of `K⟮X⟯`.
 See also `induction_on'`, which is a recursion principle defined in terms of `RatFunc.mk`.
 -/
 protected theorem induction_on {P : K⟮X⟯ → Prop} (x : K⟮X⟯)
-    (f : ∀ (p q : K[X]) (_ : q ≠ 0), P (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) : P x :=
+    (f : ∀ (p q : K[X]) (_ : q ≠ 0), P (algebraMap _ K⟮X⟯ p / algebraMap _ _ q)) : P x :=
   x.induction_on' fun p q hq => by simpa using f p q hq
 
 theorem ofFractionRing_mk' (x : K[X]) (y : K[X]⁰) :
     ofFractionRing (IsLocalization.mk' _ x y) =
-      IsLocalization.mk' (K⟮X⟯) x y := by
+      IsLocalization.mk' K⟮X⟯ x y := by
   rw [IsFractionRing.mk'_eq_div, IsFractionRing.mk'_eq_div, ← mk_eq_div', ← mk_eq_div]
 
 theorem mk_eq_mk' (f : Polynomial K) {g : Polynomial K} (hg : g ≠ 0) :
-    RatFunc.mk f g = IsLocalization.mk' (K⟮X⟯) f
+    RatFunc.mk f g = IsLocalization.mk' K⟮X⟯ f
       ⟨g, mem_nonZeroDivisors_iff_ne_zero.2 hg⟩ := by
   simp only [mk_eq_div, IsFractionRing.mk'_eq_div]
 
@@ -765,12 +765,12 @@ variable (R L : Type*) [CommRing R] [Field L] [IsDomain R] [Algebra R[X] L] [Fai
 /-- `FractionRing.liftAlgebra` specialized to `R⟮X⟯`.
 
 This is a scoped instance because it creates a diamond when `L = R⟮X⟯`. -/
-scoped instance liftAlgebra : Algebra (R⟮X⟯) L :=
+scoped instance liftAlgebra : Algebra R⟮X⟯ L :=
   RingHom.toAlgebra (IsFractionRing.lift (FaithfulSMul.algebraMap_injective R[X] _))
 
 /-- `FractionRing.isScalarTower_liftAlgebra` specialized to `R⟮X⟯`. -/
 instance isScalarTower_liftAlgebra :
-    IsScalarTower R[X] (R⟮X⟯) L :=
+    IsScalarTower R[X] R⟮X⟯ L :=
   IsScalarTower.of_algebraMap_eq fun x =>
     (IsFractionRing.lift_algebraMap (FaithfulSMul.algebraMap_injective R[X] L) x).symm
 
@@ -778,7 +778,7 @@ attribute [local instance] Polynomial.algebra
 
 /-- `FractionRing.instFaithfulSMul` specialized to `R⟮X⟯`. -/
 instance faithfulSMul (K E : Type*) [Field K] [Field E] [Algebra K E]
-    [FaithfulSMul K E] : FaithfulSMul K[X] (E⟮X⟯) :=
+    [FaithfulSMul K E] : FaithfulSMul K[X] E⟮X⟯ :=
   (faithfulSMul_iff_algebraMap_injective ..).mpr <|
     (IsFractionRing.injective E[X] _).comp
       (Polynomial.map_injective _ <| FaithfulSMul.algebraMap_injective K E)
@@ -789,12 +789,12 @@ attribute [local instance] Polynomial.algebra
 
 variable (k K : Type*) [Field k] [Field K] [Algebra k K] [Algebra.IsAlgebraic k K]
 
-theorem rank_ratFunc_ratFunc : Module.rank (k⟮X⟯) (K⟮X⟯) = Module.rank k K := by
-  rw [Algebra.IsAlgebraic.rank_of_isFractionRing k[X] (k⟮X⟯) K[X] (K⟮X⟯),
+theorem rank_ratFunc_ratFunc : Module.rank k⟮X⟯ K⟮X⟯ = Module.rank k K := by
+  rw [Algebra.IsAlgebraic.rank_of_isFractionRing k[X] k⟮X⟯ K[X] K⟮X⟯,
     rank_polynomial_polynomial]
 
-theorem finrank_ratFunc_ratFunc : Module.finrank (k⟮X⟯) (K⟮X⟯) = Module.finrank k K := by
-  by_cases hf : Module.Finite (k⟮X⟯) (K⟮X⟯)
+theorem finrank_ratFunc_ratFunc : Module.finrank k⟮X⟯ K⟮X⟯ = Module.finrank k K := by
+  by_cases hf : Module.Finite k⟮X⟯ K⟮X⟯
   · have hrank := rank_ratFunc_ratFunc k K
     rw [← Module.finrank_eq_rank] at hrank
     exact (Module.finrank_eq_of_rank_eq hrank.symm).symm
@@ -812,20 +812,20 @@ section IsScalarTower
 then so is `A⟮X⟯ / R / R₀`. -/
 instance (R₀ R A : Type*) [CommSemiring R₀] [CommSemiring R] [CommRing A] [IsDomain A]
     [Algebra R₀ A[X]] [SMul R₀ R] [Algebra R A[X]] [IsScalarTower R₀ R A[X]] :
-    IsScalarTower R₀ R (A⟮X⟯) := IsScalarTower.to₁₂₄ _ _ A[X] _
+    IsScalarTower R₀ R A⟮X⟯ := IsScalarTower.to₁₂₄ _ _ A[X] _
 
 /-- Let `K / A⟮X⟯ / A[X] / R` be a tower. If `K / A[X] / R` is a scalar tower
 then so is `K / A⟮X⟯ / R`. -/
 instance (R A K : Type*) [CommRing A] [IsDomain A] [Field K] [Algebra A[X] K]
     [FaithfulSMul A[X] K] [CommSemiring R] [Algebra R A[X]] [SMul R K] [IsScalarTower R A[X] K] :
-    IsScalarTower R (A⟮X⟯) K :=
+    IsScalarTower R A⟮X⟯ K :=
   IsScalarTower.to₁₃₄ _ A[X] _ _
 
 /-- Let `K / k / A⟮X⟯ / A[X]` be a tower. If `K / k / A[X]` is a scalar tower
 then so is `K / k / A⟮X⟯`. -/
 instance (A k K : Type*) [CommRing A] [IsDomain A] [Field k] [Field K] [Algebra A[X] k]
     [Algebra A[X] K] [SMul k K] [FaithfulSMul A[X] k] [FaithfulSMul A[X] K]
-    [IsScalarTower A[X] k K] : IsScalarTower (A⟮X⟯) k K where
+    [IsScalarTower A[X] k K] : IsScalarTower A⟮X⟯ k K where
   smul_assoc a b c := by
     induction a using RatFunc.induction_on with | f p q hq =>
     rw [← smul_right_inj hq]
@@ -976,7 +976,7 @@ theorem denom_one : denom (1 : K⟮X⟯) = 1 := by
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem denom_algebraMap (p : K[X]) : denom (algebraMap _ (K⟮X⟯) p) = 1 := by
+theorem denom_algebraMap (p : K[X]) : denom (algebraMap _ K⟮X⟯ p) = 1 := by
   convert denom_div p one_ne_zero <;> simp
 
 @[simp]
@@ -1156,13 +1156,13 @@ end NumDenom
 
 section Char
 
-instance [Field K] {p : ℕ} [CharP K p] : CharP (K⟮X⟯) p :=
+instance [Field K] {p : ℕ} [CharP K p] : CharP K⟮X⟯ p :=
   charP_of_injective_algebraMap' K p
 
-instance [Field K] {p : ℕ} [ExpChar K p] : ExpChar (K⟮X⟯) p :=
+instance [Field K] {p : ℕ} [ExpChar K p] : ExpChar K⟮X⟯ p :=
   ExpChar.of_injective_algebraMap' K p
 
-instance [Field K] [CharZero K] : CharZero (K⟮X⟯) :=
+instance [Field K] [CharZero K] : CharZero K⟮X⟯ :=
   Algebra.charZero_of_charZero K _
 
 end Char

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -17,13 +17,13 @@ public import Mathlib.RingTheory.Algebraic.Integral
 Working with rational functions as polynomials:
 - `RatFunc.instField` provides a field structure
 You can use `IsFractionRing` API to treat `RatFunc` as the field of fractions of polynomials:
-* `algebraMap K[X] (RatFunc K)` maps polynomials to rational functions
-* `IsFractionRing.algEquiv` maps other fields of fractions of `K[X]` to `RatFunc K`.
+* `algebraMap K[X] (K⟮X⟯)` maps polynomials to rational functions
+* `IsFractionRing.algEquiv` maps other fields of fractions of `K[X]` to `K⟮X⟯`.
 
 In particular:
-* `FractionRing.algEquiv K[X] (RatFunc K)` maps the generic field of
-  fraction construction to `RatFunc K`. Combine this with `AlgEquiv.restrictScalars` to change
-  the `FractionRing K[X] ≃ₐ[K[X]] RatFunc K` to `FractionRing K[X] ≃ₐ[K] RatFunc K`.
+* `FractionRing.algEquiv K[X] (K⟮X⟯)` maps the generic field of
+  fraction construction to `K⟮X⟯`. Combine this with `AlgEquiv.restrictScalars` to change
+  the `FractionRing K[X] ≃ₐ[K[X]] K⟮X⟯` to `FractionRing K[X] ≃ₐ[K] K⟮X⟯`.
 
 Working with rational functions as fractions:
 - `RatFunc.num` and `RatFunc.denom` give the numerator and denominator.
@@ -32,10 +32,10 @@ Working with rational functions as fractions:
 Lifting homomorphisms of polynomials to other types, by mapping and dividing, as long
 as the homomorphism retains the non-zero-divisor property:
   - `RatFunc.liftMonoidWithZeroHom` lifts a `K[X] →*₀ G₀` to
-    a `RatFunc K →*₀ G₀`, where `[CommRing K] [CommGroupWithZero G₀]`
-  - `RatFunc.liftRingHom` lifts a `K[X] →+* L` to a `RatFunc K →+* L`,
+    a `K⟮X⟯ →*₀ G₀`, where `[CommRing K] [CommGroupWithZero G₀]`
+  - `RatFunc.liftRingHom` lifts a `K[X] →+* L` to a `K⟮X⟯ →+* L`,
     where `[CommRing K] [Field L]`
-  - `RatFunc.liftAlgHom` lifts a `K[X] →ₐ[S] L` to a `RatFunc K →ₐ[S] L`,
+  - `RatFunc.liftAlgHom` lifts a `K[X] →ₐ[S] L` to a `K⟮X⟯ →ₐ[S] L`,
     where `[CommRing K] [Field L] [CommSemiring S] [Algebra S K[X]] [Algebra S L]`
 This is satisfied by injective homs.
 
@@ -64,20 +64,20 @@ section Field
 variable [CommRing K]
 
 /-- The zero rational function. -/
-protected irreducible_def zero : RatFunc K :=
+protected irreducible_def zero : K⟮X⟯ :=
   ⟨0⟩
 
-instance : Zero (RatFunc K) :=
+instance : Zero (K⟮X⟯) :=
   ⟨RatFunc.zero⟩
 
-theorem ofFractionRing_zero : (ofFractionRing 0 : RatFunc K) = 0 :=
+theorem ofFractionRing_zero : (ofFractionRing 0 : K⟮X⟯) = 0 :=
   zero_def.symm
 
 /-- Addition of rational functions. -/
-protected irreducible_def add : RatFunc K → RatFunc K → RatFunc K
+protected irreducible_def add : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p + q⟩
 
-instance : Add (RatFunc K) :=
+instance : Add (K⟮X⟯) :=
   ⟨RatFunc.add⟩
 
 theorem ofFractionRing_add (p q : FractionRing K[X]) :
@@ -85,10 +85,10 @@ theorem ofFractionRing_add (p q : FractionRing K[X]) :
   (add_def _ _).symm
 
 /-- Subtraction of rational functions. -/
-protected irreducible_def sub : RatFunc K → RatFunc K → RatFunc K
+protected irreducible_def sub : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p - q⟩
 
-instance : Sub (RatFunc K) :=
+instance : Sub (K⟮X⟯) :=
   ⟨RatFunc.sub⟩
 
 theorem ofFractionRing_sub (p q : FractionRing K[X]) :
@@ -96,10 +96,10 @@ theorem ofFractionRing_sub (p q : FractionRing K[X]) :
   (sub_def _ _).symm
 
 /-- Additive inverse of a rational function. -/
-protected irreducible_def neg : RatFunc K → RatFunc K
+protected irreducible_def neg : K⟮X⟯ → K⟮X⟯
   | ⟨p⟩ => ⟨-p⟩
 
-instance : Neg (RatFunc K) :=
+instance : Neg (K⟮X⟯) :=
   ⟨RatFunc.neg⟩
 
 theorem ofFractionRing_neg (p : FractionRing K[X]) :
@@ -107,20 +107,20 @@ theorem ofFractionRing_neg (p : FractionRing K[X]) :
   (neg_def _).symm
 
 /-- The multiplicative unit of rational functions. -/
-protected irreducible_def one : RatFunc K :=
+protected irreducible_def one : K⟮X⟯ :=
   ⟨1⟩
 
-instance : One (RatFunc K) :=
+instance : One (K⟮X⟯) :=
   ⟨RatFunc.one⟩
 
-theorem ofFractionRing_one : (ofFractionRing 1 : RatFunc K) = 1 :=
+theorem ofFractionRing_one : (ofFractionRing 1 : K⟮X⟯) = 1 :=
   one_def.symm
 
 /-- Multiplication of rational functions. -/
-protected irreducible_def mul : RatFunc K → RatFunc K → RatFunc K
+protected irreducible_def mul : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p * q⟩
 
-instance : Mul (RatFunc K) :=
+instance : Mul (K⟮X⟯) :=
   ⟨RatFunc.mul⟩
 
 theorem ofFractionRing_mul (p q : FractionRing K[X]) :
@@ -132,10 +132,10 @@ section IsDomain
 variable [IsDomain K]
 
 /-- Division of rational functions. -/
-protected irreducible_def div : RatFunc K → RatFunc K → RatFunc K
+protected irreducible_def div : K⟮X⟯ → K⟮X⟯ → K⟮X⟯
   | ⟨p⟩, ⟨q⟩ => ⟨p / q⟩
 
-instance : Div (RatFunc K) :=
+instance : Div (K⟮X⟯) :=
   ⟨RatFunc.div⟩
 
 theorem ofFractionRing_div (p q : FractionRing K[X]) :
@@ -143,10 +143,10 @@ theorem ofFractionRing_div (p q : FractionRing K[X]) :
   (div_def _ _).symm
 
 /-- Multiplicative inverse of a rational function. -/
-protected irreducible_def inv : RatFunc K → RatFunc K
+protected irreducible_def inv : K⟮X⟯ → K⟮X⟯
   | ⟨p⟩ => ⟨p⁻¹⟩
 
-instance : Inv (RatFunc K) :=
+instance : Inv (K⟮X⟯) :=
   ⟨RatFunc.inv⟩
 
 theorem ofFractionRing_inv (p : FractionRing K[X]) :
@@ -154,7 +154,7 @@ theorem ofFractionRing_inv (p : FractionRing K[X]) :
   (inv_def _).symm
 
 -- Auxiliary lemma for the `Field` instance
-theorem mul_inv_cancel : ∀ {p : RatFunc K}, p ≠ 0 → p * p⁻¹ = 1
+theorem mul_inv_cancel : ∀ {p : K⟮X⟯}, p ≠ 0 → p * p⁻¹ = 1
   | ⟨p⟩, h => by
     have : p ≠ 0 := fun hp => h <| by rw [hp, ofFractionRing_zero]
     simpa only [← ofFractionRing_inv, ← ofFractionRing_mul, ← ofFractionRing_one,
@@ -168,22 +168,22 @@ section SMul
 variable {R : Type*}
 
 /-- Scalar multiplication of rational functions. -/
-protected irreducible_def smul [SMul R (FractionRing K[X])] : R → RatFunc K → RatFunc K
+protected irreducible_def smul [SMul R (FractionRing K[X])] : R → K⟮X⟯ → K⟮X⟯
   | r, ⟨p⟩ => ⟨r • p⟩
 
-instance [SMul R (FractionRing K[X])] : SMul R (RatFunc K) :=
+instance [SMul R (FractionRing K[X])] : SMul R (K⟮X⟯) :=
   ⟨RatFunc.smul⟩
 
 theorem ofFractionRing_smul [SMul R (FractionRing K[X])] (c : R) (p : FractionRing K[X]) :
     ofFractionRing (c • p) = c • ofFractionRing p :=
   (smul_def _ _).symm
 
-theorem toFractionRing_smul [SMul R (FractionRing K[X])] (c : R) (p : RatFunc K) :
+theorem toFractionRing_smul [SMul R (FractionRing K[X])] (c : R) (p : K⟮X⟯) :
     toFractionRing (c • p) = c • toFractionRing p := by
   cases p
   rw [← ofFractionRing_smul]
 
-theorem smul_eq_C_smul (x : RatFunc K) (r : K) : r • x = Polynomial.C r • x := by
+theorem smul_eq_C_smul (x : K⟮X⟯) (r : K) : r • x = Polynomial.C r • x := by
   obtain ⟨x⟩ := x
   induction x using Localization.induction_on
   rw [← ofFractionRing_smul, ← ofFractionRing_smul, Localization.smul_mk,
@@ -202,7 +202,7 @@ theorem mk_smul (c : R) (p q : K[X]) : RatFunc.mk (c • p) q = c • RatFunc.mk
   · rw [mk_eq_localization_mk _ hq, mk_eq_localization_mk _ hq, ← Localization.smul_mk, ←
       ofFractionRing_smul]
 
-instance : IsScalarTower R K[X] (RatFunc K) :=
+instance : IsScalarTower R K[X] (K⟮X⟯) :=
   ⟨fun c p q => q.induction_on' fun q r _ => by rw [← mk_smul, smul_assoc, mk_smul, mk_smul]⟩
 
 end IsDomain
@@ -211,21 +211,21 @@ end SMul
 
 variable (K)
 
-instance [Subsingleton K] : Subsingleton (RatFunc K) :=
+instance [Subsingleton K] : Subsingleton (K⟮X⟯) :=
   toFractionRing_injective.subsingleton
 
-instance : Inhabited (RatFunc K) :=
+instance : Inhabited (K⟮X⟯) :=
   ⟨0⟩
 
-instance instNontrivial [Nontrivial K] : Nontrivial (RatFunc K) :=
+instance instNontrivial [Nontrivial K] : Nontrivial (K⟮X⟯) :=
   ofFractionRing_injective.nontrivial
 
-/-- `RatFunc K` is isomorphic to the field of fractions of `K[X]`, as rings.
+/-- `K⟮X⟯` is isomorphic to the field of fractions of `K[X]`, as rings.
 
 This is an auxiliary definition; `simp`-normal form is `IsLocalization.algEquiv`.
 -/
 @[simps apply]
-def toFractionRingRingEquiv : RatFunc K ≃+* FractionRing K[X] where
+def toFractionRingRingEquiv : K⟮X⟯ ≃+* FractionRing K[X] where
   toFun := toFractionRing
   invFun := ofFractionRing
   map_add' := fun ⟨_⟩ ⟨_⟩ => by simp [← ofFractionRing_add]
@@ -235,9 +235,9 @@ end Field
 
 section TacticInterlude
 
-/-- Solve equations for `RatFunc K` by working in `FractionRing K[X]`. -/
+/-- Solve equations for `K⟮X⟯` by working in `FractionRing K[X]`. -/
 macro "frac_tac" : tactic => `(tactic|
-  · repeat (rintro (⟨⟩ : RatFunc _))
+  · repeat (rintro (⟨⟩ : _⟮X⟯))
     try simp only [← ofFractionRing_zero, ← ofFractionRing_add, ← ofFractionRing_sub,
       ← ofFractionRing_neg, ← ofFractionRing_one, ← ofFractionRing_mul, ← ofFractionRing_div,
       ← ofFractionRing_inv,
@@ -245,11 +245,11 @@ macro "frac_tac" : tactic => `(tactic|
       add_comm, add_left_comm, mul_comm, mul_left_comm, sub_eq_add_neg, div_eq_mul_inv,
       add_mul, zero_mul, one_mul, neg_mul, mul_neg, add_neg_cancel])
 
-/-- Solve equations for `RatFunc K` by applying `RatFunc.induction_on`. -/
+/-- Solve equations for `K⟮X⟯` by applying `RatFunc.induction_on`. -/
 macro "smul_tac" : tactic => `(tactic|
     repeat
       (first
-        | rintro (⟨⟩ : RatFunc _)
+        | rintro (⟨⟩ : _⟮X⟯)
         | intro) <;>
     simp_rw [← ofFractionRing_smul] <;>
     simp only [add_comm, mul_comm, zero_smul, succ_nsmul, zsmul_eq_mul, mul_add, mul_one, mul_zero,
@@ -264,22 +264,22 @@ end TacticInterlude
 section CommRing
 
 variable (K) [CommRing K]
-/-- `RatFunc K` is a commutative monoid.
+/-- `K⟮X⟯` is a commutative monoid.
 
 This is an intermediate step on the way to the full instance `RatFunc.instCommRing`.
 -/
-def instCommMonoid : CommMonoid (RatFunc K) where
+def instCommMonoid : CommMonoid (K⟮X⟯) where
   mul_assoc := by frac_tac
   mul_comm := by frac_tac
   one_mul := by frac_tac
   mul_one := by frac_tac
   npow := npowRec
 
-/-- `RatFunc K` is an additive commutative group.
+/-- `K⟮X⟯` is an additive commutative group.
 
 This is an intermediate step on the way to the full instance `RatFunc.instCommRing`.
 -/
-def instAddCommGroup : AddCommGroup (RatFunc K) where
+def instAddCommGroup : AddCommGroup (K⟮X⟯) where
   add_assoc := by frac_tac
   add_comm := by frac_tac
   zero_add := by frac_tac
@@ -295,7 +295,7 @@ def instAddCommGroup : AddCommGroup (RatFunc K) where
   zsmul_neg' _ := by smul_tac
 
 set_option backward.isDefEq.respectTransparency false in
-instance instCommRing : CommRing (RatFunc K) :=
+instance instCommRing : CommRing (K⟮X⟯) :=
   { instCommMonoid K, instAddCommGroup K with
     zero_mul := by frac_tac
     mul_zero := by frac_tac
@@ -315,11 +315,11 @@ variable [FunLike F R[X] S[X]]
 set_option backward.isDefEq.respectTransparency false in
 open scoped Classical in
 /-- Lift a monoid homomorphism that maps polynomials `φ : R[X] →* S[X]`
-to a `RatFunc R →* RatFunc S`,
+to a `R⟮X⟯ →* S⟮X⟯`,
 on the condition that `φ` maps non-zero-divisors to non-zero-divisors,
 by mapping both the numerator and denominator and quotienting them. -/
 def map [MonoidHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S[X]⁰.comap φ) :
-    RatFunc R →* RatFunc S where
+    R⟮X⟯ →* S⟮X⟯ where
   toFun f :=
     RatFunc.liftOn f
       (fun n d => if h : φ d ∈ S[X]⁰ then ofFractionRing (Localization.mk (φ n) ⟨φ d, h⟩) else 0)
@@ -363,11 +363,11 @@ theorem map_injective [MonoidHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Lift a ring homomorphism that maps polynomials `φ : R[X] →+* S[X]`
-to a `RatFunc R →+* RatFunc S`,
+to a `R⟮X⟯ →+* S⟮X⟯`,
 on the condition that `φ` maps non-zero-divisors to non-zero-divisors,
 by mapping both the numerator and denominator and quotienting them. -/
 def mapRingHom [RingHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S[X]⁰.comap φ) :
-    RatFunc R →+* RatFunc S :=
+    R⟮X⟯ →+* S⟮X⟯ :=
   { map φ hφ with
     map_zero' := by
       simp_rw [MonoidHom.toFun_eq_coe, ← ofFractionRing_zero, ← Localization.mk_zero (1 : R[X]⁰),
@@ -384,15 +384,15 @@ def mapRingHom [RingHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S[X]⁰.co
           Submonoid.mk_mul_mk S[X]⁰] }
 
 theorem coe_mapRingHom_eq_coe_map [RingHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S[X]⁰.comap φ) :
-    (mapRingHom φ hφ : RatFunc R → RatFunc S) = map φ hφ :=
+    (mapRingHom φ hφ : R⟮X⟯ → S⟮X⟯) = map φ hφ :=
   rfl
 
 set_option backward.isDefEq.respectTransparency false in
 -- TODO: Generalize to `FunLike` classes,
-/-- Lift a monoid with zero homomorphism `R[X] →*₀ G₀` to a `RatFunc R →*₀ G₀`
+/-- Lift a monoid with zero homomorphism `R[X] →*₀ G₀` to a `R⟮X⟯ →*₀ G₀`
 on the condition that `φ` maps non-zero-divisors to non-zero-divisors,
 by mapping both the numerator and denominator and quotienting them. -/
-def liftMonoidWithZeroHom (φ : R[X] →*₀ G₀) (hφ : R[X]⁰ ≤ G₀⁰.comap φ) : RatFunc R →*₀ G₀ where
+def liftMonoidWithZeroHom (φ : R[X] →*₀ G₀) (hφ : R[X]⁰ ≤ G₀⁰.comap φ) : R⟮X⟯ →*₀ G₀ where
   toFun f :=
     RatFunc.liftOn f (fun p q => φ p / φ q) fun {p q p' q'} hq hq' h => by
       cases subsingleton_or_nontrivial R
@@ -433,9 +433,9 @@ theorem liftMonoidWithZeroHom_injective [Nontrivial R] (φ : R[X] →*₀ G₀) 
   all_goals exact map_ne_zero_of_mem_nonZeroDivisors _ hφ (SetLike.coe_mem _)
 
 set_option backward.isDefEq.respectTransparency false in
-/-- Lift an injective ring homomorphism `R[X] →+* L` to a `RatFunc R →+* L`
+/-- Lift an injective ring homomorphism `R[X] →+* L` to a `R⟮X⟯ →+* L`
 by mapping both the numerator and denominator and quotienting them. -/
-def liftRingHom (φ : R[X] →+* L) (hφ : R[X]⁰ ≤ L⁰.comap φ) : RatFunc R →+* L :=
+def liftRingHom (φ : R[X] →+* L) (hφ : R[X]⁰ ≤ L⁰.comap φ) : R⟮X⟯ →+* L :=
   { liftMonoidWithZeroHom φ.toMonoidWithZeroHom hφ with
     map_add' := fun x y => by
       simp only [ZeroHom.toFun_eq_coe, MonoidWithZeroHom.toZeroHom_coe]
@@ -479,7 +479,7 @@ variable (K)
 
 set_option backward.isDefEq.respectTransparency false in
 @[stacks 09FK]
-instance instField [IsDomain K] : Field (RatFunc K) where
+instance instField [IsDomain K] : Field (K⟮X⟯) where
   inv_zero := by frac_tac
   div_eq_mul_inv := by frac_tac
   mul_inv_cancel _ := mul_inv_cancel
@@ -498,7 +498,7 @@ section IsDomain
 variable [IsDomain K]
 
 set_option backward.isDefEq.respectTransparency false in
-instance (R : Type*) [CommSemiring R] [Algebra R K[X]] : Algebra R (RatFunc K) where
+instance (R : Type*) [CommSemiring R] [Algebra R K[X]] : Algebra R (K⟮X⟯) where
   algebraMap :=
   { toFun x := RatFunc.mk (algebraMap _ _ x) 1
     map_add' x y := by simp only [mk_one', map_add, ofFractionRing_add]
@@ -517,9 +517,9 @@ variable {K}
 /-- The coercion from polynomials to rational functions, implemented as the algebra map from a
 domain to its field of fractions -/
 @[coe]
-def coePolynomial (P : Polynomial K) : RatFunc K := algebraMap _ _ P
+def coePolynomial (P : Polynomial K) : K⟮X⟯ := algebraMap _ _ P
 
-instance : Coe (Polynomial K) (RatFunc K) := ⟨coePolynomial⟩
+instance : Coe (Polynomial K) (K⟮X⟯) := ⟨coePolynomial⟩
 
 theorem mk_one (x : K[X]) : RatFunc.mk x 1 = algebraMap _ _ x :=
   rfl
@@ -530,11 +530,11 @@ theorem ofFractionRing_algebraMap (x : K[X]) :
 
 variable (K) in
 /--
-The equivalence between `RatFunc K` and the field of fractions of `K[X]`
+The equivalence between `K⟮X⟯` and the field of fractions of `K[X]`
 -/
 @[simps! apply]
 def toFractionRingAlgEquiv (R : Type*) [CommSemiring R] [Algebra R K[X]] :
-    RatFunc K ≃ₐ[R] FractionRing K[X] where
+    K⟮X⟯ ≃ₐ[R] FractionRing K[X] where
   __ := RatFunc.toFractionRingRingEquiv K
   commutes' r := by
     change (RatFunc.mk (algebraMap R K[X] r) 1).toFractionRing = _
@@ -547,12 +547,12 @@ theorem mk_eq_div (p q : K[X]) : RatFunc.mk p q = algebraMap _ _ p / algebraMap 
 @[simp]
 theorem div_smul {R} [Monoid R] [DistribMulAction R K[X]] [IsScalarTower R K[X] K[X]] (c : R)
     (p q : K[X]) :
-    algebraMap _ (RatFunc K) (c • p) / algebraMap _ _ q =
+    algebraMap _ (K⟮X⟯) (c • p) / algebraMap _ _ q =
       c • (algebraMap _ _ p / algebraMap _ _ q) := by
   rw [← mk_eq_div, mk_smul, mk_eq_div]
 
 theorem algebraMap_apply {R : Type*} [CommSemiring R] [Algebra R K[X]] (x : R) :
-    algebraMap R (RatFunc K) x = algebraMap _ _ (algebraMap R K[X] x) / algebraMap K[X] _ 1 := by
+    algebraMap R (K⟮X⟯) x = algebraMap _ _ (algebraMap R K[X] x) / algebraMap K[X] _ 1 := by
   rw [← mk_eq_div]
   rfl
 
@@ -573,7 +573,7 @@ theorem map_apply_div {R F : Type*} [CommRing R] [IsDomain R]
     map φ hφ (algebraMap _ _ p / algebraMap _ _ q) =
       algebraMap _ _ (φ p) / algebraMap _ _ (φ q) := by
   rcases eq_or_ne q 0 with (rfl | hq)
-  · have : (0 : RatFunc K) = algebraMap K[X] _ 0 / algebraMap K[X] _ 1 := by simp
+  · have : (0 : K⟮X⟯) = algebraMap K[X] _ 0 / algebraMap K[X] _ 1 := by simp
     rw [map_zero, map_zero, map_zero, div_zero, div_zero, this, map_apply_div_ne_zero, map_one,
       map_one, div_one, map_zero, map_zero]
     exact one_ne_zero
@@ -620,7 +620,7 @@ theorem ofFractionRing_comp_algebraMap :
     ofFractionRing ∘ algebraMap K[X] (FractionRing K[X]) = algebraMap _ _ :=
   funext ofFractionRing_algebraMap
 
-theorem algebraMap_injective : Function.Injective (algebraMap K[X] (RatFunc K)) := by
+theorem algebraMap_injective : Function.Injective (algebraMap K[X] (K⟮X⟯)) := by
   rw [← ofFractionRing_comp_algebraMap]
   exact ofFractionRing_injective.comp (IsFractionRing.injective _ _)
 
@@ -632,22 +632,22 @@ variable {L R S : Type*} [Field L] [CommRing R] [IsDomain R] [CommSemiring S] [A
   [Algebra S L] [Algebra S R[X]] (φ : K[X] →ₐ[S] L) (hφ : K[X]⁰ ≤ L⁰.comap φ)
 
 /-- Lift an algebra homomorphism that maps polynomials `φ : K[X] →ₐ[S] R[X]`
-to a `RatFunc K →ₐ[S] RatFunc R`,
+to a `K⟮X⟯ →ₐ[S] R⟮X⟯`,
 on the condition that `φ` maps non-zero-divisors to non-zero-divisors,
 by mapping both the numerator and denominator and quotienting them. -/
-def mapAlgHom (φ : K[X] →ₐ[S] R[X]) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) : RatFunc K →ₐ[S] RatFunc R :=
+def mapAlgHom (φ : K[X] →ₐ[S] R[X]) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) : K⟮X⟯ →ₐ[S] R⟮X⟯ :=
   { mapRingHom φ hφ with
     commutes' := fun r => by
       simp_rw [RingHom.toFun_eq_coe, coe_mapRingHom_eq_coe_map, algebraMap_apply r, map_apply_div,
         map_one, AlgHom.commutes] }
 
 theorem coe_mapAlgHom_eq_coe_map (φ : K[X] →ₐ[S] R[X]) (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) :
-    (mapAlgHom φ hφ : RatFunc K → RatFunc R) = map φ hφ :=
+    (mapAlgHom φ hφ : K⟮X⟯ → R⟮X⟯) = map φ hφ :=
   rfl
 
-/-- Lift an injective algebra homomorphism `K[X] →ₐ[S] L` to a `RatFunc K →ₐ[S] L`
+/-- Lift an injective algebra homomorphism `K[X] →ₐ[S] L` to a `K⟮X⟯ →ₐ[S] L`
 by mapping both the numerator and denominator and quotienting them. -/
-def liftAlgHom : RatFunc K →ₐ[S] L :=
+def liftAlgHom : K⟮X⟯ →ₐ[S] L :=
   { liftRingHom φ.toRingHom hφ with
     commutes' := fun r => by
       simp_rw [RingHom.toFun_eq_coe, AlgHom.toRingHom_eq_coe, algebraMap_apply r,
@@ -676,8 +676,8 @@ end LiftAlgHom
 variable (K)
 
 set_option backward.isDefEq.respectTransparency false in
-/-- `RatFunc K` is the field of fractions of the polynomials over `K`. -/
-instance : IsFractionRing K[X] (RatFunc K) where
+/-- `K⟮X⟯` is the field of fractions of the polynomials over `K`. -/
+instance : IsFractionRing K[X] (K⟮X⟯) where
   map_units y := by
     rw [← ofFractionRing_algebraMap]
     exact (toFractionRingRingEquiv K).symm.toRingHom.isUnit_map (IsLocalization.map_units _ y)
@@ -693,7 +693,7 @@ instance : IsFractionRing K[X] (RatFunc K) where
 variable {K}
 
 set_option backward.isDefEq.respectTransparency false in
-theorem algebraMap_ne_zero {x : K[X]} (hx : x ≠ 0) : algebraMap K[X] (RatFunc K) x ≠ 0 := by
+theorem algebraMap_ne_zero {x : K[X]} (hx : x ≠ 0) : algebraMap K[X] (K⟮X⟯) x ≠ 0 := by
   simpa
 
 @[simp]
@@ -701,38 +701,38 @@ theorem liftOn_div {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀
     (H' : ∀ {p q p' q'} (_hq : q ≠ 0) (_hq' : q' ≠ 0), q' * p = q * p' → f p q = f p' q')
     (H : ∀ {p q p' q'} (_hq : q ∈ K[X]⁰) (_hq' : q' ∈ K[X]⁰), q' * p = q * p' → f p q = f p' q' :=
       fun {_ _ _ _} hq hq' h => H' (nonZeroDivisors.ne_zero hq) (nonZeroDivisors.ne_zero hq') h) :
-    (RatFunc.liftOn (algebraMap _ (RatFunc K) p / algebraMap _ _ q)) f @H = f p q := by
+    (RatFunc.liftOn (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) f @H = f p q := by
   rw [← mk_eq_div, liftOn_mk _ _ f f0 @H']
 
 @[simp]
 theorem liftOn'_div {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀ p, f p 0 = f 0 1)
     (H) :
-    (RatFunc.liftOn' (algebraMap _ (RatFunc K) p / algebraMap _ _ q)) f @H = f p q := by
+    (RatFunc.liftOn' (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) f @H = f p q := by
   rw [RatFunc.liftOn', liftOn_div _ _ _ f0]
   apply liftOn_condition_of_liftOn'_condition H
 
-/-- Induction principle for `RatFunc K`: if `f p q : P (p / q)` for all `p q : K[X]`,
-then `P` holds on all elements of `RatFunc K`.
+/-- Induction principle for `K⟮X⟯`: if `f p q : P (p / q)` for all `p q : K[X]`,
+then `P` holds on all elements of `K⟮X⟯`.
 
 See also `induction_on'`, which is a recursion principle defined in terms of `RatFunc.mk`.
 -/
-protected theorem induction_on {P : RatFunc K → Prop} (x : RatFunc K)
-    (f : ∀ (p q : K[X]) (_ : q ≠ 0), P (algebraMap _ (RatFunc K) p / algebraMap _ _ q)) : P x :=
+protected theorem induction_on {P : K⟮X⟯ → Prop} (x : K⟮X⟯)
+    (f : ∀ (p q : K[X]) (_ : q ≠ 0), P (algebraMap _ (K⟮X⟯) p / algebraMap _ _ q)) : P x :=
   x.induction_on' fun p q hq => by simpa using f p q hq
 
 theorem ofFractionRing_mk' (x : K[X]) (y : K[X]⁰) :
     ofFractionRing (IsLocalization.mk' _ x y) =
-      IsLocalization.mk' (RatFunc K) x y := by
+      IsLocalization.mk' (K⟮X⟯) x y := by
   rw [IsFractionRing.mk'_eq_div, IsFractionRing.mk'_eq_div, ← mk_eq_div', ← mk_eq_div]
 
 theorem mk_eq_mk' (f : Polynomial K) {g : Polynomial K} (hg : g ≠ 0) :
-    RatFunc.mk f g = IsLocalization.mk' (RatFunc K) f
+    RatFunc.mk f g = IsLocalization.mk' (K⟮X⟯) f
       ⟨g, mem_nonZeroDivisors_iff_ne_zero.2 hg⟩ := by
   simp only [mk_eq_div, IsFractionRing.mk'_eq_div]
 
 @[simp]
 theorem ofFractionRing_eq :
-    (ofFractionRing : FractionRing K[X] → RatFunc K) = IsLocalization.algEquiv K[X]⁰ _ _ :=
+    (ofFractionRing : FractionRing K[X] → K⟮X⟯) = IsLocalization.algEquiv K[X]⁰ _ _ :=
   funext fun x =>
     Localization.induction_on x fun x => by
       simp only [Localization.mk_eq_mk'_apply, ofFractionRing_mk', IsLocalization.algEquiv_apply,
@@ -740,7 +740,7 @@ theorem ofFractionRing_eq :
 
 @[simp]
 theorem toFractionRing_eq :
-    (toFractionRing : RatFunc K → FractionRing K[X]) = IsLocalization.algEquiv K[X]⁰ _ _ :=
+    (toFractionRing : K⟮X⟯ → FractionRing K[X]) = IsLocalization.algEquiv K[X]⁰ _ _ :=
   funext fun ⟨x⟩ =>
     Localization.induction_on x fun x => by
       simp only [Localization.mk_eq_mk'_apply, ofFractionRing_mk', IsLocalization.algEquiv_apply,
@@ -756,29 +756,29 @@ theorem toFractionRingRingEquiv_symm_eq :
 section lift
 
 /-
-As `RatFunc R` is a one-field-struct, we need to specialize the following instances of
+As `R⟮X⟯` is a one-field-struct, we need to specialize the following instances of
 `FractionRing`.
 -/
 
 variable (R L : Type*) [CommRing R] [Field L] [IsDomain R] [Algebra R[X] L] [FaithfulSMul R[X] L]
 
-/-- `FractionRing.liftAlgebra` specialized to `RatFunc R`.
+/-- `FractionRing.liftAlgebra` specialized to `R⟮X⟯`.
 
-This is a scoped instance because it creates a diamond when `L = RatFunc R`. -/
-scoped instance liftAlgebra : Algebra (RatFunc R) L :=
+This is a scoped instance because it creates a diamond when `L = R⟮X⟯`. -/
+scoped instance liftAlgebra : Algebra (R⟮X⟯) L :=
   RingHom.toAlgebra (IsFractionRing.lift (FaithfulSMul.algebraMap_injective R[X] _))
 
-/-- `FractionRing.isScalarTower_liftAlgebra` specialized to `RatFunc R`. -/
+/-- `FractionRing.isScalarTower_liftAlgebra` specialized to `R⟮X⟯`. -/
 instance isScalarTower_liftAlgebra :
-    IsScalarTower R[X] (RatFunc R) L :=
+    IsScalarTower R[X] (R⟮X⟯) L :=
   IsScalarTower.of_algebraMap_eq fun x =>
     (IsFractionRing.lift_algebraMap (FaithfulSMul.algebraMap_injective R[X] L) x).symm
 
 attribute [local instance] Polynomial.algebra
 
-/-- `FractionRing.instFaithfulSMul` specialized to `RatFunc R`. -/
+/-- `FractionRing.instFaithfulSMul` specialized to `R⟮X⟯`. -/
 instance faithfulSMul (K E : Type*) [Field K] [Field E] [Algebra K E]
-    [FaithfulSMul K E] : FaithfulSMul K[X] (RatFunc E) :=
+    [FaithfulSMul K E] : FaithfulSMul K[X] (E⟮X⟯) :=
   (faithfulSMul_iff_algebraMap_injective ..).mpr <|
     (IsFractionRing.injective E[X] _).comp
       (Polynomial.map_injective _ <| FaithfulSMul.algebraMap_injective K E)
@@ -789,13 +789,13 @@ attribute [local instance] Polynomial.algebra
 
 variable (k K : Type*) [Field k] [Field K] [Algebra k K] [Algebra.IsAlgebraic k K]
 
-theorem rank_ratFunc_ratFunc : Module.rank (RatFunc k) (RatFunc K) = Module.rank k K := by
-  rw [Algebra.IsAlgebraic.rank_of_isFractionRing k[X] (RatFunc k) K[X] (RatFunc K),
+theorem rank_ratFunc_ratFunc : Module.rank (k⟮X⟯) (K⟮X⟯) = Module.rank k K := by
+  rw [Algebra.IsAlgebraic.rank_of_isFractionRing k[X] (k⟮X⟯) K[X] (K⟮X⟯),
     rank_polynomial_polynomial]
 
-theorem finrank_ratFunc_ratFunc : Module.finrank (RatFunc k) (RatFunc K) = Module.finrank k K := by
-  by_cases hf : Module.Finite (RatFunc k) (RatFunc K)
-  · have hrank := rank_ratFunc_ratFunc k K
+theorem finrank_ratFunc_ratFunc : Module.finrank (k⟮X⟯) (K⟮X⟯) = Module.finrank k K := by
+  by_cases hf : Module.Finite (k⟮X⟯) (K⟮X⟯)
+  · have hrank := rank_ratFunc_k⟮X⟯ K
     rw [← Module.finrank_eq_rank] at hrank
     exact (Module.finrank_eq_of_rank_eq hrank.symm).symm
   · have hf' : ¬ Module.Finite k K := by
@@ -808,24 +808,24 @@ end lift
 
 section IsScalarTower
 
-/-- Let `RatFunc A / A[X] / R / R₀` be a tower. If `A[X] / R / R₀` is a scalar tower
-then so is `RatFunc A / R / R₀`. -/
+/-- Let `A⟮X⟯ / A[X] / R / R₀` be a tower. If `A[X] / R / R₀` is a scalar tower
+then so is `A⟮X⟯ / R / R₀`. -/
 instance (R₀ R A : Type*) [CommSemiring R₀] [CommSemiring R] [CommRing A] [IsDomain A]
     [Algebra R₀ A[X]] [SMul R₀ R] [Algebra R A[X]] [IsScalarTower R₀ R A[X]] :
-    IsScalarTower R₀ R (RatFunc A) := IsScalarTower.to₁₂₄ _ _ A[X] _
+    IsScalarTower R₀ R (A⟮X⟯) := IsScalarTower.to₁₂₄ _ _ A[X] _
 
-/-- Let `K / RatFunc A / A[X] / R` be a tower. If `K / A[X] / R` is a scalar tower
-then so is `K / RatFunc A / R`. -/
+/-- Let `K / A⟮X⟯ / A[X] / R` be a tower. If `K / A[X] / R` is a scalar tower
+then so is `K / A⟮X⟯ / R`. -/
 instance (R A K : Type*) [CommRing A] [IsDomain A] [Field K] [Algebra A[X] K]
     [FaithfulSMul A[X] K] [CommSemiring R] [Algebra R A[X]] [SMul R K] [IsScalarTower R A[X] K] :
-    IsScalarTower R (RatFunc A) K :=
+    IsScalarTower R (A⟮X⟯) K :=
   IsScalarTower.to₁₃₄ _ A[X] _ _
 
-/-- Let `K / k / RatFunc A / A[X]` be a tower. If `K / k / A[X]` is a scalar tower
-then so is `K / k / RatFunc A`. -/
+/-- Let `K / k / A⟮X⟯ / A[X]` be a tower. If `K / k / A[X]` is a scalar tower
+then so is `K / k / A⟮X⟯`. -/
 instance (A k K : Type*) [CommRing A] [IsDomain A] [Field k] [Field K] [Algebra A[X] k]
     [Algebra A[X] K] [SMul k K] [FaithfulSMul A[X] k] [FaithfulSMul A[X] K]
-    [IsScalarTower A[X] k K] : IsScalarTower (RatFunc A) k K where
+    [IsScalarTower A[X] k K] : IsScalarTower (A⟮X⟯) k K where
   smul_assoc a b c := by
     induction a using RatFunc.induction_on with | f p q hq =>
     rw [← smul_right_inj hq]
@@ -853,7 +853,7 @@ set_option backward.isDefEq.respectTransparency false in
 open scoped Classical in
 /-- `RatFunc.numDenom` are numerator and denominator of a rational function over a field,
 normalized such that the denominator is monic. -/
-def numDenom (x : RatFunc K) : K[X] × K[X] :=
+def numDenom (x : K⟮X⟯) : K[X] × K[X] :=
   x.liftOn'
     (fun p q =>
       if q = 0 then ⟨0, 1⟩
@@ -898,7 +898,7 @@ theorem numDenom_div (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
 
 /-- `RatFunc.num` is the numerator of a rational function,
 normalized such that the denominator is monic. -/
-def num (x : RatFunc K) : K[X] :=
+def num (x : K⟮X⟯) : K[X] :=
   x.numDenom.1
 
 open scoped Classical in
@@ -909,7 +909,7 @@ private theorem num_div' (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem num_zero : num (0 : RatFunc K) = 0 := by convert num_div' (0 : K[X]) one_ne_zero <;> simp
+theorem num_zero : num (0 : K⟮X⟯) = 0 := by convert num_div' (0 : K[X]) one_ne_zero <;> simp
 
 set_option backward.isDefEq.respectTransparency false in
 open scoped Classical in
@@ -923,7 +923,7 @@ theorem num_div (p q : K[X]) :
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem num_one : num (1 : RatFunc K) = 1 := by convert num_div (1 : K[X]) 1 <;> simp
+theorem num_one : num (1 : K⟮X⟯) = 1 := by convert num_div (1 : K[X]) 1 <;> simp
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
@@ -944,7 +944,7 @@ theorem num_div_dvd' (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
 
 /-- `RatFunc.denom` is the denominator of a rational function,
 normalized such that it is monic. -/
-def denom (x : RatFunc K) : K[X] :=
+def denom (x : K⟮X⟯) : K[X] :=
   x.numDenom.2
 
 open scoped Classical in
@@ -954,29 +954,29 @@ theorem denom_div (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
       Polynomial.C (q / gcd p q).leadingCoeff⁻¹ * (q / gcd p q) := by
   rw [denom, numDenom_div _ hq]
 
-theorem monic_denom (x : RatFunc K) : (denom x).Monic := by
+theorem monic_denom (x : K⟮X⟯) : (denom x).Monic := by
   classical
   induction x using RatFunc.induction_on with
   | f p q hq =>
     rw [denom_div p hq, mul_comm]
     exact Polynomial.monic_mul_leadingCoeff_inv (right_div_gcd_ne_zero hq)
 
-theorem denom_ne_zero (x : RatFunc K) : denom x ≠ 0 :=
+theorem denom_ne_zero (x : K⟮X⟯) : denom x ≠ 0 :=
   (monic_denom x).ne_zero
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem denom_zero : denom (0 : RatFunc K) = 1 := by
+theorem denom_zero : denom (0 : K⟮X⟯) = 1 := by
   convert denom_div (0 : K[X]) one_ne_zero <;> simp
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem denom_one : denom (1 : RatFunc K) = 1 := by
+theorem denom_one : denom (1 : K⟮X⟯) = 1 := by
   convert denom_div (1 : K[X]) one_ne_zero <;> simp
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem denom_algebraMap (p : K[X]) : denom (algebraMap _ (RatFunc K) p) = 1 := by
+theorem denom_algebraMap (p : K[X]) : denom (algebraMap _ (K⟮X⟯) p) = 1 := by
   convert denom_div p one_ne_zero <;> simp
 
 @[simp]
@@ -990,7 +990,7 @@ theorem denom_div_dvd (p q : K[X]) : denom (algebraMap _ _ p / algebraMap _ _ q)
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem num_div_denom (x : RatFunc K) : algebraMap _ _ (num x) / algebraMap _ _ (denom x) = x := by
+theorem num_div_denom (x : K⟮X⟯) : algebraMap _ _ (num x) / algebraMap _ _ (denom x) = x := by
   classical
   induction x using RatFunc.induction_on with | _ p q hq
   have q_div_ne_zero : q / gcd p q ≠ 0 := right_div_gcd_ne_zero hq
@@ -1004,7 +1004,7 @@ theorem num_div_denom (x : RatFunc K) : algebraMap _ _ (num x) / algebraMap _ _ 
   · refine algebraMap_ne_zero (mt Polynomial.C_eq_zero.mp ?_)
     exact inv_ne_zero (Polynomial.leadingCoeff_ne_zero.mpr q_div_ne_zero)
 
-theorem isCoprime_num_denom (x : RatFunc K) : IsCoprime x.num x.denom := by
+theorem isCoprime_num_denom (x : K⟮X⟯) : IsCoprime x.num x.denom := by
   classical
   induction x using RatFunc.induction_on with | _ p q hq
   rw [num_div, denom_div _ hq]
@@ -1014,14 +1014,14 @@ theorem isCoprime_num_denom (x : RatFunc K) : IsCoprime x.num x.denom := by
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem num_eq_zero_iff {x : RatFunc K} : num x = 0 ↔ x = 0 :=
+theorem num_eq_zero_iff {x : K⟮X⟯} : num x = 0 ↔ x = 0 :=
   ⟨fun h => by rw [← num_div_denom x, h, map_zero, zero_div], fun h => h.symm ▸ num_zero⟩
 
-theorem num_ne_zero {x : RatFunc K} (hx : x ≠ 0) : num x ≠ 0 :=
+theorem num_ne_zero {x : K⟮X⟯} (hx : x ≠ 0) : num x ≠ 0 :=
   mt num_eq_zero_iff.mp hx
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_mul_eq_mul_denom_iff {x : RatFunc K} {p q : K[X]} (hq : q ≠ 0) :
+theorem num_mul_eq_mul_denom_iff {x : K⟮X⟯} {p q : K[X]} (hq : q ≠ 0) :
     x.num * q = p * x.denom ↔ x = algebraMap _ _ p / algebraMap _ _ q := by
   rw [← (algebraMap_injective K).eq_iff, eq_div_iff (algebraMap_ne_zero hq)]
   conv_rhs => rw [← num_div_denom x]
@@ -1030,7 +1030,7 @@ theorem num_mul_eq_mul_denom_iff {x : RatFunc K} {p q : K[X]} (hq : q ≠ 0) :
   exact algebraMap_ne_zero (denom_ne_zero x)
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_denom_add (x y : RatFunc K) :
+theorem num_denom_add (x y : K⟮X⟯) :
     (x + y).num * (x.denom * y.denom) = (x.num * y.denom + x.denom * y.num) * (x + y).denom :=
   (num_mul_eq_mul_denom_iff (mul_ne_zero (denom_ne_zero x) (denom_ne_zero y))).mpr <| by
     conv_lhs => rw [← num_div_denom x, ← num_div_denom y]
@@ -1039,18 +1039,18 @@ theorem num_denom_add (x y : RatFunc K) :
     · exact algebraMap_ne_zero (denom_ne_zero y)
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_denom_neg (x : RatFunc K) : (-x).num * x.denom = -x.num * (-x).denom := by
+theorem num_denom_neg (x : K⟮X⟯) : (-x).num * x.denom = -x.num * (-x).denom := by
   rw [num_mul_eq_mul_denom_iff (denom_ne_zero x), map_neg, neg_div, num_div_denom]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_denom_mul (x y : RatFunc K) :
+theorem num_denom_mul (x y : K⟮X⟯) :
     (x * y).num * (x.denom * y.denom) = x.num * y.num * (x * y).denom :=
   (num_mul_eq_mul_denom_iff (mul_ne_zero (denom_ne_zero x) (denom_ne_zero y))).mpr <| by
     conv_lhs =>
       rw [← num_div_denom x, ← num_div_denom y, div_mul_div_comm, ← map_mul, ← map_mul]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_dvd {x : RatFunc K} {p : K[X]} (hp : p ≠ 0) :
+theorem num_dvd {x : K⟮X⟯} {p : K[X]} (hp : p ≠ 0) :
     num x ∣ p ↔ ∃ q : K[X], q ≠ 0 ∧ x = algebraMap _ _ p / algebraMap _ _ q := by
   constructor
   · rintro ⟨q, rfl⟩
@@ -1063,7 +1063,7 @@ theorem num_dvd {x : RatFunc K} {p : K[X]} (hp : p ≠ 0) :
     exact num_div_dvd p hq
 
 set_option backward.isDefEq.respectTransparency false in
-theorem denom_dvd {x : RatFunc K} {q : K[X]} (hq : q ≠ 0) :
+theorem denom_dvd {x : K⟮X⟯} {q : K[X]} (hq : q ≠ 0) :
     denom x ∣ q ↔ ∃ p : K[X], x = algebraMap _ _ p / algebraMap _ _ q := by
   constructor
   · rintro ⟨p, rfl⟩
@@ -1075,7 +1075,7 @@ theorem denom_dvd {x : RatFunc K} {q : K[X]} (hq : q ≠ 0) :
     exact denom_div_dvd p q
 
 set_option backward.isDefEq.respectTransparency false in
-theorem num_mul_dvd (x y : RatFunc K) : num (x * y) ∣ num x * num y := by
+theorem num_mul_dvd (x y : K⟮X⟯) : num (x * y) ∣ num x * num y := by
   by_cases hx : x = 0
   · simp [hx]
   by_cases hy : y = 0
@@ -1085,67 +1085,67 @@ theorem num_mul_dvd (x y : RatFunc K) : num (x * y) ∣ num x * num y := by
   rw [map_mul, map_mul, ← div_mul_div_comm, num_div_denom, num_div_denom]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem denom_mul_dvd (x y : RatFunc K) : denom (x * y) ∣ denom x * denom y := by
+theorem denom_mul_dvd (x y : K⟮X⟯) : denom (x * y) ∣ denom x * denom y := by
   rw [denom_dvd (mul_ne_zero (denom_ne_zero x) (denom_ne_zero y))]
   refine ⟨x.num * y.num, ?_⟩
   rw [map_mul, map_mul, ← div_mul_div_comm, num_div_denom, num_div_denom]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem denom_add_dvd (x y : RatFunc K) : denom (x + y) ∣ denom x * denom y := by
+theorem denom_add_dvd (x y : K⟮X⟯) : denom (x + y) ∣ denom x * denom y := by
   rw [denom_dvd (mul_ne_zero (denom_ne_zero x) (denom_ne_zero y))]
   refine ⟨x.num * y.denom + x.denom * y.num, ?_⟩
   rw [map_mul, map_add, map_mul, map_mul, ← div_add_div, num_div_denom, num_div_denom]
   · exact algebraMap_ne_zero (denom_ne_zero x)
   · exact algebraMap_ne_zero (denom_ne_zero y)
 
-theorem num_inv_dvd {x : RatFunc K} (hx : x ≠ 0) : num x⁻¹ ∣ denom x := by
+theorem num_inv_dvd {x : K⟮X⟯} (hx : x ≠ 0) : num x⁻¹ ∣ denom x := by
   rw [num_dvd x.denom_ne_zero]
   refine ⟨x.num, num_ne_zero hx, ?_⟩
   nth_rw 1 [← x.num_div_denom]
   rw [inv_div]
 
-theorem denom_inv_dvd {x : RatFunc K} (hx : x ≠ 0) : denom x⁻¹ ∣ num x := by
+theorem denom_inv_dvd {x : K⟮X⟯} (hx : x ≠ 0) : denom x⁻¹ ∣ num x := by
   rw [denom_dvd (num_ne_zero hx)]
   refine ⟨x.denom, ?_⟩
   nth_rw 1 [← x.num_div_denom]
   rw [inv_div]
 
-theorem associated_num_inv {x : RatFunc K} (hx : x ≠ 0) : Associated (num x⁻¹) (denom x) := by
+theorem associated_num_inv {x : K⟮X⟯} (hx : x ≠ 0) : Associated (num x⁻¹) (denom x) := by
   apply associated_of_dvd_dvd (num_inv_dvd hx)
   convert denom_inv_dvd (inv_ne_zero hx)
   rw [inv_inv]
 
-theorem associated_denom_inv {x : RatFunc K} (hx : x ≠ 0) : Associated (denom x⁻¹) (num x) := by
+theorem associated_denom_inv {x : K⟮X⟯} (hx : x ≠ 0) : Associated (denom x⁻¹) (num x) := by
   apply Associated.symm
   convert associated_num_inv (inv_ne_zero hx)
   rw [inv_inv]
 
 theorem map_denom_ne_zero {L F : Type*} [Zero L] [FunLike F K[X] L] [ZeroHomClass F K[X] L]
-    (φ : F) (hφ : Function.Injective φ) (f : RatFunc K) : φ f.denom ≠ 0 := fun H =>
+    (φ : F) (hφ : Function.Injective φ) (f : K⟮X⟯) : φ f.denom ≠ 0 := fun H =>
   (denom_ne_zero f) ((map_eq_zero_iff φ hφ).mp H)
 
 theorem map_apply {R F : Type*} [CommRing R] [IsDomain R]
     [FunLike F K[X] R[X]] [MonoidHomClass F K[X] R[X]] (φ : F)
-    (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) (f : RatFunc K) :
+    (hφ : K[X]⁰ ≤ R[X]⁰.comap φ) (f : K⟮X⟯) :
     map φ hφ f = algebraMap _ _ (φ f.num) / algebraMap _ _ (φ f.denom) := by
   rw [← num_div_denom f, map_apply_div_ne_zero, num_div_denom f]
   exact denom_ne_zero _
 
 theorem liftMonoidWithZeroHom_apply {L : Type*} [CommGroupWithZero L] (φ : K[X] →*₀ L)
-    (hφ : K[X]⁰ ≤ L⁰.comap φ) (f : RatFunc K) :
+    (hφ : K[X]⁰ ≤ L⁰.comap φ) (f : K⟮X⟯) :
     liftMonoidWithZeroHom φ hφ f = φ f.num / φ f.denom := by
   rw [← num_div_denom f, liftMonoidWithZeroHom_apply_div, num_div_denom]
 
 theorem liftRingHom_apply {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ)
-    (f : RatFunc K) : liftRingHom φ hφ f = φ f.num / φ f.denom :=
+    (f : K⟮X⟯) : liftRingHom φ hφ f = φ f.num / φ f.denom :=
   liftMonoidWithZeroHom_apply _ hφ _
 
 theorem liftAlgHom_apply {L S : Type*} [Field L] [CommSemiring S] [Algebra S K[X]] [Algebra S L]
-    (φ : K[X] →ₐ[S] L) (hφ : K[X]⁰ ≤ L⁰.comap φ) (f : RatFunc K) :
+    (φ : K[X] →ₐ[S] L) (hφ : K[X]⁰ ≤ L⁰.comap φ) (f : K⟮X⟯) :
     liftAlgHom φ hφ f = φ f.num / φ f.denom :=
   liftMonoidWithZeroHom_apply _ hφ _
 
-theorem num_mul_denom_add_denom_mul_num_ne_zero {x y : RatFunc K} (hxy : x + y ≠ 0) :
+theorem num_mul_denom_add_denom_mul_num_ne_zero {x y : K⟮X⟯} (hxy : x + y ≠ 0) :
     x.num * y.denom + x.denom * y.num ≠ 0 := by
   intro h_zero
   have h := num_denom_add x y
@@ -1156,13 +1156,13 @@ end NumDenom
 
 section Char
 
-instance [Field K] {p : ℕ} [CharP K p] : CharP (RatFunc K) p :=
+instance [Field K] {p : ℕ} [CharP K p] : CharP (K⟮X⟯) p :=
   charP_of_injective_algebraMap' K p
 
-instance [Field K] {p : ℕ} [ExpChar K p] : ExpChar (RatFunc K) p :=
+instance [Field K] {p : ℕ} [ExpChar K p] : ExpChar (K⟮X⟯) p :=
   ExpChar.of_injective_algebraMap' K p
 
-instance [Field K] [CharZero K] : CharZero (RatFunc K) :=
+instance [Field K] [CharZero K] : CharZero (K⟮X⟯) :=
   Algebra.charZero_of_charZero K _
 
 end Char

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -795,7 +795,7 @@ theorem rank_ratFunc_ratFunc : Module.rank (k⟮X⟯) (K⟮X⟯) = Module.rank k
 
 theorem finrank_ratFunc_ratFunc : Module.finrank (k⟮X⟯) (K⟮X⟯) = Module.finrank k K := by
   by_cases hf : Module.Finite (k⟮X⟯) (K⟮X⟯)
-  · have hrank := rank_ratFunc_k⟮X⟯ K
+  · have hrank := rank_ratFunc_ratFunc k K
     rw [← Module.finrank_eq_rank] at hrank
     exact (Module.finrank_eq_of_rank_eq hrank.symm).symm
   · have hf' : ¬ Module.Finite k K := by

--- a/Mathlib/FieldTheory/RatFunc/Defs.lean
+++ b/Mathlib/FieldTheory/RatFunc/Defs.lean
@@ -35,7 +35,7 @@ To provide good API encapsulation and speed up unification problems,
 We need a couple of maps to set up the `Field` and `IsFractionRing` structure,
 namely `RatFunc.ofFractionRing`, `RatFunc.toFractionRing`, `RatFunc.mk` and
 `RatFunc.toFractionRingRingEquiv`.
-All these maps get `simp`ed to bundled morphisms like `algebraMap K[X] (K⟮X⟯)`
+All these maps get `simp`ed to bundled morphisms like `algebraMap K[X] K⟮X⟯`
 and `IsLocalization.algEquiv`.
 
 There are separate lifts and maps of homomorphisms, to provide routes of lifting even when
@@ -61,7 +61,7 @@ variable (K : Type u)
 
 /-- `RatFunc K` is `K(X)`, the field of rational functions over `K`.
 
-The inclusion of polynomials into `RatFunc` is `algebraMap K[X] (K⟮X⟯)`,
+The inclusion of polynomials into `RatFunc` is `algebraMap K[X] K⟮X⟯`,
 the maps between `K⟮X⟯` and another field of fractions of `K[X]`,
 especially `FractionRing K[X]`, are given by `IsLocalization.algEquiv`.
 -/

--- a/Mathlib/FieldTheory/RatFunc/Defs.lean
+++ b/Mathlib/FieldTheory/RatFunc/Defs.lean
@@ -69,6 +69,8 @@ structure RatFunc [CommRing K] : Type u where ofFractionRing ::
 /-- the coercion to the fraction ring of the polynomial ring -/
   toFractionRing : FractionRing K[X]
 
+@[inherit_doc] scoped[RatFunc] notation:9000 R "⟮X⟯" => RatFunc R
+
 namespace RatFunc
 
 section CommRing

--- a/Mathlib/FieldTheory/RatFunc/Defs.lean
+++ b/Mathlib/FieldTheory/RatFunc/Defs.lean
@@ -12,7 +12,7 @@ public import Mathlib.RingTheory.Localization.FractionRing
 /-!
 # The field of rational functions
 
-Files in this folder define the field `RatFunc K` of rational functions over a field `K`, show it
+Files in this folder define the field `K⟮X⟯` of rational functions over a field `K`, show it
 is the field of fractions of `K[X]` and provide the main results concerning it. This file contains
 the basic definition.
 
@@ -35,7 +35,7 @@ To provide good API encapsulation and speed up unification problems,
 We need a couple of maps to set up the `Field` and `IsFractionRing` structure,
 namely `RatFunc.ofFractionRing`, `RatFunc.toFractionRing`, `RatFunc.mk` and
 `RatFunc.toFractionRingRingEquiv`.
-All these maps get `simp`ed to bundled morphisms like `algebraMap K[X] (RatFunc K)`
+All these maps get `simp`ed to bundled morphisms like `algebraMap K[X] (K⟮X⟯)`
 and `IsLocalization.algEquiv`.
 
 There are separate lifts and maps of homomorphisms, to provide routes of lifting even when
@@ -61,8 +61,8 @@ variable (K : Type u)
 
 /-- `RatFunc K` is `K(X)`, the field of rational functions over `K`.
 
-The inclusion of polynomials into `RatFunc` is `algebraMap K[X] (RatFunc K)`,
-the maps between `RatFunc K` and another field of fractions of `K[X]`,
+The inclusion of polynomials into `RatFunc` is `algebraMap K[X] (K⟮X⟯)`,
+the maps between `K⟮X⟯` and another field of fractions of `K[X]`,
 especially `FractionRing K[X]`, are given by `IsLocalization.algEquiv`.
 -/
 structure RatFunc [CommRing K] : Type u where ofFractionRing ::
@@ -82,30 +82,30 @@ section Rec
 
 /-! ### Constructing `RatFunc`s and their induction principles -/
 
-theorem ofFractionRing_injective : Function.Injective (ofFractionRing : _ → RatFunc K) :=
+theorem ofFractionRing_injective : Function.Injective (ofFractionRing : _ → K⟮X⟯) :=
   fun _ _ => ofFractionRing.inj
 
 theorem toFractionRing_injective : Function.Injective (toFractionRing : _ → FractionRing K[X])
   | ⟨x⟩, ⟨y⟩, xy => by subst xy; rfl
 
-@[simp] lemma toFractionRing_inj {x y : RatFunc K} :
+@[simp] lemma toFractionRing_inj {x y : K⟮X⟯} :
     toFractionRing x = toFractionRing y ↔ x = y :=
   toFractionRing_injective.eq_iff
 
-/-- Non-dependent recursion principle for `RatFunc K`:
-To construct a term of `P : Sort*` out of `x : RatFunc K`,
+/-- Non-dependent recursion principle for `K⟮X⟯`:
+To construct a term of `P : Sort*` out of `x : K⟮X⟯`,
 it suffices to provide a constructor `f : Π (p q : K[X]), P`
 and a proof that `f p q = f p' q'` for all `p q p' q'` such that `q' * p = q * p'` where
 both `q` and `q'` are not zero divisors, stated as `q ∉ K[X]⁰`, `q' ∉ K[X]⁰`.
 
 If considering `K` as an integral domain, this is the same as saying that
-we construct a value of `P` for such elements of `RatFunc K` by setting
+we construct a value of `P` for such elements of `K⟮X⟯` by setting
 `liftOn (p / q) f _ = f p q`.
 
 When `[IsDomain K]`, one can use `RatFunc.liftOn'`, which has the stronger requirement
 of `∀ {p q a : K[X]} (hq : q ≠ 0) (ha : a ≠ 0), f (a * p) (a * q) = f p q)`.
 -/
-protected irreducible_def liftOn {P : Sort v} (x : RatFunc K) (f : K[X] → K[X] → P)
+protected irreducible_def liftOn {P : Sort v} (x : K⟮X⟯) (f : K[X] → K[X] → P)
     (H : ∀ {p q p' q'} (_hq : q ∈ K[X]⁰) (_hq' : q' ∈ K[X]⁰), q' * p = q * p' → f p q = f p' q') :
     P :=
   Localization.liftOn (toFractionRing x) (fun p q => f p q) fun {_ _ q q'} h =>
@@ -137,7 +137,7 @@ If `q = 0`, then `mk` returns 0.
 This is an auxiliary definition used to define an `Algebra` structure on `RatFunc`;
 the `simp` normal form of `mk p q` is `algebraMap _ _ p / algebraMap _ _ q`.
 -/
-protected irreducible_def mk (p q : K[X]) : RatFunc K :=
+protected irreducible_def mk (p q : K[X]) : K⟮X⟯ :=
   ofFractionRing (algebraMap _ _ p / algebraMap _ _ q)
 
 theorem mk_eq_div' (p q : K[X]) :
@@ -186,14 +186,14 @@ theorem liftOn_mk {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀ 
       liftOn_ofFractionRing_mk, Submonoid.coe_one]
   · simp only [mk_eq_localization_mk _ hq, liftOn_ofFractionRing_mk]
 
-/-- Non-dependent recursion principle for `RatFunc K`: if `f p q : P` for all `p q`,
+/-- Non-dependent recursion principle for `K⟮X⟯`: if `f p q : P` for all `p q`,
 such that `f (a * p) (a * q) = f p q`, then we can find a value of `P`
-for all elements of `RatFunc K` by setting `lift_on' (p / q) f _ = f p q`.
+for all elements of `K⟮X⟯` by setting `lift_on' (p / q) f _ = f p q`.
 
 The value of `f p 0` for any `p` is never used and in principle this may be anything,
 although many usages of `lift_on'` assume `f p 0 = f 0 1`.
 -/
-protected irreducible_def liftOn' {P : Sort v} (x : RatFunc K) (f : K[X] → K[X] → P)
+protected irreducible_def liftOn' {P : Sort v} (x : K⟮X⟯) (f : K[X] → K[X] → P)
   (H : ∀ {p q a} (_hq : q ≠ 0) (_ha : a ≠ 0), f (a * p) (a * q) = f p q) : P :=
   x.liftOn f fun {_p _q _p' _q'} hq hq' =>
     liftOn_condition_of_liftOn'_condition (@H) (nonZeroDivisors.ne_zero hq)
@@ -205,14 +205,14 @@ theorem liftOn'_mk {P : Sort v} (p q : K[X]) (f : K[X] → K[X] → P) (f0 : ∀
   rw [RatFunc.liftOn', RatFunc.liftOn_mk _ _ _ f0]
   apply liftOn_condition_of_liftOn'_condition H
 
-/-- Induction principle for `RatFunc K`: if `f p q : P (RatFunc.mk p q)` for all `p q`,
-then `P` holds on all elements of `RatFunc K`.
+/-- Induction principle for `K⟮X⟯`: if `f p q : P (RatFunc.mk p q)` for all `p q`,
+then `P` holds on all elements of `K⟮X⟯`.
 
 See also `induction_on`, which is a recursion principle defined in terms of `algebraMap`.
 -/
 @[elab_as_elim]
-protected theorem induction_on' {P : RatFunc K → Prop} :
-    ∀ (x : RatFunc K) (_pq : ∀ (p q : K[X]) (_ : q ≠ 0), P (RatFunc.mk p q)), P x
+protected theorem induction_on' {P : K⟮X⟯ → Prop} :
+    ∀ (x : K⟮X⟯) (_pq : ∀ (p q : K[X]) (_ : q ≠ 0), P (RatFunc.mk p q)), P x
   | ⟨x⟩, f =>
     Localization.induction_on x fun ⟨p, q⟩ => by
       simpa only [mk_coe_def, Localization.mk_eq_mk'] using

--- a/Mathlib/FieldTheory/RatFunc/Degree.lean
+++ b/Mathlib/FieldTheory/RatFunc/Degree.lean
@@ -62,7 +62,7 @@ theorem intDegree_X : intDegree (X : K⟮X⟯) = 1 := by
 
 @[simp]
 theorem intDegree_polynomial {p : K[X]} :
-    intDegree (algebraMap K[X] (K⟮X⟯) p) = natDegree p := by
+    intDegree (algebraMap K[X] K⟮X⟯ p) = natDegree p := by
   rw [intDegree, RatFunc.num_algebraMap, RatFunc.denom_algebraMap, Polynomial.natDegree_one,
     Int.ofNat_zero, sub_zero]
 

--- a/Mathlib/FieldTheory/RatFunc/Degree.lean
+++ b/Mathlib/FieldTheory/RatFunc/Degree.lean
@@ -40,15 +40,15 @@ variable [Field K]
 /-- `intDegree x` is the degree of the rational function `x`, defined as the difference between
 the `natDegree` of its numerator and the `natDegree` of its denominator. In particular,
 `intDegree 0 = 0`. -/
-def intDegree (x : RatFunc K) : ℤ :=
+def intDegree (x : K⟮X⟯) : ℤ :=
   natDegree x.num - natDegree x.denom
 
 @[simp]
-theorem intDegree_zero : intDegree (0 : RatFunc K) = 0 := by
+theorem intDegree_zero : intDegree (0 : K⟮X⟯) = 0 := by
   rw [intDegree, num_zero, natDegree_zero, denom_zero, natDegree_one, sub_self]
 
 @[simp]
-theorem intDegree_one : intDegree (1 : RatFunc K) = 0 := by
+theorem intDegree_one : intDegree (1 : K⟮X⟯) = 0 := by
   rw [intDegree, num_one, denom_one, sub_self]
 
 @[simp]
@@ -56,18 +56,18 @@ theorem intDegree_C (k : K) : intDegree (C k) = 0 := by
   rw [intDegree, num_C, natDegree_C, denom_C, natDegree_one, sub_self]
 
 @[simp]
-theorem intDegree_X : intDegree (X : RatFunc K) = 1 := by
+theorem intDegree_X : intDegree (X : K⟮X⟯) = 1 := by
   rw [intDegree, num_X, Polynomial.natDegree_X, denom_X, Polynomial.natDegree_one,
     Int.ofNat_one, Int.ofNat_zero, sub_zero]
 
 @[simp]
 theorem intDegree_polynomial {p : K[X]} :
-    intDegree (algebraMap K[X] (RatFunc K) p) = natDegree p := by
+    intDegree (algebraMap K[X] (K⟮X⟯) p) = natDegree p := by
   rw [intDegree, RatFunc.num_algebraMap, RatFunc.denom_algebraMap, Polynomial.natDegree_one,
     Int.ofNat_zero, sub_zero]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem intDegree_mul {x y : RatFunc K} (hx : x ≠ 0) (hy : y ≠ 0) :
+theorem intDegree_mul {x y : K⟮X⟯} (hx : x ≠ 0) (hy : y ≠ 0) :
     intDegree (x * y) = intDegree x + intDegree y := by
   simp only [intDegree, add_sub, sub_add, sub_sub_eq_add_sub, sub_sub, sub_eq_sub_iff_add_eq_add]
   norm_cast
@@ -81,12 +81,12 @@ theorem intDegree_mul {x y : RatFunc K} (hx : x ≠ 0) (hy : y ≠ 0) :
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem intDegree_inv (x : RatFunc K) : intDegree (x⁻¹) = - intDegree x := by
+theorem intDegree_inv (x : K⟮X⟯) : intDegree (x⁻¹) = - intDegree x := by
   by_cases hx : x = 0 <;> simp [hx, eq_neg_iff_add_eq_zero, ← intDegree_mul (inv_ne_zero hx) hx]
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
-theorem intDegree_neg (x : RatFunc K) : intDegree (-x) = intDegree x := by
+theorem intDegree_neg (x : K⟮X⟯) : intDegree (-x) = intDegree x := by
   by_cases hx : x = 0
   · rw [hx, neg_zero]
   · rw [intDegree, intDegree, ← natDegree_neg x.num]
@@ -94,14 +94,14 @@ theorem intDegree_neg (x : RatFunc K) : intDegree (-x) = intDegree x := by
       natDegree_sub_eq_of_prod_eq (num_ne_zero (neg_ne_zero.mpr hx)) (denom_ne_zero (-x))
         (neg_ne_zero.mpr (num_ne_zero hx)) (denom_ne_zero x) (num_denom_neg x)
 
-theorem intDegree_add {x y : RatFunc K} (hxy : x + y ≠ 0) :
+theorem intDegree_add {x y : K⟮X⟯} (hxy : x + y ≠ 0) :
     (x + y).intDegree =
       (x.num * y.denom + x.denom * y.num).natDegree - (x.denom * y.denom).natDegree :=
   natDegree_sub_eq_of_prod_eq (num_ne_zero hxy) (x + y).denom_ne_zero
     (num_mul_denom_add_denom_mul_num_ne_zero hxy) (mul_ne_zero x.denom_ne_zero y.denom_ne_zero)
     (num_denom_add x y)
 
-theorem natDegree_num_mul_right_sub_natDegree_denom_mul_left_eq_intDegree {x : RatFunc K}
+theorem natDegree_num_mul_right_sub_natDegree_denom_mul_left_eq_intDegree {x : K⟮X⟯}
     (hx : x ≠ 0) {s : K[X]} (hs : s ≠ 0) :
     ((x.num * s).natDegree : ℤ) - (s * x.denom).natDegree = x.intDegree := by
   apply natDegree_sub_eq_of_prod_eq (mul_ne_zero (num_ne_zero hx) hs)
@@ -109,7 +109,7 @@ theorem natDegree_num_mul_right_sub_natDegree_denom_mul_left_eq_intDegree {x : R
   rw [mul_assoc]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem intDegree_add_le {x y : RatFunc K} (hy : y ≠ 0) (hxy : x + y ≠ 0) :
+theorem intDegree_add_le {x y : K⟮X⟯} (hy : y ≠ 0) (hxy : x + y ≠ 0) :
     intDegree (x + y) ≤ max (intDegree x) (intDegree y) := by
   by_cases hx : x = 0
   · simp [hx]

--- a/Mathlib/FieldTheory/RatFunc/Luroth.lean
+++ b/Mathlib/FieldTheory/RatFunc/Luroth.lean
@@ -36,23 +36,23 @@ namespace RatFunc
 
 open IntermediateField algebraAdjoinAdjoin Polynomial
 
-variable {K : Type*} [Field K] (f : RatFunc K)
+variable {K : Type*} [Field K] (f : K⟮X⟯)
 
-local notation "K[f]" => Algebra.adjoin K {(f : RatFunc K)}
+local notation "K[f]" => Algebra.adjoin K {(f : K⟮X⟯)}
 
-theorem adjoin_X : K⟮(X : RatFunc K)⟯ = ⊤ :=
+theorem adjoin_X : K⟮(X : K⟮X⟯)⟯ = ⊤ :=
   eq_top_iff.mpr fun g _ ↦ (mem_adjoin_simple_iff _ _).mpr ⟨g.num, g.denom, by simp⟩
 
 set_option backward.isDefEq.respectTransparency false in
-theorem IntermediateField.adjoin_X (E : IntermediateField K (RatFunc K)) :
-    E⟮(X : RatFunc K)⟯ = ⊤ := by
+theorem IntermediateField.adjoin_X (E : IntermediateField K (K⟮X⟯)) :
+    E⟮(X : K⟮X⟯)⟯ = ⊤ := by
   rw [← restrictScalars_eq_top_iff (K := K), restrictScalars_adjoin, eq_top_iff]
   exact le_trans (le_of_eq RatFunc.adjoin_X.symm) (IntermediateField.adjoin.mono _ _ _ (by simp))
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The equivalence between `E⟮X⟯` and `RatFunc K` as `E`-algebras. -/
-noncomputable def IntermediateField.adjoinXEquiv (E : IntermediateField K (RatFunc K)) :
-    E⟮(X : RatFunc K)⟯ ≃ₐ[E] RatFunc K :=
+/-- The equivalence between `E⟮X⟯` and `K⟮X⟯` as `E`-algebras. -/
+noncomputable def IntermediateField.adjoinXEquiv (E : IntermediateField K (K⟮X⟯)) :
+    E⟮(X : K⟮X⟯)⟯ ≃ₐ[E] K⟮X⟯ :=
   (IntermediateField.equivOfEq (IntermediateField.adjoin_X E)).trans IntermediateField.topEquiv
 
 /-- The minimal polynomial of `X` over `K⟮f⟯`. It is defined as `f.num - f * f.denom`, viewed
@@ -73,7 +73,7 @@ theorem C_minpolyX (x : K) : (C x).minpolyX K⟮C x⟯ = 0 := by
   simp [minpolyX, sub_eq_zero, Subtype.ext_iff]
 
 set_option backward.isDefEq.respectTransparency false in
-theorem minpolyX_aeval_X : (f.minpolyX K⟮f⟯).aeval (X : RatFunc K) = 0 := by
+theorem minpolyX_aeval_X : (f.minpolyX K⟮f⟯).aeval (X : K⟮X⟯) = 0 := by
   simp only [aeval_sub, aeval_map_algebraMap, aeval_X_left_eq_algebraMap, map_mul, aeval_C,
     IntermediateField.algebraMap_apply, coe_algebraMap]
   nth_rw 2 [← num_div_denom f]
@@ -82,7 +82,7 @@ theorem minpolyX_aeval_X : (f.minpolyX K⟮f⟯).aeval (X : RatFunc K) = 0 := by
 
 set_option backward.isDefEq.respectTransparency false in
 theorem eq_C_of_minpolyX_coeff_eq_zero
-  (hf : (f.minpolyX K⟮f⟯).coeff f.denom.natDegree = (0 : RatFunc K)) : ∃ c, f = C c := by
+  (hf : (f.minpolyX K⟮f⟯).coeff f.denom.natDegree = (0 : K⟮X⟯)) : ∃ c, f = C c := by
   use f.num.coeff f.denom.natDegree / f.denom.leadingCoeff
   rw [map_div₀, eq_div_iff ((_root_.map_ne_zero C).mpr
     (leadingCoeff_ne_zero.mpr f.denom_ne_zero)), eq_comm]
@@ -93,13 +93,13 @@ theorem minpolyX_eq_zero_iff : (f.minpolyX K⟮f⟯) = 0 ↔ ∃ c, f = C c :=
   ⟨fun h ↦ f.eq_C_of_minpolyX_coeff_eq_zero (by simp [h]), by rintro ⟨c, rfl⟩; simp⟩
 
 set_option backward.isDefEq.respectTransparency false in
-theorem isAlgebraic_adjoin_simple_X (hf : ¬∃ c, f = C c) : IsAlgebraic K⟮f⟯ (X : RatFunc K) :=
+theorem isAlgebraic_adjoin_simple_X (hf : ¬∃ c, f = C c) : IsAlgebraic K⟮f⟯ (X : K⟮X⟯) :=
    ⟨f.minpolyX K⟮f⟯, fun H ↦ hf (f.minpolyX_eq_zero_iff.mp H), f.minpolyX_aeval_X⟩
 
 set_option backward.isDefEq.respectTransparency false in
 theorem isAlgebraic_adjoin_simple_X' (hf : ¬∃ c, f = C c) :
-    Algebra.IsAlgebraic K⟮f⟯ (RatFunc K) := by
-  have : Algebra.IsAlgebraic K⟮f⟯ K⟮f⟯⟮(X : RatFunc K)⟯ :=
+    Algebra.IsAlgebraic K⟮f⟯ (K⟮X⟯) := by
+  have : Algebra.IsAlgebraic K⟮f⟯ K⟮f⟯⟮(X : K⟮X⟯)⟯ :=
     isAlgebraic_adjoin_simple <| isAlgebraic_iff_isIntegral.mp <| f.isAlgebraic_adjoin_simple_X hf
   exact (IntermediateField.adjoinXEquiv K⟮f⟯).isAlgebraic
 
@@ -141,7 +141,7 @@ set_option backward.isDefEq.respectTransparency false in
 theorem transcendental_of_ne_C (hf : ¬∃ c, f = C c) : Transcendental K f := by
   intro H
   have := IntermediateField.isAlgebraic_adjoin_simple H.isIntegral
-  have tr : Algebra.Transcendental K (RatFunc K) := by infer_instance
+  have tr : Algebra.Transcendental K (K⟮X⟯) := by infer_instance
   rw [Algebra.transcendental_iff_not_isAlgebraic] at tr
   exact tr <| Algebra.IsAlgebraic.trans _ _ _ (alg := f.isAlgebraic_adjoin_simple_X' hf)
 
@@ -186,12 +186,12 @@ theorem irreducible_minpolyX (hf : ¬∃ c, f = C c) : Irreducible (f.minpolyX K
 
 set_option backward.isDefEq.respectTransparency false in
 theorem finrank_eq_max_natDegree :
-    Module.finrank K⟮f⟯ (RatFunc K) = max f.num.natDegree f.denom.natDegree := by
+    Module.finrank K⟮f⟯ (K⟮X⟯) = max f.num.natDegree f.denom.natDegree := by
   by_cases hf : ∃ c, f = C c
   · obtain ⟨c, rfl⟩ := hf
     rw [adjoin_simple_eq_bot_iff.mpr (show C c ∈ ⊥ from ⟨c, rfl⟩), finrank_bot',
       Module.finrank_of_not_finite fun H ↦  Algebra.transcendental_iff_not_isAlgebraic.mp
-      transcendental <| Algebra.IsAlgebraic.of_finite K (RatFunc K)]
+      transcendental <| Algebra.IsAlgebraic.of_finite K (K⟮X⟯)]
     simp
   rw [← (IntermediateField.adjoinXEquiv K⟮f⟯).toLinearEquiv.finrank_eq,
     adjoin.finrank (f.isAlgebraic_adjoin_simple_X hf).isIntegral,

--- a/Mathlib/FieldTheory/RatFunc/Luroth.lean
+++ b/Mathlib/FieldTheory/RatFunc/Luroth.lean
@@ -44,14 +44,14 @@ theorem adjoin_X : K⟮(X : K⟮X⟯)⟯ = ⊤ :=
   eq_top_iff.mpr fun g _ ↦ (mem_adjoin_simple_iff _ _).mpr ⟨g.num, g.denom, by simp⟩
 
 set_option backward.isDefEq.respectTransparency false in
-theorem IntermediateField.adjoin_X (E : IntermediateField K (K⟮X⟯)) :
+theorem IntermediateField.adjoin_X (E : IntermediateField K K⟮X⟯) :
     E⟮(X : K⟮X⟯)⟯ = ⊤ := by
   rw [← restrictScalars_eq_top_iff (K := K), restrictScalars_adjoin, eq_top_iff]
   exact le_trans (le_of_eq RatFunc.adjoin_X.symm) (IntermediateField.adjoin.mono _ _ _ (by simp))
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The equivalence between `E⟮X⟯` and `K⟮X⟯` as `E`-algebras. -/
-noncomputable def IntermediateField.adjoinXEquiv (E : IntermediateField K (K⟮X⟯)) :
+noncomputable def IntermediateField.adjoinXEquiv (E : IntermediateField K K⟮X⟯) :
     E⟮(X : K⟮X⟯)⟯ ≃ₐ[E] K⟮X⟯ :=
   (IntermediateField.equivOfEq (IntermediateField.adjoin_X E)).trans IntermediateField.topEquiv
 
@@ -98,7 +98,7 @@ theorem isAlgebraic_adjoin_simple_X (hf : ¬∃ c, f = C c) : IsAlgebraic K⟮f�
 
 set_option backward.isDefEq.respectTransparency false in
 theorem isAlgebraic_adjoin_simple_X' (hf : ¬∃ c, f = C c) :
-    Algebra.IsAlgebraic K⟮f⟯ (K⟮X⟯) := by
+    Algebra.IsAlgebraic K⟮f⟯ K⟮X⟯ := by
   have : Algebra.IsAlgebraic K⟮f⟯ K⟮f⟯⟮(X : K⟮X⟯)⟯ :=
     isAlgebraic_adjoin_simple <| isAlgebraic_iff_isIntegral.mp <| f.isAlgebraic_adjoin_simple_X hf
   exact (IntermediateField.adjoinXEquiv K⟮f⟯).isAlgebraic
@@ -141,7 +141,7 @@ set_option backward.isDefEq.respectTransparency false in
 theorem transcendental_of_ne_C (hf : ¬∃ c, f = C c) : Transcendental K f := by
   intro H
   have := IntermediateField.isAlgebraic_adjoin_simple H.isIntegral
-  have tr : Algebra.Transcendental K (K⟮X⟯) := by infer_instance
+  have tr : Algebra.Transcendental K K⟮X⟯ := by infer_instance
   rw [Algebra.transcendental_iff_not_isAlgebraic] at tr
   exact tr <| Algebra.IsAlgebraic.trans _ _ _ (alg := f.isAlgebraic_adjoin_simple_X' hf)
 
@@ -186,12 +186,12 @@ theorem irreducible_minpolyX (hf : ¬∃ c, f = C c) : Irreducible (f.minpolyX K
 
 set_option backward.isDefEq.respectTransparency false in
 theorem finrank_eq_max_natDegree :
-    Module.finrank K⟮f⟯ (K⟮X⟯) = max f.num.natDegree f.denom.natDegree := by
+    Module.finrank K⟮f⟯ K⟮X⟯ = max f.num.natDegree f.denom.natDegree := by
   by_cases hf : ∃ c, f = C c
   · obtain ⟨c, rfl⟩ := hf
     rw [adjoin_simple_eq_bot_iff.mpr (show C c ∈ ⊥ from ⟨c, rfl⟩), finrank_bot',
       Module.finrank_of_not_finite fun H ↦  Algebra.transcendental_iff_not_isAlgebraic.mp
-      transcendental <| Algebra.IsAlgebraic.of_finite K (K⟮X⟯)]
+      transcendental <| Algebra.IsAlgebraic.of_finite K K⟮X⟯]
     simp
   rw [← (IntermediateField.adjoinXEquiv K⟮f⟯).toLinearEquiv.finrank_eq,
     adjoin.finrank (f.isAlgebraic_adjoin_simple_X hf).isIntegral,

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -422,7 +422,7 @@ def idealX : IsDedekindDomain.HeightOneSpectrum K⟦X⟧ where
   isPrime := PowerSeries.span_X_isPrime
   ne_bot  := by rw [ne_eq, Ideal.span_singleton_eq_bot]; exact X_ne_zero
 
-open IsDedekindDomain.HeightOneSpectrum WithZero⟮X⟯
+open IsDedekindDomain.HeightOneSpectrum WithZero RatFunc
 
 variable {K}
 
@@ -487,7 +487,7 @@ end RatFunc
 namespace LaurentSeries
 
 
-open IsDedekindDomain.HeightOneSpectrum PowerSeries WithZero⟮X⟯
+open IsDedekindDomain.HeightOneSpectrum PowerSeries WithZero RatFunc
 
 set_option backward.isDefEq.respectTransparency false in
 instance : Valued K⸨X⸩ ℤᵐ⁰ := Valued.mk' ((PowerSeries.idealX K).valuation _)
@@ -887,7 +887,7 @@ end Dense
 
 section Comparison
 
-open AbstractCompletion⟮X⟯ IsDedekindDomain.HeightOneSpectrum WithZero
+open AbstractCompletion RatFunc IsDedekindDomain.HeightOneSpectrum WithZero
 
 lemma exists_ratFunc_eq_v (x : K⸨X⸩) : ∃ f : K⟮X⟯, Valued.v f = Valued.v x := by
   by_cases hx : Valued.v x = 0

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -370,8 +370,8 @@ instance : FaithfulSMul F[X] F⸨X⸩ := by
   refine (faithfulSMul_iff_algebraMap_injective F[X] F⸨X⸩).mpr ?_
   exact algebraMap_hahnSeries_injective ℤ
 
-instance coeToLaurentSeries : Coe (F⟮X⟯) F⸨X⸩ :=
-  ⟨algebraMap (F⟮X⟯) F⸨X⸩⟩
+instance coeToLaurentSeries : Coe F⟮X⟯ F⸨X⸩ :=
+  ⟨algebraMap F⟮X⟯ F⸨X⸩⟩
 
 theorem coe_coe (P : Polynomial F) : ((P : F⟦X⟧) : F⸨X⸩) = (P : F⟮X⟯) := by
   simp [coePolynomial, coe_def, ← IsScalarTower.algebraMap_apply]
@@ -380,7 +380,7 @@ theorem coe_coe (P : Polynomial F) : ((P : F⟦X⟧) : F⸨X⸩) = (P : F⟮X⟯
 -- even though `single 1 1` is a bundled function application, not a "real" coercion
 @[simp]
 theorem coe_X : ((X : F⟮X⟯) : F⸨X⸩) = single 1 1 := by
-  simp [← algebraMap_X, ← IsScalarTower.algebraMap_apply F[X] (F⟮X⟯) F⸨X⸩]
+  simp [← algebraMap_X, ← IsScalarTower.algebraMap_apply F[X] F⟮X⟯ F⸨X⸩]
 
 theorem single_one_eq_pow {R : Type*} [Semiring R] (n : ℕ) :
     single (n : ℤ) (1 : R) = single (1 : ℤ) 1 ^ n := by
@@ -402,9 +402,9 @@ theorem single_zpow (n : ℤ) :
       inv_inj, zpow_natCast, single_one_eq_pow, inv_one]
 
 theorem algebraMap_apply_div :
-    algebraMap (F⟮X⟯) F⸨X⸩ (algebraMap _ _ p / algebraMap _ _ q) =
+    algebraMap F⟮X⟯ F⸨X⸩ (algebraMap _ _ p / algebraMap _ _ q) =
       algebraMap F[X] F⸨X⸩ p / algebraMap _ _ q := by
-  simp only [map_div₀, IsScalarTower.algebraMap_apply F[X] (F⟮X⟯) F⸨X⸩]
+  simp only [map_div₀, IsScalarTower.algebraMap_apply F[X] F⟮X⟯ F⸨X⸩]
 
 end RatFunc
 
@@ -467,8 +467,8 @@ open IsDedekindDomain.HeightOneSpectrum PowerSeries
 open scoped LaurentSeries
 
 /-- `valuationX` is an abbrevation for the `X`-adic valuation given by
-`(Polynomial.idealX K).valuation (K⟮X⟯)`. -/
-abbrev polynomialValuationX : Valuation (K⟮X⟯) ℤᵐ⁰ :=
+`(Polynomial.idealX K).valuation K⟮X⟯`. -/
+abbrev polynomialValuationX : Valuation K⟮X⟯ ℤᵐ⁰ :=
   (Polynomial.idealX K).valuation _
 
 set_option backward.isDefEq.respectTransparency false in
@@ -479,7 +479,7 @@ theorem valuation_eq_LaurentSeries_valuation (P : K⟮X⟯) :
   rw [Polynomial.valuation_of_mk K f h, RatFunc.mk_eq_mk' f h, Eq.comm]
   convert @valuation_of_mk' K⟦X⟧ _ _ K⸨X⸩ _ _ _ (PowerSeries.idealX K) f
         ⟨g, mem_nonZeroDivisors_iff_ne_zero.2 <| (by simp [h])⟩
-  · simp [← IsScalarTower.algebraMap_apply K[X] (K⟮X⟯) K⸨X⸩]
+  · simp [← IsScalarTower.algebraMap_apply K[X] K⟮X⟯ K⸨X⸩]
   exacts [intValuation_eq_of_coe _, intValuation_eq_of_coe _]
 
 end RatFunc
@@ -848,7 +848,7 @@ theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤᵐ⁰ˣ) :
     have F_mul := f.ofPowerSeries_powerSeriesPart
     obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (le_of_lt ord_nonpos)
     rw [← hF, hs, neg_neg, ← ofPowerSeries_X_pow s, ← inv_mul_eq_iff_eq_mul₀] at F_mul
-    · have : (algebraMap (K⟮X⟯) K⸨X⸩) 1 = 1 := by exact algebraMap.coe_one
+    · have : (algebraMap K⟮X⟯ K⸨X⸩) 1 = 1 := by exact algebraMap.coe_one
       rw [hs, ← F_mul, PowerSeries.coe_pow, PowerSeries.coe_X, map_mul, zpow_neg,
         zpow_natCast, inv_eq_one_div (RatFunc.X ^ s), map_div₀, map_pow,
         RatFunc.coe_X]
@@ -969,10 +969,10 @@ theorem LaurentSeries_coe (x : K⟮X⟯) :
 homomorphism -/
 abbrev extensionAsRingHom :=
   UniformSpace.Completion.extensionHom <|
-    (algebraMap (K⟮X⟯) K⸨X⸩).comp (WithVal.equiv (polynomialValuationX K)).toRingHom
+    (algebraMap K⟮X⟯ K⸨X⸩).comp (WithVal.equiv (polynomialValuationX K)).toRingHom
 
 /-- An abbreviation for the `X`-adic completion of `K⟮X⟯` -/
-abbrev RatFuncAdicCompl := adicCompletion (K⟮X⟯) (idealX K)
+abbrev RatFuncAdicCompl := adicCompletion K⟮X⟯ (idealX K)
 
 /- The two instances below make `comparePkg` and `comparePkg_eq_extension` slightly faster. -/
 instance : UniformSpace (RatFuncAdicCompl K) := inferInstance
@@ -1043,9 +1043,9 @@ theorem valuation_LaurentSeries_equal_extension :
     rfl
   · exact Valued.continuous_valuation (K := K⸨X⸩)
 
-theorem tendsto_valuation (a : (idealX K).adicCompletion (K⟮X⟯)) :
+theorem tendsto_valuation (a : (idealX K).adicCompletion K⟮X⟯) :
     Tendsto (Valued.v : K⟮X⟯ → ℤᵐ⁰) (comap (↑) (𝓝 a)) (𝓝 (Valued.v a : ℤᵐ⁰)) := by
-  have := Valued.is_topological_valuation (R := (idealX K).adicCompletion (K⟮X⟯))
+  have := Valued.is_topological_valuation (R := (idealX K).adicCompletion K⟮X⟯)
   by_cases ha : a = 0
   · rw [tendsto_def]
     intro S hS
@@ -1102,7 +1102,7 @@ lemma powerSeriesEquivSubring_coe_apply (f : K⟦X⟧) :
 /- Through the isomorphism `LaurentSeriesRingEquiv`, power series land in the unit ball inside the
 completion of `K⟮X⟯`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
-    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (K⟮X⟯) := by
+    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers K⟮X⟯ := by
   simp only [mem_adicCompletionIntegers, LaurentSeriesRingEquiv_def,
     valuation_compare, val_le_one_iff_eq_coe]
   exact ⟨F, rfl⟩
@@ -1110,7 +1110,7 @@ theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
 /- Conversely, all elements in the unit ball inside the completion of `K⟮X⟯` come from a power
 series through the isomorphism `LaurentSeriesRingEquiv`. -/
 theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
-    (hx : x ∈ (idealX K).adicCompletionIntegers (K⟮X⟯)) :
+    (hx : x ∈ (idealX K).adicCompletionIntegers K⟮X⟯) :
     ∃ F : K⟦X⟧, (LaurentSeriesRingEquiv K) F = x := by
   set f := (ratfuncAdicComplRingEquiv K) x with hf
   have H_x : (LaurentSeriesPkg K).compare ratfuncAdicComplPkg ((ratfuncAdicComplRingEquiv K) x) =
@@ -1121,7 +1121,7 @@ theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
 
 theorem powerSeries_ext_subring :
     Subring.map (LaurentSeriesRingEquiv K).toRingHom (powerSeries_as_subring K) =
-      ((idealX K).adicCompletionIntegers (K⟮X⟯)).toSubring := by
+      ((idealX K).adicCompletionIntegers K⟮X⟯).toSubring := by
   ext x
   refine ⟨fun ⟨f, ⟨F, _, coe_F⟩, hF⟩ ↦ ?_, fun H ↦ ?_⟩
   · simp only [ValuationSubring.mem_toSubring, ← hF, ← coe_F]
@@ -1132,7 +1132,7 @@ theorem powerSeries_ext_subring :
 
 /-- The ring isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
 `K⟮X⟯`. -/
-abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (K⟮X⟯) :=
+abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers K⟮X⟯ :=
   ((powerSeriesEquivSubring K).trans (LaurentSeriesRingEquiv K).subringMap).trans
     <| RingEquiv.subringCongr (powerSeries_ext_subring K)
 
@@ -1148,13 +1148,13 @@ lemma LaurentSeriesRingEquiv_mem_valuationSubring (f : K⟦X⟧) :
 
 lemma algebraMap_C_mem_adicCompletionIntegers (x : K) :
     ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C) x ∈
-      adicCompletionIntegers (K⟮X⟯) (idealX K) := by
+      adicCompletionIntegers K⟮X⟯ (idealX K) := by
   have : HahnSeries.C x = ofPowerSeries ℤ K (PowerSeries.C x) := by
     simp [C_apply, ofPowerSeries_C]
   simp only [RingHom.comp_apply, RingEquiv.toRingHom_eq_coe, RingHom.coe_coe, this]
   apply LaurentSeriesRingEquiv_mem_valuationSubring
 
-instance : Algebra K ((idealX K).adicCompletionIntegers (K⟮X⟯)) :=
+instance : Algebra K ((idealX K).adicCompletionIntegers K⟮X⟯) :=
   RingHom.toAlgebra <|
     ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C).codRestrict _
       (algebraMap_C_mem_adicCompletionIntegers K)
@@ -1162,7 +1162,7 @@ instance : Algebra K ((idealX K).adicCompletionIntegers (K⟮X⟯)) :=
 set_option backward.isDefEq.respectTransparency false in
 /-- The algebra isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
 `K⟮X⟯`. -/
-def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (K⟮X⟯) := by
+def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers K⟮X⟯ := by
   apply AlgEquiv.ofRingEquiv (f := powerSeriesRingEquiv K)
   intro a
   rw [PowerSeries.algebraMap_eq, RingHom.algebraMap_toAlgebra, ← Subtype.coe_inj,

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -56,31 +56,31 @@ type with a zero. They are denoted `R⸨X⸩`.
   stating that for every Laurent series `f` and every `γ : ℤᵐ⁰` one can find a rational function `Q`
   such that the `X`-adic valuation `v` satisfies `v (f - Q) < γ`.
 * In `LaurentSeries.valuation_compare` we prove that the extension of the `X`-adic valuation from
-  `RatFunc K` up to its abstract completion coincides, modulo the isomorphism with `K⸨X⸩`, with the
+  `K⟮X⟯` up to its abstract completion coincides, modulo the isomorphism with `K⸨X⸩`, with the
   `X`-adic valuation on `K⸨X⸩`.
 * The two declarations `LaurentSeries.mem_integers_of_powerSeries` and
   `LaurentSeries.exists_powerSeries_of_memIntegers` show that an element in the completion of
-  `RatFunc K` is in the unit ball if and only if it comes from a power series through the
+  `K⟮X⟯` is in the unit ball if and only if it comes from a power series through the
   isomorphism `LaurentSeriesRingEquiv`.
 * `LaurentSeries.powerSeriesAlgEquiv` is the `K`-algebra isomorphism between `K⟦X⟧`
-  and the unit ball inside the `X`-adic completion of `RatFunc K`.
+  and the unit ball inside the `X`-adic completion of `K⟮X⟯`.
 
 ## Implementation details
 
 * Since `LaurentSeries` is just an abbreviation of `HahnSeries ℤ`, the definition of the
   coefficients is given in terms of `HahnSeries.coeff` and this forces sometimes to go
   back-and-forth from `X : R⸨X⸩` to `single 1 1 : R⟦ℤ⟧`.
-* To prove the isomorphism between the `X`-adic completion of `RatFunc K` and `K⸨X⸩` we construct
-  two completions of `RatFunc K`: the first (`LaurentSeries.ratfuncAdicComplPkg`) is its abstract
+* To prove the isomorphism between the `X`-adic completion of `K⟮X⟯` and `K⸨X⸩` we construct
+  two completions of `K⟮X⟯`: the first (`LaurentSeries.ratfuncAdicComplPkg`) is its abstract
   uniform completion; the second (`LaurentSeries.LaurentSeriesPkg`) is simply `K⸨X⸩`, once we prove
-  that it is complete and contains `RatFunc K` as a dense subspace. The isomorphism is the
+  that it is complete and contains `K⟮X⟯` as a dense subspace. The isomorphism is the
   comparison equivalence, expressing the mathematical idea that the completion "is unique". It is
   `LaurentSeries.comparePkg`.
 * For applications to `K⟦X⟧` it is actually more handy to use the *inverse* of the above
   equivalence: `LaurentSeries.LaurentSeriesAlgEquiv` is the *topological, algebra equivalence*
   `K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K`.
 * In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
-  `RatFunc K` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
+  `K⟮X⟯` we consider its alias `LaurentSeries.powerSeries_as_subring` as a subring of `K⸨X⸩`,
   that is itself clearly isomorphic (via the inverse of `LaurentSeries.powerSeriesEquivSubring`)
   to `K⟦X⟧`.
 
@@ -364,23 +364,23 @@ namespace RatFunc
 
 open scoped LaurentSeries
 
-variable {F : Type u} [Field F] (p q : F[X]) (f g : RatFunc F)
+variable {F : Type u} [Field F] (p q : F[X]) (f g : F⟮X⟯)
 
 instance : FaithfulSMul F[X] F⸨X⸩ := by
   refine (faithfulSMul_iff_algebraMap_injective F[X] F⸨X⸩).mpr ?_
   exact algebraMap_hahnSeries_injective ℤ
 
-instance coeToLaurentSeries : Coe (RatFunc F) F⸨X⸩ :=
-  ⟨algebraMap (RatFunc F) F⸨X⸩⟩
+instance coeToLaurentSeries : Coe (F⟮X⟯) F⸨X⸩ :=
+  ⟨algebraMap (F⟮X⟯) F⸨X⸩⟩
 
-theorem coe_coe (P : Polynomial F) : ((P : F⟦X⟧) : F⸨X⸩) = (P : RatFunc F) := by
+theorem coe_coe (P : Polynomial F) : ((P : F⟦X⟧) : F⸨X⸩) = (P : F⟮X⟯) := by
   simp [coePolynomial, coe_def, ← IsScalarTower.algebraMap_apply]
 
 -- Porting note: removed `norm_cast` because "badly shaped lemma, rhs can't start with coe"
 -- even though `single 1 1` is a bundled function application, not a "real" coercion
 @[simp]
-theorem coe_X : ((X : RatFunc F) : F⸨X⸩) = single 1 1 := by
-  simp [← algebraMap_X, ← IsScalarTower.algebraMap_apply F[X] (RatFunc F) F⸨X⸩]
+theorem coe_X : ((X : F⟮X⟯) : F⸨X⸩) = single 1 1 := by
+  simp [← algebraMap_X, ← IsScalarTower.algebraMap_apply F[X] (F⟮X⟯) F⸨X⸩]
 
 theorem single_one_eq_pow {R : Type*} [Semiring R] (n : ℕ) :
     single (n : ℤ) (1 : R) = single (1 : ℤ) 1 ^ n := by
@@ -402,9 +402,9 @@ theorem single_zpow (n : ℤ) :
       inv_inj, zpow_natCast, single_one_eq_pow, inv_one]
 
 theorem algebraMap_apply_div :
-    algebraMap (RatFunc F) F⸨X⸩ (algebraMap _ _ p / algebraMap _ _ q) =
+    algebraMap (F⟮X⟯) F⸨X⸩ (algebraMap _ _ p / algebraMap _ _ q) =
       algebraMap F[X] F⸨X⸩ p / algebraMap _ _ q := by
-  simp only [map_div₀, IsScalarTower.algebraMap_apply F[X] (RatFunc F) F⸨X⸩]
+  simp only [map_div₀, IsScalarTower.algebraMap_apply F[X] (F⟮X⟯) F⸨X⸩]
 
 end RatFunc
 
@@ -422,7 +422,7 @@ def idealX : IsDedekindDomain.HeightOneSpectrum K⟦X⟧ where
   isPrime := PowerSeries.span_X_isPrime
   ne_bot  := by rw [ne_eq, Ideal.span_singleton_eq_bot]; exact X_ne_zero
 
-open IsDedekindDomain.HeightOneSpectrum RatFunc WithZero
+open IsDedekindDomain.HeightOneSpectrum WithZero⟮X⟯
 
 variable {K}
 
@@ -467,19 +467,19 @@ open IsDedekindDomain.HeightOneSpectrum PowerSeries
 open scoped LaurentSeries
 
 /-- `valuationX` is an abbrevation for the `X`-adic valuation given by
-`(Polynomial.idealX K).valuation (RatFunc K)`. -/
-abbrev polynomialValuationX : Valuation (RatFunc K) ℤᵐ⁰ :=
+`(Polynomial.idealX K).valuation (K⟮X⟯)`. -/
+abbrev polynomialValuationX : Valuation (K⟮X⟯) ℤᵐ⁰ :=
   (Polynomial.idealX K).valuation _
 
 set_option backward.isDefEq.respectTransparency false in
-theorem valuation_eq_LaurentSeries_valuation (P : RatFunc K) :
+theorem valuation_eq_LaurentSeries_valuation (P : K⟮X⟯) :
     polynomialValuationX K P = (PowerSeries.idealX K).valuation K⸨X⸩ P := by
   refine RatFunc.induction_on' P ?_
   intro f g h
   rw [Polynomial.valuation_of_mk K f h, RatFunc.mk_eq_mk' f h, Eq.comm]
   convert @valuation_of_mk' K⟦X⟧ _ _ K⸨X⸩ _ _ _ (PowerSeries.idealX K) f
         ⟨g, mem_nonZeroDivisors_iff_ne_zero.2 <| (by simp [h])⟩
-  · simp [← IsScalarTower.algebraMap_apply K[X] (RatFunc K) K⸨X⸩]
+  · simp [← IsScalarTower.algebraMap_apply K[X] (K⟮X⟯) K⸨X⸩]
   exacts [intValuation_eq_of_coe _, intValuation_eq_of_coe _]
 
 end RatFunc
@@ -487,7 +487,7 @@ end RatFunc
 namespace LaurentSeries
 
 
-open IsDedekindDomain.HeightOneSpectrum PowerSeries RatFunc WithZero
+open IsDedekindDomain.HeightOneSpectrum PowerSeries WithZero⟮X⟯
 
 set_option backward.isDefEq.respectTransparency false in
 instance : Valued K⸨X⸩ ℤᵐ⁰ := Valued.mk' ((PowerSeries.idealX K).valuation _)
@@ -496,7 +496,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma valuation_def : (Valued.v : Valuation K⸨X⸩ ℤᵐ⁰) = (PowerSeries.idealX K).valuation _ := rfl
 
 set_option backward.isDefEq.respectTransparency false in
-lemma valuation_coe_ratFunc (f : RatFunc K) :
+lemma valuation_coe_ratFunc (f : K⟮X⟯) :
     Valued.v (f : K⸨X⸩) = Valued.v f := by
   simp [adicValued_apply, ← valuation_eq_LaurentSeries_valuation]
 
@@ -838,17 +838,17 @@ set_option backward.isDefEq.respectTransparency false in
 /-- For every Laurent series `f` and every `γ : ℤᵐ⁰` one can find a rational function `Q` such
 that the `X`-adic valuation `v` satisfies `v (f - Q) < γ`. -/
 theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤᵐ⁰ˣ) :
-    ∃ Q : RatFunc K, Valued.v (f - Q) < γ := by
+    ∃ Q : K⟮X⟯, Valued.v (f - Q) < γ := by
   set F := f.powerSeriesPart with hF
   by_cases! ord_nonpos : f.order < 0
   · set η : ℤᵐ⁰ˣ := Units.mk0 (exp f.order) coe_ne_zero
       with hη
     obtain ⟨P, hP⟩ := exists_Polynomial_intValuation_lt F (η * γ)
-    use RatFunc.X ^ f.order * (P : RatFunc K)
+    use RatFunc.X ^ f.order * (P : K⟮X⟯)
     have F_mul := f.ofPowerSeries_powerSeriesPart
     obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (le_of_lt ord_nonpos)
     rw [← hF, hs, neg_neg, ← ofPowerSeries_X_pow s, ← inv_mul_eq_iff_eq_mul₀] at F_mul
-    · have : (algebraMap (RatFunc K) K⸨X⸩) 1 = 1 := by exact algebraMap.coe_one
+    · have : (algebraMap (K⟮X⟯) K⸨X⸩) 1 = 1 := by exact algebraMap.coe_one
       rw [hs, ← F_mul, PowerSeries.coe_pow, PowerSeries.coe_X, map_mul, zpow_neg,
         zpow_natCast, inv_eq_one_div (RatFunc.X ^ s), map_div₀, map_pow,
         RatFunc.coe_X]
@@ -868,7 +868,7 @@ theorem exists_ratFunc_val_lt (f : K⸨X⸩) (γ : ℤᵐ⁰ˣ) :
       ← PowerSeries.coe_sub, ← coe_algebraMap, adicValued_apply, valuation_of_algebraMap]
     exact hP
 
-theorem coe_range_dense : DenseRange ((↑) : RatFunc K → K⸨X⸩) := by
+theorem coe_range_dense : DenseRange ((↑) : K⟮X⟯ → K⸨X⸩) := by
   rw [denseRange_iff_closure_range]
   ext f
   simp only [UniformSpace.mem_closure_iff_symm_ball, Set.mem_univ, iff_true, Set.Nonempty,
@@ -887,9 +887,9 @@ end Dense
 
 section Comparison
 
-open RatFunc AbstractCompletion IsDedekindDomain.HeightOneSpectrum WithZero
+open AbstractCompletion⟮X⟯ IsDedekindDomain.HeightOneSpectrum WithZero
 
-lemma exists_ratFunc_eq_v (x : K⸨X⸩) : ∃ f : RatFunc K, Valued.v f = Valued.v x := by
+lemma exists_ratFunc_eq_v (x : K⸨X⸩) : ∃ f : K⟮X⟯, Valued.v f = Valued.v x := by
   by_cases hx : Valued.v x = 0
   · use 0
     simp [hx]
@@ -897,7 +897,7 @@ lemma exists_ratFunc_eq_v (x : K⸨X⸩) : ∃ f : RatFunc K, Valued.v f = Value
   rw [zpow_neg, map_inv₀, map_zpow₀, v_def, valuation_X_eq_neg_one, ← exp_zsmul, ← exp_neg]
   simp [exp_log, hx]
 
-theorem inducing_coe : IsUniformInducing ((↑) : RatFunc K → K⸨X⸩) := by
+theorem inducing_coe : IsUniformInducing ((↑) : K⟮X⟯ → K⸨X⸩) := by
   rw [isUniformInducing_iff, Filter.comap]
   ext S
   simp only [Filter.mem_mk, Set.mem_setOf_eq, uniformity_eq_comap_nhds_zero,
@@ -905,7 +905,7 @@ theorem inducing_coe : IsUniformInducing ((↑) : RatFunc K → K⸨X⸩) := by
   constructor
   · rintro ⟨T, ⟨⟨R, ⟨hR, pre_R⟩⟩, pre_T⟩⟩
     obtain ⟨d, hd⟩ := Valued.mem_nhds.mp hR
-    use {P : RatFunc K | Valued.v P < ↑d}
+    use {P : K⟮X⟯ | Valued.v P < ↑d}
     simp only [Valued.mem_nhds, sub_zero]
     refine ⟨⟨d, by rfl⟩, subset_trans (fun _ _ ↦ pre_R ?_) pre_T⟩
     apply hd
@@ -930,16 +930,16 @@ theorem uniformContinuous_withVal_equiv :
   Valuation.IsEquiv.uniformContinuous_equiv rfl
     (Valuation.exists_div_eq_of_surjective <| valuation_surjective _ _) .refl
 
-theorem continuous_coe : Continuous ((↑) : RatFunc K → K⸨X⸩) :=
+theorem continuous_coe : Continuous ((↑) : K⟮X⟯ → K⸨X⸩) :=
   (isUniformInducing_iff'.1 (inducing_coe)).1.continuous
 
-/-- The `X`-adic completion as an abstract completion of `RatFunc K` -/
+/-- The `X`-adic completion as an abstract completion of `K⟮X⟯` -/
 abbrev ratfuncAdicComplPkg : AbstractCompletion (WithVal (polynomialValuationX K)) :=
   UniformSpace.Completion.cPkg
 
 variable (K)
-/-- Having established that the `K⸨X⸩` is complete and contains `RatFunc K` as a dense
-subspace, it gives rise to an abstract completion of `RatFunc K`. -/
+/-- Having established that the `K⸨X⸩` is complete and contains `K⟮X⟯` as a dense
+subspace, it gives rise to an abstract completion of `K⟮X⟯`. -/
 noncomputable def LaurentSeriesPkg :
     AbstractCompletion (WithVal (polynomialValuationX K)) where
   space := K⸨X⸩
@@ -954,14 +954,14 @@ noncomputable def LaurentSeriesPkg :
   dense := .comp coe_range_dense (WithVal.equiv _).surjective.denseRange continuous_coe
 
 theorem continuous_coe' :
-    Continuous (((↑) : RatFunc K → K⸨X⸩) ∘ WithVal.equiv (polynomialValuationX K)) :=
+    Continuous (((↑) : K⟮X⟯ → K⸨X⸩) ∘ WithVal.equiv (polynomialValuationX K)) :=
   continuous_coe.comp (uniformContinuous_withVal_equiv).continuous
 
 instance : TopologicalSpace (LaurentSeriesPkg K).space :=
   (LaurentSeriesPkg K).uniformStruct.toTopologicalSpace
 
 @[simp]
-theorem LaurentSeries_coe (x : RatFunc K) :
+theorem LaurentSeries_coe (x : K⟮X⟯) :
     (LaurentSeriesPkg K).coe (WithVal.toVal _ x) = (x : K⸨X⸩) := by
   rfl
 
@@ -969,23 +969,23 @@ theorem LaurentSeries_coe (x : RatFunc K) :
 homomorphism -/
 abbrev extensionAsRingHom :=
   UniformSpace.Completion.extensionHom <|
-    (algebraMap (RatFunc K) K⸨X⸩).comp (WithVal.equiv (polynomialValuationX K)).toRingHom
+    (algebraMap (K⟮X⟯) K⸨X⸩).comp (WithVal.equiv (polynomialValuationX K)).toRingHom
 
-/-- An abbreviation for the `X`-adic completion of `RatFunc K` -/
-abbrev RatFuncAdicCompl := adicCompletion (RatFunc K) (idealX K)
+/-- An abbreviation for the `X`-adic completion of `K⟮X⟯` -/
+abbrev RatFuncAdicCompl := adicCompletion (K⟮X⟯) (idealX K)
 
 /- The two instances below make `comparePkg` and `comparePkg_eq_extension` slightly faster. -/
 instance : UniformSpace (RatFuncAdicCompl K) := inferInstance
 instance : UniformSpace K⸨X⸩ := inferInstance
 
-/-- The uniform space isomorphism between two abstract completions of `ratfunc K` -/
+/-- The uniform space isomorphism between two abstract completions of `K⟮X⟯` -/
 abbrev comparePkg : RatFuncAdicCompl K ≃ᵤ K⸨X⸩ :=
   compareEquiv ratfuncAdicComplPkg (LaurentSeriesPkg K)
 
 lemma comparePkg_eq_extension (x : RatFuncAdicCompl K) :
     (comparePkg K) x = (extensionAsRingHom K (continuous_coe' _)) x := rfl
 
-/-- The uniform space equivalence between two abstract completions of `ratfunc K` as a ring
+/-- The uniform space equivalence between two abstract completions of `K⟮X⟯` as a ring
 equivalence: this will be the *inverse* of the fundamental one. -/
 abbrev ratfuncAdicComplRingEquiv : RatFuncAdicCompl K ≃+* K⸨X⸩ :=
   { comparePkg K with
@@ -1000,7 +1000,7 @@ abbrev ratfuncAdicComplRingEquiv : RatFuncAdicCompl K ≃+* K⸨X⸩ :=
         (extensionAsRingHom K (continuous_coe' _)).map_add]
       simp [← comparePkg_eq_extension] }
 
-/-- The uniform space equivalence between two abstract completions of `ratfunc K` as a ring
+/-- The uniform space equivalence between two abstract completions of `K⟮X⟯` as a ring
 equivalence: it goes from `K⸨X⸩` to `RatFuncAdicCompl K` -/
 abbrev LaurentSeriesRingEquiv : K⸨X⸩ ≃+* RatFuncAdicCompl K :=
   (ratfuncAdicComplRingEquiv K).symm
@@ -1015,7 +1015,7 @@ theorem ratfuncAdicComplRingEquiv_apply (x : RatFuncAdicCompl K) :
     ratfuncAdicComplRingEquiv K x = ratfuncAdicComplPkg.compare (LaurentSeriesPkg K) x := rfl
 
 theorem coe_X_compare :
-    (ratfuncAdicComplRingEquiv K) ((RatFunc.X : RatFunc K) : RatFuncAdicCompl K) =
+    (ratfuncAdicComplRingEquiv K) ((RatFunc.X : K⟮X⟯) : RatFuncAdicCompl K) =
       ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := by
   rw [PowerSeries.coe_X, ← RatFunc.coe_X, ← LaurentSeries_coe, ← compare_coe]
   rfl
@@ -1026,7 +1026,7 @@ theorem algebraMap_apply (a : K) : algebraMap K K⸨X⸩ a = HahnSeries.C a := b
 instance : Algebra K (RatFuncAdicCompl K) :=
   RingHom.toAlgebra ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C)
 
-/-- The algebra equivalence between `K⸨X⸩` and the `X`-adic completion of `RatFunc X` -/
+/-- The algebra equivalence between `K⸨X⸩` and the `X`-adic completion of `X⟮X⟯` -/
 def LaurentSeriesAlgEquiv : K⸨X⸩ ≃ₐ[K] RatFuncAdicCompl K :=
   AlgEquiv.ofRingEquiv (f := LaurentSeriesRingEquiv K)
     (fun a ↦ by simp [RingHom.algebraMap_toAlgebra])
@@ -1043,9 +1043,9 @@ theorem valuation_LaurentSeries_equal_extension :
     rfl
   · exact Valued.continuous_valuation (K := K⸨X⸩)
 
-theorem tendsto_valuation (a : (idealX K).adicCompletion (RatFunc K)) :
-    Tendsto (Valued.v : RatFunc K → ℤᵐ⁰) (comap (↑) (𝓝 a)) (𝓝 (Valued.v a : ℤᵐ⁰)) := by
-  have := Valued.is_topological_valuation (R := (idealX K).adicCompletion (RatFunc K))
+theorem tendsto_valuation (a : (idealX K).adicCompletion (K⟮X⟯)) :
+    Tendsto (Valued.v : K⟮X⟯ → ℤᵐ⁰) (comap (↑) (𝓝 a)) (𝓝 (Valued.v a : ℤᵐ⁰)) := by
+  have := Valued.is_topological_valuation (R := (idealX K).adicCompletion (K⟮X⟯))
   by_cases ha : a = 0
   · rw [tendsto_def]
     intro S hS
@@ -1066,7 +1066,7 @@ theorem tendsto_valuation (a : (idealX K).adicCompletion (RatFunc K)) :
     rintro y val_y b rfl
     rw [← Valuation.map_eq_of_sub_lt _ val_y, valuedAdicCompletion_eq_valuation']
 
-/- The extension of the `X`-adic valuation from `RatFunc K` up to its abstract completion coincides,
+/- The extension of the `X`-adic valuation from `K⟮X⟯` up to its abstract completion coincides,
 modulo the isomorphism with `K⸨X⸩`, with the `X`-adic valuation on `K⸨X⸩`. -/
 theorem valuation_compare (f : K⸨X⸩) :
     (Valued.v : (RatFuncAdicCompl K) → ℤᵐ⁰)
@@ -1081,7 +1081,7 @@ theorem valuation_compare (f : K⸨X⸩) :
 section PowerSeries
 
 /-- In order to compare `K⟦X⟧` with the valuation subring in the `X`-adic completion of
-`RatFunc K` we consider its alias as a subring of `K⸨X⸩`. -/
+`K⟮X⟯` we consider its alias as a subring of `K⸨X⸩`. -/
 abbrev powerSeries_as_subring : Subring K⸨X⸩ :=
   Subring.map (HahnSeries.ofPowerSeries ℤ K) ⊤
 
@@ -1100,17 +1100,17 @@ lemma powerSeriesEquivSubring_coe_apply (f : K⟦X⟧) :
   rfl
 
 /- Through the isomorphism `LaurentSeriesRingEquiv`, power series land in the unit ball inside the
-completion of `RatFunc K`. -/
+completion of `K⟮X⟯`. -/
 theorem mem_integers_of_powerSeries (F : K⟦X⟧) :
-    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (RatFunc K) := by
+    (LaurentSeriesRingEquiv K) F ∈ (idealX K).adicCompletionIntegers (K⟮X⟯) := by
   simp only [mem_adicCompletionIntegers, LaurentSeriesRingEquiv_def,
     valuation_compare, val_le_one_iff_eq_coe]
   exact ⟨F, rfl⟩
 
-/- Conversely, all elements in the unit ball inside the completion of `RatFunc K` come from a power
+/- Conversely, all elements in the unit ball inside the completion of `K⟮X⟯` come from a power
 series through the isomorphism `LaurentSeriesRingEquiv`. -/
 theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
-    (hx : x ∈ (idealX K).adicCompletionIntegers (RatFunc K)) :
+    (hx : x ∈ (idealX K).adicCompletionIntegers (K⟮X⟯)) :
     ∃ F : K⟦X⟧, (LaurentSeriesRingEquiv K) F = x := by
   set f := (ratfuncAdicComplRingEquiv K) x with hf
   have H_x : (LaurentSeriesPkg K).compare ratfuncAdicComplPkg ((ratfuncAdicComplRingEquiv K) x) =
@@ -1121,7 +1121,7 @@ theorem exists_powerSeries_of_memIntegers {x : RatFuncAdicCompl K}
 
 theorem powerSeries_ext_subring :
     Subring.map (LaurentSeriesRingEquiv K).toRingHom (powerSeries_as_subring K) =
-      ((idealX K).adicCompletionIntegers (RatFunc K)).toSubring := by
+      ((idealX K).adicCompletionIntegers (K⟮X⟯)).toSubring := by
   ext x
   refine ⟨fun ⟨f, ⟨F, _, coe_F⟩, hF⟩ ↦ ?_, fun H ↦ ?_⟩
   · simp only [ValuationSubring.mem_toSubring, ← hF, ← coe_F]
@@ -1131,8 +1131,8 @@ theorem powerSeries_ext_subring :
     exact ⟨F, ⟨F, trivial, rfl⟩, hF⟩
 
 /-- The ring isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
-`RatFunc K`. -/
-abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (RatFunc K) :=
+`K⟮X⟯`. -/
+abbrev powerSeriesRingEquiv : K⟦X⟧ ≃+* (idealX K).adicCompletionIntegers (K⟮X⟯) :=
   ((powerSeriesEquivSubring K).trans (LaurentSeriesRingEquiv K).subringMap).trans
     <| RingEquiv.subringCongr (powerSeries_ext_subring K)
 
@@ -1148,21 +1148,21 @@ lemma LaurentSeriesRingEquiv_mem_valuationSubring (f : K⟦X⟧) :
 
 lemma algebraMap_C_mem_adicCompletionIntegers (x : K) :
     ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C) x ∈
-      adicCompletionIntegers (RatFunc K) (idealX K) := by
+      adicCompletionIntegers (K⟮X⟯) (idealX K) := by
   have : HahnSeries.C x = ofPowerSeries ℤ K (PowerSeries.C x) := by
     simp [C_apply, ofPowerSeries_C]
   simp only [RingHom.comp_apply, RingEquiv.toRingHom_eq_coe, RingHom.coe_coe, this]
   apply LaurentSeriesRingEquiv_mem_valuationSubring
 
-instance : Algebra K ((idealX K).adicCompletionIntegers (RatFunc K)) :=
+instance : Algebra K ((idealX K).adicCompletionIntegers (K⟮X⟯)) :=
   RingHom.toAlgebra <|
     ((LaurentSeriesRingEquiv K).toRingHom.comp HahnSeries.C).codRestrict _
       (algebraMap_C_mem_adicCompletionIntegers K)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The algebra isomorphism between `K⟦X⟧` and the unit ball inside the `X`-adic completion of
-`RatFunc K`. -/
-def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (RatFunc K) := by
+`K⟮X⟯`. -/
+def powerSeriesAlgEquiv : K⟦X⟧ ≃ₐ[K] (idealX K).adicCompletionIntegers (K⟮X⟯) := by
   apply AlgEquiv.ofRingEquiv (f := powerSeriesRingEquiv K)
   intro a
   rw [PowerSeries.algebraMap_eq, RingHom.algebraMap_toAlgebra, ← Subtype.coe_inj,


### PR DESCRIPTION
This PR adds notation for RatFunc.

This syntax makes it fit nicely with preexisting notation for Polynomial, as you can see in this example:

```
Algebra.IsAlgebraic.rank_of_isFractionRing k[X] k⟮X⟯ K[X] K⟮X⟯
```

The parentheses are chosen to be like the one for `IntermediateField.adjoin` on purpose.
I think this is nice because of consistency and it's easy to remember. However this means that there's a potential clash when using a variable `X : F` that one would like to adjoin to a field.

See also related PR #35928 and discussion [#mathlib4 > Notation for Algebra.adjoin @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Notation.20for.20Algebra.2Eadjoin/near/576551144).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
