### PR TITLE
[Merged by Bors] - doc(RingTheory): avoid lazy continuation lines

### DIFF
--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -20,6 +20,7 @@ To avoid coercions, we rather consider `DividedPowers.dpow : ℕ → A → A`, e
 
 * `DividedPowers.dpow_null` asserts that `dpow n x = 0` for `x ∉ I`
 * `DividedPowers.dpow_mem` : `dpow n x ∈ I` for `n ≠ 0`
+
 For `x y : A` and `m n : ℕ` such that `x ∈ I` and `y ∈ I`, one has
 * `DividedPowers.dpow_zero` : `dpow 0 x = 1`
 * `DividedPowers.dpow_one` : `dpow 1 x = 1`

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -248,6 +248,7 @@ Let `N₁ -l₁₂-> N₂ -l₂₃-> N₃` be two linear maps.
   This is `range_le_ker_of_exact_rTensor`.
 - Then in `rTensor_reflects_exact`, we show `ker l₂₃ = range l₁₂` by considering the cohomology
   `ker l₂₃ ⧸ range l₁₂`.
+
 This shows that when `M` is faithfully flat, `- ⊗ M` reflects exact sequences. For details, see
 comments in the proof. Since `M` is flat, `- ⊗ M` preserves exact sequences.
 

--- a/Mathlib/RingTheory/GradedAlgebra/RingHom.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/RingHom.lean
@@ -28,7 +28,7 @@ We do **not** define a separate class of graded ring homomorphisms; instead, we 
 ## Implementation notes
 
 * We don't really need the fact that they are graded rings until the theorem
-`DirectSum.decompose_map` which describes how the decomposition interacts with the map.
+  `DirectSum.decompose_map` which describes how the decomposition interacts with the map.
 -/
 
 @[expose] public section

--- a/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/HasFiniteQuotients.lean
@@ -19,9 +19,9 @@ quotient `R ⧸ I` is finite.
 - `Ring.HasFiniteQuotients.instDimensionLEOne`: A ring with finite quotients has dimension `≤ 1`.
 - `Ring.HasFiniteQuotients.instIsNoetherianRing` : A ring with finite quotients is noetherian.
 - `Ring.HasFiniteQuotients.of_module_finite`: Assume that `R` has finite quotients and that `S` is
-a domain and a finite `R`-module. Then `S` has finite quotients.
+  a domain and a finite `R`-module. Then `S` has finite quotients.
 - `Ring.HasFiniteQuotients.instOfIsDomainOfFG`: A domain that is also a finite `ℤ`-module
-has finite quotients.
+  has finite quotients.
 
 -/
 

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -12,17 +12,20 @@ public import Mathlib.RingTheory.Artinian.Module
 
 /-!
 # Jacobson Rings
+
 The following conditions are equivalent for a ring `R`:
 1. Every radical ideal `I` is equal to its Jacobson radical
 2. Every radical ideal `I` can be written as an intersection of maximal ideals
 3. Every prime ideal `I` is equal to its Jacobson radical
+
 Any ring satisfying any of these equivalent conditions is said to be Jacobson.
 Some particular examples of Jacobson rings are also proven.
-`isJacobsonRing_quotient` says that the quotient of a Jacobson ring is Jacobson.
-`isJacobsonRing_localization` says the localization of a Jacobson ring
+- `isJacobsonRing_quotient` says that the quotient of a Jacobson ring is Jacobson.
+- `isJacobsonRing_localization` says the localization of a Jacobson ring
   to a single element is Jacobson.
-`isJacobsonRing_polynomial_iff_isJacobsonRing` says polynomials over a Jacobson ring
+- `isJacobsonRing_polynomial_iff_isJacobsonRing` says polynomials over a Jacobson ring
   form a Jacobson ring.
+
 ## Main definitions
 Let `R` be a commutative ring. Jacobson rings are defined using the first of the above conditions
 * `IsJacobsonRing R` is the proposition that `R` is a Jacobson ring. It is a class,
@@ -35,6 +38,7 @@ Let `R` be a commutative ring. Jacobson rings are defined using the first of the
   `f : R →+* S` is surjective, then `S` is also a Jacobson ring
 * `MvPolynomial.isJacobsonRing` says that multi-variate polynomials
   over a Jacobson ring are Jacobson.
+
 ## Tags
 Jacobson, Jacobson Ring
 -/

--- a/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
+++ b/Mathlib/RingTheory/Kaehler/JacobiZariski.lean
@@ -22,6 +22,7 @@ The maps are
 - `Algebra.H1Cotangent.δ`
 - `KaehlerDifferential.mapBaseChange`
 - `KaehlerDifferential.map`
+
 and the exactness lemmas are
 - `Algebra.H1Cotangent.exact_map_δ`
 - `Algebra.H1Cotangent.exact_δ_mapBaseChange`

--- a/Mathlib/RingTheory/KrullDimension/Polynomial.lean
+++ b/Mathlib/RingTheory/KrullDimension/Polynomial.lean
@@ -20,6 +20,7 @@ This file proves properties of the Krull dimension of the polynomial ring over a
 
 * `Polynomial.ringKrullDim_le`: the Krull dimension of the polynomial ring over a commutative ring
   `R` is less than `2 * (ringKrullDim R) + 1`.
+
 For noetherian rings:
 * `Polynomial.ringKrullDim_of_isNoetherianRing`: the Krull dimension of `R[X]` is `dim R + 1`.
 * `MvPolynomial.ringKrullDim_of_isNoetherianRing`: the Krull dimension of `R[X₁, ..., Xₙ]` is

--- a/Mathlib/RingTheory/MvPowerSeries/LinearTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/LinearTopology.lean
@@ -14,7 +14,7 @@ public import Mathlib.RingTheory.TwoSidedIdeal.Operations
 /-! # Linear topology on the ring of multivariate power series
 
 - `MvPowerSeries.LinearTopology.basis`: the ideals of the ring of multivariate power series
-all coefficients the exponent of which is smaller than some bound vanish.
+  all coefficients the exponent of which is smaller than some bound vanish.
 
 - `MvPowerSeries.LinearTopology.hasBasis_nhds_zero` :
   the two-sided ideals from `MvPowerSeries.LinearTopology.basis` form a basis

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -25,6 +25,7 @@ It is only well defined under one of the two following conditions:
     - For every `s`, the constant coefficient of `a s` is nilpotent;
     - For every `d : σ →₀ ℕ`, all but finitely many of the coefficients
       `(a s).coeff d` vanish.
+
 In the other cases, it is defined as 0 (dummy value).
 
 When `HasSubst a`, `MvPowerSeries.subst a` gives rise to an algebra homomorphism

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
@@ -11,7 +11,7 @@ public import Mathlib.RingTheory.Ideal.Quotient.Operations
 
 /-! # The Eisenstein criterion
 
-`Polynomial.generalizedEisenstein` :
+- `Polynomial.generalizedEisenstein` :
   Let `R` be an integral domain
   and let `K` an `R`-algebra which is a field
   Let `q : R[X]` be a monic polynomial which is prime in `K[X]`.
@@ -20,6 +20,7 @@ public import Mathlib.RingTheory.Ideal.Quotient.Operations
   * the image of `f` in `K[X]` is a power of `q`.
   * the leading coefficient of `f` is not zero in `K`
   * the polynomial `f` is primitive.
+
   Assume moreover that `f.modByMonic q` is not zero in `(R ⧸ (P ^ 2))[X]`,
   where `P` is the kernel of `algebraMap R K`.
   Then `f` is irreducible.

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -18,7 +18,7 @@ This operation is called `PowerSeries.expand` and it is an algebra homomorphism.
 ### Main declaration
 
 * `PowerSeries.expand`: expand a power series by a nonzero factor of p,
-so `∑ aₙ xⁿ` becomes `∑ aₙ xⁿᵖ`.
+  so `∑ aₙ xⁿ` becomes `∑ aₙ xⁿᵖ`.
 -/
 
 @[expose] public section

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -131,6 +131,7 @@ variable (R S) in
 A finite-type `R`-algebra `S` is (formally) unramified iff there exists a `t : S ⊗[R] S` satisfying
 1. `t` annihilates every `1 ⊗ s - s ⊗ 1`.
 2. the image of `t` is `1` under the map `S ⊗[R] S → S`.
+
 See `Algebra.FormallyUnramified.iff_exists_tensorProduct`.
 This is the choice of such a `t`.
 -/

--- a/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/RankOne.lean
@@ -17,7 +17,7 @@ a discrete valuation in `ℤᵐ⁰` that contains `exp (-1)` in its range is equ
 * `Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective` : the generator of
 a surjective discrete valuation in `ℤᵐ⁰` is equal to `exp (-1)`.
 * `Valuation.IsRankOneDiscrete.valueGroup₀_equiv_withZeroMulInt` : the order-preserving isomorphism
-between the `ValueGroup₀` of a discrete valuation and `ℤᵐ⁰`.
+  between the `ValueGroup₀` of a discrete valuation and `ℤᵐ⁰`.
 * `Valuation.IsRankOneDiscrete.rankOne` : a discrete valuation has rank one.
 
 ## Tags

--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -22,10 +22,10 @@ We define rank one valuations.
 
 ## Main Definitions
 * `RankOne` : A valuation has rank one if it is nontrivial and its image (defined as
-`MonoidWithZeroHom.valueGroup₀ v`) is contained in `ℝ≥0`. Note that this class includes the data
-of an inclusion morphism `MonoidWithZeroHom.valueGroup₀ v → ℝ≥0`.
+  `MonoidWithZeroHom.valueGroup₀ v`) is contained in `ℝ≥0`. Note that this class includes the data
+  of an inclusion morphism `MonoidWithZeroHom.valueGroup₀ v → ℝ≥0`.
 * `RankOne.restrict_RankOne` is the `RankOne` instance for the restriction of a valuation to its
-image, as defined in
+  image, as defined in
 
 ## Tags
 

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -75,6 +75,7 @@ dvd_sub_pow_of_dvd_sub {R : Type*} [CommRing R] {p : ℕ} {a b : R} :
   - `WittVector.wittAdd`
   - `WittVector.wittMul`
   - `WittVector.wittNeg`
+
   (We also define `WittVector.wittSub`, and later we will prove that it describes subtraction,
   which is defined as `fun a b ↦ a + -b`. See `WittVector.sub_coeff` for this proof.)
 

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -40,6 +40,7 @@ We follow https://stacks.math.columbia.edu/tag/00PI and proceed in the following
     One first reduces to when `R ⊆ S` are domains, and then to when `R` is integrally closed.
     A going down theorem is now available, which could be applied to
     `Polynomial.map_under_lt_comap_of_quasiFiniteAt`:`(p ∩ R)[X] < p ∩ R<x>` to get a contradiction.
+
   The second result applied to `S/√𝔣` together with the first result implies that
   `p` does not contain `𝔣`.
   The claim then follows from `Localization.localRingHom_bijective_of_not_conductor_le`.


### PR DESCRIPTION
We resolve the ambiguity inherent in lazy (un-indented) list item continuation lines by either indenting them or separating them by inserting a newline in the cases where the item continuation was a mistake.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
