### PR TITLE
[Merged by Bors] - feat(RingTheory/Etale): descent along faithfully flat maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6298,6 +6298,7 @@ public import Mathlib.RingTheory.DividedPowers.SubDPIdeal
 public import Mathlib.RingTheory.DualNumber
 public import Mathlib.RingTheory.EssentialFiniteness
 public import Mathlib.RingTheory.Etale.Basic
+public import Mathlib.RingTheory.Etale.Descent
 public import Mathlib.RingTheory.Etale.Field
 public import Mathlib.RingTheory.Etale.Kaehler
 public import Mathlib.RingTheory.Etale.Locus

--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -212,11 +212,16 @@ section
 
 variable (R A) in
 /-- An `R`-algebra `A` is étale if it is formally étale and of finite presentation. -/
-@[stacks 00U1 "Note that this is a different definition from this Stacks entry, but
+@[mk_iff, stacks 00U1 "Note that this is a different definition from this Stacks entry, but
 <https://stacks.math.columbia.edu/tag/00UR> shows that it is equivalent to the definition here."]
 class Etale : Prop where
   formallyEtale : FormallyEtale R A := by infer_instance
   finitePresentation : FinitePresentation R A := by infer_instance
+
+lemma Etale.iff_formallyUnramified_and_smooth :
+    Etale R A ↔ FormallyUnramified R A ∧ Smooth R A := by
+  rw [etale_iff, FormallyEtale.iff_formallyUnramified_and_formallySmooth, smooth_iff]
+  tauto
 
 end
 
@@ -225,6 +230,8 @@ namespace Etale
 attribute [instance] formallyEtale finitePresentation
 
 instance [Etale R A] : Smooth R A where
+
+instance (priority := low) [Etale R A] : Unramified R A where
 
 /-- Being étale is transported via algebra isomorphisms. -/
 theorem of_equiv [Etale R A] (e : A ≃ₐ[R] B) : Etale R B where

--- a/Mathlib/RingTheory/Etale/Descent.lean
+++ b/Mathlib/RingTheory/Etale/Descent.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.RingTheory.RingHom.Etale
+public import Mathlib.RingTheory.Finiteness.Descent
+public import Mathlib.RingTheory.Extension.Cotangent.BaseChange
+
+/-!
+# Etale descends along faithfully flat ring maps
+
+In this file we show that smooth, unramified and étale descends along faithfully flat
+base change.
+
+## Main results
+
+- `Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat`: Smooth descends.
+- `Algebra.Unramified.of_smooth_tensorProduct_of_faithfullyFlat`: Unramified descends.
+- `Algebra.Etale.of_etale_tensorProduct_of_faithfullyFlat`: Etale descends.
+
+We also provide the corresponding `RingHom.CodescendsAlong` lemmas.
+
+## TODOs
+
+- The lemma `Algebra.FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat` has an
+  additional `Algebra.FinitePresentation` assumption, because the proof uses that a flat module
+  of finite presentation is projective and the former descends. This also holds without
+  the finite presentation assumption, but requires showing that projectivity descends
+  along faithfully flat base change, which is due to Raynaud and Gruson
+  (see https://stacks.math.columbia.edu/tag/058B).
+-/
+
+public section
+
+open TensorProduct
+
+namespace Algebra
+
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+variable (T : Type*) [CommRing T] [Algebra R T] [Module.FaithfullyFlat R T]
+
+/-- The `FinitePresentation` assumption is not necessary (see the TODO in the module docstring). -/
+lemma FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat
+    [FinitePresentation R S] [FormallySmooth T (T ⊗[R] S)] :
+    FormallySmooth R S := by
+  rw [formallySmooth_iff]
+  constructor
+  · let _ : Algebra T (S ⊗[R] T) := TensorProduct.rightAlgebra
+    let e : S ⊗[R] T ≃ₐ[T] T ⊗[R] S :=
+      .ofRingEquiv (f := TensorProduct.comm R S T) <| by simp [RingHom.algebraMap_toAlgebra]
+    have : FormallySmooth T (S ⊗[R] T) := .of_equiv e.symm
+    let e' : (S ⊗[R] T) ⊗[S] Ω[S⁄R] ≃ₗ[S ⊗[R] T] Ω[S ⊗[R] T⁄T] :=
+      KaehlerDifferential.tensorKaehlerEquiv R T S (S ⊗[R] T)
+    have : Module.Flat (S ⊗[R] T) ((S ⊗[R] T) ⊗[S] Ω[S⁄R]) := .of_linearEquiv e'
+    have : Module.Flat S (Ω[S⁄R]) := Module.Flat.of_flat_tensorProduct _ _ (S ⊗[R] T)
+    exact Module.Flat.projective_of_finitePresentation
+  · have : Subsingleton (T ⊗[R] H1Cotangent R S) := (tensorH1CotangentOfFlat R S T).subsingleton
+    exact Module.FaithfullyFlat.lTensor_reflects_triviality R T (H1Cotangent R S)
+
+lemma FormallyUnramified.of_formallyUnramified_tensorProduct_of_faithfullyFlat
+    [FormallyUnramified T (T ⊗[R] S)] :
+    FormallyUnramified R S := by
+  constructor
+  let _ : Algebra S (T ⊗[R] S) := TensorProduct.rightAlgebra
+  have : Subsingleton (T ⊗[R] Ω[S⁄R]) :=
+    (KaehlerDifferential.tensorKaehlerEquivBase R T S (T ⊗[R] S)).subsingleton
+  exact Module.FaithfullyFlat.lTensor_reflects_triviality R T _
+
+lemma Smooth.of_smooth_tensorProduct_of_faithfullyFlat [Smooth T (T ⊗[R] S)] :
+    Smooth R S := by
+  have : Algebra.FinitePresentation R S := .of_finitePresentation_tensorProduct_of_faithfullyFlat T
+  exact ⟨.of_formallySmooth_tensorProduct_of_faithfullyFlat T,
+    .of_finitePresentation_tensorProduct_of_faithfullyFlat T⟩
+
+lemma Unramified.of_unramified_tensorProduct_of_faithfullyFlat [Unramified T (T ⊗[R] S)] :
+    Unramified R S :=
+  ⟨.of_formallyUnramified_tensorProduct_of_faithfullyFlat T,
+    .of_finiteType_tensorProduct_of_faithfullyFlat T⟩
+
+lemma Etale.of_etale_tensorProduct_of_faithfullyFlat [Etale T (T ⊗[R] S)] :
+    Etale R S := by
+  rw [Etale.iff_formallyUnramified_and_smooth]
+  exact ⟨.of_formallyUnramified_tensorProduct_of_faithfullyFlat T,
+    .of_smooth_tensorProduct_of_faithfullyFlat T⟩
+
+end Algebra
+
+namespace RingHom
+
+lemma Smooth.codescendsAlong_faithfullyFlat : CodescendsAlong Smooth FaithfullyFlat := by
+  refine .mk _ Smooth.respectsIso fun R S T _ _ _ _ _ h h' ↦ ?_
+  rw [smooth_algebraMap] at h' ⊢
+  rw [faithfullyFlat_algebraMap_iff] at h
+  exact .of_smooth_tensorProduct_of_faithfullyFlat S
+
+lemma FormallyUnramified.codescendsAlong_faithfullyFlat :
+    CodescendsAlong FormallyUnramified FaithfullyFlat := by
+  refine .mk _ FormallyUnramified.respectsIso fun R S T _ _ _ _ _ h h' ↦ ?_
+  rw [formallyUnramified_algebraMap] at h' ⊢
+  rw [faithfullyFlat_algebraMap_iff] at h
+  exact .of_formallyUnramified_tensorProduct_of_faithfullyFlat S
+
+lemma Etale.codescendsAlong_faithfullyFlat : CodescendsAlong Etale FaithfullyFlat := by
+  refine .mk _ Etale.respectsIso fun R S T _ _ _ _ _ h h' ↦ ?_
+  rw [etale_algebraMap] at h' ⊢
+  rw [faithfullyFlat_algebraMap_iff] at h
+  exact .of_etale_tensorProduct_of_faithfullyFlat S
+
+end RingHom

--- a/Mathlib/RingTheory/Etale/Descent.lean
+++ b/Mathlib/RingTheory/Etale/Descent.lean
@@ -55,7 +55,7 @@ lemma FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat
     let e' : (S ⊗[R] T) ⊗[S] Ω[S⁄R] ≃ₗ[S ⊗[R] T] Ω[S ⊗[R] T⁄T] :=
       KaehlerDifferential.tensorKaehlerEquiv R T S (S ⊗[R] T)
     have : Module.Flat (S ⊗[R] T) ((S ⊗[R] T) ⊗[S] Ω[S⁄R]) := .of_linearEquiv e'
-    have : Module.Flat S (Ω[S⁄R]) := Module.Flat.of_flat_tensorProduct _ _ (S ⊗[R] T)
+    have : Module.Flat S Ω[S⁄R] := Module.Flat.of_flat_tensorProduct _ _ (S ⊗[R] T)
     exact Module.Flat.projective_of_finitePresentation
   · have : Subsingleton (T ⊗[R] H1Cotangent R S) := (tensorH1CotangentOfFlat R S T).subsingleton
     exact Module.FaithfullyFlat.lTensor_reflects_triviality R T (H1Cotangent R S)

--- a/Mathlib/RingTheory/Etale/Descent.lean
+++ b/Mathlib/RingTheory/Etale/Descent.lean
@@ -12,7 +12,7 @@ public import Mathlib.RingTheory.Extension.Cotangent.BaseChange
 /-!
 # Etale descends along faithfully flat ring maps
 
-In this file we show that smooth, unramified and étale descends along faithfully flat
+In this file we show that smooth, unramified and étale algebras descend along faithfully flat
 base change.
 
 ## Main results

--- a/Mathlib/RingTheory/Etale/Descent.lean
+++ b/Mathlib/RingTheory/Etale/Descent.lean
@@ -42,10 +42,27 @@ namespace Algebra
 variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 variable (T : Type*) [CommRing T] [Algebra R T] [Module.FaithfullyFlat R T]
 
-/-- The `FinitePresentation` assumption is not necessary (see the TODO in the module docstring). -/
-lemma FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat
-    [FinitePresentation R S] [FormallySmooth T (T ⊗[R] S)] :
-    FormallySmooth R S := by
+lemma FormallyUnramified.of_formallyUnramified_tensorProduct_of_faithfullyFlat
+    [FormallyUnramified T (T ⊗[R] S)] :
+    FormallyUnramified R S := by
+  constructor
+  let _ : Algebra S (T ⊗[R] S) := TensorProduct.rightAlgebra
+  have : Subsingleton (T ⊗[R] Ω[S⁄R]) :=
+    (KaehlerDifferential.tensorKaehlerEquivBase R T S (T ⊗[R] S)).subsingleton
+  exact Module.FaithfullyFlat.lTensor_reflects_triviality R T _
+
+/-- Formally smooth algebras descend along faithfully flat base change. See the TODO
+in the module docstring. -/
+proof_wanted FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat
+    {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    (T : Type*) [CommRing T] [Algebra R T] [Module.FaithfullyFlat R T]
+    [FormallySmooth T (T ⊗[R] S)] :
+    FormallySmooth R S
+
+lemma Smooth.of_smooth_tensorProduct_of_faithfullyFlat [Smooth T (T ⊗[R] S)] :
+    Smooth R S := by
+  have : Algebra.FinitePresentation R S := .of_finitePresentation_tensorProduct_of_faithfullyFlat T
+  refine ⟨?_, .of_finitePresentation_tensorProduct_of_faithfullyFlat T⟩
   rw [formallySmooth_iff]
   constructor
   · let _ : Algebra T (S ⊗[R] T) := TensorProduct.rightAlgebra
@@ -59,21 +76,6 @@ lemma FormallySmooth.of_formallySmooth_tensorProduct_of_faithfullyFlat
     exact Module.Flat.projective_of_finitePresentation
   · have : Subsingleton (T ⊗[R] H1Cotangent R S) := (tensorH1CotangentOfFlat R S T).subsingleton
     exact Module.FaithfullyFlat.lTensor_reflects_triviality R T (H1Cotangent R S)
-
-lemma FormallyUnramified.of_formallyUnramified_tensorProduct_of_faithfullyFlat
-    [FormallyUnramified T (T ⊗[R] S)] :
-    FormallyUnramified R S := by
-  constructor
-  let _ : Algebra S (T ⊗[R] S) := TensorProduct.rightAlgebra
-  have : Subsingleton (T ⊗[R] Ω[S⁄R]) :=
-    (KaehlerDifferential.tensorKaehlerEquivBase R T S (T ⊗[R] S)).subsingleton
-  exact Module.FaithfullyFlat.lTensor_reflects_triviality R T _
-
-lemma Smooth.of_smooth_tensorProduct_of_faithfullyFlat [Smooth T (T ⊗[R] S)] :
-    Smooth R S := by
-  have : Algebra.FinitePresentation R S := .of_finitePresentation_tensorProduct_of_faithfullyFlat T
-  exact ⟨.of_formallySmooth_tensorProduct_of_faithfullyFlat T,
-    .of_finitePresentation_tensorProduct_of_faithfullyFlat T⟩
 
 lemma Unramified.of_unramified_tensorProduct_of_faithfullyFlat [Unramified T (T ⊗[R] S)] :
     Unramified R S :=


### PR DESCRIPTION
From Pi1.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
