### PR TITLE
[Merged by Bors] - ci: Better choosing of cache namespaces

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -27,8 +27,9 @@ jobs:
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
       pr_branch_ref: ${{ github.sha }}
-      # Note bors is contributing to the 'master' cache
-      cache_application_id: ${{ vars.CACHE_MASTER_WRITER_AZURE_APP_ID }}
+      # Use the MASTER cache key only when merging into mathlib4 (staging branch);
+      # 'bors try' runs (trying branch) and nightly-testing use NON_MASTER
+      cache_application_id: ${{ github.ref_name == 'staging' && github.repository == 'leanprover-community/mathlib4' && vars.CACHE_MASTER_WRITER_AZURE_APP_ID || vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
       # bors runs should build the tools from their commit-under-test: after all, we are trying to
       # test 'what would happen if this was merged', so we need to use the 'would-be-post-merge' tools
       tools_branch_ref: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
     with:
       concurrency_group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/master' && github.run_id) || '' }}
       pr_branch_ref: ${{ github.sha }}
-      cache_application_id: ${{ vars.CACHE_MASTER_WRITER_AZURE_APP_ID }}
+      # Use the MASTER cache key only on mathlib4 itself; nightly-testing uses NON_MASTER
+      cache_application_id: ${{ github.repository == 'leanprover-community/mathlib4' && vars.CACHE_MASTER_WRITER_AZURE_APP_ID || vars.CACHE_NON_MASTER_WRITER_AZURE_APP_ID }}
       runs_on: pr
     secrets: inherit


### PR DESCRIPTION
Today, these two identities are contributing to the same container anyways, but I'd like to scope "master" to really only "mathlib4/master" (and, for now, bors), whereas `nightly-testing` should be treated as "non-master"