### PR TITLE
[Merged by Bors] - feat(RingTheory/Localization/AtPrime/Basic): add equiv versions of `localRingHom` and `localAlgHom`

### DIFF
--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -280,6 +280,16 @@ theorem localRingHom_comp {S : Type*} [CommSemiring S] (J : Ideal S) [hJ : J.IsP
   localRingHom_unique _ _ _ _ fun r => by
     simp only [Function.comp_apply, RingHom.coe_comp, localRingHom_to_map]
 
+/-- Isomorphic rings have isomorphic localizations. -/
+@[simps]
+noncomputable def localRingEquiv (J : Ideal P) [J.IsPrime] (f : R ≃+* P) (hIJ : I = J.comap f) :
+    Localization.AtPrime I ≃+* Localization.AtPrime J where
+  __ := localRingHom I J f hIJ
+  invFun := localRingHom J I f.symm
+    (by rw [hIJ, ← Ideal.comap_coe f, Ideal.comap_comap, RingEquiv.comp_symm, Ideal.comap_id])
+  left_inv x := by simp [localRingHom, map_map]
+  right_inv x := by simp [localRingHom, map_map]
+
 variable {S} in
 /-- For an algebra hom `f : S →ₐ[R] P` and a prime ideal `J` in `P`, the induced ring hom from the
 localization of `R` at `J ∩ S` to the localization of `P` at `J`. -/
@@ -295,6 +305,15 @@ variable {S} in
 @[simp] lemma localAlgHom_apply [Algebra R P] (I : Ideal S) [I.IsPrime] (J : Ideal P) [J.IsPrime]
     (f : S →ₐ[R] P) (hIJ : I = J.comap f) (x) :
     localAlgHom I J f hIJ x = localRingHom I J f.toRingHom hIJ x := rfl
+
+variable {S} in
+/-- Isomorphic algebras have isomorphic localizations. -/
+@[simps]
+noncomputable def localAlgEquiv [Algebra R P] (I : Ideal S) [I.IsPrime] (J : Ideal P) [J.IsPrime]
+    (f : S ≃ₐ[R] P) (hIJ : I = J.comap f) :
+    Localization.AtPrime I ≃ₐ[R] Localization.AtPrime J where
+  __ := localAlgHom I J f.toAlgHom hIJ
+  __ := localRingEquiv I J f.toRingEquiv hIJ
 
 lemma localRingHom_bijective_of_saturated_inf_eq_top
     {P : Ideal S} [P.IsPrime] {s : Subalgebra R S}


### PR DESCRIPTION
This PR adds equiv versions of `localRingHom` and `localAlgHom`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
