### PR TITLE
[Merged by Bors] - feat: compatible (pairs of) derivations form a Lie algebra

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -710,6 +710,7 @@ public import Mathlib.Algebra.Lie.Nilpotent
 public import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
 public import Mathlib.Algebra.Lie.Normalizer
 public import Mathlib.Algebra.Lie.OfAssociative
+public import Mathlib.Algebra.Lie.Prod
 public import Mathlib.Algebra.Lie.Quotient
 public import Mathlib.Algebra.Lie.Rank
 public import Mathlib.Algebra.Lie.SemiDirect

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -99,75 +99,6 @@ section Algebras
 
 /-! The direct sum of Lie algebras carries a natural Lie algebra structure. -/
 
-namespace Binary
-
-variable (R L₁ L₂ : Type*)
-  [CommRing R] [LieRing L₁] [LieAlgebra R L₁] [LieRing L₂] [LieAlgebra R L₂]
-
-instance : LieRing (L₁ × L₂) where
-  bracket x y := ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩
-  add_lie := by simp
-  lie_add := by simp
-  lie_self := by simp
-  leibniz_lie := by simp
-
-@[simp]
-theorem bracket_apply (x y : L₁ × L₂) : ⁅x, y⁆ = ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩ := rfl
-
-instance : LieAlgebra R (L₁ × L₂) where
-  __ := inferInstanceAs (Module R (L₁ × L₂))
-  lie_smul _ _ _ := by simp
-
-/-- The first projection of a product is a Lie algebra map. -/
-def fst : L₁ × L₂ →ₗ⁅R⁆ L₁ where
-  toLinearMap := LinearMap.fst R L₁ L₂
-  map_lie' := by simp
-
-/-- The second projection of a product is a Lie algebra map. -/
-def snd : L₁ × L₂ →ₗ⁅R⁆ L₂ where
-  toLinearMap := LinearMap.snd R L₁ L₂
-  map_lie' := by simp
-
-@[simp] theorem fst_apply (x : L₁ × L₂) : fst R L₁ L₂ x = x.1 := rfl
-
-@[simp] theorem snd_apply (x : L₁ × L₂) : snd R L₁ L₂ x = x.2 := rfl
-
-@[simp, norm_cast] lemma coe_fst : ⇑(fst R L₁ L₂) = Prod.fst := rfl
-
-@[simp, norm_cast] lemma coe_snd : ⇑(snd R L₁ L₂) = Prod.snd := rfl
-
-theorem fst_surjective : Function.Surjective (fst R L₁ L₂) := fun x => ⟨(x, 0), rfl⟩
-
-theorem snd_surjective : Function.Surjective (snd R L₁ L₂) := fun x => ⟨(0, x), rfl⟩
-
-
-/-- The left injection into a product is a Lie algebra map. -/
-def inl : L₁ →ₗ⁅R⁆ L₁ × L₂ where
-  toLinearMap := LinearMap.inl R L₁ L₂
-  map_lie' := by simp
-
-/-- The right injection into a product is a Lie algebra map. -/
-def inr : L₂ →ₗ⁅R⁆ L₁ × L₂ where
-  toLinearMap := LinearMap.inr R L₁ L₂
-  map_lie' := by simp
-
-
-theorem inl_apply (x : L₁) : inl R L₁ L₂ x = (x, 0) := rfl
-
-theorem inr_apply (x : L₂) : inr R L₁ L₂ x = (0, x) := rfl
-
-@[simp] theorem coe_inl : (inl R L₁ L₂ : L₁ → L₁ × L₂) = fun x => (x, 0) := rfl
-
-@[simp] theorem coe_inr : (inr R L₁ L₂ : L₂ → L₁ × L₂) = Prod.mk 0 := rfl
-
-theorem inl_injective : Function.Injective (inl R L₁ L₂) := fun _ => by simp
-
-theorem inr_injective : Function.Injective (inr R L₁ L₂) := fun _ => by simp
-
-end Binary
-
-section Families
-
 variable (L : ι → Type w)
 variable [∀ i, LieRing (L i)] [∀ i, LieAlgebra R (L i)]
 
@@ -281,7 +212,6 @@ def toLieAlgebra [DecidableEq ι] (L' : Type w₁) [LieRing L'] [LieAlgebra R L'
       · simp_rw [lie_of_of_ne _ hij.symm, map_zero, LinearMap.toAddMonoidHom_coe,
           LieHom.coe_toLinearMap, hf hij.symm x y] }
 
-end Families
 end Algebras
 
 section Ideals

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -99,6 +99,74 @@ section Algebras
 
 /-! The direct sum of Lie algebras carries a natural Lie algebra structure. -/
 
+namespace Binary
+
+variable (R L₁ L₂ : Type*)
+  [CommRing R] [LieRing L₁] [LieAlgebra R L₁] [LieRing L₂] [LieAlgebra R L₂]
+
+instance : LieRing (L₁ × L₂) where
+  bracket x y := ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩
+  add_lie := by simp
+  lie_add := by simp
+  lie_self := by simp
+  leibniz_lie := by simp
+
+@[simp]
+theorem bracket_apply (x y : L₁ × L₂) : ⁅x, y⁆ = ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩ := rfl
+
+instance : LieAlgebra R (L₁ × L₂) where
+  __ := inferInstanceAs (Module R (L₁ × L₂))
+  lie_smul _ _ _ := by simp
+
+/-- The first projection of a product is a Lie algebra map. -/
+def fst : L₁ × L₂ →ₗ⁅R⁆ L₁ where
+  toLinearMap := LinearMap.fst R L₁ L₂
+  map_lie' := by simp
+
+/-- The second projection of a product is a Lie algebra map. -/
+def snd : L₁ × L₂ →ₗ⁅R⁆ L₂ where
+  toLinearMap := LinearMap.snd R L₁ L₂
+  map_lie' := by simp
+
+@[simp] theorem fst_apply (x : L₁ × L₂) : fst R L₁ L₂ x = x.1 := rfl
+
+@[simp] theorem snd_apply (x : L₁ × L₂) : snd R L₁ L₂ x = x.2 := rfl
+
+@[simp, norm_cast] lemma coe_fst : ⇑(fst R L₁ L₂) = Prod.fst := rfl
+
+@[simp, norm_cast] lemma coe_snd : ⇑(snd R L₁ L₂) = Prod.snd := rfl
+
+theorem fst_surjective : Function.Surjective (fst R L₁ L₂) := fun x => ⟨(x, 0), rfl⟩
+
+theorem snd_surjective : Function.Surjective (snd R L₁ L₂) := fun x => ⟨(0, x), rfl⟩
+
+
+/-- The left injection into a product is a Lie algebra map. -/
+def inl : L₁ →ₗ⁅R⁆ L₁ × L₂ where
+  toLinearMap := LinearMap.inl R L₁ L₂
+  map_lie' := by simp
+
+/-- The right injection into a product is a Lie algebra map. -/
+def inr : L₂ →ₗ⁅R⁆ L₁ × L₂ where
+  toLinearMap := LinearMap.inr R L₁ L₂
+  map_lie' := by simp
+
+
+theorem inl_apply (x : L₁) : inl R L₁ L₂ x = (x, 0) := rfl
+
+theorem inr_apply (x : L₂) : inr R L₁ L₂ x = (0, x) := rfl
+
+@[simp] theorem coe_inl : (inl R L₁ L₂ : L₁ → L₁ × L₂) = fun x => (x, 0) := rfl
+
+@[simp] theorem coe_inr : (inr R L₁ L₂ : L₂ → L₁ × L₂) = Prod.mk 0 := rfl
+
+theorem inl_injective : Function.Injective (inl R L₁ L₂) := fun _ => by simp
+
+theorem inr_injective : Function.Injective (inr R L₁ L₂) := fun _ => by simp
+
+end Binary
+
+section Families
 
 variable (L : ι → Type w)
 variable [∀ i, LieRing (L i)] [∀ i, LieAlgebra R (L i)]
@@ -213,6 +281,7 @@ def toLieAlgebra [DecidableEq ι] (L' : Type w₁) [LieRing L'] [LieAlgebra R L'
       · simp_rw [lie_of_of_ne _ hij.symm, map_zero, LinearMap.toAddMonoidHom_coe,
           LieHom.coe_toLinearMap, hf hij.symm x y] }
 
+end Families
 end Algebras
 
 section Ideals

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -99,6 +99,7 @@ section Algebras
 
 /-! The direct sum of Lie algebras carries a natural Lie algebra structure. -/
 
+
 variable (L : ι → Type w)
 variable [∀ i, LieRing (L i)] [∀ i, LieAlgebra R (L i)]
 

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -151,7 +151,6 @@ def inr : L₂ →ₗ⁅R⁆ L₁ × L₂ where
   toLinearMap := LinearMap.inr R L₁ L₂
   map_lie' := by simp
 
-
 theorem inl_apply (x : L₁) : inl R L₁ L₂ x = (x, 0) := rfl
 
 theorem inr_apply (x : L₂) : inr R L₁ L₂ x = (0, x) := rfl

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -24,7 +24,7 @@ This file defines the Lie algebra structure the Product of two Lie algebras
   - `LieHom.prodMap`
 
 ## Todo: Extend to further functionality from LinearMap.prod e.g.
- - Lie Equivalences related tp product
+ - Lie Equivalences related to products
  - Lie Submodule statements
 
 -/

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -37,7 +37,7 @@ variable {R L₁ L₂ L L₃ L₄ L₅ L₆ : Type*}
   [LieRing L] [LieAlgebra R L] [LieRing L₃] [LieAlgebra R L₃] [LieRing L₄] [LieAlgebra R L₄]
   [LieRing L₅] [LieAlgebra R L₅] [LieRing L₆] [LieAlgebra R L₆]
 
-namespace Prod
+namespace LieAlgebra.Prod
 
 instance instLieRing : LieRing (L₁ × L₂) where
   bracket x y := ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩
@@ -52,7 +52,7 @@ theorem bracket_apply (x y : L₁ × L₂) : ⁅x, y⁆ = ⟨⁅x.1, y.1⁆, ⁅
 instance instLieAlgebra : LieAlgebra R (L₁ × L₂) where
   lie_smul _ _ _ := by simp
 
-end Prod
+end LieAlgebra.Prod
 
 namespace LieHom
 

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -13,15 +13,16 @@ This file defines the Lie algebra structure the Product of two Lie algebras
 ## Main definitions
 
 - products in the domain:
-  - `LieHom.fst`
-  - `LieHom.snd`
-  - `LieHom.prod_ext`
+  - `LieHom.fst` The first projection of a product is a Lie algebra map.
+  - `LieHom.snd` The second projection of a product is a Lie algebra map.
+  - `LieHom.prod_ext` Split equality of Lie algebra homomorphisms from a product into Lie algebra
+  homomorphism over each component,
 - products in the codomain:
-  - `LieHom.inl`
-  - `LieHom.inr`
-  - `LieHom.prod`
+  - `LieHom.inl` The left injection into a product is a Lie algebra map.
+  - `LieHom.inr` The right injection into a product is a Lie algebra map.
+  - `LieHom.prod` The prod of two Lie algebra homomorphisms is a Lie algebra homomorphism.
 - products in both domain and codomain:
-  - `LieHom.prodMap`
+  - `LieHom.prodMap` the `Prod.map` of two Lie algebra homomorphisms is a Lie algebra homomorphism.
 
 ## Todo: Extend to further functionality from LinearMap.prod e.g.
  - Lie Equivalences related to products
@@ -49,7 +50,6 @@ instance instLieRing : LieRing (L₁ × L₂) where
 theorem bracket_apply (x y : L₁ × L₂) : ⁅x, y⁆ = ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩ := rfl
 
 instance instLieAlgebra : LieAlgebra R (L₁ × L₂) where
-  __ := inferInstanceAs (Module R (L₁ × L₂))
   lie_smul _ _ _ := by simp
 
 end Prod

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -54,7 +54,6 @@ instance instLieAlgebra : LieAlgebra R (L₁ × L₂) where
 
 end Prod
 
-
 namespace LieHom
 
 section
@@ -128,7 +127,6 @@ theorem inl_injective : Function.Injective (inl R L₁ L₂) := fun _ => by simp
 
 theorem inr_injective : Function.Injective (inr R L₁ L₂) := fun _ => by simp
 
-
 section
 variable (R L₁ L₂)
 
@@ -199,7 +197,6 @@ theorem prodMap_id : (id : L →ₗ⁅R⁆ L).prodMap (id : L₁ →ₗ⁅R⁆ L
 @[simp]
 theorem prodMap_one : (1 : L →ₗ⁅R⁆ L).prodMap (1 : L₁ →ₗ⁅R⁆ L₁) = 1 :=
   rfl
-
 
 theorem prodMap_comp (f₁₂ : L₁ →ₗ⁅R⁆ L₂) (f₂₃ : L₂ →ₗ⁅R⁆ L₃) (g₁₂ : L₄ →ₗ⁅R⁆ L₅)
     (g₂₃ : L₅ →ₗ⁅R⁆ L₆) :

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 Leonid Ryvkin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonid Ryvkin
+-/
+module
+public import Mathlib.Algebra.Lie.Ideal
+
+/-! ### Products of Lie algebras
+
+This file defines the Lie algebra structure the Product of two Lie algebras
+
+## Main definitions
+
+- products in the domain:
+  - `LieHom.fst`
+  - `LieHom.snd`
+  - `LieHom.prod_ext`
+- products in the codomain:
+  - `LieHom.inl`
+  - `LieHom.inr`
+  - `LieHom.prod`
+- products in both domain and codomain:
+  - `LieHom.prodMap`
+
+## Todo: Extend to further functionality from LinearMap.prod e.g.
+ - Lie Equivalences related tp product
+ - Lie Submodule statements
+
+-/
+
+@[expose] public section
+
+variable {R L₁ L₂ L L₃ L₄ L₅ L₆ : Type*}
+  [CommRing R] [LieRing L₁] [LieAlgebra R L₁] [LieRing L₂] [LieAlgebra R L₂]
+  [LieRing L] [LieAlgebra R L] [LieRing L₃] [LieAlgebra R L₃] [LieRing L₄] [LieAlgebra R L₄]
+  [LieRing L₅] [LieAlgebra R L₅] [LieRing L₆] [LieAlgebra R L₆]
+
+namespace Prod
+
+instance instLieRing : LieRing (L₁ × L₂) where
+  bracket x y := ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩
+  add_lie := by simp
+  lie_add := by simp
+  lie_self := by simp
+  leibniz_lie := by simp
+
+@[simp]
+theorem bracket_apply (x y : L₁ × L₂) : ⁅x, y⁆ = ⟨⁅x.1, y.1⁆, ⁅x.2, y.2⁆⟩ := rfl
+
+instance instLieAlgebra : LieAlgebra R (L₁ × L₂) where
+  __ := inferInstanceAs (Module R (L₁ × L₂))
+  lie_smul _ _ _ := by simp
+
+end Prod
+
+
+namespace LieHom
+
+section
+variable (R L₁ L₂)
+
+/-- The first projection of a product is a Lie algebra map. -/
+def fst : L₁ × L₂ →ₗ⁅R⁆ L₁ where
+  toLinearMap := LinearMap.fst R L₁ L₂
+  map_lie' := by simp
+
+/-- The second projection of a product is a Lie algebra map. -/
+def snd : L₁ × L₂ →ₗ⁅R⁆ L₂ where
+  toLinearMap := LinearMap.snd R L₁ L₂
+  map_lie' := by simp
+
+/-- The left injection into a product is a Lie algebra map. -/
+def inl : L₁ →ₗ⁅R⁆ L₁ × L₂ where
+  toLinearMap := LinearMap.inl R L₁ L₂
+  map_lie' := by simp
+
+/-- The right injection into a product is a Lie algebra map. -/
+def inr : L₂ →ₗ⁅R⁆ L₁ × L₂ where
+  toLinearMap := LinearMap.inr R L₁ L₂
+  map_lie' := by simp
+
+end
+
+@[simp] theorem fst_apply (x : L₁ × L₂) : fst R L₁ L₂ x = x.1 := rfl
+
+@[simp] theorem snd_apply (x : L₁ × L₂) : snd R L₁ L₂ x = x.2 := rfl
+
+@[simp, norm_cast] lemma coe_fst : ⇑(fst R L₁ L₂) = Prod.fst := rfl
+
+@[simp, norm_cast] lemma coe_snd : ⇑(snd R L₁ L₂) = Prod.snd := rfl
+
+theorem fst_surjective : Function.Surjective (fst R L₁ L₂) := fun x => ⟨(x, 0), rfl⟩
+
+theorem snd_surjective : Function.Surjective (snd R L₁ L₂) := fun x => ⟨(0, x), rfl⟩
+
+/-- The prod of two Lie algebra homomorphisms is a Lie algebra homomorphism. -/
+@[simps!]
+def prod (f : L →ₗ⁅R⁆ L₁) (g : L →ₗ⁅R⁆ L₂) : L →ₗ⁅R⁆ L₁ × L₂ where
+  toLinearMap := LinearMap.prod f g
+  map_lie' := by simp
+
+theorem coe_prod (f : L →ₗ⁅R⁆ L₁) (g : L →ₗ⁅R⁆ L₂) : ⇑(f.prod g) = Pi.prod f g :=
+  rfl
+
+@[simp]
+theorem fst_prod (f : L →ₗ⁅R⁆ L₁) (g : L →ₗ⁅R⁆ L₂) : (fst R L₁ L₂).comp (prod f g) = f := rfl
+
+@[simp]
+theorem snd_prod (f : L →ₗ⁅R⁆ L₁) (g : L →ₗ⁅R⁆ L₂) : (snd R L₁ L₂).comp (prod f g) = g := rfl
+
+@[simp]
+theorem pair_fst_snd : prod (fst R L₁ L₂) (snd R L₁ L₂) = LieHom.id := rfl
+
+theorem prod_comp (f : L₁ →ₗ⁅R⁆ L₂) (g : L₁ →ₗ⁅R⁆ L)
+    (h : L →ₗ⁅R⁆ L₁) : (f.prod g).comp h = (f.comp h).prod (g.comp h) :=
+  rfl
+
+theorem inl_apply (x : L₁) : inl R L₁ L₂ x = (x, 0) := rfl
+
+theorem inr_apply (x : L₂) : inr R L₁ L₂ x = (0, x) := rfl
+
+@[simp] theorem coe_inl : (inl R L₁ L₂ : L₁ → L₁ × L₂) = fun x => (x, 0) := rfl
+
+@[simp] theorem coe_inr : (inr R L₁ L₂ : L₂ → L₁ × L₂) = Prod.mk 0 := rfl
+
+theorem inl_injective : Function.Injective (inl R L₁ L₂) := fun _ => by simp
+
+theorem inr_injective : Function.Injective (inr R L₁ L₂) := fun _ => by simp
+
+
+section
+variable (R L₁ L₂)
+
+-- TODO: This probably is easier using existing linearMap statement
+theorem range_inl : range (inl R L₁ L₂) = ker (snd R L₁ L₂) := by
+  ext x
+  simp only [mem_range]
+  constructor
+  · rintro ⟨y, rfl⟩
+    rfl
+  · intro h
+    exact ⟨x.fst, Prod.ext rfl h.symm⟩
+
+theorem ker_snd : ker (snd R L₁ L₂) = range (inl R L₁ L₂) :=
+  Eq.symm <| range_inl R L₁ L₂
+
+-- TODO: This probably is easier using existing linearMap statement
+theorem range_inr : range (inr R L₁ L₂) = ker (fst R L₁ L₂) := by
+  ext x
+  simp only [mem_range]
+  constructor
+  · rintro ⟨y, rfl⟩
+    rfl
+  · intro h
+    exact ⟨x.snd, Prod.ext h.symm rfl⟩
+
+theorem ker_fst : ker (fst R L₁ L₂) = range (inr R L₁ L₂) :=
+  Eq.symm <| range_inr R L₁ L₂
+
+@[simp] theorem fst_comp_inl : (fst R L₁ L₂).comp (inl R L₁ L₂) = id := rfl
+
+@[simp] theorem snd_comp_inl : (snd R L₁ L₂).comp (inl R L₁ L₂) = 0 := rfl
+
+@[simp] theorem fst_comp_inr : (fst R L₁ L₂).comp (inr R L₁ L₂) = 0 := rfl
+
+@[simp] theorem snd_comp_inr : (snd R L₁ L₂).comp (inr R L₁ L₂) = id := rfl
+
+theorem inl_eq_prod : inl R L₁ L₂ = prod LieHom.id 0 :=
+  rfl
+
+theorem inr_eq_prod : inr R L₁ L₂ = prod 0 LieHom.id :=
+  rfl
+
+--TODO: this needs to be improved
+theorem prod_ext_iff {f g : L₁ × L₂ →ₗ⁅R⁆ L} :
+    f = g ↔ f.comp (inl _ _ _) = g.comp (inl _ _ _) ∧ f.comp (inr _ _ _) = g.comp (inr _ _ _) := by
+  constructor
+  · exact fun a ↦
+    ⟨congrFun (congrArg comp a) (inl R L₁ L₂), congrFun (congrArg comp a) (inr R L₁ L₂)⟩
+  · intro h
+    obtain ⟨h1,h2⟩ := h
+    refine LieHom.ext_iff.mpr ?_
+    intro x
+    have h1 := congrArg (fun φ => φ x.1) h1
+    have h2 := congrArg (fun φ => φ x.2) h2
+    simp only [coe_comp, coe_inl, Function.comp_apply, coe_inr] at h1 h2
+    have h : x = (x.1,0)+(0,x.2) := by simp
+    rw [h, _root_.map_add,  _root_.map_add, h1, h2]
+
+/--
+Split equality of Lie algebra homomorphisms from a product into Lie algebra homomorphism over
+each component, to allow `ext` to apply lemmas specific to `L₁ →ₗ L` and `L₂ →ₗ L`.
+
+See note [partially-applied ext lemmas]. -/
+@[ext 1100]
+theorem prod_ext {f g : L₁ × L₂ →ₗ⁅R⁆ L} (hl : f.comp (inl _ _ _) = g.comp (inl _ _ _))
+    (hr : f.comp (inr _ _ _) = g.comp (inr _ _ _)) : f = g := by
+  refine (prod_ext_iff R L₁ L₂).mpr ⟨hl,hr⟩
+
+end
+
+/-- `Prod.map` of two Lie algebra homomorphisms. -/
+def prodMap (f : L₁ →ₗ⁅R⁆ L₃) (g : L₂ →ₗ⁅R⁆ L₄) : L₁ × L₂ →ₗ⁅R⁆ L₃ × L₄ :=
+  (f.comp (fst R L₁ L₂)).prod (g.comp (snd R L₁ L₂))
+
+theorem coe_prodMap (f : L₁ →ₗ⁅R⁆ L₃) (g : L₂ →ₗ⁅R⁆ L₄) : ⇑(prodMap f g) = Prod.map f g :=
+  rfl
+
+@[simp]
+theorem prodMap_apply (f : L₁ →ₗ⁅R⁆ L₃) (g : L₂ →ₗ⁅R⁆ L₄) (x) : f.prodMap g x = (f x.1, g x.2) :=
+  rfl
+
+@[simp]
+theorem prodMap_id : (id : L →ₗ⁅R⁆ L).prodMap (id : L₁ →ₗ⁅R⁆ L₁) = id :=
+  rfl
+
+@[simp]
+theorem prodMap_one : (1 : L →ₗ⁅R⁆ L).prodMap (1 : L₁ →ₗ⁅R⁆ L₁) = 1 :=
+  rfl
+
+
+theorem prodMap_comp (f₁₂ : L₁ →ₗ⁅R⁆ L₂) (f₂₃ : L₂ →ₗ⁅R⁆ L₃) (g₁₂ : L₄ →ₗ⁅R⁆ L₅)
+    (g₂₃ : L₅ →ₗ⁅R⁆ L₆) :
+    (f₂₃.prodMap g₂₃).comp (f₁₂.prodMap g₁₂) = (f₂₃.comp f₁₂).prodMap (g₂₃.comp g₁₂) :=
+  rfl
+
+@[simp]
+theorem prodMap_zero : (0 : L₁ →ₗ⁅R⁆ L₃).prodMap (0 : L₂ →ₗ⁅R⁆ L₄) = 0 :=
+  rfl
+
+end LieHom
+
+end

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -132,28 +132,18 @@ theorem inr_injective : Function.Injective (inr R L₁ L₂) := fun _ => by simp
 section
 variable (R L₁ L₂)
 
--- TODO: This probably is easier using existing linearMap statement
 theorem range_inl : range (inl R L₁ L₂) = ker (snd R L₁ L₂) := by
-  ext x
-  simp only [mem_range]
-  constructor
-  · rintro ⟨y, rfl⟩
-    rfl
-  · intro h
-    exact ⟨x.fst, Prod.ext rfl h.symm⟩
+  rw [← LieSubalgebra.toSubmodule_inj, range_toSubmodule, LieIdeal.toLieSubalgebra_toSubmodule,
+   ker_toSubmodule]
+  exact LinearMap.range_inl R L₁ L₂
 
 theorem ker_snd : ker (snd R L₁ L₂) = range (inl R L₁ L₂) :=
   Eq.symm <| range_inl R L₁ L₂
 
--- TODO: This probably is easier using existing linearMap statement
 theorem range_inr : range (inr R L₁ L₂) = ker (fst R L₁ L₂) := by
-  ext x
-  simp only [mem_range]
-  constructor
-  · rintro ⟨y, rfl⟩
-    rfl
-  · intro h
-    exact ⟨x.snd, Prod.ext h.symm rfl⟩
+  rw [← LieSubalgebra.toSubmodule_inj, range_toSubmodule, LieIdeal.toLieSubalgebra_toSubmodule,
+   ker_toSubmodule]
+  exact LinearMap.range_inr R L₁ L₂
 
 theorem ker_fst : ker (fst R L₁ L₂) = range (inr R L₁ L₂) :=
   Eq.symm <| range_inr R L₁ L₂
@@ -172,21 +162,12 @@ theorem inl_eq_prod : inl R L₁ L₂ = prod LieHom.id 0 :=
 theorem inr_eq_prod : inr R L₁ L₂ = prod 0 LieHom.id :=
   rfl
 
---TODO: this needs to be improved
 theorem prod_ext_iff {f g : L₁ × L₂ →ₗ⁅R⁆ L} :
     f = g ↔ f.comp (inl _ _ _) = g.comp (inl _ _ _) ∧ f.comp (inr _ _ _) = g.comp (inr _ _ _) := by
-  constructor
-  · exact fun a ↦
-    ⟨congrFun (congrArg comp a) (inl R L₁ L₂), congrFun (congrArg comp a) (inr R L₁ L₂)⟩
-  · intro h
-    obtain ⟨h1,h2⟩ := h
-    refine LieHom.ext_iff.mpr ?_
-    intro x
-    have h1 := congrArg (fun φ => φ x.1) h1
-    have h2 := congrArg (fun φ => φ x.2) h2
-    simp only [coe_comp, coe_inl, Function.comp_apply, coe_inr] at h1 h2
-    have h : x = (x.1,0)+(0,x.2) := by simp
-    rw [h, _root_.map_add,  _root_.map_add, h1, h2]
+  simp_rw [LieHom.ext_iff]
+  have h := LinearMap.prod_ext_iff (f:=f.toLinearMap) (g:= g.toLinearMap)
+  simp_rw [LinearMap.ext_iff] at h
+  exact h
 
 /--
 Split equality of Lie algebra homomorphisms from a product into Lie algebra homomorphism over

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -145,10 +145,14 @@ instance : LieAlgebra.IsExtension (inl ψ) (projr ψ) where
 section DirectSum
 
 variable (R K L) in
+/-- The direct sum of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
 abbrev DirectLieSum := K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L
 
+@[inherit_doc]
 notation:35 K " ⊕⁅" R "⁆" L:35 => DirectLieSum R K L
 
+/-- When a semidirect sum is a direct sum, the projection to the left component is a Lie algebra
+homomorphism -/
 def projl' : (K ⊕⁅R⁆ L →ₗ⁅R⁆ K) where
   __ := projl 0
   map_lie' := by simp

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.Derivation.Basic
 public import Mathlib.Algebra.Lie.Extension
-public import Mathlib.Algebra.Lie.DirectSum
+public import Mathlib.Algebra.Lie.Prod
 
 /-!
 # Semi-direct products

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.Derivation.Basic
 public import Mathlib.Algebra.Lie.Extension
+public import Mathlib.Algebra.Lie.DirectSum
 
 /-!
 # Semi-direct products
@@ -50,6 +51,8 @@ namespace SemiDirectSum
 variable {R : Type*} [CommRing R]
 variable {K : Type*} [LieRing K] [LieAlgebra R K]
 variable {L : Type*} [LieRing L] [LieAlgebra R L]
+
+section
 variable (ψ : L →ₗ⁅R⁆ LieDerivation R K K)
 
 variable {ψ} in
@@ -60,6 +63,8 @@ def toProd : K ⋊⁅ψ⁆ L ≃ K × L where
   left_inv _ := rfl
   right_inv _ := rfl
 
+@[simp] lemma toProd_apply (x : K ⋊⁅ψ⁆ L) : toProd (x) = ⟨x.left, x.right⟩ := rfl
+
 instance : AddCommGroup (K ⋊⁅ψ⁆ L) := toProd.addCommGroup
 
 instance : Module R (K ⋊⁅ψ⁆ L) := toProd.module R
@@ -69,6 +74,8 @@ def toProdl : (K ⋊⁅ψ⁆ L) ≃ₗ[R] K × L :=
   { __ := toProd
     map_add' _ _ := rfl
     map_smul' _ _ := rfl }
+
+@[simp] lemma toProdl_coe (x : K ⋊⁅ψ⁆ L) : toProdl ψ x = toProd x := rfl
 
 instance : Bracket (K ⋊⁅ψ⁆ L) (K ⋊⁅ψ⁆ L) where
   bracket x y := ⟨⁅x.left, y.left⁆ + ψ x.right y.left - ψ y.right x.left, ⁅x.right, y.right⁆⟩
@@ -142,22 +149,13 @@ instance : LieAlgebra.IsExtension (inl ψ) (projr ψ) where
   range_eq_top := by simp [LieHom.range_eq_top]
   exact := by ext ⟨x, y⟩; aesop
 
-section DirectSum
+end
 
 variable (R K L) in
-/-- The direct sum of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
-abbrev DirectLieSum := K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L
-
-@[inherit_doc]
-notation:35 K " ⊕⁅" R "⁆" L:35 => DirectLieSum R K L
-
-/-- When a semidirect sum is a direct sum, the projection to the left component is a Lie algebra
-homomorphism -/
-def projl' : (K ⊕⁅R⁆ L →ₗ⁅R⁆ K) where
-  __ := projl 0
-  map_lie' := by simp
-
-end DirectSum
+/-- The product of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
+def prod_iso: (K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
+  __ := toProdl 0
+  map_lie' {_ _} := by simp
 
 end SemiDirectSum
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -142,6 +142,19 @@ instance : LieAlgebra.IsExtension (inl ψ) (projr ψ) where
   range_eq_top := by simp [LieHom.range_eq_top]
   exact := by ext ⟨x, y⟩; aesop
 
+section DirectSum
+
+variable (R K L) in
+abbrev DirectLieSum := K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L
+
+notation:35 K " ⊕⁅" R "⁆" L:35 => DirectLieSum R K L
+
+def projl' : (K ⊕⁅R⁆ L →ₗ⁅R⁆ K) where
+  __ := projl 0
+  map_lie' := by simp
+
+end DirectSum
+
 end SemiDirectSum
 end LieAlgebra
 end

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -153,7 +153,7 @@ end
 
 variable (R K L) in
 /-- The product of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
-def prod_iso: (K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
+def prod_iso : (K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
   __ := toProdl 0
   map_lie' {_ _} := by simp
 

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -153,6 +153,7 @@ end
 
 variable (R K L) in
 /-- The product of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
+@[simps!]
 def prod_iso : (K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
   __ := toProdl 0
   map_lie' {_ _} := by simp

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -89,8 +89,7 @@ def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') × (Derivati
     have hxx (a : A) := congrArg (fun f => f a) hx
     have hyy (a : A) := congrArg (fun f => f a) hy
     ext z
-    simp at hxx hyy
-    simp [Derivation.commutator_apply, hxx, hyy]
+    simp_all [Derivation.commutator_apply]
 end CompatibleDerivations
 
 end LieStructures

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.RingTheory.Derivation.Basic
-public import Mathlib.Algebra.Lie.SemiDirect
+public import Mathlib.Algebra.Lie.Prod
 
 /-!
 # Lie Algebra Structure on Derivations

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.RingTheory.Derivation.Basic
+public import Mathlib.Algebra.Lie.SemiDirect
 
 /-!
 # Lie Algebra Structure on Derivations
@@ -70,6 +71,24 @@ instance : LieModule R (Derivation R A A) A where
 
 @[simp]
 lemma bracket_eq_fun (X : Derivation R A A) (a : A) : ⁅X, a⁆ = X a := rfl
+
+section CompatibleDerivations
+variable {A' : Type*} [CommRing A'] [Algebra R A'] [Algebra A A'] [IsScalarTower R A A']
+
+variable (R A A') in
+def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') ⊕⁅R⁆ (Derivation R A A)) where
+  carrier := { x | (x.left).compAlgebraMapL R A A' A'
+    = (Algebra.ofId A A').toLinearMap.compDer (x.right) }
+  add_mem' {x y} hx hy  := by simp at hx hy; simp [hx,hy]
+  zero_mem' := by simp
+  smul_mem'  c x h := by simp at h; simp [h]
+  lie_mem' {x y} hx hy := by
+    have hxx (a : A) := congrArg (fun f => f a) hx
+    have hyy (a : A) := congrArg (fun f => f a) hy
+    ext z
+    simp at hxx hyy
+    simp [Derivation.commutator_apply, hxx, hyy]
+end CompatibleDerivations
 
 end LieStructures
 

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -99,7 +99,7 @@ lemma mem (x : (Derivation R A' A') × (Derivation R A A)) :
   · intro hx; ext a; exact congrArg (· a) hx
   · intro hx; ext a; exact congrArg (· a) hx
 
-/- Generate an element of `Compatible` from `x y` satisfying the compatibility equation-/
+/-- Generate an element of `Compatible` from `x y` satisfying the compatibility equation. -/
 def mk (x : Derivation R A' A') (y : Derivation R A A)
   (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : Compatible R A A' :=
 ⟨(x, y), (Compatible.mem _).mpr h⟩

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -98,9 +98,9 @@ lemma mem (x : (Derivation R A' A') × (Derivation R A A)) :
   · intro hx; ext a; exact congrArg (· a) hx
   · intro hx; ext a; exact congrArg (· a) hx
 
-/-- Generate an element of `Compatible` from `x y` satisfying the compatibility equation. -/
+/-- Generate an element of `couple` from `x y` satisfying the compatibility equation. -/
 def mk (x : Derivation R A' A') (y : Derivation R A A)
-  (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : Compatible R A A' :=
+  (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : couple R A A' :=
 ⟨(x, y), (Compatible.mem _).mpr h⟩
 
 lemma mk_left (x : Derivation R A' A') (y : Derivation R A A)
@@ -109,7 +109,7 @@ lemma mk_left (x : Derivation R A' A') (y : Derivation R A A)
 lemma mk_right (x : Derivation R A' A') (y : Derivation R A A)
     (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : (mk x y h).1.2 = y := rfl
 
-lemma apply (x : Compatible R A A') (a : A) :
+lemma apply (x : couple R A A') (a : A) :
     x.1.1 (Algebra.ofId A A' a) = (Algebra.ofId A A')  (x.1.2 a) := by
   exact congrArg (· a) x.2
 

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -79,7 +79,7 @@ variable (R A A') in
 /-- Let $\sigma: A \to A'$ be a an homomorphism. A derivation $d:A \to A$ and a derivation
 $d':A\to A'$ are called compatible if $d'\circ \sigma = \sigma \circ d$. Couples of derivations
 with this property form a Lie subalgebra of all couples of derivations. -/
-def CompatibleDerivations : LieSubalgebra R  ((Derivation R A' A') × (Derivation R A A)) where
+def Compatible : LieSubalgebra R  ((Derivation R A' A') × (Derivation R A A)) where
   carrier := { x | (x.fst).compAlgebraMapL R A A' A'
     = (Algebra.ofId A A').toLinearMap.compDer (x.snd) }
   add_mem' {x y} hx hy  := by simp at hx hy; simp [hx,hy]
@@ -91,7 +91,39 @@ def CompatibleDerivations : LieSubalgebra R  ((Derivation R A' A') × (Derivatio
     ext z
     simp at hxx hyy
     simp [Derivation.commutator_apply, hxx, hyy]
+
+namespace Compatible
+lemma mem (x : (Derivation R A' A') × (Derivation R A A)) :
+    x ∈ (Compatible R A A') ↔ x.1 ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ x.2 := by
+  constructor
+  · intro hx; ext a; exact congrArg (· a) hx
+  · intro hx; ext a; exact congrArg (· a) hx
+
+/- Generate an element of `Compatible` from `x y` satisfying the compatibility equation-/
+def mk (x : Derivation R A' A') (y : Derivation R A A)
+  (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : Compatible R A A' :=
+⟨(x, y), (Compatible.mem _).mpr h⟩
+
+lemma mk_left (x : Derivation R A' A') (y : Derivation R A A)
+    (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : (mk x y h).1.1 = x := rfl
+
+lemma mk_right (x : Derivation R A' A') (y : Derivation R A A)
+    (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : (mk x y h).1.2 = y := rfl
+
+lemma apply (x : Compatible R A A') (a : A) :
+    x.1.1 (Algebra.ofId A A' a) = (Algebra.ofId A A')  (x.1.2 a) := by
+  exact congrArg (· a) x.2
+
+end Compatible
+
 end CompatibleDerivations
+
+
+
+
+
+
+
 
 end LieStructures
 

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -79,7 +79,7 @@ variable (R A A') in
 /-- Let $\sigma: A \to A'$ be a an homomorphism. A derivation $d:A \to A$ and a derivation
 $d':A\to A'$ are called compatible if $d'\circ \sigma = \sigma \circ d$. Couples of derivations
 with this property form a Lie subalgebra of all couples of derivations. -/
-def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') × (Derivation R A A)) where
+def CompatibleDerivations : LieSubalgebra R  ((Derivation R A' A') × (Derivation R A A)) where
   carrier := { x | (x.fst).compAlgebraMapL R A A' A'
     = (Algebra.ofId A A').toLinearMap.compDer (x.snd) }
   add_mem' {x y} hx hy  := by simp at hx hy; simp [hx,hy]
@@ -89,7 +89,8 @@ def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') × (Derivati
     have hxx (a : A) := congrArg (fun f => f a) hx
     have hyy (a : A) := congrArg (fun f => f a) hy
     ext z
-    simp_all [Derivation.commutator_apply]
+    simp at hxx hyy
+    simp [Derivation.commutator_apply, hxx, hyy]
 end CompatibleDerivations
 
 end LieStructures

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -79,9 +79,9 @@ variable (R A A') in
 /-- Let $\sigma: A \to A'$ be a an homomorphism. A derivation $d:A \to A$ and a derivation
 $d':A\to A'$ are called compatible if $d'\circ \sigma = \sigma \circ d$. Couples of derivations
 with this property form a Lie subalgebra of all couples of derivations. -/
-def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') ⊕⁅R⁆ (Derivation R A A)) where
-  carrier := { x | (x.left).compAlgebraMapL R A A' A'
-    = (Algebra.ofId A A').toLinearMap.compDer (x.right) }
+def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') × (Derivation R A A)) where
+  carrier := { x | (x.fst).compAlgebraMapL R A A' A'
+    = (Algebra.ofId A A').toLinearMap.compDer (x.snd) }
   add_mem' {x y} hx hy  := by simp at hx hy; simp [hx,hy]
   zero_mem' := by simp
   smul_mem'  c x h := by simp at h; simp [h]

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -76,15 +76,14 @@ section CompatibleDerivations
 variable {A' : Type*} [CommRing A'] [Algebra R A'] [Algebra A A'] [IsScalarTower R A A']
 
 variable (R A A') in
-/-- Let $\sigma: A \to A'$ be a an homomorphism. A derivation $d:A \to A$ and a derivation
-$d':A\to A'$ are called compatible if $d'\circ \sigma = \sigma \circ d$. Couples of derivations
+/-- Let `σ : A → A'` be a an homomorphism. A derivation `d : A → A` and a derivation
+`d' : A' → A'` are called compatible if `d' ∘ σ = σ ∘ d`. Couples of derivations
 with this property form a Lie subalgebra of all couples of derivations. -/
-def Compatible : LieSubalgebra R  ((Derivation R A' A') × (Derivation R A A)) where
-  carrier := { x | (x.fst).compAlgebraMapL R A A' A'
-    = (Algebra.ofId A A').toLinearMap.compDer (x.snd) }
-  add_mem' {x y} hx hy  := by simp at hx hy; simp [hx,hy]
+def couple : LieSubalgebra R  (Derivation R A' A' × Derivation R A A) where
+  carrier := { x | x.fst.compAlgebraMapL R A A' A' = (Algebra.ofId A A').toLinearMap.compDer x.snd }
+  add_mem' := by simp_all
   zero_mem' := by simp
-  smul_mem'  c x h := by simp at h; simp [h]
+  smul_mem' := by simp_all
   lie_mem' {x y} hx hy := by
     have hxx (a : A) := congrArg (fun f => f a) hx
     have hyy (a : A) := congrArg (fun f => f a) hy
@@ -94,7 +93,7 @@ def Compatible : LieSubalgebra R  ((Derivation R A' A') × (Derivation R A A)) w
 
 namespace Compatible
 lemma mem (x : (Derivation R A' A') × (Derivation R A A)) :
-    x ∈ (Compatible R A A') ↔ x.1 ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ x.2 := by
+    x ∈ couple R A A' ↔ x.1 ∘ Algebra.ofId A A' = Algebra.ofId A A' ∘ x.2 := by
   constructor
   · intro hx; ext a; exact congrArg (· a) hx
   · intro hx; ext a; exact congrArg (· a) hx
@@ -117,13 +116,6 @@ lemma apply (x : Compatible R A A') (a : A) :
 end Compatible
 
 end CompatibleDerivations
-
-
-
-
-
-
-
 
 end LieStructures
 

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -76,6 +76,9 @@ section CompatibleDerivations
 variable {A' : Type*} [CommRing A'] [Algebra R A'] [Algebra A A'] [IsScalarTower R A A']
 
 variable (R A A') in
+/-- Let $\sigma: A \to A'$ be a an homomorphism. A derivation $d:A \to A$ and a derivation
+$d':A\to A'$ are called compatible if $d'\circ \sigma = \sigma \circ d$. Couples of derivations
+with this property form a Lie subalgebra of all couples of derivations. -/
 def CompatibleDerivations : LieSubalgebra R  ( (Derivation R A' A') ⊕⁅R⁆ (Derivation R A A)) where
   carrier := { x | (x.left).compAlgebraMapL R A A' A'
     = (Algebra.ofId A A').toLinearMap.compDer (x.right) }


### PR DESCRIPTION
Given a map of $R$-algebras $\sigma: A\to A'$, a derivation $X$ of $A$ is called compatible with a Derivation $X'$ of $A'$, if  $\sigma\circ X =X'\circ \sigma$. Given two such pairs $(X,X')$ and $(Y,Y')$, their Lie brackets $([X,Y], [X',Y'])$ again form such a pair. This concept is relevant in differential geometry, where $A$, $A'$ are the algebras of smooth functions on manifolds and $\sigma$ comes from a smooth map between manifolds. (In this case one calls the vector fields (= Derivations) 'related'). 
This concept can be encoded by the fact that the compatible Derivations form a Lie subalgebra of the direct sum of the derivations of $A$ with the derivations of $A'$.

In this PR we add this fact, along with a convenient way to express the direct sum of two Lie algebras, as a special case of their semidirect sum. (There already is a direct sum construction for aribtrary families of Lie algebras in `Mathlib.Algebra.Lie.DirectSum`), but I don't know if there is a very convenient way to use it in the binary case. 
 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
