### PR TITLE
[Merged by Bors] - feat(Tactic/Linter): weekly lint for Verso syntax in docstrings

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -120,6 +120,7 @@ register_linter_set linter.nightlyRegressionSet :=
 -/
 register_linter_set linter.weeklyLintSet :=
   linter.tacticAnalysis.mergeWithGrind
+  linter.style.docStringVerso
 
 -- Check that all linter options mentioned in the mathlib standard linter set exist.
 open Lean Elab.Command Linter Mathlib.Linter Style UnusedInstancesInType

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -37,6 +37,14 @@ public register_option linter.style.docString.empty : Bool := {
 }
 
 /--
+The `docStringVerso` linter warns on docstrings that cannot be parsed by Verso.
+-/
+public register_option linter.style.docStringVerso : Bool := {
+  defValue := false
+  descr := "enable the style.docStringVerso linter"
+}
+
+/--
 Extract all `declModifiers` from the input syntax. We later extract the `docstring` from it,
 but we avoid extracting directly the `docComment` node, to skip `#adaptation_note`s.
 -/
@@ -55,12 +63,39 @@ def deindentString (currIndent : Nat) (docString : String) : String :=
   let indent : String := String.ofList ('\n' :: List.replicate currIndent ' ')
   docString.replace indent " "
 
+open Parser in
+/--
+Try to parse `docComment` as a Verso docstring, and report any parse errors.
+
+`fileName` is the file where this docstring is defined (default: the file currently being
+elaborated).
+
+Based on `versoDocStringFromString`, which also does elaboration (but here we only report parse
+errors).
+-/
+def checkVersoSyntax (fileName : Option String := none) (docComment : String) :
+    Elab.TermElabM (Array (String.Pos.Raw × SyntaxStack × Error)) := do
+  let fileName := fileName.getD (← getFileName)
+  let env ← getEnv
+  let ictx : InputContext := .mk docComment fileName
+  let text := ictx.fileMap
+  let pmctx : ParserModuleContext := {
+    env,
+    options := ← getOptions,
+    currNamespace := (← getCurrNamespace),
+    openDecls := (← getOpenDecls)
+  }
+  let s := mkParserState docComment
+  let s := Doc.Parser.document.run ictx pmctx (getTokenTable env) s
+  return s.allErrors
+
 namespace Style
 
 @[inherit_doc Mathlib.Linter.linter.style.docString]
 def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless getLinterValue linter.style.docString (← getLinterOptions) ||
-      getLinterValue linter.style.docString.empty (← getLinterOptions) do
+      getLinterValue linter.style.docString.empty (← getLinterOptions) ||
+      getLinterValue linter.style.docStringVerso (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
     return
@@ -104,8 +139,39 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
     if tail + 1 != deIndentedDocString.length then
       Linter.logLintIf linter.style.docString (endRange 3)
         s!"error: doc-strings should end with a single space or newline"
+    -- Check for verso syntax, but only if it is not already enabled.
+    -- If Verso is already enabled for docstrings, then this check would be superfluous.
+    if !doc.verso.get (← getOptions) &&
+        getLinterValue linter.style.docStringVerso (← getLinterOptions) then do
+      let errs ← Command.liftTermElabM (checkVersoSyntax (docComment := docString))
+      for (pos, stxStack, err) in errs do
+        Linter.logLint linter.style.docStringVerso stxStack.back m!"{err}"
 
 initialize addLinter docStringLinter
+
+/-- Lint module docs for Verso syntax errors.
+
+Verso syntax in declaration docstrings is already handled by the `docStringLinter`. -/
+def moduleDocVersoLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless getLinterValue linter.style.docStringVerso (← getLinterOptions) do
+    return
+  -- Check for verso syntax, but only if it is not already enabled.
+  -- If Verso is already enabled for module docs, then this check would be superfluous.
+  let opts ← getOptions
+  if (doc.verso.module.get? opts).getD (doc.verso.get opts) then return
+  if (← get).messages.hasErrors then
+    return
+  let some moduleDoc := (match stx with
+  | s@(.node _ ``Parser.Command.moduleDoc args) => some s
+  | _ => none) | return
+  try
+    let docString ← getDocStringText ⟨moduleDoc⟩
+    let errs ← Command.liftTermElabM (checkVersoSyntax (docComment := docString))
+    for (pos, stxStack, err) in errs do
+      Linter.logLint linter.style.docStringVerso stxStack.back m!"{err}"
+  catch _ => return
+
+initialize addLinter moduleDocVersoLinter
 
 end Style
 

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -38,6 +38,8 @@ public register_option linter.style.docString.empty : Bool := {
 
 /--
 The `docStringVerso` linter warns on docstrings that cannot be parsed by Verso.
+Since this linter only checks syntax, not semantics, it is no assurance that complying docstrings
+are actually accepted by Verso.
 -/
 public register_option linter.style.docStringVerso : Bool := {
   defValue := false
@@ -70,8 +72,8 @@ Try to parse `docComment` as a Verso docstring, and report any parse errors.
 `fileName` is the file where this docstring is defined (default: the file currently being
 elaborated).
 
-Based on `versoDocStringFromString`, which also does elaboration (but here we only report parse
-errors).
+This is a copy of the first half of `versoDocStringFromString`, which also does elaboration
+(but here we only report parse errors).
 -/
 def checkVersoSyntax (fileName : Option String := none) (docComment : String) :
     Elab.TermElabM (Array (String.Pos.Raw × SyntaxStack × Error)) := do


### PR DESCRIPTION
This PR defines the linter option `linter.style.docStringVerso`, which tries to parse docstrings as Verso documents (while skipping the elaboration part), and reports any parse errors that may occur. This should help the eventual transition to Verso-based docstrings by already collecting examples of docstrings will need to be updated. Verso is not perfectly backward-compatible with Markdown, and so it doesn't make sense to enable this for all CI runs. Instead, I added the linter to the weekly report (that also contains the suggestions for replacing `tac; grind` with `grind`).

Since this linter only checks syntax, not semantics, of Verso it won't detect issues that we also need to fix before enabling Verso in Mathlib, like:

* `#`-headings being wrongly nested
* code snippets referring to non-existent declarations
* broken code blocks
* code snippets not defining which language / parser to use

etc. I argue it is better to incrementally tackle the syntax, since this would also directly improve the quality of our current Markdown rendering.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
