### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/EllipticCurve/Affine/Point): x-coordinate map and API

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -839,13 +839,13 @@ end Point
 /-!
 ### The x-coordinate map to ℙ¹
 
-We define the map from affine points of `W` to the projective line by producing a coordinate
-vector in `Fin 2 → F` that represents the projective point.
+We define the map from affine points of an affine Weierstrass curve over `R` to the projective line
+by producing a coordinate vector in `Fin 2 → R` that represents the projective point.
 -/
 
 namespace Point
 
-/-- This map sends an affine point `P` on `W` to a representative of its image on ℙ¹
+/-- This map sends an affine point `P` on `W'` to a representative of its image on ℙ¹
 under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,
 where `x` is the x-coordinate of `P` for a finite point. -/
 noncomputable def xRep : W'.Point → Fin 2 → R
@@ -853,7 +853,7 @@ noncomputable def xRep : W'.Point → Fin 2 → R
   | some x _ _ => ![x, 1]
 
 @[simp]
-lemma xRep_zero : (0 : W.Point).xRep = ![1, 0] :=
+lemma xRep_zero : (0 : W'.Point).xRep = ![1, 0] :=
   rfl
 
 @[simp]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -650,9 +650,9 @@ instance : InvolutiveNeg W'.Point where
     · rfl
     · simp only [neg_some, negY_negY]
 
-lemma X_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
-    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
-    xP = xQ ↔ P = Q ∨ P = -Q := by
+lemma X_eq_iff {P Q : W.Point} {x₁ y₁ x₂ y₂ : F} {hP' : W.Nonsingular x₁ y₁}
+    {hQ' : W.Nonsingular x₂ y₂} (hP : P = some x₁ y₁ hP') (hQ : Q = some x₂ y₂ hQ') :
+    x₁ = x₂ ↔ P = Q ∨ P = -Q := by
   refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
   simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
   exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -850,7 +850,8 @@ under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x
 where `x` is the x-coordinate of `P` for a finite point.
 
 We define it in the general setting of a commutative base ring, even though the definition
-of points in this setting is not really correct. -/
+of points in this setting is not really correct. For Weierstrass curves over fields, this
+gives the correct notion. -/
 noncomputable def xRep : W'.Point → Fin 2 → R
   | 0 => ![1, 0]
   | some x _ _ => ![x, 1]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -836,6 +836,61 @@ lemma map_baseChange [Algebra F K] [IsScalarTower R F K] [Algebra F L] [IsScalar
 
 end Point
 
+/-!
+### The x-coordinate map to ℙ¹
+
+We define the map from affine points of `W` to the projective line by producing a coordinate
+vector in `Fin 2 → F` that represents the projective point.
+-/
+
+namespace Point
+
+lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
+    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
+    xP = xQ ↔ P = Q ∨ P = -Q := by
+  refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
+  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
+  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
+
+/-- This map sends an affine point `P` on `W` to a representative of its image on ℙ¹
+under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,
+where `x` is the x-coordinate of `P` for a finite point. -/
+noncomputable def xRep : W.Point → Fin 2 → F
+  | 0 => ![1, 0]
+  | some x _ _ => ![x, 1]
+
+@[simp]
+lemma xRep_zero : (0 : W.Point).xRep = ![1, 0] :=
+  rfl
+
+@[simp]
+lemma xRep_some {x y : F} (h : W.Nonsingular x y) : (some x y h).xRep = ![x, 1] :=
+  rfl
+
+lemma xRep_ne_zero (P : W.Point) : P.xRep ≠ 0 := by
+  cases P <;> simp [← zero_def]
+
+@[simp]
+lemma xRep_neg (P : W.Point) : (-P).xRep = P.xRep := by
+  cases P <;> simp [← zero_def]
+
+lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) :
+    P = Q ∨ P = -Q := by
+  match P, Q with
+  | 0, 0 => exact .inl rfl
+  | 0, some .. => simp [xRep] at h
+  | some .., 0 => simp [xRep] at h
+  | some x₁ _ _, some x₂ _ _ =>
+    simp only [xRep, Matrix.vecCons_inj, and_true] at h
+    exact (x_eq_iff rfl rfl).mp h
+
+lemma xRep_eq_xRep_iff {P Q : W.Point} :
+    P.xRep = Q.xRep ↔ P = Q ∨ P = -Q := by
+  refine ⟨eq_or_eq_neg_of_xRep_eq_xRep, fun H ↦ ?_⟩
+  rcases H with rfl | rfl <;> simp
+
+end Point
+
 end Affine
 
 end WeierstrassCurve

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -834,16 +834,12 @@ lemma map_baseChange [Algebra F K] [IsScalarTower R F K] [Algebra F L] [IsScalar
   have : Subsingleton (F →ₐ[F] L) := inferInstance
   convert map_map (Algebra.ofId F K) f P
 
-end Point
-
 /-!
 ### The x-coordinate map to ℙ¹
 
 We define the map from affine points of an affine Weierstrass curve over `R` to the projective line
 by producing a coordinate vector in `Fin 2 → R` that represents the projective point.
 -/
-
-namespace Point
 
 /-- This map sends an affine point `P` on `W'` to a representative of its image on ℙ¹
 under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -847,7 +847,10 @@ namespace Point
 
 /-- This map sends an affine point `P` on `W'` to a representative of its image on ℙ¹
 under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,
-where `x` is the x-coordinate of `P` for a finite point. -/
+where `x` is the x-coordinate of `P` for a finite point.
+
+We define it in the general setting of a commutative base ring, even though the definition
+of points in this setting is not really correct. -/
 noncomputable def xRep : W'.Point → Fin 2 → R
   | 0 => ![1, 0]
   | some x _ _ => ![x, 1]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -650,6 +650,13 @@ instance : InvolutiveNeg W'.Point where
     · rfl
     · simp only [neg_some, negY_negY]
 
+lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
+    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
+    xP = xQ ↔ P = Q ∨ P = -Q := by
+  refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
+  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
+  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
+
 variable [DecidableEq F] [DecidableEq K] [DecidableEq L]
 
 /-- The addition of two nonsingular points on a Weierstrass curve in affine coordinates.
@@ -872,13 +879,6 @@ lemma xRep_neg (P : W'.Point) : (-P).xRep = P.xRep := by
   cases P <;> simp [← zero_def]
 
 -- The following lemmas need a field as base ring.
-
-lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
-    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
-    xP = xQ ↔ P = Q ∨ P = -Q := by
-  refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
-  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
-  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
 
 lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) : P = Q ∨ P = -Q := by
   match P, Q with

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -650,12 +650,11 @@ instance : InvolutiveNeg W'.Point where
     · rfl
     · simp only [neg_some, negY_negY]
 
-lemma X_eq_iff {P Q : W.Point} {x₁ y₁ x₂ y₂ : F} {hP' : W.Nonsingular x₁ y₁}
-    {hQ' : W.Nonsingular x₂ y₂} (hP : P = some x₁ y₁ hP') (hQ : Q = some x₂ y₂ hQ') :
-    x₁ = x₂ ↔ P = Q ∨ P = -Q := by
+lemma X_eq_iff {x₁ y₁ x₂ y₂ : F} {h₁ : W.Nonsingular x₁ y₁} {h₂ : W.Nonsingular x₂ y₂} :
+    x₁ = x₂ ↔ some x₁ y₁ h₁ = some x₂ y₂ h₂ ∨ some x₁ y₁ h₁ = -some x₂ y₂ h₂ := by
   refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
-  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
-  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
+  simp_rw [neg_some, some.injEq, ← and_or_left]
+  exact ⟨H, Y_eq_of_X_eq h₁.1 h₂.1 H⟩
 
 variable [DecidableEq F] [DecidableEq K] [DecidableEq L]
 
@@ -846,15 +845,16 @@ end Point
 /-!
 ### The x-coordinate map to ℙ¹
 
-We define the map from affine points of an affine Weierstrass curve over `R` to the projective line
+We define the map from points on an affine Weierstrass curve over `R` to the projective line
 by producing a coordinate vector in `Fin 2 → R` that represents the projective point.
 -/
 
 namespace Point
 
-/-- This map sends an affine point `P` on `W'` to a representative of its image on ℙ¹
-under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,
-where `x` is the x-coordinate of `P` for a finite point.
+/-- This map sends a point `P` on a Weierstrass curve `W'` in affine coordinates
+to a representative of its image on ℙ¹ under the x-coordinate map.
+We take `![1, 0]` for the point at infinity and `![x, 1]`,
+where `x` is the x-coordinate of `P`, for an affine point.
 
 We define it in the general setting of a commutative base ring, even though the definition
 of points in this setting is not really correct. For Weierstrass curves over fields, this
@@ -885,9 +885,9 @@ lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) : P = Q
   | 0, 0 => exact .inl rfl
   | 0, some .. => simp [xRep] at h
   | some .., 0 => simp [xRep] at h
-  | some x₁ _ _, some x₂ _ _ =>
+  | some x₁ .., some x₂ .. =>
     simp only [xRep, Matrix.vecCons_inj, and_true] at h
-    exact (X_eq_iff rfl rfl).mp h
+    exact X_eq_iff.mp h
 
 lemma xRep_eq_xRep_iff {P Q : W.Point} : P.xRep = Q.xRep ↔ P = Q ∨ P = -Q := by
   refine ⟨eq_or_eq_neg_of_xRep_eq_xRep, fun H ↦ ?_⟩

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -650,7 +650,7 @@ instance : InvolutiveNeg W'.Point where
     · rfl
     · simp only [neg_some, negY_negY]
 
-lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
+lemma X_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
     {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
     xP = xQ ↔ P = Q ∨ P = -Q := by
   refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
@@ -887,7 +887,7 @@ lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) : P = Q
   | some .., 0 => simp [xRep] at h
   | some x₁ _ _, some x₂ _ _ =>
     simp only [xRep, Matrix.vecCons_inj, and_true] at h
-    exact (x_eq_iff rfl rfl).mp h
+    exact (X_eq_iff rfl rfl).mp h
 
 lemma xRep_eq_xRep_iff {P Q : W.Point} : P.xRep = Q.xRep ↔ P = Q ∨ P = -Q := by
   refine ⟨eq_or_eq_neg_of_xRep_eq_xRep, fun H ↦ ?_⟩

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -876,8 +876,7 @@ lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
   simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
   exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
 
-lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) :
-    P = Q ∨ P = -Q := by
+lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) : P = Q ∨ P = -Q := by
   match P, Q with
   | 0, 0 => exact .inl rfl
   | 0, some .. => simp [xRep] at h
@@ -886,8 +885,7 @@ lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) :
     simp only [xRep, Matrix.vecCons_inj, and_true] at h
     exact (x_eq_iff rfl rfl).mp h
 
-lemma xRep_eq_xRep_iff {P Q : W.Point} :
-    P.xRep = Q.xRep ↔ P = Q ∨ P = -Q := by
+lemma xRep_eq_xRep_iff {P Q : W.Point} : P.xRep = Q.xRep ↔ P = Q ∨ P = -Q := by
   refine ⟨eq_or_eq_neg_of_xRep_eq_xRep, fun H ↦ ?_⟩
   rcases H with rfl | rfl <;> simp
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -834,12 +834,16 @@ lemma map_baseChange [Algebra F K] [IsScalarTower R F K] [Algebra F L] [IsScalar
   have : Subsingleton (F →ₐ[F] L) := inferInstance
   convert map_map (Algebra.ofId F K) f P
 
+end Point
+
 /-!
 ### The x-coordinate map to ℙ¹
 
 We define the map from affine points of an affine Weierstrass curve over `R` to the projective line
 by producing a coordinate vector in `Fin 2 → R` that represents the projective point.
 -/
+
+namespace Point
 
 /-- This map sends an affine point `P` on `W'` to a representative of its image on ℙ¹
 under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -845,17 +845,10 @@ vector in `Fin 2 → F` that represents the projective point.
 
 namespace Point
 
-lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
-    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
-    xP = xQ ↔ P = Q ∨ P = -Q := by
-  refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
-  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
-  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
-
 /-- This map sends an affine point `P` on `W` to a representative of its image on ℙ¹
 under the x-coordinate map. We take `![1, 0]` for the point at infinity and `![x, 1]`,
 where `x` is the x-coordinate of `P` for a finite point. -/
-noncomputable def xRep : W.Point → Fin 2 → F
+noncomputable def xRep : W'.Point → Fin 2 → R
   | 0 => ![1, 0]
   | some x _ _ => ![x, 1]
 
@@ -864,15 +857,24 @@ lemma xRep_zero : (0 : W.Point).xRep = ![1, 0] :=
   rfl
 
 @[simp]
-lemma xRep_some {x y : F} (h : W.Nonsingular x y) : (some x y h).xRep = ![x, 1] :=
+lemma xRep_some {x y : R} (h : W'.Nonsingular x y) : (some x y h).xRep = ![x, 1] :=
   rfl
 
-lemma xRep_ne_zero (P : W.Point) : P.xRep ≠ 0 := by
-  cases P <;> simp [← zero_def]
+lemma xRep_ne_zero [Nontrivial R] (P : W'.Point) : P.xRep ≠ 0 := by
+  cases P <;> simp [xRep]
 
 @[simp]
-lemma xRep_neg (P : W.Point) : (-P).xRep = P.xRep := by
+lemma xRep_neg (P : W'.Point) : (-P).xRep = P.xRep := by
   cases P <;> simp [← zero_def]
+
+-- The following lemmas need a field as base ring.
+
+lemma x_eq_iff {P Q : W.Point} {xP yP xQ yQ : F} {hP' : W.Nonsingular xP yP}
+    {hQ' : W.Nonsingular xQ yQ} (hP : P = some xP yP hP') (hQ : Q = some xQ yQ hQ') :
+    xP = xQ ↔ P = Q ∨ P = -Q := by
+  refine ⟨fun H ↦ ?_, fun H ↦ by grind [neg_some]⟩
+  simp_rw [hP, hQ, neg_some, some.injEq, ← and_or_left]
+  exact ⟨H, Y_eq_of_X_eq hP'.1 hQ'.1 H⟩
 
 lemma eq_or_eq_neg_of_xRep_eq_xRep {P Q : W.Point} (h : P.xRep = Q.xRep) :
     P = Q ∨ P = -Q := by


### PR DESCRIPTION
This defines the `x`-coordinate map on points on an affine Weierstrass model by giving a representative coordinate vector of the image and adds some API for it.

This is needed on the way to the Mordell-Weil Theorem.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
