### PR TITLE
[Merged by Bors] - chore(FieldTheory/AbsoluteGaloisGroup): remove `set_option backward.isDefEq.respectTransparency false`

### DIFF
--- a/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
+++ b/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
@@ -49,9 +49,10 @@ noncomputable instance : Group (G_K K) := AlgEquiv.aut
 /-- `absoluteGaloisGroup` is a topological space with the Krull topology. -/
 noncomputable instance : TopologicalSpace (G_K K) := krullTopology K (AlgebraicClosure K)
 
+instance : IsTopologicalGroup (G_K K) := inferInstanceAs (IsTopologicalGroup (_ ≃ₐ[K] _))
+
 /-! ### The topological abelianization of the absolute Galois group -/
 
-set_option backward.isDefEq.respectTransparency false in
 instance absoluteGaloisGroup.commutator_closure_isNormal :
     (commutator (G_K K)).topologicalClosure.Normal :=
   Subgroup.is_normal_topologicalClosure (commutator (G_K K))

--- a/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
+++ b/Mathlib/FieldTheory/AbsoluteGaloisGroup.lean
@@ -57,7 +57,6 @@ instance absoluteGaloisGroup.commutator_closure_isNormal :
     (commutator (G_K K)).topologicalClosure.Normal :=
   Subgroup.is_normal_topologicalClosure (commutator (G_K K))
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The topological abelianization of `absoluteGaloisGroup`, that is, the quotient of
   `absoluteGaloisGroup` by the topological closure of its commutator subgroup. -/
 abbrev absoluteGaloisGroupAbelianization := TopologicalAbelianization (G_K K)


### PR DESCRIPTION
Remove a `set_option backward.isDefEq.respectTransparency false in`. `Subgroup.topologicalClosure` requires `IsTopologicalGroup (G_K K)`, which is not available, so I have no idea how this was working before.

See also [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib.2FFieldTheory.2FAbsoluteGaloisGroup/near/582074231).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
