### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty/Shift): Shift closure is iSup of shifts

### DIFF
--- a/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
@@ -148,7 +148,7 @@ lemma isStableUnderShift_iff_shiftClosure_eq_self [P.IsClosedUnderIsomorphisms] 
     IsStableUnderShift P A ↔ shiftClosure P A = P :=
   ⟨fun _ ↦ shiftClosure_eq_self _, fun h ↦ by rw [← h]; infer_instance⟩
 
-lemma isStableUnderShift_iSup_shift [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G]
+instance [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G]
     [HasShift C G] : (⨆ (a : G), P.shift a).IsStableUnderShift G where
   isStableUnderShiftBy a := IsStableUnderShiftBy.mk <| by
     rw [shift_iSup]

--- a/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
@@ -160,8 +160,7 @@ instance [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G]
 lemma shiftClosure_eq_iSup [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G] [HasShift C G] :
     P.shiftClosure G = ⨆ (x : G), P.shift x := by
   apply le_antisymm
-  · haveI := P.isStableUnderShift_iSup_shift G
-    rw [shiftClosure_le_iff]
+  · rw [shiftClosure_le_iff]
     conv_lhs => rw [← P.shift_zero G]
     exact le_iSup P.shift (0 : G)
   · intro X hX

--- a/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Shift.lean
@@ -5,7 +5,9 @@ Authors: Joël Riou
 -/
 module
 
+public import Mathlib.CategoryTheory.ObjectProperty.CompleteLattice
 public import Mathlib.CategoryTheory.Shift.CommShift
+public import Mathlib.Order.ConditionallyCompleteLattice.Basic
 
 /-!
 # Properties of objects on categories equipped with shift
@@ -52,6 +54,15 @@ lemma shift_shift (a b c : A) (h : a + b = c) [P.IsClosedUnderIsomorphisms] :
     (P.shift b).shift a = P.shift c := by
   ext X
   exact P.prop_iff_of_iso ((shiftFunctorAdd' C a b c h).symm.app X)
+
+lemma shift_sup (a : A) : (P ⊔ Q).shift a = P.shift a ⊔ Q.shift a := by
+  ext
+  simp [prop_shift_iff]
+
+lemma shift_iSup {ι : Sort*} (P : ι → ObjectProperty C) (a : A) :
+    (⨆ (i : ι), P i).shift a = ⨆ (i : ι), (P i).shift a := by
+  ext
+  simp [prop_shift_iff]
 
 /-- `P : ObjectProperty C` is stable under the shift by `a : A` if
 `P X` implies `P X⟦a⟧`. -/
@@ -137,6 +148,25 @@ lemma isStableUnderShift_iff_shiftClosure_eq_self [P.IsClosedUnderIsomorphisms] 
     IsStableUnderShift P A ↔ shiftClosure P A = P :=
   ⟨fun _ ↦ shiftClosure_eq_self _, fun h ↦ by rw [← h]; infer_instance⟩
 
+lemma isStableUnderShift_iSup_shift [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G]
+    [HasShift C G] : (⨆ (a : G), P.shift a).IsStableUnderShift G where
+  isStableUnderShiftBy a := IsStableUnderShiftBy.mk <| by
+    rw [shift_iSup]
+    intro X hX
+    rw [prop_iSup_iff] at hX ⊢
+    obtain ⟨b, hb⟩ := hX
+    exact ⟨-a + b, by rwa [P.shift_shift _ _ _ (add_neg_cancel_left a b)]⟩
+
+lemma shiftClosure_eq_iSup [P.IsClosedUnderIsomorphisms] (G : Type*) [AddGroup G] [HasShift C G] :
+    P.shiftClosure G = ⨆ (x : G), P.shift x := by
+  apply le_antisymm
+  · haveI := P.isStableUnderShift_iSup_shift G
+    rw [shiftClosure_le_iff]
+    conv_lhs => rw [← P.shift_zero G]
+    exact le_iSup P.shift (0 : G)
+  · intro X hX
+    obtain ⟨a, ha⟩ := (prop_iSup_iff _ _).mp hX
+    exact ⟨X⟦a⟧, -a, (shiftShiftNeg X a).symm, ha⟩
 
 variable [P.IsStableUnderShift A]
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
