### PR TITLE
chore(RingTheory): Connecting dimensionLEOne and krullDimLE

### DIFF
--- a/Mathlib/RingTheory/KrullDimension/Regular.lean
+++ b/Mathlib/RingTheory/KrullDimension/Regular.lean
@@ -212,9 +212,13 @@ lemma _root_.ringKrullDim_add_length_eq_ringKrullDim_of_isRegular (rs : List R)
     ← supportDim_quotient_eq_ringKrullDim, ← supportDim_self_eq_ringKrullDim]
   exact supportDim_add_length_eq_supportDim_of_isRegular rs reg
 
-open Ring in
-lemma Ring.dimensionLEOne_iff_krullDimLE_one {R : Type*} [CommRing R] [NoZeroDivisors R] :
+end Module
+namespace Ring
+
+variable {R : Type*} [CommRing R] [NoZeroDivisors R]
+
+lemma dimensionLEOne_iff_krullDimLE_one :
     DimensionLEOne R ↔ KrullDimLE 1 R :=
   .trans ⟨fun h _ ↦ h.maximalOfPrime, fun h ↦ ⟨@h⟩⟩ krullDimLE_one_iff_of_noZeroDivisors.symm
 
-end Module
+end Ring

--- a/Mathlib/RingTheory/KrullDimension/Regular.lean
+++ b/Mathlib/RingTheory/KrullDimension/Regular.lean
@@ -212,4 +212,9 @@ lemma _root_.ringKrullDim_add_length_eq_ringKrullDim_of_isRegular (rs : List R)
     ← supportDim_quotient_eq_ringKrullDim, ← supportDim_self_eq_ringKrullDim]
   exact supportDim_add_length_eq_supportDim_of_isRegular rs reg
 
+open Ring in
+lemma Ring.dimensionLEOne_iff_krullDimLE_one {R : Type*} [CommRing R] [NoZeroDivisors R] :
+    DimensionLEOne R ↔ KrullDimLE 1 R :=
+  .trans ⟨fun h _ ↦ h.maximalOfPrime, fun h ↦ ⟨@h⟩⟩ krullDimLE_one_iff_of_noZeroDivisors.symm
+
 end Module


### PR DESCRIPTION
---
We should probably also change the name of DimensionLEOne to something more descriptive. I'm not sure what this should be, perhaps NonZeroPrimesMaximal or if we want to keep the relation to krull dim maybe KrullDimZeroOrDomainOfKrullDimOne (this is horrendous but maybe somebody can come up with a nice refinement)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
