### PR TITLE
[Merged by Bors] - feat: `TryThis` suggestion for the `mergeWithGrind` linter

### DIFF
--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -8,6 +8,7 @@ module
 public meta import Mathlib.Tactic.TacticAnalysis
 public meta import Lean.Elab.Command
 public meta import Mathlib.Lean.Elab.InfoTree
+public meta import Lean.Meta.Tactic.TryThis
 public import Mathlib.Tactic.ExtractGoal
 public import Mathlib.Tactic.TacticAnalysis
 public import Mathlib.Util.ParseCommand
@@ -272,7 +273,13 @@ def Mathlib.TacticAnalysis.mergeWithGrind : TacticAnalysis.Config where
           catch _e =>
             pure [goal]
           if goals.isEmpty then
-            logWarningAt preI.tacI.stx m!"'{preI.tacI.stx}; grind' can be replaced with 'grind'"
+            let msg ← addMessageContext m!"'{preI.tacI.stx}; grind' can be replaced with 'grind'"
+            let header := (← msg.toString) ++ "\n\nTry this:"
+            if let some start := preI.tacI.stx.getPos? then
+            if let some stop := postI.tacI.stx.getTailPos? then
+            let synth := Lean.Syntax.setInfo (Lean.SourceInfo.synthetic start stop) preI.tacI.stx
+            Elab.Command.liftCoreM <|
+              Tactic.TryThis.addSuggestion (header := header) synth (← `(tactic | grind))
 
 /-- Suggest replacing a sequence of tactics with `grind` if that also solves the goal. -/
 register_option linter.tacticAnalysis.terminalToGrind : Bool := {

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -128,7 +128,10 @@ example : 1 + 1 = 2 := by
   grind
 
 /--
-warning: 'have : 1 + 1 < 3 := by omega; grind' can be replaced with 'grind'
+info: 'have : 1 + 1 < 3 := by omega; grind' can be replaced with 'grind'
+
+Try this:
+  [apply] grind
 -/
 #guard_msgs in
 example : 1 + 1 = 2 := by
@@ -142,7 +145,11 @@ example : 1 + 1 = 2 := by
 
 set_option linter.unusedTactic false
 
-/-- warning: 'skip; grind' can be replaced with 'grind' -/
+/-- info: 'skip; grind' can be replaced with 'grind'
+
+Try this:
+  [apply] grind
+-/
 #guard_msgs in
 example : 0 = 0 := by
   intros
@@ -157,7 +164,11 @@ set_option linter.unusedTactic true
 -- This is a false positive. Before `convert_to`, there is an mvar for the `DecidableEq` instance
 -- used with `Finset.instInsert` that is not properly handled
 
-/-- warning: 'convert_to Associated (∏ i ∈ insert j s, f i) (∏ i ∈ insert j s, g i); grind' can be replaced with 'grind' -/
+/-- info: 'convert_to Associated (∏ i ∈ insert j s, f i) (∏ i ∈ insert j s, g i); grind' can be replaced with 'grind'
+
+Try this:
+  [apply] grind
+-/
 #guard_msgs in
 theorem Associated.prod' {M : Type*} [CommMonoid M] {ι : Type*} (s : Finset ι) (f : ι → M)
     (g : ι → M) (h : ∀ i, i ∈ s → Associated (f i) (g i)) : Associated (∏ i ∈ s, f i) (∏ i ∈ s, g i) := by


### PR DESCRIPTION
This PR changes the `mergeWithGrind` linter to provide a `TryThis` suggestion. The same message is provided as the currently logged warning, and should still be processed properly by `zulip_build_report.sh` during the weekly linting, just under `info` instead of `warning`.

The motivation here (discussed in [#general > automatically apply code actions](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/automatically.20apply.20code.20actions/with/581065286)) is that following #36712 we should be able to partially automate the weekly linting PRs using Skimmer. As an example, the changes in #37018 were prepared in part in this way.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
