### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Integral/Lebesgue): add `lintegral_eq_iSup_eapprox_lintegral'` and `lintegral_comp'`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
@@ -232,6 +232,11 @@ theorem lintegral_eq_iSup_eapprox_lintegral {f : α → ℝ≥0∞} (hf : Measur
     _ = ⨆ n, (eapprox f n).lintegral μ := by
       congr; ext n; rw [(eapprox f n).lintegral_eq_lintegral]
 
+/-- Generalization of `lintegral_eq_iSup_eapprox_lintegral` to ae-measurable functions. -/
+theorem lintegral_eq_iSup_eapprox_lintegral' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
+    ∫⁻ a, f a ∂μ = ⨆ n, (eapprox (hf.mk f) n).lintegral μ := by
+  rw [lintegral_congr_ae hf.ae_eq_mk, lintegral_eq_iSup_eapprox_lintegral hf.measurable_mk]
+
 lemma lintegral_eapprox_le_lintegral {f : α → ℝ≥0∞} (hf : Measurable f) (n : ℕ) :
     (eapprox f n).lintegral μ ≤ ∫⁻ x, f x ∂μ := by
   rw [lintegral_eq_iSup_eapprox_lintegral hf]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Map.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Map.lean
@@ -59,6 +59,11 @@ theorem lintegral_comp {f : β → ℝ≥0∞} {g : α → β} (hf : Measurable 
     (hg : Measurable g) : lintegral μ (f ∘ g) = ∫⁻ a, f a ∂map g μ :=
   (lintegral_map hf hg).symm
 
+/-- Generalization of `lintegral_comp` to ae-measurable functions. -/
+theorem lintegral_comp' {f : β → ℝ≥0∞} {g : α → β} (hf : AEMeasurable f (μ.map g))
+    (hg : AEMeasurable g μ) : lintegral μ (f ∘ g) = ∫⁻ a, f a ∂μ.map g :=
+  (lintegral_map' hf hg).symm
+
 theorem setLIntegral_map {f : β → ℝ≥0∞} {g : α → β} {s : Set β}
     (hs : MeasurableSet s) (hf : Measurable f) (hg : Measurable g) :
     ∫⁻ y in s, f y ∂map g μ = ∫⁻ x in g ⁻¹' s, f (g x) ∂μ := by


### PR DESCRIPTION
Add ae-measurable generalizations of two Lebesgue integral lemmas:
- `lintegral_eq_iSup_eapprox_lintegral'` generalizes `lintegral_eq_iSup_eapprox_lintegral`
- `lintegral_comp'` generalizes `lintegral_comp`

Upstreamed from the [Carleson](https://github.com/fpvandoorn/carleson) project.

Co-authored-by: Leo Diedering <129694072+ldiedering@users.noreply.github.com>
Co-authored-by: James Sundstrom <James.Sundstrom@gmail.com>

---