### PR TITLE
[Merged by Bors] - feat: invariant root submodules are spanned by their roots

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -64,15 +64,14 @@ instance [Nontrivial M] : Nontrivial P.invtRootSubmodule where
 
 @[simp] lemma coe_top : ((⊤ : P.invtRootSubmodule) : Submodule R M) = ⊤ := rfl
 
-lemma eq_zero_of_forall_coroot'_eq_zero {K : Type*} [Field K] [NeZero (2 : K)]
-    [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
-    {x : M} (h : ∀ i, P.coroot' i x = 0) : x = 0 := by
+lemma eq_zero_of_forall_coroot'_eq_zero {K : Type*} [Field K] [Module K M] [Module K N]
+    {P : RootPairing ι K M N} [P.IsRootSystem] {x : M} (h : ∀ i, P.coroot' i x = 0) : x = 0 := by
   have : Module.IsReflexive K M := .of_isPerfPair P.toLinearMap
   exact ((Module.Dual.eval K M).map_eq_zero_iff (Module.bijective_dual_eval K M).injective).mp
     (LinearMap.ext_on_range P.span_coroot'_eq_top h)
 
 lemma invtRootSubmodule.le_ker_coroot' {K : Type*} [Field K] [NeZero (2 : K)]
-    [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
+    [Module K M] [Module K N] {P : RootPairing ι K M N}
     (q : P.invtRootSubmodule) {k : ι} (hk : P.root k ∉ (q : Submodule K M)) :
     (q : Submodule K M) ≤ LinearMap.ker (P.coroot' k) :=
   (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two k)

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -93,7 +93,6 @@ lemma invtRootSubmodule.eq_top_iff {K : Type*} [Field K] [Module K M] [Module K 
   ⟨fun h ↦ by simp [h], fun h ↦ by simpa using Submodule.span_mono h (R := K)⟩
 
 open Module in
-/-- An invariant root submodule equals the span of the roots it contains. -/
 lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
     (q : P.invtRootSubmodule) :

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -109,8 +109,7 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
   set T := span K (P.root '' {i | P.root i ∉ Q})
   have h_sup : S ⊔ T = ⊤ := by
     rw [← Submodule.span_union, ← Set.image_union]
-    have : {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ :=
-      Set.eq_univ_of_forall fun _ => em _
+    have : {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ := by ext; simp [em]
     rw [this, Set.image_univ]
     simp
   intro v hv

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -64,11 +64,11 @@ instance [Nontrivial M] : Nontrivial P.invtRootSubmodule where
 
 @[simp] lemma coe_top : ((⊤ : P.invtRootSubmodule) : Submodule R M) = ⊤ := rfl
 
-lemma eq_zero_of_forall_coroot'_eq_zero {K : Type*} [Field K] [Module K M] [Module K N]
-    {P : RootPairing ι K M N} [P.IsRootSystem] {x : M} (h : ∀ i, P.coroot' i x = 0) : x = 0 := by
-  have : Module.IsReflexive K M := .of_isPerfPair P.toLinearMap
-  exact ((Module.Dual.eval K M).map_eq_zero_iff (Module.bijective_dual_eval K M).injective).mp
-    (LinearMap.ext_on_range P.span_coroot'_eq_top h)
+lemma eq_zero_iff_forall_coroot'_eq_zero [P.IsRootSystem] {x : M} :
+    x = 0 ↔ ∀ i, P.coroot' i x = 0 := by
+  refine ⟨fun h ↦ by simp [h], fun h ↦ ?_⟩
+  replace h : x ∈ ⨅ i, ker (P.coroot' i) := by aesop
+  simpa [← P.corootSpan_dualAnnihilator_map_eq_iInf_ker_coroot'] using h
 
 lemma invtRootSubmodule.le_ker_coroot' {K : Type*} [Field K] [NeZero (2 : K)]
     [Module K M] [Module K N] {P : RootPairing ι K M N}

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -98,43 +98,38 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
     (q : P.invtRootSubmodule) :
     (q : Submodule K M) = span K (P.root '' {i | P.root i ∈ (q : Submodule K M)}) := by
+  set Q := (q : Submodule K M)
   refine le_antisymm ?_ (span_le.mpr (Set.image_subset_iff.mpr fun _ h => h))
-  have hq_ker : ∀ ℓ, P.root ℓ ∉ (q : Submodule K _) →
-      (q : Submodule K _) ≤ ker (P.coroot' ℓ) := fun ℓ hℓ =>
-    (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two ℓ)
-      (Submodule.disjoint_span_singleton_of_notMem hℓ)).mp
-      (P.mem_invtRootSubmodule_iff.mp q.property ℓ)
-  set S := span K (P.root '' {i | P.root i ∈ (q : Submodule K _)})
-  set T := span K (P.root '' {i | P.root i ∉ (q : Submodule K _)})
-  have hS_ker : ∀ ℓ, P.root ℓ ∉ (q : Submodule K _) →
-      S ≤ ker (P.coroot' ℓ) := by
-    intro ℓ hℓ; apply span_le.mpr; rintro _ ⟨i, hi, rfl⟩
-    exact hq_ker ℓ hℓ hi
-  have hT_ker : ∀ i, P.root i ∈ (q : Submodule K _) →
-      T ≤ ker (P.coroot' i) := by
+  have hq_ker : ∀ k, P.root k ∉ Q → Q ≤ ker (P.coroot' k) := fun k hk =>
+    (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two k)
+      (Submodule.disjoint_span_singleton_of_notMem hk)).mp
+      (P.mem_invtRootSubmodule_iff.mp q.property k)
+  set S := span K (P.root '' {i | P.root i ∈ Q})
+  set T := span K (P.root '' {i | P.root i ∉ Q})
+  have hT_ker : ∀ i, P.root i ∈ Q → T ≤ ker (P.coroot' i) := by
     intro i hi; apply span_le.mpr; rintro _ ⟨j, hj, rfl⟩
     rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing]
     have h₁ := LinearMap.mem_ker.mp (hq_ker j hj hi)
     rw [P.root_coroot'_eq_pairing] at h₁
     exact P.pairing_eq_zero_iff'.mpr h₁
   have h_sup : S ⊔ T = ⊤ := by
-    rw [← Submodule.span_union, ← Set.image_union]
-    have : {i | P.root i ∈ (q : Submodule K _)} ∪
-        {i | P.root i ∉ (q : Submodule K _)} = Set.univ := by
-      ext; exact ⟨fun _ => trivial, fun _ => em _⟩
-    rw [this, Set.image_univ]; simp
+    rw [← Submodule.span_union, ← Set.image_union,
+      show {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ from
+        Set.eq_univ_of_forall fun _ => em _,
+      Set.image_univ]
+    simp
   intro v hv
   obtain ⟨s, hs, t, ht, rfl⟩ := Submodule.mem_sup.mp (h_sup ▸ Submodule.mem_top (x := v))
   suffices t = 0 by rw [this, add_zero]; exact hs
-  have h_ker : ∀ ℓ, P.coroot' ℓ t = 0 := fun ℓ ↦ by
-    by_cases hℓ : P.root ℓ ∈ (q : Submodule K _)
-    · exact LinearMap.mem_ker.mp (hT_ker ℓ hℓ ht)
-    · have h1 := LinearMap.mem_ker.mp (hq_ker ℓ hℓ hv)
-      have h2 := LinearMap.mem_ker.mp (hS_ker ℓ hℓ hs)
+  have h_ker : ∀ k, P.coroot' k t = 0 := fun k ↦ by
+    by_cases hk : P.root k ∈ Q
+    · exact LinearMap.mem_ker.mp (hT_ker k hk ht)
+    · have h1 := LinearMap.mem_ker.mp (hq_ker k hk hv)
+      have h2 := LinearMap.mem_ker.mp (hq_ker k hk (span_le.mpr
+        (Set.image_subset_iff.mpr fun _ h => h) hs))
       rw [map_add, h2, zero_add] at h1; exact h1
   have : IsReflexive K M := .of_isPerfPair P.toLinearMap
-  exact ((Module.Dual.eval K _).map_eq_zero_iff
-    (bijective_dual_eval K _).injective).mp
+  exact ((Dual.eval K _).map_eq_zero_iff (bijective_dual_eval K _).injective).mp
     (LinearMap.ext_on_range P.span_coroot'_eq_top h_ker)
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -83,10 +83,9 @@ lemma invtRootSubmodule.eq_bot_iff {K : Type*} [Field K] [NeZero (2 : K)]
     (q : P.invtRootSubmodule) :
     q = ⊥ ↔ ∀ i, P.root i ∉ (q : Submodule K M) := by
   refine ⟨fun h ↦ by simp [h, P.ne_zero], fun h ↦ ?_⟩
-  rw [Subtype.mk_eq_bot_iff (by simp), Submodule.eq_bot_iff]
-  intro x hx
-  exact eq_zero_of_forall_coroot'_eq_zero fun i =>
-    LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q (h i) hx)
+  simp_rw [Subtype.mk_eq_bot_iff (invtRootSubmodule.bot_mem P), Submodule.eq_bot_iff,
+    P.eq_zero_iff_forall_coroot'_eq_zero, ← LinearMap.mem_ker]
+  exact fun x hx i ↦ invtRootSubmodule.le_ker_coroot' q (h i) hx
 
 lemma invtRootSubmodule.eq_top_iff {K : Type*} [Field K] [Module K M] [Module K N]
     {P : RootPairing ι K M N} [P.IsRootSystem] (q : P.invtRootSubmodule) :

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -121,10 +121,9 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     by_cases hk : P.root k ∈ Q
     · refine LinearMap.mem_ker.mp (span_le.mpr ?_ ht)
       rintro _ ⟨j, hj, rfl⟩
-      rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing]
-      have := LinearMap.mem_ker.mp (hq_ker j hj hk)
-      rw [P.root_coroot'_eq_pairing] at this
-      exact P.pairing_eq_zero_iff'.mpr this
+      rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing, P.pairing_eq_zero_iff',
+        ← P.root_coroot'_eq_pairing]
+      exact LinearMap.mem_ker.mp (hq_ker j hj hk)
     · exact LinearMap.mem_ker.mp (hq_ker k hk htQ)
   have : IsReflexive K M := .of_isPerfPair P.toLinearMap
   exact ((Dual.eval K _).map_eq_zero_iff (bijective_dual_eval K _).injective).mp

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -120,7 +120,7 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
         ← P.root_coroot'_eq_pairing]
       exact LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q hj hk)
     · exact LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q hk htQ)
-  exact eq_zero_of_forall_coroot'_eq_zero h_ker
+  exact P.eq_zero_iff_forall_coroot'_eq_zero.mpr h_ker
 
 set_option backward.isDefEq.respectTransparency false in
 lemma isSimpleModule_weylGroupRootRep_iff [Nontrivial M] :

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -116,7 +116,8 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
   obtain ⟨s, hs, t, ht, rfl⟩ := Submodule.mem_sup.mp (h_sup ▸ Submodule.mem_top (x := v))
   suffices t = 0 by rw [this, add_zero]; exact hs
   have htQ : t ∈ Q := by simpa using Q.sub_mem hv (hSQ hs)
-  have h_ker : ∀ k, P.coroot' k t = 0 := fun k ↦ by
+  have h_ker : ∀ k, P.coroot' k t = 0 := by
+    intro k
     by_cases hk : P.root k ∈ Q
     · refine LinearMap.mem_ker.mp (span_le.mpr ?_ ht)
       rintro _ ⟨j, hj, rfl⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -112,10 +112,10 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     rw [P.root_coroot'_eq_pairing] at h₁
     exact P.pairing_eq_zero_iff'.mpr h₁
   have h_sup : S ⊔ T = ⊤ := by
-    rw [← Submodule.span_union, ← Set.image_union,
-      show {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ from
-        Set.eq_univ_of_forall fun _ => em _,
-      Set.image_univ]
+    rw [← Submodule.span_union, ← Set.image_union]
+    have : {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ :=
+      Set.eq_univ_of_forall fun _ => em _
+    rw [this, Set.image_univ]
     simp
   intro v hv
   obtain ⟨s, hs, t, ht, rfl⟩ := Submodule.mem_sup.mp (h_sup ▸ Submodule.mem_top (x := v))

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -92,6 +92,51 @@ lemma invtRootSubmodule.eq_top_iff {K : Type*} [Field K] [Module K M] [Module K 
     q = ⊤ ↔ range P.root ⊆ q :=
   ⟨fun h ↦ by simp [h], fun h ↦ by simpa using Submodule.span_mono h (R := K)⟩
 
+open Module in
+/-- An invariant root submodule equals the span of the roots it contains. -/
+lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
+    [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
+    (q : P.invtRootSubmodule) :
+    (q : Submodule K M) = span K (P.root '' {i | P.root i ∈ (q : Submodule K M)}) := by
+  refine le_antisymm ?_ (span_le.mpr (Set.image_subset_iff.mpr fun _ h => h))
+  have hq_ker : ∀ ℓ, P.root ℓ ∉ (q : Submodule K _) →
+      (q : Submodule K _) ≤ ker (P.coroot' ℓ) := fun ℓ hℓ =>
+    (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two ℓ)
+      (Submodule.disjoint_span_singleton_of_notMem hℓ)).mp
+      (P.mem_invtRootSubmodule_iff.mp q.property ℓ)
+  set S := span K (P.root '' {i | P.root i ∈ (q : Submodule K _)})
+  set T := span K (P.root '' {i | P.root i ∉ (q : Submodule K _)})
+  have hS_ker : ∀ ℓ, P.root ℓ ∉ (q : Submodule K _) →
+      S ≤ ker (P.coroot' ℓ) := by
+    intro ℓ hℓ; apply span_le.mpr; rintro _ ⟨i, hi, rfl⟩
+    exact hq_ker ℓ hℓ hi
+  have hT_ker : ∀ i, P.root i ∈ (q : Submodule K _) →
+      T ≤ ker (P.coroot' i) := by
+    intro i hi; apply span_le.mpr; rintro _ ⟨j, hj, rfl⟩
+    rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing]
+    have h₁ := LinearMap.mem_ker.mp (hq_ker j hj hi)
+    rw [P.root_coroot'_eq_pairing] at h₁
+    exact P.pairing_eq_zero_iff'.mpr h₁
+  have h_sup : S ⊔ T = ⊤ := by
+    rw [← Submodule.span_union, ← Set.image_union]
+    have : {i | P.root i ∈ (q : Submodule K _)} ∪
+        {i | P.root i ∉ (q : Submodule K _)} = Set.univ := by
+      ext; exact ⟨fun _ => trivial, fun _ => em _⟩
+    rw [this, Set.image_univ]; simp
+  intro v hv
+  obtain ⟨s, hs, t, ht, rfl⟩ := Submodule.mem_sup.mp (h_sup ▸ Submodule.mem_top (x := v))
+  suffices t = 0 by rw [this, add_zero]; exact hs
+  have h_ker : ∀ ℓ, P.coroot' ℓ t = 0 := fun ℓ ↦ by
+    by_cases hℓ : P.root ℓ ∈ (q : Submodule K _)
+    · exact LinearMap.mem_ker.mp (hT_ker ℓ hℓ ht)
+    · have h1 := LinearMap.mem_ker.mp (hq_ker ℓ hℓ hv)
+      have h2 := LinearMap.mem_ker.mp (hS_ker ℓ hℓ hs)
+      rw [map_add, h2, zero_add] at h1; exact h1
+  have : IsReflexive K M := .of_isPerfPair P.toLinearMap
+  exact ((Module.Dual.eval K _).map_eq_zero_iff
+    (bijective_dual_eval K _).injective).mp
+    (LinearMap.ext_on_range P.span_coroot'_eq_top h_ker)
+
 set_option backward.isDefEq.respectTransparency false in
 lemma isSimpleModule_weylGroupRootRep_iff [Nontrivial M] :
     IsSimpleModule R[P.weylGroup] P.weylGroupRootRep.asModule ↔

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -98,19 +98,15 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     (q : P.invtRootSubmodule) :
     (q : Submodule K M) = span K (P.root '' {i | P.root i ∈ (q : Submodule K M)}) := by
   set Q := (q : Submodule K M)
-  refine le_antisymm ?_ (span_le.mpr (Set.image_subset_iff.mpr fun _ h => h))
+  have hSQ : span K (P.root '' {i | P.root i ∈ Q}) ≤ Q :=
+    span_le.mpr (Set.image_subset_iff.mpr fun _ h => h)
+  refine le_antisymm ?_ hSQ
   have hq_ker : ∀ k, P.root k ∉ Q → Q ≤ ker (P.coroot' k) := fun k hk =>
     (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two k)
       (Submodule.disjoint_span_singleton_of_notMem hk)).mp
       (P.mem_invtRootSubmodule_iff.mp q.property k)
   set S := span K (P.root '' {i | P.root i ∈ Q})
   set T := span K (P.root '' {i | P.root i ∉ Q})
-  have hT_ker : ∀ i, P.root i ∈ Q → T ≤ ker (P.coroot' i) := by
-    intro i hi; apply span_le.mpr; rintro _ ⟨j, hj, rfl⟩
-    rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing]
-    have h₁ := LinearMap.mem_ker.mp (hq_ker j hj hi)
-    rw [P.root_coroot'_eq_pairing] at h₁
-    exact P.pairing_eq_zero_iff'.mpr h₁
   have h_sup : S ⊔ T = ⊤ := by
     rw [← Submodule.span_union, ← Set.image_union]
     have : {i | P.root i ∈ Q} ∪ {i | P.root i ∉ Q} = Set.univ :=
@@ -120,13 +116,16 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
   intro v hv
   obtain ⟨s, hs, t, ht, rfl⟩ := Submodule.mem_sup.mp (h_sup ▸ Submodule.mem_top (x := v))
   suffices t = 0 by rw [this, add_zero]; exact hs
+  have htQ : t ∈ Q := by simpa using Q.sub_mem hv (hSQ hs)
   have h_ker : ∀ k, P.coroot' k t = 0 := fun k ↦ by
     by_cases hk : P.root k ∈ Q
-    · exact LinearMap.mem_ker.mp (hT_ker k hk ht)
-    · have h1 := LinearMap.mem_ker.mp (hq_ker k hk hv)
-      have h2 := LinearMap.mem_ker.mp (hq_ker k hk (span_le.mpr
-        (Set.image_subset_iff.mpr fun _ h => h) hs))
-      rw [map_add, h2, zero_add] at h1; exact h1
+    · refine LinearMap.mem_ker.mp (span_le.mpr ?_ ht)
+      rintro _ ⟨j, hj, rfl⟩
+      rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing]
+      have := LinearMap.mem_ker.mp (hq_ker j hj hk)
+      rw [P.root_coroot'_eq_pairing] at this
+      exact P.pairing_eq_zero_iff'.mpr this
+    · exact LinearMap.mem_ker.mp (hq_ker k hk htQ)
   have : IsReflexive K M := .of_isPerfPair P.toLinearMap
   exact ((Dual.eval K _).map_eq_zero_iff (bijective_dual_eval K _).injective).mp
     (LinearMap.ext_on_range P.span_coroot'_eq_top h_ker)

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -64,35 +64,36 @@ instance [Nontrivial M] : Nontrivial P.invtRootSubmodule where
 
 @[simp] lemma coe_top : ((⊤ : P.invtRootSubmodule) : Submodule R M) = ⊤ := rfl
 
-open Module in
+lemma eq_zero_of_forall_coroot'_eq_zero {K : Type*} [Field K] [NeZero (2 : K)]
+    [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
+    {x : M} (h : ∀ i, P.coroot' i x = 0) : x = 0 := by
+  have : Module.IsReflexive K M := .of_isPerfPair P.toLinearMap
+  exact ((Module.Dual.eval K M).map_eq_zero_iff (Module.bijective_dual_eval K M).injective).mp
+    (LinearMap.ext_on_range P.span_coroot'_eq_top h)
+
+lemma invtRootSubmodule.le_ker_coroot' {K : Type*} [Field K] [NeZero (2 : K)]
+    [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
+    (q : P.invtRootSubmodule) {k : ι} (hk : P.root k ∉ (q : Submodule K M)) :
+    (q : Submodule K M) ≤ LinearMap.ker (P.coroot' k) :=
+  (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two k)
+    (Submodule.disjoint_span_singleton_of_notMem hk)).mp
+    (P.mem_invtRootSubmodule_iff.mp q.property k)
+
 lemma invtRootSubmodule.eq_bot_iff {K : Type*} [Field K] [NeZero (2 : K)]
     [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
     (q : P.invtRootSubmodule) :
     q = ⊥ ↔ ∀ i, P.root i ∉ (q : Submodule K M) := by
-  have : IsReflexive K M := .of_isPerfPair P.toLinearMap
   refine ⟨fun h ↦ by simp [h, P.ne_zero], fun h ↦ ?_⟩
   rw [Subtype.mk_eq_bot_iff (by simp), Submodule.eq_bot_iff]
   intro x hx
-  by_contra hx₀
-  obtain ⟨i, hi⟩ : ∃ i, P.coroot' i x ≠ 0 := by
-    contrapose! hx₀
-    suffices Dual.eval K M x = 0 from
-      ((Dual.eval K M).map_eq_zero_iff (bijective_dual_eval K M).injective).mp this
-    exact LinearMap.ext_on_range P.span_coroot'_eq_top hx₀
-  replace h : P.reflection i x ∉ (q : Submodule K M) := by
-    specialize h i
-    contrapose! h
-    rw [reflection_apply, LinearMap.flip_apply, Submodule.sub_mem_iff_right _ hx] at h
-    exact (Submodule.smul_mem_iff _ hi).mp h
-  have h' : P.reflection i x ∈ (q : Submodule K M) := P.mem_invtRootSubmodule_iff.mp q.property i hx
-  contradiction
+  exact eq_zero_of_forall_coroot'_eq_zero fun i =>
+    LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q (h i) hx)
 
 lemma invtRootSubmodule.eq_top_iff {K : Type*} [Field K] [Module K M] [Module K N]
     {P : RootPairing ι K M N} [P.IsRootSystem] (q : P.invtRootSubmodule) :
     q = ⊤ ↔ range P.root ⊆ q :=
   ⟨fun h ↦ by simp [h], fun h ↦ by simpa using Submodule.span_mono h (R := K)⟩
 
-open Module in
 lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
     [Module K M] [Module K N] {P : RootPairing ι K M N} [P.IsRootSystem]
     (q : P.invtRootSubmodule) :
@@ -101,10 +102,6 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
   have hSQ : span K (P.root '' {i | P.root i ∈ Q}) ≤ Q :=
     span_le.mpr (Set.image_subset_iff.mpr fun _ h => h)
   refine le_antisymm ?_ hSQ
-  have hq_ker : ∀ k, P.root k ∉ Q → Q ≤ ker (P.coroot' k) := fun k hk =>
-    (Submodule.mem_invtSubmodule_reflection_iff (P.flip.root_coroot_two k)
-      (Submodule.disjoint_span_singleton_of_notMem hk)).mp
-      (P.mem_invtRootSubmodule_iff.mp q.property k)
   set S := span K (P.root '' {i | P.root i ∈ Q})
   set T := span K (P.root '' {i | P.root i ∉ Q})
   have h_sup : S ⊔ T = ⊤ := by
@@ -123,11 +120,9 @@ lemma invtRootSubmodule.eq_span_root {K : Type*} [Field K] [NeZero (2 : K)]
       rintro _ ⟨j, hj, rfl⟩
       rw [SetLike.mem_coe, LinearMap.mem_ker, P.root_coroot'_eq_pairing, P.pairing_eq_zero_iff',
         ← P.root_coroot'_eq_pairing]
-      exact LinearMap.mem_ker.mp (hq_ker j hj hk)
-    · exact LinearMap.mem_ker.mp (hq_ker k hk htQ)
-  have : IsReflexive K M := .of_isPerfPair P.toLinearMap
-  exact ((Dual.eval K _).map_eq_zero_iff (bijective_dual_eval K _).injective).mp
-    (LinearMap.ext_on_range P.span_coroot'_eq_top h_ker)
+      exact LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q hj hk)
+    · exact LinearMap.mem_ker.mp (invtRootSubmodule.le_ker_coroot' q hk htQ)
+  exact eq_zero_of_forall_coroot'_eq_zero h_ker
 
 set_option backward.isDefEq.respectTransparency false in
 lemma isSimpleModule_weylGroupRootRep_iff [Nontrivial M] :


### PR DESCRIPTION
Invariant root submodules are spanned by their roots
---
PR adds three lemmas about invariant root submodules of root systems:

- `RootPairing.eq_zero_of_forall_coroot'_eq_zero`: coroot functionals separate points.
- `RootPairing.invtRootSubmodule.le_ker_coroot'`: an invariant submodule lies in the kernel of the coroot functional for any root it does not contain.
- `RootPairing.invtRootSubmodule.eq_span_root`: an invariant root submodule equals the span of the roots it contains.

The first two lemmas are factored out from `invtRootSubmodule.eq_bot_iff`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
