### PR TITLE
[Merged by Bors] - fix(Algebra/Group/Hom/End): use `fast_instance%` on leaky `Ring` instance

### DIFF
--- a/Mathlib/Algebra/Group/Hom/End.lean
+++ b/Mathlib/Algebra/Group/Hom/End.lean
@@ -41,7 +41,7 @@ lemma natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) : (↑n : AddMonoid.End 
     (ofNat(n) : AddMonoid.End M) m = n • m := rfl
 
 instance instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
-  { AddMonoid.End.instMonoid M,
+  fast_instance% { AddMonoid.End.instMonoid M,
     AddMonoidHom.instAddCommMonoid,
     AddMonoid.End.instAddMonoidWithOne M with
     zero_mul := fun _ => AddMonoidHom.ext fun _ => rfl,
@@ -50,7 +50,7 @@ instance instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
     right_distrib := fun _ _ _ => AddMonoidHom.ext fun _ => rfl }
 
 instance instRing [AddCommGroup M] : Ring (AddMonoid.End M) :=
-  { AddMonoid.End.instSemiring, AddMonoid.End.instAddCommGroup with
+  fast_instance% { AddMonoid.End.instSemiring, AddMonoid.End.instAddCommGroup with
     intCast := fun z => z • (1 : AddMonoid.End M),
     intCast_ofNat := natCast_zsmul _,
     intCast_negSucc := negSucc_zsmul _ }

--- a/Mathlib/Algebra/Group/Hom/End.lean
+++ b/Mathlib/Algebra/Group/Hom/End.lean
@@ -55,4 +55,9 @@ instance instRing [AddCommGroup M] : Ring (AddMonoid.End M) :=
     intCast_ofNat := natCast_zsmul _,
     intCast_negSucc := negSucc_zsmul _ }
 
+example [AddCommGroup M] :
+    (AddMonoid.End.instRing (M := M)).toAddCommGroup.toAddGroup.toSubNegMonoid =
+    (AddMonoid.End.instRing (M := M)).toAddGroupWithOne.toAddGroup.toSubNegMonoid := by
+  with_reducible_and_instances rfl
+
 end AddMonoid.End


### PR DESCRIPTION
This PR fixes some leaky instances by using `fast_instance%`. The instances abuse the defeq of `AddMonoid.End M` and `M →+ M`, which is now fixed.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
