### PR TITLE
fix: properly tag structures with the stacks tag

### DIFF
--- a/Mathlib/Algebra/Field/Subfield/Defs.lean
+++ b/Mathlib/Algebra/Field/Subfield/Defs.lean
@@ -128,12 +128,13 @@ instance (priority := 75) toField {K} [Field K] [SetLike S K] [SubfieldClass S K
 end SubfieldClass
 
 /-- `Subfield R` is the type of subfields of `R`. A subfield of `R` is a subset `s` that is a
-  multiplicative submonoid and an additive subgroup. Note in particular that it shares the
-  same 0 and 1 as R. -/
-@[stacks 09FD "second part"]
+multiplicative submonoid and an additive subgroup. Note in particular that it shares the
+same 0 and 1 as R. -/
 structure Subfield (K : Type u) [DivisionRing K] extends Subring K where
   /-- A subfield is closed under multiplicative inverses. -/
   inv_mem' : ∀ x ∈ carrier, x⁻¹ ∈ carrier
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 09FD "second part"] Subfield
 
 /-- Reinterpret a `Subfield` as a `Subring`. -/
 add_decl_doc Subfield.toSubring

--- a/Mathlib/AlgebraicGeometry/RelativeGluing.lean
+++ b/Mathlib/AlgebraicGeometry/RelativeGluing.lean
@@ -70,13 +70,14 @@ transformation.
 The `Xᵢ` then glue to a scheme over `S`
 (see `AlgebraicGeometry.Scheme.Cover.RelativeGluingData.glued`).
 -/
-@[stacks 01LH]
 structure RelativeGluingData where
   /-- The schemes `Xᵢ`. -/
   functor : 𝒰.I₀ ⥤ Scheme.{u}
   /-- The natural maps `Xᵢ ⟶ Uᵢ`. -/
   natTrans : functor ⟶ 𝒰.functorOfLocallyDirected
   equifibered : natTrans.Equifibered
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 01LH] RelativeGluingData
 
 variable {𝒰} (d : RelativeGluingData 𝒰)
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -105,7 +105,6 @@ hom set equivalence.
 
 To construct adjoints to a given functor, there are constructors `leftAdjointOfEquiv` and
 `adjunctionOfEquivLeft` (as well as their duals). -/
-@[stacks 0037]
 structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   /-- The unit of an adjunction -/
   unit : 𝟭 C ⟶ F.comp G
@@ -117,6 +116,8 @@ structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   /-- Equality of the composition of the unit and counit with the identity `G ⟶ GFG ⟶ G = 𝟙` -/
   right_triangle_components (Y : D) :
     dsimp% unit.app (G.obj Y) ≫ G.map (counit.app Y) = 𝟙 (G.obj Y) := by cat_disch
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 0037] Adjunction
 
 /-- The notation `F ⊣ G` stands for `Adjunction F G` representing that `F` is left adjoint to `G` -/
 infixl:15 " ⊣ " => Adjunction

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -36,7 +36,6 @@ To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map 
 
 The axiom `map_id` expresses preservation of identities, and
 `map_comp` expresses functoriality. -/
-@[stacks 001B]
 structure Functor (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D] :
     Type max v₁ v₂ u₁ u₂ where
   /-- The action of a functor on objects. -/
@@ -47,6 +46,8 @@ structure Functor (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.
   map_id : ∀ X : C, map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   /-- A functor preserves composition. -/
   map_comp : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map (f ≫ g) = map f ≫ map g := by cat_disch
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 001B] Functor
 
 /-- Notation for a functor between categories. -/
 -- A functor is basically a function, so give ⥤ a similar precedence to → (25).

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -49,7 +49,6 @@ The inverse morphism is bundled.
 
 See also `CategoryTheory.Core` for the category with the same objects and isomorphisms playing
 the role of morphisms. -/
-@[stacks 0017]
 structure Iso {C : Type u} [Category.{v} C] (X Y : C) where
   /-- The forward direction of an isomorphism. -/
   hom : X ⟶ Y
@@ -60,6 +59,8 @@ structure Iso {C : Type u} [Category.{v} C] (X Y : C) where
   /-- Composition of the two directions of an isomorphism in reverse order
   is the identity on the target. -/
   inv_hom_id : inv ≫ hom = 𝟙 Y := by cat_disch
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 0017] Iso
 
 attribute [to_dual existing inv] Iso.hom
 attribute [to_dual self] Iso.mk Iso.casesOn

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -49,9 +49,7 @@ variable {J : Type u₁} [Category.{v₁} J] {K : Type u₂} [Category.{v₂} K]
 variable {C : Type u₃} [Category.{v₃} C]
 variable {F : J ⥤ C}
 
-/-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
-cone morphism to `t`. -/
-@[stacks 002E]
+/-- A cone `t` on `F` is a limit cone if each cone on `F` admits a unique cone morphism to `t`. -/
 structure IsLimit (t : Cone F) where
   /-- There is a morphism from any cone point to `t.pt` -/
   lift : ∀ s : Cone F, s.pt ⟶ t.pt
@@ -60,6 +58,8 @@ structure IsLimit (t : Cone F) where
   /-- It is the unique such map to do this -/
   uniq : ∀ (s : Cone F) (m : s.pt ⟶ t.pt) (_ : ∀ j : J, m ≫ t.π.app j = s.π.app j), m = lift s := by
     cat_disch
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 002E] IsLimit
 
 attribute [reassoc (attr := simp)] IsLimit.fac
 
@@ -525,7 +525,6 @@ end IsLimit
 
 /-- A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
 cocone morphism from `t`. -/
-@[stacks 002F]
 structure IsColimit (t : Cocone F) where
   /-- `t.pt` maps to all other cocone covertices -/
   desc : ∀ s : Cocone F, t.pt ⟶ s.pt
@@ -535,6 +534,8 @@ structure IsColimit (t : Cocone F) where
   uniq :
     ∀ (s : Cocone F) (m : t.pt ⟶ s.pt) (_ : ∀ j : J, t.ι.app j ≫ m = s.ι.app j), m = desc s := by
     cat_disch
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 002F] IsColimit
 
 attribute [reassoc (attr := simp)] IsColimit.fac
 

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -72,7 +72,6 @@ three axioms:
 A sieve `S` on `X` is referred to as `J`-covering, (or just covering), if `S ∈ J X`.
 
 See also [nlab] or [MM92] Chapter III, Section 2, Definition 1. -/
-@[stacks 00Z4]
 structure GrothendieckTopology where
   /-- A Grothendieck topology on `C` consists of a set of sieves for each object `X`,
   which satisfy some axioms. -/
@@ -86,6 +85,8 @@ structure GrothendieckTopology where
   transitive' :
     ∀ ⦃X⦄ ⦃S : Sieve X⦄ (_ : S ∈ sieves X) (R : Sieve X),
       (∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → R.pullback f ∈ sieves Y) → R ∈ sieves X
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 00Z4] GrothendieckTopology
 
 namespace GrothendieckTopology
 

--- a/Mathlib/CategoryTheory/Sites/Point/Conservative.lean
+++ b/Mathlib/CategoryTheory/Sites/Point/Conservative.lean
@@ -43,15 +43,15 @@ variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
 
 namespace ObjectProperty
 
-/-- Let `P : ObjectProperty J.Point` a family of points of a
-site `(C, J)`). We say that it is a conservative family of points
-if the corresponding fiber functors `Sheaf J (Type w) ⥤ Type w`
-jointly reflect isomorphisms. -/
-@[stacks 00YK "(1)"]
+/-- Let `P : ObjectProperty J.Point` a family of points of a site `(C, J)`).
+We say that it is a conservative family of points
+if the corresponding fiber functors `Sheaf J (Type w) ⥤ Type w` jointly reflect isomorphisms. -/
 structure IsConservativeFamilyOfPoints : Prop where
   jointlyReflectIsomorphisms_type :
     JointlyReflectIsomorphisms
       (fun (Φ : P.FullSubcategory) ↦ Φ.obj.sheafFiber (A := Type w))
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 00YK "(1)"] IsConservativeFamilyOfPoints
 
 namespace IsConservativeFamilyOfPoints
 

--- a/Mathlib/CategoryTheory/Triangulated/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Basic.lean
@@ -40,7 +40,6 @@ variable (C : Type u) [Category.{v} C] [HasShift C ℤ]
 
 /-- A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`,
 and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`. -/
-@[stacks 0144]
 structure Triangle where mk' ::
   /-- the first object of a triangle -/
   obj₁ : C
@@ -54,6 +53,8 @@ structure Triangle where mk' ::
   mor₂ : obj₂ ⟶ obj₃
   /-- the third morphism of a triangle -/
   mor₃ : obj₃ ⟶ obj₁⟦(1 : ℤ)⟧
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 0144] Triangle
 
 variable {C}
 

--- a/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
@@ -67,7 +67,6 @@ a distinguished triangle and the completed diagram commutes:
               w₁₂
 ```
 -/
-@[stacks 05QK]
 structure Octahedron
   {X₁ X₂ X₃ Z₁₂ Z₂₃ Z₁₃ : C}
   {u₁₂ : X₁ ⟶ X₂} {u₂₃ : X₂ ⟶ X₃} {u₁₃ : X₁ ⟶ X₃} (comm : u₁₂ ≫ u₂₃ = u₁₃)
@@ -83,6 +82,8 @@ structure Octahedron
   comm₃ : v₁₃ ≫ m₃ = v₂₃
   comm₄ : w₁₃ ≫ u₁₂⟦1⟧' = m₃ ≫ w₂₃
   mem : Triangle.mk m₁ m₃ (w₂₃ ≫ v₁₂⟦1⟧') ∈ distTriang C
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 05QK]
 
 instance (X : C) :
     Nonempty (Octahedron (comp_id (𝟙 X)) (contractible_distinguished X)

--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -34,10 +34,11 @@ variable {R : Type*} [CommSemiring R]
 /-- A predicate `P : Ideal R → Prop` over the ideals of a ring `R` is said to be Oka if R satisfies
 it (`P ⊤`) and whenever we have `I : Ideal R`, `P (I.colon (span {a})` and `P (I ⊔ span {a})` for
 some `a : R` then `P I`. -/
-@[stacks 05K9]
 structure IsOka (P : Ideal R → Prop) : Prop where
   top : P ⊤
   oka {I : Ideal R} {a : R} : P (I ⊔ span {a}) → P (I.colon (span {a})) → P I
+-- TODO: @[stacks] doesn't work on structures and classes
+attribute [stacks 05K9] IsOka
 
 namespace IsOka
 

--- a/Mathlib/Topology/Spectral/Hom.lean
+++ b/Mathlib/Topology/Spectral/Hom.lean
@@ -39,11 +39,11 @@ variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ] {f : 
 
 /-- A function between topological spaces is spectral if it is continuous and the preimage of every
 compact open set is compact open. -/
-@[stacks 005A, stacks 08YG]
 structure IsSpectralMap (f : α → β) : Prop extends Continuous f where
   /-- A function between topological spaces is spectral if it is continuous and the preimage of
   every compact open set is compact open. -/
   isCompact_preimage_of_isOpen ⦃s : Set β⦄ : IsOpen s → IsCompact s → IsCompact (f ⁻¹' s)
+attribute [stacks 005A, stacks 08YG] IsSpectralMap
 
 theorem IsCompact.preimage_of_isOpen (hf : IsSpectralMap f) (h₀ : IsCompact s) (h₁ : IsOpen s) :
     IsCompact (f ⁻¹' s) :=


### PR DESCRIPTION
Currently, tagging a structure or class with the stacks or kerodon attribute [has no effect](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Tagging.20a.20class.20with.20.40stacks.20attribute.20has.20no.20effect/with/585908804)

To demonstrate the issue, we manually fix all stacks tags on structures.
There are 37 further instances of @[stacks] on classes, and 6 misplaced Kerodon tags;
these are left to a future PR.

---

Arguably, the stacks attribute should be fixed instead.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
