### PR TITLE
refactor(LinearAlgebra): move Basis.equivFun_symm_single

### DIFF
--- a/Mathlib/LinearAlgebra/Basis/Defs.lean
+++ b/Mathlib/LinearAlgebra/Basis/Defs.lean
@@ -262,6 +262,12 @@ theorem Basis.sum_repr [Fintype ι] (b : Basis ι R M) (u : M) : ∑ i, b.repr u
 theorem Basis.equivFun_self [Finite ι] [DecidableEq ι] (b : Basis ι R M) (i j : ι) :
     b.equivFun (b i) j = if i = j then 1 else 0 := by rw [b.equivFun_apply, b.repr_self_apply]
 
+@[simp]
+theorem Basis.equivFun_symm_single [Finite ι] [DecidableEq ι] (b : Basis ι R M) (i : ι) :
+    b.equivFun.symm (Pi.single i 1) = b i := by
+  cases nonempty_fintype ι
+  simp [Pi.single_apply]
+
 theorem Basis.repr_sum_self [Fintype ι] (b : Basis ι R M) (c : ι → R) :
     b.repr (∑ i, c i • b i) = c := by
   simp_rw [← b.equivFun_symm_apply, ← b.equivFun_apply, b.equivFun.apply_symm_apply]

--- a/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean
@@ -193,12 +193,6 @@ theorem _root_.Finset.sum_single_ite [Fintype n] (a : R) (i : n) :
   simp only [apply_ite (Finsupp.single _), Finsupp.single_zero, Finset.sum_ite_eq,
     if_pos (Finset.mem_univ _)]
 
-@[simp]
-theorem equivFun_symm_single [Finite n] (b : Basis n R M) (i : n) :
-    b.equivFun.symm (Pi.single i 1) = b i := by
-  cases nonempty_fintype n
-  simp [Pi.single_apply]
-
 end Basis
 
 section Algebra


### PR DESCRIPTION
## Summary
- move `Basis.equivFun_symm_single` from `Mathlib/LinearAlgebra/Finsupp/VectorSpace.lean` to `Mathlib/LinearAlgebra/Basis/Defs.lean`
- keep the theorem statement and proof unchanged
- remove the later duplicate after the move

## Why
- `Basis.equivFun_symm_single` is a `Basis` theorem about `Basis.equivFun`
- it fits naturally with the nearby `Basis.equivFun_self` API in `Mathlib/LinearAlgebra/Basis/Defs.lean`
- this makes the lemma available from the earlier basis import layer

## Testing
- `lake build Mathlib.LinearAlgebra.Basis.Defs`
- `lake build Mathlib.LinearAlgebra.Finsupp.VectorSpace`
- `lake build Mathlib.LinearAlgebra.Matrix.SesquilinearForm`
