### PR TITLE
[Merged by Bors] - doc(SetTheory): fix typos

### DIFF
--- a/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
+++ b/Mathlib/SetTheory/Cardinal/HasCardinalLT.lean
@@ -136,7 +136,7 @@ lemma hasCardinalLT_union
     HasCardinalLT (S₁ ∪ S₂ : Set _) κ :=
   hasCardinalLT_subtype_max hκ h₁ h₂
 
-/-- The particular case of `hasCardinatLT_sigma` when all the inputs are in the
+/-- The particular case of `hasCardinalLT_sigma` when all the inputs are in the
 same universe `w`. It is used to prove the general case. -/
 lemma hasCardinalLT_sigma' {ι : Type w} (α : ι → Type w) (κ : Cardinal.{w}) [Fact κ.IsRegular]
     (hι : HasCardinalLT ι κ) (hα : ∀ i, HasCardinalLT (α i) κ) :
@@ -175,7 +175,7 @@ lemma hasCardinalLT_iUnion
   convert show HasCardinalLT (setOf ((⨆ i, S i))) κ from hasCardinalLT_subtype_iSup S hι hS
   aesop
 
-/-- The particular case of `hasCardinatLT_prod` when all the inputs are in the
+/-- The particular case of `hasCardinalLT_prod` when all the inputs are in the
 same universe `w`. It is used to prove the general case. -/
 lemma hasCardinalLT_prod' {T₁ T₂ : Type w} {κ : Cardinal.{w}} (hκ : Cardinal.aleph0 ≤ κ)
     (h₁ : HasCardinalLT T₁ κ) (h₂ : HasCardinalLT T₂ κ) :


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
