### PR TITLE
[Merged by Bors] - refactor(Kernel.discard): redefine using `PUnit`

### DIFF
--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -21,7 +21,7 @@ kernels.
   the identity function.
 * `ProbabilityTheory.Kernel.copy α`: the deterministic kernel that maps `x : α` to
   the Dirac measure at `(x, x) : α × α`.
-* `ProbabilityTheory.Kernel.discard α`: the Markov kernel to the type `Unit`.
+* `ProbabilityTheory.Kernel.discard α`: the Markov kernel to the type `PUnit`.
 * `ProbabilityTheory.Kernel.swap α β`: the deterministic kernel that maps `(x, y)` to
   the Dirac measure at `(y, x)`.
 * `ProbabilityTheory.Kernel.const α (μβ : measure β)`: constant kernel `a ↦ μβ`.
@@ -142,13 +142,13 @@ section Discard
 
 /-- The Markov kernel to the `Unit` type. -/
 noncomputable
-def discard (α : Type*) [MeasurableSpace α] : Kernel α Unit :=
-  Kernel.deterministic (fun _ ↦ ()) measurable_const
+def discard (α : Type*) [MeasurableSpace α] : Kernel α PUnit :=
+  Kernel.deterministic (fun _ ↦ PUnit.unit) measurable_const
 
 instance : IsMarkovKernel (discard α) := by rw [discard]; infer_instance
 
 @[simp]
-lemma discard_apply (a : α) : discard α a = Measure.dirac () := deterministic_apply _ _
+lemma discard_apply (a : α) : discard α a = Measure.dirac PUnit.unit := deterministic_apply _ _
 
 end Discard
 
@@ -228,7 +228,7 @@ theorem lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} :
 theorem setLIntegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} {s : Set β} :
     ∫⁻ x in s, f x ∂const α μ a = ∫⁻ x in s, f x ∂μ := by rw [const_apply]
 
-lemma discard_eq_const : discard α = const α (Measure.dirac ()) := rfl
+lemma discard_eq_const : discard α = const α (Measure.dirac PUnit.unit) := rfl
 
 end Const
 

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -140,7 +140,7 @@ end Copy
 
 section Discard
 
-/-- The Markov kernel to the `Unit` type. -/
+/-- The Markov kernel to the `PUnit` type. -/
 noncomputable
 def discard (α : Type*) [MeasurableSpace α] : Kernel α PUnit :=
   Kernel.deterministic (fun _ ↦ default) measurable_const

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -143,12 +143,12 @@ section Discard
 /-- The Markov kernel to the `Unit` type. -/
 noncomputable
 def discard (α : Type*) [MeasurableSpace α] : Kernel α PUnit :=
-  Kernel.deterministic (fun _ ↦ PUnit.unit) measurable_const
+  Kernel.deterministic (fun _ ↦ default) measurable_const
 
 instance : IsMarkovKernel (discard α) := by rw [discard]; infer_instance
 
 @[simp]
-lemma discard_apply (a : α) : discard α a = Measure.dirac PUnit.unit := deterministic_apply _ _
+lemma discard_apply (a : α) : discard α a = Measure.dirac default := deterministic_apply _ _
 
 end Discard
 
@@ -228,7 +228,7 @@ theorem lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} :
 theorem setLIntegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} {s : Set β} :
     ∫⁻ x in s, f x ∂const α μ a = ∫⁻ x in s, f x ∂μ := by rw [const_apply]
 
-lemma discard_eq_const : discard α = const α (Measure.dirac PUnit.unit) := rfl
+lemma discard_eq_const : discard α = const α (Measure.dirac default) := rfl
 
 end Const
 

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -143,12 +143,12 @@ section Discard
 /-- The Markov kernel to the `PUnit` type. -/
 noncomputable
 def discard (α : Type*) [MeasurableSpace α] : Kernel α PUnit :=
-  Kernel.deterministic (fun _ ↦ default) measurable_const
+  Kernel.deterministic (fun _ ↦ PUnit.unit) measurable_const
 
 instance : IsMarkovKernel (discard α) := by rw [discard]; infer_instance
 
 @[simp]
-lemma discard_apply (a : α) : discard α a = Measure.dirac default := deterministic_apply _ _
+lemma discard_apply (a : α) : discard α a = Measure.dirac PUnit.unit := deterministic_apply _ _
 
 end Discard
 
@@ -228,7 +228,7 @@ theorem lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} :
 theorem setLIntegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} {s : Set β} :
     ∫⁻ x in s, f x ∂const α μ a = ∫⁻ x in s, f x ∂μ := by rw [const_apply]
 
-lemma discard_eq_const : discard α = const α (Measure.dirac default) := rfl
+lemma discard_eq_const : discard α = const α (Measure.dirac PUnit.unit) := rfl
 
 end Const
 

--- a/Mathlib/Probability/Kernel/Composition/Comp.lean
+++ b/Mathlib/Probability/Kernel/Composition/Comp.lean
@@ -147,7 +147,7 @@ theorem comp_assoc {δ : Type*} {mδ : MeasurableSpace δ} (ξ : Kernel γ δ)
 
 lemma comp_discard' (κ : Kernel α β) :
     discard β ∘ₖ κ =
-      { toFun a := κ a .univ • Measure.dirac ()
+      { toFun a := κ a .univ • Measure.dirac PUnit.unit
         measurable' := (κ.measurable_coe .univ).smul_measure _ } := by
   ext a s hs
   simp [comp_apply' _ _ _ hs, mul_comm]

--- a/Mathlib/Probability/Kernel/Composition/Comp.lean
+++ b/Mathlib/Probability/Kernel/Composition/Comp.lean
@@ -147,7 +147,7 @@ theorem comp_assoc {δ : Type*} {mδ : MeasurableSpace δ} (ξ : Kernel γ δ)
 
 lemma comp_discard' (κ : Kernel α β) :
     discard β ∘ₖ κ =
-      { toFun a := κ a .univ • Measure.dirac PUnit.unit
+      { toFun a := κ a .univ • Measure.dirac default
         measurable' := (κ.measurable_coe .univ).smul_measure _ } := by
   ext a s hs
   simp [comp_apply' _ _ _ hs, mul_comm]

--- a/Mathlib/Probability/Kernel/Composition/Comp.lean
+++ b/Mathlib/Probability/Kernel/Composition/Comp.lean
@@ -147,7 +147,7 @@ theorem comp_assoc {δ : Type*} {mδ : MeasurableSpace δ} (ξ : Kernel γ δ)
 
 lemma comp_discard' (κ : Kernel α β) :
     discard β ∘ₖ κ =
-      { toFun a := κ a .univ • Measure.dirac default
+      { toFun a := κ a .univ • Measure.dirac PUnit.unit
         measurable' := (κ.measurable_coe .univ).smul_measure _ } := by
   ext a s hs
   simp [comp_apply' _ _ _ hs, mul_comm]


### PR DESCRIPTION
Make `Kernel.discard` universe-polymorphic. The main purpose is to use this kernel in categories.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
