### PR TITLE
[Merged by Bors] - chore: reduce some Batteries imports

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Defs.lean
@@ -6,7 +6,7 @@ Authors: Johannes Hölzl, Floris van Doorn, Sébastien Gouëzel, Alex J. Best
 module
 
 public import Mathlib.Algebra.Group.Defs
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Sums and products from lists

--- a/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
@@ -6,7 +6,7 @@ Authors: Stuart Presnell
 module
 
 public import Mathlib.Algebra.Order.Ring.Canonical
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Big operators on a list in ordered rings

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.List.Monad
 public import Mathlib.Logic.OpClass
 public import Mathlib.Logic.Unique
 public import Mathlib.Tactic.Common
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 public import Batteries.Tactic.Lint.Simp
 public import Batteries.Tactic.SeqFocus
 public import Mathlib.Data.Subtype

--- a/Mathlib/Data/List/ChainOfFn.lean
+++ b/Mathlib/Data/List/ChainOfFn.lean
@@ -5,7 +5,7 @@ Authors: Joseph Myers
 -/
 module
 
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 public import Mathlib.Tactic.Common
 public import Mathlib.Tactic.Finiteness.Attr
 public import Mathlib.Tactic.ToDual

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -7,7 +7,7 @@ module
 
 public import Batteries.Data.List.Perm
 public import Mathlib.Tactic.Common
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Counting in lists

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -8,7 +8,7 @@ module
 public import Batteries.Data.List.Pairwise
 public import Mathlib.Logic.Pairwise
 public import Mathlib.Logic.Relation
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Pairwise relations on a list

--- a/Mathlib/Data/List/Triplewise.lean
+++ b/Mathlib/Data/List/Triplewise.lean
@@ -6,7 +6,7 @@ Authors: Joseph Myers, Yaël Dillies
 module
 
 public import Mathlib.Tactic.MkIffOfInductiveProp
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Triplewise predicates on list.

--- a/Mathlib/Data/Ordmap/Ordnode.lean
+++ b/Mathlib/Data/Ordmap/Ordnode.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Order.Compare
 public import Mathlib.Data.Nat.PSub
-public import Batteries.Data.List
+public import Batteries.Data.List.Lemmas
 
 /-!
 # Ordered sets

--- a/Mathlib/Tactic/Order/ToInt.lean
+++ b/Mathlib/Tactic/Order/ToInt.lean
@@ -5,7 +5,7 @@ Authors: Vasilii Nesterov
 -/
 module
 
-public import Batteries.Data.List
+public import Batteries.Data.List.Pairwise
 public import Batteries.Tactic.GeneralizeProofs
 public import Mathlib.Tactic.Order.CollectFacts
 public meta import Mathlib.Util.AtomM


### PR DESCRIPTION
Stopgap measure until we get `shake` running in Mathlib again.

(If these imports had been minimized already, it would have saved me some time while working on lean-pr-testing-13283.)