### PR TITLE
[Merged by Bors] - doc(Dynamics): fix typos

### DIFF
--- a/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
@@ -212,11 +212,11 @@ variable {G : Type*} [Group G] [TopologicalSpace G]
 
 /-- Let `f : G →* G` be a group endomorphism of a topological group with second countable topology.
 If the preimages of `1` under the iterations of `f` are dense,
-then it is preergodic with respect to any finite inner regular left invariant measure. -/
+then it is pre-ergodic with respect to any finite inner regular left invariant measure. -/
 @[to_additive /-- Let `f : G →+ G` be an additive group endomorphism
 of a topological additive group with second countable topology.
 If the preimages of `0` under the iterations of `f` are dense,
-then it is preergodic with respect to any finite inner regular left invariant measure. -/]
+then it is pre-ergodic with respect to any finite inner regular left invariant measure. -/]
 theorem preErgodic_of_dense_iUnion_preimage_one
     {μ : Measure G} [IsFiniteMeasure μ] [μ.InnerRegular] [μ.IsMulLeftInvariant]
     (f : G →* G) (hf : Dense (⋃ n, f^[n] ⁻¹' 1)) : PreErgodic f μ := by

--- a/Mathlib/Dynamics/Ergodic/Function.lean
+++ b/Mathlib/Dynamics/Ergodic/Function.lean
@@ -9,7 +9,7 @@ public import Mathlib.Dynamics.Ergodic.Ergodic
 public import Mathlib.MeasureTheory.Function.AEEqFun
 
 /-!
-# Functions invariant under (quasi)ergodic map
+# Functions invariant under a (quasi)ergodic map
 
 In this file we prove that an a.e. strongly measurable function `g : α → X`
 that is a.e. invariant under a (quasi)ergodic map is a.e. equal to a constant.
@@ -24,10 +24,10 @@ open Function Set Filter MeasureTheory Topology TopologicalSpace
 
 variable {α X : Type*} [MeasurableSpace α] {μ : MeasureTheory.Measure α}
 
-/-- Let `f : α → α` be a (quasi)ergodic map. Let `g : α → X` is a null-measurable function
+/-- Let `f : α → α` be a (quasi)ergodic map. Let `g : α → X` be a null-measurable function
 from `α` to a nonempty space with a countable family of measurable sets
-separating points of a set `s` such that `f x ∈ s` for a.e. `x`.
-If `g` that is a.e.-invariant under `f`, then `g` is a.e. constant. -/
+separating points of a set `s` such that `g x ∈ s` for a.e. `x`.
+If `g` is a.e.-invariant under `f`, then `g` is a.e. constant. -/
 theorem QuasiErgodic.ae_eq_const_of_ae_eq_comp_of_ae_range₀ [Nonempty X] [MeasurableSpace X]
     {s : Set X} [MeasurableSpace.CountablySeparated s] {f : α → α} {g : α → X}
     (h : QuasiErgodic f μ) (hs : ∀ᵐ x ∂μ, g x ∈ s) (hgm : NullMeasurable g μ)

--- a/Mathlib/Dynamics/Newton.lean
+++ b/Mathlib/Dynamics/Newton.lean
@@ -16,8 +16,8 @@ public import Mathlib.RingTheory.Polynomial.Nilpotent
 Given a single-variable polynomial `P` with derivative `P'`, Newton's method concerns iteration of
 the rational map: `x ↦ x - P(x) / P'(x)`.
 
-Over a field it can serve as a root-finding algorithm. It is also useful tool in certain proofs
-such as Hensel's lemma and Jordan-Chevalley decomposition.
+Over a field, it can serve as a root-finding algorithm. It is also useful in proving results such
+as Hensel's lemma and the Jordan-Chevalley decomposition.
 
 ## Main definitions / results:
 
@@ -28,7 +28,7 @@ such as Hensel's lemma and Jordan-Chevalley decomposition.
 * `Polynomial.existsUnique_nilpotent_sub_and_aeval_eq_zero`: if `x` is almost a root of `P` in the
   sense that `P(x)` is nilpotent (and `P'(x)` is a unit) then we may write `x` as a sum
   `x = n + r` where `n` is nilpotent and `r` is a root of `P`. This can be used to prove the
-  Jordan-Chevalley decomposition of linear endomorphims.
+  Jordan-Chevalley decomposition of linear endomorphisms.
 
 -/
 
@@ -105,7 +105,7 @@ theorem aeval_pow_two_pow_dvd_aeval_iterate_newtonMap
 unit) then we may write `x` as a sum `x = n + r` where `n` is nilpotent and `r` is a root of `P`.
 Moreover, `n` and `r` are unique.
 
-This can be used to prove the Jordan-Chevalley decomposition of linear endomorphims. -/
+This can be used to prove the Jordan-Chevalley decomposition of linear endomorphisms. -/
 theorem existsUnique_nilpotent_sub_and_aeval_eq_zero
     (h : IsNilpotent (aeval x P)) (h' : IsUnit (aeval x <| derivative P)) :
     ∃! r, IsNilpotent (x - r) ∧ aeval r P = 0 := by

--- a/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
@@ -184,20 +184,20 @@ lemma coverEntropyInf_restrict_subset [UniformSpace X] {T : X → X} {F G : Set 
   rw [← coverEntropyInf_image_of_comap _ hG.val_restrict_apply (val ⁻¹' F), image_preimage_coe G F,
     inter_eq_right.2 hF]
 
-/-- The entropy of the restriction of `T` to an invariant set `F` is `coverEntropy S F`. This
+/-- The entropy of the restriction of `T` to an invariant set `F` is `coverEntropy T F`. This
 theorem justifies our definition of `coverEntropy T F`. -/
 theorem coverEntropy_restrict [UniformSpace X] {T : X → X} {F : Set X} (h : MapsTo T F F) :
     coverEntropy (h.restrict T F F) univ = coverEntropy T F := by
   rw [← coverEntropy_restrict_subset Subset.rfl h, coe_preimage_self F]
 
-/-- The entropy of `φ '' F` is lower than entropy of `F` if  `φ` is uniformly continuous. -/
+/-- The entropy of `φ '' F` is at most the entropy of `F` if `φ` is uniformly continuous. -/
 theorem coverEntropy_image_le_of_uniformContinuous [UniformSpace X] [UniformSpace Y] {S : X → X}
     {T : Y → Y} {φ : X → Y} (h : Semiconj φ S T) (h' : UniformContinuous φ) (F : Set X) :
     coverEntropy T (φ '' F) ≤ coverEntropy S F := by
   rw [coverEntropy_image_of_comap _ h F]
   exact coverEntropy_antitone S F (uniformContinuous_iff.1 h')
 
-/-- The entropy of `φ '' F` is lower than entropy of `F` if  `φ` is uniformly continuous. This
+/-- The entropy of `φ '' F` is at most the entropy of `F` if `φ` is uniformly continuous. This
   version uses a `liminf`. -/
 theorem coverEntropyInf_image_le_of_uniformContinuous [UniformSpace X] [UniformSpace Y] {S : X → X}
     {T : Y → Y} {φ : X → Y} (h : Semiconj φ S T) (h' : UniformContinuous φ) (F : Set X) :


### PR DESCRIPTION
The issues were found and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
