### PR TITLE
chore: try to change argument order

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -631,7 +631,6 @@ namespace CStarMatrix
 variable {m n A : Type*} [Fintype m] [Fintype n]
   [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
-set_option backward.privateInPublic true in
 private noncomputable local instance normedAddCommGroupAux :
     NormedAddCommGroup (CStarMatrix m n A) :=
   .ofCore CStarMatrix.normedSpaceCore
@@ -685,7 +684,6 @@ private lemma uniformInducing_toMatrixAux :
     lipschitzWith_toMatrixAux.uniformContinuous
 
 set_option backward.isDefEq.respectTransparency false in
-set_option backward.privateInPublic true in
 private lemma uniformity_eq_aux :
     𝓤 (CStarMatrix m n A) = (𝓤[Pi.uniformSpace _] :
       Filter (CStarMatrix m n A × CStarMatrix m n A)) := by
@@ -697,7 +695,6 @@ private lemma uniformity_eq_aux :
   rfl
 
 open Bornology in
-set_option backward.privateInPublic true in
 private lemma cobounded_eq_aux :
     cobounded (CStarMatrix m n A) = @cobounded _ Pi.instBornology := by
   have : cobounded (CStarMatrix m n A) = Filter.comap ofMatrix.symm (cobounded _) := by
@@ -745,22 +742,19 @@ instance instContinuousSMul {R : Type*} [SMul R A] [TopologicalSpace R] [Continu
     ContinuousSMul R (CStarMatrix m n A) :=
   inferInstanceAs <| ContinuousSMul R (Matrix m n A)
 
-
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 noncomputable instance instNormedAddCommGroup :
     NormedAddCommGroup (CStarMatrix m n A) :=
-  .ofCoreReplaceAll CStarMatrix.normedSpaceCore
-    CStarMatrix.uniformity_eq_aux.symm
-      fun _ => Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _
+  .ofCoreReplaceAll CStarMatrix.normedSpaceCore ?_ (fun _ ↦ ?_)
+where finally
+  exacts [CStarMatrix.uniformity_eq_aux.symm, Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _]
 
 noncomputable instance instNormedSpace : NormedSpace ℂ (CStarMatrix m n A) :=
   .ofCore CStarMatrix.normedSpaceCore
 
 noncomputable instance instNonUnitalNormedRing :
     NonUnitalNormedRing (CStarMatrix n n A) where
-  __ : NormedAddCommGroup (CStarMatrix n n A) := inferInstance
   __ : NonUnitalRing (CStarMatrix n n A) := inferInstance
+  __ : NormedAddCommGroup (CStarMatrix n n A) := inferInstance
   norm_mul_le _ _ := by simpa only [norm_def', map_mul] using norm_mul_le _ _
 
 open ContinuousLinearMap CStarModule in
@@ -792,7 +786,6 @@ instance instCStarRing : CStarRing (CStarMatrix n n A) :=
     rw [← Real.sqrt_le_sqrt_iff (by positivity)]
     simp [hmain]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Matrices with entries in a non-unital C⋆-algebra form a non-unital C⋆-algebra. -/
 noncomputable instance instNonUnitalCStarAlgebra :
     NonUnitalCStarAlgebra (CStarMatrix n n A) where

--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -631,6 +631,7 @@ namespace CStarMatrix
 variable {m n A : Type*} [Fintype m] [Fintype n]
   [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
 
+set_option backward.privateInPublic true in
 private noncomputable local instance normedAddCommGroupAux :
     NormedAddCommGroup (CStarMatrix m n A) :=
   .ofCore CStarMatrix.normedSpaceCore
@@ -684,6 +685,7 @@ private lemma uniformInducing_toMatrixAux :
     lipschitzWith_toMatrixAux.uniformContinuous
 
 set_option backward.isDefEq.respectTransparency false in
+set_option backward.privateInPublic true in
 private lemma uniformity_eq_aux :
     𝓤 (CStarMatrix m n A) = (𝓤[Pi.uniformSpace _] :
       Filter (CStarMatrix m n A × CStarMatrix m n A)) := by
@@ -695,6 +697,7 @@ private lemma uniformity_eq_aux :
   rfl
 
 open Bornology in
+set_option backward.privateInPublic true in
 private lemma cobounded_eq_aux :
     cobounded (CStarMatrix m n A) = @cobounded _ Pi.instBornology := by
   have : cobounded (CStarMatrix m n A) = Filter.comap ofMatrix.symm (cobounded _) := by
@@ -742,11 +745,72 @@ instance instContinuousSMul {R : Type*} [SMul R A] [TopologicalSpace R] [Continu
     ContinuousSMul R (CStarMatrix m n A) :=
   inferInstanceAs <| ContinuousSMul R (Matrix m n A)
 
-noncomputable instance instNormedAddCommGroup :
+@[implicit_reducible]
+noncomputable def instNormedAddCommGroup2 :
     NormedAddCommGroup (CStarMatrix m n A) :=
   .ofCoreReplaceAll CStarMatrix.normedSpaceCore ?_ (fun _ ↦ ?_)
 where finally
   exacts [CStarMatrix.uniformity_eq_aux.symm, Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _]
+
+#print instNormedAddCommGroup2
+/-
+@NormedAddCommGroup.ofCoreReplaceAll ℂ (CStarMatrix m n A) Complex.instNormedField
+  instAddCommGroup instModule instNorm
+  instUniformSpace instBornology ⋯ ⋯ ⋯ : NormedAddCommGroup (CStarMatrix m n A)
+-/
+
+@[implicit_reducible]
+noncomputable def instNormedAddCommGroup4 :
+    NormedAddCommGroup (CStarMatrix m n A) :=
+  fast_instance% .ofCoreReplaceAll CStarMatrix.normedSpaceCore ?_ (fun _ ↦ ?_)
+where finally
+  exacts [CStarMatrix.uniformity_eq_aux.symm, Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _]
+
+#print instNormedAddCommGroup4
+/-
+{ toNorm := instNorm, toAddCommGroup := instAddCommGroup, dist := fun a a_1 ↦ ‖-a + a_1‖, dist_self := ⋯,
+    dist_comm := ⋯, dist_triangle := ⋯, edist := fun a a_1 ↦ PseudoMetricSpace.edist a a_1, edist_dist := ⋯,
+    toUniformSpace := PseudoMetricSpace.toUniformSpace, uniformity_dist := ⋯, toBornology := instBornology,
+    cobounded_sets := ⋯, eq_of_dist_eq_zero := ⋯, dist_eq := ⋯ }
+-/
+
+
+
+set_option backward.privateInPublic true in
+set_option backward.privateInPublic.warn false in
+@[implicit_reducible]
+noncomputable def instNormedAddCommGroup1 :
+    NormedAddCommGroup (CStarMatrix m n A) :=
+  .ofCoreReplaceAll CStarMatrix.normedSpaceCore
+    CStarMatrix.uniformity_eq_aux.symm
+      fun _ => Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _
+
+#print instNormedAddCommGroup1
+/-
+@NormedAddCommGroup.ofCoreReplaceAll ℂ (CStarMatrix m n A) Complex.instNormedField instAddCommGroup instModule instNorm
+  (Pi.uniformSpace fun a ↦ n → A) Pi.instBornology ⋯ ⋯ ⋯ : NormedAddCommGroup (CStarMatrix m n A)
+-/
+
+lemma foo : (instNormedAddCommGroup1 :
+    NormedAddCommGroup (CStarMatrix m n A)) = instNormedAddCommGroup2 := by
+  with_reducible_and_instances rfl
+
+set_option backward.privateInPublic true in
+set_option backward.privateInPublic.warn false in
+@[implicit_reducible]
+noncomputable def instNormedAddCommGroup3 :
+    NormedAddCommGroup (CStarMatrix m n A) :=
+  fast_instance% .ofCoreReplaceAll CStarMatrix.normedSpaceCore
+    CStarMatrix.uniformity_eq_aux.symm
+      fun _ => Filter.ext_iff.1 CStarMatrix.cobounded_eq_aux.symm _
+
+lemma foot : (instNormedAddCommGroup2 :
+    NormedAddCommGroup (CStarMatrix m n A)) = instNormedAddCommGroup4 := by
+  with_reducible_and_instances rfl
+
+
+
+#exit
 
 noncomputable instance instNormedSpace : NormedSpace ℂ (CStarMatrix m n A) :=
   .ofCore CStarMatrix.normedSpaceCore

--- a/Mathlib/Analysis/CStarAlgebra/Module/Constructions.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Module/Constructions.lean
@@ -182,12 +182,10 @@ private lemma lipschitzWith_one_equiv_prod_aux : LipschitzWith 1 (equiv A (E × 
   AddMonoidHomClass.lipschitz_of_bound_nnnorm (linearEquiv ℂ A (E × F)) 1 <| by
     simpa using norm_equiv_le_norm_prod
 
-set_option backward.privateInPublic true in
 private lemma uniformity_prod_eq_aux :
     𝓤[(inferInstance : UniformSpace (E × F)).comap <| equiv _ _] = 𝓤 C⋆ᵐᵒᵈ(A, E × F) :=
   uniformity_eq_of_bilipschitz antilipschitzWith_two_equiv_prod_aux lipschitzWith_one_equiv_prod_aux
 
-set_option backward.privateInPublic true in
 private lemma isBounded_prod_iff_aux (s : Set C⋆ᵐᵒᵈ(A, E × F)) :
     @IsBounded _ (induced <| equiv A (E × F)) s ↔ IsBounded s :=
   isBounded_iff_of_bilipschitz antilipschitzWith_two_equiv_prod_aux
@@ -195,10 +193,10 @@ private lemma isBounded_prod_iff_aux (s : Set C⋆ᵐᵒᵈ(A, E × F)) :
 
 end Aux
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 noncomputable instance : NormedAddCommGroup C⋆ᵐᵒᵈ(A, E × F) :=
-  .ofCoreReplaceAll (normedSpaceCore A) uniformity_prod_eq_aux isBounded_prod_iff_aux
+  .ofCoreReplaceAll (normedSpaceCore A) ?_ ?_
+where finally
+  exacts [uniformity_prod_eq_aux, isBounded_prod_iff_aux]
 
 noncomputable instance : NormedSpace ℂ C⋆ᵐᵒᵈ(A, E × F) := .ofCore (normedSpaceCore A)
 
@@ -312,22 +310,20 @@ private lemma lipschitzWith_one_equiv_pi_aux : LipschitzWith 1 (equiv A (Π i, E
   AddMonoidHomClass.lipschitz_of_bound_nnnorm (linearEquiv ℂ A (Π i, E i)) 1 <| by
     simpa using norm_equiv_le_norm_pi
 
-set_option backward.privateInPublic true in
 private lemma uniformity_pi_eq_aux :
     𝓤[(inferInstance : UniformSpace (Π i, E i)).comap <| equiv A _] = 𝓤 C⋆ᵐᵒᵈ(A, Π i, E i) :=
   uniformity_eq_of_bilipschitz antilipschitzWith_card_equiv_pi_aux lipschitzWith_one_equiv_pi_aux
 
-set_option backward.privateInPublic true in
 private lemma isBounded_pi_iff_aux (s : Set C⋆ᵐᵒᵈ(A, Π i, E i)) :
     @IsBounded _ (induced <| equiv A (Π i, E i)) s ↔ IsBounded s :=
   isBounded_iff_of_bilipschitz antilipschitzWith_card_equiv_pi_aux lipschitzWith_one_equiv_pi_aux s
 
 end Aux
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 noncomputable instance : NormedAddCommGroup C⋆ᵐᵒᵈ(A, Π i, E i) :=
-  .ofCoreReplaceAll (normedSpaceCore A) uniformity_pi_eq_aux isBounded_pi_iff_aux
+  .ofCoreReplaceAll (normedSpaceCore A) ?_ ?_
+where finally
+  exacts [uniformity_pi_eq_aux, isBounded_pi_iff_aux]
 
 noncomputable instance : NormedSpace ℂ C⋆ᵐᵒᵈ(A, Π i, E i) := .ofCore (normedSpaceCore A)
 

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -600,8 +600,8 @@ abbrev PseudoEMetricSpace.ofSeminormedSpaceCore {𝕜 E : Type*} [NormedField �
 already has an existing uniform space structure. This requires a proof that the uniformity induced
 by the norm is equal to the preexisting uniformity. See note [reducible non-instances]. -/
 abbrev PseudoMetricSpace.ofSeminormedSpaceCoreReplaceUniformity {𝕜 E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [U : UniformSpace E]
-    (core : SeminormedSpace.Core 𝕜 E)
+    [AddCommGroup E] [Norm E] [Module 𝕜 E] (core : SeminormedSpace.Core 𝕜 E)
+    [U : UniformSpace E]
     (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
         (self := PseudoEMetricSpace.ofSeminormedSpaceCore core)]) :
     PseudoMetricSpace E :=
@@ -611,8 +611,8 @@ abbrev PseudoMetricSpace.ofSeminormedSpaceCoreReplaceUniformity {𝕜 E : Type*}
 already has an existing topology. This requires a proof that the topology induced
 by the norm is equal to the preexisting topology. See note [reducible non-instances]. -/
 abbrev PseudoMetricSpace.ofSeminormedSpaceCoreReplaceTopology {𝕜 E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [T : TopologicalSpace E]
-    (core : SeminormedSpace.Core 𝕜 E)
+    [AddCommGroup E] [Norm E] [Module 𝕜 E] (core : SeminormedSpace.Core 𝕜 E)
+    [T : TopologicalSpace E]
     (H : T = (PseudoEMetricSpace.ofSeminormedSpaceCore
       core).toUniformSpace.toTopologicalSpace) :
     PseudoMetricSpace E :=
@@ -624,8 +624,8 @@ already has a preexisting uniform space structure and a preexisting bornology. T
 that the uniformity induced by the norm is equal to the preexisting uniformity, and likewise for
 the bornology. See note [reducible non-instances]. -/
 abbrev PseudoMetricSpace.ofSeminormedSpaceCoreReplaceAll {𝕜 E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [U : UniformSpace E] [B : Bornology E]
-    (core : SeminormedSpace.Core 𝕜 E)
+    [AddCommGroup E] [Norm E] [Module 𝕜 E] (core : SeminormedSpace.Core 𝕜 E)
+    [U : UniformSpace E] [B : Bornology E]
     (HU : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
       (self := PseudoEMetricSpace.ofSeminormedSpaceCore core)])
     (HB : ∀ s : Set E, @IsBounded _ B s
@@ -645,8 +645,7 @@ abbrev SeminormedAddCommGroup.ofCore {𝕜 : Type*} {E : Type*} [NormedField �
 that already has an existing uniform space structure. This requires a proof that the uniformity
 induced by the norm is equal to the preexisting uniformity. See note [reducible non-instances]. -/
 abbrev SeminormedAddCommGroup.ofCoreReplaceUniformity {𝕜 : Type*} {E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [U : UniformSpace E]
-    (core : SeminormedSpace.Core 𝕜 E)
+    [AddCommGroup E] [Norm E] [Module 𝕜 E] (core : SeminormedSpace.Core 𝕜 E) [U : UniformSpace E]
     (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
       (self := PseudoEMetricSpace.ofSeminormedSpaceCore core)]) :
     SeminormedAddCommGroup E :=
@@ -656,8 +655,8 @@ abbrev SeminormedAddCommGroup.ofCoreReplaceUniformity {𝕜 : Type*} {E : Type*}
 that already has an existing topology. This requires a proof that the uniformity
 induced by the norm is equal to the preexisting uniformity. See note [reducible non-instances]. -/
 abbrev SeminormedAddCommGroup.ofCoreReplaceTopology {𝕜 : Type*} {E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [T : TopologicalSpace E]
-    (core : SeminormedSpace.Core 𝕜 E)
+    [AddCommGroup E] [Norm E] [Module 𝕜 E] (core : SeminormedSpace.Core 𝕜 E)
+    [T : TopologicalSpace E]
     (H : T = (PseudoEMetricSpace.ofSeminormedSpaceCore
       core).toUniformSpace.toTopologicalSpace) :
     SeminormedAddCommGroup E :=
@@ -669,8 +668,9 @@ that already has a preexisting uniform space structure and a preexisting bornolo
 proofs that the uniformity induced by the norm is equal to the preexisting uniformity, and likewise
 for the bornology. See note [reducible non-instances]. -/
 abbrev SeminormedAddCommGroup.ofCoreReplaceAll {𝕜 : Type*} {E : Type*} [NormedField 𝕜]
-    [AddCommGroup E] [Norm E] [Module 𝕜 E] [U : UniformSpace E] [B : Bornology E]
+    [AddCommGroup E] [Norm E] [Module 𝕜 E]
     (core : SeminormedSpace.Core 𝕜 E)
+    [U : UniformSpace E] [B : Bornology E]
     (HU : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
       (self := PseudoEMetricSpace.ofSeminormedSpaceCore core)])
     (HB : ∀ s : Set E, @IsBounded _ B s
@@ -703,7 +703,8 @@ abbrev NormedAddCommGroup.ofCore (core : NormedSpace.Core 𝕜 E) : NormedAddCom
 /-- Produces a `NormedAddCommGroup E` instance from a `NormedSpace.Core` on a type
 that already has an existing uniform space structure. This requires a proof that the uniformity
 induced by the norm is equal to the preexisting uniformity. See note [reducible non-instances]. -/
-abbrev NormedAddCommGroup.ofCoreReplaceUniformity [U : UniformSpace E] (core : NormedSpace.Core 𝕜 E)
+abbrev NormedAddCommGroup.ofCoreReplaceUniformity (core : NormedSpace.Core 𝕜 E)
+    [U : UniformSpace E]
     (H : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
       (self := PseudoEMetricSpace.ofSeminormedSpaceCore core.toCore)]) :
     NormedAddCommGroup E :=
@@ -717,8 +718,8 @@ abbrev NormedAddCommGroup.ofCoreReplaceUniformity [U : UniformSpace E] (core : N
 /-- Produces a `NormedAddCommGroup E` instance from a `NormedSpace.Core` on a type
 that already has an existing topology. This requires a proof that the uniformity
 induced by the norm is equal to the preexisting uniformity. See note [reducible non-instances]. -/
-abbrev NormedAddCommGroup.ofCoreReplaceTopology [T : TopologicalSpace E]
-    (core : NormedSpace.Core 𝕜 E)
+abbrev NormedAddCommGroup.ofCoreReplaceTopology
+    (core : NormedSpace.Core 𝕜 E) [T : TopologicalSpace E]
     (H : T = (PseudoEMetricSpace.ofSeminormedSpaceCore
       core.toCore).toUniformSpace.toTopologicalSpace) :
     NormedAddCommGroup E :=
@@ -734,8 +735,8 @@ open Bornology in
 that already has a preexisting uniform space structure and a preexisting bornology. This requires
 proofs that the uniformity induced by the norm is equal to the preexisting uniformity, and likewise
 for the bornology. See note [reducible non-instances]. -/
-abbrev NormedAddCommGroup.ofCoreReplaceAll [U : UniformSpace E] [B : Bornology E]
-    (core : NormedSpace.Core 𝕜 E)
+abbrev NormedAddCommGroup.ofCoreReplaceAll (core : NormedSpace.Core 𝕜 E)
+    [U : UniformSpace E] [B : Bornology E]
     (HU : 𝓤[U] = 𝓤[PseudoEMetricSpace.toUniformSpace
       (self := PseudoEMetricSpace.ofSeminormedSpaceCore core.toCore)])
     (HB : ∀ s : Set E, @IsBounded _ B s


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
