### PR TITLE
[Merged by Bors] - ci: Fix permissions in maintainer_merge_wf_run.yml

### DIFF
--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -7,11 +7,6 @@ on:
     types:
       - completed
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-
 jobs:
   ping_zulip:
     name: Ping maintainers on Zulip
@@ -21,6 +16,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
+      pull-requests: write
     steps:
       - name: Consume bridge artifact
         id: bridge


### PR DESCRIPTION
Job-level permissions override top-level ones