### PR TITLE
[Merged by Bors] - chore: golf using `grind`

### DIFF
--- a/Mathlib/Algebra/CharP/CharAndCard.lean
+++ b/Mathlib/Algebra/CharP/CharAndCard.lean
@@ -36,12 +36,8 @@ theorem isUnit_iff_not_dvd_char_of_ringChar_ne_zero (R : Type*) [CommRing R] (p 
       rw [hr, ← mul_assoc, mul_comm p, mul_assoc] at hq
       nth_rw 1 [← mul_one (ringChar R)] at hq
       exact Nat.Prime.not_dvd_one hp ⟨r, mul_left_cancel₀ hR hq⟩
-    have h₄ := mt (CharP.intCast_eq_zero_iff R (ringChar R) q).mp
-    apply_fun ((↑) : ℕ → R) at hq
-    apply_fun (· * ·) a at hq
-    rw [Nat.cast_mul, hch, mul_zero, ← mul_assoc, ha, one_mul] at hq
-    norm_cast at h₄
-    exact h₄ h₃ hq.symm
+    simp_all only [ne_eq]
+    grind [ringChar.dvd]
   · intro h
     rcases (hp.coprime_iff_not_dvd.mpr h).isCoprime with ⟨a, b, hab⟩
     apply_fun ((↑) : ℤ → R) at hab

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -397,12 +397,7 @@ lemma sSupNormIm_scale_right (f : ℂ → E) {l u : ℝ} (hul : l < u) :
       use ((z - l) / (u - l))
       constructor
       · norm_cast
-        rw [Complex.div_re, Complex.normSq_ofReal, Complex.ofReal_re]
-        simp only [sub_re, hz₁, ofReal_re, sub_im, ofReal_im, sub_zero, ofReal_sub, sub_self,
-          mul_zero, zero_div, add_zero]
-        rw [div_mul_eq_div_div_swap, mul_div_assoc,
-          div_self (by norm_cast; linarith),
-          mul_one, div_self (by norm_cast; linarith)]
+        grind [Complex.div_re, Complex.normSq_ofReal, sub_re, ofReal_re, ofReal_im, mul_eq_zero]
       · rw [div_mul_comm, div_self (by norm_cast; linarith)]
         simp only [one_mul, add_sub_cancel, hz₂]
   rw [this]


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `✅️ isUnit_iff_not_dvd_char_of_ringChar_ne_zero`: unchanged 🎉
* `✅️ Complex.HadamardThreeLines.sSupNormIm_scale_right`: 499 ms before, 434 ms after  🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
