### PR TITLE
[Merged by Bors] - fix(positivity): still prove non-negativity in the `Nat.cast` extension if positivity fails

### DIFF
--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -376,8 +376,11 @@ meta def evalNatCast : PositivityExt where eval {u α} _zα _pα e := do
   assumeInstancesCommute
   match ← core zα' pα' a with
   | .positive pa =>
-    let _nz ← synthInstanceQ q(NeZero (1 : $α))
-    pure (.positive q(Nat.cast_pos'.2 $pa))
+    try
+      let _nz ← synthInstanceQ q(NeZero (1 : $α))
+      pure (.positive q(Nat.cast_pos'.2 $pa))
+    catch _ =>
+      pure (.nonnegative q(Nat.cast_nonneg' _))
   | _ =>
     pure (.nonnegative q(Nat.cast_nonneg' _))
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -126,6 +126,12 @@ https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tacti
 
 example : 0 ≤ 0 := by apply le_trans _ (le_refl _); positivity
 
+-- Test for a bug in the Nat.cast extension: if a natural number is positive
+-- and applying `cast_pos'` fails, we still prove non-negativity.
+example [Ring α] [PartialOrder α] [AddLeftMono α] [ZeroLEOneClass α] (b : ℕ) (_hb : 0 < b) :
+    (0 : α) ≤ ↑b := by
+  fail_if_success positivity
+  exact Nat.cast_nonneg' _
 
 /- ## Tests of the @[positivity] plugin tactics (addition, multiplication, division) -/
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -127,11 +127,11 @@ https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tacti
 example : 0 ≤ 0 := by apply le_trans _ (le_refl _); positivity
 
 -- Test for a bug in the Nat.cast extension: if a natural number is positive
--- and applying `cast_pos'` fails, we still prove non-negativity.
+-- and applying `cast_pos'` fails (e.g., because our ring could be trivial),
+-- we still prove non-negativity.
 example [Ring α] [PartialOrder α] [AddLeftMono α] [ZeroLEOneClass α] (b : ℕ) (_hb : 0 < b) :
     (0 : α) ≤ ↑b := by
-  fail_if_success positivity
-  exact Nat.cast_nonneg' _
+  positivity
 
 /- ## Tests of the @[positivity] plugin tactics (addition, multiplication, division) -/
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
