### PR TITLE
[Merged by Bors] - chore(Order/UpperLower/Relative): remove `backward.isDefEq.respectTransparency`

### DIFF
--- a/Mathlib/Order/UpperLower/Relative.lean
+++ b/Mathlib/Order/UpperLower/Relative.lean
@@ -141,23 +141,21 @@ protected lemma IsRelLowerSet.iInter₂ [Nonempty ι] [∀ i, Nonempty (κ i)]
     IsRelLowerSet (⋂ (i) (j), f i j) P :=
   .iInter fun i ↦ .iInter (hf i)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma isUpperSet_subtype_iff_isRelUpperSet {s : Set { x // P x }} :
     IsUpperSet s ↔ IsRelUpperSet (Subtype.val '' s) P := by
   refine ⟨fun h a x ↦ ?_, fun h a b x y ↦ ?_⟩
   · obtain ⟨a, ma, rfl⟩ := x
     exact ⟨a.2, fun b x y ↦ by simpa [h (show a ≤ ⟨b, y⟩ by exact x) ma]⟩
   · have ma : a.1 ∈ Subtype.val '' s := by simp [a.2, y]
-    simpa only [mem_image, SetCoe.ext_iff, exists_eq_right] using (h ma).2 x b.2
+    simpa only [mem_image, Subtype.coe_inj, exists_eq_right] using (h ma).2 x b.2
 
-set_option backward.isDefEq.respectTransparency false in
 lemma isLowerSet_subtype_iff_isRelLowerSet {s : Set { x // P x }} :
     IsLowerSet s ↔ IsRelLowerSet (Subtype.val '' s) P := by
   refine ⟨fun h a x ↦ ?_, fun h a b x y ↦ ?_⟩
   · obtain ⟨a, ma, rfl⟩ := x
     exact ⟨a.2, fun b x y ↦ by simpa [h (show ⟨b, y⟩ ≤ a by exact x) ma]⟩
   · have ma : a.1 ∈ Subtype.val '' s := by simp [a.2, y]
-    simpa only [mem_image, SetCoe.ext_iff, exists_eq_right] using (h ma).2 x b.2
+    simpa only [mem_image, Subtype.coe_inj, exists_eq_right] using (h ma).2 x b.2
 
 instance : SetLike (RelUpperSet P) α where
   coe := RelUpperSet.carrier


### PR DESCRIPTION
Remove two `backward.isDefEq.respectTransparency` by using a lemma that doesn't abuse defeq.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
