### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet): simplices of `Δ[1]`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1484,6 +1484,7 @@ public import Mathlib.AlgebraicTopology.SimplexCategory.GeneratorsRelations.EpiM
 public import Mathlib.AlgebraicTopology.SimplexCategory.GeneratorsRelations.NormalForms
 public import Mathlib.AlgebraicTopology.SimplexCategory.MorphismProperty
 public import Mathlib.AlgebraicTopology.SimplexCategory.Rev
+public import Mathlib.AlgebraicTopology.SimplexCategory.ToMkOne
 public import Mathlib.AlgebraicTopology.SimplexCategory.Truncated
 public import Mathlib.AlgebraicTopology.SimplicialCategory.Basic
 public import Mathlib.AlgebraicTopology.SimplicialCategory.SimplicialObject

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1534,6 +1534,7 @@ public import Mathlib.AlgebraicTopology.SimplicialSet.RelativeMorphism
 public import Mathlib.AlgebraicTopology.SimplicialSet.Simplices
 public import Mathlib.AlgebraicTopology.SimplicialSet.Skeleton
 public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
+public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplexOne
 public import Mathlib.AlgebraicTopology.SimplicialSet.StrictSegal
 public import Mathlib.AlgebraicTopology.SimplicialSet.Subcomplex
 public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits

--- a/Mathlib/AlgebraicTopology/SimplexCategory/ToMkOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/ToMkOne.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplexCategory.Basic
+
+/-!
+# Morphisms to `⦋1⦌`
+
+We define a bijective map `SimplexCategory.toMk₁ : Fin (n + 2) → `⦋n⦌ ⟶ ⦋1⦌`.
+This is used in the file `Mathlib.AlgebraicTopology.SimplicialSet.StdSimplexOne`
+in the study of simplices in the simplicial set `Δ[1]`.
+
+-/
+
+@[expose] public section
+
+universe u
+
+open CategoryTheory Simplicial
+
+namespace SimplexCategory
+
+/-- Given `i : Fin (n + 2)`, this is the morphism `⦋n⦌ ⟶ ⦋1⦌` in the simplex
+category which corresponds to the monotone map `Fin (n + 1) → Fin 2` which
+takes `i` times the value `0`. -/
+def toMk₁ {n : ℕ} (i : Fin (n + 2)) : ⦋n⦌ ⟶ ⦋1⦌ :=
+  Hom.mk
+    { toFun j := if j.castSucc < i then 0 else 1
+      monotone' j₁ j₂ h := by
+        dsimp
+        split_ifs <;> grind }
+
+@[local grind =]
+lemma toMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+  dsimp% toMk₁ i j = if j.castSucc < i then 0 else 1 := rfl
+
+lemma toMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+    dsimp% toMk₁ i j = 0 ↔ j.castSucc < i := by
+  grind
+
+lemma toMk₁_of_castSucc_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
+    dsimp% toMk₁ i j = 0 := by
+  grind
+
+lemma toMk₁_apply_eq_one_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+    dsimp% toMk₁ i j = 1 ↔ i ≤ j.castSucc := by
+  grind
+
+lemma toMk₁_of_le_castSucc {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
+    dsimp% toMk₁ i j = 1 := by
+  grind
+
+set_option backward.isDefEq.respectTransparency false in
+lemma δ_comp_toMk₁_of_le {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : i ≤ j.castSucc) :
+    δ j ≫ toMk₁ i =
+      toMk₁ (i.castPred (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))) := by
+  obtain ⟨i, rfl⟩ := Fin.eq_castSucc_of_ne_last
+    (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))
+  simp only [Fin.castSucc_le_castSucc_iff] at h
+  rw [Fin.castPred_castSucc]
+  refine ConcreteCategory.hom_ext _ _ (fun k ↦ ?_)
+  change toMk₁ i.castSucc (j.succAbove k) = _
+  dsimp
+  rw [Fin.eq_iff_eq_zero_iff, toMk₁_apply_eq_zero_iff, toMk₁_apply_eq_zero_iff]
+  grind [Fin.succAbove]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma δ_comp_toMk₁_of_lt {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : j.castSucc < i) :
+    δ j ≫ toMk₁ i = toMk₁ (i.pred (Fin.ne_zero_of_lt h)) := by
+  obtain ⟨i, rfl⟩ := Fin.eq_succ_of_ne_zero (Fin.ne_zero_of_lt h)
+  rw [Fin.pred_succ]
+  refine ConcreteCategory.hom_ext _ _ (fun k ↦ ?_)
+  change toMk₁ i.succ (j.succAbove k) = _
+  dsimp
+  rw [Fin.eq_iff_eq_zero_iff, toMk₁_apply_eq_zero_iff, toMk₁_apply_eq_zero_iff]
+  grind [Fin.succAbove]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma σ_comp_toMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
+    σ j ≫ toMk₁ i = toMk₁ i.castSucc := by
+  refine ConcreteCategory.hom_ext _ _ (fun k ↦ ?_)
+  change toMk₁ i (j.predAbove k) = _
+  by_cases! hk : k < i
+  · grind [Fin.castPred, Fin.predAbove_of_le_castSucc, toMk₁_of_castSucc_lt]
+  · dsimp
+    rw [toMk₁_of_le_castSucc, toMk₁_of_le_castSucc _ _ (by simpa)]
+    by_cases hk' : k ≤ j.castSucc
+    · rwa [Fin.predAbove_of_le_castSucc _ _ hk', Fin.castSucc_castPred]
+    · grind [Fin.predAbove]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma σ_comp_toMk₁_of_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
+    σ j ≫ toMk₁ i = toMk₁ i.succ := by
+  refine ConcreteCategory.hom_ext _ _ (fun k ↦ ?_)
+  change toMk₁ i (j.predAbove k) = _
+  by_cases! hk : i < k
+  · grind [Fin.predAbove_of_castSucc_lt, toMk₁_of_le_castSucc]
+  · dsimp
+    rw [toMk₁_of_castSucc_lt i.succ k (by simpa), toMk₁_of_castSucc_lt]
+    by_cases hk' : j.castSucc < k
+    · rwa [Fin.predAbove_of_castSucc_lt _ _ hk', Fin.castSucc_pred_lt_iff]
+    · simp only [not_lt] at hk'
+      rw [Fin.predAbove_of_le_castSucc _ _ hk']
+      exact lt_of_le_of_lt (by simpa) h
+
+lemma toMk₁_injective {n : ℕ} : Function.Injective (toMk₁ (n := n)) := by
+  intro i j h
+  wlog hij : i < j generalizing i j
+  · grind
+  have := ConcreteCategory.congr_hom h ⟨i.1, lt_of_lt_of_le hij (by dsimp; lia)⟩
+  simp [toMk₁_apply, if_pos hij] at this
+
+set_option backward.isDefEq.respectTransparency false in
+lemma toMk₁_surjective {n : ℕ} : Function.Surjective (toMk₁ (n := n)) := by
+  intro f
+  let S : Finset (Fin (n + 1)) := { i | f i = 1}
+  by_cases hS : S.Nonempty
+  · refine ⟨(S.min' hS).castSucc, ConcreteCategory.hom_ext _ _ (fun i ↦ ?_)⟩
+    dsimp [toMk₁_apply]
+    split_ifs with h
+    · have hi : i ∉ S := fun hi ↦ by have := S.min'_le _ hi; grind
+      grind
+    · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
+        not_lt] at h
+      obtain ⟨j, hj, hij⟩ := h
+      grind [show f j ≤ f i from f.toOrderHom.monotone hij]
+  · refine ⟨Fin.last _, ConcreteCategory.hom_ext _ _ (fun i ↦ ?_)⟩
+    dsimp [toMk₁_apply]
+    rw [if_pos (by simp)]
+    obtain ⟨j, hj⟩ : ∃ (j : Fin 2), f i = j := ⟨_, rfl⟩
+    fin_cases j
+    · grind
+    · exact (hS ⟨i, by simpa [S]⟩).elim
+
+lemma toMk₁_bijective {n : ℕ} : Function.Bijective (toMk₁ (n := n)) :=
+  ⟨toMk₁_injective, toMk₁_surjective⟩
+
+/-- The bijection `Fin (n + 2) ≃ (⦋n⦌ ⟶ ⦋1⦌)` which sends `i : Fin (n + 2)` to the
+morphism `⦋n⦌ ⟶ ⦋1⦌` in the simplex category which corresponds to the monotone map
+`Fin (n + 1) → Fin 2` which takes `i` times the value `0`. -/
+@[simps! apply]
+noncomputable def toMk₁Equiv {n : ℕ} : Fin (n + 2) ≃ (⦋n⦌ ⟶ ⦋1⦌) :=
+  Equiv.ofBijective _ toMk₁_bijective
+
+end SimplexCategory

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -104,6 +104,10 @@ lemma objMk_apply {n m : ℕ} (f : Fin (m + 1) →o Fin (n + 1)) (i : Fin (m + 1
     objMk.{u} (n := ⦋n⦌) (m := op ⦋m⦌) f i = f i :=
   rfl
 
+lemma objMk_bijective {n : SimplexCategory} {m : SimplexCategoryᵒᵖ} :
+    Function.Bijective (objMk (n := n) (m := m)) :=
+  (objEquiv.trans homEquivOrderHom).symm.bijective
+
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `Fin (m+1)` to `Fin (n+1)`. -/
 def asOrderHom {n} {m} (α : Δ[n].obj m) : OrderHom (Fin (m.unop.len + 1)) (Fin (n + 1)) :=

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -87,7 +87,7 @@ lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤
   ext k : 1
   dsimp [SimplicialObject.σ, SimplexCategory.σ]
   change objMk₁.{u} i (j.predAbove k) = _
-  by_cases hk : k < i
+  by_cases! hk : k < i
   · grind [Fin.castPred, Fin.predAbove_of_le_castSucc, objMk₁_of_castSucc_lt]
   · simp at hk
     rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -37,27 +37,25 @@ def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
         · dsimp
           rw [if_neg hi, if_neg (fun hj' ↦ hi (lt_of_le_of_lt (by simpa using h) hj'))] }
 
-set_option backward.isDefEq.respectTransparency false in
+@[local grind =]
+private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) : 
+    dsimp% objMk₁ i j = if j.castSucc < i then 0 else 1 := rfl
+
 lemma objMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
     dsimp% objMk₁.{u} i j = 0 ↔ j.castSucc < i := by
-  by_cases hj : j.castSucc < i
-  · simpa [objMk₁, if_pos hj]
-  · simpa [objMk₁, if_neg hj] using hj
+  grind
 
 lemma objMk₁_of_castSucc_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
     dsimp% objMk₁.{u} i j = 0 := by
-  simpa [objMk₁_apply_eq_zero_iff]
+  grind
 
-set_option backward.isDefEq.respectTransparency false in
 lemma objMk₁_apply_eq_one_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
     dsimp% objMk₁.{u} i j = 1 ↔ i ≤ j.castSucc := by
-  by_cases hj : j.castSucc < i
-  · simpa [objMk₁, if_pos hj]
-  · simpa [objMk₁, if_neg hj] using hj
+  grind
 
 lemma objMk₁_of_le_castSucc {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
     dsimp% objMk₁.{u} i j = 1 := by
-  simpa [objMk₁_apply_eq_one_iff]
+  grind
 
 lemma δ_objMk₁_of_le {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : i ≤ j.castSucc) :
     Δ[1].δ j (objMk₁.{u} i) =

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -6,11 +6,12 @@ Authors: Joël Riou
 module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
+public import Mathlib.AlgebraicTopology.SimplexCategory.ToMkOne
 
 /-!
 # Simplices in `Δ[1]`
 
-We define a bijection `SSet.objMk₁` between `Fin (n + 2)` and `Δ[1] _⦋n⦌`
+We define a bijection `SSet.stdSimplex.objMk₁` between `Fin (n + 2)` and `Δ[1] _⦋n⦌`
 for any `n : ℕ`.
 
 -/
@@ -25,7 +26,6 @@ namespace SSet
 
 namespace stdSimplex
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `i : Fin (n + 2)`, this is the `n`-simplex of `Δ[1]` which corresponds
 to the monotone map `Fin (n + 1) → Fin 2` which takes `i` times the value `0`. -/
 def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
@@ -35,112 +35,54 @@ def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
         dsimp
         split_ifs <;> grind }
 
-@[local grind =]
-private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
     dsimp% objMk₁ i j = if j.castSucc < i then 0 else 1 := rfl
 
 lemma objMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
-    dsimp% objMk₁.{u} i j = 0 ↔ j.castSucc < i := by
-  grind
+    dsimp% objMk₁.{u} i j = 0 ↔ j.castSucc < i :=
+  SimplexCategory.toMk₁_apply_eq_zero_iff ..
 
 lemma objMk₁_of_castSucc_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
-    dsimp% objMk₁.{u} i j = 0 := by
-  grind
+    dsimp% objMk₁.{u} i j = 0 :=
+  SimplexCategory.toMk₁_of_castSucc_lt _ _ h
 
 lemma objMk₁_apply_eq_one_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
-    dsimp% objMk₁.{u} i j = 1 ↔ i ≤ j.castSucc := by
-  grind
+    dsimp% objMk₁.{u} i j = 1 ↔ i ≤ j.castSucc :=
+  SimplexCategory.toMk₁_apply_eq_one_iff ..
 
 lemma objMk₁_of_le_castSucc {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
-    dsimp% objMk₁.{u} i j = 1 := by
-  grind
+    dsimp% objMk₁.{u} i j = 1 :=
+  SimplexCategory.toMk₁_of_le_castSucc _ _ h
 
 lemma δ_objMk₁_of_le {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : i ≤ j.castSucc) :
     Δ[1].δ j (objMk₁.{u} i) =
       objMk₁.{u} (i.castPred (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))) := by
-  obtain ⟨i, rfl⟩ := Fin.eq_castSucc_of_ne_last
-    (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))
-  simp only [Fin.castSucc_le_castSucc_iff] at h
-  rw [Fin.castPred_castSucc]
   ext k : 1
-  change objMk₁.{u} i.castSucc (j.succAbove k) = _
-  rw [Fin.eq_iff_eq_zero_iff]
-  simp only [objMk₁_apply_eq_zero_iff, Fin.castSucc_lt_castSucc_iff]
-  grind [Fin.succAbove]
+  exact ConcreteCategory.congr_hom (SimplexCategory.δ_comp_toMk₁_of_le _ _ h) k
 
 lemma δ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : j.castSucc < i) :
     Δ[1].δ j (objMk₁.{u} i) = objMk₁.{u} (i.pred (Fin.ne_zero_of_lt h)) := by
-  obtain ⟨i, rfl⟩ := Fin.eq_succ_of_ne_zero (Fin.ne_zero_of_lt h)
-  rw [Fin.pred_succ]
   ext k : 1
-  change objMk₁.{u} i.succ (j.succAbove k) = _
-  rw [Fin.eq_iff_eq_zero_iff]
-  simp only [objMk₁_apply_eq_zero_iff]
-  grind [Fin.succAbove]
+  exact ConcreteCategory.congr_hom (SimplexCategory.δ_comp_toMk₁_of_lt _ _ h) k
 
 lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
     Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.castSucc := by
   ext k : 1
-  dsimp [SimplicialObject.σ, SimplexCategory.σ]
-  change objMk₁.{u} i (j.predAbove k) = _
-  by_cases! hk : k < i
-  · grind [Fin.castPred, Fin.predAbove_of_le_castSucc, objMk₁_of_castSucc_lt]
-  · rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
-    by_cases hk' : k ≤ j.castSucc
-    · rwa [Fin.predAbove_of_le_castSucc _ _ hk', Fin.castSucc_castPred]
-    · grind [Fin.predAbove]
+  exact ConcreteCategory.congr_hom (SimplexCategory.σ_comp_toMk₁_of_le _ _ h) k
 
 lemma σ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
     Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.succ := by
   ext k : 1
-  dsimp [SimplicialObject.σ, SimplexCategory.σ]
-  change objMk₁.{u} i (j.predAbove k) = _
-  by_cases hk : i < k
-  · grind [Fin.predAbove_of_castSucc_lt, objMk₁_of_le_castSucc]
-  · simp only [not_lt] at hk
-    rw [objMk₁_of_castSucc_lt i.succ k (by simpa),
-      objMk₁_of_castSucc_lt]
-    by_cases hk' : j.castSucc < k
-    · rwa [Fin.predAbove_of_castSucc_lt _ _ hk', Fin.castSucc_pred_lt_iff]
-    · simp only [not_lt] at hk'
-      rw [Fin.predAbove_of_le_castSucc _ _ hk']
-      exact lt_of_le_of_lt (by simpa) h
-
-set_option backward.isDefEq.respectTransparency false in
-lemma objMk₁_injective {n : ℕ} : Function.Injective (objMk₁.{u} (n := n)) := by
-  intro i j h
-  wlog hij : i < j generalizing i j
-  · grind
-  have := DFunLike.congr_fun (objMk_bijective.1 h)
-    ⟨i.1, lt_of_lt_of_le hij (by dsimp; lia)⟩
-  simp [if_pos hij] at this
-
-set_option backward.isDefEq.respectTransparency false in
-lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)) := by
-  intro f
-  let S : Finset (Fin (n + 1)) := { i | f i = 1}
-  by_cases hS : S.Nonempty
-  · refine ⟨(S.min' hS).castSucc, ?_⟩
-    ext i : 1
-    dsimp [objMk₁]
-    split_ifs with h
-    · have hi : i ∉ S := fun hi ↦ by have := S.min'_le _ hi; grind
-      grind
-    · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
-        not_lt] at h
-      obtain ⟨j, hj, hij⟩ := h
-      grind [show f j ≤ f i from (objEquiv f).toOrderHom.monotone hij]
-  · refine ⟨Fin.last _, ?_⟩
-    ext i : 1
-    dsimp [objMk₁]
-    rw [if_pos (by simp)]
-    obtain ⟨j, hj⟩ : ∃ (j : Fin 2), f i = j := ⟨_, rfl⟩
-    fin_cases j
-    · simp [hj]
-    · exact (hS ⟨i, by simpa [S]⟩).elim
+  exact ConcreteCategory.congr_hom (SimplexCategory.σ_comp_toMk₁_of_lt _ _ h) k
 
 lemma objMk₁_bijective {n : ℕ} : Function.Bijective (objMk₁.{u} (n := n)) :=
-  ⟨objMk₁_injective, objMk₁_surjective⟩
+  ((SimplexCategory.toMk₁Equiv (n := n)).trans objEquiv.symm).bijective
+
+lemma objMk₁_injective {n : ℕ} : Function.Injective (objMk₁.{u} (n := n)) :=
+  objMk₁_bijective.injective
+
+lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)) :=
+  objMk₁_bijective.surjective
 
 end stdSimplex
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -36,7 +36,7 @@ def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
         split_ifs <;> grind }
 
 @[local grind =]
-private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) : 
+private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
     dsimp% objMk₁ i j = if j.castSucc < i then 0 else 1 := rfl
 
 lemma objMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
@@ -85,8 +85,7 @@ lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤
   change objMk₁.{u} i (j.predAbove k) = _
   by_cases! hk : k < i
   · grind [Fin.castPred, Fin.predAbove_of_le_castSucc, objMk₁_of_castSucc_lt]
-  · simp at hk
-    rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
+  · rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
     by_cases hk' : k ≤ j.castSucc
     · rwa [Fin.predAbove_of_le_castSucc _ _ hk', Fin.castSucc_castPred]
     · grind [Fin.predAbove]
@@ -125,14 +124,12 @@ lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)
     ext i : 1
     dsimp [objMk₁]
     split_ifs with h
-    · have hi : i ∉ S := fun hi ↦ by
-        have := S.min'_le _ hi
-        grind
+    · have hi : i ∉ S := fun hi ↦ by have := S.min'_le _ hi; grind
       grind
     · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
         not_lt] at h
       obtain ⟨j, hj, hij⟩ := h
-      grind [ show f j ≤ f i from (objEquiv f).toOrderHom.monotone hij]
+      grind [show f j ≤ f i from (objEquiv f).toOrderHom.monotone hij]
   · refine ⟨Fin.last _, ?_⟩
     ext i : 1
     dsimp [objMk₁]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -85,12 +85,7 @@ lemma δ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : j.cas
   change objMk₁.{u} i.succ (j.succAbove k) = _
   rw [Fin.eq_iff_eq_zero_iff]
   simp only [objMk₁_apply_eq_zero_iff]
-  by_cases hk : j ≤ k.castSucc
-  · rw [Fin.succAbove_of_le_castSucc _ _ hk,
-      Fin.castSucc_lt_succ_iff, Fin.castSucc_lt_iff_succ_le]
-  · simp only [not_le] at hk
-    rw [Fin.succAbove_of_castSucc_lt _ _ hk, Fin.castSucc_lt_succ_iff]
-    exact ⟨fun _ ↦ lt_of_lt_of_le hk (by simpa using h), fun h ↦ h.le⟩
+  grind [Fin.succAbove]
 
 lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
     Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.castSucc := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
+
+/-!
+# Simplices in `Δ[1]`
+
+We define a bijection `SSet.objMk₁` between `Fin (n + 2)` and `Δ[1] _⦋n⦌`
+for any `n : ℕ`.
+
+-/
+
+@[expose] public section
+
+universe u
+
+open CategoryTheory Simplicial
+
+namespace SSet
+
+namespace stdSimplex
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Given `i : Fin (n + 2)`, this is the `n`-simplex of `Δ[1]` which corresponds
+to the monotone map `Fin (n + 1) → Fin 2` which takes `i` times the value `0`. -/
+def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
+  objMk
+    { toFun j := if j.castSucc < i then 0 else 1
+      monotone' j₁ j₂ h := by
+        by_cases hi : j₁.castSucc < i
+        · simp [if_pos hi]
+        · dsimp
+          rw [if_neg hi, if_neg (fun hj' ↦ hi (lt_of_le_of_lt (by simpa using h) hj'))] }
+
+set_option backward.isDefEq.respectTransparency false in
+lemma objMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+    dsimp% objMk₁.{u} i j = 0 ↔ j.castSucc < i := by
+  by_cases hj : j.castSucc < i
+  · simpa [objMk₁, if_pos hj]
+  · simpa [objMk₁, if_neg hj] using hj
+
+lemma objMk₁_of_castSucc_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
+    dsimp% objMk₁.{u} i j = 0 := by
+  simpa [objMk₁_apply_eq_zero_iff]
+
+set_option backward.isDefEq.respectTransparency false in
+lemma objMk₁_apply_eq_one_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
+    dsimp% objMk₁.{u} i j = 1 ↔ i ≤ j.castSucc := by
+  by_cases hj : j.castSucc < i
+  · simpa [objMk₁, if_pos hj]
+  · simpa [objMk₁, if_neg hj] using hj
+
+lemma objMk₁_of_le_castSucc {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
+    dsimp% objMk₁.{u} i j = 1 := by
+  simpa [objMk₁_apply_eq_one_iff]
+
+lemma δ_objMk₁_of_le {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : i ≤ j.castSucc) :
+    Δ[1].δ j (objMk₁.{u} i) =
+      objMk₁.{u} (i.castPred (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))) := by
+  obtain ⟨i, rfl⟩ := Fin.eq_castSucc_of_ne_last
+    (Fin.ne_last_of_lt (lt_of_le_of_lt h j.castSucc_lt_succ))
+  simp only [Fin.castSucc_le_castSucc_iff] at h
+  rw [Fin.castPred_castSucc]
+  ext k : 1
+  change objMk₁.{u} i.castSucc (j.succAbove k) = _
+  rw [Fin.eq_iff_eq_zero_iff]
+  simp only [objMk₁_apply_eq_zero_iff, Fin.castSucc_lt_castSucc_iff]
+  by_cases hk : k.castSucc < j
+  · rw [Fin.succAbove_of_castSucc_lt _ _ hk]
+  · simp only [not_lt] at hk
+    rw [Fin.succAbove_of_le_castSucc _ _ hk]
+    exact ⟨fun h' ↦ (Fin.lt_irrefl _
+      (lt_of_le_of_lt ((h.trans hk).trans k.castSucc_le_succ) h')).elim, by lia⟩
+
+lemma δ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : j.castSucc < i) :
+    Δ[1].δ j (objMk₁.{u} i) = objMk₁.{u} (i.pred (Fin.ne_zero_of_lt h)) := by
+  obtain ⟨i, rfl⟩ := Fin.eq_succ_of_ne_zero (Fin.ne_zero_of_lt h)
+  rw [Fin.pred_succ]
+  ext k : 1
+  change objMk₁.{u} i.succ (j.succAbove k) = _
+  rw [Fin.eq_iff_eq_zero_iff]
+  simp only [objMk₁_apply_eq_zero_iff]
+  by_cases hk : j ≤ k.castSucc
+  · rw [Fin.succAbove_of_le_castSucc _ _ hk,
+      Fin.castSucc_lt_succ_iff, Fin.castSucc_lt_iff_succ_le]
+  · simp only [not_le] at hk
+    rw [Fin.succAbove_of_castSucc_lt _ _ hk, Fin.castSucc_lt_succ_iff]
+    exact ⟨fun _ ↦ lt_of_lt_of_le hk (by simpa using h), fun h ↦ h.le⟩
+
+lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤ j.castSucc) :
+    Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.castSucc := by
+  ext k : 1
+  dsimp [SimplicialObject.σ, SimplexCategory.σ]
+  change objMk₁.{u} i (j.predAbove k) = _
+  by_cases hk : k < i
+  · rw [Fin.predAbove_of_le_castSucc _ _ (by
+      rw [Fin.le_castSucc_iff]
+      exact lt_of_lt_of_le hk (h.trans j.castSucc_le_succ)),
+      objMk₁_of_castSucc_lt _ _ (by simpa),
+      objMk₁_of_castSucc_lt _ _ (by simpa using hk)]
+  · simp at hk
+    rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
+    by_cases hk' : k ≤ j.castSucc
+    · rwa [Fin.predAbove_of_le_castSucc _ _ hk', Fin.castSucc_castPred]
+    · simp only [not_le] at hk'
+      rw [Fin.predAbove_of_castSucc_lt _ _ hk']
+      refine h.trans ?_
+      rwa [Fin.castSucc_le_castSucc_iff, Fin.le_pred_iff, ← Fin.castSucc_lt_iff_succ_le]
+
+lemma σ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
+    Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.succ := by
+  ext k : 1
+  dsimp [SimplicialObject.σ, SimplexCategory.σ]
+  change objMk₁.{u} i (j.predAbove k) = _
+  by_cases hk : i < k
+  · obtain ⟨k, rfl⟩ := Fin.eq_succ_of_ne_zero (Fin.ne_zero_of_lt hk)
+    rw [Fin.predAbove_of_castSucc_lt _ _ (h.trans hk),
+      objMk₁_of_le_castSucc _ _ (by simpa [Fin.le_castSucc_iff]),
+      objMk₁_of_le_castSucc _ _ (by simpa [Fin.le_castSucc_iff])]
+  · simp only [not_lt] at hk
+    rw [objMk₁_of_castSucc_lt i.succ k (by simpa),
+      objMk₁_of_castSucc_lt]
+    by_cases hk' : j.castSucc < k
+    · rwa [Fin.predAbove_of_castSucc_lt _ _ hk', Fin.castSucc_pred_lt_iff]
+    · simp only [not_lt] at hk'
+      rw [Fin.predAbove_of_le_castSucc _ _ hk']
+      exact lt_of_le_of_lt (by simpa) h
+
+set_option backward.isDefEq.respectTransparency false in
+lemma objMk₁_injective {n : ℕ} : Function.Injective (objMk₁.{u} (n := n)) := by
+  intro i j h
+  wlog hij : i < j generalizing i j
+  · simp only [not_lt] at hij
+    obtain hij | rfl := hij.lt_or_eq
+    · exact (this h.symm hij).symm
+    · rfl
+  have := DFunLike.congr_fun (objMk_bijective.1 h)
+    ⟨i.1, lt_of_lt_of_le hij (by dsimp; lia)⟩
+  simp [if_pos hij] at this
+
+set_option backward.isDefEq.respectTransparency false in
+lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)) := by
+  intro f
+  let S : Finset (Fin (n + 1)) := { i | f i = 1}
+  by_cases hS : S.Nonempty
+  · refine ⟨(S.min' hS).castSucc, ?_⟩
+    ext i : 1
+    dsimp [objMk₁]
+    split_ifs with h
+    · have hi : i ∉ S := fun hi ↦ by
+        have := S.min'_le _ hi
+        rw [Fin.le_iff_val_le_val] at this
+        rw [Fin.lt_def] at h
+        dsimp at h
+        lia
+      obtain ⟨j, hj⟩ : ∃ (j : Fin 2), f i = j := ⟨_, rfl⟩
+      fin_cases j
+      · exact hj.symm
+      · exact (hi (by simpa [S])).elim
+    · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
+        not_lt] at h
+      obtain ⟨j, hj, hij⟩ := h
+      replace hj : f j = 1 := by simpa [S] using hj
+      have : f j ≤ f i := (objEquiv f).toOrderHom.monotone hij
+      exact le_antisymm (by simpa [hj] using this) (by lia)
+  · refine ⟨Fin.last _, ?_⟩
+    ext i : 1
+    dsimp [objMk₁]
+    rw [if_pos (by simp)]
+    obtain ⟨j, hj⟩ : ∃ (j : Fin 2), f i = j := ⟨_, rfl⟩
+    fin_cases j
+    · simp [hj]
+    · exact (hS ⟨i, by simpa [S]⟩).elim
+
+lemma objMk₁_bijective {n : ℕ} : Function.Bijective (objMk₁.{u} (n := n)) :=
+  ⟨objMk₁_injective, objMk₁_surjective⟩
+
+end stdSimplex
+
+end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -32,10 +32,8 @@ def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
   objMk
     { toFun j := if j.castSucc < i then 0 else 1
       monotone' j₁ j₂ h := by
-        by_cases hi : j₁.castSucc < i
-        · simp [if_pos hi]
-        · dsimp
-          rw [if_neg hi, if_neg (fun hj' ↦ hi (lt_of_le_of_lt (by simpa using h) hj'))] }
+        dsimp
+        split_ifs <;> grind }
 
 @[local grind =]
 private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) : 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -36,7 +36,7 @@ def objMk₁ {n : ℕ} (i : Fin (n + 2)) : (Δ[1] _⦋n⦌ : Type u) :=
         split_ifs <;> grind }
 
 @[local grind =]
-private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) : 
+private lemma objMk₁_apply {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :
     dsimp% objMk₁ i j = if j.castSucc < i then 0 else 1 := rfl
 
 lemma objMk₁_apply_eq_zero_iff {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) :

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -115,10 +115,7 @@ set_option backward.isDefEq.respectTransparency false in
 lemma objMk₁_injective {n : ℕ} : Function.Injective (objMk₁.{u} (n := n)) := by
   intro i j h
   wlog hij : i < j generalizing i j
-  · simp only [not_lt] at hij
-    obtain hij | rfl := hij.lt_or_eq
-    · exact (this h.symm hij).symm
-    · rfl
+  · grind
   have := DFunLike.congr_fun (objMk_bijective.1 h)
     ⟨i.1, lt_of_lt_of_le hij (by dsimp; lia)⟩
   simp [if_pos hij] at this

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -88,11 +88,7 @@ lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤
   dsimp [SimplicialObject.σ, SimplexCategory.σ]
   change objMk₁.{u} i (j.predAbove k) = _
   by_cases hk : k < i
-  · rw [Fin.predAbove_of_le_castSucc _ _ (by
-      rw [Fin.le_castSucc_iff]
-      exact lt_of_lt_of_le hk (h.trans j.castSucc_le_succ)),
-      objMk₁_of_castSucc_lt _ _ (by simpa),
-      objMk₁_of_castSucc_lt _ _ (by simpa using hk)]
+  · grind [Fin.castPred, Fin.predAbove_of_le_castSucc, objMk₁_of_castSucc_lt]
   · simp at hk
     rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
     by_cases hk' : k ≤ j.castSucc

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -97,10 +97,7 @@ lemma σ_objMk₁_of_le {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : i ≤
     rw [objMk₁_of_le_castSucc, objMk₁_of_le_castSucc _ _ (by simpa)]
     by_cases hk' : k ≤ j.castSucc
     · rwa [Fin.predAbove_of_le_castSucc _ _ hk', Fin.castSucc_castPred]
-    · simp only [not_le] at hk'
-      rw [Fin.predAbove_of_castSucc_lt _ _ hk']
-      refine h.trans ?_
-      rwa [Fin.castSucc_le_castSucc_iff, Fin.le_pred_iff, ← Fin.castSucc_lt_iff_succ_le]
+    · grind [Fin.predAbove]
 
 lemma σ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.castSucc < i) :
     Δ[1].σ j (objMk₁.{u} i) = objMk₁ i.succ := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -101,10 +101,7 @@ lemma σ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 2)) (j : Fin (n + 1)) (h : j.cas
   dsimp [SimplicialObject.σ, SimplexCategory.σ]
   change objMk₁.{u} i (j.predAbove k) = _
   by_cases hk : i < k
-  · obtain ⟨k, rfl⟩ := Fin.eq_succ_of_ne_zero (Fin.ne_zero_of_lt hk)
-    rw [Fin.predAbove_of_castSucc_lt _ _ (h.trans hk),
-      objMk₁_of_le_castSucc _ _ (by simpa [Fin.le_castSucc_iff]),
-      objMk₁_of_le_castSucc _ _ (by simpa [Fin.le_castSucc_iff])]
+  · grind [Fin.predAbove_of_castSucc_lt, objMk₁_of_le_castSucc]
   · simp only [not_lt] at hk
     rw [objMk₁_of_castSucc_lt i.succ k (by simpa),
       objMk₁_of_castSucc_lt]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -154,14 +154,8 @@ lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)
     split_ifs with h
     · have hi : i ∉ S := fun hi ↦ by
         have := S.min'_le _ hi
-        rw [Fin.le_iff_val_le_val] at this
-        rw [Fin.lt_def] at h
-        dsimp at h
-        lia
-      obtain ⟨j, hj⟩ : ∃ (j : Fin 2), f i = j := ⟨_, rfl⟩
-      fin_cases j
-      · exact hj.symm
-      · exact (hi (by simpa [S])).elim
+        grind
+      grind
     · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
         not_lt] at h
       obtain ⟨j, hj, hij⟩ := h

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -165,9 +165,7 @@ lemma objMk₁_surjective {n : ℕ} : Function.Surjective (objMk₁.{u} (n := n)
     · simp only [Fin.castSucc_lt_castSucc_iff, Finset.lt_min'_iff, not_forall,
         not_lt] at h
       obtain ⟨j, hj, hij⟩ := h
-      replace hj : f j = 1 := by simpa [S] using hj
-      have : f j ≤ f i := (objEquiv f).toOrderHom.monotone hij
-      exact le_antisymm (by simpa [hj] using this) (by lia)
+      grind [ show f j ≤ f i from (objEquiv f).toOrderHom.monotone hij]
   · refine ⟨Fin.last _, ?_⟩
     ext i : 1
     dsimp [objMk₁]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplexOne.lean
@@ -70,12 +70,7 @@ lemma δ_objMk₁_of_le {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : i ≤
   change objMk₁.{u} i.castSucc (j.succAbove k) = _
   rw [Fin.eq_iff_eq_zero_iff]
   simp only [objMk₁_apply_eq_zero_iff, Fin.castSucc_lt_castSucc_iff]
-  by_cases hk : k.castSucc < j
-  · rw [Fin.succAbove_of_castSucc_lt _ _ hk]
-  · simp only [not_lt] at hk
-    rw [Fin.succAbove_of_le_castSucc _ _ hk]
-    exact ⟨fun h' ↦ (Fin.lt_irrefl _
-      (lt_of_le_of_lt ((h.trans hk).trans k.castSucc_le_succ) h')).elim, by lia⟩
+  grind [Fin.succAbove]
 
 lemma δ_objMk₁_of_lt {n : ℕ} (i : Fin (n + 3)) (j : Fin (n + 2)) (h : j.castSucc < i) :
     Δ[1].δ j (objMk₁.{u} i) = objMk₁.{u} (i.pred (Fin.ne_zero_of_lt h)) := by

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -107,6 +107,9 @@ theorem Fin.univ_image_get' [DecidableEq β] (l : List α) (f : α → β) :
     Finset.univ.image (f <| l.get ·) = (l.map f).toFinset := by
   simp
 
+lemma Fin.eq_iff_eq_zero_iff (a b : Fin 2) : a = b ↔ (a = 0 ↔ b = 0) :=
+  ⟨by rintro rfl; rfl, fin_two_eq_of_eq_zero_iff⟩
+
 instance Unique.fintype {α : Type*} [Unique α] : Fintype α :=
   Fintype.ofSubsingleton default
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
