### PR TITLE
refactor: change Encodable to uniquely specify `decode`

### DIFF
--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -55,9 +55,9 @@ class Encodable (α : Type*) where
   /-- Decoding from ℕ to Option α -/
   decode : ℕ → Option α
   /-- Invariant relationship between encoding and decoding -/
-  encodek : ∀ a, decode (encode a) = some a
+  isPartialInv : IsPartialInv encode decode
 
-attribute [simp] Encodable.encodek
+attribute [simp] Encodable.isPartialInv
 
 namespace Encodable
 
@@ -65,8 +65,8 @@ variable {α : Type*} {β : Type*}
 
 universe u
 
-theorem encode_injective [Encodable α] : Function.Injective (@encode α _)
-  | x, y, e => Option.some.inj <| by rw [← encodek, e, encodek]
+theorem encode_injective [Encodable α] : Function.Injective (@encode α _) :=
+  isPartialInv.injective
 
 @[simp]
 theorem encode_inj [Encodable α] {a b : α} : encode a = encode b ↔ a = b :=
@@ -78,8 +78,8 @@ instance (priority := 400) countable [Encodable α] : Countable α where
   exists_injective_nat' := ⟨_,encode_injective⟩
 
 theorem surjective_decode_getD (α : Type*) [Encodable α] (d : α) :
-    Surjective fun n => (Encodable.decode n).getD d := fun x =>
-  ⟨Encodable.encode x, by simp_rw [Encodable.encodek]; rfl⟩
+    Surjective fun n => (Encodable.decode n).getD d :=
+  isPartialInv.surjective_getD _
 
 @[deprecated surjective_decode_getD (since := "2026-01-05")]
 theorem surjective_decode_iget (α : Type*) [Encodable α] [Inhabited α] :
@@ -94,18 +94,17 @@ def decidableEqOfEncodable (α) [Encodable α] : DecidableEq α
 
 /-- If `α` is encodable and there is an injection `f : β → α`, then `β` is encodable as well. -/
 def ofLeftInjection [Encodable α] (f : β → α) (finv : α → Option β)
-    (linv : ∀ b, finv (f b) = some b) : Encodable β :=
-  ⟨fun b => encode (f b), fun n => (decode n).bind finv, fun b => by
-    simp [Encodable.encodek, linv]⟩
+    (linv : IsPartialInv f finv) : Encodable β :=
+  ⟨fun b => encode (f b), fun n => (decode n).bind finv, linv.comp isPartialInv⟩
 
-/-- If `α` is encodable and `f : β → α` is invertible, then `β` is encodable as well. -/
-def ofLeftInverse [Encodable α] (f : β → α) (finv : α → β) (linv : ∀ b, finv (f b) = b) :
-    Encodable β :=
-  ofLeftInjection f (some ∘ finv) fun b => congr_arg some (linv b)
+-- /-- If `α` is encodable and `f : β → α` is invertible, then `β` is encodable as well. -/
+-- def ofLeftInverse [Encodable α] (f : β → α) (finv : α → β) (linv : ∀ b, finv (f b) = b) :
+--     Encodable β :=
+--   ofLeftInjection f (some ∘ finv) fun b => congr_arg some (linv b)
 
 /-- Encodability is preserved by equivalence. -/
 def ofEquiv (α) [Encodable α] (e : β ≃ α) : Encodable β :=
-  ofLeftInverse e e.symm e.left_inv
+  ofLeftInjection e (some ∘ e.symm) <| e.symm.surjective.forall.2 <| by simp [eq_comm]
 
 theorem encode_ofEquiv {α β} [Encodable α] (e : β ≃ α) (b : β) :
     @encode _ (ofEquiv _ e) b = encode (e b) :=
@@ -117,7 +116,7 @@ theorem decode_ofEquiv {α β} [Encodable α] (e : β ≃ α) (n : ℕ) :
   by rw [Option.map_eq_bind]
 
 instance _root_.Nat.encodable : Encodable ℕ :=
-  ⟨id, some, fun _ => rfl⟩
+  ⟨id, some, fun _ => by simp [eq_comm]⟩
 
 @[simp]
 theorem encode_nat (n : ℕ) : encode n = n :=
@@ -131,7 +130,8 @@ instance (priority := 100) _root_.IsEmpty.toEncodable [IsEmpty α] : Encodable �
   ⟨isEmptyElim, fun _ => none, isEmptyElim⟩
 
 instance _root_.PUnit.encodable : Encodable PUnit :=
-  ⟨fun _ => 0, fun n => Nat.casesOn n (some PUnit.unit) fun _ => none, fun _ => by simp⟩
+  ⟨fun _ => 0, fun n => Nat.casesOn n (some PUnit.unit) fun _ => none, fun _ y => by
+    cases y <;> simp⟩
 
 @[simp]
 theorem encode_star : encode PUnit.unit = 0 :=
@@ -148,8 +148,8 @@ theorem decode_unit_succ (n) : decode (succ n) = (none : Option PUnit) :=
 /-- If `α` is encodable, then so is `Option α`. -/
 instance _root_.Option.encodable {α : Type*} [h : Encodable α] : Encodable (Option α) :=
   ⟨fun o => Option.casesOn o Nat.zero fun a => succ (encode a), fun n =>
-    Nat.casesOn n (some none) fun m => (decode m).map some, fun o => by
-    cases o <;> simp [encodek]⟩
+    Nat.casesOn n (some none) fun m => (decode m).map some, fun o y => by
+    cases o <;> cases y <;> simp [isPartialInv _]⟩
 
 @[simp]
 theorem encode_none [Encodable α] : encode (@none α) = 0 :=
@@ -171,15 +171,14 @@ theorem decode_option_succ [Encodable α] (n) :
 /-- Failsafe variant of `decode`. `decode₂ α n` returns the preimage of `n` under `encode` if it
 exists, and returns `none` if it doesn't. This requirement could be imposed directly on `decode` but
 is not to help make the definition easier to use. -/
-def decode₂ (α) [Encodable α] (n : ℕ) : Option α :=
-  (decode n).bind (Option.guard fun a => encode a = n)
+def decode₂ (α) [Encodable α] (n : ℕ) : Option α := decode n
 
 theorem mem_decode₂' [Encodable α] {n : ℕ} {a : α} :
     a ∈ decode₂ α n ↔ a ∈ decode n ∧ encode a = n := by
-  simp [decode₂, Option.bind_eq_some_iff]
+  simp [decode₂, isPartialInv _]
 
 theorem mem_decode₂ [Encodable α] {n : ℕ} {a : α} : a ∈ decode₂ α n ↔ encode a = n :=
-  mem_decode₂'.trans (and_iff_right_of_imp fun e => e ▸ encodek _)
+  isPartialInv _ _
 
 theorem decode₂_eq_some [Encodable α] {n : ℕ} {a : α} : decode₂ α n = some a ↔ encode a = n :=
   mem_decode₂
@@ -224,7 +223,8 @@ def equivRangeEncode (α : Type*) [Encodable α] : α ≃ Set.range (@encode α 
 
 /-- A type with unique element is encodable. This is not an instance to avoid diamonds. -/
 def _root_.Unique.encodable [Unique α] : Encodable α :=
-  ⟨fun _ => 0, fun _ => some default, Unique.forall_iff.2 rfl⟩
+  ⟨fun _ => 0, fun | 0 => some default | _ => none, fun x y => by
+    cases y <;> simp [Subsingleton.elim default x]⟩
 
 section Sum
 
@@ -239,11 +239,12 @@ def encodeSum : α ⊕ β → ℕ
 def decodeSum (n : ℕ) : Option (α ⊕ β) :=
   match boddDiv2 n with
   | (false, m) => (decode m : Option α).map Sum.inl
-  | (_, m) => (decode m : Option β).map Sum.inr
+  | (true, m) => (decode m : Option β).map Sum.inr
 
 /-- If `α` and `β` are encodable, then so is their sum. -/
 instance _root_.Sum.encodable : Encodable (α ⊕ β) :=
-  ⟨encodeSum, decodeSum, fun s => by cases s <;> simp [encodeSum, div2_val, decodeSum, encodek]⟩
+  ⟨encodeSum, decodeSum, fun s y => by
+    cases s <;> simp only [encodeSum, div2_val, decodeSum] <;> split <;> simp [isPartialInv _]⟩
 
 @[simp]
 theorem encode_inl (a : α) : @encode (α ⊕ β) _ (Sum.inl a) = 2 * (encode a) :=
@@ -306,8 +307,8 @@ def decodeSigma (n : ℕ) : Option (Sigma γ) :=
   (decode n₁).bind fun a => (decode n₂).map <| Sigma.mk a
 
 instance _root_.Sigma.encodable : Encodable (Sigma γ) :=
-  ⟨encodeSigma, decodeSigma, fun ⟨a, b⟩ => by
-    simp [encodeSigma, decodeSigma, unpair_pair, encodek]⟩
+  ⟨encodeSigma, decodeSigma, fun ⟨a, b⟩ y => by
+    simp [encodeSigma, decodeSigma, unpair_pair, Option.bind_eq_some_iff, isPartialInv _]⟩
 
 @[simp]
 theorem decode_sigma_val (n : ℕ) :
@@ -359,7 +360,8 @@ def decodeSubtype (v : ℕ) : Option { a : α // P a } :=
 
 /-- A decidable subtype of an encodable type is encodable. -/
 instance _root_.Subtype.encodable : Encodable { a : α // P a } :=
-  ⟨encodeSubtype, decodeSubtype, fun ⟨v, h⟩ => by simp [encodeSubtype, decodeSubtype, encodek, h]⟩
+  ⟨encodeSubtype, decodeSubtype, fun ⟨v, h⟩ y => by
+    simp [encodeSubtype, decodeSubtype, ← isPartialInv _, Option.bind_eq_some_iff, h]⟩
 
 theorem Subtype.encode_eq (a : Subtype P) : encode a = encode a.val := by cases a; rfl
 
@@ -384,7 +386,7 @@ instance _root_.PLift.encodable [Encodable α] : Encodable (PLift α) :=
 
 /-- If `β` is encodable and there is an injection `f : α → β`, then `α` is encodable as well. -/
 noncomputable def ofInj [Encodable β] (f : α → β) (hf : Injective f) : Encodable α :=
-  ofLeftInjection f (partialInv f) hf.isPartialInv.eq
+  ofLeftInjection f (partialInv f) hf.isPartialInv
 
 /-- If `α` is countable, then it has a (non-canonical) `Encodable` structure. -/
 @[no_expose]
@@ -499,7 +501,7 @@ set_option backward.privateInPublic.warn false in
 def chooseX (h : ∃ x, p x) : { a : α // p a } :=
   have : ∃ n, good p (decode n) :=
     let ⟨w, pw⟩ := h
-    ⟨encode w, by simp [good, encodek, pw]⟩
+    ⟨encode w, by simp [good, isPartialInv.eq, pw]⟩
   match (motive := ∀ o, good p o → { a // p a }) _, Nat.find_spec this with
   | some a, h => ⟨a, h⟩
 
@@ -564,7 +566,7 @@ theorem sequence_mono_nat {r : β → β → Prop} {f : α → β} (hf : Directe
 
 theorem rel_sequence {r : β → β → Prop} {f : α → β} (hf : Directed r f) (a : α) :
     r (f a) (f (hf.sequence f (encode a + 1))) := by
-  simp only [Directed.sequence, encodek]
+  simp only [Directed.sequence, isPartialInv.eq]
   exact (Classical.choose_spec (hf _ a)).2
 
 variable [Preorder β] {f : α → β}
@@ -606,12 +608,20 @@ on an encodable type. -/
 def Quotient.rep (q : Quotient s) : α :=
   choose (exists_rep q)
 
+@[simp, grind =]
 theorem Quotient.rep_spec (q : Quotient s) : ⟦q.rep⟧ = q :=
   choose_spec (exists_rep q)
 
 /-- The quotient of an encodable space by a decidable equivalence relation is encodable. -/
-def encodableQuotient : Encodable (Quotient s) :=
-  ⟨fun q => encode q.rep, fun n => Quotient.mk'' <$> decode n, by
-    rintro ⟨l⟩; dsimp; rw [encodek]; exact congr_arg some ⟦l⟧.rep_spec⟩
+def encodableQuotient : Encodable (Quotient s) where
+  encode q := encode q.rep
+  decode n := decode n |>.bind fun a => if encode ⟦a⟧.rep = n then some ⟦a⟧ else none
+  isPartialInv l y := by
+    induction l using Quotient.ind with | _ l
+    dsimp
+    cases h : (decode y : Option α)
+    · simp [← isPartialInv _, h]
+    · simp [← isPartialInv _, h]
+      grind
 
 end Quotient

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -193,8 +193,10 @@ theorem decode₂_ne_none_iff [Encodable α] {n : ℕ} :
   simp_rw [Set.range, Set.mem_setOf_eq, Ne, Option.eq_none_iff_forall_not_mem,
     Encodable.mem_decode₂, not_forall, not_not]
 
-theorem decode₂_is_partial_inv [Encodable α] : IsPartialInv encode (decode₂ α) := fun _ _ =>
+theorem decode₂_isPartialInv [Encodable α] : IsPartialInv encode (decode₂ α) := fun _ _ =>
   mem_decode₂
+
+@[deprecated (since := "2026-03-11")] alias decode₂_is_partial_inv := decode₂_isPartialInv
 
 theorem decode₂_inj [Encodable α] {n : ℕ} {a₁ a₂ : α} (h₁ : a₁ ∈ decode₂ α n)
     (h₂ : a₂ ∈ decode₂ α n) : a₁ = a₂ :=
@@ -208,7 +210,7 @@ theorem encodek₂ [Encodable α] (a : α) : decode₂ α (encode a) = some a :=
 def decidableRangeEncode (α : Type*) [Encodable α] : DecidablePred (· ∈ Set.range (@encode α _)) :=
   fun x =>
   decidable_of_iff (Option.isSome (decode₂ α x))
-    ⟨fun h => ⟨Option.get _ h, by rw [← decode₂_is_partial_inv (Option.get _ h), Option.some_get]⟩,
+    ⟨fun h => ⟨Option.get _ h, by rw [← decode₂_isPartialInv (Option.get _ h), Option.some_get]⟩,
       fun ⟨n, hn⟩ => by rw [← hn, encodek₂]; exact rfl⟩
 
 /-- An encodable type is equivalent to the range of its encoding function. -/
@@ -218,13 +220,7 @@ def equivRangeEncode (α : Type*) [Encodable α] : α ≃ Set.range (@encode α 
     Option.get _
       (show isSome (decode₂ α n.1) by obtain ⟨x, hx⟩ := n.2; rw [← hx, encodek₂]; exact rfl)
   left_inv a := by dsimp; rw [← Option.some_inj, Option.some_get, encodek₂]
-  right_inv := fun ⟨n, x, hx⟩ => by
-    apply Subtype.ext
-    dsimp
-    conv =>
-      rhs
-      rw [← hx]
-    rw [encode_injective.eq_iff, ← Option.some_inj, Option.some_get, ← hx, encodek₂]
+  right_inv := fun ⟨n, x, hx⟩ => Subtype.ext <| decode₂_isPartialInv.get_eq _ _
 
 /-- A type with unique element is encodable. This is not an instance to avoid diamonds. -/
 def _root_.Unique.encodable [Unique α] : Encodable α :=
@@ -388,7 +384,7 @@ instance _root_.PLift.encodable [Encodable α] : Encodable (PLift α) :=
 
 /-- If `β` is encodable and there is an injection `f : α → β`, then `α` is encodable as well. -/
 noncomputable def ofInj [Encodable β] (f : α → β) (hf : Injective f) : Encodable α :=
-  ofLeftInjection f (partialInv f) fun _ => (partialInv_of_injective hf _ _).2 rfl
+  ofLeftInjection f (partialInv f) hf.isPartialInv.eq
 
 /-- If `α` is countable, then it has a (non-canonical) `Encodable` structure. -/
 @[no_expose]

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -277,16 +277,34 @@ theorem not_surjective_Type {α : Type u} (f : α → Type max u v) : ¬Surjecti
 def IsPartialInv {α β} (f : α → β) (g : β → Option α) : Prop :=
   ∀ x y, g y = some x ↔ f x = y
 
-theorem isPartialInv_left {α β} {f : α → β} {g} (H : IsPartialInv f g) (x) : g (f x) = some x :=
+theorem IsPartialInv.eq {α β} {f : α → β} {g} (H : IsPartialInv f g) (x) : g (f x) = some x :=
   (H _ _).2 rfl
 
-theorem injective_of_isPartialInv {α β} {f : α → β} {g} (H : IsPartialInv f g) :
+theorem IsPartialInv.get_eq {α β} {f : α → β} {g} (H : IsPartialInv f g) (x) (h : g x |>.isSome) :
+    f (g x |>.get h) = x :=
+  match hg : g x, h with | some _, _ => (H _ _).1 hg
+
+theorem IsPartialInv.surjective_getD {α β} {f : α → β} {g} (H : IsPartialInv f g) (x) :
+    Function.Surjective (g · |>.getD x) :=
+  fun y => ⟨f y, by cases g (f y) <;> simp [H.eq]⟩
+
+@[deprecated (since := "2026-03-11")] alias isPartialInv_left := IsPartialInv.eq
+
+theorem IsPartialInv.injective {α β} {f : α → β} {g} (H : IsPartialInv f g) :
     Injective f := fun _ _ h ↦
   Option.some.inj <| ((H _ _).2 h).symm.trans ((H _ _).2 rfl)
+
+@[deprecated (since := "2026-03-11")] alias injective_of_isPartialInv := IsPartialInv.injective
 
 theorem injective_of_isPartialInv_right {α β} {f : α → β} {g} (H : IsPartialInv f g) (x y b)
     (h₁ : b ∈ g x) (h₂ : b ∈ g y) : x = y :=
   ((H _ _).1 h₁).symm.trans ((H _ _).1 h₂)
+
+theorem IsPartialInv.comp {α β γ} {f : α → β} {g : β → Option α} {h : β → γ} {i : γ → Option β}
+    (hf : IsPartialInv f g) (hh : IsPartialInv h i) :
+    IsPartialInv (h ∘ f) (i · |>.bind g) := by
+  intros a b
+  simp [Option.bind_eq_some_iff, hh _, hf _]
 
 lemma LeftInverse.eq {g : β → α} {f : α → β} (h : LeftInverse g f) (x : α) : g (f x) = x := h x
 
@@ -352,7 +370,7 @@ noncomputable def partialInv {α β} (f : α → β) (b : β) : Option α :=
   open scoped Classical in
   if h : ∃ a, f a = b then some (Classical.choose h) else none
 
-theorem partialInv_of_injective {α β} {f : α → β} (I : Injective f) : IsPartialInv f (partialInv f)
+theorem Injective.isPartialInv {α β} {f : α → β} (I : Injective f) : IsPartialInv f (partialInv f)
   | a, b =>
   ⟨fun h =>
     open scoped Classical in
@@ -367,8 +385,10 @@ theorem partialInv_of_injective {α β} {f : α → β} (I : Injective f) : IsPa
   fun e => e ▸ have h : ∃ a', f a' = f a := ⟨_, rfl⟩
               (dif_pos h).trans (congr_arg _ (I <| Classical.choose_spec h))⟩
 
+@[deprecated (since := "2026-03-11")] alias partialInv_of_injective := Injective.isPartialInv
+
 theorem partialInv_left {α β} {f : α → β} (I : Injective f) : ∀ x, partialInv f (f x) = some x :=
-  isPartialInv_left (partialInv_of_injective I)
+  I.isPartialInv.eq
 
 end
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
