### PR TITLE
[Merged by Bors] - feat: add `NonUnitalSubring.centralizer`

### DIFF
--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.Algebra.Field.Defs
 public import Mathlib.Algebra.Group.Subgroup.Basic
 public import Mathlib.Algebra.Ring.Subring.Defs
 public import Mathlib.Algebra.Ring.Subsemiring.Basic
-public import Mathlib.RingTheory.NonUnitalSubring.Defs
+public import Mathlib.RingTheory.NonUnitalSubring.Basic
 public import Mathlib.Data.Set.Finite.Basic
 
 /-!
@@ -451,6 +451,10 @@ theorem centralizer_toSubmonoid (s : Set R) :
 
 theorem centralizer_toSubsemiring (s : Set R) :
     (centralizer s).toSubsemiring = Subsemiring.centralizer s :=
+  rfl
+
+theorem centralizer_toNonUnitalSubring (s : Set R) :
+    (centralizer s).toNonUnitalSubring = NonUnitalSubring.centralizer s :=
   rfl
 
 theorem mem_centralizer_iff {s : Set R} {z : R} : z ∈ centralizer s ↔ ∀ g ∈ s, g * z = z * g :=

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -393,6 +393,47 @@ theorem center_eq_top (R) [NonUnitalCommRing R] : center R = ⊤ :=
 
 end NonUnitalRing
 
+section Centralizer
+
+/-- The centralizer of a set as non-unital subring. -/
+def centralizer {R} [NonUnitalRing R] (s : Set R) : NonUnitalSubring R :=
+  { Subsemigroup.centralizer s with
+    carrier := s.centralizer
+    zero_mem' := Set.zero_mem_centralizer
+    add_mem' := Set.add_mem_centralizer
+    neg_mem' := Set.neg_mem_centralizer }
+
+@[simp, norm_cast]
+theorem coe_centralizer {R} [NonUnitalRing R] (s : Set R) :
+    (centralizer s : Set R) = s.centralizer :=
+  rfl
+
+theorem centralizer_toSubsemigroup {R} [NonUnitalRing R] (s : Set R) :
+    (centralizer s).toSubsemigroup = Subsemigroup.centralizer s :=
+  rfl
+
+theorem mem_centralizer_iff {R} [NonUnitalRing R] {s : Set R} {z : R} :
+    z ∈ centralizer s ↔ ∀ g ∈ s, g * z = z * g :=
+  Iff.rfl
+
+theorem center_le_centralizer {R} [NonUnitalRing R] (s) : center R ≤ centralizer s :=
+  s.center_subset_centralizer
+
+theorem centralizer_le {R} [NonUnitalRing R] (s t : Set R) (h : s ⊆ t) :
+    centralizer t ≤ centralizer s :=
+  Set.centralizer_subset h
+
+@[simp]
+theorem centralizer_eq_top_iff_subset {R} [NonUnitalRing R] {s : Set R} :
+    centralizer s = ⊤ ↔ s ⊆ center R :=
+  SetLike.ext'_iff.trans Set.centralizer_eq_top_iff_subset
+
+@[simp]
+theorem centralizer_univ {R} [NonUnitalRing R] : centralizer Set.univ = center R :=
+  SetLike.ext' (Set.centralizer_univ R)
+
+end Centralizer
+
 end Center
 
 /-! ## `NonUnitalSubring` closure of a subset -/
@@ -503,24 +544,10 @@ theorem mem_closure_iff {s : Set R} {x} :
     | add _ _ _ _ h₁ h₂ => exact add_mem h₁ h₂
     | neg _ _ h => exact neg_mem h⟩
 
-/-- If all elements of `s : Set A` commute pairwise, then `closure s` is a commutative ring. -/
-@[implicit_reducible]
-def closureNonUnitalCommRingOfComm {R : Type u} [NonUnitalRing R] {s : Set R}
-    (hcomm : ∀ a ∈ s, ∀ b ∈ s, a * b = b * a) : NonUnitalCommRing (closure s) :=
-  { (closure s).toNonUnitalRing with
-    mul_comm := fun ⟨x, hx⟩ ⟨y, hy⟩ => by
-      ext
-      simp only [MulMemClass.mk_mul_mk]
-      induction hx, hy using closure_induction₂ with
-      | mem_mem x y hx hy => exact hcomm x hx y hy
-      | zero_left x _ => exact Commute.zero_left x
-      | zero_right x _ => exact Commute.zero_right x
-      | mul_left _ _ _ _ _ _ h₁ h₂ => exact Commute.mul_left h₁ h₂
-      | mul_right _ _ _ _ _ _ h₁ h₂ => exact Commute.mul_right h₁ h₂
-      | add_left _ _ _ _ _ _ h₁ h₂ => exact Commute.add_left h₁ h₂
-      | add_right _ _ _ _ _ _ h₁ h₂ => exact Commute.add_right h₁ h₂
-      | neg_left _ _ _ _ h => exact Commute.neg_left h
-      | neg_right _ _ _ _ h => exact Commute.neg_right h }
+lemma closure_le_centralizer_centralizer {R : Type*} [NonUnitalRing R] (s : Set R) :
+    closure s ≤ centralizer (centralizer s) :=
+  closure_le.mpr Set.subset_centralizer_centralizer
+
 
 variable (R) in
 /-- `closure` forms a Galois insertion with the coercion to set. -/

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -395,41 +395,41 @@ end NonUnitalRing
 
 section Centralizer
 
+variable {R : Type*} [NonUnitalRing R]
+
 /-- The centralizer of a set as non-unital subring. -/
-def centralizer {R} [NonUnitalRing R] (s : Set R) : NonUnitalSubring R :=
-  { Subsemigroup.centralizer s with
+def centralizer (s : Set R) : NonUnitalSubring R :=
+  { NonUnitalSubsemiring.centralizer s with
     carrier := s.centralizer
-    zero_mem' := Set.zero_mem_centralizer
-    add_mem' := Set.add_mem_centralizer
     neg_mem' := Set.neg_mem_centralizer }
 
 @[simp, norm_cast]
-theorem coe_centralizer {R} [NonUnitalRing R] (s : Set R) :
+theorem coe_centralizer (s : Set R) :
     (centralizer s : Set R) = s.centralizer :=
   rfl
 
-theorem centralizer_toSubsemigroup {R} [NonUnitalRing R] (s : Set R) :
-    (centralizer s).toSubsemigroup = Subsemigroup.centralizer s :=
+theorem centralizer_toNonUnitalSubsemiring (s : Set R) :
+    (centralizer s).toNonUnitalSubsemiring = NonUnitalSubsemiring.centralizer s :=
   rfl
 
-theorem mem_centralizer_iff {R} [NonUnitalRing R] {s : Set R} {z : R} :
+theorem mem_centralizer_iff {s : Set R} {z : R} :
     z ∈ centralizer s ↔ ∀ g ∈ s, g * z = z * g :=
   Iff.rfl
 
-theorem center_le_centralizer {R} [NonUnitalRing R] (s) : center R ≤ centralizer s :=
+theorem center_le_centralizer (s) : center R ≤ centralizer s :=
   s.center_subset_centralizer
 
-theorem centralizer_le {R} [NonUnitalRing R] (s t : Set R) (h : s ⊆ t) :
+theorem centralizer_le (s t : Set R) (h : s ⊆ t) :
     centralizer t ≤ centralizer s :=
   Set.centralizer_subset h
 
 @[simp]
-theorem centralizer_eq_top_iff_subset {R} [NonUnitalRing R] {s : Set R} :
+theorem centralizer_eq_top_iff_subset {s : Set R} :
     centralizer s = ⊤ ↔ s ⊆ center R :=
   SetLike.ext'_iff.trans Set.centralizer_eq_top_iff_subset
 
 @[simp]
-theorem centralizer_univ {R} [NonUnitalRing R] : centralizer Set.univ = center R :=
+theorem centralizer_univ : centralizer Set.univ = center R :=
   SetLike.ext' (Set.centralizer_univ R)
 
 end Centralizer

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -548,6 +548,24 @@ lemma closure_le_centralizer_centralizer {R : Type*} [NonUnitalRing R] (s : Set 
     closure s ≤ centralizer (centralizer s) :=
   closure_le.mpr Set.subset_centralizer_centralizer
 
+/-- If all elements of `s : Set A` commute pairwise, then `closure s` is a commutative ring. -/
+@[implicit_reducible]
+def closureNonUnitalCommRingOfComm {R : Type u} [NonUnitalRing R] {s : Set R}
+    (hcomm : ∀ a ∈ s, ∀ b ∈ s, a * b = b * a) : NonUnitalCommRing (closure s) :=
+  { (closure s).toNonUnitalRing with
+    mul_comm := fun ⟨x, hx⟩ ⟨y, hy⟩ => by
+      ext
+      simp only [MulMemClass.mk_mul_mk]
+      induction hx, hy using closure_induction₂ with
+      | mem_mem x y hx hy => exact hcomm x hx y hy
+      | zero_left x _ => exact Commute.zero_left x
+      | zero_right x _ => exact Commute.zero_right x
+      | mul_left _ _ _ _ _ _ h₁ h₂ => exact Commute.mul_left h₁ h₂
+      | mul_right _ _ _ _ _ _ h₁ h₂ => exact Commute.mul_right h₁ h₂
+      | add_left _ _ _ _ _ _ h₁ h₂ => exact Commute.add_left h₁ h₂
+      | add_right _ _ _ _ _ _ h₁ h₂ => exact Commute.add_right h₁ h₂
+      | neg_left _ _ _ _ h => exact Commute.neg_left h
+      | neg_right _ _ _ _ h => exact Commute.neg_right h }
 
 variable (R) in
 /-- `closure` forms a Galois insertion with the coercion to set. -/


### PR DESCRIPTION
We have this for all the other variants (`NonUnitalSemiring`, `Subsemiring`, `Subring`), but this one was missing. The lemmas are copy-pasted from their counterparts.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
