### PR TITLE
chore(Order/Filter/AtTopBot/Map): use `to_dual`

### DIFF
--- a/Mathlib/Order/Filter/AtTopBot/Map.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Map.lean
@@ -28,36 +28,21 @@ open Filter
 
 variable [Preorder α] [Preorder β]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem comap_atTop (e : α ≃o β) : comap e atTop = atTop := by
-  simp [atTop, ← e.surjective.iInf_comp]
+  unfold atTop; rw [← e.surjective.iInf_comp]; simp
 
-@[simp]
-theorem comap_atBot (e : α ≃o β) : comap e atBot = atBot :=
-  e.dual.comap_atTop
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem map_atTop (e : α ≃o β) : map (e : α → β) atTop = atTop := by
   rw [← e.comap_atTop, map_comap_of_surjective e.surjective]
 
-@[simp]
-theorem map_atBot (e : α ≃o β) : map (e : α → β) atBot = atBot :=
-  e.dual.map_atTop
-
+@[to_dual]
 theorem tendsto_atTop (e : α ≃o β) : Tendsto e atTop atTop :=
   e.map_atTop.le
 
-theorem tendsto_atBot (e : α ≃o β) : Tendsto e atBot atBot :=
-  e.map_atBot.le
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem tendsto_atTop_iff {l : Filter γ} {f : γ → α} (e : α ≃o β) :
     Tendsto (fun x => e (f x)) l atTop ↔ Tendsto f l atTop := by
   rw [← e.comap_atTop, tendsto_comap_iff, Function.comp_def]
-
-@[simp]
-theorem tendsto_atBot_iff {l : Filter γ} {f : γ → α} (e : α ≃o β) :
-    Tendsto (fun x => e (f x)) l atBot ↔ Tendsto f l atBot :=
-  e.dual.tendsto_atTop_iff
 
 end OrderIso


### PR DESCRIPTION
This PR uses `to_dual` on 4 declarations.

`comap_atTop` is problematic, because the heuristic fails, and mistakenly thinks that it should translate `Surjective.iInf_comp`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
