### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): reflecting (co)limits and opposites

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -530,4 +530,503 @@ lemma preservesFiniteCoproducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [PreservesFiniteP
     apply +allowSynthFailures preservesColimitsOfShape_unop
     exact preservesLimitsOfShape_of_equiv (Discrete.opposite _).symm _
 
+/-- If `F : C ⥤ D` reflects colimits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects
+limits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsLimit_op (K : J ⥤ Cᵒᵖ) (F : C ⥤ D) [ReflectsColimit K.leftOp F] :
+    ReflectsLimit K F.op where
+  reflects {_} hc :=
+    ⟨isLimitOfCoconeLeftOpOfCone _ <| isColimitOfReflects F (isColimitCoconeLeftOpOfCone _ hc)⟩
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ D` reflects
+limits of `K : J ⥤ C`. -/
+lemma reflectsLimit_of_op (K : J ⥤ C) (F : C ⥤ D) [ReflectsColimit K.op F.op] :
+    ReflectsLimit K F where
+  reflects {_} hc := ⟨isLimitOfOp (isColimitOfReflects F.op (IsLimit.op hc))⟩
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects colimits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.leftOp : Cᵒᵖ ⥤ D`
+reflects limits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsLimit_leftOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ Dᵒᵖ) [ReflectsColimit K.leftOp F] :
+    ReflectsLimit K F.leftOp where
+  reflects {_} hc :=
+    ⟨isLimitOfCoconeLeftOpOfCone _ <| isColimitOfReflects F hc.op⟩
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ Dᵒᵖ` reflects
+limits of `K : J ⥤ C`. -/
+lemma reflectsLimit_of_leftOp (K : J ⥤ C) (F : C ⥤ Dᵒᵖ) [ReflectsColimit K.op F.leftOp] :
+    ReflectsLimit K F where
+  reflects {_} hc :=
+    ⟨isLimitOfOp <|
+      isColimitOfReflects F.leftOp (isColimitOfConeRightOpOfCocone _ hc)⟩
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` reflects
+limits of `K : J ⥤ C`. -/
+lemma reflectsLimit_rightOp (K : J ⥤ C) (F : Cᵒᵖ ⥤ D) [ReflectsColimit K.op F] :
+    ReflectsLimit K F.rightOp where
+  reflects {_} hc :=
+    ⟨isLimitOfOp <| isColimitOfReflects F <| isColimitOfConeRightOpOfCocone _ hc⟩
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits of `K.leftOp : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : Cᵒᵖ ⥤ D`
+reflects limits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsLimit_of_rightOp (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ D) [ReflectsColimit K.leftOp F.rightOp] :
+    ReflectsLimit K F where
+  reflects {_} hc :=
+    ⟨isLimitOfCoconeLeftOpOfCone _ <| isColimitOfReflects F.rightOp <|
+      isColimitOfConeUnopOfCocone _ hc⟩
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.unop : C ⥤ D` reflects
+limits of `K : J ⥤ C`. -/
+lemma reflectsLimit_unop (K : J ⥤ C) (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimit K.op F] :
+    ReflectsLimit K F.unop where
+  reflects {_} hc := ⟨isLimitOfOp (isColimitOfReflects F hc.op)⟩
+
+/-- If `F.unop : C ⥤ D` reflects colimits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects
+limits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsLimit_of_unop (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimit K.leftOp F.unop] :
+    ReflectsLimit K F where
+  reflects {_} hc :=
+    ⟨isLimitOfCoconeLeftOpOfCone _ (isColimitOfReflects F.unop (isColimitCoconeLeftOpOfCone _ hc))⟩
+
+/-- If `F : C ⥤ D` reflects limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects
+colimits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsColimit_op (K : J ⥤ Cᵒᵖ) (F : C ⥤ D) [ReflectsLimit K.leftOp F] :
+    ReflectsColimit K F.op where
+  reflects {_} hc :=
+    ⟨isColimitOfConeLeftOpOfCocone _ (isLimitOfReflects F (isLimitConeLeftOpOfCocone _ hc))⟩
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ D` reflects
+colimits of `K : J ⥤ C`. -/
+lemma reflectsColimit_of_op (K : J ⥤ C) (F : C ⥤ D) [ReflectsLimit K.op F.op] :
+    ReflectsColimit K F where
+  reflects {_} hc := ⟨isColimitOfOp (isLimitOfReflects F.op (IsColimit.op hc))⟩
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F.leftOp : Cᵒᵖ ⥤ D` reflects
+colimits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsColimit_leftOp (K : J ⥤ Cᵒᵖ) (F : C ⥤ Dᵒᵖ) [ReflectsLimit K.leftOp F] :
+    ReflectsColimit K F.leftOp where
+  reflects {_} hc :=
+    ⟨isColimitOfConeLeftOpOfCocone _ (isLimitOfReflects F (isLimitOfCoconeUnopOfCone _ hc))⟩
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F : C ⥤ Dᵒᵖ` reflects
+colimits of `K : J ⥤ C`. -/
+lemma reflectsColimit_of_leftOp (K : J ⥤ C) (F : C ⥤ Dᵒᵖ) [ReflectsLimit K.op F.leftOp] :
+    ReflectsColimit K F where
+  reflects {_} hc :=
+    ⟨isColimitOfOp (isLimitOfReflects F.leftOp <| isLimitOfCoconeRightOpOfCone _ hc)⟩
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` reflects
+colimits of `K : J ⥤ C`. -/
+lemma reflectsColimit_rightOp (K : J ⥤ C) (F : Cᵒᵖ ⥤ D) [ReflectsLimit K.op F] :
+    ReflectsColimit K F.rightOp where
+  reflects {_} hc := ⟨isColimitOfOp (isLimitOfReflects F <| isLimitOfCoconeRightOpOfCone _ hc)⟩
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects limits of `K.leftOp : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ D`
+reflects colimits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsColimit_of_rightOp (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ D) [ReflectsLimit K.leftOp F.rightOp] :
+    ReflectsColimit K F where
+  reflects {_} hc :=
+    ⟨isColimitOfConeLeftOpOfCocone _ (isLimitOfReflects F.rightOp hc.op)⟩
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits of `K.op : Jᵒᵖ ⥤ Cᵒᵖ`, then `F.unop : C ⥤ D` reflects
+colimits of `K : J ⥤ C`. -/
+lemma reflectsColimit_unop (K : J ⥤ C) (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimit K.op F] :
+    ReflectsColimit K F.unop where
+  reflects {_} hc := ⟨isColimitOfOp (isLimitOfReflects F hc.op)⟩
+
+/-- If `F.unop : C ⥤ D` reflects limits of `K.op : Jᵒᵖ ⥤ C`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects
+colimits of `K : J ⥤ Cᵒᵖ`. -/
+lemma reflectsColimit_of_unop (K : J ⥤ Cᵒᵖ) (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimit K.leftOp F.unop] :
+    ReflectsColimit K F where
+  reflects {_} hc :=
+    ⟨isColimitOfConeLeftOpOfCocone _ (isLimitOfReflects F.unop (isLimitConeLeftOpOfCocone _ hc))⟩
+
+section
+
+variable (J)
+
+/-- If `F : C ⥤ D` reflects colimits of shape `Jᵒᵖ`, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits of
+shape `J`. -/
+lemma reflectsLimitsOfShape_op (F : C ⥤ D) [ReflectsColimitsOfShape Jᵒᵖ F] :
+    ReflectsLimitsOfShape J F.op where reflectsLimit {K} := reflectsLimit_op K F
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects colimits of shape `Jᵒᵖ`, then `F.leftOp : Cᵒᵖ ⥤ D` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimitsOfShape Jᵒᵖ F] :
+    ReflectsLimitsOfShape J F.leftOp where reflectsLimit {K} := reflectsLimit_leftOp K F
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects colimits of shape `Jᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimitsOfShape Jᵒᵖ F] :
+    ReflectsLimitsOfShape J F.rightOp where reflectsLimit {K} := reflectsLimit_rightOp K F
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits of shape `Jᵒᵖ`, then `F.unop : C ⥤ D` reflects limits of
+shape `J`. -/
+lemma reflectsLimitsOfShape_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimitsOfShape Jᵒᵖ F] :
+    ReflectsLimitsOfShape J F.unop where reflectsLimit {K} := reflectsLimit_unop K F
+
+/-- If `F : C ⥤ D` reflects limits of shape `Jᵒᵖ`, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits of
+shape `J`. -/
+lemma reflectsColimitsOfShape_op (F : C ⥤ D) [ReflectsLimitsOfShape Jᵒᵖ F] :
+    ReflectsColimitsOfShape J F.op where reflectsColimit {K} := reflectsColimit_op K F
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects limits of shape `Jᵒᵖ`, then `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimitsOfShape Jᵒᵖ F] :
+    ReflectsColimitsOfShape J F.leftOp where reflectsColimit {K} := reflectsColimit_leftOp K F
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects limits of shape `Jᵒᵖ`, then `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimitsOfShape Jᵒᵖ F] :
+    ReflectsColimitsOfShape J F.rightOp where reflectsColimit {K} := reflectsColimit_rightOp K F
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits of shape `Jᵒᵖ`, then `F.unop : C ⥤ D` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimitsOfShape Jᵒᵖ F] :
+    ReflectsColimitsOfShape J F.unop where reflectsColimit {K} := reflectsColimit_unop K F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits of shape `Jᵒᵖ`, then `F : C ⥤ D` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_of_op (F : C ⥤ D) [ReflectsColimitsOfShape Jᵒᵖ F.op] :
+    ReflectsLimitsOfShape J F where reflectsLimit {K} := reflectsLimit_of_op K F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits of shape `Jᵒᵖ`, then `F : C ⥤ Dᵒᵖ` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimitsOfShape Jᵒᵖ F.leftOp] :
+    ReflectsLimitsOfShape J F where reflectsLimit {K} := reflectsLimit_of_leftOp K F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ D` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimitsOfShape Jᵒᵖ F.rightOp] :
+    ReflectsLimitsOfShape J F where reflectsLimit {K} := reflectsLimit_of_rightOp K F
+
+/-- If `F.unop : C ⥤ D` reflects colimits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits
+of shape `J`. -/
+lemma reflectsLimitsOfShape_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimitsOfShape Jᵒᵖ F.unop] :
+    ReflectsLimitsOfShape J F where reflectsLimit {K} := reflectsLimit_of_unop K F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits of shape `Jᵒᵖ`, then `F : C ⥤ D` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_of_op (F : C ⥤ D) [ReflectsLimitsOfShape Jᵒᵖ F.op] :
+    ReflectsColimitsOfShape J F where reflectsColimit {K} := reflectsColimit_of_op K F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects limits of shape `Jᵒᵖ`, then `F : C ⥤ Dᵒᵖ` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimitsOfShape Jᵒᵖ F.leftOp] :
+    ReflectsColimitsOfShape J F where reflectsColimit {K} := reflectsColimit_of_leftOp K F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects limits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ D` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimitsOfShape Jᵒᵖ F.rightOp] :
+    ReflectsColimitsOfShape J F where reflectsColimit {K} := reflectsColimit_of_rightOp K F
+
+/-- If `F.unop : C ⥤ D` reflects limits of shape `Jᵒᵖ`, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits
+of shape `J`. -/
+lemma reflectsColimitsOfShape_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimitsOfShape Jᵒᵖ F.unop] :
+    ReflectsColimitsOfShape J F where reflectsColimit {K} := reflectsColimit_of_unop K F
+
+end
+
+/-- If `F : C ⥤ D` reflects colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimitsOfSize_op (F : C ⥤ D) [ReflectsColimitsOfSize.{w, w'} F] :
+    ReflectsLimitsOfSize.{w, w'} F.op where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_op _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects colimits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects limits. -/
+lemma reflectsLimitsOfSize_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimitsOfSize.{w, w'} F] :
+    ReflectsLimitsOfSize.{w, w'} F.leftOp where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_leftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects colimits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimitsOfSize_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimitsOfSize.{w, w'} F] :
+    ReflectsLimitsOfSize.{w, w'} F.rightOp where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_rightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits, then `F.unop : C ⥤ D` reflects limits. -/
+lemma reflectsLimitsOfSize_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimitsOfSize.{w, w'} F] :
+    ReflectsLimitsOfSize.{w, w'} F.unop where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_unop _ _
+
+/-- If `F : C ⥤ D` reflects limits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimitsOfSize_op (F : C ⥤ D) [ReflectsLimitsOfSize.{w, w'} F] :
+    ReflectsColimitsOfSize.{w, w'} F.op where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_op _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects limits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits. -/
+lemma reflectsColimitsOfSize_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimitsOfSize.{w, w'} F] :
+    ReflectsColimitsOfSize.{w, w'} F.leftOp where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_leftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects limits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimitsOfSize_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimitsOfSize.{w, w'} F] :
+    ReflectsColimitsOfSize.{w, w'} F.rightOp where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_rightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits, then `F.unop : C ⥤ D` reflects colimits. -/
+lemma reflectsColimitsOfSize_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimitsOfSize.{w, w'} F] :
+    ReflectsColimitsOfSize.{w, w'} F.unop where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_unop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits, then `F : C ⥤ D` reflects limits. -/
+lemma reflectsLimitsOfSize_of_op (F : C ⥤ D) [ReflectsColimitsOfSize.{w, w'} F.op] :
+    ReflectsLimitsOfSize.{w, w'} F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_op _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits, then `F : C ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimitsOfSize_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimitsOfSize.{w, w'} F.leftOp] :
+    ReflectsLimitsOfSize.{w, w'} F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_leftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits, then `F : Cᵒᵖ ⥤ D` reflects limits. -/
+lemma reflectsLimitsOfSize_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimitsOfSize.{w, w'} F.rightOp] :
+    ReflectsLimitsOfSize.{w, w'} F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_rightOp _ _
+
+/-- If `F.unop : C ⥤ D` reflects colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimitsOfSize_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimitsOfSize.{w, w'} F.unop] :
+    ReflectsLimitsOfSize.{w, w'} F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_unop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits, then `F : C ⥤ D` reflects colimits. -/
+lemma reflectsColimitsOfSize_of_op (F : C ⥤ D) [ReflectsLimitsOfSize.{w, w'} F.op] :
+    ReflectsColimitsOfSize.{w, w'} F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_op _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects limits, then `F : C ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimitsOfSize_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimitsOfSize.{w, w'} F.leftOp] :
+    ReflectsColimitsOfSize.{w, w'} F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_leftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects limits, then `F : Cᵒᵖ ⥤ D` reflects colimits. -/
+lemma reflectsColimitsOfSize_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimitsOfSize.{w, w'} F.rightOp] :
+    ReflectsColimitsOfSize.{w, w'} F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_rightOp _ _
+
+/-- If `F.unop : C ⥤ D` reflects limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimitsOfSize_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimitsOfSize.{w, w'} F.unop] :
+    ReflectsColimitsOfSize.{w, w'} F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_unop _ _
+
+/-- If `F : C ⥤ D` reflects colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimits_op (F : C ⥤ D) [ReflectsColimits F] : ReflectsLimits F.op where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_op _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects colimits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects limits. -/
+lemma reflectsLimits_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimits F] : ReflectsLimits F.leftOp where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_leftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects colimits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimits_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimits F] : ReflectsLimits F.rightOp where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_rightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits, then `F.unop : C ⥤ D` reflects limits. -/
+lemma reflectsLimits_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimits F] : ReflectsLimits F.unop where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_unop _ _
+
+/-- If `F : C ⥤ D` reflects limits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimits_op (F : C ⥤ D) [ReflectsLimits F] : ReflectsColimits F.op where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_op _ _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects limits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits. -/
+lemma reflectsColimits_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimits F] : ReflectsColimits F.leftOp where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_leftOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects limits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimits_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimits F] :
+    ReflectsColimits F.rightOp where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_rightOp _ _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits, then `F.unop : C ⥤ D` reflects colimits. -/
+lemma reflectsColimits_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimits F] : ReflectsColimits F.unop where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_unop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits, then `F : C ⥤ D` reflects limits. -/
+lemma reflectsLimits_of_op (F : C ⥤ D) [ReflectsColimits F.op] : ReflectsLimits F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_op _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects colimits, then `F : C ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimits_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsColimits F.leftOp] : ReflectsLimits F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_leftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects colimits, then `F : Cᵒᵖ ⥤ D` reflects limits. -/
+lemma reflectsLimits_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsColimits F.rightOp] :
+    ReflectsLimits F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_rightOp _ _
+
+/-- If `F.unop : C ⥤ D` reflects colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits. -/
+lemma reflectsLimits_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsColimits F.unop] : ReflectsLimits F where
+  reflectsLimitsOfShape {_} _ := reflectsLimitsOfShape_of_unop _ _
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects limits, then `F : C ⥤ D` reflects colimits. -/
+lemma reflectsColimits_of_op (F : C ⥤ D) [ReflectsLimits F.op] : ReflectsColimits F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_op _ _
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects limits, then `F : C ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimits_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsLimits F.leftOp] :
+    ReflectsColimits F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_leftOp _ _
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects limits, then `F : Cᵒᵖ ⥤ D` reflects colimits. -/
+lemma reflectsColimits_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsLimits F.rightOp] :
+    ReflectsColimits F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_rightOp _ _
+
+/-- If `F.unop : C ⥤ D` reflects limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects colimits. -/
+lemma reflectsColimits_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsLimits F.unop] : ReflectsColimits F where
+  reflectsColimitsOfShape {_} _ := reflectsColimitsOfShape_of_unop _ _
+
+/-- If `F : C ⥤ D` reflects finite colimits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_op (F : C ⥤ D) [ReflectsFiniteColimits F] :
+    ReflectsFiniteLimits F.op where
+  reflects J _ _ := reflectsLimitsOfShape_op J F
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects finite colimits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteColimits F] :
+    ReflectsFiniteLimits F.leftOp where
+  reflects J _ _ := reflectsLimitsOfShape_leftOp J F
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects finite colimits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteColimits F] :
+    ReflectsFiniteLimits F.rightOp where
+  reflects J _ _ := reflectsLimitsOfShape_rightOp J F
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite colimits, then `F.unop : C ⥤ D` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteColimits F] :
+    ReflectsFiniteLimits F.unop where
+  reflects J _ _ := reflectsLimitsOfShape_unop J F
+
+/-- If `F : C ⥤ D` reflects finite limits, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_op (F : C ⥤ D) [ReflectsFiniteLimits F] :
+    ReflectsFiniteColimits F.op where
+  reflects J _ _ := reflectsColimitsOfShape_op J F
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects finite limits, then `F.leftOp : Cᵒᵖ ⥤ D` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteLimits F] :
+    ReflectsFiniteColimits F.leftOp where
+  reflects J _ _ := reflectsColimitsOfShape_leftOp J F
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects finite limits, then `F.rightOp : C ⥤ Dᵒᵖ` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteLimits F] :
+    ReflectsFiniteColimits F.rightOp where
+  reflects J _ _ := reflectsColimitsOfShape_rightOp J F
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite limits, then `F.unop : C ⥤ D` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteLimits F] :
+    ReflectsFiniteColimits F.unop where
+  reflects J _ _ := reflectsColimitsOfShape_unop J F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite colimits, then `F : C ⥤ D` reflects finite limits. -/
+lemma reflectsFiniteLimits_of_op (F : C ⥤ D) [ReflectsFiniteColimits F.op] :
+    ReflectsFiniteLimits F where
+  reflects J _ _ := reflectsLimitsOfShape_of_op J F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects finite colimits, then `F : C ⥤ Dᵒᵖ` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteColimits F.leftOp] :
+    ReflectsFiniteLimits F where
+  reflects J _ _ := reflectsLimitsOfShape_of_leftOp J F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects finite colimits, then `F : Cᵒᵖ ⥤ D` reflects finite
+limits. -/
+lemma reflectsFiniteLimits_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteColimits F.rightOp] :
+    ReflectsFiniteLimits F where
+  reflects J _ _ := reflectsLimitsOfShape_of_rightOp J F
+
+/-- If `F.unop : C ⥤ D` reflects finite colimits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite limits. -/
+lemma reflectsFiniteLimits_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteColimits F.unop] :
+    ReflectsFiniteLimits F where
+  reflects J _ _ := reflectsLimitsOfShape_of_unop J F
+
+/-- If `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite limits, then `F : C ⥤ D` reflects finite colimits. -/
+lemma reflectsFiniteColimits_of_op (F : C ⥤ D) [ReflectsFiniteLimits F.op] :
+    ReflectsFiniteColimits F where
+  reflects J _ _ := reflectsColimitsOfShape_of_op J F
+
+/-- If `F.leftOp : Cᵒᵖ ⥤ D` reflects finite limits, then `F : C ⥤ Dᵒᵖ` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_of_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteLimits F.leftOp] :
+    ReflectsFiniteColimits F where
+  reflects J _ _ := reflectsColimitsOfShape_of_leftOp J F
+
+/-- If `F.rightOp : C ⥤ Dᵒᵖ` reflects finite limits, then `F : Cᵒᵖ ⥤ D` reflects finite
+colimits. -/
+lemma reflectsFiniteColimits_of_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteLimits F.rightOp] :
+    ReflectsFiniteColimits F where
+  reflects J _ _ := reflectsColimitsOfShape_of_rightOp J F
+
+/-- If `F.unop : C ⥤ D` reflects finite limits, then `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite colimits. -/
+lemma reflectsFiniteColimits_of_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteLimits F.unop] :
+    ReflectsFiniteColimits F where
+  reflects J _ _ := reflectsColimitsOfShape_of_unop J F
+
+/-- If `F : C ⥤ D` reflects finite coproducts, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite
+products. -/
+lemma reflectsFiniteProducts_op (F : C ⥤ D) [ReflectsFiniteCoproducts F] :
+    ReflectsFiniteProducts F.op where
+  reflects n := by
+    apply +allowSynthFailures reflectsLimitsOfShape_op
+    exact reflectsColimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects finite coproducts, then `F.leftOp : Cᵒᵖ ⥤ D` reflects finite
+products. -/
+lemma reflectsFiniteProducts_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteCoproducts F] :
+    ReflectsFiniteProducts F.leftOp where
+  reflects _ := by
+    apply +allowSynthFailures reflectsLimitsOfShape_leftOp
+    exact reflectsColimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects finite coproducts, then `F.rightOp : C ⥤ Dᵒᵖ` reflects finite
+products. -/
+lemma reflectsFiniteProducts_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteCoproducts F] :
+    ReflectsFiniteProducts F.rightOp where
+  reflects _ := by
+    apply +allowSynthFailures reflectsLimitsOfShape_rightOp
+    exact reflectsColimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite coproducts, then `F.unop : C ⥤ D` reflects finite
+products. -/
+lemma reflectsFiniteProducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteCoproducts F] :
+    ReflectsFiniteProducts F.unop where
+  reflects _ := by
+    apply +allowSynthFailures reflectsLimitsOfShape_unop
+    exact reflectsColimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : C ⥤ D` reflects finite products, then `F.op : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite
+coproducts. -/
+lemma reflectsFiniteCoproducts_op (F : C ⥤ D) [ReflectsFiniteProducts F] :
+    ReflectsFiniteCoproducts F.op where
+  reflects _ := by
+    apply +allowSynthFailures reflectsColimitsOfShape_op
+    exact reflectsLimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : C ⥤ Dᵒᵖ` reflects finite products, then `F.leftOp : Cᵒᵖ ⥤ D` reflects finite
+coproducts. -/
+lemma reflectsFiniteCoproducts_leftOp (F : C ⥤ Dᵒᵖ) [ReflectsFiniteProducts F] :
+    ReflectsFiniteCoproducts F.leftOp where
+  reflects _ := by
+    apply +allowSynthFailures reflectsColimitsOfShape_leftOp
+    exact reflectsLimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : Cᵒᵖ ⥤ D` reflects finite products, then `F.rightOp : C ⥤ Dᵒᵖ` reflects finite
+coproducts. -/
+lemma reflectsFiniteCoproducts_rightOp (F : Cᵒᵖ ⥤ D) [ReflectsFiniteProducts F] :
+    ReflectsFiniteCoproducts F.rightOp where
+  reflects _ := by
+    apply +allowSynthFailures reflectsColimitsOfShape_rightOp
+    exact reflectsLimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
+/-- If `F : Cᵒᵖ ⥤ Dᵒᵖ` reflects finite products, then `F.unop : C ⥤ D` reflects finite
+coproducts. -/
+lemma reflectsFiniteCoproducts_unop (F : Cᵒᵖ ⥤ Dᵒᵖ) [ReflectsFiniteProducts F] :
+    ReflectsFiniteCoproducts F.unop where
+  reflects _ := by
+    apply +allowSynthFailures reflectsColimitsOfShape_unop
+    exact reflectsLimitsOfShape_of_equiv (Discrete.opposite _).symm _
+
 end CategoryTheory.Limits


### PR DESCRIPTION
This is mostly copied from the variants for preservation of (co)limits. The only exceptions, modulo search and replace, are the proofs up until `reflectsLimitsOfShape_op`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
