### PR TITLE
[Merged by Bors] - feat(Algebra/MonoidAlgebra): explicit conversion functions to/from `Finsupp`

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -105,19 +105,19 @@ variable [Semiring R] {x y : R[M]} {r r₁ r₂ : R} {m m' m₁ m₂ : M}
 
 /-- Construct an element of the monoid algebra `R[M]` from its coefficients `M →₀ R`. -/
 @[to_additive
-/-- Construct an element of the additive monoid algebra `R[M]` from its coefficients `M →₀ R`. -/ ]
-def ofCoeff : (M →₀ R) → R[M] := id
+/-- Construct an element of the additive monoid algebra `R[M]` from its coefficients `M →₀ R`. -/]
+def ofCoeff (x : M →₀ R) : R[M] := x
 
 /-- The coefficients `M →₀ R` of an element of the monoid algebra `R[M]`. -/
 @[to_additive
 /-- The coefficients `M →₀ R` of an element of the additive monoid algebra `R[M]`. -/]
-def coeff : R[M] → M →₀ R := id
+def coeff (x : R[M]) : M →₀ R := x
 
 @[to_additive (attr := simp)] lemma coeff_ofCoeff (x : M →₀ R) : coeff (ofCoeff x) = x := rfl
 @[to_additive (attr := simp)] lemma ofCoeff_coeff (x : R[M]) : ofCoeff x.coeff = x := rfl
 
 /-- `MonoidAlgebra.coeff` as an equiv. -/
-@[to_additive (attr := simps! apply symm_apply)
+@[to_additive (attr := simps apply symm_apply)
 /-- `AddMonoidAlgebra.coeff` as an equiv. -/]
 def coeffEquiv : R[M] ≃ (M →₀ R) where
   toFun := coeff
@@ -158,6 +158,7 @@ lemma ofCoeff_inj {x y : M →₀ R} : ofCoeff x = ofCoeff y ↔ x = y := ofCoef
 @[to_additive] instance instIsCancelAdd [IsCancelAdd R] : IsCancelAdd R[M] :=
   inferInstanceAs <| IsCancelAdd <| M →₀ R
 
+-- TODO: Replace this with `coeff`. See https://github.com/leanprover-community/mathlib4/pull/36746
 @[to_additive] instance instCoeFun : CoeFun R[M] fun _ ↦ M → R :=
   inferInstanceAs <| CoeFun (M →₀ R) fun _ ↦ M → R
 
@@ -222,7 +223,13 @@ variable {A : Type*} [SMulZeroClass A R]
 instance smulZeroClass : SMulZeroClass A R[M] :=
   Finsupp.smulZeroClass
 
-@[to_additive (attr := simp) (dont_translate := A) coeff_smul]
+@[to_additive (dont_translate := A) (attr := simp) coeff_smul]
+lemma coeff_smul (a : A) (x : R[M]) : coeff (a • x) = a • coeff x := rfl
+
+@[to_additive (dont_translate := A) (attr := simp) ofCoeff_smul]
+lemma ofCoeff_smul (a : A) (x : M →₀ R) : ofCoeff (a • x) = a • ofCoeff x := rfl
+
+@[to_additive (attr := simp) (dont_translate := A) smul_apply]
 lemma smul_apply (a : A) (x : R[M]) (m : M) : (a • x) m = a • x m := rfl
 
 @[to_additive (attr := simp) (dont_translate := A) smul_single]
@@ -666,6 +673,18 @@ variable [Ring R]
 @[to_additive (dont_translate := R)]
 instance addCommGroup : AddCommGroup R[M] :=
   inferInstanceAs <| AddCommGroup <| M →₀ R
+
+@[to_additive (attr := simp)]
+lemma coeff_neg (x : R[M]) : coeff (-x) = -coeff x := rfl
+
+@[to_additive (attr := simp)]
+lemma ofCoeff_neg (x : M →₀ R) : ofCoeff (-x) = -ofCoeff x := rfl
+
+@[to_additive (attr := simp)]
+lemma coeff_sub (x y : R[M]) : coeff (x - y) = coeff x - coeff y := rfl
+
+@[to_additive (attr := simp)]
+lemma ofCoeff_sub (x y : M →₀ R) : ofCoeff (x - y) = ofCoeff x - ofCoeff y := rfl
 
 @[to_additive (attr := simp) (dont_translate := R)]
 lemma neg_apply (m : M) (x : R[M]) : (-x) m = -x m := rfl

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
 -/
 module
 
+public import Mathlib.Algebra.GroupWithZero.Action.TransferInstance
 public import Mathlib.Algebra.Module.Defs
 public import Mathlib.Data.Finsupp.Basic
 public import Mathlib.Data.Finsupp.SMulWithZero
@@ -42,6 +43,12 @@ When the domain is multiplicative, e.g. a group, this will be used to define the
 We introduce the notation `R[M]` for both `MonoidAlgebra R M` and `AddMonoidAlgebra R M`.
 The notations are scoped to their respective namespaces, and which one `R[M]` resolves to therefore
 depends on which of the two namespaces is open.
+
+## TODO
+
+Use `coeff`/`ofCoeff` more widely. See
+https://github.com/leanprover-community/mathlib4/pull/36746
+https://github.com/leanprover-community/mathlib4/pull/25273
 -/
 
 @[expose] public section
@@ -96,6 +103,46 @@ meta def unexpander : Lean.PrettyPrinter.Unexpander
 section Semiring
 variable [Semiring R] {x y : R[M]} {r r₁ r₂ : R} {m m' m₁ m₂ : M}
 
+/-- Construct an element of the monoid algebra `R[M]` from its coefficients `M →₀ R`. -/
+@[to_additive
+/-- Construct an element of the additive monoid algebra `R[M]` from its coefficients `M →₀ R`. -/ ]
+def ofCoeff : (M →₀ R) → R[M] := id
+
+/-- The coefficients `M →₀ R` of an element of the monoid algebra `R[M]`. -/
+@[to_additive
+/-- The coefficients `M →₀ R` of an element of the additive monoid algebra `R[M]`. -/]
+def coeff : R[M] → M →₀ R := id
+
+@[to_additive (attr := simp)] lemma coeff_ofCoeff (x : M →₀ R) : coeff (ofCoeff x) = x := rfl
+@[to_additive (attr := simp)] lemma ofCoeff_coeff (x : R[M]) : ofCoeff x.coeff = x := rfl
+
+/-- `MonoidAlgebra.coeff` as an equiv. -/
+@[to_additive (attr := simps! apply symm_apply)
+/-- `AddMonoidAlgebra.coeff` as an equiv. -/]
+def coeffEquiv : R[M] ≃ (M →₀ R) where
+  toFun := coeff
+  invFun := ofCoeff
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+@[to_additive] lemma «forall» {P : R[M] → Prop} : (∀ p, P p) ↔ ∀ q, P (ofCoeff q) :=
+  coeffEquiv.forall_congr_left
+
+@[to_additive] lemma «exists» {P : R[M] → Prop} : (∃ p, P p) ↔ ∃ q, P (ofCoeff q) :=
+  coeffEquiv.exists_congr_left
+
+@[to_additive]
+lemma coeff_injective : (coeff : R[M] → M →₀ R).Injective := coeffEquiv.injective
+
+@[to_additive]
+lemma ofCoeff_injective : (ofCoeff : (M →₀ R) → R[M]).Injective := coeffEquiv.symm.injective
+
+@[to_additive (attr := simp)]
+lemma coeff_inj : x.coeff = y.coeff ↔ x = y := coeff_injective.eq_iff
+
+@[to_additive]
+lemma ofCoeff_inj {x y : M →₀ R} : ofCoeff x = ofCoeff y ↔ x = y := ofCoeff_injective.eq_iff
+
 @[to_additive] instance inhabited : Inhabited R[M] :=
   inferInstanceAs <| Inhabited <| M →₀ R
 
@@ -117,6 +164,39 @@ variable [Semiring R] {x y : R[M]} {r r₁ r₂ : R} {m m' m₁ m₂ : M}
 /-- A copy of `Finsupp.ext` for `MonoidAlgebra`. -/
 @[to_additive (attr := ext) /-- A copy of `Finsupp.ext` for `AddMonoidAlgebra`. -/]
 lemma ext ⦃f g : R[M]⦄ (hfg : ∀ m, f m = g m) : f = g := Finsupp.ext hfg
+
+/-- `MonoidAlgebra.coeff` as an `AddEquiv`. -/
+@[to_additive (attr := simps! apply symm_apply)
+/-- `AddMonoidAlgebra.coeff` as an `AddEquiv`. -/]
+def coeffAddEquiv : R[M] ≃+ (M →₀ R) := coeffEquiv.addEquiv
+
+@[to_additive (attr := simp)] lemma coeff_zero : coeff (0 : R[M]) = 0 := rfl
+@[to_additive (attr := simp)] lemma ofCoeff_zero : (ofCoeff 0 : R[M]) = 0 := rfl
+@[to_additive (attr := simp)] lemma coeff_eq_zero : coeff x = 0 ↔ x = 0 := coeff_inj
+@[to_additive (attr := simp)] lemma ofCoeff_eq_zero {x : M →₀ R} : ofCoeff x = 0 ↔ x = 0 :=
+  ofCoeff_inj
+
+@[to_additive (attr := simp)]
+lemma coeff_add (x y : R[M]) : coeff (x + y) = coeff x + coeff y := rfl
+
+@[to_additive (attr := simp)]
+lemma ofCoeff_add (x y : M →₀ R) : ofCoeff (x + y) = ofCoeff x + ofCoeff y := rfl
+
+@[to_additive (attr := simp)]
+lemma coeff_sum (s : Finset ι) (f : ι → R[M]) :
+    coeff (∑ i ∈ s, f i) = ∑ i ∈ s, coeff (f i) := map_sum coeffAddEquiv ..
+
+@[to_additive (attr := simp)]
+lemma ofCoeff_sum (s : Finset ι) (f : ι → M →₀ R) :
+    ofCoeff (∑ i ∈ s, f i) = ∑ i ∈ s, ofCoeff (f i) := map_sum coeffAddEquiv.symm ..
+
+@[to_additive (attr := simp)]
+lemma coeff_finsuppSum [AddCommMonoid N] (f : ι →₀ N) (g : ι → N → R[M]) :
+    coeff (f.sum g) = f.sum (fun i n ↦ coeff (g i n)) := map_finsuppSum coeffAddEquiv ..
+
+@[to_additive (attr := simp)]
+lemma ofCoeff_finsuppSum [AddCommMonoid N] (f : ι →₀ N) (g : ι → N → M →₀ R) :
+    ofCoeff (f.sum g) = f.sum (fun i n ↦ ofCoeff (g i n)) := map_finsuppSum coeffAddEquiv.symm ..
 
 -- TODO: This definition is very leaky, and we later have frequent problems conflating the two
 -- versions of `single`. Perhaps someone wants to try making this a `def` rather than an `abbrev`?

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -582,7 +582,7 @@ theorem coeff_add (m : σ →₀ ℕ) (p q : MvPolynomial σ R) : coeff m (p + q
 @[simp]
 theorem coeff_smul {S₁ : Type*} [SMulZeroClass S₁ R] (m : σ →₀ ℕ) (C : S₁) (p : MvPolynomial σ R) :
     coeff m (C • p) = C • coeff m p :=
-  smul_apply C p m
+  AddMonoidAlgebra.smul_apply C p m
 
 @[simp]
 theorem coeff_zero (m : σ →₀ ℕ) : coeff m (0 : MvPolynomial σ R) = 0 :=

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -312,7 +312,7 @@ theorem trunc_C_mul_T (n : ℤ) (r : R) : trunc (C r * T n) = ite (0 ≤ n) (mon
   · rw [toFinsupp_inj]
     ext a
     have : a ≠ n := by lia
-    simp only [coeff_ofFinsupp, comapDomain_apply, Int.ofNat_eq_natCast, coeff_zero,
+    simp only [coeff_ofFinsupp, comapDomain_apply, Int.ofNat_eq_natCast, Polynomial.coeff_zero,
       single_eq_of_ne this]
 
 @[simp]


### PR DESCRIPTION
Introduce `coeff : R[M] → M →₀ R` and `ofCoeff : (M →₀ R) → R[M]` as a way to convert explicitly between `MonoidAlgebra` and `Finsupp` and thus avoid defeq abuse.

These will be used more widely in future PRs.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
