### PR TITLE
feat(Order/Causal): add `Causal` ordering for stream functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5747,6 +5747,8 @@ public import Mathlib.Order.Category.PartOrd
 public import Mathlib.Order.Category.PartOrdEmb
 public import Mathlib.Order.Category.Preord
 public import Mathlib.Order.Category.Semilat
+public import Mathlib.Order.Causal.Basic
+public import Mathlib.Order.Causal.Defs
 public import Mathlib.Order.Circular
 public import Mathlib.Order.Circular.ZMod
 public import Mathlib.Order.Closure

--- a/Mathlib/Order/Causal/Basic.lean
+++ b/Mathlib/Order/Causal/Basic.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Matt Hunzinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matt Hunzinger
+-/
+module
+
+public import Mathlib.Order.Causal.Defs
+
+/-!
+# Causal stream functions
+-/
+
+@[expose] public section
+
+universe u v
+
+variable {α : Type u} {β : Type v}
+
+namespace Stream'
+
+theorem map_causal {f : α → β} : Causal (map f) := by
+  intro x y t h
+  simpa [map] using congrArg f (h t (Nat.le_refl t))
+
+theorem enum_causal : Causal (enum (α := α)) := by
+  intro x y t h
+  simpa [enum] using congrArg (fun a => (t, a)) (h t (Nat.le_refl t))
+
+end Stream'

--- a/Mathlib/Order/Causal/Defs.lean
+++ b/Mathlib/Order/Causal/Defs.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 Matt Hunzinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matt Hunzinger
+-/
+module
+
+public import Mathlib.Data.Stream.Defs
+public import Mathlib.Order.Defs.PartialOrder
+
+/-!
+# Causal stream functions
+-/
+
+@[expose] public section
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {δ : Type w}
+
+/-- A stream function is causal if the output at time `t` depends only on inputs up to time `t`. -/
+def Causal (f : Stream' α → Stream' β) : Prop :=
+  ∀ (x y : Stream' α) (t : ℕ), (∀ s, s ≤ t → x s = y s) → f x t = f y t
+
+instance
+    {f : Stream' α → Stream' β}
+    [i : Decidable
+          (∀ (x y : Stream' α) (t : ℕ),
+            (∀ s, s ≤ t → x s = y s) → f x t = f y t)] :
+    Decidable (Causal f) := i
+
+theorem causal_id : Causal (id (α:=Stream' α)) := by
+  intro x y t h
+  exact h t (Nat.le_refl t)
+
+theorem causal_comp
+    {f : Stream' α → Stream' β}
+    {g : Stream' β → Stream' δ}
+    (hf : Causal f)
+    (hg : Causal g) :
+    Causal (g ∘ f) := by
+  intro x y t h
+  apply hg
+  intro s hs
+  apply hf
+  intro s' hs'
+  exact h s' (Nat.le_trans hs' hs)


### PR DESCRIPTION
Adds `Causal` ordering for stream functions and related theorems:

```lean
def Causal (f : Stream' α → Stream' β) : Prop :=
  ∀ (x y : Stream' α) (t : ℕ), (∀ s, s ≤ t → x s = y s) → f x t = f y t
```

A stream function is causal if the output at time `t` depends only on inputs up to time `t`. Causal stream functions are commonly used in signal processing, reactive systems, and semantics of stateful computations, where outputs cannot depend on future inputs.

## Future work
- Mealy machines: define Mealy machines as causal stream functions with state, and relate them to standard automata-theoretic constructions.
- Feedback and delay operators: formalize feedback loops and delayed composition, enabling modeling of stateful and recursive stream definitions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
