### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace): transfer lemmas about charpoly/eigenvalues from matrix to linear map

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.Rayleigh
 public import Mathlib.Analysis.Normed.Group.Submodule
 public import Mathlib.Analysis.Normed.Operator.FredholmAlternative
+public import Mathlib.LinearAlgebra.Eigenspace.Charpoly
 public import Mathlib.LinearAlgebra.Eigenspace.ContinuousLinearMap
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 public import Mathlib.Data.Fin.Tuple.Sort
@@ -68,6 +69,7 @@ self-adjoint operator, spectral theorem, diagonalization theorem
 
 variable {𝕜 : Type*} [RCLike 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E']
 
 local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 
@@ -79,7 +81,7 @@ namespace LinearMap
 
 namespace IsSymmetric
 
-variable {T : E →ₗ[𝕜] E}
+variable {T : E →ₗ[𝕜] E} {T' : E' →ₗ[𝕜] E'}
 
 /-- A self-adjoint operator preserves orthogonal complements of its eigenspaces. -/
 theorem invariant_orthogonalComplement_eigenspace (hT : T.IsSymmetric) (μ : 𝕜)
@@ -130,6 +132,7 @@ theorem orthogonalComplement_iSup_eigenspaces (hT : T.IsSymmetric) (μ : 𝕜) :
 /-! ### Finite-dimensional theory -/
 
 variable [FiniteDimensional 𝕜 E]
+variable [FiniteDimensional 𝕜 E']
 
 /-- The mutual orthogonal complement of the eigenspaces of a self-adjoint operator on a
 finite-dimensional inner product space is trivial. -/
@@ -342,6 +345,52 @@ theorem eigenvectorBasis_apply_self_apply (hT : T.IsSymmetric) (hn : Module.finr
   apply Fintype.sum_congr
   intro a
   rw [smul_smul, mul_comm, ofLp_toLp]
+
+theorem toMatrix_eigenvectorBasis (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    letI b := (hT.eigenvectorBasis hn).toBasis
+    T.toMatrix b b = Matrix.diagonal (RCLike.ofReal ∘ hT.eigenvalues hn) := by
+  ext i j
+  simp [toMatrix_apply, Matrix.diagonal_apply, RCLike.real_smul_eq_coe_mul]
+  grind
+
+open Polynomial in
+theorem charpoly_eq (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    T.charpoly = ∏ i, (X - C (hT.eigenvalues hn i : 𝕜)) := by
+  simp [← T.charpoly_toMatrix (hT.eigenvectorBasis hn).toBasis, toMatrix_eigenvectorBasis,
+    Matrix.charpoly_diagonal]
+
+theorem roots_charpoly_eq_eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    T.charpoly.roots = Multiset.map (RCLike.ofReal ∘ hT.eigenvalues hn) Finset.univ.val := by
+  rw [← charpoly_toMatrix _ (hT.eigenvectorBasis hn).toBasis, toMatrix_eigenvectorBasis,
+    Matrix.charpoly_diagonal, Polynomial.roots_prod _ _ (by
+      simp [Finset.prod_ne_zero_iff, Polynomial.X_sub_C_ne_zero])]
+  simp
+
+theorem sort_roots_charpoly_eq_eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    (T.charpoly.roots.map RCLike.re).sort (· ≥ ·) = List.ofFn (hT.eigenvalues hn) := by
+  simp_rw [hT.roots_charpoly_eq_eigenvalues, Fin.univ_val_map, Multiset.map_coe, List.map_ofFn,
+    Function.comp_def, RCLike.ofReal_re, Multiset.coe_sort]
+  have := hn.symm
+  convert List.mergeSort_of_pairwise ?_
+  simp_rw [decide_eq_true_eq, ← List.sortedGE_iff_pairwise]
+  convert (hT.eigenvalues_antitone hn).sortedGE_ofFn
+
+theorem eigenvalues_eq_eigenvalues_iff (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+    (hT' : T'.IsSymmetric) (hn' : Module.finrank 𝕜 E' = n) :
+    hT.eigenvalues hn = hT'.eigenvalues hn' ↔ T.charpoly = T'.charpoly where
+  mp h := by rw [hT.charpoly_eq hn, hT'.charpoly_eq hn', h]
+  mpr h := by
+    rw [← List.ofFn_inj, ← sort_roots_charpoly_eq_eigenvalues, ← sort_roots_charpoly_eq_eigenvalues]
+    rw [h]
+
+theorem splits_charpoly (hT : T.IsSymmetric) : T.charpoly.Splits :=
+  Polynomial.splits_iff_card_roots.mpr (by
+    simp [hT.roots_charpoly_eq_eigenvalues rfl, LinearMap.charpoly_natDegree])
+
+theorem det_eq_prod_eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
+    T.det = ∏ i, (hT.eigenvalues hn i : 𝕜) := by
+  simp [det_eq_prod_roots_charpoly_of_splits hT.splits_charpoly,
+    hT.roots_charpoly_eq_eigenvalues hn, List.prod_ofFn]
 
 end Version2
 

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -131,8 +131,7 @@ theorem orthogonalComplement_iSup_eigenspaces (hT : T.IsSymmetric) (μ : 𝕜) :
 
 /-! ### Finite-dimensional theory -/
 
-variable [FiniteDimensional 𝕜 E]
-variable [FiniteDimensional 𝕜 E']
+variable [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
 
 /-- The mutual orthogonal complement of the eigenspaces of a self-adjoint operator on a
 finite-dimensional inner product space is trivial. -/

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -379,12 +379,12 @@ theorem eigenvalues_eq_eigenvalues_iff {E' : Type*} [NormedAddCommGroup E'] [Inn
     hT.eigenvalues hn = hT'.eigenvalues hn' ↔ T.charpoly = T'.charpoly where
   mp h := by rw [hT.charpoly_eq hn, hT'.charpoly_eq hn', h]
   mpr h := by
-    rw [← List.ofFn_inj, ← sort_roots_charpoly_eq_eigenvalues, ← sort_roots_charpoly_eq_eigenvalues]
-    rw [h]
+    rw [← List.ofFn_inj, ← sort_roots_charpoly_eq_eigenvalues, ← sort_roots_charpoly_eq_eigenvalues,
+      h]
 
-theorem splits_charpoly (hT : T.IsSymmetric) : T.charpoly.Splits :=
-  Polynomial.splits_iff_card_roots.mpr (by
-    simp [hT.roots_charpoly_eq_eigenvalues rfl, LinearMap.charpoly_natDegree])
+theorem splits_charpoly (hT : T.IsSymmetric) : T.charpoly.Splits := by
+  refine Polynomial.splits_iff_card_roots.mpr ?_
+  simp [hT.roots_charpoly_eq_eigenvalues rfl, LinearMap.charpoly_natDegree]
 
 theorem det_eq_prod_eigenvalues (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n) :
     T.det = ∏ i, (hT.eigenvalues hn i : 𝕜) := by

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -69,7 +69,6 @@ self-adjoint operator, spectral theorem, diagonalization theorem
 
 variable {𝕜 : Type*} [RCLike 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
-variable {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E']
 
 local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
 
@@ -81,7 +80,7 @@ namespace LinearMap
 
 namespace IsSymmetric
 
-variable {T : E →ₗ[𝕜] E} {T' : E' →ₗ[𝕜] E'}
+variable {T : E →ₗ[𝕜] E}
 
 /-- A self-adjoint operator preserves orthogonal complements of its eigenspaces. -/
 theorem invariant_orthogonalComplement_eigenspace (hT : T.IsSymmetric) (μ : 𝕜)
@@ -131,7 +130,7 @@ theorem orthogonalComplement_iSup_eigenspaces (hT : T.IsSymmetric) (μ : 𝕜) :
 
 /-! ### Finite-dimensional theory -/
 
-variable [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
+variable [FiniteDimensional 𝕜 E]
 
 /-- The mutual orthogonal complement of the eigenspaces of a self-adjoint operator on a
 finite-dimensional inner product space is trivial. -/
@@ -374,7 +373,8 @@ theorem sort_roots_charpoly_eq_eigenvalues (hT : T.IsSymmetric) (hn : Module.fin
   simp_rw [decide_eq_true_eq, ← List.sortedGE_iff_pairwise]
   convert (hT.eigenvalues_antitone hn).sortedGE_ofFn
 
-theorem eigenvalues_eq_eigenvalues_iff (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+theorem eigenvalues_eq_eigenvalues_iff {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E']
+    [FiniteDimensional 𝕜 E'] {T' : E' →ₗ[𝕜] E'} (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
     (hT' : T'.IsSymmetric) (hn' : Module.finrank 𝕜 E' = n) :
     hT.eigenvalues hn = hT'.eigenvalues hn' ↔ T.charpoly = T'.charpoly where
   mp h := by rw [hT.charpoly_eq hn, hT'.charpoly_eq hn', h]

--- a/Mathlib/Analysis/InnerProductSpace/Trace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Trace.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.Analysis.InnerProductSpace.Spectrum
-public import Mathlib.LinearAlgebra.Trace
+public import Mathlib.LinearAlgebra.Eigenspace.Charpoly
 
 /-!
 # Traces in inner product spaces
@@ -38,12 +38,8 @@ variable {n : ℕ} (hn : Module.finrank 𝕜 E = n)
 
 lemma IsSymmetric.trace_eq_sum_eigenvalues {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) :
     T.trace 𝕜 E = ∑ i, hT.eigenvalues hn i := by
-  let b := hT.eigenvectorBasis hn
-  rw [T.trace_eq_sum_inner b, RCLike.ofReal_sum]
-  apply Fintype.sum_congr
-  intro i
-  rw [hT.apply_eigenvectorBasis, inner_smul_real_right, inner_self_eq_norm_sq_to_K, b.norm_eq_one]
-  simp [RCLike.ofReal_alg]
+  simp [Module.End.trace_eq_sum_roots_charpoly_of_splits hT.splits_charpoly,
+    hT.roots_charpoly_eq_eigenvalues hn, List.sum_ofFn]
 
 lemma IsSymmetric.re_trace_eq_sum_eigenvalues {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) :
     RCLike.re (T.trace 𝕜 E) = ∑ i, hT.eigenvalues hn i := by

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.Matrix.Hermitian
-import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-!
 # Hermitian matrices over ℝ and ℂ
@@ -39,21 +38,18 @@ lemma IsHermitian.coe_re_apply_self (h : A.IsHermitian) (i : n) : (re (A i i) : 
 lemma IsHermitian.coe_re_diag (h : A.IsHermitian) : (fun i => (re (A.diag i) : 𝕜)) = A.diag :=
   funext h.coe_re_apply_self
 
-/-- A matrix is Hermitian iff the corresponding linear map with an orthonormal basis is self
-adjoint. -/
-lemma isHermitian_iff_isSymmetric_of_orthonormalBasis [Fintype n] [DecidableEq n] {E : Type*}
-    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (b : OrthonormalBasis n 𝕜 E) :
-    IsHermitian A ↔ (A.toLin b.toBasis b.toBasis).IsSymmetric := by
-  have : FiniteDimensional 𝕜 E := b.toBasis.finiteDimensional_of_finite
-  simp_rw [LinearMap.IsSymmetric, ← LinearMap.adjoint_inner_left, ← toLin_conjTranspose]
-  refine ⟨fun h _ _ ↦ by rw [h.eq], fun h ↦ ?_⟩
-  simpa using (LinearMap.ext fun x ↦ ext_inner_right _ (h x)).symm
-
-/-- A matrix is Hermitian iff the corresponding linear map on the Euclidean space is self adjoint.
--/
+/-- A matrix is Hermitian iff the corresponding linear map is self adjoint. -/
 lemma isHermitian_iff_isSymmetric [Fintype n] [DecidableEq n] :
-    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric :=
-  isHermitian_iff_isSymmetric_of_orthonormalBasis (EuclideanSpace.basisFun n 𝕜)
+    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric := by
+  rw [LinearMap.IsSymmetric, (WithLp.toLp_surjective _).forall₂]
+  simp only [toLpLin_toLp, Matrix.toLin'_apply, EuclideanSpace.inner_eq_star_dotProduct,
+    star_mulVec]
+  constructor
+  · rintro (h : Aᴴ = A) x y
+    rw [dotProduct_comm, ← dotProduct_mulVec, h, dotProduct_comm]
+  · intro h
+    ext i j
+    simpa [(Pi.single_star i 1).symm] using h (Pi.single i 1) (Pi.single j 1)
 
 lemma IsHermitian.im_star_dotProduct_mulVec_self [Fintype n] (hA : A.IsHermitian) (x : n → 𝕜) :
      RCLike.im (star x ⬝ᵥ A *ᵥ x) = 0 := by

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -39,8 +39,8 @@ lemma IsHermitian.coe_re_apply_self (h : A.IsHermitian) (i : n) : (re (A i i) : 
 lemma IsHermitian.coe_re_diag (h : A.IsHermitian) : (fun i => (re (A.diag i) : 𝕜)) = A.diag :=
   funext h.coe_re_apply_self
 
-
-/-- A matrix is Hermitian iff the corresponding linear map is self adjoint. -/
+/-- A matrix is Hermitian iff the corresponding linear map with an orthonormal basis is self
+adjoint. -/
 lemma isHermitian_iff_isSymmetric_of_orthonormalBasis [Fintype n] [DecidableEq n] {E : Type*}
     [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (b : OrthonormalBasis n 𝕜 E) :
     IsHermitian A ↔ (A.toLin b.toBasis b.toBasis).IsSymmetric := by

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -39,30 +39,23 @@ lemma IsHermitian.coe_re_apply_self (h : A.IsHermitian) (i : n) : (re (A i i) : 
 lemma IsHermitian.coe_re_diag (h : A.IsHermitian) : (fun i => (re (A.diag i) : 𝕜)) = A.diag :=
   funext h.coe_re_apply_self
 
-/-- A matrix is Hermitian iff the corresponding linear map is self adjoint. -/
-lemma isHermitian_iff_isSymmetric [Fintype n] [DecidableEq n] :
-    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric := by
-  rw [LinearMap.IsSymmetric, (WithLp.toLp_surjective _).forall₂]
-  simp only [toLpLin_toLp, Matrix.toLin'_apply, EuclideanSpace.inner_eq_star_dotProduct,
-    star_mulVec]
-  constructor
-  · rintro (h : Aᴴ = A) x y
-    rw [dotProduct_comm, ← dotProduct_mulVec, h, dotProduct_comm]
-  · intro h
-    ext i j
-    simpa [(Pi.single_star i 1).symm] using h (Pi.single i 1) (Pi.single j 1)
 
-/-- A version of `Matrix.isHermitian_iff_isSymmetric` that allows using any `OrthonormalBasis`. -/
+/-- A matrix is Hermitian iff the corresponding linear map is self adjoint. -/
 lemma isHermitian_iff_isSymmetric_of_orthonormalBasis [Fintype n] [DecidableEq n] {E : Type*}
     [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (b : OrthonormalBasis n 𝕜 E) :
     IsHermitian A ↔ (A.toLin b.toBasis b.toBasis).IsSymmetric := by
   have : FiniteDimensional 𝕜 E := b.toBasis.finiteDimensional_of_finite
   simp_rw [LinearMap.IsSymmetric, ← LinearMap.adjoint_inner_left, ← toLin_conjTranspose]
-  constructor
-  · intro (h : Aᴴ = A) x y
-    rw [h]
-  · intro h
-    simpa using (LinearMap.ext fun x ↦ ext_inner_right _ (h x)).symm
+  refine ⟨fun h _ _ ↦ by rw [h.eq], fun h ↦ ?_⟩
+  simpa using (LinearMap.ext fun x ↦ ext_inner_right _ (h x)).symm
+
+/-- A matrix is Hermitian iff the corresponding linear map on the Euclidean space is self adjoint.
+-/
+lemma isHermitian_iff_isSymmetric [Fintype n] [DecidableEq n] :
+    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric := by
+  rw [toEuclideanLin, isHermitian_iff_isSymmetric_of_orthonormalBasis
+      (EuclideanSpace.basisFun n 𝕜), toLpLin_eq_toLin]
+  rfl
 
 lemma IsHermitian.im_star_dotProduct_mulVec_self [Fintype n] (hA : A.IsHermitian) (x : n → 𝕜) :
      RCLike.im (star x ⬝ᵥ A *ᵥ x) = 0 := by

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.Analysis.InnerProductSpace.Adjoint
 
 /-!
 # Hermitian matrices over ℝ and ℂ
@@ -50,6 +51,18 @@ lemma isHermitian_iff_isSymmetric [Fintype n] [DecidableEq n] :
   · intro h
     ext i j
     simpa [(Pi.single_star i 1).symm] using h (Pi.single i 1) (Pi.single j 1)
+
+/-- A version of `Matrix.isHermitian_iff_isSymmetric` that allows using any `OrthonormalBasis`. -/
+lemma isHermitian_iff_isSymmetric_of_orthonormalBasis [Fintype n] [DecidableEq n] {E : Type*}
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (b : OrthonormalBasis n 𝕜 E) :
+    IsHermitian A ↔ (A.toLin b.toBasis b.toBasis).IsSymmetric := by
+  have : FiniteDimensional 𝕜 E := b.toBasis.finiteDimensional_of_finite
+  simp_rw [LinearMap.IsSymmetric, ← LinearMap.adjoint_inner_left, ← toLin_conjTranspose]
+  constructor
+  · intro (h : Aᴴ = A) x y
+    rw [h]
+  · intro h
+    simpa using (LinearMap.ext fun x ↦ ext_inner_right _ (h x)).symm
 
 lemma IsHermitian.im_star_dotProduct_mulVec_self [Fintype n] (hA : A.IsHermitian) (x : n → 𝕜) :
      RCLike.im (star x ⬝ᵥ A *ᵥ x) = 0 := by

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -52,10 +52,8 @@ lemma isHermitian_iff_isSymmetric_of_orthonormalBasis [Fintype n] [DecidableEq n
 /-- A matrix is Hermitian iff the corresponding linear map on the Euclidean space is self adjoint.
 -/
 lemma isHermitian_iff_isSymmetric [Fintype n] [DecidableEq n] :
-    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric := by
-  rw [toEuclideanLin, isHermitian_iff_isSymmetric_of_orthonormalBasis
-      (EuclideanSpace.basisFun n 𝕜), toLpLin_eq_toLin]
-  rfl
+    IsHermitian A ↔ A.toEuclideanLin.IsSymmetric :=
+  isHermitian_iff_isSymmetric_of_orthonormalBasis (EuclideanSpace.basisFun n 𝕜)
 
 lemma IsHermitian.im_star_dotProduct_mulVec_self [Fintype n] (hA : A.IsHermitian) (x : n → 𝕜) :
      RCLike.im (star x ⬝ᵥ A *ᵥ x) = 0 := by

--- a/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Charpoly.BaseChange
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
+public import Mathlib.LinearAlgebra.Trace
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
@@ -50,6 +51,13 @@ lemma det_eq_prod_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits)
   let b := Module.Free.chooseBasis K V
   rw [← det_toMatrix b, Matrix.det_eq_prod_roots_charpoly_of_splits (by simpa using h),
     charpoly_toMatrix]
+
+lemma trace_eq_sum_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits) :
+    f.trace K V = f.charpoly.roots.sum := by
+  let b := Module.Free.chooseBasis K V
+  rw [trace_eq_matrix_trace K b, Matrix.trace_eq_sum_roots_charpoly_of_splits (by simpa using h),
+    charpoly_toMatrix]
+
 
 end End
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
@@ -48,15 +48,14 @@ lemma mem_spectrum_iff_isRoot_charpoly (f : End K V) (μ : K) :
 
 lemma det_eq_prod_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits) :
     f.det = f.charpoly.roots.prod := by
-  let b := Module.Free.chooseBasis K V
-  rw [← det_toMatrix b, Matrix.det_eq_prod_roots_charpoly_of_splits (by simpa using h),
-    charpoly_toMatrix]
+  rw [← det_toMatrix (Module.Free.chooseBasis K V),
+    Matrix.det_eq_prod_roots_charpoly_of_splits (by simpa using h), charpoly_toMatrix]
 
 lemma trace_eq_sum_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits) :
     f.trace K V = f.charpoly.roots.sum := by
   let b := Module.Free.chooseBasis K V
-  rw [trace_eq_matrix_trace K b, Matrix.trace_eq_sum_roots_charpoly_of_splits (by simpa using h),
-    charpoly_toMatrix]
+  rw [trace_eq_matrix_trace K (Module.Free.chooseBasis K V),
+    Matrix.trace_eq_sum_roots_charpoly_of_splits (by simpa using h), charpoly_toMatrix]
 
 end End
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Charpoly.BaseChange
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
 # Eigenvalues are the roots of the characteristic polynomial.
@@ -43,6 +44,12 @@ lemma hasEigenvalue_iff_isRoot_charpoly (f : End R M) (μ : R) :
 lemma mem_spectrum_iff_isRoot_charpoly (f : End K V) (μ : K) :
     μ ∈ spectrum K f ↔ f.charpoly.IsRoot μ := by
   rw [← hasEigenvalue_iff_mem_spectrum, hasEigenvalue_iff_isRoot_charpoly]
+
+lemma det_eq_prod_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits) :
+    f.det = f.charpoly.roots.prod := by
+  let b := Module.Free.chooseBasis K V
+  rw [← det_toMatrix b, Matrix.det_eq_prod_roots_charpoly_of_splits (by simpa using h),
+    charpoly_toMatrix]
 
 end End
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Charpoly.lean
@@ -58,7 +58,6 @@ lemma trace_eq_sum_roots_charpoly_of_splits {f : End K V} (h : f.charpoly.Splits
   rw [trace_eq_matrix_trace K b, Matrix.trace_eq_sum_roots_charpoly_of_splits (by simpa using h),
     charpoly_toMatrix]
 
-
 end End
 
 end Module


### PR DESCRIPTION
These are some lemmas existing for matrix but missing for linear map. 

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>

---

AI usage disclosure: I used Aristotle initially to one-shot the missing lemma `LinearMap.det_eq_prod_eigenvalues`, and then worked manually to break them into small pieces and align them with existing lemmas.

Here is a list of correspondence between new lemma and existing ones. Some of these have names and statements that I wouldn't be sure about if I had come up on my own, so I used the existing ones as justification for how they are named / stated

 - LinearMap.IsSymmetric.charpoly_eq - [Matrix.IsHermitian.charpoly_eq](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.charpoly_eq)
 - LinearMap.IsSymmetric.roots_charpoly_eq_eigenvalues - [Matrix.IsHermitian.roots_charpoly_eq_eigenvalues₀](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.roots_charpoly_eq_eigenvalues%E2%82%80)
 - LinearMap.IsSymmetric.sort_roots_charpoly_eq_eigenvalues - [Matrix.IsHermitian.sort_roots_charpoly_eq_eigenvalues₀](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.sort_roots_charpoly_eq_eigenvalues%E2%82%80)
 - LinearMap.IsSymmetric.eigenvalues_eq_eigenvalues_iff - [Matrix.IsHermitian.eigenvalues_eq_eigenvalues_iff](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.eigenvalues_eq_eigenvalues_iff)
 - LinearMap.IsSymmetric.splits_charpoly - [Matrix.IsHermitian.splits_charpoly](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.splits_charpoly)
 - LinearMap.IsSymmetric.det_eq_prod_eigenvalues - [Matrix.IsHermitian.det_eq_prod_eigenvalues](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Matrix/Spectrum.html#Matrix.IsHermitian.det_eq_prod_eigenvalues)


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
