### PR TITLE
fix(Colimit/Ring, Padics): fix instance diamonds via inferInstanceAs

### DIFF
--- a/Mathlib/Algebra/Colimit/Ring.lean
+++ b/Mathlib/Algebra/Colimit/Ring.lean
@@ -61,11 +61,14 @@ def DirectLimit : Type _ :=
 
 namespace DirectLimit
 
+instance addCommMonoid : AddCommMonoid (DirectLimit G f) :=
+  inferInstanceAs <| AddCommMonoid (FreeCommRing (Σ i, G i) ⧸ _)
+
+instance addCommGroup : AddCommGroup (DirectLimit G f) :=
+  inferInstanceAs <| AddCommGroup (FreeCommRing (Σ i, G i) ⧸ _)
+
 instance commRing : CommRing (DirectLimit G f) :=
   Ideal.Quotient.commRing _
-
-instance ring : Ring (DirectLimit G f) :=
-  CommRing.toRing
 
 -- Porting note: Added a `Zero` instance to get rid of `0` errors.
 instance zero : Zero (DirectLimit G f) := by

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -545,11 +545,14 @@ instance : Inhabited ℚ_[p] :=
   ⟨0⟩
 
 -- short circuits
+instance : AddCommMonoid ℚ_[p] :=
+  inferInstanceAs <| AddCommMonoid (CauSeq.Completion.Cauchy (padicNorm p))
+
+instance : AddCommGroup ℚ_[p] :=
+  inferInstanceAs <| AddCommGroup (CauSeq.Completion.Cauchy (padicNorm p))
+
 instance : CommRing ℚ_[p] :=
   Cauchy.commRing
-
-instance : Ring ℚ_[p] :=
-  Cauchy.ring
 
 instance : Zero ℚ_[p] := by infer_instance
 
@@ -564,8 +567,6 @@ instance : Sub ℚ_[p] := by infer_instance
 instance : Neg ℚ_[p] := by infer_instance
 
 instance : Div ℚ_[p] := by infer_instance
-
-instance : AddCommGroup ℚ_[p] := by infer_instance
 
 /-- Builds the equivalence class of a Cauchy sequence of rationals. -/
 def mk : PadicSeq p → ℚ_[p] :=


### PR DESCRIPTION
Fix AddCommMonoid diamonds on DirectLimit and Padic detected by #37013.

The fix: add standalone additive instances via `inferInstanceAs` with the
underlying type, and remove the `Ring` short circuit (`CommRing.toRing`)
which was the diamond source.

🤖 Prepared with Claude Code