### PR TITLE
[Merged by Bors] - refactor(Combinatorics/SimpleGraph): make the vertex argument explicit in `Walk.rotate`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -803,9 +803,9 @@ theorem adj_and_reachable_delete_edges_iff_exists_cycle {v w : V} :
       intro p
       simpa [Sym2.eq_swap] using hb p.reverse
     have hvc : v ∈ c.support := Walk.fst_mem_support_of_mem_edges c he
-    refine reachable_deleteEdges_iff_exists_cycle.aux hb' (c.rotate hvc) (hc.isTrail.rotate hvc)
+    refine reachable_deleteEdges_iff_exists_cycle.aux hb' (c.rotate v hvc) (hc.isTrail.rotate hvc)
       ?_ (Walk.start_mem_support _)
-    rwa [(Walk.rotate_edges c hvc).mem_iff, Sym2.eq_swap]
+    rwa [(c.rotate_edges v hvc).mem_iff, Sym2.eq_swap]
 
 theorem isBridge_iff_adj_and_forall_cycle_notMem {v w : V} : G.IsBridge s(v, w) ↔
     G.Adj v w ∧ ∀ ⦃u : V⦄ (p : G.Walk u u), p.IsCycle → s(v, w) ∉ p.edges := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -244,7 +244,7 @@ theorem toSubgraph_reverse (p : G.Walk u v) : p.reverse.toSubgraph = p.toSubgrap
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem toSubgraph_rotate [DecidableEq V] (c : G.Walk v v) (h : u ∈ c.support) :
-    (c.rotate h).toSubgraph = c.toSubgraph := by
+    (c.rotate u h).toSubgraph = c.toSubgraph := by
   rw [rotate, toSubgraph_append, sup_comm, ← toSubgraph_append, take_spec]
 
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
@@ -297,30 +297,28 @@ lemma notMem_support_takeUntil_support_takeUntil_subset {p : G.Walk u v} {w x : 
   lia
 
 /-- Rotate a loop walk such that it is centered at the given vertex. -/
-def rotate {u v : V} (c : G.Walk v v) (h : u ∈ c.support) : G.Walk u u :=
+def rotate (c : G.Walk v v) (u : V) (h : u ∈ c.support) : G.Walk u u :=
   (c.dropUntil u h).append (c.takeUntil u h)
 
 @[simp]
-theorem support_rotate {u v : V} (c : G.Walk v v) (h : u ∈ c.support) :
-    (c.rotate h).support.tail ~r c.support.tail := by
+theorem support_rotate (c : G.Walk v v) (u : V) (h) :
+    (c.rotate u h).support.tail ~r c.support.tail := by
   simp only [rotate, tail_support_append]
   apply List.IsRotated.trans List.isRotated_append
   rw [← tail_support_append, take_spec]
 
 @[simp]
-theorem mem_support_rotate_iff (c : G.Walk v v) (h : u ∈ c.support) :
-    w ∈ (c.rotate h).support ↔ w ∈ c.support := by
+theorem mem_support_rotate_iff (c : G.Walk v v) (u : V) (h) :
+    w ∈ (c.rotate u h).support ↔ w ∈ c.support := by
   grind [rotate, take_spec, mem_support_append_iff]
 
-theorem rotate_darts {u v : V} (c : G.Walk v v) (h : u ∈ c.support) :
-    (c.rotate h).darts ~r c.darts := by
+theorem rotate_darts (c : G.Walk v v) (u : V) (h) : (c.rotate u h).darts ~r c.darts := by
   simp only [rotate, darts_append]
   apply List.IsRotated.trans List.isRotated_append
   rw [← darts_append, take_spec]
 
-theorem rotate_edges {u v : V} (c : G.Walk v v) (h : u ∈ c.support) :
-    (c.rotate h).edges ~r c.edges :=
-  (rotate_darts c h).map _
+theorem rotate_edges (c : G.Walk v v) (u : V) (h) : (c.rotate u h).edges ~r c.edges :=
+  (rotate_darts c u h).map _
 
 end WalkDecomp
 

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -264,10 +264,10 @@ theorem not_isHamiltonian_of_isBridge (G : SimpleGraph V)
   have hWalkAllMem :
       ∀ p : G.Walk x y, s(x, y) ∈ p.edges :=
     (SimpleGraph.isBridge_iff_adj_and_forall_walk_mem_edges.mp hbr).2
-  let cX := c.rotate (hcHam.mem_support x)
+  let cX := c.rotate x (hcHam.mem_support x)
   have hcycleX : cX.IsCycle := hcHam.isCycle.rotate (hcHam.mem_support x)
   have he_not_in_cX : s(x, y) ∉ cX.edges :=
-    fun h => he_not_in_cycle ((Walk.rotate_edges c (hcHam.mem_support x)).mem_iff.mp h)
+    fun h => he_not_in_cycle ((c.rotate_edges x (hcHam.mem_support x)).mem_iff.mp h)
   have hyX : y ∈ cX.support := by
     by_cases hxy : x = y
     · subst hxy
@@ -280,7 +280,7 @@ theorem not_isHamiltonian_of_isBridge (G : SimpleGraph V)
         Walk.support_tail_of_not_nil c hc_not_nil
       rw [this] at hy_tail
       have hperm : cX.support.tail.Perm c.support.tail :=
-        (Walk.support_rotate c (hcHam.mem_support x)).perm
+        (c.support_rotate _ (hcHam.mem_support x)).perm
       have : y ∈ cX.support.tail := hperm.symm.mem_iff.mp hy_tail
       exact List.mem_of_mem_tail this
   let p := cX.takeUntil y hyX

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -528,7 +528,7 @@ lemma IsCycles.exists_cycle_toSubgraph_verts_eq_connectedComponentSupp [Finite V
       rw [← hc', Walk.mem_verts_toSubgraph]
       exact hvp
     simp_all
-  use p.rotate hvp
+  use p.rotate v hvp
   rw [← this]
   exact ⟨hp.1.rotate _, by simp⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -564,12 +564,12 @@ lemma IsTrail.disjoint_edges_takeUntil_dropUntil {x : V} {w : G.Walk u v} (hw : 
   List.disjoint_of_nodup_append <| by simpa [← edges_append] using hw.edges_nodup
 
 protected theorem IsTrail.rotate {u v : V} {c : G.Walk v v} (hc : c.IsTrail) (h : u ∈ c.support) :
-    (c.rotate h).IsTrail := by
-  rw [isTrail_def, (c.rotate_edges h).perm.nodup_iff]
+    (c.rotate u h).IsTrail := by
+  rw [isTrail_def, (c.rotate_edges u h).perm.nodup_iff]
   exact hc.edges_nodup
 
 protected theorem IsCircuit.rotate {u v : V} {c : G.Walk v v} (hc : c.IsCircuit)
-    (h : u ∈ c.support) : (c.rotate h).IsCircuit := by
+    (h : u ∈ c.support) : (c.rotate u h).IsCircuit := by
   refine ⟨hc.isTrail.rotate _, ?_⟩
   cases c
   · exact (hc.ne_nil rfl).elim
@@ -579,9 +579,9 @@ protected theorem IsCircuit.rotate {u v : V} {c : G.Walk v v} (hc : c.IsCircuit)
     simp at hn'
 
 protected theorem IsCycle.rotate {u v : V} {c : G.Walk v v} (hc : c.IsCycle) (h : u ∈ c.support) :
-    (c.rotate h).IsCycle := by
+    (c.rotate u h).IsCycle := by
   refine ⟨hc.isCircuit.rotate _, ?_⟩
-  rw [List.IsRotated.nodup_iff (support_rotate _ _)]
+  rw [(support_rotate ..).nodup_iff]
   exact hc.support_nodup
 
 lemma IsCycle.isPath_takeUntil {c : G.Walk v v} (hc : c.IsCycle) (h : w ∈ c.support) :


### PR DESCRIPTION
It is annoying for it not to appear in the infoview. In general, no implicit data argument to a definition should be inferrable only through proof arguments.

---

I could further remove the proof obligation by making `Walk.rotate` return the original walk if the vertex is not in the support. What do you think?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
