### PR TITLE
[Merged by Bors] - chore(Order/Lattice): use `to_dual` for lemmas about `Monotone`

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -686,72 +686,47 @@ end Function
 namespace Monotone
 
 /-- Pointwise supremum of two monotone functions is a monotone function. -/
+@[to_dual /-- Pointwise infimum of two monotone functions is a monotone function. -/]
 protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} (hf : Monotone f)
     (hg : Monotone g) :
     Monotone (f ⊔ g) := fun _ _ h => sup_le_sup (hf h) (hg h)
 
-/-- Pointwise infimum of two monotone functions is a monotone function. -/
-protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} (hf : Monotone f)
-    (hg : Monotone g) :
-    Monotone (f ⊓ g) := fun _ _ h => inf_le_inf (hf h) (hg h)
-
 /-- Pointwise maximum of two monotone functions is a monotone function. -/
+@[to_dual /-- Pointwise minimum of two monotone functions is a monotone function. -/]
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} (hf : Monotone f)
     (hg : Monotone g) :
     Monotone fun x => max (f x) (g x) :=
   hf.sup hg
 
-/-- Pointwise minimum of two monotone functions is a monotone function. -/
-protected theorem min [Preorder α] [LinearOrder β] {f g : α → β} (hf : Monotone f)
-    (hg : Monotone g) :
-    Monotone fun x => min (f x) (g x) :=
-  hf.inf hg
-
+@[to_dual map_inf_le]
 theorem le_map_sup [SemilatticeSup α] [SemilatticeSup β] {f : α → β} (h : Monotone f) (x y : α) :
     f x ⊔ f y ≤ f (x ⊔ y) :=
   sup_le (h le_sup_left) (h le_sup_right)
 
-@[to_dual existing le_map_sup]
-theorem map_inf_le [SemilatticeInf α] [SemilatticeInf β] {f : α → β} (h : Monotone f) (x y : α) :
-    f (x ⊓ y) ≤ f x ⊓ f y :=
-  le_inf (h inf_le_left) (h inf_le_right)
-
-theorem of_map_inf_le_left [SemilatticeInf α] [Preorder β] {f : α → β}
-    (h : ∀ x y, f (x ⊓ y) ≤ f x) : Monotone f := by
+@[to_dual of_map_inf_le_left]
+theorem of_left_le_map_sup [SemilatticeSup α] [Preorder β] {f : α → β}
+    (h : ∀ x y, f x ≤ f (x ⊔ y)) : Monotone f := by
   intro x y hxy
-  rw [← inf_eq_right.2 hxy]
+  rw [← sup_eq_right.2 hxy]
   apply h
 
-theorem of_map_inf_le [SemilatticeInf α] [SemilatticeInf β] {f : α → β}
-    (h : ∀ x y, f (x ⊓ y) ≤ f x ⊓ f y) : Monotone f :=
-  of_map_inf_le_left fun x y ↦ (h x y).trans inf_le_left
-
-theorem of_map_inf [SemilatticeInf α] [SemilatticeInf β] {f : α → β}
-    (h : ∀ x y, f (x ⊓ y) = f x ⊓ f y) : Monotone f :=
-  of_map_inf_le fun x y ↦ (h x y).le
-
-theorem of_left_le_map_sup [SemilatticeSup α] [Preorder β] {f : α → β}
-    (h : ∀ x y, f x ≤ f (x ⊔ y)) : Monotone f :=
-  monotone_dual_iff.1 <| of_map_inf_le_left h
-
+@[to_dual of_map_inf_le]
 theorem of_le_map_sup [SemilatticeSup α] [SemilatticeSup β] {f : α → β}
     (h : ∀ x y, f x ⊔ f y ≤ f (x ⊔ y)) : Monotone f :=
-  monotone_dual_iff.mp <| of_map_inf_le h
+  of_left_le_map_sup fun x y ↦ le_sup_left.trans (h x y)
 
+@[to_dual]
 theorem of_map_sup [SemilatticeSup α] [SemilatticeSup β] {f : α → β}
     (h : ∀ x y, f (x ⊔ y) = f x ⊔ f y) : Monotone f :=
-  (@of_map_inf (OrderDual α) (OrderDual β) _ _ _ h).dual
+  of_le_map_sup fun x y ↦ (h x y).ge
 
 variable [LinearOrder α]
 
+@[to_dual]
 theorem map_sup [SemilatticeSup β] {f : α → β} (hf : Monotone f) (x y : α) :
     f (x ⊔ y) = f x ⊔ f y :=
   (Std.Total.total x y).elim (fun h : x ≤ y => by simp only [h, hf h, sup_of_le_right]) fun h => by
     simp only [h, hf h, sup_of_le_left]
-
-theorem map_inf [SemilatticeInf β] {f : α → β} (hf : Monotone f) (x y : α) :
-    f (x ⊓ y) = f x ⊓ f y :=
-  hf.dual.map_sup _ _
 
 end Monotone
 
@@ -769,35 +744,25 @@ namespace MonotoneOn
 variable {f : α → β} {s : Set α} {x y : α}
 
 /-- Pointwise supremum of two monotone functions is a monotone function. -/
+@[to_dual /-- Pointwise infimum of two monotone functions is a monotone function. -/]
 protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} {s : Set α}
     (hf : MonotoneOn f s) (hg : MonotoneOn g s) : MonotoneOn (f ⊔ g) s :=
   fun _ hx _ hy h => sup_le_sup (hf hx hy h) (hg hx hy h)
 
-/-- Pointwise infimum of two monotone functions is a monotone function. -/
-protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} {s : Set α}
-    (hf : MonotoneOn f s) (hg : MonotoneOn g s) : MonotoneOn (f ⊓ g) s :=
-  (hf.dual.sup hg.dual).dual
-
 /-- Pointwise maximum of two monotone functions is a monotone function. -/
+@[to_dual /-- Pointwise minimum of two monotone functions is a monotone function. -/]
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : MonotoneOn f s)
     (hg : MonotoneOn g s) : MonotoneOn (fun x => max (f x) (g x)) s :=
   hf.sup hg
 
-/-- Pointwise minimum of two monotone functions is a monotone function. -/
-protected theorem min [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : MonotoneOn f s)
-    (hg : MonotoneOn g s) : MonotoneOn (fun x => min (f x) (g x)) s :=
-  hf.inf hg
-
-theorem of_map_inf [SemilatticeInf α] [SemilatticeInf β]
-    (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊓ y) = f x ⊓ f y) : MonotoneOn f s := fun x hx y hy hxy =>
-  inf_eq_left.1 <| by rw [← h _ hx _ hy, inf_eq_left.2 hxy]
-
+@[to_dual]
 theorem of_map_sup [SemilatticeSup α] [SemilatticeSup β]
-    (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊔ y) = f x ⊔ f y) : MonotoneOn f s :=
-  (@of_map_inf αᵒᵈ βᵒᵈ _ _ _ _ h).dual
+    (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊔ y) = f x ⊔ f y) : MonotoneOn f s := fun x hx y hy hxy =>
+  sup_eq_right.1 <| by rw [← h _ hx _ hy, sup_eq_right.2 hxy]
 
 variable [LinearOrder α]
 
+@[to_dual]
 theorem map_sup [SemilatticeSup β] (hf : MonotoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
     f (x ⊔ y) = f x ⊔ f y := by
   cases le_total x y <;> have := hf ?_ ?_ ‹_› <;>
@@ -805,53 +770,34 @@ theorem map_sup [SemilatticeSup β] (hf : MonotoneOn f s) (hx : x ∈ s) (hy : y
     | assumption
     | simp only [*, sup_of_le_left, sup_of_le_right]
 
-theorem map_inf [SemilatticeInf β] (hf : MonotoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
-    f (x ⊓ y) = f x ⊓ f y :=
-  hf.dual.map_sup hx hy
-
 end MonotoneOn
 
 namespace Antitone
 
-/-- Pointwise supremum of two monotone functions is a monotone function. -/
+/-- Pointwise supremum of two antitone functions is an antitone function. -/
+@[to_dual /-- Pointwise infimum of two antitone functions is an antitone function. -/]
 protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} (hf : Antitone f)
     (hg : Antitone g) :
     Antitone (f ⊔ g) := fun _ _ h => sup_le_sup (hf h) (hg h)
 
-/-- Pointwise infimum of two monotone functions is a monotone function. -/
-protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} (hf : Antitone f)
-    (hg : Antitone g) :
-    Antitone (f ⊓ g) := fun _ _ h => inf_le_inf (hf h) (hg h)
-
-/-- Pointwise maximum of two monotone functions is a monotone function. -/
+/-- Pointwise maximum of two antitone functions is an antitone function. -/
+@[to_dual /-- Pointwise minimum of two antitone functions is an antitone function. -/]
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} (hf : Antitone f)
     (hg : Antitone g) :
     Antitone fun x => max (f x) (g x) :=
   hf.sup hg
 
-/-- Pointwise minimum of two monotone functions is a monotone function. -/
-protected theorem min [Preorder α] [LinearOrder β] {f g : α → β} (hf : Antitone f)
-    (hg : Antitone g) :
-    Antitone fun x => min (f x) (g x) :=
-  hf.inf hg
-
+@[to_dual le_map_inf]
 theorem map_sup_le [SemilatticeSup α] [SemilatticeInf β] {f : α → β} (h : Antitone f) (x y : α) :
     f (x ⊔ y) ≤ f x ⊓ f y :=
   h.dual_right.le_map_sup x y
 
-theorem le_map_inf [SemilatticeInf α] [SemilatticeSup β] {f : α → β} (h : Antitone f) (x y : α) :
-    f x ⊔ f y ≤ f (x ⊓ y) :=
-  h.dual_right.map_inf_le x y
-
 variable [LinearOrder α]
 
+@[to_dual]
 theorem map_sup [SemilatticeInf β] {f : α → β} (hf : Antitone f) (x y : α) :
     f (x ⊔ y) = f x ⊓ f y :=
   hf.dual_right.map_sup x y
-
-theorem map_inf [SemilatticeSup β] {f : α → β} (hf : Antitone f) (x y : α) :
-    f (x ⊓ y) = f x ⊔ f y :=
-  hf.dual_right.map_inf x y
 
 end Antitone
 
@@ -868,45 +814,31 @@ namespace AntitoneOn
 variable {f : α → β} {s : Set α} {x y : α}
 
 /-- Pointwise supremum of two antitone functions is an antitone function. -/
+@[to_dual /-- Pointwise infimum of two antitone functions is an antitone function. -/]
 protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} {s : Set α}
     (hf : AntitoneOn f s) (hg : AntitoneOn g s) : AntitoneOn (f ⊔ g) s :=
   fun _ hx _ hy h => sup_le_sup (hf hx hy h) (hg hx hy h)
 
-/-- Pointwise infimum of two antitone functions is an antitone function. -/
-protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} {s : Set α}
-    (hf : AntitoneOn f s) (hg : AntitoneOn g s) : AntitoneOn (f ⊓ g) s :=
-  (hf.dual.sup hg.dual).dual
-
 /-- Pointwise maximum of two antitone functions is an antitone function. -/
+@[to_dual /-- Pointwise minimum of two antitone functions is an antitone function. -/]
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : AntitoneOn f s)
     (hg : AntitoneOn g s) : AntitoneOn (fun x => max (f x) (g x)) s :=
   hf.sup hg
 
-/-- Pointwise minimum of two antitone functions is an antitone function. -/
-protected theorem min [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : AntitoneOn f s)
-    (hg : AntitoneOn g s) : AntitoneOn (fun x => min (f x) (g x)) s :=
-  hf.inf hg
-
+@[to_dual]
 theorem of_map_inf [SemilatticeInf α] [SemilatticeSup β]
     (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊓ y) = f x ⊔ f y) : AntitoneOn f s := fun x hx y hy hxy =>
   sup_eq_left.1 <| by rw [← h _ hx _ hy, inf_eq_left.2 hxy]
 
-theorem of_map_sup [SemilatticeSup α] [SemilatticeInf β]
-    (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊔ y) = f x ⊓ f y) : AntitoneOn f s :=
-  (@of_map_inf αᵒᵈ βᵒᵈ _ _ _ _ h).dual
-
 variable [LinearOrder α]
 
+@[to_dual]
 theorem map_sup [SemilatticeInf β] (hf : AntitoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
     f (x ⊔ y) = f x ⊓ f y := by
   cases le_total x y <;> have := hf ?_ ?_ ‹_› <;>
     first
     | assumption
     | simp only [*, sup_of_le_left, sup_of_le_right, inf_of_le_left, inf_of_le_right]
-
-theorem map_inf [SemilatticeSup β] (hf : AntitoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
-    f (x ⊓ y) = f x ⊔ f y :=
-  hf.dual.map_sup hx hy
 
 end AntitoneOn
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
