### PR TITLE
[Merged by Bors] - feat(Tactic/FastInstance): skip mkAuxTheorem for proof fields when types agree at instances transparency

### DIFF
--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -93,11 +93,11 @@ partial def makeFastInstance (inst expectedType : Expr) (trace : Array Name := #
       if ← isProp argExpectedType then
         let actualType ← inferType arg
         if ← withDefault <| isDefEq argExpectedType actualType then
-          -- Only wrap in an aux theorem if the types differ at instances transparency,
-          -- indicating a binder type mismatch that needs fixing.
           if ← withTransparency .instances <| isDefEq argExpectedType actualType then
             mvarId.assign arg
           else
+            -- Wrap in an aux theorem if the types differ at instances transparency,
+            -- indicating a binder type mismatch that needs fixing.
             mvarId.assign <| ← mkAuxTheorem argExpectedType arg (zetaDelta := true)
         else
           throwError "Proof `{arg}` does not have expected type `{argExpectedType}`"

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -91,9 +91,14 @@ partial def makeFastInstance (inst expectedType : Expr) (trace : Array Name := #
       let argExpectedType ← instantiateMVars mvarDecl.type
       let arg := args[i]!
       if ← isProp argExpectedType then
-        -- For proofs, create an auxiliary theorem of the expected type.
-        if ← withDefault <| isDefEq argExpectedType (← inferType arg) then
-          mvarId.assign <| ← mkAuxTheorem argExpectedType arg (zetaDelta := true)
+        let actualType ← inferType arg
+        if ← withDefault <| isDefEq argExpectedType actualType then
+          -- Only wrap in an aux theorem if the types differ at instances transparency,
+          -- indicating a binder type mismatch that needs fixing.
+          if ← withTransparency .instances <| isDefEq argExpectedType actualType then
+            mvarId.assign arg
+          else
+            mvarId.assign <| ← mkAuxTheorem argExpectedType arg (zetaDelta := true)
         else
           throwError "Proof `{arg}` does not have expected type `{argExpectedType}`"
       -- Recurse into instance arguments of the constructor

--- a/MathlibTest/fast_instance.lean
+++ b/MathlibTest/fast_instance.lean
@@ -117,7 +117,7 @@ abbrev dec1 : Decidable It := isTrue sorry
 #guard_msgs in
 def dec2 : Decidable It := isTrue sorry
 
-/-- info: @Dec.mk It (@isTrue It dec2._proof_1) : Dec It -/
+/-- info: @Dec.mk It (@isTrue It dec1._proof_1) : Dec It -/
 #guard_msgs in
 set_option pp.explicit true in
 #check fast_instance% { dec := dec1 : Dec It }

--- a/MathlibTest/fast_instance.lean
+++ b/MathlibTest/fast_instance.lean
@@ -138,3 +138,18 @@ info: @Dec.mk It dec2 : Dec It
 #guard_msgs in
 set_option pp.explicit true in
 #check fast_instance% { dec := dec2 : Dec It }
+
+/-!
+Checking that proof fields whose types already match at instances transparency
+are used directly, without wrapping in an auxiliary theorem.
+-/
+
+class Pointed (α : Type) where
+  val : α
+  h : True
+
+abbrev myPointed : Pointed Nat := ⟨0, trivial⟩
+
+/-- info: { val := 0, h := trivial } : Pointed Nat -/
+#guard_msgs in
+#check fast_instance% (myPointed : Pointed Nat)


### PR DESCRIPTION
This PR improves how \`fast_instance%\` handles proof-valued constructor fields.

Previously, proof fields were always wrapped in \`mkAuxTheorem\`, which creates a separate auxiliary theorem carrying the expected type. This is unnecessary when the proof's actual type already agrees with the expected type at instances transparency — in that case the proof can be assigned directly.

The new behaviour: check whether the proof's type agrees with the expected type at instances transparency. If yes, assign directly. If no (indicating a binder type mismatch), wrap with \`mkAuxTheorem\` as before.

This is a natural analogue of the data-field binder type checking that \`fast_instance%\` already performs, applied to proof fields.

🤖 Prepared with Claude Code