### PR TITLE
[Merged by Bors] - fix(Tactic/Ring/Common): remove `Ord Rat` instance

### DIFF
--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -76,7 +76,7 @@ This feature wasn't needed yet, so it's not implemented yet.
 ring, semiring, exponent, power
 -/
 
-@[expose] public meta section
+public meta section
 
 assert_not_exists IsOrderedMonoid
 
@@ -171,8 +171,8 @@ def ExSum.eq
   | _, _ => false
 end
 
-/-- TODO: this instance should probably be upstreamed -/
-local instance : Ord Rat where
+-- TODO: this should be somewhere else
+private local instance : Ord Rat where
   compare a b := compareOfLessAndEq a b
 
 mutual

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -171,7 +171,7 @@ def ExSum.eq
   | _, _ => false
 end
 
--- TODO: this should be somewhere else
+/-- TODO: this instance should probably be upstreamed -/
 local instance : Ord Rat where
   compare a b := compareOfLessAndEq a b
 

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -172,8 +172,8 @@ def ExSum.eq
 end
 
 -- TODO: this should be somewhere else
-instance : Ord Rat where
-  compare a b := if a ≤ b then if b ≤ a then .eq else .lt else .gt
+local instance : Ord Rat where
+  compare a b := compareOfLessAndEq a b
 
 mutual
 /--

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -9,6 +9,8 @@ public import Mathlib.Tactic.NormNum.Inv
 public import Mathlib.Tactic.NormNum.Pow
 public meta import Mathlib.Tactic.NormNum.Result
 
+meta import Mathlib.Algebra.Order.Ring.Unbundled.Rat
+
 /-!
 # `ring` tactic
 
@@ -170,10 +172,6 @@ def ExSum.eq
   | .add a₁ a₂, .add b₁ b₂ => a₁.eq b₁ && a₂.eq b₂
   | _, _ => false
 end
-
--- TODO: this should be somewhere else
-private local instance : Ord Rat where
-  compare a b := compareOfLessAndEq a b
 
 mutual
 /--


### PR DESCRIPTION
This PR fixes a diamond that I accidentally introduced with an `Ord Rat` instance. We instead use the instance coming from `LinearOrder Rat`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
