### PR TITLE
[Merged by Bors] - chore(Order/SuccPred/Limit): deprecate contrapositive versions of other theorems

### DIFF
--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -189,9 +189,21 @@ protected theorem IsSuccLimit.isMax (h : IsSuccLimit (succ a)) : IsMax a :=
 theorem not_isSuccPrelimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccPrelimit (succ a) :=
   mt IsSuccPrelimit.isMax ha
 
+attribute [deprecated IsSuccPrelimit.isMax (since := "2026-03-31")]
+not_isSuccPrelimit_succ_of_not_isMax
+
+attribute [deprecated IsPredPrelimit.isMin (since := "2026-03-31")]
+not_isPredPrelimit_pred_of_not_isMin
+
 @[to_dual]
 theorem not_isSuccLimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccLimit (succ a) :=
   mt IsSuccLimit.isMax ha
+
+attribute [deprecated IsSuccLimit.isMax (since := "2026-03-31")]
+not_isSuccLimit_succ_of_not_isMax
+
+attribute [deprecated IsPredLimit.isMin (since := "2026-03-31")]
+not_isPredLimit_pred_of_not_isMin
 
 /-- Given `j < i` with `i` a prelimit, `IsSuccPrelimit.mid` picks an arbitrary element strictly
 between `j` and `i`. -/
@@ -484,7 +496,7 @@ variable [LinearOrder α] [SuccOrder α]
 @[to_dual]
 theorem isSuccPrelimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     isSuccPrelimitRecOn (Order.succ b) succ isSuccPrelimit = succ b hb := by
-  have hb' := not_isSuccPrelimit_succ_of_not_isMax hb
+  have hb' := mt IsSuccPrelimit.isMax hb
   have H := Classical.choose_spec (not_isSuccPrelimit_iff.1 hb')
   rw [isSuccPrelimitRecOn, dif_neg hb', cast_eq_iff_heq]
   congr!
@@ -595,7 +607,7 @@ variable [LinearOrder α] [SuccOrder α] [WellFoundedLT α]
 theorem prelimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     prelimitRecOn (Order.succ b) succ isSuccPrelimit =
       succ b hb (prelimitRecOn b succ isSuccPrelimit) := by
-  have h := not_isSuccPrelimit_succ_of_not_isMax hb
+  have h := mt IsSuccPrelimit.isMax hb
   have H := Classical.choose_spec (not_isSuccPrelimit_iff.1 h)
   rw [prelimitRecOn, WellFounded.fix_eq, dif_neg h]
   have {a c : α} {ha hc} {x : ∀ a, motive a} (h : a = c) :

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -185,22 +185,18 @@ protected theorem IsSuccPrelimit.isMax (h : IsSuccPrelimit (succ a)) : IsMax a :
 protected theorem IsSuccLimit.isMax (h : IsSuccLimit (succ a)) : IsMax a :=
   h.isSuccPrelimit.isMax
 
-@[to_dual]
+set_option linter.existingAttributeWarning false in
+@[to_dual, deprecated IsSuccPrelimit.isMax (since := "2026-03-31")]
 theorem not_isSuccPrelimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccPrelimit (succ a) :=
   mt IsSuccPrelimit.isMax ha
-
-attribute [deprecated IsSuccPrelimit.isMax (since := "2026-03-31")]
-not_isSuccPrelimit_succ_of_not_isMax
 
 attribute [deprecated IsPredPrelimit.isMin (since := "2026-03-31")]
 not_isPredPrelimit_pred_of_not_isMin
 
-@[to_dual]
+set_option linter.existingAttributeWarning false in
+@[to_dual, deprecated IsSuccLimit.isMax (since := "2026-03-31")]
 theorem not_isSuccLimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccLimit (succ a) :=
   mt IsSuccLimit.isMax ha
-
-attribute [deprecated IsSuccLimit.isMax (since := "2026-03-31")]
-not_isSuccLimit_succ_of_not_isMax
 
 attribute [deprecated IsPredLimit.isMin (since := "2026-03-31")]
 not_isPredLimit_pred_of_not_isMin


### PR DESCRIPTION
We deprecate some `¬ Q → ¬ P` theorems in favor of their non-contraposed `P → Q` versions. This reduces duplication.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
