### PR TITLE
feat(CategoryTheory/Monoidal/Braded/Traced): add `TracedCategory` class

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2947,6 +2947,7 @@ public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 public import Mathlib.CategoryTheory.Monoidal.Braided.Multifunctor
 public import Mathlib.CategoryTheory.Monoidal.Braided.Opposite
 public import Mathlib.CategoryTheory.Monoidal.Braided.Reflection
+public import Mathlib.CategoryTheory.Monoidal.Braided.Traced
 public import Mathlib.CategoryTheory.Monoidal.Braided.Transport
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Basic
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Cat

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3020,6 +3020,7 @@ public import Mathlib.CategoryTheory.Monoidal.Rigid.Braided
 public import Mathlib.CategoryTheory.Monoidal.Rigid.Functor
 public import Mathlib.CategoryTheory.Monoidal.Rigid.FunctorCategory
 public import Mathlib.CategoryTheory.Monoidal.Rigid.OfEquivalence
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Traced
 public import Mathlib.CategoryTheory.Monoidal.Skeleton
 public import Mathlib.CategoryTheory.Monoidal.Subcategory
 public import Mathlib.CategoryTheory.Monoidal.Tor

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Traced.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Traced.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Matt Hunzinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matt Hunzinger
+-/
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Traced monoidal categories
+
+## References
+
+* [A. Joyal and R. Street and D. R. Verity, *Traced monoidal categories*][JoyalStreet1996]
+
+-/
+
+@[expose] public section
+
+
+
+universe v v₁ v₂ v₃ u u₁ u₂ u₃
+
+namespace CategoryTheory
+
+open Category MonoidalCategory
+
+/-- A traced symmetric monoidal category. -/
+class TracedCategory
+    (C : Type u)
+    [Category.{v} C]
+    [MonoidalCategory.{v} C]
+    [SymmetricCategory.{v} C] where
+  /-- The trace operator. -/
+  trace : ∀ {A B : C} (W : C), (A ⊗ W ⟶ B ⊗ W) → (A ⟶ B)
+  /-- Left tightening: sliding a morphism past the trace on the left. -/
+  trace_naturality_left : ∀ {A A' B : C} (W : C) (f : A' ⟶ A) (g : A ⊗ W ⟶ B ⊗ W),
+      trace W (f ▷ W ≫ g) = f ≫ trace W g := by cat_disch
+  /-- Right tightening: sliding a morphism past the trace on the right. -/
+  trace_naturality_right : ∀ {A B B' : C} (W : C) (f : A ⊗ W ⟶ B ⊗ W) (g : B ⟶ B'),
+      trace W (f ≫ g ▷ W) = trace W f ≫ g := by cat_disch
+  /-- Sliding: an endomorphism on the feedback wire slides past the trace. -/
+  trace_dinaturality : ∀ {A B W : C} (f : A ⊗ W ⟶ B ⊗ W) (h : W ⟶ W),
+      trace W (f ≫ B ◁ h) = trace W (A ◁ h ≫ f) := by cat_disch
+  /-- Superposing: trace commutes with left tensoring by a bystander object. -/
+  trace_superposing : ∀ {A B : C} (C' W : C) (f : A ⊗ W ⟶ B ⊗ W),
+      C' ◁ trace W f = trace W ((α_ C' A W).hom ≫ C' ◁ f ≫ (α_ C' B W).inv) := by cat_disch
+  /-- Vanishing I: trace over the tensor unit is the morphism itself (up to unitors). -/
+  trace_vanishing_one : ∀ {A B : C} (f : A ⊗ 𝟙_ C ⟶ B ⊗ 𝟙_ C),
+      trace (𝟙_ C) f = (ρ_ A).inv ≫ f ≫ (ρ_ B).hom := by cat_disch
+  /-- Vanishing II: trace over a tensor product equals iterated trace. -/
+  trace_vanishing_two : ∀ {A B X Y : C} (f : A ⊗ (X ⊗ Y) ⟶ B ⊗ (X ⊗ Y)),
+      trace (X ⊗ Y) f = trace X (trace Y ((α_ A X Y).hom ≫ f ≫ (α_ B X Y).inv)) := by cat_disch
+  /-- Yanking: the trace of the braiding is the identity. -/
+  trace_yanking : ∀ (W : C), trace W (β_ W W).hom = 𝟙 W := by cat_disch
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Traced.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Traced.lean
@@ -20,7 +20,7 @@ public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 
 
 
-universe v v₁ v₂ v₃ u u₁ u₂ u₃
+universe u v
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Traced.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Traced.lean
@@ -37,6 +37,7 @@ variable
   [SymmetricCategory.{v} C]
   [RRC : RightRigidCategory C]
 
+/-- `TracedCategory.trace` -/
 @[inline]
 def trace {A B : C} (W : C) (f : A ⊗ W ⟶ B ⊗ W) : A ⟶ B :=
   (ρ_ A).inv ≫ A ◁ η_ W Wᘁ ≫ (α_ A W Wᘁ).inv ≫ f ▷ Wᘁ ≫

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Traced.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Traced.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 Matt Hunzinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matt Hunzinger
+-/
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+public import Mathlib.CategoryTheory.Monoidal.Braided.Traced
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Braided
+
+/-!
+# Right rigid to traced monoidal categories
+
+## References
+
+* [A. Joyal and R. Street and D. R. Verity, *Traced monoidal categories*][JoyalStreet1996]
+
+-/
+
+@[expose] public section
+
+
+
+universe v v₁ v₂ v₃ u u₁ u₂ u₃
+
+namespace CategoryTheory
+
+namespace RightRigidCategory
+
+open Category MonoidalCategory BraidedCategory ExactPairing
+
+variable
+  {C : Type u}
+  [Category.{v} C]
+  [MonoidalCategory.{v} C]
+  [SymmetricCategory.{v} C]
+  [RRC : RightRigidCategory C]
+
+@[inline]
+def trace {A B : C} (W : C) (f : A ⊗ W ⟶ B ⊗ W) : A ⟶ B :=
+  (ρ_ A).inv ≫ A ◁ η_ W Wᘁ ≫ (α_ A W Wᘁ).inv ≫ f ▷ Wᘁ ≫
+    (α_ B W Wᘁ).hom ≫ B ◁ (β_ W Wᘁ).hom ≫ B ◁ ε_ W Wᘁ ≫ (ρ_ B).hom
+
+@[simp]
+lemma trace_naturality_left
+    {A A' B : C}
+    (W : C)
+    (f : A' ⟶ A)
+    (g : A ⊗ W ⟶ B ⊗ W) :
+    trace W (f ▷ W ≫ g) = f ≫ trace W g := by
+  simp only [trace, comp_whiskerRight, Category.assoc]
+  slice_lhs 3 4 => rw [← associator_inv_naturality_left]
+  slice_lhs 2 3 => rw [whisker_exchange]
+  slice_lhs 1 2 => rw [← rightUnitor_inv_naturality]
+  simp [Category.assoc]
+
+@[simp]
+lemma trace_naturality_right
+    {A B B' : C}
+    (W : C)
+    (f : A ⊗ W ⟶ B ⊗ W)
+    (g : B ⟶ B') :
+    trace W (f ≫ g ▷ W) = trace W f ≫ g := by
+  simp only [trace, comp_whiskerRight, Category.assoc]
+  slice_lhs 5 6 => rw [associator_naturality_left]
+  slice_lhs 6 7 => rw [← whisker_exchange]
+  slice_lhs 7 8 => rw [← whisker_exchange]
+  slice_lhs 8 9 => rw [rightUnitor_naturality]
+
+@[simp]
+lemma trace_dinaturality
+    {A B W : C}
+    (f : A ⊗ W ⟶ B ⊗ W)
+    (h : W ⟶ W) :
+    trace W (f ≫ B ◁ h) = trace W (A ◁ h ≫ f) := by
+  simp only [trace, comp_whiskerRight, Category.assoc]
+  slice_lhs 5 6 => rw [associator_naturality_middle]
+  slice_lhs 6 7 => rw [← whiskerLeft_comp, braiding_naturality_left, whiskerLeft_comp]
+  slice_lhs 7 8 => rw [← whiskerLeft_comp, ← rightAdjointMate_comp_evaluation, whiskerLeft_comp]
+  slice_lhs 6 7 => rw [← whiskerLeft_comp, ← braiding_naturality_right, whiskerLeft_comp]
+  slice_lhs 5 6 => rw [← associator_naturality_right]
+  slice_lhs 4 5 => rw [← whisker_exchange]
+  slice_lhs 3 4 => rw [← associator_inv_naturality_right]
+  slice_lhs 2 3 => rw [← whiskerLeft_comp, coevaluation_comp_rightAdjointMate, whiskerLeft_comp]
+  slice_lhs 3 4 => rw [associator_inv_naturality_middle]
+  simp [Category.assoc]
+
+@[simp]
+lemma trace_superposing
+    {A B : C}
+    (C' W : C)
+    (f : A ⊗ W ⟶ B ⊗ W) :
+    C' ◁ trace W f = trace W ((α_ C' A W).hom ≫ C' ◁ f ≫ (α_ C' B W).inv) := by
+  simp only [trace, whiskerLeft_comp, comp_whiskerRight, Category.assoc]
+  monoidal
+
+omit [RightRigidCategory C] in
+@[reassoc]
+lemma cap_unit (B : C) [HasRightDual (𝟙_ C)] :
+    (α_ B (𝟙_ C) (𝟙_ C)ᘁ).hom ≫ B ◁ (β_ (𝟙_ C) (𝟙_ C)ᘁ).hom =
+    (ρ_ B).hom ▷ (𝟙_ C)ᘁ ≫ B ◁ (ρ_ (𝟙_ C)ᘁ).inv := by
+  rw [braiding_tensorUnit_left, whiskerLeft_comp, ← Category.assoc, triangle]
+
+omit [RightRigidCategory C] [SymmetricCategory C] in
+lemma unit_coevaluation [HasRightDual (𝟙_ C)] :
+    η_ (𝟙_ C) (𝟙_ C)ᘁ ▷ (𝟙_ C) ≫ (α_ (𝟙_ C) (𝟙_ C)ᘁ (𝟙_ C)).hom ≫ (𝟙_ C) ◁ ε_ (𝟙_ C) (𝟙_ C)ᘁ =
+    𝟙 (𝟙_ C ⊗ 𝟙_ C) := by
+  rw [evaluation_coevaluation]
+  monoidal
+
+omit [RightRigidCategory C] in
+@[reassoc]
+lemma unit_loop [RD : HasRightDual (𝟙_ C)] :
+    η_ (𝟙_ C) (𝟙_ C)ᘁ ≫ (β_ (𝟙_ C) (𝟙_ C)ᘁ).hom ≫ ε_ (𝟙_ C) (𝟙_ C)ᘁ = 𝟙 (𝟙_ C) := by
+  rw [braiding_tensorUnit_left]
+  calc η_ (𝟙_ C) (𝟙_ C)ᘁ ≫ ((λ_ (𝟙_ C)ᘁ).hom ≫ (ρ_ (𝟙_ C)ᘁ).inv) ≫ ε_ (𝟙_ C) (𝟙_ C)ᘁ
+      = (ρ_ (𝟙_ C)).inv ≫ (η_ (𝟙_ C) (𝟙_ C)ᘁ ▷ (𝟙_ C) ≫ (α_ (𝟙_ C) (𝟙_ C)ᘁ (𝟙_ C)).hom ≫
+          (𝟙_ C) ◁ ε_ (𝟙_ C) (𝟙_ C)ᘁ) ≫ (ρ_ (𝟙_ C)).hom := by monoidal
+    _ = (ρ_ (𝟙_ C)).inv ≫ 𝟙 _ ≫ (ρ_ (𝟙_ C)).hom := by rw [unit_coevaluation]
+    _ = 𝟙 _ := by simp
+
+omit [RightRigidCategory C] [SymmetricCategory C] in
+@[reassoc]
+lemma cup_unit (A : C) [HasRightDual (𝟙_ C)] :
+    A ◁ η_ (𝟙_ C) (𝟙_ C)ᘁ ≫ (α_ A (𝟙_ C) (𝟙_ C)ᘁ).inv =
+    A ◁ (η_ (𝟙_ C) (𝟙_ C)ᘁ ≫ (λ_ (𝟙_ C)ᘁ).hom) ≫ (ρ_ A).inv ▷ (𝟙_ C)ᘁ := by
+  rw [whiskerLeft_comp, Category.assoc]
+  congr 1
+  monoidal
+
+lemma trace_vanishing_one
+    {A B : C}
+    (f : A ⊗ 𝟙_ C ⟶ B ⊗ 𝟙_ C) :
+    trace (𝟙_ C) f = (ρ_ A).inv ≫ f ≫ (ρ_ B).hom := by
+  unfold trace
+  rw [cup_unit_assoc, cap_unit_assoc, whiskerLeft_comp_assoc, ← comp_whiskerRight_assoc]
+  congr 1
+  rw [← whiskerLeft_comp_assoc, ← comp_whiskerRight_assoc, whisker_exchange_assoc,
+      ← whiskerLeft_comp_assoc, ← whiskerLeft_comp_assoc]
+  simp only [Category.assoc, ← braiding_tensorUnit_left]
+  rw [unit_loop (RD:=RRC.rightDual (𝟙_ C)), whiskerLeft_id]
+  simp
+
+@[reassoc]
+lemma trace_congr_rightDual
+    {A B W : C} {W' : C} (φ : Wᘁ ≅ W') (f : A ⊗ W ⟶ B ⊗ W) :
+    trace W f =
+    (ρ_ A).inv ≫ A ◁ (η_ W Wᘁ ≫ W ◁ φ.hom) ≫ (α_ A W W').inv ≫ f ▷ W' ≫
+    (α_ B W W').hom ≫ B ◁ ((β_ W W').hom ≫ φ.inv ▷ W ≫ ε_ W Wᘁ) ≫ (ρ_ B).hom := by
+  unfold trace
+  have hf : f ▷ Wᘁ = (A ⊗ W) ◁ φ.hom ≫ f ▷ W' ≫ (B ⊗ W) ◁ φ.inv := by
+    rw [← whisker_exchange, ← Category.assoc, ← whiskerLeft_comp, φ.hom_inv_id,
+        whiskerLeft_id, Category.id_comp]
+  rw [hf]
+  simp only [Category.assoc]
+  rw [← associator_inv_naturality_right_assoc]
+  rw [associator_naturality_right_assoc]
+  simp only [← whiskerLeft_comp_assoc]
+  simp
+
+end RightRigidCategory
+
+end CategoryTheory

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3151,7 +3151,8 @@
   pages         = {447 - 468},
   title         = {Traced monoidal categories},
   volume        = {119},
-  journal       = {Mathematical Proceedings of the Cambridge Philosophical Society},
+  journal       = {Mathematical Proceedings of the Cambridge Philosophical
+                  Society},
   doi           = {10.1017/S0305004100074338}
 }
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -3144,6 +3144,17 @@
   url           = {http://maths.mq.edu.au/~street/JS1.pdf}
 }
 
+@Article{         JoyalStreet1996,
+  author        = {Joyal, André and Street, Ross and Verity, Dominic},
+  year          = {1996},
+  month         = {04},
+  pages         = {447 - 468},
+  title         = {Traced monoidal categories},
+  volume        = {119},
+  journal       = {Mathematical Proceedings of the Cambridge Philosophical Society},
+  doi           = {10.1017/S0305004100074338}
+}
+
 @Article{         Joyce1982,
   author        = {David Joyce},
   title         = {A classifying invariant of knots, the knot quandle},


### PR DESCRIPTION
Adds a `TracedCategory` class following [A. Joyal and R. Street and D. R. Verity, *Traced monoidal categories*](https://www.cambridge.org/core/journals/mathematical-proceedings-of-the-cambridge-philosophical-society/article/abs/traced-monoidal-categories/2BE85628D269D9FABAB41B6364E117C8#article):


```lean
/-- A traced symmetric monoidal category. -/
class TracedCategory
    (C : Type u)
    [Category.{v} C]
    [MonoidalCategory.{v} C]
    [SymmetricCategory.{v} C] where
  /-- The trace operator. -/
  trace : ∀ {A B : C} (W : C), (A ⊗ W ⟶ B ⊗ W) → (A ⟶ B)
  /-- Left tightening: sliding a morphism past the trace on the left. -/
  trace_naturality_left : ∀ {A A' B : C} (W : C) (f : A' ⟶ A) (g : A ⊗ W ⟶ B ⊗ W),
      trace W (f ▷ W ≫ g) = f ≫ trace W g := by cat_disch
  /-- Right tightening: sliding a morphism past the trace on the right. -/
  trace_naturality_right : ∀ {A B B' : C} (W : C) (f : A ⊗ W ⟶ B ⊗ W) (g : B ⟶ B'),
      trace W (f ≫ g ▷ W) = trace W f ≫ g := by cat_disch
  /-- Sliding: an endomorphism on the feedback wire slides past the trace. -/
  trace_dinaturality : ∀ {A B W : C} (f : A ⊗ W ⟶ B ⊗ W) (h : W ⟶ W),
      trace W (f ≫ B ◁ h) = trace W (A ◁ h ≫ f) := by cat_disch
  /-- Superposing: trace commutes with left tensoring by a bystander object. -/
  trace_superposing : ∀ {A B : C} (C' W : C) (f : A ⊗ W ⟶ B ⊗ W),
      C' ◁ trace W f = trace W ((α_ C' A W).hom ≫ C' ◁ f ≫ (α_ C' B W).inv) := by cat_disch
  /-- Vanishing I: trace over the tensor unit is the morphism itself (up to unitors). -/
  trace_vanishing_one : ∀ {A B : C} (f : A ⊗ 𝟙_ C ⟶ B ⊗ 𝟙_ C),
      trace (𝟙_ C) f = (ρ_ A).inv ≫ f ≫ (ρ_ B).hom := by cat_disch
  /-- Vanishing II: trace over a tensor product equals iterated trace. -/
  trace_vanishing_two : ∀ {A B X Y : C} (f : A ⊗ (X ⊗ Y) ⟶ B ⊗ (X ⊗ Y)),
      trace (X ⊗ Y) f = trace X (trace Y ((α_ A X Y).hom ≫ f ≫ (α_ B X Y).inv)) := by cat_disch
  /-- Yanking: the trace of the braiding is the identity. -/
  trace_yanking : ∀ (W : C), trace W (β_ W W).hom = 𝟙 W := by cat_disch
```

## Motivation
`TracedCategory` can be used for denoting things like electric circuits, which require a traced symmetric monoidal category for the wire graph network.

## Future work

- `instance [CompactClosedCategory C] : TracedCategory C`
- possible notation such as `Tr_[W] f`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
