### PR TITLE
[Merged by Bors] - feat: weekly linting for successful `grind?`

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -123,6 +123,7 @@ register_linter_set linter.nightlyRegressionSet :=
 register_linter_set linter.weeklyLintSet :=
   linter.tacticAnalysis.mergeWithGrind
   linter.style.docStringVerso
+  linter.tacticAnalysis.verifyGrindOnly
 
 -- Check that all linter options mentioned in the mathlib standard linter set exist.
 open Lean Elab.Command Linter Mathlib.Linter Style UnusedInstancesInType

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -596,7 +596,7 @@ Runs the given tactic at each proof step, captures any "Try this:" suggestions,
 then re-runs the suggested tactic to verify it succeeds.
 Only reports failures (where the suggestion doesn't close the goal). -/
 def Mathlib.TacticAnalysis.verifyTryThisSuggestions
-    (tac : Syntax → MVarId → CommandElabM (TSyntax `tactic))
+    (tac : Syntax → MVarId → CommandElabM (Option (TSyntax `tactic)))
     (label : String) : TacticAnalysis.Config where
   run seq := do
     let opts ← getOptions
@@ -608,7 +608,7 @@ def Mathlib.TacticAnalysis.verifyTryThisSuggestions
           withOptions (·.setBool `pp.mvars.anonymous false) do
             return toString (← Meta.ppGoal goal)
         if (hash goalPP) % fraction = 0 then
-          let tac ← tac i.tacI.stx goal
+          if let some tac ← tac i.tacI.stx goal then
           -- Save message state to suppress "Try this:" info messages from grind?
           let savedMessages := (← get).messages
           -- Run tactic and capture InfoTree
@@ -693,3 +693,18 @@ register_option linter.tacticAnalysis.verifyGrindSuggestions : Bool := {
 def verifyGrindSuggestions := verifyTryThisSuggestions
   (fun _ _ => `(tactic| grind? +suggestions))
   "grind? +suggestions"
+
+/-- Verify that replacing `grind` with `grind?` produces a valid `grind only` suggestion. -/
+register_option linter.tacticAnalysis.verifyGrindOnly : Bool := {
+  defValue := false
+}
+
+@[tacticAnalysis linter.tacticAnalysis.verifyGrindOnly,
+   inherit_doc linter.tacticAnalysis.verifyGrindOnly]
+def verifyGrindOnly := verifyTryThisSuggestions
+  (fun stx _ =>
+    return match stx with
+    | .node info ``Lean.Parser.Tactic.grind args => some ⟨.node info ``Lean.Parser.Tactic.grindTrace args⟩
+    | _ => none
+  )
+  "grind?"


### PR DESCRIPTION
See [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/A.20feature.20I.20hope.20.60grind.60.20has/near/583506932). This PR adds `linter.tacticAnalysis.verifyGrindOnly` to the weekly linting set, which checks if replacing `grind` with `grind?` produces a valid `grind only` suggestion. This is implemented by very slightly altering `Mathlib.TacticAnalysis.verifyTryThisSuggestions` to allow exiting earlier. Building Mathlib with this enabled, I count 117 calls to `grind` that this lints.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
