### PR TITLE
[Merged by Bors] - feat(Analysis/Convex): convex metric spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1830,6 +1830,7 @@ public import Mathlib.Analysis.Convex.Join
 public import Mathlib.Analysis.Convex.KreinMilman
 public import Mathlib.Analysis.Convex.LinearIsometry
 public import Mathlib.Analysis.Convex.Measure
+public import Mathlib.Analysis.Convex.MetricSpace
 public import Mathlib.Analysis.Convex.Mul
 public import Mathlib.Analysis.Convex.NNReal
 public import Mathlib.Analysis.Convex.PartitionOfUnity

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang, Yaël Dillies
+-/
+module
+
+public import Mathlib.Analysis.Convex.Combination
+public import Mathlib.Analysis.Normed.Group.AddTorsor
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.LinearAlgebra.ConvexSpace.AffineSpace
+
+/-!
+
+# Convex metric spaces
+
+A convex metric space is a convex space with a compatible metric structure.
+Concretely, we ask for `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)`,
+which is what one would expect from the triangle inequality.
+
+## Main results
+- `IsConvexMetricSpace`: The (`Prop`-valued) class of convex metric spaces.
+- `continuous_convexComboPair`: Binary convex combination is continuous.
+- `Convex.isConvexMetricSpace`: Convex subspaces of normed spaces are convex metric spaces.
+
+## TODO
+- Equip `StdSimplex` with a topology and show the analogous continuity result for n-ary
+  convex combinations.
+
+-/
+
+@[expose] public section
+
+lemma Topology.IsOpenEmbedding.continuousAt_iff' {X Y Z : Type*} {f : X → Y}
+    {g : Y → Z} [TopologicalSpace Y] [TopologicalSpace X] [TopologicalSpace Z]
+    (hf : Topology.IsOpenEmbedding f) {x : X} : ContinuousAt (g ∘ f) x ↔ ContinuousAt g (f x) :=
+  hf.isInducing.continuousAt_iff' (hf.isOpen_range.mem_nhds (by simp))
+
+open ConvexSpace
+
+variable {X : Type*} [ConvexSpace ℝ X] [MetricSpace X]
+
+variable (X) in
+/-- A convex metric space is a convex space with a compatible metric structure.
+Concretely, we ask for `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)`,
+which is what one would expect from the triangle inequality.
+
+In particular, convex subsets of affine spaces are convex metric spaces. -/
+class IsConvexMetricSpace : Prop where
+  /-- Use `dist_convexCombination_map_le` instead. -/
+  dist_convexCombination_map_le' (f : StdSimplex ℝ ℕ) (σ₁ σ₂ : ℕ → X) :
+    dist (convexCombination (f.map σ₁)) (convexCombination (f.map σ₂)) ≤
+      f.weights.sum fun i r ↦ r * dist (σ₁ i) (σ₂ i)
+
+variable [IsConvexMetricSpace X]
+
+lemma dist_convexCombination_map_le {ι : Type*} (f : StdSimplex ℝ ι) (σ₁ σ₂ : ι → X) :
+    dist (convexCombination (f.map σ₁)) (convexCombination (f.map σ₂)) ≤
+      f.weights.sum fun i r ↦ r * dist (σ₁ i) (σ₂ i) := by
+  classical
+  let e : ι → ℕ := Function.extend (↑) (f.support.equivFin ·) 0
+  have he (x : _) (hx : x ∈ f.support) : e x = ↑(f.support.equivFin ⟨x, hx⟩) :=
+      Function.Injective.extend_apply Subtype.val_injective _ _ ⟨x, hx⟩
+  let einv : ℕ → ι := Function.extend (↑) (f.support.equivFin.symm ·) (fun _ ↦ f.nonempty.some)
+  have H (x : _) (hx : x ∈ f.support) : einv (e x) = x := by simp [he, hx, einv, Fin.val_injective]
+  convert IsConvexMetricSpace.dist_convexCombination_map_le' (f.map e) (σ₁ ∘ einv) (σ₂ ∘ einv)
+    using 3
+  · ext1
+    simp only [StdSimplex.map, ← Finsupp.mapDomain_comp]
+    exact Finsupp.mapDomain_congr fun x hx ↦ by simp [H, hx]
+  · ext1
+    simp only [StdSimplex.map, ← Finsupp.mapDomain_comp]
+    exact Finsupp.mapDomain_congr fun x hx ↦ by simp [H, hx]
+  · simp only [StdSimplex.map, Function.comp_apply, zero_mul, implies_true, add_mul,
+      Finsupp.sum_mapDomain_index]
+    exact Finsupp.sum_congr fun x hx ↦ by simp [H, hx]
+
+lemma dist_convexCombination_left (f : StdSimplex ℝ X) (x : X) :
+    dist (convexCombination f) x ≤ f.weights.sum fun i r ↦ r * dist i x := by
+  simpa using dist_convexCombination_map_le f id (fun _ ↦ x)
+
+lemma dist_convexCombination_right (f : StdSimplex ℝ X) (x : X) :
+    dist x (convexCombination f) ≤ f.weights.sum fun i r ↦ r * dist x i := by
+  simpa using dist_convexCombination_map_le f (fun _ ↦ x) id
+
+@[simp]
+lemma dist_convexComboPair_left
+    {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X) :
+    dist (convexComboPair s t hs ht h x y) x = t * dist x y := by
+  classical
+  suffices H : ∀ {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X),
+      dist (convexComboPair s t hs ht h x y) x ≤ t * dist x y by
+    refine (H ..).antisymm ?_
+    conv_lhs => rw [eq_sub_iff_add_eq'.mpr h, sub_mul, one_mul]
+    grw [sub_le_iff_le_add, dist_comm x y, ← H ht hs ((add_comm _ _).trans h) y x, dist_comm,
+      convexComboPair_symm, ← dist_triangle_left]
+  intro s t hs ht h x y
+  grw [convexComboPair, dist_convexCombination_left]
+  simp [StdSimplex.duple, Finsupp.sum_add_index, add_mul, dist_comm y x]
+
+@[simp]
+lemma dist_convexComboPair_right
+    {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X) :
+    dist (convexComboPair s t hs ht h x y) y = s * dist x y := by
+  rw [convexComboPair_symm, dist_convexComboPair_left, dist_comm]
+
+@[simp]
+lemma dist_left_convexComboPair
+    {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X) :
+    dist x (convexComboPair s t hs ht h x y) = t * dist x y := by
+  rw [dist_comm, dist_convexComboPair_left]
+
+@[simp]
+lemma dist_right_convexComboPair
+    {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : X) :
+    dist y (convexComboPair s t hs ht h x y) = s * dist x y := by
+  rw [dist_comm, dist_convexComboPair_right]
+
+lemma dist_convexComboPair_convexComboPair
+    {s t s' t' : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1)
+    (hs' : 0 ≤ s') (ht' : 0 ≤ t') (h' : s' + t' = 1) (x y : X) :
+    dist (convexComboPair s t hs ht h x y) (convexComboPair s' t' hs' ht' h' x y) =
+      |s - s'| * dist x y := by
+  wlog hss' : s' ≤ s generalizing s t s' t'
+  · rw [dist_comm, this, abs_sub_comm]; exact le_of_not_ge hss'
+  suffices dist (convexComboPair s t hs ht h x y) (convexComboPair s' t' hs' ht' h' x y) ≤
+      |s - s'| * dist x y by
+    refine this.antisymm ?_
+    nth_grw 2 [← abs_dist_sub_le (z := x)]
+    have : |t - t'| = |s - s'| := by
+      rw [eq_sub_iff_add_eq.mpr h, eq_sub_iff_add_eq.mpr h']; simp [abs_sub_comm t t']
+    simp [← sub_mul, this]
+  let f : StdSimplex ℝ (Fin 3) :=
+  { weights := Finsupp.equivFunOnFinite.symm ![s', s - s', t]
+    nonneg i := by fin_cases i <;> simp [*]
+    total := by simp [Finsupp.sum_fintype, Fin.sum_univ_succ, ← add_assoc, h] }
+  convert dist_convexCombination_map_le f ![x, x, y] ![x, y, y] using 1
+  swap; · simp [Finsupp.sum_fintype, Fin.sum_univ_succ, f, hss']
+  congr 1
+  · delta convexComboPair
+    congr 1
+    ext a
+    simp [StdSimplex.duple, StdSimplex.map, Finsupp.mapDomain,
+      Finsupp.sum_fintype, Fin.sum_univ_succ, f, ← add_assoc]
+  · delta convexComboPair
+    congr 1
+    ext a
+    simp [StdSimplex.duple, StdSimplex.map, Finsupp.mapDomain,
+      Finsupp.sum_fintype, Fin.sum_univ_succ, f, show t' = s - s' + t by grind]
+
+lemma dist_convexComboPair_convexComboPair_le
+    {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y x' y' : X) :
+    dist (convexComboPair s t hs ht h x y) (convexComboPair s t hs ht h x' y') ≤
+      s * dist x x' + t * dist y y' := by
+  convert dist_convexCombination_map_le (.duple (M := Fin 2) 0 1 hs ht h) ![x, y] ![x', y']
+  · simp [convexComboPair]
+  · simp [convexComboPair]
+  · simp [Finsupp.sum_fintype, Fin.sum_univ_succ, StdSimplex.duple]
+
+/-- The convex combination `(t, p, q) ↦ t • p + (1 - t) • q` is continuous on `[0, 1] × X × X`
+for a convex metric space `X`. -/
+lemma continuous_convexComboPair :
+    Continuous fun x : Set.Icc (0 : ℝ) 1 × (X × X) ↦ convexComboPair (R := ℝ)
+      ↑x.1 (1 - ↑x.1) x.1.prop.left (by simpa using x.1.prop.right) (add_sub_cancel ..)
+      x.2.1 x.2.2 := by
+  apply continuous_prod_of_continuous_lipschitzWith' (K := 1)
+  · intro i x y
+    simp only [← coe_nnreal_ennreal_nndist, ENNReal.coe_one, one_mul, ENNReal.coe_le_coe,
+      NNReal.toReal_le, coe_nndist]
+    grw [dist_convexComboPair_convexComboPair_le, Prod.dist_eq]
+    nth_grw 1 [le_max_left (dist x.1 y.1) (dist x.2 y.2)]
+    swap; · simpa using i.prop.left
+    nth_grw 2 [le_max_right (dist x.1 y.1) (dist x.2 y.2)]
+    swap; · simpa using i.prop.right
+    rw [← add_mul, add_sub_cancel, one_mul]
+  · intro b
+    refine LipschitzWith.continuous (K := nndist b.1 b.2) fun x y ↦ ?_
+    rw [mul_comm]
+    simp [← coe_nnreal_ennreal_nndist, ← ENNReal.coe_mul, NNReal.toReal_le,
+      dist_convexComboPair_convexComboPair, Subtype.dist_eq, dist_eq_norm]
+
+/-- When `X` is a bounded convex metric space, to check continuity of
+`f(i) • x(i) + (1 - f(i)) • y(i)` it suffices to show that `f` is continuous,
+`x` is continuous away from `f(i) = 0`, and `y` is continuous away from `f(i) = 1`. -/
+lemma continuous_convexComboPair' [BoundedSpace X]
+    {ι : Type*} [TopologicalSpace ι] (f : ι → ℝ) (hf : Continuous f)
+    (hf0 : ∀ i, 0 ≤ f i) (hf1 : ∀ i, f i ≤ 1) (x y : ι → X)
+    (hx : ContinuousOn x (f ⁻¹' {0}ᶜ)) (hy : ContinuousOn y (f ⁻¹' {1}ᶜ)) :
+    Continuous fun i ↦ convexComboPair (f i) (1 - f i) (hf0 _) (by simpa using hf1 _)
+      (add_sub_cancel ..) (x i) (y i) := by
+  obtain ⟨D, hD, hD'⟩ := ((Metric.isBounded_iff_eventually.mp (Bornology.isBounded_univ.mpr
+    ‹_›)).and (Filter.eventually_gt_atTop 0)).exists
+  simp only [Set.mem_univ, forall_const] at hD
+  rw [continuous_iff_continuousAt]
+  intro i
+  by_cases hi : f i ∈ Set.Ioo 0 1
+  · exact ((isOpen_Ioo.preimage hf).isOpenEmbedding_subtypeVal.continuousAt_iff'
+      (x := ⟨i, hi⟩)).mp ((continuous_convexComboPair (X := X)).comp₃ (W := f ⁻¹' Set.Ioo 0 1)
+      (e := fun i ↦ ⟨f i, Set.Ioo_subset_Icc_self i.prop⟩) (f := x ∘ (↑)) (k := y ∘ (↑))
+      (by fun_prop) (hx.comp_continuous continuous_subtype_val (by simp_all; grind))
+      (hy.comp_continuous continuous_subtype_val (by simp_all; grind))).continuousAt
+  obtain hi | hi : f i = 0 ∨ f i = 1 := by
+    simpa [le_antisymm_iff, hf0 _, hf1 _, -not_and, not_and_or] using hi
+  · simp only [ContinuousAt, hi, sub_zero, convexComboPair_zero]
+    rw [Metric.nhds_basis_ball.tendsto_right_iff]
+    intro r hr
+    filter_upwards [hy.continuousAt ((hf.isOpen_preimage _ isClosed_singleton.isOpen_compl).mem_nhds
+      (x := i) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
+      hf.tendsto' _ _ hi (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
+    simp only [Set.mem_preimage, Metric.mem_ball, dist_zero_right, Real.norm_eq_abs] at hj hj' ⊢
+    grw [dist_triangle _ (convexComboPair (f j) (1 - f j) (hf0 _) (by simpa using hf1 _)
+      (add_sub_cancel ..) (x j) (y i)), dist_convexComboPair_convexComboPair_le]
+    simp only [dist_self, mul_zero, zero_add, dist_convexComboPair_right]
+    grw [sub_le_self _ (hf0 _), hj, hD, (le_abs_self _).trans hj'.le]
+    · field_simp; norm_num
+    · exact hf0 _
+  · simp only [ContinuousAt, hi, sub_self, convexComboPair_one]
+    rw [Metric.nhds_basis_ball.tendsto_right_iff]
+    intro r hr
+    filter_upwards [hx.continuousAt ((hf.isOpen_preimage _ isClosed_singleton.isOpen_compl).mem_nhds
+      (x := i) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
+      hf.tendsto' _ _ hi (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
+    simp only [Set.mem_preimage, Metric.mem_ball, Real.dist_eq] at hj hj' ⊢
+    grw [dist_triangle _ (convexComboPair (f j) (1 - f j) (hf0 _) (by simpa using hf1 _)
+      (add_sub_cancel ..) (x i) (y j)), dist_convexComboPair_convexComboPair_le]
+    simp only [dist_self, mul_zero, add_zero, dist_convexComboPair_left]
+    grw [abs_sub_comm, ← le_abs_self] at hj'
+    grw [hj, hj', hf1, hD]
+    · field_simp; norm_num
+    · exact hf0 _
+
+section Convex
+
+/-- A convex subset of a vector space is a convex space. -/
+-- TODO: this should generalize to arbitrary convex space once `Convex` is redefined.
+noncomputable def Convex.convexSpace
+    {R E : Type*} [LinearOrder R] [Field R] [IsStrictOrderedRing R]
+      [AddCommGroup E] [Module R E] (S : Set E) (H : Convex R S) :
+    ConvexSpace R S where
+  convexCombination f :=
+    letI : ConvexSpace R E := inferInstance
+    ⟨convexCombination (f.map (↑)), by
+    simpa [convexCombination_eq_sum, StdSimplex.map, Finsupp.sum_mapDomain_index, add_smul] using
+      H.sum_mem (fun _ _ ↦ f.nonneg _) f.total fun i _ ↦ i.2⟩
+  assoc f := by
+    simp [convexCombination_eq_sum, StdSimplex.map, Finsupp.sum_mapDomain_index, add_smul,
+      StdSimplex.join, Finsupp.sum_sum_index, Finsupp.sum_smul_index, mul_smul, Finsupp.smul_sum]
+  single x := by simp [convexCombination_eq_sum, ← StdSimplex.mk_single, StdSimplex.map]
+
+@[simp]
+lemma Convex.coe_convexCombination {R E : Type*} [LinearOrder R] [Field R] [IsStrictOrderedRing R]
+      [AddCommGroup E] [Module R E] (S : Set E) (H : Convex R S) (f : StdSimplex R S) :
+    letI : ConvexSpace R E := inferInstance; letI := H.convexSpace
+    (↑(convexCombination f) : E) = convexCombination (f.map (↑)) :=
+  rfl
+
+instance (priority := low) {V : Type*} {P : Type*}
+    [NormedAddCommGroup V] [NormedSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P] :
+    IsConvexMetricSpace P where
+  dist_convexCombination_map_le' f σ₁ σ₂ := by
+    let p : P := Nonempty.some inferInstance
+    simp only [AddTorsor.convexCombination_eq_affineCombination, ge_iff_le]
+    rw [Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ _ (f.map σ₁).total p,
+      Finset.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ _ (f.map σ₂).total p]
+    trans ‖((StdSimplex.map σ₁ f).sum fun x i ↦ i • (x -ᵥ p)) -
+      (StdSimplex.map σ₂ f).sum fun x i ↦ i • (x -ᵥ p)‖
+    · simp [dist_eq_norm_vsub, Finsupp.sum]
+    trans ‖f.sum fun a b ↦ b • (σ₁ a -ᵥ σ₂ a)‖
+    · simp [StdSimplex.map, Finsupp.sum_mapDomain_index, add_smul, ← Finsupp.sum_sub, ← smul_sub]
+    grw [Finsupp.sum, Finsupp.sum, norm_sum_le]
+    simp [norm_smul, abs_eq_self.mpr (f.nonneg _), dist_eq_norm_vsub]
+
+lemma Convex.isConvexMetricSpace {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (S : Set E) (H : Convex ℝ S) :
+    letI := H.convexSpace
+    IsConvexMetricSpace S := by
+  let := H.convexSpace
+  refine ⟨fun f σ₁ σ₂ ↦ .trans ?_ (dist_convexCombination_map_le (X := E) f (σ₁ ·) (σ₂ ·))⟩
+  simp [Subtype.dist_eq, StdSimplex.map_map]
+
+end Convex

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -36,29 +36,29 @@ open ConvexSpace
 variable {X : Type*} [ConvexSpace ℝ X] [MetricSpace X]
 
 variable (X) in
-/-- A convex metric space is a convex space with a compatible metric structure.
+/-- A convex metric space is a real convex space with a compatible metric structure.
 Concretely, we ask for `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)`,
 which is what one would expect from the triangle inequality.
 
 In particular, convex subsets of affine spaces are convex metric spaces. -/
 class IsConvexMetricSpace : Prop where
   /-- Use `dist_convexCombination_map_le` instead. -/
-  dist_convexCombination_map_le' (f : StdSimplex ℝ ℕ) (σ₁ σ₂ : ℕ → X) :
-    dist (convexCombination (f.map σ₁)) (convexCombination (f.map σ₂)) ≤
-      f.weights.sum fun i r ↦ r * dist (σ₁ i) (σ₂ i)
+  dist_convexCombination_map_le' (f : StdSimplex ℝ ℕ) (x y : ℕ → X) :
+    dist (convexCombination (f.map x)) (convexCombination (f.map y)) ≤
+      f.weights.sum fun i r ↦ r * dist (x i) (y i)
 
 variable [IsConvexMetricSpace X]
 
-lemma dist_convexCombination_map_le {ι : Type*} (f : StdSimplex ℝ ι) (σ₁ σ₂ : ι → X) :
-    dist (convexCombination (f.map σ₁)) (convexCombination (f.map σ₂)) ≤
-      f.weights.sum fun i r ↦ r * dist (σ₁ i) (σ₂ i) := by
+lemma dist_convexCombination_map_le {ι : Type*} (f : StdSimplex ℝ ι) (x y : ι → X) :
+    dist (convexCombination (f.map x)) (convexCombination (f.map y)) ≤
+      f.weights.sum fun i r ↦ r * dist (x i) (y i) := by
   classical
   let e : ι → ℕ := Function.extend (↑) (f.support.equivFin ·) 0
   have he (x : _) (hx : x ∈ f.support) : e x = ↑(f.support.equivFin ⟨x, hx⟩) :=
       Function.Injective.extend_apply Subtype.val_injective _ _ ⟨x, hx⟩
   let einv : ℕ → ι := Function.extend (↑) (f.support.equivFin.symm ·) (fun _ ↦ f.nonempty.some)
   have H (x : _) (hx : x ∈ f.support) : einv (e x) = x := by simp [he, hx, einv, Fin.val_injective]
-  convert IsConvexMetricSpace.dist_convexCombination_map_le' (f.map e) (σ₁ ∘ einv) (σ₂ ∘ einv)
+  convert IsConvexMetricSpace.dist_convexCombination_map_le' (f.map e) (x ∘ einv) (y ∘ einv)
     using 3
   · ext1
     simp only [StdSimplex.map, ← Finsupp.mapDomain_comp]
@@ -70,11 +70,11 @@ lemma dist_convexCombination_map_le {ι : Type*} (f : StdSimplex ℝ ι) (σ₁ 
       Finsupp.sum_mapDomain_index]
     exact Finsupp.sum_congr fun x hx ↦ by simp [H, hx]
 
-lemma dist_convexCombination_left (f : StdSimplex ℝ X) (x : X) :
+lemma dist_convexCombination_left_le (f : StdSimplex ℝ X) (x : X) :
     dist (convexCombination f) x ≤ f.weights.sum fun i r ↦ r * dist i x := by
   simpa using dist_convexCombination_map_le f id (fun _ ↦ x)
 
-lemma dist_convexCombination_right (f : StdSimplex ℝ X) (x : X) :
+lemma dist_convexCombination_right_le (f : StdSimplex ℝ X) (x : X) :
     dist x (convexCombination f) ≤ f.weights.sum fun i r ↦ r * dist x i := by
   simpa using dist_convexCombination_map_le f (fun _ ↦ x) id
 
@@ -90,7 +90,7 @@ lemma dist_convexComboPair_left
     grw [sub_le_iff_le_add, dist_comm x y, ← H ht hs ((add_comm _ _).trans h) y x, dist_comm,
       convexComboPair_symm, ← dist_triangle_left]
   intro s t hs ht h x y
-  grw [convexComboPair, dist_convexCombination_left]
+  grw [convexComboPair, dist_convexCombination_left_le]
   simp [StdSimplex.duple, Finsupp.sum_add_index, add_mul, dist_comm y x]
 
 @[simp]
@@ -111,6 +111,10 @@ lemma dist_right_convexComboPair
     dist y (convexComboPair s t hs ht h x y) = s * dist x y := by
   rw [dist_comm, dist_convexComboPair_right]
 
+/-- `dist(sx + (1-s)y, s'x + (1-s')y) = |s - s'| dist(x, y)`.
+
+See `dist_convexComboPair_convexComboPair_le`
+for the version where the weights are fixed and the points change. -/
 lemma dist_convexComboPair_convexComboPair
     {s t s' t' : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1)
     (hs' : 0 ≤ s') (ht' : 0 ≤ t') (h' : s' + t' = 1) (x y : X) :
@@ -143,6 +147,10 @@ lemma dist_convexComboPair_convexComboPair
     simp [StdSimplex.duple, StdSimplex.map, Finsupp.mapDomain,
       Finsupp.sum_fintype, Fin.sum_univ_succ, f, show t' = s - s' + t by grind]
 
+/-- `dist(sx + (1-s)y, sx' + (1-s)y') ≤ s dist(x, x') + (1-s) dist(y, y')`.
+
+See `dist_convexComboPair_convexComboPair`
+for the version where the points are fixed and the weights change. -/
 lemma dist_convexComboPair_convexComboPair_le
     {s t : ℝ} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y x' y' : X) :
     dist (convexComboPair s t hs ht h x y) (convexComboPair s t hs ht h x' y') ≤
@@ -175,11 +183,11 @@ lemma continuous_convexComboPair :
       dist_convexComboPair_convexComboPair, Subtype.dist_eq, dist_eq_norm]
 
 /-- When `X` is a bounded convex metric space, to check continuity of
-`f(i) • x(i) + (1 - f(i)) • y(i)` it suffices to show that `f` is continuous,
-`x` is continuous away from `f(i) = 0`, and `y` is continuous away from `f(i) = 1`. -/
+`t ↦ f(t) • x(t) + (1 - f(t)) • y(t)` it suffices to show that `f` is continuous,
+`x` is continuous away from `f(t) = 0`, and `y` is continuous away from `f(t) = 1`. -/
 lemma continuous_convexComboPair' [BoundedSpace X]
-    {ι : Type*} [TopologicalSpace ι] (f : ι → ℝ) (hf : Continuous f)
-    (hf0 : ∀ i, 0 ≤ f i) (hf1 : ∀ i, f i ≤ 1) (x y : ι → X)
+    {T : Type*} [TopologicalSpace T] (f : T → ℝ) (hf : Continuous f)
+    (hf0 : ∀ t, 0 ≤ f t) (hf1 : ∀ t, f t ≤ 1) (x y : T → X)
     (hx : ContinuousOn x (f ⁻¹' {0}ᶜ)) (hy : ContinuousOn y (f ⁻¹' {1}ᶜ)) :
     Continuous fun i ↦ convexComboPair (f i) (1 - f i) (hf0 _) (by simpa using hf1 _)
       (add_sub_cancel ..) (x i) (y i) := by
@@ -187,37 +195,37 @@ lemma continuous_convexComboPair' [BoundedSpace X]
     ‹_›)).and (Filter.eventually_gt_atTop 0)).exists
   simp only [Set.mem_univ, forall_const] at hD
   rw [continuous_iff_continuousAt]
-  intro i
-  by_cases hi : f i ∈ Set.Ioo 0 1
+  intro t
+  by_cases ht : f t ∈ Set.Ioo 0 1
   · exact ((isOpen_Ioo.preimage hf).isOpenEmbedding_subtypeVal.continuousAt_iff
-      (x := ⟨i, hi⟩)).mp ((continuous_convexComboPair (X := X)).comp₃ (W := f ⁻¹' Set.Ioo 0 1)
+      (x := ⟨t, ht⟩)).mp ((continuous_convexComboPair (X := X)).comp₃ (W := f ⁻¹' Set.Ioo 0 1)
       (e := fun i ↦ ⟨f i, Set.Ioo_subset_Icc_self i.prop⟩) (f := x ∘ (↑)) (k := y ∘ (↑))
       (by fun_prop) (hx.comp_continuous continuous_subtype_val (by simp_all; grind))
       (hy.comp_continuous continuous_subtype_val (by simp_all; grind))).continuousAt
-  obtain hi | hi : f i = 0 ∨ f i = 1 := by
-    simpa [le_antisymm_iff, hf0 _, hf1 _, -not_and, not_and_or] using hi
-  · simp only [ContinuousAt, hi, sub_zero, convexComboPair_zero]
+  obtain ht | ht : f t = 0 ∨ f t = 1 := by
+    simpa [le_antisymm_iff, hf0 _, hf1 _, -not_and, not_and_or] using ht
+  · simp only [ContinuousAt, ht, sub_zero, convexComboPair_zero]
     rw [Metric.nhds_basis_ball.tendsto_right_iff]
     intro r hr
     filter_upwards [hy.continuousAt ((hf.isOpen_preimage _ isClosed_singleton.isOpen_compl).mem_nhds
-      (x := i) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
-      hf.tendsto' _ _ hi (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
+      (x := t) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
+      hf.tendsto' _ _ ht (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
     simp only [Set.mem_preimage, Metric.mem_ball, dist_zero_right, Real.norm_eq_abs] at hj hj' ⊢
     grw [dist_triangle _ (convexComboPair (f j) (1 - f j) (hf0 _) (by simpa using hf1 _)
-      (add_sub_cancel ..) (x j) (y i)), dist_convexComboPair_convexComboPair_le]
+      (add_sub_cancel ..) (x j) (y t)), dist_convexComboPair_convexComboPair_le]
     simp only [dist_self, mul_zero, zero_add, dist_convexComboPair_right]
     grw [sub_le_self _ (hf0 _), hj, hD, (le_abs_self _).trans hj'.le]
     · field_simp; norm_num
     · exact hf0 _
-  · simp only [ContinuousAt, hi, sub_self, convexComboPair_one]
+  · simp only [ContinuousAt, ht, sub_self, convexComboPair_one]
     rw [Metric.nhds_basis_ball.tendsto_right_iff]
     intro r hr
     filter_upwards [hx.continuousAt ((hf.isOpen_preimage _ isClosed_singleton.isOpen_compl).mem_nhds
-      (x := i) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
-      hf.tendsto' _ _ hi (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
+      (x := t) (by simp [*])) (Metric.ball_mem_nhds _ (show 0 < r / 3 by simpa)),
+      hf.tendsto' _ _ ht (Metric.ball_mem_nhds _ (show 0 < r / D / 3 by simp [*]))] with j hj hj'
     simp only [Set.mem_preimage, Metric.mem_ball, Real.dist_eq] at hj hj' ⊢
     grw [dist_triangle _ (convexComboPair (f j) (1 - f j) (hf0 _) (by simpa using hf1 _)
-      (add_sub_cancel ..) (x i) (y j)), dist_convexComboPair_convexComboPair_le]
+      (add_sub_cancel ..) (x t) (y j)), dist_convexComboPair_convexComboPair_le]
     simp only [dist_self, mul_zero, add_zero, dist_convexComboPair_left]
     grw [abs_sub_comm, ← le_abs_self] at hj'
     grw [hj, hj', hf1, hD]
@@ -228,9 +236,10 @@ section Convex
 
 /-- A convex subset of a vector space is a convex space. -/
 -- TODO: this should generalize to arbitrary convex space once `Convex` is redefined.
-noncomputable def Convex.convexSpace
+@[implicit_reducible]
+noncomputable def ConvexSpace.ofConvex
     {R E : Type*} [LinearOrder R] [Field R] [IsStrictOrderedRing R]
-      [AddCommGroup E] [Module R E] (S : Set E) (H : Convex R S) :
+      [AddCommGroup E] [Module R E] {S : Set E} (H : Convex R S) :
     ConvexSpace R S where
   convexCombination f :=
     letI : ConvexSpace R E := inferInstance
@@ -243,13 +252,14 @@ noncomputable def Convex.convexSpace
   single x := by simp [convexCombination_eq_sum, ← StdSimplex.mk_single, StdSimplex.map]
 
 @[simp]
-lemma Convex.coe_convexCombination {R E : Type*} [LinearOrder R] [Field R] [IsStrictOrderedRing R]
+lemma ConvexSpace.ofConvex.coe_convexCombination
+      {R E : Type*} [LinearOrder R] [Field R] [IsStrictOrderedRing R]
       [AddCommGroup E] [Module R E] (S : Set E) (H : Convex R S) (f : StdSimplex R S) :
-    letI : ConvexSpace R E := inferInstance; letI := H.convexSpace
+    letI : ConvexSpace R E := inferInstance; letI : ConvexSpace R S := .ofConvex H
     (↑(convexCombination f) : E) = convexCombination (f.map (↑)) :=
   rfl
 
-instance (priority := low) {V : Type*} {P : Type*}
+instance (priority := low) {V P : Type*}
     [NormedAddCommGroup V] [NormedSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P] :
     IsConvexMetricSpace P where
   dist_convexCombination_map_le' f σ₁ σ₂ := by
@@ -265,11 +275,11 @@ instance (priority := low) {V : Type*} {P : Type*}
     grw [Finsupp.sum, Finsupp.sum, norm_sum_le]
     simp [norm_smul, abs_eq_self.mpr (f.nonneg _), dist_eq_norm_vsub]
 
-lemma Convex.isConvexMetricSpace {E : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] (S : Set E) (H : Convex ℝ S) :
-    letI := H.convexSpace
+lemma IsConvexMetricSpace.of_convex {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {S : Set E} (H : Convex ℝ S) :
+    letI : ConvexSpace ℝ S := .ofConvex H
     IsConvexMetricSpace S := by
-  let := H.convexSpace
+  letI : ConvexSpace ℝ S := .ofConvex H
   refine ⟨fun f σ₁ σ₂ ↦ .trans ?_ (dist_convexCombination_map_le (X := E) f (σ₁ ·) (σ₂ ·))⟩
   simp [Subtype.dist_eq, StdSimplex.map_map]
 

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -26,6 +26,8 @@ which is what one would expect from the triangle inequality.
 ## TODO
 - Equip `StdSimplex` with a topology and show the analogous continuity result for n-ary
   convex combinations.
+- Reverse the import direction with `Mathlib.LinearAlgebra.ConvexSpace.AffineSpace`
+  once that file is moved to the proper location.
 
 -/
 
@@ -49,6 +51,7 @@ class IsConvexMetricSpace : Prop where
 
 variable [IsConvexMetricSpace X]
 
+/-- `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)` -/
 lemma dist_convexCombination_map_le {ι : Type*} (f : StdSimplex ℝ ι) (x y : ι → X) :
     dist (convexCombination (f.map x)) (convexCombination (f.map y)) ≤
       f.weights.sum fun i r ↦ r * dist (x i) (y i) := by

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -26,8 +26,8 @@ which is what one would expect from the triangle inequality.
 ## TODO
 - Equip `StdSimplex` with a topology and show the analogous continuity result for n-ary
   convex combinations.
-- Reverse the import direction with `Mathlib.LinearAlgebra.ConvexSpace.AffineSpace`
-  once that file is moved to the proper location.
+- Tidy up the imports with `Mathlib.LinearAlgebra.ConvexSpace.AffineSpace` etc once those files
+  are moved to proper places.
 
 -/
 
@@ -185,18 +185,16 @@ lemma continuous_convexComboPair :
     simp [← coe_nnreal_ennreal_nndist, ← ENNReal.coe_mul, NNReal.toReal_le,
       dist_convexComboPair_convexComboPair, Subtype.dist_eq, dist_eq_norm]
 
-/-- When `X` is a bounded convex metric space, to check continuity of
-`t ↦ f(t) • x(t) + (1 - f(t)) • y(t)` it suffices to show that `f` is continuous,
-`x` is continuous away from `f(t) = 0`, and `y` is continuous away from `f(t) = 1`. -/
-lemma continuous_convexComboPair' [BoundedSpace X]
+lemma continuous_convexComboPair_of_isBounded
     {T : Type*} [TopologicalSpace T] (f : T → ℝ) (hf : Continuous f)
     (hf0 : ∀ t, 0 ≤ f t) (hf1 : ∀ t, f t ≤ 1) (x y : T → X)
-    (hx : ContinuousOn x (f ⁻¹' {0}ᶜ)) (hy : ContinuousOn y (f ⁻¹' {1}ᶜ)) :
+    (hx : ContinuousOn x (f ⁻¹' {0}ᶜ)) (hy : ContinuousOn y (f ⁻¹' {1}ᶜ))
+    (hx' : Bornology.IsBounded (Set.range x)) (hy' : Bornology.IsBounded (Set.range y)) :
     Continuous fun i ↦ convexComboPair (f i) (1 - f i) (hf0 _) (by simpa using hf1 _)
       (add_sub_cancel ..) (x i) (y i) := by
-  obtain ⟨D, hD, hD'⟩ := ((Metric.isBounded_iff_eventually.mp (Bornology.isBounded_univ.mpr
-    ‹_›)).and (Filter.eventually_gt_atTop 0)).exists
-  simp only [Set.mem_univ, forall_const] at hD
+  obtain ⟨D, hD, hD'⟩ := ((Metric.isBounded_iff_eventually.mp (hx'.union hy')).and
+    (Filter.eventually_gt_atTop 0)).exists
+  replace hD := fun t₁ t₂ ↦ hD (.inl (Set.mem_range_self t₁)) (.inr (Set.mem_range_self t₂))
   rw [continuous_iff_continuousAt]
   intro t
   by_cases ht : f t ∈ Set.Ioo 0 1
@@ -234,6 +232,17 @@ lemma continuous_convexComboPair' [BoundedSpace X]
     grw [hj, hj', hf1, hD]
     · field_simp; norm_num
     · exact hf0 _
+
+/-- When `X` is a bounded convex metric space, to check continuity of
+`t ↦ f(t) • x(t) + (1 - f(t)) • y(t)` it suffices to show that `f` is continuous,
+`x` is continuous away from `f(t) = 0`, and `y` is continuous away from `f(t) = 1`. -/
+lemma continuous_convexComboPair' [BoundedSpace X]
+    {T : Type*} [TopologicalSpace T] (f : T → ℝ) (hf : Continuous f)
+    (hf0 : ∀ t, 0 ≤ f t) (hf1 : ∀ t, f t ≤ 1) (x y : T → X)
+    (hx : ContinuousOn x (f ⁻¹' {0}ᶜ)) (hy : ContinuousOn y (f ⁻¹' {1}ᶜ)) :
+    Continuous fun i ↦ convexComboPair (f i) (1 - f i) (hf0 _) (by simpa using hf1 _)
+      (add_sub_cancel ..) (x i) (y i) :=
+  continuous_convexComboPair_of_isBounded f hf hf0 hf1 x y hx hy (.all _) (.all _)
 
 section Convex
 

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -31,11 +31,6 @@ which is what one would expect from the triangle inequality.
 
 @[expose] public section
 
-lemma Topology.IsOpenEmbedding.continuousAt_iff' {X Y Z : Type*} {f : X → Y}
-    {g : Y → Z} [TopologicalSpace Y] [TopologicalSpace X] [TopologicalSpace Z]
-    (hf : Topology.IsOpenEmbedding f) {x : X} : ContinuousAt (g ∘ f) x ↔ ContinuousAt g (f x) :=
-  hf.isInducing.continuousAt_iff' (hf.isOpen_range.mem_nhds (by simp))
-
 open ConvexSpace
 
 variable {X : Type*} [ConvexSpace ℝ X] [MetricSpace X]
@@ -194,7 +189,7 @@ lemma continuous_convexComboPair' [BoundedSpace X]
   rw [continuous_iff_continuousAt]
   intro i
   by_cases hi : f i ∈ Set.Ioo 0 1
-  · exact ((isOpen_Ioo.preimage hf).isOpenEmbedding_subtypeVal.continuousAt_iff'
+  · exact ((isOpen_Ioo.preimage hf).isOpenEmbedding_subtypeVal.continuousAt_iff
       (x := ⟨i, hi⟩)).mp ((continuous_convexComboPair (X := X)).comp₃ (W := f ⁻¹' Set.Ioo 0 1)
       (e := fun i ↦ ⟨f i, Set.Ioo_subset_Icc_self i.prop⟩) (f := x ∘ (↑)) (k := y ∘ (↑))
       (by fun_prop) (hx.comp_continuous continuous_subtype_val (by simp_all; grind))

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -40,7 +40,7 @@ variable (X) in
 Concretely, we ask for `dist(∑ tᵢ xᵢ, ∑ tᵢ yᵢ) ≤ ∑ tᵢ dist(xᵢ, yᵢ)`,
 which is what one would expect from the triangle inequality.
 
-In particular, convex subsets of affine spaces are convex metric spaces. -/
+In particular, convex subsets of normed affine spaces are convex metric spaces. -/
 class IsConvexMetricSpace : Prop where
   /-- Use `dist_convexCombination_map_le` instead. -/
   dist_convexCombination_map_le' (f : StdSimplex ℝ ℕ) (x y : ℕ → X) :

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -203,7 +203,7 @@ lemma continuous_convexComboPair' [BoundedSpace X]
       (by fun_prop) (hx.comp_continuous continuous_subtype_val (by simp_all; grind))
       (hy.comp_continuous continuous_subtype_val (by simp_all; grind))).continuousAt
   obtain ht | ht : f t = 0 ∨ f t = 1 := by
-    simpa [le_antisymm_iff, hf0 _, hf1 _, -not_and, not_and_or] using ht
+    simpa [le_antisymm_iff, hf0, hf1, -not_and, not_and_or] using ht
   · simp only [ContinuousAt, ht, sub_zero, convexComboPair_zero]
     rw [Metric.nhds_basis_ball.tendsto_right_iff]
     intro r hr

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -49,10 +49,10 @@ theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι
 noncomputable
 instance (𝕜 : Type*) [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] :
     ConvexSpace 𝕜 ↑(stdSimplex 𝕜 ι) :=
-  (convex_stdSimplex 𝕜 ι).convexSpace _
+  .ofConvex (convex_stdSimplex 𝕜 ι)
 
 instance : IsConvexMetricSpace ↑(stdSimplex ℝ ι) :=
-  (convex_stdSimplex _ _).isConvexMetricSpace
+  .of_convex (convex_stdSimplex _ _)
 
 @[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
   eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -5,10 +5,10 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies, Joël Riou
 -/
 module
 
-public import Mathlib.Analysis.Convex.MetricSpace
 public import Mathlib.Analysis.Convex.PathConnected
 public import Mathlib.Topology.Algebra.Monoid.FunOnFinite
 public import Mathlib.Topology.UnitInterval
+public import Mathlib.LinearAlgebra.ConvexSpace
 
 /-!
 # The standard simplex
@@ -50,9 +50,6 @@ noncomputable
 instance (𝕜 : Type*) [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] :
     ConvexSpace 𝕜 ↑(stdSimplex 𝕜 ι) :=
   .ofConvex (convex_stdSimplex 𝕜 ι)
-
-instance : IsConvexMetricSpace ↑(stdSimplex ℝ ι) :=
-  .of_convex (convex_stdSimplex _ _)
 
 @[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
   eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -5,10 +5,10 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies, Joël Riou
 -/
 module
 
+public import Mathlib.Analysis.Convex.Combination
 public import Mathlib.Analysis.Convex.PathConnected
 public import Mathlib.Topology.Algebra.Monoid.FunOnFinite
 public import Mathlib.Topology.UnitInterval
-public import Mathlib.LinearAlgebra.ConvexSpace
 
 /-!
 # The standard simplex
@@ -45,11 +45,6 @@ theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι
   · simp_rw [Pi.add_apply, Pi.smul_apply]
     rwa [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, hf.2, hg.2, smul_eq_mul,
       smul_eq_mul, mul_one, mul_one]
-
-noncomputable
-instance (𝕜 : Type*) [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] :
-    ConvexSpace 𝕜 ↑(stdSimplex 𝕜 ι) :=
-  .ofConvex (convex_stdSimplex 𝕜 ι)
 
 @[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
   eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩
@@ -271,7 +266,7 @@ theorem diam_stdSimplex [Nontrivial ι] : Metric.diam (stdSimplex ℝ ι) = 1 :=
   obtain ⟨i, j, hij⟩ := exists_pair_ne ι
   classical
   rw [show (1 : ℝ) = dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) by
-    simp [dist_single_single i j (1 : ℝ) 1 hij]]
+    simp [dist_single_single i j (1 : ℝ) 1 hij, Real.dist_eq]]
   exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _)
     (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
 

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -5,7 +5,7 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies, Joël Riou
 -/
 module
 
-public import Mathlib.Analysis.Convex.Combination
+public import Mathlib.Analysis.Convex.MetricSpace
 public import Mathlib.Analysis.Convex.PathConnected
 public import Mathlib.Topology.Algebra.Monoid.FunOnFinite
 public import Mathlib.Topology.UnitInterval
@@ -45,6 +45,14 @@ theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι
   · simp_rw [Pi.add_apply, Pi.smul_apply]
     rwa [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, hf.2, hg.2, smul_eq_mul,
       smul_eq_mul, mul_one, mul_one]
+
+noncomputable
+instance (𝕜 : Type*) [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] :
+    ConvexSpace 𝕜 ↑(stdSimplex 𝕜 ι) :=
+  (convex_stdSimplex 𝕜 ι).convexSpace _
+
+instance : IsConvexMetricSpace ↑(stdSimplex ℝ ι) :=
+  (convex_stdSimplex _ _).isConvexMetricSpace
 
 @[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
   eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩
@@ -266,7 +274,7 @@ theorem diam_stdSimplex [Nontrivial ι] : Metric.diam (stdSimplex ℝ ι) = 1 :=
   obtain ⟨i, j, hij⟩ := exists_pair_ne ι
   classical
   rw [show (1 : ℝ) = dist (Pi.single i 1 : ι → ℝ) (Pi.single j 1) by
-    simp [dist_single_single i j (1 : ℝ) 1 hij, Real.dist_eq]]
+    simp [dist_single_single i j (1 : ℝ) 1 hij]]
   exact Metric.dist_le_diam_of_mem (bounded_stdSimplex _)
     (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
 

--- a/Mathlib/LinearAlgebra/ConvexSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace.lean
@@ -64,8 +64,11 @@ grind_pattern StdSimplex.total => self.weights
 
 namespace StdSimplex
 
-variable {R : Type u} [PartialOrder R] [Semiring R]
-  {M : Type v}
+variable {R : Type u} [PartialOrder R] [Semiring R] {M N P : Type*}
+
+lemma nonempty [Nontrivial R] (f : StdSimplex R M) : Nonempty M := by
+  by_contra!
+  simpa [Subsingleton.elim f.weights 0, -total] using f.total
 
 @[ext]
 theorem ext {f g : StdSimplex R M} (h : f.weights = g.weights) : f = g := by
@@ -74,12 +77,12 @@ theorem ext {f g : StdSimplex R M} (h : f.weights = g.weights) : f = g := by
 variable [IsStrictOrderedRing R]
 
 /-- The point mass distribution concentrated at `x`. -/
+@[simps weights]
 def single (x : M) : StdSimplex R M where
   weights := Finsupp.single x 1
   nonneg := by simp
   total := by simp
 
-@[simp]
 theorem mk_single (x : M) {nonneg total} :
     (StdSimplex.mk (Finsupp.single x (1 : R)) nonneg total) = single x := rfl
 
@@ -99,6 +102,37 @@ def map {M : Type v} {N : Type w} (g : M → N) (f : StdSimplex R M) : StdSimple
   weights := f.weights.mapDomain g
   nonneg := f.mapDomain_nonneg f.nonneg
   total := by simp [Finsupp.sum_mapDomain_index]
+
+@[simp]
+lemma map_const (f : StdSimplex R M) (x : N) : f.map (fun _ ↦ x) = .single x := by
+  classical
+  ext a
+  suffices (f.sum fun a₁ b ↦ if x = a then b else 0) = if x = a then 1 else 0 by
+    simpa [map, Finsupp.mapDomain, ← mk_single, Finsupp.single_apply]
+  split_ifs <;> simp
+
+@[simp]
+lemma map_single (x : M) (f : M → N) : (single (R := R) x).map f = .single (f x) := by
+  ext a
+  simp [map, ← mk_single]
+
+@[simp]
+lemma map_duple {s t : R} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y : M) (f : M → N) :
+    (duple x y hs ht h).map f = duple (f x) (f y) hs ht h := by
+  ext a
+  simp [map, duple, Finsupp.mapDomain_add]
+
+@[simp]
+lemma map_id (f : StdSimplex R M) : f.map id = f := by
+  ext; simp [map]
+
+lemma map_comp (f : StdSimplex R M) (g₁ : M → N) (g₂ : N → P) :
+    f.map (g₂ ∘ g₁) = (f.map g₁).map g₂ := by
+  ext; simp [map, Finsupp.mapDomain_comp]
+
+lemma map_map (f : StdSimplex R M) (g₁ : M → N) (g₂ : N → P) :
+    (f.map g₁).map g₂ = f.map (fun x ↦ g₂ (g₁ x)) :=
+  (map_comp ..).symm
 
 /--
 Join operation for standard simplices (monadic join).
@@ -139,18 +173,28 @@ def convexComboPair (s t : R) (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) (x y
   convexCombination (.duple x y hs ht h)
 
 /-- A binary convex combination with weight 0 on the first point returns the second point. -/
+@[simp]
 theorem convexComboPair_zero {x y : M} :
     convexComboPair (0 : R) 1 (by simp) (by simp) (by simp) x y = y := by
-  simp [convexComboPair, StdSimplex.duple]
+  simp [convexComboPair, StdSimplex.duple, StdSimplex.mk_single]
 
 /-- A binary convex combination with weight 1 on the first point returns the first point. -/
+@[simp]
 theorem convexComboPair_one {x y : M} :
     convexComboPair (1 : R) 0 (by simp) (by simp) (by simp) x y = x := by
-  simp [convexComboPair, StdSimplex.duple]
+  simp [convexComboPair, StdSimplex.duple, StdSimplex.mk_single]
 
 /-- A convex combination of a point with itself is that point. -/
+@[simp]
 theorem convexComboPair_same {s t : R} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) {x : M} :
     convexComboPair s t hs ht h x x = x := by
   unfold convexComboPair
   convert ConvexSpace.single x
   simp only [StdSimplex.duple, StdSimplex.single, ← Finsupp.single_add, h]
+
+theorem convexComboPair_symm {s t : R} (hs : 0 ≤ s) (ht : 0 ≤ t) (h : s + t = 1) {x y : M} :
+    convexComboPair s t hs ht h x y = convexComboPair t s ht hs ((add_comm _ _).trans h) y x := by
+  unfold convexComboPair
+  congr 1
+  ext1
+  simp [StdSimplex.duple, add_comm]

--- a/Mathlib/LinearAlgebra/ConvexSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace.lean
@@ -107,7 +107,7 @@ def map {M : Type v} {N : Type w} (g : M → N) (f : StdSimplex R M) : StdSimple
 lemma map_const (f : StdSimplex R M) (x : N) : f.map (fun _ ↦ x) = .single x := by
   classical
   ext a
-  suffices (f.sum fun a₁ b ↦ if x = a then b else 0) = if x = a then 1 else 0 by
+  suffices f.sum (fun a₁ b ↦ if x = a then b else 0) = if x = a then 1 else 0 by
     simpa [map, Finsupp.mapDomain, ← mk_single, Finsupp.single_apply]
   split_ifs <;> simp
 

--- a/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
+++ b/Mathlib/LinearAlgebra/ConvexSpace/AffineSpace.lean
@@ -102,9 +102,15 @@ public instance instConvexSpace : ConvexSpace R P where
 
 /-- `ConvexSpace.convexCombination` in an affine space is the affine combination. -/
 public theorem convexCombination_eq_affineCombination (s : StdSimplex R P) :
-    letI : ConvexSpace R P := instConvexSpace
+    letI : ConvexSpace R P := inferInstance
     ConvexSpace.convexCombination s = s.weights.support.affineCombination R id s.weights := by
   rfl
+
+public lemma _root_.convexCombination_eq_sum (f : StdSimplex R V) :
+    letI : ConvexSpace R V := inferInstance
+    ConvexSpace.convexCombination f = f.sum fun i r ↦ r • i := by
+  simp [AddTorsor.convexCombination_eq_affineCombination,
+    Finset.affineCombination_eq_linear_combination _ _ _ f.total, Finsupp.sum]
 
 /-- `convexComboPair` in an affine space is the affine line map. -/
 public theorem convexComboPair_eq_lineMap (s t : R) (hs : 0 ≤ s) (ht : 0 ≤ t)

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -175,6 +175,8 @@ theorem _root_.IsCompact.isBounded {s : Set α} (h : IsCompact s) : IsBounded s 
   -- A compact set is totally bounded, thus bounded
   h.totallyBounded.isBounded
 
+instance (priority := low) [CompactSpace α] : BoundedSpace α := ⟨isCompact_univ.isBounded⟩
+
 theorem cobounded_le_cocompact : cobounded α ≤ cocompact α :=
   hasBasis_cocompact.ge_iff.2 fun _s hs ↦ hs.isBounded
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Note: Yaël provided me the mathematical definition of `IsConvexMetricSpace`, hence the name in the authors field. But they have not interfered with anything else in this PR and hence not a coauthor of this PR. Thus I believe that they are qualified to review everything but the question of "is this the correct mathematical definition of convex metric spaces?".

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
