### PR TITLE
feat(Algebra/Group/Submonoid/Support): properties of submonoid support

### DIFF
--- a/Mathlib/Algebra/Group/Submonoid/Support.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Support.lean
@@ -117,4 +117,53 @@ theorem maximal_isMulPointed (hMp : M.IsMulPointed) (hMs : M.IsMulSpanning) :
     Maximal IsMulPointed M :=
   ⟨hMp, fun N hN h ↦ by rw [SetLike.le_def] at h ⊢; aesop⟩
 
-end Submonoid.IsMulSpanning
+end IsMulSpanning
+
+section Group
+
+variable {G H : Type*} [Group G] [Group H] (f : G →* H) (M N : Submonoid G) (M' : Submonoid H)
+         {s : Set (Submonoid G)}
+
+variable {M N} in
+@[to_additive]
+theorem mulSupport_mono (h : M ≤ N) : M.mulSupport ≤ N.mulSupport := fun _ ↦ by aesop
+
+@[to_additive (attr := simp)]
+theorem mulSupport_inf : (M ⊓ N).mulSupport = M.mulSupport ⊓ N.mulSupport := by aesop
+
+@[to_additive (attr := simp)]
+theorem mulSupport_sInf (s : Set (Submonoid G)) :
+    (sInf s).mulSupport = InfSet.sInf (mulSupport '' s) := by aesop
+
+variable {M'} in
+@[to_additive (attr := aesop 90%)]
+theorem IsMulSpanning.comap (hM' : M'.IsMulSpanning) : (M'.comap f).IsMulSpanning := by aesop
+
+@[to_additive (attr := simp)]
+theorem comap_mulSupport : (M'.comap f).mulSupport = (M'.mulSupport).comap f := by aesop
+
+variable {f M} in
+@[to_additive]
+theorem IsMulSpanning.map (hM : M.IsMulSpanning) (hf : Function.Surjective f) :
+    (M.map f).IsMulSpanning := fun x ↦ by
+  obtain ⟨x', rfl⟩ := hf x
+  aesop
+
+end Group
+
+section CommGroup
+
+variable {G H : Type*} [CommGroup G] [CommGroup H] (f : G →* H) (M : Submonoid G)
+
+variable {f M} in
+@[to_additive (attr := simp)]
+theorem map_mulSupport (hsupp : f.ker ≤ M.mulSupport) :
+    (M.map f).mulSupport = (M.mulSupport).map f := by
+  ext
+  refine ⟨fun ⟨⟨a, ⟨ha₁, ha₂⟩⟩, ⟨b, ⟨hb₁, hb₂⟩⟩⟩ => ?_, by aesop⟩
+  have : (a * b)⁻¹ * b ∈ M := by exact mul_mem (hsupp (show f (a * b) = 1 by simp_all)).2 hb₁
+  aesop
+
+end CommGroup
+
+end Submonoid


### PR DESCRIPTION
* Prove how the support of a submonoid interacts with various operations

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
