### PR TITLE
[Merged by Bors] - feat(Topology/Order/Bornology): generalize `cobounded_eq`

### DIFF
--- a/Mathlib/Analysis/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Polynomial/Basic.lean
@@ -374,7 +374,7 @@ end Cobounded
 lemma finite_abs_eval_le_of_degree_lt {P Q : ℤ[X]} (h : Q.degree < P.degree) :
     {x | |P.eval x| ≤ |Q.eval x|}.Finite := by
   have o := isLittleO_cobounded_of_degree_lt h
-  rw [Int.cobounded_eq, ← Int.cofinite_eq] at o
+  rw [IsOrderBornology.cobounded_eq, ← Int.cofinite_eq] at o
   have nr := eventually_cofinite_not_isRoot (ne_zero_of_degree_gt h)
   have key := o.eventuallyLT_norm_of_eventually_pos (nr.congr (.of_forall (by simp)))
   simp_rw [eventually_cofinite, not_lt, Int.norm_eq_abs] at key

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -385,11 +385,8 @@ where `t : ℝ` is the limit of `x * g x`. -/
 lemma tendsto_mul_log_one_add_of_tendsto {g : ℝ → ℝ} {t : ℝ}
     (hg : Tendsto (fun x ↦ x * g x) atTop (𝓝 t)) :
     Tendsto (fun x ↦ x * log (1 + g x)) atTop (𝓝 t) := by
-  #adaptation_note /-- Prior to https://github.com/leanprover/lean4/pull/12179,
-  `Real.cobounded_eq` was marked `@[simp]`, so didn't have to be passed explicitly here.
-  Now the `simpNF` linter complains about it. -/
   have hg0 := tendsto_zero_of_isBoundedUnder_smul_of_tendsto_cobounded
-    hg.norm.isBoundedUnder_le (tendsto_id'.mpr (by simp [Real.cobounded_eq]))
+    hg.norm.isBoundedUnder_le (tendsto_id'.mpr (by simp))
   rw [← tendsto_ofReal_iff] at hg ⊢
   push_cast at hg ⊢
   apply (Complex.tendsto_mul_log_one_add_of_tendsto hg).congr'
@@ -408,11 +405,8 @@ where `t : ℝ` is the limit of `x * g x`. -/
 lemma tendsto_one_add_rpow_exp_of_tendsto {g : ℝ → ℝ} {t : ℝ}
     (hg : Tendsto (fun x ↦ x * g x) atTop (𝓝 t)) :
     Tendsto (fun x ↦ (1 + g x) ^ x) atTop (𝓝 (exp t)) := by
-  #adaptation_note /-- Prior to https://github.com/leanprover/lean4/pull/12179,
-  `Real.cobounded_eq` was marked `@[simp]`, so didn't have to be passed explicitly here.
-  Now the `simpNF` linter complains about it. -/
   have hg0 := tendsto_zero_of_isBoundedUnder_smul_of_tendsto_cobounded
-    hg.norm.isBoundedUnder_le (tendsto_id'.mpr (by simp [Real.cobounded_eq]))
+    hg.norm.isBoundedUnder_le (tendsto_id'.mpr (by simp))
   rw [← tendsto_ofReal_iff] at hg ⊢
   push_cast at hg ⊢
   apply (Complex.tendsto_one_add_cpow_exp_of_tendsto hg).congr'

--- a/Mathlib/Topology/Instances/Int.lean
+++ b/Mathlib/Topology/Instances/Int.lean
@@ -70,11 +70,6 @@ instance : IsOrderBornology ℤ :=
   .of_isCompactIcc 0 (by simp [Int.closedBall_eq_Icc]) (by simp [Int.closedBall_eq_Icc])
 
 @[simp]
-theorem cobounded_eq : Bornology.cobounded ℤ = atBot ⊔ atTop := by
-  simp_rw [← comap_dist_right_atTop (0 : ℤ), dist_eq', sub_zero,
-    ← comap_abs_atTop, ← @Int.comap_cast_atTop ℝ, comap_comap]; rfl
-
-@[simp]
 theorem cofinite_eq : (cofinite : Filter ℤ) = atBot ⊔ atTop := by
   rw [← cocompact_eq_cofinite, cocompact_eq_atBot_atTop]
 

--- a/Mathlib/Topology/Instances/Int.lean
+++ b/Mathlib/Topology/Instances/Int.lean
@@ -69,6 +69,9 @@ instance : ProperSpace ℤ :=
 instance : IsOrderBornology ℤ :=
   .of_isCompactIcc 0 (by simp [Int.closedBall_eq_Icc]) (by simp [Int.closedBall_eq_Icc])
 
+@[deprecated (since := "2026-04-07")]
+alias cobounded_eq := IsOrderBornology.cobounded_eq
+
 @[simp]
 theorem cofinite_eq : (cofinite : Filter ℤ) = atBot ⊔ atTop := by
   rw [← cocompact_eq_cofinite, cocompact_eq_atBot_atTop]

--- a/Mathlib/Topology/Instances/Real/Lemmas.lean
+++ b/Mathlib/Topology/Instances/Real/Lemmas.lean
@@ -42,11 +42,6 @@ theorem Real.isTopologicalBasis_Ioo_rat :
       exact ⟨q, p, Rat.cast_lt.1 <| hqa.trans hap, rfl⟩, ⟨hqa, hap⟩, fun _ ⟨hqa', ha'p⟩ =>
       h ⟨hlq.trans hqa', ha'p.trans hpu⟩⟩
 
-#adaptation_note /-- After https://github.com/leanprover/lean4/pull/12179
-the simpNF linter complains about this being `@[simp]`. -/
-theorem Real.cobounded_eq : cobounded ℝ = atBot ⊔ atTop := by
-  simp only [← comap_dist_right_atTop (0 : ℝ), Real.dist_eq, sub_zero, comap_abs_atTop]
-
 /- TODO(Mario): Prove that these are uniform isomorphisms instead of uniform embeddings
 lemma uniform_embedding_add_rat {r : ℚ} : uniform_embedding (fun p : ℚ => p + r) :=
 _

--- a/Mathlib/Topology/Instances/Real/Lemmas.lean
+++ b/Mathlib/Topology/Instances/Real/Lemmas.lean
@@ -115,6 +115,9 @@ theorem closure_of_rat_image_lt {q : ℚ} :
   · exact (closure_Ioi _).symm
   · exact ⟨q + 1, show (q : ℝ) < _ by linarith, q + 2, show (q : ℝ) < _ by linarith, by simp⟩
 
+@[deprecated (since := "2026-04-07")]
+alias Real.cobounded_eq := IsOrderBornology.cobounded_eq
+
 /- TODO(Mario): Put these back only if needed later
 lemma closure_of_rat_image_le_eq {q : ℚ} : closure ((coe : ℚ → ℝ) '' {x | q ≤ x}) = {r | ↑q ≤ r} :=
   _

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -108,74 +108,44 @@ lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology
   intro s
   rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
     Filter.atTop_basis_Ioi.mem_iff]
-  rintro ⟨_, b, hb⟩
+  intro ⟨_, b, hb⟩
   rw [mem_upperBounds_iff_subset_Iic, ← compl_compl (Iic b), compl_subset_compl, compl_Iic] at hb
   use b
 
-lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α := by
-  intro s
-  rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
-    Filter.atBot_basis_Iio.mem_iff]
-  rintro ⟨⟨a, ha⟩, _⟩
-  rw [mem_lowerBounds_iff_subset_Ici, ← compl_compl (Ici a), compl_subset_compl, compl_Ici] at ha
-  use a
+-- TODO (khw): Generate this in the future with `to_dual`
+-- See https://github.com/leanprover-community/mathlib4/pull/37738
+lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α :=
+  atTop_le_cobounded (α := αᵒᵈ)
 
 lemma IsOrderBornology.cobounded_le_atBot_sup_atTop :
     cobounded α ≤ .atBot ⊔ .atTop := by
   intro s
   rw [Filter.mem_sup, Filter.atTop_basis.mem_iff, Filter.atBot_basis.mem_iff,
     ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
-  rintro ⟨⟨b, _, hb⟩, ⟨a, _, ha⟩⟩
-  constructor
-  · use b
-    intro x hx
-    by_contra! hx'
-    exact hx (hb hx'.le)
-  · use a
-    intro x hx
-    by_contra! hx'
-    exact hx (ha hx'.le)
+  intro ⟨⟨b, _, hb⟩, ⟨a, _, ha⟩⟩
+  refine ⟨⟨b, fun x hx ↦ ?_⟩, ⟨a, fun x hx ↦ ?_⟩⟩ <;> by_contra! hx'
+  · exact hx (hb hx'.le)
+  · exact hx (ha hx'.le)
 
 @[simp]
 lemma IsOrderBornology.cobounded_eq [NoMaxOrder α] [NoMinOrder α] :
-    Bornology.cobounded α = .atBot ⊔ .atTop := by
-  apply le_antisymm
-  · exact cobounded_le_atBot_sup_atTop
-  · exact sup_le IsOrderBornology.atBot_le_cobounded IsOrderBornology.atTop_le_cobounded
+    Bornology.cobounded α = .atBot ⊔ .atTop :=
+  cobounded_le_atBot_sup_atTop.antisymm <|
+    sup_le IsOrderBornology.atBot_le_cobounded IsOrderBornology.atTop_le_cobounded
 
 lemma IsOrderBornology.cobounded_eq_atTop [NoMaxOrder α] [OrderBot α] :
     Bornology.cobounded α = .atTop := by
-  apply le_antisymm
-  · intro s
-    rw [Filter.atTop_basis.mem_iff,
-      ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
-    rintro ⟨b, _, hb⟩
-    constructor
-    · use ⊥
-      intro x hx
-      simp
-    · use b
-      intro x hx
-      by_contra! hx'
-      exact hx (hb hx'.le)
-  · exact IsOrderBornology.atTop_le_cobounded
+  refine atTop_le_cobounded.antisymm' fun s ↦ ?_
+  rw [Filter.atTop_basis.mem_iff,
+    ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
+  refine fun ⟨b, _, hb⟩ ↦ ⟨⟨⊥, fun x hx ↦ by simp⟩, ⟨b, fun x hx ↦ ?_⟩⟩
+  by_contra! hx'
+  exact hx (hb hx'.le)
 
+-- TODO (khw): Generate this in the future with `to_dual`
+-- See https://github.com/leanprover-community/mathlib4/pull/37738
 lemma IsOrderBornology.cobounded_eq_atBot [NoMinOrder α] [OrderTop α] :
-    Bornology.cobounded α = .atBot := by
-  apply le_antisymm
-  · intro s
-    rw [Filter.atBot_basis.mem_iff,
-      ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
-    rintro ⟨a, _, ha⟩
-    constructor
-    · use a
-      intro x hx
-      by_contra! hx'
-      exact hx (ha hx'.le)
-    · use ⊤
-      intro x hx
-      simp
-  · exact IsOrderBornology.atBot_le_cobounded
+    Bornology.cobounded α = .atBot := cobounded_eq_atTop (α := αᵒᵈ)
 
 end LinearOrder
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -100,6 +100,85 @@ instance Pi.instIsOrderBornology {ι : Type*} {α : ι → Type*} [∀ i, Preord
 
 end Preorder
 
+section LinearOrder
+
+variable [Nonempty α] [LinearOrder α] [IsOrderBornology α]
+
+lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology.cobounded α := by
+  intro s
+  rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
+    Filter.atTop_basis_Ioi.mem_iff]
+  rintro ⟨_, ⟨b, hb⟩⟩
+  rw [mem_upperBounds_iff_subset_Iic, ← compl_compl (Iic b), compl_subset_compl, compl_Iic] at hb
+  use b
+
+lemma IsOrderBornology.atBot_le_cobounded [NoMinOrder α] : .atBot ≤ Bornology.cobounded α := by
+  intro s
+  rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
+    Filter.atBot_basis_Iio.mem_iff]
+  rintro ⟨⟨a, ha⟩, _⟩
+  rw [mem_lowerBounds_iff_subset_Ici, ← compl_compl (Ici a), compl_subset_compl, compl_Ici] at ha
+  use a
+
+lemma IsOrderBornology.cobounded_le_atBot_sup_atTop :
+    cobounded α ≤ .atBot ⊔ .atTop := by
+  intro s
+  rw [Filter.mem_sup, Filter.atTop_basis.mem_iff, Filter.atBot_basis.mem_iff,
+    ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
+  rintro ⟨⟨b, _, hb⟩, ⟨a, _, ha⟩⟩
+  constructor
+  · use b
+    intro x hx
+    by_contra! hx'
+    exact hx (hb hx'.le)
+  · use a
+    intro x hx
+    by_contra! hx'
+    exact hx (ha hx'.le)
+
+@[simp]
+lemma IsOrderBornology.cobounded_eq [NoMaxOrder α] [NoMinOrder α] :
+    Bornology.cobounded α = .atBot ⊔ .atTop := by
+  apply le_antisymm
+  · exact cobounded_le_atBot_sup_atTop
+  · exact sup_le IsOrderBornology.atBot_le_cobounded IsOrderBornology.atTop_le_cobounded
+
+lemma IsOrderBornology.cobounded_eq_atTop [NoMaxOrder α] [OrderBot α] :
+    Bornology.cobounded α = .atTop := by
+  apply le_antisymm
+  · intro s
+    rw [Filter.atTop_basis.mem_iff,
+      ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
+    rintro ⟨b, _, hb⟩
+    constructor
+    · use ⊥
+      intro x hx
+      simp
+    · use b
+      intro x hx
+      by_contra! hx'
+      exact hx (hb hx'.le)
+  · exact IsOrderBornology.atTop_le_cobounded
+
+lemma IsOrderBornology.cobounded_eq_atBot [NoMinOrder α] [OrderTop α] :
+    Bornology.cobounded α = .atBot := by
+  apply le_antisymm
+  · intro s
+    rw [Filter.atBot_basis.mem_iff,
+      ← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s]
+    rintro ⟨a, _, ha⟩
+    constructor
+    · use a
+      intro x hx
+      by_contra! hx'
+      exact hx (ha hx'.le)
+    · use ⊤
+      intro x hx
+      simp
+  · exact IsOrderBornology.atBot_le_cobounded
+
+end LinearOrder
+
 section ConditionallyCompleteLattice
 variable [ConditionallyCompleteLattice α] [IsOrderBornology α] {s : Set α}
 

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -108,7 +108,7 @@ lemma IsOrderBornology.atTop_le_cobounded [NoMaxOrder α] : .atTop ≤ Bornology
   intro s
   rw [← compl_compl s, ← isBounded_def, isBounded_iff_bddBelow_bddAbove, compl_compl s,
     Filter.atTop_basis_Ioi.mem_iff]
-  rintro ⟨_, ⟨b, hb⟩⟩
+  rintro ⟨_, b, hb⟩
   rw [mem_upperBounds_iff_subset_Iic, ← compl_compl (Iic b), compl_subset_compl, compl_Iic] at hb
   use b
 


### PR DESCRIPTION
`Real.cobounded_eq` and `Int.cobounded_eq` are used in several places throughout Mathlib. They are currently proved in terms of the Metric topology on `Int` and `Real`, but they're really properties of the order bornology on those objects.

Generalize those constructions to `IsOrderBornology` for `LinearOrder`'s and add a few more constructions that are true in other circumstances, e.g., `cobounded NNReal = .atTop` follows from the fact that `NNReal` is both `NoMaxOrder` and `OrderBot`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
