### PR TITLE
[Merged by Bors] - chore(GroupTheory/Coxeter/Length): deprecate nat subtraction lemmas

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -111,24 +111,31 @@ theorem length_inv (w : W) : ℓ (w⁻¹) = ℓ w := by
     have := cs.length_wordProd_le (List.reverse ω)
     rwa [wordProd_reverse, length_reverse, ← h'ω, hω, inv_inv] at this
 
-theorem length_mul_le (w₁ w₂ : W) :
-    ℓ (w₁ * w₂) ≤ ℓ w₁ + ℓ w₂ := by
+theorem length_mul_le (w₁ w₂ : W) : ℓ (w₁ * w₂) ≤ ℓ w₁ + ℓ w₂ := by
   rcases cs.exists_reduced_word w₁ with ⟨ω₁, hω₁, rfl⟩
   rcases cs.exists_reduced_word w₂ with ⟨ω₂, hω₂, rfl⟩
   have := cs.length_wordProd_le (ω₁ ++ ω₂)
   simpa [hω₁, hω₂, wordProd_append] using this
 
-theorem length_mul_ge_length_sub_length (w₁ w₂ : W) :
-    ℓ w₁ - ℓ w₂ ≤ ℓ (w₁ * w₂) := by
-  simpa [Nat.sub_le_of_le_add] using cs.length_mul_le (w₁ * w₂) w₂⁻¹
+theorem length_le_length_mul_add_left (w₁ w₂ : W) : ℓ w₂ ≤ ℓ (w₁ * w₂) + ℓ w₁ := by
+  simpa [add_comm] using cs.length_mul_le w₁⁻¹ (w₁ * w₂)
 
-theorem length_mul_ge_length_sub_length' (w₁ w₂ : W) :
-    ℓ w₂ - ℓ w₁ ≤ ℓ (w₁ * w₂) := by
-  simpa [Nat.sub_le_of_le_add, add_comm] using cs.length_mul_le w₁⁻¹ (w₁ * w₂)
+theorem length_le_length_mul_add_right (w₁ w₂ : W) : ℓ w₁ ≤ ℓ (w₁ * w₂) + ℓ w₂ := by
+  simpa using cs.length_mul_le (w₁ * w₂) w₂⁻¹
 
-theorem length_mul_ge_max (w₁ w₂ : W) :
-    max (ℓ w₁ - ℓ w₂) (ℓ w₂ - ℓ w₁) ≤ ℓ (w₁ * w₂) :=
-  max_le_iff.mpr ⟨length_mul_ge_length_sub_length _ _ _, length_mul_ge_length_sub_length' _ _ _⟩
+@[deprecated length_le_length_mul_add_right (since := "2026-03-25")]
+theorem length_mul_ge_length_sub_length (w₁ w₂ : W) : ℓ w₁ - ℓ w₂ ≤ ℓ (w₁ * w₂) := by
+  rw [Nat.sub_le_iff_le_add]; exact length_le_length_mul_add_right ..
+
+@[deprecated length_le_length_mul_add_left (since := "2026-03-25")]
+theorem length_mul_ge_length_sub_length' (w₁ w₂ : W) : ℓ w₂ - ℓ w₁ ≤ ℓ (w₁ * w₂) := by
+  rw [Nat.sub_le_iff_le_add]; exact length_le_length_mul_add_left ..
+
+set_option linter.deprecated false in
+@[deprecated "use `length_le_length_mul_add_left` and `length_le_length_mul_add_right"
+(since := "2026-03-25")]
+theorem length_mul_ge_max (w₁ w₂ : W) : max (ℓ w₁ - ℓ w₂) (ℓ w₂ - ℓ w₁) ≤ ℓ (w₁ * w₂) :=
+  max_le (length_mul_ge_length_sub_length ..) (length_mul_ge_length_sub_length' ..)
 
 /-- The homomorphism that sends each element `w : W` to the parity of the length of `w`.
 (See `lengthParity_eq_ofAdd_length`.) -/
@@ -179,29 +186,17 @@ theorem length_mul_simple_ne (w : W) (i : B) : ℓ (w * s i) ≠ ℓ w := by
   lia
 
 theorem length_simple_mul_ne (w : W) (i : B) : ℓ (s i * w) ≠ ℓ w := by
-  convert cs.length_mul_simple_ne w⁻¹ i using 1
-  · convert cs.length_inv ?_ using 2
-    simp
-  · simp
+  rw [← length_inv]
+  simpa using cs.length_mul_simple_ne w⁻¹ i
 
-theorem length_mul_simple (w : W) (i : B) :
-    ℓ (w * s i) = ℓ w + 1 ∨ ℓ (w * s i) + 1 = ℓ w := by
-  rcases Nat.lt_or_gt_of_ne (cs.length_mul_simple_ne w i) with lt | gt
-  · -- lt : ℓ (w * s i) < ℓ w
-    right
-    have length_ge := cs.length_mul_ge_length_sub_length w (s i)
-    simp only [length_simple, tsub_le_iff_right] at length_ge
-    -- length_ge : ℓ w ≤ ℓ (w * s i) + 1
-    lia
-  · -- gt : ℓ w < ℓ (w * s i)
-    left
-    have length_le := cs.length_mul_le w (s i)
-    simp only [length_simple] at length_le
-    -- length_le : ℓ (w * s i) ≤ ℓ w + 1
-    lia
+theorem length_mul_simple (w : W) (i : B) : ℓ (w * s i) = ℓ w + 1 ∨ ℓ (w * s i) + 1 = ℓ w := by
+  rcases (cs.length_mul_simple_ne w i).lt_or_gt with h | h <;> rw [← Nat.add_one_le_iff] at h
+  · refine .inr (h.antisymm ?_)
+    simpa using cs.length_le_length_mul_add_right w (s i)
+  · refine .inl (h.antisymm' ?_)
+    simpa using cs.length_mul_le w (s i)
 
-theorem length_simple_mul (w : W) (i : B) :
-    ℓ (s i * w) = ℓ w + 1 ∨ ℓ (s i * w) + 1 = ℓ w := by
+theorem length_simple_mul (w : W) (i : B) : ℓ (s i * w) = ℓ w + 1 ∨ ℓ (s i * w) + 1 = ℓ w := by
   have := cs.length_mul_simple w⁻¹ i
   rwa [(by simp : w⁻¹ * (s i) = ((s i) * w)⁻¹), length_inv, length_inv] at this
 


### PR DESCRIPTION
In favor of equivalent theorems expressed with addition.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
