### PR TITLE
[Merged by Bors] - fix(GroupTheory): avoid unintentional list item continuation lines

### DIFF
--- a/Mathlib/GroupTheory/Descent.lean
+++ b/Mathlib/GroupTheory/Descent.lean
@@ -29,6 +29,7 @@ and constants `a, b, c : ℝ` such that
 * for all `x : G`, `h (f x) ≥ b * h x - c`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`, and
 * `0 ≤ a < b`,
+
 then `G` is finitely generated. See `Group.fg_of_descent` / `AddGroup.fg_of_descent`.
 
 We use this to deduce a more specific version when `G` is commutative and `f` is the `n`th power
@@ -94,6 +95,7 @@ If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
 * for all `g x : G`, `h x ≤ a * h (g * x) + c g`,
 * for all `x : G`, `h (x ^ n) ≥ b * h x - c₀`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
 where `0 ≤ a < b` and `c₀` are real numbers, `c : G → ℝ`, then `G` is finitely generated.
 -/
 @[to_additive /-- If `G` is a commutative additive group and `n : ℕ`, `h : G → ℝ` satisfy
@@ -101,6 +103,7 @@ where `0 ≤ a < b` and `c₀` are real numbers, `c : G → ℝ`, then `G` is fi
 * for all `g x : G`, `h x ≤ a * h (g + x) + c g`,
 * for all `x : G`, `h (n • x) ≥ b * h x - c₀`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
 where `0 ≤ a < b` and `c₀` are real numbers, `c : G → ℝ`, then `G` is finitely generated. -/]
 theorem CommGroup.fg_of_descent {G : Type*} [CommGroup G] {n : ℕ} {h : G → ℝ} {a b c₀ : ℝ}
     {c : G → ℝ} (ha : 0 ≤ a) (H₀ : a < b) (H₁ : (powMonoidHom (α := G) n).range.FiniteIndex)
@@ -129,6 +132,7 @@ If `G` is a commutative group and `n : ℕ`, `h : G → ℝ` satisfy
 * `0 ≤ h x` for all `x : G`,
 * there is `C : ℝ` such that for all `x y : G`, `|h (x * y) + h(x / y) - 2 * (h x + h y)| ≤ C`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
 then `G` is finitely generated.
 -/
 @[to_additive /-- If `G` is a commutative additive group and `n : ℕ`, `h : G → ℝ` satisfy
@@ -136,6 +140,7 @@ then `G` is finitely generated.
 * `0 ≤ h x` for all `x : G`,
 * there is `C : ℝ` such that for all `x y : G`, `|h (x + y) + h(x - y) - 2 * (h x + h y)| ≤ C`,
 * for all `B : ℝ`, there are only finitely many `x : G` such that `h x ≤ B`,
+
 then `G` is finitely generated. -/]
 theorem CommGroup.fg_of_descent' {G : Type*} [CommGroup G] {h : G → ℝ} {C : ℝ}
     (H₁ : (powMonoidHom (α := G) 2).range.FiniteIndex) (H₂ : ∀ x, 0 ≤ h x)


### PR DESCRIPTION
Currently, all of the sentence fragments that we're separating with a newline are rendering as part of the preceding list item. The addition of these newlines renders the sentence fragments as a separate paragraph following the list.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
