### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/UnitaryGroup): {Kronecker} tensor product of unitaries is a unitary

### DIFF
--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -121,6 +121,8 @@ theorem kroneckerTMul_mem_unitary {m : Type*} [Fintype m] [DecidableEq m] {U : M
   simp_rw [Unitary.mem_iff, star_eq_conjTranspose] at hU hV ⊢
   simp [conjTranspose_kroneckerTMul, ← mul_kroneckerTMul_mul, hU, hV]
 
+end TensorProduct
+
 namespace UnitaryGroup
 
 instance coeMatrix : Coe (unitaryGroup n α) (Matrix n n α) :=

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -105,6 +105,15 @@ theorem kronecker_mem_unitary {R m : Type*} [Semiring R] [StarRing R] [Fintype m
       ite_mul, zero_mul, Finset.sum_ite_irrel, ← Matrix.mul_apply, hU₁.2, Matrix.one_apply,
       Finset.sum_const_zero, ← ite_and, and_comm, Prod.eq_iff_fst_eq_snd_eq]
 
+open scoped Kronecker TensorProduct in
+theorem Matrix.kroneckerTMul_mem_unitary {R A B m : Type*} [Fintype m] [DecidableEq m]
+    [CommSemiring R] [StarRing R] [Semiring A] [Semiring B] [StarRing A] [StarRing B] [Algebra R A]
+    [Algebra R B] [StarModule R A] [StarModule R B] {U : Matrix m m A} {V : Matrix n n B}
+    (hU : U ∈ unitary (Matrix m m A)) (hV : V ∈ unitary (Matrix n n B)) :
+    U ⊗ₖₜ[R] V ∈ unitary (Matrix (m × n) (m × n) (A ⊗[R] B)) := by
+  simp_rw [Unitary.mem_iff, star_eq_conjTranspose] at hU hV ⊢
+  simp [conjTranspose_kroneckerTMul, ← mul_kroneckerTMul_mul, hU, hV]
+
 namespace UnitaryGroup
 
 instance coeMatrix : Coe (unitaryGroup n α) (Matrix n n α) :=

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -105,11 +105,17 @@ theorem kronecker_mem_unitary {R m : Type*} [Semiring R] [StarRing R] [Fintype m
       ite_mul, zero_mul, Finset.sum_ite_irrel, ← Matrix.mul_apply, hU₁.2, Matrix.one_apply,
       Finset.sum_const_zero, ← ite_and, and_comm, Prod.eq_iff_fst_eq_snd_eq]
 
-open scoped Kronecker TensorProduct in
-theorem kroneckerTMul_mem_unitary {R A B m : Type*} [Fintype m] [DecidableEq m]
-    [CommSemiring R] [StarRing R] [Semiring A] [Semiring B] [StarRing A] [StarRing B] [Algebra R A]
-    [Algebra R B] [StarModule R A] [StarModule R B] {U : Matrix m m A} {V : Matrix n n B}
-    (hU : U ∈ unitary (Matrix m m A)) (hV : V ∈ unitary (Matrix n n B)) :
+section TensorProduct
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A] [Algebra R B]
+  [StarRing A] [StarRing B] [StarRing R] [StarModule R A] [StarModule R B]
+
+open scoped TensorProduct Kronecker
+
+theorem _root_.Unitary.tmul_mem {U : A} {V : B} (hU : U ∈ unitary A) (hV : V ∈ unitary B) :
+    U ⊗ₜ[R] V ∈ unitary (A ⊗[R] B) := by simp [mem_iff, hU, hV, Algebra.TensorProduct.one_def]
+
+theorem kroneckerTMul_mem_unitary {m : Type*} [Fintype m] [DecidableEq m] {U : Matrix m m A}
+    {V : Matrix n n B} (hU : U ∈ unitary (Matrix m m A)) (hV : V ∈ unitary (Matrix n n B)) :
     U ⊗ₖₜ[R] V ∈ unitary (Matrix (m × n) (m × n) (A ⊗[R] B)) := by
   simp_rw [Unitary.mem_iff, star_eq_conjTranspose] at hU hV ⊢
   simp [conjTranspose_kroneckerTMul, ← mul_kroneckerTMul_mul, hU, hV]

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -112,7 +112,8 @@ variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A
 open scoped TensorProduct Kronecker
 
 theorem _root_.Unitary.tmul_mem {U : A} {V : B} (hU : U ∈ unitary A) (hV : V ∈ unitary B) :
-    U ⊗ₜ[R] V ∈ unitary (A ⊗[R] B) := by simp [mem_iff, hU, hV, Algebra.TensorProduct.one_def]
+    U ⊗ₜ[R] V ∈ unitary (A ⊗[R] B) := by
+  simp [Unitary.mem_iff, hU, hV, Algebra.TensorProduct.one_def]
 
 theorem kroneckerTMul_mem_unitary {m : Type*} [Fintype m] [DecidableEq m] {U : Matrix m m A}
     {V : Matrix n n B} (hU : U ∈ unitary (Matrix m m A)) (hV : V ∈ unitary (Matrix n n B)) :

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -106,7 +106,7 @@ theorem kronecker_mem_unitary {R m : Type*} [Semiring R] [StarRing R] [Fintype m
       Finset.sum_const_zero, ← ite_and, and_comm, Prod.eq_iff_fst_eq_snd_eq]
 
 open scoped Kronecker TensorProduct in
-theorem Matrix.kroneckerTMul_mem_unitary {R A B m : Type*} [Fintype m] [DecidableEq m]
+theorem kroneckerTMul_mem_unitary {R A B m : Type*} [Fintype m] [DecidableEq m]
     [CommSemiring R] [StarRing R] [Semiring A] [Semiring B] [StarRing A] [StarRing B] [Algebra R A]
     [Algebra R B] [StarModule R A] [StarModule R B] {U : Matrix m m A} {V : Matrix n n B}
     (hU : U ∈ unitary (Matrix m m A)) (hV : V ∈ unitary (Matrix n n B)) :

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Algebra.Operations
 public import Mathlib.Algebra.Star.TensorProduct
-public import Mathlib.Algebra.Star.Unitary
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import Mathlib.RingTheory.Adjoin.Basic
 
@@ -752,9 +751,6 @@ noncomputable instance : StarMul (A ⊗[R] B) where
 
 noncomputable instance : StarRing (A ⊗[R] B) where
   star_add := by simp
-
-theorem _root_.Unitary.tmul_mem {U : A} {V : B} (hU : U ∈ unitary A) (hV : V ∈ unitary B) :
-    U ⊗ₜ[R] V ∈ unitary (A ⊗[R] B) := by simp [mem_iff, hU, hV, Algebra.TensorProduct.one_def]
 
 end TensorProduct
 

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Algebra.Operations
 public import Mathlib.Algebra.Star.TensorProduct
+public import Mathlib.Algebra.Star.Unitary
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import Mathlib.RingTheory.Adjoin.Basic
 
@@ -751,6 +752,9 @@ noncomputable instance : StarMul (A ⊗[R] B) where
 
 noncomputable instance : StarRing (A ⊗[R] B) where
   star_add := by simp
+
+theorem _root_.Unitary.tmul_mem {U : A} {V : B} (hU : U ∈ unitary A) (hV : V ∈ unitary B) :
+    U ⊗ₜ[R] V ∈ unitary (A ⊗[R] B) := by simp [mem_iff, hU, hV, Algebra.TensorProduct.one_def]
 
 end TensorProduct
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
