### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `noncomm_ring` tactic docstring

### DIFF
--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -35,15 +35,32 @@ lemma mul_nat_lit_eq_nsmul [n.AtLeastTwo] : r * ofNat(n) = OfNat.ofNat n • r :
 end nat_lit_mul
 
 open Lean.Parser.Tactic
-/-- A tactic for simplifying identities in not-necessarily-commutative rings.
+/-- `noncomm_ring` simplifies expressions in not-necessarily-commutative rings in the main goal
+then tries closing it by "cheap" (reducible) `rfl`.
+This tactic supports the operators `+`, `*`, `-`, `^` and `•` (for scalar multiplication by
+natural numbers or integers).
 
-An example:
+The tactic is implemented as a combination of `simp only [...]` and `abel`. The precise invocation
+of `simp only` can be customized using the options listed below.
+
+Limitation: numeric powers are unfolded entirely with `pow_succ` and can easily exceed the
+maximum recursion depth.
+
+* `noncomm_ring [h]` adds the term `h` as simplification lemma, rewriting from left to right.
+  Multiple arguments can be combined as `noncomm_ring [h₁, ..., hₙ]`.
+* `noncomm_ring [← h]` adds the term `h` as simplification lemma, rewriting from right to left.
+* `noncomm_ring [*]` simplifies using all hypotheses in the local context.
+* `noncomm_ring (config := cfg)` uses `cfg` as configuration for the simplification step.
+  See `Lean.Meta.Simp.Config` for more details.
+* `noncomm_ring (discharger := tac)` uses the tactic sequence `tac` to discharge assumptions
+  to the simplification lemmas. This only applies to user-supplied lemmas, since the default lemmas
+  used by `noncomm_ring` do not require a discharger.
+
+Example:
 ```lean
 example {R : Type*} [Ring R] (a b c : R) : a * (b + c + c - b) = 2 * a * c := by
   noncomm_ring
 ```
-
-You can use `noncomm_ring [h]` to also simplify using `h`.
 -/
 syntax (name := noncomm_ring) "noncomm_ring" optConfig (discharger)?
   (" [" ((simpStar <|> simpErase <|> simpLemma),*,?) "]")? : tactic

--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -40,6 +40,7 @@ then tries closing it by "cheap" (reducible) `rfl`.
 This tactic supports the operators `+`, `*`, `-`, `^` and `•` (for scalar multiplication by
 natural numbers or integers).
 
+If the ring is commutative, prefer the `ring` tactic instead, which is more powerful and efficient.
 The tactic is implemented as a combination of `simp only [...]` and `abel`. The precise invocation
 of `simp only` can be customized using the options listed below.
 


### PR DESCRIPTION
This PR rewrites the docstrings for the `noncomm_ring` tactic, to consistently match the official style guide, to make sure they are complete while not getting too long.

In particular adding all the configuration options and explaining the relations between this and other tactics.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
