### PR TITLE
[Merged by Bors] - feat(Valuation/Discrete/RankOne): generalize results to Ring

### DIFF
--- a/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
@@ -12,6 +12,10 @@ public import Mathlib.RingTheory.Valuation.RankOne
 # Discrete valuations have rank one
 
 ## Main Definitions and Results
+* `Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_mem_range` : the generator of
+a discrete valuation in `ℤᵐ⁰` that contains `exp (-1)` in its range is equal to `exp (-1)`.
+* `Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective` : the generator of
+a surjective discrete valuation in `ℤᵐ⁰` is equal to `exp (-1)`.
 * `Valuation.IsRankOneDiscrete.valueGroup₀_equiv_withZeroMulInt` : the order-preserving isomorphism
 between the `ValueGroup₀` of a discrete valuation and `ℤᵐ⁰`.
 * `Valuation.IsRankOneDiscrete.rankOne` : a discrete valuation has rank one.
@@ -61,6 +65,13 @@ lemma valueGroup₀_equiv_withZeroMulInt_strictMono :
     (Subgroup.zpowers_inv (g := hv.generator') ▸ hv.generator'_zpowers_eq_top)
     (Left.one_lt_inv_iff.mpr hv.generator'_lt_one)))).lt_iff_lt]
 
+/-- A discrete valuation has rank one. -/
+@[implicit_reducible]
+noncomputable def rankOne {e : ℝ≥0} (he : 1 < e) : v.RankOne where
+  hom' := (toNNReal (ne_of_gt (lt_trans zero_lt_one he))).comp (valueGroup₀_equiv_withZeroMulInt v)
+  strictMono' := (toNNReal_strictMono he).comp (valueGroup₀_equiv_withZeroMulInt_strictMono v)
+  exists_val_nontrivial := IsNontrivial.exists_val_nontrivial
+
 end LinearOrderedCommGroupWithZero
 
 section WithZeroMulInt
@@ -68,6 +79,9 @@ section WithZeroMulInt
 variable {v : Valuation R ℤᵐ⁰} [hv : v.IsRankOneDiscrete]
 
 open LinearOrderedCommGroup in
+/--
+The generator of a discrete valuation in `ℤᵐ⁰` that contains `exp (-1)` in its range
+is equal to `exp (-1)`. -/
 theorem generator_eq_exp_neg_one_of_mem_range (hπ : exp (-1) ∈ Set.range v) :
     hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) := by
   rw [← Valuation.IsRankOneDiscrete.valueGroup_genLTOne_eq_generator]
@@ -84,6 +98,8 @@ theorem generator_eq_exp_neg_one_of_mem_range (hπ : exp (-1) ∈ Set.range v) :
     | ofNat n => refine ⟨1, ?_, π ^ n, ?_⟩ <;> simp [hπ]
     | negSucc n => refine ⟨π ^ (n + 1), ?_, 1, ?_⟩ <;> simp [hπ, Int.negSucc_eq, mul_assoc]
 
+/--
+The generator of a surjective discrete valuation in `ℤᵐ⁰` is equal to `exp (-1)`. -/
 lemma generator_eq_exp_neg_one_of_surjective (hsurj : Function.Surjective v) :
     hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) :=
   generator_eq_exp_neg_one_of_mem_range (by aesop)
@@ -115,14 +131,6 @@ lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : F
       Units.val_zpow_eq_zpow_val, Units.val_mk0, inv_zpow', ← exp_zsmul, Int.zsmul_eq_mul, mul_one,
       inv_inv]
     simp [WithZero.exp]
-
-variable (v) in
-/-- A discrete valuation has rank one. -/
-@[implicit_reducible]
-noncomputable def rankOne {e : ℝ≥0} (he : 1 < e) : v.RankOne where
-  hom' := (toNNReal (ne_of_gt (lt_trans zero_lt_one he))).comp (valueGroup₀_equiv_withZeroMulInt v)
-  strictMono' := (toNNReal_strictMono he).comp (valueGroup₀_equiv_withZeroMulInt_strictMono v)
-  exists_val_nontrivial := IsNontrivial.exists_val_nontrivial
 
 end WithZeroMulInt
 

--- a/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
@@ -88,6 +88,11 @@ lemma generator_eq_exp_neg_one_of_surjective (hsurj : Function.Surjective v) :
     hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) :=
   generator_eq_exp_neg_one_of_mem_range (by aesop)
 
+@[deprecated generator_eq_exp_neg_one_of_surjective (since := "2026-04-01")]
+lemma generator_eq_neg_exp_one_of_surjective (hsurj : Function.Surjective v) :
+    hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) :=
+  generator_eq_exp_neg_one_of_surjective hsurj
+
 lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : Function.Surjective v)
     (x : R) : (valueGroup₀_equiv_withZeroMulInt v) (v.restrict x) = v x := by
   simp only [Valuation.restrict_def, ValueGroup₀.restrict₀_apply,

--- a/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
@@ -30,7 +30,11 @@ variable {Γ : Type*} [LinearOrderedCommGroupWithZero Γ]
 
 section Ring
 
-variable {R : Type*} [CommRing R] (v : Valuation R Γ) [hv : v.IsRankOneDiscrete]
+variable {R : Type*} [Ring R]
+
+section LinearOrderedCommGroupWithZero
+
+variable (v : Valuation R Γ) [hv : v.IsRankOneDiscrete]
 
 /-- An order-preserving isomorphism between the `ValueGroup₀` of a discrete valuation and `ℤᵐ⁰`. -/
 @[simps!]
@@ -57,32 +61,35 @@ lemma valueGroup₀_equiv_withZeroMulInt_strictMono :
     (Subgroup.zpowers_inv (g := hv.generator') ▸ hv.generator'_zpowers_eq_top)
     (Left.one_lt_inv_iff.mpr hv.generator'_lt_one)))).lt_iff_lt]
 
-end Ring
+end LinearOrderedCommGroupWithZero
 
-section Field
+section WithZeroMulInt
 
-variable {K : Type*} [Field K] {v : Valuation K ℤᵐ⁰} [hv : v.IsRankOneDiscrete]
+variable {v : Valuation R ℤᵐ⁰} [hv : v.IsRankOneDiscrete]
 
-lemma generator_eq_neg_exp_one_of_surjective (hsurj : Function.Surjective v) :
-    hv.generator = Units.mk0 (WithZero.exp (-1 : ℤ) : ℤᵐ⁰) (by simp) := by
-  rw [← valueGroup_genLTOne_eq_generator, eq_comm]
-  refine LinearOrderedCommGroup.Subgroup.genLTOne_unique (valueGroup v) ?_ ?_
-  · rw [← Units.val_lt_val, Units.val_one,← WithZero.exp_zero, Units.val_mk0]
-    exact compareOfLessAndEq_eq_lt.mp rfl
+open LinearOrderedCommGroup in
+theorem generator_eq_exp_neg_one_of_mem_range (hπ : exp (-1) ∈ Set.range v) :
+    hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) := by
+  rw [← Valuation.IsRankOneDiscrete.valueGroup_genLTOne_eq_generator]
+  suffices Units.mk0 (exp (-1)) (by simp) = (Subgroup.genLTOne (valueGroup v)) by simp [← this]
+  apply LinearOrderedCommGroup.Subgroup.genLTOne_unique
+  · exact compareOfLessAndEq_eq_lt.mp rfl
   · ext n
-    simp only [Int.reduceNeg, exp_neg, Subgroup.mem_zpowers_iff, mem_valueGroup_iff_of_comm,
-      ne_eq, map_eq_zero]
-    refine ⟨fun _ ↦ ⟨1, one_ne_zero, ?_⟩ , fun _ ↦ ?_⟩
-    · obtain ⟨x, hx⟩ := hsurj n
-      exact ⟨x, by simp [hx]⟩
-    · have hn0 : (n : ℤᵐ⁰) ≠ 0 := by simp only [ne_eq, Units.ne_zero, not_false_eq_true]
-      use -WithZero.log n
-      ext
-      simp [zpow_neg, Units.val_inv_eq_inv_val, Units.val_zpow_eq_zpow_val, Units.val_mk0,
-        inv_zpow', inv_inv]
+    simp_all only [Int.reduceNeg, exp_neg, Subgroup.mem_zpowers_iff, mem_valueGroup_iff_of_comm,
+      ne_eq]
+    refine ⟨fun ⟨k, h⟩ ↦ ?_ , fun _ ↦ ⟨-WithZero.log n, by aesop⟩⟩
+    rw [← h]
+    have ⟨π, hπ⟩ := hπ
+    cases k with
+    | ofNat n => refine ⟨1, ?_, π ^ n, ?_⟩ <;> simp [hπ]
+    | negSucc n => refine ⟨π ^ (n + 1), ?_, 1, ?_⟩ <;> simp [hπ, Int.negSucc_eq, mul_assoc]
+
+lemma generator_eq_exp_neg_one_of_surjective (hsurj : Function.Surjective v) :
+    hv.generator = Units.mk0 (exp (-1 : ℤ) : ℤᵐ⁰) (by simp) :=
+  generator_eq_exp_neg_one_of_mem_range (by aesop)
 
 lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : Function.Surjective v)
-    (x : K) : (valueGroup₀_equiv_withZeroMulInt v) (v.restrict x) = v x := by
+    (x : R) : (valueGroup₀_equiv_withZeroMulInt v) (v.restrict x) = v x := by
   simp only [Valuation.restrict_def, ValueGroup₀.restrict₀_apply,
     valueGroup₀_equiv_withZeroMulInt_apply]
   split_ifs with h0
@@ -96,7 +103,7 @@ lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : F
     simp only [Units.val_mk0, intEquivOfZPowersEqTop_apply, inv_zpow', generator',
       SubgroupClass.coe_zpow]
     have hg : hv.generator = Units.mk0 (WithZero.exp (-1 : ℤ) : ℤᵐ⁰) (by simp) :=
-      generator_eq_neg_exp_one_of_surjective hsurj
+      generator_eq_exp_neg_one_of_surjective hsurj
     rw [hg]
     conv_lhs => rw [← coe_unzero h0]
     simp only [coe_unzero, Int.reduceNeg, exp_neg, zpow_neg, Units.val_inv_eq_inv_val,
@@ -106,14 +113,13 @@ lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : F
 
 /-- A discrete valuation has rank one. -/
 @[implicit_reducible]
-noncomputable def rankOne (v : Valuation K Γ) [hv : v.IsRankOneDiscrete]
-    {e : ℝ≥0} (he : 1 < e) : v.RankOne where
+noncomputable def rankOne {e : ℝ≥0} (he : 1 < e) : v.RankOne where
   hom' := (toNNReal (ne_of_gt (lt_trans zero_lt_one he))).comp (valueGroup₀_equiv_withZeroMulInt v)
   strictMono' := (toNNReal_strictMono he).comp (valueGroup₀_equiv_withZeroMulInt_strictMono v)
-  exists_val_nontrivial := by
-    obtain ⟨x, hx⟩ := v.exists_isUniformizer_of_isCyclic_of_nontrivial
-    exact ⟨x, hx.val_ne_zero, ne_of_lt hx.val_lt_one⟩
+  exists_val_nontrivial := IsNontrivial.exists_val_nontrivial
 
-end Field
+end WithZeroMulInt
+
+end Ring
 
 end Valuation.IsRankOneDiscrete

--- a/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
@@ -116,6 +116,7 @@ lemma valueGroup₀_equiv_withZeroMulInt_restrict_apply_of_surjective (hsurj : F
       inv_inv]
     simp [WithZero.exp]
 
+variable (v) in
 /-- A discrete valuation has rank one. -/
 @[implicit_reducible]
 noncomputable def rankOne {e : ℝ≥0} (he : 1 < e) : v.RankOne where


### PR DESCRIPTION
This PR generalize the `RankOne` file to use `Ring` instead of `CommRing` and `Field.`

The lemma `generator_eq_neg_exp_one_of_surjective` has been renamed to `generator_eq_exp_neg_one_of_surjective`.
This same lemma is also generalized in the form of `generator_eq_exp_neg_one_of_mem_range`.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
