### PR TITLE
[Merged by Bors] - chore: expand docstrings to explain the meaning of `C^n` and `C^ω`

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -116,6 +116,8 @@ variable {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type uE} [NormedAdd
 variable (𝕜) in
 /-- A function is continuously differentiable up to order `n` within a set `s` at a point `x` if
 it admits continuous derivatives up to order `n` in a neighborhood of `x` in `s ∪ {x}`.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open).
 For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
 depend on the finite order we consider).
 For `n = ω`, we require the function to be analytic within `s` at `x`. The precise definition we
@@ -447,9 +449,14 @@ theorem contDiffWithinAt_succ_iff_hasFDerivWithinAt' (hn : n ≠ ∞) :
 variable (𝕜) in
 /-- A function is continuously differentiable up to `n` on `s` if, for any point `x` in `s`, it
 admits continuous derivatives up to order `n` on a neighborhood of `x` in `s`.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open).
 
 For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
 depend on the finite order we consider).
+For `n = ω`, we require the function to be analytic within `s` at every point of `s`. The precise
+definition we give (all the derivatives should be analytic) is more involved to work around issues
+when the space is not complete, but it is equivalent when the space is complete.
 -/
 @[fun_prop]
 def ContDiffOn (n : WithTop ℕ∞) (f : E → F) (s : Set E) : Prop :=
@@ -907,6 +914,14 @@ theorem ContDiffOn.continuousOn_fderiv_of_isOpen (h : ContDiffOn 𝕜 n f s) (hs
 variable (𝕜) in
 /-- A function is continuously differentiable up to `n` at a point `x` if, for any integer `k ≤ n`,
 there is a neighborhood of `x` where `f` admits derivatives up to order `n`, which are continuous.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open).
+
+For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
+depend on the finite order we consider).
+For `n = ω`, we require the function to be analytic at `x`. The precise
+definition we give (all the derivatives should be analytic) is more involved to work around issues
+when the space is not complete, but it is equivalent when the space is complete.
 -/
 @[fun_prop]
 def ContDiffAt (n : WithTop ℕ∞) (f : E → F) (x : E) : Prop :=
@@ -1032,6 +1047,12 @@ variable (𝕜) in
 /-- A function is continuously differentiable up to `n` if it admits derivatives up to
 order `n`, which are continuous. Contrary to the case of definitions in domains (where derivatives
 might not be unique) we do not need to localize the definition in space or time.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open).
+
+For `n = ω`, we require the function to be analytic. The precise
+definition we give (all the derivatives should be analytic) is more involved to work around issues
+when the space is not complete, but it is equivalent when the space is complete.
 -/
 @[fun_prop]
 def ContDiff (n : WithTop ℕ∞) (f : E → F) : Prop :=

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -116,7 +116,7 @@ variable {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type uE} [NormedAdd
 variable (𝕜) in
 /-- A function is continuously differentiable up to order `n` within a set `s` at a point `x` if
 it admits continuous derivatives up to order `n` in a neighborhood of `x` in `s ∪ {x}`.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open).
 For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
 depend on the finite order we consider).
@@ -449,7 +449,7 @@ theorem contDiffWithinAt_succ_iff_hasFDerivWithinAt' (hn : n ≠ ∞) :
 variable (𝕜) in
 /-- A function is continuously differentiable up to `n` on `s` if, for any point `x` in `s`, it
 admits continuous derivatives up to order `n` on a neighborhood of `x` in `s`.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open).
 
 For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
@@ -914,7 +914,7 @@ theorem ContDiffOn.continuousOn_fderiv_of_isOpen (h : ContDiffOn 𝕜 n f s) (hs
 variable (𝕜) in
 /-- A function is continuously differentiable up to `n` at a point `x` if, for any integer `k ≤ n`,
 there is a neighborhood of `x` where `f` admits derivatives up to order `n`, which are continuous.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open).
 
 For `n = ∞`, we only require that this holds up to any finite order (where the neighborhood may
@@ -1047,7 +1047,7 @@ variable (𝕜) in
 /-- A function is continuously differentiable up to `n` if it admits derivatives up to
 order `n`, which are continuous. Contrary to the case of definitions in domains (where derivatives
 might not be unique) we do not need to localize the definition in space or time.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open).
 
 For `n = ω`, we require the function to be analytic. The precise

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -76,7 +76,7 @@ variable (I I') in
 /-- Property in the model space of a model with corners of being `C^n` within a set at a point,
 when read in the model vector space. This property will be lifted to manifolds to define `C^n`
 functions between manifolds.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions.
 -/
 def ContDiffWithinAtProp (n : WithTop ℕ∞) (f : H → H') (s : Set H) (x : H) : Prop :=
@@ -164,7 +164,7 @@ variable (I I') in
 /-- A function is `n` times continuously differentiable within a set at a point in a manifold if
 it is continuous and it is `n` times continuously differentiable in this set around this point, when
 read in the preferred chart at this point.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffWithinAt (n : WithTop ℕ∞) (f : M → M') (s : Set M) (x : M) :=
   LiftPropWithinAt (ContDiffWithinAtProp I I' n) f s x
@@ -173,7 +173,7 @@ variable (I I') in
 /-- A function is `n` times continuously differentiable at a point in a manifold if
 it is continuous and it is `n` times continuously differentiable around this point, when
 read in the preferred chart at this point.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffAt (n : WithTop ℕ∞) (f : M → M') (x : M) :=
   ContMDiffWithinAt I I' n f univ x
@@ -189,7 +189,7 @@ variable (I I') in
 /-- A function is `n` times continuously differentiable in a set of a manifold if it is continuous
 and, for any pair of points, it is `n` times continuously differentiable on this set in the charts
 around these points.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffOn (n : WithTop ℕ∞) (f : M → M') (s : Set M) :=
   ∀ x ∈ s, ContMDiffWithinAt I I' n f s x
@@ -198,7 +198,7 @@ variable (I I') in
 /-- A function is `n` times continuously differentiable in a manifold if it is continuous
 and, for any pair of points, it is `n` times continuously differentiable in the charts
 around these points.
-The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, `∞`, or `ω`
 (when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiff (n : WithTop ℕ∞) (f : M → M') :=
   ∀ x, ContMDiffAt I I' n f x

--- a/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Defs.lean
@@ -75,7 +75,10 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 variable (I I') in
 /-- Property in the model space of a model with corners of being `C^n` within a set at a point,
 when read in the model vector space. This property will be lifted to manifolds to define `C^n`
-functions between manifolds. -/
+functions between manifolds.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions.
+-/
 def ContDiffWithinAtProp (n : WithTop ℕ∞) (f : H → H') (s : Set H) (x : H) : Prop :=
   ContDiffWithinAt 𝕜 n (I' ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ range I) (I x)
 
@@ -160,14 +163,18 @@ theorem contDiffWithinAtProp_id (x : H) : ContDiffWithinAtProp I I n id univ x :
 variable (I I') in
 /-- A function is `n` times continuously differentiable within a set at a point in a manifold if
 it is continuous and it is `n` times continuously differentiable in this set around this point, when
-read in the preferred chart at this point. -/
+read in the preferred chart at this point.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffWithinAt (n : WithTop ℕ∞) (f : M → M') (s : Set M) (x : M) :=
   LiftPropWithinAt (ContDiffWithinAtProp I I' n) f s x
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable at a point in a manifold if
 it is continuous and it is `n` times continuously differentiable around this point, when
-read in the preferred chart at this point. -/
+read in the preferred chart at this point.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffAt (n : WithTop ℕ∞) (f : M → M') (x : M) :=
   ContMDiffWithinAt I I' n f univ x
 
@@ -181,14 +188,18 @@ theorem contMDiffAt_iff {n : WithTop ℕ∞} {f : M → M'} {x : M} :
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a set of a manifold if it is continuous
 and, for any pair of points, it is `n` times continuously differentiable on this set in the charts
-around these points. -/
+around these points.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiffOn (n : WithTop ℕ∞) (f : M → M') (s : Set M) :=
   ∀ x ∈ s, ContMDiffWithinAt I I' n f s x
 
 variable (I I') in
 /-- A function is `n` times continuously differentiable in a manifold if it is continuous
 and, for any pair of points, it is `n` times continuously differentiable in the charts
-around these points. -/
+around these points.
+The parameter `n` belongs to `WithTop ℕ∞`, i.e., it can be a natural number, or `∞`, or `ω`
+(when the `ContDiff` scope is open), where `C^ω` corresponds to analytic functions. -/
 def ContMDiff (n : WithTop ℕ∞) (f : M → M') :=
   ∀ x, ContMDiffAt I I' n f x
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
