### PR TITLE
[Merged by Bors] - feat(Analysis/Polynomial/MahlerMeasure): Landau's inequality and Mignotte bound

### DIFF
--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Fabrizio Barroero. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fabrizio Barroero
+Authors: Fabrizio Barroero, Kim Morrison
 -/
 module
 
@@ -33,6 +33,10 @@ properties.
 - `mahlerMeasure_eq_leadingCoeff_mul_prod_roots`: the Mahler measure of a polynomial is the absolute
   value of its leading coefficient times the product of the absolute values of its roots lying
   outside the unit disk.
+- `mahlerMeasure_le_sqrt_sum_sq_norm_coeff`: **Landau's inequality** — the Mahler measure is
+  at most the ℓ² norm of the coefficient vector.
+- `norm_coeff_le_choose_mul_mahlerMeasure_mul`: **Mignotte's coefficient bound** — if `f = g * h`
+  with `M(h) ≥ 1`, then `‖g.coeff n‖ ≤ C(deg g, n) · M(f)`.
 -/
 
 @[expose] public section
@@ -248,6 +252,12 @@ lemma prod_max_one_norm_roots_le_mahlerMeasure_of_one_le_leadingCoeff {p : ℂ[X
   gcongr
   exact zero_le_one.trans <| one_le_prod_max_one_norm_roots p
 
+/-- If the leading coefficient of a polynomial has norm at least 1, then its Mahler measure
+is at least 1. This holds in particular for nonzero polynomials with integer coefficients,
+since their leading coefficient is a nonzero integer. -/
+lemma one_le_mahlerMeasure {p : ℂ[X]} (hlc : 1 ≤ ‖p.leadingCoeff‖) : 1 ≤ p.mahlerMeasure :=
+  hlc.trans (leading_coeff_le_mahlerMeasure p)
+
 open Filter MeasureTheory Set in
 /-- The Mahler measure of a polynomial is bounded above by the sum of the norms of its coefficients.
 -/
@@ -280,20 +290,23 @@ theorem mahlerMeasure_le_sum_norm_coeff (p : ℂ[X]) : p.mahlerMeasure ≤ p.sum
 
 set_option linter.style.emptyLine false in
 open MeasureTheory Set in
-/-- The Mahler measure of a polynomial is at most the sup norm of the polynomial times the square
-root of its degree plus one. -/
-theorem mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm (p : Polynomial ℂ) :
-    p.mahlerMeasure ≤ √(p.natDegree + 1) * p.supNorm := by
-  -- Proof strategy: Apply Jensen's inequality to the definition of the Mahler measure, then to the
-  -- square function, and finally apply Parseval's inequality to the polynomial
-  -- Instances necessary for Jensen's inequality
+/-- **Landau's inequality**: the Mahler measure of a polynomial is at most the ℓ² norm
+of its coefficient vector, `√(∑ ‖coeff i‖²)`.
+
+This is the classical inequality due to Landau (1905). Combined with the multiplicativity of the
+Mahler measure (`mahlerMeasure_mul`), it gives the Mignotte bound on coefficients of polynomial
+factors.
+
+TODO: restate using a dedicated polynomial ℓ² norm once one is defined (see the TODO in
+`Mathlib.Analysis.Polynomial.Norm`). -/
+theorem mahlerMeasure_le_sqrt_sum_sq_norm_coeff (p : Polynomial ℂ) :
+    p.mahlerMeasure ≤ √(∑ i ∈ p.support, ‖p.coeff i‖ ^ 2) := by
+  -- Proof: Jensen's inequality (twice) + Parseval's identity
   have : IsFiniteMeasure (volume.restrict (uIoc 0 (2 * π))) := by
     rw [uIoc_of_le (by positivity)]; infer_instance
   have : NeZero (volume (uIoc 0 (2 * π))) := ⟨by simp⟩
-  -- Trivial case
   by_cases! hp : p = 0
   · simp [hp]
-  -- Elementary facts
   have : ∀ᵐ (θ : ℝ) ∂volume.restrict (uIoc 0 (2 * π)), 0 < ‖p.eval (circleMap 0 1 θ)‖ := by
     rw [ae_restrict_iff' measurableSet_uIoc]
     refine Set.Finite.measure_zero ?_ _
@@ -308,12 +321,10 @@ theorem mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm (p : Polynomial ℂ)
     filter_upwards [this] with θ hθ
     exact exp_log hθ
   have hcont : Continuous (fun x : ℝ ↦ ‖eval (circleMap 0 1 x) p‖) := by fun_prop
-  -- Main calc block
   simp only [mahlerMeasure, logMahlerMeasure, ne_eq, hp, not_false_eq_true, ↓reduceIte]
   rw [circleAverage_eq_intervalAverage]
   calc exp (⨍ (θ : ℝ) in 0..(2 * π), log ‖p.eval (circleMap 0 1 θ)‖)
     ≤ ⨍ (θ : ℝ) in 0..(2 * π), exp (log ‖p.eval (circleMap 0 1 θ)‖) := by
-        -- First Jensen's inequality invocation
         refine convexOn_exp.map_average_le continuousOn_exp isClosed_univ (by simp) ?_ ?_
         · rw [Set.uIoc_of_le (by positivity : 0 ≤ 2 * Real.pi)]
           exact (circleIntegrable_log_norm_meromorphicOn
@@ -323,7 +334,6 @@ theorem mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm (p : Polynomial ℂ)
     _ = √ ((⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖) ^ 2) := by
         rw [sqrt_sq]; exact integral_nonneg (fun _ ↦ norm_nonneg _)
     _ ≤ √ (⨍ (θ : ℝ) in 0..(2 * π),  ‖p.eval (circleMap 0 1 θ)‖ ^ 2) := by
-        -- Second Jensen's inequality invocation
         gcongr
         refine (convexOn_pow 2).map_average_le (continuousOn_pow 2)
             isClosed_Ici (by filter_upwards; simp) ?_ ?_
@@ -331,16 +341,20 @@ theorem mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm (p : Polynomial ℂ)
         · exact ((continuous_pow 2).comp hcont).integrableOn_Icc.mono_set Set.Ioc_subset_Icc_self
     _ = √ (circleAverage (fun θ ↦ ‖p.eval θ‖ ^ 2) 0 1) := by simp [circleAverage_eq_intervalAverage]
     _ = √ (∑ i ∈ p.support, ‖p.coeff i‖ ^ 2) := by simp [p.sum_sq_norm_coeff_eq_circleAverage]
-    _ ≤ √ ((p.natDegree + 1) * p.supNorm ^ 2) := by
-        gcongr
-        refine (p.support.sum_le_card_nsmul _ (p.supNorm ^ 2) fun i hi ↦ ?_).trans ?_
-        · gcongr
-          exact p.le_supNorm _
-        · simp only [nsmul_eq_mul]
-          gcongr
-          exact mod_cast p.card_supp_le_succ_natDegree
-    _ = √(p.natDegree + 1) * p.supNorm := by
-        rw [Real.sqrt_mul (by positivity), Real.sqrt_sq p.supNorm_nonneg]
+
+/-- The Mahler measure of a polynomial is at most the sup norm of the polynomial times the square
+root of its degree plus one. -/
+theorem mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm (p : Polynomial ℂ) :
+    p.mahlerMeasure ≤ √(p.natDegree + 1) * p.supNorm :=
+  (p.mahlerMeasure_le_sqrt_sum_sq_norm_coeff).trans <| by
+    rw [show √(↑(p.natDegree) + 1) * p.supNorm = √((p.natDegree + 1) * p.supNorm ^ 2) from by
+      rw [Real.sqrt_mul (by positivity), Real.sqrt_sq p.supNorm_nonneg]]
+    gcongr
+    refine (p.support.sum_le_card_nsmul _ (p.supNorm ^ 2) fun i _ ↦ ?_).trans ?_
+    · gcongr; exact p.le_supNorm _
+    · simp only [nsmul_eq_mul]
+      gcongr
+      exact mod_cast p.card_supp_le_succ_natDegree
 
 open Multiset in
 theorem norm_coeff_le_choose_mul_mahlerMeasure (n : ℕ) (p : ℂ[X]) :
@@ -399,5 +413,37 @@ theorem supNorm_le_choose_natDegree_div_two_mul_mahlerMeasure (p : Polynomial �
     _ ≤ (p.natDegree.choose (p.natDegree / 2)) * p.mahlerMeasure :=
       mul_le_mul_of_nonneg_right (by exact_mod_cast Nat.choose_le_middle i p.natDegree)
         p.mahlerMeasure_nonneg
+
+/-!
+### Monotonicity under multiplication and the Mignotte bound
+-/
+
+/-- Multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
+measure. -/
+theorem le_mahlerMeasure_mul_right {q : ℂ[X]} (hq : 1 ≤ q.mahlerMeasure) (p : ℂ[X]) :
+    p.mahlerMeasure ≤ (p * q).mahlerMeasure := by
+  rw [mahlerMeasure_mul]
+  exact le_mul_of_one_le_right p.mahlerMeasure_nonneg hq
+
+/-- Multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
+measure. -/
+theorem le_mahlerMeasure_mul_left {p : ℂ[X]} (hp : 1 ≤ p.mahlerMeasure) (q : ℂ[X]) :
+    q.mahlerMeasure ≤ (p * q).mahlerMeasure := by
+  rw [mahlerMeasure_mul]
+  exact le_mul_of_one_le_left q.mahlerMeasure_nonneg hp
+
+/-- **Mignotte's coefficient bound**: if `f = g * h` and `h` has Mahler measure at least 1
+(which holds in particular when `h` has integer coefficients with nonzero leading coefficient),
+then the coefficients of `g` are bounded by a binomial coefficient times the Mahler measure of `f`.
+
+Combined with `mahlerMeasure_le_sqrt_sum_sq_norm_coeff` (Landau's inequality), this gives
+the classical Mignotte bound `‖g.coeff n‖ ≤ C(deg g, n) · ‖f‖₂` used in polynomial
+factorization algorithms (Berlekamp–Zassenhaus). -/
+theorem norm_coeff_le_choose_mul_mahlerMeasure_mul (n : ℕ) (g h : ℂ[X])
+    (hh : 1 ≤ h.mahlerMeasure) :
+    ‖g.coeff n‖ ≤ g.natDegree.choose n * (g * h).mahlerMeasure :=
+  (g.norm_coeff_le_choose_mul_mahlerMeasure n).trans <| by
+    gcongr
+    exact le_mahlerMeasure_mul_right hh g
 
 end Polynomial

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -35,8 +35,8 @@ properties.
   outside the unit disk.
 - `mahlerMeasure_le_sqrt_sum_sq_norm_coeff`: **Landau's inequality** — the Mahler measure is
   at most the ℓ² norm of the coefficient vector.
-- `norm_coeff_le_choose_mul_mahlerMeasure_mul`: **Mignotte's coefficient bound** — if `f = g * h`
-  with `M(h) ≥ 1`, then `‖g.coeff n‖ ≤ C(deg g, n) · M(f)`.
+- `norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure`: **Mignotte's coefficient
+  bound** — if `f = g * h` with `M(h) ≥ 1`, then `‖g.coeff n‖ ≤ C(deg g, n) · M(f)`.
 -/
 
 @[expose] public section
@@ -255,7 +255,8 @@ lemma prod_max_one_norm_roots_le_mahlerMeasure_of_one_le_leadingCoeff {p : ℂ[X
 /-- If the leading coefficient of a polynomial has norm at least 1, then its Mahler measure
 is at least 1. This holds in particular for nonzero polynomials with integer coefficients,
 since their leading coefficient is a nonzero integer. -/
-lemma one_le_mahlerMeasure {p : ℂ[X]} (hlc : 1 ≤ ‖p.leadingCoeff‖) : 1 ≤ p.mahlerMeasure :=
+lemma one_le_mahlerMeasure_of_one_le_norm_leadingCoeff {p : ℂ[X]}
+    (hlc : 1 ≤ ‖p.leadingCoeff‖) : 1 ≤ p.mahlerMeasure :=
   hlc.trans (leading_coeff_le_mahlerMeasure p)
 
 open Filter MeasureTheory Set in
@@ -418,14 +419,14 @@ theorem supNorm_le_choose_natDegree_div_two_mul_mahlerMeasure (p : Polynomial �
 ### Monotonicity under multiplication and the Mignotte bound
 -/
 
-/-- Multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
+/-- Right-multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
 measure. -/
 theorem le_mahlerMeasure_mul_right {q : ℂ[X]} (hq : 1 ≤ q.mahlerMeasure) (p : ℂ[X]) :
     p.mahlerMeasure ≤ (p * q).mahlerMeasure := by
   rw [mahlerMeasure_mul]
   exact le_mul_of_one_le_right p.mahlerMeasure_nonneg hq
 
-/-- Multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
+/-- Left-multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
 measure. -/
 theorem le_mahlerMeasure_mul_left {p : ℂ[X]} (hp : 1 ≤ p.mahlerMeasure) (q : ℂ[X]) :
     q.mahlerMeasure ≤ (p * q).mahlerMeasure := by
@@ -434,12 +435,14 @@ theorem le_mahlerMeasure_mul_left {p : ℂ[X]} (hp : 1 ≤ p.mahlerMeasure) (q :
 
 /-- **Mignotte's coefficient bound**: if `f = g * h` and `h` has Mahler measure at least 1
 (which holds in particular when `h` has integer coefficients with nonzero leading coefficient),
-then the coefficients of `g` are bounded by a binomial coefficient times the Mahler measure of `f`.
+then the coefficients of `g` are bounded by a binomial coefficient times the Mahler measure
+of `g * h`.
 
 Combined with `mahlerMeasure_le_sqrt_sum_sq_norm_coeff` (Landau's inequality), this gives
-the classical Mignotte bound `‖g.coeff n‖ ≤ C(deg g, n) · ‖f‖₂` used in polynomial
-factorization algorithms (Berlekamp–Zassenhaus). -/
-theorem norm_coeff_le_choose_mul_mahlerMeasure_mul (n : ℕ) (g h : ℂ[X])
+the classical Mignotte bound
+`‖g.coeff n‖ ≤ C(deg g, n) · √(∑ i ∈ f.support, ‖f.coeff i‖ ^ 2)`
+used in polynomial factorization algorithms (Berlekamp–Zassenhaus). -/
+theorem norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure (n : ℕ) (g h : ℂ[X])
     (hh : 1 ≤ h.mahlerMeasure) :
     ‖g.coeff n‖ ≤ g.natDegree.choose n * (g * h).mahlerMeasure :=
   (g.norm_coeff_le_choose_mul_mahlerMeasure n).trans <| by

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Fabrizio Barroero. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fabrizio Barroero, Kim Morrison
+Authors: Fabrizio Barroero
 -/
 module
 
@@ -326,6 +326,7 @@ theorem mahlerMeasure_le_sqrt_sum_sq_norm_coeff (p : Polynomial ℂ) :
   rw [circleAverage_eq_intervalAverage]
   calc exp (⨍ (θ : ℝ) in 0..(2 * π), log ‖p.eval (circleMap 0 1 θ)‖)
     ≤ ⨍ (θ : ℝ) in 0..(2 * π), exp (log ‖p.eval (circleMap 0 1 θ)‖) := by
+        -- First Jensen's inequality invocation
         refine convexOn_exp.map_average_le continuousOn_exp isClosed_univ (by simp) ?_ ?_
         · rw [Set.uIoc_of_le (by positivity : 0 ≤ 2 * Real.pi)]
           exact (circleIntegrable_log_norm_meromorphicOn
@@ -335,6 +336,7 @@ theorem mahlerMeasure_le_sqrt_sum_sq_norm_coeff (p : Polynomial ℂ) :
     _ = √ ((⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖) ^ 2) := by
         rw [sqrt_sq]; exact integral_nonneg (fun _ ↦ norm_nonneg _)
     _ ≤ √ (⨍ (θ : ℝ) in 0..(2 * π),  ‖p.eval (circleMap 0 1 θ)‖ ^ 2) := by
+        -- Second Jensen's inequality invocation
         gcongr
         refine (convexOn_pow 2).map_average_le (continuousOn_pow 2)
             isClosed_Ici (by filter_upwards; simp) ?_ ?_
@@ -416,22 +418,8 @@ theorem supNorm_le_choose_natDegree_div_two_mul_mahlerMeasure (p : Polynomial �
         p.mahlerMeasure_nonneg
 
 /-!
-### Monotonicity under multiplication and the Mignotte bound
+### The Mignotte bound
 -/
-
-/-- Right-multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
-measure. -/
-theorem le_mahlerMeasure_mul_right {q : ℂ[X]} (hq : 1 ≤ q.mahlerMeasure) (p : ℂ[X]) :
-    p.mahlerMeasure ≤ (p * q).mahlerMeasure := by
-  rw [mahlerMeasure_mul]
-  exact le_mul_of_one_le_right p.mahlerMeasure_nonneg hq
-
-/-- Left-multiplying by a polynomial with Mahler measure at least 1 does not decrease the Mahler
-measure. -/
-theorem le_mahlerMeasure_mul_left {p : ℂ[X]} (hp : 1 ≤ p.mahlerMeasure) (q : ℂ[X]) :
-    q.mahlerMeasure ≤ (p * q).mahlerMeasure := by
-  rw [mahlerMeasure_mul]
-  exact le_mul_of_one_le_left q.mahlerMeasure_nonneg hp
 
 /-- **Mignotte's coefficient bound**: if `f = g * h` and `h` has Mahler measure at least 1
 (which holds in particular when `h` has integer coefficients with nonzero leading coefficient),
@@ -447,6 +435,7 @@ theorem norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure (n : ℕ)
     ‖g.coeff n‖ ≤ g.natDegree.choose n * (g * h).mahlerMeasure :=
   (g.norm_coeff_le_choose_mul_mahlerMeasure n).trans <| by
     gcongr
-    exact le_mahlerMeasure_mul_right hh g
+    rw [mahlerMeasure_mul]
+    exact le_mul_of_one_le_right g.mahlerMeasure_nonneg hh
 
 end Polynomial


### PR DESCRIPTION
This PR extracts Landau's inequality as a standalone theorem and adds the Mignotte coefficient bound for polynomial factors.

Landau's inequality (`mahlerMeasure_le_sqrt_sum_sq_norm_coeff`) states that the Mahler measure of a polynomial is at most `√(∑ ‖coeff i‖²)`. This was previously buried as an intermediate step inside the proof of `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm`, which is now a short corollary.

The Mignotte bound (`norm_coeff_le_choose_mul_mahlerMeasure_mul`) says that if `f = g * h` with `M(h) ≥ 1`, then `‖g.coeff n‖ ≤ C(deg g, n) · M(f)`. The hypothesis `M(h) ≥ 1` holds in particular for nonzero integer polynomials (via `one_le_mahlerMeasure_of_one_le_norm_leadingCoeff`, also added here). This is the classical bound used in Berlekamp–Zassenhaus polynomial factorization.

New declarations:
- `one_le_mahlerMeasure_of_one_le_norm_leadingCoeff`
- `mahlerMeasure_le_sqrt_sum_sq_norm_coeff`
- `norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure`

The ℓ² norm is stated explicitly as `√(∑ i ∈ p.support, ‖p.coeff i‖ ^ 2)` with a TODO to restate using a dedicated polynomial ℓ² norm once one is defined (cf. the TODO in `Mathlib.Analysis.Polynomial.Norm`).

🤖 Prepared with [Claude Code](https://claude.ai/code)