### PR TITLE
feat(FreeGroup): injection between types induces injection between free groups

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -796,9 +796,17 @@ then the induced map on their additive free groups is also surjective. -/]
 theorem map_surjective (hf : Function.Surjective f) : Function.Surjective (map f) := by
   rw [← MonoidHom.range_eq_top, range_map, hf.range_eq, Set.image_univ, closure_range_of]
 
+/-- If `α` and `β` are arbitrary types and there is a injection between them,
+then the induced map on their free groups is also injective. -/
+@[to_additive /-- If `α` and `β` are arbitrary types and there is a injection between them,
+then the induced map on their additive free groups is also injective. -/]
 theorem map_injective (hf : Function.Injective f) : Function.Injective (map f) := by
   sorry
 
+/-- If `α` and `β` are arbitrary types and there is a bijection between them,
+then the induced map on their free groups is also bijective. -/
+@[to_additive /-- If `α` and `β` are arbitrary types and there is a bijection between them,
+then the induced map on their additive free groups is also bijective. -/]
 theorem map_bijective (hf : Function.Bijective f) : Function.Bijective (map f) :=
   ⟨map_injective hf.1, map_surjective hf.2⟩
 

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -796,6 +796,12 @@ then the induced map on their additive free groups is also surjective. -/]
 theorem map_surjective (hf : Function.Surjective f) : Function.Surjective (map f) := by
   rw [← MonoidHom.range_eq_top, range_map, hf.range_eq, Set.image_univ, closure_range_of]
 
+theorem map_injective (hf : Function.Injective f) : Function.Injective (map f) := by
+  sorry
+
+theorem map_bijective (hf : Function.Bijective f) : Function.Bijective (map f) :=
+  ⟨map_injective hf.1, map_surjective hf.2⟩
+
 /-- Equivalent types give rise to multiplicatively equivalent free groups.
 
 The converse can be found in `Mathlib/GroupTheory/FreeGroup/GeneratorEquiv.lean`, as


### PR DESCRIPTION
Adds the theorem that if α and β are arbitrary types and there is a injection between them, then the induced FreeGroup.map is also injective.

I accidentally closed the old draft from here: #34996. 

The reason this is left as a WIP is because I gave it as an exercise to the [MadLean](https://leanprover.zulipchat.com/#narrow/channel/224796-Geographic-locality/topic/Madrid.2C.20Spain/with/326103886) attendees to encourage them to do a first contribution to mathlib. The goal is to PR it next week after the workshop. 

Update: @j-mayoral won! His PR is here: #36858!

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
