### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Dimension/StrongRankCondition): `algebraMap` bijective implies rank one

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -477,13 +477,15 @@ module over itself. -/
 theorem finrank_self : finrank R R = 1 :=
   finrank_eq_of_rank_eq (by simp)
 
+variable {R} in
 theorem finrank_of_bijective_toSpanSingleton {x : M}
     (h : Bijective (LinearMap.toSpanSingleton R M x)) : finrank R M = 1 := by
   rw [← (LinearEquiv.ofBijective _ h).finrank_eq, finrank_self]
 
+variable {R} in
 theorem rank_of_bijective_toSpanSingleton {x : M}
     (h : Bijective (LinearMap.toSpanSingleton R M x)) : Module.rank R M = 1 := by
-  rw [rank_eq_one_iff_finrank_eq_one, finrank_of_bijective_toSpanSingleton R h]
+  rw [rank_eq_one_iff_finrank_eq_one, finrank_of_bijective_toSpanSingleton h]
 
 theorem finrank_of_bijective_algebraMap {R S : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
     [StrongRankCondition R] (h : Bijective (algebraMap R S)) : finrank R S = 1 := by

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -477,6 +477,14 @@ module over itself. -/
 theorem finrank_self : finrank R R = 1 :=
   finrank_eq_of_rank_eq (by simp)
 
+theorem finrank_of_bijective_toSpanSingleton {x : M}
+    (h : Bijective (LinearMap.toSpanSingleton R M x)) : finrank R M = 1 := by
+  rw [← (LinearEquiv.ofBijective _ h).finrank_eq, finrank_self]
+
+theorem rank_of_bijective_toSpanSingleton {x : M}
+    (h : Bijective (LinearMap.toSpanSingleton R M x)) : Module.rank R M = 1 := by
+  rw [rank_eq_one_iff_finrank_eq_one, finrank_of_bijective_toSpanSingleton R h]
+
 theorem finrank_of_bijective_algebraMap {R S : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
     [StrongRankCondition R] (h : Bijective (algebraMap R S)) : finrank R S = 1 := by
   rw [← (AlgEquiv.ofBijective (Algebra.ofId R S) h).toLinearEquiv.finrank_eq, finrank_self]

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -477,6 +477,14 @@ module over itself. -/
 theorem finrank_self : finrank R R = 1 :=
   finrank_eq_of_rank_eq (by simp)
 
+theorem finrank_of_bijective_algebraMap {R S : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
+    [StrongRankCondition R] (h : Bijective (algebraMap R S)) : finrank R S = 1 := by
+  rw [← (AlgEquiv.ofBijective (Algebra.ofId R S) h).toLinearEquiv.finrank_eq, finrank_self]
+
+theorem rank_of_bijective_algebraMap {R S : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
+    [StrongRankCondition R] (h : Bijective (algebraMap R S)) : Module.rank R S = 1 := by
+  rw [rank_eq_one_iff_finrank_eq_one, finrank_of_bijective_algebraMap h]
+
 /-- Given a basis of a ring over itself indexed by a type `ι`, then `ι` is `Unique`. -/
 @[implicit_reducible]
 noncomputable def _root_.Module.Basis.unique {ι : Type*} (b : Basis ι R R) : Unique ι := by


### PR DESCRIPTION
This PR proves that if `algebraMap R S` is bijective, then `S` has rank one as an `R`-algebra.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
