### PR TITLE
[Merged by Bors] - chore: new file for sets closed under directed suprema

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5756,6 +5756,7 @@ public import Mathlib.Order.Cover
 public import Mathlib.Order.Defs.LinearOrder
 public import Mathlib.Order.Defs.PartialOrder
 public import Mathlib.Order.Defs.Unbundled
+public import Mathlib.Order.DirSupClosed
 public import Mathlib.Order.Directed
 public import Mathlib.Order.DirectedInverseSystem
 public import Mathlib.Order.Disjoint

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.UpperLower.Basic
 We say that a set `s` is closed under directed suprema whenever it contains all least upper bounds
 for nonempty, directed subsets. Conversely, a set `s` is inaccessible by directed suprema whenever
 its complement is closed under directed suprema. Equivalently, if the least upper bound of a
-non-empty directed set `t` is contained in `s`, then `t` and `s` must have non-empty intersection.
+nonempty directed set `t` is contained in `s`, then `t` and `s` must have nonempty intersection.
 
 ## Main definitions
 

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2023 Christopher Hoskin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christopher Hoskin
+-/
+module
+
+public import Mathlib.Order.CompleteLattice.Defs
+public import Mathlib.Order.UpperLower.Basic
+
+/-!
+# Sets closed under directed suprema
+
+We say that a set `s` is closed under directed suprema whenever it contains all least upper bounds
+for nonempty, directed subsets. Conversely, a set `s` is inaccessible by directed suprema whenever
+its complement is closed under directed suprema. Equivalently, if the least upper bound of a
+non-empty directed set `t` is contained in `s`, then `t` and `s` must have non-empty intersection.
+
+## Main definitions
+
+- `DirSupClosed`: sets closed under directed suprema.
+- `DirSupInacc`: sets inaccessible by directed suprema.
+-/
+
+@[expose] public section
+
+variable {α : Type*}
+
+open Set
+
+section Preorder
+variable [Preorder α] {s t : Set α}
+
+/--
+A set `s` is said to be closed under directed joins if, whenever a directed set `d` has a least
+upper bound `a` and is a subset of `s` then `a` also lies in `s`.
+-/
+def DirSupClosed (s : Set α) : Prop :=
+  ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → d ⊆ s → a ∈ s
+
+/-- A set `s` is said to be inaccessible by directed joins on `D` if, when the least upper bound of
+a directed set `d` in `D` lies in `s` then `d` has non-empty intersection with `s`. -/
+def DirSupInaccOn (D : Set (Set α)) (s : Set α) : Prop :=
+  ∀ ⦃d⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty
+
+/-- A set `s` is said to be inaccessible by directed joins if, when the least upper bound of a
+directed set `d` lies in `s` then `d` has non-empty intersection with `s`. -/
+def DirSupInacc (s : Set α) : Prop :=
+  ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty
+
+@[simp] lemma dirSupInaccOn_univ : DirSupInaccOn univ s ↔ DirSupInacc s := by
+  simp [DirSupInaccOn, DirSupInacc]
+
+@[simp] lemma DirSupInacc.dirSupInaccOn {D : Set (Set α)} :
+    DirSupInacc s → DirSupInaccOn D s := fun h _ _ d₂ d₃ _ hda => h d₂ d₃ hda
+
+lemma DirSupInaccOn.mono {D₁ D₂ : Set (Set α)} (hD : D₁ ⊆ D₂) (hf : DirSupInaccOn D₂ s) :
+    DirSupInaccOn D₁ s := fun ⦃_⦄ a ↦ hf (hD a)
+
+@[simp] lemma dirSupInacc_compl : DirSupInacc sᶜ ↔ DirSupClosed s := by
+  simp [DirSupInacc, DirSupClosed, ← not_disjoint_iff_nonempty_inter, not_imp_not,
+    disjoint_compl_right_iff]
+
+@[simp] lemma dirSupClosed_compl : DirSupClosed sᶜ ↔ DirSupInacc s := by
+  rw [← dirSupInacc_compl, compl_compl]
+
+alias ⟨DirSupInacc.of_compl, DirSupClosed.compl⟩ := dirSupInacc_compl
+alias ⟨DirSupClosed.of_compl, DirSupInacc.compl⟩ := dirSupClosed_compl
+
+lemma DirSupClosed.inter (hs : DirSupClosed s) (ht : DirSupClosed t) : DirSupClosed (s ∩ t) :=
+  fun _d hd hd' _a ha hds ↦ ⟨hs hd hd' ha <| hds.trans inter_subset_left,
+    ht hd hd' ha <| hds.trans inter_subset_right⟩
+
+lemma DirSupInacc.union (hs : DirSupInacc s) (ht : DirSupInacc t) : DirSupInacc (s ∪ t) := by
+  rw [← dirSupClosed_compl, compl_union]; exact hs.compl.inter ht.compl
+
+lemma IsUpperSet.dirSupClosed (hs : IsUpperSet s) : DirSupClosed s :=
+  fun _d ⟨_b, hb⟩ _ _a ha hds ↦ hs (ha.1 hb) <| hds hb
+
+lemma IsLowerSet.dirSupInacc (hs : IsLowerSet s) : DirSupInacc s := hs.compl.dirSupClosed.of_compl
+
+lemma dirSupClosed_Iic (a : α) : DirSupClosed (Iic a) := fun _d _ _ _a ha ↦ (isLUB_le_iff ha).2
+
+end Preorder
+
+section CompleteLattice
+variable [CompleteLattice α] {s : Set α}
+
+lemma dirSupClosed_iff_forall_sSup :
+    DirSupClosed s ↔ ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → d ⊆ s → sSup d ∈ s := by
+  simp [DirSupClosed, isLUB_iff_sSup_eq]
+
+lemma dirSupInacc_iff_forall_sSup :
+    DirSupInacc s ↔ ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → sSup d ∈ s → (d ∩ s).Nonempty := by
+  simp [DirSupInacc, isLUB_iff_sSup_eq]
+
+end CompleteLattice

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -5,6 +5,7 @@ Authors: Christopher Hoskin
 -/
 module
 
+public import Mathlib.Order.DirSupClosed
 public import Mathlib.Order.ScottContinuity
 public import Mathlib.Topology.Order.UpperLowerSetTopology
 
@@ -15,10 +16,8 @@ This file introduces the Scott topology on a preorder.
 
 ## Main definitions
 
-- `DirSupInacc` - a set `u` is said to be inaccessible by directed joins if, when the least upper
-  bound of a directed set `d` lies in `u` then `d` has non-empty intersection with `u`.
-- `DirSupClosed` - a set `s` is said to be closed under directed joins if, whenever a directed set
-  `d` has a least upper bound `a` and is a subset of `s` then `a` also lies in `s`.
+- `Topology.scottHausdorff`: the Scott-Hausdorff topology is the topology whose closed sets are
+  `DirSupClosed`, i.e. closed under directed suprema.
 - `Topology.scott` - the Scott topology is defined as the join of the topology of upper sets and the
   Scott-Hausdorff topology (the topological space where a set `u` is open if, when the least upper
   bound of a directed set `d` lies in `u` then there is a tail of `d` which is a subset of `u`).
@@ -66,76 +65,6 @@ Scott topology, preorder
 open Set
 
 variable {α β : Type*}
-
-/-! ### Prerequisite order properties -/
-
-section Preorder
-variable [Preorder α] {s t : Set α}
-
-/-- A set `s` is said to be inaccessible by directed joins on `D` if, when the least upper bound of
-a directed set `d` in `D` lies in `s` then `d` has non-empty intersection with `s`. -/
-def DirSupInaccOn (D : Set (Set α)) (s : Set α) : Prop :=
-  ∀ ⦃d⦄, d ∈ D → d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty
-
-/-- A set `s` is said to be inaccessible by directed joins if, when the least upper bound of a
-directed set `d` lies in `s` then `d` has non-empty intersection with `s`. -/
-def DirSupInacc (s : Set α) : Prop :=
-  ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty
-
-@[simp] lemma dirSupInaccOn_univ : DirSupInaccOn univ s ↔ DirSupInacc s := by
-  simp [DirSupInaccOn, DirSupInacc]
-
-@[simp] lemma DirSupInacc.dirSupInaccOn {D : Set (Set α)} :
-    DirSupInacc s → DirSupInaccOn D s := fun h _ _ d₂ d₃ _ hda => h d₂ d₃ hda
-
-lemma DirSupInaccOn.mono {D₁ D₂ : Set (Set α)} (hD : D₁ ⊆ D₂) (hf : DirSupInaccOn D₂ s) :
-    DirSupInaccOn D₁ s := fun ⦃_⦄ a ↦ hf (hD a)
-
-/--
-A set `s` is said to be closed under directed joins if, whenever a directed set `d` has a least
-upper bound `a` and is a subset of `s` then `a` also lies in `s`.
--/
-def DirSupClosed (s : Set α) : Prop :=
-  ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a⦄, IsLUB d a → d ⊆ s → a ∈ s
-
-@[simp] lemma dirSupInacc_compl : DirSupInacc sᶜ ↔ DirSupClosed s := by
-  simp [DirSupInacc, DirSupClosed, ← not_disjoint_iff_nonempty_inter, not_imp_not,
-    disjoint_compl_right_iff]
-
-@[simp] lemma dirSupClosed_compl : DirSupClosed sᶜ ↔ DirSupInacc s := by
-  rw [← dirSupInacc_compl, compl_compl]
-
-alias ⟨DirSupInacc.of_compl, DirSupClosed.compl⟩ := dirSupInacc_compl
-alias ⟨DirSupClosed.of_compl, DirSupInacc.compl⟩ := dirSupClosed_compl
-
-lemma DirSupClosed.inter (hs : DirSupClosed s) (ht : DirSupClosed t) : DirSupClosed (s ∩ t) :=
-  fun _d hd hd' _a ha hds ↦ ⟨hs hd hd' ha <| hds.trans inter_subset_left,
-    ht hd hd' ha <| hds.trans inter_subset_right⟩
-
-lemma DirSupInacc.union (hs : DirSupInacc s) (ht : DirSupInacc t) : DirSupInacc (s ∪ t) := by
-  rw [← dirSupClosed_compl, compl_union]; exact hs.compl.inter ht.compl
-
-lemma IsUpperSet.dirSupClosed (hs : IsUpperSet s) : DirSupClosed s :=
-  fun _d ⟨_b, hb⟩ _ _a ha hds ↦ hs (ha.1 hb) <| hds hb
-
-lemma IsLowerSet.dirSupInacc (hs : IsLowerSet s) : DirSupInacc s := hs.compl.dirSupClosed.of_compl
-
-lemma dirSupClosed_Iic (a : α) : DirSupClosed (Iic a) := fun _d _ _ _a ha ↦ (isLUB_le_iff ha).2
-
-end Preorder
-
-section CompleteLattice
-variable [CompleteLattice α] {s : Set α}
-
-lemma dirSupInacc_iff_forall_sSup :
-    DirSupInacc s ↔ ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → sSup d ∈ s → (d ∩ s).Nonempty := by
-  simp [DirSupInacc, isLUB_iff_sSup_eq]
-
-lemma dirSupClosed_iff_forall_sSup :
-    DirSupClosed s ↔ ∀ ⦃d⦄, d.Nonempty → DirectedOn (· ≤ ·) d → d ⊆ s → sSup d ∈ s := by
-  simp [DirSupClosed, isLUB_iff_sSup_eq]
-
-end CompleteLattice
 
 namespace Topology
 


### PR DESCRIPTION
I plan to add more material to this file in the near future, and I figured it might be good to give it its own place.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
