### PR TITLE
[Merged by Bors] - feat(RingTheory/UniqueFactorizationDomain/Multiplicity): more API

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Finprod
 public import Mathlib.RingTheory.Multiplicity
 public import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 
@@ -57,8 +58,6 @@ variable [NormalizationMonoid R]
 
 open Multiset
 
-section
-
 theorem le_emultiplicity_iff_replicate_le_normalizedFactors {a b : R} {n : ℕ} (ha : Irreducible a)
     (hb : b ≠ 0) :
     ↑n ≤ emultiplicity a b ↔ replicate n (normalize a) ≤ normalizedFactors b := by
@@ -79,14 +78,16 @@ theorem le_emultiplicity_iff_replicate_le_normalizedFactors {a b : R} {n : ℕ} 
     rw [← (prod_normalizedFactors hb).dvd_iff_dvd_right, hu, prod_add, prod_replicate]
     exact (Associated.pow_pow <| associated_normalize a).dvd.trans (Dvd.intro u.prod rfl)
 
+variable [DecidableEq R]
+
 /-- The multiplicity of an irreducible factor of a nonzero element is exactly the number of times
 the normalized factor occurs in the `normalizedFactors`.
 
 See also `count_normalizedFactors_eq` which expands the definition of `multiplicity`
 to produce a specification for `count (normalizedFactors _) _`..
 -/
-theorem emultiplicity_eq_count_normalizedFactors [DecidableEq R] {a b : R} (ha : Irreducible a)
-    (hb : b ≠ 0) : emultiplicity a b = (normalizedFactors b).count (normalize a) := by
+theorem emultiplicity_eq_count_normalizedFactors {a b : R} (ha : Irreducible a) (hb : b ≠ 0) :
+    emultiplicity a b = (normalizedFactors b).count (normalize a) := by
   apply le_antisymm
   · apply Order.le_of_lt_add_one
     rw [← Nat.cast_one, ← Nat.cast_add, lt_iff_not_ge,
@@ -94,7 +95,15 @@ theorem emultiplicity_eq_count_normalizedFactors [DecidableEq R] {a b : R} (ha :
     simp
   rw [le_emultiplicity_iff_replicate_le_normalizedFactors ha hb, ← le_count_iff_replicate_le]
 
-end
+/-- The multiplicity of an irreducible factor of a nonzero element is exactly the number of times
+the normalized factor occurs in the `normalizedFactors`.
+
+For a version using `emultiplicity`, see `emultiplicity_eq_count_normalizedFactors`. -/
+theorem multiplicity_eq_count_normalizedFactors {a b : R} (ha : Irreducible a) (hb : b ≠ 0) :
+    multiplicity a b = (normalizedFactors b).count (normalize a) := by
+  have := emultiplicity_eq_count_normalizedFactors ha hb
+  rwa [(finiteMultiplicity_of_emultiplicity_eq_natCast this).emultiplicity_eq_multiplicity,
+    ENat.coe_inj] at this
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The number of times an irreducible factor `p` appears in `normalizedFactors x` is defined by
@@ -102,9 +111,9 @@ the number of times it divides `x`.
 
 See also `multiplicity_eq_count_normalizedFactors` if `n` is given by `multiplicity p x`.
 -/
-theorem count_normalizedFactors_eq [DecidableEq R] {p x : R} (hp : Irreducible p)
-    (hnorm : normalize p = p) {n : ℕ} (hle : p ^ n ∣ x) (hlt : ¬p ^ (n + 1) ∣ x) :
-    (normalizedFactors x).count p = n := by classical
+theorem count_normalizedFactors_eq {p x : R} (hp : Irreducible p) (hnorm : normalize p = p) {n : ℕ}
+    (hle : p ^ n ∣ x) (hlt : ¬p ^ (n + 1) ∣ x) :
+    (normalizedFactors x).count p = n := by
   by_cases hx0 : x = 0
   · simp [hx0] at hlt
   apply Nat.cast_injective (R := ℕ∞)
@@ -118,8 +127,8 @@ the number of times it divides `x`. This is a slightly more general version of
 
 See also `multiplicity_eq_count_normalizedFactors` if `n` is given by `multiplicity p x`.
 -/
-theorem count_normalizedFactors_eq' [DecidableEq R] {p x : R} (hp : p = 0 ∨ Irreducible p)
-    (hnorm : normalize p = p) {n : ℕ} (hle : p ^ n ∣ x) (hlt : ¬p ^ (n + 1) ∣ x) :
+theorem count_normalizedFactors_eq' {p x : R} (hp : p = 0 ∨ Irreducible p) (hnorm : normalize p = p)
+    {n : ℕ} (hle : p ^ n ∣ x) (hlt : ¬p ^ (n + 1) ∣ x) :
     (normalizedFactors x).count p = n := by
   rcases hp with (rfl | hp)
   · cases n
@@ -127,6 +136,19 @@ theorem count_normalizedFactors_eq' [DecidableEq R] {p x : R} (hp : p = 0 ∨ Ir
     · rw [zero_pow (Nat.succ_ne_zero _)] at hle hlt
       exact absurd hle hlt
   · exact count_normalizedFactors_eq hp hnorm hle hlt
+
+/-- The `finprod` over the powers of the elements `p` of `R` with exponent their multiplicity
+in `normalizedFactors x` is associated to `x`. -/
+lemma associated_finprod_pow_count {x : R} (hx : x ≠ 0) :
+    Associated (∏ᶠ p : R, p ^ (normalizedFactors x).count p) x := by
+  rw [← Multiset.prod_map_eq_finprod, Multiset.map_id']
+  exact prod_normalizedFactors hx
+
+/-- The `finprod` over the powers of the elements `p` of `R` with exponent their multiplicity
+in `normalizedFactors x` is equal to `x` when `R` has only one unit. -/
+lemma finprod_pow_count_eq_of_subsingleton_units [Subsingleton Rˣ] {x : R} (hx : x ≠ 0) :
+    ∏ᶠ p : R, p ^ (normalizedFactors x).count p = x :=
+  associated_iff_eq.mp <| associated_finprod_pow_count hx
 
 end multiplicity
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
@@ -83,6 +83,8 @@ variable [DecidableEq R]
 /-- The multiplicity of an irreducible factor of a nonzero element is exactly the number of times
 the normalized factor occurs in the `normalizedFactors`.
 
+For a version using `multiplicity`, see `multiplicity_eq_count_normalizedFactors`.
+
 See also `count_normalizedFactors_eq` which expands the definition of `multiplicity`
 to produce a specification for `count (normalizedFactors _) _`..
 -/
@@ -137,15 +139,11 @@ theorem count_normalizedFactors_eq' {p x : R} (hp : p = 0 ∨ Irreducible p) (hn
       exact absurd hle hlt
   · exact count_normalizedFactors_eq hp hnorm hle hlt
 
-/-- The `finprod` over the powers of the elements `p` of `R` with exponent their multiplicity
-in `normalizedFactors x` is associated to `x`. -/
 lemma associated_finprod_pow_count {x : R} (hx : x ≠ 0) :
     Associated (∏ᶠ p : R, p ^ (normalizedFactors x).count p) x := by
   rw [← Multiset.prod_map_eq_finprod, Multiset.map_id']
   exact prod_normalizedFactors hx
 
-/-- The `finprod` over the powers of the elements `p` of `R` with exponent their multiplicity
-in `normalizedFactors x` is equal to `x` when `R` has only one unit. -/
 lemma finprod_pow_count_eq_of_subsingleton_units [Subsingleton Rˣ] {x : R} (hx : x ≠ 0) :
     ∏ᶠ p : R, p ^ (normalizedFactors x).count p = x :=
   associated_iff_eq.mp <| associated_finprod_pow_count hx


### PR DESCRIPTION
This adds a few API lemmas on factorization in `UniqueFactorizationMonoid`s.
It also includes a minor cleanup of sections and variables.

The results will be useful for proving the Northcott property for heights on number fields.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
