### PR TITLE
[Merged by Bors] - chore(Order/OrdContinuous): dualize

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -179,11 +179,9 @@ section ConditionallyCompleteLattice
 
 variable [ConditionallyCompleteLattice α] {s t : Set α} {a b : α}
 
+@[to_dual]
 theorem isLUB_csSup (hn : s.Nonempty) (hb : BddAbove s := by bddDefault) : IsLUB s (sSup s) :=
   ConditionallyCompleteLattice.isLUB_csSup _ hn hb
-
-theorem isGLB_csInf (hn : s.Nonempty) (hb : BddBelow s := by bddDefault) : IsGLB s (sInf s) :=
-  ConditionallyCompleteLattice.isGLB_csInf _ hn hb
 
 theorem le_csSup (h₁ : BddAbove s) (h₂ : a ∈ s) : a ≤ sSup s :=
   (isLUB_csSup (nonempty_of_mem h₂) h₁).1 h₂
@@ -218,11 +216,9 @@ theorem le_csSup_iff (h : BddAbove s) (hs : s.Nonempty) :
 theorem csInf_le_iff (h : BddBelow s) (hs : s.Nonempty) : sInf s ≤ a ↔ ∀ b ∈ lowerBounds s, b ≤ a :=
   ⟨fun h _ hb => le_trans (le_csInf hs hb) h, fun hb => hb _ fun _ => csInf_le h⟩
 
+@[to_dual]
 theorem IsLUB.csSup_eq (H : IsLUB s a) (ne : s.Nonempty) : sSup s = a :=
   (isLUB_csSup ne ⟨a, H.1⟩).unique H
-
-theorem IsGLB.csInf_eq (H : IsGLB s a) (ne : s.Nonempty) : sInf s = a :=
-  (isGLB_csInf ne ⟨a, H.1⟩).unique H
 
 instance (priority := 100) ConditionallyCompleteLattice.toConditionallyCompletePartialOrder :
     ConditionallyCompletePartialOrder α where

--- a/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
@@ -69,6 +69,9 @@ least upper (respectively, greatest lower) bound. -/
 class ConditionallyCompletePartialOrder (α : Type*)
     extends ConditionallyCompletePartialOrderSup α, ConditionallyCompletePartialOrderInf α where
 
+attribute [to_dual existing]
+  ConditionallyCompletePartialOrder.toConditionallyCompletePartialOrderSup
+
 variable [ConditionallyCompletePartialOrderSup α]
 variable {f : ι → α} {s : Set α} {a : α}
 

--- a/Mathlib/Order/OrdContinuous.lean
+++ b/Mathlib/Order/OrdContinuous.lean
@@ -57,10 +57,14 @@ protected theorem id : LeftOrdContinuous (id : α → α) := fun s x h => by
 
 variable {α}
 
-@[to_dual orderDual]
-protected theorem rightOrdContinuous_dual :
+@[to_dual]
+protected theorem dual :
     LeftOrdContinuous f → RightOrdContinuous (toDual ∘ f ∘ ofDual) :=
   id
+
+@[deprecated (since := "2026-04-08")] alias rightOrdContinuous_dual := LeftOrdContinuous.dual
+
+@[deprecated (since := "2026-04-08")] alias RightOrdContinuous.orderDual := RightOrdContinuous.dual
 
 @[to_dual]
 theorem map_isGreatest (hf : LeftOrdContinuous f) {s : Set α} {x : α} (h : IsGreatest s x) :

--- a/Mathlib/Order/OrdContinuous.lean
+++ b/Mathlib/Order/OrdContinuous.lean
@@ -40,8 +40,7 @@ conditionally complete lattices. -/
 @[to_dual
 /-- A function `f` between preorders is right order continuous if it preserves all infima.  We
 define it using `IsGLB` instead of `sInf` so that the proof works both for complete lattices and
-conditionally complete lattices. -/
-]
+conditionally complete lattices. -/]
 def LeftOrdContinuous [Preorder α] [Preorder β] (f : α → β) :=
   ∀ ⦃s : Set α⦄ ⦃x⦄, IsLUB s x → IsLUB (f '' s) (f x)
 
@@ -109,8 +108,7 @@ variable (f)
 
 /-- Convert an injective left order continuous function to an order embedding. -/
 @[to_dual
-/-- Convert an injective right order continuous function to an order embedding. -/
-]
+/-- Convert an injective right order continuous function to an order embedding. -/]
 def toOrderEmbedding (hf : LeftOrdContinuous f) (h : Injective f) : α ↪o β :=
   ⟨⟨f, h⟩, hf.le_iff h⟩
 

--- a/Mathlib/Order/OrdContinuous.lean
+++ b/Mathlib/Order/OrdContinuous.lean
@@ -63,7 +63,8 @@ protected theorem dual :
 
 @[deprecated (since := "2026-04-08")] alias rightOrdContinuous_dual := LeftOrdContinuous.dual
 
-@[deprecated (since := "2026-04-08")] alias RightOrdContinuous.orderDual := RightOrdContinuous.dual
+@[deprecated (since := "2026-04-08")] alias _root_.RightOrdContinuous.orderDual :=
+  RightOrdContinuous.dual
 
 @[to_dual]
 theorem map_isGreatest (hf : LeftOrdContinuous f) {s : Set α} {x : α} (h : IsGreatest s x) :

--- a/Mathlib/Order/OrdContinuous.lean
+++ b/Mathlib/Order/OrdContinuous.lean
@@ -37,14 +37,13 @@ open Function OrderDual Set
 /-- A function `f` between preorders is left order continuous if it preserves all suprema.  We
 define it using `IsLUB` instead of `sSup` so that the proof works both for complete lattices and
 conditionally complete lattices. -/
-def LeftOrdContinuous [Preorder α] [Preorder β] (f : α → β) :=
-  ∀ ⦃s : Set α⦄ ⦃x⦄, IsLUB s x → IsLUB (f '' s) (f x)
-
+@[to_dual
 /-- A function `f` between preorders is right order continuous if it preserves all infima.  We
 define it using `IsGLB` instead of `sInf` so that the proof works both for complete lattices and
 conditionally complete lattices. -/
-def RightOrdContinuous [Preorder α] [Preorder β] (f : α → β) :=
-  ∀ ⦃s : Set α⦄ ⦃x⦄, IsGLB s x → IsGLB (f '' s) (f x)
+]
+def LeftOrdContinuous [Preorder α] [Preorder β] (f : α → β) :=
+  ∀ ⦃s : Set α⦄ ⦃x⦄, IsLUB s x → IsLUB (f '' s) (f x)
 
 namespace LeftOrdContinuous
 
@@ -52,26 +51,32 @@ section Preorder
 
 variable (α) [Preorder α] [Preorder β] [Preorder γ] {g : β → γ} {f : α → β}
 
+@[to_dual]
 protected theorem id : LeftOrdContinuous (id : α → α) := fun s x h => by
   simpa only [image_id] using h
 
 variable {α}
 
+@[to_dual orderDual]
 protected theorem rightOrdContinuous_dual :
     LeftOrdContinuous f → RightOrdContinuous (toDual ∘ f ∘ ofDual) :=
   id
 
+@[to_dual]
 theorem map_isGreatest (hf : LeftOrdContinuous f) {s : Set α} {x : α} (h : IsGreatest s x) :
     IsGreatest (f '' s) (f x) :=
   ⟨mem_image_of_mem f h.1, (hf h.isLUB).1⟩
 
+@[to_dual]
 theorem mono (hf : LeftOrdContinuous f) : Monotone f := fun a₁ a₂ h =>
   have : IsGreatest {a₁, a₂} a₂ := ⟨Or.inr rfl, by simp [*]⟩
   (hf.map_isGreatest this).2 <| mem_image_of_mem _ (Or.inl rfl)
 
+@[to_dual]
 theorem comp (hg : LeftOrdContinuous g) (hf : LeftOrdContinuous f) : LeftOrdContinuous (g ∘ f) :=
   fun s x h => by simpa only [image_image] using hg (hf h)
 
+@[to_dual]
 protected theorem iterate {f : α → α} (hf : LeftOrdContinuous f) (n : ℕ) :
     LeftOrdContinuous f^[n] :=
   match n with
@@ -84,24 +89,28 @@ section SemilatticeSup
 
 variable [SemilatticeSup α] [SemilatticeSup β] {f : α → β}
 
+@[to_dual]
 theorem map_sup (hf : LeftOrdContinuous f) (x y : α) : f (x ⊔ y) = f x ⊔ f y :=
   (hf isLUB_pair).unique <| by simp only [image_pair, isLUB_pair]
 
+@[to_dual]
 theorem le_iff (hf : LeftOrdContinuous f) (h : Injective f) {x y} : f x ≤ f y ↔ x ≤ y := by
   simp only [← sup_eq_right, ← hf.map_sup, h.eq_iff]
 
+@[to_dual]
 theorem lt_iff (hf : LeftOrdContinuous f) (h : Injective f) {x y} : f x < f y ↔ x < y := by
   simp only [lt_iff_le_not_ge, hf.le_iff h]
 
 variable (f)
 
 /-- Convert an injective left order continuous function to an order embedding. -/
+@[to_dual]
 def toOrderEmbedding (hf : LeftOrdContinuous f) (h : Injective f) : α ↪o β :=
   ⟨⟨f, h⟩, hf.le_iff h⟩
 
 variable {f}
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem coe_toOrderEmbedding (hf : LeftOrdContinuous f) (h : Injective f) :
     ⇑(hf.toOrderEmbedding f h) = f :=
   rfl
@@ -112,12 +121,15 @@ section CompleteLattice
 
 variable [CompleteLattice α] [CompleteLattice β] {f : α → β}
 
+@[to_dual]
 theorem map_sSup' (hf : LeftOrdContinuous f) (s : Set α) : f (sSup s) = sSup (f '' s) :=
   (hf <| isLUB_sSup s).sSup_eq.symm
 
+@[to_dual]
 theorem map_sSup (hf : LeftOrdContinuous f) (s : Set α) : f (sSup s) = ⨆ x ∈ s, f x := by
   rw [hf.map_sSup', sSup_image]
 
+@[to_dual]
 theorem map_iSup (hf : LeftOrdContinuous f) (g : ι → α) : f (⨆ i, g i) = ⨆ i, f (g i) := by
   simp only [iSup, hf.map_sSup', ← range_comp]
   rfl
@@ -128,10 +140,12 @@ section ConditionallyCompleteLattice
 
 variable [ConditionallyCompleteLattice α] [ConditionallyCompleteLattice β] [Nonempty ι] {f : α → β}
 
+@[to_dual]
 theorem map_csSup (hf : LeftOrdContinuous f) {s : Set α} (sne : s.Nonempty) (sbdd : BddAbove s) :
     f (sSup s) = sSup (f '' s) :=
   ((hf <| isLUB_csSup sne sbdd).csSup_eq <| sne.image f).symm
 
+@[to_dual]
 theorem map_ciSup (hf : LeftOrdContinuous f) {g : ι → α} (hg : BddAbove (range g)) :
     f (⨆ i, g i) = ⨆ i, f (g i) := by
   simp only [iSup, hf.map_csSup (range_nonempty _) hg, ← range_comp]
@@ -140,95 +154,6 @@ theorem map_ciSup (hf : LeftOrdContinuous f) {g : ι → α} (hg : BddAbove (ran
 end ConditionallyCompleteLattice
 
 end LeftOrdContinuous
-
-namespace RightOrdContinuous
-
-section Preorder
-
-variable (α) [Preorder α] [Preorder β] [Preorder γ] {g : β → γ} {f : α → β}
-
-protected theorem id : RightOrdContinuous (id : α → α) := fun s x h => by
-  simpa only [image_id] using h
-
-variable {α}
-
-protected theorem orderDual : RightOrdContinuous f → LeftOrdContinuous (toDual ∘ f ∘ ofDual) :=
-  id
-
-theorem map_isLeast (hf : RightOrdContinuous f) {s : Set α} {x : α} (h : IsLeast s x) :
-    IsLeast (f '' s) (f x) :=
-  hf.orderDual.map_isGreatest h
-
-theorem mono (hf : RightOrdContinuous f) : Monotone f :=
-  hf.orderDual.mono.dual
-
-theorem comp (hg : RightOrdContinuous g) (hf : RightOrdContinuous f) : RightOrdContinuous (g ∘ f) :=
-  hg.orderDual.comp hf.orderDual
-
-protected theorem iterate {f : α → α} (hf : RightOrdContinuous f) (n : ℕ) :
-    RightOrdContinuous f^[n] :=
-  hf.orderDual.iterate n
-
-end Preorder
-
-section SemilatticeInf
-
-variable [SemilatticeInf α] [SemilatticeInf β] {f : α → β}
-
-theorem map_inf (hf : RightOrdContinuous f) (x y : α) : f (x ⊓ y) = f x ⊓ f y :=
-  hf.orderDual.map_sup x y
-
-theorem le_iff (hf : RightOrdContinuous f) (h : Injective f) {x y} : f x ≤ f y ↔ x ≤ y :=
-  hf.orderDual.le_iff h
-
-theorem lt_iff (hf : RightOrdContinuous f) (h : Injective f) {x y} : f x < f y ↔ x < y :=
-  hf.orderDual.lt_iff h
-
-variable (f)
-
-/-- Convert an injective left order continuous function to an `OrderEmbedding`. -/
-def toOrderEmbedding (hf : RightOrdContinuous f) (h : Injective f) : α ↪o β :=
-  ⟨⟨f, h⟩, hf.le_iff h⟩
-
-variable {f}
-
-@[simp]
-theorem coe_toOrderEmbedding (hf : RightOrdContinuous f) (h : Injective f) :
-    ⇑(hf.toOrderEmbedding f h) = f :=
-  rfl
-
-end SemilatticeInf
-
-section CompleteLattice
-
-variable [CompleteLattice α] [CompleteLattice β] {f : α → β}
-
-theorem map_sInf' (hf : RightOrdContinuous f) (s : Set α) : f (sInf s) = sInf (f '' s) :=
-  hf.orderDual.map_sSup' s
-
-theorem map_sInf (hf : RightOrdContinuous f) (s : Set α) : f (sInf s) = ⨅ x ∈ s, f x :=
-  hf.orderDual.map_sSup s
-
-theorem map_iInf (hf : RightOrdContinuous f) (g : ι → α) : f (⨅ i, g i) = ⨅ i, f (g i) :=
-  hf.orderDual.map_iSup g
-
-end CompleteLattice
-
-section ConditionallyCompleteLattice
-
-variable [ConditionallyCompleteLattice α] [ConditionallyCompleteLattice β] [Nonempty ι] {f : α → β}
-
-theorem map_csInf (hf : RightOrdContinuous f) {s : Set α} (sne : s.Nonempty) (sbdd : BddBelow s) :
-    f (sInf s) = sInf (f '' s) :=
-  hf.orderDual.map_csSup sne sbdd
-
-theorem map_ciInf (hf : RightOrdContinuous f) {g : ι → α} (hg : BddBelow (range g)) :
-    f (⨅ i, g i) = ⨅ i, f (g i) :=
-  hf.orderDual.map_ciSup hg
-
-end ConditionallyCompleteLattice
-
-end RightOrdContinuous
 
 namespace GaloisConnection
 variable [Preorder α] [Preorder β] {f : α → β} {g : β → α}
@@ -248,6 +173,7 @@ variable [Preorder α] [Preorder β] (e : α ≃o β)
 
 protected lemma leftOrdContinuous : LeftOrdContinuous e := e.to_galoisConnection.leftOrdContinuous
 
+@[to_dual existing]
 protected lemma rightOrdContinuous : RightOrdContinuous e :=
   e.symm.to_galoisConnection.rightOrdContinuous
 

--- a/Mathlib/Order/OrdContinuous.lean
+++ b/Mathlib/Order/OrdContinuous.lean
@@ -104,7 +104,9 @@ theorem lt_iff (hf : LeftOrdContinuous f) (h : Injective f) {x y} : f x < f y �
 variable (f)
 
 /-- Convert an injective left order continuous function to an order embedding. -/
-@[to_dual]
+@[to_dual
+/-- Convert an injective right order continuous function to an order embedding. -/
+]
 def toOrderEmbedding (hf : LeftOrdContinuous f) (h : Injective f) : α ↪o β :=
   ⟨⟨f, h⟩, hf.le_iff h⟩
 

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -243,6 +243,8 @@ def abbreviationDict : Std.HashMap String String := .ofList [
   ("directedOrder", "CodirectedOrder"),
   ("galoisInsertion", "GaloisCoinsertion"),
   ("galoisCoinsertion", "GaloisInsertion"),
+  ("leftOrdContinuous", "RightOrdContinuous"),
+  ("rightOrdContinuous", "LeftOrdContinuous"),
 
   ("neTop", "NeBot"),
   ("decidableSucc", "DecidablePred"),

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -864,6 +864,6 @@ lemma LeftOrdContinuous.continuousWithinAt_Iic (hf : LeftOrdContinuous f) :
 the function is between conditionally complete linear orders with order topologies, and the domain
 is densely ordered. -/
 lemma RightOrdContinuous.continuousWithinAt_Ici (hf : RightOrdContinuous f) :
-    ContinuousWithinAt f (Ici x) x := hf.orderDual.continuousWithinAt_Iic
+    ContinuousWithinAt f (Ici x) x := hf.dual.continuousWithinAt_Iic
 
 end ConditionallyCompleteLinearOrder


### PR DESCRIPTION
Implement all the RightOrdContinuous functionality by dualizing the LeftOrdContinuous versions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Moves:
- `LeftOrdContinuous.rightOrdContinuous_dual` -> `LeftOrdContinuous.dual`
- `RightOrdContinuous.orderDual` -> `RightOrdContinuous.dual`

- [x] depends on: #37735

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
