### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal): use to_additive for the Yoneda embedding of monoid objects

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
@@ -28,17 +28,21 @@ section SemiCartesianMonoidalCategory
 
 variable {D : Type*} [Category* D] [SemiCartesianMonoidalCategory D]
 
-@[simps]
-instance uniqueHomToTrivial (A : Mon D) : Unique (A ⟶ Mon.trivial D) where
+@[to_additive (attr := simps)]
+instance Mon.uniqueHomToTrivial (A : Mon D) : Unique (A ⟶ Mon.trivial D) where
   default.hom := toUnit A.X
   default.isMonHom_hom.mul_hom := toUnit_unique _ _
   uniq f := Mon.Hom.ext (toUnit_unique _ _)
 
+@[deprecated (since := "2026-03-20")] alias uniqueHomToTrivial := Mon.uniqueHomToTrivial
+
+@[to_additive instHasZeroObjectAddMon]
 instance : HasZeroObject (Mon D) where
   zero := ⟨Mon.trivial D,
     fun A ↦ nonempty_unique (Mon.trivial D ⟶ A),
     fun A ↦ nonempty_unique (A ⟶ Mon.trivial D)⟩
 
+@[to_additive instHasZeroMorphismsAddMon]
 noncomputable instance : HasZeroMorphisms (Mon D) := HasZeroObject.zeroMorphismsOfZeroObject
 
 end SemiCartesianMonoidalCategory
@@ -50,23 +54,26 @@ variable {C D : Type*} [Category.{v} C] [CartesianMonoidalCategory C]
 
 namespace MonObj
 
+@[to_additive]
 instance : IsMonHom (toUnit M) where
 
+@[to_additive]
 instance : IsMonHom η[M] where
   mul_hom := by simp [toUnit_unique (ρ_ (𝟙_ C)).hom (λ_ (𝟙_ C)).hom]
 
+@[to_additive]
 theorem lift_lift_assoc {A : C} {B : C} [MonObj B] (f g h : A ⟶ B) :
     lift (lift f g ≫ μ) h ≫ μ = lift f (lift g h ≫ μ) ≫ μ := by
   have := lift (lift f g) h ≫= mul_assoc B
   rwa [lift_whiskerRight_assoc, lift_lift_associator_hom_assoc, lift_whiskerLeft_assoc] at this
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 theorem lift_comp_one_left {A : C} {B : C} [MonObj B] (f : A ⟶ 𝟙_ C) (g : A ⟶ B) :
     lift (f ≫ η) g ≫ μ = g := by
   have := lift f g ≫= one_mul B
   rwa [lift_whiskerRight_assoc, lift_leftUnitor_hom] at this
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 theorem lift_comp_one_right {A : C} {B : C} [MonObj B] (f : A ⟶ B) (g : A ⟶ 𝟙_ C) :
     lift f (g ≫ η) ≫ μ = f := by
   have := lift f g ≫= mul_one B
@@ -76,11 +83,16 @@ variable [BraidedCategory C]
 
 attribute [local simp] tensorObj.one_def tensorObj.mul_def
 
+@[to_additive]
 instance : IsMonHom (fst M N) where
+
+@[to_additive]
 instance : IsMonHom (snd M N) where
 
+@[to_additive]
 instance {f : M ⟶ N} {g : M ⟶ O} [IsMonHom f] [IsMonHom g] : IsMonHom (lift f g) where
 
+@[to_additive]
 instance [IsCommMonObj M] : IsMonHom μ[M] where
   one_hom := by simp [toUnit_unique (ρ_ (𝟙_ C)).hom (λ_ (𝟙_ C)).hom]
 
@@ -91,6 +103,7 @@ variable [BraidedCategory C]
 
 set_option backward.isDefEq.respectTransparency false in
 attribute [local simp] tensorObj.one_def tensorObj.mul_def in
+@[to_additive]
 instance : CartesianMonoidalCategory (Mon C) where
   isTerminalTensorUnit := .ofUniqueHom (fun M ↦ ⟨toUnit _⟩) fun M f ↦ by ext; exact toUnit_unique ..
   fst M N := .mk (fst M.X N.X)
@@ -103,21 +116,35 @@ instance : CartesianMonoidalCategory (Mon C) where
 
 variable {M N N₁ N₂ : Mon C}
 
-@[simp] lemma lift_hom (f : M ⟶ N₁) (g : M ⟶ N₂) : (lift f g).hom = lift f.hom g.hom := rfl
-@[simp] lemma fst_hom (M N : Mon C) : (fst M N).hom = fst M.X N.X := rfl
-@[simp] lemma snd_hom (M N : Mon C) : (snd M N).hom = snd M.X N.X := rfl
+@[to_additive (attr := simp)]
+lemma lift_hom (f : M ⟶ N₁) (g : M ⟶ N₂) : (lift f g).hom = lift f.hom g.hom := rfl
+
+@[to_additive (attr := simp)]
+lemma fst_hom (M N : Mon C) : (fst M N).hom = fst M.X N.X := rfl
+
+@[to_additive (attr := simp)]
+lemma snd_hom (M N : Mon C) : (snd M N).hom = snd M.X N.X := rfl
 
 /-! ### Comm monoid objects are internal monoid objects -/
 
 /-- A commutative monoid object is a monoid object in the category of monoid objects. -/
+@[to_additive
+/-- A commutative additive monoid object is an additive monoid object in the category
+of additive monoid objects. -/]
 instance [IsCommMonObj M.X] : MonObj M where
   one := .mk η[M.X]
   mul := .mk μ[M.X]
 
-@[simp] lemma hom_one (M : Mon C) [IsCommMonObj M.X] : η[M].hom = η[M.X] := rfl
-@[simp] lemma hom_mul (M : Mon C) [IsCommMonObj M.X] : μ[M].hom = μ[M.X] := rfl
+@[to_additive (attr := simp)]
+lemma hom_one (M : Mon C) [IsCommMonObj M.X] : η[M].hom = η[M.X] := rfl
+
+@[to_additive (attr := simp)]
+lemma hom_mul (M : Mon C) [IsCommMonObj M.X] : μ[M].hom = μ[M.X] := rfl
 
 /-- A commutative monoid object is a commutative monoid object in the category of monoid objects. -/
+@[to_additive
+/-- A commutative additive monoid object is a commutative additive monoid object in the
+category of additive monoid objects. -/]
 instance [IsCommMonObj M.X] : IsCommMonObj M where
 
 end Mon
@@ -125,7 +152,8 @@ end Mon
 set_option backward.isDefEq.respectTransparency false in
 variable (X) in
 /-- If `X` represents a presheaf of monoids, then `X` is a monoid object. -/
-@[simps, implicit_reducible]
+@[to_additive (attr := simps, implicit_reducible)
+/-- If `X` represents a presheaf of additive monoids, then `X` is an additive monoid object. -/]
 def MonObj.ofRepresentableBy (F : Cᵒᵖ ⥤ MonCat.{w}) (α : (F ⋙ forget _).RepresentableBy X) :
     MonObj X where
   one := α.homEquiv.symm 1
@@ -159,6 +187,8 @@ def MonObj.ofRepresentableBy (F : Cᵒᵖ ⥤ MonCat.{w}) (α : (F ⋙ forget _)
     simp
 
 /-- If `M` is a monoid object, then `Hom(X, M)` has a monoid structure. -/
+@[to_additive
+/-- If `M` is an additive monoid object, then `Hom(X, M)` has an additive monoid structure. -/]
 abbrev Hom.monoid : Monoid (X ⟶ M) where
   mul f₁ f₂ := lift f₁ f₂ ≫ μ
   mul_assoc f₁ f₂ f₃ := by
@@ -185,7 +215,9 @@ abbrev Hom.monoid : Monoid (X ⟶ M) where
 
 scoped[CategoryTheory.MonObj] attribute [instance] Hom.monoid
 
+@[to_additive]
 lemma Hom.one_def : (1 : X ⟶ M) = toUnit X ≫ η := rfl
+@[to_additive]
 lemma Hom.mul_def (f₁ f₂ : X ⟶ M) : f₁ * f₂ = lift f₁ f₂ ≫ μ := rfl
 
 namespace Functor
@@ -193,20 +225,23 @@ variable (F : C ⥤ D) [F.Monoidal]
 
 open scoped Obj
 
+@[to_additive map_add']
 protected lemma map_mul (f g : X ⟶ M) : F.map (f * g) = F.map f * F.map g := by
   simp [Hom.mul_def]
 
-@[simp] protected lemma map_one : F.map (1 : X ⟶ M) = 1 := by simp [Hom.one_def]
+@[to_additive (attr := simp) map_zero']
+protected lemma map_one : F.map (1 : X ⟶ M) = 1 := by simp [Hom.one_def]
 
 /-- `Functor.map` of a monoidal functor as a `MonoidHom`. -/
-@[simps]
+@[to_additive (attr := simps) /-- `Functor.map` of a monoidal functor as a `AddMonoidHom`. -/]
 def homMonoidHom : (X ⟶ M) →* (F.obj X ⟶ F.obj M) where
   toFun := F.map
   map_one' := F.map_one
   map_mul' := F.map_mul
 
 /-- `Functor.map` of a fully faithful monoidal functor as a `MulEquiv`. -/
-@[simps!]
+@[to_additive (attr := simps!)
+/-- `Functor.map` of a fully faithful monoidal functor as a `AddEquiv`. -/]
 def FullyFaithful.homMulEquiv (hF : F.FullyFaithful) : (X ⟶ M) ≃* (F.obj X ⟶ F.obj M) where
   __ := hF.homEquiv
   __ := F.homMonoidHom
@@ -217,26 +252,33 @@ section BraidedCategory
 variable [BraidedCategory C]
 
 /-- If `M` is a commutative monoid object, then `Hom(X, M)` has a commutative monoid structure. -/
+@[to_additive
+/-- If `M` is a commutative additive monoid object, then `Hom(X, M)` has a commutative additive
+monoid structure. -/]
 abbrev Hom.commMonoid [IsCommMonObj M] : CommMonoid (X ⟶ M) where
   mul_comm f g := by simpa [-IsCommMonObj.mul_comm] using lift g f ≫= IsCommMonObj.mul_comm M
 
 namespace Mon.Hom
 variable {M N : Mon C} [IsCommMonObj N.X]
 
-@[simp] lemma hom_one : (1 : M ⟶ N).hom = 1 := rfl
-@[simp] lemma hom_mul (f g : M ⟶ N) : (f * g).hom = f.hom * g.hom := rfl
-@[simp] lemma hom_pow (f : M ⟶ N) (n : ℕ) : (f ^ n).hom = f.hom ^ n := by
+@[to_additive (attr := simp)]
+lemma hom_one : (1 : M ⟶ N).hom = 1 := rfl
+@[to_additive (attr := simp)]
+lemma hom_mul (f g : M ⟶ N) : (f * g).hom = f.hom * g.hom := rfl
+@[to_additive (attr := simp)]
+lemma hom_pow (f : M ⟶ N) (n : ℕ) : (f ^ n).hom = f.hom ^ n := by
   induction n <;> simp [pow_succ, *]
 
 end Mon.Hom
 
-scoped[CategoryTheory.MonObj] attribute [instance] Hom.commMonoid
+scoped[CategoryTheory.MonObj] attribute [instance] Hom.commMonoid Hom.addCommMonoid
 
 end BraidedCategory
 
 variable (M) in
 /-- If `M` is a monoid object, then `Hom(-, M)` is a presheaf of monoids. -/
-@[simps]
+@[to_additive (attr := simps)
+/-- If `M` is an additive monoid object, then `Hom(-, M)` is a presheaf of additive monoids. -/]
 def yonedaMonObj : Cᵒᵖ ⥤ MonCat.{v} where
   obj X := MonCat.of (unop X ⟶ M)
   map {X Y₂} φ := MonCat.ofHom
@@ -255,7 +297,9 @@ set_option backward.isDefEq.respectTransparency false in
 variable (X) in
 /-- If `X` represents a presheaf of monoids `F`, then `Hom(-, X)` is isomorphic to `F` as
 a presheaf of monoids. -/
-@[simps!]
+@[to_additive (attr := simps!)
+/-- If `X` represents a presheaf of additive monoids `F`, then `Hom(-, X)` is isomorphic
+to `F` as a presheaf of additive monoids. -/]
 def yonedaMonObjIsoOfRepresentableBy
     (F : Cᵒᵖ ⥤ MonCat.{v}) (α : (F ⋙ forget _).RepresentableBy X) :
     letI := MonObj.ofRepresentableBy X F α
@@ -271,8 +315,9 @@ def yonedaMonObjIsoOfRepresentableBy
         simp only [← Functor.comp_map, ← ConcreteCategory.forget_map_eq_coe, ← α.homEquiv_comp]
         simp }) (fun φ ↦ MonCat.hom_ext (MonoidHom.ext (α.homEquiv_comp φ.unop)))
 
-/-- The yoneda embedding of `Mon_C` into presheaves of monoids. -/
-@[simps]
+/-- The yoneda embedding of `Mon C` into presheaves of monoids. -/
+@[to_additive (attr := simps)
+/-- The yoneda embedding of `AddMon C` into presheaves of additive monoids. -/]
 def yonedaMon : Mon C ⥤ Cᵒᵖ ⥤ MonCat.{v} where
   obj M := yonedaMonObj M.X
   map {M N} ψ :=
@@ -285,22 +330,27 @@ def yonedaMon : Mon C ⥤ Cᵒᵖ ⥤ MonCat.{v} where
   map_comp _ _ :=
     NatTrans.ext <| funext fun _ ↦ MonCat.hom_ext <| MonoidHom.ext (.symm <| Category.assoc · _ _)
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma yonedaMon_naturality (α : yonedaMonObj M ⟶ yonedaMonObj N) (f : X ⟶ Y) (g : Y ⟶ M) :
       α.app _ (f ≫ g) = f ≫ α.app _ g := congr($(α.naturality f.op) g)
 
 variable (M) in
 /-- If `M` is a monoid object, then `Hom(-, M)` as a presheaf of monoids is represented by `M`. -/
+@[to_additive
+/-- If `M` is an additive monoid object, then `Hom(-, M)` as a presheaf of additive monoids
+is represented by `M`. -/]
 def yonedaMonObjRepresentableBy : (yonedaMonObj M ⋙ forget _).RepresentableBy M :=
   Functor.representableByEquiv.symm (.refl _)
 
 variable (M) in
+@[to_additive]
 lemma MonObj.ofRepresentableBy_yonedaMonObjRepresentableBy :
     ofRepresentableBy M _ (yonedaMonObjRepresentableBy M) = ‹_› := by
   ext; change lift (fst M M) (snd M M) ≫ μ = μ; rw [lift_fst_snd, Category.id_comp]
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The yoneda embedding for `Mon_C` is fully faithful. -/
+/-- The yoneda embedding for `Mon C` is fully faithful. -/
+@[to_additive /-- The yoneda embedding for `AddMon C` is fully faithful. -/]
 def yonedaMonFullyFaithful : yonedaMon (C := C).FullyFaithful where
   preimage {M N} α :=
     { hom := α.app (op M.X) (𝟙 M.X)
@@ -325,9 +375,12 @@ def yonedaMonFullyFaithful : yonedaMon (C := C).FullyFaithful where
     simp
   preimage_map φ := Mon.Hom.ext (Category.id_comp φ.hom)
 
+@[to_additive]
 instance : yonedaMon (C := C).Full := yonedaMonFullyFaithful.full
+@[to_additive]
 instance : yonedaMon (C := C).Faithful := yonedaMonFullyFaithful.faithful
 
+@[to_additive]
 lemma essImage_yonedaMon :
     yonedaMon (C := C).essImage = fun F ↦ (F ⋙ forget _).IsRepresentable := by
   ext F
@@ -338,35 +391,37 @@ lemma essImage_yonedaMon :
     letI := MonObj.ofRepresentableBy X F e
     exact ⟨Mon.mk X, ⟨yonedaMonObjIsoOfRepresentableBy X F e⟩⟩
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma MonObj.one_comp (f : M ⟶ N) [IsMonHom f] : (1 : X ⟶ M) ≫ f = 1 := by simp [Hom.one_def]
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma MonObj.mul_comp (f₁ f₂ : X ⟶ M) (g : M ⟶ N) [IsMonHom g] :
     (f₁ * f₂) ≫ g = f₁ ≫ g * f₂ ≫ g := by simp [Hom.mul_def]
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma MonObj.pow_comp (f : X ⟶ M) (n : ℕ) (g : M ⟶ N) [IsMonHom g] :
     (f ^ n) ≫ g = (f ≫ g) ^ n := by
   induction n <;> simp [pow_succ, MonObj.mul_comp, *]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma MonObj.comp_one (f : X ⟶ Y) : f ≫ (1 : Y ⟶ M) = 1 :=
   ((yonedaMon.obj <| .mk M).map f.op).hom.map_one
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma MonObj.comp_mul (f : X ⟶ Y) (g₁ g₂ : Y ⟶ M) : f ≫ (g₁ * g₂) = f ≫ g₁ * f ≫ g₂ :=
   ((yonedaMon.obj <| .mk M).map f.op).hom.map_mul _ _
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma MonObj.comp_pow (f : X ⟶ M) (n : ℕ) (h : Y ⟶ X) : h ≫ f ^ n = (h ≫ f) ^ n := by
   induction n <;> simp [pow_succ, MonObj.comp_mul, *]
 
 variable (M) in
+@[to_additive]
 lemma MonObj.one_eq_one : η = (1 : _ ⟶ M) :=
   show _ = _ ≫ _ by rw [toUnit_unique (toUnit _) (𝟙 _), Category.id_comp]
 
 variable (M) in
+@[to_additive]
 lemma MonObj.mul_eq_mul : μ = fst M M * snd _ _ :=
   show _ = _ ≫ _ by rw [lift_fst_snd, Category.id_comp]
 
@@ -374,13 +429,16 @@ namespace Hom
 
 /-- If `M` and `N` are isomorphic as monoid objects, then `X ⟶ M` and `X ⟶ N` are isomorphic
 monoids. -/
-@[simps!]
+@[to_additive (attr := simps!)
+/-- If `M` and `N` are isomorphic as additive monoid objects, then `X ⟶ M` and `X ⟶ N`
+are isomorphic additive monoids. -/]
 def mulEquivCongrRight (e : M ≅ N) [IsMonHom e.hom] (X : C) : (X ⟶ M) ≃* (X ⟶ N) :=
   ((yonedaMon.mapIso <| Mon.mkIso' e).app <| .op X).monCatIsoToMulEquiv
 
 end Hom
 
 /-- A monoid object `M` is commutative if and only if `X ⟶ M` is commutative for all `X`. -/
+@[to_additive]
 lemma isCommMonObj_iff_isMulCommutative (M : C) [MonObj M] [BraidedCategory C] :
     IsCommMonObj M ↔ ∀ (X : C), IsMulCommutative (X ⟶ M) := by
   exact ⟨fun h X ↦ ⟨⟨by simp [mul_comm]⟩⟩, fun h ↦ ⟨by simp [mul_eq_mul, comp_mul, mul_comm]⟩⟩


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
