### PR TITLE
[Merged by Bors] - chore: modulize tests (5/N)

### DIFF
--- a/MathlibTest/CategoryTheory/PrettyPrinting.lean
+++ b/MathlibTest/CategoryTheory/PrettyPrinting.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
+module
 import Mathlib.CategoryTheory.Functor.Basic
 
 /-!

--- a/MathlibTest/DefEqAbuse.lean
+++ b/MathlibTest/DefEqAbuse.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Tactic.DefEqAbuse

--- a/MathlibTest/DefEqTransformations.lean
+++ b/MathlibTest/DefEqTransformations.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.DefEqTransformations
 
 set_option autoImplicit true

--- a/MathlibTest/FBinop.lean
+++ b/MathlibTest/FBinop.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.FBinop
 import Mathlib.Data.Set.Prod
 import Mathlib.Data.Finset.Prod
@@ -15,7 +16,7 @@ class SProd' (α : Type u) (β : Type v) (γ : outParam (Type w)) where
   sprod : α → β → γ
 
 -- This notation binds more strongly than (pre)images, unions and intersections.
-@[inherit_doc SProd'.sprod] infixr:82 " ×ˢ' " => SProd'.sprod
+@[inherit_doc SProd'.sprod] local infixr:82 " ×ˢ' " => SProd'.sprod
 macro_rules | `($x ×ˢ' $y)   => `(fbinop% SProd'.sprod $x $y)
 
 @[default_instance]

--- a/MathlibTest/FunLike.lean
+++ b/MathlibTest/FunLike.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.FunLike.Basic
 
 variable {F α β : Sort*} [i : FunLike F α β] (f : F) (a : α)

--- a/MathlibTest/InstanceTransparency.lean
+++ b/MathlibTest/InstanceTransparency.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.Real.Basic
 
 /-! # Test transparency level of `Div` field in `DivInvMonoid`

--- a/MathlibTest/Linarith/Basic.lean
+++ b/MathlibTest/Linarith/Basic.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Linarith.Oracle.FourierMotzkin
 import Mathlib.Algebra.BigOperators.Group.Finset.Pi
@@ -9,7 +10,7 @@ set_option linter.unusedVariables false
 set_option autoImplicit false
 
 open Lean.Elab.Tactic in
-def testSorryTac : TacticM Unit := do
+meta def testSorryTac : TacticM Unit := do
   let e ← getMainTarget
   let t ← `(test_sorry)
   closeMainGoalUsing `sorry fun _ _ => elabTerm t e
@@ -720,11 +721,11 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
 
 section findSquares
 
-private abbrev wrapped (z : ℤ) : ℤ := z
+abbrev wrapped (z : ℤ) : ℤ := z
 /-- the `findSquares` preprocessor can look through reducible defeq -/
 example (x : ℤ) : 0 ≤ x * wrapped x := by nlinarith
 
-private def tightlyWrapped (z : ℤ) : ℤ := z
+def tightlyWrapped (z : ℤ) : ℤ := z
 /--
 error: linarith failed to find a contradiction
 case h

--- a/MathlibTest/Linarith/NNReal.lean
+++ b/MathlibTest/Linarith/NNReal.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Linarith.NNRealPreprocessor
 import Mathlib.Data.ENNReal.Operations
 import Mathlib.Data.ENNReal.Inv

--- a/MathlibTest/Monotonicity.lean
+++ b/MathlibTest/Monotonicity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
+module
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.List.Defs
 import Mathlib.Tactic.Monotonicity

--- a/MathlibTest/Replace.lean
+++ b/MathlibTest/Replace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino
 -/
+module
 import Mathlib.Tactic.Replace
 
 set_option linter.unusedVariables false

--- a/MathlibTest/SimpRw.lean
+++ b/MathlibTest/SimpRw.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Mario Carneiro
 -/
-
+module
 import Mathlib.Tactic.SimpRw
 
 private axiom test_sorry : ∀ {α}, α

--- a/MathlibTest/Subsingleton.lean
+++ b/MathlibTest/Subsingleton.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Subsingleton
 
 private axiom test_sorry : ∀ {α}, α

--- a/MathlibTest/Zify.lean
+++ b/MathlibTest/Zify.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Moritz Doll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Doll, Robert Y. Lewis
 -/
-
+module
 import Mathlib.Tactic.Zify
 import Mathlib.Algebra.Ring.Int.Parity
 import Mathlib.Algebra.Ring.Int.Units

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -55,7 +55,7 @@ example [AddCommGroup α] (a b c : α) :
   right; trivial
 
 /-- `MyTrue` should be opaque to `abel`. -/
-private def MyTrue := True
+def MyTrue := True
 
 /--
 error: `abel_nf` made no progress on goal

--- a/MathlibTest/apply_fun.lean
+++ b/MathlibTest/apply_fun.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Data.Nat.Notation
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.ApplyFun

--- a/MathlibTest/cancel_denoms.lean
+++ b/MathlibTest/cancel_denoms.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.Ring

--- a/MathlibTest/congr.lean
+++ b/MathlibTest/congr.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.CongrExclamation
 import Mathlib.Algebra.BigOperators.Ring.List
 import Mathlib.Algebra.Group.Basic

--- a/MathlibTest/congrm.lean
+++ b/MathlibTest/congrm.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic.CongrM

--- a/MathlibTest/convert.lean
+++ b/MathlibTest/convert.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Convert
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Data.Set.Image

--- a/MathlibTest/convert2.lean
+++ b/MathlibTest/convert2.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.BigOperators.Ring.List
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Tactic.Convert

--- a/MathlibTest/itauto.lean
+++ b/MathlibTest/itauto.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+module
 import Mathlib.Tactic.ITauto
 
 section ITauto₀

--- a/MathlibTest/linear_combination'.lean
+++ b/MathlibTest/linear_combination'.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.Linarith
 
@@ -8,7 +9,7 @@ private axiom test_sorry : ∀ {α}, α
 
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
-notation "ℝ" => Real
+local notation "ℝ" => Real
 @[instance] axiom Real.field : Field ℝ
 @[instance] axiom Real.linearOrder : LinearOrder ℝ
 @[instance] axiom Real.isStrictOrderedRing : IsStrictOrderedRing ℝ

--- a/MathlibTest/linear_combination.lean
+++ b/MathlibTest/linear_combination.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.LinearCombination
@@ -11,7 +12,7 @@ private axiom test_sorry : ∀ {α}, α
 
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
-notation "ℝ" => Real
+local notation "ℝ" => Real
 @[instance] axiom Real.field : Field ℝ
 @[instance] axiom Real.linearOrder : LinearOrder ℝ
 @[instance] axiom Real.isStrictOrderedRing : IsStrictOrderedRing ℝ

--- a/MathlibTest/mod_cases.lean
+++ b/MathlibTest/mod_cases.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.ModCases
 
 private axiom test_sorry : ∀ {a}, a

--- a/MathlibTest/norm_num.lean
+++ b/MathlibTest/norm_num.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Mario Carneiro, Thomas Murrills
 -/
-
+module
 import Mathlib.Tactic.NormNum
 
 private axiom test_sorry : ∀ {α}, α
@@ -14,19 +14,19 @@ set_option autoImplicit true
 
 -- We deliberately mock R and C here so that we don't have to import the deps
 axiom Real : Type
-notation "ℝ" => Real
+local notation "ℝ" => Real
 @[instance] axiom Real.field : Field ℝ
 @[instance] axiom Real.linearOrder : LinearOrder ℝ
 @[instance] axiom Real.isStrictOrderedRing : IsStrictOrderedRing ℝ
 
 axiom NNReal : Type
-notation "ℝ≥0" => NNReal
+local notation "ℝ≥0" => NNReal
 @[instance] axiom NNReal.semifield : Semifield ℝ≥0
 @[instance] axiom NNReal.linearOrder : LinearOrder ℝ≥0
 @[instance] axiom NNReal.isStrictOrderedRing : IsStrictOrderedRing ℝ≥0
 
 axiom Complex : Type
-notation "ℂ" => Complex
+local notation "ℂ" => Complex
 @[instance] axiom Complex.field : Field ℂ
 @[instance] axiom Complex.charZero : CharZero ℂ
 

--- a/MathlibTest/norm_num_abs.lean
+++ b/MathlibTest/norm_num_abs.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.NormNum
 import Mathlib.Data.Real.Basic
 

--- a/MathlibTest/push.lean
+++ b/MathlibTest/push.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Tactic.Push
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Set.Basic

--- a/MathlibTest/push_neg.lean
+++ b/MathlibTest/push_neg.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Alice Laroche. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alice Laroche, Frédéric Dupuis, Jireh Loreaux
 -/
-
+module
 import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Data.Set.Basic
 import Mathlib.Tactic.Push

--- a/MathlibTest/set_like.lean
+++ b/MathlibTest/set_like.lean
@@ -1,3 +1,4 @@
+module
 import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Star.Subalgebra
 import Mathlib.Algebra.Star.SelfAdjoint


### PR DESCRIPTION

---

Privately imports are intentional.

I manually modulize each test so that the purpose of the tests is not lost by modulizing.

This PR is extracted from draft PR #34466.

* Adds `local`s for `notation`s
* Drops `private`s except `private axiom test_sorry : ∀ {α}, α`s, to prevent abuse when `test_sorry` accidentially enters a public section
* In `MathlibTest.Linarith.Basic`, `meta` for `testSorryTac` is unnecessary for building, but desirable for robustness.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
