### PR TITLE
[Merged by Bors] - feat(NumberTheory/NumberField/InfiniteAdeleRing): norm and product formula for the infinite adele ring

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
@@ -5,6 +5,7 @@ Authors: Salvatore Mercuri, María Inés de Frutos-Fernández
 -/
 module
 
+public import Mathlib.Algebra.Group.Pi.Units
 public import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.Completion
 
@@ -113,6 +114,30 @@ theorem denseRange_algebraMap [NumberField K] : DenseRange <| algebraMap K (Infi
   (DenseRange.piMap fun _ => UniformSpace.Completion.denseRange_coe).comp
     (InfinitePlace.denseRange_algebraMap_pi K)
       (.piMap fun _ => UniformSpace.Completion.continuous_coe _)
+
+/-- The norm on the infinite adele ring is given by the product of the normalized norms
+across infinite places. The normalized norm is the real norm at real places and the
+square of the complex norm at complex places. -/
+instance [NumberField K] : Norm (InfiniteAdeleRing K) where
+  norm x := ∏ v, ‖x v‖ ^ v.mult
+
+variable {K}
+
+theorem norm_def [NumberField K] (x : InfiniteAdeleRing K) :
+    ‖x‖ = ∏ v, ‖x v‖ ^ v.mult := rfl
+
+set_option backward.isDefEq.respectTransparency false in
+theorem norm_eq_zero_of_not_isUnit [NumberField K] {x : InfiniteAdeleRing K} (hx : ¬IsUnit x) :
+    ‖x‖ = 0 := by
+  rw [Pi.isUnit_iff, not_forall] at hx
+  obtain ⟨v, hv⟩ := hx
+  exact Finset.prod_eq_zero_iff.2 ⟨v, Finset.mem_univ v, by simpa [isUnit_iff_ne_zero] using hv⟩
+
+/-- The product formula for the infinite adele ring. This is the adelic version of
+`NumberField.InfinitePlace.prod_eq_abs_norm`. -/
+theorem coe_norm_eq_abs_norm [NumberField K] (x : K) :
+    ‖algebraMap K (InfiniteAdeleRing K) x‖ = |Algebra.norm ℚ x| := by
+  simpa [-Rat.cast_abs, norm_def] using InfinitePlace.prod_eq_abs_norm x
 
 end InfiniteAdeleRing
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
