### PR TITLE
feat(Order/Filter): add Filter.IsFree and Filter.IsNonprincipal

### DIFF
--- a/Mathlib/Order/Filter/Cofinite.lean
+++ b/Mathlib/Order/Filter/Cofinite.lean
@@ -22,7 +22,12 @@ In this file we define
 
 `Filter.cofinite`: the filter of sets with finite complement
 
-and prove its basic properties. In particular, we prove that for `ℕ` it is equal to `Filter.atTop`.
+`Filter.IsFree`: a filter is *free* if no point belongs to every set in the filter
+
+`Filter.IsNonprincipal`: a filter is *non-principal* if it is not `𝓟 s` for any `s`
+
+and prove their basic properties. In particular, we prove that for `ℕ` the cofinite filter is equal
+to `Filter.atTop`.
 
 ## TODO
 
@@ -104,6 +109,65 @@ theorem le_cofinite_iff_compl_singleton_mem : l ≤ cofinite ↔ ∀ x, {x}ᶜ �
 theorem le_cofinite_iff_eventually_ne : l ≤ cofinite ↔ ∀ x, ∀ᶠ y in l, y ≠ x :=
   le_cofinite_iff_compl_singleton_mem
 
+/-- A filter is *free* (or *non-fixed*) if no point belongs to every set in the filter.
+Equivalently, the filter extends the Fréchet (cofinite) filter; see `isFree_iff_le_cofinite`.
+On finite types, no `NeBot` filter is free; see `not_isFree_of_neBot`. -/
+def IsFree (f : Filter α) : Prop := ∀ a, {a}ᶜ ∈ f
+
+theorem isFree_iff_le_cofinite : l.IsFree ↔ l ≤ cofinite :=
+  le_cofinite_iff_compl_singleton_mem.symm
+
+theorem isFree_iff_ker_eq_empty : l.IsFree ↔ l.ker = ∅ := by
+  constructor
+  · intro h; ext x; simp only [Set.mem_empty_iff_false, iff_false]
+    exact fun hx => absurd (mem_ker.mp hx _ (h x)) (by simp)
+  · intro h x
+    have : x ∉ l.ker := by simp [h]
+    rw [mem_ker] at this; push_neg at this
+    obtain ⟨s, hs, hxs⟩ := this
+    exact mem_of_superset hs fun y hy hya => hxs (hya ▸ hy)
+
+theorem isFree_iff_eventually_ne : l.IsFree ↔ ∀ x, ∀ᶠ y in l, y ≠ x :=
+  isFree_iff_le_cofinite.trans le_cofinite_iff_eventually_ne
+
+theorem IsFree.le_cofinite (h : l.IsFree) : l ≤ cofinite := isFree_iff_le_cofinite.mp h
+theorem IsFree.ker_eq_empty (h : l.IsFree) : l.ker = ∅ := isFree_iff_ker_eq_empty.mp h
+theorem IsFree.eventually_ne (h : l.IsFree) (x : α) : ∀ᶠ y in l, y ≠ x := h x
+theorem IsFree.compl_singleton_mem (h : l.IsFree) (x : α) : {x}ᶜ ∈ l := h x
+
+theorem IsFree.mono {l l' : Filter α} (h : l.IsFree) (hl : l' ≤ l) : l'.IsFree :=
+  isFree_iff_le_cofinite.mpr (hl.trans h.le_cofinite)
+
+@[simp]
+theorem cofinite_isFree [Infinite α] : (cofinite : Filter α).IsFree :=
+  isFree_iff_le_cofinite.mpr le_rfl
+
+theorem not_isFree_of_neBot {α : Type*} [Finite α] {l : Filter α} (hl : l.NeBot) :
+    ¬l.IsFree := by
+  intro h; rw [isFree_iff_le_cofinite, cofinite_eq_bot] at h
+  exact hl.ne (le_bot_iff.mp h)
+
+/-- A filter is *non-principal* if it is not equal to `𝓟 s` for any set `s`.
+
+This is weaker than `IsFree`: every free `NeBot` filter is non-principal, but the converse
+fails in general (e.g. `𝓝 x` in a non-discrete T₁ space is non-principal but not free).
+For ultrafilters the two notions coincide; see `Ultrafilter.isNonprincipal_iff_isFree`. -/
+def IsNonprincipal (f : Filter α) : Prop := ∀ s, f ≠ 𝓟 s
+
+theorem isNonprincipal_iff_ne_principal : l.IsNonprincipal ↔ ∀ s, l ≠ 𝓟 s :=
+  Iff.rfl
+
+theorem isNonprincipal_iff_ker : l.IsNonprincipal ↔ l ≠ 𝓟 l.ker :=
+  ⟨fun h => h l.ker, fun h s hs => h (by rw [hs, ker_principal])⟩
+
+theorem IsFree.isNonprincipal (hf : l.IsFree) (hne : l.NeBot) : l.IsNonprincipal := by
+  intro s hs
+  have : s = ∅ := by rw [← ker_principal s, ← hs]; exact hf.ker_eq_empty
+  subst this; simp at hs; exact hne.ne hs
+
+theorem IsNonprincipal.ne_pure (h : l.IsNonprincipal) (a : α) : l ≠ pure a := by
+  intro ha; exact h {a} (by rw [ha, principal_singleton])
+
 /-- If `α` is a preorder with no top element, then `atTop ≤ cofinite`. -/
 theorem atTop_le_cofinite [Preorder α] [NoTopOrder α] : (atTop : Filter α) ≤ cofinite :=
   le_cofinite_iff_eventually_ne.mpr eventually_ne_atTop
@@ -111,6 +175,12 @@ theorem atTop_le_cofinite [Preorder α] [NoTopOrder α] : (atTop : Filter α) �
 /-- If `α` is a preorder with no bottom element, then `atBot ≤ cofinite`. -/
 theorem atBot_le_cofinite [Preorder α] [NoBotOrder α] : (atBot : Filter α) ≤ cofinite :=
   le_cofinite_iff_eventually_ne.mpr eventually_ne_atBot
+
+theorem atTop_isFree [Preorder α] [NoTopOrder α] : (atTop : Filter α).IsFree :=
+  isFree_iff_le_cofinite.mpr atTop_le_cofinite
+
+theorem atBot_isFree [Preorder α] [NoBotOrder α] : (atBot : Filter α).IsFree :=
+  isFree_iff_le_cofinite.mpr atBot_le_cofinite
 
 theorem comap_cofinite_le (f : α → β) : comap f cofinite ≤ cofinite :=
   le_cofinite_iff_eventually_ne.mpr fun x =>

--- a/Mathlib/Order/Filter/Ultrafilter/Basic.lean
+++ b/Mathlib/Order/Filter/Ultrafilter/Basic.lean
@@ -63,6 +63,30 @@ theorem le_cofinite_or_eq_pure (f : Ultrafilter α) : (f : Filter α) ≤ cofini
     let ⟨a, _, hf⟩ := eq_pure_of_finite_mem hfin hs
     ⟨a, hf⟩
 
+theorem isFree_iff_not_exists_eq_pure (f : Ultrafilter α) :
+    (f : Filter α).IsFree ↔ ¬∃ a, f = pure a := by
+  rw [Filter.isFree_iff_le_cofinite]
+  exact ⟨fun h ⟨a, ha⟩ => by
+    have : ({a}ᶜ : Set α) ∈ f := h (finite_singleton a).compl_mem_cofinite
+    simp [ha] at this,
+    fun h => (le_cofinite_or_eq_pure f).resolve_right h⟩
+
+/-- An ultrafilter is free (non-principal) iff it is not `pure a` for any `a`. -/
+theorem isFree_iff_forall_ne_pure (f : Ultrafilter α) :
+    (f : Filter α).IsFree ↔ ∀ a, f ≠ pure a := by
+  rw [isFree_iff_not_exists_eq_pure]; push_neg; rfl
+
+/-- For ultrafilters, non-principal and free coincide: an ultrafilter is either `pure a`
+(a principal filter) or free (extends the cofinite filter). -/
+theorem isNonprincipal_iff_isFree (f : Ultrafilter α) :
+    (f : Filter α).IsNonprincipal ↔ (f : Filter α).IsFree := by
+  constructor
+  · intro h
+    rw [isFree_iff_forall_ne_pure]
+    exact fun a ha => h.ne_pure a (congrArg Ultrafilter.toFilter ha)
+  · intro h
+    exact h.isNonprincipal f.neBot
+
 theorem exists_ultrafilter_of_finite_inter_nonempty (S : Set (Set α))
     (cond : ∀ T : Finset (Set α), (↑T : Set (Set α)) ⊆ S → (⋂₀ (↑T : Set (Set α))).Nonempty) :
     ∃ F : Ultrafilter α, S ⊆ F.sets :=
@@ -122,6 +146,9 @@ alias _root_.Set.Finite.compl_mem_hyperfilter := compl_mem_hyperfilter_of_finite
 
 theorem mem_hyperfilter_of_finite_compl {s : Set α} (hf : Set.Finite sᶜ) : s ∈ hyperfilter α :=
   compl_compl s ▸ hf.compl_mem_hyperfilter
+
+theorem hyperfilter_isFree : (hyperfilter α : Filter α).IsFree :=
+  Filter.isFree_iff_le_cofinite.mpr hyperfilter_le_cofinite
 
 end Hyperfilter
 


### PR DESCRIPTION
## Summary

Adds two filter predicates and their basic API:

- **`Filter.IsFree`**: no point belongs to every set (`f.ker = ∅`), equivalently `f ≤ cofinite`
- **`Filter.IsNonprincipal`**: not equal to `𝓟 s` for any set `s`

Every free `NeBot` filter is non-principal (`IsFree.isNonprincipal`), but the converse fails for general filters (e.g. `𝓝 x` in a non-discrete T₁ space is non-principal but not free). For ultrafilters the two notions coincide (`Ultrafilter.isNonprincipal_iff_isFree`).

On finite types, no `NeBot` filter is free (`not_isFree_of_neBot`).

## Test plan

- [x] `lake build Mathlib.Order.Filter.Cofinite` passes
- [x] `lake build Mathlib.Order.Filter.Ultrafilter.Basic` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)