### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Adjunction): preservation of colimits

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2382,6 +2382,7 @@ public import Mathlib.CategoryTheory.Adjunction.Comma
 public import Mathlib.CategoryTheory.Adjunction.CompositionIso
 public import Mathlib.CategoryTheory.Adjunction.Evaluation
 public import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+public import Mathlib.CategoryTheory.Adjunction.FullyFaithfulLimits
 public import Mathlib.CategoryTheory.Adjunction.Lifting.Left
 public import Mathlib.CategoryTheory.Adjunction.Lifting.Right
 public import Mathlib.CategoryTheory.Adjunction.Limits

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+public import Mathlib.CategoryTheory.Adjunction.Limits
+
+/-!
+# Preservations of colimits and adjunctions
+
+Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful.
+We show that if colimits of shape `J` exists in `C`, then a functor
+`H : D ⥤ E` preserves colimits of shape `J` ifff `F ⋙ H` does.
+
+In particular, a functor from a category of sheaves preserves colimits
+iff it is so after precomposition with the sheafification functor.
+
+-/
+
+@[expose] public section
+
+universe v u v₁ v₂ v₃ u₁ u₂ u₃
+
+namespace CategoryTheory.Adjunction
+
+open Limits
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+  {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G)
+  {E : Type u₃} [Category.{v₃} E] (H : D ⥤ E)
+  (J : Type u) [Category.{v} J]
+
+include adj
+
+lemma preservesColimitsOfShape_iff (J : Type u) [Category.{v} J]
+    [HasColimitsOfShape J C] [G.Full] [G.Faithful] :
+    PreservesColimitsOfShape J H ↔ PreservesColimitsOfShape J (F ⋙ H) := by
+  have := adj.isLeftAdjoint
+  refine ⟨fun _ ↦ inferInstance, fun _ ↦ ⟨fun {K} ↦ ?_⟩⟩
+  let iso : (K ⋙ G) ⋙ F ≅ K :=
+    Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft _ (asIso adj.counit) ≪≫ K.rightUnitor
+  refine preservesColimit_of_preserves_colimit_cocone
+    ((IsColimit.precomposeInvEquiv iso _).symm
+      (isColimitOfPreserves F (colimit.isColimit (K ⋙ G)))) ?_
+  exact IsColimit.ofIsoColimit
+    ((IsColimit.precomposeInvEquiv ((Functor.associator _ _ _).symm ≪≫
+      Functor.isoWhiskerRight iso H) _).symm
+      (isColimitOfPreserves (F ⋙ H) (colimit.isColimit (K ⋙ G))))
+      (Cocone.ext (Iso.refl _))
+
+lemma preservesColimitsOfSize_iff
+    [HasColimitsOfSize.{v, u} C] [G.Full] [G.Faithful] :
+    PreservesColimitsOfSize.{v, u} H ↔ PreservesColimitsOfSize.{v, u} (F ⋙ H) := by
+  have := adj.isLeftAdjoint
+  refine ⟨fun _ ↦ inferInstance, fun _ ↦ ⟨fun {J _} ↦ ?_⟩⟩
+  rw [adj.preservesColimitsOfShape_iff]
+  infer_instance
+
+end CategoryTheory.Adjunction

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -12,7 +12,7 @@ public import Mathlib.CategoryTheory.Adjunction.Limits
 # Preservation of colimits and reflective adjunctions
 
 Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful.
-We show that if colimits of shape `J` exists in `C`, then a functor
+We show that if colimits of shape `J` exist in `C`, then a functor
 `H : D ⥤ E` preserves colimits of shape `J` iff `F ⋙ H` does.
 
 In particular, a functor from a category of sheaves preserves colimits

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -16,7 +16,7 @@ We show that if colimits of shape `J` exists in `C`, then a functor
 `H : D ⥤ E` preserves colimits of shape `J` iff `F ⋙ H` does.
 
 In particular, a functor from a category of sheaves preserves colimits
-iff it is so after precomposition with the sheafification functor.
+iff it does so after precomposition with the sheafification functor.
 
 -/
 

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Adjunction.Limits
 
 Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful.
 We show that if colimits of shape `J` exists in `C`, then a functor
-`H : D ⥤ E` preserves colimits of shape `J` ifff `F ⋙ H` does.
+`H : D ⥤ E` preserves colimits of shape `J` iff `F ⋙ H` does.
 
 In particular, a functor from a category of sheaves preserves colimits
 iff it is so after precomposition with the sheafification functor.

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -9,7 +9,7 @@ public import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 public import Mathlib.CategoryTheory.Adjunction.Limits
 
 /-!
-# Preservations of colimits and adjunctions
+# Preservations of colimits and reflective adjunctions
 
 Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful.
 We show that if colimits of shape `J` exists in `C`, then a functor

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -46,10 +46,10 @@ lemma preservesColimitsOfShape_iff (J : Type u) [Category.{v} J]
     ((IsColimit.precomposeInvEquiv iso _).symm
       (isColimitOfPreserves F (colimit.isColimit (K ⋙ G)))) ?_
   exact IsColimit.ofIsoColimit
-    ((IsColimit.precomposeInvEquiv ((Functor.associator _ _ _).symm ≪≫
-      Functor.isoWhiskerRight iso H) _).symm
-      (isColimitOfPreserves (F ⋙ H) (colimit.isColimit (K ⋙ G))))
-      (Cocone.ext (Iso.refl _))
+    ((IsColimit.precomposeInvEquiv
+      ((Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight iso H) _).symm
+        (isColimitOfPreserves (F ⋙ H) (colimit.isColimit (K ⋙ G))))
+          (Cocone.ext (Iso.refl _))
 
 lemma preservesColimitsOfSize_iff
     [HasColimitsOfSize.{v, u} C] [G.Full] [G.Faithful] :

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithfulLimits.lean
@@ -9,7 +9,7 @@ public import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 public import Mathlib.CategoryTheory.Adjunction.Limits
 
 /-!
-# Preservations of colimits and reflective adjunctions
+# Preservation of colimits and reflective adjunctions
 
 Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful.
 We show that if colimits of shape `J` exists in `C`, then a functor


### PR DESCRIPTION
Let `adj : F ⊣ G` be an adjunction with `G : D ⥤ C` full and faithful. We show that if colimits of shape `J` exists in `C`, then a functor `H : D ⥤ E` preserves colimits of shape `J` iff `F ⋙ H` does.

In particular, a functor from a category of sheaves preserves colimits iff it is so after precomposition with the sheafification functor.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
