### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/EllipticCurve/Affine/Point): expose coordinates

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -478,7 +478,8 @@ point at infinity `WeierstrassCurve.Affine.Point.zero` or a nonsingular affine p
 `WeierstrassCurve.Affine.Point.some (x, y)` satisfying the Weierstrass equation of `W`. -/
 inductive Point
   | zero
-  | some {x y : R} (h : W'.Nonsingular x y)
+  | some (x y : R) (h : W'.Nonsingular x y)
+deriving DecidableEq
 
 /-- For an algebraic extension `S` of a ring `R`, the type of nonsingular `S`-points on a
 Weierstrass curve `W` over `R` in affine coordinates. -/
@@ -487,11 +488,11 @@ scoped notation3:max W' "⟮" S "⟯" => Point <| baseChange W' S
 /-- The equivalence between the nonsingular points on a Weierstrass curve `W` in affine coordinates
 satisfying a predicate and the set of pairs `⟨x, y⟩` satisfying `W.Nonsingular x y` with zero. -/
 def nonsingularPointEquivSubtype {p : W'.Point → Prop} (p0 : p .zero) : {P : W'.Point // p P} ≃
-    WithZero {xy : R × R // ∃ h : W'.Nonsingular xy.fst xy.snd, p <| .some h} where
+    WithZero {xy : R × R // ∃ h : W'.Nonsingular xy.fst xy.snd, p <| .some _ _ h} where
   toFun
     | ⟨.zero, _⟩ => none
-    | ⟨.some h, ph⟩ => .some ⟨⟨_, _⟩, h, ph⟩
-  invFun P := P.casesOn ⟨.zero, p0⟩ fun xy => ⟨.some xy.prop.choose, xy.prop.choose_spec⟩
+    | ⟨.some _ _ h, ph⟩ => .some ⟨⟨_, _⟩, h, ph⟩
+  invFun P := P.casesOn ⟨.zero, p0⟩ fun xy => ⟨.some _ _ xy.prop.choose, xy.prop.choose_spec⟩
   left_inv := by rintro (_ | _) <;> rfl
   right_inv := by rintro (_ | _) <;> rfl
 
@@ -502,8 +503,8 @@ lemma nonsingularPointEquivSubtype_zero {p : W'.Point → Prop} (p0 : p .zero) :
 
 @[simp]
 lemma nonsingularPointEquivSubtype_some {x y : R} {h : W'.Nonsingular x y} {p : W'.Point → Prop}
-    (p0 : p .zero) (ph : p <| .some h) :
-    nonsingularPointEquivSubtype p0 ⟨.some h, ph⟩ = .some ⟨⟨x, y⟩, h, ph⟩ :=
+    (p0 : p .zero) (ph : p <| .some _ _ h) :
+    nonsingularPointEquivSubtype p0 ⟨.some _ _ h, ph⟩ = .some ⟨⟨x, y⟩, h, ph⟩ :=
   rfl
 
 @[simp]
@@ -513,8 +514,8 @@ lemma nonsingularPointEquivSubtype_symm_none {p : W'.Point → Prop} (p0 : p .ze
 
 @[simp]
 lemma nonsingularPointEquivSubtype_symm_some {x y : R} {h : W'.Nonsingular x y}
-    {p : W'.Point → Prop} (p0 : p .zero) (ph : p <| .some h) :
-    (nonsingularPointEquivSubtype p0).symm (.some ⟨⟨x, y⟩, h, ph⟩) = ⟨.some h, ph⟩ :=
+    {p : W'.Point → Prop} (p0 : p .zero) (ph : p <| .some _ _ h) :
+    (nonsingularPointEquivSubtype p0).symm (.some ⟨⟨x, y⟩, h, ph⟩) = ⟨.some _ _ h, ph⟩ :=
   rfl
 
 variable (W') in
@@ -530,7 +531,7 @@ lemma nonsingularPointEquiv_zero : nonsingularPointEquiv W' .zero = none :=
 
 @[simp]
 lemma nonsingularPointEquiv_some {x y : R} (h : W'.Nonsingular x y) :
-    W'.nonsingularPointEquiv (.some h) = .some ⟨⟨x, y⟩, h⟩ := by
+    W'.nonsingularPointEquiv (.some _ _ h) = .some ⟨⟨x, y⟩, h⟩ := by
   rfl
 
 @[simp]
@@ -539,7 +540,7 @@ lemma nonsingularPointEquiv_symm_none : W'.nonsingularPointEquiv.symm none = .ze
 
 @[simp]
 lemma nonsingularPointEquiv_symm_some {x y : R} (h : W'.Nonsingular x y) :
-    W'.nonsingularPointEquiv.symm (.some ⟨⟨x, y⟩, h⟩) = .some h :=
+    W'.nonsingularPointEquiv.symm (.some ⟨⟨x, y⟩, h⟩) = .some _ _ h :=
   rfl
 
 section IsElliptic
@@ -548,7 +549,7 @@ variable [Nontrivial R] [W'.IsElliptic]
 
 /-- A point on an elliptic curve `W` over `R`. -/
 def Point.mk {x y : R} (h : W'.Equation x y) : W'.Point :=
-  .some <| equation_iff_nonsingular.mp h
+  .some _ _ <| equation_iff_nonsingular.mp h
 
 /-- The equivalence between the points on an elliptic curve `W` in affine coordinates satisfying a
 predicate and the set of pairs `⟨x, y⟩` satisfying `W.Equation x y` with zero. -/
@@ -618,7 +619,7 @@ instance : Zero W'.Point :=
 lemma zero_def : 0 = (zero : W'.Point) :=
   rfl
 
-lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : some h ≠ 0 := by
+lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : some _ _ h ≠ 0 := by
   rintro (_ | _)
 
 /-- The negation of a nonsingular point on a Weierstrass curve in affine coordinates.
@@ -626,7 +627,7 @@ lemma some_ne_zero {x y : R} (h : W'.Nonsingular x y) : some h ≠ 0 := by
 Given a nonsingular point `P` in affine coordinates, use `-P` instead of `neg P`. -/
 def neg : W'.Point → W'.Point
   | 0 => 0
-  | some h => some <| (nonsingular_neg ..).mpr h
+  | some _ _ h => some _ _ <| (nonsingular_neg ..).mpr h
 
 instance : Neg W'.Point :=
   ⟨neg⟩
@@ -639,7 +640,8 @@ lemma neg_zero : (-0 : W'.Point) = 0 :=
   rfl
 
 @[simp]
-lemma neg_some {x y : R} (h : W'.Nonsingular x y) : -some h = some ((nonsingular_neg ..).mpr h) :=
+lemma neg_some {x y : R} (h : W'.Nonsingular x y) :
+    -some _ _ h = some _ _ ((nonsingular_neg ..).mpr h) :=
   rfl
 
 instance : InvolutiveNeg W'.Point where
@@ -656,8 +658,8 @@ Given two nonsingular points `P` and `Q` in affine coordinates, use `P + Q` inst
 def add [DecidableEq F] : W.Point → W.Point → W.Point
   | 0, P => P
   | P, 0 => P
-  | @some _ _ _ x₁ y₁ h₁, @some _ _ _ x₂ y₂ h₂ =>
-    if hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0 else some <| nonsingular_add h₁ h₂ hxy
+  | some x₁ y₁ h₁, some x₂ y₂ h₂ =>
+    if hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂ then 0 else some _ _ <| nonsingular_add h₁ h₂ hxy
 
 instance : Add W.Point :=
   ⟨add⟩
@@ -670,46 +672,49 @@ lemma add_def (P Q : W.Point) : P + Q = P.add Q :=
   rfl
 
 lemma add_some {x₁ x₂ y₁ y₂ : F} (hxy : ¬(x₁ = x₂ ∧ y₁ = W.negY x₂ y₂)) {h₁ : W.Nonsingular x₁ y₁}
-    {h₂ : W.Nonsingular x₂ y₂} : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ hxy) := by
+    {h₂ : W.Nonsingular x₂ y₂} :
+    some _ _ h₁ + some _ _ h₂ = some _ _ (nonsingular_add h₁ h₂ hxy) := by
   simp only [add_def, add, dif_neg hxy]
 
 @[simp]
 lemma add_of_Y_eq {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) : some h₁ + some h₂ = 0 := by
+    (hx : x₁ = x₂) (hy : y₁ = W.negY x₂ y₂) : some _ _ h₁ + some _ _ h₂ = 0 := by
   simpa only [add_def, add] using dif_pos ⟨hx, hy⟩
 
 -- Removing `@[simp]`, because `hy` causes a maximum recursion depth error in the simpNF linter.
 lemma add_self_of_Y_eq {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ = W.negY x₁ y₁) :
-    some h₁ + some h₁ = 0 :=
+    some _ _ h₁ + some _ _ h₁ = 0 :=
   add_of_Y_eq rfl hy
 
 -- @[simp] -- Not a good simp lemma, since `hy` is not in simp normal form.
 lemma add_of_Y_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hy hxy.right) :=
+    some _ _ h₁ + some _ _ h₂ = some _ _ (nonsingular_add h₁ h₂ fun hxy => hy hxy.right) :=
   add_some fun hxy => hy hxy.right
 
 lemma add_of_Y_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
     (hy : y₁ ≠ W.negY x₂ y₂) :
-    some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hy hxy.right) :=
+    some _ _ h₁ + some _ _ h₂ = -some _ _ (nonsingular_negAdd h₁ h₂ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 -- @[simp] -- Not a good simp lemma, since `hy` is not in simp normal form.
 lemma add_self_of_Y_ne {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = some (nonsingular_add h₁ h₁ fun hxy => hy hxy.right) :=
+    some _ _ h₁ + some _ _ h₁ = some _ _ (nonsingular_add h₁ h₁ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 lemma add_self_of_Y_ne' {x₁ y₁ : F} {h₁ : W.Nonsingular x₁ y₁} (hy : y₁ ≠ W.negY x₁ y₁) :
-    some h₁ + some h₁ = -some (nonsingular_negAdd h₁ h₁ fun hxy => hy hxy.right) :=
+    some _ _ h₁ + some _ _ h₁ = -some _ _ (nonsingular_negAdd h₁ h₁ fun hxy => hy hxy.right) :=
   add_of_Y_ne hy
 
 @[simp]
 lemma add_of_X_ne {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = some (nonsingular_add h₁ h₂ fun hxy => hx hxy.left) :=
+    (hx : x₁ ≠ x₂) :
+    some _ _ h₁ + some _ _ h₂ = some _ _ (nonsingular_add h₁ h₂ fun hxy => hx hxy.left) :=
   add_some fun hxy => hx hxy.left
 
 lemma add_of_X_ne' {x₁ x₂ y₁ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂}
-    (hx : x₁ ≠ x₂) : some h₁ + some h₂ = -some (nonsingular_negAdd h₁ h₂ fun hxy => hx hxy.left) :=
+    (hx : x₁ ≠ x₂) :
+    some _ _ h₁ + some _ _ h₂ = -some _ _ (nonsingular_negAdd h₁ h₂ fun hxy => hx hxy.left) :=
   add_of_X_ne hx
 
 /-- The group homomorphism mapping a nonsingular affine point `(x, y)` of a Weierstrass curve `W` to
@@ -718,10 +723,10 @@ the class of the non-zero fractional ideal `⟨X - x, Y - y⟩` in the ideal cla
 noncomputable def toClass : W.Point →+ Additive (ClassGroup W.CoordinateRing) where
   toFun P := match P with
     | 0 => 0
-    | some h => Additive.ofMul <| ClassGroup.mk <| CoordinateRing.XYIdeal' h
+    | some _ _ h => ClassGroup.mk <| CoordinateRing.XYIdeal' h
   map_zero' := rfl
   map_add' := by
-    rintro (_ | @⟨x₁, y₁, h₁⟩) (_ | @⟨x₂, y₂, h₂⟩)
+    rintro (_ | ⟨x₁, y₁, h₁⟩) (_ | ⟨x₂, y₂, h₂⟩)
     any_goals simp only [← zero_def, zero_add, add_zero]
     by_cases hxy : x₁ = x₂ ∧ y₁ = W.negY x₂ y₂
     · simp only [hxy.left, hxy.right, add_of_Y_eq rfl rfl]
@@ -733,11 +738,11 @@ lemma toClass_zero : toClass (0 : W.Point) = 0 :=
   rfl
 
 lemma toClass_some {x y : F} (h : W.Nonsingular x y) :
-    toClass (some h) = ClassGroup.mk (CoordinateRing.XYIdeal' h) :=
+    toClass (some _ _ h) = ClassGroup.mk (CoordinateRing.XYIdeal' h) :=
   rfl
 
 private lemma add_eq_zero (P Q : W.Point) : P + Q = 0 ↔ P = -Q := by
-  rcases P, Q with ⟨_ | @⟨x₁, y₁, _⟩, _ | @⟨x₂, y₂, _⟩⟩
+  rcases P, Q with ⟨_ | ⟨x₁, y₁, _⟩, _ | ⟨x₂, y₂, _⟩⟩
   any_goals rfl
   · rw [← zero_def, zero_add, eq_comm (a := 0), neg_eq_iff_eq_neg, neg_zero]
   · rw [neg_some, some.injEq]
@@ -749,7 +754,7 @@ private lemma add_eq_zero (P Q : W.Point) : P + Q = 0 ↔ P = -Q := by
 lemma toClass_eq_zero (P : W.Point) : toClass P = 0 ↔ P = 0 := by
   constructor
   · intro hP
-    rcases P with (_ | ⟨h, _⟩)
+    rcases P with (_ | ⟨_, _, h, _⟩)
     · rfl
     · rcases (ClassGroup.mk_eq_one_of_coe_ideal <| by rfl).mp hP with ⟨p, h0, hp⟩
       apply (p.natDegree_norm_ne_one _).elim
@@ -759,7 +764,7 @@ lemma toClass_eq_zero (P : W.Point) : toClass P = 0 ↔ P = 0 := by
   · exact congr_arg toClass
 
 lemma toClass_injective : Function.Injective <| toClass (W := W) := by
-  rintro (_ | h) _ hP
+  rintro (_ | ⟨_, _, h⟩) _ hP
   all_goals rw [← neg_inj, ← add_eq_zero, ← toClass_eq_zero, map_add, ← hP]
   · exact zero_add 0
   · exact CoordinateRing.mk_XYIdeal'_neg_mul h
@@ -788,22 +793,22 @@ where `W` is defined over a subring of a ring `S`, and `F` and `K` are field ext
 noncomputable def map : W'⟮F⟯ →+ W'⟮K⟯ where
   toFun P := match P with
     | 0 => 0
-    | some h => some <| (baseChange_nonsingular _ _ f.injective).mpr h
+    | some _ _ h => some _ _ <| (baseChange_nonsingular _ _ f.injective).mpr h
   map_zero' := rfl
   map_add' := by
-    rintro (_ | @⟨x₁, y₁, _⟩) (_ | @⟨x₂, y₂, _⟩)
+    rintro (_ | ⟨x₁, y₁, h₁⟩) (_ | ⟨x₂, y₂, h₂⟩)
     any_goals rfl
     by_cases hxy : x₁ = x₂ ∧ y₁ = (W'.baseChange F).toAffine.negY x₂ y₂
     · rw [add_of_Y_eq hxy.left hxy.right,
         add_of_Y_eq (congr_arg _ hxy.left) <| by rw [hxy.right, baseChange_negY]]
-    · simp only [add_some hxy, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope]
-      rw [add_some fun h => hxy ⟨f.injective h.1, f.injective (W'.baseChange_negY f .. ▸ h).2⟩]
+    · simpa only [add_some hxy, ← baseChange_addX, ← baseChange_addY, ← baseChange_slope] using
+        (add_some fun h ↦ hxy ⟨f.injective h.1, f.injective (W'.baseChange_negY f .. ▸ h).2⟩).symm
 
 lemma map_zero : map f (0 : W'⟮F⟯) = 0 :=
   rfl
 
 lemma map_some {x y : F} (h : (W'.baseChange F).toAffine.Nonsingular x y) :
-    map f (some h) = some ((W'.baseChange_nonsingular _ _ f.injective).mpr h) :=
+    map f (some _ _ h) = some _ _ ((W'.baseChange_nonsingular _ _ f.injective).mpr h) :=
   rfl
 
 lemma map_id (P : W'⟮F⟯) : map (Algebra.ofId F F) P = P := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -394,17 +394,17 @@ lemma mk_ne_zero [Nontrivial R] {X Y : R} (h : W'.NonsingularLift ⟦![X, Y, 1]�
 corresponding nonsingular Jacobian point. -/
 def fromAffine [Nontrivial R] : W'.toAffine.Point → W'.Point
   | 0 => 0
-  | .some h => ⟨(nonsingularLift_some ..).mpr h⟩
+  | .some _ _ h => ⟨(nonsingularLift_some ..).mpr h⟩
 
 lemma fromAffine_zero [Nontrivial R] : fromAffine 0 = (0 : W'.Point) :=
   rfl
 
 lemma fromAffine_some [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
-    fromAffine (.some h) = ⟨(nonsingularLift_some ..).mpr h⟩ :=
+    fromAffine (.some _ _ h) = ⟨(nonsingularLift_some ..).mpr h⟩ :=
   rfl
 
 lemma fromAffine_some_ne_zero [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
-    fromAffine (.some h) ≠ 0 :=
+    fromAffine (.some _ _ h) ≠ 0 :=
   mk_ne_zero <| (nonsingularLift_some ..).mpr h
 
 /-- The negation of a nonsingular Jacobian point on a Weierstrass curve `W`.
@@ -444,7 +444,7 @@ variable (W) in
 /-- The natural map from a nonsingular Jacobian point representative on a Weierstrass curve to its
 corresponding nonsingular point in affine coordinates. -/
 noncomputable def toAffine (P : Fin 3 → F) : W.toAffine.Point :=
-  if hP : W.Nonsingular P ∧ P z ≠ 0 then .some <| (nonsingular_of_Z_ne_zero hP.2).mp hP.1 else 0
+  if hP : W.Nonsingular P ∧ P z ≠ 0 then .some _ _ <| (nonsingular_of_Z_ne_zero hP.2).mp hP.1 else 0
 
 lemma toAffine_of_singular {P : Fin 3 → F} (hP : ¬W.Nonsingular P) : toAffine W P = 0 := by
   rw [toAffine, dif_neg <| not_and_of_not_left _ hP]
@@ -456,11 +456,11 @@ lemma toAffine_zero : toAffine W ![1, 1, 0] = 0 :=
   toAffine_of_Z_eq_zero rfl
 
 lemma toAffine_of_Z_ne_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z ≠ 0) :
-    toAffine W P = .some ((nonsingular_of_Z_ne_zero hPz).mp hP) := by
+    toAffine W P = .some _ _ ((nonsingular_of_Z_ne_zero hPz).mp hP) := by
   rw [toAffine, dif_pos ⟨hP, hPz⟩]
 
 lemma toAffine_some {X Y : F} (h : W.Nonsingular ![X, Y, 1]) :
-    toAffine W ![X, Y, 1] = .some ((nonsingular_some ..).mp h) := by
+    toAffine W ![X, Y, 1] = .some _ _ ((nonsingular_some ..).mp h) := by
   simp only [toAffine_of_Z_ne_zero h one_ne_zero, fin3_def_ext, one_pow, div_one]
 
 lemma toAffine_smul (P : Fin 3 → F) {u : F} (hu : IsUnit u) :
@@ -546,11 +546,11 @@ lemma toAffineLift_zero : toAffineLift (0 : W.Point) = 0 :=
   toAffine_zero
 
 lemma toAffineLift_of_Z_ne_zero {P : Fin 3 → F} {hP : W.NonsingularLift ⟦P⟧} (hPz : P z ≠ 0) :
-    toAffineLift ⟨hP⟩ = .some ((nonsingular_of_Z_ne_zero hPz).mp hP) :=
+    toAffineLift ⟨hP⟩ = .some _ _ ((nonsingular_of_Z_ne_zero hPz).mp hP) :=
   toAffine_of_Z_ne_zero hP hPz
 
 lemma toAffineLift_some {X Y : F} (h : W.NonsingularLift ⟦![X, Y, 1]⟧) :
-    toAffineLift ⟨h⟩ = .some ((nonsingular_some ..).mp h) :=
+    toAffineLift ⟨h⟩ = .some _ _ ((nonsingular_some ..).mp h) :=
   toAffine_some h
 
 lemma toAffineLift_neg (P : W.Point) : (-P).toAffineLift = -P.toAffineLift := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
@@ -380,17 +380,17 @@ lemma mk_ne_zero [Nontrivial R] {X Y : R} (h : W'.NonsingularLift ⟦![X, Y, 1]�
 corresponding nonsingular projective point. -/
 def fromAffine [Nontrivial R] : W'.toAffine.Point → W'.Point
   | 0 => 0
-  | .some h => ⟨(nonsingularLift_some ..).mpr h⟩
+  | .some _ _ h => ⟨(nonsingularLift_some ..).mpr h⟩
 
 lemma fromAffine_zero [Nontrivial R] : fromAffine 0 = (0 : W'.Point) :=
   rfl
 
 lemma fromAffine_some [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
-    fromAffine (.some h) = ⟨(nonsingularLift_some ..).mpr h⟩ :=
+    fromAffine (.some _ _ h) = ⟨(nonsingularLift_some ..).mpr h⟩ :=
   rfl
 
 lemma fromAffine_some_ne_zero [Nontrivial R] {X Y : R} (h : W'.toAffine.Nonsingular X Y) :
-    fromAffine (.some h) ≠ 0 :=
+    fromAffine (.some _ _ h) ≠ 0 :=
   mk_ne_zero <| (nonsingularLift_some ..).mpr h
 
 /-- The negation of a nonsingular projective point on a Weierstrass curve `W`.
@@ -430,7 +430,7 @@ variable (W) in
 /-- The natural map from a nonsingular projective point representative on a Weierstrass curve to its
 corresponding nonsingular point in affine coordinates. -/
 noncomputable def toAffine (P : Fin 3 → F) : W.toAffine.Point :=
-  if hP : W.Nonsingular P ∧ P z ≠ 0 then .some <| (nonsingular_of_Z_ne_zero hP.2).mp hP.1 else 0
+  if hP : W.Nonsingular P ∧ P z ≠ 0 then .some _ _ <| (nonsingular_of_Z_ne_zero hP.2).mp hP.1 else 0
 
 lemma toAffine_of_singular {P : Fin 3 → F} (hP : ¬W.Nonsingular P) : toAffine W P = 0 := by
   rw [toAffine, dif_neg <| not_and_of_not_left _ hP]
@@ -442,11 +442,11 @@ lemma toAffine_zero : toAffine W ![0, 1, 0] = 0 :=
   toAffine_of_Z_eq_zero rfl
 
 lemma toAffine_of_Z_ne_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z ≠ 0) :
-    toAffine W P = .some ((nonsingular_of_Z_ne_zero hPz).mp hP) := by
+    toAffine W P = .some _ _ ((nonsingular_of_Z_ne_zero hPz).mp hP) := by
   rw [toAffine, dif_pos ⟨hP, hPz⟩]
 
 lemma toAffine_some {X Y : F} (h : W.Nonsingular ![X, Y, 1]) :
-    toAffine W ![X, Y, 1] = .some ((nonsingular_some ..).mp h) := by
+    toAffine W ![X, Y, 1] = .some _ _ ((nonsingular_some ..).mp h) := by
   simp only [toAffine_of_Z_ne_zero h one_ne_zero, fin3_def_ext, div_one]
 
 lemma toAffine_smul (P : Fin 3 → F) {u : F} (hu : IsUnit u) :
@@ -532,11 +532,11 @@ lemma toAffineLift_zero : toAffineLift (0 : W.Point) = 0 :=
   toAffine_zero
 
 lemma toAffineLift_of_Z_ne_zero {P : Fin 3 → F} {hP : W.NonsingularLift ⟦P⟧} (hPz : P z ≠ 0) :
-    toAffineLift ⟨hP⟩ = .some ((nonsingular_of_Z_ne_zero hPz).mp hP) :=
+    toAffineLift ⟨hP⟩ = .some _ _ ((nonsingular_of_Z_ne_zero hPz).mp hP) :=
   toAffine_of_Z_ne_zero hP hPz
 
 lemma toAffineLift_some {X Y : F} (h : W.NonsingularLift ⟦![X, Y, 1]⟧) :
-    toAffineLift ⟨h⟩ = .some ((nonsingular_some ..).mp h) :=
+    toAffineLift ⟨h⟩ = .some _ _ ((nonsingular_some ..).mp h) :=
   toAffine_some h
 
 lemma toAffineLift_neg (P : W.Point) : (-P).toAffineLift = -P.toAffineLift := by


### PR DESCRIPTION
This PR seems to add a lot of noise, but there are two good reasons for it:
- Currently the infoview shows `Point.some ...` for any affine point, so the computation of an addition of two points would show `Point.some ... + Point.some ... = Point.some ...` in the infoview, so the user has to hover over each of them to see what's going on.
- When creating (resp extracting) the coordinates of explicit points in downstream files, one needs to type `Point.some (x := x) (y := y) h` (resp `@Point.some _ _ _ x y h`) to create (resp extract) an affine point `(x, y)` and the proof `h` that it is nonsingular, which has been pretty annoying so far.

Of course the former can be solved by some metaprogramming / pretty printing, but I think the latter is good enough a reason to have this quality of life change.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
