### PR TITLE
refactor(RingTheory/DedekindDomain/Ideal/Lemmas): generalize `primesOverFinset`

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -1028,28 +1028,8 @@ section primesOverFinset
 
 open UniqueFactorizationMonoid Ideal
 
-variable {A : Type*} [CommRing A] (p : Ideal A) (B : Type*) [CommRing B] [Algebra A B]
-
-open scoped Classical in
-/-- The finite set of all prime factors of the pushforward of `p`. -/
-noncomputable abbrev primesOverFinset [hf : Finite (p.primesOver B)] : Finset (Ideal B) :=
-  Set.Finite.toFinset hf
-
-theorem coe_primesOverFinset [hf : Finite (p.primesOver B)] :
-    primesOverFinset p B = primesOver p B :=
-  Set.Finite.coe_toFinset hf
-
-theorem mem_primesOverFinset_iff [Finite (p.primesOver B)] {P : Ideal B} :
-    P ∈ primesOverFinset p B ↔ P ∈ primesOver p B := by
-  rw [← Finset.mem_coe, coe_primesOverFinset]
-
-variable {p} (hpb : p ≠ ⊥) [hpm : p.IsMaximal] [IsDedekindDomain B] [IsDomain A] [IsTorsionFree A B]
-
-include hpb in
-theorem IsLocalRing.primesOverFinset_eq
-    [IsLocalRing B] [Module.Finite A B] [Finite (p.primesOver B)] :
-    primesOverFinset p B = {IsLocalRing.maximalIdeal B} := by
-  rw [← Finset.coe_eq_singleton, coe_primesOverFinset, IsLocalRing.primesOver_eq B hpb]
+variable {A : Type*} [CommRing A] {p : Ideal A} (hpb : p ≠ ⊥) [hpm : p.IsMaximal]
+  (B : Type*) [CommRing B] [IsDedekindDomain B] [Algebra A B] [IsDomain A] [IsTorsionFree A B]
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
@@ -1093,6 +1073,11 @@ theorem primesOver_finite : (primesOver p B).Finite := by
     simp [mem_primesOver_iff_mem_normalizedFactors B hpb]
 
 noncomputable instance : Fintype (p.primesOver B) := Set.Finite.fintype (primesOver_finite p B)
+
+include hpb in
+theorem IsLocalRing.primesOverFinset_eq [IsLocalRing B] [Module.Finite A B] :
+    primesOverFinset p B = {IsLocalRing.maximalIdeal B} := by
+  rw [← Finset.coe_eq_singleton, coe_primesOverFinset, IsLocalRing.primesOver_eq B hpb]
 
 theorem primesOver_ncard_ne_zero : (primesOver p B).ncard ≠ 0 := by
   rcases exists_maximal_ideal_liesOver_of_isIntegral (S := B) p with ⟨P, hPm, hp⟩

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -1028,30 +1028,28 @@ section primesOverFinset
 
 open UniqueFactorizationMonoid Ideal
 
+variable {A : Type*} [CommRing A] (p : Ideal A) (B : Type*) [CommRing B] [Algebra A B]
+
 open scoped Classical in
 /-- The finite set of all prime factors of the pushforward of `p`. -/
-noncomputable abbrev primesOverFinset {A : Type*} [CommRing A] (p : Ideal A) (B : Type*)
-    [CommRing B] [IsDedekindDomain B] [Algebra A B] : Finset (Ideal B) :=
-  (factors (p.map (algebraMap A B))).toFinset
+noncomputable abbrev primesOverFinset [hf : Finite (p.primesOver B)] : Finset (Ideal B) :=
+  Set.Finite.toFinset hf
 
-variable {A : Type*} [CommRing A] {p : Ideal A} (hpb : p ≠ ⊥) [hpm : p.IsMaximal]
-  (B : Type*) [CommRing B] [IsDedekindDomain B] [Algebra A B] [IsDomain A] [IsTorsionFree A B]
+theorem coe_primesOverFinset [hf : Finite (p.primesOver B)] :
+    primesOverFinset p B = primesOver p B :=
+  Set.Finite.coe_toFinset hf
+
+theorem mem_primesOverFinset_iff [Finite (p.primesOver B)] {P : Ideal B} :
+    P ∈ primesOverFinset p B ↔ P ∈ primesOver p B := by
+  rw [← Finset.mem_coe, coe_primesOverFinset]
+
+variable {p} (hpb : p ≠ ⊥) [hpm : p.IsMaximal] [IsDedekindDomain B] [IsDomain A] [IsTorsionFree A B]
 
 include hpb in
-theorem coe_primesOverFinset : primesOverFinset p B = primesOver p B := by
-  ext
-  simpa using (mem_primesOver_iff_mem_normalizedFactors _ hpb).symm
-
-include hpb in
-theorem mem_primesOverFinset_iff {P : Ideal B} : P ∈ primesOverFinset p B ↔ P ∈ primesOver p B := by
-  rw [← Finset.mem_coe, coe_primesOverFinset hpb]
-
-variable {R} (A) in
-theorem IsLocalRing.primesOverFinset_eq [IsLocalRing A] [IsDedekindDomain A]
-    [Algebra R A] [FaithfulSMul R A] [Module.Finite R A] {p : Ideal R} [p.IsMaximal] (hp0 : p ≠ ⊥) :
-    primesOverFinset p A = {IsLocalRing.maximalIdeal A} := by
-  have : IsDomain R := .of_faithfulSMul R A
-  rw [← Finset.coe_eq_singleton, coe_primesOverFinset hp0, IsLocalRing.primesOver_eq A hp0]
+theorem IsLocalRing.primesOverFinset_eq
+    [IsLocalRing B] [Module.Finite A B] [Finite (p.primesOver B)] :
+    primesOverFinset p B = {IsLocalRing.maximalIdeal B} := by
+  rw [← Finset.coe_eq_singleton, coe_primesOverFinset, IsLocalRing.primesOver_eq B hpb]
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
@@ -1090,8 +1088,11 @@ theorem primesOver_finite : (primesOver p B).Finite := by
     haveI : IsDomain A := IsDomain.of_bot_isPrime A
     rw [primesOver_bot A B]
     exact Set.finite_singleton ⊥
-  · rw [← coe_primesOverFinset hpb B]
-    exact (primesOverFinset p B).finite_toSet
+  · have : p.primesOver B = (normalizedFactors (p.map (algebraMap A B))).toFinset := by
+      ext P
+      simp [mem_primesOver_iff_mem_normalizedFactors B hpb]
+    rw [this]
+    apply Finset.finite_toSet
 
 noncomputable instance : Fintype (p.primesOver B) := Set.Finite.fintype (primesOver_finite p B)
 

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -1088,11 +1088,9 @@ theorem primesOver_finite : (primesOver p B).Finite := by
     haveI : IsDomain A := IsDomain.of_bot_isPrime A
     rw [primesOver_bot A B]
     exact Set.finite_singleton ⊥
-  · have : p.primesOver B = (normalizedFactors (p.map (algebraMap A B))).toFinset := by
-      ext P
-      simp [mem_primesOver_iff_mem_normalizedFactors B hpb]
-    rw [this]
-    apply Finset.finite_toSet
+  · convert Finset.finite_toSet (normalizedFactors (p.map (algebraMap A B))).toFinset
+    ext P
+    simp [mem_primesOver_iff_mem_normalizedFactors B hpb]
 
 noncomputable instance : Fintype (p.primesOver B) := Set.Finite.fintype (primesOver_finite p B)
 

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -367,6 +367,20 @@ theorem ne_bot_of_mem_primesOver [IsDomain R] {S : Type*} [Ring S] [Algebra R S]
     [Module.IsTorsionFree R S] {p : Ideal R} (hp : p ≠ ⊥) {P : Ideal S} (hP : P ∈ p.primesOver S) :
     P ≠ ⊥ := by have : P.LiesOver p := hP.2; exact ne_bot_of_liesOver_of_ne_bot hp P
 
+variable (B)
+
+/-- The finset of all prime factors of the pushforward of `p`. -/
+noncomputable abbrev primesOverFinset [hf : Finite (p.primesOver B)] : Finset (Ideal B) :=
+  Set.Finite.toFinset hf
+
+theorem coe_primesOverFinset [hf : Finite (p.primesOver B)] :
+    primesOverFinset p B = primesOver p B :=
+  Set.Finite.coe_toFinset hf
+
+theorem mem_primesOverFinset_iff [Finite (p.primesOver B)] {P : Ideal B} :
+    P ∈ primesOverFinset p B ↔ P ∈ primesOver p B := by
+  rw [← Finset.mem_coe, coe_primesOverFinset]
+
 end primesOver
 
 end Ideal


### PR DESCRIPTION
This PR generalizes `primesOverFinset` to any situation in which `primesOver` is `Finite` (e.g., when the extension is quasifinite but not a Dedekind domain).

The motivation is that this will let us write down the algebraic number theory formula "sum of e_i * f_i = n" in greater generality.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
