### PR TITLE
chore: improve performance in NNReal by only inheriting SMul from Real for MulAction

### DIFF
--- a/Mathlib/Analysis/Convex/Body.lean
+++ b/Mathlib/Analysis/Convex/Body.lean
@@ -141,9 +141,20 @@ instance : SMul ℝ (ConvexBody V) where
 theorem coe_smul (c : ℝ) (K : ConvexBody V) : (↑(c • K) : Set V) = c • (K : Set V) :=
   rfl
 
+variable [ContinuousAdd V]
+
+noncomputable instance : DistribMulAction ℝ (ConvexBody V) :=
+  fast_instance% SetLike.coe_injective.distribMulAction ⟨⟨_, coe_zero⟩, coe_add⟩ coe_smul
+
 @[simp, norm_cast]
 theorem coe_smul' (c : ℝ≥0) (K : ConvexBody V) : (↑(c • K) : Set V) = c • (K : Set V) :=
   rfl
+
+/-- The convex bodies in a fixed space $V$ form a module over the nonnegative reals.
+-/
+noncomputable instance : Module ℝ≥0 (ConvexBody V) where
+  add_smul c d K := SetLike.ext' <| Convex.add_smul K.convex c.coe_nonneg d.coe_nonneg
+  zero_smul K := SetLike.ext' <| Set.zero_smul_set K.nonempty
 
 theorem smul_le_of_le (K : ConvexBody V) (h_zero : 0 ∈ K) {a b : ℝ≥0} (h : a ≤ b) :
     a • K ≤ b • K := by
@@ -156,16 +167,6 @@ theorem smul_le_of_le (K : ConvexBody V) (h_zero : 0 ∈ K) {a b : ℝ≥0} (h :
     rw [← Set.mem_inv_smul_set_iff₀ ha.ne', smul_smul]
     refine Convex.mem_smul_of_zero_mem K.convex h_zero hy (?_ : 1 ≤ a⁻¹ * b)
     rwa [le_inv_mul_iff₀ ha, mul_one]
-
-variable [ContinuousAdd V]
-
-noncomputable instance : DistribMulAction ℝ (ConvexBody V) :=
-  SetLike.coe_injective.distribMulAction ⟨⟨_, coe_zero⟩, coe_add⟩ coe_smul
-
-/-- The convex bodies in a fixed space $V$ form a module over the nonnegative reals. -/
-noncomputable instance : Module ℝ≥0 (ConvexBody V) where
-  add_smul c d K := SetLike.ext' <| Convex.add_smul K.convex c.coe_nonneg d.coe_nonneg
-  zero_smul K := SetLike.ext' <| Set.zero_smul_set K.nonempty
 
 end TVS
 

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -242,14 +242,14 @@ def toRealHom : ℝ≥0 →+* ℝ where
 section Actions
 
 /-- A scalar multiplication over `ℝ` restricts to a scalar multiplication over `ℝ≥0`. -/
-instance {M : Type*} [SMul ℝ M] : SMul ℝ≥0 M :=
+instance {M : Type*} [MulAction ℝ M] : SMul ℝ≥0 M :=
   ⟨fun c m ↦ (c : ℝ) • m⟩
 
 /-- A `MulAction` over `ℝ` restricts to a `MulAction` over `ℝ≥0`. -/
 instance {M : Type*} [MulAction ℝ M] : MulAction ℝ≥0 M :=
   fast_instance% MulAction.compHom M toRealHom.toMonoidHom
 
-theorem smul_def {M : Type*} [SMul ℝ M] (c : ℝ≥0) (x : M) : c • x = (c : ℝ) • x :=
+theorem smul_def {M : Type*} [MulAction ℝ M] (c : ℝ≥0) (x : M) : c • x = (c : ℝ) • x :=
   rfl
 
 instance {M N : Type*} [MulAction ℝ M] [MulAction ℝ N] [SMul M N] [IsScalarTower ℝ M N] :


### PR DESCRIPTION
Partly reverts #37609 which had bad performance impact.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
