### PR TITLE
feat(SimpleGraph): hamiltonian cycle from cyclic permutation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3614,6 +3614,7 @@ public import Mathlib.Combinatorics.SimpleGraph.FiveWheelLike
 public import Mathlib.Combinatorics.SimpleGraph.Girth
 public import Mathlib.Combinatorics.SimpleGraph.Hall
 public import Mathlib.Combinatorics.SimpleGraph.Hamiltonian
+public import Mathlib.Combinatorics.SimpleGraph.Hamiltonian.Perm
 public import Mathlib.Combinatorics.SimpleGraph.Hasse
 public import Mathlib.Combinatorics.SimpleGraph.IncMatrix
 public import Mathlib.Combinatorics.SimpleGraph.Init

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3650,6 +3650,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Walk.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Chord
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Counting
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Decomp
+public import Mathlib.Combinatorics.SimpleGraph.Walk.Iterate
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Maps
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Operations
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Subwalks

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -322,8 +322,8 @@ theorem isHamiltonianCycle_cons_iterate {σ : Perm α}
   · simp only [Walk.length_cons, Walk.length_copy, Walk.length_iterate]
     omega
 
-/-- If `σ` is a cycle with full support on at least 3 elements and every step is
-a graph edge, then `G` is Hamiltonian. -/
+/-- Given a cyclic permutation with full support on at least 3 elements which
+sends each vertex to an adjacent one, then the graph is hamiltonian. -/
 theorem IsHamiltonian.ofPerm {σ : Perm α}
     (hcycle : σ.IsCycle) (hsupport : σ.support = Finset.univ)
     (hadj : ∀ x, G.Adj x (σ x))

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -209,6 +209,14 @@ lemma isHamiltonianCycle_iff_isCycle_and_length_eq [Fintype α] :
   refine isHamiltonian_iff_isPath_and_length_eq.mpr ⟨h₁.isPath_tail, ?_⟩
   grind [length_tail_add_one, IsCycle.not_nil]
 
+/-- Closing a Hamiltonian path with a back-edge produces a Hamiltonian cycle, and conversely. -/
+theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
+    (Walk.cons h p).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
+  have htail : (cons h p).tail.IsHamiltonian ↔ p.IsHamiltonian := by
+    simp [IsHamiltonian, tail_cons, support_copy]
+  rw [isHamiltonianCycle_isCycle_and_isHamiltonian_tail, cons_isCycle_iff, htail]
+  exact ⟨fun ⟨⟨_, hedge⟩, hp⟩ ↦ ⟨hp, hedge⟩, fun ⟨hp, hedge⟩ ↦ ⟨⟨hp.isPath, hedge⟩, hp⟩⟩
+
 @[simp]
 lemma isHamiltonianCycle_rotate (hv : v ∈ p.support) :
     (p.rotate v hv).IsHamiltonianCycle ↔ p.IsHamiltonianCycle := by
@@ -289,39 +297,6 @@ open Equiv Equiv.Perm
 
 variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
 
-/-- If `σ` is a cycle with full support on at least 3 elements and every step is a graph edge,
-then for any `x` with `σ^[n-1] (σ x) = x`, the walk
-`x → σ x → σ² x → ⋯ → σ^(n-1) x → x` is a Hamiltonian cycle. -/
-theorem isHamiltonianCycle_cons_iterate {σ : Perm α}
-    (hcycle : σ.IsCycle) (hsupport : σ.support = Finset.univ)
-    (hadj : ∀ x, G.Adj x (σ x)) (hcard3 : 3 ≤ Fintype.card α) (x : α)
-    (h : (↑σ : α → α)^[Fintype.card α - 1] (σ x) = x) :
-    (Walk.cons (hadj x)
-      ((Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl h)).IsHamiltonianCycle := by
-  have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
-    hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
-  have hx : σ x ≠ x := σ.mem_support.mp (hsupport ▸ Finset.mem_univ x)
-  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.cons_isCycle_iff]
-  refine ⟨⟨?_, ?_⟩, ?_⟩
-  · rw [Walk.isPath_def]
-    simp only [Walk.support_copy, Walk.support_iterate,
-      show Fintype.card α - 1 + 1 = Fintype.card α by omega]
-    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
-    have hcard : Fintype.card α = (σ.toList (σ x)).length := by
-      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
-    rw [hcard, ← List.range_map_iterate]
-    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
-    exact σ.nodup_toList (σ x)
-  · simp only [Walk.edges_copy, Walk.edges_iterate]
-    rw [List.mem_map]
-    rintro ⟨i, hi, heq⟩
-    rw [List.mem_range] at hi
-    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
-      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
-  · simp only [Walk.length_cons, Walk.length_copy, Walk.length_iterate]
-    omega
-
 /-- Given a cyclic permutation with full support on at least 3 elements which
 sends each vertex to an adjacent one, then the graph is hamiltonian. -/
 theorem IsHamiltonian.ofPerm {σ : Perm α}
@@ -329,13 +304,35 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     (hadj : ∀ x, G.Adj x (σ x))
     (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
   intro _
-  obtain ⟨x, _⟩ := hcycle.nonempty_support
+  obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support
+  have hx : σ x ≠ x := σ.mem_support.mp hx_mem
   have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
     hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
-  refine ⟨x, _, isHamiltonianCycle_cons_iterate hcycle hsupport hadj hcard3 x ?_⟩
-  change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
-  rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
-    ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)]
+  set p : G.Walk (σ x) x := (Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl (by
+    change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
+    rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
+      ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
+  refine ⟨x, .cons (hadj x) p, Walk.cons_isHamiltonianCycle_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
+  · -- p is a Hamiltonian path: visits every vertex exactly once.
+    rw [Walk.isHamiltonian_iff_isPath_and_length_eq]
+    refine ⟨?_, by simp [p]⟩
+    rw [Walk.isPath_def]
+    simp only [p, Walk.support_copy, Walk.support_iterate,
+      show Fintype.card α - 1 + 1 = Fintype.card α by omega]
+    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
+    have hcard : Fintype.card α = (σ.toList (σ x)).length := by
+      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+    rw [hcard, ← List.range_map_iterate]
+    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
+    exact σ.nodup_toList (σ x)
+  · -- The closure edge `s(x, σ x)` is not already used in `p`.
+    simp only [p, Walk.edges_copy, Walk.edges_iterate]
+    rw [List.mem_map]
+    rintro ⟨i, hi, heq⟩
+    rw [List.mem_range] at hi
+    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
+    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
+      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -310,7 +310,7 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
     hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
   set p : G.Walk (σ x) x := (Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl (by
     change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
-    rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
+    rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
       ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
   refine ⟨x, .cons (hadj x) p, Walk.cons_isHamiltonianCycle_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
   · -- p is a Hamiltonian path: visits every vertex exactly once.
@@ -318,7 +318,7 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
     refine ⟨?_, by simp [p]⟩
     rw [Walk.isPath_def]
     simp only [p, Walk.support_copy, Walk.support_iterate,
-      show Fintype.card α - 1 + 1 = Fintype.card α by omega]
+      show Fintype.card α - 1 + 1 = Fintype.card α by lia]
     have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
     have hcard : Fintype.card α = (σ.toList (σ x)).length := by
       rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
@@ -331,8 +331,8 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
     rintro ⟨i, hi, heq⟩
     rw [List.mem_range] at hi
     simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
-      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
+    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by lia)
+      (by rw [Finset.card_univ]; lia) (by rwa [Finset.card_univ]) heq
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -299,7 +299,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
 
 /-- Given a cyclic permutation with full support on at least 3 elements which
 sends each vertex to an adjacent one, then the graph is hamiltonian. -/
-theorem IsHamiltonian.ofPerm {σ : Perm α}
+theorem IsHamiltonian.of_perm {σ : Perm α}
     (hcycle : σ.IsCycle) (hsupport : σ.support = .univ)
     (hadj : ∀ x, G.Adj x (σ x))
     (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -326,13 +326,13 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
   set p := (Walk.iterate (↑σ) hadj (σ x) (n - 1)).copy rfl (by
     change (↑σ)^[n - 1 + 1] x = x
-    rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
+    rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
       hn_def, ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
   refine ⟨x, .cons (hadj x) p, ?_⟩
   rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.cons_isCycle_iff]
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · rw [Walk.isPath_def]
-    simp only [p, Walk.support_copy, Walk.support_iterate, show n - 1 + 1 = n by lia]
+    simp only [p, Walk.support_copy, Walk.support_iterate, show n - 1 + 1 = n by omega]
     have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
     have hcard : n = (σ.toList (σ x)).length := by
       rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
@@ -344,9 +344,9 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     rintro ⟨i, hi, heq⟩
     rw [List.mem_range] at hi
     simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact edge_ne_of_isCycleOn hcycOn (by lia) (by lia) hcard3 heq
+    exact edge_ne_of_isCycleOn hcycOn (by omega) (by omega) hcard3 heq
   · simp only [Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
-    lia
+    omega
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.Algebra.GroupWithZero.Nat
 public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
-public import Mathlib.Combinatorics.SimpleGraph.Walk.Iterate
-public import Mathlib.GroupTheory.Perm.Cycle.Concrete
 
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
 
@@ -291,51 +289,5 @@ theorem IsBridge.not_isHamiltonian {e : Sym2 α} (he : G.IsBridge e) : ¬G.IsHam
   refine hp.isHamiltonian_tail.isPath.isTrail.not_mem_support_of_not_reachable
     (fun huv ↦ he.2 <| .trans ?_ huv) he.2 (hp.isHamiltonian_tail.mem_support v)
   apply hp.isTrail.isEdgeReachable_two <;> simp
-
-section Perm
-
-open Equiv Equiv.Perm
-
-variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
-
-/-- Given a cyclic permutation with full support on at least 3 elements which
-sends each vertex to an adjacent one, then the graph is hamiltonian. -/
-theorem IsHamiltonian.of_perm {σ : Perm α}
-    (hcycle : σ.IsCycle) (hsupport : σ.support = .univ)
-    (hadj : ∀ x, G.Adj x (σ x))
-    (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
-  intro _
-  obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support
-  have hx : σ x ≠ x := σ.mem_support.mp hx_mem
-  have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
-    hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
-  set p : G.Walk (σ x) x := (Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl (by
-    change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
-    rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
-      ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
-  refine ⟨x, .cons (hadj x) p, Walk.cons_isHamiltonianCycle_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
-  · -- p is a Hamiltonian path: visits every vertex exactly once.
-    rw [Walk.isHamiltonian_iff_isPath_and_length_eq]
-    refine ⟨?_, by simp [p]⟩
-    rw [Walk.isPath_def]
-    simp only [p, Walk.support_copy, Walk.support_iterate,
-      show Fintype.card α - 1 + 1 = Fintype.card α by lia]
-    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
-    have hcard : Fintype.card α = (cycleOf σ (σ x)).support.card := by
-      rw [hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
-    rw [hcard, ← List.range_map_iterate]
-    simp only [Equiv.Perm.iterate_eq_pow]
-    rw [← σ.toList_eq_range_map_pow]
-    exact σ.nodup_toList (σ x)
-  · -- The closure edge `s(x, σ x)` is not already used in `p`.
-    simp only [p, Walk.edges_copy, Walk.edges_iterate]
-    rw [List.mem_map]
-    rintro ⟨i, hi, heq⟩
-    rw [List.mem_range] at hi
-    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by lia)
-      (by rw [Finset.card_univ]; lia) (by rw [Finset.card_univ]; lia) heq
-
-end Perm
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -209,7 +209,7 @@ lemma isHamiltonianCycle_iff_isCycle_and_length_eq [Fintype α] :
   refine isHamiltonian_iff_isPath_and_length_eq.mpr ⟨h₁.isPath_tail, ?_⟩
   grind [length_tail_add_one, IsCycle.not_nil]
 
-/-- A Hamiltonian path closed into a cycle by an edge is a Hamiltonian cycle, and conversely. -/
+/-- A Hamiltonian path closed into a cycle by an edge outside its support is a Hamiltonian cycle, and conversely. -/
 theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
     (Walk.cons h p).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
   have htail : (cons h p).tail.IsHamiltonian ↔ p.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -207,6 +207,10 @@ lemma isHamiltonianCycle_iff_isCycle_and_length_eq [Fintype α] :
   refine isHamiltonian_iff_isPath_and_length_eq.mpr ⟨h₁.isPath_tail, ?_⟩
   grind [length_tail_add_one, IsCycle.not_nil]
 
+theorem isHamiltonian_copy {u v u' v' : α} (p : G.Walk u v) (hu : u = u') (hv : v = v') :
+    (p.copy hu hv).IsHamiltonian ↔ p.IsHamiltonian := by
+  simp [IsHamiltonian, support_copy]
+
 /-- A Hamiltonian path closed into a cycle by an edge outside its support is a Hamiltonian cycle,
 and conversely. -/
 theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -209,7 +209,7 @@ lemma isHamiltonianCycle_iff_isCycle_and_length_eq [Fintype α] :
   refine isHamiltonian_iff_isPath_and_length_eq.mpr ⟨h₁.isPath_tail, ?_⟩
   grind [length_tail_add_one, IsCycle.not_nil]
 
-/-- Closing a Hamiltonian path with a back-edge produces a Hamiltonian cycle, and conversely. -/
+/-- A Hamiltonian path closed into a cycle by an edge is a Hamiltonian cycle, and conversely. -/
 theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
     (Walk.cons h p).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
   have htail : (cons h p).tail.IsHamiltonian ↔ p.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -334,7 +334,7 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
     rw [List.mem_range] at hi
     simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
     exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by lia)
-      (by rw [Finset.card_univ]; lia) (by rwa [Finset.card_univ]) heq
+      (by rw [Finset.card_univ]; lia) (by rw [Finset.card_univ]; lia) heq
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -213,12 +213,10 @@ theorem isHamiltonian_copy {u v u' v' : α} (p : G.Walk u v) (hu : u = u') (hv :
 
 /-- A Hamiltonian path closed into a cycle by an edge outside its support is a Hamiltonian cycle,
 and conversely. -/
-theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
-    (Walk.cons h p).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
-  have htail : (cons h p).tail.IsHamiltonian ↔ p.IsHamiltonian := by
-    simp [IsHamiltonian, tail_cons, support_copy]
-  rw [isHamiltonianCycle_isCycle_and_isHamiltonian_tail, cons_isCycle_iff, htail]
-  exact ⟨fun ⟨⟨_, hedge⟩, hp⟩ ↦ ⟨hp, hedge⟩, fun ⟨hp, hedge⟩ ↦ ⟨⟨hp.isPath, hedge⟩, hp⟩⟩
+theorem isHamiltonianCycle_cons_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
+    (p.cons h).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
+  rw [isHamiltonianCycle_isCycle_and_isHamiltonian_tail, cons_isCycle_iff, tail_cons]
+  grind [IsHamiltonian.isPath, isHamiltonian_copy, getVert_cons_succ]
 
 @[simp]
 lemma isHamiltonianCycle_rotate (hv : v ∈ p.support) :

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -320,10 +320,11 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
     simp only [p, Walk.support_copy, Walk.support_iterate,
       show Fintype.card α - 1 + 1 = Fintype.card α by lia]
     have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
-    have hcard : Fintype.card α = (σ.toList (σ x)).length := by
-      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+    have hcard : Fintype.card α = (cycleOf σ (σ x)).support.card := by
+      rw [hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
     rw [hcard, ← List.range_map_iterate]
-    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
+    simp only [Equiv.Perm.iterate_eq_pow]
+    rw [← σ.toList_eq_range_map_pow]
     exact σ.nodup_toList (σ x)
   · -- The closure edge `s(x, σ x)` is not already used in `p`.
     simp only [p, Walk.edges_copy, Walk.edges_iterate]

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -46,20 +46,11 @@ theorem edge_ne_of_isCycleOn {σ : Perm α} {x : α}
     s((σ ^ k) x, (σ ^ (k + 1)) x) ≠ s(x, σ x) := by
   have hinj := hcycOn.injOn_pow_apply (Finset.mem_univ x)
   rw [Finset.card_univ] at hinj
+  have h0 : (σ ^ (0 : ℕ)) x = x := by simp
+  have h1 : (σ ^ (1 : ℕ)) x = σ x := by simp
   intro heq
   rw [Sym2.eq_iff] at heq
-  rcases heq with ⟨h1, h2⟩ | ⟨h1, h2⟩
-  · -- Injectivity: `(σ^k) x = (σ^0) x` gives `k = 0`, contradicts `1 ≤ k`
-    have : k = 0 := hinj (Finset.mem_range.mpr hk2)
-      (Finset.mem_range.mpr (by lia)) (by simpa using h1)
-    lia
-  · -- Injectivity: `(σ^k) x = (σ^1) x` gives `k = 1`,
-    -- then `(σ^2) x = (σ^0) x` gives `2 = 0`
-    have hk1eq : k = 1 := hinj (Finset.mem_range.mpr hk2)
-      (Finset.mem_range.mpr (by lia)) (by simpa using h1)
-    have : 2 = 0 := hinj (Finset.mem_range.mpr (by lia))
-      (Finset.mem_range.mpr (by lia)) (by subst hk1eq; simpa using h2)
-    lia
+  grind [Set.InjOn]
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Algebra.GroupWithZero.Nat
 public import Mathlib.Algebra.Order.Group.Nat
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.Walk.Iterate
+public import Mathlib.GroupTheory.Perm.Cycle.Concrete
 
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
 
@@ -28,6 +30,38 @@ In this file we introduce Hamiltonian paths, cycles and graphs.
 open Finset Function
 
 namespace SimpleGraph
+
+section Perm
+
+open Equiv Equiv.Perm
+
+variable {α : Type*} [Fintype α]
+
+/-- For a cycle on `Finset.univ` with `Fintype.card α ≥ 3`, the edge `s((σ^k) x, (σ^(k+1)) x)`
+is distinct from `s(x, σ x)` when `1 ≤ k < Fintype.card α`. -/
+theorem edge_ne_of_isCycleOn {σ : Perm α} {x : α}
+    (hcycOn : σ.IsCycleOn (Finset.univ : Finset α))
+    {k : ℕ} (hk1 : 1 ≤ k) (hk2 : k < Fintype.card α)
+    (hn3 : 3 ≤ Fintype.card α) :
+    s((σ ^ k) x, (σ ^ (k + 1)) x) ≠ s(x, σ x) := by
+  have hinj := hcycOn.injOn_pow_apply (Finset.mem_univ x)
+  rw [Finset.card_univ] at hinj
+  intro heq
+  rw [Sym2.eq_iff] at heq
+  rcases heq with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- Injectivity: `(σ^k) x = (σ^0) x` gives `k = 0`, contradicts `1 ≤ k`
+    have : k = 0 := hinj (Finset.mem_range.mpr hk2)
+      (Finset.mem_range.mpr (by lia)) (by simpa using h1)
+    lia
+  · -- Injectivity: `(σ^k) x = (σ^1) x` gives `k = 1`,
+    -- then `(σ^2) x = (σ^0) x` gives `2 = 0`
+    have hk1eq : k = 1 := hinj (Finset.mem_range.mpr hk2)
+      (Finset.mem_range.mpr (by lia)) (by simpa using h1)
+    have : 2 = 0 := hinj (Finset.mem_range.mpr (by lia))
+      (Finset.mem_range.mpr (by lia)) (by subst hk1eq; simpa using h2)
+    lia
+
+end Perm
 
 variable {α : Type*} [DecidableEq α] {G : SimpleGraph α}
 variable {β : Type*} [DecidableEq β] {H : SimpleGraph β}
@@ -280,5 +314,55 @@ theorem IsBridge.not_isHamiltonian {e : Sym2 α} (he : G.IsBridge e) : ¬G.IsHam
   refine hp.isHamiltonian_tail.isPath.isTrail.not_mem_support_of_not_reachable
     (fun huv ↦ he.2 <| .trans ?_ huv) he.2 (hp.isHamiltonian_tail.mem_support v)
   apply hp.isTrail.isEdgeReachable_two <;> simp
+
+section Perm
+
+open Equiv Equiv.Perm
+
+variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
+
+/-- If `σ` is a cycle with full support on at least 3 elements and every step is
+a graph edge, then `G` is Hamiltonian. -/
+theorem IsHamiltonian.ofPerm {σ : Perm α}
+    (hcycle : σ.IsCycle) (hsupport : σ.support = Finset.univ)
+    (hadj : ∀ x, G.Adj x (σ x))
+    (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
+  intro _
+  obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support
+  have hx : σ x ≠ x := σ.mem_support.mp hx_mem
+  set n := Fintype.card α with hn_def
+  have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
+    hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
+  set p := (Walk.iterate (↑σ) hadj (σ x) (n - 1)).copy rfl (by
+    change (↑σ)^[n - 1 + 1] x = x
+    rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
+      hn_def, ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
+  set w := Walk.cons (hadj x) p
+  refine ⟨x, w, ?_⟩
+  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq]
+  constructor
+  · rw [Walk.cons_isCycle_iff]
+    constructor
+    · -- `p` is a path
+      rw [Walk.isPath_def]
+      simp only [p, Walk.support_copy, Walk.support_iterate,
+        show n - 1 + 1 = n by lia]
+      have hsx : σ (σ x) ≠ σ x := fun h => hx (σ.injective h)
+      have hcard : n = (σ.cycleOf (σ x)).support.card := by
+        rw [hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+      rw [hcard, ← List.range_map_iterate]
+      simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
+      exact σ.nodup_toList (σ x)
+    · -- `s(x, σ x) ∉ p.edges`
+      simp only [p, Walk.edges_copy, Walk.edges_iterate]
+      rw [List.mem_map]
+      rintro ⟨i, hi, heq⟩
+      rw [List.mem_range] at hi
+      simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
+      exact edge_ne_of_isCycleOn hcycOn (by lia) (by lia) hcard3 heq
+  · simp only [w, Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
+    lia
+
+end Perm
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -209,7 +209,8 @@ lemma isHamiltonianCycle_iff_isCycle_and_length_eq [Fintype α] :
   refine isHamiltonian_iff_isPath_and_length_eq.mpr ⟨h₁.isPath_tail, ?_⟩
   grind [length_tail_add_one, IsCycle.not_nil]
 
-/-- A Hamiltonian path closed into a cycle by an edge outside its support is a Hamiltonian cycle, and conversely. -/
+/-- A Hamiltonian path closed into a cycle by an edge outside its support is a Hamiltonian cycle,
+and conversely. -/
 theorem cons_isHamiltonianCycle_iff {x y : α} (h : G.Adj x y) (p : G.Walk y x) :
     (Walk.cons h p).IsHamiltonianCycle ↔ p.IsHamiltonian ∧ s(x, y) ∉ p.edges := by
   have htail : (cons h p).tail.IsHamiltonian ↔ p.IsHamiltonian := by

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -348,8 +348,8 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
       simp only [p, Walk.support_copy, Walk.support_iterate,
         show n - 1 + 1 = n by lia]
       have hsx : σ (σ x) ≠ σ x := fun h => hx (σ.injective h)
-      have hcard : n = (σ.cycleOf (σ x)).support.card := by
-        rw [hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+      have hcard : n = (σ.toList (σ x)).length := by
+        rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
       rw [hcard, ← List.range_map_iterate]
       simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
       exact σ.nodup_toList (σ x)

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -289,6 +289,39 @@ open Equiv Equiv.Perm
 
 variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
 
+/-- If `σ` is a cycle with full support on at least 3 elements and every step is a graph edge,
+then for any `x` with `σ^[n-1] (σ x) = x`, the walk
+`x → σ x → σ² x → ⋯ → σ^(n-1) x → x` is a Hamiltonian cycle. -/
+theorem isHamiltonianCycle_cons_iterate {σ : Perm α}
+    (hcycle : σ.IsCycle) (hsupport : σ.support = Finset.univ)
+    (hadj : ∀ x, G.Adj x (σ x)) (hcard3 : 3 ≤ Fintype.card α) (x : α)
+    (h : (↑σ : α → α)^[Fintype.card α - 1] (σ x) = x) :
+    (Walk.cons (hadj x)
+      ((Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl h)).IsHamiltonianCycle := by
+  have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
+    hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
+  have hx : σ x ≠ x := σ.mem_support.mp (hsupport ▸ Finset.mem_univ x)
+  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.cons_isCycle_iff]
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · rw [Walk.isPath_def]
+    simp only [Walk.support_copy, Walk.support_iterate,
+      show Fintype.card α - 1 + 1 = Fintype.card α by omega]
+    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
+    have hcard : Fintype.card α = (σ.toList (σ x)).length := by
+      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+    rw [hcard, ← List.range_map_iterate]
+    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
+    exact σ.nodup_toList (σ x)
+  · simp only [Walk.edges_copy, Walk.edges_iterate]
+    rw [List.mem_map]
+    rintro ⟨i, hi, heq⟩
+    rw [List.mem_range] at hi
+    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
+    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
+      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
+  · simp only [Walk.length_cons, Walk.length_copy, Walk.length_iterate]
+    omega
+
 /-- If `σ` is a cycle with full support on at least 3 elements and every step is
 a graph edge, then `G` is Hamiltonian. -/
 theorem IsHamiltonian.ofPerm {σ : Perm α}
@@ -296,35 +329,13 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     (hadj : ∀ x, G.Adj x (σ x))
     (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
   intro _
-  obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support
-  have hx : σ x ≠ x := σ.mem_support.mp hx_mem
-  set n := Fintype.card α with hn_def
+  obtain ⟨x, _⟩ := hcycle.nonempty_support
   have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
     hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
-  set p := (Walk.iterate (↑σ) hadj (σ x) (n - 1)).copy rfl (by
-    change (↑σ)^[n - 1 + 1] x = x
-    rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
-      hn_def, ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
-  refine ⟨x, .cons (hadj x) p, ?_⟩
-  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.cons_isCycle_iff]
-  refine ⟨⟨?_, ?_⟩, ?_⟩
-  · rw [Walk.isPath_def]
-    simp only [p, Walk.support_copy, Walk.support_iterate, show n - 1 + 1 = n by omega]
-    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
-    have hcard : n = (σ.toList (σ x)).length := by
-      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
-    rw [hcard, ← List.range_map_iterate]
-    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
-    exact σ.nodup_toList (σ x)
-  · simp only [p, Walk.edges_copy, Walk.edges_iterate]
-    rw [List.mem_map]
-    rintro ⟨i, hi, heq⟩
-    rw [List.mem_range] at hi
-    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
-      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
-  · simp only [Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
-    omega
+  refine ⟨x, _, isHamiltonianCycle_cons_iterate hcycle hsupport hadj hcard3 x ?_⟩
+  change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
+  rw [Nat.sub_add_cancel (by omega), Equiv.Perm.iterate_eq_pow,
+    ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)]
 
 end Perm
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -300,7 +300,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
 /-- Given a cyclic permutation with full support on at least 3 elements which
 sends each vertex to an adjacent one, then the graph is hamiltonian. -/
 theorem IsHamiltonian.ofPerm {σ : Perm α}
-    (hcycle : σ.IsCycle) (hsupport : σ.support = Finset.univ)
+    (hcycle : σ.IsCycle) (hsupport : σ.support = .univ)
     (hadj : ∀ x, G.Adj x (σ x))
     (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
   intro _

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -337,30 +337,24 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     change (↑σ)^[n - 1 + 1] x = x
     rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
       hn_def, ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
-  set w := Walk.cons (hadj x) p
-  refine ⟨x, w, ?_⟩
-  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq]
-  constructor
-  · rw [Walk.cons_isCycle_iff]
-    constructor
-    · -- `p` is a path
-      rw [Walk.isPath_def]
-      simp only [p, Walk.support_copy, Walk.support_iterate,
-        show n - 1 + 1 = n by lia]
-      have hsx : σ (σ x) ≠ σ x := fun h => hx (σ.injective h)
-      have hcard : n = (σ.toList (σ x)).length := by
-        rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
-      rw [hcard, ← List.range_map_iterate]
-      simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
-      exact σ.nodup_toList (σ x)
-    · -- `s(x, σ x) ∉ p.edges`
-      simp only [p, Walk.edges_copy, Walk.edges_iterate]
-      rw [List.mem_map]
-      rintro ⟨i, hi, heq⟩
-      rw [List.mem_range] at hi
-      simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-      exact edge_ne_of_isCycleOn hcycOn (by lia) (by lia) hcard3 heq
-  · simp only [w, Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
+  refine ⟨x, .cons (hadj x) p, ?_⟩
+  rw [Walk.isHamiltonianCycle_iff_isCycle_and_length_eq, Walk.cons_isCycle_iff]
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · rw [Walk.isPath_def]
+    simp only [p, Walk.support_copy, Walk.support_iterate, show n - 1 + 1 = n by lia]
+    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
+    have hcard : n = (σ.toList (σ x)).length := by
+      rw [Equiv.Perm.length_toList, hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+    rw [hcard, ← List.range_map_iterate]
+    simp only [Equiv.Perm.iterate_eq_pow, ← σ.toList_eq_range_map_pow]
+    exact σ.nodup_toList (σ x)
+  · simp only [p, Walk.edges_copy, Walk.edges_iterate]
+    rw [List.mem_map]
+    rintro ⟨i, hi, heq⟩
+    rw [List.mem_range] at hi
+    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
+    exact edge_ne_of_isCycleOn hcycOn (by lia) (by lia) hcard3 heq
+  · simp only [Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
     lia
 
 end Perm

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -31,29 +31,6 @@ open Finset Function
 
 namespace SimpleGraph
 
-section Perm
-
-open Equiv Equiv.Perm
-
-variable {α : Type*} [Fintype α]
-
-/-- For a cycle on `Finset.univ` with `Fintype.card α ≥ 3`, the edge `s((σ^k) x, (σ^(k+1)) x)`
-is distinct from `s(x, σ x)` when `1 ≤ k < Fintype.card α`. -/
-theorem edge_ne_of_isCycleOn {σ : Perm α} {x : α}
-    (hcycOn : σ.IsCycleOn (Finset.univ : Finset α))
-    {k : ℕ} (hk1 : 1 ≤ k) (hk2 : k < Fintype.card α)
-    (hn3 : 3 ≤ Fintype.card α) :
-    s((σ ^ k) x, (σ ^ (k + 1)) x) ≠ s(x, σ x) := by
-  have hinj := hcycOn.injOn_pow_apply (Finset.mem_univ x)
-  rw [Finset.card_univ] at hinj
-  have h0 : (σ ^ (0 : ℕ)) x = x := by simp
-  have h1 : (σ ^ (1 : ℕ)) x = σ x := by simp
-  intro heq
-  rw [Sym2.eq_iff] at heq
-  grind [Set.InjOn]
-
-end Perm
-
 variable {α : Type*} [DecidableEq α] {G : SimpleGraph α}
 variable {β : Type*} [DecidableEq β] {H : SimpleGraph β}
 variable {a b v : α} {p : G.Walk a b} {f : G →g H}
@@ -344,7 +321,8 @@ theorem IsHamiltonian.ofPerm {σ : Perm α}
     rintro ⟨i, hi, heq⟩
     rw [List.mem_range] at hi
     simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
-    exact edge_ne_of_isCycleOn hcycOn (by omega) (by omega) hcard3 heq
+    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by omega)
+      (by rw [Finset.card_univ]; omega) (by rwa [Finset.card_univ]) heq
   · simp only [Walk.length_cons, p, Walk.length_copy, Walk.length_iterate]
     omega
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
@@ -36,11 +36,11 @@ theorem IsHamiltonian.of_perm {σ : Perm α}
   have hx : σ x ≠ x := σ.mem_support.mp hx_mem
   have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
     hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
-  set p : G.Walk (σ x) x := (Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl (by
+  set p : G.Walk (σ x) x := (Walk.iterate (↑σ) (σ x) (Fintype.card α - 1) hadj).copy rfl (by
     change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
     rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
       ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
-  refine ⟨x, .cons (hadj x) p, Walk.cons_isHamiltonianCycle_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
+  refine ⟨x, .cons (hadj x) p, Walk.isHamiltonianCycle_cons_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
   · -- p is a Hamiltonian path: visits every vertex exactly once.
     rw [Walk.isHamiltonian_iff_isPath_and_length_eq]
     refine ⟨?_, by simp [p]⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
@@ -29,7 +29,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
 sends each vertex to an adjacent one, then the graph is hamiltonian. -/
 theorem IsHamiltonian.of_perm {σ : Perm α}
     (hcycle : σ.IsCycle) (hsupport : σ.support = .univ)
-    (hadj : ∀ x, G.Adj x (σ x))
+    (hadj : ∀ v, G.Adj v (σ v))
     (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
   intro _
   obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian/Perm.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Jesse Alama. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jesse Alama
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Hamiltonian
+public import Mathlib.Combinatorics.SimpleGraph.Walk.Iterate
+public import Mathlib.GroupTheory.Perm.Cycle.Concrete
+
+/-!
+# Hamiltonian graphs from cyclic permutations
+
+If `σ : Perm α` is a single cycle with full support, `3 ≤ #α`, and `G.Adj x (σ x)` for every
+`x`, then `G` is Hamiltonian. The witnessing walk is `Walk.iterate σ … x (#α − 1)` closed by
+the edge `s(x, σ x)`.
+-/
+
+public section
+
+open Finset Function Equiv Equiv.Perm
+
+namespace SimpleGraph
+
+variable {α : Type*} [Fintype α] [DecidableEq α] {G : SimpleGraph α}
+
+/-- Given a cyclic permutation with full support on at least 3 elements which
+sends each vertex to an adjacent one, then the graph is hamiltonian. -/
+theorem IsHamiltonian.of_perm {σ : Perm α}
+    (hcycle : σ.IsCycle) (hsupport : σ.support = .univ)
+    (hadj : ∀ x, G.Adj x (σ x))
+    (hcard3 : 3 ≤ Fintype.card α) : G.IsHamiltonian := by
+  intro _
+  obtain ⟨x, hx_mem⟩ := hcycle.nonempty_support
+  have hx : σ x ≠ x := σ.mem_support.mp hx_mem
+  have hcycOn : σ.IsCycleOn (Finset.univ : Finset α) :=
+    hsupport ▸ σ.coe_support_eq_set_support ▸ hcycle.isCycleOn
+  set p : G.Walk (σ x) x := (Walk.iterate (↑σ) hadj (σ x) (Fintype.card α - 1)).copy rfl (by
+    change (↑σ : α → α)^[Fintype.card α - 1 + 1] x = x
+    rw [Nat.sub_add_cancel (by lia), Equiv.Perm.iterate_eq_pow,
+      ← Finset.card_univ, hcycOn.pow_card_apply (Finset.mem_univ x)])
+  refine ⟨x, .cons (hadj x) p, Walk.cons_isHamiltonianCycle_iff (hadj x) p |>.mpr ⟨?_, ?_⟩⟩
+  · -- p is a Hamiltonian path: visits every vertex exactly once.
+    rw [Walk.isHamiltonian_iff_isPath_and_length_eq]
+    refine ⟨?_, by simp [p]⟩
+    rw [Walk.isPath_def]
+    simp only [p, Walk.support_copy, Walk.support_iterate,
+      show Fintype.card α - 1 + 1 = Fintype.card α by lia]
+    have hsx : σ (σ x) ≠ σ x := σ.injective.ne hx
+    have hcard : Fintype.card α = (cycleOf σ (σ x)).support.card := by
+      rw [hcycle.cycleOf_eq hsx, hsupport, Finset.card_univ]
+    rw [hcard, ← List.range_map_iterate]
+    simp only [Equiv.Perm.iterate_eq_pow]
+    rw [← σ.toList_eq_range_map_pow]
+    exact σ.nodup_toList (σ x)
+  · -- The closure edge `s(x, σ x)` is not already used in `p`.
+    simp only [p, Walk.edges_copy, Walk.edges_iterate]
+    rw [List.mem_map]
+    rintro ⟨i, hi, heq⟩
+    rw [List.mem_range] at hi
+    simp only [Equiv.Perm.iterate_eq_pow, ← mul_apply, ← pow_succ] at heq
+    exact hcycOn.sym2_pow_apply_ne (Finset.mem_univ x) (by lia)
+      (by rw [Finset.card_univ]; lia) (by rw [Finset.card_univ]; lia) heq
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -28,7 +28,7 @@ variable {α : Type*} {G : SimpleGraph α}
 /-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
 given that each step is adjacent in `G`. -/
 def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
-  (Walk.ofSupport _ (by simp) (List.isChain_iterate x (n + 1) hadj)).copy rfl
+  (Walk.ofSupport _ (by simp) (List.isChain_iterate x hadj (n + 1))).copy rfl
     (List.getLast_iterate f x n (by simp))
 
 /-- The walk built by `Walk.iterate` has length `n`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -37,11 +37,11 @@ theorem length_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : 
     (iterate f hadj v n).length = n := by
   simp [iterate, -List.iterate]
 
-/-- The support of `Walk.iterate` is `[x, f x, f^[2] x, ..., f^[n] x]`. -/
+/-- The support of `Walk.iterate` is `[v, f v, f^[2] v, ..., f^[n] v]`. -/
 @[simp]
-theorem support_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
-    (iterate f hadj x n).support = List.iterate f x (n + 1) := by
-  simp only [iterate, support_copy, support_ofSupport]
+theorem support_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
+    (iterate f hadj v n).support = List.iterate f v (n + 1) := by
+  simp [iterate, -List.iterate]
 
 /-- The edges of `Walk.iterate` are `s(f^[i] x, f^[i+1] x)` for `i < n`. -/
 theorem edges_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Jesse Alama. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jesse Alama
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Walk.Operations
+public import Mathlib.Data.List.Iterate
+
+/-!
+# Walks from iterated functions
+
+Given a function `f : α → α` such that `G.Adj x (f x)` for all `x`,
+we construct a walk of length `n` from `x` to `f^[n] x`.
+-/
+
+@[expose] public section
+
+open Function
+
+namespace SimpleGraph
+
+namespace Walk
+
+variable {α : Type*} {G : SimpleGraph α}
+
+/-- The list `List.iterate f x (n + 1)` is a chain under `G.Adj` when every step is adjacent. -/
+theorem isChain_adj_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
+    (List.iterate f x (n + 1)).IsChain G.Adj := by
+  simp only [List.isChain_iff_getElem, List.getElem_iterate, iterate_succ']
+  exact fun _ _ => hadj _
+
+/-- The last element of `List.iterate f x (n + 1)` is `f^[n] x`. -/
+theorem getLast_iterate (f : α → α) (x : α) (n : ℕ)
+    (h : List.iterate f x (n + 1) ≠ []) :
+    (List.iterate f x (n + 1)).getLast h = f^[n] x := by
+  rw [List.getLast_eq_getElem, List.getElem_iterate]
+  simp [List.length_iterate]
+
+/-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
+given that each step is adjacent in `G`. -/
+def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
+  (Walk.ofSupport _ (by simp) (isChain_adj_iterate f hadj x n)).copy rfl
+    (getLast_iterate f x n (by simp))
+
+/-- The walk built by `Walk.iterate` has length `n`. -/
+@[simp]
+theorem length_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
+    (iterate f hadj x n).length = n := by
+  simp only [iterate, length_copy, length_ofSupport, List.length_iterate, Nat.add_sub_cancel]
+
+/-- The support of `Walk.iterate` is `[x, f x, f^[2] x, ..., f^[n] x]`. -/
+@[simp]
+theorem support_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
+    (iterate f hadj x n).support = List.iterate f x (n + 1) := by
+  simp only [iterate, support_copy, support_ofSupport]
+
+/-- The edges of `Walk.iterate` are `s(f^[i] x, f^[i+1] x)` for `i < n`. -/
+theorem edges_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
+    (iterate f hadj x n).edges = (List.range n).map fun i ↦ s(f^[i] x, f^[i + 1] x) := by
+  simp only [edges_eq_zipWith_support, support_iterate]
+  induction n generalizing x with
+  | zero => simp
+  | succ n ih =>
+    simp only [List.iterate, List.zipWith, List.tail_cons, List.range_succ_eq_map,
+      List.map_cons, iterate_zero, id_eq, List.map_map]
+    congr 1
+    convert ih (f x) using 1
+
+end Walk
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -27,25 +27,25 @@ variable {α : Type*} {G : SimpleGraph α}
 
 /-- Build a walk of length `n` from `v` to `f^[n] v` following `f`,
 given that each step is adjacent in `G`. -/
-def iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : α) (n : ℕ) : G.Walk v (f^[n] v) :=
+def iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) : G.Walk v (f^[n] v) :=
   (Walk.ofSupport _ (by simp) <| .iterate v hadj <| n + 1).copy rfl <|
     List.getLast_iterate f v (n + 1) <| by simp
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]
-theorem length_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
-    (iterate f hadj v n).length = n := by
+theorem length_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+    (iterate f v n hadj).length = n := by
   simp [iterate, -List.iterate]
 
 /-- The support of `Walk.iterate` is `[v, f v, f^[2] v, ..., f^[n] v]`. -/
 @[simp]
-theorem support_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
-    (iterate f hadj v n).support = List.iterate f v (n + 1) := by
+theorem support_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+    (iterate f v n hadj).support = List.iterate f v (n + 1) := by
   simp [iterate, -List.iterate]
 
 /-- The edges of `Walk.iterate` are `s(f^[i] v, f^[i+1] v)` for `i < n`. -/
-theorem edges_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
-    (iterate f hadj v n).edges = (List.range n).map fun i ↦ s(f^[i] v, f^[i + 1] v) := by
+theorem edges_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+    (iterate f v n hadj).edges = (List.range n).map fun i ↦ s(f^[i] v, f^[i + 1] v) := by
   rw [edges_eq_zipWith_support, support_iterate]
   induction n generalizing v with
   | zero => simp

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -25,16 +25,10 @@ namespace Walk
 
 variable {α : Type*} {G : SimpleGraph α}
 
-/-- The list `List.iterate f x (n + 1)` is a chain under `G.Adj` when every step is adjacent. -/
-theorem isChain_adj_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
-    (List.iterate f x (n + 1)).IsChain G.Adj := by
-  simp only [List.isChain_iff_getElem, List.getElem_iterate, iterate_succ']
-  exact fun _ _ => hadj _
-
 /-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
 given that each step is adjacent in `G`. -/
 def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
-  (Walk.ofSupport _ (by simp) (isChain_adj_iterate f hadj x n)).copy rfl
+  (Walk.ofSupport _ (by simp) (List.isChain_iterate hadj x (n + 1))).copy rfl
     (List.getLast_iterate f x n (by simp))
 
 /-- The walk built by `Walk.iterate` has length `n`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -25,11 +25,11 @@ namespace Walk
 
 variable {α : Type*} {G : SimpleGraph α}
 
-/-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
+/-- Build a walk of length `n` from `v` to `f^[n] v` following `f`,
 given that each step is adjacent in `G`. -/
-def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
-  (Walk.ofSupport _ (by simp) (List.IsChain.iterate x hadj (n + 1))).copy rfl
-    (List.getLast_iterate f x (n + 1) (by simp))
+def iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : α) (n : ℕ) : G.Walk v (f^[n] v) :=
+  (Walk.ofSupport _ (by simp) <| .iterate v hadj <| n + 1).copy rfl <|
+    List.getLast_iterate f v (n + 1) <| by simp
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -28,7 +28,7 @@ variable {α : Type*} {G : SimpleGraph α}
 /-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
 given that each step is adjacent in `G`. -/
 def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
-  (Walk.ofSupport _ (by simp) (List.isChain_iterate hadj x (n + 1))).copy rfl
+  (Walk.ofSupport _ (by simp) (List.isChain_iterate x (n + 1) hadj)).copy rfl
     (List.getLast_iterate f x n (by simp))
 
 /-- The walk built by `Walk.iterate` has length `n`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -43,17 +43,13 @@ theorem support_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n :
     (iterate f hadj v n).support = List.iterate f v (n + 1) := by
   simp [iterate, -List.iterate]
 
-/-- The edges of `Walk.iterate` are `s(f^[i] x, f^[i+1] x)` for `i < n`. -/
-theorem edges_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
-    (iterate f hadj x n).edges = (List.range n).map fun i ↦ s(f^[i] x, f^[i + 1] x) := by
-  simp only [edges_eq_zipWith_support, support_iterate]
-  induction n generalizing x with
+/-- The edges of `Walk.iterate` are `s(f^[i] v, f^[i+1] v)` for `i < n`. -/
+theorem edges_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
+    (iterate f hadj v n).edges = (List.range n).map fun i ↦ s(f^[i] v, f^[i + 1] v) := by
+  rw [edges_eq_zipWith_support, support_iterate]
+  induction n generalizing v with
   | zero => simp
-  | succ n ih =>
-    simp only [List.iterate, List.zipWith, List.tail_cons, List.range_succ_eq_map,
-      List.map_cons, iterate_zero, id_eq, List.map_map]
-    congr 1
-    convert ih (f x) using 1
+  | succ n ih => simpa [List.range_succ_eq_map] using congr(s(v, f v) :: $(ih <| f v))
 
 end Walk
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -15,7 +15,7 @@ Given a function `f : α → α` such that `G.Adj x (f x)` for all `x`,
 we construct a walk of length `n` from `x` to `f^[n] x`.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -33,9 +33,9 @@ def iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : α) (n : ℕ) : G.W
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]
-theorem length_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) :
-    (iterate f hadj x n).length = n := by
-  simp only [iterate, length_copy, length_ofSupport, List.length_iterate, Nat.add_sub_cancel]
+theorem length_iterate (f : V → V) (hadj : ∀ v, G.Adj v (f v)) (v : V) (n : ℕ) :
+    (iterate f hadj v n).length = n := by
+  simp [iterate, -List.iterate]
 
 /-- The support of `Walk.iterate` is `[x, f x, f^[2] x, ..., f^[n] x]`. -/
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -28,8 +28,8 @@ variable {α : Type*} {G : SimpleGraph α}
 /-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
 given that each step is adjacent in `G`. -/
 def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
-  (Walk.ofSupport _ (by simp) (List.isChain_iterate x hadj (n + 1))).copy rfl
-    (List.getLast_iterate f x n (by simp))
+  (Walk.ofSupport _ (by simp) (List.IsChain.iterate x hadj (n + 1))).copy rfl
+    (List.getLast_iterate f x (n + 1) (by simp))
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -23,7 +23,7 @@ namespace SimpleGraph
 
 namespace Walk
 
-variable {α : Type*} {G : SimpleGraph α}
+variable {V : Type*} {G : SimpleGraph α}
 
 /-- Build a walk of length `n` from `v` to `f^[n] v` following `f`,
 given that each step is adjacent in `G`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -31,18 +31,11 @@ theorem isChain_adj_iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : �
   simp only [List.isChain_iff_getElem, List.getElem_iterate, iterate_succ']
   exact fun _ _ => hadj _
 
-/-- The last element of `List.iterate f x (n + 1)` is `f^[n] x`. -/
-theorem getLast_iterate (f : α → α) (x : α) (n : ℕ)
-    (h : List.iterate f x (n + 1) ≠ []) :
-    (List.iterate f x (n + 1)).getLast h = f^[n] x := by
-  rw [List.getLast_eq_getElem, List.getElem_iterate]
-  simp [List.length_iterate]
-
 /-- Build a walk of length `n` from `x` to `f^[n] x` following `f`,
 given that each step is adjacent in `G`. -/
 def iterate (f : α → α) (hadj : ∀ x, G.Adj x (f x)) (x : α) (n : ℕ) : G.Walk x (f^[n] x) :=
   (Walk.ofSupport _ (by simp) (isChain_adj_iterate f hadj x n)).copy rfl
-    (getLast_iterate f x n (by simp))
+    (List.getLast_iterate f x n (by simp))
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.List.Iterate
 /-!
 # Walks from iterated functions
 
-Given a function `f : α → α` such that `G.Adj x (f x)` for all `x`,
+Given a function `f : V → V` such that `G.Adj x (f x)` for all `x`,
 we construct a walk of length `n` from `x` to `f^[n] x`.
 -/
 
@@ -23,28 +23,28 @@ namespace SimpleGraph
 
 namespace Walk
 
-variable {V : Type*} {G : SimpleGraph α}
+variable {V : Type*} {G : SimpleGraph V}
 
 /-- Build a walk of length `n` from `v` to `f^[n] v` following `f`,
 given that each step is adjacent in `G`. -/
-def iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) : G.Walk v (f^[n] v) :=
+def iterate (f : V → V) (v : V) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) : G.Walk v (f^[n] v) :=
   (Walk.ofSupport _ (by simp) <| .iterate v hadj <| n + 1).copy rfl <|
     List.getLast_iterate f v (n + 1) <| by simp
 
 /-- The walk built by `Walk.iterate` has length `n`. -/
 @[simp]
-theorem length_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+theorem length_iterate (f : V → V) (v : V) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
     (iterate f v n hadj).length = n := by
   simp [iterate, -List.iterate]
 
 /-- The support of `Walk.iterate` is `[v, f v, f^[2] v, ..., f^[n] v]`. -/
 @[simp]
-theorem support_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+theorem support_iterate (f : V → V) (v : V) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
     (iterate f v n hadj).support = List.iterate f v (n + 1) := by
   simp [iterate, -List.iterate]
 
 /-- The edges of `Walk.iterate` are `s(f^[i] v, f^[i+1] v)` for `i < n`. -/
-theorem edges_iterate (f : α → α) (v : α) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
+theorem edges_iterate (f : V → V) (v : V) (n : ℕ) (hadj : ∀ v, G.Adj v (f v)) :
     (iterate f v n hadj).edges = (List.range n).map fun i ↦ s(f^[i] v, f^[i + 1] v) := by
   rw [edges_eq_zipWith_support, support_iterate]
   induction n generalizing v with

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -443,14 +443,11 @@ theorem isChain_replicate_of_rel (n : ℕ) {a : α} (h : r a a) : IsChain r (rep
   induction n using Nat.twoStepInduction <;> grind
 
 /-- If `r a (f a)` holds for every `a`, then `List.iterate f a n` is a chain under `r`. -/
-theorem isChain_iterate {f : α → α} (a : α) (n : ℕ) (h : ∀ a, r a (f a)) :
-    IsChain r (iterate f a n) := by
-  induction n generalizing a with
-  | zero => exact .nil
-  | succ n ih =>
-    match n with
-    | 0 => exact .singleton _
-    | n + 1 => exact .cons_cons (h a) (ih (f a))
+theorem isChain_iterate {f : α → α} (a : α) (h : ∀ a, r a (f a)) :
+    ∀ n, IsChain r (iterate f a n)
+  | 0 => .nil
+  | 1 => .singleton _
+  | n + 2 => .cons_cons (h a) (isChain_iterate (f a) h (n + 1))
 
 theorem isChain_eq_iff_eq_replicate {l : List α} :
     IsChain (· = ·) l ↔ ∀ a ∈ l.head?, l = replicate l.length a := by

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -442,6 +442,16 @@ lemma IsChain.iterate_eq_of_apply_eq {α : Type*} {f : α → α} {l : List α}
 theorem isChain_replicate_of_rel (n : ℕ) {a : α} (h : r a a) : IsChain r (replicate n a) := by
   induction n using Nat.twoStepInduction <;> grind
 
+/-- If `r a (f a)` holds for every `a`, then `List.iterate f a n` is a chain under `r`. -/
+theorem isChain_iterate {f : α → α} (h : ∀ a, r a (f a)) (a : α) (n : ℕ) :
+    IsChain r (iterate f a n) := by
+  induction n generalizing a with
+  | zero => exact .nil
+  | succ n ih =>
+    match n with
+    | 0 => exact .singleton _
+    | n + 1 => exact .cons_cons (h a) (ih (f a))
+
 theorem isChain_eq_iff_eq_replicate {l : List α} :
     IsChain (· = ·) l ↔ ∀ a ∈ l.head?, l = replicate l.length a := by
   induction l using twoStepInduction with

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -443,7 +443,7 @@ theorem isChain_replicate_of_rel (n : ℕ) {a : α} (h : r a a) : IsChain r (rep
   induction n using Nat.twoStepInduction <;> grind
 
 /-- If `r a (f a)` holds for every `a`, then `List.iterate f a n` is a chain under `r`. -/
-theorem isChain_iterate {f : α → α} (a : α) (h : ∀ a, r a (f a)) :
+protected theorem IsChain.iterate {f : α → α} (a : α) (h : ∀ a, r a (f a)) :
     ∀ n, IsChain r (iterate f a n)
   | 0 => .nil
   | 1 => .singleton _

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -447,7 +447,7 @@ protected theorem IsChain.iterate {f : α → α} (a : α) (h : ∀ a, r a (f a)
     ∀ n, IsChain r (iterate f a n)
   | 0 => .nil
   | 1 => .singleton _
-  | n + 2 => .cons_cons (h a) (isChain_iterate (f a) h (n + 1))
+  | n + 2 => .cons_cons (h a) (IsChain.iterate (f a) h (n + 1))
 
 theorem isChain_eq_iff_eq_replicate {l : List α} :
     IsChain (· = ·) l ↔ ∀ a ∈ l.head?, l = replicate l.length a := by

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -443,7 +443,7 @@ theorem isChain_replicate_of_rel (n : ℕ) {a : α} (h : r a a) : IsChain r (rep
   induction n using Nat.twoStepInduction <;> grind
 
 /-- If `r a (f a)` holds for every `a`, then `List.iterate f a n` is a chain under `r`. -/
-theorem isChain_iterate {f : α → α} (h : ∀ a, r a (f a)) (a : α) (n : ℕ) :
+theorem isChain_iterate {f : α → α} (a : α) (n : ℕ) (h : ∀ a, r a (f a)) :
     IsChain r (iterate f a n) := by
   induction n generalizing a with
   | zero => exact .nil

--- a/Mathlib/Data/List/Iterate.lean
+++ b/Mathlib/Data/List/Iterate.lean
@@ -38,8 +38,8 @@ theorem getElem_iterate (f : α → α) (a : α) (n : ℕ) (i : Nat) (h : i < (i
     (iterate f a n)[i] = f^[i] a :=
   (getElem_eq_iff _).2 <| getElem?_iterate _ _ _ _ <| by rwa [length_iterate] at h
 
-theorem getLast_iterate (f : α → α) (a : α) (n : ℕ) (h : iterate f a (n + 1) ≠ []) :
-    (iterate f a (n + 1)).getLast h = f^[n] a := by
+theorem getLast_iterate (f : α → α) (a : α) (n : ℕ) (h : iterate f a n ≠ []) :
+    (iterate f a n).getLast h = f^[n - 1] a := by
   rw [getLast_eq_getElem, getElem_iterate]
   simp
 

--- a/Mathlib/Data/List/Iterate.lean
+++ b/Mathlib/Data/List/Iterate.lean
@@ -38,6 +38,11 @@ theorem getElem_iterate (f : α → α) (a : α) (n : ℕ) (i : Nat) (h : i < (i
     (iterate f a n)[i] = f^[i] a :=
   (getElem_eq_iff _).2 <| getElem?_iterate _ _ _ _ <| by rwa [length_iterate] at h
 
+theorem getLast_iterate (f : α → α) (a : α) (n : ℕ) (h : iterate f a (n + 1) ≠ []) :
+    (iterate f a (n + 1)).getLast h = f^[n] a := by
+  rw [getLast_eq_getElem, getElem_iterate]
+  simp
+
 @[simp]
 theorem mem_iterate {f : α → α} {a : α} {n : ℕ} {b : α} :
     b ∈ iterate f a n ↔ ∃ m < n, b = f^[m] a := by

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -773,6 +773,12 @@ theorem IsCycleOn.zpow_apply_eq_zpow_apply {s : Finset α} (hf : f.IsCycleOn s) 
   rw [Int.modEq_iff_dvd, ← hf.zpow_apply_eq ha]
   simp [sub_eq_neg_add, zpow_add, eq_symm_apply, eq_comm]
 
+/-- The map `n ↦ (f ^ n) a` is injective on `Finset.range #s` when `f.IsCycleOn s`
+and `a ∈ s`. -/
+theorem IsCycleOn.injOn_pow_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s) :
+    Set.InjOn (fun n ↦ (f ^ n) a) (Finset.range #s) := by
+  grind [Set.InjOn, IsCycleOn.pow_apply_eq_pow_apply hf ha, Nat.ModEq.eq_of_lt_of_lt]
+
 theorem IsCycleOn.pow_card_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s) :
     (f ^ #s) a = a :=
   (hf.pow_apply_eq ha).2 dvd_rfl

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -776,7 +776,7 @@ theorem IsCycleOn.zpow_apply_eq_zpow_apply {s : Finset α} (hf : f.IsCycleOn s) 
 /-- The map `n ↦ (f ^ n) a` is injective on `Finset.range #s` when `f.IsCycleOn s`
 and `a ∈ s`. -/
 theorem IsCycleOn.injOn_pow_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s) :
-    Set.InjOn (fun n ↦ (f ^ n) a) (Finset.range #s) := by
+    Set.InjOn (fun n ↦ (f ^ n) a) (.Iio #s) := by
   grind [Set.InjOn, IsCycleOn.pow_apply_eq_pow_apply hf ha, Nat.ModEq.eq_of_lt_of_lt]
 
 theorem IsCycleOn.pow_card_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s) :

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -196,12 +196,12 @@ theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
   · exact hf.injOn_pow_apply ha hj hk h1
   -- Swapped case: `j ≡ k + 1` and `j + 1 ≡ k` give `s.card ∣ 2`, forcing `s.card = 1`.
   rw [hf.pow_apply_eq_pow_apply ha] at h1 h2
-  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by omega) <| by
+  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by lia) <| by
     simpa using (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp
       ((h1.symm.add_right 1).trans h2).symm
   have hj_lt : j < s.card := hj
   have hk_lt : k < s.card := hk
-  omega
+  lia
 
 /-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the unordered
 pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `k ≠ 0` and `k < s.card`. -/

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -206,7 +206,7 @@ theorem length_toList : length (toList p x) = (cycleOf p x).support.card := by s
 
 /-- `toList` expressed as a map of powers: `toList p x = [x, p x, p² x, …]`. -/
 theorem toList_eq_range_map_pow :
-    toList p x = (List.range (cycleOf p x).support.card).map fun i => (p ^ i) x := by
+    toList p x = (List.range (toList p x).length).map fun i => (p ^ i) x := by
   simp [toList, ← List.range_map_iterate, iterate_eq_pow]
 
 theorem toList_ne_singleton (y : α) : toList p x ≠ [y] := by

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -186,10 +186,10 @@ end Cycle
 namespace Equiv.Perm
 
 /-- For a cycle `f` on a finset `s` of cardinality at least 3 and `a ∈ s`, the unordered
-pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `1 ≤ k < s.card`. -/
+pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `k ≠ 0` and `k < s.card`. -/
 theorem IsCycleOn.sym2_pow_apply_ne {f : Perm α} {a : α} {s : Finset α}
     (hcycOn : f.IsCycleOn s) (ha : a ∈ s)
-    {k : ℕ} (hk1 : 1 ≤ k) (hk2 : k < s.card) (hs : 3 ≤ s.card) :
+    {k : ℕ} (hk1 : k ≠ 0) (hk2 : k < s.card) (hs : 3 ≤ s.card) :
     s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a) := by
   have hinj := hcycOn.injOn_pow_apply ha
   have h0 : (f ^ (0 : ℕ)) a = a := by simp

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -188,22 +188,17 @@ namespace Equiv.Perm
 /-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the map
 `k ↦ s((f ^ k) a, (f ^ (k + 1)) a)` is injective on `[0, s.card)`. -/
 theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
-    (hcycOn : f.IsCycleOn s) (ha : a ∈ s) (hs : s.card ≠ 2) :
+    (hf : f.IsCycleOn s) (ha : a ∈ s) (hs : s.card ≠ 2) :
     Set.InjOn (fun k ↦ s((f ^ k) a, (f ^ (k + 1)) a)) (Set.Iio s.card) := by
   intro j hj k hk heq
   rw [Sym2.eq_iff] at heq
   obtain ⟨h1, _⟩ | ⟨h1, h2⟩ := heq
-  · exact hcycOn.injOn_pow_apply ha hj hk h1
-  -- Swapped case: derive `s.card ∣ 2`, then since `s.card ≠ 2` and `0 < s.card`,
-  -- we have `s.card = 1`, and so `j = k = 0`.
-  have h1' : j ≡ k + 1 [MOD s.card] := (hcycOn.pow_apply_eq_pow_apply ha).mp h1
-  have h2' : j + 1 ≡ k [MOD s.card] := (hcycOn.pow_apply_eq_pow_apply ha).mp h2
-  have h12 : k + 2 ≡ k [MOD s.card] := (h1'.symm.add_right 1).trans h2'
-  have h_dvd : s.card ∣ 2 := by
-    have := (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp h12.symm
-    simpa using this
-  have h_pos : 0 < s.card := Finset.card_pos.mpr ⟨a, ha⟩
-  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by omega) h_dvd
+  · exact hf.injOn_pow_apply ha hj hk h1
+  -- Swapped case: `j ≡ k + 1` and `j + 1 ≡ k` give `s.card ∣ 2`, forcing `s.card = 1`.
+  rw [hf.pow_apply_eq_pow_apply ha] at h1 h2
+  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by omega) <| by
+    simpa using (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp
+      ((h1.symm.add_right 1).trans h2).symm
   have hj_lt : j < s.card := hj
   have hk_lt : k < s.card := hk
   omega
@@ -211,14 +206,10 @@ theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
 /-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the unordered
 pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `k ≠ 0` and `k < s.card`. -/
 theorem IsCycleOn.sym2_pow_apply_ne {f : Perm α} {a : α} {s : Finset α}
-    (hcycOn : f.IsCycleOn s) (ha : a ∈ s)
+    (hf : f.IsCycleOn s) (ha : a ∈ s)
     {k : ℕ} (hk1 : k ≠ 0) (hk2 : k < s.card) (hs : s.card ≠ 2) :
-    s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a) := by
-  intro heq
-  apply hk1
-  have h_pos : 0 < s.card := Finset.card_pos.mpr ⟨a, ha⟩
-  have hzero : (fun n ↦ s((f ^ n) a, (f ^ (n + 1)) a)) 0 = s(a, f a) := by simp
-  exact hcycOn.injOn_sym2_pow_apply ha hs hk2 (Set.mem_Iio.mpr h_pos) (heq.trans hzero.symm)
+    s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a) := fun heq ↦ hk1 <|
+  hf.injOn_sym2_pow_apply ha hs hk2 (Finset.card_pos.mpr ⟨a, ha⟩) (by simpa using heq)
 
 section Fintype
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -196,7 +196,7 @@ theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
   · exact hf.injOn_pow_apply ha hj hk h1
   -- Swapped case: `j ≡ k + 1` and `j + 1 ≡ k` give `s.card ∣ 2`, forcing `s.card = 1`.
   rw [hf.pow_apply_eq_pow_apply ha] at h1 h2
-  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by lia) <| by
+  have : s.card ≤ 2 := Nat.le_of_dvd (by lia) <| by
     simpa using (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp
       ((h1.symm.add_right 1).trans h2).symm
   grind

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -185,18 +185,40 @@ end Cycle
 
 namespace Equiv.Perm
 
-/-- For a cycle `f` on a finset `s` of cardinality at least 3 and `a ∈ s`, the unordered
+/-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the map
+`k ↦ s((f ^ k) a, (f ^ (k + 1)) a)` is injective on `[0, s.card)`. -/
+theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
+    (hcycOn : f.IsCycleOn s) (ha : a ∈ s) (hs : s.card ≠ 2) :
+    Set.InjOn (fun k ↦ s((f ^ k) a, (f ^ (k + 1)) a)) (Set.Iio s.card) := by
+  intro j hj k hk heq
+  rw [Sym2.eq_iff] at heq
+  obtain ⟨h1, _⟩ | ⟨h1, h2⟩ := heq
+  · exact hcycOn.injOn_pow_apply ha hj hk h1
+  -- Swapped case: derive `s.card ∣ 2`, then since `s.card ≠ 2` and `0 < s.card`,
+  -- we have `s.card = 1`, and so `j = k = 0`.
+  have h1' : j ≡ k + 1 [MOD s.card] := (hcycOn.pow_apply_eq_pow_apply ha).mp h1
+  have h2' : j + 1 ≡ k [MOD s.card] := (hcycOn.pow_apply_eq_pow_apply ha).mp h2
+  have h12 : k + 2 ≡ k [MOD s.card] := (h1'.symm.add_right 1).trans h2'
+  have h_dvd : s.card ∣ 2 := by
+    have := (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp h12.symm
+    simpa using this
+  have h_pos : 0 < s.card := Finset.card_pos.mpr ⟨a, ha⟩
+  have h_le : s.card ≤ 2 := Nat.le_of_dvd (by omega) h_dvd
+  have hj_lt : j < s.card := hj
+  have hk_lt : k < s.card := hk
+  omega
+
+/-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the unordered
 pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `k ≠ 0` and `k < s.card`. -/
 theorem IsCycleOn.sym2_pow_apply_ne {f : Perm α} {a : α} {s : Finset α}
     (hcycOn : f.IsCycleOn s) (ha : a ∈ s)
-    {k : ℕ} (hk1 : k ≠ 0) (hk2 : k < s.card) (hs : 3 ≤ s.card) :
+    {k : ℕ} (hk1 : k ≠ 0) (hk2 : k < s.card) (hs : s.card ≠ 2) :
     s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a) := by
-  have hinj := hcycOn.injOn_pow_apply ha
-  have h0 : (f ^ (0 : ℕ)) a = a := by simp
-  have h1 : (f ^ (1 : ℕ)) a = f a := by simp
   intro heq
-  rw [Sym2.eq_iff] at heq
-  grind [Set.InjOn]
+  apply hk1
+  have h_pos : 0 < s.card := Finset.card_pos.mpr ⟨a, ha⟩
+  have hzero : (fun n ↦ s((f ^ n) a, (f ^ (n + 1)) a)) 0 = s(a, f a) := by simp
+  exact hcycOn.injOn_sym2_pow_apply ha hs hk2 (Set.mem_Iio.mpr h_pos) (heq.trans hzero.symm)
 
 section Fintype
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -219,7 +219,7 @@ theorem length_toList : length (toList p x) = (cycleOf p x).support.card := by s
 
 /-- `toList` expressed as a map of powers: `toList p x = [x, p x, p² x, …]`. -/
 theorem toList_eq_range_map_pow :
-    toList p x = (List.range (toList p x).length).map fun i => (p ^ i) x := by
+    toList p x = (List.range (cycleOf p x).support.card).map fun i => (p ^ i) x := by
   simp [toList, ← List.range_map_iterate, iterate_eq_pow]
 
 theorem toList_ne_singleton (y : α) : toList p x ≠ [y] := by

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -185,6 +185,19 @@ end Cycle
 
 namespace Equiv.Perm
 
+/-- For a cycle `f` on a finset `s` of cardinality at least 3 and `a ∈ s`, the unordered
+pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `1 ≤ k < s.card`. -/
+theorem IsCycleOn.sym2_pow_apply_ne {f : Perm α} {a : α} {s : Finset α}
+    (hcycOn : f.IsCycleOn s) (ha : a ∈ s)
+    {k : ℕ} (hk1 : 1 ≤ k) (hk2 : k < s.card) (hs : 3 ≤ s.card) :
+    s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a) := by
+  have hinj := hcycOn.injOn_pow_apply ha
+  have h0 : (f ^ (0 : ℕ)) a = a := by simp
+  have h1 : (f ^ (1 : ℕ)) a = f a := by simp
+  intro heq
+  rw [Sym2.eq_iff] at heq
+  grind [Set.InjOn]
+
 section Fintype
 
 variable [Fintype α] [DecidableEq α] (p : Equiv.Perm α) (x : α)

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -204,6 +204,11 @@ theorem toList_eq_nil_iff {p : Perm α} {x} : toList p x = [] ↔ x ∉ p.suppor
 @[simp]
 theorem length_toList : length (toList p x) = (cycleOf p x).support.card := by simp [toList]
 
+/-- `toList` expressed as a map of powers: `toList p x = [x, p x, p² x, …]`. -/
+theorem toList_eq_range_map_pow :
+    toList p x = (List.range (cycleOf p x).support.card).map fun i => (p ^ i) x := by
+  simp [toList, ← List.range_map_iterate, iterate_eq_pow]
+
 theorem toList_ne_singleton (y : α) : toList p x ≠ [y] := by
   intro H
   simpa [card_support_ne_one] using congr_arg length H

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -199,9 +199,7 @@ theorem IsCycleOn.injOn_sym2_pow_apply {f : Perm α} {a : α} {s : Finset α}
   have h_le : s.card ≤ 2 := Nat.le_of_dvd (by lia) <| by
     simpa using (Nat.modEq_iff_dvd' (Nat.le_add_right k 2)).mp
       ((h1.symm.add_right 1).trans h2).symm
-  have hj_lt : j < s.card := hj
-  have hk_lt : k < s.card := hk
-  lia
+  grind
 
 /-- For a cycle `f` on a finset `s` of cardinality not equal to `2` and `a ∈ s`, the unordered
 pair `s((f ^ k) a, (f ^ (k + 1)) a)` differs from `s(a, f a)` when `k ≠ 0` and `k < s.card`. -/


### PR DESCRIPTION
This PR provides `IsHamiltonian.of_perm`, a bridge from `Equiv.Perm.IsCycle` to `SimpleGraph.IsHamiltonian`: if σ is a permutation that is a single cycle with full support on at least 3 elements, and each step `v → σ v` is an edge of `G`, then `G` is Hamiltonian.

### New definitions and lemmas

**`Mathlib/Data/List/Chain.lean`**:
- `IsChain.iterate`: `List.iterate f a n` is a chain under `r` whenever `r a (f a)` holds for all `a`

**`Mathlib/Data/List/Iterate.lean`**:
- `getLast_iterate`: the last element of `List.iterate f a n` is `f^[n - 1] a`

**`Mathlib/Combinatorics/SimpleGraph/Walk/Iterate.lean`** (new file):
- `Walk.iterate`: builds a walk of length `n` from `x` to `f^[n] x` for any function `f` with `G.Adj x (f x)` for all `x`, defined via `Walk.ofSupport`
- `Walk.length_iterate`, `Walk.support_iterate`, `Walk.edges_iterate`: basic API

**`Mathlib/GroupTheory/Perm/Cycle/Basic.lean`**:
- `IsCycleOn.injOn_pow_apply`: the map `n ↦ (f ^ n) a` is injective on `Finset.range #s`

**`Mathlib/GroupTheory/Perm/Cycle/Concrete.lean`**:
- `IsCycleOn.injOn_sym2_pow_apply`: the unordered-pair edge map `k ↦ s((f ^ k) a, (f ^ (k + 1)) a)` is injective on `[0, #s)` when `#s ≠ 2`
- `IsCycleOn.sym2_pow_apply_ne`: edge distinctness for cycle-on permutations — `s((f ^ k) a, (f ^ (k + 1)) a) ≠ s(a, f a)` when `k ≠ 0`, `k < #s`, and `#s ≠ 2`
- `Perm.toList_eq_range_map_pow`: expresses `toList` as a range map over powers

**`Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean`**:
- `cons_isHamiltonianCycle_iff`: a Hamiltonian path closed by an edge outside its support is a Hamiltonian cycle, and conversely
- `IsHamiltonian.of_perm`: the main theorem

---

- [x] depends on: #36307
- [ ] depends on: #35255
- [ ] depends on: #34799
