### PR TITLE
[Merged by Bors] - chore(cache): Update leantar to 0.1.18

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -81,7 +81,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.16"
+  "0.1.18"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 


### PR DESCRIPTION
This includes a [bug fix](https://github.com/digama0/leangz/commit/7f12e76ca0384d558f568e9df441b43a747601d8) that is critical to our cache push logic. It caused failures today after #33044, e.g. https://github.com/leanprover-community/mathlib4/actions/runs/23060564805/job/66985730455