### PR TITLE
[Merged by Bors] - feat: add `IsUniformEmbedding.of_comp`

### DIFF
--- a/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
@@ -79,7 +79,7 @@ variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
     [UniformSpace E] [IsUniformAddGroup E] [ContinuousConstSMul K E]
 
 theorem outCLM_isUniformInducing : IsUniformInducing (outCLM K E) := by
-  rw [← isUniformInducing_mk.isUniformInducing_comp_iff, mk_comp_outCLM]
+  rw [← isUniformInducing_mk.of_comp_iff, mk_comp_outCLM]
   exact .id
 
 theorem outCLM_isUniformEmbedding : IsUniformEmbedding (outCLM K E) where

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -425,7 +425,7 @@ instance : T0Space (Closeds α) := by
   exact ⟨(x, y), hxy, y, rfl, hy⟩
 
 theorem isUniformInducing_closure : IsUniformInducing (Closeds.closure (α := α)) :=
-  isUniformEmbedding_coe.isUniformInducing_comp_iff.mp
+  isUniformEmbedding_coe.isUniformInducing.of_comp_iff.mp
     UniformSpace.hausdorff.isUniformInducing_closure
 
 theorem uniformContinuous_closure : UniformContinuous (Closeds.closure (α := α)) :=

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -89,9 +89,8 @@ theorem IsUniformInducing.uniformContinuous_iff {f : α → β} {g : β → γ} 
   dsimp only [UniformContinuous, Tendsto]
   simp only [← hg.comap_uniformity, ← map_le_iff_le_comap, Filter.map_map, Function.comp_def]
 
-protected theorem IsUniformInducing.isUniformInducing_comp_iff {f : α → β} {g : β → γ}
-    (hg : IsUniformInducing g) : IsUniformInducing (g ∘ f) ↔ IsUniformInducing f := by
-  simp only [isUniformInducing_iff, ← hg.comap_uniformity, comap_comap, Function.comp_def]
+@[deprecated (since := "2026-03-17")]
+alias IsUniformInducing.isUniformInducing_comp_iff := IsUniformInducing.of_comp_iff
 
 theorem IsUniformInducing.uniformContinuousOn_iff {f : α → β} {g : β → γ} {S : Set α}
     (hg : IsUniformInducing g) :
@@ -161,6 +160,10 @@ theorem IsUniformEmbedding.comp {g : β → γ} (hg : IsUniformEmbedding g) {f :
 theorem IsUniformEmbedding.of_comp_iff {g : β → γ} (hg : IsUniformEmbedding g) {f : α → β} :
     IsUniformEmbedding (g ∘ f) ↔ IsUniformEmbedding f := by
   simp_rw [isUniformEmbedding_iff, hg.isUniformInducing.of_comp_iff, hg.injective.of_comp_iff f]
+
+theorem IsUniformEmbedding.of_comp {f : α → β} {g : β → γ} (hf : UniformContinuous f)
+    (hg : UniformContinuous g) (hgf : IsUniformEmbedding (g ∘ f)) : IsUniformEmbedding f :=
+  ⟨.of_comp hf hg hgf.isUniformInducing, .of_comp hgf.injective⟩
 
 theorem Equiv.isUniformEmbedding {α β : Type*} [UniformSpace α] [UniformSpace β] (f : α ≃ β)
     (h₁ : UniformContinuous f) (h₂ : UniformContinuous f.symm) : IsUniformEmbedding f :=
@@ -521,7 +524,7 @@ theorem UniformContinuous.rangeFactorization {f : α → β} (hf : UniformContin
 @[simp]
 theorem isUniformInducing_rangeFactorization_iff {f : α → β} :
     IsUniformInducing (rangeFactorization f) ↔ IsUniformInducing f :=
-  (isUniformInducing_val (range f)).isUniformInducing_comp_iff.symm
+  (isUniformInducing_val (range f)).of_comp_iff.symm
 
 theorem IsUniformInducing.rangeFactorization {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (rangeFactorization f) :=
@@ -592,7 +595,7 @@ lemma IsDenseInducing.isUniformInducing_extend {γ : Type*} [UniformSpace γ]
     funext x
     simpa using (hid.inseparable_extend h.uniformContinuous.continuous.continuousAt)
   suffices Subtype.val ∘ fwd = SeparationQuotient.mk ∘ hid.extend f by
-    rw [← SeparationQuotient.isUniformInducing_mk.isUniformInducing_comp_iff, ← this]
+    rw [← SeparationQuotient.isUniformInducing_mk.of_comp_iff, ← this]
     exact (isUniformInducing_val _).comp hfu
   rw [← coe_comp_rangeFactorization (SeparationQuotient.mk ∘ hid.extend f),
     ← val_comp_inclusion hrr, Function.comp_assoc, Subtype.val_injective.comp_left.eq_iff]


### PR DESCRIPTION
Also deprecate `IsUniformInducing.isUniformInducing_comp_iff` in favor of the existing `IsUniformInducing.of_comp_iff`, which is a more standard name.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
