### PR TITLE
[Merged by Bors] - feat(Algebra/PresentedMonoid): characterise equality in presented monoids

### DIFF
--- a/Mathlib/Algebra/PresentedMonoid/Basic.lean
+++ b/Mathlib/Algebra/PresentedMonoid/Basic.lean
@@ -91,7 +91,11 @@ protected theorem inductionOn₃ {δ : P₁ → P₂ → P₃ → Prop} (q₁ : 
 
 end inductionOn
 
-variable {α : Type*} {rels : FreeMonoid α → FreeMonoid α → Prop}
+variable {α : Type*} {rels : FreeMonoid α → FreeMonoid α → Prop} {x y : FreeMonoid α}
+
+lemma mk_eq_mk_iff : mk rels x = mk rels y ↔ conGen rels x y := Quotient.eq
+
+lemma mk_eq_mk_of_rel (h : rels x y) : mk rels x = mk rels y := mk_eq_mk_iff.2 (.of _ _ h)
 
 /-- The generators of a presented monoid generate the presented monoid. That is, the submonoid
 closure of the set of generators equals `⊤`. -/
@@ -99,7 +103,7 @@ closure of the set of generators equals `⊤`. -/
 presented additive monoid. That is, the additive submonoid closure of the set of generators equals
 `⊤`. -/]
 theorem closure_range_of (rels : FreeMonoid α → FreeMonoid α → Prop) :
-    Submonoid.closure (Set.range (PresentedMonoid.of rels)) = ⊤ := by
+    Submonoid.closure (Set.range (of rels)) = ⊤ := by
   rw [Submonoid.eq_top_iff']
   intro x
   induction x with | _ a


### PR DESCRIPTION
This PR adds two simple lemmas which describe when the embedding of two words into a presented monoid are equal.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
