### PR TITLE
[Merged by Bors] - doc(NumberTheory): fix typos

### DIFF
--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -44,7 +44,7 @@ We define the following variants.
   This is the height of an element of `K`.
 * `Height.mulHeight x` and `Height.logHeight x` for `x : ι → K` with `ι` finite. This is the height
   of a tuple of elements of `K` representing a point in projective space. When `x = 0`, we
-  define the multiplicative height to be `1` (so the loarithmic height is `0`).
+  define the multiplicative height to be `1` (so the logarithmic height is `0`).
   It is invariant under scaling by nonzero elements of `K`.
 * `Finsupp.mulHeight x` and `Finsupp.logHeight x` for `x : α →₀ K`. This is the same
   as the height of `x` restricted to the support of `x`.
@@ -107,7 +107,7 @@ variable {K}
 /-!
 ### Heights of field elements
 
-We use the subscipt `₁` to denote multiplicative and logarithmic heights of field elements
+We use the subscript `₁` to denote multiplicative and logarithmic heights of field elements
 (this is because we are in the one-dimensional case of (affine) heights).
 -/
 
@@ -128,7 +128,7 @@ lemma mulHeight₁_zero : mulHeight₁ (0 : K) = 1 := by
 lemma mulHeight₁_one : mulHeight₁ (1 : K) = 1 := by
   simp [mulHeight₁_eq]
 
-/-- The mutliplicative height of a field element is always at least `1`. -/
+/-- The multiplicative height of a field element is always at least `1`. -/
 lemma one_le_mulHeight₁ (x : K) : 1 ≤ mulHeight₁ x :=
   one_le_mul_of_one_le_of_one_le (Multiset.one_le_prod_map fun _ _ ↦ le_max_right ..) <|
     one_le_finprod fun _ ↦ le_max_right ..
@@ -572,7 +572,7 @@ lemma mulHeight₁_pow (x : K) (n : ℕ) : mulHeight₁ (x ^ n) = mulHeight₁ x
   fin_cases i <;> simp
 
 /-- The logarithmic height of the `n`th power of a field element `x` (with `n : ℕ`)
-is `n` times the logaritmic height of `x`. -/
+is `n` times the logarithmic height of `x`. -/
 lemma logHeight₁_pow (x : K) (n : ℕ) : logHeight₁ (x ^ n) = n * logHeight₁ x := by
   simp only [logHeight₁_eq_log_mulHeight₁, mulHeight₁_pow, log_pow]
 

--- a/Mathlib/NumberTheory/MulChar/Duality.lean
+++ b/Mathlib/NumberTheory/MulChar/Duality.lean
@@ -77,7 +77,7 @@ lemma card_eq_card_units_of_hasEnoughRootsOfUnity : Nat.card (MulChar M R) = Nat
 
 /--
 Let `N` be a submonoid of `M` group and let R` be a ring with enough roots of unity.
-Then any `R`-value multiplicative character of `N` can be extented to a multiplicative
+Then any `R`-value multiplicative character of `N` can be extended to a multiplicative
 character of `M`.
 -/
 theorem restrictHom_surjective (N : Submonoid M) :

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -81,7 +81,7 @@ theorem spectralNorm_eq (x : PadicAlgCl p) : spectralNorm ℚ_[p] (PadicAlgCl p)
 @[simp] theorem norm_extends (x : ℚ_[p]) : ‖(x : PadicAlgCl p)‖ = ‖x‖ :=
   spectralAlgNorm_extends (K := ℚ_[p]) (L := PadicAlgCl p) _
 
-/-- The underlying metric space of `PadicAlgCl p` is ultrametic. -/
+/-- The underlying metric space of `PadicAlgCl p` is ultrametric. -/
 instance isUltrametricDist : IsUltrametricDist (PadicAlgCl p) :=
   IsUltrametricDist.isUltrametricDist_of_forall_norm_add_le_max_norm (PadicAlgCl.isNonarchimedean p)
 
@@ -204,7 +204,7 @@ theorem norm_extends (x : PadicAlgCl p) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
 theorem norm_extends' (x : ℚ_[p]) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
   simp
 
-/-- The underlying metric space of `ℂ_[p]` is ultrametic. -/
+/-- The underlying metric space of `ℂ_[p]` is ultrametric. -/
 instance isUltrametricDist : IsUltrametricDist ℂ_[p] := IsUltrametricDist.of_normedAlgebra ℚ_[p]
 
 /-- The norm on `ℂ_[p]` is nonarchimedean. -/
@@ -250,7 +250,7 @@ instance charZero : CharZero ℂ_[p] :=
   (RingHom.charZero_iff (algebraMap ℚ_[p] ℂ_[p]).injective).mp inferInstance
 
 set_option backward.isDefEq.respectTransparency false in
-/-- `ℂ_[p]` is algebrically closed. -/
+/-- `ℂ_[p]` is algebraically closed. -/
 instance isAlgClosed : IsAlgClosed ℂ_[p] :=
   IsAlgClosed.of_denseRange UniformSpace.Completion.denseRange_coe
 


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
