### PR TITLE
[Merged by Bors] - refactor(Data/Finsupp): use `single` in `uniqueEquiv`

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
+++ b/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
@@ -36,7 +36,7 @@ theorem cardinalMk_eq_max_lift [Nonempty X] [Nontrivial R] :
 
 @[simp]
 theorem cardinalMk_eq_lift [IsEmpty X] : #(FreeAlgebra R X) = Cardinal.lift.{v} #R := by
-  have := lift_mk_eq'.2 ⟨show (FreeMonoid X →₀ R) ≃ R from Equiv.finsuppUnique⟩
+  have := lift_mk_eq'.2 ⟨show (FreeMonoid X →₀ R) ≃ R from Finsupp.uniqueEquiv 1⟩
   rw [lift_id'.{u, v}, lift_umax] at this
   rwa [equivMonoidAlgebraFreeMonoid.toEquiv.cardinal_eq, MonoidAlgebra]
 

--- a/Mathlib/Algebra/Group/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Finsupp.lean
@@ -77,7 +77,19 @@ noncomputable def addEquivFunOnFinite {ι : Type*} [Finite ι] :
 
 /-- If `M` is the trivial monoid, then the monoid of finitely supported functions `ι →₀ M` is
 is isomorphic to `M`. -/
-@[simps!]
+@[simps! apply symm_apply]
+noncomputable def uniqueAddEquiv (i : ι) [Subsingleton ι] : (ι →₀ M) ≃+ M where
+  toEquiv := uniqueEquiv i
+  map_add' _ _ := rfl
+
+-- We want this lemma to fire before `uniqueAddEquiv_symm_apply`.
+@[simp↓ high] lemma uniqueAddEquiv_symm_apply_apply (i : ι) [Subsingleton ι] (m : M) (j : ι) :
+    (uniqueAddEquiv i).symm m j = m := by simp [Subsingleton.elim j i]
+
+set_option linter.deprecated false in
+/-- If `M` is the trivial monoid, then the monoid of finitely supported functions `ι →₀ M` is
+is isomorphic to `M`. -/
+@[simps!, deprecated uniqueAddEquiv (since := "2026-05-06")]
 noncomputable def _root_.AddEquiv.finsuppUnique {ι : Type*} [Unique ι] : (ι →₀ M) ≃+ M where
   toEquiv := .finsuppUnique
   map_add' _ _ := rfl
@@ -161,6 +173,8 @@ lemma support_single_add_single_subset [DecidableEq ι] {f₁ f₂ : ι} {g₁ g
   refine subset_trans Finsupp.support_add <| union_subset_iff.mpr ⟨?_, ?_⟩ <;>
   exact subset_trans Finsupp.support_single_subset (by simp)
 
+set_option linter.deprecated false in
+@[deprecated uniqueAddEquiv_symm_apply (since := "2026-05-06")]
 lemma _root_.AddEquiv.finsuppUnique_symm {M : Type*} [AddZeroClass M] (d : M) :
     AddEquiv.finsuppUnique.symm d = single () d := by ext; simp [AddEquiv.finsuppUnique]
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -634,12 +634,24 @@ instance isLocalHom_singleOneRingHom : IsLocalHom (singleOneRingHom (R := R) (M 
 set_option backward.isDefEq.respectTransparency false in
 variable (M) in
 /-- The trivial monoid algebra is the base ring. -/
-@[to_additive (dont_translate := R) (attr := simps! apply symm_apply)
+@[to_additive (dont_translate := R) (attr := simps! apply)
 /-- The trivial additive monoid algebra is the base ring. -/]
-def uniqueRingEquiv [Unique M] : R[M] ≃+* R where
-  toAddEquiv := .finsuppUnique
-  map_mul' x y :=
-    (mul_apply ..).trans <| by simp [Finsupp.sum_unique, Unique.eq_default, MonoidAlgebra]
+def uniqueRingEquiv [Subsingleton M] : R[M] ≃+* R where
+  toAddEquiv := Finsupp.uniqueAddEquiv 1
+  map_mul' x y := by
+    let : Unique M := ⟨⟨1⟩, fun _ ↦ Subsingleton.elim _ _⟩
+    refine (mul_apply ..).trans ?_
+    simp [Finsupp.sum_unique, Unique.eq_default, MonoidAlgebra]
+
+variable (M) in
+@[to_additive (dont_translate := R) (attr := simp)]
+lemma uniqueRingEquiv_symm_apply [Subsingleton M] (r : R) :
+    (uniqueRingEquiv M).symm r = single 1 r := rfl
+
+-- We want this lemma to fire before `uniqueRingEquiv_symm_apply`.
+@[to_additive (dont_translate := R) (attr := simp↓ high)]
+lemma uniqueRingEquiv_symm_apply_apply [Subsingleton M] (r : R) (m : M) :
+    (uniqueRingEquiv M).symm r m = r := by simp [Subsingleton.elim m 1]
 
 /-- A product monoid algebra is a nested monoid algebra. -/
 @[to_additive (dont_translate := R)

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -213,13 +213,6 @@ theorem equivFunOnFinite_symm_coe {α} [Finite α] (f : α →₀ M) : equivFunO
 @[simp]
 lemma coe_equivFunOnFinite_symm {α} [Finite α] (f : α → M) : ⇑(equivFunOnFinite.symm f) = f := rfl
 
-/--
-If `α` has a unique term, the type of finitely supported functions `α →₀ β` is equivalent to `β`.
--/
-@[simps!]
-noncomputable def _root_.Equiv.finsuppUnique {ι : Type*} [Unique ι] : (ι →₀ M) ≃ M :=
-  Finsupp.equivFunOnFinite.trans (Equiv.funUnique ι M)
-
 @[ext]
 theorem unique_ext [Unique α] {f g : α →₀ M} (h : f default = g default) : f = g :=
   ext fun a => by rwa [Unique.eq_default a]

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -240,6 +240,26 @@ theorem card_support_le_one' [Nonempty α] {f : α →₀ M} :
     #f.support ≤ 1 ↔ ∃ a b, f = single a b := by
   simp only [card_le_one_iff_subset_singleton, support_subset_singleton']
 
+/-- If `α` has a unique term, then finitely supported functions `α →₀ M` are in bijection with `M`.
+-/
+@[simps]
+noncomputable def uniqueEquiv (a : α) [Subsingleton α] : (α →₀ M) ≃ M where
+  toFun f := f a
+  invFun := single a
+  left_inv f := by ext b; simp [Subsingleton.elim b a]
+  right_inv x := by simp
+
+-- We want this lemma to fire before `uniqueEquiv_symm_apply`.
+@[simp↓ high] lemma uniqueEquiv_symm_apply_apply (a : α) [Subsingleton α] (m : M) (b : α) :
+    (uniqueEquiv a).symm m b = m := by simp [Subsingleton.elim b a]
+
+/--
+If `α` has a unique term, the type of finitely supported functions `α →₀ β` is equivalent to `β`.
+-/
+@[simps!, deprecated uniqueEquiv (since := "2026-05-06")]
+noncomputable def _root_.Equiv.finsuppUnique {ι : Type*} [Unique ι] : (ι →₀ M) ≃ M :=
+  Finsupp.equivFunOnFinite.trans (Equiv.funUnique ι M)
+
 @[simp]
 theorem equivFunOnFinite_single [DecidableEq α] [Finite α] (x : α) (m : M) :
     Finsupp.equivFunOnFinite (Finsupp.single x m) = Pi.single x m := by

--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -247,7 +247,7 @@ theorem eq_bot_of_rank_le_one (h : Module.rank F S ≤ 1) [Module.Free F S] : S 
     rw [← b.mk_eq_rank'', eq_one_iff_unique, ← unique_iff_subsingleton_and_nonempty] at h1
     obtain ⟨h1⟩ := h1
     obtain ⟨y, hy⟩ := (bijective_algebraMap_of_linearEquiv (b.repr ≪≫ₗ
-      Finsupp.LinearEquiv.finsuppUnique _ _ _).symm).surjective ⟨x, hx⟩
+      Finsupp.uniqueLinearEquiv _ _ default).symm).surjective ⟨x, hx⟩
     exact ⟨y, congr(Subtype.val $(hy))⟩
   haveI := mk_eq_zero_iff.1 (b.mk_eq_rank''.symm ▸ Cardinal.lt_one_iff.1 (h.lt_of_ne h1))
   haveI := b.repr.toEquiv.subsingleton

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -129,9 +129,9 @@ noncomputable def basisSingleton (ι : Type*) [Unique ι] (h : finrank K V = 1) 
       map_smul' := by simp [mul_div]
       left_inv := fun w => by
         apply_fun b.repr using b.repr.toEquiv.injective
-        apply_fun Equiv.finsuppUnique
+        apply_fun Finsupp.uniqueEquiv default
         simp only [map_smulₛₗ, Finsupp.coe_smul, Finsupp.single_eq_same,
-          smul_eq_mul, Pi.smul_apply, Equiv.finsuppUnique_apply]
+          smul_eq_mul, Pi.smul_apply, Finsupp.uniqueEquiv_apply]
         exact div_mul_cancel₀ _ h
       right_inv := fun f => by
         ext

--- a/Mathlib/LinearAlgebra/Finsupp/Pi.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Pi.lean
@@ -31,35 +31,46 @@ open Set LinearMap Submodule
 
 namespace Finsupp
 
-section LinearEquiv.finsuppUnique
+section uniqueLinearEquiv
 
-variable (R : Type*) {S : Type*} (M : Type*)
+variable (R : Type*) {S α : Type*} (M : Type*)
 variable [AddCommMonoid M] [Semiring R] [Module R M]
-variable (α : Type*) [Unique α]
 
 /-- If `α` has a unique term, then the type of finitely supported functions `α →₀ M` is
 `R`-linearly equivalent to `M`. -/
-noncomputable def LinearEquiv.finsuppUnique : (α →₀ M) ≃ₗ[R] M :=
+@[simps! apply symm_apply]
+noncomputable def uniqueLinearEquiv [Subsingleton α] (a : α) : (α →₀ M) ≃ₗ[R] M where
+  toAddEquiv := uniqueAddEquiv a
+  map_smul' _ _ := rfl
+
+-- We want this lemma to fire before `uniqueRingEquiv_symm_apply`.
+@[simp↓ high] lemma uniqueLinearEquiv_symm_apply_apply (a : α) [Subsingleton α] (m : M) (b : α) :
+    (uniqueLinearEquiv R M a).symm m b = m := by simp [Subsingleton.elim b a]
+
+/-- If `α` has a unique term, then the type of finitely supported functions `α →₀ M` is
+`R`-linearly equivalent to `M`. -/
+@[deprecated uniqueLinearEquiv (since := "2026-05-06")]
+noncomputable def LinearEquiv.finsuppUnique (α : Type*) [Unique α] : (α →₀ M) ≃ₗ[R] M :=
   { Finsupp.equivFunOnFinite.trans (Equiv.funUnique α M) with
     map_add' := fun _ _ => rfl
     map_smul' := fun _ _ => rfl }
 
 variable {R M}
 
-@[simp]
-theorem LinearEquiv.finsuppUnique_apply (f : α →₀ M) :
+set_option linter.deprecated false in
+@[deprecated uniqueLinearEquiv_apply (since := "2026-05-06")]
+theorem LinearEquiv.finsuppUnique_apply (α : Type*) [Unique α] (f : α →₀ M) :
     LinearEquiv.finsuppUnique R M α f = f default :=
   rfl
 
-variable {α}
-
-@[simp]
-theorem LinearEquiv.finsuppUnique_symm_apply (m : M) :
+set_option linter.deprecated false in
+@[deprecated uniqueLinearEquiv_symm_apply (since := "2026-05-06")]
+theorem LinearEquiv.finsuppUnique_symm_apply (α : Type*) [Unique α] (m : M) :
     (LinearEquiv.finsuppUnique R M α).symm m = Finsupp.single default m := by
   ext; simp [LinearEquiv.finsuppUnique, Equiv.funUnique, single, Pi.single,
     equivFunOnFinite, Function.update]
 
-end LinearEquiv.finsuppUnique
+end uniqueLinearEquiv
 
 variable {α : Type*} {M : Type*} {N : Type*} {P : Type*} {R : Type*} {S : Type*}
 variable [Semiring R] [Semiring S] [AddCommMonoid M] [Module R M]

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -81,7 +81,7 @@ variable (k G) in
 @[simps toLinearMap]
 def ε : (trivial k G k).IntertwiningMap (linearize k G (MonoidalCategoryStruct.tensorUnit
     (Action (Type w) G))) where
-  __ := Finsupp.LinearEquiv.finsuppUnique k k PUnit |>.symm.toLinearMap
+  __ := Finsupp.uniqueLinearEquiv k k PUnit.unit |>.symm.toLinearMap
   isIntertwining' g := by ext1; simp [linearize_single _]
 
 lemma ε_one : ε k G 1 = Finsupp.single PUnit.unit 1 := by
@@ -93,7 +93,7 @@ variable (k G) in
 /-- The unit of the linearize functor. -/
 @[simps toLinearMap]
 def η : (linearize k G (𝟙_ (Action (Type u) G))).IntertwiningMap (trivial k G k) where
-  __ := (Finsupp.LinearEquiv.finsuppUnique k k PUnit).toLinearMap
+  __ := (Finsupp.uniqueLinearEquiv k k PUnit.unit).toLinearMap
   isIntertwining' g := by ext; simp [linearize_single _]
 
 lemma η_single (x : PUnit) : η k G (Finsupp.single x 1) = 1 := by

--- a/Mathlib/RepresentationTheory/Equiv.lean
+++ b/Mathlib/RepresentationTheory/Equiv.lean
@@ -34,8 +34,7 @@ variable (k G) in
 /-- If there exists `G`-action on a trivial monoid `H` then the induced representation
   on `k[H]` is equivalent to the trivial representation. -/
 def ofMulActionSubsingletonEquivTrivial : (ofMulAction k G H).Equiv (trivial k G k) :=
-  letI : Unique H := uniqueOfSubsingleton 1
-  .mk (Finsupp.LinearEquiv.finsuppUnique _ _ _) fun g ↦ by
+  .mk (Finsupp.uniqueLinearEquiv _ _ 1) fun g ↦ by
     ext a; simp [Subsingleton.elim (g • a) a]
 
 @[simp]
@@ -45,9 +44,7 @@ lemma ofMulActionSubsingletonEquivTrivial_apply (f : H →₀ k) :
 @[simp]
 lemma ofMulActionSubsingletonEquivTrivial_symm_apply (r : k) :
     (ofMulActionSubsingletonEquivTrivial k G H).symm.toIntertwiningMap.toLinearMap r =
-      Finsupp.single 1 r := by
-  letI : Unique H := uniqueOfSubsingleton 1
-  simp [ofMulActionSubsingletonEquivTrivial, Subsingleton.elim (1 : H) (default : H)]
+      Finsupp.single 1 r := rfl
 
 variable (k G) in
 /-- The equivalence of representations between `(Fin 1 → G) →₀ k` and `G →₀ k`. -/

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -62,7 +62,7 @@ section Chains
 /-- The 0th object in the complex of inhomogeneous chains of `A : Rep k G` is isomorphic
 to `A` as a `k`-module. -/
 def chainsIso₀ : (inhomogeneousChains A).X 0 ≅ ModuleCat.of k A.V :=
-  (LinearEquiv.finsuppUnique _ _ _).toModuleIso
+  (uniqueLinearEquiv _ _ default).toModuleIso
 
 /-- The 1st object in the complex of inhomogeneous chains of `A : Rep k G` is isomorphic
 to `G →₀ A` as a `k`-module. -/

--- a/Mathlib/RepresentationTheory/Homological/Resolution.lean
+++ b/Mathlib/RepresentationTheory/Homological/Resolution.lean
@@ -252,8 +252,8 @@ def forget₂ToModuleCatHomotopyEquiv :
           (extraDegeneracyCompForgetAugmentedToModule k G)).trans
       (HomotopyEquiv.ofIso <|
         (ChainComplex.single₀ (ModuleCat.{u} k)).mapIso
-          (@Finsupp.LinearEquiv.finsuppUnique k k _ _ _ (⊤_ Type u)
-              Types.terminalIso.toEquiv.unique).toModuleIso)
+          (@Finsupp.uniqueLinearEquiv k (⊤_ Type u) k _ _ _ _
+            Types.terminalIso.toEquiv.unique.default).toModuleIso)
 
 /-- The hom of `k`-linear `G`-representations `k[G¹] → k` sending `∑ nᵢgᵢ ↦ ∑ nᵢ`. -/
 def ε : Rep.ofMulAction k G (Fin 1 → G) ⟶ Rep.trivial k G k := ofHom

--- a/Mathlib/RingTheory/PicardGroup.lean
+++ b/Mathlib/RingTheory/PicardGroup.lean
@@ -244,7 +244,7 @@ theorem free_iff_linearEquiv : Free R M ↔ Nonempty (M ≃ₗ[R] R) := by
       e.symm ≪≫ₗ linearEquiv R M ≪≫ₗ (.symm <| .funUnique Unit R R)
   have : Unique (Free.ChooseBasisIndex R M) :=
     (Fintype.card_eq_one_iff_nonempty_unique.mp (by simpa using this)).some
-  exact ⟨e ≪≫ₗ LinearEquiv.finsuppUnique R R _⟩
+  exact ⟨e ≪≫ₗ uniqueLinearEquiv R R default⟩
 
 /- TODO: The ≤ direction holds for arbitrary invertible modules over any commutative **ring** by
 considering the localization at a prime (which is free of rank 1) using the strong rank condition.

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -608,15 +608,9 @@ variable {R : Type*} [CommSemiring R] {ι : Type*}
 theorem coeff_prod [DecidableEq ι] (f : ι → PowerSeries R) (d : ℕ) (s : Finset ι) :
     coeff d (∏ j ∈ s, f j) = ∑ l ∈ finsuppAntidiag s d, ∏ i ∈ s, coeff (l i) (f i) := by
   simp only [coeff]
-  rw [MvPowerSeries.coeff_prod, ← AddEquiv.finsuppUnique_symm d, ← mapRange_finsuppAntidiag_eq,
-    sum_map, sum_congr rfl]
-  intro x _
-  apply prod_congr rfl
-  intro i _
-  congr 2
-  simp only [AddEquiv.toEquiv_eq_coe, Finsupp.mapRange.addEquiv_toEquiv, AddEquiv.toEquiv_symm,
-    Equiv.coe_toEmbedding, Finsupp.mapRange.equiv_apply, AddEquiv.coe_toEquiv_symm,
-    Finsupp.mapRange_apply, AddEquiv.finsuppUnique_symm]
+  rw [MvPowerSeries.coeff_prod, ← Finsupp.uniqueAddEquiv_symm_apply _ d,
+    ← mapRange_finsuppAntidiag_eq, sum_map]
+  rfl
 
 theorem prod_monomial (f : ι → ℕ) (g : ι → R) (s : Finset ι) :
     ∏ i ∈ s, monomial (f i) (g i) = monomial (∑ i ∈ s, f i) (∏ i ∈ s, g i) := by

--- a/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
+++ b/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
@@ -52,16 +52,16 @@ noncomputable
 abbrev gaussNorm : ℝ := MvPowerSeries.gaussNorm v (fun _ => c) f
 
 lemma gaussNorm_eq : gaussNorm v c f = ⨆ i : ℕ, v (f.coeff i) * c ^ i := by
-  refine Equiv.iSup_congr Equiv.finsuppUnique ?_
+  refine Equiv.iSup_congr (Finsupp.uniqueEquiv ()) ?_
   intro x
-  simp only [coeff, Equiv.finsuppUnique_apply, PUnit.default_eq_unit, Finsupp.prod_pow,
+  simp only [coeff, Finsupp.uniqueEquiv_apply, PUnit.default_eq_unit, Finsupp.prod_pow,
     Finset.univ_unique, Finset.prod_singleton, show (Finsupp.single () (x PUnit.unit)) = x by grind]
 
 /-- We say `f` HasGaussNorm if the values `v (coeff t f) * c ^ t` is bounded above, that is
   `gaussNormC f` is finite. -/
 abbrev HasGaussNorm := BddAbove (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t)))
 
-lemma HasGaussNorm.HasMvGaussNorm (h : HasGaussNorm v c f) :
+lemma HasGaussNorm.hasMvGaussNorm (h : HasGaussNorm v c f) :
     MvPowerSeries.HasGaussNorm v (fun _ ↦ c) f := by
   suffices (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t))) =
       Set.range fun t ↦ v ((MvPowerSeries.coeff t) f) * t.prod fun _ x2 ↦ c ^ x2 by
@@ -72,15 +72,15 @@ lemma HasGaussNorm.HasMvGaussNorm (h : HasGaussNorm v c f) :
   constructor
   · intro h
     obtain ⟨y, hy⟩ := h
-    use Equiv.finsuppUnique.invFun y
-    rw [coeff] at hy
-    convert hy
-    ext
-    simp
+    use (Finsupp.uniqueEquiv ()).symm y
+    simpa [coeff] using hy
   · intro h
     obtain ⟨y, hy⟩ := h
-    use Equiv.finsuppUnique.toFun y
+    use Finsupp.uniqueEquiv () y
     simpa [coeff, show (Finsupp.single () (y PUnit.unit)) = y by grind]
+
+@[deprecated (since := "2026-05-06")]
+alias HasGaussNorm.HasMvGaussNorm := HasGaussNorm.hasMvGaussNorm
 
 theorem gaussNorm_zero (vZero : v 0 = 0) : gaussNorm v c 0 = 0 :=
   MvPowerSeries.gaussNorm_zero v (fun _ ↦ c) vZero
@@ -97,13 +97,13 @@ lemma gaussNorm_eq_zero_iff (vZero : v 0 = 0) (vNonneg : ∀ a, v a ≥ 0)
     (h_eq_zero : ∀ x : R, v x = 0 → x = 0) (hc : 0 < c) (hbd : HasGaussNorm v c f) :
     gaussNorm v c f = 0 ↔ f = 0 :=
   MvPowerSeries.gaussNorm_eq_zero_iff v (fun _ ↦ c) f vZero vNonneg h_eq_zero
-    (by grind) (hbd.HasMvGaussNorm)
+    (by grind) hbd.hasMvGaussNorm
 
 lemma gaussNorm_add_le_max (g : PowerSeries R) (hc : 0 ≤ c)
     (vNonneg : ∀ a, v a ≥ 0) (hv : ∀ x y, v (x + y) ≤ max (v x) (v y))
     (hbfd : HasGaussNorm v c f) (hbgd : HasGaussNorm v c g) :
     gaussNorm v c (f + g) ≤ max (gaussNorm v c f) (gaussNorm v c g) :=
   MvPowerSeries.gaussNorm_add_le_max v (fun _ ↦ c) f g (fun _ => by simp [hc]) vNonneg hv
-   hbfd.HasMvGaussNorm hbgd.HasMvGaussNorm
+    hbfd.hasMvGaussNorm hbgd.hasMvGaussNorm
 
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -103,10 +103,9 @@ theorem tendsto_iff_coeff_tendsto [Semiring R] {ι : Type*}
     Tendsto f u (nhds g) ↔
     ∀ d : ℕ, Tendsto (fun i => coeff d (f i)) u (nhds (coeff d g)) := by
   rw [MvPowerSeries.WithPiTopology.tendsto_iff_coeff_tendsto]
-  apply (Finsupp.LinearEquiv.finsuppUnique ℕ ℕ Unit).toEquiv.forall_congr
+  apply (Finsupp.uniqueLinearEquiv ℕ ℕ ()).toEquiv.forall_congr
   intro d
-  simp only [LinearEquiv.coe_toEquiv, Finsupp.LinearEquiv.finsuppUnique_apply,
-    PUnit.default_eq_unit, coeff]
+  simp only [LinearEquiv.coe_toEquiv, Finsupp.uniqueLinearEquiv_apply, coeff]
   apply iff_of_eq
   congr
   · ext _; congr; ext; simp
@@ -322,14 +321,13 @@ open WithPiTopology MvPowerSeries.WithPiTopology
 
 variable {R}
 
--- NOTE : one needs an API to apply `Finsupp.LinearEquiv.finsuppUnique`
+-- NOTE : one needs an API to apply `Finsupp.uniqueLinearEquiv`
 /-- A power series is the sum (in the sense of summable families) of its monomials -/
 theorem hasSum_of_monomials_self (f : PowerSeries R) :
     HasSum (fun d : ℕ => monomial d (coeff d f)) f := by
-  rw [← (Finsupp.LinearEquiv.finsuppUnique ℕ ℕ Unit).toEquiv.hasSum_iff]
+  rw [← (Finsupp.uniqueLinearEquiv ℕ ℕ ()).toEquiv.hasSum_iff]
   convert MvPowerSeries.WithPiTopology.hasSum_of_monomials_self f
-  simp only [LinearEquiv.coe_toEquiv, comp_apply, monomial, coeff,
-    Finsupp.LinearEquiv.finsuppUnique_apply, PUnit.default_eq_unit]
+  simp only [LinearEquiv.coe_toEquiv, comp_apply, monomial, coeff]
   congr
   all_goals { ext; simp }
 

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -210,7 +210,7 @@ theorem coeff_subst_finite (ha : HasSubst a) (f : PowerSeries R) (e : τ →₀ 
     (fun (d : ℕ) ↦ coeff d f • MvPowerSeries.coeff e (a ^ d)).HasFiniteSupport := by
   rw [Function.HasFiniteSupport]
   convert (MvPowerSeries.coeff_subst_finite ha.const f e).image
-    (Finsupp.LinearEquiv.finsuppUnique ℕ ℕ Unit).toEquiv
+    (Finsupp.uniqueLinearEquiv ℕ ℕ ()).toEquiv
   rw [← Equiv.preimage_eq_iff_eq_image, ← Function.support_comp_eq_preimage]
   apply congr_arg
   rw [← Equiv.eq_comp_symm]
@@ -226,10 +226,11 @@ theorem coeff_subst (ha : HasSubst a) (f : PowerSeries R) (e : τ →₀ ℕ) :
       finsum (fun (d : ℕ) ↦
         coeff d f • (MvPowerSeries.coeff e (a ^ d))) := by
   rw [subst, MvPowerSeries.coeff_subst ha.const f e, ← finsum_comp_equiv
-    (Finsupp.LinearEquiv.finsuppUnique ℕ ℕ Unit).toEquiv.symm]
+    (Finsupp.uniqueLinearEquiv ℕ ℕ ()).toEquiv.symm]
   apply finsum_congr
   intro
-  congr <;> simp
+  congr
+  simp
 
 theorem coeff_subst' {b : S⟦X⟧} (hb : HasSubst b) (f : R⟦X⟧) (e : ℕ) :
     coeff e (f.subst b) =

--- a/Mathlib/RingTheory/TensorProduct/Free.lean
+++ b/Mathlib/RingTheory/TensorProduct/Free.lean
@@ -48,7 +48,7 @@ variable (A) in
 /-- Given an `R`-algebra `A` and an `R`-basis of `M`, this is an `R`-linear isomorphism
 `A ⊗[R] M ≃ (ι →₀ A)` (which is in fact `A`-linear). -/
 noncomputable def basisAux : A ⊗[R] M ≃ₗ[R] ι →₀ A :=
-  _root_.TensorProduct.congr (Finsupp.LinearEquiv.finsuppUnique R A PUnit.{uι + 1}).symm b.repr ≪≫ₗ
+  _root_.TensorProduct.congr (Finsupp.uniqueLinearEquiv R A ()).symm b.repr ≪≫ₗ
     (finsuppTensorFinsupp R R A R PUnit ι).trans
       (Finsupp.lcongr (Equiv.uniqueProd ι PUnit) (_root_.TensorProduct.rid R A))
 


### PR DESCRIPTION
In essence, this changes `(Finsupp.uniqueEquiv i).symm m` from having support `univ.filter (fun _ ↦ m ≠ 0)` to having support `if m = 0 then {i} else ∅`. These are equal, but having the RHS be `single 1 r` is much more useful in practice. Similarly for `MonoidAlgebra`. To avoid simp getting stuck after rewriting with `uniqueEquiv_symm_apply`, add `uniqueEquiv_symm_apply_apply` and tag it with `simp↓ high`.

Also rename `Equiv.finsuppUnique` to `Finsupp.uniqueEquiv` and change the `Unique ι` argument into `Subsingleton ι` and `i : ι`. Similarly for `AddEquiv` and `LinearEquiv`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
