### PR TITLE
feat: Church–Rosser theorem (Q1308502) for untyped λ-calculus (de Bruijn)

### DIFF
--- a/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 zayn7lie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zayn Wang
+-/
+import Mathlib.Computability.LambdaCalculus.DeBruijnSyntax
+import Mathlib.Logic.Relation
+
+/-!
+# One-step β-reduction and its reflexive-transitive closure
+
+This file defines the usual compatible one-step β-reduction on de Bruijn lambda terms.
+It also introduces its reflexive-transitive closure and proves basic closure lemmas for
+application and abstraction.
+
+## Main definitions
+
+* `Lambda.Beta`: one-step β-reduction.
+* `Lambda.BetaStar`: the reflexive-transitive closure of `Beta`.
+
+## Main lemmas
+
+Inside `namespace BetaStar` we provide the standard constructors and congruence lemmas:
+
+* `BetaStar.refl`
+* `BetaStar.head`
+* `BetaStar.tail`
+* `BetaStar.trans`
+* `BetaStar.appL`, `BetaStar.appR`, `BetaStar.app`
+* `BetaStar.abs`
+
+These lemmas are used later to compare β-reduction with parallel reduction.
+-/
+
+
+namespace Lambda
+open Term
+
+/-- One-step β-reduction (compatible closure). -/
+inductive Beta : Term → Term → Prop
+  | abs  {t t'}        : Beta t t' → Beta (λ.t) (λ.t')
+  | appL {t t' u}      : Beta t t' → Beta (t·u) (t'·u)
+  | appR {t u u'}      : Beta u u' → Beta (t·u) (t·u')
+  | red  (t' s : Term) : Beta ((λ.t')·s) (t'.sub 0 s)
+abbrev BetaStar := Relation.ReflTransGen Beta
+
+namespace BetaStar
+
+theorem refl (t : Term) : BetaStar t t :=
+  Relation.ReflTransGen.refl
+theorem head {a b c} (hab : Beta a b) (hbc : BetaStar b c) : 
+    BetaStar a c := 
+  Relation.ReflTransGen.head hab hbc
+theorem tail {a b c} (hab : BetaStar a b) (hbc : Beta b c) : 
+    BetaStar a c :=
+  Relation.ReflTransGen.tail hab hbc
+theorem trans {a b c}
+    (hab : BetaStar a b) (hbc : BetaStar b c) :
+    BetaStar a c := 
+  Relation.ReflTransGen.trans hab hbc
+
+theorem appL {t t' u : Term} (h : BetaStar t t') :
+    BetaStar (t·u) (t'·u) := by
+  induction h with
+  | refl => exact BetaStar.refl (t·u)
+  | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc)
+theorem appR {t u u' : Term} (h : BetaStar u u') :
+    BetaStar (t·u) (t·u') := by
+  induction h with
+  | refl => exact BetaStar.refl (t·u)
+  | tail hab hbc ih => exact BetaStar.tail ih (Beta.appR hbc)
+theorem app {t t' u u'}
+    (ht : BetaStar t t')
+    (hu : BetaStar u u') : 
+    BetaStar (t·u) (t'·u') := by
+  induction ht with
+  | refl => exact BetaStar.appR hu
+  | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc) 
+
+theorem abs {t t' : Term} (h : BetaStar t t') :
+    BetaStar (λ.t) (λ.t') := by
+  induction h with
+  | refl => exact BetaStar.refl (λ.t)
+  | tail hab hbc ih => exact BetaStar.tail ih (Beta.abs hbc)
+
+end BetaStar
+end Lambda

--- a/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
@@ -48,15 +48,15 @@ namespace BetaStar
 
 theorem refl (t : Term) : BetaStar t t :=
   Relation.ReflTransGen.refl
-theorem head {a b c} (hab : Beta a b) (hbc : BetaStar b c) : 
-    BetaStar a c := 
+theorem head {a b c} (hab : Beta a b) (hbc : BetaStar b c) :
+    BetaStar a c :=
   Relation.ReflTransGen.head hab hbc
-theorem tail {a b c} (hab : BetaStar a b) (hbc : Beta b c) : 
+theorem tail {a b c} (hab : BetaStar a b) (hbc : Beta b c) :
     BetaStar a c :=
   Relation.ReflTransGen.tail hab hbc
 theorem trans {a b c}
     (hab : BetaStar a b) (hbc : BetaStar b c) :
-    BetaStar a c := 
+    BetaStar a c :=
   Relation.ReflTransGen.trans hab hbc
 
 theorem appL {t t' u : Term} (h : BetaStar t t') :
@@ -71,11 +71,11 @@ theorem appR {t u u' : Term} (h : BetaStar u u') :
   | tail hab hbc ih => exact BetaStar.tail ih (Beta.appR hbc)
 theorem app {t t' u u'}
     (ht : BetaStar t t')
-    (hu : BetaStar u u') : 
+    (hu : BetaStar u u') :
     BetaStar (t·u) (t'·u') := by
   induction ht with
   | refl => exact BetaStar.appR hu
-  | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc) 
+  | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc)
 
 theorem abs {t t' : Term} (h : BetaStar t t') :
     BetaStar (λ.t) (λ.t') := by

--- a/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/BetaReduction.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zayn Wang
 -/
-import Mathlib.Computability.LambdaCalculus.DeBruijnSyntax
-import Mathlib.Logic.Relation
+module
+
+public import Mathlib.Computability.LambdaCalculus.DeBruijnSyntax
+public import Mathlib.Logic.Relation
 
 /-!
 # One-step β-reduction and its reflexive-transitive closure
@@ -37,39 +39,39 @@ namespace Lambda
 open Term
 
 /-- One-step β-reduction (compatible closure). -/
-inductive Beta : Term → Term → Prop
+public inductive Beta : Term → Term → Prop
   | abs  {t t'}        : Beta t t' → Beta (λ.t) (λ.t')
   | appL {t t' u}      : Beta t t' → Beta (t·u) (t'·u)
   | appR {t u u'}      : Beta u u' → Beta (t·u) (t·u')
   | red  (t' s : Term) : Beta ((λ.t')·s) (t'.sub 0 s)
-abbrev BetaStar := Relation.ReflTransGen Beta
+public abbrev BetaStar := Relation.ReflTransGen Beta
 
 namespace BetaStar
 
-theorem refl (t : Term) : BetaStar t t :=
+public theorem refl (t : Term) : BetaStar t t :=
   Relation.ReflTransGen.refl
-theorem head {a b c} (hab : Beta a b) (hbc : BetaStar b c) :
+public theorem head {a b c} (hab : Beta a b) (hbc : BetaStar b c) :
     BetaStar a c :=
   Relation.ReflTransGen.head hab hbc
-theorem tail {a b c} (hab : BetaStar a b) (hbc : Beta b c) :
+public theorem tail {a b c} (hab : BetaStar a b) (hbc : Beta b c) :
     BetaStar a c :=
   Relation.ReflTransGen.tail hab hbc
-theorem trans {a b c}
+public theorem trans {a b c}
     (hab : BetaStar a b) (hbc : BetaStar b c) :
     BetaStar a c :=
   Relation.ReflTransGen.trans hab hbc
 
-theorem appL {t t' u : Term} (h : BetaStar t t') :
+public theorem appL {t t' u : Term} (h : BetaStar t t') :
     BetaStar (t·u) (t'·u) := by
   induction h with
   | refl => exact BetaStar.refl (t·u)
   | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc)
-theorem appR {t u u' : Term} (h : BetaStar u u') :
+public theorem appR {t u u' : Term} (h : BetaStar u u') :
     BetaStar (t·u) (t·u') := by
   induction h with
   | refl => exact BetaStar.refl (t·u)
   | tail hab hbc ih => exact BetaStar.tail ih (Beta.appR hbc)
-theorem app {t t' u u'}
+public theorem app {t t' u u'}
     (ht : BetaStar t t')
     (hu : BetaStar u u') :
     BetaStar (t·u) (t'·u') := by
@@ -77,7 +79,7 @@ theorem app {t t' u u'}
   | refl => exact BetaStar.appR hu
   | tail hab hbc ih => exact BetaStar.tail ih (Beta.appL hbc)
 
-theorem abs {t t' : Term} (h : BetaStar t t') :
+public theorem abs {t t' : Term} (h : BetaStar t t') :
     BetaStar (λ.t) (λ.t') := by
   induction h with
   | refl => exact BetaStar.refl (λ.t)

--- a/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
+++ b/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
@@ -34,12 +34,12 @@ open Term
 /-- Parallel Reduction is Diamond. -/
 lemma diamond_par : Diamond Par := by
   intro a b c hab hac
-  exact ⟨a.dev, par_to_dev hab, par_to_dev hac⟩ 
+  exact ⟨a.dev, par_to_dev hab, par_to_dev hac⟩
 
 /-- Church–Rosser: β is confluent (on RTC). -/
 theorem churchRosser_beta : Confluent Beta := by
   -- Confluence of Par from diamond
-  have hPar : Confluent Par := 
+  have hPar : Confluent Par :=
     confluent_of_diamond (r := Par) diamond_par
   -- Identify BetaStar and ParStar via sandwich
   have hEq {a b : Term} : BetaStar a b ↔ ParStar a b :=

--- a/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
+++ b/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 zayn7lie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zayn Wang
+-/
+import Mathlib.Computability.LambdaCalculus.ConfluentReduction
+import Mathlib.Computability.LambdaCalculus.ParallelReduction
+
+/-!
+# The Church–Rosser theorem for β-reduction
+
+This file proves confluence of β-reduction on de Bruijn lambda terms.  The proof follows
+the classical route:
+
+1. define parallel β-reduction,
+2. show that parallel reduction has the diamond property using complete developments,
+3. compare parallel reduction with ordinary β-reduction via reflexive-transitive closure,
+4. transport confluence back to β-reduction.
+
+## Main results
+
+* `diamond_par`: parallel reduction is diamond.
+* `churchRosser_beta`: β-reduction is confluent.
+
+## Implementation note
+
+The proof relies on the generic rewriting lemmas from `ConfluentReduction` together with
+the complete-development machinery from `ParallelReduction`.
+-/
+
+namespace Lambda
+open Term
+
+/-- Parallel Reduction is Diamond. -/
+lemma diamond_par : Diamond Par := by
+  intro a b c hab hac
+  exact ⟨a.dev, par_to_dev hab, par_to_dev hac⟩ 
+
+/-- Church–Rosser: β is confluent (on RTC). -/
+theorem churchRosser_beta : Confluent Beta := by
+  -- Confluence of Par from diamond
+  have hPar : Confluent Par := 
+    confluent_of_diamond (r := Par) diamond_par
+  -- Identify BetaStar and ParStar via sandwich
+  have hEq {a b : Term} : BetaStar a b ↔ ParStar a b :=
+      rtc_eq_of_sandwich (r := Beta) (p := Par)
+    (by intro a b h; exact beta_subset_par h)
+    (by intro a b h; exact par_subset_betaStar h)
+  -- Transport confluence
+  intro a b c hab hac
+  have hab' : ParStar a b := (hEq).1 hab
+  have hac' : ParStar a c := (hEq).1 hac
+  rcases hPar hab' hac' with ⟨d, hbd, hcd⟩
+  exact ⟨d, (hEq).2 hbd, (hEq).2 hcd⟩
+
+end Lambda

--- a/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
+++ b/Mathlib/Computability/LambdaCalculus/ChurchRosser.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zayn Wang
 -/
-import Mathlib.Computability.LambdaCalculus.ConfluentReduction
-import Mathlib.Computability.LambdaCalculus.ParallelReduction
+module
+
+public import Mathlib.Computability.LambdaCalculus.ConfluentReduction
+public import Mathlib.Computability.LambdaCalculus.ParallelReduction
 
 /-!
 # The Church–Rosser theorem for β-reduction
@@ -32,12 +34,12 @@ namespace Lambda
 open Term
 
 /-- Parallel Reduction is Diamond. -/
-lemma diamond_par : Diamond Par := by
+private lemma diamond_par : Diamond Par := by
   intro a b c hab hac
   exact ⟨a.dev, par_to_dev hab, par_to_dev hac⟩
 
 /-- Church–Rosser: β is confluent (on RTC). -/
-theorem churchRosser_beta : Confluent Beta := by
+public theorem churchRosser_beta : Confluent Beta := by
   -- Confluence of Par from diamond
   have hPar : Confluent Par :=
     confluent_of_diamond (r := Par) diamond_par

--- a/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 zayn7lie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zayn Wang
+-/
+import Mathlib.Logic.Relation
+
+/-!
+# Confluent Reduction
+
+This file contain the definition of the Diamond property and 
+Confluent property. Then investigate the relationship between
+these two property.
+
+## Main definition
+
+- `Diamond r`: $r$ is diamond iff we have $a$ to $b$ and $a$ to $c$ through $r$,
+    then we could find a $d$ where $b$ and $c$ arrives through $r$.
+- `Confluent r`: $r$ is confluent iff we have $a$ to $b$ and $a$ to $c$ through $r^*$,
+    then we could find a $d$ where $b$ and $c$ arrives through $r^*$.
+
+## Main Theorem
+
+- `confluent_of_diamond`: Diamond is the confluence of the refl-closure.
+- `rtc_eq_of_sandwich`: if we can find a relation $p$ where `r ⊆ p ⊆ r*`,
+    then the refl-trans closure $p^* = r^*$.
+
+-/
+
+open Relation
+
+namespace Lambda
+
+def Diamond {α} (r : α → α → Prop) : Prop :=
+  ∀ ⦃a b c⦄, r a b → r a c → ∃ d, r b d ∧ r c d
+
+def Confluent {α} (r : α → α → Prop) : Prop :=
+  ∀ ⦃a b c⦄,
+    ReflTransGen r a b →
+    ReflTransGen r a c →
+    ∃ d, ReflTransGen r b d ∧ ReflTransGen r c d
+
+/-- Diamond = confluence of the refl–trans closure. -/
+theorem confluent_of_diamond {α} {r : α → α → Prop}
+    (hd : Diamond r) : Confluent r := by
+  have strip : ∀ ⦃a b c⦄, r a b → ReflTransGen r a c →
+      ∃ d, ReflTransGen r b d ∧ r c d := by
+    intro a b c hab hac
+    induction hac with
+    | refl => exact ⟨b, ReflTransGen.refl, hab⟩
+    | tail had hce ih =>
+        rcases ih with ⟨d, hbd, hcd⟩
+        rcases hd hcd hce with ⟨f, hdf, hef⟩
+        exact ⟨f, ReflTransGen.tail hbd hdf, hef⟩
+  intro a b c hab hac
+  induction hab with
+  | refl => exact ⟨c, hac, ReflTransGen.refl⟩
+  | tail hab hbc ih =>
+      rcases ih with ⟨d, hbd, hcd⟩
+      rcases strip hbc hbd with ⟨f, hcf, hdf⟩
+      exact ⟨f, hcf, ReflTransGen.tail hcd hdf⟩
+
+/-- Sandwich: if `r ⊆ p ⊆ r*` then `r* = p*`. -/
+theorem rtc_eq_of_sandwich {α} {r p : α → α → Prop}
+    (h₁ : ∀ ⦃a b⦄, r a b → p a b)
+    (h₂ : ∀ ⦃a b⦄, p a b → ReflTransGen r a b) :
+    ∀ {a b}, ReflTransGen r a b ↔ ReflTransGen p a b := by
+  intro a b
+  constructor
+  · intro hr
+    induction hr with
+    | refl => exact ReflTransGen.refl
+    | tail hab hbc ih => exact ReflTransGen.tail ih (h₁ hbc)
+  · intro hp
+    induction hp with
+    | refl => exact ReflTransGen.refl
+    | tail hab hbc ih => exact ReflTransGen.trans ih (h₂ hbc)
+
+end Lambda

--- a/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zayn Wang
 -/
-import Mathlib.Logic.Relation
+module
+
+public import Mathlib.Logic.Relation
 
 /-!
 # Confluent Reduction
@@ -31,17 +33,17 @@ open Relation
 
 namespace Lambda
 
-def Diamond {α} (r : α → α → Prop) : Prop :=
+@[simp, expose] public def Diamond {α} (r : α → α → Prop) : Prop :=
   ∀ ⦃a b c⦄, r a b → r a c → ∃ d, r b d ∧ r c d
 
-def Confluent {α} (r : α → α → Prop) : Prop :=
+@[simp, expose] public def Confluent {α} (r : α → α → Prop) : Prop :=
   ∀ ⦃a b c⦄,
     ReflTransGen r a b →
     ReflTransGen r a c →
     ∃ d, ReflTransGen r b d ∧ ReflTransGen r c d
 
 /-- Diamond = confluence of the refl–trans closure. -/
-theorem confluent_of_diamond {α} {r : α → α → Prop}
+public theorem confluent_of_diamond {α} {r : α → α → Prop}
     (hd : Diamond r) : Confluent r := by
   have strip : ∀ ⦃a b c⦄, r a b → ReflTransGen r a c →
       ∃ d, ReflTransGen r b d ∧ r c d := by
@@ -61,7 +63,7 @@ theorem confluent_of_diamond {α} {r : α → α → Prop}
       exact ⟨f, hcf, ReflTransGen.tail hcd hdf⟩
 
 /-- Sandwich: if `r ⊆ p ⊆ r*` then `r* = p*`. -/
-theorem rtc_eq_of_sandwich {α} {r p : α → α → Prop}
+public theorem rtc_eq_of_sandwich {α} {r p : α → α → Prop}
     (h₁ : ∀ ⦃a b⦄, r a b → p a b)
     (h₂ : ∀ ⦃a b⦄, p a b → ReflTransGen r a b) :
     ∀ {a b}, ReflTransGen r a b ↔ ReflTransGen p a b := by

--- a/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ConfluentReduction.lean
@@ -8,7 +8,7 @@ import Mathlib.Logic.Relation
 /-!
 # Confluent Reduction
 
-This file contain the definition of the Diamond property and 
+This file contain the definition of the Diamond property and
 Confluent property. Then investigate the relationship between
 these two property.
 

--- a/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
+++ b/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zayn Wang, Maksym Radziwill
 -/
-import Mathlib.Data.Nat.Basic
+module
+
+public import Mathlib.Data.Nat.Basic
 
 /-!
 # Untyped lambda calculus with de Bruijn indices
@@ -41,7 +43,7 @@ parallel reduction, and the Church–Rosser theorem.
 namespace Lambda
 
 /-- using de Bruijn syntax avoiding α-conversion -/
-inductive Term : Type where
+public inductive Term : Type where
   | var : Nat → Term
   | abs : Term → Term
   | app : Term → Term → Term
@@ -55,28 +57,28 @@ notation:max "λ." t => Term.abs t
 infixl:77 "·" => Term.app
 
 /-- `incre i l t` increments `i` for all free vars `≥ l`. -/
-@[simp] def incre (i : Nat) (l : Nat) : Term → Term
+@[simp, expose] public def incre (i : Nat) (l : Nat) : Term → Term
   | var k   => if l ≤ k then var (k + i) else var k
   | abs t   => abs (incre i (l + 1) t)
   | app t u => app (incre i l t) (incre i l u)
 
 /-- `subst j s t` substitutes `j` with term `s` in `t`. -/
-@[simp] def subst (j : Nat) (s : Term) : Term → Term
+@[simp, expose] public def subst (j : Nat) (s : Term) : Term → Term
   | var k   => if k = j then s else var k
   | abs t   => abs (subst (j + 1) (incre 1 0 s) t)
   | app t u => app (subst j s t) (subst j s u)
 
 /-- `decre c t` decrements free vars `> c` by 1. -/
-@[simp] def decre (l : Nat) : Term → Term
+@[simp, expose] public def decre (l : Nat) : Term → Term
   | var k   => if l < k then var (k - 1) else var k
   | abs t   => abs (decre (l + 1) t)
   | app t u => app (decre l t) (decre l u)
 
 /-- Substitute into the body of a lambda: `(λ.t) s` -/
-@[simp] def sub (t : Term) (n : Nat) (s : Term) := decre n (subst n (incre 1 n s) t)
+@[simp, expose] public def sub (t : Term) (n : Nat) (s : Term) := decre n (subst n (incre 1 n s) t)
 
 /-- Increment of 0 is identity -/
-@[simp] theorem incre_rfl {l t} : incre 0 l t = t := by
+@[simp] public theorem incre_rfl {l t} : incre 0 l t = t := by
   induction t generalizing l with
   | var k => simp_all
   | abs t ih => simp_all
@@ -84,7 +86,7 @@ infixl:77 "·" => Term.app
 
 /-- Decrement of increment with same bound is the same.
 Lemma for `var_sub` -/
-@[simp] theorem decre_incre_elim {l t} : decre l (incre 1 l t) = t := by
+@[simp] public theorem decre_incre_elim {l t} : decre l (incre 1 l t) = t := by
   induction t generalizing l with
   | var k =>
       unfold decre incre
@@ -93,27 +95,27 @@ Lemma for `var_sub` -/
       | inr h =>
           have : ¬(l < k) := by omega
           simp only [if_neg h, if_neg this]
-  | abs t ih => unfold decre incre; simp_all
-  | app t u iht ihu => unfold decre incre; simp_all
+  | abs t ih => simp_all
+  | app t u iht ihu => simp_all
 
 /-- Substitution of var n. -/
-@[simp] theorem var_sub_elim {n s} : ((𝕧 n).sub) n s = s := by
-  simp_all
+@[simp] public theorem var_sub_elim {n s} : ((𝕧 n).sub) n s = s := by
+  simp_all only [sub, subst, ↓reduceIte, decre_incre_elim] 
 
 /-- Vacuously Substitution of var k to var k. -/
-@[simp] theorem var_lt_sub {k n s} (hk : k < n) :
+@[simp] public theorem var_lt_sub {k n s} (hk : k < n) :
     ((𝕧 k).sub) n s = 𝕧 k := by
-  simp_all [Nat.ne_of_lt hk, Nat.not_lt_of_gt hk]
+  simp_all only [sub, subst, Nat.ne_of_lt hk, ↓reduceIte, decre, Nat.not_lt_of_gt hk] 
 
 /-- Vacuously Substitution of var k to var k - 1. -/
-@[simp] theorem var_gt_sub {k n s} (hk : k > n) :
+@[simp] public theorem var_gt_sub {k n s} (hk : k > n) :
     ((𝕧 k).sub) n s = 𝕧 (k - 1) := by
   simp_all [Nat.ne_of_gt hk]
 
 /-- Increments elimination for same lower bound.
 Special thanks to professor Radziwill @maksym-radziwill about
 his idea of generalizing proper variable. -/
-@[simp] theorem incre_same_bound_elim {i j n t} :
+@[simp] public theorem incre_same_bound_elim {i j n t} :
     (incre i n (incre j n t)) = (incre (i + j) n t) := by
   induction t generalizing i n with
   | var k =>
@@ -126,7 +128,7 @@ his idea of generalizing proper variable. -/
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
 /-- Communitivity of incre. -/
-theorem incre_comm {i j k l t} :
+public theorem incre_comm {i j k l t} :
     (incre j (k + l + i) (incre i l t))=
       (incre i l (incre j (k + l) t)) := by
   induction t generalizing l with
@@ -155,13 +157,13 @@ theorem incre_comm {i j k l t} :
   | abs t' ih => simp_all [Nat.add_assoc, Nat.add_comm]
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
-theorem incre_comm_zero {n s} :
+public theorem incre_comm_zero {n s} :
     incre 1 (n + 1) (incre 1 0 s) =
       incre 1 0 (incre 1 n s) := by
   simpa using
       (incre_comm (i := 1) (l := 0) (j := 1) (k := n) (t := s))
 
-@[simp] theorem abs_sub_zero {t n s} :
+@[simp] public theorem abs_sub_zero {t n s} :
     ((λ.t).sub n s) = λ.(t.sub (n + 1) (incre 1 0 s)) := by
   simp_all [incre_comm_zero]
 
@@ -196,7 +198,7 @@ private lemma incre_sub_var {i l n k s} :
               intro; omega
 
 /-- The communitivity between sub and incre for free var. -/
-@[simp] theorem incre_sub {i l n t s} :
+@[simp] public theorem incre_sub {i l n t s} :
     ((incre i (l + n + 1) t).sub n (incre i (l + n) s)) =
     (incre i (l + n) (t.sub n s)) := by
   induction t generalizing l n s with
@@ -224,7 +226,7 @@ private lemma sub_incre_same {u r m} :
     ((incre 1 m u).sub m r) = u := by
   simp_all [subst_zero_incre]
 
-@[simp] theorem sub_lift_zero {i t n u} :
+@[simp] public theorem sub_lift_zero {i t n u} :
     ((incre 1 i t).sub (n + i + 1) (incre 1 i u)) =
       incre 1 i (t.sub (n + i) u) := by
   induction t generalizing n u i with
@@ -235,18 +237,14 @@ private lemma sub_incre_same {u r m} :
         cases em (k < n + i) with
           | inl hlt =>
               have hlt' : k + 1 < n + i + 1 := by omega
-              have : ¬(n + i < k) := by omega
-              simp_all only [Nat.add_lt_add_iff_right, not_lt, sub, incre, subst,
-                ↓reduceIte, decre, if_neg this]
+              have hnlt : ¬(n + i < k) := by omega
+              simp only [sub, incre, subst]
               cases em (i ≤ k) with
-              | inl hlt' => simp_all
+              | inl hlt' => simp_all [if_neg hnlt]
               | inr hlt' =>
                   have h' : ¬(k = n + i + 1) := by omega
-                  simp_all only [not_le, if_neg hlt', subst,
-                    ↓reduceIte, decre, ite_eq_right_iff, var.injEq]
-                  intro h
-                  have hni_lt_k : n + i < k := by omega
-                  exact (Nat.lt_asymm hlt hni_lt_k).elim
+                  have : ¬(n + i + 1 < k) := by omega
+                  simp_all [if_neg hlt', if_neg this, if_neg hnlt]
           | inr hlt =>
               have hle : i ≤ k := by omega
               have hgt : n + i < k := by omega
@@ -301,7 +299,7 @@ private lemma sub_comm_var {k n m u s} :
                   have nh : ¬(n + m < k) := by omega
                   exact (nh h).elim
 
-theorem sub_comm {t : Term} {n m s u} :
+public theorem sub_comm {t : Term} {n m s u} :
     ((t.sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u))
     = ((t.sub m s).sub (n + m) u) := by
   induction t generalizing n m s u with
@@ -317,7 +315,7 @@ theorem sub_comm {t : Term} {n m s u} :
         (ih (n := n) (m := m + 1) (u := incre 1 0 u) (s := incre 1 0 s))
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
-theorem sub_sub_incre {t : Term} {n k u s} :
+public theorem sub_sub_incre {t : Term} {n k u s} :
     ((t.sub (n + 1) (incre (1 + k) 0 u)).sub 0 (s.sub n (incre k 0 u)))
     = ((t.sub 0 s).sub n (incre k 0 u)) := by
   have h' :

--- a/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
+++ b/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
@@ -1,0 +1,333 @@
+/-
+Copyright (c) 2026 zayn7lie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zayn Wang, Markym Radziwill
+-/
+import Mathlib.Data.Nat.Basic
+
+/-!
+# Untyped lambda calculus with de Bruijn indices
+
+This file defines the syntax of untyped lambda terms using de Bruijn indices, together
+with the basic operations on terms needed for β-reduction.  Using de Bruijn indices avoids
+explicit reasoning about α-conversion and variable names.
+
+## Main definitions
+
+* `Lambda.Term`: the type of lambda terms.
+* `Term.incre`: lifting (shifting) of free variables above a cutoff.
+* `Term.subst`: raw substitution at a de Bruijn index.
+* `Term.decre`: lowering of free variables above a cutoff.
+* `Term.sub`: the substitution operation implementing β-contraction.
+
+## Main lemmas
+
+* `Term.incre_rfl`: shifting by `0` is the identity.
+* `Term.decre_incre_elim`: lowering cancels a corresponding shift.
+* `Term.var_sub_elim`, `Term.var_lt_sub`, `Term.var_gt_sub`: basic computations for
+  substitution on variables.
+
+## Notes
+
+The definitions in this file are tailored to the later development of one-step β-reduction,
+parallel reduction, and the Church–Rosser theorem.
+
+## References
+
+* <https://en.wikipedia.org/wiki/De_Bruijn_index>
+-/
+
+
+namespace Lambda
+
+/-- using de Bruijn syntax avoiding α-conversion -/
+inductive Term : Type where
+  | var : Nat → Term
+  | abs : Term → Term
+  | app : Term → Term → Term
+deriving DecidableEq, Repr
+
+open Term
+namespace Term
+
+notation:max "𝕧" str => Term.var str
+notation:max "λ." t => Term.abs t
+infixl:77 "·" => Term.app
+
+/-- `incre i l t` increments `i` for all free vars `≥ l`. -/
+@[simp] def incre (i : Nat) (l : Nat) : Term → Term
+  | var k   => if l ≤ k then var (k + i) else var k
+  | abs t   => abs (incre i (l + 1) t)
+  | app t u => app (incre i l t) (incre i l u)
+
+/-- `subst j s t` substitutes `j` with term `s` in `t`. -/
+@[simp] def subst (j : Nat) (s : Term) : Term → Term
+  | var k   => if k = j then s else var k
+  | abs t   => abs (subst (j + 1) (incre 1 0 s) t)
+  | app t u => app (subst j s t) (subst j s u)
+
+/-- `decre c t` decrements free vars `> c` by 1. -/
+@[simp] def decre (l : Nat) : Term → Term
+  | var k   => if l < k then var (k - 1) else var k
+  | abs t   => abs (decre (l + 1) t)
+  | app t u => app (decre l t) (decre l u)
+
+/-- Substitute into the body of a lambda: `(λ.t) s` -/
+@[simp] def sub (t : Term) (n : Nat) (s : Term) := decre n (subst n (incre 1 n s) t)
+
+/-- Increment of 0 is identity -/
+@[simp] theorem incre_rfl {l t} : incre 0 l t = t := by
+  induction t generalizing l with
+  | var k => simp_all
+  | abs t ih => simp_all
+  | app t u iht ihu => simp_all
+
+/-- Decrement of increment with same bound is the same. 
+Lemma for `var_sub` -/
+@[simp] theorem decre_incre_elim {l t} : decre l (incre 1 l t) = t := by
+  induction t generalizing l with
+  | var k =>
+      unfold decre incre
+      cases em (l ≤ k) with
+      | inl h => simp_all [Nat.lt_succ_of_le h]
+      | inr h =>
+          have : ¬(l < k) := by omega
+          simp only [if_neg h, if_neg this]
+  | abs t ih => unfold decre incre; simp_all
+  | app t u iht ihu => unfold decre incre; simp_all
+
+/-- Substitution of var n. -/
+@[simp] theorem var_sub_elim {n s} : ((𝕧 n).sub) n s = s := by
+  simp_all
+
+/-- Vacuously Substitution of var k to var k. -/
+@[simp] theorem var_lt_sub {k n s} (hk : k < n) : 
+    ((𝕧 k).sub) n s = 𝕧 k := by
+  simp_all [Nat.ne_of_lt hk, Nat.not_lt_of_gt hk]
+
+/-- Vacuously Substitution of var k to var k - 1. -/
+@[simp] theorem var_gt_sub {k n s} (hk : k > n) : 
+    ((𝕧 k).sub) n s = 𝕧 (k - 1) := by
+  simp_all [Nat.ne_of_gt hk]
+
+/-- Increments elimination for same lower bound. 
+Special thanks to professor Radziwill @maksym-radziwill about
+his idea of generalizing proper variable. -/
+@[simp] theorem incre_same_bound_elim {i j n t} :
+    (incre i n (incre j n t)) = (incre (i + j) n t) := by
+  induction t generalizing i n with
+  | var k =>
+      cases em (n ≤ k) with
+      | inl h => 
+          simp_all [le_trans h (Nat.le_add_right k j)]
+          simp_all [Nat.add_comm, Nat.add_left_comm]
+      | inr h => simp_all [if_neg h]
+  | abs t' ih => simp_all
+  | app t₁ t₂ ih₁ ih₂ => simp_all
+
+/-- Communitivity of incre. -/
+theorem incre_comm {i j k l t} :
+    (incre j (k + l + i) (incre i l t))= 
+      (incre i l (incre j (k + l) t)) := by
+  induction t generalizing l with
+  | var n =>
+      cases em (k + l ≤ n) with
+      | inl h => 
+          have : l ≤ n := le_trans (Nat.le_add_left _ _) h
+          simp_all [le_trans this (Nat.le_add_right _ _)]
+          simp [Nat.add_comm, Nat.add_left_comm]
+      | inr h => 
+          simp only [incre, if_neg h]
+          cases em (l ≤ n) with
+          | inl h' => 
+              simp_all only [not_le, ↓reduceIte, incre, 
+                Nat.add_le_add_iff_right, ite_eq_right_iff]
+              intro hk
+              have : n < n := Nat.lt_of_lt_of_le h hk
+              exact (Nat.lt_irrefl n this).elim
+          | inr h' =>
+              simp_all only [not_le, if_neg h', incre, 
+                ite_eq_right_iff, var.injEq, Nat.add_eq_left]
+              intro hk
+              have hl : l ≤ n := by omega
+              exact (Nat.lt_irrefl n 
+                (Nat.lt_of_lt_of_le h' hl)).elim
+  | abs t' ih => simp_all [Nat.add_assoc, Nat.add_comm]
+  | app t₁ t₂ ih₁ ih₂ => simp_all
+
+theorem incre_comm_zero {n s} :
+    incre 1 (n + 1) (incre 1 0 s) =
+      incre 1 0 (incre 1 n s) := by 
+  simpa using
+      (incre_comm (i := 1) (l := 0) (j := 1) (k := n) (t := s))
+
+@[simp] theorem abs_sub_zero {t n s} :
+    ((λ.t).sub n s) = λ.(t.sub (n + 1) (incre 1 0 s)) := by
+  simp_all [incre_comm_zero]
+
+private lemma incre_sub_var {i l n k s} : 
+    (incre i (l + n + 1) 𝕧 k).sub n (incre i (l + n) s) = 
+    incre i (l + n) ((𝕧 k).sub n s) := by
+  cases em (k = n) with
+  | inl h =>
+      have : ¬ (l + n + 1 ≤ n) := by omega
+      simp_all [if_neg this]
+  | inr h => 
+      cases em (l + n + 1 ≤ k) with
+      | inl h' =>
+          have : k + i ≠ n := by omega
+          have : n < k := by omega
+          have : l + n ≤ k - 1 := by omega
+          have : n < k + i := by omega
+          have : k + i - 1 = k - 1 + i := by omega
+          simp_all only [ne_eq, sub, incre, 
+            ↓reduceIte, subst, decre]
+      | inr h' =>
+          simp_all only [not_le, sub, incre, if_neg h', 
+            subst, ↓reduceIte, decre] 
+          cases em (n < k) with
+          | inl h'' => 
+              simp_all only [↓reduceIte, incre, 
+                right_eq_ite_iff, var.injEq, Nat.left_eq_add]
+              intro; omega
+          | inr h'' => 
+              simp_all only [not_lt, if_neg h'', incre, 
+                right_eq_ite_iff, var.injEq, Nat.left_eq_add]
+              intro; omega
+
+/-- The communitivity between sub and incre for free var. -/
+@[simp] theorem incre_sub {i l n t s} : 
+    ((incre i (l + n + 1) t).sub n (incre i (l + n) s)) =
+    (incre i (l + n) (t.sub n s)) := by
+  induction t generalizing l n s with
+  | var k => exact incre_sub_var
+  | abs t' ih => 
+      simpa [← incre_comm_zero, ← incre_comm] using ih
+  | app t₁ t₂ ih₁ ih₂ => simp_all
+
+private lemma subst_zero_incre {n t u} :
+    subst n t (incre 1 n u) = incre 1 n u := by
+  induction u generalizing n t with
+  | var k =>
+      cases em (n ≤ k) with
+      | inl h =>
+          simp_all only [incre, ↓reduceIte, subst, ite_eq_right_iff]
+          intro; omega
+      | inr h =>
+          simp_all only [not_le, incre, if_neg h,
+            subst, ite_eq_right_iff] 
+          intro; omega
+  | abs t ih => simp_all
+  | app t v iht ihv => simp_all
+
+private lemma sub_incre_same {u r m} :
+    ((incre 1 m u).sub m r) = u := by
+  simp_all [subst_zero_incre]
+
+@[simp] theorem sub_lift_zero {i t n u} :
+    ((incre 1 i t).sub (n + i + 1) (incre 1 i u)) =
+      incre 1 i (t.sub (n + i) u) := by
+  induction t generalizing n u i with
+  | var k =>
+      cases em (k = n + i) with
+      | inl hk => simp_all
+      | inr hk => 
+        cases em (k < n + i) with
+          | inl hlt =>
+              have hlt' : k + 1 < n + i + 1 := by omega
+              have : ¬(n + i < k) := by omega
+              simp_all only [Nat.add_lt_add_iff_right, not_lt, sub, incre, subst, 
+                ↓reduceIte, decre, if_neg this] 
+              cases em (i ≤ k) with
+              | inl hlt' => simp_all
+              | inr hlt' => 
+                  have h' : ¬(k = n + i + 1) := by omega
+                  simp_all only [not_le, if_neg hlt', subst, 
+                    ↓reduceIte, decre, ite_eq_right_iff, var.injEq] 
+                  intro h
+                  have hni_lt_k : n + i < k := by omega
+                  exact (Nat.lt_asymm hlt hni_lt_k).elim
+          | inr hlt =>
+              have hle : i ≤ k := by omega
+              have hgt : n + i < k := by omega
+              have hlt : i ≤ k - 1 := by omega
+              simp_all
+              omega
+  | abs t ih =>
+      simpa [← incre_comm_zero] using
+        (ih (i := i + 1) (n := n) (u := incre 1 0 u))
+  | app t₁ t₂ ih₁ ih₂ => simp_all
+
+private lemma sub_comm_var {k n m u s} :
+    (((𝕧 k).sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u)) 
+    = (((𝕧 k).sub m s).sub (n + m) u) := by
+  cases em (k = n + m + 1) with
+  | inl hk =>
+      have : ¬(n + m + 1 = m) := by omega
+      have : m < n + m + 1 := by omega
+      simp_all [subst_zero_incre]
+  | inr hk =>
+      cases em (k = m) with
+      | inl hkm =>
+          have : ¬(n + m + 1 < m) := by omega
+          simp_all [if_neg this]
+      | inr hkm =>
+          have : ¬(k - 1 = n + m) := by omega
+          cases em (n + m + 1 < k) with
+          | inl hlt =>
+              have : ¬(k - 1 = m) := by omega
+              have : m < k := by omega
+              have : m < k - 1 := by omega
+              simp_all only [sub, subst, ↓reduceIte, decre, 
+                left_eq_ite_iff, not_lt, Nat.sub_le_iff_le_add, var.injEq] 
+              intro h
+              exact (Nat.not_lt_of_ge h hlt).elim
+          | inr hlt =>
+              simp_all only [not_lt, sub, subst, 
+                ↓reduceIte, decre, if_neg hlt] 
+              cases em (m < k) with
+              | inl hlt => 
+                  simp_all only [↓reduceIte, subst, decre, 
+                    right_eq_ite_iff, var.injEq] 
+                  intro h
+                  have nh : ¬(n + m < k - 1) := by omega
+                  exact (nh h).elim
+              | inr hlt =>
+                  have hneq : ¬(k = n + m) := by omega
+                  have hnlt : ¬(m < k) := by omega
+                  simp_all only [not_false_eq_true, not_lt, if_neg hnlt, subst, 
+                    ↓reduceIte, decre, right_eq_ite_iff, var.injEq] 
+                  intro h
+                  have nh : ¬(n + m < k) := by omega
+                  exact (nh h).elim
+
+theorem sub_comm {t : Term} {n m s u} : 
+    ((t.sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u)) 
+    = ((t.sub m s).sub (n + m) u) := by
+  induction t generalizing n m s u with
+  | var k => exact sub_comm_var
+  | abs t' ih =>
+      have : ∀ k, (incre 1 0 (decre k (subst k (incre 1 k u) s))) = 
+          (decre (k + 1) (subst (k + 1) (incre 1 (k + 1)
+          (incre 1 0 u)) (incre 1 0 s))) := by
+        intro k
+        simpa using
+        (sub_lift_zero (t := s) (n := k) (u := u) (i := 0)).symm 
+      simpa [← incre_comm_zero, this] using
+        (ih (n := n) (m := m + 1) (u := incre 1 0 u) (s := incre 1 0 s))
+  | app t₁ t₂ ih₁ ih₂ => simp_all
+
+theorem sub_sub_incre {t : Term} {n k u s} : 
+    ((t.sub (n + 1) (incre (1 + k) 0 u)).sub 0 (s.sub n (incre k 0 u))) 
+    = ((t.sub 0 s).sub n (incre k 0 u)) := by
+  have h' :
+      ((t.sub (n + 1) (incre 1 0 (incre k 0 u))).sub 0
+          ((s.sub n (incre k 0 u)))) =
+        ((t.sub 0 s).sub n (incre k 0 u)) := by
+    simpa using (sub_comm (t := t) (u := incre k 0 u) (s := s) (n := n) (m := 0))
+  simpa using h'
+
+
+end Term
+end Lambda
+

--- a/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
+++ b/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
@@ -100,12 +100,12 @@ Lemma for `var_sub` -/
 
 /-- Substitution of var n. -/
 @[simp] public theorem var_sub_elim {n s} : ((𝕧 n).sub) n s = s := by
-  simp_all only [sub, subst, ↓reduceIte, decre_incre_elim] 
+  simp_all only [sub, subst, ↓reduceIte, decre_incre_elim]
 
 /-- Vacuously Substitution of var k to var k. -/
 @[simp] public theorem var_lt_sub {k n s} (hk : k < n) :
     ((𝕧 k).sub) n s = 𝕧 k := by
-  simp_all only [sub, subst, Nat.ne_of_lt hk, ↓reduceIte, decre, Nat.not_lt_of_gt hk] 
+  simp_all only [sub, subst, Nat.ne_of_lt hk, ↓reduceIte, decre, Nat.not_lt_of_gt hk]
 
 /-- Vacuously Substitution of var k to var k - 1. -/
 @[simp] public theorem var_gt_sub {k n s} (hk : k > n) :

--- a/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
+++ b/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
@@ -82,7 +82,7 @@ infixl:77 "·" => Term.app
   | abs t ih => simp_all
   | app t u iht ihu => simp_all
 
-/-- Decrement of increment with same bound is the same. 
+/-- Decrement of increment with same bound is the same.
 Lemma for `var_sub` -/
 @[simp] theorem decre_incre_elim {l t} : decre l (incre 1 l t) = t := by
   induction t generalizing l with
@@ -101,16 +101,16 @@ Lemma for `var_sub` -/
   simp_all
 
 /-- Vacuously Substitution of var k to var k. -/
-@[simp] theorem var_lt_sub {k n s} (hk : k < n) : 
+@[simp] theorem var_lt_sub {k n s} (hk : k < n) :
     ((𝕧 k).sub) n s = 𝕧 k := by
   simp_all [Nat.ne_of_lt hk, Nat.not_lt_of_gt hk]
 
 /-- Vacuously Substitution of var k to var k - 1. -/
-@[simp] theorem var_gt_sub {k n s} (hk : k > n) : 
+@[simp] theorem var_gt_sub {k n s} (hk : k > n) :
     ((𝕧 k).sub) n s = 𝕧 (k - 1) := by
   simp_all [Nat.ne_of_gt hk]
 
-/-- Increments elimination for same lower bound. 
+/-- Increments elimination for same lower bound.
 Special thanks to professor Radziwill @maksym-radziwill about
 his idea of generalizing proper variable. -/
 @[simp] theorem incre_same_bound_elim {i j n t} :
@@ -118,7 +118,7 @@ his idea of generalizing proper variable. -/
   induction t generalizing i n with
   | var k =>
       cases em (n ≤ k) with
-      | inl h => 
+      | inl h =>
           simp_all [le_trans h (Nat.le_add_right k j)]
           simp_all [Nat.add_comm, Nat.add_left_comm]
       | inr h => simp_all [if_neg h]
@@ -127,37 +127,37 @@ his idea of generalizing proper variable. -/
 
 /-- Communitivity of incre. -/
 theorem incre_comm {i j k l t} :
-    (incre j (k + l + i) (incre i l t))= 
+    (incre j (k + l + i) (incre i l t))=
       (incre i l (incre j (k + l) t)) := by
   induction t generalizing l with
   | var n =>
       cases em (k + l ≤ n) with
-      | inl h => 
+      | inl h =>
           have : l ≤ n := le_trans (Nat.le_add_left _ _) h
           simp_all [le_trans this (Nat.le_add_right _ _)]
           simp [Nat.add_comm, Nat.add_left_comm]
-      | inr h => 
+      | inr h =>
           simp only [incre, if_neg h]
           cases em (l ≤ n) with
-          | inl h' => 
-              simp_all only [not_le, ↓reduceIte, incre, 
+          | inl h' =>
+              simp_all only [not_le, ↓reduceIte, incre,
                 Nat.add_le_add_iff_right, ite_eq_right_iff]
               intro hk
               have : n < n := Nat.lt_of_lt_of_le h hk
               exact (Nat.lt_irrefl n this).elim
           | inr h' =>
-              simp_all only [not_le, if_neg h', incre, 
+              simp_all only [not_le, if_neg h', incre,
                 ite_eq_right_iff, var.injEq, Nat.add_eq_left]
               intro hk
               have hl : l ≤ n := by omega
-              exact (Nat.lt_irrefl n 
+              exact (Nat.lt_irrefl n
                 (Nat.lt_of_lt_of_le h' hl)).elim
   | abs t' ih => simp_all [Nat.add_assoc, Nat.add_comm]
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
 theorem incre_comm_zero {n s} :
     incre 1 (n + 1) (incre 1 0 s) =
-      incre 1 0 (incre 1 n s) := by 
+      incre 1 0 (incre 1 n s) := by
   simpa using
       (incre_comm (i := 1) (l := 0) (j := 1) (k := n) (t := s))
 
@@ -165,14 +165,14 @@ theorem incre_comm_zero {n s} :
     ((λ.t).sub n s) = λ.(t.sub (n + 1) (incre 1 0 s)) := by
   simp_all [incre_comm_zero]
 
-private lemma incre_sub_var {i l n k s} : 
-    (incre i (l + n + 1) 𝕧 k).sub n (incre i (l + n) s) = 
+private lemma incre_sub_var {i l n k s} :
+    (incre i (l + n + 1) 𝕧 k).sub n (incre i (l + n) s) =
     incre i (l + n) ((𝕧 k).sub n s) := by
   cases em (k = n) with
   | inl h =>
       have : ¬ (l + n + 1 ≤ n) := by omega
       simp_all [if_neg this]
-  | inr h => 
+  | inr h =>
       cases em (l + n + 1 ≤ k) with
       | inl h' =>
           have : k + i ≠ n := by omega
@@ -180,28 +180,28 @@ private lemma incre_sub_var {i l n k s} :
           have : l + n ≤ k - 1 := by omega
           have : n < k + i := by omega
           have : k + i - 1 = k - 1 + i := by omega
-          simp_all only [ne_eq, sub, incre, 
+          simp_all only [ne_eq, sub, incre,
             ↓reduceIte, subst, decre]
       | inr h' =>
-          simp_all only [not_le, sub, incre, if_neg h', 
-            subst, ↓reduceIte, decre] 
+          simp_all only [not_le, sub, incre, if_neg h',
+            subst, ↓reduceIte, decre]
           cases em (n < k) with
-          | inl h'' => 
-              simp_all only [↓reduceIte, incre, 
+          | inl h'' =>
+              simp_all only [↓reduceIte, incre,
                 right_eq_ite_iff, var.injEq, Nat.left_eq_add]
               intro; omega
-          | inr h'' => 
-              simp_all only [not_lt, if_neg h'', incre, 
+          | inr h'' =>
+              simp_all only [not_lt, if_neg h'', incre,
                 right_eq_ite_iff, var.injEq, Nat.left_eq_add]
               intro; omega
 
 /-- The communitivity between sub and incre for free var. -/
-@[simp] theorem incre_sub {i l n t s} : 
+@[simp] theorem incre_sub {i l n t s} :
     ((incre i (l + n + 1) t).sub n (incre i (l + n) s)) =
     (incre i (l + n) (t.sub n s)) := by
   induction t generalizing l n s with
   | var k => exact incre_sub_var
-  | abs t' ih => 
+  | abs t' ih =>
       simpa [← incre_comm_zero, ← incre_comm] using ih
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
@@ -215,7 +215,7 @@ private lemma subst_zero_incre {n t u} :
           intro; omega
       | inr h =>
           simp_all only [not_le, incre, if_neg h,
-            subst, ite_eq_right_iff] 
+            subst, ite_eq_right_iff]
           intro; omega
   | abs t ih => simp_all
   | app t v iht ihv => simp_all
@@ -231,19 +231,19 @@ private lemma sub_incre_same {u r m} :
   | var k =>
       cases em (k = n + i) with
       | inl hk => simp_all
-      | inr hk => 
+      | inr hk =>
         cases em (k < n + i) with
           | inl hlt =>
               have hlt' : k + 1 < n + i + 1 := by omega
               have : ¬(n + i < k) := by omega
-              simp_all only [Nat.add_lt_add_iff_right, not_lt, sub, incre, subst, 
-                ↓reduceIte, decre, if_neg this] 
+              simp_all only [Nat.add_lt_add_iff_right, not_lt, sub, incre, subst,
+                ↓reduceIte, decre, if_neg this]
               cases em (i ≤ k) with
               | inl hlt' => simp_all
-              | inr hlt' => 
+              | inr hlt' =>
                   have h' : ¬(k = n + i + 1) := by omega
-                  simp_all only [not_le, if_neg hlt', subst, 
-                    ↓reduceIte, decre, ite_eq_right_iff, var.injEq] 
+                  simp_all only [not_le, if_neg hlt', subst,
+                    ↓reduceIte, decre, ite_eq_right_iff, var.injEq]
                   intro h
                   have hni_lt_k : n + i < k := by omega
                   exact (Nat.lt_asymm hlt hni_lt_k).elim
@@ -259,7 +259,7 @@ private lemma sub_incre_same {u r m} :
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
 private lemma sub_comm_var {k n m u s} :
-    (((𝕧 k).sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u)) 
+    (((𝕧 k).sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u))
     = (((𝕧 k).sub m s).sub (n + m) u) := by
   cases em (k = n + m + 1) with
   | inl hk =>
@@ -278,47 +278,47 @@ private lemma sub_comm_var {k n m u s} :
               have : ¬(k - 1 = m) := by omega
               have : m < k := by omega
               have : m < k - 1 := by omega
-              simp_all only [sub, subst, ↓reduceIte, decre, 
-                left_eq_ite_iff, not_lt, Nat.sub_le_iff_le_add, var.injEq] 
+              simp_all only [sub, subst, ↓reduceIte, decre,
+                left_eq_ite_iff, not_lt, Nat.sub_le_iff_le_add, var.injEq]
               intro h
               exact (Nat.not_lt_of_ge h hlt).elim
           | inr hlt =>
-              simp_all only [not_lt, sub, subst, 
-                ↓reduceIte, decre, if_neg hlt] 
+              simp_all only [not_lt, sub, subst,
+                ↓reduceIte, decre, if_neg hlt]
               cases em (m < k) with
-              | inl hlt => 
-                  simp_all only [↓reduceIte, subst, decre, 
-                    right_eq_ite_iff, var.injEq] 
+              | inl hlt =>
+                  simp_all only [↓reduceIte, subst, decre,
+                    right_eq_ite_iff, var.injEq]
                   intro h
                   have nh : ¬(n + m < k - 1) := by omega
                   exact (nh h).elim
               | inr hlt =>
                   have hneq : ¬(k = n + m) := by omega
                   have hnlt : ¬(m < k) := by omega
-                  simp_all only [not_false_eq_true, not_lt, if_neg hnlt, subst, 
-                    ↓reduceIte, decre, right_eq_ite_iff, var.injEq] 
+                  simp_all only [not_false_eq_true, not_lt, if_neg hnlt, subst,
+                    ↓reduceIte, decre, right_eq_ite_iff, var.injEq]
                   intro h
                   have nh : ¬(n + m < k) := by omega
                   exact (nh h).elim
 
-theorem sub_comm {t : Term} {n m s u} : 
-    ((t.sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u)) 
+theorem sub_comm {t : Term} {n m s u} :
+    ((t.sub ((n + m) + 1) (incre 1 m u)).sub m (s.sub (n + m) u))
     = ((t.sub m s).sub (n + m) u) := by
   induction t generalizing n m s u with
   | var k => exact sub_comm_var
   | abs t' ih =>
-      have : ∀ k, (incre 1 0 (decre k (subst k (incre 1 k u) s))) = 
+      have : ∀ k, (incre 1 0 (decre k (subst k (incre 1 k u) s))) =
           (decre (k + 1) (subst (k + 1) (incre 1 (k + 1)
           (incre 1 0 u)) (incre 1 0 s))) := by
         intro k
         simpa using
-        (sub_lift_zero (t := s) (n := k) (u := u) (i := 0)).symm 
+        (sub_lift_zero (t := s) (n := k) (u := u) (i := 0)).symm
       simpa [← incre_comm_zero, this] using
         (ih (n := n) (m := m + 1) (u := incre 1 0 u) (s := incre 1 0 s))
   | app t₁ t₂ ih₁ ih₂ => simp_all
 
-theorem sub_sub_incre {t : Term} {n k u s} : 
-    ((t.sub (n + 1) (incre (1 + k) 0 u)).sub 0 (s.sub n (incre k 0 u))) 
+theorem sub_sub_incre {t : Term} {n k u s} :
+    ((t.sub (n + 1) (incre (1 + k) 0 u)).sub 0 (s.sub n (incre k 0 u)))
     = ((t.sub 0 s).sub n (incre k 0 u)) := by
   have h' :
       ((t.sub (n + 1) (incre 1 0 (incre k 0 u))).sub 0
@@ -330,4 +330,3 @@ theorem sub_sub_incre {t : Term} {n k u s} :
 
 end Term
 end Lambda
-

--- a/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
+++ b/Mathlib/Computability/LambdaCalculus/DeBruijnSyntax.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Zayn Wang, Markym Radziwill
+Authors: Zayn Wang, Maksym Radziwill
 -/
 import Mathlib.Data.Nat.Basic
 

--- a/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
@@ -43,7 +43,7 @@ inductive Par : Term → Term → Prop
   | var (n) : Par (𝕧 n) (𝕧 n)
   | abs {t t'} : Par t t' → Par (λ.t) (λ.t')
   | app {t t' u u'} : Par t t' → Par u u' → Par (t·u) (t'·u')
-  | red {t t' s s'} : Par t t' → Par s s' → 
+  | red {t t' s s'} : Par t t' → Par s s' →
       Par ((λ.t)·s) (t'.sub 0 s')
 abbrev ParStar := Relation.ReflTransGen Par
 
@@ -63,19 +63,19 @@ theorem beta_subset_par {a b} (h : Beta a b) : Par a b := by
   | red t s  => exact Par.red par_refl par_refl
 
 /-- Simulation lemma: `Par ⊆ BetaStar`. -/
-theorem par_subset_betaStar {a b} (h : Par a b) : 
+theorem par_subset_betaStar {a b} (h : Par a b) :
     BetaStar a b := by
   induction h with
   | var n => exact BetaStar.refl (𝕧 n)
   | app hpt hpu hbt hbu =>
-      exact BetaStar.trans 
+      exact BetaStar.trans
               (BetaStar.appL hbt) (BetaStar.appR hbu)
   | abs h ht => exact BetaStar.abs ht
   | red ht hs iht ihs =>
       exact BetaStar.trans (BetaStar.appL (BetaStar.abs iht))
         (BetaStar.tail (BetaStar.appR ihs) (Beta.red _ _))
 
-@[simp] theorem incre_par {a b i l} (h : Par a b) : 
+@[simp] theorem incre_par {a b i l} (h : Par a b) :
     Par (incre i l a) (incre i l b) := by
   induction h generalizing l with
   | var n => exact par_refl
@@ -95,37 +95,37 @@ lemma par_subst {t t' u u'} (ht : Par t t') (hu : Par u u')
   (k : Nat) (n : Nat) :
     Par (t.sub n (incre k 0 u)) (t'.sub n (incre k 0 u')) := by
   match t, t' with
-  | var t, var t' => match ht with 
+  | var t, var t' => match ht with
       | Par.var t => cases em (t = n) with
           | inl h => simp_all
           | inr h => cases em (t < n) with
               | inl h' => simp_all
               | inr h' =>
-                  simp_all [ (Nat.lt_of_le_of_ne 
+                  simp_all [ (Nat.lt_of_le_of_ne
                       (Nat.le_of_not_gt h') (Ne.symm h))]
   | abs t, abs t' => match ht with
       | Par.abs ht' =>
-          have hp := Par.abs 
+          have hp := Par.abs
             (par_subst ht' hu (1 + k) (n + 1))
           simp_all [← incre_comm_zero]
   | app t₁ t₂, t' => match t₁ with
       | abs t₁ => match ht with
           | Par.app ht₁ ht₂ =>
-              exact Par.app 
+              exact Par.app
                 (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
           | Par.red ht₁ ht₂ =>
-              have hp := Par.red 
-                (par_subst ht₁ hu (1 + k) (n + 1)) 
+              have hp := Par.red
+                (par_subst ht₁ hu (1 + k) (n + 1))
                 (par_subst ht₂ hu k n)
               rw [sub_sub_incre] at hp
               simp_all [← incre_comm_zero]
       | var t₁ => match ht with
           | Par.app ht₁ ht₂ =>
-              exact Par.app 
+              exact Par.app
                 (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
       | app t₁ t₁' => match ht with
           | Par.app ht₁ ht₂ =>
-              exact Par.app 
+              exact Par.app
                 (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
 
 /-- Complete development (maximal Par) for a term. -/
@@ -158,16 +158,16 @@ theorem par_to_dev {t u} (h : Par t u) : Par u (t.dev) := by
       | Par.app ht hu =>
           rename_i u u'
           match t, u with
-          | abs t, abs u => match ht with 
+          | abs t, abs u => match ht with
               | Par.abs ht' =>
-                exact Par.red 
+                exact Par.red
                   (par_to_dev ht') (par_to_dev hu)
-          | var _, _ => 
+          | var _, _ =>
               exact Par.app (par_to_dev ht) (par_to_dev hu)
-          | app _ _, _ => 
+          | app _ _, _ =>
               exact Par.app (par_to_dev ht) (par_to_dev hu)
       | Par.red hu ht =>
-          have hp := par_subst 
+          have hp := par_subst
             (par_to_dev hu) (par_to_dev ht) 0 0
           repeat rw [incre_rfl] at hp
           exact hp

--- a/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 zayn7lie. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zayn Wang
 -/
-import Mathlib.Computability.LambdaCalculus.BetaReduction
+module
+
+public import Mathlib.Computability.LambdaCalculus.BetaReduction
 
 /-!
 # Parallel β-reduction and complete developments
@@ -39,23 +41,23 @@ namespace Lambda
 open Term
 
 /-- Parallel β-reduction (syntax-directed). -/
-inductive Par : Term → Term → Prop
+public inductive Par : Term → Term → Prop
   | var (n) : Par (𝕧 n) (𝕧 n)
   | abs {t t'} : Par t t' → Par (λ.t) (λ.t')
   | app {t t' u u'} : Par t t' → Par u u' → Par (t·u) (t'·u')
   | red {t t' s s'} : Par t t' → Par s s' →
       Par ((λ.t)·s) (t'.sub 0 s')
-abbrev ParStar := Relation.ReflTransGen Par
+public abbrev ParStar := Relation.ReflTransGen Par
 
 /-- reflexivity of Par. -/
-@[simp] theorem par_refl {t} : Par t t := by
+@[simp] public theorem par_refl {t} : Par t t := by
   induction t with
   | var n => exact Par.var n
   | app t u iht ihu => exact Par.app iht ihu
   | abs t iht => exact Par.abs iht
 
 /-- `Beta ⊆ Par`. -/
-theorem beta_subset_par {a b} (h : Beta a b) : Par a b := by
+public theorem beta_subset_par {a b} (h : Beta a b) : Par a b := by
   induction h with
   | appL h ih => exact Par.app ih par_refl
   | appR h ih => exact Par.app par_refl ih
@@ -63,7 +65,7 @@ theorem beta_subset_par {a b} (h : Beta a b) : Par a b := by
   | red t s  => exact Par.red par_refl par_refl
 
 /-- Simulation lemma: `Par ⊆ BetaStar`. -/
-theorem par_subset_betaStar {a b} (h : Par a b) :
+public theorem par_subset_betaStar {a b} (h : Par a b) :
     BetaStar a b := by
   induction h with
   | var n => exact BetaStar.refl (𝕧 n)
@@ -75,7 +77,7 @@ theorem par_subset_betaStar {a b} (h : Par a b) :
       exact BetaStar.trans (BetaStar.appL (BetaStar.abs iht))
         (BetaStar.tail (BetaStar.appR ihs) (Beta.red _ _))
 
-@[simp] theorem incre_par {a b i l} (h : Par a b) :
+@[simp] public theorem incre_par {a b i l} (h : Par a b) :
     Par (incre i l a) (incre i l b) := by
   induction h generalizing l with
   | var n => exact par_refl
@@ -91,7 +93,7 @@ theorem par_subset_betaStar {a b} (h : Par a b) :
       exact Par.red iht ihs
 
 /-- Substitution lemma for `par_to_dev`. -/
-lemma par_subst {t t' u u'} (ht : Par t t') (hu : Par u u')
+private lemma par_subst {t t' u u'} (ht : Par t t') (hu : Par u u')
   (k : Nat) (n : Nat) :
     Par (t.sub n (incre k 0 u)) (t'.sub n (incre k 0 u')) := by
   match t, t' with
@@ -129,14 +131,14 @@ lemma par_subst {t t' u u'} (ht : Par t t') (hu : Par u u')
                 (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
 
 /-- Complete development (maximal Par) for a term. -/
-def Term.dev : Term → Term
+public def Term.dev : Term → Term
   | 𝕧 n     => 𝕧 n
   | λ.t     => λ.(t.dev)
   | (λ.t)·s => t.dev.sub 0 s.dev
   | t·u     => t.dev·u.dev
 
 /-- t.dev is a par reduction for t. -/
-theorem par_dev (t : Term) : Par t t.dev :=
+public theorem par_dev (t : Term) : Par t t.dev :=
   match t with
   | 𝕧 n     => Par.var n
   | λ.t     => Par.abs (par_dev t)
@@ -147,7 +149,7 @@ theorem par_dev (t : Term) : Par t t.dev :=
       | app t₁ t₂ => Par.app (par_dev (t₁·t₂)) (par_dev u)
 
 /-- t.dev is max par reduction for t. -/
-theorem par_to_dev {t u} (h : Par t u) : Par u (t.dev) := by
+public theorem par_to_dev {t u} (h : Par t u) : Par u (t.dev) := by
   match t, u with
   | var t', var u' =>
       match h with | Par.var t' => exact Par.var t'

--- a/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
+++ b/Mathlib/Computability/LambdaCalculus/ParallelReduction.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 zayn7lie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zayn Wang
+-/
+import Mathlib.Computability.LambdaCalculus.BetaReduction
+
+/-!
+# Parallel β-reduction and complete developments
+
+This file defines parallel β-reduction on de Bruijn lambda terms.  Parallel reduction
+contracts β-redexes across a term in a syntax-directed way, and it is the key technical
+device used later to prove the Church–Rosser theorem.
+
+The file also defines the complete development `Term.dev` of a term and proves that every
+parallel reduct further reduces in parallel to this complete development.
+
+## Main definitions
+
+* `Lambda.Par`: parallel β-reduction.
+* `Lambda.ParStar`: the reflexive-transitive closure of `Par`.
+* `Term.dev`: the complete development of a term.
+
+## Main lemmas
+
+* `par_refl`: reflexivity of parallel reduction.
+* `beta_subset_par`: every β-step is a parallel step.
+* `par_subset_betaStar`: every parallel step induces a β-reduction sequence.
+* `incre_par`: parallel reduction is preserved by shifting.
+* `par_subst`: parallel reduction is preserved by substitution.
+* `par_dev`: every term parallel-reduces to its complete development.
+* `par_to_dev`: every parallel reduct of a term further parallel-reduces to the complete
+  development of the original term.
+
+These results provide the diamond argument used in the final Church–Rosser proof.
+-/
+
+namespace Lambda
+open Term
+
+/-- Parallel β-reduction (syntax-directed). -/
+inductive Par : Term → Term → Prop
+  | var (n) : Par (𝕧 n) (𝕧 n)
+  | abs {t t'} : Par t t' → Par (λ.t) (λ.t')
+  | app {t t' u u'} : Par t t' → Par u u' → Par (t·u) (t'·u')
+  | red {t t' s s'} : Par t t' → Par s s' → 
+      Par ((λ.t)·s) (t'.sub 0 s')
+abbrev ParStar := Relation.ReflTransGen Par
+
+/-- reflexivity of Par. -/
+@[simp] theorem par_refl {t} : Par t t := by
+  induction t with
+  | var n => exact Par.var n
+  | app t u iht ihu => exact Par.app iht ihu
+  | abs t iht => exact Par.abs iht
+
+/-- `Beta ⊆ Par`. -/
+theorem beta_subset_par {a b} (h : Beta a b) : Par a b := by
+  induction h with
+  | appL h ih => exact Par.app ih par_refl
+  | appR h ih => exact Par.app par_refl ih
+  | abs h ih  => exact Par.abs ih
+  | red t s  => exact Par.red par_refl par_refl
+
+/-- Simulation lemma: `Par ⊆ BetaStar`. -/
+theorem par_subset_betaStar {a b} (h : Par a b) : 
+    BetaStar a b := by
+  induction h with
+  | var n => exact BetaStar.refl (𝕧 n)
+  | app hpt hpu hbt hbu =>
+      exact BetaStar.trans 
+              (BetaStar.appL hbt) (BetaStar.appR hbu)
+  | abs h ht => exact BetaStar.abs ht
+  | red ht hs iht ihs =>
+      exact BetaStar.trans (BetaStar.appL (BetaStar.abs iht))
+        (BetaStar.tail (BetaStar.appR ihs) (Beta.red _ _))
+
+@[simp] theorem incre_par {a b i l} (h : Par a b) : 
+    Par (incre i l a) (incre i l b) := by
+  induction h generalizing l with
+  | var n => exact par_refl
+  | abs ht ih => exact Par.abs ih
+  | app ht hu iht ihu => exact Par.app iht ihu
+  | red ht hs iht ihs =>
+      have hsub {t s : Term} :
+          (incre i (l + 1) t).sub 0 (incre i l s) =
+          incre i l (t.sub 0 s) := by
+        simpa using
+          (incre_sub (i := i) (l := l) (n := 0) (t := t) (s := s))
+      rw [← hsub]
+      exact Par.red iht ihs
+
+/-- Substitution lemma for `par_to_dev`. -/
+lemma par_subst {t t' u u'} (ht : Par t t') (hu : Par u u')
+  (k : Nat) (n : Nat) :
+    Par (t.sub n (incre k 0 u)) (t'.sub n (incre k 0 u')) := by
+  match t, t' with
+  | var t, var t' => match ht with 
+      | Par.var t => cases em (t = n) with
+          | inl h => simp_all
+          | inr h => cases em (t < n) with
+              | inl h' => simp_all
+              | inr h' =>
+                  simp_all [ (Nat.lt_of_le_of_ne 
+                      (Nat.le_of_not_gt h') (Ne.symm h))]
+  | abs t, abs t' => match ht with
+      | Par.abs ht' =>
+          have hp := Par.abs 
+            (par_subst ht' hu (1 + k) (n + 1))
+          simp_all [← incre_comm_zero]
+  | app t₁ t₂, t' => match t₁ with
+      | abs t₁ => match ht with
+          | Par.app ht₁ ht₂ =>
+              exact Par.app 
+                (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
+          | Par.red ht₁ ht₂ =>
+              have hp := Par.red 
+                (par_subst ht₁ hu (1 + k) (n + 1)) 
+                (par_subst ht₂ hu k n)
+              rw [sub_sub_incre] at hp
+              simp_all [← incre_comm_zero]
+      | var t₁ => match ht with
+          | Par.app ht₁ ht₂ =>
+              exact Par.app 
+                (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
+      | app t₁ t₁' => match ht with
+          | Par.app ht₁ ht₂ =>
+              exact Par.app 
+                (par_subst ht₁ hu k n) (par_subst ht₂ hu k n)
+
+/-- Complete development (maximal Par) for a term. -/
+def Term.dev : Term → Term
+  | 𝕧 n     => 𝕧 n
+  | λ.t     => λ.(t.dev)
+  | (λ.t)·s => t.dev.sub 0 s.dev
+  | t·u     => t.dev·u.dev
+
+/-- t.dev is a par reduction for t. -/
+theorem par_dev (t : Term) : Par t t.dev :=
+  match t with
+  | 𝕧 n     => Par.var n
+  | λ.t     => Par.abs (par_dev t)
+  | (λ.t)·u => Par.red (par_dev t) (par_dev u)
+  | t·u => match t with
+      | var n     => Par.app (Par.var n) (par_dev u)
+      | abs t'    => Par.red (par_dev t') (par_dev u)
+      | app t₁ t₂ => Par.app (par_dev (t₁·t₂)) (par_dev u)
+
+/-- t.dev is max par reduction for t. -/
+theorem par_to_dev {t u} (h : Par t u) : Par u (t.dev) := by
+  match t, u with
+  | var t', var u' =>
+      match h with | Par.var t' => exact Par.var t'
+  | abs t', abs u' =>
+      match h with
+      | Par.abs h' => exact Par.abs (par_to_dev h')
+  | app t t', _ => match h with
+      | Par.app ht hu =>
+          rename_i u u'
+          match t, u with
+          | abs t, abs u => match ht with 
+              | Par.abs ht' =>
+                exact Par.red 
+                  (par_to_dev ht') (par_to_dev hu)
+          | var _, _ => 
+              exact Par.app (par_to_dev ht) (par_to_dev hu)
+          | app _ _, _ => 
+              exact Par.app (par_to_dev ht) (par_to_dev hu)
+      | Par.red hu ht =>
+          have hp := par_subst 
+            (par_to_dev hu) (par_to_dev ht) 0 0
+          repeat rw [incre_rfl] at hp
+          exact hp
+
+end Lambda


### PR DESCRIPTION
This PR develops a small, self-contained formalization of the untyped λ-calculus
(using de Bruijn indices), culminating in a proof of the Church–Rosser theorem
via parallel β-reduction (complete developments).

## Main contributions

* A de Bruijn syntax for λ-terms together with substitution and shifting operations.
* Definition of one-step β-reduction.
* Definition of parallel β-reduction (`Par`) and its basic properties.
* Abstract confluence infrastructure (`Diamond`, `Confluent`) for binary relations.
* Proof that parallel β-reduction satisfies the diamond property.
* Deduction of confluence of β-reduction (Church–Rosser theorem) via standard closure arguments.

The development follows the classical proof strategy:
parallel reduction → diamond → confluence → Church–Rosser.

## Design choices

* De Bruijn indices are used to avoid α-equivalence bookkeeping.
* Parallel reduction is defined inductively to enable a direct diamond proof.
* Confluence lemmas are factored through generic relation-theoretic definitions
  (`Diamond`, `Confluent`) to keep the proof modular.

## Future directions

* Integration with existing rewriting / relation infrastructure in mathlib.
* Extending to typed λ-calculi (e.g. STLC) or normalization results.
* Aligning substitution/shifting APIs with mathlib conventions if similar
  infrastructure is introduced elsewhere.

## Notes for reviewers

* The core proof follows the standard "complete developments" argument;
  feedback on structuring the confluence layer to better match mathlib
  conventions would be especially appreciated.
* Naming and API surface (especially substitution / shifting) may benefit
  from further alignment with existing libraries.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
