### PR TITLE
[Merged by Bors] - doc(LinearAlgebra): fix typos

### DIFF
--- a/Mathlib/LinearAlgebra/PiTensorProduct/Dual.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Dual.lean
@@ -100,7 +100,7 @@ theorem dualDistrib_dualDistribInvOfBasis_right_inverse [Finite ι] [∀ i, Fini
 /-- A linear equivalence between `⨂[R] i, Dual R (M i)` and `Dual R (⨂[R] i, M i)`
 given bases for all `M i`. If `f : (i : ι) → Dual R (s i)`, then this equivalence sends
 `⨂ₜ[R] i, f i` to the composition of `PiTensorProduct.map f` with the natural
-isomorphism `⨂[R] i, R ≃ R` given by multipliccation (`constantBaseRingEquiv`). -/
+isomorphism `⨂[R] i, R ≃ R` given by multiplication (`constantBaseRingEquiv`). -/
 @[simps!]
 noncomputable def dualDistribEquivOfBasis [Finite ι] [∀ i, Finite (κ i)]
     (b : Π i, Basis (κ i) R (M i)) : (⨂[R] i, Dual R (M i)) ≃ₗ[R] Dual R (⨂[R] i, M i) :=
@@ -113,7 +113,7 @@ variable [Π i, Module.Finite R (M i)] [Π i, Module.Free R (M i)]
 /-- A linear equivalence between `⨂[R] i, Dual R (M i)` and `Dual R (⨂[R] i, M i)` when all
 `M i` are finite free modules. If `f : (i : ι) → Dual R (M i)`, then this equivalence sends
 `⨂ₜ[R] i, f i` to the composition of `PiTensorProduct.map f` with the natural
-isomorphism `⨂[R] i, R ≃ R` given by multipliccation (`constantBaseRingEquiv`). -/
+isomorphism `⨂[R] i, R ≃ R` given by multiplication (`constantBaseRingEquiv`). -/
 @[simp]
 noncomputable def dualDistribEquiv [Finite ι] :
     (⨂[R] i, Dual R (M i)) ≃ₗ[R] Dual R (⨂[R] i, M i) :=

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -44,7 +44,7 @@ namespace RootPairing
 /-- A root pairing is said to be reduced if any linearly dependent pair of roots is related by a
 sign.
 
-TODO Consider redefining this to make it perfectly symemtric between roots and coroots (i.e., so
+TODO Consider redefining this to make it perfectly symmetric between roots and coroots (i.e., so
 that the same demand is made of coroots) and turning `RootPairing.instFlipIsReduced` into a
 convenience constructor. -/
 @[mk_iff] class IsReduced : Prop where

--- a/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
@@ -27,7 +27,7 @@ from `ι → M` to `Sym[R] ι M` by `⨂ₛ[R] i, f i`. We also reserve the nota
   associative and commutative, and that `n ↦ Sym[R]^n M` is a graded (semi)ring and algebra.
 * Universal property: linear maps from `Sym[R]^n M` to `N` correspond to symmetric multilinear
   maps `M ^ n` to `N`.
-* Relate to homogneous (multivariate) polynomials of degree `n`.
+* Relate to homogeneous (multivariate) polynomials of degree `n`.
 
 -/
 

--- a/Mathlib/LinearAlgebra/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Transvection.lean
@@ -32,7 +32,7 @@ public import Mathlib.LinearAlgebra.Dual.BaseChange
 
 ## Note on terminology
 
-In the mathematical litterature, linear maps of the form `LinearMap.transvection f v`
+In the mathematical literature, linear maps of the form `LinearMap.transvection f v`
 are only called “transvections” when `f v = 0`. Otherwise, they are sometimes
 called “dilations” (especially if `f v ≠ -1`).
 


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
