### PR TITLE
chore: golf using `grind`

### DIFF
--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -226,16 +226,12 @@ private theorem smul'_char (r₁ : R) (r₂ : X) (s₁ s₂ : S) (u : S) (v : R)
   simp only [smul']
   have h₀ := ore_eq r₁ s₂; set v₀ := oreNum r₁ s₂; set u₀ := oreDenom r₁ s₂
   rcases oreCondition (u₀ : R) u with ⟨r₃, s₃, h₃⟩
-  have :=
-    calc
-      r₃ * v * s₂ = r₃ * (u * r₁) := by rw [mul_assoc, ← huv]
-      _ = s₃ * (u₀ * r₁) := by rw [← mul_assoc, ← mul_assoc, h₃]
-      _ = s₃ * v₀ * s₂ := by rw [mul_assoc, h₀]
+  have : r₃ * v * ↑s₂ = ↑s₃ * v₀ * ↑s₂ := by grind => ac
   rcases ore_right_cancel _ _ _ this with ⟨s₄, hs₄⟩
   symm; rw [oreDiv_eq_iff]
   use s₄ * s₃
   use s₄ * r₃
-  simp only [Submonoid.coe_mul, Submonoid.smul_def]
+  simp [Submonoid.smul_def]
   grind [smul_smul]
 
 set_option backward.privateInPublic true in

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -236,11 +236,7 @@ private theorem smul'_char (r₁ : R) (r₂ : X) (s₁ s₂ : S) (u : S) (v : R)
   use s₄ * s₃
   use s₄ * r₃
   simp only [Submonoid.coe_mul, Submonoid.smul_def]
-  constructor
-  · rw [smul_smul, mul_assoc (c := v₀), ← hs₄]
-    simp only [smul_smul, mul_assoc]
-  · rw [← mul_assoc (b := (u₀ : R)), mul_assoc (c := (u₀ : R)), h₃]
-    simp only [mul_assoc]
+  grind [smul_smul]
 
 set_option backward.privateInPublic true in
 /-- The multiplication on the Ore localization of monoids. -/

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -556,14 +556,7 @@ theorem cycleOf_mem_cycleFactorsFinset_iff {f : Perm α} {x : α} :
     rw [notMem_support, ← cycleOf_eq_one_iff] at hc
     simp [hc]
   · intro hx
-    refine ⟨isCycle_cycleOf _ (mem_support.mp hx), ?_⟩
-    intro y hy
-    rw [mem_support] at hy
-    rw [cycleOf_apply]
-    split_ifs with H
-    · rfl
-    · rw [cycleOf_apply_of_not_sameCycle H] at hy
-      contradiction
+    exact ⟨isCycle_cycleOf _ (mem_support.mp hx), by grind [mem_support, cycleOf_apply]⟩
 
 lemma cycleOf_ne_one_iff_mem_cycleFactorsFinset {g : Equiv.Perm α} {x : α} :
     g.cycleOf x ≠ 1 ↔ g.cycleOf x ∈ g.cycleFactorsFinset := by

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -273,12 +273,7 @@ protected theorem StrictMono.ite' (hf : StrictMono f) (hg : StrictMono g) {p : �
     (hp : ∀ ⦃x y⦄, x < y → p y → p x) (hfg : ∀ ⦃x y⦄, p x → ¬p y → x < y → f x < g y) :
     StrictMono fun x ↦ if p x then f x else g x := by
   intro x y h
-  by_cases hy : p y
-  · have hx : p x := hp h hy
-    simpa [hx, hy] using hf h
-  by_cases hx : p x
-  · simpa [hx, hy] using hfg hx hy h
-  · simpa [hx, hy] using hg h
+  grind [imp]
 
 protected theorem StrictMono.ite (hf : StrictMono f) (hg : StrictMono g) {p : α → Prop}
     [DecidablePred p] (hp : ∀ ⦃x y⦄, x < y → p y → p x) (hfg : ∀ x, f x ≤ g x) :

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -272,7 +272,7 @@ protected theorem StrictMono.ite' (hf : StrictMono f) (hg : StrictMono g) {p : �
     [DecidablePred p]
     (hp : ∀ ⦃x y⦄, x < y → p y → p x) (hfg : ∀ ⦃x y⦄, p x → ¬p y → x < y → f x < g y) :
     StrictMono fun x ↦ if p x then f x else g x := by
-  intro x y h
+  intro x
   grind [imp]
 
 protected theorem StrictMono.ite (hf : StrictMono f) (hg : StrictMono g) {p : α → Prop}

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -32,8 +32,7 @@ lemma isInt_ediv {a b q m a' : ℤ} {b' r : ℕ}
     IsInt (a / b) q := ⟨by
   obtain ⟨⟨rfl⟩, ⟨rfl⟩⟩ := ha, hb
   simp only [Nat.blt_eq] at h₂; simp only [← h, ← hm, Int.cast_id]
-  rw [Int.add_mul_ediv_right _ _ (Int.ofNat_ne_zero.2 ((Nat.zero_le ..).trans_lt h₂).ne')]
-  rw [Int.ediv_eq_zero_of_lt, zero_add] <;> [simp; simpa using h₂]⟩
+  exact (Int.ediv_eq_iff_of_pos (by grind)).mpr (by grind)⟩
 
 lemma isInt_ediv_neg {a b q q' : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : IsInt (a / b) q' :=
   ⟨by rw [Int.cast_id, ← hq, ← @Int.cast_id q, ← h.out, ← Int.ediv_neg, Int.neg_neg]⟩

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -31,8 +31,10 @@ lemma isInt_ediv {a b q m a' : ℤ} {b' r : ℕ}
     (hm : q * b' = m) (h : r + m = a') (h₂ : Nat.blt r b' = true) :
     IsInt (a / b) q := ⟨by
   obtain ⟨⟨rfl⟩, ⟨rfl⟩⟩ := ha, hb
-  simp only [Nat.blt_eq] at h₂; simp only [← h, ← hm, Int.cast_id]
-  exact (Int.ediv_eq_iff_of_pos (by grind)).mpr (by grind)⟩
+  simp only [Nat.blt_eq] at h₂
+  simp only [Int.cast_id]
+  have := @Int.ediv_eq_iff_of_pos b' a q
+  lia⟩
 
 lemma isInt_ediv_neg {a b q q' : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : IsInt (a / b) q' :=
   ⟨by rw [Int.cast_id, ← hq, ← @Int.cast_id q, ← h.out, ← Int.ediv_neg, Int.neg_neg]⟩


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `OreLocalization.smul'_char`: unchanged 🎉
* `Equiv.Perm.cycleOf_mem_cycleFactorsFinset_iff`: unchanged 🎉
* `StrictMono.ite'`: unchanged 🎉
* `Mathlib.Meta.NormNum.isInt_ediv`: unchanged 🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
