### PR TITLE
[Merged by Bors] - doc(Tactic): fix typos

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -74,7 +74,7 @@ def elementwiseThms : List Name :=
 /--
 Given an equation `f = g` between morphisms `X ⟶ Y` in a category `C`
 (possibly after a `∀` binder), produce the equation `∀ (x : X), f x = g x` or
-`∀ FC CC _ [ConreteCategory C FC] (x : X), f x = g x` as needed (after the `∀` binder), but
+`∀ FC CC _ [ConcreteCategory C FC] (x : X), f x = g x` as needed (after the `∀` binder), but
 with compositions fully right associated and identities removed.
 
 Returns the proof of the new theorem along with (optionally) a new level metavariable

--- a/Mathlib/Tactic/Simproc/ExistsAndEq.lean
+++ b/Mathlib/Tactic/Simproc/ExistsAndEq.lean
@@ -189,7 +189,7 @@ example {α β : Type} (f : β → α) {p : α → Prop} :
   refine Exists.intro (f b) ?_
   -- then we traverse `newBody` and goal simultaneously
   refine And.intro ?_ ?_
-  -- at branches outside the path `h` must concide with goal
+  -- at branches outside the path `h` must coincide with goal
   · replace h := h.left
     exact h
   -- inside path we substitute variables from `fvars` into existential quantifiers.
@@ -341,7 +341,7 @@ example {α β : Type} (f : β → α) {p : α → Prop} :
   have h' := ha
   refine Exists.intro b ?_
   refine And.intro ?_ ?_
-  -- outside the path goal must concide with `h_eq ▸ h'`
+  -- outside the path goal must coincide with `h_eq ▸ h'`
   · replace h' := h'.left
     exact Eq.mp (congrArg (fun t ↦ p t) h_eq) h'
   -- inside the path:

--- a/Mathlib/Tactic/Translate/Reorder.lean
+++ b/Mathlib/Tactic/Translate/Reorder.lean
@@ -141,7 +141,7 @@ private def fixBinderInfos (bis : List BinderInfo) (e : Expr) : Expr :=
 /-
 In the implementation of `reorderForall` and `reorderLambda` we use metavariables.
 To reorder the arguments in one, we assign it to a reordered new metavariable.
-This trick lets us avoid traversing the expression manually when handling recurive reorderings.
+This trick lets us avoid traversing the expression manually when handling recursive reorderings.
 Instead, we implicitly rely on `instantiateMVars`.
 -/
 mutual
@@ -196,7 +196,7 @@ private def depForallDepth : Expr → Nat
 type `e₁` to type `e₂`. If there is no good guess, default to `[]`.
 The heuristic that we use is to compare the conclusions of `e₁` and `e₂`,
 and to observe which variables are swapped.
-We also apply this heuristic recurisvely in hypotheses. -/
+We also apply this heuristic recursively in hypotheses. -/
 partial def guessReorder (src tgt : Expr) : MetaM Reorder := withReducible do
   let src ← whnf src; let tgt ← whnf tgt
   let depth := depForallDepth src


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
