### PR TITLE
[Merged by Bors] - feat(Topology/Order): `DenselyOrdered` of `PreconnectedSpace`

### DIFF
--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -220,7 +220,16 @@ theorem IsPreconnected.eq_univ_of_unbounded {s : Set α} (hs : IsPreconnected s)
 
 end
 
-variable {α : Type u} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α] [OrderTopology α]
+variable {α : Type u} [TopologicalSpace α]
+
+theorem denselyOrdered_of_preconnectedSpace [LinearOrder α] [OrderTopology α]
+    [PreconnectedSpace α] : DenselyOrdered α where
+  dense x y hxy := by
+    suffices (Iio y ∩ Ioi x).Nonempty by grind [Set.inter_nonempty_iff_exists_left]
+    exact nonempty_inter (isOpen_Iio' y) (isOpen_Ioi' x) (Set.Iio_union_Ioi_of_lt hxy)
+      ⟨x, Set.mem_Iio.mpr hxy⟩ ⟨y, Set.mem_Ioi.mpr hxy⟩
+
+variable [ConditionallyCompleteLinearOrder α] [OrderTopology α]
 
 /-- A bounded connected subset of a conditionally complete linear order includes the open interval
 `(Inf s, Sup s)`. -/
@@ -527,15 +536,6 @@ lemma isTotallyDisconnected_iff_lt {s : Set α} :
     exact fun hs ↦ h _ inter_subset_left hs _ ⟨hx, le_rfl, hxy.le⟩ _ ⟨hy, hxy.le, le_rfl⟩ hxy
   · obtain ⟨z, h1z, h2z⟩ := h x (hts hx) y (hts hy) hxy
     exact h1z <| hts <| ht.1 hx hy ⟨h2z.1.le, h2z.2.le⟩
-
-theorem denselyOrdered_of_preconnectedSpace {α : Type*} [LinearOrder α] [TopologicalSpace α]
-    [OrderTopology α] [PreconnectedSpace α] : DenselyOrdered α where
-  dense x y hxy := by
-    have := nonempty_inter (isOpen_Iio' y) (isOpen_Ioi' x) (Set.Iio_union_Ioi_of_lt hxy)
-      (by use x; exact Set.mem_Iio.mpr hxy)
-      (by use y; exact Set.mem_Ioi.mpr hxy)
-    rw [Set.inter_nonempty_iff_exists_left] at this
-    grind
 
 /-!
 ### Intermediate Value Theorem on an interval

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -528,6 +528,15 @@ lemma isTotallyDisconnected_iff_lt {s : Set α} :
   · obtain ⟨z, h1z, h2z⟩ := h x (hts hx) y (hts hy) hxy
     exact h1z <| hts <| ht.1 hx hy ⟨h2z.1.le, h2z.2.le⟩
 
+instance {α : Type*} [LinearOrder α] [TopologicalSpace α] [OrderTopology α] [PreconnectedSpace α] :
+    DenselyOrdered α where
+  dense x y hxy := by
+    have := nonempty_inter (isOpen_Iio' y) (isOpen_Ioi' x) (Set.Iio_union_Ioi_of_lt hxy)
+      (by use x; exact Set.mem_Iio.mpr hxy)
+      (by use y; exact Set.mem_Ioi.mpr hxy)
+    rw [Set.inter_nonempty_iff_exists_left] at this
+    grind
+
 /-!
 ### Intermediate Value Theorem on an interval
 

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -528,8 +528,8 @@ lemma isTotallyDisconnected_iff_lt {s : Set α} :
   · obtain ⟨z, h1z, h2z⟩ := h x (hts hx) y (hts hy) hxy
     exact h1z <| hts <| ht.1 hx hy ⟨h2z.1.le, h2z.2.le⟩
 
-instance {α : Type*} [LinearOrder α] [TopologicalSpace α] [OrderTopology α] [PreconnectedSpace α] :
-    DenselyOrdered α where
+theorem denselyOrdered_of_preconnectedSpace {α : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [PreconnectedSpace α] : DenselyOrdered α where
   dense x y hxy := by
     have := nonempty_inter (isOpen_Iio' y) (isOpen_Ioi' x) (Set.Iio_union_Ioi_of_lt hxy)
       (by use x; exact Set.mem_Iio.mpr hxy)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
