### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `nontriviality` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Nontriviality/Core.lean
+++ b/Mathlib/Tactic/Nontriviality/Core.lean
@@ -58,41 +58,39 @@ def nontrivialityByAssumption (g : MVarId) : MetaM Unit := do
     _ ← processSyntax {maxDepth := 6}
       false false [← `(nontrivial_of_ne), ← `(nontrivial_of_lt)] [] #[] [g]
 
-/-- Attempts to generate a `Nontrivial α` hypothesis.
+/-- `nontriviality α` generates a proof of `Nontrivial α` and adds this as a hypothesis.
 
-The tactic first checks to see that there is not already a `Nontrivial α` instance
-before trying to synthesize one using other techniques.
+The tactic first tries to find a proof of `Nontrivial α` using instance synthesis.
+If this fails, it will derive this proof using `a < b`, `a ≠ b` or `a > b` hypotheses in the
+local context. Otherwise it will perform a case split on `Subsingleton α ∨ Nontrivial α`, and
+attempt to prove `Subsingleton α` implies the main goal using `simp [nontriviality]`.
+If the `Subsingleton` goal cannot be closed automatically, `nontriviality` fails.
 
-If the goal is an (in)equality, the type `α` is inferred from the goal.
-Otherwise, the type needs to be specified in the tactic invocation, as `nontriviality α`.
+This tactic is extensible: tag a lemma with `@[nontriviality]` to use it in the `simp` set for the
+`Subsingleton` case. All `@[simp]` lemmas are automatically used too.
 
-The `nontriviality` tactic will first look for strict inequalities amongst the hypotheses,
-and use these to derive the `Nontrivial` instance directly.
+* `nontriviality` (without the argument `α`) infers the type from the main goal,
+  if the goal is an (in)equality.
+* `nontriviality using h₁, h₂, ..., hₙ` uses `h₁`, ..., `hₙ` as extra arguments to `simp`
+  in the `Subsingleton` case. This supports the typical `simp` argument syntax:
+  `nontriviality using ← h` rewrites right-to-left with this argument;
+  `nontriviality using -h` removes a lemma from the default `simp` set for this tactic invocation.
+  `nontriviality using *` adds all local hypotheses to the `simp` set.
 
-Otherwise, it will perform a case split on `Subsingleton α ∨ Nontrivial α`, and attempt to discharge
-the `Subsingleton` goal using `simp [h₁, h₂, ..., hₙ, nontriviality]`, where `[h₁, h₂, ..., hₙ]` is
-a list of additional `simp` lemmas that can be passed to `nontriviality` using the syntax
-`nontriviality α using h₁, h₂, ..., hₙ`.
-
+Examples:
 ```
 example {R : Type} [OrderedRing R] {a : R} (h : 0 < a) : 0 < a := by
   nontriviality -- There is now a `Nontrivial R` hypothesis available.
   assumption
-```
 
-```
 example {R : Type} [CommRing R] {r s : R} : r * s = s * r := by
   nontriviality -- There is now a `Nontrivial R` hypothesis available.
   apply mul_comm
-```
 
-```
 example {R : Type} [OrderedRing R] {a : R} (h : 0 < a) : (2 : ℕ) ∣ 4 := by
   nontriviality R -- there is now a `Nontrivial R` hypothesis available.
   dec_trivial
-```
 
-```
 def myeq {α : Type} (a b : α) : Prop := a = b
 
 example {α : Type} (a b : α) (h : a = b) : myeq a b := by


### PR DESCRIPTION
This PR rewrites the docstrings for the `nontriviality` tactic, to consistently match the official style guide, to make sure they are complete while not getting too long.

This is mostly just restructuring and adding a few more details.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
