### PR TITLE
[Merged by Bors] - feat(RingTheory/Ideal/Span): two lemmas for span (range x)

### DIFF
--- a/Mathlib/RingTheory/Ideal/Span.lean
+++ b/Mathlib/RingTheory/Ideal/Span.lean
@@ -179,6 +179,20 @@ theorem mem_span_pair {x y z : α} : z ∈ span ({x, y} : Set α) ↔ ∃ a b, a
 theorem span_pair_zero (x : α) : span {x, 0} = span {x} := by
   rw [span_pair_comm, span_insert_zero]
 
+variable {ι : Type*}
+
+lemma span_range_eq_iSup (x : ι → α) : span (range x) = ⨆ i, span {x i} := by
+  rw [← span_iUnion, iUnion_singleton_eq_range]
+
+lemma span_range_eq_span_range_support (x : ι → α) :
+    span (range x) = span (range fun i : x.support ↦ x i.val) := by
+  rw [← span_sdiff_singleton_zero (s := range x), Function.support]
+  congr
+  ext1 a
+  simp only [mem_diff, mem_range, mem_singleton_iff]
+  exact ⟨fun ⟨⟨i, hi⟩, ha⟩ ↦ ⟨⟨i, mem_setOf.mpr (hi ▸ ha)⟩, hi⟩,
+    fun ⟨j, hj⟩ ↦ ⟨⟨j.val, hj⟩, by grind⟩⟩
+
 end Semiring
 
 section CommSemiring


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
