### PR TITLE
[Merged by Bors] - style: fix whitespace

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -904,7 +904,7 @@ theorem restrictScalars_image_smul_eq {S M : Type*}
     (algebraMap S R '' s • N).restrictScalars S = s • N.restrictScalars S := by
   refine le_antisymm (fun x x_in ↦ ?_) (set_smul_le _ _ _ fun r x r_in x_in ↦ ?_)
   · rw [restrictScalars_mem] at x_in
-    refine set_smul_inductionOn x x_in ?_ ?_ (fun _ _ _ _ h h' ↦  add_mem h h') (zero_mem _)
+    refine set_smul_inductionOn x x_in ?_ ?_ (fun _ _ _ _ h h' ↦ add_mem h h') (zero_mem _)
     · rintro _ x ⟨r, r_in, rfl⟩ x_in
       rw [algebraMap_smul]
       exact mem_set_smul_of_mem_mem r_in x_in

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/ColimitFunctor.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/ColimitFunctor.lean
@@ -252,7 +252,7 @@ noncomputable def homEquiv {N : ModuleCat.{w} cR.pt} :
         rw [hφ]
         erw [toPresheaf_map_app_apply]
         rw [map_smul]
-        rfl}
+        rfl }
   left_inv φ := (forget₂ _ AddCommGrpCat).map_injective (by
     ext : 1
     exact (homEquiv' hcR hcM).left_inv ((forget₂ _ AddCommGrpCat).map φ).hom)

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -203,7 +203,7 @@ section One
 lemma mulSupport_subset_subsingleton_of_disjoint_on_mulSupport [One β] {s : γ → Set α} (f : α → β)
   (hs : Pairwise (Disjoint on (fun j ↦ s j ∩ f.mulSupport))) (i : α) (j : γ) (hj : i ∈ s j) :
     (fun d ↦ (s d).mulIndicator f i).mulSupport ⊆ {j} := by
-  suffices ∀ j', j' ≠ j →  {i} ⊆ s j → {i} ⊆ s j' → {i} ⊆ mulSupport f → False by by_contra; aesop
+  suffices ∀ j', j' ≠ j → {i} ⊆ s j → {i} ⊆ s j' → {i} ⊆ mulSupport f → False by by_contra; aesop
   intro j' h hj hj' hi
   simp only [Pairwise, Disjoint, Set.le_eq_subset, Set.subset_inter_iff] at hs
   simpa using hs h ⟨hj', hi⟩ ⟨hj, hi⟩

--- a/Mathlib/Algebra/Group/Units/Defs.lean
+++ b/Mathlib/Algebra/Group/Units/Defs.lean
@@ -536,13 +536,13 @@ instance (x : M) [h : Decidable (∃ u : Mˣ, ↑u = x)] : Decidable (IsUnit x) 
 
 theorem mul_left_iff {a b : M} (ha : IsUnit a) :
     IsUnit (a * b) ↔ IsUnit b :=
-  show IsUnit (ha.unit * b) ↔ _ by simp [- IsUnit.unit_spec]
+  show IsUnit (ha.unit * b) ↔ _ by simp [-IsUnit.unit_spec]
 
 grind_pattern mul_left_iff => IsUnit a, IsUnit (a * b)
 
 theorem mul_right_iff {a b : M} (hb : IsUnit b) :
     IsUnit (a * b) ↔ IsUnit a :=
-  show IsUnit (a * hb.unit) ↔ _ by simp [- IsUnit.unit_spec]
+  show IsUnit (a * hb.unit) ↔ _ by simp [-IsUnit.unit_spec]
 
 grind_pattern mul_right_iff => IsUnit b, IsUnit (a * b)
 

--- a/Mathlib/Algebra/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/GroupWithZero/Range.lean
@@ -137,8 +137,8 @@ def ValueGroup₀.restrict₀ : A →*₀ ValueGroup₀ f where
   toFun a :=
     letI : DecidablePred fun b : B ↦ b = 0 := Classical.decPred fun b ↦ b = 0
     if h : f a = 0 then 0 else (⟨Units.mk0 (f a) h, mem_valueGroup _ ⟨a, rfl⟩⟩ : valueGroup f)
-  map_one'  := by simp [← WithZero.coe_one]
-  map_mul'  := by aesop
+  map_one' := by simp [← WithZero.coe_one]
+  map_mul' := by aesop
   map_zero' := by simp
 
 namespace ValueGroup₀

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
@@ -88,7 +88,7 @@ lemma extClass_hom [HasDerivedCategory.{w'} C] : hS.extClass.hom = hS.singleδ :
   dsimp [extClass, SmallShiftedHom.equiv]
   erw [SmallHom.equiv_comp]
   rw [SmallHom.equiv_mkInv, SmallHom.equiv_mk]
-  dsimp [- Q_obj_single_obj, singleδ, triangleOfSESδ]
+  dsimp [-Q_obj_single_obj, singleδ, triangleOfSESδ]
   rw [Category.assoc, Category.assoc, Category.assoc,
     singleFunctorsPostcompQIso_hom_hom, singleFunctorsPostcompQIso_inv_hom,
     NatTrans.id_app, Category.id_comp, NatTrans.id_app]

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Map.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Map.lean
@@ -105,7 +105,7 @@ lemma ShortComplex.ShortExact.mapShiftedHom_singleδ
     [HasDerivedCategory.{t} C] [HasDerivedCategory.{t'} D]
     {S : ShortComplex C} (hS : S.ShortExact) (F : C ⥤ D) [F.Additive]
     [PreservesFiniteLimits F] [PreservesFiniteColimits F] :
-    ShiftedHom.map hS.singleδ F.mapDerivedCategory  =
+    ShiftedHom.map hS.singleδ F.mapDerivedCategory =
       (F.mapDerivedCategorySingleFunctor 0).hom.app S.X₃ ≫
         (hS.map_of_exact F).singleδ ≫ ((F.mapDerivedCategorySingleFunctor 0).inv.app S.X₁)⟦1⟧' := by
   simp [← hS.mapShiftedHom_singleδ'_assoc, ← Functor.map_comp]

--- a/Mathlib/Algebra/Homology/DerivedCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/ShortExact.lean
@@ -57,7 +57,7 @@ lemma triangleOfSESδ_naturality {S₁ S₂ : ShortComplex (CochainComplex C ℤ
   simp only [triangleOfSESδ, CochainComplex.mappingCone.triangle_obj₁, Category.assoc,
     IsIso.inv_comp_eq]
   rw [← Functor.comp_map, ← (Q.commShiftIso (1 : ℤ)).hom.naturality, ← Category.assoc,
-    ← Category.assoc, ← Category.assoc, ← Category.assoc , ← Iso.app_hom,
+    ← Category.assoc, ← Category.assoc, ← Category.assoc, ← Iso.app_hom,
     Iso.cancel_iso_hom_right, ← Q.map_comp]
   simp only [Functor.comp_obj, Functor.comp_map,
     ← CochainComplex.mappingCone.descShortComplex_naturality f,

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -728,7 +728,7 @@ def isKernel (hm : n + 1 = m) :
           #adaptation_note /-- Prior to https://github.com/leanprover/lean4/pull/12244
           this was just `cat_disch`. -/
           simp +instances only [HomComplex_X, map_add]
-          rfl})
+          rfl })
     (by cat_disch) (fun s l hl ↦ by ext : 3; simp [← hl])
 
 end Cocycle

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCocone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCocone.lean
@@ -243,7 +243,7 @@ lemma δ_liftCochain (n' : ℤ) (hn' : n + 1 = n') :
   dsimp [liftCochain, inl, inr]
   ext p q hpq
   simp [mappingCone.δ_liftCochain _ _ _ _ n' hn',
-    Cochain.δ_rightShift _ (-1) _ n' _ n  (by lia),
+    Cochain.δ_rightShift _ (-1) _ n' _ n (by lia),
     Cochain.rightShift_v (n := n) _ _ _ _ p _ _ (q + -1) (by lia),
     Cochain.rightShift_v _ _ _ _ _ _ _ (q + -1) rfl,
     Cochain.rightShift_v _ _ _ _ _ _ _ _ (add_zero (q + -1)),

--- a/Mathlib/Algebra/Homology/Refinements.lean
+++ b/Mathlib/Algebra/Homology/Refinements.lean
@@ -67,7 +67,7 @@ lemma comp_homologyπ_eq_iff_up_to_refinements
     (i j : ι) (hi : c.prev j = i)
     {A : C} (z₂ z₂' : A ⟶ K.cycles j) : z₂ ≫ K.homologyπ j = z₂' ≫ K.homologyπ j ↔
       ∃ (A' : C) (π : A' ⟶ A) (_ : Epi π) (x₁ : A' ⟶ K.X i),
-        π ≫ z₂ = π ≫ z₂' + x₁ ≫ K.toCycles i j:= by
+        π ≫ z₂ = π ≫ z₂' + x₁ ≫ K.toCycles i j := by
   subst hi
   exact (K.sc j).comp_homologyπ_eq_iff_up_to_refinements z₂ z₂'
 

--- a/Mathlib/Algebra/Homology/SpectralObject/Basic.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/Basic.lean
@@ -120,7 +120,7 @@ def sc₃ (n₀ n₁ : ℤ) (hn₁ : n₀ + 1 = n₁ := by lia) : ShortComplex C
   ShortComplex.mk _ _ (X.zero₃ f g fg h n₀ n₁ hn₁)
 
 lemma exact₁ (n₀ n₁ : ℤ) (hn₁ : n₀ + 1 = n₁ := by lia) :
-    (X.sc₁ f g fg h n₀ n₁ hn₁ ).Exact := by
+    (X.sc₁ f g fg h n₀ n₁ hn₁).Exact := by
   subst h
   exact (X.exact₁' n₀ n₁ hn₁ (mk₂ f g)).exact 0
 

--- a/Mathlib/Algebra/Homology/SpectralObject/Cycles.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/Cycles.lean
@@ -195,7 +195,7 @@ noncomputable def cyclesMap (α : mk₂ f g ⟶ mk₂ f' g') (n : ℤ) :
       rw [Category.assoc, X.δ_naturality f g f' g'
         (homMk₁ (α.app 0) (α.app 1) (naturality' α 0 1))
           (homMk₁ (α.app 1) (α.app 2) (naturality' α 1 2)) n (n + 1),
-        iCycles_δ_assoc _ _ _ _ _ , zero_comp])
+        iCycles_δ_assoc _ _ _ _ _, zero_comp])
 
 @[reassoc]
 lemma cyclesMap_i (α : mk₂ f g ⟶ mk₂ f' g') (β : mk₁ g ⟶ mk₁ g') (n : ℤ)
@@ -256,8 +256,8 @@ lemma opcyclesMap_comp (α : mk₂ f g ⟶ mk₂ f' g') (α' : mk₂ f' g' ⟶ m
       X.opcyclesMap f g f'' g'' α'' n := by
   subst h
   rw [← cancel_epi (X.pOpcycles f g n),
-    X.p_opcyclesMap_assoc f g f' g' α _ ,
-    X.p_opcyclesMap f' g' f'' g'' α' _ ,
+    X.p_opcyclesMap_assoc f g f' g' α _,
+    X.p_opcyclesMap f' g' f'' g'' α' _,
     ← Functor.map_comp_assoc]
   exact (X.p_opcyclesMap _ _ _ _ _ _ _ (by cat_disch)).symm
 
@@ -483,7 +483,7 @@ lemma pOpcycles_δFromOpcycles (hn₁ : n₀ + 1 = n₁) :
 @[reassoc (attr := simp)]
 lemma fromOpcyles_δ (hn₁ : n₀ + 1 = n₁ := by lia) :
     X.fromOpcycles f₂ f₃ f₂₃ h₂₃ n₀ ≫ X.δ f₁ f₂₃ n₀ n₁ hn₁ =
-      X.δFromOpcycles f₁ f₂ f₃ n₀ n₁ hn₁  := by
+      X.δFromOpcycles f₁ f₂ f₃ n₀ n₁ hn₁ := by
   rw [← cancel_epi (X.pOpcycles f₂ f₃ n₀),
     p_fromOpcycles_assoc, pOpcycles_δFromOpcycles,
     X.δ_naturality f₁ f₂ f₁ f₂₃ (𝟙 _) (twoδ₂Toδ₁ f₂ f₃ f₂₃ h₂₃) n₀ n₁,

--- a/Mathlib/Algebra/Homology/SpectralObject/Differentials.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/Differentials.lean
@@ -52,7 +52,7 @@ noncomputable def d
   X.descE f₃ f₄ f₅ _ rfl n₀ n₁ n₂ (X.δ (f₁ ≫ f₂) (f₃ ≫ f₄) n₁ n₂ hn₂ ≫
     X.toCycles f₁ f₂ _ rfl n₂ ≫ X.πE f₁ f₂ f₃ n₁ n₂ n₃ hn₂ hn₃) (by
       rw [X.δ_naturality_assoc (f₁ ≫ f₂) f₃ (f₁ ≫ f₂) (f₃ ≫ f₄)
-        (𝟙 _) (twoδ₂Toδ₁ f₃ f₄  _ rfl) n₁ n₂ rfl hn₂, Functor.map_id, id_comp,
+        (𝟙 _) (twoδ₂Toδ₁ f₃ f₄ _ rfl) n₁ n₂ rfl hn₂, Functor.map_id, id_comp,
         δ_toCycles_assoc .., δToCycles_πE ..]) hn₁
           (by rw [δ_δ_assoc .., zero_comp])
 
@@ -96,7 +96,7 @@ lemma d_d (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia
     X.d f₃ f₄ f₅ f₆ f₇ n₀ n₁ n₂ n₃ hn₁ hn₂ hn₃ ≫
       X.d f₁ f₂ f₃ f₄ f₅ n₁ n₂ n₃ n₄ hn₂ hn₃ hn₄ = 0 := by
   rw [← cancel_epi (X.πE f₅ f₆ f₇ n₀ n₁ n₂ hn₁ hn₂),
-    ← cancel_epi (X.toCycles f₅ f₆ _ rfl n₁ ), comp_zero, comp_zero,
+    ← cancel_epi (X.toCycles f₅ f₆ _ rfl n₁), comp_zero, comp_zero,
     X.toCycles_πE_d_assoc f₃ f₄ f₅ f₆ f₇ _ rfl _ rfl n₀ n₁ n₂ n₃ hn₁ hn₂ hn₃,
     X.toCycles_πE_d f₁ f₂ f₃ f₄ f₅ _ rfl _ rfl n₁ n₂ n₃ n₄ hn₂ hn₃ hn₄,
     δ_δ_assoc .., zero_comp]
@@ -175,7 +175,7 @@ lemma cyclesMap_Ψ_exact (hn₁ : n₀ + 1 = n₁ := by lia) :
     X.liftCycles f₁₂ f₃ n₀ n₁ hn₁ (z ≫ X.iCycles f₂ f₃ n₀) ?_, ?_⟩ <;> dsimp
   · rw [assoc, ← X.Ψ_fromOpcycles f₁ f₂ f₃ f₁₂ h₁₂ n₀ n₁ hn₁, reassoc_of% hz, zero_comp]
   · rw [← cancel_mono (X.iCycles f₂ f₃ n₀), id_comp, assoc,
-      X.cyclesMap_i _ _ _ _ (threeδ₁Toδ₀ f₁ f₂ f₃ f₁₂ h₁₂) (𝟙 _) n₀ (by cat_disch) ,
+      X.cyclesMap_i _ _ _ _ (threeδ₁Toδ₀ f₁ f₂ f₃ f₁₂ h₁₂) (𝟙 _) n₀ (by cat_disch),
       Functor.map_id, comp_id, liftCycles_i]
 
 set_option backward.isDefEq.respectTransparency false in
@@ -209,7 +209,7 @@ lemma πE_d_ιE
     (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia) (hn₃ : n₂ + 1 = n₃ := by lia) :
     X.πE f₃ f₄ f₅ n₀ n₁ n₂ hn₁ hn₂ ≫ X.d f₁ f₂ f₃ f₄ f₅ n₀ n₁ n₂ n₃ hn₁ hn₂ hn₃ ≫
       X.ιE f₁ f₂ f₃ n₁ n₂ n₃ hn₂ hn₃ = X.Ψ f₂ f₃ f₄ n₁ n₂ hn₂ := by
-  rw [← cancel_epi (X.toCycles f₃ f₄ _ rfl n₁ ), toCycles_Ψ ..,
+  rw [← cancel_epi (X.toCycles f₃ f₄ _ rfl n₁), toCycles_Ψ ..,
     X.toCycles_πE_d_assoc f₁ f₂ f₃ f₄ f₅ _ rfl _ _ n₀ n₁ n₂ n₃ hn₁ hn₂ hn₃,
     πE_ιE .., toCycles_i_assoc, ← X.δ_naturality_assoc (f₁ ≫ f₂) (f₃ ≫ f₄) f₂ (f₃ ≫ f₄)
       (twoδ₁Toδ₀ f₁ f₂ _ rfl) (𝟙 _) n₁ n₂ rfl hn₂, Functor.map_id, id_comp]

--- a/Mathlib/Algebra/Homology/SpectralObject/EpiMono.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/EpiMono.lean
@@ -53,7 +53,7 @@ lemma mono_map (α : mk₃ f₁ f₂ f₃ ⟶ mk₃ f₁' f₂ f₃) (n₀ n₁ 
     (hα₃ : α.app 3 = 𝟙 _ := by cat_disch) (hn₁ : n₀ + 1 = n₁ := by lia)
     (hn₂ : n₁ + 1 = n₂ := by lia) (hn₃ : n₂ + 1 = n₃ := by lia) :
     Mono (X.map f₁ f₂ f₃ f₁' f₂ f₃ α n₀ n₁ n₂ hn₁ hn₂) := by
-  have := X.map_ιE  _ _ _ _ _ _ α (𝟙 _) n₀ n₁ n₂
+  have := X.map_ιE _ _ _ _ _ _ α (𝟙 _) n₀ n₁ n₂
   rw [opcyclesMap_id, comp_id] at this
   exact mono_of_mono_fac this
 

--- a/Mathlib/Algebra/Homology/SpectralObject/HasSpectralSequence.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/HasSpectralSequence.lean
@@ -276,7 +276,7 @@ by `data`. The conditions given allow to show that the homology of a page identi
 to the next page. -/
 class HasSpectralSequence : Prop where
   isZero_H_obj_mk₁_i₀_le (r r' : ℤ) (pq : κ) (hpq : ∀ (pq' : κ), ¬ ((c r).Rel pq pq'))
-    (n : ℤ) (hn : n = data.deg pq + 1 )
+    (n : ℤ) (hn : n = data.deg pq + 1)
     (hrr' : r + 1 = r' := by lia) (hr : r₀ ≤ r := by lia) :
       IsZero ((X.H n).obj (mk₁ (homOfLE (data.i₀_le r r' pq))))
   isZero_H_obj_mk₁_i₃_le (r r' : ℤ) (pq : κ) (hpq : ∀ (pq' : κ), ¬ ((c r).Rel pq' pq))
@@ -324,7 +324,7 @@ instance (E : SpectralObject C EInt) : E.HasSpectralSequence coreE₂Cohomologic
     exact hpq _ rfl
   isZero_H_obj_mk₁_i₃_le r r' pq hpq n hn hrr' hr := by
     exfalso
-    exact hpq (pq - (r, 1-r)) (by simp)
+    exact hpq (pq - (r, 1 - r)) (by simp)
 
 instance {l : ℕ} (E : SpectralObject C (Fin (l + 1))) :
     E.HasSpectralSequence (coreE₂CohomologicalFin l) where
@@ -374,7 +374,7 @@ variable [Y.IsFirstQuadrant]
 
 lemma isZero₁_of_isFirstQuadrant (i j : EInt) (hij : i ≤ j) (hj : j ≤ (0 : ℤ)) (n : ℤ) :
     IsZero ((Y.H n).obj (mk₁ (homOfLE hij))) :=
-  IsFirstQuadrant.isZero₁ i j hij  hj n
+  IsFirstQuadrant.isZero₁ i j hij hj n
 
 lemma isZero₂_of_isFirstQuadrant (i j : EInt) (hij : i ≤ j) (n : ℤ) (hi : n < i) :
     IsZero ((Y.H n).obj (mk₁ (homOfLE hij))) :=

--- a/Mathlib/Algebra/Homology/SpectralObject/Page.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/Page.lean
@@ -103,7 +103,7 @@ lemma shortComplexMap_id (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 =
 
 @[reassoc, simp]
 lemma shortComplexMap_comp (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia) :
-    X.shortComplexMap f₁ f₂ f₃ f₁'' f₂'' f₃'' (α ≫ β) n₀ n₁ n₂ hn₁ hn₂  =
+    X.shortComplexMap f₁ f₂ f₃ f₁'' f₂'' f₃'' (α ≫ β) n₀ n₁ n₂ hn₁ hn₂ =
     X.shortComplexMap f₁ f₂ f₃ f₁' f₂' f₃' α n₀ n₁ n₂ hn₁ hn₂ ≫
       X.shortComplexMap f₁' f₂' f₃' f₁'' f₂'' f₃'' β n₀ n₁ n₂ hn₁ hn₂ := by
   ext
@@ -621,7 +621,7 @@ lemma cokernelSequenceOpcyclesE_exact
 /-- The map `E^n(f₁, f₂, f₃) ⟶ Z^n(f₁, f₂ ≫ f₃)`. -/
 noncomputable def EToCycles (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia) :
     X.E f₁ f₂ f₃ n₀ n₁ n₂ hn₁ hn₂ ⟶ X.cycles f₁ f₂₃ n₁ :=
-  X.liftCycles  _ _ _ _ hn₂
+  X.liftCycles _ _ _ _ hn₂
     (X.ιE f₁ f₂ f₃ n₀ n₁ n₂ hn₁ hn₂ ≫ X.fromOpcycles f₂ f₃ f₂₃ h₂₃ n₁) (by simp)
 
 @[reassoc (attr := simp)]

--- a/Mathlib/Algebra/Homology/SpectralObject/SpectralSequence.lean
+++ b/Mathlib/Algebra/Homology/SpectralObject/SpectralSequence.lean
@@ -235,7 +235,7 @@ lemma kf_w (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by li
     (X.mapFourδ₁Toδ₀' i₀' i₀ i₁ i₂ i₃ (data.i₀_le' hrr' hr pq' hi₀' hi₀)
       (data.le₀₁' r hr pq' hi₀ hi₁) (data.le₁₂' pq' hi₁ hi₂) (data.le₂₃' r hr pq' hi₂ hi₃)
         n₀ n₁ n₂ hn₁ hn₂ ≫
-      (pageXIso X data _ hr _ _ _ _ _ hi₀ hi₁ hi₂ hi₃ _ _ _ hn₁' _ _ ).inv) ≫
+      (pageXIso X data _ hr _ _ _ _ _ hi₀ hi₁ hi₂ hi₃ _ _ _ hn₁' _ _).inv) ≫
         (page X data r hr).d pq' pq'' = 0 := by
   by_cases h : (c r).Rel pq' pq''
   · dsimp
@@ -318,7 +318,7 @@ noncomputable def isLimitKf (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 
     IsLimit (kf X data r r' hrr' hr pq' pq''
       i₀' i₀ i₁ i₂ i₃ hi₀' hi₀ hi₁ hi₂ hi₃ n₀ n₁ n₂ hn₁' hn₁ hn₂) :=
   (kfSc_exact X data r r' hrr' hr pq' pq'' hpq'
-    i₀' i₀ i₁ i₂ i₃ hi₀' hi₀ hi₁ hi₂ hi₃  n₀ n₁ n₂ hn₁' hn₁ hn₂).fIsKernel
+    i₀' i₀ i₁ i₂ i₃ hi₀' hi₀ hi₁ hi₂ hi₃ n₀ n₁ n₂ hn₁' hn₁ hn₂).fIsKernel
 
 lemma cc_w (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia) :
     (page X data r hr).d pq pq' ≫
@@ -587,9 +587,9 @@ unseal spectralSequence in
 lemma spectralSequenceHomologyData_left_i
     (hn₁ : n₀ + 1 = n₁ := by lia) (hn₂ : n₁ + 1 = n₂ := by lia) :
     (X.spectralSequenceHomologyData data r r' hrr' hr pq pq' pq'' hpq hpq'
-      i₀' i₀ i₁ i₂ i₃ i₃' hi₀' hi₀ hi₁ hi₂ hi₃ hi₃'  n₀ n₁ n₂ hn₁' hn₁ hn₂).left.i =
+      i₀' i₀ i₁ i₂ i₃ i₃' hi₀' hi₀ hi₁ hi₂ hi₃ hi₃' n₀ n₁ n₂ hn₁' hn₁ hn₂).left.i =
     X.mapFourδ₁Toδ₀' i₀' i₀ i₁ i₂ i₃
-      (data.i₀_le' hrr' hr pq' hi₀' hi₀) _ _ _  n₀ n₁ n₂ ≫
+      (data.i₀_le' hrr' hr pq' hi₀' hi₀) _ _ _ n₀ n₁ n₂ ≫
         (X.spectralSequencePageXIso data r hr pq'
           i₀ i₁ i₂ i₃ hi₀ hi₁ hi₂ hi₃ n₀ n₁ n₂ hn₁').inv :=
   rfl
@@ -601,7 +601,7 @@ lemma spectralSequenceHomologyData_right_p
     (X.spectralSequenceHomologyData data r r' hrr' hr pq pq' pq'' hpq hpq'
       i₀' i₀ i₁ i₂ i₃ i₃' hi₀' hi₀ hi₁ hi₂ hi₃ hi₃' n₀ n₁ n₂ hn₁' hn₁ hn₂).right.p =
     (X.spectralSequencePageXIso data r hr pq'
-      i₀ i₁ i₂ i₃ hi₀ hi₁ hi₂ hi₃  n₀ n₁ n₂ hn₁').hom ≫
+      i₀ i₁ i₂ i₃ hi₀ hi₁ hi₂ hi₃ n₀ n₁ n₂ hn₁').hom ≫
         X.mapFourδ₄Toδ₃' i₀ i₁ i₂ i₃ i₃' _ _ _
           (data.le₃₃' hrr' hr pq' hi₃ hi₃') n₀ n₁ n₂ := rfl
 

--- a/Mathlib/Algebra/Lie/Basis.lean
+++ b/Mathlib/Algebra/Lie/Basis.lean
@@ -68,7 +68,7 @@ structure Basis (ι R L : Type*) [Finite ι] [CommRing R] [LieRing L] [LieAlgebr
   nondegen : A.Nondegenerate
   sl2 (i : ι) : IsSl2Triple (h i) (e i) (f i)
   lie_h_h (i j : ι) : ⁅h i, h j⁆ = 0
-  lie_h_e (i j : ι) : ⁅h j, e i⁆ =  A i j • e i
+  lie_h_e (i j : ι) : ⁅h j, e i⁆ = A i j • e i
   lie_h_f (i j : ι) : ⁅h j, f i⁆ = -A i j • f i
   lie_e_f_ne (i j : ι) (hij : i ≠ j) : ⁅e i, f j⁆ = 0
 
@@ -206,7 +206,7 @@ private lemma iSup_cartan_borelLower_borelUpper_eq_top_aux
         exact LieSubmodule.mem_sup_right <| b.borelUpper.lie_mem (x := ⟨yc, hyc⟩) hu
       · exact hu' hyl
       · rw [← lie_skew, neg_mem_iff]
-        exact LieSubmodule.mem_sup_right <|  LieSubalgebra.lie_mem _ hyu hu
+        exact LieSubmodule.mem_sup_right <| LieSubalgebra.lie_mem _ hyu hu
     · obtain ⟨yc, hyc, yl, hyl, yu, hyu, aux⟩ :
         ∃ᵉ (yc ∈ b.cartan) (yl ∈ lieSpan R L (range b.f)) (yu ∈ lieSpan R L (range b.e)),
         yc + yl + yu = ⁅u, z⁆ := by simpa [LieSubmodule.mem_sup] using hu' hz
@@ -216,7 +216,7 @@ private lemma iSup_cartan_borelLower_borelUpper_eq_top_aux
         exact LieSubmodule.mem_sup_right <| b.borelUpper.lie_mem (x := ⟨yc, hyc⟩) hv
       · exact hv' hyl
       · rw [← lie_skew, neg_mem_iff]
-        exact LieSubmodule.mem_sup_right <|  LieSubalgebra.lie_mem _ hyu hv
+        exact LieSubmodule.mem_sup_right <| LieSubalgebra.lie_mem _ hyu hv
 
 /-- Lemma 4.5 from [Geck](Geck2017). -/
 lemma iSup_cartan_borelLower_borelUpper_eq_top :
@@ -525,7 +525,7 @@ lemma root_mem_or_mem_neg (χ : b.cartan.root) :
   replace hs : ⇑χ ∈ s :=
     (iSupIndep_genWeightSpace K b.cartan L).mem_of_biSup_eq_top hs χ.genWeightSpace_ne_bot
   replace hs : (∃ n : ι → ℕ, n ≠ 0 ∧ χ.toLinear = -∑ i, n i • b.baseSupp i) ∨
-               (∃ n : ι → ℕ, n ≠ 0 ∧ χ.toLinear =  ∑ i, n i • b.baseSupp i) := by
+               (∃ n : ι → ℕ, n ≠ 0 ∧ χ.toLinear = ∑ i, n i • b.baseSupp i) := by
     have hχ' : ¬ χ.IsZero := by simpa using hχ
     simp only [hχ', s, singleton_union, mem_union, mem_insert_iff, Weight.coe_eq_zero_iff,
       mem_setOf_eq, false_or] at hs

--- a/Mathlib/Algebra/Lie/Derivation/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/Derivation/BaseChange.lean
@@ -67,7 +67,7 @@ def ofLieDerivation : (LieDerivation R L L) →ₗ⁅R⁆ (LieDerivation R (A �
     { toFun := d.toLinearMap.lTensor A
       map_add' := by simp
       map_smul' := by simp
-      leibniz' x y:= by
+      leibniz' x y := by
         simp only [LinearMap.coe_mk, AddHom.coe_mk]
         refine x.induction_on (by simp) ?_ ?_
         · intros _ _

--- a/Mathlib/Algebra/Lie/Graded.lean
+++ b/Mathlib/Algebra/Lie/Graded.lean
@@ -75,7 +75,7 @@ lemma decompose_bracket (x y : L) : decompose ℒ ⁅x, y⁆ = ⁅decompose ℒ 
 
 @[simp]
 lemma decompose_symm_bracket (x y : ⨁ i, ℒ i) :
-    (decompose ℒ).symm ⁅x, y⁆  = ⁅(decompose ℒ).symm x, (decompose ℒ).symm y⁆ := by
+    (decompose ℒ).symm ⁅x, y⁆ = ⁅(decompose ℒ).symm x, (decompose ℒ).symm y⁆ := by
   simp only [← decomposeLinearEquiv_symm_apply]
   simp
 

--- a/Mathlib/Algebra/Lie/Prod.lean
+++ b/Mathlib/Algebra/Lie/Prod.lean
@@ -163,7 +163,7 @@ theorem inr_eq_prod : inr R L₁ L₂ = prod 0 LieHom.id :=
 theorem prod_ext_iff {f g : L₁ × L₂ →ₗ⁅R⁆ L} :
     f = g ↔ f.comp (inl _ _ _) = g.comp (inl _ _ _) ∧ f.comp (inr _ _ _) = g.comp (inr _ _ _) := by
   simp_rw [LieHom.ext_iff]
-  have h := LinearMap.prod_ext_iff (f:=f.toLinearMap) (g:= g.toLinearMap)
+  have h := LinearMap.prod_ext_iff (f := f.toLinearMap) (g := g.toLinearMap)
   simp_rw [LinearMap.ext_iff] at h
   exact h
 

--- a/Mathlib/Algebra/Lie/SemiDirect.lean
+++ b/Mathlib/Algebra/Lie/SemiDirect.lean
@@ -155,7 +155,7 @@ end
 variable (R K L) in
 /-- The product of two Lie algebras realized through a semidirect sum with trivial `ψ` -/
 @[simps!]
-def prod_iso : (K ⋊⁅(0 : L→ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
+def prod_iso : (K ⋊⁅(0 : L →ₗ⁅R⁆ (LieDerivation R K K))⁆ L) ≃ₗ⁅R⁆ (K × L) where
   __ := toProdl 0
   map_lie' {_ _} := by simp
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Range.lean
@@ -32,7 +32,7 @@ variable (f) in
 /-- The inclusion of `ValueGroup₀ f` into `WithZero Bˣ` as a homomorphism of monoids with zero. -/
 def orderMonoidWithZeroHom : ValueGroup₀ f →*₀o WithZero Bˣ where
   __ := WithZero.map' (valueGroup f).subtype
-  monotone' := map'_strictMono (Subtype.strictMono_coe _)|>.monotone
+  monotone' := map'_strictMono (Subtype.strictMono_coe _) |>.monotone
 
 lemma monoidWithZeroHom_strictMono :
     StrictMono (orderMonoidWithZeroHom f) :=

--- a/Mathlib/AlgebraicTopology/SimplicialComplex/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialComplex/Basic.lean
@@ -242,7 +242,7 @@ instance : InfSet (AbstractSimplicialComplex ι) where
         grind [IsRelLowerSet.mem_of_le, PreAbstractSimplicialComplex.isRelLowerSet_faces,
           mem_iInter]
       singleton_mem v := by
-        grind [Set.mem_iInter, Finset.singleton_nonempty, singleton_mem]  }
+        grind [Set.mem_iInter, Finset.singleton_nonempty, singleton_mem] }
 
 instance : Top (AbstractSimplicialComplex ι) where
   top :=

--- a/Mathlib/AlgebraicTopology/SingularSet.lean
+++ b/Mathlib/AlgebraicTopology/SingularSet.lean
@@ -70,7 +70,7 @@ noncomputable def SSet.toTop : SSet.{u} ⥤ TopCat.{u} :=
   stdSimplex.{u}.leftKanExtension SimplexCategory.toTop
 
 /-- The geometric realization of a simplicial set. -/
-scoped [Simplicial] notation "|" X "|" => SSet.toTop.obj X
+scoped[Simplicial] notation "|" X "|" => SSet.toTop.obj X
 
 set_option backward.isDefEq.respectTransparency false in
 /-- Geometric realization is left adjoint to the singular simplicial set construction. -/

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -351,7 +351,7 @@ lemma analyticOrderAt_deriv_of_pos {𝕜 : Type*} {E : Type*} [NontriviallyNorme
   have ⟨g, hg, hg₀, hfg⟩ := (AnalyticAt.analyticOrderAt_eq_natCast hf).1 horder
   have hz₀ : f z₀ = 0 := by
     simpa [sub_self, zero_pow, zero_smul] using Filter.Eventually.self_of_nhds hfg
-  simpa  [hz₀, sub_zero, horder] using hf.analyticOrderAt_deriv_add_one
+  simpa [hz₀, sub_zero, horder] using hf.analyticOrderAt_deriv_add_one
 
 lemma analyticOrderAt_iterated_deriv {𝕜 : Type*} {E : Type*} [NontriviallyNormedField 𝕜]
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E] {f : 𝕜 → E} {z₀ : 𝕜}

--- a/Mathlib/Analysis/Asymptotics/Defs.lean
+++ b/Mathlib/Analysis/Asymptotics/Defs.lean
@@ -1461,7 +1461,7 @@ theorem IsLittleO.sum_congr (hAB : ∀ i ∈ s, A i =o[l] B i) :
       =o[l] fun H => ‖B i H‖ + ‖∑ j ∈ s, ‖B j H‖‖ :=
           (hAB i (by simp)).add_add (h (fun j hj => hAB j (by simp [hj])))
     _ =ᶠ[l] fun H => ‖B i H‖ + ∑ j ∈ s, ‖B j H‖ := by
-        refine Eventually.of_forall fun H ↦ congr_arg (‖B i H‖ + · ) ?_
+        refine Eventually.of_forall fun H ↦ congr_arg (‖B i H‖ + ·) ?_
         exact Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ => norm_nonneg _)
 
 /-- Similar to `IsBigOWith.sum_congr` except the index set can change in the sum. This requires the

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -458,7 +458,7 @@ theorem taylor_integral_remainder_aux [NormedAddCommGroup F] [NormedSpace ℝ F]
       ∫ (t : ℝ) in x₀..x, u t • deriv v t = u x • v x - u x₀ • v x₀ -
       ∫ (t : ℝ) in x₀..x, deriv u t • v t) :
     f x - taylorWithinEval f n (uIcc x₀ x) x₀ x =
-      ∫ t in x₀..x, ((x - t) ^ n / n !) • iteratedDerivWithin (n + 1) f (uIcc x₀ x) t  := by
+      ∫ t in x₀..x, ((x - t) ^ n / n !) • iteratedDerivWithin (n + 1) f (uIcc x₀ x) t := by
   rcases eq_or_ne x₀ x with rfl | this
   · simp
   induction n with

--- a/Mathlib/Analysis/Convex/SimplicialComplex/AffineIndependentUnion.lean
+++ b/Mathlib/Analysis/Convex/SimplicialComplex/AffineIndependentUnion.lean
@@ -94,7 +94,7 @@ noncomputable def onFinsupp {𝕜 ι : Type*} [DecidableEq ι]
       refine (Finsupp.linearIndependent_single_one 𝕜 ι).affineIndependent.range.mono fun x hx => ?_
       simp only [Set.mem_iUnion, Finset.mem_coe] at hx
       obtain ⟨_, ⟨_, _, rfl⟩, hx⟩ := hx
-      grind )
+      grind)
 
 /--
 The simplicial complex associated to a simple graph, where vertices of the graph

--- a/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
+++ b/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
@@ -813,7 +813,7 @@ lemma monoCLM_eq_of_scalars (𝕜' : Type*)
   rfl
 
 theorem seminorm_fderivLM_le {i : ℕ} (f : 𝓓^{n}_{K}(E, F)) :
-    N[𝕜]_{K, k, i} (fderivLM 𝕜 n k f) ≤ N[𝕜]_{K, n, i+1} f := by
+    N[𝕜]_{K, k, i} (fderivLM 𝕜 n k f) ≤ N[𝕜]_{K, n, i + 1} f := by
   by_cases! hk : k + 1 ≤ n
   · rw [ContDiffMapSupportedIn.seminorm_le_iff 𝕜 (apply_nonneg ..)]
     intro hi x hx
@@ -823,7 +823,7 @@ theorem seminorm_fderivLM_le {i : ℕ} (f : 𝓓^{n}_{K}(E, F)) :
   · simp [fderivLM_apply_of_gt 𝕜 f hk]
 
 theorem seminorm_fderivLM_top {i : ℕ} (f : 𝓓_{K}(E, F)) :
-    N[𝕜]_{K, i} (fderivLM 𝕜 ⊤ ⊤ f) = N[𝕜]_{K, i+1} f := by
+    N[𝕜]_{K, i} (fderivLM 𝕜 ⊤ ⊤ f) = N[𝕜]_{K, i + 1} f := by
   simp [ContDiffMapSupportedIn.seminorm_apply, BoundedContinuousFunction.norm_eq_iSup_norm,
     norm_iteratedFDeriv_fderiv]
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace/Basic.lean
@@ -1327,7 +1327,7 @@ theorem norm_toLp' {f : 𝓢(E, F)} {p : ℝ≥0∞} {μ : Measure E} (hp₁ : p
     ENNReal.toReal_ofReal (by positivity)]
 
 theorem norm_toLp_one {f : 𝓢(E, F)} {μ : Measure E} [hμ : μ.HasTemperateGrowth] :
-    ‖f.toLp 1 μ‖ = ∫ x, ‖f x‖ ∂ μ := by
+    ‖f.toLp 1 μ‖ = ∫ x, ‖f x‖ ∂μ := by
   simpa using norm_toLp' (p := 1) (by simp) (by simp)
 
 theorem norm_toLp_top_le {f : 𝓢(E, F)} {μ : Measure E} [hμ : μ.HasTemperateGrowth] :

--- a/Mathlib/Analysis/Distribution/Sobolev.lean
+++ b/Mathlib/Analysis/Distribution/Sobolev.lean
@@ -106,7 +106,7 @@ open scoped Real Laplacian LineDeriv
 theorem besselPotential_neg_one_lineDerivOp_eq {m : E} (f : 𝓢'(E, F)) :
     (besselPotential E F (-1)) (∂_{m} f) =
       (2 * π * Complex.I) • fourierMultiplierCLM F (fun x ↦ Complex.ofReal <|
-      inner ℝ x m * (1 + ‖x‖ ^ 2) ^ (-1/2 : ℝ)) f := by
+      inner ℝ x m * (1 + ‖x‖ ^ 2) ^ (-1 / 2 : ℝ)) f := by
   rw [lineDeriv_eq_fourierMultiplierCLM, besselPotential,
     ContinuousLinearMap.map_smul_of_tower,
     fourierMultiplierCLM_fourierMultiplierCLM_apply (by fun_prop) (by fun_prop)]
@@ -242,8 +242,8 @@ a `L1` function.
 This is the main calculation of the Sobolev embedding theorem. -/
 theorem MemSobolev.fourier_memL1 {s : ℝ} (hs : Module.finrank ℝ E < 2 * s) {f : 𝓢'(E, F)}
     (hf : MemSobolev s 2 f) :
-    ∃ (v : Lp F 1 (volume : Measure E)), 𝓕 f  = (v : 𝓢'(E, F)) := by
-  obtain ⟨u, hu⟩ :=  memSobolev_iff_exists_smulLeftCLM_fourier.mp hf
+    ∃ (v : Lp F 1 (volume : Measure E)), 𝓕 f = (v : 𝓢'(E, F)) := by
+  obtain ⟨u, hu⟩ := memSobolev_iff_exists_smulLeftCLM_fourier.mp hf
   have : MemLp (fun x : E ↦ (1 + ‖x‖ ^ 2) ^ (-s / 2)) 2 := by
     constructor
     · have : (fun x : E ↦ (1 + ‖x‖ ^ 2) ^ (-s / 2)).HasTemperateGrowth := by

--- a/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Reproducing.lean
@@ -198,7 +198,7 @@ theorem posSemidef_tfae : List.TFAE [K.PosSemidef, K.IsHermitian ∧ ∀ (f : X 
   tfae_have 1 → 2 := fun h ff ↦ by
     rw [Finsupp.sum_comm]
     convert h (ff.sum fun xv z ↦ .single xv.1
-      ((z/‖v‖ ^ 2) • (innerSL 𝕜 v).smulRight xv.2)) v
+      ((z / ‖v‖ ^ 2) • (innerSL 𝕜 v).smulRight xv.2)) v
     simp [Finsupp.sum_sum_index, inner_add_right, inner_add_left, ← smul_assoc, hv]
     simp [inner_smul_left, inner_smul_right, ← mul_assoc, mul_comm]
   tfae_have 2 → 3 := fun h vv ↦ by

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -653,7 +653,7 @@ theorem sum (h : ∀ σ ∈ s, Meromorphic (G σ)) :
 
 @[fun_prop]
 theorem finsum (h : ∀ σ, Meromorphic (F σ)) :
-    Meromorphic (∑ᶠ σ , F σ) := fun x ↦ MeromorphicAt.finsum (h · x)
+    Meromorphic (∑ᶠ σ, F σ) := fun x ↦ MeromorphicAt.finsum (h · x)
 
 @[to_fun (attr := fun_prop)]
 lemma sub (hf : Meromorphic f) (hg : Meromorphic g) :
@@ -676,7 +676,7 @@ theorem prod (h : ∀ σ ∈ s, Meromorphic (F σ)) :
 
 @[fun_prop]
 theorem finprod (h : ∀ σ, Meromorphic (F σ)) :
-    Meromorphic (∏ᶠ σ , F σ) := fun x ↦ MeromorphicAt.finprod (h · x)
+    Meromorphic (∏ᶠ σ, F σ) := fun x ↦ MeromorphicAt.finprod (h · x)
 
 @[to_fun (attr := fun_prop)]
 lemma div {f g : 𝕜 → 𝕜'} (hf : Meromorphic f) (hg : Meromorphic g) :

--- a/Mathlib/Analysis/Meromorphic/NormalForm.lean
+++ b/Mathlib/Analysis/Meromorphic/NormalForm.lean
@@ -281,7 +281,7 @@ theorem meromorphicNFAt_prod {x : 𝕜} {ι : Type*} {s : Finset ι} {f : ι →
   obtain ⟨τ, h₁τ, h₂τ⟩ := h₄f
   have {μ : ι} (hμ : μ ∈ s.erase τ) : f μ x ≠ 0 := by
     by_contra
-    have : τ = μ :=  h₂f (by aesop) (by aesop)
+    have : τ = μ := h₂f (by aesop) (by aesop)
     aesop
   rw [← Finset.mul_prod_erase _ _ h₁τ, meromorphicNFAt_mul_iff_left]
   · apply h₁f τ h₁τ

--- a/Mathlib/Analysis/Normed/Algebra/Basic.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Basic.lean
@@ -37,7 +37,7 @@ variable {K L : Type*} [NontriviallyNormedField K] [NormedField L] [NormedAlgebr
 instance (F : IntermediateField K L) : NontriviallyNormedField F where
   __ := SubfieldClass.toNormedField F
   non_trivial := by
-    obtain ⟨k, hk⟩ :=  @NontriviallyNormedField.non_trivial K _
+    obtain ⟨k, hk⟩ := @NontriviallyNormedField.non_trivial K _
     use algebraMap K F k
     simp [hk]
 

--- a/Mathlib/Analysis/Normed/Algebra/GelfandFormula.lean
+++ b/Mathlib/Analysis/Normed/Algebra/GelfandFormula.lean
@@ -58,7 +58,7 @@ theorem hasDerivAt_resolvent_const_left {a : A} {k : 𝕜} (hk : k ∈ resolvent
     simpa using (Algebra.linearMap 𝕜 A).hasDerivAt.sub_const a
   simpa [resolvent, sq, hk.unit_spec, ← Ring.inverse_unit hk.unit] using H₁.comp_hasDerivAt k H₂
 
-@[deprecated  (since := "2026-03-26")]
+@[deprecated (since := "2026-03-26")]
 alias hasDerivAt_resolvent := hasDerivAt_resolvent_const_left
 
 theorem hasFDerivAt_resolvent {a : A} {k : 𝕜} (hk : k ∈ resolventSet 𝕜 a) :

--- a/Mathlib/Analysis/Normed/Field/Krasner.lean
+++ b/Mathlib/Analysis/Normed/Field/Krasner.lean
@@ -55,7 +55,7 @@ of the conclusion of Krasner's lemma. That is, `IsKrasner K L` means that given 
 -/
 class IsKrasner [Field K] [Algebra K L] : Prop where
   krasner' {x y : L} : IsSeparable K x → ((minpoly K x).map (algebraMap K L)).Splits →
-    IsIntegral K y → (∀ x' : L, IsConjRoot K x x' →  x ≠ x' → ‖x - y‖ < ‖x - x'‖) → x ∈ K⟮y⟯
+    IsIntegral K y → (∀ x' : L, IsConjRoot K x x' → x ≠ x' → ‖x - y‖ < ‖x - x'‖) → x ∈ K⟮y⟯
 
 namespace IsKrasner
 

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -626,7 +626,7 @@ lemma norm_mono {F : α → Type*} [∀ i, NormedAddCommGroup (F i)]
     ‖x‖ ≤ ‖y‖ := by
   obtain (rfl | rfl | hp) := p.trichotomy
   · exact hp rfl |>.elim
-  · exact norm_le_of_forall_le (by positivity) fun i ↦(h i).trans <| norm_apply_le_norm hp y i
+  · exact norm_le_of_forall_le (by positivity) fun i ↦ (h i).trans <| norm_apply_le_norm hp y i
   · exact norm_le_of_forall_sum_le hp (norm_nonneg' _) fun s ↦ calc
       ∑ i ∈ s, ‖x i‖ ^ p.toReal
       _ ≤ ∑ i ∈ s, ‖y i‖ ^ p.toReal := by gcongr with i _; exact h i
@@ -736,7 +736,7 @@ noncomputable def tsumCLM : ℓ¹(α, E) →L[𝕜] E :=
         exacts [rfl, .of_norm (by simpa using f.2.summable), .of_norm (by simpa using g.2.summable)]
       map_smul' c f := by
         simp only [coeFn_smul]
-        exact Summable.tsum_const_smul _ (.of_norm (by simpa using f.2.summable))  }
+        exact Summable.tsum_const_smul _ (.of_norm (by simpa using f.2.summable)) }
     1 (fun f ↦ by simpa using norm_tsum_le f)
 
 end Sum

--- a/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Module/PiTensorProduct/ProjectiveSeminorm.lean
@@ -92,7 +92,7 @@ theorem projectiveSeminorm_zero : ‖(0 : ⨂[𝕜] i, E i)‖ = 0 :=
   le_antisymm (ciInf_le (bddBelow_projectiveSemiNormAux _) ⟨0, lifts_zero⟩)
     (le_ciInf (fun p ↦ projectiveSeminormAux_nonneg p.val))
 
-theorem projectiveSeminorm_add_le (x y : ⨂[𝕜] i, E i) : ‖x+y‖ ≤ ‖x‖ + ‖y‖ :=
+theorem projectiveSeminorm_add_le (x y : ⨂[𝕜] i, E i) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ :=
   le_ciInf_add_ciInf (fun p q ↦ ciInf_le_of_le (bddBelow_projectiveSemiNormAux _)
     ⟨p.1 + q.1, lifts_add p.2 q.2⟩ (projectiveSeminormAux_add_le p.1 q.1))
 

--- a/Mathlib/Analysis/Normed/Ring/InfiniteProd.lean
+++ b/Mathlib/Analysis/Normed/Ring/InfiniteProd.lean
@@ -36,7 +36,7 @@ public theorem tendsto_tprod_one_add_of_dominated_convergence {𝓕 : Filter α}
     Tendsto (fun n ↦ ∏' k, (1 + f n k)) 𝓕 (𝓝 (∏' k, (1 + g k))) := by
   rcases eq_or_neBot 𝓕 with rfl | _
   · simp
-  have h_bound_g (k) :  ‖g k‖ ≤ bound k :=
+  have h_bound_g (k) : ‖g k‖ ≤ bound k :=
     le_of_tendsto ((hab k).norm) (h_bound.mono fun n hn ↦ hn k)
   have hsum_g : Summable (‖g ·‖) := h_sum.of_nonneg_of_le (fun _ ↦ norm_nonneg _) h_bound_g
   rw [show ∏' k, (1 + g k) = ∑' s, ∏ i ∈ s, g i from

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -283,7 +283,7 @@ instance (v : AbsoluteValue T S) : Algebra R (WithAbs v) :=
   fast_instance% (equiv v).algebra R
 
 theorem algebraMap_right_apply {v : AbsoluteValue T S} (x : R) :
-    algebraMap R (WithAbs v) x = toAbs v (algebraMap R T x):= rfl
+    algebraMap R (WithAbs v) x = toAbs v (algebraMap R T x) := rfl
 
 theorem algebraMap_right_injective (v : AbsoluteValue T S)
     (h : Function.Injective (algebraMap R T)) : Function.Injective (algebraMap R (WithAbs v)) :=

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -336,17 +336,17 @@ theorem mahlerMeasure_le_sqrt_sum_sq_norm_coeff (p : Polynomial ℂ) :
           exact ((analyticOnNhd_id.aeval_polynomial p).meromorphicOn.circleIntegrable_log_norm).1
         · exact (integrable_congr hlogAe).mpr hcont.integrableOn_uIoc
     _ = ⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖ := average_congr hlogAe
-    _ = √ ((⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖) ^ 2) := by
+    _ = √((⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖) ^ 2) := by
         rw [sqrt_sq]; exact integral_nonneg (fun _ ↦ norm_nonneg _)
-    _ ≤ √ (⨍ (θ : ℝ) in 0..(2 * π),  ‖p.eval (circleMap 0 1 θ)‖ ^ 2) := by
+    _ ≤ √(⨍ (θ : ℝ) in 0..(2 * π), ‖p.eval (circleMap 0 1 θ)‖ ^ 2) := by
         -- Second Jensen's inequality invocation
         gcongr
         refine (convexOn_pow 2).map_average_le (continuousOn_pow 2)
             isClosed_Ici (by filter_upwards; simp) ?_ ?_
         · exact hcont.integrableOn_Icc.mono_set Set.Ioc_subset_Icc_self
         · exact ((continuous_pow 2).comp hcont).integrableOn_Icc.mono_set Set.Ioc_subset_Icc_self
-    _ = √ (circleAverage (fun θ ↦ ‖p.eval θ‖ ^ 2) 0 1) := by simp [circleAverage_eq_intervalAverage]
-    _ = √ (∑ i ∈ p.support, ‖p.coeff i‖ ^ 2) := by simp [p.sum_sq_norm_coeff_eq_circleAverage]
+    _ = √(circleAverage (fun θ ↦ ‖p.eval θ‖ ^ 2) 0 1) := by simp [circleAverage_eq_intervalAverage]
+    _ = √(∑ i ∈ p.support, ‖p.coeff i‖ ^ 2) := by simp [p.sum_sq_norm_coeff_eq_circleAverage]
 
 /-- The Mahler measure of a polynomial is at most the sup norm of the polynomial times the square
 root of its degree plus one. -/

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
@@ -788,7 +788,7 @@ lemma sqrt_ringInverse {a : A} : sqrt a⁻¹ʳ = (sqrt a)⁻¹ʳ := by
         inverse_eq_rpow_neg_one, rpow_rpow _ _ _ (by grind)]
     grind only
   · have ha' : ¬IsUnit (sqrt a) := by rwa [CFC.isUnit_sqrt_iff_isStrictlyPositive]
-    obtain (H|H) : ¬0 ≤ a ∨ ¬IsUnit a := by grind
+    obtain (H | H) : ¬0 ≤ a ∨ ¬IsUnit a := by grind
     · rw [sqrt_of_not_nonneg H, inverse_zero]
       by_cases hunit : IsUnit a
       · have h₂ : ¬0 ≤ inverse a := by grind [CFC.ringInverse_nonneg_iff_nonneg_of_isUnit]

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Digamma.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Digamma.lean
@@ -47,7 +47,7 @@ theorem digamma_one : digamma 1 = - Real.eulerMascheroniConstant := by
 
 theorem digamma_one_half : digamma (1 / 2) = - 2 * log 2 - Real.eulerMascheroniConstant := by
   rw [digamma_def, logDeriv_apply, hasDerivAt_Gamma_one_half.deriv, add_comm, Gamma_one_half_eq,
-    neg_mul, ← mul_neg, neg_add',  Real.sqrt_eq_rpow, ofReal_cpow Real.pi_nonneg]
+    neg_mul, ← mul_neg, neg_add', Real.sqrt_eq_rpow, ofReal_cpow Real.pi_nonneg]
   simp
 
 theorem digamma_apply_add_one (s : ℂ) (hs : ∀ m : ℕ, s ≠ - m) :

--- a/Mathlib/Analysis/SumIntegralExpDecay.lean
+++ b/Mathlib/Analysis/SumIntegralExpDecay.lean
@@ -42,7 +42,7 @@ lemma intervalIntegral_pow_mul_exp_neg_le {k : ℕ} {M c : ℝ} (hM : 0 ≤ M) (
 lemma sum_Ico_pow_mul_exp_neg_le {k : ℕ} {M : ℕ} {c : ℝ} (hc : 0 < c) :
     ∑ i ∈ Finset.Ico 0 M, i ^ k * rexp (- (c * i)) ≤ rexp c * k ! / c ^ (k + 1) := calc
   ∑ i ∈ Finset.Ico 0 M, i ^ k * rexp (- (c * i))
-  _ ≤ ∫ x in (0 : ℕ).. M, x ^ k * rexp (- (c * (x - 1))) := by
+  _ ≤ ∫ x in (0 : ℕ)..M, x ^ k * rexp (- (c * (x - 1))) := by
     apply sum_mul_Ico_le_integral_of_monotone_antitone
       (f := fun x ↦ x ^ k) (g := fun x ↦ rexp (- (c * x)))
     · exact Nat.zero_le M

--- a/Mathlib/CategoryTheory/Abelian/SerreClass/Localization.lean
+++ b/Mathlib/CategoryTheory/Abelian/SerreClass/Localization.lean
@@ -324,7 +324,7 @@ lemma preservesCokernel {X Y : C} (f : X ⟶ Y) :
   have := preservesEpimorphisms L P
   have := Localization.essSurj L P.isoModSerre
   suffices ∀ (W : D) (z : L.obj Y ⟶ W) (hz : L.map f ≫ z = 0),
-      ∃ (l : L.obj (cokernel f) ⟶ W), L.map (cokernel.π  f) ≫ l = z from
+      ∃ (l : L.obj (cokernel f) ⟶ W), L.map (cokernel.π f) ≫ l = z from
     preservesColimit_of_preserves_colimit_cocone (cokernelIsCokernel f)
       ((CokernelCofork.isColimitMapCoconeEquiv _ L).2
         (Cofork.IsColimit.ofExistsUnique
@@ -444,13 +444,13 @@ def abelian : Abelian D := by
 
 lemma preservesFiniteLimits : PreservesFiniteLimits L := by
   letI := abelian L P
-  rw [((Functor.preservesFiniteLimits_tfae L).out 3 2:)]
+  rw [((Functor.preservesFiniteLimits_tfae L).out 3 2 :)]
   intro _ _ f
   exact preservesKernel L P f
 
 lemma preservesFiniteColimits : PreservesFiniteColimits L := by
   letI := abelian L P
-  rw [((Functor.preservesFiniteColimits_tfae L).out 3 2:)]
+  rw [((Functor.preservesFiniteColimits_tfae L).out 3 2 :)]
   intro _ _ f
   exact preservesCokernel L P f
 
@@ -557,7 +557,7 @@ lemma essImage_whiskeringLeft :
   refine ⟨?_, fun hF ↦ ?_⟩
   · rintro ⟨G, ⟨e⟩⟩
     rw [← MorphismProperty.IsInvertedBy.iff_of_iso _
-      (show  L ⋙ G.obj ≅ F.obj from (ObjectProperty.ι _).mapIso e)]
+      (show L ⋙ G.obj ≅ F.obj from (ObjectProperty.ι _).mapIso e)]
     exact MorphismProperty.IsInvertedBy.of_comp _ _ (Localization.inverts L _) _
   · refine ⟨⟨Localization.lift F.obj hF L, ?_⟩,
       ⟨ObjectProperty.isoMk _ (Localization.fac F.obj hF L)⟩⟩

--- a/Mathlib/CategoryTheory/Adhesive/Basic.lean
+++ b/Mathlib/CategoryTheory/Adhesive/Basic.lean
@@ -74,7 +74,7 @@ lemma IsPushout.IsVanKampen.exists_cube_filling {H : IsPushout f g h i} (H' : H.
   · refine IsPullback.of_right' ?_ hi
     rw [← H.w]
     exact IsPullback.paste_horiz (IsPullback.of_hasPullback αX f) hh
-  · refine (H' (pullback.fst αX f) l  h' i' (pullback.snd αX f) αX αY αZ
+  · refine (H' (pullback.fst αX f) l h' i' (pullback.snd αX f) αX αY αZ
       (IsPullback.of_hasPullback αX f) ?_
         hh.toCommSq hi.toCommSq ⟨by simp only [IsPullback.lift_fst, l]⟩).2 ⟨hh, hi⟩
     · refine IsPullback.of_right' ?_ hi

--- a/Mathlib/CategoryTheory/Bicategory/FunctorBicategory/Lax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/FunctorBicategory/Lax.lean
@@ -113,7 +113,7 @@ def whiskerLeft (η : F ⟶ G) {θ ι : G ⟶ H} (Γ : θ ⟶ ι) : η ≫ θ �
       dsimp only [comp_app, comp_naturality]
       calc
         _ = 𝟙 _ ⊗≫ ((F.map f ≫ η.app b) ◁ Γ.as.app b ≫ η.naturality f ▷ ι.app b) ⊗≫
-            η.app a ◁ ι.naturality f ⊗≫ 𝟙 _  := by
+            η.app a ◁ ι.naturality f ⊗≫ 𝟙 _ := by
           bicategory
         _ = 𝟙 _ ⊗≫ η.naturality f ▷ θ.app b ⊗≫ η.app a ◁ (G.map f ◁ Γ.as.app b ≫
             ι.naturality f) ⊗≫ 𝟙 _ := by

--- a/Mathlib/CategoryTheory/Bicategory/FunctorBicategory/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/FunctorBicategory/Oplax.lean
@@ -39,7 +39,7 @@ def whiskerLeft (η : F ⟶ G) {θ ι : G ⟶ H} (Γ : θ ⟶ ι) : η ≫ θ �
     naturality {a b} f := by
       dsimp only [comp_app, comp_naturality]
       calc
-        _ =  𝟙 _ ⊗≫ η.app a ◁ (Γ.as.app a ▷ H.map f ≫ ι.naturality f) ⊗≫
+        _ = 𝟙 _ ⊗≫ η.app a ◁ (Γ.as.app a ▷ H.map f ≫ ι.naturality f) ⊗≫
                 η.naturality f ▷ ι.app b ⊗≫ 𝟙 _ := by
           bicategory
         _ = 𝟙 _ ⊗≫ η.app a ◁ θ.naturality f ⊗≫ ((η.app a ≫ G.map f) ◁ Γ.as.app b ≫

--- a/Mathlib/CategoryTheory/Bicategory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Yoneda.lean
@@ -102,7 +102,7 @@ This is an implementation detail, and `Bicategory.yoneda.map` should be preferre
 @[simps!]
 def postcomposing₂ (a b : B) : (a ⟶ b) ⥤ (yoneda₀ a ⟶ yoneda₀ b) where
   obj := postcomp₂
-  map η := { as := { app x := (postcomposingCat (unop x) a b).map η }}
+  map η := { as := { app x := (postcomposingCat (unop x) a b).map η } }
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The Yoneda pseudofunctor from `B` to `Bᵒᵖ ⥤ᵖ Cat`.

--- a/Mathlib/CategoryTheory/Comma/Over/OverClass.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/OverClass.lean
@@ -155,8 +155,7 @@ instance (f : X ⟶ Y) [IsIso f] [HomIsOver f S] : IsIso (asOverHom S f) :=
 attribute [local simp] Iso.inv_comp_eq in
 instance {e : X ≅ Y} [HomIsOver e.hom S] : HomIsOver e.inv S where
 
--- FIXME: False positive from the linter
-set_option linter.style.whitespace false in
+set_option linter.style.whitespace false in -- linter false positive
 attribute [local simp ←] Iso.eq_inv_comp in
 instance {e : X ≅ Y} [HomIsOver e.inv S] : HomIsOver e.hom S where
 

--- a/Mathlib/CategoryTheory/Functor/ReflectsIso/Exact.lean
+++ b/Mathlib/CategoryTheory/Functor/ReflectsIso/Exact.lean
@@ -107,7 +107,7 @@ section
 variable {α : Type*} {c : ComplexShape α} {K L : HomologicalComplex C c}
 
 lemma quasiIsoAt_iff (f : K ⟶ L) (a : α) :
-    QuasiIsoAt f a ↔ ∀ (i : I), QuasiIsoAt (((F i).mapHomologicalComplex c).map f) a  := by
+    QuasiIsoAt f a ↔ ∀ (i : I), QuasiIsoAt (((F i).mapHomologicalComplex c).map f) a := by
   simpa only [quasiIsoAt_iff' _ _ _ _ rfl rfl] using
     hP.shortComplexQuasiIso_iff _
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -768,7 +768,7 @@ theorem ImageMap.map_uniq {f g : Arrow C} [HasImage f.hom] [HasImage g.hom]
   apply ImageMap.map_uniq_aux _ F.map_ι _ G.map_ι
 
 @[deprecated (since := "2026-04-08")]
-alias ImageMap.mk.injEq' :=  ImageMap.mk.injEq
+alias ImageMap.mk.injEq' := ImageMap.mk.injEq
 
 instance : Subsingleton (ImageMap sq) :=
   Subsingleton.intro fun a b =>

--- a/Mathlib/CategoryTheory/Limits/Shapes/IsTerminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/IsTerminal.lean
@@ -476,7 +476,7 @@ variable (C : Type*) [Category* C] {D : Type*} [Category* D]
 /-- The constant functor returning a specific terminal object is indeed terminal. -/
 def isTerminalConst {X : D} (hX : IsTerminal X) :
     IsTerminal ((Functor.const C).obj X) :=
-  .ofUniqueHom (fun Y => {app Z := hX.from (Y.obj Z)}) (by intros; ext; apply hX.hom_ext)
+  .ofUniqueHom (fun Y => { app Z := hX.from (Y.obj Z) }) (by intros; ext; apply hX.hom_ext)
 
 @[simp]
 lemma isTerminalConst_from_app {X : D} (hX : IsTerminal X)
@@ -485,7 +485,7 @@ lemma isTerminalConst_from_app {X : D} (hX : IsTerminal X)
 /-- The constant functor returning a specific initial object is indeed initial. -/
 def isInitialConst {X : D} (hX : IsInitial X) :
     IsInitial ((Functor.const C).obj X) :=
-  .ofUniqueHom (fun Y => {app Z := hX.to (Y.obj Z)}) (by intros; ext; apply hX.hom_ext)
+  .ofUniqueHom (fun Y => { app Z := hX.to (Y.obj Z) }) (by intros; ext; apply hX.hom_ext)
 
 @[simp]
 lemma isInitialConst_to_app {X : D} (hX : IsInitial X)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/IsPullback/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/IsPullback/Basic.lean
@@ -471,7 +471,7 @@ lemma epi_inl_of_epi (h : IsPushout f g inl inr) (inst : Epi g := by infer_insta
     Epi inl := by
   constructor
   intro W fst' snd' heq
-  exact h.hom_ext heq (by simp [← cancel_epi g, ← h.w_assoc,heq])
+  exact h.hom_ext heq (by simp [← cancel_epi g, ← h.w_assoc, heq])
 
 lemma epi_inr_of_epi (h : IsPushout f g inl inr) (inst : Epi f := by infer_instance) :
     Epi inr := h.flip.epi_inl_of_epi

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -807,7 +807,7 @@ variable {C : Type*} [Category* C] [HasZeroMorphisms C] (P : ObjectProperty C)
 
 instance [HasZeroMorphisms C] : HasZeroMorphisms P.FullSubcategory where
   -- Note: Add zero field explicitly for a better transparency of definitional properties
-  zero _ _ := { zero := P.homMk 0}
+  zero _ _ := { zero := P.homMk 0 }
   __ := P.fullyFaithfulι.hasZeroMorphisms
 
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/Point/OfIsCofiltered.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/OfIsCofiltered.lean
@@ -69,7 +69,7 @@ variable {p} in
 lemma exists_of_fiberMk_eq_fiberMk [IsCofiltered N]
     {U : N} {X : C} {f₁ f₂ : p.obj U ⟶ X} (hf : fiberMk f₁ = fiberMk f₂) :
     ∃ (V : N) (g : V ⟶ U), p.map g ≫ f₁ = p.map g ≫ f₂ := by
-  obtain ⟨V, g, hg⟩  :=
+  obtain ⟨V, g, hg⟩ :=
     (Types.FilteredColimit.isColimit_eq_iff'
       (colimit.isColimit (p.op ⋙ shrinkYoneda.{w}.obj X)) _ _).1 hf
   refine ⟨V.unop, g.unop, ?_⟩

--- a/Mathlib/CategoryTheory/Topos/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Topos/Sheaf.lean
@@ -199,7 +199,7 @@ lemma χ_unique (m : F ⟶ G) [Mono m] (χ' : G ⟶ Sheaf.Ω J)
     (hχ' : IsPullback m ((isTerminalTerminal J _).from F) χ' (Sheaf.truth J)) :
     χ' = Sheaf.χ m := by
   ext : 1
-  rw [← cancel_mono (closedSieves J).ι,χ_hom, Subfunctor.lift_ι]
+  rw [← cancel_mono (closedSieves J).ι, χ_hom, Subfunctor.lift_ι]
   apply Presheaf.χ_unique _
   have pb : IsPullback (𝟙 G.obj) χ'.hom (χ'.hom ≫ (closedSieves J).ι)
     (closedSieves J).ι := IsPullback.of_horiz_isIso_mono (by simp)

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/ETrunc.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/ETrunc.lean
@@ -253,7 +253,7 @@ lemma isGE_eTruncGE_obj_obj (n : ℤ) (i : EInt) (h : n ≤ i) (X : C) :
   | bot => simp at h
   | coe i =>
     dsimp
-    exact t.isGE_of_ge  _ _ _ (by simpa using h)
+    exact t.isGE_of_ge _ _ _ (by simpa using h)
   | top => exact t.isGE_of_isZero (Functor.zero_obj _) _
 
 lemma isLE_eTruncLT_obj_obj (n : ℤ) (i : EInt) (h : i ≤ (n + 1 :)) (X : C) :
@@ -509,7 +509,7 @@ lemma eTruncLTGEIsoGELT_hom_naturality (a b : EInt) {X Y : C} (f : X ⟶ Y) :
 lemma eTruncLTGEIsoGELT_hom_app_fac (a b : EInt) (X : C) :
     (t.eTruncLT.obj b).map ((t.eTruncGE.obj a).map ((t.eTruncLTι b).app X)) ≫
       (t.eTruncLTGEIsoGELT a b).hom.app X =
-    (t.eTruncLTι b).app ((t.eTruncGE.obj a).obj ((t.eTruncLT.obj b).obj X)):= by
+    (t.eTruncLTι b).app ((t.eTruncGE.obj a).obj ((t.eTruncLT.obj b).obj X)) := by
   simp [eTruncLTGEIsoGELT]
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/TruncLEGT.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/TruncLEGT.lean
@@ -108,7 +108,7 @@ lemma truncLEIsoTruncLT_inv_ι_app (a b : ℤ) (h : a + 1 = b) (X : C) :
 /-- The natural transformation `t.truncLE a ⟶ t.truncLE b` when `a ≤ b`. -/
 noncomputable def natTransTruncLEOfLE (a b : ℤ) (h : a ≤ b) :
     t.truncLE a ⟶ t.truncLE b :=
-  t.natTransTruncLTOfLE (a+1) (b+1) (by lia)
+  t.natTransTruncLTOfLE (a + 1) (b + 1) (by lia)
 
 @[reassoc (attr := simp)]
 lemma natTransTruncLEOfLE_ι_app (n₀ n₁ : ℤ) (h : n₀ ≤ n₁) (X : C) :
@@ -206,7 +206,7 @@ lemma triangleLEGE_distinguished (a b : ℤ) (h : a + 1 = b) (X : C) :
 for `n : ℤ`, as a natural transformation. -/
 noncomputable def truncGTδLE (n : ℤ) :
     t.truncGT n ⟶ t.truncLE n ⋙ shiftFunctor C (1 : ℤ) :=
-  (t.truncGTIsoTruncGE n (n+1) rfl).hom ≫ t.truncGEδLE n (n + 1) (by lia)
+  (t.truncGTIsoTruncGE n (n + 1) rfl).hom ≫ t.truncGEδLE n (n + 1) (by lia)
 
 /-- The distinguished triangle `(t.truncLE n).obj A ⟶ A ⟶ (t.truncGT n).obj A ⟶ ...`
 as a functor `C ⥤ Triangle C` when `t` is a t-structure on a pretriangulated
@@ -229,8 +229,8 @@ noncomputable def triangleLEGTIsoTriangleLEGE (a b : ℤ) (h : a + 1 = b) :
 
 lemma triangleLEGT_distinguished (n : ℤ) (X : C) :
     (t.triangleLEGT n).obj X ∈ distTriang C :=
-  isomorphic_distinguished _ (t.triangleLEGE_distinguished n (n+1) rfl X) _
-    ((t.triangleLEGTIsoTriangleLEGE n (n+1) rfl).app X)
+  isomorphic_distinguished _ (t.triangleLEGE_distinguished n (n + 1) rfl X) _
+    ((t.triangleLEGTIsoTriangleLEGE n (n + 1) rfl).app X)
 
 lemma isLE_iff_isIso_truncLEι_app (n : ℤ) (X : C) :
     t.IsLE X n ↔ IsIso ((t.truncLEι n).app X) :=
@@ -244,7 +244,7 @@ lemma isGE_iff_isIso_truncGTπ_app (n₀ n₁ : ℤ) (hn₁ : n₀ + 1 = n₁) (
     (Arrow.isoMk (Iso.refl _) ((t.truncGTIsoTruncGE _ _ hn₁).symm.app X))
 
 instance (X : C) (n : ℤ) [t.IsLE X n] : IsIso ((t.truncLEι n).app X) := by
-  rw [← isLE_iff_isIso_truncLEι_app ]
+  rw [← isLE_iff_isIso_truncLEι_app]
   infer_instance
 
 lemma isLE_iff_isZero_truncGT_obj (n : ℤ) (X : C) :
@@ -278,7 +278,7 @@ variable {X Y : C} (f : X ⟶ Y) (n : ℤ) [t.IsLE X n]
 lemma liftTruncLE_aux :
     ∃ (f' : X ⟶ (t.truncLE n).obj Y), f = f' ≫ (t.truncLEι n).app Y :=
   Triangle.coyoneda_exact₂ _ (t.triangleLEGT_distinguished n Y) f
-    (t.zero_of_isLE_of_isGE  _ n (n + 1) (by lia) inferInstance (by dsimp; infer_instance))
+    (t.zero_of_isLE_of_isGE _ n (n + 1) (by lia) inferInstance (by dsimp; infer_instance))
 
 /-- Constructor for morphisms to `(t.truncLE n).obj Y`. -/
 noncomputable def liftTruncLE :

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/TruncLTGE.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/TruncLTGE.lean
@@ -361,7 +361,7 @@ lemma π_natTransTruncGEOfLE_app (a b : ℤ) (h : a ≤ b) (X : C) :
 
 @[reassoc]
 lemma truncGEδLT_comp_natTransTruncLTOfLE_app (a b : ℤ) (h : a ≤ b) (X : C) :
-  (t.truncGEδLT a).app X ≫ ((natTransTruncLTOfLE t a b h).app X)⟦(1 :ℤ)⟧' =
+  (t.truncGEδLT a).app X ≫ ((natTransTruncLTOfLE t a b h).app X)⟦(1 : ℤ)⟧' =
     (t.natTransTruncGEOfLE a b h).app X ≫ (t.truncGEδLT b).app X :=
   ((TruncAux.triangleFunctorNatTransOfLE t a b h).app X).comm₃
 
@@ -581,7 +581,7 @@ variable {X Y : C} (f : X ⟶ Y) (n : ℤ) [t.IsGE Y n]
 lemma descTruncGE_aux :
   ∃ (f' : (t.truncGE n).obj X ⟶ Y), f = (t.truncGEπ n).app X ≫ f' :=
   Triangle.yoneda_exact₂ _ (t.triangleLTGE_distinguished n X) f
-    (t.zero_of_isLE_of_isGE _ (n-1)  n (by lia) (by dsimp; infer_instance) inferInstance)
+    (t.zero_of_isLE_of_isGE _ (n-1) n (by lia) (by dsimp; infer_instance) inferInstance)
 
 /-- Constructor for morphisms from `(t.truncGE n).obj X`. -/
 noncomputable def descTruncGE :
@@ -590,7 +590,7 @@ noncomputable def descTruncGE :
 
 @[reassoc (attr := simp)]
 lemma π_descTruncGE {X Y : C} (f : X ⟶ Y) (n : ℤ) [t.IsGE Y n] :
-    (t.truncGEπ n).app X ≫ t.descTruncGE f n  = f :=
+    (t.truncGEπ n).app X ≫ t.descTruncGE f n = f :=
   (t.descTruncGE_aux f n).choose_spec.symm
 
 end
@@ -609,10 +609,10 @@ lemma isGE_iff_orthogonal (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) (X : C) :
 
 lemma isLE₂ (T : Triangle C) (hT : T ∈ distTriang C) (n : ℤ) (h₁ : t.IsLE T.obj₁ n)
     (h₃ : t.IsLE T.obj₃ n) : t.IsLE T.obj₂ n := by
-  rw [t.isLE_iff_orthogonal n (n+1) rfl]
+  rw [t.isLE_iff_orthogonal n (n + 1) rfl]
   intro Y f hY
   obtain ⟨f', hf'⟩ := Triangle.yoneda_exact₂ _ hT f
-    (t.zero _ n (n + 1) (by lia) )
+    (t.zero _ n (n + 1) (by lia))
   rw [hf', t.zero f' n (n + 1) (by lia), comp_zero]
 
 lemma isGE₂ (T : Triangle C) (hT : T ∈ distTriang C) (n : ℤ) (h₁ : t.IsGE T.obj₁ n)
@@ -850,7 +850,7 @@ instance (a b : ℤ) : IsIso (t.truncGELTToLTGE a b) := by
     have eq : u₁₂ ≫ u₂₃ = u₁₃ := by simp [u₁₂, u₂₃, u₁₃]
     have H := someOctahedron eq (t.triangleLTLTGELT_distinguished a b h X)
       (t.triangleLTGE_distinguished b X) (t.triangleLTGE_distinguished a X)
-    let m₁ : (t.truncGELT a b).obj X ⟶  _ := H.m₁
+    let m₁ : (t.truncGELT a b).obj X ⟶ _ := H.m₁
     have : IsIso ((t.truncLT b).map H.m₁) :=
       t.isIso₁_truncLT_map_of_isGE _ H.mem b (by dsimp; infer_instance)
     have eq' : t.liftTruncLT m₁ (b - 1) b (by lia) = (t.truncGELTToLTGE a b).app X :=

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -560,7 +560,7 @@ lemma eq_bouquet_of_subsingleton (hv : v ∈ V(G)) (hss : V(G).Subsingleton) :
   refine Graph.ext_inc (by simpa) fun e x ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · simp [← mem_singleton_iff, ← hrw, h.edge_mem, h.vertex_mem]
   simp only [bouquet_inc] at h
-  obtain ⟨z,w, hzw⟩ := exists_isLink_of_mem_edgeSet h.1
+  obtain ⟨z, w, hzw⟩ := exists_isLink_of_mem_edgeSet h.1
   rw [h.2, ← show z = v from (show z ∈ {v} from hrw ▸ hzw.left_mem)]
   exact hzw.inc_left
 

--- a/Mathlib/Combinatorics/Graph/Subgraph.lean
+++ b/Mathlib/Combinatorics/Graph/Subgraph.lean
@@ -302,7 +302,7 @@ lemma mk' (hHG : H ≤ G) (hclosed : ∀ ⦃e x⦄, G.Inc e x → x ∈ V(H) →
   closed _ _ he hx := hclosed he hx
 
 protected lemma trans (h₁ : G ≤c G₁) (h₂ : G₁ ≤c G₂) : G ≤c G₂ :=
-  mk' (h₁.le.trans h₂.le) fun _ _ h hx ↦  h₁.closed (h.of_compatible (Compatible.of_ge h₂.le)
+  mk' (h₁.le.trans h₂.le) fun _ _ h hx ↦ h₁.closed (h.of_compatible (Compatible.of_ge h₂.le)
     (h₂.closed h (h₁.vertexSet_mono hx))) hx
 
 instance : IsPartialOrder (Graph α β) (· ≤c ·) where
@@ -337,7 +337,7 @@ lemma mem_iff_of_adj (hxy : G.Adj x y) (hHG : H ≤c G) : x ∈ V(H) ↔ y ∈ V
   hHG.mem_iff_of_isLink hxy.choose_spec
 
 lemma anti_right (hHG₁ : H ≤ G₁) (hG₁ : G₁ ≤ G) (hHG : H ≤c G) : H ≤c G₁ :=
-  mk' hHG₁ fun  _ _ he hx ↦ hHG.inc_congr hx |>.mpr (he.mono hG₁) |>.edge_mem
+  mk' hHG₁ fun _ _ he hx ↦ hHG.inc_congr hx |>.mpr (he.mono hG₁) |>.edge_mem
 
 end IsClosedSubgraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -622,7 +622,7 @@ lemma disjoint_verts_iff_disjoint {H H' : Subgraph G} :
     · grind [verts_bot]
     · exact ⟨(hdisj hsub₀ hsub₁ <| M'.edge_vert · :), False.elim⟩
   · intro hdisj S h₀ h₁ v hvS
-    let M' : Subgraph G := {verts := {v}, Adj := ⊥, adj_sub := by simp, edge_vert := by simp}
+    let M' : Subgraph G := { verts := {v}, Adj := ⊥, adj_sub := by simp, edge_vert := by simp }
     have hle {M : Subgraph G} (h : v ∈ M.verts) : M' ≤ M := by constructor <;> simp [h, M']
     exact hdisj (hle <| h₀ hvS) (hle <| h₁ hvS) |>.left <| Set.mem_singleton v
 

--- a/Mathlib/Data/Finsupp/Fin.lean
+++ b/Mathlib/Data/Finsupp/Fin.lean
@@ -69,7 +69,7 @@ lemma cons_zero_eq_single_zero : cons y (0 : Fin n →₀ M) = single 0 y := by
   ext j
   cases j using Fin.cases <;> simp
 
-lemma cons_zero_single_eq_single_succ : cons 0 (single i y) = single i.succ y :=  by
+lemma cons_zero_single_eq_single_succ : cons 0 (single i y) = single i.succ y := by
   ext j
   cases j using Fin.cases <;> simp [single_apply]
 

--- a/Mathlib/Data/Finsupp/Indicator.lean
+++ b/Mathlib/Data/Finsupp/Indicator.lean
@@ -80,12 +80,12 @@ theorem eq_indicator_iff {g : ι → α} :
     g = indicator s f ↔ g.support ⊆ s ∧ ∀ ⦃i⦄ (hi : i ∈ s), f i hi = g i := by
   classical
   suffices g.support ⊆ s ∧ (∀ i (hi : i ∈ s), f i hi = g i) ↔
-      (∀ i , if hi : i ∈ s then f i hi = g i else g i = 0) by
+      (∀ i, if hi : i ∈ s then f i hi = g i else g i = 0) by
     simp only [this, funext_iff, indicator_apply]
     grind
   rw [Set.subset_def, and_comm]
   have : (∀ (i : ι), if hi : i ∈ s then f i hi = g i else g i = 0) ↔
-      ((∀ (i : ι) (hi : i ∈ s),  f i hi = g i) ∧ ∀ i (hi : i ∉ s), g i = 0) := by grind
+      ((∀ (i : ι) (hi : i ∈ s), f i hi = g i) ∧ ∀ i (hi : i ∉ s), g i = 0) := by grind
   simp [this, not_imp_comm]
 
 theorem eq_indicator_self_iff {d : ι →₀ α} : (d = indicator s fun i _ ↦ d i) ↔ d.support ⊆ s := by

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -744,7 +744,7 @@ end Sub
 section Inv
 
 @[simp]
-theorem inv_mk {r : ℝ} (hr : 0 ≤ r) : (NNReal.mk r hr)⁻¹  = .mk (r⁻¹) (inv_nonneg.2 hr) := rfl
+theorem inv_mk {r : ℝ} (hr : 0 ≤ r) : (NNReal.mk r hr)⁻¹ = .mk (r⁻¹) (inv_nonneg.2 hr) := rfl
 
 @[simp]
 theorem inv_le {r p : ℝ≥0} (h : r ≠ 0) : r⁻¹ ≤ p ↔ 1 ≤ r * p := by

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -434,7 +434,7 @@ theorem multinomial_cons (x : ℕ) (l : List ℕ) :
   congr 1
   · congr
     exact List.toFinsupp_sum (x :: l)
-  let succEmb : ℕ ↪ ℕ :=  { toFun := Nat.succ, inj' := Nat.succ_injective }
+  let succEmb : ℕ ↪ ℕ := { toFun := Nat.succ, inj' := Nat.succ_injective }
   simp only [toFinsupp_cons_eq_single_add_embDomain, Finsupp.multinomial_eq]
   have : (Finsupp.single 0 x + l.toFinsupp.embDomain succEmb).update 0 0 =
     (l.toFinsupp.embDomain succEmb).update 0 0 := by

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
@@ -69,7 +69,7 @@ theorem recF_eq {α : TypeVec n} {β : Type u} (g : F (α.append1 β) → β) (a
 set_option backward.isDefEq.respectTransparency false in
 theorem recF_eq' {α : TypeVec n} {β : Type u} (g : F (α.append1 β) → β) (x : q.P.W α) :
     recF g x = g (abs (appendFun id (recF g) <$$> q.P.wDest' x)) := by
-  induction x using  q.P.wCases
+  induction x using q.P.wCases
   case ih a f' f =>
     rw [recF_eq, q.P.wDest'_wMk, MvPFunctor.map_eq, appendFun_comp_splitFun, TypeVec.id_comp]
 

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -246,7 +246,7 @@ theorem elim_injective {γ : Sort*} {f : α → γ} {g : β → γ} :
 @[simp]
 theorem elim_injective' {γ : Sort*} {f : α → γ} :
     Injective (Sum.elim f : (β → γ) → (α ⊕ β → γ)) :=
-  fun g₁ g₂ hg ↦  funext fun b ↦ by simpa using congr_fun hg (Sum.inr b)
+  fun g₁ g₂ hg ↦ funext fun b ↦ by simpa using congr_fun hg (Sum.inr b)
 
 @[simp]
 theorem map_injective {f : α → γ} {g : β → δ} :

--- a/Mathlib/FieldTheory/RatFunc/IntermediateField.lean
+++ b/Mathlib/FieldTheory/RatFunc/IntermediateField.lean
@@ -164,7 +164,7 @@ theorem finrank_eq_max_natDegree :
   by_cases hf : ∃ c, f = C c
   · obtain ⟨c, rfl⟩ := hf
     rw [adjoin_simple_eq_bot_iff.mpr (show C c ∈ ⊥ from ⟨c, rfl⟩), finrank_bot',
-      Module.finrank_of_not_finite fun H ↦  Algebra.transcendental_iff_not_isAlgebraic.mp
+      Module.finrank_of_not_finite fun H ↦ Algebra.transcendental_iff_not_isAlgebraic.mp
       transcendental <| Algebra.IsAlgebraic.of_finite K K⟮X⟯]
     simp
   rw [← (IntermediateField.adjoinXEquiv K⟮f⟯).toLinearEquiv.finrank_eq,

--- a/Mathlib/FieldTheory/RatFunc/Luroth.lean
+++ b/Mathlib/FieldTheory/RatFunc/Luroth.lean
@@ -93,7 +93,7 @@ public lemma generator_mem : generator E ∈ E := by
   by_cases h : E = ⊥
   · rw [generator_eq_zero h]
     exact E.zero_mem
-  · rw [generator_eq_coeff h,]
+  · rw [generator_eq_coeff h]
     exact SetLike.coe_mem _
 
 public lemma generator_spec (h : E ≠ ⊥) : generator E ∉ (algebraMap K K⟮X⟯).range := by
@@ -174,7 +174,7 @@ lemma C_c_mul_φ (h : E ≠ ⊥) :
   conv =>
     enter [1, 2]
     rw [← Polynomial.smul_eq_C_mul, algebraMap_smul, ← Φ'_map, eq_C_content_mul_primPart (Φ' E)]
-  rw [Polynomial.map_mul, map_C, ← mul_assoc, ← C_mul, inv_mul_cancel₀,  map_one, one_mul]
+  rw [Polynomial.map_mul, map_C, ← mul_assoc, ← C_mul, inv_mul_cancel₀, map_one, one_mul]
   · rw [ne_eq, FaithfulSMul.algebraMap_eq_zero_iff, content_eq_zero_iff]
     exact Φ'_ne_zero h
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -368,7 +368,7 @@ inclusion into a larger affine subspace `S₂` is cospherical. -/
 theorem Cospherical.inclusion_iff {S₁ S₂ : AffineSubspace ℝ P} [Nonempty S₁] {ps : Set S₁}
     [S₁.direction.HasOrthogonalProjection] [S₂.direction.HasOrthogonalProjection] (hS : S₁ ≤ S₂) :
     Cospherical (AffineSubspace.inclusion hS '' ps) ↔ Cospherical ps := by
-  haveI : Nonempty S₂ := by obtain ⟨p⟩ := ‹Nonempty S₁›;exact ⟨⟨p, hS p.property⟩⟩
+  haveI : Nonempty S₂ := by obtain ⟨p⟩ := ‹Nonempty S₁›; exact ⟨⟨p, hS p.property⟩⟩
   simp [(Cospherical.subtype_val_iff (S := S₂) (ps := AffineSubspace.inclusion hS '' ps)).symm,
     Set.image_image]
 

--- a/Mathlib/Geometry/Euclidean/Volume/Measure.lean
+++ b/Mathlib/Geometry/Euclidean/Volume/Measure.lean
@@ -73,7 +73,7 @@ scoped[MeasureTheory] notation "μHE[" d "]" => MeasureTheory.Measure.euclideanH
 $\pi^{d/2} / (2^d \Gamma (d/2+1))$. -/
 proof_wanted MeasureTheory.Measure.addHaarScalarFactor_hausdorffMeasure_eq (d : ℕ) :
     addHaarScalarFactor (volume : Measure (EuclideanSpace ℝ (Fin d))) μH[d] =
-    volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) 1) / volume (Metric.ball (0 : Fin d -> ℝ) 1)
+    volume (Metric.ball (0 : EuclideanSpace ℝ (Fin d)) 1) / volume (Metric.ball (0 : Fin d → ℝ) 1)
 
 theorem MeasureTheory.Measure.euclideanHausdorffMeasure_def (d : ℕ) :
     (μHE[d] : Measure X) =
@@ -302,7 +302,7 @@ theorem AffineSubspace.euclideanHausdorffMeasure_eq_lintegral (s : AffineSubspac
   have hinter : t ∩ (mk' (x +ᵥ p).val s.directionᗮ) = Subtype.val '' u := by
     ext x
     simp [u]
-  have hxp: (x +ᵥ p).val ∈ mk' (x +ᵥ p).val s.directionᗮ := by simp
+  have hxp : (x +ᵥ p).val ∈ mk' (x +ᵥ p).val s.directionᗮ := by simp
   have hrank : finrank ℝ s.directionᗮ = finrank ℝ (mk' (x +ᵥ p).val s.directionᗮ).direction := by
     rw [direction_mk']
   rw [IsometryEquiv.vaddConst_apply, hinter, euclideanHausdorffMeasure_coe_image, hrank,

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -134,8 +134,8 @@ protected theorem ContMDiffWithinAt.mfderivWithin {x₀ : N} {f : N → M → M'
     · exact UniqueMDiffOn.uniqueDiffOn_target_inter h'u (g x₀)
   -- reformulate the previous point as `C^n` in the manifold sense (but still for a map between
   -- vector spaces)
-  have : CMDiffAt[t'] m (
-      fun x ↦ fderivWithin 𝕜 (extChartAt I' (f x₀ (g x₀)) ∘ f x ∘ (extChartAt I (g x₀)).symm)
+  have : CMDiffAt[t'] m
+      (fun x ↦ fderivWithin 𝕜 (extChartAt I' (f x₀ (g x₀)) ∘ f x ∘ (extChartAt I (g x₀)).symm)
       ((extChartAt I (g x₀)).target ∩ (extChartAt I (g x₀)).symm ⁻¹' u)
         (extChartAt I (g x₀) (g x))) x₀ := by
     simp_rw [contMDiffWithinAt_iff_source (x := x₀),

--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -277,7 +277,7 @@ lemma HasMFDerivAt.smul
     letI g'_ : TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, V) ((f • g) x) :=
       (fromTangentSpace _).symm.toContinuousLinearMap ∘L g'
     -- canonically identify `g x` with a linear map into a tangent space at `(f • g) x`
-    letI gx :  𝕜 →L[𝕜] TangentSpace 𝓘(𝕜, V) ((f • g) x) :=
+    letI gx : 𝕜 →L[𝕜] TangentSpace 𝓘(𝕜, V) ((f • g) x) :=
       toSpanSingleton 𝕜 ((fromTangentSpace _).symm (g x))
     -- now the main statement typechecks
     HasMFDerivAt% (f • g) x (f x • g'_ + gx ∘L f') := by

--- a/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/CovariantDerivative/Basic.lean
@@ -249,7 +249,7 @@ lemma affine_combination (hcov : IsCovariantDerivativeOn F cov s)
 lemma _root_.ContMDiffCovariantDerivativeOn.affine_combination [IsManifold I 1 M]
     [VectorBundle 𝕜 F V]
     {cov cov' : (Π x : M, V x) → (Π x : M, TangentSpace I x →L[𝕜] V x)}
-    {u: Set M} {f : M → 𝕜} {n : WithTop ℕ∞} (hf : CMDiff[u] n f)
+    {u : Set M} {f : M → 𝕜} {n : WithTop ℕ∞} (hf : CMDiff[u] n f)
     (Hcov : ContMDiffCovariantDerivativeOn (F := F) n cov u)
     (Hcov' : ContMDiffCovariantDerivativeOn (F := F) n cov' u) :
     ContMDiffCovariantDerivativeOn F n (fun σ ↦ (f • (cov σ)) + (1 - f) • (cov' σ)) u where

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -135,7 +135,7 @@ variable (e e' : Trivialization F (π F E)) [MemTrivializationAtlas e] [MemTrivi
 variable {IB}
 
 theorem mdifferentiableOn_coordChangeL :
-    MDiff[e.baseSet ∩ e'.baseSet] (fun b : B ↦ (e.coordChangeL 𝕜 e' b : F →L[𝕜] F))  :=
+    MDiff[e.baseSet ∩ e'.baseSet] (fun b : B ↦ (e.coordChangeL 𝕜 e' b : F →L[𝕜] F)) :=
   (contMDiffOn_coordChangeL e e').mdifferentiableOn one_ne_zero
 
 theorem mdifferentiableOn_symm_coordChangeL :

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tensoriality.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tensoriality.lean
@@ -98,7 +98,6 @@ protected theorem «local» (hΦ : TensorialAt I F Φ x) {σ σ' : Π x : M, V x
 
 variable [VectorBundle 𝕜 F V] [VectorBundle 𝕜 F' V']
 
-set_option linter.style.whitespace false in -- linter does not recognise manual alignment
 /-- A tensorial operation on sections of a vector bundle respects zero (since it respects scalar
 multiplication). -/
 theorem zero (hΦ : TensorialAt I F Φ x) : Φ 0 = 0 := by

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tensoriality.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tensoriality.lean
@@ -98,8 +98,9 @@ protected theorem «local» (hΦ : TensorialAt I F Φ x) {σ σ' : Π x : M, V x
 
 variable [VectorBundle 𝕜 F V] [VectorBundle 𝕜 F' V']
 
+set_option linter.style.whitespace false in -- linter does not recognise manual alignment
 /-- A tensorial operation on sections of a vector bundle respects zero (since it respects scalar
-  multiplication). -/
+multiplication). -/
 theorem zero (hΦ : TensorialAt I F Φ x) : Φ 0 = 0 := by
   calc
     Φ 0 = Φ ((0 : M → 𝕜) • (0 : Π x, V x)) := by simp

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -682,7 +682,7 @@ lemma mpullbackWithin_mlieBracketWithin_of_isSymmSndFDerivWithinAt
   obtain ⟨u, u_open, x₀u, ut, maps_u, u_smooth⟩ :
       ∃ u, IsOpen u ∧ x₀ ∈ u ∧ s ∩ u ⊆ f ⁻¹' t ∧
         s ∩ u ⊆ f ⁻¹' (extChartAt I' (f x₀)).source ∧ CMDiff[s ∩ u] 2 f := by
-    obtain ⟨u, u_open, x₀u, hu⟩ : ∃ u, IsOpen u ∧ x₀ ∈ u ∧ CMDiff[insert x₀ s ∩ u] 2 f  :=
+    obtain ⟨u, u_open, x₀u, hu⟩ : ∃ u, IsOpen u ∧ x₀ ∈ u ∧ CMDiff[insert x₀ s ∩ u] 2 f :=
       hf.contMDiffOn' le_rfl (by simp)
     have : f ⁻¹' (extChartAt I' (f x₀)).source ∈ 𝓝[s] x₀ :=
       hf.continuousWithinAt.preimage_mem_nhdsWithin (extChartAt_source_mem_nhds (f x₀))

--- a/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/Pullback.lean
@@ -325,7 +325,7 @@ lemma _root_.MDifferentiableWithinAt.mpullbackWithin_vectorField_inter_of_eq
     (hV : MDiffAt[t] (T% V) y₀) (hf : CMDiffAt[s] n f x₀)
     (hf' : (mfderiv[s] f x₀).IsInvertible)
     (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : 2 ≤ n) (h : y₀ = f x₀) :
-    MDiffAt[s ∩ f⁻¹' t] (T% (mpullbackWithin I I' f V s)) x₀ := by
+    MDiffAt[s ∩ f ⁻¹' t] (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst h
   exact hV.mpullbackWithin_vectorField_inter hf hf' hx₀ hs hmn
 
@@ -335,7 +335,7 @@ protected lemma _root_.MDifferentiableOn.mpullbackWithin_vectorField_inter
     (hV : MDiff[t] (T% V)) (hf : CMDiff[s] n f)
     (hf' : ∀ x ∈ s ∩ f ⁻¹' t, (mfderiv[s] f x).IsInvertible)
     (hs : UniqueMDiffOn I s) (hmn : 2 ≤ n) :
-    MDiff[(s ∩ f ⁻¹' t)] (T% (mpullbackWithin I I' f V s))  :=
+    MDiff[(s ∩ f ⁻¹' t)] (T% (mpullbackWithin I I' f V s)) :=
   fun _ hx₀ ↦ MDifferentiableWithinAt.mpullbackWithin_vectorField_inter
     (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
 
@@ -428,7 +428,7 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
   have : CMDiffAt[s] m
       (ContinuousLinearMap.inverse ∘ (fun (x : M) ↦ ContinuousLinearMap.inCoordinates
         E (TangentSpace I (M := M)) E' (TangentSpace I' (M := M'))
-        x₀ x (f x₀) (f x) (mfderiv[s]f x))) x₀ := by
+        x₀ x (f x₀) (f x) (mfderiv[s] f x))) x₀ := by
     apply ContMDiffAt.comp_contMDiffWithinAt _ _ this
     apply ContDiffAt.contMDiffAt
     apply IsInvertible.contDiffAt_map_inverse
@@ -455,7 +455,7 @@ protected lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter
 lemma _root_.ContMDiffWithinAt.mpullbackWithin_vectorField_inter_of_eq
     (hV : CMDiffAt[t] m (T% V) y₀) (hf : CMDiffAt[s] n f x₀) (hf' : (mfderiv[s] f x₀).IsInvertible)
     (hx₀ : x₀ ∈ s) (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) (h : f x₀ = y₀) :
-    CMDiffAt[s ∩ f⁻¹' t] m (T% (mpullbackWithin I I' f V s)) x₀ := by
+    CMDiffAt[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s)) x₀ := by
   subst h
   exact ContMDiffWithinAt.mpullbackWithin_vectorField_inter hV hf hf' hx₀ hs hmn
 
@@ -543,7 +543,7 @@ protected lemma _root_.ContMDiffOn.mpullbackWithin_vectorField_inter
     (hV : CMDiff[t] m (T% V)) (hf : CMDiff[s] n f)
     (hf' : ∀ x ∈ s ∩ f ⁻¹' t, (mfderiv[s] f x).IsInvertible)
     (hs : UniqueMDiffOn I s) (hmn : m + 1 ≤ n) :
-    CMDiff[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s))  :=
+    CMDiff[s ∩ f ⁻¹' t] m (T% (mpullbackWithin I I' f V s)) :=
   fun _ hx₀ ↦ ContMDiffWithinAt.mpullbackWithin_vectorField_inter
     (hV _ hx₀.2) (hf _ hx₀.1) (hf' _ hx₀) hx₀.1 hs hmn
 

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -226,7 +226,7 @@ lemma iUnion_image_mk_leftRel {H K : Subgroup G} :
   rw [Set.iUnion_eq_univ_iff]
   intro x
   obtain ⟨y, hy⟩ := exists_rep x
-  have ⟨i, hi⟩ : ∃ i : Quotient H K, y ∈ doubleCoset (out i) H K  := by
+  have ⟨i, hi⟩ : ∃ i : Quotient H K, y ∈ doubleCoset (out i) H K := by
     contrapose cover
     exact (Set.ne_univ_iff_exists_notMem _).mpr ⟨y, by simpa using cover⟩
   exact ⟨i, y, hi, hy⟩
@@ -237,7 +237,7 @@ lemma iUnion_image_mk_rightRel {H K : Subgroup G} :
   rw [Set.iUnion_eq_univ_iff]
   intro x
   obtain ⟨y, hy⟩ := exists_rep x
-  have ⟨i, hi⟩ : ∃ i : Quotient H K, y ∈ doubleCoset (out i) H K  := by
+  have ⟨i, hi⟩ : ∃ i : Quotient H K, y ∈ doubleCoset (out i) H K := by
     contrapose cover
     exact (Set.ne_univ_iff_exists_notMem _).mpr ⟨y, by simpa using cover⟩
   exact ⟨i, y, hi, hy⟩
@@ -254,7 +254,7 @@ lemma iUnion_finset_leftRel_eq_univ_of_leftRel {H K : Subgroup G} {t : Finset (Q
   contrapose! hx
   simp only [Set.mem_iUnion, exists_prop]
   refine ⟨y, hy, ?_⟩
-  rw [← doubleCoset_eq_of_mem hq,  mem_doubleCoset]
+  rw [← doubleCoset_eq_of_mem hq, mem_doubleCoset]
   obtain ⟨a', ha'⟩ := Quotient.eq.mp hx
   exact ⟨1, one_mem H, MulOpposite.unop a'⁻¹, Subgroup.mem_op.mp (by simp), by simpa
     using (eq_mul_inv_of_mul_eq ha')⟩

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -47,7 +47,7 @@ protected theorem map {N : Subgroup G} (hN : IsNormalClosureFG N)
     {f : G →* H} (hf : Function.Surjective f) : (N.map f).IsNormalClosureFG := by
   obtain ⟨S, hSfinite, hSclosure⟩ := hN
   refine ⟨f '' S, hSfinite.image _, ?_⟩
-  rw [ ← hSclosure, Subgroup.map_normalClosure _ _ hf]
+  rw [← hSclosure, Subgroup.map_normalClosure _ _ hf]
 
 end Subgroup.IsNormalClosureFG
 

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -962,7 +962,7 @@ def mulEquivIntOfUnique [Unique α] : FreeGroup α ≃* Multiplicative ℤ where
   invFun := equivIntOfUnique.symm ∘ Multiplicative.toAdd
   left_inv _ := by simp
   right_inv _ := by simp
-  map_mul' _ _  := by simp [equivIntOfUnique]
+  map_mul' _ _ := by simp [equivIntOfUnique]
 
 /-- A free group over one generator is an instance of a cyclic group. -/
 instance [Unique α] : IsCyclic (FreeGroup α) :=

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -799,14 +799,14 @@ instance [AddMonoid A] [DistribMulAction M A] [AddMonoid B] [DistribMulAction N 
 def _root_.DistribMulActionHom.comp [AddMonoid A] [DistribMulAction M A]
   [AddMonoid B] [DistribMulAction N B] [AddMonoid C] [DistribMulAction P C]
   (g : B →ₑ+[ψ] C) (f : A →ₑ+[φ] B)
-    [κ : MonoidHom.CompTriple φ ψ χ] :  A →ₑ+[χ] C :=
+    [κ : MonoidHom.CompTriple φ ψ χ] : A →ₑ+[χ] C :=
   { MulActionHom.comp (g : B →ₑ[ψ] C) (f : A →ₑ[φ] B),
     AddMonoidHom.comp (g : B →+ C) (f : A →+ B) with }
 
 /-- Composition of two equivariant monoid homomorphisms. -/
 @[to_additive existing (dont_translate := M N P)]
 def comp (g : B →ₑ*[ψ] C) (f : A →ₑ*[φ] B)
-    [κ : MonoidHom.CompTriple φ ψ χ] :  A →ₑ*[χ] C :=
+    [κ : MonoidHom.CompTriple φ ψ χ] : A →ₑ*[χ] C :=
   { MulActionHom.comp (g : B →ₑ[ψ] C) (f : A →ₑ[φ] B),
     MonoidHom.comp (g : B →* C) (f : A →* B) with }
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Centroid.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Centroid.lean
@@ -303,14 +303,14 @@ theorem faceOppositeCentroid_vsub_faceOppositeCentroid [CharZero k] (s : Affine.
   rw [faceOppositeCentroid_eq_sum_vsub_vadd s i, faceOppositeCentroid_eq_sum_vsub_vadd s j,
     vadd_vsub_vadd_comm _ _ (s.points i) (s.points j)]
   have h1 (i : Fin (n + 1)) : ∑ x, (s.points x -ᵥ s.points i) =
-      ∑ x, (s.points x -ᵥ s.points 0 - (s.points i-ᵥ s.points 0)) := by
+      ∑ x, (s.points x -ᵥ s.points 0 - (s.points i -ᵥ s.points 0)) := by
     apply sum_congr rfl
     simp
   simp_rw [h1 i, h1 j, sum_sub_distrib]
   rw [smul_sub, smul_sub, sub_sub_sub_cancel_left, ← smul_sub, ← sum_sub_distrib,
     vsub_sub_vsub_cancel_right, sum_const, card_univ, Fintype.card_fin]
   have : (s.points i -ᵥ s.points j) = -(s.points j -ᵥ s.points i) := by simp
-  rw [this, ← sub_eq_add_neg, add_smul, sub_eq_iff_eq_add , one_smul, smul_add, add_comm]
+  rw [this, ← sub_eq_add_neg, add_smul, sub_eq_iff_eq_add, one_smul, smul_add, add_comm]
   have : (n : k)⁻¹ • n • (s.points j -ᵥ s.points i) =
       (n : k)⁻¹ • (n : k) • (s.points j -ᵥ s.points i) := by
     norm_cast0

--- a/Mathlib/LinearAlgebra/Center.lean
+++ b/Mathlib/LinearAlgebra/Center.lean
@@ -175,7 +175,7 @@ theorem exists_mem_center_apply_eq_smul_of_forall_notLinearIndependent_of_basis
     rw [commute_iff_eq, h' i j (Ne.symm hij), feq i j, feq i i]
     simp
   refine ⟨⟨b.coord i (f (b i)), ?_⟩, ?_⟩
-  · simpa  [Subring.mem_center_iff, commute_iff_eq, eq_comm] using ha
+  · simpa [Subring.mem_center_iff, commute_iff_eq, eq_comm] using ha
   apply b.ext
   simpa only [smul_apply, End.one_apply, Subring.smul_def] using feq i
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -260,7 +260,7 @@ theorem ι_mul_ι_comm (a b : M) :
 theorem mul_ι_mul_ι_mul_comm (x : CliffordAlgebra Q) (a b : M) (y : CliffordAlgebra Q) :
     (x * ι Q a) * (ι Q b * y) =
       algebraMap R _ (QuadraticMap.polar Q a b) * (x * y) - (x * ι Q b) * (ι Q a * y) := by
-  rw [mul_assoc, ← mul_assoc _ _ y, ι_mul_ι_comm, sub_mul, mul_sub, Algebra.left_comm,  mul_assoc,
+  rw [mul_assoc, ← mul_assoc _ _ y, ι_mul_ι_comm, sub_mul, mul_sub, Algebra.left_comm, mul_assoc,
     mul_assoc]
 
 section isOrtho

--- a/Mathlib/LinearAlgebra/FixedSubmodule.lean
+++ b/Mathlib/LinearAlgebra/FixedSubmodule.lean
@@ -57,7 +57,7 @@ theorem fixedSubmodule_inf_fixedSubmodule_le_comp (f g : V →ₗ[R] V) :
   intro; simp_all
 
 theorem fixedSubmodule_comp_inf_fixedSubmodule_le (f g : V →ₗ[R] V) :
-    (f ∘ₗ g).fixedSubmodule ⊓ g.fixedSubmodule ≤ f.fixedSubmodule := by  intro; aesop
+    (f ∘ₗ g).fixedSubmodule ⊓ g.fixedSubmodule ≤ f.fixedSubmodule := by intro; aesop
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Decomposition.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Decomposition.lean
@@ -30,7 +30,7 @@ section Decomposition
 variable [Decomposition ℳ]
 
 instance Decomposition.baseChange : Decomposition fun i ↦ (ℳ i).baseChange S := by
-  refine .ofLinearMap _ (lmap (ℳ ·|>.toBaseChange S) ∘ₗ
+  refine .ofLinearMap _ (lmap (ℳ · |>.toBaseChange S) ∘ₗ
     (directSumRight R S S fun i ↦ ℳ i).toLinearMap ∘ₗ
     ((decomposeLinearEquiv ℳ).baseChange R S)) ?_ ?_
   · simp_rw [← comp_assoc]
@@ -43,7 +43,7 @@ instance Decomposition.baseChange : Decomposition fun i ↦ (ℳ i).baseChange S
     simp
 
 theorem toBaseChange_injective (i : ι) : Function.Injective ((ℳ i).toBaseChange S) := fun x y h ↦ by
-  have := (Function.Bijective.of_comp_iff (lmap (ℳ ·|>.toBaseChange S))
+  have := (Function.Bijective.of_comp_iff (lmap (ℳ · |>.toBaseChange S))
     (by rw [← LinearEquiv.coe_trans]; exact LinearEquiv.bijective _)).1
     (decompose (M := S ⊗[R] M) fun i ↦ (ℳ i).baseChange S).bijective
   refine of_injective (β := fun i ↦ S ⊗[R] ℳ i) i <| this.injective ?_

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/LebesgueBochner.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/LebesgueBochner.lean
@@ -34,7 +34,7 @@ variable {𝓧 : Type*}
 Lebesgue integrals respectively) agree almost everywhere. -/
 lemma toReal_condLExp (m : MeasurableSpace 𝓧) {m𝓧 : MeasurableSpace 𝓧} {μ : Measure 𝓧}
     {f : 𝓧 → ℝ≥0∞} (hf_meas : AEMeasurable f μ) (hf : ∫⁻ x, f x ∂μ ≠ ∞) :
-    (fun x ↦ (μ⁻[f | m] x).toReal) =ᵐ[μ] μ[fun x ↦ (f x).toReal | m] := by
+    (fun x ↦ (μ⁻[f|m] x).toReal) =ᵐ[μ] μ[fun x ↦ (f x).toReal | m] := by
   by_cases hm : m ≤ m𝓧
   swap; · simp [condLExp_of_not_le hm, condExp_of_not_le hm]; rfl
   by_cases hμ : SigmaFinite (μ.trim hm)

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/RadonNikodym.lean
@@ -86,7 +86,7 @@ See `rnDeriv_map_ae_eq_trim` for the same statement, but with a.e. equality with
 the trimmed measure `ν.trim hg.comap_le`. -/
 lemma rnDeriv_map [IsFiniteMeasure μ] (hμν : μ ≪ ν)
     {g : 𝓧 → 𝓨} (hg : Measurable g) [hσ : SigmaFinite (ν.map g)] :
-    (fun a ↦ (μ.map g).rnDeriv (ν.map g) (g a)) =ᵐ[ν] ν⁻[μ.rnDeriv ν | m𝓨.comap g] := by
+    (fun a ↦ (μ.map g).rnDeriv (ν.map g) (g a)) =ᵐ[ν] ν⁻[μ.rnDeriv ν|m𝓨.comap g] := by
   have : SigmaFinite ν := SigmaFinite.of_map _ hg.aemeasurable hσ
   have h_ne_top1 : ∀ᵐ x ∂ν, (μ.map g).rnDeriv (ν.map g) (g x) ≠ ∞ :=
     ae_of_ae_map hg.aemeasurable (Measure.rnDeriv_ne_top (μ.map g) (ν.map g))
@@ -107,7 +107,7 @@ See `rnDeriv_map` for the same statement, but with a.e. equality with respect to
 lemma rnDeriv_map_ae_eq_trim [IsFiniteMeasure μ] (hμν : μ ≪ ν)
     {g : 𝓧 → 𝓨} (hg : Measurable g) [SigmaFinite (ν.map g)] :
     (fun a ↦ (μ.map g).rnDeriv (ν.map g) (g a)) =ᵐ[ν.trim hg.comap_le]
-      ν⁻[μ.rnDeriv ν | m𝓨.comap g] := by
+      ν⁻[μ.rnDeriv ν|m𝓨.comap g] := by
   rw [StronglyMeasurable.ae_eq_trim_iff]
   · exact rnDeriv_map hμν hg
   · refine Measurable.stronglyMeasurable fun s hs ↦ ?_

--- a/Mathlib/MeasureTheory/Function/ConditionalLExpectation.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalLExpectation.lean
@@ -151,14 +151,14 @@ theorem lintegral_condLExp (P : Measure[mΩ₀] Ω) [hσ : SigmaFinite (P.trim h
     ∫⁻ ω, P⁻[X|mΩ] ω ∂P = ∫⁻ ω, X ω ∂P := by
   simpa [← setLIntegral_univ] using setLIntegral_condLExp _ _ _ .univ
 
-lemma condLExp_lt_top {f : Ω → ℝ≥0∞} (hf : ∫⁻ x, f x ∂P ≠ ∞) : ∀ᵐ x ∂P, P⁻[f | mΩ] x < ∞ := by
+lemma condLExp_lt_top {f : Ω → ℝ≥0∞} (hf : ∫⁻ x, f x ∂P ≠ ∞) : ∀ᵐ x ∂P, P⁻[f|mΩ] x < ∞ := by
   by_cases hm : mΩ ≤ mΩ₀
   swap; · simp [condLExp_of_not_le hm]
   by_cases hσ : SigmaFinite (P.trim hm)
   · exact ae_lt_top' (by fun_prop) (by rwa [lintegral_condLExp])
   · simp [condLExp_of_not_sigmaFinite hm hσ]
 
-lemma condLExp_ne_top {f : Ω → ℝ≥0∞} (hf : ∫⁻ x, f x ∂P ≠ ∞) : ∀ᵐ x ∂P, P⁻[f | mΩ] x ≠ ∞ := by
+lemma condLExp_ne_top {f : Ω → ℝ≥0∞} (hf : ∫⁻ x, f x ∂P ≠ ∞) : ∀ᵐ x ∂P, P⁻[f|mΩ] x ≠ ∞ := by
   filter_upwards [condLExp_lt_top hf] with x hx using hx.ne
 
 theorem ae_eq_condLExp₀ {P : Measure[mΩ₀] Ω} [hσ : SigmaFinite (P.trim hm)]

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -235,7 +235,7 @@ lemma integrable_norm_rpow_of_le [IsFiniteMeasure μ] {f : α → β} (hf : AESt
   rcases hq.eq_or_lt with (rfl | hq)
   · grind
   rw [← ENNReal.toReal_ofReal hp.le, integrable_norm_rpow_iff hf (by simp [hp]) (by simp)]
-  rw [← ENNReal.toReal_ofReal hq.le, integrable_norm_rpow_iff hf  (by simp [hq]) (by simp)] at hint
+  rw [← ENNReal.toReal_ofReal hq.le, integrable_norm_rpow_iff hf (by simp [hq]) (by simp)] at hint
   exact MemLp.mono_exponent hint (ENNReal.ofReal_le_ofReal hpq)
 
 lemma integrable_norm_pow_of_le [IsFiniteMeasure μ] {f : α → β} (hf : AEStronglyMeasurable f μ)

--- a/Mathlib/MeasureTheory/Integral/Bochner/SumMeasure.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/SumMeasure.lean
@@ -159,7 +159,7 @@ lemma integral_sum_dirac [FiniteDimensional ℝ E] (hc : ∀ i, c i ≠ ∞) :
 lemma hasSum_integral_sum_dirac [CompleteSpace E] (hc : ∀ i, c i ≠ ∞)
     (hf : Summable (fun i ↦ (c i).toReal * ‖f (x i)‖)) :
     HasSum (fun i ↦ (c i).toReal • f (x i))
-      (∫ x, f x ∂Measure.sum (fun i ↦ (c i) • .dirac (x i)))  := by
+      (∫ x, f x ∂Measure.sum (fun i ↦ (c i) • .dirac (x i))) := by
   simpa using hasSum_integral_measure (integrable_sum_dirac hc hf)
 
 /-- If the sequence `fun i ↦ (c i).toReal * ‖f (x i)‖` is summable, then

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -208,7 +208,7 @@ lemma mutuallySingular_of_disjoint (h : Disjoint μ ν) : μ ⟂ₘ ν := by
     conv =>
       -- this tweak is needed due to the known issue of `norm_cast` with numeric fractions
       enter [1, 1]
-      equals ((1:ℝ≥0) / (2:ℝ≥0)) => rfl
+      equals ((1 : ℝ≥0) / (2 : ℝ≥0)) => rfl
     norm_cast
     ring
   choose s hs₂ hs₃ using h'

--- a/Mathlib/ModelTheory/Topology/Types.lean
+++ b/Mathlib/ModelTheory/Topology/Types.lean
@@ -66,7 +66,7 @@ public instance : TotallySeparatedSpace (CompleteType T α) := by
     rwa [mem_compl_iff, mem_typesWith_iff, ← hφ, not_not]
   | inr h =>
     refine ⟨T.typesWith ∼φ, isClopen_typesWith _, h, ?_⟩
-    rwa [mem_compl_iff, mem_typesWith_iff, not_mem_iff, ← hφ, not_not, ←not_mem_iff]
+    rwa [mem_compl_iff, mem_typesWith_iff, not_mem_iff, ← hφ, not_not, ← not_mem_iff]
 
 
 end CompleteType

--- a/Mathlib/NumberTheory/Chebyshev.lean
+++ b/Mathlib/NumberTheory/Chebyshev.lean
@@ -346,7 +346,7 @@ theorem theta_eq_primeCounting_mul_log_sub_integral {x : ℝ} (hx : 2 ≤ x) :
     split_ifs with h <;> simp [a, h]
   rw [sum_mul_eq_sub_integral_mul₁ a (by simp [a, Nat.not_prime_zero])
     (by simp [a, Nat.not_prime_one]) _ (fun z ⟨hz, _⟩ ↦ (by fun_prop (disch := linarith))) ?hint,
-    ←intervalIntegral.integral_of_le hx]
+    ← intervalIntegral.integral_of_le hx]
   case hint =>
     rw [deriv_log']
     refine ContinuousOn.integrableOn_Icc ?_

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -608,7 +608,7 @@ lemma divisorsAntidiagonal_eq_prod_filter_of_le {n N : ℕ} (n_ne_zero : n ≠ 0
 
 /-- `Finset.antidiagonal k` embeds as a subset of `Nat.divisorsAntidiagonal (q ^ k)`. -/
 theorem antidiagonal_map_subset_divisorsAntidiagonal_pow {q : ℕ} (hq : 1 < q) (k : ℕ) :
-    letI ι : ℕ ↪ ℕ :=  ⟨fun k ↦ q ^ k, Nat.pow_right_injective hq⟩
+    letI ι : ℕ ↪ ℕ := ⟨fun k ↦ q ^ k, Nat.pow_right_injective hq⟩
     (Finset.antidiagonal k).map (.prodMap ι ι) ⊆ (q ^ k).divisorsAntidiagonal := by
   intro k hk
   obtain ⟨i, hi, rfl⟩ := Finset.mem_map.mp hk

--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -87,7 +87,7 @@ theorem deficient_one : Deficient 1 := by
 theorem deficient_two : Deficient 2 := by
   decide
 
-theorem deficient_three : Deficient 3 :=  by
+theorem deficient_three : Deficient 3 := by
   decide
 
 theorem not_abundant_zero : ¬ Abundant 0 := by

--- a/Mathlib/NumberTheory/Height/Basic.lean
+++ b/Mathlib/NumberTheory/Height/Basic.lean
@@ -398,7 +398,7 @@ lemma mulHeight_sumElim_zero_eq (x : ι → K) :
   have : Nonempty ι := .intro i
   have hx' : Sum.elim x (0 : ι' → K) ≠ 0 := ne_iff.mpr ⟨.inl i, by simpa using hi⟩
   rw [mulHeight_eq hx, mulHeight_eq hx']
-  have H (v : AbsoluteValue K ℝ) :  ⨆ j, v (Sum.elim x (0 : ι' → K) j) = ⨆ i, v (x i) := by
+  have H (v : AbsoluteValue K ℝ) : ⨆ j, v (Sum.elim x (0 : ι' → K) j) = ⨆ i, v (x i) := by
     refine le_antisymm ?_ <| ciSup_le fun i ↦ Finite.le_ciSup_of_le (.inl i) le_rfl
     refine ciSup_le fun j ↦ ?_
     cases j with
@@ -421,7 +421,7 @@ lemma mulHeight_eq_mulHeight_restrict_support (x : ι → K) :
     simp only [comp_apply]
     cases i with
     | inl val => simp [e]
-    | inr val => exact notMem_support.mp <| (Set.mem_compl_iff _ _ ).mp val.prop
+    | inr val => exact notMem_support.mp <| (Set.mem_compl_iff _ _).mp val.prop
   rw [← mulHeight_comp_equiv e, hx]
   exact mulHeight_sumElim_zero_eq ..
 

--- a/Mathlib/NumberTheory/Height/MvPolynomial.lean
+++ b/Mathlib/NumberTheory/Height/MvPolynomial.lean
@@ -536,7 +536,7 @@ namespace Height
 variable [AdmissibleAbsValues K]
 
 lemma mulHeight_mul_mulHeight {a b c d : K} (hab : ![a, b] ≠ 0) (hcd : ![c, d] ≠ 0) :
-    mulHeight ![a, b]* mulHeight ![c, d] = mulHeight ![a * c, a * d, b * c, b * d] := by
+    mulHeight ![a, b] * mulHeight ![c, d] = mulHeight ![a * c, a * d, b * c, b * d] := by
   simp only [← mulHeight_fun_mul_eq hab hcd]
   convert mulHeight_comp_equiv finProdFinEquiv _ with i
   fin_cases i <;> simp [finProdFinEquiv]
@@ -583,7 +583,7 @@ lemma mulHeight_sym2_ge :
   simp only [pow_one] at hC
   refine ⟨C, hC₀, fun hab hcd ↦ ?_⟩
   rw [mul_assoc, mulHeight_mul_mulHeight hab hcd]
-  convert hC p fun j ↦ ?H  with i
+  convert hC p fun j ↦ ?H with i
   case H => fin_cases j <;> simp [p, q, Fin.sum_univ_three] <;> ring
   fin_cases i <;> simp [p]
 

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -482,8 +482,8 @@ theorem abs_c_le_one (hz : z ∈ 𝒟) (hg : g • z ∈ 𝒟) : |g 1 0| ≤ 1 :
 
 /-- Classify cases when `z ∈ 𝒟` and `g • z ∈ 𝒟` such that `c = 0`. -/
 private lemma cases_c_zero (hz : z ∈ 𝒟) (hg : g • z ∈ 𝒟) (hc : g 1 0 = 0) :
-    ((g = T ∨ g = -T) ∧ z.re = -1/2) ∨
-    ((g = T⁻¹ ∨ g = -T⁻¹) ∧ z.re = 1/2) ∨
+    ((g = T ∨ g = -T) ∧ z.re = -1 / 2) ∨
+    ((g = T⁻¹ ∨ g = -T⁻¹) ∧ z.re = 1 / 2) ∨
     (g = 1 ∨ g = -1) := by
   wlog hd : 0 ≤ g 1 1
   · specialize this hz (g := -g) (SL_neg_smul g z ▸ hg) (by simpa using hc) ?_
@@ -613,7 +613,7 @@ private lemma case_c_one_d_neg_one (hz : z ∈ 𝒟) (hg : g • z ∈ 𝒟) (hg
     rw [coe_mul, coe_mul, coe_T_zpow, coe_S, ← zpow_neg_one, coe_T_zpow, mul_fin_two, mul_fin_two]
     ring_nf
     ext i j
-    fin_cases i <;> fin_cases j <;> [tauto ; skip ; tauto ; tauto]
+    fin_cases i <;> fin_cases j <;> [tauto; skip; tauto; tauto]
     simp [this]
     ring_nf
   have hnorm : ‖(z : ℂ) - 1‖ ≤ 1 := by
@@ -624,7 +624,7 @@ private lemma case_c_one_d_neg_one (hz : z ∈ 𝒟) (hg : g • z ∈ 𝒟) (hg
     simp [normSq]
     ring
   rw [this] at hnorm
-  obtain ⟨h, h'⟩ : normSq z = 1 ∧ z.re = 1/2 := by
+  obtain ⟨h, h'⟩ : normSq z = 1 ∧ z.re = 1 / 2 := by
     have : 1 ≤ normSq z := hz.1
     have : 0 ≤ -2 * z.re + 1 := by linarith [(le_abs_self _).trans hz.2]
     constructor <;> linarith
@@ -754,7 +754,7 @@ lemma stabilizer_ρ :
         rw [ne_eq, UpperHalfPlane.ext_iff, modular_S_smul, coe_mk, Complex.ext_iff]
         norm_num [ρ, ← pow_two, div_pow]
       grind [SL_neg_smul]
-    have neT : g ≠ T ∧ g ≠ -T ∧ g ≠ T⁻¹ ∧ g ≠ -T⁻¹:= by
+    have neT : g ≠ T ∧ g ≠ -T ∧ g ≠ T⁻¹ ∧ g ≠ -T⁻¹ := by
       have : T • ρ ≠ ρ := by
         rw [ne_eq, UpperHalfPlane.ext_iff, modular_T_smul, coe_vadd]
         norm_num

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/Summable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/Summable.lean
@@ -243,8 +243,8 @@ lemma tendsto_tsum_one_div_linear_sub_succ_eq :
     Tendsto (fun N : ℕ+ ↦ ∑ n ∈ Ico (-N : ℤ) N,
     ∑' m : ℤ, (1 / ((m : ℂ) * z + n) - 1 / (m * z + n + 1))) atTop (𝓝 (-2 * π * I / z)) := by
   have (N : ℕ+) :
-      ∑ n ∈ Ico (-N : ℤ) N, ∑' m : ℤ , (1 / ((m : ℂ) * z + n) - 1 / (m * z + n + 1))
-      = ∑' m : ℤ , ∑ n ∈ Ico (-N : ℤ) N, (1 / ((m : ℂ) * z + n) - 1 / (m * z + n + 1)) := by
+      ∑ n ∈ Ico (-N : ℤ) N, ∑' m : ℤ, (1 / ((m : ℂ) * z + n) - 1 / (m * z + n + 1))
+      = ∑' m : ℤ, ∑ n ∈ Ico (-N : ℤ) N, (1 / ((m : ℂ) * z + n) - 1 / (m * z + n + 1)) := by
     rw [Summable.tsum_finsetSum (fun i hi ↦ ?_)]
     apply (summable_left_one_div_linear_sub_one_div_linear z i (i + 1)).congr
     grind

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/Transform.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/E2/Transform.lean
@@ -76,10 +76,10 @@ namespace EisensteinSeries
 
 /-- This is an auxiliary correction term for proving how E2 transforms. It allows us to work with
 nicer indexing sets for our infinite sums. The key is the `aux_identity` below. -/
-def δ (x : Fin 2 → ℤ) : ℂ := if x = ![0,0] then 1 else if x = ![0, -1] then 2 else 0
+def δ (x : Fin 2 → ℤ) : ℂ := if x = ![0, 0] then 1 else if x = ![0, -1] then 2 else 0
 
 @[simp]
-lemma δ_eq : δ ![0,0] = 1 := by simp [δ]
+lemma δ_eq : δ ![0, 0] = 1 := by simp [δ]
 
 @[simp]
 lemma δ_eq_two : δ ![0, -1] = 2 := by simp [δ]
@@ -111,7 +111,7 @@ lemma aux_identity (z : ℍ) (b n : ℤ) : ((b : ℂ) * z + n + 1)⁻¹ * (((b :
   · simp only [not_and] at h
     by_cases hb : b = 0
     · by_cases hn : n = -1
-      · simp [hb,  hn, δ_eq_two]
+      · simp [hb, hn, δ_eq_two]
         ring
       · have hn0 : (n : ℂ) ≠ 0 := by aesop
         have hn1 : (n : ℂ) + 1 ≠ 0 := by norm_cast; grind
@@ -186,13 +186,13 @@ section transform
 
 /-- This is the key identity for how `G2` transforms under the slash action by `S`. -/
 lemma G2_S_transform (z : ℍ) : G2 z = ((z : ℂ) ^ 2)⁻¹ * G2 (S • z) - -2 * π * I / z := by
-  rw [G2_S_action_eq_tsum_G2Term, G2_eq_tsum_G2Term z , ← tsum_G2Term_eq_tsum',
+  rw [G2_S_action_eq_tsum_G2Term, G2_eq_tsum_G2Term z, ← tsum_G2Term_eq_tsum',
   tsum_G2Term_eq_tsum]
 
 lemma G2_T_transform : G2 ∣[(2 : ℤ)] T = G2 := by
   ext z
   simp_rw [SL_slash_def, modular_T_smul z]
-  simp [G2_eq_tsum_cexp,  T, denom_apply,  ← exp_periodic.nat_mul 1 (2 * π * I * z)]
+  simp [G2_eq_tsum_cexp, T, denom_apply, ← exp_periodic.nat_mul 1 (2 * π * I * z)]
   grind
 
 lemma G2_slash_action (γ : SL(2, ℤ)) : G2 ∣[(2 : ℤ)] γ = G2 - D2 γ := by
@@ -212,7 +212,7 @@ lemma G2_slash_action (γ : SL(2, ℤ)) : G2 ∣[(2 : ℤ)] γ = G2 - D2 γ := b
       rw [D2_mul, SlashAction.slash_mul, ig, sub_eq_add_neg, SlashAction.add_slash, ih]
       grind [SlashAction.neg_slash, SL_slash]
   | inv g _ ig =>
-      have H1 : (G2 ∣[(2 : ℤ)] g)∣[(2 : ℤ)] g⁻¹ = (G2 - D2 g)∣[(2 : ℤ)] g⁻¹ := by
+      have H1 : (G2 ∣[(2 : ℤ)] g) ∣[(2 : ℤ)] g⁻¹ = (G2 - D2 g) ∣[(2 : ℤ)] g⁻¹ := by
         rw [ig]
       simp_rw [← SlashAction.slash_mul, sub_eq_add_neg, SlashAction.add_slash, mul_inv_cancel,
         SlashAction.slash_one, SL_slash, SlashAction.neg_slash] at H1

--- a/Mathlib/NumberTheory/NumberField/Completion/InfinitePlace.lean
+++ b/Mathlib/NumberTheory/NumberField/Completion/InfinitePlace.lean
@@ -220,7 +220,7 @@ If `w.embedding : L →+* ℂ` extends `v.embedding : K →+* ℂ`, then the cor
 to completions are also extensions. -/
 theorem liesOver_extensionEmbedding [ContinuousSMul v.Completion w.Completion]
     [ComplexEmbedding.LiesOver w.embedding v.embedding] :
-    ComplexEmbedding.LiesOver (extensionEmbedding w) (extensionEmbedding v)where
+    ComplexEmbedding.LiesOver (extensionEmbedding w) (extensionEmbedding v) where
   over := by
     ext x
     induction x using induction_on

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Galois.lean
@@ -99,10 +99,10 @@ theorem mem_zpowers_galEquivZMod_of_mem_stabilizer {σ : Gal(K/ℚ)} (hσ : σ �
     galEquivZMod n K σ ∈ Subgroup.zpowers (ZMod.unitOfCoprime p hn) := by
   have hζ := IsCyclotomicExtension.zeta_spec n ℚ K
   let τ := IsFractionRing.stabilizerHom Gal(K/ℚ) (Ideal.span {(p : ℤ)}) P
-     (ℤ ⧸ span {(p : ℤ)}) (𝓞 K⧸ P) ⟨σ, hσ⟩
+     (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ P) ⟨σ, hσ⟩
   have : CharP (ℤ ⧸ span {(p : ℤ)}) p := ringChar.of_eq <| Int.ringChar_idealQuot p
-  have : Finite (𝓞 K⧸ P) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne P)
-  obtain ⟨i, hi⟩ := FiniteField.exists_forall_apply_eq_pow (ℤ ⧸ span {(p : ℤ)}) p (𝓞 K⧸ P) τ
+  have : Finite (𝓞 K ⧸ P) := Ring.HasFiniteQuotients.finiteQuotient (NeZero.ne P)
+  obtain ⟨i, hi⟩ := FiniteField.exists_forall_apply_eq_pow (ℤ ⧸ span {(p : ℤ)}) p (𝓞 K ⧸ P) τ
   refine ⟨i, ?_⟩
   have h₀ : IsPrimitiveRoot (Ideal.Quotient.mk P hζ.toInteger) n := by
     refine hζ.toInteger_isPrimitiveRoot.idealQuotient_mk
@@ -110,7 +110,7 @@ theorem mem_zpowers_galEquivZMod_of_mem_stabilizer {σ : Gal(K/ℚ)} (hσ : σ �
     rw [Ideal.absNorm_eq_pow_inertiaDeg' _ hp.out]
     exact Nat.Coprime.pow_left _ hn
   have h₁ := IsFractionRing.stabilizerHom_apply_apply_mk Gal(K/ℚ) (Ideal.span {(p : ℤ)}) P
-      (ℤ ⧸ span {(p : ℤ)}) (𝓞 K⧸ P) ⟨σ, hσ⟩ hζ.toInteger
+      (ℤ ⧸ span {(p : ℤ)}) (𝓞 K ⧸ P) ⟨σ, hσ⟩ hζ.toInteger
   simp only [Algebra.algebraMap_self, RingHomCompTriple.comp_apply] at h₁
   specialize hi (Ideal.Quotient.mk P hζ.toInteger)
   rwa [h₁, Int.card_ideal_quot, galEquivZMod_smul_of_pow_eq n _ _
@@ -130,7 +130,7 @@ theorem galEquivZMod_stabilizer :
   · replace hn : ¬ p ∣ n := (Nat.Prime.coprime_iff_not_dvd hp.out).mp hn
     rw [Fintype.card_eq_nat_card, Fintype.card_eq_nat_card, SetLike.coe_sort_coe, Nat.card_zpowers,
       MulEquiv.mapSubgroup_apply, Subgroup.coe_map]
-    change _  ≤ Nat.card ((galEquivZMod n K).toEquiv '' _)
+    change _ ≤ Nat.card ((galEquivZMod n K).toEquiv '' _)
     rw [Nat.card_image_equiv, SetLike.coe_sort_coe, Ideal.card_stabilizer_eq (span {(p : ℤ)})
       (by simp [hp.out.ne_zero]), inertiaDegIn_eq_of_not_dvd p K hn,
       ramificationIdxIn_eq_of_not_dvd p K hn, one_mul, ← orderOf_injective _ Units.coeHom_injective,

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -184,7 +184,7 @@ theorem RankOne.hom_eq_embedding : RankOne.hom (PadicComplex.valued p).v = embed
 instance normedField : NormedField ℂ_[p] := inferInstance
 
 -- Ensure that the norm instance on `ℂ_[p]` is extended from `PadicAlgCl p`.
-example : (‖·‖ : ℂ_[p] → ℝ)  = (UniformSpace.Completion.instNorm (PadicAlgCl p)).norm := by
+example : (‖·‖ : ℂ_[p] → ℝ) = (UniformSpace.Completion.instNorm (PadicAlgCl p)).norm := by
   with_reducible_and_instances rfl
 
 /-- The norm on `ℂ_[p]` extends the norm on `PadicAlgCl p`. -/

--- a/Mathlib/NumberTheory/Padics/WithVal.lean
+++ b/Mathlib/NumberTheory/Padics/WithVal.lean
@@ -49,7 +49,7 @@ lemma isUniformInducing_cast_withVal : IsUniformInducing ((Rat.castHom ℚ_[p]).
     ← map_sub, Padic.eq_padicNorm, true_and, forall_const]
   constructor
   · intro n
-    have hn :  Valued.v (R := (WithVal (Rat.padicValuation p))) (p ^ n) =
+    have hn : Valued.v (R := (WithVal (Rat.padicValuation p))) (p ^ n) =
       exp (-n : ℤ) := by
       simp only [← WithVal.val_apply_equiv, map_pow, map_natCast, Rat.padicValuation_self,
         Int.reduceNeg, exp_neg, inv_pow, ← exp_nsmul, nsmul_eq_mul, mul_one]

--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -40,7 +40,7 @@ lemma valuation_eq_valuation_X_zpow_intDegree_of_one_lt_valuation_X {f : RatFunc
   | f p q hq =>
     rw [intDegree_div (by grind only) (by grind only), v.map_div, zpow_sub₀ (ne_zero_of_lt hlt)]
     simp_rw [intDegree_polynomial, zpow_natCast, ← coePolynomial_eq_algebraMap]
-    have hp : p ≠ 0  := by contrapose! hf; simp [hf]
+    have hp : p ≠ 0 := by contrapose! hf; simp [hf]
     rw [valuation_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X _ hlt hp,
       valuation_eq_valuation_X_pow_natDegree_of_one_lt_valuation_X _ hlt hq]
 
@@ -62,7 +62,7 @@ open IsDedekindDomain HeightOneSpectrum Set Valuation FunctionField Polynomial
 
 lemma setOf_polynomial_valuation_lt_one_and_ne_zero_nonempty [v.IsNontrivial] [v.IsTrivialOn K]
     (hle : v RatFunc.X ≤ 1) : {p : K[X] | v p < 1 ∧ p ≠ 0}.Nonempty := by
-  obtain ⟨w , h0, h1⟩ := IsNontrivial.exists_lt_one (v := v)
+  obtain ⟨w, h0, h1⟩ := IsNontrivial.exists_lt_one (v := v)
   induction w using RatFunc.induction_on with
   | f p q =>
     simp only [ne_eq, _root_.div_eq_zero_iff, FaithfulSMul.algebraMap_eq_zero_iff, not_or,
@@ -170,7 +170,7 @@ lemma valuation_eq_valuation_uniformizingPolynomial_pow_of_valuation_X_le_one {p
       using mul_lt_one_of_lt_of_le hπ.1 <| (q / π).valuation_le_one_of_valuation_X_le_one _ hle
 
 lemma exists_zpow_uniformizingPolynomial {f : RatFunc K} (hf : f ≠ 0) :
-    ∃ (z : ℤ), v f = v πᵥ ^ z:= by
+    ∃ (z : ℤ), v f = v πᵥ ^ z := by
   have h0 : v πᵥ ≠ 0 := by simpa using uniformizingPolynomial_ne_zero hle
   induction f using RatFunc.induction_on with
   | f p q hq =>

--- a/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Indexed.lean
@@ -399,7 +399,7 @@ theorem cbiInf_of_not_bddBelow {p : ι → Prop} {f : ∀ i, p i → α}
 
 theorem cbiSup_eq_of_not_forall {p : ι → Prop} {f : Subtype p → α} (hp : ¬ (∀ i, p i)) :
     ⨆ (i) (h : p i), f ⟨i, h⟩ = iSup f ⊔ sSup ∅ := by
-  rcases le_or_gt (sSup ∅) (iSup f) with le|gt
+  rcases le_or_gt (sSup ∅) (iSup f) with le | gt
   · rw [max_eq_left le]
     by_cases bdd : BddAbove (range f)
     · rw [← ciSup_subtype bdd le]

--- a/Mathlib/Probability/CentralLimitTheorem.lean
+++ b/Mathlib/Probability/CentralLimitTheorem.lean
@@ -46,7 +46,7 @@ lemma charFun_inv_sqrt_mul_sum (hindep : iIndepFun X P)
     charFun (P.map (fun ω ↦ (√n)⁻¹ * ∑ k ∈ Finset.range n, X k ω)) t =
       (charFun (P.map (X 0)) ((√n)⁻¹ * t)) ^ n := by
   have mX n := (hident n).aemeasurable_fst
-  rw [charFun_map_mul_comp, (hindep.restrict _).charFun_map_fun_finset_sum_eq_prod (fun _  _↦ mX _)]
+  rw [charFun_map_mul_comp, (hindep.restrict _).charFun_map_fun_finset_sum_eq_prod (fun _ _ ↦ mX _)]
   · simp [fun i ↦ (hident i).map_eq]
   · exact Finset.aemeasurable_fun_sum _ fun _ _ ↦ mX _
 

--- a/Mathlib/Probability/Kernel/Representation.lean
+++ b/Mathlib/Probability/Kernel/Representation.lean
@@ -55,7 +55,7 @@ private lemma exists_measurable_map_eq_unitInterval_aux (κ : Kernel X I) [IsMar
       simp_all only [lt_sSup_iff, mem_setOf_eq, Subtype.exists, mem_Icc, Rat.cast_nonneg,
         mem_iUnion, exists_prop, exists_and_left, f]
       constructor
-      · rintro ⟨y, hyI,y_mem, (hy : a.1 < y)⟩
+      · rintro ⟨y, hyI, y_mem, (hy : a.1 < y)⟩
         obtain ⟨q, hqa, hqy⟩ := exists_rat_btwn hy
         refine ⟨q, hqa, ⟨?_, hqy.le.trans hyI.2⟩, lt_of_lt_of_le' y_mem (h_monotone e.1 hqy.le)⟩
         simp [← Rat.cast_nonneg (K := ℝ), a.2.1.trans hqa.le]

--- a/Mathlib/RepresentationTheory/Action.lean
+++ b/Mathlib/RepresentationTheory/Action.lean
@@ -81,7 +81,7 @@ variable (k G) in
 @[simps toLinearMap]
 def ε : (trivial k G k).IntertwiningMap (linearize k G (MonoidalCategoryStruct.tensorUnit
     (Action (Type w) G))) where
-  __ := Finsupp.LinearEquiv.finsuppUnique k k PUnit|>.symm.toLinearMap
+  __ := Finsupp.LinearEquiv.finsuppUnique k k PUnit |>.symm.toLinearMap
   isIntertwining' g := by ext1; simp [linearize_single _]
 
 lemma ε_one : ε k G 1 = Finsupp.single PUnit.unit 1 := by
@@ -209,7 +209,7 @@ lemma assoc_comp_δ : ((assoc (linearize k G X) (linearize k G Y)
   simp [linearizeMap, δ, finsuppTensorFinsupp'_symm_single_eq_single_one_tmul k]
 
 lemma leftUnitor_δ (X : Action (Type u) G) : (lid k (linearize k G X)).symm.toIntertwiningMap =
-    (((η k G).rTensor (linearize k G X) ).comp (δ (𝟙_ (Action (Type u) G)) X)).comp
+    (((η k G).rTensor (linearize k G X)).comp (δ (𝟙_ (Action (Type u) G)) X)).comp
       (linearizeMap (λ_ X).inv) := by
   ext
   -- TODO : try not to `simp` with `δ` and `linearizeMap` directly here

--- a/Mathlib/RepresentationTheory/Coinduced.lean
+++ b/Mathlib/RepresentationTheory/Coinduced.lean
@@ -251,7 +251,7 @@ def resCoindToHom (B : Rep k H) (A : Rep k G) (f : res φ B ⟶ A) : B ⟶ (coin
 
 @[simp]
 lemma resCoindToHom_hom_apply_coe (B : Rep k H) (A : Rep k G) (f : res φ B ⟶ A) (c : ↑B.V)
-    (i : H) : (DFunLike.coe (F := no_index(_)) (resCoindToHom φ B A f).hom c).1 i =
+    (i : H) : (DFunLike.coe (F := no_index (_)) (resCoindToHom φ B A f).hom c).1 i =
     (Hom.hom f) ((B.ρ i) c) := rfl
 
 -- this `no_index` is to prevent simp discrimination tree from acting weird, i.e before
@@ -308,7 +308,7 @@ noncomputable instance : (resFunctor.{max w t} (k := k) φ).IsLeftAdjoint :=
   (resCoindAdjunction k φ).isLeftAdjoint
 
 instance {G : Type w} [Group G] (S : Subgroup G) :
-    (resFunctor.{max w t} (k := k) S.subtype).PreservesProjectiveObjects  :=
+    (resFunctor.{max w t} (k := k) S.subtype).PreservesProjectiveObjects :=
   (resFunctor S.subtype).preservesProjectiveObjects_of_adjunction_of_preservesEpimorphisms
     (resCoindAdjunction k S.subtype)
 

--- a/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
+++ b/Mathlib/RepresentationTheory/Homological/FiniteCyclic.lean
@@ -117,7 +117,7 @@ lemma range_applyAsHom_sub_eq_ker_linearCombination (hg : ∀ x, x ∈ Subgroup.
 
 lemma range_applyAsHom_sub_eq_ker_norm (hg : ∀ x, x ∈ Subgroup.zpowers g) :
     LinearMap.range (applyAsHom (leftRegular k G) g - 𝟙 _).hom.toLinearMap =
-      LinearMap.ker (leftRegular k G).norm.hom.toLinearMap:= by
+      LinearMap.ker (leftRegular k G).norm.hom.toLinearMap := by
   simp [norm, ker_leftRegular_norm_eq, range_applyAsHom_sub_eq_ker_linearCombination k g hg]
 
 end leftRegular

--- a/Mathlib/RepresentationTheory/Homological/Resolution.lean
+++ b/Mathlib/RepresentationTheory/Homological/Resolution.lean
@@ -380,7 +380,7 @@ lemma d_comp_diagonalSuccIsoFree_inv_eq :
   free_ext k G _ _ _ fun i ↦ by
     have eq3 : single (i 0 • Fin.partialProd fun i_1 ↦ i i_1.succ) (1 : k) =
       single (Fin.partialProd i ∘ Fin.succ) 1 := by
-      congr; exact funext fun j ↦ Fin.partialProd_succ' i j|>.symm
+      congr; exact funext fun j ↦ Fin.partialProd_succ' i j |>.symm
     simp [μ_hom, d_single (k := k), Rep.mkIso_inv_hom_apply _,
       Representation.linearizeOfMulActionIso_symm_apply,
       Representation.linearizeTrivialIso_symm_apply _, d_apply (k := k),

--- a/Mathlib/RepresentationTheory/Intertwining.lean
+++ b/Mathlib/RepresentationTheory/Intertwining.lean
@@ -40,7 +40,7 @@ structure IntertwiningMap extends V →ₗ[A] W where
 /-- An intertwining map constructed form the linear map and the fact that it is intertwining. -/
 def _root_.LinearMap.intertwiningMap_of_isIntertwiningMap
     (hf : ∀ (g : G), ∀ (v : V), f (ρ g v) = σ g (f v)) : IntertwiningMap ρ σ :=
-  { f with isIntertwining' g := by ext v; exact hf g v}
+  { f with isIntertwining' g := by ext v; exact hf g v }
 
 lemma IntertwiningMap.isIntertwining_assoc {f : IntertwiningMap ρ σ} (g : G) (l : U →ₗ[A] V) :
     f.toLinearMap ∘ₗ ρ g ∘ₗ l = σ g ∘ₗ f.toLinearMap ∘ₗ l := by
@@ -307,7 +307,7 @@ def refl : Equiv ρ ρ where
 lemma coe_invFun : φ.invFun = φ.symm := rfl
 
 theorem toLinearEquiv_toLinearMap :
-  φ.toLinearEquiv.toLinearMap  = φ.toIntertwiningMap.toLinearMap := rfl
+  φ.toLinearEquiv.toLinearMap = φ.toIntertwiningMap.toLinearMap := rfl
 
 theorem toLinearEquiv_apply (v : V) : φ.toLinearEquiv v = φ.toIntertwiningMap v := rfl
 
@@ -324,7 +324,7 @@ open LinearMap in
 lemma _root_.LinearEquiv.isIntertwining_symm_isIntertwining {e : V ≃ₗ[A] W}
     (he : ∀ g, e ∘ₗ (ρ g) = (σ g) ∘ₗ e) (g : G) :
     e.symm ∘ₗ (σ g) = (ρ g) ∘ₗ e.symm := by
-  apply e.comp_toLinearMap_eq_iff _ _|>.1
+  apply e.comp_toLinearMap_eq_iff _ _ |>.1
   rw [← comp_assoc, ← comp_assoc, he g, e.comp_symm, id_comp, comp_assoc, e.comp_symm, comp_id]
 
 @[simp]
@@ -532,7 +532,7 @@ noncomputable
 def ofBijective (f : IntertwiningMap ρ σ) (hf : Function.Bijective f) :
     Equiv ρ σ where
   isIntertwining' := f.isIntertwining'
-  toLinearEquiv :=  LinearEquiv.ofBijective f.toLinearMap hf
+  toLinearEquiv := LinearEquiv.ofBijective f.toLinearMap hf
 
 @[simp]
 theorem coe_ofBijective (f : IntertwiningMap ρ σ) (hf : Function.Bijective f) :

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -115,7 +115,7 @@ def invariantsEquivIntertwiningMap : (linHom ρ σ).invariants ≃ₗ[k] Intertw
   invFun g :=
     { val := g.toLinearMap
       property := (mem_linHom_invariants_iff_isIntertwining g.toLinearMap).mpr
-        {isIntertwining := g.isIntertwining} }
+        { isIntertwining := g.isIntertwining } }
 
 section
 

--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -516,10 +516,10 @@ def repIsoAction : Rep.{w} k G ≌ Action (ModuleCat.{w} k) G where
   counitIso := NatIso.ofComponents (RepToAction_ActionToRep k G)
 
 instance : (RepToAction k G).IsEquivalence :=
-  repIsoAction k G|>.isEquivalence_functor
+  repIsoAction k G |>.isEquivalence_functor
 
 instance : (ActionToRep k G).IsEquivalence :=
-  repIsoAction k G|>.isEquivalence_inverse
+  repIsoAction k G |>.isEquivalence_inverse
 
 instance : (forget₂ (Rep.{w} k G) (ModuleCat.{w} k)).Additive where
   map_add {X Y} f g := by ext1; simp [add_hom]
@@ -761,8 +761,9 @@ noncomputable instance : MonoidalClosed (Rep k G) where
         homEquiv := Rep.tensorHomEquiv A
         homEquiv_naturality_left_symm := fun _ _ => Rep.hom_ext <|
           Representation.IntertwiningMap.ext <| TensorProduct.ext' fun _ _ => rfl
-        homEquiv_naturality_right := fun _ _ => Rep.hom_ext <|
-          Representation.IntertwiningMap.ext <| LinearMap.ext fun _ => LinearMap.ext fun _ => rfl})}
+        homEquiv_naturality_right _ _ := Rep.hom_ext <|
+          Representation.IntertwiningMap.ext <|
+            LinearMap.ext fun _ ↦ LinearMap.ext fun _ => rfl }) }
 
 @[simp]
 theorem ihom_obj_ρ_def (A B : Rep k G) : ((ihom A).obj B).ρ = ((Rep.ihom A).obj B).ρ :=

--- a/Mathlib/RingTheory/AdicCompletion/Basic.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Basic.lean
@@ -697,7 +697,7 @@ namespace IsAdicComplete
 open AdicCompletion
 
 theorem map_algebraMap_iff [CommRing S] [Module S M] [Algebra R S]
-    [IsScalarTower R S M] :  IsAdicComplete (I.map (algebraMap R S)) M ↔ IsAdicComplete I M := by
+    [IsScalarTower R S M] : IsAdicComplete (I.map (algebraMap R S)) M ↔ IsAdicComplete I M := by
   simp [isAdicComplete_iff, IsPrecomplete.map_algebraMap_iff, IsHausdorff.map_algebraMap_iff]
 
 section lift

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -79,7 +79,7 @@ variable (R A A') in
 /-- Let `σ : A → A'` be a an homomorphism. A derivation `d : A → A` and a derivation
 `d' : A' → A'` are called compatible if `d' ∘ σ = σ ∘ d`. Couples of derivations
 with this property form a Lie subalgebra of all couples of derivations. -/
-def couple : LieSubalgebra R  (Derivation R A' A' × Derivation R A A) where
+def couple : LieSubalgebra R (Derivation R A' A' × Derivation R A A) where
   carrier := { x | x.fst.compAlgebraMapL R A A' A' = (Algebra.ofId A A').toLinearMap.compDer x.snd }
   add_mem' := by simp_all
   zero_mem' := by simp
@@ -110,7 +110,7 @@ lemma mk_right (x : Derivation R A' A') (y : Derivation R A A)
     (h : x ∘ (Algebra.ofId A A') = (Algebra.ofId A A') ∘ y) : (mk x y h).1.2 = y := rfl
 
 lemma apply (x : couple R A A') (a : A) :
-    x.1.1 (Algebra.ofId A A' a) = (Algebra.ofId A A')  (x.1.2 a) := by
+    x.1.1 (Algebra.ofId A A' a) = (Algebra.ofId A A') (x.1.2 a) := by
   exact congrArg (· a) x.2
 
 end Compatible

--- a/Mathlib/RingTheory/DividedPowerAlgebra/Init.lean
+++ b/Mathlib/RingTheory/DividedPowerAlgebra/Init.lean
@@ -208,8 +208,8 @@ theorem natFactorial_mul_dp_eq (n : ℕ) (x : M) :
 variable (R M) in
 /-- The canonical linear map `M →ₗ[R] DividedPowerAlgebra R M`. -/
 def embed : M →ₗ[R] DividedPowerAlgebra R M where
-  toFun m   := dp R 1 m
-  map_add' _ _  := by simp [dp_add, Nat.antidiagonal_succ, dp_zero, add_comm]
+  toFun m := dp R 1 m
+  map_add' _ _ := by simp [dp_add, Nat.antidiagonal_succ, dp_zero, add_comm]
   map_smul' _ _ := by simp [dp_smul, pow_one, RingHom.id_apply]
 
 theorem embed_def (m : M) : embed R M m = dp R 1 m := rfl

--- a/Mathlib/RingTheory/FormalGroup/Basic.lean
+++ b/Mathlib/RingTheory/FormalGroup/Basic.lean
@@ -142,6 +142,6 @@ def map (f : R →+* S) : FormalGroup S where
       fun i => (![g₁, g₂] i).map f := by ext1 i; fin_cases i <;> simp
     simp_rw [(map_X f _).symm, this, ← map_subst .X_X, this, ← map_subst
       (HasSubst.cons_subst_zero_left (0 : Fin 3) 1 2 F.zero_constantCoeff), F.assoc,
-      ← map_subst (HasSubst.cons_subst_zero_right (0 : Fin 3) 1 2  F.zero_constantCoeff)]
+      ← map_subst (HasSubst.cons_subst_zero_right (0 : Fin 3) 1 2 F.zero_constantCoeff)]
 
 end FormalGroup

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -372,7 +372,7 @@ lemma Ideal.mapCotangent_surjective_of_comap_eq (surj : Function.Surjective (alg
 lemma Ideal.mapCotangent_ker_of_surjective (surj : Function.Surjective (algebraMap A B))
     {I : Ideal B} {J : Ideal A} (eq : I.comap (algebraMap A B) = RingHom.ker (algebraMap A B) ⊔ J) :
     (Ideal.mapCotangent J I (Algebra.ofId A B) (le_of_le_of_eq le_sup_right eq.symm)).ker =
-      (Submodule.comap J.subtype ((RingHom.ker (algebraMap A B)) ⊓ J)).map J.toCotangent  := by
+      (Submodule.comap J.subtype ((RingHom.ker (algebraMap A B)) ⊓ J)).map J.toCotangent := by
   have eqmap := Ideal.eq_map_of_comap_eq_ker_sup _ surj eq
   refine le_antisymm (fun x hx ↦ ?_) ?_
   · rcases J.toCotangent_surjective x with ⟨x', hx'⟩

--- a/Mathlib/RingTheory/Invariant/Basic.lean
+++ b/Mathlib/RingTheory/Invariant/Basic.lean
@@ -353,7 +353,7 @@ noncomputable def IsFractionRing.stabilizerHom : MulAction.stabilizer G Q →* G
 omit [Finite G] [Q.IsPrime] [Algebra.IsInvariant A B G] in
 @[simp]
 theorem IsFractionRing.stabilizerHom_apply_apply_mk (σ : MulAction.stabilizer G Q) (x : B) :
-    IsFractionRing.stabilizerHom G P Q K L σ (algebraMap _  L (Ideal.Quotient.mk Q x)) =
+    IsFractionRing.stabilizerHom G P Q K L σ (algebraMap _ L (Ideal.Quotient.mk Q x)) =
       algebraMap _ L (Ideal.Quotient.mk Q (σ.val • x)) := by
   simp [IsFractionRing.stabilizerHom, MulAction.subgroup_smul_def]
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -1079,7 +1079,7 @@ theorem tendsto_valuation (a : (idealX K).adicCompletion K⟮X⟯) :
       obtain ⟨x, hx⟩ := valuedAdicCompletion_surjective K⟮X⟯ (idealX K) γ
       use Units.mk0 (Valued.v.restrict x) (by
         rwa [Valuation.restrict_def, ne_eq, restrict₀_eq_zero_iff, hx])
-      simp  [Units.val_mk0, Valuation.restrict_lt_iff, hx]
+      simp [Units.val_mk0, Valuation.restrict_lt_iff, hx]
     · refine Set.Subset.trans (fun a _ ↦ ?_) (Set.preimage_mono γ_le)
       rw [Set.mem_preimage, Set.mem_Iio, ← Valued.valuedCompletion_apply a]
       simp_all

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -621,7 +621,7 @@ theorem Localization.mk_intCast (m : ℤ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℤ) _
 
 theorem Localization.r_iff_of_le_nonZeroDivisors (hM : M ≤ nonZeroDivisors R) (a c : R) (b d : M) :
-    Localization.r _ (a, b) (c, d) ↔ a * d = b * c  := by
+    Localization.r _ (a, b) (c, d) ↔ a * d = b * c := by
   simp only [Localization.r_eq_r', Localization.r', Subtype.exists, exists_prop, Con.rel_mk]
   refine ⟨fun ⟨u, hu, h⟩ ↦ ?_,
     fun h ↦ ⟨1, Submonoid.one_mem M, by simpa only [one_mul, mul_comm a] using h⟩⟩

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -266,7 +266,7 @@ theorem substAlgHom_monomial (ha : HasSubst a) (e : σ →₀ ℕ) (r : R) :
 
 @[simp]
 theorem subst_C (r : S) :
-    (C r).subst a = MvPowerSeries.C r:= by
+    (C r).subst a = MvPowerSeries.C r := by
   simp [subst, algebraMap_apply]
 
 @[simp]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -94,9 +94,9 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
     calc ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • (a + b) ^ i
         = ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • ∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j := ?_
       _ = ∑ i ∈ R2N, (∑ j ∈ range (i + 1),
-            ((j ! : ℚ)⁻¹ * ((i - j) ! : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := ?_
+            ((j ! : ℚ)⁻¹ * ((i - j)! : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := ?_
       _ = ∑ ij ∈ R2N ×ˢ R2N with ij.1 + ij.2 ≤ 2 * N,
-            ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
+            ((ij.1! : ℚ)⁻¹ * (ij.2! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
     · refine sum_congr rfl fun i _ ↦ ?_
       rw [Commute.add_pow h₁ i]
     · simp_rw [smul_sum]
@@ -123,7 +123,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
         exact fun x y _ _ _ ↦ ⟨x + y, x, by lia⟩
       · simp only [mem_sigma, mem_range, implies_true]
   have z₁ : ∑ ij ∈ R2N ×ˢ R2N with ¬ ij.1 + ij.2 ≤ 2 * N,
-      ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+      ((ij.1! : ℚ)⁻¹ * (ij.2! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
       rw [mem_filter] at hi
       cases le_or_gt (N + 1) i.1 with

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -94,9 +94,9 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
     calc ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • (a + b) ^ i
         = ∑ i ∈ R2N, (i ! : ℚ)⁻¹ • ∑ j ∈ range (i + 1), a ^ j * b ^ (i - j) * i.choose j := ?_
       _ = ∑ i ∈ R2N, (∑ j ∈ range (i + 1),
-            ((j ! : ℚ)⁻¹ * ((i - j)! : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := ?_
+            ((j ! : ℚ)⁻¹ * ((i - j) ! : ℚ)⁻¹) • (a ^ j * b ^ (i - j))) := ?_
       _ = ∑ ij ∈ R2N ×ˢ R2N with ij.1 + ij.2 ≤ 2 * N,
-            ((ij.1! : ℚ)⁻¹ * (ij.2! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
+            ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) := ?_
     · refine sum_congr rfl fun i _ ↦ ?_
       rw [Commute.add_pow h₁ i]
     · simp_rw [smul_sum]
@@ -123,7 +123,7 @@ theorem exp_add_of_commute {a b : A} (h₁ : Commute a b) (h₂ : IsNilpotent a)
         exact fun x y _ _ _ ↦ ⟨x + y, x, by lia⟩
       · simp only [mem_sigma, mem_range, implies_true]
   have z₁ : ∑ ij ∈ R2N ×ˢ R2N with ¬ ij.1 + ij.2 ≤ 2 * N,
-      ((ij.1! : ℚ)⁻¹ * (ij.2! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
+      ((ij.1 ! : ℚ)⁻¹ * (ij.2 ! : ℚ)⁻¹) • (a ^ ij.1 * b ^ ij.2) = 0 :=
     sum_eq_zero fun i hi ↦ by
       rw [mem_filter] at hi
       cases le_or_gt (N + 1) i.1 with

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -307,7 +307,7 @@ theorem subst_coe (ha : HasSubst a) (p : Polynomial R) :
   rw [← coe_substAlgHom ha, substAlgHom_coe]
 
 @[simp]
-theorem subst_C (r : S) : (C r).subst a = MvPowerSeries.C r:= MvPowerSeries.subst_C _
+theorem subst_C (r : S) : (C r).subst a = MvPowerSeries.C r := MvPowerSeries.subst_C _
 
 theorem subst_X (ha : HasSubst a) :
     subst a (X : R⟦X⟧) = a := by
@@ -437,8 +437,8 @@ this is the construction of a power series `Q` such that `P(Q(X)) = X`. -/
 noncomputable
 def substInvFun : ℕ → R
   | 0 => 0
-  | 1 => ⅟ (P.coeff 1)
-  | n + 1 => - ⅟ (P.coeff 1) *
+  | 1 => ⅟(P.coeff 1)
+  | n + 1 => - ⅟(P.coeff 1) *
       (coeff (n + 1) (P.subst (∑ i : Fin (n + 1), C (substInvFun i.1) * X ^ i.1)))
 
 /-- Given a power series `P = u • X + O(X²)` with `u` invertible,
@@ -449,14 +449,14 @@ def substInv : PowerSeries R := .mk (substInvFun P)
 include hP in
 lemma coeff_subst_sum_C_substInvFun_mul_X_pow_sub_X (n : ℕ) :
     coeff n (P.subst (∑ i : Fin (n + 1), C (substInvFun P i.1) * X ^ i.1) - X) = 0 := by
-  obtain (_|_|n) := n
+  obtain (_ | _ | n) := n
   · rw [map_sub, coeff_subst']
     · simp +contextual [finsum_eq_single (a := 0), substInvFun, zero_pow_eq, hP]
     · simp [substInvFun, HasSubst]
   · rw [map_sub, coeff_subst']
     · rw [finsum_eq_single (a := 1)]
       · simp [substInvFun]
-      · rintro (_|_|_) _ <;> simp_all [substInvFun, mul_pow, coeff_mul_X_pow']
+      · rintro (_ | _ | _) _ <;> simp_all [substInvFun, mul_pow, coeff_mul_X_pow']
     · simp [HasSubst, X, substInvFun]
   · rw [Fin.sum_univ_castSucc]
     simp only [Fin.val_castSucc, Fin.val_last, map_sub, substInvFun]
@@ -466,17 +466,17 @@ lemma coeff_subst_sum_C_substInvFun_mul_X_pow_sub_X (n : ℕ) :
       one_ne_zero, and_false, ↓reduceIte, sub_zero]
     rw [coeff_subst']
     · simp only [smul_eq_mul, ← map_mul]
-      generalize hk : ⅟ (P.coeff 1) * coeff (n + 1 + 1) (subst B P) = k
+      generalize hk : ⅟(P.coeff 1) * coeff (n + 1 + 1) (subst B P) = k
       trans ∑ᶠ d, P.coeff d * (coeff (n + 1 + 1) (B ^ d) - if d = 1 then k else 0)
       · refine finsum_congr fun i ↦ ?_
         · congr 1
-          obtain (_|_|i) := i
+          obtain (_ | _ | i) := i
           · simp
           · simp [← sub_eq_add_neg]
           · simp only [add_assoc, Nat.reduceAdd]
             rw [add_comm B, add_pow, map_sum, Finset.sum_eq_single (a := 0)]
             · simp
-            · rintro (_|_|j) hj hj'
+            · rintro (_ | _ | j) hj hj'
               · simp at hj'
               · simp [mul_comm (C k), hB', mul_assoc, coeff_X_pow_mul']
               · rw [← neg_mul, mul_pow, ← pow_mul, mul_comm (_ ^ _)]
@@ -523,7 +523,7 @@ lemma constantCoeff_substInv : P.substInv.constantCoeff = 0 := by
 lemma hasSubst_substInv : HasSubst P.substInv := by simp [HasSubst, ← constantCoeff.eq_def]
 
 @[simp]
-lemma coeff_one_substInv : P.substInv.coeff 1 = ⅟ (P.coeff 1) := by
+lemma coeff_one_substInv : P.substInv.coeff 1 = ⅟(P.coeff 1) := by
   simp [substInv, substInvFun]
 
 include hP in
@@ -537,7 +537,7 @@ lemma subst_substInv_left : P.substInv.subst P = X := by
     · have (n : ℕ) : (P ^ (n + 1 + 1)).coeff 1 = 0 := by
         obtain ⟨P, rfl⟩ := X_dvd_iff.mpr hP
         simp [mul_pow, coeff_X_pow_mul']
-      rintro (_|_|n) hn <;> simp_all
+      rintro (_ | _ | n) hn <;> simp_all
   have hQ : Q.constantCoeff = 0 := by
     trans coeff 0 (P.substInv.subst P)
     · simp [Q]

--- a/Mathlib/RingTheory/Teichmuller.lean
+++ b/Mathlib/RingTheory/Teichmuller.lean
@@ -30,7 +30,7 @@ namespace Perfection
 power of an arbitrary lift in `R` of the `n`-th component from the perfection of `R ⧸ I`. -/
 noncomputable def teichmullerAux (x : Perfection (R ⧸ I) p) : ℕ → R
   | 0 => 1
-  | n+1 => (coeff _ p n x).out ^ p ^ n
+  | n + 1 => (coeff _ p n x).out ^ p ^ n
 
 theorem teichmullerAux_sModEq (x : Perfection (R ⧸ I) p) (m : ℕ) :
     teichmullerAux x m ≡ teichmullerAux x (m + 1) [SMOD I ^ m] := by

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -523,12 +523,12 @@ lemma restrict_le_one_iff {x : R} : v.restrict x ≤ 1 ↔ v x ≤ 1 := by
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma restrict_eq_zero_iff {x : R} : v.restrict x = 0 ↔ v x = 0 := by
-  rw [restrict_def,restrict₀_eq_zero_iff]
+  rw [restrict_def, restrict₀_eq_zero_iff]
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma restrict_eq_one_iff {x : R} : v.restrict x = 1 ↔ v x = 1 := by
-  rw [restrict_def,restrict₀_eq_one_iff]
+  rw [restrict_def, restrict₀_eq_one_iff]
 
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
@@ -826,7 +826,7 @@ noncomputable def valueGroup₀Fun (h : v.IsEquiv w) (x : ValueGroup₀ v) : Val
 
 theorem valueGroup₀Fun_spec (h : v.IsEquiv w) {r s : R} (hr : v r ≠ 0) (hs : v s ≠ 0) :
     valueGroup₀Fun h (valueGroup.mk v r s hr hs) =
-      valueGroup.mk w r s ((h.eq_zero).ne.mp hr) ((h.eq_zero).ne.mp hs)  := by
+      valueGroup.mk w r s ((h.eq_zero).ne.mp hr) ((h.eq_zero).ne.mp hs) := by
   rw [valueGroup₀Fun, dif_neg (by simp)]
   generalize_proofs _ _ _ _ H _
   have c_spec := H.choose_spec

--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -66,8 +66,8 @@ lemma nonempty_rankOne_iff_mulArchimedean {v : Valuation R Γ₀} [v.IsNontrivia
     exact MulArchimedean.comap hv.hom'.toMonoidHom hv.strictMono'
   · intro _
     obtain ⟨f, hf⟩ :=
-      Archimedean.exists_orderAddMonoidHom_real_injective (Additive  (ValueGroup₀ v)ˣ)
-    let e := AddMonoidHom.toMultiplicativeRight (α :=  (ValueGroup₀ v)ˣ) (β := ℝ) f
+      Archimedean.exists_orderAddMonoidHom_real_injective (Additive (ValueGroup₀ v)ˣ)
+    let e := AddMonoidHom.toMultiplicativeRight (α := (ValueGroup₀ v)ˣ) (β := ℝ) f
     have he : StrictMono e := by
       simp only [AddMonoidHom.coe_toMultiplicativeRight, AddMonoidHom.coe_coe, e]
       -- toAdd_strictMono is already in an applied form, do defeq abuse instead
@@ -156,7 +156,7 @@ theorem exists_val_lt {γ : ℝ≥0} (hγ : γ ≠ 0) : ∃ x ≠ 0, RankOne.hom
   · simp only [restrict₀_apply, restrict_def, map_eq_zero, dite_eq_left_iff, coe_ne_zero,
       imp_false, not_not] at hk
     by_contra h0
-    rw [dif_pos (by  rw [dif_pos ((zero_iff v).mpr h0)]), eq_comm] at hk
+    rw [dif_pos (by rw [dif_pos ((zero_iff v).mpr h0)]), eq_comm] at hk
     simp at hk
   · convert h
     simp only [restrict_RankOne_hom_eq, coe_comp, Function.comp_apply, ← hk]

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -383,7 +383,7 @@ theorem lift_cof_iSup_add_one [Small.{u} β] {f : β → Ordinal} (hf : StrictMo
       obtain ⟨i, hi⟩ := hb
       exact ⟨_, Set.mem_range_self i, hi⟩
   · rw [mem_Iio]
-    exact (lt_add_one _).trans_le <| le_ciSup  (bddAbove_of_small _) _
+    exact (lt_add_one _).trans_le <| le_ciSup (bddAbove_of_small _) _
 
 theorem cof_iSup_add_one {f : γ → Ordinal} (hf : StrictMono f) :
     cof (⨆ i, f i + 1) = Order.cof γ := by

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1055,7 +1055,8 @@ theorem exists_ord_eq (α) : ∃ (r : α → α → Prop) (_ : IsWellOrder α r)
 
 open Classical in
 /-- There exists a well-order on `α` whose order type is exactly `ord #α`. -/
-theorem exists_ord_eq_type_lt (α) : ∃ (_ : LinearOrder α) (_: WellFoundedLT α), ord #α = typeLT α :=
+theorem exists_ord_eq_type_lt (α) :
+    ∃ (_ : LinearOrder α) (_ : WellFoundedLT α), ord #α = typeLT α :=
   let ⟨r, _, hr⟩ := exists_ord_eq α
   let := linearOrderOfSTO r
   ⟨this, inferInstance, hr⟩

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -650,7 +650,7 @@ lemma tprod_mulIndicator_of_disjoint_on_mulSupport_of_mem (s : γ → Set β) (f
 lemma tprod_mulIndicator_of_mem_union_disjoint (s : γ → Set β) (f : β → α)
     (hs : Pairwise (Disjoint on s)) (i : β) (hi : i ∈ ⋃ d, s d) :
     ∏' d, (s d).mulIndicator f i = f i :=
-  tprod_mulIndicator_of_disjoint_on_mulSupport_of_mem  s f i hi (pairwise_disjoint_mono hs
+  tprod_mulIndicator_of_disjoint_on_mulSupport_of_mem s f i hi (pairwise_disjoint_mono hs
     <| fun _ _ hi ↦ hi.1)
 
 @[to_additive]

--- a/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimensionBilinear.lean
@@ -37,7 +37,7 @@ variable
   vector spaces over a complete field. -/
 def LinearMap.toContinuousBilinearMap (f : E →ₗ[𝕜] F →ₗ[𝕜] G) : E →L[𝕜] F →L[𝕜] G :=
   IsLinearMap.mk' (fun x : E ↦ f x |>.toContinuousLinearMap)
-      (by constructor <;> (intros;simp)) |>.toContinuousLinearMap
+      (by constructor <;> (intros; simp)) |>.toContinuousLinearMap
 
 @[simp]
 lemma LinearMap.toContinuousBilinearMap_apply (f : E →ₗ[𝕜] F →ₗ[𝕜] G) (x : E) (y : F) :

--- a/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
@@ -59,7 +59,7 @@ instance (priority := low) {R : Type*} [CommRing R] [ValuativeRel R] [UniformSpa
     simp_rw [Valuation.restrict_lt_iff_lt_embedding]
     convert mem_nhds_zero_iff (R := R)
     simpa [← Valuation.restrict_lt_iff_lt_embedding] using
-        (valuation R).exists_setOf_restrict_le_iff 0 _
+      (valuation R).exists_setOf_restrict_le_iff 0 _
 
 lemma v_eq_valuation {R : Type*} [CommRing R] [ValuativeRel R] [UniformSpace R]
     [IsUniformAddGroup R] [IsValuativeTopology R] :

--- a/Mathlib/Topology/Algebra/Valued/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuedField.lean
@@ -288,7 +288,7 @@ theorem continuous_extension : Continuous (Valued.extension : hat K → ValueGro
     rw [WithZeroTopology.tendsto_of_ne_zero vz₀_ne, eventually_comap]
     filter_upwards [nhds_right] with x x_in a ha
     rcases x_in with ⟨y, y_in, rfl⟩
-    have : (v.restrict (a * z₀⁻¹) ) = 1 := by
+    have : (v.restrict (a * z₀⁻¹)) = 1 := by
       rw [v.restrict_def, ValueGroup₀.restrict₀_eq_one_iff]
       apply hV
       have : (z₀⁻¹ : K) = (z₀ : hat K)⁻¹ := map_inv₀ (Completion.coeRingHom : K →+* hat K) z₀
@@ -506,7 +506,7 @@ noncomputable def valueGroup₀_equiv_extensionValuation :
         simp only [ne_eq, extension_eq_zero_iff, map_eq_zero]
         rw [← hy_def] at hy
         simpa [← hy] using hb0
-      simp only [h0, ↓reduceDIte,  h0', WithZero.coe_inj, Subtype.mk.injEq, Units.mk0_inj] at this
+      simp only [h0, ↓reduceDIte, h0', WithZero.coe_inj, Subtype.mk.injEq, Units.mk0_inj] at this
       erw [embedding_strictMono.injective.eq_iff, extension_extends, extension_extends] at this
       simp only [Valuation.restrict_def, Algebra.algebraMap_self, RingHom.id_apply] at this
       rw [hx, hy] at this

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -481,7 +481,7 @@ theorem IsEquiv.uniformContinuous_equiv [hval : Valued R Γ₀'] (hv : Valued.v 
   have h' : v.restrict.IsEquiv w.restrict := h.restrict
   rw [← hr, equiv_apply, Set.mem_setOf_eq, lt_div_iff₀ ((restrict_pos_iff Valued.v s).mpr hs₀), hv,
     ← map_mul, ← lt_def, ← ofVal_mul,
-    ← hy, ← toVal_mul, ←  h'.orderRingIso_apply, ← h'.orderRingIso.lt_symm_apply]
+    ← hy, ← toVal_mul, ← h'.orderRingIso_apply, ← h'.orderRingIso.lt_symm_apply]
   simp only [toVal_mul, orderRingIso_symm_apply, lt_def, ofVal_mul, restrict_lt_iff]
   simp only [equiv_symm_apply, Units.val_mk0, Set.mem_setOf_eq, lt_div_iff₀ hs0'] at hx
   erw [← map_mul] at hx -- Why erw?
@@ -505,7 +505,7 @@ theorem IsEquiv.uniformContinuous_equiv_symm [hval : Valued R Γ₀'] (hv : Valu
   intro x hx
   simp only [equiv_symm_apply, Set.mem_setOf_eq]
   simp only [equiv_apply, Units.val_mk0, Set.mem_setOf_eq] at hx
-  erw [lt_div_iff₀ , ← map_mul, restrict_lt_iff, hv, h.lt_iff_lt, map_mul] at hx
+  erw [lt_div_iff₀, ← map_mul, restrict_lt_iff, hv, h.lt_iff_lt, map_mul] at hx
   · rw [← hr, lt_div_iff₀ ((restrict_pos_iff Valued.v s).mpr hs₀), ← map_mul, ← lt_def,
       ← h.orderRingIso_apply]
     simp only [orderRingIso_apply, toVal_mul, lt_def, ofVal_mul, restrict_lt_iff]

--- a/Mathlib/Topology/Compactness/CountablyCompact.lean
+++ b/Mathlib/Topology/Compactness/CountablyCompact.lean
@@ -273,7 +273,7 @@ theorem IsCountablyCompact.union (hA : IsCountablyCompact A) (hB : IsCountablyCo
   intro U hUo hAU
   obtain ⟨t₁, ht₁, hA_sub⟩ : ∃ (t₁ : Set ℕ), t₁.Finite ∧ A ⊆ ⋃ k ∈ t₁, U k :=
     hA U hUo (subset_union_left.trans hAU)
-  obtain  ⟨t₂, ht₂, hB_sub⟩ : ∃ (t₂ : Set ℕ), t₂.Finite ∧ B ⊆ ⋃ k ∈ t₂, U k :=
+  obtain ⟨t₂, ht₂, hB_sub⟩ : ∃ (t₂ : Set ℕ), t₂.Finite ∧ B ⊆ ⋃ k ∈ t₂, U k :=
     hB U hUo (subset_union_right.trans hAU)
   have h : (⋃ k ∈ t₁, U k) ∪ (⋃ k ∈ t₂, U k) = ⋃ k ∈ (t₁ ∪ t₂), U k := by ext; aesop
   exact ⟨t₁ ∪ t₂, ht₁.union ht₂, h ▸ union_subset_union hA_sub hB_sub⟩

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -653,7 +653,7 @@ lemma exists_fun_isClopen_of_infinite [Infinite (ConnectedComponents α)] (n : �
     · simpa [Fin.forall_iff_succ, *] using fun x ↦ h₂ (Equiv.swap 0 i (.succ x))
     · have h₃' (j : _) : Disjoint (U j) a ∧ Disjoint (U j) b := by
         simpa [onFun] using h₃ ((Equiv.swap 0 i).injective.ne (Fin.succ_ne_zero j))
-      simpa [Pairwise, Fin.forall_iff_succ, onFun, hab,  disjoint_comm (a := a),
+      simpa [Pairwise, Fin.forall_iff_succ, onFun, hab, disjoint_comm (a := a),
         disjoint_comm (a := b), h₃'] using
         h₃.comp_of_injective ((Equiv.swap 0 i).injective.comp (Fin.succ_injective _))
     · simpa [← union_assoc, (Equiv.surjective _).iUnion_comp] using h₄

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -45,7 +45,7 @@ namespace IsDenseInducing
 variable [TopologicalSpace α] [TopologicalSpace β]
 
 theorem _root_.Dense.isDenseInducing_val {s : Set α} (hs : Dense s) :
-    IsDenseInducing ((↑) : s →  α) := ⟨IsInducing.subtypeVal, hs.denseRange_val⟩
+    IsDenseInducing ((↑) : s → α) := ⟨IsInducing.subtypeVal, hs.denseRange_val⟩
 
 variable {i : α → β}
 

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -112,11 +112,11 @@ namespace NNRat
 instance : MetricSpace ℚ≥0 :=
   inferInstanceAs <| MetricSpace (Subtype _)
 
-set_option linter.style.whitespace false in
+set_option linter.style.whitespace false in -- linter false positive
 @[simp ←, push_cast]
 lemma dist_eq (p q : ℚ≥0) : dist p q = dist (p : ℚ) (q : ℚ) := rfl
 
-set_option linter.style.whitespace false in
+set_option linter.style.whitespace false in -- linter false positive
 @[simp ←, push_cast]
 lemma nndist_eq (p q : ℚ≥0) : nndist p q = nndist (p : ℚ) (q : ℚ) := rfl
 

--- a/Mathlib/Topology/MetricSpace/Holder.lean
+++ b/Mathlib/Topology/MetricSpace/Holder.lean
@@ -194,8 +194,8 @@ lemma of_le {C D s : ℝ≥0} {A : Set X}
   have hr : 0 < r := ht.trans_le hsr
   rw [← NNReal.coe_le_coe] at hsr
   rw [← NNReal.coe_pos] at hr
-  set θ₁ : ℝ≥0 := .mk (s/r) (by positivity)
-  set θ₂ : ℝ≥0 := .mk (1 - s/r) (by simpa using div_le_one_of_le₀ hsr (by positivity))
+  set θ₁ : ℝ≥0 := .mk (s / r) (by positivity)
+  set θ₂ : ℝ≥0 := .mk (1 - s / r) (by simpa using div_le_one_of_le₀ hsr (by positivity))
   have hθ : θ₁ + θ₂ = 1 := by ext; simp [θ₁, θ₂]
   have hθt : r * θ₁ + 0 * θ₂ = s := by ext; simp [θ₁, mul_div_cancel₀ _ hr.ne']
   have hθC : C * D ^ (r - s : ℝ) = C ^ (θ₁ : ℝ) * (C * D ^ (r : ℝ)) ^ (θ₂ : ℝ) := by

--- a/Mathlib/Topology/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Order/LiminfLimsup.lean
@@ -345,7 +345,7 @@ theorem exists_seq_tendsto_limsSup [NeBot f] [IsCountablyGenerated f]
 theorem exists_seq_tendsto_limsInf [NeBot f] [IsCountablyGenerated f]
     (hc : f.IsCobounded (· ≥ ·) := by isBoundedDefault)
     (hb : f.IsBounded (· ≥ ·) := by isBoundedDefault) :
-    ∃ x : ℕ → α, Tendsto x atTop (𝓝 f.limsInf) ∧ Tendsto x atTop f  :=
+    ∃ x : ℕ → α, Tendsto x atTop (𝓝 f.limsInf) ∧ Tendsto x atTop f :=
   (ClusterPt.limsInf).exists_seq_tendsto
 
 variable {f : Filter β}

--- a/Mathlib/Topology/Sheaves/Abelian.lean
+++ b/Mathlib/Topology/Sheaves/Abelian.lean
@@ -92,7 +92,7 @@ lemma isZero_iff_stalkFunctor_obj_isZero (F : Sheaf C X) :
   intro h
   let f : F ⟶ 0 := (isZero_zero (Sheaf C X)).from_ F
   have : IsIso f := by
-    rw[Presheaf.isIso_iff_stalkFunctor_map_iso]
+    rw [Presheaf.isIso_iff_stalkFunctor_map_iso]
     exact fun x => isIso_of_source_target_iso_zero _ (h x).isoZero
       ((forget C X ⋙ stalkFunctor C x).map_isZero (isZero_zero _)).isoZero
   exact (isZero_zero _).of_iso (asIso f)

--- a/Mathlib/Topology/Sheaves/AddCommGrpCat.lean
+++ b/Mathlib/Topology/Sheaves/AddCommGrpCat.lean
@@ -45,7 +45,7 @@ lemma Sheaf.sections_exact_of_left_exact {S : ShortComplex (TopCat.Sheaf AddComm
     inferInstance S ⟨hS, hf⟩).left h
 
 lemma Presheaf.restrict_sum {V : Opens X} {F : Presheaf AddCommGrpCat X} (h : V ≤ U)
-    (s t : F.obj (op U)) : (s + t) |_ V = s |_V + t |_V := by
+    (s t : F.obj (op U)) : (s + t) |_ V = s |_ V + t |_ V := by
   delta Presheaf.restrictOpen Presheaf.restrict
   cat_disch
 

--- a/Mathlib/Topology/Sheaves/LocallySurjective.lean
+++ b/Mathlib/Topology/Sheaves/LocallySurjective.lean
@@ -63,7 +63,7 @@ def IsLocallySurjective (T : ℱ ⟶ 𝒢) :=
 
 theorem isLocallySurjective_iff (T : ℱ ⟶ 𝒢) :
     IsLocallySurjective T ↔
-      ∀ (U t), ∀ x ∈ U, ∃ (V : _) (_ : V ≤ U), (∃ s, (T.app _) s = t |_ V ) ∧ x ∈ V := by
+      ∀ (U t), ∀ x ∈ U, ∃ (V : _) (_ : V ≤ U), (∃ s, (T.app _) s = t |_ V) ∧ x ∈ V := by
   refine ⟨fun h _ t x hx ↦ ?_, fun h => ⟨fun s x hx ↦ ?_⟩⟩
   · obtain ⟨V, i, hi⟩ := h.imageSieve_mem t x hx
     exact ⟨V, leOfHom i, hi⟩

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -326,13 +326,13 @@ theorem pullbackObjObjOfImageOpen_hom_naturality {X Y : TopCat.{v}} (f : X ⟶ Y
     (fun j ↦ ?_)
   have eq : ((LeftExtension.mk ((Opens.map f).op.leftKanExtension ℱ)
       ((Opens.map f).op.leftKanExtensionUnit ℱ)).coconeAt
-      (op V)).ι.app j ≫ ((pullback C f).obj ℱ).map (homOfLE le).op  =
+      (op V)).ι.app j ≫ ((pullback C f).obj ℱ).map (homOfLE le).op =
       ((LeftExtension.mk ((Opens.map f).op.leftKanExtension ℱ)
       ((Opens.map f).op.leftKanExtensionUnit ℱ)).coconeAt
       (op U)).ι.app ((CostructuredArrow.map (homOfLE le).op).obj j) := by cat_disch
   rw [Limits.IsColimit.comp_coconePointUniqueUpToIso_hom_assoc, reassoc_of% eq,
     Limits.IsColimit.comp_coconePointUniqueUpToIso_hom,
-    Limits.coconeOfDiagramTerminal_ι_app,Limits.coconeOfDiagramTerminal_ι_app]
+    Limits.coconeOfDiagramTerminal_ι_app, Limits.coconeOfDiagramTerminal_ι_app]
   dsimp
   rw [← Functor.map_comp]
   cat_disch

--- a/Mathlib/Topology/Sion.lean
+++ b/Mathlib/Topology/Sion.lean
@@ -74,7 +74,7 @@ variable {E F : Type*} {β : Type*} [LinearOrder β]
 
 /-- The familywise sublevel sets of `f`, the first variable serving as a parameter -/
 def sublevelLeft (b : β) (z : F) : Set X :=
-  (fun x => f x z) ∘ (fun x ↦ ↑x)⁻¹' Iic b
+  (fun x => f x z) ∘ (fun x ↦ ↑x) ⁻¹' Iic b
 
 variable {X Y f}
 
@@ -355,7 +355,7 @@ public theorem minimax
   · -- the case when `Y` is empty is trivial
     simp only [mem_empty_iff_false, IsEmpty.forall_iff, implies_true, false_and, exists_const,
       setOf_false, isLUB_empty_iff] at *
-    replace hsup_y : ∀ x ∈ X,  sup_y x = sup_inf :=
+    replace hsup_y : ∀ x ∈ X, sup_y x = sup_inf :=
       fun x hx ↦ le_antisymm (hsup_y x hx sup_inf) (hsup_inf (sup_y x))
     suffices {t | ∃ x ∈ X, sup_y x = t} = {sup_inf} from (this ▸ hinf_sup).unique (by simp) |>.le
     ext t
@@ -392,7 +392,7 @@ public theorem minimax
   simp only [lt_isLUB_iff hsup_inf, mem_setOf_eq, exists_exists_and_eq_and]
   use y0 hs', hy0 hs'
   specialize ht0 hs'
-  obtain ⟨a, ha, h⟩ := LowerSemicontinuousOn.exists_isMinOn ne_X kX (hfy (y0  hs') (hy0 hs'))
+  obtain ⟨a, ha, h⟩ := LowerSemicontinuousOn.exists_isMinOn ne_X kX (hfy (y0 hs') (hy0 hs'))
   apply lt_of_lt_of_le (ht0 a ha)
   simpa [le_isGLB_iff (hinf_x (y0 hs') (hy0 hs')), mem_lowerBounds]
 
@@ -501,7 +501,7 @@ when `β` is given a Dedekind-MacNeille completion `ι : β ↪o γ` -/
 public theorem DMCompletion.exists_isSaddlePointOn :
   ∃ a ∈ X, ∃ b ∈ Y, IsSaddlePointOn X Y f a b := by
   -- Reduce to the cae of EReal-valued functions
-  let φ : E → F → γ := fun x y ↦  ι (f x y)
+  let φ : E → F → γ := fun x y ↦ ι (f x y)
   -- suffices : ∃ a ∈ X, ∃ b ∈ Y, IsSaddlePointOn X Y φ a b
   have hφx (x) (hx : x ∈ X) : UpperSemicontinuousOn (fun y ↦ φ x y) Y := by
     convert Continuous.comp_upperSemicontinuousOn hι (hfx x hx) ι.monotone


### PR DESCRIPTION
Found by extending the whitespace linter to proof bodies in #30658.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
