### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `match_scalars` and `module` tactic docstrings

### DIFF
--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -589,50 +589,56 @@ def matchScalars (g : MVarId) : MetaM (List MVarId) := do
   let mvars ← AtomM.run .instances (matchScalarsAux g)
   mvars.mapM postprocess
 
-/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
-RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
-the respective equalities of the `R`-coefficients of each atom.
+/-- Given a goal parseable as a linear combination `⊢ a • x + ... + b • y = c • x + ... + d • y`,
+`match_scalars` splits up the goal into equalities of the scalars for each respective atom. This
+means the example goal above is replaced by goals `⊢ a = c` (from `x`), ..., `⊢ b = d` (from `y`).
 
-For example, this produces the goal `⊢ a * 1 + b * 1 = (b + a) * 1`:
+The `module` tactic is equivalent to `match_scalars <;> ring1`.
+
+`match_scalars` can parse into expressions made of the operators `+`, `-`, `•` and the numeral `0`.
+Any other subexpressions (including variables) are treated as atoms.
+If the goal is an equality in the type `M`, then `match_scalars` requires an `AddCommMonoid M`
+instance. If the goal contains a scalar multiplication `(a : R) • (x : M)`, this requires a
+`Semiring R` and `Module R M` instance. If any of the instances are missing, `match_scalars` fails.
+
+The scalar type for the goals produced by the `match_scalars` tactic is the largest scalar type
+encountered; for example, if `ℕ`, `ℚ` and a characteristic-zero field `K` all occur as scalars, then
+the goals produced are equalities in `K` with the appropriate casts (from `ℕ`, `ℤ`, `ℚ`) and
+`algebraMap`s (otherwise) inserted. Inserted casts are simplified by lemmas tagged `@[push_cast]`.
+If the set of scalar types encountered is not totally ordered (in the sense that for all rings `R`,
+`S` encountered, it holds that either `Algebra R S` or `Algebra S R`), then `match_scalars` fails.
+
+Examples:
 ```
 example [AddCommMonoid M] [Semiring R] [Module R M] (a b : R) (x : M) :
     a • x + b • x = (b + a) • x := by
   match_scalars
-```
-This produces the two goals `⊢ a * (a * 1) + b * (b * 1) = 1` (from the `x` atom) and
-`⊢ a * -(b * 1) + b * (a * 1) = 0` (from the `y` atom):
-```
+  -- one goal: `⊢ a * 1 + b * 1 = (b + a) * 1`
+
 example [AddCommGroup M] [Ring R] [Module R M] (a b : R) (x : M) :
     a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
   match_scalars
-```
-This produces the goal `⊢ -2 * (a * 1) = a * (-2 * 1)`:
-```
-example [AddCommGroup M] [Ring R] [Module R M] (a : R) (x : M) :
-    -(2:R) • a • x = a • (-2:ℤ) • x  := by
-  match_scalars
-```
-The scalar type for the goals produced by the `match_scalars` tactic is the largest scalar type
-encountered; for example, if `ℕ`, `ℚ` and a characteristic-zero field `K` all occur as scalars, then
-the goals produced are equalities in `K`.  A variant of `push_cast` is used internally in
-`match_scalars` to interpret scalars from the other types in this largest type.
+  -- two goals:
+  -- `⊢ a * (a * 1) + b * (b * 1) = 1` (from the `x` atom)
+  -- `⊢ a * -(b * 1) + b * (a * 1) = 0` (from the `y` atom)
 
-If the set of scalar types encountered is not totally ordered (in the sense that for all rings `R`,
-`S` encountered, it holds that either `Algebra R S` or `Algebra S R`), then the `match_scalars`
-tactic fails.
+example [AddCommGroup M] [Ring R] [Module R M] (a : R) (x : M) :
+    -(2:R) • a • x = a • (-2:ℤ) • x := by
+  match_scalars
+  -- one goal: `⊢ -2 * (a * 1) = a * (-2 * 1)`
+```
 -/
 elab "match_scalars" : tactic => Tactic.liftMetaTactic matchScalars
 
-/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
-RHS of the goal as linear combinations of `M`-atoms over some commutative semiring `R`, and prove
-the goal by checking that the LHS- and RHS-coefficients of each atom are the same up to
-ring-normalization in `R`.
+/-- Given a goal parseable as a linear combination `⊢ a • x + ... + b • y = c • x + ... + d • y`,
+`module` proves the equalities of the scalars for each respective atom, by ring normalization.
+This means the example goal above is solved if `ring` can prove `⊢ a = c` (from `x`), ..., `⊢ b = d`
+(from `y`).
 
-(If the proofs of coefficient-wise equality will require more reasoning than just
-ring-normalization, use the tactic `match_scalars` instead, and then prove coefficient-wise equality
-by hand.)
+`module` is equivalent to `match_scalars <;> ring1`. If `ring1` fails to prove one of the
+equalities, you can instead use `match_scalars` followed by specialized proofs for each scalar.
 
-Example uses of the `module` tactic:
+Examples:
 ```
 example [AddCommMonoid M] [CommSemiring R] [Module R M] (a b : R) (x : M) :
     a • x + b • x = (b + a) • x := by


### PR DESCRIPTION
This PR rewrites the docstrings for the `match_scalars` and `module` tactics, to make sure they are complete while not getting too long.

Apart from a few stylistic changes, the main changes are to make the description a bit denser in relevant information, while restructuring the ideas so they are grouped together a bit better.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
