### PR TITLE
[Merged by Bors] - chore(Order/GaloisConnection/Basic): use `to_dual`

### DIFF
--- a/Mathlib/Geometry/Diffeology/Basic.lean
+++ b/Mathlib/Geometry/Diffeology/Basic.lean
@@ -603,7 +603,7 @@ theorem generateFrom_iInter_of_generateFrom_eq_self {ι : Type*}
     (G : ι → Set ((n : ℕ) × (𝔼ⁿ → X)))
     (hG : ∀ i, (generateFrom (G i)).toPlots = G i) :
     generateFrom (⋂ i, G i) = ⨅ i, generateFrom (G i) :=
-  (giGenerateFrom X).l_iInf_of_ul_eq_self G hG
+  (giGenerateFrom X).l_iInf_of_u_l_eq_self G hG
 
 theorem isPlot_inf_iff {d₁ d₂ : DiffeologicalSpace X} {n : ℕ} {p : 𝔼ⁿ → X} :
     (@IsPlot _ (d₁ ⊓ d₂)) p ↔ (@IsPlot _ d₁) p ∧ (@IsPlot _ d₂) p :=

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -125,6 +125,7 @@ class CompleteLattice (α : Type*) extends Lattice α, CompleteSemilatticeSup α
     CompleteSemilatticeInf α, BoundedOrder α
 
 attribute [to_dual existing] CompleteLattice.toCompleteSemilatticeInf
+attribute [to_dual self (reorder := toSupSet toInfSet, isLUB_sSup isGLB_sInf)] CompleteLattice.mk
 
 -- Shortcut instance to ensure that the path
 -- `CompleteLattice α → CompletePartialOrder α → PartialOrder α` isn't taken,

--- a/Mathlib/Order/GaloisConnection/Basic.lean
+++ b/Mathlib/Order/GaloisConnection/Basic.lean
@@ -57,38 +57,27 @@ variable [Preorder α] [Preorder β] {l : α → β} {u : β → α}
 variable (gc : GaloisConnection l u)
 include gc
 
+@[to_dual]
 theorem upperBounds_l_image (s : Set α) :
     upperBounds (l '' s) = u ⁻¹' upperBounds s :=
   Set.ext fun b => by simp [upperBounds, gc _ _]
 
-theorem lowerBounds_u_image (s : Set β) :
-    lowerBounds (u '' s) = l ⁻¹' lowerBounds s :=
-  gc.dual.upperBounds_l_image s
-
+@[to_dual]
 theorem bddAbove_l_image {s : Set α} : BddAbove (l '' s) ↔ BddAbove s :=
   ⟨fun ⟨x, hx⟩ => ⟨u x, by rwa [gc.upperBounds_l_image] at hx⟩, gc.monotone_l.map_bddAbove⟩
 
-theorem bddBelow_u_image {s : Set β} : BddBelow (u '' s) ↔ BddBelow s :=
-  gc.dual.bddAbove_l_image
-
+@[to_dual]
 theorem isLUB_l_image {s : Set α} {a : α} (h : IsLUB s a) : IsLUB (l '' s) (l a) :=
   ⟨gc.monotone_l.mem_upperBounds_image h.left, fun b hb =>
     gc.l_le <| h.right <| by rwa [gc.upperBounds_l_image] at hb⟩
 
-theorem isGLB_u_image {s : Set β} {b : β} (h : IsGLB s b) : IsGLB (u '' s) (u b) :=
-  gc.dual.isLUB_l_image h
-
+@[to_dual]
 theorem isLeast_l {a : α} : IsLeast { b | a ≤ u b } (l a) :=
   ⟨gc.le_u_l _, fun _ hb => gc.l_le hb⟩
 
-theorem isGreatest_u {b : β} : IsGreatest { a | l a ≤ b } (u b) :=
-  gc.dual.isLeast_l
-
+@[to_dual]
 theorem isGLB_l {a : α} : IsGLB { b | a ≤ u b } (l a) :=
   gc.isLeast_l.isGLB
-
-theorem isLUB_u {b : β} : IsLUB { a | l a ≤ b } (u b) :=
-  gc.isGreatest_u.isLUB
 
 end
 
@@ -96,53 +85,39 @@ section SemilatticeSup
 
 variable [SemilatticeSup α] [SemilatticeSup β] {l : α → β} {u : β → α}
 
+@[to_dual]
 theorem l_sup (gc : GaloisConnection l u) : l (a₁ ⊔ a₂) = l a₁ ⊔ l a₂ :=
   (gc.isLUB_l_image isLUB_pair).unique <| by simp only [image_pair, isLUB_pair]
 
 end SemilatticeSup
 
-section SemilatticeInf
-
-variable [SemilatticeInf α] [SemilatticeInf β] {l : α → β} {u : β → α}
-
-theorem u_inf (gc : GaloisConnection l u) : u (b₁ ⊓ b₂) = u b₁ ⊓ u b₂ := gc.dual.l_sup
-
-end SemilatticeInf
-
 section CompleteLattice
 
-variable [CompleteLattice α] [CompleteLattice β] {l : α → β} {u : β → α}
+variable [CompleteLattice α] [CompleteLattice β] {l : α → β} {u : β → α} (gc : GaloisConnection l u)
+include gc
 
-theorem l_iSup (gc : GaloisConnection l u) {f : ι → α} : l (iSup f) = ⨆ i, l (f i) :=
+@[to_dual]
+theorem l_iSup {f : ι → α} : l (iSup f) = ⨆ i, l (f i) :=
   Eq.symm <|
     IsLUB.iSup_eq <|
       show IsLUB (range (l ∘ f)) (l (iSup f)) by
         rw [range_comp, ← sSup_range]; exact gc.isLUB_l_image (isLUB_sSup _)
 
-theorem l_iSup₂ (gc : GaloisConnection l u) {f : ∀ i, κ i → α} :
+@[to_dual]
+theorem l_iSup₂ {f : ∀ i, κ i → α} :
     l (⨆ (i) (j), f i j) = ⨆ (i) (j), l (f i j) := by
   simp_rw [gc.l_iSup]
 
-variable (gc : GaloisConnection l u)
-include gc
-
-theorem u_iInf {f : ι → β} : u (iInf f) = ⨅ i, u (f i) :=
-  gc.dual.l_iSup
-
-theorem u_iInf₂ {f : ∀ i, κ i → β} : u (⨅ (i) (j), f i j) = ⨅ (i) (j), u (f i j) :=
-  gc.dual.l_iSup₂
-
+@[to_dual]
 theorem l_sSup {s : Set α} : l (sSup s) = ⨆ a ∈ s, l a := by
   simp only [sSup_eq_iSup, gc.l_iSup]
-
-theorem u_sInf {s : Set β} : u (sInf s) = ⨅ a ∈ s, u a :=
-  gc.dual.l_sSup
 
 end CompleteLattice
 
 -- Constructing Galois connections
 section Constructions
 
+@[to_dual self]
 protected theorem compl [BooleanAlgebra α] [BooleanAlgebra β] {l : α → β} {u : β → α}
     (gc : GaloisConnection l u) :
     GaloisConnection (compl ∘ u ∘ compl) (compl ∘ l ∘ compl) := fun a b ↦ by
@@ -155,16 +130,6 @@ end GaloisConnection
 
 section
 
-/-- `sSup` and `Iic` form a Galois connection. -/
-theorem gc_sSup_Iic [CompleteSemilatticeSup α] :
-    GaloisConnection (sSup : Set α → α) (Iic : α → Set α) :=
-  fun _ _ ↦ sSup_le_iff
-
-/-- `toDual ∘ Ici` and `sInf ∘ ofDual` form a Galois connection. -/
-theorem gc_Ici_sInf [CompleteSemilatticeInf α] :
-    GaloisConnection (toDual ∘ Ici : α → (Set α)ᵒᵈ) (sInf ∘ ofDual : (Set α)ᵒᵈ → α) :=
-  fun _ _ ↦ le_sInf_iff.symm
-
 section image2
 
 section LUB_GLB
@@ -173,6 +138,7 @@ variable [Preorder α] [Preorder β] [Preorder γ] {s : Set α}
   {t : Set β} {l u : α → β → γ} {l₁ u₁ : β → γ → α} {l₂ u₂ : α → γ → β}
   {a₀ : α} {b₀ : β} {c₀ : γ}
 
+@[to_dual]
 theorem isLUB_image2_of_isLUB_isLUB (h₁ : ∀ b, GaloisConnection (swap l b) (u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a) (u₂ a))
     (ha₀ : IsLUB s a₀) (hb₀ : IsLUB t b₀) :
@@ -181,48 +147,26 @@ theorem isLUB_image2_of_isLUB_isLUB (h₁ : ∀ b, GaloisConnection (swap l b) (
   simp_rw [isLUB_iff_le_iff, mem_upperBounds, forall_mem_image2, (h₂ _).le_iff_le,
     ← hb₀, ← (h₂ _).le_iff_le, (h₁ _).le_iff_le, ← ha₀, forall_true_iff]
 
+@[to_dual]
 theorem isLUB_image2_of_isLUB_isGLB (h₁ : ∀ b, GaloisConnection (swap l b) (u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a ∘ ofDual) (toDual ∘ u₂ a))
     (ha₀ : IsLUB s a₀) (hb₀ : IsGLB t b₀) :
     IsLUB (image2 l s t) (l a₀ b₀) :=
   isLUB_image2_of_isLUB_isLUB (β := βᵒᵈ) h₁ h₂ ha₀ hb₀
 
+@[to_dual]
 theorem isLUB_image2_of_isGLB_isLUB (h₁ : ∀ b, GaloisConnection (swap l b ∘ ofDual) (toDual ∘ u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a) (u₂ a))
     (ha₀ : IsGLB s a₀) (hb₀ : IsLUB t b₀) :
     IsLUB (image2 l s t) (l a₀ b₀) :=
   isLUB_image2_of_isLUB_isLUB (α := αᵒᵈ) h₁ h₂ ha₀ hb₀
 
+@[to_dual]
 theorem isLUB_image2_of_isGLB_isGLB (h₁ : ∀ b, GaloisConnection (swap l b ∘ ofDual) (toDual ∘ u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a ∘ ofDual) (toDual ∘ u₂ a))
     (ha₀ : IsGLB s a₀) (hb₀ : IsGLB t b₀) :
     IsLUB (image2 l s t) (l a₀ b₀) :=
   isLUB_image2_of_isLUB_isLUB (α := αᵒᵈ) (β := βᵒᵈ) h₁ h₂ ha₀ hb₀
-
-theorem isGLB_image2_of_isGLB_isGLB (h₁ : ∀ b, GaloisConnection (l₁ b) (swap u b))
-    (h₂ : ∀ a, GaloisConnection (l₂ a) (u a))
-    (ha₀ : IsGLB s a₀) (hb₀ : IsGLB t b₀) :
-    IsGLB (image2 u s t) (u a₀ b₀) :=
-  isLUB_image2_of_isLUB_isLUB (α := αᵒᵈ) (β := βᵒᵈ) (γ := γᵒᵈ)
-    (fun b ↦ (h₁ b).dual) (fun a ↦ (h₂ a).dual) ha₀ hb₀
-
-theorem isGLB_image2_of_isGLB_isLUB (h₁ : ∀ b, GaloisConnection (l₁ b) (swap u b))
-    (h₂ : ∀ a, GaloisConnection (toDual ∘ l₂ a) (u a ∘ ofDual))
-    (ha₀ : IsGLB s a₀) (hb₀ : IsLUB t b₀) :
-    IsGLB (image2 u s t) (u a₀ b₀) :=
-  isGLB_image2_of_isGLB_isGLB (β := βᵒᵈ) h₁ h₂ ha₀ hb₀
-
-theorem isGLB_image2_of_isLUB_isGLB (h₁ : ∀ b, GaloisConnection (toDual ∘ l₁ b) (swap u b ∘ ofDual))
-    (h₂ : ∀ a, GaloisConnection (l₂ a) (u a))
-    (ha₀ : IsLUB s a₀) (hb₀ : IsGLB t b₀) :
-    IsGLB (image2 u s t) (u a₀ b₀) :=
-  isGLB_image2_of_isGLB_isGLB (α := αᵒᵈ) h₁ h₂ ha₀ hb₀
-
-theorem isGLB_image2_of_isLUB_isLUB (h₁ : ∀ b, GaloisConnection (toDual ∘ l₁ b) (swap u b ∘ ofDual))
-    (h₂ : ∀ a, GaloisConnection (toDual ∘ l₂ a) (u a ∘ ofDual))
-    (ha₀ : IsLUB s a₀) (hb₀ : IsLUB t b₀) :
-    IsGLB (image2 u s t) (u a₀ b₀) :=
-  isGLB_image2_of_isGLB_isGLB (α := αᵒᵈ) (β := βᵒᵈ) h₁ h₂ ha₀ hb₀
 
 end LUB_GLB
 
@@ -231,41 +175,27 @@ section CompleteLattice
 variable [CompleteLattice α] [CompleteLattice β] [CompleteLattice γ] {s : Set α}
   {t : Set β} {l u : α → β → γ} {l₁ u₁ : β → γ → α} {l₂ u₂ : α → γ → β}
 
+@[to_dual]
 theorem sSup_image2_eq_sSup_sSup (h₁ : ∀ b, GaloisConnection (swap l b) (u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a) (u₂ a)) : sSup (image2 l s t) = l (sSup s) (sSup t) :=
   (isLUB_image2_of_isLUB_isLUB h₁ h₂ (isLUB_sSup _) (isLUB_sSup _)).sSup_eq
 
+@[to_dual]
 theorem sSup_image2_eq_sSup_sInf (h₁ : ∀ b, GaloisConnection (swap l b) (u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a ∘ ofDual) (toDual ∘ u₂ a)) :
     sSup (image2 l s t) = l (sSup s) (sInf t) :=
   sSup_image2_eq_sSup_sSup (β := βᵒᵈ) h₁ h₂
 
+@[to_dual]
 theorem sSup_image2_eq_sInf_sSup (h₁ : ∀ b, GaloisConnection (swap l b ∘ ofDual) (toDual ∘ u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a) (u₂ a)) : sSup (image2 l s t) = l (sInf s) (sSup t) :=
   sSup_image2_eq_sSup_sSup (α := αᵒᵈ) h₁ h₂
 
+@[to_dual]
 theorem sSup_image2_eq_sInf_sInf (h₁ : ∀ b, GaloisConnection (swap l b ∘ ofDual) (toDual ∘ u₁ b))
     (h₂ : ∀ a, GaloisConnection (l a ∘ ofDual) (toDual ∘ u₂ a)) :
     sSup (image2 l s t) = l (sInf s) (sInf t) :=
   sSup_image2_eq_sSup_sSup (α := αᵒᵈ) (β := βᵒᵈ) h₁ h₂
-
-theorem sInf_image2_eq_sInf_sInf (h₁ : ∀ b, GaloisConnection (l₁ b) (swap u b))
-    (h₂ : ∀ a, GaloisConnection (l₂ a) (u a)) : sInf (image2 u s t) = u (sInf s) (sInf t) :=
-  (isGLB_image2_of_isGLB_isGLB h₁ h₂ (isGLB_sInf _) (isGLB_sInf _)).sInf_eq
-
-theorem sInf_image2_eq_sInf_sSup (h₁ : ∀ b, GaloisConnection (l₁ b) (swap u b))
-    (h₂ : ∀ a, GaloisConnection (toDual ∘ l₂ a) (u a ∘ ofDual)) :
-    sInf (image2 u s t) = u (sInf s) (sSup t) :=
-  sInf_image2_eq_sInf_sInf (β := βᵒᵈ) h₁ h₂
-
-theorem sInf_image2_eq_sSup_sInf (h₁ : ∀ b, GaloisConnection (toDual ∘ l₁ b) (swap u b ∘ ofDual))
-    (h₂ : ∀ a, GaloisConnection (l₂ a) (u a)) : sInf (image2 u s t) = u (sSup s) (sInf t) :=
-  sInf_image2_eq_sInf_sInf (α := αᵒᵈ) h₁ h₂
-
-theorem sInf_image2_eq_sSup_sSup (h₁ : ∀ b, GaloisConnection (toDual ∘ l₁ b) (swap u b ∘ ofDual))
-    (h₂ : ∀ a, GaloisConnection (toDual ∘ l₂ a) (u a ∘ ofDual)) :
-    sInf (image2 u s t) = u (sSup s) (sSup t) :=
-  sInf_image2_eq_sInf_sInf (α := αᵒᵈ) (β := βᵒᵈ) h₁ h₂
 
 end CompleteLattice
 
@@ -278,8 +208,9 @@ namespace OrderIso
 variable [Preorder α] [Preorder β]
 
 /-- Makes a Galois connection from an order-preserving bijection. -/
+@[to_dual none]
 lemma to_galoisConnection (e : α ≃o β) : GaloisConnection e e.symm :=
-  fun _ _ => e.rel_symm_apply.symm
+  fun _ _ => e.le_symm_apply.symm
 
 /-- Makes a Galois insertion from an order-preserving bijection. -/
 protected def toGaloisInsertion (e : α ≃o β) : GaloisInsertion e e.symm where
@@ -295,21 +226,13 @@ protected def toGaloisCoinsertion (e : α ≃o β) : GaloisCoinsertion e e.symm 
   u_l_le g := le_of_eq (e.left_inv g)
   choice_eq _ _ := rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem bddAbove_image (e : α ≃o β) {s : Set α} : BddAbove (e '' s) ↔ BddAbove s :=
   e.to_galoisConnection.bddAbove_l_image
 
-@[simp]
-theorem bddBelow_image (e : α ≃o β) {s : Set α} : BddBelow (e '' s) ↔ BddBelow s :=
-  e.dual.bddAbove_image
-
-@[simp]
+@[to_dual (attr := simp)]
 theorem bddAbove_preimage (e : α ≃o β) {s : Set β} : BddAbove (e ⁻¹' s) ↔ BddAbove s := by
   rw [← e.bddAbove_image, e.image_preimage]
-
-@[simp]
-theorem bddBelow_preimage (e : α ≃o β) {s : Set β} : BddBelow (e ⁻¹' s) ↔ BddBelow s := by
-  rw [← e.bddBelow_image, e.image_preimage]
 
 end OrderIso
 
@@ -324,61 +247,76 @@ namespace GaloisInsertion
 
 variable {l : α → β} {u : β → α}
 
+@[to_dual]
 theorem l_sup_u [SemilatticeSup α] [SemilatticeSup β] (gi : GaloisInsertion l u) (a b : β) :
     l (u a ⊔ u b) = a ⊔ b :=
   calc
     l (u a ⊔ u b) = l (u a) ⊔ l (u b) := gi.gc.l_sup
     _ = a ⊔ b := by simp only [gi.l_u_eq]
 
+@[to_dual]
 theorem l_iSup_u [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u) {ι : Sort x}
     (f : ι → β) : l (⨆ i, u (f i)) = ⨆ i, f i :=
   calc
     l (⨆ i : ι, u (f i)) = ⨆ i : ι, l (u (f i)) := gi.gc.l_iSup
     _ = ⨆ i : ι, f i := congr_arg _ <| funext fun i => gi.l_u_eq (f i)
 
+@[to_dual]
 theorem l_biSup_u [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u) {ι : Sort x}
     {p : ι → Prop} (f : ∀ i, p i → β) : l (⨆ (i) (hi), u (f i hi)) = ⨆ (i) (hi), f i hi := by
   simp only [iSup_subtype', gi.l_iSup_u]
 
+@[to_dual]
 theorem l_sSup_u_image [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
     (s : Set β) : l (sSup (u '' s)) = sSup s := by rw [sSup_image, gi.l_biSup_u, sSup_eq_iSup]
 
+@[to_dual]
 theorem l_inf_u [SemilatticeInf α] [SemilatticeInf β] (gi : GaloisInsertion l u) (a b : β) :
     l (u a ⊓ u b) = a ⊓ b :=
   calc
     l (u a ⊓ u b) = l (u (a ⊓ b)) := congr_arg l gi.gc.u_inf.symm
     _ = a ⊓ b := by simp only [gi.l_u_eq]
 
+@[to_dual]
 theorem l_iInf_u [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u) {ι : Sort x}
     (f : ι → β) : l (⨅ i, u (f i)) = ⨅ i, f i :=
   calc
     l (⨅ i : ι, u (f i)) = l (u (⨅ i : ι, f i)) := congr_arg l gi.gc.u_iInf.symm
     _ = ⨅ i : ι, f i := gi.l_u_eq _
 
+@[to_dual]
 theorem l_biInf_u [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u) {ι : Sort x}
     {p : ι → Prop} (f : ∀ (i) (_ : p i), β) : l (⨅ (i) (hi), u (f i hi)) = ⨅ (i) (hi), f i hi := by
   simp only [iInf_subtype', gi.l_iInf_u]
 
+@[to_dual]
 theorem l_sInf_u_image [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
     (s : Set β) : l (sInf (u '' s)) = sInf s := by rw [sInf_image, gi.l_biInf_u, sInf_eq_iInf]
 
-theorem l_iInf_of_ul_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
+@[to_dual]
+theorem l_iInf_of_u_l_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
     {ι : Sort x} (f : ι → α) (hf : ∀ i, u (l (f i)) = f i) : l (⨅ i, f i) = ⨅ i, l (f i) :=
   calc
     l (⨅ i, f i) = l (⨅ i : ι, u (l (f i))) := by simp [hf]
     _ = ⨅ i, l (f i) := gi.l_iInf_u _
 
-theorem l_biInf_of_ul_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
+@[to_dual]
+theorem l_biInf_of_u_l_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisInsertion l u)
     {ι : Sort x} {p : ι → Prop} (f : ∀ (i) (_ : p i), α) (hf : ∀ i hi, u (l (f i hi)) = f i hi) :
     l (⨅ (i) (hi), f i hi) = ⨅ (i) (hi), l (f i hi) := by
   rw [iInf_subtype', iInf_subtype']
-  exact gi.l_iInf_of_ul_eq_self _ fun _ => hf _ _
+  exact gi.l_iInf_of_u_l_eq_self _ fun _ => hf _ _
 
+@[deprecated (since := "2026-04-10")] alias l_iInf_of_ul_eq_self := l_iInf_of_u_l_eq_self
+@[deprecated (since := "2026-04-10")] alias l_biInf_of_ul_eq_self := l_biInf_of_u_l_eq_self
+
+@[to_dual]
 theorem isLUB_of_u_image [Preorder α] [Preorder β] (gi : GaloisInsertion l u) {s : Set β} {a : α}
     (hs : IsLUB (u '' s) a) : IsLUB s (l a) :=
   ⟨fun x hx => (gi.le_l_u x).trans <| gi.gc.monotone_l <| hs.1 <| mem_image_of_mem _ hx, fun _ hx =>
     gi.gc.l_le <| hs.2 <| gi.gc.monotone_u.mem_upperBounds_image hx⟩
 
+@[to_dual]
 theorem isGLB_of_u_image [Preorder α] [Preorder β] (gi : GaloisInsertion l u) {s : Set β} {a : α}
     (hs : IsGLB (u '' s) a) : IsGLB s (l a) :=
   ⟨fun _ hx => gi.gc.l_le <| hs.1 <| mem_image_of_mem _ hx, fun x hx =>
@@ -390,6 +328,7 @@ variable [PartialOrder β]
 
 -- See note [reducible non-instances]
 /-- Lift the suprema along a Galois insertion -/
+@[to_dual /-- Lift the infima along a Galois coinsertion -/]
 abbrev liftSemilatticeSup [SemilatticeSup α] (gi : GaloisInsertion l u) : SemilatticeSup β :=
   { ‹PartialOrder β› with
     sup := fun a b => l (u a ⊔ u b)
@@ -400,6 +339,7 @@ abbrev liftSemilatticeSup [SemilatticeSup α] (gi : GaloisInsertion l u) : Semil
 
 -- See note [reducible non-instances]
 /-- Lift the infima along a Galois insertion -/
+@[to_dual /-- Lift the suprema along a Galois coinsertion -/]
 abbrev liftSemilatticeInf [SemilatticeInf α] (gi : GaloisInsertion l u) : SemilatticeInf β :=
   { ‹PartialOrder β› with
     inf := fun a b =>
@@ -420,7 +360,14 @@ abbrev liftLattice [Lattice α] (gi : GaloisInsertion l u) : Lattice β :=
   { gi.liftSemilatticeSup, gi.liftSemilatticeInf with }
 
 -- See note [reducible non-instances]
+/-- Lift the suprema and infima along a Galois coinsertion -/
+@[to_dual existing]
+abbrev _root_.GaloisCoinsertion.liftLattice [Lattice α] (gi : GaloisCoinsertion u l) : Lattice β :=
+  { gi.liftSemilatticeSup, gi.liftSemilatticeInf with }
+
+-- See note [reducible non-instances]
 /-- Lift the top along a Galois insertion -/
+@[to_dual /-- Lift the bot along a Galois coinsertion -/]
 abbrev liftOrderTop [Preorder α] [OrderTop α] (gi : GaloisInsertion l u) :
     OrderTop β where
   top := gi.choice ⊤ <| le_top
@@ -429,11 +376,13 @@ abbrev liftOrderTop [Preorder α] [OrderTop α] (gi : GaloisInsertion l u) :
 
 -- See note [reducible non-instances]
 /-- Lift the top, bottom, suprema, and infima along a Galois insertion -/
+@[to_dual /-- Lift the top, bottom, suprema, and infima along a Galois coinsertion -/]
 abbrev liftBoundedOrder [Preorder α] [BoundedOrder α] (gi : GaloisInsertion l u) : BoundedOrder β :=
   { gi.liftOrderTop, gi.gc.liftOrderBot with }
 
 -- See note [reducible non-instances]
 /-- Lift all suprema and infima along a Galois insertion -/
+@[to_dual /-- Lift all suprema and infima along a Galois coinsertion -/]
 abbrev liftCompleteLattice [CompleteLattice α] (gi : GaloisInsertion l u) : CompleteLattice β :=
   { gi.liftBoundedOrder, gi.liftLattice with
     sSup := fun s => l (sSup (u '' s))
@@ -452,110 +401,20 @@ end GaloisInsertion
 
 namespace GaloisCoinsertion
 
-variable {l : α → β} {u : β → α}
-
-theorem u_inf_l [SemilatticeInf α] [SemilatticeInf β] (gi : GaloisCoinsertion l u) (a b : α) :
-    u (l a ⊓ l b) = a ⊓ b :=
-  gi.dual.l_sup_u a b
-
-theorem u_iInf_l [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u) {ι : Sort x}
-    (f : ι → α) : u (⨅ i, l (f i)) = ⨅ i, f i :=
-  gi.dual.l_iSup_u _
-
-theorem u_sInf_l_image [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u)
-    (s : Set α) : u (sInf (l '' s)) = sInf s :=
-  gi.dual.l_sSup_u_image _
-
-theorem u_sup_l [SemilatticeSup α] [SemilatticeSup β] (gi : GaloisCoinsertion l u) (a b : α) :
-    u (l a ⊔ l b) = a ⊔ b :=
-  gi.dual.l_inf_u _ _
-
-theorem u_iSup_l [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u) {ι : Sort x}
-    (f : ι → α) : u (⨆ i, l (f i)) = ⨆ i, f i :=
-  gi.dual.l_iInf_u _
-
-theorem u_biSup_l [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u) {ι : Sort x}
-    {p : ι → Prop} (f : ∀ (i) (_ : p i), α) : u (⨆ (i) (hi), l (f i hi)) = ⨆ (i) (hi), f i hi :=
-  gi.dual.l_biInf_u _
-
-theorem u_sSup_l_image [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u)
-    (s : Set α) : u (sSup (l '' s)) = sSup s :=
-  gi.dual.l_sInf_u_image _
-
-theorem u_iSup_of_lu_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u)
-    {ι : Sort x} (f : ι → β) (hf : ∀ i, l (u (f i)) = f i) : u (⨆ i, f i) = ⨆ i, u (f i) :=
-  gi.dual.l_iInf_of_ul_eq_self _ hf
-
-theorem u_biSup_of_lu_eq_self [CompleteLattice α] [CompleteLattice β] (gi : GaloisCoinsertion l u)
-    {ι : Sort x} {p : ι → Prop} (f : ∀ (i) (_ : p i), β) (hf : ∀ i hi, l (u (f i hi)) = f i hi) :
-    u (⨆ (i) (hi), f i hi) = ⨆ (i) (hi), u (f i hi) :=
-  gi.dual.l_biInf_of_ul_eq_self _ hf
-
-theorem isGLB_of_l_image [Preorder α] [Preorder β] (gi : GaloisCoinsertion l u) {s : Set α} {a : β}
-    (hs : IsGLB (l '' s) a) : IsGLB s (u a) :=
-  gi.dual.isLUB_of_u_image hs
-
-theorem isLUB_of_l_image [Preorder α] [Preorder β] (gi : GaloisCoinsertion l u) {s : Set α} {a : β}
-    (hs : IsLUB (l '' s) a) : IsLUB s (u a) :=
-  gi.dual.isGLB_of_u_image hs
-
-section lift
-
-variable [PartialOrder α]
-
--- See note [reducible non-instances]
-/-- Lift the infima along a Galois coinsertion -/
-abbrev liftSemilatticeInf [SemilatticeInf β] (gi : GaloisCoinsertion l u) : SemilatticeInf α :=
-  { ‹PartialOrder α› with
-    inf_le_left := fun a b =>
-      (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_left a b
-    inf_le_right := fun a b =>
-      (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_right a b
-    le_inf := fun a b c =>
-      (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).le_inf a b c
-    inf := fun a b => u (l a ⊓ l b) }
-
--- See note [reducible non-instances]
-/-- Lift the suprema along a Galois coinsertion -/
-abbrev liftSemilatticeSup [SemilatticeSup β] (gi : GaloisCoinsertion l u) : SemilatticeSup α :=
-  { ‹PartialOrder α› with
-    sup := fun a b =>
-      gi.choice (l a ⊔ l b) <|
-        sup_le (gi.gc.monotone_l <| gi.gc.le_u <| le_sup_left)
-          (gi.gc.monotone_l <| gi.gc.le_u <| le_sup_right)
-    le_sup_left := fun a b =>
-      (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_left a b
-    le_sup_right := fun a b =>
-      (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_right a b
-    sup_le := fun a b c =>
-      (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).sup_le a b c }
-
--- See note [reducible non-instances]
-/-- Lift the suprema and infima along a Galois coinsertion -/
-abbrev liftLattice [Lattice β] (gi : GaloisCoinsertion l u) : Lattice α :=
-  { gi.liftSemilatticeSup, gi.liftSemilatticeInf with }
-
--- See note [reducible non-instances]
-/-- Lift the bot along a Galois coinsertion -/
-abbrev liftOrderBot [Preorder β] [OrderBot β] (gi : GaloisCoinsertion l u) : OrderBot α :=
-  { @OrderDual.instOrderBotOfOrderTop _ _ gi.dual.liftOrderTop with bot := gi.choice ⊥ <| bot_le }
-
--- See note [reducible non-instances]
-/-- Lift the top, bottom, suprema, and infima along a Galois coinsertion -/
-abbrev liftBoundedOrder
-    [Preorder β] [BoundedOrder β] (gi : GaloisCoinsertion l u) : BoundedOrder α :=
-  { gi.liftOrderBot, gi.gc.liftOrderTop with }
-
--- See note [reducible non-instances]
-/-- Lift all suprema and infima along a Galois coinsertion -/
-abbrev liftCompleteLattice [CompleteLattice β] (gi : GaloisCoinsertion l u) : CompleteLattice α :=
-  { @OrderDual.instCompleteLattice αᵒᵈ gi.dual.liftCompleteLattice with
-    sInf := fun s => u (sInf (l '' s))
-    sSup := fun s => gi.choice (sSup (l '' s)) _ }
-
-end lift
+@[deprecated (since := "2026-04-10")] alias u_iSup_of_lu_eq_self := u_iSup_of_l_u_eq_self
+@[deprecated (since := "2026-04-10")] alias u_biSup_of_lu_eq_self := u_biSup_of_l_u_eq_self
 
 end GaloisCoinsertion
+
+/-- `sSup` and `Iic` form a Galois connection. -/
+theorem gc_sSup_Iic [CompleteSemilatticeSup α] :
+    GaloisConnection (sSup : Set α → α) (Iic : α → Set α) :=
+  fun _ _ ↦ sSup_le_iff
+
+/-- `toDual ∘ Ici` and `sInf ∘ ofDual` form a Galois connection. -/
+theorem gc_Ici_sInf [CompleteSemilatticeInf α] :
+    GaloisConnection (toDual ∘ Ici : α → (Set α)ᵒᵈ) (sInf ∘ ofDual : (Set α)ᵒᵈ → α) :=
+  fun _ _ ↦ le_sInf_iff.symm
 
 /-- `sSup` and `Iic` form a Galois insertion. -/
 def gi_sSup_Iic [CompleteSemilatticeSup α] :
@@ -569,6 +428,9 @@ def gci_Ici_sInf [CompleteSemilatticeInf α] :
 
 /-- If `α` is a partial order with bottom element (e.g., `ℕ`, `ℝ≥0`), then `WithBot.unbot' ⊥` and
 coercion form a Galois insertion. -/
+@[to_dual giUntopDTop
+/-- If `α` is a partial order with top element, then `WithTop.untop' ⊥` and
+coercion form a Galois insertion. -/]
 def WithBot.giUnbotDBot [Preorder α] [OrderBot α] :
     GaloisInsertion (WithBot.unbotD ⊥) (some : α → WithBot α) where
   gc _ _ := WithBot.unbotD_le_iff (fun _ ↦ bot_le)

--- a/Mathlib/Order/GaloisConnection/Basic.lean
+++ b/Mathlib/Order/GaloisConnection/Basic.lean
@@ -85,7 +85,7 @@ section SemilatticeSup
 
 variable [SemilatticeSup α] [SemilatticeSup β] {l : α → β} {u : β → α}
 
-@[to_dual]
+@[to_dual (rename := α ↔ β, a₁ → b₁, a₂ → b₂)]
 theorem l_sup (gc : GaloisConnection l u) : l (a₁ ⊔ a₂) = l a₁ ⊔ l a₂ :=
   (gc.isLUB_l_image isLUB_pair).unique <| by simp only [image_pair, isLUB_pair]
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -1026,7 +1026,7 @@ theorem generateFrom_iInter (f : ι → TopologicalSpace α) :
 theorem generateFrom_iInter_of_generateFrom_eq_self (f : ι → Set (Set α))
     (hf : ∀ i, { s | IsOpen[generateFrom (f i)] s } = f i) :
     generateFrom (⋂ i, f i) = ⨆ i, generateFrom (f i) :=
-  (gciGenerateFrom α).u_iSup_of_lu_eq_self f hf
+  (gciGenerateFrom α).u_iSup_of_l_u_eq_self f hf
 
 variable {t : ι → TopologicalSpace α}
 


### PR DESCRIPTION
This PR uses `to_dual` for material on `GaloisConnection` and `GaloisInsertion`/`GaloisCoinsertion`.

In particular, the instance lifting constructions on `GaloisCoinsertion` now do not anymore abuse defeq of `OrderDual`, meaning that we should be able to remove some more `backward.isDefEq.respectTransparency`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
