### PR TITLE
[Merged by Bors] - chore: golf using `grind` and `simp`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Closed.lean
+++ b/Mathlib/CategoryTheory/Sites/Closed.lean
@@ -171,12 +171,8 @@ theorem classifier_isSheaf : Presieve.IsSheaf J₁ (Functor.closedSieves J₁) :
     have q : ∀ ⦃Z : C⦄ (g : Z ⟶ X) (_ : S g), M.pullback g = N.pullback g :=
       fun Z g hg => congr_arg Subtype.val ((hM₂ g hg).trans (hN₂ g hg).symm)
     have MSNS : M ⊓ S = N ⊓ S := by
-      ext Z g
-      rw [Sieve.inter_apply, Sieve.inter_apply]
-      simp only [and_comm]
-      apply and_congr_right
-      intro hg
-      rw [Sieve.mem_iff_pullback_eq_top, Sieve.mem_iff_pullback_eq_top, q g hg]
+      ext
+      grind [Sieve.inter_apply, Sieve.mem_iff_pullback_eq_top]
     constructor
     · intro hf
       rw [J₁.covers_iff]

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -265,12 +265,8 @@ in the orthogonal direction. -/
 theorem orthogonalProjection_vadd_eq_self {s : AffineSubspace 𝕜 P} [Nonempty s]
     [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∈ s) {v : V} (hv : v ∈ s.directionᗮ) :
     orthogonalProjection s (v +ᵥ p) = ⟨p, hp⟩ := by
-  have h := vsub_orthogonalProjection_mem_direction_orthogonal s (v +ᵥ p)
-  rw [vadd_vsub_assoc, Submodule.add_mem_iff_right _ hv] at h
-  refine (eq_of_vsub_eq_zero ?_).symm
   ext
-  refine Submodule.disjoint_def.1 s.direction.orthogonal_disjoint _ ?_ h
-  exact (_ : s.direction).2
+  exact coe_orthogonalProjection_eq_iff_mem.mpr (by simp [*])
 
 /-- Adding a vector to a point in the given subspace, then taking the
 orthogonal projection, produces the original point if the vector is a

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -130,10 +130,8 @@ theorem add_measure {f : α → β} (hμ : AEMeasurable f μ) (hν : AEMeasurabl
 protected theorem map_add₀ {μ ν : Measure α} {f : α → β}
     (hμ : AEMeasurable f μ) (hν : AEMeasurable f ν) :
     (μ + ν).map f = μ.map f + ν.map f := by
-  rw [Measure.map_congr (hμ.add_measure hν).ae_eq_mk, Measure.map_add _ _ (by fun_prop)]
-  congr 1 <;> apply Measure.map_congr
-  · exact (AbsolutelyContinuous.rfl.add_right ν) (hμ.add_measure hν).ae_eq_mk.symm
-  · exact (AbsolutelyContinuous.rfl.add_right' μ) (hμ.add_measure hν).ae_eq_mk.symm
+  ext
+  simp [*]
 
 @[measurability]
 protected theorem iUnion [Countable ι] {s : ι → Set α}

--- a/Mathlib/Topology/Order/HullKernel.lean
+++ b/Mathlib/Topology/Order/HullKernel.lean
@@ -76,12 +76,7 @@ variable {T : Set α}
 pairwise union. -/
 lemma hull_inf (hT : ∀ p ∈ T, InfPrime p) (a b : α) :
     hull T (a ⊓ b) = hull T a ∪ hull T b := by
-  ext p
-  constructor <;> intro h
-  · exact (hT p p.2).2 h
-  · rcases h with (h1 | h3)
-    · exact inf_le_of_left_le h1
-    · exact inf_le_of_right_le h3
+  grind [InfPrime.inf_le]
 
 variable [OrderTop α]
 


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `CategoryTheory.classifier_isSheaf`: unchanged 🎉
* `EuclideanGeometry.orthogonalProjection_vadd_eq_self`: unchanged 🎉
* `AEMeasurable.map_add₀`: unchanged 🎉
* `PrimitiveSpectrum.hull_inf`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
