### PR TITLE
[Merged by Bors] - chore(Geometry/Manifold/MFDeriv/NormedSpace): use custom elaborators …

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -58,7 +58,7 @@ theorem DifferentiableWithinAt.comp_mdifferentiableWithinAt
   hg.mdifferentiableWithinAt.comp x hf h
 
 theorem DifferentiableAt.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M} {x : M}
-(hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt[s] f x) : MDiffAt[s] (g ∘ f) x :=
+    (hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt[s] f x) : MDiffAt[s] (g ∘ f) x :=
   hg.mdifferentiableAt.comp_mdifferentiableWithinAt x hf
 
 theorem DifferentiableAt.comp_mdifferentiableAt {g : F → F'} {f : M → F} {x : M}
@@ -116,10 +116,9 @@ theorem MDifferentiableOn.clm_precomp {f : M → F₁ →L[𝕜] F₂} {s : Set 
     MDiff[s] (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) :=
   fun x hx ↦ (hf x hx).clm_precomp
 
-theorem MDifferentiable.clm_precomp
-    {f : M → F₁ →L[𝕜] F₂} (hf : MDiff f) :
-    MDiff (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
-  (hf x).clm_precomp
+theorem MDifferentiable.clm_precomp {f : M → F₁ →L[𝕜] F₂} (hf : MDiff f) :
+    MDiff (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) :=
+  fun x ↦ (hf x).clm_precomp
 
 theorem MDifferentiableWithinAt.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {s : Set M} {x : M}
     (hf : MDiffAt[s] f x) :
@@ -137,8 +136,8 @@ nonrec theorem MDifferentiableOn.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {
   (hf x hx).clm_postcomp
 
 theorem MDifferentiable.clm_postcomp {f : M → F₂ →L[𝕜] F₃} (hf : MDiff f) :
-    MDiff (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
-  (hf x).clm_postcomp
+    MDiff (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) :=
+  fun x ↦ (hf x).clm_postcomp
 
 theorem MDifferentiableWithinAt.clm_comp
     {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₁} {s : Set M} {x : M}
@@ -191,8 +190,8 @@ theorem MDifferentiable.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F�
     (hg : MDiff g) (hf : MDiff f) : MDiff fun x ↦ g x (f x) :=
   fun x ↦ (hg x).clm_apply (hf x)
 
-theorem MDifferentiableWithinAt.cle_arrowCongr {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄}
-    {s : Set M} {x : M}
+theorem MDifferentiableWithinAt.cle_arrowCongr
+    {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄} {s : Set M} {x : M}
     (hf : MDiffAt[s] (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) x)
     (hg : MDiffAt[s] (fun x ↦ (g x : F₃ →L[𝕜] F₄)) x) :
     MDiffAt[s] (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) x :=
@@ -368,10 +367,9 @@ typecheck we need a phrasing involving the canonical identification `NormedSpace
 between the vector space `V` and the tangent space to this vector space at any point. This is
 because two different tangent spaces (at `(f • g) x` and `g x`) appear in the equation. -/
 lemma fromTangentSpace_mfderiv_smul_apply (hf : MDiffAt f x) (hg : MDiffAt g x)
-    (v : TangentSpace I x)  :
+    (v : TangentSpace I x) :
     fromTangentSpace _ (mfderiv% (f • g) x v)
-    = f x • fromTangentSpace _ (mfderiv% g x v)
-    + fromTangentSpace _ (mfderiv% f x v) • g x := by
+    = f x • fromTangentSpace _ (mfderiv% g x v) + fromTangentSpace _ (mfderiv% f x v) • g x := by
   simpa using congr($(fromTangentSpace_mfderiv_smul hf hg) v)
 
 /-- Given maps `f`, `g` from a manifold into a field `𝕜` and `𝕜`-vector space `V`, respectively, the
@@ -388,8 +386,7 @@ the tangent space at `f x • g x` (the simp-normal form) rather than at `(f •
 lemma fromTangentSpace_mfderiv_smul_apply' (hf : MDiffAt f x) (hg : MDiffAt g x)
     (v : TangentSpace I x) :
     fromTangentSpace (f x • g x) (mfderiv% (f • g) x v)
-    = f x • fromTangentSpace _ (mfderiv% g x v)
-    + fromTangentSpace _ (mfderiv% f x v) • g x :=
+    = f x • fromTangentSpace _ (mfderiv% g x v) + fromTangentSpace _ (mfderiv% f x v) • g x :=
   fromTangentSpace_mfderiv_smul_apply hf hg v
 
 end smul

--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -53,32 +53,31 @@ section Module
 
 theorem DifferentiableWithinAt.comp_mdifferentiableWithinAt
     {g : F → F'} {f : M → F} {s : Set M} {t : Set F}
-    {x : M} (hg : DifferentiableWithinAt 𝕜 g t (f x)) (hf : MDifferentiableWithinAt I 𝓘(𝕜, F) f s x)
-    (h : MapsTo f s t) : MDifferentiableWithinAt I 𝓘(𝕜, F') (g ∘ f) s x :=
+    {x : M} (hg : DifferentiableWithinAt 𝕜 g t (f x)) (hf : MDiffAt[s] f x)
+    (h : MapsTo f s t) : MDiffAt[s] (g ∘ f) x :=
   hg.mdifferentiableWithinAt.comp x hf h
 
 theorem DifferentiableAt.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M}
-    {x : M} (hg : DifferentiableAt 𝕜 g (f x)) (hf : MDifferentiableWithinAt I 𝓘(𝕜, F) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F') (g ∘ f) s x :=
+    {x : M} (hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (g ∘ f) x :=
   hg.mdifferentiableAt.comp_mdifferentiableWithinAt x hf
 
 theorem DifferentiableAt.comp_mdifferentiableAt
     {g : F → F'} {f : M → F} {x : M} (hg : DifferentiableAt 𝕜 g (f x))
-    (hf : MDifferentiableAt I 𝓘(𝕜, F) f x) : MDifferentiableAt I 𝓘(𝕜, F') (g ∘ f) x :=
+    (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
   hg.comp_mdifferentiableWithinAt hf
 
 theorem Differentiable.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M} {x : M}
-    (hg : Differentiable 𝕜 g) (hf : MDifferentiableWithinAt I 𝓘(𝕜, F) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F') (g ∘ f) s x :=
+    (hg : Differentiable 𝕜 g) (hf : MDiffAt[s] f x) : MDiffAt[s] (g ∘ f) x :=
   hg.differentiableAt.comp_mdifferentiableWithinAt hf
 
 theorem Differentiable.comp_mdifferentiableAt
     {g : F → F'} {f : M → F} {x : M} (hg : Differentiable 𝕜 g)
-    (hf : MDifferentiableAt I 𝓘(𝕜, F) f x) : MDifferentiableAt I 𝓘(𝕜, F') (g ∘ f) x :=
+    (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
   hg.comp_mdifferentiableWithinAt hf
 
 theorem Differentiable.comp_mdifferentiable {g : F → F'} {f : M → F} (hg : Differentiable 𝕜 g)
-    (hf : MDifferentiable I 𝓘(𝕜, F) f) : MDifferentiable I 𝓘(𝕜, F') (g ∘ f) := fun x =>
+    (hf : MDiff f) : MDiff (g ∘ f) := fun x =>
   hg.differentiableAt.comp_mdifferentiableAt (hf x)
 
 end Module
@@ -88,8 +87,7 @@ section ExtChartAt
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : M → F}
 
 -- TODO: add pre-composition version also
-theorem MDifferentiableWithinAt.differentiableWithinAt_comp_extChartAt_symm
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F) f s x) :
+theorem MDifferentiableWithinAt.differentiableWithinAt_comp_extChartAt_symm (hf : MDiffAt[s] f x) :
     letI φ := extChartAt I x
     DifferentiableWithinAt 𝕜 (f ∘ φ.symm) (φ.symm ⁻¹' s ∩ range I) (φ x) := by
   simpa [extChartAt_self_eq] using (mdifferentiableWithinAt_iff.1 hf).2
@@ -98,7 +96,7 @@ theorem MDifferentiableWithinAt.differentiableWithinAt_comp_extChartAt_symm
 theorem DifferentiableWithinAt.mdifferentiableWithinAt_of_comp_extChartAt_symm [IsManifold I 1 M]
     (hf : letI φ := extChartAt I x
       DifferentiableWithinAt 𝕜 (f ∘ φ.symm) (φ.symm ⁻¹' s ∩ range I) (φ x)) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F) f s x := by
+    MDiffAt[s] f x := by
   refine (mdifferentiableWithinAt_iff_source_of_mem_source (mem_chart_source H x)).2 ?_
   simpa [extChartAt_self_eq] using hf.mdifferentiableWithinAt
 
@@ -107,95 +105,73 @@ end ExtChartAt
 /-! ### Linear maps between normed spaces are differentiable -/
 
 theorem MDifferentiableWithinAt.clm_precomp {f : M → F₁ →L[𝕜] F₂} {s : Set M} {x : M}
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) s x :=
+    (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
   Differentiable.comp_mdifferentiableWithinAt
-    (ContinuousLinearMap.differentiable
-      (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃).flip) hf
+    (ContinuousLinearMap.differentiable (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃).flip) hf
 
-nonrec theorem MDifferentiableAt.clm_precomp {f : M → F₁ →L[𝕜] F₂} {x : M}
-    (hf : MDifferentiableAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) f x) :
-    MDifferentiableAt I 𝓘(𝕜, (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
+nonrec theorem MDifferentiableAt.clm_precomp {f : M → F₁ →L[𝕜] F₂} {x : M} (hf : MDiffAt f x) :
+    MDiffAt (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
   Differentiable.comp_mdifferentiableAt
-    (ContinuousLinearMap.differentiable
-      (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃).flip) hf
+    (ContinuousLinearMap.differentiable (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃).flip) hf
 
-theorem MDifferentiableOn.clm_precomp {f : M → F₁ →L[𝕜] F₂} {s : Set M}
-    (hf : MDifferentiableOn I 𝓘(𝕜, F₁ →L[𝕜] F₂) f s) :
-    MDifferentiableOn I 𝓘(𝕜, (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) s := fun x hx ↦
-  (hf x hx).clm_precomp
+theorem MDifferentiableOn.clm_precomp {f : M → F₁ →L[𝕜] F₂} {s : Set M} (hf : MDiff[s] f) :
+    MDiff[s] (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) :=
+  fun x hx ↦ (hf x hx).clm_precomp
 
 theorem MDifferentiable.clm_precomp
-    {f : M → F₁ →L[𝕜] F₂} (hf : MDifferentiable I 𝓘(𝕜, F₁ →L[𝕜] F₂) f) :
-    MDifferentiable I 𝓘(𝕜, (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
+    {f : M → F₁ →L[𝕜] F₂} (hf : MDiff f) :
+    MDiff (fun y ↦ (f y).precomp F₃ : M → (F₂ →L[𝕜] F₃) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
   (hf x).clm_precomp
 
 theorem MDifferentiableWithinAt.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {s : Set M} {x : M}
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₂ →L[𝕜] F₃) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) s x :=
+    (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
   Differentiable.comp_mdifferentiableWithinAt
-    (ContinuousLinearMap.differentiable
-      (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃)) hf
+    (ContinuousLinearMap.differentiable (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃)) hf
 
-theorem MDifferentiableAt.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {x : M}
-    (hf : MDifferentiableAt I 𝓘(𝕜, F₂ →L[𝕜] F₃) f x) :
-    MDifferentiableAt I 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
+theorem MDifferentiableAt.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {x : M} (hf : MDiffAt f x) :
+    MDiffAt (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) x :=
   Differentiable.comp_mdifferentiableAt
-    (ContinuousLinearMap.differentiable
-      (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃)) hf
+    (ContinuousLinearMap.differentiable (ContinuousLinearMap.compL 𝕜 F₁ F₂ F₃)) hf
 
-nonrec theorem MDifferentiableOn.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {s : Set M}
-    (hf : MDifferentiableOn I 𝓘(𝕜, F₂ →L[𝕜] F₃) f s) :
-    MDifferentiableOn I 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) s := fun x hx ↦
+nonrec theorem MDifferentiableOn.clm_postcomp {f : M → F₂ →L[𝕜] F₃} {s : Set M} (hf : MDiff[s] f) :
+    MDiff[s] (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x hx ↦
   (hf x hx).clm_postcomp
 
-theorem MDifferentiable.clm_postcomp
-    {f : M → F₂ →L[𝕜] F₃} (hf : MDifferentiable I 𝓘(𝕜, F₂ →L[𝕜] F₃) f) :
-    MDifferentiable I 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃))
-      (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
+theorem MDifferentiable.clm_postcomp {f : M → F₂ →L[𝕜] F₃} (hf : MDiff f) :
+    MDiff (fun y ↦ (f y).postcomp F₁ : M → (F₁ →L[𝕜] F₂) →L[𝕜] (F₁ →L[𝕜] F₃)) := fun x ↦
   (hf x).clm_postcomp
 
 theorem MDifferentiableWithinAt.clm_comp
     {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₁} {s : Set M} {x : M}
-    (hg : MDifferentiableWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₃) g s x)
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₂ →L[𝕜] F₁) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F₂ →L[𝕜] F₃) (fun x => (g x).comp (f x)) s x :=
+    (hg : MDiffAt[s] g x) (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (fun x ↦ (g x).comp (f x)) x :=
   Differentiable.comp_mdifferentiableWithinAt
     (g := fun x : (F₁ →L[𝕜] F₃) × (F₂ →L[𝕜] F₁) => x.1.comp x.2)
     (f := fun x => (g x, f x)) (differentiable_fst.clm_comp differentiable_snd)
     (hg.prodMk_space hf)
 
 theorem MDifferentiableAt.clm_comp {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₁} {x : M}
-    (hg : MDifferentiableAt I 𝓘(𝕜, F₁ →L[𝕜] F₃) g x)
-    (hf : MDifferentiableAt I 𝓘(𝕜, F₂ →L[𝕜] F₁) f x) :
-    MDifferentiableAt I 𝓘(𝕜, F₂ →L[𝕜] F₃) (fun x => (g x).comp (f x)) x :=
+    (hg : MDiffAt g x) (hf : MDiffAt f x) :
+    MDiffAt (fun x ↦ (g x).comp (f x)) x :=
   (hg.mdifferentiableWithinAt.clm_comp hf.mdifferentiableWithinAt).mdifferentiableAt Filter.univ_mem
 
 theorem MDifferentiableOn.clm_comp {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₁} {s : Set M}
-    (hg : MDifferentiableOn I 𝓘(𝕜, F₁ →L[𝕜] F₃) g s)
-    (hf : MDifferentiableOn I 𝓘(𝕜, F₂ →L[𝕜] F₁) f s) :
-    MDifferentiableOn I 𝓘(𝕜, F₂ →L[𝕜] F₃) (fun x => (g x).comp (f x)) s := fun x hx =>
-  (hg x hx).clm_comp (hf x hx)
+    (hg : MDiff[s] g) (hf : MDiff[s] f) : MDiff[s] (fun x ↦ (g x).comp (f x)) :=
+  fun x hx ↦ (hg x hx).clm_comp (hf x hx)
 
 theorem MDifferentiable.clm_comp {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₁}
-    (hg : MDifferentiable I 𝓘(𝕜, F₁ →L[𝕜] F₃) g) (hf : MDifferentiable I 𝓘(𝕜, F₂ →L[𝕜] F₁) f) :
-    MDifferentiable I 𝓘(𝕜, F₂ →L[𝕜] F₃) fun x => (g x).comp (f x) := fun x => (hg x).clm_comp (hf x)
+    (hg : MDiff g) (hf : MDiff f) : MDiff fun x ↦ (g x).comp (f x) :=
+  fun x ↦ (hg x).clm_comp (hf x)
 
 /-- Applying a linear map to a vector is differentiable within a set. Version in vector spaces. For
 a version in nontrivial vector bundles, see `MDifferentiableWithinAt.clm_apply_of_inCoordinates`. -/
 theorem MDifferentiableWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {s : Set M} {x : M}
-    (hg : MDifferentiableWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) g s x)
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₁) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F₂) (fun x => g x (f x)) s x :=
+    (hg : MDiffAt[s] g x) (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (fun x ↦ g x (f x)) x :=
   DifferentiableWithinAt.comp_mdifferentiableWithinAt (t := univ)
-    (g := fun x : (F₁ →L[𝕜] F₂) × F₁ => x.1 x.2)
+    (g := fun x : (F₁ →L[𝕜] F₂) × F₁ ↦ x.1 x.2)
     (by apply (Differentiable.differentiableAt _).differentiableWithinAt
         exact differentiable_fst.clm_apply differentiable_snd) (hg.prodMk_space hf)
     (by simp_rw [mapsTo_univ])
@@ -203,8 +179,7 @@ theorem MDifferentiableWithinAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : 
 /-- Applying a linear map to a vector is differentiable. Version in vector spaces. For a
 version in nontrivial vector bundles, see `MDifferentiableAt.clm_apply_of_inCoordinates`. -/
 theorem MDifferentiableAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {x : M}
-    (hg : MDifferentiableAt I 𝓘(𝕜, F₁ →L[𝕜] F₂) g x) (hf : MDifferentiableAt I 𝓘(𝕜, F₁) f x) :
-    MDifferentiableAt I 𝓘(𝕜, F₂) (fun x => g x (f x)) x :=
+    (hg : MDiffAt g x) (hf : MDiffAt f x) : MDiffAt (fun x ↦ g x (f x)) x :=
   DifferentiableWithinAt.comp_mdifferentiableWithinAt (t := univ)
     (g := fun x : (F₁ →L[𝕜] F₂) × F₁ => x.1 x.2)
     (by apply (Differentiable.differentiableAt _).differentiableWithinAt
@@ -212,74 +187,65 @@ theorem MDifferentiableAt.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → 
     (by simp_rw [mapsTo_univ])
 
 theorem MDifferentiableOn.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁} {s : Set M}
-    (hg : MDifferentiableOn I 𝓘(𝕜, F₁ →L[𝕜] F₂) g s) (hf : MDifferentiableOn I 𝓘(𝕜, F₁) f s) :
-    MDifferentiableOn I 𝓘(𝕜, F₂) (fun x => g x (f x)) s := fun x hx => (hg x hx).clm_apply (hf x hx)
+    (hg : MDiff[s] g) (hf : MDiff[s] f) : MDiff[s] (fun x ↦ g x (f x)) :=
+  fun x hx ↦ (hg x hx).clm_apply (hf x hx)
 
 theorem MDifferentiable.clm_apply {g : M → F₁ →L[𝕜] F₂} {f : M → F₁}
-    (hg : MDifferentiable I 𝓘(𝕜, F₁ →L[𝕜] F₂) g) (hf : MDifferentiable I 𝓘(𝕜, F₁) f) :
-    MDifferentiable I 𝓘(𝕜, F₂) fun x => g x (f x) := fun x => (hg x).clm_apply (hf x)
+    (hg : MDiff g) (hf : MDiff f) : MDiff fun x ↦ g x (f x) :=
+  fun x ↦ (hg x).clm_apply (hf x)
 
 theorem MDifferentiableWithinAt.cle_arrowCongr {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄}
     {s : Set M} {x : M}
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₂ →L[𝕜] F₁) (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) s x)
-    (hg : MDifferentiableWithinAt I 𝓘(𝕜, F₃ →L[𝕜] F₄) (fun x ↦ (g x : F₃ →L[𝕜] F₄)) s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
-      (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) s x :=
+    (hf : MDiffAt[s] (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) x)
+    (hg : MDiffAt[s] (fun x ↦ (g x : F₃ →L[𝕜] F₄)) x) :
+    MDiffAt[s] (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) x :=
   show MDifferentiableWithinAt I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
     (fun y ↦ (((f y).symm : F₂ →L[𝕜] F₁).precomp F₄).comp ((g y : F₃ →L[𝕜] F₄).postcomp F₁)) s x
   from hf.clm_precomp (F₃ := F₄) |>.clm_comp <| hg.clm_postcomp (F₁ := F₁)
 
 theorem MDifferentiableAt.cle_arrowCongr {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄} {x : M}
-    (hf : MDifferentiableAt I 𝓘(𝕜, F₂ →L[𝕜] F₁) (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) x)
-    (hg : MDifferentiableAt I 𝓘(𝕜, F₃ →L[𝕜] F₄) (fun x ↦ (g x : F₃ →L[𝕜] F₄)) x) :
-    MDifferentiableAt I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
-      (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) x :=
+    (hf : MDiffAt (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) x)
+    (hg : MDiffAt (fun x ↦ (g x : F₃ →L[𝕜] F₄)) x) :
+    MDiffAt (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) x :=
   show MDifferentiableAt I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
     (fun y ↦ (((f y).symm : F₂ →L[𝕜] F₁).precomp F₄).comp ((g y : F₃ →L[𝕜] F₄).postcomp F₁)) x
   from hf.clm_precomp (F₃ := F₄) |>.clm_comp <| hg.clm_postcomp (F₁ := F₁)
 
 theorem MDifferentiableOn.cle_arrowCongr {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄} {s : Set M}
-    (hf : MDifferentiableOn I 𝓘(𝕜, F₂ →L[𝕜] F₁) (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)) s)
-    (hg : MDifferentiableOn I 𝓘(𝕜, F₃ →L[𝕜] F₄) (fun x ↦ (g x : F₃ →L[𝕜] F₄)) s) :
-    MDifferentiableOn I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
-      (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) s := fun x hx ↦
+    (hf : MDiff[s] (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)))
+    (hg : MDiff[s] (fun x ↦ (g x : F₃ →L[𝕜] F₄))) :
+    MDiff[s] (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) := fun x hx ↦
   (hf x hx).cle_arrowCongr (hg x hx)
 
 theorem MDifferentiable.cle_arrowCongr {f : M → F₁ ≃L[𝕜] F₂} {g : M → F₃ ≃L[𝕜] F₄}
-    (hf : MDifferentiable I 𝓘(𝕜, F₂ →L[𝕜] F₁) (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)))
-    (hg : MDifferentiable I 𝓘(𝕜, F₃ →L[𝕜] F₄) (fun x ↦ (g x : F₃ →L[𝕜] F₄))) :
-    MDifferentiable I 𝓘(𝕜, (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄))
-      (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) := fun x ↦
+    (hf : MDiff (fun x ↦ ((f x).symm : F₂ →L[𝕜] F₁)))
+    (hg : MDiff (fun x ↦ (g x : F₃ →L[𝕜] F₄))) :
+    MDiff (fun y ↦ (f y).arrowCongr (g y) : M → (F₁ →L[𝕜] F₃) →L[𝕜] (F₂ →L[𝕜] F₄)) := fun x ↦
   (hf x).cle_arrowCongr (hg x)
 
 theorem MDifferentiableWithinAt.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₄} {s : Set M}
-    {x : M} (hg : MDifferentiableWithinAt I 𝓘(𝕜, F₁ →L[𝕜] F₃) g s x)
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜, F₂ →L[𝕜] F₄) f s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, F₁ × F₂ →L[𝕜] F₃ × F₄) (fun x => (g x).prodMap (f x)) s x :=
+    {x : M} (hg : MDiffAt[s] g x) (hf : MDiffAt[s] f x) :
+    MDiffAt[s] (fun x ↦ (g x).prodMap (f x)) x :=
   Differentiable.comp_mdifferentiableWithinAt
     (g := fun x : (F₁ →L[𝕜] F₃) × (F₂ →L[𝕜] F₄) => x.1.prodMap x.2)
     (f := fun x => (g x, f x)) (ContinuousLinearMap.prodMapL 𝕜 F₁ F₃ F₂ F₄).differentiable
     (hg.prodMk_space hf)
 
 nonrec theorem MDifferentiableAt.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₄} {x : M}
-    (hg : MDifferentiableAt I 𝓘(𝕜, F₁ →L[𝕜] F₃) g x)
-    (hf : MDifferentiableAt I 𝓘(𝕜, F₂ →L[𝕜] F₄) f x) :
-    MDifferentiableAt I 𝓘(𝕜, F₁ × F₂ →L[𝕜] F₃ × F₄) (fun x => (g x).prodMap (f x)) x :=
+    (hg : MDiffAt g x) (hf : MDiffAt f x) : MDiffAt (fun x ↦ (g x).prodMap (f x)) x :=
   Differentiable.comp_mdifferentiableWithinAt
     (g := fun x : (F₁ →L[𝕜] F₃) × (F₂ →L[𝕜] F₄) => x.1.prodMap x.2)
     (f := fun x => (g x, f x)) (ContinuousLinearMap.prodMapL 𝕜 F₁ F₃ F₂ F₄).differentiable
     (hg.prodMk_space hf)
 
 theorem MDifferentiableOn.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₄} {s : Set M}
-    (hg : MDifferentiableOn I 𝓘(𝕜, F₁ →L[𝕜] F₃) g s)
-    (hf : MDifferentiableOn I 𝓘(𝕜, F₂ →L[𝕜] F₄) f s) :
-    MDifferentiableOn I 𝓘(𝕜, F₁ × F₂ →L[𝕜] F₃ × F₄) (fun x => (g x).prodMap (f x)) s := fun x hx =>
-  (hg x hx).clm_prodMap (hf x hx)
+    (hg : MDiff[s] g) (hf : MDiff[s] f) :
+    MDiff[s] (fun x ↦ (g x).prodMap (f x)) :=
+  fun x hx ↦ (hg x hx).clm_prodMap (hf x hx)
 
 theorem MDifferentiable.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ →L[𝕜] F₄}
-    (hg : MDifferentiable I 𝓘(𝕜, F₁ →L[𝕜] F₃) g) (hf : MDifferentiable I 𝓘(𝕜, F₂ →L[𝕜] F₄) f) :
-    MDifferentiable I 𝓘(𝕜, F₁ × F₂ →L[𝕜] F₃ × F₄) fun x => (g x).prodMap (f x) := fun x =>
-  (hg x).clm_prodMap (hf x)
+    (hg : MDiff g) (hf : MDiff f) : MDiff fun x ↦ (g x).prodMap (f x) :=
+  fun x ↦ (hg x).clm_prodMap (hf x)
 
 /-! ### Differentiability of scalar multiplication -/
 
@@ -304,9 +270,9 @@ canonical identification. (It would also be possible to phrase the formula witho
 instead using casting and definitional abuse.) -/
 lemma HasMFDerivAt.smul
     {f' : TangentSpace I x →L[𝕜] 𝕜}
-    (hs : HasMFDerivAt I 𝓘(𝕜, 𝕜) f x ((fromTangentSpace _).symm.toContinuousLinearMap ∘L f'))
+    (hs : HasMFDerivAt% f x ((fromTangentSpace (f x)).symm.toContinuousLinearMap ∘L f'))
     {g' : TangentSpace I x →L[𝕜] V}
-    (hg : HasMFDerivAt I 𝓘(𝕜, V) g x ((fromTangentSpace _).symm.toContinuousLinearMap ∘L g')) :
+    (hg : HasMFDerivAt% g x ((fromTangentSpace (g x)).symm.toContinuousLinearMap ∘L g')) :
     -- canonically identify `g'` with a linear map into the tangent space at `(f • g) x`
     letI g'_ : TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, V) ((f • g) x) :=
       (fromTangentSpace _).symm.toContinuousLinearMap ∘L g'
@@ -314,28 +280,27 @@ lemma HasMFDerivAt.smul
     letI gx :  𝕜 →L[𝕜] TangentSpace 𝓘(𝕜, V) ((f • g) x) :=
       toSpanSingleton 𝕜 ((fromTangentSpace _).symm (g x))
     -- now the main statement typechecks
-    HasMFDerivAt I 𝓘(𝕜, V) (f • g) x (f x • g'_ + gx ∘L f') := by
+    HasMFDerivAt% (f • g) x (f x • g'_ + gx ∘L f') := by
   constructor
   · exact hs.1.smul hg.1
   · simpa using hs.2.smul hg.2
 
 theorem MDifferentiableWithinAt.smul
-    (hf : MDifferentiableWithinAt I 𝓘(𝕜) f s x) (hg : MDifferentiableWithinAt I 𝓘(𝕜, V) g s x) :
-    MDifferentiableWithinAt I 𝓘(𝕜, V) (fun p => f p • g p) s x :=
+    (hf : MDiffAt[s] f x) (hg : MDiffAt[s] g x) :
+    MDiffAt[s] (fun p ↦ f p • g p) x :=
   ((contMDiff_smul.of_le le_top).mdifferentiable one_ne_zero _).comp_mdifferentiableWithinAt x
     (hf.prodMk hg)
 
-theorem MDifferentiableAt.smul (hf : MDifferentiableAt I 𝓘(𝕜) f x)
-    (hg : MDifferentiableAt I 𝓘(𝕜, V) g x) : MDifferentiableAt I 𝓘(𝕜, V) (fun p => f p • g p) x :=
+theorem MDifferentiableAt.smul (hf : MDiffAt f x)
+    (hg : MDiffAt g x) : MDiffAt (fun p ↦ f p • g p) x :=
   ((contMDiff_smul.of_le le_top).mdifferentiable one_ne_zero _).comp x (hf.prodMk hg)
 
-theorem MDifferentiableOn.smul (hf : MDifferentiableOn I 𝓘(𝕜) f s)
-    (hg : MDifferentiableOn I 𝓘(𝕜, V) g s) : MDifferentiableOn I 𝓘(𝕜, V) (fun p => f p • g p) s :=
-  fun x hx => (hf x hx).smul (hg x hx)
+theorem MDifferentiableOn.smul (hf : MDiff[s] f)
+    (hg : MDiff[s] g) : MDiff[s] (fun p ↦ f p • g p) :=
+  fun x hx ↦ (hf x hx).smul (hg x hx)
 
-theorem MDifferentiable.smul (hf : MDifferentiable I 𝓘(𝕜) f)
-    (hg : MDifferentiable I 𝓘(𝕜, V) g) : MDifferentiable I 𝓘(𝕜, V) fun p => f p • g p := fun x =>
-  (hf x).smul (hg x)
+theorem MDifferentiable.smul (hf : MDiff f) (hg : MDiff g) : MDiff fun p ↦ f p • g p :=
+  fun x ↦ (hf x).smul (hg x)
 
 /-- Given maps `f`, `g` from a manifold into a field `𝕜` and `𝕜`-vector space `V`, respectively, the
 formula for the `mfderiv` (differential) of their scalar multiplication `f • g`.

--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -52,33 +52,30 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : WithTop ℕ∞}
 section Module
 
 theorem DifferentiableWithinAt.comp_mdifferentiableWithinAt
-    {g : F → F'} {f : M → F} {s : Set M} {t : Set F}
-    {x : M} (hg : DifferentiableWithinAt 𝕜 g t (f x)) (hf : MDiffAt[s] f x)
-    (h : MapsTo f s t) : MDiffAt[s] (g ∘ f) x :=
+    {g : F → F'} {f : M → F} {s : Set M} {t : Set F} {x : M}
+    (hg : DifferentiableWithinAt 𝕜 g t (f x)) (hf : MDiffAt[s] f x) (h : MapsTo f s t) :
+    MDiffAt[s] (g ∘ f) x :=
   hg.mdifferentiableWithinAt.comp x hf h
 
-theorem DifferentiableAt.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M}
-    {x : M} (hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt[s] f x) :
-    MDiffAt[s] (g ∘ f) x :=
+theorem DifferentiableAt.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M} {x : M}
+(hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt[s] f x) : MDiffAt[s] (g ∘ f) x :=
   hg.mdifferentiableAt.comp_mdifferentiableWithinAt x hf
 
-theorem DifferentiableAt.comp_mdifferentiableAt
-    {g : F → F'} {f : M → F} {x : M} (hg : DifferentiableAt 𝕜 g (f x))
-    (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
+theorem DifferentiableAt.comp_mdifferentiableAt {g : F → F'} {f : M → F} {x : M}
+    (hg : DifferentiableAt 𝕜 g (f x)) (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
   hg.comp_mdifferentiableWithinAt hf
 
 theorem Differentiable.comp_mdifferentiableWithinAt {g : F → F'} {f : M → F} {s : Set M} {x : M}
     (hg : Differentiable 𝕜 g) (hf : MDiffAt[s] f x) : MDiffAt[s] (g ∘ f) x :=
   hg.differentiableAt.comp_mdifferentiableWithinAt hf
 
-theorem Differentiable.comp_mdifferentiableAt
-    {g : F → F'} {f : M → F} {x : M} (hg : Differentiable 𝕜 g)
-    (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
+theorem Differentiable.comp_mdifferentiableAt {g : F → F'} {f : M → F} {x : M}
+    (hg : Differentiable 𝕜 g) (hf : MDiffAt f x) : MDiffAt (g ∘ f) x :=
   hg.comp_mdifferentiableWithinAt hf
 
-theorem Differentiable.comp_mdifferentiable {g : F → F'} {f : M → F} (hg : Differentiable 𝕜 g)
-    (hf : MDiff f) : MDiff (g ∘ f) := fun x =>
-  hg.differentiableAt.comp_mdifferentiableAt (hf x)
+theorem Differentiable.comp_mdifferentiable {g : F → F'} {f : M → F}
+    (hg : Differentiable 𝕜 g) (hf : MDiff f) : MDiff (g ∘ f) :=
+  fun x ↦ hg.differentiableAt.comp_mdifferentiableAt (hf x)
 
 end Module
 


### PR DESCRIPTION
…at scale

-------------

Somehow, I previously assumed that the elaborators could not be used in that file for dependency reasons. This was wrong, so we can make the file a lot nicer to read \o/


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
