### PR TITLE
[Merged by Bors] - refactor: PowerSeries.gaussNorm

### DIFF
--- a/Mathlib/RingTheory/Polynomial/GaussNorm.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussNorm.lean
@@ -106,7 +106,7 @@ theorem gaussNorm_coe_powerSeries (hc : 0 ≤ c) :
     (p.toPowerSeries).gaussNorm v c = p.gaussNorm v c := by
   by_cases hp : p = 0
   · simp [hp]
-  · simp only [PowerSeries.gaussNorm, coeff_coe, gaussNorm, support_nonempty, ne_eq, hp,
+  · simp only [PowerSeries.gaussNorm_eq, coeff_coe, gaussNorm, support_nonempty, ne_eq, hp,
       not_false_eq_true, ↓reduceDIte]
     apply le_antisymm
     · apply ciSup_le
@@ -124,9 +124,10 @@ only if the polynomial is zero. -/
 @[simp]
 theorem gaussNorm_eq_zero_iff (h_eq_zero : ∀ x : R, v x = 0 → x = 0) (hc : 0 < c) :
     p.gaussNorm v c = 0 ↔ p = 0 := by
-  rw [← gaussNorm_coe_powerSeries _ _ (le_of_lt hc),
-    PowerSeries.gaussNorm_eq_zero_iff h_eq_zero hc (by simpa only [coeff_coe] using aux_bdd v p),
-    coe_eq_zero_iff]
+  rw [← gaussNorm_coe_powerSeries _ _ (le_of_lt hc)]
+  convert PowerSeries.gaussNorm_eq_zero_iff v c p (by grind) (by simp) h_eq_zero hc
+    (by simpa [PowerSeries.HasGaussNorm] using aux_bdd v p)
+  exact Iff.symm coe_eq_zero_iff
 
 omit [ZeroHomClass F R ℝ] in
 /-- If `v` is a nonnegative function, then the Gauss norm is nonnegative. -/
@@ -137,7 +138,7 @@ theorem gaussNorm_nonneg (hc : 0 ≤ c) : 0 ≤ p.gaussNorm v c := by
 lemma le_gaussNorm (hc : 0 ≤ c) (i : ℕ) : v (p.coeff i) * c ^ i ≤ p.gaussNorm v c := by
   rw [← gaussNorm_coe_powerSeries _ _ hc, ← coeff_coe]
   apply PowerSeries.le_gaussNorm
-  simpa using aux_bdd v p
+  simpa [PowerSeries.HasGaussNorm] using aux_bdd v p
 
 @[simp]
 lemma gaussNorm_zero_right : p.gaussNorm v 0 = v (p.coeff 0) := by

--- a/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
+++ b/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
@@ -61,8 +61,11 @@ lemma gaussNorm_eq : gaussNorm v c f = ⨆ i : ℕ, v (f.coeff i) * c ^ i := by
   `gaussNormC f` is finite. -/
 abbrev HasGaussNorm := BddAbove (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t)))
 
-lemma foo : (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t))) =
-    Set.range fun t ↦ v ((MvPowerSeries.coeff t) f) * t.prod fun _ x2 ↦ c ^ x2 := by
+lemma HasGaussNorm.HasMvGaussNorm (h : HasGaussNorm v c f) :
+    MvPowerSeries.HasGaussNorm v (fun _ ↦ c) f := by
+  suffices (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t))) =
+      Set.range fun t ↦ v ((MvPowerSeries.coeff t) f) * t.prod fun _ x2 ↦ c ^ x2 by
+    simpa only [MvPowerSeries.HasGaussNorm, ← this]
   refine Set.ext (fun _ ↦ ?_)
   simp only [Set.mem_range, Finsupp.prod_pow, Finset.univ_unique, PUnit.default_eq_unit,
     Finset.prod_singleton]
@@ -79,12 +82,6 @@ lemma foo : (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t))) =
     use Equiv.finsuppUnique.toFun y
     simpa [coeff, show (Finsupp.single () (y PUnit.unit)) = y by grind]
 
-lemma HasGaussNorm_MvHasGaussNorm (h : HasGaussNorm v c f) :
-    MvPowerSeries.HasGaussNorm v (fun _ ↦ c) f := by
-  simpa only [MvPowerSeries.HasGaussNorm, ← foo]
-
--- Note: not convinced that foo + HasGaussNorm... is the best way to do this
-
 theorem gaussNorm_zero (vZero : v 0 = 0) : gaussNorm v c 0 = 0 :=
   MvPowerSeries.gaussNorm_zero v (fun _ ↦ c) vZero
 
@@ -100,13 +97,13 @@ lemma gaussNorm_eq_zero_iff (vZero : v 0 = 0) (vNonneg : ∀ a, v a ≥ 0)
     (h_eq_zero : ∀ x : R, v x = 0 → x = 0) (hc : 0 < c) (hbd : HasGaussNorm v c f) :
     gaussNorm v c f = 0 ↔ f = 0 :=
   MvPowerSeries.gaussNorm_eq_zero_iff v (fun _ ↦ c) f vZero vNonneg h_eq_zero
-    (by grind) (HasGaussNorm_MvHasGaussNorm v c f hbd)
+    (by grind) (hbd.HasMvGaussNorm)
 
 lemma gaussNorm_add_le_max (g : PowerSeries R) (hc : 0 ≤ c)
     (vNonneg : ∀ a, v a ≥ 0) (hv : ∀ x y, v (x + y) ≤ max (v x) (v y))
     (hbfd : HasGaussNorm v c f) (hbgd : HasGaussNorm v c g) :
     gaussNorm v c (f + g) ≤ max (gaussNorm v c f) (gaussNorm v c g) :=
   MvPowerSeries.gaussNorm_add_le_max v (fun _ ↦ c) f g (fun _ => by simp [hc]) vNonneg hv
-    (HasGaussNorm_MvHasGaussNorm v c f hbfd) (HasGaussNorm_MvHasGaussNorm v c g hbgd)
+   hbfd.HasMvGaussNorm hbgd.HasMvGaussNorm
 
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
+++ b/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
@@ -7,71 +7,107 @@ module
 
 public import Mathlib.Data.Real.Archimedean
 public import Mathlib.RingTheory.PowerSeries.Order
+public import Mathlib.RingTheory.MvPowerSeries.GaussNorm
 
 /-!
 # Gauss norm for power series
-This file defines the Gauss norm for power series. Given a power series `f` in `R⟦X⟧`, a function
-`v : R → ℝ` and a real number `c`, the Gauss norm is defined as the supremum of the set of all
-values of `v (f.coeff i) * c ^ i` for all `i : ℕ`.
+This file defines the Gauss norm for power series using the gaussNorm for multivariate power series.
+Given a power series `f` in `R⟦X⟧`, a function `v : R → ℝ` and a real number `c`, the Gauss norm is
+defined as the supremum of the set of all values of `v (f.coeff i) * c ^ i` for all `i : ℕ`.
 
 In case `f` is a polynomial, `v` is a non-negative function with `v 0 = 0` and `c ≥ 0`,
 `f.gaussNorm v c` reduces to the Gauss norm defined in
 `Mathlib/RingTheory/Polynomial/GaussNorm.lean`, see `Polynomial.gaussNorm_coe_powerSeries`.
 
 ## Main Definitions and Results
-* `PowerSeries.gaussNorm` is the supremum of the set of all values of `v (f.coeff i) * c ^ i`
-  for all `i : ℕ`, where `f` is a power series in `R⟦X⟧`, `v : R → ℝ` is a function and `c` is a
-  real number.
+* Using `PowerSeries.gaussNorm_eq`, `PowerSeries.gaussNorm` is the supremum of the set of all values
+  of `v (f.coeff i) * c ^ i` for all `i : ℕ`, where `f` is a power series in `R⟦X⟧`, `v : R → ℝ` is
+  a function and `c` is a real number.
+
 * `PowerSeries.gaussNorm_nonneg`: if `v` is a non-negative function, then the Gauss norm is
   non-negative.
+
 * `PowerSeries.gaussNorm_eq_zero_iff`: if `v` is a non-negative function and `v x = 0 ↔ x = 0` for
   all `x : R` and `c` is positive, then the Gauss norm is zero if and only if the power series is
   zero.
 
-## TODO:
-* Set up `gaussNorm` as an abbrev of the MvPowerSeries version from
-  Mathlib.RingTheory.MvPowerSeries.GaussNorm
-* Refactor to remove the use of FunLike as in MvPowerSeries version
+* `PowerSeries.gaussNormC_eq_zero_iff`: if `v` is a non-negative function and `v x = 0 ↔ x = 0`
+  for all `x : R` and `c` is positive, then the Gauss norm is zero if and only if the power series
+  is zero.
+
+* `PowerSeries.gaussNorm_add_le_max`: if `v` is a non-negative non-archimedean function and the
+  set of values `v (coeff t f) * c ^ t` is bounded above (similarily for `g`), then
+  the Gauss norm has the non-archimedean property.
 -/
 
 @[expose] public section
 
 namespace PowerSeries
 
-variable {R F : Type*} [Semiring R] [FunLike F R ℝ] (v : F) (c : ℝ) (f : R⟦X⟧)
+variable {R : Type*} [Semiring R] (v : R → ℝ) (c : ℝ) (f : PowerSeries R)
 
-/-- Given a power series `f` in `R⟦X⟧`, a function `v : R → ℝ` and a real number `c`, the Gauss norm
-is defined as the supremum of the set of all values of `v (f.coeff i) * c ^ i` for all `i : ℕ`. -/
-noncomputable def gaussNorm : ℝ := ⨆ i : ℕ, v (f.coeff i) * c ^ i
+/-- Given a power series `f` in, a function `v : R → ℝ` and a real number `c`, the Gauss norm is
+  defined as the supremum of the set of all values of `v (coeff t f) * c ^ t` for all `t : ℕ`. -/
+noncomputable
+abbrev gaussNorm : ℝ := MvPowerSeries.gaussNorm v (fun _ => c) f
 
-lemma le_gaussNorm (hbd : BddAbove {x | ∃ i, v (f.coeff i) * c ^ i = x}) (i : ℕ) :
-    v (f.coeff i) * c ^ i ≤ f.gaussNorm v c := le_ciSup hbd i
+lemma gaussNorm_eq : gaussNorm v c f = ⨆ i : ℕ, v (f.coeff i) * c ^ i := by
+  refine Equiv.iSup_congr Equiv.finsuppUnique ?_
+  intro x
+  simp only [coeff, Equiv.finsuppUnique_apply, PUnit.default_eq_unit, Finsupp.prod_pow,
+    Finset.univ_unique, Finset.prod_singleton, show (Finsupp.single () (x PUnit.unit)) = x by grind]
+
+/-- We say `f` HasGaussNorm if the values `v (coeff t f) * c ^ t` is bounded above, that is
+  `gaussNormC f` is finite. -/
+abbrev HasGaussNorm := BddAbove (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t)))
+
+lemma foo : (Set.range (fun (t : ℕ) ↦ (v (coeff t f) * c ^ t))) =
+    Set.range fun t ↦ v ((MvPowerSeries.coeff t) f) * t.prod fun _ x2 ↦ c ^ x2 := by
+  refine Set.ext (fun _ ↦ ?_)
+  simp only [Set.mem_range, Finsupp.prod_pow, Finset.univ_unique, PUnit.default_eq_unit,
+    Finset.prod_singleton]
+  constructor
+  · intro h
+    obtain ⟨y, hy⟩ := h
+    use Equiv.finsuppUnique.invFun y
+    rw [coeff] at hy
+    convert hy
+    ext
+    simp
+  · intro h
+    obtain ⟨y, hy⟩ := h
+    use Equiv.finsuppUnique.toFun y
+    simpa [coeff, show (Finsupp.single () (y PUnit.unit)) = y by grind]
+
+lemma HasGaussNorm_MvHasGaussNorm (h : HasGaussNorm v c f) :
+    MvPowerSeries.HasGaussNorm v (fun _ ↦ c) f := by
+  simpa only [MvPowerSeries.HasGaussNorm, ← foo]
+
+-- Note: not convinced that foo + HasGaussNorm... is the best way to do this
 
 @[simp]
-theorem gaussNorm_zero [ZeroHomClass F R ℝ] : gaussNorm v c 0 = 0 := by simp [gaussNorm]
+theorem gaussNorm_zero (vZero : v 0 = 0) : gaussNorm v c 0 = 0 :=
+  MvPowerSeries.gaussNorm_zero v (fun _ ↦ c) vZero
 
-theorem gaussNorm_nonneg [NonnegHomClass F R ℝ] : 0 ≤ f.gaussNorm v c := by
-  by_cases h : BddAbove (Set.range fun i ↦ v (f.coeff i) * c ^ i)
-  · calc
-    0 ≤ v (f.coeff 0) * c ^ 0 :=
-      mul_nonneg (apply_nonneg v (f.coeff 0)) <| pow_nonneg (le_of_lt (zero_lt_one)) 0
-    _ ≤ f.gaussNorm v c := le_ciSup h 0
-  · simp [gaussNorm, h]
+lemma le_gaussNorm (hbd : HasGaussNorm v c f) (t : ℕ) :
+    v (coeff t f) * c ^ t ≤ gaussNorm v c f := by
+  rw [gaussNorm_eq]
+  apply le_ciSup hbd
 
-@[simp]
-theorem gaussNorm_eq_zero_iff [ZeroHomClass F R ℝ] [NonnegHomClass F R ℝ] {v : F}
-    (h_eq_zero : ∀ x : R, v x = 0 → x = 0) {f : R⟦X⟧} {c : ℝ} (hc : 0 < c)
-    (hbd : BddAbove (Set.range fun i ↦ v (f.coeff i) * c ^ i)) :
-    f.gaussNorm v c = 0 ↔ f = 0 := by
-  refine ⟨?_, fun hf ↦ by simp [hf]⟩
-  contrapose!
-  intro hf
-  apply ne_of_gt
-  obtain ⟨n, hn⟩ := exists_coeff_ne_zero_iff_ne_zero.mpr hf
-  calc
-  0 < v (f.coeff n) * c ^ n := by
-    have := fun h ↦ hn (h_eq_zero (coeff n f) h)
-    positivity
-  _ ≤ gaussNorm v c f := le_ciSup hbd n
+lemma gaussNorm_nonneg (vNonneg : ∀ a, v a ≥ 0) : 0 ≤ gaussNorm v c f :=
+  MvPowerSeries.gaussNorm_nonneg v (fun _ ↦ c) f vNonneg
+
+lemma gaussNorm_eq_zero_iff (vZero : v 0 = 0) (vNonneg : ∀ a, v a ≥ 0)
+    (h_eq_zero : ∀ x : R, v x = 0 → x = 0) (hc : 0 < c) (hbd : HasGaussNorm v c f) :
+    gaussNorm v c f = 0 ↔ f = 0 :=
+  MvPowerSeries.gaussNorm_eq_zero_iff v (fun _ ↦ c) f vZero vNonneg h_eq_zero
+    (by grind) (HasGaussNorm_MvHasGaussNorm v c f hbd)
+
+lemma gaussNorm_add_le_max (g : PowerSeries R) (hc : 0 ≤ c)
+    (vNonneg : ∀ a, v a ≥ 0) (hv : ∀ x y, v (x + y) ≤ max (v x) (v y))
+    (hbfd : HasGaussNorm v c f) (hbgd : HasGaussNorm v c g) :
+    gaussNorm v c (f + g) ≤ max (gaussNorm v c f) (gaussNorm v c g) :=
+  MvPowerSeries.gaussNorm_add_le_max v (fun _ ↦ c) f g (fun _ => by simp [hc]) vNonneg hv
+    (HasGaussNorm_MvHasGaussNorm v c f hbfd) (HasGaussNorm_MvHasGaussNorm v c g hbgd)
 
 end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
+++ b/Mathlib/RingTheory/PowerSeries/GaussNorm.lean
@@ -85,7 +85,6 @@ lemma HasGaussNorm_MvHasGaussNorm (h : HasGaussNorm v c f) :
 
 -- Note: not convinced that foo + HasGaussNorm... is the best way to do this
 
-@[simp]
 theorem gaussNorm_zero (vZero : v 0 = 0) : gaussNorm v c 0 = 0 :=
   MvPowerSeries.gaussNorm_zero v (fun _ ↦ c) vZero
 


### PR DESCRIPTION
We refactor the definition of the gauss norm on power series to an abbrev of the gauss norm on multivariate power series, and remove the use of `Funlike`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
