### PR TITLE
[Merged by Bors] - doc(Topology): avoid lazy continuation lines

### DIFF
--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -30,11 +30,11 @@ compact, then `Πʳ i, [R i, A i]` is a locally compact topological ring.
 
 The topology on the restricted product `Πʳ i, [R i, A i]_[𝓕]` is defined in the following way:
 1. If `𝓕` is some principal filter `𝓟 s`, recall that `Πʳ i, [R i, A i]_[𝓟 s]` is canonically
-identified with `(Π i ∈ s, A i) × (Π i ∉ s, R i)`. We endow it with the product topology,
-which is also the topology induced from the full product `Π i, R i`.
+   identified with `(Π i ∈ s, A i) × (Π i ∉ s, R i)`. We endow it with the product topology,
+   which is also the topology induced from the full product `Π i, R i`.
 2. In general, we note that `𝓕` is the infimum of the principal filters coarser than `𝓕`. We
-then endow `Πʳ i, [R i, A i]_[𝓕]` with the inductive limit / final topology associated to the
-inclusion maps `Πʳ i, [R i, A i]_[𝓟 s] → Πʳ i, [R i, A i]_[𝓕]` where `𝓕 ≤ 𝓟 s`.
+   then endow `Πʳ i, [R i, A i]_[𝓕]` with the inductive limit / final topology associated to the
+   inclusion maps `Πʳ i, [R i, A i]_[𝓟 s] → Πʳ i, [R i, A i]_[𝓕]` where `𝓕 ≤ 𝓟 s`.
 
 In particular:
 * On the classical restricted product, with respect to the cofinite filter, this corresponds to
@@ -110,11 +110,11 @@ section Topology
 
 The topology on the restricted product `Πʳ i, [R i, A i]_[𝓕]` is defined in the following way:
 1. If `𝓕` is some principal filter `𝓟 s`, recall that `Πʳ i, [R i, A i]_[𝓟 s]` is canonically
-identified with `(Π i ∈ s, A i) × (Π i ∉ s, R i)`. We endow it with the product topology,
-which is also the topology induced from the full product `Π i, R i`.
+   identified with `(Π i ∈ s, A i) × (Π i ∉ s, R i)`. We endow it with the product topology,
+   which is also the topology induced from the full product `Π i, R i`.
 2. In general, we note that `𝓕` is the infimum of the principal filters coarser than `𝓕`. We
-then endow `Πʳ i, [R i, A i]_[𝓕]` with the inductive limit / final topology associated to the
-inclusion maps `Πʳ i, [R i, A i]_[𝓟 s] → Πʳ i, [R i, A i]_[𝓕]` where `𝓕 ≤ 𝓟 s`.
+   then endow `Πʳ i, [R i, A i]_[𝓕]` with the inductive limit / final topology associated to the
+   inclusion maps `Πʳ i, [R i, A i]_[𝓟 s] → Πʳ i, [R i, A i]_[𝓕]` where `𝓕 ≤ 𝓟 s`.
 
 In particular:
 * On the classical restricted product, with respect to the cofinite filter, this corresponds to

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -19,6 +19,7 @@ public import Mathlib.Data.Set.Constructions
 Recall that, given a monad `M` on `Type*`, an *algebra* for `M` consists of the following data:
 - A type `X : Type*`
 - A "structure" map `M X → X`.
+
 This data must also satisfy a distributivity and unit axiom, and algebras for `M` form a category
 in an evident way.
 

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -72,6 +72,7 @@ namespace TopCat
   limits library easier.)
 4. An open embedding `f i j : V i j ⟶ U i` for each `i j : ι`.
 5. A transition map `t i j : V i j ⟶ V j i` for each `i j : ι`.
+
 such that
 6. `f i i` is an isomorphism.
 7. `t i i` is the identity.
@@ -270,6 +271,7 @@ theorem ι_isOpenEmbedding (i : D.J) : IsOpenEmbedding (𝖣.ι i) :=
 2. A bundled topological space `U i` for each `i : J`.
 3. An open set `V i j ⊆ U i` for each `i j : J`.
 4. A transition map `t i j : V i j ⟶ V j i` for each `i j : ι`.
+
 such that
 6. `V i i = U i`.
 7. `t i i` is the identity.

--- a/Mathlib/Topology/Sheaves/Abelian.lean
+++ b/Mathlib/Topology/Sheaves/Abelian.lean
@@ -18,7 +18,7 @@ We provide instances for categories of sheaves over Abelian categories.
 ## Main Results
 
 * `TopCat.Sheaf.exact_iff_stalkFunctor_map_exact`: A complex of sheaves over a concrete abelian
-category is exact if and only if it is exact on stalks.
+  category is exact if and only if it is exact on stalks.
 
 -/
 

--- a/Mathlib/Topology/Sheaves/Points.lean
+++ b/Mathlib/Topology/Sheaves/Points.lean
@@ -18,7 +18,7 @@ attached to `X`.
 ## TODO
 
 * Redefine the stalks functors in `Mathlib/Topology/Sheaves/Stalks.lean`
-using `GrothendieckTopology.Point.presheafFiber`.
+  using `GrothendieckTopology.Point.presheafFiber`.
 
 -/
 

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -20,6 +20,7 @@ We define
 * Given `{X Y : TopCat.{w}}` and `f : X ⟶ Y`, we define
   `TopCat.Presheaf.pushforward C f : X.Presheaf C ⥤ Y.Presheaf C`,
   with notation `f _* ℱ` for `ℱ : X.Presheaf C`.
+
 and for `ℱ : X.Presheaf C` provide the natural isomorphisms
 * `TopCat.Presheaf.Pushforward.id : (𝟙 X) _* ℱ ≅ ℱ`
 * `TopCat.Presheaf.Pushforward.comp : (f ≫ g) _* ℱ ≅ g _* (f _* ℱ)`

--- a/Mathlib/Topology/Sheaves/SheafOfFunctions.lean
+++ b/Mathlib/Topology/Sheaves/SheafOfFunctions.lean
@@ -17,6 +17,7 @@ We show that
 
 For
 * `Top.sheafToTop`: continuous functions into a topological space form a sheaf
+
 please see `Mathlib/Topology/Sheaves/LocalPredicate.lean`, where we set up a general framework
 for constructing sub(pre)sheaves of the sheaf of dependent functions.
 


### PR DESCRIPTION
We resolve the ambiguity inherent in lazy (un-indented) list item continuation lines by either indenting them or separating them by inserting a newline in the cases where the item continuation was a mistake.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
