### PR TITLE
[Merged by Bors] - chore(ModelTheory/Types): expose `T` in `typesWith` and move it to `Theory`

### DIFF
--- a/Mathlib/ModelTheory/Topology/Types.lean
+++ b/Mathlib/ModelTheory/Topology/Types.lean
@@ -30,13 +30,14 @@ universe u
 
 variable {L : Language} {T : L.Theory} {α : Type*}
 
-public instance : TopologicalSpace (CompleteType T α) := generateFrom (range typesWith)
+public instance : TopologicalSpace (CompleteType T α) :=
+  generateFrom (range (T.typesWith))
 
 public lemma isTopologicalBasis_range_typesWith :
-    IsTopologicalBasis (range (typesWith (α := α) (T := T))) where
+    IsTopologicalBasis (range (T.typesWith (α := α))) where
   exists_subset_inter := by
     intro t₁ ⟨φ, ht₁⟩ t₂ ⟨ψ, ht₂⟩ x hx
-    refine ⟨typesWith (φ ⊓ ψ), ⟨φ ⊓ ψ, rfl⟩, ?_⟩
+    refine ⟨T.typesWith (φ ⊓ ψ), ⟨φ ⊓ ψ, rfl⟩, ?_⟩
     rw [typesWith_inf, ht₁, ht₂]
     exact ⟨hx, fun _ ↦ id⟩
   sUnion_eq := by
@@ -44,13 +45,13 @@ public lemma isTopologicalBasis_range_typesWith :
     exact Set.subset_sUnion_of_mem ⟨_, typesWith_top⟩
   eq_generateFrom := rfl
 
-public lemma isOpen_typesWith (φ : L[[α]].Sentence) : IsOpen (typesWith (T := T) φ) :=
+public lemma isOpen_typesWith (φ : L[[α]].Sentence) : IsOpen (T.typesWith φ) :=
   isOpen_generateFrom_of_mem ⟨φ, rfl⟩
 
-public lemma isClosed_typesWith (φ : L[[α]].Sentence) : IsClosed (typesWith (T := T) φ) where
+public lemma isClosed_typesWith (φ : L[[α]].Sentence) : IsClosed (T.typesWith φ) where
   isOpen_compl := by rw [← typesWith_not]; exact isOpen_typesWith _
 
-public lemma isClopen_typesWith (φ : L[[α]].Sentence) : IsClopen (typesWith (T := T) φ) where
+public lemma isClopen_typesWith (φ : L[[α]].Sentence) : IsClopen (T.typesWith φ) where
   left := isClosed_typesWith _
   right := isOpen_typesWith _
 
@@ -61,10 +62,10 @@ public instance : TotallySeparatedSpace (CompleteType T α) := by
   obtain ⟨φ, hφ⟩ := hpq
   cases mem_or_not_mem p φ with
   | inl h =>
-    refine ⟨typesWith φ, isClopen_typesWith _, h, ?_⟩
+    refine ⟨T.typesWith φ, isClopen_typesWith _, h, ?_⟩
     rwa [mem_compl_iff, mem_typesWith_iff, ← hφ, not_not]
   | inr h =>
-    refine ⟨typesWith ∼φ, isClopen_typesWith _, h, ?_⟩
+    refine ⟨T.typesWith ∼φ, isClopen_typesWith _, h, ?_⟩
     rwa [mem_compl_iff, mem_typesWith_iff, not_mem_iff, ← hφ, not_not, ←not_mem_iff]
 
 

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -62,7 +62,13 @@ structure CompleteType where
   subset' : (L.lhomWithConstants α).onTheory T ⊆ toTheory
   isMaximal' : toTheory.IsMaximal
 
-variable {T α}
+variable {α}
+
+/-- The clopen set of complete types which contain a formula. -/
+def typesWith (T : L.Theory) : L[[α]].Sentence → Set (CompleteType T α) :=
+  fun φ ↦ {p | φ ∈ p.toTheory}
+
+variable {T}
 
 namespace CompleteType
 
@@ -185,29 +191,27 @@ theorem mem_typeOf {φ : L[[α]].Sentence} :
 theorem formula_mem_typeOf {φ : L.Formula α} :
     Formula.equivSentence φ ∈ T.typeOf v ↔ φ.Realize v := by simp
 
-/-- The clopen set of complete types which contain a formula. -/
-def typesWith : L[[α]].Sentence → Set (CompleteType T α) := fun φ ↦ {p | φ ∈ p}
-
 @[simp]
-lemma mem_typesWith_iff (φ : L[[α]].Sentence) (p : CompleteType T α) : p ∈ typesWith φ ↔ φ ∈ p := by
-  simp [typesWith]
+lemma mem_typesWith_iff (φ : L[[α]].Sentence) (p : CompleteType T α) :
+    p ∈ T.typesWith φ ↔ φ ∈ p := by
+  rfl
 
 lemma typesWith_inf (φ ψ : L[[α]].Sentence) :
-    typesWith (T := T) (φ ⊓ ψ) = typesWith φ ∩ typesWith ψ := by
+    T.typesWith (φ ⊓ ψ) = T.typesWith φ ∩ T.typesWith ψ := by
   ext p
   simp only [mem_typesWith_iff, mem_inter_iff, ← SetLike.mem_coe, p.isMaximal.mem_iff_models,
     ModelsBoundedFormula, ← forall_and]
   exact forall₃_congr fun _ _ _ ↦ BoundedFormula.realize_inf
 
 lemma typesWith_eq_univ_of_mem_onTheory_lhomWithConstants {φ}
-    (hφ : φ ∈ (L.lhomWithConstants α).onTheory T) : typesWith (T := T) φ = Set.univ :=
+    (hφ : φ ∈ (L.lhomWithConstants α).onTheory T) : T.typesWith φ = Set.univ :=
   univ_subset_iff.mp fun p _ ↦ p.subset hφ
 
-lemma typesWith_top : typesWith (T := T) (α := α) ⊤ = Set.univ :=
+lemma typesWith_top : T.typesWith (α := α) ⊤ = Set.univ :=
   univ_subset_iff.mp fun p _ ↦ p.isMaximal.mem_of_models (φ := ⊤) (fun _ _ _ a ↦ a)
 
-lemma typesWith_not (φ : L[[α]].Sentence) : typesWith ∼φ = (typesWith (T := T) φ)ᶜ := by
-  simp [typesWith]
+lemma typesWith_not (φ : L[[α]].Sentence) : T.typesWith ∼φ = (T.typesWith φ)ᶜ := by
+  exact Eq.symm compl_setOf_mem
 
 end CompleteType
 


### PR DESCRIPTION
Make the `T : L.Theory` argument explicit in `typesWith` and place the definition in `FirstOrder.Language.Theory` to enable dot notation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
