### PR TITLE
[Merged by Bors] - doc(AlgebraicGeometry): fix typos

### DIFF
--- a/Mathlib/AlgebraicGeometry/Geometrically/Irreducible.lean
+++ b/Mathlib/AlgebraicGeometry/Geometrically/Irreducible.lean
@@ -14,7 +14,7 @@ public import Mathlib.AlgebraicGeometry.Morphisms.UniversallyOpen
 ## Main results
 - `AlgebraicGeometry.GeometricallyIrreducible`:
   We say that morphism `f : X ⟶ Y` is geometrically irreducible if for all `Spec K ⟶ Y` with `K`
-  a field, `X ×[Y] Spec K` is irrreducible.
+  a field, `X ×[Y] Spec K` is irreducible.
   We also provide the fact that this is stable under base change (by infer_instance)
 - `GeometricallyIrreducible.iff_geometricallyIrreducible_fiber`:
   A scheme is geometrically irreducible over `S` iff the fibers of all
@@ -35,7 +35,7 @@ namespace AlgebraicGeometry
 variable {X Y Z S : Scheme} (f : X ⟶ S) (g : Y ⟶ S)
 
 /-- We say that morphism `f : X ⟶ Y` is geometrically irreducible if for all `Spec K ⟶ Y` with `K`
-a field, `X ×[Y] Spec K` is irrreducible. -/
+a field, `X ×[Y] Spec K` is irreducible. -/
 @[mk_iff]
 class GeometricallyIrreducible (f : X ⟶ Y) : Prop where
   geometrically_irreducibleSpace : geometrically (IrreducibleSpace ·) f

--- a/Mathlib/AlgebraicGeometry/Geometrically/Reduced.lean
+++ b/Mathlib/AlgebraicGeometry/Geometrically/Reduced.lean
@@ -39,7 +39,7 @@ namespace AlgebraicGeometry
 variable {X Y Z S : Scheme} (f : X ⟶ S) (g : Y ⟶ S)
 
 /-- We say that morphism `f : X ⟶ Y` is geometrically reduced if for all `Spec K ⟶ Y` with `K`
-a field, `X ×[Y] Spec K` is irrreducible. -/
+a field, `X ×[Y] Spec K` is reduced. -/
 @[mk_iff]
 class GeometricallyReduced (f : X ⟶ Y) : Prop where
   geometrically_isReduced : geometrically IsReduced f

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -104,7 +104,7 @@ def modulesSpecToSheafIso :
       map_smul' r m := IsScalarTower.algebraMap_smul (M := ((structureSheafInType R M).obj.obj U))
         ((structureSheafInType R R).obj.obj U) r m }) fun _ ↦ rfl
 
-/-- The map from `M` to `Γ(M, U)`. This is a localiation map when `U = D(f)`. -/
+/-- The map from `M` to `Γ(M, U)`. This is a localization map when `U = D(f)`. -/
 def toOpen (U : (Spec R).Opens) : M ⟶ (modulesSpecToSheaf.obj (tilde M)).presheaf.obj (.op U) :=
   ModuleCat.ofHom (StructureSheaf.toOpenₗ R M U) ≫ ((modulesSpecToSheafIso M).app _).inv
 
@@ -276,7 +276,7 @@ def tilde.toTildeΓNatIso : 𝟭 _ ≅ tilde.functor R ⋙ moduleSpecΓFunctor :
 
 set_option backward.isDefEq.respectTransparency false in
 open Scheme.Modules in
-/-- The tilde-Gamma adjuntion. -/
+/-- The tilde-Gamma adjunction. -/
 def tilde.adjunction : tilde.functor R ⊣ moduleSpecΓFunctor where
   unit := toTildeΓNatIso.hom
   counit := fromTildeΓNatTrans

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -291,7 +291,7 @@ lemma mono_pushoutSection_of_iSup_eq {ι : Type*} [Finite ι] (VX : ι → X.Ope
   let e : pushout (iX.appLE US UX hUSX) (f.appLE US UT hUST) ≅
       .of (Γ(T, UT) ⊗[Γ(S, US)] Γ(X, UX)) :=
     (CommRingCat.isPushout_tensorProduct _ _ _).flip.isoPushout.symm
-  -- It remains to check that the square indeed commutes, and we may concluce that the map
+  -- It remains to check that the square indeed commutes, and we may conclude that the map
   -- at the left is also injective.
   suffices (ψY.comp (pushoutSection H hUST hUSX hUY).hom).comp e.inv.hom = φ.comp
       (Algebra.TensorProduct.map (AlgHom.id Γ(T, UT) Γ(T, UT)) ψ).toRingHom by

--- a/Mathlib/AlgebraicGeometry/Normalization.lean
+++ b/Mathlib/AlgebraicGeometry/Normalization.lean
@@ -209,7 +209,7 @@ instance : IsIntegralHom f.fromNormalization := by
   rw [← cancel_mono U.2.fromSpec]
   simp [IsAffineOpen.isoSpec_hom, e, ι_fromNormalization]
 
-/-- The sections of the relative normalization on the preimage of an affine open is isomorpic to
+/-- The sections of the relative normalization on the preimage of an affine open is isomorphic to
 the integral closure. -/
 noncomputable
 def normalizationObjIso {U : Y.Opens} (hU : IsAffineOpen U) :

--- a/Mathlib/AlgebraicGeometry/Sites/SheafQuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/SheafQuasiCompact.lean
@@ -30,7 +30,7 @@ variable {P : MorphismProperty Scheme.{u}} [P.IsStableUnderBaseChange]
 set_option backward.isDefEq.respectTransparency false in
 /-- A presheaf of types is a sheaf for the `P`-qc topology if and only if it is a sheaf
 for the Zariski topology and satisfies the sheaf property for all single object coverings
-`{ f : Spec S ⟶ Spec R }` where `f` satisifies `P`. -/
+`{ f : Spec S ⟶ Spec R }` where `f` satisfies `P`. -/
 @[stacks 022H]
 nonrec lemma isSheaf_type_propQCTopology_iff [P.IsMultiplicative] (F : Scheme.{u}ᵒᵖ ⥤ Type*)
     [IsZariskiLocalAtSource P] :
@@ -94,7 +94,7 @@ variable {A : Type*} [Category* A]
 
 /-- A presheaf is a sheaf for the `P`-qc topology if and only if it is a sheaf
 for the Zariski topology and satisfies the sheaf property for all single object coverings
-`{ f : Spec S ⟶ Spec R }` where `f` satisifies `P`. -/
+`{ f : Spec S ⟶ Spec R }` where `f` satisfies `P`. -/
 @[stacks 022H]
 nonrec lemma isSheaf_propQCTopology_iff [P.IsMultiplicative] (F : Scheme.{u}ᵒᵖ ⥤ A)
     [IsZariskiLocalAtSource P] :


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
