### PR TITLE
[Merged by Bors] - refactor(NumberTheory/RamificationInertia/Basic): remove the ring homomorphism from `Ideal.ramificationIdx`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Ideal.lean
@@ -115,7 +115,7 @@ theorem map_eq_span_zeta_sub_one_pow :
     ← Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank]
 
 theorem ramificationIdx_span_zeta_sub_one :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 (span {hζ.toInteger - 1}) = p ^ k * (p - 1) := by
+    ramificationIdx 𝒑 (span {hζ.toInteger - 1}) = p ^ k * (p - 1) := by
   have h := isPrime_span_zeta_sub_one p k hζ
   rw [← Nat.totient_prime_pow_succ hp.out, ← finrank _ K,
     IsDedekindDomain.ramificationIdx_eq_multiplicity _ h, map_eq_span_zeta_sub_one_pow p k hζ,
@@ -154,7 +154,7 @@ theorem inertiaDeg_eq_of_prime_pow (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP�
 
 include hK in
 theorem ramificationIdx_eq_of_prime_pow (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 P = p ^ k * (p - 1) := by
+    ramificationIdx 𝒑 P = p ^ k * (p - 1) := by
   rw [eq_span_zeta_sub_one_of_liesOver p k K hK.zeta_spec P, ramificationIdx_span_zeta_sub_one]
 
 include hK in
@@ -186,7 +186,7 @@ theorem inertiaDeg_span_zeta_sub_one' : inertiaDeg 𝒑 (span {hζ.toInteger - 1
   exact inertiaDeg_span_zeta_sub_one p 0 hζ
 
 theorem ramificationIdx_span_zeta_sub_one' :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 (span {hζ.toInteger - 1}) = p - 1 := by
+    ramificationIdx 𝒑 (span {hζ.toInteger - 1}) = p - 1 := by
   rw [← pow_one p] at hK hζ
   rw [ramificationIdx_span_zeta_sub_one p 0 hζ, pow_zero, one_mul]
 
@@ -210,7 +210,7 @@ theorem inertiaDeg_eq_of_prime (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ :
 
 include hK in
 theorem ramificationIdx_eq_of_prime (P : Ideal (𝓞 K)) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver 𝒑] :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 P = p - 1 := by
+    ramificationIdx 𝒑 P = p - 1 := by
   rw [eq_span_zeta_sub_one_of_liesOver' p K hK.zeta_spec P, ramificationIdx_span_zeta_sub_one']
 
 include hK in
@@ -259,7 +259,7 @@ theorem inertiaDeg_eq_of_not_dvd (hm : ¬ p ∣ m) :
 alias inertiaDeg_of_not_dvd := inertiaDeg_eq_of_not_dvd
 
 theorem ramificationIdx_eq_of_not_dvd (hm : ¬ p ∣ m) :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 P = 1 := by
+    ramificationIdx 𝒑 P = 1 := by
   let ζ := (zeta_spec m ℚ K).toInteger
   have h₁ : ¬ p ∣ exponent ζ := by
     rw [exponent_eq_one_iff.mpr <| adjoin_singleton_eq_top (zeta_spec m ℚ K)]
@@ -377,7 +377,7 @@ theorem inertiaDeg_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
   rw [← inertiaDegIn_eq_inertiaDeg 𝒑 P Gal(K/ℚ), inertiaDegIn_eq n K hn hm]
 
 theorem ramificationIdx_eq (hn : n = p ^ (k + 1) * m) (hm : ¬ p ∣ m) :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) 𝒑 P = p ^ k * (p - 1) := by
+    ramificationIdx 𝒑 P = p ^ k * (p - 1) := by
   have : IsGalois ℚ K := isGalois {n} ℚ K
   rw [← ramificationIdxIn_eq_ramificationIdx 𝒑 P Gal(K/ℚ), ramificationIdxIn_eq n K hn hm]
 

--- a/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/NumberField/Ideal/KummerDedekind.lean
@@ -233,7 +233,7 @@ The ramification index of the ideal corresponding to the class of `Q ∈ ℤ[X]`
 -/
 theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p ∣ exponent θ)
     {Q : ℤ[X]} (hQ : Q.map (Int.castRingHom (ZMod p)) ∈ monicFactorsMod θ p) :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) (span {(p : ℤ)})
+    ramificationIdx (span {(p : ℤ)})
       ((primesOverSpanEquivMonicFactorsMod hp).symm
         ⟨Q.map (Int.castRingHom (ZMod p)), hQ⟩ : Ideal (𝓞 K)) =
           multiplicity (Q.map (Int.castRingHom (ZMod p)))
@@ -251,7 +251,7 @@ theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply (hp : ¬ p
 
 theorem ramificationIdx_primesOverSpanEquivMonicFactorsMod_symm_apply' (hp : ¬ p ∣ exponent θ)
     {Q : (ZMod p)[X]} (hQ : Q ∈ monicFactorsMod θ p) :
-    ramificationIdx (algebraMap ℤ (𝓞 K)) (span {(p : ℤ)})
+    ramificationIdx (span {(p : ℤ)})
       ((primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩ : Ideal (𝓞 K)) =
         multiplicity Q ((minpoly ℤ θ).map (Int.castRingHom (ZMod p))) := by
   obtain ⟨S, rfl⟩ := (map_surjective _ (ZMod.ringHom_surjective (Int.castRingHom (ZMod p)))) Q

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -51,8 +51,10 @@ namespace Ideal
 universe u v
 
 variable {R : Type u} [CommRing R]
-variable {S : Type v} [CommRing S] (f : R →+* S)
+variable {S : Type v} [CommRing S] [Algebra R S]
 variable (p : Ideal R) (P : Ideal S)
+
+local notation "f" => algebraMap R S
 
 open Module
 
@@ -72,19 +74,19 @@ defined to be 0.
 -/
 noncomputable def ramificationIdx : ℕ := sSup {n | map f p ≤ P ^ n}
 
-variable {f p P}
+variable {p P}
 
 theorem ramificationIdx_eq_find [DecidablePred fun n ↦ ∀ (k : ℕ), map f p ≤ P ^ k → k ≤ n]
     (h : ∃ n, ∀ k, map f p ≤ P ^ k → k ≤ n) :
-    ramificationIdx f p P = Nat.find h := by
+    ramificationIdx p P = Nat.find h := by
   convert Nat.sSup_def h
 
 theorem ramificationIdx_eq_zero (h : ∀ n : ℕ, ∃ k, map f p ≤ P ^ k ∧ n < k) :
-    ramificationIdx f p P = 0 :=
+    ramificationIdx p P = 0 :=
   dif_neg (by push_neg; exact h)
 
 theorem ramificationIdx_spec {n : ℕ} (hle : map f p ≤ P ^ n) (hgt : ¬map f p ≤ P ^ (n + 1)) :
-    ramificationIdx f p P = n := by
+    ramificationIdx p P = n := by
   classical
   let Q : ℕ → Prop := fun m => ∀ k : ℕ, map f p ≤ P ^ k → k ≤ m
   have : Q n := by
@@ -96,7 +98,7 @@ theorem ramificationIdx_spec {n : ℕ} (hle : map f p ≤ P ^ n) (hgt : ¬map f 
   obtain this' := Nat.find_spec ⟨n, this⟩
   exact h.not_ge (this' _ hle)
 
-theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationIdx f p P < n := by
+theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationIdx p P < n := by
   classical
   rcases n with - | n
   · simp at hgt
@@ -108,40 +110,40 @@ theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationI
     exact Nat.find_min' ⟨n, this⟩ this
 
 @[simp]
-theorem ramificationIdx_bot : ramificationIdx f ⊥ P = 0 :=
+theorem ramificationIdx_bot : ramificationIdx (⊥ : Ideal R) P = 0 :=
   dif_neg <| not_exists.mpr fun n hn => n.lt_succ_self.not_ge (hn _ (by simp))
 
 @[simp]
-theorem ramificationIdx_of_not_le (h : ¬map f p ≤ P) : ramificationIdx f p P = 0 :=
+theorem ramificationIdx_of_not_le (h : ¬map f p ≤ P) : ramificationIdx p P = 0 :=
   ramificationIdx_spec (by simp) (by simpa using h)
 
 theorem ramificationIdx_bot' (hp : p ≠ ⊥) (hf : Function.Injective f) :
-    ramificationIdx f p ⊥ = 0 :=
+    ramificationIdx p (⊥ : Ideal S) = 0 :=
   ramificationIdx_of_not_le <| le_bot_iff.not.mpr <| (map_eq_bot_iff_of_injective hf).not.mpr hp
 
 theorem ramificationIdx_ne_zero {e : ℕ} (he : e ≠ 0) (hle : map f p ≤ P ^ e)
-    (hnle : ¬map f p ≤ P ^ (e + 1)) : ramificationIdx f p P ≠ 0 := by
+    (hnle : ¬map f p ≤ P ^ (e + 1)) : ramificationIdx p P ≠ 0 := by
   rwa [ramificationIdx_spec hle hnle]
 
-theorem le_pow_of_le_ramificationIdx {n : ℕ} (hn : n ≤ ramificationIdx f p P) :
+theorem le_pow_of_le_ramificationIdx {n : ℕ} (hn : n ≤ ramificationIdx p P) :
     map f p ≤ P ^ n := by
   contrapose! hn
   exact ramificationIdx_lt hn
 
-theorem le_pow_ramificationIdx : map f p ≤ P ^ ramificationIdx f p P :=
+theorem le_pow_ramificationIdx : map f p ≤ P ^ ramificationIdx p P :=
   le_pow_of_le_ramificationIdx (le_refl _)
 
-theorem le_comap_pow_ramificationIdx : p ≤ comap f (P ^ ramificationIdx f p P) :=
+theorem le_comap_pow_ramificationIdx : p ≤ comap f (P ^ ramificationIdx p P) :=
   map_le_iff_le_comap.mp le_pow_ramificationIdx
 
-theorem le_comap_of_ramificationIdx_ne_zero (h : ramificationIdx f p P ≠ 0) : p ≤ comap f P :=
+theorem le_comap_of_ramificationIdx_ne_zero (h : ramificationIdx p P ≠ 0) : p ≤ comap f P :=
   Ideal.map_le_iff_le_comap.mp <| le_pow_ramificationIdx.trans <| Ideal.pow_le_self <| h
 
 variable {S₁ : Type*} [CommRing S₁] [Algebra R S₁]
 
 variable (p) in
-lemma ramificationIdx_comap_eq [Algebra R S] (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
-    ramificationIdx (algebraMap R S) p (P.comap e) = ramificationIdx (algebraMap R S₁) p P := by
+lemma ramificationIdx_comap_eq (e : S ≃ₐ[R] S₁) (P : Ideal S₁) :
+    ramificationIdx p (P.comap e) = ramificationIdx p P := by
   dsimp only [ramificationIdx]
   congr 1
   ext n
@@ -152,14 +154,14 @@ lemma ramificationIdx_comap_eq [Algebra R S] (e : S ≃ₐ[R] S₁) (P : Ideal S
     AlgHom.comp_algebraMap]
 
 variable (p) in
-lemma ramificationIdx_map_eq [Algebra R S] {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁]
+lemma ramificationIdx_map_eq {E : Type*} [EquivLike E S S₁] [AlgEquivClass E R S S₁]
     (P : Ideal S) (e : E) :
-    ramificationIdx (algebraMap R S₁) p (P.map e) = ramificationIdx (algebraMap R S) p P := by
+    ramificationIdx p (P.map e) = ramificationIdx p P := by
   rw [show P.map e = _ from P.map_comap_of_equiv (e : S ≃+* S₁)]
   exact p.ramificationIdx_comap_eq (e : S ≃ₐ[R] S₁).symm P
 
 lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
-    ramificationIdx f p P ≠ 1 ↔ p.map f ≤ P ^ 2 := by
+    ramificationIdx p P ≠ 1 ↔ p.map f ≤ P ^ 2 := by
   classical
   by_cases! H : ∀ n : ℕ, ∃ k, p.map f ≤ P ^ k ∧ n < k
   · obtain ⟨k, hk, h2k⟩ := H 2
@@ -180,13 +182,13 @@ open IsLocalRing in
 /-- The converse is true when `S` is a Dedekind domain.
 See `Ideal.ramificationIdx_eq_one_iff_of_isDedekindDomain`. -/
 lemma ramificationIdx_eq_one_of_map_localization
-    [Algebra R S] {p : Ideal R} {P : Ideal S} [P.IsPrime] [IsNoetherianRing S]
+    {p : Ideal R} {P : Ideal S} [P.IsPrime] [IsNoetherianRing S]
     (hpP : map (algebraMap R S) p ≤ P) (hp : P ≠ ⊥) (hp' : P.primeCompl ≤ nonZeroDivisors S)
     (H : p.map (algebraMap R (Localization.AtPrime P)) = maximalIdeal (Localization.AtPrime P)) :
-    ramificationIdx (algebraMap R S) p P = 1 := by
+    ramificationIdx p P = 1 := by
   rw [← not_ne_iff (b := 1), Ideal.ramificationIdx_ne_one_iff hpP]
   intro h₂
-  replace h₂ := Ideal.map_mono (f := algebraMap S (Localization.AtPrime P)) h₂
+  replace h₂ := Ideal.map_mono («f» := algebraMap S (Localization.AtPrime P)) h₂
   rw [Ideal.map_pow, Localization.AtPrime.map_eq_maximalIdeal, Ideal.map_map,
     ← IsScalarTower.algebraMap_eq, H, pow_two] at h₂
   have := Submodule.eq_bot_of_le_smul_of_le_jacobson_bot _ _ (IsNoetherian.noetherian _) h₂
@@ -196,7 +198,7 @@ lemma ramificationIdx_eq_one_of_map_localization
   · exact IsLocalization.injective _ hp'
 
 theorem ramificationIdx_map_self_eq_one [IsDedekindDomain S] (h₁ : map f p ≠ ⊤) (h₂ : map f p ≠ ⊥) :
-    ramificationIdx f p (map f p) = 1 := by
+    ramificationIdx p (map f p) = 1 := by
   refine ramificationIdx_spec (by simp) fun h ↦ ?_
   have : map f p ^ 1 = (map f p) ^ 2 := by
     rw [pow_one]
@@ -210,7 +212,7 @@ variable [IsDedekindDomain S]
 
 theorem ramificationIdx_eq_normalizedFactors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime)
-    (hP0 : P ≠ ⊥) : ramificationIdx f p P = (normalizedFactors (map f p)).count P := by
+    (hP0 : P ≠ ⊥) : ramificationIdx p P = (normalizedFactors (map f p)).count P := by
   have hPirr := (Ideal.prime_of_isPrime hP0 hP).irreducible
   refine ramificationIdx_spec (Ideal.le_of_dvd ?_) (mt Ideal.dvd_iff_le.mpr ?_) <;>
     rw [dvd_iff_normalizedFactors_le_normalizedFactors (pow_ne_zero _ hP0) hp0,
@@ -219,7 +221,7 @@ theorem ramificationIdx_eq_normalizedFactors_count
   exact (Nat.lt_succ_self _).not_ge
 
 theorem ramificationIdx_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime) :
-    ramificationIdx f p P = multiplicity P (Ideal.map f p) := by
+    ramificationIdx p P = multiplicity P (Ideal.map f p) := by
   classical
   by_cases hP₂ : P = ⊥
   · rw [hP₂, ← Ideal.zero_eq_bot, multiplicity_zero_eq_zero_of_ne_zero _ hp]
@@ -231,12 +233,12 @@ theorem ramificationIdx_eq_multiplicity (hp : map f p ≠ ⊥) (hP : P.IsPrime) 
 
 theorem ramificationIdx_eq_factors_count
     (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (hP0 : P ≠ ⊥) :
-    ramificationIdx f p P = (factors (map f p)).count P := by
+    ramificationIdx p P = (factors (map f p)).count P := by
   rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hp0 hP hP0,
     factors_eq_normalizedFactors]
 
 theorem ramificationIdx_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : map f p ≤ P) :
-    ramificationIdx f p P ≠ 0 := by
+    ramificationIdx p P ≠ 0 := by
   classical
   have hP0 : P ≠ ⊥ := by
     rintro rfl
@@ -247,17 +249,17 @@ theorem ramificationIdx_ne_zero (hp0 : map f p ≠ ⊥) (hP : P.IsPrime) (le : m
     exists_mem_normalizedFactors_of_dvd hp0 hPirr (Ideal.dvd_iff_le.mpr le)
   rwa [Multiset.count_ne_zero, associated_iff_eq.mp P'_eq]
 
-theorem ramificationIdx_ne_zero_of_liesOver [Algebra R S] [IsDomain R] [IsTorsionFree R S]
+theorem ramificationIdx_ne_zero_of_liesOver [IsDomain R] [IsTorsionFree R S]
     (P : Ideal S) [hP : P.IsPrime] {p : Ideal R} (hp : p ≠ ⊥) [hPp : P.LiesOver p] :
-    ramificationIdx (algebraMap R S) p P ≠ 0 :=
+    ramificationIdx p P ≠ 0 :=
   IsDedekindDomain.ramificationIdx_ne_zero (map_ne_bot_of_ne_bot hp) hP <|
     map_le_iff_le_comap.mpr <| le_of_eq <| (liesOver_iff _ _).mp hPp
 
 open IsLocalRing in
 lemma ramificationIdx_eq_one_iff
-    [Algebra R S] {p : Ideal R} {P : Ideal S} [P.IsPrime]
+    {p : Ideal R} {P : Ideal S} [P.IsPrime]
     (hp : P ≠ ⊥) (hpP : p.map (algebraMap R S) ≤ P) :
-    ramificationIdx (algebraMap R S) p P = 1 ↔
+    ramificationIdx p P = 1 ↔
       p.map (algebraMap R (Localization.AtPrime P)) = maximalIdeal (Localization.AtPrime P) := by
   refine ⟨?_, ramificationIdx_eq_one_of_map_localization hpP hp (primeCompl_le_nonZeroDivisors _)⟩
   let Sₚ := Localization.AtPrime P
@@ -272,7 +274,7 @@ lemma ramificationIdx_eq_one_iff
   rw [← not_ne_iff, IsLocalization.map_algebraMap_ne_top_iff_disjoint P.primeCompl]
   simpa [primeCompl, Set.disjoint_compl_left_iff_subset]
 
-theorem emultiplicity_map_eq_zero_of_ne [IsDedekindDomain R] [Algebra R S] {v : Ideal R}
+theorem emultiplicity_map_eq_zero_of_ne [IsDedekindDomain R] {v : Ideal R}
     {w : Ideal S} {p : Ideal R} (hv : Irreducible v) (hp : Prime p) (hvp : v ≠ p) [w.LiesOver v] :
     emultiplicity w (p.map (algebraMap R S)) = 0 := by
   refine emultiplicity_eq_zero.2 fun h ↦ hvp.symm ?_
@@ -281,11 +283,11 @@ theorem emultiplicity_map_eq_zero_of_ne [IsDedekindDomain R] [Algebra R S] {v : 
 
 /-- Use the more general result `emultiplicity_map_eq_ramificationIdx_mul`.
 This is a helper lemma. -/
-private theorem emultiplicity_map_eq_ramificationIdx_mul_of_prime [IsDedekindDomain R] [Algebra R S]
+private theorem emultiplicity_map_eq_ramificationIdx_mul_of_prime [IsDedekindDomain R]
     [FaithfulSMul R S] {v : Ideal R} {w : Ideal S} {p : Ideal R}
     (hv : Irreducible v) (hp : Prime p) (hw : Irreducible w) (hw_bot : w ≠ ⊥)
     [w.LiesOver v] : emultiplicity w (p.map (algebraMap R S)) =
-      v.ramificationIdx (algebraMap R S) w * emultiplicity v p := by
+      v.ramificationIdx w * emultiplicity v p := by
   have hp_bot : p.map (algebraMap R S) ≠ ⊥ := map_ne_bot_of_ne_bot hp.ne_zero
   by_cases hvp : v = p
   · simp [hvp, (FiniteMultiplicity.of_prime_left hp hp.ne_zero).emultiplicity_self,
@@ -297,11 +299,11 @@ private theorem emultiplicity_map_eq_ramificationIdx_mul_of_prime [IsDedekindDom
 /-- If `v` is an irreducible ideal of `R`, `w` is an irreducible ideal of `S` lying over `v`, and
 `I` is an ideal of `R`, then the multiplicity of `w` in `I.map (algebraMap R S)` is given by
 the multiplicity of `v` in `I` multiplied by the ramification index of `w` over `v`. -/
-theorem emultiplicity_map_eq_ramificationIdx_mul [IsDedekindDomain R] [Algebra R S]
+theorem emultiplicity_map_eq_ramificationIdx_mul [IsDedekindDomain R]
     [FaithfulSMul R S] {v : Ideal R} {w : Ideal S} {I : Ideal R} (h : I ≠ ⊥)
     (hv : Irreducible v) (hw : Irreducible w) (hw_bot : w ≠ ⊥) [w.LiesOver v] :
     emultiplicity w (I.map (algebraMap R S)) =
-      v.ramificationIdx (algebraMap R S) w * emultiplicity v I := by
+      v.ramificationIdx w * emultiplicity v I := by
   induction I using induction_on_prime with
   | h₁ => aesop
   | h₂ I hI =>
@@ -315,9 +317,7 @@ theorem emultiplicity_map_eq_ramificationIdx_mul [IsDedekindDomain R] [Algebra R
 
 end IsDedekindDomain
 
-variable (f p P) [Algebra R S]
-
-local notation "f" => algebraMap R S
+variable (p P)
 
 open Classical in
 /-- The inertia degree of `P : Ideal S` lying over `p : Ideal R` is the degree of the
@@ -415,7 +415,6 @@ section FinrankQuotientMap
 
 open scoped nonZeroDivisors
 
-variable [Algebra R S]
 variable {K : Type*} [Field K] [Algebra R K]
 variable {L : Type*} [Field L] [Algebra S L] [IsFractionRing S L]
 variable {V V' V'' : Type*}
@@ -505,7 +504,7 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
   -- Because `det A ≠ 0`, we have `span L {det A} = ⊤`.
   · rw [eq_comm, Submodule.restrictScalars_eq_top_iff, Ideal.span_singleton_eq_top]
     refine IsUnit.mk0 _ ((map_ne_zero_iff (algebraMap R L) hRL).mpr ?_)
-    refine ne_zero_of_map (f := Ideal.Quotient.mk p) ?_
+    refine ne_zero_of_map («f» := Ideal.Quotient.mk p) ?_
     have := Ideal.Quotient.nontrivial_iff.mpr hp
     calc
       Ideal.Quotient.mk p A.det = Matrix.det ((Ideal.Quotient.mk p).mapMatrix A) := by
@@ -537,9 +536,9 @@ The statement we prove is actually slightly more general:
 * the function `f' : V'' → V'` doesn't need to be injective
 -/
 theorem FinrankQuotientMap.linearIndependent_of_nontrivial [IsDedekindDomain R]
-    (hRS : RingHom.ker (algebraMap R S) ≠ ⊤) (f : V'' →ₗ[R] V) (hf : Function.Injective f)
+    (hRS : RingHom.ker (algebraMap R S) ≠ ⊤) (F : V'' →ₗ[R] V) (hf : Function.Injective F)
     (f' : V'' →ₗ[R] V') {ι : Type*} {b : ι → V''} (hb' : LinearIndependent S (f' ∘ b)) :
-    LinearIndependent K (f ∘ b) := by
+    LinearIndependent K (F ∘ b) := by
   contrapose! hb' with hb
   -- Informally, if we have a nontrivial linear dependence with coefficients `g` in `K`,
   -- then we can find a linear dependence with coefficients `I.Quotient.mk g'` in `R/I`,
@@ -559,14 +558,14 @@ theorem FinrankQuotientMap.linearIndependent_of_nontrivial [IsDedekindDomain R]
     simp only [FractionalIdeal.mem_coeIdeal, not_exists, not_and'] at hgI
     exact hgI _ (hg' j hjs)
   refine ⟨fun i => algebraMap R S (g' i), ?_, j, hjs, hgI⟩
-  have eq : f (∑ i ∈ s, g' i • b i) = 0 := by
+  have eq : F (∑ i ∈ s, g' i • b i) = 0 := by
     rw [map_sum, ← smul_zero a, ← eq, Finset.smul_sum]
     refine Finset.sum_congr rfl ?_
     intro i hi
     rw [map_smul, ← IsScalarTower.algebraMap_smul K, hg' i hi, ← smul_assoc,
       smul_eq_mul, Function.comp_apply]
   simp only [IsScalarTower.algebraMap_smul, ← map_smul, ← map_sum,
-    (f.map_eq_zero_iff hf).mp eq, map_zero, (· ∘ ·)]
+    (F.map_eq_zero_iff hf).mp eq, map_zero, (· ∘ ·)]
 
 variable (L)
 
@@ -621,10 +620,7 @@ end FinrankQuotientMap
 
 section FactLeComap
 
-variable [Algebra R S]
-
-local notation "f" => algebraMap R S
-local notation "e" => ramificationIdx f p P
+local notation "e" => ramificationIdx p P
 
 /-- `R / p` has a canonical map to `S / (P ^ e)`, where `e` is the ramification index
 of `P` over `p`. -/
@@ -689,7 +685,7 @@ theorem quotientToQuotientRangePowQuotSuccAux_mk {i : ℕ} {a : S} (a_mem : a �
   apply Quotient.map'_mk''
 
 section
-variable [hfp : NeZero (ramificationIdx (algebraMap R S) p P)]
+variable [hfp : NeZero (ramificationIdx p P)]
 
 /-- `S ⧸ P` embeds into the quotient by `P^(i+1) ⧸ P^e` as a subspace of `P^i ⧸ P^e`. -/
 noncomputable def quotientToQuotientRangePowQuotSucc
@@ -848,7 +844,7 @@ section FactorsMap
 /-! ## Properties of the factors of `p.map (algebraMap R S)` -/
 
 
-variable [IsDedekindDomain S] [Algebra R S]
+variable [IsDedekindDomain S]
 
 open scoped Classical in
 theorem Factors.ne_bot (P : (factors (map (algebraMap R S) p)).toFinset) : (P : Ideal S) ≠ ⊥ :=
@@ -861,13 +857,13 @@ instance Factors.isPrime (P : (factors (map (algebraMap R S) p)).toFinset) :
 
 open scoped Classical in
 theorem Factors.ramificationIdx_ne_zero (P : (factors (map (algebraMap R S) p)).toFinset) :
-    ramificationIdx (algebraMap R S) p P ≠ 0 :=
+    ramificationIdx p P.1 ≠ 0 :=
   IsDedekindDomain.ramificationIdx_ne_zero (ne_zero_of_mem_factors (Multiset.mem_toFinset.mp P.2))
     (Factors.isPrime p P) (Ideal.le_of_dvd (dvd_of_mem_factors (Multiset.mem_toFinset.mp P.2)))
 
 open scoped Classical in
 instance Factors.fact_ramificationIdx_neZero (P : (factors (map (algebraMap R S) p)).toFinset) :
-    NeZero (ramificationIdx (algebraMap R S) p P) :=
+    NeZero (ramificationIdx p P.1) :=
   ⟨Factors.ramificationIdx_ne_zero p P⟩
 
 attribute [local instance] Quotient.algebraQuotientOfRamificationIdxNeZero
@@ -885,15 +881,15 @@ instance Factors.liesOver [p.IsMaximal] (P : (factors (map (algebraMap R S) p)).
 open scoped Classical in
 theorem Factors.finrank_pow_ramificationIdx [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
-    finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P) =
-      ramificationIdx (algebraMap R S) p P * inertiaDeg p (P : Ideal S) := by
+    finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) =
+      ramificationIdx p P.1 * inertiaDeg p (P : Ideal S) := by
   rw [finrank_prime_pow_ramificationIdx, inertiaDeg_algebraMap]
   exacts [Factors.ne_bot p P, NeZero.ne _]
 
 open scoped Classical in
 instance Factors.finiteDimensional_quotient_pow [Module.Finite R S] [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :
-    FiniteDimensional (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P) := by
+    FiniteDimensional (R ⧸ p) (S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) := by
   refine .of_finrank_pos ?_
   rw [pos_iff_ne_zero, Factors.finrank_pow_ramificationIdx]
   exact mul_ne_zero (Factors.ramificationIdx_ne_zero p P) (inertiaDeg_pos p P.1).ne'
@@ -906,11 +902,11 @@ factors in `S` as `∏ i, P i ^ e i`, then `S ⧸ I` factors as `Π i, R ⧸ (P 
 noncomputable def Factors.piQuotientEquiv (p : Ideal R) (hp : map (algebraMap R S) p ≠ ⊥) :
     S ⧸ map (algebraMap R S) p ≃+*
       ∀ P : (factors (map (algebraMap R S) p)).toFinset,
-        S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P :=
+        S ⧸ (P : Ideal S) ^ ramificationIdx p P.1 :=
   (IsDedekindDomain.quotientEquivPiFactors hp).trans <|
     @RingEquiv.piCongrRight (factors (map (algebraMap R S) p)).toFinset
       (fun P => S ⧸ (P : Ideal S) ^ (factors (map (algebraMap R S) p)).count (P : Ideal S))
-      (fun P => S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P) _ _
+      (fun P => S ⧸ (P : Ideal S) ^ ramificationIdx p P.1) _ _
       fun P : (factors (map (algebraMap R S) p)).toFinset =>
       Ideal.quotEquivOfEq <| by
         rw [IsDedekindDomain.ramificationIdx_eq_factors_count hp (Factors.isPrime p P)
@@ -934,7 +930,7 @@ then `S ⧸ I` factors `R ⧸ I`-linearly as `Π i, R ⧸ (P i ^ e i)`. -/
 noncomputable def Factors.piQuotientLinearEquiv (p : Ideal R) (hp : map (algebraMap R S) p ≠ ⊥) :
     (S ⧸ map (algebraMap R S) p) ≃ₗ[R ⧸ p]
       ∀ P : (factors (map (algebraMap R S) p)).toFinset,
-        S ⧸ (P : Ideal S) ^ ramificationIdx (algebraMap R S) p P :=
+        S ⧸ (P : Ideal S) ^ ramificationIdx p P.1 :=
   { Factors.piQuotientEquiv p hp with
     map_smul' := by
       rintro ⟨c⟩ ⟨x⟩; ext P
@@ -954,11 +950,10 @@ here `S` is a finite `R`-module (and thus `Frac(S) : Frac(R)` is a finite extens
 is maximal. -/
 theorem sum_ramification_inertia {p : Ideal R} [p.IsMaximal] (hp0 : p ≠ ⊥) :
     ∑ P ∈ primesOverFinset p S,
-        ramificationIdx (algebraMap R S) p P * inertiaDeg p P = finrank K L := by
-  set e := ramificationIdx (algebraMap R S) p
-  set f := inertiaDeg p (S := S)
+        ramificationIdx p P * inertiaDeg p P = finrank K L := by
+  set e := ramificationIdx p (S := S)
   calc
-    (∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * f P) =
+    ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset, e P * inertiaDeg p P =
         ∑ P ∈ (factors (map (algebraMap R S) p)).toFinset.attach,
           finrank (R ⧸ p) (S ⧸ (P : Ideal S) ^ e P) := ?_
     _ = finrank (R ⧸ p)
@@ -985,7 +980,7 @@ theorem inertiaDeg_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaxima
 
 theorem ramificationIdx_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} [p.IsMaximal]
     (P : Ideal S) [hP₁ : P.IsPrime] [hP₂ : P.LiesOver p] :
-    p.ramificationIdx (algebraMap R S) P ≤ Module.finrank K L := by
+    p.ramificationIdx P ≤ Module.finrank K L := by
   classical
   by_cases hp0 : p = ⊥
   · simp [hp0]
@@ -1007,7 +1002,7 @@ theorem card_primesOverFinset_le_finrank [NoZeroSMulDivisors R S] {p : Ideal R} 
 /-- `Ideal.sum_ramification_inertia`, in the local (DVR) case. -/
 lemma ramificationIdx_mul_inertiaDeg_of_isLocalRing [IsLocalRing S] {p : Ideal R} [p.IsMaximal]
     (hp0 : p ≠ ⊥) :
-    ramificationIdx (algebraMap R S) p (IsLocalRing.maximalIdeal S) *
+    ramificationIdx p (IsLocalRing.maximalIdeal S) *
       p.inertiaDeg (IsLocalRing.maximalIdeal S) = Module.finrank K L := by
   have := FaithfulSMul.of_field_isFractionRing R S K L
   simp_rw [← sum_ramification_inertia S K L hp0, IsLocalRing.primesOverFinset_eq S hp0,
@@ -1018,30 +1013,6 @@ end FactorsMap
 section tower
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
-
-theorem ramificationIdx_tower [IsDedekindDomain S] [IsDedekindDomain T] {f : R →+* S} {g : S →+* T}
-    {p : Ideal R} {P : Ideal S} {Q : Ideal T} [hpm : P.IsPrime] [hqm : Q.IsPrime]
-    (hg0 : map g P ≠ ⊥) (hfg : map (g.comp f) p ≠ ⊥) (hg : map g P ≤ Q) :
-    ramificationIdx (g.comp f) p Q = ramificationIdx f p P * ramificationIdx g P Q := by
-  classical
-  have hf0 : map f p ≠ ⊥ :=
-    ne_bot_of_map_ne_bot (Eq.mp (congrArg (fun I ↦ I ≠ ⊥) (map_map f g).symm) hfg)
-  have hp0 : P ≠ ⊥ := ne_bot_of_map_ne_bot hg0
-  have hq0 : Q ≠ ⊥ := ne_bot_of_le_ne_bot hg0 hg
-  letI : P.IsMaximal := Ring.DimensionLEOne.maximalOfPrime hp0 hpm
-  rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hf0 hpm hp0,
-    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hg0 hqm hq0,
-    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hfg hqm hq0, ← map_map]
-  rcases eq_prime_pow_mul_coprime hf0 P with ⟨I, hcp, heq⟩
-  have hcp : ⊤ = map g P ⊔ map g I := by rw [← map_sup, hcp, map_top g]
-  have hntq : ¬ ⊤ ≤ Q := fun ht ↦ IsPrime.ne_top hqm (Iff.mpr (eq_top_iff_one Q) (ht trivial))
-  nth_rw 1 [heq, Ideal.map_mul, Ideal.map_pow, normalizedFactors_mul (pow_ne_zero _ hg0) <| by
-    by_contra h
-    simp only [h, Submodule.zero_eq_bot, bot_le, sup_of_le_left] at hcp
-    exact hntq (hcp.trans_le hg), Multiset.count_add, normalizedFactors_pow, Multiset.count_nsmul]
-  exact add_eq_left.mpr <| Decidable.byContradiction fun h ↦ hntq <| hcp.trans_le <|
-    sup_le hg <| le_of_dvd <| dvd_of_mem_normalizedFactors <| Multiset.count_ne_zero.mp h
-
 variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 /-- Let `T / S / R` be a tower of algebras, `p, P, Q` be ideals in `R, S, T` respectively,
@@ -1050,16 +1021,36 @@ theorem ramificationIdx_algebra_tower [IsDedekindDomain S] [IsDedekindDomain T]
     {p : Ideal R} {P : Ideal S} {Q : Ideal T} [hpm : P.IsPrime] [hqm : Q.IsPrime]
     (hg0 : map (algebraMap S T) P ≠ ⊥)
     (hfg : map (algebraMap R T) p ≠ ⊥) (hg : map (algebraMap S T) P ≤ Q) :
-    ramificationIdx (algebraMap R T) p Q =
-    ramificationIdx (algebraMap R S) p P * ramificationIdx (algebraMap S T) P Q := by
-  rw [IsScalarTower.algebraMap_eq R S T] at hfg ⊢
-  exact ramificationIdx_tower hg0 hfg hg
+    ramificationIdx p Q =
+    ramificationIdx p P * ramificationIdx P Q := by
+  classical
+  have hf0 : map (algebraMap R S) p ≠ ⊥ := by
+    rw [IsScalarTower.algebraMap_eq R S T, ← map_map] at hfg
+    exact ne_bot_of_map_ne_bot hfg
+  have hp0 : P ≠ ⊥ := ne_bot_of_map_ne_bot hg0
+  have hq0 : Q ≠ ⊥ := ne_bot_of_le_ne_bot hg0 hg
+  letI : P.IsMaximal := Ring.DimensionLEOne.maximalOfPrime hp0 hpm
+  rw [IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hf0 hpm hp0,
+    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hg0 hqm hq0,
+    IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count hfg hqm hq0,
+    IsScalarTower.algebraMap_eq R S T, ← map_map]
+  rcases eq_prime_pow_mul_coprime hf0 P with ⟨I, hcp, heq⟩
+  have hcp : ⊤ = map (algebraMap S T) P ⊔ map (algebraMap S T) I := by rw [← map_sup, hcp, map_top]
+  have hntq : ¬ ⊤ ≤ Q := fun ht ↦ IsPrime.ne_top hqm (Iff.mpr (eq_top_iff_one Q) (ht trivial))
+  nth_rw 1 [heq, Ideal.map_mul, Ideal.map_pow, normalizedFactors_mul (pow_ne_zero _ hg0) <| by
+    by_contra h
+    simp only [h, Submodule.zero_eq_bot, bot_le, sup_of_le_left] at hcp
+    exact hntq (hcp.trans_le hg), Multiset.count_add, normalizedFactors_pow, Multiset.count_nsmul]
+  exact add_eq_left.mpr <| Decidable.byContradiction fun h ↦ hntq <| hcp.trans_le <|
+    sup_le hg <| le_of_dvd <| dvd_of_mem_normalizedFactors <| Multiset.count_ne_zero.mp h
+
+@[deprecated (since := "2026-03-25")] alias ramificationIdx_tower := ramificationIdx_algebra_tower
 
 theorem ramificationIdx_algebra_tower' [IsDedekindDomain S] [IsDedekindDomain T] [IsDomain R]
     [Module.IsTorsionFree R S] [Module.IsTorsionFree S T] (p : Ideal R) (P : Ideal S) (Q : Ideal T)
     [Q.IsPrime] [Q.LiesOver P] [P.LiesOver p] :
-    ramificationIdx (algebraMap R T) p Q =
-      ramificationIdx (algebraMap R S) p P * ramificationIdx (algebraMap S T) P Q := by
+    ramificationIdx p Q =
+      ramificationIdx p P * ramificationIdx P Q := by
   obtain rfl | hp := eq_or_ne p ⊥
   · simp
   have : P.IsPrime := Ideal.over_def Q P ▸ Ideal.IsPrime.under S Q

--- a/Mathlib/NumberTheory/RamificationInertia/Galois.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Galois.lean
@@ -58,7 +58,7 @@ open scoped Classical in
   maximal ideal `p` of `A` are the same, which we define as `Ideal.ramificationIdxIn`. -/
 noncomputable def ramificationIdxIn {A : Type*} [CommRing A] (p : Ideal A)
     (B : Type*) [CommRing B] [Algebra A B] : ℕ :=
-  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then p.ramificationIdx (algebraMap A B) h.choose
+  if h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p then p.ramificationIdx h.choose
   else 0
 
 open scoped Classical in
@@ -144,7 +144,7 @@ alias isPretransitive_of_isGalois := isPretransitive_of_isGaloisGroup
 include G in
 /-- All the `Ideal.ramificationIdx` over a fixed maximal ideal are the same. -/
 theorem ramificationIdx_eq_of_isGaloisGroup :
-    ramificationIdx (algebraMap A B) p P = ramificationIdx (algebraMap A B) p Q := by
+    ramificationIdx p P = ramificationIdx p Q := by
   rcases exists_smul_eq_of_isGaloisGroup p P Q G with ⟨σ, rfl⟩
   exact (ramificationIdx_map_eq p P (MulSemiringAction.toAlgEquiv A B σ)).symm
 
@@ -164,7 +164,7 @@ alias inertiaDeg_eq_of_isGalois := inertiaDeg_eq_of_isGaloisGroup
 include G in
 /-- The `ramificationIdxIn` is equal to any ramification index over the same ideal. -/
 theorem ramificationIdxIn_eq_ramificationIdx :
-    ramificationIdxIn p B = ramificationIdx (algebraMap A B) p P := by
+    ramificationIdxIn p B = ramificationIdx p P := by
   have h : ∃ P : Ideal B, P.IsPrime ∧ P.LiesOver p := ⟨P, hPp, hp⟩
   obtain ⟨_, _⟩ := h.choose_spec
   rw [ramificationIdxIn, dif_pos h]

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -29,7 +29,7 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
 
 local notation3 "e(" P "|" R ")" =>
-  Ideal.ramificationIdx (algebraMap _ _) (Ideal.under R P) P
+  Ideal.ramificationIdx (Ideal.under R P) P
 
 open IsLocalRing Algebra
 

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -821,7 +821,7 @@ If `p` is a maximal ideal, then the lift of `p` in an extension is the product o
 over `p` to the power the ramification index.
 -/
 theorem Ideal.map_algebraMap_eq_finset_prod_pow {p : Ideal S} [p.IsMaximal] (hp : p ≠ 0) :
-    map (algebraMap S R) p = ∏ P ∈ p.primesOver R, P ^ p.ramificationIdx (algebraMap S R) P := by
+    map (algebraMap S R) p = ∏ P ∈ p.primesOver R, P ^ p.ramificationIdx P := by
   classical
   have h : map (algebraMap S R) p ≠ 0 := map_ne_bot_of_ne_bot hp
   rw [← finprod_heightOneSpectrum_factorization (I := p.map (algebraMap S R)) h]

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -410,7 +410,7 @@ theorem relNorm_eq_pow_of_isPrime_isGalois [p.IsMaximal] [P.IsPrime]
   obtain ⟨s, hs⟩ := exists_relNorm_eq_pow_of_isPrime P p
   suffices s = p.inertiaDeg P by rwa [this] at hs
   have h₀ : ∀ Q ∈ (p.primesOver S).toFinset,
-      relNorm R Q ^ ramificationIdx (algebraMap R S) p Q = p ^ ((p.ramificationIdxIn S) * s) := by
+      relNorm R Q ^ ramificationIdx p Q = p ^ ((p.ramificationIdxIn S) * s) := by
     intro Q hQ
     rw [Set.mem_toFinset] at hQ
     have : Q.IsPrime := hQ.1

--- a/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
@@ -180,8 +180,8 @@ theorem inertiaDeg_map_eq_inertiaDeg [p.IsMaximal] [P.IsMaximal]
 theorem ramificationIdx_map_eq_ramificationIdx [IsDomain R] [IsTorsionFree R S] [IsTorsionFree R Rₚ]
     [IsTorsionFree S Sₚ] [IsTorsionFree Rₚ Sₚ] [IsDedekindDomain S] [IsDedekindDomain Rₚ]
     [IsDedekindDomain Sₚ] (hp : p ≠ ⊥) [P.IsPrime] :
-    (maximalIdeal Rₚ).ramificationIdx (algebraMap Rₚ Sₚ) (P.map (algebraMap S Sₚ)) =
-      p.ramificationIdx (algebraMap R S) P := by
+    (maximalIdeal Rₚ).ramificationIdx (P.map (algebraMap S Sₚ)) =
+      p.ramificationIdx P := by
   have h₁ : maximalIdeal Rₚ ≠ ⊥ := by
     rw [← map_eq_maximalIdeal p]
     exact map_ne_bot_of_ne_bot hp
@@ -255,9 +255,9 @@ theorem primesOverEquivPrimesOver_inertiagDeg_eq [p.IsMaximal] (hp : p ≠ ⊥) 
 theorem primesOverEquivPrimesOver_ramificationIdx_eq (hp : p ≠ ⊥) [NoZeroSMulDivisors R Rₚ]
     [NoZeroSMulDivisors S Sₚ] [NoZeroSMulDivisors Rₚ Sₚ] [IsDedekindDomain Rₚ] [IsDedekindDomain Sₚ]
     (P : p.primesOver S) :
-    (maximalIdeal Rₚ).ramificationIdx (algebraMap Rₚ Sₚ)
+    (maximalIdeal Rₚ).ramificationIdx
       (primesOverEquivPrimesOver p Rₚ Sₚ hp P : Ideal Sₚ) =
-        p.ramificationIdx (algebraMap R S) P.val :=
+        p.ramificationIdx P.val :=
   ramificationIdx_map_eq_ramificationIdx p _ _ _ hp
 
 end IsDedekindDomain


### PR DESCRIPTION
This PR removes the ring homomorphism from `Ideal.ramificationIdx`, following the analogous refactor for `Ideal.inertiaDeg` in #19847.

This ring homomorphism is never used in practice, and only makes statements more clunky.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
