### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): extract characterization of topology in terms of subobject classifier

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Closed.lean
+++ b/Mathlib/CategoryTheory/Sites/Closed.lean
@@ -209,27 +209,35 @@ theorem classifier_isSheaf : Presieve.IsSheaf J₁ (Functor.closedSieves J₁) :
     rw [← J₁.pullback_close, this _ hf]
     apply le_antisymm (J₁.le_close_of_isClosed le_rfl (x f hf).2) (J₁.le_close _)
 
+/-- A sieve `S` is covering for `J` if and only if the subobject classifier
+is a sheaf for `S`. -/
+lemma GrothendieckTopology.mem_iff_isSheafFor_closedSieves
+    (J : GrothendieckTopology C) {X : C} (S : Sieve X) :
+    S ∈ J X ↔ Presieve.IsSheafFor (Functor.closedSieves J) S.arrows := by
+  refine ⟨fun hS ↦ classifier_isSheaf _ _ hS, fun H ↦ ?_⟩
+  rw [← J.close_eq_top_iff_mem]
+  have : J.IsClosed (⊤ : Sieve X) := by
+    intro Y f _
+    trivial
+  suffices (⟨J.close S, J.close_isClosed S⟩ : Subtype _) = ⟨⊤, this⟩ by
+    rw [Subtype.ext_iff] at this
+    exact this
+  refine H.isSeparatedFor.ext fun Y f hf ↦ ?_
+  simp only [Functor.closedSieves_obj]
+  ext1
+  dsimp
+  rw [Sieve.pullback_top, ← J.pullback_close, S.pullback_eq_top_of_mem hf,
+    J.close_eq_top_iff_mem]
+  apply J.top_mem
+
 /-- If presheaf of `J₁`-closed sieves is a `J₂`-sheaf then `J₁ ≤ J₂`. Note the converse is true by
 `classifier_isSheaf` and `isSheaf_of_le`.
 -/
 theorem le_topology_of_closedSieves_isSheaf {J₁ J₂ : GrothendieckTopology C}
     (h : Presieve.IsSheaf J₁ (Functor.closedSieves J₂)) : J₁ ≤ J₂ := by
   intro X S hS
-  rw [← J₂.close_eq_top_iff_mem]
-  have : J₂.IsClosed (⊤ : Sieve X) := by
-    intro Y f _
-    trivial
-  suffices (⟨J₂.close S, J₂.close_isClosed S⟩ : Subtype _) = ⟨⊤, this⟩ by
-    rw [Subtype.ext_iff] at this
-    exact this
-  apply (h S hS).isSeparatedFor.ext
-  intro Y f hf
-  simp only [Functor.closedSieves_obj]
-  ext1
-  dsimp
-  rw [Sieve.pullback_top, ← J₂.pullback_close, S.pullback_eq_top_of_mem hf,
-    J₂.close_eq_top_iff_mem]
-  apply J₂.top_mem
+  rw [GrothendieckTopology.mem_iff_isSheafFor_closedSieves]
+  exact h _ hS
 
 /-- If being a sheaf for `J₁` is equivalent to being a sheaf for `J₂`, then `J₁ = J₂`. -/
 theorem topology_eq_iff_same_sheaves {J₁ J₂ : GrothendieckTopology C} :


### PR DESCRIPTION
We extract the following marvelous lemma from an existing proof by Bhavik Mehta: Let `J` be a Grothendieck topology and `S` a sieve. Then `S` is covering for `J` if and only if the subobject classifier of `Sheaf J (Type max u v)` (the sheaf of closed `J`-sieves) is a sheaf for `S`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
