### PR TITLE
[Merged by Bors] - chore(Algebra): shorten proof by using tactic mode instead of calc mode

### DIFF
--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -20,7 +20,8 @@ theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R 
     congr_arg star ((mem_center_iff.1 ha).comm <| star g).symm
   left_assoc b c := by
     simpa only [star_mul, star_star] using congr_arg star (ha.right_assoc (star c) (star b))
-  right_assoc b c := by simpa using congr(star $(ha.left_assoc (star c) (star b)))
+  right_assoc b c := by
+    simpa only [star_mul, star_star] using congr_arg star (ha.left_assoc (star c) (star b))
 
 theorem Set.star_centralizer : star s.centralizer = (star s).centralizer := by
   simp_rw [centralizer, ← commute_iff_eq]

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -18,7 +18,8 @@ variable {R : Type*} [Mul R] [StarMul R] {a : R} {s : Set R}
 theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R where
   comm := by simpa only [star_mul, star_star] using fun g =>
     congr_arg star ((mem_center_iff.1 ha).comm <| star g).symm
-  left_assoc b c := by simpa using congr(star $(ha.right_assoc (star c) (star b)))
+  left_assoc b c := by
+    simpa only [star_mul, star_star] using congr_arg star (ha.right_assoc (star c) (star b))
   right_assoc b c := by simpa using congr(star $(ha.left_assoc (star c) (star b)))
 
 theorem Set.star_centralizer : star s.centralizer = (star s).centralizer := by

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -18,10 +18,8 @@ variable {R : Type*} [Mul R] [StarMul R] {a : R} {s : Set R}
 theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R where
   comm := by simpa only [star_mul, star_star] using fun g =>
     congr_arg star ((mem_center_iff.1 ha).comm <| star g).symm
-  left_assoc b c := by
-    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul]; simp [ha.right_assoc]
-  right_assoc b c := by
-    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul]; simp [ha.left_assoc]
+  left_assoc b c := by simpa using congr(star $(ha.right_assoc (star c) (star b)))
+  right_assoc b c := by simpa using congr(star $(ha.left_assoc (star c) (star b)))
 
 theorem Set.star_centralizer : star s.centralizer = (star s).centralizer := by
   simp_rw [centralizer, ← commute_iff_eq]

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -18,19 +18,12 @@ variable {R : Type*} [Mul R] [StarMul R] {a : R} {s : Set R}
 theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R where
   comm := by simpa only [star_mul, star_star] using fun g =>
     congr_arg star ((mem_center_iff.1 ha).comm <| star g).symm
-  left_assoc b c := calc
-    star a * (b * c) = star a * (star (star b) * star (star c)) := by rw [star_star, star_star]
-    _ = star a * star (star c * star b) := by rw [star_mul]
-    _ = star ((star c * star b) * a) := by rw [← star_mul]
-    _ = star (star c * (star b * a)) := by rw [ha.right_assoc]
-    _ = star (star b * a) * c := by rw [star_mul, star_star]
-    _ = (star a * b) * c := by rw [star_mul, star_star]
-  right_assoc b c := calc
-    b * c * star a = star (a * star (b * c)) := by rw [star_mul, star_star]
-    _ = star (a * (star c * star b)) := by rw [star_mul b]
-    _ = star ((a * star c) * star b) := by rw [ha.left_assoc]
-    _ = b * star (a * star c) := by rw [star_mul, star_star]
-    _ = b * (c * star a) := by rw [star_mul, star_star]
+  left_assoc b c := by
+    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul, ha.right_assoc, star_mul,
+      star_mul, star_star, star_star]
+  right_assoc b c := by
+    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul, ha.left_assoc, star_mul,
+      star_mul, star_star, star_star]
 
 theorem Set.star_centralizer : star s.centralizer = (star s).centralizer := by
   simp_rw [centralizer, ← commute_iff_eq]

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -19,11 +19,9 @@ theorem Set.star_mem_center (ha : a ∈ Set.center R) : star a ∈ Set.center R 
   comm := by simpa only [star_mul, star_star] using fun g =>
     congr_arg star ((mem_center_iff.1 ha).comm <| star g).symm
   left_assoc b c := by
-    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul, ha.right_assoc, star_mul,
-      star_mul, star_star, star_star]
+    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul]; simp [ha.right_assoc]
   right_assoc b c := by
-    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul, ha.left_assoc, star_mul,
-      star_mul, star_star, star_star]
+    rw [← star_star b, ← star_star c, ← star_mul, ← star_mul]; simp [ha.left_assoc]
 
 theorem Set.star_centralizer : star s.centralizer = (star s).centralizer := by
   simp_rw [centralizer, ← commute_iff_eq]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
