### PR TITLE
[Merged by Bors] - feat: add finitely presented instance for free groups

### DIFF
--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -71,10 +71,11 @@ theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgr
   ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
 /-- A free group (with a finite number of generators) is finitely presented. -/
-instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
-  refine ⟨n, FreeGroup.map id, ?surjective, ?closure⟩
-  · exact FreeGroup.map_surjective Function.surjective_id
-  · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
+instance [Finite α] : Group.IsFinitelyPresented (FreeGroup α) := by
+  have ⟨n, _, f, hf_split_epi, hf_split_mono⟩ := Finite.exists_equiv_fin α
+  refine ⟨n, FreeGroup.map f, ?surjective, ?closure⟩
+  · exact FreeGroup.map_surjective hf_split_epi.surjective
+  · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_split_mono.injective)]
     exact Subgroup.isNormalClosureFG_bot
 
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -73,8 +73,7 @@ theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgr
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance [Finite α] : Group.IsFinitelyPresented (FreeGroup α) := by
   have ⟨n, _, f, hf_surj, hf_inj⟩ := Finite.exists_equiv_fin α
-  refine ⟨n, FreeGroup.map f, ?_, ?_⟩
-  · exact FreeGroup.map_surjective hf_surj.surjective
+  refine ⟨n, FreeGroup.map f, FreeGroup.map_surjective hf_surj.surjective, ?_⟩
   · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_inj.injective)]
     exact Subgroup.isNormalClosureFG_bot
 

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -72,10 +72,10 @@ theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgr
 
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance [Finite α] : Group.IsFinitelyPresented (FreeGroup α) := by
-  have ⟨n, _, f, hf_split_epi, hf_split_mono⟩ := Finite.exists_equiv_fin α
-  refine ⟨n, FreeGroup.map f, ?surjective, ?closure⟩
-  · exact FreeGroup.map_surjective hf_split_epi.surjective
-  · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_split_mono.injective)]
+  have ⟨n, _, f, hf_surj, hf_inj⟩ := Finite.exists_equiv_fin α
+  refine ⟨n, FreeGroup.map f, ?_, ?_⟩
+  · exact FreeGroup.map_surjective hf_surj.surjective
+  · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_inj.injective)]
     exact Subgroup.isNormalClosureFG_bot
 
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -49,6 +49,10 @@ protected theorem map {N : Subgroup G} (hN : IsNormalClosureFG N)
   refine ⟨f '' S, hSfinite.image _, ?_⟩
   rw [← hSclosure, Subgroup.map_normalClosure _ _ hf]
 
+/-- The trivial group is the normal closure of a finite set of relations. -/
+protected theorem bot : IsNormalClosureFG (⊥ : Subgroup G) :=
+  ⟨∅, Finite.of_subsingleton, normalClosure_empty⟩
+
 end Subgroup.IsNormalClosureFG
 
 /-- A group is finitely presented if it has a finite generating set such that the kernel
@@ -66,15 +70,11 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   refine ⟨n, (iso : G →* H).comp φ, iso.surjective.comp hφsurj, ?_⟩
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
-/-- The trivial group is the normal closure of a finite set of relations. -/
-theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
-  ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
-
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance [Finite α] : Group.IsFinitelyPresented (FreeGroup α) := by
   have ⟨n, _, f, hf_surj, hf_inj⟩ := Finite.exists_equiv_fin α
   refine ⟨n, FreeGroup.map f, FreeGroup.map_surjective hf_surj.surjective, ?_⟩
   · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_inj.injective)]
-    exact Subgroup.isNormalClosureFG_bot
+    exact Subgroup.IsNormalClosureFG.bot
 
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -67,8 +67,9 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
 /-- The trivial group is the normal closure of a finite set of relations. -/
-instance : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
-  ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
+theorem BotIsNormalClosureFG : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
+  use ∅
+  exact ⟨Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
@@ -76,6 +77,6 @@ instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
   constructor
   · exact FreeGroup.map_surjective Function.surjective_id
   · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
-    exact instIsNormalClosureFGBotSubgroup
+    exact BotIsNormalClosureFG
 
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -72,8 +72,7 @@ theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgr
 
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
-  use n, FreeGroup.map id
-  constructor
+  refine ⟨n, FreeGroup.map id, ?surjective, ?closure⟩
   · exact FreeGroup.map_surjective Function.surjective_id
   · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
     exact Subgroup.isNormalClosureFG_bot

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -71,7 +71,7 @@ instance : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
   ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
 /-- A free group (with a finite number of generators) is finitely generated. -/
-instance {n : Nat} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
+instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
   use n, FreeGroup.map id
   constructor
   · exact FreeGroup.map_surjective Function.surjective_id

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -67,7 +67,7 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
 /-- The trivial group is the normal closure of a finite set of relations. -/
-theorem BotIsNormalClosureFG : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
+theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
   use ∅
   exact ⟨Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
@@ -77,6 +77,6 @@ instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
   constructor
   · exact FreeGroup.map_surjective Function.surjective_id
   · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
-    exact BotIsNormalClosureFG
+    exact Subgroup.isNormalClosureFG_bot
 
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -70,7 +70,7 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
 instance : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
   ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
-/-- A free group (with a finite number of generators) is finitely generated. -/
+/-- A free group (with a finite number of generators) is finitely presented. -/
 instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
   use n, FreeGroup.map id
   constructor

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -66,4 +66,17 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   refine ⟨n, (iso : G →* H).comp φ, iso.surjective.comp hφsurj, ?_⟩
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
+/-- The trivial group is the normal closure of a finite set of relations. -/
+theorem BotIsNormalClosureFG : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
+  use ∅
+  exact ⟨Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
+
+/-- A free group (with a finite number of generators) is finitely generated. -/
+instance {n : Nat} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
+  use n, FreeGroup.map id
+  constructor
+  · exact FreeGroup.map_surjective Function.surjective_id
+  · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
+    exact BotIsNormalClosureFG
+
 end Group.IsFinitelyPresented

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -67,9 +67,8 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
 /-- The trivial group is the normal closure of a finite set of relations. -/
-theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
-  use ∅
-  exact ⟨Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
+theorem Subgroup.isNormalClosureFG_bot : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
+  ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
 /-- A free group (with a finite number of generators) is finitely presented. -/
 instance {n : ℕ} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by

--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -67,9 +67,8 @@ theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented
   rwa [MonoidHom.ker_mulEquiv_comp φ iso]
 
 /-- The trivial group is the normal closure of a finite set of relations. -/
-theorem BotIsNormalClosureFG : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) := by
-  use ∅
-  exact ⟨Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
+instance : Subgroup.IsNormalClosureFG (⊥ : Subgroup G) :=
+  ⟨∅, Finite.of_subsingleton, Subgroup.normalClosure_empty⟩
 
 /-- A free group (with a finite number of generators) is finitely generated. -/
 instance {n : Nat} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
@@ -77,6 +76,6 @@ instance {n : Nat} : Group.IsFinitelyPresented (FreeGroup (Fin n)) := by
   constructor
   · exact FreeGroup.map_surjective Function.surjective_id
   · rw [(FreeGroup.map id).ker_eq_bot_iff.mpr (FreeGroup.map_injective Function.injective_id)]
-    exact BotIsNormalClosureFG
+    exact instIsNormalClosureFGBotSubgroup
 
 end Group.IsFinitelyPresented


### PR DESCRIPTION
Add `IsFinitelyPresented` instance for free groups

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This commit adds a `IsFinitelyPresented` instance for free groups over `Fin n`.
@homeowmorphism 