### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology): remove some `set_option linter.flexible false`

### DIFF
--- a/Mathlib/Algebra/Homology/Augment.lean
+++ b/Mathlib/Algebra/Homology/Augment.lean
@@ -202,8 +202,6 @@ def toTruncate [HasZeroObject V] [HasZeroMorphisms V] (C : CochainComplex V ℕ)
 
 variable [HasZeroMorphisms V]
 
--- TODO: fix non-terminal simp (acting on six goals, with different simp sets)
-set_option linter.flexible false in
 /-- We can "augment" a cochain complex by inserting an arbitrary object in degree zero
 (shifting everything else up), along with a suitable differential.
 -/
@@ -215,19 +213,15 @@ def augment (C : CochainComplex V ℕ) {X : V} (f : X ⟶ C.X 0) (w : f ≫ C.d 
     | i + 1, j + 1 => C.d i j
     | _, _ => 0
   shape i j s := by
-    rcases j with (_ | _ | j) <;> cases i <;> try simp
-    · contradiction
-    · rw [C.shape]
-      simp only [ComplexShape.up_Rel] at ⊢ s
-      contrapose! s
-      rw [← s]
+    rcases j with (_ | _ | j) <;> cases i <;> simp_all
   d_comp_d' i j k hij hjk := by
-    rcases k with (_ | _ | k) <;> rcases j with (_ | _ | j) <;> cases i <;> try simp
-    cases k
-    · exact w
-    · rw [C.shape, comp_zero]
-      simp only [ComplexShape.up_Rel, zero_add]
-      exact (Nat.one_lt_succ_succ _).ne
+    have (k : ℕ) : f ≫ C.d 0 (k + 1) = 0 := by
+      cases k
+      · exact w
+      · rw [C.shape, comp_zero]
+        simp only [ComplexShape.up_Rel, zero_add]
+        exact (Nat.one_lt_succ_succ _).ne
+    rcases k with (_ | _ | k) <;> rcases j with (_ | _ | j) <;> cases i <;> simp [this]
 
 @[simp]
 theorem augment_X_zero (C : CochainComplex V ℕ) {X : V} (f : X ⟶ C.X 0) (w : f ≫ C.d 0 1 = 0) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
@@ -56,8 +56,6 @@ def tensorObj (m n : AugmentedSimplexCategory) : AugmentedSimplexCategory :=
   | .star, x => x
   | x, .star => x
 
--- TODO: fix non-terminal simp: run on four different goals with different simp sets
-set_option linter.flexible false in
 /-- The action of the tensor product on maps coming from `SimplexCategory`. -/
 def tensorHomOf {x₁ y₁ x₂ y₂ : SimplexCategory} (f₁ : x₁ ⟶ y₁) (f₂ : x₂ ⟶ y₂) :
     tensorObjOf x₁ x₂ ⟶ tensorObjOf y₁ y₂ :=
@@ -72,11 +70,8 @@ def tensorHomOf {x₁ y₁ x₂ y₂ : SimplexCategory} (f₁ : x₁ ⟶ y₁) (
         cases i using Fin.addCases <;>
         cases j using Fin.addCases <;>
         rw [Fin.le_def] at h ⊢ <;>
-        simp [Fin.addCases_left, Fin.addCases_right] at h ⊢
-        · case left.left i j => exact f₁.toOrderHom.monotone h
-        · case left.right i j => lia
-        · case right.left i j => lia
-        · case right.right i j => exact f₂.toOrderHom.monotone h }
+        simp at h ⊢ <;>
+        grind only [OrderHom.apply_mono] }
   (eqToHom (congrArg _ (Nat.succ_add _ _)).symm ≫ (SimplexCategory.mkHom f₁) ≫
     eqToHom (congrArg _ (Nat.succ_add _ _)) : _ ⟶ ⦋y₁.len + y₂.len + 1⦌)
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
