### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MorphismProperty/Comma): API for `mapLeft` and `mapRight`

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -357,6 +357,60 @@ def mapLeft (l : L₁ ⟶ L₂) (hl : ∀ X : P.Comma L₂ R Q W, P (l.app X.lef
   lift (forget _ _ _ _ _ ⋙ CategoryTheory.Comma.mapLeft R l) hl
     (fun f ↦ f.prop_hom_left) (fun f ↦ f.prop_hom_right)
 
+variable (L R) in
+/-- The functor `P.Comma L R Q W ⥤ P.Comma L R Q W` induced by the identity natural transformation
+on `L` is naturally isomorphic to the identity functor. -/
+@[simps!]
+def mapLeftId [Q.RespectsIso] [W.RespectsIso] :
+    mapLeft (P := P) (Q := Q) (W := W) R (𝟙 L) (fun X ↦ by simpa using X.prop) ≅ 𝟭 _ :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (R) in
+/-- The functor `P.Comma L₁ R Q W ⥤ P.Comma L₃ R Q W` induced by the composition of two natural
+transformations `l : L₁ ⟶ L₂` and `l' : L₂ ⟶ L₃` is naturally isomorphic to the composition of the
+two functors induced by these natural transformations. -/
+@[simps!]
+def mapLeftComp [Q.RespectsIso] [W.RespectsIso] (l : L₁ ⟶ L₂) (l' : L₂ ⟶ L₃)
+    (hl : ∀ (X : P.Comma L₂ R Q W), P (l.app X.left ≫ X.hom))
+    (hl' : ∀ (X : P.Comma L₃ R Q W), P (l'.app X.left ≫ X.hom))
+    (hll' : ∀ (X : P.Comma L₃ R Q W), P ((l ≫ l').app X.left ≫ X.hom)) :
+    mapLeft (P := P) (Q := Q) (W := W) R (l ≫ l') hll' ≅
+      mapLeft R l' hl' ⋙ mapLeft R l hl :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (R) in
+/-- Two equal natural transformations `L₁ ⟶ L₂` yield naturally isomorphic functors
+`P.Comma L₁ R Q W ⥤ P.Comma L₂ R Q W`. -/
+@[simps!]
+def mapLeftEq [Q.RespectsIso] [W.RespectsIso] (l l' : L₁ ⟶ L₂) (h : l = l')
+    (hl : ∀ (X : P.Comma L₂ R Q W), P (l.app X.left ≫ X.hom)) :
+    mapLeft R l hl ≅ mapLeft R l' (h ▸ hl) :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (R) in
+/-- A natural isomorphism `L₁ ≅ L₂` induces an equivalence of categories
+`P.Comma L₁ R Q W ≌ P.Comma L₂ R Q W`. -/
+@[simps!]
+def mapLeftIso [P.RespectsIso] [Q.RespectsIso] [W.RespectsIso]
+      (e : L₁ ≅ L₂) :
+    P.Comma L₁ R Q W ≌ P.Comma L₂ R Q W where
+  functor := Comma.mapLeft R e.inv (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+  inverse := Comma.mapLeft R e.hom (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+  unitIso := (mapLeftId _ _).symm ≪≫
+    mapLeftEq _ _ _ e.hom_inv_id.symm (fun X ↦ by simpa using X.prop) ≪≫
+    mapLeftComp _ _ _
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+  counitIso :=
+    (mapLeftComp _ _ _
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop)).symm ≪≫
+    mapLeftEq _ _ _ e.inv_hom_id
+      (fun X ↦ (P.cancel_left_of_respectsIso _ _).mpr X.prop) ≪≫
+    mapLeftId _ _
+
 variable (L) in
 /-- A natural transformation `R₁ ⟶ R₂` induces a functor `P.Comma L R₁ Q W ⥤ P.Comma L R₂ Q W`. -/
 @[simps!]
@@ -364,6 +418,60 @@ def mapRight (r : R₁ ⟶ R₂) (hr : ∀ X : P.Comma L R₁ Q W, P (X.hom ≫ 
     P.Comma L R₁ Q W ⥤ P.Comma L R₂ Q W :=
   lift (forget _ _ _ _ _ ⋙ CategoryTheory.Comma.mapRight L r) hr
     (fun f ↦ f.prop_hom_left) (fun f ↦ f.prop_hom_right)
+
+variable (L R) in
+/-- The functor `P.Comma L R Q W ⥤ P.Comma L R Q W` induced by the identity natural transformation
+on `R` is naturally isomorphic to the identity functor. -/
+@[simps!]
+def mapRightId [Q.RespectsIso] [W.RespectsIso] :
+    mapRight (P := P) (Q := Q) (W := W) L (𝟙 R) (fun X ↦ by simpa using X.prop) ≅ 𝟭 _ :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (L) in
+/-- The functor `P.Comma L R₁ Q W ⥤ P.Comma L R₃ Q W` induced by the composition of the natural
+transformations `r : R₁ ⟶ R₂` and `r' : R₂ ⟶ R₃` is naturally isomorphic to the composition of the
+functors induced by these natural transformations. -/
+@[simps!]
+def mapRightComp [Q.RespectsIso] [W.RespectsIso] (r : R₁ ⟶ R₂) (r' : R₂ ⟶ R₃)
+    (hr : ∀ (X : P.Comma L R₁ Q W), P (X.hom ≫ r.app X.right))
+    (hr' : ∀ (X : P.Comma L R₂ Q W), P (X.hom ≫ r'.app X.right))
+    (hrr' : ∀ (X : P.Comma L R₁ Q W), P (X.hom ≫ (r ≫ r').app X.right)) :
+    mapRight (P := P) (Q := Q) (W := W) L (r ≫ r') hrr' ≅
+      mapRight L r hr ⋙ mapRight L r' hr' :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (L) in
+/-- Two equal natural transformations `R₁ ⟶ R₂` yield naturally isomorphic functors
+`P.Comma L R₁ Q W ⥤ P.Comma L R₂ Q W`. -/
+@[simps!]
+def mapRightEq [Q.RespectsIso] [W.RespectsIso] (r r' : R₁ ⟶ R₂) (h : r = r')
+    (hr : ∀ (X : P.Comma L R₁ Q W), P (X.hom ≫ r.app X.right)) :
+    mapRight L r hr ≅ mapRight L r' (h ▸ hr) :=
+  NatIso.ofComponents (fun X => isoMk (Iso.refl _) (Iso.refl _))
+
+variable (L) in
+/-- A natural isomorphism `R₁ ≅ R₂` induces an equivalence of categories
+`P.Comma L R₁ Q W ≌ P.Comma L R₂ Q W`. -/
+@[simps!]
+def mapRightIso [P.RespectsIso] [Q.RespectsIso] [W.RespectsIso]
+      (e : R₁ ≅ R₂) :
+    P.Comma L R₁ Q W ≌ P.Comma L R₂ Q W where
+  functor := Comma.mapRight L e.hom (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+  inverse := Comma.mapRight L e.inv (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+  unitIso := (mapRightId _ _).symm ≪≫
+    mapRightEq _ _ _ e.hom_inv_id.symm (fun X ↦ by simpa using X.prop) ≪≫
+    mapRightComp _ _ _
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+  counitIso :=
+    (mapRightComp _ _ _
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop)).symm ≪≫
+    mapRightEq _ _ _ e.inv_hom_id
+      (fun X ↦ (P.cancel_right_of_respectsIso _ _).mpr X.prop) ≪≫
+    mapRightId _ _
 
 end Functoriality
 


### PR DESCRIPTION
From Pi1.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
