### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `qify` and `zify` tactic docstrings

### DIFF
--- a/Mathlib/Tactic/Qify.lean
+++ b/Mathlib/Tactic/Qify.lean
@@ -38,8 +38,23 @@ open Lean.Parser.Tactic
 open Lean.Elab.Tactic
 
 /--
-The `qify` tactic is used to shift propositions from `ℕ` or `ℤ` to `ℚ`.
-This is often useful since `ℚ` has well-behaved division.
+`qify` rewrites the main goal by shifting propositions from `ℕ` or `ℤ` to `ℚ`.
+This is often useful since `ℚ` has well-behaved subtraction and division.
+
+`qify` makes use of the `@[zify_simps]` and `@[qify_simps]` attributes to insert casts into
+propositions, and the `push_cast` tactic to simplify the `ℚ`-valued expressions.
+
+`qify` is in some sense dual to the `lift` tactic. `lift (z : ℚ) to ℤ` will change the type of a
+rational number `q` (in the supertype) to `ℤ` (the subtype), given a proof that `q.den = 1`;
+propositions concerning `q` will still be over `ℚ`. `qify` changes propositions about `ℕ` or `ℤ`
+(the subtype) to propositions about `ℚ` (the supertype), without changing the type of any variable.
+
+* `qify at l1 l2 ...` rewrites at the given locations.
+* `qify [h₁, ..., hₙ]` uses the expressions `h₁`, ..., `hₙ` as extra lemmas for simplification.
+  This is especially useful in the presence of nat subtraction or of division: passing arguments of
+  type `· ≤ ·` or `· ∣ ·` will allow `push_cast` to do more work.
+
+Examples:
 ```
 example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b := by
   qify
@@ -49,16 +64,13 @@ example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b := by
   ⊢ ↑c < ↑a + 3 * ↑b
   -/
   sorry
-```
-`qify` can be given extra lemmas to use in simplification. This is especially useful in the
-presence of nat subtraction: passing `≤` arguments will allow `push_cast` to do more work.
-```
+
 example (a b c : ℤ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b := by
+  -- Divisibility hypothesis allows pushing `· / ·`.
   qify [hab] at h hb ⊢
   exact (div_eq_iff hb).1 h
 ```
-`qify` makes use of the `@[zify_simps]` and `@[qify_simps]` attributes to move propositions,
-and the `push_cast` tactic to simplify the `ℚ`-valued expressions. -/
+-/
 syntax (name := qify) "qify" (simpArgs)? (location)? : tactic
 
 macro_rules

--- a/Mathlib/Tactic/Qify.lean
+++ b/Mathlib/Tactic/Qify.lean
@@ -44,7 +44,7 @@ This is often useful since `ℚ` has well-behaved subtraction and division.
 `qify` makes use of the `@[zify_simps]` and `@[qify_simps]` attributes to insert casts into
 propositions, and the `push_cast` tactic to simplify the `ℚ`-valued expressions.
 
-`qify` is in some sense dual to the `lift` tactic. `lift (z : ℚ) to ℤ` will change the type of a
+`qify` is in some sense dual to the `lift` tactic. `lift (q : ℚ) to ℤ` will change the type of a
 rational number `q` (in the supertype) to `ℤ` (the subtype), given a proof that `q.den = 1`;
 propositions concerning `q` will still be over `ℚ`. `qify` changes propositions about `ℕ` or `ℤ`
 (the subtype) to propositions about `ℚ` (the supertype), without changing the type of any variable.

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -38,8 +38,23 @@ open Lean.Parser.Tactic
 open Lean.Elab.Tactic
 
 /--
-The `zify` tactic is used to shift propositions from `Nat` to `Int`.
-This is often useful since `Int` has well-behaved subtraction.
+`zify` rewrites the main goal by shifting propositions from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
+
+`zify` makes use of the `@[zify_simps]` attribute to insert casts into propositions, and the
+`push_cast` tactic to simplify the `ℤ`-valued expressions.
+
+`zify` is in some sense dual to the `lift` tactic. `lift (z : Int) to Nat` will change the type of
+an integer `z` (in the supertype) to `Nat` (the subtype), given a proof that `z ≥ 0`; propositions
+concerning `z` will still be over `Int`. `zify` changes propositions about `Nat` (the subtype) to
+propositions about `Int` (the supertype), without changing the type of any variable.
+
+* `zify at l1 l2 ...` rewrites at the given locations.
+* `zify [h₁, ..., hₙ]` uses the expressions `h₁`, ..., `hₙ` as extra lemmas for simplification.
+  This is especially useful in the presence of nat subtraction or of division: passing arguments of
+  type `· ≤ ·` will allow `push_cast` to do more work.
+
+Examples:
 ```
 example (a b c x y z : Nat) (h : ¬ x*y*z < 0) : c < a + 3*b := by
   zify
@@ -48,22 +63,14 @@ example (a b c x y z : Nat) (h : ¬ x*y*z < 0) : c < a + 3*b := by
   h : ¬↑x * ↑y * ↑z < 0
   ⊢ ↑c < ↑a + 3 * ↑b
   -/
-```
-`zify` can be given extra lemmas to use in simplification. This is especially useful in the
-presence of nat subtraction: passing `≤` arguments will allow `push_cast` to do more work.
-```
-example (a b c : Nat) (h : a - b < c) (hab : b ≤ a) : false := by
+  sorry
+
+example (a b c : Nat) (h : a - b < c) (hab : b ≤ a) : False := by
+  -- Nonnegativity hypothesis allows pushing `· - ·`.
   zify [hab] at h
   /- h : ↑a - ↑b < ↑c -/
+  sorry
 ```
-`zify` makes use of the `@[zify_simps]` attribute to move propositions,
-and the `push_cast` tactic to simplify the `Int`-valued expressions.
-`zify` is in some sense dual to the `lift` tactic.
-`lift (z : Int) to Nat` will change the type of an
-integer `z` (in the supertype) to `Nat` (the subtype), given a proof that `z ≥ 0`;
-propositions concerning `z` will still be over `Int`.
-`zify` changes propositions about `Nat` (the subtype) to propositions about `Int` (the supertype),
-without changing the type of any variable.
 -/
 syntax (name := zify) "zify" (simpArgs)? (location)? : tactic
 


### PR DESCRIPTION
This PR rewrites the docstrings for the `qify` and `zify` structure, to consistently match the official style guide, to make sure they are complete while not getting too long.

In particular, the contents and structure of the two docstrings should now be analogous to each other again.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
