### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `group` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -72,7 +72,7 @@ macro_rules
   `(tactic| ring_nf -failIfUnchanged $[at $location]?)
 
 /-- `group` normalizes expressions in multiplicative groups that occur in the goal. `group` does not
-assume commutativity, using only the group axioms without any information about which group is
+assume commutativity, instead using only the group axioms without any information about which group is
 manipulated. If the goal is an equality, and after normalization the two sides are equal, `group`
 closes the goal.
 

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -71,11 +71,14 @@ macro_rules
 | `(tactic| aux_group₂ $[at $location]?) =>
   `(tactic| ring_nf -failIfUnchanged $[at $location]?)
 
-/-- Tactic for normalizing expressions in multiplicative groups, without assuming
-commutativity, using only the group axioms without any information about which group
-is manipulated.
+/-- `group` normalizes expressions in multiplicative groups that occur in the goal. `group` does not
+assume commutativity, using only the group axioms without any information about which group is
+manipulated. If the goal is an equality, and after normalization the two sides are equal, `group`
+closes the goal.
 
-(For additive commutative groups, use the `abel` tactic instead.)
+For additive commutative groups, use the `abel` tactic instead.
+
+* `group at l1 l2 ...` normalizes at the given locations.
 
 Example:
 ```lean

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -72,8 +72,8 @@ macro_rules
   `(tactic| ring_nf -failIfUnchanged $[at $location]?)
 
 /-- `group` normalizes expressions in multiplicative groups that occur in the goal. `group` does not
-assume commutativity, instead using only the group axioms without any information about which group is
-manipulated. If the goal is an equality, and after normalization the two sides are equal, `group`
+assume commutativity, instead using only the group axioms without any information about which group
+is manipulated. If the goal is an equality, and after normalization the two sides are equal, `group`
 closes the goal.
 
 For additive commutative groups, use the `abel` tactic instead.


### PR DESCRIPTION
This PR rewrites the docstrings for the `group` tactic, to consistently match the official style guide, to make sure they are complete while not getting too long.

Apart from a few stylistic changes, we make precise where `group` performs its normalization, and that it can close the goal if it becomes a syntactic equality.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
