### PR TITLE
feat(Tactic/CategoryTheory): add support for specific functors in the map attribute

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6880,6 +6880,7 @@ public import Mathlib.Tactic.CategoryTheory.Coherence.Normalize
 public import Mathlib.Tactic.CategoryTheory.Coherence.PureCoherence
 public import Mathlib.Tactic.CategoryTheory.Elementwise
 public import Mathlib.Tactic.CategoryTheory.IsoReassoc
+public import Mathlib.Tactic.CategoryTheory.Map
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Datatypes
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Normalize

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -37,6 +37,7 @@ public import Mathlib.Tactic.CategoryTheory.Coherence.Normalize
 public import Mathlib.Tactic.CategoryTheory.Coherence.PureCoherence
 public import Mathlib.Tactic.CategoryTheory.Elementwise
 public import Mathlib.Tactic.CategoryTheory.IsoReassoc
+public import Mathlib.Tactic.CategoryTheory.Map
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Basic
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Datatypes
 public import Mathlib.Tactic.CategoryTheory.Monoidal.Normalize

--- a/Mathlib/Tactic/CategoryTheory/Map.lean
+++ b/Mathlib/Tactic/CategoryTheory/Map.lean
@@ -14,8 +14,13 @@ public import Mathlib.Util.AddRelatedDecl
 
 Adding `@[map]` to a lemma named `H` of shape `∀ .., f = g`, where `f` and `g` are morphisms
 in some category `C`, creates a new lemma named `H_map` of the form
-`∀ .. {D} (func : C ⥤ D), F.map f = F.map g` and then applies
+`∀ .. {D} (F : C ⥤ D), F.map f = F.map g` and then applies
 `simp only [Functor.map_comp, Functor.map_id]`.
+
+Declarations tagged with `@[map_functor]` register concrete functors. For each registered functor
+compatible with the source category of `H`, `@[map]` also generates a specialized lemma
+`H_map_<functorDeclName>` by specializing `F` to that functor and simplifying the result with
+`dsimp`.
 
 There is also a term elaborator `map_of% t` for use within proofs.
 -/
@@ -27,10 +32,55 @@ open CategoryTheory
 
 namespace Mathlib.Tactic.CategoryTheory.Map
 
+initialize mapFunctorExt : SimplePersistentEnvExtension Name (Array Name) ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn := Array.push
+    addImportedFn := fun as => as.foldl (init := #[]) (· ++ ·)
+  }
+
+/-- Flatten a declaration name into an underscore-separated suffix. -/
+private def flattenName : Name → String
+  | .anonymous => ""
+  | .str .anonymous s => s
+  | .num .anonymous n => toString n
+  | .str p s => s!"{flattenName p}_{s}"
+  | .num p n => s!"{flattenName p}_{n}"
+
+/-- The target name for the `@[map]` specialization at a registered functor. -/
+private def specializedMapName (src functorName : Name) : Name :=
+  src.appendAfter s!"_map_{flattenName (privateToUserName functorName)}"
+
+/-- Read the registered `@[map_functor]` functors. -/
+private def getMapFunctors : CoreM (Array Name) :=
+  return mapFunctorExt.getState (← getEnv)
+
+/-- Extract the source and target categories from a functor type. -/
+private def extractFunctorType? (ty : Expr) : MetaM (Option (Expr × Expr)) := do
+  let ty ← whnf (← instantiateMVars ty)
+  let (``CategoryTheory.Functor, args) := ty.getAppFnArgs | return none
+  if args.size == 4 then
+    return some (args[0]!, args[2]!)
+  else
+    return none
+
+/-- Validate that a declaration tagged with `@[map_functor]` is a concrete functor constant. -/
+private def validateMapFunctorDecl (declName : Name) : MetaM Unit := do
+  let F ← mkConstWithFreshMVarLevels declName
+  let Fty := (← inferType F).cleanupAnnotations
+  if Fty.isForall then
+    throwError "`map_functor` expects a declaration whose type is directly a functor, not a family"
+  unless (← extractFunctorType? Fty).isSome do
+    throwError "`map_functor` expects a declaration whose type reduces to `C ⥤ D`"
+
 /-- `simp only` with `Functor.map_comp` and `Functor.map_id` on a single expression
 (used on each side via `simpEq`). -/
 def mapCompSimp (e : Expr) : MetaM Simp.Result :=
   simpOnlyNames [``Functor.map_comp, ``Functor.map_id] e (config := { decide := false })
+
+/-- Apply `dsimp` to an expression. -/
+def dsimpExpr (e : Expr) : MetaM Expr := do
+  let ctx ← Simp.Context.mkDefault
+  return (← Meta.dsimp (← instantiateMVars e) ctx #[]).1
 
 private def extractCatInstanceFromEq (eqTy : Expr) : MetaM (Expr × Expr) := do
   let some (α, _, _) := eqTy.cleanupAnnotations.eq? | throwError "`@[map]` expects an equality"
@@ -102,16 +152,51 @@ def mapExprElab (pf : Expr) : TermElabM Expr :=
   liftMetaM <| mapExprMVars pf
 
 /--
+Produce the `@[map]`-specialized proof obtained by fixing `F` to a registered concrete functor and
+then simplifying with `dsimp`. Returns `none` when the functor has an incompatible source category.
+-/
+def mapSpecializedExpr (pf F : Expr) : MetaM (Option Expr) := do
+  let Fty := (← inferType F).cleanupAnnotations
+  let some (CF, _) ← extractFunctorType? Fty
+    | throwError "`@[map]` internal error: registered declaration is not a functor"
+  forallTelescopeReducing (← inferType pf) fun xs _ => do
+    let pfApp := mkAppN pf xs
+    let eqTy := (← inferType pfApp).cleanupAnnotations
+    let (C, _) ← extractCatInstanceFromEq eqTy
+    unless ← isDefEq C CF do
+      return none
+    let pf₀ ← mkAppM ``CategoryTheory.Functor.congr_map #[F, pfApp]
+    let ty ← instantiateMVars (← inferType pf₀)
+    let (ty', pf') ← simpEq (fun e => mapCompSimp e) ty pf₀
+    let ty'' ← dsimpExpr ty'
+    let pf'' ← mkExpectedTypeHint pf' ty''
+    return some (← mkLambdaFVars xs pf'')
+
+/--
 Adding `@[map]` to a lemma named `H` of shape `∀ .., f = g`, where `f` and `g` are morphisms
 in some category `C`, creates a new lemma named `H_map` of the form
 `∀ .. {D} (F : C ⥤ D), F.map f = F.map g` and then applies
-`simp only [Functor.map_comp, Functor.map_id]`.
+`simp only [Functor.map_comp, Functor.map_id]`. For each compatible registered `@[map_functor]`
+declaration `G`, it also creates `H_map_<G>` by specializing `F := G` and applying `dsimp`.
 
 Use `@[map (attr := simp)]` to mark both the original lemma and `H_map` as `simp` lemmas, and
 `@[reassoc (attr := map)]` to generate `_map` versions of both the original lemma the reassociated
 version.
 -/
 syntax (name := map) "map" optAttrArg : attr
+syntax (name := map_functor) "map_functor" : attr
+
+initialize registerBuiltinAttribute {
+  name := `map_functor
+  descr := "Register a concrete functor for specialized `@[map]` lemmas."
+  applicationTime := .afterTypeChecking
+  add := fun declName stx kind => match stx with
+  | `(attr| map_functor) => do
+    if kind != AttributeKind.global then
+      throwError "`map_functor` can only be used as a global attribute"
+    MetaM.run' do validateMapFunctorDecl declName
+    modifyEnv (mapFunctorExt.addEntry · declName)
+  | _ => throwUnsupportedSyntax }
 
 initialize registerBuiltinAttribute {
   name := `map
@@ -130,6 +215,22 @@ initialize registerBuiltinAttribute {
         let r := (← getMCtx).levelMVarToParam (fun _ => false) (fun _ => false) pf
         let outLevels := tgtLevelNames.toList ++ r.newParamNames.toList
         pure (r.expr, outLevels)
+    for functorName in ← getMapFunctors do
+      let info ← withoutExporting <| getConstInfo src
+      let levelMVars ← info.levelParams.mapM fun _ => mkFreshLevelMVar
+      let value := (Expr.const src (info.levelParams.map mkLevelParam)).instantiateLevelParams
+        info.levelParams levelMVars
+      let F ← mkConstWithFreshMVarLevels functorName
+      if (← mapSpecializedExpr value F).isSome then
+        addRelatedDecl src (specializedMapName src functorName) ref optAttr fun value levels => do
+          Term.TermElabM.run' <| Term.withSynthesize do
+            let levelMVars ← levels.mapM fun _ => mkFreshLevelMVar
+            let value := value.instantiateLevelParams levels levelMVars
+            let F ← mkConstWithFreshMVarLevels functorName
+            let some pf ← mapSpecializedExpr value F
+              | throwError "`@[map]` internal error: specialization disappeared unexpectedly"
+            let r := (← getMCtx).levelMVarToParam (fun _ => false) (fun _ => false) pf
+            pure (r.expr, r.newParamNames.toList)
   | _ => throwUnsupportedSyntax }
 
 /--

--- a/Mathlib/Tactic/CategoryTheory/Map.lean
+++ b/Mathlib/Tactic/CategoryTheory/Map.lean
@@ -12,10 +12,10 @@ public import Mathlib.Util.AddRelatedDecl
 /-!
 # The `map` attribute
 
-Adding `@[map]` to a lemma named `F` of shape `∀ .., f = g`, where `f` and `g` are morphisms
-in some category, creates a new lemma named `F_map` that universally quantifies over every target
-category `D` and every functor `F : C ⥤ D`, states the corresponding `F.map` equality, then applies
-`simp only [Functor.map_comp]` independently to the left- and right-hand sides of that equality.
+Adding `@[map]` to a lemma named `H` of shape `∀ .., f = g`, where `f` and `g` are morphisms
+in some category `C`, creates a new lemma named `H_map` of the form
+`∀ .. {D} (func : C ⥤ D), F.map f = F.map g` and then applies
+`simp only [Functor.map_comp, Functor.map_id]`.
 
 There is also a term elaborator `map_of% t` for use within proofs.
 -/
@@ -27,11 +27,10 @@ open CategoryTheory
 
 namespace Mathlib.Tactic.CategoryTheory.Map
 
-/-- `simp only` with `Functor.map_comp` and other standard `CategoryTheory`
-lemmas on a single expression (used on each side via `simpEq`). -/
+/-- `simp only` with `Functor.map_comp` and `Functor.map_id` on a single expression
+(used on each side via `simpEq`). -/
 def mapCompSimp (e : Expr) : MetaM Simp.Result :=
-  simpOnlyNames [``Functor.map_comp, ``Functor.map_id, ``Category.id_comp, ``Category.comp_id,
-    ``Category.assoc] e (config := { decide := false })
+  simpOnlyNames [``Functor.map_comp, ``Functor.map_id] e (config := { decide := false })
 
 private def extractCatInstanceFromEq (eqTy : Expr) : MetaM (Expr × Expr) := do
   let some (α, _, _) := eqTy.cleanupAnnotations.eq? | throwError "`@[map]` expects an equality"
@@ -60,8 +59,8 @@ def mapExprHomAux (e : Expr) (uLev vLev : Level) : MetaM Expr := do
 
 /--
 For `e : f = g`, build `∀ ⦃D⦄ [Category D] (F : C ⥤ D), …` with
-`simp only [Functor.map_comp]` on each side of `F.map f = F.map g`, using fresh level names `uD`
-(objects) and `vD` (morphisms) for the target category (for `@[map]` declarations).
+`simp only [Functor.map_comp, Functor.map_id]` on each side of `F.map f = F.map g`, using fresh
+level names `uD` (objects) and `vD` (morphisms) for the target category (for `@[map]` declarations).
 -/
 def mapExprHom (e : Expr) (uD vD : Name) : MetaM Expr :=
   mapExprHomAux e (Level.param uD) (Level.param vD)
@@ -102,19 +101,21 @@ def mapExprMVars (pf : Expr) : MetaM Expr := do
 def mapExprElab (pf : Expr) : TermElabM Expr :=
   liftMetaM <| mapExprMVars pf
 
-/--
-Adding `@[map]` to a lemma named `F` of shape `∀ .., f = g`, where `f` and `g` are morphisms in a
-category, generates `F_map`, quantifying over every target category `D` (fresh universes) and every
-functor `F : C ⥤ D`, then `simp only [Functor.map_comp]` on each side of the `F.map` equation.
-
-Use `@[map (attr := simp)]` to mark both the original lemma and `F_map` as `simp` lemmas (see
-`@[reassoc (attr := simp)]`).
-
-If the original declaration is tagged with `to_dual`, then `F_map` gets `@[to_dual none]`. In the
-rare case that only `F_map` should be tagged with `to_dual`, use `@[map +to_dual]`.
--/
 syntax toDualOpt := " +" &"to_dual"
 
+/--
+Adding `@[map]` to a lemma named `H` of shape `∀ .., f = g`, where `f` and `g` are morphisms
+in some category `C`, creates a new lemma named `H_map` of the form
+`∀ .. {D} (F : C ⥤ D), F.map f = F.map g` and then applies
+`simp only [Functor.map_comp, Functor.map_id]`.
+
+Use `@[map (attr := simp)]` to mark both the original lemma and `H_map` as `simp` lemmas, and
+`@[reassoc (attr := map)]` to generate `_map` versions of both the original lemma the reassociated
+version.
+
+If the original declaration is tagged with `to_dual`, then `H_map` gets `@[to_dual none]`. In the
+rare case that only `H_map` should be tagged with `to_dual`, use `@[map +to_dual]`.
+-/
 syntax (name := map) "map" (toDualOpt)? optAttrArg : attr
 
 initialize registerBuiltinAttribute {
@@ -142,8 +143,8 @@ initialize registerBuiltinAttribute {
 
 /--
 `map_of% t`, where `t` is an equality `f = g` between morphisms (possibly under `∀` binders),
-produces the corresponding statement with a functor applied and `simp only [Functor.map_comp]` on
-each side.
+produces the corresponding statement with a functor applied and
+`simp only [Functor.map_comp, Functor.map_id]` on each side.
 -/
 elab "map_of% " t:term : term => do
   let e ← Term.withSynthesizeLight <| Term.elabTerm t none

--- a/Mathlib/Tactic/CategoryTheory/Map.lean
+++ b/Mathlib/Tactic/CategoryTheory/Map.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+module
+
+public import Mathlib.CategoryTheory.Functor.Basic
+public import Mathlib.Lean.Meta.Simp
+public import Mathlib.Util.AddRelatedDecl
+
+/-!
+# The `map` attribute
+
+Adding `@[map]` to a lemma named `F` of shape `∀ .., f = g`, where `f` and `g` are morphisms
+in some category, creates a new lemma named `F_map` that universally quantifies over every target
+category `D` and every functor `F : C ⥤ D`, states the corresponding `F.map` equality, then applies
+`simp only [Functor.map_comp]` independently to the left- and right-hand sides of that equality.
+
+There is also a term elaborator `map_of% t` for use within proofs.
+-/
+
+public meta section
+
+open Lean Meta Elab Tactic
+open CategoryTheory
+
+namespace Mathlib.Tactic.CategoryTheory.Map
+
+/-- `simp only` with `Functor.map_comp` and other standard `CategoryTheory`
+lemmas on a single expression (used on each side via `simpEq`). -/
+def mapCompSimp (e : Expr) : MetaM Simp.Result :=
+  simpOnlyNames [``Functor.map_comp, ``Functor.map_id, ``Category.id_comp, ``Category.comp_id,
+    ``Category.assoc] e (config := { decide := false })
+
+private def extractCatInstanceFromEq (eqTy : Expr) : MetaM (Expr × Expr) := do
+  let some (α, _, _) := eqTy.cleanupAnnotations.eq? | throwError "`@[map]` expects an equality"
+  let (``Quiver.Hom, #[_, instQuiv, _, _]) := α.getAppFnArgs |
+    throwError "`@[map]` expects an equality of morphisms"
+  let (``CategoryTheory.CategoryStruct.toQuiver, #[_, instCS]) := instQuiv.getAppFnArgs |
+    throwError "`@[map]` expects an equality of morphisms"
+  let (``CategoryTheory.Category.toCategoryStruct, #[C, instC]) := instCS.getAppFnArgs |
+    throwError "`@[map]` expects an equality of morphisms"
+  return (C, instC)
+
+/-- Build the functor `map` lemma for `e : f = g` with target category levels `uLev`, `vLev`. -/
+def mapExprHomAux (e : Expr) (uLev vLev : Level) : MetaM Expr := do
+  let eqTy := (← inferType e).cleanupAnnotations
+  let (C, instC) ← extractCatInstanceFromEq eqTy
+  let Dsort := mkSort (Level.succ uLev)
+  withLocalDecl `D .implicit Dsort fun dFVar => do
+    let catD := mkApp (.const ``CategoryTheory.Category [vLev, uLev]) dFVar
+    withLocalDecl `instD .instImplicit catD fun instDFVar => do
+      let Fty ← mkAppOptM ``CategoryTheory.Functor #[C, instC, dFVar, instDFVar]
+      withLocalDecl `F .default Fty fun fFVar => do
+        let pf₀ ← mkAppM ``CategoryTheory.Functor.congr_map #[fFVar, e]
+        let ty ← instantiateMVars (← inferType pf₀)
+        let (_, pf') ← simpEq (fun e' => mapCompSimp e') ty pf₀
+        mkLambdaFVars #[dFVar, instDFVar, fFVar] pf'
+
+/--
+For `e : f = g`, build `∀ ⦃D⦄ [Category D] (F : C ⥤ D), …` with
+`simp only [Functor.map_comp]` on each side of `F.map f = F.map g`, using fresh level names `uD`
+(objects) and `vD` (morphisms) for the target category (for `@[map]` declarations).
+-/
+def mapExprHom (e : Expr) (uD vD : Name) : MetaM Expr :=
+  mapExprHomAux e (Level.param uD) (Level.param vD)
+
+/--
+Given a proof `pf` of `∀ .., f = g` with `f g` morphisms in a category, produce a proof of the
+`map` lemma, quantifying over every target category `D` and every functor `F : C ⥤ D` (using two
+fresh level parameters per generated lemma).
+
+Returns the target category's level names for `levelParams`, after `levelMVarToParam` on the rest.
+-/
+def mapExpr (pf : Expr) : MetaM (Expr × Array Name) := do
+  let uD ← mkFreshUserName `u
+  let vD ← mkFreshUserName `v
+  forallTelescopeReducing (← inferType pf) fun xs _ => do
+    let pfApp := mkAppN pf xs
+    let inner ← mapExprHom pfApp uD vD
+    let full ← mkLambdaFVars xs inner
+    return (full, #[uD, vD])
+
+/-- Version of `mapExpr` for `TermElabM`. -/
+def mapExpr' (pf : Expr) : TermElabM (Expr × Array Name) := do
+  mapExpr pf
+
+/--
+Like `mapExpr`, but uses fresh level metavariables for the target category so that `map_of% t` can
+specialize to any `D` and `F` in context (see `addRelatedDecl` path for rigid universe parameters).
+-/
+def mapExprMVars (pf : Expr) : MetaM Expr := do
+  let uLev ← mkFreshLevelMVar
+  let vLev ← mkFreshLevelMVar
+  forallTelescopeReducing (← inferType pf) fun xs _ => do
+    let pfApp := mkAppN pf xs
+    let inner ← mapExprHomAux pfApp uLev vLev
+    mkLambdaFVars xs inner
+
+/-- `mapExprMVars` lifted to `TermElabM`. -/
+def mapExprElab (pf : Expr) : TermElabM Expr :=
+  liftMetaM <| mapExprMVars pf
+
+/--
+Adding `@[map]` to a lemma named `F` of shape `∀ .., f = g`, where `f` and `g` are morphisms in a
+category, generates `F_map`, quantifying over every target category `D` (fresh universes) and every
+functor `F : C ⥤ D`, then `simp only [Functor.map_comp]` on each side of the `F.map` equation.
+
+Use `@[map (attr := simp)]` to mark both the original lemma and `F_map` as `simp` lemmas (see
+`@[reassoc (attr := simp)]`).
+
+If the original declaration is tagged with `to_dual`, then `F_map` gets `@[to_dual none]`. In the
+rare case that only `F_map` should be tagged with `to_dual`, use `@[map +to_dual]`.
+-/
+syntax toDualOpt := " +" &"to_dual"
+
+syntax (name := map) "map" (toDualOpt)? optAttrArg : attr
+
+initialize registerBuiltinAttribute {
+  name := `map
+  descr := ""
+  applicationTime := .afterCompilation
+  add := fun src ref kind => match ref with
+  | `(attr| map $[$toDual:toDualOpt]? $optAttr) => MetaM.run' do
+    if (kind != AttributeKind.global) then
+      throwError "`map` can only be used as a global attribute"
+    let toDual := toDual.isSome || (Translate.findTranslation? (← getEnv) ToDual.data src).isSome
+    let tgt := src.appendAfter "_map"
+    addRelatedDecl src tgt ref optAttr fun value levels => do
+      Term.TermElabM.run' <| Term.withSynthesize do
+        let levelMVars ← levels.mapM fun _ => mkFreshLevelMVar
+        let value := value.instantiateLevelParams levels levelMVars
+        let (pf, tgtLevelNames) ← mapExpr' value
+        let r := (← getMCtx).levelMVarToParam (fun _ => false) (fun _ => false) pf
+        let outLevels := tgtLevelNames.toList ++ r.newParamNames.toList
+        pure (r.expr, outLevels)
+    if toDual then
+      liftCommandElabM <| Command.elabCommand <| ←
+        `(command| attribute [to_dual none] $(mkIdent tgt))
+  | _ => throwUnsupportedSyntax }
+
+/--
+`map_of% t`, where `t` is an equality `f = g` between morphisms (possibly under `∀` binders),
+produces the corresponding statement with a functor applied and `simp only [Functor.map_comp]` on
+each side.
+-/
+elab "map_of% " t:term : term => do
+  let e ← Term.withSynthesizeLight <| Term.elabTerm t none
+  mapExprElab e
+
+end Mathlib.Tactic.CategoryTheory.Map

--- a/Mathlib/Tactic/CategoryTheory/Map.lean
+++ b/Mathlib/Tactic/CategoryTheory/Map.lean
@@ -101,8 +101,6 @@ def mapExprMVars (pf : Expr) : MetaM Expr := do
 def mapExprElab (pf : Expr) : TermElabM Expr :=
   liftMetaM <| mapExprMVars pf
 
-syntax toDualOpt := " +" &"to_dual"
-
 /--
 Adding `@[map]` to a lemma named `H` of shape `∀ .., f = g`, where `f` and `g` are morphisms
 in some category `C`, creates a new lemma named `H_map` of the form
@@ -112,21 +110,17 @@ in some category `C`, creates a new lemma named `H_map` of the form
 Use `@[map (attr := simp)]` to mark both the original lemma and `H_map` as `simp` lemmas, and
 `@[reassoc (attr := map)]` to generate `_map` versions of both the original lemma the reassociated
 version.
-
-If the original declaration is tagged with `to_dual`, then `H_map` gets `@[to_dual none]`. In the
-rare case that only `H_map` should be tagged with `to_dual`, use `@[map +to_dual]`.
 -/
-syntax (name := map) "map" (toDualOpt)? optAttrArg : attr
+syntax (name := map) "map" optAttrArg : attr
 
 initialize registerBuiltinAttribute {
   name := `map
   descr := ""
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| map $[$toDual:toDualOpt]? $optAttr) => MetaM.run' do
+  | `(attr| map $optAttr) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`map` can only be used as a global attribute"
-    let toDual := toDual.isSome || (Translate.findTranslation? (← getEnv) ToDual.data src).isSome
     let tgt := src.appendAfter "_map"
     addRelatedDecl src tgt ref optAttr fun value levels => do
       Term.TermElabM.run' <| Term.withSynthesize do
@@ -136,9 +130,6 @@ initialize registerBuiltinAttribute {
         let r := (← getMCtx).levelMVarToParam (fun _ => false) (fun _ => false) pf
         let outLevels := tgtLevelNames.toList ++ r.newParamNames.toList
         pure (r.expr, outLevels)
-    if toDual then
-      liftCommandElabM <| Command.elabCommand <| ←
-        `(command| attribute [to_dual none] $(mkIdent tgt))
   | _ => throwUnsupportedSyntax }
 
 /--

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -45,6 +45,16 @@ lemma comp_eq_id {x y : C} (f : x ⟶ y) (g : y ⟶ x) (w : f ≫ g = 𝟙 _) :
 #guard_msgs in
 #check comp_eq_id_map
 
+@[to_dual (attr := map) comp_map_dual]
+lemma comp_map_to_dual {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
+    f ≫ g = h := w
+
+/-- info: Tests.Map.comp_map_dual_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : y ⟶ x)
+  (g : z ⟶ y) (h : z ⟶ x) (w : g ≫ f = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) :
+  F.map g ≫ F.map f = F.map h -/
+#guard_msgs in
+#check comp_map_dual_map
+
 /-!
 `map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp, Functor.map_id]` on each
 side.

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -1,0 +1,32 @@
+module
+
+public import Mathlib.Tactic.CategoryTheory.Map
+
+open CategoryTheory
+
+namespace Tests.Map
+
+universe v₁ v₂ u₁ u₂
+
+variable {C : Type u₁} [Category.{v₁} C]
+
+@[map]
+lemma comp_map {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
+    f ≫ g = h := w
+
+/--
+info: Tests.Map.comp_map_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y) (g : y ⟶ z)
+  (h : x ⟶ z) (w : f ≫ g = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) : F.map f ≫ F.map g = F.map h
+-/
+#guard_msgs in
+#check comp_map_map
+
+/-!
+`map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp]` on each
+side.
+-/
+example {x y z : C} {D : Type u₂} [Category.{v₂} D] (F : C ⥤ D) (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z)
+    (w : f ≫ g = h) : F.map f ≫ F.map g = F.map h := by
+  exact (map_of% w) F
+
+end Tests.Map

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -1,6 +1,7 @@
 module
 
 public import Mathlib.Tactic.CategoryTheory.Map
+public import Mathlib.Tactic.CategoryTheory.Reassoc
 
 open CategoryTheory
 
@@ -10,7 +11,7 @@ universe v₁ v₂ u₁ u₂
 
 variable {C : Type u₁} [Category.{v₁} C]
 
-@[map]
+@[reassoc (attr := map)]
 lemma comp_map {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
     f ≫ g = h := w
 
@@ -20,6 +21,13 @@ info: Tests.Map.comp_map_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_
 -/
 #guard_msgs in
 #check comp_map_map
+
+/--
+info: Tests.Map.comp_map_assoc_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
+  (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) {Z : C} (h✝ : z ⟶ Z) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) :
+  F.map f ≫ F.map g ≫ F.map h✝ = F.map h ≫ F.map h✝-/
+#guard_msgs in
+#check comp_map_assoc_map
 
 /-!
 `map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp]` on each

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -27,14 +27,14 @@ lemma comp_map {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ 
 #check comp_map_assoc_map
 
 @[map (attr := reassoc)]
-lemma comp_map' {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
+lemma comp_map_reassoc {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
     f ≫ g = h := w
 
-/-- info: Tests.Map.comp_map'_map_assoc.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
+/-- info: Tests.Map.comp_map_reassoc_map_assoc.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
   (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) {Z : D}
   (h✝ : F.obj z ⟶ Z) : F.map f ≫ F.map g ≫ h✝ = F.map h ≫ h✝ -/
 #guard_msgs in
-#check comp_map'_map_assoc
+#check comp_map_reassoc_map_assoc
 
 @[map]
 lemma comp_eq_id {x y : C} (f : x ⟶ y) (g : y ⟶ x) (w : f ≫ g = 𝟙 _) :

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -15,22 +15,38 @@ variable {C : Type u₁} [Category.{v₁} C]
 lemma comp_map {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
     f ≫ g = h := w
 
-/--
-info: Tests.Map.comp_map_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y) (g : y ⟶ z)
-  (h : x ⟶ z) (w : f ≫ g = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) : F.map f ≫ F.map g = F.map h
--/
+/-- info: Tests.Map.comp_map_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y) (g : y ⟶ z)
+  (h : x ⟶ z) (w : f ≫ g = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) : F.map f ≫ F.map g = F.map h -/
 #guard_msgs in
 #check comp_map_map
 
-/--
-info: Tests.Map.comp_map_assoc_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
+/-- info: Tests.Map.comp_map_assoc_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
   (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) {Z : C} (h✝ : z ⟶ Z) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) :
-  F.map f ≫ F.map g ≫ F.map h✝ = F.map h ≫ F.map h✝-/
+  F.map f ≫ F.map g ≫ F.map h✝ = F.map h ≫ F.map h✝ -/
 #guard_msgs in
 #check comp_map_assoc_map
 
+@[map (attr := reassoc)]
+lemma comp_map' {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) :
+    f ≫ g = h := w
+
+/-- info: Tests.Map.comp_map'_map_assoc.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y z : C} (f : x ⟶ y)
+  (g : y ⟶ z) (h : x ⟶ z) (w : f ≫ g = h) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) {Z : D}
+  (h✝ : F.obj z ⟶ Z) : F.map f ≫ F.map g ≫ h✝ = F.map h ≫ h✝ -/
+#guard_msgs in
+#check comp_map'_map_assoc
+
+@[map]
+lemma comp_eq_id {x y : C} (f : x ⟶ y) (g : y ⟶ x) (w : f ≫ g = 𝟙 _) :
+    f ≫ g = 𝟙 _ := w
+
+/-- info: Tests.Map.comp_eq_id_map.{u✝, v✝, u_1, u_2} {C : Type u_1} [Category.{u_2, u_1} C] {x y : C} (f : x ⟶ y) (g : y ⟶ x)
+  (w : f ≫ g = 𝟙 x) {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : C ⥤ D) : F.map f ≫ F.map g = 𝟙 (F.obj x) -/
+#guard_msgs in
+#check comp_eq_id_map
+
 /-!
-`map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp]` on each
+`map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp, Functor.map_id]` on each
 side.
 -/
 example {x y z : C} {D : Type u₂} [Category.{v₂} D] (F : C ⥤ D) (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z)

--- a/MathlibTest/CategoryTheory/Map.lean
+++ b/MathlibTest/CategoryTheory/Map.lean
@@ -2,6 +2,7 @@ module
 
 public import Mathlib.Tactic.CategoryTheory.Map
 public import Mathlib.Tactic.CategoryTheory.Reassoc
+public import Mathlib.CategoryTheory.Types.Basic
 
 open CategoryTheory
 
@@ -54,6 +55,22 @@ lemma comp_map_to_dual {x y z : C} (f : x ⟶ y) (g : y ⟶ z) (h : x ⟶ z) (w 
   F.map g ≫ F.map f = F.map h -/
 #guard_msgs in
 #check comp_map_dual_map
+
+@[map_functor] abbrev typesId : Type u₁ ⥤ Type u₁ := 𝟭 (Type u₁)
+
+@[map]
+lemma type_comp {α β γ : Type u₁} (f : α ⟶ β) (g : β ⟶ γ) (h : α ⟶ γ) (w : f ≫ g = h) :
+    f ≫ g = h := w
+
+/-- info: Tests.Map.type_comp_map.{u✝, v✝, u_1} {α β γ : Type u_1} (f : α ⟶ β) (g : β ⟶ γ) (h : α ⟶ γ) (w : f ≫ g = h)
+  {D : Type u✝} [instD : Category.{v✝, u✝} D] (F : Type u_1 ⥤ D) : F.map f ≫ F.map g = F.map h -/
+#guard_msgs in
+#check type_comp_map
+
+/-- info: Tests.Map.type_comp_map_Tests_Map_typesId.{u_1} {α β γ : Type u_1} (f : α ⟶ β) (g : β ⟶ γ) (h : α ⟶ γ) (w : f ≫ g = h) :
+  f ≫ g = h -/
+#guard_msgs in
+#check type_comp_map_Tests_Map_typesId
 
 /-!
 `map_of%` pushes `Functor.map` through an equality and applies `simp only [Functor.map_comp, Functor.map_id]` on each


### PR DESCRIPTION
---

- [ ] depends on: #37183 

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
