### PR TITLE
[Merged by Bors] - feat(Topology/Order/AtTopBotIxx): locally finite families of intervals

### DIFF
--- a/Mathlib/Topology/Order/AtTopBotIxx.lean
+++ b/Mathlib/Topology/Order/AtTopBotIxx.lean
@@ -209,12 +209,12 @@ theorem locallyFinite_Icc_of_tendsto {f g : α → X}
   cases isEmpty_or_nonempty α
   · use univ
     simp [Subsingleton.elim _ (∅ : Set α)]
-  obtain ⟨x_R, hx_R⟩ := exists_gt x
   obtain ⟨x_L, hx_L⟩ := exists_lt x
-  obtain ⟨N₂, hN₂ : ∀ b ≥ N₂, x_R ≤ f b⟩ :=
-    eventually_atTop.mp <| hl.eventually <| eventually_ge_atTop x_R
+  obtain ⟨x_R, hx_R⟩ := exists_gt x
   obtain ⟨N₁, hN₁ : ∀ b ≤ N₁, g b ≤ x_L⟩ :=
     eventually_atBot.mp <| hu.eventually <| eventually_le_atBot x_L
+  obtain ⟨N₂, hN₂ : ∀ b ≥ N₂, x_R ≤ f b⟩ :=
+    eventually_atTop.mp <| hl.eventually <| eventually_ge_atTop x_R
   refine ⟨Ioo x_L x_R, Ioo_mem_nhds hx_L hx_R, (finite_Icc N₁ N₂).subset ?_⟩
   rintro n ⟨y, ⟨hf, hg⟩, ⟨hxL, hxR⟩⟩
   constructor

--- a/Mathlib/Topology/Order/AtTopBotIxx.lean
+++ b/Mathlib/Topology/Order/AtTopBotIxx.lean
@@ -211,17 +211,17 @@ theorem locallyFinite_Icc_of_tendsto {f g : α → X}
     simp [Subsingleton.elim _ (∅ : Set α)]
   obtain ⟨x_L, hx_L⟩ := exists_lt x
   obtain ⟨x_R, hx_R⟩ := exists_gt x
-  obtain ⟨N₁, hN₁ : ∀ b ≤ N₁, g b ≤ x_L⟩ :=
-    eventually_atBot.mp <| hu.eventually <| eventually_le_atBot x_L
-  obtain ⟨N₂, hN₂ : ∀ b ≥ N₂, x_R ≤ f b⟩ :=
-    eventually_atTop.mp <| hl.eventually <| eventually_ge_atTop x_R
-  refine ⟨Ioo x_L x_R, Ioo_mem_nhds hx_L hx_R, (finite_Icc N₁ N₂).subset ?_⟩
+  obtain ⟨a_L, ha_L : ∀ a ≤ a_L, g a ≤ x_L⟩ :=
+    hu.eventually_le_atBot x_L |>.exists_forall_of_atBot
+  obtain ⟨a_R, ha_R : ∀ a ≥ a_R, x_R ≤ f a⟩ :=
+    hl.eventually_ge_atTop x_R |>.exists_forall_of_atTop
+  refine ⟨Ioo x_L x_R, Ioo_mem_nhds hx_L hx_R, (finite_Icc a_L a_R).subset ?_⟩
   rintro n ⟨y, ⟨hf, hg⟩, ⟨hxL, hxR⟩⟩
   constructor
   · contrapose! hxL
-    exact hg.trans (hN₁ n hxL.le)
+    exact hg.trans (ha_L n hxL.le)
   · contrapose! hxR
-    exact (hN₂ n hxR.le).trans hf
+    exact (ha_R n hxR.le).trans hf
 
 /-- A family of half-open intervals bounded by diverging limits is locally finite. -/
 theorem locallyFinite_Ico_of_tendsto {l u : α → X}

--- a/Mathlib/Topology/Order/AtTopBotIxx.lean
+++ b/Mathlib/Topology/Order/AtTopBotIxx.lean
@@ -197,3 +197,48 @@ theorem tendsto_Ioi_atBot {f : α → Ioi a} (ha : IsPredPrelimit a := by exact 
 theorem tendsto_Iio_atTop {f : α → Iio a} (ha : IsSuccPrelimit a := by exact .of_dense _) :
     Tendsto f l atTop ↔ Tendsto (fun x => (f x : X)) l (𝓝[<] a) := by
   rw [← comap_coe_Iio_nhdsLT a ha, tendsto_comap_iff, Function.comp_def]
+
+section LocallyFinite
+variable [LinearOrder α] [LocallyFiniteOrder α] [NoMaxOrder X] [NoMinOrder X]
+
+/-- A family of closed intervals bounded by diverging limits is locally finite. -/
+theorem locallyFinite_Icc_of_tendsto {f g : α → X}
+    (hl : Tendsto f atTop atTop) (hu : Tendsto g atBot atBot) :
+    LocallyFinite (fun n => Set.Icc (f n) (g n)) := by
+  intro x
+  cases isEmpty_or_nonempty α
+  · use univ
+    simp [Subsingleton.elim _ (∅ : Set α)]
+  obtain ⟨x_R, hx_R⟩ := exists_gt x
+  obtain ⟨x_L, hx_L⟩ := exists_lt x
+  obtain ⟨N₂, hN₂ : ∀ b ≥ N₂, x_R ≤ f b⟩ :=
+    eventually_atTop.mp <| hl.eventually <| eventually_ge_atTop x_R
+  obtain ⟨N₁, hN₁ : ∀ b ≤ N₁, g b ≤ x_L⟩ :=
+    eventually_atBot.mp <| hu.eventually <| eventually_le_atBot x_L
+  refine ⟨Ioo x_L x_R, Ioo_mem_nhds hx_L hx_R, (finite_Icc N₁ N₂).subset ?_⟩
+  rintro n ⟨y, ⟨hf, hg⟩, ⟨hxL, hxR⟩⟩
+  constructor
+  · contrapose! hxL
+    exact hg.trans (hN₁ n hxL.le)
+  · contrapose! hxR
+    exact (hN₂ n hxR.le).trans hf
+
+/-- A family of half-open intervals bounded by diverging limits is locally finite. -/
+theorem locallyFinite_Ico_of_tendsto {l u : α → X}
+    (hl : Tendsto l atTop atTop) (hu : Tendsto u atBot atBot) :
+    LocallyFinite (fun n => Set.Ico (l n) (u n)) :=
+  locallyFinite_Icc_of_tendsto hl hu |>.subset fun _ => Set.Ico_subset_Icc_self
+
+/-- A family of half-open intervals bounded by diverging limits is locally finite. -/
+theorem locallyFinite_Ioc_of_tendsto {l u : α → X}
+    (hl : Tendsto l atTop atTop) (hu : Tendsto u atBot atBot) :
+    LocallyFinite (fun n => Set.Ioc (l n) (u n)) :=
+  locallyFinite_Icc_of_tendsto hl hu |>.subset fun _ => Set.Ioc_subset_Icc_self
+
+/-- A family of open intervals bounded by diverging limits is locally finite. -/
+theorem locallyFinite_Ioo_of_tendsto {l u : α → X}
+    (hl : Tendsto l atTop atTop) (hu : Tendsto u atBot atBot) :
+    LocallyFinite (fun n => Set.Ioo (l n) (u n)) :=
+  locallyFinite_Icc_of_tendsto hl hu |>.subset fun _ => Set.Ioo_subset_Icc_self
+
+end LocallyFinite


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
