### PR TITLE
[Merged by Bors] - chore(Order/Closure): generalize from `PartialOrder` to `Preorder` where possible

### DIFF
--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -102,9 +102,9 @@ lemma conjBy_trans {α β γ} [Preorder α] [Preorder β] [Preorder γ]
     (e₁ : α ≃o β) (e₂ : β ≃o γ) (c : ClosureOperator α) :
     c.conjBy (e₁.trans e₂) = (c.conjBy e₁).conjBy e₂ := rfl
 
-section PartialOrder
+section Preorder
 
-variable [PartialOrder α]
+variable [Preorder α]
 
 /-- The identity function as a closure operator. -/
 @[simps!]
@@ -117,12 +117,59 @@ def id : ClosureOperator α where
 instance : Inhabited (ClosureOperator α) :=
   ⟨id α⟩
 
-variable {α}
-variable (c : ClosureOperator α)
+variable {α} (c : ClosureOperator α)
 
 @[ext]
 theorem ext : ∀ c₁ c₂ : ClosureOperator α, (∀ x, c₁ x = c₂ x) → c₁ = c₂ :=
   DFunLike.ext
+
+@[mono]
+theorem monotone : Monotone c :=
+  c.monotone'
+
+/-- Every element is less than its closure. This property is sometimes referred to as extensivity or
+inflationarity. -/
+theorem le_closure (x : α) : x ≤ c x :=
+  c.le_closure' x
+
+@[simp]
+theorem idempotent (x : α) : c (c x) = c x :=
+  c.idempotent' x
+
+@[simp] lemma isClosed_closure (x : α) : c.IsClosed (c x) := c.isClosed_iff.2 <| c.idempotent x
+
+/-- The type of elements closed under a closure operator. -/
+abbrev Closeds := {x // c.IsClosed x}
+
+/-- Send an element to a closed element (by taking the closure). -/
+def toCloseds (x : α) : c.Closeds := ⟨c x, c.isClosed_closure x⟩
+
+variable {c} {x y : α}
+
+theorem IsClosed.closure_eq : c.IsClosed x → c x = x := c.isClosed_iff.1
+
+/-- The set of closed elements for `c` is exactly its range. -/
+theorem setOf_isClosed_eq_range_closure : {x | c.IsClosed x} = Set.range c := by
+  ext x; exact ⟨fun hx ↦ ⟨x, hx.closure_eq⟩, by rintro ⟨y, rfl⟩; exact c.isClosed_closure _⟩
+
+theorem le_closure_iff : x ≤ c y ↔ c x ≤ c y :=
+  ⟨fun h ↦ c.idempotent y ▸ c.monotone h, (c.le_closure x).trans⟩
+
+@[simp]
+theorem IsClosed.closure_le_iff (hy : c.IsClosed y) : c x ≤ y ↔ x ≤ y := by
+  rw [← hy.closure_eq, ← le_closure_iff]
+
+lemma closure_min (hxy : x ≤ y) (hy : c.IsClosed y) : c x ≤ y := hy.closure_le_iff.2 hxy
+
+lemma closure_isGLB (x : α) : IsGLB { y | x ≤ y ∧ c.IsClosed y } (c x) where
+  left _ := and_imp.mpr closure_min
+  right _ h := h ⟨c.le_closure x, c.isClosed_closure x⟩
+
+end Preorder
+
+section PartialOrder
+
+variable [PartialOrder α] {α} {c : ClosureOperator α} {x y : α}
 
 /-- Constructor for a closure operator using the weaker idempotency axiom: `f (f x) ≤ f x`. -/
 @[simps]
@@ -152,50 +199,8 @@ def ofPred (f : α → α) (p : α → Prop) (hf : ∀ x, x ≤ f x) (hfp : ∀ 
   IsClosed := p
   isClosed_iff := ⟨fun hx ↦ (hmin le_rfl hx).antisymm <| hf _, fun hx ↦ hx ▸ hfp _⟩
 
-@[mono]
-theorem monotone : Monotone c :=
-  c.monotone'
-
-/-- Every element is less than its closure. This property is sometimes referred to as extensivity or
-inflationarity. -/
-theorem le_closure (x : α) : x ≤ c x :=
-  c.le_closure' x
-
-@[simp]
-theorem idempotent (x : α) : c (c x) = c x :=
-  c.idempotent' x
-
-@[simp] lemma isClosed_closure (x : α) : c.IsClosed (c x) := c.isClosed_iff.2 <| c.idempotent x
-
-/-- The type of elements closed under a closure operator. -/
-abbrev Closeds := {x // c.IsClosed x}
-
-/-- Send an element to a closed element (by taking the closure). -/
-def toCloseds (x : α) : c.Closeds := ⟨c x, c.isClosed_closure x⟩
-
-variable {c} {x y : α}
-
-theorem IsClosed.closure_eq : c.IsClosed x → c x = x := c.isClosed_iff.1
-
 theorem isClosed_iff_closure_le : c.IsClosed x ↔ c x ≤ x :=
   ⟨fun h ↦ h.closure_eq.le, fun h ↦ c.isClosed_iff.2 <| h.antisymm <| c.le_closure x⟩
-
-/-- The set of closed elements for `c` is exactly its range. -/
-theorem setOf_isClosed_eq_range_closure : {x | c.IsClosed x} = Set.range c := by
-  ext x; exact ⟨fun hx ↦ ⟨x, hx.closure_eq⟩, by rintro ⟨y, rfl⟩; exact c.isClosed_closure _⟩
-
-theorem le_closure_iff : x ≤ c y ↔ c x ≤ c y :=
-  ⟨fun h ↦ c.idempotent y ▸ c.monotone h, (c.le_closure x).trans⟩
-
-@[simp]
-theorem IsClosed.closure_le_iff (hy : c.IsClosed y) : c x ≤ y ↔ x ≤ y := by
-  rw [← hy.closure_eq, ← le_closure_iff]
-
-lemma closure_min (hxy : x ≤ y) (hy : c.IsClosed y) : c x ≤ y := hy.closure_le_iff.2 hxy
-
-lemma closure_isGLB (x : α) : IsGLB { y | x ≤ y ∧ c.IsClosed y } (c x) where
-  left _ := and_imp.mpr closure_min
-  right _ h := h ⟨c.le_closure x, c.isClosed_closure x⟩
 
 theorem ext_isClosed (c₁ c₂ : ClosureOperator α)
     (h : ∀ x, c₁.IsClosed x ↔ c₂.IsClosed x) : c₁ = c₂ :=
@@ -385,7 +390,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] [PartialOrder β] {u : β → α} (l : LowerAdjoint u)
+variable [PartialOrder α] [Preorder β] {u : β → α} (l : LowerAdjoint u)
 
 theorem mem_closed_iff_closure_le (x : α) : x ∈ l.closed ↔ u (l x) ≤ x :=
   l.closureOperator.isClosed_iff_closure_le

--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -169,7 +169,7 @@ end Preorder
 
 section PartialOrder
 
-variable [PartialOrder α] {α} {c : ClosureOperator α} {x y : α}
+variable {α} [PartialOrder α] {c : ClosureOperator α} {x y : α}
 
 /-- Constructor for a closure operator using the weaker idempotency axiom: `f (f x) ≤ f x`. -/
 @[simps]


### PR DESCRIPTION
Rearranges declarations to a new `Preorder` section above the existing `PartialOrder` section.

---
Only reordered existing decls, and modified `variable` statements.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
