### PR TITLE
chore: replace long terminal `rw […]`:s (≥4 lemmas) with bare `simp`:s

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Finset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Finset.lean
@@ -85,7 +85,7 @@ theorem lcm_singleton {b : β} : ({b} : Finset β).lcm f = normalize (f b) :=
 theorem normalize_lcm : normalize (s.lcm f) = s.lcm f := by simp [lcm_def]
 
 theorem lcm_union [DecidableEq β] : (s₁ ∪ s₂).lcm f = GCDMonoid.lcm (s₁.lcm f) (s₂.lcm f) :=
-  Finset.induction_on s₁ (by rw [empty_union, lcm_empty, lcm_one_left, normalize_lcm])
+  Finset.induction_on s₁ (by simp)
     fun a s _ ih ↦ by rw [insert_union, lcm_insert, lcm_insert, ih, lcm_assoc]
 
 theorem lcm_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀ a ∈ s₂, f a = g a) :
@@ -164,7 +164,7 @@ theorem gcd_singleton {b : β} : ({b} : Finset β).gcd f = normalize (f b) :=
 theorem normalize_gcd : normalize (s.gcd f) = s.gcd f := by simp [gcd_def]
 
 theorem gcd_union [DecidableEq β] : (s₁ ∪ s₂).gcd f = GCDMonoid.gcd (s₁.gcd f) (s₂.gcd f) :=
-  Finset.induction_on s₁ (by rw [empty_union, gcd_empty, gcd_zero_left, normalize_gcd])
+  Finset.induction_on s₁ (by simp)
     fun a s _ ih ↦ by rw [insert_union, gcd_insert, gcd_insert, ih, gcd_assoc]
 
 theorem gcd_congr {f g : β → α} (hs : s₁ = s₂) (hfg : ∀ a ∈ s₂, f a = g a) :

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -571,7 +571,7 @@ theorem derivative_comp (p q : R[X]) :
 /-- Chain rule for formal derivative of polynomials. -/
 theorem derivative_eval₂_C (p q : R[X]) :
     derivative (p.eval₂ C q) = p.derivative.eval₂ C q * derivative q :=
-  Polynomial.induction_on p (fun r => by rw [eval₂_C, derivative_C, eval₂_zero, zero_mul])
+  Polynomial.induction_on p (fun r => by simp)
     (fun p₁ p₂ ih₁ ih₂ => by
       rw [eval₂_add, derivative_add, ih₁, ih₂, derivative_add, eval₂_add, add_mul])
     fun n r ih => by

--- a/Mathlib/Algebra/Polynomial/Expand.lean
+++ b/Mathlib/Algebra/Polynomial/Expand.lean
@@ -80,7 +80,7 @@ theorem expand_one (f : R[X]) : expand R 1 f = f :=
     rw [map_mul, expand_C, map_pow, expand_X, pow_one]
 
 theorem expand_pow (f : R[X]) : expand R (p ^ q) f = (expand R p)^[q] f :=
-  Nat.recOn q (by rw [pow_zero, expand_one, Function.iterate_zero, id]) fun n ih => by
+  Nat.recOn q (by simp) fun n ih => by
     rw [Function.iterate_succ_apply', pow_succ', expand_mul, ih]
 
 theorem derivative_expand (f : R[X]) : Polynomial.derivative (expand R p f) =

--- a/Mathlib/Analysis/Real/Cardinality.lean
+++ b/Mathlib/Analysis/Real/Cardinality.lean
@@ -187,9 +187,9 @@ theorem mk_real : #ℝ = 𝔠 := by
   · rw [Real.equivCauchy.cardinal_eq]
     apply mk_quotient_le.trans
     apply (mk_subtype_le _).trans_eq
-    rw [← power_def, mk_nat, mkRat, aleph0_power_aleph0]
+    simp
   · convert mk_le_of_injective (cantorFunction_injective _ _)
-    · rw [← power_def, mk_bool, mk_nat, two_power_aleph0]
+    · simp
     · exact 1 / 3
     · simp
     · norm_num

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -283,7 +283,7 @@ theorem log_pow (x : ℝ) (n : ℕ) : log (x ^ n) = n * log x := by
 @[simp, push]
 theorem log_zpow (x : ℝ) (n : ℤ) : log (x ^ n) = n * log x := by
   cases n
-  · rw [Int.ofNat_eq_natCast, zpow_natCast, log_pow, Int.cast_natCast]
+  · simp
   · rw [zpow_negSucc, log_inv, log_pow, Int.cast_negSucc, Nat.cast_add_one, neg_mul_eq_neg_mul]
 
 @[push]

--- a/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
@@ -330,8 +330,7 @@ lemma eRk_union_le_eRk_add_encard (M : Matroid α) (X Y : Set α) :
 
 lemma eRank_le_encard_add_eRk_compl (M : Matroid α) (X : Set α) :
     M.eRank ≤ X.encard + M.eRk (M.E \ X) :=
-  le_trans (by rw [← eRk_inter_ground, eRank_def, union_diff_self,
-    union_inter_cancel_right]) (M.eRk_union_le_encard_add_eRk X (M.E \ X))
+  le_trans (by simp) (M.eRk_union_le_encard_add_eRk X (M.E \ X))
 
 end Basic
 

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -263,7 +263,7 @@ variable {α} [DecidableEq ι]
 theorem single_tsub : single i (a - b) = single i a - single i b := by
   ext j
   obtain rfl | h := eq_or_ne j i
-  · rw [tsub_apply, single_eq_same, single_eq_same, single_eq_same]
+  · simp
   · rw [tsub_apply, single_eq_of_ne h, single_eq_of_ne h, single_eq_of_ne h, tsub_self]
 
 variable [∀ (i) (x : α i), Decidable (x ≠ 0)]

--- a/Mathlib/Data/EReal/Inv.lean
+++ b/Mathlib/Data/EReal/Inv.lean
@@ -224,7 +224,7 @@ noncomputable instance : DivInvOneMonoid EReal where
 
 lemma inv_neg (a : EReal) : (-a)⁻¹ = -a⁻¹ := by
   induction a
-  · rw [neg_bot, inv_top, inv_bot, neg_zero]
+  · simp
   · rw [← coe_inv _, ← coe_neg _⁻¹, ← coe_neg _, ← coe_inv (-_)]
     exact EReal.coe_eq_coe_iff.2 _root_.inv_neg
   · rw [neg_top, inv_bot, inv_top, neg_zero]

--- a/Mathlib/Data/Finsupp/Multiset.lean
+++ b/Mathlib/Data/Finsupp/Multiset.lean
@@ -69,7 +69,7 @@ theorem card_toMultiset (f : α →₀ ℕ) : Multiset.card (toMultiset f) = f.s
 theorem toMultiset_map (f : α →₀ ℕ) (g : α → β) :
     f.toMultiset.map g = toMultiset (f.mapDomain g) := by
   refine f.induction ?_ ?_
-  · rw [toMultiset_zero, Multiset.map_zero, mapDomain_zero, toMultiset_zero]
+  · simp
   · intro a n f _ _ ih
     rw [toMultiset_add, Multiset.map_add, ih, mapDomain_add, mapDomain_single,
       toMultiset_single, toMultiset_add, toMultiset_single, ← Multiset.coe_mapAddMonoidHom,

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -268,7 +268,7 @@ theorem tsub_apply (f g : ι →₀ α) (a : ι) : (f - g) a = f a - g a :=
 theorem single_tsub : single i (a - b) = single i a - single i b := by
   ext j
   obtain rfl | h := eq_or_ne j i
-  · rw [tsub_apply, single_eq_same, single_eq_same, single_eq_same]
+  · simp
   · rw [tsub_apply, single_eq_of_ne h, single_eq_of_ne h, single_eq_of_ne h, tsub_self]
 
 theorem support_tsub {f1 f2 : ι →₀ α} : (f1 - f2).support ⊆ f1.support := by

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -283,7 +283,7 @@ theorem countP_eq_countP_filter_add (s) (p q : α → Prop) [DecidablePred p] [D
 theorem countP_map (f : α → β) (s : Multiset α) (p : β → Prop) [DecidablePred p] :
     countP p (map f s) = card (s.filter fun a => p (f a)) := by
   refine Multiset.induction_on s ?_ fun a t IH => ?_
-  · rw [map_zero, countP_zero, filter_zero, card_zero]
+  · simp
   · rw [map_cons, countP_cons, IH, filter_cons, card_add, apply_ite card, card_zero, card_singleton,
       Nat.add_comm]
 

--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -270,7 +270,7 @@ theorem ascFactorial_eq_factorial_mul_choose' (n k : ℕ) :
     n.ascFactorial k = k ! * (n + k - 1).choose k := by
   cases n
   · cases k
-    · rw [ascFactorial_zero, choose_zero_right, factorial_zero, Nat.mul_one]
+    · simp
     · simp only [zero_ascFactorial, Nat.zero_add, succ_sub_succ_eq_sub,
         Nat.sub_zero, choose_succ_self, Nat.mul_zero]
   rw [ascFactorial_eq_factorial_mul_choose]

--- a/Mathlib/Data/Real/Sign.lean
+++ b/Mathlib/Data/Real/Sign.lean
@@ -69,7 +69,7 @@ theorem sign_intCast (z : ℤ) : sign (z : ℝ) = ↑(Int.sign z) := by
   obtain hn | rfl | hp := lt_trichotomy z (0 : ℤ)
   · rw [sign_of_neg (Int.cast_lt_zero.mpr hn), Int.sign_eq_neg_one_of_neg hn, Int.cast_neg,
       Int.cast_one]
-  · rw [Int.cast_zero, sign_zero, Int.sign_zero, Int.cast_zero]
+  · simp
   · rw [sign_of_pos (Int.cast_pos.mpr hp), Int.sign_eq_one_of_pos hp, Int.cast_one]
 
 theorem sign_neg {r : ℝ} : sign (-r) = -sign r := by

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -151,7 +151,7 @@ theorem volume_real_closedBall {a r : ℝ} (hr : 0 ≤ r) :
 @[simp]
 theorem volume_eball (a : ℝ) (r : ℝ≥0∞) : volume (Metric.eball a r) = 2 * r := by
   rcases eq_or_ne r ∞ with (rfl | hr)
-  · rw [Metric.eball_top, volume_univ, two_mul, _root_.top_add]
+  · simp
   · lift r to ℝ≥0 using hr
     rw [Metric.eball_coe, volume_ball, two_mul, ← NNReal.coe_add,
       ENNReal.ofReal_coe_nnreal, ENNReal.coe_add, two_mul]
@@ -162,7 +162,7 @@ alias volume_emetric_ball := volume_eball
 @[simp]
 theorem volume_closedEBall (a : ℝ) (r : ℝ≥0∞) : volume (Metric.closedEBall a r) = 2 * r := by
   rcases eq_or_ne r ∞ with (rfl | hr)
-  · rw [Metric.closedEBall_top, volume_univ, two_mul, _root_.top_add]
+  · simp
   · lift r to ℝ≥0 using hr
     rw [Metric.closedEBall_coe, volume_closedBall, two_mul, ← NNReal.coe_add,
       ENNReal.ofReal_coe_nnreal, ENNReal.coe_add, two_mul]

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -359,7 +359,7 @@ private lemma LFunction_ne_zero_of_not_quadratic_or_ne_one {t : ℝ} (h : χ ^ 2
     h.symm.imp_left <| mul_ne_zero two_ne_zero
   have help (x : ℝ) : ((1 / x) ^ 3 * x ^ 4 * 1 : ℂ) = x := by
     rcases eq_or_ne x 0 with rfl | h
-    · rw [ofReal_zero, zero_pow (by lia), mul_zero, mul_one]
+    · simp
     · rw [one_div, inv_pow, pow_succ _ 3, ← mul_assoc,
         inv_mul_cancel₀ <| pow_ne_zero 3 (ofReal_ne_zero.mpr h), one_mul, mul_one]
   -- put together the various `IsBigO` statements and `norm_LFunction_product_ge_one`

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -362,7 +362,7 @@ theorem hasSum_one_div_nat_pow_mul_cos {k : ℕ} (hk : k ≠ 0) {x : ℝ} (hx : 
     convert
       hasSum_one_div_nat_pow_mul_fourier (by lia : 2 ≤ 2 * k)
         hx using 3
-    · rw [pow_mul (-1 : ℂ), neg_one_sq, one_pow, one_mul]
+    · simp
     · rw [pow_add, pow_one]
       conv_rhs =>
         rw [mul_pow]

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -654,7 +654,7 @@ theorem inv_eq_of_aeval_divX_ne_zero {x : L} {p : K[X]} (aeval_ne : aeval x (div
     x⁻¹ = aeval x (divX p) / (aeval x p - algebraMap _ _ (p.coeff 0)) := by
   rw [inv_eq_iff_eq_inv, inv_div, eq_comm, div_eq_iff, sub_eq_iff_eq_add, mul_comm]
   conv_lhs => rw [← divX_mul_X_add p]
-  · rw [map_add, map_mul, aeval_X, aeval_C]
+  · simp
   · exact aeval_ne
 
 theorem inv_eq_of_root_of_coeff_zero_ne_zero {x : L} {p : K[X]} (aeval_eq : aeval x p = 0)

--- a/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
@@ -485,8 +485,7 @@ theorem AlgebraicIndependent.aeval_comp_mvPolynomialOptionEquivPolynomialAdjoin
     rw [hx.mvPolynomialOptionEquivPolynomialAdjoin_C, aeval_C, Polynomial.aeval_C,
       IsScalarTower.algebraMap_apply R (adjoin R (range x)) A]
   · rintro (⟨⟩ | ⟨i⟩)
-    · rw [hx.mvPolynomialOptionEquivPolynomialAdjoin_X_none, aeval_X, Polynomial.aeval_X,
-        Option.elim]
+    · simp
     · rw [hx.mvPolynomialOptionEquivPolynomialAdjoin_X_some, Polynomial.aeval_C,
         hx.algebraMap_aevalEquiv, aeval_X, aeval_X, Option.elim]
 

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -532,7 +532,7 @@ theorem deriv_mul_eq_opow_omega0_mul {a : Ordinal.{u}} (ha : 0 < a) (b) :
   rw [← funext_iff,
     IsNormal.ext_iff (isNormal_deriv _) (isNormal_mul_right (opow_pos ω ha))]
   refine ⟨?_, fun c h => ?_⟩
-  · rw [bot_eq_zero, deriv_zero_right, nfp_mul_zero, mul_zero]
+  · simp
   · rw [deriv_succ, h]
     exact nfp_mul_opow_omega0_add c ha zero_lt_one (one_le_iff_pos.2 (opow_pos _ ha))
 


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `Finset.lcm_union`: unchanged 🎉
* `Finset.gcd_union`: unchanged 🎉
* `Polynomial.derivative_eval₂_C`: unchanged 🎉
* `Polynomial.expand_pow`: unchanged 🎉
* `Cardinal.mk_real`: unchanged 🎉
* `Real.log_zpow`: unchanged 🎉
* `Matroid.eRank_le_encard_add_eRk_compl`: unchanged 🎉
* `DFinsupp.single_tsub`: unchanged 🎉
* `EReal.inv_neg`: unchanged 🎉
* `Finsupp.toMultiset_map`: unchanged 🎉
* `Finsupp.single_tsub`: unchanged 🎉
* `Multiset.countP_map`: unchanged 🎉
* `Nat.ascFactorial_eq_factorial_mul_choose'`: unchanged 🎉
* `Real.sign_intCast`: unchanged 🎉
* `Real.volume_eball`: unchanged 🎉
* `Real.volume_closedEBall`: unchanged 🎉
* `LFunction_ne_zero_of_not_quadratic_or_ne_one`: 295 ms before, 152 ms after  🎉
* `hasSum_one_div_nat_pow_mul_cos`: unchanged 🎉
* `inv_eq_of_aeval_divX_ne_zero`: unchanged 🎉
* `AlgebraicIndependent.aeval_comp_mvPolynomialOptionEquivPolynomialAdjoin`: unchanged 🎉
* `Ordinal.deriv_mul_eq_opow_omega0_mul`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
