### PR TITLE
[Merged by Bors] - feat(CategoryTheory/MorphismProperty): Morphism property from object properties

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3020,6 +3020,7 @@ public import Mathlib.CategoryTheory.MorphismProperty.IsSmall
 public import Mathlib.CategoryTheory.MorphismProperty.LiftingProperty
 public import Mathlib.CategoryTheory.MorphismProperty.Limits
 public import Mathlib.CategoryTheory.MorphismProperty.Local
+public import Mathlib.CategoryTheory.MorphismProperty.OfObjectProperty
 public import Mathlib.CategoryTheory.MorphismProperty.OverAdjunction
 public import Mathlib.CategoryTheory.MorphismProperty.Quotient
 public import Mathlib.CategoryTheory.MorphismProperty.Representable

--- a/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Justus Springer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Justus Springer
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Limits
+
+/-!
+# Morphism properties from object properties
+
+Given two object properties `P` and `Q`, we introduce a morphism property
+`ofObjectProperty P Q`, given by all morphisms whose source satisfies `P` and
+target satisfies `Q`.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory.MorphismProperty
+
+variable {C : Type*} [Category* C]
+
+/-- Given two object properties `P` and `Q`, the property of morphisms whose source
+satisfies `P` and target satisfies `Q`. -/
+def ofObjectProperty (P Q : ObjectProperty C) : MorphismProperty C := fun X Y _ => P X ∧ Q Y
+
+variable (P Q : ObjectProperty C)
+
+lemma ofObjectProperty_iff {X Y : C} (f : X ⟶ Y) :
+    ofObjectProperty P Q f ↔ P X ∧ Q Y := Iff.rfl
+
+variable {P} in
+lemma monotone_ofObjectProperty_left {P' : ObjectProperty C} (h : P ≤ P') :
+    ofObjectProperty P Q ≤ ofObjectProperty P' Q := by
+  intro _ _ _ ⟨hX, hY⟩
+  exact ⟨h _ hX, hY⟩
+
+variable {Q} in
+lemma monotone_ofObjectProperty_right {Q' : ObjectProperty C} (h : Q ≤ Q') :
+    ofObjectProperty P Q ≤ ofObjectProperty P Q' := by
+  intro _ _ _ ⟨hX, hY⟩
+  exact ⟨hX, h _ hY⟩
+
+lemma ofObjectProperty_inverseImage {D : Type*} [Category* D] (F : D ⥤ C) :
+    ofObjectProperty (P.inverseImage F) (Q.inverseImage F) =
+    (ofObjectProperty P Q).inverseImage F := by
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+lemma ofObjectProperty_map_le {D : Type*} [Category* D] (F : C ⥤ D) :
+    (ofObjectProperty P Q).map F ≤ ofObjectProperty (P.map F) (Q.map F) := by
+  intro X Y f ⟨X', Y', f', ⟨hX', hY'⟩, ⟨i⟩⟩
+  exact ⟨⟨X', hX', ⟨Comma.leftIso i⟩⟩, ⟨Y', hY', ⟨Comma.rightIso i⟩⟩⟩
+
+instance [P.IsClosedUnderIsomorphisms] : (ofObjectProperty P Q).RespectsLeft (isomorphisms C) where
+  precomp := by
+    intro X Y Z i hi f ⟨hY, hZ⟩
+    rw [isomorphisms.iff] at hi
+    exact ⟨(P.prop_iff_of_isIso i).mpr hY, hZ⟩
+
+instance [Q.IsClosedUnderIsomorphisms] : (ofObjectProperty P Q).RespectsRight (isomorphisms C) where
+  postcomp := by
+    intro X Y Z i hi f ⟨hY, hZ⟩
+    rw [isomorphisms.iff] at hi
+    exact ⟨hY, (Q.prop_iff_of_isIso i).mp hZ⟩
+
+end CategoryTheory.MorphismProperty
+
+

--- a/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OfObjectProperty.lean
@@ -67,5 +67,3 @@ instance [Q.IsClosedUnderIsomorphisms] : (ofObjectProperty P Q).RespectsRight (i
     exact ⟨hY, (Q.prop_iff_of_isIso i).mp hZ⟩
 
 end CategoryTheory.MorphismProperty
-
-


### PR DESCRIPTION
Introduces `MorphismProperty.ofObjectProperty` with basic API.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
