### PR TITLE
feat(Algebra/Module/LocalizedModule): algebra lemmas for localization equivalences

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Localization.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Localization.lean
@@ -102,3 +102,18 @@ instance [Small.{v} R] (S : Submonoid R) :
   exact this.2
 
 end ModuleCat
+
+namespace IsLocalizedModule
+
+/-- A morphism in `ModuleCat` factoring between two `S`-localizations is an isomorphism. -/
+lemma isIso_of_comp_eq {R : Type u} [CommRing R] {A B C : ModuleCat.{u} R}
+    (S : Submonoid R) (g : A ⟶ B) (h : A ⟶ C)
+    [IsLocalizedModule S g.hom] [IsLocalizedModule S h.hom]
+    (α : B ⟶ C) (fac : α.hom ∘ₗ g.hom = h.hom) :
+    IsIso α := by
+  have hα : α = (IsLocalizedModule.linearEquiv S g.hom h.hom).toModuleIso.hom :=
+    ModuleCat.hom_ext (eq_linearEquiv S g.hom h.hom α.hom fac)
+  rw [hα]
+  infer_instance
+
+end IsLocalizedModule

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -935,6 +935,25 @@ lemma linearEquiv_symm_apply [IsLocalizedModule S g] (x : M) :
     (linearEquiv S f g).symm (g x) = f x := by
   simp [linearEquiv]
 
+@[simp]
+lemma linearEquiv_comp [IsLocalizedModule S g] :
+    (linearEquiv S f g).toLinearMap ∘ₗ f = g :=
+  LinearMap.ext fun x => linearEquiv_apply S f g x
+
+/-- A linear map factoring between two `S`-localizations equals the canonical
+`linearEquiv` between them. -/
+theorem eq_linearEquiv [IsLocalizedModule S g]
+    (l : M' →ₗ[R] M'') (hl : l ∘ₗ f = g) :
+    l = (linearEquiv S f g).toLinearMap :=
+  linearMap_ext S f g (by rw [hl, linearEquiv_comp])
+
+/-- A linear map factoring between two `S`-localizations is bijective.
+This is the module-level analogue of `IsLocalization.bijective`. -/
+protected theorem bijective [IsLocalizedModule S g]
+    (l : M' →ₗ[R] M'') (hl : l ∘ₗ f = g) :
+    Function.Bijective l :=
+  eq_linearEquiv S f g l hl ▸ (linearEquiv S f g).bijective
+
 variable {S}
 
 include f in

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -938,7 +938,7 @@ lemma linearEquiv_symm_apply [IsLocalizedModule S g] (x : M) :
 @[simp]
 lemma linearEquiv_comp [IsLocalizedModule S g] :
     (linearEquiv S f g).toLinearMap ∘ₗ f = g :=
-  LinearMap.ext fun x => linearEquiv_apply S f g x
+  LinearMap.ext fun x ↦ linearEquiv_apply S f g x
 
 /-- A linear map factoring between two `S`-localizations equals the canonical
 `linearEquiv` between them. -/


### PR DESCRIPTION
Add uniqueness/bijectivity lemmas for localization factoring maps and a categorical
`IsIso` wrapper in `ModuleCat`:

- `IsLocalizedModule.linearEquiv_comp`: composition `linearEquiv ∘ₗ f = g`
- `IsLocalizedModule.eq_linearEquiv`: a factoring map equals `linearEquiv`
- `IsLocalizedModule.bijective`: a factoring map is bijective (analogue of `IsLocalization.bijective`)
- `IsLocalizedModule.isIso_of_comp_eq`: categorical `IsIso` for factoring morphism in `ModuleCat`

### Declarations

- `IsLocalizedModule.linearEquiv_comp`
- `IsLocalizedModule.eq_linearEquiv`
- `IsLocalizedModule.bijective`
- `IsLocalizedModule.isIso_of_comp_eq`

### Motivation

These lemmas are needed by the pushforward-tilde iso for quasi-coherent sheaves
([Stacks, Tag 01I9], Part 2), where the comparison map on each basic open `D(r)`
factors between two localizations of global sections. They will be used in a
follow-up PR adding `Mathlib.AlgebraicGeometry.Modules.PushforwardTilde`.

### Details

The algebra lemmas (`linearEquiv_comp`, `eq_linearEquiv`, `bijective`) are placed in
`LocalizedModule/Basic.lean` alongside the existing `linearEquiv`. The categorical
wrapper `isIso_of_comp_eq` uses `eq_linearEquiv` to show the factoring morphism equals
the canonical `linearEquiv`, then lifts to `IsIso` via `ModuleIso`.

### AI Assistance

This PR was developed with Claude Code (Claude Opus).
The tool was used for proof development, API discovery, and code formatting.
All code has been reviewed and verified by the author.
