### PR TITLE
[Merged by Bors] - feat(CategoryTheory/CommSq): use `to_dual`

### DIFF
--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -44,17 +44,29 @@ variable {C : Type*} [Category* C]
 ```
 is a commuting square.
 -/
+@[to_dual self (reorder := W Z, X Y, f i, g h)]
 structure CommSq {W X Y Z : C} (f : W ⟶ X) (g : W ⟶ Y) (h : X ⟶ Z) (i : Y ⟶ Z) : Prop where
   /-- The square commutes. -/
   w : f ≫ h = g ≫ i := by cat_disch
-
-attribute [reassoc] CommSq.w
-attribute [simp] CommSq.mk
 
 namespace CommSq
 
 variable {W X Y Z : C} {f : W ⟶ X} {g : W ⟶ Y} {h : X ⟶ Z} {i : Y ⟶ Z}
 
+set_option linter.translateOverwrite false in
+@[to_dual existing w]
+lemma w' (self : CommSq f g h i) : g ≫ i = f ≫ h := self.w.symm
+
+set_option linter.translateOverwrite false in
+/-- `CommSq.mk'` is the dual of `CommSq.mk`, which we need for `to_dual`.
+Please avoid using this directly. -/
+@[to_dual existing mk]
+abbrev mk' (w : g ≫ i = f ≫ h := by cat_disch) : CommSq f g h i where
+  w := w.symm
+
+attribute [reassoc] CommSq.w
+
+@[to_dual self]
 theorem flip (p : CommSq f g h i) : CommSq g f i h :=
   ⟨p.w.symm⟩
 
@@ -62,18 +74,22 @@ theorem of_arrow {f g : Arrow C} (h : f ⟶ g) : CommSq f.hom h.left h.right g.h
   ⟨h.w.symm⟩
 
 /-- The commutative square in the opposite category associated to a commutative square. -/
+@[to_dual self]
 theorem op (p : CommSq f g h i) : CommSq i.op h.op g.op f.op :=
   ⟨by simp only [← op_comp, p.w]⟩
 
 /-- The commutative square associated to a commutative square in the opposite category. -/
+@[to_dual self]
 theorem unop {W X Y Z : Cᵒᵖ} {f : W ⟶ X} {g : W ⟶ Y} {h : X ⟶ Z} {i : Y ⟶ Z} (p : CommSq f g h i) :
     CommSq i.unop h.unop g.unop f.unop :=
   ⟨by simp only [← unop_comp, p.w]⟩
 
+@[to_dual none]
 theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
     CommSq i g.inv h.inv f :=
   ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp, p.w]⟩
 
+@[to_dual none]
 theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
     CommSq f.inv h g i.inv :=
   flip (vert_inv (flip p))
@@ -89,6 +105,7 @@ theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
 
 ```
 -/
+@[to_dual self (reorder := W Z', X Z, X' Y, f i', f' i, g h', hsq₁ hsq₂)]
 lemma horiz_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
     {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
     CommSq (f ≫ f') g h' (i ≫ i') :=
@@ -110,6 +127,7 @@ lemma horiz_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y}
 
 ```
 -/
+@[to_dual self (reorder := W Z', Y Z, Y' X, g h', g' h, f i', hsq₁ hsq₂)]
 lemma vert_comp {W X Y Y' Z Z' : C} {f : W ⟶ X} {g : W ⟶ Y} {g' : Y ⟶ Y'} {h : X ⟶ Z}
     {h' : Z ⟶ Z'} {i : Y ⟶ Z} {i' : Y' ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq i g' h' i') :
     CommSq f (g ≫ g') (h ≫ h') i' :=
@@ -120,9 +138,11 @@ section
 
 variable {W X Y : C}
 
+@[to_dual none]
 theorem eq_of_mono {f : W ⟶ X} {g : W ⟶ X} {i : X ⟶ Y} [Mono i] (sq : CommSq f g i i) : f = g :=
   (cancel_mono i).1 sq.w
 
+@[to_dual none]
 theorem eq_of_epi {f : W ⟶ X} {h : X ⟶ Y} {i : X ⟶ Y} [Epi f] (sq : CommSq f f h i) : h = i :=
   (cancel_epi f).1 sq.w
 
@@ -135,11 +155,13 @@ namespace Functor
 variable {D : Type*} [Category* D]
 variable (F : C ⥤ D) {W X Y Z : C} {f : W ⟶ X} {g : W ⟶ Y} {h : X ⟶ Z} {i : Y ⟶ Z}
 
+@[to_dual self]
 theorem map_commSq (s : CommSq f g h i) : CommSq (F.map f) (F.map g) (F.map h) (F.map i) :=
   ⟨by simpa using congr_arg (fun k : W ⟶ Z => F.map k) s.w⟩
 
 end Functor
 
+@[to_dual self]
 alias CommSq.map := Functor.map_commSq
 
 namespace CommSq
@@ -159,7 +181,7 @@ variable {A B X Y : C} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g : B ⟶ Y}
 
 The datum of a lift in a commutative square, i.e. an up-right-diagonal
 morphism which makes both triangles commute. -/
-@[ext]
+@[ext, to_dual self]
 structure LiftStruct (sq : CommSq f i p g) where
   /-- The lift. -/
   l : B ⟶ X
@@ -168,11 +190,16 @@ structure LiftStruct (sq : CommSq f i p g) where
   /-- The lower right triangle commutes. -/
   fac_right : l ≫ p = g := by cat_disch
 
+attribute [to_dual self] LiftStruct.ext
+set_option linter.translateOverwrite false in
+attribute [to_dual existing fac_left] LiftStruct.fac_right
+attribute [to_dual self (reorder := A Y, B X, f g, i p, fac_left fac_right)] LiftStruct.mk
+
 namespace LiftStruct
 
 /-- A `LiftStruct` for a commutative square gives a `LiftStruct` for the
 corresponding square in the opposite category. -/
-@[simps]
+@[simps, to_dual self]
 def op {sq : CommSq f i p g} (l : LiftStruct sq) : LiftStruct sq.op where
   l := l.l.op
   fac_left := by rw [← op_comp, l.fac_right]
@@ -180,7 +207,7 @@ def op {sq : CommSq f i p g} (l : LiftStruct sq) : LiftStruct sq.op where
 
 /-- A `LiftStruct` for a commutative square in the opposite category
 gives a `LiftStruct` for the corresponding square in the original category. -/
-@[simps]
+@[simps, to_dual self]
 def unop {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g : B ⟶ Y} {sq : CommSq f i p g}
     (l : LiftStruct sq) : LiftStruct sq.unop where
   l := l.l.unop
@@ -189,7 +216,7 @@ def unop {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g : B �
 
 /-- Equivalences of `LiftStruct` for a square and the corresponding square
 in the opposite category. -/
-@[simps]
+@[simps, to_dual self]
 def opEquiv (sq : CommSq f i p g) : LiftStruct sq ≃ LiftStruct sq.op where
   toFun := op
   invFun := unop
@@ -198,6 +225,7 @@ def opEquiv (sq : CommSq f i p g) : LiftStruct sq ≃ LiftStruct sq.op where
 
 /-- Equivalences of `LiftStruct` for a square in the opposite category and
 the corresponding square in the original category. -/
+@[simps, to_dual self]
 def unopEquiv {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g : B ⟶ Y}
     (sq : CommSq f i p g) : LiftStruct sq ≃ LiftStruct sq.unop where
   toFun := unop
@@ -207,6 +235,7 @@ def unopEquiv {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g :
 
 end LiftStruct
 
+@[to_dual]
 instance subsingleton_liftStruct_of_epi (sq : CommSq f i p g) [Epi i] :
     Subsingleton (LiftStruct sq) :=
   ⟨fun l₁ l₂ => by
@@ -214,16 +243,10 @@ instance subsingleton_liftStruct_of_epi (sq : CommSq f i p g) [Epi i] :
     rw [← cancel_epi i]
     simp only [LiftStruct.fac_left]⟩
 
-instance subsingleton_liftStruct_of_mono (sq : CommSq f i p g) [Mono p] :
-    Subsingleton (LiftStruct sq) :=
-  ⟨fun l₁ l₂ => by
-    ext
-    rw [← cancel_mono p]
-    simp only [LiftStruct.fac_right]⟩
-
 variable (sq : CommSq f i p g)
 
 /-- The assertion that a square has a `LiftStruct`. -/
+@[to_dual self]
 class HasLift : Prop where
   /-- Square has a `LiftStruct`. -/
   exists_lift : Nonempty sq.LiftStruct
@@ -231,17 +254,21 @@ class HasLift : Prop where
 namespace HasLift
 
 variable {sq} in
+@[to_dual self]
 theorem mk' (l : sq.LiftStruct) : HasLift sq :=
   ⟨Nonempty.intro l⟩
 
+@[to_dual self]
 theorem iff : HasLift sq ↔ Nonempty sq.LiftStruct := by
   constructor
   exacts [fun h => h.exists_lift, fun h => mk h]
 
+@[to_dual self]
 theorem iff_op : HasLift sq ↔ HasLift sq.op := by
   rw [iff, iff]
   exact Nonempty.congr (LiftStruct.opEquiv sq).toFun (LiftStruct.opEquiv sq).invFun
 
+@[to_dual self]
 theorem iff_unop {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g : B ⟶ Y}
     (sq : CommSq f i p g) : HasLift sq ↔ HasLift sq.unop := by
   rw [iff, iff]
@@ -251,16 +278,13 @@ end HasLift
 
 /-- A choice of a diagonal morphism that is part of a `LiftStruct` when
 the square has a lift. -/
+@[to_dual self]
 noncomputable def lift [hsq : HasLift sq] : B ⟶ X :=
   hsq.exists_lift.some.l
 
-@[reassoc (attr := simp)]
+@[to_dual (attr := reassoc (attr := simp)) fac_right]
 theorem fac_left [hsq : HasLift sq] : i ≫ sq.lift = f :=
   hsq.exists_lift.some.fac_left
-
-@[reassoc (attr := simp)]
-theorem fac_right [hsq : HasLift sq] : sq.lift ≫ p = g :=
-  hsq.exists_lift.some.fac_right
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -49,6 +49,8 @@ structure CommSq {W X Y Z : C} (f : W ⟶ X) (g : W ⟶ Y) (h : X ⟶ Z) (i : Y 
   /-- The square commutes. -/
   w : f ≫ h = g ≫ i := by cat_disch
 
+attribute [simp] CommSq.mk
+
 namespace CommSq
 
 variable {W X Y Z : C} {f : W ⟶ X} {g : W ⟶ Y} {h : X ⟶ Z} {i : Y ⟶ Z}

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -63,8 +63,8 @@ set_option linter.translateOverwrite false in
 /-- `CommSq.mk'` is the dual of `CommSq.mk`, which we need for `to_dual`.
 Please avoid using this directly. -/
 @[to_dual existing mk]
-abbrev mk' (w : g ≫ i = f ≫ h := by cat_disch) : CommSq f g h i where
-  w := w.symm
+lemma mk' (w : g ≫ i = f ≫ h := by cat_disch) : CommSq f g h i :=
+  ⟨w.symm⟩
 
 attribute [reassoc] CommSq.w
 


### PR DESCRIPTION
This PR uses `to_dual` on `CommSq`. There are two possible ways to dualize `CommSq`, due to its inherent symmetry. I picked to option that is consistent with `CommSq.op` and which allows dualizing `LiftStruct` to itself.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
