### PR TITLE
[Merged by Bors] - chore(Topology/Connected): generalize `preimage_connectedComponent_connected` to closed connected sets

### DIFF
--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -403,31 +403,31 @@ variable [TopologicalSpace β] {f : α → β}
 
 /-- The preimage of a connected component is preconnected if the function has connected fibers
 and a subset is closed iff the preimage is. -/
-theorem preimage_connectedComponent_connected
+theorem Topology.IsCoinducing.isConnected_preimage_of_isClosed
     (connected_fibers : ∀ t : β, IsConnected (f ⁻¹' {t}))
-    (hcl : Topology.IsCoinducing f) (t : β) :
-    IsConnected (f ⁻¹' connectedComponent t) := by
+    (hcl : Topology.IsCoinducing f) {t : Set β} (ht : IsClosed t) (ht' : IsConnected t) :
+    IsConnected (f ⁻¹' t) := by
   -- The following proof is essentially https://stacks.math.columbia.edu/tag/0377
   -- although the statement is slightly different
   have hf : Surjective f := Surjective.of_comp fun t : β => (connected_fibers t).1
-  refine ⟨Nonempty.preimage connectedComponent_nonempty hf, ?_⟩
-  have hT : IsClosed (f ⁻¹' connectedComponent t) :=
-    hcl.isClosed_preimage.mpr isClosed_connectedComponent
-  -- To show it's preconnected we decompose (f ⁻¹' connectedComponent t) as a subset of two
+  refine ⟨Nonempty.preimage ht'.nonempty hf, ?_⟩
+  have hT : IsClosed (f ⁻¹' t) :=
+    hcl.isClosed_preimage.mpr ht
+  -- To show it's preconnected we decompose (f ⁻¹' t) as a subset of two
   -- closed disjoint sets in α. We want to show that it's a subset of either.
   rw [isPreconnected_iff_subset_of_fully_disjoint_closed hT]
   intro u v hu hv huv uv_disj
-  -- To do this we decompose connectedComponent t into T₁ and T₂
-  -- we will show that connectedComponent t is a subset of either and hence
-  -- (f ⁻¹' connectedComponent t) is a subset of u or v
-  let T₁ := { t' ∈ connectedComponent t | f ⁻¹' {t'} ⊆ u }
-  let T₂ := { t' ∈ connectedComponent t | f ⁻¹' {t'} ⊆ v }
-  have fiber_decomp : ∀ t' ∈ connectedComponent t, f ⁻¹' {t'} ⊆ u ∨ f ⁻¹' {t'} ⊆ v := by
+  -- To do this we decompose t into T₁ and T₂
+  -- we will show that t is a subset of either and hence
+  -- (f ⁻¹' t) is a subset of u or v
+  let T₁ := { t' ∈ t | f ⁻¹' {t'} ⊆ u }
+  let T₂ := { t' ∈ t | f ⁻¹' {t'} ⊆ v }
+  have fiber_decomp : ∀ t' ∈ t, f ⁻¹' {t'} ⊆ u ∨ f ⁻¹' {t'} ⊆ v := by
     intro t' ht'
     apply isPreconnected_iff_subset_of_disjoint_closed.1 (connected_fibers t').2 u v hu hv
     · exact Subset.trans (preimage_mono (singleton_subset_iff.2 ht')) huv
     rw [uv_disj.inter_eq, inter_empty]
-  have T₁_u : f ⁻¹' T₁ = f ⁻¹' connectedComponent t ∩ u := by
+  have T₁_u : f ⁻¹' T₁ = f ⁻¹' t ∩ u := by
     apply eq_of_subset_of_subset
     · rw [← biUnion_preimage_singleton]
       refine iUnion₂_subset fun t' ht' => subset_inter ?_ ht'.2
@@ -439,7 +439,7 @@ theorem preimage_connectedComponent_connected
     refine (fiber_decomp (f a) (mem_preimage.1 hat)).resolve_right fun h => ?_
     exact uv_disj.subset_compl_right hau (h rfl)
   -- This proof is exactly the same as the above (modulo some symmetry)
-  have T₂_v : f ⁻¹' T₂ = f ⁻¹' connectedComponent t ∩ v := by
+  have T₂_v : f ⁻¹' T₂ = f ⁻¹' t ∩ v := by
     apply eq_of_subset_of_subset
     · rw [← biUnion_preimage_singleton]
       refine iUnion₂_subset fun t' ht' => subset_inter ?_ ht'.2
@@ -450,10 +450,10 @@ theorem preimage_connectedComponent_connected
     · exact mem_preimage.1 hat
     · refine (fiber_decomp (f a) (mem_preimage.1 hat)).resolve_left fun h => ?_
       exact uv_disj.subset_compl_left hav (h rfl)
-  -- Now we show T₁, T₂ are closed, cover connectedComponent t and are disjoint.
+  -- Now we show T₁, T₂ are closed, cover t and are disjoint.
   have hT₁ : IsClosed T₁ := hcl.isClosed_preimage.mp (T₁_u.symm ▸ IsClosed.inter hT hu)
   have hT₂ : IsClosed T₂ := hcl.isClosed_preimage.mp (T₂_v.symm ▸ IsClosed.inter hT hv)
-  have T_decomp : connectedComponent t ⊆ T₁ ∪ T₂ := fun t' ht' => by
+  have T_decomp : t ⊆ T₁ ∪ T₂ := fun t' ht' => by
     rw [mem_union t' T₁ T₂]
     rcases fiber_decomp t' ht' with htu | htv
     · left; exact ⟨ht', htu⟩
@@ -462,20 +462,29 @@ theorem preimage_connectedComponent_connected
     refine Disjoint.of_preimage hf ?_
     rw [T₁_u, T₂_v, disjoint_iff_inter_eq_empty, ← inter_inter_distrib_left, uv_disj.inter_eq,
       inter_empty]
-  -- Now we do cases on whether (connectedComponent t) is a subset of T₁ or T₂ to show
+  -- Now we do cases on whether t is a subset of T₁ or T₂ to show
   -- that the preimage is a subset of u or v.
-  rcases (isPreconnected_iff_subset_of_fully_disjoint_closed isClosed_connectedComponent).1
-    isPreconnected_connectedComponent T₁ T₂ hT₁ hT₂ T_decomp T_disjoint with h | h
+  rcases (isPreconnected_iff_subset_of_fully_disjoint_closed ht).1
+    ht'.isPreconnected T₁ T₂ hT₁ hT₂ T_decomp T_disjoint with h | h
   · left
     rw [Subset.antisymm_iff] at T₁_u
-    suffices f ⁻¹' connectedComponent t ⊆ f ⁻¹' T₁
+    suffices f ⁻¹' t ⊆ f ⁻¹' T₁
       from (this.trans T₁_u.1).trans inter_subset_right
     exact preimage_mono h
   · right
     rw [Subset.antisymm_iff] at T₂_v
-    suffices f ⁻¹' connectedComponent t ⊆ f ⁻¹' T₂
+    suffices f ⁻¹' t ⊆ f ⁻¹' T₂
       from (this.trans T₂_v.1).trans inter_subset_right
     exact preimage_mono h
+
+@[deprecated Topology.IsCoinducing.isConnected_preimage_of_isClosed (since := "2026-04-01")]
+theorem preimage_connectedComponent_connected (connected_fibers : ∀ t : β, IsConnected (f ⁻¹' {t}))
+    (hcl : Topology.IsCoinducing f) (t : β) :
+    IsConnected (f ⁻¹' connectedComponent t) := by
+  apply hcl.isConnected_preimage_of_isClosed
+  · exact isClosed_connectedComponent
+  · exact isConnected_connectedComponent
+  · exact connected_fibers
 
 theorem Topology.IsCoinducing.preimage_connectedComponent (hf : IsCoinducing f)
     (h_fibers : ∀ y : β, IsConnected (f ⁻¹' {y})) (a : α) :

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -405,7 +405,7 @@ variable [TopologicalSpace β] {f : α → β}
 and a subset is closed iff the preimage is. -/
 theorem Topology.IsCoinducing.isConnected_preimage_of_isClosed
     (connected_fibers : ∀ t : β, IsConnected (f ⁻¹' {t}))
-    (hcl : Topology.IsCoinducing f) {t : Set β} (ht : IsClosed t) (ht' : IsConnected t) :
+    (hcl : IsCoinducing f) {t : Set β} (ht : IsClosed t) (ht' : IsConnected t) :
     IsConnected (f ⁻¹' t) := by
   -- The following proof is essentially https://stacks.math.columbia.edu/tag/0377
   -- although the statement is slightly different

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -479,7 +479,7 @@ theorem Topology.IsCoinducing.isConnected_preimage_of_isClosed
 
 @[deprecated Topology.IsCoinducing.isConnected_preimage_of_isClosed (since := "2026-04-01")]
 theorem preimage_connectedComponent_connected (connected_fibers : ∀ t : β, IsConnected (f ⁻¹' {t}))
-    (hcl : Topology.IsCoinducing f) (t : β) :
+    (hcl : IsCoinducing f) (t : β) :
     IsConnected (f ⁻¹' connectedComponent t) := by
   apply hcl.isConnected_preimage_of_isClosed
   · exact isClosed_connectedComponent

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -489,8 +489,8 @@ theorem preimage_connectedComponent_connected (connected_fibers : ∀ t : β, Is
 theorem Topology.IsCoinducing.preimage_connectedComponent (hf : IsCoinducing f)
     (h_fibers : ∀ y : β, IsConnected (f ⁻¹' {y})) (a : α) :
     f ⁻¹' connectedComponent (f a) = connectedComponent a :=
-  ((preimage_connectedComponent_connected h_fibers hf
-      _).subset_connectedComponent mem_connectedComponent).antisymm
+  ((hf.isConnected_preimage_of_isClosed h_fibers isClosed_connectedComponent
+    isConnected_connectedComponent).subset_connectedComponent mem_connectedComponent).antisymm
     (hf.continuous.mapsTo_connectedComponent a)
 
 lemma Topology.IsCoinducing.image_connectedComponent {f : α → β} (hf : IsCoinducing f)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
