### PR TITLE
[Merged by Bors] - feat: generalize rank_submatrix_le to arbitrary column maps

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -223,8 +223,9 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
 /-- Taking a subset of the rows and columns reduces the rank. -/
-theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (r : m₀ → m) (c : n₀ → n) (A : Matrix m n R) :
+theorem rank_submatrix_le [Fintype n₀] (A : Matrix m n R) (r : m₀ → m) (c : n₀ → n) :
     (A.submatrix r c).rank ≤ A.rank := by
+  nontriviality R
   have := Module.Finite.span_of_finite R (Set.finite_range (A.submatrix r id).col)
   calc
     _ = (((A.submatrix r id)ᵀᵀ.submatrix id c)ᵀᵀ).rank := by simp

--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -222,13 +222,23 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   have hAB : mulVecLin (A * B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
-omit [Fintype n] in
-/-- Taking a subset of the rows and permuting the columns reduces the rank. -/
-theorem rank_submatrix_le [Nontrivial R] [Fintype m] [Fintype m₀] (f : n₀ → n) (e : m₀ ≃ m)
-    (A : Matrix n m R) : rank (A.submatrix f e) ≤ rank A := by
+/-- Taking a subset of the rows and columns reduces the rank. -/
+theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (A : Matrix m n R) (r : m₀ → m) (c : n₀ → n) :
+    (A.submatrix r c).rank ≤ A.rank := by
+  have h : (A.submatrix r c).rank ≤ (A.submatrix r ⇑(Equiv.refl n)).rank := by
+    rw [show (A.submatrix r c).rank = ((A.submatrix r (Equiv.refl n)).submatrix id c).rank by rfl]
+    set B := A.submatrix r (Equiv.refl n)
+    rw [show (B.submatrix id c) = (B.submatrix id c)ᵀᵀ by rw[transpose_transpose],
+      show B = Bᵀᵀ by rw[transpose_transpose], rank, rank, Matrix.mulVecLin_transpose,
+      Matrix.mulVecLin_transpose, Matrix.transpose_submatrix, transpose_transpose,
+      range_vecMulLinear, range_vecMulLinear, ← Matrix.transpose_submatrix, row_transpose,
+      row_transpose]
+    haveI := Module.Finite.span_of_finite R (Set.finite_range B.col)
+    exact Submodule.finrank_mono (Submodule.span_mono (fun v ⟨j, hj⟩ => ⟨c j, hj⟩))
+  apply le_trans h ?_
   rw [rank, rank, mulVecLin_submatrix, LinearMap.range_comp, LinearMap.range_comp,
-    show LinearMap.funLeft R R e.symm = LinearEquiv.funCongrLeft R R e.symm from rfl,
-    LinearEquiv.range, Submodule.map_top]
+    show LinearMap.funLeft R R (Equiv.refl n).symm =
+    LinearEquiv.funCongrLeft R R (Equiv.refl n).symm by rfl, LinearEquiv.range, Submodule.map_top]
   exact Submodule.finrank_map_le _ _
 
 theorem rank_reindex [Fintype n₀] (em : m ≃ m₀) (en : n ≃ n₀) (A : Matrix m n R) :

--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -225,20 +225,20 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
 /-- Taking a subset of the rows and columns reduces the rank. -/
 theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (r : m₀ → m) (c : n₀ → n) (A : Matrix m n R) :
     (A.submatrix r c).rank ≤ A.rank := by
-  have h : (A.submatrix r c).rank ≤ (A.submatrix r (Equiv.refl n)).rank := by
-    rw [show (A.submatrix r c).rank = ((A.submatrix r (Equiv.refl n)).submatrix id c).rank by rfl]
-    set B := A.submatrix r (Equiv.refl n)
-    rw [show (B.submatrix id c) = (B.submatrix id c)ᵀᵀ by rw[transpose_transpose],
-      show B = Bᵀᵀ by rw[transpose_transpose], rank, rank, Matrix.mulVecLin_transpose,
-      Matrix.mulVecLin_transpose, Matrix.transpose_submatrix, transpose_transpose,
-      range_vecMulLinear, range_vecMulLinear, ← Matrix.transpose_submatrix, row_transpose,
-      row_transpose]
-    haveI := Module.Finite.span_of_finite R (Set.finite_range B.col)
-    exact Submodule.finrank_mono (Submodule.span_mono (fun v ⟨j, hj⟩ => ⟨c j, hj⟩))
-  apply le_trans h
+  have := Module.Finite.span_of_finite R (Set.finite_range (A.submatrix r id).col)
+  calc
+    _ = (((A.submatrix r id)ᵀᵀ.submatrix id c)ᵀᵀ).rank := by simp
+    _ ≤ finrank R (span R (range (A.submatrix r id).col)) := by
+      rw [rank, Matrix.mulVecLin_transpose, Matrix.transpose_submatrix, transpose_transpose,
+        range_vecMulLinear, ← Matrix.transpose_submatrix, row_transpose]
+      exact Submodule.finrank_mono (Submodule.span_mono (fun v ⟨j, hj⟩ => ⟨c j, hj⟩))
+    _ = (A.submatrix r id)ᵀᵀ.rank := by
+      rw [rank, Matrix.mulVecLin_transpose, range_vecMulLinear]
+      rfl
+    _ = (A.submatrix r (Equiv.refl n)).rank := by simp
   rw [rank, rank, mulVecLin_submatrix, LinearMap.range_comp, LinearMap.range_comp,
-    show LinearMap.funLeft R R (Equiv.refl n).symm =
-    LinearEquiv.funCongrLeft R R (Equiv.refl n).symm by rfl, LinearEquiv.range, Submodule.map_top]
+    show LinearMap.funLeft R R (Equiv.refl n).symm = LinearEquiv.funCongrLeft R R
+      (Equiv.refl n).symm from rfl, LinearEquiv.range, Submodule.map_top]
   exact Submodule.finrank_map_le _ _
 
 theorem rank_reindex [Fintype n₀] (em : m ≃ m₀) (en : n ≃ n₀) (A : Matrix m n R) :

--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -223,9 +223,9 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
 /-- Taking a subset of the rows and columns reduces the rank. -/
-theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (A : Matrix m n R) (r : m₀ → m) (c : n₀ → n) :
+theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (r : m₀ → m) (c : n₀ → n) (A : Matrix m n R) :
     (A.submatrix r c).rank ≤ A.rank := by
-  have h : (A.submatrix r c).rank ≤ (A.submatrix r ⇑(Equiv.refl n)).rank := by
+  have h : (A.submatrix r c).rank ≤ (A.submatrix r (Equiv.refl n)).rank := by
     rw [show (A.submatrix r c).rank = ((A.submatrix r (Equiv.refl n)).submatrix id c).rank by rfl]
     set B := A.submatrix r (Equiv.refl n)
     rw [show (B.submatrix id c) = (B.submatrix id c)ᵀᵀ by rw[transpose_transpose],
@@ -235,7 +235,7 @@ theorem rank_submatrix_le [Nontrivial R] [Fintype n₀] (A : Matrix m n R) (r : 
       row_transpose]
     haveI := Module.Finite.span_of_finite R (Set.finite_range B.col)
     exact Submodule.finrank_mono (Submodule.span_mono (fun v ⟨j, hj⟩ => ⟨c j, hj⟩))
-  apply le_trans h ?_
+  apply le_trans h
   rw [rank, rank, mulVecLin_submatrix, LinearMap.range_comp, LinearMap.range_comp,
     show LinearMap.funLeft R R (Equiv.refl n).symm =
     LinearEquiv.funCongrLeft R R (Equiv.refl n).symm by rfl, LinearEquiv.range, Submodule.map_top]


### PR DESCRIPTION
This PR generalizes `rank_submatrix_le` to allow an arbitrary function on columns
instead of requiring an `Equiv`. The previous version required `e : m₀ ≃ m` and
`[Fintype m]`, while this version only requires `c : n₀ → n` and `[Fintype n₀]`.
The previous version can be recovered as a special case of the new one.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
