### PR TITLE
chore(Data/Analysis/Filter): golf CFilter.ofEquiv_val to rfl

### DIFF
--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -70,8 +70,7 @@ def ofEquiv (E : σ ≃ τ) : CFilter α σ → CFilter α τ
       inf_le_right := fun a b ↦ by simpa using h₂ (E.symm a) (E.symm b) }
 
 @[simp]
-theorem ofEquiv_val (E : σ ≃ τ) (F : CFilter α σ) (a : τ) : F.ofEquiv E a = F (E.symm a) := by
-  cases F; rfl
+theorem ofEquiv_val (E : σ ≃ τ) (F : CFilter α σ) (a : τ) : F.ofEquiv E a = F (E.symm a) := rfl
 
 end
 


### PR DESCRIPTION
---

cases F is unnecessary, the result holds definitionally.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
