### PR TITLE
[Merged by Bors] - feat: (continuous) bilinear map

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7133,6 +7133,7 @@ public import Mathlib.Topology.Algebra.Module.Compact
 public import Mathlib.Topology.Algebra.Module.Determinant
 public import Mathlib.Topology.Algebra.Module.Equiv
 public import Mathlib.Topology.Algebra.Module.FiniteDimension
+public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
 public import Mathlib.Topology.Algebra.Module.LinearMap
 public import Mathlib.Topology.Algebra.Module.LinearMapPiProd
 public import Mathlib.Topology.Algebra.Module.LinearPMap

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -612,7 +612,8 @@ variable
 /-- Bundled statement of bilinearity for a function.
 
 The bundled type `E →ₗ[R] F →ₗ[R] G` should be preferred in cases where that can be used.
-`IsBilinearMap` can be useful to have `IsBilinearMap (myFunction ..)` as a hypothesis to a declaration. -/
+`IsBilinearMap` can be useful to have `IsBilinearMap (myFunction ..)` as a hypothesis to a
+declaration. -/
 structure IsBilinearMap (f : E → F → G) : Prop where
   add_left : ∀ (x₁ x₂ : E) (y : F), f (x₁ + x₂) y = f x₁ y + f x₂ y
   smul_left : ∀ (c : R) (x : E) (y : F), f (c • x) y = c • f x y

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -625,8 +625,4 @@ def IsBilinearMap.toLinearMap {f : E → F → G} (hf : IsBilinearMap R f) :
     E →ₗ[R] F →ₗ[R] G :=
   LinearMap.mk₂ _ f hf.add_left hf.smul_left hf.add_right hf.smul_right
 
-/-- Evaluation of linear maps is bilinear. -/
-lemma isBilinearMap_eval : IsBilinearMap R (fun (e : E) (φ : E →ₗ[R] F) ↦ φ e) := by
-  constructor <;> simp
-
 end IsBilinearMap

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -65,6 +65,7 @@ variable [SMulCommClass S₂ R P₂]
 variable {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
 variable (ρ₁₂ σ₁₂)
 
+-- TODO: refactor to use a structure holding the assumptions, as in `IsBilinearMap` below.
 /-- Create a bilinear map from a function that is semilinear in each component.
 See `mk₂'` and `mk₂` for the linear case. -/
 def mk₂'ₛₗ (f : M → N → P) (H1 : ∀ m₁ m₂ n, f (m₁ + m₂) n = f m₁ n + f m₂ n)
@@ -598,3 +599,31 @@ lemma restrictScalarsRange₂_apply_eq_zero_iff (m : M') (n : N') :
 end restrictScalarsRange₂
 
 end LinearMap
+
+section IsBilinearMap
+
+variable
+  (R : Type*) [CommSemiring R]
+  {E : Type*} [AddCommMonoid E] [Module R E]
+  {F : Type*} [AddCommMonoid F] [Module R F]
+  {G : Type*} [AddCommMonoid G] [Module R G]
+
+-- TODO Also make a semi-linear version.
+/-- Bundled statement of bilinearity for a function. -/
+structure IsBilinearMap (f : E → F → G) : Prop where
+  add_left : ∀ (x₁ x₂ : E) (y : F), f (x₁ + x₂) y = f x₁ y + f x₂ y
+  smul_left : ∀ (c : R) (x : E) (y : F), f (c • x) y = c • f x y
+  add_right : ∀ (x : E) (y₁ y₂ : F), f x (y₁ + y₂) = f x y₁ + f x y₂
+  smul_right : ∀ (c : R) (x : E) (y : F), f x (c • y) = c • f x y
+
+variable {R} in
+/-- Make a bilinear map from a function and a bundled statement of bilinearity. -/
+def IsBilinearMap.toLinearMap {f : E → F → G} (hf : IsBilinearMap R f) :
+    E →ₗ[R] F →ₗ[R] G :=
+  LinearMap.mk₂ _ f hf.add_left hf.smul_left hf.add_right hf.smul_right
+
+/-- Evaluation of linear maps is bilinear. -/
+lemma isBilinearMap_eval : IsBilinearMap R (fun (e : E) (φ : E →ₗ[R] F) ↦ φ e) := by
+  constructor <;> simp
+
+end IsBilinearMap

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -609,7 +609,10 @@ variable
   {G : Type*} [AddCommMonoid G] [Module R G]
 
 -- TODO Also make a semi-linear version.
-/-- Bundled statement of bilinearity for a function. -/
+/-- Bundled statement of bilinearity for a function. 
+
+The bundled type `E →ₗ[R] F →ₗ[R] G` should be preferred in cases where that can be used.
+`IsBilinearMap` can be useful to have `IsBilinearMap (myFunction ..)` as a hypothesis to a declaration. -/
 structure IsBilinearMap (f : E → F → G) : Prop where
   add_left : ∀ (x₁ x₂ : E) (y : F), f (x₁ + x₂) y = f x₁ y + f x₂ y
   smul_left : ∀ (c : R) (x : E) (y : F), f (c • x) y = c • f x y

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -609,7 +609,7 @@ variable
   {G : Type*} [AddCommMonoid G] [Module R G]
 
 -- TODO Also make a semi-linear version.
-/-- Bundled statement of bilinearity for a function. 
+/-- Bundled statement of bilinearity for a function.
 
 The bundled type `E →ₗ[R] F →ₗ[R] G` should be preferred in cases where that can be used.
 `IsBilinearMap` can be useful to have `IsBilinearMap (myFunction ..)` as a hypothesis to a declaration. -/

--- a/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
@@ -35,13 +35,36 @@ variable
 
 /-- Building continuous bilinear maps from bilinear maps between finite dimensional topological
   vector spaces over a complete field. -/
-def IsBilinearMap.toContinuousLinearMap
-    {f : E → F → G} (h : IsBilinearMap 𝕜 f) : E →L[𝕜] F →L[𝕜] G :=
-  IsLinearMap.mk' (fun x : E ↦ h.toLinearMap x |>.toContinuousLinearMap)
+def LinearMap.toContinuousBilinearMap (f : E →ₗ[𝕜] F →ₗ[𝕜] G) : E →L[𝕜] F →L[𝕜] G :=
+  IsLinearMap.mk' (fun x : E ↦ f x |>.toContinuousLinearMap)
       (by constructor <;> (intros;simp)) |>.toContinuousLinearMap
 
-variable (𝕜 E F)
+@[simp]
+lemma LinearMap.toContinuousBilinearMap_apply (f : E →ₗ[𝕜] F →ₗ[𝕜] G) (x : E) (y : F) :
+  f.toContinuousBilinearMap x y = f x y := rfl
 
-def evalL : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
-  haveI : IsBilinearMap 𝕜 fun e (φ : E →L[𝕜] F) ↦ φ e := by constructor <;> simp
-  this.toContinuousLinearMap
+/-- Building continuous bilinear maps from bilinear functions between finite dimensional topological
+  vector spaces over a complete field. -/
+def IsBilinearMap.toContinuousBilinearMap
+    {f : E → F → G} (h : IsBilinearMap 𝕜 f) : E →L[𝕜] F →L[𝕜] G :=
+  h.toLinearMap |>.toContinuousBilinearMap
+
+@[simp]
+lemma IsBilinearMap.toContinuousBilinearMap_apply {f : E → F → G} (h : IsBilinearMap 𝕜 f)
+    (x : E) (y : F) :
+  h.toContinuousBilinearMap x y = f x y := rfl
+
+variable (𝕜 E F) in
+/-- Evaluation of continuous linear maps as a continuous linear map in the
+case of finite dimensional topological vector spaces over a complete field.
+See also `ContinuousLinearMap.apply` for the case of normed spaces.
+
+TODO: generalize the two constructions in the setting of maps from a bornological space to a locally
+convex one, or define a `NormableSpace` class to deduce this case from the normed case:
+-/
+def ContinuousLinearMap.evalL : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
+  LinearMap.toContinuousLinearMap.symm.toLinearMap |>.flip |>.toContinuousBilinearMap
+
+@[simp]
+lemma ContinuousLinearMap.evalL_apply (x : E) (φ : E →L[𝕜] F) : φ.evalL 𝕜 E F x = φ x := rfl
+

--- a/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
@@ -11,7 +11,7 @@ public import Mathlib.Topology.Algebra.Module.StrongTopology
 /-!
 # Building continuous bilinear maps in finite dimensions over complete fields
 
-Given a complete nontrivially normed field `𝕜` and finite dimension T₂ topological vector spaces
+Given a complete nontrivially normed field `𝕜` and finite dimensional T₂ topological vector spaces
 over `𝕜`, this file builds a continuous bilinear map from any bilinear function.
 
 This applies in particular to evaluation of linear maps between such spaces.
@@ -47,7 +47,7 @@ lemma LinearMap.toContinuousBilinearMap_apply (f : E →ₗ[𝕜] F →ₗ[𝕜]
   vector spaces over a complete field. -/
 def IsBilinearMap.toContinuousBilinearMap
     {f : E → F → G} (h : IsBilinearMap 𝕜 f) : E →L[𝕜] F →L[𝕜] G :=
-  h.toLinearMap |>.toContinuousBilinearMap
+  h.toLinearMap.toContinuousBilinearMap
 
 @[simp]
 lemma IsBilinearMap.toContinuousBilinearMap_apply {f : E → F → G} (h : IsBilinearMap 𝕜 f)
@@ -60,7 +60,7 @@ case of finite dimensional topological vector spaces over a complete field.
 See also `ContinuousLinearMap.apply` for the case of normed spaces.
 
 TODO: generalize the two constructions in the setting of maps from a bornological space to a locally
-convex one, or define a `NormableSpace` class to deduce this case from the normed case:
+convex one, or define a `NormableSpace` class to deduce this case from the normed case.
 -/
 def ContinuousLinearMap.evalL : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
   LinearMap.toContinuousLinearMap.symm.toLinearMap |>.flip |>.toContinuousBilinearMap

--- a/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
@@ -67,4 +67,3 @@ def ContinuousLinearMap.evalL : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
 
 @[simp]
 lemma ContinuousLinearMap.evalL_apply (x : E) (φ : E →L[𝕜] F) : φ.evalL 𝕜 E F x = φ x := rfl
-

--- a/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2025 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Michael Rothgang
+-/
+module
+
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
+public import Mathlib.Topology.Algebra.Module.StrongTopology
+
+/-!
+# Building continuous bilinear maps in finite dimensions over complete fields
+
+Given a complete nontrivially normed field `𝕜` and finite dimension T₂ topological vector spaces
+over `𝕜`, this file builds a continuous bilinear map from any bilinear function.
+
+This applies in particular to evaluation of linear maps between such spaces.
+
+Working with topological vector spaces instead of normed spaces is important for applications in the
+differential geometry part of Mathlib where we don’t want to fix a norm on tangent spaces for
+instance.
+
+-/
+
+@[expose] public section
+
+variable
+    {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+    {E : Type*} [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
+    [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E] [FiniteDimensional 𝕜 E] [T2Space E]
+    {F : Type*} [AddCommGroup F] [Module 𝕜 F] [TopologicalSpace F]
+    [IsTopologicalAddGroup F] [ContinuousSMul 𝕜 F] [FiniteDimensional 𝕜 F] [T2Space F]
+    {G : Type*} [AddCommGroup G] [Module 𝕜 G] [TopologicalSpace G]
+    [IsTopologicalAddGroup G] [ContinuousSMul 𝕜 G]
+
+/-- Building continuous bilinear maps from bilinear maps between finite dimensional topological
+  vector spaces over a complete field. -/
+def IsBilinearMap.toContinuousLinearMap
+    {f : E → F → G} (h : IsBilinearMap 𝕜 f) : E →L[𝕜] F →L[𝕜] G :=
+  IsLinearMap.mk' (fun x : E ↦ h.toLinearMap x |>.toContinuousLinearMap)
+      (by constructor <;> (intros;simp)) |>.toContinuousLinearMap
+
+variable (𝕜 E F)
+
+def evalL : E →L[𝕜] (E →L[𝕜] F) →L[𝕜] F :=
+  haveI : IsBilinearMap 𝕜 fun e (φ : E →L[𝕜] F) ↦ φ e := by constructor <;> simp
+  this.toContinuousLinearMap


### PR DESCRIPTION
On the path towards Riemannian geometry.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
