### PR TITLE
feat(Order/Hom/BoundedLattice): use `to_dual`

### DIFF
--- a/Mathlib/Order/Hom/Bounded.lean
+++ b/Mathlib/Order/Hom/Bounded.lean
@@ -61,8 +61,6 @@ structure BoundedOrderHom (α β : Type*) [Preorder α] [Preorder β] [BoundedOr
 attribute [to_dual self (reorder := map_top' map_bot')] BoundedOrderHom.mk
 attribute [to_dual existing] BoundedOrderHom.map_bot'
 
-section
-
 /-- `TopHomClass F α β` states that `F` is a type of `⊤`-preserving morphisms.
 
 You should extend this class when you extend `TopHom`. -/
@@ -85,33 +83,15 @@ class BotHomClass (F : Type*) (α β : outParam Type*) [Bot α] [Bot β] [FunLik
 You should extend this class when you extend `BoundedOrderHom`. -/
 class BoundedOrderHomClass (F α β : Type*) [LE α] [LE β]
     [BoundedOrder α] [BoundedOrder β] [FunLike F α β] : Prop
-  extends RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop) where
-  /-- Morphisms preserve the top element. The preferred spelling is `_root_.map_top`. -/
-  map_top (f : F) : f ⊤ = ⊤
-  /-- Morphisms preserve the bottom element. The preferred spelling is `_root_.map_bot`. -/
-  map_bot (f : F) : f ⊥ = ⊥
+  extends OrderHomClass F α β, TopHomClass F α β, BotHomClass F α β where
 
-attribute [to_dual existing] BoundedOrderHomClass.map_bot
-
-end
+attribute [to_dual existing] BoundedOrderHomClass.toTopHomClass
 
 export TopHomClass (map_top)
 
 export BotHomClass (map_bot)
 
 attribute [simp] map_top map_bot
-
-section Hom
-
-variable [FunLike F α β]
-
--- See note [lower instance priority]
-@[to_dual]
-instance (priority := 100) BoundedOrderHomClass.toTopHomClass [LE α] [LE β]
-    [BoundedOrder α] [BoundedOrder β] [BoundedOrderHomClass F α β] : TopHomClass F α β where
-  __ := ‹BoundedOrderHomClass F α β›
-
-end Hom
 
 section Equiv
 

--- a/Mathlib/Order/Hom/BoundedLattice.lean
+++ b/Mathlib/Order/Hom/BoundedLattice.lean
@@ -49,6 +49,7 @@ structure SupBotHom (α β : Type*) [Max α] [Max β] [Bot α] [Bot β] extends 
   map_bot' : toFun ⊥ = ⊥
 
 /-- The type of finitary infimum-preserving homomorphisms from `α` to `β`. -/
+@[to_dual]
 structure InfTopHom (α β : Type*) [Min α] [Min β] [Top α] [Top β] extends InfHom α β where
   /-- An `InfTopHom` preserves the top element.
 
@@ -57,17 +58,9 @@ structure InfTopHom (α β : Type*) [Min α] [Min β] [Top α] [Top β] extends 
 
 /-- The type of bounded lattice homomorphisms from `α` to `β`. -/
 structure BoundedLatticeHom (α β : Type*) [Lattice α] [Lattice β] [BoundedOrder α]
-  [BoundedOrder β] extends LatticeHom α β where
-  /-- A `BoundedLatticeHom` preserves the top element.
+  [BoundedOrder β] extends LatticeHom α β, InfTopHom α β, SupBotHom α β where
 
-  Do not use this directly. Use `map_top` instead. -/
-  map_top' : toFun ⊤ = ⊤
-  /-- A `BoundedLatticeHom` preserves the bottom element.
-
-  Do not use this directly. Use `map_bot` instead. -/
-  map_bot' : toFun ⊥ = ⊥
-
-section
+attribute [to_dual existing] BoundedLatticeHom.toSupBotHom
 
 /-- `SupBotHomClass F α β` states that `F` is a type of finitary supremum-preserving morphisms.
 
@@ -80,6 +73,7 @@ class SupBotHomClass (F α β : Type*) [Max α] [Max β] [Bot α] [Bot β] [FunL
 /-- `InfTopHomClass F α β` states that `F` is a type of finitary infimum-preserving morphisms.
 
 You should extend this class when you extend `SupBotHom`. -/
+@[to_dual]
 class InfTopHomClass (F α β : Type*) [Min α] [Min β] [Top α] [Top β] [FunLike F α β] : Prop
   extends InfHomClass F α β where
   /-- An `InfTopHomClass` morphism preserves the top element. -/
@@ -90,39 +84,19 @@ class InfTopHomClass (F α β : Type*) [Min α] [Min β] [Top α] [Top β] [FunL
 You should extend this class when you extend `BoundedLatticeHom`. -/
 class BoundedLatticeHomClass (F α β : Type*) [Lattice α] [Lattice β] [BoundedOrder α]
     [BoundedOrder β] [FunLike F α β] : Prop
-  extends LatticeHomClass F α β where
-  /-- A `BoundedLatticeHomClass` morphism preserves the top element. -/
-  map_top (f : F) : f ⊤ = ⊤
-  /-- A `BoundedLatticeHomClass` morphism preserves the bottom element. -/
-  map_bot (f : F) : f ⊥ = ⊥
+  extends LatticeHomClass F α β, InfTopHomClass F α β, SupBotHomClass F α β where
 
-end
+attribute [to_dual existing] BoundedLatticeHomClass.toSupBotHomClass
 
 section Hom
 
 variable [FunLike F α β]
 
 -- See note [lower instance priority]
+@[to_dual]
 instance (priority := 100) SupBotHomClass.toBotHomClass [Max α] [Max β] [Bot α]
     [Bot β] [SupBotHomClass F α β] : BotHomClass F α β :=
   { ‹SupBotHomClass F α β› with }
-
--- See note [lower instance priority]
-instance (priority := 100) InfTopHomClass.toTopHomClass [Min α] [Min β] [Top α]
-    [Top β] [InfTopHomClass F α β] : TopHomClass F α β :=
-  { ‹InfTopHomClass F α β› with }
-
--- See note [lower instance priority]
-instance (priority := 100) BoundedLatticeHomClass.toSupBotHomClass [Lattice α] [Lattice β]
-    [BoundedOrder α] [BoundedOrder β] [BoundedLatticeHomClass F α β] :
-    SupBotHomClass F α β :=
-  { ‹BoundedLatticeHomClass F α β› with }
-
--- See note [lower instance priority]
-instance (priority := 100) BoundedLatticeHomClass.toInfTopHomClass [Lattice α] [Lattice β]
-    [BoundedOrder α] [BoundedOrder β] [BoundedLatticeHomClass F α β] :
-    InfTopHomClass F α β :=
-  { ‹BoundedLatticeHomClass F α β› with }
 
 -- See note [lower instance priority]
 instance (priority := 100) BoundedLatticeHomClass.toBoundedOrderHomClass [Lattice α]
@@ -137,14 +111,10 @@ section Equiv
 variable [EquivLike F α β]
 
 -- See note [lower instance priority]
+@[to_dual]
 instance (priority := 100) OrderIsoClass.toSupBotHomClass [SemilatticeSup α] [OrderBot α]
     [SemilatticeSup β] [OrderBot β] [OrderIsoClass F α β] : SupBotHomClass F α β :=
   { OrderIsoClass.toSupHomClass, OrderIsoClass.toBotHomClass with }
-
--- See note [lower instance priority]
-instance (priority := 100) OrderIsoClass.toInfTopHomClass [SemilatticeInf α] [OrderTop α]
-    [SemilatticeInf β] [OrderTop β] [OrderIsoClass F α β] : InfTopHomClass F α β :=
-  { OrderIsoClass.toInfHomClass, OrderIsoClass.toTopHomClass with }
 
 -- See note [lower instance priority]
 instance (priority := 100) OrderIsoClass.toBoundedLatticeHomClass [Lattice α] [Lattice β]
@@ -158,13 +128,10 @@ section BoundedLattice
 
 variable [Lattice α] [Lattice β] [FunLike F α β]
 
+@[to_dual]
 theorem Disjoint.map [OrderBot α] [OrderBot β] [BotHomClass F α β] [InfHomClass F α β] {a b : α}
     (f : F) (h : Disjoint a b) : Disjoint (f a) (f b) := by
   rw [disjoint_iff, ← map_inf, h.eq_bot, map_bot]
-
-theorem Codisjoint.map [OrderTop α] [OrderTop β] [TopHomClass F α β] [SupHomClass F α β] {a b : α}
-    (f : F) (h : Codisjoint a b) : Codisjoint (f a) (f b) := by
-  rw [codisjoint_iff, ← map_sup, h.eq_top, map_top]
 
 theorem IsCompl.map [BoundedOrder α] [BoundedOrder β] [BoundedLatticeHomClass F α β] {a b : α}
     (f : F) (h : IsCompl a b) : IsCompl (f a) (f b) :=
@@ -194,11 +161,9 @@ end BooleanAlgebra
 
 variable [FunLike F α β]
 
+@[to_dual]
 instance [Max α] [Max β] [Bot α] [Bot β] [SupBotHomClass F α β] : CoeTC F (SupBotHom α β) :=
   ⟨fun f => ⟨f, map_bot f⟩⟩
-
-instance [Min α] [Min β] [Top α] [Top β] [InfTopHomClass F α β] : CoeTC F (InfTopHom α β) :=
-  ⟨fun f => ⟨f, map_top f⟩⟩
 
 instance [Lattice α] [Lattice β] [BoundedOrder α] [BoundedOrder β] [BoundedLatticeHomClass F α β] :
     CoeTC F (BoundedLatticeHom α β) :=
@@ -219,9 +184,11 @@ section Sup
 variable [Max β] [Bot β] [Max γ] [Bot γ] [Max δ] [Bot δ]
 
 /-- Reinterpret a `SupBotHom` as a `BotHom`. -/
+@[to_dual /-- Reinterpret an `InfTopHom` as a `TopHom`. -/]
 def toBotHom (f : SupBotHom α β) : BotHom α β :=
   { f with }
 
+@[to_dual]
 instance : FunLike (SupBotHom α β) α β where
   coe f := f.toFun
   coe_injective' f g h := by
@@ -229,79 +196,89 @@ instance : FunLike (SupBotHom α β) α β where
     obtain ⟨⟨_, _⟩, _⟩ := g
     congr
 
+@[to_dual]
 instance : SupBotHomClass (SupBotHom α β) α β where
   map_sup f := f.map_sup'
   map_bot f := f.map_bot'
 
+@[to_dual]
 lemma toFun_eq_coe (f : SupBotHom α β) : f.toFun = f := rfl
 
-@[simp] lemma coe_toSupHom (f : SupBotHom α β) : ⇑f.toSupHom = f := rfl
-@[simp] lemma coe_toBotHom (f : SupBotHom α β) : ⇑f.toBotHom = f := rfl
-@[simp] lemma coe_mk (f : SupHom α β) (hf) : ⇑(mk f hf) = f := rfl
+@[to_dual (attr := simp)] lemma coe_toSupHom (f : SupBotHom α β) : ⇑f.toSupHom = f := rfl
+@[to_dual (attr := simp)] lemma coe_toBotHom (f : SupBotHom α β) : ⇑f.toBotHom = f := rfl
+@[to_dual (attr := simp)] lemma coe_mk (f : SupHom α β) (hf) : ⇑(mk f hf) = f := rfl
 
-@[ext]
+@[to_dual (attr := ext)]
 theorem ext {f g : SupBotHom α β} (h : ∀ a, f a = g a) : f = g :=
   DFunLike.ext f g h
 
 /-- Copy of a `SupBotHom` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
+@[to_dual
+/-- Copy of an `InfTopHom` with a new `toFun` equal to the old one. Useful to fix definitional
+equalities. -/]
 protected def copy (f : SupBotHom α β) (f' : α → β) (h : f' = f) : SupBotHom α β :=
   { f.toBotHom.copy f' h with toSupHom := f.toSupHom.copy f' h }
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem coe_copy (f : SupBotHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f' h) = f' :=
   rfl
 
+@[to_dual]
 theorem copy_eq (f : SupBotHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
   DFunLike.ext' h
 
 variable (α)
 
 /-- `id` as a `SupBotHom`. -/
-@[simps!]
+@[to_dual (attr := simps!) /-- `id` as an `InfTopHom`. -/]
 protected def id : SupBotHom α α :=
   ⟨SupHom.id α, rfl⟩
 
+@[to_dual]
 instance : Inhabited (SupBotHom α α) :=
   ⟨SupBotHom.id α⟩
 
-@[simp, norm_cast]
+@[to_dual (attr := simp, norm_cast)]
 theorem coe_id : ⇑(SupBotHom.id α) = id :=
   rfl
 
 variable {α}
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem id_apply (a : α) : SupBotHom.id α a = a :=
   rfl
 
 /-- Composition of `SupBotHom`s as a `SupBotHom`. -/
+@[to_dual /-- Composition of `InfTopHom`s as an `InfTopHom`. -/]
 def comp (f : SupBotHom β γ) (g : SupBotHom α β) : SupBotHom α γ :=
   { f.toSupHom.comp g.toSupHom, f.toBotHom.comp g.toBotHom with }
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem coe_comp (f : SupBotHom β γ) (g : SupBotHom α β) : (f.comp g : α → γ) = f ∘ g :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem comp_apply (f : SupBotHom β γ) (g : SupBotHom α β) (a : α) : (f.comp g) a = f (g a) :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem comp_assoc (f : SupBotHom γ δ) (g : SupBotHom β γ) (h : SupBotHom α β) :
     (f.comp g).comp h = f.comp (g.comp h) :=
   rfl
 
-@[simp] theorem comp_id (f : SupBotHom α β) : f.comp (SupBotHom.id α) = f := rfl
+@[to_dual (attr := simp)]
+theorem comp_id (f : SupBotHom α β) : f.comp (SupBotHom.id α) = f := rfl
 
-@[simp] theorem id_comp (f : SupBotHom α β) : (SupBotHom.id β).comp f = f := rfl
+@[to_dual (attr := simp)]
+theorem id_comp (f : SupBotHom α β) : (SupBotHom.id β).comp f = f := rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem cancel_right {g₁ g₂ : SupBotHom β γ} {f : SupBotHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
   ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem cancel_left {g : SupBotHom β γ} {f₁ f₂ : SupBotHom α β} (hg : Injective g) :
     g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
   ⟨fun h => SupBotHom.ext fun a => hg <| by rw [← comp_apply, h, comp_apply], congr_arg _⟩
@@ -310,36 +287,41 @@ end Sup
 
 variable [SemilatticeSup β] [OrderBot β]
 
+@[to_dual]
 instance : Max (SupBotHom α β) :=
   ⟨fun f g => { f.toBotHom ⊔ g.toBotHom with toSupHom := f.toSupHom ⊔ g.toSupHom }⟩
 
+@[to_dual]
 instance : PartialOrder (SupBotHom α β) :=
   PartialOrder.lift _ DFunLike.coe_injective
 
+@[to_dual]
 instance : SemilatticeSup (SupBotHom α β) :=
   DFunLike.coe_injective.semilatticeSup _ .rfl .rfl fun _ _ ↦ rfl
 
+@[to_dual]
 instance : OrderBot (SupBotHom α β) where
   bot := ⟨⊥, rfl⟩
   bot_le _ _ := bot_le
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem coe_sup (f g : SupBotHom α β) : ⇑(f ⊔ g) = ⇑f ⊔ ⇑g :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem coe_bot : ⇑(⊥ : SupBotHom α β) = ⊥ :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem sup_apply (f g : SupBotHom α β) (a : α) : (f ⊔ g) a = f a ⊔ g a :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem bot_apply (a : α) : (⊥ : SupBotHom α β) a = ⊥ :=
   rfl
 
 /-- `Subtype.val` as a `SupBotHom`. -/
+@[to_dual /-- `Subtype.val` as an `InfTopHom`. -/]
 def subtypeVal {P : β → Prop}
     (Pbot : P ⊥) (Psup : ∀ ⦃x y : β⦄, P x → P y → P (x ⊔ y)) :
     letI := Subtype.orderBot Pbot
@@ -349,170 +331,18 @@ def subtypeVal {P : β → Prop}
   letI := Subtype.semilatticeSup Psup
   .mk (SupHom.subtypeVal Psup) (by simp [Subtype.coe_bot Pbot])
 
-@[simp]
+@[to_dual (attr := simp)]
 lemma subtypeVal_apply {P : β → Prop}
     (Pbot : P ⊥) (Psup : ∀ ⦃x y : β⦄, P x → P y → P (x ⊔ y)) (x : {x : β // P x}) :
     subtypeVal Pbot Psup x = x := rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 lemma subtypeVal_coe {P : β → Prop}
     (Pbot : P ⊥) (Psup : ∀ ⦃x y : β⦄, P x → P y → P (x ⊔ y)) :
     ⇑(subtypeVal Pbot Psup) = Subtype.val := rfl
 
 end SupBotHom
 
-/-! ### Finitary infimum homomorphisms -/
-
-namespace InfTopHom
-
-variable [Min α] [Top α]
-
-section Inf
-
-variable [Min β] [Top β] [Min γ] [Top γ] [Min δ] [Top δ]
-
-/-- Reinterpret an `InfTopHom` as a `TopHom`. -/
-def toTopHom (f : InfTopHom α β) : TopHom α β :=
-  { f with }
-
-instance : FunLike (InfTopHom α β) α β where
-  coe f := f.toFun
-  coe_injective' f g h := by
-    obtain ⟨⟨_, _⟩, _⟩ := f
-    obtain ⟨⟨_, _⟩, _⟩ := g
-    congr
-
-instance : InfTopHomClass (InfTopHom α β) α β where
-  map_inf f := f.map_inf'
-  map_top f := f.map_top'
-
-theorem toFun_eq_coe (f : InfTopHom α β) : f.toFun = f := rfl
-
-@[simp] lemma coe_toInfHom (f : InfTopHom α β) : ⇑f.toInfHom = f := rfl
-@[simp] lemma coe_toTopHom (f : InfTopHom α β) : ⇑f.toTopHom = f := rfl
-@[simp] lemma coe_mk (f : InfHom α β) (hf) : ⇑(mk f hf) = f := rfl
-
-@[ext]
-theorem ext {f g : InfTopHom α β} (h : ∀ a, f a = g a) : f = g :=
-  DFunLike.ext f g h
-
-/-- Copy of an `InfTopHom` with a new `toFun` equal to the old one. Useful to fix definitional
-equalities. -/
-protected def copy (f : InfTopHom α β) (f' : α → β) (h : f' = f) : InfTopHom α β :=
-  { f.toTopHom.copy f' h with toInfHom := f.toInfHom.copy f' h }
-
-@[simp]
-theorem coe_copy (f : InfTopHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f' h) = f' :=
-  rfl
-
-theorem copy_eq (f : InfTopHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  DFunLike.ext' h
-
-variable (α)
-
-/-- `id` as an `InfTopHom`. -/
-@[simps!]
-protected def id : InfTopHom α α :=
-  ⟨InfHom.id α, rfl⟩
-
-instance : Inhabited (InfTopHom α α) :=
-  ⟨InfTopHom.id α⟩
-
-@[simp, norm_cast]
-theorem coe_id : ⇑(InfTopHom.id α) = id :=
-  rfl
-
-variable {α}
-
-@[simp]
-theorem id_apply (a : α) : InfTopHom.id α a = a :=
-  rfl
-
-/-- Composition of `InfTopHom`s as an `InfTopHom`. -/
-def comp (f : InfTopHom β γ) (g : InfTopHom α β) : InfTopHom α γ :=
-  { f.toInfHom.comp g.toInfHom, f.toTopHom.comp g.toTopHom with }
-
-@[simp]
-theorem coe_comp (f : InfTopHom β γ) (g : InfTopHom α β) : (f.comp g : α → γ) = f ∘ g :=
-  rfl
-
-@[simp]
-theorem comp_apply (f : InfTopHom β γ) (g : InfTopHom α β) (a : α) : (f.comp g) a = f (g a) :=
-  rfl
-
-@[simp]
-theorem comp_assoc (f : InfTopHom γ δ) (g : InfTopHom β γ) (h : InfTopHom α β) :
-    (f.comp g).comp h = f.comp (g.comp h) :=
-  rfl
-
-@[simp] theorem comp_id (f : InfTopHom α β) : f.comp (InfTopHom.id α) = f := rfl
-
-@[simp] theorem id_comp (f : InfTopHom α β) : (InfTopHom.id β).comp f = f := rfl
-
-@[simp]
-theorem cancel_right {g₁ g₂ : InfTopHom β γ} {f : InfTopHom α β} (hf : Surjective f) :
-    g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
-
-@[simp]
-theorem cancel_left {g : InfTopHom β γ} {f₁ f₂ : InfTopHom α β} (hg : Injective g) :
-    g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
-  ⟨fun h => InfTopHom.ext fun a => hg <| by rw [← comp_apply, h, comp_apply], congr_arg _⟩
-
-end Inf
-
-variable [SemilatticeInf β] [OrderTop β]
-
-instance : Min (InfTopHom α β) :=
-  ⟨fun f g => { f.toTopHom ⊓ g.toTopHom with toInfHom := f.toInfHom ⊓ g.toInfHom }⟩
-
-instance : PartialOrder (InfTopHom α β) :=
-  PartialOrder.lift _ DFunLike.coe_injective
-
-instance : SemilatticeInf (InfTopHom α β) :=
-  DFunLike.coe_injective.semilatticeInf _ .rfl .rfl fun _ _ ↦ rfl
-
-instance : OrderTop (InfTopHom α β) where
-  top := ⟨⊤, rfl⟩
-  le_top _ _ := le_top
-
-@[simp]
-theorem coe_inf (f g : InfTopHom α β) : ⇑(f ⊓ g) = ⇑f ⊓ ⇑g :=
-  rfl
-
-@[simp]
-theorem coe_top : ⇑(⊤ : InfTopHom α β) = ⊤ :=
-  rfl
-
-@[simp]
-theorem inf_apply (f g : InfTopHom α β) (a : α) : (f ⊓ g) a = f a ⊓ g a :=
-  rfl
-
-@[simp]
-theorem top_apply (a : α) : (⊤ : InfTopHom α β) a = ⊤ :=
-  rfl
-
-/-- `Subtype.val` as an `InfTopHom`. -/
-def subtypeVal {P : β → Prop}
-    (Ptop : P ⊤) (Pinf : ∀ ⦃x y : β⦄, P x → P y → P (x ⊓ y)) :
-    letI := Subtype.orderTop Ptop
-    letI := Subtype.semilatticeInf Pinf
-    InfTopHom {x : β // P x} β :=
-  letI := Subtype.orderTop Ptop
-  letI := Subtype.semilatticeInf Pinf
-  .mk (InfHom.subtypeVal Pinf) (by simp [Subtype.coe_top Ptop])
-
-@[simp]
-lemma subtypeVal_apply {P : β → Prop}
-    (Ptop : P ⊤) (Pinf : ∀ ⦃x y : β⦄, P x → P y → P (x ⊓ y)) (x : {x : β // P x}) :
-    subtypeVal Ptop Pinf x = x := rfl
-
-@[simp]
-lemma subtypeVal_coe {P : β → Prop}
-    (Ptop : P ⊤) (Pinf : ∀ ⦃x y : β⦄, P x → P y → P (x ⊓ y)) :
-    ⇑(subtypeVal Ptop Pinf) = Subtype.val := rfl
-
-end InfTopHom
 
 /-! ### Bounded lattice homomorphisms -/
 
@@ -520,14 +350,6 @@ namespace BoundedLatticeHom
 
 variable [Lattice α] [Lattice β] [Lattice γ] [Lattice δ] [BoundedOrder α] [BoundedOrder β]
   [BoundedOrder γ] [BoundedOrder δ]
-
-/-- Reinterpret a `BoundedLatticeHom` as a `SupBotHom`. -/
-def toSupBotHom (f : BoundedLatticeHom α β) : SupBotHom α β :=
-  { f with }
-
-/-- Reinterpret a `BoundedLatticeHom` as an `InfTopHom`. -/
-def toInfTopHom (f : BoundedLatticeHom α β) : InfTopHom α β :=
-  { f with }
 
 /-- Reinterpret a `BoundedLatticeHom` as a `BoundedOrderHom`. -/
 def toBoundedOrderHom (f : BoundedLatticeHom α β) : BoundedOrderHom α β :=
@@ -682,60 +504,32 @@ variable [Max α] [Bot α] [Max β] [Bot β] [Max γ] [Bot γ]
 
 /-- Reinterpret a finitary supremum homomorphism as a finitary infimum homomorphism between the dual
 lattices. -/
+@[to_dual (attr := simps!)
+/-- Reinterpret a finitary infimum homomorphism as a finitary supremum homomorphism between the dual
+lattices. -/]
 def dual : SupBotHom α β ≃ InfTopHom αᵒᵈ βᵒᵈ where
   toFun f := ⟨SupHom.dual f.toSupHom, f.map_bot'⟩
   invFun f := ⟨SupHom.dual.symm f.toInfHom, f.map_top'⟩
 
-@[simp] theorem dual_id : SupBotHom.dual (SupBotHom.id α) = InfTopHom.id _ := rfl
+@[to_dual (attr := simp)]
+theorem dual_id : SupBotHom.dual (SupBotHom.id α) = InfTopHom.id _ := rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem dual_comp (g : SupBotHom β γ) (f : SupBotHom α β) :
     SupBotHom.dual (g.comp f) = (SupBotHom.dual g).comp (SupBotHom.dual f) :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem symm_dual_id : SupBotHom.dual.symm (InfTopHom.id _) = SupBotHom.id α :=
   rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem symm_dual_comp (g : InfTopHom βᵒᵈ γᵒᵈ) (f : InfTopHom αᵒᵈ βᵒᵈ) :
     SupBotHom.dual.symm (g.comp f) =
       (SupBotHom.dual.symm g).comp (SupBotHom.dual.symm f) :=
   rfl
 
 end SupBotHom
-
-namespace InfTopHom
-
-variable [Min α] [Top α] [Min β] [Top β] [Min γ] [Top γ]
-
-/-- Reinterpret a finitary infimum homomorphism as a finitary supremum homomorphism between the dual
-lattices. -/
-@[simps!]
-protected def dual : InfTopHom α β ≃ SupBotHom αᵒᵈ βᵒᵈ where
-  toFun f := ⟨InfHom.dual f.toInfHom, f.map_top'⟩
-  invFun f := ⟨InfHom.dual.symm f.toSupHom, f.map_bot'⟩
-
-@[simp]
-theorem dual_id : InfTopHom.dual (InfTopHom.id α) = SupBotHom.id _ :=
-  rfl
-
-@[simp]
-theorem dual_comp (g : InfTopHom β γ) (f : InfTopHom α β) :
-    InfTopHom.dual (g.comp f) = (InfTopHom.dual g).comp (InfTopHom.dual f) :=
-  rfl
-
-@[simp]
-theorem symm_dual_id : InfTopHom.dual.symm (SupBotHom.id _) = InfTopHom.id α :=
-  rfl
-
-@[simp]
-theorem symm_dual_comp (g : SupBotHom βᵒᵈ γᵒᵈ) (f : SupBotHom αᵒᵈ βᵒᵈ) :
-    InfTopHom.dual.symm (g.comp f) =
-      (InfTopHom.dual.symm g).comp (InfTopHom.dual.symm f) :=
-  rfl
-
-end InfTopHom
 
 namespace BoundedLatticeHom
 


### PR DESCRIPTION
This PR uses `to_dual` on `BoundedLatticeHom` and friends. This PR also takes the opportunity to make more use of `extends` to avoid redefining the same structure fields.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
