### PR TITLE
chore(Data/ZMod) mark `a - b = a + b` (for ZMod 2) as simp lemma

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1237,6 +1237,7 @@ lemma ZModModule.add_self (x : G) : x + x = 0 := by
 
 lemma ZModModule.neg_eq_self (x : G) : -x = x := by simp [add_self, eq_comm, ← sub_eq_zero]
 
+@[simp]
 lemma ZModModule.sub_eq_add (x y : G) : x - y = x + y := by simp [neg_eq_self, sub_eq_add_neg]
 
 lemma ZModModule.add_add_add_cancel (x y z : G) : (x + y) + (y + z) = x + z := by


### PR DESCRIPTION
I find myself using this lemma quite a bit and have an alias marked `@[simp]` in my code. Maybe it's good to have it generally?

 I think replacing subtraction in `ZMod 2` by addition is always a simplification (and then it's automatically clear, e.g., that it commutes).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->


Is it a concern that it might impact `simp` performance? In theory, I guess it has to always check if there is an instance `[Module (ZMod 2) G]`, which sounds like it could be expensive. However, in my testing it doesn't seem to add much.

Note: I read about [how to name PRs](https://leanprover-community.github.io/contribute/commit.html) but I'm still not sure what prefix (could be `feat`?) is appropriate for this PR (assuming the PR is even appropriate in the first place. Sorry if it isn't!)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
