### PR TITLE
refactor: weaken assumptions in `LpSeminorm/Count`, `ProductMeasure`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -450,23 +450,6 @@ theorem ae_eq_set_pi {I : Set ι} {s t : ∀ i, Set (α i)} (h : ∀ i ∈ I, s 
     Set.pi I s =ᵐ[Measure.pi μ] Set.pi I t :=
   (ae_le_set_pi fun i hi => (h i hi).le).antisymm (ae_le_set_pi fun i hi => (h i hi).symm.le)
 
-lemma pi_map_piCongrLeft [hι' : Fintype ι'] (e : ι ≃ ι') {β : ι' → Type*}
-    [∀ i, MeasurableSpace (β i)] (μ : (i : ι') → Measure (β i)) [∀ i, SigmaFinite (μ i)] :
-    (Measure.pi fun i ↦ μ (e i)).map (MeasurableEquiv.piCongrLeft (fun i ↦ β i) e)
-      = Measure.pi μ := by
-  let e_meas : ((b : ι) → β (e b)) ≃ᵐ ((a : ι') → β a) :=
-    MeasurableEquiv.piCongrLeft (fun i ↦ β i) e
-  refine Measure.pi_eq (fun s _ ↦ ?_) |>.symm
-  rw [e_meas.measurableEmbedding.map_apply]
-  let s' : (i : ι) → Set (β (e i)) := fun i ↦ s (e i)
-  have : e_meas ⁻¹' pi univ s = pi univ s' := by
-    ext x
-    simp only [mem_preimage, Set.mem_pi, mem_univ, forall_true_left, s']
-    refine (e.forall_congr ?_).symm
-    intro i
-    rw [MeasurableEquiv.piCongrLeft_apply_apply e x i]
-  simpa [this] using Fintype.prod_equiv _ (fun _ ↦ (μ _) (s' _)) _ (congrFun rfl)
-
 lemma pi_map_piOptionEquivProd {β : Option ι → Type*} [∀ i, MeasurableSpace (β i)]
     (μ : (i : Option ι) → Measure (β i)) [∀ (i : Option ι), SigmaFinite (μ i)] :
     ((Measure.pi fun i ↦ μ (some i)).prod (μ none)).map
@@ -754,6 +737,12 @@ theorem volume_measurePreserving_piCongrLeft (α : ι → Type*) (f : ι' ≃ ι
     [∀ i, MeasureSpace (α i)] [∀ i, SigmaFinite (volume : Measure (α i))] :
     MeasurePreserving (MeasurableEquiv.piCongrLeft α f) volume volume :=
   measurePreserving_piCongrLeft (fun _ ↦ volume) f
+
+lemma pi_map_piCongrLeft (e : ι ≃ ι') {β : ι' → Type*} [∀ i, MeasurableSpace (β i)]
+    (μ : (i : ι') → Measure (β i)) [∀ i, SigmaFinite (μ i)] :
+    (Measure.pi fun i ↦ μ (e i)).map (MeasurableEquiv.piCongrLeft (fun i ↦ β i) e) =
+      Measure.pi μ :=
+  (measurePreserving_piCongrLeft (α := fun i ↦ β i) (μ := μ) e).map_eq
 
 theorem measurePreserving_arrowProdEquivProdArrow (α β γ : Type*) [MeasurableSpace α]
     [MeasurableSpace β] [Fintype γ] (μ : γ → Measure α) (ν : γ → Measure β) [∀ i, SigmaFinite (μ i)]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
@@ -35,16 +35,13 @@ lemma enorm_le_eLpNorm_count (f : α → ε) (i : α) (hp : p ≠ 0) :
       _ ≤ eLpNorm f p count := eLpNorm_restrict_le ..
 
 omit [MeasurableSingletonClass α] in
-lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) :
-    eLpNorm f p .count < ∞ := by
-  letI _ := Fintype.ofFinite α
+lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) : eLpNorm f p .count < ∞ := by
+  haveI := Fintype.ofFinite α
   let C : ℝ≥0∞ := Finset.univ.sup (‖f ·‖ₑ)
-  have hC : ∀ x, ‖f x‖ₑ ≤ C := fun x => Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
-  have hC_lt : C < ∞ := by
-    simp [C, Finset.sup_lt_iff, h]
-  refine (eLpNorm_mono_enorm (μ := (count : Measure α)) (p := p) (f := f)
-    (g := fun _ : α => C) fun x => by simpa [C] using hC x).trans_lt ?_
-  exact (memLp_const_enorm (μ := (count : Measure α)) (p := p) (c := C) hC_lt.ne).eLpNorm_lt_top
+  have hC : ∀ x, ‖f x‖ₑ ≤ C := fun x ↦ Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
+  have hC_lt : C < ∞ := by simp [C, h]
+  exact (eLpNorm_mono_enorm (g := fun _ ↦ C) fun x => by simp [hC x]).trans_lt
+    (memLp_const_enorm hC_lt.ne).eLpNorm_lt_top
 
 lemma eLpNorm_count_lt_top [Finite α] (hp : p ≠ 0) :
     eLpNorm f p .count < ∞ ↔ ∀ i, ‖f i‖ₑ < ∞ :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
@@ -37,11 +37,9 @@ lemma enorm_le_eLpNorm_count (f : α → ε) (i : α) (hp : p ≠ 0) :
 omit [MeasurableSingletonClass α] in
 lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) : eLpNorm f p .count < ∞ := by
   haveI := Fintype.ofFinite α
-  let C : ℝ≥0∞ := Finset.univ.sup (‖f ·‖ₑ)
-  have hC : ∀ x, ‖f x‖ₑ ≤ C := fun x ↦ Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
-  have hC_lt : C < ∞ := by simp [C, h]
-  exact (eLpNorm_mono_enorm (g := fun _ ↦ C) fun x => by simp [hC x]).trans_lt
-    (memLp_const_enorm hC_lt.ne).eLpNorm_lt_top
+  refine (eLpNorm_mono_enorm (g := fun _ ↦ Finset.univ.sup (‖f ·‖ₑ)) ?_).trans_lt ?_
+  · exact fun x ↦ Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
+  · exact (memLp_const_enorm <| by simp [h, LT.lt.ne]).eLpNorm_lt_top
 
 lemma eLpNorm_count_lt_top [Finite α] (hp : p ≠ 0) :
     eLpNorm f p .count < ∞ ↔ ∀ i, ‖f i‖ₑ < ∞ :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
@@ -34,22 +34,17 @@ lemma enorm_le_eLpNorm_count (f : α → ε) (i : α) (hp : p ≠ 0) :
       _ = eLpNorm f p (count.restrict {i}) := by simp
       _ ≤ eLpNorm f p count := eLpNorm_restrict_le ..
 
+omit [MeasurableSingletonClass α] in
 lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) :
     eLpNorm f p .count < ∞ := by
   letI _ := Fintype.ofFinite α
-  simp_rw [eLpNorm]
-  split_ifs with h2 h3
-  · exact ENNReal.zero_lt_top
-  · refine (essSup_le_of_ae_le (Finset.univ.sup (‖f ·‖ₑ)) ?_).trans_lt ?_
-    · filter_upwards with x
-      exact Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ _)
-    · simp_rw [Finset.sup_lt_iff ENNReal.zero_lt_top, h, implies_true]
-  · refine (ENNReal.rpow_lt_top_iff_of_pos ?_).mpr ?_
-    · rw [one_div, inv_pos]
-      exact ENNReal.toReal_pos h2 h3
-    · simp_rw [lintegral_count, tsum_eq_sum (s := Finset.univ) (by simp), ENNReal.sum_lt_top,
-        Finset.mem_univ, forall_const, ENNReal.rpow_lt_top_iff_of_pos (ENNReal.toReal_pos h2 h3), h,
-        implies_true]
+  let C : ℝ≥0∞ := Finset.univ.sup (‖f ·‖ₑ)
+  have hC : ∀ x, ‖f x‖ₑ ≤ C := fun x => Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
+  have hC_lt : C < ∞ := by
+    simp [C, Finset.sup_lt_iff, h]
+  refine (eLpNorm_mono_enorm (μ := (count : Measure α)) (p := p) (f := f)
+    (g := fun _ : α => C) fun x => by simpa [C] using hC x).trans_lt ?_
+  exact (memLp_const_enorm (μ := (count : Measure α)) (p := p) (c := C) hC_lt.ne).eLpNorm_lt_top
 
 lemma eLpNorm_count_lt_top [Finite α] (hp : p ≠ 0) :
     eLpNorm f p .count < ∞ ↔ ∀ i, ‖f i‖ₑ < ∞ :=

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -89,7 +89,7 @@ theorem piContent_eq_measure_pi [Fintype ι] {s : Set (Π i, X i)} (hs : Measura
   have : s = cylinder univ (MeasurableEquiv.piCongrLeft X e ⁻¹' s) := rfl
   nth_rw 1 [this]
   dsimp [e]
-  rw [piContent_cylinder _ (hs.preimage (by fun_prop)), ← Measure.pi_map_piCongrLeft e,
+  rw [piContent_cylinder _ (hs.preimage (by fun_prop)), ← MeasureTheory.pi_map_piCongrLeft e,
     ← Measure.map_apply (by fun_prop) hs]; rfl
 
 end Preliminaries


### PR DESCRIPTION
This selectively ports part of #38104.

Included files only:
- `Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean`
- `Mathlib/MeasureTheory/Constructions/Pi.lean`
- `Mathlib/Probability/ProductMeasure.lean`

Concretely, it does three things.
- In `Mathlib/MeasureTheory/Constructions/Pi.lean`, it rewrites `pi_map_piCongrLeft` so that it is derived directly from `measurePreserving_piCongrLeft`; this removes the old `[Fintype ι']` assumption and makes the lemma more general.
- In `Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean`, it replaces a case-split proof of `eLpNorm_count_lt_top_of_lt` with a cleaner argument that bounds the function by a finite constant on a finite type and then applies general `eLpNorm` / `MemLp` lemmas; as a result, that theorem no longer needs `MeasurableSingletonClass α`.
- Finally, in `Mathlib/Probability/ProductMeasure.lean`, it updates `piContent_eq_measure_pi` to use the generalized `pi_map_piCongrLeft`.
