### PR TITLE
[Merged by Bors] - perf(CategoryTheory/Functor/TypeValueFlat): overwrite `aesop_cat`

### DIFF
--- a/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
+++ b/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
@@ -97,6 +97,7 @@ def fromOverFunctorElementsEquivalence :
     (by cat_disch)
   unitIso := Iso.refl _
   counitIso := Iso.refl _
+  functor_unitIso_comp X := by simp_all; rfl
 
 instance [IsCofiltered F.Elements] : IsCofiltered (fromOverFunctor F x).Elements :=
   .of_equivalence (fromOverFunctorElementsEquivalence F x).symm

--- a/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
+++ b/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
@@ -97,6 +97,7 @@ def fromOverFunctorElementsEquivalence :
     (by cat_disch)
   unitIso := Iso.refl _
   counitIso := Iso.refl _
+  -- `cat_disch` can fill in this proof, but is unfortunately quite slow.
   functor_unitIso_comp X := by simp_all; rfl
 
 instance [IsCofiltered F.Elements] : IsCofiltered (fromOverFunctor F x).Elements :=


### PR DESCRIPTION
This PR replaces a slow `aesop_cat` call with an explicit proof. This speeds it up by more that 10x.

The trace of the `aesop_cat` call looks incredibly suspicious. It is spending all the 5 seconds on a `<norm simp>` node, but inside that trace node, the nodes only add up to less than 0.5 seconds. So it is a mystery to me what `aesop` is doing during this extra time.

This was identified in #36613

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
