### PR TITLE
[Merged by Bors] - chore(GroupTheory/Nilpotent): move declarations into namespace

### DIFF
--- a/Mathlib/GroupTheory/Commutator/Basic.lean
+++ b/Mathlib/GroupTheory/Commutator/Basic.lean
@@ -62,7 +62,7 @@ theorem commutatorElement_self : ⁅g, g⁆ = 1 :=
 theorem commutatorElement_inv : ⁅g₁, g₂⁆⁻¹ = ⁅g₂, g₁⁆ := by
   simp_rw [commutatorElement_def, mul_inv_rev, inv_inv, mul_assoc]
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem map_commutatorElement : (f ⁅g₁, g₂⁆ : G') = ⁅f g₁, f g₂⁆ := by
   simp_rw [commutatorElement_def, map_mul f, map_inv f]
 

--- a/Mathlib/GroupTheory/Frattini.lean
+++ b/Mathlib/GroupTheory/Frattini.lean
@@ -57,7 +57,7 @@ theorem frattini_nongenerating [IsCoatomic (Subgroup G)] {K : Subgroup G}
 /-- When `G` is finite, the Frattini subgroup is nilpotent. -/
 theorem frattini_nilpotent [Finite G] : Group.IsNilpotent (frattini G) := by
   -- We use the characterisation of nilpotency in terms of all Sylow subgroups being normal.
-  have q := (isNilpotent_of_finite_tfae (G := frattini G)).out 0 3
+  have q := (Group.isNilpotent_of_finite_tfae (G := frattini G)).out 0 3
   rw [q]; clear q
   -- Consider each prime `p` and Sylow `p`-subgroup `P` of `frattini G`.
   intro p p_prime P

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -79,29 +79,31 @@ are not central series if `G` is not nilpotent is a standard abuse of notation.
 @[expose] public section
 
 
-open Subgroup
+open commutatorElement Subgroup
 
 section WithGroup
 
 variable {G : Type*} [Group G] (H : Subgroup G) [Normal H]
+
+namespace Subgroup
 
 /-- If `H` is a normal subgroup of `G`, then the set `{x : G | ∀ y : G, x*y*x⁻¹*y⁻¹ ∈ H}`
 is a subgroup of `G` (because it is the preimage in `G` of the centre of the
 quotient group `G/H`.)
 -/
 def upperCentralSeriesStep : Subgroup G where
-  carrier := { x : G | ∀ y : G, x * y * x⁻¹ * y⁻¹ ∈ H }
+  carrier := { x : G | ∀ y : G, ⁅x, y⁆ ∈ H }
   one_mem' y := by simp
   mul_mem' {a b} ha hb y := by
     convert Subgroup.mul_mem _ (ha (b * y * b⁻¹)) (hb y) using 1
     group
   inv_mem' {x} hx y := by
     specialize hx y⁻¹
-    rw [mul_assoc, inv_inv] at hx ⊢
+    rw [commutatorElement_def, mul_assoc, inv_inv] at hx ⊢
     exact Subgroup.Normal.mem_comm inferInstance hx
 
 theorem mem_upperCentralSeriesStep (x : G) :
-    x ∈ upperCentralSeriesStep H ↔ ∀ y, x * y * x⁻¹ * y⁻¹ ∈ H := Iff.rfl
+    x ∈ upperCentralSeriesStep H ↔ ∀ y, ⁅x, y⁆ ∈ H := Iff.rfl
 
 open QuotientGroup
 
@@ -113,7 +115,8 @@ theorem upperCentralSeriesStep_eq_comap_center :
   rw [mem_comap, mem_center_iff, forall_mk]
   refine forall_congr' fun y => ?_
   rw [coe_mk', ← QuotientGroup.mk_mul, ← QuotientGroup.mk_mul, eq_comm, eq_iff_div_mem,
-    div_eq_mul_inv, mul_inv_rev, mul_assoc]
+    div_eq_mul_inv, mul_inv_rev, commutatorElement_def]
+  simp_rw [mul_assoc]
 
 instance [H.Characteristic] : Characteristic (upperCentralSeriesStep H) :=
   (upperCentralSeriesStep_eq_comap_center H) ▸ Characteristic.comap_quotient_mk centerCharacteristic
@@ -156,14 +159,15 @@ theorem upperCentralSeries_one : upperCentralSeries G 1 = center G := by
   ext
   simp only [upperCentralSeries, upperCentralSeriesAux, upperCentralSeriesStep, mem_bot, mem_mk,
     Submonoid.mem_mk, Subsemigroup.mem_mk, Set.mem_setOf_eq, mem_center_iff]
-  exact forall_congr' fun y => by rw [mul_inv_eq_one, mul_inv_eq_iff_eq_mul, eq_comm]
+  exact forall_congr' fun y => by
+    rw [commutatorElement_def, mul_inv_eq_one, mul_inv_eq_iff_eq_mul, eq_comm]
 
 variable {G}
 
 /-- The `n+1`st term of the upper central series `H i` has underlying set equal to the `x` such
 that `⁅x,G⁆ ⊆ H n`. -/
 theorem mem_upperCentralSeries_succ_iff {n : ℕ} {x : G} :
-    x ∈ upperCentralSeries G (n + 1) ↔ ∀ y : G, x * y * x⁻¹ * y⁻¹ ∈ upperCentralSeries G n :=
+    x ∈ upperCentralSeries G (n + 1) ↔ ∀ y : G, ⁅x, y⁆ ∈ upperCentralSeries G n :=
   Iff.rfl
 
 @[simp] lemma comap_upperCentralSeries {H : Type*} [Group H] (e : H ≃* G) :
@@ -172,7 +176,9 @@ theorem mem_upperCentralSeries_succ_iff {n : ℕ} {x : G} :
   | n + 1 => by
     ext
     simp [mem_upperCentralSeries_succ_iff, ← comap_upperCentralSeries e n,
-      ← e.toEquiv.forall_congr_right]
+      ← e.toEquiv.forall_congr_right, commutatorElement_def]
+
+end Subgroup
 
 namespace Group
 
@@ -207,15 +213,17 @@ end Group
 
 open Group
 
+namespace Subgroup
+
 /-- A sequence of subgroups of `G` is an ascending central series if `H 0` is trivial and
   `⁅H (n + 1), G⁆ ⊆ H n` for all `n`. Note that we do not require that `H n = G` for some `n`. -/
 def IsAscendingCentralSeries (H : ℕ → Subgroup G) : Prop :=
-  H 0 = ⊥ ∧ ∀ (x : G) (n : ℕ), x ∈ H (n + 1) → ∀ g, x * g * x⁻¹ * g⁻¹ ∈ H n
+  H 0 = ⊥ ∧ ∀ (x : G) (n : ℕ), x ∈ H (n + 1) → ∀ g, ⁅x, g⁆ ∈ H n
 
 /-- A sequence of subgroups of `G` is a descending central series if `H 0` is `G` and
   `⁅H n, G⁆ ⊆ H (n + 1)` for all `n`. Note that we do not require that `H n = {1}` for some `n`. -/
 def IsDescendingCentralSeries (H : ℕ → Subgroup G) :=
-  H 0 = ⊤ ∧ ∀ (x : G) (n : ℕ), x ∈ H n → ∀ g, x * g * x⁻¹ * g⁻¹ ∈ H (n + 1)
+  H 0 = ⊤ ∧ ∀ (x : G) (n : ℕ), x ∈ H n → ∀ g, ⁅x, g⁆ ∈ H (n + 1)
 
 /-- Any ascending central series for a group is bounded above by the upper central series. -/
 theorem ascending_central_series_le_upper (H : ℕ → Subgroup G) (hH : IsAscendingCentralSeries H) :
@@ -236,7 +244,7 @@ theorem upperCentralSeries_isAscendingCentralSeries :
 theorem upperCentralSeries_mono : Monotone (upperCentralSeries G) := by
   refine monotone_nat_of_le_succ ?_
   intro n x hx y
-  rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹]
+  rw [commutatorElement_def, mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹]
   exact mul_mem hx (Normal.conj_mem inferInstance x⁻¹ (inv_mem hx) y)
 
 /-- A group `G` is nilpotent iff there exists an ascending central series which reaches `G` in
@@ -259,7 +267,7 @@ theorem is_descending_rev_series_of_is_ascending {H : ℕ → Subgroup G} {n : �
   by_cases! hm : n ≤ m
   · rw [tsub_eq_zero_of_le hm, h0, Subgroup.mem_bot] at hx
     subst hx
-    rw [show (1 : G) * g * (1⁻¹ : G) * g⁻¹ = 1 by group]
+    rw [commutatorElement_one_left]
     exact Subgroup.one_mem _
   · apply hH
     convert hx using 1
@@ -306,16 +314,16 @@ variable {G}
 theorem lowerCentralSeries_zero : lowerCentralSeries G 0 = ⊤ := rfl
 
 @[simp]
-theorem lowerCentralSeries_one : lowerCentralSeries G 1 = commutator G := rfl
+theorem lowerCentralSeries_one : lowerCentralSeries G 1 = _root_.commutator G := rfl
 
 theorem mem_lowerCentralSeries_succ_iff (n : ℕ) (q : G) :
     q ∈ lowerCentralSeries G (n + 1) ↔
     q ∈ closure { x | ∃ p ∈ lowerCentralSeries G n,
-                        ∃ q ∈ (⊤ : Subgroup G), p * q * p⁻¹ * q⁻¹ = x } := Iff.rfl
+                        ∃ q ∈ (⊤ : Subgroup G), ⁅p, q⁆ = x } := Iff.rfl
 
 theorem lowerCentralSeries_succ (n : ℕ) :
     lowerCentralSeries G (n + 1) =
-      closure { x | ∃ p ∈ lowerCentralSeries G n, ∃ q ∈ (⊤ : Subgroup G), p * q * p⁻¹ * q⁻¹ = x } :=
+      closure { x | ∃ p ∈ lowerCentralSeries G n, ∃ q ∈ (⊤ : Subgroup G), ⁅p, q⁆ = x } :=
   rfl
 
 instance (n : ℕ) : Characteristic (lowerCentralSeries G n) := by
@@ -330,7 +338,7 @@ theorem lowerCentralSeries_antitone : Antitone (lowerCentralSeries G) := by
   refine
     closure_induction ?_ (Subgroup.one_mem _) (fun _ _ _ _ ↦ mul_mem) (fun _ _ ↦ inv_mem) hx
   rintro y ⟨z, hz, a, ha⟩
-  rw [← ha, mul_assoc, mul_assoc, ← mul_assoc a z⁻¹ a⁻¹]
+  rw [← ha, commutatorElement_def, mul_assoc, mul_assoc, ← mul_assoc a z⁻¹ a⁻¹]
   exact mul_mem hz (Normal.conj_mem inferInstance z⁻¹ (inv_mem hz) a)
 
 /-- The lower central series of a group is a descending central series. -/
@@ -360,6 +368,8 @@ theorem nilpotent_iff_lowerCentralSeries : IsNilpotent G ↔ ∃ n, lowerCentral
   · rintro ⟨n, hn⟩
     exact ⟨n, lowerCentralSeries G, lowerCentralSeries_isDescendingCentralSeries, hn⟩
 
+end Subgroup
+
 section Classical
 
 variable (G) in
@@ -380,6 +390,8 @@ open scoped Classical in
 theorem Group.nilpotencyClass_def :
     Group.nilpotencyClass G = Nat.find (IsNilpotent.nilpotent G) :=
   dif_pos hG
+
+namespace Subgroup
 
 @[simp]
 theorem upperCentralSeries_nilpotencyClass :
@@ -461,7 +473,11 @@ theorem lowerCentralSeries_eq_bot_iff_nilpotencyClass_le {n : ℕ} :
     rw [eq_bot_iff, ← lowerCentralSeries_nilpotencyClass]
     exact lowerCentralSeries_antitone h
 
+end Subgroup
+
 end Classical
+
+namespace Subgroup
 
 theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
     (lowerCentralSeries H n).map H.subtype ≤ lowerCentralSeries G n := by
@@ -474,7 +490,7 @@ theorem lowerCentralSeries_map_subtype_le (H : Subgroup G) (n : ℕ) :
     exact ⟨x3, hd (mem_map.mpr ⟨x3, hx3, rfl⟩), x4, by simp⟩
 
 /-- A subgroup of a nilpotent group is nilpotent -/
-instance Subgroup.isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpotent H := by
+instance isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpotent H := by
   rw [nilpotent_iff_lowerCentralSeries] at *
   rcases hG with ⟨n, hG⟩
   use n
@@ -483,7 +499,7 @@ instance Subgroup.isNilpotent (H : Subgroup G) [hG : IsNilpotent G] : IsNilpoten
   exact eq_bot_iff.mpr fun x hx => Subtype.ext (this x ⟨hx, rfl⟩)
 
 /-- The nilpotency class of a subgroup is less or equal to the nilpotency class of the group -/
-theorem Subgroup.nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
+theorem nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
     Group.nilpotencyClass H ≤ Group.nilpotencyClass G := by
   repeat rw [← lowerCentralSeries_length_eq_nilpotencyClass]
   classical apply Nat.find_mono
@@ -492,7 +508,8 @@ theorem Subgroup.nilpotencyClass_le (H : Subgroup G) [hG : IsNilpotent G] :
   simp only [hG, SetLike.le_def, mem_map, exists_imp] at this
   exact eq_bot_iff.mpr fun x hx => Subtype.ext (this x ⟨hx, rfl⟩)
 
-instance (priority := 100) Group.isNilpotent_of_subsingleton [Subsingleton G] : IsNilpotent G :=
+instance (priority := 100) _root_.Group.isNilpotent_of_subsingleton [Subsingleton G] :
+    IsNilpotent G :=
   nilpotent_iff_lowerCentralSeries.2 ⟨0, Subsingleton.elim ⊤ ⊥⟩
 
 theorem upperCentralSeries.map {H : Type*} [Group H] {f : G →* H} (h : Function.Surjective f)
@@ -521,7 +538,7 @@ theorem lowerCentralSeries_succ_eq_bot {n : ℕ} (h : lowerCentralSeries G n ≤
     lowerCentralSeries G (n + 1) = ⊥ := by
   rw [lowerCentralSeries_succ, closure_eq_bot_iff, Set.subset_singleton_iff]
   rintro x ⟨y, hy1, z, ⟨⟩, rfl⟩
-  rw [mul_assoc, ← mul_inv_rev, mul_inv_eq_one, eq_comm]
+  rw [commutatorElement_def, mul_assoc, ← mul_inv_rev, mul_inv_eq_one, eq_comm]
   exact mem_center_iff.mp (h hy1) z
 
 /-- The preimage of a nilpotent group is nilpotent if the kernel of the homomorphism is contained
@@ -533,6 +550,10 @@ theorem isNilpotent_of_ker_le_center {H : Type*} [Group H] (f : G →* H) (hf1 :
   use n + 1
   refine lowerCentralSeries_succ_eq_bot (le_trans ((Subgroup.map_eq_bot_iff _).mp ?_) hf1)
   exact eq_bot_iff.mpr (hn ▸ lowerCentralSeries.map f n)
+
+end Subgroup
+
+namespace Group
 
 theorem nilpotencyClass_le_of_ker_le_center {H : Type*} [Group H] (f : G →* H)
     (hf1 : f.ker ≤ center G) [IsNilpotent H] :
@@ -588,6 +609,12 @@ theorem nilpotencyClass_quotient_le (H : Subgroup G) [H.Normal] [_h : IsNilpoten
     Group.nilpotencyClass (G ⧸ H) ≤ Group.nilpotencyClass G :=
   nilpotencyClass_le_of_surjective (QuotientGroup.mk' H) QuotientGroup.mk_surjective
 
+end Group
+
+open QuotientGroup
+
+namespace Subgroup
+
 -- This technical lemma helps with rewriting the subgroup, which occurs in indices
 private theorem comap_center_subst {H₁ H₂ : Subgroup G} [Normal H₁] [Normal H₂] (h : H₁ = H₂) :
     comap (mk' H₁) (center (G ⧸ H₁)) = comap (mk' H₂) (center (G ⧸ H₂)) := by subst h; rfl
@@ -610,6 +637,10 @@ theorem comap_upperCentralSeries_quotient_center (n : ℕ) :
         (comap_center_subst ih)
       _ = upperCentralSeriesStep (upperCentralSeries G n.succ) :=
         symm (upperCentralSeriesStep_eq_comap_center _)
+
+end Subgroup
+
+namespace Group
 
 theorem nilpotencyClass_zero_iff_subsingleton [IsNilpotent G] :
     Group.nilpotencyClass G = 0 ↔ Subsingleton G := by
@@ -673,7 +704,9 @@ theorem nilpotent_center_quotient_ind {P : ∀ (G) [Group G] [IsNilpotent G], Pr
       simp [nilpotencyClass_quotient_center, h]
     exact hstep _ (ih _ hn)
 
-theorem derived_le_lower_central (n : ℕ) : derivedSeries G n ≤ lowerCentralSeries G n := by
+end Group
+
+theorem Subgroup.derived_le_lower_central (n : ℕ) : derivedSeries G n ≤ lowerCentralSeries G n := by
   induction n with
   | zero => simp
   | succ i ih => apply commutator_mono ih; simp
@@ -696,6 +729,8 @@ def commGroupOfNilpotencyClass [IsNilpotent G] (h : Group.nilpotencyClass G ≤ 
   Group.commGroupOfCenterEqTop <| by
     rw [← upperCentralSeries_one]
     exact upperCentralSeries_eq_top_iff_nilpotencyClass_le.mpr h
+
+namespace Subgroup
 
 lemma upperCentralSeries.eq_ge_of_eq_succ {a b : ℕ} (ab : a ≤ b)
     (hn : upperCentralSeries G a = upperCentralSeries G (a + 1)) :
@@ -750,11 +785,13 @@ lemma upperCentralSeries.card_image_eq_of_le_nilpotencyClass {a : ℕ}
   · intros i j hi hj
     refine (upperCentralSeries.StrictMonoOn G).injOn ?_ ?_ <;> grind
 
+end Subgroup
+
 section Prod
 
 variable {G₁ G₂ : Type*} [Group G₁] [Group G₂]
 
-theorem lowerCentralSeries_prod (n : ℕ) :
+theorem Subgroup.lowerCentralSeries_prod (n : ℕ) :
     lowerCentralSeries (G₁ × G₂) n = (lowerCentralSeries G₁ n).prod (lowerCentralSeries G₂ n) := by
   induction n with
   | zero => simp
@@ -769,7 +806,7 @@ theorem lowerCentralSeries_prod (n : ℕ) :
       _ = (lowerCentralSeries G₁ n.succ).prod (lowerCentralSeries G₂ n.succ) := rfl
 
 /-- Products of nilpotent groups are nilpotent -/
-instance isNilpotent_prod [IsNilpotent G₁] [IsNilpotent G₂] : IsNilpotent (G₁ × G₂) := by
+instance Group.isNilpotent_prod [IsNilpotent G₁] [IsNilpotent G₂] : IsNilpotent (G₁ × G₂) := by
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂), ?_⟩
   rw [lowerCentralSeries_prod,
@@ -777,7 +814,7 @@ instance isNilpotent_prod [IsNilpotent G₁] [IsNilpotent G₂] : IsNilpotent (G
     lowerCentralSeries_eq_bot_iff_nilpotencyClass_le.mpr (le_max_right _ _), bot_prod_bot]
 
 /-- The nilpotency class of a product is the max of the nilpotency classes of the factors -/
-theorem nilpotencyClass_prod [IsNilpotent G₁] [IsNilpotent G₂] :
+theorem Group.nilpotencyClass_prod [IsNilpotent G₁] [IsNilpotent G₂] :
     Group.nilpotencyClass (G₁ × G₂) =
     max (Group.nilpotencyClass G₁) (Group.nilpotencyClass G₂) := by
   refine eq_of_forall_ge_iff fun k => ?_
@@ -791,7 +828,7 @@ section BoundedPi
 -- First the case of infinite products with bounded nilpotency class
 variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 
-theorem lowerCentralSeries_pi_le (n : ℕ) :
+theorem Subgroup.lowerCentralSeries_pi_le (n : ℕ) :
     lowerCentralSeries (∀ i, Gs i) n ≤ Subgroup.pi Set.univ
       fun i => lowerCentralSeries (Gs i) n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
@@ -806,7 +843,7 @@ theorem lowerCentralSeries_pi_le (n : ℕ) :
       _ = pi fun i => lowerCentralSeries (Gs i) n.succ := rfl
 
 /-- products of nilpotent groups are nilpotent if their nilpotency class is bounded -/
-theorem isNilpotent_pi_of_bounded_class [∀ i, IsNilpotent (Gs i)] (n : ℕ)
+theorem Group.isNilpotent_pi_of_bounded_class [∀ i, IsNilpotent (Gs i)] (n : ℕ)
     (h : ∀ i, Group.nilpotencyClass (Gs i) ≤ n) : IsNilpotent (∀ i, Gs i) := by
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨n, ?_⟩
@@ -823,7 +860,7 @@ section FinitePi
 -- Now for finite products
 variable {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
 
-theorem lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
+theorem Subgroup.lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
     lowerCentralSeries (∀ i, Gs i) n = Subgroup.pi Set.univ
       fun i => lowerCentralSeries (Gs i) n := by
   let pi := fun f : ∀ i, Subgroup (Gs i) => Subgroup.pi Set.univ f
@@ -838,7 +875,7 @@ theorem lowerCentralSeries_pi_of_finite [Finite η] (n : ℕ) :
       _ = pi fun i => lowerCentralSeries (Gs i) n.succ := rfl
 
 /-- n-ary products of nilpotent groups are nilpotent -/
-instance isNilpotent_pi [Finite η] [∀ i, IsNilpotent (Gs i)] : IsNilpotent (∀ i, Gs i) := by
+instance Group.isNilpotent_pi [Finite η] [∀ i, IsNilpotent (Gs i)] : IsNilpotent (∀ i, Gs i) := by
   cases nonempty_fintype η
   rw [nilpotent_iff_lowerCentralSeries]
   refine ⟨Finset.univ.sup fun i => Group.nilpotencyClass (Gs i), ?_⟩
@@ -848,7 +885,7 @@ instance isNilpotent_pi [Finite η] [∀ i, IsNilpotent (Gs i)] : IsNilpotent (�
   exact Finset.le_sup (f := fun i => Group.nilpotencyClass (Gs i)) (Finset.mem_univ i)
 
 /-- The nilpotency class of an n-ary product is the sup of the nilpotency classes of the factors -/
-theorem nilpotencyClass_pi [Fintype η] [∀ i, IsNilpotent (Gs i)] :
+theorem Group.nilpotencyClass_pi [Fintype η] [∀ i, IsNilpotent (Gs i)] :
     Group.nilpotencyClass (∀ i, Gs i) = Finset.univ.sup fun i => Group.nilpotencyClass (Gs i) := by
   apply eq_of_forall_ge_iff
   intro k
@@ -869,6 +906,8 @@ instance [IsSimpleGroup G] [IsNilpotent G] : CommGroup G :=
 
 instance [IsSimpleGroup G] [IsNilpotent G] : IsCyclic G :=
   inferInstance
+
+namespace Group
 
 lemma nilpotencyClass_le_one_of_isSimple_of_isNilpotent [IsSimpleGroup G] [IsNilpotent G] :
     nilpotencyClass G ≤ 1 :=
@@ -891,6 +930,8 @@ theorem normalizerCondition_of_isNilpotent [h : IsNilpotent G] : NormalizerCondi
       exact hH
     apply map_injective_of_ker_le (mk' (center G)) hkh le_top
     exact (ih H' hH').trans (symm (map_top_of_surjective _ hsur))
+
+end Group
 
 end WithGroup
 
@@ -924,7 +965,7 @@ theorem IsPGroup.isNilpotent [Finite G] {p : ℕ} [hp : Fact (Nat.Prime p)] (h :
 variable [Finite G]
 
 /-- If a finite group is the direct product of its Sylow groups, it is nilpotent -/
-theorem isNilpotent_of_product_of_sylow_group
+theorem Group.isNilpotent_of_product_of_sylow_group
     (e : (∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G) :
     IsNilpotent G := by
   classical
@@ -938,7 +979,7 @@ theorem isNilpotent_of_product_of_sylow_group
 /-- A finite group is nilpotent iff the normalizer condition holds, and iff all maximal groups are
 normal and iff all Sylow groups are normal and iff the group is the direct product of its Sylow
 groups. -/
-theorem isNilpotent_of_finite_tfae :
+theorem Group.isNilpotent_of_finite_tfae :
     List.TFAE
       [IsNilpotent G, NormalizerCondition G, ∀ H : Subgroup G, IsCoatom H → H.Normal,
         ∀ (p : ℕ) (_hp : Fact p.Prime) (P : Sylow p G), (↑P : Subgroup G).Normal,

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -997,3 +997,122 @@ theorem Group.isNilpotent_of_finite_tfae :
   tfae_finish
 
 end WithFiniteGroup
+
+open Group
+
+@[deprecated (since := "2026-03-25")] alias upperCentralSeriesStep := upperCentralSeriesStep
+@[deprecated (since := "2026-03-25")] alias mem_upperCentralSeriesStep := mem_upperCentralSeriesStep
+@[deprecated (since := "2026-03-25")] alias upperCentralSeriesStep_eq_comap_center :=
+  upperCentralSeriesStep_eq_comap_center
+@[deprecated (since := "2026-03-25")] alias upperCentralSeriesAux := upperCentralSeriesAux
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries := upperCentralSeries
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_zero := upperCentralSeries_zero
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_one := upperCentralSeries_one
+@[deprecated (since := "2026-03-25")] alias mem_upperCentralSeries_succ_iff :=
+  mem_upperCentralSeries_succ_iff
+@[deprecated (since := "2026-03-25")] alias comap_upperCentralSeries := comap_upperCentralSeries
+@[deprecated (since := "2026-03-25")] alias IsAscendingCentralSeries := IsAscendingCentralSeries
+@[deprecated (since := "2026-03-25")] alias IsDescendingCentralSeries := IsDescendingCentralSeries
+@[deprecated (since := "2026-03-25")] alias ascending_central_series_le_upper :=
+  ascending_central_series_le_upper
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_isAscendingCentralSeries :=
+  upperCentralSeries_isAscendingCentralSeries
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_mono := upperCentralSeries_mono
+@[deprecated (since := "2026-03-25")] alias nilpotent_iff_finite_ascending_central_series :=
+  nilpotent_iff_finite_ascending_central_series
+@[deprecated (since := "2026-03-25")] alias is_descending_rev_series_of_is_ascending :=
+  is_descending_rev_series_of_is_ascending
+@[deprecated (since := "2026-03-25")] alias is_ascending_rev_series_of_is_descending :=
+  is_ascending_rev_series_of_is_descending
+@[deprecated (since := "2026-03-25")] alias nilpotent_iff_finite_descending_central_series :=
+  nilpotent_iff_finite_descending_central_series
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries := lowerCentralSeries
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_zero := lowerCentralSeries_zero
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_one := lowerCentralSeries_one
+@[deprecated (since := "2026-03-25")] alias mem_lowerCentralSeries_succ_iff :=
+  mem_lowerCentralSeries_succ_iff
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_succ := lowerCentralSeries_succ
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_antitone :=
+  lowerCentralSeries_antitone
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_isDescendingCentralSeries :=
+  lowerCentralSeries_isDescendingCentralSeries
+@[deprecated (since := "2026-03-25")] alias descending_central_series_ge_lower :=
+  descending_central_series_ge_lower
+@[deprecated (since := "2026-03-25")] alias nilpotent_iff_lowerCentralSeries :=
+  nilpotent_iff_lowerCentralSeries
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_nilpotencyClass :=
+  upperCentralSeries_nilpotencyClass
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries_eq_top_iff_nilpotencyClass_le :=
+  upperCentralSeries_eq_top_iff_nilpotencyClass_le
+@[deprecated (since := "2026-03-25")]
+alias least_ascending_central_series_length_eq_nilpotencyClass :=
+  least_ascending_central_series_length_eq_nilpotencyClass
+@[deprecated (since := "2026-03-25")]
+alias least_descending_central_series_length_eq_nilpotencyClass :=
+  least_descending_central_series_length_eq_nilpotencyClass
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_length_eq_nilpotencyClass :=
+  lowerCentralSeries_length_eq_nilpotencyClass
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_nilpotencyClass :=
+  lowerCentralSeries_nilpotencyClass
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_eq_bot_iff_nilpotencyClass_le :=
+  lowerCentralSeries_eq_bot_iff_nilpotencyClass_le
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_map_subtype_le :=
+  lowerCentralSeries_map_subtype_le
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries.map := upperCentralSeries.map
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries.map := lowerCentralSeries.map
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_succ_eq_bot :=
+  lowerCentralSeries_succ_eq_bot
+@[deprecated (since := "2026-03-25")] alias isNilpotent_of_ker_le_center :=
+  isNilpotent_of_ker_le_center
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_ker_le_center :=
+  nilpotencyClass_le_of_ker_le_center
+@[deprecated (since := "2026-03-25")] alias nilpotent_of_surjective := nilpotent_of_surjective
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_surjective :=
+  nilpotencyClass_le_of_surjective
+@[deprecated (since := "2026-03-25")] alias nilpotent_of_mulEquiv := nilpotent_of_mulEquiv
+@[deprecated (since := "2026-03-25")] alias nilpotent_quotient_of_nilpotent :=
+  nilpotent_quotient_of_nilpotent
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_quotient_le :=
+  nilpotencyClass_quotient_le
+@[deprecated (since := "2026-03-25")] alias comap_upperCentralSeries_quotient_center :=
+  comap_upperCentralSeries_quotient_center
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_zero_iff_subsingleton :=
+  nilpotencyClass_zero_iff_subsingleton
+@[deprecated (since := "2026-03-25")] alias of_quotient_center_nilpotent :=
+  of_quotient_center_nilpotent
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_quotient_center :=
+  nilpotencyClass_quotient_center
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_eq_quotient_center_plus_one :=
+  nilpotencyClass_eq_quotient_center_plus_one
+@[deprecated (since := "2026-03-25")] alias nilpotent_center_quotient_ind :=
+  nilpotent_center_quotient_ind
+@[deprecated (since := "2026-03-25")] alias derived_le_lower_central := derived_le_lower_central
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries.eq_ge_of_eq_succ :=
+  upperCentralSeries.eq_ge_of_eq_succ
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries.eq_ge_of_eq_gt :=
+  upperCentralSeries.eq_ge_of_eq_gt
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries.eq_top := upperCentralSeries.eq_top
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_of_upperCentralSeries_eq :=
+  nilpotencyClass_le_of_upperCentralSeries_eq
+@[deprecated (since := "2026-03-25")] alias upperCentralSeries.StrictMonoOn :=
+  upperCentralSeries.StrictMonoOn
+@[deprecated (since := "2026-03-25")]
+alias upperCentralSeries.card_image_eq_of_le_nilpotencyClass :=
+  upperCentralSeries.card_image_eq_of_le_nilpotencyClass
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_prod := lowerCentralSeries_prod
+@[deprecated (since := "2026-03-25")] alias isNilpotent_prod := isNilpotent_prod
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_prod := nilpotencyClass_prod
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_pi_le := lowerCentralSeries_pi_le
+@[deprecated (since := "2026-03-25")] alias isNilpotent_pi_of_bounded_class :=
+  isNilpotent_pi_of_bounded_class
+@[deprecated (since := "2026-03-25")] alias lowerCentralSeries_pi_of_finite :=
+  lowerCentralSeries_pi_of_finite
+@[deprecated (since := "2026-03-25")] alias isNilpotent_pi := isNilpotent_pi
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_pi := nilpotencyClass_pi
+@[deprecated (since := "2026-03-25")] alias nilpotencyClass_le_one_of_isSimple_of_isNilpotent :=
+  nilpotencyClass_le_one_of_isSimple_of_isNilpotent
+@[deprecated (since := "2026-03-25")] alias normalizerCondition_of_isNilpotent :=
+  normalizerCondition_of_isNilpotent
+@[deprecated (since := "2026-03-25")] alias isNilpotent_of_product_of_sylow_group :=
+  isNilpotent_of_product_of_sylow_group
+@[deprecated (since := "2026-03-25")] alias isNilpotent_of_finite_tfae := isNilpotent_of_finite_tfae

--- a/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/ZGroup.lean
@@ -125,7 +125,7 @@ theorem exponent_eq_card [Finite G] [IsZGroup G] : Monoid.exponent G = Nat.card 
 instance [Finite G] [IsZGroup G] [hG : Group.IsNilpotent G] : IsCyclic G := by
   have (p : { x // x ∈ (Nat.card G).primeFactors }) : Fact p.1.Prime :=
     ⟨Nat.prime_of_mem_primeFactors p.2⟩
-  obtain ⟨ϕ⟩ := ((isNilpotent_of_finite_tfae (G := G)).out 0 4).mp hG
+  obtain ⟨ϕ⟩ := ((Group.isNilpotent_of_finite_tfae (G := G)).out 0 4).mp hG
   let _ : CommGroup G :=
     ⟨fun g h ↦ by rw [← ϕ.symm.injective.eq_iff, map_mul, mul_comm, ← map_mul]⟩
   exact IsCyclic.of_exponent_eq_card (exponent_eq_card G)


### PR DESCRIPTION
This PR moves the declarations of `GroupTheory/Nilpotent` from the root namespace to either the `Subgroup` namespace or the `Group` namespace.

I also switched over to the commutator element notation in a few places.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
