### PR TITLE
[Merged by Bors] - doc(RingTheory/MvPowerSeries): fix typos in module docstrings

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/GaussNorm.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/GaussNorm.lean
@@ -17,14 +17,14 @@ the set of all values of `v (coeff t f) * ∏ i : t.support, c i` for all `t : �
 
 ## Main definitions and results
 
-* `MvPowerSeries.gaussNormC` is the supremum of the set of all values of
+* `MvPowerSeries.gaussNorm` is the supremum of the set of all values of
   `v (coeff t f) * ∏ i : t.support, c i` for all `t : σ →₀ ℕ`, where `f` is a multivariate power
   series, `v : R → ℝ` is a function and `c` is a tuple of real numbers.
 
-* `MvPowerSeries.gaussNormC_nonneg`: if `v` is a non-negative function, then the Gauss norm is
+* `MvPowerSeries.gaussNorm_nonneg`: if `v` is a non-negative function, then the Gauss norm is
   non-negative.
 
-* `MvPowerSeries.gaussNormC_eq_zero_iff`: if `v` is a non-negative function and `v x = 0 ↔ x = 0`
+* `MvPowerSeries.gaussNorm_eq_zero_iff`: if `v` is a non-negative function and `v x = 0 ↔ x = 0`
   for all `x : R` and `c` is positive, then the Gauss norm is zero if and only if the power series
   is zero.
 
@@ -46,7 +46,7 @@ noncomputable def gaussNorm : ℝ :=
    ⨆ t : σ →₀ ℕ, v (coeff t f) * t.prod (c · ^ ·)
 
 /-- We say `f` HasGaussNorm if the values `v (coeff t f) * ∏ i : t.support, c i` is bounded above,
-  that is `gaussNormC f` is finite. -/
+  that is `gaussNorm f` is finite. -/
 abbrev HasGaussNorm := BddAbove (Set.range (fun (t : σ →₀ ℕ) ↦ (v (coeff t f) * t.prod (c · ^ ·))))
 
 @[simp]

--- a/Mathlib/RingTheory/MvPowerSeries/LexOrder.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/LexOrder.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.Finsupp.WellFounded
 
 /-! LexOrder of multivariate power series
 
-Given an ordering of `σ` such that `WellOrderGT σ`,
+Given an ordering of `σ` such that `WellFoundedGT σ`,
 the lexicographic order on `σ →₀ ℕ` is a well ordering,
 which can be used to define a natural valuation `lexOrder` on the ring `MvPowerSeries σ R`:
 the smallest exponent in the support.


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
