### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `positivity` tactic and `@[positivity]` attr docstrings

### DIFF
--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -30,8 +30,10 @@ The term (with underscores) `t` indicates which expressions this extension accep
 An extension will be given an expression `e : α`, together with hypotheses
 `[Zero α] [PartialOrder α]` and attempts to prove `e > 0`, `e ≥ 0`, or `e ≠ 0`.
 
-It is not guaranteed that the extension is called on expressions that match `t` perfectly:
-validate the form of the expression before building a proof.
+When `Positivity.core` calls this extension on an expression `e`, it does not guarantee that `e`
+matches `t` perfectly: validate the form of the expression (using e.g.
+`match_expr (← withReducible (whnf e))`) before building a proof. See also the
+`let .app ... ← withReducible (whnf e) | throwError ...` lines in the example below.
 
 An extension can call `Mathlib.Meta.Positivity.core` to recursively solve subgoals.
 

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -25,7 +25,27 @@ public meta section
 open Lean
 open Lean.Meta Qq Lean.Elab Term
 
-/-- Attribute for identifying `positivity` extensions. -/
+/-- A definition of type `PositivityExt` tagged `@[positivity t]` extends the `positivity` tactic.
+The term (with underscores) `t` indicates which expressions this extension accepts.
+An extension will be given an expression `e : α`, together with hypotheses
+`[Zero α] [PartialOrder α]` and attempts to prove `e > 0`, `e ≥ 0`, or `e ≠ 0`.
+
+It is not guaranteed that the extension is called on expressions that match `t` perfectly:
+validate the form of the expression before building a proof.
+
+An extension can call `Mathlib.Meta.Positivity.core` to recursively solve subgoals.
+
+Example:
+```lean
+@[positivity ite _ _ _] def evalIte : PositivityExt where eval {u α} zα pα e := do
+  let .app (.app (.app (.app f (p : Q(Prop))) (_ : Q(Decidable $p))) (a : Q($α))) (b : Q($α))
+    ← withReducible (whnf e) | throwError "not ite"
+  haveI' : $e =Q ite $p $a $b := ⟨⟩
+  guard <| ← withDefault <| withNewMCtxDepth <| isDefEq f q(ite (α := $α))
+  let ra ← core zα pα a; let rb ← core zα pα b
+  ...
+```
+-/
 syntax (name := positivity) "positivity " term,+ : attr
 
 lemma ne_of_ne_of_eq' {α : Sort*} {a c b : α} (hab : (a : α) ≠ c) (hbc : a = b) : b ≠ c := hbc ▸ hab
@@ -490,14 +510,23 @@ namespace Tactic.Positivity
 
 open Tactic
 
-/-- Tactic solving goals of the form `0 ≤ x`, `0 < x` and `x ≠ 0`.  The tactic works recursively
-according to the syntax of the expression `x`, if the atoms composing the expression all have
-numeric lower bounds which can be proved positive/nonnegative/nonzero by `norm_num`.  This tactic
-either closes the goal or fails.
+/-- `positivity` solves goals of the form `0 ≤ x`, `0 < x` and `x ≠ 0`. The tactic works recursively
+according to the syntax of the expression `x`, by attempting to prove subexpressions are
+positive/nonnegative/nonzero and combining this into a final proof. This tactic either closes the
+goal or fails.
 
-`positivity [t₁, …, tₙ]` first executes `have := t₁; …; have := tₙ` in the current goal,
-then runs `positivity`. This is useful when `positivity` needs derived premises such as `0 < y`
-for division/reciprocal, or `0 ≤ x` for real powers.
+For each subexpression `e`, `positivity` will try to:
+* try `@[positivity]`-tagged extensions to recursively prove `e` is positive/nonnegative/nonzero
+  based on its subexpressions (see the `positivity` attribute for more details), or
+* try the `norm_num` tactic to prove `e` is positive/nonnegative/nonzero, or
+* try showing `e : t` is nonnegative because there is a `CanonicallyOrderedAdd t` instance, or
+* use a local hypothesis of the form `0 ≤ e`, `0 < e` or `e ≠ 0`.
+
+This tactic is extensible. See the `positivity` attribute documentation for more details.
+
+* `positivity [t₁, …, tₙ]` first executes `have := t₁; …; have := tₙ` in the current goal,
+  then runs `positivity`. This is useful when `positivity` needs derived premises such as `0 < y`
+  for division/reciprocal, or `0 ≤ x` for real powers.
 
 Examples:
 ```


### PR DESCRIPTION
This PR rewrites the docstrings for the `positivity` tactic and `@[positivity]` attribute, to consistently match the official style guide, to make sure they are complete while not getting too long.

The goal was to make it clearer what an extension does exactly, and document how to write one in the `@[positivity]` docstring.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
