### PR TITLE
[Merged by Bors] - chore: remove standalone `respectTransparency` options

### DIFF
--- a/Mathlib/Algebra/Homology/BifunctorAssociator.lean
+++ b/Mathlib/Algebra/Homology/BifunctorAssociator.lean
@@ -38,8 +38,6 @@ the associator for the monoidal category structure on homological complexes.
 
 @[expose] public section
 
-set_option backward.isDefEq.respectTransparency false
-
 assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Category Limits
@@ -720,6 +718,7 @@ variable [DecidableEq ι₁₂] [DecidableEq ι₂₃]
   [HasGoodTrifunctor₁₂Obj F₁₂ G K₁ K₂ K₃ c₁₂ c₄]
   [HasGoodTrifunctor₂₃Obj F G₂₃ K₁ K₂ K₃ c₁₂ c₂₃ c₄]
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 lemma ι_mapBifunctorAssociatorX_hom (i₁ : ι₁) (i₂ : ι₂) (i₃ : ι₃) (j : ι₄)
     (h : ComplexShape.r c₁ c₂ c₃ c₁₂ c₄ (i₁, i₂, i₃) = j) :
@@ -729,6 +728,7 @@ lemma ι_mapBifunctorAssociatorX_hom (i₁ : ι₁) (i₂ : ι₂) (i₃ : ι₃
         mapBifunctor₂₃.ι F G₂₃ K₁ K₂ K₃ c₁₂ c₂₃ c₄ i₁ i₂ i₃ j h := by
   apply GradedObject.ι_mapBifunctorAssociator_hom
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 lemma ιOrZero_mapBifunctorAssociatorX_hom (i₁ : ι₁) (i₂ : ι₂) (i₃ : ι₃) (j : ι₄) :
     mapBifunctor₁₂.ιOrZero F₁₂ G K₁ K₂ K₃ c₁₂ c₄ i₁ i₂ i₃ j ≫
@@ -743,6 +743,7 @@ lemma ιOrZero_mapBifunctorAssociatorX_hom (i₁ : ι₁) (i₂ : ι₂) (i₃ :
       mapBifunctor₂₃.ιOrZero_eq_zero _ _ _ _ _ _ _ _ _ _ _ _ h,
       zero_comp, comp_zero]
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma mapBifunctorAssociatorX_hom_D₁ (j j' : ι₄) :
     (mapBifunctorAssociatorX associator K₁ K₂ K₃ c₁₂ c₂₃ c₄ j).hom ≫
@@ -763,6 +764,7 @@ lemma mapBifunctorAssociatorX_hom_D₁ (j j' : ι₄) :
   · rw [mapBifunctor₁₂.d₁_eq_zero _ _ _ _ _ _ _ _ _ _ _ h₁,
       mapBifunctor₂₃.d₁_eq_zero _ _ _ _ _ _ _ _ _ _ _ _ h₁, comp_zero, zero_comp]
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma mapBifunctorAssociatorX_hom_D₂ (j j' : ι₄) :
     (mapBifunctorAssociatorX associator K₁ K₂ K₃ c₁₂ c₂₃ c₄ j).hom ≫
@@ -781,6 +783,7 @@ lemma mapBifunctorAssociatorX_hom_D₂ (j j' : ι₄) :
   · rw [mapBifunctor₁₂.d₂_eq_zero _ _ _ _ _ _ _ _ _ _ _ h₁,
       mapBifunctor₂₃.d₂_eq_zero _ _ _ _ _ _ _ _ _ _ _ _ h₁, comp_zero, zero_comp]
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma mapBifunctorAssociatorX_hom_D₃ (j j' : ι₄) :
     (mapBifunctorAssociatorX associator K₁ K₂ K₃ c₁₂ c₂₃ c₄ j).hom ≫

--- a/Mathlib/Algebra/Homology/BifunctorHomotopy.lean
+++ b/Mathlib/Algebra/Homology/BifunctorHomotopy.lean
@@ -31,8 +31,6 @@ variable {C₁ C₂ D I₁ I₂ J : Type*} [Category* C₁] [Category* C₂] [Ca
 
 namespace HomologicalComplex
 
-set_option backward.isDefEq.respectTransparency false
-
 variable {K₁ L₁ : HomologicalComplex C₁ c₁} {f₁ f₁' : K₁ ⟶ L₁} (h₁ : Homotopy f₁ f₁')
   {K₂ L₂ : HomologicalComplex C₂ c₂} (f₂ f₂' : K₂ ⟶ L₂) (h₂ : Homotopy f₂ f₂')
   (F : C₁ ⥤ C₂ ⥤ D) [F.Additive] [∀ X₁, (F.obj X₁).Additive]
@@ -49,6 +47,7 @@ noncomputable def hom₁ (j j' : J) :
       (F.map (h₁.hom i₁ (c₁.prev i₁))).app (K₂.X i₂) ≫
       (F.obj (L₁.X (c₁.prev i₁))).map (f₂.f i₂) ≫ ιMapBifunctorOrZero L₁ L₂ F c _ _ j')
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma ιMapBifunctor_hom₁ (i₁ i₁' : I₁) (i₂ : I₂) (j j' : J)
     (h : ComplexShape.π c₁ c₂ c (i₁', i₂) = j) (h' : c₁.prev i₁' = i₁) :
@@ -68,6 +67,7 @@ noncomputable def hom₂ (j j' : J) :
         (F.obj (L₁.X i₁)).map (h₂.hom i₂ (c₂.prev i₂)) ≫
           ιMapBifunctorOrZero L₁ L₂ F c _ _ j')
 
+set_option backward.isDefEq.respectTransparency false in
 variable (f₁) {f₂ f₂'} in
 @[reassoc]
 lemma ιMapBifunctor_hom₂ (i₁ : I₁) (i₂ i₂' : I₂) (j j' : J)
@@ -79,6 +79,7 @@ lemma ιMapBifunctor_hom₂ (i₁ : I₁) (i₂ i₂' : I₂) (j j' : J)
   subst h'
   simp [hom₂]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma zero₁ (j j' : J) (h : ¬ c.Rel j' j) :
     hom₁ h₁ f₂ F c j j' = 0 := by
   ext i₁ i₂ h'
@@ -93,6 +94,7 @@ lemma zero₁ (j j' : J) (h : ¬ c.Rel j' j) :
   · dsimp
     rw [h₁.zero _ _ h₃, Functor.map_zero, zero_app, zero_comp, smul_zero]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma comm₁_aux {i₁ i₁' : I₁} (hi₁ : c₁.Rel i₁ i₁') {i₂ i₂' : I₂} (hi₂ : c₂.Rel i₂ i₂') (j : J)
     (hj : ComplexShape.π c₁ c₂ c (i₁', i₂) = j) :
     ComplexShape.ε₁ c₁ c₂ c (i₁, i₂) • (F.map (h₁.hom i₁' i₁)).app (K₂.X i₂) ≫
@@ -113,6 +115,7 @@ lemma comm₁_aux {i₁ i₁' : I₁} (hi₁ : c₁.Rel i₁ i₁') {i₂ i₂' 
     NatTrans.naturality_assoc, ComplexShape.ε₁_ε₂ c hi₁ hi₂, neg_mul, Units.neg_smul, neg_inj,
     smul_left_cancel_iff, ← Functor.map_comp_assoc, ← Functor.map_comp_assoc, f₂.comm]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma comm₁ (j : J) :
     (mapBifunctorMap f₁ f₂ F c).f j =
     (mapBifunctor K₁ K₂ F c).d j (c.next j) ≫
@@ -180,6 +183,7 @@ noncomputable def mapBifunctorMapHomotopy₁ :
   zero := zero₁ h₁ f₂ F c
   comm := comm₁ h₁ f₂ F c
 
+set_option backward.isDefEq.respectTransparency false in
 variable (f₁) {f₂ f₂'} in
 open mapBifunctorMapHomotopy in
 /-- The homotopy between `mapBifunctorMap f₁ f₂ F c` and `mapBifunctorMap f₁ f₂' F c` that

--- a/Mathlib/Algebra/Homology/BifunctorShift.lean
+++ b/Mathlib/Algebra/Homology/BifunctorShift.lean
@@ -34,8 +34,6 @@ commutes with shifts by `ℤ`.
 
 assert_not_exists TwoSidedIdeal
 
-set_option backward.isDefEq.respectTransparency false
-
 open CategoryTheory Category Limits HomologicalComplex
 
 variable {C₁ C₂ D : Type*} [Category* C₁] [Category* C₂] [Category* D]
@@ -74,6 +72,7 @@ variable [Preadditive C₁] [HasZeroMorphisms C₂] [Preadditive D]
   (F : C₁ ⥤ C₂ ⥤ D) [F.Additive] [∀ (X₁ : C₁), (F.obj X₁).PreservesZeroMorphisms] (x : ℤ)
   [HasMapBifunctor K₁ K₂ F]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Auxiliary definition for `mapBifunctorShift₁Iso`. -/
 @[simps! hom_f_f inv_f_f]
 def mapBifunctorHomologicalComplexShift₁Iso :
@@ -97,6 +96,7 @@ noncomputable def mapBifunctorShift₁Iso :
   HomologicalComplex₂.total.mapIso (mapBifunctorHomologicalComplexShift₁Iso K₁ K₂ F x) _ ≪≫
     (((F.mapBifunctorHomologicalComplex _ _).obj K₁).obj K₂).totalShift₁Iso x
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma ι_mapBifunctorShift₁Iso_hom_f (n₁ n₂ n : ℤ) (h : n₁ + n₂ = n)
     (m₁ m : ℤ) (hm₁ : m₁ = n₁ + x) (hm : m = n + x) :
@@ -110,6 +110,7 @@ lemma ι_mapBifunctorShift₁Iso_hom_f (n₁ n₂ n : ℤ) (h : n₁ + n₂ = n)
   simp [HomologicalComplex₂.ιTotal, HomologicalComplex₂.shiftFunctor₁XXIso,
     HomologicalComplex.XIsoOfEq, eqToHom_map]
 
+set_option backward.isDefEq.respectTransparency false in
 variable {K₁ L₁} in
 @[reassoc (attr := simp)]
 lemma mapBifunctorShift₁Iso_hom_naturality₁ [HasMapBifunctor L₁ K₂ F] :
@@ -153,6 +154,7 @@ noncomputable def mapBifunctorShift₂Iso :
     (mapBifunctorHomologicalComplexShift₂Iso K₁ K₂ F y) (ComplexShape.up ℤ) ≪≫
     (((F.mapBifunctorHomologicalComplex _ _).obj K₁).obj K₂).totalShift₂Iso y
 
+set_option backward.isDefEq.respectTransparency false in
 @[reassoc]
 lemma ι_mapBifunctorShift₂Iso_hom_f (n₁ n₂ n : ℤ) (h : n₁ + n₂ = n)
     (m₂ m : ℤ) (hm₂ : m₂ = n₂ + y) (hm : m = n + y) :
@@ -166,6 +168,7 @@ lemma ι_mapBifunctorShift₂Iso_hom_f (n₁ n₂ n : ℤ) (h : n₁ + n₂ = n)
   simp [HomologicalComplex₂.ιTotal, HomologicalComplex₂.shiftFunctor₂XXIso,
     HomologicalComplex.XIsoOfEq, eqToHom_map]
 
+set_option backward.isDefEq.respectTransparency false in
 variable {K₂ L₂} in
 @[reassoc (attr := simp)]
 lemma mapBifunctorShift₂Iso_hom_naturality₂ [HasMapBifunctor K₁ L₂ F] :
@@ -184,6 +187,7 @@ variable [Preadditive C₁] [Preadditive C₂] [Preadditive D]
   (F : C₁ ⥤ C₂ ⥤ D) [F.Additive] [∀ (X₁ : C₁), (F.obj X₁).Additive] (x y : ℤ)
   [HasMapBifunctor K₁ K₂ F]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma mapBifunctorShift₁Iso_trans_mapBifunctorShift₂Iso :
     mapBifunctorShift₁Iso K₁ (K₂⟦y⟧) F x ≪≫
       (CategoryTheory.shiftFunctor _ x).mapIso (mapBifunctorShift₂Iso K₁ K₂ F y) =
@@ -217,6 +221,7 @@ variable [Preadditive C₁] [Preadditive C₂] [Preadditive D]
   [∀ (K₁ : CochainComplex C₁ ℤ) (K₂ : CochainComplex C₂ ℤ),
     CochainComplex.HasMapBifunctor K₁ K₂ F]
 
+set_option backward.isDefEq.respectTransparency false in
 noncomputable instance (K₁ : CochainComplex C₁ ℤ) :
     (F.map₂CochainComplex.obj K₁).CommShift ℤ where
   commShiftIso n :=
@@ -250,6 +255,7 @@ lemma commShiftIso_map₂CochainComplex_inv_app (K₁ : CochainComplex C₁ ℤ)
     ((F.map₂CochainComplex.obj K₁).commShiftIso n).inv.app K₂ =
       (CochainComplex.mapBifunctorShift₂Iso K₁ K₂ F n).inv := rfl
 
+set_option backward.isDefEq.respectTransparency false in
 instance {K₁ L₁ : CochainComplex C₁ ℤ} (f : K₁ ⟶ L₁) :
     NatTrans.CommShift (F.map₂CochainComplex.map f) ℤ where
   shift_comm n := by
@@ -260,6 +266,7 @@ instance {K₁ L₁ : CochainComplex C₁ ℤ} (f : K₁ ⟶ L₁) :
       CochainComplex.ι_mapBifunctorShift₂Iso_hom_f _ _ _ _ _ _ _ _ (q + n) (d + n) rfl rfl,
       CochainComplex.ι_mapBifunctorShift₂Iso_hom_f_assoc _ _ _ _ _ _ _ _ (q + n) (d + n) rfl rfl]
 
+set_option backward.isDefEq.respectTransparency false in
 noncomputable instance (K₂ : CochainComplex C₂ ℤ) :
     (F.map₂CochainComplex.flip.obj K₂).CommShift ℤ where
   commShiftIso n :=
@@ -292,6 +299,7 @@ lemma commShiftIso_map₂CochainComplex_flip_inv_app (K₁ : CochainComplex C₁
     ((F.map₂CochainComplex.flip.obj K₂).commShiftIso n).inv.app K₁ =
       (CochainComplex.mapBifunctorShift₁Iso K₁ K₂ F n).inv := rfl
 
+set_option backward.isDefEq.respectTransparency false in
 instance {K₂ L₂ : CochainComplex C₂ ℤ} (g : K₂ ⟶ L₂) :
     NatTrans.CommShift (F.map₂CochainComplex.flip.map g) ℤ where
   shift_comm n := by
@@ -302,6 +310,7 @@ instance {K₂ L₂ : CochainComplex C₂ ℤ} (g : K₂ ⟶ L₂) :
       CochainComplex.ι_mapBifunctorShift₁Iso_hom_f _ _ _ _ _ _ _ _ (p + n) (d + n) rfl rfl,
       CochainComplex.ι_mapBifunctorShift₁Iso_hom_f_assoc _ _ _ _ _ _ _ _ (p + n) (d + n) rfl rfl]
 
+set_option backward.isDefEq.respectTransparency false in
 noncomputable instance :
     F.map₂CochainComplex.CommShift₂Int where
   comm K₁ K₂ p q := by

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -32,8 +32,6 @@ continuous functional calculus, normal, selfadjoint
 
 @[expose] public section
 
-set_option backward.isDefEq.respectTransparency false
-
 open Topology
 
 noncomputable section
@@ -125,7 +123,6 @@ lemma cfcₙAux_mem_range_inr (f : C(σₙ 𝕜 a, 𝕜)₀) :
 
 variable [CStarRing A]
 
-#adaptation_note /-- After nightly-2026-02-23 we need this to avoid timeouts. -/
 include hp₁ in
 open Unitization NonUnitalStarAlgHom in
 theorem RCLike.nonUnitalContinuousFunctionalCalculus :
@@ -188,6 +185,7 @@ variable {A : Type*} [TopologicalSpace A] [NonUnitalRing A] [StarRing A] [Module
   [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
   [NonUnitalContinuousFunctionalCalculus ℂ A IsStarNormal]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- An element in a non-unital C⋆-algebra is selfadjoint if and only if it is normal and its
 quasispectrum is contained in `ℝ`. -/
 lemma isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts {a : A} :
@@ -213,6 +211,7 @@ lemma QuasispectrumRestricts.isSelfAdjoint (a : A) (ha : QuasispectrumRestricts 
     [IsStarNormal a] : IsSelfAdjoint a :=
   isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts.mpr ⟨‹_›, ha⟩
 
+set_option backward.isDefEq.respectTransparency false in
 instance IsSelfAdjoint.instNonUnitalContinuousFunctionalCalculus :
     NonUnitalContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
   QuasispectrumRestricts.cfc (q := IsStarNormal) (p := IsSelfAdjoint) Complex.reCLM
@@ -231,6 +230,7 @@ lemma IsSelfAdjoint.spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
     SpectrumRestricts a Complex.reCLM :=
   ha.quasispectrumRestricts
 
+set_option backward.isDefEq.respectTransparency false in
 instance IsSelfAdjoint.instContinuousFunctionalCalculus :
     ContinuousFunctionalCalculus ℝ A IsSelfAdjoint :=
   SpectrumRestricts.cfc (q := IsStarNormal) (p := IsSelfAdjoint) Complex.reCLM
@@ -343,12 +343,14 @@ section RealEqComplex
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
   [ContinuousFunctionalCalculus ℂ A IsStarNormal] [T2Space A]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma cfcHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
     cfcHom ha =
       ha.spectrumRestricts.starAlgHom (R := ℝ) (S := ℂ)
         (cfcHom ha.isStarNormal) (f := Complex.reCLM) :=
   ha.spectrumRestricts.cfcHom_eq_restrict _ ha ha.isStarNormal
 
+set_option backward.isDefEq.respectTransparency false in
 lemma cfc_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfc f a = cfc (fun x ↦ f x.re : ℂ → ℂ) a := by
   exact ha.spectrumRestricts.cfc_eq_restrict (f := Complex.reCLM)
@@ -371,11 +373,13 @@ variable {A : Type*} [TopologicalSpace A] [NonUnitalRing A] [StarRing A] [Module
   [IsScalarTower ℂ A A] [SMulCommClass ℂ A A] [T2Space A]
   [NonUnitalContinuousFunctionalCalculus ℂ A IsStarNormal]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma cfcₙHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
     cfcₙHom ha = ha.quasispectrumRestricts.nonUnitalStarAlgHom (cfcₙHom ha.isStarNormal)
       (R := ℝ) (S := ℂ) (f := Complex.reCLM) :=
   ha.quasispectrumRestricts.cfcₙHom_eq_restrict _ ha ha.isStarNormal
 
+set_option backward.isDefEq.respectTransparency false in
 lemma cfcₙ_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfcₙ f a = cfcₙ (fun x ↦ f x.re : ℂ → ℂ) a := by
   exact ha.quasispectrumRestricts.cfcₙ_eq_restrict (f := Complex.reCLM)

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -201,16 +201,13 @@ end Complex
 
 section Real
 
--- set flag locally in this section; every decl fails without it
--- the underlying problem seems to be elsewhere, something to do with unifying different
--- `ℝ`-module structures on `ℂ`
-set_option backward.isDefEq.respectTransparency false
-
+set_option backward.isDefEq.respectTransparency false in
 /-- `ℝ`-linear map from `ℂ` to itself, which we shall show is the real derivative of the
 `GL(2, ℝ)`-action on `ℍ`. -/
 noncomputable def smulFDeriv (g : GL (Fin 2) ℝ) (z : ℂ) : ℂ →L[ℝ] ℂ :=
   (σ g) ∘L (ContinuousLinearMap.toSpanSingleton ℂ (g.det.val / denom g z ^ 2)).restrictScalars ℝ
 
+set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem smulFDeriv_J_mul (g : GL (Fin 2) ℝ) (z : ℂ) :
     smulFDeriv (J * g) z = -Complex.conjCLE ∘L smulFDeriv g z := by
@@ -219,6 +216,7 @@ theorem smulFDeriv_J_mul (g : GL (Fin 2) ℝ) (z : ℂ) :
   · simp [smulFDeriv, σ, hg, hg.not_gt, neg_div]
   · simp [smulFDeriv, σ, hg, g.det_ne_zero.lt_or_gt.resolve_right hg, neg_div]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Determinant of the derivative of `g : ℍ → ℍ` considered as an `ℝ`-linear map. This is used in
 the proof that the action is measure-preserving. Note this formula applies for both orientation-
 preserving and orientation-reserving isometries. -/
@@ -232,6 +230,7 @@ lemma det_smulFDeriv (g : GL (Fin 2) ℝ) (z : ℂ) :
   · simp [ContinuousLinearMap.det, h, LinearMap.det_restrictScalars,
       Algebra.norm_complex_eq, Complex.normSq_eq_norm_sq, ← pow_mul]
 
+set_option backward.isDefEq.respectTransparency false in
 lemma hasStrictFDerivAt_smul (g : GL (Fin 2) ℝ) (τ : ℍ) :
     HasStrictFDerivAt (fun z ↦ ↑(g • ofComplex z) : ℂ → ℂ) (smulFDeriv g τ) τ := by
   wlog hg : 0 < g.det.val generalizing g

--- a/Mathlib/Analysis/Distribution/SchwartzSpace/Fourier.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace/Fourier.lean
@@ -172,19 +172,16 @@ end eval
 
 section deriv
 
-set_option backward.isDefEq.respectTransparency false
-
 /-- The derivative of the Fourier transform is given by the Fourier transform of the multiplication
 with `-(2 * π * Complex.I) • innerSL ℝ`. -/
 theorem fderivCLM_fourier_eq (f : 𝓢(V, E)) :
     fderivCLM 𝕜 V E (𝓕 f) = 𝓕 (-(2 * π * Complex.I) • smulRightCLM ℂ E (innerSL ℝ) f) := by
   ext1 x
-  change fderiv ℝ (𝓕 ⇑f) x = _
-  calc
-    _ = 𝓕 (VectorFourier.fourierSMulRight (innerSL ℝ) f) x := by
-      rw [fderiv_fourier f.integrable]
-      simpa using f.integrable_pow_mul volume 1
+  change fderiv ℝ (𝓕 ⇑f) x = 𝓕 (VectorFourier.fourierSMulRight (innerSL ℝ) f) x
+  rw [fderiv_fourier f.integrable]
+  simpa using f.integrable_pow_mul volume 1
 
+set_option backward.isDefEq.respectTransparency false in
 /-- The Fourier transform of the derivative is given by multiplication of
 `(2 * π * Complex.I) • innerSL ℝ` with the Fourier transform. -/
 theorem fourier_fderivCLM_eq (f : 𝓢(V, E)) :
@@ -196,6 +193,7 @@ theorem fourier_fderivCLM_eq (f : 𝓢(V, E)) :
 
 open LineDeriv
 
+set_option backward.isDefEq.respectTransparency false in
 /- The line derivative in direction `m` of the Fourier transform is given by the Fourier transform
 of the multiplication with `-(2 * π * Complex.I) • (inner ℝ · m)`. -/
 theorem lineDerivOp_fourier_eq (f : 𝓢(V, E)) (m : V) :
@@ -207,6 +205,7 @@ theorem lineDerivOp_fourier_eq (f : 𝓢(V, E)) (m : V) :
   have : (inner ℝ · m).HasTemperateGrowth := ((innerSL ℝ).flip m).hasTemperateGrowth
   simp [this, innerSL_apply_apply ℝ]
 
+set_option backward.isDefEq.respectTransparency false in
 /- The Fourier transform of line derivative in direction `m` is given by multiplication of
 `(2 * π * Complex.I) • (inner ℝ · m)` with the Fourier transform. -/
 theorem fourier_lineDerivOp_eq (f : 𝓢(V, E)) (m : V) :

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -436,8 +436,6 @@ instance {E} [Semiring E] [Algebra L E] : Algebra S E := inferInstanceAs (Algebr
 
 section shortcut_instances
 
-set_option backward.isDefEq.respectTransparency false
-
 variable {E} [Field E] [Algebra L E] (T : IntermediateField S E) {S}
 
 instance : Algebra S T := T.algebra

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondJensen.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondJensen.lean
@@ -46,7 +46,7 @@ private lemma Convex.condExp_mem_of_hereditarilyLindelofSpace [IsFiniteMeasure �
   simp_all only [condExp_const, comp_apply]
   exact hb
 
-set_option backward.isDefEq.respectTransparency false
+set_option backward.isDefEq.respectTransparency false in
 private lemma Convex.condExp_mem_of_isFiniteMeasure [IsFiniteMeasure μ] (hm : m ≤ mα)
     (hf_int : Integrable f μ) (hs : IsClosed s) (hc : Convex ℝ s) (hf : ∀ᵐ a ∂μ, f a ∈ s) :
     ∀ᵐ a ∂μ, μ[f | m] a ∈ s := by
@@ -113,7 +113,7 @@ private lemma ConvexOn.map_condExp_le_of_hereditarilyLindelofSpace [IsFiniteMeas
   rw [show φ (μ[f | m] a) = s.restrict φ ⟨μ[f | m] a, hq⟩ by simp, ← hLc2]
   simpa [iSup_congr hp] using ciSup_le hw
 
-set_option backward.isDefEq.respectTransparency false
+set_option backward.isDefEq.respectTransparency false in
 /-- Conditional Jensen's inequality for finite measures. -/
 private theorem ConvexOn.map_condExp_le_of_isFiniteMeasure [IsFiniteMeasure μ] (hm : m ≤ mα)
     (hφ_cvx : ConvexOn ℝ s φ) (hφ_cont : LowerSemicontinuousOn φ s) (hf : ∀ᵐ a ∂μ, f a ∈ s)

--- a/Mathlib/MeasureTheory/Measure/LevyConvergence.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyConvergence.lean
@@ -173,7 +173,7 @@ lemma ProbabilityMeasure.tendsto_of_tight_of_separatesPoints (𝕜 : Type*) [RCL
 
 variable {ι : Type*} {𝓕 : Filter ι} {μ₀ : ProbabilityMeasure E}
 
-set_option backward.isDefEq.respectTransparency false
+set_option backward.isDefEq.respectTransparency false in
 omit [FiniteDimensional ℝ E] in
 lemma ProbabilityMeasure.tendsto_charPoly_of_tendsto_charFun {μ : ι → ProbabilityMeasure E}
     (h : ∀ t : E, Tendsto (fun n ↦ charFun (μ n) t) 𝓕 (𝓝 (charFun μ₀ t)))

--- a/Mathlib/RingTheory/SimpleModule/Isotypic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Isotypic.lean
@@ -44,8 +44,6 @@ isotypic component, fully invariant submodule
 
 @[expose] public section
 
-set_option backward.isDefEq.respectTransparency false
-
 universe u
 
 variable (R₀ R : Type*) (M : Type u) (N S : Type*) [CommSemiring R₀]
@@ -115,6 +113,7 @@ theorem LinearEquiv.isIsotypicOfType_iff_type (e : N ≃ₗ[R] S) :
 theorem LinearEquiv.isIsotypic_iff (e : M ≃ₗ[R] N) : IsIsotypic R M ↔ IsIsotypic R N :=
   ⟨(·.of_injective _ e.symm.injective), (·.of_injective _ e.injective)⟩
 
+set_option backward.isDefEq.respectTransparency false in
 theorem isIsotypicOfType_submodule_iff {N : Submodule R M} :
     IsIsotypicOfType R N S ↔ ∀ m ≤ N, [IsSimpleModule R m] → Nonempty (m ≃ₗ[R] S) := by
   rw [Subtype.forall', ← (Submodule.MapSubtype.orderIso N).forall_congr_right]
@@ -122,6 +121,7 @@ theorem isIsotypicOfType_submodule_iff {N : Submodule R M} :
   simp_rw [Submodule.MapSubtype.orderIso, Equiv.coe_fn_mk, ← (e _).isSimpleModule_iff]
   exact forall₂_congr fun m _ ↦ ⟨fun ⟨e'⟩ ↦ ⟨(e m).symm.trans e'⟩, fun ⟨e'⟩ ↦ ⟨(e m).trans e'⟩⟩
 
+set_option backward.isDefEq.respectTransparency false in
 theorem isIsotypic_submodule_iff {N : Submodule R M} :
     IsIsotypic R N ↔ ∀ m ≤ N, [IsSimpleModule R m] → IsIsotypicOfType R N m := by
   rw [Subtype.forall', ← (Submodule.MapSubtype.orderIso N).forall_congr_right]

--- a/Mathlib/RingTheory/Smooth/Fiber.lean
+++ b/Mathlib/RingTheory/Smooth/Fiber.lean
@@ -49,12 +49,10 @@ variable [CommRing P] [Algebra R P] [Algebra P S] [IsScalarTower R P S]
 
 section IsLocalRing
 
-set_option backward.isDefEq.respectTransparency false
-
 variable [IsLocalRing R] [IsLocalRing S] [IsLocalHom (algebraMap R S)]
   [Algebra.FormallySmooth 𝓀[R] (𝓀[R] ⊗[R] S)]
 
-#adaptation_note /-- After nightly-2026-02-23 we need this to avoid timeouts. -/
+set_option backward.isDefEq.respectTransparency false in
 attribute [local irreducible] KaehlerDifferential in
 attribute [local instance] TensorProduct.rightAlgebra in
 /--

--- a/MathlibTest/norm_num.lean
+++ b/MathlibTest/norm_num.lean
@@ -628,8 +628,6 @@ attribute [-norm_num] Mathlib.Meta.NormNum.evalPow
 
 end norm_num_erase
 
-set_option backward.isDefEq.respectTransparency false
-
 -- auto gen tests
 variable [Field α] [LinearOrder α] [IsStrictOrderedRing α]
 example : ((25 * (1 / 1)) + (30 - 16)) = (39 : α) := by norm_num1


### PR DESCRIPTION
This PR makes sure that all `respectTransparency` options are localized to single declarations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
