### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): action of a bifunctor on cokernels

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2744,6 +2744,7 @@ public import Mathlib.CategoryTheory.Limits.Preorder
 public import Mathlib.CategoryTheory.Limits.Presentation
 public import Mathlib.CategoryTheory.Limits.Preserves.Basic
 public import Mathlib.CategoryTheory.Limits.Preserves.Bifunctor
+public import Mathlib.CategoryTheory.Limits.Preserves.BifunctorCokernel
 public import Mathlib.CategoryTheory.Limits.Preserves.Creates.Finite
 public import Mathlib.CategoryTheory.Limits.Preserves.Creates.Pullbacks
 public import Mathlib.CategoryTheory.Limits.Preserves.Filtered

--- a/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
@@ -37,9 +37,12 @@ variable {X₁ Y₁ : C₁} {f₁ : X₁ ⟶ Y₁} {c₁ : CokernelCofork f₁} 
   [F.PreservesZeroMorphisms]
 
 set_option backward.isDefEq.respectTransparency false in
-variable (c₁ c₂) [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)] in
-/-- The action of a bifunctor on a pair of cokernel coforks. -/
-noncomputable abbrev mapBifunctor :
+variable (c₁ c₂) in
+/-- Let `c₁` (resp. `c₂`) be a cokernel cofork for a morphism `f₁ : X₁ ⟶ Y₁`
+in a category `C₁` (resp. `f₂ : X₂ ⟶ Y₂` in `C₂`). Given a bifunctor `F : C₁ ⥤ C₂ ⥤ C`,
+this is the cokernel cofork with point `(F.obj c₁.pt).obj c₂.pt` for
+the obvious morphism `(F.obj X₁).obj Y₂ ⨿ (F.obj Y₁).obj X₂ ⟶ (F.obj Y₁).obj Y₂`. -/
+noncomputable abbrev mapBifunctor [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)] :
     CokernelCofork (coprod.desc ((F.map f₁).app Y₂) ((F.obj Y₁).map f₂)) :=
   CokernelCofork.ofπ (Z := (F.obj c₁.pt).obj c₂.pt)
     ((F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π) (by
@@ -84,7 +87,12 @@ variable [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)]
   [PreservesColimit (parallelPair f₁ 0) (F.flip.obj X₂)]
 
 open isColimitMapBifunctor in
-/-- The action of a bifunctor on a pair of colimit cokernel coforks. -/
+/-- Let `c₁` (resp. `c₂`) be a colimit cokernel cofork for a morphism `f₁ : X₁ ⟶ Y₁`
+in a category `C₁` (resp. `f₂ : X₂ ⟶ Y₂` in `C₂`). If `F : C₁ ⥤ C₂ ⥤ C` is a bifunctor,
+then `(F.obj c₁.pt).obj c₂.pt` identifies to the cokernel of the morphism
+`(F.obj X₁).obj Y₂ ⨿ (F.obj Y₁).obj X₂ ⟶ (F.obj Y₁).obj Y₂`
+when the cokernel of `f₁` is preserved by `F.obj c₁.pt` and the cokernel of `f₂`
+is preserved by `F.flip.obj X₁` and `F.flip.obj Y₁`. -/
 noncomputable def isColimitMapBifunctor :
     IsColimit (mapBifunctor c₁ c₂ F) :=
   Cofork.IsColimit.mk _

--- a/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
@@ -43,12 +43,9 @@ noncomputable abbrev mapBifunctor :
     CokernelCofork (coprod.desc ((F.map f₁).app Y₂) ((F.obj Y₁).map f₂)) :=
   CokernelCofork.ofπ (Z := (F.obj c₁.pt).obj c₂.pt)
     ((F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π) (by
-      dsimp
       ext
-      · rw [comp_zero, coprod.inl_desc_assoc, ← NatTrans.comp_app_assoc, ← Functor.map_comp]
-        simp
-      · rw [comp_zero, coprod.inr_desc_assoc, NatTrans.naturality_assoc, ← Functor.map_comp]
-        simp)
+      · simp [← NatTrans.comp_app_assoc, ← Functor.map_comp]
+      · simp [← Functor.map_comp])
 
 variable [PreservesColimit (parallelPair f₂ 0) (F.obj c₁.pt)]
   [PreservesColimit (parallelPair f₁ 0) (F.flip.obj Y₂)]

--- a/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
@@ -15,8 +15,8 @@ Let `c₁` (resp. `c₂`) be a cokernel cofork for a morphism `f₁ : X₁ ⟶ Y
 in a category `C₁` (resp. `f₂ : X₂ ⟶ Y₂` in `C₂`). Given a bifunctor `F : C₁ ⥤ C₂ ⥤ C`,
 we construct a cokernel cofork with point `(F.obj c₁.pt).obj c₂.pt` for
 the obvious morphism `(F.obj X₁).obj Y₂ ⨿ (F.obj Y₁).obj X₂ ⟶ (F.obj Y₁).obj Y₂`,
-and show that it is a colimit when the cokernel of `f₁` is preserved
-by `F.obj c₁.pt` and the cokernel of `f₂` is perserved by
+and show that it is a colimit when both coforks are colimit, the cokernel of `f₁`
+is preserved by `F.obj c₁.pt` and the cokernel of `f₂` is preserved by
 `F.flip.obj X₁` and `F.flip.obj Y₁`.
 
 -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Kernels
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+
+/-!
+# Action of bifunctors on cokernels
+
+Let `c₁` (resp. `c₂`) be a cokernel cofork for a morphism `f₁ : X₁ ⟶ Y₁`
+in a category `C₁` (resp. `f₂ : X₂ ⟶ Y₂` in `C₂`). Given a bifunctor `F : C₁ ⥤ C₂ ⥤ C`,
+we construct a cokernel cofork with point `(F.obj c₁.pt).obj c₂.pt` for
+the obvious morphism `(F.obj X₁).obj Y₂ ⨿ (F.obj Y₁).obj X₂ ⟶ (F.obj Y₁).obj Y₂`,
+and show that it is a colimit when the cokernel of `f₁` is preserved
+by `F.obj c₁.pt` and the cokernel of `f₂` is perserved by
+`F.flip.obj X₁` and `F.flip.obj Y₁`.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory.Limits
+
+variable {C₁ C₂ C : Type*} [Category C₁] [Category C₂] [Category C]
+  [HasZeroMorphisms C₁] [HasZeroMorphisms C₂] [HasZeroMorphisms C]
+
+namespace CokernelCofork
+
+variable {X₁ Y₁ : C₁} {f₁ : X₁ ⟶ Y₁} {c₁ : CokernelCofork f₁} (hc₁ : IsColimit c₁)
+  {X₂ Y₂ : C₂} {f₂ : X₂ ⟶ Y₂} {c₂ : CokernelCofork f₂} (hc₂ : IsColimit c₂)
+  (F : C₁ ⥤ C₂ ⥤ C)
+  [(F.obj c₁.pt).PreservesZeroMorphisms]
+  [F.PreservesZeroMorphisms]
+
+set_option backward.isDefEq.respectTransparency false in
+variable (c₁ c₂) [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)] in
+/-- The action of a bifunctor on a pair of cokernel coforks. -/
+noncomputable abbrev mapBifunctor :
+    CokernelCofork (coprod.desc ((F.map f₁).app Y₂) ((F.obj Y₁).map f₂)) :=
+  CokernelCofork.ofπ (Z := (F.obj c₁.pt).obj c₂.pt)
+    ((F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π) (by
+      dsimp
+      ext
+      · rw [comp_zero, coprod.inl_desc_assoc, ← NatTrans.comp_app_assoc, ← Functor.map_comp]
+        simp
+      · rw [comp_zero, coprod.inr_desc_assoc, NatTrans.naturality_assoc, ← Functor.map_comp]
+        simp)
+
+variable [PreservesColimit (parallelPair f₂ 0) (F.obj c₁.pt)]
+  [PreservesColimit (parallelPair f₁ 0) (F.flip.obj Y₂)]
+
+namespace isColimitMapBifunctor
+
+include hc₁ hc₂
+
+lemma hom_ext {T : C} {f g : (F.obj c₁.pt).obj c₂.pt ⟶ T}
+    (h : (F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π ≫ f =
+      (F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π ≫ g) : f = g :=
+  Cofork.IsColimit.hom_ext (mapIsColimit _ hc₂ (F.obj c₁.pt))
+    (Cofork.IsColimit.hom_ext (mapIsColimit _ hc₁ (F.flip.obj Y₂)) h)
+
+variable [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)]
+  [PreservesColimit (parallelPair f₁ 0) (F.flip.obj X₂)]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma exists_desc (s : CokernelCofork (coprod.desc ((F.map f₁).app Y₂) ((F.obj Y₁).map f₂))) :
+    ∃ (l : (F.obj c₁.pt).obj c₂.pt ⟶ s.pt),
+      (F.map c₁.π).app Y₂ ≫ (F.obj c₁.pt).map c₂.π ≫ l = s.π := by
+  obtain ⟨l, hl⟩ := Cofork.IsColimit.desc' (mapIsColimit _ hc₁ (F.flip.obj Y₂)) s.π (by
+    have := coprod.inl ≫= s.condition
+    rw [coprod.inl_desc_assoc, comp_zero] at this
+    rwa [zero_comp])
+  obtain ⟨l', hl'⟩ := Cofork.IsColimit.desc' (mapIsColimit _ hc₂ (F.obj c₁.pt)) l (by
+    have := coprod.inr ≫= s.condition
+    rw [coprod.inr_desc_assoc, ← dsimp% hl, NatTrans.naturality_assoc, comp_zero] at this
+    apply Cofork.IsColimit.hom_ext (mapIsColimit _ hc₁ (F.flip.obj X₂))
+    rwa [zero_comp, comp_zero])
+  exact ⟨l', by cat_disch⟩
+
+end isColimitMapBifunctor
+
+variable [HasBinaryCoproduct ((F.obj X₁).obj Y₂) ((F.obj Y₁).obj X₂)]
+  [PreservesColimit (parallelPair f₁ 0) (F.flip.obj X₂)]
+
+open isColimitMapBifunctor in
+/-- The action of a bifunctor on a pair of colimit cokernel coforks. -/
+noncomputable def isColimitMapBifunctor :
+    IsColimit (mapBifunctor c₁ c₂ F) :=
+  Cofork.IsColimit.mk _
+    (fun s ↦ (exists_desc hc₁ hc₂ F s).choose)
+    (fun s ↦ by simpa using (exists_desc hc₁ hc₂ F s).choose_spec)
+    (fun s m hm ↦ hom_ext hc₁ hc₂ F (by
+      dsimp
+      rw [dsimp% (exists_desc hc₁ hc₂ F s).choose_spec, ← dsimp% hm, Category.assoc]))
+
+end CokernelCofork
+
+end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/BifunctorCokernel.lean
@@ -25,7 +25,7 @@ by `F.obj c₁.pt` and the cokernel of `f₂` is perserved by
 
 namespace CategoryTheory.Limits
 
-variable {C₁ C₂ C : Type*} [Category C₁] [Category C₂] [Category C]
+variable {C₁ C₂ C : Type*} [Category* C₁] [Category* C₂] [Category* C]
   [HasZeroMorphisms C₁] [HasZeroMorphisms C₂] [HasZeroMorphisms C]
 
 namespace CokernelCofork


### PR DESCRIPTION
Let `c₁` (resp. `c₂`) be a cokernel cofork for a morphism `f₁ : X₁ ⟶ Y₁` in a category `C₁` (resp. `f₂ : X₂ ⟶ Y₂` in `C₂`). Given a bifunctor `F : C₁ ⥤ C₂ ⥤ C`, we construct a cokernel cofork with point `(F.obj c₁.pt).obj c₂.pt` for the obvious morphism `(F.obj X₁).obj Y₂ ⨿ (F.obj Y₁).obj X₂ ⟶ (F.obj Y₁).obj Y₂`, and show that it is a colimit when the cokernel of `f₁` is preserved by `F.obj c₁.pt` and the cokernel of `f₂` is perserved by `F.flip.obj X₁` and `F.flip.obj Y₁`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
