### PR TITLE
[Merged by Bors] - feat(TestFunction): add `limitCLM`, a variant of `mkCLM` starting from buncled CLMs on D^n_K

### DIFF
--- a/Mathlib/Analysis/Distribution/TestFunction.lean
+++ b/Mathlib/Analysis/Distribution/TestFunction.lean
@@ -338,7 +338,7 @@ protected theorem continuous_iff_continuous_comp [Algebra ℝ 𝕜] [IsScalarTow
 variable (𝕜) in
 /-- Reformulation of the universal property of the topology on `𝓓^{n}(Ω, F)`, in the form of a
 custom constructor for continuous linear maps `𝓓^{n}(Ω, F) →L[𝕜] V`, where `V` is an arbitrary
-locally convex topological vector space. -/
+locally convex topological vector space. See also `limitCLM`. -/
 @[simps]
 protected noncomputable def mkCLM [Algebra ℝ 𝕜] [IsScalarTower ℝ 𝕜 F] [Module 𝕜 V]
     [IsScalarTower ℝ 𝕜 V]
@@ -351,6 +351,36 @@ protected noncomputable def mkCLM [Algebra ℝ 𝕜] [IsScalarTower ℝ 𝕜 F] 
   letI Φ : 𝓓^{n}(Ω, F) →ₗ[𝕜] V := ⟨⟨toFun, map_add⟩, map_smul⟩
   { toLinearMap := Φ
     cont := show Continuous Φ by rwa [TestFunction.continuous_iff_continuous_comp] }
+
+variable (𝕜) in
+/-- Reformulation of the universal property of the topology on `𝓓^{n}(Ω, F)`, in the form of a
+custom constructor for continuous linear maps `𝓓^{n}(Ω, F) →L[𝕜] V`, where `V` is an arbitrary
+locally convex topological vector space. See also `mkCLM`. -/
+@[simps!]
+protected noncomputable def limitCLM [Algebra ℝ 𝕜] [IsScalarTower ℝ 𝕜 F] [Module 𝕜 V]
+    [IsScalarTower ℝ 𝕜 V]
+    (toFun : 𝓓^{n}(Ω, F) → V)
+    (T : Π (K : Compacts E), (K : Set E) ⊆ Ω → 𝓓^{n}_{K}(E, F) →L[𝕜] V)
+    (toFun_eq_T : ∀ K K_sub_Ω f, toFun (ofSupportedIn K_sub_Ω f) = T K K_sub_Ω f) :
+    𝓓^{n}(Ω, F) →L[𝕜] V :=
+  haveI toFun_add (f g : 𝓓^{n}(Ω, F)) : toFun (f + g) = toFun f + toFun g := by
+    set K : Compacts E := ⟨tsupport f ∪ tsupport g, .union f.hasCompactSupport g.hasCompactSupport⟩
+    have K_sub_Ω : (K : Set E) ⊆ Ω := union_subset f.tsupport_subset g.tsupport_subset
+    let f_K : 𝓓^{n}_{K}(E, F) :=
+      .of_support_subset f.contDiff (subset_closure.trans subset_union_left)
+    let g_K : 𝓓^{n}_{K}(E, F) :=
+      .of_support_subset g.contDiff (subset_closure.trans subset_union_right)
+    change toFun (ofSupportedIn K_sub_Ω (f_K + g_K)) =
+      toFun (ofSupportedIn K_sub_Ω f_K) + toFun (ofSupportedIn K_sub_Ω g_K)
+    simp [toFun_eq_T]
+  haveI toFun_smul (c : 𝕜) (f : 𝓓^{n}(Ω, F)) : toFun (c • f) = c • toFun f := by
+    set K : Compacts E := ⟨tsupport f, f.hasCompactSupport⟩
+    have K_sub_Ω : (K : Set E) ⊆ Ω := f.tsupport_subset
+    let f_K : 𝓓^{n}_{K}(E, F) := .of_support_subset f.contDiff subset_closure
+    change toFun (ofSupportedIn K_sub_Ω (c • f_K)) = c • toFun (ofSupportedIn K_sub_Ω f_K)
+    simp [toFun_eq_T]
+  TestFunction.mkCLM 𝕜 toFun toFun_add toFun_smul
+    (fun K K_sub_Ω ↦ .congr (T K K_sub_Ω).continuous (fun f ↦ (toFun_eq_T K K_sub_Ω f).symm))
 
 end Topology
 
@@ -396,13 +426,9 @@ noncomputable def postcompCLM (T : F →L[𝕜] F') :
     ⟨T ∘ f, T.restrictScalars ℝ |>.contDiff.comp f.contDiff,
       f.hasCompactSupport.comp_left (map_zero _),
       (tsupport_comp_subset (map_zero _) f).trans f.tsupport_subset⟩
-  haveI key (K : Compacts E) (K_sub_Ω : (K : Set E) ⊆ Ω) (f : 𝓓^{n}_{K}(E, F)) :
-      ofSupportedIn K_sub_Ω (ContDiffMapSupportedIn.postcompCLM T f) =
-        Φ (ofSupportedIn K_sub_Ω f) := by
-    ext; simp [Φ]
-  TestFunction.mkCLM 𝕜 Φ
-    (fun f g ↦ by ext; simp [Φ]) (fun c f ↦ by ext; simp [Φ])
-    (fun K K_sub_Ω ↦ by refine .congr ?_ (key K K_sub_Ω); fun_prop)
+  TestFunction.limitCLM 𝕜 Φ
+    (fun K K_sub_Ω ↦ ofSupportedInCLM 𝕜 K_sub_Ω ∘L ContDiffMapSupportedIn.postcompCLM T)
+    (fun _ _ _ ↦ by ext; simp [Φ])
 
 @[simp]
 lemma postcompCLM_apply (T : F →L[𝕜] F')


### PR DESCRIPTION
This will make it much more convenient to deduce not only continuity but also linearity from the work done on D^n_K.
This makes it convenient enough to define differentiation (for example) directly as a CLM, hence avoiding the LM/CLM duplication.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
