### PR TITLE
[Merged by Bors] - feat(Algebra/DualNumber): ext lemma for ring morphisms

### DIFF
--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -123,7 +123,7 @@ theorem algHom_ext ⦃f g : R[ε] →ₐ[R] A⦄ (hε : f ε = g ε) : f = g := 
 
 /-- A ring morphism `R[ε] →+* R'` is determined by its restriction
 on `R` and its value on `ε`. -/
-@[ext]
+@[ext high]
 lemma ringHom_ext {R' : Type*} [CommSemiring R'] {f g : R[ε] →+* R'}
     (h₀ : f.comp (algebraMap R R[ε]) = g.comp (algebraMap R R[ε]))
     (hε : f ε = g ε) : f = g := by

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -80,6 +80,10 @@ theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
   inr_mul_inr _ _ _
 
 @[simp]
+lemma eps_pow_two [Semiring R] : (ε : R[ε]) ^ 2 = 0 := by
+  simp [pow_two]
+
+@[simp]
 theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = 0 :=
   TrivSqZeroExt.inv_inr 1
 
@@ -116,6 +120,23 @@ theorem algHom_ext ⦃f g : R[ε] →ₐ[R] A⦄ (hε : f ε = g ε) : f = g := 
   ext
   dsimp
   simp only [one_smul, hε]
+
+/-- A ring morphism `R[ε] →+* R'` is determined by its restriction
+on `R` and its value on `ε`. -/
+@[ext]
+lemma ringHom_ext {R' : Type*} [CommSemiring R'] {f g : R[ε] →+* R'}
+    (h₀ : f.comp (algebraMap R R[ε]) = g.comp (algebraMap R R[ε]))
+    (hε : f ε = g ε) : f = g := by
+  letI : Algebra R R' := by
+    letI := f.toAlgebra
+    exact Algebra.compHom _ (algebraMap R R[ε])
+  let f' : R[ε] →ₐ[R] R' :=
+    { toRingHom := f
+      commutes' _ := rfl }
+  let g' : R[ε] →ₐ[R] R' :=
+    { toRingHom := g
+      commutes' r := (DFunLike.congr_fun h₀ r).symm }
+  exact congr_arg AlgHom.toRingHom (show f' = g' from algHom_ext hε)
 
 /-- A universal property of the dual numbers, providing a unique `A[ε] →ₐ[R] B` for every map
 `f : A →ₐ[R] B` and a choice of element `e : B` which squares to `0` and commutes with the range of


### PR DESCRIPTION
A ring morphism `R[ε] →+* R'` is determined by its restriction on `R` and its value on `ε`.
(We also add a lemma saying that `ε ^ 2 = 0`.)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
