### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace): `IndiscreteTopology` on a `UniformSpace`

### DIFF
--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -333,25 +333,24 @@ end SeparationQuotient
 
 namespace IndiscreteTopology
 
-theorem of_top_uniformity {α : Type*} [u : UniformSpace α] (h : uniformity α = ⊤) :
-    IndiscreteTopology α :=
+variable {α : Type*} [u : UniformSpace α]
+
+theorem of_top_uniformity (h : uniformity α = ⊤) : IndiscreteTopology α :=
   ⟨(UniformSpace.ext h.symm : ⊤ = u) ▸ rfl⟩
 
-lemma eq_top_uniformSpace (α : Type*) [u : UniformSpace α] [IndiscreteTopology α] :
-    u = ⊤ := by
+lemma eq_top_uniformSpace [IndiscreteTopology α] : u = ⊤ := by
   refine UniformSpace.ext ?_
   rw [top_uniformity, ← Filter.ker_eq_univ]
   ext x
   rw [← inseparable_iff_ker_uniformity]
   simp
 
-lemma eq_top_iff_indiscrete {α : Type*} [u : UniformSpace α] : u = ⊤ ↔ IndiscreteTopology α :=
+lemma eq_top_iff_indiscrete : u = ⊤ ↔ IndiscreteTopology α :=
   ⟨fun h ↦ IndiscreteTopology.mk <| h ▸ UniformSpace.toTopologicalSpace_top (α := α),
-  fun _ ↦ eq_top_uniformSpace α⟩
+  fun _ ↦ eq_top_uniformSpace⟩
 
-lemma uniformContinuous {α β : Type*} [UniformSpace α] [UniformSpace β]
-    [IndiscreteTopology β] {f : α → β} : UniformContinuous f := by
-  rw [UniformContinuous, eq_top_uniformSpace β, top_uniformity]
+lemma uniformContinuous [IndiscreteTopology β] {f : α → β} : UniformContinuous f := by
+  rw [UniformContinuous, eq_top_uniformSpace (α := β), top_uniformity]
   exact Filter.tendsto_top
 
 end IndiscreteTopology

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -330,3 +330,28 @@ theorem map_comp {f : α → β} {g : β → γ} (hf : UniformContinuous f) (hg 
   (map_unique (hg.comp hf) <| by simp only [Function.comp_def, map_mk, hf, hg]).symm
 
 end SeparationQuotient
+
+namespace IndiscreteTopology
+
+theorem of_top_uniformity {α : Type*} [u : UniformSpace α] (h : uniformity α = ⊤) :
+    IndiscreteTopology α :=
+  ⟨(UniformSpace.ext h.symm : ⊤ = u) ▸ rfl⟩
+
+lemma eq_top_uniformSpace (α : Type*) [u : UniformSpace α] [IndiscreteTopology α] :
+    u = ⊤ := by
+  refine UniformSpace.ext ?_
+  rw [top_uniformity, ← Filter.ker_eq_univ]
+  ext x
+  rw [← inseparable_iff_ker_uniformity]
+  simp
+
+lemma eq_top_iff_indiscrete {α : Type*} [u : UniformSpace α] : u = ⊤ ↔ IndiscreteTopology α :=
+  ⟨fun h ↦ IndiscreteTopology.mk <| h ▸ UniformSpace.toTopologicalSpace_top (α := α),
+  fun _ ↦ eq_top_uniformSpace α⟩
+
+lemma uniformContinuous {α β : Type*} [UniformSpace α] [UniformSpace β]
+    [IndiscreteTopology β] {f : α → β} : UniformContinuous f := by
+  rw [UniformContinuous, eq_top_uniformSpace β, top_uniformity]
+  exact Filter.tendsto_top
+
+end IndiscreteTopology

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -335,7 +335,7 @@ namespace IndiscreteTopology
 
 variable {α : Type*} [u : UniformSpace α]
 
-theorem of_top_uniformity (h : uniformity α = ⊤) : IndiscreteTopology α :=
+theorem of_uniformity_eq_top (h : uniformity α = ⊤) : IndiscreteTopology α :=
   ⟨(UniformSpace.ext h.symm : ⊤ = u) ▸ rfl⟩
 
 lemma eq_top_uniformSpace [IndiscreteTopology α] : u = ⊤ := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
