### PR TITLE
[Merged by Bors] - feat(Torsion/PrimaryComponent): restricted surjective map on primaryComponent is surjective

### DIFF
--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -218,10 +218,7 @@ theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
       DFinsupp.filter_ne_eq_erase, DFinsupp.support_erase, DFinsupp.erase_apply,
       DFinsupp.mapRange_apply, LinearMap.toAddMonoidHom_coe, subtype_apply, Finset.erase_eq]
     apply Finset.sum_congr_of_eq_on_inter
-    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, DFinsupp.mapRange_apply, ne_eq,
-      Finset.mem_singleton, not_and, Decidable.not_not, ZeroMemClass.coe_eq_zero, ite_eq_left_iff,
-      and_imp]
-      grind
+    · simp_all
     · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, ne_eq, Finset.mem_singleton,
       DFinsupp.mapRange_apply, not_and, Decidable.not_not, and_imp]
       intro a ha hne hnfa
@@ -229,10 +226,7 @@ theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
       suffices ¬(primaryComponent.map a.asIdeal φ) (f a) = 0 by grind
       simpa [Subtype.ext_iff, primaryComponent.map, LinearMap.codRestrict_apply,
         LinearMap.domRestrict_apply]
-    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, DFinsupp.mapRange_apply, ne_eq,
-      Finset.mem_singleton, and_imp]
-      intro a ha hne hnfa hne
-      simp [if_neg hne, map]
+    · aesop
 
 end IsDedekindDomain
 

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -186,6 +186,61 @@ theorem iSupIndep_primaryComponent :
   apply hSupIndep _ _ ?_ hsum
   exact fun P hP ↦ torsionBySet_le_torsionBySet_pow _ _ (Finset.le_sup hP) _ (hmem P hP)
 
+open Classical in
+theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
+    [AddCommGroup M₁] [AddCommGroup M₂] [Module A M₁] [Module A M₂]
+    (hM₁ : IsTorsion A M₁) (hM₂ : IsTorsion A M₂)
+    (P : HeightOneSpectrum A) (φ : M₁ →ₗ[A] M₂) (hf : Surjective φ) :
+    Surjective (primaryComponent.map P.asIdeal φ) := by
+  rintro ⟨y, hy⟩
+  obtain ⟨b, rfl⟩ := hf y
+  simp only [primaryComponent_mem, mem_torsionBySet_iff, SetLike.coe_sort_coe, Subtype.forall] at hy
+  obtain ⟨n, hn⟩ := hy
+  obtain ⟨h1, h2⟩ := by simpa [isInternal_submodule_iff_iSupIndep_and_iSup_eq_top, eq_top_iff']
+    using isInternal_primaryComponent hM₁
+  specialize h2 b
+  rw [mem_iSup_iff_exists_dfinsupp] at h2
+  obtain ⟨f, hf⟩ := h2
+  use f P
+  ext
+  simp only [map, LinearMap.codRestrict_apply, LinearMap.domRestrict_apply, ← hf, DFinsupp.sum,
+    DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, LinearMap.toAddMonoidHom_coe,
+    subtype_apply, map_sum]
+  rw [Finset.sum_eq_add_sum_diff_singleton P _ (by aesop), left_eq_add]
+  obtain ⟨h1, h2⟩ := by simpa [isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+    using isInternal_primaryComponent hM₂
+  specialize h1 P
+  simp only [ne_eq, disjoint_iff, Submodule.eq_bot_iff, Submodule.mem_inf] at h1
+  apply h1
+  constructor
+  · have := (Finset.sum_eq_add_sum_diff_singleton (s := f.support) P (fun P ↦ φ (f P))
+      (by clear h1; aesop))
+    rw [← sub_eq_of_eq_add' this]
+    replace hf := by simpa [DFinsupp.sumAddHom_apply, DFinsupp.sum] using congr(φ $hf)
+    rw [hf]
+    exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)
+  · rw [Submodule.mem_biSup_iff_exists_dfinsupp]
+    use (DFinsupp.mapRange (fun Q : HeightOneSpectrum A ↦ map Q.asIdeal φ) (by simp) f)
+    simp only [DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, DFinsupp.sum,
+      DFinsupp.filter_ne_eq_erase, DFinsupp.support_erase, DFinsupp.erase_apply,
+      DFinsupp.mapRange_apply, LinearMap.toAddMonoidHom_coe, subtype_apply, Finset.erase_eq]
+    apply Finset.sum_congr_of_eq_on_inter
+    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, DFinsupp.mapRange_apply, ne_eq,
+      Finset.mem_singleton, not_and, Decidable.not_not, ZeroMemClass.coe_eq_zero, ite_eq_left_iff,
+      and_imp]
+      grind
+    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, ne_eq, Finset.mem_singleton,
+      DFinsupp.mapRange_apply, not_and, Decidable.not_not, and_imp]
+      intro a ha hne hnfa
+      by_contra!
+      suffices ¬(primaryComponent.map a.asIdeal φ) (f a) = 0 by grind
+      simpa [Subtype.ext_iff, primaryComponent.map, LinearMap.codRestrict_apply,
+        LinearMap.domRestrict_apply]
+    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, DFinsupp.mapRange_apply, ne_eq,
+      Finset.mem_singleton, and_imp]
+      intro a ha hne hnfa hne
+      simp [if_neg hne, map]
+
 end IsDedekindDomain
 
 end AddCommGroup

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -186,46 +186,43 @@ theorem iSupIndep_primaryComponent :
   apply hSupIndep _ _ ?_ hsum
   exact fun P hP ↦ torsionBySet_le_torsionBySet_pow _ _ (Finset.le_sup hP) _ (hmem P hP)
 
-open Classical in
+open DFinsupp hiding disjoint_iff
 theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
     [AddCommGroup M₁] [AddCommGroup M₂] [Module A M₁] [Module A M₂] (hM₁ : IsTorsion A M₁)
     (P : HeightOneSpectrum A) (φ : M₁ →ₗ[A] M₂) (hf : Surjective φ) :
     Surjective (primaryComponent.map P.asIdeal φ) := by
+  classical
   rintro ⟨y, hy⟩
-  obtain ⟨b, rfl⟩ := hf y
-  simp only [primaryComponent_mem, mem_torsionBySet_iff, SetLike.coe_sort_coe, Subtype.forall] at hy
-  obtain ⟨n, hn⟩ := hy
-  have h₁ := by simpa [eq_top_iff'] using iSup_primaryComponent_eq_top hM₁
-  specialize h₁ b
-  rw [mem_iSup_iff_exists_dfinsupp] at h₁
-  obtain ⟨f, hf⟩ := h₁
+  obtain ⟨b, rfl⟩ : ∃ a, φ a = y := hf y
+  obtain ⟨f, hf⟩ : ∃ f : Π₀ i : HeightOneSpectrum A, primaryComponent M₁ i.asIdeal,
+      (lsum ℕ fun i : HeightOneSpectrum A ↦ (primaryComponent M₁ i.asIdeal).subtype) f = b := by
+    rw [← mem_iSup_iff_exists_dfinsupp]
+    have := iSup_primaryComponent_eq_top hM₁
+    simp only [eq_top_iff'] at this
+    exact this b
   use f P
   ext
-  simp only [map, LinearMap.codRestrict_apply, LinearMap.domRestrict_apply, ← hf, DFinsupp.sum,
-    DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, LinearMap.toAddMonoidHom_coe,
-    subtype_apply, map_sum]
-  rw [Finset.sum_eq_add_sum_diff_singleton P _ (by aesop), left_eq_add]
-  apply (by simpa [disjoint_iff, Submodule.eq_bot_iff] using iSupIndep_primaryComponent A M₂ P)
-  · have := (Finset.sum_eq_add_sum_diff_singleton (s := f.support) P (fun P ↦ φ (f P))
-      (by aesop))
-    rw [← sub_eq_of_eq_add' this]
-    replace hf := by simpa [DFinsupp.sumAddHom_apply, DFinsupp.sum] using congr(φ $hf)
-    rw [hf]
+  suffices ∑ x ∈ f.support \ {P}, φ ↑(f x) = 0 by
+    aesop (add norm [(Finset.sum_eq_add_sum_diff_singleton P (fun x ↦ φ (f x))), map,
+      sumAddHom_apply, sum])
+  have hboth : ∀ x ∈ primaryComponent M₂ P.asIdeal,
+      x ∈ ⨆ Q ≠ P, primaryComponent M₂ Q.asIdeal → x = 0 := by
+    simpa [disjoint_iff, Submodule.eq_bot_iff] using iSupIndep_primaryComponent A M₂ P
+  apply hboth <;> clear hboth
+  · have h_sum_eq : ∑ x ∈ f.support, φ ↑(f x) = φ b := by
+      simpa [sumAddHom_apply, sum] using congr(φ $hf)
+    rw [← sub_eq_of_eq_add' (Finset.sum_eq_add_sum_diff_singleton P (fun P ↦ φ (f P)) (by aesop)),
+      h_sum_eq]
     exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)
   · rw [Submodule.mem_biSup_iff_exists_dfinsupp]
-    use (DFinsupp.mapRange (fun Q : HeightOneSpectrum A ↦ map Q.asIdeal φ) (by simp) f)
+    use (mapRange (fun Q : HeightOneSpectrum A ↦ map Q.asIdeal φ) (by simp) f)
     simp only [DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, DFinsupp.sum,
       DFinsupp.filter_ne_eq_erase, DFinsupp.support_erase, DFinsupp.erase_apply,
       DFinsupp.mapRange_apply, LinearMap.toAddMonoidHom_coe, subtype_apply, Finset.erase_eq]
     apply Finset.sum_congr_of_eq_on_inter
     · simp_all
-    · simp only [Finset.mem_sdiff, DFinsupp.mem_support_toFun, ne_eq, Finset.mem_singleton,
-      DFinsupp.mapRange_apply, not_and, Decidable.not_not, and_imp]
-      intro a ha hne hnfa
-      by_contra!
-      suffices ¬(primaryComponent.map a.asIdeal φ) (f a) = 0 by grind
-      simpa [Subtype.ext_iff, primaryComponent.map, LinearMap.codRestrict_apply,
-        LinearMap.domRestrict_apply]
+    · grind only [= Finset.mem_sdiff, map, = mem_support_toFun, mapRange_apply,
+      !LinearMap.codRestrict_apply, = map_zero, LinearMap.domRestrict_apply, #f5c8]
     · aesop
 
 end IsDedekindDomain

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -188,33 +188,26 @@ theorem iSupIndep_primaryComponent :
 
 open Classical in
 theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
-    [AddCommGroup M₁] [AddCommGroup M₂] [Module A M₁] [Module A M₂]
-    (hM₁ : IsTorsion A M₁) (hM₂ : IsTorsion A M₂)
+    [AddCommGroup M₁] [AddCommGroup M₂] [Module A M₁] [Module A M₂] (hM₁ : IsTorsion A M₁)
     (P : HeightOneSpectrum A) (φ : M₁ →ₗ[A] M₂) (hf : Surjective φ) :
     Surjective (primaryComponent.map P.asIdeal φ) := by
   rintro ⟨y, hy⟩
   obtain ⟨b, rfl⟩ := hf y
   simp only [primaryComponent_mem, mem_torsionBySet_iff, SetLike.coe_sort_coe, Subtype.forall] at hy
   obtain ⟨n, hn⟩ := hy
-  obtain ⟨h1, h2⟩ := by simpa [isInternal_submodule_iff_iSupIndep_and_iSup_eq_top, eq_top_iff']
-    using isInternal_primaryComponent hM₁
-  specialize h2 b
-  rw [mem_iSup_iff_exists_dfinsupp] at h2
-  obtain ⟨f, hf⟩ := h2
+  have h₁ := by simpa [eq_top_iff'] using iSup_primaryComponent_eq_top hM₁
+  specialize h₁ b
+  rw [mem_iSup_iff_exists_dfinsupp] at h₁
+  obtain ⟨f, hf⟩ := h₁
   use f P
   ext
   simp only [map, LinearMap.codRestrict_apply, LinearMap.domRestrict_apply, ← hf, DFinsupp.sum,
     DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, LinearMap.toAddMonoidHom_coe,
     subtype_apply, map_sum]
   rw [Finset.sum_eq_add_sum_diff_singleton P _ (by aesop), left_eq_add]
-  obtain ⟨h1, h2⟩ := by simpa [isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
-    using isInternal_primaryComponent hM₂
-  specialize h1 P
-  simp only [ne_eq, disjoint_iff, Submodule.eq_bot_iff, Submodule.mem_inf] at h1
-  apply h1
-  constructor
+  apply (by simpa [disjoint_iff, Submodule.eq_bot_iff] using iSupIndep_primaryComponent A M₂ P)
   · have := (Finset.sum_eq_add_sum_diff_singleton (s := f.support) P (fun P ↦ φ (f P))
-      (by clear h1; aesop))
+      (by aesop))
     rw [← sub_eq_of_eq_add' this]
     replace hf := by simpa [DFinsupp.sumAddHom_apply, DFinsupp.sum] using congr(φ $hf)
     rw [hf]

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -186,8 +186,7 @@ theorem iSupIndep_primaryComponent :
   apply hSupIndep _ _ ?_ hsum
   exact fun P hP ↦ torsionBySet_le_torsionBySet_pow _ _ (Finset.le_sup hP) _ (hmem P hP)
 
-open DFinsupp hiding disjoint_iff
-theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
+theorem primaryComponent.map_surjective {M₁ M₂ : Type*}
     [AddCommGroup M₁] [AddCommGroup M₂] [Module A M₁] [Module A M₂] (hM₁ : IsTorsion A M₁)
     (P : HeightOneSpectrum A) (φ : M₁ →ₗ[A] M₂) (hf : Surjective φ) :
     Surjective (primaryComponent.map P.asIdeal φ) := by
@@ -195,35 +194,19 @@ theorem primaryComponent.map_surjective (M₁ M₂ : Type*)
   rintro ⟨y, hy⟩
   obtain ⟨b, rfl⟩ : ∃ a, φ a = y := hf y
   obtain ⟨f, hf⟩ : ∃ f : Π₀ i : HeightOneSpectrum A, primaryComponent M₁ i.asIdeal,
-      (lsum ℕ fun i : HeightOneSpectrum A ↦ (primaryComponent M₁ i.asIdeal).subtype) f = b := by
-    rw [← mem_iSup_iff_exists_dfinsupp]
-    have := iSup_primaryComponent_eq_top hM₁
-    simp only [eq_top_iff'] at this
-    exact this b
-  use f P
-  ext
-  suffices ∑ x ∈ f.support \ {P}, φ ↑(f x) = 0 by
-    aesop (add norm [(Finset.sum_eq_add_sum_diff_singleton P (fun x ↦ φ (f x))), map,
-      sumAddHom_apply, sum])
-  have hboth : ∀ x ∈ primaryComponent M₂ P.asIdeal,
-      x ∈ ⨆ Q ≠ P, primaryComponent M₂ Q.asIdeal → x = 0 := by
-    simpa [disjoint_iff, Submodule.eq_bot_iff] using iSupIndep_primaryComponent A M₂ P
-  apply hboth <;> clear hboth
-  · have h_sum_eq : ∑ x ∈ f.support, φ ↑(f x) = φ b := by
-      simpa [sumAddHom_apply, sum] using congr(φ $hf)
-    rw [← sub_eq_of_eq_add' (Finset.sum_eq_add_sum_diff_singleton P (fun P ↦ φ (f P)) (by aesop)),
-      h_sum_eq]
-    exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)
-  · rw [Submodule.mem_biSup_iff_exists_dfinsupp]
-    use (mapRange (fun Q : HeightOneSpectrum A ↦ map Q.asIdeal φ) (by simp) f)
-    simp only [DFinsupp.lsum_apply_apply, DFinsupp.sumAddHom_apply, DFinsupp.sum,
-      DFinsupp.filter_ne_eq_erase, DFinsupp.support_erase, DFinsupp.erase_apply,
-      DFinsupp.mapRange_apply, LinearMap.toAddMonoidHom_coe, subtype_apply, Finset.erase_eq]
-    apply Finset.sum_congr_of_eq_on_inter
-    · simp_all
-    · grind only [= Finset.mem_sdiff, map, = mem_support_toFun, mapRange_apply,
-      !LinearMap.codRestrict_apply, = map_zero, LinearMap.domRestrict_apply, #f5c8]
-    · aesop
+      (DFinsupp.lsum ℕ fun i : HeightOneSpectrum A ↦
+      (primaryComponent M₁ i.asIdeal).subtype) f = b := by
+    simp only [← mem_iSup_iff_exists_dfinsupp, iSup_primaryComponent_eq_top hM₁, mem_top]
+  refine ⟨f P, Subtype.ext ?_⟩
+  change φ (f P) = φ b
+  rw [eq_comm, ← sub_eq_zero]
+  refine (Submodule.disjoint_def.mp (iSupIndep_primaryComponent A M₂ P)) _ ?mP ?muQ
+  · exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)
+  · rw [(?diff : φ b - φ ↑(f P) = ∑ Q ∈ f.support \ {P}, φ ↑(f Q))]
+    · exact Submodule.sum_mem _ fun Q hQ ↦ Submodule.mem_iSup_of_mem Q <|
+        Submodule.mem_iSup_of_mem (by grind) (primaryComponent_map_mem _ _ _)
+    · rw [sub_eq_iff_eq_add', ← Finset.sum_eq_add_sum_diff_singleton P (fun P ↦ φ (f P)) (by aesop)]
+      simpa [DFinsupp.sumAddHom_apply, DFinsupp.sum] using congr(φ $hf).symm
 
 end IsDedekindDomain
 

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -200,13 +200,14 @@ theorem primaryComponent.map_surjective {M₁ M₂ : Type*}
   refine ⟨f P, Subtype.ext ?_⟩
   change φ (f P) = φ b
   rw [eq_comm, ← sub_eq_zero]
-  refine (Submodule.disjoint_def.mp (iSupIndep_primaryComponent A M₂ P)) _ ?mP ?muQ
+  refine (Submodule.disjoint_def.mp (iSupIndep_primaryComponent A M₂ P)) _ ?_ ?_
   · exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)
-  · rw [(?diff : φ b - φ ↑(f P) = ∑ Q ∈ f.support \ {P}, φ ↑(f Q))]
-    · exact Submodule.sum_mem _ fun Q hQ ↦ Submodule.mem_iSup_of_mem Q <|
-        Submodule.mem_iSup_of_mem (by grind) (primaryComponent_map_mem _ _ _)
-    · rw [sub_eq_iff_eq_add', ← Finset.sum_eq_add_sum_diff_singleton P (fun P ↦ φ (f P)) (by aesop)]
+  · have hdiff : φ b - φ ↑(f P) = ∑ Q ∈ f.support \ {P}, φ ↑(f Q) := by
+      rw [sub_eq_iff_eq_add', ← Finset.sum_eq_add_sum_diff_singleton P (fun P ↦ φ (f P)) (by aesop)]
       simpa [DFinsupp.sumAddHom_apply, DFinsupp.sum] using congr(φ $hf).symm
+    rw [hdiff]
+    exact Submodule.sum_mem _ fun Q hQ ↦ Submodule.mem_iSup_of_mem Q <|
+        Submodule.mem_iSup_of_mem (by grind) (primaryComponent_map_mem _ _ _)
 
 end IsDedekindDomain
 

--- a/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
+++ b/Mathlib/Algebra/Module/Torsion/PrimaryComponent.lean
@@ -72,6 +72,7 @@ theorem primaryComponent_map_mem (φ : M₁ →ₗ[A] M₂) (c : primaryComponen
 
 /-- Given an A-linear map between M₁ and M₂, `primaryComponent.map` is the
 restriction to the I-primaryComponent components of M₁ and M₂. -/
+@[simps!]
 def primaryComponent.map (φ : M₁ →ₗ[A] M₂) : primaryComponent M₁ I →ₗ[A] primaryComponent M₂ I :=
   (φ.domRestrict (primaryComponent M₁ I)).codRestrict (primaryComponent M₂ I) (fun c ↦
     by simpa only [LinearMap.domRestrict_apply] using primaryComponent_map_mem I φ c)
@@ -198,7 +199,7 @@ theorem primaryComponent.map_surjective {M₁ M₂ : Type*}
       (primaryComponent M₁ i.asIdeal).subtype) f = b := by
     simp only [← mem_iSup_iff_exists_dfinsupp, iSup_primaryComponent_eq_top hM₁, mem_top]
   refine ⟨f P, Subtype.ext ?_⟩
-  change φ (f P) = φ b
+  simp only [map_apply_coe]
   rw [eq_comm, ← sub_eq_zero]
   refine (Submodule.disjoint_def.mp (iSupIndep_primaryComponent A M₂ P)) _ ?_ ?_
   · exact Submodule.sub_mem _ hy (primaryComponent_map_mem _ _ _)


### PR DESCRIPTION
Given a surjective linear map between modules ` φ : M₁ →ₗ[A] M₂`, its restriction to primary components
```
primaryComponent.map P.asIdeal φ : ↥(primaryComponent M₁ P.asIdeal) →ₗ[A] ↥(primaryComponent M₂ P.asIdeal)
```
is also surjective when `P` is a non zero prime ideal in a Dedekind domain `A` and `M₁` and `M₂` are torsion.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #37466

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
