### PR TITLE
[Merged by Bors] - chore(Algebra): unsqueeze terminal `simp`:s (`simp only […]` to `simp`)

### DIFF
--- a/Mathlib/Algebra/Algebra/Spectrum/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum/Basic.lean
@@ -314,7 +314,7 @@ variable {R : Type u} {A : Type v} [Semifield R] [Ring A] [Algebra R A]
 lemma inv₀_mem_iff {r : R} {a : Aˣ} :
     r⁻¹ ∈ spectrum R (a : A) ↔ r ∈ spectrum R (↑a⁻¹ : A) := by
   obtain (rfl | hr) := eq_or_ne r 0
-  · simp [zero_mem_iff]
+  · simp
   · lift r to Rˣ using hr.isUnit
     simp [inv_mem_iff]
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -520,7 +520,7 @@ lemma partialProd_contractNth {G : Type*} [Monoid G] {n : ℕ}
     partialProd (contractNth a (· * ·) g) = partialProd g ∘ a.succ.succAbove := by
   ext i
   refine inductionOn i ?_ ?_
-  · simp only [partialProd_zero, Function.comp_apply, succ_succAbove_zero]
+  · simp
   · intro i hi
     simp only [Function.comp_apply, succ_succAbove_succ] at *
     rw [partialProd_succ, partialProd_succ, hi]

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -213,7 +213,7 @@ theorem fib_le_of_contsAux_b :
       intro n IH hyp
       rcases n with (_ | _ | n)
       · simp [contsAux] -- case n = 0
-      · simp [contsAux] -- case n = 1
+      · simp -- case n = 1
       · let g := of v -- case 2 ≤ n
         have : ¬n + 2 ≤ 1 := by lia
         have not_terminatedAt_n : ¬g.TerminatedAt n := Or.resolve_left hyp this

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -150,7 +150,7 @@ theorem normalize_eq_normalize [IsCancelMulZero α] {a b : α} (hab : a ∣ b) (
     normalize a = normalize b := by
   nontriviality α
   rcases associated_of_dvd_dvd hab hba with ⟨u, rfl⟩
-  refine by_cases (by rintro rfl; simp only [zero_mul]) fun ha : a ≠ 0 => ?_
+  refine by_cases (by rintro rfl; simp) fun ha : a ≠ 0 => ?_
   suffices a * ↑(normUnit a) = a * ↑u * ↑(normUnit a) * ↑u⁻¹ by
     simpa only [normalize_apply, mul_assoc, normUnit_mul ha u.ne_zero, normUnit_coe_units]
   calc
@@ -412,7 +412,7 @@ theorem gcd_same [NormalizedGCDMonoid α] (a : α) : gcd a a = normalize a :=
 @[simp]
 theorem gcd_mul_left [NormalizedGCDMonoid α] (a b c : α) :
     gcd (a * b) (a * c) = normalize a * gcd b c :=
-  (by_cases (by rintro rfl; simp only [zero_mul, gcd_zero_left, normalize_zero]))
+  (by_cases (by rintro rfl; simp))
     fun ha : a ≠ 0 =>
     suffices gcd (a * b) (a * c) = normalize (a * gcd b c) by simpa
     let ⟨d, eq⟩ := dvd_gcd (dvd_mul_right a b) (dvd_mul_right a c)
@@ -777,7 +777,7 @@ theorem lcm_eq_one_iff [NormalizedGCDMonoid α] (a b : α) : lcm a b = 1 ↔ a �
 @[simp]
 theorem lcm_mul_left [NormalizedGCDMonoid α] (a b c : α) :
     lcm (a * b) (a * c) = normalize a * lcm b c :=
-  (by_cases (by rintro rfl; simp only [zero_mul, lcm_zero_left, normalize_zero]))
+  (by_cases (by rintro rfl; simp))
     fun ha : a ≠ 0 =>
     suffices lcm (a * b) (a * c) = normalize (a * lcm b c) by simpa
     have : a ∣ lcm (a * b) (a * c) := (dvd_mul_right _ _).trans (dvd_lcm_left _ _)

--- a/Mathlib/Algebra/Lie/IdealOperations.lean
+++ b/Mathlib/Algebra/Lie/IdealOperations.lean
@@ -93,7 +93,7 @@ theorem lieIdeal_oper_eq_linear_span [LieModule R L M] :
         refine Submodule.add_mem _ ?_ ?_ <;> apply Submodule.subset_span
         · use ⟨⁅y, ↑x⁆, I.lie_mem x.property⟩, n
         · use x, ⟨⁅y, ↑n⁆, N.lie_mem n.property⟩
-      · simp only [lie_zero, Submodule.zero_mem]
+      · simp
       · intro m₁ m₂ _ _ hm₁ hm₂; rw [lie_add]; exact Submodule.add_mem _ hm₁ hm₂
       · intro t m'' _ hm''; rw [lie_smul]; exact Submodule.smul_mem _ t hm''
     change _ ≤ ({ Submodule.span R s with lie_mem := fun hm' => aux _ _ hm' } : LieSubmodule R L M)
@@ -295,7 +295,7 @@ theorem comap_bracket_incl {I₁ I₂ : LieIdeal R L} :
     next => skip
     rw [← I.incl_idealRange]
   rw [comap_bracket_eq]
-  · simp only [ker_incl, sup_bot_eq]
+  · simp
   · exact I.incl_isIdealMorphism
 
 /-- This is a very useful result; it allows us to use the fact that inclusion distributes over the

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -360,7 +360,7 @@ theorem eval₂_eq_eval_map (g : σ → S₁) (p : MvPolynomial σ R) : p.eval�
   rw [h]
   congr
   · ext1 a
-    simp only [coe_eval₂Hom, RingHom.id_apply, comp_apply, eval₂_C, RingHom.coe_comp]
+    simp
   · ext1 n
     simp only [comp_apply, eval₂_X]
 

--- a/Mathlib/Algebra/Order/Ring/GeomSum.lean
+++ b/Mathlib/Algebra/Order/Ring/GeomSum.lean
@@ -100,7 +100,7 @@ lemma geom_sum_pos' (hx : 0 < x + 1) (hn : n ≠ 0) : 0 < ∑ i ∈ range n, x ^
   · simp only [zero_add, range_one, sum_singleton, pow_zero, zero_lt_one]
   obtain hx' | hx' := lt_or_ge x 0
   · exact (geom_sum_pos_and_lt_one hx' hx n.one_lt_succ_succ).1
-  · exact geom_sum_pos hx' (by simp only [Nat.succ_ne_zero, Ne, not_false_iff])
+  · exact geom_sum_pos hx' (by simp)
 
 lemma Odd.geom_sum_pos (h : Odd n) : 0 < ∑ i ∈ range n, x ^ i := by
   rcases n with (_ | _ | k)

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -329,8 +329,7 @@ variable [Nontrivial R]
 lemma natDegree_multiset_prod_X_sub_C_eq_card (s : Multiset R) :
     (s.map (X - C ·)).prod.natDegree = Multiset.card s := by
   rw [natDegree_multiset_prod_of_monic, Multiset.map_map]
-  · simp only [(· ∘ ·), natDegree_X_sub_C, Multiset.map_const', Multiset.sum_replicate, smul_eq_mul,
-      mul_one]
+  · simp
   · exact Multiset.forall_mem_map_iff.2 fun a _ => monic_X_sub_C a
 
 @[simp] lemma natDegree_finset_prod_X_sub_C_eq_card {α} (s : Finset α) (f : α → R) :

--- a/Mathlib/Algebra/Polynomial/Degree/SmallDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/SmallDegree.lean
@@ -31,7 +31,7 @@ variable [Semiring R] {p q r : R[X]}
 theorem eq_X_add_C_of_degree_le_one (h : degree p ≤ 1) : p = C (p.coeff 1) * X + C (p.coeff 0) :=
   ext fun n =>
     Nat.casesOn n (by simp) fun n =>
-      Nat.casesOn n (by simp [coeff_C]) fun m => by
+      Nat.casesOn n (by simp) fun m => by
         have : degree p < m.succ.succ := lt_of_le_of_lt h Nat.one_lt_ofNat
         simp [coeff_eq_zero_of_degree_lt this]
 

--- a/Mathlib/Algebra/Polynomial/HasseDeriv.lean
+++ b/Mathlib/Algebra/Polynomial/HasseDeriv.lean
@@ -67,7 +67,7 @@ theorem hasseDeriv_apply :
 theorem hasseDeriv_coeff (n : ℕ) :
     (hasseDeriv k f).coeff n = (n + k).choose k * f.coeff (n + k) := by
   rw [hasseDeriv_apply, coeff_sum, sum_def, Finset.sum_eq_single (n + k), coeff_monomial]
-  · simp only [if_true, add_tsub_cancel_right]
+  · simp
   · #adaptation_note
     /-- Prior to nightly-2025-08-14, this was working as
     `grind [coeff_monomial, Nat.choose_eq_zero_of_lt, Nat.cast_zero, zero_mul]` -/

--- a/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/Defs.lean
@@ -507,7 +507,7 @@ theorem algebraMap_dvd_iff {r : R} {z : QuadraticAlgebra R a b} :
     (algebraMap R (QuadraticAlgebra R a b) r) ∣ z ↔ r ∣ z.re ∧ r ∣ z.im := by
   constructor
   · rintro ⟨x, rfl⟩
-    simp [dvd_mul_right, ← C_eq_algebraMap]
+    simp
   · rintro ⟨⟨r, hr⟩, ⟨i, hi⟩⟩
     use ⟨r, i⟩
     simp [QuadraticAlgebra.ext_iff, hr, hi, ← C_eq_algebraMap]


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `spectrum.inv₀_mem_iff`: unchanged 🎉
* `Fin.partialProd_contractNth`: unchanged 🎉
* `GenContFract.fib_le_of_contsAux_b`: 1225 ms before, 1045 ms after  🎉
* `normalize_eq_normalize`: unchanged 🎉
* `gcd_mul_left`: 100 ms before, 65 ms after  🎉
* `lcm_mul_left`: unchanged 🎉
* `LieSubmodule.lieIdeal_oper_eq_linear_span`: unchanged 🎉
* `LieIdeal.comap_bracket_incl`: unchanged 🎉
* `MvPolynomial.eval₂_eq_eval_map`: unchanged 🎉
* `geom_sum_pos'`: unchanged 🎉
* `Polynomial.natDegree_multiset_prod_X_sub_C_eq_card`: unchanged 🎉
* `Polynomial.eq_X_add_C_of_degree_le_one`: unchanged 🎉
* `Polynomial.hasseDeriv_coeff`: 491 ms before, 433 ms after  🎉
* `QuadraticAlgebra.algebraMap_dvd_iff`: unchanged 🎉
* `AlgebraicGeometry.IsAffineOpen.iSup_of_disjoint_aux`: 679 ms before, 609 ms after  🎉

Profiled using `set_option trace.profiler true in`.

This PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
