### PR TITLE
add subsingleton case to ExpChar

### DIFF
--- a/Mathlib/Algebra/CharP/Algebra.lean
+++ b/Mathlib/Algebra/CharP/Algebra.lean
@@ -95,34 +95,36 @@ protected theorem RingHom.charP_iff [NonAssocSemiring R] [NonAssocSemiring A]
 as `R`. -/
 lemma expChar_of_injective_ringHom
     [NonAssocSemiring R] [NonAssocSemiring A] {f : R →+* A} (h : Function.Injective f)
-    (q : ℕ) [hR : ExpChar R q] : ExpChar A q := by
-  rcases hR with _ | hprime
+    (q : ℕ) [hR : ExpChar R q] [Nontrivial R] : ExpChar A q := by
+  rcases hR with _ | _ | hprime
+  · exfalso; exact false_of_nontrivial_of_subsingleton R
   · haveI := charZero_of_injective_ringHom h; exact .zero
-  haveI := charP_of_injective_ringHom h q; exact .prime hprime
+  · haveI := charP_of_injective_ringHom h q; exact .prime hprime
 
 /-- If `R →+* A` is injective, and `A` is of exponential characteristic `p`, then `R` is also of
 exponential characteristic `p`. Similar to `RingHom.charZero`. -/
 lemma RingHom.expChar [NonAssocSemiring R] [NonAssocSemiring A] (f : R →+* A)
     (H : Function.Injective f) (p : ℕ) [ExpChar A p] : ExpChar R p := by
   cases ‹ExpChar A p› with
+  | subsingleton => have := Function.Injective.subsingleton H; exact .subsingleton p
   | zero => haveI := f.charZero; exact .zero
   | prime hp => haveI := f.charP H p; exact .prime hp
 
 /-- If `R →+* A` is injective, then `R` is of exponential characteristic `p` if and only if `A` is
 also of exponential characteristic `p`. Similar to `RingHom.charZero_iff`. -/
 lemma RingHom.expChar_iff [NonAssocSemiring R] [NonAssocSemiring A] (f : R →+* A)
-    (H : Function.Injective f) (p : ℕ) : ExpChar R p ↔ ExpChar A p :=
+    (H : Function.Injective f) (p : ℕ) [Nontrivial R] : ExpChar R p ↔ ExpChar A p :=
   ⟨fun _ ↦ expChar_of_injective_ringHom H p, fun _ ↦ f.expChar H p⟩
 
 /-- If the algebra map `R →+* A` is injective then `A` has the same exponential characteristic
 as `R`. -/
 lemma expChar_of_injective_algebraMap [CommSemiring R] [Semiring A] [Algebra R A]
-    (h : Function.Injective (algebraMap R A)) (q : ℕ) [ExpChar R q] : ExpChar A q :=
+    (h : Function.Injective (algebraMap R A)) (q : ℕ) [ExpChar R q] [Nontrivial R] : ExpChar A q :=
   expChar_of_injective_ringHom h q
 
 variable (R) in
 theorem ExpChar.of_injective_algebraMap' [CommRing R] [CommRing A]
-    [Algebra R A] [FaithfulSMul R A] (q : ℕ) [ExpChar R q] : ExpChar A q :=
+    [Algebra R A] [FaithfulSMul R A] (q : ℕ) [ExpChar R q] [Nontrivial R] : ExpChar A q :=
   expChar_of_injective_ringHom (FaithfulSMul.algebraMap_injective R A) q
 
 namespace Subfield

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -200,12 +200,38 @@ end Fin
 section AddMonoidWithOne
 variable [AddMonoidWithOne R]
 
-instance (S : Type*) [Semiring S] (p) [ExpChar R p] [ExpChar S p] : ExpChar (R × S) p := by
-  obtain hp | ⟨hp⟩ := ‹ExpChar R p›
+-- TODO: fix this
+instance (S : Type*) [AddMonoidWithOne S] (p) [ExpChar R p] [ExpChar S p] : ExpChar (R × S) p := by
+  obtain _ | hp | ⟨hp⟩ := ‹ExpChar R p›
+  · obtain _ | _ | ⟨hp⟩ := ‹ExpChar S p›
+    · exact .subsingleton p
+    · constructor
+    · apply @ExpChar.prime _ _ p hp ?_
+      constructor
+      intro x
+      rw [← CharP.cast_eq_zero_iff S]
+      constructor
+      · intro h
+        simpa using congrArg Prod.snd h
+      · intro h
+        ext
+        · subsingleton
+        · exact h
   · constructor
-  obtain _ | _ := ‹ExpChar S p›
-  · exact (Nat.not_prime_one hp).elim
-  · have := Prod.charP R S p; exact .prime hp
+  · obtain _ | _ | _ := ‹ExpChar S p›
+    · apply @ExpChar.prime _ _ p hp ?_
+      constructor
+      intro x
+      rw [← CharP.cast_eq_zero_iff R]
+      constructor
+      · intro h
+        simpa using congrArg Prod.fst h
+      · intro h
+        ext
+        · exact h
+        · subsingleton
+    · exact (Nat.not_prime_one hp).elim
+    · have := Prod.charP R S p; exact .prime hp
 
 end AddMonoidWithOne
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -400,7 +400,7 @@ noncomputable def ringExpChar : ℕ := max (ringChar R) 1
 
 lemma ringExpChar.eq (q : ℕ) [h : ExpChar R q] [Nontrivial R] : ringExpChar R = q := by
   rcases h with _ | _ | h
-  · exfalso ; exact false_of_nontrivial_of_subsingleton R
+  · exact (false_of_nontrivial_of_subsingleton R).elim
   · haveI := CharP.ofCharZero R
     rw [ringExpChar, ringChar.eq R 0]; rfl
   rw [ringExpChar, ringChar.eq R q]
@@ -416,7 +416,7 @@ variable [Nontrivial R]
 lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] :
     p = 0 := by
   cases hq
-  · exfalso ; exact false_of_nontrivial_of_subsingleton R
+  · exact (false_of_nontrivial_of_subsingleton R).elim
   · exact CharP.eq R hp (.ofCharZero R)
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 
@@ -424,7 +424,7 @@ lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] :
 /-- The characteristic is zero if the exponential characteristic is one. -/
 lemma charZero_of_expChar_one' [hq : ExpChar R 1] : CharZero R := by
   cases hq
-  · exfalso ; exact false_of_nontrivial_of_subsingleton R
+  · exact (false_of_nontrivial_of_subsingleton R).elim
   · assumption
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -91,6 +91,11 @@ lemma eq {p q : ℕ} (hp : CharP R p) (hq : CharP R q) : p = q :=
 instance ofCharZero [CharZero R] : CharP R 0 where
   cast_eq_zero_iff x := by rw [zero_dvd_iff, ← Nat.cast_zero, Nat.cast_inj]
 
+variable {R} in
+lemma nontrivial_of_char_ne_one {v : ℕ} (hv : v ≠ 1) [hr : CharP R v] : Nontrivial R :=
+  ⟨⟨(1 : ℕ), 0, fun h =>
+      hv <| by rwa [CharP.cast_eq_zero_iff _ v, Nat.dvd_one] at h⟩⟩
+
 end AddMonoidWithOne
 
 section AddGroupWithOne
@@ -290,10 +295,6 @@ lemma false_of_nontrivial_of_char_one [Nontrivial R] [CharP R 1] : False := by
 lemma ringChar_ne_one [Nontrivial R] : ringChar R ≠ 1 := by
   simpa using not_subsingleton R
 
-lemma nontrivial_of_char_ne_one {v : ℕ} (hv : v ≠ 1) [hr : CharP R v] : Nontrivial R :=
-  ⟨⟨(1 : ℕ), 0, fun h =>
-      hv <| by rwa [CharP.cast_eq_zero_iff _ v, Nat.dvd_one] at h⟩⟩
-
 end NonAssocSemiring
 end CharP
 
@@ -326,56 +327,67 @@ variable [AddMonoidWithOne R]
 
 /-- The definition of the exponential characteristic of a semiring. -/
 class inductive ExpChar : ℕ → Prop
+  | subsingleton (q : ℕ) [Subsingleton R] : ExpChar q
   | zero [CharZero R] : ExpChar 1
   | prime {q : ℕ} (hprime : q.Prime) [hchar : CharP R q] : ExpChar q
 
 instance expChar_prime (p) [CharP R p] [Fact p.Prime] : ExpChar R p := ExpChar.prime Fact.out
 instance expChar_one [CharZero R] : ExpChar R 1 := ExpChar.zero
 
-lemma expChar_ne_zero (p : ℕ) [hR : ExpChar R p] : p ≠ 0 := by
+lemma expChar_ne_zero (p : ℕ) [Nontrivial R] [hR : ExpChar R p] : p ≠ 0 := by
   cases hR
+  · exfalso
+    exact (false_of_nontrivial_of_subsingleton R).elim
   · exact one_ne_zero
   · exact ‹p.Prime›.ne_zero
 
 variable {R} in
 /-- The exponential characteristic is unique. -/
-lemma ExpChar.eq {p q : ℕ} (hp : ExpChar R p) (hq : ExpChar R q) : p = q := by
-  rcases hp with ⟨hp⟩ | ⟨hp'⟩
-  · rcases hq with hq | hq'
-    exacts [rfl, False.elim (Nat.not_prime_zero (CharP.eq R ‹_› (CharP.ofCharZero R) ▸ hq'))]
-  · rcases hq with hq | hq'
-    exacts [False.elim (Nat.not_prime_zero (CharP.eq R ‹_› (CharP.ofCharZero R) ▸ hp')),
+lemma ExpChar.eq {p q : ℕ} (hp : ExpChar R p) (hq : ExpChar R q) [Nontrivial R] : p = q := by
+  rcases hp with _ | ⟨hp⟩ | ⟨hp'⟩
+  · exact (false_of_nontrivial_of_subsingleton R).elim
+  · rcases hq with _ | hq | hq'
+    exacts [(false_of_nontrivial_of_subsingleton R).elim, rfl,
+      False.elim (Nat.not_prime_zero (CharP.eq R ‹_› (CharP.ofCharZero R) ▸ hq'))]
+  · rcases hq with _ | hq | hq'
+    exacts [(false_of_nontrivial_of_subsingleton R).elim,
+      False.elim (Nat.not_prime_zero (CharP.eq R ‹_› (CharP.ofCharZero R) ▸ hp')),
       CharP.eq R ‹_› ‹_›]
 
 lemma ExpChar.congr {p : ℕ} (q : ℕ) [hq : ExpChar R q] (h : q = p) : ExpChar R p := h ▸ hq
 
 /-- The exponential characteristic is one if the characteristic is zero. -/
 lemma expChar_one_of_char_zero (q : ℕ) [hp : CharP R 0] [hq : ExpChar R q] : q = 1 := by
-  rcases hq with q | hq_prime
+  rcases hq with _ | q | hq_prime
+  · exact (not_nontrivial R <| CharP.nontrivial_of_char_ne_one <| by decide).elim
   · rfl
   · exact False.elim <| hq_prime.ne_zero <| ‹CharP R q›.eq R hp
 
 /-- The characteristic equals the exponential characteristic iff the former is prime. -/
-lemma char_eq_expChar_iff (p q : ℕ) [hp : CharP R p] [hq : ExpChar R q] : p = q ↔ p.Prime := by
-  rcases hq with q | hq_prime
+lemma char_eq_expChar_iff (p q : ℕ) [hp : CharP R p] [hq : ExpChar R q] [Nontrivial R] :
+    p = q ↔ p.Prime := by
+  rcases hq with _ | q | hq_prime
+  · exact (false_of_nontrivial_of_subsingleton R).elim
   · rw [(CharP.eq R hp (.ofCharZero R) : p = 0)]
     decide
   · exact ⟨fun hpq => hpq.symm ▸ hq_prime, fun _ => CharP.eq R hp ‹CharP R q›⟩
 
 /-- The exponential characteristic is a prime number or one.
 See also `CharP.char_is_prime_or_zero`. -/
-lemma expChar_is_prime_or_one (q : ℕ) [hq : ExpChar R q] : Nat.Prime q ∨ q = 1 := by
+lemma expChar_is_prime_or_one (q : ℕ) [hq : ExpChar R q] [Nontrivial R] :
+    Nat.Prime q ∨ q = 1 := by
   cases hq with
+  | subsingleton q => exact (false_of_nontrivial_of_subsingleton R).elim
   | zero => exact .inr rfl
   | prime hp => exact .inl hp
 
 /-- The exponential characteristic is positive. -/
-lemma expChar_pos (q : ℕ) [ExpChar R q] : 0 < q := by
+lemma expChar_pos (q : ℕ) [ExpChar R q] [Nontrivial R] : 0 < q := by
   rcases expChar_is_prime_or_one R q with h | rfl
   exacts [Nat.Prime.pos h, Nat.one_pos]
 
 /-- Any power of the exponential characteristic is positive. -/
-lemma expChar_pow_pos (q : ℕ) [ExpChar R q] (n : ℕ) : 0 < q ^ n :=
+lemma expChar_pow_pos (q : ℕ) [ExpChar R q] [Nontrivial R] (n : ℕ) : 0 < q ^ n :=
   Nat.pow_pos (expChar_pos R q)
 
 end AddMonoidWithOne
@@ -386,8 +398,9 @@ variable [NonAssocSemiring R]
 /-- Noncomputable function that outputs the unique exponential characteristic of a semiring. -/
 noncomputable def ringExpChar : ℕ := max (ringChar R) 1
 
-lemma ringExpChar.eq (q : ℕ) [h : ExpChar R q] : ringExpChar R = q := by
-  rcases h with _ | h
+lemma ringExpChar.eq (q : ℕ) [h : ExpChar R q] [Nontrivial R] : ringExpChar R = q := by
+  rcases h with _ | _ | h
+  · exfalso ; exact false_of_nontrivial_of_subsingleton R
   · haveI := CharP.ofCharZero R
     rw [ringExpChar, ringChar.eq R 0]; rfl
   rw [ringExpChar, ringChar.eq R q]
@@ -400,8 +413,10 @@ section Nontrivial
 variable [Nontrivial R]
 
 /-- The exponential characteristic is one if the characteristic is zero. -/
-lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] : p = 0 := by
+lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] :
+    p = 0 := by
   cases hq
+  · exfalso ; exact false_of_nontrivial_of_subsingleton R
   · exact CharP.eq R hp (.ofCharZero R)
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 
@@ -409,6 +424,7 @@ lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] : p
 /-- The characteristic is zero if the exponential characteristic is one. -/
 lemma charZero_of_expChar_one' [hq : ExpChar R 1] : CharZero R := by
   cases hq
+  · exfalso ; exact false_of_nontrivial_of_subsingleton R
   · assumption
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 

--- a/Mathlib/Algebra/CharP/Lemmas.lean
+++ b/Mathlib/Algebra/CharP/Lemmas.lean
@@ -324,15 +324,13 @@ variable (p n : ℕ) [ExpChar R p]
 /-- The Frobenius map `x ↦ x ^ p`. -/
 def frobenius : R →+* R where
   __ := powMonoidHom p
-  map_zero' := by
-    nontriviality
-    exact zero_pow (expChar_pos R p).ne'
+  map_zero' := by nontriviality; exact zero_pow (expChar_pos R p).ne'
   map_add' _ _ := add_pow_expChar ..
 
 /-- The iterated Frobenius map `x ↦ x ^ p ^ n`. -/
 def iterateFrobenius : R →+* R where
   __ := powMonoidHom (p ^ n)
-  map_zero' := by nontriviality ; exact zero_pow (expChar_pow_pos R p n).ne'
+  map_zero' := by nontriviality; exact zero_pow (expChar_pow_pos R p n).ne'
   map_add' _ _ := add_pow_expChar_pow ..
 
 variable {R}

--- a/Mathlib/Algebra/CharP/Lemmas.lean
+++ b/Mathlib/Algebra/CharP/Lemmas.lean
@@ -119,14 +119,16 @@ section ExpChar
 variable [hR : ExpChar R p]
 
 lemma add_pow_expChar_of_commute (h : Commute x y) : (x + y) ^ p = x ^ p + y ^ p := by
-  obtain _ | hprime := hR
+  obtain _ | _ | hprime := hR
+  · subsingleton
   · simp only [pow_one]
   · let ⟨r, hr⟩ := h.exists_add_pow_prime_eq hprime
     simp [hr]
 
 lemma add_pow_expChar_pow_of_commute (h : Commute x y) :
     (x + y) ^ p ^ n = x ^ p ^ n + y ^ p ^ n := by
-  obtain _ | hprime := hR
+  obtain _ | _ | hprime := hR
+  · subsingleton
   · simp only [one_pow, pow_one]
   · let ⟨r, hr⟩ := h.exists_add_pow_prime_pow_eq hprime n
     simp [hr]
@@ -204,12 +206,14 @@ lemma sub_pow_eq_mul_pow_sub_pow_div_expChar_of_commute (h : Commute x y) :
 variable (R)
 
 lemma neg_one_pow_expChar : (-1 : R) ^ p = -1 := by
+  nontriviality
   rw [eq_neg_iff_add_eq_zero]
   nth_rw 2 [← one_pow p]
   rw [← add_pow_expChar_of_commute _ (Commute.one_right _), neg_add_cancel,
     zero_pow (expChar_ne_zero R p)]
 
 lemma neg_one_pow_expChar_pow : (-1 : R) ^ p ^ n = -1 := by
+  nontriviality
   rw [eq_neg_iff_add_eq_zero]
   nth_rw 2 [← one_pow (p ^ n)]
   rw [← add_pow_expChar_pow_of_commute _ _ (Commute.one_right _), neg_add_cancel,
@@ -320,13 +324,15 @@ variable (p n : ℕ) [ExpChar R p]
 /-- The Frobenius map `x ↦ x ^ p`. -/
 def frobenius : R →+* R where
   __ := powMonoidHom p
-  map_zero' := zero_pow (expChar_pos R p).ne'
+  map_zero' := by
+    nontriviality
+    exact zero_pow (expChar_pos R p).ne'
   map_add' _ _ := add_pow_expChar ..
 
 /-- The iterated Frobenius map `x ↦ x ^ p ^ n`. -/
 def iterateFrobenius : R →+* R where
   __ := powMonoidHom (p ^ n)
-  map_zero' := zero_pow (expChar_pow_pos R p n).ne'
+  map_zero' := by nontriviality ; exact zero_pow (expChar_pow_pos R p n).ne'
   map_add' _ _ := add_pow_expChar_pow ..
 
 variable {R}

--- a/Mathlib/Algebra/CharP/Subring.lean
+++ b/Mathlib/Algebra/CharP/Subring.lean
@@ -47,7 +47,8 @@ end CharP
 namespace ExpChar
 
 theorem expChar_center_iff {R : Type u} [Ring R] {p : ℕ} :
-    ExpChar (Subring.center R) p ↔ ExpChar R p :=
-  (algebraMap (Subring.center R) R).expChar_iff Subtype.val_injective p
+    ExpChar (Subring.center R) p ↔ ExpChar R p := by
+  nontriviality R using ExpChar.subsingleton
+  exact (algebraMap (Subring.center R) R).expChar_iff Subtype.val_injective p
 
 end ExpChar

--- a/Mathlib/Algebra/Polynomial/Expand.lean
+++ b/Mathlib/Algebra/Polynomial/Expand.lean
@@ -255,7 +255,8 @@ variable [ExpChar R p]
 
 theorem expand_contract' [NoZeroDivisors R] {f : R[X]} (hf : Polynomial.derivative f = 0) :
     expand R p (contract p f) = f := by
-  obtain _ | @⟨_, hprime, hchar⟩ := ‹ExpChar R p›
+  obtain _ | _ | @⟨_, hprime, hchar⟩ := ‹ExpChar R p›
+  · subsingleton
   · rw [expand_one, contract_one]
   · haveI := Fact.mk hchar; exact expand_contract p hf hprime.ne_zero
 
@@ -295,6 +296,7 @@ theorem rootMultiplicity_expand_pow :
   obtain rfl | h0 := eq_or_ne f 0; · simp
   obtain ⟨g, hg, ndvd⟩ := f.exists_eq_pow_rootMultiplicity_mul_and_not_dvd h0 (r ^ p ^ n)
   rw [dvd_iff_isRoot, ← eval_X (x := r), ← eval_pow, ← isRoot_comp, ← expand_eq_comp_X_pow] at ndvd
+  nontriviality R using rootMultiplicity_eq_multiplicity
   conv_lhs => rw [hg, map_mul, map_pow, map_sub, expand_X, expand_C, map_pow, ← sub_pow_expChar_pow,
     ← pow_mul, mul_comm, rootMultiplicity_mul_X_sub_C_pow (expand_ne_zero (expChar_pow_pos R p n)
       |>.mpr <| right_ne_zero_of_mul <| hg ▸ h0), rootMultiplicity_eq_zero ndvd, zero_add]

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -294,7 +294,8 @@ class PerfectField (K : Type*) [Field K] : Prop where
 
 lemma PerfectRing.toPerfectField (K : Type*) (p : ℕ)
     [Field K] [ExpChar K p] [PerfectRing K p] : PerfectField K := by
-  obtain hp | ⟨hp⟩ := ‹ExpChar K p›
+  obtain _ | hp | ⟨hp⟩ := ‹ExpChar K p›
+  · exact (false_of_nontrivial_of_subsingleton K).elim
   · exact ⟨Irreducible.separable⟩
   refine PerfectField.mk fun hf ↦ ?_
   rcases separable_or p hf with h | ⟨-, g, -, rfl⟩
@@ -317,7 +318,8 @@ variable [PerfectField K]
 /-- A perfect field of characteristic `p` (prime) is a perfect ring. -/
 instance toPerfectRing (p : ℕ) [hp : ExpChar K p] : PerfectRing K p := by
   refine PerfectRing.ofSurjective _ _ fun y ↦ ?_
-  rcases hp with _ | hp
+  rcases hp with _ | _ | hp
+  · exact (false_of_nontrivial_of_subsingleton K).elim
   · simp [frobenius]
   rw [← not_forall_not]
   apply mt (X_pow_sub_C_irreducible_of_prime hp)

--- a/Mathlib/FieldTheory/PurelyInseparable/Exponent.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Exponent.lean
@@ -56,7 +56,7 @@ class HasExponent : Prop where
   has_exponent : ∃ e, ∀ a, a ^ ringExpChar K ^ e ∈ (algebraMap K L).range
 
 /-- Version of `hasExponent_iff` using `ExpChar`. -/
-theorem hasExponent_iff' (p : ℕ) [ExpChar K p] :
+theorem hasExponent_iff' (p : ℕ) [ExpChar K p] [Nontrivial K] :
     HasExponent K L ↔ ∃ e, ∀ (a : L), a ^ p ^ e ∈ (algebraMap K L).range :=
   ringExpChar.eq K p ▸ hasExponent_iff K L
 
@@ -74,7 +74,7 @@ theorem exponent_def [HasExponent K L] (a : L) :
   Nat.find_spec ‹HasExponent K L›.has_exponent a
 
 /-- Version of `exponent_def` using `ExpChar`. -/
-theorem exponent_def' [HasExponent K L] (p : ℕ) [ExpChar K p] (a : L) :
+theorem exponent_def' [HasExponent K L] (p : ℕ) [ExpChar K p] [Nontrivial K] (a : L) :
     a ^ p ^ exponent K L ∈ (algebraMap K L).range :=
   ringExpChar.eq K p ▸ exponent_def K a
 
@@ -86,8 +86,8 @@ theorem exponent_min [HasExponent K L] {e : ℕ} (h : e < exponent K L) :
   not_forall.mp <| Nat.find_min ‹HasExponent K L›.has_exponent h
 
 /-- Version of `exponent_min` using `ExpChar`. -/
-theorem exponent_min' [HasExponent K L] (p : ℕ) [ExpChar K p] {e : ℕ} (h : e < exponent K L) :
-    ∃ a, a ^ p ^ e ∉ (algebraMap K L).range :=
+theorem exponent_min' [HasExponent K L] (p : ℕ) [ExpChar K p] [Nontrivial K] {e : ℕ}
+    (h : e < exponent K L) : ∃ a, a ^ p ^ e ∉ (algebraMap K L).range :=
   ringExpChar.eq K p ▸ exponent_min h
 
 end Ring
@@ -180,7 +180,8 @@ variable {K} in
 theorem elemExponent_le_of_pow_mem {a : L} {n : ℕ}
     (h : a ^ ringExpChar K ^ n ∈ (algebraMap K L).range) : elemExponent K a ≤ n := by
   let ⟨p, _⟩ := ExpChar.exists K
-  rcases ‹ExpChar K p› with _ | ⟨hp⟩
+  rcases ‹ExpChar K p› with _ | _ | ⟨hp⟩
+  · exact (false_of_nontrivial_of_subsingleton K).elim
   · exact elemExponent_eq_zero_of_charZero K a ▸ Nat.zero_le _
   · obtain ⟨y, hy⟩ := RingHom.mem_range.mp <| h
     let f := X ^ ringExpChar K ^ n - C y
@@ -217,7 +218,8 @@ variable {K} in
 instance hasExponent_of_finiteDimensional [IsPurelyInseparable K L] [FiniteDimensional K L] :
     HasExponent K L := by
   let ⟨p, _⟩ := ExpChar.exists K
-  rcases ‹ExpChar K p› with _ | ⟨hp⟩
+  rcases ‹ExpChar K p› with _ | _ | ⟨hp⟩
+  · exact (false_of_nontrivial_of_subsingleton K).elim
   · exact ⟨0, fun a ↦ surjective_algebraMap_of_isSeparable K L _⟩
   · let e := Nat.log (ringExpChar K) (Module.finrank K L)
     refine ⟨e, fun a ↦ ⟨elemReduct K a ^ ringExpChar K ^ (e - elemExponent K a), ?_⟩⟩

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -476,7 +476,8 @@ theorem natSepDegree_le_of_dvd (g : F[X]) (h1 : f ∣ g) (h2 : g ≠ 0) :
 and `f` have the same separable degree. -/
 theorem natSepDegree_expand (q : ℕ) [hF : ExpChar F q] {n : ℕ} :
     (expand F (q ^ n) f).natSepDegree = f.natSepDegree := by
-  obtain - | hprime := hF
+  obtain  _ | - | hprime := hF
+  · exact (false_of_nontrivial_of_subsingleton F).elim
   · simp only [one_pow, expand_one]
   haveI := Fact.mk hprime
   classical
@@ -573,6 +574,8 @@ theorem eq_X_pow_char_pow_sub_C_of_natSepDegree_eq_one_of_irreducible (q : ℕ) 
       (n = 0 ∨ y ∉ (frobenius F q).range) ∧ f = X ^ q ^ n - C y := by
   obtain ⟨n, y, hf⟩ := (hm.natSepDegree_eq_one_iff_of_irreducible q hi).1 h
   cases id ‹ExpChar F q› with
+  | subsingleton =>
+    exact (false_of_nontrivial_of_subsingleton F).elim
   | zero =>
     simp_rw [one_pow, pow_one] at hf ⊢
     exact ⟨0, y, .inl rfl, hf⟩

--- a/Mathlib/FieldTheory/SeparablyGenerated.lean
+++ b/Mathlib/FieldTheory/SeparablyGenerated.lean
@@ -225,6 +225,7 @@ lemma exists_isTranscendenceBasis_and_isSeparable_of_linearIndepOn_pow
     (K := k').1 hF₁irr
   contrapose coeff_ne with Hsep
   have : CharP k' p := (expChar_of_injective_algebraMap (algebraMap k k').injective p).casesOn
+    (fun _ ↦ (false_of_nontrivial_of_subsingleton k').elim)
     (fun e ↦ (e rfl).elim) (fun _ _ _ ↦ ‹_›) hp.ne_one
   obtain ⟨g, hg, eq⟩ := (((minpoly k' (a i)).separable_or p (minpoly.irreducible
     (isAlgebraic_iff_isIntegral.mp <| isAlgebraic_adjoin_iff.mpr alg))).resolve_left Hsep).2

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -74,7 +74,7 @@ section ExpChar
 variable [ExpChar R p]
 
 instance : ExpChar (MvPolynomial σ R) p := by
-  cases ‹ExpChar R p›; exacts [ExpChar.zero, ExpChar.prime ‹_›]
+  cases ‹ExpChar R p›; exacts [ExpChar.subsingleton p, ExpChar.zero, ExpChar.prime ‹_›]
 
 end ExpChar
 

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -240,6 +240,7 @@ theorem map_frobenius_expand {f : MvPowerSeries σ R} :
       MvPowerSeries.map (frobenius R p) ((trunc' R (p • n) f).expand p) := by
       simp only [MvPolynomial.map_expand, ← expand_eq_expand p hp, map_expand]
       congr
+    nontriviality R
     rw [trunc'_map, trunc'_expand, ← trunc'_trunc'_pow (Nat.one_le_iff_ne_zero.mpr
       (expChar_ne_zero R p)), ← MvPolynomial.coe_pow p, ← MvPolynomial.map_frobenius_expand, this,
         trunc'_map, trunc'_expand_trunc' p hp (le_self_nsmul (zero_le n) hp)]

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -44,7 +44,7 @@ instance instCharP (p : ℕ) [h : CharP R p] : CharP R[X] p :=
   ⟨fun n => by rw [← map_natCast C, ← C_0, C_inj, h]⟩
 
 instance instExpChar (p : ℕ) [h : ExpChar R p] : ExpChar R[X] p := by
-  cases h; exacts [ExpChar.zero, ExpChar.prime ‹_›]
+  cases h; exacts [ExpChar.subsingleton p, ExpChar.zero, ExpChar.prime ‹_›]
 
 variable (R)
 

--- a/Mathlib/RingTheory/Polynomial/SeparableDegree.lean
+++ b/Mathlib/RingTheory/Polynomial/SeparableDegree.lean
@@ -103,6 +103,7 @@ variable (q : ℕ) {f : F[X]} (hf : HasSeparableContraction q f)
 theorem _root_.Irreducible.hasSeparableContraction (q : ℕ) [hF : ExpChar F q] {f : F[X]}
     (irred : Irreducible f) : HasSeparableContraction q f := by
   cases hF
+  · exact (false_of_nontrivial_of_subsingleton F).elim
   · exact ⟨f, irred.separable, ⟨0, by rw [pow_zero, expand_one]⟩⟩
   · rcases exists_separable_of_irreducible q irred ‹q.Prime›.ne_zero with ⟨n, g, hgs, hge⟩
     exact ⟨g, hgs, n, hge⟩
@@ -125,6 +126,7 @@ theorem contraction_degree_eq_or_insep [hq : NeZero q] [CharP F q] (g g' : F[X])
 theorem IsSeparableContraction.degree_eq [hF : ExpChar F q] (g : F[X])
     (hg : IsSeparableContraction q f g) : g.natDegree = hf.degree := by
   cases hF
+  · exact (false_of_nontrivial_of_subsingleton F).elim
   · rcases hg with ⟨_, m, hm⟩
     rw [one_pow, expand_one] at hm
     rw [hf.eq_degree, hm]

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -295,6 +295,8 @@ lemma Algebra.trace_eq_zero_of_not_isSeparable (H : ¬ Algebra.IsSeparable K L) 
       cases H hn
     | succ n =>
       cases hp with
+      | subsingleton =>
+        exact (false_of_nontrivial_of_subsingleton K).elim
       | zero =>
         rw [one_pow, IntermediateField.finrank_eq_one_iff_eq_top, separableClosure.eq_top_iff] at hn
         cases H hn


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
