### PR TITLE
[Merged by Bors] - chore(CategoryTheory): fix left/right unitors confusion

### DIFF
--- a/Mathlib/CategoryTheory/CatCommSq.lean
+++ b/Mathlib/CategoryTheory/CatCommSq.lean
@@ -46,12 +46,12 @@ namespace CatCommSq
 /-- The vertical identity `CatCommSq` -/
 @[instance_reducible, simps!]
 def vId : CatCommSq T (𝟭 C₁) (𝟭 C₂) T where
-  iso := (Functor.leftUnitor _) ≪≫ (Functor.rightUnitor _).symm
+  iso := Functor.rightUnitor _ ≪≫ (Functor.leftUnitor _).symm
 
 /-- The horizontal identity `CatCommSq` -/
 @[simps!, implicit_reducible]
 def hId : CatCommSq (𝟭 C₁) L L (𝟭 C₃) where
-  iso := (Functor.rightUnitor _) ≪≫ (Functor.leftUnitor _).symm
+  iso := Functor.leftUnitor _ ≪≫ (Functor.rightUnitor _).symm
 
 @[reassoc (attr := simp)]
 lemma iso_hom_naturality [h : CatCommSq T L R B] {x y : C₁} (f : x ⟶ y) :

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -82,7 +82,7 @@ lemma ext (w w' : TwoSquare T L R B) (h : ∀ (X : C₁), w.natTrans.app X = w'.
 /-- The horizontal identity 2-square. -/
 @[simps!]
 def hId (L : C₁ ⥤ C₃) : TwoSquare (𝟭 _) L L (𝟭 _) :=
-  𝟙 _
+  (Functor.leftUnitor L).hom ≫ (Functor.rightUnitor L).inv
 
 /-- Notation for the horizontal identity 2-square. -/
 scoped notation "𝟙ₕ" => hId  -- type as \b1\_h
@@ -90,7 +90,7 @@ scoped notation "𝟙ₕ" => hId  -- type as \b1\_h
 /-- The vertical identity 2-square. -/
 @[simps!]
 def vId (T : C₁ ⥤ C₂) : TwoSquare T (𝟭 _) (𝟭 _) T :=
-  𝟙 _
+  (Functor.rightUnitor T).hom ≫ (Functor.leftUnitor T).inv
 
 /-- Notation for the vertical identity 2-square. -/
 scoped notation "𝟙ᵥ" => vId  -- type as \b1\_v

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -60,7 +60,7 @@ class ShiftSequence where
 @[implicit_reducible]
 noncomputable def ShiftSequence.tautological : ShiftSequence F M where
   sequence n := shiftFunctor C n ⋙ F
-  isoZero := isoWhiskerRight (shiftFunctorZero C M) F ≪≫ F.rightUnitor
+  isoZero := isoWhiskerRight (shiftFunctorZero C M) F ≪≫ F.leftUnitor
   shiftIso n a a' ha' := (Functor.associator _ _ _).symm ≪≫
     isoWhiskerRight (shiftFunctorAdd' C n a a' ha').symm _
   shiftIso_zero a := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Related information:
[#mathlib4 > Functor identity &#96;𝟭 _ ⋙ F = F&#96; is definitional equality](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Functor.20identity.20.60.F0.9D.9F.AD.20_.20.E2.8B.99.20F.20.3D.20F.60.20is.20definitional.20equality/with/523978659)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
