### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Order): `{map,emb}Domain` preserve tsub

### DIFF
--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -242,6 +242,19 @@ theorem subset_support_tsub [DecidableEq ι] {f1 f2 : ι →₀ α} :
     f1.support \ f2.support ⊆ (f1 - f2).support := by
   simp +contextual [subset_iff]
 
+lemma mapDomain_tsub {f : ι → κ} (h : f.Injective) (f1 f2 : ι →₀ α) :
+    (f1 - f2).mapDomain f = f1.mapDomain f - f2.mapDomain f := by
+  ext y
+  rw [tsub_apply]
+  wlog h : y ∈ Set.range f
+  · simp [mapDomain_notin_range _ _ h]
+  obtain ⟨x, rfl⟩ := h
+  simp [mapDomain_apply h _ x]
+
+lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
+    (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by
+  simp_rw [embDomain_eq_mapDomain, mapDomain_tsub f.injective]
+
 end PartialOrder
 
 section LinearOrder

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -245,11 +245,10 @@ theorem subset_support_tsub [DecidableEq ι] {f1 f2 : ι →₀ α} :
 lemma mapDomain_tsub {f : ι → κ} (h : f.Injective) (f1 f2 : ι →₀ α) :
     (f1 - f2).mapDomain f = f1.mapDomain f - f2.mapDomain f := by
   ext y
-  rw [tsub_apply]
-  by_cases! h : y ∉ Set.range f
-  · simp [mapDomain_notin_range _ _ h]
-  obtain ⟨x, rfl⟩ := h
-  simp [mapDomain_apply h _ x]
+  by_cases! hy : y ∉ Set.range f
+  · simp [mapDomain_notin_range _ _ hy]
+  · obtain ⟨x, rfl⟩ := hy
+    simp [mapDomain_apply h]
 
 lemma embDomain_tsub (f : ι ↪ κ) (f1 f2 : ι →₀ α) :
     (f1 - f2).embDomain f = f1.embDomain f - f2.embDomain f := by

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -246,7 +246,7 @@ lemma mapDomain_tsub {f : ι → κ} (h : f.Injective) (f1 f2 : ι →₀ α) :
     (f1 - f2).mapDomain f = f1.mapDomain f - f2.mapDomain f := by
   ext y
   rw [tsub_apply]
-  wlog h : y ∈ Set.range f
+  by_cases! h : y ∉ Set.range f
   · simp [mapDomain_notin_range _ _ h]
   obtain ⟨x, rfl⟩ := h
   simp [mapDomain_apply h _ x]


### PR DESCRIPTION
`mapDomain` by an injective map, and `embDomain`, preserve truncated subtraction.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
