### PR TITLE
[Merged by Bors] - chore(Order/UpperLower/Closure): use `to_dual`

### DIFF
--- a/Mathlib/Order/GaloisConnection/Defs.lean
+++ b/Mathlib/Order/GaloisConnection/Defs.lean
@@ -41,7 +41,8 @@ but do not depend on the category theory library in mathlib. -/
 def GaloisConnection [Preorder α] [Preorder β] (l : α → β) (u : β → α) :=
   ∀ a b, l a ≤ b ↔ a ≤ u b
 
-to_dual_insert_cast GaloisConnection := by grind
+to_dual_insert_cast GaloisConnection := by
+  rw [forall_comm]; simp only [Iff.comm]
 
 namespace GaloisConnection
 

--- a/Mathlib/Order/UpperLower/Closure.lean
+++ b/Mathlib/Order/UpperLower/Closure.lean
@@ -32,95 +32,56 @@ section Preorder
 variable [Preorder α] [Preorder β] {s t : Set α} {x : α}
 
 /-- The greatest upper set containing a given set. -/
+@[to_dual /-- The least lower set containing a given set. -/]
 def upperClosure (s : Set α) : UpperSet α :=
   ⟨{ x | ∃ a ∈ s, a ≤ x }, fun _ _ hle h => h.imp fun _x hx => ⟨hx.1, hx.2.trans hle⟩⟩
 
-/-- The least lower set containing a given set. -/
-def lowerClosure (s : Set α) : LowerSet α :=
-  ⟨{ x | ∃ a ∈ s, x ≤ a }, fun _ _ hle h => h.imp fun _x hx => ⟨hx.1, hle.trans hx.2⟩⟩
-
--- TODO: move `GaloisInsertion`s up, use them to prove lemmas
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem mem_upperClosure : x ∈ upperClosure s ↔ ∃ a ∈ s, a ≤ x :=
   Iff.rfl
 
-@[simp]
-theorem mem_lowerClosure : x ∈ lowerClosure s ↔ ∃ a ∈ s, x ≤ a :=
-  Iff.rfl
-
--- We do not tag those two as `simp` to respect the abstraction.
-@[norm_cast]
+-- We do not tag this as `simp` to respect the abstraction.
+@[to_dual (attr := norm_cast)]
 theorem coe_upperClosure (s : Set α) : ↑(upperClosure s) = ⋃ a ∈ s, Ici a := by
   ext
   simp
 
-@[norm_cast]
-theorem coe_lowerClosure (s : Set α) : ↑(lowerClosure s) = ⋃ a ∈ s, Iic a := by
-  ext
-  simp
-
+@[to_dual]
 instance instDecidablePredMemUpperClosure [DecidablePred (∃ a ∈ s, a ≤ ·)] :
     DecidablePred (· ∈ upperClosure s) := ‹DecidablePred _›
 
-instance instDecidablePredMemLowerClosure [DecidablePred (∃ a ∈ s, · ≤ a)] :
-    DecidablePred (· ∈ lowerClosure s) := ‹DecidablePred _›
-
+@[to_dual]
 theorem subset_upperClosure : s ⊆ upperClosure s := fun x hx => ⟨x, hx, le_rfl⟩
 
-theorem subset_lowerClosure : s ⊆ lowerClosure s := fun x hx => ⟨x, hx, le_rfl⟩
-
+@[to_dual lowerClosure_min]
 theorem upperClosure_min (h : s ⊆ t) (ht : IsUpperSet t) : ↑(upperClosure s) ⊆ t :=
   fun _a ⟨_b, hb, hba⟩ => ht hba <| h hb
 
-theorem lowerClosure_min (h : s ⊆ t) (ht : IsLowerSet t) : ↑(lowerClosure s) ⊆ t :=
-  fun _a ⟨_b, hb, hab⟩ => ht hab <| h hb
-
+@[to_dual]
 protected theorem IsUpperSet.upperClosure (hs : IsUpperSet s) : ↑(upperClosure s) = s :=
   (upperClosure_min Subset.rfl hs).antisymm subset_upperClosure
 
-protected theorem IsLowerSet.lowerClosure (hs : IsLowerSet s) : ↑(lowerClosure s) = s :=
-  (lowerClosure_min Subset.rfl hs).antisymm subset_lowerClosure
-
-@[simp]
+@[to_dual (attr := simp)]
 protected theorem UpperSet.upperClosure (s : UpperSet α) : upperClosure (s : Set α) = s :=
   SetLike.coe_injective s.2.upperClosure
 
-@[simp]
-protected theorem LowerSet.lowerClosure (s : LowerSet α) : lowerClosure (s : Set α) = s :=
-  SetLike.coe_injective s.2.lowerClosure
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem upperClosure_image (f : α ≃o β) :
     upperClosure (f '' s) = UpperSet.map f (upperClosure s) := by
   rw [← f.symm_symm, ← UpperSet.symm_map, f.symm_symm]
   ext
-  simp [-UpperSet.symm_map, UpperSet.map, OrderIso.symm, ← f.le_symm_apply]
+  simp only [SetLike.mem_coe]
+  simp [f.le_symm_apply]
 
-@[simp]
-theorem lowerClosure_image (f : α ≃o β) :
-    lowerClosure (f '' s) = LowerSet.map f (lowerClosure s) := by
-  rw [← f.symm_symm, ← LowerSet.symm_map, f.symm_symm]
-  ext
-  simp [-LowerSet.symm_map, LowerSet.map, OrderIso.symm, ← f.symm_apply_le]
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem UpperSet.iInf_Ici (s : Set α) : ⨅ a ∈ s, UpperSet.Ici a = upperClosure s := by
   ext
   simp
 
-@[simp]
-theorem LowerSet.iSup_Iic (s : Set α) : ⨆ a ∈ s, LowerSet.Iic a = lowerClosure s := by
-  ext
-  simp
-
-@[simp] lemma lowerClosure_le {t : LowerSet α} : lowerClosure s ≤ t ↔ s ⊆ t :=
+@[to_dual (attr := simp) le_upperClosure]
+lemma lowerClosure_le {t : LowerSet α} : lowerClosure s ≤ t ↔ s ⊆ t :=
   ⟨fun h ↦ subset_lowerClosure.trans <| LowerSet.coe_subset_coe.2 h,
     fun h ↦ lowerClosure_min h t.lower⟩
-
-@[simp] lemma le_upperClosure {s : UpperSet α} : s ≤ upperClosure t ↔ t ⊆ s :=
-  ⟨fun h ↦ subset_upperClosure.trans <| UpperSet.coe_subset_coe.2 h,
-    fun h ↦ upperClosure_min h s.upper⟩
 
 theorem gc_upperClosure_coe :
     GaloisConnection (toDual ∘ upperClosure : Set α → (UpperSet α)ᵒᵈ) ((↑) ∘ ofDual) :=
@@ -150,63 +111,40 @@ theorem upperClosure_anti : Antitone (upperClosure : Set α → UpperSet α) :=
 theorem lowerClosure_mono : Monotone (lowerClosure : Set α → LowerSet α) :=
   gc_lowerClosure_coe.monotone_l
 
-@[simp]
+@[to_dual (attr := simp)]
+theorem upperClosure_eq_top_iff : upperClosure s = ⊤ ↔ s = ∅ := by
+  rw [eq_top_iff, le_upperClosure]; simp
+
+@[to_dual (attr := simp)]
 theorem upperClosure_empty : upperClosure (∅ : Set α) = ⊤ :=
-  (@gc_upperClosure_coe α).l_bot
+  upperClosure_eq_top_iff.mpr rfl
 
-@[simp]
-theorem lowerClosure_empty : lowerClosure (∅ : Set α) = ⊥ :=
-  (@gc_lowerClosure_coe α).l_bot
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem upperClosure_singleton (a : α) : upperClosure ({a} : Set α) = UpperSet.Ici a := by
   ext
   simp
 
-@[simp]
-theorem lowerClosure_singleton (a : α) : lowerClosure ({a} : Set α) = LowerSet.Iic a := by
-  ext
-  simp
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem upperClosure_univ : upperClosure (univ : Set α) = ⊥ :=
   bot_unique subset_upperClosure
 
-@[simp]
-theorem lowerClosure_univ : lowerClosure (univ : Set α) = ⊤ :=
-  top_unique subset_lowerClosure
-
-@[simp]
-theorem upperClosure_eq_top_iff : upperClosure s = ⊤ ↔ s = ∅ :=
-  (@gc_upperClosure_coe α _).l_eq_bot.trans subset_empty_iff
-
-@[simp]
-theorem lowerClosure_eq_bot_iff : lowerClosure s = ⊥ ↔ s = ∅ :=
-  (@gc_lowerClosure_coe α _).l_eq_bot.trans subset_empty_iff
-
-@[simp]
 theorem upperClosure_union (s t : Set α) : upperClosure (s ∪ t) = upperClosure s ⊓ upperClosure t :=
   (@gc_upperClosure_coe α _).l_sup
 
-@[simp]
+@[to_dual existing (attr := simp)]
 theorem lowerClosure_union (s t : Set α) : lowerClosure (s ∪ t) = lowerClosure s ⊔ lowerClosure t :=
   (@gc_lowerClosure_coe α _).l_sup
 
-@[simp]
 theorem upperClosure_iUnion (f : ι → Set α) : upperClosure (⋃ i, f i) = ⨅ i, upperClosure (f i) :=
   (@gc_upperClosure_coe α _).l_iSup
 
-@[simp]
+@[to_dual existing (attr := simp)]
 theorem lowerClosure_iUnion (f : ι → Set α) : lowerClosure (⋃ i, f i) = ⨆ i, lowerClosure (f i) :=
   (@gc_lowerClosure_coe α _).l_iSup
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem upperClosure_sUnion (S : Set (Set α)) : upperClosure (⋃₀ S) = ⨅ s ∈ S, upperClosure s := by
   simp_rw [sUnion_eq_biUnion, upperClosure_iUnion]
-
-@[simp]
-theorem lowerClosure_sUnion (S : Set (Set α)) : lowerClosure (⋃₀ S) = ⨆ s ∈ S, lowerClosure s := by
-  simp_rw [sUnion_eq_biUnion, lowerClosure_iUnion]
 
 theorem Set.OrdConnected.upperClosure_inter_lowerClosure (h : s.OrdConnected) :
     ↑(upperClosure s) ∩ ↑(lowerClosure s) = s :=
@@ -219,51 +157,34 @@ theorem ordConnected_iff_upperClosure_inter_lowerClosure :
   rw [← h]
   exact (UpperSet.upper _).ordConnected.inter (LowerSet.lower _).ordConnected
 
-@[simp]
-theorem upperBounds_lowerClosure : upperBounds (lowerClosure s : Set α) = upperBounds s :=
-  (upperBounds_mono_set subset_lowerClosure).antisymm
-    fun _a ha _b ⟨_c, hc, hcb⟩ ↦ hcb.trans <| ha hc
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem lowerBounds_upperClosure : lowerBounds (upperClosure s : Set α) = lowerBounds s :=
   (lowerBounds_mono_set subset_upperClosure).antisymm
     fun _a ha _b ⟨_c, hc, hcb⟩ ↦ (ha hc).trans hcb
 
-@[simp]
-theorem bddAbove_lowerClosure : BddAbove (lowerClosure s : Set α) ↔ BddAbove s := by
-  simp_rw [BddAbove, upperBounds_lowerClosure]
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem bddBelow_upperClosure : BddBelow (upperClosure s : Set α) ↔ BddBelow s := by
   simp_rw [BddBelow, lowerBounds_upperClosure]
 
-protected alias ⟨BddAbove.of_lowerClosure, BddAbove.lowerClosure⟩ := bddAbove_lowerClosure
-
+@[to_dual]
 protected alias ⟨BddBelow.of_upperClosure, BddBelow.upperClosure⟩ := bddBelow_upperClosure
 
-@[simp] lemma IsLowerSet.disjoint_upperClosure_left (ht : IsLowerSet t) :
+@[to_dual (attr := simp) disjoint_lowerClosure_left]
+lemma IsLowerSet.disjoint_upperClosure_left (ht : IsLowerSet t) :
     Disjoint ↑(upperClosure s) t ↔ Disjoint s t := by
   refine ⟨Disjoint.mono_left subset_upperClosure, ?_⟩
   simp only [disjoint_left, SetLike.mem_coe, mem_upperClosure, forall_exists_index, and_imp]
   exact fun h a b hb hba ha ↦ h hb <| ht hba ha
 
-@[simp] lemma IsLowerSet.disjoint_upperClosure_right (hs : IsLowerSet s) :
+@[to_dual (attr := simp) disjoint_lowerClosure_right]
+lemma IsLowerSet.disjoint_upperClosure_right (hs : IsLowerSet s) :
     Disjoint s (upperClosure t) ↔ Disjoint s t := by
   simpa only [disjoint_comm] using hs.disjoint_upperClosure_left
 
-@[simp] lemma IsUpperSet.disjoint_lowerClosure_left (ht : IsUpperSet t) :
-    Disjoint ↑(lowerClosure s) t ↔ Disjoint s t := ht.toDual.disjoint_upperClosure_left
-
-@[simp] lemma IsUpperSet.disjoint_lowerClosure_right (hs : IsUpperSet s) :
-    Disjoint s (lowerClosure t) ↔ Disjoint s t := hs.toDual.disjoint_upperClosure_right
-
-@[simp] lemma upperClosure_eq :
+@[to_dual (attr := simp)]
+lemma upperClosure_eq :
     ↑(upperClosure s) = s ↔ IsUpperSet s :=
   ⟨(· ▸ UpperSet.upper _), IsUpperSet.upperClosure⟩
-
-@[simp] lemma lowerClosure_eq :
-    ↑(lowerClosure s) = s ↔ IsLowerSet s :=
-  @upperClosure_eq αᵒᵈ _ _
 
 end Preorder
 
@@ -288,124 +209,69 @@ section LinearOrder
 
 variable [LinearOrder α]
 
+@[to_dual]
 lemma upperClosure_eq_bot {s : Set α} (hs : ¬ BddBelow s) : upperClosure s = ⊥ :=
   le_bot_iff.mp fun x _ ↦ ⟨_, (not_bddBelow_iff.mp hs x).choose_spec.imp id le_of_lt⟩
 
+@[to_dual]
 lemma upperClosure_eq_bot_iff [NoMinOrder α] {s : Set α} : upperClosure s = ⊥ ↔ ¬ BddBelow s :=
   ⟨fun h₁ h₂ ↦ by simpa [h₁] using bddBelow_upperClosure.mpr h₂, upperClosure_eq_bot⟩
-
-lemma lowerClosure_eq_top {s : Set α} (hs : ¬ BddAbove s) : lowerClosure s = ⊤ :=
-  SetLike.coe_injective congr($(upperClosure_eq_bot (α := αᵒᵈ) hs).1)
-
-lemma lowerClosure_eq_top_iff [NoMaxOrder α] {s : Set α} : lowerClosure s = ⊤ ↔ ¬ BddAbove s :=
-  ⟨fun h₁ h₂ ↦ by simpa [h₁] using bddAbove_lowerClosure.mpr h₂, lowerClosure_eq_top⟩
 
 end LinearOrder
 
 /-! ### Set Difference -/
 
-namespace LowerSet
-variable [Preorder α] {s : LowerSet α} {t : Set α} {a : α}
-
-/-- The biggest lower subset of a lower set `s` disjoint from a set `t`. -/
-def sdiff (s : LowerSet α) (t : Set α) : LowerSet α where
-  carrier := s \ upperClosure t
-  lower' := s.lower.sdiff_of_isUpperSet (upperClosure t).upper
-
-/-- The biggest lower subset of a lower set `s` not containing an element `a`. -/
-def erase (s : LowerSet α) (a : α) : LowerSet α where
-  carrier := s \ UpperSet.Ici a
-  lower' := s.lower.sdiff_of_isUpperSet (UpperSet.Ici a).upper
-
-@[simp, norm_cast]
-lemma coe_sdiff (s : LowerSet α) (t : Set α) : s.sdiff t = (s : Set α) \ upperClosure t := rfl
-
-@[simp, norm_cast]
-lemma coe_erase (s : LowerSet α) (a : α) : s.erase a = (s : Set α) \ UpperSet.Ici a := rfl
-
-@[simp] lemma sdiff_singleton (s : LowerSet α) (a : α) : s.sdiff {a} = s.erase a := by
-  simp [sdiff, erase]
-
-lemma sdiff_le_left : s.sdiff t ≤ s := diff_subset
-lemma erase_le : s.erase a ≤ s := diff_subset
-
-@[simp] protected lemma sdiff_eq_left : s.sdiff t = s ↔ Disjoint ↑s t := by
-  simp [← SetLike.coe_set_eq]
-
-@[simp] lemma erase_eq : s.erase a = s ↔ a ∉ s := by rw [← sdiff_singleton]; simp [-sdiff_singleton]
-
-@[simp] lemma sdiff_lt_left : s.sdiff t < s ↔ ¬ Disjoint ↑s t :=
-  sdiff_le_left.lt_iff_ne.trans LowerSet.sdiff_eq_left.not
-
-@[simp] lemma erase_lt : s.erase a < s ↔ a ∈ s := erase_le.lt_iff_ne.trans erase_eq.not_left
-
-@[simp] protected lemma sdiff_idem (s : LowerSet α) (t : Set α) : (s.sdiff t).sdiff t = s.sdiff t :=
-  SetLike.coe_injective sdiff_idem
-
-@[simp] lemma erase_idem (s : LowerSet α) (a : α) : (s.erase a).erase a = s.erase a :=
-  SetLike.coe_injective sdiff_idem
-
-lemma sdiff_sup_lowerClosure (hts : t ⊆ s) (hst : ∀ b ∈ s, ∀ c ∈ t, c ≤ b → b ∈ t) :
-    s.sdiff t ⊔ lowerClosure t = s := by
-  refine le_antisymm (sup_le sdiff_le_left <| lowerClosure_le.2 hts) fun a ha ↦ ?_
-  obtain hat | hat := em (a ∈ t)
-  · exact subset_union_right (subset_lowerClosure hat)
-  · refine subset_union_left ⟨ha, ?_⟩
-    rintro ⟨b, hb, hba⟩
-    exact hat <| hst _ ha _ hb hba
-
-lemma lowerClosure_sup_sdiff (hts : t ⊆ s) (hst : ∀ b ∈ s, ∀ c ∈ t, c ≤ b → b ∈ t) :
-    lowerClosure t ⊔ s.sdiff t = s := by rw [sup_comm, sdiff_sup_lowerClosure hts hst]
-
-lemma erase_sup_Iic (ha : a ∈ s) (has : ∀ b ∈ s, a ≤ b → b = a) : s.erase a ⊔ Iic a = s := by
-  rw [← lowerClosure_singleton, ← sdiff_singleton, sdiff_sup_lowerClosure] <;> simpa
-
-lemma Iic_sup_erase (ha : a ∈ s) (has : ∀ b ∈ s, a ≤ b → b = a) : Iic a ⊔ s.erase a = s := by
-  rw [sup_comm, erase_sup_Iic ha has]
-
-end LowerSet
-
 namespace UpperSet
 variable [Preorder α] {s : UpperSet α} {t : Set α} {a : α}
 
 /-- The biggest upper subset of an upper set `s` disjoint from a set `t`. -/
+@[to_dual /-- The biggest lower subset of a lower set `s` disjoint from a set `t`. -/]
 def sdiff (s : UpperSet α) (t : Set α) : UpperSet α where
   carrier := s \ lowerClosure t
   upper' := s.upper.sdiff_of_isLowerSet (lowerClosure t).lower
 
 /-- The biggest upper subset of an upper set `s` not containing an element `a`. -/
+@[to_dual /-- The biggest lower subset of a lower set `s` not containing an element `a`. -/]
 def erase (s : UpperSet α) (a : α) : UpperSet α where
   carrier := s \ LowerSet.Iic a
   upper' := s.upper.sdiff_of_isLowerSet (LowerSet.Iic a).lower
 
-@[simp, norm_cast]
+@[to_dual (attr := simp, norm_cast)]
 lemma coe_sdiff (s : UpperSet α) (t : Set α) : s.sdiff t = (s : Set α) \ lowerClosure t := rfl
 
-@[simp, norm_cast]
+@[to_dual (attr := simp, norm_cast)]
 lemma coe_erase (s : UpperSet α) (a : α) : s.erase a = (s : Set α) \ LowerSet.Iic a := rfl
 
-@[simp] lemma sdiff_singleton (s : UpperSet α) (a : α) : s.sdiff {a} = s.erase a := by
+@[to_dual (attr := simp)]
+lemma sdiff_singleton (s : UpperSet α) (a : α) : s.sdiff {a} = s.erase a := by
   simp [sdiff, erase]
 
-lemma le_sdiff_left : s ≤ s.sdiff t := diff_subset
-lemma le_erase : s ≤ s.erase a := diff_subset
+@[to_dual sdiff_le_left] lemma le_sdiff_left : s ≤ s.sdiff t := diff_subset
+@[to_dual erase_le] lemma le_erase : s ≤ s.erase a := diff_subset
 
-@[simp] protected lemma sdiff_eq_left : s.sdiff t = s ↔ Disjoint ↑s t := by
+@[to_dual (attr := simp)]
+protected lemma sdiff_eq_left : s.sdiff t = s ↔ Disjoint ↑s t := by
   simp [← SetLike.coe_set_eq]
 
-@[simp] lemma erase_eq : s.erase a = s ↔ a ∉ s := by rw [← sdiff_singleton]; simp [-sdiff_singleton]
+@[to_dual (attr := simp)]
+lemma erase_eq : s.erase a = s ↔ a ∉ s := by rw [← sdiff_singleton]; simp [-sdiff_singleton]
 
-@[simp] lemma lt_sdiff_left : s < s.sdiff t ↔ ¬ Disjoint ↑s t :=
+@[to_dual (attr := simp) sdiff_lt_left]
+lemma lt_sdiff_left : s < s.sdiff t ↔ ¬ Disjoint ↑s t :=
   le_sdiff_left.lt_iff_ne'.trans UpperSet.sdiff_eq_left.not
 
-@[simp] lemma lt_erase : s < s.erase a ↔ a ∈ s := le_erase.lt_iff_ne'.trans erase_eq.not_left
+@[to_dual (attr := simp) erase_lt]
+lemma lt_erase : s < s.erase a ↔ a ∈ s := le_erase.lt_iff_ne'.trans erase_eq.not_left
 
-@[simp] protected lemma sdiff_idem (s : UpperSet α) (t : Set α) : (s.sdiff t).sdiff t = s.sdiff t :=
+@[to_dual (attr := simp)]
+protected lemma sdiff_idem (s : UpperSet α) (t : Set α) : (s.sdiff t).sdiff t = s.sdiff t :=
   SetLike.coe_injective sdiff_idem
 
-@[simp] lemma erase_idem (s : UpperSet α) (a : α) : (s.erase a).erase a = s.erase a :=
+@[to_dual (attr := simp)]
+lemma erase_idem (s : UpperSet α) (a : α) : (s.erase a).erase a = s.erase a :=
   SetLike.coe_injective sdiff_idem
 
+@[to_dual]
 lemma sdiff_inf_upperClosure (hts : t ⊆ s) (hst : ∀ b ∈ s, ∀ c ∈ t, b ≤ c → b ∈ t) :
     s.sdiff t ⊓ upperClosure t = s := by
   refine ge_antisymm (le_inf le_sdiff_left <| le_upperClosure.2 hts) fun a ha ↦ ?_
@@ -415,12 +281,15 @@ lemma sdiff_inf_upperClosure (hts : t ⊆ s) (hst : ∀ b ∈ s, ∀ c ∈ t, b 
     rintro ⟨b, hb, hab⟩
     exact hat <| hst _ ha _ hb hab
 
+@[to_dual]
 lemma upperClosure_inf_sdiff (hts : t ⊆ s) (hst : ∀ b ∈ s, ∀ c ∈ t, b ≤ c → b ∈ t) :
     upperClosure t ⊓ s.sdiff t = s := by rw [inf_comm, sdiff_inf_upperClosure hts hst]
 
+@[to_dual]
 lemma erase_inf_Ici (ha : a ∈ s) (has : ∀ b ∈ s, b ≤ a → b = a) : s.erase a ⊓ Ici a = s := by
   rw [← upperClosure_singleton, ← sdiff_singleton, sdiff_inf_upperClosure] <;> simpa
 
+@[to_dual]
 lemma Ici_inf_erase (ha : a ∈ s) (has : ∀ b ∈ s, b ≤ a → b = a) : Ici a ⊓ s.erase a = s := by
   rw [inf_comm, erase_inf_Ici ha has]
 

--- a/Mathlib/Order/UpperLower/CompleteLattice.lean
+++ b/Mathlib/Order/UpperLower/CompleteLattice.lean
@@ -326,7 +326,7 @@ variable [Preorder α] [Preorder β] [Preorder γ]
 variable {f : α ≃o β} {s t : UpperSet α} {a : α} {b : β}
 
 /-- An order isomorphism of Preorders induces an order isomorphism of their upper sets. -/
-@[to_dual
+@[to_dual (attr := simps)
 /-- An order isomorphism of Preorders induces an order isomorphism of their lower sets. -/]
 def map (f : α ≃o β) : UpperSet α ≃o UpperSet β where
   toFun s := ⟨f '' s, s.upper.image f⟩

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -231,18 +231,19 @@ def nameDict : Std.HashMap String (List String) := .ofList [
 def abbreviationDict : Std.HashMap String String := .ofList [
   ("wellFoundedLT", "WellFoundedGT"),
   ("wellFoundedGT", "WellFoundedLT"),
-  ("succColimit", "SuccLimit"),
-  ("predColimit", "PredLimit"),
-  ("codirectedOrder", "DirectedOrder"),
-  ("directedOrder", "CodirectedOrder"),
   ("nhdsLT", "NhdsGT"),
   ("nhdsGT", "NhdsLT"),
   ("nhdsLE", "NhdsGE"),
   ("nhdsGE", "NhdsLE"),
-  ("neTop", "NeBot"),
-  ("decidableSucc", "DecidablePred"),
+  ("succColimit", "SuccLimit"),
+  ("predColimit", "PredLimit"),
+  ("codirectedOrder", "DirectedOrder"),
+  ("directedOrder", "CodirectedOrder"),
   ("galoisInsertion", "GaloisCoinsertion"),
   ("galoisCoinsertion", "GaloisInsertion"),
+
+  ("neTop", "NeBot"),
+  ("decidableSucc", "DecidablePred"),
 ]
 
 /-- The bundle of environment extensions for `to_dual` -/

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -239,7 +239,8 @@ def abbreviationDict : Std.HashMap String String := .ofList [
   ("nhdsGT", "NhdsLT"),
   ("nhdsLE", "NhdsGE"),
   ("nhdsGE", "NhdsLE"),
-  ("neTop", "NeBot")
+  ("neTop", "NeBot"),
+  ("decidableSucc", "DecidablePred"),
 ]
 
 /-- The bundle of environment extensions for `to_dual` -/


### PR DESCRIPTION
This PR tags `upperClosure` with `to_dual`.

- `to_dual` was not happy with the proof of `upperClosure_image`. I replaced it with a proof with less defeq abuse, by tagging `UpperSet.map` with `simps`.
- `to_dual` is not happy with the galois connections, because they are between the order and a set-containment order, and only one of the two is translated by `to_dual`. Hence, the proofs using the galois connection cannot be translated automatically, and we need to use `to_dual existing`. I changed two proofs to avoid this dependency.
- I changed the `to_dual_insert_cast` proof of `GaloisInsertion` to clarify what is going on there.
- `DecidablePred` was being translated to `DecidableSucc`, so I added a fix in the abbreviation dictionary.



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
