### PR TITLE
[Merged by Bors] - fix(Translate): correctly translate namespace of private names

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -865,7 +865,7 @@ def targetName (t : TranslateData) (cfg : Config) (src : Name) : CoreM Name := d
   trace[translate_detail] "The name {s} splits as {open GuessName in s.splitCase}"
   let tgt_auto := GuessName.guessName t.guessNameData s
   let depth := cfg.tgt.getNumParts
-  let pre := Name.mapPrefix (findTranslationName? (← getEnv) t) pre
+  let pre := translateNamespace (← getEnv) pre
   let (pre1, pre2) := pre.splitAt (depth - 1)
   let res := if cfg.tgt == .anonymous then pre.str tgt_auto else pre1 ++ cfg.tgt
   if res == src then
@@ -881,6 +881,13 @@ def targetName (t : TranslateData) (cfg : Config) (src : Name) : CoreM Name := d
   if cfg.tgt != .anonymous then
     trace[translate_detail] "The automatically generated name would be {pre.str tgt_auto}"
   return res
+where
+  translateNamespace (env : Environment) (n : Name) : Name :=
+    let n' := Name.mapPrefix (findTranslationName? env t) n
+    if n' == n && isPrivateName n then
+      mkPrivateName env <| .mapPrefix (findTranslationName? env t) (privateToUserName n)
+    else
+      n'
 
 /-- Verify that the type of `srcDecl` translates to that of `tgtDecl`.
 Also try to autogenerate the `reorder` option for this translation. -/

--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -207,11 +207,11 @@ def lt_sum_eq_of_le [DecidableLE α] {a b : α} (hab : a ≤ b) :
     a < b ⊕' a = b :=
   if hba : b ≤ a then PSum.inr (le_antisymm hab hba) else PSum.inl (lt_of_le_not_ge hab hba)
 
--- set_option warn.classDefReducibility false in
+set_option warn.classDefReducibility false in
 @[to_dual DecidableLE1_dual]
 def DecidableLE1 (h : ∀ a b : α, Decidable (a ≤ b)) : DecidableLE α := fun a b ↦ h a b
 
--- set_option warn.classDefReducibility false in
+set_option warn.classDefReducibility false in
 @[to_dual DecidableLE2_dual]
 def DecidableLE2 (h : ∀ a b : α, Decidable (a ≤ b)) : DecidableLE α := id h
 

--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -207,11 +207,11 @@ def lt_sum_eq_of_le [DecidableLE α] {a b : α} (hab : a ≤ b) :
     a < b ⊕' a = b :=
   if hba : b ≤ a then PSum.inr (le_antisymm hab hba) else PSum.inl (lt_of_le_not_ge hab hba)
 
-set_option warn.classDefReducibility false in
+-- set_option warn.classDefReducibility false in
 @[to_dual DecidableLE1_dual]
 def DecidableLE1 (h : ∀ a b : α, Decidable (a ≤ b)) : DecidableLE α := fun a b ↦ h a b
 
-set_option warn.classDefReducibility false in
+-- set_option warn.classDefReducibility false in
 @[to_dual DecidableLE2_dual]
 def DecidableLE2 (h : ∀ a b : α, Decidable (a ≤ b)) : DecidableLE α := id h
 
@@ -341,7 +341,15 @@ inductive WithTop.LE : WithTop α → WithTop α → Prop where
   | le_top (x : WithTop α) : WithTop.LE x .top
   | coe_le_coe {a b : α} : a ≤ b → WithTop.LE (.coe a) (.coe b)
 
+attribute [to_dual existing] WithTop.LE.le_top
+
 @[to_dual]
 instance WithBot.instLE : _root_.LE (WithBot α) := ⟨WithBot.LE⟩
 
 example (a : α) : WithTop.coe a ≤ .top := .le_top (WithTop.coe a)
+
+-- The namespace is translated correctly for private names:
+@[to_dual]
+private theorem WithBot.coe_le_top : WithTop.coe a ≤ .top := .le_top (WithTop.coe a)
+
+run_meta guard <| (← getEnv).contains ``WithTop.coe_le_bot

--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -353,3 +353,11 @@ example (a : α) : WithTop.coe a ≤ .top := .le_top (WithTop.coe a)
 private theorem WithBot.coe_le_top : WithTop.coe a ≤ .top := .le_top (WithTop.coe a)
 
 run_meta guard <| (← getEnv).contains ``WithTop.coe_le_bot
+
+@[to_dual]
+private abbrev WithBotPrivate := WithBot
+
+@[to_dual]
+private theorem WithBotPrivate.coe_le_top : WithTop.coe a ≤ .top := .le_top (WithTop.coe a)
+
+run_meta guard <| (← getEnv).contains ``WithTopPrivate.coe_le_bot


### PR DESCRIPTION
This PR fixes a limitation of `to_additive`/`to_dual` when used on private declarations. The name translation algorithm has been improved so that when it tries to translate the namespace, it tries this both with and without the private prefix.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
