### PR TITLE
[Merged by Bors] - chore: transparency-defeq of `Primcodable (Fin n)`

### DIFF
--- a/Mathlib/Computability/Primrec/Basic.lean
+++ b/Mathlib/Computability/Primrec/Basic.lean
@@ -822,7 +822,11 @@ def subtype {p : α → Prop} [DecidablePred p] (hp : PrimrecPred p) : Primcodab
       by_cases h : p a <;> simp [h]; rfl⟩
 
 instance fin {n} : Primcodable (Fin n) :=
-  @ofEquiv _ _ (subtype <| nat_lt.comp .id (const n)) Fin.equivSubtype
+  letI : Primcodable { i : ℕ // i < n } := subtype <| nat_lt.comp .id (const n)
+  ofEquiv { i : ℕ // i < n } Fin.equivSubtype
+
+example (n) : (fin (n := n)).toEncodable = Fin.encodable n := by
+  with_reducible_and_instances rfl
 
 section ULower
 
@@ -889,7 +893,7 @@ theorem ulower_up : Primrec (ULower.up : ULower α → α) :=
   option_get (Primrec.decode₂.comp subtype_val)
 
 theorem fin_val_iff {n} {f : α → Fin n} : (Primrec fun a => (f a).1) ↔ Primrec f := by
-  letI : Primcodable { a // id a < n } := Primcodable.subtype (nat_lt.comp .id (const _))
+  letI : Primcodable { a // a < n } := Primcodable.subtype (nat_lt.comp .id (const _))
   exact (Iff.trans (by rfl) subtype_val_iff).trans (of_equiv_iff _)
 
 theorem fin_val {n} : Primrec (fun (i : Fin n) => (i : ℕ)) :=


### PR DESCRIPTION
Found by JovanGerb 's linter. ([Zulip Link](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/linter.20for.20instance.20diamonds/near/582554439))

The cause of this defeq issue is not `def` of a type, but a type is inferred as `{ i : ℕ // id i < n }` instead of `{ i : ℕ // i < n }`, so the fix is straightforward.

This change does not decrease the number of `respectTransparency`, as confirmed by running `python3 ./scripts/rm_set_option.py --files Mathlib/Computability/**`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
