### PR TITLE
[Merged by Bors] - fix(Translate): check if target is reserved name

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -250,7 +250,7 @@ def findPrefixTranslation? (n : Name) (t : TranslateData) : CoreM (Option Transl
     return info
   let .str n postFix := n | return none
   let some info := go env n [postFix] | return none
-  unless ← realizeGlobalConst n do return none
+  unless ← realizeGlobalConst info.translation do return none
   return info
 where
   /-- Loop through the prefixes of `n` to try to find a translation.

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -225,6 +225,21 @@ def findTranslation? (env : Environment) (t : TranslateData) : Name → Option T
 def findTranslationName? (env : Environment) (t : TranslateData) (n : Name) : Option Name :=
   (findTranslation? env t n).map (·.translation)
 
+/-- Check if the given constant exists in the environment, also checking for reserved names.
+This function is based on `Lean.realizeGlobalName`. -/
+private def realizeGlobalConst (c : Name) : CoreM Bool := do
+  let env ← getEnv
+  if env.contains c then
+    return true
+  unless isReservedName env c do
+    return false
+  try
+    executeReservedNameAction c
+    return (← getEnv).containsOnBranch c
+  catch ex =>
+    logError m!"Failed to realize constant {c}:{indentD ex.toMessageData}"
+    return false
+
 /-- Get the translation for the given name,
 falling back to translating a prefix of the name if the full name can't be translated.
 This allows translating automatically generated declarations such as `IsRegular.casesOn`.
@@ -235,12 +250,8 @@ def findPrefixTranslation? (n : Name) (t : TranslateData) : CoreM (Option Transl
     return info
   let .str n postFix := n | return none
   let some info := go env n [postFix] | return none
-  if env.contains (skipRealize := false) info.translation then
-    return info
-  if isReservedName env info.translation then
-    executeReservedNameAction info.translation
-    return info
-  return none
+  unless ← realizeGlobalConst n do return none
+  return info
 where
   /-- Loop through the prefixes of `n` to try to find a translation.
   In such a case, we inherit the `relevantArg` option from the translation. -/
@@ -1134,7 +1145,7 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
     throwError "`{t.attrName}` can only be used as a global attribute"
   withOptions (fun o => if cfg.trace then o.set `trace.translate true else o) do
   let tgt ← targetName t cfg src
-  let alreadyExists := (← getEnv).contains tgt
+  let alreadyExists ← realizeGlobalConst tgt
   if cfg.existing != alreadyExists && !(← isInductive src) && !cfg.self then
     Linter.logLintIf linter.translateExisting cfg.ref <|
       if alreadyExists then

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -893,3 +893,8 @@ def dontTranslateId {α} : α → α := id
 @[to_additive]
 theorem functionTypeMonoid {ι : Type*} {R : ι → Type*} [(i : ι) → Monoid (R i)] (i : ι)
   (a : R (dontTranslateId i)) : a * a = a * a := rfl
+
+class AddClass (α : Type) extends Add α where
+class MulClass (α : Type) extends Mul α where
+-- Test that the reserved `MulClass.mk.congr_simp` can be translated to `AddClass.mk.congr_cimp`
+attribute [to_additive existing] MulClass MulClass.mk.congr_simp


### PR DESCRIPTION
This PR makes sure that `to_dual`/`to_additive` can translate between reserved names by first realizing them. This is needed in #35031 to translate `CoconeMorphism.mk.congr_simp`.

I've made a private function `realizeGlobalConst` which is basically a variant of `Lean.hasConst` but which also checks for reserved names. This should ideally be an API function provided by Lean, but I didn't find it.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
