### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus): logarithmic residue at simple zeros

### DIFF
--- a/Mathlib/Analysis/Calculus/LogDeriv.lean
+++ b/Mathlib/Analysis/Calculus/LogDeriv.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Analysis.Calculus.Deriv.ZPow
 public import Mathlib.Analysis.Calculus.MeanValue
 
+import Mathlib.Analysis.Analytic.IsolatedZeros
+import Mathlib.Analysis.Calculus.Deriv.Slope
 /-!
 # Logarithmic Derivatives
 
@@ -137,3 +139,23 @@ lemma logDeriv_eqOn_iff [IsRCLikeNormedField 𝕜] {f g : 𝕜 → 𝕜'} {s : S
     · rintro ⟨z, hz0, hz⟩ x hx
       simp [logDeriv_apply, hz.deriv hs2 hx, hz hx, deriv_const_smul _
         (hg.differentiableAt (hs2.mem_nhds hx)), mul_div_mul_left (deriv g x) (g x) hz0]
+
+
+/-- At a simple zero of an analytic function, the logarithmic residue
+`(w - x) * logDeriv f w` tends to 1. -/
+theorem AnalyticAt.tendsto_mul_logDeriv_simple_zero [CompleteSpace 𝕜]
+    {f : 𝕜 → 𝕜} {x : 𝕜}
+    (hf : AnalyticAt 𝕜 f x) (hfx : f x = 0) (hf' : deriv f x ≠ 0) :
+    Filter.Tendsto (fun w => (w - x) * logDeriv f w)
+      (𝓝[≠] x) (𝓝 1) := by
+  have h_slope := hasDerivAt_iff_tendsto_slope.mp hf.differentiableAt.hasDerivAt
+  have h_deriv : Filter.Tendsto (deriv f) (𝓝[≠] x) (𝓝 (deriv f x)) :=
+    (hf.deriv.continuousAt).mono_left nhdsWithin_le_nhds
+  have h_div : Filter.Tendsto (fun w => deriv f w / slope f x w) (𝓝[≠] x) (𝓝 1) := by
+    have := h_deriv.div h_slope hf'
+    rwa [div_self hf'] at this
+  apply h_div.congr'
+  filter_upwards [self_mem_nhdsWithin] with w hw
+  have hsub : w - x ≠ 0 := sub_ne_zero.mpr hw
+  simp only [logDeriv_apply, slope, vsub_eq_sub, hfx, sub_zero, smul_eq_mul]
+  field_simp [hsub]

--- a/Mathlib/Analysis/Calculus/LogDeriv.lean
+++ b/Mathlib/Analysis/Calculus/LogDeriv.lean
@@ -149,13 +149,7 @@ theorem AnalyticAt.tendsto_mul_logDeriv_simple_zero [CompleteSpace 𝕜]
     Filter.Tendsto (fun w => (w - x) * logDeriv f w)
       (𝓝[≠] x) (𝓝 1) := by
   have h_slope := hasDerivAt_iff_tendsto_slope.mp hf.differentiableAt.hasDerivAt
-  have h_deriv : Filter.Tendsto (deriv f) (𝓝[≠] x) (𝓝 (deriv f x)) :=
-    (hf.deriv.continuousAt).mono_left nhdsWithin_le_nhds
-  have h_div : Filter.Tendsto (fun w => deriv f w / slope f x w) (𝓝[≠] x) (𝓝 1) := by
-    have := h_deriv.div h_slope hf'
-    rwa [div_self hf'] at this
-  apply h_div.congr'
-  filter_upwards [self_mem_nhdsWithin] with w hw
-  have hsub : w - x ≠ 0 := sub_ne_zero.mpr hw
-  simp only [logDeriv_apply, slope, vsub_eq_sub, hfx, sub_zero, smul_eq_mul]
-  field_simp [hsub]
+  rw [← div_self hf']
+  convert hf.deriv.continuousAt.tendsto.mono_left nhdsWithin_le_nhds |>.div h_slope hf' using 2
+  simp [logDeriv, slope, hfx]
+  field


### PR DESCRIPTION
Add `AnalyticAt.tendsto_mul_logDeriv_simple_zero`: if f is analytic at x, f(x) = 0, and f'(x) ≠ 0, then `(w - x) * logDeriv f w → 1` as `w → x`.

Restated with `logDeriv` and placed in `LogDeriv.lean` per review feedback from @wwylele on #36778. Split from #36778 (3 of 3).

AI disclosure: Lean code developed with Claude (Anthropic) assistance in workflow. Mathematical content and proof strategies are original. All code verified locally with lake env lean before submission.