### PR TITLE
[Merged by Bors] - chore: refactor `CartesianMonoidalCategory` instance on functors

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -105,36 +105,26 @@ lemma rightUnitor_inv_app (F : J ⥤ C) (j : J) :
   rw [← cancel_mono ((ρ_ (F.obj j)).hom), Iso.inv_hom_id, ← rightUnitor_hom_app,
     Iso.inv_hom_id_app]
 
-@[reassoc (attr := simp)]
 lemma tensorHom_app_fst {F₁ F₁' F₂ F₂' : J ⥤ C} (f : F₁ ⟶ F₁') (g : F₂ ⟶ F₂') (j : J) :
     (f ⊗ₘ g).app j ≫ fst _ _ = fst _ _ ≫ f.app j := by
-  change (f ⊗ₘ g).app j ≫ (fst F₁' F₂').app j = _
-  rw [← NatTrans.comp_app, tensorHom_fst, NatTrans.comp_app]
-  rfl
+  simp
 
-@[reassoc (attr := simp)]
 lemma tensorHom_app_snd {F₁ F₁' F₂ F₂' : J ⥤ C} (f : F₁ ⟶ F₁') (g : F₂ ⟶ F₂') (j : J) :
     (f ⊗ₘ g).app j ≫ snd _ _ = snd _ _ ≫ g.app j := by
-  change (f ⊗ₘ g).app j ≫ (snd F₁' F₂').app j = _
-  rw [← NatTrans.comp_app, tensorHom_snd, NatTrans.comp_app]
-  rfl
+  simp
 
-@[reassoc (attr := simp)]
 lemma whiskerLeft_app_fst (F₁ : J ⥤ C) {F₂ F₂' : J ⥤ C} (g : F₂ ⟶ F₂') (j : J) :
     (F₁ ◁ g).app j ≫ fst _ _ = fst _ _ := by
   simp
 
-@[reassoc (attr := simp)]
 lemma whiskerLeft_app_snd (F₁ : J ⥤ C) {F₂ F₂' : J ⥤ C} (g : F₂ ⟶ F₂') (j : J) :
     (F₁ ◁ g).app j ≫ snd _ _ = snd _ _ ≫ g.app j := by
   simp
 
-@[reassoc (attr := simp)]
 lemma whiskerRight_app_fst {F₁ F₁' : J ⥤ C} (f : F₁ ⟶ F₁') (F₂ : J ⥤ C) (j : J) :
     (f ▷ F₂).app j ≫ fst _ _ = fst _ _ ≫ f.app j := by
   simp
 
-@[reassoc (attr := simp)]
 lemma whiskerRight_app_snd {F₁ F₁' : J ⥤ C} (f : F₁ ⟶ F₁') (F₂ : J ⥤ C) (j : J) :
     (f ▷ F₂).app j ≫ snd _ _ = snd _ _ := by
   simp

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -64,7 +64,8 @@ instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) where
 @[deprecated (since := "2026-03-07")] alias chosenProd := MonoidalCategory.tensorObj
 @[deprecated (since := "2026-03-07")] alias chosenProd.fst := CartesianMonoidalCategory.fst
 @[deprecated (since := "2026-03-07")] alias chosenProd.snd := CartesianMonoidalCategory.snd
-@[deprecated (since := "2026-03-07")] alias chosenProd.isLimit := CartesianMonoidalCategory.tensorProductIsBinaryProduct
+@[deprecated (since := "2026-03-07")] alias chosenProd.isLimit :=
+  CartesianMonoidalCategory.tensorProductIsBinaryProduct
 
 namespace Monoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -30,8 +30,8 @@ variable {J C D E : Type*} [Category* J] [Category* C] [Category* D] [Category* 
 namespace Functor
 
 instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) where
-  fst X Y := {app _ := CartesianMonoidalCategory.fst _ _}
-  snd X Y := {app _ := CartesianMonoidalCategory.snd _ _}
+  fst X Y := { app _ := CartesianMonoidalCategory.fst _ _ }
+  snd X Y := { app _ := CartesianMonoidalCategory.snd _ _ }
   tensorProductIsBinaryProduct X Y :=
     evaluationJointlyReflectsLimits _ (fun j =>
       (IsLimit.postcomposeHomEquiv
@@ -58,13 +58,13 @@ instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) where
     subsingleton
 
 @[deprecated (since := "2026-03-07")] alias chosenTerminal := MonoidalCategory.tensorUnit
-@[deprecated (since := "2026-03-07")] alias chosenTerminal.chosenTerminalIsTerminal :=
+@[deprecated (since := "2026-03-07")] alias chosenTerminalIsTerminal :=
   CartesianMonoidalCategory.isTerminalTensorUnit
 
 @[deprecated (since := "2026-03-07")] alias chosenProd := MonoidalCategory.tensorObj
 @[deprecated (since := "2026-03-07")] alias chosenProd.fst := CartesianMonoidalCategory.fst
 @[deprecated (since := "2026-03-07")] alias chosenProd.snd := CartesianMonoidalCategory.snd
-@[deprecated (since := "2026-03-07")] alias chosenProd.isLimit := CartesianMonoidalCategory.snd
+@[deprecated (since := "2026-03-07")] alias chosenProd.isLimit := CartesianMonoidalCategory.tensorProductIsBinaryProduct
 
 namespace Monoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Limits.FunctorCategory.Basic
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Basic
 public import Mathlib.CategoryTheory.Monoidal.Types.Basic
+public import Mathlib.CategoryTheory.Monoidal.FunctorCategory
 
 /-!
 # Functor categories have chosen finite products
@@ -28,51 +29,42 @@ variable {J C D E : Type*} [Category* J] [Category* C] [Category* D] [Category* 
 
 namespace Functor
 
-variable (J C) in
-/-- The chosen terminal object in `J ⥤ C`. -/
-abbrev chosenTerminal : J ⥤ C := (Functor.const J).obj (𝟙_ C)
+instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) where
+  fst X Y := {app _ := CartesianMonoidalCategory.fst _ _}
+  snd X Y := {app _ := CartesianMonoidalCategory.snd _ _}
+  tensorProductIsBinaryProduct X Y :=
+    evaluationJointlyReflectsLimits _ (fun j =>
+      (IsLimit.postcomposeHomEquiv
+        (mapPairIso (by exact Iso.refl _) (by exact Iso.refl _)) _).1
+        (IsLimit.ofIsoLimit
+          (tensorProductIsBinaryProduct (X := X.obj j) (Y := Y.obj j))
+          (Cone.ext (Iso.refl _) (by rintro ⟨_ | _⟩; all_goals cat_disch))))
+  isTerminalTensorUnit :=
+    evaluationJointlyReflectsLimits _
+      fun _ ↦ isLimitChangeEmptyCone _ isTerminalTensorUnit _ (.refl _)
+  fst_def X Y := by
+    ext
+    simp only [Monoidal.tensorObj_obj, fst_def, asEmptyCone_pt, NatTrans.comp_app,
+      Monoidal.tensorUnit_obj, Monoidal.whiskerLeft_app, Monoidal.rightUnitor_hom_app,
+      Iso.cancel_iso_hom_right]
+    congr
+    subsingleton
+  snd_def X Y := by
+    ext
+    simp only [Monoidal.tensorObj_obj, snd_def, asEmptyCone_pt, NatTrans.comp_app,
+      Monoidal.tensorUnit_obj, Monoidal.whiskerRight_app, Monoidal.leftUnitor_hom_app,
+      Iso.cancel_iso_hom_right]
+    congr
+    subsingleton
 
-variable (J C) in
-/-- The chosen terminal object in `J ⥤ C` is terminal. -/
-def chosenTerminalIsTerminal : IsTerminal (chosenTerminal J C) :=
-  evaluationJointlyReflectsLimits _
-    fun _ ↦ isLimitChangeEmptyCone _ isTerminalTensorUnit _ (.refl _)
+@[deprecated (since := "2026-03-07")] alias chosenTerminal := MonoidalCategory.tensorUnit
+@[deprecated (since := "2026-03-07")] alias chosenTerminal.chosenTerminalIsTerminal :=
+  CartesianMonoidalCategory.isTerminalTensorUnit
 
-section
-
-variable (F₁ F₂ : J ⥤ C)
-
-/-- The chosen binary product on `J ⥤ C`. -/
-@[simps]
-def chosenProd : J ⥤ C where
-  obj j := F₁.obj j ⊗ F₂.obj j
-  map φ := F₁.map φ ⊗ₘ F₂.map φ
-
-namespace chosenProd
-
-/-- The first projection `chosenProd F₁ F₂ ⟶ F₁`. -/
-def fst : chosenProd F₁ F₂ ⟶ F₁ where
-  app _ := CartesianMonoidalCategory.fst _ _
-
-/-- The second projection `chosenProd F₁ F₂ ⟶ F₂`. -/
-def snd : chosenProd F₁ F₂ ⟶ F₂ where
-  app _ := CartesianMonoidalCategory.snd _ _
-
-/-- `Functor.chosenProd F₁ F₂` is a binary product of `F₁` and `F₂`. -/
-def isLimit : IsLimit (BinaryFan.mk (fst F₁ F₂) (snd F₁ F₂)) :=
-  evaluationJointlyReflectsLimits _ (fun j =>
-    (IsLimit.postcomposeHomEquiv (mapPairIso (by exact Iso.refl _) (by exact Iso.refl _)) _).1
-      (IsLimit.ofIsoLimit
-        (tensorProductIsBinaryProduct (X := F₁.obj j) (Y := F₂.obj j))
-        (Cone.ext (Iso.refl _) (by rintro ⟨_ | _⟩; all_goals cat_disch))))
-
-end chosenProd
-
-end
-
-instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) :=
-  .ofChosenFiniteProducts ⟨_, chosenTerminalIsTerminal J C⟩
-    fun F₁ F₂ ↦ ⟨_, chosenProd.isLimit F₁ F₂⟩
+@[deprecated (since := "2026-03-07")] alias chosenProd := MonoidalCategory.tensorObj
+@[deprecated (since := "2026-03-07")] alias chosenProd.fst := CartesianMonoidalCategory.fst
+@[deprecated (since := "2026-03-07")] alias chosenProd.snd := CartesianMonoidalCategory.snd
+@[deprecated (since := "2026-03-07")] alias chosenProd.isLimit := CartesianMonoidalCategory.snd
 
 namespace Monoidal
 
@@ -93,7 +85,7 @@ lemma snd_app (F₁ F₂ : J ⥤ C) (j : J) : (snd F₁ F₂).app j = snd (F₁.
 
 @[simp]
 lemma leftUnitor_hom_app (F : J ⥤ C) (j : J) :
-    (λ_ F).hom.app j = (λ_ (F.obj j)).hom := (leftUnitor_hom _).symm
+    (λ_ F).hom.app j = (λ_ (F.obj j)).hom := rfl
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
@@ -104,7 +96,7 @@ lemma leftUnitor_inv_app (F : J ⥤ C) (j : J) :
 
 @[simp]
 lemma rightUnitor_hom_app (F : J ⥤ C) (j : J) :
-    (ρ_ F).hom.app j = (ρ_ (F.obj j)).hom := (rightUnitor_hom _).symm
+    (ρ_ F).hom.app j = (ρ_ (F.obj j)).hom := rfl
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
@@ -129,23 +121,23 @@ lemma tensorHom_app_snd {F₁ F₁' F₂ F₂' : J ⥤ C} (f : F₁ ⟶ F₁') (
 
 @[reassoc (attr := simp)]
 lemma whiskerLeft_app_fst (F₁ : J ⥤ C) {F₂ F₂' : J ⥤ C} (g : F₂ ⟶ F₂') (j : J) :
-    (F₁ ◁ g).app j ≫ fst _ _ = fst _ _ :=
-  (tensorHom_app_fst (𝟙 F₁) g j).trans (by simp)
+    (F₁ ◁ g).app j ≫ fst _ _ = fst _ _ := by
+  simp
 
 @[reassoc (attr := simp)]
 lemma whiskerLeft_app_snd (F₁ : J ⥤ C) {F₂ F₂' : J ⥤ C} (g : F₂ ⟶ F₂') (j : J) :
-    (F₁ ◁ g).app j ≫ snd _ _ = snd _ _ ≫ g.app j :=
-  (tensorHom_app_snd (𝟙 F₁) g j)
+    (F₁ ◁ g).app j ≫ snd _ _ = snd _ _ ≫ g.app j := by
+  simp
 
 @[reassoc (attr := simp)]
 lemma whiskerRight_app_fst {F₁ F₁' : J ⥤ C} (f : F₁ ⟶ F₁') (F₂ : J ⥤ C) (j : J) :
-    (f ▷ F₂).app j ≫ fst _ _ = fst _ _ ≫ f.app j :=
-  (tensorHom_app_fst f (𝟙 F₂) j)
+    (f ▷ F₂).app j ≫ fst _ _ = fst _ _ ≫ f.app j := by
+  simp
 
 @[reassoc (attr := simp)]
 lemma whiskerRight_app_snd {F₁ F₁' : J ⥤ C} (f : F₁ ⟶ F₁') (F₂ : J ⥤ C) (j : J) :
-    (f ▷ F₂).app j ≫ snd _ _ = snd _ _ :=
-  (tensorHom_app_snd f (𝟙 F₂) j).trans (by simp)
+    (f ▷ F₂).app j ≫ snd _ _ = snd _ _ := by
+  simp
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]


### PR DESCRIPTION
The `CartesianMonoidalCategory` instance on functors categories to a cartesian monoidal category is bad: it is defined using `ofChosenFiniteProduct`, which redefines a whole `MonoidalCategoryStruct` on the category, instead of using the already existing pointwise monoidal structure from the file `CategoryTheory.Monoidal.FunctorCategory`. The two structures end up being `defeq`, as [Functor.chosenProd](https://leanprover-community.github.io/mathlib4_docs/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.html#CategoryTheory.Functor.chosenProd) is defeq to the pointwise tensor product, but this defeq requires unfolding a few defs to be seen.

This PR deprecates the `Functor.chosenProd` and `Functor.chosenTerminal` and use the underlying pointwise monoidal structure for the instance underlying the cartesian monoidal category instance.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
