### PR TITLE
[Merged by Bors] - feat(GroupTheory/Finiteness): copy FreeGroup lemmas to FreeMonoid

### DIFF
--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -173,18 +173,6 @@ theorem Monoid.fg_iff :
     Monoid.FG M ↔ ∃ S : Set M, Submonoid.closure S = (⊤ : Submonoid M) ∧ S.Finite :=
   ⟨fun _ => (Submonoid.fg_iff ⊤).1 FG.fg_top, fun h => ⟨(Submonoid.fg_iff ⊤).2 h⟩⟩
 
-/-- A monoid is finitely generated iff there exists a surjective homomorphism from a `FreeMonoid`
-on finitely many generators. -/
-@[to_additive /-- An additive monoid is finitely generated iff there exists a surjective
-homomorphism from a `FreeAddMonoid` on finitely many generators.-/]
-theorem Monoid.fg_iff_exists_freeMonoid_hom_surjective :
-    Monoid.FG M ↔ ∃ (S : Set M) (_ : S.Finite) (φ : FreeMonoid S →* M), Function.Surjective φ := by
-  refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeMonoid.lift Subtype.val, ?_⟩, ?_⟩
-  · rwa [← MonoidHom.mrange_eq_top, ← Submonoid.closure_eq_mrange]
-  · rintro ⟨S, hfin : Finite S, φ, hφ⟩
-    refine fg_iff.mpr ⟨φ '' Set.range FreeMonoid.of, ?_, Set.toFinite _⟩
-    simp [← MonoidHom.map_mclosure, hφ, FreeMonoid.closure_range_of, ← MonoidHom.mrange_eq_map]
-
 variable (M) in
 /-- A finitely generated monoid has a minimal generating set. -/
 @[to_additive /-- A finitely generated monoid has a minimal generating set. -/]
@@ -254,6 +242,38 @@ theorem Monoid.fg_of_surjective {M' : Type*} [Monoid M'] [Monoid.FG M] (f : M �
 instance Monoid.fg_range {M' : Type*} [Monoid M'] [Monoid.FG M] (f : M →* M') :
     Monoid.FG (MonoidHom.mrange f) :=
   Monoid.fg_of_surjective f.mrangeRestrict f.mrangeRestrict_surjective
+
+open FreeMonoid in
+@[to_additive]
+instance (α : Type*) [Finite α] : Monoid.FG (FreeMonoid α) :=
+  Monoid.fg_iff.mpr ⟨Set.range of, closure_range_of, Set.finite_range of⟩
+
+/-- A monoid is finitely generated iff there exists a surjective homomorphism from a `FreeMonoid`
+on finitely many generators. -/
+@[to_additive /-- An additive monoid is finitely generated iff there exists a surjective
+homomorphism from a `FreeAddMonoid` on finitely many generators.-/]
+theorem Monoid.fg_iff_exists_freeMonoid_hom_surjective :
+    Monoid.FG M ↔ ∃ (S : Set M) (_ : S.Finite) (φ : FreeMonoid S →* M), Function.Surjective φ := by
+  refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeMonoid.lift Subtype.val, ?_⟩, ?_⟩
+  · rwa [← MonoidHom.mrange_eq_top, ← Submonoid.closure_eq_mrange]
+  · rintro ⟨S, hfin : Finite S, φ, hφ⟩
+    refine fg_iff.mpr ⟨φ '' Set.range FreeMonoid.of, ?_, Set.toFinite _⟩
+    simp [← MonoidHom.map_mclosure, hφ, FreeMonoid.closure_range_of, ← MonoidHom.mrange_eq_map]
+
+/-- A monoid if finitely generated if and only if there exists a surjective homomorphism from a
+`FreeMonoid` on an arbitrary finite type `α` to the monoid. -/
+@[to_additive /-- An additive monoid is finitely generated iff there exists a surjective
+homomorphism from a `FreeAddMonoid` on an arbitrary finite type `α` to the monoid. -/]
+theorem Monoid.fg_iff_exists_freeGroup_hom_surjective_finite :
+    Monoid.FG M ↔ ∃ (α : Type) (_ : Finite α) (φ : FreeMonoid α →* M), Function.Surjective φ := by
+  constructor
+  · rw [fg_iff_exists_freeMonoid_hom_surjective]
+    intro ⟨S, hS, φ, hφ⟩
+    obtain ⟨n, ⟨e⟩⟩ := hS.exists_equiv_fin S
+    exact ⟨Fin n, inferInstance, φ.comp (FreeMonoid.freeMonoidCongr e).symm,
+      hφ.comp (FreeMonoid.freeMonoidCongr e).symm.surjective⟩
+  · intro ⟨α, _, φ, hφ⟩
+    exact Monoid.fg_of_surjective _ hφ
 
 @[to_additive]
 theorem Submonoid.powers_fg (r : M) : (Submonoid.powers r).FG :=


### PR DESCRIPTION
In #35033 and #36589 an instance and lemma were added about finitely generated FreeGroups, duplicate these for FreeMonoids.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
