### PR TITLE
[Merged by Bors] - feat(RingTheory/Artinian/Module): add `pow` version of `quotNilradicalEquivPi`

### DIFF
--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -612,6 +612,18 @@ lemma primeSpectrum_asIdeal_range_eq :
 
 variable (R)
 
+theorem nilradical_pow_eq_iInf (n : ℕ) :
+    nilradical R ^ n = iInf fun I : MaximalSpectrum R ↦ I.1 ^ n := by
+  have : Fintype (MaximalSpectrum R) := Fintype.ofFinite (MaximalSpectrum R)
+  rw [← iInf_univ, ← Finset.coe_univ, PrimeSpectrum.nilradical_eq_iInf]
+  simp only [Finset.mem_coe]
+  rw [← Ideal.prod_eq_iInf_of_pairwise_isCoprime fun I _ _ _ ↦ .pow ∘ I.isCoprime_of_ne,
+    Finset.prod_pow, Ideal.prod_eq_iInf_of_pairwise_isCoprime fun I _ _ _ ↦ I.isCoprime_of_ne]
+  simp [Finset.mem_univ, iInf, IsArtinianRing.primeSpectrum_asIdeal_range_eq]
+
+theorem nilradical_eq_iInf : nilradical R = iInf MaximalSpectrum.asIdeal := by
+  simpa using nilradical_pow_eq_iInf R 1
+
 lemma setOf_isPrime_finite : {I : Ideal R | I.IsPrime}.Finite := by
   simpa only [isPrime_iff_isMaximal] using setOf_isMaximal_finite R
 
@@ -626,15 +638,21 @@ instance : Finite (PrimeSpectrum R) :=
 
 /-- The quotient of a commutative Artinian ring by its nilradical is isomorphic to
 a finite product of fields, namely the quotients by the maximal ideals. -/
+@[simps!]
 noncomputable def quotNilradicalEquivPi :
-    R ⧸ nilradical R ≃+* ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal :=
-  let f := MaximalSpectrum.asIdeal (R := R)
-  .trans
-    (Ideal.quotEquivOfEq <| ext fun x ↦ by
-      rw [PrimeSpectrum.nilradical_eq_iInf, iInf, primeSpectrum_asIdeal_range_eq]; rfl)
-    (Ideal.quotientInfRingEquivPiQuotient f <| fun I J h ↦
-      Ideal.isCoprime_iff_sup_eq.mpr <| I.2.coprime_of_ne J.2 <|
-      fun hIJ ↦ h <| MaximalSpectrum.ext hIJ)
+    (R ⧸ nilradical R) ≃ₐ[R] ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal :=
+  (Ideal.quotientEquivAlgOfEq R (nilradical_eq_iInf R)).trans
+    { __ := Ideal.quotientInfRingEquivPiQuotient _ fun I _ ↦ I.isCoprime_of_ne
+      commutes' _ := rfl}
+
+/-- The quotient of a commutative Artinian ring by a power of its nilradical is isomorphic to
+a finite product of local rings, namely the quotients by the powers of the maximal ideals. -/
+@[simps!]
+noncomputable def IsArtinainRing.quotNilradicalPowEquivPi (n : ℕ) :
+    (R ⧸ nilradical R ^ n) ≃ₐ[R] ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal ^ n :=
+  (Ideal.quotientEquivAlgOfEq R (nilradical_pow_eq_iInf R n)).trans
+    { __ := Ideal.quotientInfRingEquivPiQuotient _ fun I _ ↦ .pow ∘ I.isCoprime_of_ne
+      commutes' _ := rfl}
 
 /-- A reduced commutative Artinian ring is isomorphic to a finite product of fields,
 namely the quotients by the maximal ideals. -/

--- a/Mathlib/RingTheory/Artinian/Module.lean
+++ b/Mathlib/RingTheory/Artinian/Module.lean
@@ -648,7 +648,7 @@ noncomputable def quotNilradicalEquivPi :
 /-- The quotient of a commutative Artinian ring by a power of its nilradical is isomorphic to
 a finite product of local rings, namely the quotients by the powers of the maximal ideals. -/
 @[simps!]
-noncomputable def IsArtinainRing.quotNilradicalPowEquivPi (n : ℕ) :
+noncomputable def quotNilradicalPowEquivPi (n : ℕ) :
     (R ⧸ nilradical R ^ n) ≃ₐ[R] ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal ^ n :=
   (Ideal.quotientEquivAlgOfEq R (nilradical_pow_eq_iInf R n)).trans
     { __ := Ideal.quotientInfRingEquivPiQuotient _ fun I _ ↦ .pow ∘ I.isCoprime_of_ne
@@ -656,10 +656,9 @@ noncomputable def IsArtinainRing.quotNilradicalPowEquivPi (n : ℕ) :
 
 /-- A reduced commutative Artinian ring is isomorphic to a finite product of fields,
 namely the quotients by the maximal ideals. -/
-noncomputable def equivPi [IsReduced R] : R ≃ₐ[R] ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal where
-  __ := RingEquiv.trans (.symm <| .quotientBot R) <| .trans
-    (Ideal.quotEquivOfEq (nilradical_eq_zero R).symm) (quotNilradicalEquivPi R)
-  commutes' _ := rfl
+noncomputable def equivPi [IsReduced R] : R ≃ₐ[R] ∀ I : MaximalSpectrum R, R ⧸ I.asIdeal :=
+  .trans (.symm <| .quotientBot R R) <| .trans
+    (Ideal.quotientEquivAlgOfEq R (nilradical_eq_zero R).symm) (quotNilradicalEquivPi R)
 
 set_option backward.isDefEq.respectTransparency false in
 theorem isSemisimpleRing_of_isReduced [IsReduced R] : IsSemisimpleRing R :=

--- a/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Basic.lean
@@ -5,6 +5,7 @@ Authors: David Kurniadi Angdinata
 -/
 module
 
+public import Mathlib.RingTheory.Ideal.Operations
 public import Mathlib.RingTheory.Spectrum.Maximal.Defs
 public import Mathlib.RingTheory.Spectrum.Prime.Defs
 
@@ -45,5 +46,8 @@ def toPrimeSpectrum (x : MaximalSpectrum R) : PrimeSpectrum R :=
 
 theorem toPrimeSpectrum_injective : (@toPrimeSpectrum R _).Injective := fun ⟨_, _⟩ ⟨_, _⟩ h => by
   simpa only [MaximalSpectrum.mk.injEq] using PrimeSpectrum.ext_iff.mp h
+
+theorem isCoprime_of_ne {I J : MaximalSpectrum R} (h : I ≠ J) : IsCoprime I.1 J.1 :=
+  Ideal.isCoprime_iff_sup_eq.mpr <| I.2.coprime_of_ne J.2 <| mt MaximalSpectrum.ext h
 
 end MaximalSpectrum


### PR DESCRIPTION
This PR upgrades `IsArtinianRing.quotNilradicalEquivPi` and adds a `pow` version.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
