### PR TITLE
feat(Algebra): add multivariate Laurent polynomials

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -842,6 +842,7 @@ public import Mathlib.Algebra.MonoidAlgebra.NoZeroDivisors
 public import Mathlib.Algebra.MonoidAlgebra.Opposite
 public import Mathlib.Algebra.MonoidAlgebra.Support
 public import Mathlib.Algebra.MonoidAlgebra.ToDirectSum
+public import Mathlib.Algebra.MvLaurentPolynomial.Basic
 public import Mathlib.Algebra.MvPolynomial.Basic
 public import Mathlib.Algebra.MvPolynomial.Cardinal
 public import Mathlib.Algebra.MvPolynomial.Comap

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -5,258 +5,206 @@ Authors: Yuma Mizuno
 -/
 module
 
+public import Mathlib.Algebra.MonoidAlgebra.Basic
+public import Mathlib.Algebra.MonoidAlgebra.Support
 public import Mathlib.Algebra.MvPolynomial.Basic
+public import Mathlib.LinearAlgebra.Basis.Defs
+public import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
-# Multivariate Laurent polynomials
+# Laurent monomials relative to a basis
 
-This file defines `MvLaurentPolynomial σ R`, the type of multivariate Laurent polynomials
-with coefficients in a commutative semiring `R` and variables indexed by `σ`.
+This file develops a basis-parametric Laurent-monomial API on `AddMonoidAlgebra R M`, where
+`M` is an additive abelian group equipped with a chosen basis `v : Basis σ ℤ M`. In this setting,
+`AddMonoidAlgebra R M` can be thought of as the algebra of multivariate Laurent polynomials whose
+variables are indexed by `σ`.
 
-The exponent vectors live in `σ →₀ ℤ`, so negative exponents are allowed.
-The implementation is `AddMonoidAlgebra R (σ →₀ ℤ)`.
+## Important definitions
 
-## Definitions
-
-Let `R` be a commutative semiring and let `σ` be an arbitrary type.
-
-* `MvLaurentPolynomial σ R` : the type of multivariate Laurent polynomials in variables indexed by
-  `σ` and coefficients in `R`
-* `MvLaurentPolynomial.monomial d r` : the Laurent monomial with exponent vector `d` and
-  coefficient `r`
-* `MvLaurentPolynomial.C r` : the constant Laurent polynomial with value `r`
-* `MvLaurentPolynomial.X n` : the Laurent monomial corresponding to the variable `n`
-* `MvLaurentPolynomial.coeff d p` : the coefficient of the monomial `d` in `p`
+* `MvLaurentPolynomial.monomial v d r` : the Laurent monomial with exponent vector `d` and
+  coefficient `r` with respect to the basis `v`
+* `MvLaurentPolynomial.X v n` : the Laurent monomial corresponding to the variable `n` with respect
+  to the basis `v`
+* `MvLaurentPolynomial.basisAlgEquiv v` : the algebra equivalence from `AddMonoidAlgebra R M` to
+  the coordinate Laurent model `AddMonoidAlgebra R (σ →₀ ℤ)` induced by `v`
 * `MvPolynomial.toMvLaurent` : the natural inclusion from multivariate polynomials to
-  multivariate Laurent polynomials
+  Laurent monomials written in the basis `v`
 
 -/
 
 @[expose] public section
 
-open Function Finsupp AddMonoidAlgebra
+open Function AddMonoidAlgebra Module
 
 noncomputable section
 
-variable {R : Type*} {S : Type*} {σ : Type*}
-
-/-- Multivariate Laurent polynomials over `R` in variables indexed by `σ`. -/
-abbrev MvLaurentPolynomial (σ : Type*) (R : Type*) [CommSemiring R] :=
-  AddMonoidAlgebra R (σ →₀ ℤ)
+variable {R : Type*} {S : Type*} {σ : Type*} {M : Type*}
 
 namespace MvLaurentPolynomial
 
 section CommSemiring
 
-variable [CommSemiring R] [CommSemiring S] {p q : MvLaurentPolynomial σ R}
+variable [CommSemiring R] [AddCommGroup M] {p q : AddMonoidAlgebra R M}
 
-/-- The coefficient of the monomial `d` in the multivariate Laurent polynomial `p`. -/
-def coeff (d : σ →₀ ℤ) (p : MvLaurentPolynomial σ R) : R :=
-  p d
+/-- The Laurent monomial with exponent vector `d`, expressed in the basis `v`. -/
+def monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) : R →ₗ[R] AddMonoidAlgebra R M :=
+  AddMonoidAlgebra.lsingle (v.repr.symm d)
 
-/-- `monomial d r` is the Laurent monomial with coefficient `r` and exponent vector `d`. -/
-def monomial (d : σ →₀ ℤ) : R →ₗ[R] MvLaurentPolynomial σ R :=
-  AddMonoidAlgebra.lsingle d
+theorem one_def (v : Basis σ ℤ M) : (1 : AddMonoidAlgebra R M) = monomial v 0 1 := by
+  simp [monomial, AddMonoidAlgebra.one_def]
 
-theorem one_def : (1 : MvLaurentPolynomial σ R) = monomial 0 1 :=
+theorem single_eq_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
+    (AddMonoidAlgebra.single (v.repr.symm d) r : AddMonoidAlgebra R M) = monomial v d r :=
   rfl
 
-theorem single_eq_monomial (d : σ →₀ ℤ) (r : R) :
-    (Finsupp.single d r : MvLaurentPolynomial σ R) = monomial d r :=
+theorem mul_def (v : Basis σ ℤ M) :
+    p * q = p.sum fun d r ↦ q.sum fun e s ↦ monomial v (v.repr d + v.repr e) (r * s) := by
+  simp [AddMonoidAlgebra.mul_def, monomial]
+
+/-- The Laurent variable corresponding to the basis vector indexed by `i`. -/
+abbrev X (v : σ → M) (i : σ) : AddMonoidAlgebra R M := AddMonoidAlgebra.single (v i) (1 : R)
+
+theorem X_eq_monomial (v : Basis σ ℤ M) (i : σ) : X v i = monomial v (Finsupp.single i 1) (1 : R) :=
   rfl
 
-theorem mul_def : p * q = p.sum fun d r ↦ q.sum fun e s ↦ monomial (d + e) (r * s) :=
-  AddMonoidAlgebra.mul_def ..
-
-/-- `X n` is the Laurent monomial with exponent vector `Finsupp.single n 1`. -/
-def X (n : σ) : MvLaurentPolynomial σ R :=
-  monomial (Finsupp.single n 1) 1
-
-theorem monomial_left_injective {r : R} (hr : r ≠ 0) :
-    Function.Injective fun d : σ →₀ ℤ ↦ monomial d r :=
-  Finsupp.single_left_injective hr
+theorem monomial_left_injective (v : Basis σ ℤ M) {r : R} (hr : r ≠ 0) :
+    Function.Injective fun d : σ →₀ ℤ => monomial v d r := by
+  intro d e h
+  exact v.repr.symm.injective (Finsupp.single_left_injective hr h)
 
 @[simp]
-theorem monomial_left_inj {d e : σ →₀ ℤ} {r : R} (hr : r ≠ 0) :
-    monomial d r = monomial e r ↔ d = e :=
-  Finsupp.single_left_inj hr
+theorem monomial_left_inj (v : Basis σ ℤ M) {d e : σ →₀ ℤ} {r : R} (hr : r ≠ 0) :
+    monomial v d r = monomial v e r ↔ d = e :=
+  (monomial_left_injective v hr).eq_iff
 
-theorem smul_monomial {T : Type*} [SMulZeroClass T R] (t : T) (d : σ →₀ ℤ) (r : R) :
-    t • monomial d r = monomial d (t • r) :=
-  Finsupp.smul_single _ _ _
+theorem smul_monomial {T : Type*} [SMulZeroClass T R] (t : T) (v : Basis σ ℤ M)
+    (d : σ →₀ ℤ) (r : R) : t • monomial v d r = monomial v d (t • r) := by
+  simp [monomial]
 
-theorem X_injective [Nontrivial R] : Function.Injective (X : σ → MvLaurentPolynomial σ R) :=
-  (monomial_left_injective one_ne_zero).comp (Finsupp.single_left_injective one_ne_zero)
-
-@[simp]
-theorem X_inj [Nontrivial R] (m n : σ) : X m = (X n : MvLaurentPolynomial σ R) ↔ m = n :=
-  X_injective.eq_iff
-
-theorem monomial_pow (d : σ →₀ ℤ) (r : R) (n : ℕ) :
-    monomial d r ^ n = monomial (n • d) (r ^ n) :=
-  AddMonoidAlgebra.single_pow ..
-
-theorem X_pow_eq_monomial (n : σ) (e : ℕ) :
-    X n ^ e = monomial (Finsupp.single n (e : ℤ)) (1 : R) := by
-  simp [X, monomial_pow]
+theorem X_injective (v : Basis σ ℤ M) [Nontrivial R] :
+    Function.Injective (X v : σ → AddMonoidAlgebra R M) :=
+  (monomial_left_injective v one_ne_zero).comp (Finsupp.single_left_injective (one_ne_zero))
 
 @[simp]
-theorem monomial_mul {d e : σ →₀ ℤ} {r s : R} :
-    monomial d r * monomial e s = monomial (d + e) (r * s) :=
-  AddMonoidAlgebra.single_mul_single ..
+theorem X_inj (v : Basis σ ℤ M) [Nontrivial R] {i j : σ} :
+    X v i = (X v j : AddMonoidAlgebra R M) ↔ i = j := by
+  constructor
+  · intro h
+    exact X_injective v h
+  · intro h
+    simp [h]
 
-theorem monomial_add_single (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
-    monomial (d + Finsupp.single n (e : ℤ)) r = monomial d r * X n ^ e := by
+theorem monomial_pow (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) (n : ℕ) :
+    monomial v d r ^ n = monomial v (n • d) (r ^ n) := by
+  simp only [monomial, Basis.repr_symm_apply, lsingle_apply, single_pow,
+    LinearMap.map_smul_of_tower]
+
+theorem X_pow_eq_monomial (v : Basis σ ℤ M) (i : σ) (e : ℕ) :
+    X v i ^ e = monomial v (Finsupp.single i (e : ℤ)) (1 : R) := by
+  simp only [X, single_pow, one_pow]
+  simp [monomial]
+
+@[simp]
+theorem monomial_mul (v : Basis σ ℤ M) {d e : σ →₀ ℤ} {r s : R} :
+    monomial v d r * monomial v e s = monomial v (d + e) (r * s) := by
+  simp [monomial, AddMonoidAlgebra.single_mul_single]
+
+@[simp]
+theorem monomial_mul_monomial_neg (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
+    monomial v d (1 : R) * monomial v (-d) 1 = 1 := by
+  rw [monomial_mul, add_neg_cancel, one_mul, ← one_def v]
+
+@[simp]
+theorem monomial_neg_mul_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
+    monomial v (-d) (1 : R) * monomial v d 1 = 1 := by
+  rw [mul_comm, monomial_mul_monomial_neg]
+
+theorem isUnit_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
+    IsUnit (monomial v d (1 : R) : AddMonoidAlgebra R M) := by
+  refine ⟨⟨monomial v d 1, monomial v (-d) 1, monomial_mul_monomial_neg v d,
+      monomial_neg_mul_monomial v d⟩, rfl⟩
+
+theorem monomial_add_single (v : Basis σ ℤ M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
+    monomial v (d + Finsupp.single i (e : ℤ)) r = monomial v d r * X v i ^ e := by
   rw [X_pow_eq_monomial, monomial_mul, mul_one]
 
-theorem monomial_single_add (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
-    monomial (Finsupp.single n (e : ℤ) + d) r = X n ^ e * monomial d r := by
+theorem monomial_single_add (v : Basis σ ℤ M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
+    monomial v (Finsupp.single i (e : ℤ) + d) r = X v i ^ e * monomial v d r := by
   rw [X_pow_eq_monomial, monomial_mul, one_mul]
 
 @[simp]
-theorem monomial_zero {d : σ →₀ ℤ} : monomial d (0 : R) = 0 :=
-  Finsupp.single_zero _
+theorem monomial_zero (v : Basis σ ℤ M) {d : σ →₀ ℤ} : monomial v d (0 : R) = 0 := by
+  rw [monomial, AddMonoidAlgebra.lsingle_apply]
+  exact Finsupp.single_eq_zero.2 rfl
 
 @[simp]
-theorem monomial_eq_zero {d : σ →₀ ℤ} {r : R} : monomial d r = 0 ↔ r = 0 :=
-  Finsupp.single_eq_zero
-
-theorem isUnit_monomial (d : σ →₀ ℤ) : IsUnit (monomial d (1 : R) : MvLaurentPolynomial σ R) :=
-  ⟨⟨monomial d 1, monomial (-d) 1, by sorry, by sorry⟩, rfl⟩
+theorem monomial_eq_zero (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R} :
+    monomial v d r = 0 ↔ r = 0 := by
+  simp [monomial]
 
 @[simp]
-theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] {d : σ →₀ ℤ} {r : R}
-    {f : (σ →₀ ℤ) → R → A} (h0 : f d 0 = 0) :
-    sum (monomial d r) f = f d r :=
-  Finsupp.sum_single_index h0
+theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R}
+    {f : M → R → A} (h0 : f (v.repr.symm d) 0 = 0) :
+    (monomial v d r).sum f = f (v.repr.symm d) r := by
+  simpa [monomial] using (Finsupp.sum_single_index h0 : _)
 
-theorem support_monomial {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
-    (monomial d r : MvLaurentPolynomial σ R).support = if r = 0 then ∅ else {d} := by
+theorem support_monomial (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
+    (monomial v d r : AddMonoidAlgebra R M).support = if r = 0 then ∅ else {v.repr.symm d} := by
   by_cases hr : r = 0
   · simp [monomial, hr]
-  · simpa [monomial, hr] using (Finsupp.support_single_ne_zero d hr)
+  · simpa [monomial, hr] using Finsupp.support_single_ne_zero (v.repr.symm d) hr
 
-theorem support_monomial_subset (d : σ →₀ ℤ) (r : R) :
-    (monomial d r : MvLaurentPolynomial σ R).support ⊆ {d} := by
-  by_cases hr : r = 0
-  · subst r
-    intro e he
-    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by simpa using he
-    exact (h0 rfl).elim
-  · classical
-    simp [support_monomial, hr]
-
-@[simp]
-theorem coeff_zero (d : σ →₀ ℤ) : coeff d (0 : MvLaurentPolynomial σ R) = 0 :=
-  rfl
-
-@[simp]
-theorem coeff_monomial (d e : σ →₀ ℤ) [Decidable (e = d)] (r : R) :
-    coeff d (monomial e r : MvLaurentPolynomial σ R) = if e = d then r else 0 := by
-  rw [coeff, monomial, AddMonoidAlgebra.lsingle_apply, Finsupp.single_apply]
-
-theorem coeff_X' (n : σ) (d : σ →₀ ℤ) [Decidable (Finsupp.single n 1 = d)] :
-    coeff d (X n : MvLaurentPolynomial σ R) = if Finsupp.single n 1 = d then 1 else 0 := by
-  rw [X, coeff_monomial]
-
-@[simp]
-theorem coeff_X (n : σ) :
-    coeff (Finsupp.single n 1) (X n : MvLaurentPolynomial σ R) = 1 := by
+theorem support_monomial_subset (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
+    (monomial v d r : AddMonoidAlgebra R M).support ⊆ {v.repr.symm d} := by
   classical
-  simp [coeff_X']
+  by_cases hr : r = 0
+  · simp [monomial, hr]
+  · simp [support_monomial v, hr]
 
 @[simp]
-theorem coeff_mul_monomial (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
-    coeff (m + s) (p * monomial s r) = coeff m p * r :=
-  AddMonoidAlgebra.mul_single_apply_aux fun _ _ ↦ add_left_inj _
-
-@[simp]
-theorem coeff_monomial_mul (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
-    coeff (s + m) (monomial s r * p) = r * coeff m p :=
-  AddMonoidAlgebra.single_mul_apply_aux fun _ _ ↦ add_right_inj _
-
-theorem coeff_mul_monomial' (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
-    coeff m (p * monomial s r) = coeff (m - s) p * r := by
-  simpa [sub_eq_add_neg, add_assoc] using coeff_mul_monomial (m - s) s r p
-
-theorem coeff_monomial_mul' (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
-    coeff m (monomial s r * p) = r * coeff (m - s) p := by
-  simpa [sub_eq_add_neg, add_assoc] using coeff_monomial_mul (m - s) s r p
-
-@[simp]
-theorem mem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
-    d ∈ p.support ↔ p.coeff d ≠ 0 := by
-  simp [coeff]
-
-theorem notMem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
-    d ∉ p.support ↔ p.coeff d = 0 := by
-  simp [coeff]
-
-@[simp]
-theorem support_zero : (0 : MvLaurentPolynomial σ R).support = ∅ :=
-  rfl
-
-@[simp]
-theorem support_eq_empty {p : MvLaurentPolynomial σ R} : p.support = ∅ ↔ p = 0 :=
-  Finsupp.support_eq_empty
-
-@[simp]
-theorem support_X [Nontrivial R] (n : σ) :
-    (X n : MvLaurentPolynomial σ R).support = {Finsupp.single n 1} :=
-  Finsupp.support_single_ne_zero _ one_ne_zero
-
-theorem eq_zero_iff {p : MvLaurentPolynomial σ R} : p = 0 ↔ ∀ d, coeff d p = 0 := by
-  constructor
-  · intro hp d
-    subst hp
-    exact coeff_zero d
-  · intro hp
-    ext d
-    simpa using hp d
-
-theorem ne_zero_iff {p : MvLaurentPolynomial σ R} : p ≠ 0 ↔ ∃ d, coeff d p ≠ 0 := by
-  rw [Ne, eq_zero_iff]
-  push_neg
-  rfl
-
-@[simp]
-theorem support_nonempty {p : MvLaurentPolynomial σ R} : p.support.Nonempty ↔ p ≠ 0 := by
-  rw [Finset.nonempty_iff_ne_empty, ne_eq, support_eq_empty]
-
-theorem exists_coeff_ne_zero {p : MvLaurentPolynomial σ R} (hp : p ≠ 0) :
-    ∃ d, coeff d p ≠ 0 :=
-  ne_zero_iff.mp hp
-
-@[simp]
-theorem X_ne_zero [Nontrivial R] (n : σ) :
-    X n ≠ (0 : MvLaurentPolynomial σ R) := by
-  rw [ne_zero_iff]
-  exact ⟨Finsupp.single n 1, by simp⟩
+theorem X_ne_zero (v : Basis σ ℤ M) [Nontrivial R] (i : σ) :
+    X v i ≠ (0 : AddMonoidAlgebra R M) :=
+  (monomial_eq_zero v).not.2 one_ne_zero
 
 section AsSum
 
 @[simp]
-theorem support_sum_monomial_coeff (p : MvLaurentPolynomial σ R) :
-    (∑ d ∈ p.support, monomial d (coeff d p)) = p :=
-  Finsupp.sum_single p
+theorem support_sum_monomial_coeff (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) :
+    (∑ m ∈ p.support, monomial v (v.repr m) (p m)) = p := by
+  simpa [Finsupp.sum, monomial] using (Finsupp.sum_single p)
 
-theorem as_sum (p : MvLaurentPolynomial σ R) :
-    p = ∑ d ∈ p.support, monomial d (coeff d p) :=
-  (support_sum_monomial_coeff p).symm
+theorem as_sum (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) :
+    p = ∑ m ∈ p.support, monomial v (v.repr m) (p m) :=
+  (support_sum_monomial_coeff v p).symm
 
 end AsSum
 
-/-- To prove something about multivariate Laurent polynomials, it suffices to prove it for
+/-- To prove something about Laurent monomials relative to `v`, it suffices to prove it for
 monomials and to show that it is preserved by addition. -/
 @[elab_as_elim]
-theorem induction_on' {P : MvLaurentPolynomial σ R → Prop} (p : MvLaurentPolynomial σ R)
-    (monomial : ∀ (d : σ →₀ ℤ) (r : R), P (MvLaurentPolynomial.monomial d r))
-    (add : ∀ p q : MvLaurentPolynomial σ R, P p → P q → P (p + q)) : P p :=
-  Finsupp.induction p
-    (suffices P (MvLaurentPolynomial.monomial 0 0) by
-      rwa [monomial_zero] at this
-    show P (MvLaurentPolynomial.monomial 0 0) from monomial 0 0)
-    fun _ _ _ _ha _hb hp ↦ add _ _ (monomial _ _) hp
+theorem induction_on' (v : Basis σ ℤ M) {P : AddMonoidAlgebra R M → Prop} (p : AddMonoidAlgebra R M)
+    (hmonomial : ∀ (d : σ →₀ ℤ) (r : R), P (monomial v d r))
+    (hadd : ∀ p q : AddMonoidAlgebra R M, P p → P q → P (p + q)) : P p := by
+  refine Finsupp.induction p ?_ ?_
+  · simpa [monomial] using hmonomial 0 0
+  · intro m r p _ _ hp
+    simpa [monomial] using hadd (monomial v (v.repr m) r) p (hmonomial (v.repr m) r) hp
+
+/-- The algebra equivalence to the coordinate Laurent model induced by the basis `v`. -/
+def basisAlgEquiv (v : Basis σ ℤ M) :
+    AddMonoidAlgebra R M ≃ₐ[R] AddMonoidAlgebra R (σ →₀ ℤ) :=
+  AddMonoidAlgebra.domCongr R R v.repr.toAddEquiv
+
+@[simp]
+theorem basisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
+    basisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
+  ext e
+  simp [basisAlgEquiv, monomial]
+
+@[simp]
+theorem basisAlgEquiv_apply (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) (d : σ →₀ ℤ) :
+    basisAlgEquiv v p d = p (v.repr.symm d) := by
+  simp [basisAlgEquiv]
 
 end CommSemiring
 
@@ -266,49 +214,57 @@ namespace MvPolynomial
 
 section CommSemiring
 
-variable [CommSemiring R]
+variable [CommSemiring R] [AddCommGroup M]
 
-/-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials. -/
-def toMvLaurent : MvPolynomial σ R →+* MvLaurentPolynomial σ R :=
-  AddMonoidAlgebra.mapDomainRingHom R <| Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)
-
-/-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials as an
-`R`-algebra homomorphism. -/
-def toMvLaurentAlg : MvPolynomial σ R →ₐ[R] MvLaurentPolynomial σ R :=
-  AddMonoidAlgebra.mapDomainAlgHom R R <| Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)
+/-- The natural inclusion from multivariate polynomials to Laurent monomials written in the basis
+`v`. -/
+def toMvLaurent (v : Basis σ ℤ M) : MvPolynomial σ R →ₐ[R] AddMonoidAlgebra R M :=
+  (MvLaurentPolynomial.basisAlgEquiv v).symm.toAlgHom.comp
+    (AddMonoidAlgebra.mapDomainAlgHom R R
+      (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)))
 
 @[simp]
-theorem coe_toMvLaurentAlg :
-    ((toMvLaurentAlg : MvPolynomial σ R →ₐ[R] MvLaurentPolynomial σ R) :
-      MvPolynomial σ R → MvLaurentPolynomial σ R) = toMvLaurent :=
+theorem basisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
+    MvLaurentPolynomial.basisAlgEquiv v (p.toMvLaurent v) =
+      (AddMonoidAlgebra.mapDomainAlgHom R R
+        (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ))) p := by
+  simp only [toMvLaurent, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe, comp_apply,
+    AlgEquiv.apply_symm_apply, mapDomainAlgHom_apply]
   rfl
 
-theorem toMvLaurentAlg_apply (p : MvPolynomial σ R) : toMvLaurentAlg p = toMvLaurent p :=
-  rfl
+@[simp]
+theorem toMvLaurent_monomial (v : Basis σ ℤ M) (d : σ →₀ ℕ) (r : R) :
+    (MvPolynomial.monomial d r).toMvLaurent v =
+      MvLaurentPolynomial.monomial v (d.mapRange Int.ofNat (by simp)) r := by
+  apply (MvLaurentPolynomial.basisAlgEquiv v).injective
+  simp only [basisAlgEquiv_toMvLaurent, mapDomainAlgHom_apply,
+    MvLaurentPolynomial.basisAlgEquiv_monomial]
+  apply mapDomain_single
 
 @[simp]
-theorem toMvLaurent_monomial (d : σ →₀ ℕ) (r : R) :
-    toMvLaurent (monomial d r) = MvLaurentPolynomial.monomial (d.mapRange Int.ofNat (by simp)) r :=
-  AddMonoidAlgebra.mapDomain_single
+theorem toMvLaurent_X (v : Basis σ ℤ M) (i : σ) :
+    (MvPolynomial.X i : MvPolynomial σ R).toMvLaurent v = MvLaurentPolynomial.X v i := by
+  simp only [X, toMvLaurent_monomial, Finsupp.mapRange_single, Int.ofNat_eq_natCast, Nat.cast_one,
+    MvLaurentPolynomial.X_eq_monomial]
 
-@[simp]
-theorem toMvLaurent_X (n : σ) :
-    toMvLaurent (X n : MvPolynomial σ R) = MvLaurentPolynomial.X n := by
-  simp [MvPolynomial.X, MvLaurentPolynomial.X, toMvLaurent_monomial]
-
-theorem toMvLaurent_injective :
-    Function.Injective (toMvLaurent : MvPolynomial σ R →+* MvLaurentPolynomial σ R) :=
-  AddMonoidAlgebra.mapDomain_injective
+theorem toMvLaurent_injective (v : Basis σ ℤ M) :
+    Function.Injective fun p : MvPolynomial σ R ↦ p.toMvLaurent v := by
+  intro p q hpq
+  apply AddMonoidAlgebra.mapDomain_injective
     (Finsupp.mapRange_injective Int.ofNat (by simp) Int.ofNat_injective)
+  simpa [basisAlgEquiv_toMvLaurent] using congrArg (MvLaurentPolynomial.basisAlgEquiv v) hpq
 
-theorem toMvLaurent_inj (p q : MvPolynomial σ R) : toMvLaurent p = toMvLaurent q ↔ p = q :=
-  toMvLaurent_injective.eq_iff
+theorem toMvLaurent_inj (v : Basis σ ℤ M) {p q : MvPolynomial σ R} :
+    p.toMvLaurent v = q.toMvLaurent v ↔ p = q :=
+  (toMvLaurent_injective v).eq_iff
 
-theorem toMvLaurent_eq_zero {p : MvPolynomial σ R} : toMvLaurent p = 0 ↔ p = 0 :=
-  map_eq_zero_iff _ toMvLaurent_injective
+theorem toMvLaurent_eq_zero (v : Basis σ ℤ M) {p : MvPolynomial σ R} :
+    p.toMvLaurent v = 0 ↔ p = 0 :=
+  map_eq_zero_iff _ (toMvLaurent_injective v)
 
-theorem toMvLaurent_ne_zero {p : MvPolynomial σ R} : toMvLaurent p ≠ 0 ↔ p ≠ 0 :=
-  map_ne_zero_iff _ toMvLaurent_injective
+theorem toMvLaurent_ne_zero (v : Basis σ ℤ M) {p : MvPolynomial σ R} :
+    p.toMvLaurent v ≠ 0 ↔ p ≠ 0 :=
+  map_ne_zero_iff _ (toMvLaurent_injective v)
 
 end CommSemiring
 
@@ -318,14 +274,16 @@ namespace MvLaurentPolynomial
 
 section CommSemiring
 
-variable [CommSemiring R]
+variable [CommSemiring R] [AddCommGroup M] [Free ℤ M]
 
-instance algebraMvPolynomial : Algebra (MvPolynomial σ R) (MvLaurentPolynomial σ R) where
-  __ := MvPolynomial.toMvLaurent.toAlgebra
+instance algebraMvPolynomial :
+    Algebra (MvPolynomial (Free.ChooseBasisIndex ℤ M) R) (AddMonoidAlgebra R M) where
+  __ := (MvPolynomial.toMvLaurent <| Free.chooseBasis ℤ M).toAlgebra
 
 @[simp]
-theorem algebraMap_eq_toMvLaurent (p : MvPolynomial σ R) :
-    algebraMap (MvPolynomial σ R) (MvLaurentPolynomial σ R) p = MvPolynomial.toMvLaurent p :=
+theorem algebraMap_eq_toMvLaurent (p : MvPolynomial (Free.ChooseBasisIndex ℤ M) R) :
+    algebraMap (MvPolynomial (Free.ChooseBasisIndex ℤ M) R) (AddMonoidAlgebra R M) p =
+      p.toMvLaurent (Free.chooseBasis ℤ M) :=
   rfl
 
 end CommSemiring

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -47,14 +47,14 @@ section CommSemiring
 variable [CommSemiring R] [AddCommGroup M] {p q : AddMonoidAlgebra R M}
 
 /-- The Laurent monomial with exponent vector `d`, expressed in the basis `v`. -/
-def monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) : R →ₗ[R] AddMonoidAlgebra R M :=
-  AddMonoidAlgebra.lsingle (v.repr.symm d)
+def monomial (v : σ → M) (d : σ →₀ ℤ) (r : R) : AddMonoidAlgebra R M :=
+  AddMonoidAlgebra.single (Finsupp.linearCombination ℤ v d) r
 
-theorem one_def (v : Basis σ ℤ M) : (1 : AddMonoidAlgebra R M) = monomial v 0 1 := by
+theorem one_def (v : σ → M) : (1 : AddMonoidAlgebra R M) = monomial v 0 1 := by
   simp [monomial, AddMonoidAlgebra.one_def]
 
-theorem single_eq_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
-    (AddMonoidAlgebra.single (v.repr.symm d) r : AddMonoidAlgebra R M) = monomial v d r :=
+theorem single_eq_monomial (v : σ → M) (d : σ →₀ ℤ) (r : R) :
+    AddMonoidAlgebra.single (Finsupp.linearCombination ℤ v d) r = monomial v d r := by
   rfl
 
 theorem mul_def (v : Basis σ ℤ M) :
@@ -62,17 +62,17 @@ theorem mul_def (v : Basis σ ℤ M) :
   simp [AddMonoidAlgebra.mul_def, monomial]
 
 /-- The Laurent variable corresponding to the basis vector indexed by `i`. -/
-abbrev X (v : σ → M) (i : σ) : AddMonoidAlgebra R M := AddMonoidAlgebra.single (v i) (1 : R)
+abbrev X (v : σ → M) (i : σ) : AddMonoidAlgebra R M := monomial v (Finsupp.single i 1) 1
 
-theorem X_eq_monomial (v : Basis σ ℤ M) (i : σ) : X v i = monomial v (Finsupp.single i 1) (1 : R) :=
-  rfl
+theorem X_eq_monomial (v : σ → M) (i : σ) :
+    X v i = monomial v (Finsupp.single i 1) (1 : R) := by
+  simp [X, monomial]
 
 theorem monomial_left_injective (v : Basis σ ℤ M) {r : R} (hr : r ≠ 0) :
-    Function.Injective fun d : σ →₀ ℤ => monomial v d r := by
+    Function.Injective fun d : σ →₀ ℤ ↦ monomial v d r := by
   intro d e h
-  exact v.repr.symm.injective (Finsupp.single_left_injective hr h)
+  exact v.repr.symm.injective (Finsupp.single_left_injective hr (by simpa using h))
 
-@[simp]
 theorem monomial_left_inj (v : Basis σ ℤ M) {d e : σ →₀ ℤ} {r : R} (hr : r ≠ 0) :
     monomial v d r = monomial v e r ↔ d = e :=
   (monomial_left_injective v hr).eq_iff
@@ -85,86 +85,69 @@ theorem X_injective (v : Basis σ ℤ M) [Nontrivial R] :
     Function.Injective (X v : σ → AddMonoidAlgebra R M) :=
   (monomial_left_injective v one_ne_zero).comp (Finsupp.single_left_injective (one_ne_zero))
 
-@[simp]
 theorem X_inj (v : Basis σ ℤ M) [Nontrivial R] {i j : σ} :
-    X v i = (X v j : AddMonoidAlgebra R M) ↔ i = j := by
-  constructor
-  · intro h
-    exact X_injective v h
-  · intro h
-    simp [h]
+    X v i = (X v j : AddMonoidAlgebra R M) ↔ i = j :=
+  ⟨fun h ↦ X_injective v h, fun h ↦ congrArg _ h⟩
 
-theorem monomial_pow (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) (n : ℕ) :
+theorem monomial_pow (v : σ → M) (d : σ →₀ ℤ) (r : R) (n : ℕ) :
     monomial v d r ^ n = monomial v (n • d) (r ^ n) := by
-  simp only [monomial, Basis.repr_symm_apply, lsingle_apply, single_pow,
-    LinearMap.map_smul_of_tower]
+  simp only [monomial, single_pow, LinearMap.map_smul_of_tower]
 
-theorem X_pow_eq_monomial (v : Basis σ ℤ M) (i : σ) (e : ℕ) :
+theorem X_pow_eq_monomial (v : σ → M) (i : σ) (e : ℕ) :
     X v i ^ e = monomial v (Finsupp.single i (e : ℤ)) (1 : R) := by
-  simp only [X, single_pow, one_pow]
-  simp [monomial]
+  simp only [X, monomial, Finsupp.linearCombination_single, one_smul, single_pow, one_pow,
+    natCast_zsmul]
 
 @[simp]
-theorem monomial_mul (v : Basis σ ℤ M) {d e : σ →₀ ℤ} {r s : R} :
+theorem monomial_mul (v : σ → M) {d e : σ →₀ ℤ} {r s : R} :
     monomial v d r * monomial v e s = monomial v (d + e) (r * s) := by
   simp [monomial, AddMonoidAlgebra.single_mul_single]
 
-@[simp]
-theorem monomial_mul_monomial_neg (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
-    monomial v d (1 : R) * monomial v (-d) 1 = 1 := by
-  rw [monomial_mul, add_neg_cancel, one_mul, ← one_def v]
+theorem isUnit_monomial (v : σ → M) (d : σ →₀ ℤ) :
+    IsUnit (monomial v d (1 : R) : AddMonoidAlgebra R M) :=
+  ⟨⟨monomial v d 1, monomial v (-d) 1, by simp [← one_def v], by simp [← one_def v],⟩, rfl⟩
 
-@[simp]
-theorem monomial_neg_mul_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
-    monomial v (-d) (1 : R) * monomial v d 1 = 1 := by
-  rw [mul_comm, monomial_mul_monomial_neg]
-
-theorem isUnit_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) :
-    IsUnit (monomial v d (1 : R) : AddMonoidAlgebra R M) := by
-  refine ⟨⟨monomial v d 1, monomial v (-d) 1, monomial_mul_monomial_neg v d,
-      monomial_neg_mul_monomial v d⟩, rfl⟩
-
-theorem monomial_add_single (v : Basis σ ℤ M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
+theorem monomial_add_single (v : σ → M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
     monomial v (d + Finsupp.single i (e : ℤ)) r = monomial v d r * X v i ^ e := by
   rw [X_pow_eq_monomial, monomial_mul, mul_one]
 
-theorem monomial_single_add (v : Basis σ ℤ M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
+theorem monomial_single_add (v : σ → M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
     monomial v (Finsupp.single i (e : ℤ) + d) r = X v i ^ e * monomial v d r := by
   rw [X_pow_eq_monomial, monomial_mul, one_mul]
 
 @[simp]
-theorem monomial_zero (v : Basis σ ℤ M) {d : σ →₀ ℤ} : monomial v d (0 : R) = 0 := by
-  rw [monomial, AddMonoidAlgebra.lsingle_apply]
+theorem monomial_zero (v : σ → M) {d : σ →₀ ℤ} : monomial v d (0 : R) = 0 := by
+  rw [monomial]
   exact Finsupp.single_eq_zero.2 rfl
 
 @[simp]
-theorem monomial_eq_zero (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R} :
+theorem monomial_eq_zero (v : σ → M) {d : σ →₀ ℤ} {r : R} :
     monomial v d r = 0 ↔ r = 0 := by
   simp [monomial]
 
 @[simp]
-theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R}
-    {f : M → R → A} (h0 : f (v.repr.symm d) 0 = 0) :
-    (monomial v d r).sum f = f (v.repr.symm d) r := by
+theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] (v : σ → M) {d : σ →₀ ℤ} {r : R}
+    {f : M → R → A} (h0 : f ((Finsupp.linearCombination ℤ v) d) 0 = 0) :
+    (monomial v d r).sum f = f (Finsupp.linearCombination ℤ v d) r := by
   simpa [monomial] using (Finsupp.sum_single_index h0 : _)
 
-theorem support_monomial (v : Basis σ ℤ M) {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
-    (monomial v d r : AddMonoidAlgebra R M).support = if r = 0 then ∅ else {v.repr.symm d} := by
+theorem support_monomial (v : σ → M) {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
+    (monomial v d r : AddMonoidAlgebra R M).support =
+      if r = 0 then ∅ else {Finsupp.linearCombination ℤ v d} := by
   by_cases hr : r = 0
   · simp [monomial, hr]
-  · simpa [monomial, hr] using Finsupp.support_single_ne_zero (v.repr.symm d) hr
+  · simpa [monomial, hr] using Finsupp.support_single_ne_zero (Finsupp.linearCombination ℤ v d) hr
 
-theorem support_monomial_subset (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
-    (monomial v d r : AddMonoidAlgebra R M).support ⊆ {v.repr.symm d} := by
+theorem support_monomial_subset (v : σ → M) (d : σ →₀ ℤ) (r : R) :
+    (monomial v d r : AddMonoidAlgebra R M).support ⊆ {Finsupp.linearCombination ℤ v d} := by
   classical
   by_cases hr : r = 0
   · simp [monomial, hr]
   · simp [support_monomial v, hr]
 
-@[simp]
-theorem X_ne_zero (v : Basis σ ℤ M) [Nontrivial R] (i : σ) :
-    X v i ≠ (0 : AddMonoidAlgebra R M) :=
-  (monomial_eq_zero v).not.2 one_ne_zero
+theorem X_ne_zero (v : σ → M) [Nontrivial R] (i : σ) :
+    X v i ≠ (0 : AddMonoidAlgebra R M) := by
+  simp
 
 section AsSum
 

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -184,20 +184,6 @@ theorem monomial_mul {d e : σ →₀ ℤ} {r s : R} :
     monomial d r * monomial e s = monomial (d + e) (r * s) :=
   AddMonoidAlgebra.single_mul_single ..
 
-@[simp]
-theorem monomial_mul_monomial_neg (d : σ →₀ ℤ) :
-    monomial d (1 : R) * monomial (-d) 1 = 1 := by
-  rw [monomial_mul, add_neg_cancel, one_mul, ← one_def]
-
-@[simp]
-theorem monomial_neg_mul_monomial (d : σ →₀ ℤ) :
-    monomial (-d) (1 : R) * monomial d 1 = 1 := by
-  rw [mul_comm, monomial_mul_monomial_neg]
-
-theorem isUnit_monomial (d : σ →₀ ℤ) :
-    IsUnit (monomial d (1 : R) : MvLaurentPolynomial σ R) :=
-  ⟨⟨monomial d 1, monomial (-d) 1, monomial_mul_monomial_neg d, monomial_neg_mul_monomial d⟩, rfl⟩
-
 theorem monomial_add_single (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
     monomial (d + Finsupp.single n (e : ℤ)) r = monomial d r * X n ^ e := by
   rw [X_pow_eq_monomial, monomial_mul, mul_one]
@@ -225,6 +211,9 @@ theorem monomial_zero' : (monomial (0 : σ →₀ ℤ) : R → MvLaurentPolynomi
 @[simp]
 theorem monomial_eq_zero {d : σ →₀ ℤ} {r : R} : monomial d r = 0 ↔ r = 0 :=
   Finsupp.single_eq_zero
+
+theorem isUnit_monomial (d : σ →₀ ℤ) : IsUnit (monomial d (1 : R) : MvLaurentPolynomial σ R) :=
+  ⟨⟨monomial d 1, monomial (-d) 1, by simp, by simp⟩, rfl⟩
 
 @[simp]
 theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] {d : σ →₀ ℤ} {r : R}

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -50,13 +50,13 @@ section CommSemiring
 
 variable [CommSemiring R] [CommSemiring S] {p q : MvLaurentPolynomial σ R}
 
-@[ext]
-theorem ext {p q : MvLaurentPolynomial σ R} (h : ∀ d, p d = q d) : p = q :=
-  Finsupp.ext h
-
 /-- The coefficient of the monomial `d` in the multivariate Laurent polynomial `p`. -/
 def coeff (d : σ →₀ ℤ) (p : MvLaurentPolynomial σ R) : R :=
   p d
+
+@[ext]
+theorem ext {p q : MvLaurentPolynomial σ R} (h : ∀ d, coeff d p = coeff d q) : p = q :=
+  Finsupp.ext h
 
 /-- The finite support of a multivariate Laurent polynomial. -/
 def support (p : MvLaurentPolynomial σ R) : Finset (σ →₀ ℤ) :=
@@ -237,8 +237,7 @@ theorem support_monomial_subset (d : σ →₀ ℤ) (r : R) :
   by_cases hr : r = 0
   · subst r
     intro e he
-    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by
-      simpa [support, coeff, monomial_zero] using he
+    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by simpa [support] using he
     exact (h0 rfl).elim
   · classical
     simp [support_monomial, hr]
@@ -314,7 +313,7 @@ theorem eq_zero_iff {p : MvLaurentPolynomial σ R} : p = 0 ↔ ∀ d, coeff d p 
     exact coeff_zero d
   · intro hp
     ext d
-    simpa [coeff] using hp d
+    simpa using hp d
 
 theorem ne_zero_iff {p : MvLaurentPolynomial σ R} : p ≠ 0 ↔ ∃ d, coeff d p ≠ 0 := by
   rw [Ne, eq_zero_iff]
@@ -334,11 +333,6 @@ theorem X_ne_zero [Nontrivial R] (n : σ) :
     X n ≠ (0 : MvLaurentPolynomial σ R) := by
   rw [ne_zero_iff]
   exact ⟨Finsupp.single n 1, by simp⟩
-
-theorem sum_def {A : Type*} [AddCommMonoid A] {p : MvLaurentPolynomial σ R}
-    {f : (σ →₀ ℤ) → R → A} :
-    p.sum f = ∑ d ∈ p.support, f d (p.coeff d) := by
-  simp [support, coeff, Finsupp.sum]
 
 section AsSum
 

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -96,7 +96,6 @@ theorem X_pow_eq_monomial (v : σ → M) (i : σ) (e : ℕ) :
   simp only [X, monomial, Finsupp.linearCombination_single, one_smul, lsingle_apply, single_pow,
     one_pow, natCast_zsmul]
 
-@[simp]
 theorem monomial_mul (v : σ → M) {d e : σ →₀ ℤ} {r s : R} :
     monomial v d r * monomial v e s = monomial v (d + e) (r * s) := by
   simp [monomial, AddMonoidAlgebra.single_mul_single]
@@ -113,17 +112,14 @@ theorem monomial_single_add (v : σ → M) (d : σ →₀ ℤ) (i : σ) (e : ℕ
     monomial v (Finsupp.single i (e : ℤ) + d) r = X v i ^ e * monomial v d r := by
   rw [X_pow_eq_monomial, monomial_mul, one_mul]
 
-@[simp]
 theorem monomial_zero (v : σ → M) {d : σ →₀ ℤ} : monomial v d (0 : R) = 0 := by
   rw [monomial]
   exact Finsupp.single_eq_zero.2 rfl
 
-@[simp]
 theorem monomial_eq_zero (v : σ → M) {d : σ →₀ ℤ} {r : R} :
     monomial v d r = 0 ↔ r = 0 := by
-  simp [monomial]
+  simp
 
-@[simp]
 theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] (v : σ → M) {d : σ →₀ ℤ} {r : R}
     {f : M → R → A} (h0 : f ((Finsupp.linearCombination ℤ v) d) 0 = 0) :
     (monomial v d r).sum f = f (Finsupp.linearCombination ℤ v d) r := by
@@ -149,7 +145,6 @@ theorem X_ne_zero (v : σ → M) [Nontrivial R] (i : σ) :
 
 section AsSum
 
-@[simp]
 theorem support_sum_monomial_coeff (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) :
     (∑ m ∈ p.support, monomial v (v.repr m) (p m)) = p := by
   simpa [Finsupp.sum, monomial] using (Finsupp.sum_single p)
@@ -176,7 +171,6 @@ def laurentBasisAlgEquiv (v : Basis σ ℤ M) :
     AddMonoidAlgebra R M ≃ₐ[R] AddMonoidAlgebra R (σ →₀ ℤ) :=
   AddMonoidAlgebra.domCongr R R v.repr.toAddEquiv
 
-@[simp]
 theorem laurentBasisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
     laurentBasisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
   ext e

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -5,10 +5,7 @@ Authors: Yuma Mizuno
 -/
 module
 
-public import Mathlib.Algebra.MonoidAlgebra.Basic
-public import Mathlib.Algebra.MonoidAlgebra.Support
 public import Mathlib.Algebra.MvPolynomial.Basic
-public import Mathlib.LinearAlgebra.Basis.Defs
 public import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
@@ -40,24 +37,25 @@ noncomputable section
 
 variable {R : Type*} {S : Type*} {σ : Type*} {M : Type*}
 
-namespace MvLaurentPolynomial
+namespace AddMonoidAlgebra
 
 section CommSemiring
 
 variable [CommSemiring R] [AddCommGroup M] {p q : AddMonoidAlgebra R M}
 
 /-- The Laurent monomial with exponent vector `d`, expressed in the basis `v`. -/
-def monomial (v : σ → M) (d : σ →₀ ℤ) (r : R) : AddMonoidAlgebra R M :=
-  AddMonoidAlgebra.single (Finsupp.linearCombination ℤ v d) r
+abbrev monomial (v : σ → M) (d : σ →₀ ℤ) : R →ₗ[R] AddMonoidAlgebra R M :=
+  lsingle (Finsupp.linearCombination ℤ v d)
 
-theorem one_def (v : σ → M) : (1 : AddMonoidAlgebra R M) = monomial v 0 1 := by
-  simp [monomial, AddMonoidAlgebra.one_def]
-
-theorem single_eq_monomial (v : σ → M) (d : σ →₀ ℤ) (r : R) :
-    AddMonoidAlgebra.single (Finsupp.linearCombination ℤ v d) r = monomial v d r := by
+theorem one_eq_monomial (v : σ → M) :
+    (1 : AddMonoidAlgebra R M) = monomial v 0 1 := by
   rfl
 
-theorem mul_def (v : Basis σ ℤ M) :
+theorem single_eq_monomial (v : σ → M) (d : σ →₀ ℤ) (r : R) :
+    single (Finsupp.linearCombination ℤ v d) r = monomial v d r := by
+  rfl
+
+theorem mul_eq_sum_monomial (v : Basis σ ℤ M) :
     p * q = p.sum fun d r ↦ q.sum fun e s ↦ monomial v (v.repr d + v.repr e) (r * s) := by
   simp [AddMonoidAlgebra.mul_def, monomial]
 
@@ -91,12 +89,12 @@ theorem X_inj (v : Basis σ ℤ M) [Nontrivial R] {i j : σ} :
 
 theorem monomial_pow (v : σ → M) (d : σ →₀ ℤ) (r : R) (n : ℕ) :
     monomial v d r ^ n = monomial v (n • d) (r ^ n) := by
-  simp only [monomial, single_pow, LinearMap.map_smul_of_tower]
+  simp only [monomial, lsingle_apply, single_pow, LinearMap.map_smul_of_tower]
 
 theorem X_pow_eq_monomial (v : σ → M) (i : σ) (e : ℕ) :
     X v i ^ e = monomial v (Finsupp.single i (e : ℤ)) (1 : R) := by
-  simp only [X, monomial, Finsupp.linearCombination_single, one_smul, single_pow, one_pow,
-    natCast_zsmul]
+  simp only [X, monomial, Finsupp.linearCombination_single, one_smul, lsingle_apply, single_pow,
+    one_pow, natCast_zsmul]
 
 @[simp]
 theorem monomial_mul (v : σ → M) {d e : σ →₀ ℤ} {r s : R} :
@@ -105,7 +103,7 @@ theorem monomial_mul (v : σ → M) {d e : σ →₀ ℤ} {r s : R} :
 
 theorem isUnit_monomial (v : σ → M) (d : σ →₀ ℤ) :
     IsUnit (monomial v d (1 : R) : AddMonoidAlgebra R M) :=
-  ⟨⟨monomial v d 1, monomial v (-d) 1, by simp [← one_def v], by simp [← one_def v],⟩, rfl⟩
+  ⟨⟨monomial v d 1, monomial v (-d) 1, by simp [← one_def], by simp [← one_def]⟩, rfl⟩
 
 theorem monomial_add_single (v : σ → M) (d : σ →₀ ℤ) (i : σ) (e : ℕ) (r : R) :
     monomial v (d + Finsupp.single i (e : ℤ)) r = monomial v d r * X v i ^ e := by
@@ -143,7 +141,7 @@ theorem support_monomial_subset (v : σ → M) (d : σ →₀ ℤ) (r : R) :
   classical
   by_cases hr : r = 0
   · simp [monomial, hr]
-  · simp [support_monomial v, hr]
+  · grind [lsingle_apply]
 
 theorem X_ne_zero (v : σ → M) [Nontrivial R] (i : σ) :
     X v i ≠ (0 : AddMonoidAlgebra R M) := by
@@ -174,24 +172,24 @@ theorem induction_on' (v : Basis σ ℤ M) {P : AddMonoidAlgebra R M → Prop} (
     simpa [monomial] using hadd (monomial v (v.repr m) r) p (hmonomial (v.repr m) r) hp
 
 /-- The algebra equivalence to the coordinate Laurent model induced by the basis `v`. -/
-def basisAlgEquiv (v : Basis σ ℤ M) :
+def laurentBasisAlgEquiv (v : Basis σ ℤ M) :
     AddMonoidAlgebra R M ≃ₐ[R] AddMonoidAlgebra R (σ →₀ ℤ) :=
   AddMonoidAlgebra.domCongr R R v.repr.toAddEquiv
 
 @[simp]
-theorem basisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
-    basisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
+theorem laurentBasisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
+    laurentBasisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
   ext e
-  simp [basisAlgEquiv, monomial]
+  simp [laurentBasisAlgEquiv, monomial]
 
 @[simp]
-theorem basisAlgEquiv_apply (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) (d : σ →₀ ℤ) :
-    basisAlgEquiv v p d = p (v.repr.symm d) := by
-  simp [basisAlgEquiv]
+theorem laurentBasisAlgEquiv_apply (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) (d : σ →₀ ℤ) :
+    laurentBasisAlgEquiv v p d = p (v.repr.symm d) := by
+  simp [laurentBasisAlgEquiv]
 
 end CommSemiring
 
-end MvLaurentPolynomial
+end AddMonoidAlgebra
 
 namespace MvPolynomial
 
@@ -199,16 +197,16 @@ section CommSemiring
 
 variable [CommSemiring R] [AddCommGroup M]
 
-/-- The natural inclusion from multivariate polynomials to Laurent monomials written in the basis
-`v`. -/
+/-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials
+written in the basis `v`. -/
 def toMvLaurent (v : Basis σ ℤ M) : MvPolynomial σ R →ₐ[R] AddMonoidAlgebra R M :=
-  (MvLaurentPolynomial.basisAlgEquiv v).symm.toAlgHom.comp
+  (AddMonoidAlgebra.laurentBasisAlgEquiv v).symm.toAlgHom.comp
     (AddMonoidAlgebra.mapDomainAlgHom R R
       (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)))
 
 @[simp]
-theorem basisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
-    MvLaurentPolynomial.basisAlgEquiv v (p.toMvLaurent v) =
+theorem laurentBasisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
+    AddMonoidAlgebra.laurentBasisAlgEquiv v (p.toMvLaurent v) =
       (AddMonoidAlgebra.mapDomainAlgHom R R
         (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ))) p := by
   simp only [toMvLaurent, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe, comp_apply,
@@ -218,24 +216,25 @@ theorem basisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
 @[simp]
 theorem toMvLaurent_monomial (v : Basis σ ℤ M) (d : σ →₀ ℕ) (r : R) :
     (MvPolynomial.monomial d r).toMvLaurent v =
-      MvLaurentPolynomial.monomial v (d.mapRange Int.ofNat (by simp)) r := by
-  apply (MvLaurentPolynomial.basisAlgEquiv v).injective
-  simp only [basisAlgEquiv_toMvLaurent, mapDomainAlgHom_apply,
-    MvLaurentPolynomial.basisAlgEquiv_monomial]
+      AddMonoidAlgebra.monomial v (d.mapRange Int.ofNat (by simp)) r := by
+  apply (AddMonoidAlgebra.laurentBasisAlgEquiv v).injective
+  simp only [laurentBasisAlgEquiv_toMvLaurent, mapDomainAlgHom_apply,
+    AddMonoidAlgebra.laurentBasisAlgEquiv_monomial]
   apply mapDomain_single
 
 @[simp]
 theorem toMvLaurent_X (v : Basis σ ℤ M) (i : σ) :
-    (MvPolynomial.X i : MvPolynomial σ R).toMvLaurent v = MvLaurentPolynomial.X v i := by
+    (MvPolynomial.X i : MvPolynomial σ R).toMvLaurent v = AddMonoidAlgebra.X v i := by
   simp only [X, toMvLaurent_monomial, Finsupp.mapRange_single, Int.ofNat_eq_natCast, Nat.cast_one,
-    MvLaurentPolynomial.X_eq_monomial]
+    AddMonoidAlgebra.X_eq_monomial]
 
 theorem toMvLaurent_injective (v : Basis σ ℤ M) :
     Function.Injective fun p : MvPolynomial σ R ↦ p.toMvLaurent v := by
   intro p q hpq
   apply AddMonoidAlgebra.mapDomain_injective
     (Finsupp.mapRange_injective Int.ofNat (by simp) Int.ofNat_injective)
-  simpa [basisAlgEquiv_toMvLaurent] using congrArg (MvLaurentPolynomial.basisAlgEquiv v) hpq
+  simpa [laurentBasisAlgEquiv_toMvLaurent] using
+    congrArg (AddMonoidAlgebra.laurentBasisAlgEquiv v) hpq
 
 theorem toMvLaurent_inj (v : Basis σ ℤ M) {p q : MvPolynomial σ R} :
     p.toMvLaurent v = q.toMvLaurent v ↔ p = q :=

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -37,7 +37,7 @@ noncomputable section
 
 variable {R : Type*} {S : Type*} {σ : Type*} {M : Type*}
 
-namespace AddMonoidAlgebra
+namespace MvLaurentPolynomial
 
 section CommSemiring
 
@@ -167,23 +167,23 @@ theorem induction_on' (v : Basis σ ℤ M) {P : AddMonoidAlgebra R M → Prop} (
     simpa [monomial] using hadd (monomial v (v.repr m) r) p (hmonomial (v.repr m) r) hp
 
 /-- The algebra equivalence to the coordinate Laurent model induced by the basis `v`. -/
-def laurentBasisAlgEquiv (v : Basis σ ℤ M) :
+def basisAlgEquiv (v : Basis σ ℤ M) :
     AddMonoidAlgebra R M ≃ₐ[R] AddMonoidAlgebra R (σ →₀ ℤ) :=
   AddMonoidAlgebra.domCongr R R v.repr.toAddEquiv
 
-theorem laurentBasisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
-    laurentBasisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
+theorem basisAlgEquiv_monomial (v : Basis σ ℤ M) (d : σ →₀ ℤ) (r : R) :
+    basisAlgEquiv v (monomial v d r) = AddMonoidAlgebra.single d r := by
   ext e
-  simp [laurentBasisAlgEquiv, monomial]
+  simp [basisAlgEquiv, monomial]
 
 @[simp]
-theorem laurentBasisAlgEquiv_apply (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) (d : σ →₀ ℤ) :
-    laurentBasisAlgEquiv v p d = p (v.repr.symm d) := by
-  simp [laurentBasisAlgEquiv]
+theorem basisAlgEquiv_apply (v : Basis σ ℤ M) (p : AddMonoidAlgebra R M) (d : σ →₀ ℤ) :
+    basisAlgEquiv v p d = p (v.repr.symm d) := by
+  simp [basisAlgEquiv]
 
 end CommSemiring
 
-end AddMonoidAlgebra
+end MvLaurentPolynomial
 
 namespace MvPolynomial
 
@@ -194,13 +194,13 @@ variable [CommSemiring R] [AddCommGroup M]
 /-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials
 written in the basis `v`. -/
 def toMvLaurent (v : Basis σ ℤ M) : MvPolynomial σ R →ₐ[R] AddMonoidAlgebra R M :=
-  (AddMonoidAlgebra.laurentBasisAlgEquiv v).symm.toAlgHom.comp
+  (MvLaurentPolynomial.basisAlgEquiv v).symm.toAlgHom.comp
     (AddMonoidAlgebra.mapDomainAlgHom R R
       (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)))
 
 @[simp]
-theorem laurentBasisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
-    AddMonoidAlgebra.laurentBasisAlgEquiv v (p.toMvLaurent v) =
+theorem basisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial σ R) :
+    MvLaurentPolynomial.basisAlgEquiv v (p.toMvLaurent v) =
       (AddMonoidAlgebra.mapDomainAlgHom R R
         (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ))) p := by
   simp only [toMvLaurent, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe, comp_apply,
@@ -210,25 +210,25 @@ theorem laurentBasisAlgEquiv_toMvLaurent (v : Basis σ ℤ M) (p : MvPolynomial 
 @[simp]
 theorem toMvLaurent_monomial (v : Basis σ ℤ M) (d : σ →₀ ℕ) (r : R) :
     (MvPolynomial.monomial d r).toMvLaurent v =
-      AddMonoidAlgebra.monomial v (d.mapRange Int.ofNat (by simp)) r := by
-  apply (AddMonoidAlgebra.laurentBasisAlgEquiv v).injective
-  simp only [laurentBasisAlgEquiv_toMvLaurent, mapDomainAlgHom_apply,
-    AddMonoidAlgebra.laurentBasisAlgEquiv_monomial]
+      MvLaurentPolynomial.monomial v (d.mapRange Int.ofNat (by simp)) r := by
+  apply (MvLaurentPolynomial.basisAlgEquiv v).injective
+  simp only [basisAlgEquiv_toMvLaurent, mapDomainAlgHom_apply,
+    MvLaurentPolynomial.basisAlgEquiv_monomial]
   apply mapDomain_single
 
 @[simp]
 theorem toMvLaurent_X (v : Basis σ ℤ M) (i : σ) :
-    (MvPolynomial.X i : MvPolynomial σ R).toMvLaurent v = AddMonoidAlgebra.X v i := by
+    (MvPolynomial.X i : MvPolynomial σ R).toMvLaurent v = MvLaurentPolynomial.X v i := by
   simp only [X, toMvLaurent_monomial, Finsupp.mapRange_single, Int.ofNat_eq_natCast, Nat.cast_one,
-    AddMonoidAlgebra.X_eq_monomial]
+    MvLaurentPolynomial.X_eq_monomial]
 
 theorem toMvLaurent_injective (v : Basis σ ℤ M) :
     Function.Injective fun p : MvPolynomial σ R ↦ p.toMvLaurent v := by
   intro p q hpq
   apply AddMonoidAlgebra.mapDomain_injective
     (Finsupp.mapRange_injective Int.ofNat (by simp) Int.ofNat_injective)
-  simpa [laurentBasisAlgEquiv_toMvLaurent] using
-    congrArg (AddMonoidAlgebra.laurentBasisAlgEquiv v) hpq
+  simpa [basisAlgEquiv_toMvLaurent] using
+    congrArg (MvLaurentPolynomial.basisAlgEquiv v) hpq
 
 theorem toMvLaurent_inj (v : Basis σ ℤ M) {p q : MvPolynomial σ R} :
     p.toMvLaurent v = q.toMvLaurent v ↔ p = q :=

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -54,14 +54,6 @@ variable [CommSemiring R] [CommSemiring S] {p q : MvLaurentPolynomial σ R}
 def coeff (d : σ →₀ ℤ) (p : MvLaurentPolynomial σ R) : R :=
   p d
 
-@[ext]
-theorem ext {p q : MvLaurentPolynomial σ R} (h : ∀ d, coeff d p = coeff d q) : p = q :=
-  Finsupp.ext h
-
-/-- The finite support of a multivariate Laurent polynomial. -/
-def support (p : MvLaurentPolynomial σ R) : Finset (σ →₀ ℤ) :=
-  Finsupp.support p
-
 /-- `monomial d r` is the Laurent monomial with coefficient `r` and exponent vector `d`. -/
 def monomial (d : σ →₀ ℤ) : R →ₗ[R] MvLaurentPolynomial σ R :=
   AddMonoidAlgebra.lsingle d
@@ -76,23 +68,6 @@ theorem single_eq_monomial (d : σ →₀ ℤ) (r : R) :
 theorem mul_def : p * q = p.sum fun d r ↦ q.sum fun e s ↦ monomial (d + e) (r * s) :=
   AddMonoidAlgebra.mul_def ..
 
-/-- `C r` is the constant Laurent polynomial with value `r`. -/
-def C : R →+* MvLaurentPolynomial σ R :=
-  { singleZeroRingHom with toFun := monomial 0 }
-
-variable (R σ)
-
-@[simp]
-theorem algebraMap_eq : algebraMap R (MvLaurentPolynomial σ R) = C :=
-  rfl
-
-variable {R σ}
-
-@[simp]
-theorem algebraMap_apply [Algebra R S] (r : R) :
-    algebraMap R (MvLaurentPolynomial σ S) r = C (algebraMap R S r) :=
-  rfl
-
 /-- `X n` is the Laurent monomial with exponent vector `Finsupp.single n 1`. -/
 def X (n : σ) : MvLaurentPolynomial σ R :=
   monomial (Finsupp.single n 1) 1
@@ -105,60 +80,6 @@ theorem monomial_left_injective {r : R} (hr : r ≠ 0) :
 theorem monomial_left_inj {d e : σ →₀ ℤ} {r : R} (hr : r ≠ 0) :
     monomial d r = monomial e r ↔ d = e :=
   Finsupp.single_left_inj hr
-
-theorem C_apply (r : R) : (C r : MvLaurentPolynomial σ R) = monomial 0 r :=
-  rfl
-
-@[simp]
-theorem C_0 : (C (0 : R) : MvLaurentPolynomial σ R) = 0 :=
-  map_zero _
-
-@[simp]
-theorem C_1 : (C (1 : R) : MvLaurentPolynomial σ R) = 1 :=
-  rfl
-
-theorem C_mul_monomial (r s : R) (d : σ →₀ ℤ) :
-    C r * monomial d s = monomial d (r * s) := by
-  have h := AddMonoidAlgebra.single_mul_single (0 : σ →₀ ℤ) d r s
-  rw [zero_add] at h
-  rw [C_apply, monomial, monomial]
-  exact h
-
-@[simp]
-theorem C_add (r s : R) : (C (r + s) : MvLaurentPolynomial σ R) = C r + C s :=
-  Finsupp.single_add _ _ _
-
-@[simp]
-theorem C_mul (r s : R) : (C (r * s) : MvLaurentPolynomial σ R) = C r * C s := by
-  simpa [C_apply] using (C_mul_monomial r s (0 : σ →₀ ℤ)).symm
-
-@[simp]
-theorem C_pow (r : R) (n : ℕ) : (C (r ^ n) : MvLaurentPolynomial σ R) = C r ^ n :=
-  map_pow _ _ _
-
-theorem C_injective : Function.Injective (C : R → MvLaurentPolynomial σ R) :=
-  Finsupp.single_injective _
-
-@[simp]
-theorem C_inj (r s : R) : (C r : MvLaurentPolynomial σ R) = C s ↔ r = s :=
-  C_injective.eq_iff
-
-@[simp]
-theorem C_eq_zero {r : R} : (C r : MvLaurentPolynomial σ R) = 0 ↔ r = 0 :=
-  ⟨fun h ↦ C_injective <| by simpa using h, fun h ↦ by simp [h]⟩
-
-theorem C_ne_zero {r : R} : (C r : MvLaurentPolynomial σ R) ≠ 0 ↔ r ≠ 0 :=
-  C_eq_zero.ne
-
-theorem C_mul' (r : R) (p : MvLaurentPolynomial σ R) : C r * p = r • p :=
-  (Algebra.smul_def r p).symm
-
-theorem smul_eq_C_mul (p : MvLaurentPolynomial σ R) (r : R) : r • p = C r * p :=
-  (C_mul' r p).symm
-
-theorem C_eq_smul_one (r : R) :
-    (C r : MvLaurentPolynomial σ R) = r • (1 : MvLaurentPolynomial σ R) := by
-  rw [← C_mul' r 1, mul_one]
 
 theorem smul_monomial {T : Type*} [SMulZeroClass T R] (t : T) (d : σ →₀ ℤ) (r : R) :
     t • monomial d r = monomial d (t • r) :=
@@ -192,28 +113,16 @@ theorem monomial_single_add (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
     monomial (Finsupp.single n (e : ℤ) + d) r = X n ^ e * monomial d r := by
   rw [X_pow_eq_monomial, monomial_mul, one_mul]
 
-theorem C_mul_X_pow_eq_monomial (n : σ) (r : R) (e : ℕ) :
-    C r * X n ^ e = monomial (Finsupp.single n (e : ℤ)) r := by
-  rw [← zero_add (Finsupp.single n (e : ℤ)), monomial_add_single, C_apply]
-
-theorem C_mul_X_eq_monomial (n : σ) (r : R) :
-    C r * X n = monomial (Finsupp.single n 1) r := by
-  simpa using C_mul_X_pow_eq_monomial n r 1
-
 @[simp]
 theorem monomial_zero {d : σ →₀ ℤ} : monomial d (0 : R) = 0 :=
   Finsupp.single_zero _
-
-@[simp]
-theorem monomial_zero' : (monomial (0 : σ →₀ ℤ) : R → MvLaurentPolynomial σ R) = C :=
-  rfl
 
 @[simp]
 theorem monomial_eq_zero {d : σ →₀ ℤ} {r : R} : monomial d r = 0 ↔ r = 0 :=
   Finsupp.single_eq_zero
 
 theorem isUnit_monomial (d : σ →₀ ℤ) : IsUnit (monomial d (1 : R) : MvLaurentPolynomial σ R) :=
-  ⟨⟨monomial d 1, monomial (-d) 1, by simp, by simp⟩, rfl⟩
+  ⟨⟨monomial d 1, monomial (-d) 1, by sorry, by sorry⟩, rfl⟩
 
 @[simp]
 theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] {d : σ →₀ ℤ} {r : R}
@@ -221,23 +130,18 @@ theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] {d : σ →₀ ℤ} {r : R
     sum (monomial d r) f = f d r :=
   Finsupp.sum_single_index h0
 
-@[simp]
-theorem sum_C {A : Type*} [AddCommMonoid A] {f : (σ →₀ ℤ) → R → A} (r : R) (h0 : f 0 0 = 0) :
-    sum (C r) f = f 0 r :=
-  sum_monomial_eq h0
-
 theorem support_monomial {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
     (monomial d r : MvLaurentPolynomial σ R).support = if r = 0 then ∅ else {d} := by
   by_cases hr : r = 0
-  · simp [support, monomial, hr]
-  · simpa [support, monomial, hr] using (Finsupp.support_single_ne_zero d hr)
+  · simp [monomial, hr]
+  · simpa [monomial, hr] using (Finsupp.support_single_ne_zero d hr)
 
 theorem support_monomial_subset (d : σ →₀ ℤ) (r : R) :
     (monomial d r : MvLaurentPolynomial σ R).support ⊆ {d} := by
   by_cases hr : r = 0
   · subst r
     intro e he
-    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by simpa [support] using he
+    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by simpa using he
     exact (h0 rfl).elim
   · classical
     simp [support_monomial, hr]
@@ -250,11 +154,6 @@ theorem coeff_zero (d : σ →₀ ℤ) : coeff d (0 : MvLaurentPolynomial σ R) 
 theorem coeff_monomial (d e : σ →₀ ℤ) [Decidable (e = d)] (r : R) :
     coeff d (monomial e r : MvLaurentPolynomial σ R) = if e = d then r else 0 := by
   rw [coeff, monomial, AddMonoidAlgebra.lsingle_apply, Finsupp.single_apply]
-
-@[simp]
-theorem coeff_C (d : σ →₀ ℤ) [Decidable (0 = d)] (r : R) :
-    coeff d (C r : MvLaurentPolynomial σ R) = if 0 = d then r else 0 := by
-  rw [C_apply, coeff_monomial]
 
 theorem coeff_X' (n : σ) (d : σ →₀ ℤ) [Decidable (Finsupp.single n 1 = d)] :
     coeff d (X n : MvLaurentPolynomial σ R) = if Finsupp.single n 1 = d then 1 else 0 := by
@@ -287,11 +186,11 @@ theorem coeff_monomial_mul' (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p :
 @[simp]
 theorem mem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
     d ∈ p.support ↔ p.coeff d ≠ 0 := by
-  simp [support, coeff]
+  simp [coeff]
 
 theorem notMem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
     d ∉ p.support ↔ p.coeff d = 0 := by
-  simp [support, coeff]
+  simp [coeff]
 
 @[simp]
 theorem support_zero : (0 : MvLaurentPolynomial σ R).support = ∅ :=
@@ -391,15 +290,6 @@ theorem toMvLaurentAlg_apply (p : MvPolynomial σ R) : toMvLaurentAlg p = toMvLa
 theorem toMvLaurent_monomial (d : σ →₀ ℕ) (r : R) :
     toMvLaurent (monomial d r) = MvLaurentPolynomial.monomial (d.mapRange Int.ofNat (by simp)) r :=
   AddMonoidAlgebra.mapDomain_single
-
-@[simp]
-theorem toMvLaurent_C (r : R) :
-    toMvLaurent (C r : MvPolynomial σ R) = MvLaurentPolynomial.C r := by
-  change
-    AddMonoidAlgebra.mapDomain (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ))
-      (Finsupp.single 0 r) = MvLaurentPolynomial.C r
-  rw [AddMonoidAlgebra.mapDomain_single]
-  simp [MvLaurentPolynomial.C_apply, MvLaurentPolynomial.monomial]
 
 @[simp]
 theorem toMvLaurent_X (n : σ) :

--- a/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvLaurentPolynomial/Basic.lean
@@ -1,0 +1,460 @@
+/-
+Copyright (c) 2026 Yuma Mizuno. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yuma Mizuno
+-/
+module
+
+public import Mathlib.Algebra.MvPolynomial.Basic
+
+/-!
+# Multivariate Laurent polynomials
+
+This file defines `MvLaurentPolynomial σ R`, the type of multivariate Laurent polynomials
+with coefficients in a commutative semiring `R` and variables indexed by `σ`.
+
+The exponent vectors live in `σ →₀ ℤ`, so negative exponents are allowed.
+The implementation is `AddMonoidAlgebra R (σ →₀ ℤ)`.
+
+## Definitions
+
+Let `R` be a commutative semiring and let `σ` be an arbitrary type.
+
+* `MvLaurentPolynomial σ R` : the type of multivariate Laurent polynomials in variables indexed by
+  `σ` and coefficients in `R`
+* `MvLaurentPolynomial.monomial d r` : the Laurent monomial with exponent vector `d` and
+  coefficient `r`
+* `MvLaurentPolynomial.C r` : the constant Laurent polynomial with value `r`
+* `MvLaurentPolynomial.X n` : the Laurent monomial corresponding to the variable `n`
+* `MvLaurentPolynomial.coeff d p` : the coefficient of the monomial `d` in `p`
+* `MvPolynomial.toMvLaurent` : the natural inclusion from multivariate polynomials to
+  multivariate Laurent polynomials
+
+-/
+
+@[expose] public section
+
+open Function Finsupp AddMonoidAlgebra
+
+noncomputable section
+
+variable {R : Type*} {S : Type*} {σ : Type*}
+
+/-- Multivariate Laurent polynomials over `R` in variables indexed by `σ`. -/
+abbrev MvLaurentPolynomial (σ : Type*) (R : Type*) [CommSemiring R] :=
+  AddMonoidAlgebra R (σ →₀ ℤ)
+
+namespace MvLaurentPolynomial
+
+section CommSemiring
+
+variable [CommSemiring R] [CommSemiring S] {p q : MvLaurentPolynomial σ R}
+
+@[ext]
+theorem ext {p q : MvLaurentPolynomial σ R} (h : ∀ d, p d = q d) : p = q :=
+  Finsupp.ext h
+
+/-- The coefficient of the monomial `d` in the multivariate Laurent polynomial `p`. -/
+def coeff (d : σ →₀ ℤ) (p : MvLaurentPolynomial σ R) : R :=
+  p d
+
+/-- The finite support of a multivariate Laurent polynomial. -/
+def support (p : MvLaurentPolynomial σ R) : Finset (σ →₀ ℤ) :=
+  Finsupp.support p
+
+/-- `monomial d r` is the Laurent monomial with coefficient `r` and exponent vector `d`. -/
+def monomial (d : σ →₀ ℤ) : R →ₗ[R] MvLaurentPolynomial σ R :=
+  AddMonoidAlgebra.lsingle d
+
+theorem one_def : (1 : MvLaurentPolynomial σ R) = monomial 0 1 :=
+  rfl
+
+theorem single_eq_monomial (d : σ →₀ ℤ) (r : R) :
+    (Finsupp.single d r : MvLaurentPolynomial σ R) = monomial d r :=
+  rfl
+
+theorem mul_def : p * q = p.sum fun d r ↦ q.sum fun e s ↦ monomial (d + e) (r * s) :=
+  AddMonoidAlgebra.mul_def ..
+
+/-- `C r` is the constant Laurent polynomial with value `r`. -/
+def C : R →+* MvLaurentPolynomial σ R :=
+  { singleZeroRingHom with toFun := monomial 0 }
+
+variable (R σ)
+
+@[simp]
+theorem algebraMap_eq : algebraMap R (MvLaurentPolynomial σ R) = C :=
+  rfl
+
+variable {R σ}
+
+@[simp]
+theorem algebraMap_apply [Algebra R S] (r : R) :
+    algebraMap R (MvLaurentPolynomial σ S) r = C (algebraMap R S r) :=
+  rfl
+
+/-- `X n` is the Laurent monomial with exponent vector `Finsupp.single n 1`. -/
+def X (n : σ) : MvLaurentPolynomial σ R :=
+  monomial (Finsupp.single n 1) 1
+
+theorem monomial_left_injective {r : R} (hr : r ≠ 0) :
+    Function.Injective fun d : σ →₀ ℤ ↦ monomial d r :=
+  Finsupp.single_left_injective hr
+
+@[simp]
+theorem monomial_left_inj {d e : σ →₀ ℤ} {r : R} (hr : r ≠ 0) :
+    monomial d r = monomial e r ↔ d = e :=
+  Finsupp.single_left_inj hr
+
+theorem C_apply (r : R) : (C r : MvLaurentPolynomial σ R) = monomial 0 r :=
+  rfl
+
+@[simp]
+theorem C_0 : (C (0 : R) : MvLaurentPolynomial σ R) = 0 :=
+  map_zero _
+
+@[simp]
+theorem C_1 : (C (1 : R) : MvLaurentPolynomial σ R) = 1 :=
+  rfl
+
+theorem C_mul_monomial (r s : R) (d : σ →₀ ℤ) :
+    C r * monomial d s = monomial d (r * s) := by
+  have h := AddMonoidAlgebra.single_mul_single (0 : σ →₀ ℤ) d r s
+  rw [zero_add] at h
+  rw [C_apply, monomial, monomial]
+  exact h
+
+@[simp]
+theorem C_add (r s : R) : (C (r + s) : MvLaurentPolynomial σ R) = C r + C s :=
+  Finsupp.single_add _ _ _
+
+@[simp]
+theorem C_mul (r s : R) : (C (r * s) : MvLaurentPolynomial σ R) = C r * C s := by
+  simpa [C_apply] using (C_mul_monomial r s (0 : σ →₀ ℤ)).symm
+
+@[simp]
+theorem C_pow (r : R) (n : ℕ) : (C (r ^ n) : MvLaurentPolynomial σ R) = C r ^ n :=
+  map_pow _ _ _
+
+theorem C_injective : Function.Injective (C : R → MvLaurentPolynomial σ R) :=
+  Finsupp.single_injective _
+
+@[simp]
+theorem C_inj (r s : R) : (C r : MvLaurentPolynomial σ R) = C s ↔ r = s :=
+  C_injective.eq_iff
+
+@[simp]
+theorem C_eq_zero {r : R} : (C r : MvLaurentPolynomial σ R) = 0 ↔ r = 0 :=
+  ⟨fun h ↦ C_injective <| by simpa using h, fun h ↦ by simp [h]⟩
+
+theorem C_ne_zero {r : R} : (C r : MvLaurentPolynomial σ R) ≠ 0 ↔ r ≠ 0 :=
+  C_eq_zero.ne
+
+theorem C_mul' (r : R) (p : MvLaurentPolynomial σ R) : C r * p = r • p :=
+  (Algebra.smul_def r p).symm
+
+theorem smul_eq_C_mul (p : MvLaurentPolynomial σ R) (r : R) : r • p = C r * p :=
+  (C_mul' r p).symm
+
+theorem C_eq_smul_one (r : R) :
+    (C r : MvLaurentPolynomial σ R) = r • (1 : MvLaurentPolynomial σ R) := by
+  rw [← C_mul' r 1, mul_one]
+
+theorem smul_monomial {T : Type*} [SMulZeroClass T R] (t : T) (d : σ →₀ ℤ) (r : R) :
+    t • monomial d r = monomial d (t • r) :=
+  Finsupp.smul_single _ _ _
+
+theorem X_injective [Nontrivial R] : Function.Injective (X : σ → MvLaurentPolynomial σ R) :=
+  (monomial_left_injective one_ne_zero).comp (Finsupp.single_left_injective one_ne_zero)
+
+@[simp]
+theorem X_inj [Nontrivial R] (m n : σ) : X m = (X n : MvLaurentPolynomial σ R) ↔ m = n :=
+  X_injective.eq_iff
+
+theorem monomial_pow (d : σ →₀ ℤ) (r : R) (n : ℕ) :
+    monomial d r ^ n = monomial (n • d) (r ^ n) :=
+  AddMonoidAlgebra.single_pow ..
+
+theorem X_pow_eq_monomial (n : σ) (e : ℕ) :
+    X n ^ e = monomial (Finsupp.single n (e : ℤ)) (1 : R) := by
+  simp [X, monomial_pow]
+
+@[simp]
+theorem monomial_mul {d e : σ →₀ ℤ} {r s : R} :
+    monomial d r * monomial e s = monomial (d + e) (r * s) :=
+  AddMonoidAlgebra.single_mul_single ..
+
+@[simp]
+theorem monomial_mul_monomial_neg (d : σ →₀ ℤ) :
+    monomial d (1 : R) * monomial (-d) 1 = 1 := by
+  rw [monomial_mul, add_neg_cancel, one_mul, ← one_def]
+
+@[simp]
+theorem monomial_neg_mul_monomial (d : σ →₀ ℤ) :
+    monomial (-d) (1 : R) * monomial d 1 = 1 := by
+  rw [mul_comm, monomial_mul_monomial_neg]
+
+theorem isUnit_monomial (d : σ →₀ ℤ) :
+    IsUnit (monomial d (1 : R) : MvLaurentPolynomial σ R) :=
+  ⟨⟨monomial d 1, monomial (-d) 1, monomial_mul_monomial_neg d, monomial_neg_mul_monomial d⟩, rfl⟩
+
+theorem monomial_add_single (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
+    monomial (d + Finsupp.single n (e : ℤ)) r = monomial d r * X n ^ e := by
+  rw [X_pow_eq_monomial, monomial_mul, mul_one]
+
+theorem monomial_single_add (d : σ →₀ ℤ) (n : σ) (e : ℕ) (r : R) :
+    monomial (Finsupp.single n (e : ℤ) + d) r = X n ^ e * monomial d r := by
+  rw [X_pow_eq_monomial, monomial_mul, one_mul]
+
+theorem C_mul_X_pow_eq_monomial (n : σ) (r : R) (e : ℕ) :
+    C r * X n ^ e = monomial (Finsupp.single n (e : ℤ)) r := by
+  rw [← zero_add (Finsupp.single n (e : ℤ)), monomial_add_single, C_apply]
+
+theorem C_mul_X_eq_monomial (n : σ) (r : R) :
+    C r * X n = monomial (Finsupp.single n 1) r := by
+  simpa using C_mul_X_pow_eq_monomial n r 1
+
+@[simp]
+theorem monomial_zero {d : σ →₀ ℤ} : monomial d (0 : R) = 0 :=
+  Finsupp.single_zero _
+
+@[simp]
+theorem monomial_zero' : (monomial (0 : σ →₀ ℤ) : R → MvLaurentPolynomial σ R) = C :=
+  rfl
+
+@[simp]
+theorem monomial_eq_zero {d : σ →₀ ℤ} {r : R} : monomial d r = 0 ↔ r = 0 :=
+  Finsupp.single_eq_zero
+
+@[simp]
+theorem sum_monomial_eq {A : Type*} [AddCommMonoid A] {d : σ →₀ ℤ} {r : R}
+    {f : (σ →₀ ℤ) → R → A} (h0 : f d 0 = 0) :
+    sum (monomial d r) f = f d r :=
+  Finsupp.sum_single_index h0
+
+@[simp]
+theorem sum_C {A : Type*} [AddCommMonoid A] {f : (σ →₀ ℤ) → R → A} (r : R) (h0 : f 0 0 = 0) :
+    sum (C r) f = f 0 r :=
+  sum_monomial_eq h0
+
+theorem support_monomial {d : σ →₀ ℤ} {r : R} [Decidable (r = 0)] :
+    (monomial d r : MvLaurentPolynomial σ R).support = if r = 0 then ∅ else {d} := by
+  by_cases hr : r = 0
+  · simp [support, monomial, hr]
+  · simpa [support, monomial, hr] using (Finsupp.support_single_ne_zero d hr)
+
+theorem support_monomial_subset (d : σ →₀ ℤ) (r : R) :
+    (monomial d r : MvLaurentPolynomial σ R).support ⊆ {d} := by
+  by_cases hr : r = 0
+  · subst r
+    intro e he
+    have h0 : coeff e (0 : MvLaurentPolynomial σ R) ≠ 0 := by
+      simpa [support, coeff, monomial_zero] using he
+    exact (h0 rfl).elim
+  · classical
+    simp [support_monomial, hr]
+
+@[simp]
+theorem coeff_zero (d : σ →₀ ℤ) : coeff d (0 : MvLaurentPolynomial σ R) = 0 :=
+  rfl
+
+@[simp]
+theorem coeff_monomial (d e : σ →₀ ℤ) [Decidable (e = d)] (r : R) :
+    coeff d (monomial e r : MvLaurentPolynomial σ R) = if e = d then r else 0 := by
+  rw [coeff, monomial, AddMonoidAlgebra.lsingle_apply, Finsupp.single_apply]
+
+@[simp]
+theorem coeff_C (d : σ →₀ ℤ) [Decidable (0 = d)] (r : R) :
+    coeff d (C r : MvLaurentPolynomial σ R) = if 0 = d then r else 0 := by
+  rw [C_apply, coeff_monomial]
+
+theorem coeff_X' (n : σ) (d : σ →₀ ℤ) [Decidable (Finsupp.single n 1 = d)] :
+    coeff d (X n : MvLaurentPolynomial σ R) = if Finsupp.single n 1 = d then 1 else 0 := by
+  rw [X, coeff_monomial]
+
+@[simp]
+theorem coeff_X (n : σ) :
+    coeff (Finsupp.single n 1) (X n : MvLaurentPolynomial σ R) = 1 := by
+  classical
+  simp [coeff_X']
+
+@[simp]
+theorem coeff_mul_monomial (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
+    coeff (m + s) (p * monomial s r) = coeff m p * r :=
+  AddMonoidAlgebra.mul_single_apply_aux fun _ _ ↦ add_left_inj _
+
+@[simp]
+theorem coeff_monomial_mul (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
+    coeff (s + m) (monomial s r * p) = r * coeff m p :=
+  AddMonoidAlgebra.single_mul_apply_aux fun _ _ ↦ add_right_inj _
+
+theorem coeff_mul_monomial' (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
+    coeff m (p * monomial s r) = coeff (m - s) p * r := by
+  simpa [sub_eq_add_neg, add_assoc] using coeff_mul_monomial (m - s) s r p
+
+theorem coeff_monomial_mul' (m : σ →₀ ℤ) (s : σ →₀ ℤ) (r : R) (p : MvLaurentPolynomial σ R) :
+    coeff m (monomial s r * p) = r * coeff (m - s) p := by
+  simpa [sub_eq_add_neg, add_assoc] using coeff_monomial_mul (m - s) s r p
+
+@[simp]
+theorem mem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
+    d ∈ p.support ↔ p.coeff d ≠ 0 := by
+  simp [support, coeff]
+
+theorem notMem_support_iff {p : MvLaurentPolynomial σ R} {d : σ →₀ ℤ} :
+    d ∉ p.support ↔ p.coeff d = 0 := by
+  simp [support, coeff]
+
+@[simp]
+theorem support_zero : (0 : MvLaurentPolynomial σ R).support = ∅ :=
+  rfl
+
+@[simp]
+theorem support_eq_empty {p : MvLaurentPolynomial σ R} : p.support = ∅ ↔ p = 0 :=
+  Finsupp.support_eq_empty
+
+@[simp]
+theorem support_X [Nontrivial R] (n : σ) :
+    (X n : MvLaurentPolynomial σ R).support = {Finsupp.single n 1} :=
+  Finsupp.support_single_ne_zero _ one_ne_zero
+
+theorem eq_zero_iff {p : MvLaurentPolynomial σ R} : p = 0 ↔ ∀ d, coeff d p = 0 := by
+  constructor
+  · intro hp d
+    subst hp
+    exact coeff_zero d
+  · intro hp
+    ext d
+    simpa [coeff] using hp d
+
+theorem ne_zero_iff {p : MvLaurentPolynomial σ R} : p ≠ 0 ↔ ∃ d, coeff d p ≠ 0 := by
+  rw [Ne, eq_zero_iff]
+  push_neg
+  rfl
+
+@[simp]
+theorem support_nonempty {p : MvLaurentPolynomial σ R} : p.support.Nonempty ↔ p ≠ 0 := by
+  rw [Finset.nonempty_iff_ne_empty, ne_eq, support_eq_empty]
+
+theorem exists_coeff_ne_zero {p : MvLaurentPolynomial σ R} (hp : p ≠ 0) :
+    ∃ d, coeff d p ≠ 0 :=
+  ne_zero_iff.mp hp
+
+@[simp]
+theorem X_ne_zero [Nontrivial R] (n : σ) :
+    X n ≠ (0 : MvLaurentPolynomial σ R) := by
+  rw [ne_zero_iff]
+  exact ⟨Finsupp.single n 1, by simp⟩
+
+theorem sum_def {A : Type*} [AddCommMonoid A] {p : MvLaurentPolynomial σ R}
+    {f : (σ →₀ ℤ) → R → A} :
+    p.sum f = ∑ d ∈ p.support, f d (p.coeff d) := by
+  simp [support, coeff, Finsupp.sum]
+
+section AsSum
+
+@[simp]
+theorem support_sum_monomial_coeff (p : MvLaurentPolynomial σ R) :
+    (∑ d ∈ p.support, monomial d (coeff d p)) = p :=
+  Finsupp.sum_single p
+
+theorem as_sum (p : MvLaurentPolynomial σ R) :
+    p = ∑ d ∈ p.support, monomial d (coeff d p) :=
+  (support_sum_monomial_coeff p).symm
+
+end AsSum
+
+/-- To prove something about multivariate Laurent polynomials, it suffices to prove it for
+monomials and to show that it is preserved by addition. -/
+@[elab_as_elim]
+theorem induction_on' {P : MvLaurentPolynomial σ R → Prop} (p : MvLaurentPolynomial σ R)
+    (monomial : ∀ (d : σ →₀ ℤ) (r : R), P (MvLaurentPolynomial.monomial d r))
+    (add : ∀ p q : MvLaurentPolynomial σ R, P p → P q → P (p + q)) : P p :=
+  Finsupp.induction p
+    (suffices P (MvLaurentPolynomial.monomial 0 0) by
+      rwa [monomial_zero] at this
+    show P (MvLaurentPolynomial.monomial 0 0) from monomial 0 0)
+    fun _ _ _ _ha _hb hp ↦ add _ _ (monomial _ _) hp
+
+end CommSemiring
+
+end MvLaurentPolynomial
+
+namespace MvPolynomial
+
+section CommSemiring
+
+variable [CommSemiring R]
+
+/-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials. -/
+def toMvLaurent : MvPolynomial σ R →+* MvLaurentPolynomial σ R :=
+  AddMonoidAlgebra.mapDomainRingHom R <| Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)
+
+/-- The natural inclusion from multivariate polynomials to multivariate Laurent polynomials as an
+`R`-algebra homomorphism. -/
+def toMvLaurentAlg : MvPolynomial σ R →ₐ[R] MvLaurentPolynomial σ R :=
+  AddMonoidAlgebra.mapDomainAlgHom R R <| Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ)
+
+@[simp]
+theorem coe_toMvLaurentAlg :
+    ((toMvLaurentAlg : MvPolynomial σ R →ₐ[R] MvLaurentPolynomial σ R) :
+      MvPolynomial σ R → MvLaurentPolynomial σ R) = toMvLaurent :=
+  rfl
+
+theorem toMvLaurentAlg_apply (p : MvPolynomial σ R) : toMvLaurentAlg p = toMvLaurent p :=
+  rfl
+
+@[simp]
+theorem toMvLaurent_monomial (d : σ →₀ ℕ) (r : R) :
+    toMvLaurent (monomial d r) = MvLaurentPolynomial.monomial (d.mapRange Int.ofNat (by simp)) r :=
+  AddMonoidAlgebra.mapDomain_single
+
+@[simp]
+theorem toMvLaurent_C (r : R) :
+    toMvLaurent (C r : MvPolynomial σ R) = MvLaurentPolynomial.C r := by
+  change
+    AddMonoidAlgebra.mapDomain (Finsupp.mapRange.addMonoidHom (Int.ofNatHom : ℕ →+ ℤ))
+      (Finsupp.single 0 r) = MvLaurentPolynomial.C r
+  rw [AddMonoidAlgebra.mapDomain_single]
+  simp [MvLaurentPolynomial.C_apply, MvLaurentPolynomial.monomial]
+
+@[simp]
+theorem toMvLaurent_X (n : σ) :
+    toMvLaurent (X n : MvPolynomial σ R) = MvLaurentPolynomial.X n := by
+  simp [MvPolynomial.X, MvLaurentPolynomial.X, toMvLaurent_monomial]
+
+theorem toMvLaurent_injective :
+    Function.Injective (toMvLaurent : MvPolynomial σ R →+* MvLaurentPolynomial σ R) :=
+  AddMonoidAlgebra.mapDomain_injective
+    (Finsupp.mapRange_injective Int.ofNat (by simp) Int.ofNat_injective)
+
+theorem toMvLaurent_inj (p q : MvPolynomial σ R) : toMvLaurent p = toMvLaurent q ↔ p = q :=
+  toMvLaurent_injective.eq_iff
+
+theorem toMvLaurent_eq_zero {p : MvPolynomial σ R} : toMvLaurent p = 0 ↔ p = 0 :=
+  map_eq_zero_iff _ toMvLaurent_injective
+
+theorem toMvLaurent_ne_zero {p : MvPolynomial σ R} : toMvLaurent p ≠ 0 ↔ p ≠ 0 :=
+  map_ne_zero_iff _ toMvLaurent_injective
+
+end CommSemiring
+
+end MvPolynomial
+
+namespace MvLaurentPolynomial
+
+section CommSemiring
+
+variable [CommSemiring R]
+
+instance algebraMvPolynomial : Algebra (MvPolynomial σ R) (MvLaurentPolynomial σ R) where
+  __ := MvPolynomial.toMvLaurent.toAlgebra
+
+@[simp]
+theorem algebraMap_eq_toMvLaurent (p : MvPolynomial σ R) :
+    algebraMap (MvPolynomial σ R) (MvLaurentPolynomial σ R) p = MvPolynomial.toMvLaurent p :=
+  rfl
+
+end CommSemiring
+
+end MvLaurentPolynomial


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

~~I used Codex to imitate the  `MvPolynomial` API.~~ Now it has been rewritten by hand to focus on its `AddMonoidAlgebra` features.
Proving `UniqueFactorizationMonoid` is my next plan.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
