### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty/Retract): Retracts and biproducts/zeros

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
@@ -202,25 +202,23 @@ theorem binary_cofan_inl_toCocone (c : BinaryBicone P Q) : BinaryCofan.inl c.toC
 theorem binary_cofan_inr_toCocone (c : BinaryBicone P Q) : BinaryCofan.inr c.toCocone = c.inr :=
   rfl
 
-instance (c : BinaryBicone P Q) : IsSplitMono c.inl :=
-  IsSplitMono.mk'
-    { retraction := c.fst
-      id := c.inl_fst }
+/-- The retract of a binary bicone `c` given by `c.inl` and `c.fst`. -/
+def retract_left (c : BinaryBicone P Q) : Retract P c.pt where
+  i := c.inl
+  r := c.fst
 
-instance (c : BinaryBicone P Q) : IsSplitMono c.inr :=
-  IsSplitMono.mk'
-    { retraction := c.snd
-      id := c.inr_snd }
+/-- The retract of a binary bicone `c` given by `c.inr` and `c.snd`. -/
+def retract_right (c : BinaryBicone P Q) : Retract Q c.pt where
+  i := c.inr
+  r := c.snd
 
-instance (c : BinaryBicone P Q) : IsSplitEpi c.fst :=
-  IsSplitEpi.mk'
-    { section_ := c.inl
-      id := c.inl_fst }
+instance (c : BinaryBicone P Q) : IsSplitMono c.inl := c.retract_left.instIsSplitMonoI
 
-instance (c : BinaryBicone P Q) : IsSplitEpi c.snd :=
-  IsSplitEpi.mk'
-    { section_ := c.inr
-      id := c.inr_snd }
+instance (c : BinaryBicone P Q) : IsSplitMono c.inr := c.retract_right.instIsSplitMonoI
+
+instance (c : BinaryBicone P Q) : IsSplitEpi c.fst := c.retract_left.instIsSplitEpiR
+
+instance (c : BinaryBicone P Q) : IsSplitEpi c.snd := c.retract_right.instIsSplitEpiR
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Convert a `BinaryBicone` into a `Bicone` over a pair. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -197,6 +197,14 @@ theorem toCocone_ι_app (B : Bicone F) (j : Discrete J) : B.toCocone.ι.app j = 
 
 theorem toCocone_ι_app_mk (B : Bicone F) (j : J) : B.toCocone.ι.app ⟨j⟩ = B.ι j := rfl
 
+def retract (B : Bicone F) (j : J) : Retract (F j) B.pt where
+  i := B.ι j
+  r := B.π j
+
+instance (B : Bicone F) (j : J) : IsSplitMono (B.ι j) := (B.retract j).instIsSplitMonoI
+
+instance (B : Bicone F) (j : J) : IsSplitEpi (B.π j) := (B.retract j).instIsSplitEpiR
+
 set_option backward.isDefEq.respectTransparency false in
 open scoped Classical in
 /-- We can turn any limit cone over a discrete collection of objects into a bicone. -/
@@ -1008,11 +1016,11 @@ variable {J : Type w}
 variable {C : Type u} [Category.{v} C] [HasZeroMorphisms C]
 variable {D : Type uD} [Category.{uD'} D] [HasZeroMorphisms D]
 
-instance biproduct.ι_mono (f : J → C) [HasBiproduct f] (b : J) : IsSplitMono (biproduct.ι f b) := by
-  classical exact IsSplitMono.mk' { retraction := biproduct.desc <| Pi.single b (𝟙 (f b)) }
+instance biproduct.ι_mono (f : J → C) [HasBiproduct f] (b : J) : IsSplitMono (biproduct.ι f b) :=
+  (biproduct.bicone f).instIsSplitMonoι b
 
-instance biproduct.π_epi (f : J → C) [HasBiproduct f] (b : J) : IsSplitEpi (biproduct.π f b) := by
-  classical exact IsSplitEpi.mk' { section_ := biproduct.lift <| Pi.single b (𝟙 (f b)) }
+instance biproduct.π_epi (f : J → C) [HasBiproduct f] (b : J) : IsSplitEpi (biproduct.π f b) :=
+  (biproduct.bicone f).instIsSplitEpiπ b
 
 /-- Auxiliary lemma for `biproduct.uniqueUpToIso`. -/
 theorem biproduct.conePointUniqueUpToIso_hom (f : J → C) [HasBiproduct f] {b : Bicone f}

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -197,6 +197,7 @@ theorem toCocone_ι_app (B : Bicone F) (j : Discrete J) : B.toCocone.ι.app j = 
 
 theorem toCocone_ι_app_mk (B : Bicone F) (j : J) : B.toCocone.ι.app ⟨j⟩ = B.ι j := rfl
 
+/-- The retract of a bicone `B` given by `B.ι j` and `B.π j`. -/
 def retract (B : Bicone F) (j : J) : Retract (F j) B.pt where
   i := B.ι j
   r := B.π j

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroObjects.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroObjects.lean
@@ -131,6 +131,13 @@ theorem unop {X : Cᵒᵖ} (h : IsZero X) : IsZero (Opposite.unop X) :=
   ⟨fun Y => ⟨⟨⟨(h.from_ (Opposite.op Y)).unop⟩, fun _ => Quiver.Hom.op_inj (h.eq_of_tgt _ _)⟩⟩,
     fun Y => ⟨⟨⟨(h.to_ (Opposite.op Y)).unop⟩, fun _ => Quiver.Hom.op_inj (h.eq_of_src _ _)⟩⟩⟩
 
+variable (Y) in
+/-- A zero object is a retract of every object. -/
+def retract (h : IsZero X) : Retract X Y where
+  i := h.to_ Y
+  r := h.from_ Y
+  retract := h.isInitial.hom_ext _ _
+
 end IsZero
 
 end Limits

--- a/Mathlib/CategoryTheory/ObjectProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Retract.lean
@@ -6,6 +6,9 @@ Authors: Dagur Asgeirsson
 module
 
 public import Mathlib.CategoryTheory.EssentiallySmall
+public import Mathlib.CategoryTheory.Limits.Shapes.ZeroObjects
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
+public import Mathlib.CategoryTheory.ObjectProperty.ContainsZero
 public import Mathlib.CategoryTheory.ObjectProperty.Small
 public import Mathlib.CategoryTheory.Retract
 
@@ -21,6 +24,8 @@ universe w v u
 
 namespace CategoryTheory.ObjectProperty
 
+open Limits
+
 variable {C : Type u} [Category.{v} C] (P : ObjectProperty C)
 
 /-- A predicate `C → Prop` on the objects of a category is stable under retracts
@@ -30,6 +35,44 @@ class IsStableUnderRetracts where
 
 lemma prop_of_retract [IsStableUnderRetracts P] {X Y : C} (h : Retract X Y) (hY : P Y) : P X :=
   IsStableUnderRetracts.of_retract h hY
+
+namespace IsStableUnderRetracts
+
+open scoped ZeroObject
+
+variable [P.IsStableUnderRetracts]
+
+instance : P.IsClosedUnderIsomorphisms where
+  of_iso i h := IsStableUnderRetracts.of_retract i.symm.retract h
+
+lemma containsZero [HasZeroObject C] {X : C} (h : P X) : P.ContainsZero where
+  exists_zero := ⟨0, isZero_zero _, of_retract ((isZero_zero _).retract X) h⟩
+
+lemma of_binaryBicone_left [HasZeroMorphisms C] {X Y : C} (c : BinaryBicone X Y) (h : P c.pt) :
+    P X :=
+  of_retract c.retract_left h
+
+lemma of_binaryBicone_right [HasZeroMorphisms C] {X Y : C} (c : BinaryBicone X Y) (h : P c.pt) :
+    P Y :=
+  of_retract c.retract_right h
+
+lemma of_biprod_left [HasZeroMorphisms C] {X Y : C} [HasBinaryBiproduct X Y] (h : P (X ⊞ Y)) :
+    P X :=
+  of_binaryBicone_left P (BinaryBiproduct.bicone X Y) h
+
+lemma of_biprod_right [HasZeroMorphisms C] {X Y : C} [HasBinaryBiproduct X Y] (h : P (X ⊞ Y)) :
+    P Y :=
+  of_binaryBicone_right P (BinaryBiproduct.bicone X Y) h
+
+lemma of_bicone [HasZeroMorphisms C] {J : Type*} (F : J → C) (c : Bicone F) (h : P c.pt) (j : J) :
+    P (F j) :=
+  of_retract (c.retract j) h
+
+lemma of_biproduct [HasZeroMorphisms C] {J : Type*} (F : J → C) [HasBiproduct F] (h : P (⨁ F))
+    (j : J) : P (F j) :=
+  of_bicone P F (biproduct.bicone F) h j
+
+end IsStableUnderRetracts
 
 /-- The closure by retracts of a predicate on objects in a category. -/
 def retractClosure : ObjectProperty C := fun X => ∃ (Y : C) (_ : P Y), Nonempty (Retract X Y)


### PR DESCRIPTION
Bicones and zeros are always retracts, hence if an object property is stable under retracts, it is also is stable under taking summands.

This is used in the definition of strong generators in #37046

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
