### PR TITLE
[Merged by Bors] - chore(MvPolynomial): fix instances

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -89,8 +89,6 @@ section CommSemiring
 
 section Instances
 
-set_option backward.inferInstanceAs.wrap.data false
-
 instance decidableEqMvPolynomial [CommSemiring R] [DecidableEq σ] [DecidableEq R] :
     DecidableEq (MvPolynomial σ R) :=
   Finsupp.instDecidableEq
@@ -100,6 +98,10 @@ instance commSemiring [CommSemiring R] : CommSemiring (MvPolynomial σ R) :=
 
 instance inhabited [CommSemiring R] : Inhabited (MvPolynomial σ R) :=
   ⟨0⟩
+
+instance smul [CommSemiring S₁] [SMulZeroClass R S₁] :
+    SMul R (MvPolynomial σ S₁) where
+  smul a v := v.mapRange (a • ·) (smul_zero _)
 
 instance distribuMulAction [Monoid R] [CommSemiring S₁] [DistribMulAction R S₁] :
     DistribMulAction R (MvPolynomial σ S₁) :=

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -89,58 +89,60 @@ section CommSemiring
 
 section Instances
 
+set_option backward.inferInstanceAs.wrap.data false
+
 instance decidableEqMvPolynomial [CommSemiring R] [DecidableEq σ] [DecidableEq R] :
     DecidableEq (MvPolynomial σ R) :=
   Finsupp.instDecidableEq
 
 instance commSemiring [CommSemiring R] : CommSemiring (MvPolynomial σ R) :=
-  AddMonoidAlgebra.commSemiring
+  inferInstanceAs <| CommSemiring (AddMonoidAlgebra R _)
 
 instance inhabited [CommSemiring R] : Inhabited (MvPolynomial σ R) :=
   ⟨0⟩
 
 instance distribuMulAction [Monoid R] [CommSemiring S₁] [DistribMulAction R S₁] :
     DistribMulAction R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.distribMulAction
+  inferInstanceAs <| DistribMulAction R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance smulZeroClass [CommSemiring S₁] [SMulZeroClass R S₁] :
     SMulZeroClass R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.smulZeroClass
+  inferInstanceAs <| SMulZeroClass R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance faithfulSMul [CommSemiring S₁] [SMulZeroClass R S₁] [FaithfulSMul R S₁] :
     FaithfulSMul R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.faithfulSMul
+  inferInstanceAs <| FaithfulSMul R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance module [Semiring R] [CommSemiring S₁] [Module R S₁] : Module R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.module
+  inferInstanceAs <| Module R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance isScalarTower [CommSemiring S₂] [SMul R S₁] [SMulZeroClass R S₂] [SMulZeroClass S₁ S₂]
     [IsScalarTower R S₁ S₂] : IsScalarTower R S₁ (MvPolynomial σ S₂) :=
-  AddMonoidAlgebra.isScalarTower
+  inferInstanceAs <| IsScalarTower R S₁ (AddMonoidAlgebra S₂ (σ →₀ ℕ))
 
 instance smulCommClass [CommSemiring S₂] [SMulZeroClass R S₂] [SMulZeroClass S₁ S₂]
     [SMulCommClass R S₁ S₂] : SMulCommClass R S₁ (MvPolynomial σ S₂) :=
-  AddMonoidAlgebra.smulCommClass
+  inferInstanceAs <| SMulCommClass R S₁ (AddMonoidAlgebra S₂ (σ →₀ ℕ))
 
 instance isCentralScalar [CommSemiring S₁] [SMulZeroClass R S₁] [SMulZeroClass Rᵐᵒᵖ S₁]
     [IsCentralScalar R S₁] : IsCentralScalar R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.isCentralScalar
+  inferInstanceAs <| IsCentralScalar R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance algebra [CommSemiring R] [CommSemiring S₁] [Algebra R S₁] :
     Algebra R (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.algebra
+  inferInstanceAs <| Algebra R (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance isScalarTower_right [CommSemiring S₁] [DistribSMul R S₁] [IsScalarTower R S₁ S₁] :
     IsScalarTower R (MvPolynomial σ S₁) (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.isScalarTower_self _
+  inferInstanceAs <| IsScalarTower R (AddMonoidAlgebra S₁ (σ →₀ ℕ)) (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 instance smulCommClass_right [CommSemiring S₁] [DistribSMul R S₁] [SMulCommClass R S₁ S₁] :
     SMulCommClass R (MvPolynomial σ S₁) (MvPolynomial σ S₁) :=
-  AddMonoidAlgebra.smulCommClass_self _
+  inferInstanceAs <| SMulCommClass R (AddMonoidAlgebra S₁ (σ →₀ ℕ)) (AddMonoidAlgebra S₁ (σ →₀ ℕ))
 
 /-- If `R` is a subsingleton, then `MvPolynomial σ R` has a unique element -/
 instance unique [CommSemiring R] [Subsingleton R] : Unique (MvPolynomial σ R) :=
-  AddMonoidAlgebra.unique
+  inferInstanceAs <| Unique (AddMonoidAlgebra R (σ →₀ ℕ))
 
 end Instances
 
@@ -198,11 +200,10 @@ theorem C_0 : C 0 = (0 : MvPolynomial σ R) := map_zero _
 theorem C_1 : C 1 = (1 : MvPolynomial σ R) :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 theorem C_mul_monomial : C a * monomial s a' = monomial s (a * a') := by
-  -- Porting note: this `change` feels like defeq abuse, but I can't find the appropriate lemmas
-  change AddMonoidAlgebra.single _ _ * AddMonoidAlgebra.single _ _ = AddMonoidAlgebra.single _ _
-  simp [single_mul_single]
+  have := single_mul_single 0 s a a'
+  rw [zero_add] at this
+  exact this
 
 @[simp]
 theorem C_add : (C (a + a') : MvPolynomial σ R) = C a + C a' :=
@@ -1082,12 +1083,10 @@ lemma coeffsIn_mul (M N : Submodule R S) : coeffsIn σ (M * N) = coeffsIn σ M *
     rw [MvPolynomial.coeff_mul]
     exact sum_mem fun c hc ↦ Submodule.mul_mem_mul (hx _) (hy _)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma coeffsIn_pow : ∀ {n}, n ≠ 0 → ∀ M : Submodule R S, coeffsIn σ (M ^ n) = coeffsIn σ M ^ n
   | 1, _, M => by simp
   | n + 2, _, M => by rw [pow_succ, coeffsIn_mul, coeffsIn_pow, ← pow_succ]; exact n.succ_ne_zero
 
-set_option backward.isDefEq.respectTransparency false in
 lemma le_coeffsIn_pow : ∀ {n}, coeffsIn σ M ^ n ≤ coeffsIn σ (M ^ n)
   | 0 => by simpa using ⟨1, map_one _⟩
   | n + 1 => (coeffsIn_pow n.succ_ne_zero _).ge

--- a/Mathlib/Algebra/MvPolynomial/CommRing.lean
+++ b/Mathlib/Algebra/MvPolynomial/CommRing.lean
@@ -39,7 +39,7 @@ As in other polynomial files, we typically use the notation:
 
 noncomputable section
 
-open Set Function Finsupp AddMonoidAlgebra
+open Set Function Finsupp
 
 universe u v
 
@@ -55,7 +55,7 @@ variable [CommRing R]
 variable {p q : MvPolynomial σ R}
 
 instance instCommRingMvPolynomial : CommRing (MvPolynomial σ R) :=
-  AddMonoidAlgebra.commRing
+  inferInstanceAs <| CommRing (AddMonoidAlgebra R (σ →₀ ℕ))
 
 variable (σ a a')
 

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -577,7 +577,6 @@ theorem mapAlgHom_coe_ringHom [CommSemiring S₂] [Algebra R S₁] [Algebra R S�
       (map ↑f : MvPolynomial σ S₁ →+* MvPolynomial σ S₂) :=
   RingHom.mk_coe _ _ _ _ _
 
-set_option backward.isDefEq.respectTransparency false in
 lemma range_mapAlgHom [CommSemiring S₂] [Algebra R S₁] [Algebra R S₂] (f : S₁ →ₐ[R] S₂) :
     (mapAlgHom f).range.toSubmodule = coeffsIn σ f.range.toSubmodule := by
   ext

--- a/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
@@ -12,7 +12,7 @@ public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 /-!
 # Matrices of multivariate polynomials
 
-In this file, we prove results about matrices over an `MVPolynomial` ring.
+In this file, we prove results about matrices over an `MvPolynomial` ring.
 In particular, we provide `Matrix.mvPolynomialX` which associates every entry of a matrix with a
 unique variable.
 

--- a/Mathlib/RingTheory/MvPolynomial.lean
+++ b/Mathlib/RingTheory/MvPolynomial.lean
@@ -44,16 +44,12 @@ theorem quotient_mk_comp_C_injective [Field K] (I : Ideal (MvPolynomial σ K)) (
 variable {σ K} [CommRing K] [Nontrivial K]
 open Cardinal
 
-set_option backward.isDefEq.respectTransparency false in
 theorem rank_eq_lift : Module.rank K (MvPolynomial σ K) = lift.{v} #(σ →₀ ℕ) := by
   rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank, lift_lift, lift_umax.{u, v}]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem rank_eq {σ : Type v} : Module.rank K (MvPolynomial σ K) = #(σ →₀ ℕ) := by
   rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank]
 
-#adaptation_note /-- Needed after leanprover/lean4#12564 -/
-set_option backward.inferInstanceAs.wrap false in
 instance : Module K (MvPolynomial σ K) :=
   inferInstanceAs <| Module K (AddMonoidAlgebra K (σ →₀ ℕ))
 

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -116,7 +116,6 @@ lemma monomial_mem_restrictSupport {s : Set (σ →₀ ℕ)} {m} {r : R} :
   classical
   by_cases r = 0 <;> simp [mem_restrictSupport_iff, support_monomial, *]
 
-set_option backward.isDefEq.respectTransparency false in
 open Pointwise in
 lemma restrictSupport_add (s t : Set (σ →₀ ℕ)) :
     restrictSupport R (s + t) = restrictSupport R s * restrictSupport R t := by
@@ -142,7 +141,6 @@ open Pointwise in
 lemma restrictSupport_univ : restrictSupport R (.univ : Set (σ →₀ ℕ)) = ⊤ := by
   ext; simp [mem_restrictSupport_iff]
 
-set_option backward.isDefEq.respectTransparency false in
 open Pointwise in
 lemma restrictSupport_nsmul (n : ℕ) (s : Set (σ →₀ ℕ)) :
     restrictSupport R (n • s) = restrictSupport R s ^ n := by

--- a/Mathlib/RingTheory/MvPolynomial/EulerIdentity.lean
+++ b/Mathlib/RingTheory/MvPolynomial/EulerIdentity.lean
@@ -28,6 +28,7 @@ open Finsupp
 
 variable {R σ M : Type*} [CommSemiring R] {φ : MvPolynomial σ R}
 
+set_option backward.isDefEq.respectTransparency false in
 protected lemma IsWeightedHomogeneous.pderiv [AddCancelCommMonoid M] {w : σ → M} {n n' : M} {i : σ}
     (h : φ.IsWeightedHomogeneous w n) (h' : n' + w i = n) :
     (pderiv i φ).IsWeightedHomogeneous w n' := by


### PR DESCRIPTION
This PR uses the new `inferInstanceAs` to clean up the instances of `MvPolynomial`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
