### PR TITLE
[Merged by Bors] - feat: `SemilatticeSup.ofIsLUB`, `Lattice.ofIsLUBofIsGLB`

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -783,7 +783,9 @@ instance Nat.instDecidableIsLeast (p : ℕ → Prop) (n : ℕ) [DecidablePred p]
   decidable_of_iff (p n ∧ ∀ k < n, ¬p k) <| .and .rfl <| by
     simp [mem_lowerBounds, @imp_not_comm _ (p _)]
 
-@[to_dual (attr := implicit_reducible)]
+/-- An alternative constructor for `SemilatticeSup` using `IsLUB`. -/
+@[to_dual (attr := implicit_reducible)
+/-- An alternative constructor for `SemilatticeInf` using `IsGLB`. -/]
 def SemilatticeSup.ofIsLUB [PartialOrder α] (sup : α → α → α)
     (isLUB_pair : ∀ a b, IsLUB {a, b} (sup a b)) :
     SemilatticeSup α where
@@ -792,6 +794,7 @@ def SemilatticeSup.ofIsLUB [PartialOrder α] (sup : α → α → α)
   le_sup_right a b := (isLUB_pair a b).1 (mem_insert_of_mem _ (mem_singleton _))
   sup_le a b _ hac hbc := (isLUB_pair a b).2 (forall_insert_of_forall (forall_eq.mpr hbc) hac)
 
+/-- An alternative constructor for `Lattice` using `IsLUB` and `IsGLB`. -/
 @[implicit_reducible, to_dual self (reorder := 3 4, 5 6)]
 def Lattice.ofIsLUBofIsGLB [PartialOrder α] (sup inf : α → α → α)
     (isLUB_pair : ∀ a b, IsLUB {a, b} (sup a b)) (isGLB_pair : ∀ a b, IsGLB {a, b} (inf a b)) :

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -782,3 +782,19 @@ instance Nat.instDecidableIsLeast (p : ℕ → Prop) (n : ℕ) [DecidablePred p]
     Decidable (IsLeast { n : ℕ | p n } n) :=
   decidable_of_iff (p n ∧ ∀ k < n, ¬p k) <| .and .rfl <| by
     simp [mem_lowerBounds, @imp_not_comm _ (p _)]
+
+@[to_dual (attr := implicit_reducible)]
+def SemilatticeSup.ofIsLUB [PartialOrder α] (sup : α → α → α)
+    (isLUB_pair : ∀ a b, IsLUB {a, b} (sup a b)) :
+    SemilatticeSup α where
+  sup := sup
+  le_sup_left a b := (isLUB_pair a b).1 (mem_insert _ _)
+  le_sup_right a b := (isLUB_pair a b).1 (mem_insert_of_mem _ (mem_singleton _))
+  sup_le a b _ hac hbc := (isLUB_pair a b).2 (forall_insert_of_forall (forall_eq.mpr hbc) hac)
+
+@[implicit_reducible, to_dual self (reorder := 3 4, 5 6)]
+def Lattice.ofIsLUBofIsGLB [PartialOrder α] (sup inf : α → α → α)
+    (isLUB_pair : ∀ a b, IsLUB {a, b} (sup a b)) (isGLB_pair : ∀ a b, IsGLB {a, b} (inf a b)) :
+    Lattice α where
+  __ := SemilatticeSup.ofIsLUB sup isLUB_pair
+  __ := SemilatticeInf.ofIsGLB inf isGLB_pair

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -49,6 +49,10 @@ class ConditionallyCompleteLattice (α : Type*) extends Lattice α, SupSet α, I
   /-- Every nonempty subset which is bounded below has a greatest lower bound. -/
   isGLB_csInf : ∀ s : Set α, s.Nonempty → BddBelow s → IsGLB s (sInf s)
 
+attribute [to_dual self (reorder := 3 4, 5 6)] ConditionallyCompleteLattice.mk
+attribute [to_dual existing] ConditionallyCompleteLattice.toSupSet
+attribute [to_dual existing] ConditionallyCompleteLattice.isLUB_csSup
+
 /-- A conditionally complete linear order is a linear order in which
 every nonempty subset which is bounded above has a supremum, and
 every nonempty subset which is bounded below has an infimum.
@@ -108,38 +112,7 @@ instance : ConditionallyCompleteLattice my_T where
   __ := conditionallyCompleteLatticeOfsSup my_T ...
 ```
 -/
-@[implicit_reducible]
-def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
-    (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
-    (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
-    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
-    ConditionallyCompleteLattice α where
-  sup a b := sSup {a, b}
-  le_sup_left a b :=
-    (isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _)).1 (mem_insert _ _)
-  le_sup_right a b :=
-    (isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _)).1
-      (mem_insert_of_mem _ (mem_singleton _))
-  sup_le a b _ hac hbc :=
-    (isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _)).2
-      (forall_insert_of_forall (forall_eq.mpr hbc) hac)
-  inf a b := sSup (lowerBounds {a, b})
-  inf_le_left a b :=
-    (isLUB_sSup (lowerBounds {a, b}) (insert_nonempty _ _).bddAbove_lowerBounds
-          (bddBelow_pair a b)).2
-      fun _ hc => hc <| mem_insert _ _
-  inf_le_right a b :=
-    (isLUB_sSup (lowerBounds {a, b}) (insert_nonempty _ _).bddAbove_lowerBounds
-          (bddBelow_pair a b)).2
-      fun _ hc => hc <| mem_insert_of_mem _ (mem_singleton _)
-  le_inf c a b hca hcb :=
-    (isLUB_sSup (lowerBounds {a, b}) (insert_nonempty _ _).bddAbove_lowerBounds
-          ⟨c, forall_insert_of_forall (forall_eq.mpr hcb) hca⟩).1
-      (forall_insert_of_forall (forall_eq.mpr hcb) hca)
-  sInf s := sSup (lowerBounds s)
-  isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
-  isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
-
+@[to_dual (attr := implicit_reducible) (reorder := 4 5)
 /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
 that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
 constructor provides poor definitional equalities.  If other fields are known explicitly, they
@@ -154,44 +127,28 @@ instance : ConditionallyCompleteLattice my_T :=
   -- don't care to fix sup, sSup
   __ := conditionallyCompleteLatticeOfsInf my_T ...
 ```
--/
-@[implicit_reducible]
-def conditionallyCompleteLatticeOfsInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
+-/]
+def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
     (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
-    (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s)) :
+    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
     ConditionallyCompleteLattice α where
-  inf a b := sInf {a, b}
-  inf_le_left a b :=
-    (isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _)).1 (mem_insert _ _)
-  inf_le_right a b :=
-    (isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _)).1
-      (mem_insert_of_mem _ (mem_singleton _))
-  le_inf _ a b hca hcb :=
-    (isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _)).2
-      (forall_insert_of_forall (forall_eq.mpr hcb) hca)
-  sup a b := sInf (upperBounds {a, b})
-  le_sup_left a b :=
-    (isGLB_sInf (upperBounds {a, b}) (insert_nonempty _ _).bddBelow_upperBounds
-          (bddAbove_pair a b)).2
-      fun _ hc => hc <| mem_insert _ _
-  le_sup_right a b :=
-    (isGLB_sInf (upperBounds {a, b}) (insert_nonempty _ _).bddBelow_upperBounds
-          (bddAbove_pair a b)).2
-      fun _ hc => hc <| mem_insert_of_mem _ (mem_singleton _)
-  sup_le a b c hac hbc :=
-    (isGLB_sInf (upperBounds {a, b}) (insert_nonempty _ _).bddBelow_upperBounds
-          ⟨c, forall_insert_of_forall (forall_eq.mpr hbc) hac⟩).1
-      (forall_insert_of_forall (forall_eq.mpr hbc) hac)
-  sSup s := sInf (upperBounds s)
-  isGLB_csInf _ hn hb := isGLB_sInf _ hb hn
-  isLUB_csSup _ hn hb :=
-    isGLB_upperBounds.mp (isGLB_sInf _ hn.bddBelow_upperBounds hb)
+  __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
+    (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
+    (fun a b ↦ isLUB_lowerBounds.mp <| isLUB_sSup (lowerBounds {a, b})
+      (insert_nonempty _ _).bddAbove_lowerBounds (bddBelow_pair a b))
+  __ := H2
+  sInf s := sSup (lowerBounds s)
+  isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
+  isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
 
 /-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
 
 This should only be used when it is both hard and unnecessary to provide `sInf` explicitly. -/
-@[implicit_reducible]
+@[to_dual (attr := implicit_reducible)
+/-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
+
+This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
 def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
     (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
     ConditionallyCompleteLattice α :=
@@ -200,19 +157,6 @@ def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [
       (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
       (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
       isLUB_sSup with }
-
-/-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
-
-This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/
-@[implicit_reducible]
-def conditionallyCompleteLatticeOfLatticeOfsInf (α : Type*) [H1 : Lattice α] [InfSet α]
-    (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s)) :
-    ConditionallyCompleteLattice α :=
-  { H1,
-    conditionallyCompleteLatticeOfsInf α
-      (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
-      (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
-      isGLB_sInf with }
 
 open scoped Classical in
 /-- A well-founded linear order is conditionally complete, with a bottom element. -/


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
