### PR TITLE
[Merged by Bors] - chore(Algebra): remove simps projections for structures of bundled objects

### DIFF
--- a/Mathlib/Algebra/Category/BialgCat/Basic.lean
+++ b/Mathlib/Algebra/Category/BialgCat/Basic.lean
@@ -34,6 +34,7 @@ structure BialgCat where
   [instRing : Ring carrier]
   [instBialgebra : Bialgebra R carrier]
 
+initialize_simps_projections BialgCat (-instRing, -instBialgebra)
 attribute [instance] BialgCat.instBialgebra BialgCat.instRing
 
 variable {R}

--- a/Mathlib/Algebra/Category/HopfAlgCat/Basic.lean
+++ b/Mathlib/Algebra/Category/HopfAlgCat/Basic.lean
@@ -35,6 +35,7 @@ structure HopfAlgCat where
   [instRing : Ring carrier]
   [instHopfAlgebra : HopfAlgebra R carrier]
 
+initialize_simps_projections HopfAlgCat (-instRing, -instHopfAlgebra)
 attribute [instance] HopfAlgCat.instHopfAlgebra HopfAlgCat.instRing
 
 variable {R}

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -60,6 +60,7 @@ structure ModuleCat where
   [isAddCommGroup : AddCommGroup carrier]
   [isModule : Module R carrier]
 
+initialize_simps_projections ModuleCat (-isModule, -isAddCommGroup)
 attribute [instance] ModuleCat.isAddCommGroup
 attribute [instance 1100] ModuleCat.isModule
 

--- a/Mathlib/Algebra/Category/ModuleCat/Semi.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Semi.lean
@@ -59,6 +59,7 @@ structure SemimoduleCat where
   [isAddCommMonoid : AddCommMonoid carrier]
   [isModule : Module R carrier]
 
+initialize_simps_projections SemimoduleCat (-isModule, -isAddCommMonoid)
 attribute [instance] SemimoduleCat.isAddCommMonoid SemimoduleCat.isModule
 
 namespace SemimoduleCat


### PR DESCRIPTION
I noticed that currently, adding a `@[simps]` tag to a `ModuleCat`-valued definition will generate projections for the `isModule` fields. These projections are removed. Same in `BialgCat` and `HopfAlgCat`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I did not look very hard for all cases of this, but those three should be a starter.

Renaming `carrier` to `coe` will break a few things, so I opted for keeping it like this for now, feel free to disagree, but this will make the diff bigger. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
