### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): uniform continuity of product

### DIFF
--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -24,7 +24,7 @@ induced by the Hausdorff metric to hyperspaces of uniform spaces.
 open Topology
 open scoped Uniformity
 
-variable {α β : Type*}
+variable {α β γ : Type*}
 
 section hausdorffEntourage
 
@@ -107,9 +107,16 @@ theorem TotallyBounded.exists_prodMk_finset_mem_hausdorffEntourage [UniformSpace
   obtain ⟨y, hy, hxy⟩ := Set.mem_iUnion₂.mp (ht₂ hx)
   exact ⟨y, ⟨hy, x, hx, hxy⟩, hxy⟩
 
+theorem prod_mem_hausdorffEntourage_entourageProd
+    (U₁ : SetRel α α) (U₂ : SetRel β β) {s₁ t₁ : Set α} {s₂ t₂ : Set β}
+    (h₁ : (s₁, t₁) ∈ hausdorffEntourage U₁) (h₂ : (s₂, t₂) ∈ hausdorffEntourage U₂) :
+    (s₁ ×ˢ s₂, t₁ ×ˢ t₂) ∈ hausdorffEntourage (entourageProd U₁ U₂) := by
+  simp only [mem_hausdorffEntourage] at *
+  grind [preimage_entourageProd_prod, image_entourageProd_prod]
+
 end hausdorffEntourage
 
-variable [UniformSpace α] [UniformSpace β]
+variable [UniformSpace α] [UniformSpace β] [UniformSpace γ]
 
 variable (α) in
 /-- The Hausdorff uniformity on the powerset of a uniform space. Used for defining the uniformities
@@ -199,6 +206,12 @@ theorem uniformContinuous_union : UniformContinuous (fun x : Set α × Set α =>
   refine Filter.tendsto_lift'.mpr fun U hU => ?_
   filter_upwards [entourageProd_mem_uniformity (Filter.mem_lift' hU) (Filter.mem_lift' hU)]
     with _ ⟨h₁, h₂⟩ using union_mem_hausdorffEntourage U h₁ h₂
+
+theorem uniformContinuous_prod : UniformContinuous (fun x : Set α × Set β => x.1 ×ˢ x.2) := by
+  refine (𝓤 α).basis_sets.uniformity_prod (𝓤 β).basis_sets |>.lift' monotone_hausdorffEntourage
+    |>.tendsto_right_iff.mpr fun ⟨U, V⟩ ⟨hU, hV⟩ => ?_
+  filter_upwards [entourageProd_mem_uniformity (Filter.mem_lift' hU) (Filter.mem_lift' hV)]
+    with ⟨⟨s₁, s₂⟩, ⟨t₁, t₂⟩⟩ ⟨h₁, h₂⟩ using prod_mem_hausdorffEntourage_entourageProd U V h₁ h₂
 
 theorem uniformContinuous_closure : UniformContinuous (closure (X := α)) := by
   simp_rw [UniformContinuous, (𝓤 α).basis_sets.uniformity_hausdorff.tendsto_iff
@@ -413,6 +426,20 @@ theorem _root_.UniformContinuous.sup_closeds
 instance : ContinuousSup (Closeds α) :=
   ⟨uniformContinuous_sup.continuous⟩
 
+theorem uniformContinuous_prod : UniformContinuous (fun x : Closeds α × Closeds β => x.1 ×ˢ x.2) :=
+  isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
+    UniformSpace.hausdorff.uniformContinuous_prod.comp <|
+      uniformContinuous_coe.prodMap uniformContinuous_coe
+
+theorem _root_.UniformContinuous.prod_closeds {f : α → Closeds β} {g : α → Closeds γ}
+    (hf : UniformContinuous f) (hg : UniformContinuous g) :
+    UniformContinuous (fun x => f x ×ˢ g x) :=
+  uniformContinuous_prod.comp (hf.prodMk hg)
+
+@[fun_prop]
+theorem continuous_prod : Continuous (fun x : Closeds α × Closeds β => x.1 ×ˢ x.2) :=
+  uniformContinuous_prod.continuous
+
 instance : T0Space (Closeds α) := by
   suffices ∀ F₁ F₂ : Closeds α, Inseparable F₁ F₂ → F₁ ≤ F₂ from
     ⟨fun F₁ F₂ h => le_antisymm (this F₁ F₂ h) (this F₂ F₁ h.symm)⟩
@@ -520,6 +547,17 @@ theorem _root_.UniformContinuous.sup_compacts
     UniformContinuous (fun x => f x ⊔ g x) :=
   uniformContinuous_sup.comp <| hf.prodMk hg
 
+theorem uniformContinuous_prod :
+    UniformContinuous (fun x : Compacts α × Compacts β => x.1 ×ˢ x.2) :=
+  isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
+    UniformSpace.hausdorff.uniformContinuous_prod.comp <|
+      uniformContinuous_coe.prodMap uniformContinuous_coe
+
+theorem _root_.UniformContinuous.prod_compacts {f : α → Compacts β} {g : α → Compacts γ}
+    (hf : UniformContinuous f) (hg : UniformContinuous g) :
+    UniformContinuous (fun x => f x ×ˢ g x) :=
+  uniformContinuous_prod.comp (hf.prodMk hg)
+
 theorem _root_.UniformContinuous.compacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (Compacts.map f hf.continuous) :=
   isUniformEmbedding_coe.uniformContinuous_iff.mpr <| hf.image_hausdorff.comp uniformContinuous_coe
@@ -608,6 +646,17 @@ theorem _root_.UniformContinuous.sup_nonemptyCompacts
     {f g : α → NonemptyCompacts β} (hf : UniformContinuous f) (hg : UniformContinuous g) :
     UniformContinuous (fun x => f x ⊔ g x) :=
   uniformContinuous_sup.comp <| hf.prodMk hg
+
+theorem uniformContinuous_prod :
+    UniformContinuous (fun x : NonemptyCompacts α × NonemptyCompacts β => x.1 ×ˢ x.2) :=
+  isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
+    UniformSpace.hausdorff.uniformContinuous_prod.comp <|
+      uniformContinuous_coe.prodMap uniformContinuous_coe
+
+theorem _root_.UniformContinuous.prod_nonemptyCompacts
+    {f : α → NonemptyCompacts β} {g : α → NonemptyCompacts γ} (hf : UniformContinuous f)
+    (hg : UniformContinuous g) : UniformContinuous (fun x => f x ×ˢ g x) :=
+  uniformContinuous_prod.comp (hf.prodMk hg)
 
 theorem _root_.UniformContinuous.nonemptyCompacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (NonemptyCompacts.map f hf.continuous) :=


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
