### PR TITLE
[Merged by Bors] - chore(ENat): clean up `deriving` instances

### DIFF
--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -76,6 +76,7 @@ theorem trinomial_natDegree (hkm : k < m) (hmn : m < n) (hw : w ≠ 0) :
   · exact WithBot.coe_le_coe.mpr hmn.le
   · exact le_rfl
 
+set_option backward.isDefEq.respectTransparency false in
 theorem trinomial_natTrailingDegree (hkm : k < m) (hmn : m < n) (hu : u ≠ 0) :
     (trinomial k m n u v w).natTrailingDegree = k := by
   refine

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -645,7 +645,7 @@ lemma exists_isCycle_of_two_le_isEdgeReachable {u v : V} (huv : u ≠ v) {n : �
     (h : G.IsEdgeReachable n u v) : ∃ w : G.Walk u u, w.IsCycle := by
   classical
   obtain ⟨w, hw, h⟩ := exists_adj_isEdgeReachable_two huv (h.anti hn)
-  have := @h {s(u, w)} (by simp; norm_cast)
+  have := @h {s(u, w)} (by simp)
   obtain ⟨w, p, hp₁, hp₂⟩ := adj_and_reachable_delete_edges_iff_exists_cycle.mp ⟨hw, this⟩
   exact ⟨p.rotate _ (p.fst_mem_support_of_mem_edges hp₂), IsCycle.rotate hp₁ _⟩
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -69,9 +69,6 @@ theorem coe_inj {a b : ℕ} : (a : ℕ∞) = b ↔ a = b := WithTop.coe_inj
 
 @[simp] theorem succ_top : SuccOrder.succ (⊤ : ℕ∞) = ⊤ := rfl
 
-@[simp] theorem top_add {x : ℕ∞} : ⊤ + x = ⊤ := WithTop.top_add x
-@[simp] theorem add_top {x : ℕ∞} : x + ⊤ = ⊤ := WithTop.add_top x
-
 instance : SuccAddOrder ℕ∞ where
   succ_eq_add_one x := by cases x <;> simp
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -44,14 +44,11 @@ assert_not_exists Field
 
 deriving instance Nontrivial,
   Add, Sub, LE, LT, Bot,
-  Preorder, LinearOrder, OrderTop, OrderBot, WellFoundedLT,
+  Preorder, LinearOrder, OrderTop, OrderBot, WellFoundedLT, SuccOrder,
   AddMonoidWithOne, CommSemiring, LinearOrderedAddCommMonoidWithTop,
   ZeroLEOneClass, OrderedSub, CanonicallyOrderedAdd, IsOrderedRing,
   CharZero, NoZeroDivisors
   for ENat
-
-set_option backward.inferInstanceAs.wrap.data false in
-deriving instance SuccOrder for ENat
 
 namespace ENat
 
@@ -63,9 +60,7 @@ variable {a b c d m n : ℕ∞}
 
 theorem coe_inj {a b : ℕ} : (a : ℕ∞) = b ↔ a = b := WithTop.coe_inj
 
-@[simp] theorem succ_coe (n : ℕ) : SuccOrder.succ (n : ℕ∞) = (n + 1 : ℕ) := by
-  simp [SuccOrder.succ]
-  rfl
+@[simp] theorem succ_coe (n : ℕ) : SuccOrder.succ (n : ℕ∞) = (n + 1 : ℕ) := WithTop.succ_coe
 
 @[simp] theorem succ_top : SuccOrder.succ (⊤ : ℕ∞) = ⊤ := rfl
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -42,34 +42,14 @@ open Function
 
 assert_not_exists Field
 
-deriving instance Nontrivial,
-  LinearOrder, Bot, Sub,
-  IsOrderedRing, CanonicallyOrderedAdd,
-  OrderBot, OrderTop, OrderedSub,
-  WellFoundedLT,
-  CharZero,
-  NoZeroDivisors,
-  ZeroLEOneClass
-  for ENat
-
-set_option backward.inferInstanceAs.wrap false in
-deriving instance LinearOrderedAddCommMonoidWithTop for ENat
-
 set_option backward.inferInstanceAs.wrap.data false in
-deriving instance SuccOrder for ENat
-
-deriving instance CanonicallyOrderedAdd for ENat
-
-#adaptation_note /-- Upon bumping to v4.29.0-rc3, we write out the `CommSemiring` instance rather
-than using `deriving`, to ensure that the `NatCast` instance is definitionally equal to the one
-expected by `grind`. The `deriving` mechanism produces a `NatCast` instance
-(`ENat.instNatCast`) that is not reducibly defeq to `Lean.Grind.Semiring.natCast`.
-See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/576566138
--/
-instance : CommSemiring ENat := {
-  __ := (inferInstance : CommSemiring (WithTop ℕ))
-  toNatCast := inferInstance
-}
+deriving instance Nontrivial,
+  Add, Sub, LE, LT, Bot,
+  Preorder, SuccOrder, LinearOrder, OrderTop, OrderBot, WellFoundedLT,
+  AddMonoidWithOne, CommSemiring, LinearOrderedAddCommMonoidWithTop,
+  ZeroLEOneClass, OrderedSub, CanonicallyOrderedAdd, IsOrderedRing,
+  CharZero, NoZeroDivisors
+  for ENat
 
 namespace ENat
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -42,14 +42,16 @@ open Function
 
 assert_not_exists Field
 
-set_option backward.inferInstanceAs.wrap.data false in
 deriving instance Nontrivial,
   Add, Sub, LE, LT, Bot,
-  Preorder, SuccOrder, LinearOrder, OrderTop, OrderBot, WellFoundedLT,
+  Preorder, LinearOrder, OrderTop, OrderBot, WellFoundedLT,
   AddMonoidWithOne, CommSemiring, LinearOrderedAddCommMonoidWithTop,
   ZeroLEOneClass, OrderedSub, CanonicallyOrderedAdd, IsOrderedRing,
   CharZero, NoZeroDivisors
   for ENat
+
+set_option backward.inferInstanceAs.wrap.data false in
+deriving instance SuccOrder for ENat
 
 namespace ENat
 

--- a/Mathlib/Data/ENat/Defs.lean
+++ b/Mathlib/Data/ENat/Defs.lean
@@ -12,7 +12,6 @@ public import Mathlib.Order.TypeTags
 
 @[expose] public section
 
-set_option backward.inferInstanceAs.wrap.data false in
 /-- Extended natural numbers `ℕ∞ = WithTop ℕ`. -/
 def ENat : Type := WithTop ℕ deriving Top, Inhabited
 

--- a/Mathlib/Data/ENat/Defs.lean
+++ b/Mathlib/Data/ENat/Defs.lean
@@ -12,6 +12,7 @@ public import Mathlib.Order.TypeTags
 
 @[expose] public section
 
+set_option backward.inferInstanceAs.wrap.data false in
 /-- Extended natural numbers `ℕ∞ = WithTop ℕ`. -/
 def ENat : Type := WithTop ℕ deriving Top, Inhabited
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -170,7 +170,6 @@ theorem finite_of_encard_le_coe {k : ℕ} (h : s.encard ≤ k) : s.Finite := by
 theorem finite_of_encard_eq_coe {k : ℕ} (h : s.encard = k) : s.Finite :=
   finite_of_encard_le_coe h.le
 
-set_option backward.isDefEq.respectTransparency false in
 theorem encard_le_coe_iff {k : ℕ} : s.encard ≤ k ↔ s.Finite ∧ ∃ (n₀ : ℕ), s.encard = n₀ ∧ n₀ ≤ k :=
   ⟨fun h ↦ ⟨finite_of_encard_le_coe h, by rwa [ENat.le_coe_iff] at h⟩,
     fun ⟨_,⟨n₀,hs, hle⟩⟩ ↦ by rwa [hs, Nat.cast_le]⟩
@@ -331,6 +330,7 @@ theorem encard_eq_add_one_iff {k : ℕ∞} :
   rintro ⟨a, t, h, rfl, rfl⟩
   rw [encard_insert_of_notMem h]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Every set is either empty, infinite, or can have its `encard` reduced by a removal. Intended
   for well-founded induction on the value of `encard`. -/
 theorem eq_empty_or_encard_eq_top_or_encard_diff_singleton_lt (s : Set α) :
@@ -614,7 +614,6 @@ theorem encard_le_coe_iff_finite_ncard_le {k : ℕ} : s.encard ≤ k ↔ s.Finit
 theorem Infinite.ncard (hs : s.Infinite) : s.ncard = 0 := by
   rw [← _root_.Nat.card_coe_set_eq, @Nat.card_eq_zero_of_infinite _ hs.to_subtype]
 
-set_option backward.isDefEq.respectTransparency false in
 @[gcongr]
 theorem ncard_le_ncard (hst : s ⊆ t) (ht : t.Finite := by toFinite_tac) :
     s.ncard ≤ t.ncard := by
@@ -623,7 +622,6 @@ theorem ncard_le_ncard (hst : s ⊆ t) (ht : t.Finite := by toFinite_tac) :
 
 theorem ncard_mono [Finite α] : @Monotone (Set α) _ _ _ ncard := fun _ _ ↦ ncard_le_ncard
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] theorem ncard_eq_zero (hs : s.Finite := by toFinite_tac) :
     s.ncard = 0 ↔ s = ∅ := by
   rw [← Nat.cast_inj (R := ℕ∞), hs.cast_ncard_eq, Nat.cast_zero, encard_eq_zero]
@@ -659,7 +657,6 @@ theorem nonempty_of_ncard_ne_zero (hs : s.ncard ≠ 0) : s.Nonempty := by
 @[simp] theorem ncard_singleton (a : α) : ({a} : Set α).ncard = 1 := by
   simp [ncard]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_singleton_inter (a : α) (s : Set α) : ({a} ∩ s).ncard ≤ 1 := by
   rw [← Nat.cast_le (α := ℕ∞), (toFinite _).cast_ncard_eq, Nat.cast_one]
   apply encard_singleton_inter
@@ -677,7 +674,6 @@ theorem ncard_powerset (s : Set α) (hs : s.Finite := by toFinite_tac) :
 
 section InsertErase
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] theorem ncard_insert_of_notMem {a : α} (h : a ∉ s) (hs : s.Finite := by toFinite_tac) :
     (insert a s).ncard = s.ncard + 1 := by
   rw [← Nat.cast_inj (R := ℕ∞), (hs.insert a).cast_ncard_eq, Nat.cast_add, Nat.cast_one,
@@ -686,7 +682,6 @@ set_option backward.isDefEq.respectTransparency false in
 theorem ncard_insert_of_mem {a : α} (h : a ∈ s) : ncard (insert a s) = s.ncard := by
   rw [insert_eq_of_mem h]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_insert_le (a : α) (s : Set α) : (insert a s).ncard ≤ s.ncard + 1 := by
   obtain hs | hs := s.finite_or_infinite
   · to_encard_tac; rw [hs.cast_ncard_eq, (hs.insert _).cast_ncard_eq]; apply encard_insert_le
@@ -712,7 +707,6 @@ theorem ncard_le_ncard_insert (a : α) (s : Set α) : s.ncard ≤ (insert a s).n
 theorem ncard_pair {a b : α} (h : a ≠ b) : ({a, b} : Set α).ncard = 2 := by
   simp [h]
 
-set_option backward.isDefEq.respectTransparency false in
 -- removing `@[simp]` because the LHS is not in simp normal form
 theorem ncard_diff_singleton_add_one {a : α} (h : a ∈ s)
     (hs : s.Finite := by toFinite_tac) : (s \ {a}).ncard + 1 = s.ncard := by
@@ -762,7 +756,6 @@ end InsertErase
 
 variable {f : α → β}
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_image_le (hs : s.Finite := by toFinite_tac) : (f '' s).ncard ≤ s.ncard := by
   to_encard_tac; rw [hs.cast_ncard_eq, (hs.image _).cast_ncard_eq]; apply encard_image_le
 
@@ -771,7 +764,6 @@ theorem InjOn.ncard_image (H : Set.InjOn f s) : (f '' s).ncard = s.ncard :=
 
 @[deprecated (since := "2026-01-30")] alias ncard_image_of_injOn := InjOn.ncard_image
 
-set_option backward.isDefEq.respectTransparency false in
 theorem injOn_of_ncard_image_eq (h : (f '' s).ncard = s.ncard) (hs : s.Finite := by toFinite_tac) :
     Set.InjOn f s := by
   rw [← Nat.cast_inj (R := ℕ∞), hs.cast_ncard_eq, (hs.image _).cast_ncard_eq] at h
@@ -813,7 +805,6 @@ theorem ncard_inter_le_ncard_right (s t : Set α) (ht : t.Finite := by toFinite_
     (s ∩ t).ncard ≤ t.ncard :=
   ncard_le_ncard inter_subset_right ht
 
-set_option backward.isDefEq.respectTransparency false in
 theorem eq_of_subset_of_ncard_le (h : s ⊆ t) (h' : t.ncard ≤ s.ncard)
     (ht : t.Finite := by toFinite_tac) : s = t :=
   ht.eq_of_subset_of_encard_le' h
@@ -831,7 +822,6 @@ theorem sep_of_ncard_eq {a : α} {P : α → Prop} (h : { x ∈ s | P x }.ncard 
     (hs : s.Finite := by toFinite_tac) : P a :=
   sep_eq_self_iff_mem_true.mp (eq_of_subset_of_ncard_le (by simp) h.symm.le hs) _ ha
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_lt_ncard (h : s ⊂ t) (ht : t.Finite := by toFinite_tac) :
     s.ncard < t.ncard := by
   rw [← Nat.cast_lt (α := ℕ∞), ht.cast_ncard_eq, (ht.subset h.subset).cast_ncard_eq]
@@ -878,7 +868,6 @@ theorem ncard_congr {t : Set β} (f : ∀ a ∈ s, β) (h₁ : ∀ a ha, f a ha 
 theorem ncard_congr' {S : Set α} {T : Set β} (f : S ≃ T) : Set.ncard S = Set.ncard T :=
   Cardinal.toNat_congr f
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_le_ncard_of_injOn {t : Set β} (f : α → β) (hf : ∀ a ∈ s, f a ∈ t) (f_inj : InjOn f s)
     (ht : t.Finite := by toFinite_tac) :
     s.ncard ≤ t.ncard := by
@@ -957,7 +946,6 @@ theorem ncard_coe {α : Type*} (s : Set α) :
 
 section Lattice
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_union_add_ncard_inter (s t : Set α) (hs : s.Finite := by toFinite_tac)
     (ht : t.Finite := by toFinite_tac) : (s ∪ t).ncard + (s ∩ t).ncard = s.ncard + t.ncard := by
   to_encard_tac; rw [hs.cast_ncard_eq, ht.cast_ncard_eq, (hs.union ht).cast_ncard_eq,
@@ -967,7 +955,6 @@ theorem ncard_inter_add_ncard_union (s t : Set α) (hs : s.Finite := by toFinite
     (ht : t.Finite := by toFinite_tac) : (s ∩ t).ncard + (s ∪ t).ncard = s.ncard + t.ncard := by
   rw [add_comm, ncard_union_add_ncard_inter _ _ hs ht]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_union_le (s t : Set α) : (s ∪ t).ncard ≤ s.ncard + t.ncard := by
   obtain (h | h) := (s ∪ t).finite_or_infinite
   · to_encard_tac
@@ -977,7 +964,6 @@ theorem ncard_union_le (s t : Set α) : (s ∪ t).ncard ≤ s.ncard + t.ncard :=
   rw [h.ncard]
   apply zero_le
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_union_eq (h : Disjoint s t) (hs : s.Finite := by toFinite_tac)
     (ht : t.Finite := by toFinite_tac) : (s ∪ t).ncard = s.ncard + t.ncard := by
   to_encard_tac
@@ -993,7 +979,6 @@ theorem ncard_union_lt (hs : s.Finite := by toFinite_tac)
     (s ∪ t).ncard < s.ncard + t.ncard :=
   (ncard_union_le s t).lt_of_ne (mt (ncard_union_eq_iff hs ht).mp h)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_diff_add_ncard_of_subset (h : s ⊆ t) (ht : t.Finite := by toFinite_tac) :
     (t \ s).ncard + s.ncard = t.ncard := by
   to_encard_tac
@@ -1010,7 +995,6 @@ lemma cast_ncard_sdiff {R : Type*} [AddGroupWithOne R] (hst : s ⊆ t) (ht : t.F
     ((t \ s).ncard : R) = t.ncard - s.ncard := by
   rw [ncard_diff hst (ht.subset hst), Nat.cast_sub (ncard_le_ncard hst ht)]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ncard_le_ncard_diff_add_ncard (s t : Set α) (ht : t.Finite := by toFinite_tac) :
     s.ncard ≤ (s \ t).ncard + t.ncard := by
   rcases s.finite_or_infinite with hs | hs

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -155,7 +155,6 @@ theorem weightedOrder_eq_top_iff :
     f.weightedOrder w = ⊤ ↔ f = 0 := by
   rw [← not_iff_not, ← ne_eq, ← ne_eq, ne_zero_iff_weightedOrder_finite w, coe_toNat_eq_self]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If the order of a formal power series `f` is finite,
 then some coefficient of weight equal to the order of `f` is nonzero. -/
 theorem exists_coeff_ne_zero_and_weightedOrder
@@ -166,7 +165,6 @@ theorem exists_coeff_ne_zero_and_weightedOrder
   generalize_proofs h1
   exact Nat.find_spec h1
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If the `d`th coefficient of a formal power series is nonzero,
 then the weighted order of the power series is less than or equal to `weight d w`. -/
 theorem weightedOrder_le {d : σ →₀ ℕ} (h : coeff d f ≠ 0) :
@@ -182,7 +180,6 @@ theorem coeff_eq_zero_of_lt_weightedOrder {d : σ →₀ ℕ} (h : (weight w d) 
     coeff d f = 0 := by
   contrapose! h; exact weightedOrder_le w h
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The order of a formal power series is at least `n` if
 the `d`th coefficient is `0` for all `d` such that `weight w d < n`. -/
 theorem nat_le_weightedOrder {n : ℕ} (h : ∀ d, weight w d < n → coeff d f = 0) :
@@ -194,7 +191,6 @@ theorem nat_le_weightedOrder {n : ℕ} (h : ∀ d, weight w d < n → coeff d f 
   rw [← hd, Nat.cast_lt] at H
   exact hfd (h d H)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The order of a formal power series is at least `n` if
 the `d`th coefficient is `0` for all `d` such that `weight w d < n`. -/
 theorem le_weightedOrder {n : ℕ∞} (h : ∀ d : σ →₀ ℕ, weight w d < n → coeff d f = 0) :
@@ -205,7 +201,6 @@ theorem le_weightedOrder {n : ℕ∞} (h : ∀ d : σ →₀ ℕ, weight w d < n
   · apply nat_le_weightedOrder;
     simpa only [ENat.some_eq_coe, Nat.cast_lt] using h
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The order of a formal power series is exactly `n` if and only if some coefficient of weight `n`
 is nonzero, and the `d`th coefficient is `0` for all `d` such that `weight w d < n`. -/
 theorem weightedOrder_eq_nat {n : ℕ} :
@@ -253,7 +248,6 @@ theorem min_weightedOrder_le_add :
     [coeff_eq_zero_of_lt_weightedOrder w, lt_min_iff, map_add, add_zero,
       imp_true_iff]
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem weightedOrder_add_of_weightedOrder_lt.aux
     (H : f.weightedOrder w < g.weightedOrder w) :
     (f + g).weightedOrder w = f.weightedOrder w := by
@@ -484,7 +478,6 @@ theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*}
     (f : ι → MvPowerSeries σ R) (s : Finset ι) : ∑ i ∈ s, (f i).order ≤ (∏ i ∈ s, f i).order :=
   le_weightedOrder_prod _ _ _
 
-set_option backward.isDefEq.respectTransparency false in
 theorem one_le_order_iff_constCoeff_eq_zero :
     1 ≤ f.order ↔ f.constantCoeff = 0 := by
   constructor
@@ -624,7 +617,6 @@ theorem weightedHomogeneousComponent_of_lt_weightedOrder_eq_zero
     exact hf
   · rw [map_zero]
 
-set_option backward.isDefEq.respectTransparency false in
 variable {w} in
 theorem weightedHomogeneousComponent_of_weightedOrder
     {f : MvPowerSeries σ R} {p : ℕ} (hf : p = f.weightedOrder w) :


### PR DESCRIPTION
This PR cleans up the `deriving` clause for `ENat`. in particular, the `CharP` instance was being derived before `ENat` had a `AddMonoidWithOne` instance, which corrupted the `CharP` instance.

I added a few shortcut instances to the `deriving`, as this typically gives some speedup.

This PR removes `ENat.top_add` and `ENat.add_top` without deprecation, because they are now superseded by `top_add` and `add_top` in the root namespace. In particular I think it would be harmful to add the deprecations, because without deprecations, we automatically switch to using the ones from the root namespace.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
