### PR TITLE
[Merged by Bors] - feat: characterization of open/closed sets in Scott-Hausdorff topology

### DIFF
--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -217,7 +217,6 @@ theorem isOpen_iff_dirSupInacc [IsScottHausdorff α .univ] : IsOpen s ↔ DirSup
   mpr h := by
     rw [IsScottHausdorff.isOpen_iff (D := .univ)]
     intro t _ ht₀ ht₁ a ha has
-    have := h ht₀ ht₁ ha has
     by_contra! H
     have H : ∀ b : t, ∃ c, b.1 ≤ c ∧ c ∈ t ∧ c ∉ s := by simpa [not_subset, and_assoc] using H
     choose f hf using H

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -215,29 +215,25 @@ variable [PartialOrder α]
 theorem isOpen_iff_dirSupInacc [IsScottHausdorff α .univ] : IsOpen s ↔ DirSupInacc s where
   mp h := dirSupInaccOn_univ.1 <| Topology.IsScottHausdorff.dirSupInaccOn_of_isOpen h
   mpr h := by
-    rw [Topology.IsScottHausdorff.isOpen_iff (D := .univ)]
+    rw [IsScottHausdorff.isOpen_iff (D := .univ)]
     intro t _ ht₀ ht₁ a ha has
     have := h ht₀ ht₁ ha has
-    by_cases ht : a ∈ t
-    · refine ⟨a, ht, fun b ⟨hba, hbt⟩ ↦ ?_⟩
-      obtain rfl := (ha.1 hbt).antisymm hba
-      exact has
-    · by_contra! H
-      have H : ∀ b : t, ∃ c, b.1 ≤ c ∧ c ∈ t ∧ c ∉ s := by simpa [Set.not_subset, and_assoc] using H
-      choose f hf using H
-      have := ht₀.to_subtype
-      have hft : Set.range f ⊆ t := by grind
-      apply (h (Set.range_nonempty f) _ _ has).ne_empty
-      · aesop
-      · intro a ha b hb
-        obtain ⟨c, hc, _, _⟩ := ht₁ _ (hft ha) _ (hft hb)
-        have := hf ⟨c, hc⟩
-        grind
-      · exact ⟨upperBounds_mono_set hft ha.1,
-          fun b hb ↦ ha.2 fun c hc ↦ (hf ⟨c, hc⟩).1.trans (hb <| by simp)⟩
+    by_contra! H
+    have H : ∀ b : t, ∃ c, b.1 ≤ c ∧ c ∈ t ∧ c ∉ s := by simpa [not_subset, and_assoc] using H
+    choose f hf using H
+    have := ht₀.to_subtype
+    have hft : range f ⊆ t := by grind
+    apply (h (range_nonempty f) _ _ has).ne_empty
+    · aesop
+    · intro a ha b hb
+      obtain ⟨c, hc, _, _⟩ := ht₁ _ (hft ha) _ (hft hb)
+      have := hf ⟨c, hc⟩
+      grind
+    · exact ⟨upperBounds_mono_set hft ha.1,
+        fun b hb ↦ ha.2 fun c hc ↦ (hf ⟨c, hc⟩).1.trans (hb <| by simp)⟩
 
 theorem isClosed_iff_dirSupClosed [IsScottHausdorff α .univ] : IsClosed s ↔ DirSupClosed s := by
-  rw [← isOpen_compl_iff, Topology.IsScottHausdorff.isOpen_iff_dirSupInacc, dirSupInacc_compl]
+  rw [← isOpen_compl_iff, isOpen_iff_dirSupInacc, dirSupInacc_compl]
 
 end PartialOrder
 end IsScottHausdorff

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -161,8 +161,6 @@ def scottHausdorff (α : Type*) (D : Set (Set α)) [Preorder α] : TopologicalSp
     obtain ⟨b, hbd, hbds₀⟩ := h s₀ hs₀s hd₀ hd₁ hd₂ hd₃ has₀
     exact ⟨b, hbd, Set.subset_sUnion_of_subset s s₀ hbds₀ hs₀s⟩
 
-section
-
 variable (α) (D : Set (Set α)) [Preorder α] [TopologicalSpace α]
 
 /-- Predicate for an ordered topological space to be equipped with its Scott-Hausdorff topology.
@@ -175,16 +173,12 @@ class IsScottHausdorff : Prop where
 instance : @IsScottHausdorff α D _ (scottHausdorff α D) :=
   @IsScottHausdorff.mk _ _ _ (scottHausdorff α D) rfl
 
-end
-
 namespace IsScottHausdorff
-variable {D : Set (Set α)} [t : TopologicalSpace α] {s : Set α}
+variable {s : Set α}
 
-section Preorder
-variable [Preorder α]
-
-variable (α D) in
 lemma topology_eq [IsScottHausdorff α D] : ‹_› = scottHausdorff α D := topology_eq_scottHausdorff
+
+variable {α D}
 
 lemma isOpen_iff [IsScottHausdorff α D] :
     IsOpen s ↔ ∀ ⦃d : Set α⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a : α⦄, IsLUB d a →
@@ -200,19 +194,7 @@ lemma dirSupClosed_of_isClosed [IsScottHausdorff α univ] (h : IsClosed s) : Dir
   rw [← dirSupInaccOn_univ]
   exact (dirSupInaccOn_of_isOpen h.isOpen_compl)
 
-lemma isOpen_of_isLowerSet [IsScottHausdorff α univ] (h : IsLowerSet s) : IsOpen s :=
-  (isOpen_iff (D := univ)).2 fun _d _ ⟨b, hb⟩ _ _ hda ha ↦
-    ⟨b, hb, fun _ hc ↦ h (mem_upperBounds.1 hda.1 _ hc.2) ha⟩
-
-lemma isClosed_of_isUpperSet [IsScottHausdorff α univ] (h : IsUpperSet s) : IsClosed s :=
-  isOpen_compl_iff.1 <| isOpen_of_isLowerSet h.compl
-
-end Preorder
-
-section PartialOrder
-variable [PartialOrder α] [IsScottHausdorff α .univ]
-
-theorem isOpen_iff_dirSupInacc : IsOpen s ↔ DirSupInacc s where
+theorem isOpen_iff_dirSupInacc [IsScottHausdorff α univ] : IsOpen s ↔ DirSupInacc s where
   mp h := dirSupInaccOn_univ.1 <| Topology.IsScottHausdorff.dirSupInaccOn_of_isOpen h
   mpr h := by
     rw [IsScottHausdorff.isOpen_iff (D := .univ)]
@@ -231,10 +213,24 @@ theorem isOpen_iff_dirSupInacc : IsOpen s ↔ DirSupInacc s where
     · exact ⟨upperBounds_mono_set hft ha.1,
         fun b hb ↦ ha.2 fun c hc ↦ (hf ⟨c, hc⟩).1.trans (hb <| by simp)⟩
 
-theorem isClosed_iff_dirSupClosed : IsClosed s ↔ DirSupClosed s := by
+theorem isClosed_iff_dirSupClosed [IsScottHausdorff α univ] : IsClosed s ↔ DirSupClosed s := by
   rw [← isOpen_compl_iff, isOpen_iff_dirSupInacc, dirSupInacc_compl]
 
-end PartialOrder
+end IsScottHausdorff
+end ScottHausdorff
+
+section ScottHausdorff
+namespace IsScottHausdorff
+
+variable {s : Set α} [Preorder α] {t : TopologicalSpace α} [IsScottHausdorff α univ]
+
+lemma isOpen_of_isLowerSet (h : IsLowerSet s) : IsOpen s :=
+  (isOpen_iff (D := univ)).2 fun _d _ ⟨b, hb⟩ _ _ hda ha ↦
+    ⟨b, hb, fun _ hc ↦ h (mem_upperBounds.1 hda.1 _ hc.2) ha⟩
+
+lemma isClosed_of_isUpperSet (h : IsUpperSet s) : IsClosed s :=
+  isOpen_compl_iff.1 <| isOpen_of_isLowerSet h.compl
+
 end IsScottHausdorff
 end ScottHausdorff
 
@@ -280,7 +276,7 @@ lemma isOpen_iff_isUpperSet_and_dirSupInaccOn [IsScott α D] :
     IsOpen s ↔ IsUpperSet s ∧ DirSupInaccOn D s := by
   rw [isOpen_iff_isUpperSet_and_scottHausdorff_open (D := D)]
   refine and_congr_right fun h ↦
-    ⟨@IsScottHausdorff.dirSupInaccOn_of_isOpen _ _ (scottHausdorff α D) _ _ _,
+    ⟨@IsScottHausdorff.dirSupInaccOn_of_isOpen _ _ _ (scottHausdorff α D) _ _,
       fun h' d d₀ d₁ d₂ _ d₃ ha ↦ ?_⟩
   obtain ⟨b, hbd, hbu⟩ := h' d₀ d₁ d₂ d₃ ha
   exact ⟨b, hbd, Subset.trans inter_subset_left (h.Ici_subset hbu)⟩

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -210,9 +210,9 @@ lemma isClosed_of_isUpperSet [IsScottHausdorff α univ] (h : IsUpperSet s) : IsC
 end Preorder
 
 section PartialOrder
-variable [PartialOrder α]
+variable [PartialOrder α] [IsScottHausdorff α .univ]
 
-theorem isOpen_iff_dirSupInacc [IsScottHausdorff α .univ] : IsOpen s ↔ DirSupInacc s where
+theorem isOpen_iff_dirSupInacc : IsOpen s ↔ DirSupInacc s where
   mp h := dirSupInaccOn_univ.1 <| Topology.IsScottHausdorff.dirSupInaccOn_of_isOpen h
   mpr h := by
     rw [IsScottHausdorff.isOpen_iff (D := .univ)]
@@ -231,7 +231,7 @@ theorem isOpen_iff_dirSupInacc [IsScottHausdorff α .univ] : IsOpen s ↔ DirSup
     · exact ⟨upperBounds_mono_set hft ha.1,
         fun b hb ↦ ha.2 fun c hc ↦ (hf ⟨c, hc⟩).1.trans (hb <| by simp)⟩
 
-theorem isClosed_iff_dirSupClosed [IsScottHausdorff α .univ] : IsClosed s ↔ DirSupClosed s := by
+theorem isClosed_iff_dirSupClosed : IsClosed s ↔ DirSupClosed s := by
   rw [← isOpen_compl_iff, isOpen_iff_dirSupInacc, dirSupInacc_compl]
 
 end PartialOrder

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -161,6 +161,8 @@ def scottHausdorff (α : Type*) (D : Set (Set α)) [Preorder α] : TopologicalSp
     obtain ⟨b, hbd, hbds₀⟩ := h s₀ hs₀s hd₀ hd₁ hd₂ hd₃ has₀
     exact ⟨b, hbd, Set.subset_sUnion_of_subset s s₀ hbds₀ hs₀s⟩
 
+section
+
 variable (α) (D : Set (Set α)) [Preorder α] [TopologicalSpace α]
 
 /-- Predicate for an ordered topological space to be equipped with its Scott-Hausdorff topology.
@@ -173,12 +175,16 @@ class IsScottHausdorff : Prop where
 instance : @IsScottHausdorff α D _ (scottHausdorff α D) :=
   @IsScottHausdorff.mk _ _ _ (scottHausdorff α D) rfl
 
+end
+
 namespace IsScottHausdorff
-variable {s : Set α}
+variable {D : Set (Set α)} [t : TopologicalSpace α] {s : Set α}
 
+section Preorder
+variable [Preorder α]
+
+variable (α D) in
 lemma topology_eq [IsScottHausdorff α D] : ‹_› = scottHausdorff α D := topology_eq_scottHausdorff
-
-variable {α D}
 
 lemma isOpen_iff [IsScottHausdorff α D] :
     IsOpen s ↔ ∀ ⦃d : Set α⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a : α⦄, IsLUB d a →
@@ -194,21 +200,46 @@ lemma dirSupClosed_of_isClosed [IsScottHausdorff α univ] (h : IsClosed s) : Dir
   rw [← dirSupInaccOn_univ]
   exact (dirSupInaccOn_of_isOpen h.isOpen_compl)
 
-end IsScottHausdorff
-end ScottHausdorff
-
-section ScottHausdorff
-namespace IsScottHausdorff
-
-variable {s : Set α} [Preorder α] {t : TopologicalSpace α} [IsScottHausdorff α univ]
-
-lemma isOpen_of_isLowerSet (h : IsLowerSet s) : IsOpen s :=
+lemma isOpen_of_isLowerSet [IsScottHausdorff α univ] (h : IsLowerSet s) : IsOpen s :=
   (isOpen_iff (D := univ)).2 fun _d _ ⟨b, hb⟩ _ _ hda ha ↦
     ⟨b, hb, fun _ hc ↦ h (mem_upperBounds.1 hda.1 _ hc.2) ha⟩
 
-lemma isClosed_of_isUpperSet (h : IsUpperSet s) : IsClosed s :=
+lemma isClosed_of_isUpperSet [IsScottHausdorff α univ] (h : IsUpperSet s) : IsClosed s :=
   isOpen_compl_iff.1 <| isOpen_of_isLowerSet h.compl
 
+end Preorder
+
+section PartialOrder
+variable [PartialOrder α]
+
+theorem isOpen_iff_dirSupInacc [IsScottHausdorff α .univ] : IsOpen s ↔ DirSupInacc s where
+  mp h := dirSupInaccOn_univ.1 <| Topology.IsScottHausdorff.dirSupInaccOn_of_isOpen h
+  mpr h := by
+    rw [Topology.IsScottHausdorff.isOpen_iff (D := .univ)]
+    intro t _ ht₀ ht₁ a ha has
+    have := h ht₀ ht₁ ha has
+    by_cases ht : a ∈ t
+    · refine ⟨a, ht, fun b ⟨hba, hbt⟩ ↦ ?_⟩
+      obtain rfl := (ha.1 hbt).antisymm hba
+      exact has
+    · by_contra! H
+      have H : ∀ b : t, ∃ c, b.1 ≤ c ∧ c ∈ t ∧ c ∉ s := by simpa [Set.not_subset, and_assoc] using H
+      choose f hf using H
+      have := ht₀.to_subtype
+      have hft : Set.range f ⊆ t := by grind
+      apply (h (Set.range_nonempty f) _ _ has).ne_empty
+      · aesop
+      · intro a ha b hb
+        obtain ⟨c, hc, _, _⟩ := ht₁ _ (hft ha) _ (hft hb)
+        have := hf ⟨c, hc⟩
+        grind
+      · exact ⟨upperBounds_mono_set hft ha.1,
+          fun b hb ↦ ha.2 fun c hc ↦ (hf ⟨c, hc⟩).1.trans (hb <| by simp)⟩
+
+theorem isClosed_iff_dirSupClosed [IsScottHausdorff α .univ] : IsClosed s ↔ DirSupClosed s := by
+  rw [← isOpen_compl_iff, Topology.IsScottHausdorff.isOpen_iff_dirSupInacc, dirSupInacc_compl]
+
+end PartialOrder
 end IsScottHausdorff
 end ScottHausdorff
 
@@ -254,7 +285,7 @@ lemma isOpen_iff_isUpperSet_and_dirSupInaccOn [IsScott α D] :
     IsOpen s ↔ IsUpperSet s ∧ DirSupInaccOn D s := by
   rw [isOpen_iff_isUpperSet_and_scottHausdorff_open (D := D)]
   refine and_congr_right fun h ↦
-    ⟨@IsScottHausdorff.dirSupInaccOn_of_isOpen _ _ _ (scottHausdorff α D) _ _,
+    ⟨@IsScottHausdorff.dirSupInaccOn_of_isOpen _ _ (scottHausdorff α D) _ _ _,
       fun h' d d₀ d₁ d₂ _ d₃ ha ↦ ?_⟩
   obtain ⟨b, hbd, hbu⟩ := h' d₀ d₁ d₂ d₃ ha
   exact ⟨b, hbd, Subset.trans inter_subset_left (h.Ici_subset hbu)⟩


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
