### PR TITLE
[Merged by Bors] - chore(Tactic/Recall): suppress unused variable linter

### DIFF
--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -48,7 +48,10 @@ syntax (name := recall) (docComment)? "recall " ident ppIndent(optDeclSig) (decl
 open Lean Meta Elab Command Term
 
 elab_rules : command
-  | `($[$_doc?:docComment]? recall $id $sig:optDeclSig $[$val?]?) => withoutModifyingEnv do
+  | `($[$_doc?:docComment]? recall $id $sig:optDeclSig $[$val?]?) =>
+    -- `recall` doesn't introduce new definitions, so suppress the unused variable linter.
+    withScope (fun sc => { sc with opts := sc.opts.set `linter.unusedVariables false }) <|
+    withoutModifyingEnv do
     let declName := id.getId
     addConstInfo id declName
     let info ← getConstInfo declName

--- a/MathlibTest/Recall.lean
+++ b/MathlibTest/Recall.lean
@@ -96,3 +96,7 @@ recall List.cons_append (a : α) (as bs : List α) : (a :: as) ++ bs = a :: (as 
 
 /-- Recalling `Nat.add_comm`. -/
 recall Nat.add_comm (n m : Nat) : n + m = m + n
+
+-- Test that the unused variable linter does not fire on `recall`.
+#guard_msgs in
+recall Eq.symm {α : Sort _} {a b : α} (h : a = b) : b = a


### PR DESCRIPTION
This PR suppresses the unused variable linter within the `recall` command elaborator. Since `recall` doesn't introduce new definitions (it only checks type-correctness against existing ones), unused variable warnings on binders that appear only in the type are noise.

For example, `recall Eq.symm {α : Sort _} {a b : α} (h : a = b) : b = a` would previously warn about `h` being unused.

🤖 Prepared with Claude Code