### PR TITLE
[Merged by Bors] - doc(Computability): fix typo in TM Config description

### DIFF
--- a/Mathlib/Computability/TuringMachine/Config.lean
+++ b/Mathlib/Computability/TuringMachine/Config.lean
@@ -84,7 +84,7 @@ inductive Code
   deriving DecidableEq, Inhabited
 
 /-- The semantics of the `Code` primitives, as partial functions `List ℕ →. List ℕ`. By convention
-we use functions that return a single result return a singleton `[n]`, or in some cases `n :: v`
+functions that return a single result return a singleton `[n]`, or in some cases `n :: v`
 where `v` will be ignored by a subsequent function.
 
 * `zero'` appends a `0` to the input. That is, `zero' v = 0 :: v`.

--- a/Mathlib/Computability/TuringMachine/Config.lean
+++ b/Mathlib/Computability/TuringMachine/Config.lean
@@ -84,7 +84,7 @@ inductive Code
   deriving DecidableEq, Inhabited
 
 /-- The semantics of the `Code` primitives, as partial functions `List ℕ →. List ℕ`. By convention
-we use functions that return a single result return a singleton `[n]`, or in some cases `n :: v` 
+we use functions that return a single result return a singleton `[n]`, or in some cases `n :: v`
 where `v` will be ignored by a subsequent function.
 
 * `zero'` appends a `0` to the input. That is, `zero' v = 0 :: v`.

--- a/Mathlib/Computability/TuringMachine/Config.lean
+++ b/Mathlib/Computability/TuringMachine/Config.lean
@@ -84,8 +84,8 @@ inductive Code
   deriving DecidableEq, Inhabited
 
 /-- The semantics of the `Code` primitives, as partial functions `List ℕ →. List ℕ`. By convention
-we functions that return a single result return a singleton `[n]`, or in some cases `n :: v` where
-`v` will be ignored by a subsequent function.
+we use functions that return a single result return a singleton `[n]`, or in some cases `n :: v` 
+where `v` will be ignored by a subsequent function.
 
 * `zero'` appends a `0` to the input. That is, `zero' v = 0 :: v`.
 * `succ` returns the successor of the head of the input, defaulting to zero if there is no head:

--- a/Mathlib/Computability/TuringMachine/Config.lean
+++ b/Mathlib/Computability/TuringMachine/Config.lean
@@ -83,9 +83,9 @@ inductive Code
   | fix : Code → Code
   deriving DecidableEq, Inhabited
 
-/-- The semantics of the `Code` primitives, as partial functions `List ℕ →. List ℕ`. By convention
-functions that return a single result return a singleton `[n]`, or in some cases `n :: v`
-where `v` will be ignored by a subsequent function.
+/-- The semantics of the `Code` primitives, as partial functions `List ℕ →. List ℕ`.
+By convention, functions that return a single result return a singleton `[n]`,
+or in some cases `n :: v` where `v` will be ignored by a subsequent function.
 
 * `zero'` appends a `0` to the input. That is, `zero' v = 0 :: v`.
 * `succ` returns the successor of the head of the input, defaulting to zero if there is no head:


### PR DESCRIPTION
Corrects minor grammatical error in comments.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
