### PR TITLE
feat(RingTheory/UniqueFactorizationDomain): UFD iff height one primes are principal

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -129,96 +129,59 @@ section CommRing
 
 variable [CommRing R]
 
-/-- Given a prime P of finite height ≥ 1, there exists a prime Q of height one contained in P. -/
+/-- Given a prime `P` of finite height ≥ 1, there exists a prime `Q` of height one contained
+in `P`. -/
 lemma exists_height_one_le_of_finite_height
     {P : Ideal R} (h_prime : P.IsPrime) (h_fin : P.FiniteHeight) (hP : P.primeHeight ≥ 1) :
     ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
-  /- If height P is one, then done -/
-  by_cases hP : P.primeHeight = 1
-  · rw[← P.height_eq_primeHeight] at hP
-    use P
-  /- Otherwise, height P > 1 -/
-  have hPgt1 : 1 < P.primeHeight := by
-    rw[lt_iff_le_and_ne]
-    refine ⟨?_, by push_neg at hP; exact hP.symm⟩
-    expose_names; exact le_of_eq_of_le rfl hP_1
-  /- We obtain an element of height 1 preceeding P in PrimeSpectrum R -/
-  obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp hPgt1
-  use Q.asIdeal
-  exact ⟨hQ.1.1, ⟨ Q.2, by rw[Ideal.height_eq_primeHeight]; exact hQ.right ⟩⟩
+  by_cases h1 : P.primeHeight = 1
+  · rw [← P.height_eq_primeHeight] at h1
+    exact ⟨P, le_refl _, h_prime, h1⟩
+  · have hPgt1 : 1 < P.primeHeight := hP.lt_of_ne' h1
+    obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp hPgt1
+    exact ⟨Q.asIdeal, hQ.1.1, Q.2, by rw [Ideal.height_eq_primeHeight]; exact hQ.right⟩
 
 variable [IsDomain R]
 
-/-- Height of non zero prime ideal in a domain is greater than or equal to one. -/
+/-- An ideal of height one is nonzero. -/
+lemma ne_bot_of_height_one {I : Ideal R} (h : I.height = 1) : I ≠ ⊥ :=
+  fun h_bot => by simp [h_bot, Ideal.height_bot] at h
+
+/-- Height of a nonzero prime ideal in a domain is at least one. -/
 public lemma height_ge_one_of_prime_ne_bot
     {P : Ideal R} (h_prime : P.IsPrime) (h_ne : P ≠ ⊥) :
     P.height ≥ 1 := by
-  /- Suppose P is height 0 -/
   by_contra hC
   push_neg at hC
-  rw[ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight] at hC
-  /- Order.height is defined for P : PrimeSpectrum R -/
-  let Pp : PrimeSpectrum R := ⟨ P, h_prime ⟩
-  change Order.height Pp = 0 at hC
-  /- Then P is the zero ideal since R is domain -/
-  rw[Order.height_eq_zero, isMin_iff_eq_bot] at hC
-  have : Pp.asIdeal = ⊥ := by
-    rw[hC]
-    simp only [PrimeSpectrum.asIdeal_bot]
-  exact h_ne this
+  rw [ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight] at hC
+  have hC' : Order.height (⟨P, h_prime⟩ : PrimeSpectrum R) = 0 := hC
+  rw [Order.height_eq_zero, isMin_iff_eq_bot] at hC'
+  exact h_ne (congrArg PrimeSpectrum.asIdeal hC' |>.trans PrimeSpectrum.asIdeal_bot)
 
-/- This following lemma is provided kindly by
-Bianca Viray, Bryan Boehnke, Grant Yang, George Peykanu, Tianshuo Wang, see
-<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93>-/
-/-- UFD implies height one prime principal. -/
+/-
+This following lemma is edited down and refactored from proof first shown kindly to us by
+Bianca Viray, Bryan Boehnke, Grant Yang, George Peykanu, and Tianshuo Wang, see
+<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93>
+-/
+/-- UFD implies every prime ideal of height one is principal. -/
 lemma height_one_prime_principal [UniqueFactorizationMonoid R]
     (q : Ideal R) [hq_prime : q.IsPrime] (hq_height : q.height = 1) :
     ∃ q₀ : R, q = Ideal.span {q₀} := by
-  /- Step 1: q ≠ ⊥ because height q = 1 > 0 -/
-  have hq_ne_bot : q ≠ ⊥ := by
-    intro h
-    rw [h, Ideal.height_bot] at hq_height
-    exact zero_ne_one hq_height
-  /- Step 2: By UFD property, every nonzero prime ideal contains a prime element -/
-  obtain ⟨p, hp_mem, hp_prime⟩ := Ideal.IsPrime.exists_mem_prime_of_ne_bot hq_prime hq_ne_bot
-  /- Step 3: span {p} is a prime ideal since p is prime -/
-  have h_span_prime : (Ideal.span {p}).IsPrime := by
-    rw [Ideal.span_singleton_prime hp_prime.ne_zero]
-    exact hp_prime
-  /- Step 4: span {p} ⊆ q -/
+  obtain ⟨p, hp_mem, hp_prime⟩ :=
+    hq_prime.exists_mem_prime_of_ne_bot (ne_bot_of_height_one hq_height)
+  have h_span_prime : (Ideal.span {p}).IsPrime :=
+    (Ideal.span_singleton_prime hp_prime.ne_zero).mpr hp_prime
   have h_span_le : Ideal.span {p} ≤ q := (Ideal.span_singleton_le_iff_mem (I := q)).mpr hp_mem
-  /- Step 5: span {p} ≠ ⊥ -/
-  have h_span_ne_bot : Ideal.span {p} ≠ ⊥ := by
-    simp only [ne_eq, Ideal.span_singleton_eq_bot]
-    exact hp_prime.ne_zero
-  /- Step 6: Since height q = 1, if span {p} < q, then span {p} has height 0
-  In a domain, height 0 primes are just ⊥, but span {p} ≠ ⊥, contradiction.
-  So span {p} = q. -/
-  have h_eq : Ideal.span {p} = q := by
-    by_contra h_ne
-    have h_lt : Ideal.span {p} < q := lt_of_le_of_ne h_span_le h_ne
-    /- height (span {p}) < height q = 1, so height (span {p}) = 0 -/
-    haveI : (Ideal.span {p}).IsPrime := h_span_prime
-    have hq_ht_ne_top : q.height ≠ ⊤ := by
-      rw [hq_height]
-      exact ENat.one_ne_top
-    haveI : q.FiniteHeight := ⟨Or.inr hq_ht_ne_top⟩
-    haveI : (Ideal.span {p}).FiniteHeight := Ideal.finiteHeight_of_le h_span_le hq_prime.ne_top
-    have h_ht_lt := Ideal.height_strict_mono_of_is_prime h_lt
-    rw [hq_height] at h_ht_lt
-    /- height (span {p}) < 1 means height (span {p}) = 0 -/
-    have h_ht_zero : (Ideal.span {p}).height = 0 := ENat.lt_one_iff_eq_zero.mp h_ht_lt
-    /- span {p} is a minimal prime of R (height 0 prime) -/
-    rw [Ideal.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff] at h_ht_zero
-    /- In a domain, minimalPrimes of (⊥ : Ideal R) is just {⊥} -/
-    have h_span_eq_bot : Ideal.span {p} = ⊥ := by
-      have h_mem : Ideal.span {p} ∈ (⊥ : Ideal R).minimalPrimes := h_ht_zero
-      /- (⊥ : Ideal R).minimalPrimes = minimalPrimes R by definition -/
-      have : (⊥ : Ideal R).minimalPrimes = minimalPrimes R := rfl
-      rw [this, IsDomain.minimalPrimes_eq_singleton_bot] at h_mem
-      exact Set.mem_singleton_iff.mp h_mem
-    exact h_span_ne_bot h_span_eq_bot
-  exact ⟨p, h_eq.symm⟩
+  refine ⟨p, ?_⟩
+  by_contra h_ne
+  have h_lt : Ideal.span {p} < q := h_span_le.lt_of_ne (Ne.symm h_ne)
+  haveI : q.FiniteHeight := ⟨Or.inr (hq_height ▸ ENat.one_ne_top)⟩
+  haveI : (Ideal.span {p}).FiniteHeight := Ideal.finiteHeight_of_le h_span_le hq_prime.ne_top
+  have h_ht_zero : (Ideal.span {p}).height = 0 :=
+    ENat.lt_one_iff_eq_zero.mp (hq_height ▸ Ideal.height_strict_mono_of_is_prime h_lt)
+  rw [Ideal.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff,
+      IsDomain.minimalPrimes_eq_singleton_bot] at h_ht_zero
+  exact hp_prime.ne_zero (Ideal.span_singleton_eq_bot.mp (Set.mem_singleton_iff.mp h_ht_zero))
 
 end CommRing
 
@@ -226,52 +189,29 @@ section IsNoetherianDomain
 
 variable [CommRing R] [IsDomain R] [IsNoetherian R R]
 
-/-- Height one prime is principal implies UFD -/
-public theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
+/-- Every height one prime being principal implies UFD. -/
+theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
     I.height = 1 → ∃ x : R, I = Ideal.span {x}) → UniqueFactorizationMonoid R := by
   intro h
-  rw[iff_exists_prime_mem_of_isPrime]
-  intros I hI_ne hI_prime
-  /- Since R is a domain, height of I is >= 1 -/
+  rw [iff_exists_prime_mem_of_isPrime]
+  intro I hI_ne hI_prime
   have hIge1 : I.height ≥ 1 := height_ge_one_of_prime_ne_bot hI_prime hI_ne
-  /- There exists a height 1 prime ideal I contained in J -/
-  have hJ : ∃ (J : Ideal R), J ≤ I ∧ J.IsPrime ∧ J.height = 1 := by
-    apply exists_height_one_le_of_finite_height
-    · exact Ideal.finiteHeight_of_isNoetherianRing I
-    · rw[I.height_eq_primeHeight] at hIge1
-      exact hIge1
-  rcases hJ with ⟨J, hJI, hJprime, h_height⟩
-  /- By hypothesis J is principal -/
-  have hJ_princ := h J hJprime h_height
-  obtain ⟨x, hx⟩ := hJ_princ
-  /- Since J is height 1, it is not the zero ideal -/
-  have hJ_ne: J ≠ ⊥ := by
-    intro h_bot
-    rw [h_bot, Ideal.height_bot (R := R)] at h_height
-    cases h_height
-  /- Then x is not zero -/
+  obtain ⟨J, hJI, hJprime, h_height⟩ :=
+    exists_height_one_le_of_finite_height hI_prime (Ideal.finiteHeight_of_isNoetherianRing I)
+      (I.height_eq_primeHeight ▸ hIge1)
+  obtain ⟨x, hx⟩ := h J hJprime h_height
   have hx_ne : x ≠ 0 := by
-    intro hx_zero
-    apply hJ_ne
-    rw [hx, hx_zero]
-    exact Ideal.span_singleton_zero
-  /- Then x is prime -/
+    rintro rfl; simp only [Ideal.span_singleton_zero] at hx
+    exact ne_bot_of_height_one h_height hx
   have hx_prime : Prime x := by
-    rw [hx] at hJprime
-    exact (Ideal.span_singleton_prime hx_ne).mp hJprime
-  /- Also x is in J -/
-  have hxJ : x ∈ J := by
-    rw [hx]
-    have hx_set : x ∈ ({x} : Set R) := by aesop
-    exact Ideal.subset_span hx_set
-  /- Then x is in I -/
-  exact ⟨x, hJI hxJ, hx_prime⟩
+    rw [← Ideal.span_singleton_prime hx_ne, ← hx]; exact hJprime
+  exact ⟨x, hJI (hx ▸ Ideal.subset_span (mem_singleton_iff.mpr rfl)), hx_prime⟩
 
 /-- Factoriality criterion: a Noetherian integral domain is a UFD
-if and only if every height one prime is principal -/
+if and only if every height one prime is principal. -/
 public theorem iff_height_one_prime_principal :
     UniqueFactorizationMonoid R ↔ (∀ (I : Ideal R), I.IsPrime →
-    I.height = 1 → ∃ x : R, I = Ideal.span {x}):=
+    I.height = 1 → ∃ x : R, I = Ideal.span {x}) :=
   ⟨fun _ I _ hI_height => height_one_prime_principal I hI_height,
   of_height_one_prime_principal⟩
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -33,6 +33,16 @@ every prime ideal of height one is principal.
 
 See <https://stacks.math.columbia.edu/tag/0AFT> for reference for `iff_height_one_prime_principal`
 
+## Acknowledgements
+
+The proof of `height_one_prime_principal` is based on work by Bianca Viray, Bryan Boehnke,
+Grant Yang, George Peykanu, and Tianshuo Wang; see
+<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93>.
+
+The proof of `height_ge_one_of_prime_ne_bot` is based on work by Brian Nugent.
+
+Thanks to Dora Kassabova and Leopold Mayer for edit suggestions.
+
 -/
 
 variable {R : Type*}
@@ -132,7 +142,7 @@ variable [CommRing R]
 /-- Given a prime `P` of finite height ≥ 1, there exists a prime `Q` of height one contained
 in `P`. -/
 lemma exists_height_one_le_of_finite_height {P : Ideal R} (h_prime : P.IsPrime)
-    (h_fin : P.FiniteHeight) (hP : P.primeHeight ≥ 1) : ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
+    (h_fin : P.FiniteHeight) (hP : 1 ≤ P.primeHeight) : ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
   by_cases h1 : P.primeHeight = 1
   · exact ⟨P, le_rfl, h_prime, P.height_eq_primeHeight ▸ h1⟩
   · obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp (hP.lt_of_ne' h1)
@@ -144,19 +154,15 @@ variable [IsDomain R]
 lemma ne_bot_of_height_one {I : Ideal R} (h : I.height = 1) : I ≠ ⊥ := by
   rintro rfl; simp [Ideal.height_bot] at h
 
-/-This following lemma is edited down from proof provided by Brian Nugent -/
 /-- Height of a nonzero prime ideal in a domain is at least one. -/
 public lemma height_ge_one_of_prime_ne_bot {P : Ideal R} (h_prime : P.IsPrime) (h_ne : P ≠ ⊥) :
-    P.height ≥ 1 := by
+    1 ≤ P.height := by
   by_contra hC
   push_neg at hC
   rw [ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff,
       IsDomain.minimalPrimes_eq_singleton_bot, Set.mem_singleton_iff] at hC
   exact h_ne hC
 
-/- This following lemma is edited down and refactored from proof first shown kindly to us by
-Bianca Viray, Bryan Boehnke, Grant Yang, George Peykanu, and Tianshuo Wang, see
-<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93> -/
 /-- UFD implies every prime ideal of height one is principal. -/
 lemma height_one_prime_principal [UniqueFactorizationMonoid R] (q : Ideal R) [hq_prime : q.IsPrime]
     (hq_height : q.height = 1) : ∃ q₀ : R, q = Ideal.span {q₀} := by
@@ -187,7 +193,7 @@ theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
   intro h
   rw [iff_exists_prime_mem_of_isPrime]
   intro I hI_ne hI_prime
-  have hIge1 : I.height ≥ 1 := height_ge_one_of_prime_ne_bot hI_prime hI_ne
+  have hIge1 : 1 ≤ I.height := height_ge_one_of_prime_ne_bot hI_prime hI_ne
   obtain ⟨J, hJI, hJprime, h_height⟩ :=
     exists_height_one_le_of_finite_height hI_prime (Ideal.finiteHeight_of_isNoetherianRing I)
       (I.height_eq_primeHeight ▸ hIge1)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Riccardo Brasca, Emilie Uthaiwat, Haoming Ning, Brian Nugent
+Authors: Riccardo Brasca, Emilie Uthaiwat, Haoming Ning
 -/
 module
 
@@ -131,57 +131,49 @@ variable [CommRing R]
 
 /-- Given a prime `P` of finite height ≥ 1, there exists a prime `Q` of height one contained
 in `P`. -/
-lemma exists_height_one_le_of_finite_height
-    {P : Ideal R} (h_prime : P.IsPrime) (h_fin : P.FiniteHeight) (hP : P.primeHeight ≥ 1) :
-    ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
+lemma exists_height_one_le_of_finite_height {P : Ideal R} (h_prime : P.IsPrime)
+    (h_fin : P.FiniteHeight) (hP : P.primeHeight ≥ 1) : ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
   by_cases h1 : P.primeHeight = 1
-  · rw [← P.height_eq_primeHeight] at h1
-    exact ⟨P, le_refl _, h_prime, h1⟩
-  · have hPgt1 : 1 < P.primeHeight := hP.lt_of_ne' h1
-    obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp hPgt1
-    exact ⟨Q.asIdeal, hQ.1.1, Q.2, by rw [Ideal.height_eq_primeHeight]; exact hQ.right⟩
+  · exact ⟨P, le_rfl, h_prime, P.height_eq_primeHeight ▸ h1⟩
+  · obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp (hP.lt_of_ne' h1)
+    exact ⟨Q.asIdeal, hQ.1.1, Q.2, Q.asIdeal.height_eq_primeHeight ▸ hQ.right⟩
 
 variable [IsDomain R]
 
 /-- An ideal of height one is nonzero. -/
-lemma ne_bot_of_height_one {I : Ideal R} (h : I.height = 1) : I ≠ ⊥ :=
-  fun h_bot => by simp [h_bot, Ideal.height_bot] at h
+lemma ne_bot_of_height_one {I : Ideal R} (h : I.height = 1) : I ≠ ⊥ := by
+  rintro rfl; simp [Ideal.height_bot] at h
 
+/-This following lemma is edited down from proof provided by Brian Nugent -/
 /-- Height of a nonzero prime ideal in a domain is at least one. -/
-public lemma height_ge_one_of_prime_ne_bot
-    {P : Ideal R} (h_prime : P.IsPrime) (h_ne : P ≠ ⊥) :
+public lemma height_ge_one_of_prime_ne_bot {P : Ideal R} (h_prime : P.IsPrime) (h_ne : P ≠ ⊥) :
     P.height ≥ 1 := by
   by_contra hC
   push_neg at hC
-  rw [ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight] at hC
-  have hC' : Order.height (⟨P, h_prime⟩ : PrimeSpectrum R) = 0 := hC
-  rw [Order.height_eq_zero, isMin_iff_eq_bot] at hC'
-  exact h_ne (congrArg PrimeSpectrum.asIdeal hC' |>.trans PrimeSpectrum.asIdeal_bot)
+  rw [ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff,
+      IsDomain.minimalPrimes_eq_singleton_bot, Set.mem_singleton_iff] at hC
+  exact h_ne hC
 
-/-
-This following lemma is edited down and refactored from proof first shown kindly to us by
+/- This following lemma is edited down and refactored from proof first shown kindly to us by
 Bianca Viray, Bryan Boehnke, Grant Yang, George Peykanu, and Tianshuo Wang, see
-<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93>
--/
+<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93> -/
 /-- UFD implies every prime ideal of height one is principal. -/
-lemma height_one_prime_principal [UniqueFactorizationMonoid R]
-    (q : Ideal R) [hq_prime : q.IsPrime] (hq_height : q.height = 1) :
-    ∃ q₀ : R, q = Ideal.span {q₀} := by
+lemma height_one_prime_principal [UniqueFactorizationMonoid R] (q : Ideal R) [hq_prime : q.IsPrime]
+    (hq_height : q.height = 1) : ∃ q₀ : R, q = Ideal.span {q₀} := by
   obtain ⟨p, hp_mem, hp_prime⟩ :=
     hq_prime.exists_mem_prime_of_ne_bot (ne_bot_of_height_one hq_height)
-  have h_span_prime : (Ideal.span {p}).IsPrime :=
-    (Ideal.span_singleton_prime hp_prime.ne_zero).mpr hp_prime
+  haveI : (Ideal.span {p}).IsPrime := (Ideal.span_singleton_prime hp_prime.ne_zero).mpr hp_prime
   have h_span_le : Ideal.span {p} ≤ q := (Ideal.span_singleton_le_iff_mem (I := q)).mpr hp_mem
   refine ⟨p, ?_⟩
   by_contra h_ne
-  have h_lt : Ideal.span {p} < q := h_span_le.lt_of_ne (Ne.symm h_ne)
   haveI : q.FiniteHeight := ⟨Or.inr (hq_height ▸ ENat.one_ne_top)⟩
   haveI : (Ideal.span {p}).FiniteHeight := Ideal.finiteHeight_of_le h_span_le hq_prime.ne_top
-  have h_ht_zero : (Ideal.span {p}).height = 0 :=
-    ENat.lt_one_iff_eq_zero.mp (hq_height ▸ Ideal.height_strict_mono_of_is_prime h_lt)
+  have h_ht_zero : (Ideal.span {p}).height = 0 := ENat.lt_one_iff_eq_zero.mp
+    (hq_height ▸ Ideal.height_strict_mono_of_is_prime (h_span_le.lt_of_ne (Ne.symm h_ne)))
   rw [Ideal.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff,
-      IsDomain.minimalPrimes_eq_singleton_bot] at h_ht_zero
-  exact hp_prime.ne_zero (Ideal.span_singleton_eq_bot.mp (Set.mem_singleton_iff.mp h_ht_zero))
+      IsDomain.minimalPrimes_eq_singleton_bot, Set.mem_singleton_iff,
+      Ideal.span_singleton_eq_bot] at h_ht_zero
+  exact hp_prime.ne_zero h_ht_zero
 
 end CommRing
 
@@ -201,19 +193,16 @@ theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
       (I.height_eq_primeHeight ▸ hIge1)
   obtain ⟨x, hx⟩ := h J hJprime h_height
   have hx_ne : x ≠ 0 := by
-    rintro rfl; simp only [Ideal.span_singleton_zero] at hx
-    exact ne_bot_of_height_one h_height hx
-  have hx_prime : Prime x := by
-    rw [← Ideal.span_singleton_prime hx_ne, ← hx]; exact hJprime
-  exact ⟨x, hJI (hx ▸ Ideal.subset_span (mem_singleton_iff.mpr rfl)), hx_prime⟩
+    rintro rfl
+    exact ne_bot_of_height_one h_height (hx.trans Ideal.span_singleton_zero)
+  exact ⟨x, hJI (hx ▸ Ideal.subset_span (mem_singleton_iff.mpr rfl)),
+    (Ideal.span_singleton_prime hx_ne).mp (hx ▸ hJprime)⟩
 
 /-- Factoriality criterion: a Noetherian integral domain is a UFD
 if and only if every height one prime is principal. -/
-public theorem iff_height_one_prime_principal :
-    UniqueFactorizationMonoid R ↔ (∀ (I : Ideal R), I.IsPrime →
-    I.height = 1 → ∃ x : R, I = Ideal.span {x}) :=
-  ⟨fun _ I _ hI_height => height_one_prime_principal I hI_height,
-  of_height_one_prime_principal⟩
+public theorem iff_height_one_prime_principal : UniqueFactorizationMonoid R ↔
+    (∀ (I : Ideal R), I.IsPrime → I.height = 1 → ∃ x : R, I = Ideal.span {x}) :=
+  ⟨fun _ I _ hI_height => height_one_prime_principal I hI_height, of_height_one_prime_principal⟩
 
 end IsNoetherianDomain
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -207,8 +207,9 @@ theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
 /-- Factoriality criterion: a Noetherian integral domain is a UFD
 if and only if every height one prime is principal. -/
 public theorem iff_height_one_prime_principal : UniqueFactorizationMonoid R ↔
-    (∀ (I : Ideal R), I.IsPrime → I.height = 1 → ∃ x : R, I = Ideal.span {x}) :=
-  ⟨fun _ I _ hI_height => height_one_prime_principal I hI_height, of_height_one_prime_principal⟩
+    (∀ (I : Ideal R), I.IsPrime → I.height = 1 → I.IsPrincipal) :=
+  ⟨fun _ I _ hI_height => ⟨height_one_prime_principal I hI_height⟩,
+    fun h => of_height_one_prime_principal (fun I hI hH => (h I hI hH).principal)⟩
 
 end IsNoetherianDomain
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -1,12 +1,15 @@
 /-
 Copyright (c) 2025 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Riccardo Brasca, Emilie Uthaiwat
+Authors: Riccardo Brasca, Emilie Uthaiwat, Haoming Ning, Brian Nugent
 -/
 module
 
 public import Mathlib.RingTheory.UniqueFactorizationDomain.Basic
 public import Mathlib.RingTheory.UniqueFactorizationDomain.Ideal
+public import Mathlib.RingTheory.Ideal.Height
+public import Mathlib.RingTheory.Ideal.Maximal
+public import Mathlib.RingTheory.Ideal.KrullsHeightTheorem
 
 /-!
 
@@ -15,10 +18,20 @@ public import Mathlib.RingTheory.UniqueFactorizationDomain.Ideal
 We prove Kaplansky criterion for factoriality: an integral domain is a UFD if and only if every
 nonzero prime ideal contains a prime element.
 
+We prove a closely related criterion for factoriality: a Noetherian integral domain is a UFD
+if and only if every prime ideal of height one is principal.
+
 ## Main declarations
 
 `iff_exists_prime_mem_of_isPrime`: an integral domain is a UFD if and only if every nonzero prime
 ideal contains a prime element.
+
+`iff_height_one_prime_principal`: a Noetherian integral domain is a UFD if and only if
+every prime ideal of height one is principal.
+
+## References
+
+See <https://stacks.math.columbia.edu/tag/0AFT> for reference for `iff_height_one_prime_principal`
 
 -/
 
@@ -111,5 +124,157 @@ public theorem iff_exists_prime_mem_of_isPrime :
     fun H ↦ of_exists_prime_mem_of_isPrime H⟩
 
 end IsDomain
+
+section CommRing
+
+variable [CommRing R]
+
+/-- Given a prime P of finite height ≥ 1, there exists a prime Q of height one contained in P. -/
+lemma exists_height_one_le_of_finite_height
+    {P : Ideal R} (h_prime : P.IsPrime) (h_fin : P.FiniteHeight) (hP : P.primeHeight ≥ 1) :
+    ∃ Q ≤ P, Q.IsPrime ∧ Q.height = 1 := by
+  /- If height P is one, then done -/
+  by_cases hP : P.primeHeight = 1
+  · rw[← P.height_eq_primeHeight] at hP
+    use P
+  /- Otherwise, height P > 1 -/
+  have hPgt1 : 1 < P.primeHeight := by
+    rw[lt_iff_le_and_ne]
+    refine ⟨?_, by push_neg at hP; exact hP.symm⟩
+    expose_names; exact le_of_eq_of_le rfl hP_1
+  /- We obtain an element of height 1 preceeding P in PrimeSpectrum R -/
+  obtain ⟨Q, hQ⟩ := (Order.coe_lt_height_iff P.primeHeight_lt_top).mp hPgt1
+  use Q.asIdeal
+  exact ⟨hQ.1.1, ⟨ Q.2, by rw[Ideal.height_eq_primeHeight]; exact hQ.right ⟩⟩
+
+variable [IsDomain R]
+
+/-- Height of non zero prime ideal in a domain is greater than or equal to one. -/
+public lemma height_ge_one_of_prime_ne_bot
+    {P : Ideal R} (h_prime : P.IsPrime) (h_ne : P ≠ ⊥) :
+    P.height ≥ 1 := by
+  /- Suppose P is height 0 -/
+  by_contra hC
+  push_neg at hC
+  rw[ENat.lt_one_iff_eq_zero, P.height_eq_primeHeight] at hC
+  /- Order.height is defined for P : PrimeSpectrum R -/
+  let Pp : PrimeSpectrum R := ⟨ P, h_prime ⟩
+  change Order.height Pp = 0 at hC
+  /- Then P is the zero ideal since R is domain -/
+  rw[Order.height_eq_zero, isMin_iff_eq_bot] at hC
+  have : Pp.asIdeal = ⊥ := by
+    rw[hC]
+    simp only [PrimeSpectrum.asIdeal_bot]
+  exact h_ne this
+
+/- This following lemma is provided kindly by
+Bianca Viray, Bryan Boehnke, Grant Yang, George Peykanu, Tianshuo Wang, see
+<https://github.com/uw-math-ai/monogenic-extensions/blob/9a46c352a33af11818cc10f474b383f0a2d6dcac/Monogenic/MonogenicOfNonEtale.lean#L93>-/
+/-- UFD implies height one prime principal. -/
+lemma height_one_prime_principal [UniqueFactorizationMonoid R]
+    (q : Ideal R) [hq_prime : q.IsPrime] (hq_height : q.height = 1) :
+    ∃ q₀ : R, q = Ideal.span {q₀} := by
+  /- Step 1: q ≠ ⊥ because height q = 1 > 0 -/
+  have hq_ne_bot : q ≠ ⊥ := by
+    intro h
+    rw [h, Ideal.height_bot] at hq_height
+    exact zero_ne_one hq_height
+  /- Step 2: By UFD property, every nonzero prime ideal contains a prime element -/
+  obtain ⟨p, hp_mem, hp_prime⟩ := Ideal.IsPrime.exists_mem_prime_of_ne_bot hq_prime hq_ne_bot
+  /- Step 3: span {p} is a prime ideal since p is prime -/
+  have h_span_prime : (Ideal.span {p}).IsPrime := by
+    rw [Ideal.span_singleton_prime hp_prime.ne_zero]
+    exact hp_prime
+  /- Step 4: span {p} ⊆ q -/
+  have h_span_le : Ideal.span {p} ≤ q := (Ideal.span_singleton_le_iff_mem (I := q)).mpr hp_mem
+  /- Step 5: span {p} ≠ ⊥ -/
+  have h_span_ne_bot : Ideal.span {p} ≠ ⊥ := by
+    simp only [ne_eq, Ideal.span_singleton_eq_bot]
+    exact hp_prime.ne_zero
+  /- Step 6: Since height q = 1, if span {p} < q, then span {p} has height 0
+  In a domain, height 0 primes are just ⊥, but span {p} ≠ ⊥, contradiction.
+  So span {p} = q. -/
+  have h_eq : Ideal.span {p} = q := by
+    by_contra h_ne
+    have h_lt : Ideal.span {p} < q := lt_of_le_of_ne h_span_le h_ne
+    /- height (span {p}) < height q = 1, so height (span {p}) = 0 -/
+    haveI : (Ideal.span {p}).IsPrime := h_span_prime
+    have hq_ht_ne_top : q.height ≠ ⊤ := by
+      rw [hq_height]
+      exact ENat.one_ne_top
+    haveI : q.FiniteHeight := ⟨Or.inr hq_ht_ne_top⟩
+    haveI : (Ideal.span {p}).FiniteHeight := Ideal.finiteHeight_of_le h_span_le hq_prime.ne_top
+    have h_ht_lt := Ideal.height_strict_mono_of_is_prime h_lt
+    rw [hq_height] at h_ht_lt
+    /- height (span {p}) < 1 means height (span {p}) = 0 -/
+    have h_ht_zero : (Ideal.span {p}).height = 0 := ENat.lt_one_iff_eq_zero.mp h_ht_lt
+    /- span {p} is a minimal prime of R (height 0 prime) -/
+    rw [Ideal.height_eq_primeHeight, Ideal.primeHeight_eq_zero_iff] at h_ht_zero
+    /- In a domain, minimalPrimes of (⊥ : Ideal R) is just {⊥} -/
+    have h_span_eq_bot : Ideal.span {p} = ⊥ := by
+      have h_mem : Ideal.span {p} ∈ (⊥ : Ideal R).minimalPrimes := h_ht_zero
+      /- (⊥ : Ideal R).minimalPrimes = minimalPrimes R by definition -/
+      have : (⊥ : Ideal R).minimalPrimes = minimalPrimes R := rfl
+      rw [this, IsDomain.minimalPrimes_eq_singleton_bot] at h_mem
+      exact Set.mem_singleton_iff.mp h_mem
+    exact h_span_ne_bot h_span_eq_bot
+  exact ⟨p, h_eq.symm⟩
+
+end CommRing
+
+section IsNoetherianDomain
+
+variable [CommRing R] [IsDomain R] [IsNoetherian R R]
+
+/-- Height one prime is principal implies UFD -/
+public theorem of_height_one_prime_principal : (∀ (I : Ideal R), I.IsPrime →
+    I.height = 1 → ∃ x : R, I = Ideal.span {x}) → UniqueFactorizationMonoid R := by
+  intro h
+  rw[iff_exists_prime_mem_of_isPrime]
+  intros I hI_ne hI_prime
+  /- Since R is a domain, height of I is >= 1 -/
+  have hIge1 : I.height ≥ 1 := height_ge_one_of_prime_ne_bot hI_prime hI_ne
+  /- There exists a height 1 prime ideal I contained in J -/
+  have hJ : ∃ (J : Ideal R), J ≤ I ∧ J.IsPrime ∧ J.height = 1 := by
+    apply exists_height_one_le_of_finite_height
+    · exact Ideal.finiteHeight_of_isNoetherianRing I
+    · rw[I.height_eq_primeHeight] at hIge1
+      exact hIge1
+  rcases hJ with ⟨J, hJI, hJprime, h_height⟩
+  /- By hypothesis J is principal -/
+  have hJ_princ := h J hJprime h_height
+  obtain ⟨x, hx⟩ := hJ_princ
+  /- Since J is height 1, it is not the zero ideal -/
+  have hJ_ne: J ≠ ⊥ := by
+    intro h_bot
+    rw [h_bot, Ideal.height_bot (R := R)] at h_height
+    cases h_height
+  /- Then x is not zero -/
+  have hx_ne : x ≠ 0 := by
+    intro hx_zero
+    apply hJ_ne
+    rw [hx, hx_zero]
+    exact Ideal.span_singleton_zero
+  /- Then x is prime -/
+  have hx_prime : Prime x := by
+    rw [hx] at hJprime
+    exact (Ideal.span_singleton_prime hx_ne).mp hJprime
+  /- Also x is in J -/
+  have hxJ : x ∈ J := by
+    rw [hx]
+    have hx_set : x ∈ ({x} : Set R) := by aesop
+    exact Ideal.subset_span hx_set
+  /- Then x is in I -/
+  exact ⟨x, hJI hxJ, hx_prime⟩
+
+/-- Factoriality criterion: a Noetherian integral domain is a UFD
+if and only if every height one prime is principal -/
+public theorem iff_height_one_prime_principal :
+    UniqueFactorizationMonoid R ↔ (∀ (I : Ideal R), I.IsPrime →
+    I.height = 1 → ∃ x : R, I = Ideal.span {x}):=
+  ⟨fun _ I _ hI_height => height_one_prime_principal I hI_height,
+  of_height_one_prime_principal⟩
+
+end IsNoetherianDomain
 
 end UniqueFactorizationMonoid


### PR DESCRIPTION
We prove that a Noetherian integral domain is a UFD if and only if every prime ideal of height one is principal (`UniqueFactorizationMonoid.iff_height_one_prime_principal`).

## New declarations

* `UniqueFactorizationMonoid.exists_height_one_le_of_finite_height`: given a prime of finite height ≥ 1, there exists a height one prime contained in it.
* `UniqueFactorizationMonoid.ne_bot_of_height_one`: an ideal of height one is nonzero.
* `UniqueFactorizationMonoid.height_ge_one_of_prime_ne_bot`: the height of a nonzero prime ideal in a domain is at least one.
* `UniqueFactorizationMonoid.height_one_prime_principal`: in a UFD, every height one prime is principal.
* `UniqueFactorizationMonoid.of_height_one_prime_principal`: every height one prime being principal implies UFD (Noetherian case).
* `UniqueFactorizationMonoid.iff_height_one_prime_principal`: the full iff statement.

## References

See https://stacks.math.columbia.edu/tag/0AFT


## AI Disclosure

This code is written without AI, then uses Claude Code with cameronfreer's [Lean4-skills](https://github.com/cameronfreer/lean4-skills) (specifically, the `review`, `refactor`, and `golf` workflow) for style changes, refactoring and golfing.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
