### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): add SimpleGraph.ball (open metric ball)

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -415,7 +415,8 @@ theorem mem_ball : v ∈ G.ball c r ↔ G.edist c v < r :=
 
 /-- The ball of radius zero is empty. -/
 @[simp]
-theorem ball_zero : G.ball c 0 = ∅ := by ext v; simp [ball]
+theorem ball_zero : G.ball c 0 = ∅ := by
+  ext v; simp [ball]
 
 /-- The ball of radius one consists of just the center. -/
 @[simp]
@@ -444,14 +445,11 @@ theorem ball_top :
     G.ball c ⊤ = (G.connectedComponentMk c).supp := by
   ext v
   simp only [mem_ball, ConnectedComponent.mem_supp_iff]
-  constructor
-  · intro h
-    exact (ConnectedComponent.eq.mpr
-      (reachable_of_edist_ne_top (ne_top_of_lt h))).symm
-  · intro h
-    exact lt_top_iff_ne_top.mpr
-      (edist_ne_top_iff_reachable.mpr
-        (ConnectedComponent.eq.mp h.symm))
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · rw [eq_comm, ConnectedComponent.eq]
+    exact reachable_of_edist_ne_top (ne_top_of_lt h)
+  · rw [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
+    exact ConnectedComponent.eq.mp h.symm
 
 /-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
 theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by
@@ -459,7 +457,7 @@ theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by
 
 /-- Balls are monotone in the radius. -/
 @[gcongr]
-theorem ball_subset_ball (h : r₁ ≤ r₂) : G.ball c r₁ ⊆ G.ball c r₂ :=
+theorem ball_mono (h : r₁ ≤ r₂) : G.ball c r₁ ⊆ G.ball c r₂ :=
   fun _ hv ↦ lt_of_lt_of_le hv h
 
 /-- The center vertex belongs to any ball of positive radius. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kyle Miller, Vincent Beffara, Rida Hamadani
+Authors: Kyle Miller, Vincent Beffara, Rida Hamadani, Nelson Spence
 -/
 module
 
@@ -13,12 +13,14 @@ public import Mathlib.Data.ENat.Lattice
 
 This module defines the `SimpleGraph.edist` function, which takes pairs of vertices to the length of
 the shortest walk between them, or `⊤` if they are disconnected. It also defines `SimpleGraph.dist`
-which is the `ℕ`-valued version of `SimpleGraph.edist`.
+which is the `ℕ`-valued version of `SimpleGraph.edist`, and `SimpleGraph.ball` which is the open
+ball in the graph extended metric.
 
 ## Main definitions
 
 - `SimpleGraph.edist` is the graph extended metric.
 - `SimpleGraph.dist` is the graph metric.
+- `SimpleGraph.ball` is the open ball of a given radius around a vertex.
 
 ## TODO
 
@@ -30,7 +32,7 @@ which is the `ℕ`-valued version of `SimpleGraph.edist`.
 
 ## Tags
 
-graph metric, distance
+graph metric, distance, ball
 
 -/
 
@@ -396,5 +398,63 @@ lemma Walk.exists_adj_adj_not_adj_ne {p : G.Walk v w} (hp : p.length = G.dist v 
   exact ⟨p.adj_snd hnp, p.adj_getVert_succ (hp ▸ hl), hadj, hv⟩
 
 end dist
+
+/-! ## Ball -/
+
+section ball
+
+/-- The open ball of radius `r` around vertex `c` in the graph extended metric. -/
+def ball (c : V) (r : ℕ∞) : Set V :=
+  {v | G.edist c v < r}
+
+variable {G} {c v : V} {r r₁ r₂ : ℕ∞}
+
+@[simp]
+theorem mem_ball : v ∈ G.ball c r ↔ G.edist c v < r :=
+  Iff.rfl
+
+@[simp]
+theorem ball_zero : G.ball c 0 = ∅ := by
+  ext v; simp [ball]
+
+@[simp]
+theorem ball_one : G.ball c 1 = {c} := by
+  ext v
+  simp only [mem_ball, Set.mem_singleton_iff]
+  constructor
+  · intro h
+    rcases eq_or_ne c v with rfl | hne
+    · rfl
+    · exact absurd h (not_lt.mpr
+        (Order.one_le_iff_pos.mpr (edist_pos_of_ne hne)))
+  · rintro rfl; simp
+
+theorem ball_top :
+    G.ball c ⊤ = (G.connectedComponentMk c).supp := by
+  ext v
+  simp only [mem_ball, ConnectedComponent.mem_supp_iff]
+  constructor
+  · intro h
+    exact (ConnectedComponent.eq.mpr
+      (reachable_of_edist_ne_top (ne_top_of_lt h))).symm
+  · intro h
+    exact lt_top_iff_ne_top.mpr
+      (edist_ne_top_iff_reachable.mpr
+        (ConnectedComponent.eq.mp h.symm))
+
+/-- Balls are monotone in the radius. -/
+@[gcongr]
+theorem ball_subset_ball (h : r₁ ≤ r₂) : G.ball c r₁ ⊆ G.ball c r₂ :=
+  fun _ hv ↦ lt_of_lt_of_le hv h
+
+/-- The center vertex belongs to any ball of positive radius. -/
+theorem mem_ball_self (hr : 0 < r) : c ∈ G.ball c r := by
+  simp [ball, hr]
+
+/-- Ball membership is symmetric in center and point. -/
+theorem mem_ball_comm : v ∈ G.ball c r ↔ c ∈ G.ball v r := by
+  simp [ball, edist_comm]
+
+end ball
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -419,7 +419,6 @@ theorem ball_zero : G.ball c 0 = ∅ := by simp [ball]
 /-- The ball of radius one consists of just the center. -/
 @[simp]
 theorem ball_one : G.ball c 1 = {c} := by
-  ext v
   simp [ball, ENat.lt_one_iff_eq_zero]
 
 /-- The ball of radius two consists of the center and its neighbors. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -405,55 +405,39 @@ section ball
 
 /-- The open ball of radius `r` centered at the vertex `c` in the graph extended metric. -/
 def ball (c : V) (r : ℕ∞) : Set V :=
-  {v | G.edist c v < r}
+  {v | G.edist v c < r}
 
 variable {G} {c v : V} {r r₁ r₂ : ℕ∞}
 
 @[simp]
-theorem mem_ball : v ∈ G.ball c r ↔ G.edist c v < r :=
-  Iff.rfl
+theorem mem_ball : v ∈ G.ball c r ↔ G.edist v c < r := .rfl
 
 /-- The ball of radius zero is empty. -/
 @[simp]
-theorem ball_zero : G.ball c 0 = ∅ := by
-  ext v; simp [ball]
+theorem ball_zero : G.ball c 0 = ∅ := by simp [ball]
 
 /-- The ball of radius one consists of just the center. -/
 @[simp]
 theorem ball_one : G.ball c 1 = {c} := by
   ext v
-  simp only [mem_ball, Set.mem_singleton_iff]
-  constructor
-  · intro h
-    rcases eq_or_ne c v with rfl | hne
-    · rfl
-    · exact absurd h (not_lt.mpr
-        (Order.one_le_iff_pos.mpr (edist_pos_of_ne hne)))
-  · rintro rfl; simp
+  simp [ball, ENat.lt_one_iff_eq_zero]
 
 /-- The ball of radius two consists of the center and its neighbors. -/
 @[simp]
 theorem ball_two : G.ball c 2 = insert c (G.neighborSet c) := by
   ext v
-  simp only [mem_ball, Set.mem_insert_iff, mem_neighborSet,
-    show (2 : ℕ∞) = 1 + 1 from rfl, ENat.lt_add_one_iff ENat.one_ne_top,
-    edist_le_one_iff_adj_or_eq]
-  tauto
+  simp [one_add_one_eq_two.symm, ENat.lt_add_one_iff ENat.one_ne_top,
+    edist_le_one_iff_adj_or_eq, adj_comm, or_comm]
 
 /-- The ball of radius `⊤` is the connected component of the center. -/
 theorem ball_top :
     G.ball c ⊤ = (G.connectedComponentMk c).supp := by
   ext v
-  simp only [mem_ball, ConnectedComponent.mem_supp_iff]
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · rw [eq_comm, ConnectedComponent.eq]
-    exact reachable_of_edist_ne_top (ne_top_of_lt h)
-  · rw [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
-    exact ConnectedComponent.eq.mp h.symm
+  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable, reachable_comm]
 
 /-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
 theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by
-  simp only [mem_ball, lt_top_iff_ne_top, edist_ne_top_iff_reachable]
+  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable, reachable_comm]
 
 /-- Balls are monotone in the radius. -/
 @[gcongr]

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -435,8 +435,8 @@ theorem ball_top :
   simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
 
 /-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
-theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by
-  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable, reachable_comm]
+theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable v c := by
+  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
 
 /-- Balls are monotone in the radius. -/
 @[gcongr]

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -431,8 +431,7 @@ theorem ball_two : G.ball c 2 = insert c (G.neighborSet c) := by
 /-- The ball of radius `⊤` is the connected component of the center. -/
 theorem ball_top :
     G.ball c ⊤ = (G.connectedComponentMk c).supp := by
-  ext v
-  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
+  simp [Set.ext_iff, lt_top_iff_ne_top, edist_ne_top_iff_reachable]
 
 /-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
 theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable v c := by

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -432,7 +432,7 @@ theorem ball_two : G.ball c 2 = insert c (G.neighborSet c) := by
 theorem ball_top :
     G.ball c ⊤ = (G.connectedComponentMk c).supp := by
   ext v
-  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable, reachable_comm]
+  simp [lt_top_iff_ne_top, edist_ne_top_iff_reachable]
 
 /-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
 theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -403,7 +403,7 @@ end dist
 
 section ball
 
-/-- The open ball of radius `r` around vertex `c` in the graph extended metric. -/
+/-- The open ball of radius `r` centered at the vertex `c` in the graph extended metric. -/
 def ball (c : V) (r : ℕ∞) : Set V :=
   {v | G.edist c v < r}
 
@@ -413,10 +413,11 @@ variable {G} {c v : V} {r r₁ r₂ : ℕ∞}
 theorem mem_ball : v ∈ G.ball c r ↔ G.edist c v < r :=
   Iff.rfl
 
+/-- The ball of radius zero is empty. -/
 @[simp]
-theorem ball_zero : G.ball c 0 = ∅ := by
-  ext v; simp [ball]
+theorem ball_zero : G.ball c 0 = ∅ := by ext v; simp [ball]
 
+/-- The ball of radius one consists of just the center. -/
 @[simp]
 theorem ball_one : G.ball c 1 = {c} := by
   ext v
@@ -429,6 +430,16 @@ theorem ball_one : G.ball c 1 = {c} := by
         (Order.one_le_iff_pos.mpr (edist_pos_of_ne hne)))
   · rintro rfl; simp
 
+/-- The ball of radius two consists of the center and its neighbors. -/
+@[simp]
+theorem ball_two : G.ball c 2 = insert c (G.neighborSet c) := by
+  ext v
+  simp only [mem_ball, Set.mem_insert_iff, mem_neighborSet,
+    show (2 : ℕ∞) = 1 + 1 from rfl, ENat.lt_add_one_iff ENat.one_ne_top,
+    edist_le_one_iff_adj_or_eq]
+  tauto
+
+/-- The ball of radius `⊤` is the connected component of the center. -/
 theorem ball_top :
     G.ball c ⊤ = (G.connectedComponentMk c).supp := by
   ext v
@@ -441,6 +452,10 @@ theorem ball_top :
     exact lt_top_iff_ne_top.mpr
       (edist_ne_top_iff_reachable.mpr
         (ConnectedComponent.eq.mp h.symm))
+
+/-- A vertex is in the ball of radius `⊤` iff it is reachable from the center. -/
+theorem mem_ball_top : v ∈ G.ball c ⊤ ↔ G.Reachable c v := by
+  simp only [mem_ball, lt_top_iff_ne_top, edist_ne_top_iff_reachable]
 
 /-- Balls are monotone in the radius. -/
 @[gcongr]


### PR DESCRIPTION
Add `SimpleGraph.ball`, the open ball in the graph extended metric.

## Design decisions

- **Open ball** (strict `<`, not `≤`): `ball c ⊤` coincides with the connected
  component of `c`, whereas a closed ball would give `closedBall c ⊤ = univ`.
- **Named `SimpleGraph.ball`** (not `eball`): since `dist`-valued balls are less
  natural for disconnected graphs, the `e` prefix is unnecessary.
- **Graph-specific** (not via `PseudoEMetricSpace`): avoids importing `ℝ`.

AI assistance: Claude (Opus 4.6) helped draft and iterate on the implementation. I reviewed the code line by line and vouch for the final contents.

Discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/252551-graph-theory/topic/SimpleGraph.20metric.20balls/with/577846803).

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)