### PR TITLE
[Merged by Bors] - ci: explain the expected format of bad PR titles better

### DIFF
--- a/Mathlib/Tactic/Linter/ValidatePRTitle.lean
+++ b/Mathlib/Tactic/Linter/ValidatePRTitle.lean
@@ -19,8 +19,8 @@ verify whether the title or body are written in present imperative tense.
 
 open Std.Internal.Parsec String
 
-/-- Basic parser for PR titles: given a title `feat(scope): main title` or `feat: title`,
-extracts the `feat` and `scope` components. In the future, this will be extended to also parse
+/-- Basic parser for PR titles: given a title `kind(scope): main title` or `kind: title`,
+extracts the `kind` and `scope` components. In the future, this will be extended to also parse
 the main PR title. -/
 -- TODO: also parse and return the main PR title
 def prTitle : Parser (String × Option String) :=
@@ -79,20 +79,13 @@ public def validateTitle (title : String) : Array String := Id.run do
   if title.startsWith " " then
     errors := #["error: the PR title starts with a space"]
 
+  let knownKinds := ["feat", "chore", "perf", "refactor", "style", "fix", "doc", "test", "ci"]
   match Parser.run prTitle title.trimAsciiStart.copy with
   | Except.error _ =>
-    return errors.push s!"error: the PR title should be of the form\n  abbrev: main title\n\
-      or\n  abbrev(scope): main title"
-  | Except.ok (kind, _scope?) =>
+    return errors.push s!"error: the PR title should be of the form\n  kind: main title\n\
+      or\n  kind(scope): main title\nAllowed values for `kind` are {knownKinds}"
+  | Except.ok (_kind, _scope?) =>
     -- Future: also check scope (and the main PR title)
-    let knownKinds := ["feat", "chore", "perf", "refactor", "style", "fix", "doc", "test", "ci"]
-    let mut isFine := false
-    for k in knownKinds do
-      isFine := isFine || kind.startsWith k
-    if isFine == false then
-      errors := errors.push s!"error: the PR title should be of the form \
-        \"kind: main title\" or \"kind(scope): main title\"\n
-        Known PR title kinds are {knownKinds}"
     if title.contains "  " then
       errors := errors.push
         "error: the PR title contains multiple consecutive spaces; please add just one"

--- a/MathlibTest/ValidatePRTitle.lean
+++ b/MathlibTest/ValidatePRTitle.lean
@@ -24,9 +24,10 @@ elab "#check_title " title:str : command => do
 
 /--
 info: Message: 'error: the PR title should be of the form
-  abbrev: main title
+  kind: main title
 or
-  abbrev(scope): main title'
+  kind(scope): main title
+Allowed values for `kind` are [feat, chore, perf, refactor, style, fix, doc, test, ci]'
 -/
 #guard_msgs in
 #check_title "fsdfs: bad title"


### PR DESCRIPTION
If a PR kind was not recognised, explain which ones are expected.

This also clarifies the check's logic: this error was supposed to be emitted already, but wasn't (due to a last-minute refactoring of the linter). Remove the old code path was never run (and is run now).


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
