### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Cones): fixing non-dsimp-nf lemmas

### DIFF
--- a/Mathlib/Algebra/Category/Ring/FinitePresentation.lean
+++ b/Mathlib/Algebra/Category/Ring/FinitePresentation.lean
@@ -132,7 +132,8 @@ lemma RingHom.EssFiniteType.exists_eq_comp_ι_app_of_isColimit (hf : f.hom.Finit
   · ext x
     obtain ⟨x, rfl⟩ := hπ x
     suffices (π ≫ g) x = (g' ≫ F.map (c'.ι.app none) ≫ c.ι.app _) x by
-      simpa [RingHom.liftOfRightInverse_comp_apply, -NatTrans.naturality] using this
+      simpa only [CommRingCat.hom_comp, CommRingCat.hom_ofHom,
+        RingHom.liftOfRightInverse_comp_apply, coe_comp, Function.comp_apply] using this
     rw [c.w, hg']
     rfl
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -1045,9 +1045,7 @@ lemma exists_isAffineOpen_preimage_eq
     (isQuasiSeparated_iff_quasiSeparatedSpace _ (D.map _ ⁻¹ᵁ _).2).mp (.of_quasiSeparatedSpace _)
   have : IsAffine (opensCone D c i U).pt := hU
   obtain ⟨j, hj⟩ := Scheme.exists_isAffine_of_isLimit _ _ (isLimitOpensCone D c hc i U)
-  refine ⟨_, _, hj, ?_⟩
-  rw [← Scheme.Hom.comp_preimage, c.w]
-  simp
+  exact ⟨_, _, hj, by simp [← Scheme.Hom.comp_preimage]⟩
 
 set_option backward.isDefEq.respectTransparency false in
 open TopologicalSpace in

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -123,6 +123,26 @@ abbrev unitInv (e : C ≌ D) : e.functor ⋙ e.inverse ⟶ 𝟭 C :=
 abbrev counitInv (e : C ≌ D) : 𝟭 D ⟶ e.inverse ⋙ e.functor :=
   e.counitIso.inv
 
+@[reassoc (attr := simp)]
+lemma unitIso_hom_inv_id_app (e : C ≌ D) (X : C) :
+    dsimp% e.unit.app X ≫ e.unitInv.app X = 𝟙 X :=
+  e.unitIso.hom_inv_id_app X
+
+@[reassoc (attr := simp)]
+lemma unitIso_inv_hom_id_app (e : C ≌ D) (X : C) :
+    dsimp% e.unitInv.app X ≫ e.unit.app X = 𝟙 _ :=
+  e.unitIso.inv_hom_id_app X
+
+@[reassoc (attr := simp)]
+lemma counitIso_hom_inv_id_app (e : C ≌ D) (Y : D) :
+    dsimp% e.counit.app Y ≫ e.counitInv.app Y = 𝟙 _ :=
+  e.counitIso.hom_inv_id_app Y
+
+@[reassoc (attr := simp)]
+lemma counitIso_inv_hom_id_app (e : C ≌ D) (Y : D) :
+    dsimp% e.counitInv.app Y ≫ e.counit.app Y = 𝟙 Y :=
+  e.counitIso.inv_hom_id_app Y
+
 section CategoryStructure
 
 instance : Category (C ≌ D) where
@@ -206,33 +226,34 @@ theorem Equivalence_mk'_counitInv (functor inverse unit_iso counit_iso f) :
 
 @[reassoc]
 theorem counit_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
-    e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
+    dsimp% e.functor.map (e.inverse.map f) ≫ e.counit.app Y = e.counit.app X ≫ f :=
   e.counit.naturality f
 
 @[reassoc]
 theorem unit_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
-    e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
+    dsimp% e.unit.app X ≫ e.inverse.map (e.functor.map f) = f ≫ e.unit.app Y :=
   (e.unit.naturality f).symm
 
 @[reassoc]
 theorem counitInv_naturality (e : C ≌ D) {X Y : D} (f : X ⟶ Y) :
-    e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
+    dsimp% e.counitInv.app X ≫ e.functor.map (e.inverse.map f) = f ≫ e.counitInv.app Y :=
   (e.counitInv.naturality f).symm
 
 @[reassoc]
 theorem unitInv_naturality (e : C ≌ D) {X Y : C} (f : X ⟶ Y) :
-    e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
+    dsimp% e.inverse.map (e.functor.map f) ≫ e.unitInv.app Y = e.unitInv.app X ≫ f :=
   e.unitInv.naturality f
 
 @[reassoc (attr := simp)]
 theorem functor_unit_comp (e : C ≌ D) (X : C) :
-    e.functor.map (e.unit.app X) ≫ e.counit.app (e.functor.obj X) = 𝟙 (e.functor.obj X) :=
+    dsimp% e.functor.map (e.unit.app X) ≫ e.counit.app (e.functor.obj X) =
+      𝟙 (e.functor.obj X) :=
   e.functor_unitIso_comp X
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 theorem counitInv_functor_comp (e : C ≌ D) (X : C) :
-    e.counitInv.app (e.functor.obj X) ≫ e.functor.map (e.unitInv.app X) = 𝟙 (e.functor.obj X) := by
+    dsimp% e.counitInv.app (e.functor.obj X) ≫ e.functor.map (e.unitInv.app X) =
+      𝟙 (e.functor.obj X) := by
   simpa using Iso.inv_eq_inv
     (e.functor.mapIso (e.unitIso.app X) ≪≫ e.counitIso.app (e.functor.obj X)) (Iso.refl _)
 
@@ -265,7 +286,9 @@ theorem unit_inverse_comp (e : C ≌ D) (Y : D) :
     rw [← Iso.hom_inv_id_assoc (e.inverse.mapIso (e.counitIso.app _)) (e.unitInv.app _)]
   slice_lhs 3 4 =>
     dsimp only [Functor.mapIso_hom, Iso.app_hom]
-    rw [← map_comp e.inverse, e.counit_naturality, e.counitIso.hom_inv_id_app]
+    rw [← map_comp e.inverse]
+    dsimp
+    rw [e.counit_naturality, e.counitIso.hom_inv_id_app]
     dsimp only [Functor.comp_obj]
     rw [map_id]
   dsimp only [comp_obj, id_obj]
@@ -278,7 +301,6 @@ theorem unit_inverse_comp (e : C ≌ D) (Y : D) :
     rw [← map_comp e.inverse, ← map_comp e.functor, e.unitIso.hom_inv_id_app]
     dsimp only [Functor.id_obj]
     rw [map_id, map_id]
-  dsimp only [comp_obj, id_obj]
   rw [id_comp]
   slice_lhs 3 4 => rw [← e.unitInv_naturality]
   slice_lhs 2 3 =>

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -136,9 +136,8 @@ instance inhabitedCone (F : Discrete PUnit ⥤ C) : Inhabited (Cone F) :=
 
 @[reassoc (attr := simp)]
 theorem Cone.w {F : J ⥤ C} (c : Cone F) {j j' : J} (f : j ⟶ j') :
-    c.π.app j ≫ F.map f = c.π.app j' := by
-  rw [← c.π.naturality f]
-  apply id_comp
+    dsimp% c.π.app j ≫ F.map f = c.π.app j' := by
+  simpa using (c.π.naturality f).symm
 
 /-- A `c : Cocone F` is
 * an object `c.pt` and
@@ -167,11 +166,10 @@ instance inhabitedCocone (F : Discrete PUnit ⥤ C) : Inhabited (Cocone F) :=
            }
   }⟩
 
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem Cocone.w {F : J ⥤ C} (c : Cocone F) {j j' : J} (f : j ⟶ j') :
-    F.map f ≫ c.ι.app j' = c.ι.app j := by
-  rw [c.ι.naturality f]
-  apply comp_id
+    dsimp% F.map f ≫ c.ι.app j' = c.ι.app j := by
+  simpa using c.ι.naturality f
 
 end
 
@@ -258,7 +256,7 @@ structure ConeMorphism (A B : Cone F) where
   /-- A morphism between the two vertex objects of the cones -/
   hom : A.pt ⟶ B.pt
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  w : ∀ j : J, hom ≫ B.π.app j = A.π.app j := by cat_disch
+  w : dsimp% ∀ j : J, hom ≫ B.π.app j = A.π.app j := by cat_disch
 
 attribute [reassoc (attr := simp)] ConeMorphism.w
 
@@ -293,11 +291,10 @@ instance {c d : Cone F} (f : c ≅ d) : IsIso f.hom.hom := ⟨f.inv.hom, by simp
 
 instance {c d : Cone F} (f : c ≅ d) : IsIso f.inv.hom := ⟨f.hom.hom, by simp⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 lemma ConeMorphism.map_w {c c' : Cone F} (f : c ⟶ c') (G : C ⥤ D) (j : J) :
     G.map f.hom ≫ G.map (c'.π.app j) = G.map (c.π.app j) := by
-  simp only [← map_comp, ConeMorphism.w]
+  simp [← map_comp]
 
 namespace Cone
 
@@ -388,7 +385,6 @@ def whiskering (E : K ⥤ J) : Cone F ⥤ Cone (E ⋙ F) where
   obj c := c.whisker E
   map f := { hom := f.hom }
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Whiskering by an equivalence gives an equivalence between categories of cones.
 -/
 @[simps]
@@ -423,7 +419,6 @@ def forget : Cone F ⥤ C where
 
 variable (G : C ⥤ D)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A functor `G : C ⥤ D` sends cones over `F` to cones over `F ⋙ G` functorially. -/
 @[simps]
 def functoriality : Cone F ⥤ Cone (F ⋙ G) where
@@ -436,11 +431,10 @@ def functoriality : Cone F ⥤ Cone (F ⋙ G) where
     { hom := G.map f.hom
       w := ConeMorphism.map_w f G }
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Functoriality is functorial. -/
 def functorialityCompFunctoriality (H : D ⥤ E) :
     functoriality F G ⋙ functoriality (F ⋙ G) H ≅ functoriality F (G ⋙ H) :=
-  NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [functoriality])
+  NatIso.ofComponents (fun _ ↦ Iso.refl _)
 
 instance functoriality_full [G.Full] [G.Faithful] : (functoriality F G).Full where
   map_surjective t :=
@@ -451,7 +445,6 @@ instance functoriality_faithful [G.Faithful] : (functoriality F G).Faithful wher
   map_injective {_X} {_Y} f g h :=
     ConeMorphism.ext f g <| G.map_injective <| congr_arg ConeMorphism.hom h
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `e : C ≌ D` is an equivalence of categories, then `functoriality F e.functor` induces an
 equivalence between cones over `F` and cones over `F ⋙ e.functor`.
 -/
@@ -461,8 +454,8 @@ def functorialityEquivalence (e : C ≌ D) : Cone F ≌ Cone (F ⋙ e.functor) :
     Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ e.unitIso.symm ≪≫ Functor.rightUnitor _
   { functor := functoriality F e.functor
     inverse := functoriality (F ⋙ e.functor) e.inverse ⋙ (postcomposeEquivalence f).functor
-    unitIso := NatIso.ofComponents fun c => ext (e.unitIso.app _)
-    counitIso := NatIso.ofComponents fun c => ext (e.counitIso.app _) }
+    unitIso := NatIso.ofComponents (fun c => ext (e.unitIso.app _))
+    counitIso := NatIso.ofComponents (fun c => ext (e.counitIso.app _)) }
 
 /-- If `F` reflects isomorphisms, then `functoriality F` reflects isomorphisms
 as well.
@@ -486,14 +479,13 @@ structure CoconeMorphism (A B : Cocone F) where
   /-- A morphism between the (co)vertex objects in `C` -/
   hom : A.pt ⟶ B.pt
   /-- The triangle made from the two natural transformations and `hom` commutes -/
-  w : ∀ j : J, A.ι.app j ≫ hom = B.ι.app j := by cat_disch
+  w : dsimp% ∀ j : J, A.ι.app j ≫ hom = B.ι.app j := by cat_disch
 
 instance inhabitedCoconeMorphism (A : Cocone F) : Inhabited (CoconeMorphism A A) :=
   ⟨{ hom := 𝟙 _ }⟩
 
 attribute [reassoc (attr := simp)] CoconeMorphism.w
 
-set_option backward.isDefEq.respectTransparency false in
 @[simps]
 instance Cocone.category : Category (Cocone F) where
   Hom A B := CoconeMorphism A B
@@ -521,11 +513,10 @@ instance {c d : Cocone F} (f : c ≅ d) : IsIso f.hom.hom := ⟨f.inv.hom, by si
 
 instance {c d : Cocone F} (f : c ≅ d) : IsIso f.inv.hom := ⟨f.hom.hom, by simp⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 lemma CoconeMorphism.map_w {c c' : Cocone F} (f : c ⟶ c') (G : C ⥤ D) (j : J) :
-    G.map (c.ι.app j) ≫ G.map f.hom = G.map (c'.ι.app j) := by
-  simp only [← map_comp, CoconeMorphism.w]
+    dsimp% G.map (c.ι.app j) ≫ G.map f.hom = G.map (c'.ι.app j) := by
+  simp [← map_comp]
 
 namespace Cocone
 
@@ -578,7 +569,6 @@ def extendIso (s : Cocone F) {X : C} (f : s.pt ≅ X) : s ≅ s.extend f.hom whe
 instance {s : Cocone F} {X : C} (f : s.pt ⟶ X) [IsIso f] : IsIso (s.extendHom f) :=
   ⟨(extendIso s (asIso f)).inv, by cat_disch⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Functorially precompose a cocone for `F` by a natural transformation `G ⟶ F` to give a cocone
 for `G`. -/
 @[simps]
@@ -608,7 +598,6 @@ def precomposeEquivalence {G : J ⥤ C} (α : G ≅ F) : Cocone F ≌ Cocone G w
   unitIso := NatIso.ofComponents fun s => ext (Iso.refl _)
   counitIso := NatIso.ofComponents fun s => ext (Iso.refl _)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Whiskering on the left by `E : K ⥤ J` gives a functor from `Cocone F` to `Cocone (E ⋙ F)`.
 -/
 @[simps]
@@ -616,7 +605,6 @@ def whiskering (E : K ⥤ J) : Cocone F ⥤ Cocone (E ⋙ F) where
   obj c := c.whisker E
   map f := { hom := f.hom }
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Whiskering by an equivalence gives an equivalence between categories of cones.
 -/
 @[simps]
@@ -651,7 +639,6 @@ def forget : Cocone F ⥤ C where
 
 variable (G : C ⥤ D)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A functor `G : C ⥤ D` sends cocones over `F` to cocones over `F ⋙ G` functorially. -/
 @[simps]
 def functoriality : Cocone F ⥤ Cocone (F ⋙ G) where
@@ -664,11 +651,10 @@ def functoriality : Cocone F ⥤ Cocone (F ⋙ G) where
     { hom := G.map f.hom
       w := CoconeMorphism.map_w f G }
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Functoriality is functorial. -/
 def functorialityCompFunctoriality (H : D ⥤ E) :
     functoriality F G ⋙ functoriality (F ⋙ G) H ≅ functoriality F (G ⋙ H) :=
-  NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [functoriality])
+  NatIso.ofComponents (fun _ ↦ Iso.refl _)
 
 instance functoriality_full [G.Full] [G.Faithful] : (functoriality F G).Full where
   map_surjective t :=
@@ -679,7 +665,6 @@ instance functoriality_faithful [G.Faithful] : (functoriality F G).Faithful wher
   map_injective {_X} {_Y} f g h :=
     CoconeMorphism.ext f g <| G.map_injective <| congr_arg CoconeMorphism.hom h
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `e : C ≌ D` is an equivalence of categories, then `functoriality F e.functor` induces an
 equivalence between cocones over `F` and cocones over `F ⋙ e.functor`.
 -/
@@ -981,8 +966,7 @@ def coconeEquivalenceOpConeOp : Cocone F ≌ (Cone F.op)ᵒᵖ where
   counitIso :=
     NatIso.ofComponents
       (fun c => (Cone.ext (Iso.refl c.unop.pt)).op)
-      fun {X} {Y} f =>
-      Quiver.Hom.unop_inj (ConeMorphism.ext _ _ (by simp))
+      (fun f ↦ Quiver.Hom.unop_inj (by cat_disch))
   functor_unitIso_comp c := by
     apply Quiver.Hom.unop_inj
     apply ConeMorphism.ext

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -454,8 +454,8 @@ def functorialityEquivalence (e : C ≌ D) : Cone F ≌ Cone (F ⋙ e.functor) :
     Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ e.unitIso.symm ≪≫ Functor.rightUnitor _
   { functor := functoriality F e.functor
     inverse := functoriality (F ⋙ e.functor) e.inverse ⋙ (postcomposeEquivalence f).functor
-    unitIso := NatIso.ofComponents (fun c => ext (e.unitIso.app _))
-    counitIso := NatIso.ofComponents (fun c => ext (e.counitIso.app _)) }
+    unitIso := NatIso.ofComponents fun c => ext (e.unitIso.app _)
+    counitIso := NatIso.ofComponents fun c => ext (e.counitIso.app _) }
 
 /-- If `F` reflects isomorphisms, then `functoriality F` reflects isomorphisms
 as well.

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -256,7 +256,7 @@ structure ConeMorphism (A B : Cone F) where
   /-- A morphism between the two vertex objects of the cones -/
   hom : A.pt ⟶ B.pt
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  w : dsimp% ∀ j : J, hom ≫ B.π.app j = A.π.app j := by cat_disch
+  w : ∀ j : J, hom ≫ B.π.app j = A.π.app j := by cat_disch
 
 attribute [reassoc (attr := simp)] ConeMorphism.w
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
@@ -181,8 +181,7 @@ noncomputable def isLimit : IsLimit (cone f) where
         Discrete.functor_obj_eq_as, Fan.mk_π_app, Category.assoc, eqToHom_trans]
       have hh : m + 1 ≤ n := by lia
       rw [← s.w (homOfLE hh).op]
-      simp only [Functor.const_obj_obj, Functor.ofOpSequence_obj, homOfLE_leOfHom,
-        Category.assoc]
+      simp only [Functor.ofOpSequence_obj, homOfLE_leOfHom, Category.assoc]
       congr
       induction hh using Nat.leRec with
       | refl => simp

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -48,7 +48,7 @@ def colimitCoconeIsColimit (X : Cᵒᵖ) : IsColimit (colimitCocone X) where
   fac s Y := by
     funext f
     convert congr_fun (s.w f).symm (𝟙 (unop X))
-    simp only [Functor.flip_obj_obj, yoneda_obj_obj, Functor.const_obj_obj, Functor.flip_obj_map,
+    simp only [Functor.flip_obj_obj, yoneda_obj_obj, Functor.flip_obj_map,
       types_comp_apply, yoneda_map_app, Category.id_comp]
   uniq s m w := by
     apply funext; rintro ⟨⟩

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -58,7 +58,8 @@ noncomputable def isColimitLocallyConstantPresheaf (hc : IsLimit c) [∀ i, Epi 
     change fi ((c.π.app k ≫ (F ⋙ toProfinite).map _) x) =
       fj ((c.π.app k ≫ (F ⋙ toProfinite).map _) x)
     have h := LocallyConstant.congr_fun h x
-    rwa [c.w, c.w]
+    dsimp
+    rwa [dsimp% c.w, dsimp% c.w]
 
 @[simp]
 lemma isColimitLocallyConstantPresheaf_desc_apply (hc : IsLimit c) [∀ i, Epi (c.π.app i)]
@@ -324,7 +325,8 @@ noncomputable def isColimitLocallyConstantPresheaf (hc : IsLimit c) [∀ i, Epi 
     change fi ((c.π.app k ≫ (F ⋙ toLightProfinite).map _) x) =
       fj ((c.π.app k ≫ (F ⋙ toLightProfinite).map _) x)
     have h := LocallyConstant.congr_fun h x
-    rwa [c.w, c.w]
+    dsimp
+    rwa [dsimp% c.w, dsimp% c.w]
 
 @[simp]
 lemma isColimitLocallyConstantPresheaf_desc_apply (hc : IsLimit c) [∀ i, Epi (c.π.app i)]


### PR DESCRIPTION
We use the `dsimp%` term elaborator to put certain lemmas into dsimp normal form, so that they can be used without doing `set_option backward.isDefEq.respectTransparency false`. This removes all but one of these in the file `CategoryTheory/Limits/Cones`. The remaining one has to do with `Quiver.Hom.unop_op`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
