### PR TITLE
[Merged by Bors] - feat: delaborators for `MDifferentiable(On)`

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -996,6 +996,25 @@ arguments that can use the `T%` elaborator. -/
 
 -- TODO: add a delaborator for `MDifferentiable` (with a test)
 
+/-- Delaborator for `MDifferentiable` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab MDifferentiable] meta def delabMDifferentiable : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 21 do
+  try
+    let fe := (← getExpr).appArg!
+    let .lam n _ b _ := fe | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let σe := b.getAppArgs[4]!.getAppFn
+    guard <| σe.isFVar
+    let Tσs ← withAppArg do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(MDiffAt $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withAppArg delab
+    `(MDiff $fs) >>= annotateGoToSyntaxDef
+
 /-- Delaborator for `MDifferentiableAt` using the custom elaborator, and special-casing
 arguments that can use the `T%` elaborator. -/
 @[app_delab MDifferentiableAt] meta def delabMDifferentiableAt : Delab := do
@@ -1042,6 +1061,10 @@ variable
   [ChartedSpace H M] [IsManifold I ∞ M]
   (f : M → M) (x : M) (s : Set M)
   (v : (x : M) → TangentSpace I x)
+
+/-- info: MDiff f : Prop -/
+#guard_msgs in
+#check MDifferentiable I I f
 
 -- The partially applied form omitting `s` is not delaborated.
 /-- info: MDifferentiableOn I I f : Set M → Prop -/

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -1038,43 +1038,21 @@ arguments that can use the `T%` elaborator. -/
 arguments that can use the `T%` elaborator. -/
 @[app_delab MDifferentiableOn] meta def delabMDifferentiableOn : Delab := do
   whenPPOption getPPNotation do
-  withOverApp 22 do -- count arguments until the set s
+  withOverApp 22 do -- count arguments until the set s (exclusive)
+  let ss ← withAppArg delab -- the set s
   try
-    let fe := (← getExpr).appArg!
-    let .lam n _ b _ := fe | failure
+    let f := (← getExpr).getAppArgs[20]!
+    let .lam n _ b _ := f | failure
     guard <| b.isAppOf ``Bundle.TotalSpace.mk'
     let σe := b.getAppArgs[4]!.getAppFn -- why this magic number?
     guard <| σe.isFVar
-    let Tσs ← withAppArg do
+    let Tσs ← withNaryArg 20 do
       let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
       `((T% $σs)) >>= annotateGoToSyntaxDef
-    `(MDiffAt $Tσs) >>= annotateGoToSyntaxDef
+    `(MDiff[$ss] $Tσs) >>= annotateGoToSyntaxDef
   catch _ =>
-    let fs ← withAppArg delab
-    -- TODO: omitting the second $fs is a parse error!
-    `(MDiff[$fs] $fs) >>= annotateGoToSyntaxDef
-
--- TODO: move this test to `.../Delaborators.lean`
-variable
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M]
-  [ChartedSpace H M] [IsManifold I ∞ M]
-  (f : M → M) (x : M) (s : Set M)
-  (v : (x : M) → TangentSpace I x)
-
-/-- info: MDiff f : Prop -/
-#guard_msgs in
-#check MDifferentiable I I f
-
--- The partially applied form omitting `s` is not delaborated.
-/-- info: MDifferentiableOn I I f : Set M → Prop -/
-#guard_msgs in
-#check MDifferentiableOn I I f
-
--- TODO: almost what I want, except for the repeated s
-/-- info: MDiff[s] s : Prop -/
-#guard_msgs in
-#check MDifferentiableOn I I f s
+    let fs ← withNaryArg 20 <| delab
+    `(MDiff[$ss] $fs) >>= annotateGoToSyntaxDef
 
 /-- Delaborator for `MDifferentiableWithinAt` using the custom elaborator, and special-casing
 arguments that can use the `T%` elaborator. -/

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -992,6 +992,10 @@ arguments that can use the `T%` elaborator. -/
     let fs ← withAppArg delab
     `(mfderiv% $fs) >>= annotateGoToSyntaxDef
 
+-- TODO: add a delaborator for mfderivWithin (with a test)
+
+-- TODO: add a delaborator for `MDifferentiable` (with a test)
+
 /-- Delaborator for `MDifferentiableAt` using the custom elaborator, and special-casing
 arguments that can use the `T%` elaborator. -/
 @[app_delab MDifferentiableAt] meta def delabMDifferentiableAt : Delab := do
@@ -1031,6 +1035,7 @@ arguments that can use the `T%` elaborator. -/
     -- TODO: omitting the second $fs is a parse error!
     `(MDiff[$fs] $fs) >>= annotateGoToSyntaxDef
 
+-- TODO: move this test to `.../Delaborators.lean`
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M]
@@ -1067,5 +1072,11 @@ arguments that can use the `T%` elaborator. -/
   catch _ =>
     let fs ← withNaryArg 20 <| delab
     `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
+
+-- TODO: add more delaborators (and tests) for
+-- ContMDiff, ContMDiffOn, ContMDiffAt, ContMDiffWithinAt, HasMFDerivAt, HasMFDerivWithinAt
+
+-- TODO: when adding more elaborators (for e.g. UniqueDiffOn, TangentSpace, tangentMap(Within),
+-- mlieBracket(Within), mpullback(Within))
 
 end delaborators

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -977,7 +977,7 @@ open Bundle PrettyPrinter Delaborator SubExpr
 arguments that can use the `T%` elaborator. -/
 @[app_delab mfderiv] meta def delab_mfderiv : Delab := do
   whenPPOption getPPNotation do
-  withOverApp 21 do -- counting the number of arguments until f (inclusive): the x can be omitted
+  withOverApp 21 do
   try
     let fe := (← getExpr).appArg!
     let .lam n _ b _ := fe | failure
@@ -1036,13 +1036,13 @@ arguments that can use the `T%` elaborator. -/
 arguments that can use the `T%` elaborator. -/
 @[app_delab MDifferentiableOn] meta def delabMDifferentiableOn : Delab := do
   whenPPOption getPPNotation do
-  withOverApp 22 do -- count arguments until the set s (exclusive)
-  let ss ← withAppArg delab -- the set s
+  withOverApp 22 do
+  let ss ← withAppArg delab
   try
     let f := (← getExpr).getAppArgs[20]!
     let .lam n _ b _ := f | failure
     guard <| b.isAppOf ``Bundle.TotalSpace.mk'
-    let σe := b.getAppArgs[4]!.getAppFn -- why this magic number?
+    let σe := b.getAppArgs[4]!.getAppFn
     guard <| σe.isFVar
     let Tσs ← withNaryArg 20 do
       let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -977,7 +977,7 @@ open Bundle PrettyPrinter Delaborator SubExpr
 arguments that can use the `T%` elaborator. -/
 @[app_delab mfderiv] meta def delab_mfderiv : Delab := do
   whenPPOption getPPNotation do
-  withOverApp 21 do
+  withOverApp 21 do -- counting the number of arguments until f: the x can be omitted
   try
     let fe := (← getExpr).appArg!
     let .lam n _ b _ := fe | failure
@@ -1010,6 +1010,43 @@ arguments that can use the `T%` elaborator. -/
   catch _ =>
     let fs ← withAppArg delab
     `(MDiffAt $fs) >>= annotateGoToSyntaxDef
+
+/-- Delaborator for `MDifferentiableOn` using the custom elaborator, and special-casing
+arguments that can use the `T%` elaborator. -/
+@[app_delab MDifferentiableOn] meta def delabMDifferentiableOn : Delab := do
+  whenPPOption getPPNotation do
+  withOverApp 22 do -- count arguments until the set s
+  try
+    let fe := (← getExpr).appArg!
+    let .lam n _ b _ := fe | failure
+    guard <| b.isAppOf ``Bundle.TotalSpace.mk'
+    let σe := b.getAppArgs[4]!.getAppFn -- why this magic number?
+    guard <| σe.isFVar
+    let Tσs ← withAppArg do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(MDiffAt $Tσs) >>= annotateGoToSyntaxDef
+  catch _ =>
+    let fs ← withAppArg delab
+    -- TODO: omitting the second $fs is a parse error!
+    `(MDiff[$fs] $fs) >>= annotateGoToSyntaxDef
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M]
+  [ChartedSpace H M] [IsManifold I ∞ M]
+  (f : M → M) (x : M) (s : Set M)
+  (v : (x : M) → TangentSpace I x)
+
+-- The partially applied form omitting `s` is not delaborated.
+/-- info: MDifferentiableOn I I f : Set M → Prop -/
+#guard_msgs in
+#check MDifferentiableOn I I f
+
+-- TODO: almost what I want, except for the repeated s
+/-- info: MDiff[s] s : Prop -/
+#guard_msgs in
+#check MDifferentiableOn I I f s
 
 /-- Delaborator for `MDifferentiableWithinAt` using the custom elaborator, and special-casing
 arguments that can use the `T%` elaborator. -/

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -952,8 +952,8 @@ section delaborators
 /-!
 ### Delaborators
 
-In this section we make sure the info view also uses those notations. Not all notations are
-supported so far.
+In this section we make sure the infoview also uses those notations.
+Not all notations are supported yet.
 -/
 open Bundle PrettyPrinter Delaborator SubExpr
 
@@ -977,7 +977,7 @@ open Bundle PrettyPrinter Delaborator SubExpr
 arguments that can use the `T%` elaborator. -/
 @[app_delab mfderiv] meta def delab_mfderiv : Delab := do
   whenPPOption getPPNotation do
-  withOverApp 21 do -- counting the number of arguments until f: the x can be omitted
+  withOverApp 21 do -- counting the number of arguments until f (inclusive): the x can be omitted
   try
     let fe := (← getExpr).appArg!
     let .lam n _ b _ := fe | failure
@@ -993,8 +993,6 @@ arguments that can use the `T%` elaborator. -/
     `(mfderiv% $fs) >>= annotateGoToSyntaxDef
 
 -- TODO: add a delaborator for mfderivWithin (with a test)
-
--- TODO: add a delaborator for `MDifferentiable` (with a test)
 
 /-- Delaborator for `MDifferentiable` using the custom elaborator, and special-casing
 arguments that can use the `T%` elaborator. -/
@@ -1066,10 +1064,10 @@ arguments that can use the `T%` elaborator. -/
     guard <| b.isAppOf ``Bundle.TotalSpace.mk'
     let s := b.getAppArgs[4]!.getAppFn
     guard <| s.isFVar
-    let fs ← withNaryArg 20 do
-      let fs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
-      `((T% $fs)) >>= annotateGoToSyntaxDef
-    `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
+    let Tσs ← withNaryArg 20 do
+      let σs ← withBindingBody n <| withNaryArg 4 <| withNaryFn delab
+      `((T% $σs)) >>= annotateGoToSyntaxDef
+    `(MDiffAt[$ss] $Tσs) >>= annotateGoToSyntaxDef
   catch _ =>
     let fs ← withNaryArg 20 <| delab
     `(MDiffAt[$ss] $fs) >>= annotateGoToSyntaxDef
@@ -1077,7 +1075,6 @@ arguments that can use the `T%` elaborator. -/
 -- TODO: add more delaborators (and tests) for
 -- ContMDiff, ContMDiffOn, ContMDiffAt, ContMDiffWithinAt, HasMFDerivAt, HasMFDerivWithinAt
 
--- TODO: when adding more elaborators (for e.g. UniqueDiffOn, TangentSpace, tangentMap(Within),
--- mlieBracket(Within), mpullback(Within))
+-- TODO: when adding more elaborators, also add the corresponding delaborators
 
 end delaborators

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -21,9 +21,38 @@ variable
   (f : M → M) (x : M) (s : Set M)
   (v : (x : M) → TangentSpace I x)
 
+/-- info: MDiff f : Prop -/
+#guard_msgs in
+#check MDifferentiable I I f
+
+/-- info: MDiffAt (T% v) : Prop -/
+#guard_msgs in
+#check MDiff (T% v)
+
 /-- info: MDiffAt f x : Prop -/
 #guard_msgs in
 #check MDiffAt f x
+
+/-- info: MDiffAt (T% v) x : Prop -/
+#guard_msgs in
+#check MDiffAt (T% v) x
+
+/-- info: MDiff[s] f : Prop -/
+#guard_msgs in
+#check MDifferentiableOn I I f s
+
+/-- info: MDiff[s] (T% v) : Prop -/
+#guard_msgs in
+#check MDifferentiableOn I I.tangent (T% v) s
+
+/-- info: MDiff[s] (T% v) : Prop -/
+#guard_msgs in
+#check MDiff[s] (T% v)
+
+-- The partially applied form omitting `s` is not delaborated.
+/-- info: MDifferentiableOn I I f : Set M → Prop -/
+#guard_msgs in
+#check MDifferentiableOn I I f
 
 /-- info: MDiffAt[s] f x : Prop -/
 #guard_msgs in

--- a/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Delaborators.lean
@@ -1,5 +1,6 @@
 import Mathlib.Geometry.Manifold.Notation
 import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
 
 /-!
 # Tests for the differential geometry delaborators
@@ -51,3 +52,70 @@ variable
 /-- info: ⟨x, v x⟩ : TotalSpace E (TangentSpace I) -/
 #guard_msgs in
 #check TotalSpace.mk (F := E) x (v x)
+
+section ambiguity
+
+variable {g : E × E → M} in
+/-- info: MDiff g : Prop -/
+#guard_msgs in
+#check MDifferentiable 𝓘(ℝ, E × E) I g
+
+variable {g : E × E → M} in
+/-- info: MDiff g : Prop -/
+#guard_msgs in
+#check MDifferentiable ((𝓘(ℝ, E)).prod (𝓘(ℝ, E))) I g
+
+-- Note: information about the model with corners is omitted even in ambiguous situations.
+variable {g : E × E → E × E}
+/-- info: MDiff g : Prop -/
+#guard_msgs in
+#check MDifferentiable 𝓘(ℝ, E × E) ((𝓘(ℝ, E)).prod (𝓘(ℝ, E))) g
+
+-- This can yield rather confusing errors
+set_option pp.mvars.anonymous false in
+/--
+error: Tactic `apply` failed: could not unify the conclusion of `@mdifferentiable_id`
+  MDiff id
+with the goal
+  MDiff id
+
+Note: The full type of `@mdifferentiable_id` is
+  ∀ {𝕜 : Type _} [inst : NontriviallyNormedField 𝕜] {E : Type _} [inst_1 : NormedAddCommGroup E]
+    [inst_2 : NormedSpace 𝕜 E] {H : Type _} [inst_3 : TopologicalSpace H] {I : ModelWithCorners 𝕜 E H} {M : Type _}
+    [inst_4 : TopologicalSpace M] [inst_5 : ChartedSpace H M], MDiff id
+
+E : Type u_1
+inst✝⁵ : NormedAddCommGroup E
+inst✝⁴ : NormedSpace ℝ E
+H : Type u_2
+inst✝³ : TopologicalSpace H
+I : ModelWithCorners ℝ E H
+M : Type u_3
+inst✝² : TopologicalSpace M
+inst✝¹ : ChartedSpace H M
+inst✝ : IsManifold I ∞ M
+f : M → M
+x : M
+s : Set M
+v : (x : M) → TangentSpace I x
+g✝ g : E × E → E × E
+⊢ MDiff id
+-/
+#guard_msgs in
+example {g : E × E → E × E} : MDifferentiable 𝓘(ℝ, E × E) ((𝓘(ℝ, E)).prod (𝓘(ℝ, E))) (@id (E × E)) := by
+  apply mdifferentiable_id
+
+-- However, hovering over the goal in the infoview shows the different models used,
+-- so the information is still there (just not presented by default).
+
+-- Disabling the use of notation also displays that two different models with corners are used.
+variable {g : E × E → E × E}
+/--
+info: MDifferentiable (modelWithCornersSelf Real (Prod E E))
+  ((modelWithCornersSelf Real E).prod (modelWithCornersSelf Real E)) g : Prop
+-/
+#guard_msgs in
+set_option pp.notation false in
+#check MDifferentiable 𝓘(ℝ, E × E) ((𝓘(ℝ, E)).prod (𝓘(ℝ, E))) g
+
+end ambiguity

--- a/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
+++ b/MathlibTest/DifferentialGeometry/Notation/Sphere.lean
@@ -78,44 +78,44 @@ variable {G : Type*} [NormedAddCommGroup G] [InnerProductSpace ℝ G]
 -- The tests for the standard notation passes.
 
 variable [Fact (Module.finrank ℝ G = 3)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f : Prop -/
+/-- info: MDiff f : Prop -/
 #guard_msgs in
 #check MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f
 
 variable [Fact (Module.finrank ℝ G = 2 + 1)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f : Prop -/
+/-- info: MDiff f : Prop -/
 #guard_msgs in
 #check MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f
 
 variable [Fact (Module.finrank ℝ G = 4 + 1)] in
-/-- info: MDifferentiable 𝓘(ℝ, ℝ) (𝓡 4) g : Prop -/
+/-- info: MDiff g : Prop -/
 #guard_msgs in
 #check MDifferentiable 𝓘(ℝ) (𝓡 4) g
 
 variable [Fact (Module.finrank ℝ G = 3)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f : Prop -/
+/-- info: MDiff f : Prop -/
 #guard_msgs in
 #check MDiff f
 
 variable [Fact (Module.finrank ℝ G = 2 + 1)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E'') f : Prop -/
+/-- info: MDiff f : Prop -/
 #guard_msgs in
 #check MDiff f
 
 -- The following two tests are variants of the previous tests with target an inner product space
 -- and not a normed space: this used to fail in the past.
 variable {f' : (Metric.sphere (0 : G) 1) → E'} [Fact (Module.finrank ℝ G = 3)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E') f' : Prop -/
+/-- info: MDiff f' : Prop -/
 #guard_msgs in
 #check MDiff f'
 
 variable {f' : (Metric.sphere (0 : G) 1) → E'} [Fact (Module.finrank ℝ G = 2 + 1)] in
-/-- info: MDifferentiable (𝓡 2) 𝓘(ℝ, E') f' : Prop -/
+/-- info: MDiff f' : Prop -/
 #guard_msgs in
 #check MDiff f'
 
 variable [Fact (Module.finrank ℝ G = 4 + 1)] in
-/-- info: MDifferentiable 𝓘(ℝ, ℝ) (𝓡 4) g : Prop -/
+/-- info: MDiff g : Prop -/
 #guard_msgs in
 #check MDiff g
 
@@ -174,7 +174,7 @@ end
 
 -- This matching is not too clever, though. 2 + 4 is unified as (2 + 3) + 1 (not 5 + 1).
 variable [Fact (Module.finrank ℝ E'' = 2 + 4)] in
-/-- info: MDifferentiable (𝓡 2 + 3) 𝓘(ℝ, ℝ) f : Prop -/
+/-- info: MDiff f : Prop -/
 #guard_msgs in
 #check MDiff f
 


### PR DESCRIPTION
And make a precise list which elaborators are missing delaborators at the moment.
Continuation of #36230.

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
