### PR TITLE
[Merged by Bors] - feat(Tactic/Recall): add recall? command and type mismatch suggestions

### DIFF
--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Init
 public meta import Lean.Elab.Command
 public meta import Lean.Elab.DeclUtil
+public meta import Lean.Meta.Tactic.TryThis
+public meta import Lean.PrettyPrinter.Delaborator
 
 /-!
 # `recall` command
@@ -45,7 +47,37 @@ recall Nat.add_comm (n m : Nat) : n + m = m + n
 -/
 syntax (name := recall) (docComment)? "recall " ident ppIndent(optDeclSig) (declVal)? : command
 
+/--
+The `recall?` command looks up a previous definition and suggests the correct
+`recall` statement for it.
+```
+recall? Nat.add_comm
+-- Try this: recall Nat.add_comm (n m : Nat) : n + m = m + n
+```
+-/
+syntax (name := recall?) "recall? " ident : command
+
 open Lean Meta Elab Command Term
+
+/-- Format a `recall` suggestion string for the given constant name.
+Uses `delabConstWithSignature` with `universes := false` to produce the idiomatic
+decomposed binder form without universe parameters on the name. -/
+private def mkRecallSuggestion (declName : Name) : MetaM String := do
+  let decl ← getConstInfo declName
+  let e := Expr.const declName (decl.levelParams.map Level.param)
+  let (stx, _) ← PrettyPrinter.delabCore e
+    (delab := PrettyPrinter.Delaborator.delabConstWithSignature (universes := false))
+  let sig := toString (← PrettyPrinter.ppTerm ⟨stx⟩)
+  return s!"recall {sig}"
+
+elab_rules : command
+  | `(recall?%$tk $id) => withoutModifyingEnv do
+    let declName := id.getId
+    addConstInfo id declName
+    let _ ← getConstInfo declName
+    let suggestion ← liftTermElabM <| mkRecallSuggestion declName
+    liftTermElabM <|
+      Tactic.TryThis.addSuggestion tk (suggestion : String) (origSpan? := ← getRef)
 
 elab_rules : command
   | `($[$_doc?:docComment]? recall $id $sig:optDeclSig $[$val?]?) =>
@@ -56,6 +88,7 @@ elab_rules : command
     addConstInfo id declName
     let info ← getConstInfo declName
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
+    let stxRef ← getRef
     let recallName := Name.mkSimple
       s!"_recall_{(← liftTermElabM Lean.mkFreshId)}"
     let newId := mkIdentFrom id recallName
@@ -70,6 +103,8 @@ elab_rules : command
         let mvs ← newInfo.levelParams.mapM fun _ => mkFreshLevelMVar
         let newType := newInfo.type.instantiateLevelParams newInfo.levelParams mvs
         unless (← isDefEq info.type newType) do
+          let suggestion ← mkRecallSuggestion declName
+          Tactic.TryThis.addSuggestion stxRef (suggestion : String) (origSpan? := stxRef)
           throwTypeMismatchError none info.type newInfo.type declConst
         let newVal := newInfo.value?.get!.instantiateLevelParams newInfo.levelParams mvs
         unless (← isDefEq infoVal newVal) do
@@ -92,6 +127,8 @@ elab_rules : command
                 let mvs ← info.levelParams.mapM fun _ => mkFreshLevelMVar
                 pure <| info.type.instantiateLevelParams info.levelParams mvs
               unless (← isDefEq infoType type) do
+                let suggestion ← mkRecallSuggestion declName
+                Tactic.TryThis.addSuggestion stxRef (suggestion : String) (origSpan? := stxRef)
                 throwTypeMismatchError none info.type type declConst
       else
         unless binders.getNumArgs == 0 do

--- a/MathlibTest/Recall.lean
+++ b/MathlibTest/Recall.lean
@@ -48,6 +48,9 @@ Other example tests
 recall id (x : α) : α := x
 
 /--
+info: Try this:
+  [apply] recall id {α : Sort u} (a : α) : α
+---
 error: Type mismatch
   @id
 has type
@@ -125,3 +128,65 @@ end RecallTest
 -- Test that `recall` works with `open` namespaces.
 open RecallTest in
 recall myDef : Nat
+
+/-
+## `recall?` tests
+-/
+
+-- Test recall? with a simple function
+/--
+info: Try this:
+  [apply] recall Nat.add_comm (n m : ℕ) : n + m = m + n
+-/
+#guard_msgs in recall? Nat.add_comm
+-- Verify the suggestion is accepted:
+recall Nat.add_comm (n m : ℕ) : n + m = m + n
+
+-- Test recall? with a polymorphic function
+/--
+info: Try this:
+  [apply] recall id {α : Sort u} (a : α) : α
+-/
+#guard_msgs in recall? id
+-- Verify the suggestion is accepted:
+recall id {α : Sort u} (a : α) : α
+
+-- Test recall? with unknown constant
+/-- error: Unknown constant `nonexistent` -/
+#guard_msgs in recall? nonexistent
+
+-- Test recall? with a simple def
+/--
+info: Try this:
+  [apply] recall foo : ℕ
+-/
+#guard_msgs in recall? foo
+-- Verify the suggestion is accepted:
+recall foo : ℕ
+
+-- Test recall? with instance implicit arguments
+/--
+info: Try this:
+  [apply] recall add_assoc {G : Type u_1} [AddSemigroup G] (a b c : G) : a + b + c = a + (b + c)
+-/
+#guard_msgs in recall? add_assoc
+-- Verify the suggestion is accepted:
+recall add_assoc {G : Type u_1} [AddSemigroup G] (a b c : G) : a + b + c = a + (b + c)
+
+/-
+## Type mismatch suggestion tests
+-/
+
+-- Test that type mismatch on recall without value gives a suggestion
+/--
+info: Try this:
+  [apply] recall Nat.add_comm (n m : ℕ) : n + m = m + n
+---
+error: Type mismatch
+  Nat.add_comm
+has type
+  ∀ (n m : ℕ), n + m = m + m
+but is expected to have type
+  ∀ (n m : ℕ), n + m = m + n
+-/
+#guard_msgs in recall Nat.add_comm (n m : Nat) : n + m = m + m


### PR DESCRIPTION
This PR adds two features to the `recall` command:

1. **`recall?`**: Looks up a constant and suggests the correct `recall` statement via "Try this:". Uses `delabConstWithSignature` from Lean core for proper binder grouping and formatting.

2. **Type mismatch suggestions**: When `recall foo : wrong_type` errors with a type mismatch, a "Try this:" suggestion with the correct signature is shown alongside the error.

🤖 Prepared with Claude Code