### PR TITLE
[Merged by Bors] - chore: fix typos

### DIFF
--- a/Mathlib/Algebra/Homology/Factorizations/CM5a.lean
+++ b/Mathlib/Algebra/Homology/Factorizations/CM5a.lean
@@ -39,7 +39,7 @@ induces a monomorphism in homology in degree `n₁`, and we proceed further
 in `step₂`.
 
 As we assume that both `K` and `L` are bounded below, we may find `n₀ : ℤ`
-such that `K` and `L` are striclty `≥ n₀ + 1`: in particular, `f` induces
+such that `K` and `L` are strictly `≥ n₀ + 1`: in particular, `f` induces
 an isomorphism in degrees `≤ n₀`. Iterating the lemma `step`, we construct
 a projective system `ℕᵒᵖ ⥤ CochainComplex C ℤ`
 (see `CochainComplex.Plus.modelCategoryQuillen.cm5a_cof.cochainComplexFunctor`).

--- a/Mathlib/Algebra/Lie/Basis.lean
+++ b/Mathlib/Algebra/Lie/Basis.lean
@@ -145,14 +145,14 @@ private lemma cartan_lie_mem_lieSpan_e {x y : L}
     rw [leibniz_lie, ← lie_skew _ v, neg_add_eq_sub]
     exact sub_mem (LieSubalgebra.lie_mem _ hu hv') (LieSubalgebra.lie_mem _ hv hu')
 
-/-- The nilpotent part of the "upper" Borel subalgebra assocated to a basis. -/
+/-- The nilpotent part of the "upper" Borel subalgebra associated to a basis. -/
 def borelUpper : LieSubmodule R b.cartan L where
   __ := lieSpan R L <| range b.e
   lie_mem {x y} hy := by
     obtain ⟨x, hx⟩ := x
     simpa using b.cartan_lie_mem_lieSpan_e hx hy
 
-/-- The nilpotent part of the "lower" Borel subalgebra assocated to a basis. -/
+/-- The nilpotent part of the "lower" Borel subalgebra associated to a basis. -/
 def borelLower : LieSubmodule R b.cartan L where
   __ := lieSpan R L <| range b.f
   lie_mem := b.symm.borelUpper.lie_mem

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -271,7 +271,7 @@ section
 example : (smulZeroClass (A := ℕ) (R := R) (M := M)).toSMul = addCommMonoid.toNSMul := by
   with_reducible_and_instances rfl
 
--- Enusre that smul has good defeq properties
+-- Ensure that smul has good defeq properties
 private local instance {α} [Monoid M] [SMul M α] : SMul Mˣ α where smul m a := (m : M) • a
 example [Monoid A] [SMulZeroClass A R] (a : Units A) (x : R[M]) :
     a • x = (a : A) • x := by

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -648,7 +648,7 @@ lemma coeff_weierstrassPExceptSeries (l₀ x : ℂ) (i : ℕ) :
 
 /--
 In the power series expansion of `℘(z) = ∑ᵢ aᵢ (z - x)ⁱ` at some `x ∉ L`,
-each `aᵢ` can be writen as a sum over `l ∈ L`, i.e.
+each `aᵢ` can be written as a sum over `l ∈ L`, i.e.
 `aᵢ = ∑ₗ, (i + 1) * (l - x)⁻ⁱ⁻²` for `i ≠ 0` and `a₀ = ∑ₗ, (l - x)⁻² - l⁻²`.
 
 We show that the double sum converges if `z` falls in a ball centered at `x` that doesn't touch `L`.

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -56,7 +56,7 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
 class AddMonObj (X : C) where
   /-- The zero morphism of an additive monoid object. -/
   zero : 𝟙_ C ⟶ X
-  /-- The additiion morphism of an additive monoid object. -/
+  /-- The addition morphism of an additive monoid object. -/
   add : X ⊗ X ⟶ X
   zero_add (X) : zero ▷ X ≫ add = (λ_ X).hom := by cat_disch
   add_zero (X) : X ◁ zero ≫ add = (ρ_ X).hom := by cat_disch

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -104,7 +104,7 @@ namespace RetractArrow
 
 variable {X Y Z W : C} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g)
 
-set_option backward.isDefEq.respectTransparency false in -- This is needed for MorphismPropert/Retract.lean
+set_option backward.isDefEq.respectTransparency false in -- This is needed for `MorphismProperty/Retract.lean`
 @[reassoc]
 lemma i_w : h.i.left ≫ g = f ≫ h.i.right := h.i.w
 

--- a/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
+++ b/Mathlib/CategoryTheory/Triangulated/SpectralObject.lean
@@ -80,7 +80,7 @@ are composable. -/
 def δ : X.ω₁.obj (mk₁ g) ⟶ (X.ω₁.obj (mk₁ f))⟦(1 : ℤ)⟧ :=
   X.δ'.app (mk₂ f g)
 
-/-- The distinguished triangle attached to a spectral object `E : SpectralObjet C ι`
+/-- The distinguished triangle attached to a spectral object `E : SpectralObject C ι`
 and composable morphisms `f : i ⟶ j` and `g : j ⟶ k` in `ι`. -/
 @[simps!]
 def triangle : Triangle C :=

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/TuranDensity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/TuranDensity.lean
@@ -31,7 +31,7 @@ This file defines the **Turán density** of a simple graph.
   asymptotically equivalent to `turanDensity H * n.choose 2` as `n` approaches `∞`.
 
 * `SimpleGraph.isContained_of_card_edgeFinset`: simple graphs on `n` vertices with at least
-  `(turanDensity H + o(1)) * n ^ 2` edges contain `H`, for all sufficently large `n`.
+  `(turanDensity H + o(1)) * n ^ 2` edges contain `H`, for all sufficiently large `n`.
 -/
 
 @[expose] public section

--- a/Mathlib/NumberTheory/Height/MvPolynomial.lean
+++ b/Mathlib/NumberTheory/Height/MvPolynomial.lean
@@ -36,7 +36,7 @@ variable {R α : Type*} [CommRing R]
 
 -- NOTE: The following cannot be moved to Mathlib.Algebra.Order.Ring.IsNonarchimedean,
 --       because it needs the target to be the reals (to have the default value zero
---       for emtpy iSups), which are not known there.
+--       for empty iSups), which are not known there.
 /-- The ultrametric triangle inequality for finite sums. -/
 lemma apply_sum_le {α β F : Type*} [AddCommMonoid β] [FunLike F β ℝ] [NonnegHomClass F β ℝ]
     [ZeroHomClass F β ℝ] {v : F} (hv : IsNonarchimedean v) {l : α → β} {s : Finset α} :
@@ -392,7 +392,7 @@ If
 * `x : ι → K` is such that for all `k : ι`,
   `∑ j, (q (k, j)).eval x * (p j).eval x = (x k) ^ (M + N)`,
 then the multiplicative height of `fun j ↦ (p j).eval x` is bounded below by an (explicit) positive
-constant depending only on `q` times the `N`th power of the mutiplicative height of `x`.
+constant depending only on `q` times the `N`th power of the multiplicative height of `x`.
 A similar statement holds for the logarithmic height.
 
 Note that we only require the polynomial relations `∑ j, q (k, j) * p j = X k ^ (M + N)`
@@ -429,7 +429,7 @@ open AdmissibleAbsValues
 * `x : ι → K` is such that for all `k : ι`,
   `∑ j, (q (k, j)).eval x * (p j).eval x = (x k) ^ (M + N)`,
 then the multiplicative height of `fun j ↦ (p j).eval x` is bounded below by an (explicit) positive
-constant depending only on `q` times the `N`th power of the mutiplicative height of `x`. -/
+constant depending only on `q` times the `N`th power of the multiplicative height of `x`. -/
 theorem mulHeight_eval_ge {M N : ℕ} {q : ι × ι' → MvPolynomial ι K}
     (hq : ∀ a, (q a).IsHomogeneous M) (p : ι' → MvPolynomial ι K) {x : ι → K}
     (h : ∀ k, ∑ j, (q (k, j)).eval x * (p j).eval x = (x k) ^ (M + N)) :
@@ -459,7 +459,7 @@ theorem mulHeight_eval_ge {M N : ℕ} {q : ι × ι' → MvPolynomial ι K}
 * `x : ι → K` is such that for all `k : ι`,
   `∑ j, (q (k, j)).eval x * (p j).eval x = (x k) ^ (M + N)`,
 then the multiplicative height of `fun j ↦ (p j).eval x` is bounded below by a positive
-constant depending only on `q` times the `N`th power of the mutiplicative height of `x`.
+constant depending only on `q` times the `N`th power of the multiplicative height of `x`.
 
 The difference to `mulHeight_eval_ge` is that the constant is not made explicit. -/
 theorem mulHeight_eval_ge' {M N : ℕ} {q : ι × ι' → MvPolynomial ι K}

--- a/Mathlib/RingTheory/AdicCompletion/Completeness.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Completeness.lean
@@ -78,7 +78,7 @@ private lemma ofValEqZeroAux_exists {x : AdicCompletion I M} (h : c = b + a)
   simpa [← LinearMap.mem_range, range_powSMulQuotInclusion] using
     (val_apply_mem_smul_top_iff I (show a ≤ c by lia)).mpr ha
 
-/-- An auxillary lift function used in the definition of `ofValEqZero`.
+/-- An auxiliary lift function used in the definition of `ofValEqZero`.
 Use `ofValEqZero` instead. -/
 def ofValEqZeroAux {x : AdicCompletion I M} (h : c = b + a) (ha : x.val a = 0) :
     ↥(I ^ a • ⊤ : Submodule R M) ⧸ I ^ b • (⊤ : Submodule R ↥(I ^ a • ⊤ : Submodule R M)) :=

--- a/Mathlib/RingTheory/ZariskisMainTheorem.lean
+++ b/Mathlib/RingTheory/ZariskisMainTheorem.lean
@@ -338,7 +338,7 @@ private lemma not_isStronglyTranscendental_of_weaklyQuasiFiniteAt_of_isIntegrall
   ext
   simp [Ideal.mem_map_C_iff, coeff_C, apply_ite]
 
-/-- This asks for an explict `K = Frac(R)`, `L = Frac(S)`,
+/-- This asks for an explicit `K = Frac(R)`, `L = Frac(S)`,
 `R'` the integral closure of `R` in `K`, and `S' ⊆ L` the subalgebra spanned by `R'` and `S`,
 to aid typeclass synthesis.
 

--- a/Mathlib/Topology/Homotopy/TopCat/Basic.lean
+++ b/Mathlib/Topology/Homotopy/TopCat/Basic.lean
@@ -27,7 +27,7 @@ namespace TopCat
 variable {X Y : TopCat.{u}}
 
 /-- An homotopy between morphisms in `TopCat` is a homotopy between
-the corresponding continous maps. -/
+the corresponding continuous maps. -/
 abbrev Homotopy (f g : X ⟶ Y) := ContinuousMap.Homotopy f.hom g.hom
 
 namespace Homotopy

--- a/scripts/autolabel.lean
+++ b/scripts/autolabel.lean
@@ -144,7 +144,7 @@ run_cmd
     let mut out : List String := []
     for (a, b) in labelNames.zip constants do
       if a != b then
-        out := s!"expexcted {a} got {b}" :: out
+        out := s!"expected {a} got {b}" :: out
     logWarning m!"The available Labels is out of sync with the labels listed in \
     { .ofConstName ``mathlibLabels }.\n\
     Please keep them sorted and in sync!\n{"\n".intercalate out.reverse}"


### PR DESCRIPTION
Typos were found with
```
pip install codespell --upgrade
codespell --summary --ignore-words-list accpt,bu,calle,commmon,comon,disjointness,enew,haa,hax,hda,hge,homs,hsa,hsi,ihs,mor,nailin,ofmodule,ofset,ore,pres,toword,ue --check-filenames
codespell --summary --ignore-words-list accpt,bu,calle,commmon,comon,disjointness,enew,haa,hax,hda,hge,homs,hsa,hsi,ihs,mor,nailin,ofmodule,ofset,ore,pres,toword,ue --check-filenames --regex '[A-Z][a-z]*'
codespell --summary --ignore-words-list accpt,bu,calle,commmon,comon,disjointness,enew,haa,hax,hda,hge,homs,hsa,hsi,ihs,mor,nailin,ofmodule,ofset,ore,pres,toword,ue --check-filenames --regex "\b[a-z']*"
```

There were 2 public-facing typos that I didn't fix in this PR: `isHomogenous_toTupleMvPolynomial`, `eventualy_isUnit_of_isUnit`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
