### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Subgroup/Defs): merge `setNormalizer` into `normalizer`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -324,14 +324,14 @@ section Normalizer
 variable {H}
 
 @[to_additive]
-theorem normalizer_eq_top_iff : H.normalizer = ⊤ ↔ H.Normal :=
+theorem normalizer_eq_top_iff : normalizer (H : Set G) = ⊤ ↔ H.Normal :=
   eq_top_iff.trans
     ⟨fun h => ⟨fun a ha b => (h (mem_top b) a).mp ha⟩, fun h a _ha b =>
-      ⟨fun hb => h.conj_mem b hb a, fun hb => by rwa [h.mem_comm_iff, inv_mul_cancel_left] at hb⟩⟩
+      ⟨fun hb => h.conj_mem b hb a, fun hb => inv_mul_cancel_left a b ▸ h.mem_comm_iff.mp hb⟩⟩
 
 variable (H) in
 @[to_additive]
-theorem normalizer_eq_top [h : H.Normal] : H.normalizer = ⊤ :=
+theorem normalizer_eq_top [h : H.Normal] : normalizer (H : Set G) = ⊤ :=
   normalizer_eq_top_iff.mpr h
 
 variable {N : Type*} [Group N]
@@ -339,14 +339,14 @@ variable {N : Type*} [Group N]
 /-- The preimage of the normalizer is contained in the normalizer of the preimage. -/
 @[to_additive /-- The preimage of the normalizer is contained in the normalizer of the preimage. -/]
 theorem le_normalizer_comap (f : N →* G) :
-    H.normalizer.comap f ≤ (H.comap f).normalizer := fun x => by
+    (normalizer H).comap f ≤ normalizer (H.comap f) := fun x => by
   simp only [mem_normalizer_iff, mem_comap]
   intro h n
   simp [h (f n)]
 
 /-- The image of the normalizer is contained in the normalizer of the image. -/
 @[to_additive /-- The image of the normalizer is contained in the normalizer of the image. -/]
-theorem le_normalizer_map (f : G →* N) : H.normalizer.map f ≤ (H.map f).normalizer := fun _ => by
+theorem le_normalizer_map (f : G →* N) : (normalizer H).map f ≤ normalizer (H.map f) := fun _ => by
   simp only [and_imp, mem_map, exists_imp, mem_normalizer_iff]
   rintro x hx rfl n
   constructor
@@ -360,7 +360,7 @@ theorem le_normalizer_map (f : G →* N) : H.normalizer.map f ≤ (H.map f).norm
 
 @[to_additive]
 theorem comap_normalizer_eq_of_le_range {f : N →* G} (h : H ≤ f.range) :
-    comap f H.normalizer = (comap f H).normalizer := by
+    (normalizer H).comap f = normalizer (H.comap f) := by
   apply le_antisymm (le_normalizer_comap f)
   rw [← map_le_iff_le_comap]
   apply (le_normalizer_map f).trans
@@ -368,37 +368,38 @@ theorem comap_normalizer_eq_of_le_range {f : N →* G} (h : H ≤ f.range) :
 
 @[to_additive]
 theorem subgroupOf_normalizer_eq {H N : Subgroup G} (h : H ≤ N) :
-    H.normalizer.subgroupOf N = (H.subgroupOf N).normalizer :=
+    (normalizer H).subgroupOf N = normalizer (H.subgroupOf N) :=
   comap_normalizer_eq_of_le_range (h.trans_eq N.range_subtype.symm)
 
 @[to_additive]
 theorem normal_subgroupOf_iff_le_normalizer (h : H ≤ K) :
-    (H.subgroupOf K).Normal ↔ K ≤ H.normalizer := by
+    (H.subgroupOf K).Normal ↔ K ≤ normalizer H := by
   rw [← subgroupOf_eq_top, subgroupOf_normalizer_eq h, normalizer_eq_top_iff]
 
 @[to_additive]
 theorem normal_subgroupOf_iff_le_normalizer_inf :
-    (H.subgroupOf K).Normal ↔ K ≤ (H ⊓ K).normalizer :=
+    (H.subgroupOf K).Normal ↔ K ≤ normalizer (H ⊓ K : Subgroup G) :=
   inf_subgroupOf_right H K ▸ normal_subgroupOf_iff_le_normalizer inf_le_right
 
 @[to_additive]
-instance (priority := 100) normal_in_normalizer : (H.subgroupOf H.normalizer).Normal :=
+instance (priority := 100) normal_in_normalizer : (H.subgroupOf <| normalizer H).Normal :=
   (normal_subgroupOf_iff_le_normalizer H.le_normalizer).mpr le_rfl
 
 @[to_additive]
 theorem le_normalizer_of_normal_subgroupOf [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) :
-    K ≤ H.normalizer :=
+    K ≤ normalizer H :=
   (normal_subgroupOf_iff_le_normalizer HK).mp hK
 
 @[to_additive]
-theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ H.normalizer :=
+theorem subset_normalizer_of_normal {S : Set G} [hH : H.Normal] : S ⊆ normalizer (H : Set G) :=
   (@normalizer_eq_top _ _ H hH) ▸ le_top
 
 @[to_additive]
-theorem le_normalizer_of_normal [H.Normal] : K ≤ H.normalizer := subset_normalizer_of_normal
+theorem le_normalizer_of_normal [H.Normal] : K ≤ normalizer H := subset_normalizer_of_normal
 
 @[to_additive]
-theorem inf_normalizer_le_normalizer_inf : H.normalizer ⊓ K.normalizer ≤ (H ⊓ K).normalizer :=
+theorem inf_normalizer_le_normalizer_inf :
+    normalizer H ⊓ normalizer K ≤ normalizer ((H ⊓ K :) : Set G) :=
   fun _ h g ↦ and_congr (h.1 g) (h.2 g)
 
 variable (G) in
@@ -409,7 +410,7 @@ def _root_.NormalizerCondition :=
 /-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
 This may be easier to work with, as it avoids inequalities and negations. -/
 theorem _root_.normalizerCondition_iff_only_full_group_self_normalizing :
-    NormalizerCondition G ↔ ∀ H : Subgroup G, H.normalizer = H → H = ⊤ := by
+    NormalizerCondition G ↔ ∀ H : Subgroup G, normalizer H = H → H = ⊤ := by
   apply forall_congr'; intro H
   simp only [lt_iff_le_and_ne, le_normalizer, Ne]
   tauto
@@ -624,7 +625,7 @@ variable {N : Type*} [Group N] (f : G →* N)
       /-- The preimage of the normalizer is equal to the normalizer of the preimage of
       a surjective function. -/]
 theorem comap_normalizer_eq_of_surjective (H : Subgroup G) {f : N →* G}
-    (hf : Function.Surjective f) : H.normalizer.comap f = (H.comap f).normalizer :=
+    (hf : Function.Surjective f) : (normalizer H).comap f = normalizer (H.comap f) :=
   comap_normalizer_eq_of_le_range fun x _ ↦ hf x
 
 /-- The image of the normalizer is equal to the normalizer of the image of an isomorphism. -/
@@ -632,7 +633,7 @@ theorem comap_normalizer_eq_of_surjective (H : Subgroup G) {f : N →* G}
       /-- The image of the normalizer is equal to the normalizer of the image of an
       isomorphism. -/]
 theorem map_equiv_normalizer_eq (H : Subgroup G) (f : G ≃* N) :
-    H.normalizer.map f.toMonoidHom = (H.map f.toMonoidHom).normalizer := by
+    (normalizer H).map f.toMonoidHom = normalizer (H.map f.toMonoidHom) := by
   ext x
   simp only [mem_normalizer_iff, mem_map_equiv]
   rw [f.toEquiv.forall_congr]
@@ -645,7 +646,7 @@ theorem map_equiv_normalizer_eq (H : Subgroup G) (f : G ≃* N) :
       /-- The image of the normalizer is equal to the normalizer of the image of a bijective
         function. -/]
 theorem map_normalizer_eq_of_bijective (H : Subgroup G) {f : G →* N} (hf : Function.Bijective f) :
-    H.normalizer.map f = (H.map f).normalizer :=
+    (normalizer H).map f = normalizer (H.map f) :=
   map_equiv_normalizer_eq H (MulEquiv.ofBijective f hf)
 
 end Subgroup
@@ -876,13 +877,13 @@ theorem commute_of_normal_of_disjoint (H₁ H₂ : Subgroup G) (hH₁ : H₁.Nor
 
 @[to_additive]
 theorem normal_subgroupOf_of_le_normalizer {H N : Subgroup G}
-    (hLE : H ≤ N.normalizer) : (N.subgroupOf H).Normal := by
+    (hLE : H ≤ normalizer N) : (N.subgroupOf H).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer_inf]
   exact (le_inf hLE H.le_normalizer).trans inf_normalizer_le_normalizer_inf
 
 @[to_additive]
 theorem normal_subgroupOf_sup_of_le_normalizer {H N : Subgroup G}
-    (hLE : H ≤ N.normalizer) : (N.subgroupOf (H ⊔ N)).Normal := by
+    (hLE : H ≤ normalizer N) : (N.subgroupOf (H ⊔ N)).Normal := by
   rw [normal_subgroupOf_iff_le_normalizer le_sup_right]
   exact sup_le hLE le_normalizer
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -657,26 +657,12 @@ variable (H : Subgroup G)
 
 section Normalizer
 
-/-- The `normalizer` of `H` is the largest subgroup of `G` inside which `H` is normal. -/
+/-- The `normalizer` of `S` is the subgroup of `G` whose elements satisfy `g * S * g⁻¹ = S`.
+When `S` is a subgroup, this is the largest subgroup of `G` inside which `S` is normal. -/
 @[to_additive
-/-- The `normalizer` of `H` is the largest subgroup of `G` inside which `H` is normal. -/]
-def normalizer : Subgroup G where
-  carrier := { g : G | ∀ n, n ∈ H ↔ g * n * g⁻¹ ∈ H }
-  one_mem' := by simp
-  mul_mem' {a b} (ha : ∀ n, n ∈ H ↔ a * n * a⁻¹ ∈ H) (hb : ∀ n, n ∈ H ↔ b * n * b⁻¹ ∈ H) n := by
-    rw [hb, ha]
-    simp only [mul_assoc, mul_inv_rev]
-  inv_mem' {a} (ha : ∀ n, n ∈ H ↔ a * n * a⁻¹ ∈ H) n := by
-    rw [ha (a⁻¹ * n * a⁻¹⁻¹)]
-    simp only [inv_inv, mul_assoc, mul_inv_cancel_left, mul_inv_cancel, mul_one]
-
--- variant for sets.
--- TODO should this replace `normalizer`?
-/-- The `setNormalizer` of `S` is the subgroup of `G` whose elements satisfy `g*S*g⁻¹=S` -/
-@[to_additive
-      /-- The `setNormalizer` of `S` is the subgroup of `G` whose elements satisfy
-      `g+S-g=S`. -/]
-def setNormalizer (S : Set G) : Subgroup G where
+/-- The `normalizer` of `S` is the subgroup of `G` whose elements satisfy `g + S - g = S`.
+When `S` is a subgroup, this is the largest subgroup of `G` inside which `S` is normal. -/]
+def normalizer (S : Set G) : Subgroup G where
   carrier := { g : G | ∀ n, n ∈ S ↔ g * n * g⁻¹ ∈ S }
   one_mem' := by simp
   mul_mem' {a b} (ha : ∀ n, n ∈ S ↔ a * n * a⁻¹ ∈ S) (hb : ∀ n, n ∈ S ↔ b * n * b⁻¹ ∈ S) n := by
@@ -686,24 +672,27 @@ def setNormalizer (S : Set G) : Subgroup G where
     rw [ha (a⁻¹ * n * a⁻¹⁻¹)]
     simp only [inv_inv, mul_assoc, mul_inv_cancel_left, mul_inv_cancel, mul_one]
 
+@[deprecated (since := "2026-03-19")] alias setNormalizer := normalizer
+
 variable {H}
 
 @[to_additive]
-theorem mem_normalizer_iff {g : G} : g ∈ H.normalizer ↔ ∀ h, h ∈ H ↔ g * h * g⁻¹ ∈ H :=
+theorem mem_normalizer_iff {g : G} : g ∈ normalizer H ↔ ∀ h, h ∈ H ↔ g * h * g⁻¹ ∈ H :=
   Iff.rfl
 
 @[to_additive]
-theorem mem_normalizer_iff'' {g : G} : g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
+theorem mem_normalizer_iff'' {g : G} : g ∈ normalizer H ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H := by
   rw [← inv_mem_iff (x := g), mem_normalizer_iff, inv_inv]
 
 @[to_additive]
-theorem mem_normalizer_iff' {g : G} : g ∈ H.normalizer ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
-  ⟨fun h n => by rw [h, mul_assoc, mul_inv_cancel_right], fun h n => by
-    rw [mul_assoc, ← h, inv_mul_cancel_right]⟩
+theorem mem_normalizer_iff' {g : G} : g ∈ normalizer H ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
+  ⟨fun h n ↦ by rw [← SetLike.mem_coe, ← SetLike.mem_coe, h, mul_assoc, mul_inv_cancel_right],
+    fun h n ↦ by rw [SetLike.mem_coe, SetLike.mem_coe, mul_assoc, ← h, inv_mul_cancel_right]⟩
 
 @[to_additive]
 theorem le_normalizer : H ≤ normalizer H := fun x xH n => by
-  rw [H.mul_mem_cancel_right (H.inv_mem xH), H.mul_mem_cancel_left xH]
+  rw [SetLike.mem_coe, SetLike.mem_coe, H.mul_mem_cancel_right <| H.inv_mem xH,
+    H.mul_mem_cancel_left xH]
 
 end Normalizer
 

--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -211,7 +211,7 @@ end Pi
 section Normalizer
 
 theorem mem_normalizer_fintype {S : Set G} [Finite S] {x : G} (h : ∀ n, n ∈ S → x * n * x⁻¹ ∈ S) :
-    x ∈ Subgroup.setNormalizer S := by
+    x ∈ Subgroup.normalizer S := by
   haveI := Classical.propDecidable; cases nonempty_fintype S
   exact fun n =>
     ⟨h n, fun h₁ =>

--- a/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/MulOpposite.lean
@@ -114,12 +114,14 @@ def equivOp (H : Subgroup G) : H ≃ H.op :=
   MulOpposite.opEquiv.subtypeEquiv fun _ => Iff.rfl
 
 @[to_additive]
-theorem op_normalizer (H : Subgroup G) : H.normalizer.op = H.op.normalizer := by
+theorem op_normalizer (H : Subgroup G) : (normalizer H : Subgroup G).op = normalizer H.op := by
   ext x
-  simp [mem_normalizer_iff', iff_comm]
+  rw [mem_op, mem_normalizer_iff', mem_normalizer_iff']
+  simp [iff_comm]
 
 @[to_additive]
-theorem unop_normalizer (H : Subgroup Gᵐᵒᵖ) : H.normalizer.unop = H.unop.normalizer := by
+theorem unop_normalizer (H : Subgroup Gᵐᵒᵖ) :
+    (normalizer H).unop = normalizer (H.unop : Set G) := by
   rw [← op_inj, op_unop, op_normalizer, op_unop]
 
 end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -239,7 +239,7 @@ theorem sup_eq_closure_mul (H K : Subgroup G) : H ⊔ K = closure ((H : Set G) *
     ((closure_mul_le _ _).trans <| by rw [closure_eq, closure_eq])
 
 @[to_additive]
-theorem set_mul_normalizer_comm (S : Set G) (N : Subgroup G) (hLE : S ⊆ N.normalizer) :
+theorem set_mul_normalizer_comm (S : Set G) (N : Subgroup G) (hLE : S ⊆ normalizer (N : Set G)) :
     S * N = N * S := by
   rw [← iUnion_mul_left_image, ← iUnion_mul_right_image]
   simp only [image_mul_left, image_mul_right, Set.preimage]
@@ -254,7 +254,7 @@ theorem set_mul_normal_comm (S : Set G) (N : Subgroup G) [hN : N.Normal] :
 when `H` is a subgroup of the normalizer of `N` in `G`. -/
 @[to_additive /-- The carrier of `H ⊔ N` is just `↑H + ↑N` (pointwise set addition)
 when `H` is a subgroup of the normalizer of `N` in `G`. -/]
-theorem coe_mul_of_left_le_normalizer_right (H N : Subgroup G) (hLE : H ≤ N.normalizer) :
+theorem coe_mul_of_left_le_normalizer_right (H N : Subgroup G) (hLE : H ≤ normalizer N) :
     (↑(H ⊔ N) : Set G) = H * N := by
   rw [sup_eq_closure_mul]
   refine Set.Subset.antisymm (fun x hx => ?_) subset_closure
@@ -276,7 +276,7 @@ theorem coe_mul_of_left_le_normalizer_right (H N : Subgroup G) (hLE : H ≤ N.no
 `H` is a subgroup of the normalizer of `N` in `G`. -/
 @[to_additive /-- The carrier of `N ⊔ H` is just `↑N + ↑H` (pointwise set addition)
 when `H` is a subgroup of the normalizer of `N` in `G`. -/]
-theorem coe_mul_of_right_le_normalizer_left (N H : Subgroup G) (hLE : H ≤ N.normalizer) :
+theorem coe_mul_of_right_le_normalizer_left (N H : Subgroup G) (hLE : H ≤ normalizer N) :
     (↑(N ⊔ H) : Set G) = N * H := by
   rw [← set_mul_normalizer_comm _ _ hLE, sup_comm, coe_mul_of_left_le_normalizer_right _ _ hLE]
 
@@ -497,7 +497,7 @@ theorem normalCore_eq_iInf_conjAct (H : Subgroup G) :
 
 lemma conjAct_pointwise_smul_iff {H : Subgroup G} {g : G} :
     ConjAct.toConjAct g • H = H ↔ g ∈ normalizer H := by
-  rw [← H.normalizer.inv_mem_iff]
+  rw [← (normalizer H : Subgroup G).inv_mem_iff]
   simp only [Subgroup.ext_iff, mem_pointwise_smul_iff_inv_smul_mem,
     ← ConjAct.toConjAct_inv, ConjAct.toConjAct_smul, mem_normalizer_iff, inv_inv, Iff.comm]
 

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -66,7 +66,7 @@ instance left_quotientAction : QuotientAction α H :=
   ⟨fun _ _ _ _ => by rwa [smul_eq_mul, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left]⟩
 
 @[to_additive]
-instance right_quotientAction : QuotientAction (normalizer H).op H :=
+instance right_quotientAction : QuotientAction (normalizer H : Subgroup α).op H :=
   ⟨fun b c _ _ => by
     rwa [smul_def, smul_def, smul_eq_mul_unop, smul_eq_mul_unop, mul_inv_rev, ← mul_assoc,
       mem_normalizer_iff'.mp b.prop, mul_assoc, mul_inv_cancel_left]⟩

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -885,7 +885,7 @@ theorem normalizerCondition_of_isNilpotent [h : IsNilpotent G] : NormalizerCondi
     have hkh : (mk' (center G)).ker ≤ H := by simpa using hch
     have hsur : Function.Surjective (mk' (center G)) := Quot.mk_surjective
     let H' := H.map (mk' (center G))
-    have hH' : H'.normalizer = H' := by
+    have hH' : normalizer H' = H' := by
       apply comap_injective hsur
       rw [comap_normalizer_eq_of_surjective _ hsur, comap_map_eq_self hkh]
       exact hH

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -278,17 +278,17 @@ theorem to_sup_of_normal_left {H K : Subgroup G} (hH : IsPGroup p H) (hK : IsPGr
     [H.Normal] : IsPGroup p (H ⊔ K : Subgroup G) := sup_comm H K ▸ to_sup_of_normal_right hK hH
 
 theorem to_sup_of_normal_right' {H K : Subgroup G} (hH : IsPGroup p H) (hK : IsPGroup p K)
-    (hHK : H ≤ K.normalizer) : IsPGroup p (H ⊔ K : Subgroup G) :=
+    (hHK : H ≤ Subgroup.normalizer K) : IsPGroup p (H ⊔ K : Subgroup G) :=
   let hHK' :=
     to_sup_of_normal_right (hH.of_equiv (Subgroup.subgroupOfEquivOfLe hHK).symm)
       (hK.of_equiv (Subgroup.subgroupOfEquivOfLe Subgroup.le_normalizer).symm)
-  ((congr_arg (fun H : Subgroup K.normalizer => IsPGroup p H)
+  ((congr_arg (fun H : Subgroup (Subgroup.normalizer K) => IsPGroup p H)
             ((Subgroup.subgroupOf_sup hHK Subgroup.le_normalizer).symm)).mp
         hHK').of_equiv
     (Subgroup.subgroupOfEquivOfLe (sup_le hHK Subgroup.le_normalizer))
 
 theorem to_sup_of_normal_left' {H K : Subgroup G} (hH : IsPGroup p H) (hK : IsPGroup p K)
-    (hHK : K ≤ H.normalizer) : IsPGroup p (H ⊔ K : Subgroup G) :=
+    (hHK : K ≤ Subgroup.normalizer H) : IsPGroup p (H ⊔ K : Subgroup G) :=
   sup_comm H K ▸ to_sup_of_normal_right' hK hH hHK
 
 /-- finite p-groups with different p have coprime orders -/

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -264,7 +264,7 @@ defines an isomorphism between `H/(H ∩ N)` and `(HN)/N`. -/
 subgroup `H` of the normalizer of `N` in `G`,
 defines an isomorphism between `H/(H ∩ N)` and `(H + N)/N` -/]
 noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
-    (hLE : H ≤ N.normalizer) :
+    (hLE : H ≤ normalizer N) :
     letI := Subgroup.normal_subgroupOf_of_le_normalizer hLE
     letI := Subgroup.normal_subgroupOf_sup_of_le_normalizer hLE
     H ⧸ N.subgroupOf H ≃* (H ⊔ N : Subgroup G) ⧸ N.subgroupOf (H ⊔ N) :=

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -241,7 +241,7 @@ private theorem step6 : IsPGroup (Nat.card N).minFac N := by
   refine Sylow.nonempty.elim fun P => P.2.of_surjective P.1.subtype ?_
   rw [← MonoidHom.range_eq_top, range_subtype]
   haveI : (P.1.map N.subtype).Normal :=
-    normalizer_eq_top_iff.mp (step1 h1 h2 h3 (P.map N.subtype).normalizer P.normalizer_sup_eq_top)
+    normalizer_eq_top_iff.mp (step1 h1 h2 h3 _ P.normalizer_sup_eq_top)
   exact (step3 h1 h2 h3 P.1).resolve_left (step5 h1 h3)
 
 include h2 in

--- a/Mathlib/GroupTheory/SemidirectProduct.lean
+++ b/Mathlib/GroupTheory/SemidirectProduct.lean
@@ -229,7 +229,7 @@ theorem hom_ext {f g : N ⋊[φ] G →* H} (hl : f.comp inl = g.comp inl)
 
 /-- The homomorphism from a semidirect product of subgroups to the ambient group. -/
 @[simps!]
-def monoidHomSubgroup {H K : Subgroup G} (h : K ≤ H.normalizer) :
+def monoidHomSubgroup {H K : Subgroup G} (h : K ≤ normalizer H) :
     H ⋊[(H.normalizerMonoidHom).comp (inclusion h)] K →* G :=
   lift H.subtype K.subtype (by simp [DFunLike.ext_iff])
 

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -210,8 +210,8 @@ theorem smul_mul_inv_trivial_or_surjective [IsCyclic G] (hG : IsPGroup p G)
 /-- If a cyclic `p`-subgroup `P` acts by conjugation on a subgroup `K` of coprime order, then
   either `⁅K, P⁆ = ⊥` or `⁅K, P⁆ = P`. -/
 theorem commutator_eq_bot_or_commutator_eq_self {P K : Subgroup G} [IsCyclic P]
-    (hP : IsPGroup p P) (hKP : K ≤ P.normalizer) (hPK : (Nat.card P).Coprime (Nat.card K)) :
-    ⁅K, P⁆ = ⊥ ∨ ⁅K, P⁆ = P := by
+    (hP : IsPGroup p P) (hKP : K ≤ Subgroup.normalizer (P : Subgroup G))
+    (hPK : (Nat.card P).Coprime (Nat.card K)) : ⁅K, P⁆ = ⊥ ∨ ⁅K, P⁆ = P := by
   let _ := MulDistribMulAction.compHom P (P.normalizerMonoidHom.comp (Subgroup.inclusion hKP))
   refine (smul_mul_inv_trivial_or_surjective hP hPK).imp (fun h ↦ ?_) fun h ↦ ?_
   · rw [eq_bot_iff, Subgroup.commutator_le]
@@ -247,15 +247,15 @@ theorem le_center_or_le_commutator [P.Normal] : P ≤ Subgroup.center G ∨ P �
 /-- A cyclic Sylow subgroup is either central in its normalizer or contained in the commutator
   subgroup. -/
 theorem normalizer_le_centralizer_or_le_commutator :
-    P.normalizer ≤ Subgroup.centralizer P ∨ P ≤ commutator G := by
-  let Q : Sylow p P.normalizer := P.subtype P.le_normalizer
+    Subgroup.normalizer (P : Subgroup G) ≤ Subgroup.centralizer (P : Set G) ∨ P ≤ commutator G := by
+  let Q : Sylow p (Subgroup.normalizer (P : Subgroup G)) := P.subtype P.le_normalizer
   have : Q.Normal := P.normal_in_normalizer
   have : IsCyclic Q :=
     isCyclic_of_surjective _ (Subgroup.subgroupOfEquivOfLe P.le_normalizer).symm.surjective
   refine (le_center_or_le_commutator Q).imp (fun h ↦ ?_) (fun h ↦ ?_)
   · rw [← SetLike.coe_subset_coe, ← Subgroup.centralizer_eq_top_iff_subset, eq_top_iff,
       ← Subgroup.map_subtype_le_map_subtype, ← MonoidHom.range_eq_map,
-      P.normalizer.range_subtype] at h
+      (Subgroup.normalizer ((P : Subgroup G) : Set G)).range_subtype] at h
     replace h := h.trans (Subgroup.map_centralizer_le_centralizer_image _ _)
     rwa [← Subgroup.coe_map, P.coe_subtype, Subgroup.map_subgroupOf_eq_of_le P.le_normalizer] at h
   · rw [P.coe_subtype, ← Subgroup.map_subtype_le_map_subtype,

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -98,7 +98,7 @@ instance instNormalCenter : (center G).Normal :=
   ⟨fun a ha b ↦ by simp [mul_assoc, mem_center_iff.mp ha b, ha]⟩
 
 @[to_additive]
-theorem center_le_normalizer : center G ≤ H.normalizer := fun x hx y => by
+theorem center_le_normalizer : center G ≤ normalizer H := fun x hx y => by
   simp [← mem_center_iff.mp hx y, mul_assoc]
 
 end Normalizer

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -134,7 +134,7 @@ abbrev closureCommGroupOfComm {k : Set G} (hcomm : ∀ x ∈ k, ∀ y ∈ k, x *
 
 /-- The conjugation action of N(H) on H. -/
 @[simps]
-instance : MulDistribMulAction H.normalizer H where
+instance : MulDistribMulAction (normalizer H : Subgroup G) H where
   smul g h := ⟨g * h * g⁻¹, (g.2 h).mp h.2⟩
   one_smul g := by simp [HSMul.hSMul]
   mul_smul := by simp [HSMul.hSMul, mul_assoc]
@@ -143,11 +143,11 @@ instance : MulDistribMulAction H.normalizer H where
 
 /-- The homomorphism N(H) → Aut(H) with kernel C(H). -/
 @[simps!]
-def normalizerMonoidHom : H.normalizer →* MulAut H :=
-  MulDistribMulAction.toMulAut H.normalizer H
+def normalizerMonoidHom : normalizer (H : Set G) →* MulAut H :=
+  MulDistribMulAction.toMulAut (normalizer H : Subgroup G) H
 
 theorem normalizerMonoidHom_ker :
-    H.normalizerMonoidHom.ker = (Subgroup.centralizer H).subgroupOf H.normalizer := by
+    H.normalizerMonoidHom.ker = (centralizer H).subgroupOf (normalizer H : Subgroup G) := by
   simp [Subgroup.ext_iff, DFunLike.ext_iff, Subtype.ext_iff,
     mem_subgroupOf, mem_centralizer_iff, eq_mul_inv_iff_mul_eq, eq_comm]
 

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -256,7 +256,7 @@ theorem smul_subtype {P : Sylow p G} {H : Subgroup G} (hP : P ≤ H) (h : H) :
   ext (Subgroup.conj_smul_subgroupOf hP h)
 
 theorem smul_eq_iff_mem_normalizer {g : G} {P : Sylow p G} :
-    g • P = P ↔ g ∈ P.normalizer := by
+    g • P = P ↔ g ∈ normalizer (P : Subgroup G) := by
   rw [eq_comm, SetLike.ext_iff, ← inv_mem_iff (G := G) (H := normalizer P.toSubgroup),
       mem_normalizer_iff, inv_inv]
   exact
@@ -271,11 +271,11 @@ theorem smul_eq_of_normal {g : G} {P : Sylow p G} [h : P.Normal] :
 end Sylow
 
 theorem Subgroup.sylow_mem_fixedPoints_iff (H : Subgroup G) {P : Sylow p G} :
-    P ∈ fixedPoints H (Sylow p G) ↔ H ≤ P.normalizer := by
+    P ∈ fixedPoints H (Sylow p G) ↔ H ≤ normalizer (P : Subgroup G) := by
   simp_rw [SetLike.le_def, ← Sylow.smul_eq_iff_mem_normalizer]; exact Subtype.forall
 
 theorem IsPGroup.inf_normalizer_sylow {P : Subgroup G} (hP : IsPGroup p P) (Q : Sylow p G) :
-    P ⊓ Q.normalizer = P ⊓ Q :=
+    P ⊓ normalizer (Q : Subgroup G) = P ⊓ Q :=
   le_antisymm
     (le_inf inf_le_left
       (sup_eq_right.mp
@@ -354,13 +354,13 @@ theorem orbit_eq_top [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) : orbit
   top_le_iff.mp fun Q _ => exists_smul_eq G P Q
 
 theorem stabilizer_eq_normalizer (P : Sylow p G) :
-    stabilizer G P = P.normalizer := by
+    stabilizer G P = normalizer (P : Subgroup G) := by
   ext; simp [smul_eq_iff_mem_normalizer]
 
 theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow p G)]
     (P : Sylow p G) (x g : G) (hx : x ∈ centralizer P)
     (hy : g⁻¹ * x * g ∈ centralizer P) :
-    ∃ n ∈ P.normalizer, g⁻¹ * x * g = n⁻¹ * x * n := by
+    ∃ n ∈ normalizer (P : Subgroup G), g⁻¹ * x * g = n⁻¹ * x * n := by
   have h1 : P ≤ centralizer (zpowers x : Set G) := by rwa [le_centralizer_iff, zpowers_le]
   have h2 : ↑(g • P) ≤ centralizer (zpowers x : Set G) := by
     rw [le_centralizer_iff, zpowers_le]
@@ -376,29 +376,29 @@ theorem conj_eq_normalizer_conj_of_mem_centralizer [Fact p.Prime] [Finite (Sylow
 
 theorem conj_eq_normalizer_conj_of_mem [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
     [_hP : IsMulCommutative P] (x g : G) (hx : x ∈ P) (hy : g⁻¹ * x * g ∈ P) :
-    ∃ n ∈ P.normalizer, g⁻¹ * x * g = n⁻¹ * x * n :=
+    ∃ n ∈ normalizer (P : Subgroup G), g⁻¹ * x * g = n⁻¹ * x * n :=
   P.conj_eq_normalizer_conj_of_mem_centralizer x g
     (P.le_centralizer hx) (P.le_centralizer hy)
 
 /-- Sylow `p`-subgroups are in bijection with cosets of the normalizer of a Sylow `p`-subgroup -/
 noncomputable def equivQuotientNormalizer [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) : Sylow p G ≃ G ⧸ P.normalizer :=
+    (P : Sylow p G) : Sylow p G ≃ G ⧸ normalizer (P : Subgroup G) :=
   calc
     Sylow p G ≃ (⊤ : Set (Sylow p G)) := (Equiv.Set.univ (Sylow p G)).symm
     _ ≃ orbit G P := Equiv.setCongr P.orbit_eq_top.symm
     _ ≃ G ⧸ stabilizer G P := orbitEquivQuotientStabilizer G P
-    _ ≃ G ⧸ P.normalizer := by rw [P.stabilizer_eq_normalizer]
+    _ ≃ G ⧸ normalizer (P : Subgroup G) := by rw [P.stabilizer_eq_normalizer]
 
 instance [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    Finite (G ⧸ P.normalizer) :=
+    Finite (G ⧸ normalizer (P : Subgroup G)) :=
   Finite.of_equiv (Sylow p G) P.equivQuotientNormalizer
 
 theorem card_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
-    (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ P.normalizer) :=
+    (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ normalizer (P : Subgroup G)) :=
   Nat.card_congr P.equivQuotientNormalizer
 
 theorem card_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    Nat.card (Sylow p G) = P.normalizer.index :=
+    Nat.card (Sylow p G) = (normalizer ((P : Subgroup G) : Set G)).index :=
   P.card_eq_card_quotient_normalizer
 
 theorem card_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
@@ -426,7 +426,7 @@ private theorem not_dvd_index_aux [hp : Fact p.Prime] (P : Sylow p G) [P.Normal]
 
 /-- A Sylow p-subgroup has index indivisible by `p`, assuming [N(P) : P] < ∞. -/
 theorem not_dvd_index' [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (hP : P.relIndex P.normalizer ≠ 0) : ¬ p ∣ P.index := by
+    (hP : P.relIndex (normalizer (P : Subgroup G)) ≠ 0) : ¬ p ∣ P.index := by
   rw [← relIndex_mul_index le_normalizer, ← card_eq_index_normalizer]
   haveI : (P.subtype le_normalizer).Normal :=
     Subgroup.normal_in_normalizer
@@ -475,7 +475,7 @@ end mapSurjective
   of `N`, then `N_G(P) ⊔ N = G`. -/
 theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
     [Finite (Sylow p N)] (P : Sylow p N) :
-    (P.map N.subtype).normalizer ⊔ N = ⊤ := by
+    normalizer (P.map N.subtype) ⊔ N = ⊤ := by
   refine top_le_iff.mp fun g _ => ?_
   obtain ⟨n, hn⟩ := exists_smul_eq N ((MulAut.conjNormal g : MulAut N) • P) P
   rw [← inv_mul_cancel_left (↑n) g, sup_comm]
@@ -490,7 +490,7 @@ theorem normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Norma
 /-- **Frattini's Argument**: If `N` is a normal subgroup of `G`, and if `P` is a Sylow `p`-subgroup
   of `N`, then `N_G(P) ⊔ N = G`. -/
 theorem normalizer_sup_eq_top' {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N.Normal]
-    [Finite (Sylow p N)] (P : Sylow p G) (hP : P ≤ N) : P.normalizer ⊔ N = ⊤ := by
+    [Finite (Sylow p N)] (P : Sylow p G) (hP : P ≤ N) : normalizer (P : Subgroup G) ⊔ N = ⊤ := by
   rw [← normalizer_sup_eq_top (P.subtype hP), P.coe_subtype, subgroupOf_map_subtype,
     inf_of_le_left hP]
 
@@ -534,21 +534,21 @@ theorem mem_fixedPoints_mul_left_cosets_iff_mem_normalizer {H : Subgroup G} [Fin
 /-- The fixed points of the action of `H` on its cosets correspond to `normalizer H / H`. -/
 def fixedPointsMulLeftCosetsEquivQuotient (H : Subgroup G) [Finite (H : Set G)] :
     MulAction.fixedPoints H (G ⧸ H) ≃
-      normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H :=
+      normalizer H ⧸ H.comap (normalizer (H : Set G)).subtype :=
   @subtypeQuotientEquivQuotientSubtype G (· ∈ normalizer H) (_) (_)
     (· ∈ MulAction.fixedPoints H (G ⧸ H))
     (fun _ => (@mem_fixedPoints_mul_left_cosets_iff_mem_normalizer _ _ _ ‹_› _).symm)
     (by
       intros
       unfold_projs
-      rw [leftRel_apply (α := normalizer H), leftRel_apply]
+      rw [leftRel_apply (α := normalizer (H : Set G)), leftRel_apply]
       rfl)
 
 /-- If `H` is a `p`-subgroup of `G`, then the index of `H` inside its normalizer is congruent
   mod `p` to the index of `H`. -/
 theorem card_quotient_normalizer_modEq_card_quotient [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
     {H : Subgroup G} (hH : Nat.card H = p ^ n) :
-    Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) ≡
+    Nat.card (normalizer H ⧸ H.comap (normalizer (H : Set G)).subtype) ≡
       Nat.card (G ⧸ H) [MOD p] := by
   rw [← Nat.card_congr (fixedPointsMulLeftCosetsEquivQuotient H)]
   exact ((IsPGroup.of_card hH).card_modEq_card_fixedPoints _).symm
@@ -556,7 +556,8 @@ theorem card_quotient_normalizer_modEq_card_quotient [Finite G] {p : ℕ} {n : �
 /-- If `H` is a subgroup of `G` of cardinality `p ^ n`, then the cardinality of the
   normalizer of `H` is congruent mod `p ^ (n + 1)` to the cardinality of `G`. -/
 theorem card_normalizer_modEq_card [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime] {H : Subgroup G}
-    (hH : Nat.card H = p ^ n) : Nat.card (normalizer H) ≡ Nat.card G [MOD p ^ (n + 1)] := by
+    (hH : Nat.card H = p ^ n) :
+    Nat.card (normalizer (H : Set G)) ≡ Nat.card G [MOD p ^ (n + 1)] := by
   have : H.subgroupOf (normalizer H) ≃ H := (subgroupOfEquivOfLe le_normalizer).toEquiv
   rw [card_eq_card_quotient_mul_card_subgroup H,
     card_eq_card_quotient_mul_card_subgroup (H.subgroupOf (normalizer H)), Nat.card_congr this,
@@ -567,7 +568,7 @@ theorem card_normalizer_modEq_card [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.P
   index of `H` inside its normalizer. -/
 theorem prime_dvd_card_quotient_normalizer [Finite G] {p : ℕ} {n : ℕ} [Fact p.Prime]
     (hdvd : p ^ (n + 1) ∣ Nat.card G) {H : Subgroup G} (hH : Nat.card H = p ^ n) :
-    p ∣ Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) :=
+    p ∣ Nat.card (normalizer (H : Set G) ⧸ H.comap (normalizer (H : Set G)).subtype) :=
   let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd
   have hcard : Nat.card (G ⧸ H) = s * p :=
     (mul_left_inj' (show Nat.card H ≠ 0 from Nat.card_pos.ne')).1
@@ -575,7 +576,7 @@ theorem prime_dvd_card_quotient_normalizer [Finite G] {p : ℕ} {n : ℕ} [Fact 
         rw [← card_eq_card_quotient_mul_card_subgroup H, hH, hs, pow_succ', mul_assoc, mul_comm p])
   have hm :
     s * p % p =
-      Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) % p :=
+      Nat.card (normalizer H ⧸ H.comap (normalizer (H : Set G)).subtype) % p :=
     hcard ▸ (card_quotient_normalizer_modEq_card_quotient hH).symm
   Nat.dvd_of_mod_eq_zero (by rwa [Nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm)
 
@@ -583,7 +584,7 @@ theorem prime_dvd_card_quotient_normalizer [Finite G] {p : ℕ} {n : ℕ} [Fact 
   then `p ^ (n + 1)` divides the cardinality of the normalizer of `H`. -/
 theorem prime_pow_dvd_card_normalizer [Finite G] {p : ℕ} {n : ℕ} [_hp : Fact p.Prime]
     (hdvd : p ^ (n + 1) ∣ Nat.card G) {H : Subgroup G} (hH : Nat.card H = p ^ n) :
-    p ^ (n + 1) ∣ Nat.card (normalizer H) :=
+    p ^ (n + 1) ∣ Nat.card (normalizer (H : Set G)) :=
   Nat.modEq_zero_iff_dvd.1 ((card_normalizer_modEq_card hH).trans hdvd.modEq_zero_nat)
 
 /-- If `H` is a subgroup of `G` of cardinality `p ^ n`,
@@ -597,27 +598,24 @@ theorem exists_subgroup_card_pow_succ [Finite G] {p : ℕ} {n : ℕ} [hp : Fact 
     (mul_left_inj' (show Nat.card H ≠ 0 from Nat.card_pos.ne')).1
       (by
         rw [← card_eq_card_quotient_mul_card_subgroup H, hH, hs, pow_succ', mul_assoc, mul_comm p])
-  have hm : s * p % p = Nat.card (normalizer H ⧸ H.subgroupOf H.normalizer) % p :=
+  have hm : s * p % p = Nat.card (normalizer H ⧸ H.subgroupOf (normalizer H)) % p :=
     Nat.card_congr (fixedPointsMulLeftCosetsEquivQuotient H) ▸
       hcard ▸ (IsPGroup.of_card hH).card_modEq_card_fixedPoints _
-  have hm' : p ∣ Nat.card (normalizer H ⧸ H.subgroupOf H.normalizer) :=
+  have hm' : p ∣ Nat.card (normalizer H ⧸ H.subgroupOf (normalizer H)) :=
     Nat.dvd_of_mod_eq_zero (by rwa [Nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm)
   let ⟨x, hx⟩ := @exists_prime_orderOf_dvd_card' _ (QuotientGroup.Quotient.group _) _ _ hp hm'
-  have hequiv : H ≃ H.subgroupOf H.normalizer := (subgroupOfEquivOfLe le_normalizer).symm.toEquiv
-  ⟨Subgroup.map (normalizer H).subtype
-      (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x)), by
-    show Nat.card (Subgroup.map H.normalizer.subtype
-              (comap (mk' (H.subgroupOf H.normalizer)) (Subgroup.zpowers x))) = p ^ (n + 1)
+  have hequiv : H ≃ H.subgroupOf (normalizer H) := (subgroupOfEquivOfLe le_normalizer).symm.toEquiv
+  ⟨((zpowers x).comap (mk' (H.subgroupOf (normalizer H)))).map (normalizer H).subtype, by
+    show Nat.card (Subgroup.map (normalizer (H : Set G)).subtype
+      (comap (mk' (H.subgroupOf (normalizer H))) (Subgroup.zpowers x))) = p ^ (n + 1)
     suffices Nat.card (Subtype.val ''
-              (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x) : Set H.normalizer)) =
-        p ^ (n + 1)
+      ((zpowers x).comap (mk' (H.subgroupOf (normalizer H))) : Set (normalizer H))) = p ^ (n + 1)
       by convert this using 2
     rw [Nat.card_image_of_injective Subtype.val_injective
-        (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x) : Set H.normalizer),
-      pow_succ, ← hH, Nat.card_congr hequiv, ← hx, ← Nat.card_zpowers, ←
-      Nat.card_prod]
+        ((zpowers x).comap (mk' (H.subgroupOf (normalizer H))) : Set (normalizer (H : Set G))),
+      pow_succ, ← hH, Nat.card_congr hequiv, ← hx, ← Nat.card_zpowers, ← Nat.card_prod]
     exact Nat.card_congr
-      (preimageMkEquivSubgroupProdSet (H.subgroupOf H.normalizer) (zpowers x)), by
+      (preimageMkEquivSubgroupProdSet (H.subgroupOf (normalizer H)) (zpowers x)), by
     intro y hy
     simp only [Subgroup.coe_subtype, mk'_apply, Subgroup.mem_map, Subgroup.mem_comap]
     refine ⟨⟨y, le_normalizer hy⟩, ⟨0, ?_⟩, rfl⟩
@@ -741,12 +739,12 @@ theorem characteristic_of_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (
   exact characteristic_of_subsingleton _
 
 theorem normal_of_normalizer_normal {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
-    (hn : P.normalizer.Normal) : P.Normal := by
+    (hn : (normalizer ((P : Subgroup G) : Set G)).Normal) : P.Normal := by
   rw [← normalizer_eq_top_iff, ← normalizer_sup_eq_top' P le_normalizer, sup_idem]
 
 @[simp]
 theorem normalizer_normalizer {p : ℕ} [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
-    P.normalizer.normalizer = P.normalizer := by
+    normalizer (normalizer ((P : Subgroup G) : Set G)) = normalizer ((P : Subgroup G) : Set G) := by
   have := normal_of_normalizer_normal (P.subtype (le_normalizer.trans le_normalizer))
   rw [coe_subtype, normal_subgroupOf_iff_le_normalizer (le_normalizer.trans le_normalizer),
     ← subgroupOf_normalizer_eq (le_normalizer.trans le_normalizer)] at this
@@ -757,7 +755,8 @@ theorem normal_of_all_max_subgroups_normal [Finite G]
     (P : Sylow p G) : P.Normal :=
   normalizer_eq_top_iff.mp
     (by
-      rcases eq_top_or_exists_le_coatom P.normalizer with (heq | ⟨K, hK, hNK⟩)
+      rcases eq_top_or_exists_le_coatom (normalizer ((P : Subgroup G) : Set G))
+        with (heq | ⟨K, hK, hNK⟩)
       · exact heq
       · haveI := hnc _ hK
         have hPK : P ≤ K := le_trans le_normalizer hNK

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -238,7 +238,7 @@ theorem transferCenterPow_apply [FiniteIndex (center G)] (g : G) :
 
 section BurnsideTransfer
 
-variable {p : ℕ} (P : Sylow p G) (hP : (P : Subgroup G).normalizer ≤ centralizer (P : Set G))
+variable {p : ℕ} (P : Sylow p G) (hP : normalizer (P : Subgroup G) ≤ centralizer (P : Set G))
 include hP
 
 /-- The homomorphism `G →* P` in Burnside's transfer theorem. -/
@@ -305,11 +305,12 @@ open Subgroup
 variable {G : Type*} [Group G] [Finite G] {p : ℕ} (hp : (Nat.card G).minFac = p) {P : Sylow p G}
 
 include hp in
-theorem normalizer_le_centralizer (hP : IsCyclic P) : P.normalizer ≤ centralizer (P : Set G) := by
+theorem normalizer_le_centralizer (hP : IsCyclic P) :
+    normalizer (P : Subgroup G) ≤ centralizer (P : Set G) := by
   subst hp
   by_cases hn : Nat.card G = 1
   · have := (Nat.card_eq_one_iff_unique.mp hn).1
-    rw [Subsingleton.elim P.normalizer (centralizer P)]
+    rw [Subsingleton.elim (normalizer _) (centralizer P)]
   have := Fact.mk (Nat.minFac_prime hn)
   have key := card_dvd_of_injective _ (QuotientGroup.kerLift_injective P.normalizerMonoidHom)
   rw [normalizerMonoidHom_ker, ← index, ← relIndex] at key
@@ -320,12 +321,12 @@ theorem normalizer_le_centralizer (hP : IsCyclic P) : P.normalizer ≤ centraliz
     apply Nat.coprime_one_right
   rw [hP.card_mulAut, hk, Nat.totient_prime_pow Fact.out h0]
   refine (Nat.Coprime.pow_right _ ?_).mul_right ?_
-  · apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_of_le_left P.normalizer P.le_centralizer)
+  · apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_of_le_left _ P.le_centralizer)
     apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_index_of_le P.le_normalizer)
     rw [Nat.coprime_comm, Nat.Prime.coprime_iff_not_dvd Fact.out]
     exact P.not_dvd_index
-  · apply Nat.Coprime.coprime_dvd_left (relIndex_dvd_card (centralizer P) P.normalizer)
-    apply Nat.Coprime.coprime_dvd_left (card_subgroup_dvd_card P.normalizer)
+  · apply Nat.Coprime.coprime_dvd_left <| relIndex_dvd_card ..
+    apply Nat.Coprime.coprime_dvd_left <| card_subgroup_dvd_card _
     have h1 := Nat.gcd_dvd_left (Nat.card G) ((Nat.card G).minFac - 1)
     have h2 := Nat.gcd_le_right (n := (Nat.card G).minFac - 1) (Nat.card G)
       (tsub_pos_iff_lt.mpr (Nat.minFac_prime hn).one_lt)


### PR DESCRIPTION
Change `Subgroup.normalizer` to take in a `Set G` rather than a `Subgroup G`, and deprecate `Subgroup.setNormalizer`.

This joins `Subgroup.centralizer` which is already defined on sets rather than subgroups.
Subgroups can use both of them through their `SetLike` instance.

---

Addresses this TODO on `Subgroup.setNormalizer`:
https://github.com/leanprover-community/mathlib4/blob/34ad346d5509066e2d41dc59c6a92a917ba55661/Mathlib/Algebra/Group/Subgroup/Defs.lean#L674
(originated in leanprover-community/mathlib3#3321)

See also https://github.com/leanprover-community/mathlib4/pull/36760#issuecomment-4081930110

Note that `Sylow p G` has a separate `SetLike` instance (for some reason), which means there are now two defeq-but-not-syntactically-equal ways to spell "the normalizer of a Sylow p-group". To avoid modifying the statements of theorems (syntactically) this PR makes sure to always coerce them first to `Subgroup G` and then to `Set G`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
