### PR TITLE
[Merged by Bors] - chore(Combinatorics/SimpleGraph): fix projection names for `IsTree`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -55,11 +55,13 @@ def IsAcyclic : Prop := ∀ ⦃v : V⦄ (c : G.Walk v v), ¬c.IsCycle
 
 /-- A *tree* is a connected acyclic graph. -/
 @[mk_iff]
-structure IsTree : Prop where
-  /-- Graph is connected. -/
-  protected isConnected : G.Connected
-  /-- Graph is acyclic. -/
-  protected IsAcyclic : G.IsAcyclic
+structure IsTree : Prop extends
+  connected : G.Connected where
+  /-- A tree is acyclic. -/
+  isAcyclic : G.IsAcyclic
+
+@[deprecated (since := "2026-03-18")] alias IsTree.isConnected := IsTree.connected
+@[deprecated (since := "2026-03-18")] alias IsTree.IsAcyclic := IsTree.isAcyclic
 
 variable {G G'}
 
@@ -132,8 +134,8 @@ theorem exists_maximal_isAcyclic_of_le_isAcyclic
 /-- A connected component of an acyclic graph is a tree. -/
 lemma IsAcyclic.isTree_connectedComponent (h : G.IsAcyclic) (c : G.ConnectedComponent) :
     c.toSimpleGraph.IsTree where
-  isConnected := c.connected_toSimpleGraph
-  IsAcyclic := h.comap c.toSimpleGraph_hom <| by simp [ConnectedComponent.toSimpleGraph_hom]
+  connected := c.connected_toSimpleGraph
+  isAcyclic := h.comap c.toSimpleGraph_hom <| by simp [ConnectedComponent.toSimpleGraph_hom]
 
 lemma IsAcyclic.of_subsingleton [Subsingleton V] {G : SimpleGraph V} : G.IsAcyclic :=
   fun v p hp ↦ hp.ne_nil <| match p with
@@ -293,7 +295,7 @@ theorem IsAcyclic.isPath_iff_isTrail (hG : G.IsAcyclic) {v w : V} (p : G.Walk v 
 
 lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
     Finset.card G.edgeFinset + 1 = Fintype.card V := by
-  have := hG.isConnected.nonempty
+  have := hG.connected.nonempty
   inhabit V
   classical
   have : Finset.card ({default} : Finset V)ᶜ + 1 = Fintype.card V := by
@@ -350,10 +352,10 @@ lemma isTree_of_minimal_connected (h : Minimal Connected G) : IsTree G := by
 
 set_option backward.isDefEq.respectTransparency false in
 lemma isTree_iff_minimal_connected : IsTree G ↔ Minimal Connected G := by
-  refine ⟨fun htree ↦ ⟨htree.isConnected, fun G' h' hle u v hadj ↦ ?_⟩, isTree_of_minimal_connected⟩
+  refine ⟨fun htree ↦ ⟨htree.connected, fun G' h' hle u v hadj ↦ ?_⟩, isTree_of_minimal_connected⟩
   have ⟨p, hp⟩ := h'.exists_isPath u v
   have := congrArg Walk.edges <| congrArg Subtype.val <|
-    htree.IsAcyclic.path_unique ⟨p.mapLe hle, hp.mapLe hle⟩ <| Path.singleton hadj
+    htree.isAcyclic.path_unique ⟨p.mapLe hle, hp.mapLe hle⟩ <| Path.singleton hadj
   simp only [edges_map, Hom.coe_ofLE, Sym2.map_id, List.map_id_fun, id_eq] at this
   simp [this, p.adj_of_mem_edges]
 
@@ -423,8 +425,8 @@ theorem Connected.maximal_le_isAcyclic_iff_isTree {T : SimpleGraph V} (hG : G.Co
   have := hG.nonempty
   refine ⟨fun h ↦ ⟨⟨fun u v ↦ ?_⟩, h.1.2⟩, fun hT' ↦ ?_⟩
   · exact G.reachable_eq_of_maximal_isAcyclic T h ▸ hG.preconnected u v
-  · rw [maximal_isAcyclic_iff_reachable_eq hT hT'.IsAcyclic,
-      T.preconnected_iff_reachable_eq_top.mp hT'.isConnected.preconnected,
+  · rw [maximal_isAcyclic_iff_reachable_eq hT hT'.isAcyclic,
+      T.preconnected_iff_reachable_eq_top.mp hT'.preconnected,
       G.preconnected_iff_reachable_eq_top.mp hG.preconnected]
 
 @[simp]
@@ -436,7 +438,7 @@ theorem maximal_isAcyclic_iff_isTree [Nonempty V] {T : SimpleGraph V} :
 with `Nonempty V` as part of the iff rather than an assumption. -/
 theorem isTree_iff_maximal_isAcyclic : G.IsTree ↔ Nonempty V ∧ Maximal IsAcyclic G := by
   refine ⟨fun h ↦ ?_, fun ⟨_, h⟩ ↦ G.maximal_isAcyclic_iff_isTree.mp h⟩
-  have := h.isConnected.nonempty
+  have := h.nonempty
   exact ⟨this, G.maximal_isAcyclic_iff_isTree.mpr h⟩
 
 /-- Every acyclic subgraph can be extended to a spanning forest. -/
@@ -480,7 +482,7 @@ lemma isTree_iff_connected_and_card [Finite V] :
     G.IsTree ↔ G.Connected ∧ Nat.card G.edgeSet + 1 = Nat.card V := by
   have := Fintype.ofFinite V
   classical
-  refine ⟨fun h ↦ ⟨h.isConnected, by simpa [edgeFinset] using h.card_edgeFinset⟩,
+  refine ⟨fun h ↦ ⟨h.connected, by simpa [edgeFinset] using h.card_edgeFinset⟩,
     fun ⟨h₁, h₂⟩ ↦ ⟨h₁, ?_⟩⟩
   simp_rw [isAcyclic_iff_forall_adj_isBridge]
   refine fun x y h ↦ by_contra fun hbr ↦
@@ -500,7 +502,7 @@ lemma IsTree.minDegree_eq_one_of_nontrivial (h : G.IsTree) [Fintype V] [Nontrivi
       exact le_trans q (G.minDegree_le_degree _)
     rw [Finset.sum_const, Finset.card_univ, smul_eq_mul] at hle
     lia
-  · have := h.isConnected.preconnected.minDegree_pos_of_nontrivial
+  · have := h.preconnected.minDegree_pos_of_nontrivial
     lia
 
 /-- A nontrivial tree has a vertex of degree one. -/
@@ -574,7 +576,7 @@ lemma IsAcyclic.dist_ne_of_adj (hG : G.IsAcyclic) {u v w : V} (hadj : G.Adj v w)
 
 lemma IsTree.dist_ne_of_adj (hG : G.IsTree) (u : V) {v w : V} (hadj : G.Adj v w) :
     G.dist u v ≠ G.dist u w :=
-  hG.IsAcyclic.dist_ne_of_adj hadj <| hG.isConnected u v
+  hG.isAcyclic.dist_ne_of_adj hadj <| hG.connected u v
 
 lemma IsAcyclic.dist_eq_dist_add_one_of_adj_of_reachable
     (hG : G.IsAcyclic) (u : V) {v w : V} (hadj : G.Adj v w) (hreach : G.Reachable u v) :
@@ -592,7 +594,7 @@ noncomputable def IsTree.coloringTwoOfVert (hG : G.IsTree) (u : V) : G.Coloring 
 
 /-- Arbitrary coloring with two colors for a tree -/
 noncomputable def IsTree.coloringTwo (hG : G.IsTree) : G.Coloring (Fin 2) :=
-  hG.coloringTwoOfVert hG.isConnected.nonempty.some
+  hG.coloringTwoOfVert hG.connected.nonempty.some
 
 lemma IsTree.isBipartite (hG : G.IsTree) : G.IsBipartite :=
   ⟨hG.coloringTwo⟩
@@ -622,7 +624,7 @@ lemma IsAcyclic.colorable_two (hG : G.IsAcyclic) : G.Colorable 2 :=
 
 /-- A tree is 2-colorable. -/
 lemma IsTree.colorable_two (hG : G.IsTree) : G.Colorable 2 :=
-  hG.IsAcyclic.colorable_two
+  hG.isAcyclic.colorable_two
 
 /-- The chromatic number of an acyclic graph (forest) is at most 2. -/
 lemma IsAcyclic.chromaticNumber_le_two (hG : G.IsAcyclic) : G.chromaticNumber ≤ 2 :=


### PR DESCRIPTION
Both `isConnected` and `IsAcyclic` were wrong. They should have been `connected` and `isAcyclic` respectively.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
