### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Comma): API separation for Arrow

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -976,7 +976,7 @@ def SpecMapRestrictBasicOpenIso {R S : CommRingCat} (f : R ⟶ S) (r : R) :
   · have := AlgebraicGeometry.IsOpenImmersion.of_isLocalization
       (S := (Localization.Away r)) r
     rw [← cancel_mono (Spec.map (CommRingCat.ofHom (algebraMap R (Localization.Away r))))]
-    simp only [Arrow.mk_left, Arrow.mk_right, Functor.id_obj, Scheme.isoOfEq_rfl, Iso.refl_trans,
+    simp only [Arrow.mk_left, Arrow.mk_right, Scheme.isoOfEq_rfl, Iso.refl_trans,
       Iso.trans_hom, Functor.mapIso_hom, Iso.op_hom, Scheme.Spec_map, Quiver.Hom.unop_op,
       Arrow.mk_hom, Category.assoc, ← Spec.map_comp]
     conv =>

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -645,8 +645,9 @@ def morphismRestrictOpensRange {X Y U : Scheme.{u}} (f : X ⟶ Y) (g : U ⟶ Y) 
       (by rw [Category.comp_id, IsOpenImmersion.isoOfRangeEq_hom_fac])
   symm
   refine Arrow.isoMk (asIso t ≪≫ pullbackRestrictIsoRestrict f V) e ?_
-  rw [Iso.trans_hom, asIso_hom, ← Iso.comp_inv_eq, ← cancel_mono g, Arrow.mk_hom, Arrow.mk_hom,
-    Category.assoc, Category.assoc, Category.assoc, IsOpenImmersion.isoOfRangeEq_inv_fac,
+  rw [Iso.trans_hom, asIso_hom, ← Iso.comp_inv_eq, ← cancel_mono g]
+  dsimp
+  rw [Category.assoc, Category.assoc, Category.assoc, IsOpenImmersion.isoOfRangeEq_inv_fac,
     ← pullback.condition, morphismRestrict_ι,
     pullbackRestrictIsoRestrict_hom_ι_assoc, pullback.lift_fst_assoc, Category.comp_id]
 
@@ -796,7 +797,7 @@ set_option backward.isDefEq.respectTransparency false in
 noncomputable def arrowResLEAppIso (f : X ⟶ Y) (U : Y.Opens) (V : X.Opens) (e : V ≤ f ⁻¹ᵁ U) :
     Arrow.mk ((f.resLE U V e).appTop) ≅ Arrow.mk (f.appLE U V e) :=
   Arrow.isoMk U.topIso V.topIso <| by
-  simp only [Arrow.mk_left, Arrow.mk_right, Functor.id_obj, Scheme.Opens.topIso_hom,
+  simp only [Arrow.mk_left, Arrow.mk_right, Scheme.Opens.topIso_hom,
     eqToHom_op, Arrow.mk_hom, Scheme.Hom.map_appLE]
   rw [Scheme.Hom.appTop, ← Scheme.Hom.appLE_eq_app, Scheme.Hom.resLE_appLE, Scheme.Hom.appLE_map]
 

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -1035,7 +1035,7 @@ noncomputable def arrowStalkMapIsoOfEq {x y : X}
     (h : x = y) : Arrow.mk (f.stalkMap x) ≅ Arrow.mk (f.stalkMap y) :=
   Arrow.isoMk (Y.presheaf.stalkCongr <| (Inseparable.of_eq h).map f.continuous)
       (X.presheaf.stalkCongr <| Inseparable.of_eq h) <| by
-    simp only [Arrow.mk_left, Arrow.mk_right, Functor.id_obj, TopCat.Presheaf.stalkCongr_hom,
+    simp only [Arrow.mk_left, Arrow.mk_right, TopCat.Presheaf.stalkCongr_hom,
       Arrow.mk_hom]
     rw [stalkSpecializes_stalkMap]
 

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -243,7 +243,6 @@ def augmentedCechConerve : Arrow C ⥤ CosimplicialObject.Augmented C where
   obj f := f.augmentedCechConerve
   map F := Arrow.mapAugmentedCechConerve F
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A helper function used in defining the Čech conerve adjunction. -/
 @[simps!]
 def equivalenceLeftToRight (F : Arrow C) (X : CosimplicialObject.Augmented C)

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -245,16 +245,13 @@ def augmentedCechConerve : Arrow C ⥤ CosimplicialObject.Augmented C where
 
 set_option backward.isDefEq.respectTransparency false in
 /-- A helper function used in defining the Čech conerve adjunction. -/
-@[simps]
+@[simps!]
 def equivalenceLeftToRight (F : Arrow C) (X : CosimplicialObject.Augmented C)
-    (G : F.augmentedCechConerve ⟶ X) : F ⟶ Augmented.toArrow.obj X where
-  left := G.left
-  right := (WidePushout.ι _ 0 ≫ G.right.app ⦋0⦌ :)
-  w := by
+    (G : F.augmentedCechConerve ⟶ X) : F ⟶ Augmented.toArrow.obj X :=
+  Arrow.homMk G.left (WidePushout.ι _ 0 ≫ G.right.app ⦋0⦌ :) (by
     dsimp
-    rw [@WidePushout.arrow_ι_assoc _ _ _ _ _ (fun (_ : Fin 1) => F.hom)
-      (by dsimp; infer_instance)]
-    exact congr_app G.w ⦋0⦌
+    rw [WidePushout.arrow_ι_assoc (fun (_ : Fin 1) => F.hom)]
+    exact congr_app G.w ⦋0⦌)
 
 set_option backward.isDefEq.respectTransparency false in
 /-- A helper function used in defining the Čech conerve adjunction. -/

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -68,7 +68,7 @@ theorem id_left (f : Arrow T) : Arrow.Hom.left (𝟙 f) = 𝟙 f.left :=
   rfl
 
 @[simp]
-theorem id_right (f : Arrow T) : Arrow.Hom.right (𝟙 f) = 𝟙 f.right := by
+theorem id_right (f : Arrow T) : Arrow.Hom.right (𝟙 f) = 𝟙 f.right :=
   rfl
 
 @[simp, reassoc]
@@ -311,7 +311,7 @@ theorem square_to_iso_invert (i : Arrow T) {X Y : T} (p : X ≅ Y) (sq : i ⟶ A
 in terms of the inverse of `i`. -/
 theorem square_from_iso_invert {X Y : T} (i : X ≅ Y) (p : Arrow T) (sq : Arrow.mk i.hom ⟶ p) :
     i.inv ≫ sq.left ≫ p.hom = sq.right := by
-  simp [dsimp% sq.w]
+  simp [Arrow.w_mk_left]
 
 variable {C : Type u} [Category.{v} C]
 
@@ -325,10 +325,10 @@ A  → X
 B  → Z                 B → Z
 ```
 -/
---@[simps!]
+@[simps!]
 def squareToSnd {X Y Z : C} {i : Arrow C} {f : X ⟶ Y} {g : Y ⟶ Z} (sq : i ⟶ Arrow.mk (f ≫ g)) :
     i ⟶ Arrow.mk g :=
-  Arrow.homMk (sq.left ≫ f) (sq.right) (by simp [dsimp% sq.w])
+  Arrow.homMk (sq.left ≫ f) (sq.right) (by simp [w_mk sq])
 
 /-- The functor sending an arrow to its source. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -177,10 +177,19 @@ def homMk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} (u : X ⟶ P) (v : Y 
   right := v
   w := w
 
--- `w_mk_left` is not needed, as it is a consequence of `w` and `mk_hom`.
+@[reassoc]
+theorem w_mk_left {X Y : T} {f : X ⟶ Y} {g : Arrow T} (sq : mk f ⟶ g) :
+    dsimp% sq.left ≫ g.hom = f ≫ sq.right :=
+  sq.w
+
 @[reassoc (attr := simp)]
 theorem w_mk_right {f : Arrow T} {X Y : T} {g : X ⟶ Y} (sq : f ⟶ mk g) :
-    sq.left ≫ g = f.hom ≫ sq.right :=
+    dsimp% sq.left ≫ g = f.hom ≫ sq.right :=
+  sq.w
+
+@[reassoc]
+theorem w_mk {X Y X' Y' : T} {f : X ⟶ Y} {g : X' ⟶ Y'} (sq : mk f ⟶ mk g) :
+    dsimp% sq.left ≫ g = f ≫ sq.right :=
   sq.w
 
 theorem isIso_of_isIso_left_of_isIso_right {f g : Arrow T} (ff : f ⟶ g) [IsIso ff.left]
@@ -258,7 +267,7 @@ instance mono_left [Mono sq] : Mono sq.left where
     rw [← cancel_mono sq]
     ext
     · exact h
-    · simp [this, ← Arrow.w, reassoc_of% h]
+    · simp [this, ← Arrow.w_mk_right, reassoc_of% h]
 
 instance epi_right [Epi sq] : Epi sq.right where
   left_cancellation {Z} φ ψ h := by

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -106,11 +106,13 @@ theorem mk_inj (A B : T) {f g : A ⟶ B} : Arrow.mk f = Arrow.mk g ↔ f = g :=
 instance {X Y : T} : CoeOut (X ⟶ Y) (Arrow T) where
   coe := mk
 
--- Note: it could be good to add variants of this in the case `f` or `g` is of
--- the form `Arrow.mk _`, so that we do not need to use `dsimp% sq.w` below
 @[reassoc (attr := simp high)]
 theorem w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right :=
   CommaMorphism.w sq
+
+@[reassoc]
+lemma Hom.w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right := by
+  simp
 
 theorem hom.congr_left {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.left = φ₂.left := by
   rw [h]

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -106,17 +106,40 @@ theorem mk_inj (A B : T) {f g : A ⟶ B} : Arrow.mk f = Arrow.mk g ↔ f = g :=
 instance {X Y : T} : CoeOut (X ⟶ Y) (Arrow T) where
   coe := mk
 
-set_option backward.isDefEq.respectTransparency false in
+-- Note: it could be good to add variants of this in the case `f` or `g` is of
+-- the form `Arrow.mk _`, so that we do not need to use `dsimp% sq.w` below
+@[reassoc (attr := simp high)]
+theorem w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right :=
+  CommaMorphism.w sq
+
+theorem hom.congr_left {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.left = φ₂.left := by
+  rw [h]
+
+theorem hom.congr_right {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.right = φ₂.right := by
+  simp [h]
+
+theorem iso_w {f g : Arrow T} (e : f ≅ g) : g.hom = e.inv.left ≫ f.hom ≫ e.hom.right := by
+  have eq := Arrow.hom.congr_right e.inv_hom_id
+  rw [Arrow.comp_right, Arrow.id_right] at eq
+  rw [Arrow.w_assoc, eq, Category.comp_id]
+
+theorem iso_w' {W X Y Z : T} {f : W ⟶ X} {g : Y ⟶ Z} (e : Arrow.mk f ≅ Arrow.mk g) :
+    g = e.inv.left ≫ f ≫ e.hom.right :=
+  iso_w e
+
+lemma eqToHom_left {X Y : Arrow T} (h : X = Y) :
+    (eqToHom h).left = eqToHom (by rw [h]) := by subst h; rfl
+
+lemma eqToHom_right {X Y : Arrow T} (h : X = Y) :
+    (eqToHom h).right = eqToHom (by rw [h]) := by subst h; rfl
+
 lemma mk_eq_mk_iff {X Y X' Y' : T} (f : X ⟶ Y) (f' : X' ⟶ Y') :
     Arrow.mk f = Arrow.mk f' ↔
       ∃ (hX : X = X') (hY : Y = Y'), f = eqToHom hX ≫ f' ≫ eqToHom hY.symm := by
   constructor
   · intro h
-    refine ⟨congr_arg Comma.left h, congr_arg Comma.right h, ?_⟩
-    have := (eqToIso h).hom.w
-    dsimp at this
-    rw [Comma.eqToHom_left, Comma.eqToHom_right] at this
-    rw [reassoc_of% this, eqToHom_trans, eqToHom_refl, Category.comp_id]
+    refine ⟨congr_arg Arrow.left h, congr_arg Arrow.right h, ?_⟩
+    simpa [eqToHom_left, eqToHom_right] using iso_w (eqToIso h.symm)
   · rintro ⟨rfl, rfl, h⟩
     simp only [eqToHom_refl, Category.comp_id, Category.id_comp] at h
     rw [h]
@@ -160,10 +183,6 @@ theorem w_mk_right {f : Arrow T} {X Y : T} {g : X ⟶ Y} (sq : f ⟶ mk g) :
     sq.left ≫ g = f.hom ≫ sq.right :=
   sq.w
 
-@[reassoc (attr := simp high)]
-theorem w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right :=
-  CommaMorphism.w sq
-
 theorem isIso_of_isIso_left_of_isIso_right {f g : Arrow T} (ff : f ⟶ g) [IsIso ff.left]
     [IsIso ff.right] : IsIso ff where
   out := ⟨homMk (inv ff.left) (inv ff.right), by cat_disch⟩
@@ -182,21 +201,6 @@ abbrev isoMk' {W X Y Z : T} (f : W ⟶ X) (g : Y ⟶ Z) (e₁ : W ≅ Y) (e₂ :
     (h : e₁.hom ≫ g = f ≫ e₂.hom := by cat_disch) : Arrow.mk f ≅ Arrow.mk g :=
   Arrow.isoMk e₁ e₂ h
 
-theorem hom.congr_left {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.left = φ₂.left := by
-  rw [h]
-
-theorem hom.congr_right {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.right = φ₂.right := by
-  simp [h]
-
-theorem iso_w {f g : Arrow T} (e : f ≅ g) : g.hom = e.inv.left ≫ f.hom ≫ e.hom.right := by
-  have eq := Arrow.hom.congr_right e.inv_hom_id
-  rw [Arrow.comp_right, Arrow.id_right] at eq
-  rw [Arrow.w_assoc, eq, Category.comp_id]
-
-theorem iso_w' {W X Y Z : T} {f : W ⟶ X} {g : Y ⟶ Z} (e : Arrow.mk f ≅ Arrow.mk g) :
-    g = e.inv.left ≫ f ≫ e.hom.right :=
-  iso_w e
-
 section
 
 variable {f g : Arrow T} (sq : f ⟶ g)
@@ -207,16 +211,19 @@ instance isIso_left [IsIso sq] : IsIso sq.left :=
 instance isIso_right [IsIso sq] : IsIso sq.right :=
   ⟨(inv sq).right, by simp [← comp_right]⟩
 
-set_option backward.isDefEq.respectTransparency false in
-lemma isIso_of_isIso {X Y : T} {f : X ⟶ Y} {g : Arrow T} (sq : mk f ⟶ g) [IsIso sq] [IsIso f] :
+lemma isIso_of_isIso' {f g : Arrow T} (sq : f ⟶ g) [IsIso sq] [IsIso f.hom] :
     IsIso g.hom := by
-  simp only [iso_w' (asIso sq)]
+  rw [iso_w (asIso sq)]
   infer_instance
 
-set_option backward.isDefEq.respectTransparency false in
+lemma isIso_of_isIso {X Y : T} {f : X ⟶ Y} {g : Arrow T} (sq : mk f ⟶ g) [IsIso sq] [IsIso f] :
+    IsIso g.hom := by
+  have : IsIso (mk f).hom := by assumption
+  apply isIso_of_isIso' sq
+
 lemma isIso_hom_iff_isIso_hom_of_isIso {f g : Arrow T} (sq : f ⟶ g) [IsIso sq] :
     IsIso f.hom ↔ IsIso g.hom :=
-  ⟨fun _ => isIso_of_isIso sq, fun _ => isIso_of_isIso (inv sq)⟩
+  ⟨fun _ => isIso_of_isIso' sq, fun _ => isIso_of_isIso' (inv sq)⟩
 
 lemma isIso_iff_isIso_of_isIso {W X Y Z : T} {f : W ⟶ X} {g : Y ⟶ Z} (sq : mk f ⟶ mk g) [IsIso sq] :
     IsIso f ↔ IsIso g :=
@@ -226,7 +233,6 @@ lemma isIso_hom_iff_isIso_of_isIso {Y Z : T} {f : Arrow T} {g : Y ⟶ Z} (sq : f
     IsIso f.hom ↔ IsIso g :=
   isIso_hom_iff_isIso_hom_of_isIso sq
 
---set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem inv_left [IsIso sq] : (inv sq).left = inv sq.left :=
   IsIso.eq_inv_of_hom_inv_id (by simp [← comp_left])
@@ -254,17 +260,15 @@ instance mono_left [Mono sq] : Mono sq.left where
     · exact h
     · simp [this, ← Arrow.w, reassoc_of% h]
 
-set_option backward.isDefEq.respectTransparency false in
 instance epi_right [Epi sq] : Epi sq.right where
   left_cancellation {Z} φ ψ h := by
     let aux : (g.right ⟶ Z) → (g ⟶ Arrow.mk (𝟙 Z)) := fun φ =>
-      { right := φ
-        left := g.hom ≫ φ }
+      Arrow.homMk (g.hom ≫ φ) φ
     change (aux φ).right = (aux ψ).right
     congr 1
     rw [← cancel_epi sq]
-    apply CommaMorphism.ext
-    · rw [Comma.comp_left, Comma.comp_left, Arrow.w_assoc, Arrow.w_assoc, h]
+    ext
+    · simp only [comp_left, comp_left, aux, mk_left, homMk_left, w_assoc, h]
     · exact h
 
 @[reassoc (attr := simp)]
@@ -285,23 +289,21 @@ lemma inv_hom_id_right (e : f ≅ g) : e.inv.right ≫ e.hom.right = 𝟙 _ := b
 
 end
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given a square from an arrow `i` to an isomorphism `p`, express the source part of `sq`
 in terms of the inverse of `p`. -/
 @[simp]
 theorem square_to_iso_invert (i : Arrow T) {X Y : T} (p : X ≅ Y) (sq : i ⟶ Arrow.mk p.hom) :
     i.hom ≫ sq.right ≫ p.inv = sq.left := by
-  simpa only [Category.assoc] using (Iso.comp_inv_eq p).mpr (Arrow.w_mk_right sq).symm
+  simpa only [mk_right, Category.assoc] using (Iso.comp_inv_eq p).mpr (Arrow.w_mk_right sq).symm
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given a square from an isomorphism `i` to an arrow `p`, express the target part of `sq`
 in terms of the inverse of `i`. -/
 theorem square_from_iso_invert {X Y : T} (i : X ≅ Y) (p : Arrow T) (sq : Arrow.mk i.hom ⟶ p) :
-    i.inv ≫ sq.left ≫ p.hom = sq.right := by simp only [Iso.inv_hom_id_assoc, Arrow.w, Arrow.mk_hom]
+    i.inv ≫ sq.left ≫ p.hom = sq.right := by
+  simp [dsimp% sq.w]
 
 variable {C : Type u} [Category.{v} C]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A helper construction: given a square between `i` and `f ≫ g`, produce a square between
 `i` and `g`, whose top leg uses `f`:
 ```
@@ -312,11 +314,10 @@ A  → X
 B  → Z                 B → Z
 ```
 -/
-@[simps]
+--@[simps!]
 def squareToSnd {X Y Z : C} {i : Arrow C} {f : X ⟶ Y} {g : Y ⟶ Z} (sq : i ⟶ Arrow.mk (f ≫ g)) :
-    i ⟶ Arrow.mk g where
-  left := sq.left ≫ f
-  right := sq.right
+    i ⟶ Arrow.mk g :=
+  Arrow.homMk (sq.left ≫ f) (sq.right) (by simp [dsimp% sq.w])
 
 /-- The functor sending an arrow to its source. -/
 @[simps!]
@@ -328,7 +329,6 @@ def leftFunc : Arrow C ⥤ C :=
 def rightFunc : Arrow C ⥤ C :=
   Comma.snd _ _
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The natural transformation from `leftFunc` to `rightFunc`, given by the arrow itself. -/
 @[simps]
 def leftToRight : (leftFunc : Arrow C ⥤ C) ⟶ rightFunc where app f := f.hom
@@ -341,7 +341,6 @@ universe v₁ v₂ u₁ u₂
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- A functor `C ⥤ D` induces a functor between the corresponding arrow categories. -/
 @[simps]
 def mapArrow (F : C ⥤ D) : Arrow C ⥤ Arrow D where

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -29,19 +29,34 @@ universe v u
 -- morphism levels before object levels. See note [category theory universes].
 variable {T : Type u} [Category.{v} T]
 
-section
-
-variable (T)
-
+variable (T) in
 /-- The arrow category of `T` has as objects all morphisms in `T` and as morphisms commutative
 squares in `T`. -/
-def Arrow :=
-  Comma.{v, v, v} (𝟭 T) (𝟭 T)
-deriving Category, [Inhabited T] → Inhabited _
+def Arrow := Comma (𝟭 T) (𝟭 T)
 
-end
+/-- The type of morphisms in the category `Arrow T`. -/
+protected def Arrow.Hom (f g : Arrow T) := CommaMorphism f g
+
+instance : Category (Arrow T) where
+  Hom := Arrow.Hom
+  __ := (inferInstance : Category (Comma (𝟭 T) (𝟭 T)))
 
 namespace Arrow
+
+/-- The left object of an arrow. -/
+abbrev left (X : Arrow T) : T := Comma.left X
+
+/-- The right object of an arrow. -/
+abbrev right (X : Arrow T) : T := Comma.right X
+
+/-- Given `X : Arrow T`, this is the morphism `X.left ⟶ X.right`. -/
+abbrev hom (X : Arrow T) : X.left ⟶ X.right := Comma.hom X
+
+/-- The left part of a morphism in the category of arrows. -/
+abbrev Hom.left {X Y : Arrow T} (f : X ⟶ Y) : X.left ⟶ Y.left := CommaMorphism.left f
+
+/-- The right part of a morphism in the category of arrows. -/
+abbrev Hom.right {X Y : Arrow T} (f : X ⟶ Y) : X.right ⟶ Y.right := CommaMorphism.right f
 
 @[ext]
 lemma hom_ext {X Y : Arrow T} (f g : X ⟶ Y) (h₁ : f.left = g.left) (h₂ : f.right = g.right) :
@@ -49,11 +64,11 @@ lemma hom_ext {X Y : Arrow T} (f g : X ⟶ Y) (h₁ : f.left = g.left) (h₂ : f
   CommaMorphism.ext h₁ h₂
 
 @[simp]
-theorem id_left (f : Arrow T) : CommaMorphism.left (𝟙 f) = 𝟙 f.left :=
+theorem id_left (f : Arrow T) : Arrow.Hom.left (𝟙 f) = 𝟙 f.left :=
   rfl
 
 @[simp]
-theorem id_right (f : Arrow T) : CommaMorphism.right (𝟙 f) = 𝟙 f.right :=
+theorem id_right (f : Arrow T) : Arrow.Hom.right (𝟙 f) = 𝟙 f.right := by
   rfl
 
 @[simp, reassoc]
@@ -140,24 +155,18 @@ def homMk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} (u : X ⟶ P) (v : Y 
   w := w
 
 -- `w_mk_left` is not needed, as it is a consequence of `w` and `mk_hom`.
-set_option backward.isDefEq.respectTransparency false in -- This is needed in Algebra/Homology/ShortComplex/QuasiIso.lean
 @[reassoc (attr := simp)]
 theorem w_mk_right {f : Arrow T} {X Y : T} {g : X ⟶ Y} (sq : f ⟶ mk g) :
     sq.left ≫ g = f.hom ≫ sq.right :=
   sq.w
 
-set_option backward.isDefEq.respectTransparency false in
-@[reassoc]
-theorem w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right := by
-  simp
+@[reassoc (attr := simp high)]
+theorem w {f g : Arrow T} (sq : f ⟶ g) : sq.left ≫ g.hom = f.hom ≫ sq.right :=
+  CommaMorphism.w sq
 
-set_option backward.isDefEq.respectTransparency false in
 theorem isIso_of_isIso_left_of_isIso_right {f g : Arrow T} (ff : f ⟶ g) [IsIso ff.left]
     [IsIso ff.right] : IsIso ff where
-  out := by
-    let inverse : g ⟶ f := ⟨inv ff.left, inv ff.right, (by simp)⟩
-    apply Exists.intro inverse
-    cat_disch
+  out := ⟨homMk (inv ff.left) (inv ff.right), by cat_disch⟩
 
 /-- Create an isomorphism between arrows,
 by providing isomorphisms between the domains and codomains,
@@ -179,7 +188,6 @@ theorem hom.congr_left {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ�
 theorem hom.congr_right {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.right = φ₂.right := by
   simp [h]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem iso_w {f g : Arrow T} (e : f ≅ g) : g.hom = e.inv.left ≫ f.hom ≫ e.hom.right := by
   have eq := Arrow.hom.congr_right e.inv_hom_id
   rw [Arrow.comp_right, Arrow.id_right] at eq
@@ -193,24 +201,16 @@ section
 
 variable {f g : Arrow T} (sq : f ⟶ g)
 
-set_option backward.isDefEq.respectTransparency false in
-instance isIso_left [IsIso sq] : IsIso sq.left where
-  out := by
-    apply Exists.intro (inv sq).left
-    simp only [← Comma.comp_left, IsIso.hom_inv_id, IsIso.inv_hom_id]
-    simp
+instance isIso_left [IsIso sq] : IsIso sq.left :=
+  ⟨(inv sq).left, by simp [← comp_left]⟩
 
-set_option backward.isDefEq.respectTransparency false in
-instance isIso_right [IsIso sq] : IsIso sq.right where
-  out := by
-    apply Exists.intro (inv sq).right
-    simp only [← Comma.comp_right, IsIso.hom_inv_id, IsIso.inv_hom_id]
-    simp
+instance isIso_right [IsIso sq] : IsIso sq.right :=
+  ⟨(inv sq).right, by simp [← comp_right]⟩
 
 set_option backward.isDefEq.respectTransparency false in
 lemma isIso_of_isIso {X Y : T} {f : X ⟶ Y} {g : Arrow T} (sq : mk f ⟶ g) [IsIso sq] [IsIso f] :
     IsIso g.hom := by
-  rw [iso_w' (asIso sq)]
+  simp only [iso_w' (asIso sq)]
   infer_instance
 
 set_option backward.isDefEq.respectTransparency false in
@@ -226,39 +226,33 @@ lemma isIso_hom_iff_isIso_of_isIso {Y Z : T} {f : Arrow T} {g : Y ⟶ Z} (sq : f
     IsIso f.hom ↔ IsIso g :=
   isIso_hom_iff_isIso_hom_of_isIso sq
 
-set_option backward.isDefEq.respectTransparency false in
+--set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem inv_left [IsIso sq] : (inv sq).left = inv sq.left :=
-  IsIso.eq_inv_of_hom_inv_id <| by rw [← Comma.comp_left, IsIso.hom_inv_id, id_left]
+  IsIso.eq_inv_of_hom_inv_id (by simp [← comp_left])
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem inv_right [IsIso sq] : (inv sq).right = inv sq.right :=
-  IsIso.eq_inv_of_hom_inv_id <| by rw [← Comma.comp_right, IsIso.hom_inv_id, id_right]
+  IsIso.eq_inv_of_hom_inv_id (by simp [← comp_right])
 
-set_option backward.isDefEq.respectTransparency false in
 theorem left_hom_inv_right [IsIso sq] : sq.left ≫ g.hom ≫ inv sq.right = f.hom := by
   simp only [← Category.assoc, IsIso.comp_inv_eq, w]
 
-set_option backward.isDefEq.respectTransparency false in
 theorem inv_left_hom_right [IsIso sq] : inv sq.left ≫ f.hom ≫ sq.right = g.hom := by
   simp only [w, IsIso.inv_comp_eq]
 
-set_option backward.isDefEq.respectTransparency false in
 instance mono_left [Mono sq] : Mono sq.left where
   right_cancellation {Z} φ ψ h := by
     let aux : (Z ⟶ f.left) → (Arrow.mk (𝟙 Z) ⟶ f) := fun φ =>
       { left := φ
         right := φ ≫ f.hom }
-    have : ∀ g, (aux g).right = g ≫ f.hom := fun g => by dsimp
+    have : ∀ g, (aux g).right = g ≫ f.hom := fun g => rfl
     change (aux φ).left = (aux ψ).left
     congr 1
     rw [← cancel_mono sq]
-    apply CommaMorphism.ext
+    ext
     · exact h
-    · rw [Comma.comp_right, Comma.comp_right, this, this, Category.assoc, Category.assoc]
-      rw [← Arrow.w]
-      simp only [← Category.assoc, h]
+    · simp [this, ← Arrow.w, reassoc_of% h]
 
 set_option backward.isDefEq.respectTransparency false in
 instance epi_right [Epi sq] : Epi sq.right where
@@ -352,14 +346,7 @@ set_option backward.isDefEq.respectTransparency false in
 @[simps]
 def mapArrow (F : C ⥤ D) : Arrow C ⥤ Arrow D where
   obj a := Arrow.mk (F.map a.hom)
-  map f :=
-    { left := F.map f.left
-      right := F.map f.right
-      w := by
-        let w := f.w
-        simp only [id_map] at w
-        dsimp
-        simp only [← F.map_comp, w] }
+  map f := Arrow.homMk (F.map f.left) (F.map f.right) (by simp [← Functor.map_comp])
 
 variable (C D)
 
@@ -368,14 +355,12 @@ a functor `F : C ⥤ D` to `F.mapArrow`. -/
 @[simps]
 def mapArrowFunctor : (C ⥤ D) ⥤ (Arrow C ⥤ Arrow D) where
   obj F := F.mapArrow
-  map τ :=
-    { app := fun f =>
-        { left := τ.app _
-          right := τ.app _ } }
+  map τ := { app f := Arrow.homMk (τ.app _) (τ.app _) }
 
 variable {C D}
 
 /-- The equivalence of categories `Arrow C ≌ Arrow D` induced by an equivalence `C ≌ D`. -/
+@[simps]
 def mapArrowEquivalence (e : C ≌ D) : Arrow C ≌ Arrow D where
   functor := e.functor.mapArrow
   inverse := e.inverse.mapArrow

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -121,9 +121,7 @@ theorem hom.congr_right {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ�
   simp [h]
 
 theorem iso_w {f g : Arrow T} (e : f ≅ g) : g.hom = e.inv.left ≫ f.hom ≫ e.hom.right := by
-  have eq := Arrow.hom.congr_right e.inv_hom_id
-  rw [Arrow.comp_right, Arrow.id_right] at eq
-  rw [Arrow.w_assoc, eq, Category.comp_id]
+  simp [← Arrow.comp_right]
 
 theorem iso_w' {W X Y Z : T} {f : W ⟶ X} {g : Y ⟶ Z} (e : Arrow.mk f ≅ Arrow.mk g) :
     g = e.inv.left ≫ f ≫ e.hom.right :=

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -290,7 +290,7 @@ instance [Small.{w} C] [LocallySmall.{w} C] :
   refine small_of_injective (f := φ) ?_
   rintro ⟨s, t, f⟩ ⟨s', t', f'⟩ h
   obtain rfl : s = s' := congr_arg Sigma.fst h
-  simp only [Functor.id_obj, Sigma.mk.injEq, heq_eq_eq, true_and, φ] at h
+  simp only [Sigma.mk.injEq, heq_eq_eq, true_and, φ] at h
   obtain rfl : t = t' := h.1
   obtain rfl : f = f' := by simpa using h
   rfl

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -84,7 +84,7 @@ lemma autEmbedding_range :
     Set.range (autEmbedding F) = ⋂ (f : Arrow C), { a | (F.map f.hom ≫ (a f.right).hom : _ → _) =
       (a f.left).hom ≫ F.map f.hom } := by
   ext a
-  simp +instances only [Set.mem_range, id_obj, DFunLike.coe_fn_eq, Set.mem_iInter, Set.mem_setOf_eq]
+  simp +instances only [Set.mem_range, DFunLike.coe_fn_eq, Set.mem_iInter, Set.mem_setOf_eq]
   refine ⟨fun ⟨σ, h⟩ i ↦ by cat_disch, fun h ↦ ?_⟩
   exact ⟨NatIso.ofComponents a (fun {X Y} f ↦ by
     ext; simpa using ConcreteCategory.congr_hom (h ⟨X, Y, f⟩) _), rfl⟩

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -753,7 +753,7 @@ instance HasImageMap.comp {f g h : Arrow C} [HasImage f.hom] [HasImage g.hom] [H
   HasImageMap.mk
     { map := (HasImageMap.imageMap sq1).map ≫ (HasImageMap.imageMap sq2).map
       map_ι := by
-        rw [Category.assoc, ImageMap.map_ι, ImageMap.map_ι_assoc, Comma.comp_right] }
+        rw [Category.assoc, ImageMap.map_ι, ImageMap.map_ι_assoc, Arrow.comp_right] }
 
 variable {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] (sq : f ⟶ g)
 
@@ -780,7 +780,7 @@ theorem ImageMap.mk.injEq' {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] {sq
     (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by cat_disch)
     (map' : image f.hom ⟶ image g.hom)
     (map_ι' : map' ≫ image.ι g.hom = image.ι f.hom ≫ sq.right) : (map = map') = True := by
-  simp only [Functor.id_obj, eq_iff_iff, iff_true]
+  simp only [eq_iff_iff, iff_true]
   apply ImageMap.map_uniq_aux _ map_ι _ map_ι'
 
 instance : Subsingleton (ImageMap sq) :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -685,8 +685,6 @@ end
 
 section HasImageMap
 
--- Don't generate unnecessary injectivity lemmas which the `simpNF` linter will complain about.
-set_option genInjectivity false in
 /-- An image map is a morphism `image f → image g` fitting into a commutative square and satisfying
 the obvious commutativity conditions. -/
 structure ImageMap {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] (sq : f ⟶ g) where
@@ -773,15 +771,8 @@ theorem ImageMap.map_uniq {f g : Arrow C} [HasImage f.hom] [HasImage g.hom]
     {sq : f ⟶ g} (F G : ImageMap sq) : F.map = G.map := by
   apply ImageMap.map_uniq_aux _ F.map_ι _ G.map_ι
 
-/-- `@[simp]`-normal form of `ImageMap.mk.injEq`. -/
-@[simp]
-theorem ImageMap.mk.injEq' {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] {sq : f ⟶ g}
-    (map : image f.hom ⟶ image g.hom)
-    (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by cat_disch)
-    (map' : image f.hom ⟶ image g.hom)
-    (map_ι' : map' ≫ image.ι g.hom = image.ι f.hom ≫ sq.right) : (map = map') = True := by
-  simp only [eq_iff_iff, iff_true]
-  apply ImageMap.map_uniq_aux _ map_ι _ map_ι'
+@[deprecated (since := "2026-04-08")]
+alias ImageMap.mk.injEq' :=  ImageMap.mk.injEq
 
 instance : Subsingleton (ImageMap sq) :=
   Subsingleton.intro fun a b =>

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackObjObj.lean
@@ -453,37 +453,32 @@ namespace LeibnizAdjunction
 set_option backward.isDefEq.respectTransparency false in
 /-- Given a parametrized adjunction `F ⊣₂ G` and an arrow `X₁ : Arrow C₁`, this is the induced
   adjunction `F.leibnizPushout.obj X₁ ⊣ G.leibnizPullback.obj (op X₁)`. -/
-@[simps]
+@[simps!]
 def adj (adj₂ : F ⊣₂ G) (X₁ : Arrow C₁) [HasPullbacks C₂] [HasPushouts C₃] :
     F.leibnizPushout.obj X₁ ⊣ G.leibnizPullback.obj (op X₁) where
-  unit := {
-    app X₂ := {
-      left := adj₂.homEquiv (pushout.inl ..)
-      right := pullback.lift (adj₂.homEquiv (pushout.inr ..)) (adj₂.homEquiv (𝟙 _))
-          (by simp [← homEquiv_naturality_one, ← homEquiv_naturality_three])
-      w := by
-        apply pullback.hom_ext
-        · simp [← homEquiv_naturality_one, ← homEquiv_naturality_two, pushout.condition]
-        · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three] }
-    naturality _ _ _ := by
-      ext
-      · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]
-      · apply pullback.hom_ext <;> simp [← homEquiv_naturality_two, ← homEquiv_naturality_three] }
-  counit := {
-    app X₃ := {
-      left := pushout.desc (adj₂.homEquiv.symm (𝟙 _)) (adj₂.homEquiv.symm (pullback.fst ..))
-        (by simp [← homEquiv_symm_naturality_one, ← homEquiv_symm_naturality_two])
-      right := adj₂.homEquiv.symm (pullback.snd ..)
-      w := by
-        apply pushout.hom_ext
-        · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three]
-        · simp [← homEquiv_symm_naturality_one, ← homEquiv_symm_naturality_three,
-            pullback.condition] }
-    naturality _ _ _ := by
-      ext
-      · apply pushout.hom_ext <;> simp [← homEquiv_symm_naturality_two,
-          ← homEquiv_symm_naturality_three]
-      · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three] }
+  unit.app X₂ := Arrow.homMk (adj₂.homEquiv (pushout.inl ..))
+    (pullback.lift (adj₂.homEquiv (pushout.inr ..)) (adj₂.homEquiv (𝟙 _))
+      (by simp [← homEquiv_naturality_one, ← homEquiv_naturality_three])) (by
+      apply pullback.hom_ext
+      · simp [← homEquiv_naturality_one, ← homEquiv_naturality_two, pushout.condition]
+      · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three])
+  unit.naturality _ _ _ := by
+    ext
+    · simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]
+    · apply pullback.hom_ext <;> simp [← homEquiv_naturality_two, ← homEquiv_naturality_three]
+  counit.app X₃ := Arrow.homMk
+    (pushout.desc (adj₂.homEquiv.symm (𝟙 _)) (adj₂.homEquiv.symm (pullback.fst ..))
+        (by simp [← homEquiv_symm_naturality_one, ← homEquiv_symm_naturality_two]))
+    (adj₂.homEquiv.symm (pullback.snd ..)) (by
+    apply pushout.hom_ext
+    · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three]
+    · simp [← homEquiv_symm_naturality_one, ← homEquiv_symm_naturality_three,
+      pullback.condition])
+  counit.naturality _ _ _ := by
+    ext
+    · apply pushout.hom_ext <;> simp [← homEquiv_symm_naturality_two,
+        ← homEquiv_symm_naturality_three]
+    · simp [← homEquiv_symm_naturality_two, ← homEquiv_symm_naturality_three]
   left_triangle_components _ := by
     ext
     · apply pushout.hom_ext <;> simp [← homEquiv_symm_naturality_two, ofHasPushout_pt]

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -87,9 +87,7 @@ def RegularMono.ofArrowIso {X'} {Y'} {f : X ⟶ Y} {g : X' ⟶ Y'}
   Z := h.Z
   left := e.inv.right ≫ h.left
   right := e.inv.right ≫ h.right
-  w := by
-    have := Arrow.mk_hom g ▸ Arrow.w_mk_right e.inv
-    simp_rw [← reassoc_of% this, h.w]
+  w := by simp only [← (Arrow.w_mk_assoc e.inv), h.w]
   isLimit := Fork.isLimitOfIsos _ h.isLimit _
     (Arrow.rightFunc.mapIso e) (Iso.refl _) (Arrow.leftFunc.mapIso e)
 

--- a/Mathlib/CategoryTheory/Limits/Types/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Images.lean
@@ -78,8 +78,8 @@ instance : HasImageMaps (Type u) where
       (fun x => ⟨st.right x.1, ⟨st.left (Classical.choose x.2), by
         have p := st.w
         replace p := congr_fun p (Classical.choose x.2)
-        simp only [Functor.id_obj, Functor.id_map, types_comp_apply] at p
-        rw [p, Classical.choose_spec x.2]⟩⟩) rfl
+        simp only [Functor.id_map, types_comp_apply] at p
+        simp [p, Classical.choose_spec x.2]⟩⟩) rfl
 
 variable {F : ℕᵒᵖ ⥤ Type u} {c : Cone F}
   (hF : ∀ n, Function.Surjective (F.map (homOfLE (Nat.le_succ n)).op))

--- a/Mathlib/CategoryTheory/Limits/Types/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Images.lean
@@ -78,8 +78,7 @@ instance : HasImageMaps (Type u) where
       (fun x => ⟨st.right x.1, ⟨st.left (Classical.choose x.2), by
         have p := st.w
         replace p := congr_fun p (Classical.choose x.2)
-        simp only [types_comp_apply] at p
-        simp [p, Classical.choose_spec x.2]⟩⟩) rfl
+        simp [dsimp% p, Classical.choose_spec x.2]⟩⟩) rfl
 
 variable {F : ℕᵒᵖ ⥤ Type u} {c : Cone F}
   (hF : ∀ n, Function.Surjective (F.map (homOfLE (Nat.le_succ n)).op))

--- a/Mathlib/CategoryTheory/Limits/Types/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Images.lean
@@ -78,7 +78,7 @@ instance : HasImageMaps (Type u) where
       (fun x => ⟨st.right x.1, ⟨st.left (Classical.choose x.2), by
         have p := st.w
         replace p := congr_fun p (Classical.choose x.2)
-        simp only [Functor.id_map, types_comp_apply] at p
+        simp only [types_comp_apply] at p
         simp [p, Classical.choose_spec x.2]⟩⟩) rfl
 
 variable {F : ℕᵒᵖ ⥤ Type u} {c : Cone F}

--- a/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Constructor.lean
+++ b/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Constructor.lean
@@ -103,8 +103,8 @@ lemma isConnected :
     ext
     dsimp
     rw [← cancel_epi (isoOfHom L W₂ ρ.w.left ρ.hw.1).hom, isoOfHom_hom,
-      isoOfHom_hom_inv_id_assoc, ← L.map_comp_assoc, Arrow.w_mk_right, Arrow.mk_hom,
-      L.map_comp, assoc, isoOfHom_hom_inv_id_assoc, fac]
+      isoOfHom_hom_inv_id_assoc, ← L.map_comp_assoc]
+    simp [fac]
 
 end Constructor
 

--- a/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Constructor.lean
+++ b/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Constructor.lean
@@ -101,10 +101,7 @@ lemma isConnected :
   · apply Zigzag.of_inv
     refine CostructuredArrow.homMk (StructuredArrow.homMk ρ.X₁.hom (by simp)) ?_
     ext
-    dsimp
-    rw [← cancel_epi (isoOfHom L W₂ ρ.w.left ρ.hw.1).hom, isoOfHom_hom,
-      isoOfHom_hom_inv_id_assoc, ← L.map_comp_assoc]
-    simp [fac]
+    simp [← cancel_epi (isoOfHom L W₂ ρ.w.left ρ.hw.1).hom, ← L.map_comp_assoc, fac]
 
 end Constructor
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -193,7 +193,7 @@ def functorCategory.Z : Arrow (J ⥤ C) ⥤ J ⥤ C where
       map_id j := by
         rw [← data.mapZ_id (f.hom.app j)]
         congr <;> simp
-      map_comp _ _ :=by
+      map_comp _ _ := by
         rw [← data.mapZ_comp]
         congr <;> simp }
   map τ :=

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -188,24 +188,17 @@ set_option backward.isDefEq.respectTransparency false in
 @[simps]
 def functorCategory.Z : Arrow (J ⥤ C) ⥤ J ⥤ C where
   obj f :=
-    { obj := fun j => (data.factorizationData (f.hom.app j)).Z
-      map := fun φ => data.mapZ
-        { left := f.left.map φ
-          right := f.right.map φ }
-      map_id := fun j => by
-        dsimp
+    { obj j := (data.factorizationData (f.hom.app j)).Z
+      map φ := data.mapZ (Arrow.homMk (f.left.map φ) (f.right.map φ))
+      map_id j := by
         rw [← data.mapZ_id (f.hom.app j)]
         congr <;> simp
-      map_comp := fun _ _ => by
-        dsimp
+      map_comp _ _ :=by
         rw [← data.mapZ_comp]
         congr <;> simp }
   map τ :=
-    { app := fun j => data.mapZ
-        { left := τ.left.app j
-          right := τ.right.app j
-          w := congr_app τ.w j }
-      naturality := fun _ _ α => by
+    { app j := data.mapZ (Arrow.homMk (τ.left.app j) (τ.right.app j) (congr_app τ.w j))
+      naturality _ _ _ := by
         dsimp
         rw [← data.mapZ_comp, ← data.mapZ_comp]
         congr 1

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -143,12 +143,8 @@ set_option backward.isDefEq.respectTransparency false in
 /-- If a morphism `f` is a retract of `g`, then `f.op` is a retract of `g.op`. -/
 @[simps]
 def op : RetractArrow f.op g.op where
-  i.left := h.r.right.op
-  i.right := h.r.left.op
-  i.w := by simp [← op_comp]
-  r.left := h.i.right.op
-  r.right := h.i.left.op
-  r.w := by simp [← op_comp]
+  i := Arrow.homMk (h.r.right.op) (h.r.left.op) (by simp [← op_comp])
+  r := Arrow.homMk (h.i.right.op) (h.i.left.op) (by simp [← op_comp])
   retract := by ext <;> simp [← op_comp]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -157,12 +153,8 @@ then `f.unop` is a retract of `g.unop`. -/
 @[simps]
 def unop {X Y Z W : Cᵒᵖ} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g) :
     RetractArrow f.unop g.unop where
-  i.left := h.r.right.unop
-  i.right := h.r.left.unop
-  i.w := by simp [← unop_comp]
-  r.left := h.i.right.unop
-  r.right := h.i.left.unop
-  r.w := by simp [← unop_comp]
+  i := Arrow.homMk (h.r.right.unop) (h.r.left.unop) (by simp [← unop_comp])
+  r := Arrow.homMk (h.i.right.unop) (h.i.left.unop) (by simp [← unop_comp])
   retract := by ext <;> simp [← unop_comp]
 
 end RetractArrow

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -448,7 +448,7 @@ def imageSubobjectMap {W X Y Z : C} {f : W ⟶ X} [HasImage f] {g : Y ⟶ Z} [Ha
 theorem imageSubobjectMap_arrow {W X Y Z : C} {f : W ⟶ X} [HasImage f] {g : Y ⟶ Z} [HasImage g]
     (sq : Arrow.mk f ⟶ Arrow.mk g) [HasImageMap sq] :
     imageSubobjectMap sq ≫ (imageSubobject g).arrow = (imageSubobject f).arrow ≫ sq.right := by
-  simp only [imageSubobjectMap, Category.assoc, Arrow.mk_left, Functor.id_obj, Arrow.mk_right,
+  simp only [imageSubobjectMap, Category.assoc, Arrow.mk_left, Arrow.mk_right,
     Arrow.mk_hom, imageSubobject_arrow']
   rw [dsimp% image.map_ι sq]
   simp


### PR DESCRIPTION
The category of arrows is a particular case of a comma category. If `f : Arrow T`, the morphism `Comma.hom` would be a morphism `(𝟭 T).obj (Comma.left f) ⟶ (𝟭 T).obj (Comma.right f)`. In this PR, we introduce abbreviations `left/right/hom`, so that `f.hom : f.left ⟶ f.right`, and similarly for morphisms, one should now use `Arrow.homMk` which avoids making `(𝟭 T).obj` appear in the terms. This allows to remove some `set_option backward.isDefEq.respectTransparency false`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
