### PR TITLE
[Merged by Bors] - perf(Data/Complex/Basic): don't expose complex multiplication

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -228,7 +228,7 @@ theorem c_mul_im_sq_le_normSq_denom : (g 1 0 * z.im) ^ 2 ≤ Complex.normSq (den
   set d := g 1 1
   calc
     (c * z.im) ^ 2 ≤ (c * z.im) ^ 2 + (c * z.re + d) ^ 2 := by nlinarith
-    _ = Complex.normSq (denom g z) := by dsimp [c, d, denom, Complex.normSq]; ring
+    _ = Complex.normSq (denom g z) := by simp [denom, Complex.normSq]; ring
 
 @[simp]
 theorem neg_smul : -g • z = g • z := by

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -172,14 +172,9 @@ theorem add_re (z w : ℂ) : (z + w).re = z.re + w.re :=
 theorem add_im (z w : ℂ) : (z + w).im = z.im + w.im :=
   rfl
 
--- replaced by `re_ofNat`
--- replaced by `im_ofNat`
-
 @[simp, norm_cast]
 theorem ofReal_add (r s : ℝ) : ((r + s : ℝ) : ℂ) = r + s :=
   Complex.ext_iff.2 <| by simp [ofReal]
-
--- replaced by `Complex.ofReal_ofNat`
 
 instance : Neg ℂ :=
   ⟨fun z => ⟨-z.re, -z.im⟩⟩
@@ -199,16 +194,28 @@ theorem ofReal_neg (r : ℝ) : ((-r : ℝ) : ℂ) = -r :=
 instance : Sub ℂ :=
   ⟨fun z w => ⟨z.re - w.re, z.im - w.im⟩⟩
 
+/--
+`mulAux` is an auxiliary definition for defining multiplication and scalar multiplication on `ℂ`
+in such a way that `real_smul {x : ℝ} {z : ℂ} : x • z = x * z` holds definitionally.
+This makes sure that `Module.restrictScalars ℝ ℂ ℂ = Complex.module` definitionally.
+-/
+@[no_expose]
+def mulAux {R : Type*} [SMul R ℝ] (s : R) (r : ℝ) (z : ℂ) : ℂ :=
+  ⟨s • z.re - r * z.im, s • z.im + r * z.re⟩
+
 instance : Mul ℂ :=
-  ⟨fun z w => ⟨z.re * w.re - z.im * w.im, z.re * w.im + z.im * w.re⟩⟩
+  ⟨fun z w => mulAux z.re z.im w⟩
+
+theorem mk_mul_mk (x₁ x₂ y₁ y₂ : ℝ) :
+  (⟨x₁, y₁⟩ : ℂ) * ⟨x₂, y₂⟩ = ⟨x₁ * x₂ - y₁ * y₂, x₁ * y₂ + y₁ * x₂⟩ := (rfl)
 
 @[simp]
 theorem mul_re (z w : ℂ) : (z * w).re = z.re * w.re - z.im * w.im :=
-  rfl
+  (rfl)
 
 @[simp]
 theorem mul_im (z w : ℂ) : (z * w).im = z.re * w.im + z.im * w.re :=
-  rfl
+  (rfl)
 
 @[simp, norm_cast]
 theorem ofReal_mul (r s : ℝ) : ((r * s : ℝ) : ℂ) = r * s :=
@@ -286,15 +293,13 @@ instance : Nontrivial ℂ :=
 
 namespace SMul
 
--- The useless `0` multiplication in `smul` is to make sure that
--- `Module.restrictScalars ℝ ℂ ℂ = Complex.module` definitionally.
 -- instance made scoped to avoid situations like instance synthesis
 -- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
 /-- Scalar multiplication by `R` on `ℝ` extends to `ℂ`. This is used here and in
 `Mathlib/LinearAlgebra/Complex/Module.lean` to transfer instances from `ℝ` to `ℂ`, but is not
 needed outside, so we make it scoped. -/
 scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
-  smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
+  smul r x := mulAux r 0 x
 
 end SMul
 
@@ -304,9 +309,11 @@ section SMul
 
 variable {R : Type*} [SMul R ℝ]
 
-theorem smul_re (r : R) (z : ℂ) : (r • z).re = r • z.re := by simp [(· • ·), SMul.smul]
+theorem smul_re (r : R) (z : ℂ) : (r • z).re = r • z.re :=
+  show r • z.re - 0 * z.im = r • z.re by simp
 
-theorem smul_im (r : R) (z : ℂ) : (r • z).im = r • z.im := by simp [(· • ·), SMul.smul]
+theorem smul_im (r : R) (z : ℂ) : (r • z).im = r • z.im :=
+  show r • z.im + 0 * z.re = r • z.im by simp
 
 @[simp]
 theorem real_smul {x : ℝ} {z : ℂ} : x • z = x * z :=
@@ -482,7 +489,7 @@ def normSq : ℂ →*₀ ℝ where
   map_zero' := by simp
   map_one' := by simp
   map_mul' z w := by
-    dsimp
+    simp only [mul_re, mul_im]
     ring
 
 theorem normSq_apply (z : ℂ) : normSq z = z.re * z.re + z.im * z.im :=
@@ -546,7 +553,7 @@ theorem normSq_mul (z w : ℂ) : normSq (z * w) = normSq z * normSq w :=
   normSq.map_mul z w
 
 theorem normSq_add (z w : ℂ) : normSq (z + w) = normSq z + normSq w + 2 * (z * conj w).re := by
-  dsimp [normSq]; ring
+  simp [normSq]; ring
 
 theorem re_sq_le_normSq (z : ℂ) : z.re * z.re ≤ normSq z :=
   le_add_of_nonneg_right (mul_self_nonneg _)

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -200,14 +200,14 @@ in such a way that `real_smul {x : ℝ} {z : ℂ} : x • z = x * z` holds defin
 This makes sure that `Module.restrictScalars ℝ ℂ ℂ = Complex.module` definitionally.
 -/
 @[no_expose]
-def mulAux {R : Type*} [SMul R ℝ] (s : R) (r : ℝ) (z : ℂ) : ℂ :=
-  ⟨s • z.re - r * z.im, s • z.im + r * z.re⟩
+def mulAux {R : Type*} [SMul R ℝ] (re : R) (im : ℝ) (z : ℂ) : ℂ :=
+  ⟨re • z.re - im * z.im, re • z.im + im * z.re⟩
 
 instance : Mul ℂ :=
   ⟨fun z w => mulAux z.re z.im w⟩
 
 theorem mk_mul_mk (x₁ x₂ y₁ y₂ : ℝ) :
-  (⟨x₁, y₁⟩ : ℂ) * ⟨x₂, y₂⟩ = ⟨x₁ * x₂ - y₁ * y₂, x₁ * y₂ + y₁ * x₂⟩ := (rfl)
+    (⟨x₁, y₁⟩ : ℂ) * ⟨x₂, y₂⟩ = ⟨x₁ * x₂ - y₁ * y₂, x₁ * y₂ + y₁ * x₂⟩ := (rfl)
 
 @[simp]
 theorem mul_re (z w : ℂ) : (z * w).re = z.re * w.re - z.im * w.im :=

--- a/Mathlib/LinearAlgebra/Complex/Module.lean
+++ b/Mathlib/LinearAlgebra/Complex/Module.lean
@@ -288,18 +288,20 @@ See `Complex.lift` for this as an equiv. -/
 def liftAux (I' : A) (hf : I' * I' = -1) : ℂ →ₐ[ℝ] A :=
   AlgHom.ofLinearMap
     ((Algebra.linearMap ℝ A).comp reLm + (LinearMap.toSpanSingleton _ _ I').comp imLm)
-    (show algebraMap ℝ A 1 + (0 : ℝ) • I' = 1 by rw [map_one, zero_smul, add_zero])
-    fun ⟨x₁, y₁⟩ ⟨x₂, y₂⟩ =>
-    show
-      algebraMap ℝ A (x₁ * x₂ - y₁ * y₂) + (x₁ * y₂ + y₁ * x₂) • I' =
-        (algebraMap ℝ A x₁ + y₁ • I') * (algebraMap ℝ A x₂ + y₂ • I') by
-      rw [add_mul, mul_add, mul_add, add_comm _ (y₁ • I' * y₂ • I'), add_add_add_comm]
-      congr 1
-      -- equate "real" and "imaginary" parts
-      · rw [smul_mul_smul_comm, hf, smul_neg, ← algebraMap_eq_smul_one, ← sub_eq_add_neg,
-          ← map_mul, ← map_sub]
-      · rw [smul_def, smul_def, smul_def, ← right_comm _ x₂,
-          ← mul_assoc, ← add_mul, ← map_mul, ← map_mul, ← map_add]
+    (show algebraMap ℝ A 1 + (0 : ℝ) • I' = 1 by rw [map_one, zero_smul, add_zero]) ?_
+where finally
+  rintro ⟨x₁, y₁⟩ ⟨x₂, y₂⟩
+  rw [mk_mul_mk]
+  change
+    algebraMap ℝ A (x₁ * x₂ - y₁ * y₂) + (x₁ * y₂ + y₁ * x₂) • I' =
+      (algebraMap ℝ A x₁ + y₁ • I') * (algebraMap ℝ A x₂ + y₂ • I')
+  rw [add_mul, mul_add, mul_add, add_comm _ (y₁ • I' * y₂ • I'), add_add_add_comm]
+  congr 1
+  -- equate "real" and "imaginary" parts
+  · rw [smul_mul_smul_comm, hf, smul_neg, ← algebraMap_eq_smul_one, ← sub_eq_add_neg,
+      ← map_mul, ← map_sub]
+  · rw [smul_def, smul_def, smul_def, ← right_comm _ x₂,
+      ← mul_assoc, ← add_mul, ← map_mul, ← map_mul, ← map_add]
 
 @[simp]
 theorem liftAux_apply (I' : A) (hI') (z : ℂ) : liftAux I' hI' z = algebraMap ℝ A z.re + z.im • I' :=


### PR DESCRIPTION
This PR uses the module system to not expose the definition of complex multiplication.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
