### PR TITLE
[Merged by Bors] - chore(Cache): improve cache miss warning message

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -526,8 +526,12 @@ def downloadFiles
     if warnOnMissing && s.success + s.failed < s.done then
       IO.eprintln "Warning: some files were not found in the cache."
       IO.eprintln "This usually means that your local checkout of mathlib4 has diverged from upstream."
-      IO.eprintln "If you push your commits to a branch of the mathlib4 repository, CI will build the oleans and they will be available later."
-      IO.eprintln "Alternatively, if you already have pushed your commits to a branch, this may mean the CI build has failed part-way through building."
+      IO.eprintln ""
+      IO.eprintln "  * If you push your commits to a PR to the mathlib4 repository"
+      IO.eprintln "    (use a draft PR if it is not ready for review),"
+      IO.eprintln "    then CI will build the oleans and they will be available later."
+      IO.eprintln "  * If you have already opened a PR, this may mean"
+      IO.eprintln "    the CI build has failed part-way through building."
     pure (s.failed, s)
   else
     let r ← hashMap.foldM (init := []) fun acc _ hash => do


### PR DESCRIPTION
This PR clarifies the warning message shown when `lake exe cache get` can't find some files. The old message incorrectly said pushing to a "branch" would trigger CI; it now correctly says to open a pull request (with a note about draft PRs). Also reformats as a bulleted list for readability.

🤖 Prepared with Claude Code