### PR TITLE
fix(Tactic/Continuity): mark Continuous.comp' as unsafe

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1183,7 +1183,7 @@ lemma instOrderClosedTopology : OrderClosedTopology K where
   isClosed_le' := by
     conv in _ ≤ _ => rw [RCLike.le_iff_re_im]
     simp_rw [Set.setOf_and]
-    refine IsClosed.inter (isClosed_le ?_ ?_) (isClosed_eq ?_ ?_) <;> continuity
+    refine IsClosed.inter (isClosed_le ?_ ?_) (isClosed_eq ?_ ?_) <;> fun_prop
 
 scoped[ComplexOrder] attribute [instance] RCLike.instOrderClosedTopology
 

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -81,6 +81,11 @@ def _root_.lightCondSetToTopCat : LightCondSet.{u} ⥤ TopCat.{u} where
   obj X := X.toTopCat
   map f := toTopCatMap f
 
+section
+
+-- TODO: without this, `continuity` times out
+attribute [-aesop] Continuous.comp'
+attribute [aesop (rule_sets := [Continuous]) safe apply] Continuous.comp'
 /-- The counit of the adjunction `lightCondSetToTopCat ⊣ topCatToLightCondSet` -/
 noncomputable def topCatAdjunctionCounit (X : TopCat.{u}) : X.toLightCondSet.toTopCat ⟶ X :=
   TopCat.ofHom
@@ -88,6 +93,8 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u}) : X.toLightCondSet.toT
     continuous_toFun := by
       rw [continuous_coinduced_dom]
       continuity }
+
+end
 
 /-- The counit of the adjunction `lightCondSetToTopCat ⊣ topCatToLightCondSet` is always bijective,
 but not an isomorphism in general (the inverse isn't continuous unless `X` is sequential).

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -82,6 +82,10 @@ def condensedSetToTopCat : CondensedSet.{u} ⥤ TopCat.{u + 1} where
 
 namespace CondensedSet
 
+section
+-- TODO: without this, `continuity` times out
+attribute [-aesop] Continuous.comp'
+attribute [aesop (rule_sets := [Continuous]) safe apply] Continuous.comp'
 /-- The counit of the adjunction `condensedSetToTopCat ⊣ topCatToCondensedSet` -/
 noncomputable def topCatAdjunctionCounit (X : TopCat.{u + 1}) : X.toCondensedSet.toTopCat ⟶ X :=
   TopCat.ofHom
@@ -89,6 +93,7 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u + 1}) : X.toCondensedSet
     continuous_toFun := by
       rw [continuous_coinduced_dom]
       continuity }
+end
 
 /-- `simp`-normal form of the lemma that `@[simps]` would generate. -/
 @[simp] lemma topCatAdjunctionCounit_hom_apply (X : TopCat) (x) :

--- a/Mathlib/Topology/Continuous.lean
+++ b/Mathlib/Topology/Continuous.lean
@@ -115,9 +115,14 @@ theorem Continuous.comp {g : Y → Z} (hg : Continuous g) (hf : Continuous f) :
   continuous_def.2 fun _ h => (h.preimage hg).preimage hf
 
 -- This is needed due to reducibility issues with the `continuity` tactic.
-@[continuity, fun_prop]
+@[fun_prop]
 theorem Continuous.comp' {g : Y → Z} (hg : Continuous g) (hf : Continuous f) :
     Continuous (fun x => g (f x)) := hg.comp hf
+
+-- The `continuity` attribute adds a lemma as a *safe* aesop rule. This rule is *unsafe*,
+-- however: the composition of any function with a constant function is continuous,
+-- and we don't want aesop to get stuck proving that an arbitrary function is continuous.
+attribute [aesop (rule_sets := [Continuous]) unsafe 95% apply] Continuous.comp'
 
 @[fun_prop]
 theorem Continuous.iterate {f : X → X} (h : Continuous f) (n : ℕ) : Continuous f^[n] :=

--- a/MathlibTest/Continuity.lean
+++ b/MathlibTest/Continuity.lean
@@ -39,11 +39,114 @@ example {κ ι : Type}
 
 open Real
 
+section
+
+attribute [-aesop] Continuous.comp'
+attribute [aesop (rule_sets := [Continuous]) unsafe 99% apply] Continuous.comp'
+
+/--
+error: tactic 'aesop' failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
+Initial goal:
+  W : Type ?u.507636
+  X : Type ?u.507639
+  Y : Type ?u.507642
+  Z : Type ?u.507645
+  inst✝⁴ : TopologicalSpace W
+  inst✝³ : TopologicalSpace X
+  inst✝² : TopologicalSpace Y
+  inst✝¹ : TopologicalSpace Z
+  I : Type ?u.507648
+  X' : I → Type ?u.507653
+  inst✝ : (i : I) → TopologicalSpace (X' i)
+  ⊢ Continuous fun x => rexp (max x (-x) + sin x) ^ 2
+Remaining goals after safe rules:
+  case h.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf
+  W : Type ?u.507636
+  X : Type ?u.507639
+  Y : Type ?u.507642
+  Z : Type ?u.507645
+  inst : TopologicalSpace W
+  inst_1 : TopologicalSpace X
+  inst_2 : TopologicalSpace Y
+  inst_3 : TopologicalSpace Z
+  I : Type ?u.507648
+  X' : I → Type ?u.507653
+  inst_4 : (i : I) → TopologicalSpace (X' i)
+  ⊢ Continuous fun x => (Complex.exp (↑(max x (-x)) + Complex.sin ↑x)).1
+The safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
+-/
+#guard_msgs in
+example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
+  -- This invocation fails, with an error about maximal rule application depth being reached.
+  -- continuity itself does not support passing further options.
+  continuity
+  sorry
+
+/--
+error: Tactic `simp` failed with a nested error:
+(deterministic) timeout at `whnf`, maximum number of heartbeats (200000) has been reached
+
+Note: Use `set_option maxHeartbeats <num>` to set the limit.
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
+  -- Let's manually expand `continuity` to its aesop invocation, and pass that option.
+  -- Now we get an error about simp's maximal recursion depth being reached.
+  aesop (config := { terminal := true, maxRuleApplicationDepth := 200 }) (rule_sets := [Continuous])
+  sorry
+
+/--
+error: tactic 'aesop' failed, maximum number of rule applications (200) reached. Set the 'maxRuleApplications' option to increase the limit.
+Initial goal:
+  W : Type ?u.1782759
+  X : Type ?u.1782762
+  Y : Type ?u.1782765
+  Z : Type ?u.1782768
+  inst✝⁴ : TopologicalSpace W
+  inst✝³ : TopologicalSpace X
+  inst✝² : TopologicalSpace Y
+  inst✝¹ : TopologicalSpace Z
+  I : Type ?u.1782771
+  X' : I → Type ?u.1782776
+  inst✝ : (i : I) → TopologicalSpace (X' i)
+  ⊢ Continuous fun x => rexp (max x (-x) + sin x) ^ 2
+Remaining goals after safe rules:
+  case h.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf
+  W : Type ?u.1782759
+  X : Type ?u.1782762
+  Y : Type ?u.1782765
+  Z : Type ?u.1782768
+  inst : TopologicalSpace W
+  inst_1 : TopologicalSpace X
+  inst_2 : TopologicalSpace Y
+  inst_3 : TopologicalSpace Z
+  I : Type ?u.1782771
+  X' : I → Type ?u.1782776
+  inst_4 : (i : I) → TopologicalSpace (X' i)
+  ⊢ Continuous fun x => (Complex.exp ↑(max x (-x) + sin x)).1
+The safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
+-/
+#guard_msgs in
+example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
+  -- If we disable simp, aesop fails to make meaningful progress.
+  aesop (config := { terminal := true, maxRuleApplicationDepth := 200, enableSimp := false }) (rule_sets := [Continuous])
+  sorry
+
+-- If we make this a safe rule instead, the test succeeds quickly.
+attribute [-aesop] Continuous.comp'
+attribute [aesop (rule_sets := [Continuous]) safe apply] Continuous.comp'
+
 example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
   continuity
 
+-- The story for this more complicated example is similar.
+
 example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin (cos x))^2) := by
   continuity
+
+end
 
 -- Examples taken from `Topology.ContinuousMap.Basic`:
 

--- a/MathlibTest/Continuity.lean
+++ b/MathlibTest/Continuity.lean
@@ -27,9 +27,23 @@ example {g : X → X} (y : Y) : Continuous ((fun _ ↦ y) ∘ g) := by continuit
 
 example {f : X → Y} (x : X) : Continuous (fun (_ : X) ↦ f x) := by continuity
 
+-- This test points at an internal error in aesop. With fewer imports, `continuity` succeeds.
+-- See https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/aesop.20error.20during.20proof.20reconstruction.2C.20goal.20not.20normalised/with/580202602.
+/-- error: aesop: internal error during proof reconstruction: goal 31 was not normalised. -/
+#guard_msgs in
 example (f₁ f₂ : X → Y) (hf₁ : Continuous f₁) (hf₂ : Continuous f₂)
     (g : Y → ℝ) (hg : Continuous g) : Continuous (fun x => (max (g (f₁ x)) (g (f₂ x))) + 1) := by
   continuity
+
+section
+
+attribute [-aesop] Continuous.comp'
+attribute [aesop (rule_sets := [Continuous]) safe apply] Continuous.comp'
+example (f₁ f₂ : X → Y) (hf₁ : Continuous f₁) (hf₂ : Continuous f₂)
+    (g : Y → ℝ) (hg : Continuous g) : Continuous (fun x => (max (g (f₁ x)) (g (f₂ x))) + 1) := by
+  continuity
+
+end
 
 example {κ ι : Type}
     (K : κ → Type) [∀ k, TopologicalSpace (K k)] (I : ι → Type) [∀ i, TopologicalSpace (I i)]
@@ -46,92 +60,10 @@ attribute [aesop (rule_sets := [Continuous]) unsafe 99% apply] Continuous.comp'
 
 /--
 error: tactic 'aesop' failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
-Initial goal:
-  W : Type ?u.507636
-  X : Type ?u.507639
-  Y : Type ?u.507642
-  Z : Type ?u.507645
-  inst✝⁴ : TopologicalSpace W
-  inst✝³ : TopologicalSpace X
-  inst✝² : TopologicalSpace Y
-  inst✝¹ : TopologicalSpace Z
-  I : Type ?u.507648
-  X' : I → Type ?u.507653
-  inst✝ : (i : I) → TopologicalSpace (X' i)
-  ⊢ Continuous fun x => rexp (max x (-x) + sin x) ^ 2
-Remaining goals after safe rules:
-  case h.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf
-  W : Type ?u.507636
-  X : Type ?u.507639
-  Y : Type ?u.507642
-  Z : Type ?u.507645
-  inst : TopologicalSpace W
-  inst_1 : TopologicalSpace X
-  inst_2 : TopologicalSpace Y
-  inst_3 : TopologicalSpace Z
-  I : Type ?u.507648
-  X' : I → Type ?u.507653
-  inst_4 : (i : I) → TopologicalSpace (X' i)
-  ⊢ Continuous fun x => (Complex.exp (↑(max x (-x)) + Complex.sin ↑x)).1
-The safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
 -/
-#guard_msgs in
+#guard_msgs (substring := true) in
 example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
-  -- This invocation fails, with an error about maximal rule application depth being reached.
-  -- continuity itself does not support passing further options.
   continuity
-  sorry
-
-/--
-error: Tactic `simp` failed with a nested error:
-(deterministic) timeout at `whnf`, maximum number of heartbeats (200000) has been reached
-
-Note: Use `set_option maxHeartbeats <num>` to set the limit.
-
-Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
--/
-#guard_msgs in
-example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
-  -- Let's manually expand `continuity` to its aesop invocation, and pass that option.
-  -- Now we get an error about simp's maximal recursion depth being reached.
-  aesop (config := { terminal := true, maxRuleApplicationDepth := 200 }) (rule_sets := [Continuous])
-  sorry
-
-/--
-error: tactic 'aesop' failed, maximum number of rule applications (200) reached. Set the 'maxRuleApplications' option to increase the limit.
-Initial goal:
-  W : Type ?u.1782759
-  X : Type ?u.1782762
-  Y : Type ?u.1782765
-  Z : Type ?u.1782768
-  inst✝⁴ : TopologicalSpace W
-  inst✝³ : TopologicalSpace X
-  inst✝² : TopologicalSpace Y
-  inst✝¹ : TopologicalSpace Z
-  I : Type ?u.1782771
-  X' : I → Type ?u.1782776
-  inst✝ : (i : I) → TopologicalSpace (X' i)
-  ⊢ Continuous fun x => rexp (max x (-x) + sin x) ^ 2
-Remaining goals after safe rules:
-  case h.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf.hf
-  W : Type ?u.1782759
-  X : Type ?u.1782762
-  Y : Type ?u.1782765
-  Z : Type ?u.1782768
-  inst : TopologicalSpace W
-  inst_1 : TopologicalSpace X
-  inst_2 : TopologicalSpace Y
-  inst_3 : TopologicalSpace Z
-  I : Type ?u.1782771
-  X' : I → Type ?u.1782776
-  inst_4 : (i : I) → TopologicalSpace (X' i)
-  ⊢ Continuous fun x => (Complex.exp ↑(max x (-x) + sin x)).1
-The safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
--/
-#guard_msgs in
-example : Continuous (fun x : ℝ => exp ((max x (-x)) + sin x)^2) := by
-  -- If we disable simp, aesop fails to make meaningful progress.
-  aesop (config := { terminal := true, maxRuleApplicationDepth := 200, enableSimp := false }) (rule_sets := [Continuous])
   sorry
 
 -- If we make this a safe rule instead, the test succeeds quickly.


### PR DESCRIPTION
This issue was pre-existing: `Continuous.comp'` was never full safe, as a constant function could be written as the composition of any function and a constant function (and then applying the lemma could lead to something unprovable). The change in #31607 triggered such a case: make is an unsafe rule with very high probability instead.

This change broke three proofs: one was easy to switch to fun_prop; the others seemed to depend on this being a safe rule. I have added a workaround for now.

There was another test failure, exposing a pre-existing internal bug in aesop. With smaller imports, continuity succeeds [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/aesop.20error.20during.20proof.20reconstruction.2C.20goal.20not.20normalised/with/580202602), so I have accepted this result as fine.

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
