### PR TITLE
[Merged by Bors] - chore: remove obsolete set_option backward.*

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Functor.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Functor.lean
@@ -159,7 +159,6 @@ noncomputable def map : Proj ℬ ⟶ Proj 𝒜 where
 theorem ι_comp_map (s : A) : (basicOpen ℬ (f s)).ι ≫ map f hf =
     (map f hf).resLE _ _ le_rfl ≫ (basicOpen 𝒜 s).ι := by simp
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc] lemma awayToSection_comp_appLE {i : ℕ} {s : A} (hs : s ∈ 𝒜 i) :
     awayToSection 𝒜 s ≫
       Scheme.Hom.appLE (map f hf) (basicOpen 𝒜 s) (basicOpen ℬ (f s)) (by rfl) =

--- a/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
@@ -96,7 +96,6 @@ theorem compatibility_N₂_N₁_karoubi :
       karoubiChainComplexEquivalence_functor_obj_X_p, N₂_obj_p_f, eqToHom_refl,
       PInfty_f_naturality_assoc, app_comp_p, PInfty_f_idem_assoc]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- We deduce that `N₂ : Karoubi (SimplicialObject C) ⥤ Karoubi (ChainComplex C ℕ)`
 reflects isomorphisms from the fact that
 `N₁ : SimplicialObject (Karoubi C) ⥤ Karoubi (ChainComplex (Karoubi C) ℕ)` does. -/

--- a/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
@@ -58,7 +58,6 @@ lemma Quasicategory.hornFilling {S : SSet} [Quasicategory S] ⦃n : ℕ⦄ ⦃i 
 instance (S : SSet) [KanComplex S] : Quasicategory S where
   hornFilling' _ _ σ₀ _ _ := KanComplex.hornFilling σ₀
 
-set_option backward.isDefEq.respectTransparency false in
 lemma quasicategory_of_filler (S : SSet)
     (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n + 3)⦄ (σ₀ : (Λ[n + 2, i] : SSet) ⟶ S)
       (_h0 : 0 < i) (_hn : i < Fin.last (n + 2)),

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -62,7 +62,6 @@ scoped[Simplicial]
 
 open Simplicial
 
-set_option backward.isDefEq.respectTransparency false in
 instance {J : Type v} [SmallCategory J] [HasLimitsOfShape J C] :
     HasLimitsOfShape J (SimplicialObject C) := by
   dsimp [SimplicialObject]
@@ -71,7 +70,6 @@ instance {J : Type v} [SmallCategory J] [HasLimitsOfShape J C] :
 instance [HasLimits C] : HasLimits (SimplicialObject C) :=
   ⟨inferInstance⟩
 
-set_option backward.isDefEq.respectTransparency false in
 instance {J : Type v} [SmallCategory J] [HasColimitsOfShape J C] :
     HasColimitsOfShape J (SimplicialObject C) := by
   dsimp [SimplicialObject]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
@@ -325,7 +325,6 @@ lemma image_degenerate_le (f : X ⟶ Y) (n : ℕ) :
     (f.app _) '' (X.degenerate n) ⊆ Y.degenerate n := by
   simpa using degenerate_le_preimage f n
 
-set_option backward.isDefEq.respectTransparency false in
 lemma degenerate_iff_of_isIso (f : X ⟶ Y) [IsIso f] {n : ℕ} (x : X _⦋n⦌) :
     f.app _ x ∈ Y.degenerate n ↔ x ∈ X.degenerate n := by
   constructor

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Dimension.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Dimension.lean
@@ -99,7 +99,6 @@ lemma Subcomplex.hasDimensionLT_of_le
     HasDimensionLT A d :=
   hasDimensionLT_of_mono (Subcomplex.homOfLE h) d
 
-set_option backward.isDefEq.respectTransparency false in
 lemma hasDimensionLT_of_epi {X Y : SSet.{u}} (f : X ⟶ Y) [Epi f] (d : ℕ)
     [X.HasDimensionLT d] : Y.HasDimensionLT d where
   degenerate_eq_top n hn := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Finite.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Finite.lean
@@ -90,7 +90,6 @@ instance [X.Finite] (A : X.Subcomplex) : SSet.Finite A := by
 
 variable {X}
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finite_of_mono {Y : SSet.{u}} [Y.Finite] (f : X ⟶ Y) [hf : Mono f] : X.Finite := by
   obtain ⟨d, _⟩ := Y.hasDimensionLT_of_finite
   have := hasDimensionLT_of_mono f d
@@ -98,7 +97,6 @@ lemma finite_of_mono {Y : SSet.{u}} [Y.Finite] (f : X ⟶ Y) [hf : Mono f] : X.F
     (fun _ _ ↦ Finite.of_injective _
       ((injective_of_mono (f.app _)).comp Subtype.val_injective))
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finite_of_epi {Y : SSet.{u}} [X.Finite] (f : X ⟶ Y) [hf : Epi f] : Y.Finite := by
   obtain ⟨d, _⟩ := X.hasDimensionLT_of_finite
   have := hasDimensionLT_of_epi f d

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorMonoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorMonoidal.lean
@@ -236,7 +236,6 @@ def iso :
   hom_inv_id := by ext; exact functor_comp_inverse X Y
   inv_hom_id := by ext; exact inverse_comp_functor X Y
 
-set_option backward.isDefEq.respectTransparency false in
 variable {X} in
 /-- The naturality of `HomotopyCategory.BinaryProduct.inverse`
 with respect to the first variable. -/
@@ -249,7 +248,6 @@ def mapHomotopyCategoryProdIdCompInverseIso (f : X ⟶ X') :
       obtain ⟨y, rfl⟩ := y.mk_surjective
       simp))
 
-set_option backward.isDefEq.respectTransparency false in
 variable {Y} in
 /-- The naturality of `HomotopyCategory.BinaryProduct.inverse`
 with respect to the second variable. -/

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -190,7 +190,6 @@ def face {n : ℕ} (i j : Fin (n + 2)) (h : j ≠ i) : (Λ[n + 1, i] : SSet.{u})
   yonedaEquiv (Subfunctor.lift (stdSimplex.δ j) (by
     simpa using face_le_horn _ _ h))
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Two morphisms from a horn are equal if they are equal on all suitable faces. -/
 protected
 lemma hom_ext {n : ℕ} {i : Fin (n + 2)} {S : SSet} (σ₁ σ₂ : (Λ[n + 1, i] : SSet.{u}) ⟶ S)
@@ -226,7 +225,6 @@ lemma yonedaEquiv_ι {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 2)) (hij : j ≠ 
     yonedaEquiv (ι i j hij) = face i j hij := by
   rw [ι, Equiv.apply_symm_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 lemma ι_ι {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 2)) (hij : j ≠ i) :
     ι i j hij ≫ Λ[n + 1, i].ι =

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -438,7 +438,6 @@ instance isIso_prodComparison_stdSimplex.{w} (n m : ℕ) :
   IsIso.of_isIso_fac_right (prodComparison_natural.{w}
     hoFunctor (stdSimplex.isoNerve n).hom (stdSimplex.isoNerve m).hom).symm
 
-set_option backward.isDefEq.respectTransparency false in
 lemma isIso_prodComparison_of_stdSimplex {D : SSet.{u}} (X : SSet.{u})
     (H : ∀ m, IsIso (prodComparison hoFunctor D Δ[m])) :
     IsIso (prodComparison hoFunctor D X) := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Subcomplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Subcomplex.lean
@@ -25,7 +25,6 @@ open CategoryTheory Simplicial Limits
 
 namespace SSet
 
-set_option backward.isDefEq.respectTransparency false in
 -- Note: this could be obtained as `inferInstanceAs (Balanced (_ ⥤ _))`
 -- by importing `Mathlib.CategoryTheory.Adhesive.Basic`, but we give a
 -- different proof so as to reduce imports
@@ -186,7 +185,6 @@ instance [Mono f] : Mono (toRange f) :=
 instance [Mono f] : IsIso (toRange f) :=
   isIso_of_mono_of_epi _
 
-set_option backward.isDefEq.respectTransparency false in
 lemma range_eq_top_iff : Subcomplex.range f = ⊤ ↔ Epi f := by
   rw [NatTrans.epi_iff_epi_app, Subfunctor.ext_iff, funext_iff]
   simp only [epi_iff_surjective, Subfunctor.range_obj, Subfunctor.top_obj,

--- a/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
+++ b/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
@@ -351,7 +351,6 @@ theorem isEquiv_iff_exists_rpow_eq {v w : AbsoluteValue F ℝ} :
         rcases eq_or_ne x 0 with rfl | h₀ <;>
         aesop (add simp [h.isNontrivial_congr])⟩
 
-set_option backward.isDefEq.respectTransparency false in
 theorem IsEquiv.equivWithAbs_image_mem_nhds_zero (h : v.IsEquiv w) {U : Set (WithAbs v)}
     (hU : U ∈ 𝓝 0) : WithAbs.congr v w (.refl F) '' U ∈ 𝓝 0 := by
   rw [Metric.mem_nhds_iff] at hU ⊢
@@ -376,7 +375,6 @@ theorem IsEquiv.isEmbedding_equivWithAbs (h : v.IsEquiv w) :
     rw [← RingEquiv.coe_toEquiv_symm, WithAbs.congr_symm] at hss
     exact Filter.mem_of_superset (h.symm.equivWithAbs_image_mem_nhds_zero hs) hss
 
-set_option backward.isDefEq.respectTransparency false in
 theorem isEquiv_iff_isHomeomorph (v w : AbsoluteValue F ℝ) :
     v.IsEquiv w ↔ IsHomeomorph (WithAbs.congr v w (.refl F)) := by
   rw [isHomeomorph_iff_isEmbedding_surjective]

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -177,7 +177,6 @@ variable [Ring R]
 set_option backward.isDefEq.respectTransparency false in
 instance (v : AbsoluteValue R S) : Ring (WithAbs v) := fast_instance% (equiv v).ring
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable instance normedRing (v : AbsoluteValue R ℝ) : NormedRing (WithAbs v) :=
   letI := v.toNormedRing
   (equiv v).normedRing

--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -1030,7 +1030,6 @@ theorem infinitesimal_sub_st {x : ℝ*} (hx : ¬Infinite x) : Infinitesimal (x -
   (isSt_st' hx).infinitesimal_sub
 
 set_option linter.deprecated false in
-set_option backward.isDefEq.respectTransparency false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinitePos_iff_infinitesimal_inv_pos {x : ℝ*} :
     InfinitePos x ↔ Infinitesimal x⁻¹ ∧ 0 < x⁻¹ := by
@@ -1050,7 +1049,6 @@ theorem infinitesimal_inv_of_infinite {x : ℝ*} : Infinite x → Infinitesimal 
   Or.casesOn hi (fun hip => (infinitePos_iff_infinitesimal_inv_pos.mp hip).1) fun hin =>
     (infiniteNeg_iff_infinitesimal_inv_neg.mp hin).1
 
-set_option backward.isDefEq.respectTransparency false in
 set_option linter.deprecated false in
 @[deprecated "`Infinitesimal` is deprecated" (since := "2026-01-05")]
 theorem infinite_of_infinitesimal_inv {x : ℝ*} (h0 : x ≠ 0) (hi : Infinitesimal x⁻¹) :
@@ -1081,7 +1079,6 @@ set_option linter.deprecated false in
 theorem infinitesimal_iff_infinite_inv {x : ℝ*} (h : x ≠ 0) : Infinitesimal x ↔ Infinite x⁻¹ :=
   Iff.trans (by rw [inv_inv]) (infinite_iff_infinitesimal_inv (inv_ne_zero h)).symm
 
-set_option backward.isDefEq.respectTransparency false in
 set_option linter.deprecated false in
 @[deprecated stdPart_inv (since := "2026-01-05")]
 theorem IsSt.inv {x : ℝ*} {r : ℝ} (hi : ¬Infinitesimal x) (hr : IsSt x r) : IsSt x⁻¹ r⁻¹ :=

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -151,7 +151,6 @@ lemma associator_inv_app (F₁ F₂ F₃ : J ⥤ C) (j : J) :
     (α_ F₁ F₂ F₃).inv.app j = (α_ _ _ _).inv := by
   rw [← cancel_mono ((α_ _ _ _).hom), Iso.inv_hom_id, ← associator_hom_app, Iso.inv_hom_id_app]
 
-set_option backward.isDefEq.respectTransparency false in
 instance {K : Type*} [Category* K] [HasColimitsOfShape K C]
     [∀ X : C, PreservesColimitsOfShape K (tensorLeft X)] {F : J ⥤ C} :
     PreservesColimitsOfShape K (tensorLeft F) := by

--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -64,7 +64,6 @@ lemma adjunction_unit_app_hom [HasWeakSheafify J D] [HasSheafCompose J F] (adj :
 @[deprecated (since := "2026-03-05")]
 alias adjunction_unit_app_val := adjunction_unit_app_hom
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma adjunction_counit_app_hom [HasWeakSheafify J D] [HasSheafCompose J F] (adj : G ⊣ F)
     (Y : Sheaf J D) : ((adjunction J adj).counit.app Y).hom =

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -44,7 +44,6 @@ theorem card_derangements_invariant {α β : Type*} [Fintype α] [DecidableEq α
     [DecidableEq β] (h : card α = card β) : card (derangements α) = card (derangements β) :=
   Fintype.card_congr (Equiv.derangementsCongr <| equivOfCardEq h)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem card_derangements_fin_add_two (n : ℕ) :
     card (derangements (Fin (n + 2))) =
       (n + 1) * card (derangements (Fin n)) + (n + 1) * card (derangements (Fin (n + 1))) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -597,7 +597,6 @@ theorem map_neighborFinset_induce_of_neighborSet_subset {v : s} (h : G.neighborS
   rwa [← Set.toFinset_subset_toFinset, ← neighborFinset_def, ← inter_eq_left,
     ← map_neighborFinset_induce v] at h
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If the neighbor set of a vertex `v` is a subset of `s`, then the degree of the vertex in the
 induced subgraph of `s` is the same as in `G`. -/
 theorem degree_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -234,7 +234,6 @@ theorem algEquivOfTranscendental_algebraMap (g : K[X]) :
   ext
   simp [algEquivOfTranscendental]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem algEquivOfTranscendental_X :
     algEquivOfTranscendental f h (X : RatFunc K) = f := by

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -422,7 +422,6 @@ lemma mlieBracket_smul_left {f : M → 𝕜} (hf : MDiffAt f x)
   rw [← mlieBracketWithin_univ, ← mfderivWithin_univ]
   exact mlieBracketWithin_smul_left hf hV (uniqueMDiffWithinAt_univ I)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma mlieBracketWithin_const_smul_left
     (hV : MDiffAt[s] (T% V) x) (hs : UniqueMDiffWithinAt I s x) :
     mlieBracketWithin I (c • V) W s x = c • mlieBracketWithin I V W s x := by
@@ -434,7 +433,6 @@ lemma mlieBracket_const_smul_left (hV : MDiffAt (T% V) x) :
   simp only [← mlieBracketWithin_univ] at hV ⊢
   exact mlieBracketWithin_const_smul_left hV (uniqueMDiffWithinAt_univ _)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma mlieBracketWithin_const_smul_right
     (hW : MDiffAt[s] (T% W) x) (hs : UniqueMDiffWithinAt I s x) :
     mlieBracketWithin I V (c • W) s x = c • mlieBracketWithin I V W s x := by

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -531,7 +531,6 @@ theorem mem_fixedPoints_mul_left_cosets_iff_mem_normalizer {H : Subgroup G} [Fin
               (mul_mem_cancel_left (inv_mem hb₁)).1 <| by
                 rw [hx] at hb₂; simpa [mul_inv_rev, mul_assoc] using hb₂)⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The fixed points of the action of `H` on its cosets correspond to `normalizer H / H`. -/
 def fixedPointsMulLeftCosetsEquivQuotient (H : Subgroup G) [Finite (H : Set G)] :
     MulAction.fixedPoints H (G ⧸ H) ≃

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -32,7 +32,6 @@ attribute [local instance] nontrivial_of_invariantBasisNumber
 
 open Basis Cardinal Function Module Set Submodule
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If every finite set of linearly independent vectors has cardinality at most `n`,
 then the same is true for arbitrary sets of linearly independent vectors.
 -/

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Completion.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Completion.lean
@@ -78,7 +78,6 @@ abbrev Completion := v.1.Completion
 
 namespace Completion
 
-set_option backward.isDefEq.respectTransparency false in
 instance : NormedField v.Completion :=
   letI := v.isometry_embedding.isUniformInducing.completableTopField
   UniformSpace.Completion.instNormedFieldOfCompletableTopField (WithAbs v.1)
@@ -277,7 +276,6 @@ variable {L : Type*} [Field L] [Algebra K L] (w : InfinitePlace L) [w.1.LiesOver
 
 attribute [local instance] WithAbs.algebraLeft
 
-set_option backward.isDefEq.respectTransparency false in
 theorem isometry_algebraMap : Isometry (algebraMap (WithAbs v.1) (WithAbs w.1)) :=
   AddMonoidHomClass.isometry_of_norm _ fun x ↦ by
     simpa [WithAbs.norm_eq_apply_ofAbs] using

--- a/Mathlib/Order/Interval/Set/OrdConnected.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnected.lean
@@ -329,19 +329,16 @@ theorem ordConnected_iff_uIcc_subset_right (hx : x ∈ s) :
     OrdConnected s ↔ ∀ ⦃y⦄, y ∈ s → [[y, x]] ⊆ s := by
   simp_rw [ordConnected_iff_uIcc_subset_left hx, uIcc_comm]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem image_subtype_val_uIcc [OrdConnected s] (a b : s) :
     Subtype.val '' [[a, b]] = [[a.1, b.1]] := by
   simp [uIcc, (Subtype.mono_coe (· ∈ s)).map_inf, (Subtype.mono_coe (· ∈ s)).map_sup]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem image_subtype_val_uIoc [OrdConnected s] (a b : s) :
     Subtype.val '' uIoc a b = uIoc a.1 b.1 := by
   simp [uIoc, (Subtype.mono_coe (· ∈ s)).map_inf, (Subtype.mono_coe (· ∈ s)).map_sup]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem image_subtype_val_uIoo [OrdConnected s] (a b : s) :
     Subtype.val '' uIoo a b = uIoo a.1 b.1 := by

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -47,7 +47,6 @@ lemma linearize_single (g : G) (x : X.V) :
     linearize k G X g (Finsupp.single x 1) = Finsupp.single (X.ρ g x) 1 := by
   simp
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Every morphism between `G`-sets could be made into an intertwining map between
   `Representation`s by the linear map induced on the indexing sets. -/
 def linearizeMap (f : X ⟶ Y) : IntertwiningMap (A := k) (linearize k G X) (linearize k G Y) where
@@ -76,7 +75,6 @@ unif_hint where ⊢ (𝟙_ (Action (Type w) G)).V ≟ PUnit
 lemma _root_.Action.tensor_ρ_apply (g : G) (xy : (X ⊗ Y).V) :
     (X ⊗ Y).ρ g xy = (X.ρ g xy.1, Y.ρ g xy.2) := rfl
 
-set_option backward.isDefEq.respectTransparency false in
 variable (k G) in
 -- I could use `Action.trivial G (PUnit)` but that's not reducibly equal to the tensor unit
 /-- The counit of the linearize functor. -/

--- a/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
@@ -251,7 +251,6 @@ theorem algebraicIndependent_finset_map_embedding_subtype (s : Set A)
   obtain ⟨b, _, rfl⟩ := hy
   simp only [f, imp_self, Subtype.mk_eq_mk]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If every finite set of algebraically independent element has cardinality at most `n`,
 then the same is true for arbitrary sets of algebraically independent elements. -/
 theorem algebraicIndependent_bounded_of_finset_algebraicIndependent_bounded {n : ℕ}

--- a/Mathlib/RingTheory/KrullDimension/Polynomial.lean
+++ b/Mathlib/RingTheory/KrullDimension/Polynomial.lean
@@ -46,7 +46,6 @@ namespace Polynomial
 
 open Ideal IsLocalization
 
-set_option backward.isDefEq.respectTransparency false in
 /--
 Let `p` be a maximal ideal of `A`. If `P` is a maximal ideal of `A[X]` lying above `p`,
 then `ht(P) = ht(p) + 1`.

--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -130,7 +130,6 @@ instance : IsNontrivial v where
 
 section Restrict
 
-set_option backward.isDefEq.respectTransparency false in
 instance isNontrivial_restrict [v.IsNontrivial] : (v.restrict).IsNontrivial where
   exists_val_nontrivial := by
     obtain ⟨x, ⟨hx0, hx1⟩⟩ := IsNontrivial.exists_val_nontrivial (v := v)

--- a/Mathlib/Topology/IndicatorConstPointwise.lean
+++ b/Mathlib/Topology/IndicatorConstPointwise.lean
@@ -111,7 +111,6 @@ for every `x`, we eventually have the equivalence `x ∈ Asᵢ ↔ x ∈ A`. -/
   · simp only [compl_singleton_mem_nhds_iff, ne_eq, NeZero.ne, not_false_eq_true]
   · simp only [compl_singleton_mem_nhds_iff, ne_eq, (NeZero.ne b).symm, not_false_eq_true]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma tendsto_indicator_const_iff_tendsto_pi_pure'
     (b : β) (nhds_b : {0}ᶜ ∈ 𝓝 b) (nhds_o : {b}ᶜ ∈ 𝓝 0) :
     Tendsto (fun i ↦ (As i).indicator (fun (_ : α) ↦ b)) L (𝓝 (A.indicator (fun (_ : α) ↦ b)))
@@ -120,7 +119,6 @@ lemma tendsto_indicator_const_iff_tendsto_pi_pure'
   simp_rw [tendsto_pure]
   aesop
 
-set_option backward.isDefEq.respectTransparency false in
 lemma tendsto_indicator_const_iff_tendsto_pi_pure [T1Space β] (b : β) [NeZero b] :
     Tendsto (fun i ↦ (As i).indicator (fun (_ : α) ↦ b)) L (𝓝 (A.indicator (fun (_ : α) ↦ b)))
       ↔ (Tendsto (fun i x ↦ x ∈ As i) L <| Filter.pi (pure <| · ∈ A)) := by

--- a/Mathlib/Topology/IsClosedRestrict.lean
+++ b/Mathlib/Topology/IsClosedRestrict.lean
@@ -131,7 +131,6 @@ theorem IsCompact.isClosed_image_restrict (S : Set ι)
   rw [Homeomorph.isClosed_image]
   exact hs_closed.preimage continuous_subtype_val
 
-set_option backward.isDefEq.respectTransparency false in
 lemma isClosedMap_restrict_of_compactSpace [∀ i, CompactSpace (α i)] :
     IsClosedMap (S.restrict : (Π i, α i) → _) := fun s hs ↦ by
   classical

--- a/Mathlib/Topology/Order/HullKernel.lean
+++ b/Mathlib/Topology/Order/HullKernel.lean
@@ -110,7 +110,6 @@ lemma preimage_upperClosure_compl_finset (hT : ∀ p ∈ T, InfPrime p) (F : Fin
 
 variable [TopologicalSpace α] [IsLower α]
 
-set_option backward.isDefEq.respectTransparency false in
 /-
 The relative-open sets of the form `(hull T a)ᶜ` for `a` in `α` form a basis for the relative
 Lower topology.


### PR DESCRIPTION
Removes another 45 no-longer-needed `set_option backward.*`, in preparation for moving Mathlib to `v4.29.0-rc6`.