### PR TITLE
refactor(GroupTheory/Complement): simplify complement proofs

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -78,13 +78,13 @@ theorem IsComplement.existsUnique (h : IsComplement S T) (g : G) :
 @[to_additive]
 theorem IsComplement'.symm (h : IsComplement' H K) : IsComplement' K H := by
   let ϕ : H × K ≃ K × H :=
-    Equiv.mk (fun x => ⟨x.2⁻¹, x.1⁻¹⟩) (fun x => ⟨x.2⁻¹, x.1⁻¹⟩)
-      (fun x => Prod.ext (inv_inv _) (inv_inv _)) fun x => Prod.ext (inv_inv _) (inv_inv _)
-  let ψ : G ≃ G := Equiv.mk (fun g : G => g⁻¹) (fun g : G => g⁻¹) inv_inv inv_inv
-  suffices hf : (ψ ∘ fun x : H × K => x.1.1 * x.2.1) = (fun x : K × H => x.1.1 * x.2.1) ∘ ϕ by
-    rwa [isComplement'_def, isComplement_iff_bijective, ← Equiv.bijective_comp ϕ, ← hf,
-      ψ.comp_bijective]
-  exact funext fun x => mul_inv_rev _ _
+    ⟨fun x => ⟨x.2⁻¹, x.1⁻¹⟩, fun x => ⟨x.2⁻¹, x.1⁻¹⟩,
+      fun _ => Prod.ext (inv_inv _) (inv_inv _), fun _ => Prod.ext (inv_inv _) (inv_inv _)⟩
+  let ψ : G ≃ G := ⟨fun g : G => g⁻¹, fun g : G => g⁻¹, inv_inv, inv_inv⟩
+  have hf : (ψ ∘ fun x : H × K => x.1.1 * x.2.1) = (fun x : K × H => x.1.1 * x.2.1) ∘ ϕ :=
+    funext fun _ => mul_inv_rev _ _
+  rwa [isComplement'_def, isComplement_iff_bijective, ← Equiv.bijective_comp ϕ, ← hf,
+    ψ.comp_bijective]
 
 @[to_additive]
 theorem isComplement'_comm : IsComplement' H K ↔ IsComplement' K H :=
@@ -102,19 +102,17 @@ theorem isComplement_singleton_univ {g : G} : IsComplement ({g} : Set G) univ :=
 
 @[to_additive]
 theorem isComplement_singleton_left {g : G} : IsComplement {g} S ↔ S = univ := by
-  refine
-    ⟨fun h => top_le_iff.mp fun x _ => ?_, fun h => (congr_arg _ h).mpr isComplement_singleton_univ⟩
-  obtain ⟨⟨⟨z, rfl : z = g⟩, y, _⟩, hy⟩ := h.2 (g * x)
-  rwa [← mul_left_cancel hy]
+  refine ⟨fun ⟨_, h_top⟩ => top_le_iff.mp ?_, fun h => h.symm ▸ isComplement_singleton_univ⟩
+  intro x _
+  obtain ⟨⟨⟨_, rfl⟩, ⟨s, hs⟩⟩, hmul⟩ := h_top (g * x)
+  exact mul_left_cancel hmul ▸ hs
 
 @[to_additive]
 theorem isComplement_singleton_right {g : G} : IsComplement S {g} ↔ S = univ := by
-  refine
-    ⟨fun h => top_le_iff.mp fun x _ => ?_, fun h => h ▸ isComplement_univ_singleton⟩
-  obtain ⟨y, hy⟩ := h.2 (x * g)
-  conv_rhs at hy => rw [← show y.2.1 = g from y.2.2]
-  rw [← mul_right_cancel hy]
-  exact y.1.2
+  refine ⟨fun ⟨_, h_top⟩ => top_le_iff.mp ?_, fun h => h.symm ▸ isComplement_univ_singleton⟩
+  intro x _
+  obtain ⟨⟨⟨s, hs⟩, ⟨_, rfl⟩⟩, hmul⟩ := h_top (x * g)
+  exact mul_right_cancel hmul ▸ hs
 
 @[to_additive]
 theorem isComplement_univ_left : IsComplement univ S ↔ ∃ g : G, S = {g} := by


### PR DESCRIPTION
Simplifies the proofs of:
- `Subgroup.IsComplement'.symm`
- `Subgroup.isComplement_singleton_left`
- `Subgroup.isComplement_singleton_right`

No API changes.

AI assistance: I used Codex/LLM suggestions as a starting point, then manually checked the proofs, and verified the final version locally.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
