### PR TITLE
[Merged by Bors] - feat(Cache): warn when downstream project pins different dependency versions

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -429,6 +429,45 @@ into the `lean-toolchain` file at the root directory of your project"
     IO.Process.exit 1
   return ()
 
+/-- Extract the `(name, rev)` pairs from a `lake-manifest.json` file. -/
+def readManifestRevs (path : FilePath) : IO (Std.HashMap String String) := do
+  let contents ← IO.FS.readFile path
+  let .ok json := Lean.Json.parse contents | return ∅
+  let .ok packages := json.getObjValAs? (Array Lean.Json) "packages" | return ∅
+  let mut result : Std.HashMap String String := ∅
+  for pkg in packages do
+    if let (.ok name, .ok rev) :=
+        (pkg.getObjValAs? String "name", pkg.getObjValAs? String "rev") then
+      result := result.insert name rev
+  return result
+
+/-- Check if the project's `lake-manifest.json` pins shared dependencies at different versions
+than mathlib's `lake-manifest.json`. Print a warning and exit if so, since the cache will compute
+wrong hashes. -/
+def checkForManifestMismatch : IO.CacheM Unit := do
+  let mathlibDepPath := (← read).mathlibDepPath
+  let downstreamManifest := "lake-manifest.json"
+  let mathlibManifest := mathlibDepPath / "lake-manifest.json"
+  if !(← mathlibManifest.pathExists) || !(← (FilePath.mk downstreamManifest).pathExists) then
+    return
+  let downstreamRevs ← readManifestRevs downstreamManifest
+  let mathlibRevs ← readManifestRevs mathlibManifest
+  let mut mismatches : Array (String × String × String) := #[]
+  for (name, mathlibRev) in mathlibRevs do
+    if let some downstreamRev := downstreamRevs[name]? then
+      if downstreamRev != mathlibRev then
+        mismatches := mismatches.push (name, downstreamRev, mathlibRev)
+  unless mismatches.isEmpty do
+    IO.println "Warning: your project pins different versions of some dependencies than Mathlib."
+    IO.println "This will cause `lake exe cache get` to compute wrong hashes.\n"
+    for (name, downstreamRev, mathlibRev) in mismatches do
+      IO.println s!"  {name}:"
+      IO.println s!"    project: {downstreamRev.take 12}"
+      IO.println s!"    mathlib: {mathlibRev.take 12}"
+    IO.println "\nRemove these dependencies from your lakefile and let them come \
+      transitively from Mathlib."
+    IO.Process.exit 1
+
 /-- Fetches the ProofWidgets cloud release and prunes non-JS files. -/
 def getProofWidgets (buildDir : FilePath) : IO Unit := do
   if (← buildDir.pathExists) then
@@ -477,7 +516,9 @@ def getFiles
     (forceDownload forceUnpack parallel decompress skipProofWidgets : Bool)
     : IO.CacheM Unit := do
   let isMathlibRoot ← IO.isMathlibRoot
-  unless isMathlibRoot do checkForToolchainMismatch
+  unless isMathlibRoot do
+    checkForToolchainMismatch
+    checkForManifestMismatch
   if skipProofWidgets then
     IO.println "Skipping ProofWidgets release fetch"
   else

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -7,6 +7,7 @@ Authors: Arthur Paulino
 import Batteries.Data.String.Matcher
 import Cache.Hashing
 import Cache.Init
+import Lake.Load.Manifest
 
 namespace Cache.Requests
 
@@ -429,43 +430,57 @@ into the `lean-toolchain` file at the root directory of your project"
     IO.Process.exit 1
   return ()
 
-/-- Extract the `(name, rev)` pairs from a `lake-manifest.json` file. -/
-def readManifestRevs (path : FilePath) : IO (Std.HashMap String String) := do
-  let contents ← IO.FS.readFile path
-  let .ok json := Lean.Json.parse contents | return ∅
-  let .ok packages := json.getObjValAs? (Array Lean.Json) "packages" | return ∅
-  let mut result : Std.HashMap String String := ∅
-  for pkg in packages do
-    if let (.ok name, .ok rev) :=
-        (pkg.getObjValAs? String "name", pkg.getObjValAs? String "rev") then
-      result := result.insert name rev
-  return result
+/-- A human-readable description of a manifest package entry's source. -/
+def packageEntrySrcDesc (entry : Lake.PackageEntry) : String :=
+  match entry.src with
+  | .git _ rev _ _ => (rev.take 12).toString
+  | .path dir => s!"path:{dir}"
+
+/-- Check whether two manifest package entries refer to the same source. -/
+def packageEntrySrcMatch (a b : Lake.PackageEntry) : Bool :=
+  match a.src, b.src with
+  | .git urlA revA _ subDirA, .git urlB revB _ subDirB =>
+    urlA == urlB && revA == revB && subDirA == subDirB
+  | .path dirA, .path dirB => dirA == dirB
+  | _, _ => false
 
 /-- Check if the project's `lake-manifest.json` pins shared dependencies at different versions
 than mathlib's `lake-manifest.json`. Print a warning and exit if so, since the cache will compute
 wrong hashes. -/
 def checkForManifestMismatch : IO.CacheM Unit := do
   let mathlibDepPath := (← read).mathlibDepPath
-  let downstreamManifest := "lake-manifest.json"
-  let mathlibManifest := mathlibDepPath / "lake-manifest.json"
-  if !(← mathlibManifest.pathExists) || !(← (FilePath.mk downstreamManifest).pathExists) then
-    return
-  let downstreamRevs ← readManifestRevs downstreamManifest
-  let mathlibRevs ← readManifestRevs mathlibManifest
-  let mut mismatches : Array (String × String × String) := #[]
-  for (name, mathlibRev) in mathlibRevs do
-    if let some downstreamRev := downstreamRevs[name]? then
-      if downstreamRev != mathlibRev then
-        mismatches := mismatches.push (name, downstreamRev, mathlibRev)
-  unless mismatches.isEmpty do
+  let downstreamEntries ← Lake.Manifest.tryLoadEntries "lake-manifest.json"
+  let mathlibEntries ← Lake.Manifest.tryLoadEntries (mathlibDepPath / "lake-manifest.json")
+  let downstreamByName : Std.HashMap Lean.Name Lake.PackageEntry :=
+    downstreamEntries.foldl (init := ∅) fun m e => m.insert e.name e
+  let mut directMismatches : Array (String × String × String) := #[]
+  let mut inheritedMismatches : Array (String × String × String) := #[]
+  for mathlibEntry in mathlibEntries do
+    if let some downstreamEntry := downstreamByName[mathlibEntry.name]? then
+      unless packageEntrySrcMatch mathlibEntry downstreamEntry do
+        let name := mathlibEntry.name.toString
+        let downstreamDesc := packageEntrySrcDesc downstreamEntry
+        let mathlibDesc := packageEntrySrcDesc mathlibEntry
+        if downstreamEntry.inherited then
+          inheritedMismatches := inheritedMismatches.push (name, downstreamDesc, mathlibDesc)
+        else
+          directMismatches := directMismatches.push (name, downstreamDesc, mathlibDesc)
+  let allMismatches := directMismatches ++ inheritedMismatches
+  unless allMismatches.isEmpty do
     IO.println "Warning: your project pins different versions of some dependencies than Mathlib."
     IO.println "This will cause `lake exe cache get` to compute wrong hashes.\n"
-    for (name, downstreamRev, mathlibRev) in mismatches do
+    for (name, downstreamDesc, mathlibDesc) in allMismatches do
       IO.println s!"  {name}:"
-      IO.println s!"    project: {downstreamRev.take 12}"
-      IO.println s!"    mathlib: {mathlibRev.take 12}"
-    IO.println "\nRemove these dependencies from your lakefile and let them come \
-      transitively from Mathlib."
+      IO.println s!"    project: {downstreamDesc}"
+      IO.println s!"    mathlib: {mathlibDesc}"
+    if !directMismatches.isEmpty then
+      IO.println "\nRemove these dependencies from your lakefile and let them come \
+        transitively from Mathlib."
+    if !inheritedMismatches.isEmpty then
+      IO.println "\nSome mismatched dependencies come transitively from other packages \
+        in your lakefile. \
+        Try putting `require mathlib` last in your lakefile so that Mathlib's versions take \
+        precedence, then run `lake update`."
     IO.Process.exit 1
 
 /-- Fetches the ProofWidgets cloud release and prunes non-JS files. -/


### PR DESCRIPTION
This PR adds a check in `lake exe cache get` that detects when a downstream project's `lake-manifest.json` pins shared dependencies at different sources than mathlib's manifest. When this happens, `lake exe cache get` computes wrong hashes (because `LEAN_SRC_PATH` resolves source files from the downstream project's dependency versions) and downloads 0 files with no explanation.

Uses `Lake.Manifest.tryLoadEntries` and `Lake.PackageEntry` rather than hand-rolling JSON parsing. Compares the full source (url, rev, subDir) not just rev, and also detects git-vs-path mismatches.

Distinguishes direct vs inherited (transitive) dependencies via `PackageEntry.inherited`, giving different advice for each case:

- Direct deps: "Remove these dependencies from your lakefile and let them come transitively from Mathlib."
- Inherited deps (e.g. via doc-gen): "Try putting `require mathlib` last in your lakefile so that Mathlib's versions take precedence, then run `lake update`."

Context: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.60lake.20exe.20cache.20get.60.20does.20not.20download.20mathlib/near/577412808

🤖 Prepared with Claude Code