### PR TITLE
feat: Exponential map of Lie group is smooth

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4462,6 +4462,7 @@ public import Mathlib.Geometry.Manifold.Algebra.LeftInvariantDerivation
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
 public import Mathlib.Geometry.Manifold.Algebra.Monoid
 public import Mathlib.Geometry.Manifold.Algebra.SmoothFunctions
+public import Mathlib.Geometry.Manifold.Algebra.SmoothLieExp
 public import Mathlib.Geometry.Manifold.Algebra.Structures
 public import Mathlib.Geometry.Manifold.Bordism
 public import Mathlib.Geometry.Manifold.BumpFunction

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothLieExp.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothLieExp.lean
@@ -1,0 +1,405 @@
+/-
+Copyright (c) 2026 Dominic Steinitz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dominic Steinitz
+-/
+
+import Mathlib.Geometry.Manifold.GroupLieAlgebra
+import Mathlib.Geometry.Manifold.IntegralCurve.UniformTime
+import Mathlib.Geometry.Manifold.Sheaf.Basic
+import Mathlib.Order.BourbakiWitt
+
+/-!
+# The Exponential Map of a Lie Group
+
+We construct the exponential map `expLie : g → G` for a Lie group `G` and prove that it
+is smooth. The main reference is:
+
+* Eckhard Meinrenken, *Lie Groups and Lie Algebras*, Lecture Notes, University of Toronto.
+  Available at https://www.math.toronto.edu/mein/teaching/LectureNotes/lie.pdf
+
+The key steps, following Meinrenken §3–4, are:
+
+* Every left-invariant vector field on `G` admits a unique global integral curve through
+  the identity (`IsMIntegralCurve.exists_global`, `IsMIntegralCurve.unique_global`),
+  corresponding to Theorem 3.8.
+
+* The exponential map is defined as `expLie v := γᵥ 1`, where `γᵥ` is this integral curve
+  (`expLie`), corresponding to Definition 4.4.
+
+* Any integral curve of `mulInvariantVectorField v` starting at 1 equals `t ↦ expLie (t • v)`
+  (`expLie_smul`, `isMIntegralCurve_expLie_smul`), corresponding to Proposition 4.3.
+
+* The exponential map is smooth (`contMDiff_expLie`), corresponding to the smoothness
+  assertion in Definition 4.4. This relies on `contMDiff_flow`, an axiom asserting smooth
+  dependence of ODE solutions on parameters (Lee, *Introduction to Smooth Manifolds*,
+  Theorem 9.12), which is currently missing from Mathlib.
+-/
+
+open Set Bundle ContDiff Manifold Trivialization
+
+noncomputable section
+
+variable
+  {EG : Type*} [NormedAddCommGroup EG] [NormedSpace ℝ EG]
+  {HG : Type*} [TopologicalSpace HG]
+  {IG : ModelWithCorners ℝ EG HG}
+  {G : Type*} [TopologicalSpace G]
+  [ChartedSpace HG G] [Group G]
+  [LieGroup IG ⊤ G]
+
+lemma IsMIntegralCurve.left_translate
+    (γ : ℝ → G) (v : GroupLieAlgebra IG G)
+    (hγ : IsMIntegralCurve γ (mulInvariantVectorField v))
+    (g : G) :
+    IsMIntegralCurve (fun t ↦ g * γ t) (mulInvariantVectorField v) := by
+  intro t
+  have h1 : ∞ ≠ 0 := Ne.symm (not_eq_of_beq_eq_false rfl)
+  have hMDiff : ∀ a b : G, MDifferentiableAt IG IG (a * ·) b :=
+  fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable h1 |>.mdifferentiableAt
+  have h6 : mulInvariantVectorField v (g * γ t) =
+    mfderiv IG IG (g * ·) (γ t) (mulInvariantVectorField v (γ t)) := by
+    simp only [mulInvariantVectorField]
+    have h3 : (fun x => (g * γ t) * x) = (fun x => g * x) ∘ (fun x => γ t * x) := by
+      ext; simp [mul_assoc]
+    rw [h3]
+    have h4 : MDifferentiableAt IG IG (g * ·) (γ t * 1) := by rw [mul_one]; exact (hMDiff g (γ t))
+    have h5 : HMul.hMul (γ t) = fun x ↦ γ t * x := rfl
+    rw [mfderiv_comp (1 : G) h4 (hMDiff (γ t) 1), mul_one (γ t), h5]
+    exact ContinuousLinearMap.comp_apply
+      ((mfderiv% fun x ↦ g * x) (γ t)) ((mfderiv% fun x ↦ γ t * x) 1) v
+  rw [h6]
+  convert ((hMDiff g (γ t)).hasMFDerivAt.comp t (hγ t)) using 1
+  ext
+  simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, one_smul]
+  have h2 : (((mfderiv% fun x ↦ g * x) (γ t)).comp
+    (ContinuousLinearMap.smulRight (1 : ℝ →L[ℝ] ℝ) (mulInvariantVectorField v (γ t)))) 1 =
+    ((mfderiv% fun x ↦ g * x) (γ t)) (mulInvariantVectorField v (γ t)) := by
+      simp [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply]
+  exact h2.symm
+
+omit [Group G] [LieGroup IG ⊤ G] in
+lemma IsMIntegralCurve.time_shift
+    (γ : ℝ → G) (v : (x : G) → TangentSpace IG x)
+    (hγ : IsMIntegralCurve γ v)
+    (s : ℝ) :
+    IsMIntegralCurve (fun t ↦ γ (s + t)) v := by
+  intro t
+  have hshift : HasMFDerivAt 𝓘(ℝ, ℝ) 𝓘(ℝ, ℝ) (fun t ↦ s + t) t
+      (ContinuousLinearMap.id ℝ ℝ) := by
+    have h := (hasDerivAt_id t).const_add s
+    rw [hasMFDerivAt_iff_hasFDerivAt, hasFDerivAt_iff_hasDerivAt]
+    simpa using h
+  exact (hγ (s + t)).comp t hshift
+
+lemma IsMIntegralCurveOn.left_translate
+    (γ : ℝ → G) (v : GroupLieAlgebra IG G) (s : Set ℝ)
+    (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s)
+    (g : G) :
+    IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
+  intro t ht
+  have hMDiff : ∀ a b : G, MDifferentiableAt IG IG (a * ·) b :=
+    fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable
+      (by exact Ne.symm (not_eq_of_beq_eq_false rfl)) |>.mdifferentiableAt
+  have h6 : mulInvariantVectorField v (g * γ t) =
+      mfderiv IG IG (g * ·) (γ t) (mulInvariantVectorField v (γ t)) := by
+    simp only [mulInvariantVectorField]
+    have h3 : (fun x => (g * γ t) * x) = (fun x => g * x) ∘ (fun x => γ t * x) := by
+      ext; simp [mul_assoc]
+    rw [h3]
+    have h4 : MDifferentiableAt IG IG (g * ·) (γ t * 1) := by rw [mul_one]; exact hMDiff g (γ t)
+    have h5 : HMul.hMul (γ t) = fun x ↦ γ t * x := rfl
+    rw [mfderiv_comp (1 : G) h4 (hMDiff (γ t) 1), mul_one (γ t), h5]
+    exact ContinuousLinearMap.comp_apply _ _ v
+  rw [h6]
+  convert ((hMDiff g (γ t)).hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)) using 1
+  ext
+  simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, one_smul]
+  have h2 : (((mfderiv% fun x ↦ g * x) (γ t)).comp
+      (ContinuousLinearMap.smulRight (1 : ℝ →L[ℝ] ℝ) (mulInvariantVectorField v (γ t)))) 1 =
+      ((mfderiv% fun x ↦ g * x) (γ t)) (mulInvariantVectorField v (γ t)) := by
+    simp [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply]
+  exact h2.symm
+
+section Whatever
+
+variable [T2Space G]
+
+lemma IsMIntegralCurve.exists_global
+    (v : GroupLieAlgebra IG G)
+    [BoundarylessManifold IG G]
+    [CompleteSpace EG] :
+    ∃ γ : ℝ → G, γ 0 = 1 ∧ IsMIntegralCurve γ (mulInvariantVectorField v) := by
+  let X : G → TangentBundle IG G :=
+    fun x => ⟨x, mulInvariantVectorField v x⟩
+  have : minSmoothness ℝ 3 ≤ ∞ := by
+    simp only [minSmoothness_of_isRCLikeNormedField]
+    exact ENat.LEInfty.out
+  haveI : LieGroup IG (minSmoothness ℝ 3) G := LieGroup.of_le (n := ∞) this
+  have hv' : CMDiff 1 X :=
+    (contMDiff_mulInvariantVectorField v).of_le (le_trans (by norm_num) le_minSmoothness)
+  have hv : CMDiffAt 1 X 1 := hv'.contMDiffAt
+  obtain ⟨γ₀, hγ₀_start, hγ₀_local⟩ :=
+    exists_isMIntegralCurveAt_of_contMDiffAt_boundaryless (t₀ := 0) hv
+  rw [isMIntegralCurveAt_iff] at hγ₀_local
+  obtain ⟨s, hs, hγ₀_on⟩ := hγ₀_local
+  rw [Metric.mem_nhds_iff] at hs
+  obtain ⟨ε, hε, hεs⟩ := hs
+  have hunif : ∀ g : G, ∃ γ : ℝ → G, γ 0 = g ∧
+      IsMIntegralCurveOn γ (mulInvariantVectorField v) (Ioo (-ε) ε) := by
+    intro g
+    refine ⟨fun t ↦ g * γ₀ t, by simp [hγ₀_start], ?_⟩
+    have : Ioo (-ε) ε = Metric.ball 0 ε := by
+      simp only [Metric.ball, dist_zero_right, Real.norm_eq_abs, abs_lt]
+      exact Eq.symm (Ioo_def (-ε) ε)
+    rw [this]
+    apply (hγ₀_on.mono hεs).left_translate
+  obtain ⟨γ, hγ_start, hγ⟩ :=
+    exists_isMIntegralCurve_of_isMIntegralCurveOn hv' hε hunif (1 : G)
+  exact ⟨γ, hγ_start, hγ⟩
+
+noncomputable def expLie (v : GroupLieAlgebra IG G)
+    [BoundarylessManifold IG G] [CompleteSpace EG] : G :=
+  (IsMIntegralCurve.exists_global v).choose 1
+
+lemma IsMIntegralCurve.unique_global
+    (v : GroupLieAlgebra IG G)
+    [BoundarylessManifold IG G]
+    (γ γ' : ℝ → G)
+    (hγ : IsMIntegralCurve γ (mulInvariantVectorField v))
+    (hγ' : IsMIntegralCurve γ' (mulInvariantVectorField v))
+    (hγ0 : γ 0 = 1)
+    (hγ'0 : γ' 0 = 1) :
+    γ = γ' := by
+  have hv' : CMDiff 1 (fun x ↦ (⟨x, mulInvariantVectorField v x⟩ : TangentBundle IG G)) := by
+    have : minSmoothness ℝ 3 ≤ ∞ := by
+      simp only [minSmoothness_of_isRCLikeNormedField]; exact ENat.LEInfty.out
+    haveI : LieGroup IG (minSmoothness ℝ 3) G := LieGroup.of_le (n := ∞) this
+    exact (contMDiff_mulInvariantVectorField v).of_le (le_trans (by norm_num) le_minSmoothness)
+  exact isMIntegralCurve_eq_of_contMDiff
+    (fun _ ↦ BoundarylessManifold.isInteriorPoint) hv' hγ hγ' (by rw [hγ0, hγ'0])
+
+lemma expLie_smul
+    (γ : ℝ → G) (v : GroupLieAlgebra IG G)
+    [BoundarylessManifold IG G]
+    [CompleteSpace EG]
+    (hγ : IsMIntegralCurve γ (mulInvariantVectorField v))
+    (hγ0 : γ 0 = 1)
+    (t : ℝ) :
+    γ t = expLie (t • v) := by
+  have hγ' := (IsMIntegralCurve.exists_global (t • v)).choose_spec
+  have hγ'0 : (IsMIntegralCurve.exists_global (t • v)).choose 0 = 1 := hγ'.1
+  have hγ'_curve : IsMIntegralCurve (IsMIntegralCurve.exists_global (t • v)).choose
+      (mulInvariantVectorField (t • v)) := hγ'.2
+  have hscaled : IsMIntegralCurve (fun s ↦ γ (s * t)) (mulInvariantVectorField (t • v)) := by
+    have := hγ.comp_mul t
+    rwa [← mulInvariantVectorField_smul] at this
+  have : minSmoothness ℝ 3 ≤ ∞ := by
+    simp only [minSmoothness_of_isRCLikeNormedField]
+    exact ENat.LEInfty.out
+  haveI : LieGroup IG (minSmoothness ℝ 3) G := LieGroup.of_le (n := ∞) this
+  have hs : 1 ≤ (minSmoothness ℝ 2) := le_trans (by norm_num) le_minSmoothness
+  have heq : (fun s ↦ γ (s * t)) = (IsMIntegralCurve.exists_global (t • v)).choose :=
+    isMIntegralCurve_eq_of_contMDiff (t₀ := 0)
+      (fun _ ↦ BoundarylessManifold.isInteriorPoint)
+      ((contMDiff_mulInvariantVectorField (t • v)).of_le hs)
+      hscaled
+      hγ'_curve
+      (by simp [hγ0, hγ'0])
+  have := congr_fun heq 1
+  simp only [one_mul, expLie] at this ⊢
+  exact this
+
+lemma expLie_zero
+    [BoundarylessManifold IG G] [CompleteSpace EG] :
+    expLie (0 : GroupLieAlgebra IG G) = 1 := by
+  have hconst : IsMIntegralCurve (fun _ ↦ (1 : G))
+               (mulInvariantVectorField (0 : GroupLieAlgebra IG G)) := by
+    unfold mulInvariantVectorField
+    apply isMIntegralCurve_const
+    simp only [map_zero]
+    exact rfl
+  have hγ := (IsMIntegralCurve.exists_global (0 : GroupLieAlgebra IG G)).choose_spec
+  have heq : (fun _ : ℝ ↦ (1 : G)) =
+             (IsMIntegralCurve.exists_global (0 : GroupLieAlgebra IG G)).choose :=
+    IsMIntegralCurve.unique_global 0 _ _ hconst hγ.2 rfl hγ.1
+  have := congr_fun heq 1
+  simp only [expLie] at this ⊢
+  exact this.symm
+
+end Whatever
+
+lemma isMIntegralCurve_expLie_smul
+    {EG : Type*} [NormedAddCommGroup EG] [NormedSpace ℝ EG]
+    {HG : Type*} [TopologicalSpace HG]
+    {IG : ModelWithCorners ℝ EG HG}
+    {G : Type*} [TopologicalSpace G] [ChartedSpace HG G] [Group G]
+    [LieGroup IG ⊤ G] [BoundarylessManifold IG G] [CompleteSpace EG] [T2Space G]
+    (A : GroupLieAlgebra IG G) :
+    IsMIntegralCurve
+      (fun t => expLie (IG := IG) (t • A))
+      (mulInvariantVectorField (I := IG) A) := by
+  obtain ⟨γ, hγ0, hγ⟩ := IsMIntegralCurve.exists_global (EG := EG) A
+  have heq : ∀ t, γ t = expLie (IG := IG) (t • A) :=
+    fun t => expLie_smul γ A hγ hγ0 t
+  rw [show (fun t => expLie (IG := IG) (t • A)) = γ from (funext heq).symm]
+  exact hγ
+
+/-- The smooth flow theorem on manifolds: if `X` is a smooth vector field on a smooth manifold `M`,
+    then its flow `Φ : ℝ × M → M` is smooth. This is Lee's Fundamental Theorem on Flows
+    (Theorem 9.12) and is currently missing from Mathlib. -/
+axiom contMDiff_flow
+    {M : Type*} [TopologicalSpace M] [ChartedSpace HG M] [IsManifold IG ∞ M]
+    (X : ∀ x : M, TangentSpace IG x)
+    (hX : ContMDiff IG IG.tangent ∞ (fun x => (⟨x, X x⟩ : TangentBundle IG M)))
+    (Φ : ℝ → M → M)
+    (hΦ : ∀ x, IsMIntegralCurve (fun t => Φ t x) (fun x => X x)) :
+    ContMDiff (𝓘(ℝ, ℝ).prod IG) IG ∞ (fun p : ℝ × M => Φ p.1 p.2)
+
+def dMult : TangentBundle (IG.prod IG) (G × G) → TangentBundle IG G :=
+  tangentMap (IG.prod IG) IG (fun p : G × G => p.1 * p.2)
+
+theorem contMDiff_dMult : ContMDiff (IG.prod IG).tangent IG.tangent ∞
+  (dMult (IG := IG) (G := G)) := by
+  apply ContMDiff.contMDiff_tangentMap
+  · exact contMDiff_mul (𝕜 := ℝ) (E := EG) (H := HG) IG ∞
+  · exact Std.IsPreorder.le_refl (∞ + 1)
+
+def dMultProd : TangentBundle IG G × TangentBundle IG G → TangentBundle IG G :=
+  dMult ∘ (equivTangentBundleProd IG G IG G).symm
+
+theorem contMDiff_dMultProd : ContMDiff (IG.tangent.prod IG.tangent) IG.tangent ∞
+    (dMultProd (IG := IG) (G := G)) := by
+  unfold dMultProd
+  apply contMDiff_dMult.comp
+  exact contMDiff_equivTangentBundleProd_symm (I := IG) (M := G) (I' := IG) (M' := G)
+
+def zeroSectionProdFiber : G × EG → TangentBundle IG G × TangentBundle IG G :=
+  fun (g, ξ) => (zeroSection EG (TangentSpace IG) g, ⟨1, ξ⟩)
+
+theorem smooth_tangentBundle_mk (b : G) :
+    ContMDiff (modelWithCornersSelf ℝ EG) IG.tangent ⊤
+      (fun v : EG => (⟨b, v⟩ : TangentBundle IG G)) := by
+  intro v
+  rw [Bundle.contMDiffAt_totalSpace]
+  refine ⟨contMDiffAt_const, ?_⟩
+  have h_linear : ∃ L : EG →L[ℝ] EG, ∀ v : EG,
+      (trivializationAt EG (TangentSpace IG) b) ⟨b, v⟩ = (b, L v) := by
+    have h1 : ∀ (v : EG),
+      (trivializationAt EG (TangentSpace IG) b) ⟨b, v⟩ =
+      (b, (continuousLinearMapAt ℝ (trivializationAt EG (TangentSpace IG) b) b) v) := by
+      intro v
+      have h0 : b ∈ (trivializationAt EG (TangentSpace IG) b).baseSet :=
+        FiberBundle.mem_baseSet_trivializationAt' b
+      simp only [(trivializationAt EG (TangentSpace IG) b).continuousLinearMapAt_apply ℝ b]
+      simp only [TangentBundle.trivializationAt_baseSet, mem_chart_source, coe_linearMapAt_of_mem]
+      exact Prod.fst_eq_iff.mp rfl
+    exact ⟨(trivializationAt EG (TangentSpace IG) b).continuousLinearMapAt ℝ b, h1⟩
+  obtain ⟨L, hL⟩ := h_linear
+  simpa only [hL] using L.contDiff.contMDiff.contMDiffAt
+
+theorem contMDiff_zeroSectionProdFiber :
+    ContMDiff (IG.prod 𝓘(ℝ, EG)) (IG.tangent.prod IG.tangent) ∞
+      (zeroSectionProdFiber (IG := IG) (G := G)) := by
+  apply ContMDiff.prodMk
+  · exact (Bundle.contMDiff_zeroSection (B := G) ℝ (TangentSpace IG)).comp contMDiff_fst
+  · have : ContMDiff (IG.prod 𝓘(ℝ, EG)) (𝓘(ℝ, EG)) ω (fun x : G × EG => x.2) := contMDiff_snd
+    have fu := (smooth_tangentBundle_mk (IG := IG) (1:G)).comp this
+    exact fu.of_le le_top
+
+theorem mfderiv_mul_apply_zero_right
+    (g : G) (ξ : TangentSpace IG (1 : G)) :
+    mfderiv (IG.prod IG) IG (fun p : G × G => p.1 * p.2) (g, 1)
+      ((0 : TangentSpace IG g), ξ) =
+    mfderiv IG IG (fun x => g * x) 1 ξ := by
+  have fu :  ∞ ≠ 0 := Ne.symm (not_eq_of_beq_eq_false rfl)
+  have hf : MDifferentiableAt (IG.prod IG) IG (fun p : G × G => p.1 * p.2) (g, 1) :=
+    (contMDiff_mul (𝕜 := ℝ) (I := IG) (n := ∞)).mdifferentiableAt fu
+  rw [mfderiv_prod_eq_add_apply hf]
+  simp [map_zero]
+
+theorem dMultProd_zeroSectionProdFiber_eq (g : G) (ξ : EG) :
+    dMultProd (IG := IG) (zeroSectionProdFiber (IG := IG) (g, ξ)) =
+    ⟨g, mfderiv IG IG (g * ·) 1 ξ⟩ := by
+  simp only [dMultProd, zeroSectionProdFiber, dMult, equivTangentBundleProd]
+  simp only [Equiv.coe_fn_symm_mk, Function.comp_apply, zeroSection_proj, zeroSection_snd]
+  simp only [tangentMap]
+  ext
+  · simp [mul_one]
+  · simp only
+    exact heq_of_eq (mfderiv_mul_apply_zero_right (IG := IG) g ξ)
+
+theorem contMDiff_mulLeft_deriv :
+    ContMDiff (IG.prod 𝓘(ℝ, EG)) IG.tangent ∞
+      (fun p : G × EG => (⟨p.1, mfderiv IG IG (p.1 * ·) 1 p.2⟩ : TangentBundle IG G)) := by
+  have key : (fun p : G × EG => (⟨p.1, mfderiv IG IG (p.1 * ·) 1 p.2⟩ : TangentBundle IG G)) =
+      dMultProd ∘ zeroSectionProdFiber := by
+    funext ⟨g, ξ⟩
+    exact (dMultProd_zeroSectionProdFiber_eq (IG := IG) g ξ).symm
+  rw [key]
+  exact contMDiff_dMultProd.comp contMDiff_zeroSectionProdFiber
+
+theorem smooth_augmentedVF [T2Space G] [FiniteDimensional ℝ EG]
+    [IsManifold (IG.prod 𝓘(ℝ, EG)) ∞ (G × EG)] :
+    ContMDiff (IG.prod 𝓘(ℝ, EG)) (IG.prod 𝓘(ℝ, EG)).tangent ∞
+      (fun p : G × EG => (⟨p, (mfderiv IG IG (p.1 * ·) 1 p.2, 0)⟩ :
+        TangentBundle (IG.prod 𝓘(ℝ, EG)) (G × EG))) := by
+  have key : (fun p : G × EG => (⟨p, (mfderiv IG IG (p.1 * ·) 1 p.2, 0)⟩ :
+        TangentBundle (IG.prod 𝓘(ℝ, EG)) (G × EG))) =
+      (equivTangentBundleProd IG G 𝓘(ℝ, EG) EG).symm ∘
+        (fun p : G × EG => (
+          (⟨p.1, mfderiv IG IG (p.1 * ·) 1 p.2⟩ : TangentBundle IG G),
+          (⟨p.2, 0⟩ : TangentBundle 𝓘(ℝ, EG) EG))) := by
+    funext ⟨g, v⟩; simp only [equivTangentBundleProd]
+    simp only [Equiv.coe_fn_symm_mk, Function.comp_apply, TotalSpace.mk_inj]
+    exact rfl
+  rw [key]
+  exact (contMDiff_equivTangentBundleProd_symm).comp
+    (ContMDiff.prodMk
+      (contMDiff_mulLeft_deriv)
+      ((Bundle.contMDiff_zeroSection ℝ (TangentSpace 𝓘(ℝ, EG))).comp contMDiff_snd))
+
+omit [Group G] [LieGroup IG ω G] in
+lemma isMIntegralCurve_prod_mk
+    [T2Space G] [BoundarylessManifold IG G] [CompleteSpace EG]
+    (γ₁ : ℝ → G) (γ₂ : ℝ → EG)
+    (X₁ : ∀ x : G, TangentSpace IG x)
+    (X₂ : ∀ x : EG, TangentSpace (𝓘(ℝ, EG)) x)
+    (h₁ : IsMIntegralCurve (I := IG) γ₁ X₁)
+    (h₂ : IsMIntegralCurve (I := 𝓘(ℝ, EG)) γ₂ X₂) :
+    IsMIntegralCurve (I := IG.prod 𝓘(ℝ, EG)) (fun t => (γ₁ t, γ₂ t))
+      (fun p : G × EG => (X₁ p.1, X₂ p.2)) := by
+  intro t;
+  convert HasMFDerivAt.prodMk ( h₁ t ) ( h₂ t ) using 1
+
+theorem contMDiff_expLie [T2Space G] [CompleteSpace EG] [BoundarylessManifold IG G]
+  [FiniteDimensional ℝ EG] :
+    ContMDiff 𝓘(ℝ, EG) IG ∞ (fun v : EG => expLie (G := G) (IG := IG) v) := by
+  have hXi : ContMDiff (IG.prod 𝓘(ℝ, EG)) (IG.prod 𝓘(ℝ, EG)).tangent ∞
+      (fun p : G × EG => (⟨p, (mfderiv IG IG (p.1 * ·) 1 p.2, (0:EG))⟩ :
+        TangentBundle (IG.prod 𝓘(ℝ, EG)) (G × EG))) :=
+    smooth_augmentedVF
+  have hflow := contMDiff_flow
+    (fun p : G × EG => (mfderiv IG IG (p.1 * ·) 1 p.2, (0:EG)))
+    hXi
+    (fun t p => (expLie (t • p.2), p.2))
+    (fun p : G × EG => isMIntegralCurve_prod_mk
+      (γ₁ := fun t => expLie (t • p.2)) (γ₂ := fun _ => p.2)
+      (X₁ := fun x => mfderiv IG IG (x * ·) 1 p.2) (X₂ := fun _ => (0 : EG))
+      (isMIntegralCurve_expLie_smul p.2)
+      (isMIntegralCurve_const (by rfl)))
+  have hexp : (fun v : EG => expLie (G := G) (IG := IG) v) =
+      fun v => (expLie (G := G) (IG := IG) ((1:ℝ) • v)) := by
+    simp only [one_smul]
+    exact List.map_inj.mp rfl
+  rw [hexp]
+  have hkey : ContMDiff 𝓘(ℝ, EG) (𝓘(ℝ, ℝ).prod (IG.prod 𝓘(ℝ, EG))) ∞
+      (fun v : EG => ((1:ℝ), ((1:G), v))) :=
+    contMDiff_const.prodMk (contMDiff_const.prodMk contMDiff_id)
+  have hcomp := hflow.comp hkey
+  have hcomp2 : ContMDiff 𝓘(ℝ, EG) IG ∞
+      (fun v : EG => expLie (G := G) (IG := IG) v) := by
+    have := contMDiff_fst (I := IG) (J := 𝓘(ℝ, EG)).comp hcomp
+    convert this using 1
+  simp only [one_smul]
+  exact hcomp2

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothLieExp.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothLieExp.lean
@@ -4,10 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dominic Steinitz
 -/
 
-import Mathlib.Geometry.Manifold.GroupLieAlgebra
-import Mathlib.Geometry.Manifold.IntegralCurve.UniformTime
-import Mathlib.Geometry.Manifold.Sheaf.Basic
-import Mathlib.Order.BourbakiWitt
+module
+
+public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import Mathlib.Geometry.Manifold.IntegralCurve.UniformTime
+public import Mathlib.Geometry.Manifold.Sheaf.Basic
+public import Mathlib.Order.BourbakiWitt
 
 /-!
 # The Exponential Map of a Lie Group
@@ -48,27 +50,38 @@ variable
   [ChartedSpace HG G] [Group G]
   [LieGroup IG ⊤ G]
 
-lemma IsMIntegralCurve.left_translate
+/-- The vector field `mulInvariantVectorField v`, defined at each `g` by `d(L_g)_e(v)`, satisfies
+the left-invariance property: its value at `g * h` equals the pushforward of its value at `h`
+under `d(L_g)_h`. -/
+public lemma mulInvariantVectorField_left_invariant
+    (v : GroupLieAlgebra IG G) (g h : G) :
+    mulInvariantVectorField v (g * h) =
+      mfderiv IG IG (g * ·) h (mulInvariantVectorField v h) := by
+  have h1 : ∞ ≠ 0 := Ne.symm (not_eq_of_beq_eq_false rfl)
+  have h2 : ∀ a b : G, MDifferentiableAt IG IG (a * ·) b :=
+    fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable h1 |>.mdifferentiableAt
+  simp only [mulInvariantVectorField]
+  have h3 : (fun x => (g * h) * x) = (fun x => g * x) ∘ (fun x => h * x) := by
+    ext; simp [mul_assoc]
+  rw [h3]
+  have h4 : MDifferentiableAt IG IG (g * ·) (h * 1) := by rw [mul_one]; exact h2 g h
+  have h7 : mfderiv IG IG ((fun x => g * x) ∘ (h * ·)) 1 =
+      (mfderiv IG IG (fun x => g * x) (h * 1)).comp (mfderiv IG IG (h * ·) 1) :=
+    mfderiv_comp (1 : G) h4 (h2 h 1)
+  rw [h7, mul_one h]
+  exact ContinuousLinearMap.comp_apply
+    ((mfderiv% fun x ↦ g * x) h) ((mfderiv% fun x ↦ h * x) 1) v
+
+public lemma IsMIntegralCurve.left_translate
     (γ : ℝ → G) (v : GroupLieAlgebra IG G)
     (hγ : IsMIntegralCurve γ (mulInvariantVectorField v))
     (g : G) :
     IsMIntegralCurve (fun t ↦ g * γ t) (mulInvariantVectorField v) := by
-  intro t
   have h1 : ∞ ≠ 0 := Ne.symm (not_eq_of_beq_eq_false rfl)
   have hMDiff : ∀ a b : G, MDifferentiableAt IG IG (a * ·) b :=
-  fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable h1 |>.mdifferentiableAt
-  have h6 : mulInvariantVectorField v (g * γ t) =
-    mfderiv IG IG (g * ·) (γ t) (mulInvariantVectorField v (γ t)) := by
-    simp only [mulInvariantVectorField]
-    have h3 : (fun x => (g * γ t) * x) = (fun x => g * x) ∘ (fun x => γ t * x) := by
-      ext; simp [mul_assoc]
-    rw [h3]
-    have h4 : MDifferentiableAt IG IG (g * ·) (γ t * 1) := by rw [mul_one]; exact (hMDiff g (γ t))
-    have h5 : HMul.hMul (γ t) = fun x ↦ γ t * x := rfl
-    rw [mfderiv_comp (1 : G) h4 (hMDiff (γ t) 1), mul_one (γ t), h5]
-    exact ContinuousLinearMap.comp_apply
-      ((mfderiv% fun x ↦ g * x) (γ t)) ((mfderiv% fun x ↦ γ t * x) 1) v
-  rw [h6]
+    fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable h1 |>.mdifferentiableAt
+  intro t
+  rw [mulInvariantVectorField_left_invariant]
   convert ((hMDiff g (γ t)).hasMFDerivAt.comp t (hγ t)) using 1
   ext
   simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, one_smul]
@@ -78,40 +91,16 @@ lemma IsMIntegralCurve.left_translate
       simp [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply]
   exact h2.symm
 
-omit [Group G] [LieGroup IG ⊤ G] in
-lemma IsMIntegralCurve.time_shift
-    (γ : ℝ → G) (v : (x : G) → TangentSpace IG x)
-    (hγ : IsMIntegralCurve γ v)
-    (s : ℝ) :
-    IsMIntegralCurve (fun t ↦ γ (s + t)) v := by
-  intro t
-  have hshift : HasMFDerivAt 𝓘(ℝ, ℝ) 𝓘(ℝ, ℝ) (fun t ↦ s + t) t
-      (ContinuousLinearMap.id ℝ ℝ) := by
-    have h := (hasDerivAt_id t).const_add s
-    rw [hasMFDerivAt_iff_hasFDerivAt, hasFDerivAt_iff_hasDerivAt]
-    simpa using h
-  exact (hγ (s + t)).comp t hshift
-
-lemma IsMIntegralCurveOn.left_translate
+public lemma IsMIntegralCurveOn.left_translate
     (γ : ℝ → G) (v : GroupLieAlgebra IG G) (s : Set ℝ)
     (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s)
     (g : G) :
     IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
-  intro t ht
   have hMDiff : ∀ a b : G, MDifferentiableAt IG IG (a * ·) b :=
     fun a b => (contMDiff_mul_left (a := a) (n := ∞)).mdifferentiable
       (by exact Ne.symm (not_eq_of_beq_eq_false rfl)) |>.mdifferentiableAt
-  have h6 : mulInvariantVectorField v (g * γ t) =
-      mfderiv IG IG (g * ·) (γ t) (mulInvariantVectorField v (γ t)) := by
-    simp only [mulInvariantVectorField]
-    have h3 : (fun x => (g * γ t) * x) = (fun x => g * x) ∘ (fun x => γ t * x) := by
-      ext; simp [mul_assoc]
-    rw [h3]
-    have h4 : MDifferentiableAt IG IG (g * ·) (γ t * 1) := by rw [mul_one]; exact hMDiff g (γ t)
-    have h5 : HMul.hMul (γ t) = fun x ↦ γ t * x := rfl
-    rw [mfderiv_comp (1 : G) h4 (hMDiff (γ t) 1), mul_one (γ t), h5]
-    exact ContinuousLinearMap.comp_apply _ _ v
-  rw [h6]
+  intro t ht
+  rw [mulInvariantVectorField_left_invariant]
   convert ((hMDiff g (γ t)).hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)) using 1
   ext
   simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, one_smul]
@@ -125,7 +114,7 @@ section Whatever
 
 variable [T2Space G]
 
-lemma IsMIntegralCurve.exists_global
+public lemma IsMIntegralCurve.exists_global
     (v : GroupLieAlgebra IG G)
     [BoundarylessManifold IG G]
     [CompleteSpace EG] :
@@ -158,11 +147,11 @@ lemma IsMIntegralCurve.exists_global
     exists_isMIntegralCurve_of_isMIntegralCurveOn hv' hε hunif (1 : G)
   exact ⟨γ, hγ_start, hγ⟩
 
-noncomputable def expLie (v : GroupLieAlgebra IG G)
+public noncomputable def expLie (v : GroupLieAlgebra IG G)
     [BoundarylessManifold IG G] [CompleteSpace EG] : G :=
   (IsMIntegralCurve.exists_global v).choose 1
 
-lemma IsMIntegralCurve.unique_global
+public lemma IsMIntegralCurve.unique_global
     (v : GroupLieAlgebra IG G)
     [BoundarylessManifold IG G]
     (γ γ' : ℝ → G)
@@ -179,7 +168,7 @@ lemma IsMIntegralCurve.unique_global
   exact isMIntegralCurve_eq_of_contMDiff
     (fun _ ↦ BoundarylessManifold.isInteriorPoint) hv' hγ hγ' (by rw [hγ0, hγ'0])
 
-lemma expLie_smul
+public lemma expLie_smul
     (γ : ℝ → G) (v : GroupLieAlgebra IG G)
     [BoundarylessManifold IG G]
     [CompleteSpace EG]
@@ -210,26 +199,9 @@ lemma expLie_smul
   simp only [one_mul, expLie] at this ⊢
   exact this
 
-lemma expLie_zero
-    [BoundarylessManifold IG G] [CompleteSpace EG] :
-    expLie (0 : GroupLieAlgebra IG G) = 1 := by
-  have hconst : IsMIntegralCurve (fun _ ↦ (1 : G))
-               (mulInvariantVectorField (0 : GroupLieAlgebra IG G)) := by
-    unfold mulInvariantVectorField
-    apply isMIntegralCurve_const
-    simp only [map_zero]
-    exact rfl
-  have hγ := (IsMIntegralCurve.exists_global (0 : GroupLieAlgebra IG G)).choose_spec
-  have heq : (fun _ : ℝ ↦ (1 : G)) =
-             (IsMIntegralCurve.exists_global (0 : GroupLieAlgebra IG G)).choose :=
-    IsMIntegralCurve.unique_global 0 _ _ hconst hγ.2 rfl hγ.1
-  have := congr_fun heq 1
-  simp only [expLie] at this ⊢
-  exact this.symm
-
 end Whatever
 
-lemma isMIntegralCurve_expLie_smul
+public lemma isMIntegralCurve_expLie_smul
     {EG : Type*} [NormedAddCommGroup EG] [NormedSpace ℝ EG]
     {HG : Type*} [TopologicalSpace HG]
     {IG : ModelWithCorners ℝ EG HG}
@@ -245,10 +217,24 @@ lemma isMIntegralCurve_expLie_smul
   rw [show (fun t => expLie (IG := IG) (t • A)) = γ from (funext heq).symm]
   exact hγ
 
-/-- The smooth flow theorem on manifolds: if `X` is a smooth vector field on a smooth manifold `M`,
-    then its flow `Φ : ℝ × M → M` is smooth. This is Lee's Fundamental Theorem on Flows
-    (Theorem 9.12) and is currently missing from Mathlib. -/
-axiom contMDiff_flow
+/-- Smooth dependence of integral curves on parameters.
+
+Let `X` be a smooth vector field on a manifold `M`. Suppose `Φ : ℝ → M → M`
+is a family of maps such that for every `x : M`, the curve `t ↦ Φ t x` is an
+integral curve of `X`. Then the map `(t, x) ↦ Φ t x` is smooth.
+
+This is a consequence of Lee, *Introduction to Smooth Manifolds*, Theorem 9.12
+(Fundamental Theorem on Flows), which constructs a smooth maximal flow for any
+smooth vector field. Here we assume only the smooth dependence of integral curves
+on initial conditions.
+
+Note: This statement does not assume that `Φ` satisfies the usual flow identities
+(e.g. `Φ 0 x = x` or `Φ (t + s) x = Φ t (Φ s x)`), only that it parametrises
+integral curves of `X`.
+
+TODO: Replace this axiom with a proper development of flows (Lee Theorem 9.12)
+once available in Mathlib. -/
+axiom contMDiff_flow_like
     {M : Type*} [TopologicalSpace M] [ChartedSpace HG M] [IsManifold IG ∞ M]
     (X : ∀ x : M, TangentSpace IG x)
     (hX : ContMDiff IG IG.tangent ∞ (fun x => (⟨x, X x⟩ : TangentBundle IG M)))
@@ -305,7 +291,7 @@ theorem contMDiff_zeroSectionProdFiber :
   · exact (Bundle.contMDiff_zeroSection (B := G) ℝ (TangentSpace IG)).comp contMDiff_fst
   · have : ContMDiff (IG.prod 𝓘(ℝ, EG)) (𝓘(ℝ, EG)) ω (fun x : G × EG => x.2) := contMDiff_snd
     have fu := (smooth_tangentBundle_mk (IG := IG) (1:G)).comp this
-    exact fu.of_le le_top
+    exact fu.of_le (right_eq_inf.mp rfl)
 
 theorem mfderiv_mul_apply_zero_right
     (g : G) (ξ : TangentSpace IG (1 : G)) :
@@ -339,7 +325,7 @@ theorem contMDiff_mulLeft_deriv :
   rw [key]
   exact contMDiff_dMultProd.comp contMDiff_zeroSectionProdFiber
 
-theorem smooth_augmentedVF [T2Space G] [FiniteDimensional ℝ EG]
+public theorem smooth_augmentedVF [T2Space G] [FiniteDimensional ℝ EG]
     [IsManifold (IG.prod 𝓘(ℝ, EG)) ∞ (G × EG)] :
     ContMDiff (IG.prod 𝓘(ℝ, EG)) (IG.prod 𝓘(ℝ, EG)).tangent ∞
       (fun p : G × EG => (⟨p, (mfderiv IG IG (p.1 * ·) 1 p.2, 0)⟩ :
@@ -372,14 +358,14 @@ lemma isMIntegralCurve_prod_mk
   intro t;
   convert HasMFDerivAt.prodMk ( h₁ t ) ( h₂ t ) using 1
 
-theorem contMDiff_expLie [T2Space G] [CompleteSpace EG] [BoundarylessManifold IG G]
+public theorem contMDiff_expLie [T2Space G] [CompleteSpace EG] [BoundarylessManifold IG G]
   [FiniteDimensional ℝ EG] :
     ContMDiff 𝓘(ℝ, EG) IG ∞ (fun v : EG => expLie (G := G) (IG := IG) v) := by
   have hXi : ContMDiff (IG.prod 𝓘(ℝ, EG)) (IG.prod 𝓘(ℝ, EG)).tangent ∞
       (fun p : G × EG => (⟨p, (mfderiv IG IG (p.1 * ·) 1 p.2, (0:EG))⟩ :
         TangentBundle (IG.prod 𝓘(ℝ, EG)) (G × EG))) :=
     smooth_augmentedVF
-  have hflow := contMDiff_flow
+  have hflow := contMDiff_flow_like
     (fun p : G × EG => (mfderiv IG IG (p.1 * ·) 1 p.2, (0:EG)))
     hXi
     (fun t p => (expLie (t • p.2), p.2))
@@ -389,9 +375,9 @@ theorem contMDiff_expLie [T2Space G] [CompleteSpace EG] [BoundarylessManifold IG
       (isMIntegralCurve_expLie_smul p.2)
       (isMIntegralCurve_const (by rfl)))
   have hexp : (fun v : EG => expLie (G := G) (IG := IG) v) =
-      fun v => (expLie (G := G) (IG := IG) ((1:ℝ) • v)) := by
-    simp only [one_smul]
-    exact List.map_inj.mp rfl
+    fun v => expLie (G := G) (IG := IG) ((1 : ℝ) • v) := by
+    funext v
+    simp
   rw [hexp]
   have hkey : ContMDiff 𝓘(ℝ, EG) (𝓘(ℝ, ℝ).prod (IG.prod 𝓘(ℝ, EG))) ∞
       (fun v : EG => ((1:ℝ), ((1:G), v))) :=


### PR DESCRIPTION
We construct the exponential map `expLie : g → G` for a Lie group `G` and prove that it
is smooth. The main reference is:

* Eckhard Meinrenken, *Lie Groups and Lie Algebras*, Lecture Notes, University of Toronto.
  Available at https://www.math.toronto.edu/mein/teaching/LectureNotes/lie.pdf

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
