### PR TITLE
[Merged by Bors] - fix(Tactic/Recall): use flat name to avoid `module` namespace issues

### DIFF
--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -47,13 +47,16 @@ elab_rules : command
     addConstInfo id declName
     let info ← getConstInfo declName
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
-    let newId := ({ namePrefix := declName : DeclNameGenerator }.mkUniqueName (← getEnv) `recall).1
-    let newId := mkIdentFrom id newId
+    let recallName := Name.mkSimple
+      s!"_recall_{(← liftTermElabM Lean.mkFreshId)}"
+    let newId := mkIdentFrom id recallName
     if let some val := val? then
       let some infoVal := info.value?
         | throwErrorAt val "constant '{declName}' has no defined value"
       elabCommand <| ← `(noncomputable def $newId $sig:optDeclSig $val)
-      let some newInfo := (← getEnv).find? newId.getId | return -- def already threw
+      let ns ← getCurrNamespace
+      let some newInfo := (← getEnv).find? (ns ++ recallName)
+        | return -- def already threw
       liftTermElabM do
         let mvs ← newInfo.levelParams.mapM fun _ => mkFreshLevelMVar
         let newType := newInfo.type.instantiateLevelParams newInfo.levelParams mvs

--- a/MathlibTest/RecallModule.lean
+++ b/MathlibTest/RecallModule.lean
@@ -1,0 +1,11 @@
+module
+public import Mathlib.Tactic.Recall
+
+@[expose] public section
+
+/-- Test that `recall` works inside a `module` file. -/
+def recallModuleTest := 42
+
+recall recallModuleTest := 42
+
+recall recallModuleTest : Nat


### PR DESCRIPTION
This PR fixes the `recall` command to work inside `module` files.

The `recall` command generates a temporary definition (inside `withoutModifyingEnv`) to type-check the recalled value. Previously, it used the recalled declaration's name as the `DeclNameGenerator` prefix, creating hierarchical names like `IfNormalization.recall_1`. In `module` files, this opens deep namespaces that cause "Invalid name after `end`" errors.

Since the generated name is discarded anyway, use `.anonymous` as the prefix to produce a flat name, avoiding the namespace issue entirely.

🤖 Prepared with Claude Code