### PR TITLE
[Merged by Bors] - doc(LinearAlgebra): fix typos

### DIFF
--- a/Mathlib/LinearAlgebra/Center.lean
+++ b/Mathlib/LinearAlgebra/Center.lean
@@ -21,13 +21,13 @@ the center of `Module.End R V`.
 In what follows, `V` is assumed to be a free `R`-module.
 
 * `LinearMap.commute_transvections_iff_of_basis`:
-  if an endomorphism `f : V →ₗ[R] V` commutes with every elementary transvections
-  (in a given basis), then it is an homothety with central ratio.
+  if an endomorphism `f : V →ₗ[R] V` commutes with every elementary transvection
+  (in a given basis), then it is a homothety with central ratio.
   (Assumes that the basis is provided and has a non trivial set of indices.)
 
 * `LinearMap.exists_eq_smul_id_of_forall_notLinearIndependent`:
   over a commutative ring `R` which is a domain, an endomorphism `f : V →ₗ[R] V`
-  of a free domain such that `v` and `f v` are not linearly independent,
+  of a free module such that `v` and `f v` are not linearly independent,
   for all `v : V`, is a homothety.
 
 * `LinearMap.exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent`:
@@ -41,7 +41,7 @@ In what follows, `V` is assumed to be a free `R`-module.
 Note. In the noncommutative case, the last two results do not hold
 when the rank is equal to 1. Indeed, right multiplications
 with noncentral ratio of the `R`-module `R` satisfy the property
-that `f v` and `v` are linearly independent, for all `v : V`,
+that `f v` and `v` are linearly dependent, for all `v : V`,
 but they are not left multiplication by some element.
 
 -/
@@ -92,17 +92,17 @@ theorem commute_transvections_iff_of_basis
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Over a domain, an endomorphism `f` of a free module `V`
-of rank ≠ 1 such that `f v` and `v` are colinear, for all `v : V`,
+of rank ≠ 1 such that `f v` and `v` are collinear, for all `v : V`,
 consists of homotheties with central ratio.
 
 In the commutative case, use `LinearMap.exists_eq_smul_id`.
 
 This is a variant of `LinearMap.exists_mem_center_apply_smul`
-which switches the use `StrongRankInduction` and `finrank`
+which switches the use of `StrongRankInduction` and `finrank`
 for the cardinality of a given basis.
 
 When `finrank R V = 1`, up to a linear equivalence `V ≃ₗ[R] R`,
-then any `f` is *right*-multiplication by some `a : K`,
+then any `f` is *right*-multiplication by some `a : R`,
 but not necessarily *left*-multiplication by an element of the center of `R`. -/
 theorem exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent_of_basis
     [Ring R] [IsDomain R] [AddCommGroup V] [Module R V]
@@ -181,14 +181,14 @@ theorem exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent_of_basis
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Over a domain `R`, an endomorphism `f` of a free module `V`
-of rank ≠ 1 such that `f v` and `v` are colinear, for all `v : V`,
+of rank ≠ 1 such that `f v` and `v` are collinear, for all `v : V`,
 consists of homotheties with central ratio.
 
-When `R`does not satisfy `StrongRankCondition`, use
+When `R` does not satisfy `StrongRankCondition`, use
 `LinearMap.exists_mem_center_apply_eq_smul_of_basis`.
 
 When `finrank R V = 1`, up to a linear equivalence `V ≃ₗ[R] R`,
-then any `f` is *right*-multiplication by some `a : K`,
+then any `f` is *right*-multiplication by some `a : R`,
 but not necessarily *left*-multiplication by an element of the center of `R`. -/
 theorem exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent
     [Ring R] [IsDomain R] [StrongRankCondition R]
@@ -210,7 +210,7 @@ theorem exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent
   exact exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent_of_basis b h
 
 /-- Over a commutative domain, an endomorphism `f` of a free module `V`
-such that `f v` and `v` are colinear, for all `v : V`,
+such that `f v` and `v` are collinear, for all `v : V`,
 consists of homotheties. -/
 theorem exists_eq_smul_id_of_forall_notLinearIndependent
     [CommRing R] [IsDomain R] [AddCommGroup V] [Module R V] [Free R V] {f : V →ₗ[R] V}

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -17,10 +17,10 @@ sufficient condition for there to exist a nilpotent endomorphism `n` and a semis
 `s`, such that `f = n + s` and both `n` and `s` are polynomial expressions in `f`.
 
 The condition is that there exists a separable polynomial `P` such that the endomorphism `P(f)` is
-nilpotent. This condition is always satisfied when the coefficients are a perfect field.
+nilpotent. This condition is always satisfied when the coefficient field is perfect.
 
 The proof given here uses Newton's method and is taken from Chambert-Loir's notes:
-[Algebre](http://webusers.imj-prg.fr/~antoine.chambert-loir/enseignement/2022-23/agreg/algebre.pdf)
+[Algèbre](http://webusers.imj-prg.fr/~antoine.chambert-loir/enseignement/2022-23/agreg/algebre.pdf)
 
 ## Main definitions / results:
 


### PR DESCRIPTION
These typos were found and fixed by Claude Opus 4.6.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
