### PR TITLE
[Merged by Bors] - feat: tag `Pow.mk` with `to_additive`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -624,7 +624,7 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
   protected npow_succ : ∀ (n : ℕ) (x), npow (n + 1) x = npow n x * x := by intros; rfl
 
 @[default_instance high, to_additive]
-instance Monoid.instPow {M : Type*} [Monoid M] : Pow M ℕ :=
+instance Monoid.toPow {M : Type*} [Monoid M] : Pow M ℕ :=
   ⟨fun x n ↦ Monoid.npow n x⟩
 
 section Monoid

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -623,13 +623,9 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
   /-- Raising to the power `(n + 1 : ℕ)` behaves as expected. -/
   protected npow_succ : ∀ (n : ℕ) (x), npow (n + 1) x = npow n x * x := by intros; rfl
 
-@[default_instance high] instance Monoid.toNatPow {M : Type*} [Monoid M] : Pow M ℕ :=
+@[default_instance high, to_additive]
+instance Monoid.instPow {M : Type*} [Monoid M] : Pow M ℕ :=
   ⟨fun x n ↦ Monoid.npow n x⟩
-
-instance AddMonoid.toNatSMul {M : Type*} [AddMonoid M] : SMul ℕ M :=
-  ⟨AddMonoid.nsmul⟩
-
-attribute [to_additive existing toNatSMul] Monoid.toNatPow
 
 section Monoid
 variable {M : Type*} [Monoid M] {a b c : M}

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -32,24 +32,13 @@ universe uM uN uP uQ
 
 variable {M : Type uM} {N : Type uN} {P : Type uP} {Q : Type uQ}
 
-instance ZeroHom.instNatSMul [Zero M] [AddMonoid N] : SMul ℕ (ZeroHom M N) where
-  smul a f :=
-    { toFun := a • f
-      map_zero' := by simp }
-
-instance AddMonoidHom.instNatSMul [AddZeroClass M] [AddCommMonoid N] : SMul ℕ (M →+ N) where
-  smul a f :=
-    { toFun := a • f
-      map_zero' := by simp
-      map_add' x y := by simp [nsmul_add] }
-
-@[to_additive existing ZeroHom.instNatSMul]
+@[to_additive]
 instance OneHom.instPow [One M] [Monoid N] : Pow (OneHom M N) ℕ where
   pow f n :=
     { toFun := f ^ n
       map_one' := by simp }
 
-@[to_additive existing AddMonoidHom.instNatSMul]
+@[to_additive]
 instance MonoidHom.instPow [MulOneClass M] [CommMonoid N] : Pow (M →* N) ℕ where
   pow f n :=
     { toFun := f ^ n
@@ -84,25 +73,14 @@ instance MonoidHom.instCommMonoid [MulOneClass M] [CommMonoid N] : CommMonoid (M
   fast_instance%
     DFunLike.coe_injective.commMonoid DFunLike.coe rfl (fun _ _ => rfl) (fun _ _ => rfl)
 
-instance ZeroHom.instIntSMul [Zero M] [AddGroup N] : SMul ℤ (ZeroHom M N) where
-  smul a f :=
-    { toFun := a • f
-      map_zero' := by simp [zsmul_zero] }
-
-instance AddMonoidHom.instIntSMul [AddZeroClass M] [AddCommGroup N] : SMul ℤ (M →+ N) where
-  smul a f :=
-    { toFun := a • f
-      map_zero' := by simp [zsmul_zero]
-      map_add' x y := by simp [zsmul_add] }
-
-@[to_additive existing ZeroHom.instIntSMul]
-instance OneHom.instIntPow [One M] [Group N] : Pow (OneHom M N) ℤ where
+@[to_additive]
+instance OneHom.instZPow [One M] [Group N] : Pow (OneHom M N) ℤ where
   pow f n :=
     { toFun := f ^ n
       map_one' := by simp }
 
-@[to_additive existing AddMonoidHom.instIntSMul]
-instance MonoidHom.instIntPow [MulOneClass M] [CommGroup N] : Pow (M →* N) ℤ where
+@[to_additive]
+instance MonoidHom.instZPow [MulOneClass M] [CommGroup N] : Pow (M →* N) ℤ where
   pow f n :=
     { toFun := f ^ n
       map_one' := by simp

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -695,30 +695,19 @@ section Instances
 
 variable [DecidableEq α] [DecidableEq β]
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Finset`. See
-note [pointwise nat action]. -/
-@[instance_reducible]
-protected def nsmul [Zero α] [Add α] : SMul ℕ (Finset α) :=
-  ⟨nsmulRec⟩
-
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
 `Finset`. See note [pointwise nat action]. -/
-@[instance_reducible]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Finset`. See
+note [pointwise nat action]. -/]
 protected def npow [One α] [Mul α] : Pow (Finset α) ℕ :=
   ⟨fun s n => npowRec n s⟩
 
-attribute [to_additive existing] Finset.npow
-
-
-/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `Finset`. See note [pointwise nat action]. -/
-@[instance_reducible]
-protected def zsmul [Zero α] [Add α] [Neg α] : SMul ℤ (Finset α) :=
-  ⟨zsmulRec⟩
-
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
 multiplication/division!) of a `Finset`. See note [pointwise nat action]. -/
-@[instance_reducible, to_additive existing]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `Finset`. See note [pointwise nat action]. -/]
 protected def zpow [One α] [Mul α] [Inv α] : Pow (Finset α) ℤ :=
   ⟨fun s n => zpowRec npowRec n s⟩
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -531,27 +531,20 @@ theorem union_div_inter_subset_union : (s₁ ∪ s₂) / (t₁ ∩ t₂) ⊆ s�
 
 end Div
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Set`. See
-note [pointwise nat action]. -/
-@[instance_reducible]
-protected def NSMul [Zero α] [Add α] : SMul ℕ (Set α) :=
-  ⟨nsmulRec⟩
-
+-- TODO: rename `NPow` to `npow` and `ZPow` to `zpow`.
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
 `Set`. See note [pointwise nat action]. -/
-@[instance_reducible, to_additive existing]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Set`. See
+note [pointwise nat action]. -/]
 protected def NPow [One α] [Mul α] : Pow (Set α) ℕ :=
   ⟨fun s n => npowRec n s⟩
 
-/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `Set`. See note [pointwise nat action]. -/
-@[instance_reducible]
-protected def ZSMul [Zero α] [Add α] [Neg α] : SMul ℤ (Set α) :=
-  ⟨zsmulRec⟩
-
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
 multiplication/division!) of a `Set`. See note [pointwise nat action]. -/
-@[instance_reducible, to_additive existing]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `Set`. See note [pointwise nat action]. -/]
 protected def ZPow [One α] [Mul α] [Inv α] : Pow (Set α) ℤ :=
   ⟨fun s n => zpowRec npowRec n s⟩
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -190,14 +190,9 @@ theorem subset_union [LE S] [IsConcreteLE S G] {H K L : S} :
 instance div {G S : Type*} [DivInvMonoid G] [SetLike S G] [SubgroupClass S G] {H : S} : Div H :=
   ⟨fun a b => ⟨a / b, div_mem a.2 b.2⟩⟩
 
-/-- An additive subgroup of an `AddGroup` inherits an integer scaling. -/
-instance _root_.AddSubgroupClass.zsmul {M S} [SubNegMonoid M] [SetLike S M]
-    [AddSubgroupClass S M] {H : S} : SMul ℤ H :=
-  ⟨fun n a => ⟨n • a.1, zsmul_mem a.2 n⟩⟩
-
 /-- A subgroup of a group inherits an integer power. -/
-@[to_additive existing]
-instance zpow {M S} [DivInvMonoid M] [SetLike S M] [SubgroupClass S M] {H : S} : Pow H ℤ :=
+@[to_additive /-- An additive subgroup of an `AddGroup` inherits an integer scaling. -/]
+instance instZPow {M S} [DivInvMonoid M] [SetLike S M] [SubgroupClass S M] {H : S} : Pow H ℤ :=
   ⟨fun a n => ⟨a.1 ^ n, zpow_mem a.2 n⟩⟩
 
 @[to_additive (attr := simp, norm_cast)]
@@ -508,21 +503,13 @@ instance inv : Inv H :=
 instance div : Div H :=
   ⟨fun a b => ⟨a / b, H.div_mem a.2 b.2⟩⟩
 
-/-- An `AddSubgroup` of an `AddGroup` inherits a natural scaling. -/
-instance _root_.AddSubgroup.nsmul {G} [AddGroup G] {H : AddSubgroup G} : SMul ℕ H :=
-  ⟨fun n a => ⟨n • a, H.nsmul_mem a.2 n⟩⟩
-
 /-- A subgroup of a group inherits a natural power -/
-@[to_additive existing]
+@[to_additive /-- An `AddSubgroup` of an `AddGroup` inherits a natural scaling. -/]
 protected instance npow : Pow H ℕ :=
   ⟨fun a n => ⟨a ^ n, H.pow_mem a.2 n⟩⟩
 
-/-- An `AddSubgroup` of an `AddGroup` inherits an integer scaling. -/
-instance _root_.AddSubgroup.zsmul {G} [AddGroup G] {H : AddSubgroup G} : SMul ℤ H :=
-  ⟨fun n a => ⟨n • a, H.zsmul_mem a.2 n⟩⟩
-
 /-- A subgroup of a group inherits an integer power -/
-@[to_additive existing]
+@[to_additive /-- An `AddSubgroup` of an `AddGroup` inherits an integer scaling. -/]
 instance zpow : Pow H ℤ :=
   ⟨fun a n => ⟨a ^ n, H.zpow_mem a.2 n⟩⟩
 

--- a/Mathlib/Algebra/Group/Subgroup/ZPowers/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/ZPowers/Basic.lean
@@ -121,11 +121,8 @@ instance zpowers_isMulCommutative (g : G) : IsMulCommutative (zpowers g) :=
 theorem zpowers_le {g : G} {H : Subgroup G} : zpowers g ≤ H ↔ g ∈ H := by
   rw [zpowers_eq_closure, closure_le, Set.singleton_subset_iff, SetLike.mem_coe]
 
+@[to_additive]
 alias ⟨_, zpowers_le_of_mem⟩ := zpowers_le
-
-alias ⟨_, _root_.AddSubgroup.zmultiples_le_of_mem⟩ := AddSubgroup.zmultiples_le
-
-attribute [to_additive existing] zpowers_le_of_mem
 
 @[to_additive (attr := simp)]
 theorem zpowers_eq_bot {g : G} : zpowers g = ⊥ ↔ g = 1 := by rw [eq_bot_iff, zpowers_le, mem_bot]

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -357,18 +357,12 @@ end OneMemClass
 
 variable {A : Type*} [MulOneClass M] [SetLike A M] [hA : SubmonoidClass A M] (S' : A)
 
-/-- An `AddSubmonoid` of an `AddMonoid` inherits a scalar multiplication. -/
-instance AddSubmonoidClass.nSMul {M} [AddMonoid M] {A : Type*} [SetLike A M]
-    [AddSubmonoidClass A M] (S : A) : SMul ℕ S :=
-  ⟨fun n a => ⟨n • a.1, nsmul_mem a.2 n⟩⟩
-
 namespace SubmonoidClass
 
 /-- A submonoid of a monoid inherits a power operator. -/
-instance nPow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] (S : A) : Pow S ℕ :=
+@[to_additive /-- An `AddSubmonoid` of an `AddMonoid` inherits a scalar multiplication. -/]
+instance instPow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] (S : A) : Pow S ℕ :=
   ⟨fun a n => ⟨a.1 ^ n, pow_mem a.2 n⟩⟩
-
-attribute [to_additive existing nSMul] nPow
 
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_pow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] {S : A} (x : S)

--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -68,21 +68,12 @@ lemma inv_def [Inv β] (x : α) :
     x⁻¹ = e.symm (e x)⁻¹ := rfl
 
 variable (M) in
-/-- Transfer `SMul` across an `Equiv` -/
-@[to_additive /-- Transfer `VAdd` across an `Equiv` -/]
-protected abbrev smul [SMul M β] : SMul M α where smul r x := e.symm (r • e x)
-
-@[to_additive]
-lemma smul_def [SMul M β] (r : M) (x : α) :
-    letI := e.smul M
-    r • x = e.symm (r • e x) := rfl
-
-variable (M) in
 /-- Transfer `Pow` across an `Equiv` -/
-@[to_additive existing smul]
+@[to_additive (attr := to_additive /-- Transfer `VAdd` across an `Equiv` -/) smul
+/-- Transfer `SMul` across an `Equiv` -/]
 protected abbrev pow [Pow β M] : Pow α M where pow x n := e.symm (e x ^ n)
 
-@[to_additive existing smul_def]
+@[to_additive (attr := to_additive) smul_def]
 lemma pow_def [Pow β M] (n : M) (x : α) :
     letI := e.pow M
     x ^ n = e.symm (e x ^ n) := rfl

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -60,19 +60,11 @@ instance inv [Inv α] : Inv (ULift α) :=
 theorem inv_down [Inv α] : x⁻¹.down = x.down⁻¹ :=
   rfl
 
-@[to_additive]
-instance smul [SMul α β] : SMul α (ULift β) :=
-  ⟨fun n x => up (n • x.down)⟩
-
-@[to_additive (attr := simp)]
-theorem smul_down [SMul α β] (a : α) (b : ULift.{w} β) : (a • b).down = a • b.down :=
-  rfl
-
-@[to_additive existing smul]
+@[to_additive (attr := to_additive) smul]
 instance pow [Pow α β] : Pow (ULift α) β :=
   ⟨fun x n => up (x.down ^ n)⟩
 
-@[to_additive existing (attr := simp) smul_down]
+@[to_additive (attr := to_additive, simp) smul_down]
 theorem pow_down [Pow α β] (a : ULift.{w} α) (b : β) : (a ^ b).down = a.down ^ b :=
   rfl
 

--- a/Mathlib/Algebra/Notation/Defs.lean
+++ b/Mathlib/Algebra/Notation/Defs.lean
@@ -64,7 +64,9 @@ class VSub (G : outParam Type*) (P : Type*) where
   type-dependent, but it is intended to be used for additive torsors. -/
   vsub : P → P → G
 
-attribute [to_additive] SMul
+attribute [to_additive existing] SMul HSMul
+attribute [to_additive (attr := default_instance)] instHSMul
+
 attribute [ext] SMul VAdd
 
 @[inherit_doc] infixr:65 " +ᵥ " => HVAdd.hVAdd
@@ -73,18 +75,7 @@ attribute [ext] SMul VAdd
 recommended_spelling "vadd" for "+ᵥ" in [HVAdd.hVAdd, «term_+ᵥ_»]
 recommended_spelling "vsub" for "-ᵥ" in [VSub.vsub, «term_-ᵥ_»]
 
-attribute [to_additive existing] Mul Div HMul instHMul HDiv instHDiv HSMul
-attribute [to_additive (reorder := 1 2) SMul] Pow
-attribute [to_additive (reorder := 1 2)] HPow
-attribute [to_additive existing (reorder := 1 2, 5 6) hSMul] HPow.hPow
-attribute [to_additive existing (reorder := 1 2, 4 5) smul] Pow.pow
-
-attribute [to_additive (attr := default_instance)] instHSMul
-attribute [to_additive existing] instHPow
-
 variable {G : Type*}
-
-attribute [to_additive, notation_class] Inv
 
 section Star
 

--- a/Mathlib/Algebra/Notation/Pi/Defs.lean
+++ b/Mathlib/Algebra/Notation/Pi/Defs.lean
@@ -124,12 +124,9 @@ end Div
 
 section Pow
 
-@[to_additive]
-instance instSMul [∀ i, SMul α (M i)] : SMul α (∀ i, M i) where smul a f i := a • f i
-
 variable [∀ i, Pow (M i) α]
 
-@[to_additive existing instSMul]
+@[to_additive (attr := to_additive) instSMul]
 instance instPow : Pow (∀ i, M i) α where pow f a i := f i ^ a
 
 @[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]

--- a/Mathlib/Algebra/Notation/Prod.lean
+++ b/Mathlib/Algebra/Notation/Prod.lean
@@ -129,47 +129,26 @@ theorem swap_div (a b : G × H) : (a / b).swap = a.swap / b.swap := rfl
 
 end Div
 
-section SMul
-
-variable {M α β : Type*} [SMul M α] [SMul M β]
-
-@[to_additive]
-instance instSMul : SMul M (α × β) where smul a p := (a • p.1, a • p.2)
-
-@[to_additive (attr := simp)] lemma smul_fst (a : M) (x : α × β) : (a • x).1 = a • x.1 := rfl
-
-@[to_additive (attr := simp)] lemma smul_snd (a : M) (x : α × β) : (a • x).2 = a • x.2 := rfl
-
-@[to_additive (attr := simp)]
-lemma smul_mk (a : M) (b : α) (c : β) : a • (b, c) = (a • b, a • c) := rfl
-
-@[to_additive]
-lemma smul_def (a : M) (x : α × β) : a • x = (a • x.1, a • x.2) := rfl
-
-@[to_additive (attr := simp)] lemma smul_swap (a : M) (x : α × β) : (a • x).swap = a • x.swap := rfl
-
-end SMul
-
 section Pow
 
 variable {E α β : Type*} [Pow α E] [Pow β E]
 
-@[to_additive existing instSMul]
+@[to_additive (attr := to_additive) instSMul]
 instance instPow : Pow (α × β) E where pow p c := (p.1 ^ c, p.2 ^ c)
 
-@[to_additive existing (attr := simp) smul_fst]
+@[to_additive (attr := to_additive, simp) (reorder := p c) smul_fst]
 lemma pow_fst (p : α × β) (c : E) : (p ^ c).fst = p.fst ^ c := rfl
 
-@[to_additive existing (attr := simp) smul_snd]
+@[to_additive (attr := to_additive, simp) (reorder := p c) smul_snd]
 lemma pow_snd (p : α × β) (c : E) : (p ^ c).snd = p.snd ^ c := rfl
 
-@[to_additive existing (attr := simp) smul_mk]
+@[to_additive (attr := to_additive, simp) (reorder := a b c) smul_mk]
 lemma pow_mk (a : α) (b : β) (c : E) : Prod.mk a b ^ c = Prod.mk (a ^ c) (b ^ c) := rfl
 
-@[to_additive existing smul_def]
+@[to_additive (attr := to_additive) (reorder := p c) smul_def]
 lemma pow_def (p : α × β) (c : E) : p ^ c = (p.1 ^ c, p.2 ^ c) := rfl
 
-@[to_additive existing (attr := simp) smul_swap]
+@[to_additive (attr := to_additive, simp) (reorder := p c) smul_swap]
 lemma pow_swap (p : α × β) (c : E) : (p ^ c).swap = p.swap ^ c := rfl
 
 end Pow

--- a/Mathlib/Algebra/Order/Interval/Basic.lean
+++ b/Mathlib/Algebra/Order/Interval/Basic.lean
@@ -180,18 +180,12 @@ end Mul
 
 /-! ### Powers -/
 
-
--- TODO: if `to_additive` gets improved sufficiently, derive this from `hasPow`
-instance NonemptyInterval.hasNSMul [AddMonoid α] [Preorder α] [AddLeftMono α]
-    [AddRightMono α] : SMul ℕ (NonemptyInterval α) :=
-  ⟨fun n s => ⟨(n • s.fst, n • s.snd), nsmul_le_nsmul_right s.fst_le_snd _⟩⟩
-
 section Pow
 
 variable [Monoid α] [Preorder α]
 
-@[to_additive existing]
-instance NonemptyInterval.hasPow [MulLeftMono α] [MulRightMono α] :
+@[to_additive]
+instance NonemptyInterval.instPow [MulLeftMono α] [MulRightMono α] :
     Pow (NonemptyInterval α) ℕ :=
   ⟨fun s n => ⟨s.toProd ^ n, pow_le_pow_left' s.fst_le_snd _⟩⟩
 

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -81,7 +81,7 @@ lemma toFin_pow (x : BitVec w) (n : ℕ) : toFin (x ^ n) = x.toFin ^ n := by
 -/
 
 -- Verify that the `HPow` instance from Lean agrees definitionally with the instance via `Monoid`.
-example : @instHPow (Fin (2 ^ w)) ℕ Monoid.toNatPow = Lean.Grind.Fin.instHPowFinNatOfNeZero := rfl
+example : @instHPow (Fin (2 ^ w)) ℕ Monoid.toPow = Lean.Grind.Fin.instHPowFinNatOfNeZero := rfl
 
 instance : CommSemiring (BitVec w) :=
   open Fin.CommRing in

--- a/Mathlib/Data/ZMod/IntUnitsPower.lean
+++ b/Mathlib/Data/ZMod/IntUnitsPower.lean
@@ -65,7 +65,7 @@ instance Int.instUnitsPow : Pow ℤˣ R where
 
 -- The above instances form no typeclass diamonds with the standard power operators
 -- but we will need `reducible_and_instances` which currently fails https://github.com/leanprover-community/mathlib4/issues/10906
-example : Int.instUnitsPow = Monoid.toNatPow := rfl
+example : Int.instUnitsPow = Monoid.toPow := rfl
 example : Int.instUnitsPow = DivInvMonoid.toZPow := rfl
 
 @[simp] lemma ofMul_uzpow (u : ℤˣ) (r : R) : Additive.ofMul (u ^ r) = r • Additive.ofMul u := rfl

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -57,11 +57,7 @@ theorem coe_one {G : Type*} [One G] [TopologicalSpace G] [ChartedSpace H' G] :
     ⇑(1 : C^n⟮I, N; I', G⟯) = 1 :=
   rfl
 
-instance instNSMul {G : Type*} [AddMonoid G] [TopologicalSpace G] [ChartedSpace H' G]
-    [ContMDiffAdd I' n G] : SMul ℕ C^n⟮I, N; I', G⟯ where
-  smul n f := ⟨n • (f : N → G), (contMDiff_nsmul n).comp f.contMDiff⟩
-
-@[to_additive existing]
+@[to_additive]
 instance instPow {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [ContMDiffMul I' n G] :
     Pow C^n⟮I, N; I', G⟯ ℕ where

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -554,11 +554,7 @@ instance one [Mul M] [One M] (c : Con M) : One c.Quotient where
   one := Quotient.mk'' (1 : M)
   -- one := ((1 : M) : c.Quotient)
 
-instance _root_.AddCon.Quotient.nsmul {M : Type*} [AddMonoid M] (c : AddCon M) :
-    SMul ℕ c.Quotient where
-  smul n := (Quotient.map' (n • ·)) fun _ _ => c.nsmul n
-
-@[to_additive existing AddCon.Quotient.nsmul]
+@[to_additive]
 instance {M : Type*} [Monoid M] (c : Con M) : Pow c.Quotient ℕ where
   pow x n := Quotient.map' (fun x => x ^ n) (fun _ _ => c.pow n) x
 
@@ -652,16 +648,11 @@ type with a subtraction. -/]
 instance hasDiv : Div c.Quotient :=
   ⟨(Quotient.map₂ (· / ·)) fun _ _ h₁ _ _ h₂ => c.div h₁ h₂⟩
 
-/-- The integer scaling induced on the quotient by a congruence relation on a type with a
-subtraction. -/
-instance _root_.AddCon.Quotient.zsmul {M : Type*} [AddGroup M] (c : AddCon M) :
-    SMul ℤ c.Quotient :=
-  ⟨fun z => (Quotient.map' (z • ·)) fun _ _ => c.zsmul z⟩
-
 /-- The integer power induced on the quotient by a congruence relation on a type with a
 division. -/
-@[to_additive existing AddCon.Quotient.zsmul]
-instance zpowinst : Pow c.Quotient ℤ :=
+@[to_additive /-- The integer scaling induced on the quotient by a congruence relation on a type
+with a subtraction. -/]
+instance instZPow : Pow c.Quotient ℤ :=
   ⟨fun x z => Quotient.map' (fun x => x ^ z) (fun _ _ h => c.zpow z h) x⟩
 
 /-- The quotient of a group by a congruence relation is a group. -/

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -382,10 +382,7 @@ instance instMulOneClass [MulOneClass M] : MulOneClass (Germ l M) :=
   { one_mul := Quotient.ind' fun _ => congrArg ofFun <| one_mul _
     mul_one := Quotient.ind' fun _ => congrArg ofFun <| mul_one _ }
 
-@[to_additive]
-instance instSMul [SMul M G] : SMul M (Germ l G) where smul n := map (n • ·)
-
-@[to_additive existing instSMul]
+@[to_additive (attr := to_additive) instSMul]
 instance instPow [Pow G M] : Pow (Germ l G) M where pow f n := map (· ^ n) f
 
 @[to_additive (attr := simp, norm_cast)]

--- a/Mathlib/Order/Filter/Pointwise.lean
+++ b/Mathlib/Order/Filter/Pointwise.lean
@@ -476,27 +476,19 @@ instance covariant_swap_div : CovariantClass (Filter α) (Filter α) (swap (· /
 
 end Div
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Filter`. See
-Note [pointwise nat action]. -/
-@[instance_reducible]
-protected def instNSMul [Zero α] [Add α] : SMul ℕ (Filter α) :=
-  ⟨nsmulRec⟩
-
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
 `Filter`. See Note [pointwise nat action]. -/
-@[instance_reducible, to_additive existing]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `Filter`. See
+Note [pointwise nat action]. -/]
 protected def instNPow [One α] [Mul α] : Pow (Filter α) ℕ :=
   ⟨fun s n => npowRec n s⟩
 
-/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `Filter`. See Note [pointwise nat action]. -/
-@[instance_reducible]
-protected def instZSMul [Zero α] [Add α] [Neg α] : SMul ℤ (Filter α) :=
-  ⟨zsmulRec⟩
-
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
 multiplication/division!) of a `Filter`. See Note [pointwise nat action]. -/
-@[instance_reducible, to_additive existing]
+@[to_additive (attr := instance_reducible)
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `Filter`. See Note [pointwise nat action]. -/]
 protected def instZPow [One α] [Mul α] [Inv α] : Pow (Filter α) ℤ :=
   ⟨fun s n => zpowRec npowRec n s⟩
 

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -148,7 +148,7 @@ attribute [notation_class mod] HMod
 attribute [notation_class append] HAppend
 attribute [notation_class pow Simps.copyFirst] HPow
 attribute [notation_class andThen] HAndThen
-attribute [notation_class] Neg Dvd LE LT HasEquiv HasSubset HasSSubset Union Inter SDiff Insert
+attribute [notation_class] Neg Inv Dvd LE LT HasEquiv HasSubset HasSSubset Union Inter SDiff Insert
   Singleton Sep Membership
 attribute [notation_class one Simps.findOneArgs] OfNat
 attribute [notation_class zero Simps.findZeroArgs] OfNat

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -21,3 +21,13 @@ attribute [to_additive_ignore_args 2] Subtype
 attribute [to_additive] One
 attribute [to_additive existing Zero.toOfNat0] One.toOfNat1
 attribute [to_additive existing Zero.ofOfNat0] One.ofOfNat1
+
+attribute [to_additive existing] Inv Mul HMul instHMul Div HDiv instHDiv
+
+attribute [to_additive (reorder := α β) SMul] Pow
+attribute [to_additive existing (reorder := α β, 4 5) smul] Pow.pow
+attribute [to_additive existing (reorder := α β, pow (1 2))] Pow.mk
+attribute [to_additive (reorder := α β)] HPow
+attribute [to_additive existing (reorder := α β, 5 6)] HPow.hPow
+attribute [to_additive existing (reorder := α β, hPow (1 2))] HPow.mk
+attribute [to_additive existing] instHPow

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -241,12 +241,8 @@ lemma div_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
     (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x / y) i = x i / y i :=
   rfl
 
-instance instNSMul [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
-    SMul ℕ (Πʳ i, [R i, B i]_[𝓕]) where
-  smul n x := ⟨fun i ↦ n • (x i), x.2.mono fun _ hi ↦ nsmul_mem hi n⟩
-
-@[to_additive existing instNSMul]
-instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+@[to_additive]
+instance instPow [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℕ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ pow_mem hi n⟩
 
@@ -265,12 +261,8 @@ instance [Π i, CommMonoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     CommMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.commMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
-instance instZSMul [Π i, SubNegMonoid (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
-    SMul ℤ (Πʳ i, [R i, B i]_[𝓕]) where
-  smul n x := ⟨fun i ↦ n • x i, x.2.mono fun _ hi ↦ zsmul_mem hi n⟩
-
-@[to_additive existing instZSMul]
-instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
+@[to_additive]
+instance instZPow [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ zpow_mem hi n⟩
 

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -125,11 +125,11 @@ def mkMonoidHom [MulOneClass M] [ContinuousMul M] : M →* SeparationQuotient M 
   map_mul' := mk_mul
   map_one' := mk_one
 
-instance (priority := 900) instNSmul [AddMonoid M] [ContinuousAdd M] :
+instance (priority := 900) instNSMul [AddMonoid M] [ContinuousAdd M] :
     SMul ℕ (SeparationQuotient M) :=
   inferInstance
 
-@[to_additive existing instNSmul]
+@[to_additive existing]
 instance instPow [Monoid M] [ContinuousMul M] : Pow (SeparationQuotient M) ℕ where
   pow x n := Quotient.map' (s₁ := inseparableSetoid M) (· ^ n) (fun _ _ h ↦ Inseparable.pow h n) x
 

--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -121,10 +121,7 @@ theorem intCast_apply [IntCast β] (n : ℤ) (x : α) : (n : C(α, β)) x = n :=
 
 /-! ### `nsmul` and `pow` -/
 
-instance instNSMul [AddMonoid β] [ContinuousAdd β] : SMul ℕ C(α, β) :=
-  ⟨fun n f => ⟨n • ⇑f, f.continuous.nsmul n⟩⟩
-
-@[to_additive existing]
+@[to_additive]
 instance instPow [Monoid β] [ContinuousMul β] : Pow C(α, β) ℕ :=
   ⟨fun f n => ⟨(⇑f) ^ n, f.continuous.pow n⟩⟩
 
@@ -188,10 +185,7 @@ theorem div_comp [Div γ] [ContinuousDiv γ] (f g : C(β, γ)) (h : C(α, β)) :
 
 /-! ### `zpow` and `zsmul` -/
 
-instance instZSMul [AddGroup β] [IsTopologicalAddGroup β] : SMul ℤ C(α, β) where
-  smul z f := ⟨z • ⇑f, f.continuous.zsmul z⟩
-
-@[to_additive existing]
+@[to_additive]
 instance instZPow [Group β] [IsTopologicalGroup β] : Pow C(α, β) ℤ where
   pow f z := ⟨(⇑f) ^ z, f.continuous.zpow z⟩
 

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -510,19 +510,13 @@ theorem coe_mul [Mul R] [BoundedMul R] [ContinuousMul R] (f g : α →ᵇ R) : �
 theorem mul_apply [Mul R] [BoundedMul R] [ContinuousMul R] (f g : α →ᵇ R) (x : α) :
     (f * g) x = f x * g x := rfl
 
-@[simp]
+@[deprecated "dont use `nsmulRec` directly" (since := "2026-03-06")]
 theorem coe_nsmulRec [PseudoMetricSpace β] [AddMonoid β] [BoundedAdd β] [ContinuousAdd β]
     (f : α →ᵇ β) : ∀ n, ⇑(nsmulRec n f) = n • ⇑f
   | 0 => by rw [nsmulRec, zero_smul, coe_zero]
   | n + 1 => by rw [nsmulRec, succ_nsmul, coe_add, coe_nsmulRec _ n]
 
-instance instSMulNat [PseudoMetricSpace β] [AddMonoid β] [BoundedAdd β] [ContinuousAdd β] :
-    SMul ℕ (α →ᵇ β) where
-  smul n f :=
-    { toContinuousMap := n • f.toContinuousMap
-      map_bounded' := by simpa [coe_nsmulRec] using (nsmulRec n f).map_bounded' }
-
-@[to_additive existing instSMulNat]
+@[to_additive]
 instance instPow [Monoid R] [BoundedMul R] [ContinuousMul R] : Pow (α →ᵇ R) ℕ where
   pow f n :=
     { toFun := fun x ↦ (f x) ^ n

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -36,7 +36,7 @@ example : RestrictScalars.algebra ℝ ℂ ℂ = Complex.instAlgebraOfReal := by
   rfl
 
 example (α β : Type _) [AddMonoid α] [AddMonoid β] :
-    (Prod.instSMul : SMul ℕ (α × β)) = AddMonoid.toNatSMul := by
+    (Prod.instSMul : SMul ℕ (α × β)) = AddMonoid.toNSMul := by
   with_reducible_and_instances rfl
 
 example (α β : Type _) [SubNegMonoid α] [SubNegMonoid β] :
@@ -44,7 +44,7 @@ example (α β : Type _) [SubNegMonoid α] [SubNegMonoid β] :
   with_reducible_and_instances rfl
 
 example (α : Type _) (β : α → Type _) [∀ a, AddMonoid (β a)] :
-    (Pi.instSMul : SMul ℕ (∀ a, β a)) = AddMonoid.toNatSMul := by
+    (Pi.instSMul : SMul ℕ (∀ a, β a)) = AddMonoid.toNSMul := by
   with_reducible_and_instances rfl
 
 example (α : Type _) (β : α → Type _) [∀ a, SubNegMonoid (β a)] :


### PR DESCRIPTION
This PR uses the new `reorder` support in `to_additive` to automatically generate `SMul` instances from `Pow` instances.

I've tried to address most such instances, but this is probably not exhaustive. I've also taken the opportunity to uniformize the instance names a bit.

I wonder, should we change the order of the arguments in `Monoid.npow : ℕ → M → M` and `npowRec` to be consistent with the usual power operation, now that `to_additive` can support this kind of reordering? I suspect that the current ordering only exists for the sake of `to_additive`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
