### PR TITLE
[Merged by Bors] - feat(OrderDual): fix leaky instances

### DIFF
--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -11,6 +11,8 @@ public import Mathlib.Algebra.Ring.Commute
 public import Mathlib.Algebra.Ring.Invertible
 public import Mathlib.Order.OrderDual
 public import Mathlib.Order.Lex
+public import Mathlib.Algebra.Order.Ring.Synonym
+public import Mathlib.Algebra.Order.GroupWithZero.Synonym
 
 import Mathlib.Tactic.Tauto
 
@@ -292,11 +294,28 @@ end Function.Injective
 
 namespace OrderDual
 
-instance instRatCast [RatCast K] : RatCast Kᵒᵈ := ‹_›
-instance instDivisionSemiring [DivisionSemiring K] : DivisionSemiring Kᵒᵈ := ‹_›
-instance instDivisionRing [DivisionRing K] : DivisionRing Kᵒᵈ := ‹_›
-instance instSemifield [Semifield K] : Semifield Kᵒᵈ := ‹_›
-instance instField [Field K] : Field Kᵒᵈ := ‹_›
+instance [h : RatCast K] : RatCast Kᵒᵈ := h
+instance [h : NNRatCast K] : NNRatCast Kᵒᵈ := h
+
+instance [h : DivisionSemiring K] : DivisionSemiring Kᵒᵈ where
+  nnratCast_def := h.nnratCast_def
+  nnqsmul := h.nnqsmul
+  nnqsmul_def := h.nnqsmul_def
+
+instance [h : DivisionRing K] : DivisionRing Kᵒᵈ where
+  mul_inv_cancel := h.mul_inv_cancel
+  inv_zero := h.inv_zero
+  nnratCast_def := h.nnratCast_def
+  nnqsmul := h.nnqsmul
+  nnqsmul_def := h.nnqsmul_def
+  ratCast_def := h.ratCast_def
+  qsmul := h.qsmul
+  qsmul_def := h.qsmul_def
+
+instance [Semifield K] : Semifield Kᵒᵈ where
+
+instance [Field K] : Field Kᵒᵈ where
+
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -68,13 +68,13 @@ lemma MulArchimedean.comap [CommMonoid G] [LinearOrder G] [CommMonoid M] [Partia
     refine (MulArchimedean.arch (f x) (by simpa using hf h)).imp ?_
     simp [← map_pow, hf.le_iff_le]
 
-set_option backward.isDefEq.respectTransparency false in
 @[to_additive]
 instance OrderDual.instMulArchimedean [CommGroup G] [PartialOrder G] [IsOrderedMonoid G]
     [MulArchimedean G] :
     MulArchimedean Gᵒᵈ :=
   ⟨fun x y hy =>
-    let ⟨n, hn⟩ := MulArchimedean.arch (ofDual x)⁻¹ (inv_lt_one_iff_one_lt.2 hy)
+    have hy : (ofDual y) < 1 := hy
+    let ⟨n, hn⟩ := MulArchimedean.arch (ofDual x)⁻¹ (one_lt_inv'.2 hy)
     ⟨n, by rwa [inv_pow, inv_le_inv_iff] at hn⟩⟩
 
 instance Additive.instArchimedean [CommGroup G] [PartialOrder G] [MulArchimedean G] :

--- a/Mathlib/Algebra/Order/Group/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Action/Synonym.lean
@@ -26,34 +26,38 @@ variable {M N α : Type*}
 namespace OrderDual
 
 @[to_additive]
-instance instMulAction [Monoid M] [MulAction M α] : MulAction Mᵒᵈ α := ‹MulAction M α›
+instance [Monoid M] [h : MulAction M α] : MulAction Mᵒᵈ α where
+  mul_smul := h.mul_smul
+  one_smul := h.one_smul
 
 @[to_additive]
-instance instMulAction' [Monoid M] [MulAction M α] : MulAction M αᵒᵈ := ‹MulAction M α›
+instance [Monoid M] [h : MulAction M α] : MulAction M αᵒᵈ where
+  mul_smul := h.mul_smul
+  one_smul := h.one_smul
 
 @[to_additive]
-instance instSMulCommClass [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass Mᵒᵈ N α :=
+instance [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass Mᵒᵈ N α :=
   ‹SMulCommClass M N α›
 
 @[to_additive]
-instance instSMulCommClass' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M Nᵒᵈ α :=
+instance [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M Nᵒᵈ α :=
   ‹SMulCommClass M N α›
 
 @[to_additive]
-instance instSMulCommClass'' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M N αᵒᵈ :=
+instance [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M N αᵒᵈ :=
   ‹SMulCommClass M N α›
 
 @[to_additive]
-instance instIsScalarTower [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower Mᵒᵈ N α := ‹IsScalarTower M N α›
+instance [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] : IsScalarTower Mᵒᵈ N α :=
+  ‹IsScalarTower M N α›
 
 @[to_additive]
-instance instIsScalarTower' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower M Nᵒᵈ α := ‹IsScalarTower M N α›
+instance [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] : IsScalarTower M Nᵒᵈ α :=
+  ‹IsScalarTower M N α›
 
 @[to_additive]
-instance instIsScalarTower'' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower M N αᵒᵈ := ‹IsScalarTower M N α›
+instance [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] : IsScalarTower M N αᵒᵈ :=
+  ‹IsScalarTower M N α›
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -24,6 +24,7 @@ variable {α β : Type*}
 
 /-! ### `OrderDual` -/
 
+namespace OrderDual
 
 @[to_additive]
 instance [h : One α] : One αᵒᵈ := h
@@ -38,70 +39,90 @@ instance [h : Inv α] : Inv αᵒᵈ := h
 instance [h : Div α] : Div αᵒᵈ := h
 
 @[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul]
-instance OrderDual.instPow [h : Pow α β] : Pow αᵒᵈ β := h
+instance [h : Pow α β] : Pow αᵒᵈ β := h
 
 @[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul']
-instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ := h
+instance [h : Pow α β] : Pow α βᵒᵈ := h
 
 @[to_additive]
-instance [h : Semigroup α] : Semigroup αᵒᵈ := h
+instance [h : Semigroup α] : Semigroup αᵒᵈ where
+  mul_assoc := h.mul_assoc
 
 @[to_additive]
-instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ := h
+instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ where
+  mul_comm := h.mul_comm
 
 @[to_additive]
-instance [Mul α] [h : IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ := h
+instance [Mul α] [h : IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ where
+  mul_left_cancel := h.mul_left_cancel
 
 @[to_additive]
-instance [Mul α] [h : IsRightCancelMul α] : IsRightCancelMul αᵒᵈ := h
+instance [Mul α] [h : IsRightCancelMul α] : IsRightCancelMul αᵒᵈ where
+  mul_right_cancel := h.mul_right_cancel
 
 @[to_additive]
-instance [Mul α] [h : IsCancelMul α] : IsCancelMul αᵒᵈ := h
+instance [Mul α] [h : IsCancelMul α] : IsCancelMul αᵒᵈ where
 
 @[to_additive]
-instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ := h
+instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ where
 
 @[to_additive]
-instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ := h
+instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ where
 
 @[to_additive]
-instance [h : MulOneClass α] : MulOneClass αᵒᵈ := h
+instance [h : MulOneClass α] : MulOneClass αᵒᵈ where
+  one_mul := h.one_mul
+  mul_one := h.mul_one
 
 @[to_additive]
-instance [h : Monoid α] : Monoid αᵒᵈ := h
+instance [h : Monoid α] : Monoid αᵒᵈ where
+  npow := h.npow
+  npow_succ := h.npow_succ
+  npow_zero := h.npow_zero
 
 @[to_additive]
-instance OrderDual.instCommMonoid [h : CommMonoid α] : CommMonoid αᵒᵈ := h
+instance [h : CommMonoid α] : CommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ := h
+instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ := h
+instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ := h
+instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ := h
+instance [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : InvolutiveInv α] : InvolutiveInv αᵒᵈ := h
+instance [h : InvolutiveInv α] : InvolutiveInv αᵒᵈ where
+  inv_inv := h.inv_inv
 
 @[to_additive]
-instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ := h
+instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ where
+  div_eq_mul_inv := h.div_eq_mul_inv
+  zpow := h.zpow
+  zpow_zero' := h.zpow_zero'
+  zpow_succ' := h.zpow_succ'
+  zpow_neg' := h.zpow_neg'
 
 @[to_additive]
-instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ := h
+instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ where
+  mul_inv_rev := h.mul_inv_rev
+  inv_eq_of_mul := h.inv_eq_of_mul
 
 @[to_additive]
-instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ := h
+instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ where
 
 @[to_additive]
-instance OrderDual.instGroup [h : Group α] : Group αᵒᵈ := h
+instance [h : Group α] : Group αᵒᵈ where
+  inv_mul_cancel := h.inv_mul_cancel
 
 @[to_additive]
-instance [h : CommGroup α] : CommGroup αᵒᵈ := h
+instance [h : CommGroup α] : CommGroup αᵒᵈ where
+
+end OrderDual
 
 @[to_additive (attr := simp)]
 theorem toDual_one [One α] : toDual (1 : α) = 1 := rfl

--- a/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.Algebra.GroupWithZero.Action.Defs
+public import Mathlib.Algebra.Order.Group.Action.Synonym
 public import Mathlib.Algebra.Order.GroupWithZero.Synonym
 public import Mathlib.Tactic.Common
 
@@ -27,29 +28,41 @@ variable {G₀ M₀ : Type*}
 
 namespace OrderDual
 
-instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ :=
-  ‹SMulWithZero G₀ M₀›
+instance [Zero M₀] [h : SMulZeroClass G₀ M₀] : SMulZeroClass G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
 
-instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ :=
-  ‹SMulWithZero G₀ M₀›
+instance [Zero M₀] [h : SMulZeroClass G₀ M₀] : SMulZeroClass G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
 
-instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ :=
-  ‹DistribSMul G₀ M₀›
+instance [Zero G₀] [Zero M₀] [h : SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ where
+  zero_smul := h.zero_smul
 
-instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ :=
-  ‹DistribSMul G₀ M₀›
+instance [Zero G₀] [Zero M₀] [h : SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ where
+  zero_smul := h.zero_smul
 
-instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ᵒᵈ M₀ := ‹DistribMulAction G₀ M₀›
+instance [AddZeroClass M₀] [h : DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ where
+  smul_add := h.smul_add
 
-instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ M₀ᵒᵈ := ‹DistribMulAction G₀ M₀›
+instance [AddZeroClass M₀] [h : DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ where
+  smul_add := h.smul_add
 
-instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ᵒᵈ M₀ := ‹MulActionWithZero G₀ M₀›
+instance [Monoid G₀] [AddMonoid M₀] [h : DistribMulAction G₀ M₀] : DistribMulAction G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
 
-instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ M₀ᵒᵈ := ‹MulActionWithZero G₀ M₀›
+instance [Monoid G₀] [AddMonoid M₀] [h : DistribMulAction G₀ M₀] : DistribMulAction G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  smul_add := h.smul_add
+
+instance [MonoidWithZero G₀] [AddMonoid M₀] [h : MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ᵒᵈ M₀ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
+
+instance [MonoidWithZero G₀] [AddMonoid M₀] [h : MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ M₀ᵒᵈ where
+  smul_zero := h.smul_zero
+  zero_smul := h.zero_smul
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
@@ -25,27 +25,38 @@ variable {α : Type*}
 /-! ### Order dual -/
 
 
-open OrderDual
+namespace OrderDual
 
-instance [h : MulZeroClass α] : MulZeroClass αᵒᵈ := h
+instance [h : MulZeroClass α] : MulZeroClass αᵒᵈ where
+  zero_mul := h.zero_mul
+  mul_zero := h.mul_zero
 
-instance [h : MulZeroOneClass α] : MulZeroOneClass αᵒᵈ := h
+instance [h : MulZeroOneClass α] : MulZeroOneClass αᵒᵈ where
 
-instance [Mul α] [Zero α] [h : NoZeroDivisors α] : NoZeroDivisors αᵒᵈ := h
+instance [Mul α] [Zero α] [h : NoZeroDivisors α] : NoZeroDivisors αᵒᵈ where
+  eq_zero_or_eq_zero_of_mul_eq_zero := h.eq_zero_or_eq_zero_of_mul_eq_zero
 
-instance [h : SemigroupWithZero α] : SemigroupWithZero αᵒᵈ := h
+instance [h : SemigroupWithZero α] : SemigroupWithZero αᵒᵈ where
 
-instance [h : MonoidWithZero α] : MonoidWithZero αᵒᵈ := h
+instance [h : MonoidWithZero α] : MonoidWithZero αᵒᵈ where
 
-instance [Mul α] [Zero α] [h : IsLeftCancelMulZero α] : IsLeftCancelMulZero αᵒᵈ := h
-instance [Mul α] [Zero α] [h : IsRightCancelMulZero α] : IsRightCancelMulZero αᵒᵈ := h
-instance [Mul α] [Zero α] [h : IsCancelMulZero α] : IsCancelMulZero αᵒᵈ := h
+instance [Mul α] [Zero α] [h : IsLeftCancelMulZero α] : IsLeftCancelMulZero αᵒᵈ where
+  mul_left_cancel_of_ne_zero := h.mul_left_cancel_of_ne_zero
 
-instance [h : CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ := h
+instance [Mul α] [Zero α] [h : IsRightCancelMulZero α] : IsRightCancelMulZero αᵒᵈ where
+  mul_right_cancel_of_ne_zero := h.mul_right_cancel_of_ne_zero
 
-instance [h : GroupWithZero α] : GroupWithZero αᵒᵈ := h
+instance [Mul α] [Zero α] [h : IsCancelMulZero α] : IsCancelMulZero αᵒᵈ where
 
-instance [h : CommGroupWithZero α] : CommGroupWithZero αᵒᵈ := h
+instance [h : CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ where
+
+instance [h : GroupWithZero α] : GroupWithZero αᵒᵈ where
+  inv_zero := h.inv_zero
+  mul_inv_cancel := h.mul_inv_cancel
+
+instance [h : CommGroupWithZero α] : CommGroupWithZero αᵒᵈ where
+
+end OrderDual
 
 /-! ### Lexicographic order -/
 

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -208,15 +208,12 @@ theorem monotone_iff_map_nonneg [iamhc : AddMonoidHomClass F α β] :
 
 variable [iamhc : AddMonoidHomClass F α β]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem antitone_iff_map_nonpos : Antitone (f : α → β) ↔ ∀ a, 0 ≤ a → f a ≤ 0 :=
   monotone_toDual_comp_iff.symm.trans <| monotone_iff_map_nonneg (β := βᵒᵈ) (iamhc := iamhc) _
 
-set_option backward.isDefEq.respectTransparency false in
 theorem monotone_iff_map_nonpos : Monotone (f : α → β) ↔ ∀ a ≤ 0, f a ≤ 0 :=
   antitone_comp_ofDual_iff.symm.trans <| antitone_iff_map_nonpos (α := αᵒᵈ) (iamhc := iamhc) _
 
-set_option backward.isDefEq.respectTransparency false in
 theorem antitone_iff_map_nonneg : Antitone (f : α → β) ↔ ∀ a ≤ 0, 0 ≤ f a :=
   monotone_comp_ofDual_iff.symm.trans <| monotone_iff_map_nonneg (α := αᵒᵈ) (iamhc := iamhc) _
 
@@ -228,15 +225,12 @@ theorem strictMono_iff_map_pos :
   · rw [← sub_add_cancel b a, map_add f]
     exact lt_add_of_pos_left _ (h _ <| sub_pos.2 hl)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem strictAnti_iff_map_neg : StrictAnti (f : α → β) ↔ ∀ a, 0 < a → f a < 0 :=
   strictMono_toDual_comp_iff.symm.trans <| strictMono_iff_map_pos (β := βᵒᵈ) (iamhc := iamhc) _
 
-set_option backward.isDefEq.respectTransparency false in
 theorem strictMono_iff_map_neg : StrictMono (f : α → β) ↔ ∀ a < 0, f a < 0 :=
   strictAnti_comp_ofDual_iff.symm.trans <| strictAnti_iff_map_neg (α := αᵒᵈ) (iamhc := iamhc) _
 
-set_option backward.isDefEq.respectTransparency false in
 theorem strictAnti_iff_map_pos : StrictAnti (f : α → β) ↔ ∀ a < 0, 0 < f a :=
   strictMono_comp_ofDual_iff.symm.trans <| strictMono_iff_map_pos (α := αᵒᵈ) (iamhc := iamhc) _
 

--- a/Mathlib/Algebra/Order/Module/Synonym.lean
+++ b/Mathlib/Algebra/Order/Module/Synonym.lean
@@ -28,7 +28,6 @@ variable {α β : Type*}
 
 namespace OrderDual
 
-set_option backward.isDefEq.respectTransparency false in
 instance instModule [Semiring α] [AddCommMonoid β] [Module α β] : Module αᵒᵈ β where
   add_smul := add_smul (R := α)
   zero_smul := zero_smul _

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Order.Group.Abs
 public import Mathlib.Algebra.Order.Ring.Int
 public import Mathlib.Data.Nat.Cast.Order.Ring
+public import Mathlib.Algebra.Order.GroupWithZero.Synonym
 
 /-!
 # Order properties of cast of integers
@@ -107,22 +108,6 @@ lemma nneg_mul_add_sq_of_abs_le_one (n : ℤ) (hx : |x| ≤ 1) : (0 : R) ≤ n *
 
 end LinearOrderedRing
 end Int
-
-/-! ### Order dual -/
-
-open OrderDual
-
-namespace OrderDual
-
-instance instIntCast [IntCast R] : IntCast Rᵒᵈ := ‹_›
-instance instAddGroupWithOne [AddGroupWithOne R] : AddGroupWithOne Rᵒᵈ := ‹_›
-instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵒᵈ := ‹_›
-
-end OrderDual
-
-@[simp] lemma toDual_intCast [IntCast R] (n : ℤ) : toDual (n : R) = n := rfl
-
-@[simp] lemma ofDual_intCast [IntCast R] (n : ℤ) : (ofDual n : R) = n := rfl
 
 /-! ### Lexicographic order -/
 

--- a/Mathlib/Algebra/Order/Ring/Synonym.lean
+++ b/Mathlib/Algebra/Order/Ring/Synonym.lean
@@ -21,40 +21,91 @@ variable {R : Type*}
 
 /-! ### Order dual -/
 
+namespace OrderDual
 
-instance [h : Distrib R] : Distrib Rᵒᵈ := h
+instance [h : Distrib R] : Distrib Rᵒᵈ where
+  left_distrib := h.left_distrib
+  right_distrib := h.right_distrib
 
-instance [Mul R] [Add R] [h : LeftDistribClass R] : LeftDistribClass Rᵒᵈ := h
+instance [Mul R] [Add R] [h : LeftDistribClass R] : LeftDistribClass Rᵒᵈ where
+  left_distrib := h.left_distrib
 
-instance [Mul R] [Add R] [h : RightDistribClass R] : RightDistribClass Rᵒᵈ := h
+instance [Mul R] [Add R] [h : RightDistribClass R] : RightDistribClass Rᵒᵈ where
+  right_distrib := h.right_distrib
 
-instance [h : NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ := h
+instance [h : NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ where
+  zero_mul := h.zero_mul
+  mul_zero := h.mul_zero
 
-instance [h : NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ := h
+instance [h : NatCast R] : NatCast Rᵒᵈ := h
 
-instance [h : NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ := h
+instance [h : IntCast R] : IntCast Rᵒᵈ := h
 
-instance [h : Semiring R] : Semiring Rᵒᵈ := h
+instance [h : AddMonoidWithOne R] : AddMonoidWithOne Rᵒᵈ where
+  natCast_zero := h.natCast_zero
+  natCast_succ := h.natCast_succ
 
-instance [h : NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ := h
+instance [h : AddCommMonoidWithOne R] : AddCommMonoidWithOne Rᵒᵈ where
 
-instance [h : CommSemiring R] : CommSemiring Rᵒᵈ := h
+instance [h : AddGroupWithOne R] : AddGroupWithOne Rᵒᵈ where
+  intCast_ofNat := h.intCast_ofNat
+  intCast_negSucc := h.intCast_negSucc
 
-instance [Mul R] [h : HasDistribNeg R] : HasDistribNeg Rᵒᵈ := h
+instance [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵒᵈ where
 
-instance [h : NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ := h
+instance [h : NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ where
 
-instance [h : NonUnitalRing R] : NonUnitalRing Rᵒᵈ := h
+instance [h : NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ where
 
-instance [h : NonAssocRing R] : NonAssocRing Rᵒᵈ := h
+instance [h : Semiring R] : Semiring Rᵒᵈ where
 
-instance [h : Ring R] : Ring Rᵒᵈ := h
+instance [h : NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ where
 
-instance [h : NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ := h
+instance [h : CommSemiring R] : CommSemiring Rᵒᵈ where
 
-instance [h : CommRing R] : CommRing Rᵒᵈ := h
+instance [Mul R] [h : HasDistribNeg R] : HasDistribNeg Rᵒᵈ where
+  neg_mul := h.neg_mul
+  mul_neg := h.mul_neg
 
-instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ := h
+instance [h : NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ where
+
+instance [h : NonUnitalRing R] : NonUnitalRing Rᵒᵈ where
+
+instance [h : NonAssocRing R] : NonAssocRing Rᵒᵈ where
+
+instance [h : Ring R] : Ring Rᵒᵈ where
+
+instance [h : NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ where
+
+instance [h : CommRing R] : CommRing Rᵒᵈ where
+
+instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ where
+  mul_left_cancel_of_ne_zero := h.mul_left_cancel_of_ne_zero
+  mul_right_cancel_of_ne_zero := h.mul_right_cancel_of_ne_zero
+
+end OrderDual
+
+@[simp]
+theorem toDual_natCast [NatCast R] (n : ℕ) : toDual (n : R) = n :=
+  rfl
+
+@[simp]
+theorem toDual_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    (toDual (ofNat(n) : R)) = ofNat(n) :=
+  rfl
+
+@[simp]
+theorem ofDual_natCast [NatCast R] (n : ℕ) : (ofDual n : R) = n :=
+  rfl
+
+@[simp]
+theorem ofDual_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    (ofDual (ofNat(n) : Rᵒᵈ)) = ofNat(n) :=
+  rfl
+
+@[simp] lemma toDual_intCast [IntCast R] (n : ℤ) : toDual (n : R) = n := rfl
+
+@[simp] lemma ofDual_intCast [IntCast R] (n : ℤ) : (ofDual n : R) = n := rfl
 
 /-! ### Lexicographical order -/
 

--- a/Mathlib/Algebra/Order/Ring/Synonym.lean
+++ b/Mathlib/Algebra/Order/Ring/Synonym.lean
@@ -85,6 +85,8 @@ instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ where
 
 end OrderDual
 
+open OrderDual
+
 @[simp]
 theorem toDual_natCast [NatCast R] (n : ℕ) : toDual (n : R) = n :=
   rfl

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -348,11 +348,11 @@ theorem MonotoneOn.convex_lt (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β)
 
 theorem MonotoneOn.convex_ge (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | r ≤ f x }) :=
-  MonotoneOn.convex_le (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual hs r
+  MonotoneOn.convex_le (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual (by exact hs) r
 
 theorem MonotoneOn.convex_gt (hf : MonotoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | r < f x }) :=
-  MonotoneOn.convex_lt (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual hs r
+  MonotoneOn.convex_lt (E := Eᵒᵈ) (β := βᵒᵈ) hf.dual (by exact hs) r
 
 theorem AntitoneOn.convex_le (hf : AntitoneOn f s) (hs : Convex 𝕜 s) (r : β) :
     Convex 𝕜 ({ x ∈ s | f x ≤ r }) :=

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -286,12 +286,10 @@ theorem ofDual_min' {s : Finset αᵒᵈ} (hs : s.Nonempty) :
     ofDual (min' s hs) = max' (s.image ofDual) (hs.image _) := by
   simp [min'_eq_inf', max'_eq_sup']
 
-set_option backward.isDefEq.respectTransparency false in
 theorem ofDual_max' {s : Finset αᵒᵈ} (hs : s.Nonempty) :
     ofDual (max' s hs) = min' (s.image ofDual) (hs.image _) := by
   simp [min'_eq_inf', max'_eq_sup']
 
-set_option backward.isDefEq.respectTransparency false in
 theorem toDual_min' {s : Finset α} (hs : s.Nonempty) :
     toDual (min' s hs) = max' (s.image toDual) (hs.image _) := by
   simp [min'_eq_inf', max'_eq_sup']

--- a/Mathlib/Data/Nat/Cast/Synonym.lean
+++ b/Mathlib/Data/Nat/Cast/Synonym.lean
@@ -20,38 +20,6 @@ the natural numbers into an additive monoid with a one (`Nat.cast`).
 
 variable {α : Type*}
 
-/-! ### Order dual -/
-
-
-open OrderDual
-
-instance [h : NatCast α] : NatCast αᵒᵈ :=
-  h
-
-instance [h : AddMonoidWithOne α] : AddMonoidWithOne αᵒᵈ :=
-  h
-
-instance [h : AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵒᵈ :=
-  h
-
-@[simp]
-theorem toDual_natCast [NatCast α] (n : ℕ) : toDual (n : α) = n :=
-  rfl
-
-@[simp]
-theorem toDual_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    (toDual (ofNat(n) : α)) = ofNat(n) :=
-  rfl
-
-@[simp]
-theorem ofDual_natCast [NatCast α] (n : ℕ) : (ofDual n : α) = n :=
-  rfl
-
-@[simp]
-theorem ofDual_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    (ofDual (ofNat(n) : αᵒᵈ)) = ofNat(n) :=
-  rfl
-
 /-! ### Lexicographic order -/
 
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
@@ -87,14 +87,12 @@ theorem lineMap_lt_lineMap_iff_of_lt (h : r < r') : lineMap a b r < lineMap a b 
 theorem left_lt_lineMap_iff_lt (h : 0 < r) : a < lineMap a b r ↔ a < b :=
   Iff.trans (by rw [lineMap_apply_zero]) (lineMap_lt_lineMap_iff_of_lt h)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem lineMap_lt_left_iff_lt (h : 0 < r) : lineMap a b r < a ↔ b < a :=
   left_lt_lineMap_iff_lt (E := Eᵒᵈ) h
 
 theorem lineMap_lt_right_iff_lt (h : r < 1) : lineMap a b r < b ↔ a < b :=
   Iff.trans (by rw [lineMap_apply_one]) (lineMap_lt_lineMap_iff_of_lt h)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem right_lt_lineMap_iff_lt (h : r < 1) : b < lineMap a b r ↔ b < a :=
   lineMap_lt_right_iff_lt (E := Eᵒᵈ) h
 
@@ -166,7 +164,6 @@ theorem left_le_lineMap_iff_le (h : 0 < r) : a ≤ lineMap a b r ↔ a ≤ b :=
 theorem left_le_midpoint : a ≤ midpoint k a b ↔ a ≤ b :=
   left_le_lineMap_iff_le <| inv_pos.2 zero_lt_two
 
-set_option backward.isDefEq.respectTransparency false in
 theorem lineMap_le_left_iff_le (h : 0 < r) : lineMap a b r ≤ a ↔ b ≤ a :=
   left_le_lineMap_iff_le (E := Eᵒᵈ) h
 
@@ -180,7 +177,6 @@ theorem lineMap_le_right_iff_le (h : r < 1) : lineMap a b r ≤ b ↔ a ≤ b :=
 @[simp]
 theorem midpoint_le_right : midpoint k a b ≤ b ↔ a ≤ b := lineMap_le_right_iff_le two_inv_lt_one
 
-set_option backward.isDefEq.respectTransparency false in
 theorem right_le_lineMap_iff_le (h : r < 1) : b ≤ lineMap a b r ↔ b ≤ a :=
   lineMap_le_right_iff_le (E := Eᵒᵈ) h
 
@@ -236,7 +232,6 @@ theorem map_le_lineMap_iff_slope_le_slope_left (h : 0 < r * (b - a)) :
     mul_inv_cancel_right₀ (right_ne_zero_of_mul h.ne'), smul_add,
     smul_inv_smul₀ (left_ne_zero_of_mul h.ne')]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `a < c`, the point `(c, f c)` is non-strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f a b ≤ slope f a c`. -/
 theorem lineMap_le_map_iff_slope_le_slope_left (h : 0 < r * (b - a)) :
@@ -250,7 +245,6 @@ theorem map_lt_lineMap_iff_slope_lt_slope_left (h : 0 < r * (b - a)) :
   lt_iff_lt_of_le_iff_le' (lineMap_le_map_iff_slope_le_slope_left h)
     (map_le_lineMap_iff_slope_le_slope_left h)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `a < c`, the point `(c, f c)` is strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f a b < slope f a c`. -/
 theorem lineMap_lt_map_iff_slope_lt_slope_left (h : 0 < r * (b - a)) :
@@ -269,7 +263,6 @@ theorem map_le_lineMap_iff_slope_le_slope_right (h : 0 < (1 - r) * (b - a)) :
     smul_neg, neg_add_eq_sub]
   · exact right_ne_zero_of_mul h.ne'
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `c < b`, the point `(c, f c)` is non-strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f c b ≤ slope f a b`. -/
 theorem lineMap_le_map_iff_slope_le_slope_right (h : 0 < (1 - r) * (b - a)) :
@@ -283,7 +276,6 @@ theorem map_lt_lineMap_iff_slope_lt_slope_right (h : 0 < (1 - r) * (b - a)) :
   lt_iff_lt_of_le_iff_le' (lineMap_le_map_iff_slope_le_slope_right h)
     (map_le_lineMap_iff_slope_le_slope_right h)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `c < b`, the point `(c, f c)` is strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f c b < slope f a b`. -/
 theorem lineMap_lt_map_iff_slope_lt_slope_right (h : 0 < (1 - r) * (b - a)) :
@@ -299,7 +291,6 @@ theorem map_le_lineMap_iff_slope_le_slope (hab : a < b) (h₀ : 0 < r) (h₁ : r
   rw [map_le_lineMap_iff_slope_le_slope_left (mul_pos h₀ (sub_pos.2 hab)), ←
     lineMap_slope_lineMap_slope_lineMap f a b r, right_le_lineMap_iff_le h₁]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `a < c < b`, the point `(c, f c)` is non-strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f c b ≤ slope f a c`. -/
 theorem lineMap_le_map_iff_slope_le_slope (hab : a < b) (h₀ : 0 < r) (h₁ : r < 1) :
@@ -313,7 +304,6 @@ theorem map_lt_lineMap_iff_slope_lt_slope (hab : a < b) (h₀ : 0 < r) (h₁ : r
   lt_iff_lt_of_le_iff_le' (lineMap_le_map_iff_slope_le_slope hab h₀ h₁)
     (map_le_lineMap_iff_slope_le_slope hab h₀ h₁)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given `c = lineMap a b r`, `a < c < b`, the point `(c, f c)` is strictly above the
 segment `[(a, f a), (b, f b)]` if and only if `slope f c b < slope f a c`. -/
 theorem lineMap_lt_map_iff_slope_lt_slope (hab : a < b) (h₀ : 0 < r) (h₁ : r < 1) :

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -219,13 +219,12 @@ namespace OrderDual
 variable (α)
 
 @[to_dual]
-instance instTop [Bot α] : Top αᵒᵈ :=
-  ⟨(⊥ : α)⟩
+instance [h : Bot α] : Top αᵒᵈ :=
+  ⟨h.bot⟩
 
 @[to_dual]
-instance instOrderTop [LE α] [OrderBot α] : OrderTop αᵒᵈ where
-  __ := (inferInstance : Top αᵒᵈ)
-  le_top := @bot_le α _ _
+instance [LE α] [h : OrderBot α] : OrderTop αᵒᵈ where
+  le_top := h.bot_le
 
 @[to_dual (attr := simp)] lemma ofDual_top [Bot α] : ofDual ⊤ = (⊥ : α) := rfl
 @[to_dual (attr := simp)] lemma toDual_top [Top α] : toDual (⊤ : α) = ⊥ := rfl
@@ -257,8 +256,6 @@ attribute [to_dual self (reorder := 3 4)] BoundedOrder.mk
 attribute [to_dual existing] BoundedOrder.toOrderTop
 
 instance OrderDual.instBoundedOrder (α : Type u) [LE α] [BoundedOrder α] : BoundedOrder αᵒᵈ where
-  __ := (inferInstance : OrderTop αᵒᵈ)
-  __ := (inferInstance : OrderBot αᵒᵈ)
 
 section PartialOrder
 variable [PartialOrder α]

--- a/Mathlib/Order/Circular.lean
+++ b/Mathlib/Order/Circular.lean
@@ -416,26 +416,22 @@ abbrev LinearOrder.toCircularOrder (α : Type*) [LinearOrder α] : CircularOrder
 
 namespace OrderDual
 
-instance btw (α : Type*) [Btw α] : Btw αᵒᵈ :=
-  ⟨fun a b c : α => Btw.btw c b a⟩
+instance btw (α : Type*) [h : Btw α] : Btw αᵒᵈ :=
+  ⟨fun a b c => h.btw c b a⟩
 
-instance sbtw (α : Type*) [SBtw α] : SBtw αᵒᵈ :=
-  ⟨fun a b c : α => SBtw.sbtw c b a⟩
+instance sbtw (α : Type*) [h : SBtw α] : SBtw αᵒᵈ :=
+  ⟨fun a b c => h.sbtw c b a⟩
 
-instance circularPreorder (α : Type*) [CircularPreorder α] : CircularPreorder αᵒᵈ :=
-  { OrderDual.btw α,
-    OrderDual.sbtw α with
-    btw_refl := fun _ => @btw_refl α _ _
-    btw_cyclic_left := fun {_ _ _} => @btw_cyclic_right α _ _ _ _
-    sbtw_trans_left := fun {_ _ _ _} habc hbdc => hbdc.trans_right habc
-    sbtw_iff_btw_not_btw := fun {a b c} => @sbtw_iff_btw_not_btw α _ c b a }
+instance circularPreorder (α : Type*) [CircularPreorder α] : CircularPreorder αᵒᵈ where
+  btw_refl _ := btw_refl _
+  btw_cyclic_left {_ _ _} := @btw_cyclic_right α _ _ _ _
+  sbtw_trans_left {_ _ _ _} habc hbdc := hbdc.trans_right habc
+  sbtw_iff_btw_not_btw {a b c} := @sbtw_iff_btw_not_btw α _ c b a
 
-instance circularPartialOrder (α : Type*) [CircularPartialOrder α] : CircularPartialOrder αᵒᵈ :=
-  { OrderDual.circularPreorder α with
-    btw_antisymm := fun {_ _ _} habc hcba => @btw_antisymm α _ _ _ _ hcba habc }
+instance circularPartialOrder (α : Type*) [CircularPartialOrder α] : CircularPartialOrder αᵒᵈ where
+  btw_antisymm := fun {_ _ _} habc hcba => @btw_antisymm α _ _ _ _ hcba habc
 
-instance (α : Type*) [CircularOrder α] : CircularOrder αᵒᵈ :=
-  { OrderDual.circularPartialOrder α with
-    btw_total := fun {a b c} => @btw_total α _ c b a }
+instance (α : Type*) [CircularOrder α] : CircularOrder αᵒᵈ where
+  btw_total := fun {a b c} => @btw_total α _ c b a
 
 end OrderDual

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -49,8 +49,8 @@ open Function OrderDual Set
 variable {α β γ : Type*} {ι ι' : Sort*} {κ : ι → Sort*} {κ' : ι' → Sort*}
 
 @[to_dual]
-instance OrderDual.supSet (α) [InfSet α] : SupSet αᵒᵈ :=
-  ⟨(sInf : Set α → α)⟩
+instance OrderDual.supSet (α) [h : InfSet α] : SupSet αᵒᵈ :=
+  ⟨fun s ↦ h.sInf s⟩
 
 /-- Note that we rarely use `CompleteSemilatticeSup`
 (in fact, any such object is always a `CompleteLattice`, so it's usually best to start there).
@@ -256,7 +256,6 @@ instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : Linear
 namespace OrderDual
 
 instance instCompleteLattice [CompleteLattice α] : CompleteLattice αᵒᵈ where
-  __ := instBoundedOrder α
 
 instance instCompleteLinearOrder [CompleteLinearOrder α] : CompleteLinearOrder αᵒᵈ where
   __ := instCompleteLattice

--- a/Mathlib/Order/GaloisConnection/Basic.lean
+++ b/Mathlib/Order/GaloisConnection/Basic.lean
@@ -538,7 +538,7 @@ abbrev liftLattice [Lattice β] (gi : GaloisCoinsertion l u) : Lattice α :=
 -- See note [reducible non-instances]
 /-- Lift the bot along a Galois coinsertion -/
 abbrev liftOrderBot [Preorder β] [OrderBot β] (gi : GaloisCoinsertion l u) : OrderBot α :=
-  { @OrderDual.instOrderBot _ _ gi.dual.liftOrderTop with bot := gi.choice ⊥ <| bot_le }
+  { @OrderDual.instOrderBotOfOrderTop _ _ gi.dual.liftOrderTop with bot := gi.choice ⊥ <| bot_le }
 
 -- See note [reducible non-instances]
 /-- Lift the top, bottom, suprema, and infima along a Galois coinsertion -/

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -320,11 +320,11 @@ theorem SemilatticeSup.ext {α} {A B : SemilatticeSup α}
   ext; apply SemilatticeSup.ext_sup H
 
 @[to_dual]
-instance OrderDual.instSemilatticeSup (α) [SemilatticeInf α] : SemilatticeSup αᵒᵈ where
-  sup := @SemilatticeInf.inf α _
-  le_sup_left := @SemilatticeInf.inf_le_left α _
-  le_sup_right := @SemilatticeInf.inf_le_right α _
-  sup_le := fun _ _ _ hca hcb => @SemilatticeInf.le_inf α _ _ _ _ hca hcb
+instance OrderDual.instSemilatticeSup (α) [h : SemilatticeInf α] : SemilatticeSup αᵒᵈ where
+  sup a b := h.inf a b
+  le_sup_left := h.inf_le_left
+  le_sup_right := h.inf_le_right
+  sup_le _ _ _ := h.le_inf _ _ _
 
 @[to_dual]
 theorem SemilatticeSup.dual_dual (α : Type*) [H : SemilatticeSup α] :
@@ -500,7 +500,7 @@ theorem inf_sup_le {x y z : α} : x ⊓ (y ⊔ z) ≤ (x ⊓ y) ⊔ (x ⊓ z) :=
   rw [inf_sup_left]
 
 instance OrderDual.instDistribLattice (α : Type*) [DistribLattice α] : DistribLattice αᵒᵈ where
-  le_sup_inf _ _ _ := (inf_sup_left _ _ _).le
+  le_sup_inf _ _ _ := inf_sup_le
 
 @[to_dual existing]
 theorem inf_sup_right (a b c : α) : (a ⊔ b) ⊓ c = a ⊓ c ⊔ b ⊓ c := by

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -61,21 +61,21 @@ instance (α : Type*) [h : Min α] : Max αᵒᵈ :=
   ⟨fun a b ↦ h.min a b⟩
 
 instance [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
-  trans  _ _ _ hab hbc := T.trans _ _ _ hbc hab
+  trans _ _ _ hab hbc := T.trans _ _ _ hbc hab
 
 instance [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
-  trans  _ _ _ hab hbc := T.trans _ _ _ hbc hab
+  trans _ _ _ hab hbc := T.trans _ _ _ hbc hab
 
 instance [LT α] [T : @Std.Trichotomous α LT.lt] : @Std.Trichotomous αᵒᵈ LT.lt where
   trichotomous a b := by rw [eq_comm]; exact T.trichotomous b a
 
 instance (α : Type*) [Preorder α] : Preorder αᵒᵈ where
-  le_refl  _ := le_refl _
-  le_trans  _ _ _ hab hbc := hbc.trans hab
-  lt_iff_le_not_ge  _ _ := lt_iff_le_not_ge
+  le_refl _ := le_refl _
+  le_trans _ _ _ hab hbc := hbc.trans hab
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge
 
 instance (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
-  le_antisymm  a b hab hba := @le_antisymm α _ a b hba hab
+  le_antisymm a b hab hba := @le_antisymm α _ a b hba hab
 
 instance (α : Type*) [DecidableEq α] : DecidableEq αᵒᵈ := ‹DecidableEq α›
 

--- a/Mathlib/Order/OrderDual.lean
+++ b/Mathlib/Order/OrderDual.lean
@@ -47,53 +47,48 @@ instance (α : Type*) [h : Nonempty α] : Nonempty αᵒᵈ :=
 instance (α : Type*) [h : Subsingleton α] : Subsingleton αᵒᵈ :=
   h
 
-instance (α : Type*) [LE α] : LE αᵒᵈ :=
-  ⟨fun x y : α ↦ y ≤ x⟩
+instance (α : Type*) [h : LE α] : LE αᵒᵈ :=
+  ⟨fun a b ↦ h.le b a⟩
 
-instance (α : Type*) [LT α] : LT αᵒᵈ :=
-  ⟨fun x y : α ↦ y < x⟩
+instance (α : Type*) [h : LT α] : LT αᵒᵈ :=
+  ⟨fun a b ↦ h.lt b a⟩
 
-instance instOrd (α : Type*) [Ord α] : Ord αᵒᵈ where
-  compare := fun (a b : α) ↦ compare b a
+instance (α : Type*) [h : Ord α] : Ord αᵒᵈ :=
+  ⟨fun a b ↦ h.compare b a⟩
 
 @[to_dual]
-instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
-  ⟨((· ⊓ ·) : α → α → α)⟩
+instance (α : Type*) [h : Min α] : Max αᵒᵈ :=
+  ⟨fun a b ↦ h.min a b⟩
 
-instance instIsTransLE [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
-  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+instance [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
+  trans  _ _ _ hab hbc := T.trans _ _ _ hbc hab
 
-instance instIsTransLT [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
-  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+instance [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
+  trans  _ _ _ hab hbc := T.trans _ _ _ hbc hab
 
 instance [LT α] [T : @Std.Trichotomous α LT.lt] : @Std.Trichotomous αᵒᵈ LT.lt where
   trichotomous a b := by rw [eq_comm]; exact T.trichotomous b a
 
-instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
-  le_refl := fun _ ↦ le_refl _
-  le_trans := fun _ _ _ hab hbc ↦ hbc.trans hab
-  lt_iff_le_not_ge := fun _ _ ↦ lt_iff_le_not_ge
+instance (α : Type*) [Preorder α] : Preorder αᵒᵈ where
+  le_refl  _ := le_refl _
+  le_trans  _ _ _ hab hbc := hbc.trans hab
+  lt_iff_le_not_ge  _ _ := lt_iff_le_not_ge
 
-instance instPartialOrder (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
-  __ := (inferInstance : Preorder αᵒᵈ)
-  le_antisymm := fun a b hab hba ↦ @le_antisymm α _ a b hba hab
+instance (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
+  le_antisymm  a b hab hba := @le_antisymm α _ a b hba hab
 
-instance (α : Type*) [DecidableEq α] : DecidableEq (αᵒᵈ) := ‹DecidableEq α›
+instance (α : Type*) [DecidableEq α] : DecidableEq αᵒᵈ := ‹DecidableEq α›
 
-instance (α : Type*) [LT α] [DecidableLT α] : DecidableLT (αᵒᵈ) :=
-  inferInstanceAs <| DecidableRel (fun a b : α ↦ b < a)
+instance (α : Type*) [LT α] [h : DecidableLT α] : DecidableLT (αᵒᵈ) :=
+  fun a b ↦ h b a
 
-instance (α : Type*) [LE α] [DecidableLE α] : DecidableLE (αᵒᵈ) :=
-  inferInstanceAs <| DecidableRel (fun a b : α ↦ b ≤ a)
+instance (α : Type*) [LE α] [h : DecidableLE α] : DecidableLE (αᵒᵈ) :=
+  fun a b ↦ h b a
 
-instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
-  __ := (inferInstance : PartialOrder αᵒᵈ)
-  __ := (inferInstance : Ord αᵒᵈ)
-  le_total := fun a b : α ↦ le_total b a
-  max := fun a b ↦ (min a b : α)
-  min := fun a b ↦ (max a b : α)
-  min_def := fun a b ↦ show (max .. : α) = _ by rw [max_comm, max_def]; rfl
-  max_def := fun a b ↦ show (min .. : α) = _ by rw [min_comm, min_def]; rfl
+instance (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
+  le_total a b := le_total (α := α) b a
+  min_def := max_def' (α := α)
+  max_def := min_def' (α := α)
   toDecidableLE := inferInstance
   toDecidableLT := inferInstance
   toDecidableEq := inferInstance
@@ -101,13 +96,14 @@ instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ wh
     simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
     rfl
 
+-- TODO: This declaration really shouldn't exist.
 set_option backward.inferInstanceAs.wrap.reuseSubInstances false in  -- otherwise we get an identity!
 /-- The opposite linear order to a given linear order -/
 @[implicit_reducible]
 def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α :=
   inferInstanceAs <| LinearOrder (OrderDual α)
 
-instance : ∀ [Inhabited α], Inhabited αᵒᵈ := fun [x : Inhabited α] => x
+instance [h : Inhabited α] : Inhabited αᵒᵈ := ⟨h.default⟩
 
 theorem Ord.dual_dual (α : Type*) [H : Ord α] : OrderDual.instOrd αᵒᵈ = H :=
   rfl
@@ -124,7 +120,8 @@ theorem instLinearOrder.dual_dual (α : Type*) [H : LinearOrder α] :
   rfl
 
 instance [h : Nontrivial α] : Nontrivial αᵒᵈ := h
-instance [h : Unique α] : Unique αᵒᵈ := h
+instance [h : Unique α] : Unique αᵒᵈ where
+  uniq := h.uniq
 
 /-- `toDual` is the identity function to the `OrderDual` of a linear order. -/
 def toDual : α ≃ αᵒᵈ :=

--- a/Mathlib/Topology/Order/Lattice.lean
+++ b/Mathlib/Topology/Order/Lattice.lean
@@ -46,15 +46,13 @@ class ContinuousSup (L : Type*) [TopologicalSpace L] [Max L] : Prop where
   /-- The supremum is continuous -/
   continuous_sup : Continuous fun p : L × L => p.1 ⊔ p.2
 
--- see Note [lower instance priority]
-instance (priority := 100) OrderDual.continuousSup (L : Type*) [TopologicalSpace L] [Min L]
-    [ContinuousInf L] : ContinuousSup Lᵒᵈ where
-  continuous_sup := @ContinuousInf.continuous_inf L _ _ _
+instance OrderDual.continuousSup (L : Type*) [TopologicalSpace L] [Min L]
+    [h : ContinuousInf L] : ContinuousSup Lᵒᵈ where
+  continuous_sup := h.continuous_inf
 
--- see Note [lower instance priority]
-instance (priority := 100) OrderDual.continuousInf (L : Type*) [TopologicalSpace L] [Max L]
-    [ContinuousSup L] : ContinuousInf Lᵒᵈ where
-  continuous_inf := @ContinuousSup.continuous_sup L _ _ _
+instance OrderDual.continuousInf (L : Type*) [TopologicalSpace L] [Max L]
+    [h : ContinuousSup L] : ContinuousInf Lᵒᵈ where
+  continuous_inf := h.continuous_sup
 
 /-- Let `L` be a lattice equipped with a topology such that `L` has continuous infimum and supremum.
 Then `L` is said to be a *topological lattice*.
@@ -62,9 +60,7 @@ Then `L` is said to be a *topological lattice*.
 class TopologicalLattice (L : Type*) [TopologicalSpace L] [Lattice L] : Prop
   extends ContinuousInf L, ContinuousSup L
 
-set_option backward.isDefEq.respectTransparency false in
--- see Note [lower instance priority]
-instance (priority := 100) OrderDual.topologicalLattice (L : Type*) [TopologicalSpace L]
+instance OrderDual.topologicalLattice (L : Type*) [TopologicalSpace L]
     [Lattice L] [TopologicalLattice L] : TopologicalLattice Lᵒᵈ where
 
 -- see Note [lower instance priority]
@@ -136,13 +132,11 @@ lemma finset_sup'_nhds_apply [SemilatticeSup L] [ContinuousSup L]
     Tendsto (fun a ↦ s.sup' hne (f · a)) l (𝓝 (s.sup' hne g)) := by
   simpa only [← Finset.sup'_apply] using finset_sup'_nhds hne hs
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finset_inf'_nhds [SemilatticeInf L] [ContinuousInf L]
     (hne : s.Nonempty) (hs : ∀ i ∈ s, Tendsto (f i) l (𝓝 (g i))) :
     Tendsto (s.inf' hne f) l (𝓝 (s.inf' hne g)) :=
   finset_sup'_nhds (L := Lᵒᵈ) hne hs
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finset_inf'_nhds_apply [SemilatticeInf L] [ContinuousInf L]
     (hne : s.Nonempty) (hs : ∀ i ∈ s, Tendsto (f i) l (𝓝 (g i))) :
     Tendsto (fun a ↦ s.inf' hne (f · a)) l (𝓝 (s.inf' hne g)) :=
@@ -160,12 +154,10 @@ lemma finset_sup_nhds_apply [SemilatticeSup L] [OrderBot L] [ContinuousSup L]
     Tendsto (fun a ↦ s.sup (f · a)) l (𝓝 (s.sup g)) := by
   simpa only [← Finset.sup_apply] using finset_sup_nhds hs
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finset_inf_nhds [SemilatticeInf L] [OrderTop L] [ContinuousInf L]
     (hs : ∀ i ∈ s, Tendsto (f i) l (𝓝 (g i))) : Tendsto (s.inf f) l (𝓝 (s.inf g)) :=
   finset_sup_nhds (L := Lᵒᵈ) hs
 
-set_option backward.isDefEq.respectTransparency false in
 lemma finset_inf_nhds_apply [SemilatticeInf L] [OrderTop L] [ContinuousInf L]
     (hs : ∀ i ∈ s, Tendsto (f i) l (𝓝 (g i))) :
     Tendsto (fun a ↦ s.inf (f · a)) l (𝓝 (s.inf g)) :=


### PR DESCRIPTION
This PR fixes the leaky `OrderDual` instances. It is not necessarily obvious at first that this possible to do. The heuristic for making these changes is as follows:
- Start at the data instances (LE, Max, One) and define them with the data field in eta-expanded form, with the lambda binders matching the type..

For example, the previous verion
```
instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
  ⟨((· ⊓ ·) : α → α → α)⟩
```
was bad, because the lambda binder had type `α` instead of `αᵒᵈ`. This would cause unification failures in type class search.
- For structures with child structures, use `where` notation, and fill in the proof fields manually. 

This PR removes 25 uses of `backward.isDefEq.respectTransparency`.

We should think about writing a metaprogram that can make these obvious instances for type wrappers/synonyms, which would save us the manual effort. Because in principle, we will have to do the same refactor for `Lex`, `Colex`, `Additive`, `Multiplicate` and any other such types.

In one place a proof broke due to this change, which was caused by stuff unifying in the `default` transparency *before* type class synthesis had finished. I fixed by with a `by exact`, which delays that elaboration/unification.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
