### PR TITLE
Update EdgeConnectivity.lean

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -122,8 +122,39 @@ lemma isEdgeConnected_add_one (hk : k ≠ 0) :
   simp [IsEdgeConnected, isEdgeReachable_add_one hk, forall_comm (α := Sym2 _)]
 
 /-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
+/-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
 lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
     G.IsBridge s(u, v) ↔ G.Adj u v ∧ ¬G.IsEdgeReachable 2 u v := by
+  refine ⟨fun h ↦ ?_, fun ⟨hadj, hc⟩ ↦ ?_⟩
+  · rcases isBridge_iff_adj_and_forall_walk_mem_edges.mp h with ⟨hadj, hall⟩
+    refine ⟨hadj, fun h2 ↦ ?_⟩
+    have h2' :
+        ∀ e, (G.deleteEdges {e}).IsEdgeReachable 1 u v :=
+      (isEdgeReachable_add_one (G := G) (u := u) (v := v) (k := 1) (by simp)).mp h2
+    have h3 : (G \ fromEdgeSet {s(u, v)}).Reachable u v := by
+      simpa [isEdgeReachable_one] using h2' (s(u, v))
+    rw [reachable_delete_edges_iff_exists_walk] at h3
+    rcases h3 with ⟨p, hp⟩
+    exact hp (hall p)
+  · have hall : ∀ p : G.Walk u v, s(u, v) ∈ p.edges := by
+      by_contra h
+      rcases not_forall.mp h with ⟨p, hp⟩
+      have hdel : (G \ fromEdgeSet {s(u, v)}).Reachable u v := by
+        rw [reachable_delete_edges_iff_exists_walk]
+        exact ⟨p, hp⟩
+      have h2 : G.IsEdgeReachable 2 u v := by
+        refine (isEdgeReachable_add_one (G := G) (u := u) (v := v) (k := 1) (by simp)).mpr ?_
+        intro e
+        rw [isEdgeReachable_one]
+        by_cases he : e = s(u, v)
+        · simpa [he] using hdel
+        · have hne : s(u, v) ∉ ({e} : Set (Sym2 V)) := by
+            simpa [Set.mem_singleton_iff, eq_comm] using he
+          exact (deleteEdges_adj.mpr ⟨hadj, hne⟩).reachable
+      exact hc h2
+    rw [isBridge_iff_adj_and_forall_walk_mem_edges]
+    exact ⟨hadj, hall⟩
+
   refine ⟨fun h ↦ ⟨h.left, fun hc ↦ ?_⟩, fun ⟨hadj, hc⟩ ↦ ?_⟩
   · exact isBridge_iff.mp h |>.right <| hc <| Set.encard_singleton _ |>.trans_lt Nat.one_lt_ofNat
   · refine isBridge_iff.mpr ⟨hadj, fun hr ↦ hc fun s hs₂ ↦ ?_⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -122,35 +122,37 @@ lemma isEdgeConnected_add_one (hk : k ≠ 0) :
   simp [IsEdgeConnected, isEdgeReachable_add_one hk, forall_comm (α := Sym2 _)]
 
 /-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
-/-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
 lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
     G.IsBridge s(u, v) ↔ G.Adj u v ∧ ¬G.IsEdgeReachable 2 u v := by
   refine ⟨fun h ↦ ?_, fun ⟨hadj, hc⟩ ↦ ?_⟩
-  · rcases isBridge_iff_adj_and_forall_walk_mem_edges.mp h with ⟨hadj, hall⟩
+  · have h1 : G.Adj u v ∧ ∀ (p : G.Walk u v), s(u, v) ∈ p.edges :=
+      isBridge_iff_adj_and_forall_walk_mem_edges.mp h
+    rcases h1 with ⟨hadj, hall⟩
     refine ⟨hadj, fun h2 ↦ ?_⟩
-    have h2' :
-        ∀ e, (G.deleteEdges {e}).IsEdgeReachable 1 u v :=
-      (isEdgeReachable_add_one (G := G) (u := u) (v := v) (k := 1) (by simp)).mp h2
     have h3 : (G \ fromEdgeSet {s(u, v)}).Reachable u v := by
-      simpa [isEdgeReachable_one] using h2' (s(u, v))
-    rw [reachable_delete_edges_iff_exists_walk] at h3
-    rcases h3 with ⟨p, hp⟩
-    exact hp (hall p)
-  · have hall : ∀ p : G.Walk u v, s(u, v) ∈ p.edges := by
+      simpa [IsEdgeReachable] using h2 (s := {s(u, v)}) (by simp)
+    have h5 : ∃ (p : G.Walk u v), s(u, v) ∉ p.edges := by
+      rw [reachable_delete_edges_iff_exists_walk] at h3
+      exact h3
+    rcases h5 with ⟨p, hnp⟩
+    exact hnp (hall p)
+  · have hall : ∀ (p : G.Walk u v), s(u, v) ∈ p.edges := by
       by_contra h
-      rcases not_forall.mp h with ⟨p, hp⟩
-      have hdel : (G \ fromEdgeSet {s(u, v)}).Reachable u v := by
+      have h' : ∃ (p : G.Walk u v), s(u, v) ∉ p.edges := by
+        exact not_forall.mp h
+      rcases h' with ⟨p, hnp⟩
+      have h1 : (G \ fromEdgeSet {s(u, v)}).Reachable u v := by
         rw [reachable_delete_edges_iff_exists_walk]
-        exact ⟨p, hp⟩
+        exact ⟨p, hnp⟩
       have h2 : G.IsEdgeReachable 2 u v := by
-        refine (isEdgeReachable_add_one (G := G) (u := u) (v := v) (k := 1) (by simp)).mpr ?_
+        apply isEdgeReachable_two.mpr
         intro e
-        rw [isEdgeReachable_one]
-        by_cases he : e = s(u, v)
-        · simpa [he] using hdel
-        · have hne : s(u, v) ∉ ({e} : Set (Sym2 V)) := by
-            simpa [Set.mem_singleton_iff, eq_comm] using he
-          exact (deleteEdges_adj.mpr ⟨hadj, hne⟩).reachable
+        by_cases hx : e = s(u, v)
+        · rw [hx]
+          exact h1
+        · have h3 : (G.deleteEdges {e}).Adj u v := by
+            exact deleteEdges_adj.mpr ⟨hadj, hx⟩
+          exact h3.reachable
       exact hc h2
     rw [isBridge_iff_adj_and_forall_walk_mem_edges]
     exact ⟨hadj, hall⟩

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -323,3 +323,93 @@ lemma pow_mem_range_pow_of_coprime (hmn : m.Coprime n) (a : α) :
   simp [pow_eq_pow_iff_of_coprime hmn.symm]; aesop
 
 end CommGroupWithZero
+/-- If `m` and `n` are coprime integers of opposite parity, then
+`Int.gcd (m + n) (m - n) = 1`. -/
+theorem Int.gcd_add_sub_eq_one_of_gcd_eq_one_of_parity_opposite
+    (m n : ℤ)
+    (h_coprime : Int.gcd m n = 1)
+    (h_parity : (m % 2 = 0 ∧ n % 2 ≠ 0) ∨ (m % 2 ≠ 0 ∧ n % 2 = 0)) :
+    Int.gcd (m + n) (m - n) = 1 := by
+  let d : ℕ := Int.gcd (m + n) (m - n)
+  let k : ℤ := (d : ℤ)
+
+  have h_dvd_left : (k : ℤ) ∣ (m + n) := by
+    exact Int.gcd_dvd_left (m + n) (m - n)
+
+  have h_dvd_right : (k : ℤ) ∣ (m - n) := by
+    exact Int.gcd_dvd_right (m + n) (m - n)
+
+  have h_dvd_two_mul_m : (k : ℤ) ∣ 2 * m := by
+    have htmp : (k : ℤ) ∣ (m + n) + (m - n) := Int.dvd_add h_dvd_left h_dvd_right
+    have hsimp : (m + n) + (m - n) = 2 * m := by
+      ring
+    rw [hsimp] at htmp
+    exact htmp
+
+  have h_dvd_two_mul_n : (k : ℤ) ∣ 2 * n := by
+    have htmp : (k : ℤ) ∣ (m + n) - (m - n) := Int.dvd_sub h_dvd_left h_dvd_right
+    have hsimp : (m + n) - (m - n) = 2 * n := by
+      ring
+    rw [hsimp] at htmp
+    exact htmp
+
+  have h_bezout : ∃ x y : ℤ, (1 : ℤ) = m * x + n * y := by
+    have h := Int.gcd_eq_gcd_ab m n
+    rw [h_coprime] at h
+    refine ⟨Int.gcdA m n, Int.gcdB m n, ?_⟩
+    simpa using h
+
+  rcases h_bezout with ⟨x, y, h_eq⟩
+  rcases h_dvd_two_mul_m with ⟨a, ha⟩
+  rcases h_dvd_two_mul_n with ⟨b, hb⟩
+
+  have h_two_eq : (2 : ℤ) = k * (a * x + b * y) := by
+    have htmp : (2 : ℤ) = 2 * m * x + 2 * n * y := by
+      calc
+        (2 : ℤ) = 2 * (1 : ℤ) := by ring
+        _ = 2 * (m * x + n * y) := by rw [h_eq]
+        _ = 2 * m * x + 2 * n * y := by ring
+    rw [htmp, ha, hb]
+    ring
+
+  have h_dvd_two_int : k ∣ (2 : ℤ) := by
+    rw [h_two_eq]
+    exact dvd_mul_right k _
+
+  have h_dvd_two : d ∣ 2 := by
+    exact Int.ofNat_dvd.mp h_dvd_two_int
+
+  have hd_ne_zero : d ≠ 0 := by
+    intro hd0
+    rw [hd0] at h_dvd_two
+    norm_num at h_dvd_two
+
+  have h_cases : d = 1 ∨ d = 2 := by
+    have h_le : d ≤ 2 := Nat.le_of_dvd (by norm_num) h_dvd_two
+    have h_small : d = 0 ∨ d = 1 ∨ d = 2 := by
+      omega
+    rcases h_small with h0 | h1 | h2
+    · exfalso
+      exact hd_ne_zero h0
+    · exact Or.inl h1
+    · exact Or.inr h2
+
+  rcases h_cases with hd1 | hd2
+  · simpa [d] using hd1
+  · exfalso
+    have h_even_sum : (2 : ℤ) ∣ (m + n) := by
+      rw [hd2] at h_dvd_left
+      exact h_dvd_left
+    have h_sum_mod_zero : (m + n) % 2 = 0 := by
+      omega
+    rcases h_parity with hpar | hpar
+    · have hm_even : m % 2 = 0 := hpar.1
+      have hn_odd : n % 2 ≠ 0 := hpar.2
+      have h_sum_mod_one : (m + n) % 2 = 1 := by
+        omega
+      omega
+    · have hm_odd : m % 2 ≠ 0 := hpar.1
+      have hn_even : n % 2 = 0 := hpar.2
+      have h_sum_mod_one : (m + n) % 2 = 1 := by
+        omega
+      omega


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
