### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet/Subcomplex): add `Subcomplex.unionProd`, a union of products of subcomplexes

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -298,6 +298,7 @@ lemma image_β_inv : (unionProd S T).image (β_ _ _).inv = unionProd T S := by
   apply image_β_hom
 
 /-- The isomorphism `unionProd S T ≅ unionProd T S` as simplicial sets. -/
+@[simps]
 noncomputable def symmIso : (unionProd S T : SSet) ≅ (unionProd T S : SSet) where
   hom := lift ((unionProd S T).ι ≫ (β_ _ _).hom) (by simp [range_comp])
   inv := lift ((unionProd T S).ι ≫ (β_ _ _).hom) (by simp [range_comp])

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -147,6 +147,7 @@ lemma range_tensorHom {X₁ X₂ Y₁ Y₂ : SSet.{u}} (f₁ : X₁ ⟶ Y₁) (f
     exact ⟨⟨x₁, x₂⟩, rfl⟩
 
 /-- The isomorphism `(A.prod B).toSSet ≅ A.toSSet ⊗ B.toSSet`. -/
+@[simps]
 def prodIso {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex) :
     (A.prod B).toSSet ≅ A ⊗ B where
   hom := CartesianMonoidalCategory.lift

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -234,8 +234,7 @@ def unionProd : (X ⊗ Y).Subcomplex := ((⊤ : X.Subcomplex).prod T) ⊔ (S.pro
 lemma mem_unionProd_iff {n : SimplexCategoryᵒᵖ} (x : (X ⊗ Y).obj n) :
     x ∈ (unionProd S T).obj _ ↔ x.2 ∈ T.obj _ ∨ x.1 ∈ S.obj _ := by
   dsimp [unionProd, Set.prod]
-  simp only [Set.mem_univ, true_and, and_true]
-  exact Set.mem_union _ _ _
+  cat_disch
 
 lemma top_prod_le_unionProd : (⊤ : X.Subcomplex).prod T ≤ S.unionProd T := le_sup_left
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -6,6 +6,8 @@ Authors: Joël Riou, Jack McKoen
 module
 
 public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
+public import Mathlib.AlgebraicTopology.SimplicialSet.SubcomplexColimits
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Basic
 public import Mathlib.CategoryTheory.Monoidal.Closed.FunctorToTypes
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.FunctorCategory
 
@@ -125,6 +127,14 @@ lemma prod_monotone {X Y : SSet.{u}}
     A₁.prod B₁ ≤ A₂.prod B₂ :=
   fun _ _ hx => ⟨hX _ hx.1, hY _ hx.2⟩
 
+lemma prod_le_top_prod {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex) :
+    A.prod B ≤ (⊤ : X.Subcomplex).prod B :=
+  prod_monotone le_top (by rfl)
+
+lemma prod_le_prod_top {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex) :
+    A.prod B ≤ A.prod ⊤ :=
+  prod_monotone (by rfl) le_top
+
 set_option backward.isDefEq.respectTransparency false in
 lemma range_tensorHom {X₁ X₂ Y₁ Y₂ : SSet.{u}} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) :
     range (f₁ ⊗ₘ f₂) = (range f₁).prod (range f₂) := by
@@ -135,6 +145,20 @@ lemma range_tensorHom {X₁ X₂ Y₁ Y₂ : SSet.{u}} (f₁ : X₁ ⟶ Y₁) (f
     exact ⟨⟨x₁, h.1⟩, ⟨x₂, h.2⟩⟩
   · rintro ⟨⟨x₁, rfl⟩, ⟨x₂, rfl⟩⟩
     exact ⟨⟨x₁, x₂⟩, rfl⟩
+
+/-- The isomorphism `(A.prod B).toSSet ≅ A.toSSet ⊗ B.toSSet`. -/
+def prodIso {X Y : SSet.{u}} (A : X.Subcomplex) (B : Y.Subcomplex) :
+    (A.prod B).toSSet ≅ A ⊗ B where
+  hom := CartesianMonoidalCategory.lift
+    (lift ((A.prod B).ι ≫ CartesianMonoidalCategory.fst _ _) (by
+      intro _ _ ⟨⟨_, ⟨_, _⟩⟩, _⟩
+      cat_disch))
+    (lift ((A.prod B).ι ≫ CartesianMonoidalCategory.snd _ _) (by
+      intro _ _ ⟨⟨_, ⟨_, _⟩⟩, _⟩
+      cat_disch))
+  inv := lift (A.ι ⊗ₘ B.ι) (by
+    rintro m _ ⟨⟨y₁, y₂⟩, ⟨⟩⟩
+    exact ⟨Subtype.coe_prop _, Subtype.coe_prop _⟩)
 
 end Subcomplex
 
@@ -195,6 +219,92 @@ end
 
 @[simp, grind =] lemma prod_σ_snd {n : ℕ} (i : Fin (n + 1)) (z : (X ⊗ Y : SSet.{u}) _⦋n⦌) :
     ((X ⊗ Y).σ i z).2 = Y.σ i z.2 := rfl
+
+end
+
+section
+
+namespace Subcomplex
+
+variable {X Y : SSet.{u}} (S : X.Subcomplex) (T : Y.Subcomplex)
+
+noncomputable def unionProd : (X ⊗ Y).Subcomplex := ((⊤ : X.Subcomplex).prod T) ⊔ (S.prod ⊤)
+
+lemma mem_unionProd_iff {n : SimplexCategoryᵒᵖ} (x : (X ⊗ Y).obj n) :
+    x ∈ (unionProd S T).obj _ ↔ x.2 ∈ T.obj _ ∨ x.1 ∈ S.obj _ := by
+  dsimp [unionProd, Set.prod]
+  simp only [Set.mem_univ, true_and, and_true]
+  exact Set.mem_union _ _ _
+
+lemma top_prod_le_unionProd : (⊤ : X.Subcomplex).prod T ≤ S.unionProd T := le_sup_left
+
+lemma prod_top_le_unionProd : (S.prod ⊤) ≤ S.unionProd T := le_sup_right
+
+lemma prod_le_unionProd : S.prod T ≤ S.unionProd T :=
+  (prod_le_prod_top S T).trans (prod_top_le_unionProd S T)
+
+namespace unionProd
+
+noncomputable def ι₁ : X ⊗ T ⟶ S.unionProd T :=
+  lift (X ◁ T.ι) (by
+    rintro m _ ⟨⟨y₁, y₂⟩, ⟨⟩⟩
+    exact Or.inl ⟨Set.mem_univ _, Subtype.coe_prop _⟩)
+
+noncomputable def ι₂ : (S : SSet.{u}) ⊗ Y ⟶ (unionProd S T : SSet.{u}) :=
+  lift (S.ι ▷ Y) (by
+    rintro m _ ⟨⟨y₁, y₂⟩, ⟨⟩⟩
+    exact Or.inr ⟨Subtype.coe_prop _, Set.mem_univ _⟩)
+
+@[reassoc (attr := simp)]
+lemma ι₁_ι : ι₁ S T ≫ (unionProd S T).ι = X ◁ T.ι := rfl
+
+@[reassoc (attr := simp)]
+lemma ι₂_ι : ι₂ S T ≫ (unionProd S T).ι = S.ι ▷ Y := rfl
+
+lemma bicartSq : BicartSq (S.prod T) ((⊤ : X.Subcomplex).prod T) (S.prod ⊤) (unionProd S T) where
+  sup_eq := rfl
+  inf_eq := by
+    ext n ⟨x, y⟩
+    change _ ∧ _ ↔ _
+    simp [prod, Set.prod, Membership.mem, Set.Mem, setOf]
+    tauto
+
+lemma isPushout : IsPushout (S.ι ▷ (T : SSet)) ((S : SSet) ◁ T.ι)
+    (unionProd.ι₁ S T) (unionProd.ι₂ S T) :=
+  (bicartSq S T).isPushout.of_iso (S.prodIso T)
+    (prodIso _ _ ≪≫ whiskerRightIso (topIso X) _)
+    (prodIso _ _ ≪≫ whiskerLeftIso _ (topIso Y))
+    (Iso.refl _) rfl rfl rfl rfl
+
+@[simp]
+lemma preimage_β_hom : (unionProd S T).preimage (β_ _ _).hom = unionProd T S := by
+  ext n ⟨x, y⟩
+  simp only [mem_unionProd_iff, preimage_obj, Set.mem_preimage]
+  tauto
+
+@[simp]
+lemma preimage_β_inv : (unionProd S T).preimage (β_ _ _).inv = unionProd T S := by
+  apply preimage_β_hom
+
+@[simp]
+lemma image_β_hom : (unionProd S T).image (β_ _ _).hom = unionProd T S := by
+  rw [← preimage_β_hom, preimage_image_of_isIso]
+
+@[simp]
+lemma image_β_inv : (unionProd S T).image (β_ _ _).hom = unionProd T S := by
+  apply image_β_hom
+
+noncomputable def symmIso : (unionProd S T : SSet) ≅ (unionProd T S : SSet) where
+  hom := lift ((unionProd S T).ι ≫ (β_ _ _).hom) (by
+    simp only [Subcomplex.preimage_eq_top_iff, range_comp, Subpresheaf.range_ι, image_β_hom,
+      le_refl])
+  inv := lift ((unionProd T S).ι ≫ (β_ _ _).hom) (by
+    simp only [Subcomplex.preimage_eq_top_iff, range_comp, Subpresheaf.range_ι, image_β_hom,
+      le_refl])
+
+end unionProd
+
+end Subcomplex
 
 end
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Monoidal.lean
@@ -228,7 +228,8 @@ namespace Subcomplex
 
 variable {X Y : SSet.{u}} (S : X.Subcomplex) (T : Y.Subcomplex)
 
-noncomputable def unionProd : (X ⊗ Y).Subcomplex := ((⊤ : X.Subcomplex).prod T) ⊔ (S.prod ⊤)
+/-- Given `S ≤ X` and `T ≤ Y`, this is the subcomplex of `X ⊗ Y` given by `(X ⊗ T) ⊔ (S ⊗ Y)`. -/
+def unionProd : (X ⊗ Y).Subcomplex := ((⊤ : X.Subcomplex).prod T) ⊔ (S.prod ⊤)
 
 lemma mem_unionProd_iff {n : SimplexCategoryᵒᵖ} (x : (X ⊗ Y).obj n) :
     x ∈ (unionProd S T).obj _ ↔ x.2 ∈ T.obj _ ∨ x.1 ∈ S.obj _ := by
@@ -245,11 +246,13 @@ lemma prod_le_unionProd : S.prod T ≤ S.unionProd T :=
 
 namespace unionProd
 
+/-- The inclusion `X ⊗ T ⟶ S.unionProd T` as simplicial sets. -/
 noncomputable def ι₁ : X ⊗ T ⟶ S.unionProd T :=
   lift (X ◁ T.ι) (by
     rintro m _ ⟨⟨y₁, y₂⟩, ⟨⟩⟩
     exact Or.inl ⟨Set.mem_univ _, Subtype.coe_prop _⟩)
 
+/-- The inclusion `S ⊗ Y ⟶ S.unionProd T` as simplicial sets -/
 noncomputable def ι₂ : (S : SSet.{u}) ⊗ Y ⟶ (unionProd S T : SSet.{u}) :=
   lift (S.ι ▷ Y) (by
     rintro m _ ⟨⟨y₁, y₂⟩, ⟨⟩⟩
@@ -291,16 +294,13 @@ lemma image_β_hom : (unionProd S T).image (β_ _ _).hom = unionProd T S := by
   rw [← preimage_β_hom, preimage_image_of_isIso]
 
 @[simp]
-lemma image_β_inv : (unionProd S T).image (β_ _ _).hom = unionProd T S := by
+lemma image_β_inv : (unionProd S T).image (β_ _ _).inv = unionProd T S := by
   apply image_β_hom
 
+/-- The isomorphism `unionProd S T ≅ unionProd T S` as simplicial sets. -/
 noncomputable def symmIso : (unionProd S T : SSet) ≅ (unionProd T S : SSet) where
-  hom := lift ((unionProd S T).ι ≫ (β_ _ _).hom) (by
-    simp only [Subcomplex.preimage_eq_top_iff, range_comp, Subpresheaf.range_ι, image_β_hom,
-      le_refl])
-  inv := lift ((unionProd T S).ι ≫ (β_ _ _).hom) (by
-    simp only [Subcomplex.preimage_eq_top_iff, range_comp, Subpresheaf.range_ι, image_β_hom,
-      le_refl])
+  hom := lift ((unionProd S T).ι ≫ (β_ _ _).hom) (by simp [range_comp])
+  inv := lift ((unionProd T S).ι ≫ (β_ _ _).hom) (by simp [range_comp])
 
 end unionProd
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Subcomplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Subcomplex.lean
@@ -318,6 +318,13 @@ lemma image_preimage_le (B : X.Subcomplex) (f : Y ⟶ X) :
     (B.preimage f).image f ≤ B := by
   rw [image_le_iff]
 
+@[simp]
+lemma preimage_image_of_isIso (f : X ⟶ Y) (B : Y.Subcomplex) [IsIso f] :
+    (B.preimage f).image f = B := by
+  apply le_antisymm (B.image_preimage_le f)
+  · intro n y hy
+    exact ⟨(inv f).app _ y, by simpa [← NatIso.isIso_inv_app, ← FunctorToTypes.comp]⟩
+
 /-- Given a morphism of simplicial sets `p : Y ⟶ X` and
 `A : X.Subcomplex`, this is the induced morphism
 `(A.preimage p : SSet) ⟶ (A : SSet)`. -/


### PR DESCRIPTION
Given `X Y : SSet`, `S : X.Subcomplex`, and `T : Y.Subcomplex`, define the subcomplex `S.unionProd T : (X ⊗ Y).Subcomplex` given by `(X ⊗ T) ⊔ (S ⊗ Y)` and provide basic API.

All code is originally written by Joël Riou and modified for PR to mathlib (with permission).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
