### PR TITLE
chore(Function): add surjective_iff

### DIFF
--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -63,9 +63,9 @@ theorem bijective_id : Bijective (@id α) :=
 
 variable {f : α → β}
 
-/-- An explicit definitional unfolding for surjectivity. -/
-theorem surjective_def : Surjective f = (∀ b : β, ∃ a : α, f a = b) :=
-  rfl
+/-- An explicit reformulation of surjectivity. -/
+theorem surjective_iff : Surjective f ↔ (∀ b : β, ∃ a : α, f a = b) :=
+  Iff.rfl
 
 theorem Injective.beq_eq {α β : Type*} [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] {f : α → β}
     (I : Injective f) {a b : α} : (f a == f b) = (a == b) := by

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -63,6 +63,10 @@ theorem bijective_id : Bijective (@id α) :=
 
 variable {f : α → β}
 
+/-- An explicit definitional unfolding for surjectivity. -/
+theorem surjective_def : Surjective f = (∀ b : β, ∃ a : α, f a = b) :=
+  rfl
+
 theorem Injective.beq_eq {α β : Type*} [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] {f : α → β}
     (I : Injective f) {a b : α} : (f a == f b) = (a == b) := by
   by_cases h : a == b <;> simp [h] <;> simpa [I.eq_iff] using h


### PR DESCRIPTION
Adds an explicit discoverable definitional lemma for `Function.Surjective`.

- addresses #31745
- scope is intentionally tiny: one theorem in `Mathlib/Logic/Function/Defs.lean`

AI was used for drafting; I reviewed the final code and understand it well enough to vouch for it.
