### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus): define absolutely monotone functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1649,6 +1649,7 @@ public import Mathlib.Analysis.CStarAlgebra.Unitary.Maps
 public import Mathlib.Analysis.CStarAlgebra.Unitary.Span
 public import Mathlib.Analysis.CStarAlgebra.Unitization
 public import Mathlib.Analysis.CStarAlgebra.lpSpace
+public import Mathlib.Analysis.Calculus.AbsolutelyMonotone
 public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 public import Mathlib.Analysis.Calculus.AddTorsor.Coord
 public import Mathlib.Analysis.Calculus.BumpFunction.Basic

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -5,21 +5,40 @@ Authors: Michael R. Douglas
 -/
 module
 
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 
 /-!
-# Absolutely Monotone Functions
+# Absolutely monotone functions
 
-A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth on `s` and all its
-iterated derivatives within `s` are nonnegative on `s`.
+A function `f : ℝ → ℝ` is *absolutely monotone* on a set `s` if there exists a Taylor series for
+`f` on `s` whose terms are all nonnegative at each point of `s`. Phrasing the condition via
+existence of a Taylor series (`HasFTaylorSeriesUpToOn`) avoids forcing a `UniqueDiffOn s`
+hypothesis on every result: without `UniqueDiffOn`, "the" iterated derivative within `s` is not
+canonical, but the existence of a Taylor series is intrinsic to `f` and `s`.
+
+When `s` does satisfy `UniqueDiffOn`, the condition reduces to `f` being `C^∞` on `s` with every
+iterated derivative within `s` nonnegative.
 
 ## Main definitions
 
-* `AbsolutelyMonotoneOn` — smooth on `s` with nonnegative iterated derivatives within `s`
+* `AbsolutelyMonotoneOn` — there exists a Taylor series for `f` on `s` with nonnegative terms at
+  each point of `s`.
+* `CompletelyMonotoneOn` — there exists a Taylor series for `f` on `s` whose terms have
+  alternating signs (equivalently, `(-1)^n f⁽ⁿ⁾(x) ≥ 0`).
 
 ## Main results
 
-* Closure under `add`, `smul`, `mul`
+* `AbsolutelyMonotoneOn.contDiffOn` — the function is `C^∞` on `s`.
+* `AbsolutelyMonotoneOn.of_contDiff` — a globally `C^∞` function with nonnegative iterated
+  derivatives on `s` is absolutely monotone on `s` (no `UniqueDiffOn` hypothesis).
+* `AbsolutelyMonotoneOn.add` — closure under addition (no `UniqueDiffOn` hypothesis).
+* `AbsolutelyMonotoneOn.smul` — closure under nonnegative scalar multiplication (no `UniqueDiffOn`
+  hypothesis).
+* `AbsolutelyMonotoneOn.mul` — closure under multiplication (requires `UniqueDiffOn s` because the
+  proof uses the Leibniz rule for `iteratedDerivWithin`).
+* `CompletelyMonotoneOn.contDiffOn` — a completely monotone function is `C^∞` on `s`.
+* `CompletelyMonotoneOn.of_contDiff` — constructor from `(-1)^n f⁽ⁿ⁾(x) ≥ 0`.
 
 ## References
 
@@ -29,55 +48,146 @@ iterated derivatives within `s` are nonnegative on `s`.
 public section
 
 open Set Filter
-open scoped ENNReal NNReal Topology ContDiff
+open scoped ContDiff
 
-/-- A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth on `s` and all
-iterated derivatives within `s` are nonnegative. -/
-structure AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop where
-  contDiffOn : ContDiffOn ℝ ∞ f s
-  nonneg : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDerivWithin n f s x
+/-- A function `f : ℝ → ℝ` is **absolutely monotone on a set `s`** if there exists a Taylor
+series `p` for `f` on `s` whose `n`th term, evaluated at the all-ones tuple, is nonnegative for
+every `n` and every `x ∈ s`. -/
+def AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
+  ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
+    HasFTaylorSeriesUpToOn ∞ f p s ∧
+    ∀ (n : ℕ) ⦃x : ℝ⦄, x ∈ s → 0 ≤ p x n fun _ ↦ (1 : ℝ)
 
 namespace AbsolutelyMonotoneOn
 
-/-- A globally smooth function all of whose iterated derivatives are nonnegative on a set `s`
-satisfying `UniqueDiffOn` is absolutely monotone on `s`. Such sets `s` include open sets,
-`Set.Ici`, and convex sets with nonempty interior. -/
-theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
-    (hf : ContDiff ℝ ∞ f) (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
-    AbsolutelyMonotoneOn f s where
-  contDiffOn := hf.contDiffOn
-  nonneg n x hx := by
-    rw [iteratedDerivWithin_eq_iteratedDeriv hs (hf.contDiffAt.of_le (by exact_mod_cast le_top))
-      hx]
-    exact h n x hx
+variable {f g : ℝ → ℝ} {s : Set ℝ}
 
-/-! ### Basic closure properties -/
+/-- An absolutely monotone function on `s` is `C^∞` on `s`. -/
+theorem contDiffOn (hf : AbsolutelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
+  obtain ⟨_, hp, _⟩ := hf
+  exact hp.contDiffOn
 
-theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+/-- A globally `C^∞` function whose iterated derivatives are nonnegative on `s` is absolutely
+monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
+theorem of_contDiff (hf : ContDiff ℝ ∞ f) (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
+    AbsolutelyMonotoneOn f s := by
+  refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
+  -- ftaylorSeries ℝ f x n = iteratedFDeriv ℝ n f x; evaluated at (1, ..., 1) gives iteratedDeriv.
+  show 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (1 : ℝ)
+  rw [← iteratedDeriv_eq_iteratedFDeriv]
+  exact h n x hx
+
+/-- Under `UniqueDiffOn`, a Taylor witness for an absolutely monotone function agrees with
+`iteratedDerivWithin`, so the latter is nonnegative on `s`. -/
+theorem iteratedDerivWithin_nonneg (hf : AbsolutelyMonotoneOn f s) (hs : UniqueDiffOn ℝ s)
+    (n : ℕ) {x : ℝ} (hx : x ∈ s) : 0 ≤ iteratedDerivWithin n f s x := by
+  obtain ⟨p, hp, hp_nn⟩ := hf
+  have heq : p x n = iteratedFDerivWithin ℝ n f s x :=
+    hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
+  rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq]
+  exact hp_nn n hx
+
+/-! ### Closure properties -/
+
+/-- The sum of two absolutely monotone functions is absolutely monotone (no `UniqueDiffOn`
+hypothesis). -/
+theorem add (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
+    AbsolutelyMonotoneOn (f + g) s := by
+  obtain ⟨p, hp, hp_nn⟩ := hf
+  obtain ⟨q, hq, hq_nn⟩ := hg
+  refine ⟨p + q, hp.add hq, fun n x hx => ?_⟩
+  -- (p x + q x) n applied to (1, ..., 1) splits as p x n (1...) + q x n (1...).
+  show 0 ≤ ((p + q) x n) fun _ ↦ (1 : ℝ)
+  simp only [Pi.add_apply, FormalMultilinearSeries.add_apply,
+    ContinuousMultilinearMap.add_apply]
+  exact add_nonneg (hp_nn n hx) (hq_nn n hx)
+
+/-- A nonnegative scalar multiple of an absolutely monotone function is absolutely monotone
+(no `UniqueDiffOn` hypothesis). -/
+theorem smul {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
+    AbsolutelyMonotoneOn (c • f) s := by
+  obtain ⟨p, hp, hp_nn⟩ := hf
+  -- Witness: post-composition by the CLM `y ↦ c * y`.
+  set T : ℝ →L[ℝ] ℝ := c • ContinuousLinearMap.id ℝ ℝ with hT
+  have hcomp : (T ∘ f) = c • f := by ext x; simp [hT, smul_eq_mul]
+  refine ⟨_, hcomp ▸ hp.continuousLinearMap_comp T, fun n x hx => ?_⟩
+  -- The new witness's nth term applied to (1,...,1) is c * (p x n (1,...,1)).
+  show 0 ≤ T.compContinuousMultilinearMap (p x n) fun _ ↦ (1 : ℝ)
+  simp only [ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, hT,
+    ContinuousLinearMap.smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
+  exact mul_nonneg hc (hp_nn n hx)
+
+/-- The product of two absolutely monotone functions on a set `s` of unique differentiability is
+absolutely monotone on `s`. The `UniqueDiffOn` hypothesis is used by the underlying Leibniz rule
+for `iteratedDerivWithin`; it could be removed once a `HasFTaylorSeriesUpToOn.mul` lemma giving
+the Leibniz formula on `FormalMultilinearSeries` is added to Mathlib. -/
+theorem mul (hs : UniqueDiffOn ℝ s)
     (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
-    AbsolutelyMonotoneOn (f + g) s where
-  contDiffOn := hf.contDiffOn.add hg.contDiffOn
-  nonneg n x hx := by
-    rw [iteratedDerivWithin_add hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
-      ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
-    exact add_nonneg (hf.nonneg n x hx) (hg.nonneg n x hx)
-
-theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ}
-    (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
-    AbsolutelyMonotoneOn (c • f) s where
-  contDiffOn := hf.contDiffOn.const_smul c
-  nonneg n x hx := by
-    rw [iteratedDerivWithin_const_smul_field c f]
-    exact smul_nonneg hc (hf.nonneg n x hx)
-
-theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
-    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
-    AbsolutelyMonotoneOn (f * g) s where
-  contDiffOn := hf.contDiffOn.mul hg.contDiffOn
-  nonneg n x hx := by
-    rw [iteratedDerivWithin_mul hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
-      ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
-    exact Finset.sum_nonneg fun i _ =>
-      mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (hf.nonneg i x hx)) (hg.nonneg (n - i) x hx)
+    AbsolutelyMonotoneOn (f * g) s := by
+  -- Build the witness via `ftaylorSeriesWithin` for `f * g`, valid because `s` is `UniqueDiffOn`.
+  have hfg : ContDiffOn ℝ ∞ (f * g) s := hf.contDiffOn.mul hg.contDiffOn
+  refine ⟨ftaylorSeriesWithin ℝ (f * g) s, hfg.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
+  -- Reduce to nonnegativity of `iteratedDerivWithin n (f * g) s x`.
+  show 0 ≤ iteratedFDerivWithin ℝ n (f * g) s x fun _ ↦ (1 : ℝ)
+  rw [← iteratedDerivWithin_eq_iteratedFDerivWithin, iteratedDerivWithin_mul hx hs
+    ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
+    ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
+  exact Finset.sum_nonneg fun i _ =>
+    mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (hf.iteratedDerivWithin_nonneg hs i hx))
+      (hg.iteratedDerivWithin_nonneg hs (n - i) hx)
 
 end AbsolutelyMonotoneOn
+
+/-! ## Completely monotone functions -/
+
+/-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if there exists a Taylor
+series `p` for `f` on `s` whose `n`th term, evaluated at the all-minus-ones tuple, is nonnegative
+for every `n` and every `x ∈ s`. Since the `n`th term is `n`-multilinear, evaluating at
+`(−1, …, −1)` is `(−1)^n` times evaluating at `(1, …, 1)`, so this is equivalent to
+`(−1)^n f⁽ⁿ⁾(x) ≥ 0`.
+
+The prototypical example is `f(x) = exp(-x)`. By Bernstein's theorem, `f` is completely monotone
+on `[0, ∞)` if and only if `f` is the Laplace transform of a nonnegative measure. -/
+def CompletelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
+  ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
+    HasFTaylorSeriesUpToOn ∞ f p s ∧
+    ∀ (n : ℕ) ⦃x : ℝ⦄, x ∈ s → 0 ≤ p x n fun _ ↦ (-1 : ℝ)
+
+namespace CompletelyMonotoneOn
+
+variable {f g : ℝ → ℝ} {s : Set ℝ}
+
+/-- A completely monotone function on `s` is `C^∞` on `s`. -/
+theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
+  obtain ⟨_, hp, _⟩ := hf
+  exact hp.contDiffOn
+
+/-- A globally `C^∞` function whose iterated derivatives satisfy `0 ≤ (-1)^n f⁽ⁿ⁾(x)` on `s` is
+completely monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
+theorem of_contDiff (hf : ContDiff ℝ ∞ f)
+    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n f x) :
+    CompletelyMonotoneOn f s := by
+  refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
+  show 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (-1 : ℝ)
+  have : (fun _ : Fin n ↦ (-1 : ℝ)) = fun _ ↦ (-1 : ℝ) • (1 : ℝ) := by simp
+  rw [this, ContinuousMultilinearMap.map_smul_univ, ← iteratedDeriv_eq_iteratedFDeriv,
+    smul_eq_mul, Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+  exact h n x hx
+
+/-- Under `UniqueDiffOn`, a completely monotone function has alternating iterated derivatives:
+`0 ≤ (-1)^n * iteratedDerivWithin n f s x`. -/
+theorem iteratedDerivWithin_alternating (hf : CompletelyMonotoneOn f s) (hs : UniqueDiffOn ℝ s)
+    (n : ℕ) {x : ℝ} (hx : x ∈ s) :
+    0 ≤ (-1 : ℝ) ^ n * iteratedDerivWithin n f s x := by
+  obtain ⟨p, hp, hp_nn⟩ := hf
+  have heq : p x n = iteratedFDerivWithin ℝ n f s x :=
+    hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
+  have key : (p x n) (fun _ ↦ (-1 : ℝ)) =
+      (-1 : ℝ) ^ n * (p x n) (fun _ ↦ (1 : ℝ)) := by
+    have : (fun _ : Fin n ↦ (-1 : ℝ)) = fun _ ↦ (-1 : ℝ) • (1 : ℝ) := by simp
+    rw [this, ContinuousMultilinearMap.map_smul_univ, smul_eq_mul,
+      Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+  rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq, ← key]
+  exact hp_nn n hx
+
+end CompletelyMonotoneOn

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -24,9 +24,6 @@ iterated derivative within `s` nonnegative.
 
 * `AbsolutelyMonotoneOn` — there exists a Taylor series for `f` on `s` with nonnegative terms at
   each point of `s`.
-* `CompletelyMonotoneOn` — there exists a Taylor series for `f` on `s` whose terms have
-  alternating signs (equivalently, `(-1)^n f⁽ⁿ⁾(x) ≥ 0`).
-
 ## Main results
 
 * `AbsolutelyMonotoneOn.contDiffOn` — the function is `C^∞` on `s`.
@@ -35,10 +32,6 @@ iterated derivative within `s` nonnegative.
 * `AbsolutelyMonotoneOn.add` — closure under addition (no `UniqueDiffOn` hypothesis).
 * `AbsolutelyMonotoneOn.smul` — closure under nonnegative scalar multiplication (no `UniqueDiffOn`
   hypothesis).
-* `AbsolutelyMonotoneOn.mul` — closure under multiplication (requires `UniqueDiffOn s` because the
-  proof uses the Leibniz rule for `iteratedDerivWithin`).
-* `CompletelyMonotoneOn.contDiffOn` — a completely monotone function is `C^∞` on `s`.
-* `CompletelyMonotoneOn.of_contDiff` — constructor from `(-1)^n f⁽ⁿ⁾(x) ≥ 0`.
 
 ## References
 
@@ -117,77 +110,4 @@ theorem smul {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
     ContinuousLinearMap.smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
   exact mul_nonneg hc (hp_nn n hx)
 
-/-- The product of two absolutely monotone functions on a set `s` of unique differentiability is
-absolutely monotone on `s`. The `UniqueDiffOn` hypothesis is used by the underlying Leibniz rule
-for `iteratedDerivWithin`; it could be removed once a `HasFTaylorSeriesUpToOn.mul` lemma giving
-the Leibniz formula on `FormalMultilinearSeries` is added to Mathlib. -/
-theorem mul (hs : UniqueDiffOn ℝ s)
-    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
-    AbsolutelyMonotoneOn (f * g) s := by
-  -- Build the witness via `ftaylorSeriesWithin` for `f * g`, valid because `s` is `UniqueDiffOn`.
-  have hfg : ContDiffOn ℝ ∞ (f * g) s := hf.contDiffOn.mul hg.contDiffOn
-  refine ⟨ftaylorSeriesWithin ℝ (f * g) s, hfg.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
-  -- Reduce to nonnegativity of `iteratedDerivWithin n (f * g) s x`.
-  change 0 ≤ iteratedFDerivWithin ℝ n (f * g) s x fun _ ↦ (1 : ℝ)
-  rw [← iteratedDerivWithin_eq_iteratedFDerivWithin, iteratedDerivWithin_mul hx hs
-    ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
-    ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
-  exact Finset.sum_nonneg fun i _ =>
-    mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (hf.iteratedDerivWithin_nonneg hs i hx))
-      (hg.iteratedDerivWithin_nonneg hs (n - i) hx)
-
 end AbsolutelyMonotoneOn
-
-/-! ## Completely monotone functions -/
-
-/-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if there exists a Taylor
-series `p` for `f` on `s` whose `n`th term, evaluated at the all-minus-ones tuple, is nonnegative
-for every `n` and every `x ∈ s`. Since the `n`th term is `n`-multilinear, evaluating at
-`(−1, …, −1)` is `(−1)^n` times evaluating at `(1, …, 1)`, so this is equivalent to
-`(−1)^n f⁽ⁿ⁾(x) ≥ 0`.
-
-The prototypical example is `f(x) = exp(-x)`. By Bernstein's theorem, `f` is completely monotone
-on `[0, ∞)` if and only if `f` is the Laplace transform of a nonnegative measure. -/
-def CompletelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
-  ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
-    HasFTaylorSeriesUpToOn ∞ f p s ∧
-    ∀ (n : ℕ) ⦃x : ℝ⦄, x ∈ s → 0 ≤ p x n fun _ ↦ (-1 : ℝ)
-
-namespace CompletelyMonotoneOn
-
-variable {f g : ℝ → ℝ} {s : Set ℝ}
-
-/-- A completely monotone function on `s` is `C^∞` on `s`. -/
-theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
-  obtain ⟨_, hp, _⟩ := hf
-  exact hp.contDiffOn
-
-/-- A globally `C^∞` function whose iterated derivatives satisfy `0 ≤ (-1)^n f⁽ⁿ⁾(x)` on `s` is
-completely monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
-theorem of_contDiff (hf : ContDiff ℝ ∞ f)
-    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n f x) :
-    CompletelyMonotoneOn f s := by
-  refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
-  change 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (-1 : ℝ)
-  have : (fun _ : Fin n ↦ (-1 : ℝ)) = fun _ ↦ (-1 : ℝ) • (1 : ℝ) := by simp
-  rw [this, ContinuousMultilinearMap.map_smul_univ, ← iteratedDeriv_eq_iteratedFDeriv,
-    smul_eq_mul, Finset.prod_const, Finset.card_univ, Fintype.card_fin]
-  exact h n x hx
-
-/-- Under `UniqueDiffOn`, a completely monotone function has alternating iterated derivatives:
-`0 ≤ (-1)^n * iteratedDerivWithin n f s x`. -/
-theorem iteratedDerivWithin_alternating (hf : CompletelyMonotoneOn f s) (hs : UniqueDiffOn ℝ s)
-    (n : ℕ) {x : ℝ} (hx : x ∈ s) :
-    0 ≤ (-1 : ℝ) ^ n * iteratedDerivWithin n f s x := by
-  obtain ⟨p, hp, hp_nn⟩ := hf
-  have heq : p x n = iteratedFDerivWithin ℝ n f s x :=
-    hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
-  have key : (p x n) (fun _ ↦ (-1 : ℝ)) =
-      (-1 : ℝ) ^ n * (p x n) (fun _ ↦ (1 : ℝ)) := by
-    have : (fun _ : Fin n ↦ (-1 : ℝ)) = fun _ ↦ (-1 : ℝ) • (1 : ℝ) := by simp
-    rw [this, ContinuousMultilinearMap.map_smul_univ, smul_eq_mul,
-      Finset.prod_const, Finset.card_univ, Fintype.card_fin]
-  rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq, ← key]
-  exact hp_nn n hx
-
-end CompletelyMonotoneOn

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -73,7 +73,7 @@ theorem of_contDiff (hf : ContDiff ℝ ∞ f) (h : ∀ n : ℕ, ∀ x ∈ s, 0 �
     AbsolutelyMonotoneOn f s := by
   refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
   -- ftaylorSeries ℝ f x n = iteratedFDeriv ℝ n f x; evaluated at (1, ..., 1) gives iteratedDeriv.
-  show 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (1 : ℝ)
+  change 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (1 : ℝ)
   rw [← iteratedDeriv_eq_iteratedFDeriv]
   exact h n x hx
 
@@ -97,7 +97,7 @@ theorem add (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
   obtain ⟨q, hq, hq_nn⟩ := hg
   refine ⟨p + q, hp.add hq, fun n x hx => ?_⟩
   -- (p x + q x) n applied to (1, ..., 1) splits as p x n (1...) + q x n (1...).
-  show 0 ≤ ((p + q) x n) fun _ ↦ (1 : ℝ)
+  change 0 ≤ ((p + q) x n) fun _ ↦ (1 : ℝ)
   simp only [Pi.add_apply, FormalMultilinearSeries.add_apply,
     ContinuousMultilinearMap.add_apply]
   exact add_nonneg (hp_nn n hx) (hq_nn n hx)
@@ -112,7 +112,7 @@ theorem smul {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
   have hcomp : (T ∘ f) = c • f := by ext x; simp [hT, smul_eq_mul]
   refine ⟨_, hcomp ▸ hp.continuousLinearMap_comp T, fun n x hx => ?_⟩
   -- The new witness's nth term applied to (1,...,1) is c * (p x n (1,...,1)).
-  show 0 ≤ T.compContinuousMultilinearMap (p x n) fun _ ↦ (1 : ℝ)
+  change 0 ≤ T.compContinuousMultilinearMap (p x n) fun _ ↦ (1 : ℝ)
   simp only [ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, hT,
     ContinuousLinearMap.smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
   exact mul_nonneg hc (hp_nn n hx)
@@ -128,7 +128,7 @@ theorem mul (hs : UniqueDiffOn ℝ s)
   have hfg : ContDiffOn ℝ ∞ (f * g) s := hf.contDiffOn.mul hg.contDiffOn
   refine ⟨ftaylorSeriesWithin ℝ (f * g) s, hfg.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
   -- Reduce to nonnegativity of `iteratedDerivWithin n (f * g) s x`.
-  show 0 ≤ iteratedFDerivWithin ℝ n (f * g) s x fun _ ↦ (1 : ℝ)
+  change 0 ≤ iteratedFDerivWithin ℝ n (f * g) s x fun _ ↦ (1 : ℝ)
   rw [← iteratedDerivWithin_eq_iteratedFDerivWithin, iteratedDerivWithin_mul hx hs
     ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
     ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
@@ -168,7 +168,7 @@ theorem of_contDiff (hf : ContDiff ℝ ∞ f)
     (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n f x) :
     CompletelyMonotoneOn f s := by
   refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
-  show 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (-1 : ℝ)
+  change 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (-1 : ℝ)
   have : (fun _ : Fin n ↦ (-1 : ℝ)) = fun _ ↦ (-1 : ℝ) • (1 : ℝ) := by simp
   rw [this, ContinuousMultilinearMap.map_smul_univ, ← iteratedDeriv_eq_iteratedFDeriv,
     smul_eq_mul, Finset.prod_const, Finset.card_univ, Fintype.card_fin]

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -6,24 +6,20 @@ Authors: Michael R. Douglas
 module
 
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
-public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
-public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
-public import Mathlib.Analysis.Complex.Trigonometric
 
 /-!
 # Absolutely Monotone Functions
 
-A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth
-on `s` and all its iterated derivatives within `s` are nonneg on `s`.
+A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth on `s` and all its
+iterated derivatives within `s` are nonnegative on `s`.
 
 ## Main definitions
 
-* `AbsolutelyMonotoneOn` — smooth on `s` with nonneg iterated derivatives within `s`
+* `AbsolutelyMonotoneOn` — smooth on `s` with nonnegative iterated derivatives within `s`
 
 ## Main results
 
 * Closure under `add`, `smul`, `mul`
-* `absolutelyMonotoneOn_exp`, `absolutelyMonotoneOn_cosh`, `absolutelyMonotoneOn_pow`
 
 ## References
 
@@ -35,106 +31,48 @@ public section
 open Set Filter
 open scoped ENNReal NNReal Topology ContDiff
 
-/-- A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is
-smooth on `s` and all iterated derivatives within `s` are nonneg. -/
+/-- A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth on `s` and all
+iterated derivatives within `s` are nonnegative. -/
 structure AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop where
   contDiffOn : ContDiffOn ℝ ∞ f s
   nonneg : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDerivWithin n f s x
 
 namespace AbsolutelyMonotoneOn
 
-/-- Constructor from global `ContDiff` and global `iteratedDeriv`.
-Works for any `UniqueDiffOn` set (includes open sets, `Ici a`,
-convex sets with nonempty interior, etc.). -/
-theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ}
-    (hs : UniqueDiffOn ℝ s)
-    (hf : ContDiff ℝ ∞ f)
-    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
-    AbsolutelyMonotoneOn f s where
+/-- Constructor from global `ContDiff` and global `iteratedDeriv`. Works for any `UniqueDiffOn`
+set (includes open sets, `Ici a`, convex sets with nonempty interior, etc.). -/
+theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : ContDiff ℝ ∞ f)
+    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) : AbsolutelyMonotoneOn f s where
   contDiffOn := hf.contDiffOn
   nonneg n x hx := by
-    rw [iteratedDerivWithin_eq_iteratedDeriv hs
-      (hf.contDiffAt.of_le (by exact_mod_cast le_top)) hx]
+    rw [iteratedDerivWithin_eq_iteratedDeriv hs (hf.contDiffAt.of_le (by exact_mod_cast le_top))
+      hx]
     exact h n x hx
-
-/-- Nonneg Taylor coefficients at any point in `s`. -/
-theorem nonneg_taylor_coeffs {f : ℝ → ℝ} {s : Set ℝ}
-    (hf : AbsolutelyMonotoneOn f s) {x : ℝ} (hx : x ∈ s)
-    (n : ℕ) :
-    0 ≤ iteratedDerivWithin n f s x / (n.factorial : ℝ) :=
-  div_nonneg (hf.nonneg n x hx) (Nat.cast_nonneg _)
 
 /-! ### Basic closure properties -/
 
-theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
-    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
-    AbsolutelyMonotoneOn (f + g) s where
+theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : AbsolutelyMonotoneOn f s)
+    (hg : AbsolutelyMonotoneOn g s) : AbsolutelyMonotoneOn (f + g) s where
   contDiffOn := hf.contDiffOn.add hg.contDiffOn
   nonneg n x hx := by
-    rw [iteratedDerivWithin_add hx hs
-      ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
+    rw [iteratedDerivWithin_add hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
       ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
     exact add_nonneg (hf.nonneg n x hx) (hg.nonneg n x hx)
 
-theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ}
-    (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
+theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
     AbsolutelyMonotoneOn (c • f) s where
   contDiffOn := hf.contDiffOn.const_smul c
   nonneg n x hx := by
     rw [iteratedDerivWithin_const_smul_field c f]
     exact smul_nonneg hc (hf.nonneg n x hx)
 
-theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
-    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
-    AbsolutelyMonotoneOn (f * g) s where
+theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : AbsolutelyMonotoneOn f s)
+    (hg : AbsolutelyMonotoneOn g s) : AbsolutelyMonotoneOn (f * g) s where
   contDiffOn := hf.contDiffOn.mul hg.contDiffOn
   nonneg n x hx := by
-    rw [iteratedDerivWithin_mul hx hs
-      ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
+    rw [iteratedDerivWithin_mul hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
       ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
-    apply Finset.sum_nonneg
-    intro i _
-    apply mul_nonneg
-    · exact mul_nonneg (Nat.cast_nonneg _) (hf.nonneg i x hx)
-    · exact hg.nonneg (n - i) x hx
+    exact Finset.sum_nonneg fun i _ =>
+      mul_nonneg (mul_nonneg (Nat.cast_nonneg _) (hf.nonneg i x hx)) (hg.nonneg (n - i) x hx)
 
 end AbsolutelyMonotoneOn
-
-/-! ### Examples -/
-
-theorem absolutelyMonotoneOn_exp (s : Set ℝ) (hs : UniqueDiffOn ℝ s) :
-    AbsolutelyMonotoneOn Real.exp s :=
-  .of_contDiff hs Real.contDiff_exp fun n x _hx => by
-    have : iteratedDeriv n Real.exp x = Real.exp x := by
-      have h := iteratedDeriv_exp_const_mul n (1 : ℝ)
-      simp only [one_pow, one_mul] at h
-      exact congr_fun h x
-    rw [this]; exact (Real.exp_pos x).le
-
-theorem absolutelyMonotoneOn_cosh :
-    AbsolutelyMonotoneOn Real.cosh (Ici 0) :=
-  .of_contDiff (uniqueDiffOn_Ici 0) Real.contDiff_cosh
-    fun n x hx => by
-      rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
-      · rw [hk, show k + k = 2 * k from by ring,
-          Real.iteratedDeriv_even_cosh]
-        exact (Real.cosh_pos x).le
-      · rw [hk, Real.iteratedDeriv_odd_cosh]
-        exact Real.sinh_nonneg_iff.mpr (mem_Ici.mp hx)
-
-theorem absolutelyMonotoneOn_const {c : ℝ} (hc : 0 ≤ c)
-    (s : Set ℝ) (hs : UniqueDiffOn ℝ s) :
-    AbsolutelyMonotoneOn (fun _ => c) s :=
-  .of_contDiff hs contDiff_const fun n x _hx => by
-    simp only [iteratedDeriv_const]
-    split
-    · exact hc
-    · exact le_refl 0
-
-theorem absolutelyMonotoneOn_pow (n : ℕ) :
-    AbsolutelyMonotoneOn (fun x => x ^ n) (Ici 0) :=
-  .of_contDiff (uniqueDiffOn_Ici 0) (contDiff_id.pow n)
-    fun k x hx => by
-      simp only [iteratedDeriv_pow]
-      exact mul_nonneg (Nat.cast_nonneg _)
-        (pow_nonneg (mem_Ici.mp hx) _)

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2025 Michael R. Douglas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael R. Douglas
+-/
+module
+
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+public import Mathlib.Analysis.Complex.Trigonometric
+
+/-!
+# Absolutely Monotone Functions
+
+A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is smooth
+on `s` and all its iterated derivatives within `s` are nonneg on `s`.
+
+## Main definitions
+
+* `AbsolutelyMonotoneOn` — smooth on `s` with nonneg iterated derivatives within `s`
+
+## Main results
+
+* Closure under `add`, `smul`, `mul`
+* `absolutelyMonotoneOn_exp`, `absolutelyMonotoneOn_cosh`, `absolutelyMonotoneOn_pow`
+
+## References
+
+* Widder, D.V. (1941). *The Laplace Transform*.
+-/
+
+public section
+
+open Set Filter
+open scoped ENNReal NNReal Topology ContDiff
+
+/-- A function `f : ℝ → ℝ` is absolutely monotone on a set `s` if it is
+smooth on `s` and all iterated derivatives within `s` are nonneg. -/
+structure AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop where
+  contDiffOn : ContDiffOn ℝ ∞ f s
+  nonneg : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDerivWithin n f s x
+
+namespace AbsolutelyMonotoneOn
+
+/-- Constructor from global `ContDiff` and global `iteratedDeriv`.
+Works for any `UniqueDiffOn` set (includes open sets, `Ici a`,
+convex sets with nonempty interior, etc.). -/
+theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ}
+    (hs : UniqueDiffOn ℝ s)
+    (hf : ContDiff ℝ ∞ f)
+    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
+    AbsolutelyMonotoneOn f s where
+  contDiffOn := hf.contDiffOn
+  nonneg n x hx := by
+    rw [iteratedDerivWithin_eq_iteratedDeriv hs
+      (hf.contDiffAt.of_le (by exact_mod_cast le_top)) hx]
+    exact h n x hx
+
+/-- Nonneg Taylor coefficients at any point in `s`. -/
+theorem nonneg_taylor_coeffs {f : ℝ → ℝ} {s : Set ℝ}
+    (hf : AbsolutelyMonotoneOn f s) {x : ℝ} (hx : x ∈ s)
+    (n : ℕ) :
+    0 ≤ iteratedDerivWithin n f s x / (n.factorial : ℝ) :=
+  div_nonneg (hf.nonneg n x hx) (Nat.cast_nonneg _)
+
+/-! ### Basic closure properties -/
+
+theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
+    AbsolutelyMonotoneOn (f + g) s where
+  contDiffOn := hf.contDiffOn.add hg.contDiffOn
+  nonneg n x hx := by
+    rw [iteratedDerivWithin_add hx hs
+      ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
+      ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
+    exact add_nonneg (hf.nonneg n x hx) (hg.nonneg n x hx)
+
+theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ}
+    (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
+    AbsolutelyMonotoneOn (c • f) s where
+  contDiffOn := hf.contDiffOn.const_smul c
+  nonneg n x hx := by
+    rw [iteratedDerivWithin_const_smul_field c f]
+    exact smul_nonneg hc (hf.nonneg n x hx)
+
+theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
+    AbsolutelyMonotoneOn (f * g) s where
+  contDiffOn := hf.contDiffOn.mul hg.contDiffOn
+  nonneg n x hx := by
+    rw [iteratedDerivWithin_mul hx hs
+      ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
+      ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
+    apply Finset.sum_nonneg
+    intro i _
+    apply mul_nonneg
+    · exact mul_nonneg (Nat.cast_nonneg _) (hf.nonneg i x hx)
+    · exact hg.nonneg (n - i) x hx
+
+end AbsolutelyMonotoneOn
+
+/-! ### Examples -/
+
+theorem absolutelyMonotoneOn_exp (s : Set ℝ) (hs : UniqueDiffOn ℝ s) :
+    AbsolutelyMonotoneOn Real.exp s :=
+  .of_contDiff hs Real.contDiff_exp fun n x _hx => by
+    have : iteratedDeriv n Real.exp x = Real.exp x := by
+      have h := iteratedDeriv_exp_const_mul n (1 : ℝ)
+      simp only [one_pow, one_mul] at h
+      exact congr_fun h x
+    rw [this]; exact (Real.exp_pos x).le
+
+theorem absolutelyMonotoneOn_cosh :
+    AbsolutelyMonotoneOn Real.cosh (Ici 0) :=
+  .of_contDiff (uniqueDiffOn_Ici 0) Real.contDiff_cosh
+    fun n x hx => by
+      rcases Nat.even_or_odd n with ⟨k, hk⟩ | ⟨k, hk⟩
+      · rw [hk, show k + k = 2 * k from by ring,
+          Real.iteratedDeriv_even_cosh]
+        exact (Real.cosh_pos x).le
+      · rw [hk, Real.iteratedDeriv_odd_cosh]
+        exact Real.sinh_nonneg_iff.mpr (mem_Ici.mp hx)
+
+theorem absolutelyMonotoneOn_const {c : ℝ} (hc : 0 ≤ c)
+    (s : Set ℝ) (hs : UniqueDiffOn ℝ s) :
+    AbsolutelyMonotoneOn (fun _ => c) s :=
+  .of_contDiff hs contDiff_const fun n x _hx => by
+    simp only [iteratedDeriv_const]
+    split
+    · exact hc
+    · exact le_refl 0
+
+theorem absolutelyMonotoneOn_pow (n : ℕ) :
+    AbsolutelyMonotoneOn (fun x => x ^ n) (Ici 0) :=
+  .of_contDiff (uniqueDiffOn_Ici 0) (contDiff_id.pow n)
+    fun k x hx => by
+      simp only [iteratedDeriv_pow]
+      exact mul_nonneg (Nat.cast_nonneg _)
+        (pow_nonneg (mem_Ici.mp hx) _)

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -23,7 +23,7 @@ iterated derivatives within `s` are nonnegative on `s`.
 
 ## References
 
-* Widder, D.V. (1941). *The Laplace Transform*.
+* [D. V. Widder, *The Laplace Transform*][widder1941]
 -/
 
 public section
@@ -39,8 +39,9 @@ structure AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop where
 
 namespace AbsolutelyMonotoneOn
 
-/-- Constructor from global `ContDiff` and global `iteratedDeriv`. Works for any `UniqueDiffOn`
-set (includes open sets, `Ici a`, convex sets with nonempty interior, etc.). -/
+/-- A globally smooth function all of whose iterated derivatives are nonnegative on a set `s`
+satisfying `UniqueDiffOn` is absolutely monotone on `s`. Such sets `s` include open sets,
+`Set.Ici`, and convex sets with nonempty interior. -/
 theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : ContDiff ℝ ∞ f)
     (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) : AbsolutelyMonotoneOn f s where
   contDiffOn := hf.contDiffOn

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -42,8 +42,9 @@ namespace AbsolutelyMonotoneOn
 /-- A globally smooth function all of whose iterated derivatives are nonnegative on a set `s`
 satisfying `UniqueDiffOn` is absolutely monotone on `s`. Such sets `s` include open sets,
 `Set.Ici`, and convex sets with nonempty interior. -/
-theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : ContDiff ℝ ∞ f)
-    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) : AbsolutelyMonotoneOn f s where
+theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+    (hf : ContDiff ℝ ∞ f) (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
+    AbsolutelyMonotoneOn f s where
   contDiffOn := hf.contDiffOn
   nonneg n x hx := by
     rw [iteratedDerivWithin_eq_iteratedDeriv hs (hf.contDiffAt.of_le (by exact_mod_cast le_top))
@@ -52,23 +53,26 @@ theorem of_contDiff {f : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (h
 
 /-! ### Basic closure properties -/
 
-theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : AbsolutelyMonotoneOn f s)
-    (hg : AbsolutelyMonotoneOn g s) : AbsolutelyMonotoneOn (f + g) s where
+theorem add {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
+    AbsolutelyMonotoneOn (f + g) s where
   contDiffOn := hf.contDiffOn.add hg.contDiffOn
   nonneg n x hx := by
     rw [iteratedDerivWithin_add hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))
       ((hg.contDiffOn x hx).of_le (by exact_mod_cast le_top))]
     exact add_nonneg (hf.nonneg n x hx) (hg.nonneg n x hx)
 
-theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
+theorem smul {f : ℝ → ℝ} {s : Set ℝ} {c : ℝ}
+    (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
     AbsolutelyMonotoneOn (c • f) s where
   contDiffOn := hf.contDiffOn.const_smul c
   nonneg n x hx := by
     rw [iteratedDerivWithin_const_smul_field c f]
     exact smul_nonneg hc (hf.nonneg n x hx)
 
-theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s) (hf : AbsolutelyMonotoneOn f s)
-    (hg : AbsolutelyMonotoneOn g s) : AbsolutelyMonotoneOn (f * g) s where
+theorem mul {f g : ℝ → ℝ} {s : Set ℝ} (hs : UniqueDiffOn ℝ s)
+    (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
+    AbsolutelyMonotoneOn (f * g) s where
   contDiffOn := hf.contDiffOn.mul hg.contDiffOn
   nonneg n x hx := by
     rw [iteratedDerivWithin_mul hx hs ((hf.contDiffOn x hx).of_le (by exact_mod_cast le_top))

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -11,27 +11,30 @@ public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 /-!
 # Absolutely monotone functions
 
-A function `f : ℝ → ℝ` is *absolutely monotone* on a set `s` if there exists a Taylor series for
-`f` on `s` whose terms are all nonnegative at each point of `s`. Phrasing the condition via
-existence of a Taylor series (`HasFTaylorSeriesUpToOn`) avoids forcing a `UniqueDiffOn s`
-hypothesis on every result: without `UniqueDiffOn`, "the" iterated derivative within `s` is not
-canonical, but the existence of a Taylor series is intrinsic to `f` and `s`.
-
-When `s` does satisfy `UniqueDiffOn`, the condition reduces to `f` being `C^∞` on `s` with every
-iterated derivative within `s` nonnegative.
+A function `f : ℝ → ℝ` is *absolutely monotone* on a set `s` if its iterated derivatives are all
+nonnegative on `s`.
 
 ## Main definitions
 
 * `AbsolutelyMonotoneOn` — there exists a Taylor series for `f` on `s` with nonnegative terms at
   each point of `s`.
+
 ## Main results
 
 * `AbsolutelyMonotoneOn.contDiffOn` — the function is `C^∞` on `s`.
 * `AbsolutelyMonotoneOn.of_contDiff` — a globally `C^∞` function with nonnegative iterated
-  derivatives on `s` is absolutely monotone on `s` (no `UniqueDiffOn` hypothesis).
-* `AbsolutelyMonotoneOn.add` — closure under addition (no `UniqueDiffOn` hypothesis).
-* `AbsolutelyMonotoneOn.smul` — closure under nonnegative scalar multiplication (no `UniqueDiffOn`
-  hypothesis).
+  derivatives on `s` is absolutely monotone on `s`.
+* `AbsolutelyMonotoneOn.add` — closure under addition.
+* `AbsolutelyMonotoneOn.smul` — closure under nonnegative scalar multiplication.
+
+## Implementation
+
+The precise definition is phrased via the existence of a Taylor series with nonnegative terms
+(`HasFTaylorSeriesUpToOn`) rather than via `iteratedDerivWithin`. This avoids forcing a
+`UniqueDiffOn s` hypothesis on every result: without `UniqueDiffOn`, "the" iterated derivative
+within `s` is not canonical, but the existence of a Taylor series is intrinsic to `f` and `s`.
+When `s` does satisfy `UniqueDiffOn`, the condition reduces to `f` being `C^∞` on `s` with every
+iterated derivative within `s` nonnegative.
 
 ## References
 
@@ -43,9 +46,11 @@ public section
 open Set Filter
 open scoped ContDiff
 
-/-- A function `f : ℝ → ℝ` is **absolutely monotone on a set `s`** if there exists a Taylor
-series `p` for `f` on `s` whose `n`th term, evaluated at the all-ones tuple, is nonnegative for
-every `n` and every `x ∈ s`. -/
+/-- A function `f : ℝ → ℝ` is **absolutely monotone on a set `s`** if, heuristically, all
+iterated derivatives of `f` on `s` are nonnegative. For technical reasons related to unique
+differentiability, the precise definition is phrased as the existence of a Taylor series for
+`f` on `s` whose `n`th term, evaluated at the all-ones tuple, is nonnegative for every `n` and
+every `x ∈ s`. See the module docstring for the equivalence under `UniqueDiffOn`. -/
 def AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
   ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
     HasFTaylorSeriesUpToOn ∞ f p s ∧
@@ -65,10 +70,7 @@ monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
 theorem of_contDiff (hf : ContDiff ℝ ∞ f) (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDeriv n f x) :
     AbsolutelyMonotoneOn f s := by
   refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
-  -- ftaylorSeries ℝ f x n = iteratedFDeriv ℝ n f x; evaluated at (1, ..., 1) gives iteratedDeriv.
-  change 0 ≤ iteratedFDeriv ℝ n f x fun _ ↦ (1 : ℝ)
-  rw [← iteratedDeriv_eq_iteratedFDeriv]
-  exact h n x hx
+  exact iteratedDeriv_eq_iteratedFDeriv (𝕜 := ℝ) (f := f) ▸ h n x hx
 
 /-- Under `UniqueDiffOn`, a Taylor witness for an absolutely monotone function agrees with
 `iteratedDerivWithin`, so the latter is nonnegative on `s`. -/
@@ -82,21 +84,17 @@ theorem iteratedDerivWithin_nonneg (hf : AbsolutelyMonotoneOn f s) (hs : UniqueD
 
 /-! ### Closure properties -/
 
-/-- The sum of two absolutely monotone functions is absolutely monotone (no `UniqueDiffOn`
-hypothesis). -/
+/-- The sum of two absolutely monotone functions is absolutely monotone. -/
 theorem add (hf : AbsolutelyMonotoneOn f s) (hg : AbsolutelyMonotoneOn g s) :
     AbsolutelyMonotoneOn (f + g) s := by
   obtain ⟨p, hp, hp_nn⟩ := hf
   obtain ⟨q, hq, hq_nn⟩ := hg
   refine ⟨p + q, hp.add hq, fun n x hx => ?_⟩
-  -- (p x + q x) n applied to (1, ..., 1) splits as p x n (1...) + q x n (1...).
-  change 0 ≤ ((p + q) x n) fun _ ↦ (1 : ℝ)
   simp only [Pi.add_apply, FormalMultilinearSeries.add_apply,
     ContinuousMultilinearMap.add_apply]
   exact add_nonneg (hp_nn n hx) (hq_nn n hx)
 
-/-- A nonnegative scalar multiple of an absolutely monotone function is absolutely monotone
-(no `UniqueDiffOn` hypothesis). -/
+/-- A nonnegative scalar multiple of an absolutely monotone function is absolutely monotone. -/
 theorem smul {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
     AbsolutelyMonotoneOn (c • f) s := by
   obtain ⟨p, hp, hp_nn⟩ := hf
@@ -104,8 +102,6 @@ theorem smul {c : ℝ} (hf : AbsolutelyMonotoneOn f s) (hc : 0 ≤ c) :
   set T : ℝ →L[ℝ] ℝ := c • ContinuousLinearMap.id ℝ ℝ with hT
   have hcomp : (T ∘ f) = c • f := by ext x; simp [hT, smul_eq_mul]
   refine ⟨_, hcomp ▸ hp.continuousLinearMap_comp T, fun n x hx => ?_⟩
-  -- The new witness's nth term applied to (1,...,1) is c * (p x n (1,...,1)).
-  change 0 ≤ T.compContinuousMultilinearMap (p x n) fun _ ↦ (1 : ℝ)
   simp only [ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, hT,
     ContinuousLinearMap.smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
   exact mul_nonneg hc (hp_nn n hx)

--- a/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
+++ b/Mathlib/Analysis/Calculus/AbsolutelyMonotone.lean
@@ -24,6 +24,8 @@ nonnegative on `s`.
 * `AbsolutelyMonotoneOn.contDiffOn` — the function is `C^∞` on `s`.
 * `AbsolutelyMonotoneOn.of_contDiff` — a globally `C^∞` function with nonnegative iterated
   derivatives on `s` is absolutely monotone on `s`.
+* `AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg` — under `UniqueDiffOn`, the definition
+  is equivalent to `f` being `C^∞` on `s` with every iterated derivative within `s` nonnegative.
 * `AbsolutelyMonotoneOn.add` — closure under addition.
 * `AbsolutelyMonotoneOn.smul` — closure under nonnegative scalar multiplication.
 
@@ -50,7 +52,8 @@ open scoped ContDiff
 iterated derivatives of `f` on `s` are nonnegative. For technical reasons related to unique
 differentiability, the precise definition is phrased as the existence of a Taylor series for
 `f` on `s` whose `n`th term, evaluated at the all-ones tuple, is nonnegative for every `n` and
-every `x ∈ s`. See the module docstring for the equivalence under `UniqueDiffOn`. -/
+every `x ∈ s`. See `AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg` for the equivalence
+under `UniqueDiffOn`. -/
 def AbsolutelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
   ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
     HasFTaylorSeriesUpToOn ∞ f p s ∧
@@ -81,6 +84,16 @@ theorem iteratedDerivWithin_nonneg (hf : AbsolutelyMonotoneOn f s) (hs : UniqueD
     hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
   rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq]
   exact hp_nn n hx
+
+/-- Under `UniqueDiffOn`, a function is absolutely monotone on `s` iff it is `C^∞` on `s` with
+every iterated derivative within `s` nonnegative. -/
+theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
+    AbsolutelyMonotoneOn f s ↔
+      ContDiffOn ℝ ∞ f s ∧ ∀ n : ℕ, ∀ x ∈ s, 0 ≤ iteratedDerivWithin n f s x := by
+  refine ⟨fun hf => ⟨hf.contDiffOn, fun n x hx => hf.iteratedDerivWithin_nonneg hs n hx⟩, ?_⟩
+  rintro ⟨hcont, hnn⟩
+  refine ⟨ftaylorSeriesWithin ℝ f s, hcont.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
+  exact iteratedDerivWithin_eq_iteratedFDerivWithin (𝕜 := ℝ) (f := f) (s := s) ▸ hnn n x hx
 
 /-! ### Closure properties -/
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -5761,6 +5761,15 @@
   isbn          = {978-0-12-749650-4}
 }
 
+@Book{            widder1941,
+  author        = {Widder, David Vernon},
+  title         = {The {L}aplace Transform},
+  year          = {1941},
+  publisher     = {Princeton University Press},
+  series        = {Princeton Mathematical Series},
+  volume        = {6}
+}
+
 @Article{         Wiles-FLT,
   author        = {Wiles, Andrew},
   title         = {Modular elliptic curves and {F}ermat's last theorem},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -5750,6 +5750,15 @@
   url           = {https://ti.inf.ethz.ch/ew/lehre/ApproxSDP09/notes/conelp.pdf}
 }
 
+@Book{            widder1941,
+  author        = {Widder, David Vernon},
+  title         = {The {L}aplace Transform},
+  year          = {1941},
+  publisher     = {Princeton University Press},
+  series        = {Princeton Mathematical Series},
+  volume        = {6}
+}
+
 @Book{            Wielandt-1964,
   title         = {Finite Permutation Groups},
   author        = {Wielandt, Helmut},
@@ -5759,15 +5768,6 @@
   publisher     = {Academic Press},
   address       = {New York},
   isbn          = {978-0-12-749650-4}
-}
-
-@Book{            widder1941,
-  author        = {Widder, David Vernon},
-  title         = {The {L}aplace Transform},
-  year          = {1941},
-  publisher     = {Princeton University Press},
-  series        = {Princeton Mathematical Series},
-  volume        = {6}
 }
 
 @Article{         Wiles-FLT,


### PR DESCRIPTION
## Summary

- Define `AbsolutelyMonotoneOn f s` for functions `f : ℝ → ℝ` that are smooth on `s` with all iterated derivatives within `s` nonneg
- Prove closure under `add`, `smul`, `mul`
- Show `exp`, `cosh`, constants, and powers are absolutely monotone on appropriate domains

This is the first part of a split of #37879. Follow-up PRs will add:
- Bernstein backward direction (nonneg coefficients → absolutely monotone)
- Bernstein forward direction (absolutely monotone → analytic at 0)
- Matrix applications (Schur product theorem for power series, entrywise exp)

## Test plan

- [ ] CI passes (build + lint)
- [ ] Verify `AbsolutelyMonotoneOn` structure and examples type-check


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>