### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite the `move_oper` tactic docstring

### DIFF
--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -88,7 +88,7 @@ needs to have inbuilt the lemmas asserting the analogues of
 `add_comm, add_assoc, add_left_comm` for the new operation.
 Currently, `move_oper` supports `HAdd.hAdd`, `HMul.hMul`, `And`, `Or`, `Max.max`, `Min.min`.
 
-These lemmas should be added to `Mathlib.MoveAdd.move_oper_simpCtx`.
+These lemmas should be added to `Mathlib.MoveAdd.moveOperSimpCtx`.
 
 See `MathlibTest/MoveAdd.lean` for sample usage of `move_oper`.
 
@@ -339,7 +339,7 @@ def pairUp : List (Expr × Bool × Syntax) → List Expr →
                   return ((d, m.2.1)::found, unfound)
   | _, _ => return ([], [])
 
-/-- `move_oper_simpCtx` is the `Simp.Context` for the reordering internal to `move_oper`.
+/-- `moveOperSimpCtx` is the `Simp.Context` for the reordering internal to `move_oper`.
 To support a new binary operation, extend the list in this definition, so that it contains
 enough lemmas to allow `simp` to close a generic permutation goal for the new binary operation.
 -/
@@ -426,20 +426,22 @@ def parseArrows : TSyntax `Lean.Parser.Tactic.rwRuleSeq → TermElabM (Array (Ex
 
 initialize registerTraceClass `Tactic.move_oper
 
-/-- The tactic `move_add` rearranges summands of expressions.
-Calling `move_add [a, ← b, ...]` matches `a, b,...` with summands in the main goal.
-It then moves `a` to the far right and `b` to the far left of each addition in which they appear.
-The side to which the summands are moved is determined by the presence or absence of the arrow `←`.
+/-- `move_oper op [a]` repeatedly moves `a` to the far right hand side in applications of `op`.
+Here the constant `op` refers to a binary associative commutative operation, and `a` is any term
+(potentially with underscores).
 
-The inputs `a, b,...` can be any terms, also with underscores.
-The tactic uses the first "new" summand that unifies with each one of the given inputs.
+If `a` contains underscores, they are filled in by unification with the first matching occurrence.
+Subterms with different values for the underscores are not matched, unless you repeat `a`.
 
-There is a multiplicative variant, called `move_mul`.
+Currently, `move_oper` supports the operators `HAdd.hAdd` (`· + ·`), `HMul.hMul` (`· * ·`),
+`And` (`· ∧ ·`), `Or` (`· ∨ ·`), `Max.max` and `Min.min`. To support more operations, add them to
+`Mathlib.MoveAdd.moveOperSimpCtx`.
 
-There is also a general tactic for a "binary associative commutative operation": `move_oper`.
-In this case the syntax requires providing first a term whose head symbol is the operation.
-E.g. `move_oper HAdd.hAdd [...]` is the same as `move_add`, while `move_oper Max.max [...]`
-rearranges `max`s.
+* `move_add [...]` uses addition as the operation: it abbreviates `move_oper HAdd.add [...]`.
+* `move_mul [...]` uses multiplication as the operation: it abbreviates `move_oper HMul.mul [...]`.
+* `move_oper op [← a]` moves the atoms matching `a` to the far left hand side instead of the right.
+* `move_oper op [a, b, ← c, ← d, ...]` moves multiple atoms simultaneously, in the order indicated
+  by the arguments: `c` will appear to the left of `d` and `a` will appear to the left of `b`.
 -/
 elab (name := moveOperTac) "move_oper" id:ident rws:rwRuleSeq : tactic => withMainContext do
   -- parse the operation


### PR DESCRIPTION
This PR (re)writes the docstrings for the `move_oper` tactic (and its alternatives `move_add`/`move_mul`) to consistently match the official style guide, to make sure it is complete while not getting too long.

I decided to focus on the form `move_oper op [a]` first, since this allows us to explain the basic functionality while being quite general. After that we can specialize to `move_add`/`move_mul`/...


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
