### PR TITLE
[Merged by Bors] - feat(Order/Cover): intervals equal singletons iff

### DIFF
--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -115,6 +115,9 @@ lemma IsAtom.ne_bot_iff_eq (ha : IsAtom a) (hba : b ≤ a) : b ≠ ⊥ ↔ b = a
 theorem IsAtom.Iic_eq (h : IsAtom a) : Set.Iic a = {⊥, a} :=
   Set.ext fun _ => h.le_iff
 
+lemma Set.Iio_eq_singleton_bot_iff : Iio a = {⊥} ↔ IsAtom a := by
+  simp [IsAtom, superset_antisymm_iff, bot_lt_iff_ne_bot]
+
 @[simp]
 theorem bot_covBy_iff : ⊥ ⋖ a ↔ IsAtom a := by
   simp only [CovBy, bot_lt_iff_ne_bot, IsAtom, not_imp_not]
@@ -208,6 +211,9 @@ lemma IsCoatom.ne_top_iff_eq (ha : IsCoatom a) (hab : a ≤ b) : b ≠ ⊤ ↔ b
 
 theorem IsCoatom.Ici_eq (h : IsCoatom a) : Set.Ici a = {⊤, a} :=
   h.dual.Iic_eq
+
+lemma Set.Ioi_eq_singleton_top_iff : Ioi a = {⊤} ↔ IsCoatom a := by
+  simp [IsCoatom, superset_antisymm_iff, lt_top_iff_ne_top]
 
 @[simp]
 theorem covBy_top_iff : a ⋖ ⊤ ↔ IsCoatom a :=

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -444,6 +444,16 @@ theorem Set.Ioo_eq_singleton_iff : Ioo a b = {c} ↔ a ⋖ c ∧ c ⋖ b where
     ⟨fun ⟨hxa, hxb⟩ ↦ le_antisymm (hcb.le_of_lt hxb) (hac.ge_of_gt hxa),
       fun | rfl => ⟨hac.lt, hcb.lt⟩⟩
 
+@[to_dual]
+theorem Set.Ioi_eq_singleton_iff : Ioi a = {b} ↔ IsTop b ∧ a ⋖ b where
+  mp h :=
+    have h := Set.ext_iff.mp h
+    have hb : a < b := (h b).mpr rfl
+    ⟨fun c ↦ not_lt.mp fun hc ↦ hc.ne.symm ((h c).mp (hb.trans hc)),
+      ⟨hb, fun c hac hcb ↦ hcb.ne ((h c).mp hac)⟩⟩
+  mpr := fun ⟨hb, ha⟩ ↦ Set.ext_iff.mpr fun c ↦
+    ⟨fun hc ↦ le_antisymm (hb c) (ha.ge_of_gt hc), fun | rfl => ha.lt⟩
+
 @[to_dual unique_right]
 theorem CovBy.unique_left (ha : a ⋖ c) (hb : b ⋖ c) : a = b :=
   (hb.le_of_lt ha.lt).antisymm <| ha.le_of_lt hb.lt

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -402,12 +402,16 @@ theorem Set.Ioc_eq_singleton_iff : Ioc a b = {c} ↔ b = c ∧ a ⋖ b where
 @[to_dual existing]
 theorem Set.Ico_eq_singleton_iff : Ico a b = {c} ↔ a = c ∧ a ⋖ b where
   mp h := by
-    rw [Set.ext_iff] at h
+    simp_rw [Set.ext_iff, mem_Ico, mem_singleton_iff] at h
     have ⟨hac, hcb⟩ := (h c).mpr rfl
     have ha := (h a).mp ⟨le_refl a, hac.trans_lt hcb⟩
     rw [ha] at h ⊢
     exact ⟨rfl, ⟨hcb, fun d hcd hdb ↦ hcd.ne ((h d).mp ⟨hcd.le, hdb⟩).symm⟩⟩
   mpr := fun ⟨rfl, hcov⟩ ↦ hcov.Ico_eq
+
+@[to_dual Ioc_eq_singleton_right_iff]
+lemma Set.Ico_eq_singleton_left_iff : Ico a b = {a} ↔ a ⋖ b := by
+  simp [Ico_eq_singleton_iff]
 
 end PartialOrder
 
@@ -434,26 +438,30 @@ theorem CovBy.Iio_eq (h : a ⋖ b) : Iio b = Iic a := by
 theorem CovBy.Ioo_eq_Ico (h : a ⋖ b) (c : α) : Ioo a c = Ico b c :=
   subset_antisymm (fun _x hx ↦ ⟨h.ge_of_gt hx.1, hx.2⟩) <| Ico_subset_Ioo_left h.lt
 
+@[to_dual none]
 theorem Set.Ioo_eq_singleton_iff : Ioo a b = {c} ↔ a ⋖ c ∧ c ⋖ b where
   mp h := by
-    rw [Set.ext_iff] at h
+    simp_rw [Set.ext_iff, mem_Ioo, mem_singleton_iff] at h
     have ⟨hac, hcb⟩ := (h c).mpr rfl
     exact ⟨⟨hac, fun d had hdc ↦ hdc.ne ((h d).mp ⟨had, hdc.trans hcb⟩)⟩,
       ⟨hcb, fun d hcd hdb ↦ hcd.ne ((h d).mp ⟨hac.trans hcd, hdb⟩).symm⟩⟩
-  mpr := fun ⟨hac, hcb⟩ ↦ Set.ext_iff.mpr fun _x ↦
-    ⟨fun ⟨hxa, hxb⟩ ↦ le_antisymm (hcb.le_of_lt hxb) (hac.ge_of_gt hxa),
-      fun | rfl => ⟨hac.lt, hcb.lt⟩⟩
+  mpr := fun ⟨hac, hcb⟩ ↦ by
+    rw [← Ioc_union_Ico_eq_Ioo hac.lt hcb.lt, hac.Ioc_eq, hcb.Ico_eq, union_self]
 
 @[to_dual]
 theorem Set.Ioi_eq_singleton_iff : Ioi a = {b} ↔ IsTop b ∧ a ⋖ b where
-  mp h :=
-    have h := Set.ext_iff.mp h
+  mp h := by
+    simp_rw [Set.ext_iff, mem_Ioi, mem_singleton_iff] at h
     have hb : a < b := (h b).mpr rfl
-    ⟨fun c ↦ not_lt.mp fun hc ↦ hc.ne.symm ((h c).mp (hb.trans hc)),
+    exact ⟨fun c ↦ not_lt.mp fun hc ↦ hc.ne.symm ((h c).mp (hb.trans hc)),
       ⟨hb, fun c hac hcb ↦ hcb.ne ((h c).mp hac)⟩⟩
-  mpr := fun ⟨hb, ha⟩ ↦ Set.ext_iff.mpr fun c ↦
-    ⟨fun hc ↦ le_antisymm (hb c) (ha.ge_of_gt hc), fun | rfl => ha.lt⟩
+  mpr := fun ⟨hb, hab⟩ ↦ by
+    cases b, hb using IsTop.rec; rwa [← Ioc_top, Ioc_eq_singleton_right_iff]
 
+@[to_dual]
+lemma Set.Ioi_eq_singleton_top_iff [OrderTop α] : Ioi a = {⊤} ↔ a ⋖ ⊤ := by
+  simp [Ioi_eq_singleton_iff]
+  
 @[to_dual unique_right]
 theorem CovBy.unique_left (ha : a ⋖ c) (hb : b ⋖ c) : a = b :=
   (hb.le_of_lt ha.lt).antisymm <| ha.le_of_lt hb.lt

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -395,8 +395,7 @@ theorem Set.Ico_eq_singleton_iff : Ico a b = {c} ↔ a = c ∧ a ⋖ b where
   mp h := by
     simp_rw [Set.ext_iff, mem_Ico, mem_singleton_iff] at h
     have ⟨hac, hcb⟩ := (h c).mpr rfl
-    have ha := (h a).mp ⟨le_refl a, hac.trans_lt hcb⟩
-    rw [ha] at h ⊢
+    obtain rfl := (h a).mp ⟨le_refl a, hac.trans_lt hcb⟩
     exact ⟨rfl, ⟨hcb, fun d hcd hdb ↦ hcd.ne ((h d).mp ⟨hcd.le, hdb⟩).symm⟩⟩
   mpr := fun ⟨rfl, hcov⟩ ↦ hcov.Ico_eq
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -448,10 +448,6 @@ theorem Set.Ioi_eq_singleton_iff : Ioi a = {b} ↔ IsTop b ∧ a ⋖ b where
   mpr := fun ⟨hb, hab⟩ ↦ by
     cases b, hb using IsTop.rec; rwa [← Ioc_top, Ioc_eq_singleton_right_iff]
 
-@[to_dual]
-lemma Set.Ioi_eq_singleton_top_iff [OrderTop α] : Ioi a = {⊤} ↔ a ⋖ ⊤ := by
-  simp [Ioi_eq_singleton_iff]
-
 @[to_dual unique_right]
 theorem CovBy.unique_left (ha : a ⋖ c) (hb : b ⋖ c) : a = b :=
   (hb.le_of_lt ha.lt).antisymm <| ha.le_of_lt hb.lt

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -390,16 +390,7 @@ theorem CovBy.Ico_eq (h : a ⋖ b) : Ico a b = {a} := by
 theorem CovBy.Icc_eq (h : a ⋖ b) : Icc a b = {a, b} :=
   h.wcovBy.Icc_eq
 
-theorem Set.Ioc_eq_singleton_iff : Ioc a b = {c} ↔ b = c ∧ a ⋖ b where
-  mp h := by
-    rw [Set.ext_iff] at h
-    have ⟨hac, hcb⟩ := (h c).mpr rfl
-    have hb := (h b).mp ⟨hac.trans_le hcb, le_refl b⟩
-    rw [hb] at h ⊢
-    exact ⟨rfl, ⟨hac, fun d had hdc ↦ hdc.ne ((h d).mp ⟨had, hdc.le⟩)⟩⟩
-  mpr := fun ⟨rfl, hcov⟩ ↦ hcov.Ioc_eq
-
-@[to_dual existing]
+@[to_dual]
 theorem Set.Ico_eq_singleton_iff : Ico a b = {c} ↔ a = c ∧ a ⋖ b where
   mp h := by
     simp_rw [Set.ext_iff, mem_Ico, mem_singleton_iff] at h
@@ -461,7 +452,7 @@ theorem Set.Ioi_eq_singleton_iff : Ioi a = {b} ↔ IsTop b ∧ a ⋖ b where
 @[to_dual]
 lemma Set.Ioi_eq_singleton_top_iff [OrderTop α] : Ioi a = {⊤} ↔ a ⋖ ⊤ := by
   simp [Ioi_eq_singleton_iff]
-  
+
 @[to_dual unique_right]
 theorem CovBy.unique_left (ha : a ⋖ c) (hb : b ⋖ c) : a = b :=
   (hb.le_of_lt ha.lt).antisymm <| ha.le_of_lt hb.lt

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -390,6 +390,25 @@ theorem CovBy.Ico_eq (h : a ⋖ b) : Ico a b = {a} := by
 theorem CovBy.Icc_eq (h : a ⋖ b) : Icc a b = {a, b} :=
   h.wcovBy.Icc_eq
 
+theorem Set.Ioc_eq_singleton_iff : Ioc a b = {c} ↔ b = c ∧ a ⋖ b where
+  mp h := by
+    rw [Set.ext_iff] at h
+    have ⟨hac, hcb⟩ := (h c).mpr rfl
+    have hb := (h b).mp ⟨hac.trans_le hcb, le_refl b⟩
+    rw [hb] at h ⊢
+    exact ⟨rfl, ⟨hac, fun d had hdc ↦ hdc.ne ((h d).mp ⟨had, hdc.le⟩)⟩⟩
+  mpr := fun ⟨rfl, hcov⟩ ↦ hcov.Ioc_eq
+
+@[to_dual existing]
+theorem Set.Ico_eq_singleton_iff : Ico a b = {c} ↔ a = c ∧ a ⋖ b where
+  mp h := by
+    rw [Set.ext_iff] at h
+    have ⟨hac, hcb⟩ := (h c).mpr rfl
+    have ha := (h a).mp ⟨le_refl a, hac.trans_lt hcb⟩
+    rw [ha] at h ⊢
+    exact ⟨rfl, ⟨hcb, fun d hcd hdb ↦ hcd.ne ((h d).mp ⟨hcd.le, hdb⟩).symm⟩⟩
+  mpr := fun ⟨rfl, hcov⟩ ↦ hcov.Ico_eq
+
 end PartialOrder
 
 section LinearOrder
@@ -414,6 +433,16 @@ theorem CovBy.Iio_eq (h : a ⋖ b) : Iio b = Iic a := by
 @[to_dual]
 theorem CovBy.Ioo_eq_Ico (h : a ⋖ b) (c : α) : Ioo a c = Ico b c :=
   subset_antisymm (fun _x hx ↦ ⟨h.ge_of_gt hx.1, hx.2⟩) <| Ico_subset_Ioo_left h.lt
+
+theorem Set.Ioo_eq_singleton_iff : Ioo a b = {c} ↔ a ⋖ c ∧ c ⋖ b where
+  mp h := by
+    rw [Set.ext_iff] at h
+    have ⟨hac, hcb⟩ := (h c).mpr rfl
+    exact ⟨⟨hac, fun d had hdc ↦ hdc.ne ((h d).mp ⟨had, hdc.trans hcb⟩)⟩,
+      ⟨hcb, fun d hcd hdb ↦ hcd.ne ((h d).mp ⟨hac.trans hcd, hdb⟩).symm⟩⟩
+  mpr := fun ⟨hac, hcb⟩ ↦ Set.ext_iff.mpr fun _x ↦
+    ⟨fun ⟨hxa, hxb⟩ ↦ le_antisymm (hcb.le_of_lt hxb) (hac.ge_of_gt hxa),
+      fun | rfl => ⟨hac.lt, hcb.lt⟩⟩
 
 @[to_dual unique_right]
 theorem CovBy.unique_left (ha : a ⋖ c) (hb : b ⋖ c) : a = b :=


### PR DESCRIPTION
To complement `Set.Icc_eq_singleton_iff`, this introduces:
- `Set.Ioc_eq_singleton_iff` / `Set.Ico_eq_singleton_iff`
- `Set.Ico_eq_singleton_left_iff` / `Set.Ioc_eq_singleton_right_iff`
- `Set.Ioi_eq_singleton_iff` / `Set.Iio_eq_singleton_iff`
- `Set.Ioi_eq_singleton_top_iff` / `Set.Iio_eq_singleton_bot_iff`
- `Set.Ioo_eq_singleton_iff`


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
