### PR TITLE
[Merged by Bors] - chore: golf proofs

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -450,7 +450,7 @@ theorem orthogonalComplement_iSup_eigenspaces_eq_bot
   have hS_symm : S.IsSymmetric :=
     hT'.restrict_invariant (hT'.orthogonalComplement_iSup_eigenspaces_invariant)
   have hS μ : eigenspace (S : Module.End 𝕜 (⨆ μ, eigenspace T μ : Submodule 𝕜 E)ᗮ) μ = ⊥ :=
-    LinearMap.IsSymmetric.orthogonalComplement_iSup_eigenspaces hT' _
+    hT'.orthogonalComplement_iSup_eigenspaces _
   have h μ : HasEigenvalue (S : End 𝕜 (⨆ μ, eigenspace T μ : Submodule 𝕜 E)ᗮ) μ → μ = 0 := by
     simp_all [hasEigenvalue_iff]
   rw [eq_zero_of_forall_hasEigenvalue_eq_zero hS_compact hS_symm] at h

--- a/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Spectrum.lean
@@ -449,14 +449,8 @@ theorem orthogonalComplement_iSup_eigenspaces_eq_bot
     hT.restrict' hT'.orthogonalComplement_iSup_eigenspaces_invariant
   have hS_symm : S.IsSymmetric :=
     hT'.restrict_invariant (hT'.orthogonalComplement_iSup_eigenspaces_invariant)
-  have hS μ : eigenspace (S : Module.End 𝕜 (⨆ μ, eigenspace T μ : Submodule 𝕜 E)ᗮ) μ = ⊥ := by
-    rw [Submodule.eq_bot_iff]
-    intro v hv
-    rw [Subtype.ext_iff, Submodule.coe_zero, ← Submodule.mem_bot 𝕜,
-      ← Submodule.inf_orthogonal_eq_bot (⨆ μ, eigenspace T μ : Submodule 𝕜 E)]
-    refine ⟨Submodule.mem_iSup_of_mem μ ?_, v.2⟩
-    rw [mem_eigenspace_iff] at hv ⊢
-    exact Subtype.ext_iff.mp hv
+  have hS μ : eigenspace (S : Module.End 𝕜 (⨆ μ, eigenspace T μ : Submodule 𝕜 E)ᗮ) μ = ⊥ :=
+    LinearMap.IsSymmetric.orthogonalComplement_iSup_eigenspaces hT' _
   have h μ : HasEigenvalue (S : End 𝕜 (⨆ μ, eigenspace T μ : Submodule 𝕜 E)ᗮ) μ → μ = 0 := by
     simp_all [hasEigenvalue_iff]
   rw [eq_zero_of_forall_hasEigenvalue_eq_zero hS_compact hS_symm] at h

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -357,7 +357,7 @@ lemma nonempty_orderEmbedding_of_finite_infinite
   obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq β (Fintype.card α)
   exact ⟨((Fintype.orderIsoFinOfCardEq α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩
 
-@[elab_as_elim]
+@[elab_as_elim, deprecated "Use `WellFoundedLT.induction _ h` instead." (since := "2026-04-02")]
 lemma LinearOrder.strong_induction_of_finite
     {α : Type*} [LinearOrder α] [Finite α] {motive : α → Prop}
     (h : ∀ (j : α) (_ : ∀ (k : α), k < j → motive k), motive j) (i : α) :

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -361,13 +361,7 @@ lemma nonempty_orderEmbedding_of_finite_infinite
 lemma LinearOrder.strong_induction_of_finite
     {α : Type*} [LinearOrder α] [Finite α] {motive : α → Prop}
     (h : ∀ (j : α) (_ : ∀ (k : α), k < j → motive k), motive j) (i : α) :
-    motive i := by
-  have := Fintype.ofFinite α
-  let e := Fintype.orderIsoFinOfCardEq α rfl
-  revert i
-  rw [e.surjective.forall]
-  refine Fin.strong_induction_on (fun j hj ↦ h _ (fun k hk ↦ ?_))
-  simpa using hj (e.symm k) (by simpa [← e.lt_iff_lt])
+    motive i := WellFoundedLT.induction _ h
 
 lemma OrderEmbedding.range_eq_iff
     {α β : Type*} [LinearOrder α] [PartialOrder β] [Finite α]

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -357,7 +357,7 @@ lemma nonempty_orderEmbedding_of_finite_infinite
   obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq β (Fintype.card α)
   exact ⟨((Fintype.orderIsoFinOfCardEq α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩
 
-@[elab_as_elim, deprecated "Use `WellFoundedLT.induction _ h` instead." (since := "2026-04-02")]
+@[elab_as_elim, deprecated "Use `WellFoundedLT.induction _ h` instead." (since := "2026-04-10")]
 lemma LinearOrder.strong_induction_of_finite
     {α : Type*} [LinearOrder α] [Finite α] {motive : α → Prop}
     (h : ∀ (j : α) (_ : ∀ (k : α), k < j → motive k), motive j) (i : α) :

--- a/Mathlib/Probability/Distributions/Poisson/Basic.lean
+++ b/Mathlib/Probability/Distributions/Poisson/Basic.lean
@@ -108,10 +108,8 @@ section PoissonPMF
 noncomputable
 def poissonPMFReal (r : ℝ≥0) (n : ℕ) : ℝ := exp (-r) * r ^ n / (n)!
 
-set_option linter.deprecated false in
 @[deprecated hasSum_one_poissonMeasure (since := "2026-03-08")]
-lemma poissonPMFRealSum (r : ℝ≥0) : HasSum (fun n ↦ poissonPMFReal r n) 1 :=
-  hasSum_one_poissonMeasure _
+  alias poissonPMFRealSum := hasSum_one_poissonMeasure
 
 set_option linter.deprecated false in
 @[deprecated poissonMeasure_real_singleton_pos (since := "2026-03-08")]

--- a/Mathlib/Probability/Distributions/Poisson/Basic.lean
+++ b/Mathlib/Probability/Distributions/Poisson/Basic.lean
@@ -110,17 +110,8 @@ def poissonPMFReal (r : ℝ≥0) (n : ℕ) : ℝ := exp (-r) * r ^ n / (n)!
 
 set_option linter.deprecated false in
 @[deprecated hasSum_one_poissonMeasure (since := "2026-03-08")]
-lemma poissonPMFRealSum (r : ℝ≥0) : HasSum (fun n ↦ poissonPMFReal r n) 1 := by
-  let r := r.toReal
-  unfold poissonPMFReal
-  apply (hasSum_mul_left_iff (exp_ne_zero r)).mp
-  simp only [mul_one]
-  have : (fun i ↦ rexp r * (rexp (-r) * r ^ i / i.factorial)) =
-      fun i ↦ r ^ i / i.factorial := by
-    ext n
-    rw [mul_div_assoc, exp_neg, ← mul_assoc, ← div_eq_mul_inv, div_self (exp_ne_zero r), one_mul]
-  rw [this, exp_eq_exp_ℝ]
-  exact NormedSpace.expSeries_div_hasSum_exp r
+lemma poissonPMFRealSum (r : ℝ≥0) : HasSum (fun n ↦ poissonPMFReal r n) 1 :=
+  hasSum_one_poissonMeasure _
 
 set_option linter.deprecated false in
 @[deprecated poissonMeasure_real_singleton_pos (since := "2026-03-08")]

--- a/Mathlib/Probability/Distributions/Poisson/Basic.lean
+++ b/Mathlib/Probability/Distributions/Poisson/Basic.lean
@@ -108,8 +108,8 @@ section PoissonPMF
 noncomputable
 def poissonPMFReal (r : ℝ≥0) (n : ℕ) : ℝ := exp (-r) * r ^ n / (n)!
 
-@[deprecated hasSum_one_poissonMeasure (since := "2026-03-08")]
-  alias poissonPMFRealSum := hasSum_one_poissonMeasure
+@[deprecated (since := "2026-03-08")]
+alias poissonPMFRealSum := hasSum_one_poissonMeasure
 
 set_option linter.deprecated false in
 @[deprecated poissonMeasure_real_singleton_pos (since := "2026-03-08")]


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `✅️ LinearMap.IsSymmetric.orthogonalComplement_iSup_eigenspaces_eq_bot`: unchanged 🎉
* `✅️ LinearOrder.strong_induction_of_finite`: unchanged 🎉
* `✅️ ProbabilityTheory.poissonPMFRealSum`: 140 ms before, <30 ms after  🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
