### PR TITLE
[Merged by Bors] - ci(maintainer_*): add backwards compatibility, fix comment posting, reduce frequency

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -25,7 +25,15 @@ jobs:
       HAS_DELEGATED_LABEL: ${{ contains(github.event.issue.labels.*.name, 'delegated') }}
     name: Add ready-to-merge or delegated label
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: >- # coarse prefilter to avoid running on irrelevant comments/reviews
+      github.repository == 'leanprover-community/mathlib4' &&
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
+      (
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'bors merge') ||
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'bors d') ||
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'bors r') ||
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'Build failed:')
+      )
     steps:
       - name: Find bors merge/delegate
         id: merge_or_delegate

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -33,17 +33,57 @@ jobs:
             removeLabels=outputs.removeLabels
             mOrD=outputs.mOrD
 
+      - name: Download legacy artifact (fallback)
+        id: download-legacy-artifact
+        if: ${{ steps.bridge.outputs.mOrD == '' && steps.bridge.outputs.removeLabels == '' }}
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        with:
+          workflow: maintainer_bors.yml
+          name: workflow-data
+          path: ./artifacts
+          if_no_artifact_found: ignore
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract legacy artifact data (fallback)
+        id: legacy
+        if: ${{ steps.bridge.outputs.mOrD == '' && steps.bridge.outputs.removeLabels == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
+        run: |
+          data_file="./artifacts/artifact-data.json"
+          if [ ! -f "${data_file}" ]
+          then
+            echo "Legacy artifact not found at ${data_file}."
+            exit 0
+          fi
+          {
+            echo "author=$(jq -r '.author // empty' "${data_file}")"
+            echo "pr_number=$(jq -r '.pr_number // empty' "${data_file}")"
+            echo "bot=$(jq -r '.bot // empty' "${data_file}")"
+            echo "removeLabels=$(jq -r '.removeLabels // .remove_labels // empty' "${data_file}")"
+            echo "mOrD=$(jq -r '.mOrD // .m_or_d // empty' "${data_file}")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select bridge or legacy inputs
+        id: inputs
+        run: |
+          {
+            echo "author=${{ steps.bridge.outputs.author }}${{ steps.legacy.outputs.author }}"
+            echo "pr_number=${{ steps.bridge.outputs.pr_number }}${{ steps.legacy.outputs.pr_number }}"
+            echo "bot=${{ steps.bridge.outputs.bot }}${{ steps.legacy.outputs.bot }}"
+            echo "removeLabels=${{ steps.bridge.outputs.removeLabels }}${{ steps.legacy.outputs.removeLabels }}"
+            echo "mOrD=${{ steps.bridge.outputs.mOrD }}${{ steps.legacy.outputs.mOrD }}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Check whether user is a mathlib admin
         id: user_permission
-        if: ${{ ! steps.bridge.outputs.mOrD == '' || ! steps.bridge.outputs.removeLabels == '' }}
+        if: ${{ ! steps.inputs.outputs.mOrD == '' || ! steps.inputs.outputs.removeLabels == '' }}
         uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
-          username: ${{ steps.bridge.outputs.author }}
+          username: ${{ steps.inputs.outputs.author }}
           require: 'admin'
 
       - name: Generate app token
         id: app-token
-        if: ${{ ! steps.bridge.outputs.mOrD == '' || ! steps.bridge.outputs.removeLabels == '' }}
+        if: ${{ ! steps.inputs.outputs.mOrD == '' || ! steps.inputs.outputs.removeLabels == '' }}
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.MATHLIB_TRIAGE_APP_ID }}
@@ -51,24 +91,24 @@ jobs:
 
       - name: Add ready-to-merge or delegated label
         id: add_label
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
           # Unexpected input warning from the following is expected:
           # https://github.com/octokit/request-action?tab=readme-ov-file#warnings
           repository: ${{ github.repository }}
-          issue_number: ${{ steps.bridge.outputs.pr_number }}
-          labels: '["${{ steps.bridge.outputs.mOrD }}"]'
+          issue_number: ${{ steps.inputs.outputs.pr_number }}
+          labels: '["${{ steps.inputs.outputs.mOrD }}"]'
         env:
           # The create-github-app-token README states that this token is masked and will not be logged accidentally.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+      - if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         id: remove_labels
         name: Remove "awaiting-author" and "maintainer-merge"
         # we use curl rather than octokit/request-action so that the job won't fail
@@ -76,41 +116,41 @@ jobs:
         run: |
           for label in awaiting-author maintainer-merge; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.bridge.outputs.pr_number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.inputs.outputs.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
           done
 
       - name: On bors r/d-, remove ready-to-merge or delegated label
-        if: ${{ ! steps.bridge.outputs.removeLabels == '' && steps.user_permission.outputs.require-result == 'true' }}
+        if: ${{ ! steps.inputs.outputs.removeLabels == '' && steps.user_permission.outputs.require-result == 'true' }}
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
           for label in ready-to-merge delegated; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.bridge.outputs.pr_number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.inputs.outputs.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
           done
 
       - name: Set up Python
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         run: |
           python -m pip install --upgrade pip
           pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
 
       - name: Checkout local actions
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.workflow_sha }}
@@ -118,18 +158,18 @@ jobs:
           sparse-checkout: .github/actions
           path: workflow-actions
       - name: Get mathlib-ci
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         uses: ./workflow-actions/.github/actions/get-mathlib-ci
 
       - name: update zulip emoji reactions
-        if: ${{ ! steps.bridge.outputs.mOrD == '' &&
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.bridge.outputs.bot == 'true' ) }}
+            steps.inputs.outputs.bot == 'true' ) }}
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.mOrD }}" "${{ steps.bridge.outputs.pr_number }}"
+          python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.inputs.outputs.mOrD }}" "${{ steps.inputs.outputs.mOrD }}" "${{ steps.inputs.outputs.pr_number }}"

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -139,22 +139,6 @@ jobs:
               --header 'authorization: Bearer ${{ steps.app-token.outputs.token }}'
           done
 
-      - name: Set up Python
-        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.inputs.outputs.bot == 'true' ) }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
-          ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.inputs.outputs.bot == 'true' ) }}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
-
       - name: Checkout local actions
         if: ${{ ! steps.inputs.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
@@ -170,6 +154,22 @@ jobs:
           ( steps.user_permission.outputs.require-result == 'true' ||
             steps.inputs.outputs.bot == 'true' ) }}
         uses: ./workflow-actions/.github/actions/get-mathlib-ci
+
+      - name: Set up Python
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.inputs.outputs.bot == 'true' ) }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        if: ${{ ! steps.inputs.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.inputs.outputs.bot == 'true' ) }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r "$CI_SCRIPTS_DIR/zulip/requirements.txt"
 
       - name: update zulip emoji reactions
         if: ${{ ! steps.inputs.outputs.mOrD == '' &&

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -75,6 +75,12 @@ jobs:
             echo "input_source=${{ steps.bridge.outputs.pr_number != '' && 'bridge' || (steps.legacy.outputs.pr_number != '' && 'legacy' || 'none') }}"
           } | tee -a "$GITHUB_OUTPUT"
 
+      - name: Note legacy artifact fallback
+        if: ${{ steps.inputs.outputs.input_source == 'legacy' }}
+        run: |
+          echo "::notice::Using legacy workflow-data artifact fallback from maintainer_bors.yml"
+          echo "Using legacy workflow-data artifact fallback from maintainer_bors.yml" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check whether user is a mathlib admin
         id: user_permission
         if: ${{ ! steps.inputs.outputs.mOrD == '' || ! steps.inputs.outputs.removeLabels == '' }}

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Download legacy artifact (fallback)
         id: download-legacy-artifact
-        if: ${{ steps.bridge.outputs.mOrD == '' && steps.bridge.outputs.removeLabels == '' }}
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        if: ${{ steps.bridge.outputs.pr_number == '' }}
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
         with:
           workflow: maintainer_bors.yml
           name: workflow-data
@@ -46,7 +46,7 @@ jobs:
 
       - name: Extract legacy artifact data (fallback)
         id: legacy
-        if: ${{ steps.bridge.outputs.mOrD == '' && steps.bridge.outputs.removeLabels == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
+        if: ${{ steps.bridge.outputs.pr_number == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
         run: |
           data_file="./artifacts/artifact-data.json"
           if [ ! -f "${data_file}" ]
@@ -60,10 +60,11 @@ jobs:
             echo "bot=$(jq -r '.bot // empty' "${data_file}")"
             echo "removeLabels=$(jq -r '.removeLabels // .remove_labels // empty' "${data_file}")"
             echo "mOrD=$(jq -r '.mOrD // .m_or_d // empty' "${data_file}")"
-          } >> "$GITHUB_OUTPUT"
+          } | tee -a "$GITHUB_OUTPUT"
 
       - name: Select bridge or legacy inputs
         id: inputs
+        if: ${{ steps.bridge.outputs.pr_number != '' || steps.legacy.outputs.pr_number != '' }}
         run: |
           {
             echo "author=${{ steps.bridge.outputs.author }}${{ steps.legacy.outputs.author }}"
@@ -71,7 +72,8 @@ jobs:
             echo "bot=${{ steps.bridge.outputs.bot }}${{ steps.legacy.outputs.bot }}"
             echo "removeLabels=${{ steps.bridge.outputs.removeLabels }}${{ steps.legacy.outputs.removeLabels }}"
             echo "mOrD=${{ steps.bridge.outputs.mOrD }}${{ steps.legacy.outputs.mOrD }}"
-          } >> "$GITHUB_OUTPUT"
+            echo "input_source=${{ steps.bridge.outputs.pr_number != '' && 'bridge' || (steps.legacy.outputs.pr_number != '' && 'legacy' || 'none') }}"
+          } | tee -a "$GITHUB_OUTPUT"
 
       - name: Check whether user is a mathlib admin
         id: user_permission

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >- # crude check to skip running this on most reviews / comments
       github.repository == 'leanprover-community/mathlib4' &&
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
       (
         contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') ||
         contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer delegate')

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: write
 
 jobs:
   ping_zulip:
@@ -36,7 +37,54 @@ jobs:
             event_name=meta.event_name
             mOrD=outputs.mOrD
 
-      - if: ${{ ! steps.bridge.outputs.mOrD == '' }}
+      - name: Download legacy artifact (fallback)
+        id: download-legacy-artifact
+        if: ${{ steps.bridge.outputs.mOrD == '' }}
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        with:
+          workflow: maintainer_merge.yml
+          name: workflow-data
+          path: ./artifacts
+          if_no_artifact_found: ignore
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract legacy artifact data (fallback)
+        id: legacy
+        if: ${{ steps.bridge.outputs.mOrD == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
+        run: |
+          data_file="./artifacts/artifact-data.json"
+          if [ ! -f "${data_file}" ]
+          then
+            echo "Legacy artifact not found at ${data_file}."
+            exit 0
+          fi
+          {
+            echo "author=$(jq -r '.author // empty' "${data_file}")"
+            echo "pr_author=$(jq -r '.pr_author // empty' "${data_file}")"
+            echo "pr_number=$(jq -r '.pr_number // empty' "${data_file}")"
+            echo "pr_title=$(jq -r '.pr_title // empty' "${data_file}")"
+            echo "pr_url=$(jq -r '.pr_url // empty' "${data_file}")"
+            echo "event_name=$(jq -r '.event_name // empty' "${data_file}")"
+            echo "mOrD=$(jq -r '.mOrD // .m_or_d // empty' "${data_file}")"
+          } >> "$GITHUB_OUTPUT"
+          comment="$(jq -r '.comment // empty' "${data_file}")"
+          printf 'comment<<EOF\n%s\nEOF\n' "${comment}" >> "$GITHUB_OUTPUT"
+
+      - name: Select bridge or legacy inputs
+        id: inputs
+        run: |
+          {
+            echo "author=${{ steps.bridge.outputs.author }}${{ steps.legacy.outputs.author }}"
+            echo "pr_author=${{ steps.bridge.outputs.pr_author }}${{ steps.legacy.outputs.pr_author }}"
+            echo "pr_number=${{ steps.bridge.outputs.pr_number }}${{ steps.legacy.outputs.pr_number }}"
+            echo "pr_title=${{ steps.bridge.outputs.pr_title }}${{ steps.legacy.outputs.pr_title }}"
+            echo "pr_url=${{ steps.bridge.outputs.pr_url }}${{ steps.legacy.outputs.pr_url }}"
+            echo "event_name=${{ steps.bridge.outputs.event_name }}${{ steps.legacy.outputs.event_name }}"
+            echo "mOrD=${{ steps.bridge.outputs.mOrD }}${{ steps.legacy.outputs.mOrD }}"
+          } >> "$GITHUB_OUTPUT"
+          printf 'comment<<EOF\n%s\nEOF\n' "${{ steps.bridge.outputs.comment }}${{ steps.legacy.outputs.comment }}" >> "$GITHUB_OUTPUT"
+
+      - if: ${{ ! steps.inputs.outputs.mOrD == '' }}
         name: Check whether user is part of mathlib-reviewers team
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: actorTeams
@@ -44,7 +92,7 @@ jobs:
           organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
                   # Organization to get membership from.
           team: 'mathlib-reviewers'
-          username: ${{ steps.bridge.outputs.author }}
+          username: ${{ steps.inputs.outputs.author }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
       - name: Checkout local actions
@@ -66,24 +114,24 @@ jobs:
           "${CI_SCRIPTS_DIR}/maintainer/get_tlabel.sh" "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.inputs.outputs.pr_number }}
 
       - name: Form the message
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: form_the_message
         run: |
           message="$(
-            "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.bridge.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
+            "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.inputs.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
           )"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
         env:
-          AUTHOR: ${{ steps.bridge.outputs.author }}
-          EVENT_NAME: ${{ steps.bridge.outputs.event_name }}
-          PR_NUMBER: ${{ steps.bridge.outputs.pr_number }}
-          PR_URL: ${{ steps.bridge.outputs.pr_url }}
-          PR_TITLE: ${{ steps.bridge.outputs.pr_title }}
-          COMMENT: ${{ steps.bridge.outputs.comment }}
-          PR_AUTHOR: ${{ steps.bridge.outputs.pr_author }}
+          AUTHOR: ${{ steps.inputs.outputs.author }}
+          EVENT_NAME: ${{ steps.inputs.outputs.event_name }}
+          PR_NUMBER: ${{ steps.inputs.outputs.pr_number }}
+          PR_URL: ${{ steps.inputs.outputs.pr_url }}
+          PR_TITLE: ${{ steps.inputs.outputs.pr_title }}
+          COMMENT: ${{ steps.inputs.outputs.comment }}
+          PR_AUTHOR: ${{ steps.inputs.outputs.pr_author }}
 
       - name: Send message on Zulip
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
@@ -103,9 +151,9 @@ jobs:
         with:
           # if a comment triggers the action, then `issue.number` is set
           # if a review or review comment triggers the action, then `pull_request.number` is set
-          issue-number: ${{ steps.bridge.outputs.pr_number }}
+          issue-number: ${{ steps.inputs.outputs.pr_number }}
           body: |
-            🚀 Pull request has been placed on the maintainer queue by ${{ steps.bridge.outputs.author }}.
+            🚀 Pull request has been placed on the maintainer queue by ${{ steps.inputs.outputs.author }}.
 
       - if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         name: Generate app token
@@ -124,5 +172,5 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = ${{ steps.bridge.outputs.pr_number }};
+            const issue_number = ${{ steps.inputs.outputs.pr_number }};
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -86,6 +86,12 @@ jobs:
           } | tee -a "$GITHUB_OUTPUT"
           printf 'comment<<EOF\n%s\nEOF\n' "${{ steps.bridge.outputs.comment }}${{ steps.legacy.outputs.comment }}" | tee -a "$GITHUB_OUTPUT"
 
+      - name: Note legacy artifact fallback
+        if: ${{ steps.inputs.outputs.input_source == 'legacy' }}
+        run: |
+          echo "::notice::Using legacy workflow-data artifact fallback from maintainer_merge.yml"
+          echo "Using legacy workflow-data artifact fallback from maintainer_merge.yml" >> "$GITHUB_STEP_SUMMARY"
+
       - if: ${{ ! steps.inputs.outputs.mOrD == '' }}
         name: Check whether user is part of mathlib-reviewers team
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
@@ -125,6 +131,16 @@ jobs:
           message="$(
             "${CI_SCRIPTS_DIR}/maintainer/maintainer_merge_message.sh" "${AUTHOR}" "${{ steps.inputs.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
           )"
+          trigger_name="${{ steps.inputs.outputs.event_name }}"
+          trigger_run_url="${{ github.event.workflow_run.html_url }}"
+          wf_run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          legacy_suffix=""
+          if [ "${{ steps.inputs.outputs.input_source }}" = "legacy" ]
+          then
+            legacy_suffix=" (legacy)"
+          fi
+          metadata=$'trigger_name: ['"${trigger_name}"$']('"${trigger_run_url}"$')\nwf_run: [workflow_run]('"${wf_run_url}"$')'"${legacy_suffix}"
+          message="${message}"$'\n\n---\n'"${metadata}"
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
         env:
           AUTHOR: ${{ steps.inputs.outputs.author }}
@@ -147,6 +163,23 @@ jobs:
           topic: ${{ steps.determine_topic.outputs.topic }}
           content: ${{ steps.form_the_message.outputs.title }}
 
+      - name: Compose PR comment body
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        id: pr_comment
+        run: |
+          body="🚀 Pull request has been placed on the maintainer queue by ${{ steps.inputs.outputs.author }}."
+          trigger_name="${{ steps.inputs.outputs.event_name }}"
+          trigger_run_url="${{ github.event.workflow_run.html_url }}"
+          wf_run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          legacy_suffix=""
+          if [ "${{ steps.inputs.outputs.input_source }}" = "legacy" ]
+          then
+            legacy_suffix=" (legacy)"
+          fi
+          metadata=$'trigger_name: ['"${trigger_name}"$']('"${trigger_run_url}"$')\nwf_run: [workflow_run]('"${wf_run_url}"$')'"${legacy_suffix}"
+          body="${body}"$'\n\n---\n'"${metadata}"
+          printf 'body<<EOF\n%s\nEOF\n' "${body}" | tee -a "$GITHUB_OUTPUT"
+
       - name: Add comment to PR
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
@@ -154,8 +187,7 @@ jobs:
           # if a comment triggers the action, then `issue.number` is set
           # if a review or review comment triggers the action, then `pull_request.number` is set
           issue-number: ${{ steps.inputs.outputs.pr_number }}
-          body: |
-            🚀 Pull request has been placed on the maintainer queue by ${{ steps.inputs.outputs.author }}.
+          body: ${{ steps.pr_comment.outputs.body }}
 
       - if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         name: Generate app token

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Download legacy artifact (fallback)
         id: download-legacy-artifact
-        if: ${{ steps.bridge.outputs.mOrD == '' }}
-        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # v14
+        if: ${{ steps.bridge.outputs.pr_number == '' }}
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
         with:
           workflow: maintainer_merge.yml
           name: workflow-data
@@ -50,7 +50,7 @@ jobs:
 
       - name: Extract legacy artifact data (fallback)
         id: legacy
-        if: ${{ steps.bridge.outputs.mOrD == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
+        if: ${{ steps.bridge.outputs.pr_number == '' && steps.download-legacy-artifact.outputs.found_artifact == 'true' }}
         run: |
           data_file="./artifacts/artifact-data.json"
           if [ ! -f "${data_file}" ]
@@ -66,12 +66,13 @@ jobs:
             echo "pr_url=$(jq -r '.pr_url // empty' "${data_file}")"
             echo "event_name=$(jq -r '.event_name // empty' "${data_file}")"
             echo "mOrD=$(jq -r '.mOrD // .m_or_d // empty' "${data_file}")"
-          } >> "$GITHUB_OUTPUT"
+          } | tee -a "$GITHUB_OUTPUT"
           comment="$(jq -r '.comment // empty' "${data_file}")"
-          printf 'comment<<EOF\n%s\nEOF\n' "${comment}" >> "$GITHUB_OUTPUT"
+          printf 'comment<<EOF\n%s\nEOF\n' "${comment}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Select bridge or legacy inputs
         id: inputs
+        if: ${{ steps.bridge.outputs.pr_number != '' || steps.legacy.outputs.pr_number != '' }}
         run: |
           {
             echo "author=${{ steps.bridge.outputs.author }}${{ steps.legacy.outputs.author }}"
@@ -81,8 +82,9 @@ jobs:
             echo "pr_url=${{ steps.bridge.outputs.pr_url }}${{ steps.legacy.outputs.pr_url }}"
             echo "event_name=${{ steps.bridge.outputs.event_name }}${{ steps.legacy.outputs.event_name }}"
             echo "mOrD=${{ steps.bridge.outputs.mOrD }}${{ steps.legacy.outputs.mOrD }}"
-          } >> "$GITHUB_OUTPUT"
-          printf 'comment<<EOF\n%s\nEOF\n' "${{ steps.bridge.outputs.comment }}${{ steps.legacy.outputs.comment }}" >> "$GITHUB_OUTPUT"
+            echo "input_source=${{ steps.bridge.outputs.pr_number != '' && 'bridge' || (steps.legacy.outputs.pr_number != '' && 'legacy' || 'none') }}"
+          } | tee -a "$GITHUB_OUTPUT"
+          printf 'comment<<EOF\n%s\nEOF\n' "${{ steps.bridge.outputs.comment }}${{ steps.legacy.outputs.comment }}" | tee -a "$GITHUB_OUTPUT"
 
       - if: ${{ ! steps.inputs.outputs.mOrD == '' }}
         name: Check whether user is part of mathlib-reviewers team


### PR DESCRIPTION
Further followups to #35110. In rough order of importance:

First, on older PRs, the older versions of the bors / maintainer merge actions may still get triggered (see https://github.com/leanprover-community/mathlib4/pull/35110#issuecomment-4018550225 for an explanation; in hindsight I should have realized it would still be a problem after merging 🤦 ). This causes the new wf_run workflows not to work properly. I've adjusted the workflows so that they can read either type of artifact, making them backwards-compatible. (At some point in the future we may be able to revert this part)

Second, Zulip notifications from the maintainer merge workflow are now working but it is failing to post a comment due to missing permissions for the github token. I added `pull-requests: write` to fix that.

Third, Zulip emojis are failing for bors commands due to steps being out of order.

Fourth, in #33042 I introduced conditionals to reduce the frequency of the maintainer merge workflow getting triggered. I do the same thing for the maintainer bors workflow here.

Prepared with codex

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
