### PR TITLE
[Merged by Bors] - fix(Tactic/Ring): sort terms when evaluating nested powers

### DIFF
--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -899,6 +899,12 @@ theorem mul_pow {ea₁ b c₁ : ℕ} {xa₁ : R}
     (_ : ea₁ * b = c₁) (_ : a₂ ^ b = c₂) : (xa₁ ^ ea₁ * a₂ : R) ^ b = xa₁ ^ c₁ * c₂ := by
   subst_vars; simp [_root_.mul_pow, pow_mul]
 
+theorem mul_pow_mul {ea₁ b c₁ : ℕ} {xa₁ d : R}
+    (_ : ea₁ * b = c₁) (_ : a₂ ^ b = c₂)
+    (_ : (xa₁ ^ c₁ * (nat_lit 1).rawCast) * c₂ = d) :
+    (xa₁ ^ ea₁ * a₂ : R) ^ b = d := by
+  subst_vars; simp [_root_.mul_pow, pow_mul, Nat.rawCast]
+
 -- needed to lift from `OptionT CoreM` to `OptionT MetaM`
 private local instance {m m'} [Monad m] [Monad m'] [MonadLiftT m m'] :
     MonadLiftT (OptionT m) (OptionT m') where
@@ -933,7 +939,9 @@ def evalPowProd {a : Q($α)} {b : Q(ℕ)} (va : ExProd sα a) (vb : ExProd sℕ 
     | .mul vxa₁ vea₁ va₂, vb =>
       let ⟨_, vc₁, pc₁⟩ ← evalMulProd sℕ vea₁ vb
       let ⟨_, vc₂, pc₂⟩ ← evalPowProd va₂ vb
-      return ⟨_, .mul vxa₁ vc₁ vc₂, q(mul_pow $pc₁ $pc₂)⟩
+      let one : ExProd sα q((nat_lit 1).rawCast : $α) := .const 1 none
+      let ⟨_, vd, pd⟩ ← evalMulProd sα (.mul vxa₁ vc₁ one) vc₂
+      return ⟨_, vd, q(mul_pow_mul $pc₁ $pc₂ $pd)⟩
     | _, _ => OptionT.fail
   return (← res.run).getD (evalPowProdAtom sα va vb)
 

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -939,8 +939,7 @@ def evalPowProd {a : Q($α)} {b : Q(ℕ)} (va : ExProd sα a) (vb : ExProd sℕ 
     | .mul vxa₁ vea₁ va₂, vb =>
       let ⟨_, vc₁, pc₁⟩ ← evalMulProd sℕ vea₁ vb
       let ⟨_, vc₂, pc₂⟩ ← evalPowProd va₂ vb
-      let one : ExProd sα q((nat_lit 1).rawCast : $α) := .const 1 none
-      let ⟨_, vd, pd⟩ ← evalMulProd sα (.mul vxa₁ vc₁ one) vc₂
+      let ⟨_, vd, pd⟩ ← evalMulProd sα (vxa₁.toProd vc₁) vc₂
       return ⟨_, vd, q(mul_pow_mul $pc₁ $pc₂ $pd)⟩
     | _, _ => OptionT.fail
   return (← res.run).getD (evalPowProdAtom sα va vb)

--- a/Mathlib/Tactic/Ring/Common.lean
+++ b/Mathlib/Tactic/Ring/Common.lean
@@ -899,8 +899,7 @@ theorem mul_pow {ea₁ b c₁ : ℕ} {xa₁ : R}
     (_ : ea₁ * b = c₁) (_ : a₂ ^ b = c₂) : (xa₁ ^ ea₁ * a₂ : R) ^ b = xa₁ ^ c₁ * c₂ := by
   subst_vars; simp [_root_.mul_pow, pow_mul]
 
-theorem mul_pow_mul {ea₁ b c₁ : ℕ} {xa₁ d : R}
-    (_ : ea₁ * b = c₁) (_ : a₂ ^ b = c₂)
+theorem mul_pow_mul {ea₁ b c₁ : ℕ} {xa₁ d : R} (_ : ea₁ * b = c₁) (_ : a₂ ^ b = c₂)
     (_ : (xa₁ ^ c₁ * (nat_lit 1).rawCast) * c₂ = d) :
     (xa₁ ^ ea₁ * a₂ : R) ^ b = d := by
   subst_vars; simp [_root_.mul_pow, pow_mul, Nat.rawCast]

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -166,6 +166,7 @@ example (a b : ℤ) : a+b=0 ↔ b+a=0 := by
 
 -- Powers in the exponent get evaluated correctly
 example (X : ℤ) : (X^5 + 1) * (X^2^3 + X) = X^13 + X^8 + X^6 + X := by ring
+example (a : ℚ) (m n : ℕ) : (a ^ (m + 1)) ^ n = a ^ (n * (m + 1)) := by ring
 
 -- simulate the type of MvPolynomial
 def R : Type u → Type v → Sort (max (u+1) (v+1)) := test_sorry


### PR DESCRIPTION
`ring` currently misorders the terms in a product when evaluating nested powers.  When evaluating e.g. `(x^a*x)^b` where `x`  is an atom, it returns `x^(a*b)*x^b` even if `b` is supposed to come before `a*b` in the ordering on `ExProd`s. 

We fix this by running `evalMulProd` instead of using the `.mul` constructor directly. This in effect does an insertion sort on the terms in the `ExProd`s. We do a similar thing when evaluating multiplication. 
```
/--
error: ring failed, ring expressions not equal
a : ℚ
m n : ℕ
⊢ a ^ n * a ^ (m * n) = a ^ (m * n) * a ^ n
-/
#guard_msgs in
example (a : ℚ) (m n : ℕ) : (a ^ (m + 1)) ^ n = a ^ (n * (m + 1)) := by ring1
```
---

This bug was pointed out to me by @Multramate 

The fix in this PR was written and investigated with the help of Claude code. 

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
