### PR TITLE
[Merged by Bors] - feat(LinearAlgebra): add AlternatingMap.map_add_univ, map_smul_univ, and Matrix.map_neg

### DIFF
--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -625,9 +625,9 @@ theorem map_add_univ [DecidableEq ι] [Fintype ι] (m m' : ι → M) :
     f (m + m') = ∑ s : Finset ι, f (s.piecewise m m') :=
   f.toMultilinearMap.map_add_univ m m'
 
-theorem map_smul_univ {R' : Type*} [CommSemiring R'] {M₁ : Type*} [AddCommMonoid M₁]
-    [Module R' M₁] {N₁ : Type*} [AddCommMonoid N₁] [Module R' N₁] [Fintype ι]
-    (f : M₁ [⋀^ι]→ₗ[R'] N₁) (c : ι → R') (m : ι → M₁) :
+theorem map_smul_univ {R : Type*} [CommSemiring R] {M : Type*} [AddCommMonoid M]
+    [Module R M] {N : Type*} [AddCommMonoid N] [Module R N] [Fintype ι]
+    (f : M [⋀^ι]→ₗ[R] N) (c : ι → R) (m : ι → M) :
     (f fun i => c i • m i) = (∏ i, c i) • f m :=
   f.toMultilinearMap.map_smul_univ c m
 

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -621,6 +621,16 @@ theorem map_update_sum {α : Type*} [DecidableEq ι] (t : Finset α) (i : ι) (g
     f (update m i (∑ a ∈ t, g a)) = ∑ a ∈ t, f (update m i (g a)) :=
   f.toMultilinearMap.map_update_sum t i g m
 
+theorem map_add_univ [DecidableEq ι] [Fintype ι] (m m' : ι → M) :
+    f (m + m') = ∑ s : Finset ι, f (s.piecewise m m') :=
+  f.toMultilinearMap.map_add_univ m m'
+
+theorem map_smul_univ {R' : Type*} [CommSemiring R'] {M₁ : Type*} [AddCommMonoid M₁]
+    [Module R' M₁] {N₁ : Type*} [AddCommMonoid N₁] [Module R' N₁] [Fintype ι]
+    (f : M₁ [⋀^ι]→ₗ[R'] N₁) (c : ι → R') (m : ι → M₁) :
+    (f fun i => c i • m i) = (∏ i, c i) • f m :=
+  f.toMultilinearMap.map_smul_univ c m
+
 end
 
 /-!

--- a/Mathlib/LinearAlgebra/Matrix/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Defs.lean
@@ -281,6 +281,10 @@ protected theorem map_add [Add α] [Add β] (f : α → β) (hf : ∀ a₁ a₂,
     (M N : Matrix m n α) : (M + N).map f = M.map f + N.map f :=
   ext fun _ _ => hf _ _
 
+protected theorem map_neg [Neg α] [Neg β] (f : α → β) (hf : ∀ a, f (-a) = -f a)
+    (M : Matrix m n α) : (-M).map f = -(M.map f) :=
+  ext fun _ _ => hf _
+
 protected theorem map_sub [Sub α] [Sub β] (f : α → β) (hf : ∀ a₁ a₂, f (a₁ - a₂) = f a₁ - f a₂)
     (M N : Matrix m n α) : (M - N).map f = M.map f - N.map f :=
   ext fun _ _ => hf _ _


### PR DESCRIPTION
This PR adds missing API lemmas requested during review of #37625:

- `AlternatingMap.map_add_univ`: additivity along all coordinates, mirroring `MultilinearMap.map_add_univ`
- `AlternatingMap.map_smul_univ`: multiplicativity along all coordinates, mirroring `MultilinearMap.map_smul_univ`
- `Matrix.map_neg`: negation distributes over `Matrix.map`, complementing `Matrix.map_add` and `Matrix.map_sub`

---