### PR TITLE
[Merged by Bors] - chore: remove backward.inferInstanceAs.wrap.data in spectralNorm_unique

### DIFF
--- a/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
@@ -713,8 +713,8 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
   let E : Type v := id K⟮x⟯
   let : Field E := show Field K⟮x⟯ by infer_instance
   let : Module K E := show Module K K⟮x⟯ by infer_instance
-  let id1 : ↥K⟮x⟯ →ₗ[K] E := LinearMap.id
-  let id2 : E →ₗ[K] ↥K⟮x⟯ := LinearMap.id
+  let id1 : K⟮x⟯ →ₗ[K] E := LinearMap.id
+  let id2 : E →ₗ[K] K⟮x⟯ := LinearMap.id
   set hs_norm : RingNorm E :=
     { toFun y := spectralNorm K L (id2 y : L)
       map_zero' := by simp [map_zero, spectralNorm_zero, ZeroMemClass.coe_zero]

--- a/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
@@ -703,7 +703,6 @@ universe u v
 variable {K : Type u} [NontriviallyNormedField K] {L : Type v} [Field L] [Algebra K L]
   [Algebra.IsAlgebraic K L] [hu : IsUltrametricDist K]
 
-set_option backward.inferInstanceAs.wrap.data false in
 /-- If `K` is a field complete with respect to a nontrivial nonarchimedean multiplicative norm and
   `L/K` is an algebraic extension, then any power-multiplicative `K`-algebra norm on `L` coincides
   with the spectral norm. -/
@@ -711,11 +710,11 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
     f = spectralAlgNorm K L := by
   apply eq_of_powMul_faithful f hf_pm _ spectralAlgNorm_isPowMul
   intro x
-  set E : Type v := id K⟮x⟯
-  letI hE : Field E := inferInstanceAs (Field K⟮x⟯)
-  letI : Algebra K E := inferInstanceAs (Algebra K K⟮x⟯)
-  let id1 : K⟮x⟯ →ₗ[K] E := LinearMap.id
-  let id2 : E →ₗ[K] K⟮x⟯ := LinearMap.id
+  let E : Type v := id K⟮x⟯
+  let : Field E := show Field K⟮x⟯ by infer_instance
+  let : Module K E := show Module K K⟮x⟯ by infer_instance
+  let id1 : ↥K⟮x⟯ →ₗ[K] E := LinearMap.id
+  let id2 : E →ₗ[K] ↥K⟮x⟯ := LinearMap.id
   set hs_norm : RingNorm E :=
     { toFun y := spectralNorm K L (id2 y : L)
       map_zero' := by simp [map_zero, spectralNorm_zero, ZeroMemClass.coe_zero]
@@ -729,8 +728,8 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
       eq_zero_of_map_eq_zero' a ha := by
         simpa [id_eq, eq_mpr_eq_cast, cast_eq, LinearMap.coe_mk, ← spectralAlgNorm_def,
           map_eq_zero_iff_eq_zero, ZeroMemClass.coe_eq_zero] using ha }
-  letI n1 : NormedRing E := RingNorm.toNormedRing hs_norm
-  letI N1 : NormedSpace K E :=
+  let n1 : NormedRing E := RingNorm.toNormedRing hs_norm
+  let N1 : NormedSpace K E :=
     { one_smul e := by simp [one_smul]
       mul_smul k1 k2 e := by simp [mul_smul]
       smul_zero e := by simp
@@ -749,8 +748,8 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
       mul_le' a b := map_mul_le_mul _ _ _
       eq_zero_of_map_eq_zero' a ha := by
         simpa [map_eq_zero_iff_eq_zero, map_eq_zero] using ha }
-  letI n2 : NormedRing K⟮x⟯ := RingNorm.toNormedRing hf_norm
-  letI N2 : NormedSpace K K⟮x⟯ :=
+  let n2 : NormedRing K⟮x⟯ := RingNorm.toNormedRing hf_norm
+  let N2 : NormedSpace K K⟮x⟯ :=
     { one_smul e := by simp [one_smul]
       mul_smul k1 k2 e := by simp [mul_smul]
       smul_zero e := by simp
@@ -762,7 +761,7 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
         have : (algebraMap (↥K⟮x⟯) L) (k • y) = k • algebraMap (↥K⟮x⟯) L y := by
           simp [IntermediateField.algebraMap_apply]
         rw [this, map_smul_eq_mul] }
-  haveI hKx_fin : FiniteDimensional K ↥K⟮x⟯ :=
+  have hKx_fin : FiniteDimensional K ↥K⟮x⟯ :=
     IntermediateField.adjoin.finiteDimensional (Algebra.IsAlgebraic.isAlgebraic x).isIntegral
   haveI : FiniteDimensional K E := hKx_fin
   set Id1 : K⟮x⟯ →L[K] E := ⟨id1, id1.continuous_of_finiteDimensional⟩

--- a/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SpectralNorm.lean
@@ -763,7 +763,7 @@ theorem spectralNorm_unique [CompleteSpace K] {f : AlgebraNorm K L} (hf_pm : IsP
         rw [this, map_smul_eq_mul] }
   have hKx_fin : FiniteDimensional K ↥K⟮x⟯ :=
     IntermediateField.adjoin.finiteDimensional (Algebra.IsAlgebraic.isAlgebraic x).isIntegral
-  haveI : FiniteDimensional K E := hKx_fin
+  have : FiniteDimensional K E := hKx_fin
   set Id1 : K⟮x⟯ →L[K] E := ⟨id1, id1.continuous_of_finiteDimensional⟩
   set Id2 : E →L[K] K⟮x⟯ := ⟨id2, id2.continuous_of_finiteDimensional⟩
   obtain ⟨C1, hC1_pos, hC1⟩ : ∃ C1 : ℝ, 0 < C1 ∧ ∀ y : K⟮x⟯, ‖id1 y‖ ≤ C1 * ‖y‖ :=


### PR DESCRIPTION
Also letI -> let and haveI -> have. 

Discussion at [#general > backward.isDefEq.respectTransparency @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/585495786) . 

Upshot: to make a type synonym in a proof and then copy some structure over you can now do
```lean 
  let E : Type v := id K⟮x⟯
  let : Field E := show Field K⟮x⟯ by infer_instance
```
but `inferInstanceAs` doesn't work any more.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

