### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/SimplicialSet): nondegenerate simplices in `Δ[n] ⊗ Δ[1]`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1532,6 +1532,7 @@ public import Mathlib.AlgebraicTopology.SimplicialSet.Op
 public import Mathlib.AlgebraicTopology.SimplicialSet.Path
 public import Mathlib.AlgebraicTopology.SimplicialSet.Presentable
 public import Mathlib.AlgebraicTopology.SimplicialSet.ProdStdSimplex
+public import Mathlib.AlgebraicTopology.SimplicialSet.ProdStdSimplexOne
 public import Mathlib.AlgebraicTopology.SimplicialSet.RegularEpi
 public import Mathlib.AlgebraicTopology.SimplicialSet.RelativeMorphism
 public import Mathlib.AlgebraicTopology.SimplicialSet.Simplices

--- a/Mathlib/AlgebraicTopology/SimplicialSet/ProdStdSimplexOne.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/ProdStdSimplexOne.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialSet.ProdStdSimplex
+public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplexOne
+
+/-!
+# Binary products `Δ[n] ⊗ Δ[1]`
+
+In this file, we define a bijection `SSet.prodStdSimplex.nonDegenerateEquiv₁`
+between `Fin (p + 1)` and the type of nondegenerate `(p + 1)`-simplices
+of `Δ[p] ⊗ Δ[1]`.
+
+-/
+
+@[expose] public section
+
+universe u
+
+open CategoryTheory Simplicial MonoidalCategory Opposite
+
+namespace SSet
+
+namespace prodStdSimplex
+
+variable {p : ℕ}
+
+open stdSimplex in
+/-- This is an enumeration of the `p + 1` nondegenerate dimension-`(p + 1)`
+simplices of `Δ[p] ⊗ Δ[1]`. It sends `i : Fin (p + 1)` to the nondegenerate
+simplex consisting of the vertices
+`(0, 0) ≤ (1,0) ≤ ... ≤ (i, 0) ≤ (i, 1) ≤ ... ≤ (p, 1)`. -/
+noncomputable def nonDegenerateEquiv₁ :
+    Fin (p + 1) ≃ (Δ[p] ⊗ Δ[1] : SSet.{u}).nonDegenerate (p + 1) :=
+  Equiv.ofBijective
+    (fun i ↦ ⟨⟨stdSimplex.objEquiv.{u}.symm (SimplexCategory.σ i),
+      objMk₁ i.succ.castSucc⟩, by
+      rw [nonDegenerate_max_dim_iff _ rfl]
+      ext j
+      dsimp
+      by_cases hj : j ≤ i.castSucc
+      · rw [objMk₁_of_castSucc_lt _ _ (by simpa),
+          Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero]
+        change (i.predAbove j : ℕ) = _
+        simp [Fin.predAbove_of_le_castSucc _ _ hj]
+      · simp only [not_le] at hj
+        rw [objMk₁_of_le_castSucc _ _ (by simpa), objEquiv_symm_apply]
+        change (i.predAbove j : ℕ) + 1 = _
+        rw [Fin.predAbove_of_castSucc_lt _ _ hj, Fin.val_pred]
+        lia⟩) (by
+    refine ⟨fun _ _ h ↦ ?_, fun ⟨⟨s₁, s₂⟩, hs⟩ ↦ ?_⟩
+    · simpa using stdSimplex.objMk₁_injective (congr_arg (Prod.snd ∘ Subtype.val) h)
+    · rw [nonDegenerate_max_dim_iff _ rfl] at hs
+      obtain ⟨i, rfl⟩ := stdSimplex.objMk₁_surjective s₂
+      obtain ⟨i, rfl⟩ := Fin.eq_succ_of_ne_zero (i := i) (by
+        rintro rfl
+        have := DFunLike.congr_fun hs 0
+        simp only [orderHomOfSimplex_coe, OrderHom.id_coe, id_eq, Fin.ext_iff,
+          stdSimplex.objMk₁_of_le_castSucc (0 : Fin (p + 3)) 0 (by simp)] at this
+        lia)
+      obtain ⟨i, rfl⟩ | rfl := i.eq_castSucc_or_eq_last
+      · exact ⟨i, nonDegenerate_ext₂ rfl rfl⟩
+      · have := DFunLike.congr_fun hs (Fin.last _)
+        simp only [Fin.succ_last, orderHomOfSimplex_coe,
+          OrderHom.id_coe, id_eq, Fin.ext_iff, Fin.val_last,
+          stdSimplex.objMk₁_of_castSucc_lt (Fin.last (p + 2))
+            (Fin.last (p + 1)) (by simp),
+          Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero] at this
+        lia)
+
+@[simp]
+lemma nonDegenerateEquiv₁_fst (i : Fin (p + 1)) :
+    dsimp% (nonDegenerateEquiv₁ i).1.1 =
+      (stdSimplex.objEquiv (m := (op ⦋p + 1⦌))).symm (SimplexCategory.σ i) := rfl
+
+@[simp]
+lemma nonDegenerateEquiv₁_snd (i : Fin (p + 1)) :
+    dsimp% (nonDegenerateEquiv₁ i).1.2 =
+      stdSimplex.objMk₁ i.succ.castSucc := rfl
+
+end prodStdSimplex
+
+end SSet


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
