### PR TITLE
[Merged by Bors] - feat(Order/Lattice): add `DistribLattice` instance for subtype

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -930,6 +930,16 @@ theorem mk_sup_mk [SemilatticeSup α] {P : α → Prop}
       ⟨x ⊔ y, Psup hx hy⟩ :=
   rfl
 
+/-- A subtype forms a distributive lattice if `⊔` and `⊓` preserve the property.
+See note [reducible non-instances]. -/
+protected abbrev distribLattice [DistribLattice α] {P : α → Prop}
+    (Psup : ∀ ⦃s t : α⦄, P s → P t → P (s ⊔ t)) (Pinf : ∀ ⦃s t : α⦄, P s → P t → P (s ⊓ t)) :
+    DistribLattice (Subtype P) where
+  toLattice := Subtype.lattice Psup Pinf
+  le_sup_inf a b c := by
+    rw [← coe_le_coe, coe_sup Psup, coe_inf Pinf, coe_sup Psup, coe_sup Psup, Subtype.coe_inf Pinf]
+    exact @DistribLattice.le_sup_inf α _ a b c
+
 end Subtype
 
 section lift

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -930,16 +930,6 @@ theorem mk_sup_mk [SemilatticeSup α] {P : α → Prop}
       ⟨x ⊔ y, Psup hx hy⟩ :=
   rfl
 
-/-- A subtype forms a distributive lattice if `⊔` and `⊓` preserve the property.
-See note [reducible non-instances]. -/
-protected abbrev distribLattice [DistribLattice α] {P : α → Prop}
-    (Psup : ∀ ⦃s t : α⦄, P s → P t → P (s ⊔ t)) (Pinf : ∀ ⦃s t : α⦄, P s → P t → P (s ⊓ t)) :
-    DistribLattice (Subtype P) where
-  toLattice := Subtype.lattice Psup Pinf
-  le_sup_inf a b c := by
-    rw [← coe_le_coe, coe_sup Psup, coe_inf Pinf, coe_sup Psup, coe_sup Psup, Subtype.coe_inf Pinf]
-    exact @DistribLattice.le_sup_inf α _ a b c
-
 end Subtype
 
 section lift
@@ -993,6 +983,14 @@ protected abbrev Function.Injective.distribLattice [Max α] [Min α] [LE α] [LT
   le_sup_inf a b c := by
     rw [← le, map_inf, map_sup, map_sup, map_sup, map_inf]
     exact le_sup_inf
+
+/-- A subtype forms a distributive lattice if `⊔` and `⊓` preserve the property.
+See note [reducible non-instances]. -/
+protected abbrev Subtype.distribLattice [DistribLattice α] {P : α → Prop}
+    (Psup : ∀ ⦃s t : α⦄, P s → P t → P (s ⊔ t)) (Pinf : ∀ ⦃s t : α⦄, P s → P t → P (s ⊓ t)) :
+    DistribLattice (Subtype P) :=
+  letI := Subtype.lattice Psup Pinf
+  Subtype.coe_injective.distribLattice _ coe_le_coe coe_lt_coe (coe_sup Psup) (coe_inf Pinf)
 
 end lift
 


### PR DESCRIPTION
Add `DistribLattice` instance when `⊔` and `⊓` in the original lattice preserve the property defining the subtype.

---

Split from #36489