### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `lift` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -73,39 +73,15 @@ namespace Mathlib.Tactic
 
 open Lean Parser Elab Tactic Meta
 
-/-- Lift an expression to another type.
-* Usage: `'lift' expr 'to' expr ('using' expr)? ('with' id (id id?)?)?`.
-* If `n : ℤ` and `hn : n ≥ 0` then the tactic `lift n to ℕ using hn` creates a new
-  constant of type `ℕ`, also named `n` and replaces all occurrences of the old variable `(n : ℤ)`
-  with `↑n` (where `n` in the new variable). It will clear `n` from the context and
-  try to clear `hn` from the context.
-  + So for example the tactic `lift n to ℕ using hn` transforms the goal
-    `n : ℤ, hn : n ≥ 0, h : P n ⊢ n = 3` to `n : ℕ, h : P ↑n ⊢ ↑n = 3`
-    (here `P` is some term of type `ℤ → Prop`).
-* The argument `using hn` is optional, the tactic `lift n to ℕ` does the same, but also creates a
-  new subgoal that `n ≥ 0` (where `n` is the old variable).
-  This subgoal will be placed at the top of the goal list.
-  + So for example the tactic `lift n to ℕ` transforms the goal
-    `n : ℤ, h : P n ⊢ n = 3` to two goals
-    `n : ℤ, h : P n ⊢ n ≥ 0` and `n : ℕ, h : P ↑n ⊢ ↑n = 3`.
-* You can also use `lift n to ℕ using e` where `e` is any expression of type `n ≥ 0`.
-* Use `lift n to ℕ with k` to specify the name of the new variable.
-* Use `lift n to ℕ with k hk` to also specify the name of the equality `↑k = n`. In this case, `n`
-  will remain in the context. You can use `rfl` for the name of `hk` to substitute `n` away
-  (i.e. the default behavior).
-* You can also use `lift e to ℕ with k hk` where `e` is any expression of type `ℤ`.
-  In this case, the `hk` will always stay in the context, but it will be used to rewrite `e` in
-  all hypotheses and the target.
-  + So for example the tactic `lift n + 3 to ℕ using hn with k hk` transforms the goal
-    `n : ℤ, hn : n + 3 ≥ 0, h : P (n + 3) ⊢ n + 3 = 2 * n` to the goal
-    `n : ℤ, k : ℕ, hk : ↑k = n + 3, h : P ↑k ⊢ ↑k = 2 * n`.
-* The tactic `lift n to ℕ using h` will remove `h` from the context. If you want to keep it,
-  specify it again as the third argument to `with`, like this: `lift n to ℕ using h with n rfl h`.
-* More generally, this can lift an expression from `α` to `β` assuming that there is an instance
-  of `CanLift α β`. In this case the proof obligation is specified by `CanLift.prf`.
-* Given an instance `CanLift β γ`, it can also lift `α → β` to `α → γ`; more generally, given
-  `β : Π a : α, Type*`, `γ : Π a : α, Type*`, and `[Π a : α, CanLift (β a) (γ a)]`, it
-  automatically generates an instance `CanLift (Π a, β a) (Π a, γ a)`.
+/--
+`lift e to t with x` lifts the expression `e` to the type `t` by introducing a new variable `x : t`
+such that `↑x = e`, and then replacing occurrences of `e` with `↑x`. `lift` requires an instance of
+the class `CanLift t' t coe cond`, where `t'` is the type of `e`, and creates a side goal for the
+lifting condition, of the form `⊢ cond x`, placing this on top of the goal stack.
+
+Given an instance `CanLift β γ`, `lift` can also lift `α → β` to `α → γ`; more generally, given
+`β : Π a : α, Type*`, `γ : Π a : α, Type*`, and `[Π a : α, CanLift (β a) (γ a)]`, it
+automatically generates an instance `CanLift (Π a, β a) (Π a, γ a)`.
 
 `lift` is in some sense dual to the `zify` tactic. `lift (z : ℤ) to ℕ` will change the type of an
 integer `z` (in the supertype) to `ℕ` (the subtype), given a proof that `z ≥ 0`;
@@ -113,6 +89,58 @@ propositions concerning `z` will still be over `ℤ`. `zify` changes proposition
 subtype) to propositions about `ℤ` (the supertype), without changing the type of any variable.
 
 The `norm_cast` tactic can be used after `lift` to normalize introduced casts.
+
+* `lift e to t using h with x` uses the expression `h` to prove the lifting condition `cond e`.
+  If `h` is a variable, `lift` will try to clear it from the context. If you want to keep `h` in
+  the context, write `lift e to t using h with x rfl h` (see below).
+* If `e` is a variable, `lift e to t` is equivalent to `lift e to t with e`. The original variable
+  `e` will be cleared from the context.
+* `lift e to t with x hx` adds `hx : ↑x = e` to the context (and if `e` is a variable, does not
+  clear it).
+* `lift e to t with x hx h` adds `hx : ↑x = e` and `h : cond e` to the context (and if `e` is a
+  variable, does not clear it). In particular, `lift e to t using h with x hx h`, where `h` is a
+  variable, keeps `h` in the context.
+* `lift e to t with x rfl h` adds `h : cond e` to the context (and if `e` is a variable, does not
+  clear it). In particular, `lift e to t using h with x rfl h`, where `h` is a variable, keeps `h`
+  in the context.
+
+Examples:
+```
+def P (n : ℤ) : Prop := n = 3
+
+example (n : ℤ) (h : P n) : n = 3 := by
+  lift n to ℕ
+  /-
+  Two goals:
+  n : ℤ, h : P n ⊢ n ≥ 0
+  n : ℕ, h : P ↑n ⊢ ↑n = 3
+  -/
+  · unfold P at h; linarith
+  · exact h
+
+example (n : ℤ) (hn : n ≥ 0) (h : P n) : n = 3 := by
+  lift n to ℕ using hn
+  /-
+  One goal:
+  n : ℕ
+  h : P ↑n
+  ⊢ ↑n = 3
+  -/
+  exact h
+
+example (n : ℤ) (hn : n + 3 ≥ 0) (h : P (n + 3)) :
+    n + 3 = n * 2 + 3 := by
+  lift n + 3 to ℕ using hn with k hk
+  /-
+  One goal:
+  n : ℤ
+  k : ℕ
+  hk : ↑k = n + 3
+  h : P ↑k
+  ⊢ ↑k = 2 * n + 3
+  -/
+  unfold P at h; linarith
+```
 -/
 syntax (name := lift) "lift " term " to " term (" using " term)?
   (" with " ident (ppSpace colGt ident)? (ppSpace colGt ident)?)? : tactic


### PR DESCRIPTION
This PR rewrites the docstrings for the `lift` tactic, to make sure they are complete while not getting too long.

The main change, apart from restructuring the bullet points to fit the style guide, is to treat the form `lift e to t with x`, where `e` is any expression, as the "general" form, and the case where `e` is a variable as a specialized form. Although it doesn't match the historical development, I think this is clearer for new users (since explaining `lift` without `with` as a special case can be done with only one line). Similarly, we separate `using` into its own bullet point.

In this docstring I did not include the alternative form `lift e to t with x rfl`, since it is exactly equivalent to `lift e to to with x` as far as I can tell. I did include `lift e to t with x rfl h`, because it is useful for preserving the `using` hypothesis without naming the introduced equality.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
