### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Subgroup/Ker): add commonly used `map_subtype_inj`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Ker.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Ker.lean
@@ -507,6 +507,11 @@ theorem map_subtype_lt_map_subtype {G' : Subgroup G} {H K : Subgroup G'} :
 theorem map_injective {f : G →* N} (h : Function.Injective f) : Function.Injective (map f) :=
   Function.LeftInverse.injective <| comap_map_eq_self_of_injective h
 
+@[to_additive]
+theorem map_subtype_inj {H : Subgroup G} {K L : Subgroup H} :
+    K.map H.subtype = L.map H.subtype ↔ K = L :=
+  (map_injective H.subtype_injective).eq_iff
+
 /-- Given `f(A) = f(B)`, `ker f ≤ A`, and `ker f ≤ B`, deduce that `A = B`. -/
 @[to_additive /-- Given `f(A) = f(B)`, `ker f ≤ A`, and `ker f ≤ B`, deduce that `A = B`. -/]
 theorem map_injective_of_ker_le {H K : Subgroup G} (hH : f.ker ≤ H) (hK : f.ker ≤ K)

--- a/Mathlib/GroupTheory/Focal.lean
+++ b/Mathlib/GroupTheory/Focal.lean
@@ -110,8 +110,7 @@ lemma focalSubgroupOf.mk'_conj_eq {h : G} (hh : h ∈ H) (g : G)
 
 theorem focalSubgroupOf_eq_closure :
     focalSubgroupOf H = closure { g : H | ∃ x ∈ H, ∃ u : G, g = ⁅x, u⁆ } := by
-  rw [← (map_injective H.subtype_injective).eq_iff, map_focalSubgroupOf,
-    MonoidHom.map_closure, focalSubgroup_def]
+  rw [← map_subtype_inj, map_focalSubgroupOf, MonoidHom.map_closure, focalSubgroup_def]
   congr
   simp
   grind

--- a/Mathlib/GroupTheory/IsPerfect.lean
+++ b/Mathlib/GroupTheory/IsPerfect.lean
@@ -48,7 +48,7 @@ lemma isPerfect_def : IsPerfect G ↔ commutator G = ⊤ :=
   ⟨fun h ↦ h.commutator_eq_top, fun h ↦ ⟨h⟩⟩
 
 lemma _root_.Subgroup.isPerfect_iff : IsPerfect H ↔ ⁅H, H⁆ = H := by
-  rw [Group.isPerfect_def, ← (map_injective H.subtype_injective).eq_iff,
+  rw [Group.isPerfect_def, ← map_subtype_inj,
     map_subtype_commutator, ← MonoidHom.range_eq_map, range_subtype]
 
 lemma _root_.Subgroup.commutator_eq_self [hH : IsPerfect H] : ⁅H, H⁆ = H :=
@@ -64,7 +64,7 @@ instance [Subsingleton G] : IsPerfect G where
   commutator_eq_top := Subsingleton.elim _ _
 
 theorem top_iff : IsPerfect (⊤ : Subgroup G) ↔ IsPerfect G := by
-  rw [isPerfect_def, isPerfect_def, ← (map_injective (⊤ : Subgroup G).subtype_injective).eq_iff,
+  rw [isPerfect_def, isPerfect_def, ← map_subtype_inj,
     map_subtype_commutator, ← MonoidHom.range_eq_map, subtype_range, commutator_def]
 
 instance [IsPerfect G] : IsPerfect (⊤ : Subgroup G) :=

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -222,8 +222,7 @@ private theorem step3 (K : Subgroup N) [(K.map N.subtype).Normal] : K = ⊥ ∨ 
     rhs
     rhs
     rw [← N.range_subtype, N.subtype.range_eq_map]
-  have inj := map_injective N.subtype_injective
-  rwa [inj.eq_iff, inj.eq_iff] at key
+  rwa [map_subtype_inj, map_subtype_inj] at key
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step4 : (Nat.card N).minFac.Prime :=

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -181,7 +181,7 @@ theorem isSolvable_iff_commutator_lt [WellFoundedLT (Subgroup G)] :
   · infer_instance
   · obtain ⟨n, hn⟩ := hH ⁅H, H⁆ (h H h')
     use n + 1
-    rw [← (map_injective (subtype_injective _)).eq_iff, Subgroup.map_bot] at hn ⊢
+    rw [← map_subtype_inj, Subgroup.map_bot] at hn ⊢
     rw [← hn]
     clear hn
     induction n with

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -239,8 +239,7 @@ theorem IsThreeCycle.alternating_normalClosure (h5 : 5 ≤ Fintype.card α) {f :
     normalClosure ({⟨f, hf.mem_alternatingGroup⟩} : Set (alternatingGroup α)) = ⊤ :=
   eq_top_iff.2
     (by
-      have hi : Function.Injective (alternatingGroup α).subtype := Subtype.coe_injective
-      refine eq_top_iff.1 (map_injective hi (le_antisymm (map_mono le_top) ?_))
+      rw [← map_subtype_le_map_subtype]
       rw [← MonoidHom.range_eq_map, range_subtype, normalClosure, MonoidHom.map_closure]
       refine (le_of_eq closure_three_cycles_eq_alternating.symm).trans (closure_mono ?_)
       intro g h

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -279,7 +279,7 @@ theorem ker_transferSylow_isComplement' : IsComplement' (transferSylow P hP).ker
   have := range_eq_top.mp (top_le_iff.mp (hf.2.ge.trans
     (map_le_range (transferSylow P hP) P)))
   rw [← (comap_injective this).eq_iff, comap_top, comap_map_eq, sup_comm, SetLike.ext'_iff,
-    normal_mul, ← ker_eq_bot_iff, ← (map_injective (P : Subgroup G).subtype_injective).eq_iff,
+    normal_mul, ← ker_eq_bot_iff, ← map_subtype_inj,
     ker_restrict, subgroupOf_map_subtype, Subgroup.map_bot, coe_top] at hf
   exact isComplement'_of_disjoint_and_mul_eq_univ (disjoint_iff.2 hf.1) hf.2
 


### PR DESCRIPTION
This PR adds `Subgroup.map_subtype_inj` which has come up several times now.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
