### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal): use to_additive for the Yoneda embedding of group objects

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -31,7 +31,8 @@ variable {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C]
 set_option backward.isDefEq.respectTransparency false in
 variable (X) in
 /-- If `X` represents a presheaf of monoids, then `X` is a monoid object. -/
-@[implicit_reducible]
+@[to_additive (attr := implicit_reducible)
+/-- If `X` represents a presheaf of additive monoids, then `X` is an additive monoid object. -/]
 def GrpObj.ofRepresentableBy (F : Cᵒᵖ ⥤ GrpCat.{w}) (α : (F ⋙ forget _).RepresentableBy X) :
     GrpObj X where
   __ := MonObj.ofRepresentableBy X (F ⋙ forget₂ GrpCat MonCat) α
@@ -56,6 +57,8 @@ def GrpObj.ofRepresentableBy (F : Cᵒᵖ ⥤ GrpCat.{w}) (α : (F ⋙ forget _)
     simp [-Functor.comp_obj]
 
 /-- If `G` is a group object, then `Hom(X, G)` has a group structure. -/
+@[to_additive
+/-- If `G` is an additive group object, then `Hom(X, G)` has an additive group structure. -/]
 abbrev Hom.group : Group (X ⟶ G) where
   inv f := f ≫ ι
   inv_mul_cancel f := calc
@@ -63,23 +66,29 @@ abbrev Hom.group : Group (X ⟶ G) where
     _ = (f ≫ lift ι (𝟙 G)) ≫ μ := by simp
     _ = toUnit X ≫ η := by rw [Category.assoc]; simp
 
-scoped[CategoryTheory.MonObj] attribute [instance] Hom.group
+scoped[CategoryTheory.MonObj] attribute [instance] Hom.group Hom.addGroup
 
+@[to_additive]
 lemma Hom.inv_def (f : X ⟶ G) : f⁻¹ = f ≫ ι := rfl
 
 variable (G) in
 /-- If `G` is a group object, then `Hom(-, G)` is a presheaf of groups. -/
-@[simps]
+@[to_additive (attr := simps)
+/-- If `G` is an additive group object, then `Hom(-, G)` is a presheaf of additive groups. -/]
 def yonedaGrpObj : Cᵒᵖ ⥤ GrpCat.{v} where
   obj X := GrpCat.of (unop X ⟶ G)
   map φ := GrpCat.ofHom ((yonedaMonObj G).map φ).hom
 
 variable (G) in
 /-- If `G` is a monoid object, then `Hom(-, G)` as a presheaf of monoids is represented by `G`. -/
+@[to_additive
+/-- If `G` is an additive monoid object, then `Hom(-, G)` as a presheaf of additive monoids
+is represented by `G`. -/]
 def yonedaGrpObjRepresentableBy : (yonedaGrpObj G ⋙ forget _).RepresentableBy G :=
   Functor.representableByEquiv.symm (.refl _)
 
 variable (G) in
+@[to_additive]
 lemma GrpObj.ofRepresentableBy_yonedaGrpObjRepresentableBy :
     ofRepresentableBy G _ (yonedaGrpObjRepresentableBy G) = ‹GrpObj G› := by
   ext; change lift (fst G G) (snd G G) ≫ μ = μ; rw [lift_fst_snd, Category.id_comp]
@@ -87,7 +96,9 @@ lemma GrpObj.ofRepresentableBy_yonedaGrpObjRepresentableBy :
 variable (X) in
 /-- If `X` represents a presheaf of groups `F`, then `Hom(-, X)` is isomorphic to `F` as
 a presheaf of groups. -/
-@[simps! hom inv]
+@[to_additive (attr := simps! hom inv)
+/-- If `X` represents a presheaf of additive groups `F`, then `Hom(-, X)` is isomorphic to `F` as
+a presheaf of additive groups. -/]
 def yonedaGrpObjIsoOfRepresentableBy (F : Cᵒᵖ ⥤ GrpCat.{v}) (α : (F ⋙ forget _).RepresentableBy X) :
     letI := GrpObj.ofRepresentableBy X F α
     yonedaGrpObj X ≅ F :=
@@ -99,17 +110,20 @@ def yonedaGrpObjIsoOfRepresentableBy (F : Cᵒᵖ ⥤ GrpCat.{v}) (α : (F ⋙ f
       fun φ ↦ GrpCat.hom_ext <| MonoidHom.ext <| α.homEquiv_comp φ.unop
 
 set_option backward.isDefEq.respectTransparency false in
-/-- The yoneda embedding of `Grp_C` into presheaves of groups. -/
-@[simps]
+/-- The yoneda embedding of `Grp C` into presheaves of groups. -/
+@[to_additive (attr := simps)
+/-- The yoneda embedding of `AddGrp_C` into presheaves of additive groups. -/]
 def yonedaGrp : Grp C ⥤ Cᵒᵖ ⥤ GrpCat.{v} where
   obj G := yonedaGrpObj G.X
   map {G H} ψ := { app Y := GrpCat.ofHom ((yonedaMon.map ψ.hom).app Y).hom }
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma yonedaGrp_naturality (α : yonedaGrpObj G ⟶ yonedaGrpObj H) (f : X ⟶ Y) (g : Y ⟶ G) :
     α.app _ (f ≫ g) = f ≫ α.app _ g := congr($(α.naturality f.op) g)
 
-/-- The yoneda embedding for `Grp_C` is fully faithful. -/
+/-- The yoneda embedding for `Grp C` is fully faithful. -/
+@[to_additive
+/-- The yoneda embedding for `AddGrp C` is fully faithful. -/]
 def yonedaGrpFullyFaithful : yonedaGrp (C := C).FullyFaithful where
   preimage {G H} α :=
     Grp.homMk' (yonedaMonFullyFaithful.preimage ((Functor.whiskerRight α (forget₂ GrpCat MonCat))))
@@ -122,9 +136,12 @@ def yonedaGrpFullyFaithful : yonedaGrp (C := C).FullyFaithful where
     congr
     apply yonedaMonFullyFaithful.preimage_map
 
+@[to_additive]
 instance : yonedaGrp (C := C).Full := yonedaGrpFullyFaithful.full
+@[to_additive]
 instance : yonedaGrp (C := C).Faithful := yonedaGrpFullyFaithful.faithful
 
+@[to_additive]
 lemma essImage_yonedaGrp :
     yonedaGrp (C := C).essImage = fun F ↦ (F ⋙ forget _).IsRepresentable := by
   ext F
@@ -135,52 +152,57 @@ lemma essImage_yonedaGrp :
     letI := GrpObj.ofRepresentableBy X F e
     exact ⟨⟨X⟩, ⟨yonedaGrpObjIsoOfRepresentableBy X F e⟩⟩
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.inv_comp (f : X ⟶ G) (g : G ⟶ H) [IsMonHom g] : f⁻¹ ≫ g = (f ≫ g)⁻¹ := by
   simp [Hom.inv_def]
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.div_comp (f g : X ⟶ G) (h : G ⟶ H) [IsMonHom h] :
     (f / g) ≫ h = (f ≫ h) / (g ≫ h) :=
   ((yonedaGrp.map (Grp.homMk (A := .mk G) (B := .mk H) h)).app (op X)).hom.map_div f g
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.zpow_comp (f : X ⟶ G) (n : ℤ) (g : G ⟶ H) [IsMonHom g] :
     (f ^ n) ≫ g = (f ≫ g) ^ n :=
   ((yonedaGrp.map (Grp.homMk (A := .mk G) (B := .mk H) g)).app (op X)).hom.map_zpow f n
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.comp_inv (f : X ⟶ Y) (g : Y ⟶ G) : f ≫ g⁻¹ = (f ≫ g)⁻¹ :=
   ((yonedaGrp.obj ⟨G⟩).map f.op).hom.map_inv g
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.comp_div (f : X ⟶ Y) (g h : Y ⟶ G) : f ≫ (g / h) = f ≫ g / f ≫ h :=
   ((yonedaGrp.obj ⟨G⟩).map f.op).hom.map_div g h
 
-@[reassoc]
+@[to_additive (attr := reassoc)]
 lemma GrpObj.comp_zpow (f : X ⟶ Y) (g : Y ⟶ G) : ∀ n : ℤ, f ≫ g ^ n = (f ≫ g) ^ n
   | (n : ℕ) => by simp [comp_pow]
   | .negSucc n => by simp [comp_pow, comp_inv]
 
+@[to_additive]
 lemma GrpObj.inv_eq_inv : ι = (𝟙 G)⁻¹ := by simp [Hom.inv_def]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma GrpObj.one_inv : η[G] ≫ ι = η := by simp [GrpObj.inv_eq_inv, GrpObj.comp_inv, one_eq_one]
 
 open scoped _root_.CategoryTheory.Obj in
 /-- If `G` is a group object and `F` is monoidal,
 then `Hom(X, G) → Hom(F X, F G)` preserves inverses. -/
-@[simp] lemma Functor.map_inv' {D : Type*} [Category* D] [CartesianMonoidalCategory D] (F : C ⥤ D)
+@[to_additive (attr := simp)]
+lemma Functor.map_inv' {D : Type*} [Category* D] [CartesianMonoidalCategory D] (F : C ⥤ D)
     [F.Monoidal] {X G : C} (f : X ⟶ G) [GrpObj G] :
     F.map (f⁻¹) = (F.map f)⁻¹ := by
   rw [eq_inv_iff_mul_eq_one, ← Functor.map_mul, inv_mul_cancel, Functor.map_one]
 
 /-- Conjugation in `G` as a morphism. This is the map `(x, y) ↦ x * y * x⁻¹`,
 see `CategoryTheory.GrpObj.lift_conj_eq_mul_mul_inv`. -/
+@[to_additive
+/-- Conjugation in `G` as a morphism. This is the map `(x, y) ↦ x + y + (-x)`,
+see `CategoryTheory.AddGrpObj.lift_conj_eq_add_add_neg`. -/]
 def GrpObj.conj (G : C) [GrpObj G] : G ⊗ G ⟶ G :=
   fst _ _ * snd _ _ * (fst _ _)⁻¹
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma GrpObj.lift_conj_eq_mul_mul_inv {X G : C} [GrpObj G] (f₁ f₂ : X ⟶ G) :
     lift f₁ f₂ ≫ conj G = f₁ * f₂ * f₁⁻¹ := by
   simp [conj, comp_mul, comp_inv]
@@ -189,46 +211,59 @@ lemma GrpObj.lift_conj_eq_mul_mul_inv {X G : C} [GrpObj G] (f₁ f₂ : X ⟶ G)
 see `CategoryTheory.GrpObj.lift_commutator_eq_mul_mul_inv_inv`.
 This morphism is constant with value `1` if and only if `G` is commutative
 (see `CategoryTheory.isCommMonObj_iff_commutator_eq_toUnit_η`). -/
+@[to_additive
+/-- The commutator of `G` as a morphism. This is the map `(x, y) ↦ x + y + (-x) + (-y)`,
+see `CategoryTheory.AddGrpObj.lift_commutator_eq_add_add_neg_neg`.
+This morphism is constant with value `0` if and only if `G` is commutative
+(see `CategoryTheory.isCommAddMonObj_iff_commutator_eq_toAddUnit_η`). -/]
 def GrpObj.commutator (G : C) [GrpObj G] : G ⊗ G ⟶ G :=
   fst _ _ * snd _ _ * (fst _ _)⁻¹ * (snd _ _)⁻¹
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma GrpObj.lift_commutator_eq_mul_mul_inv_inv {X G : C} [GrpObj G] (f₁ f₂ : X ⟶ G) :
     lift f₁ f₂ ≫ commutator G = f₁ * f₂ * f₁⁻¹ * f₂⁻¹ := by
   simp [commutator, comp_mul, comp_inv]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma GrpObj.η_whiskerRight_commutator : η ▷ G ≫ commutator G = toUnit _ ≫ η := by
   simp [commutator, comp_mul, comp_inv, one_eq_one]
 
-@[reassoc (attr := simp)]
+@[to_additive (attr := reassoc (attr := simp))]
 lemma GrpObj.whiskerLeft_η_commutator : G ◁ η ≫ commutator G = toUnit _ ≫ η := by
   simp [commutator, comp_mul, comp_inv, one_eq_one]
 
 variable [BraidedCategory C]
 
+@[to_additive]
 instance [IsCommMonObj G] : IsMonHom ι[G] where
   one_hom := by simp [one_eq_one, ← Hom.inv_def]
   mul_hom := by simp [GrpObj.mul_inv_rev]
 
 attribute [local simp] Hom.inv_def in
+@[to_additive]
 instance [IsCommMonObj G] {f : M ⟶ G} [IsMonHom f] : IsMonHom f⁻¹ where
 
 namespace Grp
 variable {G H : Grp C} [IsCommMonObj H.X]
 
+@[to_additive]
 instance : MonObj H where
   one := Grp.homMk η[H.toMon].hom
   mul := Grp.homMk μ[H.toMon].hom
 
-@[simp] lemma hom_one (H : Grp C) [IsCommMonObj H.X] : η[H].hom.hom = η[H.X] := rfl
-@[simp] lemma hom_mul (H : Grp C) [IsCommMonObj H.X] : μ[H].hom.hom = μ[H.X] := rfl
+@[to_additive (attr := simp)]
+lemma hom_one (H : Grp C) [IsCommMonObj H.X] : η[H].hom.hom = η[H.X] := rfl
+@[to_additive (attr := simp)]
+lemma hom_mul (H : Grp C) [IsCommMonObj H.X] : μ[H].hom.hom = μ[H.X] := rfl
 
 namespace Hom
 
-@[simp] lemma hom_one : (1 : G ⟶ H).hom = 1 := rfl
-@[simp] lemma hom_mul (f g : G ⟶ H) : (f * g).hom = f.hom * g.hom := rfl
-@[simp] lemma hom_pow (f : G ⟶ H) (n : ℕ) : (f ^ n).hom = f.hom ^ n := by
+@[to_additive (attr := simp)]
+lemma hom_one : (1 : G ⟶ H).hom = 1 := rfl
+@[to_additive (attr := simp)]
+lemma hom_mul (f g : G ⟶ H) : (f * g).hom = f.hom * g.hom := rfl
+@[to_additive (attr := simp)]
+lemma hom_pow (f : G ⟶ H) (n : ℕ) : (f ^ n).hom = f.hom ^ n := by
   induction n with
   | zero => simp
   | succ n hn => simp [pow_succ, hn]
@@ -236,13 +271,17 @@ namespace Hom
 end Hom
 
 /-- A commutative group object is a group object in the category of group objects. -/
+@[to_additive]
 instance : GrpObj H where inv := Grp.homMk' { hom := ι[H.X] }
 
 namespace Hom
 
-@[simp] lemma hom_hom_inv (f : G ⟶ H) : f⁻¹.hom.hom = f.hom.hom⁻¹ := rfl
-@[simp] lemma hom_hom_div (f g : G ⟶ H) : (f / g).hom.hom = f.hom.hom / g.hom.hom := rfl
-@[simp] lemma hom_hom_zpow (f : G ⟶ H) (n : ℤ) : (f ^ n).hom.hom = f.hom.hom ^ n := by
+@[to_additive (attr := simp)]
+lemma hom_hom_inv (f : G ⟶ H) : f⁻¹.hom.hom = f.hom.hom⁻¹ := rfl
+@[to_additive (attr := simp)]
+lemma hom_hom_div (f g : G ⟶ H) : (f / g).hom.hom = f.hom.hom / g.hom.hom := rfl
+@[to_additive (attr := simp)]
+lemma hom_hom_zpow (f : G ⟶ H) (n : ℤ) : (f ^ n).hom.hom = f.hom.hom ^ n := by
   cases n <;> simp
 
 @[deprecated (since := "2025-12-18")] alias hom_inv := hom_hom_inv
@@ -253,13 +292,18 @@ end Hom
 
 attribute [local simp] mul_eq_mul comp_mul mul_comm mul_div_mul_comm in
 /-- A commutative group object is a commutative group object in the category of group objects. -/
+@[to_additive]
 instance : IsCommMonObj H where
 
+@[to_additive]
 instance [IsCommMonObj G.X] (f : G ⟶ H) : IsMonHom f where
 
 end Grp
 
 /-- If `G` is a commutative group object, then `Hom(X, G)` has a commutative group structure. -/
+@[to_additive
+/-- If `G` is a commutative additive group object, then `Hom(X, G)` has a commutative
+additive group structure. -/]
 abbrev Hom.commGroup [IsCommMonObj G] : CommGroup (X ⟶ G) where
 
 scoped[CategoryTheory.MonObj] attribute [instance] Hom.commGroup
@@ -269,6 +313,7 @@ section
 open scoped IsMulCommutative in
 /-- `G` is a commutative group object if and only if the commutator map `(x, y) ↦ x * y * x⁻¹ * y⁻¹`
 is constant. -/
+@[to_additive]
 lemma isCommMonObj_iff_commutator_eq_toUnit_η :
     IsCommMonObj G ↔ GrpObj.commutator G = toUnit _ ≫ η := by
   rw [isCommMonObj_iff_isMulCommutative]

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -66,7 +66,8 @@ abbrev Hom.group : Group (X ⟶ G) where
     _ = (f ≫ lift ι (𝟙 G)) ≫ μ := by simp
     _ = toUnit X ≫ η := by rw [Category.assoc]; simp
 
-scoped[CategoryTheory.MonObj] attribute [instance] Hom.group Hom.addGroup
+scoped[CategoryTheory.MonObj] attribute [instance] Hom.group
+scoped[CategoryTheory.AddMonObj] attribute [instance] Hom.addGroup
 
 @[to_additive]
 lemma Hom.inv_def (f : X ⟶ G) : f⁻¹ = f ≫ ι := rfl
@@ -307,6 +308,7 @@ additive group structure. -/]
 abbrev Hom.commGroup [IsCommMonObj G] : CommGroup (X ⟶ G) where
 
 scoped[CategoryTheory.MonObj] attribute [instance] Hom.commGroup
+scoped[CategoryTheory.AddMonObj] attribute [instance] Hom.addCommGroup
 
 section
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
