### PR TITLE
[Merged by Bors] - ci: Revert splice_bot_wf_run.yaml to using app keys

### DIFF
--- a/.github/workflows/splice_bot_wf_run.yaml
+++ b/.github/workflows/splice_bot_wf_run.yaml
@@ -8,48 +8,8 @@ on:
 permissions: {}
 
 jobs:
-  mint-splicebot-tokens:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    outputs:
-      token: ${{ steps.token.outputs.token }}
-      authz_token: ${{ steps.authz-token.outputs.token }}
-      branch_token: ${{ steps.branch-token.outputs.token }}
-    steps:
-      - name: Mint splicebot token
-        id: token
-        uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
-        with:
-          app-id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
-          key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
-          key-name: mathlib-splicebot-app-pk
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_SPLICEBOT }}
-          azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
-          owner: leanprover-community
-
-      - name: Mint branch token
-        id: branch-token
-        uses: leanprover-community/mathlib-ci/.github/actions/azure-create-github-app-token@3bb576208589a435eeaeac9b144a1b7c3e948760
-        with:
-          app-id: ${{ secrets.MATHLIB_COPY_SPLICEBOT_APP_ID }}
-          key-vault-name: ${{ vars.MATHLIB_AZ_KEY_VAULT_NAME }}
-          key-name: mathlib-copy-splicebot-app-pk
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID_SPLICEBOT }}
-          azure-tenant-id: ${{ secrets.LPC_AZ_TENANT_ID }}
-          owner: leanprover-community
-
-      - name: Mint authz token
-        id: authz-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.LPC_TEAM_CHECK_APP_ID }}
-          private-key: ${{ secrets.LPC_TEAM_CHECK_PRIVATE_KEY }}
-          owner: leanprover-community
-
   run-reusable:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    needs: [mint-splicebot-tokens]
     uses: leanprover-community/SpliceBot/.github/workflows/splice_wf_run.yaml@fdb442693d6f613b25d2599ad64fd87cf019b9ce # master
     with:
       source_workflow: ${{ github.event.workflow_run.name }}
@@ -58,7 +18,12 @@ jobs:
       allowed_teams: |
         leanprover-community/mathlib-reviewers
         leanprover-community/mathlib-maintainers
+      # Installation owner used when minting token from app secrets below.
+      token_app_owner: leanprover-community
     secrets:
-      token: ${{ needs.mint-splicebot-tokens.outputs.token }}
-      authz_token: ${{ needs.mint-splicebot-tokens.outputs.authz_token }}
-      branch_token: ${{ needs.mint-splicebot-tokens.outputs.branch_token }}
+      token_app_id: ${{ secrets.MATHLIB_SPLICEBOT_APP_ID }}
+      token_app_private_key: ${{ secrets.MATHLIB_SPLICEBOT_PRIVATE_KEY }}
+      authz_token_app_id: ${{ secrets.LPC_TEAM_CHECK_APP_ID }}
+      authz_token_app_private_key: ${{ secrets.LPC_TEAM_CHECK_PRIVATE_KEY }}
+      branch_token_app_id: ${{ secrets.MATHLIB_COPY_SPLICEBOT_APP_ID }}
+      branch_token_app_private_key: ${{ secrets.MATHLIB_COPY_SPLICEBOT_PRIVATE_KEY }}


### PR DESCRIPTION
The change for this file was unsound, as you can't share secrets across jobs. We can come up with another strategy for this file (e.g., a reusable action), but let's revert to restore functionality