### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Triangulated/Subcategory): `extensionProductIter`

### DIFF
--- a/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
@@ -262,7 +262,7 @@ lemma extensionProduct_le_of_isTriangulatedClosed₂ {P₁ P₂ Q : ObjectProper
   intro _ ⟨_, _, _, _, _, hT, hY, hZ⟩
   exact ext_of_isTriangulatedClosed₂ Q _ hT (h₁ _ hY) (h₂ _ hZ)
 
-@[stacks 0FX2]
+@[stacks 0FX2 "first part"]
 lemma extensionProduct_retractClosure_retractClosure_le :
     extensionProduct P.retractClosure Q.retractClosure ≤
       (extensionProduct P Q).retractClosure := by
@@ -279,6 +279,7 @@ lemma extensionProduct_retractClosure_retractClosure_le :
   haveI : IsIso (a₂ ≫ b₂) := isIso₂_of_isIso₁₃ φ hT hT (IsIso.id _) (IsIso.id _)
   exact ⟨a₂, b₂ ≫ inv (a₂ ≫ b₂), by grind⟩
 
+@[stacks 0FX2 "second part"]
 lemma retractClosure_extensionProduct_retractClosure_retractClosure :
     (extensionProduct P.retractClosure Q.retractClosure).retractClosure =
       (extensionProduct P Q).retractClosure := by

--- a/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
@@ -169,6 +169,18 @@ lemma extensionProduct_iff (X : C) : extensionProduct P Q X ↔
   ∃ (Y Z : C) (f : Y ⟶ X) (g : X ⟶ Z) (h : Z ⟶ Y⟦(1 : ℤ)⟧),
     Triangle.mk f g h ∈ distTriang C ∧ P Y ∧ Q Z := Iff.rfl
 
+@[simp]
+lemma extensionProduct_bot_left : extensionProduct ⊥ P = ⊥ := by
+  rw [eq_bot_iff]
+  intro _ ⟨_, _, _, _, _, _, h, _⟩
+  exact h
+
+@[simp]
+lemma extensionProduct_bot_right : extensionProduct P ⊥ = ⊥ := by
+  rw [eq_bot_iff]
+  intro _ ⟨_, _, _, _, _, _, _, h⟩
+  exact h
+
 variable {P} in
 lemma monotone_extensionProduct_left {P' : ObjectProperty C} (h : P ≤ P') :
     extensionProduct P Q ≤ extensionProduct P' Q := by
@@ -237,6 +249,152 @@ lemma extensionProduct_assoc [IsTriangulated C] :
     obtain ⟨Y, f'', h'', hT''⟩ := distinguished_cocone_triangle₁ (g ≫ g')
     let o := someOctahedron' rfl hT hT' hT''
     exact ⟨_, _, _, _, _, hT'', ⟨_, _, _, _, _, o.mem, hP, hQ⟩, hR⟩
+
+lemma extensionProduct_le_of_isTriangulatedClosed₂' {P₁ P₂ Q : ObjectProperty C}
+    [Q.IsTriangulatedClosed₂] (h₁ : P₁ ≤ Q) (h₂ : P₂ ≤ Q) :
+    extensionProduct P₁ P₂ ≤ Q.isoClosure := by
+  intro _ ⟨_, _, _, _, _, hT, hY, hZ⟩
+  exact ext_of_isTriangulatedClosed₂' Q _ hT (h₁ _ hY) (h₂ _ hZ)
+
+lemma extensionProduct_le_of_isTriangulatedClosed₂ {P₁ P₂ Q : ObjectProperty C}
+    [Q.IsTriangulatedClosed₂] [Q.IsClosedUnderIsomorphisms] (h₁ : P₁ ≤ Q) (h₂ : P₂ ≤ Q) :
+    extensionProduct P₁ P₂ ≤ Q := by
+  intro _ ⟨_, _, _, _, _, hT, hY, hZ⟩
+  exact ext_of_isTriangulatedClosed₂ Q _ hT (h₁ _ hY) (h₂ _ hZ)
+
+@[stacks 0FX2]
+lemma extensionProduct_retractClosure_retractClosure_le :
+    extensionProduct P.retractClosure Q.retractClosure ≤
+      (extensionProduct P Q).retractClosure := by
+  intro X ⟨A, B, f₁, f₂, f₃, hT, ⟨A', hP, ⟨a₁, b₁, h₁⟩⟩, ⟨B', hQ, ⟨a₃, b₃, h₃⟩⟩⟩
+  obtain ⟨X', g₁, g₂, hT'⟩ := distinguished_cocone_triangle₂ (b₃ ≫ f₃ ≫ a₁⟦(1 : ℤ)⟧')
+  obtain ⟨a₂ : X ⟶ X', ha₁₂, ha₂₃⟩ :=
+    complete_distinguished_triangle_morphism₂ _ _ hT hT' a₁ a₃ (by dsimp; grind)
+  obtain ⟨b₂ : X' ⟶ X, hb₁₂, hb₂₃⟩ :=
+    complete_distinguished_triangle_morphism₂ _ _ hT' hT b₁ b₃ (by dsimp; grind)
+  dsimp at ha₁₂ ha₂₃ hb₁₂ hb₂₃
+  refine ⟨X', ⟨_, _, _, _, _, hT', hP, hQ⟩, ⟨?_⟩⟩
+  let φ := Triangle.homMk (Triangle.mk f₁ f₂ f₃) (Triangle.mk f₁ f₂ f₃) (𝟙 A)
+    (a₂ ≫ b₂) (𝟙 B) (by dsimp; grind) (by dsimp; grind)
+  haveI : IsIso (a₂ ≫ b₂) := isIso₂_of_isIso₁₃ φ hT hT (IsIso.id _) (IsIso.id _)
+  exact ⟨a₂, b₂ ≫ inv (a₂ ≫ b₂), by grind⟩
+
+lemma retractClosure_extensionProduct_retractClosure_retractClosure :
+    (extensionProduct P.retractClosure Q.retractClosure).retractClosure =
+      (extensionProduct P Q).retractClosure := by
+  apply le_antisymm
+  · rw [retractClosure_le_iff]
+    exact extensionProduct_retractClosure_retractClosure_le P Q
+  · apply monotone_retractClosure
+    grw [monotone_extensionProduct_right _ (le_retractClosure Q),
+      monotone_extensionProduct_left _ (le_retractClosure P)]
+
+/-- All objects that can be reached by exactly `n` extensions from objects in `P`. -/
+def extensionProductIter (n : ℕ) : ObjectProperty C := (extensionProduct P)^[n] P
+
+@[simp]
+lemma extensionProductIter_zero : P.extensionProductIter 0 = P := rfl
+
+lemma extensionProductIter_succ (n : ℕ) :
+    P.extensionProductIter (n + 1) = extensionProduct P (P.extensionProductIter n) :=
+  Function.iterate_succ_apply' _ _ _
+
+lemma extensionProductIter_succ' [IsTriangulated C] (n : ℕ) :
+    P.extensionProductIter (n + 1) = extensionProduct (P.extensionProductIter n) P := by
+  induction n with
+  | zero => rfl
+  | succ n h =>
+    rw [extensionProductIter_succ, h, ← extensionProduct_assoc, ← extensionProductIter_succ, ← h]
+
+lemma extensionProductIter_add [IsTriangulated C] {n m n' : ℕ} (h : n = n' + 1) :
+    P.extensionProductIter (n + m) =
+      extensionProduct (P.extensionProductIter n') (P.extensionProductIter m) := by
+  induction m with
+  | zero => rw [add_zero, extensionProductIter_zero, h, extensionProductIter_succ']
+  | succ m hm =>
+    rw [← add_assoc, extensionProductIter_succ', extensionProductIter_succ', hm,
+      extensionProduct_assoc]
+
+lemma extensionProductIter_add' [IsTriangulated C] {n m m' : ℕ} (h : m = m' + 1) :
+    P.extensionProductIter (n + m) =
+      extensionProduct (P.extensionProductIter n) (P.extensionProductIter m') := by
+  induction n with
+  | zero => rw [zero_add, extensionProductIter_zero, h, extensionProductIter_succ]
+  | succ n hn => rw [add_assoc, add_comm 1 m, ← add_assoc, extensionProductIter_succ,
+    extensionProductIter_succ, hn, extensionProduct_assoc]
+
+variable {P} in
+lemma monotone_extensionProductIter {Q : ObjectProperty C} (hPQ : P ≤ Q) (n : ℕ) :
+    P.extensionProductIter n ≤ Q.extensionProductIter n := by
+  induction n with
+  | zero => exact hPQ
+  | succ n h => grw [extensionProductIter_succ, extensionProductIter_succ,
+    monotone_extensionProduct_left _ hPQ, monotone_extensionProduct_right _ h]
+
+lemma monotone'_extensionProductIter [P.ContainsZero] {n m : ℕ} (h : n ≤ m) :
+    P.extensionProductIter n ≤ P.extensionProductIter m := by
+  induction m, h using Nat.le_induction
+  case base => rfl
+  case succ n m hnm h =>
+    refine le_trans h ?_
+    rw [extensionProductIter_succ]
+    exact le_extensionProduct_right P
+
+lemma le_extensionProductIter [P.ContainsZero] (n : ℕ) : P ≤ P.extensionProductIter n :=
+  P.monotone'_extensionProductIter (Nat.zero_le n)
+
+@[simp]
+lemma extensionProductIter_bot (n : ℕ) : extensionProductIter (⊥ : ObjectProperty C) n = ⊥ := by
+  cases n
+  case zero => rw [extensionProductIter_zero]
+  case succ n => rw [extensionProductIter_succ, extensionProduct_bot_left]
+
+@[simp]
+lemma extensionProductIter_top (n : ℕ) : extensionProductIter (⊤ : ObjectProperty C) n = ⊤ :=
+  eq_top_iff.mpr (le_extensionProductIter _ n)
+
+instance [P.IsStableUnderShift ℤ] (n : ℕ) : (P.extensionProductIter n).IsStableUnderShift ℤ := by
+  induction n with
+  | zero => assumption
+  | succ n h =>
+    rw [extensionProductIter_succ]
+    infer_instance
+
+lemma extensionProductIter_le_of_isTriangulatedClosed₂' {Q : ObjectProperty C}
+    [Q.IsTriangulatedClosed₂] (h : P ≤ Q) (n : ℕ) : P.extensionProductIter n ≤ Q.isoClosure := by
+  induction n with
+  | zero =>
+    rw [extensionProductIter_zero]
+    exact h.trans Q.le_isoClosure
+  | succ n H =>
+    rw [extensionProductIter_succ]
+    exact extensionProduct_le_of_isTriangulatedClosed₂ (h.trans Q.le_isoClosure) H
+
+lemma extensionProductIter_le_of_isTriangulatedClosed₂ {Q : ObjectProperty C}
+    [Q.IsTriangulatedClosed₂] [Q.IsClosedUnderIsomorphisms] (h : P ≤ Q) (n : ℕ) :
+    P.extensionProductIter n ≤ Q :=
+  Q.isoClosure_eq_self ▸ P.extensionProductIter_le_of_isTriangulatedClosed₂' h n
+
+instance [P.IsStableUnderShift ℤ] (n : ℕ) : (P.extensionProductIter n).IsStableUnderShift ℤ := by
+  induction n with
+  | zero => rwa [extensionProductIter_zero]
+  | succ n H => rw [extensionProductIter_succ]; infer_instance
+
+lemma extensionProductIter_retractClosure_le {n : ℕ} :
+    (P.retractClosure.extensionProductIter n) ≤ (P.extensionProductIter n).retractClosure := by
+  induction n with
+  | zero => simp
+  | succ n H =>
+    grw [extensionProductIter_succ, extensionProductIter_succ, monotone_extensionProduct_right _ H,
+      extensionProduct_retractClosure_retractClosure_le]
+
+lemma retractClosure_extensionProductIter_retractClosure {n : ℕ} :
+    (P.retractClosure.extensionProductIter n).retractClosure =
+      (P.extensionProductIter n).retractClosure := by
+  apply le_antisymm
+  · rw [retractClosure_le_iff]
+    exact extensionProductIter_retractClosure_le P
+  · exact monotone_retractClosure (monotone_extensionProductIter (le_retractClosure P) n)
 
 end
 


### PR DESCRIPTION
This PR adds some more API to `extensionProduct` and then defines `extensionProductIter`, the `n`-fold extension product of an object property with itself. Note that there is no "neutral element" for the extension product, hence `extensionProductIter P 0` is `P`, and `extensionProductIter P n` is `P * ... * P` with `n+1` terms. See also `extensionProductIter_add`, where this offset is clearly visible.

This is used in the definition of strong generators in #37046.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
