### PR TITLE
[Merged by Bors] - doc(Algebra): fix typos

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Colimits.lean
@@ -168,7 +168,7 @@ def finsuppCocone : Cofan fun _ : ι ↦ ModuleCat.of R M :=
     ModuleCat.ofHom (Finsupp.lsingle i (R := R) (M := ModuleCat.of R M))
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The concrete cocoproduct cone is colimiting. -/
+/-- The concrete coproduct cone is colimiting. -/
 noncomputable
 def finsuppCoconeIsColimit : IsColimit (finsuppCocone R M ι) where
   desc s := ModuleCat.ofHom <| Finsupp.lsum R (N := s.pt) (fun i ↦ (s.ι.app ⟨i⟩).hom)

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -32,7 +32,7 @@ namespace LieAlgebra
 
 /--
 The semi-direct sum of two Lie algebras `K` and `L` over `R`, relative to a Lie algebra homomorphism
-`ψ: L → Liederivation R K K`. As a set it just `K × L`, however the Lie bracket is twisted by `ψ`.
+`ψ: L → LieDerivation R K K`. As a set it is just `K × L`, however the Lie bracket is twisted by `ψ`.
 -/
 @[ext] structure SemiDirectSum {R : Type*} [CommRing R] (K : Type*) [LieRing K] [LieAlgebra R K]
     (L : Type*) [LieRing L] [LieAlgebra R L] (_ : L →ₗ⁅R⁆ LieDerivation R K K) where

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -32,7 +32,7 @@ namespace LieAlgebra
 
 /--
 The semi-direct sum of two Lie algebras `K` and `L` over `R`, relative to a Lie algebra homomorphism
-`ψ: L → LieDerivation R K K`. As a set it is just `K × L`, however the Lie bracket is twisted by `ψ`.
+`ψ: L → LieDerivation R K K`. As a set, it is just `K × L`, however the Lie bracket is twisted by `ψ`.
 -/
 @[ext] structure SemiDirectSum {R : Type*} [CommRing R] (K : Type*) [LieRing K] [LieAlgebra R K]
     (L : Type*) [LieRing L] [LieAlgebra R L] (_ : L →ₗ⁅R⁆ LieDerivation R K K) where

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -32,7 +32,8 @@ namespace LieAlgebra
 
 /--
 The semi-direct sum of two Lie algebras `K` and `L` over `R`, relative to a Lie algebra homomorphism
-`ψ: L → LieDerivation R K K`. As a set, it is just `K × L`, however the Lie bracket is twisted by `ψ`.
+`ψ: L → LieDerivation R K K`. As a set, it is just `K × L`, however the Lie bracket is twisted by
+`ψ`.
 -/
 @[ext] structure SemiDirectSum {R : Type*} [CommRing R] (K : Type*) [LieRing K] [LieAlgebra R K]
     (L : Type*) [LieRing L] [LieAlgebra R L] (_ : L →ₗ⁅R⁆ LieDerivation R K K) where

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -329,7 +329,7 @@ open Algebra.TensorProduct MvPolynomial in
 
 Proof strategy:
 1. Rewrite `polyCharpolyAux` as the (honest, ordinary) characteristic polynomial
-   of the basechange of `φ` to the multivariate polynomial ring `MvPolynomial ι R`.
+   of the base change of `φ` to the multivariate polynomial ring `MvPolynomial ι R`.
 2. Use that the characteristic polynomial of a linear map is independent of the choice of basis.
    This independence result is used transitively via
    `LinearMap.polyCharpolyAux_map_aeval` and `LinearMap.polyCharpolyAux_map_eq_charpoly`. -/

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -332,7 +332,8 @@ Proof strategy:
    of the base change of `φ` to the multivariate polynomial ring `MvPolynomial ι R`.
 2. Use that the characteristic polynomial of a linear map is independent of the choice of basis.
    This independence result is used transitively via
-   `LinearMap.polyCharpolyAux_map_aeval` and `LinearMap.polyCharpolyAux_map_eq_charpoly`. -/
+   `LinearMap.polyCharpolyAux_map_aeval` and `LinearMap.polyCharpolyAux_map_eq_charpoly`.
+-/
 lemma polyCharpolyAux_basisIndep {ιM' : Type*} [Fintype ιM'] [DecidableEq ιM']
     (bₘ' : Basis ιM' R M) :
     polyCharpolyAux φ b bₘ = polyCharpolyAux φ b bₘ' := by

--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -136,7 +136,7 @@ def AddCommMonoid.uniqueNatModule : Unique (Module ℕ M) where
   default := inferInstance
   uniq P := (Module.ext' P _) fun n => by convert nat_smul_eq_nsmul P n
 
-/-- All `ℕ`-module structures are equal. See also `AddCommMoniod.uniqueNatModule`. -/
+/-- All `ℕ`-module structures are equal. See also `AddCommMonoid.uniqueNatModule`. -/
 instance AddCommMonoid.subsingletonNatModule : Subsingleton (Module ℕ M) :=
   AddCommMonoid.uniqueNatModule.instSubsingleton
 

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -19,9 +19,9 @@ predicate is called `IsSMulRegular`.
 There are very limited typeclass assumptions on `R` and `M`, but the "mathematical" case of interest
 is a commutative ring `R` acting on a module `M`. Since the properties are "multiplicative", there
 is no actual requirement of having an addition, but there is a zero in both `R` and `M`.
-SMultiplications involving `0` are, of course, all trivial.
+Scalar multiplications involving `0` are, of course, all trivial.
 
-The defining property is that an element `a ∈ R` is `M`-regular if the smultiplication map
+The defining property is that an element `a ∈ R` is `M`-regular if the scalar multiplication map
 `M → M`, defined by `m ↦ a • m`, is injective.
 
 This property is the direct generalization to modules of the property `IsLeftRegular` defined in

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -55,9 +55,9 @@ variable {F M N R α : Type*}
 
 /-- The type of centroid homomorphisms from `α` to `α`. -/
 structure CentroidHom (α : Type*) [NonUnitalNonAssocSemiring α] extends α →+ α where
-  /-- Commutativity of centroid homomorphims with left multiplication. -/
+  /-- Commutativity of centroid homomorphisms with left multiplication. -/
   map_mul_left' (a b : α) : toFun (a * b) = a * toFun b
-  /-- Commutativity of centroid homomorphims with right multiplication. -/
+  /-- Commutativity of centroid homomorphisms with right multiplication. -/
   map_mul_right' (a b : α) : toFun (a * b) = toFun a * b
 
 attribute [nolint docBlame] CentroidHom.toAddMonoidHom
@@ -67,9 +67,9 @@ attribute [nolint docBlame] CentroidHom.toAddMonoidHom
 You should extend this class when you extend `CentroidHom`. -/
 class CentroidHomClass (F : Type*) (α : outParam Type*)
     [NonUnitalNonAssocSemiring α] [FunLike F α α] : Prop extends AddMonoidHomClass F α α where
-  /-- Commutativity of centroid homomorphims with left multiplication. -/
+  /-- Commutativity of centroid homomorphisms with left multiplication. -/
   map_mul_left (f : F) (a b : α) : f (a * b) = a * f b
-  /-- Commutativity of centroid homomorphims with right multiplication. -/
+  /-- Commutativity of centroid homomorphisms with right multiplication. -/
   map_mul_right (f : F) (a b : α) : f (a * b) = f a * b
 
 


### PR DESCRIPTION
We fix some typos flagged by `PyCharm`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
