### PR TITLE
[Merged by Bors] - chore(RingTheory/Smooth): remove fg condition for `Algebra.FormallySmooth.of_algebraicIndependent_of_isSeparable`

### DIFF
--- a/Mathlib/RingTheory/Smooth/Field.lean
+++ b/Mathlib/RingTheory/Smooth/Field.lean
@@ -41,15 +41,13 @@ lemma Algebra.FormallySmooth.of_algebraicIndependent {v : ι → L}
   exact .of_equiv IntermediateField.topEquiv
 
 /-- Separably generated extensions are formally smooth. -/
-lemma Algebra.FormallySmooth.of_algebraicIndependent_of_isSeparable [EssFiniteType K L]
+lemma Algebra.FormallySmooth.of_algebraicIndependent_of_isSeparable
     {v : ι → L} (hb : AlgebraicIndependent K v)
     [Algebra.IsSeparable (IntermediateField.adjoin K (Set.range v)) L] :
     Algebra.FormallySmooth K L := by
-  have := Algebra.FormallySmooth.adjoin_of_algebraicIndependent hb
-  have : EssFiniteType (IntermediateField.adjoin K (Set.range v)) L :=
-    .of_comp K _ _
+  have := FormallySmooth.adjoin_of_algebraicIndependent hb
   have : FormallyEtale (IntermediateField.adjoin K (Set.range v)) L :=
-    (FormallyEtale.iff_isSeparable _ _).mpr inferInstance
+    Algebra.FormallyEtale.of_isSeparable _ L
   exact .comp _ (IntermediateField.adjoin K (Set.range v)) _
 
 instance (priority := low) Algebra.FormallySmooth.of_perfectField


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
