### PR TITLE
[Merged by Bors] - chore(RepresentationTheory): drop some useless commutativity argument

### DIFF
--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -559,7 +559,7 @@ end Action
 
 end ring
 
-section commsemiring
+section CommSemiring
 
 variable {k : Type u} {G : Type v} [CommSemiring k] [Monoid G]
 

--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -589,7 +589,7 @@ instance : Linear k (Rep k G) where
   smul_comp _ _ _ := smul_comp
   comp_smul _ _ _ := comp_smul
 
-end commsemiring
+end CommSemiring
 
 variable {k : Type u} {G : Type v} [CommRing k] [Monoid G]
 

--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -559,7 +559,9 @@ end Action
 
 end ring
 
-variable {k : Type u} {G : Type v} [CommRing k] [Monoid G]
+section commsemiring
+
+variable {k : Type u} {G : Type v} [CommSemiring k] [Monoid G]
 
 instance {M N : Rep k G} : SMul k (M ⟶ N) where
   smul r f := ofHom (r • f.hom)
@@ -587,8 +589,13 @@ instance : Linear k (Rep k G) where
   smul_comp _ _ _ := smul_comp
   comp_smul _ _ _ := comp_smul
 
+end commsemiring
+
+variable {k : Type u} {G : Type v} [CommRing k] [Monoid G]
+
 set_option backward.isDefEq.respectTransparency false in
-instance : Functor.Linear k (forget₂ (Rep.{w} k G) (ModuleCat.{w} k)) where
+instance : Functor.Linear k (forget₂ (Rep.{w} k G)
+    (ModuleCat.{w} k)) where
   map_smul {X Y} f r := by
     ext
     simp [smul_hom]

--- a/Mathlib/RepresentationTheory/Rep/Basic.lean
+++ b/Mathlib/RepresentationTheory/Rep/Basic.lean
@@ -594,8 +594,7 @@ end commsemiring
 variable {k : Type u} {G : Type v} [CommRing k] [Monoid G]
 
 set_option backward.isDefEq.respectTransparency false in
-instance : Functor.Linear k (forget₂ (Rep.{w} k G)
-    (ModuleCat.{w} k)) where
+instance : Functor.Linear k (forget₂ (Rep.{w} k G) (ModuleCat.{w} k)) where
   map_smul {X Y} f r := by
     ext
     simp [smul_hom]

--- a/Mathlib/RepresentationTheory/Rep/Res.lean
+++ b/Mathlib/RepresentationTheory/Rep/Res.lean
@@ -19,7 +19,7 @@ Given a group homomorphism `f : H →* G`, we have the restriction functor
 
 universe t w u v v1 v2
 
-variable {k : Type u} [CommRing k] {G : Type v1} {H : Type v2} [Monoid G] [Monoid H]
+variable {k : Type u} [Semiring k] {G : Type v1} {H : Type v2} [Monoid G] [Monoid H]
 
 open CategoryTheory
 
@@ -72,7 +72,7 @@ instance : (resFunctor (k := k) f).Additive where
     simp only [add_hom, Representation.IntertwiningMap.add_toLinearMap]
     rfl
 
-instance : (resFunctor (k := k) f).Linear k where
+instance {k : Type u} [CommSemiring k] : (resFunctor (k := k) f).Linear k where
   map_smul {X Y} l r := by
     ext : 2;
     rw [smul_hom, Representation.IntertwiningMap.toLinearMap_smul,


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
