### PR TITLE
[Merged by Bors] - perf(Analysis/Normed/Lp/lpSpace): clean up instances

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -900,14 +900,10 @@ def _root_.lpInftySubring : Subring (PreLp B) :=
     carrier := { f | Memℓp f ∞ }
     one_mem' := one_memℓp_infty
     mul_mem' := Memℓp.infty_mul }
-#synth AddCommGroup ↥(lp B ∞)
--- #synth SMul Nat ↥(lp B ⊤)
-set_option trace.Meta.isDefEq true in
-set_option trace.Meta.synthInstance true in
+
 instance inftyRing : Ring (lp B ∞) :=
-  inferInstanceAs <|
-   Ring (lpInftySubring B)
-#print inftyRing
+  inferInstanceAs <| Ring (lpInftySubring B)
+
 theorem _root_.Memℓp.infty_pow {f : ∀ i, B i} (hf : Memℓp f ∞) (n : ℕ) : Memℓp (f ^ n) ∞ :=
   (lpInftySubring B).pow_mem hf n
 
@@ -938,7 +934,7 @@ instance [Nonempty I] : NormOneClass (lp B ∞) where
 
 instance inftyNormedRing : NormedRing (lp B ∞) :=
   { lp.inftyRing, lp.nonUnitalNormedRing with }
-#print inftyNormedRing
+
 end NormedRing
 
 section NormedCommRing
@@ -947,7 +943,7 @@ variable {I : Type*} {B : I → Type*} [∀ i, NormedCommRing (B i)] [∀ i, Nor
 
 instance inftyNormedCommRing : NormedCommRing (lp B ∞) where
   mul_comm := mul_comm
-#print inftyNormedCommRing
+
 end NormedCommRing
 
 section Algebra

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -837,12 +837,12 @@ instance : Mul (lp B ∞) where
 theorem infty_coeFn_mul (f g : lp B ∞) : ⇑(f * g) = ⇑f * ⇑g :=
   rfl
 
-instance nonUnitalRing : NonUnitalRing (lp B ∞) :=
+instance nonUnitalRing : NonUnitalRing (lp B ∞) := fast_instance%
   Function.Injective.nonUnitalRing lp.coeFun.coe Subtype.coe_injective (lp.coeFn_zero B ∞)
     lp.coeFn_add infty_coeFn_mul lp.coeFn_neg lp.coeFn_sub (fun _ _ => rfl) fun _ _ => rfl
 
 instance nonUnitalNormedRing : NonUnitalNormedRing (lp B ∞) :=
-  { lp.normedAddCommGroup, lp.nonUnitalRing with
+  { lp.nonUnitalRing, lp.normedAddCommGroup with
     norm_mul_le f g := lp.norm_le_of_forall_le (by positivity) fun i ↦ calc
       ‖(f * g) i‖ ≤ ‖f i‖ * ‖g i‖ := norm_mul_le _ _
       _ ≤ ‖f‖ * ‖g‖ := mul_le_mul (lp.norm_apply_le_norm ENNReal.top_ne_zero f i)
@@ -900,10 +900,14 @@ def _root_.lpInftySubring : Subring (PreLp B) :=
     carrier := { f | Memℓp f ∞ }
     one_mem' := one_memℓp_infty
     mul_mem' := Memℓp.infty_mul }
-
+#synth AddCommGroup ↥(lp B ∞)
+-- #synth SMul Nat ↥(lp B ⊤)
+set_option trace.Meta.isDefEq true in
+set_option trace.Meta.synthInstance true in
 instance inftyRing : Ring (lp B ∞) :=
-  inferInstanceAs <| Ring (lpInftySubring B)
-
+  inferInstanceAs <|
+   Ring (lpInftySubring B)
+#print inftyRing
 theorem _root_.Memℓp.infty_pow {f : ∀ i, B i} (hf : Memℓp f ∞) (n : ℕ) : Memℓp (f ^ n) ∞ :=
   (lpInftySubring B).pow_mem hf n
 
@@ -934,7 +938,7 @@ instance [Nonempty I] : NormOneClass (lp B ∞) where
 
 instance inftyNormedRing : NormedRing (lp B ∞) :=
   { lp.inftyRing, lp.nonUnitalNormedRing with }
-
+#print inftyNormedRing
 end NormedRing
 
 section NormedCommRing
@@ -943,7 +947,7 @@ variable {I : Type*} {B : I → Type*} [∀ i, NormedCommRing (B i)] [∀ i, Nor
 
 instance inftyNormedCommRing : NormedCommRing (lp B ∞) where
   mul_comm := mul_comm
-
+#print inftyNormedCommRing
 end NormedCommRing
 
 section Algebra


### PR DESCRIPTION
This PR is just for performance (no diamonds are being fixed).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
