### PR TITLE
[Merged by Bors] - chore: change a simp only to simp_rw for easier debugging

### DIFF
--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -178,8 +178,8 @@ noncomputable def equivPolynomialSelf : PolynomialModule R R ≃ₗ[R[X]] R[X] :
       | add _ _ hp hq => rw [smul_add, map_add, map_add, mul_add, hp, hq]
       | single n a =>
         ext i
-        simp only [coeff_ofFinsupp, smul_single_apply, toFinsuppIso_symm_apply, coeff_ofFinsupp,
-        single_apply, smul_eq_mul, Polynomial.coeff_mul, mul_ite, mul_zero]
+        simp_rw [toFinsuppIso_symm_apply, coeff_ofFinsupp, coeff_mul, smul_single_apply,
+          smul_eq_mul, coeff_ofFinsupp, single_apply, mul_ite, mul_zero]
         split_ifs with hn
         · rw [Finset.sum_eq_single (i - n, n)]
           · simp only [ite_true]


### PR DESCRIPTION
Minor backport from an experimental branch. There's some defeq abuse going on here, and it's easier to debug as a `simp_rw` than a `simp only`.