### PR TITLE
[Merged by Bors] - chore(Order/MinMax): use `to_dual`

### DIFF
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -171,6 +171,10 @@ lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
     (fun h₁ h₂ ↦
       le_min (le_min h₁ (le_trans h₂ (min_le_left ..))) (le_trans h₂ (min_le_right ..)))
 
+@[to_dual]
+lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
+  rw [← min_assoc, min_comm a, min_assoc]
+
 @[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by rw [min_def, ite_id]
 
 @[to_dual]

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -171,10 +171,6 @@ lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) :=
     (fun h₁ h₂ ↦
       le_min (le_min h₁ (le_trans h₂ (min_le_left ..))) (le_trans h₂ (min_le_right ..)))
 
-@[to_dual]
-lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
-  rw [← min_assoc, min_comm a, min_assoc]
-
 @[to_dual (attr := simp)] lemma min_self (a : α) : min a a = a := by rw [min_def, ite_id]
 
 @[to_dual]

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -130,10 +130,6 @@ theorem max_lt_max (h₁ : a < c) (h₂ : b < d) : max a b < max c d :=
   max_lt (lt_max_of_lt_left h₁) (lt_max_of_lt_right h₂)
 
 @[to_dual]
-lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
-  rw [← min_assoc, min_comm a, min_assoc]
-
-@[to_dual]
 lemma min_right_comm (a b c : α) : min (min a b) c = min (min a c) b := by
   rw [min_assoc, min_comm b, ← min_assoc]
 

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -30,172 +30,125 @@ section
 variable [LinearOrder α] [LinearOrder β] {f : α → β} {s : Set α} {a b c d : α}
 
 -- translate from lattices to linear orders (sup → max, inf → min)
+@[to_dual max_le_iff]
 theorem le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b :=
   le_inf_iff
 
+@[to_dual min_le_iff]
 theorem le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
   le_sup_iff
 
-theorem min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
-  inf_le_iff
-
-theorem max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
-  sup_le_iff
-
+@[to_dual]
 instance [LinearOrder α] : Std.LawfulOrderSup α where
   max_le_iff _ _ _ := max_le_iff
 
-instance [LinearOrder α] : Std.LawfulOrderInf α where
-  le_min_iff _ _ _ := le_min_iff
-
+@[to_dual max_lt_iff]
 theorem lt_min_iff : a < min b c ↔ a < b ∧ a < c :=
   lt_inf_iff
 
+@[to_dual min_lt_iff]
 theorem lt_max_iff : a < max b c ↔ a < b ∨ a < c :=
   lt_sup_iff
 
-theorem min_lt_iff : min a b < c ↔ a < c ∨ b < c :=
-  inf_lt_iff
-
-theorem max_lt_iff : max a b < c ↔ a < c ∧ b < c :=
-  sup_lt_iff
-
+@[to_dual]
 theorem max_le_max : a ≤ c → b ≤ d → max a b ≤ max c d :=
   sup_le_sup
 
+@[to_dual]
 theorem max_le_max_left (c) (h : a ≤ b) : max c a ≤ max c b := sup_le_sup_left h c
 
+@[to_dual]
 theorem max_le_max_right (c) (h : a ≤ b) : max a c ≤ max b c := sup_le_sup_right h c
 
-theorem min_le_min : a ≤ c → b ≤ d → min a b ≤ min c d :=
-  inf_le_inf
-
-theorem min_le_min_left (c) (h : a ≤ b) : min c a ≤ min c b := inf_le_inf_left c h
-
-theorem min_le_min_right (c) (h : a ≤ b) : min a c ≤ min b c := inf_le_inf_right c h
-
+@[to_dual min_le_of_left_le]
 theorem le_max_of_le_left : a ≤ b → a ≤ max b c :=
   le_sup_of_le_left
 
+@[to_dual min_le_of_right_le]
 theorem le_max_of_le_right : a ≤ c → a ≤ max b c :=
   le_sup_of_le_right
 
+@[to_dual min_lt_of_left_lt]
 theorem lt_max_of_lt_left (h : a < b) : a < max b c :=
   h.trans_le (le_max_left b c)
 
+@[to_dual min_lt_of_right_lt]
 theorem lt_max_of_lt_right (h : a < c) : a < max b c :=
   h.trans_le (le_max_right b c)
 
-theorem min_le_of_left_le : a ≤ c → min a b ≤ c :=
-  inf_le_of_left_le
-
-theorem min_le_of_right_le : b ≤ c → min a b ≤ c :=
-  inf_le_of_right_le
-
-theorem min_lt_of_left_lt (h : a < c) : min a b < c :=
-  (min_le_left a b).trans_lt h
-
-theorem min_lt_of_right_lt (h : b < c) : min a b < c :=
-  (min_le_right a b).trans_lt h
-
+@[to_dual]
 lemma max_min_distrib_left (a b c : α) : max a (min b c) = min (max a b) (max a c) :=
   sup_inf_left _ _ _
 
+@[to_dual]
 lemma max_min_distrib_right (a b c : α) : max (min a b) c = min (max a c) (max b c) :=
   sup_inf_right _ _ _
-
-lemma min_max_distrib_left (a b c : α) : min a (max b c) = max (min a b) (min a c) :=
-  inf_sup_left _ _ _
-
-lemma min_max_distrib_right (a b c : α) : min (max a b) c = max (min a c) (min b c) :=
-  inf_sup_right _ _ _
 
 theorem min_le_max : min a b ≤ max a b :=
   le_trans (min_le_left a b) (le_max_left a b)
 
+@[to_dual]
 theorem min_eq_left_iff : min a b = a ↔ a ≤ b :=
   inf_eq_left
 
+@[to_dual]
 theorem min_eq_right_iff : min a b = b ↔ b ≤ a :=
   inf_eq_right
-
-theorem max_eq_left_iff : max a b = a ↔ b ≤ a :=
-  sup_eq_left
-
-theorem max_eq_right_iff : max a b = b ↔ a ≤ b :=
-  sup_eq_right
 
 /-- For elements `a` and `b` of a linear order, either `min a b = a` and `a ≤ b`,
 or `min a b = b` and `b < a`.
 Use cases on this lemma to automate linarith in inequalities -/
+@[to_dual
+/-- For elements `a` and `b` of a linear order, either `max a b = a` and `b ≤ a`,
+or `max a b = b` and `a < b`.
+Use cases on this lemma to automate linarith in inequalities -/]
 theorem min_cases (a b : α) : min a b = a ∧ a ≤ b ∨ min a b = b ∧ b < a := by
   grind
 
-/-- For elements `a` and `b` of a linear order, either `max a b = a` and `b ≤ a`,
-or `max a b = b` and `a < b`.
-Use cases on this lemma to automate linarith in inequalities -/
-theorem max_cases (a b : α) : max a b = a ∧ b ≤ a ∨ max a b = b ∧ a < b :=
-  @min_cases αᵒᵈ _ a b
-
+@[to_dual]
 theorem min_eq_iff : min a b = c ↔ a = c ∧ a ≤ b ∨ b = c ∧ b ≤ a := by
   grind
 
-theorem max_eq_iff : max a b = c ↔ a = c ∧ b ≤ a ∨ b = c ∧ a ≤ b :=
-  @min_eq_iff αᵒᵈ _ a b c
-
+@[to_dual]
 theorem min_lt_min_left_iff : min a c < min b c ↔ a < b ∧ a < c := by
   grind
 
+@[to_dual]
 theorem min_lt_min_right_iff : min a b < min a c ↔ b < c ∧ b < a := by
   grind
 
-theorem max_lt_max_left_iff : max a c < max b c ↔ a < b ∧ c < b :=
-  @min_lt_min_left_iff αᵒᵈ _ _ _ _
-
-theorem max_lt_max_right_iff : max a b < max a c ↔ b < c ∧ a < c :=
-  @min_lt_min_right_iff αᵒᵈ _ _ _ _
-
 /-- An instance asserting that `max a a = a` -/
+@[to_dual /-- An instance asserting that `min a a = a` -/]
 instance max_idem : Std.IdempotentOp (α := α) max where
   idempotent := by simp
 
--- short-circuit type class inference
-/-- An instance asserting that `min a a = a` -/
-instance min_idem : Std.IdempotentOp (α := α) min where
-  idempotent := by simp
-
--- short-circuit type class inference
 theorem min_lt_max : min a b < max a b ↔ a ≠ b :=
   inf_lt_sup
 
+@[to_dual]
 theorem max_lt_max (h₁ : a < c) (h₂ : b < d) : max a b < max c d :=
   max_lt (lt_max_of_lt_left h₁) (lt_max_of_lt_right h₂)
 
-theorem min_lt_min (h₁ : a < c) (h₂ : b < d) : min a b < min c d :=
-  @max_lt_max αᵒᵈ _ _ _ _ _ h₁ h₂
+@[to_dual]
+lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
+  rw [← min_assoc, min_comm a, min_assoc]
 
-theorem min_right_comm (a b c : α) : min (min a b) c = min (min a c) b := by
-  grind
+@[to_dual]
+lemma min_right_comm (a b c : α) : min (min a b) c = min (min a c) b := by
+  rw [min_assoc, min_comm b, ← min_assoc]
 
-theorem Max.left_comm (a b c : α) : max a (max b c) = max b (max a c) := by
-  grind
+@[deprecated (since := "2026-03-22")] alias Max.left_comm := max_left_comm
+@[deprecated (since := "2026-03-22")] alias Max.right_comm := max_right_comm
 
-theorem Max.right_comm (a b c : α) : max (max a b) c = max (max a c) b := by
-  grind
-
+@[to_dual]
 theorem MonotoneOn.map_max (hf : MonotoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (max a b) =
     max (f a) (f b) := by
   rcases le_total a b with h | h <;>
     simp only [max_eq_right, max_eq_left, hf ha hb, hf hb ha, h]
 
-theorem MonotoneOn.map_min (hf : MonotoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (min a b) =
-    min (f a) (f b) := hf.dual.map_max ha hb
-
+@[to_dual]
 theorem AntitoneOn.map_max (hf : AntitoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (max a b) =
     min (f a) (f b) := hf.dual_right.map_max ha hb
-
-theorem AntitoneOn.map_min (hf : AntitoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (min a b) =
-    max (f a) (f b) := hf.dual.map_max ha hb
 
 @[to_dual]
 theorem Monotone.map_max (hf : Monotone f) : f (max a b) = max (f a) (f b) := by
@@ -205,23 +158,21 @@ theorem Monotone.map_max (hf : Monotone f) : f (max a b) = max (f a) (f b) := by
 theorem Antitone.map_max (hf : Antitone f) : f (max a b) = min (f a) (f b) := by
   rcases le_total a b with h | h <;> simp [h, hf h]
 
+@[to_dual]
 theorem min_choice (a b : α) : min a b = a ∨ min a b = b := by cases le_total a b <;> simp [*]
 
-theorem max_choice (a b : α) : max a b = a ∨ max a b = b :=
-  @min_choice αᵒᵈ _ a b
-
+@[to_dual le_of_le_min_left]
 theorem le_of_max_le_left {a b c : α} (h : max a b ≤ c) : a ≤ c :=
   le_trans (le_max_left _ _) h
 
+@[to_dual le_of_le_min_right]
 theorem le_of_max_le_right {a b c : α} (h : max a b ≤ c) : b ≤ c :=
   le_trans (le_max_right _ _) h
 
-instance instCommutativeMax : Std.Commutative (α := α) max where comm := max_comm
-instance instAssociativeMax : Std.Associative (α := α) max where assoc := max_assoc
-instance instCommutativeMin : Std.Commutative (α := α) min where comm := min_comm
-instance instAssociativeMin : Std.Associative (α := α) min where assoc := min_assoc
+@[to_dual] instance instCommutativeMax : Std.Commutative (α := α) max where comm := max_comm
+@[to_dual] instance instAssociativeMax : Std.Associative (α := α) max where assoc := max_assoc
 
+@[to_dual]
 theorem max_left_commutative : LeftCommutative (max : α → α → α) := ⟨max_left_comm⟩
-theorem min_left_commutative : LeftCommutative (min : α → α → α) := ⟨min_left_comm⟩
 
 end

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -161,7 +161,7 @@ protected theorem map_add : ∀ x y, v (x + y) ≤ max (v x) (v y) :=
 @[simp]
 theorem map_add' : ∀ x y, v (x + y) ≤ v x ∨ v (x + y) ≤ v y := by
   intro x y
-  rw [← le_max_iff, ← ge_iff_le]
+  rw [← le_max_iff]
   apply v.map_add
 
 theorem map_add_le {x y g} (hx : v x ≤ g) (hy : v y ≤ g) : v (x + y) ≤ g :=
@@ -1171,7 +1171,7 @@ theorem map_add : ∀ (x y : R), min (v x) (v y) ≤ v (x + y) :=
 @[simp]
 theorem map_add' : ∀ (x y : R), v x ≤ v (x + y) ∨ v y ≤ v (x + y) := by
   intro x y
-  rw [← @min_le_iff _ _ (v x) (v y) (v (x + y)), ← ge_iff_le]
+  rw [← min_le_iff]
   apply map_add
 
 theorem map_le_add {x y : R} {g : Γ₀} (hx : g ≤ v x) (hy : g ≤ v y) : g ≤ v (x + y) :=

--- a/Mathlib/Tactic/ToDual.lean
+++ b/Mathlib/Tactic/ToDual.lean
@@ -34,6 +34,8 @@ attribute [to_dual lt_of_lt_of_eq''] lt_of_lt_of_eq
 
 attribute [to_dual] Max
 
+attribute [to_dual existing] Std.LawfulOrderSup Std.LawfulOrderSup.mk Std.LawfulOrderSup.max_le_iff
+
 -- We need to tag the lemmas used by `grind` in order to translate `grind` proofs.
 namespace Lean.Grind.Order
 


### PR DESCRIPTION
This PR uses `to_dual` on some declarations about `max`/`min`.

This file, `Order.MinMax`, is mostly silly now because the `max`/`min` theorems are copies of the same `sup`/`inf` declarations, except specialized to linear orders.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
