### PR TITLE
feat: add informal attribute

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6992,6 +6992,7 @@ public import Mathlib.Tactic.Conv
 public import Mathlib.Tactic.Convert
 public import Mathlib.Tactic.Core
 public import Mathlib.Tactic.DSimpPercent
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Tactic.DeclarationNames
 public import Mathlib.Tactic.DefEqAbuse
 public import Mathlib.Tactic.DefEqTransformations
@@ -7206,7 +7207,6 @@ public import Mathlib.Tactic.Simps.Basic
 public import Mathlib.Tactic.Simps.NotationClass
 public import Mathlib.Tactic.SplitIfs
 public import Mathlib.Tactic.Spread
-public import Mathlib.Tactic.StacksAttribute
 public import Mathlib.Tactic.Subsingleton
 public import Mathlib.Tactic.Substs
 public import Mathlib.Tactic.SuccessIfFailWithMsg

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.GroupWithZero.Defs
 public import Mathlib.Data.Int.Cast.Defs
 public import Mathlib.Tactic.Spread
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 
 /-!
 # Semirings and rings

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.CategoryTheory.Category.Init
 public import Mathlib.Combinatorics.Quiver.Basic
 public import Mathlib.Tactic.PPWithUniv
 public import Mathlib.Tactic.Common
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Tactic.TryThis
 
 /-!

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Normed.Module.Convex
 public import Mathlib.Analysis.RCLike.TangentCone
 public import Mathlib.Data.Bundle
 public import Mathlib.Geometry.Manifold.HasGroupoid
+import Mathlib.Tactic.DatabaseAttributes
 
 /-!
 # `C^n` manifolds (possibly with boundary or corners)
@@ -782,6 +783,7 @@ field `𝕜`. This definition includes the model with corners `I` (which might a
 or not, so this class covers both manifolds with boundary and manifolds without boundary), and
 a smoothness parameter `n : WithTop ℕ∞` (where `n = 0` means topological manifold, `n = ∞` means
 smooth manifold and `n = ω` means analytic manifold). -/
+@[informal "smooth manifold"]
 class IsManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
     (I : ModelWithCorners 𝕜 E H) (n : WithTop ℕ∞) (M : Type*)
@@ -927,6 +929,7 @@ example [Unique E] : IsManifold (𝓘(𝕜, E)) n (Fin 2) := of_discreteTopology
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The product of two `C^n` manifolds is naturally a `C^n` manifold. -/
+@[informal "product of manifolds"]
 instance prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
     [NormedSpace 𝕜 E] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H : Type*}
     [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H} {H' : Type*} [TopologicalSpace H']

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -74,6 +74,7 @@ public import Mathlib.Tactic.Conv
 public import Mathlib.Tactic.Convert
 public import Mathlib.Tactic.Core
 public import Mathlib.Tactic.DSimpPercent
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Tactic.DeclarationNames
 public import Mathlib.Tactic.DefEqAbuse
 public import Mathlib.Tactic.DefEqTransformations
@@ -288,7 +289,6 @@ public import Mathlib.Tactic.Simps.Basic
 public import Mathlib.Tactic.Simps.NotationClass
 public import Mathlib.Tactic.SplitIfs
 public import Mathlib.Tactic.Spread
-public import Mathlib.Tactic.StacksAttribute
 public import Mathlib.Tactic.Subsingleton
 public import Mathlib.Tactic.Substs
 public import Mathlib.Tactic.SuccessIfFailWithMsg

--- a/Mathlib/Tactic/DatabaseAttributes.lean
+++ b/Mathlib/Tactic/DatabaseAttributes.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Damiano Testa
+Authors: Damiano Testa, Michael Rothgang
 -/
 module
 
@@ -9,13 +9,16 @@ public meta import Lean.Elab.Command
 public import Mathlib.Init
 
 /-!
-# The `stacks` and `kerodon` attributes
+# The `stacks`, `kerodon` and `informal` attributes
 
-This allows tagging of mathlib results with the corresponding
-tags from the [Stacks Project](https://stacks.math.columbia.edu/tags) and
+This allows tagging of mathlib results with a natural language concept name,
+or the corresponding tags from the [Stacks Project](https://stacks.math.columbia.edu/tags) and
 [Kerodon](https://kerodon.net/tag/).
 
-While the Stacks Project is the main focus, because the tag format at Kerodon is
+The `informal` attribute allows annotating a declaration as corresponding to a natural language
+mathematics concept (such as "linear map", "smooth manifold" or "Faltings' theorem").
+
+While the Stacks Project is the main focus over Kerodon, because the tag format at Kerodon is
 compatible, the attribute can be used to tag results with Kerodon tags as well.
 -/
 
@@ -23,12 +26,13 @@ public meta section
 
 open Lean Elab
 
-namespace Mathlib.StacksTag
+namespace Mathlib.DatabaseTag
 
 /-- Web database users of projects tags -/
 inductive Database where
   | kerodon
   | stacks
+  | informal
   deriving BEq, Hashable
 
 /-- `Tag` is the structure that carries the data of a project tag and a corresponding
@@ -54,7 +58,7 @@ initialize tagExt : SimplePersistentEnvExtension Tag (Array (Array Tag)) ←
 
 /--
 `addTagEntry declName db tag comment` takes as input the `Name` `declName` of a declaration,
-whether it is a Kerodon or Stacks tag (`db`) and
+whether it is a Kerodon, Stacks tag or natural language concept (`db`),
 the `String`s `tag` and `comment` of the `stacks` or `kerodon` attribute.
 It extends the `Tag` environment extension with the data `declName, db, tag, comment`.
 -/
@@ -98,9 +102,9 @@ def stacksTagNoAntiquot : Parser := {
 def stacksTagParser : Parser :=
   withAntiquot (mkAntiquot "stacksTag" stacksTagKind) stacksTagNoAntiquot
 
-end Mathlib.StacksTag
+end Mathlib.DatabaseTag
 
-open Mathlib.StacksTag
+open Mathlib.DatabaseTag
 
 /-- Extract the underlying tag as a string from a `stacksTag` node. -/
 def Lean.TSyntax.getStacksTag (stx : TSyntax stacksTagKind) : CoreM String := do
@@ -124,7 +128,7 @@ namespace Parenthesizer
 
 end Lean.PrettyPrinter.Parenthesizer
 
-namespace Mathlib.StacksTag
+namespace Mathlib.DatabaseTag
 
 /-- The syntax category for the database name. -/
 declare_syntax_cat stacksTagDB
@@ -133,6 +137,26 @@ declare_syntax_cat stacksTagDB
 syntax "kerodon" : stacksTagDB
 /-- The syntax for a "stacks" database identifier in a `@[stacks]` attribute. -/
 syntax "stacks" : stacksTagDB
+
+/-- The `informalMathTag` attribute. Use it as `@[informal "concept" "Optional comment"]` -/
+syntax (name := informalMathTag) "informal" ppSpace str (ppSpace str)? : attr
+
+-- TODO: can we this with the parser below?
+/-- The `informal` attribute: use it as `@[informal "concept" "Optional comment"]`
+to annotate a declaration corresponding to an informal concept (or result).
+At the moment, no formatting restrictions on "concept" are imposed.
+-/
+initialize Lean.registerBuiltinAttribute {
+  name := `informalMathTag
+  descr := "Tag a declaration as corresponding to an informal math concept or result."
+  add := fun decl stx _attrKind => do
+    let (tag, comment) ← match stx with
+    | `(attr| informal $tag $[$comment]?) => pure (tag, comment)
+    | _ => throwUnsupportedSyntax
+    addTagEntry decl Database.informal tag.getString ((comment.map (·.getString)).getD "")
+  -- docstrings are immutable once an asynchronous elaboration task has been started
+  applicationTime := .beforeElaboration
+}
 
 /-- The `stacksTag` attribute.
 Use it as `@[kerodon TAG "Optional comment"]` or `@[stacks TAG "Optional comment"]`
@@ -150,13 +174,12 @@ initialize Lean.registerBuiltinAttribute {
   descr := "Apply a Stacks or Kerodon project tag to a theorem."
   add := fun decl stx _attrKind => do
     let oldDoc := (← findDocString? (← getEnv) decl).getD ""
-    let (SorK, database, url, tag, comment) := ← match stx with
+    let (SorK, database, url, tagStr, comment) := ← match stx with
       | `(attr| stacks $tag $[$comment]?) =>
-        return ("Stacks", Database.stacks, "https://stacks.math.columbia.edu/tag", tag, comment)
+        return ("Stacks", Database.stacks, "https://stacks.math.columbia.edu/tag", ← tag.getStacksTag, comment)
       | `(attr| kerodon $tag $[$comment]?) =>
-        return ("Kerodon", Database.kerodon, "https://kerodon.net/tag", tag, comment)
+        return ("Kerodon", Database.kerodon, "https://kerodon.net/tag", ← tag.getStacksTag, comment)
       | _ => throwUnsupportedSyntax
-    let tagStr ← tag.getStacksTag
     let comment := (comment.map (·.getString)).getD ""
     let commentInDoc := if comment = "" then "" else s!" ({comment})"
     let newDoc := [oldDoc, s!"[{SorK} Tag {tagStr}]({url}/{tagStr}){commentInDoc}"]
@@ -166,7 +189,7 @@ initialize Lean.registerBuiltinAttribute {
   applicationTime := .beforeElaboration
 }
 
-end Mathlib.StacksTag
+end Mathlib.DatabaseTag
 
 /--
 `getSortedStackProjectTags env` returns the array of `Tags`, sorted by alphabetical order of tag.
@@ -184,18 +207,19 @@ private def Lean.Environment.getSortedStackProjectDeclNames (env : Environment) 
   let tags := env.getSortedStackProjectTags
   tags.filterMap fun d => if d.tag == tag then some d.declName else none
 
-namespace Mathlib.StacksTag
+namespace Mathlib.DatabaseTag
 
 private def databaseURL (db : Database) : String :=
   match db with
   | .kerodon => "https://kerodon.net/tag/"
   | .stacks => "https://stacks.math.columbia.edu/tag/"
+  | .informal => ""
 
 /--
-`traceStacksTags db verbose` prints the tags of the database `db` to the user and
+`traceDatabaseTags db verbose` prints the tags of the database `db` to the user and
 inlines the theorem statements if `verbose` is `true`.
 -/
-def traceStacksTags (db : Database) (verbose : Bool := false) :
+def traceDatabaseTags (db : Database) (verbose : Bool := false) :
     Command.CommandElabM Unit := do
   let env ← getEnv
   let entries := env.getSortedStackProjectTags |>.filter (·.database == db)
@@ -204,9 +228,9 @@ def traceStacksTags (db : Database) (verbose : Bool := false) :
   for d in entries do
     let (parL, parR) := if d.comment.isEmpty then ("", "") else (" (", ")")
     let cmt := parL ++ d.comment ++ parR
-    msgs := msgs.push
-      m!"[Stacks Tag {d.tag}]({databaseURL db ++ d.tag}) \
-        corresponds to declaration '{.ofConstName d.declName}'.{cmt}"
+    let start := if db == Database.informal then m!"informal concept \"{d.tag}\"" else
+      s!"[Stacks Tag {d.tag}]({databaseURL db ++ d.tag})"
+    msgs := msgs.push m!"{start} corresponds to declaration '{.ofConstName d.declName}'.{cmt}"
     if verbose then
       let dType := ((env.find? d.declName).getD default).type
       msgs := (msgs.push m!"{dType}").push ""
@@ -224,7 +248,7 @@ The variant `#stacks_tags!` also adds the theorem statement (for theorems)
 or declaration type (for definitions, structures, instances, etc.) after each summary line.
 -/
 elab (name := stacksTags) "#stacks_tags" tk:("!")? : command =>
-  traceStacksTags .stacks (tk.isSome)
+  traceDatabaseTags .stacks (tk.isSome)
 
 /-- The `#kerodon_tags` command retrieves all declarations that have the `kerodon` attribute.
 
@@ -236,6 +260,18 @@ The variant `#kerodon_tags!` also adds the theorem statement (for theorems)
 or declaration type (for definitions, structures, instances, etc.) after each summary line.
 -/
 elab (name := kerodonTags) "#kerodon_tags" tk:("!")? : command =>
-  traceStacksTags .kerodon (tk.isSome)
+  traceDatabaseTags .kerodon (tk.isSome)
 
-end Mathlib.StacksTag
+/--
+`#informal_concepts` retrieves all declarations that have the `informal` attribute.
+
+For each found declaration, it prints a line
+```
+'declaration_name' corresponds to tag 'declaration_tag'.
+```
+The variant `informal_concepts!` also adds the theorem statement after each summary line.
+-/
+elab (name := informalConcepts) "#informal_concepts" tk:("!")?: command =>
+  traceDatabaseTags Database.informal (tk.isSome)
+
+end Mathlib.DatabaseTag

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Order.Minimal
 public import Mathlib.Order.Zorn
 public import Mathlib.Topology.ContinuousOn
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Topology.DiscreteSubset
 
 /-!

--- a/Mathlib/Topology/JacobsonSpace.lean
+++ b/Mathlib/Topology/JacobsonSpace.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Topology.LocalAtTarget
 public import Mathlib.Topology.Separation.Regular
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 
 /-!
 

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -11,7 +11,7 @@ public import Mathlib.Topology.Piecewise
 public import Mathlib.Topology.Separation.SeparatedNhds
 public import Mathlib.Topology.Compactness.LocallyCompact
 public import Mathlib.Topology.Bases
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 
 /-!
 # Separation properties of topological spaces

--- a/Mathlib/Topology/Separation/Regular.lean
+++ b/Mathlib/Topology/Separation/Regular.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 module
 
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Topology.Compactness.Lindelof
 public import Mathlib.Topology.Separation.Hausdorff
 public import Mathlib.Topology.Connected.Clopen

--- a/Mathlib/Topology/Spectral/Hom.lean
+++ b/Mathlib/Topology/Spectral/Hom.lean
@@ -5,7 +5,7 @@ Authors: Yaël Dillies
 -/
 module
 
-public import Mathlib.Tactic.StacksAttribute
+public import Mathlib.Tactic.DatabaseAttributes
 public import Mathlib.Topology.ContinuousMap.Basic
 public import Mathlib.Topology.Maps.Proper.Basic
 

--- a/MathlibTest/DatabaseAttributes.lean
+++ b/MathlibTest/DatabaseAttributes.lean
@@ -1,4 +1,4 @@
-import Mathlib.Tactic.StacksAttribute
+import Mathlib.Tactic.DatabaseAttributes
 import Mathlib.Util.ParseCommand
 
 /-- info: No tags found. -/
@@ -11,6 +11,47 @@ namespace X
 theorem tagged : True := .intro
 
 end X
+
+section informal
+
+/-- info: No tags found. -/
+#guard_msgs in
+#informal_concepts
+
+namespace Y
+
+@[informal "my concept"]
+theorem tagged : True := .intro
+
+@[informal "another concept" "with a comment"]
+theorem tagged' : True := .intro
+
+end Y
+
+/--
+info:
+informal concept "another concept" corresponds to declaration 'Y.tagged''. (with a comment)
+informal concept "my concept" corresponds to declaration 'Y.tagged'.
+-/
+#guard_msgs in
+#informal_concepts
+
+@[informal "concept1", informal "another concept"]
+theorem twice : True := .intro
+
+/--
+info:
+informal concept "another concept" corresponds to declaration 'twice'.
+informal concept "another concept" corresponds to declaration 'Y.tagged''. (with a comment)
+informal concept "concept1" corresponds to declaration 'twice'.
+informal concept "my concept" corresponds to declaration 'Y.tagged'.
+-/
+#guard_msgs in
+#informal_concepts
+
+end informal
+
+section StacksAttribute
 
 /--
 info: some ([Stacks Tag A04Q](https://stacks.math.columbia.edu/tag/A04Q) (A comment)
@@ -38,13 +79,13 @@ example : True := .intro
 example : True := .intro
 
 /-- error: <input>:1:3: Stacks tags must be exactly 4 characters -/
-#guard_msgs in #parse Mathlib.StacksTag.stacksTagFn => "A05"
+#guard_msgs in #parse Mathlib.DatabaseTag.stacksTagFn => "A05"
 
 /-- error: <input>:1:4: Stacks tags must consist only of digits and uppercase letters. -/
-#guard_msgs in #parse Mathlib.StacksTag.stacksTagFn => "A05b"
+#guard_msgs in #parse Mathlib.DatabaseTag.stacksTagFn => "A05b"
 
 /-- info: 0BD5 -/
-#guard_msgs in #parse Mathlib.StacksTag.stacksTagFn => "0BD5"
+#guard_msgs in #parse Mathlib.DatabaseTag.stacksTagFn => "0BD5"
 
 /--
 info:
@@ -71,7 +112,7 @@ True
 
 section errors
 
-open Lean Parser Mathlib.StacksTag
+open Lean Parser Mathlib.DatabaseTag
 
 def captureException (env : Environment) (s : ParserFn) (input : String) : Except String Syntax :=
   let ictx := mkInputContext input "<input>"
@@ -100,3 +141,5 @@ run_cmd do
   let _ ← Lean.ofExcept <| captureException env stacksTagFn "\"A04Q\""
 
 end errors
+
+end StacksAttribute

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -170,7 +170,7 @@
   "Mathlib.Tactic.Simps.NotationClass",
   "Mathlib.Tactic.SplitIfs",
   "Mathlib.Tactic.Spread",
-  "Mathlib.Tactic.StacksAttribute",
+  "Mathlib.Tactic.DatabaseAttributes",
   "Mathlib.Tactic.Substs",
   "Mathlib.Tactic.SuppressCompilation",
   "Mathlib.Tactic.SwapVar",


### PR DESCRIPTION
This allows tagging a definition or concept with an informal mathematics concept:
the details are subject to discussion.
The implementation largely parallels the stacks tags attribute.
   
--------

This PR, if desired, should land in stages: pre-requisites to merge before include (in order):
- fix comment typos in the stacks file
- rename the file to DatabaseAttributes
- add a module deprecation
- then this PR, which should be relatively small

Open question: can the parsers be shared better?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
