### PR TITLE
[Merged by Bors] - fix: some norm_num exts are not available in the module system

### DIFF
--- a/Mathlib/Tactic/NormNum/Irrational.lean
+++ b/Mathlib/Tactic/NormNum/Irrational.lean
@@ -136,7 +136,7 @@ private theorem not_power_rat_of_num {a b d : ℕ}
     rw [← h_odd.pow_nonneg_iff, ← hq]
     positivity
 
-private theorem irrational_rpow_rat_rat_of_num {x y : ℝ} {x_num x_den y_num y_den k_num : ℕ}
+theorem irrational_rpow_rat_rat_of_num {x y : ℝ} {x_num x_den y_num y_den k_num : ℕ}
     (hx_isNNRat : IsNNRat x x_num x_den)
     (hy_isNNRat : IsNNRat y y_num y_den)
     (hx_coprime : Nat.Coprime x_num x_den)
@@ -166,7 +166,7 @@ private theorem irrational_rpow_rat_rat_of_num {x y : ℝ} {x_num x_den y_num y_
     · apply not_power_nat_pow_of_bounds hy_den_pos hy_coprime hn1 hn2
   · positivity
 
-private theorem irrational_rpow_rat_rat_of_den {x y : ℝ} {x_num x_den y_num y_den k_den : ℕ}
+theorem irrational_rpow_rat_rat_of_den {x y : ℝ} {x_num x_den y_num y_den k_den : ℕ}
     (hx_isNNRat : IsNNRat x x_num x_den)
     (hy_isNNRat : IsNNRat y y_num y_den)
     (hx_coprime : Nat.Coprime x_num x_den)
@@ -182,7 +182,7 @@ private theorem irrational_rpow_rat_rat_of_den {x y : ℝ} {x_num x_den y_num y_
   refine ⟨invertibleOfNonzero (fun _ ↦ ?_), by simp [hx_eq]⟩
   simp_all
 
-private theorem irrational_rpow_nat_rat {x y : ℝ} {x_num y_num y_den k : ℕ}
+theorem irrational_rpow_nat_rat {x y : ℝ} {x_num y_num y_den k : ℕ}
     (hx_isNat : IsNat x x_num)
     (hy_isNNRat : IsNNRat y y_num y_den)
     (hy_coprime : Nat.Coprime y_num y_den)
@@ -191,7 +191,7 @@ private theorem irrational_rpow_nat_rat {x y : ℝ} {x_num y_num y_den k : ℕ}
     Irrational (x ^ y) :=
   irrational_rpow_rat_rat_of_num hx_isNat.to_isNNRat hy_isNNRat (by simp) hy_coprime hn1 hn2
 
-private theorem irrational_sqrt_rat_of_num {x : ℝ} {num den num_k : ℕ}
+theorem irrational_sqrt_rat_of_num {x : ℝ} {num den num_k : ℕ}
     (hx_isNNRat : IsNNRat x num den)
     (hx_coprime : Nat.Coprime num den)
     (hn1 : num_k ^ 2 < num)
@@ -202,7 +202,7 @@ private theorem irrational_sqrt_rat_of_num {x : ℝ} {num den num_k : ℕ}
     hn1 hn2
   exact ⟨Invertible.mk (1/2) (by simp) (by simp), by simp⟩
 
-private theorem irrational_sqrt_rat_of_den {x : ℝ} {num den den_k : ℕ}
+theorem irrational_sqrt_rat_of_den {x : ℝ} {num den den_k : ℕ}
     (hx_isNNRat : IsNNRat x num den)
     (hx_coprime : Nat.Coprime num den)
     (hd1 : den_k ^ 2 < den)
@@ -213,7 +213,7 @@ private theorem irrational_sqrt_rat_of_den {x : ℝ} {num den den_k : ℕ}
     hd1 hd2
   exact ⟨Invertible.mk (1/2) (by simp) (by simp), by simp⟩
 
-private theorem irrational_sqrt_nat {x : ℝ} {n k : ℕ}
+theorem irrational_sqrt_nat {x : ℝ} {n k : ℕ}
     (hx_isNat : IsNat x n)
     (hn1 : k ^ 2 < n)
     (hn2 : n < (k + 1) ^ 2) :

--- a/Mathlib/Tactic/NormNum/NatLog.lean
+++ b/Mathlib/Tactic/NormNum/NatLog.lean
@@ -20,20 +20,20 @@ namespace Mathlib.Meta.NormNum
 
 open Qq Lean Elab.Tactic
 
-private lemma nat_log_zero (n : Nat) : Nat.log 0 n = 0 := Nat.log_zero_left n
-private lemma nat_log_one (n : Nat) : Nat.log 1 n = 0 := Nat.log_one_left n
+lemma nat_log_zero (n : Nat) : Nat.log 0 n = 0 := Nat.log_zero_left n
+lemma nat_log_one (n : Nat) : Nat.log 1 n = 0 := Nat.log_one_left n
 
-private lemma nat_log_helper0 (b n : Nat) (hl : Nat.blt n b = true) :
+lemma nat_log_helper0 (b n : Nat) (hl : Nat.blt n b = true) :
     Nat.log b n = 0 := by
   rw [Nat.blt_eq] at hl
   simp [hl]
 
-private lemma nat_log_helper (b n k : Nat)
+lemma nat_log_helper (b n k : Nat)
     (hl : Nat.ble (b ^ k) n = true) (hh : Nat.blt n (b ^ (k + 1)) = true) :
     Nat.log b n = k :=
   Nat.log_eq_of_pow_le_of_lt_pow (Nat.le_of_ble_eq_true hl) (Nat.le_of_ble_eq_true hh)
 
-private theorem isNat_log : {b nb n nn k : ℕ} → IsNat b nb → IsNat n nn →
+theorem isNat_log : {b nb n nn k : ℕ} → IsNat b nb → IsNat n nn →
     Nat.log nb nn = k → IsNat (Nat.log b n) k
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨rfl⟩
 
@@ -70,9 +70,9 @@ def evalNatLog : NormNumExt where eval {u α} e := do
   let pf' : Q(IsNat (Nat.log $b $n) $ek) := q(isNat_log $pb $pn $pf)
   return .isNat sℕ ek pf'
 
-private lemma nat_clog_zero_left (b n : Nat) (hb : Nat.ble b 1 = true) :
+lemma nat_clog_zero_left (b n : Nat) (hb : Nat.ble b 1 = true) :
     Nat.clog b n = 0 := Nat.clog_of_left_le_one (Nat.le_of_ble_eq_true hb) n
-private lemma nat_clog_zero_right (b n : Nat) (hn : Nat.ble n 1 = true) :
+lemma nat_clog_zero_right (b n : Nat) (hn : Nat.ble n 1 = true) :
     Nat.clog b n = 0 := Nat.clog_of_right_le_one (Nat.le_of_ble_eq_true hn) b
 
 theorem nat_clog_helper {b m n : ℕ} (hb : Nat.blt 1 b = true)
@@ -83,7 +83,7 @@ theorem nat_clog_helper {b m n : ℕ} (hb : Nat.blt 1 b = true)
   rw [Nat.ble_eq, ← Nat.clog_le_iff_le_pow hb] at h₂
   lia
 
-private theorem isNat_clog : {b nb n nn k : ℕ} → IsNat b nb → IsNat n nn →
+theorem isNat_clog : {b nb n nn k : ℕ} → IsNat b nb → IsNat n nn →
     Nat.clog nb nn = k → IsNat (Nat.clog b n) k
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨rfl⟩
 

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+module
 import Mathlib.Tactic.NormNum.BigOperators
 import Mathlib.Tactic.NormNum.GCD
 import Mathlib.Tactic.NormNum.IsCoprime


### PR DESCRIPTION
`norm_num` used to generate proof terms containing private lemmas, leading to errors in downstream modules. Fix this by making the lemmas public; they are still namespaced (so unlikely to lead to confusion elsewhere).

Found while modulizing tests in #34466.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
