### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Over): `Over X` is equivalent to `PUnit` if `X` is strict initial

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2475,6 +2475,7 @@ public import Mathlib.CategoryTheory.Comma.LocallySmall
 public import Mathlib.CategoryTheory.Comma.Over.Basic
 public import Mathlib.CategoryTheory.Comma.Over.OverClass
 public import Mathlib.CategoryTheory.Comma.Over.Pullback
+public import Mathlib.CategoryTheory.Comma.Over.StrictInitial
 public import Mathlib.CategoryTheory.Comma.Presheaf.Basic
 public import Mathlib.CategoryTheory.Comma.Presheaf.Colimit
 public import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -45,7 +45,7 @@ set_option backward.isDefEq.respectTransparency false in
 `Under X` is equivalent to a point. -/
 @[simps, pp_with_univ]
 noncomputable
-def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
+def underEquivOfIsTerminal [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     Under X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk (𝟙 X))

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -75,7 +75,8 @@ set_option backward.isDefEq.respectTransparency false in
 `P.Under Q X` is equivalent to a point. -/
 @[simps, pp_with_univ]
 noncomputable
-def MorphismProperty.underEquivOfIsTerminal [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
+def MorphismProperty.underEquivOfIsTerminal [HasStrictTerminalObjects C] (X : C)
+    (h : IsTerminal X) :
     P.Under Q X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Comma
+public import Mathlib.CategoryTheory.Limits.Shapes.StrictInitial
+
+/-!
+# `Over X` when `C` has strict initial objects
+
+In this file we define the canonical equivalence of `Over X` with `PUnit` when
+`C` has strict initial objects. We also provide the variants for `P.Over Q X`
+and the dual versions.
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type*} [Category* C]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- If `C` has strict initial objects and `X` is an initial object, the category
+`Over X` is equivalent to a point. -/
+noncomputable
+def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
+    Over X ≌ PUnit where
+  functor := (Functor.const _).obj ⟨⟩
+  inverse := (Functor.const _).obj (.mk (𝟙 X))
+  unitIso := NatIso.ofComponents fun A ↦
+    haveI := h.isIso_to A.hom
+    Over.isoMk (asIso A.hom)
+  counitIso := Iso.refl _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- If `C` has strict terminal objects and `X` is a terminal object, the category
+`Under X` is equivalent to a point. -/
+noncomputable
+def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
+    Under X ≌ PUnit where
+  functor := (Functor.const _).obj ⟨⟩
+  inverse := (Functor.const _).obj (.mk (𝟙 X))
+  counitIso := Iso.refl _
+  unitIso := NatIso.ofComponents fun A ↦
+    haveI := h.isIso_from A.hom
+    Under.isoMk (asIso A.hom).symm
+
+variable (P Q : MorphismProperty C) [P.ContainsIdentities] [Q.IsMultiplicative] [Q.RespectsIso]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- If `C` has strict initial objects and `X` is an initial object, the category
+`P.Over Q X` is equivalent to a point. -/
+noncomputable
+def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
+    P.Over Q X ≌ PUnit where
+  functor := (Functor.const _).obj ⟨⟩
+  inverse := (Functor.const _).obj (.mk _ (𝟙 X) (P.id_mem _))
+  unitIso := NatIso.ofComponents fun A ↦
+    haveI := h.isIso_to A.hom
+    Over.isoMk (asIso A.hom)
+  counitIso := Iso.refl _
+
+set_option backward.isDefEq.respectTransparency false in
+/-- If `C` has strict terminal objects and `X` is a terminal object, the category
+`P.Under Q X` is equivalent to a point. -/
+noncomputable
+def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
+    P.Under Q X ≌ PUnit where
+  functor := (Functor.const _).obj ⟨⟩
+  inverse := (Functor.const _).obj (.mk _ (𝟙 X) (P.id_mem _))
+  counitIso := Iso.refl _
+  unitIso := NatIso.ofComponents fun A ↦
+    haveI := h.isIso_from A.hom
+    Under.isoMk (asIso A.hom).symm
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -75,7 +75,7 @@ set_option backward.isDefEq.respectTransparency false in
 `P.Under Q X` is equivalent to a point. -/
 @[simps, pp_with_univ]
 noncomputable
-def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
+def MorphismProperty.underEquivOfIsTerminal [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     P.Under Q X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -29,9 +29,9 @@ set_option backward.isDefEq.respectTransparency false in
 `Over X` is equivalent to a point. -/
 noncomputable
 def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
-    Over X ≌ PUnit where
-  functor := (Functor.const _).obj ⟨⟩
-  inverse := (Functor.const _).obj (.mk (𝟙 X))
+    Over X ≌ Discrete PUnit where
+  functor := Functor.star _
+  inverse := Functor.fromPUnit (.mk (𝟙 X))
   unitIso := NatIso.ofComponents fun A ↦
     haveI := h.isIso_to A.hom
     Over.isoMk (asIso A.hom)

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -29,7 +29,7 @@ variable {C : Type*} [Category* C]
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict initial objects and `X` is an initial object, the category
 `Over X` is equivalent to a point. -/
-@[pp_with_univ]
+@[simps, pp_with_univ]
 noncomputable
 def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
     Over X ≌ Discrete PUnit.{w + 1} where
@@ -43,7 +43,7 @@ def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict terminal objects and `X` is a terminal object, the category
 `Under X` is equivalent to a point. -/
-@[pp_with_univ]
+@[simps, pp_with_univ]
 noncomputable
 def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     Under X ≌ Discrete PUnit.{w + 1} where
@@ -59,7 +59,7 @@ variable (P Q : MorphismProperty C) [P.ContainsIdentities] [Q.IsMultiplicative] 
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict initial objects and `X` is an initial object, the category
 `P.Over Q X` is equivalent to a point. -/
-@[pp_with_univ]
+@[simps, pp_with_univ]
 noncomputable
 def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
     P.Over Q X ≌ Discrete PUnit.{w + 1} where
@@ -73,7 +73,7 @@ def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict terminal objects and `X` is a terminal object, the category
 `P.Under Q X` is equivalent to a point. -/
-@[pp_with_univ]
+@[simps, pp_with_univ]
 noncomputable
 def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     P.Under Q X ≌ Discrete PUnit.{w + 1} where

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -18,6 +18,8 @@ and the dual versions.
 
 @[expose] public section
 
+universe w
+
 namespace CategoryTheory
 
 open Limits
@@ -30,7 +32,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[pp_with_univ]
 noncomputable
 def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
-    Over X ≌ Discrete PUnit where
+    Over X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk (𝟙 X))
   unitIso := NatIso.ofComponents fun A ↦
@@ -44,7 +46,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[pp_with_univ]
 noncomputable
 def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
-    Under X ≌ Discrete PUnit where
+    Under X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk (𝟙 X))
   counitIso := Iso.refl _
@@ -60,7 +62,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[pp_with_univ]
 noncomputable
 def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
-    P.Over Q X ≌ Discrete PUnit where
+    P.Over Q X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))
   unitIso := NatIso.ofComponents fun A ↦
@@ -74,7 +76,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[pp_with_univ]
 noncomputable
 def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
-    P.Under Q X ≌ Discrete PUnit where
+    P.Under Q X ≌ Discrete PUnit.{w + 1} where
   functor := Functor.star _
   inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))
   counitIso := Iso.refl _

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -27,6 +27,7 @@ variable {C : Type*} [Category* C]
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict initial objects and `X` is an initial object, the category
 `Over X` is equivalent to a point. -/
+@[pp_with_univ]
 noncomputable
 def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
     Over X ≌ Discrete PUnit where
@@ -40,6 +41,7 @@ def overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict terminal objects and `X` is a terminal object, the category
 `Under X` is equivalent to a point. -/
+@[pp_with_univ]
 noncomputable
 def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     Under X ≌ Discrete PUnit where
@@ -55,6 +57,7 @@ variable (P Q : MorphismProperty C) [P.ContainsIdentities] [Q.IsMultiplicative] 
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict initial objects and `X` is an initial object, the category
 `P.Over Q X` is equivalent to a point. -/
+@[pp_with_univ]
 noncomputable
 def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
     P.Over Q X ≌ Discrete PUnit where
@@ -68,6 +71,7 @@ def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h
 set_option backward.isDefEq.respectTransparency false in
 /-- If `C` has strict terminal objects and `X` is a terminal object, the category
 `P.Under Q X` is equivalent to a point. -/
+@[pp_with_univ]
 noncomputable
 def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
     P.Under Q X ≌ Discrete PUnit where

--- a/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/StrictInitial.lean
@@ -11,7 +11,7 @@ public import Mathlib.CategoryTheory.Limits.Shapes.StrictInitial
 /-!
 # `Over X` when `C` has strict initial objects
 
-In this file we define the canonical equivalence of `Over X` with `PUnit` when
+In this file we define the canonical equivalence of `Over X` with `Discrete PUnit` when
 `C` has strict initial objects. We also provide the variants for `P.Over Q X`
 and the dual versions.
 -/
@@ -42,9 +42,9 @@ set_option backward.isDefEq.respectTransparency false in
 `Under X` is equivalent to a point. -/
 noncomputable
 def underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
-    Under X ≌ PUnit where
-  functor := (Functor.const _).obj ⟨⟩
-  inverse := (Functor.const _).obj (.mk (𝟙 X))
+    Under X ≌ Discrete PUnit where
+  functor := Functor.star _
+  inverse := Functor.fromPUnit (.mk (𝟙 X))
   counitIso := Iso.refl _
   unitIso := NatIso.ofComponents fun A ↦
     haveI := h.isIso_from A.hom
@@ -57,9 +57,9 @@ set_option backward.isDefEq.respectTransparency false in
 `P.Over Q X` is equivalent to a point. -/
 noncomputable
 def MorphismProperty.overEquivOfIsInitial [HasStrictInitialObjects C] (X : C) (h : IsInitial X) :
-    P.Over Q X ≌ PUnit where
-  functor := (Functor.const _).obj ⟨⟩
-  inverse := (Functor.const _).obj (.mk _ (𝟙 X) (P.id_mem _))
+    P.Over Q X ≌ Discrete PUnit where
+  functor := Functor.star _
+  inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))
   unitIso := NatIso.ofComponents fun A ↦
     haveI := h.isIso_to A.hom
     Over.isoMk (asIso A.hom)
@@ -70,9 +70,9 @@ set_option backward.isDefEq.respectTransparency false in
 `P.Under Q X` is equivalent to a point. -/
 noncomputable
 def MorphismProperty.underEquivOfIsInitial [HasStrictTerminalObjects C] (X : C) (h : IsTerminal X) :
-    P.Under Q X ≌ PUnit where
-  functor := (Functor.const _).obj ⟨⟩
-  inverse := (Functor.const _).obj (.mk _ (𝟙 X) (P.id_mem _))
+    P.Under Q X ≌ Discrete PUnit where
+  functor := Functor.star _
+  inverse := Functor.fromPUnit (.mk _ (𝟙 X) (P.id_mem _))
   counitIso := Iso.refl _
   unitIso := NatIso.ofComponents fun A ↦
     haveI := h.isIso_from A.hom


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
