### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MorphismProperty): dualise `IsStableUnderBaseChangeAlong` and related declarations

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -157,7 +157,7 @@ instance [P.IsStableUnderCobaseChange] {X Y : C} (f : X ⟶ Y) :
     P.IsStableUnderCobaseChangeAlong f where
   of_isPushout := IsStableUnderCobaseChange.of_isPushout
 
-alias of_isPullback := IsStableUnderBaseChangeAlong.of_isPullback
+alias of_isPullback := IsStableUnderBaseChange.of_isPullback
 
 lemma isStableUnderBaseChange_iff_pullbacks_le :
     P.IsStableUnderBaseChange ↔ P.pullbacks ≤ P := by
@@ -280,7 +280,7 @@ instance IsStableUnderBaseChange.hasOfPostcompProperty_monomorphisms
     rw [this, cancel_left_of_respectsIso (P := P)]
     exact P.pullback_snd _ _ hcomp
 
-alias of_isPushout := IsStableUnderCobaseChangeAlong.of_isPushout
+alias of_isPushout := IsStableUnderCobaseChange.of_isPushout
 
 lemma isStableUnderCobaseChange_iff_pushouts_le :
     P.IsStableUnderCobaseChange ↔ P.pushouts ≤ P := by
@@ -339,11 +339,11 @@ instance IsStableUnderCobaseChange.respectsIso
 theorem pushout_inl {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g]
     [P.IsStableUnderCobaseChangeAlong f] (H : P g) :
     P (pushout.inl f g) :=
-  of_isPushout (IsPushout.of_hasPushout f g) H
+  IsStableUnderCobaseChangeAlong.of_isPushout (IsPushout.of_hasPushout f g) H
 
 theorem pushout_inr {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g]
     [P.IsStableUnderCobaseChangeAlong g] (H : P f) : P (pushout.inr f g) :=
-  of_isPushout (IsPushout.of_hasPushout f g).flip H
+  IsStableUnderCobaseChangeAlong.of_isPushout (IsPushout.of_hasPushout f g).flip H
 
 set_option backward.isDefEq.respectTransparency false in
 theorem pushoutDesc_inl_inr [IsStableUnderCobaseChange P] {S S' X Y : C} (f : S ⟶ S')
@@ -352,7 +352,7 @@ theorem pushoutDesc_inl_inr [IsStableUnderCobaseChange P] {S S' X Y : C} (f : S 
     P (pushout.desc (f := v₂₂) (g := f) (g ≫ pushout.inl v₁₂ f)
       (pushout.inr v₁₂ f) (by simp [pushout.condition, ← reassoc_of% hv₁₂])) := by
   subst hv₁₂
-  refine of_isPushout (f' := pushout.inl (v₂₂ ≫ g) f)
+  refine IsStableUnderCobaseChangeAlong.of_isPushout (f' := pushout.inl (v₂₂ ≫ g) f)
     (f := pushout.inl v₂₂ f) ?_ H
   refine IsPushout.of_top ?_ (by simp) (IsPushout.of_hasPushout v₂₂ f).flip
   simpa using (IsPushout.of_hasPushout (v₂₂ ≫ g) f).flip
@@ -831,7 +831,7 @@ instance IsStableUnderBaseChange.diagonal [IsStableUnderBaseChange P] [P.Respect
       introv h
       rw [diagonal_iff, diagonal_pullback_fst, P.cancel_left_of_respectsIso,
         P.cancel_right_of_respectsIso]
-      exact P.baseChange_map f _ (by simpa))
+      exact P.overPullbackMap f _ (by simpa))
 
 lemma diagonal_isomorphisms : (isomorphisms C).diagonal = monomorphisms C :=
   ext _ _ fun _ _ _ ↦ pullback.isIso_diagonal_iff _

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -133,6 +133,11 @@ as `f`, the pullback of that morphism along `f` exists. -/
 protected class HasPullbacksAlong {X Y : C} (f : X ⟶ Y) : Prop where
   hasPullback {W} (g : W ⟶ Y) : P g → HasPullback g f
 
+/-- `P.HasPullbacksAlong f` states that for any morphism satisfying `P` with the same codomain
+as `f`, the pullback of that morphism along `f` exists. -/
+protected class HasPushoutsAlong {X Y : C} (f : X ⟶ Y) : Prop where
+  hasPushout {W} (g : X ⟶ W) : P g → HasPushout g f
+
 /-- `P.IsStableUnderBaseChangeAlong f` states that for any morphism satisfying `P` with the same
 codomain as `f`, any pullback of that morphism along `f` also satisfies `P`. -/
 class IsStableUnderBaseChangeAlong {X Y : C} (f : X ⟶ Y) : Prop where
@@ -142,11 +147,17 @@ class IsStableUnderBaseChangeAlong {X Y : C} (f : X ⟶ Y) : Prop where
 instance [P.IsStableUnderBaseChange] {X Y : C} (f : X ⟶ Y) : P.IsStableUnderBaseChangeAlong f where
   of_isPullback := IsStableUnderBaseChange.of_isPullback
 
-variable {P} in
-lemma of_isPullback [P.IsStableUnderBaseChange]
-    {X Y Y' S : C} {f : X ⟶ S} {g : Y ⟶ S} {f' : Y' ⟶ Y} {g' : Y' ⟶ X}
-    (sq : IsPullback f' g' g f) (hg : P g) : P g' :=
-  IsStableUnderBaseChange.of_isPullback sq hg
+/-- `P.IsStableUnderCobaseChangeAlong f` states that for any morphism satisfying `P` with the same
+codomain as `f`, any pullback of that morphism along `f` also satisfies `P`. -/
+class IsStableUnderCobaseChangeAlong {X Y : C} (f : X ⟶ Y) : Prop where
+  of_isPushout {Z W : C} {f' : Z ⟶ W} {g' : Y ⟶ W} {g : X ⟶ Z}
+    (pb : IsPushout f g g' f') : P g → P g'
+
+instance [P.IsStableUnderCobaseChange] {X Y : C} (f : X ⟶ Y) :
+    P.IsStableUnderCobaseChangeAlong f where
+  of_isPushout := IsStableUnderCobaseChange.of_isPushout
+
+alias of_isPullback := IsStableUnderBaseChangeAlong.of_isPullback
 
 lemma isStableUnderBaseChange_iff_pullbacks_le :
     P.IsStableUnderBaseChange ↔ P.pullbacks ≤ P := by
@@ -214,7 +225,7 @@ theorem baseChange_obj {S S' : C} (f : S' ⟶ S)
   pullback_snd X.hom f H
 
 set_option backward.isDefEq.respectTransparency false in
-theorem baseChange_map' [IsStableUnderBaseChange P] {S S' X Y : C} (f : S' ⟶ S)
+theorem pullbackLift_fst_snd [IsStableUnderBaseChange P] {S S' X Y : C} (f : S' ⟶ S)
     {v₁₂ : X ⟶ S} {v₂₂ : Y ⟶ S} {g : X ⟶ Y} (hv₁₂ : v₁₂ = g ≫ v₂₂) [HasPullback v₁₂ f]
     [HasPullback v₂₂ f] (H : P g) : P (pullback.lift (f := v₂₂) (g := f) (pullback.fst v₁₂ f ≫ g)
     (pullback.snd v₁₂ f) (by simp [pullback.condition, ← hv₁₂])) := by
@@ -224,15 +235,21 @@ theorem baseChange_map' [IsStableUnderBaseChange P] {S S' X Y : C} (f : S' ⟶ S
   refine IsPullback.of_bot ?_ (by simp) (IsPullback.of_hasPullback v₂₂ f)
   simpa using IsPullback.of_hasPullback (g ≫ v₂₂) f
 
-theorem baseChange_map [IsStableUnderBaseChange P] {S S' : C} (f : S' ⟶ S)
+@[deprecated (since := "2026-03-20")]
+alias baseChange_map' := pullbackLift_fst_snd
+
+theorem overPullbackMap [IsStableUnderBaseChange P] {S S' : C} (f : S' ⟶ S)
     [HasPullbacksAlong f] {X Y : Over S} (g : X ⟶ Y) (H : P g.left) :
     P ((Over.pullback f).map g).left := by
   dsimp only [Over.pullback_obj_left, Over.pullback_map_left]
-  convert baseChange_map' f (g.w.symm) H <;> simp
+  convert pullbackLift_fst_snd f (g.w.symm) H <;> simp
+
+@[deprecated (since := "2026-03-20")]
+alias baseChange_map := overPullbackMap
 
 set_option backward.isDefEq.respectTransparency false in
 attribute [local instance] hasPullback_symmetry_of_hasPullbacksAlong in
-theorem pullback_map
+theorem pullbackMap
     [IsStableUnderBaseChange P] [P.IsStableUnderComposition] {S X X' Y Y' : C} {f : X ⟶ S}
     [HasPullbacksAlong f] {g : Y ⟶ S} {f' : X' ⟶ S} {g' : Y' ⟶ S} {i₁ : X ⟶ X'}
     [HasPullbacksAlong g'] {i₂ : Y ⟶ Y'} (h₁ : P i₁) (h₂ : P i₂)
@@ -249,8 +266,11 @@ theorem pullback_map
     ext <;> simp
   rw [this]
   apply P.comp_mem <;> rw [P.cancel_left_of_respectsIso]
-  exacts [baseChange_map _ (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g') h₂,
-    baseChange_map _ (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f') h₁]
+  exacts [overPullbackMap _ (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g') h₂,
+    overPullbackMap _ (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f') h₁]
+
+@[deprecated (since := "2026-03-20")]
+alias pullback_map := pullbackMap
 
 instance IsStableUnderBaseChange.hasOfPostcompProperty_monomorphisms
     [P.IsStableUnderBaseChange] : P.HasOfPostcompProperty (MorphismProperty.monomorphisms C) where
@@ -260,10 +280,7 @@ instance IsStableUnderBaseChange.hasOfPostcompProperty_monomorphisms
     rw [this, cancel_left_of_respectsIso (P := P)]
     exact P.pullback_snd _ _ hcomp
 
-lemma of_isPushout [P.IsStableUnderCobaseChange]
-    {A A' B B' : C} {f : A ⟶ A'} {g : A ⟶ B} {f' : B ⟶ B'} {g' : A' ⟶ B'}
-    (sq : IsPushout g f f' g') (hf : P f) : P f' :=
-  IsStableUnderCobaseChange.of_isPushout sq hf
+alias of_isPushout := IsStableUnderCobaseChangeAlong.of_isPushout
 
 lemma isStableUnderCobaseChange_iff_pushouts_le :
     P.IsStableUnderCobaseChange ↔ P.pushouts ≤ P := by
@@ -319,14 +336,52 @@ instance IsStableUnderCobaseChange.respectsIso
   RespectsIso.of_respects_arrow_iso _ fun _ _ e ↦
     of_isPushout (IsPushout.of_horiz_isIso (CommSq.mk e.hom.w))
 
-theorem pushout_inl [IsStableUnderCobaseChange P]
-    {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g] (H : P g) :
+theorem pushout_inl {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g]
+    [P.IsStableUnderCobaseChangeAlong f] (H : P g) :
     P (pushout.inl f g) :=
   of_isPushout (IsPushout.of_hasPushout f g) H
 
-theorem pushout_inr [IsStableUnderCobaseChange P]
-    {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g] (H : P f) : P (pushout.inr f g) :=
+theorem pushout_inr {A B A' : C} (f : A ⟶ A') (g : A ⟶ B) [HasPushout f g]
+    [P.IsStableUnderCobaseChangeAlong g] (H : P f) : P (pushout.inr f g) :=
   of_isPushout (IsPushout.of_hasPushout f g).flip H
+
+set_option backward.isDefEq.respectTransparency false in
+theorem pushoutDesc_inl_inr [IsStableUnderCobaseChange P] {S S' X Y : C} (f : S ⟶ S')
+    {v₁₂ : S ⟶ X} {v₂₂ : S ⟶ Y} {g : Y ⟶ X} (hv₁₂ : v₁₂ = v₂₂ ≫ g) [HasPushout v₁₂ f]
+    [HasPushout v₂₂ f] (H : P g) :
+    P (pushout.desc (f := v₂₂) (g := f) (g ≫ pushout.inl v₁₂ f)
+      (pushout.inr v₁₂ f) (by simp [pushout.condition, ← reassoc_of% hv₁₂])) := by
+  subst hv₁₂
+  refine of_isPushout (f' := pushout.inl (v₂₂ ≫ g) f)
+    (f := pushout.inl v₂₂ f) ?_ H
+  refine IsPushout.of_top ?_ (by simp) (IsPushout.of_hasPushout v₂₂ f).flip
+  simpa using (IsPushout.of_hasPushout (v₂₂ ≫ g) f).flip
+
+theorem underPushoutMap [IsStableUnderCobaseChange P] {S S' : C} (f : S' ⟶ S)
+    [HasPushoutsAlong f] {X Y : Under S'} (g : X ⟶ Y) (H : P g.right) :
+    P ((Under.pushout f).map g).right := by
+  dsimp only [Under.pushout_obj, Functor.const_obj_obj, Functor.id_obj, Under.mk_right,
+    Under.pushout_map, Under.homMk_right]
+  convert pushoutDesc_inl_inr f (g.w) H <;> simp
+
+set_option backward.isDefEq.respectTransparency false in
+attribute [local instance] hasPushouts_symmetry_of_hasPushoutsAlong in
+theorem pushoutMap
+    [IsStableUnderCobaseChange P] [P.IsStableUnderComposition] {S X X' Y Y' : C} {f : S ⟶ X}
+    {g : S ⟶ Y} {f' : S ⟶ X'} {g' : S ⟶ Y'} {i₁ : X ⟶ X'} [HasPushoutsAlong f]
+    [HasPushoutsAlong g'] {i₂ : Y ⟶ Y'} (h₁ : P i₁) (h₂ : P i₂)
+    (e₁ : f' = f ≫ i₁) (e₂ : g' = g ≫ i₂) :
+    P (pushout.map f g f' g' i₁ i₂ (𝟙 _) (by simp [e₁]) (by simp [e₂])) := by
+  have : HasPushoutsAlong (Under.mk g').hom := by cat_disch
+  have : pushout.map f g f' g' i₁ i₂ (𝟙 _) (by simp [e₁]) (by simp [e₂]) =
+      ((pushoutSymmetry _ _).hom ≫
+        ((Under.pushout f).map (Under.homMk _ e₂.symm : Under.mk g ⟶ Under.mk g')).right) ≫
+        (pushoutSymmetry _ _).hom ≫
+        ((Under.pushout g').map (Under.homMk _ e₁.symm : Under.mk f ⟶ Under.mk f')).right := by
+    ext <;> simp
+  rw [this]
+  apply P.comp_mem <;> rw [P.cancel_left_of_respectsIso]
+  exacts [underPushoutMap _ _ h₂, underPushoutMap _ _ h₁]
 
 instance IsStableUnderCobaseChange.hasOfPrecompProperty_epimorphisms
     [P.IsStableUnderCobaseChange] : P.HasOfPrecompProperty (MorphismProperty.epimorphisms C) where
@@ -876,6 +931,18 @@ alias hasPullback := HasPullbacks.hasPullback
 instance [P.HasPullbacks] {X Y : C} {f : X ⟶ Y} : P.HasPullbacksAlong f where
   hasPullback _ := hasPullback _
 
+/-- `P` has pushouts if for every `f` satisfying `P`, pushouts of arbitrary morphisms along `f`
+exist. -/
+protected class HasPushouts : Prop where
+  hasPushout {X Y S : C} {f : S ⟶ X} (g : S ⟶ Y) : P f → HasPushout f g := by infer_instance
+
+instance [HasPushouts C] : P.HasPushouts where
+
+alias hasPushout := HasPushouts.hasPushout
+
+instance [P.HasPushouts] {X Y : C} {f : X ⟶ Y} : P.HasPushoutsAlong f where
+  hasPushout _ := hasPushout _
+
 instance {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderBaseChangeAlong g]
     [P.HasPullbacksAlong f] [P.HasPullbacksAlong g] : P.HasPullbacksAlong (f ≫ g) where
   hasPullback h p :=
@@ -893,6 +960,23 @@ instance {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderBaseChangeAlong
     have right := IsPullback.of_hasPullback p g
     IsStableUnderBaseChangeAlong.of_isPullback (IsPullback.of_right' pb right)
       (IsStableUnderBaseChangeAlong.of_isPullback right hp)
+
+instance {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderCobaseChangeAlong f]
+    [P.HasPushoutsAlong f] [P.HasPushoutsAlong g] : P.HasPushoutsAlong (f ≫ g) where
+  hasPushout h p :=
+    have : HasPushout h f := HasPushoutsAlong.hasPushout h p
+    have : HasPushout (pushout.inr h f) g := HasPushoutsAlong.hasPushout _
+      (P.pushout_inr _ _ p)
+    IsPushout.hasPushout (IsPushout.paste_vert (.of_hasPushout _ _) (.of_hasPushout _ _))
+
+instance {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [P.IsStableUnderCobaseChangeAlong f]
+    [P.IsStableUnderCobaseChangeAlong g] [P.HasPushoutsAlong f] :
+    P.IsStableUnderCobaseChangeAlong (f ≫ g) where
+  of_isPushout {_ _ _ _ p} pb hp :=
+    have : HasPushout p f := HasPushoutsAlong.hasPushout p hp
+    have right := IsPushout.of_hasPushout p f
+    IsStableUnderCobaseChangeAlong.of_isPushout (IsPushout.of_left' pb right.flip)
+      (IsStableUnderCobaseChangeAlong.of_isPushout right.flip hp)
 
 end MorphismProperty
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -133,8 +133,8 @@ as `f`, the pullback of that morphism along `f` exists. -/
 protected class HasPullbacksAlong {X Y : C} (f : X ⟶ Y) : Prop where
   hasPullback {W} (g : W ⟶ Y) : P g → HasPullback g f
 
-/-- `P.HasPullbacksAlong f` states that for any morphism satisfying `P` with the same codomain
-as `f`, the pullback of that morphism along `f` exists. -/
+/-- `P.HasPushoutsAlong f` states that for any morphism satisfying `P` with the same domain
+as `f`, the pushout of that morphism along `f` exists. -/
 protected class HasPushoutsAlong {X Y : C} (f : X ⟶ Y) : Prop where
   hasPushout {W} (g : X ⟶ W) : P g → HasPushout g f
 

--- a/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
@@ -94,7 +94,7 @@ noncomputable def Over.pullback (f : X ⟶ Y) [P.HasPullbacksAlong f]
     (pullback_snd A.hom f A.prop)
   map {A B} g := Over.homMk (pullback.lift (pullback.fst A.hom f ≫ g.left)
     (pullback.snd A.hom f) (by simp [pullback.condition])) (by simp)
-    (baseChange_map' _ _ g.prop_hom_left)
+    (pullbackLift_fst_snd _ _ g.prop_hom_left)
 
 variable {P} {Q}
 
@@ -153,7 +153,7 @@ noncomputable def Over.pullbackMapHomPullback [P.IsStableUnderComposition]
       Over.pullback P Q g where
   app A :=
     Over.homMk (pullback.map _ _ _ _ (𝟙 A.left) f (𝟙 Z) (by simp) (by cat_disch))
-    (by simp) (Q.pullback_map (Q.id_mem _) hQf (by simp) (by cat_disch))
+    (by simp) (Q.pullbackMap (Q.id_mem _) hQf (by simp) (by cat_disch))
 
 end Pullback
 


### PR DESCRIPTION
We also fix some naming inconsistencies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
