### PR TITLE
[Merged by Bors] - chore: fix grammar in abel,field_simp error message

### DIFF
--- a/Mathlib/Util/AtLocation.lean
+++ b/Mathlib/Util/AtLocation.lean
@@ -56,7 +56,7 @@ def transformAtTarget (m : Expr → ReaderT Simp.Context MetaM Simp.Result) (pro
   -- we use expression equality here (rather than defeq) to be consistent with, e.g.,
   -- `applySimpResultToTarget`
   let unchanged := tgt.cleanupAnnotations == r.expr.cleanupAnnotations
-  if failIfUnchanged && unchanged then throwError "{proc} made no progress on goal"
+  if failIfUnchanged && unchanged then throwError "{proc} made no progress on the goal"
   if r.expr.isTrue then
     goal.assign (← mkOfEqTrue (← r.getProof))
     pure none

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -959,7 +959,7 @@ example {K : Type} [Semifield K] {x y : K} (h : x + y ≠ 0) : x / (x + y) + y /
 -- Extracted from `Mathlib/Analysis/SpecificLimits/Basic.lean`
 
 -- `field_simp` assumes commutativity: in its absence, it does nothing.
-/-- error: `field_simp` made no progress on goal -/
+/-- error: `field_simp` made no progress on the goal -/
 #guard_msgs in
 example {K : Type*} [DivisionRing K] {n' x : K} (h : n' ≠ 0) (h' : n' + x ≠ 0) :
     1 / (1 + x / n') = n' / (n' + x) := by

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -29,7 +29,7 @@ section
 
 variable {P : ℚ → Prop} {x y z : ℚ}
 
-/-- error: `field_simp` made no progress on goal -/
+/-- error: `field_simp` made no progress on the goal -/
 #guard_msgs in
 example : P (1 : ℚ) := by test_field_simp
 
@@ -43,7 +43,7 @@ example : P (x ^ 0) := by test_field_simp
 #guard_msgs in
 example : P (x ^ 1) := by test_field_simp
 
-/-- error: `field_simp` made no progress on goal -/
+/-- error: `field_simp` made no progress on the goal -/
 #guard_msgs in
 example : P x := by test_field_simp
 
@@ -181,7 +181,7 @@ example {a : Nat} : P (a* x - a * x) := by test_field_simp
 
 /-! ### Two atoms -/
 
-/-- error: `field_simp` made no progress on goal -/
+/-- error: `field_simp` made no progress on the goal -/
 #guard_msgs in
 example : P (x + y) := by test_field_simp
 

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -58,7 +58,7 @@ example [AddCommGroup α] (a b c : α) :
 def MyTrue := True
 
 /--
-error: `abel_nf` made no progress on goal
+error: `abel_nf` made no progress on the goal
 -/
 #guard_msgs in
 example : MyTrue := by
@@ -87,14 +87,14 @@ example [AddCommGroup α] (x y z : α) : y = x + z - (x - y + z) := by
 example [AddCommGroup α] (a b s : α) : -b + (s - a) = s - b - a := by abel_nf
 
 -- inspired by automated testing
-/-- error: `abel_nf` made no progress on goal -/
+/-- error: `abel_nf` made no progress on the goal -/
 #guard_msgs in
 example : True := by
   have := 0
   abel_nf
 
 /--
-error: `abel_nf` made no progress on goal
+error: `abel_nf` made no progress on the goal
 -/
 #guard_msgs in
 example : False := by abel_nf
@@ -149,7 +149,7 @@ example [AddCommGroup α] (x y z : α) (w : x = y + z) : x - x = 0 := by
   abel_nf at w ⊢
 
 /--
-error: `abel_nf` made no progress on goal
+error: `abel_nf` made no progress on the goal
 -/
 #guard_msgs in
 example [AddCommGroup α] (x y z : α) (w : x - x = y + z) : x = 0 := by


### PR DESCRIPTION
Extracted from #31597.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
