### PR TITLE
[Merged by Bors] - feat: cof α < ℵ₀ ↔ cof α ≤ 1

### DIFF
--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -134,6 +134,18 @@ lemma Finite.exists_lt_map_eq_of_forall_mem [Infinite α] (hf : ∀ a, f a ∈ t
   obtain ⟨a, -, b, -, h⟩ := infinite_univ.exists_lt_map_eq_of_mapsTo hf ht
   exact ⟨a, b, h⟩
 
+/-- If the cofinality of an order is finite, it's at most one. -/
+theorem Finite.exists_subsingleton_isCofinal {s : Set α} (hs : s.Finite) (hs' : IsCofinal s) :
+    ∃ t : Set α, t.Subsingleton ∧ IsCofinal t := by
+  obtain rfl | hn := s.eq_empty_or_nonempty
+  · use ∅; simpa
+  · obtain ⟨a, ha⟩ := hs.exists_maximal hn
+    use {a}
+    suffices IsTop a by simpa [IsCofinal]
+    intro b
+    obtain ⟨c, hc, hbc⟩ := hs' b
+    exact hbc.trans (ha.le hc)
+
 end LinearOrder
 end Set
 

--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -134,7 +134,7 @@ lemma Finite.exists_lt_map_eq_of_forall_mem [Infinite α] (hf : ∀ a, f a ∈ t
   obtain ⟨a, -, b, -, h⟩ := infinite_univ.exists_lt_map_eq_of_mapsTo hf ht
   exact ⟨a, b, h⟩
 
-/-- If the cofinality of an order is finite, it's at most one. -/
+/-- If the cofinality of a linear order is finite, it's at most one. -/
 theorem Finite.exists_subsingleton_isCofinal {s : Set α} (hs : s.Finite) (hs' : IsCofinal s) :
     ∃ t : Set α, t.Subsingleton ∧ IsCofinal t := by
   obtain rfl | hn := s.eq_empty_or_nonempty

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -325,6 +325,9 @@ theorem one_le_iff_ne_zero {c : Cardinal} : 1 ≤ c ↔ c ≠ 0 := by
 theorem lt_one_iff_zero {c : Cardinal} : c < 1 ↔ c = 0 := by
   simpa using lt_succ_bot_iff (a := c)
 
+theorem le_one_iff {c : Cardinal} : c ≤ 1 ↔ c = 0 ∨ c = 1 := by
+  simpa using @le_succ_bot_iff _ _ _ c _
+
 /-! ### Properties about `aleph0` -/
 
 @[simp] lemma natCast_lt_aleph0 {n : ℕ} : (n : Cardinal.{u}) < ℵ₀ := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -326,7 +326,7 @@ theorem lt_one_iff_zero {c : Cardinal} : c < 1 ↔ c = 0 := by
   simpa using lt_succ_bot_iff (a := c)
 
 theorem le_one_iff {c : Cardinal} : c ≤ 1 ↔ c = 0 ∨ c = 1 := by
-  simpa using @le_succ_bot_iff _ _ _ c _
+  simpa using le_succ_bot_iff (a := c)
 
 /-! ### Properties about `aleph0` -/
 

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -255,6 +255,59 @@ theorem cof_one : cof 1 = 1 := by
 theorem cof_succ (o) : cof (succ o) = 1 :=
   cof_add_one o
 
+theorem _root_.Order.cof_le_one_of_cof_lt_aleph0 [LinearOrder α] (h : Order.cof α < ℵ₀) :
+    Order.cof α ≤ 1 := by
+  obtain ⟨s, hs, hs'⟩ := Order.cof_eq α
+  have hf : s.Finite := by
+    rw [Set.Finite, ← mk_lt_aleph0_iff]
+    exact hs'.trans_lt h
+  obtain ⟨t, ht, ht'⟩ := hf.exists_subsingleton_isCofinal hs
+  apply (cof_le ht').trans
+  simpa
+
+theorem cof_le_one_of_cof_lt_aleph0 {o : Ordinal} : cof o < ℵ₀ → cof o ≤ 1 := by
+  simpa using Order.cof_le_one_of_cof_lt_aleph0 (α := o.ToType)
+
+theorem _root_.Order.aleph0_le_cof_of_one_lt_cof [LinearOrder α] [WellFoundedLT α] :
+    1 < Order.cof α → ℵ₀ ≤ Order.cof α := by
+  contrapose!
+  exact Order.cof_le_one_of_cof_lt_aleph0
+
+theorem aleph0_le_cof_of_one_lt_cof {o : Ordinal} : 1 < cof o → ℵ₀ ≤ cof o := by
+  simpa using Order.aleph0_le_cof_of_one_lt_cof (α := o.ToType)
+
+theorem _root_.Order.aleph0_le_cof_iff [LinearOrder α] [WellFoundedLT α] [Nonempty α] :
+    ℵ₀ ≤ Order.cof α ↔ NoMaxOrder α := by
+  rw [← not_iff_not, not_le]
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · obtain ⟨(_ | n), hn⟩ := Cardinal.lt_aleph0.1 h
+    · simp_all
+    · have hn' := hn
+      rw [← Order.cof_ord_cof, hn, ord_nat, eq_comm] at hn'
+      aesop (add simp [cof_add_one, Order.cof_eq_one_iff])
+  · rw [← noTopOrder_iff_noMaxOrder, noTopOrder_iff] at h
+    rw [Order.cof_eq_one_iff.2]
+    · exact one_lt_aleph0
+    · simpa using h
+#exit
+
+variable (α) in
+theorem _root_.Order.aleph0_le_cof [LinearOrder α] [WellFoundedLT α] [Nonempty α] [NoMaxOrder α] :
+    ℵ₀ ≤ Order.cof α :=
+  Order.aleph0_le_cof_iff.2 ‹_›
+
+theorem aleph0_le_cof_iff {o} : ℵ₀ ≤ cof o ↔ IsSuccLimit o := by
+  induction o using Ordinal.inductionOnWellOrder with | _ α
+  cases isEmpty_or_nonempty α with
+  | inl => simp [type_eq_zero_of_empty]
+  | inr h => simp [isSuccLimit_iff, Order.aleph0_le_cof_iff, isSuccPrelimit_type_lt_iff]
+
+@[deprecated (since := "2026-03-21")] alias aleph0_le_cof := aleph0_le_cof_iff
+
+@[simp]
+theorem cof_omega0 : cof ω = ℵ₀ :=
+  (card_omega0 ▸ cof_le_card _).antisymm (aleph0_le_cof_iff.2 isSuccLimit_omega0)
+
 theorem cof_iSup_Iio {f} (hf : StrictMono f) {a} (ha : IsSuccPrelimit a) :
     cof (⨆ i : Iio a, f i.1) = cof a := by
   have : StrictMono (β := Iio (⨆ i : Iio a, f i.1)) (fun i : Iio a ↦ ⟨f i, ?_⟩) := fun x y h ↦ hf h

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -106,6 +106,26 @@ theorem cof_eq_one_iff : cof α = 1 ↔ ∃ x : α, IsTop x := by
 theorem cof_eq_one [OrderTop α] : cof α = 1 :=
   cof_eq_one_iff.2 ⟨⊤, isTop_top⟩
 
+theorem cof_ne_one_iff : cof α ≠ 1 ↔ NoTopOrder α := by
+  rw [← not_iff_not, not_not, noTopOrder_iff, cof_eq_one_iff]
+  simp
+
+@[simp]
+theorem cof_ne_one [h : NoTopOrder α] : cof α ≠ 1 :=
+  cof_ne_one_iff.2 h
+
+theorem cof_le_one_iff [Nonempty α] : cof α ≤ 1 ↔ ∃ x : α, IsTop x := by
+  rw [le_iff_lt_or_eq, Cardinal.lt_one_iff_zero, cof_eq_one_iff]
+  simp
+
+theorem one_lt_cof_iff [Nonempty α] : 1 < cof α ↔ NoTopOrder α := by
+  rw [← not_iff_not, not_lt, noTopOrder_iff, cof_le_one_iff]
+  simp
+
+@[simp]
+theorem one_lt_cof [Nonempty α] [h : NoTopOrder α] : 1 < cof α :=
+  one_lt_cof_iff.2 h
+
 end Preorder
 
 section LinearOrder
@@ -127,6 +147,21 @@ theorem lift_cof_congr_of_strictMono {f : α → β} (hf : StrictMono f) (hf' : 
 theorem cof_congr_of_strictMono {f : α → γ} (hf : StrictMono f) (hf' : IsCofinal (range f)) :
     cof α = cof γ := by
   simpa using lift_cof_congr_of_strictMono hf hf'
+
+@[simp]
+theorem cof_lt_aleph0_iff : Order.cof α < ℵ₀ ↔ Order.cof α ≤ 1 := by
+  refine ⟨fun h ↦ ?_, (lt_of_le_of_lt · one_lt_aleph0)⟩
+  obtain ⟨s, hs, hs'⟩ := Order.cof_eq α
+  have hf : s.Finite := by
+    rw [Set.Finite, ← mk_lt_aleph0_iff]
+    exact hs'.trans_lt h
+  obtain ⟨t, ht, ht'⟩ := hf.exists_subsingleton_isCofinal hs
+  apply (cof_le ht').trans
+  simpa
+
+@[simp]
+theorem aleph0_le_cof_iff : ℵ₀ ≤ Order.cof α ↔ 1 < Order.cof α := by
+  simp [← not_lt]
 
 end LinearOrder
 end Order
@@ -255,58 +290,29 @@ theorem cof_one : cof 1 = 1 := by
 theorem cof_succ (o) : cof (succ o) = 1 :=
   cof_add_one o
 
-theorem _root_.Order.cof_le_one_of_cof_lt_aleph0 [LinearOrder α] (h : Order.cof α < ℵ₀) :
-    Order.cof α ≤ 1 := by
-  obtain ⟨s, hs, hs'⟩ := Order.cof_eq α
-  have hf : s.Finite := by
-    rw [Set.Finite, ← mk_lt_aleph0_iff]
-    exact hs'.trans_lt h
-  obtain ⟨t, ht, ht'⟩ := hf.exists_subsingleton_isCofinal hs
-  apply (cof_le ht').trans
-  simpa
-
-theorem cof_le_one_of_cof_lt_aleph0 {o : Ordinal} : cof o < ℵ₀ → cof o ≤ 1 := by
-  simpa using Order.cof_le_one_of_cof_lt_aleph0 (α := o.ToType)
-
-theorem _root_.Order.aleph0_le_cof_of_one_lt_cof [LinearOrder α] [WellFoundedLT α] :
-    1 < Order.cof α → ℵ₀ ≤ Order.cof α := by
-  contrapose!
-  exact Order.cof_le_one_of_cof_lt_aleph0
-
-theorem aleph0_le_cof_of_one_lt_cof {o : Ordinal} : 1 < cof o → ℵ₀ ≤ cof o := by
-  simpa using Order.aleph0_le_cof_of_one_lt_cof (α := o.ToType)
-
-theorem _root_.Order.aleph0_le_cof_iff [LinearOrder α] [WellFoundedLT α] [Nonempty α] :
-    ℵ₀ ≤ Order.cof α ↔ NoMaxOrder α := by
-  rw [← not_iff_not, not_le]
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨(_ | n), hn⟩ := Cardinal.lt_aleph0.1 h
-    · simp_all
-    · have hn' := hn
-      rw [← Order.cof_ord_cof, hn, ord_nat, eq_comm] at hn'
-      aesop (add simp [cof_add_one, Order.cof_eq_one_iff])
-  · rw [← noTopOrder_iff_noMaxOrder, noTopOrder_iff] at h
-    rw [Order.cof_eq_one_iff.2]
-    · exact one_lt_aleph0
-    · simpa using h
-#exit
-
-variable (α) in
-theorem _root_.Order.aleph0_le_cof [LinearOrder α] [WellFoundedLT α] [Nonempty α] [NoMaxOrder α] :
-    ℵ₀ ≤ Order.cof α :=
-  Order.aleph0_le_cof_iff.2 ‹_›
-
-theorem aleph0_le_cof_iff {o} : ℵ₀ ≤ cof o ↔ IsSuccLimit o := by
-  induction o using Ordinal.inductionOnWellOrder with | _ α
-  cases isEmpty_or_nonempty α with
-  | inl => simp [type_eq_zero_of_empty]
-  | inr h => simp [isSuccLimit_iff, Order.aleph0_le_cof_iff, isSuccPrelimit_type_lt_iff]
-
-@[deprecated (since := "2026-03-21")] alias aleph0_le_cof := aleph0_le_cof_iff
+theorem one_lt_cof_iff {o : Ordinal} : 1 < cof o ↔ IsSuccLimit o := by
+  rw [← not_iff_not, not_lt, Cardinal.le_one_iff, isSuccLimit_iff,
+    not_and_or, not_ne_iff, not_isSuccPrelimit_iff', cof_eq_zero, cof_eq_one_iff]
 
 @[simp]
-theorem cof_omega0 : cof ω = ℵ₀ :=
-  (card_omega0 ▸ cof_le_card _).antisymm (aleph0_le_cof_iff.2 isSuccLimit_omega0)
+theorem cof_lt_aleph0_iff {o : Ordinal} : cof o < ℵ₀ ↔ cof o ≤ 1 := by
+  simpa using Order.cof_lt_aleph0_iff (α := o.ToType)
+
+@[simp]
+theorem aleph0_le_cof_iff {o : Ordinal} : ℵ₀ ≤ cof o ↔ 1 < cof o := by
+  simp [← not_lt]
+
+@[deprecated one_lt_cof_iff (since := "2026-03-22")]
+theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsSuccLimit o := by
+  rw [aleph0_le_cof_iff, one_lt_cof_iff]
+
+@[simp]
+theorem cof_omega0 : cof ω = ℵ₀ := by
+  apply le_antisymm
+  · rw [← card_omega0]
+    exact cof_le_card ω
+  · rw [aleph0_le_cof_iff, one_lt_cof_iff]
+    exact isSuccLimit_omega0
 
 theorem cof_iSup_Iio {f} (hf : StrictMono f) {a} (ha : IsSuccPrelimit a) :
     cof (⨆ i : Iio a, f i.1) = cof a := by
@@ -695,23 +701,6 @@ theorem cof_add (a b : Ordinal) : b ≠ 0 → cof (a + b) = cof b := fun h => by
   · rw [succ_eq_add_one, ← add_assoc, cof_add_one, cof_add_one]
   · exact cof_map_of_isNormal (isNormal_add_right a) hb
 
-theorem aleph0_le_cof {o} : ℵ₀ ≤ cof o ↔ IsSuccLimit o := by
-  rcases zero_or_succ_or_isSuccLimit o with (rfl | ⟨o, rfl⟩ | l)
-  · simp [Cardinal.aleph0_ne_zero]
-  · simp
-  · simp only [l, iff_true]
-    refine le_of_not_gt fun h => ?_
-    obtain ⟨n, e⟩ := Cardinal.lt_aleph0.1 h
-    have := cof_cof o
-    rw [e, ord_nat] at this
-    cases n
-    · apply l.ne_bot
-      simpa using e
-    · rw [natCast_succ, cof_succ] at this
-      rw [← this, cof_eq_one_iff] at e
-      rcases e with ⟨a, rfl⟩
-      exact not_isSuccLimit_succ _ l
-
 @[simp]
 theorem cof_preOmega {o : Ordinal} (ho : IsSuccPrelimit o) : (preOmega o).cof = o.cof := by
   by_cases h : IsMin o
@@ -721,12 +710,6 @@ theorem cof_preOmega {o : Ordinal} (ho : IsSuccPrelimit o) : (preOmega o).cof = 
 @[simp]
 theorem cof_omega {o : Ordinal} (ho : IsSuccLimit o) : (ω_ o).cof = o.cof :=
   cof_map_of_isNormal isNormal_omega ho
-
-@[simp]
-theorem cof_omega0 : cof ω = ℵ₀ :=
-  (aleph0_le_cof.2 isSuccLimit_omega0).antisymm' <| by
-    rw [← card_omega0]
-    apply cof_le_card
 
 -- TODO: deprecate in favor of `Order.cof_eq`
 theorem cof_eq' (r : α → α → Prop) [H : IsWellOrder α r] (h : IsSuccLimit (type r)) :
@@ -816,8 +799,8 @@ theorem mk_subset_mk_lt_cof {α : Type*} (h : ∀ x < #α, 2 ^ x < #α) :
     simp_rw [IsCofinal, ← not_lt]
     exact hs
   · refine @mk_le_of_injective α _ (fun x => Subtype.mk {x} ?_) ?_
-    · rw [mk_singleton]
-      exact one_lt_aleph0.trans_le (aleph0_le_cof.2 (isSuccLimit_ord h'.aleph0_le))
+    · rw [mk_singleton, one_lt_cof_iff]
+      exact isSuccLimit_ord h'.aleph0_le
     · intro a b hab
       simpa [singleton_eq_singleton_iff] using hab
 

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -384,12 +384,10 @@ theorem sInf_empty : sInf (∅ : Set Cardinal.{u}) = 0 :=
   dif_neg Set.not_nonempty_empty
 
 /-- Note that the successor of `c` is not the same as `c + 1` except in the case of finite `c`. -/
-@[no_expose]
 instance : SuccOrder Cardinal := ConditionallyCompleteLinearOrder.toSuccOrder
 
-@[deprecated Order.succ_eq_csInf (since := "2026-03-21")]
 theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } :=
-  Order.succ_eq_csInf c
+  dif_neg <| not_isMax c
 
 theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
   bot_lt_succ
@@ -397,26 +395,27 @@ theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
 theorem succ_ne_zero (c : Cardinal) : succ c ≠ 0 :=
   (succ_pos _).ne'
 
-theorem add_one_le_of_lt {a b : Cardinal} (h : a < b) : a + 1 ≤ b := by
-  induction a, b using Cardinal.inductionOn₂ with | mk α β
-  obtain ⟨f⟩ := le_of_lt h
-  have hf : ¬Surjective f := fun hn => h.not_ge (mk_le_of_surjective hn)
-  rw [Surjective, not_forall] at hf
-  obtain ⟨b, hb⟩ := hf
-  rw [← mk_option]
-  exact (f.optionElim b hb).cardinal_le
-
-@[deprecated add_one_le_of_lt (since := "2026-03-21")]
-theorem add_one_le_succ (c : Cardinal) : c + 1 ≤ succ c :=
-  add_one_le_of_lt (lt_succ c)
+theorem add_one_le_succ (c : Cardinal.{u}) : c + 1 ≤ succ c := by
+  have : Set.Nonempty { c' | c < c' } := exists_gt c
+  simp_rw [succ_def, le_csInf_iff'' this, mem_setOf]
+  intro b hlt
+  rcases b, c with ⟨⟨β⟩, ⟨γ⟩⟩
+  obtain ⟨f⟩ := le_of_lt hlt
+  have : ¬Surjective f := fun hn => (not_le_of_gt hlt) (mk_le_of_surjective hn)
+  simp only [Surjective, not_forall] at this
+  rcases this with ⟨b, hb⟩
+  calc
+    #γ + 1 = #(Option γ) := mk_option.symm
+    _ ≤ #β := (f.optionElim b hb).cardinal_le
 
 @[simp]
-theorem lift_succ (a) : lift.{v, u} (succ a) = succ (lift.{v, u} a) := by
-  apply (succ_le_of_lt <| lift_lt.2 <| lt_succ a).antisymm'
-  by_contra! h
-  rcases lt_lift_iff.1 h with ⟨b, h, hb⟩
-  rw [lt_succ_iff, ← lift_le, hb] at h
-  exact h.not_gt (lt_succ _)
+theorem lift_succ (a) : lift.{v, u} (succ a) = succ (lift.{v, u} a) :=
+  le_antisymm
+    (le_of_not_gt fun h => by
+      rcases lt_lift_iff.1 h with ⟨b, h, e⟩
+      rw [lt_succ_iff, ← lift_le, e] at h
+      exact h.not_gt (lt_succ _))
+    (succ_le_of_lt <| lift_lt.2 <| lt_succ a)
 
 /-! ### Limit cardinals -/
 

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -384,10 +384,12 @@ theorem sInf_empty : sInf (∅ : Set Cardinal.{u}) = 0 :=
   dif_neg Set.not_nonempty_empty
 
 /-- Note that the successor of `c` is not the same as `c + 1` except in the case of finite `c`. -/
+@[no_expose]
 instance : SuccOrder Cardinal := ConditionallyCompleteLinearOrder.toSuccOrder
 
+@[deprecated Order.succ_eq_csInf (since := "2026-03-21")]
 theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } :=
-  dif_neg <| not_isMax c
+  Order.succ_eq_csInf c
 
 theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
   bot_lt_succ
@@ -395,27 +397,26 @@ theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
 theorem succ_ne_zero (c : Cardinal) : succ c ≠ 0 :=
   (succ_pos _).ne'
 
-theorem add_one_le_succ (c : Cardinal.{u}) : c + 1 ≤ succ c := by
-  have : Set.Nonempty { c' | c < c' } := exists_gt c
-  simp_rw [succ_def, le_csInf_iff'' this, mem_setOf]
-  intro b hlt
-  rcases b, c with ⟨⟨β⟩, ⟨γ⟩⟩
-  obtain ⟨f⟩ := le_of_lt hlt
-  have : ¬Surjective f := fun hn => (not_le_of_gt hlt) (mk_le_of_surjective hn)
-  simp only [Surjective, not_forall] at this
-  rcases this with ⟨b, hb⟩
-  calc
-    #γ + 1 = #(Option γ) := mk_option.symm
-    _ ≤ #β := (f.optionElim b hb).cardinal_le
+theorem add_one_le_of_lt {a b : Cardinal} (h : a < b) : a + 1 ≤ b := by
+  induction a, b using Cardinal.inductionOn₂ with | mk α β
+  obtain ⟨f⟩ := le_of_lt h
+  have hf : ¬Surjective f := fun hn => h.not_ge (mk_le_of_surjective hn)
+  rw [Surjective, not_forall] at hf
+  obtain ⟨b, hb⟩ := hf
+  rw [← mk_option]
+  exact (f.optionElim b hb).cardinal_le
+
+@[deprecated add_one_le_of_lt (since := "2026-03-21")]
+theorem add_one_le_succ (c : Cardinal) : c + 1 ≤ succ c :=
+  add_one_le_of_lt (lt_succ c)
 
 @[simp]
-theorem lift_succ (a) : lift.{v, u} (succ a) = succ (lift.{v, u} a) :=
-  le_antisymm
-    (le_of_not_gt fun h => by
-      rcases lt_lift_iff.1 h with ⟨b, h, e⟩
-      rw [lt_succ_iff, ← lift_le, e] at h
-      exact h.not_gt (lt_succ _))
-    (succ_le_of_lt <| lift_lt.2 <| lt_succ a)
+theorem lift_succ (a) : lift.{v, u} (succ a) = succ (lift.{v, u} a) := by
+  apply (succ_le_of_lt <| lift_lt.2 <| lt_succ a).antisymm'
+  by_contra! h
+  rcases lt_lift_iff.1 h with ⟨b, h, hb⟩
+  rw [lt_succ_iff, ← lift_le, hb] at h
+  exact h.not_gt (lt_succ _)
 
 /-! ### Limit cardinals -/
 

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -60,8 +60,9 @@ theorem IsRegular.ord_pos {c : Cardinal} (H : c.IsRegular) : 0 < c.ord := by
   rw [Cardinal.lt_ord, card_zero]
   exact H.pos
 
-theorem isRegular_cof {o : Ordinal} (h : IsSuccLimit o) : IsRegular o.cof :=
-  ⟨aleph0_le_cof.2 h, (cof_cof o).ge⟩
+theorem isRegular_cof {o : Ordinal} (h : IsSuccLimit o) : IsRegular o.cof := by
+  refine ⟨?_, (cof_cof o).ge⟩
+  rwa [aleph0_le_cof_iff, one_lt_cof_iff]
 
 /-- If `c` is a regular cardinal, then `c.ord.ToType` has a least element. -/
 lemma IsRegular.ne_zero {c : Cardinal} (H : c.IsRegular) : c ≠ 0 :=


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
