### PR TITLE
[Merged by Bors] - chore: use `inferInstanceAs` in uniform convergence

### DIFF
--- a/Mathlib/Topology/Algebra/UniformConvergence.lean
+++ b/Mathlib/Topology/Algebra/UniformConvergence.lean
@@ -49,7 +49,7 @@ section AlgebraicInstances
 
 variable {α β ι R : Type*} {𝔖 : Set <| Set α} {x : α}
 
-@[to_additive] instance [One β] : One (α →ᵤ β) := Pi.instOne
+@[to_additive] instance [One β] : One (α →ᵤ β) := inferInstanceAs <| One (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformFun.toFun_one [One β] : toFun (1 : α →ᵤ β) = 1 := rfl
@@ -57,7 +57,7 @@ lemma UniformFun.toFun_one [One β] : toFun (1 : α →ᵤ β) = 1 := rfl
 @[to_additive (attr := simp)]
 lemma UniformFun.ofFun_one [One β] : ofFun (1 : α → β) = 1 := rfl
 
-@[to_additive] instance [One β] : One (α →ᵤ[𝔖] β) := Pi.instOne
+@[to_additive] instance [One β] : One (α →ᵤ[𝔖] β) := inferInstanceAs <| One (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformOnFun.toFun_one [One β] : toFun 𝔖 (1 : α →ᵤ[𝔖] β) = 1 := rfl
@@ -65,7 +65,7 @@ lemma UniformOnFun.toFun_one [One β] : toFun 𝔖 (1 : α →ᵤ[𝔖] β) = 1 
 @[to_additive (attr := simp)]
 lemma UniformOnFun.one_apply [One β] : ofFun 𝔖 (1 : α → β) = 1 := rfl
 
-@[to_additive] instance [Mul β] : Mul (α →ᵤ β) := Pi.instMul
+@[to_additive] instance [Mul β] : Mul (α →ᵤ β) := inferInstanceAs <| Mul (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformFun.toFun_mul [Mul β] (f g : α →ᵤ β) : toFun (f * g) = toFun f * toFun g := rfl
@@ -73,7 +73,7 @@ lemma UniformFun.toFun_mul [Mul β] (f g : α →ᵤ β) : toFun (f * g) = toFun
 @[to_additive (attr := simp)]
 lemma UniformFun.ofFun_mul [Mul β] (f g : α → β) : ofFun (f * g) = ofFun f * ofFun g := rfl
 
-@[to_additive] instance [Mul β] : Mul (α →ᵤ[𝔖] β) := Pi.instMul
+@[to_additive] instance [Mul β] : Mul (α →ᵤ[𝔖] β) := inferInstanceAs <| Mul (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformOnFun.toFun_mul [Mul β] (f g : α →ᵤ[𝔖] β) :
@@ -83,7 +83,7 @@ lemma UniformOnFun.toFun_mul [Mul β] (f g : α →ᵤ[𝔖] β) :
 @[to_additive (attr := simp)]
 lemma UniformOnFun.ofFun_mul [Mul β] (f g : α → β) : ofFun 𝔖 (f * g) = ofFun 𝔖 f * ofFun 𝔖 g := rfl
 
-@[to_additive] instance [Inv β] : Inv (α →ᵤ β) := Pi.instInv
+@[to_additive] instance [Inv β] : Inv (α →ᵤ β) := inferInstanceAs <| Inv (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformFun.toFun_inv [Inv β] (f : α →ᵤ β) : toFun (f⁻¹) = (toFun f)⁻¹ := rfl
@@ -91,7 +91,7 @@ lemma UniformFun.toFun_inv [Inv β] (f : α →ᵤ β) : toFun (f⁻¹) = (toFun
 @[to_additive (attr := simp)]
 lemma UniformFun.ofFun_inv [Inv β] (f : α → β) : ofFun (f⁻¹) = (ofFun f)⁻¹ := rfl
 
-@[to_additive] instance [Inv β] : Inv (α →ᵤ[𝔖] β) := Pi.instInv
+@[to_additive] instance [Inv β] : Inv (α →ᵤ[𝔖] β) := inferInstanceAs <| Inv (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformOnFun.toFun_inv [Inv β] (f : α →ᵤ[𝔖] β) : toFun 𝔖 (f⁻¹) = (toFun 𝔖 f)⁻¹ := rfl
@@ -99,7 +99,7 @@ lemma UniformOnFun.toFun_inv [Inv β] (f : α →ᵤ[𝔖] β) : toFun 𝔖 (f�
 @[to_additive (attr := simp)]
 lemma UniformOnFun.ofFun_inv [Inv β] (f : α → β) : ofFun 𝔖 (f⁻¹) = (ofFun 𝔖 f)⁻¹ := rfl
 
-@[to_additive] instance [Div β] : Div (α →ᵤ β) := Pi.instDiv
+@[to_additive] instance [Div β] : Div (α →ᵤ β) := inferInstanceAs <| Div (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformFun.toFun_div [Div β] (f g : α →ᵤ β) : toFun (f / g) = toFun f / toFun g := rfl
@@ -107,7 +107,7 @@ lemma UniformFun.toFun_div [Div β] (f g : α →ᵤ β) : toFun (f / g) = toFun
 @[to_additive (attr := simp)]
 lemma UniformFun.ofFun_div [Div β] (f g : α → β) : ofFun (f / g) = ofFun f / ofFun g := rfl
 
-@[to_additive] instance [Div β] : Div (α →ᵤ[𝔖] β) := Pi.instDiv
+@[to_additive] instance [Div β] : Div (α →ᵤ[𝔖] β) := inferInstanceAs <| Div (α → β)
 
 @[to_additive (attr := simp)]
 lemma UniformOnFun.toFun_div [Div β] (f g : α →ᵤ[𝔖] β) :
@@ -118,38 +118,30 @@ lemma UniformOnFun.toFun_div [Div β] (f g : α →ᵤ[𝔖] β) :
 lemma UniformOnFun.ofFun_div [Div β] (f g : α → β) : ofFun 𝔖 (f / g) = ofFun 𝔖 f / ofFun 𝔖 g := rfl
 
 @[to_additive]
-instance [Monoid β] : Monoid (α →ᵤ β) :=
-  Pi.monoid
+instance [Monoid β] : Monoid (α →ᵤ β) := inferInstanceAs <| Monoid (α → β)
 
 @[to_additive]
-instance [Monoid β] : Monoid (α →ᵤ[𝔖] β) :=
-  Pi.monoid
+instance [Monoid β] : Monoid (α →ᵤ[𝔖] β) := inferInstanceAs <| Monoid (α → β)
 
 @[to_additive]
-instance [CommMonoid β] : CommMonoid (α →ᵤ β) :=
-  Pi.commMonoid
+instance [CommMonoid β] : CommMonoid (α →ᵤ β) := inferInstanceAs <| CommMonoid (α → β)
 
 @[to_additive]
-instance [CommMonoid β] : CommMonoid (α →ᵤ[𝔖] β) :=
-  Pi.commMonoid
+instance [CommMonoid β] : CommMonoid (α →ᵤ[𝔖] β) := inferInstanceAs <| CommMonoid (α → β)
 
 @[to_additive]
-instance [Group β] : Group (α →ᵤ β) :=
-  Pi.group
+instance [Group β] : Group (α →ᵤ β) := inferInstanceAs <| Group (α → β)
 
 @[to_additive]
-instance [Group β] : Group (α →ᵤ[𝔖] β) :=
-  Pi.group
+instance [Group β] : Group (α →ᵤ[𝔖] β) := inferInstanceAs <| Group (α → β)
 
 @[to_additive]
-instance [CommGroup β] : CommGroup (α →ᵤ β) :=
-  Pi.commGroup
+instance [CommGroup β] : CommGroup (α →ᵤ β) := inferInstanceAs <| CommGroup (α → β)
 
 @[to_additive]
-instance [CommGroup β] : CommGroup (α →ᵤ[𝔖] β) :=
-  Pi.commGroup
+instance [CommGroup β] : CommGroup (α →ᵤ[𝔖] β) := inferInstanceAs <| CommGroup (α → β)
 
-instance {M : Type*} [SMul M β] : SMul M (α →ᵤ β) := Pi.instSMul
+instance {M : Type*} [SMul M β] : SMul M (α →ᵤ β) := inferInstanceAs <| SMul M (α → β)
 
 @[simp]
 lemma UniformFun.toFun_smul {M : Type*} [SMul M β] (c : M) (f : α →ᵤ β) :
@@ -161,7 +153,7 @@ lemma UniformFun.ofFun_smul {M : Type*} [SMul M β] (c : M) (f : α → β) :
     ofFun (c • f) = c • ofFun f :=
   rfl
 
-instance {M : Type*} [SMul M β] : SMul M (α →ᵤ[𝔖] β) := Pi.instSMul
+instance {M : Type*} [SMul M β] : SMul M (α →ᵤ[𝔖] β) := inferInstanceAs <| SMul M (α → β)
 
 @[simp]
 lemma UniformOnFun.toFun_smul {M : Type*} [SMul M β] (c : M) (f : α →ᵤ[𝔖] β) :
@@ -175,37 +167,39 @@ lemma UniformOnFun.ofFun_smul {M : Type*} [SMul M β] (c : M) (f : α → β) :
 
 instance {M N : Type*} [SMul M N] [SMul M β] [SMul N β] [IsScalarTower M N β] :
     IsScalarTower M N (α →ᵤ β) :=
-  Pi.isScalarTower
+  inferInstanceAs <| IsScalarTower M N (α → β)
 
 instance {M N : Type*} [SMul M N] [SMul M β] [SMul N β] [IsScalarTower M N β] :
     IsScalarTower M N (α →ᵤ[𝔖] β) :=
-  Pi.isScalarTower
+  inferInstanceAs <| IsScalarTower M N (α → β)
 
 instance {M N : Type*} [SMul M β] [SMul N β] [SMulCommClass M N β] :
     SMulCommClass M N (α →ᵤ β) :=
-  Pi.smulCommClass
+  inferInstanceAs <| SMulCommClass M N (α → β)
 
 instance {M N : Type*} [SMul M β] [SMul N β] [SMulCommClass M N β] :
     SMulCommClass M N (α →ᵤ[𝔖] β) :=
-  Pi.smulCommClass
+  inferInstanceAs <| SMulCommClass M N (α → β)
 
-instance {M : Type*} [Monoid M] [MulAction M β] : MulAction M (α →ᵤ β) := Pi.mulAction _
+instance {M : Type*} [Monoid M] [MulAction M β] : MulAction M (α →ᵤ β) :=
+  inferInstanceAs <| MulAction M (α → β)
 
-instance {M : Type*} [Monoid M] [MulAction M β] : MulAction M (α →ᵤ[𝔖] β) := Pi.mulAction _
+instance {M : Type*} [Monoid M] [MulAction M β] : MulAction M (α →ᵤ[𝔖] β) :=
+  inferInstanceAs <| MulAction M (α → β)
 
 instance {M : Type*} [Monoid M] [AddMonoid β] [DistribMulAction M β] :
     DistribMulAction M (α →ᵤ β) :=
-  Pi.distribMulAction _
+  inferInstanceAs <| DistribMulAction M (α → β)
 
 instance {M : Type*} [Monoid M] [AddMonoid β] [DistribMulAction M β] :
     DistribMulAction M (α →ᵤ[𝔖] β) :=
-  Pi.distribMulAction _
+  inferInstanceAs <| DistribMulAction M (α → β)
 
 instance [Semiring R] [AddCommMonoid β] [Module R β] : Module R (α →ᵤ β) :=
-  Pi.module _ _ _
+  inferInstanceAs <| Module R (α → β)
 
 instance [Semiring R] [AddCommMonoid β] [Module R β] : Module R (α →ᵤ[𝔖] β) :=
-  Pi.module _ _ _
+  inferInstanceAs <| Module R (α → β)
 
 end AlgebraicInstances
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
