### PR TITLE
[Merged by Bors] - feat: cache only emits a warning when Git is not found

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -13,6 +13,9 @@ namespace Cache.Requests
 
 open System (FilePath)
 
+/-- The full name of the main Mathlib GitHub repository. -/
+def MATHLIBREPO := "leanprover-community/mathlib4"
+
 /--
 Structure to hold repository information with priority ordering
 -/
@@ -37,7 +40,7 @@ def isRemoteURL (url : String) : Bool :=
 /--
 Helper function to get repository from a remote name
 -/
-def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorContext : String) : IO String := do
+def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorContext : String) : IO (Option String) := do
   -- If the remote is already a valid URL, attempt to extract the repo from it. This happens with `gh pr checkout`
   if isRemoteURL remoteName then
     repoFromURL remoteName
@@ -46,23 +49,25 @@ def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorCo
   -- standard name like `origin` or `upstream` or it errors out.
   let out ← IO.Process.output
     {cmd := "git", args := #["remote", "get-url", remoteName], cwd := mathlibDepPath}
-  -- If `git remote get-url` fails then bail out with an error to help debug
+  -- If `git remote get-url` fails then return none.
   let output := out.stdout.trimAscii
   unless out.exitCode == 0 do
-    throw <| IO.userError s!"\
-      Failed to run Git to determine Mathlib's repository from {remoteName} remote (exit code: {out.exitCode}).\n\
+    IO.println s!"\
+      Warning: failed to run Git to determine Mathlib's repository from {remoteName} remote\n\
       {errorContext}\n\
-      Stdout:\n{output}\nStderr:\n{out.stderr.trimAscii}\n"
+      Continuing to fetch the cache from {MATHLIBREPO}."
+    return none
   -- Finally attempt to extract the repository from the remote URL returned by `git remote get-url`
   repoFromURL output.copy
-where repoFromURL (url : String) : IO String := do
+where repoFromURL (url : String) : IO (Option String) := do
     if let some repo := extractRepoFromUrl url then
-      return repo
+      return some repo
     else
-      throw <| IO.userError s!"\
-        Failed to extract repository from remote URL: {url}.\n\
+      IO.println s!"\
+        Warning: Failed to extract repository from remote URL: {url}.\n\
         {errorContext}\n\
-        Please ensure the remote URL is valid and points to a GitHub repository."
+        Continuing to fetch the cache from {MATHLIBREPO}."
+      return none
 
 /--
 Finds the remote name that points to `leanprover-community/mathlib4` repository.
@@ -146,7 +151,7 @@ Attempts to determine the GitHub repository of a version of Mathlib from its Git
 If the current commit coincides with a PR ref, it will determine the source fork
 of that PR rather than just using the origin remote.
 -/
-def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
+def getRemoteRepo (mathlibDepPath : FilePath) : IO (Option RepoInfo) := do
 
   -- Since currently we need to push a PR to `leanprover-community/mathlib` build a user cache,
   -- we check if we are a special branch or a branch with PR. This leaves out non-PRed fork
@@ -176,7 +181,7 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
       let repo := "leanprover-community/mathlib4-nightly-testing"
       let cacheService := if useCloudflareCache then "Cloudflare" else "Azure"
       IO.println s!"Using cache ({cacheService}) from nightly-testing remote: {repo}"
-      return {repo := repo, useFirst := true}
+      return some {repo := repo, useFirst := true}
 
     -- Only search for PR refs if we're not on a regular branch like master, bump/*, or nightly-testing*
     -- let isSpecialBranch := branchName == "master" || branchName.startsWith "bump/" ||
@@ -234,11 +239,16 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
     -- If no tracking remote is configured, fall back to origin
     "origin"
 
-  let repo ← getRepoFromRemote mathlibDepPath remoteName
+  let repo? ← getRepoFromRemote mathlibDepPath remoteName
     s!"Ensure Git is installed and the '{remoteName}' remote points to its GitHub repository."
   let cacheService := if useCloudflareCache then "Cloudflare" else "Azure"
-  IO.println s!"Using cache ({cacheService}) from {remoteName}: {repo}"
-  return {repo := repo, useFirst := false}
+  match repo? with
+  | some repo =>
+    IO.println s!"Using cache ({cacheService}) from {remoteName}: {repo?}"
+    return some {repo := repo, useFirst := false}
+  | none =>
+    IO.println s!"Using cache ({cacheService}) from {MATHLIBREPO}."
+    return none
 
 /-- Public URL for mathlib cache -/
 initialize URL : String ← do
@@ -274,9 +284,6 @@ def getUploadAuth : IO UploadAuth := do
         return .azureSas token
     throw <| IO.userError
       "environment variable MATHLIB_CACHE_AZURE_BEARER_TOKEN or MATHLIB_CACHE_SAS must be set to upload caches"
-
-/-- The full name of the main Mathlib GitHub repository. -/
-def MATHLIBREPO := "leanprover-community/mathlib4"
 
 /--
 Given a file name like `"1234.tar.gz"`, makes the URL to that file on the server.
@@ -663,16 +670,19 @@ def getFiles
       isMathlibRoot mathlibDepPath
     if failed > 0 then IO.Process.exit 1
   else
-    let repoInfo ← getRemoteRepo (← read).mathlibDepPath
+    let repoInfo? ← getRemoteRepo (← read).mathlibDepPath
 
     -- Build list of repositories to download from in order
     let repos : List String :=
-      if repoInfo.repo == MATHLIBREPO then
-        [repoInfo.repo]
-      else if repoInfo.useFirst then
-        [repoInfo.repo, MATHLIBREPO]
+      if let some repoInfo := repoInfo? then
+        if repoInfo.repo == MATHLIBREPO then
+          [MATHLIBREPO]
+        else if repoInfo.useFirst then
+          [repoInfo.repo, MATHLIBREPO]
+        else
+          [MATHLIBREPO, repoInfo.repo]
       else
-        [MATHLIBREPO, repoInfo.repo]
+        [MATHLIBREPO]
 
     let mut failed : Nat := 0
     for h : i in [0:repos.length] do


### PR DESCRIPTION
Currently `lake exe cache get` requires `git` to be installed, and that the current folder is a git repo.
Sometimes this is annoying: 
- someone sends a ZIP without `.git` subfolder,
- someone uploads supplementary material of a publication without `.git` subfolder
- probably annoying for a trylean bundle

This PR downgrades the currently emitted errors to warnings, and continues to fetch from the `leanprover-community/mathlib4` cache only in case any of these warnings is triggered.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
