### PR TITLE
[Merged by Bors] - fix(Tactic/ToFun): only show lemma hover on `to_fun` keyword

### DIFF
--- a/Mathlib/Tactic/ToFun.lean
+++ b/Mathlib/Tactic/ToFun.lean
@@ -37,11 +37,11 @@ Use the `to_fun (attr := ...)` syntax to add the same attribute to both declarat
 syntax (name := to_fun) "to_fun" optAttrArg : attr
 
 def toFunImpl (src : Name) (stx : Syntax) (kind : AttributeKind) : AttrM Name := do
-  let `(attr| to_fun $optAttr) := stx | throwUnsupportedSyntax
+  let `(attr| to_fun%$tk $optAttr) := stx | throwUnsupportedSyntax
   if (kind != AttributeKind.global) then
     throwError "`to_fun` can only be used as a global attribute"
   let tgt := (src.appendBefore "fun_")
-  MetaM.run' <| addRelatedDecl src tgt stx optAttr
+  MetaM.run' <| addRelatedDecl src tgt tk optAttr
     (docstringPrefix? := s!"Eta-expanded form of `{src}`") (hoverInfo := true)
     fun value levels => do
     let type ← inferType value


### PR DESCRIPTION
This PR changes the lemma hover for `to_fun` so that it shows up only on the  `to_fun` keyword itself, and not also on the `(attr := ...)` part. As a result, you can now go to the definition of `to_fun` by clicking on the `(attr := ...)` part.

This PR also fixes the bug reported in [#**mathlib4>to_fun names**](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/to_fun.20names/with/580441233) that the lemma hover doesn't show up in combination with `(attr := ...)`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
