### PR TITLE
[Merged by Bors] - feat: improve `fin_cases` on `DihedralGroup`

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -142,6 +142,7 @@ def equivSum : DihedralGroup n ≃ (ZMod n) ⊕ (ZMod n) where
   left_inv := by rintro (x | x) <;> rfl
   right_inv := by rintro (x | x) <;> rfl
 
+/-- The equivalence between the sum of `ZMod`s and the dihedral group. -/
 @[deprecated DihedralGroup.equivSum (since := "2026-03-12")]
 abbrev fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n :=
   equivSum.symm

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -130,34 +130,37 @@ theorem r_pow (i : ZMod n) (k : ℕ) : (r i) ^ k = r (i * k : ZMod n) := by
 theorem r_zpow (i : ZMod n) (k : ℤ) : (r i) ^ k = r (i * k : ZMod n) := by
   cases k <;> simp [r_pow, neg_mul_eq_mul_neg]
 
-set_option backward.privateInPublic true in
-private def fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n where
-  invFun
+/-- The equivalence between the dihedral group and the sum of `ZMod`s. -/
+@[simps]
+def equivSum : DihedralGroup n ≃ (ZMod n) ⊕ (ZMod n) where
+  toFun
     | r j => .inl j
     | sr j => .inr j
-  toFun
+  invFun
     | .inl j => r j
     | .inr j => sr j
   left_inv := by rintro (x | x) <;> rfl
   right_inv := by rintro (x | x) <;> rfl
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
+@[deprecated DihedralGroup.equivSum (since := "2026-03-12")]
+abbrev fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n :=
+  equivSum.symm
+
 /-- If `0 < n`, then `DihedralGroup n` is a finite group.
 -/
 instance [NeZero n] : Fintype (DihedralGroup n) :=
-  Fintype.ofEquiv _ fintypeHelper
+  Fintype.ofEquiv _ equivSum.symm
 
 instance : Infinite (DihedralGroup 0) :=
-  DihedralGroup.fintypeHelper.infinite_iff.mp inferInstance
+  equivSum.symm.infinite_iff.mp inferInstance
 
 instance : Nontrivial (DihedralGroup n) :=
-  ⟨⟨r 0, sr 0, by simp_rw [ne_eq, reduceCtorEq, not_false_eq_true]⟩⟩
+  ⟨⟨r 0, sr 0, by by_contra h; injection h⟩⟩
 
 /-- If `0 < n`, then `DihedralGroup n` has `2n` elements.
 -/
 theorem card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n := by
-  rw [← Fintype.card_eq.mpr ⟨fintypeHelper⟩, Fintype.card_sum, ZMod.card, two_mul]
+  rw [← Fintype.card_eq.mpr ⟨equivSum.symm⟩, Fintype.card_sum, ZMod.card, two_mul]
 
 theorem nat_card : Nat.card (DihedralGroup n) = 2 * n := by
   cases n

--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -142,11 +142,6 @@ def equivSum : DihedralGroup n ≃ (ZMod n) ⊕ (ZMod n) where
   left_inv := by rintro (x | x) <;> rfl
   right_inv := by rintro (x | x) <;> rfl
 
-/-- The equivalence between the sum of `ZMod`s and the dihedral group. -/
-@[deprecated DihedralGroup.equivSum (since := "2026-03-12")]
-abbrev fintypeHelper : (ZMod n) ⊕ (ZMod n) ≃ DihedralGroup n :=
-  equivSum.symm
-
 /-- If `0 < n`, then `DihedralGroup n` is a finite group.
 -/
 instance [NeZero n] : Fintype (DihedralGroup n) :=


### PR DESCRIPTION
Better version of https://github.com/leanprover-community/mathlib4/pull/33504

This PR:

- Renames `fintypeHelper` -> `equivSum` and flips the direction
- Makes `equivSum` public
- Generates lemmas via `@[simps]`
- The deprecation of `fintypeHelper` is unnecessary because it is private

The same motivating example still works; after using `fin_cases <;> dsimp` on a goal about a finite dihedral group, we're left with simple goal states.

```
example (g : DihedralGroup 3) : (g^6 = 1) := by
  fin_cases g
  <;> dsimp

unsolved goals
case «0»
n : ℕ
⊢ r 0 ^ 6 = 1


case «1»
n : ℕ
⊢ r 1 ^ 6 = 1


case «2»
n : ℕ
⊢ r 2 ^ 6 = 1


case «3»
n : ℕ
⊢ sr 0 ^ 6 = 1


case «4»
n : ℕ
⊢ sr 1 ^ 6 = 1


case «5»
n : ℕ
⊢ sr 2 ^ 6 = 1
```

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
