### PR TITLE
feat: try using grind as gcongr discharger

### DIFF
--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -281,7 +281,7 @@ example {a b : ℕ} (h : a * b ∣ a ^ 2 + b ^ 2 + 1) : 3 * a * b = a ^ 2 + b ^ 
       apply ne_of_gt
       push Not at h_base
       calc
-        z * y > x * y := by gcongr; lia
+        z * y > x * y := by gcongr
         _ ≥ x * (x + 1) := by apply mul_le_mul <;> lia
         _ > x * x + 1 := by
           rw [mul_add]

--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -48,7 +48,7 @@ theorem upper_bound {k n : ℕ} (hk : k > 0)
   · gcongr
     · intro i hi
       rw [mem_range] at hi
-      have : (2 : ℤ) ^ i ≤ (2 : ℤ) ^ n := by gcongr; norm_num
+      have : (2 : ℤ) ^ i ≤ (2 : ℤ) ^ n := by gcongr
       linarith
     · apply sub_le_self
       positivity
@@ -65,7 +65,7 @@ theorem upper_bound {k n : ℕ} (hk : k > 0)
       apply sum_le_sum_of_subset
       simpa using hn'
     calc 2 ^ ((n' + 1) * (n' + 1))
-        ≤ 2 ^ (n' * n' + 4 * n') := by gcongr <;> linarith
+        ≤ 2 ^ (n' * n' + 4 * n') := by gcongr; linarith
       _ = 2 ^ (n' * n') * (2 ^ 4) ^ n' := by rw [← pow_mul, ← pow_add]
       _ < A ! * (2 ^ 4) ^ n' := by gcongr
       _ = A ! * (15 + 1) ^ n' := rfl

--- a/Archive/Imo/Imo2020Q2.lean
+++ b/Archive/Imo/Imo2020Q2.lean
@@ -28,7 +28,7 @@ theorem imo2020_q2 (a b c d : ℝ) (hd0 : 0 < d) (hdc : d ≤ c) (hcb : c ≤ b)
   calc
     (a + 2 * b + 3 * c + 4 * d) * a ^ a * b ^ b * c ^ c * d ^ d =
         (a + 2 * b + 3 * c + 4 * d) * (a ^ a * b ^ b * c ^ c * d ^ d) := by ac_rfl
-    _ ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) := by gcongr; linarith
+    _ ≤ (a + 2 * b + 3 * c + 4 * d) * (a * a + b * b + c * c + d * d) := by gcongr
     _ = (a + 2 * b + 3 * c + 4 * d) * a ^ 2 + (a + 2 * b + 3 * c + 4 * d) * b ^ 2
         + (a + 2 * b + 3 * c + 4 * d) * c ^ 2 + (a + 2 * b + 3 * c + 4 * d) * d ^ 2 := by ring
     _ ≤ (a + 3 * b + 3 * c + 3 * d) * a ^ 2 + (3 * a + b + 3 * c + 3 * d) * b ^ 2

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Finset.lean
@@ -43,7 +43,7 @@ lemma prod_le_prod (h0 : ∀ i ∈ s, 0 ≤ f i) (h1 : ∀ i ∈ s, f i ≤ g i)
     simp only [prod_cons, forall_mem_cons] at h0 h1 ⊢
     have := posMulMono_iff_mulPosMono.1 ‹PosMulMono R›
     gcongr
-    exacts [prod_nonneg h0.2, h0.1.trans h1.1, h1.1, ih h0.2 h1.2]
+    exacts [prod_nonneg h0.2, h1.1, ih h0.2 h1.2]
 
 /-- If each `f i`, `i ∈ s` belongs to `[0, 1]`, then their product is less than or equal to one.
 See also `Finset.prod_le_one'` for the case of an ordered commutative multiplicative monoid. -/

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -38,8 +38,7 @@ lemma sum_sq_le_sq_sum_of_nonneg (hf : ∀ i ∈ s, 0 ≤ f i) :
   refine sum_le_sum fun i hi ↦ ?_
   rw [← mul_sum]
   gcongr
-  · exact hf i hi
-  · exact single_le_sum hf hi
+  exact single_le_sum hf hi
 
 end OrderedSemiring
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -43,8 +43,7 @@ theorem Multiset.le_prod_of_submultiplicative_on_pred_of_nonneg (f : α → β) 
   · have hps : ∀ x, x ∈ s → p x := fun x hx ↦ hpsa x (mem_cons_of_mem hx)
     have hp_prod : p s.prod := prod_induction_nonempty p hp_mul hs0 hps
     rw [prod_cons, map_cons, prod_cons]
-    exact (h_mul a s.prod (hpsa a (mem_cons_self a s)) hp_prod).trans
-      (by gcongr; exacts [h0 _, hs hps])
+    exact (h_mul a s.prod (hpsa a (mem_cons_self a s)) hp_prod).trans (by gcongr; exact hs hps)
 
 theorem Multiset.le_prod_of_submultiplicative_of_nonneg (f : α → β) (h0 : ∀ a, 0 ≤ f a)
     (h_one : f 1 ≤ 1) (h_mul : ∀ a b, f (a * b) ≤ f a * f b) (s : Multiset α) :

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -686,7 +686,6 @@ theorem uniform_continuous_npow_on_bounded (B : α) {ε : α} (hε : 0 < ε) (n 
   refine (lt_of_le_of_lt ?_ <| lt_add_of_pos_left _ h).trans_le hqr.2
   gcongr
   · exact mul_nonneg (abs_nonneg _) n.cast_nonneg
-  · exact (abs_nonneg _).trans le_sup_left
   refine max_le ?_ (hr.trans <| le_add_of_nonneg_right zero_le_one)
   exact add_sub_cancel r q ▸ (abs_add_le ..).trans (add_le_add hr hqr.1)
 

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -171,10 +171,11 @@ private theorem abs_geomSum_le [IsOrderedRing α] : |geomSum a b n| ≤ (n + 1) 
   induction n with | zero => simp [geomSum] | succ n ih => ?_
   refine (abs_add_le ..).trans ?_
   rw [abs_mul, abs_pow, Nat.cast_succ, add_one_mul]
-  refine add_le_add ?_ (pow_le_pow_left₀ (abs_nonneg _) le_sup_right _)
-  rw [pow_succ, ← mul_assoc, mul_comm |a|]
-  gcongr
-  exacts [abs_nonneg _, (abs_nonneg _).trans ih, le_sup_left]
+  gcongr ?_ + ?_; swap
+  · gcongr; exact le_sup_right
+  · rw [pow_succ, ← mul_assoc, mul_comm |a|]
+    gcongr
+    exact le_sup_left
 
 omit [LinearOrder α] in
 private theorem pow_sub_pow_eq_sub_mul_geomSum :
@@ -188,8 +189,7 @@ theorem abs_pow_sub_pow_le [IsOrderedRing α] :
   obtain _ | n := n; · simp
   rw [Nat.add_sub_cancel, pow_sub_pow_eq_sub_mul_geomSum, abs_mul, mul_assoc, Nat.cast_succ]
   gcongr
-  · exact abs_nonneg _
-  · exact abs_geomSum_le ..
+  exact abs_geomSum_le ..
 
 end LinearOrderedCommRing
 

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -89,7 +89,7 @@ theorem Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le (p q n : ℕ) (dvd : p.g
   have ha := Int.emod_lt a_n (by lia : (q.succ : ℤ) ≠ 0)
   rw [p.pred_succ, q.pred_succ] at le
   calc n = a * p.succ + b * q.succ := this.symm
-       _ ≤ q * p.succ + -1 * q.succ := by gcongr <;> lia
+       _ ≤ q * p.succ + -1 * q.succ := by gcongr; lia
        _ = p * q - 1 := by simp_rw [Nat.cast_succ, mul_add, mul_comm]; lia
        _ ≤ n - 1 := by rwa [sub_le_sub_iff_right, ← Nat.cast_mul, Nat.cast_le]
        _ < n := by lia

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -701,7 +701,6 @@ theorem HasFPowerSeriesWithinOnBall.uniform_geometric_approx' {r' : ℝ≥0}
     refine this.trans ?_
     have : 0 < a := ha.1
     gcongr
-    apply_rules [sub_pos.2, ha.2]
   apply norm_sub_le_of_geometric_bound_of_hasSum (ya.trans_lt ha.2) _ (hf.hasSum ys this)
   intro n
   calc

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -196,7 +196,7 @@ theorem ContinuousLinearMap.norm_iteratedFDerivWithin_le_of_bilinear (B : E →L
         ‖iteratedFDerivWithin 𝕜 (n - i) gu su xu‖ :=
     Bu.norm_iteratedFDerivWithin_le_of_bilinear_aux hfu hgu hsu hxu
   simp only [Nfu, Ngu, NBu] at this
-  exact this.trans <| by gcongr
+  exact this.trans <| by sorry -- was: gcongr, TODO robustify!
 
 /-- Bounding the norm of the iterated derivative of `B (f x) (g x)` in terms of the
 iterated derivatives of `f` and `g` when `B` is bilinear:

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -172,7 +172,7 @@ theorem mem_A_of_differentiable {ε : ℝ} (hε : 0 < ε) {x : E} (hx : Differen
       add_le_add (hR _ (ball_subset_ball hr.2.le hz)) (hR _ (ball_subset_ball hr.2.le hy))
     _ ≤ δ * r + δ * r := by rw [mem_ball_iff_norm] at hz hy; gcongr
     _ = (ε / 2) * r := by ring
-    _ < ε * r := by gcongr; exacts [hr.1, half_lt_self hε]
+    _ < ε * r := by gcongr; exact half_lt_self hε
 
 theorem norm_sub_le_of_mem_A {c : 𝕜} (hc : 1 < ‖c‖) {r ε : ℝ} (hε : 0 < ε) (hr : 0 < r) {x : E}
     {L₁ L₂ : E →L[𝕜] F} (h₁ : x ∈ A f L₁ r ε) (h₂ : x ∈ A f L₂ r ε) : ‖L₁ - L₂‖ ≤ 4 * ‖c‖ * ε := by

--- a/Mathlib/Analysis/Calculus/TangentCone/Seq.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Seq.lean
@@ -115,8 +115,7 @@ theorem mem_tangentConeAt_iff_exists_seq_norm_tendsto_atTop {𝕜 E : Type*}
         rw [← lt_div_iff₀' (by positivity)]
         refine (hd n).trans_le ?_
         grw [hn]
-        · simp [mul_pow, div_eq_inv_mul]
-        · norm_num1
+        simp [mul_pow, div_eq_inv_mul]
     · rw [mem_tangentConeAt_iff_exists_seq]
       rintro ⟨c, d, hd₀, hds, hcd⟩
       refine ⟨c, d, ?_, hds, hcd⟩

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -404,7 +404,6 @@ theorem taylor_mean_remainder_bound {f : ℝ → E} {a b C x : ℝ} {n : ℕ} (h
     gcongr
     · rw [abs_mul, abs_pow, abs_inv, Nat.abs_cast]
       gcongr
-      exact sub_nonneg.2 hyx.le
     -- Estimate the iterated derivative by `C`
     · exact hC y ⟨hay, hyx.le.trans hx.2⟩
   -- Apply the mean value theorem for vector-valued functions:

--- a/Mathlib/Analysis/Complex/AbelLimit.lean
+++ b/Mathlib/Analysis/Complex/AbelLimit.lean
@@ -229,7 +229,7 @@ theorem tendsto_tsum_powerSeries_nhdsWithin_stolzSet
           (summable_geometric_of_lt_one (by positivity) zn)
       _ = ‖1 - z‖ * (ε / 4 / M) / (1 - ‖z‖) := by
         rw [tsum_geometric_of_lt_one (by positivity) zn, ← div_eq_mul_inv]
-      _ < M * (1 - ‖z‖) * (ε / 4 / M) / (1 - ‖z‖) := by gcongr; linarith only [zn]
+      _ < M * (1 - ‖z‖) * (ε / 4 / M) / (1 - ‖z‖) := by gcongr
       _ = _ := by
         rw [← mul_rotate, mul_div_cancel_right₀ _ (by linarith only [zn]),
           div_mul_cancel₀ _ (by linarith only [hM])]

--- a/Mathlib/Analysis/Complex/BorelCaratheodory.lean
+++ b/Mathlib/Analysis/Complex/BorelCaratheodory.lean
@@ -50,7 +50,7 @@ lemma eq_mul_div_one_add_of_eq_div_sub (_ : M ≠ 0) (_ : 2 * M - z ≠ 0)
 lemma norm_two_mul_div_one_add_le (hM : 0 < M) (hw : ‖w‖ < 1) :
     ‖2 * ↑M * w / (1 + w)‖ ≤ 2 * M * ‖w‖ / (1 - ‖w‖) := by
   simp only [norm_div, norm_mul, norm_ofNat, norm_real, Real.norm_eq_abs, abs_of_pos hM]
-  gcongr; · linarith
+  gcongr
   rw [← norm_one (α := ℂ)]; exact norm_sub_le_norm_add 1 w
 
 /-- If `z.re ≤ M`, then `‖z‖ ≤ ‖2M - z‖`. This shows that the Schwarz transform

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -544,8 +544,6 @@ lemma scale_id_mem_verticalStrip_of_mem_verticalStrip {l u : ℝ} (hul : l < u) 
   rw [add_comm, ← sub_lt_sub_iff_right l, add_sub_assoc, sub_self, add_zero]
   nth_rewrite 2 [← one_mul (u - l)]
   gcongr
-  simp only [sub_pos]
-  exact hul
 
 /-- If z is on the closed strip `re ⁻¹' [l, u]`, then `(z - l) / (u - l)` is on the closed strip
   `re ⁻¹' [0, 1]`. -/
@@ -560,8 +558,7 @@ lemma mem_verticalClosedStrip_of_scale_id_mem_verticalClosedStrip {z : ℂ} {l u
     div_self (by linarith : u - l ≠ 0), ← div_eq_mul_one_div]
   constructor
   · gcongr
-    · apply le_of_lt; simp [hul]
-    · exact hz.1
+    exact hz.1
   · rw [← sub_le_sub_iff_right (l / (u - l)), add_sub_assoc, sub_self, add_zero, div_sub_div_same,
       div_le_one (by simp [hul]), sub_le_sub_iff_right l]
     exact hz.2

--- a/Mathlib/Analysis/Convex/BetweenList.lean
+++ b/Mathlib/Analysis/Convex/BetweenList.lean
@@ -247,7 +247,6 @@ lemma exists_map_eq_of_sorted_nonempty_iff_wbtw {l : List P} (hl : l ≠ []) :
                 nlinarith
               · refine hl''s.pairwise.map _ fun a b hab ↦ ?_
                 gcongr
-                linarith
             · simp only [map_cons, lineMap_apply_zero, map_map, ← hl'', cons.injEq,
                 map_inj_left, Function.comp_apply, lineMap_lineMap_left, lineMap_eq_lineMap_iff,
                 true_and]

--- a/Mathlib/Analysis/Convex/MetricSpace.lean
+++ b/Mathlib/Analysis/Convex/MetricSpace.lean
@@ -175,9 +175,7 @@ lemma continuous_convexComboPair :
       NNReal.toReal_le, coe_nndist]
     grw [dist_convexComboPair_convexComboPair_le, Prod.dist_eq]
     nth_grw 1 [le_max_left (dist x.1 y.1) (dist x.2 y.2)]
-    swap; · simpa using i.prop.left
     nth_grw 2 [le_max_right (dist x.1 y.1) (dist x.2 y.2)]
-    swap; · simpa using i.prop.right
     rw [← add_mul, add_sub_cancel, one_mul]
   · intro b
     refine LipschitzWith.continuous (K := nndist b.1 b.2) fun x y ↦ ?_
@@ -216,8 +214,7 @@ lemma continuous_convexComboPair_of_isBounded
       (add_sub_cancel ..) (x j) (y t)), dist_convexComboPair_convexComboPair_le]
     simp only [dist_self, mul_zero, zero_add, dist_convexComboPair_right]
     grw [sub_le_self _ (hf0 _), hj, hD, (le_abs_self _).trans hj'.le]
-    · field_simp; norm_num
-    · exact hf0 _
+    field_simp; norm_num
   · simp only [ContinuousAt, ht, sub_self, convexComboPair_one]
     rw [Metric.nhds_basis_ball.tendsto_right_iff]
     intro r hr
@@ -230,8 +227,7 @@ lemma continuous_convexComboPair_of_isBounded
     simp only [dist_self, mul_zero, add_zero, dist_convexComboPair_left]
     grw [abs_sub_comm, ← le_abs_self] at hj'
     grw [hj, hj', hf1, hD]
-    · field_simp; norm_num
-    · exact hf0 _
+    field_simp; norm_num
 
 /-- When `X` is a bounded convex metric space, to check continuity of
 `t ↦ f(t) • x(t) + (1 - f(t)) • y(t)` it suffices to show that `f` is continuous,

--- a/Mathlib/Analysis/Distribution/Support.lean
+++ b/Mathlib/Analysis/Distribution/Support.lean
@@ -215,16 +215,16 @@ section Support
 
 theorem dsupport_smulLeftCLM_subset {g : E → ℂ} (hg : g.HasTemperateGrowth) :
     dsupport (smulLeftCLM F g f) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr
 
 open LineDeriv
 
 theorem dsupport_lineDerivOp_subset (m : E) : dsupport (∂_{m} f : 𝓢'(E, F)) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr
 
 theorem dsupport_iteratedLineDerivOp_subset {n : ℕ} (m : Fin n → E) :
     dsupport (∂^{m} f : 𝓢'(E, F)) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr
 
 theorem dsupport_delta [FiniteDimensional ℝ E] (x : E) :
     dsupport (TemperedDistribution.delta x) = {x} := by

--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -415,12 +415,12 @@ lemma norm_iteratedFDeriv_fourierPowSMulRight
     congr with i
     ring
   _ ≤ ∑ i ∈ Finset.range (k + 1), (k.choose i * (n + 1 : ℕ) ^ k * ‖L‖ ^ n) * C := by
-    gcongr with i hi
+    sorry /- was: gcongr with i hi
     · rw [← Nat.cast_pow, Nat.cast_le]
       calc n.descFactorial i ≤ n ^ i := Nat.descFactorial_le_pow _ _
       _ ≤ (n + 1) ^ i := by gcongr; lia
       _ ≤ (n + 1) ^ k := by gcongr; exacts [le_add_self, Finset.mem_range_succ_iff.mp hi]
-    · exact hv _ (by lia) _ (by lia)
+    · exact hv _ (by lia) _ (by lia) -/
   _ = (2 * n + 2) ^ k * (‖L‖ ^ n * C) := by
     simp only [← Finset.sum_mul, ← Nat.cast_sum, Nat.sum_range_choose, mul_one, ← mul_assoc,
       Nat.cast_pow, Nat.cast_ofNat, Nat.cast_add, Nat.cast_one, ← mul_pow, mul_add]

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -120,7 +120,6 @@ theorem sum_schlomilch_le {C : ℕ} (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f
     intro k _
     rw [smul_smul]
     gcongr
-    · exact h_nonneg (u (k + 1))
     exact mod_cast h_succ_diff k
   convert sum_le_sum this
   simp [smul_sum]

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -393,8 +393,7 @@ theorem norm_coeff_le_choose_mul_mahlerMeasure (n : ℕ) (p : ℂ[X]) :
         (fun a _ _ ↦ one_le_pow₀ (le_max_left 1 ‖a‖))
     _ ≤ ∏ z ∈ p.roots.toFinset, (1 ⊔ ‖z‖) ^ count z p.roots := by
       gcongr with a
-      · exact le_max_left 1 ‖a‖
-      · exact hx.1
+      exact hx.1
   --final calc block:
   calc ∑ x ∈ S.toFinset, count x S * ‖x.prod‖
     _ ≤ ∑ x ∈ S.toFinset, count x S * ((p.roots).map (fun a ↦ max 1 ‖a‖)).prod := by

--- a/Mathlib/Analysis/Real/Pi/Bounds.lean
+++ b/Mathlib/Analysis/Real/Pi/Bounds.lean
@@ -47,7 +47,7 @@ theorem pi_lt_sqrtTwoAddSeries (n : ℕ) :
     calc
       π ≤ 4 := pi_le_four
       _ = 2 ^ (0 + 2) := by norm_num
-      _ ≤ 2 ^ (n + 2) := by gcongr <;> norm_num
+      _ ≤ 2 ^ (n + 2) := by gcongr; norm_num
   refine lt_of_lt_of_le this (le_of_eq ?_); rw [add_mul]; congr 1
   · ring
   simp only [show (4 : ℝ) = 2 ^ 2 by norm_num, ← pow_mul, div_div, ← pow_add]

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
@@ -78,9 +78,7 @@ lemma CFC.log_monotoneOn : MonotoneOn log {a : A | IsStrictlyPositive a} := by
       rw [cfc_smul _ (hf := by fun_prop (disch := grind -abstractProof)),
         cfc_sub _ _ (hf := by fun_prop (disch := grind -abstractProof)),
         cfc_const_one .., rpow_eq_cfc_real ..]
-    refine MonotoneOn.congr (fun a ha b hb hab ↦ ?_) hf
-    gcongr
-    grind
+    exact MonotoneOn.congr (fun a ha b hb hab ↦ by gcongr) hf
 
 @[gcongr]
 lemma CFC.log_le_log {a b : A} (hab : a ≤ b) (ha : IsStrictlyPositive a := by cfc_tac) :

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -243,7 +243,6 @@ theorem abs_log_sub_add_sum_range_le {x : ℝ} (h : |x| < 1) (n : ℕ) :
         have : |y| ≤ |x| := abs_le.2 hy
         have : 1 - |x| ≤ |1 - y| := le_trans (by linarith [hy.2]) (le_abs_self _)
         gcongr
-        exact sub_pos.2 h
   -- third step: apply the mean value inequality
   have C : ‖F x - F 0‖ ≤ |x| ^ n / (1 - |x|) * ‖x - 0‖ := by
     refine Convex.norm_image_sub_le_of_norm_hasDerivWithin_le

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Extremal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Extremal.lean
@@ -126,8 +126,7 @@ theorem sumNodes_le_sumNodes_T {n : ℕ} {c : ℕ → ℝ}
       negOnePow_mul_negOnePow_mul_cancel.symm
     _ ≤ 1 * ((-1) ^ i * (c i)) := by
       gcongr
-      · exact (hcnonneg i (Finset.mem_Iic.mp hi))
-      · exact (negOnePow_mul_le (hPbnd _ node_mem_Icc))
+      exact (negOnePow_mul_le (hPbnd _ node_mem_Icc))
     _ = (T ℝ n).eval (node n i) * (c i) := by
       rw [eval_T_real_node hi, one_mul]
 
@@ -209,7 +208,6 @@ theorem leadingCoeff_le_of_forall_abs_le_one {n : ℕ} {P : ℝ[X]}
     replace hPdeg : d ≤ n := (WithBot.coe_le rfl).mp hPdeg
     rw [leadingCoeff, natDegree_eq_of_degree_eq_some hd.symm]
     grw [coeff_le_of_forall_abs_le_one (le_of_eq hd.symm) hPbnd, hPdeg]
-    norm_num
 
 theorem coeff_eq_iff_of_forall_abs_le_one {n : ℕ} {P : ℝ[X]}
     (hPdeg : P.degree ≤ n) (hPbnd : ∀ x ∈ Set.Icc (-1) 1, |P.eval x| ≤ 1) :
@@ -235,7 +233,7 @@ theorem leadingCoeff_eq_iff_of_forall_abs_le_one {n : ℕ} {P : ℝ[X]} (hn : 2 
   contrapose! hP
   have : d - 1 < n - 1 := by grind [Nat.cast_withBot, WithBot.coe_le_coe, WithBot.coe_lt_coe]
   calc P.leadingCoeff ≤ 2 ^ (d - 1) := leadingCoeff_le_of_forall_abs_le_one (le_of_eq hd.symm) hPbnd
-  _ < 2 ^ (n - 1) := by gcongr; norm_num
+  _ < 2 ^ (n - 1) := by gcongr
 
 /-- Coefficients used to compute the iterated derivative of a polynomial given its values on the
 Chebyshev nodes. -/

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -241,9 +241,8 @@ theorem sum_div_pow_sq_le_div_sq (N : ℕ) {j : ℝ} (hj : 0 < j) {c : ℝ} (hc 
       geom_sum_Ico_le_of_lt_one (sq_nonneg _) C
     _ ≤ (c⁻¹ ^ 2) ^ (Real.log j / Real.log c - 1) / ((1 : ℝ) - c⁻¹ ^ 2) := by
       gcongr
-      · exact sub_nonneg.2 C.le
-      · rw [← Real.rpow_natCast]
-        exact Real.rpow_le_rpow_of_exponent_ge A C.le (Nat.sub_one_lt_floor _).le
+      rw [← Real.rpow_natCast]
+      exact Real.rpow_le_rpow_of_exponent_ge A C.le (Nat.sub_one_lt_floor _).le
     _ = c ^ 2 * ((1 : ℝ) - c⁻¹ ^ 2)⁻¹ / j ^ 2 := by
       have I : (c⁻¹ ^ 2) ^ (Real.log j / Real.log c) = (1 : ℝ) / j ^ 2 := by
         apply Real.log_injOn_pos (Real.rpow_pos_of_pos A _)

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -427,7 +427,7 @@ theorem roth_lower_bound_explicit (hN : 4096 ≤ N) :
   have : (2 * dValue N - 1) ^ n ≤ N := le_N (hN.trans' <| by norm_num1)
   calc
     _ ≤ (N ^ (nValue N : ℝ)⁻¹ / rexp 1 : ℝ) ^ (n - 2) / n := ?_
-    _ < _ := by gcongr; exacts [(tsub_pos_of_lt hn₂).ne', bound hN]
+    _ < _ := by gcongr; exact bound hN
     _ ≤ rothNumberNat ((2 * dValue N - 1) ^ n) := bound_aux hd.ne' hn₂.le
     _ ≤ rothNumberNat N := mod_cast rothNumberNat.mono this
   rw [← rpow_natCast, div_rpow (rpow_nonneg hN₀.le _) (exp_pos _).le, ← rpow_mul hN₀.le,

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -743,7 +743,7 @@ theorem card_mul_finset_lt_two {ε : ℝ} (hε₀ : 0 < ε) (hε₁ : ε ≤ 1) 
       _ = κ                               := hH.isFragment
       _ ≤ #(A * S) - K * #A :=
         connectivity_le_expansion hK.le hS <| card_pos.mp <| hS.card_pos.trans_le hA₁
-      _ ≤ (2 - ε) * #S - (1 - ε / 2) * #S := by gcongr; linarith
+      _ ≤ (2 - ε) * #S - (1 - ε / 2) * #S := by gcongr
       _ = (1 - ε / 2) * #S                := by linarith
   refine ⟨H, inferInstance, Z, ?cardH, ?cardZ, by
     simpa only [hHZS] using Set.subset_mul_right _ H.one_mem⟩
@@ -784,8 +784,7 @@ theorem card_mul_finset_lt_two {ε : ℝ} (hε₀ : 0 < ε) (hε₁ : ε ≤ 1) 
       _ ≤ K * #(H : Set G).toFinset + (1 - ε / 2) * #(Set.toFinset H * S) := by
         grw [calc₁]
         gcongr
-        · linarith
-        · simp only [Set.mem_toFinset, SetLike.mem_coe, H.one_mem, subset_mul_right]
+        simp [subset_mul_right]
 
 /-- Corollary of `card_mul_finset_lt_two` in the case `A = S`, giving characterisation of sets of
 doubling less than `2 - ε`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -45,7 +45,7 @@ def stepBound (n : ℕ) : ℕ :=
 theorem le_stepBound : id ≤ stepBound := fun n =>
   Nat.le_mul_of_pos_right _ <| pow_pos (by simp) n
 
-theorem stepBound_mono : Monotone stepBound := fun _ _ h => by unfold stepBound; gcongr; decide
+theorem stepBound_mono : Monotone stepBound := fun _ _ h => by unfold stepBound; gcongr
 
 theorem stepBound_pos_iff {n : ℕ} : 0 < stepBound n ↔ 0 < n :=
   mul_pos_iff_of_pos_right <| by positivity

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -116,7 +116,7 @@ private theorem card_nonuniformWitness_sdiff_biUnion_star (hV : V ∈ P.parts) (
     · convert card_parts_equitabilise_subset_le _ (card_aux₁ h₁) hB
     · convert card_parts_equitabilise_subset_le _ (card_aux₂ hP hU h₁) hB
   grw [sum_const, smul_eq_mul, card_filter_atomise_le_two_pow (s := U) hX,
-    Finpartition.card_nonuniformWitnesses_le, filter_subset] <;> simp
+    Finpartition.card_nonuniformWitnesses_le, filter_subset]
 
 private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ P.parts)
     (hUV : U ≠ V) (hunif : ¬G.IsUniform ε U V) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -97,7 +97,7 @@ theorem ack_three (n : ℕ) : ack 3 n = 2 ^ (n + 3) - 3 := by
         Nat.mul_sub_left_distrib, ← Nat.sub_add_comm, two_mul 3, Nat.add_sub_add_right]
     calc 2 * 3
       _ ≤ 2 * 2 ^ 3 := by simp
-      _ ≤ 2 * 2 ^ (n + 3) := by gcongr <;> lia
+      _ ≤ 2 * 2 ^ (n + 3) := by gcongr; lia
 
 theorem ack_pos : ∀ m n, 0 < ack m n
   | 0, n => by simp

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -116,8 +116,7 @@ lemma eventually_zero_of_frequently_zero (hf : GrowsPolynomially f) (hf' : ∃�
       case ineq =>
         rw [Set.left_mem_Icc]
         gcongr
-        · norm_num
-        · lia
+        norm_num
       simp only [ih, mul_zero, Set.Icc_self, Set.mem_singleton_iff] at hx
       refine hx ⟨?lb₁, ?ub₁⟩
       case lb₁ =>

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -570,8 +570,7 @@ lemma mul_add_one_le_add_one_pow {a : ℝ} (ha : 0 ≤ a) (b : ℕ) : a * b + 1 
         simp [mul_add, add_assoc, add_left_comm]
       _ ≤ (a + 1) ^ b * a + (a + 1) ^ b := by
         gcongr
-        · norm_num
-        · exact hb ha'
+        exact hb ha'
       _ = (a + 1) ^ (b + 1) := by simp [pow_succ, mul_add]
 
 end Real

--- a/Mathlib/GroupTheory/Archimedean.lean
+++ b/Mathlib/GroupTheory/Archimedean.lean
@@ -93,7 +93,7 @@ theorem Subgroup.exists_isLeast_one_lt {H : Subgroup G} (hbot : H ≠ ⊥) {a : 
   · exact hmin m hmn ⟨y, hyH, hm, hya⟩
   · refine disjoint_left.1 hd (div_mem hxH hyH) ⟨one_lt_div'.2 hxy, div_lt_iff_lt_mul'.2 ?_⟩
     calc x ≤ a ^ (n + 1) := hxn
-    _ ≤ a ^ (m + 1) := by grw [hnm]; exact h₀.le
+    _ ≤ a ^ (m + 1) := by grw [hnm]
     _ = a ^ m * a := pow_succ _ _
     _ < y * a := by gcongr
 

--- a/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
+++ b/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
@@ -435,7 +435,7 @@ theorem exists_normalized_aux3 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
           calc
             a.r j - ‖a.c j - a.c i‖ ≤ τ * a.r i - a.r i := sub_le_sub H.2 H.1
             _ = a.r i * (τ - 1) := by ring
-            _ ≤ s * (τ - 1) := by gcongr; exact sub_nonneg.2 hτ
+            _ ≤ s * (τ - 1) := by gcongr
       _ ≤ s * (δ / 2) := by gcongr; linarith only [δnonneg, hδ1]
       _ = s / 2 * δ := by ring
   have invs_nonneg : 0 ≤ 2 / s := div_nonneg zero_le_two (zero_le_two.trans hi.le)

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -203,7 +203,6 @@ theorem ae_eventually_measure_zero_of_singular (hρ : ρ ⟂ₘ μ) :
   intro a ha μa_pos μa_lt_top
   grw [ENNReal.div_lt_iff (.inl μa_pos.ne') (.inl μa_lt_top.ne), ha, hn]
   gcongr
-  exact μa_lt_top.ne
 
 section AbsolutelyContinuous
 

--- a/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
+++ b/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
@@ -183,7 +183,6 @@ theorem of_measure_le {μ' : Measure α} (h : μ ≤ μ') (hT : DominatedFinMeas
     _ ≤ C * μ'.real s := by
       simp only [measureReal_def]
       gcongr
-      exact hμ's.ne
 
 theorem add_measure_right {_ : MeasurableSpace α} (μ ν : Measure α)
     (hT : DominatedFinMeasAdditive μ T C) (hC : 0 ≤ C) : DominatedFinMeasAdditive (μ + ν) T C :=

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -314,8 +314,7 @@ theorem tendsto_setIntegral_pow_smul_of_unique_maximum_of_isCompact_of_measure_n
       have := ENNReal.toReal_pos (hμ v v_open x₀_v).ne'
         ((measure_mono inter_subset_right).trans_lt hs.measure_lt_top).ne
       gcongr
-      · exact hnc _ hx.1
-      · exact ht x hx
+      exact ht x hx
     have N :
       Tendsto (fun n => (μ.real (v ∩ s))⁻¹ * (t / t') ^ n) atTop
         (𝓝 ((μ.real (v ∩ s))⁻¹ * 0)) := by

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -132,7 +132,6 @@ theorem bertrand_main_inequality {n : ℕ} (n_large : 512 ≤ n) :
   · have n2_pos : 0 < 2 * n := by positivity
     exact mod_cast n2_pos
   · exact_mod_cast Real.nat_sqrt_le_real_sqrt
-  · norm_num1
   · exact cast_div_le.trans (by norm_cast)
 
 /-- A lemma that tells us that, in the case where Bertrand's postulate does not hold, the prime

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -259,9 +259,7 @@ lemma continuousOn_term (n : ℕ) :
     have : 1 < x := lt_of_le_of_lt (by simp) hx.1
     rw [norm_of_nonneg (div_nonneg (sub_nonneg.mpr hx.1.le) (by positivity)), Nat.cast_add_one]
     gcongr
-    · exact_mod_cast sub_nonneg.mpr hx.1.le
-    · exact this.le
-    · linarith
+    linarith
   · rw [← IntegrableOn, ← intervalIntegrable_iff_integrableOn_Ioc_of_le (by linarith)]
     exact_mod_cast term_welldef (by lia : 0 < (n + 1)) zero_lt_one
   · rw [ae_restrict_iff' measurableSet_Ioc]
@@ -281,8 +279,7 @@ lemma continuousOn_term_tsum : ContinuousOn term_tsum (Ici 1) := by
     · exact (term_welldef n.succ_pos zero_lt_one).1
     · have : 1 ≤ x := le_trans (by simp) hx.1.le
       gcongr
-      · exact sub_nonneg.mpr hx.1.le
-      · exact hs
+      exact hs
   · rw [intervalIntegral.integral_of_le (by linarith)]
     refine setIntegral_nonneg measurableSet_Ioc (fun x hx ↦ div_nonneg ?_ (rpow_nonneg ?_ _))
     all_goals linarith [hx.1]

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -286,7 +286,6 @@ private theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div_aux₃
     refine setIntegral_mono_on ?_ h₂ measurableSet_Ioc fun t ht ↦ ?_
     · exact h₁.mono_set <| Set.Ioc_subset_Ioi_self.trans Set.Ioi_subset_Ici_self
     · gcongr
-      exact ht.1.le
   calc
     -- First, we replace `s * l` by `(s - 1) * s` times the integral of `l * t ^ (-s)` using `h₃`
     -- and replace `LSeries f s` by its integral representation.

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -39,7 +39,7 @@ def mersenne (p : ℕ) : ℕ :=
   2 ^ p - 1
 
 theorem strictMono_mersenne : StrictMono mersenne := fun m n h ↦
-  (Nat.sub_lt_sub_iff_right <| Nat.one_le_pow _ _ two_pos).2 <| by gcongr; norm_num1
+  (Nat.sub_lt_sub_iff_right <| Nat.one_le_pow _ _ two_pos).2 <| by gcongr
 
 @[simp, gcongr]
 theorem mersenne_lt_mersenne {p q : ℕ} : mersenne p < mersenne q ↔ p < q :=

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -249,10 +249,10 @@ theorem abs_discr_ge (h : 1 < finrank ℚ K) :
   suffices ∀ n, 2 ≤ n → (4 / 9 : ℝ) * (3 * π / 4) ^ n ≤ a n by
     refine le_trans (this (finrank ℚ K) h) ?_
     simp only [a]
-    gcongr
+    sorry /- was: gcongr
     · exact (one_le_div Real.pi_pos).2 Real.pi_le_four
     · rw [← card_add_two_mul_card_eq_rank, mul_comm]
-      exact Nat.le_add_left _ _
+      exact Nat.le_add_left _ _ -/
   intro n hn
   induction n, hn using Nat.le_induction with
   | base => exact le_of_eq <| by simp [a, Nat.factorial_two]; field
@@ -425,11 +425,11 @@ theorem finite_of_discr_bdd_of_isReal :
       · refine le_trans ?_ (Nat.le_ceil _)
         rw [show max ↑(max (B : ℝ≥0) 1) (1 : ℝ) = max (B : ℝ) 1 by simp, val_eq_coe, NNReal.coe_mul,
           NNReal.coe_pow, NNReal.coe_max, NNReal.coe_one, NNReal.coe_natCast]
-        gcongr
+        sorry /- was: gcongr
         · exact le_max_right _ 1
         · exact rank_le_rankOfDiscrBdd hK₂
         · exact (Nat.choose_le_choose _ (rank_le_rankOfDiscrBdd hK₂)).trans
-            (Nat.choose_le_middle _ _)
+            (Nat.choose_le_middle _ _) -/
     · refine mem_rootSet.mpr ⟨minpoly.ne_zero hx, ?_⟩
       exact (aeval_algebraMap_eq_zero_iff A (x : K) _).mpr (minpoly.aeval ℤ (x : K))
     · rw [← (IntermediateField.lift_injective _).eq_iff, eq_comm] at hx₁
@@ -474,12 +474,12 @@ theorem finite_of_discr_bdd_of_isComplex :
       · refine le_trans ?_ (Nat.le_ceil _)
         rw [val_eq_coe, NNReal.coe_mul, NNReal.coe_pow, NNReal.coe_max, NNReal.coe_one,
           Real.coe_sqrt, NNReal.coe_add 1, NNReal.coe_one, NNReal.coe_pow]
-        gcongr
+        sorry /- was: gcongr
         · exact le_max_right _ 1
         · exact rank_le_rankOfDiscrBdd hK₂
         · rw [NNReal.coe_natCast, Nat.cast_le]
           exact (Nat.choose_le_choose _ (rank_le_rankOfDiscrBdd hK₂)).trans
-            (Nat.choose_le_middle _ _)
+            (Nat.choose_le_middle _ _) -/
     · refine mem_rootSet.mpr ⟨minpoly.ne_zero hx, ?_⟩
       exact (aeval_algebraMap_eq_zero_iff A (x : K) _).mpr (minpoly.aeval ℤ (x : K))
     · rw [← (IntermediateField.lift_injective _).eq_iff, eq_comm] at hx₁

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -861,7 +861,7 @@ theorem eq_pow_of_pell_lem {a y k : ℕ} (hy0 : y ≠ 0) (hk0 : k ≠ 0) (hyk : 
     _ ≤ (a : ℤ) ^ 2 - (a - 1 : ℤ) ^ 2 - 1 := by lia
     _ ≤ (a : ℤ) ^ 2 - (a - y : ℤ) ^ 2 - 1 := by
       have := hya.le
-      gcongr <;> norm_cast <;> lia
+      gcongr; norm_cast; lia
     _ = 2 * a * y - y * y - 1 := by ring
 
 theorem eq_pow_of_pell {m n k} :

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
@@ -118,10 +118,9 @@ theorem exists_one_le_pow_mul_dist {Z N R : Type*} [PseudoMetricSpace R] {d : N 
     refine (L this).trans ?_
     -- remove a common factor and use the Lipschitz assumption `B`
     gcongr
-    · exact zero_le_one.trans (d0 a)
-    · refine (B this).trans ?_
-      gcongr
-      apply le_max_right
+    refine (B this).trans ?_
+    gcongr
+    apply le_max_right
 
 theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : ℤ[X]} (f0 : f ≠ 0)
     (fa : eval α (map (algebraMap ℤ ℝ) f) = 0) :

--- a/Mathlib/Probability/Distributions/Fernique.lean
+++ b/Mathlib/Probability/Distributions/Fernique.lean
@@ -472,7 +472,6 @@ lemma lintegral_exp_mul_sq_norm_le_mul [IsProbabilityMeasure μ]
   · simp only [ENNReal.toReal_pos_iff, tsub_pos_iff_lt]
     exact ⟨ha_lt, by finiteness⟩
   · finiteness
-  · finiteness
 
 end Fernique
 

--- a/Mathlib/Probability/Martingale/Basic.lean
+++ b/Mathlib/Probability/Martingale/Basic.lean
@@ -584,8 +584,6 @@ theorem Submartingale.sum_smul_sub [IsFiniteMeasure μ] {R : ℝ} {f : ℕ → �
       ((hf.integrable _).sub (hf.integrable _))] with ω hω1 hω2
   simp only [Pi.zero_apply, Nat.succ_eq_add_one, Pi.smul_apply'] at hω1 hω2 ⊢
   grw [← smul_zero (0 : ℝ), hnonneg i ω, hω1, hω2]
-  · exact hnonneg i ω
-  · simp
 
 /-- Given a discrete submartingale `f` and a predictable process `ξ` (i.e. `ξ (n + 1)` is strongly
 adapted) the process defined by `fun n => ∑ k ∈ Finset.range n, ξ (k + 1) * (f (k + 1) - f k)` is

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -282,8 +282,9 @@ lemma _root_.MeasureTheory.memLp_id_of_self_sub_integral {p : ℝ≥0∞}
   · have : ‖c‖ ≤ ‖y‖ + ‖y - c‖ := Eq.trans_le (by abel_nf) (norm_sub_le y (y - c))
     calc ‖c‖ ^ (p : ℝ)
     _ ≤ (2 * ‖y - c‖) ^ (p : ℝ) := by
+      sorry /- was:
       gcongr
-      linarith
+      linarith -/
     _ = 0 + 2 ^ (p : ℝ) * ‖y - c‖ ^ (p : ℝ) := by
       rw [Real.mul_rpow (by simp) (by positivity)]
       ring
@@ -293,7 +294,7 @@ lemma _root_.MeasureTheory.memLp_id_of_self_sub_integral {p : ℝ≥0∞}
   · calc ‖c‖ ^ (p : ℝ)
     _ = ‖c‖ ^ ((p - 1) + 1 : ℝ) := by abel_nf
     _ = ‖c‖ ^ (p - 1 : ℝ) * ‖c‖ := by rw [Real.rpow_add (by positivity), Real.rpow_one]
-    _ ≤ ‖c‖ ^ (p - 1 : ℝ) * (2 * ‖y‖) := by gcongr; linarith
+    _ ≤ ‖c‖ ^ (p - 1 : ℝ) * (2 * ‖y‖) := by sorry -- was: gcongr; linarith
     _ = 2 * ‖c‖ ^ (p - 1 : ℝ) * ‖y‖ + 0 := by ring
     _ ≤ 2 * ‖c‖ ^ (p - 1 : ℝ) * ‖y‖ + 2 ^ (p : ℝ) * ‖y - c‖ ^ (p : ℝ) := by gcongr; positivity
 

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -525,7 +525,7 @@ private lemma statement : ∀ S : InductionObj R n, Statement R₀ R n S := by
             exact Finset.single_le_sum (f := fun i ↦ (c.val i).degree.succ)
               (by intros; positivity) (Finset.mem_univ _)
           _ = c.degBound ^ (c'.degBound + 1) := by rw [pow_succ']
-          _ ≤ c.degBound ^ c.degBound := by gcongr <;> lia
+          _ ≤ c.degBound ^ c.degBound := by gcongr; lia
       rw [coeffSubmodule]
       simp only [Submodule.span_le, Set.union_subset_iff, Set.singleton_subset_iff, SetLike.mem_coe,
         Set.iUnion_subset_iff, Set.range_subset_iff, c']
@@ -581,7 +581,6 @@ lemma chevalley_polynomialC {R : Type*} [CommRing R] (M : Submodule ℤ R) (hM :
       · have : degBound ⟨y.g⟩ = 0 := by nlinarith
         rw [h, this]
       gcongr
-      rwa [Nat.one_le_iff_ne_zero]
 
 /-! ### The `C : R → R[X₁, ..., Xₘ]` case -/
 

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -417,16 +417,17 @@ private lemma induction_aux (R : Type*) [CommRing R] [Algebra R₀ R]
           gcongr; simpa [Set.insert_subset_iff] using ⟨_, _, hi.symm⟩
         _ ≤ e.coeffSubmodule R₀ ^ e.powBound := by
           unfold coeffSubmodule powBound
-          gcongr
+          sorry /-gcongr
           · exact one_le_coeffSubmodule
           · exact Set.subset_union_right
-          · lia
+          · lia-/
     · exact le_self_pow one_le_coeffSubmodule powBound_ne_zero <| subset_span <| .inr <| by
         simpa using ⟨_, _, hi.symm⟩
     · unfold powBound
+      sorry /- TODO: this times out; does gcongr need more robustness?
       gcongr
       · exact one_le_coeffSubmodule
-      · lia
+      · lia -/
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The main induction in the proof of Chevalley's theorem for `R →+* R[X]`.

--- a/Mathlib/Tactic/GCongr.lean
+++ b/Mathlib/Tactic/GCongr.lean
@@ -15,10 +15,10 @@ The core implementation of the `gcongr` ("generalized congruence") tactic is in 
 
 public meta section
 
-/-! We also use `assumption` to discharge side goals.
+/-! We also use `grind` to discharge side goals.
 In a further downstream file, `positivity` will also be registered as a discharger.
-From that point, `positivity` will be tried before `assumption` is: that is perfectly fine. -/
-macro_rules | `(tactic| gcongr_discharger) => `(tactic| assumption)
+From that point, `positivity` will be tried before `grind` is: that is intentional. -/
+macro_rules | `(tactic| gcongr_discharger) => `(tactic| grind)
 
 /-!
 We register `gcongr` with the `hint` tactic.

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -557,9 +557,11 @@ end Mathlib.Tactic
 
 /-!
 We set up `positivity` as a first-pass discharger for `gcongr` side goals.
+We use `grind` as second discharger, making sure to run it after positivity for performance.
 -/
 
 macro_rules | `(tactic| gcongr_discharger) => `(tactic| positivity)
+macro_rules | `(tactic| gcongr_discharger) => `(tactic| grind)
 
 /-!
 We register `positivity` with the `hint` tactic.

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -560,8 +560,9 @@ We set up `positivity` as a first-pass discharger for `gcongr` side goals.
 We use `grind` as second discharger, making sure to run it after positivity for performance.
 -/
 
-macro_rules | `(tactic| gcongr_discharger) => `(tactic| positivity)
-macro_rules | `(tactic| gcongr_discharger) => `(tactic| grind)
+macro_rules
+  | `(tactic| gcongr_discharger) => `(tactic| positivity)
+  | `(tactic| gcongr_discharger) => `(tactic| grind)
 
 /-!
 We register `positivity` with the `hint` tactic.

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -557,12 +557,11 @@ end Mathlib.Tactic
 
 /-!
 We set up `positivity` as a first-pass discharger for `gcongr` side goals.
-We use `grind` as second discharger, making sure to run it after positivity for performance.
+`grind` was already registered as a discharger: this means `positivity` is tried first.
 -/
 
 macro_rules
   | `(tactic| gcongr_discharger) => `(tactic| positivity)
-  | `(tactic| gcongr_discharger) => `(tactic| grind)
 
 /-!
 We register `positivity` with the `hint` tactic.

--- a/Mathlib/Topology/Algebra/Polynomial.lean
+++ b/Mathlib/Topology/Algebra/Polynomial.lean
@@ -207,8 +207,7 @@ theorem coeff_bdd_of_roots_le {B : ℝ} {d : ℕ} (f : F →+* K) {p : F[X]} (h1
       _ ≤ max B 1 ^ (p.natDegree - i) * p.natDegree.choose i := by gcongr; apply le_max_left
       _ ≤ max B 1 ^ d * p.natDegree.choose i := by
         gcongr
-        · apply le_max_right
-        · exact le_trans (Nat.sub_le _ _) h3
+        grind
       _ ≤ max B 1 ^ d * d.choose (d / 2) := by
         gcongr; exact (i.choose_mono h3).trans (i.choose_le_middle d)
   · rw [eq_one_of_roots_le hB h1 h2 h4, Polynomial.map_one, coeff_one]

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -767,7 +767,6 @@ lemma monotone_truncateToReal {t : ℝ≥0∞} (t_ne_top : t ≠ ∞) : Monotone
   intro x y x_le_y
   simp only [truncateToReal]
   gcongr
-  exact ne_top_of_le_ne_top t_ne_top (min_le_left _ _)
 
 /-- The truncated cast `ENNReal.truncateToReal t : ℝ≥0∞ → ℝ` is continuous when `t ≠ ∞`. -/
 @[fun_prop]


### PR DESCRIPTION
Let's see what benchmarks say!

---

- [x] depends on: #37591
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
