### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Complex/Log): natural number versions of exp_eq_one_iff

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -159,13 +159,11 @@ theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
 
 theorem exp_two_pi_mul_I_mul_div_eq_one_iff {k N : ℕ} (hN : N ≠ 0) :
     exp (2 * π * I * k / N) = 1 ↔ N ∣ k := by
-  have hN' : (N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hN
   rw [exp_eq_one_iff]
-  refine ⟨fun ⟨n, hn⟩ ↦ ?_, fun ⟨m, hm⟩ ↦ ⟨m, by rw [hm]; push_cast; field_simp⟩⟩
-  suffices k = n * N by exact Int.ofNat_dvd.1 ⟨n, by grind⟩
-  have h0 : 2 * π * I ≠ 0 := by simp
-  refine Int.cast_inj.1 ((mul_left_inj' h0).1 ?_)
-  grind [Int.cast_natCast]
+  conv in _ = _ => rw [← mul_comm (2 * π * I), mul_div_assoc, mul_right_inj' (by simp)]
+  field_simp [Nat.cast_ne_zero.mpr hN]
+  norm_cast
+  simp [← dvd_def]
 
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -163,7 +163,7 @@ theorem exp_two_pi_mul_I_mul_div_eq_one_iff {k N : ℕ} (hN : N ≠ 0) :
   conv in _ = _ => rw [← mul_comm (2 * π * I), mul_div_assoc, mul_right_inj' (by simp)]
   field_simp [Nat.cast_ne_zero.mpr hN]
   norm_cast
-  simp [← dvd_def]
+  simp [← dvd_def, Int.ofNat_dvd]
 
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -162,18 +162,12 @@ theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
 theorem exp_two_pi_mul_I_mul_div_eq_one_iff {k N : ℕ} (hN : N ≠ 0) :
     exp (2 * π * I * k / N) = 1 ↔ N ∣ k := by
   have hN' : (N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hN
-  have h2πI : (2 * ↑π * I : ℂ) ≠ 0 := by simp [Real.pi_ne_zero, I_ne_zero]
   rw [exp_eq_one_iff]
-  constructor
-  · rintro ⟨n, hn⟩
-    have h1 : (k : ℂ) = n * N := by
-      have h := mul_right_cancel₀ h2πI (show (↑k / ↑N) * (2 * ↑π * I) = n * (2 * ↑π * I) by
-        rw [show (↑k : ℂ) / ↑N * (2 * ↑π * I) = 2 * ↑π * I * ↑k / ↑N from by ring]; exact hn)
-      rwa [div_eq_iff hN'] at h
-    have h2 : (k : ℤ) = n * ↑N := by exact_mod_cast h1
-    exact_mod_cast (show (↑N : ℤ) ∣ ↑k from ⟨n, h2.symm ▸ mul_comm n ↑N⟩)
-  · rintro ⟨m, hm⟩
-    exact ⟨m, by subst hm; push_cast; field_simp [hN']⟩
+  refine ⟨fun ⟨n, hn⟩ ↦ ?_, fun ⟨m, hm⟩ ↦ ⟨m, by rw [hm]; push_cast; field_simp⟩⟩
+  suffices k = n * N by exact Int.ofNat_dvd.1 ⟨n, by grind⟩
+  have h0 : 2 * π * I ≠ 0 := by simp
+  refine Int.cast_inj.1 ((mul_left_inj' h0).1 ?_)
+  grind [Int.cast_natCast]
 
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -152,16 +152,12 @@ theorem exp_eq_one_iff {x : ℂ} : exp x = 1 ↔ ∃ n : ℤ, x = n * (2 * π * 
 theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
     exp x = 1 ↔ ∃ n : ℕ, x = n * (2 * π * I) := by
   rw [exp_eq_one_iff]
-  constructor
-  · rintro ⟨n, rfl⟩
-    have hn : 0 ≤ n := by
-      have h1 : (↑n * (2 * ↑π * I)).im = ↑n * (2 * π) := by
-        simp [mul_im, I_re, I_im]
-      rw [h1] at hx
-      exact_mod_cast nonneg_of_mul_nonneg_left hx (by positivity)
-    exact ⟨n.toNat, by congr 1; exact_mod_cast (Int.toNat_of_nonneg hn).symm⟩
-  · rintro ⟨n, rfl⟩
-    exact ⟨n, by push_cast; ring⟩
+  refine ⟨fun ⟨n, hn⟩ ↦ ?_, fun ⟨n, hn⟩ ↦ ⟨n, by rw [hn]; norm_cast⟩⟩
+  lift n to ℕ
+  · rw [hn] at hx
+    rw [show (n * (2 * ↑π * I) : ℂ).im = n * (2 * π) by simp] at hx
+    exact_mod_cast nonneg_of_mul_nonneg_left hx (mul_pos two_pos Real.pi_pos)
+  · exact ⟨n, hn⟩
 
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -153,11 +153,9 @@ theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
     exp x = 1 ↔ ∃ n : ℕ, x = n * (2 * π * I) := by
   rw [exp_eq_one_iff]
   refine ⟨fun ⟨n, hn⟩ ↦ ?_, fun ⟨n, hn⟩ ↦ ⟨n, by rw [hn]; norm_cast⟩⟩
-  lift n to ℕ
-  · rw [hn] at hx
-    rw [show (n * (2 * ↑π * I) : ℂ).im = n * (2 * π) by simp] at hx
-    exact_mod_cast nonneg_of_mul_nonneg_left hx (mul_pos two_pos Real.pi_pos)
-  · exact ⟨n, hn⟩
+  have : 0 ≤ n * (2 * π) := by simpa [hn] using hx
+  lift n to ℕ using by exact_mod_cast nonneg_of_mul_nonneg_left this (by positivity)
+  exact ⟨n, hn⟩
 
 theorem exp_two_pi_mul_I_mul_div_eq_one_iff {k N : ℕ} (hN : N ≠ 0) :
     exp (2 * π * I * k / N) = 1 ↔ N ∣ k := by

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -149,6 +149,20 @@ theorem exp_eq_one_iff {x : ℂ} : exp x = 1 ↔ ∃ n : ℤ, x = n * (2 * π * 
   · rintro ⟨n, rfl⟩
     exact (exp_periodic.int_mul n).eq.trans exp_zero
 
+theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
+    exp x = 1 ↔ ∃ n : ℕ, x = n * (2 * π * I) := by
+  rw [exp_eq_one_iff]
+  constructor
+  · rintro ⟨n, rfl⟩
+    have hn : 0 ≤ n := by
+      have h1 : (↑n * (2 * ↑π * I)).im = ↑n * (2 * π) := by
+        simp [mul_im, I_re, I_im]
+      rw [h1] at hx
+      exact_mod_cast nonneg_of_mul_nonneg_left hx (by positivity)
+    exact ⟨n.toNat, by congr 1; exact_mod_cast (Int.toNat_of_nonneg hn).symm⟩
+  · rintro ⟨n, rfl⟩
+    exact ⟨n, by push_cast; ring⟩
+
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -159,6 +159,22 @@ theorem exp_eq_one_iff_of_im_nonneg {x : ℂ} (hx : 0 ≤ x.im) :
     exact_mod_cast nonneg_of_mul_nonneg_left hx (mul_pos two_pos Real.pi_pos)
   · exact ⟨n, hn⟩
 
+theorem exp_two_pi_mul_I_mul_div_eq_one_iff {k N : ℕ} (hN : N ≠ 0) :
+    exp (2 * π * I * k / N) = 1 ↔ N ∣ k := by
+  have hN' : (N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hN
+  have h2πI : (2 * ↑π * I : ℂ) ≠ 0 := by simp [Real.pi_ne_zero, I_ne_zero]
+  rw [exp_eq_one_iff]
+  constructor
+  · rintro ⟨n, hn⟩
+    have h1 : (k : ℂ) = n * N := by
+      have h := mul_right_cancel₀ h2πI (show (↑k / ↑N) * (2 * ↑π * I) = n * (2 * ↑π * I) by
+        rw [show (↑k : ℂ) / ↑N * (2 * ↑π * I) = 2 * ↑π * I * ↑k / ↑N from by ring]; exact hn)
+      rwa [div_eq_iff hN'] at h
+    have h2 : (k : ℤ) = n * ↑N := by exact_mod_cast h1
+    exact_mod_cast (show (↑N : ℤ) ∣ ↑k from ⟨n, h2.symm ▸ mul_comm n ↑N⟩)
+  · rintro ⟨m, hm⟩
+    exact ⟨m, by subst hm; push_cast; field_simp [hN']⟩
+
 theorem exp_eq_exp_iff_exp_sub_eq_one {x y : ℂ} : exp x = exp y ↔ exp (x - y) = 1 := by
   rw [exp_sub, div_eq_one_iff_eq (exp_ne_zero _)]
 


### PR DESCRIPTION
Add two lemmas:
- `Complex.exp_eq_one_iff_of_im_nonneg`, a variant of `Complex.exp_eq_one_iff` that gives a natural number instead of an integer, under the hypothesis that the imaginary part is nonneg.
- `Complex.exp_two_pi_mul_I_mul_div_eq_one_iff`, showing that `exp (2πik/N) = 1` if and only if `N ∣ k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)