### PR TITLE
[Merged by Bors] - feat: integral of the evaluation map

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -152,7 +152,7 @@ lemma integral_comp_eval [NormedSpace ℝ E] [∀ i, IsProbabilityMeasure (μ i)
 lemma integral_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, NormedSpace ℝ (X i)]
     [∀ i, IsProbabilityMeasure (μ i)] {i : ι} [OpensMeasurableSpace (X i)]
     [SecondCountableTopology (X i)] :
-    ∫ x : Π i, X i, x i ∂Measure.pi μ = ∫ x, x ∂μ i :=
+    ∫ x, x i ∂Measure.pi μ = ∫ x, x ∂μ i :=
   integral_comp_eval aestronglyMeasurable_id
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -136,8 +136,8 @@ lemma integrable_comp_eval [∀ i, IsFiniteMeasure (μ i)] {i : ι} {f : X i →
   rw [Measure.pi_map_eval]
   exact hf.smul_measure <| ENNReal.prod_ne_top (by finiteness)
 
-lemma integrable_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, NormedSpace ℝ (X i)]
-    [∀ i, IsFiniteMeasure (μ i)] {i : ι} (h : Integrable id (μ i)) :
+lemma integrable_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, IsFiniteMeasure (μ i)] {i : ι}
+    (h : Integrable id (μ i)) :
     Integrable (fun x ↦ x i) (Measure.pi μ) :=
   integrable_comp_eval h
 

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -136,11 +136,23 @@ lemma integrable_comp_eval [∀ i, IsFiniteMeasure (μ i)] {i : ι} {f : X i →
   rw [Measure.pi_map_eval]
   exact hf.smul_measure <| ENNReal.prod_ne_top (by finiteness)
 
+lemma integrable_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, NormedSpace ℝ (X i)]
+    [∀ i, IsFiniteMeasure (μ i)] {i : ι} [OpensMeasurableSpace (X i)]
+    [SecondCountableTopology (X i)] (h : Integrable id (μ i)) :
+    Integrable (fun x ↦ x i) (Measure.pi μ) :=
+  integrable_comp_eval h
+
 lemma integral_comp_eval [NormedSpace ℝ E] [∀ i, IsProbabilityMeasure (μ i)] {i : ι} {f : X i → E}
     (hf : AEStronglyMeasurable f (μ i)) :
     ∫ x : Π i, X i, f (x i) ∂Measure.pi μ = ∫ x, f x ∂μ i := by
   rw [← (measurePreserving_eval μ i).map_eq, integral_map]
   · exact Measurable.aemeasurable (by fun_prop)
   · rwa [(measurePreserving_eval μ i).map_eq]
+
+lemma integral_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, NormedSpace ℝ (X i)]
+    [∀ i, IsProbabilityMeasure (μ i)] {i : ι} [OpensMeasurableSpace (X i)]
+    [SecondCountableTopology (X i)] :
+    ∫ x : Π i, X i, x i ∂Measure.pi μ = ∫ x, x ∂μ i :=
+  integral_comp_eval aestronglyMeasurable_id
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -137,8 +137,7 @@ lemma integrable_comp_eval [∀ i, IsFiniteMeasure (μ i)] {i : ι} {f : X i →
   exact hf.smul_measure <| ENNReal.prod_ne_top (by finiteness)
 
 lemma integrable_eval [∀ i, NormedAddCommGroup (X i)] [∀ i, NormedSpace ℝ (X i)]
-    [∀ i, IsFiniteMeasure (μ i)] {i : ι} [OpensMeasurableSpace (X i)]
-    [SecondCountableTopology (X i)] (h : Integrable id (μ i)) :
+    [∀ i, IsFiniteMeasure (μ i)] {i : ι} (h : Integrable id (μ i)) :
     Integrable (fun x ↦ x i) (Measure.pi μ) :=
   integrable_comp_eval h
 


### PR DESCRIPTION
`∫ x, x i ∂Measure.pi μ = ∫ x, x ∂μ i`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
