### PR TITLE
[Merged by Bors] - doc(AlgebraicGeometry): fix typos

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -157,8 +157,8 @@ instance {X : Scheme} [CompactSpace X] : QuasiCompact X.toSpecΓ :=
   HasAffineProperty.iff_of_isAffine.mpr ‹_›
 
 /-
-A quasi-compact scheme over quasi-compact base is also quasi-compact as a topological space.
-For the coverse, see `quasiCompact_of_compactSpace` for the fact that
+A quasi-compact scheme over a quasi-compact base is also quasi-compact as a topological space.
+For the converse, see `quasiCompact_of_compactSpace` for the fact that
 a (topologically) quasi-compact scheme is quasi-compact over a base if the base is quasi-separated.
 -/
 lemma QuasiCompact.compactSpace_of_compactSpace {X Y : Scheme.{u}} (f : X ⟶ Y) [QuasiCompact f]

--- a/Mathlib/AlgebraicGeometry/Sites/SheafQuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/SheafQuasiCompact.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.AlgebraicGeometry.Sites.QuasiCompact
 
 /-!
-# Sheafs for the quasi-compact topology
+# Sheaves for the quasi-compact topology
 
 In this file we show that a presheaf is a sheaf in the `AlgebraicGeometry.Scheme.propQCTopology`
 if and only if it is a sheaf in the Zariski topology and a sheaf on single object


### PR DESCRIPTION
Found by `PyCharm`'s code inspection tool.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
