### PR TITLE
[Merged by Bors] - doc(Analysis/DifferentialForm): fix equations in docstrings

### DIFF
--- a/Mathlib/Analysis/Calculus/DifferentialForm/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/VectorField.lean
@@ -16,13 +16,13 @@ In this file we prove the following formula and its corollaries.
 If `ω` is a differentiable `k`-form and `V i` are `k + 1` differentiable vector fields, then
 
 $$
-  dω(V_0(x), \dots, V_n(x)) =
-    \left(\sum_{i=0}^k (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_k(x)))(V_i(x)) +
-      \sum_{0 \le i < j\le k} (-1)^{i + j}
-        ω(x; [V_i, V_j](x), V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)),
+  dω(V_0(x), \dots, V_n(x)) = \sum_{i=0}^k (-1)^i •
+      D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_k(x)\big)\right)(V_i(x)) +
+    \sum_{0 \le i < j\le k} (-1)^{i + j}
+        ω\big(x; [V_i, V_j](x), V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)\big),
 $$
-where $$[V_i, V_j]$$ is the commutator of the vector fields $$V_i$$ and $$V_j$$.
-As usual, $$\widehat{V_i(x)}$$ means that this item is removed from the sequence.
+where $[V_i, V_j]$ is the commutator of the vector fields $V_i$ and $V_j$.
+As usual, $\widehat{V_i(x)}$ means that this item is removed from the sequence.
 
 There is no convenient way to write the second term in Lean for `k = 0`,
 so we only state this theorem for `k = n + 1`,
@@ -51,25 +51,25 @@ If `ω` is a differentiable `(n + 1)`-form and `V i` are `n + 2` differentiable 
 
 $$
   dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)) -
+    \sum_{i=0}^{n + 1} (-1)^i •
+      D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)) -
       \sum_{0 \le i \le j\le n} (-1)^{i + j}
-        ω(x; [V_i, V_{j + 1}](x),
-          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_{j + 1}(x)}, …, V_k(x)),
+        ω\big(x; [V_i, V_{j + 1}](x),
+          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_{j + 1}(x)}, …, V_k(x)\big),
 $$
 
-where $$[V_i, V_{j + 1}]$$ is the commutator of the vector fields $$V_i$$ and $$V_{j + 1}$$.
-As usual, $$\widehat{V_i(x)}$$ means that this item is removed from the sequence.
+where $[V_i, V_{j + 1}]$ is the commutator of the vector fields $V_i$ and $V_{j + 1}$.
+As usual, $\widehat{V_i(x)}$ means that this item is removed from the sequence.
 
 In informal texts, this formula is usually written as
 
 $$
   dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)) -
+    \sum_{i=0}^{n + 1} (-1)^i •
+      D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)) -
       \sum_{0 \le i < j\le n + 1} (-1)^{i + j}
-        ω(x; [V_i, V_j](x),
-          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)).
+        ω\big(x; [V_i, V_j](x),
+          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)\big).
 $$
 
 In the sum from our formalization,
@@ -112,25 +112,25 @@ If `ω` is a differentiable `(n + 1)`-form and `V i` are `n + 2` differentiable 
 
 $$
   dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)) -
+    \sum_{i=0}^{n + 1} (-1)^i •
+      D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)) -
       \sum_{0 \le i \le j\le n} (-1)^{i + j}
-        ω(x; [V_i, V_{j + 1}](x),
-          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_{j + 1}(x)}, …, V_k(x)),
+        ω\big(x; [V_i, V_{j + 1}](x),
+          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_{j + 1}(x)}, …, V_k(x)\big),
 $$
 
-where $$[V_i, V_{j + 1}]$$ is the commutator of the vector fields $$V_i$$ and $$V_{j + 1}$$.
-As usual, $$\widehat{V_i(x)}$$ means that this item is removed from the sequence.
+where $[V_i, V_{j + 1}]$ is the commutator of the vector fields $V_i$ and $V_{j + 1}$.
+As usual, $\widehat{V_i(x)}$ means that this item is removed from the sequence.
 
 In informal texts, this formula is usually written as
 
 $$
   dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)) -
+    \sum_{i=0}^{n + 1} (-1)^i •
+      D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)) -
       \sum_{0 \le i < j\le n + 1} (-1)^{i + j}
-        ω(x; [V_i, V_j](x),
-          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)).
+        ω\big(x; [V_i, V_j](x),
+          V_0(x), …, \widehat{V_i(x)}, …, \widehat{V_j(x)}, …, V_k(x)\big).
 $$
 
 In the sum from our formalization,
@@ -153,12 +153,11 @@ theorem extDeriv_apply_vectorField {ω : E → E [⋀^Fin (n + 1)]→L[𝕜] F} 
   exact extDerivWithin_apply_vectorField hω hV (by simp)
 
 /-- Let `ω` be a differentiable `n`-form and `V i` be `n + 1` differentiable vector fields.
-If `V i` pairwise commute at `x`, i.e., $$[V_i, V_j](x) = 0$$ for all `i ≠ j`, then
+If `V i` pairwise commute at `x`, i.e., $[V_i, V_j](x) = 0$ for all `i ≠ j`, then
 
 $$
-  dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)).
+  dω(V_0(x), \dots, V_{n + 1}(x)) = \sum_{i=0}^{n + 1} (-1)^i •
+    D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)).
 $$
 -/
 theorem extDerivWithin_apply_vectorField_of_pairwise_commute
@@ -179,12 +178,11 @@ theorem extDerivWithin_apply_vectorField_of_pairwise_commute
       simp
 
 /-- Let `ω` be a differentiable `n`-form and `V i` be `n + 1` differentiable vector fields.
-If `V i` pairwise commute at `x`, i.e., $$[V_i, V_j](x) = 0$$ for all `i ≠ j`, then
+If `V i` pairwise commute at `x`, i.e., $[V_i, V_j](x) = 0$ for all `i ≠ j`, then
 
 $$
-  dω(V_0(x), \dots, V_{n + 1}(x)) =
-    \left(\sum_{i=0}^{n + 1}
-      (-1)^i • D_x(ω(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)))(V_i(x)).
+  dω(V_0(x), \dots, V_{n + 1}(x)) = \sum_{i=0}^{n + 1} (-1)^i •
+    D_x\left(ω\big(x; V_0(x), \dots, \widehat{V_i(x)}, \dots, V_{n + 1}(x)\big)\right)(V_i(x)).
 $$
 -/
 theorem extDeriv_apply_vectorField_of_pairwise_commute


### PR DESCRIPTION
Fix equations in the docstrings in `Mathlib.Analysis.DifferentialForm.VectorField`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

A lot of the equations in `Mathlib.Analysis.DifferentialForm.VectorField` contained an extra `\left(` preventing them from getting rendered in the documentation; see [here](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Calculus/DifferentialForm/VectorField.html). I've removed the extra `\left(`, adjusted the size of some of the remaining parentheses to make the equations more readable, and changed some of the shorter terms / equations to get rendered inline instead of in their own line each.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
