### PR TITLE
[Merged by Bors] - fix: replace @[simp] on coe_toWeakDual/coe_toStrongDual with _apply lemmas

### DIFF
--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -107,15 +107,14 @@ def toWeakDual : StrongDual R M ≃ₗ[R] WeakDual R M :=
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.toWeakDual := toWeakDual
 
-theorem coe_toWeakDual (x' : StrongDual R M) : toWeakDual x' = x' :=
-  rfl
+theorem coe_toWeakDual (x' : StrongDual R M) : (toWeakDual x' : M → R) = x' := rfl
 
 @[simp]
-theorem toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' y :=
-  rfl
+theorem toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' y := rfl
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.coe_toWeakDual := coe_toWeakDual
 
+@[simp]
 theorem toWeakDual_inj (x' y' : StrongDual R M) : toWeakDual x' = toWeakDual y' ↔ x' = y' :=
   (LinearEquiv.injective toWeakDual).eq_iff
 
@@ -137,12 +136,11 @@ def toStrongDual : WeakDual 𝕜 E ≃ₗ[𝕜] StrongDual 𝕜 E :=
   StrongDual.toWeakDual.symm
 
 @[simp]
-theorem toStrongDual_apply (x : WeakDual 𝕜 E) (y : E) : (toStrongDual x) y = x y :=
-  rfl
+theorem toStrongDual_apply (x : WeakDual 𝕜 E) (y : E) : (toStrongDual x) y = x y := rfl
 
-theorem coe_toStrongDual (x' : WeakDual 𝕜 E) : toStrongDual x' = x' :=
-  rfl
+theorem coe_toStrongDual (x' : WeakDual 𝕜 E) : (toStrongDual x' : E → 𝕜) = x' := rfl
 
+@[simp]
 theorem toStrongDual_inj (x' y' : WeakDual 𝕜 E) : toStrongDual x' = toStrongDual y' ↔ x' = y' :=
   (LinearEquiv.injective toStrongDual).eq_iff
 

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -107,8 +107,11 @@ def toWeakDual : StrongDual R M ≃ₗ[R] WeakDual R M :=
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.toWeakDual := toWeakDual
 
-@[simp]
 theorem coe_toWeakDual (x' : StrongDual R M) : toWeakDual x' = x' :=
+  rfl
+
+@[simp]
+theorem toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' y :=
   rfl
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.coe_toWeakDual := coe_toWeakDual
@@ -134,10 +137,10 @@ equivalence `StrongDual.toWeakDual` in the other direction. -/
 def toStrongDual : WeakDual 𝕜 E ≃ₗ[𝕜] StrongDual 𝕜 E :=
   StrongDual.toWeakDual.symm
 
+@[simp]
 theorem toStrongDual_apply (x : WeakDual 𝕜 E) (y : E) : (toStrongDual x) y = x y :=
   rfl
 
-@[simp]
 theorem coe_toStrongDual (x' : WeakDual 𝕜 E) : toStrongDual x' = x' :=
   rfl
 

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -114,7 +114,6 @@ theorem toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' 
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.coe_toWeakDual := coe_toWeakDual
 
-@[simp]
 theorem toWeakDual_inj (x' y' : StrongDual R M) : toWeakDual x' = toWeakDual y' ↔ x' = y' :=
   (LinearEquiv.injective toWeakDual).eq_iff
 
@@ -140,7 +139,6 @@ theorem toStrongDual_apply (x : WeakDual 𝕜 E) (y : E) : (toStrongDual x) y = 
 
 theorem coe_toStrongDual (x' : WeakDual 𝕜 E) : (toStrongDual x' : E → 𝕜) = x' := rfl
 
-@[simp]
 theorem toStrongDual_inj (x' y' : WeakDual 𝕜 E) : toStrongDual x' = toStrongDual y' ↔ x' = y' :=
   (LinearEquiv.injective toStrongDual).eq_iff
 

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -116,7 +116,6 @@ theorem toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' 
 
 @[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.Dual.coe_toWeakDual := coe_toWeakDual
 
-@[simp]
 theorem toWeakDual_inj (x' y' : StrongDual R M) : toWeakDual x' = toWeakDual y' ↔ x' = y' :=
   (LinearEquiv.injective toWeakDual).eq_iff
 
@@ -144,7 +143,6 @@ theorem toStrongDual_apply (x : WeakDual 𝕜 E) (y : E) : (toStrongDual x) y = 
 theorem coe_toStrongDual (x' : WeakDual 𝕜 E) : toStrongDual x' = x' :=
   rfl
 
-@[simp]
 theorem toStrongDual_inj (x' y' : WeakDual 𝕜 E) : toStrongDual x' = toStrongDual y' ↔ x' = y' :=
   (LinearEquiv.injective toStrongDual).eq_iff
 


### PR DESCRIPTION
`coe_toWeakDual` and `coe_toStrongDual` stated equalities between bundled maps (`toWeakDual x' = x'`), which is not a useful `simp` normal form. This PR removes `@[simp]` from these lemmas and replaces them with pointwise `_apply` variants:

- `toWeakDual_apply (x' : StrongDual R M) (y : M) : (toWeakDual x') y = x' y`
- `toStrongDual_apply (x : WeakDual k E) (y : E) : (toStrongDual x) y = x y`

These are the correct simp normal form, rewriting function application rather than bundled map equality.
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
