### PR TITLE
[Merged by Bors] - doc: correct the LLM-hallucinated reference

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
@@ -218,7 +218,7 @@ variable {p : ℕ} {ζ : K}
 
 /-- For a prime `p`, a ℚ-linear combination `∑_{i < p} αᵢ ζⁱ` vanishes if and only if all
 coefficients `αᵢ` are equal. This follows from the irreducibility of the `p`-th cyclotomic
-polynomial. See Washington, *Introduction to Cyclotomic Fields*, Lemma 2.8.5. -/
+polynomial. -/
 lemma sum_eq_zero_iff_forall_eq (hp : p.Prime) (hζ : IsPrimitiveRoot ζ p) (α : Fin p → ℚ) :
     ∑ i, α i * ζ ^ i.val = 0 ↔ ∀ i j, α i = α j := by
   haveI : Fact p.Prime := ⟨hp⟩

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
@@ -218,7 +218,7 @@ variable {p : ℕ} {ζ : K}
 
 /-- For a prime `p`, a ℚ-linear combination `∑_{i < p} αᵢ ζⁱ` vanishes if and only if all
 coefficients `αᵢ` are equal. This follows from the irreducibility of the `p`-th cyclotomic
-polynomial. -/
+polynomial. See de Launey–Flannery, *Algebraic Design Theory*, Lemma 2.8.5. -/
 lemma sum_eq_zero_iff_forall_eq (hp : p.Prime) (hζ : IsPrimitiveRoot ζ p) (α : Fin p → ℚ) :
     ∑ i, α i * ζ ^ i.val = 0 ↔ ∀ i j, α i = α j := by
   haveI : Fact p.Prime := ⟨hp⟩


### PR DESCRIPTION
```lean4
/-- For a prime `p`, a ℚ-linear combination `∑_{i < p} αᵢ ζⁱ` vanishes if and only if all
coefficients `αᵢ` are equal. This follows from the irreducibility of the `p`-th cyclotomic
polynomial. See Washington, *Introduction to Cyclotomic Fields*, Lemma 2.8.5. -/
lemma sum_eq_zero_iff_forall_eq (hp : p.Prime) (hζ : IsPrimitiveRoot ζ p) (α : Fin p → ℚ) :
```

This lemma was introduced in #34592.
According to the author's other PRs (especially #34578), #34592 seems to have been generated by LLM.

This docstring references Lemma 2.8.5 in "Washington, Introduction to Cyclotomic Fields". I checked it on Springer, and found that there is no Lemma 2.8.5.

According to the author's last comment in #34578 and @bryangingechen 's check in this PR, the correct reference is "de Launey–Flannery, Algebraic Design Theory".

So, I correct this LLM-hallucination reference, but I keep the lemma itself since it may be useful. (I don't know much about cyclotomic fields)


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
