### PR TITLE
[Merged by Bors] - fix(RefinedDiscrTree/Lookup): improve the matching score heuristic

### DIFF
--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Lookup.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Lookup.lean
@@ -170,27 +170,63 @@ private def matchEverything (root : Std.HashMap Key TrieIndex) : TreeM α (Match
     let { values, .. } ← evalNode pMatch.trie
     return result.push (score := 0) values
 
+/--
+Types are counted less towards the total matching score.
+The reason is that types are usually implicit arguments. For example
+
+- If the goal is `(1 : ℕ) = 1`, we could find
+  - `rfl (a : α) : a = a`.
+    This gets extra points for matching `1`
+  - `Nat.succ.inj (n m : ℕ) (h : n.succ = m.succ) : n = m`.
+    This gets extra points for matching `ℕ`
+  Clearly, `rfl` is better.
+- If we rewrite `|(0 : ℝ)|`, we could find
+  - `abs_zero : |(0 : α)| = 0`
+    This gets extra points for matching `0`
+  - `Real.norm_eq_abs : ∀ (r : ℝ), ‖r‖ = |r|`
+    This gets extra points for matching `ℝ`
+  Clearly, `abs_zero` is better
+
+In both examples, matching the type (`ℕ` or `ℝ`) was not very important for how good
+the match actually was.
+-/
+private def Key.score (key : Key) : MetaM Nat := do
+  match key with
+  | .const n _ =>
+    if (← getConstInfo n).type.getForallBody.isSort then
+      return 1
+    else
+      return 10
+  | .fvar fvarId _ =>
+    if (← fvarId.getType).getForallBody.isSort then
+      return 1
+    else
+      return 10
+  | _ => return 10
+
 /-- Add to the `todo` stack all matches that result from a `.star _` in the discrimination tree. -/
 private partial def matchTreeStars (key : Key) (node : Trie α) (pMatch : PartialMatch)
-    (todo : Array PartialMatch) (unify : Bool) : Array PartialMatch := Id.run do
+    (todo : Array PartialMatch) (unify : Bool) : MetaM (Array PartialMatch) := do
   let { star, labelledStars, .. } := node
   if labelledStars.isEmpty && star.isNone then
-    todo
+    return todo
   else
     let (dropped, keys) := drop [key] pMatch.keys key.arity
     let mut todo := todo
     if let some trie := star then
       todo := todo.push { pMatch with keys, trie }
-    todo := node.labelledStars.fold (init := todo) fun todo id trie =>
+    todo ← node.labelledStars.foldM (init := todo) fun todo id trie => do
       if let some assignment := pMatch.treeStars[id]? then
         let eq lhs rhs := if unify then (isEq lhs.reverse rhs.reverse).isSome else lhs == rhs
         if eq dropped assignment then
-          todo.push { pMatch with keys, trie, score := pMatch.score + dropped.length }
+          return todo.push { pMatch with
+            keys, trie
+            score := (← dropped.mapM (·.score)).foldl (· + ·) pMatch.score }
         else
-          todo
+          return todo
       else
         let treeStars := pMatch.treeStars.insert id dropped
-        todo.push { pMatch with keys, trie, treeStars }
+        return todo.push { pMatch with keys, trie, treeStars }
     return todo
 where
   /-- Drop the keys corresponding to the next `n` expressions. -/
@@ -246,10 +282,10 @@ private partial def getMatchLoop (todo : Array PartialMatch) (result : MatchResu
           let todo ← matchQueryStar pMatch.trie pMatch todo
           getMatchLoop todo result unify
         else
-          let todo := matchTreeStars key node pMatch todo unify
+          let todo ← matchTreeStars key node pMatch todo unify
           getMatchLoop todo result unify
       | _ =>
-        let todo := matchTreeStars key node pMatch todo unify
+        let todo ← matchTreeStars key node pMatch todo unify
         let todo := matchKey key node.children pMatch todo
         getMatchLoop todo result unify
 


### PR DESCRIPTION
This PR improves the order in which results come out of the `RefinedDiscrTree`. I've explained the motivation in the doc-string. This is probably not the most principled fix, but it is the least disruptive solution I could think of.

For an example, try clicking on `|0|` in
```
import Mathlib

example : |(0 : ℝ)| = 1 := by
  rw??
```
And notice that the obvious result `abs_zero` is not the first result.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
