### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `introv` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -56,35 +56,37 @@ def pushFVarAliasInfo {m : Type → Type} [Monad m] [MonadInfoTree m]
       pushInfoLeaf (.ofFVarAliasInfo { id := new, baseId := old, userName := decl.userName })
 
 /--
-The tactic `introv` allows the user to automatically introduce the variables of a theorem and
-explicitly name the non-dependent hypotheses.
-Any dependent hypotheses are assigned their default names.
+`introv` introduces the parameters to a dependent function according to their parameter name. If the
+first parameter is non-dependent, `introv` does nothing.
+
+* `introv h₁ h₂ ...` introduces non-dependent parameters in between sequences of dependent
+  parameters, using the names `h₁`, `h₂`, ... in turn. Use `_` to anonymize a specific hypothesis.
 
 Examples:
 ```
 example : ∀ a b : Nat, a = b → b = a := by
-  introv h,
+  introv h
+  /-
+  The goal state is:
+  a b : ℕ,
+  h : a = b
+  ⊢ b = a
+  -/
   exact h.symm
-```
-The state after `introv h` is
-```
-a b : ℕ,
-h : a = b
-⊢ b = a
 ```
 
 ```
 example : ∀ a b : Nat, a = b → ∀ c, b = c → a = c := by
-  introv h₁ h₂,
+  introv h₁ h₂
+  /-
+  The goal state is:
+  a b : ℕ,
+  h₁ : a = b,
+  c : ℕ,
+  h₂ : b = c
+  ⊢ a = c
+  -/
   exact h₁.trans h₂
-```
-The state after `introv h₁ h₂` is
-```
-a b : ℕ,
-h₁ : a = b,
-c : ℕ,
-h₂ : b = c
-⊢ a = c
 ```
 -/
 syntax (name := introv) "introv" (ppSpace colGt binderIdent)* : tactic

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -57,7 +57,8 @@ def pushFVarAliasInfo {m : Type → Type} [Monad m] [MonadInfoTree m]
 
 /--
 `introv` introduces the parameters to a dependent function according to their parameter name. If the
-first parameter is not depended on by the rest of the function type, `introv` with no (remaining) arguments does nothing.
+first parameter is not depended on by the rest of the function type, `introv` with no (remaining)
+arguments does nothing.
 
 * `introv h₁ h₂ ...` introduces non-depended-on parameters in between sequences of depended-on
   parameters, using the names `h₁`, `h₂`, ... in turn. Use `_` to anonymize a specific hypothesis.

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -57,9 +57,9 @@ def pushFVarAliasInfo {m : Type → Type} [Monad m] [MonadInfoTree m]
 
 /--
 `introv` introduces the parameters to a dependent function according to their parameter name. If the
-first parameter is non-dependent, `introv` does nothing.
+first parameter is not depended on by the rest of the function type, `introv` with no (remaining) arguments does nothing.
 
-* `introv h₁ h₂ ...` introduces non-dependent parameters in between sequences of dependent
+* `introv h₁ h₂ ...` introduces non-depended-on parameters in between sequences of depended-on
   parameters, using the names `h₁`, `h₂`, ... in turn. Use `_` to anonymize a specific hypothesis.
 
 Examples:


### PR DESCRIPTION
This PR rewrites the docstrings for the `introv` tactic, to consistently match the official style guide, to make sure they are complete while not getting too long.

In particular, I wanted to clarify exactly what `introv` does and does not introduce, depending on the list of names given to it.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
