### PR TITLE
[Merged by Bors] - chore(Order/Minimal): use `to_dual`

### DIFF
--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -52,15 +52,11 @@ variable {ι α β : Type*}
 section LE
 variable [LE α] {P Q : ι → Prop} {f : ι → α} {i j : ι}
 
-@[simp] lemma minimalFor_eq_iff : MinimalFor (· = j) f i ↔ i = j := by simp +contextual [MinimalFor]
-@[simp] lemma maximalFor_eq_iff : MaximalFor (· = j) f i ↔ i = j := by simp +contextual [MaximalFor]
+@[to_dual (attr := simp)]
+lemma minimalFor_eq_iff : MinimalFor (· = j) f i ↔ i = j := by simp +contextual [MinimalFor]
 
-@[gcongr]
+@[to_dual (attr := gcongr)]
 theorem MinimalFor.anti (h : MinimalFor P f i) (hle : Q ≤ P) (hQ : Q i) : MinimalFor Q f i :=
-  ⟨hQ, (h.le_of_le <| hle · ·)⟩
-
-@[gcongr]
-theorem MaximalFor.anti (h : MaximalFor P f i) (hle : Q ≤ P) (hQ : Q i) : MaximalFor Q f i :=
   ⟨hQ, (h.le_of_le <| hle · ·)⟩
 
 end LE
@@ -70,119 +66,82 @@ variable {P Q : α → Prop} {a x y : α}
 section LE
 variable [LE α]
 
-@[simp] lemma minimalFor_id : MinimalFor P id x ↔ Minimal P x := .rfl
-@[simp] lemma maximalFor_id : MaximalFor P id x ↔ Maximal P x := .rfl
+@[to_dual (attr := simp)]
+lemma minimalFor_id : MinimalFor P id x ↔ Minimal P x := .rfl
 
-@[simp] theorem minimal_toDual : Minimal (fun x ↦ P (ofDual x)) (toDual x) ↔ Maximal P x :=
+@[to_dual (attr := simp)]
+theorem minimal_toDual : Minimal (fun x ↦ P (ofDual x)) (toDual x) ↔ Maximal P x :=
   Iff.rfl
 
+@[to_dual]
 alias ⟨Minimal.of_dual, Minimal.dual⟩ := minimal_toDual
 
-@[simp] theorem maximal_toDual : Maximal (fun x ↦ P (ofDual x)) (toDual x) ↔ Minimal P x :=
-  Iff.rfl
-
-alias ⟨Maximal.of_dual, Maximal.dual⟩ := maximal_toDual
-
-@[simp] theorem minimal_false : ¬ Minimal (fun _ ↦ False) x := by
+@[to_dual (attr := simp)]
+theorem minimal_false : ¬ Minimal (fun _ ↦ False) x := by
   simp [Minimal]
 
-@[simp] theorem maximal_false : ¬ Maximal (fun _ ↦ False) x := by
-  simp [Maximal]
-
-@[simp] theorem minimal_true : Minimal (fun _ ↦ True) x ↔ IsMin x := by
+@[to_dual (attr := simp)] theorem minimal_true : Minimal (fun _ ↦ True) x ↔ IsMin x := by
   simp [IsMin, Minimal]
 
-@[simp] theorem maximal_true : Maximal (fun _ ↦ True) x ↔ IsMax x :=
-  minimal_true (α := αᵒᵈ)
-
-@[simp] theorem minimal_subtype {x : Subtype Q} :
+@[to_dual (attr := simp)]
+theorem minimal_subtype {x : Subtype Q} :
     Minimal (fun x ↦ P x.1) x ↔ Minimal (P ⊓ Q) x := by
   obtain ⟨x, hx⟩ := x
   simp only [Minimal, Subtype.forall, Subtype.mk_le_mk, Pi.inf_apply, inf_Prop_eq]
   tauto
 
-@[simp] theorem maximal_subtype {x : Subtype Q} :
-    Maximal (fun x ↦ P x.1) x ↔ Maximal (P ⊓ Q) x :=
-  minimal_subtype (α := αᵒᵈ)
-
+@[to_dual]
 theorem maximal_true_subtype {x : Subtype P} : Maximal (fun _ ↦ True) x ↔ Maximal P x := by
   obtain ⟨x, hx⟩ := x
   simp [Maximal, hx]
 
-theorem minimal_true_subtype {x : Subtype P} : Minimal (fun _ ↦ True) x ↔ Minimal P x := by
-  obtain ⟨x, hx⟩ := x
-  simp [Minimal, hx]
-
-@[simp] theorem minimal_minimal : Minimal (Minimal P) x ↔ Minimal P x :=
+@[to_dual (attr := simp)]
+theorem minimal_minimal : Minimal (Minimal P) x ↔ Minimal P x :=
   ⟨fun h ↦ h.prop, fun h ↦ ⟨h, fun _ hy hyx ↦ h.le_of_le hy.prop hyx⟩⟩
-
-@[simp] theorem maximal_maximal : Maximal (Maximal P) x ↔ Maximal P x :=
-  minimal_minimal (α := αᵒᵈ)
 
 /-- If `P` is down-closed, then minimal elements satisfying `P` are exactly the globally minimal
 elements satisfying `P`. -/
+@[to_dual
+/-- If `P` is up-closed, then maximal elements satisfying `P` are exactly the globally maximal
+elements satisfying `P`. -/]
 theorem minimal_iff_isMin (hP : ∀ ⦃x y⦄, P y → x ≤ y → P x) : Minimal P x ↔ P x ∧ IsMin x :=
   ⟨fun h ↦ ⟨h.prop, fun _ h' ↦ h.le_of_le (hP h.prop h') h'⟩, fun h ↦ ⟨h.1, fun _ _  h' ↦ h.2 h'⟩⟩
 
-/-- If `P` is up-closed, then maximal elements satisfying `P` are exactly the globally maximal
-elements satisfying `P`. -/
-theorem maximal_iff_isMax (hP : ∀ ⦃x y⦄, P y → y ≤ x → P x) : Maximal P x ↔ P x ∧ IsMax x :=
-  ⟨fun h ↦ ⟨h.prop, fun _ h' ↦ h.le_of_ge (hP h.prop h') h'⟩, fun h ↦ ⟨h.1, fun _ _  h' ↦ h.2 h'⟩⟩
-
+@[to_dual]
 theorem Minimal.mono (h : Minimal P x) (hle : Q ≤ P) (hQ : Q x) : Minimal Q x :=
   ⟨hQ, fun y hQy ↦ h.le_of_le (hle y hQy)⟩
 
-theorem Maximal.mono (h : Maximal P x) (hle : Q ≤ P) (hQ : Q x) : Maximal Q x :=
-  ⟨hQ, fun y hQy ↦ h.le_of_ge (hle y hQy)⟩
-
+@[to_dual]
 theorem Minimal.and_right (h : Minimal P x) (hQ : Q x) : Minimal (fun x ↦ P x ∧ Q x) x :=
   h.mono (fun _ ↦ And.left) ⟨h.prop, hQ⟩
 
+@[to_dual]
 theorem Minimal.and_left (h : Minimal P x) (hQ : Q x) : Minimal (fun x ↦ (Q x ∧ P x)) x :=
   h.mono (fun _ ↦ And.right) ⟨hQ, h.prop⟩
 
-theorem Maximal.and_right (h : Maximal P x) (hQ : Q x) : Maximal (fun x ↦ (P x ∧ Q x)) x :=
-  h.mono (fun _ ↦ And.left) ⟨h.prop, hQ⟩
-
-theorem Maximal.and_left (h : Maximal P x) (hQ : Q x) : Maximal (fun x ↦ (Q x ∧ P x)) x :=
-  h.mono (fun _ ↦ And.right) ⟨hQ, h.prop⟩
-
-@[simp] theorem minimal_eq_iff : Minimal (· = y) x ↔ x = y := by
+@[to_dual (attr := simp)] theorem minimal_eq_iff : Minimal (· = y) x ↔ x = y := by
   simp +contextual [Minimal]
 
-@[simp] theorem maximal_eq_iff : Maximal (· = y) x ↔ x = y := by
-  simp +contextual [Maximal]
-
+@[to_dual]
 theorem not_minimal_iff (hx : P x) : ¬ Minimal P x ↔ ∃ y, P y ∧ y ≤ x ∧ ¬ (x ≤ y) := by
   simp [Minimal, hx]
 
-theorem not_maximal_iff (hx : P x) : ¬ Maximal P x ↔ ∃ y, P y ∧ x ≤ y ∧ ¬ (y ≤ x) :=
-  not_minimal_iff (α := αᵒᵈ) hx
-
+@[to_dual]
 theorem Minimal.or (h : Minimal (fun x ↦ P x ∨ Q x) x) : Minimal P x ∨ Minimal Q x := by
   obtain ⟨h | h, hmin⟩ := h
   · exact .inl ⟨h, fun y hy hyx ↦ hmin (Or.inl hy) hyx⟩
   exact .inr ⟨h, fun y hy hyx ↦ hmin (Or.inr hy) hyx⟩
 
-theorem Maximal.or (h : Maximal (fun x ↦ P x ∨ Q x) x) : Maximal P x ∨ Maximal Q x :=
-  Minimal.or (α := αᵒᵈ) h
-
+@[to_dual]
 theorem minimal_and_iff_right_of_imp (hPQ : ∀ ⦃x⦄, P x → Q x) :
     Minimal (fun x ↦ P x ∧ Q x) x ↔ (Minimal P x) ∧ Q x := by
   simp_rw [and_iff_left_of_imp (fun x ↦ hPQ x), iff_self_and]
   exact fun h ↦ hPQ h.prop
 
+@[to_dual]
 theorem minimal_and_iff_left_of_imp (hPQ : ∀ ⦃x⦄, P x → Q x) :
     Minimal (fun x ↦ Q x ∧ P x) x ↔ Q x ∧ (Minimal P x) := by
   simp_rw [iff_comm, and_comm, minimal_and_iff_right_of_imp hPQ, and_comm]
-
-theorem maximal_and_iff_right_of_imp (hPQ : ∀ ⦃x⦄, P x → Q x) :
-    Maximal (fun x ↦ P x ∧ Q x) x ↔ (Maximal P x) ∧ Q x :=
-  minimal_and_iff_right_of_imp (α := αᵒᵈ) hPQ
-
-theorem maximal_and_iff_left_of_imp (hPQ : ∀ ⦃x⦄, P x → Q x) :
-    Maximal (fun x ↦ Q x ∧ P x) x ↔ Q x ∧ (Maximal P x) :=
-  minimal_and_iff_left_of_imp (α := αᵒᵈ) hPQ
 
 end LE
 
@@ -190,114 +149,82 @@ section Preorder
 
 variable [Preorder α] [Preorder β] {Q : ι → Prop} {f : ι → α} {g : α → β} {i j : ι}
 
+@[to_dual maximal_iff_forall_gt]
 theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → ¬ P y := by
   simp [Minimal, lt_iff_le_not_ge, imp.swap]
 
-theorem maximal_iff_forall_gt : Maximal P x ↔ P x ∧ ∀ ⦃y⦄, x < y → ¬ P y :=
-  minimal_iff_forall_lt (α := αᵒᵈ)
-
+@[to_dual maximalFor_iff_forall_gt]
 theorem minimalFor_iff_forall_lt : MinimalFor Q f i ↔ Q i ∧ ∀ ⦃j⦄, f j < f i → ¬ Q j := by
   simp [MinimalFor, lt_iff_le_not_ge, imp.swap]
 
-theorem maximalFor_iff_forall_gt : MaximalFor Q f i ↔ Q i ∧ ∀ ⦃j⦄, f i < f j → ¬ Q j :=
-  minimalFor_iff_forall_lt (α := αᵒᵈ)
-
+@[to_dual not_prop_of_gt]
 theorem Minimal.not_prop_of_lt (h : Minimal P x) (hlt : y < x) : ¬ P y :=
   (minimal_iff_forall_lt.1 h).2 hlt
 
-theorem Maximal.not_prop_of_gt (h : Maximal P x) (hlt : x < y) : ¬ P y :=
-  (maximal_iff_forall_gt.1 h).2 hlt
-
+@[to_dual not_prop_of_gt]
 theorem MinimalFor.not_prop_of_lt (h : MinimalFor Q f i) (hlt : f j < f i) : ¬ Q j :=
   (minimalFor_iff_forall_lt.1 h).2 hlt
 
-theorem MaximalFor.not_prop_of_gt (h : MaximalFor Q f i) (hgt : f i < f j) : ¬ Q j :=
-  (maximalFor_iff_forall_gt.1 h).2 hgt
-
+@[to_dual not_gt]
 theorem Minimal.not_lt (h : Minimal P x) (hy : P y) : ¬(y < x) :=
   fun hlt ↦ h.not_prop_of_lt hlt hy
 
-theorem Maximal.not_gt (h : Maximal P x) (hy : P y) : ¬(x < y) :=
-  fun hlt ↦ h.not_prop_of_gt hlt hy
-
+@[to_dual not_gt]
 theorem MinimalFor.not_lt (h : MinimalFor Q f i) (hj : Q j) : ¬(f j < f i) :=
   fun hlt ↦ h.not_prop_of_lt hlt hj
 
-theorem MaximalFor.not_gt (h : MaximalFor Q f i) (hj : Q j) : ¬(f i < f j) :=
-  fun hgt ↦ h.not_prop_of_gt hgt hj
-
-@[simp] theorem minimal_le_iff : Minimal (· ≤ y) x ↔ x ≤ y ∧ IsMin x :=
+@[to_dual (attr := simp) maximal_ge_iff]
+theorem minimal_le_iff : Minimal (· ≤ y) x ↔ x ≤ y ∧ IsMin x :=
   minimal_iff_isMin (fun _ _ h h' ↦ h'.trans h)
 
-@[simp] theorem maximal_ge_iff : Maximal (y ≤ ·) x ↔ y ≤ x ∧ IsMax x :=
-  minimal_le_iff (α := αᵒᵈ)
-
-@[simp] theorem minimal_lt_iff : Minimal (· < y) x ↔ x < y ∧ IsMin x :=
+@[to_dual (attr := simp) maximal_gt_iff]
+theorem minimal_lt_iff : Minimal (· < y) x ↔ x < y ∧ IsMin x :=
   minimal_iff_isMin (fun _ _ h h' ↦ h'.trans_lt h)
 
-@[simp] theorem maximal_gt_iff : Maximal (y < ·) x ↔ y < x ∧ IsMax x :=
-  minimal_lt_iff (α := αᵒᵈ)
-
+@[to_dual not_maximal_iff_exists_gt]
 theorem not_minimal_iff_exists_lt (hx : P x) : ¬ Minimal P x ↔ ∃ y, y < x ∧ P y := by
   simp_rw [not_minimal_iff hx, lt_iff_le_not_ge, and_comm]
 
+@[to_dual exists_gt_of_not_maximal]
 alias ⟨exists_lt_of_not_minimal, _⟩ := not_minimal_iff_exists_lt
 
-theorem not_maximal_iff_exists_gt (hx : P x) : ¬ Maximal P x ↔ ∃ y, x < y ∧ P y :=
-  not_minimal_iff_exists_lt (α := αᵒᵈ) hx
-
-alias ⟨exists_gt_of_not_maximal, _⟩ := not_maximal_iff_exists_gt
-
+@[to_dual]
 theorem MinimalFor.of_strictMonoOn_comp (hg : StrictMonoOn g (f '' setOf Q))
     (h : MinimalFor Q (g ∘ f) i) : MinimalFor Q f i := by
   refine ⟨h.prop, fun j hj hle ↦ ?_⟩
   by_contra
   exact h.not_lt hj <| hg ⟨j, hj, rfl⟩ ⟨i, h.prop, rfl⟩ <| lt_of_le_not_ge hle this
 
-theorem MaximalFor.of_strictMonoOn_comp (hg : StrictMonoOn g (f '' setOf Q))
-    (h : MaximalFor Q (g ∘ f) i) : MaximalFor Q f i := by
-  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
-  by_contra
-  exact h.not_gt hj <| hg ⟨i, h.prop, rfl⟩ ⟨j, hj, rfl⟩ <| lt_of_le_not_ge hle this
-
+@[to_dual]
 theorem MinimalFor.minimal_of_strictMonoOn (hg : StrictMonoOn g (setOf P)) (h : MinimalFor P g x) :
     Minimal P x :=
   minimalFor_id.mp <| .of_strictMonoOn_comp (Set.image_id _ ▸ hg) h
 
-theorem MaximalFor.maximal_of_strictMonoOn (hg : StrictMonoOn g (setOf P)) (h : MaximalFor P g x) :
-    Maximal P x :=
-  maximalFor_id.mp <| .of_strictMonoOn_comp (Set.image_id _ ▸ hg) h
-
+@[to_dual]
 theorem MinimalFor.maximalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' setOf Q))
     (h : MinimalFor Q (g ∘ f) i) : MaximalFor Q f i := by
   refine ⟨h.prop, fun j hj hle ↦ ?_⟩
   by_contra
   exact h.not_lt hj <| hg ⟨i, h.prop, rfl⟩ ⟨j, hj, rfl⟩ <| lt_of_le_not_ge hle this
 
-theorem MaximalFor.minimalFor_of_strictAntiOn_comp (hg : StrictAntiOn g (f '' setOf Q))
-    (h : MaximalFor Q (g ∘ f) i) : MinimalFor Q f i := by
-  refine ⟨h.prop, fun j hj hle ↦ ?_⟩
-  by_contra
-  exact h.not_gt hj <| hg ⟨j, hj, rfl⟩ ⟨i, h.prop, rfl⟩ <| lt_of_le_not_ge hle this
-
+@[to_dual]
 theorem MinimalFor.maximal_of_strictAntiOn (hg : StrictAntiOn g (setOf P)) (h : MinimalFor P g x) :
     Maximal P x :=
   maximalFor_id.mp <| MinimalFor.maximalFor_of_strictAntiOn_comp (Set.image_id _ ▸ hg) h
 
-theorem MaximalFor.minimal_of_strictAntiOn (hg : StrictAntiOn g (setOf P)) (h : MaximalFor P g x) :
-    Minimal P x :=
-  minimalFor_id.mp <| MaximalFor.minimalFor_of_strictAntiOn_comp (Set.image_id _ ▸ hg) h
-
 section WellFoundedLT
 variable [WellFoundedLT α]
 
+@[to_dual]
 lemma exists_minimalFor_of_wellFoundedLT (P : ι → Prop) (f : ι → α) (hP : ∃ i, P i) :
     ∃ i, MinimalFor P f i := by
   simpa [not_lt_iff_le_imp_ge, InvImage] using (instIsWellFoundedInvImage (· < ·) f).wf.has_min _ hP
 
+@[to_dual]
 lemma exists_minimal_of_wellFoundedLT (P : α → Prop) (hP : ∃ a, P a) : ∃ a, Minimal P a :=
   exists_minimalFor_of_wellFoundedLT P id hP
 
+@[to_dual exists_maximal_ge_of_wellFoundedGT]
 lemma exists_minimal_le_of_wellFoundedLT (P : α → Prop) (a : α) (ha : P a) :
     ∃ b ≤ a, Minimal P b := by
   obtain ⟨b, ⟨hba, hb⟩, hbmin⟩ :=
@@ -305,66 +232,40 @@ lemma exists_minimal_le_of_wellFoundedLT (P : α → Prop) (a : α) (ha : P a) :
   exact ⟨b, hba, hb, fun c hc hcb ↦ hbmin ⟨hcb.trans hba, hc⟩ hcb⟩
 
 end WellFoundedLT
-
-section WellFoundedGT
-variable [WellFoundedGT α]
-
-lemma exists_maximalFor_of_wellFoundedGT (P : ι → Prop) (f : ι → α) (hP : ∃ i, P i) :
-    ∃ i, MaximalFor P f i := exists_minimalFor_of_wellFoundedLT (α := αᵒᵈ) P f hP
-
-lemma exists_maximal_of_wellFoundedGT (P : α → Prop) (hP : ∃ a, P a) : ∃ a, Maximal P a :=
-  exists_minimal_of_wellFoundedLT (α := αᵒᵈ) P hP
-
-lemma exists_maximal_ge_of_wellFoundedGT (P : α → Prop) (a : α) (ha : P a) :
-    ∃ b, a ≤ b ∧ Maximal P b := exists_minimal_le_of_wellFoundedLT (α := αᵒᵈ) P a ha
-
-end WellFoundedGT
 end Preorder
 
 section PartialOrder
 
 variable [PartialOrder α]
 
+@[to_dual eq_of_le]
 theorem Minimal.eq_of_ge (hx : Minimal P x) (hy : P y) (hge : y ≤ x) : x = y :=
   (hx.2 hy hge).antisymm hge
 
+@[to_dual eq_of_ge]
 theorem Minimal.eq_of_le (hx : Minimal P x) (hy : P y) (hle : y ≤ x) : y = x :=
   (hx.eq_of_ge hy hle).symm
 
-theorem Maximal.eq_of_le (hx : Maximal P x) (hy : P y) (hle : x ≤ y) : x = y :=
-  hle.antisymm <| hx.2 hy hle
-
-theorem Maximal.eq_of_ge (hx : Maximal P x) (hy : P y) (hge : x ≤ y) : y = x :=
-  (hx.eq_of_le hy hge).symm
-
+@[to_dual]
 theorem minimal_iff : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, P y → y ≤ x → x = y :=
   ⟨fun h ↦ ⟨h.1, fun _ ↦ h.eq_of_ge⟩, fun h ↦ ⟨h.1, fun _ hy hle ↦ (h.2 hy hle).le⟩⟩
 
-theorem maximal_iff : Maximal P x ↔ P x ∧ ∀ ⦃y⦄, P y → x ≤ y → x = y :=
-  minimal_iff (α := αᵒᵈ)
-
+@[to_dual]
 theorem minimal_mem_iff {s : Set α} : Minimal (· ∈ s) x ↔ x ∈ s ∧ ∀ ⦃y⦄, y ∈ s → y ≤ x → x = y :=
   minimal_iff
 
-theorem maximal_mem_iff {s : Set α} : Maximal (· ∈ s) x ↔ x ∈ s ∧ ∀ ⦃y⦄, y ∈ s → x ≤ y → x = y :=
-  maximal_iff
-
 /-- If `P y` holds, and everything satisfying `P` is above `y`, then `y` is the unique minimal
 element satisfying `P`. -/
+@[to_dual
+/-- If `P y` holds, and everything satisfying `P` is below `y`, then `y` is the unique maximal
+element satisfying `P`. -/]
 theorem minimal_iff_eq (hy : P y) (hP : ∀ ⦃x⦄, P x → y ≤ x) : Minimal P x ↔ x = y :=
   ⟨fun h ↦ h.eq_of_ge hy (hP h.prop), by rintro rfl; exact ⟨hy, fun z hz _ ↦ hP hz⟩⟩
 
-/-- If `P y` holds, and everything satisfying `P` is below `y`, then `y` is the unique maximal
-element satisfying `P`. -/
-theorem maximal_iff_eq (hy : P y) (hP : ∀ ⦃x⦄, P x → x ≤ y) : Maximal P x ↔ x = y :=
-  minimal_iff_eq (α := αᵒᵈ) hy hP
-
-@[simp] theorem minimal_ge_iff : Minimal (y ≤ ·) x ↔ x = y :=
+@[to_dual (attr := simp) maximal_le_iff] theorem minimal_ge_iff : Minimal (y ≤ ·) x ↔ x = y :=
   minimal_iff_eq rfl.le fun _ ↦ id
 
-@[simp] theorem maximal_le_iff : Maximal (· ≤ y) x ↔ x = y :=
-  maximal_iff_eq rfl.le fun _ ↦ id
-
+@[to_dual]
 theorem minimal_iff_minimal_of_imp_of_forall (hPQ : ∀ ⦃x⦄, Q x → P x)
     (h : ∀ ⦃x⦄, P x → ∃ y, y ≤ x ∧ Q y) : Minimal P x ↔ Minimal Q x := by
   refine ⟨fun h' ↦ ⟨?_, fun y hy hyx ↦ h'.le_of_le (hPQ hy) hyx⟩,
@@ -374,27 +275,19 @@ theorem minimal_iff_minimal_of_imp_of_forall (hPQ : ∀ ⦃x⦄, Q x → P x)
   obtain ⟨z, hzy, hz⟩ := h hy
   exact (h'.le_of_le hz (hzy.trans hyx)).trans hzy
 
-theorem maximal_iff_maximal_of_imp_of_forall (hPQ : ∀ ⦃x⦄, Q x → P x)
-    (h : ∀ ⦃x⦄, P x → ∃ y, x ≤ y ∧ Q y) : Maximal P x ↔ Maximal Q x :=
-  minimal_iff_minimal_of_imp_of_forall (α := αᵒᵈ) hPQ h
-
 end PartialOrder
 
 section LinearOrder
 
 variable [LinearOrder α] {i j : ι} {Q : ι → Prop} {f : ι → α}
 
+@[to_dual]
 theorem Minimal.le (h : Minimal P x) (hy : P y) : x ≤ y :=
   le_of_not_gt (h.not_lt hy)
 
-theorem Maximal.le (h : Maximal P x) (hy : P y) : y ≤ x :=
-  le_of_not_gt (h.not_gt hy)
-
+@[to_dual]
 theorem MinimalFor.le (h : MinimalFor Q f i) (hj : Q j) : f i ≤ f j :=
   le_of_not_gt (h.not_lt hj)
-
-theorem MaximalFor.le (h : MaximalFor Q f i) (hj : Q j) : f j ≤ f i :=
-  le_of_not_gt (h.not_gt hj)
 
 end LinearOrder
 
@@ -488,22 +381,16 @@ section Preorder
 
 variable [Preorder α]
 
+@[to_dual]
 theorem setOf_minimal_subset (s : Set α) : {x | Minimal (· ∈ s) x} ⊆ s :=
   sep_subset ..
 
-theorem setOf_maximal_subset (s : Set α) : {x | Maximal (· ∈ s) x} ⊆ s :=
-  sep_subset ..
-
+@[to_dual]
 theorem Set.Subsingleton.maximal_mem_iff (h : s.Subsingleton) : Maximal (· ∈ s) x ↔ x ∈ s := by
   obtain (rfl | ⟨x, rfl⟩) := h.eq_empty_or_singleton <;> simp
 
-theorem Set.Subsingleton.minimal_mem_iff (h : s.Subsingleton) : Minimal (· ∈ s) x ↔ x ∈ s := by
-  obtain (rfl | ⟨x, rfl⟩) := h.eq_empty_or_singleton <;> simp
-
+@[to_dual]
 theorem IsLeast.minimal (h : IsLeast s x) : Minimal (· ∈ s) x :=
-  ⟨h.1, fun _b hb _ ↦ h.2 hb⟩
-
-theorem IsGreatest.maximal (h : IsGreatest s x) : Maximal (· ∈ s) x :=
   ⟨h.1, fun _b hb _ ↦ h.2 hb⟩
 
 end Preorder
@@ -512,11 +399,9 @@ section PartialOrder
 
 variable [PartialOrder α]
 
+@[to_dual]
 theorem IsLeast.minimal_iff (h : IsLeast s a) : Minimal (· ∈ s) x ↔ x = a :=
   ⟨fun h' ↦ h'.eq_of_ge h.1 (h.2 h'.prop), fun h' ↦ h' ▸ h.minimal⟩
-
-theorem IsGreatest.maximal_iff (h : IsGreatest s a) : Maximal (· ∈ s) x ↔ x = a :=
-  ⟨fun h' ↦ h'.eq_of_le h.1 (h.2 h'.prop), fun h' ↦ h' ▸ h.maximal⟩
 
 end PartialOrder
 
@@ -529,6 +414,8 @@ section Function
 
 variable {f : α → β}
 
+-- TODO: the names in this section are all wrong
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem minimal_mem_image_monotone (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y))
     (hx : Minimal (· ∈ s) x) : Minimal (· ∈ f '' s) (f x) := by
   refine ⟨mem_image_of_mem f hx.prop, ?_⟩
@@ -536,10 +423,7 @@ theorem minimal_mem_image_monotone (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → 
   rw [hf hx.prop hy, hf hy hx.prop]
   exact hx.le_of_le hy
 
-theorem maximal_mem_image_monotone (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y))
-    (hx : Maximal (· ∈ s) x) : Maximal (· ∈ f '' s) (f x) :=
-  minimal_mem_image_monotone (α := αᵒᵈ) (β := βᵒᵈ) (s := s) (fun _ _ hx hy ↦ hf hy hx) hx
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem minimal_mem_image_monotone_iff (ha : a ∈ s)
     (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y)) :
     Minimal (· ∈ f '' s) (f a) ↔ Minimal (· ∈ s) a := by
@@ -547,29 +431,18 @@ theorem minimal_mem_image_monotone_iff (ha : a ∈ s)
   rw [← hf ha hys, ← hf hys ha]
   exact h.le_of_le (mem_image_of_mem f hys)
 
-theorem maximal_mem_image_monotone_iff (ha : a ∈ s)
-    (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y)) :
-    Maximal (· ∈ f '' s) (f a) ↔ Maximal (· ∈ s) a :=
-  minimal_mem_image_monotone_iff (α := αᵒᵈ) (β := βᵒᵈ) (s := s) ha fun _ _ hx hy ↦ hf hy hx
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem minimal_mem_image_antitone (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x))
     (hx : Minimal (· ∈ s) x) : Maximal (· ∈ f '' s) (f x) :=
   minimal_mem_image_monotone (β := βᵒᵈ) (fun _ _ h h' ↦ hf h' h) hx
 
-theorem maximal_mem_image_antitone (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x))
-    (hx : Maximal (· ∈ s) x) : Minimal (· ∈ f '' s) (f x) :=
-  maximal_mem_image_monotone (β := βᵒᵈ) (fun _ _ h h' ↦ hf h' h) hx
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem minimal_mem_image_antitone_iff (ha : a ∈ s)
     (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x)) :
     Minimal (· ∈ f '' s) (f a) ↔ Maximal (· ∈ s) a :=
   maximal_mem_image_monotone_iff (β := βᵒᵈ) ha (fun _ _ h h' ↦ hf h' h)
 
-theorem maximal_mem_image_antitone_iff (ha : a ∈ s)
-    (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x)) :
-    Maximal (· ∈ f '' s) (f a) ↔ Minimal (· ∈ s) a :=
-  minimal_mem_image_monotone_iff (β := βᵒᵈ) ha (fun _ _ h h' ↦ hf h' h)
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem image_monotone_setOf_minimal (hf : ∀ ⦃x y⦄, P x → P y → (f x ≤ f y ↔ x ≤ y)) :
     f '' {x | Minimal P x} = {x | Minimal (∃ x₀, P x₀ ∧ f x₀ = ·) x} := by
   refine Set.ext fun x ↦ ⟨?_, fun h ↦ ?_⟩
@@ -578,33 +451,20 @@ theorem image_monotone_setOf_minimal (hf : ∀ ⦃x y⦄, P x → P y → (f x �
   obtain ⟨y, hy, rfl⟩ := (mem_setOf_eq ▸ h).prop
   exact mem_image_of_mem _ <| (minimal_mem_image_monotone_iff (s := setOf P) hy hf).1 h
 
-theorem image_monotone_setOf_maximal (hf : ∀ ⦃x y⦄, P x → P y → (f x ≤ f y ↔ x ≤ y)) :
-    f '' {x | Maximal P x} = {x | Maximal (∃ x₀, P x₀ ∧ f x₀ = ·) x} :=
-  image_monotone_setOf_minimal (α := αᵒᵈ) (β := βᵒᵈ) (fun _ _ hx hy ↦ hf hy hx)
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem image_antitone_setOf_minimal (hf : ∀ ⦃x y⦄, P x → P y → (f x ≤ f y ↔ y ≤ x)) :
     f '' {x | Minimal P x} = {x | Maximal (∃ x₀, P x₀ ∧ f x₀ = ·) x} :=
   image_monotone_setOf_minimal (β := βᵒᵈ) (fun _ _ hx hy ↦ hf hy hx)
 
-theorem image_antitone_setOf_maximal (hf : ∀ ⦃x y⦄, P x → P y → (f x ≤ f y ↔ y ≤ x)) :
-    f '' {x | Maximal P x} = {x | Minimal (∃ x₀, P x₀ ∧ f x₀ = ·) x} :=
-  image_monotone_setOf_maximal (β := βᵒᵈ) (fun _ _ hx hy ↦ hf hy hx)
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem image_monotone_setOf_minimal_mem (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y)) :
     f '' {x | Minimal (· ∈ s) x} = {x | Minimal (· ∈ f '' s) x} :=
   image_monotone_setOf_minimal hf
 
-theorem image_monotone_setOf_maximal_mem (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ x ≤ y)) :
-    f '' {x | Maximal (· ∈ s) x} = {x | Maximal (· ∈ f '' s) x} :=
-  image_monotone_setOf_maximal hf
-
+@[to_dual (reorder := hf (x y, 3 4))]
 theorem image_antitone_setOf_minimal_mem (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x)) :
     f '' {x | Minimal (· ∈ s) x} = {x | Maximal (· ∈ f '' s) x} :=
   image_antitone_setOf_minimal hf
-
-theorem image_antitone_setOf_maximal_mem (hf : ∀ ⦃x y⦄, x ∈ s → y ∈ s → (f x ≤ f y ↔ y ≤ x)) :
-    f '' {x | Maximal (· ∈ s) x} = {x | Minimal (· ∈ f '' s) x} :=
-  image_antitone_setOf_maximal hf
 
 end Function
 
@@ -612,18 +472,16 @@ namespace OrderEmbedding
 
 variable {f : α ↪o β} {t : Set β}
 
+@[to_dual]
 theorem minimal_mem_image (f : α ↪o β) (hx : Minimal (· ∈ s) x) : Minimal (· ∈ f '' s) (f x) :=
   _root_.minimal_mem_image_monotone (by simp [f.le_iff_le]) hx
 
-theorem maximal_mem_image (f : α ↪o β) (hx : Maximal (· ∈ s) x) : Maximal (· ∈ f '' s) (f x) :=
-  _root_.maximal_mem_image_monotone (by simp [f.le_iff_le]) hx
-
+@[to_dual]
 theorem minimal_mem_image_iff (ha : a ∈ s) : Minimal (· ∈ f '' s) (f a) ↔ Minimal (· ∈ s) a :=
   _root_.minimal_mem_image_monotone_iff ha (by simp [f.le_iff_le])
 
-theorem maximal_mem_image_iff (ha : a ∈ s) : Maximal (· ∈ f '' s) (f a) ↔ Maximal (· ∈ s) a :=
-  _root_.maximal_mem_image_monotone_iff ha (by simp [f.le_iff_le])
-
+attribute [local simp high] OrderEmbedding.eq_iff_eq in
+@[to_dual]
 theorem minimal_apply_mem_inter_range_iff :
     Minimal (· ∈ t ∩ range f) (f x) ↔ Minimal (fun x ↦ f x ∈ t) x := by
   refine ⟨fun h ↦ ⟨h.prop.1, fun y hy ↦ ?_⟩, fun h ↦ ⟨⟨h.prop, by simp⟩, ?_⟩⟩
@@ -633,58 +491,37 @@ theorem minimal_apply_mem_inter_range_iff :
   simp_rw [f.le_iff_le]
   exact h.le_of_le hyt
 
-theorem maximal_apply_mem_inter_range_iff :
-    Maximal (· ∈ t ∩ range f) (f x) ↔ Maximal (fun x ↦ f x ∈ t) x :=
-  f.dual.minimal_apply_mem_inter_range_iff
-
+@[to_dual maximal_apply_iff] -- TODO: make the names consistent
 theorem minimal_apply_mem_iff (ht : t ⊆ Set.range f) :
     Minimal (· ∈ t) (f x) ↔ Minimal (fun x ↦ f x ∈ t) x := by
   rw [← f.minimal_apply_mem_inter_range_iff, inter_eq_self_of_subset_left ht]
 
-theorem maximal_apply_iff (ht : t ⊆ Set.range f) :
-    Maximal (· ∈ t) (f x) ↔ Maximal (fun x ↦ f x ∈ t) x :=
-  f.dual.minimal_apply_mem_iff ht
-
-@[simp] theorem image_setOf_minimal : f '' {x | Minimal (· ∈ s) x} = {x | Minimal (· ∈ f '' s) x} :=
+@[to_dual (attr := simp)]
+theorem image_setOf_minimal : f '' {x | Minimal (· ∈ s) x} = {x | Minimal (· ∈ f '' s) x} :=
   _root_.image_monotone_setOf_minimal (by simp [f.le_iff_le])
 
-@[simp] theorem image_setOf_maximal : f '' {x | Maximal (· ∈ s) x} = {x | Maximal (· ∈ f '' s) x} :=
-  _root_.image_monotone_setOf_maximal (by simp [f.le_iff_le])
-
+@[to_dual]
 theorem inter_preimage_setOf_minimal_eq_of_subset (hts : t ⊆ f '' s) :
     x ∈ s ∩ f ⁻¹' {y | Minimal (· ∈ t) y} ↔ Minimal (· ∈ s ∩ f ⁻¹' t) x := by
   simp_rw [mem_inter_iff, preimage_setOf_eq, mem_setOf_eq, mem_preimage,
     f.minimal_apply_mem_iff (hts.trans (image_subset_range _ _)),
     minimal_and_iff_left_of_imp (fun _ hx ↦ f.injective.mem_set_image.1 <| hts hx)]
 
-theorem inter_preimage_setOf_maximal_eq_of_subset (hts : t ⊆ f '' s) :
-    x ∈ s ∩ f ⁻¹' {y | Maximal (· ∈ t) y} ↔ Maximal (· ∈ s ∩ f ⁻¹' t) x :=
-  f.dual.inter_preimage_setOf_minimal_eq_of_subset hts
-
 end OrderEmbedding
 
 namespace OrderIso
 
+@[to_dual]
 theorem image_setOf_minimal (f : α ≃o β) (P : α → Prop) :
     f '' {x | Minimal P x} = {x | Minimal (fun x ↦ P (f.symm x)) x} := by
   convert _root_.image_monotone_setOf_minimal (f := f) (by simp [f.le_iff_le])
   aesop
 
-theorem image_setOf_maximal (f : α ≃o β) (P : α → Prop) :
-    f '' {x | Maximal P x} = {x | Maximal (fun x ↦ P (f.symm x)) x} := by
-  convert _root_.image_monotone_setOf_maximal (f := f) (by simp [f.le_iff_le])
-  aesop
-
+@[to_dual]
 theorem map_minimal_mem (f : s ≃o t) (hx : Minimal (· ∈ s) x) :
     Minimal (· ∈ t) (f ⟨x, hx.prop⟩) := by
   simpa only [show t = range (Subtype.val ∘ f) by simp, mem_univ, minimal_true_subtype, hx,
     true_imp_iff, image_univ] using OrderEmbedding.minimal_mem_image
-    (f.toOrderEmbedding.trans (OrderEmbedding.subtype (· ∈ t))) (s := univ) (x := ⟨x, hx.prop⟩)
-
-theorem map_maximal_mem (f : s ≃o t) (hx : Maximal (· ∈ s) x) :
-    Maximal (· ∈ t) (f ⟨x, hx.prop⟩) := by
-  simpa only [show t = range (Subtype.val ∘ f) by simp, mem_univ, maximal_true_subtype, hx,
-    true_imp_iff, image_univ] using OrderEmbedding.maximal_mem_image
     (f.toOrderEmbedding.trans (OrderEmbedding.subtype (· ∈ t))) (s := univ) (x := ⟨x, hx.prop⟩)
 
 /-- If two sets are order isomorphic, their minimals are also order isomorphic. -/
@@ -696,6 +533,7 @@ def mapSetOfMinimal (f : s ≃o t) : {x | Minimal (· ∈ s) x} ≃o {x | Minima
   map_rel_iff' := f.map_rel_iff
 
 /-- If two sets are order isomorphic, their maximals are also order isomorphic. -/
+@[to_dual existing]
 def mapSetOfMaximal (f : s ≃o t) : {x | Maximal (· ∈ s) x} ≃o {x | Maximal (· ∈ t) x} where
   toFun x := ⟨f ⟨x, x.2.1⟩, f.map_maximal_mem x.2⟩
   invFun x := ⟨f.symm ⟨x, x.2.1⟩, f.symm.map_maximal_mem x.2⟩
@@ -704,20 +542,13 @@ def mapSetOfMaximal (f : s ≃o t) : {x | Maximal (· ∈ s) x} ≃o {x | Maxima
   map_rel_iff' := f.map_rel_iff
 
 /-- If two sets are antitonically order isomorphic, their minimals/maximals are too. -/
+@[to_dual /-- If two sets are antitonically order isomorphic, their maximals/minimals are too. -/]
 def setOfMinimalIsoSetOfMaximal (f : s ≃o tᵒᵈ) :
     {x | Minimal (· ∈ s) x} ≃o {x | Maximal (· ∈ t) (ofDual x)} where
       toFun x := ⟨(f ⟨x.1, x.2.1⟩).1, ((show s ≃o ofDual ⁻¹' t from f).mapSetOfMinimal x).2⟩
       invFun x := ⟨(f.symm ⟨x.1, x.2.1⟩).1,
         ((show ofDual ⁻¹' t ≃o s from f.symm).mapSetOfMinimal x).2⟩
       __ := (show s ≃o ofDual ⁻¹' t from f).mapSetOfMinimal
-
-/-- If two sets are antitonically order isomorphic, their maximals/minimals are too. -/
-def setOfMaximalIsoSetOfMinimal (f : s ≃o tᵒᵈ) :
-    {x | Maximal (· ∈ s) x} ≃o {x | Minimal (· ∈ t) (ofDual x)} where
-  toFun x := ⟨(f ⟨x.1, x.2.1⟩).1, ((show s ≃o ofDual ⁻¹' t from f).mapSetOfMaximal x).2⟩
-  invFun x := ⟨(f.symm ⟨x.1, x.2.1⟩).1,
-        ((show ofDual ⁻¹' t ≃o s from f.symm).mapSetOfMaximal x).2⟩
-  __ := (show s ≃o ofDual ⁻¹' t from f).mapSetOfMaximal
 
 end OrderIso
 
@@ -726,17 +557,13 @@ section Interval
 
 variable [PartialOrder α] {a b : α}
 
+@[to_dual]
 theorem minimal_mem_Icc (hab : a ≤ b) : Minimal (· ∈ Icc a b) x ↔ x = a :=
   minimal_iff_eq ⟨rfl.le, hab⟩ (fun _ ↦ And.left)
 
-theorem maximal_mem_Icc (hab : a ≤ b) : Maximal (· ∈ Icc a b) x ↔ x = b :=
-  maximal_iff_eq ⟨hab, rfl.le⟩ (fun _ ↦ And.right)
-
+@[to_dual]
 theorem minimal_mem_Ico (hab : a < b) : Minimal (· ∈ Ico a b) x ↔ x = a :=
   minimal_iff_eq ⟨rfl.le, hab⟩ (fun _ ↦ And.left)
-
-theorem maximal_mem_Ioc (hab : a < b) : Maximal (· ∈ Ioc a b) x ↔ x = b :=
-  maximal_iff_eq ⟨hab, rfl.le⟩ (fun _ ↦ And.right)
 
 /- Note : The one-sided interval versions of these lemmas are unnecessary,
 since `simp` handles them with `maximal_le_iff` and `minimal_ge_iff`. -/

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -91,9 +91,9 @@ theorem minimal_subtype {x : Subtype Q} :
   tauto
 
 @[to_dual]
-theorem maximal_true_subtype {x : Subtype P} : Maximal (fun _ ↦ True) x ↔ Maximal P x := by
+theorem minimal_true_subtype {x : Subtype P} : Minimal (fun _ ↦ True) x ↔ Minimal P x := by
   obtain ⟨x, hx⟩ := x
-  simp [Maximal, hx]
+  simp [Minimal, hx]
 
 @[to_dual (attr := simp)]
 theorem minimal_minimal : Minimal (Minimal P) x ↔ Minimal P x :=
@@ -238,11 +238,11 @@ section PartialOrder
 
 variable [PartialOrder α]
 
-@[to_dual eq_of_le]
+@[to_dual (rename := hge → hle) eq_of_le]
 theorem Minimal.eq_of_ge (hx : Minimal P x) (hy : P y) (hge : y ≤ x) : x = y :=
   (hx.2 hy hge).antisymm hge
 
-@[to_dual eq_of_ge]
+@[to_dual (rename := hle → hge) eq_of_ge]
 theorem Minimal.eq_of_le (hx : Minimal P x) (hy : P y) (hle : y ≤ x) : y = x :=
   (hx.eq_of_ge hy hle).symm
 
@@ -386,7 +386,7 @@ theorem setOf_minimal_subset (s : Set α) : {x | Minimal (· ∈ s) x} ⊆ s :=
   sep_subset ..
 
 @[to_dual]
-theorem Set.Subsingleton.maximal_mem_iff (h : s.Subsingleton) : Maximal (· ∈ s) x ↔ x ∈ s := by
+theorem Set.Subsingleton.minimal_mem_iff (h : s.Subsingleton) : Minimal (· ∈ s) x ↔ x ∈ s := by
   obtain (rfl | ⟨x, rfl⟩) := h.eq_empty_or_singleton <;> simp
 
 @[to_dual]
@@ -480,23 +480,23 @@ theorem minimal_mem_image (f : α ↪o β) (hx : Minimal (· ∈ s) x) : Minimal
 theorem minimal_mem_image_iff (ha : a ∈ s) : Minimal (· ∈ f '' s) (f a) ↔ Minimal (· ∈ s) a :=
   _root_.minimal_mem_image_monotone_iff ha (by simp [f.le_iff_le])
 
-attribute [local simp high] OrderEmbedding.eq_iff_eq in
 @[to_dual]
 theorem minimal_apply_mem_inter_range_iff :
     Minimal (· ∈ t ∩ range f) (f x) ↔ Minimal (fun x ↦ f x ∈ t) x := by
-  refine ⟨fun h ↦ ⟨h.prop.1, fun y hy ↦ ?_⟩, fun h ↦ ⟨⟨h.prop, by simp⟩, ?_⟩⟩
+  refine ⟨fun h ↦ ⟨h.prop.1, fun y hy ↦ ?_⟩, fun h ↦ ⟨⟨h.prop, mem_range_self x⟩, ?_⟩⟩
   · rw [← f.le_iff_le, ← f.le_iff_le]
-    exact h.le_of_le ⟨hy, by simp⟩
+    exact h.le_of_le ⟨hy, mem_range_self y⟩
   rintro _ ⟨hyt, ⟨y, rfl⟩⟩
   simp_rw [f.le_iff_le]
   exact h.le_of_le hyt
 
-@[to_dual maximal_apply_iff] -- TODO: make the names consistent
+@[to_dual]
 theorem minimal_apply_mem_iff (ht : t ⊆ Set.range f) :
     Minimal (· ∈ t) (f x) ↔ Minimal (fun x ↦ f x ∈ t) x := by
   rw [← f.minimal_apply_mem_inter_range_iff, inter_eq_self_of_subset_left ht]
 
-@[to_dual (attr := simp)]
+@[deprecated (since := "2026-04-07")] alias maximal_apply_iff := maximal_apply_mem_iff
+
 theorem image_setOf_minimal : f '' {x | Minimal (· ∈ s) x} = {x | Minimal (· ∈ f '' s) x} :=
   _root_.image_monotone_setOf_minimal (by simp [f.le_iff_le])
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
