### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Affine): (pseudo)metric on `V →ᴬ[𝕜] Q`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -6,6 +6,7 @@ Authors: Oliver Nash
 module
 
 public import Mathlib.Topology.Algebra.ContinuousAffineMap
+public import Mathlib.Topology.MetricSpace.TransferInstance
 public import Mathlib.Analysis.Normed.Operator.NormedSpace
 public import Mathlib.Analysis.Normed.Group.AddTorsor
 
@@ -40,11 +41,13 @@ submultiplicative: for a composition of maps, we have only `‖f.comp g‖ ≤ �
 
 namespace ContinuousAffineMap
 
-variable {𝕜 R V W W₂ : Type*}
-variable [NormedAddCommGroup V] [NormedAddCommGroup W] [NormedAddCommGroup W₂]
-variable [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 V] [NormedSpace 𝕜 W] [NormedSpace 𝕜 W₂]
+variable {𝕜 R V W W₂ Q : Type*}
 
-section NormedSpaceStructure
+section Seminormed
+
+variable [SeminormedAddCommGroup V] [SeminormedAddCommGroup W] [SeminormedAddCommGroup W₂]
+variable [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 V] [NormedSpace 𝕜 W] [NormedSpace 𝕜 W₂]
+variable [PseudoMetricSpace Q] [NormedAddTorsor W Q]
 
 variable (f : V →ᴬ[𝕜] W)
 
@@ -69,34 +72,17 @@ theorem norm_eq (h : f 0 = 0) : ‖f‖ = ‖f.contLinear‖ :=
     _ = max 0 ‖f.contLinear‖ := by rw [h, norm_zero]
     _ = ‖f.contLinear‖ := max_eq_right (norm_nonneg _)
 
-noncomputable instance : NormedAddCommGroup (V →ᴬ[𝕜] W) :=
-  AddGroupNorm.toNormedAddCommGroup
-    { toFun := fun f => max ‖f 0‖ ‖f.contLinear‖
-      map_zero' := by simp [(ContinuousAffineMap.zero_apply)]
-      neg' := fun f => by
-        simp [(ContinuousAffineMap.neg_apply)]
-      add_le' := fun f g => by
-        simp only [coe_add, max_le_iff, Pi.add_apply, add_contLinear]
-        exact
-          ⟨(norm_add_le _ _).trans (add_le_add (le_max_left _ _) (le_max_left _ _)),
-            (norm_add_le _ _).trans (add_le_add (le_max_right _ _) (le_max_right _ _))⟩
-      eq_zero_of_map_eq_zero' := fun f h₀ => by
-        rcases max_eq_iff.mp h₀ with (⟨h₁, h₂⟩ | ⟨h₁, h₂⟩) <;> rw [h₁] at h₂
-        · rw [norm_le_zero_iff, contLinear_eq_zero_iff_exists_const] at h₂
-          obtain ⟨q, rfl⟩ := h₂
-          simp only [norm_eq_zero, coe_const, Function.const_apply] at h₁
-          rw [h₁]
-          rfl
-        · rw [norm_eq_zero, contLinear_eq_zero_iff_exists_const] at h₁
-          obtain ⟨q, rfl⟩ := h₁
-          simp only [norm_le_zero_iff, coe_const, Function.const_apply] at h₂
-          rw [h₂]
-          rfl }
+noncomputable instance : PseudoMetricSpace (V →ᴬ[𝕜] Q) :=
+  (decompEquiv 𝕜 V Q).pseudometricSpace
+
+noncomputable instance : SeminormedAddCommGroup (V →ᴬ[𝕜] W) where
+  dist_eq _ _ := dist_eq_norm_neg_add (E := W × (V →L[𝕜] W)) _ _
+
+noncomputable instance : NormedAddTorsor (V →ᴬ[𝕜] W) (V →ᴬ[𝕜] Q) where
+  dist_eq_norm' _ _ := dist_eq_norm_vsub (P := Q × (V →L[𝕜] W)) _ _ _
 
 noncomputable instance : NormedSpace 𝕜 (V →ᴬ[𝕜] W) where
-  norm_smul_le t f := by
-    simp only [norm_def, coe_smul, Pi.smul_apply, norm_smul, smul_contLinear,
-      ← mul_max_of_nonneg _ _ (norm_nonneg t), le_refl]
+  norm_smul_le t f := norm_smul_le t (f 0, f.contLinear)
 
 theorem norm_comp_le (g : W₂ →ᴬ[𝕜] V) : ‖f.comp g‖ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by
   rw [norm_def, max_le_iff]
@@ -158,6 +144,21 @@ theorem toConstProdContinuousLinearMap_snd (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).snd = f.contLinear :=
   rfl
 
-end NormedSpaceStructure
+end Seminormed
+
+section Normed
+
+variable [NormedAddCommGroup V] [NormedAddCommGroup W]
+variable [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 V] [NormedSpace 𝕜 W]
+variable [MetricSpace Q] [NormedAddTorsor W Q]
+
+noncomputable instance : MetricSpace (V →ᴬ[𝕜] Q) :=
+  (decompEquiv 𝕜 V Q).metricSpace
+
+noncomputable instance : NormedAddCommGroup (V →ᴬ[𝕜] W) where
+  __ : SeminormedAddCommGroup (V →ᴬ[𝕜] W) := inferInstance
+  __ : MetricSpace (V →ᴬ[𝕜] W) := inferInstance
+
+end Normed
 
 end ContinuousAffineMap

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -44,7 +44,7 @@ instance (priority := 100) NormedAddTorsor.toAddTorsor' {V P : Type*} [NormedAdd
   NormedAddTorsor.toAddTorsor
 
 variable {α V P W Q : Type*} [SeminormedAddCommGroup V] [PseudoMetricSpace P] [NormedAddTorsor V P]
-  [NormedAddCommGroup W] [MetricSpace Q] [NormedAddTorsor W Q]
+  [SeminormedAddCommGroup W] [PseudoMetricSpace Q] [NormedAddTorsor W Q]
 
 instance (priority := 100) NormedAddTorsor.to_isIsIsometricVAdd : IsIsometricVAdd V P :=
   ⟨fun c => Isometry.of_dist_eq fun x y => by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #36083 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
