### PR TITLE
feat(Topology/FiberBundle): `continuousWithinAt_section` and `continuousAt_section`

### DIFF
--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -320,6 +320,18 @@ theorem continuousAt_totalSpace (f : X → TotalSpace F E) {x₀ : X} :
         ContinuousAt (fun x => ((trivializationAt F E (f x₀).proj) (f x)).2) x₀ :=
   (trivializationAt F E (f x₀).proj).tendsto_nhds_iff mem_trivializationAt_proj_source
 
+/-- Characterization of continuous sections within a set at a point of a vector bundle. -/
+theorem continuousWithinAt_section {s : ∀ x, E x} {a : Set B} {x₀ : B} :
+    ContinuousWithinAt (fun x ↦ TotalSpace.mk' F x (s x)) a x₀ ↔
+      ContinuousWithinAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) a x₀ :=
+  continuousWithinAt_totalSpace (F := F) _ |>.trans (and_iff_right continuousWithinAt_id)
+
+/-- Characterization of continuous sections of a vector bundle. -/
+theorem continuousAt_section {s : ∀ x, E x} (x₀ : B) :
+    ContinuousAt (fun x ↦ TotalSpace.mk' F x (s x)) x₀ ↔
+      ContinuousAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) x₀ :=
+  continuousAt_totalSpace (F := F) _ |>.trans (and_iff_right continuousAt_id)
+
 end FiberBundle
 
 variable (F)

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -323,14 +323,16 @@ theorem continuousAt_totalSpace (f : X → TotalSpace F E) {x₀ : X} :
 /-- Characterization of continuous sections within a set at a point of a vector bundle. -/
 theorem continuousWithinAt_section {s : ∀ x, E x} {a : Set B} {x₀ : B} :
     ContinuousWithinAt (fun x ↦ TotalSpace.mk' F x (s x)) a x₀ ↔
-      ContinuousWithinAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) a x₀ :=
-  continuousWithinAt_totalSpace (F := F) _ |>.trans (and_iff_right continuousWithinAt_id)
+      ContinuousWithinAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) a x₀ := by
+  simp_rw [continuousWithinAt_totalSpace, and_iff_right_iff_imp]
+  intro
+  exact continuousWithinAt_id
 
 /-- Characterization of continuous sections of a vector bundle. -/
 theorem continuousAt_section {s : ∀ x, E x} (x₀ : B) :
     ContinuousAt (fun x ↦ TotalSpace.mk' F x (s x)) x₀ ↔
-      ContinuousAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) x₀ :=
-  continuousAt_totalSpace (F := F) _ |>.trans (and_iff_right continuousAt_id)
+      ContinuousAt (fun x ↦ (trivializationAt F E x₀ ⟨x, s x⟩).2) x₀ := by
+  simp_rw [← continuousWithinAt_univ]; exact continuousWithinAt_section F
 
 end FiberBundle
 

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -490,19 +490,28 @@ induced by the preferred trivialisation at each `b`. -/
 noncomputable def VectorBundle.continuousLinearEquivAt (b : B) : E b ≃L[R] F :=
   (trivializationAt F E b).continuousLinearEquivAt R b (FiberBundle.mem_baseSet_trivializationAt' b)
 
-/-- The zero section of a vector bundle is continuous. -/
-theorem continuous_zeroSection (R : Type*)
-    [NontriviallyNormedField R]
-    [∀ x, Module R (E x)] [NormedSpace R F]
-    [VectorBundle R F E] :
-    Continuous (zeroSection F E) := by
-  rw [continuous_iff_continuousAt]; intro x
+/-- The zero section of a vector bundle is continuous at each point. -/
+theorem continuousAt_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
+    [NormedSpace R F] [VectorBundle R F E] (x : B) :
+    ContinuousAt (zeroSection F E) x := by
   unfold zeroSection
   rw [FiberBundle.continuousAt_section]
   apply (continuousAt_const (y := (0 : F))).congr_of_eventuallyEq
   filter_upwards [(trivializationAt F E x).open_baseSet.mem_nhds
     (mem_baseSet_trivializationAt F E x)] with y hy
-  simp only [(trivializationAt F E x).apply_eq_prod_continuousLinearEquivAt R y hy, map_zero]
+  using congr_arg Prod.snd <| (trivializationAt F E x).zeroSection R hy
+
+/-- The zero section of a vector bundle is continuous on any set. -/
+theorem continuousOn_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
+    [NormedSpace R F] [VectorBundle R F E] (s : Set B) :
+    ContinuousOn (zeroSection F E) s :=
+  fun x _ => (continuousAt_zeroSection R x).continuousWithinAt
+
+/-- The zero section of a vector bundle is continuous. -/
+theorem continuous_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
+    [NormedSpace R F] [VectorBundle R F E] :
+    Continuous (zeroSection F E) :=
+  continuous_iff_continuousAt.mpr (continuousAt_zeroSection R)
 
 /-! ### Constructing vector bundles -/
 

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -490,6 +490,20 @@ induced by the preferred trivialisation at each `b`. -/
 noncomputable def VectorBundle.continuousLinearEquivAt (b : B) : E b ≃L[R] F :=
   (trivializationAt F E b).continuousLinearEquivAt R b (FiberBundle.mem_baseSet_trivializationAt' b)
 
+/-- The zero section of a vector bundle is continuous. -/
+theorem continuous_zeroSection (R : Type*)
+    [NontriviallyNormedField R]
+    [∀ x, Module R (E x)] [NormedSpace R F]
+    [VectorBundle R F E] :
+    Continuous (zeroSection F E) := by
+  rw [continuous_iff_continuousAt]; intro x
+  unfold zeroSection
+  rw [FiberBundle.continuousAt_section]
+  apply (continuousAt_const (y := (0 : F))).congr_of_eventuallyEq
+  filter_upwards [(trivializationAt F E x).open_baseSet.mem_nhds
+    (mem_baseSet_trivializationAt F E x)] with y hy
+  simp only [(trivializationAt F E x).apply_eq_prod_continuousLinearEquivAt R y hy, map_zero]
+
 /-! ### Constructing vector bundles -/
 
 variable (B F)

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -490,28 +490,31 @@ induced by the preferred trivialisation at each `b`. -/
 noncomputable def VectorBundle.continuousLinearEquivAt (b : B) : E b ≃L[R] F :=
   (trivializationAt F E b).continuousLinearEquivAt R b (FiberBundle.mem_baseSet_trivializationAt' b)
 
-/-- The zero section of a vector bundle is continuous at each point. -/
-theorem continuousAt_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
-    [NormedSpace R F] [VectorBundle R F E] (x : B) :
-    ContinuousAt (zeroSection F E) x := by
+/-- The zero section of a vector bundle is continuous. -/
+theorem continuous_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
+    [NormedSpace R F] [VectorBundle R F E] :
+    Continuous (zeroSection F E) := by
+  rw [continuous_iff_continuousAt]
+  intro x
   unfold zeroSection
   rw [FiberBundle.continuousAt_section]
-  apply (continuousAt_const (y := (0 : F))).congr_of_eventuallyEq
+  apply (continuousAt_const (y := 0)).congr_of_eventuallyEq
   filter_upwards [(trivializationAt F E x).open_baseSet.mem_nhds
     (mem_baseSet_trivializationAt F E x)] with y hy
-  using congr_arg Prod.snd <| (trivializationAt F E x).zeroSection R hy
+    using congr_arg Prod.snd <| (trivializationAt F E x).zeroSection R hy
 
 /-- The zero section of a vector bundle is continuous on any set. -/
 theorem continuousOn_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
     [NormedSpace R F] [VectorBundle R F E] (s : Set B) :
     ContinuousOn (zeroSection F E) s :=
-  fun x _ => (continuousAt_zeroSection R x).continuousWithinAt
+  (continuous_zeroSection R).continuousOn
 
-/-- The zero section of a vector bundle is continuous. -/
-theorem continuous_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
-    [NormedSpace R F] [VectorBundle R F E] :
-    Continuous (zeroSection F E) :=
-  continuous_iff_continuousAt.mpr (continuousAt_zeroSection R)
+/-- The zero section of a vector bundle is continuous at each point. -/
+theorem continuousAt_zeroSection (R : Type*) [NontriviallyNormedField R] [∀ x, Module R (E x)]
+    [NormedSpace R F] [VectorBundle R F E] (x : B) :
+    ContinuousAt (zeroSection F E) x :=
+  (continuous_zeroSection R).continuousAt
+
 
 /-! ### Constructing vector bundles -/
 


### PR DESCRIPTION
These lemmas are analogous to `contMDiffWithinAt_section` and `contMDiffAt_section` for smooth vector bundles.

----

AI Use: Claude was used to help write the precise proof terms.
The overall API was designed to exactly mimic the existing contMDiff analogues.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
