### PR TITLE
[Merged by Bors] - chore(Data/Nat/Digits): rename `digits_len` to `digits_length`

### DIFF
--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -50,7 +50,7 @@ theorem ofDigits_eq_sum_mapIdx (b : ℕ) (L : List ℕ) :
 This section contains various lemmas of properties relating to `digits` and `ofDigits`.
 -/
 
-theorem digits_length (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length = b.log n + 1 := by
+theorem length_digits (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length = b.log n + 1 := by
   induction n using Nat.strong_induction_on with | _ n IH
   rw [digits_eq_cons_digits_div hb hn, List.length]
   by_cases h : n / b = 0
@@ -62,14 +62,14 @@ theorem digits_length (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).len
     contrapose! h
     exact div_eq_of_lt h
 
-@[deprecated (since := "2026-03-18")] alias digits_len := digits_length
+@[deprecated (since := "2026-03-18")] alias digits_len := length_digits
 
 theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     (b.digits n).length ≤ k ↔ n < b ^ k := by
   by_cases h : n = 0
   · have : 0 < b ^ k := by positivity
     simpa [h]
-  rw [digits_length b n hb h, ← log_lt_iff_lt_pow hb h]
+  rw [length_digits b n hb h, ← log_lt_iff_lt_pow hb h]
   exact add_one_le_iff
 
 theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
@@ -114,20 +114,20 @@ theorem digits_append_zeroes_append_digits {b k m n : ℕ} (hb : 1 < b) (hm : 0 
   simp only [digits_append_digits (zero_lt_of_lt hb), digits_inj_iff, add_right_inj]
   ring
 
-theorem digits_length_le_digits_length_succ (b n : ℕ) :
+theorem length_digits_le_length_digits_succ (b n : ℕ) :
     (digits b n).length ≤ (digits b (n + 1)).length := by
   rcases Decidable.eq_or_ne n 0 with (rfl | hn)
   · simp
   rcases le_or_gt b 1 with hb | hb
   · interval_cases b <;> simp +arith [digits_zero_succ', hn]
-  simpa [digits_length, hb, hn] using log_mono_right (le_succ _)
+  simpa [length_digits, hb, hn] using log_mono_right (le_succ _)
 
-@[deprecated (since := "2026-03-18")] alias digits_len_le_digits_len_succ := digits_length_le_digits_length_succ
+@[deprecated (since := "2026-03-18")] alias digits_len_le_digits_len_succ := length_digits_le_length_digits_succ
 
-theorem le_digits_length_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
-  monotone_nat_of_le_succ (digits_length_le_digits_length_succ b) h
+theorem le_length_digits_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
+  monotone_nat_of_le_succ (length_digits_le_length_digits_succ b) h
 
-@[deprecated (since := "2026-03-18")] alias le_digits_len_le := le_digits_length_le
+@[deprecated (since := "2026-03-18")] alias le_digits_len_le := le_length_digits_le
 
 theorem pow_length_le_mul_ofDigits {b : ℕ} {l : List ℕ} (hl : l ≠ []) (hl2 : l.getLast hl ≠ 0) :
     (b + 2) ^ l.length ≤ (b + 2) * ofDigits (b + 2) l := by
@@ -201,7 +201,7 @@ theorem sub_one_mul_sum_log_div_pow_eq_sub_sum_digits {p : ℕ} (n : ℕ) :
     · simp
     · convert sub_one_mul_sum_div_pow_eq_sub_sum_digits (p.digits n) (getLast_digit_ne_zero p hn) <|
           (fun l a ↦ digits_lt_base h a)
-      · refine (digits_length p n h hn).symm
+      · refine (length_digits p n h hn).symm
       all_goals exact (ofDigits_digits p n).symm
   · simp
   · simp [lt_one_iff.mp h]

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -50,7 +50,7 @@ theorem ofDigits_eq_sum_mapIdx (b : ℕ) (L : List ℕ) :
 This section contains various lemmas of properties relating to `digits` and `ofDigits`.
 -/
 
-theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length = b.log n + 1 := by
+theorem digits_length (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length = b.log n + 1 := by
   induction n using Nat.strong_induction_on with | _ n IH
   rw [digits_eq_cons_digits_div hb hn, List.length]
   by_cases h : n / b = 0
@@ -62,12 +62,14 @@ theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length
     contrapose! h
     exact div_eq_of_lt h
 
+@[deprecated (since := "2026-03-18")] alias digits_len := digits_length
+
 theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     (b.digits n).length ≤ k ↔ n < b ^ k := by
   by_cases h : n = 0
   · have : 0 < b ^ k := by positivity
     simpa [h]
-  rw [digits_len b n hb h, ← log_lt_iff_lt_pow hb h]
+  rw [digits_length b n hb h, ← log_lt_iff_lt_pow hb h]
   exact add_one_le_iff
 
 theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
@@ -112,16 +114,20 @@ theorem digits_append_zeroes_append_digits {b k m n : ℕ} (hb : 1 < b) (hm : 0 
   simp only [digits_append_digits (zero_lt_of_lt hb), digits_inj_iff, add_right_inj]
   ring
 
-theorem digits_len_le_digits_len_succ (b n : ℕ) :
+theorem digits_length_le_digits_length_succ (b n : ℕ) :
     (digits b n).length ≤ (digits b (n + 1)).length := by
   rcases Decidable.eq_or_ne n 0 with (rfl | hn)
   · simp
   rcases le_or_gt b 1 with hb | hb
   · interval_cases b <;> simp +arith [digits_zero_succ', hn]
-  simpa [digits_len, hb, hn] using log_mono_right (le_succ _)
+  simpa [digits_length, hb, hn] using log_mono_right (le_succ _)
 
-theorem le_digits_len_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
-  monotone_nat_of_le_succ (digits_len_le_digits_len_succ b) h
+@[deprecated (since := "2026-03-18")] alias digits_len_le_digits_len_succ := digits_length_le_digits_length_succ
+
+theorem le_digits_length_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
+  monotone_nat_of_le_succ (digits_length_le_digits_length_succ b) h
+
+@[deprecated (since := "2026-03-18")] alias le_digits_len_le := le_digits_length_le
 
 theorem pow_length_le_mul_ofDigits {b : ℕ} {l : List ℕ} (hl : l ≠ []) (hl2 : l.getLast hl ≠ 0) :
     (b + 2) ^ l.length ≤ (b + 2) * ofDigits (b + 2) l := by
@@ -195,7 +201,7 @@ theorem sub_one_mul_sum_log_div_pow_eq_sub_sum_digits {p : ℕ} (n : ℕ) :
     · simp
     · convert sub_one_mul_sum_div_pow_eq_sub_sum_digits (p.digits n) (getLast_digit_ne_zero p hn) <|
           (fun l a ↦ digits_lt_base h a)
-      · refine (digits_len p n h hn).symm
+      · refine (digits_length p n h hn).symm
       all_goals exact (ofDigits_digits p n).symm
   · simp
   · simp [lt_one_iff.mp h]

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -50,7 +50,8 @@ theorem ofDigits_eq_sum_mapIdx (b : ℕ) (L : List ℕ) :
 This section contains various lemmas of properties relating to `digits` and `ofDigits`.
 -/
 
-theorem length_digits (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length = b.log n + 1 := by
+theorem length_digits (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) :
+    (b.digits n).length = b.log n + 1 := by
   induction n using Nat.strong_induction_on with | _ n IH
   rw [digits_eq_cons_digits_div hb hn, List.length]
   by_cases h : n / b = 0
@@ -122,7 +123,8 @@ theorem length_digits_le_length_digits_succ (b n : ℕ) :
   · interval_cases b <;> simp +arith [digits_zero_succ', hn]
   simpa [length_digits, hb, hn] using log_mono_right (le_succ _)
 
-@[deprecated (since := "2026-03-18")] alias digits_len_le_digits_len_succ := length_digits_le_length_digits_succ
+@[deprecated (since := "2026-03-18")]
+alias digits_len_le_digits_len_succ := length_digits_le_length_digits_succ
 
 theorem le_length_digits_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=
   monotone_nat_of_le_succ (length_digits_le_length_digits_succ b) h

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -327,7 +327,7 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ n : ℕ, f n ≤ 1) {n₀ : ℕ} (h
     _ = n₀ * (Nat.log n₀ m + 1) := by
       rw [List.mapIdx_eq_zipIdx_map, List.eq_replicate_of_mem (a := (n₀ : ℝ)) (l := L.zipIdx.map _),
         List.sum_replicate, List.length_map, List.length_zipIdx, nsmul_eq_mul, mul_comm,
-        Nat.digits_len n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
+        Nat.length_digits n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
       simp +contextual
     _ ≤ n₀ * (logb n₀ m + 1) := by gcongr; exact natLog_le_logb ..
   -- For h_ineq2 we need to exclude the case n = 0.
@@ -379,7 +379,7 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ = m * ((Nat.digits m n).mapIdx fun i _ ↦ f m ^ i).sum := list_mul_sum (m.digits n) (f m) m
     _ = m * ((f m ^ (d + 1) - 1) / (f m - 1)) := by
       rw [list_geom _ (ne_of_gt (one_lt_of_not_bounded notbdd hm)),
-        ← Nat.digits_len m n hm (ne_zero_of_lt hn)]
+        ← Nat.length_digits m n hm (ne_zero_of_lt hn)]
     _ ≤ m * ((f m ^ (d + 1)) / (f m - 1)) := by
       gcongr
       · linarith only [one_lt_of_not_bounded notbdd hm]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -13,7 +13,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 public import Mathlib.NumberTheory.Padics.PadicNorm
 
 /-!
-# Ostrowski's Theorem
+# Ostrowski’s Theorem
 
 Ostrowski's Theorem for the field `ℚ`: every absolute value on `ℚ` is equivalent to either a
 `p`-adic absolute value or to the standard Archimedean (Euclidean) absolute value.
@@ -327,7 +327,7 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ n : ℕ, f n ≤ 1) {n₀ : ℕ} (h
     _ = n₀ * (Nat.log n₀ m + 1) := by
       rw [List.mapIdx_eq_zipIdx_map, List.eq_replicate_of_mem (a := (n₀ : ℝ)) (l := L.zipIdx.map _),
         List.sum_replicate, List.length_map, List.length_zipIdx, nsmul_eq_mul, mul_comm,
-        Nat.length_digits n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
+        Nat.digits_len n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
       simp +contextual
     _ ≤ n₀ * (logb n₀ m + 1) := by gcongr; exact natLog_le_logb ..
   -- For h_ineq2 we need to exclude the case n = 0.
@@ -379,7 +379,7 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ = m * ((Nat.digits m n).mapIdx fun i _ ↦ f m ^ i).sum := list_mul_sum (m.digits n) (f m) m
     _ = m * ((f m ^ (d + 1) - 1) / (f m - 1)) := by
       rw [list_geom _ (ne_of_gt (one_lt_of_not_bounded notbdd hm)),
-        ← Nat.length_digits m n hm (ne_zero_of_lt hn)]
+        ← Nat.digits_len m n hm (ne_zero_of_lt hn)]
     _ ≤ m * ((f m ^ (d + 1)) / (f m - 1)) := by
       gcongr
       · linarith only [one_lt_of_not_bounded notbdd hm]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -327,7 +327,7 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ n : ℕ, f n ≤ 1) {n₀ : ℕ} (h
     _ = n₀ * (Nat.log n₀ m + 1) := by
       rw [List.mapIdx_eq_zipIdx_map, List.eq_replicate_of_mem (a := (n₀ : ℝ)) (l := L.zipIdx.map _),
         List.sum_replicate, List.length_map, List.length_zipIdx, nsmul_eq_mul, mul_comm,
-        Nat.digits_length n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
+        Nat.length_digits n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
       simp +contextual
     _ ≤ n₀ * (logb n₀ m + 1) := by gcongr; exact natLog_le_logb ..
   -- For h_ineq2 we need to exclude the case n = 0.
@@ -379,7 +379,7 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ = m * ((Nat.digits m n).mapIdx fun i _ ↦ f m ^ i).sum := list_mul_sum (m.digits n) (f m) m
     _ = m * ((f m ^ (d + 1) - 1) / (f m - 1)) := by
       rw [list_geom _ (ne_of_gt (one_lt_of_not_bounded notbdd hm)),
-        ← Nat.digits_length m n hm (ne_zero_of_lt hn)]
+        ← Nat.length_digits m n hm (ne_zero_of_lt hn)]
     _ ≤ m * ((f m ^ (d + 1)) / (f m - 1)) := by
       gcongr
       · linarith only [one_lt_of_not_bounded notbdd hm]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -13,7 +13,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 public import Mathlib.NumberTheory.Padics.PadicNorm
 
 /-!
-# Ostrowski’s Theorem
+# Ostrowski's Theorem
 
 Ostrowski's Theorem for the field `ℚ`: every absolute value on `ℚ` is equivalent to either a
 `p`-adic absolute value or to the standard Archimedean (Euclidean) absolute value.
@@ -327,7 +327,7 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ n : ℕ, f n ≤ 1) {n₀ : ℕ} (h
     _ = n₀ * (Nat.log n₀ m + 1) := by
       rw [List.mapIdx_eq_zipIdx_map, List.eq_replicate_of_mem (a := (n₀ : ℝ)) (l := L.zipIdx.map _),
         List.sum_replicate, List.length_map, List.length_zipIdx, nsmul_eq_mul, mul_comm,
-        Nat.digits_len n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
+        Nat.digits_length n₀ m hn₀ (ne_zero_of_lt hm), Nat.cast_add_one]
       simp +contextual
     _ ≤ n₀ * (logb n₀ m + 1) := by gcongr; exact natLog_le_logb ..
   -- For h_ineq2 we need to exclude the case n = 0.
@@ -379,7 +379,7 @@ private lemma param_upperbound {k : ℕ} (hk : k ≠ 0) :
     _ = m * ((Nat.digits m n).mapIdx fun i _ ↦ f m ^ i).sum := list_mul_sum (m.digits n) (f m) m
     _ = m * ((f m ^ (d + 1) - 1) / (f m - 1)) := by
       rw [list_geom _ (ne_of_gt (one_lt_of_not_bounded notbdd hm)),
-        ← Nat.digits_len m n hm (ne_zero_of_lt hn)]
+        ← Nat.digits_length m n hm (ne_zero_of_lt hn)]
     _ ≤ m * ((f m ^ (d + 1)) / (f m - 1)) := by
       gcongr
       · linarith only [one_lt_of_not_bounded notbdd hm]


### PR DESCRIPTION
Rename `Nat.digits_len` to `Nat.length_digits` for consistency with the mathlib naming convention — the statement is about `List.length (Nat.digits b n)`, so `length_digits` follows the standard projection-first pattern.

Also renames:
- `digits_len_le_digits_len_succ` → `length_digits_le_length_digits_succ`
- `le_digits_len_le` → `le_length_digits_le`

Deprecated aliases are added for backwards compatibility. Downstream files (e.g. `Ostrowski.lean`) are left unchanged since the deprecated aliases handle the transition.

Addresses the `Nat.digits_len` item in #21584.

## AI disclosure

I used Claude Code to explore the codebase (finding references, checking naming conventions) and to draft the PR description. I also used it to help with mechanical tasks like updating references across files and fixing lint issues. I reviewed and understand all changes — these are straightforward renames with deprecated aliases.