### PR TITLE
Illustration of a weird behaviour

### DIFF
--- a/Mathlib/Topology/Algebra/Module/Spaces/CompactConvergenceCLM.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/CompactConvergenceCLM.lean
@@ -111,17 +111,6 @@ def ContinuousLinearMap.precompCompactConvergenceCLM [IsTopologicalAddGroup G]
     [ContinuousConstSMul 𝕜₃ G] (L : E →SL[σ] F) : (F →SL_c[τ] G) →L[𝕜₃] E →SL_c[ρ] G :=
   L.precompUniformConvergenceCLM G _ _ (fun _ hs ↦ hs.image L.continuous)
 
-lemma ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply [IsTopologicalAddGroup G]
-    [ContinuousConstSMul 𝕜₃ G] (L : E →SL[σ] F) (T : F →SL_c[τ] G) (x : E) :
-    L.precompCompactConvergenceCLM G T x = T (L x) :=
-  rfl
-
-lemma foo [IsTopologicalAddGroup G] [ContinuousConstSMul 𝕜₃ G] {T : F →SL_c[τ] G} :
-    (0 : E →SL[σ] F).precompCompactConvergenceCLM G T = 0 := by
-  ext x
-  simp_rw [ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply]
-  simp
-
 @[deprecated (since := "2026-01-27")]
 alias precomp_compactConvergenceCLM := precompCompactConvergenceCLM
 
@@ -146,3 +135,26 @@ alias postcomp_compactConvergenceCLM_apply := postcompCompactConvergenceCLM_appl
 end comp
 
 end CompactSets
+
+section Bug
+
+open scoped CompactConvergenceCLM
+
+variable {𝕜 : Type*} [NormedField 𝕜] {E F G : Type*}
+  [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
+  [AddCommGroup F] [Module 𝕜 F] [TopologicalSpace F]
+  [AddCommGroup G] [Module 𝕜 G] [TopologicalSpace G]
+  [IsTopologicalAddGroup G] [ContinuousConstSMul 𝕜 G]
+
+lemma ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply
+    (L : E →L[𝕜] F) (T : F →L_c[𝕜] G) (x : E) :
+    L.precompCompactConvergenceCLM G T x = T (L x) :=
+  rfl
+
+lemma foo {T : F →L_c[𝕜] G} :
+    (0 : E →L[𝕜] F).precompCompactConvergenceCLM G T = 0 := by
+  ext x
+  simp_rw [ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply]
+  simp
+
+end Bug

--- a/Mathlib/Topology/Algebra/Module/Spaces/CompactConvergenceCLM.lean
+++ b/Mathlib/Topology/Algebra/Module/Spaces/CompactConvergenceCLM.lean
@@ -111,6 +111,17 @@ def ContinuousLinearMap.precompCompactConvergenceCLM [IsTopologicalAddGroup G]
     [ContinuousConstSMul 𝕜₃ G] (L : E →SL[σ] F) : (F →SL_c[τ] G) →L[𝕜₃] E →SL_c[ρ] G :=
   L.precompUniformConvergenceCLM G _ _ (fun _ hs ↦ hs.image L.continuous)
 
+lemma ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply [IsTopologicalAddGroup G]
+    [ContinuousConstSMul 𝕜₃ G] (L : E →SL[σ] F) (T : F →SL_c[τ] G) (x : E) :
+    L.precompCompactConvergenceCLM G T x = T (L x) :=
+  rfl
+
+lemma foo [IsTopologicalAddGroup G] [ContinuousConstSMul 𝕜₃ G] {T : F →SL_c[τ] G} :
+    (0 : E →SL[σ] F).precompCompactConvergenceCLM G T = 0 := by
+  ext x
+  simp_rw [ContinuousLinearMap.precompCompactConvergenceCLM_apply_apply]
+  simp
+
 @[deprecated (since := "2026-01-27")]
 alias precomp_compactConvergenceCLM := precompCompactConvergenceCLM
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
