### PR TITLE
[Merged by Bors] - feat: add coe instances for spectrums

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -467,6 +467,9 @@ instance isMaximal : v.asIdeal.IsMaximal := v.isPrime.isMaximal v.ne_bot
 
 theorem prime : Prime v.asIdeal := Ideal.prime_of_isPrime v.ne_bot v.isPrime
 
+instance : Coe (HeightOneSpectrum R) (Ideal R) where
+  coe P := P.asIdeal
+
 /--
 The (nonzero) prime elements of the monoid with zero `Ideal R` correspond
 to an element of type `HeightOneSpectrum R`.

--- a/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Defs.lean
@@ -29,3 +29,6 @@ structure MaximalSpectrum (R : Type*) [CommSemiring R] where
   isMaximal : asIdeal.IsMaximal
 
 attribute [instance] MaximalSpectrum.isMaximal
+
+instance (R : Type*) [CommSemiring R] : Coe (MaximalSpectrum R) (Ideal R) where
+  coe P := P.asIdeal

--- a/Mathlib/RingTheory/Spectrum/Prime/Defs.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Defs.lean
@@ -49,6 +49,9 @@ See the corresponding section at `Mathlib/RingTheory/Spectrum/Prime/Topology.lea
 
 variable {R : Type*} [CommSemiring R]
 
+instance : Coe (PrimeSpectrum R) (Ideal R) where
+  coe P := P.asIdeal
+
 instance : PartialOrder (PrimeSpectrum R) :=
   PartialOrder.lift asIdeal (@PrimeSpectrum.ext _ _)
 


### PR DESCRIPTION
This PR adds `Coe` instances for the type `PrimeSpectrum` and similar.

For `P: PrimeSpectrum`, this means that when lean expects `Ideal A`, we can directly write `P : Ideal A` instead of `P.asIdeal`. The `.asIdeal` gets inserted automatically.

At the moment, I haven't set up the `@[coe]` to make delab into `↑P` - it simply shows `P.asIdeal` in the infoview. If we want the `↑P` I can add it.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
