### PR TITLE
[Merged by Bors] - fix: decompress already downloaded files

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -712,10 +712,8 @@ def getFiles
       IO.Process.exit 1
 
   if decompress then
-    -- When parallel, decompression was pipelined inside downloadFiles.
-    -- When non-parallel, fall back to batch decompression.
-    unless parallel do
-      IO.unpackCache hashMap forceUnpack
+    -- decompress anything which hasn't already been decompressed during download
+    IO.unpackCache hashMap forceUnpack
   else
     IO.println "Downloaded all files successfully!"
 


### PR DESCRIPTION
The new parallel decompression (#32987) forgets about files which are already present in the `.cache/mathlib` folder.

This PR adds the final decompression step back which only decompresses anything which hasn't already been decompressed prior.

---

Example output:

```text
jon@computer mathlib » lake exe cache get
Current branch: fix/cache-does-not-decompress-already-downloaded
Using cache (Azure) from origin: joneugster/mathlib4
Attempting to download 499 file(s) from leanprover-community/mathlib4 cache
Downloaded: 499 file(s) [attempted 499/499 = 100%, 107 KB/s], Decompressed: 486
Decompressed 499 file(s)
No files to download
Decompressing 7605 file(s) (502 already decompressed)
Decompressed in 5471 ms
Completed successfully!
```
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
