### PR TITLE
feat(NumberTheory/LSeries): Schwarz reflection for Mellin transforms with real kernels

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5562,6 +5562,7 @@ public import Mathlib.NumberTheory.LSeries.Nonvanishing
 public import Mathlib.NumberTheory.LSeries.Positivity
 public import Mathlib.NumberTheory.LSeries.PrimesInAP
 public import Mathlib.NumberTheory.LSeries.RiemannZeta
+public import Mathlib.NumberTheory.LSeries.SchwarzReflection
 public import Mathlib.NumberTheory.LSeries.SumCoeff
 public import Mathlib.NumberTheory.LSeries.ZMod
 public import Mathlib.NumberTheory.LSeries.ZetaZeros

--- a/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
+++ b/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
@@ -11,52 +11,62 @@ public import Mathlib.Analysis.Complex.RealDeriv
 # Schwarz Reflection for the Completed Riemann Zeta Function
 
 We prove that `completedRiemannZeta₀` satisfies the Schwarz reflection
-principle: `Λ₀(conj s) = conj(Λ₀(s))`. As a corollary, we establish that
-`completedRiemannZeta₀` is real-valued on the critical line `Re(s) = 1/2`.
-
-## Main results
-
-* `completedRiemannZeta₀_conj`: The Schwarz reflection identity
-  `completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s)`.
-
-* `completedRiemannZeta₀_im_eq_zero_on_half`: On the critical line,
-  `Im(completedRiemannZeta₀(1/2 + it)) = 0` for all real `t`.
-
-* `completedRiemannZeta₀_deriv_re_eq_zero_on_half`: The derivative has vanishing
-  real part on the critical line: `Re(Λ₀'(1/2 + it)) = 0` for all real `t`.
+principle: `Λ₀(conj s) = conj(Λ₀(s))`.
 
 ## Proof strategy
 
-The Schwarz reflection follows from the Mellin representation of
-`completedRiemannZeta₀`. The kernel `(hurwitzEvenFEPair 0).f_modif`
-is real-valued (its imaginary part vanishes), so the Mellin integral
-commutes with complex conjugation via `integral_conj`. The power
-`t^(s/2 - 1)` conjugates correctly for positive real `t` by `cpow_conj`.
+The proof proceeds in two stages:
 
-The critical-line reality result composes Schwarz reflection with the
-functional equation: at `s = 1/2 + it`, we have `conj(s) = 1 - s`,
-so `conj(Λ₀(s)) = Λ₀(conj s) = Λ₀(1 - s) = Λ₀(s)`.
+1. **Real on reals**: We show that the Mellin kernel `(hurwitzEvenFEPair 0).f_modif`
+   is real-valued, and that for `s : ℝ` the Mellin integrand
+   `t^(s/2-1) · kernel(t)` is real (since `t^r` is real for `t > 0, r ∈ ℝ`).
+   Therefore `completedRiemannZeta₀(s)` is real when `s ∈ ℝ`.
+
+2. **Schwarz reflection**: The same real-kernel property, combined with
+   `cpow_conj` for positive reals and `integral_conj`, gives the full
+   conjugation identity `Λ₀(conj s) = conj(Λ₀(s))`.
+
+The critical-line reality result then follows by composing Schwarz reflection
+with the functional equation: at `s = 1/2 + it`, `conj(s) = 1 - s`.
+
+## Main results
+
+* `completedRiemannZeta₀_ofReal_im`: `Λ₀` is real-valued on `ℝ`.
+* `completedRiemannZeta₀_conj`: Schwarz reflection `Λ₀(conj s) = conj(Λ₀(s))`.
+* `completedRiemannZeta₀_im_eq_zero_on_half`: `Im(Λ₀(1/2 + it)) = 0`.
+* `completedRiemannZeta₀_deriv_re_eq_zero_on_half`: `Re(Λ₀'(1/2 + it)) = 0`.
 -/
 
 @[expose] public section
 
-
 open Complex HurwitzZeta MeasureTheory Set
 
-section SchwarzReflection
+/-! ## The kernel is real-valued -/
+
+section RealKernel
 
 /-- The modified kernel of the Hurwitz even FE pair at `a = 0` is real-valued:
-its complex conjugate equals itself. This is because it is built from
+its imaginary part vanishes. This is because it is built from
 real-valued functions (exponentials of real quadratic forms). -/
-private lemma hurwitzEvenFEPair_f_modif_conj_fixed (t : ℝ) :
-    (hurwitzEvenFEPair 0).f_modif t = starRingEnd ℂ ((hurwitzEvenFEPair 0).f_modif t) := by
-  rw [eq_comm, Complex.conj_eq_iff_im]
+theorem hurwitzEvenFEPair_f_modif_im_zero (t : ℝ) :
+    ((hurwitzEvenFEPair 0).f_modif t).im = 0 := by
   simp only [WeakFEPair.f_modif, Pi.add_apply, indicator_apply]
   split_ifs <;> simp [Complex.add_im, Complex.sub_im, Complex.ofReal_im,
     Complex.one_im, Complex.zero_im, hurwitzEvenFEPair]
 
+/-- Equivalent formulation: the kernel equals its own conjugate. -/
+theorem hurwitzEvenFEPair_f_modif_conj (t : ℝ) :
+    starRingEnd ℂ ((hurwitzEvenFEPair 0).f_modif t) = (hurwitzEvenFEPair 0).f_modif t := by
+  rw [Complex.conj_eq_iff_im]
+  exact hurwitzEvenFEPair_f_modif_im_zero t
+
+end RealKernel
+
+/-! ## Schwarz reflection and real-on-reals -/
+
+section SchwarzReflection
+
 /-- **Schwarz reflection for the completed Riemann zeta function.**
-The completed Riemann zeta function `Λ₀` satisfies
 `Λ₀(conj(s)) = conj(Λ₀(s))` for all `s : ℂ`.
 
 This follows from the Mellin representation: the kernel is real-valued,
@@ -74,14 +84,13 @@ theorem completedRiemannZeta₀_conj (s : ℂ) :
       (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t) := by
     simp only [smul_eq_mul, map_mul]
     congr 1
-    · -- Inline conj_half_sub_one + cpow_conj_pos_real
-      have harg : ((t : ℂ)).arg ≠ Real.pi := by
+    · have harg : ((t : ℂ)).arg ≠ Real.pi := by
         rw [arg_ofReal_of_nonneg (le_of_lt ht)]; exact Real.pi_pos.ne
       rw [show starRingEnd ℂ s / 2 - 1 = starRingEnd ℂ (s / 2 - 1) from by
         rw [map_sub, map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by
           exact_mod_cast conj_ofReal 2, map_one]]
       rw [cpow_conj _ _ harg]; simp [conj_ofReal]
-    · exact hurwitzEvenFEPair_f_modif_conj_fixed t
+    · exact (hurwitzEvenFEPair_f_modif_conj t).symm
   calc ∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) •
         (hurwitzEvenFEPair 0).f_modif t
       = ∫ t in Ioi (0 : ℝ), (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) •
@@ -91,7 +100,18 @@ theorem completedRiemannZeta₀_conj (s : ℂ) :
         (hurwitzEvenFEPair 0).f_modif t) :=
           integral_conj
 
+/-- **`completedRiemannZeta₀` is real-valued on `ℝ`.**
+For `r : ℝ`, `Im(Λ₀(r)) = 0`. This follows from Schwarz reflection
+since `conj(↑r) = ↑r` for real `r`. -/
+theorem completedRiemannZeta₀_ofReal_im (r : ℝ) :
+    (completedRiemannZeta₀ ↑r).im = 0 := by
+  have h : starRingEnd ℂ (completedRiemannZeta₀ ↑r) = completedRiemannZeta₀ ↑r := by
+    rw [← completedRiemannZeta₀_conj, conj_ofReal]
+  exact conj_eq_iff_im.mp h
+
 end SchwarzReflection
+
+/-! ## Critical line -/
 
 section CriticalLine
 
@@ -104,7 +124,7 @@ private lemma conj_half_add_mul_I (t : ℝ) :
   · simp [Complex.conj_im, Complex.sub_im, Complex.one_im]
 
 /-- **The completed Riemann zeta function is real-valued on the critical line.**
-At every point `1/2 + it` on the critical line, `Im(Λ₀(1/2 + it)) = 0`.
+At every point `1/2 + it`, `Im(Λ₀(1/2 + it)) = 0`.
 
 Proof: Schwarz reflection gives `conj(Λ₀(s)) = Λ₀(conj s)`,
 the functional equation gives `Λ₀(1 - s) = Λ₀(s)`,
@@ -127,6 +147,8 @@ theorem completedRiemannZeta₀_conj_eq_self_on_half (t : ℝ) :
 
 end CriticalLine
 
+/-! ## Derivative on the critical line -/
+
 section DerivativeCriticalLine
 
 /-- The affine map `z ↦ 1/2 + z * I` has complex derivative `I`. -/
@@ -147,9 +169,7 @@ private lemma half_add_ofReal_mul_I (t : ℝ) :
   apply Complex.ext <;> simp
 
 set_option backward.isDefEq.respectTransparency false in
-/-- Imaginary-part analogue of `HasDerivAt.real_of_complex`: if a complex function
-is ℂ-differentiable at a real point, then the imaginary part of its restriction to ℝ
-is ℝ-differentiable with derivative equal to the imaginary part of the complex derivative. -/
+/-- Imaginary-part analogue of `HasDerivAt.real_of_complex`. -/
 private lemma HasDerivAt.im_of_complex {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
     (h : HasDerivAt e e' z) :
     HasDerivAt (fun x : ℝ => (e x).im) e'.im z := by
@@ -161,14 +181,8 @@ private lemma HasDerivAt.im_of_complex {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
   have C : HasFDerivAt im imCLM (e (ofRealCLM z)) := imCLM.hasFDerivAt
   simpa using (C.comp z (B.comp z A)).hasDerivAt
 
-/-- **The derivative of the completed Riemann zeta function has vanishing
-real part on the critical line:** `Re(Λ₀'(1/2 + it)) = 0` for all real `t`.
-
-Proof: The rotated function `e(z) = Λ₀(1/2 + z · I)` is entire with
-`e'(z) = Λ₀'(1/2 + z · I) · I`. Restricting to ℝ, `Im(e(t)) = 0` for all
-real `t` (by `completedRiemannZeta₀_im_eq_zero_on_half`), so the ℝ-derivative
-of `Im(e(t))` vanishes. But this derivative equals `(e'(t)).im = (Λ₀'(1/2+it) · I).im
-= Re(Λ₀'(1/2 + it))`, giving the result. -/
+/-- **The derivative has vanishing real part on the critical line:**
+`Re(Λ₀'(1/2 + it)) = 0` for all real `t`. -/
 theorem completedRiemannZeta₀_deriv_re_eq_zero_on_half (t : ℝ) :
     (deriv completedRiemannZeta₀ ⟨1/2, t⟩).re = 0 := by
   have hderiv := hasDerivAt_completedRiemannZeta₀_rotated (↑t)
@@ -183,3 +197,5 @@ theorem completedRiemannZeta₀_deriv_re_eq_zero_on_half (t : ℝ) :
   linarith
 
 end DerivativeCriticalLine
+
+end

--- a/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
+++ b/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
@@ -62,43 +62,61 @@ theorem hurwitzEvenFEPair_f_modif_conj (t : ℝ) :
 
 end RealKernel
 
-/-! ## Schwarz reflection and real-on-reals -/
+/-! ## General Schwarz reflection for Mellin transforms with real kernels -/
+
+section MellinConj
+
+/-- **Mellin transform commutes with conjugation for real-valued kernels.**
+If `φ : ℝ → ℂ` satisfies `conj(φ(t)) = φ(t)` for all `t`, then
+`mellin φ (conj s) = conj (mellin φ s)`. -/
+theorem mellin_conj_of_real_kernel {φ : ℝ → ℂ}
+    (hreal : ∀ t : ℝ, starRingEnd ℂ (φ t) = φ t) (s : ℂ) :
+    mellin φ (starRingEnd ℂ s) = starRingEnd ℂ (mellin φ s) := by
+  simp only [mellin]
+  have hpt {t : ℝ} (ht : t ∈ Ioi 0) :
+    (↑t : ℂ) ^ (starRingEnd ℂ s - 1) • φ t =
+      starRingEnd ℂ ((↑t : ℂ) ^ (s - 1) • φ t) := by
+    simp only [smul_eq_mul, map_mul]
+    congr 1
+    · have harg : ((t : ℂ)).arg ≠ Real.pi := by
+        rw [arg_ofReal_of_nonneg (le_of_lt ht)]; exact Real.pi_pos.ne
+      rw [show starRingEnd ℂ s - 1 = starRingEnd ℂ (s - 1) from by
+        rw [map_sub, map_one]]
+      rw [cpow_conj _ _ harg]; simp [conj_ofReal]
+    · exact (hreal t).symm
+  calc ∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ (starRingEnd ℂ s - 1) • φ t
+      = ∫ t in Ioi (0 : ℝ), starRingEnd ℂ ((↑t : ℂ) ^ (s - 1) • φ t) :=
+          setIntegral_congr_fun measurableSet_Ioi fun t ht => hpt ht
+    _ = starRingEnd ℂ (∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ (s - 1) • φ t) :=
+          integral_conj
+
+/-- **Schwarz reflection for `Λ₀` of a `WeakFEPair` with real-valued kernel.**
+If `P.f_modif` is real-valued, then `P.Λ₀ (conj s) = conj (P.Λ₀ s)`. -/
+theorem WeakFEPair.Λ₀_conj (P : WeakFEPair ℂ)
+    (hreal : ∀ t : ℝ, starRingEnd ℂ (P.f_modif t) = P.f_modif t) (s : ℂ) :
+    P.Λ₀ (starRingEnd ℂ s) = starRingEnd ℂ (P.Λ₀ s) :=
+  mellin_conj_of_real_kernel hreal s
+
+end MellinConj
+
+/-! ## Schwarz reflection for `completedRiemannZeta₀` -/
 
 section SchwarzReflection
 
 /-- **Schwarz reflection for the completed Riemann zeta function.**
 `Λ₀(conj(s)) = conj(Λ₀(s))` for all `s : ℂ`.
 
-This follows from the Mellin representation: the kernel is real-valued,
-positive-real powers conjugate correctly, and the integral commutes
-with conjugation. -/
+Specialization of `WeakFEPair.Λ₀_conj` to `hurwitzEvenFEPair 0`,
+composed with the `s/2` and `/2` rescaling. -/
 theorem completedRiemannZeta₀_conj (s : ℂ) :
     completedRiemannZeta₀ (starRingEnd ℂ s) = starRingEnd ℂ (completedRiemannZeta₀ s) := by
-  change mellin (hurwitzEvenFEPair 0).f_modif (starRingEnd ℂ s / 2) / 2 =
-    starRingEnd ℂ (mellin (hurwitzEvenFEPair 0).f_modif (s / 2) / 2)
+  change (hurwitzEvenFEPair 0).Λ₀ (starRingEnd ℂ s / 2) / 2 =
+    starRingEnd ℂ ((hurwitzEvenFEPair 0).Λ₀ (s / 2) / 2)
   rw [map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by exact_mod_cast conj_ofReal 2]
   congr 1
-  simp only [mellin]
-  have hpt {t : ℝ} (ht : t ∈ Ioi 0) :
-    (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t =
-      (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t) := by
-    simp only [smul_eq_mul, map_mul]
-    congr 1
-    · have harg : ((t : ℂ)).arg ≠ Real.pi := by
-        rw [arg_ofReal_of_nonneg (le_of_lt ht)]; exact Real.pi_pos.ne
-      rw [show starRingEnd ℂ s / 2 - 1 = starRingEnd ℂ (s / 2 - 1) from by
-        rw [map_sub, map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by
-          exact_mod_cast conj_ofReal 2, map_one]]
-      rw [cpow_conj _ _ harg]; simp [conj_ofReal]
-    · exact (hurwitzEvenFEPair_f_modif_conj t).symm
-  calc ∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) •
-        (hurwitzEvenFEPair 0).f_modif t
-      = ∫ t in Ioi (0 : ℝ), (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) •
-        (hurwitzEvenFEPair 0).f_modif t) :=
-          setIntegral_congr_fun measurableSet_Ioi fun t ht => hpt ht
-    _ = (starRingEnd ℂ) (∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ (s / 2 - 1) •
-        (hurwitzEvenFEPair 0).f_modif t) :=
-          integral_conj
+  rw [show starRingEnd ℂ s / 2 = starRingEnd ℂ (s / 2) from by
+    rw [map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by exact_mod_cast conj_ofReal 2]]
+  exact (hurwitzEvenFEPair 0).Λ₀_conj hurwitzEvenFEPair_f_modif_conj (s / 2)
 
 /-- **`completedRiemannZeta₀` is real-valued on `ℝ`.**
 For `r : ℝ`, `Im(Λ₀(r)) = 0`. This follows from Schwarz reflection

--- a/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
+++ b/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
@@ -5,6 +5,7 @@ Authors: interleaves
 -/
 module
 public import Mathlib.NumberTheory.LSeries.RiemannZeta
+public import Mathlib.Analysis.Complex.RealDeriv
 
 /-!
 # Schwarz Reflection for the Completed Riemann Zeta Function
@@ -20,6 +21,9 @@ principle: `Λ₀(conj s) = conj(Λ₀(s))`. As a corollary, we establish that
 
 * `completedRiemannZeta₀_im_eq_zero_on_half`: On the critical line,
   `Im(completedRiemannZeta₀(1/2 + it)) = 0` for all real `t`.
+
+* `completedRiemannZeta₀_deriv_re_eq_zero_on_half`: The derivative has vanishing
+  real part on the critical line: `Re(Λ₀'(1/2 + it)) = 0` for all real `t`.
 
 ## Proof strategy
 
@@ -115,18 +119,11 @@ private lemma conj_half_add_mul_I (t : ℝ) :
   · simp [Complex.conj_im, Complex.sub_im, Complex.one_im]
 
 /-- **The completed Riemann zeta function is real-valued on the critical line.**
-
 At every point `1/2 + it` on the critical line, `Im(Λ₀(1/2 + it)) = 0`.
 
-Proof: At `s = 1/2 + it`, conjugation gives `conj(s) = 1/2 - it = 1 - s`.
-By Schwarz reflection: `conj(Λ₀(s)) = Λ₀(conj s) = Λ₀(1 - s)`.
-By the functional equation: `Λ₀(1 - s) = Λ₀(s)`.
-Therefore `conj(Λ₀(s)) = Λ₀(s)`, which holds iff `Im(Λ₀(s)) = 0`.
-
-This establishes that zeros of `Λ₀` on the critical line are sign changes
-of a real-valued function (codimension 1), while off-line zeros would
-require the simultaneous vanishing of both real and imaginary parts
-(codimension 2). -/
+Proof: Schwarz reflection gives `conj(Λ₀(s)) = Λ₀(conj s)`,
+the functional equation gives `Λ₀(1 - s) = Λ₀(s)`,
+and at `s = 1/2 + it` we have `conj(s) = 1 - s`. -/
 theorem completedRiemannZeta₀_im_eq_zero_on_half (t : ℝ) :
     (completedRiemannZeta₀ ⟨1/2, t⟩).im = 0 := by
   suffices h :
@@ -144,3 +141,60 @@ theorem completedRiemannZeta₀_conj_eq_self_on_half (t : ℝ) :
   exact completedRiemannZeta₀_one_sub ⟨1 / 2, t⟩
 
 end CriticalLine
+
+section DerivativeCriticalLine
+
+/-- The affine map `z ↦ 1/2 + z * I` has complex derivative `I`. -/
+private lemma hasDerivAt_half_add_mul_I (z : ℂ) :
+    HasDerivAt (fun w : ℂ => (1/2 : ℂ) + w * I) I z := by
+  convert (hasDerivAt_const z (1/2 : ℂ)).add ((hasDerivAt_id z).mul_const I) using 1; simp
+
+/-- The rotated function `z ↦ Λ₀(1/2 + z · I)` has complex derivative
+`Λ₀'(1/2 + z · I) · I` at `z`. -/
+private lemma hasDerivAt_completedRiemannZeta₀_rotated (z : ℂ) :
+    HasDerivAt (fun w => completedRiemannZeta₀ (1/2 + w * I))
+      (deriv completedRiemannZeta₀ (1/2 + z * I) * I) z :=
+  differentiable_completedZeta₀.differentiableAt.hasDerivAt.comp z (hasDerivAt_half_add_mul_I z)
+
+/-- On the real line, `1/2 + t * I = ⟨1/2, t⟩`. -/
+private lemma half_add_ofReal_mul_I (t : ℝ) :
+    (1/2 : ℂ) + (↑t) * I = ⟨1/2, t⟩ := by
+  apply Complex.ext <;> simp
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Imaginary-part analogue of `HasDerivAt.real_of_complex`: if a complex function
+is ℂ-differentiable at a real point, then the imaginary part of its restriction to ℝ
+is ℝ-differentiable with derivative equal to the imaginary part of the complex derivative. -/
+private lemma HasDerivAt.im_of_complex {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
+    (h : HasDerivAt e e' z) :
+    HasDerivAt (fun x : ℝ => (e x).im) e'.im z := by
+  have A : HasFDerivAt ((↑) : ℝ → ℂ) ofRealCLM z := ofRealCLM.hasFDerivAt
+  have B :
+    HasFDerivAt e ((ContinuousLinearMap.smulRight 1 e' : ℂ →L[ℂ] ℂ).restrictScalars ℝ)
+      (ofRealCLM z) :=
+    h.hasFDerivAt.restrictScalars ℝ
+  have C : HasFDerivAt im imCLM (e (ofRealCLM z)) := imCLM.hasFDerivAt
+  simpa using (C.comp z (B.comp z A)).hasDerivAt
+
+/-- **The derivative of the completed Riemann zeta function has vanishing
+real part on the critical line:** `Re(Λ₀'(1/2 + it)) = 0` for all real `t`.
+
+Proof: The rotated function `e(z) = Λ₀(1/2 + z · I)` is entire with
+`e'(z) = Λ₀'(1/2 + z · I) · I`. Restricting to ℝ, `Im(e(t)) = 0` for all
+real `t` (by `completedRiemannZeta₀_im_eq_zero_on_half`), so the ℝ-derivative
+of `Im(e(t))` vanishes. But this derivative equals `(e'(t)).im = (Λ₀'(1/2+it) · I).im
+= Re(Λ₀'(1/2 + it))`, giving the result. -/
+theorem completedRiemannZeta₀_deriv_re_eq_zero_on_half (t : ℝ) :
+    (deriv completedRiemannZeta₀ ⟨1/2, t⟩).re = 0 := by
+  have hderiv := hasDerivAt_completedRiemannZeta₀_rotated (↑t)
+  have him_deriv := hderiv.im_of_complex
+  simp only [half_add_ofReal_mul_I] at him_deriv
+  have him_const : HasDerivAt (fun s : ℝ => (completedRiemannZeta₀ ⟨1/2, s⟩).im) 0 t := by
+    have : (fun s : ℝ => (completedRiemannZeta₀ ⟨1/2, s⟩).im) = fun _ => 0 :=
+      funext completedRiemannZeta₀_im_eq_zero_on_half
+    rw [this]; exact hasDerivAt_const t (0 : ℝ)
+  have h_eq := him_deriv.unique him_const
+  simp only [mul_im, I_re, I_im] at h_eq
+  linarith
+
+end DerivativeCriticalLine

--- a/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
+++ b/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 interleaves. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: interleaves
+-/
+module
+public import Mathlib.NumberTheory.LSeries.RiemannZeta
+
+/-!
+# Schwarz Reflection for the Completed Riemann Zeta Function
+
+We prove that `completedRiemannZeta₀` satisfies the Schwarz reflection
+principle: `Λ₀(conj s) = conj(Λ₀(s))`. As a corollary, we establish that
+`completedRiemannZeta₀` is real-valued on the critical line `Re(s) = 1/2`.
+
+## Main results
+
+* `completedRiemannZeta₀_conj`: The Schwarz reflection identity
+  `completedRiemannZeta₀ (conj s) = conj (completedRiemannZeta₀ s)`.
+
+* `completedRiemannZeta₀_im_eq_zero_on_half`: On the critical line,
+  `Im(completedRiemannZeta₀(1/2 + it)) = 0` for all real `t`.
+
+## Proof strategy
+
+The Schwarz reflection follows from the Mellin representation of
+`completedRiemannZeta₀`. The kernel `(hurwitzEvenFEPair 0).f_modif`
+is real-valued (its imaginary part vanishes), so the Mellin integral
+commutes with complex conjugation via `integral_conj`. The power
+`t^(s/2 - 1)` conjugates correctly for positive real `t` by `cpow_conj`.
+
+The critical-line reality result composes Schwarz reflection with the
+functional equation: at `s = 1/2 + it`, we have `conj(s) = 1 - s`,
+so `conj(Λ₀(s)) = Λ₀(conj s) = Λ₀(1 - s) = Λ₀(s)`.
+-/
+
+@[expose] public section
+
+
+open Complex HurwitzZeta MeasureTheory Set
+
+section SchwarzReflection
+
+private lemma conj_ofReal_two : (starRingEnd ℂ) (2 : ℂ) = 2 := by
+  exact_mod_cast conj_ofReal 2
+
+private lemma arg_pos_real_ne_pi (t : ℝ) (ht : 0 < t) : ((t : ℂ)).arg ≠ Real.pi := by
+  rw [arg_ofReal_of_nonneg (le_of_lt ht)]
+  exact Real.pi_pos.ne
+
+private lemma cpow_conj_pos_real (t : ℝ) (ht : 0 < t) (w : ℂ) :
+    (↑t : ℂ) ^ (starRingEnd ℂ w) = starRingEnd ℂ (t ^ w) := by
+  rw [cpow_conj _ _ (arg_pos_real_ne_pi t ht)]
+  simp [conj_ofReal]
+
+private lemma conj_div_two (s : ℂ) :
+    starRingEnd ℂ (s / 2) = starRingEnd ℂ s / 2 := by
+  rw [map_div₀, conj_ofReal_two]
+
+private lemma conj_half_sub_one (s : ℂ) :
+    starRingEnd ℂ s / 2 - 1 = starRingEnd ℂ (s / 2 - 1) := by
+  rw [map_sub, conj_div_two, map_one]
+
+/-- The modified kernel of the Hurwitz even FE pair at `a = 0` is real-valued:
+its complex conjugate equals itself. This is because it is built from
+real-valued functions (exponentials of real quadratic forms). -/
+private lemma hurwitzEvenFEPair_f_modif_conj_fixed (t : ℝ) :
+    (hurwitzEvenFEPair 0).f_modif t = starRingEnd ℂ ((hurwitzEvenFEPair 0).f_modif t) := by
+  rw [eq_comm, Complex.conj_eq_iff_im]
+  simp only [WeakFEPair.f_modif, Pi.add_apply, indicator_apply]
+  split_ifs <;> simp [Complex.add_im, Complex.sub_im, Complex.ofReal_im,
+    Complex.one_im, Complex.zero_im, hurwitzEvenFEPair]
+
+/-- **Schwarz reflection for the completed Riemann zeta function.**
+The completed Riemann zeta function `Λ₀` satisfies
+`Λ₀(conj(s)) = conj(Λ₀(s))` for all `s : ℂ`.
+
+This follows from the Mellin representation: the kernel is real-valued,
+positive-real powers conjugate correctly, and the integral commutes
+with conjugation. -/
+theorem completedRiemannZeta₀_conj (s : ℂ) :
+    completedRiemannZeta₀ (starRingEnd ℂ s) = starRingEnd ℂ (completedRiemannZeta₀ s) := by
+  change mellin (hurwitzEvenFEPair 0).f_modif (starRingEnd ℂ s / 2) / 2 =
+    starRingEnd ℂ (mellin (hurwitzEvenFEPair 0).f_modif (s / 2) / 2)
+  rw [map_div₀, conj_ofReal_two]
+  congr 1
+  simp only [mellin]
+  have hpt {t : ℝ} (ht : t ∈ Ioi 0) :
+    (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t =
+      (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t) := by
+    simp only [smul_eq_mul, map_mul]
+    congr 1
+    · rw [conj_half_sub_one]
+      exact cpow_conj_pos_real t ht (s / 2 - 1)
+    · exact hurwitzEvenFEPair_f_modif_conj_fixed t
+  calc ∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) •
+        (hurwitzEvenFEPair 0).f_modif t
+      = ∫ t in Ioi (0 : ℝ), (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) •
+        (hurwitzEvenFEPair 0).f_modif t) :=
+          setIntegral_congr_fun measurableSet_Ioi fun t ht => hpt ht
+    _ = (starRingEnd ℂ) (∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ (s / 2 - 1) •
+        (hurwitzEvenFEPair 0).f_modif t) :=
+          integral_conj
+
+end SchwarzReflection
+
+section CriticalLine
+
+/-- At `s = 1/2 + it` on the critical line, conjugation gives `1 - s`. -/
+private lemma conj_half_add_mul_I (t : ℝ) :
+    (starRingEnd ℂ) (⟨1 / 2, t⟩ : ℂ) = 1 - (⟨1 / 2, t⟩ : ℂ) := by
+  apply Complex.ext_iff.mpr
+  constructor
+  · simp [Complex.conj_re, Complex.sub_re, Complex.one_re]; ring
+  · simp [Complex.conj_im, Complex.sub_im, Complex.one_im]
+
+/-- **The completed Riemann zeta function is real-valued on the critical line.**
+
+At every point `1/2 + it` on the critical line, `Im(Λ₀(1/2 + it)) = 0`.
+
+Proof: At `s = 1/2 + it`, conjugation gives `conj(s) = 1/2 - it = 1 - s`.
+By Schwarz reflection: `conj(Λ₀(s)) = Λ₀(conj s) = Λ₀(1 - s)`.
+By the functional equation: `Λ₀(1 - s) = Λ₀(s)`.
+Therefore `conj(Λ₀(s)) = Λ₀(s)`, which holds iff `Im(Λ₀(s)) = 0`.
+
+This establishes that zeros of `Λ₀` on the critical line are sign changes
+of a real-valued function (codimension 1), while off-line zeros would
+require the simultaneous vanishing of both real and imaginary parts
+(codimension 2). -/
+theorem completedRiemannZeta₀_im_eq_zero_on_half (t : ℝ) :
+    (completedRiemannZeta₀ ⟨1/2, t⟩).im = 0 := by
+  suffices h :
+      (starRingEnd ℂ) (completedRiemannZeta₀ ⟨1 / 2, t⟩) = completedRiemannZeta₀ ⟨1 / 2, t⟩ from
+    conj_eq_iff_im.mp h
+  conv_lhs => rw [← completedRiemannZeta₀_conj ⟨1 / 2, t⟩]
+  rw [conj_half_add_mul_I]
+  exact completedRiemannZeta₀_one_sub ⟨1 / 2, t⟩
+
+/-- The completed Riemann zeta function is real-valued at `1/2 + it`,
+stated as `conj(Λ₀(1/2 + it)) = Λ₀(1/2 + it)`. -/
+theorem completedRiemannZeta₀_conj_eq_self_on_half (t : ℝ) :
+    (starRingEnd ℂ) (completedRiemannZeta₀ ⟨1 / 2, t⟩) = completedRiemannZeta₀ ⟨1 / 2, t⟩ := by
+  rw [← completedRiemannZeta₀_conj, conj_half_add_mul_I]
+  exact completedRiemannZeta₀_one_sub ⟨1 / 2, t⟩
+
+end CriticalLine

--- a/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
+++ b/Mathlib/NumberTheory/LSeries/SchwarzReflection.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 interleaves. All rights reserved.
+Copyright (c) 2026 J. York Seale. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: interleaves
+Authors: J. York Seale
 -/
 module
 public import Mathlib.NumberTheory.LSeries.RiemannZeta
@@ -45,26 +45,6 @@ open Complex HurwitzZeta MeasureTheory Set
 
 section SchwarzReflection
 
-private lemma conj_ofReal_two : (starRingEnd ℂ) (2 : ℂ) = 2 := by
-  exact_mod_cast conj_ofReal 2
-
-private lemma arg_pos_real_ne_pi (t : ℝ) (ht : 0 < t) : ((t : ℂ)).arg ≠ Real.pi := by
-  rw [arg_ofReal_of_nonneg (le_of_lt ht)]
-  exact Real.pi_pos.ne
-
-private lemma cpow_conj_pos_real (t : ℝ) (ht : 0 < t) (w : ℂ) :
-    (↑t : ℂ) ^ (starRingEnd ℂ w) = starRingEnd ℂ (t ^ w) := by
-  rw [cpow_conj _ _ (arg_pos_real_ne_pi t ht)]
-  simp [conj_ofReal]
-
-private lemma conj_div_two (s : ℂ) :
-    starRingEnd ℂ (s / 2) = starRingEnd ℂ s / 2 := by
-  rw [map_div₀, conj_ofReal_two]
-
-private lemma conj_half_sub_one (s : ℂ) :
-    starRingEnd ℂ s / 2 - 1 = starRingEnd ℂ (s / 2 - 1) := by
-  rw [map_sub, conj_div_two, map_one]
-
 /-- The modified kernel of the Hurwitz even FE pair at `a = 0` is real-valued:
 its complex conjugate equals itself. This is because it is built from
 real-valued functions (exponentials of real quadratic forms). -/
@@ -86,7 +66,7 @@ theorem completedRiemannZeta₀_conj (s : ℂ) :
     completedRiemannZeta₀ (starRingEnd ℂ s) = starRingEnd ℂ (completedRiemannZeta₀ s) := by
   change mellin (hurwitzEvenFEPair 0).f_modif (starRingEnd ℂ s / 2) / 2 =
     starRingEnd ℂ (mellin (hurwitzEvenFEPair 0).f_modif (s / 2) / 2)
-  rw [map_div₀, conj_ofReal_two]
+  rw [map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by exact_mod_cast conj_ofReal 2]
   congr 1
   simp only [mellin]
   have hpt {t : ℝ} (ht : t ∈ Ioi 0) :
@@ -94,8 +74,13 @@ theorem completedRiemannZeta₀_conj (s : ℂ) :
       (starRingEnd ℂ) ((↑t : ℂ) ^ (s / 2 - 1) • (hurwitzEvenFEPair 0).f_modif t) := by
     simp only [smul_eq_mul, map_mul]
     congr 1
-    · rw [conj_half_sub_one]
-      exact cpow_conj_pos_real t ht (s / 2 - 1)
+    · -- Inline conj_half_sub_one + cpow_conj_pos_real
+      have harg : ((t : ℂ)).arg ≠ Real.pi := by
+        rw [arg_ofReal_of_nonneg (le_of_lt ht)]; exact Real.pi_pos.ne
+      rw [show starRingEnd ℂ s / 2 - 1 = starRingEnd ℂ (s / 2 - 1) from by
+        rw [map_sub, map_div₀, show (starRingEnd ℂ) (2 : ℂ) = 2 from by
+          exact_mod_cast conj_ofReal 2, map_one]]
+      rw [cpow_conj _ _ harg]; simp [conj_ofReal]
     · exact hurwitzEvenFEPair_f_modif_conj_fixed t
   calc ∫ t in Ioi (0 : ℝ), (↑t : ℂ) ^ ((starRingEnd ℂ) s / 2 - 1) •
         (hurwitzEvenFEPair 0).f_modif t


### PR DESCRIPTION
## Summary

Proves that Mellin transforms of real-valued kernels commute with complex
conjugation, and applies this to establish Schwarz reflection for
`completedRiemannZeta₀` and reality on the critical line.

## Main results

**General (any real-valued kernel):**
- `mellin_conj_of_real_kernel`: if `conj(φ(t)) = φ(t)` for all `t`,
  then `mellin φ (conj s) = conj (mellin φ s)`
- `WeakFEPair.Λ₀_conj`: Schwarz reflection for `Λ₀` of any
  `WeakFEPair ℂ` whose `f_modif` is real-valued

**Kernel lemmas:**
- `hurwitzEvenFEPair_f_modif_im_zero`: the kernel has vanishing
  imaginary part
- `hurwitzEvenFEPair_f_modif_conj`: equivalent self-conjugacy formulation

**Specific (completed Riemann zeta):**
- `completedRiemannZeta₀_conj`: `Λ₀(conj s) = conj(Λ₀(s))`
- `completedRiemannZeta₀_ofReal_im`: `Λ₀` is real-valued on `ℝ`
- `completedRiemannZeta₀_im_eq_zero_on_half`: real-valued on the
  critical line `Re(s) = 1/2`
- `completedRiemannZeta₀_deriv_re_eq_zero_on_half`: derivative has
  vanishing real part on the critical line

## Notes

Revised per review feedback from @tb65536: generalized from
`completedRiemannZeta₀` to `WeakFEPair`, added real-on-reals result.
Kernel lemmas promoted from private to public for reuse.

AI disclosure: Claude (Anthropic) used for Mathlib API search
and compilation workflow. Mathematical content and proof
architecture are mine.