### PR TITLE
[Merged by Bors] - feat(Computability.Primrec.List): add primrec proofs for drop, takeWhile, and dropWhile

### DIFF
--- a/Mathlib/Computability/Primrec/List.lean
+++ b/Mathlib/Computability/Primrec/List.lean
@@ -373,45 +373,29 @@ theorem nat_omega_rec (f : α → β → σ) {m : α → β → ℕ}
       (hg.comp₂ (fst.comp₂ .left) (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right))
       (by simpa using Ord) (by simpa [Function.comp] using H)
 /-- `List.drop` is primitive recursive. -/
-theorem list_drop : Primrec₂ fun (l : List α) (n : ℕ) => l.drop n :=
-  (nat_rec' snd fst (list_tail.comp (snd.comp snd)).to₂).to₂.of_eq fun l n => by
+theorem list_drop : Primrec₂ (List.drop : ℕ → List α → List α) :=
+  (nat_rec' fst snd (list_tail.comp (snd.comp snd)).to₂).of_eq fun ⟨n, l⟩ => by
     induction n generalizing l with
     | zero => rfl
     | succ n ih => simp [ih]
 
-/-- `List.takeWhile` is primitive recursive if the predicate is. -/
-theorem list_takeWhile {p : α → Bool} (hp : Primrec p) :
-    Primrec fun (l : List α) => l.takeWhile p :=
-  (list_rec Primrec.id (const [])
-    (cond (hp.comp (fst.comp snd))
-      (list_cons.comp (fst.comp snd) (snd.comp (snd.comp snd)))
-      (const [])).to₂).of_eq fun l => by
-    induction l with
-    | nil => rfl
-    | cons a l ih =>
-      dsimp at ih ⊢
-      rw [ih, List.takeWhile]
-      cases p a <;> rfl
+/-- `List.take` is primitive recursive. -/
+theorem list_take : Primrec₂ (List.take : ℕ → List α → List α) :=
+  (list_reverse.comp (list_drop.comp (nat_sub.comp (list_length.comp snd) fst)
+    (list_reverse.comp snd))).of_eq fun ⟨n, l⟩ => by
+    rw [← List.reverse_reverse (l.take n), List.reverse_take]
 
-/-- `List.dropWhile` is primitive recursive if the predicate is. -/
-theorem list_dropWhile {p : α → Bool} (hp : Primrec p) :
-    Primrec fun (l : List α) => l.dropWhile p :=
-  (list_rec Primrec.id (const [])
-    (cond (hp.comp (fst.comp snd))
-      (snd.comp (snd.comp snd))
-      (list_cons.comp (fst.comp snd) (fst.comp (snd.comp snd)))).to₂).of_eq fun l => by
-    induction l with
-    | nil => rfl
-    | cons a l ih =>
-      dsimp at ih ⊢
-      rw [ih, List.dropWhile]
-      cases p a <;> rfl
+/-- `List.takeWhile` is primitive recursive. -/
+theorem list_takeWhile {p : α → Bool} (hp : Primrec p) : Primrec (List.takeWhile p) :=
+  (list_take.comp (list_findIdx Primrec.id (Primrec.not.comp (hp.comp snd)).to₂)
+    Primrec.id).of_eq fun _ => List.takeWhile_eq_take_findIdx_not.symm
 
-/-- The length of a prefix satisfying a predicate is primitive recursive. -/
-theorem list_length_takeWhile {p : α → Bool} (hp : Primrec p) :
-    Primrec fun (l : List α) => (l.takeWhile p).length :=
-  list_length.comp (list_takeWhile hp)
+/-- `List.dropWhile` is primitive recursive. -/
+theorem list_dropWhile {p : α → Bool} (hp : Primrec p) : Primrec (List.dropWhile p) :=
+  (list_drop.comp (list_findIdx Primrec.id (Primrec.not.comp (hp.comp snd)).to₂)
+    Primrec.id).of_eq fun _ => List.dropWhile_eq_drop_findIdx_not.symm
 end Primrec
+
 
 namespace PrimrecPred
 

--- a/Mathlib/Computability/Primrec/List.lean
+++ b/Mathlib/Computability/Primrec/List.lean
@@ -372,7 +372,45 @@ theorem nat_omega_rec (f : α → β → σ) {m : α → β → ℕ}
       (list_map (hl.comp fst snd) (Primrec₂.pair.comp₂ (fst.comp₂ .left) .right))
       (hg.comp₂ (fst.comp₂ .left) (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right))
       (by simpa using Ord) (by simpa [Function.comp] using H)
+/-- `List.drop` is primitive recursive. -/
+theorem list_drop : Primrec₂ fun (l : List α) (n : ℕ) => l.drop n :=
+  (nat_rec' snd fst (list_tail.comp (snd.comp snd)).to₂).to₂.of_eq fun l n => by
+    induction n generalizing l with
+    | zero => rfl
+    | succ n ih => simp [ih]
 
+/-- `List.takeWhile` is primitive recursive if the predicate is. -/
+theorem list_takeWhile {p : α → Bool} (hp : Primrec p) :
+    Primrec fun (l : List α) => l.takeWhile p :=
+  (list_rec Primrec.id (const [])
+    (cond (hp.comp (fst.comp snd))
+      (list_cons.comp (fst.comp snd) (snd.comp (snd.comp snd)))
+      (const [])).to₂).of_eq fun l => by
+    induction l with
+    | nil => rfl
+    | cons a l ih =>
+      dsimp at ih ⊢
+      rw [ih, List.takeWhile]
+      cases p a <;> rfl
+
+/-- `List.dropWhile` is primitive recursive if the predicate is. -/
+theorem list_dropWhile {p : α → Bool} (hp : Primrec p) :
+    Primrec fun (l : List α) => l.dropWhile p :=
+  (list_rec Primrec.id (const [])
+    (cond (hp.comp (fst.comp snd))
+      (snd.comp (snd.comp snd))
+      (list_cons.comp (fst.comp snd) (fst.comp (snd.comp snd)))).to₂).of_eq fun l => by
+    induction l with
+    | nil => rfl
+    | cons a l ih =>
+      dsimp at ih ⊢
+      rw [ih, List.dropWhile]
+      cases p a <;> rfl
+
+/-- The length of a prefix satisfying a predicate is primitive recursive. -/
+theorem list_length_takeWhile {p : α → Bool} (hp : Primrec p) :
+    Primrec fun (l : List α) => (l.takeWhile p).length :=
+  list_length.comp (list_takeWhile hp)
 end Primrec
 
 namespace PrimrecPred

--- a/Mathlib/Computability/Primrec/List.lean
+++ b/Mathlib/Computability/Primrec/List.lean
@@ -371,13 +371,11 @@ theorem nat_omega_rec (f : α → β → σ) {m : α → β → ℕ}
       (Primrec₂.uncurry.mpr hm)
       (list_map (hl.comp fst snd) (Primrec₂.pair.comp₂ (fst.comp₂ .left) .right))
       (hg.comp₂ (fst.comp₂ .left) (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right))
-      (by simpa using Ord) (by simpa [Function.comp] using H)
+(by simpa using Ord) (by simpa [Function.comp] using H)
+
 /-- `List.drop` is primitive recursive. -/
 theorem list_drop : Primrec₂ (List.drop : ℕ → List α → List α) :=
-  (nat_rec' fst snd (list_tail.comp (snd.comp snd)).to₂).of_eq fun ⟨n, l⟩ => by
-    induction n generalizing l with
-    | zero => rfl
-    | succ n ih => simp [ih]
+  (nat_iterate fst snd (list_tail.comp₂ .right)).to₂.of_eq fun n l => l.tail_iterate n
 
 /-- `List.take` is primitive recursive. -/
 theorem list_take : Primrec₂ (List.take : ℕ → List α → List α) :=
@@ -394,8 +392,8 @@ theorem list_takeWhile {p : α → Bool} (hp : Primrec p) : Primrec (List.takeWh
 theorem list_dropWhile {p : α → Bool} (hp : Primrec p) : Primrec (List.dropWhile p) :=
   (list_drop.comp (list_findIdx Primrec.id (Primrec.not.comp (hp.comp snd)).to₂)
     Primrec.id).of_eq fun _ => List.dropWhile_eq_drop_findIdx_not.symm
-end Primrec
 
+end Primrec
 
 namespace PrimrecPred
 

--- a/Mathlib/Computability/Primrec/List.lean
+++ b/Mathlib/Computability/Primrec/List.lean
@@ -371,7 +371,7 @@ theorem nat_omega_rec (f : α → β → σ) {m : α → β → ℕ}
       (Primrec₂.uncurry.mpr hm)
       (list_map (hl.comp fst snd) (Primrec₂.pair.comp₂ (fst.comp₂ .left) .right))
       (hg.comp₂ (fst.comp₂ .left) (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right))
-(by simpa using Ord) (by simpa [Function.comp] using H)
+      (by simpa using Ord) (by simpa [Function.comp] using H)
 
 /-- `List.drop` is primitive recursive. -/
 theorem list_drop : Primrec₂ (List.drop : ℕ → List α → List α) :=

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Data.List.Defs
 public import Mathlib.Tactic.Common
+public import Mathlib.Logic.Function.Iterate
 
 /-!
 # `Take` and `Drop` lemmas for lists
@@ -163,5 +164,17 @@ theorem length_dropSlice (i j : ℕ) (xs : List α) :
 
 theorem length_dropSlice_lt (i j : ℕ) (hj : 0 < j) (xs : List α) (hi : i < xs.length) :
     (dropSlice i j xs).length < xs.length := by grind
+
+/-- Applying `tail` to a list `n` times is strictly equivalent to dropping `n` elements. -/
+theorem tail_iterate (l : List α) (n : ℕ) : (List.tail^[n]) l = l.drop n := by
+  induction n generalizing l with
+  | zero => rfl
+  | succ n ih =>
+    cases l with
+    | nil =>
+      change (List.tail^[n]) [] = []
+      rw [ih []]
+      cases n <;> rfl
+    | cons a as => exact ih as
 
 end List

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -82,6 +82,12 @@ lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) =
     rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
     simp [getLast_cons, hl]
 
+/-- Applying `tail` to a list `n` times is strictly equivalent to dropping `n` elements. -/
+theorem tail_iterate (l : List α) (n : ℕ) : (List.tail^[n]) l = l.drop n := by
+  induction n generalizing l with
+  | zero => rfl
+  | succ n ih => cases l <;> simp [*]
+
 section TakeI
 
 variable [Inhabited α]
@@ -164,17 +170,5 @@ theorem length_dropSlice (i j : ℕ) (xs : List α) :
 
 theorem length_dropSlice_lt (i j : ℕ) (hj : 0 < j) (xs : List α) (hi : i < xs.length) :
     (dropSlice i j xs).length < xs.length := by grind
-
-/-- Applying `tail` to a list `n` times is strictly equivalent to dropping `n` elements. -/
-theorem tail_iterate (l : List α) (n : ℕ) : (List.tail^[n]) l = l.drop n := by
-  induction n generalizing l with
-  | zero => rfl
-  | succ n ih =>
-    cases l with
-    | nil =>
-      change (List.tail^[n]) [] = []
-      rw [ih []]
-      cases n <;> rfl
-    | cons a as => exact ih as
 
 end List

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -82,7 +82,7 @@ lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) =
     rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
     simp [getLast_cons, hl]
 
-/-- Applying `tail` to a list `n` times is strictly equivalent to dropping `n` elements. -/
+/-- Applying `tail` to a list `n` times is equivalent to dropping `n` elements. -/
 theorem tail_iterate (l : List α) (n : ℕ) : (List.tail^[n]) l = l.drop n := by
   induction n generalizing l with
   | zero => rfl


### PR DESCRIPTION
This PR adds missing proofs that several standard `List` operations are primitive recursive (Primrec), as well as a basic property of `tail` and `drop`.

Specifically, it introduces:
* `List.tail_iterate`: Applying `tail` to a list `n` times is equivalent to dropping `n` elements.
* `Primrec.list_drop`: `List.drop` is primitive recursive.
* `Primrec.list_take`: `List.take` is primitive recursive.
* `Primrec.list_takeWhile`: `List.takeWhile` is primitive recursive.
* `Primrec.list_dropWhile`: `List.dropWhile` is primitive recursive.

These are basic computability properties for lists that were currently missing from `Mathlib.Computability.Primrec.List`. All proofs use standard combinators and `of_eq`.