### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Preserves/Shapes/Kernels): Mapping `zeroKernelFork`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
@@ -339,7 +339,6 @@ def mapZeroKernelFork :
     (kernel.zeroKernelFork f).map G ≅ (kernel.zeroKernelFork (G.map f)) :=
   Fork.ext G.mapZeroObject
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Mapping a `zeroCokernelCofork` of `f : X ⟶ Y` along a functor `G` that preserves zero morphisms
 is isomorphic to the `zeroCokernelCofork` of `G.map f`. -/
 def mapZeroCokernelCofork :

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
@@ -337,14 +337,14 @@ set_option backward.isDefEq.respectTransparency false in
 is isomorphic to the `zeroKernelFork` of `G.map f`. -/
 def mapZeroKernelFork :
     (kernel.zeroKernelFork f).map G ≅ (kernel.zeroKernelFork (G.map f)) :=
-  Fork.ext G.mapZeroObject (by simp)
+  Fork.ext G.mapZeroObject
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Mapping a `zeroCokernelCofork` of `f : X ⟶ Y` along a functor `G` that preserves zero morphisms
 is isomorphic to the `zeroCokernelCofork` of `G.map f`. -/
 def mapZeroCokernelCofork :
     (cokernel.zeroCokernelCofork f).map G ≅ (cokernel.zeroCokernelCofork (G.map f)) :=
-  Cofork.ext G.mapZeroObject (by simp)
+  Cofork.ext G.mapZeroObject
 
 end ZeroObject
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
@@ -326,4 +326,26 @@ lemma preservesCokernel_zero' (f : X ⟶ Y) (hf : f = 0) :
   rw [hf]
   infer_instance
 
+section ZeroObject
+
+variable [HasZeroObject C] [HasZeroObject D]
+
+variable {X Y : C} (f : X ⟶ Y)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Mapping a `zeroKernelFork` of `f : X ⟶ Y` along a functor `G` that preserves zero morphisms
+is isomorphic to the `zeroKernelFork` of `G.map f`. -/
+def mapZeroKernelFork :
+    (kernel.zeroKernelFork f).map G ≅ (kernel.zeroKernelFork (G.map f)) :=
+  Fork.ext (by simpa using G.mapZeroObject) (by simp)
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Mapping a `zeroCokernelCofork` of `f : X ⟶ Y` along a functor `G` that preserves zero morphisms
+is isomorphic to the `zeroCokernelCofork` of `G.map f`. -/
+def mapZeroCokernelCofork :
+    (cokernel.zeroCokernelCofork f).map G ≅ (cokernel.zeroCokernelCofork (G.map f)) :=
+  Cofork.ext (by simpa using G.mapZeroObject) (by simp)
+
+end ZeroObject
+
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
@@ -337,14 +337,14 @@ set_option backward.isDefEq.respectTransparency false in
 is isomorphic to the `zeroKernelFork` of `G.map f`. -/
 def mapZeroKernelFork :
     (kernel.zeroKernelFork f).map G ≅ (kernel.zeroKernelFork (G.map f)) :=
-  Fork.ext (by simpa using G.mapZeroObject) (by simp)
+  Fork.ext G.mapZeroObject (by simp)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Mapping a `zeroCokernelCofork` of `f : X ⟶ Y` along a functor `G` that preserves zero morphisms
 is isomorphic to the `zeroCokernelCofork` of `G.map f`. -/
 def mapZeroCokernelCofork :
     (cokernel.zeroCokernelCofork f).map G ≅ (cokernel.zeroCokernelCofork (G.map f)) :=
-  Cofork.ext (by simpa using G.mapZeroObject) (by simp)
+  Cofork.ext G.mapZeroObject (by simp)
 
 end ZeroObject
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
@@ -495,9 +495,12 @@ variable [HasZeroObject C]
 open ZeroObject
 
 /-- The morphism from the zero object determines a cone on a kernel diagram -/
-def kernel.zeroKernelFork : KernelFork f where
-  pt := 0
-  π := { app := fun _ => 0 }
+@[simps! pt]
+def kernel.zeroKernelFork : KernelFork f :=
+  KernelFork.ofι (0 : 0 ⟶ X) zero_comp
+
+@[simp]
+lemma kernel.zeroKernelFork_ι : (kernel.zeroKernelFork f).ι = 0 := rfl
 
 /-- The map from the zero object is a kernel of a monomorphism -/
 def kernel.isLimitConeZeroCone [Mono f] : IsLimit (kernel.zeroKernelFork f) :=
@@ -1025,9 +1028,12 @@ variable [HasZeroObject C]
 open ZeroObject
 
 /-- The morphism to the zero object determines a cocone on a cokernel diagram -/
-def cokernel.zeroCokernelCofork : CokernelCofork f where
-  pt := 0
-  ι := { app := fun _ => 0 }
+@[simps! pt]
+def cokernel.zeroCokernelCofork : CokernelCofork f :=
+    CokernelCofork.ofπ (0 : Y ⟶ 0) comp_zero
+
+@[simp]
+lemma cokernel.zeroCokernelCofork_π : (cokernel.zeroCokernelCofork f).π = 0 := rfl
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The morphism to the zero object is a cokernel of an epimorphism -/


### PR DESCRIPTION
A compatibility iso relating `KernelFork.map` and `kernel.zeroKernelFork`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #36409

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
