### PR TITLE
feat(Analysis/Controls): add Control functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1848,6 +1848,7 @@ public import Mathlib.Analysis.Complex.ValueDistribution.LogCounting.Asymptotic
 public import Mathlib.Analysis.Complex.ValueDistribution.LogCounting.Basic
 public import Mathlib.Analysis.Complex.ValueDistribution.Proximity.Basic
 public import Mathlib.Analysis.ConstantSpeed
+public import Mathlib.Analysis.Controls.BoundedVariation
 public import Mathlib.Analysis.Controls.ControlOn
 public import Mathlib.Analysis.Controls.Defs
 public import Mathlib.Analysis.Convex.AmpleSet

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1848,6 +1848,8 @@ public import Mathlib.Analysis.Complex.ValueDistribution.LogCounting.Asymptotic
 public import Mathlib.Analysis.Complex.ValueDistribution.LogCounting.Basic
 public import Mathlib.Analysis.Complex.ValueDistribution.Proximity.Basic
 public import Mathlib.Analysis.ConstantSpeed
+public import Mathlib.Analysis.Controls.ControlOn
+public import Mathlib.Analysis.Controls.Defs
 public import Mathlib.Analysis.Convex.AmpleSet
 public import Mathlib.Analysis.Convex.Approximation
 public import Mathlib.Analysis.Convex.Basic

--- a/Mathlib/Analysis/Controls/BoundedVariation.lean
+++ b/Mathlib/Analysis/Controls/BoundedVariation.lean
@@ -62,7 +62,7 @@ theorem bdd_of_le_control {a b} {C : ℝ≥0} (ha : IsLeast s a) (hb : IsGreates
     intro ⟨n, u, hmon, hmem⟩
     suffices hω : ENNReal.ofNNReal (ω (u 0) (u n)) ≤ ENNReal.ofNNReal (ω a b) by
       exact (Finset.sum_le_sum (s := Finset.range n) fun i _ => hbd (hmem i) (hmem i.succ)
-        (hmon.imp i.le_succ)).trans (by exact_mod_cast ω.sum_seq_le ⟨n, u, hmon, hmem⟩) |>.trans hω 
+        (hmon.imp i.le_succ)).trans (by exact_mod_cast ω.sum_seq_le ⟨n, u, hmon, hmem⟩) |>.trans hω
     exact_mod_cast (ω.mono_right_of_le_le (hmem 0) (hmem n) hb.1
       (hmon.imp (by positivity)) (hb.2 (hmem n))).trans <|
       ω.anti_left_of_le_le ha.1 (hmem 0) hb.1 (ha.2 (hmem 0)) (hb.2 (hmem 0))
@@ -71,9 +71,8 @@ theorem boundedVariationOn_of_le {C : ℝ≥0}
     (hbd : ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → x ≤ y → edist (f y) (f x) ≤ C * ω x y) :
     LocallyBoundedVariationOn f s := by
   intro a b ha hb
-  
+
   exact ne_top_of_le_ne_top (ENNReal.mul_ne_top (ENNReal.coe_ne_top (r := C)) ()) ()
 
 
 end eVariationOn
-

--- a/Mathlib/Analysis/Controls/BoundedVariation.lean
+++ b/Mathlib/Analysis/Controls/BoundedVariation.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 Nikolas Tapia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolas Tapia
+-/
+module
+public import Mathlib.Topology.EMetricSpace.BoundedVariation
+public import Mathlib.Order.WithBotTop
+public import Mathlib.Analysis.Controls.ControlOn
+
+/-!
+# Bounded Variation
+
+## Main statements
+
+We prove facts relating control functions (see `Mathlib.Analysis.Controls.Defs`) and functions of
+bounded variation on a subset.
+
+- `eVariationOn.bdd_of_le_control`: if the consecutive values of a function distances bounded by a
+control function, then its variation is bounded by the same control.
+- `eVariationOn.boundedVariation_of_le`: under the same hypotheses, said function is of locally
+bounded variation on `s`.
+
+## Tags
+
+control function, bounded variation
+-/
+
+@[expose] public section
+
+open scoped ENNReal NNReal
+
+variable {α E} [LinearOrder α] [TopologicalSpace α] [PseudoEMetricSpace E]
+variable {s : Set α}
+
+namespace ControlOn
+
+@[simp]
+theorem sum_seq_le (ω : ControlOn α s) (p : ℕ × {u : ℕ → α // Monotone u ∧ ∀ i, u i ∈ s}) :
+    ∑ i ∈ Finset.range p.1, ω (p.2.1 i) (p.2.1 i.succ) ≤ ω (p.2.1 0) (p.2.1 p.1) := by
+  induction p.1 with
+  | zero => simp
+  | succ n ha => {
+      have := (add_le_add_left ha (ω (p.2.1 n) (p.2.1 n.succ))).trans <| ω.superadd (p.2.2.2 0)
+        (p.2.2.2 n) (p.2.2.2 n.succ) (p.2.2.1.imp (by positivity)) (p.2.2.1.imp n.le_succ)
+      simpa [Finset.sum_range_succ]
+    }
+
+end ControlOn
+
+namespace eVariationOn
+
+variable {f : α → E} {ω : ControlOn α s}
+
+theorem bdd_of_le_control {a b} {C : ℝ≥0} (ha : IsLeast s a) (hb : IsGreatest s b)
+    (hbd : ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → x ≤ y → edist (f y) (f x) ≤ C * ω x y) :
+    eVariationOn f s ≤ C * ω a b := by
+  wlog hC : C = 1 with H
+  · simpa using H (ω := C • ω) (C := 1) ha hb (by simpa)
+  · simp only [hC, ENNReal.coe_one, one_mul] at hbd ⊢
+    apply iSup_le
+    intro ⟨n, u, hmon, hmem⟩
+    suffices hω : ENNReal.ofNNReal (ω (u 0) (u n)) ≤ ENNReal.ofNNReal (ω a b) by
+      exact (Finset.sum_le_sum (s := Finset.range n) fun i _ => hbd (hmem i) (hmem i.succ)
+        (hmon.imp i.le_succ)).trans (by exact_mod_cast ω.sum_seq_le ⟨n, u, hmon, hmem⟩) |>.trans hω 
+    exact_mod_cast (ω.mono_right_of_le_le (hmem 0) (hmem n) hb.1
+      (hmon.imp (by positivity)) (hb.2 (hmem n))).trans <|
+      ω.anti_left_of_le_le ha.1 (hmem 0) hb.1 (ha.2 (hmem 0)) (hb.2 (hmem 0))
+
+theorem boundedVariationOn_of_le {C : ℝ≥0}
+    (hbd : ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → x ≤ y → edist (f y) (f x) ≤ C * ω x y) :
+    LocallyBoundedVariationOn f s := by
+  intro a b ha hb
+  
+  exact ne_top_of_le_ne_top (ENNReal.mul_ne_top (ENNReal.coe_ne_top (r := C)) ()) ()
+
+
+end eVariationOn
+

--- a/Mathlib/Analysis/Controls/ControlOn.lean
+++ b/Mathlib/Analysis/Controls/ControlOn.lean
@@ -213,4 +213,3 @@ def sub_of_monotone {f : α → ℝ} (hf : MonotoneOn f s) (hc : ContinuousOn f 
     · exact hc.comp (by fun_prop) fun x ⟨hx, _⟩ => (Set.mem_prod.mp hx).1
 
 end ControlOn
-

--- a/Mathlib/Analysis/Controls/ControlOn.lean
+++ b/Mathlib/Analysis/Controls/ControlOn.lean
@@ -47,6 +47,8 @@ control function, modulus of continuity, rough paths, superadditive, restricted 
 
 open scoped NNReal
 
+/-- A Control on a set `s` of type `α` is a superadditive function of two variables, continuous on
+  the ordered 2-simplex restricted to `s`, vanishing on the diagonal -/
 structure ControlOn (α) [PartialOrder α] [TopologicalSpace α] (s : Set α) where
   /-- The underlying two-variable function. -/
   toFun : α → α → ℝ≥0

--- a/Mathlib/Analysis/Controls/ControlOn.lean
+++ b/Mathlib/Analysis/Controls/ControlOn.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 Nikolas Tapia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolas Tapia
+-/
+module
+public import Mathlib.Analysis.Convex.SpecificFunctions.Basic
+public import Mathlib.Analysis.MeanInequalities
+public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+
+/-!
+# Control functions on a set
+
+This file defines `ControlOn α s`, a variant of `Control` (see `Roughlib.Analysis.Control`) where
+superadditivity and continuity are only required on a subset `s : Set α`. This is useful when
+working with intervals or other restricted domains.
+
+## Main definitions
+
+- `ControlOn`: the structure bundling a superadditive continuous function vanishing on the diagonal,
+  restricted to a set `s`.
+- `ControlOn.map_convex_mono`: composing a `ControlOn` with a convex, monotone, continuous
+  function preserving zero yields a new `ControlOn`.
+- `ControlOn.rpow`: the `θ`-th power of a `ControlOn` is a `ControlOn` for `1 ≤ θ`.
+- `ControlOn.mul`: the pointwise product of two `ControlOn`s is a `ControlOn`.
+- `ControlOn.mul_rpow`: the Hölder combination `(ω^(p/(p+q)) · ω'^(q/(p+q)))^(p+q)` of two
+  `ControlOn`s is a `ControlOn` for `1 ≤ p + q`.
+- `ControlOn.sub_of_monotone`: the oscillation `(f t - f s)₊` of a monotone function on `s`
+  is a `ControlOn`.
+
+## Main statements
+
+- `ControlOn.monotone_right`, `ControlOn.antitone_left`: monotonicity properties
+  (see [friz-victoir2010], Lemma 1.7).
+
+## References
+
+* [P. Friz and N. Victoir, *Multidimensional Stochastic Processes as Rough Paths*][friz-victoir2010]
+  (Section 1.2)
+
+## Tags
+
+control function, modulus of continuity, rough paths, superadditive, restricted domain
+-/
+
+@[expose] public section
+
+open scoped NNReal
+
+structure ControlOn (α) [PartialOrder α] [TopologicalSpace α] (s : Set α) where
+  /-- The underlying two-variable function. -/
+  toFun : α → α → ℝ≥0
+  /-- Superadditivity on `s`: `ω a b + ω b c ≤ ω a c` for `a, b, c ∈ s` with `a ≤ b ≤ c`. -/
+  superadd ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s) ⦃c⦄ (_ : c ∈ s) :
+    a ≤ b → b ≤ c → toFun a b + toFun b c ≤ toFun a c
+  /-- The diagonal vanishes: `ω a a = 0`. -/
+  zero_diag ⦃a⦄ : toFun a a = 0
+  /-- Continuity of `ω` on `{(s, t) ∈ s × s | s ≤ t}`. -/
+  continuous : ContinuousOn (fun p : α × α => toFun p.1 p.2) {p ∈ s ×ˢ s | p.1 ≤ p.2}
+
+namespace ControlOn
+
+variable {α} [PartialOrder α] [TopologicalSpace α] {a b c : α} {s : Set α}
+
+instance instCoeFun : CoeFun (ControlOn α s) (fun _ => α → α → ℝ≥0) := ⟨toFun⟩
+
+instance : SMul ℝ≥0 (ControlOn α s) where
+  smul r ω := by
+    refine ⟨fun s t => r * ω s t, ?_, ?_, ?_⟩
+    · intro _ ha _ hb _ hc hsu hut
+      simpa [← mul_add] using mul_le_mul_of_nonneg_left (ω.superadd ha hb hc hsu hut) (zero_le r)
+    · simp [ω.zero_diag]
+    · exact ω.continuous.const_mul r
+
+instance : Add (ControlOn α s) where
+  add ω ω' := by
+    refine ⟨fun s t => ω s t + ω' s t, ?_, ?_, ?_⟩
+    · intro _ ha _ hb _ hc hsu hut
+      simpa [add_comm, ← add_assoc] using
+        add_le_add (ω.superadd ha hb hc hsu hut) (ω'.superadd ha hb hc hsu hut)
+    · simp [ω.zero_diag, ω'.zero_diag]
+    · exact ω.continuous.add ω'.continuous
+
+variable {ω ω' : ControlOn α s}
+
+/-- A control is monotone in the right variable. See [friz-victoir2010], Lemma 1.7. -/
+theorem monotone_right (ha : a ∈ s) : MonotoneOn (fun x => ω a x) {x ∈ s | a ≤ x} := by
+  intro b ⟨hb, hbl⟩ c ⟨hc, hcl⟩ hbc
+  exact (le_add_of_nonneg_right (zero_le (ω b c))).trans <|
+    ω.superadd ha hb hc hbl hbc
+
+/-- Monotonicity in the right variable for explicit membership and inequalities `a ≤ b ≤ c`. -/
+lemma mono_right_of_le_le (ha : a ∈ s) (hb : b ∈ s) (hc : c ∈ s)
+    (hab : a ≤ b) (hbc : b ≤ c) : ω a b ≤ ω a c :=
+  monotone_right ha (Set.mem_setOf.mpr ⟨hb, hab⟩) (Set.mem_setOf.mpr ⟨hc, hab.trans hbc⟩) hbc
+
+/-- A control is antitone in the left variable. See [friz-victoir2010], Lemma 1.7. -/
+theorem antitone_left (hc : c ∈ s) : AntitoneOn (fun x => ω x c) {x ∈ s | x ≤ c} := by
+  intro a ⟨ha, hal⟩ b ⟨hb, hbl⟩ hab
+  exact (le_add_of_nonneg_left (zero_le _)).trans <|
+    ω.superadd ha hb hc hab hbl
+
+/-- Antitononicity in the left variable for explicit membership and inequalities `a ≤ b ≤ c`. -/
+lemma anti_left_of_le_le (ha : a ∈ s) (hb : b ∈ s) (hc : c ∈ s)
+    (hab : a ≤ b) (hbc : b ≤ c) : ω b c ≤ ω a c :=
+  antitone_left hc (Set.mem_setOf.mpr ⟨ha, hab.trans hbc⟩) (Set.mem_setOf.mpr ⟨hb, hbc⟩) hab
+
+/-- The right-variable function `ω a ·` is continuous on `{x ∈ s | a ≤ x}`. -/
+theorem continuous_right (ha : a ∈ s) : ContinuousOn (fun x => ω a x) {x ∈ s | a ≤ x} :=
+  ω.continuous.comp (continuousOn_const.prodMk continuousOn_id)
+    fun _ ⟨hx, hax⟩ => ⟨Set.mk_mem_prod ha hx, hax⟩
+
+/-- The left-variable function `ω · b` is continuous on `{x ∈ s | x ≤ b}`. -/
+theorem continuous_left (hb : b ∈ s) : ContinuousOn (fun a => ω a b) {x ∈ s | x ≤ b} :=
+  ω.continuous.comp (continuousOn_id.prodMk continuousOn_const)
+    fun _ ⟨hx, hxb⟩ => ⟨Set.mk_mem_prod hx hb, hxb⟩
+
+/-- Composing a control with a convex, monotone, continuous function that preserves zero yields a
+new control. See [friz-victoir2010], Exercise 1.9. -/
+def map_convex_mono {φ : ℝ≥0 → ℝ≥0} (hz : φ 0 = 0) (hφ : ConvexOn ℝ≥0 Set.univ φ)
+    (hφ_mono : Monotone φ) (hφ_cont : Continuous φ) : ControlOn α s where
+  toFun a b := φ (ω a b)
+  superadd _ ha _ hb _ hc hab hbc :=(superadd_of_convexOn_zero (u := ⊤) hz hφ (Set.mem_univ _)
+    (Set.mem_univ _) (by positivity) (by positivity)).trans
+      (hφ_mono <| ω.superadd ha hb hc hab hbc)
+  zero_diag := by simp [ω.zero_diag, hz]
+  continuous := hφ_cont.comp_continuousOn ω.continuous
+
+theorem nnreal_of_real {f : ℝ≥0 → ℝ≥0}
+    (hf : ConvexOn ℝ (Set.Ici 0) fun x : ℝ => (f x.toNNReal : ℝ)) : ConvexOn ℝ≥0 ⊤ f where
+  left := convex_univ
+  right := by
+    intro x hx y hy a b ha hb hab
+    simpa [← NNReal.coe_mul, ← NNReal.coe_add] using
+      hf.2 x.coe_nonneg y.coe_nonneg a.coe_nonneg b.coe_nonneg (by exact_mod_cast hab)
+
+/-- The `θ`-th power of a control is a control for `1 ≤ θ`.
+See [friz-victoir2010], Exercise 1.9. -/
+noncomputable def rpow {θ : ℝ} (hθ : 1 ≤ θ) : ControlOn α s :=
+  map_convex_mono (ω := ω) (φ := (· ^ θ))
+    (NNReal.zero_rpow (by positivity))
+    (nnreal_of_real <|
+      (convexOn_rpow hθ).congr fun x hx => by simp [NNReal.coe_rpow, Real.coe_toNNReal x hx])
+    (NNReal.monotone_rpow_of_nonneg (by positivity))
+    (NNReal.continuous_rpow_const (by positivity))
+
+/-- The pointwise product of two `ControlOn`s is a `ControlOn`. -/
+def mul : ControlOn α s where
+  toFun a b := ω a b * ω' a b
+  superadd _ ha _ hb _ hc hab hbc := by
+    suffices ineq : ∀ a₁ a₂ b₁ b₂ : ℝ≥0, a₁ * a₂ + b₁ * b₂ ≤ (a₁ + b₁) * (a₂ + b₂) by
+      exact (ineq (ω _ _) (ω' _ _) (ω _ _) (ω' _ _)).trans <|
+        mul_le_mul (ω.superadd ha hb hc hab hbc) (ω'.superadd ha hb hc hab hbc) (by positivity)
+        (by positivity)
+    intro a₁ a₂ b₁ b₂
+    ring_nf
+    simpa [← add_assoc] using
+      le_add_of_nonneg_right (add_nonneg
+        (mul_nonneg (zero_le a₁) (zero_le b₂))
+        (mul_nonneg (zero_le a₂) (zero_le b₁))
+      )
+  zero_diag := by simp [mul_eq_zero_of_left, ω.zero_diag]
+  continuous := ContinuousOn.mul ω.continuous ω'.continuous
+
+/-- The Hölder combination `ω^p · ω'^q` (with `p + q = 1`) of two `ControlOn`s is a `ControlOn`.
+The superadditivity follows from the two-term Hölder inequality. -/
+noncomputable def mul_rpow_base {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) (hpq : p + q = 1) :
+    ControlOn α s where
+  toFun a b := (ω a b) ^ p * (ω' a b) ^ q
+  superadd a ha b hb c hc hab hbc := by
+    rcases eq_or_lt_of_le hp, eq_or_lt_of_le hq with ⟨rfl | hp, rfl | hq⟩
+    · simp_all
+    · simp_all only [NNReal.rpow_zero, one_mul, NNReal.rpow_one, zero_add]
+      exact ω'.superadd ha hb hc hab hbc
+    · simp_all only [NNReal.rpow_zero, mul_one, NNReal.rpow_one, add_zero]
+      exact ω.superadd ha hb hc hab hbc
+    · suffices h2 : ∀ a b c d : ℝ≥0, ∀ ⦃u : ℝ⦄, 0 < u → ∀ ⦃v : ℝ⦄, 0 < v → u + v = 1 →
+          a ^ u * b ^ v + c ^ u * d ^ v ≤ (a + c) ^ u * (b + d) ^ v by
+        exact (h2 (ω a b) (ω' a b) (ω b c) (ω' b c) hp hq hpq).trans <| mul_le_mul
+          (NNReal.monotone_rpow_of_nonneg hp.le <| ω.superadd ha hb hc hab hbc)
+          (NNReal.monotone_rpow_of_nonneg hq.le <| ω'.superadd ha hb hc hab hbc)
+          (by positivity) (by positivity)
+      intro a b c d u hu v hv huv
+      simpa [Fin.sum_succ, ← NNReal.rpow_mul, mul_inv_cancel₀ hu.ne', mul_inv_cancel₀ hv.ne']
+        using NNReal.inner_le_Lp_mul_Lq ⊤ ![a ^ u, c ^ u] ![b ^ v, d ^ v]
+          (Real.HolderConjugate.inv_inv hu hv huv)
+  zero_diag := by
+    rcases eq_or_lt_of_le hp, eq_or_lt_of_le hq with ⟨rfl | hp, rfl | hq⟩
+      <;> try { simp [ω.zero_diag, ω'.zero_diag]; simp_all}
+    simp [hp.ne.symm, ω.zero_diag]
+  continuous := ContinuousOn.mul
+    (Continuous.comp_continuousOn (NNReal.continuous_rpow_const hp) ω.continuous)
+    (Continuous.comp_continuousOn (NNReal.continuous_rpow_const hq) ω'.continuous)
+
+/-- The Hölder combination `(ω^(p/(p+q)) · ω'^(q/(p+q)))^(p+q)` of two `ControlOn`s is a
+`ControlOn` for `1 ≤ p + q`. -/
+noncomputable def mul_rpow {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) (hpq : 1 ≤ p + q) : ControlOn α s :=
+  (mul_rpow_base (ω := ω) (ω' := ω') (p := p / (p + q)) (q := q / (p + q))
+    (by positivity) (by positivity) (by field_simp)).rpow (θ := p + q) hpq
+
+/-- For a function `f : α → ℝ` that is monotone and continuous on `s`, the oscillation
+`(f t - f s)₊` is a `ControlOn`. -/
+def sub_of_monotone {f : α → ℝ} (hf : MonotoneOn f s) (hc : ContinuousOn f s) : ControlOn α s where
+  toFun a b := (f b - f a).toNNReal
+  superadd _ ha _ hb _ hc hab hbc := by
+    rw [← Real.toNNReal_add (sub_nonneg.mpr (hf _ _ hab)) (sub_nonneg.mpr (hf _ _ hbc))]
+    · simp
+    all_goals simp [ha, hb, hc]
+  zero_diag := by simp
+  continuous := by
+    refine continuous_real_toNNReal.comp_continuousOn (.sub ?_ ?_)
+    · exact hc.comp (by fun_prop) fun x ⟨hx, _⟩ => (Set.mem_prod.mp hx).2
+    · exact hc.comp (by fun_prop) fun x ⟨hx, _⟩ => (Set.mem_prod.mp hx).1
+
+end ControlOn
+

--- a/Mathlib/Analysis/Controls/Defs.lean
+++ b/Mathlib/Analysis/Controls/Defs.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Nikolas Tapia. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolas Tapia
+-/
+module
+public import Mathlib.Analysis.Convex.SpecificFunctions.Basic
+public import Mathlib.Analysis.MeanInequalities
+public import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+
+/-!
+# Control functions
+
+A **control function** (or modulus of continuity) on a partially ordered topological space `α`
+is a function `ω : α → α → ℝ≥0` that vanishes on the diagonal and is superadditive:
+`ω s u + ω u t ≤ ω s t` for `s ≤ u ≤ t`, with continuity on the upper triangle
+`{(s, t) | s ≤ t}`. Control functions arise naturally in the theory of rough paths as a way to
+measure the regularity of paths and their iterated integrals.
+
+## Main definitions
+
+- `Control`: the structure bundling a superadditive continuous function vanishing on the diagonal.
+- `Control.map_convex_mono`: composing a control with a convex, monotone, continuous function
+  preserving zero yields a new control.
+- `Control.rpow`: the `θ`-th power of a control is a control for `1 ≤ θ`.
+- `Control.mul`: the pointwise product of two controls is a control.
+- `Control.mul_rpow`: the Hölder combination `(ω^(p/(p+q)) · ω'^(q/(p+q)))^(p+q)` of two
+  controls is a control for `1 ≤ p + q`.
+- `Control.sub_of_monotone`: the oscillation `(f t - f s)₊` of a monotone function is a control.
+
+## Main statements
+
+- `Control.monotone_right`, `Control.antitone_left`: monotonicity properties
+  (see [friz-victoir2010], Lemma 1.7).
+- `Control.exists_middle`: for any interval `[a, c]` there exists a midpoint `b` such that
+  `ω a b ⊔ ω b c ≤ ω a c / 2` (intermediate value argument).
+- `cex_max`: the pointwise maximum of two controls need not be a control.
+
+## References
+
+* [P. Friz and N. Victoir, *Multidimensional Stochastic Processes as Rough Paths*][friz-victoir2010]
+  (Section 1.2)
+
+## Tags
+
+control function, modulus of continuity, rough paths, superadditive
+-/
+
+@[expose] public section
+
+open scoped NNReal
+
+structure Control (α) [PartialOrder α] [TopologicalSpace α] where
+  /-- The underlying two-variable function. -/
+  toFun : α → α → ℝ≥0
+  /-- Superadditivity: `ω a b + ω b c ≤ ω a c` for `a ≤ b ≤ c`. -/
+  superadd {a b c} : a ≤ b → b ≤ c → toFun a b + toFun b c ≤ toFun a c
+  /-- The diagonal vanishes: `ω a a = 0`. -/
+  zero_diag {a} : toFun a a = 0
+  /-- Continuity of `ω` on the upper triangle `{(s, t) | s ≤ t}`. -/
+  continuous : ContinuousOn (fun p : α × α => toFun p.1 p.2) {p | p.1 ≤ p.2}
+
+namespace Control
+
+variable {α} [PartialOrder α] [TopologicalSpace α]
+
+instance instCoeFun : CoeFun (Control α) (fun _ => α → α → ℝ≥0) := ⟨toFun⟩
+
+instance : SMul ℝ≥0 (Control α) where
+  smul r ω := by
+    refine ⟨fun s t => r * ω s t, ?_, ?_, ?_⟩
+    · intro _ _ _ hab hbc
+      simpa [← mul_add] using mul_le_mul_of_nonneg_left (ω.superadd hab hbc) (zero_le r)
+    · simp [ω.zero_diag]
+    · exact ω.continuous.const_mul r
+
+instance : Add (Control α) where
+  add ω ω' := by
+    refine ⟨fun s t => ω s t + ω' s t, ?_, ?_, ?_⟩
+    · intro _ _ _ hab hbc
+      simpa [add_comm, ← add_assoc] using
+        add_le_add (ω.superadd hab hbc) (ω'.superadd hab hbc)
+    · simp [ω.zero_diag, ω'.zero_diag]
+    · exact ω.continuous.add ω'.continuous
+
+variable {a b c : α} {ω ω' : Control α}
+
+/-- A control is monotone in the second variable. -/
+theorem monotone_right : MonotoneOn (fun x => ω a x) {x | a ≤ x} := by
+  intro b hb c hc hbc
+  exact (le_add_of_nonneg_right <| zero_le (ω b c)).trans <| ω.superadd hb hbc
+
+/-- Monotonicity in the second variable for explicit inequalities `a ≤ b ≤ c`. -/
+lemma mono_right_of_le_le (hab : a ≤ b) (hbc : b ≤ c) : ω a b ≤ ω a c :=
+  monotone_right hab (hab.trans hbc) hbc
+
+/-- A control is antitone in the first variable. -/
+theorem antitone_left : AntitoneOn (fun x => ω x c) {x | x ≤ c} := by
+  intro a ha b hb hab
+  exact (le_add_of_nonneg_left (zero_le _)).trans <| ω.superadd hab hb
+
+/-- Antitononicity in the first variable for explicit inequalities `a ≤ b ≤ c`. -/
+lemma anti_left_of_le_le (hab : a ≤ b) (hbc : b ≤ c) : ω b c ≤ ω a c :=
+  antitone_left (hab.trans hbc) hbc hab
+
+/-- The right-variable function `ω a ·` is continuous on `{x | a ≤ x}`. -/
+theorem continuous_right : ContinuousOn (fun x => ω a x) {x | a ≤ x} :=
+  ω.continuous.comp (continuousOn_const.prodMk continuousOn_id) fun _ hx => hx
+
+/-- The left-variable function `ω · b` is continuous on `{x | x ≤ b}`. -/
+theorem continuous_left : ContinuousOn (fun a => ω a b) {x | x ≤ b} :=
+  ω.continuous.comp (continuousOn_id.prodMk continuousOn_const) fun _ hx => hx
+
+/-- Composing a control with a convex, monotone, continuous function that preserves zero yields a
+new control. -/
+def map_convex_mono {φ : ℝ≥0 → ℝ≥0} (hz : φ 0 = 0) (hφ : ConvexOn ℝ≥0 ⊤ φ)
+    (hφ_mono : Monotone φ) (hφ_cont : Continuous φ) : Control α where
+  toFun a b := φ (ω a b)
+  superadd {a b c} hab hbc := (superadd_of_convexOn_zero (u := ⊤) hz hφ (Set.mem_univ _)
+    (Set.mem_univ _) (by positivity) (by positivity)).trans (hφ_mono <| ω.superadd hab hbc)
+  zero_diag := by simp [ω.zero_diag, hz]
+  continuous := hφ_cont.comp_continuousOn ω.continuous
+
+/-- Transfer `ConvexOn ℝ` on `[0, ∞)` to `ConvexOn ℝ≥0` on `Set.univ` via coercion. -/
+theorem nnreal_of_real {f : ℝ≥0 → ℝ≥0}
+    (hf : ConvexOn ℝ (Set.Ici 0) fun x : ℝ => (f x.toNNReal : ℝ)) : ConvexOn ℝ≥0 ⊤ f where
+  left := convex_univ
+  right := by
+    intro x hx y hy a b ha hb hab
+    simpa [← NNReal.coe_mul, ← NNReal.coe_add] using
+      hf.2 x.coe_nonneg y.coe_nonneg a.coe_nonneg b.coe_nonneg (by exact_mod_cast hab)
+
+/-- The `θ`-th power of a control is a control for `1 ≤ θ`. -/
+noncomputable def rpow {θ : ℝ} (hθ : 1 ≤ θ) : Control α :=
+  map_convex_mono (ω := ω) (φ := (· ^ θ))
+    (NNReal.zero_rpow (by positivity))
+    (nnreal_of_real <|
+      (convexOn_rpow hθ).congr fun x hx => by simp [NNReal.coe_rpow, Real.coe_toNNReal x hx])
+    (NNReal.monotone_rpow_of_nonneg (by positivity))
+    (NNReal.continuous_rpow_const (by positivity))
+
+
+/-- The pointwise product of two controls is a control. -/
+def mul : Control α where
+  toFun a b := ω a b * ω' a b
+  superadd hab hbc := by
+    suffices ineq : ∀ a₁ a₂ b₁ b₂ : ℝ≥0, a₁ * a₂ + b₁ * b₂ ≤ (a₁ + b₁) * (a₂ + b₂) by
+      exact (ineq (ω _ _) (ω' _ _) (ω _ _) (ω' _ _)).trans <|
+        mul_le_mul (ω.superadd hab hbc) (ω'.superadd hab hbc) (by positivity)
+        (by positivity)
+    intro a₁ a₂ b₁ b₂
+    ring_nf
+    simpa [← add_assoc] using
+      le_add_of_nonneg_right (add_nonneg
+        (mul_nonneg (zero_le a₁) (zero_le b₂))
+        (mul_nonneg (zero_le a₂) (zero_le b₁))
+      )
+  zero_diag := by simp [mul_eq_zero_of_left, ω.zero_diag]
+  continuous := ContinuousOn.mul ω.continuous ω'.continuous
+
+/-- The Hölder combination `ω^p · ω'^q` (with `p + q = 1`) of two controls is a control.
+The superadditivity follows from the two-term Hölder inequality. -/
+noncomputable def mul_rpow_base {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) (hpq : p + q = 1) :
+    Control α where
+  toFun a b := (ω a b) ^ p * (ω' a b) ^ q
+  superadd {a b c} hab hbc := by
+    rcases eq_or_lt_of_le hp, eq_or_lt_of_le hq with ⟨rfl | hp, rfl | hq⟩
+    · simp_all
+    · simp_all only [NNReal.rpow_zero, one_mul, NNReal.rpow_one, zero_add]
+      exact ω'.superadd hab hbc
+    · simp_all only [NNReal.rpow_zero, mul_one, NNReal.rpow_one, add_zero]
+      exact ω.superadd hab hbc
+    · suffices h2 : ∀ a b c d : ℝ≥0, ∀ ⦃u : ℝ⦄, 0 < u → ∀ ⦃v : ℝ⦄, 0 < v → u + v = 1 →
+          a ^ u * b ^ v + c ^ u * d ^ v ≤ (a + c) ^ u * (b + d) ^ v by
+        exact (h2 (ω a b) (ω' a b) (ω b c) (ω' b c) hp hq hpq).trans <| mul_le_mul
+          (NNReal.monotone_rpow_of_nonneg hp.le <| ω.superadd hab hbc)
+          (NNReal.monotone_rpow_of_nonneg hq.le <| ω'.superadd hab hbc)
+          (by positivity) (by positivity)
+      intro a b c d u hu v hv huv
+      simpa [Fin.sum_succ, ← NNReal.rpow_mul, mul_inv_cancel₀ hu.ne', mul_inv_cancel₀ hv.ne']
+        using NNReal.inner_le_Lp_mul_Lq ⊤ ![a ^ u, c ^ u] ![b ^ v, d ^ v]
+          (Real.HolderConjugate.inv_inv hu hv huv)
+  zero_diag := by
+    rcases eq_or_lt_of_le hp, eq_or_lt_of_le hq with ⟨rfl | hp, rfl | hq⟩
+      <;> try { simp [ω.zero_diag, ω'.zero_diag]; simp_all}
+    simp [hp.ne.symm, ω.zero_diag]
+  continuous := ContinuousOn.mul
+    (Continuous.comp_continuousOn (NNReal.continuous_rpow_const hp) ω.continuous)
+    (Continuous.comp_continuousOn (NNReal.continuous_rpow_const hq) ω'.continuous)
+
+/-- The Hölder combination `(ω^(p/(p+q)) · ω'^(q/(p+q)))^(p+q)` of two controls is a control
+for `1 ≤ p + q`. -/
+noncomputable def mul_rpow {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) (hpq : 1 ≤ p + q) : Control α :=
+  (mul_rpow_base (ω := ω) (ω' := ω') (p := p / (p + q)) (q := q / (p + q))
+    (by positivity) (by positivity) (by field_simp)).rpow (θ := p + q) hpq
+
+/-- For a monotone continuous function `f : α → ℝ`, the oscillation `(f t - f s)₊` is a
+control. -/
+def sub_of_monotone {f : α → ℝ} (hf : Monotone f) (hc : Continuous f) : Control α where
+  toFun a b := (f b - f a).toNNReal
+  superadd hab hbc := by
+    rw [← Real.toNNReal_add (sub_nonneg.mpr (hf hab)) (sub_nonneg.mpr (hf hbc))]
+    · simp
+  zero_diag := by simp
+  continuous := (continuous_real_toNNReal.comp <|
+    .sub (hc.comp continuous_snd) (hc.comp continuous_fst)).continuousOn
+
+end Control
+
+/-- The identity control on `ℝ≥0`: `sub_id s t = t - s`. -/
+def sub_id : Control ℝ≥0 := Control.sub_of_monotone monotone_id NNReal.continuous_coe
+
+/-- The pointwise maximum of two controls need not be a control: the sup of `t - s` and
+`(t² - s²)₊` on `[0, 1]` is a counterexample. -/
+theorem cex_max : ∃ ω ω' : Control ℝ≥0, ¬ ∃ ω₀ : Control ℝ≥0,
+    ω₀.toFun = fun a b => (ω a b) ⊔ (ω' a b) := by
+  refine ⟨sub_id, Control.sub_of_monotone (NNReal.monotone_rpow_of_nonneg (z := 2) (by positivity))
+    (NNReal.continuous_coe.comp (NNReal.continuous_rpow_const (by positivity))), ?_⟩
+  intro ⟨ω₀, hω₀⟩
+  have h := ω₀.superadd (a := 0) (b := 1/2) (c := 1) (by positivity) (by simp)
+  simp only [hω₀, sub_id, Control.sub_of_monotone] at h
+  exact absurd (NNReal.coe_le_coe.mpr h)
+    (by push_cast [NNReal.coe_max, Real.coe_toNNReal]; norm_num)
+
+theorem Control.exists_middle {α} [ConditionallyCompleteLinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [DenselyOrdered α] {a c : α} (hac : a < c) {ω : Control α} :
+    ∃ b ∈ Set.Icc a c, ω a b ⊔ ω b c ≤ ω a c / 2 := by
+  suffices h : ∃ b ∈ Set.Icc a c, ω a b = ω b c by
+    obtain ⟨b, h_mem, hω⟩ := h
+    exists b
+    simp only [sup_le_iff, h_mem, hω, true_and, and_self]
+    apply (le_div_iff₀ (c := (2 : ℝ≥0)) (by positivity)).mpr
+    simpa [mul_two] using hω ▸ ω.superadd h_mem.left h_mem.right
+  exact IsPreconnected.intermediate_value₂ isPreconnected_Icc
+    (Set.left_mem_Icc.mpr <| hac.le)
+    (Set.right_mem_Icc.mpr <| hac.le)
+    (ω.continuous_right.mono Set.Icc_subset_Ici_self)
+    (ω.continuous_left.mono Set.Icc_subset_Iic_self)
+    (by simp [ω.zero_diag])
+    (by simp [ω.zero_diag])

--- a/Mathlib/Analysis/Controls/Defs.lean
+++ b/Mathlib/Analysis/Controls/Defs.lean
@@ -50,6 +50,8 @@ control function, modulus of continuity, rough paths, superadditive
 
 open scoped NNReal
 
+/-- A Control on a type `α` is a superadditive function of two variables, continuous on the ordered
+  2-simplex, vanishing on the diagonal -/
 structure Control (α) [PartialOrder α] [TopologicalSpace α] where
   /-- The underlying two-variable function. -/
   toFun : α → α → ℝ≥0

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -955,7 +955,7 @@ end OrderedRing
 
 section LinearOrderedField
 
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommMonoid E]
+variable [Semifield 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommMonoid E]
 
 section OrderedAddCommMonoid
 
@@ -999,6 +999,19 @@ theorem strictConcaveOn_iff_div {f : E → β} :
       Convex 𝕜 s ∧ ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → x ≠ y → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b →
         (a / (a + b)) • f x + (b / (a + b)) • f y < f ((a / (a + b)) • x + (b / (a + b)) • y) :=
   strictConvexOn_iff_div (β := βᵒᵈ)
+
+/-- A convex function `φ : u → u` on a additive submonoid u with `φ 0 = 0` is superadditive. -/
+theorem superadd_of_convexOn_zero {u : AddSubmonoid 𝕜} {f : 𝕜 → 𝕜} (hz : f 0 = 0)
+    (hc : ConvexOn 𝕜 u f) : ∀ ⦃x⦄, x ∈ u → ∀ ⦃y⦄, y ∈ u → 0 ≤ x → 0 ≤ y →
+      f x + f y ≤ f (x + y) := by
+  intro _ hxu _ hyu hx hy
+  rcases hx.eq_or_lt, hy.eq_or_lt with ⟨rfl | hx, rfl | hy⟩ <;> try simp [hz]
+  have hxle := (convexOn_iff_div.mp hc).2 (u.add_mem' hxu hyu) u.zero_mem hx.le hy.le
+    (add_pos hx hy)
+  have hyle := (convexOn_iff_div.mp hc).2 (u.add_mem' hxu hyu) u.zero_mem hy.le hx.le
+    (by simpa [add_comm] using add_pos hx hy)
+  simp [add_comm, div_mul_cancel₀ _ (add_pos hx hy).ne', hz] at hxle hyle
+  simpa [← add_mul, ← add_div, div_self (add_pos hx hy).ne', hz] using add_le_add hxle hyle
 
 end SMul
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -5858,6 +5858,23 @@
   zbl           = {1123.13002}
 }
 
+@Book{            friz-victoir2010,
+  author        = {Friz, Peter K. and Victoir, Nicolas B.},
+  title         = {Multidimensional stochastic processes as rough paths.
+                  {Theory} and applications.},
+  fseries       = {Cambridge Studies in Advanced Mathematics},
+  series        = {Camb. Stud. Adv. Math.},
+  volume        = {120},
+  isbn          = {978-0-521-87607-0},
+  year          = {2010},
+  publisher     = {Cambridge: Cambridge University Press},
+  language      = {English},
+  doi           = {10.1017/CBO9780511845079},
+  keywords      = {60G17,60H10,60H05,46N30,60H07,60F10},
+  zbmath        = {5677244},
+  zbl           = {1193.60053}
+}
+
 @Article{         zbMATH06785026,
   author        = {John F. {Clauser} and Michael A. {Horne} and Abner
                   {Shimony} and Richard A. {Holt}},


### PR DESCRIPTION
Add Control functions
----
This PR adds Control functions in the sense of rough paths theory (see e.g. [Friz-Victoir, Section 1.2.1](https://page.math.tu-berlin.de/~friz/master4_May6th.pdf)).

They are related to p-variation norms which are the goal of #38055.

I've shown most results in the above reference though those relating to 1-variation are still a work in progress.

I had to add a few statements about convex functions in order to work over NNReal instead or Real, but I am not sure this is the best way to do it. The reason is that I've defined controls as taking values in NNReal (as they should).
In particular there is 
```lean4
theorem nnreal_of_real {f : ℝ≥0 → ℝ≥0}
    (hf : ConvexOn ℝ (Set.Ici 0) fun x : ℝ => (f x.toNNReal : ℝ)) : ConvexOn ℝ≥0 ⊤ f 
```
which I didn't know where to put. It probably holds in more generality but I didn't check.

I have also included two versions of Controls, one global and one restricted to a set. I tried to follow Mathlib conventions as best as I could but perhaps that could be improved as well.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
