### PR TITLE
[Merged by Bors] - fix(Tactic/NormNum): do not re-enter `simp` from the very outside

### DIFF
--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -215,27 +215,31 @@ def tryNormNum (post := false) (e : Expr) : SimpM Simp.Step := do
   catch _ =>
     return .continue
 
-variable (ctx : Simp.Context) (useSimp := true) in
-mutual
-  /-- A discharger which calls `norm_num`. -/
-  partial def discharge (e : Expr) : SimpM (Option Expr) := do (← deriveSimp e).ofTrue
+section
+variable (ctx : Simp.Context) (useSimp := true)
 
-  /-- A `Methods` implementation which calls `norm_num`. -/
-  partial def methods : Simp.Methods :=
-    if useSimp then {
-      pre := Simp.preDefault #[] >> tryNormNum
-      post := Simp.postDefault #[] >> tryNormNum (post := true)
-      discharge? := discharge
-    } else {
-      pre := tryNormNum
-      post := tryNormNum (post := true)
-      discharge? := discharge
-    }
+/-- A `Methods` implementation which calls `norm_num`. -/
+partial def methods : Simp.Methods :=
+  if useSimp then {
+    pre := Simp.preDefault #[] >> tryNormNum
+    post := Simp.postDefault #[] >> tryNormNum (post := true)
+    discharge? := Simp.dischargeGround
+  } else {
+    pre := tryNormNum
+    post := tryNormNum (post := true)
+    discharge? := Simp.dischargeGround
+  }
 
-  /-- Traverses the given expression using simp and normalises any numbers it finds. -/
-  partial def deriveSimp (e : Expr) : MetaM Simp.Result :=
-    (·.1) <$> Simp.main e ctx (methods := methods)
+/-- Traverses the given expression using simp and normalises any numbers it finds. -/
+partial def deriveSimp (e : Expr) : MetaM Simp.Result :=
+  (·.1) <$> Simp.main e ctx (methods := methods useSimp)
+
+/-- A discharger which calls `norm_num`, for use in downstream tactics. -/
+partial def discharge (e : Expr) : SimpM (Option Expr) := do
+  withReader (fun _ => (methods useSimp).toMethodsRef) (Simp.dischargeGround e)
+
 end
+
 
 open Tactic in
 /-- Constructs a simp context from the simp argument syntax. -/

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -240,7 +240,6 @@ partial def discharge (e : Expr) : SimpM (Option Expr) := do
 
 end
 
-
 open Tactic in
 /-- Constructs a simp context from the simp argument syntax. -/
 def getSimpContext (cfg args : Syntax) (simpOnly := false) : TacticM Simp.Context := do

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -235,7 +235,8 @@ def deriveSimp (e : Expr) : MetaM Simp.Result :=
   (·.1) <$> Simp.main e ctx (methods := methods useSimp)
 
 /-- A discharger which calls `norm_num`, for use in downstream tactics. -/
-def discharge (e : Expr) : SimpM (Option Expr) := do (← deriveSimp ctx useSimp e).ofTrue
+def discharge (e : Expr) : SimpM (Option Expr) := do
+  (← deriveSimp (← readThe Simp.Context) useSimp e).ofTrue
 
 end
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -219,7 +219,7 @@ section
 variable (ctx : Simp.Context) (useSimp := true)
 
 /-- A `Methods` implementation which calls `norm_num`. -/
-partial def methods : Simp.Methods :=
+def methods : Simp.Methods :=
   if useSimp then {
     pre := Simp.preDefault #[] >> tryNormNum
     post := Simp.postDefault #[] >> tryNormNum (post := true)
@@ -231,12 +231,11 @@ partial def methods : Simp.Methods :=
   }
 
 /-- Traverses the given expression using simp and normalises any numbers it finds. -/
-partial def deriveSimp (e : Expr) : MetaM Simp.Result :=
+def deriveSimp (e : Expr) : MetaM Simp.Result :=
   (·.1) <$> Simp.main e ctx (methods := methods useSimp)
 
 /-- A discharger which calls `norm_num`, for use in downstream tactics. -/
-partial def discharge (e : Expr) : SimpM (Option Expr) := do
-  withReader (fun _ => (methods useSimp).toMethodsRef) (Simp.dischargeGround e)
+def discharge (e : Expr) : SimpM (Option Expr) := do (← deriveSimp ctx useSimp e).ofTrue
 
 end
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -215,11 +215,8 @@ def tryNormNum (post := false) (e : Expr) : SimpM Simp.Step := do
   catch _ =>
     return .continue
 
-section
-variable (ctx : Simp.Context) (useSimp := true)
-
 /-- A `Methods` implementation which calls `norm_num`. -/
-def methods : Simp.Methods :=
+def methods (useSimp := true) : Simp.Methods :=
   if useSimp then {
     pre := Simp.preDefault #[] >> tryNormNum
     post := Simp.postDefault #[] >> tryNormNum (post := true)
@@ -231,14 +228,12 @@ def methods : Simp.Methods :=
   }
 
 /-- Traverses the given expression using simp and normalises any numbers it finds. -/
-def deriveSimp (e : Expr) : MetaM Simp.Result :=
+def deriveSimp (ctx : Simp.Context) (useSimp := true) (e : Expr) : MetaM Simp.Result :=
   (·.1) <$> Simp.main e ctx (methods := methods useSimp)
 
-/-- A discharger which calls `norm_num`, for use in downstream tactics. -/
-def discharge (e : Expr) : SimpM (Option Expr) := do
+/-- A discharger which calls `norm_num`, for use in downstream tactics populating `Simp.Methods`. -/
+def discharge (useSimp := true) (e : Expr) : SimpM (Option Expr) := do
   (← deriveSimp (← readThe Simp.Context) useSimp e).ofTrue
-
-end
 
 open Tactic in
 /-- Constructs a simp context from the simp argument syntax. -/

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -256,7 +256,7 @@ partial def derive (expensive := false) (e : Expr) : MetaM Simp.Result := do
   | none => throwError "internal error: reduce_mod_char not registered as simp extension"
   let ctx ← Simp.mkContext config (congrTheorems := congrTheorems)
     (simpTheorems := #[← ext.getTheorems])
-  let discharge := Mathlib.Meta.NormNum.discharge ctx
+  let discharge := Mathlib.Meta.NormNum.discharge
   let r : Simp.Result := {expr := e}
   let pre := Simp.preDefault #[] >> fun e =>
       try return (Simp.Step.done (← matchAndNorm (expensive := expensive) e))

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -256,7 +256,7 @@ partial def derive (expensive := false) (e : Expr) : MetaM Simp.Result := do
   | none => throwError "internal error: reduce_mod_char not registered as simp extension"
   let ctx ← Simp.mkContext config (congrTheorems := congrTheorems)
     (simpTheorems := #[← ext.getTheorems])
-  let discharge := Mathlib.Meta.NormNum.discharge
+  let discharge := Mathlib.Meta.NormNum.discharge ctx
   let r : Simp.Result := {expr := e}
   let pre := Simp.preDefault #[] >> fun e =>
       try return (Simp.Step.done (← matchAndNorm (expensive := expensive) e))


### PR DESCRIPTION
This fixes a recursion error in
```lean4
import Mathlib.SetTheory.Cardinal.Basic
import Mathlib.Tactic.NormNum.Core

theorem foos.{u} (α β : Type u) : Cardinal.mk α = Cardinal.mk β → α = β := by
  norm_num [Cardinal.mk_eq_aleph0]
```
which is quite willing to be promoted to a stack overflow with a moderate recursion depth limit.

It's not entirely clear to me if `dischargeGround` is the right discharger to use here, but no tests fail because of that choice.

Note this change breaks the following proof:
```lean4
import Mathlib.Tactic.NormNum

theorem foo (x y : ℚ)
    (h₀ : x > 0 ∧ y > 0)
    (h₁ : x < 1 ∧ y < 1) :
    0 ≤ x / (1 - x) + y / (1 - y) := by
  norm_num [*, div_pos, add_pos, le_of_lt]
```

The reason is that previously `norm_num` was `simp` plus _two_ things:
* Numeral normalization.
* Hackily overriding `maxDischargeDepth` to exceed maxRecDepth

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
