### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Floor/Ring): generalize `Int.abs_sub_lt_one_of_floor_eq_floor`

### DIFF
--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -239,15 +239,15 @@ theorem floor_sub_ofNat (a : R) (n : ℕ) [n.AtLeastTwo] :
     ⌊a - ofNat(n)⌋ = ⌊a⌋ - ofNat(n) :=
   floor_sub_natCast a n
 
-theorem abs_sub_lt_one_of_floor_eq_floor {R : Type*}
-    [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] [FloorRing R]
-    {a b : R} (h : ⌊a⌋ = ⌊b⌋) : |a - b| < 1 := by
-  have : a < ⌊a⌋ + 1 := lt_floor_add_one a
-  have : b < ⌊b⌋ + 1 := lt_floor_add_one b
-  have : (⌊a⌋ : R) = ⌊b⌋ := Int.cast_inj.2 h
-  have : (⌊a⌋ : R) ≤ a := floor_le a
-  have : (⌊b⌋ : R) ≤ b := floor_le b
-  exact abs_sub_lt_iff.2 ⟨by linarith, by linarith⟩
+theorem abs_sub_lt_one_of_floor_eq_floor {a b : R} (h : ⌊a⌋ = ⌊b⌋) : |a - b| < 1 := by
+  wlog h0 : b ≤ a generalizing a b
+  · rw [abs_sub_comm]
+    exact this h.symm (le_of_not_ge h0)
+  calc |a - b|
+    _ = a - b := abs_of_nonneg (sub_nonneg_of_le h0)
+    _ < ⌊a⌋ + 1 - b := sub_lt_sub_right (lt_floor_add_one a) _
+    _ ≤ ⌊a⌋ + 1 - ⌊b⌋ := sub_le_sub_left (floor_le b) _
+    _ = 1 := by rw [h, add_sub_cancel_left]
 
 lemma floor_eq_self_iff_mem (a : R) : ⌊a⌋ = a ↔ a ∈ Set.range Int.cast := by
   aesop


### PR DESCRIPTION
This PR weakens the `CommRing R` assumption on `Int.abs_sub_lt_one_of_floor_eq_floor` into `Ring R`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
