### PR TITLE
[Merged by Bors] - perf: decompress already-cached files concurrently with downloads

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -416,6 +416,29 @@ def ModuleHashMap.filterNeedsDecompression (hashMap : ModuleHashMap) : CacheM Mo
     else
       return acc
 
+/-- Prepare the leantar JSON config for decompressing cached files that need it.
+    Returns `(config, size, skipped)` or `none` if no files need decompression.
+    This is the config-building part of `unpackCache`, separated so it can be used
+    to spawn background decompression tasks. -/
+def prepareDecompConfig (hashMap : ModuleHashMap) (force : Bool) :
+    CacheM (Option (Array Lean.Json × Nat × Nat)) := do
+  let hashMap ← hashMap.filterExists true
+  let totalCached := hashMap.size
+  if totalCached == 0 then return none
+  let hashMap ← if force then pure hashMap else hashMap.filterNeedsDecompression
+  let size := hashMap.size
+  if size == 0 then return none
+  let skipped := totalCached - size
+  let isMathlibRoot ← isMathlibRoot
+  let mathlibDepPath := (← read).mathlibDepPath.toString
+  let config : Array Lean.Json := hashMap.fold (init := #[]) fun config mod hash =>
+    let pathStr := s!"{CACHEDIR / hash.asLTar}"
+    if isMathlibRoot || !isFromMathlib mod then
+      config.push <| .str pathStr
+    else
+      config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
+  return some (config, size, skipped)
+
 /-- Decompresses build files into their respective folders -/
 def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -416,28 +416,42 @@ def ModuleHashMap.filterNeedsDecompression (hashMap : ModuleHashMap) : CacheM Mo
     else
       return acc
 
-/-- Prepare the leantar JSON config for decompressing cached files that need it.
-    Returns `(config, size, skipped)` or `none` if no files need decompression.
-    This is the config-building part of `unpackCache`, separated so it can be used
-    to spawn background decompression tasks. -/
-def prepareDecompConfig (hashMap : ModuleHashMap) (force : Bool) :
-    CacheM (Option (Array Lean.Json × Nat × Nat)) := do
-  let hashMap ← hashMap.filterExists true
-  let totalCached := hashMap.size
-  if totalCached == 0 then return none
-  let hashMap ← if force then pure hashMap else hashMap.filterNeedsDecompression
-  let size := hashMap.size
-  if size == 0 then return none
-  let skipped := totalCached - size
+/-- Build the leantar JSON config array from a module hash map.
+    Each entry is either a plain path string, or an object with `"file"` and `"base"` fields
+    for mathlib dependency files that need path redirection. -/
+def mkLeanTarConfig (hashMap : ModuleHashMap) : CacheM (Array Lean.Json) := do
   let isMathlibRoot ← isMathlibRoot
   let mathlibDepPath := (← read).mathlibDepPath.toString
-  let config : Array Lean.Json := hashMap.fold (init := #[]) fun config mod hash =>
+  return hashMap.fold (init := #[]) fun config mod hash =>
     let pathStr := s!"{CACHEDIR / hash.asLTar}"
     if isMathlibRoot || !isFromMathlib mod then
       config.push <| .str pathStr
     else
       config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
-  return some (config, size, skipped)
+
+/-- A plan for decompressing cached files, computed by `prepareDecompConfig`. -/
+structure DecompPlan where
+  /-- The leantar JSON config for files that need decompression. -/
+  config : Array Lean.Json
+  /-- Number of cached files that need decompression. -/
+  needsDecomp : Nat
+  /-- Number of cached files already decompressed (skipped). -/
+  alreadyDecompressed : Nat
+
+/-- Determine which cached files need decompression and build a plan.
+    Returns `none` if no cached files need decompression. -/
+def prepareDecompConfig (hashMap : ModuleHashMap) (force : Bool) :
+    CacheM (Option DecompPlan) := do
+  let cached ← hashMap.filterExists true
+  if cached.isEmpty then return none
+  let toDecomp ← if force then pure cached else cached.filterNeedsDecompression
+  if toDecomp.isEmpty then return none
+  let config ← mkLeanTarConfig toDecomp
+  return some {
+    config
+    needsDecomp := toDecomp.size
+    alreadyDecompressed := cached.size - toDecomp.size
+  }
 
 /-- Decompresses build files into their respective folders -/
 def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
@@ -453,30 +467,7 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
       IO.println s!"Decompressing {size} file(s) ({skipped} already decompressed)"
     else
       IO.println s!"Decompressing {size} file(s)"
-    /-
-    TODO: The case distinction below could be avoided by making use of the `leantar` option `-C`
-    (rsp the `"base"` field in JSON format, see below) here and in `packCache`.
-
-    See also https://github.com/leanprover-community/mathlib4/pull/8767#discussion_r1422077498
-
-    Doing this, one could avoid that the package directory path (for dependencies) appears
-    inside the leantar files, but unless `cache` is upstreamed to work on upstream packages
-    themselves (without `Mathlib`), this might not be too useful to change.
-
-    NOTE: making changes to the generated .ltar files invalidates them while it *DOES NOT* change
-    the file hash! This means any such change needs to be accompanied by a change
-    to the root hash affecting *ALL* files
-    (e.g. any modification to lakefile, lean-toolchain or manifest)
-    -/
-    let isMathlibRoot ← isMathlibRoot
-    let mathlibDepPath := (← read).mathlibDepPath.toString
-    let config : Array Lean.Json := hashMap.fold (init := #[]) fun config mod hash =>
-      let pathStr := s!"{CACHEDIR / hash.asLTar}"
-      if isMathlibRoot || !isFromMathlib mod then
-        config.push <| .str pathStr
-      else
-        -- only mathlib files, when not in the mathlib4 repo, need to be redirected
-        config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
+    let config ← mkLeanTarConfig hashMap
     let exitCode ← spawnLeanTarDecompress config force
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
     IO.println s!"Decompressed in {(← IO.monoMsNow) - now} ms"

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -109,7 +109,12 @@ def spawnLeanTarDecompress (config : Array Lean.Json) (force : Bool) : IO UInt32
 
 /-- Bump this number to invalidate the cache, in case the existing hashing inputs are insufficient.
 It is not a global counter, and can be reset to 0 as long as the lean githash or lake manifest has
-changed since the last time this counter was touched. -/
+changed since the last time this counter was touched.
+
+NOTE: making changes to the generated `.ltar` files invalidates them while it *does not* change
+the file hash! This means any such change needs to be accompanied by a change
+to the root hash affecting *all* files
+(e.g. any modification to lakefile, lean-toolchain or manifest). -/
 def rootHashGeneration : UInt64 := 4
 
 /--

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -664,8 +664,10 @@ def getFiles
 
   let mathlibDepPath := (← read).mathlibDepPath
 
-  -- Start background decompression of already-cached files before downloading
-  let bgDecomp ← if decompress then
+  -- Start background decompression of already-cached files before downloading.
+  -- Skip when forceDownload is set, since downloadFiles will re-download (and pipeline-decompress)
+  -- all files including already-cached ones, which would race with this background task.
+  let bgDecomp ← if decompress && !forceDownload then
     if let some (config, size, skipped) := ← IO.prepareDecompConfig hashMap forceUnpack then
       if skipped > 0 then
         IO.println s!"Decompressing {size} already-cached file(s) ({skipped} already decompressed)"

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -664,6 +664,19 @@ def getFiles
 
   let mathlibDepPath := (← read).mathlibDepPath
 
+  -- Start background decompression of already-cached files before downloading
+  let bgDecomp ← if decompress then
+    if let some (config, size, skipped) := ← IO.prepareDecompConfig hashMap forceUnpack then
+      if skipped > 0 then
+        IO.println s!"Decompressing {size} already-cached file(s) ({skipped} already decompressed)"
+      else
+        IO.println s!"Decompressing {size} already-cached file(s)"
+      let now ← IO.monoMsNow
+      let task ← IO.asTask (IO.spawnLeanTarDecompress config forceUnpack)
+      pure (some (task, size, now))
+    else pure none
+  else pure none
+
   if let some repo := repo? then
     let failed ← downloadFiles repo hashMap forceDownload parallel (warnOnMissing := true)
       (decompress := decompress) (forceUnpack := forceUnpack)
@@ -697,9 +710,26 @@ def getFiles
       IO.println s!"Downloading {failed} files failed"
       IO.Process.exit 1
 
+  -- Wait for decompression of already-cached files to complete
+  if let some (task, size, startTime) := bgDecomp then
+    match task.get with
+    | .ok exitCode =>
+      let elapsed := (← IO.monoMsNow) - startTime
+      if exitCode != 0 then
+        IO.eprintln s!"Decompression of already-cached files failed (exit code {exitCode})"
+        IO.Process.exit 1
+      IO.println s!"Decompressed {size} already-cached file(s) in {elapsed} ms"
+    | .error e =>
+      IO.eprintln s!"Decompression of already-cached files error: {e}"
+      IO.Process.exit 1
+
   if decompress then
-    -- decompress anything which hasn't already been decompressed during download
-    IO.unpackCache hashMap forceUnpack
+    if bgDecomp.isSome && parallel then
+      -- Background task handled pre-cached files, download pipeline handled new files
+      IO.println "Completed successfully!"
+    else
+      -- Either no background decompression ran, or non-parallel mode needs final sweep
+      IO.unpackCache hashMap forceUnpack
   else
     IO.println "Downloaded all files successfully!"
 

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -668,14 +668,15 @@ def getFiles
   -- Skip when forceDownload is set, since downloadFiles will re-download (and pipeline-decompress)
   -- all files including already-cached ones, which would race with this background task.
   let bgDecomp ← if decompress && !forceDownload then
-    if let some (config, size, skipped) := ← IO.prepareDecompConfig hashMap forceUnpack then
-      if skipped > 0 then
-        IO.println s!"Decompressing {size} already-cached file(s) ({skipped} already decompressed)"
+    if let some plan := ← IO.prepareDecompConfig hashMap forceUnpack then
+      if plan.alreadyDecompressed > 0 then
+        IO.println s!"Decompressing {plan.needsDecomp} already-cached file(s) \
+          ({plan.alreadyDecompressed} already decompressed)"
       else
-        IO.println s!"Decompressing {size} already-cached file(s)"
+        IO.println s!"Decompressing {plan.needsDecomp} already-cached file(s)"
       let now ← IO.monoMsNow
-      let task ← IO.asTask (IO.spawnLeanTarDecompress config forceUnpack)
-      pure (some (task, size, now))
+      let task ← IO.asTask (IO.spawnLeanTarDecompress plan.config forceUnpack)
+      pure (some (task, plan.needsDecomp, now))
     else pure none
   else pure none
 

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -663,6 +663,7 @@ def getFiles
     checkForManifestMismatch
 
   let mathlibDepPath := (← read).mathlibDepPath
+  let startTime ← IO.monoMsNow
 
   -- Start background decompression of already-cached files before downloading.
   -- Skip when forceDownload is set, since downloadFiles will re-download (and pipeline-decompress)
@@ -674,9 +675,8 @@ def getFiles
           ({plan.alreadyDecompressed} already decompressed)"
       else
         IO.println s!"Decompressing {plan.needsDecomp} already-cached file(s)"
-      let now ← IO.monoMsNow
       let task ← IO.asTask (IO.spawnLeanTarDecompress plan.config forceUnpack)
-      pure (some (task, plan.needsDecomp, now))
+      pure (some (task, plan.needsDecomp))
     else pure none
   else pure none
 
@@ -714,22 +714,22 @@ def getFiles
       IO.Process.exit 1
 
   -- Wait for decompression of already-cached files to complete
-  if let some (task, size, startTime) := bgDecomp then
+  if let some (task, size) := bgDecomp then
     match task.get with
     | .ok exitCode =>
-      let elapsed := (← IO.monoMsNow) - startTime
       if exitCode != 0 then
         IO.eprintln s!"Decompression of already-cached files failed (exit code {exitCode})"
         IO.Process.exit 1
-      IO.println s!"Decompressed {size} already-cached file(s) in {elapsed} ms"
+      IO.println s!"Decompressed {size} already-cached file(s)"
     | .error e =>
       IO.eprintln s!"Decompression of already-cached files error: {e}"
       IO.Process.exit 1
 
+  let elapsed := (← IO.monoMsNow) - startTime
   if decompress then
     if bgDecomp.isSome && parallel then
       -- Background task handled pre-cached files, download pipeline handled new files
-      IO.println "Completed successfully!"
+      IO.println s!"Completed successfully in {elapsed} ms!"
     else
       -- Either no background decompression ran, or non-parallel mode needs final sweep
       IO.unpackCache hashMap forceUnpack


### PR DESCRIPTION
This PR builds on https://github.com/leanprover-community/mathlib4/pull/32987 (pipeline downloads and decompression) and https://github.com/leanprover-community/mathlib4/pull/36367 (fix: decompress already downloaded files).

Previously, already-cached `.ltar` files were only decompressed after all downloads completed, in the final `unpackCache` sweep. This PR starts decompressing them concurrently with downloads by spawning `leantar` as a background task before the download phase begins.

The two decompression paths operate on disjoint file sets (pre-cached vs newly downloaded), so there is no conflict. In the common case where a user has most files cached but a few hundred to download, this overlaps several seconds of decompression with network I/O.

🤖 Prepared with Claude Code