### PR TITLE
[Merged by Bors] - chore(Topology/Compactness): style cleanup for some instances

### DIFF
--- a/Mathlib/Topology/Compactness/CountablyCompact.lean
+++ b/Mathlib/Topology/Compactness/CountablyCompact.lean
@@ -168,9 +168,8 @@ theorem IsCompact.isCountablyCompact (hA : IsCompact A) : IsCountablyCompact A :
   fun _ _ _ hle => hA hle
 
 /-- A compact space is countably compact. -/
-instance CompactSpace.CountablyCompactSpace
-    {X : Type*} [TopologicalSpace X] [CompactSpace X] :
-    CountablyCompactSpace X where
+instance instCompactSpaceCountablyCompactSpace
+    {X : Type*} [TopologicalSpace X] [CompactSpace X] : CountablyCompactSpace X where
   isCountablyCompact_univ := isCompact_univ.isCountablyCompact
 
 /-- A sequentially compact set is countably compact. -/
@@ -180,9 +179,8 @@ theorem IsSeqCompact.isCountablyCompact (hA : IsSeqCompact A) :
   exact ⟨a, ha, hφa.mapClusterPt.of_comp hφ.tendsto_atTop⟩
 
 /-- A sequentially compact space is countably compact. -/
-instance SeqCompactSpace.CountablyCompactSpace
-    {X : Type*} [TopologicalSpace X] [SeqCompactSpace X] :
-    CountablyCompactSpace X where
+instance instSeqCompactSpaceCountablyCompactSpace
+    {X : Type*} [TopologicalSpace X] [SeqCompactSpace X] : CountablyCompactSpace X where
   isCountablyCompact_univ := isSeqCompact_univ.isCountablyCompact
 
 /-- In a first-countable space, a countably compact set is sequentially compact. -/
@@ -191,10 +189,10 @@ theorem IsCountablyCompact.isSeqCompact [FirstCountableTopology E]
     let ⟨a, haA, hac⟩ := IsCountablyCompact.seq_clusterPt hA x (Eventually.of_forall hx)
     ⟨a, haA, TopologicalSpace.FirstCountableTopology.tendsto_subseq hac⟩
 
-/-- In a first-countable countably compact space is sequentially compact. -/
-instance CountablyCompactSpace.SeqCompactSpace {X : Type*} [TopologicalSpace X]
+/-- A first-countable countably compact space is sequentially compact. -/
+instance instCountablyCompactSpaceSeqCompactSpace {X : Type*} [TopologicalSpace X]
     [FirstCountableTopology X] [CountablyCompactSpace X] : SeqCompactSpace X where
-    isSeqCompact_univ := isCountablyCompact_univ.isSeqCompact
+  isSeqCompact_univ := CountablyCompactSpace.isCountablyCompact_univ.isSeqCompact
 
 /-- In a first-countable space, a set is countably compact iff it is sequentially compact. -/
 theorem isCountablyCompact_iff_isSeqCompact [FirstCountableTopology E] :
@@ -251,7 +249,7 @@ theorem IsLindelof.isCompact (hA : IsCountablyCompact A) (hl : IsLindelof A) :
 /-- A countably compact Lindelöf space is compact. -/
 theorem LindelofSpace.CompactSpace {X : Type*} [TopologicalSpace X]
     [LindelofSpace X] [h : CountablyCompactSpace X] : CompactSpace X where
-    isCompact_univ := isLindelof_univ.isCompact h.isCountablyCompact_univ
+  isCompact_univ := isLindelof_univ.isCompact h.isCountablyCompact_univ
 
 /-- In a Hereditarily Lindelöf space, a countably compact set is compact. -/
 theorem IsCountablyCompact.isCompact [HereditarilyLindelofSpace E]


### PR DESCRIPTION
Improves #37460 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
