### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/FiniteDimensional/Basic): a domain finitely generated as a module over a field is a field

### DIFF
--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -316,9 +316,8 @@ instance (priority := low) : IsStablyFiniteRing K := by
 theorem _root_.IsField.of_finite (K L : Type*) [Field K] [CommRing L] [IsDomain L]
     [Algebra K L] [Module.Finite K L] : IsField L where
   exists_pair_ne := Nontrivial.exists_pair_ne
-  mul_comm := CommSemiring.mul_comm
-  mul_inv_cancel {x} hx :=
-    (LinearMap.mulLeft K x).surjective_of_injective (mul_right_injective₀ hx) 1
+  mul_comm := mul_comm
+  mul_inv_cancel {x} hx := (mulLeft K x).surjective_of_injective (mul_right_injective₀ hx) 1
 
 section Semiring
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -312,6 +312,14 @@ instance (priority := low) : IsStablyFiniteRing K := by
   have : f * (g * i) = f * 1 := congr_arg _ hi
   rw [← mul_assoc, hfg, one_mul, mul_one] at this; rwa [← this]
 
+/-- A domain finitely generated over a field is a field. -/
+theorem _root_.IsField.of_finite (K L : Type*) [Field K] [CommRing L] [IsDomain L]
+    [Algebra K L] [Module.Finite K L] : IsField L where
+  exists_pair_ne := Nontrivial.exists_pair_ne
+  mul_comm := CommSemiring.mul_comm
+  mul_inv_cancel {x} hx :=
+    (LinearMap.mulLeft K x).surjective_of_injective (mul_right_injective₀ hx) 1
+
 section Semiring
 
 variable (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] [Free R M] [Module.Finite R M]

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -313,7 +313,7 @@ instance (priority := low) : IsStablyFiniteRing K := by
   rw [← mul_assoc, hfg, one_mul, mul_one] at this; rwa [← this]
 
 /-- A domain finitely generated as a module over a field is a field. -/
-theorem _root_.IsField.of_finite (K L : Type*) [Field K] [CommRing L] [IsDomain L]
+theorem _root_.IsField.of_isDomain_of_finite (K L : Type*) [Field K] [CommRing L] [IsDomain L]
     [Algebra K L] [Module.Finite K L] : IsField L where
   exists_pair_ne := Nontrivial.exists_pair_ne
   mul_comm := mul_comm

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -312,7 +312,7 @@ instance (priority := low) : IsStablyFiniteRing K := by
   have : f * (g * i) = f * 1 := congr_arg _ hi
   rw [← mul_assoc, hfg, one_mul, mul_one] at this; rwa [← this]
 
-/-- A domain finitely generated over a field is a field. -/
+/-- A domain finitely generated as a module over a field is a field. -/
 theorem _root_.IsField.of_finite (K L : Type*) [Field K] [CommRing L] [IsDomain L]
     [Algebra K L] [Module.Finite K L] : IsField L where
   exists_pair_ne := Nontrivial.exists_pair_ne


### PR DESCRIPTION
This PR proves that a domain finitely generated as a module over a field is a field. We could already prove this from `IsArtinianRing.of_finite` and `IsArtinianRing.isField_of_isDomain`, but it seems good to a have a direct proof with less imports.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
