### PR TITLE
[Merged by Bors] - feat(Algebra/Module/Submodule): Add pointwise negation lemma

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -229,6 +229,10 @@ theorem inv_subset_inv : s⁻¹ ⊆ t⁻¹ ↔ s ⊆ t :=
 @[to_additive]
 theorem inv_subset : s⁻¹ ⊆ t ↔ s ⊆ t⁻¹ := by rw [← inv_subset_inv, inv_inv]
 
+@[to_additive]
+theorem inv_eq_iff_inv_subset : s⁻¹ = s ↔ s⁻¹ ⊆ s :=
+  ⟨le_of_eq, fun h => antisymm h <| inv_subset.mp h⟩
+
 @[to_additive (attr := simp)]
 theorem inv_singleton (a : α) : ({a} : Set α)⁻¹ = {a⁻¹} := by
   rw [← image_inv_eq_inv, image_singleton]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -230,7 +230,7 @@ theorem inv_subset_inv : s⁻¹ ⊆ t⁻¹ ↔ s ⊆ t :=
 theorem inv_subset : s⁻¹ ⊆ t ↔ s ⊆ t⁻¹ := by rw [← inv_subset_inv, inv_inv]
 
 @[to_additive]
-theorem inv_eq_iff_inv_subset : s⁻¹ = s ↔ s⁻¹ ⊆ s :=
+theorem inv_eq_self_iff_inv_subset : s⁻¹ = s ↔ s⁻¹ ⊆ s :=
   ⟨le_of_eq, fun h => antisymm h <| inv_subset.mp h⟩
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -102,6 +102,9 @@ theorem neg_le_neg (S T : Submodule R M) : -S ≤ -T ↔ S ≤ T :=
 theorem neg_le (S T : Submodule R M) : -S ≤ T ↔ S ≤ -T :=
   SetLike.coe_subset_coe.symm.trans Set.neg_subset
 
+theorem neg_eq_iff_neg_le {S : Submodule R M} : -S = S ↔ -S ≤ S :=
+  ⟨le_of_eq, fun h => antisymm h <| (Submodule.neg_le S S).mp h⟩
+
 /-- `Submodule.pointwiseNeg` as an order isomorphism. -/
 def negOrderIso : Submodule R M ≃o Submodule R M where
   toEquiv := Equiv.neg _

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -102,7 +102,7 @@ theorem neg_le_neg {S T : Submodule R M} : -S ≤ -T ↔ S ≤ T :=
 theorem neg_le {S T : Submodule R M} : -S ≤ T ↔ S ≤ -T :=
   SetLike.coe_subset_coe.symm.trans Set.neg_subset
 
-theorem neg_eq_iff_neg_le {S : Submodule R M} : -S = S ↔ -S ≤ S :=
+theorem neg_eq_self_iff_neg_le {S : Submodule R M} : -S = S ↔ -S ≤ S :=
   ⟨le_of_eq, fun h => antisymm h <| neg_le.mp h⟩
 
 /-- `Submodule.pointwiseNeg` as an order isomorphism. -/

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -103,7 +103,7 @@ theorem neg_le {S T : Submodule R M} : -S ≤ T ↔ S ≤ -T :=
   SetLike.coe_subset_coe.symm.trans Set.neg_subset
 
 theorem neg_eq_iff_neg_le {S : Submodule R M} : -S = S ↔ -S ≤ S :=
-  ⟨le_of_eq, fun h => antisymm h <| Submodule.neg_le.mp h⟩
+  ⟨le_of_eq, fun h => antisymm h <| neg_le.mp h⟩
 
 /-- `Submodule.pointwiseNeg` as an order isomorphism. -/
 def negOrderIso : Submodule R M ≃o Submodule R M where

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -96,14 +96,14 @@ protected def involutivePointwiseNeg : InvolutiveNeg (Submodule R M) where
 scoped[Pointwise] attribute [instance] Submodule.involutivePointwiseNeg
 
 @[simp]
-theorem neg_le_neg (S T : Submodule R M) : -S ≤ -T ↔ S ≤ T :=
+theorem neg_le_neg {S T : Submodule R M} : -S ≤ -T ↔ S ≤ T :=
   SetLike.coe_subset_coe.symm.trans Set.neg_subset_neg
 
-theorem neg_le (S T : Submodule R M) : -S ≤ T ↔ S ≤ -T :=
+theorem neg_le {S T : Submodule R M} : -S ≤ T ↔ S ≤ -T :=
   SetLike.coe_subset_coe.symm.trans Set.neg_subset
 
 theorem neg_eq_iff_neg_le {S : Submodule R M} : -S = S ↔ -S ≤ S :=
-  ⟨le_of_eq, fun h => antisymm h <| (Submodule.neg_le S S).mp h⟩
+  ⟨le_of_eq, fun h => antisymm h <| Submodule.neg_le.mp h⟩
 
 /-- `Submodule.pointwiseNeg` as an order isomorphism. -/
 def negOrderIso : Submodule R M ≃o Submodule R M where


### PR DESCRIPTION
- Add `Submodule.neg_eq_iff_neg_le` proving `-S = S ↔ -S ≤ S`
- Make arguments of `Submodule.neg_le_neg` and `Submodule.neg_le` implicit

For completeness I added the set version:

- Add `Set.inv_eq_iff_inv_subset` proving `s⁻¹ = s ↔ s⁻¹ ⊆ s` and its additive version

I did not manage to give a short proof of the submodule version from the set version like it is the case for `neg_le` and `neg_le_neg`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
