### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): adjunction induces adjunction on `Functor.sheafPushforwardContinuous`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Continuous.lean
+++ b/Mathlib/CategoryTheory/Sites/Continuous.lean
@@ -6,6 +6,8 @@ Authors: Joël Riou, Andrew Yang
 module
 
 public import Mathlib.CategoryTheory.Sites.Hypercover.IsSheaf
+public import Mathlib.CategoryTheory.Adjunction.Opposites
+public import Mathlib.CategoryTheory.Adjunction.Whiskering
 
 /-!
 # Continuous functors between sites.
@@ -286,5 +288,21 @@ def sheafPushforwardContinuousComp'
   sheafPushforwardContinuousComp _ _ _ _ _ _ ≪≫ sheafPushforwardContinuousIso eFG _ _ _
 
 end Functor
+
+/-- If `F ⊣ G` is an adjunction between continuous functors, the associated
+pushforwards on sheaves are adjoint. -/
+@[simps!]
+def Adjunction.sheafPushforwardContinuous {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G)
+    (J : GrothendieckTopology C) (K : GrothendieckTopology D) [F.IsContinuous J K]
+    [G.IsContinuous K J] :
+    F.sheafPushforwardContinuous E J K ⊣ G.sheafPushforwardContinuous E K J where
+  unit.app P := { val := (adj.op.whiskerLeft _).unit.app P.val }
+  counit.app P := { val := (adj.op.whiskerLeft _).counit.app P.val }
+  left_triangle_components P := by
+    ext : 1
+    exact (adj.op.whiskerLeft _).left_triangle_components P.val
+  right_triangle_components P := by
+    ext : 1
+    exact (adj.op.whiskerLeft _).right_triangle_components P.val
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Continuous.lean
+++ b/Mathlib/CategoryTheory/Sites/Continuous.lean
@@ -289,7 +289,6 @@ def sheafPushforwardContinuousComp'
 
 end Functor
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `F ⊣ G` is an adjunction between continuous functors, the associated
 pushforwards on sheaves are adjoint. -/
 @[simps!]
@@ -297,13 +296,13 @@ def Adjunction.sheafPushforwardContinuous {F : C ⥤ D} {G : D ⥤ C} (adj : F �
     (J : GrothendieckTopology C) (K : GrothendieckTopology D) [F.IsContinuous J K]
     [G.IsContinuous K J] :
     F.sheafPushforwardContinuous E J K ⊣ G.sheafPushforwardContinuous E K J where
-  unit.app P := { val := (adj.op.whiskerLeft _).unit.app P.val }
-  counit.app P := { val := (adj.op.whiskerLeft _).counit.app P.val }
+  unit.app P := { hom := (adj.op.whiskerLeft _).unit.app P.obj }
+  counit.app P := { hom := (adj.op.whiskerLeft _).counit.app P.obj }
   left_triangle_components P := by
     ext : 1
-    exact (adj.op.whiskerLeft _).left_triangle_components P.val
+    exact (adj.op.whiskerLeft _).left_triangle_components P.obj
   right_triangle_components P := by
     ext : 1
-    exact (adj.op.whiskerLeft _).right_triangle_components P.val
+    exact (adj.op.whiskerLeft _).right_triangle_components P.obj
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Continuous.lean
+++ b/Mathlib/CategoryTheory/Sites/Continuous.lean
@@ -289,6 +289,7 @@ def sheafPushforwardContinuousComp'
 
 end Functor
 
+set_option backward.isDefEq.respectTransparency false in
 /-- If `F ⊣ G` is an adjunction between continuous functors, the associated
 pushforwards on sheaves are adjoint. -/
 @[simps!]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
