### PR TITLE
[Merged by Bors] - chore: modulize tests (4/N)

### DIFF
--- a/MathlibTest/Change.lean
+++ b/MathlibTest/Change.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Change
 
 set_option linter.style.setOption false

--- a/MathlibTest/ClearExcept.lean
+++ b/MathlibTest/ClearExcept.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ClearExcept
 
 set_option linter.unusedTactic false

--- a/MathlibTest/ClearExclamation.lean
+++ b/MathlibTest/ClearExclamation.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ClearExclamation
 
 set_option linter.unusedVariables false

--- a/MathlibTest/ClearValue.lean
+++ b/MathlibTest/ClearValue.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Basic
 
 example : let x := 22; 0 ≤ x := by

--- a/MathlibTest/Clear_.lean
+++ b/MathlibTest/Clear_.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Replace
 

--- a/MathlibTest/Constructor.lean
+++ b/MathlibTest/Constructor.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Constructor
 
 structure Foo where

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
-
+module
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Contrapose
 

--- a/MathlibTest/EmptyLine.lean
+++ b/MathlibTest/EmptyLine.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Linter.EmptyLine
 
 set_option linter.style.emptyLine true

--- a/MathlibTest/Equiv.lean
+++ b/MathlibTest/Equiv.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.Int.Order.Units
 import Mathlib.GroupTheory.Perm.Finite
 

--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ErwQuestion
 
 section Single

--- a/MathlibTest/ImplicitUniverses.lean
+++ b/MathlibTest/ImplicitUniverses.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.SuccessIfFailWithMsg
 
 /--

--- a/MathlibTest/InferParam.lean
+++ b/MathlibTest/InferParam.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.InferParam
 
 namespace InferParamTest

--- a/MathlibTest/IsBoundedDefault.lean
+++ b/MathlibTest/IsBoundedDefault.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.EReal.Basic
 import Mathlib.Order.LiminfLimsup
 

--- a/MathlibTest/MoveAdd.lean
+++ b/MathlibTest/MoveAdd.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.MoveAdd
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Nat.Basic

--- a/MathlibTest/NoncommRing.lean
+++ b/MathlibTest/NoncommRing.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.Tactic.NoncommRing
 

--- a/MathlibTest/NthRewrite.lean
+++ b/MathlibTest/NthRewrite.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.NthRewrite
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Vector.Defs

--- a/MathlibTest/PPRoundtrip.lean
+++ b/MathlibTest/PPRoundtrip.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Linter.PPRoundtrip
 
 /--

--- a/MathlibTest/ProdAssoc.lean
+++ b/MathlibTest/ProdAssoc.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ProdAssoc
 
 variable {α β γ δ : Type*}

--- a/MathlibTest/Rename.lean
+++ b/MathlibTest/Rename.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Rename
 
 example (a : Nat) (b : Int) : Int × Nat := by

--- a/MathlibTest/Simp.lean
+++ b/MathlibTest/Simp.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Defs
 

--- a/MathlibTest/SwapVar.lean
+++ b/MathlibTest/SwapVar.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino
 -/
-
+module
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.SwapVar
 

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.Basic
 import Batteries.Logic

--- a/MathlibTest/TermCongr2.lean
+++ b/MathlibTest/TermCongr2.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.TermCongr
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic.Ring

--- a/MathlibTest/UnusedTactic.lean
+++ b/MathlibTest/UnusedTactic.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.AdaptationNote
 

--- a/MathlibTest/apply_congr.lean
+++ b/MathlibTest/apply_congr.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ApplyCongr
 import Mathlib.Algebra.BigOperators.Group.Finset.Powerset
 

--- a/MathlibTest/apply_rules.lean
+++ b/MathlibTest/apply_rules.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Order.Field.Basic
 
 set_option autoImplicit true

--- a/MathlibTest/apply_with.lean
+++ b/MathlibTest/apply_with.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ApplyWith
 
 set_option autoImplicit true

--- a/MathlibTest/basicTactics.lean
+++ b/MathlibTest/basicTactics.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Basic
 import Batteries.Tactic.Init
 

--- a/MathlibTest/byContra.lean
+++ b/MathlibTest/byContra.lean
@@ -1,4 +1,5 @@
 -- tests for by_contra! tactic
+module
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Rename
 import Mathlib.Tactic.Set

--- a/MathlibTest/cases.lean
+++ b/MathlibTest/cases.lean
@@ -1,3 +1,4 @@
+module
 import Batteries.Logic
 import Mathlib.Tactic.Cases
 import Mathlib.Data.Nat.Notation

--- a/MathlibTest/choose_reduction.lean
+++ b/MathlibTest/choose_reduction.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.Finset.Basic
 /-!
 Tests that `List.choose` and friends all reduce appropriately.

--- a/MathlibTest/coe.lean
+++ b/MathlibTest/coe.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Coe
 
 example : { n : Nat // n > 3 } → Nat := (↑)

--- a/MathlibTest/conv.lean
+++ b/MathlibTest/conv.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Conv
 
 /-- Testing nested `conv in ... => ...` -/

--- a/MathlibTest/dfinsupp_notation.lean
+++ b/MathlibTest/dfinsupp_notation.lean
@@ -1,4 +1,3 @@
-module
 import Mathlib.Algebra.Group.Int.Defs
 import Mathlib.Data.DFinsupp.Notation
 

--- a/MathlibTest/dfinsupp_notation.lean
+++ b/MathlibTest/dfinsupp_notation.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Group.Int.Defs
 import Mathlib.Data.DFinsupp.Notation
 

--- a/MathlibTest/enat_to_nat.lean
+++ b/MathlibTest/enat_to_nat.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ENatToNat
 
 example (a b : ENat) (h : a = b) : a - b = b - a := by

--- a/MathlibTest/norm_num_flt.lean
+++ b/MathlibTest/norm_num_flt.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.NormNum
 
 -- From https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Proving.20FLT.20with.20norm_num/near/429746342

--- a/MathlibTest/norm_num_ordinal.lean
+++ b/MathlibTest/norm_num_ordinal.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.NormNum.Ordinal
 
 universe u

--- a/MathlibTest/norm_num_rpow.lean
+++ b/MathlibTest/norm_num_rpow.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, David Renshaw
 -/
+module
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 

--- a/MathlibTest/reduce_mod_char.lean
+++ b/MathlibTest/reduce_mod_char.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+module
 import Mathlib.Tactic.ReduceModChar
 
 /-!

--- a/MathlibTest/renameBvar.lean
+++ b/MathlibTest/renameBvar.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.RenameBVar
 import Lean
 

--- a/MathlibTest/right_actions.lean
+++ b/MathlibTest/right_actions.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.GroupWithZero.Action.Opposite
 
 open MulOpposite renaming op → mop

--- a/MathlibTest/wlog.lean
+++ b/MathlibTest/wlog.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Johan Commelin
 -/
+module
 import Mathlib.Tactic.WLOG
 import Mathlib.Algebra.Ring.Nat
 


### PR DESCRIPTION

---

Privately imports are intentional.

I manually modulize each test so that the purpose of the tests is not lost by modulizing.

This PR is extracted from draft PR #34466.
These tests are for tactics, which can modulize by simply adding `module`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
