### PR TITLE
[Merged by Bors] - doc(AlgebraicTopology): fix typos

### DIFF
--- a/Mathlib/AlgebraicTopology/ModelCategory/BifibrantObjectHomotopy.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/BifibrantObjectHomotopy.lean
@@ -195,7 +195,7 @@ lemma HoCat.ιFibrantObject_map_toHoCat_map {X Y : BifibrantObject C} (f : X ⟶
       FibrantObject.toHoCat.map (FibrantObject.homMk f.hom) :=
   rfl
 
-/-- The isomomorphism `toHoCat ⋙ HoCat.ιFibrantObject ≅ ιFibrantObject ⋙ FibrantObject.toHoCat`
+/-- The isomorphism `toHoCat ⋙ HoCat.ιFibrantObject ≅ ιFibrantObject ⋙ FibrantObject.toHoCat`
 between functors `BifibrantObject C ⥤ FibrantObject.HoCat C`. -/
 def toHoCatCompιFibrantObject :
     toHoCat (C := C) ⋙ HoCat.ιFibrantObject ≅
@@ -219,7 +219,7 @@ lemma HoCat.ιCofibrantObject_map_toHoCat_map {X Y : BifibrantObject C} (f : X �
       CofibrantObject.toHoCat.map (CofibrantObject.homMk f.hom) :=
   rfl
 
-/-- The isomomorphism
+/-- The isomorphism
 `toHoCat ⋙ HoCat.ιCofibrantObject ≅ ιCofibrantObject ⋙ CofibrantObject.toHoCat`
 between functors `BifibrantObject C ⥤ CofibrantObject.HoCat C`. -/
 def toHoCatCompιCofibrantObject :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Basic.lean
@@ -20,7 +20,7 @@ This definition provides a canonical full and faithful inclusion functor
 
 We prove that functors out of `AugmentedSimplexCategory` are equivalent to augmented cosimplicial
 objects and that functors out of `AugmentedSimplexCategoryᵒᵖ` are equivalent to augmented simplicial
-objects, and we provide a translation of the main constrcutions on augmented (co)simplicial objects
+objects, and we provide a translation of the main constructions on augmented (co)simplicial objects
 (i.e `drop`, `point` and `toArrow`) in terms of these equivalences.
 
 -/

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/EpiMono.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/EpiMono.lean
@@ -13,7 +13,7 @@ More precisely, we introduce two morphism properties `P_δ` and `P_σ` that
 single out morphisms that are compositions of `δ i` (resp. `σ i`).
 
 The main result of this file is `exists_P_σ_P_δ_factorization`, which asserts that every
-moprhism as a decomposition of a `P_σ` followed by a `P_δ`.
+morphism as a decomposition of a `P_σ` followed by a `P_δ`.
 
 -/
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorMonoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorMonoidal.lean
@@ -325,7 +325,7 @@ lemma right_unitality [Unique (Y _⦋0⦌₂)] [Subsingleton (Y _⦋1⦌₂)] :
 variable (Z)
 
 set_option backward.isDefEq.respectTransparency false in
-/-- Auxiliary defininition for `associativityIso`. -/
+/-- Auxiliary definition for `associativityIso`. -/
 def associativity'Iso :
     (prod.associativity ..).inverse ⋙ (inverse X Y).prod (𝟭 _) ⋙ inverse (X ⊗ Y) Z ⋙
       mapHomotopyCategory (α_ _ _ _).hom ≅

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -144,7 +144,7 @@ def app (n : (SimplexCategory.Truncated 2)ᵒᵖ) : X.obj n ⟶ Y.obj n := by
   | 1 => exact f₁
   | 2 => exact f₂ f₀ f₁ hδ₁ hδ₀ hY
 
-/-- The property of morphims in `SimplexCategory.Truncated 2` for
+/-- The property of morphisms in `SimplexCategory.Truncated 2` for
 which `liftOfStrictSegal.app` is natural. -/
 abbrev naturalityProperty : MorphismProperty (SimplexCategory.Truncated 2) :=
   (MorphismProperty.naturalityProperty (app f₀ f₁ hδ₁ hδ₀ hY)).unop


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
