### PR TITLE
[Merged by Bors] - fix(Tactic/DepRewrite): `conv` mode

### DIFF
--- a/Mathlib/Tactic/DepRewrite.lean
+++ b/Mathlib/Tactic/DepRewrite.lean
@@ -634,10 +634,10 @@ namespace Conv
 open Conv
 
 @[inherit_doc depRewriteSeq]
-syntax (name := depRewrite) "rewrite!" optConfig rwRuleSeq (location)? : conv
+syntax (name := depRewrite) "rewrite!" optConfig rwRuleSeq : conv
 
 @[inherit_doc depRwSeq]
-syntax (name := depRw) "rw!" optConfig rwRuleSeq (location)? : conv
+syntax (name := depRw) "rw!" optConfig rwRuleSeq : conv
 
 /-- Apply `rewrite!` to the goal. -/
 def depRewriteTarget (stx : Syntax) (symm : Bool) (config : DepRewrite.Config := {}) :
@@ -655,28 +655,18 @@ def depRwTarget (stx : Syntax) (symm : Bool) (config : DepRewrite.Config := {}) 
     let r ←  (← getMainGoal).depRewrite (← getLhs) e symm (config := config)
     updateLhs r.eNew r.eqProof
     changeLhs (← withTransparency config.castTransparency
-      (withMainContext <| cleanupCasts (← getMainTarget)))
+      (withMainContext <| cleanupCasts (← getLhs)))
     replaceMainGoal ((← getMainGoal) :: r.mvarIds)
 
 @[tactic depRewrite, inherit_doc depRewriteSeq]
 def evalDepRewriteSeq : Tactic := fun stx => do
   let cfg ← elabDepRewriteConfig stx[1]
-  let loc   := expandOptLocation stx[3]
-  withRWRulesSeq stx[0] stx[2] fun symm term => do
-    withLocation loc
-      (DepRewrite.depRewriteLocalDecl term symm · cfg)
-      (depRewriteTarget term symm cfg)
-      (throwTacticEx `depRewrite · "did not find instance of the pattern in the current goal")
+  withRWRulesSeq stx[0] stx[2] fun symm term => depRewriteTarget term symm cfg
 
 @[tactic depRw, inherit_doc depRwSeq]
 def evalDepRwSeq : Tactic := fun stx => do
   let cfg ← elabDepRewriteConfig stx[1]
-  let loc   := expandOptLocation stx[3]
-  withRWRulesSeq stx[0] stx[2] fun symm term => do
-    withLocation loc
-      (depRwLocalDecl term symm · cfg)
-      (depRwTarget term symm cfg)
-      (throwTacticEx `depRewrite · "did not find instance of the pattern in the current goal")
+  withRWRulesSeq stx[0] stx[2] fun symm term => depRwTarget term symm cfg
 
 end Conv
 end Mathlib.Tactic.DepRewrite

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -452,3 +452,44 @@ example (x : Fin n) : P x := by
 example {x : Bool} (h : x = x) : x = x := by
   rw! [h] at h
   exact h
+
+/-! ## Tests for `conv` mode -/
+
+example (x : Fin n) : P x.1 := by
+  conv =>
+    enter [1]
+    rewrite! (castMode := .all) [eq]
+    guard_target =ₛ (cast% eq ▸ x).1
+  guard_target =ₛ P (cast% eq ▸ x).1
+  exact test_sorry
+
+example (f : ∀ c, Fin c) : P (f n).1 := by
+  conv =>
+    enter [1, 1]
+    rewrite! (castMode := .all) [eq]
+  guard_target =ₛ P (cast% eq.symm ▸ f m).1
+  exact test_sorry
+
+example (x : Fin n) : P x.1 := by
+  conv =>
+    enter [1]
+    rw! (castMode := .all) [eq]
+    guard_target =ₛ (cast% eq ▸ x).1
+  guard_target =ₛ P (cast% eq ▸ x).1
+  exact test_sorry
+
+example (f : ∀ c, Fin c) : P (f n).1 := by
+  conv =>
+    enter [1, 1]
+    rw! (castMode := .all) [eq]
+  guard_target =ₛ P (cast% eq.symm ▸ f m).1
+  exact test_sorry
+
+example (f : Nat → ∀ c, Fin (c + n)) : P (f (f (f m n) (f n m)) n).1 := by
+  conv =>
+    enter [1, 1, 1, 1]
+    rw! (castMode := .all) [eq]
+    guard_target =~ cast% _
+  rw! (castMode := .all) [eq, ← eq]
+  guard_target =ₛ P ((f (f (f n n) (f n n))) n).1
+  exact test_sorry


### PR DESCRIPTION
Add tests for `rewrite!` and `rw!` in `conv` mode. Fix a bug where `rw!` always produces type-incorrect terms when rewriting the goal in `conv` mode. Remove support for `rw! [...] at h` in `conv` mode, for consistency with `rw`, which does not have this feature, and because it's usually not what you want to do anyways.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
