### PR TITLE
[Merged by Bors] - doc(RingTheory): fix typos

### DIFF
--- a/Mathlib/RingTheory/Algebraic/StronglyTranscendental.lean
+++ b/Mathlib/RingTheory/Algebraic/StronglyTranscendental.lean
@@ -12,7 +12,7 @@ public import Mathlib.RingTheory.LocalProperties.Reduced
 # Strongly transcendental elements
 
 In this file, we provide basic properties for strongly transcendental elements in an algebra.
-This is a relatively niche notion, but is useful for proving Zarkisi's main theorem.
+This is a relatively niche notion, but is useful for proving Zariski's main theorem.
 
 ## Reference
 - https://stacks.math.columbia.edu/tag/00PZ

--- a/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
@@ -73,7 +73,7 @@ section baseChange
 variable {A : Type*} [CommRing A] [Algebra S A] [Algebra P.Ring A] [IsScalarTower P.Ring S A]
 
 variable (R S) in
-/-- This is (isomorphic to) the base change of the contangent complex to `A`, but
+/-- This is (isomorphic to) the base change of the cotangent complex to `A`, but
 the domain and codomains of this are more manageable. -/
 noncomputable
 def _root_.KaehlerDifferential.cotangentComplexBaseChange

--- a/Mathlib/RingTheory/Flat/TorsionFree.lean
+++ b/Mathlib/RingTheory/Flat/TorsionFree.lean
@@ -80,7 +80,7 @@ lemma isSMulRegular_of_nonZeroDivisors {r : R} (hr : r ∈ R⁰) [Flat R M] : Is
 /-- Flat modules have no torsion. -/
 theorem torsion_eq_bot [Flat R M] : torsion R M = ⊥ := by
   rw [eq_bot_iff]
-  -- indeed the definition of torsion means "annihiliated by a nonzerodivisor"
+  -- indeed the definition of torsion means "annihilated by a nonzerodivisor"
   rintro m ⟨⟨r, hr⟩, h⟩
   -- and we just showed that 0 is the only element with this property
   exact isSMulRegular_of_nonZeroDivisors hr (by simpa using h)

--- a/Mathlib/RingTheory/FractionalIdeal/Extended.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Extended.lean
@@ -187,8 +187,8 @@ variable {A K : Type*} (L B : Type*) [CommRing A] [IsDomain A] [CommRing B] [IsD
   [IsFractionRing A K] [IsFractionRing B L] {I : FractionalIdeal A⁰ K}
 
 /--
-The ring homomorphisme that extends a fractional ideal of `A` to a fractional ideal of `B` for
-`A ⊆ B` an extension of domains.
+The ring homomorphism that extends a fractional ideal of `A` to a fractional ideal of `B` for
+an extension of domains `A ⊆ B`.
 -/
 abbrev extendedHomₐ : FractionalIdeal A⁰ K →+* FractionalIdeal B⁰ L :=
   extendedHom L <|

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Ideal.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Ideal.lean
@@ -19,7 +19,7 @@ public import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
 ## Note
 We actually prove something stronger, namely that the `Xⁿ⁻ⁱ`-th coefficient lives in `Iⁿ`.
-This the definitition that `x` is integral over `I` in https://stacks.math.columbia.edu/tag/00H2.
+This is the definition that `x` is integral over `I` in https://stacks.math.columbia.edu/tag/00H2.
 
 -/
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -466,7 +466,7 @@ namespace RatFunc
 open IsDedekindDomain.HeightOneSpectrum PowerSeries
 open scoped LaurentSeries
 
-/-- `valuationX` is an abbrevation for the `X`-adic valuation given by
+/-- `polynomialValuationX` is an abbreviation for the `X`-adic valuation given by
 `(Polynomial.idealX K).valuation K⟮X⟯`. -/
 abbrev polynomialValuationX : Valuation K⟮X⟯ ℤᵐ⁰ :=
   (Polynomial.idealX K).valuation _

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -84,9 +84,9 @@ theorem expand_subst {f : MvPowerSeries τ S} [Finite τ] (hf : HasSubst f) (φ 
   rw [PowerSeries.subst, MvPowerSeries.expand_subst _ hp (HasSubst.const hf) (φ := φ),
     PowerSeries.subst]
 
-/- TODO : In the original file of multi variate polynomial, there are two theorem about rename
-here, but we don't have rename for multi variate power series. And for `eval₂Hom`, `eval₂`
-and `aevel`, the expression does't look good. -/
+/- TODO : In the original file of multivariate polynomial, there are two theorems about rename
+here, but we don't have rename for multivariate power series. And for `eval₂Hom`, `eval₂`
+and `aeval`, the expression does not look good. -/
 
 variable (φ : PowerSeries R) (q : ℕ) (hq : 0 < q)
 

--- a/Mathlib/RingTheory/QuasiFinite/Basic.lean
+++ b/Mathlib/RingTheory/QuasiFinite/Basic.lean
@@ -41,7 +41,7 @@ In this file, we define the notion of quasi-finite algebras and prove basic prop
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
   [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
--- See `Mathib/RingTheory/QuasiFinite/Polynomial.lean`
+-- See `Mathlib/RingTheory/QuasiFinite/Polynomial.lean`
 assert_not_exists RatFunc
 
 open TensorProduct
@@ -62,7 +62,7 @@ This is slightly different from the
 which requires `S` to be of finite type over `R`.
 
 Also see `Algebra.QuasiFinite.iff_finite_comap_preimage_singleton` that
-this is equivalent to having finite fibers for finite-type algebas.
+this is equivalent to having finite fibers for finite-type algebras.
 -/
 @[mk_iff, stacks 00PL]
 class QuasiFinite : Prop where

--- a/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
@@ -116,8 +116,8 @@ theorem associated_pow_add_sub_sub_one (hζ : IsPrimitiveRoot ζ n) (hn : 2 ≤ 
     simp [← this, mul_assoc]
   grind [mul_geom_sum]
 
-/-- If `p` is prime and `ζ` is a `p`-th primitive root of unit, then `ζ - 1` and `η₁ - η₂` are
-  associated for all distincts `p`-th root of unit `η₁` and `η₂`. -/
+/-- If `p` is prime and `ζ` is a `p`-th primitive root of unity, then `ζ - 1` and `η₁ - η₂` are
+  associated for all distinct `p`-th roots of unity `η₁` and `η₂`. -/
 lemma ntRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveRoot ζ p)
     (hp : p.Prime) :
     Set.Pairwise (nthRootsFinset p (1 : A)) (fun η₁ η₂ ↦ Associated (ζ - 1) (η₁ - η₂)) := by

--- a/Mathlib/RingTheory/Smooth/Fiber.lean
+++ b/Mathlib/RingTheory/Smooth/Fiber.lean
@@ -31,7 +31,7 @@ public import Mathlib.RingTheory.Etale.Locus
 
 ## Note
 
-For the converse that smooth imples flat, see `Mathlib/RingTheory/Smooth/Flat.lean`.
+For the converse that smooth implies flat, see `Mathlib/RingTheory/Smooth/Flat.lean`.
 
 -/
 

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeHom.lean
@@ -63,7 +63,7 @@ variable [Free R M] [Module.Finite R M]
 
 variable {S}
 
-/-- The base change isomorphism funderlying `IsBaseChange.linearMapRight` -/
+/-- The base change isomorphism underlying `IsBaseChange.linearMapRight` -/
 noncomputable def linearMapRightBaseChangeEquiv
     {ε : N →ₗ[R] P} (ibc : IsBaseChange S ε) :
     S ⊗[R] (M →ₗ[R] N) ≃ₗ[S] (M →ₗ[R] P) := by

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -31,7 +31,7 @@ We follow https://stacks.math.columbia.edu/tag/00PI and proceed in the following
   issues, and then `S[1/gᵢ]` is basically integral over `R[1/gᵢ]`.
 2. `Algebra.ZariskisMainProperty.of_algHom_polynomial`:
   The case where `S` is finite over `R⟨x⟩` for some `x : S`.
-  The following key results are first esablished:
+  The following key results are first established:
   - `isStronglyTranscendental_mk_radical_conductor`:
     Let `𝔣` be the conductor of `x` (i.e. the largest `S`-ideal in `R⟨x⟩`).
     `x` as an element of `S/√𝔣` is strongly transcendental over `R`.
@@ -46,7 +46,7 @@ We follow https://stacks.math.columbia.edu/tag/00PI and proceed in the following
 3. `Algebra.ZariskisMainProperty.of_algHom_mvPolynomial`:
   The case where `S` is finite over `R⟨x₁,...,xₙ⟩`. This is proved using induction on `n`.
 
-## Main definiton and results
+## Main definition and results
 - `Algebra.ZariskisMainProperty`:
   We say that an `R` algebra `S` satisfies the Zariski's main property at a prime `p` of `S`
   if there exists `r ∉ p` in the integral closure `S'` of `R` in `S`, such that `S'[1/r] = S[1/r]`.


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
