### PR TITLE
[Merged by Bors] - chore(Order/Hom/Lattice): clean up `to_dual` use

### DIFF
--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -121,6 +121,8 @@ section
 abbrev OrderHomClass (F : Type*) (α β : outParam Type*) [LE α] [LE β] [FunLike F α β] :=
   RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop)
 
+to_dual_insert_cast OrderHomClass := by grind only [RelHomClass]
+
 /-- `OrderIsoClass F α β` states that `F` is a type of order isomorphisms.
 
 You should extend this class when you extend `OrderIso`. -/

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -65,6 +65,7 @@ structure InfHom (α β : Type*) [Min α] [Min β] where
 structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β, InfHom α β where
 
 attribute [to_dual existing] LatticeHom.toInfHom
+
 section
 
 /-- `SupHomClass F α β` states that `F` is a type of `⊔`-preserving morphisms.

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -62,12 +62,9 @@ structure InfHom (α β : Type*) [Min α] [Min β] where
   map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
 
 /-- The type of lattice homomorphisms from `α` to `β`. -/
-structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β where
-  /-- A `LatticeHom` preserves infima.
+structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β, InfHom α β where
 
-  Do not use this directly. Use `map_inf` instead. -/
-  map_inf' (a b : α) : toFun (a ⊓ b) = toFun a ⊓ toFun b
-
+attribute [to_dual existing] LatticeHom.toInfHom
 section
 
 /-- `SupHomClass F α β` states that `F` is a type of `⊔`-preserving morphisms.
@@ -89,9 +86,9 @@ class InfHomClass (F α β : Type*) [Min α] [Min β] [FunLike F α β] : Prop w
 
 You should extend this class when you extend `LatticeHom`. -/
 class LatticeHomClass (F α β : Type*) [Lattice α] [Lattice β] [FunLike F α β] : Prop
-  extends SupHomClass F α β where
-  /-- A `LatticeHomClass` morphism preserves infima. -/
-  map_inf (f : F) (a b : α) : f (a ⊓ b) = f a ⊓ f b
+  extends SupHomClass F α β, InfHomClass F α β where
+
+attribute [to_dual existing] LatticeHomClass.toInfHomClass
 
 end
 
@@ -106,23 +103,11 @@ section Hom
 variable [FunLike F α β]
 
 -- See note [lower instance priority]
+@[to_dual]
 instance (priority := 100) SupHomClass.toOrderHomClass [SemilatticeSup α] [SemilatticeSup β]
     [SupHomClass F α β] : OrderHomClass F α β :=
   { ‹SupHomClass F α β› with
     map_rel := fun f a b h => by rw [← sup_eq_right, ← map_sup, sup_eq_right.2 h] }
-
--- See note [lower instance priority]
-@[to_dual existing]
-instance (priority := 100) InfHomClass.toOrderHomClass [SemilatticeInf α] [SemilatticeInf β]
-    [InfHomClass F α β] : OrderHomClass F α β :=
-  { ‹InfHomClass F α β› with
-    map_rel := fun f a b h => by rw [← inf_eq_left, ← map_inf, inf_eq_left.2 h] }
-
--- See note [lower instance priority]
-@[to_dual existing]
-instance (priority := 100) LatticeHomClass.toInfHomClass [Lattice α] [Lattice β]
-    [LatticeHomClass F α β] : InfHomClass F α β :=
-  { ‹LatticeHomClass F α β› with }
 
 end Hom
 
@@ -312,29 +297,16 @@ instance [Bot β] : Bot (SupHom α β) :=
 instance [Top β] : Top (SupHom α β) :=
   ⟨SupHom.const α ⊤⟩
 
--- `OrderBot.lift` is currently not supported by `to_dual`
+@[to_dual]
 instance [OrderBot β] : OrderBot (SupHom α β) :=
   OrderBot.lift ((↑) : _ → α → β) (fun _ _ => id) rfl
 
+@[to_dual]
 instance [OrderTop β] : OrderTop (SupHom α β) :=
   OrderTop.lift ((↑) : _ → α → β) (fun _ _ => id) rfl
 
+@[to_dual]
 instance [BoundedOrder β] : BoundedOrder (SupHom α β) :=
-  BoundedOrder.lift ((↑) : _ → α → β) (fun _ _ => id) rfl rfl
-
-@[to_dual existing]
-instance _root_.InfHom.instOrderBot [Min α] [SemilatticeInf β] [OrderBot β] :
-    OrderBot (InfHom α β) :=
-  OrderBot.lift ((↑) : _ → α → β) (fun _ _ => id) rfl
-
-@[to_dual existing]
-instance _root_.InfHom.instOrderTop [Min α] [SemilatticeInf β] [OrderTop β] :
-    OrderTop (InfHom α β) :=
-  OrderTop.lift ((↑) : _ → α → β) (fun _ _ => id) rfl
-
-@[to_dual existing]
-instance _root_.InfHom.instBoundedOrder [Min α] [SemilatticeInf β] [BoundedOrder β] :
-    BoundedOrder (InfHom α β) :=
   BoundedOrder.lift ((↑) : _ → α → β) (fun _ _ => id) rfl rfl
 
 @[to_dual (attr := simp)]
@@ -421,11 +393,6 @@ end InfHom
 namespace LatticeHom
 
 variable [Lattice α] [Lattice β] [Lattice γ] [Lattice δ]
-
-/-- Reinterpret a `LatticeHom` as an `InfHom`. -/
-@[to_dual existing]
-def toInfHom (f : LatticeHom α β) : InfHom α β :=
-  { f with }
 
 instance : FunLike (LatticeHom α β) α β where
   coe f := f.toFun

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -64,6 +64,8 @@ structure InfHom (α β : Type*) [Min α] [Min β] where
 /-- The type of lattice homomorphisms from `α` to `β`. -/
 structure LatticeHom (α β : Type*) [Lattice α] [Lattice β] extends SupHom α β, InfHom α β where
 
+attribute [nolint docBlame] LatticeHom.toInfHom
+
 attribute [to_dual existing] LatticeHom.toInfHom
 
 section


### PR DESCRIPTION
This PR cleans up the use of `to_dual` for `LatticeHom` after #36159, avoiding `to_dual existing` where this is not needed.

Another benefit of this PR is that `LatticeHom.toInfHom` now becomes reducible, just like `LatticeHom.toSupHom`, as a result of generating it with `extends`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
