### PR TITLE
feat: `Order.lt_add_one`

### DIFF
--- a/Mathlib/Algebra/Order/SuccPred.lean
+++ b/Mathlib/Algebra/Order/SuccPred.lean
@@ -18,12 +18,6 @@ public import Mathlib.Order.SuccPred.WithBot
 We define the `SuccAddOrder` and `PredSubOrder` typeclasses, for orders satisfying `succ x = x + 1`
 and `pred x = x - 1` respectively. This allows us to transfer the API for successors and
 predecessors into these common arithmetical forms.
-
-## Todo
-
-In the future, we will make `x + 1` and `x - 1` the `simp`-normal forms for `succ x` and `pred x`
-respectively. This will require a refactor of `Ordinal` first, as the `simp`-normal form is
-currently set the other way around.
 -/
 
 @[expose] public section
@@ -72,6 +66,10 @@ theorem wcovBy_add_one (x : α) : x ⩿ x + 1 := by
 theorem covBy_add_one [NoMaxOrder α] (x : α) : x ⋖ x + 1 := by
   rw [← succ_eq_add_one]
   exact covBy_succ x
+
+@[simp]
+theorem lt_add_one [NoMaxOrder α] (x : α) : x < x + 1 :=
+  (covBy_add_one x).lt
 
 end Add
 

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -1038,7 +1038,7 @@ theorem not_surjective_of_ordinal {α : Type*} [Small.{u} α] (f : α → Ordina
   obtain ⟨a, ha⟩ := h (⨆ i, succ (f i))
   apply ha.not_lt
   rw [Ordinal.lt_iSup_iff]
-  exact ⟨a, Order.lt_succ _⟩
+  exact ⟨a, Order.lt_add_one _⟩
 
 theorem not_injective_of_ordinal {α : Type*} [Small.{u} α] (f : Ordinal.{u} → α) :
     ¬ Injective f := fun h ↦ not_surjective_of_ordinal _ (invFun_surjective h)

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -1038,7 +1038,7 @@ theorem not_surjective_of_ordinal {α : Type*} [Small.{u} α] (f : α → Ordina
   obtain ⟨a, ha⟩ := h (⨆ i, succ (f i))
   apply ha.not_lt
   rw [Ordinal.lt_iSup_iff]
-  exact ⟨a, Order.lt_add_one _⟩
+  exact ⟨a, Order.lt_succ _⟩
 
 theorem not_injective_of_ordinal {α : Type*} [Small.{u} α] (f : Ordinal.{u} → α) :
     ¬ Injective f := fun h ↦ not_surjective_of_ordinal _ (invFun_surjective h)


### PR DESCRIPTION
We already have `Order.lt_add_one_iff`, but this aids discoverability. We also remove an obsolete TODO.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
