### PR TITLE
[Merged by Bors] - chore(TrivSqZeroExt): clean up instances

### DIFF
--- a/Mathlib/Algebra/Colimit/Ring.lean
+++ b/Mathlib/Algebra/Colimit/Ring.lean
@@ -33,7 +33,6 @@ the disjoint union so as to make the operations (addition etc.) "computable".
 assert_not_exists Cardinal
 
 suppress_compilation
-noncomputable section -- needed for `deriving`
 
 variable {ι : Type*} [Preorder ι] (G : ι → Type*)
 
@@ -59,9 +58,22 @@ def DirectLimit : Type _ :=
           (∃ i, of (⟨i, 1⟩ : Σ i, G i) - 1 = a) ∨
             (∃ i x y, of (⟨i, x + y⟩ : Σ i, G i) - (of ⟨i, x⟩ + of ⟨i, y⟩) = a) ∨
               ∃ i x y, of (⟨i, x * y⟩ : Σ i, G i) - of ⟨i, x⟩ * of ⟨i, y⟩ = a }
-deriving Ring, CommRing
 
 namespace DirectLimit
+
+instance commRing : CommRing (DirectLimit G f) :=
+  Ideal.Quotient.commRing _
+
+instance ring : Ring (DirectLimit G f) :=
+  CommRing.toRing
+
+-- Porting note: Added a `Zero` instance to get rid of `0` errors.
+instance zero : Zero (DirectLimit G f) := by
+  unfold DirectLimit
+  exact ⟨0⟩
+
+instance : Inhabited (DirectLimit G f) :=
+  ⟨0⟩
 
 /-- The canonical map from a component to the direct limit. -/
 nonrec def of (i) : G i →+* DirectLimit G f :=
@@ -80,7 +92,7 @@ theorem quotientMk_of (i x) : Ideal.Quotient.mk _ (.of ⟨i, x⟩) = of G f i x 
 @[simp] theorem of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
   Ideal.Quotient.eq.2 <| subset_span <| Or.inl ⟨i, j, hij, x, rfl⟩
 
--- set_option backward.isDefEq.respectTransparency false in
+set_option backward.isDefEq.respectTransparency false in
 /-- Every element of the direct limit corresponds to some element in
 some component of the directed system. -/
 theorem exists_of [Nonempty ι] [IsDirectedOrder ι] (z : DirectLimit G f) :

--- a/Mathlib/Algebra/Colimit/Ring.lean
+++ b/Mathlib/Algebra/Colimit/Ring.lean
@@ -33,6 +33,7 @@ the disjoint union so as to make the operations (addition etc.) "computable".
 assert_not_exists Cardinal
 
 suppress_compilation
+noncomputable section -- needed for `deriving`
 
 variable {ι : Type*} [Preorder ι] (G : ι → Type*)
 
@@ -58,22 +59,9 @@ def DirectLimit : Type _ :=
           (∃ i, of (⟨i, 1⟩ : Σ i, G i) - 1 = a) ∨
             (∃ i x y, of (⟨i, x + y⟩ : Σ i, G i) - (of ⟨i, x⟩ + of ⟨i, y⟩) = a) ∨
               ∃ i x y, of (⟨i, x * y⟩ : Σ i, G i) - of ⟨i, x⟩ * of ⟨i, y⟩ = a }
+deriving Ring, CommRing
 
 namespace DirectLimit
-
-instance commRing : CommRing (DirectLimit G f) :=
-  Ideal.Quotient.commRing _
-
-instance ring : Ring (DirectLimit G f) :=
-  CommRing.toRing
-
--- Porting note: Added a `Zero` instance to get rid of `0` errors.
-instance zero : Zero (DirectLimit G f) := by
-  unfold DirectLimit
-  exact ⟨0⟩
-
-instance : Inhabited (DirectLimit G f) :=
-  ⟨0⟩
 
 /-- The canonical map from a component to the direct limit. -/
 nonrec def of (i) : G i →+* DirectLimit G f :=
@@ -92,7 +80,7 @@ theorem quotientMk_of (i x) : Ideal.Quotient.mk _ (.of ⟨i, x⟩) = of G f i x 
 @[simp] theorem of_f {i j} (hij) (x) : of G f j (f i j hij x) = of G f i x :=
   Ideal.Quotient.eq.2 <| subset_span <| Or.inl ⟨i, j, hij, x, rfl⟩
 
-set_option backward.isDefEq.respectTransparency false in
+-- set_option backward.isDefEq.respectTransparency false in
 /-- Every element of the direct limit corresponds to some element in
 some component of the directed system. -/
 theorem exists_of [Nonempty ι] [IsDirectedOrder ι] (z : DirectLimit G f) :

--- a/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt/Basic.lean
@@ -177,76 +177,76 @@ section Additive
 variable {T : Type*} {S : Type*} {R : Type u} {M : Type v}
 
 instance inhabited [Inhabited R] [Inhabited M] : Inhabited (tsze R M) :=
-  instInhabitedProd
+  inferInstanceAs <| Inhabited (R × M)
 
 instance zero [Zero R] [Zero M] : Zero (tsze R M) :=
-  Prod.instZero
+  inferInstanceAs <| Zero (R × M)
 
 instance add [Add R] [Add M] : Add (tsze R M) :=
-  Prod.instAdd
+  inferInstanceAs <| Add (R × M)
 
 instance sub [Sub R] [Sub M] : Sub (tsze R M) :=
-  Prod.instSub
+  inferInstanceAs <| Sub (R × M)
 
 instance neg [Neg R] [Neg M] : Neg (tsze R M) :=
-  Prod.instNeg
+  inferInstanceAs <| Neg (R × M)
 
 instance addSemigroup [AddSemigroup R] [AddSemigroup M] : AddSemigroup (tsze R M) :=
-  Prod.instAddSemigroup
+  inferInstanceAs <| AddSemigroup (R × M)
 
 instance addZeroClass [AddZeroClass R] [AddZeroClass M] : AddZeroClass (tsze R M) :=
-  Prod.instAddZeroClass
+  inferInstanceAs <| AddZeroClass (R × M)
 
 instance addMonoid [AddMonoid R] [AddMonoid M] : AddMonoid (tsze R M) :=
-  Prod.instAddMonoid
+  inferInstanceAs <| AddMonoid (R × M)
 
 instance addGroup [AddGroup R] [AddGroup M] : AddGroup (tsze R M) :=
-  Prod.instAddGroup
+  inferInstanceAs <| AddGroup (R × M)
 
 instance addCommSemigroup [AddCommSemigroup R] [AddCommSemigroup M] : AddCommSemigroup (tsze R M) :=
-  Prod.instAddCommSemigroup
+  inferInstanceAs <| AddCommSemigroup (R × M)
 
 instance addCommMonoid [AddCommMonoid R] [AddCommMonoid M] : AddCommMonoid (tsze R M) :=
-  Prod.instAddCommMonoid
+  inferInstanceAs <| AddCommMonoid (R × M)
 
 instance addCommGroup [AddCommGroup R] [AddCommGroup M] : AddCommGroup (tsze R M) :=
-  Prod.instAddCommGroup
+  inferInstanceAs <| AddCommGroup (R × M)
 
 instance smul [SMul S R] [SMul S M] : SMul S (tsze R M) :=
-  Prod.instSMul
+  inferInstanceAs <| SMul S (R × M)
 
 instance isScalarTower [SMul T R] [SMul T M] [SMul S R] [SMul S M] [SMul T S]
     [IsScalarTower T S R] [IsScalarTower T S M] : IsScalarTower T S (tsze R M) :=
-  Prod.isScalarTower
+  inferInstanceAs <| IsScalarTower T S (R × M)
 
 instance smulCommClass [SMul T R] [SMul T M] [SMul S R] [SMul S M]
     [SMulCommClass T S R] [SMulCommClass T S M] : SMulCommClass T S (tsze R M) :=
-  Prod.smulCommClass
+  inferInstanceAs <| SMulCommClass T S (R × M)
 
 instance isCentralScalar [SMul S R] [SMul S M] [SMul Sᵐᵒᵖ R] [SMul Sᵐᵒᵖ M] [IsCentralScalar S R]
     [IsCentralScalar S M] : IsCentralScalar S (tsze R M) :=
-  Prod.isCentralScalar
+  inferInstanceAs <| IsCentralScalar S (R × M)
 
 instance mulAction [Monoid S] [MulAction S R] [MulAction S M] : MulAction S (tsze R M) :=
-  Prod.mulAction
+  inferInstanceAs <| MulAction S (R × M)
 
 instance distribMulAction [Monoid S] [AddMonoid R] [AddMonoid M]
     [DistribMulAction S R] [DistribMulAction S M] : DistribMulAction S (tsze R M) :=
-  Prod.distribMulAction
+  inferInstanceAs <| DistribMulAction S (R × M)
 
 instance module [Semiring S] [AddCommMonoid R] [AddCommMonoid M] [Module S R] [Module S M] :
     Module S (tsze R M) :=
-  Prod.instModule
+  inferInstanceAs <| Module S (R × M)
 
 /-- The trivial square-zero extension is nontrivial if it is over a nontrivial ring. -/
 instance instNontrivial_of_left {R M : Type*} [Nontrivial R] [Nonempty M] :
-    Nontrivial (TrivSqZeroExt R M) :=
-  fst_surjective.nontrivial
+    Nontrivial (tsze R M) :=
+  inferInstanceAs <| Nontrivial (R × M)
 
 /-- The trivial square-zero extension is nontrivial if it is over a nontrivial module. -/
 instance instNontrivial_of_right {R M : Type*} [Nonempty R] [Nontrivial M] :
-    Nontrivial (TrivSqZeroExt R M) :=
-  snd_surjective.nontrivial
+    Nontrivial (tsze R M) :=
+  inferInstanceAs <| Nontrivial (R × M)
 
 @[simp]
 theorem fst_zero [Zero R] [Zero M] : (0 : tsze R M).fst = 0 :=
@@ -477,20 +477,18 @@ theorem mul_inl_eq_op_smul [Monoid R] [AddMonoid M] [DistribMulAction R M] [Dist
   ext rfl (by dsimp; rw [smul_zero, zero_add])
 
 instance mulOneClass [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulAction Rᵐᵒᵖ M] :
-    MulOneClass (tsze R M) :=
-  { TrivSqZeroExt.one, TrivSqZeroExt.mul with
-    one_mul := fun x =>
-      ext (one_mul x.1) <|
-        show (1 : R) •> x.2 + (0 : M) <• x.1 = x.2 by rw [one_smul, smul_zero, add_zero]
-    mul_one := fun x =>
-      ext (mul_one x.1) <|
-        show x.1 • (0 : M) + x.2 <• (1 : R) = x.2 by rw [smul_zero, zero_add, op_one, one_smul] }
+    MulOneClass (tsze R M) where
+  one_mul := fun x =>
+    ext (one_mul x.1) <|
+      show (1 : R) •> x.2 + (0 : M) <• x.1 = x.2 by rw [one_smul, smul_zero, add_zero]
+  mul_one := fun x =>
+    ext (mul_one x.1) <|
+      show x.1 • (0 : M) + x.2 <• (1 : R) = x.2 by rw [smul_zero, zero_add, op_one, one_smul]
 
-instance addMonoidWithOne [AddMonoidWithOne R] [AddMonoid M] : AddMonoidWithOne (tsze R M) :=
-  { TrivSqZeroExt.addMonoid, TrivSqZeroExt.one with
-    natCast := fun n => inl n
-    natCast_zero := by simp [Nat.cast]
-    natCast_succ := fun _ => by ext <;> simp [Nat.cast] }
+instance addMonoidWithOne [AddMonoidWithOne R] [AddMonoid M] : AddMonoidWithOne (tsze R M) where
+  natCast := fun n => inl n
+  natCast_zero := by simp [Nat.cast]
+  natCast_succ := fun _ => by ext <;> simp [Nat.cast]
 
 @[simp]
 theorem fst_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (n : tsze R M).fst = n :=
@@ -504,11 +502,10 @@ theorem snd_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (n : tsze R M
 theorem inl_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (inl n : tsze R M) = n :=
   rfl
 
-instance addGroupWithOne [AddGroupWithOne R] [AddGroup M] : AddGroupWithOne (tsze R M) :=
-  { TrivSqZeroExt.addGroup, TrivSqZeroExt.addMonoidWithOne with
-    intCast := fun z => inl z
-    intCast_ofNat := fun _n => ext (Int.cast_natCast _) rfl
-    intCast_negSucc := fun _n => ext (Int.cast_negSucc _) neg_zero.symm }
+instance addGroupWithOne [AddGroupWithOne R] [AddGroup M] : AddGroupWithOne (tsze R M) where
+  intCast := fun z => inl z
+  intCast_ofNat := fun _n => ext (Int.cast_natCast _) rfl
+  intCast_negSucc := fun _n => ext (Int.cast_negSucc _) neg_zero.symm
 
 @[simp]
 theorem fst_intCast [AddGroupWithOne R] [AddGroup M] (z : ℤ) : (z : tsze R M).fst = z :=
@@ -523,30 +520,28 @@ theorem inl_intCast [AddGroupWithOne R] [AddGroup M] (z : ℤ) : (inl z : tsze R
   rfl
 
 instance nonAssocSemiring [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] :
-    NonAssocSemiring (tsze R M) :=
-  { TrivSqZeroExt.addMonoidWithOne, TrivSqZeroExt.mulOneClass, TrivSqZeroExt.addCommMonoid with
-    zero_mul := fun x =>
-      ext (zero_mul x.1) <|
-        show (0 : R) •> x.2 + (0 : M) <• x.1 = 0 by rw [zero_smul, zero_add, smul_zero]
-    mul_zero := fun x =>
-      ext (mul_zero x.1) <|
-        show x.1 • (0 : M) + (0 : Rᵐᵒᵖ) • x.2 = 0 by rw [smul_zero, zero_add, zero_smul]
-    left_distrib := fun x₁ x₂ x₃ =>
-      ext (mul_add x₁.1 x₂.1 x₃.1) <|
-        show
-          x₁.1 •> (x₂.2 + x₃.2) + x₁.2 <• (x₂.1 + x₃.1) =
-            x₁.1 •> x₂.2 + x₁.2 <• x₂.1 + (x₁.1 •> x₃.2 + x₁.2 <• x₃.1)
-          by simp_rw [smul_add, MulOpposite.op_add, add_smul, add_add_add_comm]
-    right_distrib := fun x₁ x₂ x₃ =>
-      ext (add_mul x₁.1 x₂.1 x₃.1) <|
-        show
-          (x₁.1 + x₂.1) •> x₃.2 + (x₁.2 + x₂.2) <• x₃.1 =
-            x₁.1 •> x₃.2 + x₁.2 <• x₃.1 + (x₂.1 •> x₃.2 + x₂.2 <• x₃.1)
-          by simp_rw [add_smul, smul_add, add_add_add_comm] }
+    NonAssocSemiring (tsze R M) where
+  zero_mul := fun x =>
+    ext (zero_mul x.1) <|
+      show (0 : R) •> x.2 + (0 : M) <• x.1 = 0 by rw [zero_smul, zero_add, smul_zero]
+  mul_zero := fun x =>
+    ext (mul_zero x.1) <|
+      show x.1 • (0 : M) + (0 : Rᵐᵒᵖ) • x.2 = 0 by rw [smul_zero, zero_add, zero_smul]
+  left_distrib := fun x₁ x₂ x₃ =>
+    ext (mul_add x₁.1 x₂.1 x₃.1) <|
+      show
+        x₁.1 •> (x₂.2 + x₃.2) + x₁.2 <• (x₂.1 + x₃.1) =
+          x₁.1 •> x₂.2 + x₁.2 <• x₂.1 + (x₁.1 •> x₃.2 + x₁.2 <• x₃.1)
+        by simp_rw [smul_add, MulOpposite.op_add, add_smul, add_add_add_comm]
+  right_distrib := fun x₁ x₂ x₃ =>
+    ext (add_mul x₁.1 x₂.1 x₃.1) <|
+      show
+        (x₁.1 + x₂.1) •> x₃.2 + (x₁.2 + x₂.2) <• x₃.1 =
+          x₁.1 •> x₃.2 + x₁.2 <• x₃.1 + (x₂.1 •> x₃.2 + x₂.2 <• x₃.1)
+        by simp_rw [add_smul, smul_add, add_add_add_comm]
 
 instance nonAssocRing [Ring R] [AddCommGroup M] [Module R M] [Module Rᵐᵒᵖ M] :
-    NonAssocRing (tsze R M) :=
-  { TrivSqZeroExt.addGroupWithOne, TrivSqZeroExt.nonAssocSemiring with }
+    NonAssocRing (tsze R M) where
 
 /-- In the general non-commutative case, the power operator is
 
@@ -606,35 +601,33 @@ theorem inl_pow [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulActio
   ext rfl <| by simp [snd_pow_eq_sum, List.map_const']
 
 instance monoid [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulAction Rᵐᵒᵖ M]
-    [SMulCommClass R Rᵐᵒᵖ M] : Monoid (tsze R M) :=
-  { TrivSqZeroExt.mulOneClass with
-    mul_assoc := fun x y z =>
-      ext (mul_assoc x.1 y.1 z.1) <|
-        show
-          (x.1 * y.1) •> z.2 + (x.1 •> y.2 + x.2 <• y.1) <• z.1 =
-            x.1 •> (y.1 •> z.2 + y.2 <• z.1) + x.2 <• (y.1 * z.1)
-          by simp_rw [smul_add, ← mul_smul, add_assoc, smul_comm, op_mul]
-    npow := fun n x => x ^ n
-    npow_zero := fun x => ext (pow_zero x.fst) (by simp [snd_pow_eq_sum])
-    npow_succ := fun n x =>
-      ext (pow_succ _ _)
-        (by
-          simp_rw [snd_mul, snd_pow_eq_sum, Nat.pred_succ]
-          cases n
-          · simp [List.range_succ]
-          rw [List.sum_range_succ']
-          simp only [pow_zero, op_one, Nat.sub_zero, one_smul, Nat.succ_sub_succ_eq_sub, fst_pow,
-            Nat.pred_succ, List.smul_sum, List.map_map, Function.comp_def]
-          simp_rw [← smul_comm (_ : R) (_ : Rᵐᵒᵖ), smul_smul, pow_succ]
-          rfl) }
+    [SMulCommClass R Rᵐᵒᵖ M] : Monoid (tsze R M) where
+  mul_assoc := fun x y z =>
+    ext (mul_assoc x.1 y.1 z.1) <|
+      show
+        (x.1 * y.1) •> z.2 + (x.1 •> y.2 + x.2 <• y.1) <• z.1 =
+          x.1 •> (y.1 •> z.2 + y.2 <• z.1) + x.2 <• (y.1 * z.1)
+        by simp_rw [smul_add, ← mul_smul, add_assoc, smul_comm, op_mul]
+  npow := fun n x => x ^ n
+  npow_zero := fun x => ext (pow_zero x.fst) (by simp [snd_pow_eq_sum])
+  npow_succ := fun n x =>
+    ext (pow_succ _ _)
+      (by
+        simp_rw [snd_mul, snd_pow_eq_sum, Nat.pred_succ]
+        cases n
+        · simp [List.range_succ]
+        rw [List.sum_range_succ']
+        simp only [pow_zero, op_one, Nat.sub_zero, one_smul, Nat.succ_sub_succ_eq_sub, fst_pow,
+          Nat.pred_succ, List.smul_sum, List.map_map, Function.comp_def]
+        simp_rw [← smul_comm (_ : R) (_ : Rᵐᵒᵖ), smul_smul, pow_succ]
+        rfl)
 
 theorem fst_list_prod [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulAction Rᵐᵒᵖ M]
     [SMulCommClass R Rᵐᵒᵖ M] (l : List (tsze R M)) : l.prod.fst = (l.map fst).prod :=
   map_list_prod ({ toFun := fst, map_one' := fst_one, map_mul' := fst_mul } : tsze R M →* R) _
 
 instance semiring [Semiring R] [AddCommMonoid M]
-    [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] : Semiring (tsze R M) :=
-  { TrivSqZeroExt.monoid, TrivSqZeroExt.nonAssocSemiring with }
+    [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] : Semiring (tsze R M) where
 
 /-- The second element of a product $\prod_{i=0}^n (r_i + m_i)$ is a sum of terms of the form
 $r_0\cdots r_{i-1}m_ir_{i+1}\cdots r_n$. -/
@@ -654,8 +647,7 @@ theorem snd_list_prod [Monoid R] [AddCommMonoid M] [DistribMulAction R M] [Distr
     exact add_comm _ _
 
 instance ring [Ring R] [AddCommGroup M] [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] :
-    Ring (tsze R M) :=
-  { TrivSqZeroExt.semiring, TrivSqZeroExt.nonAssocRing with }
+    Ring (tsze R M) where
 
 instance commMonoid [CommMonoid R] [AddCommMonoid M] [DistribMulAction R M]
     [DistribMulAction Rᵐᵒᵖ M] [IsCentralScalar R M] : CommMonoid (tsze R M) :=
@@ -666,12 +658,10 @@ instance commMonoid [CommMonoid R] [AddCommMonoid M] [DistribMulAction R M]
           rw [op_smul_eq_smul, op_smul_eq_smul, add_comm] }
 
 instance commSemiring [CommSemiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M]
-    [IsCentralScalar R M] : CommSemiring (tsze R M) :=
-  { TrivSqZeroExt.commMonoid, TrivSqZeroExt.nonAssocSemiring with }
+    [IsCentralScalar R M] : CommSemiring (tsze R M) where
 
 instance commRing [CommRing R] [AddCommGroup M] [Module R M] [Module Rᵐᵒᵖ M] [IsCentralScalar R M] :
-    CommRing (tsze R M) :=
-  { TrivSqZeroExt.nonAssocRing, TrivSqZeroExt.commSemiring with }
+    CommRing (tsze R M) where
 
 variable (R M)
 
@@ -934,7 +924,6 @@ theorem algHom_ext' {A} [Semiring A] [Algebra S A] ⦃f g : tsze R M →ₐ[S] A
 
 variable {A : Type*} [Semiring A] [Algebra S A] [Algebra R' A]
 
-set_option backward.isDefEq.respectTransparency false in
 /--
 Assemble an algebra morphism `TrivSqZeroExt R M →ₐ[S] A` from separate morphisms on `R` and `M`.
 
@@ -1083,17 +1072,14 @@ def map (f : M →ₗ[R'] N) : TrivSqZeroExt R' M →ₐ[R'] TrivSqZeroExt R' N 
 theorem map_inl (f : M →ₗ[R'] N) (r : R') : map f (inl r) = inl r := by
   rw [map, liftEquivOfComm_apply, lift_apply_inl, Algebra.ofId_apply, algebraMap_eq_inl]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem map_inr (f : M →ₗ[R'] N) (x : M) : map f (inr x) = inr (f x) := by
   rw [map, liftEquivOfComm_apply, lift_apply_inr, LinearMap.comp_apply, inrHom_apply]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem fst_map (f : M →ₗ[R'] N) (x : TrivSqZeroExt R' M) : fst (map f x) = fst x := by
   simp [map, lift_def, Algebra.ofId_apply, algebraMap_eq_inl]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem snd_map (f : M →ₗ[R'] N) (x : TrivSqZeroExt R' M) : snd (map f x) = f (snd x) := by
   simp [map, lift_def, Algebra.ofId_apply, algebraMap_eq_inl]

--- a/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
@@ -69,7 +69,6 @@ variable [Field 𝕜] [Ring R] [AddCommGroup M]
   [TopologicalSpace R] [TopologicalSpace M]
   [IsTopologicalRing R] [IsTopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] theorem fst_expSeries (x : tsze R M) (n : ℕ) :
     fst (expSeries 𝕜 (tsze R M) n fun _ => x) = expSeries 𝕜 R n fun _ => x.fst := by
   simp [expSeries_apply_eq]
@@ -83,7 +82,6 @@ variable [Field 𝕜] [CharZero 𝕜] [Ring R] [AddCommGroup M]
   [TopologicalSpace R] [TopologicalSpace M]
   [IsTopologicalRing R] [IsTopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem snd_expSeries_of_smul_comm
     (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) (n : ℕ) :
     snd (expSeries 𝕜 (tsze R M) (n + 1) fun _ => x) = (expSeries 𝕜 R n fun _ => x.fst) • x.snd := by
@@ -92,7 +90,6 @@ theorem snd_expSeries_of_smul_comm
     Nat.cast_mul, mul_inv_rev,
     inv_mul_cancel_right₀ ((Nat.cast_ne_zero (R := 𝕜)).mpr <| Nat.succ_ne_zero n)]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `NormedSpace.exp R x.fst` converges to `e`
 then `(NormedSpace.exp R x).snd` converges to `e • x.snd`. -/
 theorem hasSum_snd_expSeries_of_smul_comm (x : tsze R M)
@@ -106,7 +103,6 @@ theorem hasSum_snd_expSeries_of_smul_comm (x : tsze R M)
     inv_one, one_smul, snd_one, sub_zero]
   exact h.smul_const _
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `NormedSpace.exp R x.fst` converges to `e`
 then `NormedSpace.exp R x` converges to `inl e + inr (e • x.snd)`. -/
 theorem hasSum_expSeries_of_smul_comm
@@ -121,7 +117,6 @@ theorem hasSum_expSeries_of_smul_comm
 variable [Algebra ℚ R] [Module ℚ M]
 variable [T2Space R] [T2Space M]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem exp_def_of_smul_comm (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) :
     exp x = inl (exp x.fst) + inr (exp x.fst • x.snd) := by
   simp_rw [exp_eq_expSeries_sum ℚ, FormalMultilinearSeries.sum]
@@ -134,13 +129,11 @@ theorem exp_def_of_smul_comm (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd
     refine mt ?_ h
     exact (Summable.map · (TrivSqZeroExt.fstHom ℚ R M).toLinearMap continuous_fst)
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem exp_inl (x : R) : exp (inl x : tsze R M) = inl (exp x) := by
   rw [exp_def_of_smul_comm, snd_inl, fst_inl, smul_zero, inr_zero, add_zero]
   rw [snd_inl, fst_inl, smul_zero, smul_zero]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem exp_inr (m : M) : exp (inr m : tsze R M) = 1 + inr m := by
   rw [exp_def_of_smul_comm, snd_inr, fst_inr, exp_zero, one_smul, inl_one]
@@ -156,21 +149,17 @@ variable [CommRing R] [AddCommGroup M] [Algebra ℚ R] [Module ℚ M] [Module R 
 
 variable [T2Space R] [T2Space M]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem exp_def (x : tsze R M) : exp x = inl (exp x.fst) + inr (exp x.fst • x.snd) :=
   exp_def_of_smul_comm x (op_smul_eq_smul _ _)
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem fst_exp (x : tsze R M) : fst (exp x) = exp x.fst := by
   rw [exp_def, fst_add, fst_inl, fst_inr, add_zero]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem snd_exp (x : tsze R M) : snd (exp x) = exp x.fst • x.snd := by
   rw [exp_def, snd_add, snd_inl, snd_inr, zero_add]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Polar form of trivial-square-zero extension. -/
 theorem eq_smul_exp_of_invertible (x : tsze R M) [Invertible x.fst] :
     x = x.fst • exp (⅟x.fst • inr x.snd) := by
@@ -188,7 +177,6 @@ variable [Field R] [AddCommGroup M]
 
 variable [T2Space R] [T2Space M]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- More convenient version of `TrivSqZeroExt.eq_smul_exp_of_invertible` for when `R` is a
 field. -/
 theorem eq_smul_exp_of_ne_zero (x : tsze R M) (hx : x.fst ≠ 0) :
@@ -212,15 +200,17 @@ variable [Algebra S R] [Module S M]
 variable [IsBoundedSMul S R] [IsBoundedSMul S M]
 
 instance instL1SeminormedAddCommGroup : SeminormedAddCommGroup (tsze R M) :=
-  WithLp.seminormedAddCommGroupToProd 1 R M
+  fast_instance% {
+    WithLp.seminormedAddCommGroupToProd 1 R M with
+    toUniformSpace := inferInstance }
 
 example :
     (TrivSqZeroExt.instUniformSpace : UniformSpace (tsze R M)) =
     PseudoMetricSpace.toUniformSpace := rfl
 
-set_option backward.isDefEq.respectTransparency false in
 theorem norm_def (x : tsze R M) : ‖x‖ = ‖fst x‖ + ‖snd x‖ := by
-  rw [WithLp.norm_seminormedAddCommGroupToProd, WithLp.prod_norm_eq_add (by norm_num)]
+  erw [WithLp.norm_seminormedAddCommGroupToProd]
+  rw [WithLp.prod_norm_eq_add (by norm_num)]
   simp only [WithLp.toLp_fst, ENNReal.toReal_one, Real.rpow_one, WithLp.toLp_snd, ne_eq,
     one_ne_zero, not_false_eq_true, div_self, fst, snd]
 
@@ -250,8 +240,8 @@ instance instL1SeminormedRing : SeminormedRing (tsze R M) where
       apply le_add_of_nonneg_right
       positivity
     _ = (‖r₁‖ + ‖m₁‖) * (‖r₂‖ + ‖m₂‖) := by ring
-  __ : SeminormedAddCommGroup (tsze R M) := inferInstance
   __ : Ring (tsze R M) := inferInstance
+  __ : SeminormedAddCommGroup (tsze R M) := inferInstance
 
 instance instL1IsBoundedSMul : IsBoundedSMul S (tsze R M) :=
   WithLp.isBoundedSMulSeminormedAddCommGroupToProd 1 R M
@@ -268,8 +258,8 @@ variable [Module R M] [Module Rᵐᵒᵖ M] [IsCentralScalar R M]
 variable [IsBoundedSMul R M]
 
 instance instL1SeminormedCommRing : SeminormedCommRing (tsze R M) where
-  __ : CommRing (tsze R M) := inferInstance
   __ : SeminormedRing (tsze R M) := inferInstance
+  __ : CommRing (tsze R M) := inferInstance
 
 end CommRing
 
@@ -283,11 +273,11 @@ variable [NormedRing R] [NormedAddCommGroup M] [Module R M] [Module Rᵐᵒᵖ M
 variable [IsBoundedSMul R M] [IsBoundedSMul Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M]
 
 instance instL1NormedAddCommGroup : NormedAddCommGroup (tsze R M) :=
-  WithLp.normedAddCommGroupToProd 1 R M
+  fast_instance% WithLp.normedAddCommGroupToProd 1 R M
 
 instance instL1NormedRing : NormedRing (tsze R M) where
-  __ : NormedAddCommGroup (tsze R M) := inferInstance
   __ : SeminormedRing (tsze R M) := inferInstance
+  __ : NormedAddCommGroup (tsze R M) := inferInstance
 
 end Ring
 
@@ -298,8 +288,8 @@ variable [Module R M] [Module Rᵐᵒᵖ M] [IsCentralScalar R M]
 variable [IsBoundedSMul R M]
 
 instance instL1NormedCommRing : NormedCommRing (tsze R M) where
-  __ : CommRing (tsze R M) := inferInstance
   __ : NormedRing (tsze R M) := inferInstance
+  __ : CommRing (tsze R M) := inferInstance
 
 end CommRing
 
@@ -311,7 +301,7 @@ variable [IsBoundedSMul R M] [IsBoundedSMul Rᵐᵒᵖ M] [SMulCommClass R Rᵐ�
 variable [IsScalarTower 𝕜 R M] [IsScalarTower 𝕜 Rᵐᵒᵖ M]
 
 instance instL1NormedSpace : NormedSpace 𝕜 (tsze R M) :=
-  WithLp.normedSpaceSeminormedAddCommGroupToProd 1 R M
+  fast_instance% WithLp.normedSpaceSeminormedAddCommGroupToProd 1 R M
 
 instance instL1NormedAlgebra : NormedAlgebra 𝕜 (tsze R M) where
   norm_smul_le := _root_.norm_smul_le
@@ -328,7 +318,6 @@ variable [NormedAlgebra ℚ R] [NormedSpace ℚ M] [Module R M] [Module Rᵐᵒ�
 variable [IsBoundedSMul R M] [IsBoundedSMul Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M]
 variable [CompleteSpace R] [CompleteSpace M]
 
-set_option backward.isDefEq.respectTransparency false in
 -- Evidence that we have sufficient instances on `tsze R N`
 -- to make `NormedSpace.exp_add_of_commute` usable
 example (a b : tsze R M) (h : Commute a b) : exp (a + b) = exp a * exp b :=


### PR DESCRIPTION
Clean up `TrivSqZeroExt` instances using `inferInstanceAs`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
