### PR TITLE
[Merged by Bors] - chore(Analysis/SpecificLimits): rename `tsum_geometric_nnreal` to `NNReal.tsum_geometric`

### DIFF
--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -390,8 +390,10 @@ theorem NNReal.hasSum_geometric {r : ℝ≥0} (hr : r < 1) : HasSum (fun n : ℕ
 theorem NNReal.summable_geometric {r : ℝ≥0} (hr : r < 1) : Summable fun n : ℕ ↦ r ^ n :=
   ⟨_, NNReal.hasSum_geometric hr⟩
 
-theorem tsum_geometric_nnreal {r : ℝ≥0} (hr : r < 1) : ∑' n : ℕ, r ^ n = (1 - r)⁻¹ :=
+theorem NNReal.tsum_geometric {r : ℝ≥0} (hr : r < 1) : ∑' n : ℕ, r ^ n = (1 - r)⁻¹ :=
   (NNReal.hasSum_geometric hr).tsum_eq
+
+@[deprecated (since := "2026-03-18")] alias tsum_geometric_nnreal := NNReal.tsum_geometric
 
 /-- The series `pow r` converges to `(1-r)⁻¹`. For `r < 1` the RHS is a finite number,
 and for `1 ≤ r` the RHS equals `∞`. -/


### PR DESCRIPTION
Rename `tsum_geometric_nnreal` to `NNReal.tsum_geometric` for consistency with `ENNReal.tsum_geometric`.

A deprecated alias is added for backwards compatibility.

Addresses the `tsum_geometric_nnreal` → `NNReal.tsum_geometric` item in #21584.

---

## AI disclosure

I used Claude Code to explore the codebase (finding references, checking naming conventions) and to draft the PR description. I reviewed and understand all changes — this is a straightforward rename with a deprecated alias.