### PR TITLE
[Merged by Bors] - feat(Order/Monotone/Basic): add Nat.stabilises_of_antitone

### DIFF
--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -714,6 +714,28 @@ lemma Nat.stabilises_of_monotone {f : ℕ → ℕ} {b n : ℕ} (hfmono : Monoton
     (congr_arg f (Nat.add_sub_of_le hk)).symm.trans (key (k - m)).2
   exact (key n (hmb.trans hbn)).trans (key b hmb).symm
 
+/-- An antitone function `f : ℕ → ℕ` which stabilises for the first time at step `m` remains
+constant from step `m` onward. The stabilisation index is at most `f 0`.
+
+Compared to `WellFoundedLT.antitone_chain_condition`, this lemma requires the extra hypothesis
+`hfstab` and only applies to `ℕ`-valued functions, but in return it gives an explicit bound on the
+stabilisation index. -/
+lemma Nat.stabilises_of_antitone {f : ℕ → ℕ} (hfmono : Antitone f)
+    (hfstab : ∀ m, f m = f (m + 1) → f (m + 1) = f (m + 2)) :
+    ∃ n ≤ f 0, ∀ m, n ≤ m → f m = f n := by
+  induction h : f 0 using Nat.strongRecOn generalizing f with
+  | ind n ih =>
+    by_cases heq : f 0 = f 1
+    · have flat (j : ℕ) : f j = f (j + 1) := by induction j with grind
+      exact ⟨0, Nat.zero_le _, fun m _ => by induction m with grind⟩
+    · have hlt : f 1 < f 0 := (hfmono (Nat.le_succ 0)).lt_of_ne' heq
+      let g (i : ℕ) := f (i + 1)
+      have hg_anti : Antitone g := by grind [Antitone]
+      obtain ⟨p, hp, hp'⟩ := ih (f 1) (by grind) hg_anti (by grind) rfl
+      refine ⟨p + 1, by omega, fun m hm => ?_⟩
+      specialize hp' (m - 1) (by lia)
+      grind
+
 /-- A bounded monotone function `ℕ → ℕ` converges. -/
 lemma converges_of_monotone_of_bounded {f : ℕ → ℕ} (mono_f : Monotone f)
     {c : ℕ} (hc : ∀ n, f n ≤ c) : ∃ b N, ∀ n ≥ N, f n = b := by

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -714,8 +714,8 @@ lemma Nat.stabilises_of_monotone {f : ℕ → ℕ} {b n : ℕ} (hfmono : Monoton
     (congr_arg f (Nat.add_sub_of_le hk)).symm.trans (key (k - m)).2
   exact (key n (hmb.trans hbn)).trans (key b hmb).symm
 
-/-- An antitone function `f : ℕ → ℕ` which stabilises for the first time at step `m` remains
-constant from step `m` onward. The stabilisation index is at most `f 0`.
+/-- An antitone function `f : ℕ → ℕ` which is constant after stabilising for the first time,
+stabilises in at most `f 0` steps.
 
 Compared to `WellFoundedLT.antitone_chain_condition`, this lemma requires the extra hypothesis
 `hfstab` and only applies to `ℕ`-valued functions, but in return it gives an explicit bound on the


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
