### PR TITLE
[Merged by Bors] - chore(RingTheory/Valuation/FiniteField): deprecate duplicate file

### DIFF
--- a/Mathlib/RingTheory/Valuation/FiniteField.lean
+++ b/Mathlib/RingTheory/Valuation/FiniteField.lean
@@ -3,43 +3,19 @@ Copyright (c) 2025 Xavier Généreux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xavier Généreux, María Inés de Frutos-Fernández
 -/
-module
+module -- shake: keep-all
 
-public import Mathlib.RingTheory.Valuation.Basic
-public import Mathlib.Algebra.EuclideanDomain.Field
-public import Mathlib.Data.Nat.Totient
-public import Mathlib.Data.Sym.Sym2
-public import Mathlib.Tactic.NormNum.GCD
-public import Mathlib.Tactic.Positivity
+public import Mathlib.FieldTheory.Finite.Valuation
 
-/-!
+deprecated_module (since := "2026-03-31")
 
-# Valuations on algebras over finite fields
+public section
 
-Basic results on valuations over `Fq`-algebras. -/
+@[deprecated (since := "2026-03-31")] alias Valuation.FiniteField.algebraMap_eq_one :=
+  FiniteField.valuation_algebraMap_eq_one
 
-@[expose] public section
+@[deprecated (since := "2026-03-31")] alias Valuation.FiniteField.algebraMap_le_one :=
+  FiniteField.valuation_algebraMap_le_one
 
-namespace Valuation
-
-variable {Γ₀ : Type*} [LinearOrderedCommMonoidWithZero Γ₀]
-
-variable {A : Type*} [Ring A] (v : Valuation A Γ₀)
-
-namespace FiniteField
-
-variable {Fq : Type*} [Field Fq] [Finite Fq] [Algebra Fq A]
-
-@[grind =>]
-lemma algebraMap_eq_one (a : Fq) (ha : a ≠ 0) : v (algebraMap Fq A a) = 1 :=
-  IsOfFinOrder.eq_one' <| MonoidHom.isOfFinOrder (v.toMonoidHom)
-    <| MonoidHom.isOfFinOrder _ ha.isUnit.isOfFinOrder
-
-lemma algebraMap_le_one (a : Fq) : v (algebraMap Fq A a) ≤ 1 := by
-  by_cases a = 0 <;> grind [zero_le']
-
-instance (priority := low) : v.IsTrivialOn Fq where eq_one a ha := algebraMap_eq_one v a ha
-
-end FiniteField
-
-end Valuation
+@[deprecated (since := "2026-03-31")] alias Valuation.FiniteField.instIsTrivialOn :=
+  FiniteField.instIsTrivialOn


### PR DESCRIPTION
I accidentally duplicated the contents of #33049 in #35531; this was discovered during the review of #30505 (which relied on #35531). 

For simplicity, I am deprecating the file `RingTheory.Valuation.FiniteField`, which is the version that is not currently imported by any other files.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
