### PR TITLE
[Merged by Bors] - feat: FiberBundle.extend

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -139,7 +139,7 @@ protected theorem FiberBundle.extChartAt (x : TotalSpace F E) :
     extChartAt (IB.prod 𝓘(𝕜, F)) x =
       (trivializationAt F E x.proj).toPartialEquiv ≫
         (extChartAt IB x.proj).prod (PartialEquiv.refl F) := by
-  simp_rw [extChartAt, FiberBundle.chartedSpace_chartAt, extend]
+  simp_rw [extChartAt, FiberBundle.chartedSpace_chartAt, OpenPartialHomeomorph.extend]
   simp only [PartialEquiv.trans_assoc, mfld_simps]
   -- Porting note: should not be needed
   rw [PartialEquiv.prod_trans, PartialEquiv.refl_trans]

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -690,11 +690,8 @@ lemma exists_contMDiffOn_extend [(x : M) → Module 𝕜 (V x)] [VectorBundle �
     rw [t.contMDiffWithinAt_section _ hx]
     exact this x hx
   let w : F := (t ⟨x₀, σ₀⟩).2
-  have : ContMDiffOn I 𝓘(𝕜, F) k (fun x_1 ↦ w) t.baseSet := contMDiffOn_const
-  refine this.congr ?_
-  intro x hx
-  unfold extend
-  rw [t.mk_symm hx, t.apply_symm_apply' hx]
+  have : ContMDiffOn I 𝓘(𝕜, F) k (fun _x ↦ w) t.baseSet := contMDiffOn_const
+  exact this.congr (fun x hx ↦ by simp [extend, t, w, hx])
 
 lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
     CMDiffAt k (T% (extend F σ₀)) x := by

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -693,7 +693,6 @@ lemma exists_contMDiffOn_extend [(x : M) → Module 𝕜 (V x)] [VectorBundle �
   have : ContMDiffOn I 𝓘(𝕜, F) k (fun x_1 ↦ w) t.baseSet := contMDiffOn_const
   refine this.congr ?_
   intro x hx
-  dsimp only
   unfold extend
   rw [t.mk_symm hx, t.apply_symm_apply' hx]
 
@@ -707,9 +706,7 @@ lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
   apply eventually_nhds_iff.mpr
   refine ⟨t.baseSet, ?_, t.open_baseSet, ?_⟩
   · intro x hx
-    dsimp only
-    unfold extend
-    simp [t, hx, w]
+    simp [extend, t, hx, w]
   · exact FiberBundle.mem_baseSet_trivializationAt' x
 
 lemma exists_mdifferentiableOn_extend [∀ x, Module 𝕜 (V x)] [VectorBundle 𝕜 F V]

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -721,4 +721,3 @@ lemma mdifferentiableAt_extend {x : M} (σ₀ : V x) :
 
 end FiberBundle
 end extend
-

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -712,15 +712,16 @@ lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
     simp [t, hx, w]
   · exact FiberBundle.mem_baseSet_trivializationAt' x
 
-lemma exists_mdifferentiableOn_extend [IsManifold I 1 M] [∀ x, Module 𝕜 (V x)] [VectorBundle 𝕜 F V]
+lemma exists_mdifferentiableOn_extend [∀ x, Module 𝕜 (V x)] [VectorBundle 𝕜 F V]
     [ContMDiffVectorBundle 1 F V I] {x₀ : M} (σ₀ : V x₀) :
     ∃ s ∈ 𝓝 x₀, MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (T% (extend F σ₀)) s := by
   obtain ⟨s, hs, hsσ⟩ := exists_contMDiffOn_extend (k := 1) I F σ₀
   exact ⟨s, hs, hsσ.mdifferentiableOn one_ne_zero⟩
 
-lemma mdifferentiableAt_extend [IsManifold I 1 M] {x : M} (σ₀ : V x) :
+lemma mdifferentiableAt_extend {x : M} (σ₀ : V x) :
     MDiffAt (T% (extend F σ₀)) x :=
   (contMDiffAt_extend' (k := 1) I F σ₀).mdifferentiableAt one_ne_zero
 
 end FiberBundle
 end extend
+

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -665,3 +665,62 @@ lemma MDifferentiableAt.clm_apply_of_inCoordinates
   exact MDifferentiableWithinAt.clm_apply_of_inCoordinates hϕ hv hb₂
 
 end
+
+section extend
+
+namespace FiberBundle
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  (F : Type*) [NormedAddCommGroup F]
+  {V : M → Type*} [TopologicalSpace (TotalSpace F V)] [(x : M) → AddCommGroup (V x)]
+  [(x : M) → TopologicalSpace (V x)]
+  [FiberBundle F V] [NormedSpace 𝕜 F] {k : WithTop ℕ∞}
+
+lemma exists_contMDiffOn_extend [(x : M) → Module 𝕜 (V x)] [VectorBundle 𝕜 F V]
+    [ContMDiffVectorBundle k F V I] {x₀ : M} (σ₀ : V x₀) :
+    ∃ s ∈ 𝓝 x₀, ContMDiffOn I (I.prod 𝓘(𝕜, F)) k (T% (extend F σ₀)) s := by
+  set t := trivializationAt F V x₀
+  refine ⟨t.baseSet, ?_, ?_⟩
+  · refine t.open_baseSet.mem_nhds ?_
+    exact FiberBundle.mem_baseSet_trivializationAt' x₀
+  suffices ContMDiffOn I 𝓘(𝕜, F) k (fun x ↦ (t ⟨x, extend F σ₀ x⟩).2) t.baseSet by
+    intro x hx
+    rw [t.contMDiffWithinAt_section _ hx]
+    exact this x hx
+  let w : F := (t ⟨x₀, σ₀⟩).2
+  have : ContMDiffOn I 𝓘(𝕜, F) k (fun x_1 ↦ w) t.baseSet := contMDiffOn_const
+  refine this.congr ?_
+  intro x hx
+  dsimp only
+  unfold extend
+  rw [t.mk_symm hx, t.apply_symm_apply' hx]
+
+lemma contMDiffAt_extend' {x : M} (σ₀ : V x) :
+    CMDiffAt k (T% (extend F σ₀)) x := by
+  rw [contMDiffAt_section]
+  set t := trivializationAt F V x
+  let w : F := (t ⟨x, σ₀⟩).2
+  have : CMDiffAt k (fun (_x : M) ↦ w) x := contMDiffAt_const
+  refine this.congr_of_eventuallyEq ?_
+  apply eventually_nhds_iff.mpr
+  refine ⟨t.baseSet, ?_, t.open_baseSet, ?_⟩
+  · intro x hx
+    dsimp only
+    unfold extend
+    simp [t, hx, w]
+  · exact FiberBundle.mem_baseSet_trivializationAt' x
+
+lemma exists_mdifferentiableOn_extend [IsManifold I 1 M] [∀ x, Module 𝕜 (V x)] [VectorBundle 𝕜 F V]
+    [ContMDiffVectorBundle 1 F V I] {x₀ : M} (σ₀ : V x₀) :
+    ∃ s ∈ 𝓝 x₀, MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (T% (extend F σ₀)) s := by
+  obtain ⟨s, hs, hsσ⟩ := exists_contMDiffOn_extend (k := 1) I F σ₀
+  exact ⟨s, hs, hsσ.mdifferentiableOn one_ne_zero⟩
+
+lemma mdifferentiableAt_extend [IsManifold I 1 M] {x : M} (σ₀ : V x) :
+    MDiffAt (T% (extend F σ₀)) x :=
+  (contMDiffAt_extend' (k := 1) I F σ₀).mdifferentiableAt one_ne_zero
+
+end FiberBundle
+end extend

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -869,6 +869,7 @@ The details of the extension are mostly unspecified: for covariant derivatives, 
 noncomputable def extend {x : B} (v₀ : E x) (x' : B) : E x' :=
   letI t := trivializationAt F E x
   letI w : F := (t ⟨x, v₀⟩).2
+  -- TODO: use the `funToSec` helper from #36036 once available
   t.symm x' w
 
 @[simp] lemma extend_apply_self {x : B} (v : E x) : extend F v x = v := by

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -856,3 +856,23 @@ theorem continuousOn_of_comp_right {X : Type*} [TopologicalSpace X] {f : TotalSp
     exact a.mem_base_pretrivializationAt z.proj
 
 end FiberPrebundle
+
+namespace FiberBundle
+section extend
+
+variable {E} [(x : B) → Zero (E x)] [TopologicalSpace (TotalSpace F E)] [FiberBundle F E]
+
+/-- Extend a vector `v ∈ V x` to a section of the bundle `V`, whose value at `x` is `v`.
+The details of the extension are mostly unspecified: for covariant derivatives, the value of
+`s` at points other than `x` will not matter (except for shorter proofs).
+-/
+noncomputable def extend {x : B} (v₀ : E x) (x' : B) : E x' :=
+  letI t := trivializationAt F E x
+  letI w : F := (t ⟨x, v₀⟩).2
+  t.symm x' w
+
+@[simp] lemma extend_apply_self {x : B} (v : E x) : extend F v x = v := by
+  simp [extend, FiberBundle.mem_baseSet_trivializationAt' x]
+
+end extend
+end FiberBundle


### PR DESCRIPTION
Extend an element of a fiber at a point to a local section.

From the path towards Riemannian geometry.

Co-authored-by: Michael Rothgang <rothgang@math.uni-bonn.de>
Co-authored-by: Heather Macbeth <25316162+hrmacbeth@users.noreply.github.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
