### PR TITLE
[Merged by Bors] - chore(Data/Nat/Size): simplify proofs, reduce dependencies

### DIFF
--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -373,7 +373,7 @@ lemma shiftLeft_natCast_right (m : ℤ) (n : ℕ) :
   unfold_projs; cases m <;> simp only [Nat.shiftLeft'_false, natCast_shiftLeft, ofNat_eq_natCast,
     Nat.pow_eq, Int.natCast_pow, Nat.cast_ofNat, mul_def]
   · grind [Int.shiftLeft_eq']
-  · simp only [negSucc_eq, ← natCast_add_one, Nat.shiftLeft'_tt_eq_mul_pow]
+  · simp only [negSucc_eq, ← natCast_add_one, Nat.shiftLeft'_true_eq_mul_pow]
     grind
 
 /-- Connection of `HShiftRight Int Int Int` and `HShiftRight Int Nat Int`. -/
@@ -408,7 +408,7 @@ theorem shiftLeft_sub (m : ℤ) (n : ℕ) (k : ℤ) : m <<< (n - k) = (m <<< (n 
 
 theorem shiftLeft_eq_mul_pow : ∀ (m : ℤ) (n : ℕ), m <<< (n : ℤ) = m * (2 ^ n : ℕ)
   | (m : ℕ), _ => congr_arg ((↑) : ℕ → ℤ) (by simp [Nat.shiftLeft_eq])
-  | -[_+1], _ => @congr_arg ℕ ℤ _ _ (fun i => -i) (Nat.shiftLeft'_tt_eq_mul_pow _ _)
+  | -[_+1], _ => @congr_arg ℕ ℤ _ _ (fun i => -i) (Nat.shiftLeft'_true_eq_mul_pow _ _)
 
 theorem one_shiftLeft (n : ℕ) : 1 <<< (n : ℤ) = (2 ^ n : ℕ) :=
   congr_arg ((↑) : ℕ → ℤ) (by simp [Nat.shiftLeft_eq])

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -17,18 +17,22 @@ namespace Nat
 
 theorem shiftLeft_eq_mul_pow (m) : ∀ n, m <<< n = m * 2 ^ n := shiftLeft_eq _
 
-theorem shiftLeft'_tt_eq_mul_pow (m) : ∀ n, shiftLeft' true m n + 1 = (m + 1) * 2 ^ n
+theorem shiftLeft'_true_eq_mul_pow (m) : ∀ n, shiftLeft' true m n + 1 = (m + 1) * 2 ^ n
   | 0 => by simp [shiftLeft', Nat.pow_zero]
   | k + 1 => by
     rw [shiftLeft', bit_val, Bool.toNat_true, Nat.add_assoc, ← Nat.mul_add_one,
-      shiftLeft'_tt_eq_mul_pow m k, Nat.mul_left_comm, Nat.mul_comm 2, Nat.pow_succ]
+      shiftLeft'_true_eq_mul_pow m k, Nat.mul_left_comm, Nat.mul_comm 2, Nat.pow_succ]
+
+@[deprecated (since := "2026-03-22")] alias shiftLeft'_tt_eq_mul_pow := shiftLeft'_true_eq_mul_pow
 
 theorem shiftLeft'_ne_zero_left (b) {m} (h : m ≠ 0) (n) : shiftLeft' b m n ≠ 0 := by
   induction n <;> simp [shiftLeft', *]
 
-theorem shiftLeft'_tt_ne_zero (m) : ∀ {n}, (n ≠ 0) → shiftLeft' true m n ≠ 0
+theorem shiftLeft'_true_ne_zero (m) : ∀ {n}, (n ≠ 0) → shiftLeft' true m n ≠ 0
   | 0, h => absurd rfl h
-  | succ _, _ => by dsimp [shiftLeft', bit]; lia
+  | succ _, _ => by simp [shiftLeft', bit]
+
+@[deprecated (since := "2026-03-22")] alias shiftLeft'_tt_ne_zero := shiftLeft'_true_ne_zero
 
 /-! ### `size` -/
 
@@ -56,7 +60,7 @@ theorem size_shiftLeft' {b m n} (h : shiftLeft' b m n ≠ 0) :
     rw [s0] at h ⊢
     cases b; · exact absurd rfl h
     have : shiftLeft' true m n + 1 = 1 := congr_arg (· + 1) s0
-    rw [shiftLeft'_tt_eq_mul_pow] at this
+    rw [shiftLeft'_true_eq_mul_pow] at this
     obtain rfl := succ.inj (eq_one_of_dvd_one ⟨_, this.symm⟩)
     simp only [Nat.zero_add, Nat.one_mul, Nat.pow_eq_one, succ_ne_self, false_or] at this
     rw [this, Nat.add_zero]

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -5,10 +5,7 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 module
 
-public import Mathlib.Algebra.Group.Nat.Defs
-public import Mathlib.Algebra.Group.Basic
 public import Mathlib.Data.Nat.Bits
-public import Mathlib.Data.Nat.Basic
 
 /-! Lemmas about `size`. -/
 
@@ -18,17 +15,13 @@ namespace Nat
 
 /-! ### `shiftLeft` and `shiftRight` -/
 
-section
-
 theorem shiftLeft_eq_mul_pow (m) : ∀ n, m <<< n = m * 2 ^ n := shiftLeft_eq _
 
 theorem shiftLeft'_tt_eq_mul_pow (m) : ∀ n, shiftLeft' true m n + 1 = (m + 1) * 2 ^ n
-  | 0 => by simp [shiftLeft', pow_zero]
+  | 0 => by simp [shiftLeft', Nat.pow_zero]
   | k + 1 => by
-    rw [shiftLeft', bit_val, Bool.toNat_true, add_assoc, ← Nat.mul_add_one,
-      shiftLeft'_tt_eq_mul_pow m k, mul_left_comm, mul_comm 2, pow_succ]
-
-end
+    rw [shiftLeft', bit_val, Bool.toNat_true, Nat.add_assoc, ← Nat.mul_add_one,
+      shiftLeft'_tt_eq_mul_pow m k, Nat.mul_left_comm, Nat.mul_comm 2, Nat.pow_succ]
 
 theorem shiftLeft'_ne_zero_left (b) {m} (h : m ≠ 0) (n) : shiftLeft' b m n ≠ 0 := by
   induction n <;> simp [shiftLeft', *]
@@ -41,23 +34,14 @@ theorem shiftLeft'_tt_ne_zero (m) : ∀ {n}, (n ≠ 0) → shiftLeft' true m n �
 
 
 @[simp]
-theorem size_zero : size 0 = 0 := by simp [size]
+theorem size_zero : size 0 = 0 := rfl
 
 @[simp]
-theorem size_bit {b n} (h : bit b n ≠ 0) : size (bit b n) = succ (size n) := by
-  unfold size
-  conv =>
-    lhs
-    rw [binaryRec]
-    simp [h]
-
-section
+theorem size_bit {b n} (h : bit b n ≠ 0) : size (bit b n) = succ (size n) :=
+  Nat.binaryRec_eq _ _ (.inr <| Nat.bit_ne_zero_iff.mp h)
 
 @[simp]
-theorem size_one : size 1 = 1 :=
-  show size (bit true 0) = 1 by rw [size_bit, size_zero]; exact Nat.one_ne_zero
-
-end
+theorem size_one : size 1 = 1 := rfl
 
 @[simp]
 theorem size_shiftLeft' {b m n} (h : shiftLeft' b m n ≠ 0) :
@@ -74,58 +58,44 @@ theorem size_shiftLeft' {b m n} (h : shiftLeft' b m n ≠ 0) :
     have : shiftLeft' true m n + 1 = 1 := congr_arg (· + 1) s0
     rw [shiftLeft'_tt_eq_mul_pow] at this
     obtain rfl := succ.inj (eq_one_of_dvd_one ⟨_, this.symm⟩)
-    simp only [zero_add, one_mul] at this
-    obtain rfl : n = 0 := not_ne_iff.1 fun hn ↦ ne_of_gt (Nat.one_lt_pow hn (by decide)) this
-    rw [add_zero]
+    simp only [Nat.zero_add, Nat.one_mul, Nat.pow_eq_one, succ_ne_self, false_or] at this
+    rw [this, Nat.add_zero]
 
 @[simp]
 theorem size_shiftLeft {m} (h : m ≠ 0) (n) : size (m <<< n) = size m + n := by
   simp only [size_shiftLeft' (shiftLeft'_ne_zero_left _ h _), ← shiftLeft'_false]
 
 theorem lt_size_self (n : ℕ) : n < 2 ^ size n := by
-  rw [← one_shiftLeft]
-  have : ∀ {n}, n = 0 → n < 1 <<< (size n) := by simp
-  refine binaryRec ?_ ?_ n
-  · apply this rfl
-  intro b n IH
-  by_cases h : bit b n = 0
-  · apply this h
-  rw [size_bit h, shiftLeft_succ, shiftLeft_eq, one_mul]
-  cases b <;> dsimp [bit] <;> omega
+  induction n using binaryRec' with
+  | zero => simp
+  | bit b n h IH =>
+    rw [← Nat.bit_ne_zero_iff] at h
+    rwa [size_bit h, bit_lt_two_pow_succ_iff]
 
 theorem size_le {m n : ℕ} : size m ≤ n ↔ m < 2 ^ n :=
-  ⟨fun h => lt_of_lt_of_le (lt_size_self _) (Nat.pow_le_pow_right (by decide) h), by
-    rw [← one_shiftLeft]
-    induction m using binaryRec generalizing n with
+  ⟨fun h => Nat.lt_of_lt_of_le (lt_size_self _) (Nat.pow_le_pow_right (by decide) h), fun h ↦ by
+    induction m using binaryRec' generalizing n with
     | zero => simp
-    | bit b m IH =>
-      intro h
-      by_cases e : bit b m = 0
-      · simp [e]
+    | bit b m e IH =>
+      rw [← Nat.bit_ne_zero_iff] at e
       rw [size_bit e]
       cases n with
-      | zero => exact e.elim (Nat.eq_zero_of_le_zero (le_of_lt_succ h))
-      | succ n =>
-        apply succ_le_succ (IH _)
-        apply Nat.lt_of_mul_lt_mul_left (a := 2)
-        simp only [shiftLeft_succ] at *
-        refine lt_of_le_of_lt ?_ h
-        cases b <;> dsimp [bit] <;> lia⟩
+      | zero => exact (e (Nat.lt_one_iff.mp h)).elim
+      | succ n => exact succ_le_succ (IH (bit_lt_two_pow_succ_iff.mp h))⟩
 
 theorem lt_size {m n : ℕ} : m < size n ↔ 2 ^ m ≤ n := by
-  rw [← not_lt, Decidable.iff_not_comm, not_lt, size_le]
+  rw [← Nat.not_lt, Decidable.iff_not_comm, Nat.not_lt, size_le]
 
 theorem size_pos {n : ℕ} : 0 < size n ↔ 0 < n := by rw [lt_size]; rfl
 
 theorem size_eq_zero {n : ℕ} : size n = 0 ↔ n = 0 := by
-  simpa [Nat.pos_iff_ne_zero, not_iff_not] using size_pos
+  simpa [Nat.pos_iff_ne_zero, Decidable.not_iff_not] using size_pos
 
-theorem size_pow {n : ℕ} : size (2 ^ n) = n + 1 :=
-  le_antisymm (size_le.2 <| Nat.pow_lt_pow_right (by decide) (lt_succ_self _))
-    (lt_size.2 <| le_rfl)
+theorem size_pow {n : ℕ} : size (2 ^ n) = n + 1 := by
+  simpa [shiftLeft_eq, Nat.add_comm] using size_shiftLeft (m := 1) (by decide) n
 
 theorem size_le_size {m n : ℕ} (h : m ≤ n) : size m ≤ size n :=
-  size_le.2 <| lt_of_le_of_lt h (lt_size_self _)
+  size_le.2 <| Nat.lt_of_le_of_lt h (lt_size_self _)
 
 theorem size_eq_bits_len (n : ℕ) : n.bits.length = n.size := by
   induction n using Nat.binaryRec' with


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
