### PR TITLE
[Merged by Bors] - feat(NumberTheory/Height/Basic): simp lemmas for heights of tuples

### DIFF
--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -466,4 +466,37 @@ end Val
 lemma const_fin1_eq (x : α) : (fun _ : Fin 1 => x) = ![x] :=
   (cons_fin_one x _).symm
 
+/-!
+### Interaction between cons and Equiv.swap
+-/
+
+section swap
+
+@[simp]
+lemma cons_cons_comp_swap_zero_one (a b : α) (x : Fin n → α) :
+    vecCons a (vecCons b x) ∘ ⇑(Equiv.swap 0 1) = vecCons b (vecCons a x) := by
+  ext j : 1
+  match j with
+  | 0 => simp
+  | 1 => simp
+  | ⟨i + 2, h⟩ =>
+    have h' : (⟨i + 2, h⟩ : Fin n.succ.succ) = Fin.succ (Fin.succ ⟨i, by lia⟩) := by grind
+    simp only [Nat.succ_eq_add_one, h', Function.comp_apply,
+      Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero _) (Fin.succ_succ_ne_one _), cons_val_succ]
+
+lemma cons_swap (a : α) (x : Fin n → α) (i j : Fin n) :
+    vecCons a (x ∘ ⇑(Equiv.swap i j)) = vecCons a x ∘ ⇑(Equiv.swap i.succ j.succ) := by
+  ext k : 1
+  rcases eq_or_ne k 0 with rfl | hk₀
+  · simp [Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero i).symm (Fin.succ_ne_zero j).symm]
+  rcases eq_or_ne k i.succ with rfl | hki
+  · simp
+  rcases eq_or_ne k j.succ with rfl | hkj
+  · simp
+  have hk : k = Fin.succ ⟨k - 1, by lia⟩ := by grind
+  rw [Function.comp_apply, Equiv.swap_apply_of_ne_of_ne hki hkj, hk, cons_val_succ,
+    Function.comp_apply, cons_val_succ, Equiv.swap_apply_of_ne_of_ne (by grind) (by grind)]
+
+end swap
+
 end Matrix

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -474,7 +474,7 @@ section swap
 
 @[simp]
 lemma cons_cons_comp_swap_zero_one (a b : α) (x : Fin n → α) :
-    vecCons a (vecCons b x) ∘ ⇑(Equiv.swap 0 1) = vecCons b (vecCons a x) := by
+    vecCons a (vecCons b x) ∘ (Equiv.swap 0 1) = vecCons b (vecCons a x) := by
   ext j : 1
   match j with
   | 0 => simp
@@ -485,7 +485,7 @@ lemma cons_cons_comp_swap_zero_one (a b : α) (x : Fin n → α) :
       Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero _) (Fin.succ_succ_ne_one _), cons_val_succ]
 
 lemma cons_swap (a : α) (x : Fin n → α) (i j : Fin n) :
-    vecCons a (x ∘ ⇑(Equiv.swap i j)) = vecCons a x ∘ ⇑(Equiv.swap i.succ j.succ) := by
+    vecCons a (x ∘ (Equiv.swap i j)) = vecCons a x ∘ (Equiv.swap i.succ j.succ) := by
   ext k : 1
   rcases eq_or_ne k 0 with rfl | hk₀
   · simp [Equiv.swap_apply_of_ne_of_ne (Fin.succ_ne_zero i).symm (Fin.succ_ne_zero j).symm]

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -460,15 +460,13 @@ open Matrix
 @[simp]
 lemma mulHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
     mulHeight (vecCons 0 x) = mulHeight x := by
-  let e := (Equiv.sumComm ..).trans <| (finSumFinEquiv (m := 1) (n := n)).trans <|
-    finCongr (show 1 + n = n.succ from n.one_add)
+  let e := (Equiv.sumComm ..).trans <| finSumFinEquiv.trans <| finCongr n.one_add
   have he : Matrix.vecCons 0 x ∘ ⇑e = Sum.elim x 0 := by
     ext j : 1
     match j with
     | .inl _ => simp [e]
     | .inr ⟨i, h⟩ =>
-      simp only [show i = 0 by lia]
-      simp [e, show Fin.castAdd n 0 = 0 from Fin.castAdd_mk _ _ zero_lt_one]
+      simp [show i = 0 by lia, e, show Fin.castAdd n 0 = 0 from Fin.castAdd_mk _ _ zero_lt_one]
   rw [← mulHeight_comp_equiv e, he, mulHeight_sumElim_zero_eq]
 
 @[simp]

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -460,7 +460,7 @@ open Matrix
 variable {n : ℕ} (x : Fin n → K)
 
 @[simp]
-lemma mulHeight_vecCons_zero : mulHeight (vecCons 0 x) = mulHeight x := by
+lemma mulHeight_cons_zero : mulHeight (vecCons 0 x) = mulHeight x := by
   let e := (Equiv.sumComm ..).trans <| finSumFinEquiv.trans <| finCongr n.one_add
   have he : Matrix.vecCons 0 x ∘ ⇑e = Sum.elim x 0 := by
     ext j : 1
@@ -471,28 +471,28 @@ lemma mulHeight_vecCons_zero : mulHeight (vecCons 0 x) = mulHeight x := by
   rw [← mulHeight_comp_equiv e, he, mulHeight_sumElim_zero_eq]
 
 @[simp]
-lemma logHeight_vecCons_zero : logHeight (Matrix.vecCons 0 x) = logHeight x := by
+lemma logHeight_cons_zero : logHeight (Matrix.vecCons 0 x) = logHeight x := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_vecCons_vecCons_zero (a : K) :
+lemma mulHeight_cons_cons_zero (a : K) :
     mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
   rw [← mulHeight_comp_equiv (Equiv.swap 0 1)]
   simp
 
 @[simp]
-lemma logHeight_vecCons_vecCons_zero (a : K) :
+lemma logHeight_cons_cons_zero (a : K) :
     logHeight (vecCons a (vecCons 0 x)) = logHeight (vecCons a x) := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_vecCons_vecCons_vecCons_zero (a b : K) :
+lemma mulHeight_cons_cons_cons_zero (a b : K) :
     mulHeight (vecCons a (vecCons b (vecCons 0 x))) = mulHeight (vecCons a (vecCons b x)) := by
   rw [← mulHeight_comp_equiv (Equiv.swap (Fin.succ 0) (Fin.succ 1)), ← cons_swap]
   simp
 
 @[simp]
-lemma logHeight_vecCons_vecCons_vecCons_zero (a b : K) :
+lemma logHeight_cons_cons_cons_zero (a b : K) :
     logHeight (vecCons a (vecCons b (vecCons 0 x))) = logHeight (vecCons a (vecCons b x)) := by
   simp [logHeight_eq_log_mulHeight]
 

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -457,7 +457,7 @@ TODO: Write a `simproc` that removes *all* (syntactic) zeros from a tuple in thi
 
 open Matrix
 
-variable {n : ℕ} (x : Fin n → K)
+variable {n : ℕ} (a b : K) (x : Fin n → K)
 
 @[simp]
 lemma mulHeight_cons_zero : mulHeight (vecCons 0 x) = mulHeight x := by
@@ -475,24 +475,22 @@ lemma logHeight_cons_zero : logHeight (Matrix.vecCons 0 x) = logHeight x := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_cons_cons_zero (a : K) :
-    mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
+lemma mulHeight_cons_cons_zero : mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
   rw [← mulHeight_comp_equiv (Equiv.swap 0 1)]
   simp
 
 @[simp]
-lemma logHeight_cons_cons_zero (a : K) :
-    logHeight (vecCons a (vecCons 0 x)) = logHeight (vecCons a x) := by
+lemma logHeight_cons_cons_zero : logHeight (vecCons a (vecCons 0 x)) = logHeight (vecCons a x) := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_cons_cons_cons_zero (a b : K) :
+lemma mulHeight_cons_cons_cons_zero :
     mulHeight (vecCons a (vecCons b (vecCons 0 x))) = mulHeight (vecCons a (vecCons b x)) := by
   rw [← mulHeight_comp_equiv (Equiv.swap (Fin.succ 0) (Fin.succ 1)), ← cons_swap]
   simp
 
 @[simp]
-lemma logHeight_cons_cons_cons_zero (a b : K) :
+lemma logHeight_cons_cons_cons_zero :
     logHeight (vecCons a (vecCons b (vecCons 0 x))) = logHeight (vecCons a (vecCons b x)) := by
   simp [logHeight_eq_log_mulHeight]
 

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -457,9 +457,10 @@ TODO: Write a `simproc` that removes *all* (syntactic) zeros from a tuple in thi
 
 open Matrix
 
+variable {n : ℕ} (x : Fin n → K)
+
 @[simp]
-lemma mulHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
-    mulHeight (vecCons 0 x) = mulHeight x := by
+lemma mulHeight_vecCons_zero : mulHeight (vecCons 0 x) = mulHeight x := by
   let e := (Equiv.sumComm ..).trans <| finSumFinEquiv.trans <| finCongr n.one_add
   have he : Matrix.vecCons 0 x ∘ ⇑e = Sum.elim x 0 := by
     ext j : 1
@@ -470,29 +471,28 @@ lemma mulHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
   rw [← mulHeight_comp_equiv e, he, mulHeight_sumElim_zero_eq]
 
 @[simp]
-lemma logHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
-    logHeight (Matrix.vecCons 0 x) = logHeight x := by
+lemma logHeight_vecCons_zero : logHeight (Matrix.vecCons 0 x) = logHeight x := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_vecCons_vecCons_zero {n : ℕ} (a : K) (x : Fin n → K) :
+lemma mulHeight_vecCons_vecCons_zero (a : K) :
     mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
   rw [← mulHeight_comp_equiv (Equiv.swap 0 1)]
   simp
 
 @[simp]
-lemma logHeight_vecCons_vecCons_zero {n : ℕ} (a : K) (x : Fin n → K) :
+lemma logHeight_vecCons_vecCons_zero (a : K) :
     logHeight (vecCons a (vecCons 0 x)) = logHeight (vecCons a x) := by
   simp [logHeight_eq_log_mulHeight]
 
 @[simp]
-lemma mulHeight_vecCons_vecCons_vecCons_zero {n : ℕ} (a b : K) (x : Fin n → K) :
+lemma mulHeight_vecCons_vecCons_vecCons_zero (a b : K) :
     mulHeight (vecCons a (vecCons b (vecCons 0 x))) = mulHeight (vecCons a (vecCons b x)) := by
   rw [← mulHeight_comp_equiv (Equiv.swap (Fin.succ 0) (Fin.succ 1)), ← cons_swap]
   simp
 
 @[simp]
-lemma logHeight_vecCons_vecCons_vecCons_zero {n : ℕ} (a b : K) (x : Fin n → K) :
+lemma logHeight_vecCons_vecCons_vecCons_zero (a b : K) :
     logHeight (vecCons a (vecCons b (vecCons 0 x))) = logHeight (vecCons a (vecCons b x)) := by
   simp [logHeight_eq_log_mulHeight]
 

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -479,7 +479,7 @@ lemma logHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
 @[simp]
 lemma mulHeight_vecCons_vecCons_zero {n : ℕ} (a : K) (x : Fin n → K) :
     mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
-  rw [← mulHeight_comp_equiv (Equiv.swap 0 1), cons_cons_comp_swap_zero_one]
+  rw [← mulHeight_comp_equiv (Equiv.swap 0 1)]
   simp
 
 @[simp]

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -446,6 +446,60 @@ lemma logHeight_eq_zero_of_subsingleton {ι : Type*} [Subsingleton ι] (x : ι �
     logHeight x = 0 := by
   simp [logHeight_eq_log_mulHeight]
 
+section tuple
+
+/-
+This section contains `simp` lemmas that remove a zero from one of the first three positions
+in a tuple, when `mulHeight` or `logHeight` is applied to it.
+
+TODO: Write a `simproc` that removes *all* (syntactic) zeros from a tuple in this situation.
+-/
+
+open Matrix
+
+@[simp]
+lemma mulHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
+    mulHeight (vecCons 0 x) = mulHeight x := by
+  let e := (Equiv.sumComm ..).trans <| (finSumFinEquiv (m := 1) (n := n)).trans <|
+    finCongr (show 1 + n = n.succ from n.one_add)
+  have he : Matrix.vecCons 0 x ∘ ⇑e = Sum.elim x 0 := by
+    ext j : 1
+    match j with
+    | .inl _ => simp [e]
+    | .inr ⟨i, h⟩ =>
+      simp only [show i = 0 by lia]
+      simp [e, show Fin.castAdd n 0 = 0 from Fin.castAdd_mk _ _ zero_lt_one]
+  rw [← mulHeight_comp_equiv e, he, mulHeight_sumElim_zero_eq]
+
+@[simp]
+lemma logHeight_vecCons_zero {n : ℕ} (x : Fin n → K) :
+    logHeight (Matrix.vecCons 0 x) = logHeight x := by
+  simp [logHeight_eq_log_mulHeight]
+
+@[simp]
+lemma mulHeight_vecCons_vecCons_zero {n : ℕ} (a : K) (x : Fin n → K) :
+    mulHeight (vecCons a (vecCons 0 x)) = mulHeight (vecCons a x) := by
+  rw [← mulHeight_comp_equiv (Equiv.swap 0 1), cons_cons_comp_swap_zero_one]
+  simp
+
+@[simp]
+lemma logHeight_vecCons_vecCons_zero {n : ℕ} (a : K) (x : Fin n → K) :
+    logHeight (vecCons a (vecCons 0 x)) = logHeight (vecCons a x) := by
+  simp [logHeight_eq_log_mulHeight]
+
+@[simp]
+lemma mulHeight_vecCons_vecCons_vecCons_zero {n : ℕ} (a b : K) (x : Fin n → K) :
+    mulHeight (vecCons a (vecCons b (vecCons 0 x))) = mulHeight (vecCons a (vecCons b x)) := by
+  rw [← mulHeight_comp_equiv (Equiv.swap (Fin.succ 0) (Fin.succ 1)), ← cons_swap]
+  simp
+
+@[simp]
+lemma logHeight_vecCons_vecCons_vecCons_zero {n : ℕ} (a b : K) (x : Fin n → K) :
+    logHeight (vecCons a (vecCons b (vecCons 0 x))) = logHeight (vecCons a (vecCons b x)) := by
+  simp [logHeight_eq_log_mulHeight]
+
+end tuple
+
 end Height
 
 /-!

--- a/MathlibTest/Simproc/VecPerm.lean
+++ b/MathlibTest/Simproc/VecPerm.lean
@@ -7,13 +7,13 @@ open Mathlib.Tactic.FinVec
 variable {α : Type*} (a b c d : α)
 
 example : ![a, b, c] ∘ Equiv.swap 0 1 = ![b, a, c] := by
-  simp [vecPerm, Equiv.swap_apply_def]
+  simp -- this is dealt with using `Matrix.cons_cons_comp_swap_zero_one`
 
 example : ![a, b, c] ∘ Equiv.swap 0 2 = ![c, b, a] := by
   simp [vecPerm, Equiv.swap_apply_def]
 
 example : ![a, b, c] ∘ c[0, 1] = ![b, a, c] := by
-  simp [vecPerm, Equiv.swap_apply_def]
+  simp -- this is dealt with using `Matrix.cons_cons_comp_swap_zero_one`
 
 example : ![a, b, c] ∘ c[2, 0, 1] = ![b, c, a] := by
   simp [vecPerm, Equiv.swap_apply_def]


### PR DESCRIPTION
This PR adds `simp` lemmas of the form
* `{mul|log}Height ![0, a, ...] = {mul|log}Height ![a, ...]`
* `{mul|log}Height ![a, 0, b, ...] = {mul|log}Height ![a, b, ...]`
* `{mul|log}Height ![a, b, 0, c, ...] = {mul|log}Height ![a, b, c, ...]`
and two API lemmas for the interaction of `Matrix.vecCons` and `Equiv.swap` that are useful for the proofs.
One of the latter simplifies two tests in MathlibTest.Simproc.VecPerm.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
