### PR TITLE
[Merged by Bors] - doc: remove TODO that has meanwhile been implemented

### DIFF
--- a/Mathlib/Analysis/Complex/Harmonic/Liouville.lean
+++ b/Mathlib/Analysis/Complex/Harmonic/Liouville.lean
@@ -11,7 +11,7 @@ public import Mathlib.Analysis.Complex.Harmonic.Analytic
 /-!
 # Liouville's Theorem for Harmonic Functions on the Complex Plane
 
-A real-valued, bounded harmonic function on the complex plane is constant.
+A bounded harmonic function on the complex plane is constant.
 -/
 
 public section
@@ -43,8 +43,8 @@ private theorem InnerProductSpace.bounded_harmonic_on_complex_plane_is_constant_
 
 set_option backward.isDefEq.respectTransparency false in
 /--
-**Liouville's theorem for harmonic functions on the complex plane** A real-valued, bounded harmonic
-function on the complex plane is constant.
+**Liouville's theorem for harmonic functions on the complex plane** A bounded harmonic function on
+the complex plane is constant.
 -/
 theorem InnerProductSpace.bounded_harmonic_on_complex_plane_is_constant (f : ℂ → E)
     (h_harm : HarmonicOnNhd f univ) (h_bound : IsBounded (range f)) :

--- a/Mathlib/Analysis/Complex/Harmonic/Liouville.lean
+++ b/Mathlib/Analysis/Complex/Harmonic/Liouville.lean
@@ -12,8 +12,6 @@ public import Mathlib.Analysis.Complex.Harmonic.Analytic
 # Liouville's Theorem for Harmonic Functions on the Complex Plane
 
 A real-valued, bounded harmonic function on the complex plane is constant.
-
-TODO: Prove this result for harmonic functions with values in vector spaces.
 -/
 
 public section


### PR DESCRIPTION
Remove an outdated TODO from a docstring.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
