### PR TITLE
feat(Geometry/Manifold): existence of covariant derivatives

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4453,6 +4453,7 @@ public import Mathlib.Geometry.Manifold.SmoothEmbedding
 public import Mathlib.Geometry.Manifold.StructureGroupoid
 public import Mathlib.Geometry.Manifold.VectorBundle.Basic
 public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Basic
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Existence
 public import Mathlib.Geometry.Manifold.VectorBundle.FiberwiseLinear
 public import Mathlib.Geometry.Manifold.VectorBundle.Hom
 public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Basic.lean
@@ -292,6 +292,52 @@ lemma _root_.ContMDiffCovariantDerivativeOn.finite_affine_combination [IsManifol
     simpa using ContMDiffOn.sum_section
       (fun i hi ↦ (hf i hi).smul_section <| (hcov i hi).contMDiff hσ)
 
+/-- A locally finite affine combination of covariant derivatives is a covariant derivative. -/
+theorem finsum_affine_combination {ι : Type*}
+    {cov : ι → (Π x : M, V x) → (Π x : M, TangentSpace I x →L[𝕜] V x)}
+    {U : ι → Set M}
+    (hcov : ∀ i, IsCovariantDerivativeOn F (cov i) (U i))
+    {f : ι → M → 𝕜}
+    (hf_sum : ∀ x, ∑ᶠ i, f i x = 1)
+    (hf_lf : LocallyFinite (fun i ↦ Function.support (f i)))
+    (hf_supp : ∀ i, tsupport (f i) ⊆ U i) :
+    IsCovariantDerivativeOn F
+      (fun σ x ↦ ∑ᶠ i, (f i x) • (cov i) σ x) Set.univ where
+  add {σ σ'} {x} hσ hσ' _ := by
+    have hterm : ∀ i, f i x • cov i (σ + σ') x =
+        f i x • cov i σ x + f i x • cov i σ' x := fun i ↦ by
+      by_cases hi : f i x = 0
+      · simp [hi]
+      · rw [(hcov i).add hσ hσ' (hf_supp i (subset_tsupport _ hi)), smul_add]
+    simp_rw [hterm]
+    exact finsum_add_distrib
+      ((hf_lf.point_finite x).subset
+        (Function.support_smul_subset_left (f · x) (cov · σ x)))
+      ((hf_lf.point_finite x).subset
+        (Function.support_smul_subset_left (f · x) (cov · σ' x)))
+  leibniz {σ g} {x} hσ hg _ := by
+    have hfin := hf_lf.point_finite x
+    have hs : Function.support (fun i ↦ f i x) ⊆ ↑hfin.toFinset :=
+      fun i hi ↦ hfin.mem_toFinset.mpr hi
+    have hsupp : ∀ σ, Function.support (fun i ↦ f i x • cov i σ x) ⊆ ↑hfin.toFinset :=
+      fun σ ↦ (Function.support_smul_subset_left (f · x) (cov · σ x)).trans hs
+    rw [finsum_eq_sum_of_support_subset _ (hsupp (g • σ)),
+        finsum_eq_sum_of_support_subset _ (hsupp σ)]
+    calc ∑ i ∈ hfin.toFinset, f i x • cov i (g • σ) x
+      _ = ∑ i ∈ hfin.toFinset, (g x • (f i x • cov i σ x) +
+            f i x • (extDerivFun g x).smulRight (σ x)) := by
+          apply Finset.sum_congr rfl; intro i _
+          by_cases hi : f i x = 0
+          · simp [hi]
+          · rw [(hcov i).leibniz hσ hg (hf_supp i (subset_tsupport _ hi)), smul_add]
+            module
+      _ = g x • ∑ i ∈ hfin.toFinset, f i x • cov i σ x +
+            (∑ i ∈ hfin.toFinset, f i) x • (extDerivFun g x).smulRight (σ x) := by
+          rw [Finset.sum_add_distrib, Finset.smul_sum, Finset.sum_apply, Finset.sum_smul]
+      _ = g x • ∑ i ∈ hfin.toFinset, f i x • cov i σ x +
+            (extDerivFun g x).smulRight (σ x) := by
+          rw [Finset.sum_apply, ← finsum_eq_sum_of_support_subset _ hs, hf_sum x, one_smul]
+
 /-- Adding a one-form taking values in the endomorphisms of the vector bundle to a covariant
   derivative gives a covariant derivative. -/
 lemma add_one_form (hcov : IsCovariantDerivativeOn F cov s)
@@ -468,8 +514,17 @@ lemma ContMDiffCovariantDerivative.finite_affine_combination [IsManifold I 1 M] 
     ContMDiffCovariantDerivativeOn.finite_affine_combination
       (fun i hi ↦ (hcov i hi).contMDiff) (fun i hi ↦ (hf' i hi).contMDiffOn)
 
--- TODO: prove a version with a locally finite sum, and deduce that C^k connections always
--- exist (using a partition of unity argument)
+/-- A locally finite affine combination of covariant derivatives, as a covariant derivative. -/
+def finsum_affine_combination {ι : Type*}
+    (cov : ι → CovariantDerivative I F V) {f : ι → M → 𝕜}
+    (hf_sum : ∀ x, ∑ᶠ i, f i x = 1)
+    (hf_lf : LocallyFinite (fun i ↦ Function.support (f i)))
+    (hf_supp : ∀ i, tsupport (f i) ⊆ Set.univ := by intro; exact Set.subset_univ _) :
+    CovariantDerivative I F V where
+  toFun σ x := ∑ᶠ i, (f i x) • (cov i) σ x
+  isCovariantDerivativeOnUniv :=
+    IsCovariantDerivativeOn.finsum_affine_combination
+      (fun i ↦ (cov i).isCovariantDerivativeOn) hf_sum hf_lf hf_supp
 
 /-- Adding a one-form taking values in the endomorphisms of the vector bundle to a covariant
   derivative gives a covariant derivative. -/

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Existence.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Existence.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Robin Gieseke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Gieseke
+-/
+module
+
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Basic
+import Mathlib.Geometry.Manifold.PartitionOfUnity
+
+/-!
+# Existence of covariant derivatives
+
+This file proves that covariant derivatives (connections) exist on any smooth vector bundle
+over a smooth manifold with σ-compact Hausdorff topology, using a partition of unity argument.
+
+## Main results
+
+* `Bundle.Trivialization.trivialCov`: the flat covariant derivative induced by a trivialization.
+* `Bundle.Trivialization.isCovariantDerivativeOn_trivialCov`: the flat covariant derivative is
+  indeed a covariant derivative on the base set of the trivialization.
+* `CovariantDerivative.exists`: covariant derivatives always exist on smooth vector bundles
+  over smooth σ-compact Hausdorff manifolds.
+
+## Implementation notes
+
+The flat covariant derivative decomposes as `e.symmL ∘ mfderiv (e.secToFun σ)`: it reads
+a section through a trivialization via `secToFun`, takes the manifold derivative, and maps the
+result back to the fiber via `symmL` (the inverse of the trivialization's linear equivalence).
+-/
+
+open Bundle NormedSpace
+open scoped Manifold ContDiff Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  (F : Type*) [NormedAddCommGroup F] [NormedSpace ℝ F]
+  {V : M → Type*} [TopologicalSpace (TotalSpace F V)]
+  [∀ x, AddCommGroup (V x)] [∀ x, Module ℝ (V x)]
+  [∀ x : M, TopologicalSpace (V x)]
+  [∀ x, IsTopologicalAddGroup (V x)] [∀ x, ContinuousSMul ℝ (V x)]
+  [FiberBundle F V] [VectorBundle ℝ F V]
+  [ContMDiffVectorBundle 1 F V I]
+
+@[expose] public noncomputable section
+
+/-! ## Flat covariant derivative in a trivialization -/
+
+namespace Bundle.Trivialization
+
+/-- The flat covariant derivative induced by a trivialization `e`. This reads a section `σ`
+through `e` via `secToFun`, takes the manifold derivative, and maps the result back to the
+fiber via `e.symmL`. Outside `e.baseSet` this is zero since `e.symmL` is zero there. -/
+def trivialCov (e : Trivialization F (π F V)) [e.IsLinear ℝ]
+    (σ : Π x : M, V x) (x : M) : TangentSpace I x →L[ℝ] V x :=
+  e.symmL ℝ x ∘L mfderiv I 𝓘(ℝ, F) (e.secToFun σ) x
+
+variable {F}
+
+/-- The flat covariant derivative induced by a trivialization is a covariant derivative
+on its base set. -/
+theorem isCovariantDerivativeOn_trivialCov
+    (e : Trivialization F (π F V)) [MemTrivializationAtlas e] :
+    IsCovariantDerivativeOn F (e.trivialCov (I := I) F) e.baseSet where
+  add {σ σ'} {x} hσ hσ' hx := by
+    unfold trivialCov Trivialization.secToFun
+    have heq : (fun y ↦ (e ⟨y, (σ + σ') y⟩).2) =ᶠ[𝓝 x]
+        ((fun y ↦ (e ⟨y, σ y⟩).2) + (fun y ↦ (e ⟨y, σ' y⟩).2)) :=
+      e.secToFun_add_eventuallyEq (R := ℝ) σ σ' hx
+    rw [heq.mfderiv_eq.trans (HasMFDerivAt.mfderiv
+      (((e.mdifferentiableAt_section_iff I σ hx).mp hσ).hasMFDerivAt.add
+        ((e.mdifferentiableAt_section_iff I σ' hx).mp hσ').hasMFDerivAt)),
+      ContinuousLinearMap.comp_add]
+  leibniz {σ g} {x} hσ hg hx := by
+    unfold trivialCov Trivialization.secToFun
+    have heq : (fun y ↦ (e ⟨y, (g • σ) y⟩).2) =ᶠ[𝓝 x]
+        (g • (fun y ↦ (e ⟨y, σ y⟩).2)) :=
+      e.secToFun_smul_eventuallyEq (R := ℝ) g σ hx
+    rw [heq.mfderiv_eq]; ext v
+    have := congr_arg (e.symmL ℝ x) (fromTangentSpace_mfderiv_smul_apply (V := F) hg
+      ((e.mdifferentiableAt_section_iff I σ hx).mp hσ) v)
+    simpa only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.add_apply,
+      ContinuousLinearMap.smul_apply, ContinuousLinearMap.smulRight_apply,
+      map_add, map_smul, symmL_apply, symm_apply_apply_mk _ hx] using this
+
+end Bundle.Trivialization
+
+/-! ## Existence of covariant derivatives -/
+
+variable [FiniteDimensional ℝ E] [IsManifold I ∞ M] [T2Space M] [SigmaCompactSpace M]
+
+-- TODO: `[IsManifold I ∞ M]` should be `[IsManifold I k M]` for suitable `k`: a C^k partition
+-- of unity suffices. Blocked on mathlib lacking C^k partitions of unity.
+/-- Every smooth vector bundle over a smooth σ-compact Hausdorff manifold admits a covariant
+derivative. -/
+theorem CovariantDerivative.exists : Nonempty (CovariantDerivative I F V) := by
+  obtain ⟨ρ, hρ⟩ := SmoothPartitionOfUnity.exists_isSubordinate (I := I) isClosed_univ
+    (fun x ↦ (trivializationAt F V x).baseSet)
+    (fun x ↦ (trivializationAt F V x).open_baseSet)
+    (fun x _ ↦ Set.mem_iUnion.mpr ⟨x, FiberBundle.mem_baseSet_trivializationAt' x⟩)
+  exact ⟨⟨_, .finsum_affine_combination
+    (fun i ↦ (trivializationAt F V i).isCovariantDerivativeOn_trivialCov (I := I))
+    (fun x ↦ ρ.sum_eq_one (Set.mem_univ x)) ρ.locallyFinite hρ⟩⟩
+
+end


### PR DESCRIPTION
Prove that covariant derivatives (connections) always exist on smooth vector bundles
over smooth σ-compact Hausdorff manifolds, via a partition of unity argument.
Resolves the TODO in `CovariantDerivative.Basic`.

## Main results
- `Bundle.Trivialization.trivialCov`: flat connection in a trivialization
- `IsCovariantDerivativeOn.finsum_affine_combination`: locally finite affine
  combinations of covariant derivatives are covariant derivatives
- `CovariantDerivative.exists`: the main existence theorem

## Context
This is a step towards #26221. The partition of unity gluing was left as a TODO
in #36279.

---

Co-authored-by: Claude <noreply@anthropic.com>