### PR TITLE
[Merged by Bors] - feat(Geometry.Euclidean.Sphere): inner product of chord with radius vector is negative

### DIFF
--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -453,6 +453,19 @@ theorem inner_pos_of_dist_lt_radius {s : Sphere P} {p₁ p₂ : P} (hp₁ : p₁
     exact False.elim (hp₂.ne hp₁)
   exact (inner_pos_or_eq_of_dist_le_radius hp₁ hp₂.le).resolve_right h
 
+/-- Given two distinct points on a sphere, the inner product of the chord with
+the radius vector at one endpoint is negative. -/
+theorem inner_vsub_vsub_center_lt_zero {A B : P} {s : Sphere P}
+    (hA : A ∈ s) (hB : B ∈ s) (hBA : B ≠ A) :
+    ⟪B -ᵥ A, A -ᵥ s.center⟫ < 0 := by
+  have hA' : ‖A -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hA
+  have hB' : ‖B -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hB
+  have hd : ‖B -ᵥ s.center‖ ^ 2 =
+      ‖B -ᵥ A‖ ^ 2 + 2 * ⟪B -ᵥ A, A -ᵥ s.center⟫ + ‖A -ᵥ s.center‖ ^ 2 := by
+    rw [← vsub_add_vsub_cancel B A s.center, norm_add_sq_real]
+  rw [hB', hA'] at hd
+  nlinarith [sq_pos_of_pos (norm_pos_iff.mpr (vsub_ne_zero.mpr hBA))]
+
 /-- Given three collinear points, two on a sphere and one not outside it, the one not outside it
 is weakly between the other two points. -/
 theorem wbtw_of_collinear_of_dist_center_le_radius {s : Sphere P} {p₁ p₂ p₃ : P}

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -455,9 +455,9 @@ theorem inner_pos_of_dist_lt_radius {s : Sphere P} {p₁ p₂ : P} (hp₁ : p₁
 
 /-- Given two distinct points on a sphere, the inner product of the chord with
 the radius vector at one endpoint is negative. -/
-theorem inner_vsub_vsub_center_lt_zero {A B : P} {s : Sphere P}
+theorem inner_vsub_center_vsub_pos {A B : P} {s : Sphere P}
     (hA : A ∈ s) (hB : B ∈ s) (hBA : B ≠ A) :
-    ⟪B -ᵥ A, A -ᵥ s.center⟫ < 0 := by
+    0 < ⟪B -ᵥ A, s.center -ᵥ A⟫ := by
   have hA' : ‖A -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hA
   have hB' : ‖B -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hB
   have hd : ‖B -ᵥ s.center‖ ^ 2 =

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -463,7 +463,7 @@ theorem inner_vsub_center_vsub_pos {A B : P} {s : Sphere P}
   have hd : ‖B -ᵥ s.center‖ ^ 2 =
       ‖B -ᵥ A‖ ^ 2 + 2 * ⟪B -ᵥ A, A -ᵥ s.center⟫ + ‖A -ᵥ s.center‖ ^ 2 := by
     rw [← vsub_add_vsub_cancel B A s.center, norm_add_sq_real]
-  rw [hB', hA'] at hd
+  rw [hB', hA', ← neg_vsub_eq_vsub_rev s.center A, inner_neg_right] at hd
   nlinarith [sq_pos_of_pos (norm_pos_iff.mpr (vsub_ne_zero.mpr hBA))]
 
 /-- Given three collinear points, two on a sphere and one not outside it, the one not outside it

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -455,16 +455,16 @@ theorem inner_pos_of_dist_lt_radius {s : Sphere P} {p₁ p₂ : P} (hp₁ : p₁
 
 /-- Given two distinct points on a sphere, the inner product of the chord with
 the radius vector at one endpoint is negative. -/
-theorem inner_vsub_center_vsub_pos {A B : P} {s : Sphere P}
-    (hA : A ∈ s) (hB : B ∈ s) (hBA : B ≠ A) :
-    0 < ⟪B -ᵥ A, s.center -ᵥ A⟫ := by
-  have hA' : ‖A -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hA
-  have hB' : ‖B -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hB
-  have hd : ‖B -ᵥ s.center‖ ^ 2 =
-      ‖B -ᵥ A‖ ^ 2 + 2 * ⟪B -ᵥ A, A -ᵥ s.center⟫ + ‖A -ᵥ s.center‖ ^ 2 := by
-    rw [← vsub_add_vsub_cancel B A s.center, norm_add_sq_real]
-  rw [hB', hA', ← neg_vsub_eq_vsub_rev s.center A, inner_neg_right] at hd
-  nlinarith [sq_pos_of_pos (norm_pos_iff.mpr (vsub_ne_zero.mpr hBA))]
+theorem inner_vsub_center_vsub_pos {p₁ p₂ : P} {s : Sphere P}
+    (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₁p₂ : p₁ ≠ p₂) :
+    0 < ⟪p₂ -ᵥ p₁, s.center -ᵥ p₁⟫ := by
+  have hp₁' : ‖p₁ -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hp₁
+  have hp₂' : ‖p₂ -ᵥ s.center‖ = s.radius := by rw [← dist_eq_norm_vsub']; exact mem_sphere'.mp hp₂
+  have hd : ‖p₂ -ᵥ s.center‖ ^ 2 =
+      ‖p₂ -ᵥ p₁‖ ^ 2 + 2 * ⟪p₂ -ᵥ p₁, p₁ -ᵥ s.center⟫ + ‖p₁ -ᵥ s.center‖ ^ 2 := by
+    rw [← vsub_add_vsub_cancel p₂ p₁ s.center, norm_add_sq_real]
+  rw [hp₂', hp₁', ← neg_vsub_eq_vsub_rev s.center p₁, inner_neg_right] at hd
+  nlinarith [sq_pos_of_pos (norm_pos_iff.mpr (vsub_ne_zero.mpr hp₁p₂.symm))]
 
 /-- Given three collinear points, two on a sphere and one not outside it, the one not outside it
 is weakly between the other two points. -/


### PR DESCRIPTION
For distinct points `A` and `B` on a sphere, the inner product `⟪B -ᵥ A, A -ᵥ s.center⟫`
is negative. This is a natural companion to the existing `inner_pos_of_dist_lt_radius`
and `inner_nonneg_of_dist_le_radius`.