### PR TITLE
[Merged by Bors] - feat(Probability/UniformOn): add uniformOn_pi

### DIFF
--- a/Mathlib/Probability/UniformOn.lean
+++ b/Mathlib/Probability/UniformOn.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Probability.ConditionalProbability
 public import Mathlib.MeasureTheory.Measure.Count
+public import Mathlib.MeasureTheory.Constructions.Pi
+import Mathlib.Data.Fintype.Pi
 
 /-!
 # Classical probability
@@ -218,5 +220,17 @@ theorem uniformOn_add_compl_eq (u t : Set Ω) (hs : s.Finite) :
       ← uniformOn_disjoint_union (hs.inter_of_left _) (hs.inter_of_left _)
       (disjoint_compl_right.mono inf_le_right inf_le_right)]
   simp [uniformOn_inter_self hs]
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The uniform measure on a product of sets is the product of the uniform measures. -/
+lemma uniformOn_pi [Finite Ω] {f : ι → Set Ω} :
+    uniformOn (Set.univ.pi f) = Measure.pi fun i ↦ uniformOn (f i) := by
+  refine (MeasureTheory.Measure.pi_eq fun t ht ↦ ?_).symm
+  lift f to ι → Finset Ω using by simp [Set.toFinite]
+  lift t to ι → Finset Ω using by simp [Set.toFinite]
+  classical
+  simp [← Fintype.coe_piFinset, uniformOn_apply_finset, ← Fintype.piFinset_inter,
+    ENNReal.prod_div_distrib_of_ne_top]
 
 end ProbabilityTheory

--- a/Mathlib/Probability/UniformOn.lean
+++ b/Mathlib/Probability/UniformOn.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Probability.ConditionalProbability
 public import Mathlib.MeasureTheory.Measure.Count
 public import Mathlib.MeasureTheory.Constructions.Pi
+
 import Mathlib.Data.Fintype.Pi
 
 /-!
@@ -32,7 +33,7 @@ for that purpose.
 
 The original aim of this file is to provide a measure-theoretic method of describing the
 probability an element of a set `s` satisfies some predicate `P`. Our current formulation still
-allow us to describe this by abusing the definitional equality of sets and predicates by simply
+allows us to describe this by abusing the definitional equality of sets and predicates by simply
 writing `uniformOn s P`. We should avoid this however as none of the lemmas are written for
 predicates.
 -/


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
