### PR TITLE
[Merged by Bors] - chore(RefinedDiscrTree/Lookup): remove reference counting workaround

### DIFF
--- a/Mathlib/Lean/Meta/RefinedDiscrTree.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree.lean
@@ -119,15 +119,13 @@ def findImportMatches
   setNGen ngen
   let _ : Inhabited (IO.Ref (Option (RefinedDiscrTree α))) := ⟨← IO.mkRef none⟩
   let ref := EnvExtension.getState ext (← getEnv)
-  -- empty the reference `ref`, so that the reference count stays 1
-  let importTree? ← ref.modifyGet fun tree? => (tree?, none)
-  let importTree ← importTree?.getDM do
+  let importTree ← (← ref.get).getDM do
     profileitM Exception  "RefinedDiscrTree import initialization" (← getOptions) <|
       withTheReader Core.Context withTreeCtx <|
         createImportedDiscrTree cNGen (← getEnv) addEntry constantsPerTask capacityPerTask
   let (importCandidates, importTree) ← getMatch importTree ty false false
   ref.set (some importTree)
-  MonadExcept.ofExcept importCandidates
+  return importCandidates
 
 /-- Returns candidates from this module that match the expression. -/
 def findModuleMatches (moduleRef : ModuleDiscrTreeRef α) (ty : Expr) : MetaM (MatchResult α) := do
@@ -135,7 +133,7 @@ def findModuleMatches (moduleRef : ModuleDiscrTreeRef α) (ty : Expr) : MetaM (M
     let discrTree ← moduleRef.ref.get
     let (localCandidates, localTree) ← getMatch discrTree ty false false
     moduleRef.ref.set localTree
-    MonadExcept.ofExcept localCandidates
+    return localCandidates
 
 /--
 `findMatches` combines `findImportMatches` and `findModuleMatches`.

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Lookup.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Lookup.lean
@@ -41,9 +41,9 @@ private abbrev TreeM α := StateRefT (Array (Trie α)) MetaM
 
 /-- Run a `TreeM` computation using `d : RefinedDiscrTree`, without losing the reference to `d`. -/
 @[inline] private def runTreeM (d : RefinedDiscrTree α) (m : TreeM α β) :
-    MetaM (Except Exception β × RefinedDiscrTree α) := do
+    MetaM (β × RefinedDiscrTree α) := do
   let { tries, root } := d
-  let (result, tries) ← (try Except.ok <$> m catch ex => pure (.error ex)).run tries
+  let (result, tries) ← m.run tries
   pure (result, { tries, root })
 
 private def setTrie (i : TrieIndex) (v : Trie α) : TreeM α Unit :=
@@ -269,12 +269,9 @@ Find values that match `e` in `d`.
 * If `unify == true` then metavariables in `e` can be assigned.
 * If `matchRootStar == true` then we allow metavariables at the root to unify.
   Set this to `false` to avoid getting excessively many results.
-
-Note: to preserve the reference to `d`, `getMatch` will never throw an error,
-and instead it returns an `Except Exception (MatchResult α)`.
 -/
 def getMatch (d : RefinedDiscrTree α) (e : Expr) (unify matchRootStar : Bool) :
-    MetaM (Except Exception (MatchResult α) × RefinedDiscrTree α) := do
+    MetaM (MatchResult α × RefinedDiscrTree α) := do
   withReducible do runTreeM d do
     let (key, keys) ← encodeExpr e (labelledStars := false)
     let pMatch : PartialMatch := { keys, score := 0, trie := default }

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -243,7 +243,7 @@ def getTransitionTheorems (e : Expr) : FunPropM (Array GeneralTheorem) := do
   let (candidates, thms) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
     thms.getMatch e false true
   modify ({ · with transitionTheorems := ⟨thms⟩ })
-  return (← MonadExcept.ofExcept candidates).toArray
+  return candidates.toArray
 
 /-- Environment extension for morphism theorems. -/
 initialize morTheoremsExt : GeneralTheoremsExt ←
@@ -265,7 +265,7 @@ def getMorphismTheorems (e : Expr) : FunPropM (Array GeneralTheorem) := do
   let (candidates, thms) ← withConfig (fun cfg => { cfg with iota := false, zeta := false }) <|
     thms.getMatch e false true
   modify ({ · with morTheorems := ⟨thms⟩ })
-  return (← MonadExcept.ofExcept candidates).toArray
+  return candidates.toArray
 
 
 --------------------------------------------------------------------------------

--- a/Mathlib/Tactic/Widget/LibraryRewrite.lean
+++ b/Mathlib/Tactic/Widget/LibraryRewrite.lean
@@ -283,7 +283,7 @@ def getHypotheses (except : Option FVarId) : MetaM (RefinedDiscrTree (FVarId × 
 def getHypothesisRewrites (e : Expr) (except : Option FVarId) :
     MetaM (Array (Array (Rewrite × FVarId))) := do
   let (candidates, _) ← (← getHypotheses except).getMatch e (unify := false) (matchRootStar := true)
-  let candidates := (← MonadExcept.ofExcept candidates).flatten
+  let candidates := candidates.flatten
   candidates.mapM <| Array.filterMapM fun (fvarId, symm) =>
     tryCatchRuntimeEx do
       Option.map (·, fvarId) <$> checkRewrite (.fvar fvarId) e symm


### PR DESCRIPTION
This PR removes the awkward handling of exceptions in `getMatch`. The reasoning originally was that I wanted to allow in-place mutations in the trie array. But this is not possible anyways, because it lives in a multi-threaded ref, so it cannot be used linearly. See also https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/.5Bcache.5D.20attribute/near/576556138

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
