### PR TITLE
fix(Analysis/InnerProductSpace): define instInnerProductSpaceRealComplex as RCLike.toInnerProductSpaceReal

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -957,12 +957,6 @@ def InnerProductSpace.complexToReal [SeminormedAddCommGroup G] [InnerProductSpac
     InnerProductSpace ℝ G :=
   InnerProductSpace.rclikeToReal ℂ G
 
-instance : InnerProductSpace ℝ ℂ := InnerProductSpace.complexToReal
-
-@[simp]
-protected theorem Complex.inner (w z : ℂ) : ⟪w, z⟫_ℝ = (z * conj w).re :=
-  rfl
-
 end RCLikeToReal
 
 /-- An `RCLike` field is a real inner product space. -/
@@ -976,10 +970,20 @@ noncomputable instance RCLike.toInnerProductSpaceReal : InnerProductSpace ℝ �
     show re (_ * _) = _ * re (_ * _) by
       simp only [mul_re, conj_re, conj_im, conj_trivial, smul_re, smul_im]; ring
 
--- The instance above does not create diamonds for concrete `𝕜`:
+-- The instance above directly subsumes the complexToReal construction for ℂ.
+-- We define this here (after `RCLike.toInnerProductSpaceReal`) rather than above, so that
+-- `fast_instance%` and instance synthesis can find the canonical non-leaky form.
+noncomputable instance : InnerProductSpace ℝ ℂ := RCLike.toInnerProductSpaceReal
+
+-- Check that this does not create diamonds for concrete `𝕜`:
 example : (innerProductSpace : InnerProductSpace ℝ ℝ) = RCLike.toInnerProductSpaceReal := rfl
 example :
     (instInnerProductSpaceRealComplex : InnerProductSpace ℝ ℂ) = RCLike.toInnerProductSpaceReal :=
+  rfl
+
+open scoped InnerProductSpace in
+@[simp]
+protected theorem Complex.inner (w z : ℂ) : ⟪w, z⟫_ℝ = (z * conj w).re :=
   rfl
 
 section IsPosSemidef

--- a/MathlibTest/InnerProductSpaceRealComplex.lean
+++ b/MathlibTest/InnerProductSpaceRealComplex.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Analysis.InnerProductSpace.Basic
+
+/-!
+# Test: `instInnerProductSpaceRealComplex` is canonical at `instances` transparency
+
+Previously `instInnerProductSpaceRealComplex` was defined as `InnerProductSpace.complexToReal`,
+which goes through `NormedSpace.restrictScalars ℝ ℂ ℂ`. The `Module ℝ ℂ` arising from that path
+disagrees with `Algebra.toModule ℝ ℂ` at `.instances` transparency, causing `rw [one_smul]` to
+fail with `set_option backward.isDefEq.respectTransparency true`.
+
+The fix redefines `instInnerProductSpaceRealComplex := RCLike.toInnerProductSpaceReal`, whose
+`NormedSpace ℝ ℂ` comes from `NormedAlgebra.toNormedSpace` (via `RCLike.toNormedAlgebra`),
+so its `Module ℝ ℂ` agrees with `Algebra.toModule` at `.instances` transparency.
+-/
+
+-- The `Module ℝ ℂ` from `InnerProductSpace ℝ ℂ` now agrees with `Algebra.toModule` at instances
+-- transparency.
+example : (inferInstance : InnerProductSpace ℝ ℂ).toNormedSpace.toModule =
+    (inferInstance : Algebra ℝ ℂ).toModule := by
+  with_reducible_and_instances rfl
+
+-- As a consequence, `rw [one_smul]` works with strict transparency.
+set_option backward.isDefEq.respectTransparency true in
+example (z : ℂ) : (1 : ℝ) • z = z := by
+  rw [one_smul]


### PR DESCRIPTION
This PR fixes a leaky instance that caused `rw [one_smul]` to fail with `set_option backward.isDefEq.respectTransparency true`.

**Root cause.** `instInnerProductSpaceRealComplex` was defined as `InnerProductSpace.complexToReal`, which goes through `NormedSpace.restrictScalars ℝ ℂ ℂ`. The `Module ℝ ℂ` arising from that path disagrees with `Algebra.toModule ℝ ℂ` at `.instances` transparency. Concretely:

```lean
-- FAILS at instances transparency, but succeeds at default:
example : (inferInstance : InnerProductSpace ℝ ℂ).toNormedSpace.toModule =
    (inferInstance : Algebra ℝ ℂ).toModule := by with_reducible_and_instances rfl
```

The underlying issue is that `RestrictScalars.module ℝ ℂ ℂ := Module.compHom ℂ (algebraMap ℝ ℂ)` has its `smul` with binder type `ℂ` rather than `RestrictScalars ℝ ℂ ℂ`, creating a leak that is invisible at `.default` transparency but visible at `.instances` transparency.

**Fix.** The existing `RCLike.toInnerProductSpaceReal` already provides `InnerProductSpace ℝ ℂ` (for `𝕜 = ℂ`) and was already proven equal to `instInnerProductSpaceRealComplex` by `rfl` in the same file. Its `NormedSpace ℝ ℂ` comes from `NormedAlgebra.toNormedSpace` (via `RCLike.toNormedAlgebra`), which gives the canonical `Module ℝ ℂ` from `Algebra.toModule`. We simply move `instInnerProductSpaceRealComplex` to after `RCLike.toInnerProductSpaceReal` and define it as `RCLike.toInnerProductSpaceReal` directly.

**Evidence.** After this change:
```lean
-- Now works at instances transparency:
example : (inferInstance : InnerProductSpace ℝ ℂ).toNormedSpace.toModule =
    (inferInstance : Algebra ℝ ℂ).toModule := by with_reducible_and_instances rfl

-- And the original motivating example:
set_option backward.isDefEq.respectTransparency true in
example (z : ℂ) : (1 : ℝ) • z = z := by rw [one_smul]
```

🤖 Prepared with Claude Code