### PR TITLE
[Merged by Bors] - feat: some lemmas about finite index subgroups/submodules

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Map.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Map.lean
@@ -297,6 +297,11 @@ def subgroupOfEquivOfLe {G : Type*} [Group G] {H K : Subgroup G} (h : H ≤ K) :
   invFun g := ⟨⟨g.1, h g.2⟩, g.2⟩
   map_mul' _g _h := rfl
 
+@[to_additive]
+lemma subgroupOf_mono {G : Type*} [Group G] {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) (h : H₁ ≤ H₂) :
+    H₁.subgroupOf H₃ ≤ H₂.subgroupOf H₃ :=
+  comap_mono h
+
 @[to_additive (attr := simp)]
 theorem comap_subtype (H K : Subgroup G) : H.comap K.subtype = H.subgroupOf K :=
   rfl

--- a/Mathlib/Algebra/Group/Subgroup/Map.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Map.lean
@@ -298,7 +298,7 @@ def subgroupOfEquivOfLe {G : Type*} [Group G] {H K : Subgroup G} (h : H ≤ K) :
   map_mul' _g _h := rfl
 
 @[to_additive]
-lemma subgroupOf_mono {G : Type*} [Group G] {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) (h : H₁ ≤ H₂) :
+lemma subgroupOf_mono {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) (h : H₁ ≤ H₂) :
     H₁.subgroupOf H₃ ≤ H₂.subgroupOf H₃ :=
   comap_mono h
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -234,14 +234,16 @@ lemma fg_toAddSubgroup {A : Submodule R M} (hfg : A.FG) : A.toAddSubgroup.FG := 
     rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
   exact FG.restrictScalars hfg
 
+open AddSubgroup in
 /-- If `A` and `B` are two submodules of the `R`-algebra `M`, where `R` is finitely generated
 as a `ℤ`-module, `A` is finitely generated, and `B` contains `n • A`, then `B` has finite
 relative index in `A`. -/
 lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R K} {n : ℕ} (hn : n ≠ 0)
     (hfg : A.FG) (h : A.map (LinearMap.mulLeft R (n : K)) ≤ B) :
     B.toAddSubgroup.IsFiniteRelIndex A.toAddSubgroup := by
-  refine A.toAddSubgroup.isFiniteRelIndex_of_range_nsmulAddMonoidHom_le B.toAddSubgroup
-    (fg_toAddSubgroup hfg) hn ?_
+  have := fg_toAddSubgroup hfg
+  have := isFiniteRelIndex_map_nsmulAddMonoidHom_of_fg this hn
+  refine isFiniteRelIndex_of_le (H₁ := A.toAddSubgroup.map (nsmulAddMonoidHom n)) A.toAddSubgroup ?_
   rw [SetLike.le_def] at h ⊢
   simpa using h
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -196,19 +196,11 @@ end CommGroup
 namespace Subgroup
 
 @[to_additive]
-lemma isTorsion_quotient_range_powMonoidHom (A : Type*) [CommGroup A] {n : ℕ} (hn : n ≠ 0) :
-    Monoid.IsTorsion (A ⧸ (powMonoidHom (α := A) n).range) := by
-  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
-  refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
-  rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
-  simp
-
-@[to_additive]
 lemma finiteIndex_range_powMonoidHom_of_fg (A : Type*) [CommGroup A] [Group.FG A] {n : ℕ}
     (hn : n ≠ 0) :
     (powMonoidHom (α := A) n).range.FiniteIndex :=
   finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ <|
-    isTorsion_quotient_range_powMonoidHom A hn
+    CommGroup.isTorsion_quotient_range_powMonoidHom A hn
 
 @[to_additive]
 lemma isFiniteRelIndex_map_powMonoidHom_of_fg {A : Type*} [CommGroup A] {B : Subgroup A}
@@ -230,8 +222,7 @@ variable {R K M : Type*} [CommRing R] [CommRing K] [Algebra R K] [Module.Finite 
   [AddCommGroup M] [Module R M]
 
 lemma fg_toAddSubgroup {A : Submodule R M} (hfg : A.FG) : A.toAddSubgroup.FG := by
-  suffices A.toAddSubgroup.toIntSubmodule.FG by
-    rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
+  rw [← AddSubgroup.toIntSubmodule_toAddSubgroup A.toAddSubgroup, ← fg_iff_addSubgroup_fg]
   exact FG.restrictScalars hfg
 
 open AddSubgroup in

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -211,7 +211,7 @@ lemma finiteIndex_range_powMonoidHom_of_fg (A : Type*) [CommGroup A] [Group.FG A
 additive group `A` such that `B` contains `n • A`, then `B` has finite index in `A`. -/]
 lemma finiteIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
     (B : Subgroup A) {n : ℕ} (hn : n ≠ 0) (h : (powMonoidHom (α := A) n).range ≤ B) :
-    B.FiniteIndex := by
+    B.FiniteIndex :=
   have := finiteIndex_range_powMonoidHom_of_fg A hn
   finiteIndex_of_le h
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -226,7 +226,7 @@ lemma fg_toAddSubgroup {A : Submodule R M} (hfg : A.FG) : A.toAddSubgroup.FG := 
   exact FG.restrictScalars hfg
 
 open AddSubgroup in
-/-- If `A` and `B` are two submodules of the `R`-algebra `M`, where `R` is finitely generated
+/-- If `A` and `B` are two `R`-submodules of the `R`-algebra `M`, where `R` is finitely generated
 as a `ℤ`-module, `A` is finitely generated, and `B` contains `n • A`, then `B` has finite
 relative index in `A`. -/
 lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R K} {n : ℕ} (hn : n ≠ 0)

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -196,24 +196,19 @@ end CommGroup
 namespace Subgroup
 
 @[to_additive]
-lemma finiteIndex_range_powMonoidHom_of_fg (A : Type*) [CommGroup A] [Group.FG A] {n : ℕ}
-    (hn : n ≠ 0) :
-    (powMonoidHom (α := A) n).range.FiniteIndex := by
-  refine finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ ?_
+lemma isTorsion_quotient_range_powMonoidHom (A : Type*) [CommGroup A] {n : ℕ} (hn : n ≠ 0) :
+    Monoid.IsTorsion (A ⧸ (powMonoidHom (α := A) n).range) := by
   simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
   refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
   rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
   simp
 
-/-- If `B` is a subgroup of the finitely generated commutative group `A` such that
-`B` contains all `n`th powers in `A`, then `B` has finite index in `A`. -/
-@[to_additive /-- If `B` is a subgroup of the finitely generated commutative
-additive group `A` such that `B` contains `n • A`, then `B` has finite index in `A`. -/]
-lemma finiteIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
-    (B : Subgroup A) {n : ℕ} (hn : n ≠ 0) (h : (powMonoidHom (α := A) n).range ≤ B) :
-    B.FiniteIndex :=
-  have := finiteIndex_range_powMonoidHom_of_fg A hn
-  finiteIndex_of_le h
+@[to_additive]
+lemma finiteIndex_range_powMonoidHom_of_fg (A : Type*) [CommGroup A] [Group.FG A] {n : ℕ}
+    (hn : n ≠ 0) :
+    (powMonoidHom (α := A) n).range.FiniteIndex :=
+  finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ <|
+    isTorsion_quotient_range_powMonoidHom A hn
 
 @[to_additive]
 lemma isFiniteRelIndex_map_powMonoidHom_of_fg {A : Type*} [CommGroup A] {B : Subgroup A}
@@ -226,16 +221,6 @@ lemma isFiniteRelIndex_map_powMonoidHom_of_fg {A : Type*} [CommGroup A] {B : Sub
   rw [this]
   have := (Group.fg_iff_subgroup_fg B).mpr hB
   exact finiteIndex_range_powMonoidHom_of_fg B hn
-
-/-- If `B` and `C` are subgroups of the commutative group `A` such that `B` is finitely generated
-and `C` contains all `n`th powers of elements of `B`, then `C` has finite relative index in `B`. -/
-@[to_additive /-- If `B` and `C` are subgroups of the commutative additive group `A` such that `B`
-is finitely generated and `C` contains `n • B`, then `C` has finite relative index in `B`. -/]
-lemma isFiniteRelIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] (B C : Subgroup A)
-    (hB : B.FG) {n : ℕ} (hn : n ≠ 0) (h : B.map (powMonoidHom (α := A) n) ≤ C) :
-    C.IsFiniteRelIndex B :=
-  have := isFiniteRelIndex_map_powMonoidHom_of_fg hB hn
-  isFiniteRelIndex_of_le B h
 
 end Subgroup
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -199,10 +199,10 @@ namespace Subgroup
 `B` contains all `n`th powers in `A`, then `B` has finite index in `A`. -/
 @[to_additive /-- If `B` is a subgroup of the finitely generated commutative
 additive group `A` such that `B` contains `n • A`, then `B` has finite index in `A`. -/]
-lemma index_ne_zero_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
+lemma finiteIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
     (B : Subgroup A) {n : ℕ} (hn : n ≠ 0) (h : (powMonoidHom (α := A) n).range ≤ B) :
-    B.index ≠ 0 := by
-  refine index_ne_zero_iff_finite.mpr <| CommGroup.finite_of_fg_torsion _ ?_
+    B.FiniteIndex := by
+  refine finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ ?_
   simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
   refine fun g ↦ ⟨n, Nat.zero_lt_of_ne_zero hn, ?_⟩
   have H a : a ^ n ∈ B := by
@@ -220,12 +220,14 @@ lemma index_ne_zero_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG
 and `C` contains all `n`th powers of elements of `B`, then `C` has finite relative index in `B`. -/
 @[to_additive /-- If `B` and `C` are subgroups of the commutative additive group `A` such that `B`
 is finitely generated and `C` contains `n • B`, then `C` has finite relative index in `B`. -/]
-lemma relIndex_ne_zero_of_range_powMonoidHom_le {A : Type*} [CommGroup A] (B C : Subgroup A)
+lemma isFiniteRelIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] (B C : Subgroup A)
     (hB : B.FG) {n : ℕ} (hn : n ≠ 0) (h : B.map (powMonoidHom (α := A) n) ≤ C) :
-    C.relIndex B ≠ 0 := by
+    C.IsFiniteRelIndex B := by
+  refine Subgroup.IsFiniteRelIndex.mk ?_
   simp only [relIndex]
   have : Group.FG B := (Group.fg_iff_subgroup_fg B).mpr hB
-  refine index_ne_zero_of_range_powMonoidHom_le (A := B) (C.subgroupOf B) hn ?_
+  suffices (C.subgroupOf B).FiniteIndex from finiteIndex_iff.mp this
+  refine finiteIndex_of_range_powMonoidHom_le (A := B) (C.subgroupOf B) hn ?_
   rw [SetLike.le_def] at h ⊢
   rintro ⟨b, hbmem⟩ hb
   simp only [mem_map, powMonoidHom_apply, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
@@ -244,9 +246,9 @@ variable {R M : Type*} [CommRing R] [CommRing M] [Algebra R M] [Module.Finite �
 /-- If `A` and `B` are two submodules of the `R`-algebra `M`, where `R` is finitely generated
 as a `ℤ`-module, `A` is finitely generated, and `B` contains `n • A`, then `B` has finite
 relative index in `A`. -/
-lemma relIndex_ne_zero_of_map_linearMapMulLeft_le {A B : Submodule R M} {n : ℕ} (hn : n ≠ 0)
+lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R M} {n : ℕ} (hn : n ≠ 0)
     (hfg : A.FG) (h : A.map (LinearMap.mulLeft R (n : M)) ≤ B) :
-    B.toAddSubgroup.relIndex A.toAddSubgroup ≠ 0 := by
+    B.toAddSubgroup.IsFiniteRelIndex A.toAddSubgroup := by
   have hA : A.toAddSubgroup.FG := by
     suffices A.toAddSubgroup.toIntSubmodule.FG by
       rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
@@ -255,7 +257,7 @@ lemma relIndex_ne_zero_of_map_linearMapMulLeft_le {A B : Submodule R M} {n : ℕ
       rwa [← Module.Finite.iff_fg] at hfg
     nth_rw 1 [← Module.Finite.iff_fg]
     exact Module.Finite.trans R _
-  refine A.toAddSubgroup.relIndex_ne_zero_of_range_nsmulAddMonoidHom_le B.toAddSubgroup hA hn ?_
+  refine A.toAddSubgroup.isFiniteRelIndex_of_range_nsmulAddMonoidHom_le B.toAddSubgroup hA hn ?_
   rw [SetLike.le_def] at h ⊢
   simpa using h
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -241,23 +241,22 @@ end Subgroup
 
 namespace Submodule
 
-variable {R M : Type*} [CommRing R] [CommRing M] [Algebra R M] [Module.Finite ℤ R]
+variable {R K M : Type*} [CommRing R] [CommRing K] [Algebra R K] [Module.Finite ℤ R]
+  [AddCommGroup M] [Module R M]
+
+lemma fg_toAddSubgroup {A : Submodule R M} (hfg : A.FG) : A.toAddSubgroup.FG := by
+  suffices A.toAddSubgroup.toIntSubmodule.FG by
+    rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
+  exact FG.restrictScalars hfg
 
 /-- If `A` and `B` are two submodules of the `R`-algebra `M`, where `R` is finitely generated
 as a `ℤ`-module, `A` is finitely generated, and `B` contains `n • A`, then `B` has finite
 relative index in `A`. -/
-lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R M} {n : ℕ} (hn : n ≠ 0)
-    (hfg : A.FG) (h : A.map (LinearMap.mulLeft R (n : M)) ≤ B) :
+lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R K} {n : ℕ} (hn : n ≠ 0)
+    (hfg : A.FG) (h : A.map (LinearMap.mulLeft R (n : K)) ≤ B) :
     B.toAddSubgroup.IsFiniteRelIndex A.toAddSubgroup := by
-  have hA : A.toAddSubgroup.FG := by
-    suffices A.toAddSubgroup.toIntSubmodule.FG by
-      rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
-    rw [Submodule.toIntSubmodule_toAddSubgroup A]
-    have : Module.Finite R ↥(restrictScalars ℤ A) := by
-      rwa [← Module.Finite.iff_fg] at hfg
-    nth_rw 1 [← Module.Finite.iff_fg]
-    exact Module.Finite.trans R _
-  refine A.toAddSubgroup.isFiniteRelIndex_of_range_nsmulAddMonoidHom_le B.toAddSubgroup hA hn ?_
+  refine A.toAddSubgroup.isFiniteRelIndex_of_range_nsmulAddMonoidHom_le B.toAddSubgroup
+    (fg_toAddSubgroup hfg) hn ?_
   rw [SetLike.le_def] at h ⊢
   simpa using h
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -195,6 +195,16 @@ end CommGroup
 
 namespace Subgroup
 
+@[to_additive]
+lemma finiteIndex_range_powMonoidHom_of_fg (A : Type*) [CommGroup A] [Group.FG A] {n : ℕ}
+    (hn : n ≠ 0) :
+    (powMonoidHom (α := A) n).range.FiniteIndex := by
+  refine finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ ?_
+  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
+  refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
+  rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
+  simp
+
 /-- If `B` is a subgroup of the finitely generated commutative group `A` such that
 `B` contains all `n`th powers in `A`, then `B` has finite index in `A`. -/
 @[to_additive /-- If `B` is a subgroup of the finitely generated commutative
@@ -202,19 +212,20 @@ additive group `A` such that `B` contains `n • A`, then `B` has finite index i
 lemma finiteIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
     (B : Subgroup A) {n : ℕ} (hn : n ≠ 0) (h : (powMonoidHom (α := A) n).range ≤ B) :
     B.FiniteIndex := by
-  refine finiteIndex_iff_finite_quotient.mpr <| CommGroup.finite_of_fg_torsion _ ?_
-  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
-  refine fun g ↦ ⟨n, Nat.zero_lt_of_ne_zero hn, ?_⟩
-  have H a : a ^ n ∈ B := by
-    rw [SetLike.le_def] at h
-    have ha : a ^ n ∈ (powMonoidHom n).range := by simp
-    exact h ha
-  suffices Quotient.out g ^ n ∈ B by
-    obtain ⟨b, hb₁, hb₂⟩ : ∃ b ∈ B, b = Quotient.out g ^ n := ⟨_, this, rfl⟩
-    apply_fun QuotientGroup.mk (s := B) at hb₂
-    rw [(QuotientGroup.eq_one_iff b).mpr hb₁] at hb₂
-    rw [hb₂, QuotientGroup.mk_pow, QuotientGroup.out_eq']
-  exact H _
+  have := finiteIndex_range_powMonoidHom_of_fg A hn
+  finiteIndex_of_le h
+
+@[to_additive]
+lemma isFiniteRelIndex_map_powMonoidHom_of_fg {A : Type*} [CommGroup A] {B : Subgroup A}
+    (hB : B.FG) {n : ℕ} (hn : n ≠ 0) :
+    B.map (powMonoidHom (α := A) n) |>.IsFiniteRelIndex B := by
+  rw [isFiniteRelIndex_iff_finiteIndex]
+  have : (map (powMonoidHom (α := A) n) B).subgroupOf B = (powMonoidHom (α := B) n).range := by
+    ext1
+    simp [mem_subgroupOf, Subtype.ext_iff]
+  rw [this]
+  have := (Group.fg_iff_subgroup_fg B).mpr hB
+  exact finiteIndex_range_powMonoidHom_of_fg B hn
 
 /-- If `B` and `C` are subgroups of the commutative group `A` such that `B` is finitely generated
 and `C` contains all `n`th powers of elements of `B`, then `C` has finite relative index in `B`. -/
@@ -222,20 +233,9 @@ and `C` contains all `n`th powers of elements of `B`, then `C` has finite relati
 is finitely generated and `C` contains `n • B`, then `C` has finite relative index in `B`. -/]
 lemma isFiniteRelIndex_of_range_powMonoidHom_le {A : Type*} [CommGroup A] (B C : Subgroup A)
     (hB : B.FG) {n : ℕ} (hn : n ≠ 0) (h : B.map (powMonoidHom (α := A) n) ≤ C) :
-    C.IsFiniteRelIndex B := by
-  refine Subgroup.IsFiniteRelIndex.mk ?_
-  simp only [relIndex]
-  have : Group.FG B := (Group.fg_iff_subgroup_fg B).mpr hB
-  suffices (C.subgroupOf B).FiniteIndex from finiteIndex_iff.mp this
-  refine finiteIndex_of_range_powMonoidHom_le (A := B) (C.subgroupOf B) hn ?_
-  rw [SetLike.le_def] at h ⊢
-  rintro ⟨b, hbmem⟩ hb
-  simp only [mem_map, powMonoidHom_apply, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
-    MonoidHom.mem_range, Subtype.exists, SubmonoidClass.mk_pow, Subtype.mk.injEq,
-    exists_prop] at h hb
-  rw [mem_subgroupOf, show Subtype.val ⟨b, hbmem⟩ = b from rfl]
-  obtain ⟨a, hamem, rfl⟩ := hb
-  exact mem_carrier.mp (h a hamem)
+    C.IsFiniteRelIndex B :=
+  have := isFiniteRelIndex_map_powMonoidHom_of_fg hB hn
+  isFiniteRelIndex_of_le B h
 
 end Subgroup
 

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -192,3 +192,71 @@ theorem equiv_free_prod_prod_multiplicative_zmod (G : Type*) [CommGroup G] [hG :
           (DirectSum.addEquivProd _ )).trans <| (AddEquiv.prodAdditive _ _).symm⟩⟩
 
 end CommGroup
+
+namespace Subgroup
+
+/-- If `B` is a subgroup of the finitely generated commutative group `A` such that
+`B` contains all `n`th powers in `A`, then `B` has finite index in `A`. -/
+@[to_additive /-- If `B` is a subgroup of the finitely generated commutative
+additive group `A` such that `B` contains `n • A`, then `B` has finite index in `A`. -/]
+lemma index_ne_zero_of_range_powMonoidHom_le {A : Type*} [CommGroup A] [Group.FG A]
+    (B : Subgroup A) {n : ℕ} (hn : n ≠ 0) (h : (powMonoidHom (α := A) n).range ≤ B) :
+    B.index ≠ 0 := by
+  refine index_ne_zero_iff_finite.mpr <| CommGroup.finite_of_fg_torsion _ ?_
+  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
+  refine fun g ↦ ⟨n, Nat.zero_lt_of_ne_zero hn, ?_⟩
+  have H a : a ^ n ∈ B := by
+    rw [SetLike.le_def] at h
+    have ha : a ^ n ∈ (powMonoidHom n).range := by simp
+    exact h ha
+  suffices Quotient.out g ^ n ∈ B by
+    obtain ⟨b, hb₁, hb₂⟩ : ∃ b ∈ B, b = Quotient.out g ^ n := ⟨_, this, rfl⟩
+    apply_fun QuotientGroup.mk (s := B) at hb₂
+    rw [(QuotientGroup.eq_one_iff b).mpr hb₁] at hb₂
+    rw [hb₂, QuotientGroup.mk_pow, QuotientGroup.out_eq']
+  exact H _
+
+/-- If `B` and `C` are subgroups of the commutative group `A` such that `B` is finitely generated
+and `C` contains all `n`th powers of elements of `B`, then `C` has finite relative index in `B`. -/
+@[to_additive /-- If `B` and `C` are subgroups of the commutative additive group `A` such that `B`
+is finitely generated and `C` contains `n • B`, then `C` has finite relative index in `B`. -/]
+lemma relIndex_ne_zero_of_range_powMonoidHom_le {A : Type*} [CommGroup A] (B C : Subgroup A)
+    (hB : B.FG) {n : ℕ} (hn : n ≠ 0) (h : B.map (powMonoidHom (α := A) n) ≤ C) :
+    C.relIndex B ≠ 0 := by
+  simp only [relIndex]
+  have : Group.FG B := (Group.fg_iff_subgroup_fg B).mpr hB
+  refine index_ne_zero_of_range_powMonoidHom_le (A := B) (C.subgroupOf B) hn ?_
+  rw [SetLike.le_def] at h ⊢
+  rintro ⟨b, hbmem⟩ hb
+  simp only [mem_map, powMonoidHom_apply, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
+    MonoidHom.mem_range, Subtype.exists, SubmonoidClass.mk_pow, Subtype.mk.injEq,
+    exists_prop] at h hb
+  rw [mem_subgroupOf, show Subtype.val ⟨b, hbmem⟩ = b from rfl]
+  obtain ⟨a, hamem, rfl⟩ := hb
+  exact mem_carrier.mp (h a hamem)
+
+end Subgroup
+
+namespace Submodule
+
+variable {R M : Type*} [CommRing R] [CommRing M] [Algebra R M] [Module.Finite ℤ R]
+
+/-- If `A` and `B` are two submodules of the `R`-algebra `M`, where `R` is finitely generated
+as a `ℤ`-module, `A` is finitely generated, and `B` contains `n • A`, then `B` has finite
+relative index in `A`. -/
+lemma relIndex_ne_zero_of_map_linearMapMulLeft_le {A B : Submodule R M} {n : ℕ} (hn : n ≠ 0)
+    (hfg : A.FG) (h : A.map (LinearMap.mulLeft R (n : M)) ≤ B) :
+    B.toAddSubgroup.relIndex A.toAddSubgroup ≠ 0 := by
+  have hA : A.toAddSubgroup.FG := by
+    suffices A.toAddSubgroup.toIntSubmodule.FG by
+      rwa [fg_iff_addSubgroup_fg, AddSubgroup.toIntSubmodule_toAddSubgroup] at this
+    rw [Submodule.toIntSubmodule_toAddSubgroup A]
+    have : Module.Finite R ↥(restrictScalars ℤ A) := by
+      rwa [← Module.Finite.iff_fg] at hfg
+    nth_rw 1 [← Module.Finite.iff_fg]
+    exact Module.Finite.trans R _
+  refine A.toAddSubgroup.relIndex_ne_zero_of_range_nsmulAddMonoidHom_le B.toAddSubgroup hA hn ?_
+  rw [SetLike.le_def] at h ⊢
+  simpa using h
+
+end Submodule

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -675,8 +675,18 @@ instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
   index_ne_zero := relIndex_ne_zero
 
 @[to_additive]
+lemma isFiniteRelIndex_iff_relIndex_eq_zero {G : Type*} [Group G] {H₁ H₂ : Subgroup G} :
+    H₁.IsFiniteRelIndex H₂ ↔ H₁.relIndex H₂ ≠ 0 :=
+  ⟨fun _ ↦ relIndex_ne_zero, IsFiniteRelIndex.mk⟩
+
+@[to_additive]
 theorem finiteIndex_iff : H.FiniteIndex ↔ H.index ≠ 0 :=
   ⟨fun h ↦ h.index_ne_zero, fun h ↦ ⟨h⟩⟩
+
+@[to_additive]
+lemma isFiniteRelIndex_iff_finiteIndex {G : Type*} [Group G] {H₁ H₂ : Subgroup G} :
+    H₁.IsFiniteRelIndex H₂ ↔ (H₁.subgroupOf H₂).FiniteIndex := by
+  rw [isFiniteRelIndex_iff_relIndex_eq_zero, finiteIndex_iff, relIndex]
 
 @[to_additive]
 theorem not_finiteIndex_iff {G : Type*} [Group G] {H : Subgroup G} :
@@ -744,6 +754,14 @@ instance instFiniteIndex_subgroupOf (H K : Subgroup G) [H.FiniteIndex] :
 @[to_additive]
 theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.index_ne_zero (index_dvd_of_le h)⟩
+
+@[to_additive]
+lemma isFiniteRelIndex_of_le {G : Type*} [Group G] {H₁ H₂ : Subgroup G} (H₃ : Subgroup G)
+    [H₁.IsFiniteRelIndex H₃] (h : H₁ ≤ H₂) :
+    H₂.IsFiniteRelIndex H₃ := by
+  rw [isFiniteRelIndex_iff_finiteIndex] at *
+  have : H₁.subgroupOf H₃ ≤ H₂.subgroupOf H₃ := comap_mono h
+  exact finiteIndex_of_le this
 
 @[to_additive (attr := gcongr)]
 lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -759,7 +759,7 @@ lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.
     (h : H₁ ≤ H₂) :
     H₂.IsFiniteRelIndex H₃ := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
-  have : H₁.subgroupOf H₃ ≤ H₂.subgroupOf H₃ := comap_mono h
+  have := subgroupOf_mono H₃ h
   exact finiteIndex_of_le this
 
 @[to_additive (attr := gcongr)]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -759,8 +759,7 @@ lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.
     (h : H₁ ≤ H₂) :
     H₂.IsFiniteRelIndex H₃ := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
-  have := subgroupOf_mono H₃ h
-  exact finiteIndex_of_le this
+  exact finiteIndex_of_le <| subgroupOf_mono H₃ h
 
 @[to_additive (attr := gcongr)]
 lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -675,7 +675,7 @@ instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
   index_ne_zero := relIndex_ne_zero
 
 @[to_additive]
-lemma isFiniteRelIndex_iff_relIndex_eq_zero : H.IsFiniteRelIndex K ↔ H.relIndex K ≠ 0 :=
+lemma isFiniteRelIndex_iff_relIndex_ne_zero : H.IsFiniteRelIndex K ↔ H.relIndex K ≠ 0 :=
   ⟨fun _ ↦ relIndex_ne_zero, IsFiniteRelIndex.mk⟩
 
 @[to_additive]
@@ -685,7 +685,7 @@ theorem finiteIndex_iff : H.FiniteIndex ↔ H.index ≠ 0 :=
 @[to_additive]
 lemma isFiniteRelIndex_iff_finiteIndex :
     H.IsFiniteRelIndex K ↔ (H.subgroupOf K).FiniteIndex := by
-  rw [isFiniteRelIndex_iff_relIndex_eq_zero, finiteIndex_iff, relIndex]
+  rw [isFiniteRelIndex_iff_relIndex_ne_zero, finiteIndex_iff, relIndex]
 
 @[to_additive]
 theorem not_finiteIndex_iff : ¬ H.FiniteIndex ↔ H.index = 0 :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -675,8 +675,7 @@ instance IsFiniteRelIndex.to_finiteIndex_subgroupOf [H.IsFiniteRelIndex K] :
   index_ne_zero := relIndex_ne_zero
 
 @[to_additive]
-lemma isFiniteRelIndex_iff_relIndex_eq_zero {G : Type*} [Group G] {H₁ H₂ : Subgroup G} :
-    H₁.IsFiniteRelIndex H₂ ↔ H₁.relIndex H₂ ≠ 0 :=
+lemma isFiniteRelIndex_iff_relIndex_eq_zero : H.IsFiniteRelIndex K ↔ H.relIndex K ≠ 0 :=
   ⟨fun _ ↦ relIndex_ne_zero, IsFiniteRelIndex.mk⟩
 
 @[to_additive]
@@ -684,13 +683,13 @@ theorem finiteIndex_iff : H.FiniteIndex ↔ H.index ≠ 0 :=
   ⟨fun h ↦ h.index_ne_zero, fun h ↦ ⟨h⟩⟩
 
 @[to_additive]
-lemma isFiniteRelIndex_iff_finiteIndex {G : Type*} [Group G] {H₁ H₂ : Subgroup G} :
-    H₁.IsFiniteRelIndex H₂ ↔ (H₁.subgroupOf H₂).FiniteIndex := by
+lemma isFiniteRelIndex_iff_finiteIndex :
+    H.IsFiniteRelIndex K ↔ (H.subgroupOf K).FiniteIndex := by
   rw [isFiniteRelIndex_iff_relIndex_eq_zero, finiteIndex_iff, relIndex]
 
 @[to_additive]
-theorem not_finiteIndex_iff {G : Type*} [Group G] {H : Subgroup G} :
-    ¬ H.FiniteIndex ↔ H.index = 0 := by simp [finiteIndex_iff]
+theorem not_finiteIndex_iff : ¬ H.FiniteIndex ↔ H.index = 0 :=
+  by simp [finiteIndex_iff]
 
 /-- A finite index subgroup has finite quotient. -/
 @[to_additive (attr := instance_reducible) /-- A finite index subgroup has finite quotient -/]
@@ -756,8 +755,8 @@ theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.index_ne_zero (index_dvd_of_le h)⟩
 
 @[to_additive]
-lemma isFiniteRelIndex_of_le {G : Type*} [Group G] {H₁ H₂ : Subgroup G} (H₃ : Subgroup G)
-    [H₁.IsFiniteRelIndex H₃] (h : H₁ ≤ H₂) :
+lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.IsFiniteRelIndex H₃]
+    (h : H₁ ≤ H₂) :
     H₂.IsFiniteRelIndex H₃ := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
   have : H₁.subgroupOf H₃ ≤ H₂.subgroupOf H₃ := comap_mono h

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1173,6 +1173,10 @@ theorem pow_gcd_card_eq_one_iff : x ^ n.gcd (Fintype.card G) = 1 ↔ x ^ n = 1 :
 theorem Subgroup.pow_index_mem {G : Type*} [Group G] (H : Subgroup G) [Normal H] (g : G) :
     g ^ index H ∈ H := by rw [← eq_one_iff, QuotientGroup.mk_pow H, index, pow_card_eq_one']
 
+@[to_additive]
+lemma Subgroup.pow_relIndex_mem {G : Type*} [Group G] (H : Subgroup G) [H.Normal] {K : Subgroup G}
+    {g : G} (hg : g ∈ K) : g ^ H.relIndex K ∈ H :=
+  pow_index_mem (H.subgroupOf K) ⟨g, hg⟩
 
 @[to_additive (attr := simp) mod_card_nsmul]
 lemma pow_mod_card (a : G) (n : ℕ) : a ^ (n % card G) = a ^ n := by

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -356,3 +356,12 @@ theorem neg_one_mem_torsion : -1 ∈ CommMonoid.torsion M :=
   ⟨2, zero_lt_two, (isPeriodicPt_mul_iff_pow_eq_one _).mpr (by simp)⟩
 
 end
+
+@[to_additive]
+lemma CommGroup.isTorsion_quotient_range_powMonoidHom (A : Type*) [CommGroup A] {n : ℕ}
+    (hn : n ≠ 0) :
+    Monoid.IsTorsion (A ⧸ (powMonoidHom (α := A) n).range) := by
+  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
+  refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
+  rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
+  simp

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -303,6 +303,14 @@ lemma isMulTorsionFree_iff_torsion_eq_bot : IsMulTorsionFree G ↔ CommGroup.tor
   rw [isMulTorsionFree_iff_not_isOfFinOrder, eq_bot_iff, SetLike.le_def]
   simp [not_imp_not, CommGroup.mem_torsion]
 
+@[to_additive]
+lemma isTorsion_quotient_range_powMonoidHom {n : ℕ} (hn : n ≠ 0) :
+    Monoid.IsTorsion (G ⧸ (powMonoidHom (α := G) n).range) := by
+  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
+  refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
+  rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
+  simp
+
 variable (p : ℕ) [hp : Fact p.Prime]
 
 /-- The `p`-primary component is the subgroup of elements with order prime-power of `p`. -/
@@ -356,12 +364,3 @@ theorem neg_one_mem_torsion : -1 ∈ CommMonoid.torsion M :=
   ⟨2, zero_lt_two, (isPeriodicPt_mul_iff_pow_eq_one _).mpr (by simp)⟩
 
 end
-
-@[to_additive]
-lemma CommGroup.isTorsion_quotient_range_powMonoidHom (A : Type*) [CommGroup A] {n : ℕ}
-    (hn : n ≠ 0) :
-    Monoid.IsTorsion (A ⧸ (powMonoidHom (α := A) n).range) := by
-  simp only [Monoid.IsTorsion, isOfFinOrder_iff_pow_eq_one]
-  refine fun g ↦ QuotientGroup.induction_on g fun a ↦ ⟨n, hn.pos, ?_⟩
-  rw [← QuotientGroup.mk_pow, QuotientGroup.eq_one_iff]
-  simp


### PR DESCRIPTION
This adds some results on the (quotient by the) image of the `n`th power / multiplication-by-`n` map and related material on the (relative) index of a subgroup / submodule.

These are helpful for proving the *Northcott property* of heights on number fields.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
