### PR TITLE
feat: product of Coxeter matrices

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Matrix.lean
+++ b/Mathlib/GroupTheory/Coxeter/Matrix.lean
@@ -75,12 +75,12 @@ structure CoxeterMatrix (B : Type*) where
 
 namespace CoxeterMatrix
 
-variable {B : Type*}
+variable {B B' : Type*} (e : B ≃ B')
 
 /-- A Coxeter matrix can be coerced to a matrix. -/
-instance : CoeFun (CoxeterMatrix B) fun _ ↦ (Matrix B B ℕ) := ⟨M⟩
+instance : CoeFun (CoxeterMatrix B) fun _ ↦ Matrix B B ℕ := ⟨M⟩
 
-variable {B' : Type*} (e : B ≃ B') (M : CoxeterMatrix B)
+variable (M : CoxeterMatrix B)
 
 attribute [simp] diagonal
 

--- a/Mathlib/GroupTheory/Coxeter/Matrix.lean
+++ b/Mathlib/GroupTheory/Coxeter/Matrix.lean
@@ -95,6 +95,16 @@ protected def reindex : CoxeterMatrix B' where
 
 theorem reindex_apply (i i' : B') : M.reindex e i i' = M (e.symm i) (e.symm i') := rfl
 
+/-- The Coxeter matrix `A * B` is the block matrix `!![A, 2; 2, B]`. -/
+instance : HMul (CoxeterMatrix B) (CoxeterMatrix B') (CoxeterMatrix (B ⊕ B')) where
+  hMul M N := {
+    M := Matrix.fromBlocks M (.of fun _ _ ↦ 2) (.of fun _ _ ↦ 2) N
+    isSymm := by
+      rw [Matrix.IsSymm, Matrix.fromBlocks_transpose]
+      congr! <;> exact CoxeterMatrix.isSymm _
+    diagonal i := by cases i <;> simp
+    off_diagonal i i' h := by aesop (add simp [CoxeterMatrix.off_diagonal]) }
+
 variable (n : ℕ)
 
 /-- The Coxeter matrix of type Aₙ.


### PR DESCRIPTION
The Coxeter matrix `A * B` is the block matrix `!![A, 2; 2, B]`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I've used multiplication to denote this under the logic that the product of Coxeter groups has a Coxeter matrix given by this construction. Perhaps this isn't desirable, considering it doesn't match matrix multiplication. I'm open to suggestions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
