### PR TITLE
feat(AlgebraicGeometry/EllipticCurve): add notation and pretty printer for points

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -485,6 +485,21 @@ deriving DecidableEq
 Weierstrass curve `W` over `R` in affine coordinates. -/
 scoped notation3:max W' "⟮" S "⟯" => Point <| baseChange W' S
 
+set_option quotPrecheck false in
+/-- The notation for a nonsingular affine point `(x, y)` on a Weierstrass curve `W` over a ring
+whose numerical expressions can be normalised with `norm_num`. -/
+scoped notation:max W "⟮" x "," y "⟯" =>
+  Point.some (W' := W) x y <| by norm_num [nonsingular_iff, equation_iff]
+
+open Lean.PrettyPrinter.Delaborator in
+/-- The pretty printer for a nonsingular affine point on a Weierstrass curve. -/
+@[app_delab Point.some]
+meta def Point.someDelab : Delab := do
+  let W ← SubExpr.withNaryArg 2 delab
+  let x ← SubExpr.withNaryArg 3 delab
+  let y ← SubExpr.withNaryArg 4 delab
+  `($W ⟮$x, $y⟯)
+
 /-- The equivalence between the nonsingular points on a Weierstrass curve `W` in affine coordinates
 satisfying a predicate and the set of pairs `⟨x, y⟩` satisfying `W.Nonsingular x y` with zero. -/
 def nonsingularPointEquivSubtype {p : W'.Point → Prop} (p0 : p .zero) : {P : W'.Point // p P} ≃

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -373,6 +373,19 @@ structure Point where
   /-- The nonsingular condition underlying a nonsingular Jacobian point on `W`. -/
   (nonsingular : W'.NonsingularLift point)
 
+set_option quotPrecheck false in
+/-- The notation for a nonsingular Jacobian point `[X : Y : Z]` on a Weierstrass curve `W` over a
+ring whose numerical expressions can be normalised with `norm_num`. -/
+scoped notation:max W "⟮" X ":" Y ":" Z "⟯" =>
+  Point.mk (W' := W) (point := ⟦![X, Y, Z]⟧) <|
+    by simp only [nonsingularLift_iff, nonsingular_iff, equation_iff, Matrix.cons_val]; norm_num
+
+open Lean.PrettyPrinter.Delaborator in
+/-- The pretty printer for a nonsingular Jacobian point on a Weierstrass curve. -/
+@[app_delab Point.mk]
+meta def Point.mkDelab : Delab := do
+  SubExpr.withNaryArg 3 delab >>= fun P ↦ `($P)
+
 namespace Point
 
 lemma mk_point {P : PointClass R} (h : W'.NonsingularLift P) : (mk h).point = P :=

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
@@ -359,6 +359,19 @@ structure Point where
   /-- The nonsingular condition underlying a nonsingular projective point on `W`. -/
   (nonsingular : W'.NonsingularLift point)
 
+set_option quotPrecheck false in
+/-- The notation for a nonsingular projective point `[X : Y : Z]` on a Weierstrass curve `W` over a
+ring whose numerical expressions can be normalised with `norm_num`. -/
+scoped notation:max W "⟮" X ":" Y ":" Z "⟯" =>
+  Point.mk (W' := W) (point := ⟦![X, Y, Z]⟧) <|
+    by simp only [nonsingularLift_iff, nonsingular_iff, equation_iff, Matrix.cons_val]; norm_num
+
+open Lean.PrettyPrinter.Delaborator in
+/-- The pretty printer for a nonsingular projective point on a Weierstrass curve. -/
+@[app_delab Point.mk]
+meta def Point.mkDelab : Delab := do
+  SubExpr.withNaryArg 3 delab >>= fun P ↦ `($P)
+
 namespace Point
 
 lemma mk_point {P : PointClass R} (h : W'.NonsingularLift P) : (mk h).point = P :=


### PR DESCRIPTION
Co-authored-by: Kenny Lau <kc_kennylau@yahoo.com.hk>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
