### PR TITLE
feat(Analysis/Analytic): nonvanishing in punctured neighborhood from derivative

### DIFF
--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -97,6 +97,7 @@ lemma AnalyticAt.analyticOrderAt_eq_natCast (hf : AnalyticAt 𝕜 f z₀) :
     refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
     rw [AnalyticAt.unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
+set_option backward.isDefEq.respectTransparency false in
 /-- The order of an analytic function `f` at `z₀` equals a natural number `n` iff `f` can locally
 be written as `f z = (z - z₀) ^ n • g z`, where `g` is analytic and does not vanish at `z₀`. -/
 lemma AnalyticAt.analyticOrderNatAt_eq_iff (hf : AnalyticAt 𝕜 f z₀) (hf' : analyticOrderAt f z₀ ≠ ⊤)
@@ -302,6 +303,7 @@ theorem AnalyticAt.analyticOrderAt_deriv_add_one {x : 𝕜} (hf : AnalyticAt �
       ENat.succ_def, ← Nat.cast_add_one, natCast_le_analyticOrderAt (by fun_prop)]
     exact ⟨deriv F, hFa.deriv, by simp⟩
 
+set_option backward.isDefEq.respectTransparency false in
 theorem AnalyticAt.analyticOrderAt_sub_eq_one_of_deriv_ne_zero {x : 𝕜} (hf : AnalyticAt 𝕜 f x)
     (hf' : deriv f x ≠ 0) : analyticOrderAt (f · - f x) x = 1 := by
   generalize h : analyticOrderAt (f · - f x) x = r
@@ -322,6 +324,7 @@ theorem AnalyticAt.analyticOrderAt_sub_eq_one_of_deriv_ne_zero {x : 𝕜} (hf : 
       rw [EventuallyEq.deriv_eq hfF, deriv_add_const, deriv_fun_smul (by fun_prop) (by fun_prop),
         deriv_fun_pow (by fun_prop), sub_self, zero_pow (by lia), zero_pow (by lia),
         mul_zero, zero_mul, zero_smul, zero_smul, add_zero]
+
 /-- At a zero with nonvanishing derivative, the analytic order is 1.
 This is a variant of `analyticOrderAt_sub_eq_one_of_deriv_ne_zero` with `f z₀ = 0`
 replacing the subtraction. -/

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -322,7 +322,6 @@ theorem AnalyticAt.analyticOrderAt_sub_eq_one_of_deriv_ne_zero {x : 𝕜} (hf : 
       rw [EventuallyEq.deriv_eq hfF, deriv_add_const, deriv_fun_smul (by fun_prop) (by fun_prop),
         deriv_fun_pow (by fun_prop), sub_self, zero_pow (by lia), zero_pow (by lia),
         mul_zero, zero_mul, zero_smul, zero_smul, add_zero]
-
 /-- At a zero with nonvanishing derivative, the analytic order is 1.
 This is a variant of `analyticOrderAt_sub_eq_one_of_deriv_ne_zero` with `f z₀ = 0`
 replacing the subtraction. -/
@@ -330,6 +329,19 @@ theorem AnalyticAt.analyticOrderAt_eq_one_of_zero_deriv_ne_zero {x : 𝕜}
     (hf : AnalyticAt 𝕜 f x) (hfx : f x = 0) (hf' : deriv f x ≠ 0) :
     analyticOrderAt f x = 1 := by
   simpa [hfx] using hf.analyticOrderAt_sub_eq_one_of_deriv_ne_zero hf'
+
+
+/-- If `f` is analytic at `x` and `f'(x) ≠ 0`, then `f(w) ≠ f(x)` in a punctured
+neighborhood of `x`. No hypothesis on `f x` is needed. -/
+theorem AnalyticAt.eventually_ne_nhdsWithin_of_deriv_ne_zero {x : 𝕜}
+    (hf : AnalyticAt 𝕜 f x) (hf' : deriv f x ≠ 0) :
+    ∀ᶠ w in 𝓝[≠] x, f w ≠ f x := by
+  have hg : AnalyticAt 𝕜 (f · - f x) x := hf.sub analyticAt_const
+  rcases hg.eventually_eq_zero_or_eventually_ne_zero with h | h
+  · have h1 := hf.analyticOrderAt_sub_eq_one_of_deriv_ne_zero hf'
+    rw [analyticOrderAt_eq_top.mpr h] at h1
+    simp at h1
+  · exact h.mono fun w hw => sub_ne_zero.mp hw
 
 lemma natCast_le_analyticOrderAt_iff_iteratedDeriv_eq_zero [CharZero 𝕜] [CompleteSpace E]
     (hf : AnalyticAt 𝕜 f z₀) :


### PR DESCRIPTION


Add AnalyticAt.eventually_ne_nhdsWithin_of_deriv_ne_zero: if f is analytic at x and f'(x) ≠ 0, then f(w) ≠ f(x) in a punctured neighborhood of x.
No hypothesis on f(x) needed — stronger than the version in #36778. Placed in Order.lean per review feedback from @wwylele.
Split from #36778 (2 of 3).

AI disclosure: Lean code developed with Claude (Anthropic) assistance in workflow. Mathematical content and proof strategies are original. All code verified locally with lake env lean before submission.