### PR TITLE
fix(Algebra/DirectSum/Internal): mark GradeZero.subring as implicit_reducible

### DIFF
--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -379,7 +379,7 @@ variable [Ring R] [AddMonoid ι] [SetLike σ R] [AddSubgroupClass σ R]
 variable (A : ι → σ) [SetLike.GradedMonoid A]
 
 /-- The subring `A 0` of `R`. -/
-def subring : Subring R where
+@[implicit_reducible] def subring : Subring R where
   carrier := A 0
   __ := subsemiring A
   neg_mem' := neg_mem


### PR DESCRIPTION
Mark `SetLike.GradeZero.subring` as `@[implicit_reducible]` so it unfolds at
`instances` transparency, fixing instance diamond warnings detected by #37013.

The same `@[implicit_reducible]` approach should work for other remaining
diamond warnings where a semireducible `def` creates a type barrier.

🤖 Prepared with Claude Code