### PR TITLE
[Merged by Bors] - chore(Data/Fin): rewrite `fin_omega` tactic docstring

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -251,7 +251,9 @@ attribute [fin_omega] Fin.lt_iff_val_lt_val Fin.le_iff_val_le_val
 attribute [fin_omega] val_one
 
 /--
-Preprocessor for `omega` to handle inequalities in `Fin`.
+`fin_omega` is a preprocessor for `omega` to handle inequalities in `Fin`.
+It rewrites all hypotheses and the goal, turning statements about addition, subtraction and
+inequalities in `Fin n` into statements that `omega` can use/solve.
 Note that this involves a lot of case splitting, so may be slow.
 -/
 -- Further adjustment to the simp set can probably make this more powerful.


### PR DESCRIPTION
This PR (re)writes the docstring for the `fin_omega` tactic, to consistently match the official style guide, to make sure it is complete while not getting too long.

The goal is to explain the tactic's scope a bit clearer (namely, inequalities in `Fin`).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
