### PR TITLE
[Merged by Bors] - ci: robustly extract PR numbers in emoji merge delegate workflow

### DIFF
--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -53,4 +53,4 @@ jobs:
           while read -r pr_number; do
             printf $'Running the python script with pr "%s"\n' "${pr_number}"
             python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "none" "${pr_number}"
-          done < <(git log --oneline -n 10 | grep -oP '(?<=\(#)\d+(?=\))')
+          done < <(git log --oneline -n 10 | grep -oP '.*\(#\K\d+(?=\))')

--- a/.github/workflows/zulip_emoji_merge_delegate.yaml
+++ b/.github/workflows/zulip_emoji_merge_delegate.yaml
@@ -53,4 +53,4 @@ jobs:
           while read -r pr_number; do
             printf $'Running the python script with pr "%s"\n' "${pr_number}"
             python "${CI_SCRIPTS_DIR}/zulip/zulip_emoji_reactions.py" "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "[Merged by Bors]" "none" "${pr_number}"
-          done < <(git log --oneline -n 10 | awk -F# '{ gsub(/)$/, ""); print $NF}')
+          done < <(git log --oneline -n 10 | grep -oP '(?<=\(#)\d+(?=\))')


### PR DESCRIPTION
The previous `awk -F# '{ gsub(/)$/, ""); print $NF}'` pipeline was fragile: for commits without a `(#PR)` suffix it passed the entire commit line (hash + message) to the Python script, which crashed when treating that string as a regex pattern.

There should rarely be a commit without a `(#PR)` suffix, as usually commits come via bors, but there's no point leaving this loaded gun lying around.

Replace with `grep -oP '(?<=\(#)\d+(?=\))'` which only emits the digit string from commits that contain the exact `(#NUMBER)` pattern, and silently skips any commit without a PR number.

🤖 Prepared with Claude Code