### PR TITLE
[Merged by Bors] - chore(CategoryTheory/ShrinkYoneda): `shrinkYoneda.obj X` is representable

### DIFF
--- a/Mathlib/CategoryTheory/ShrinkYoneda.lean
+++ b/Mathlib/CategoryTheory/ShrinkYoneda.lean
@@ -51,12 +51,12 @@ noncomputable def shrinkMap {F G : C ⥤ Type w'} (τ : F ⟶ G) [FunctorToTypes
     shrink.{w} F ⟶ shrink.{w} G where
   app X := equivShrink.{w} _ ∘ τ.app X ∘ (equivShrink.{w} _).symm
 
-/-- Shrinking `F` to `Type w` followed by universe lift is the same as shrinking to
+/-- Shrinking `F` to `Type w` followed by universe lifting is the same as shrinking to
 `Type (max w w')`. -/
 @[simps!]
 noncomputable
 def shrinkCompUliftFunctorIso (F : C ⥤ Type w') [FunctorToTypes.Small.{w} F]
-    [FunctorToTypes.Small.{max w w'', w', v, u} F] :
+    [FunctorToTypes.Small.{max w w''} F] :
     shrink.{w} F ⋙ uliftFunctor.{w'', w} ≅ shrink.{max w w''} F :=
   NatIso.ofComponents
     (fun X ↦ Equiv.toIso ((Equiv.ulift.trans (equivShrink _).symm).trans (equivShrink _)))
@@ -175,11 +175,10 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable
 def shrinkYonedaUliftFunctorIso [LocallySmall.{max w w'} C] :
     shrinkYoneda.{w} ⋙ (Functor.whiskeringRight Cᵒᵖ _ _).obj uliftFunctor.{w', w} ≅
-      shrinkYoneda := by
-  refine NatIso.ofComponents
-    (fun X ↦ FunctorToTypes.shrinkCompUliftFunctorIso.{w, v} (yoneda.obj X)) fun {X} Y f ↦ ?_
-  ext
-  simp [shrinkYoneda]
+      shrinkYoneda :=
+  NatIso.ofComponents
+    (fun X ↦ FunctorToTypes.shrinkCompUliftFunctorIso.{w, v} (yoneda.obj X))
+    fun _ ↦ by ext; simp [shrinkYoneda]
 
 /-- `uliftYoneda` identifies to `shrinkYoneda`. -/
 noncomputable def uliftYonedaIsoShrinkYoneda :
@@ -203,9 +202,14 @@ noncomputable def shrinkYonedaCompEvaluationCompUliftFunctorIsoUliftFunctor (Y :
       obtain ⟨g, rfl⟩ := shrinkYonedaObjObjEquiv.symm.surjective g
       simp [shrinkYoneda_map_app_shrinkYonedaObjObjEquiv_symm])
 
-instance (X : C) : (shrinkYoneda.{w}.obj X).IsRepresentable := by
-  rw [← Functor.isRepresentable_comp_uliftFunctor_iff.{v}]
-  exact CategoryTheory.isRepresentable_of_natIso _
-    (shrinkYonedaUliftFunctorIso.{w} ≪≫ uliftYonedaIsoShrinkYoneda.symm |>.app X).symm
+/-- `shrinkYoneda.obj X` is represented by `X`. -/
+@[simps]
+noncomputable
+def shrinkYonedaRepresentableBy (X : C) : (shrinkYoneda.{w}.obj X).RepresentableBy X where
+  homEquiv := shrinkYonedaObjObjEquiv.symm
+  homEquiv_comp := shrinkYonedaObjObjEquiv_symm_comp
+
+instance (X : C) : (shrinkYoneda.{w}.obj X).IsRepresentable :=
+  (shrinkYonedaRepresentableBy X).isRepresentable
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/ShrinkYoneda.lean
+++ b/Mathlib/CategoryTheory/ShrinkYoneda.lean
@@ -19,7 +19,7 @@ file `CategoryTheory.Yoneda` for the other variants `yoneda` and
 
 @[expose] public section
 
-universe w w' v u
+universe w w' w'' v u
 
 namespace CategoryTheory
 
@@ -50,6 +50,16 @@ noncomputable def shrinkMap {F G : C ⥤ Type w'} (τ : F ⟶ G) [FunctorToTypes
     [FunctorToTypes.Small.{w} G] :
     shrink.{w} F ⟶ shrink.{w} G where
   app X := equivShrink.{w} _ ∘ τ.app X ∘ (equivShrink.{w} _).symm
+
+/-- Shrinking `F` to `Type w` followed by universe lift is the same as shrinking to
+`Type (max w w')`. -/
+@[simps!]
+noncomputable
+def shrinkCompUliftFunctorIso (F : C ⥤ Type w') [FunctorToTypes.Small.{w} F]
+    [FunctorToTypes.Small.{max w w'', w', v, u} F] :
+    shrink.{w} F ⋙ uliftFunctor.{w'', w} ≅ shrink.{max w w''} F :=
+  NatIso.ofComponents
+    (fun X ↦ Equiv.toIso ((Equiv.ulift.trans (equivShrink _).symm).trans (equivShrink _)))
 
 end FunctorToTypes
 
@@ -160,6 +170,17 @@ instance : (shrinkYoneda.{w} (C := C)).Faithful := (fullyFaithfulShrinkYoneda C)
 
 instance : (shrinkYoneda.{w} (C := C)).Full := (fullyFaithfulShrinkYoneda C).full
 
+set_option backward.isDefEq.respectTransparency false in
+/-- `shrinkYoneda` is compatible with `uliftFunctor`. -/
+noncomputable
+def shrinkYonedaUliftFunctorIso [LocallySmall.{max w w'} C] :
+    shrinkYoneda.{w} ⋙ (Functor.whiskeringRight Cᵒᵖ _ _).obj uliftFunctor.{w', w} ≅
+      shrinkYoneda := by
+  refine NatIso.ofComponents
+    (fun X ↦ FunctorToTypes.shrinkCompUliftFunctorIso.{w, v} (yoneda.obj X)) fun {X} Y f ↦ ?_
+  ext
+  simp [shrinkYoneda]
+
 /-- `uliftYoneda` identifies to `shrinkYoneda`. -/
 noncomputable def uliftYonedaIsoShrinkYoneda :
     uliftYoneda.{w'} (C := C) ≅ shrinkYoneda.{max w' v} :=
@@ -181,5 +202,10 @@ noncomputable def shrinkYonedaCompEvaluationCompUliftFunctorIsoUliftFunctor (Y :
       ext ⟨g⟩
       obtain ⟨g, rfl⟩ := shrinkYonedaObjObjEquiv.symm.surjective g
       simp [shrinkYoneda_map_app_shrinkYonedaObjObjEquiv_symm])
+
+instance (X : C) : (shrinkYoneda.{w}.obj X).IsRepresentable := by
+  rw [← Functor.isRepresentable_comp_uliftFunctor_iff.{v}]
+  exact CategoryTheory.isRepresentable_of_natIso _
+    (shrinkYonedaUliftFunctorIso.{w} ≪≫ uliftYonedaIsoShrinkYoneda.symm |>.app X).symm
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -640,8 +640,13 @@ theorem corepresentable_of_natIso (F : C ⥤ Type v) {G} (i : F ≅ G) [F.IsCore
     G.IsCorepresentable :=
   (F.corepresentableBy.ofIso i).isCorepresentable
 
+/-- The identity functor on `Type v` is corepresented by `PUnit`. -/
+@[simps!]
+def Functor.CorepresentableBy.id : (𝟭 (Type v)).CorepresentableBy PUnit :=
+  corepresentableByEquiv.symm Coyoneda.punitIso
+
 instance : Functor.IsCorepresentable (𝟭 (Type v)) :=
-  corepresentable_of_natIso (coyoneda.obj (op PUnit)) Coyoneda.punitIso
+  Functor.CorepresentableBy.id.isCorepresentable
 
 open Opposite
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -641,9 +641,14 @@ theorem corepresentable_of_natIso (F : C ⥤ Type v) {G} (i : F ≅ G) [F.IsCore
   (F.corepresentableBy.ofIso i).isCorepresentable
 
 /-- The identity functor on `Type v` is corepresented by `PUnit`. -/
-@[simps!]
 def Functor.CorepresentableBy.id : (𝟭 (Type v)).CorepresentableBy PUnit :=
   corepresentableByEquiv.symm Coyoneda.punitIso
+
+@[simp] lemma Functor.CorepresentableBy.id_homEquiv_apply (X : Type v) (a : PUnit ⟶ X) :
+    dsimp% id.homEquiv a = a ⟨⟩ := rfl
+
+@[simp] lemma Functor.CorepresentableBy.id_homEquiv_symm_apply (X : Type v) (x : X) (a : PUnit) :
+    dsimp% id.homEquiv.symm x a = x := rfl
 
 instance : Functor.IsCorepresentable (𝟭 (Type v)) :=
   Functor.CorepresentableBy.id.isCorepresentable

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -632,15 +632,15 @@ instance (F : C ⥤ Type v) [F.IsCorepresentable] : (F ⋙ uliftFunctor.{w}).IsC
 
 end Functor
 
-theorem isRepresentable_of_natIso (F : Cᵒᵖ ⥤ Type v₁) {G} (i : F ≅ G) [F.IsRepresentable] :
+theorem isRepresentable_of_natIso (F : Cᵒᵖ ⥤ Type v) {G} (i : F ≅ G) [F.IsRepresentable] :
     G.IsRepresentable :=
   (F.representableBy.ofIso i).isRepresentable
 
-theorem corepresentable_of_natIso (F : C ⥤ Type v₁) {G} (i : F ≅ G) [F.IsCorepresentable] :
+theorem corepresentable_of_natIso (F : C ⥤ Type v) {G} (i : F ≅ G) [F.IsCorepresentable] :
     G.IsCorepresentable :=
   (F.corepresentableBy.ofIso i).isCorepresentable
 
-instance : Functor.IsCorepresentable (𝟭 (Type v₁)) :=
+instance : Functor.IsCorepresentable (𝟭 (Type v)) :=
   corepresentable_of_natIso (coyoneda.obj (op PUnit)) Coyoneda.punitIso
 
 open Opposite


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
