### PR TITLE
[Merged by Bors] - chore: fix a diamond in NNReal

### DIFF
--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -59,20 +59,6 @@ def NNReal := { r : ℝ // 0 ≤ r }
 
 namespace NNReal
 
-deriving instance
-  Nontrivial, Inhabited,
-  PartialOrder, SemilatticeSup, SemilatticeInf, DistribLattice,
-  Zero, One, Semiring, CommMonoidWithZero, CommSemiring, AddCancelCommMonoid,
-  Sub, OrderedSub, OrderBot,
-  CanonicallyOrderedAdd, NoZeroDivisors, DenselyOrdered,
-  Archimedean, MulArchimedean, IsOrderedRing, IsStrictOrderedRing
-  for NNReal
-
-noncomputable section
-deriving instance LinearOrder for NNReal
-end
-
-
 @[inherit_doc] scoped notation "ℝ≥0" => NNReal
 
 /-- Coercion `ℝ≥0 → ℝ`. -/
@@ -82,6 +68,25 @@ instance : Coe ℝ≥0 ℝ := ⟨toReal⟩
 
 /-- Constructor of ℝ≥0 from a nonnegative real number -/
 protected def mk (x : ℝ) (hx : 0 ≤ x) : ℝ≥0 := ⟨x, hx⟩
+
+instance : Zero ℝ≥0 := ⟨.mk 0 le_rfl⟩
+instance : One ℝ≥0 := ⟨.mk 1 zero_le_one⟩
+instance : Bot ℝ≥0 := ⟨0⟩
+
+deriving instance
+  Nontrivial, Inhabited,
+  PartialOrder, SemilatticeSup, SemilatticeInf, DistribLattice,
+  Semiring, CommMonoidWithZero, CommSemiring, AddCancelCommMonoid,
+  Sub, OrderedSub, OrderBot,
+  CanonicallyOrderedAdd, NoZeroDivisors, DenselyOrdered,
+  Archimedean, MulArchimedean, IsOrderedRing, IsStrictOrderedRing
+  for NNReal
+
+noncomputable section
+deriving instance LinearOrder for NNReal
+end
+
+example : (0 : ℝ≥0) = ⊥ := by with_reducible_and_instances rfl
 
 -- a computable copy of `Nonneg.instNNRatCast`
 instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, r.cast_nonneg⟩


### PR DESCRIPTION
Currently, 0 and bot are not reducibly defeq in NNReal

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
