### PR TITLE
[Merged by Bors] - feat(Topology/EMetricSpace/Defs): add theorems `EMetric.continuous*_iff*`

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -507,6 +507,8 @@ theorem tendsto_atTop [Nonempty β] [SemilatticeSup β] {u : β → α} {a : α}
   (atTop_basis.tendsto_iff nhds_basis_eball).trans <| by
     simp only [true_and, mem_Ici, mem_eball]
 
+section
+
 variable [PseudoEMetricSpace β] {f : α → β}
 
 theorem tendsto_nhdsWithin_nhdsWithin {t : Set β} {a b} :
@@ -525,6 +527,48 @@ theorem tendsto_nhdsWithin_nhds {a b} :
 theorem tendsto_nhds_nhds {a b} :
     Tendsto f (𝓝 a) (𝓝 b) ↔ ∀ ε > 0, ∃ δ > 0, ∀ ⦃x⦄, edist x a < δ → edist (f x) b < ε :=
   nhds_basis_eball.tendsto_iff nhds_basis_eball
+
+theorem continuousAt_iff {a} :
+    ContinuousAt f a ↔ ∀ ε > 0, ∃ δ > 0, ∀ ⦃x : α⦄, edist x a < δ → edist (f x) (f a) < ε := by
+  rw [ContinuousAt, tendsto_nhds_nhds]
+
+theorem continuousWithinAt_iff {a s} :
+    ContinuousWithinAt f s a ↔
+      ∀ ε > 0, ∃ δ > 0, ∀ ⦃x : α⦄, x ∈ s → edist x a < δ → edist (f x) (f a) < ε := by
+  rw [ContinuousWithinAt, tendsto_nhdsWithin_nhds]
+
+theorem continuousOn_iff {s} :
+    ContinuousOn f s ↔
+      ∀ b ∈ s, ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, edist a b < δ → edist (f a) (f b) < ε := by
+  simp [ContinuousOn, continuousWithinAt_iff]
+
+theorem continuous_iff :
+    Continuous f ↔ ∀ b, ∀ ε > 0, ∃ δ > 0, ∀ a, edist a b < δ → edist (f a) (f b) < ε :=
+  continuous_iff_continuousAt.trans <| forall_congr' fun _ ↦ tendsto_nhds_nhds
+
+end
+
+section
+
+variable [TopologicalSpace β] {f : β → α}
+
+theorem continuousAt_iff' {b} :
+    ContinuousAt f b ↔ ∀ ε > 0, ∀ᶠ x in 𝓝 b, edist (f x) (f b) < ε := by
+  rw [ContinuousAt, tendsto_nhds]
+
+theorem continuousWithinAt_iff' {b s} :
+    ContinuousWithinAt f s b ↔ ∀ ε > 0, ∀ᶠ x in 𝓝[s] b, edist (f x) (f b) < ε := by
+  rw [ContinuousWithinAt, tendsto_nhds]
+
+theorem continuousOn_iff' {s} :
+    ContinuousOn f s ↔ ∀ b ∈ s, ∀ ε > 0, ∀ᶠ x in 𝓝[s] b, edist (f x) (f b) < ε := by
+  simp [ContinuousOn, continuousWithinAt_iff']
+
+theorem continuous_iff' :
+    Continuous f ↔ ∀ a, ∀ ε > 0, ∀ᶠ x in 𝓝 a, edist (f x) (f a) < ε :=
+  continuous_iff_continuousAt.trans <| forall_congr' fun _ ↦ tendsto_nhds
+
+end
 
 end EMetric
 


### PR DESCRIPTION
Add 8 theorems of the form `EMetric.continuous*_iff*`, which are exactly analogous to
existing theorems of the form `Metric.continuous*_iff*`

---

Thus the API between the following files (already pretty consistent) is now more consistent
`Topology.MetricSpace.Pseudo.Defs` for `PseudoMetricSpace`
`Topology.EMetricSpace.Defs` for `PseudoEMetricSpace`

I have copied the theorems exactly (that is, changing only `[e]dist` and `Pseudo[E]MetricSpace`),
however perhaps there will be suggestions to make other changes at this opportunity.
(E.g. is it worth making the use of strict implicit parameters more consistent - possibly not?)
