### PR TITLE
[Merged by Bors] - chore: clean up `AddMonoid.End` instances

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -143,7 +143,7 @@ instance [MulOneClass M] [CommMonoid N] [IsCancelMul N] : IsCancelMul (M →* N)
 section End
 
 instance AddMonoid.End.instAddCommMonoid [AddCommMonoid M] : AddCommMonoid (AddMonoid.End M) :=
-  AddMonoidHom.instAddCommMonoid
+  inferInstanceAs <| AddCommMonoid (M →+ M)
 
 @[simp]
 theorem AddMonoid.End.zero_apply [AddCommMonoid M] (m : M) : (0 : AddMonoid.End M) m = 0 :=
@@ -154,10 +154,10 @@ theorem AddMonoid.End.one_apply [AddZeroClass M] (m : M) : (1 : AddMonoid.End M)
   rfl
 
 instance AddMonoid.End.instAddCommGroup [AddCommGroup M] : AddCommGroup (AddMonoid.End M) :=
-  AddMonoidHom.instAddCommGroup
+  inferInstanceAs <| AddCommGroup (M →+ M)
 
-instance AddMonoid.End.instIntCast [AddCommGroup M] : IntCast (AddMonoid.End M) :=
-  { intCast := fun z => z • (1 : AddMonoid.End M) }
+instance AddMonoid.End.instIntCast [AddCommGroup M] : IntCast (AddMonoid.End M) where
+  intCast := fun z => z • 1
 
 /-- See also `AddMonoid.End.intCast_def`. -/
 @[simp]

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -72,12 +72,12 @@ section
 variable [Monoid R] [Monoid S] [AddCommMonoid A]
 
 instance instDistribSMul [DistribSMul M A] : DistribSMul M (AddMonoid.End A) :=
-  AddMonoidHom.instDistribSMul
+  inferInstanceAs <| DistribSMul M (A →+ A)
 
 variable [DistribMulAction R A] [DistribMulAction S A]
 
 instance instDistribMulAction : DistribMulAction R (AddMonoid.End A) :=
-  AddMonoidHom.instDistribMulAction
+  inferInstanceAs <| DistribMulAction R (A →+ A)
 
 @[simp] theorem coe_smul (r : R) (f : AddMonoid.End A) : ⇑(r • f) = r • ⇑f := rfl
 
@@ -97,7 +97,7 @@ instance isCentralScalar [DistribMulAction Rᵐᵒᵖ A] [IsCentralScalar R A] :
 end
 
 instance instModule [Semiring R] [AddCommMonoid A] [Module R A] : Module R (AddMonoid.End A) :=
-  AddMonoidHom.instModule
+  inferInstanceAs <| Module R (A →+ A)
 
 /-- The tautological action by `AddMonoid.End α` on `α`.
 


### PR DESCRIPTION
This PR uses `inferInstanceAs` on the remaining `AddMonoid.End` instances.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
