### PR TITLE
[Merged by Bors] - fix(Algebra/Quaternion, Analysis/Normed/Lp): fix instance diamonds using inferInstanceAs

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -787,7 +787,7 @@ variable {S T R : Type*} [CommRing R] (r x y : R) (a b : ℍ[R])
 
 instance : CoeTC R ℍ[R] := ⟨coe⟩
 
-instance instRing : Ring ℍ[R] := QuaternionAlgebra.instRing
+instance instRing : Ring ℍ[R] := inferInstanceAs <| Ring ℍ[R,-1,0,-1]
 
 instance : Inhabited ℍ[R] := inferInstanceAs <| Inhabited ℍ[R,-1,0,-1]
 

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -782,7 +782,7 @@ section NormedRing
 variable {I : Type*} {B : I → Type*} [∀ i, NormedRing (B i)]
 
 instance _root_.PreLp.ring : Ring (PreLp B) :=
-  Pi.ring
+  inferInstanceAs (Ring (∀ i, B i))
 
 variable [∀ i, NormOneClass (B i)]
 


### PR DESCRIPTION
This PR uses `inferInstanceAs` to break defeq abuse in two `Ring` instances,
fixing instance diamond linter warnings detected by #37013:
- `Quaternion.instRing`: `ℍ[R]` is defeq to `ℍ[R,-1,0,-1]`, so use `inferInstanceAs` (matching the pattern of other instances in the same file)
- `PreLp.ring`: `PreLp B` is defeq to `∀ i, B i`, so use `inferInstanceAs`

🤖 Prepared with Claude Code