### PR TITLE
[Merged by Bors] - chore(Topology): rename lim -> Filter.lim and limUnder -> Filter.limUnder, and make a lemma protected

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
@@ -50,7 +50,7 @@ theorem measurableSet_exists_tendsto (hf : ∀ i, StronglyMeasurable (f i)) :
     fun ⟨c, hc⟩ ↦ ⟨c, tendsto_subtype_rng.1 hc⟩⟩
   exact mem_closure_of_tendsto hc (Eventually.of_forall fun i ↦ mem_iUnion.2 ⟨i, ⟨x, rfl⟩⟩)
 
-theorem limUnder [hE : Nonempty E] (hf : ∀ i, StronglyMeasurable (f i)) :
+protected theorem limUnder [hE : Nonempty E] (hf : ∀ i, StronglyMeasurable (f i)) :
     StronglyMeasurable (fun x ↦ limUnder l (f · x)) := by
   obtain rfl | hl := eq_or_neBot l
   · simpa [limUnder, Filter.map_bot] using stronglyMeasurable_const
@@ -59,8 +59,8 @@ theorem limUnder [hE : Nonempty E] (hf : ∀ i, StronglyMeasurable (f i)) :
   rw [stronglyMeasurable_iff_measurable_separable]; constructor
   · let conv := {x | ∃ c, Tendsto (f · x) l (𝓝 c)}
     have mconv : MeasurableSet conv := StronglyMeasurable.measurableSet_exists_tendsto hf
-    have : (fun x ↦ _root_.limUnder l (f · x)) = ((↑) : conv → X).extend
-        (fun x ↦ _root_.limUnder l (f · x)) (fun _ ↦ e) := by
+    have : (fun x ↦ limUnder l (f · x)) = ((↑) : conv → X).extend
+        (fun x ↦ limUnder l (f · x)) (fun _ ↦ e) := by
       ext x
       by_cases hx : x ∈ conv
       · rw [Function.extend_val_apply hx]

--- a/Mathlib/MeasureTheory/Function/FactorsThrough.lean
+++ b/Mathlib/MeasureTheory/Function/FactorsThrough.lean
@@ -69,7 +69,7 @@ theorem StronglyMeasurable.exists_eq_measurable_comp [Nonempty Z] [TopologicalSp
     exact ⟨t.piecewise h₁ h₂, mh₁.piecewise ht mh₂, by rw [piecewise_comp]⟩
   | @lim g i hg hi h₁ h₂ =>
     choose h mh hh using h₁
-    refine ⟨fun y ↦ _root_.limUnder atTop (h · y), StronglyMeasurable.limUnder mh, ?_⟩
+    refine ⟨fun y ↦ limUnder atTop (h · y), StronglyMeasurable.limUnder mh, ?_⟩
     ext x
     rw [Function.comp_apply, Tendsto.limUnder_eq]
     simp_all

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -247,10 +247,14 @@ section Lim
 noncomputable def Filter.lim [Nonempty X] (f : Filter X) : X :=
   Classical.epsilon fun x => f ≤ 𝓝 x
 
+@[deprecated (since := "2026-03-12")] alias lim := Filter.lim
+
 /-- If `f` is a filter in `α` and `g : α → X` is a function, then `Filter.limUnder f g` is a limit
 of `g` at `f`, if it exists. -/
 noncomputable def Filter.limUnder {α : Type*} [Nonempty X] (f : Filter α) (g : α → X) : X :=
   lim (f.map g)
+
+@[deprecated (since := "2026-03-12")] alias limUnder := Filter.limUnder
 
 end Lim
 

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -244,12 +244,12 @@ section Lim
 
 
 /-- If `f` is a filter, then `Filter.lim f` is a limit of the filter, if it exists. -/
-noncomputable def lim [Nonempty X] (f : Filter X) : X :=
+noncomputable def Filter.lim [Nonempty X] (f : Filter X) : X :=
   Classical.epsilon fun x => f ≤ 𝓝 x
 
-/-- If `f` is a filter in `α` and `g : α → X` is a function, then `limUnder f g` is a limit of `g`
-at `f`, if it exists. -/
-noncomputable def limUnder {α : Type*} [Nonempty X] (f : Filter α) (g : α → X) : X :=
+/-- If `f` is a filter in `α` and `g : α → X` is a function, then `Filter.limUnder f g` is a limit
+of `g` at `f`, if it exists. -/
+noncomputable def Filter.limUnder {α : Type*} [Nonempty X] (f : Filter α) (g : α → X) : X :=
   lim (f.map g)
 
 end Lim

--- a/Mathlib/Topology/Defs/Filter.lean
+++ b/Mathlib/Topology/Defs/Filter.lean
@@ -247,14 +247,10 @@ section Lim
 noncomputable def Filter.lim [Nonempty X] (f : Filter X) : X :=
   Classical.epsilon fun x => f ≤ 𝓝 x
 
-@[deprecated (since := "2026-03-12")] alias lim := Filter.lim
-
 /-- If `f` is a filter in `α` and `g : α → X` is a function, then `Filter.limUnder f g` is a limit
 of `g` at `f`, if it exists. -/
 noncomputable def Filter.limUnder {α : Type*} [Nonempty X] (f : Filter α) (g : α → X) : X :=
   lim (f.map g)
-
-@[deprecated (since := "2026-03-12")] alias limUnder := Filter.limUnder
 
 end Lim
 


### PR DESCRIPTION
Add the namespace `Filter` to `lim` and `limUnder`, since the docstring for `lim` suggests that they were never intended to be placed in the namespace. Also make `MeasureTheory.StronglyMeasurable.limUnder` protected, to allow its proof to refer to `Filter.limUnder` as `limUnder`.

See discussion here: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Rename.20lim.20to.20Filter.2Elim.3F/with/578862980

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
