### PR TITLE
[Merged by Bors] - chore(ci): add continue-on-error to non-critical workflow steps

### DIFF
--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -182,6 +182,7 @@ jobs:
         if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
             steps.inputs.outputs.bot == 'true' ) }}
+        continue-on-error: true
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Send message on Zulip
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        continue-on-error: true
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -182,6 +183,7 @@ jobs:
 
       - name: Add comment to PR
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        continue-on-error: true
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:
           # if a comment triggers the action, then `issue.number` is set
@@ -202,6 +204,7 @@ jobs:
 
       - name: Add label to PR
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow

--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -98,6 +98,7 @@ jobs:
 
     - name: Update CI emoji
       if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
+      continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
       env:
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/zulip_emoji_ci_status.yaml
+++ b/.github/workflows/zulip_emoji_ci_status.yaml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Update CI emoji
       if: steps.pr.outputs.skip != 'true' && steps.action.outputs.ci_action != 'skip'
-      continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
+      continue-on-error: true
       env:
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Update zulip emoji reactions
         if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
                 github.event_name == 'reopened' }}
-        continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
+        continue-on-error: true
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: Update zulip emoji reactions
         if: ${{ ! startsWith(github.event.pull_request.title, '[Merged by Bors]') ||
                 github.event_name == 'reopened' }}
+        continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -37,6 +37,7 @@ jobs:
         pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
 
     - name: Add or remove emoji
+      continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
       env:
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -40,6 +40,7 @@ jobs:
         pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
 
     - name: Update zulip emoji reactions
+      continue-on-error: true  # Emoji updates are cosmetic; never fail CI over them
       env:
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
         ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com


### PR DESCRIPTION
This PR adds `continue-on-error: true` to non-critical workflow steps that interact with Zulip or perform cosmetic actions (emoji reactions, PR comments, label additions). These should never cause CI failures.

Affected workflows:
- `zulip_emoji_ci_status.yaml` — emoji update step
- `zulip_emoji_closed_pr.yaml` — emoji update step
- `zulip_emoji_labelling.yaml` — emoji update step (already had it)
- `zulip_emoji_merge_delegate.yaml` — emoji update step (already had it)
- `maintainer_bors.yml` / `maintainer_bors_wf_run.yml` — Zulip emoji reaction step
- `maintainer_merge.yml` / `maintainer_merge_wf_run.yml` — Zulip message, PR comment, and label steps

🤖 Prepared with Claude Code