### PR TITLE
[Merged by Bors] - doc(AlgebraicTopology/DoldKan): fix typos

### DIFF
--- a/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
@@ -13,17 +13,17 @@ The purpose of this file is to introduce tools which will enable the
 construction of the Dold-Kan equivalence `SimplicialObject C ≌ ChainComplex C ℕ`
 for a pseudoabelian category `C` from the equivalence
 `Karoubi (SimplicialObject C) ≌ Karoubi (ChainComplex C ℕ)` and the two
-equivalences `simplicial_object C ≅ Karoubi (SimplicialObject C)` and
-`ChainComplex C ℕ ≅ Karoubi (ChainComplex C ℕ)`.
+equivalences `SimplicialObject C ≌ Karoubi (SimplicialObject C)` and
+`ChainComplex C ℕ ≌ Karoubi (ChainComplex C ℕ)`.
 
 It is certainly possible to get an equivalence `SimplicialObject C ≌ ChainComplex C ℕ`
 using a composition of the three equivalences above, but then neither the functor
 nor the inverse would have good definitional properties. For example, it would be better
 if the inverse functor of the equivalence was exactly the functor
-`Γ₀ : SimplicialObject C ⥤ ChainComplex C ℕ` which was constructed in `FunctorGamma.lean`.
+`Γ₀ : ChainComplex C ℕ ⥤ SimplicialObject C` which was constructed in `FunctorGamma.lean`.
 
-In this file, given four categories `A`, `A'`, `B`, `B'`, equivalences `eA : A ≅ A'`,
-`eB : B ≅ B'`, `e' : A' ≅ B'`, functors `F : A ⥤ B'`, `G : B ⥤ A` equipped with certain
+In this file, given four categories `A`, `A'`, `B`, `B'`, equivalences `eA : A ≌ A'`,
+`eB : B ≌ B'`, `e' : A' ≌ B'`, functors `F : A ⥤ B'`, `G : B ⥤ A` equipped with certain
 compatibilities, we construct successive equivalences:
 - `equivalence₀` from `A` to `B'`, which is the composition of `eA` and `e'`.
 - `equivalence₁` from `A` to `B'`, with the same inverse functor as `equivalence₀`,
@@ -55,14 +55,14 @@ variable {A A' B B' : Type*} [Category* A] [Category* A'] [Category* B] [Categor
   (eB : B ≌ B') (e' : A' ≌ B') {F : A ⥤ B'} (hF : eA.functor ⋙ e'.functor ≅ F) {G : B ⥤ A}
   (hG : eB.functor ⋙ e'.inverse ≅ G ⋙ eA.functor)
 
-/-- A basic equivalence `A ≅ B'` obtained by composing `eA : A ≅ A'` and `e' : A' ≅ B'`. -/
+/-- A basic equivalence `A ≌ B'` obtained by composing `eA : A ≌ A'` and `e' : A' ≌ B'`. -/
 @[simps! functor inverse unitIso_hom_app]
 def equivalence₀ : A ≌ B' :=
   eA.trans e'
 
 variable {eA} {e'}
 
-/-- An intermediate equivalence `A ≅ B'` whose functor is `F` and whose inverse is
+/-- An intermediate equivalence `A ≌ B'` whose functor is `F` and whose inverse is
 `e'.inverse ⋙ eA.inverse`. -/
 @[simps! functor]
 def equivalence₁ : A ≌ B' := (equivalence₀ eA e').changeFunctor hF
@@ -104,7 +104,7 @@ theorem equivalence₁UnitIso_eq : (equivalence₁ hF).unitIso = equivalence₁U
   ext X
   simp [equivalence₁]
 
-/-- An intermediate equivalence `A ≅ B` obtained as the composition of `equivalence₁` and
+/-- An intermediate equivalence `A ≌ B` obtained as the composition of `equivalence₁` and
 the inverse of `eB : B ≌ B'`. -/
 @[simps! functor]
 def equivalence₂ : A ≌ B :=
@@ -155,8 +155,8 @@ theorem equivalence₂UnitIso_eq : (equivalence₂ eB hF).unitIso = equivalence�
 
 variable {eB}
 
-/-- The equivalence `A ≅ B` whose functor is `F ⋙ eB.inverse` and
-whose inverse is `G : B ≅ A`. -/
+/-- The equivalence `A ≌ B` whose functor is `F ⋙ eB.inverse` and
+whose inverse functor is `G : B ⥤ A`. -/
 @[simps! inverse]
 def equivalence : A ≌ B :=
   ((equivalence₂ eB hF).changeInverse

--- a/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
@@ -91,7 +91,7 @@ obtained by composing the previous equivalence with the equivalences
 `Karoubi (ChainComplex C ℕ) ≌ ChainComplex C ℕ`. Instead, we polish this construction
 in `Compatibility.lean` by ensuring good definitional properties of the equivalence (e.g.
 the inverse functor is definitionally equal to
-`Γ₀' : ChainComplex C ℕ ⥤ SimplicialObject C`) and
+`Γ₀ : ChainComplex C ℕ ⥤ SimplicialObject C`, which is induced by `Γ₀'`) and
 showing compatibilities for the unit and counit isomorphisms.
 
 In this file `Equivalence.lean`, assuming the category `A` is abelian, we obtain

--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -60,7 +60,7 @@ of the equivalence `ChainComplex C ℕ ≌ Karoubi (ChainComplex C ℕ)`. -/
 def N [IsIdempotentComplete C] [HasFiniteCoproducts C] : SimplicialObject C ⥤ ChainComplex C ℕ :=
   N₁ ⋙ (toKaroubiEquivalence _).inverse
 
-/-- The functor `Γ` for the equivalence is `Γ'`. -/
+/-- The functor `Γ` for the equivalence is `Γ₀`. -/
 @[simps!, nolint unusedArguments]
 def Γ [IsIdempotentComplete C] [HasFiniteCoproducts C] : ChainComplex C ℕ ⥤ SimplicialObject C :=
   Γ₀


### PR DESCRIPTION
Issues were spotted and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
