### PR TITLE
[Merged by Bors] - chore(Dynamics/FixedPoints/Defs): create `Defs` file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4307,6 +4307,7 @@ public import Mathlib.Dynamics.Ergodic.Function
 public import Mathlib.Dynamics.Ergodic.MeasurePreserving
 public import Mathlib.Dynamics.Ergodic.RadonNikodym
 public import Mathlib.Dynamics.FixedPoints.Basic
+public import Mathlib.Dynamics.FixedPoints.Defs
 public import Mathlib.Dynamics.FixedPoints.Prufer
 public import Mathlib.Dynamics.FixedPoints.Topology
 public import Mathlib.Dynamics.Flow

--- a/Mathlib/Dynamics/FixedPoints/Basic.lean
+++ b/Mathlib/Dynamics/FixedPoints/Basic.lean
@@ -89,6 +89,11 @@ protected theorem perm_zpow (h : IsFixedPt e x) : ∀ n : ℤ, IsFixedPt (⇑(e 
 
 end IsFixedPt
 
+@[simp]
+theorem Injective.isFixedPt_apply_iff (hf : Injective f) {x : α} :
+    IsFixedPt f (f x) ↔ IsFixedPt f x :=
+  ⟨fun h => hf h.eq, IsFixedPt.apply⟩
+
 /-- If `g` semiconjugates `fa` to `fb`, then it sends fixed points of `fa` to fixed points
 of `fb`. -/
 theorem Semiconj.mapsTo_fixedPoints {g : α → β} (h : Semiconj g fa fb) :

--- a/Mathlib/Dynamics/FixedPoints/Basic.lean
+++ b/Mathlib/Dynamics/FixedPoints/Basic.lean
@@ -7,16 +7,12 @@ module
 
 public import Mathlib.Algebra.Group.End
 public import Mathlib.Data.Set.Function
+public import Mathlib.Dynamics.FixedPoints.Defs
 
 /-!
 # Fixed points of a self-map
 
-In this file we define
-
-* the predicate `IsFixedPt f x := f x = x`;
-* the set `fixedPoints f` of fixed points of a self-map `f`.
-
-We also prove some simple lemmas about `IsFixedPt` and `∘`, `iterate`, and `Semiconj`.
+We prove some simple lemmas about `IsFixedPt` and `∘`, `iterate`, and `Semiconj`.
 
 ## Tags
 
@@ -25,33 +21,17 @@ fixed point
 
 @[expose] public section
 
-
 open Equiv
 
 universe u v
 
-variable {α : Type u} {β : Type v} {f fa g : α → α} {x : α} {fb : β → β} {e : Perm α}
+variable {α β : Type*} {f fa g : α → α} {x : α} {fb : β → β} {e : Perm α}
 
 namespace Function
 
 open Function (Commute)
 
-/-- Every point is a fixed point of `id`. -/
-theorem isFixedPt_id (x : α) : IsFixedPt id x :=
-  (rfl :)
-
-/-- A function fixes every point iff it is the identity. -/
-@[simp] theorem forall_isFixedPt_iff : (∀ x, IsFixedPt f x) ↔ f = id :=
-  ⟨funext, fun h ↦ h ▸ isFixedPt_id⟩
-
 namespace IsFixedPt
-
-instance decidable [h : DecidableEq α] {f : α → α} {x : α} : Decidable (IsFixedPt f x) :=
-  h (f x) x
-
-/-- If `x` is a fixed point of `f`, then `f x = x`. This is useful, e.g., for `rw` or `simp`. -/
-protected theorem eq (hf : IsFixedPt f x) : f x = x :=
-  hf
 
 /-- If `x` is a fixed point of `f` and `g`, then it is a fixed point of `f ∘ g`. -/
 protected theorem comp (hf : IsFixedPt f x) (hg : IsFixedPt g x) : IsFixedPt (f ∘ g) x :=
@@ -108,32 +88,6 @@ protected theorem perm_zpow (h : IsFixedPt e x) : ∀ n : ℤ, IsFixedPt (⇑(e 
   | Int.negSucc n => (h.perm_pow <| n + 1).perm_inv
 
 end IsFixedPt
-
-@[simp]
-theorem Injective.isFixedPt_apply_iff (hf : Injective f) {x : α} :
-    IsFixedPt f (f x) ↔ IsFixedPt f x :=
-  ⟨fun h => hf h.eq, IsFixedPt.apply⟩
-
-/-- The set of fixed points of a map `f : α → α`. -/
-def fixedPoints (f : α → α) : Set α :=
-  { x : α | IsFixedPt f x }
-
-instance fixedPoints.decidable [DecidableEq α] (f : α → α) (x : α) :
-    Decidable (x ∈ fixedPoints f) :=
-  IsFixedPt.decidable
-
-@[simp]
-theorem mem_fixedPoints : x ∈ fixedPoints f ↔ IsFixedPt f x :=
-  Iff.rfl
-
-theorem mem_fixedPoints_iff {α : Type*} {f : α → α} {x : α} : x ∈ fixedPoints f ↔ f x = x := by
-  rfl
-
-@[simp]
-theorem fixedPoints_id : fixedPoints (@id α) = Set.univ :=
-  Set.ext fun _ => by simpa using isFixedPt_id _
-
-theorem fixedPoints_subset_range : fixedPoints f ⊆ Set.range f := fun x hx => ⟨x, hx⟩
 
 /-- If `g` semiconjugates `fa` to `fb`, then it sends fixed points of `fa` to fixed points
 of `fb`. -/

--- a/Mathlib/Dynamics/FixedPoints/Defs.lean
+++ b/Mathlib/Dynamics/FixedPoints/Defs.lean
@@ -34,10 +34,10 @@ instance fixedPoints.decidable [DecidableEq α] (f : α → α) (x : α) :
 
 @[simp]
 theorem mem_fixedPoints : x ∈ fixedPoints f ↔ IsFixedPt f x :=
-  Iff.rfl
+  .rfl
 
-theorem mem_fixedPoints_iff {α : Type*} {f : α → α} {x : α} : x ∈ fixedPoints f ↔ f x = x := by
-  rfl
+theorem mem_fixedPoints_iff {α : Type*} {f : α → α} {x : α} : x ∈ fixedPoints f ↔ f x = x :=
+  .rfl
 
 @[simp]
 theorem fixedPoints_id : fixedPoints (@id α) = Set.univ :=

--- a/Mathlib/Dynamics/FixedPoints/Defs.lean
+++ b/Mathlib/Dynamics/FixedPoints/Defs.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+module
+
+public import Mathlib.Data.Set.Operations
+
+/-!
+# Fixed points of a self-map
+
+In this file we define the set `Function.fixedPoints` of fixed points of a function `f : α → α`.
+The related predicate `IsFixedPt` is defined in `Mathlib.Logic.Function.Defs`.
+
+## Tags
+
+fixed point
+-/
+
+@[expose] public section
+
+namespace Function
+
+variable {α : Type*} {x : α} {f : α → α}
+
+/-- The set of fixed points of a map `f : α → α`. -/
+def fixedPoints (f : α → α) : Set α :=
+  { x : α | IsFixedPt f x }
+
+instance fixedPoints.decidable [DecidableEq α] (f : α → α) (x : α) :
+    Decidable (x ∈ fixedPoints f) :=
+  IsFixedPt.decidable
+
+@[simp]
+theorem mem_fixedPoints : x ∈ fixedPoints f ↔ IsFixedPt f x :=
+  Iff.rfl
+
+theorem mem_fixedPoints_iff {α : Type*} {f : α → α} {x : α} : x ∈ fixedPoints f ↔ f x = x := by
+  rfl
+
+@[simp]
+theorem fixedPoints_id : fixedPoints (@id α) = Set.univ :=
+  Set.ext fun _ => by simpa using isFixedPt_id _
+
+theorem fixedPoints_subset_range : fixedPoints f ⊆ Set.range f := fun x hx => ⟨x, hx⟩
+
+end Function

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -75,9 +75,24 @@ variable {α : Type u₁} {β : Type u₂}
 /-- A point `x` is a fixed point of `f : α → α` if `f x = x`. -/
 def IsFixedPt (f : α → α) (x : α) := f x = x
 
+/-- If `x` is a fixed point of `f`, then `f x = x`. This is useful, e.g., for `rw` or `simp`. -/
+protected theorem IsFixedPt.eq {f : α → α} {x : α} (hf : IsFixedPt f x) : f x = x :=
+  hf
+
+instance IsFixedPt.decidable [h : DecidableEq α] {f : α → α} {x : α} : Decidable (IsFixedPt f x) :=
+  h (f x) x
+
 @[nontriviality]
 theorem IsFixedPt.of_subsingleton [Subsingleton α] (f : α → α) (x : α) : IsFixedPt f x :=
   Subsingleton.elim _ _
+
+/-- Every point is a fixed point of `id`. -/
+theorem isFixedPt_id (x : α) : IsFixedPt id x :=
+  rfl
+
+/-- A function fixes every point iff it is the identity. -/
+@[simp] theorem forall_isFixedPt_iff {f : α → α} : (∀ x, IsFixedPt f x) ↔ f = id :=
+  ⟨funext, fun h ↦ h ▸ isFixedPt_id⟩
 
 end Function
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I got a large import warning on another PR for simply importing the definition `Function.fixedPoints`, which I found rather silly.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
