### PR TITLE
perf: `no_expose` for `|x|`

### DIFF
--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Order.Group.Unbundled.Abs
 public import Mathlib.Algebra.Notation
+public import Mathlib.Tactic.Order
 
 /-!
 # Positive & negative parts
@@ -162,14 +163,12 @@ lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
 
 -- Bourbaki A.VI.12 Prop 9 d)
 @[to_additive] lemma oneLePart_mul_leOnePart (a : α) : a⁺ᵐ * a⁻ᵐ = |a|ₘ := by
-  rw [oneLePart_def, sup_mul, one_mul, leOnePart_def, mul_sup, mul_one, mul_inv_cancel, sup_assoc,
-    ← sup_assoc a, sup_eq_right.2 le_sup_right]
-  exact sup_eq_left.2 <| one_le_mabs a
+  rw [oneLePart_def, sup_mul, one_mul, leOnePart_def, mul_sup, mul_one, mul_inv_cancel]
+  order [mabs_eq_max_inv (a := a), one_le_mabs a]
 
 @[to_additive] lemma leOnePart_mul_oneLePart (a : α) : a⁻ᵐ * a⁺ᵐ = |a|ₘ := by
-  rw [oneLePart_def, mul_sup, mul_one, leOnePart_def, sup_mul, one_mul, inv_mul_cancel, sup_assoc,
-    ← @sup_assoc _ _ a, sup_eq_right.2 le_sup_right]
-  exact sup_eq_left.2 <| one_le_mabs a
+  rw [oneLePart_def, mul_sup, mul_one, leOnePart_def, sup_mul, one_mul, inv_mul_cancel]
+  order [mabs_eq_max_inv (a := a), one_le_mabs a]
 
 -- Bourbaki A.VI.12 Prop 9 a)
 -- a⁺ᵐ ⊓ a⁻ᵐ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -100,10 +100,9 @@ variable [MulLeftMono α]
 
 @[to_additive] lemma mabs_of_lt_one (h : a < 1) : |a|ₘ = a⁻¹ := mabs_of_le_one h.le
 
-@[to_additive] lemma mabs_le_mabs_of_one_le (ha : 1 ≤ a) (hab : a ≤ b) : |a|ₘ ≤ |b|ₘ := by
+@[to_additive (attr := gcongr)]
+lemma mabs_le_mabs_of_one_le (ha : 1 ≤ a) (hab : a ≤ b) : |a|ₘ ≤ |b|ₘ := by
   rwa [mabs_of_one_le ha, mabs_of_one_le (ha.trans hab)]
-
-attribute [gcongr] abs_le_abs_of_nonneg
 
 @[to_additive (attr := simp)] lemma mabs_one : |(1 : α)|ₘ = 1 := mabs_of_one_le le_rfl
 
@@ -298,11 +297,12 @@ lemma solidClosure_min (hst : s ⊆ t) (ht : IsSolid t) : solidClosure s ⊆ t :
 end LatticeOrderedAddCommGroup
 
 namespace Pi
-variable {ι : Type*} {α : ι → Type*} [∀ i, AddGroup (α i)] [∀ i, Lattice (α i)]
+variable {ι : Type*} {α : ι → Type*} [∀ i, Group (α i)] [∀ i, Lattice (α i)]
 
-@[simp] lemma abs_apply (f : ∀ i, α i) (i : ι) : |f| i = |f i| := (rfl)
+@[to_additive (attr := simp)]
+lemma mabs_apply (f : ∀ i, α i) (i : ι) : |f|ₘ i = |f i|ₘ := (rfl)
 
-@[push ←]
-lemma abs_def (f : ∀ i, α i) : |f| = fun i ↦ |f i| := (rfl)
+@[to_additive (attr := push ←)]
+lemma mabs_def (f : ∀ i, α i) : |f|ₘ = fun i ↦ |f i|ₘ := (rfl)
 
 end Pi

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -35,7 +35,8 @@ section Group
 variable [Group α] {a b : α}
 
 /-- `mabs a`, denoted `|a|ₘ`, is the absolute value of `a`. -/
-@[to_additive (attr := grind) /-- `abs a`, denoted `|a|`, is the absolute value of `a` -/]
+@[no_expose, to_additive
+/-- `abs a`, denoted `|a|`, is the absolute value of `a` -/]
 def mabs (a : α) : α := a ⊔ a⁻¹
 
 @[inherit_doc mabs]
@@ -63,6 +64,8 @@ meta def abs.unexpander : Lean.PrettyPrinter.Unexpander
     | `(|$_|) | `(|$_|ₘ) | `(-$_) => `(|($a)|)
     | _ => `(|$a|)
   | _ => throw ()
+
+@[to_additive (attr := grind =)] lemma mabs_eq_max_inv : |a|ₘ = max a a⁻¹ := (rfl)
 
 @[to_additive] lemma mabs_le' : |a|ₘ ≤ b ↔ a ≤ b ∧ a⁻¹ ≤ b := sup_le_iff
 
@@ -199,8 +202,6 @@ variable [Group α] [LinearOrder α] {a b : α}
 
 @[to_additive] lemma le_mabs : a ≤ |b|ₘ ↔ a ≤ b ∨ a ≤ b⁻¹ := le_max_iff
 
-@[to_additive] lemma mabs_eq_max_inv : |a|ₘ = max a a⁻¹ := rfl
-
 @[to_additive] lemma lt_mabs : a < |b|ₘ ↔ a < b ∨ a < b⁻¹ := lt_max_iff
 
 @[to_additive] lemma mabs_by_cases (P : α → Prop) (h1 : P a) (h2 : P a⁻¹) : P |a|ₘ :=
@@ -299,9 +300,9 @@ end LatticeOrderedAddCommGroup
 namespace Pi
 variable {ι : Type*} {α : ι → Type*} [∀ i, AddGroup (α i)] [∀ i, Lattice (α i)]
 
-@[simp] lemma abs_apply (f : ∀ i, α i) (i : ι) : |f| i = |f i| := rfl
+@[simp] lemma abs_apply (f : ∀ i, α i) (i : ι) : |f| i = |f i| := (rfl)
 
 @[push ←]
-lemma abs_def (f : ∀ i, α i) : |f| = fun i ↦ |f i| := rfl
+lemma abs_def (f : ∀ i, α i) : |f| = fun i ↦ |f i| := (rfl)
 
 end Pi

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -110,7 +110,7 @@ instance archimedean_stratum : Archimedean (u.stratum c) := by
   apply ArchimedeanClass.archimedean_of_mk_eq_mk
   intro a ha b hb
   suffices ArchimedeanClass.mk a.val = ArchimedeanClass.mk b.val by
-    rw [ArchimedeanClass.mk_eq_mk] at this ⊢
+    rw [ArchimedeanClass.mk_eq_mk, abs_eq_max_neg, abs_eq_max_neg] at this ⊢
     exact this
   rw [u.archimedeanClassMk_of_mem_stratum a.prop (by simpa using ha)]
   rw [u.archimedeanClassMk_of_mem_stratum b.prop (by simpa using hb)]

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -434,7 +434,7 @@ theorem archimedeanClassMk_eq_iff [IsOrderedAddMonoid R] (x y : f.val.domain) :
   simp_rw [← toOrderAddMonoidHom_apply, ← orderHom_mk]
   trans ArchimedeanClass.mk x = .mk y
   · exact Function.Injective.eq_iff <| orderHom_injective <| toOrderAddMonoidHom_injective _
-  · simp_rw [mk_eq_mk]
+  · simp_rw [mk_eq_mk, abs_eq_max_neg]
     aesop
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Algebra/Order/Ring/StandardPart.lean
+++ b/Mathlib/Algebra/Order/Ring/StandardPart.lean
@@ -115,7 +115,7 @@ instance : FloorRing (FiniteElement K) :=
   .ofBounded _ fun x ↦ by
     obtain ⟨n, hn⟩ := x.2
     refine ⟨n, (le_abs_self x).trans ?_⟩
-    simpa using hn
+    simpa [abs_eq_max_neg] using hn
 
 end FiniteElement
 

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -87,7 +87,7 @@ lemma ConcaveOn.exists_lipschitzOnWith_of_isBounded (hf : ConcaveOn ℝ (ball x�
 
 lemma ConvexOn.isBoundedUnder_abs (hf : ConvexOn ℝ C f) {x₀ : E} (hC : C ∈ 𝓝 x₀) :
     (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f| ↔ (𝓝 x₀).IsBoundedUnder (· ≤ ·) f := by
-  refine ⟨fun h ↦ h.mono_le <| .of_forall fun x ↦ le_abs_self _, ?_⟩
+  refine ⟨fun h ↦ h.mono_le <| .of_forall (le_abs_self f), ?_⟩
   rintro ⟨r, hr⟩
   refine ⟨|r| + 2 * |f x₀|, ?_⟩
   have : (𝓝 x₀).Tendsto (fun y => 2 • x₀ - y) (𝓝 x₀) :=

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -72,10 +72,10 @@ open HasSolidNorm
 
 theorem dual_solid (a b : α) (h : b ⊓ -b ≤ a ⊓ -a) : ‖a‖ ≤ ‖b‖ := by
   apply solid
-  rw [abs]
+  rw [abs_eq_max_neg]
   nth_rw 1 [← neg_neg a]
   rw [← neg_inf]
-  rw [abs]
+  rw [abs_eq_max_neg]
   nth_rw 1 [← neg_neg b]
   rwa [← neg_inf, neg_le_neg_iff, inf_comm _ b, inf_comm _ a]
 

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -85,7 +85,7 @@ normed lattice ordered group.
 -/
 instance (priority := 100) OrderDual.instHasSolidNorm :
     HasSolidNorm αᵒᵈ :=
-  { solid := dual_solid (α := α) }
+  { solid := by simp_rw [abs_eq_max_neg]; exact dual_solid (α := α) }
 
 theorem norm_abs_eq_norm (a : α) : ‖|a|‖ = ‖a‖ :=
   (solid (abs_abs a).le).antisymm (solid (abs_abs a).symm.le)

--- a/Mathlib/Analysis/RCLike/Inner.lean
+++ b/Mathlib/Analysis/RCLike/Inner.lean
@@ -164,7 +164,7 @@ section Real
 variable {w f g : ι → ℝ}
 
 lemma abs_wInner_le (hw : 0 ≤ w) : |⟪f, g⟫_[ℝ, w]| ≤ ⟪|f|, |g|⟫_[ℝ, w] := by
-  simpa using norm_wInner_le (𝕜 := ℝ) hw
+  simpa [Pi.abs_def] using norm_wInner_le (𝕜 := ℝ) hw
 
 end Real
 end RCLike

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/RootsExtrema.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/RootsExtrema.lean
@@ -91,7 +91,7 @@ theorem abs_eval_T_real_eq_one_iff {n : ℕ} (hn : n ≠ 0) (x : ℝ) :
   constructor
   · intro hTx
     have hx := (abs_eval_T_real_le_one_iff (Nat.cast_ne_zero.mpr hn) x).mpr (le_of_eq hTx)
-    rw [← cos_arccos (neg_le_of_abs_le hx) (le_of_max_le_left hx), T_real_cos,
+    rw [← cos_arccos (neg_le_of_abs_le hx) (le_of_abs_le hx), T_real_cos,
       Int.cast_natCast, abs_cos_eq_one_iff] at hTx
     obtain ⟨k, hk⟩ := hTx
     have hk' : k = n * (arccos x / π) := by simpa [field]

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -335,7 +335,7 @@ theorem sin_eq_one_iff_angle_eq_pi_div_two : sin (angle x y) = 1 ↔ angle x y =
 
 /-- If the angle between two vectors of equal norm is equal to 0, then the vectors are equal. -/
 lemma eq_of_angle_eq_zero_of_norm_eq {x y : V} (hxy : angle x y = 0) (h : ‖x‖ = ‖y‖) : x = y := by
-  grind [angle_eq_zero_iff, norm_smul, Real.norm_eq_abs, norm_ne_zero_iff, abs, one_smul]
+  grind [angle_eq_zero_iff, norm_smul, Real.norm_eq_abs, norm_ne_zero_iff, one_smul]
 
 /-- The angle between a normalized vector and another vector is equal to the angle
 between the original vectors. -/

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -141,7 +141,7 @@ lemma angle_le_angle_add_angle_of_norm_eq_one : angle x z ≤ angle x y + angle 
 lemma ortho_ne_zero_of_not_collinear (hxy1 : angle x y ≠ 0) (hxy2 : angle x y ≠ π) :
     ortho x y ≠ 0 := by
   intro h; rw [ortho_eq_sub_inner _ hx, sub_eq_zero] at h
-  grind [abs, norm_smul, Real.norm_eq_abs, norm_zero, inner_eq_mul_norm_iff_angle_eq_zero,
+  grind [norm_smul, Real.norm_eq_abs, norm_zero, inner_eq_mul_norm_iff_angle_eq_zero,
     inner_eq_neg_mul_norm_iff_angle_eq_pi]
 
 lemma eq_of_angle_eq_zero (hxy : angle x y = 0) : x = y := by

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -183,12 +183,12 @@ lemma Subgroup.isLeast_of_closure_iff_eq_mabs {a b : G} :
     rw [Int.mul_eq_one_iff_eq_one_or_neg_one] at key
     rw [eq_comm]
     rcases key with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ <;>
-    simp [this.right.le, this.right, mabs]
+    simp [this.right.le, this.right, mabs_eq_max_inv]
   · wlog ha : 1 ≤ a generalizing a
     · convert @this (a⁻¹) ?_ (by simpa using le_of_not_ge ha) using 4
       · simp
       · rwa [mabs_inv]
-    rw [mabs, sup_eq_left.mpr ((inv_le_one'.mpr ha).trans ha)] at h
+    rw [mabs_eq_max_inv, sup_eq_left.mpr ((inv_le_one'.mpr ha).trans ha)] at h
     rcases h with ⟨rfl, h⟩
     refine ⟨?_, ?_⟩
     · simp [h]

--- a/Mathlib/MeasureTheory/Function/AEEqFun.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun.lean
@@ -913,7 +913,7 @@ section Abs
 
 theorem coeFn_abs {β} [TopologicalSpace β] [Lattice β] [TopologicalLattice β] [AddGroup β]
     [IsTopologicalAddGroup β] (f : α →ₘ[μ] β) : ⇑|f| =ᵐ[μ] fun x => |f x| := by
-  simp_rw [abs]
+  simp_rw [abs_eq_max_neg]
   filter_upwards [AEEqFun.coeFn_sup f (-f), AEEqFun.coeFn_neg f] with x hx_sup hx_neg
   rw [hx_sup, hx_neg, Pi.neg_apply]
 

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -567,6 +567,7 @@ theorem Integrable.abs {β}
     {f : α → β} (hf : Integrable f μ) :
     Integrable (fun a => |f a|) μ := by
   rw [← memLp_one_iff_integrable] at hf ⊢
+  push fun _ ↦ _
   exact hf.abs
 
 -- TODO: generalise the following lemmas to enorm classes

--- a/Mathlib/MeasureTheory/Function/LpOrder.lean
+++ b/Mathlib/MeasureTheory/Function/LpOrder.lean
@@ -90,8 +90,9 @@ theorem _root_.MeasureTheory.MemLp.inf {f g : α → E} (hf : MemLp f p μ) (hg 
   MemLp.mono' (hf.norm.add hg.norm) (hf.1.inf hg.1)
     (Filter.Eventually.of_forall fun x => norm_inf_le_add (f x) (g x))
 
-theorem _root_.MeasureTheory.MemLp.abs {f : α → E} (hf : MemLp f p μ) : MemLp |f| p μ :=
-  hf.sup hf.neg
+theorem _root_.MeasureTheory.MemLp.abs {f : α → E} (hf : MemLp f p μ) : MemLp |f| p μ := by
+  rw [abs_eq_max_neg]
+  exact hf.sup hf.neg
 
 instance instLattice : Lattice (Lp E p μ) :=
   Subtype.lattice
@@ -108,8 +109,9 @@ theorem coeFn_sup (f g : Lp E p μ) : ⇑(f ⊔ g) =ᵐ[μ] ⇑f ⊔ ⇑g :=
 theorem coeFn_inf (f g : Lp E p μ) : ⇑(f ⊓ g) =ᵐ[μ] ⇑f ⊓ ⇑g :=
   AEEqFun.coeFn_inf _ _
 
-theorem coeFn_abs (f : Lp E p μ) : ⇑|f| =ᵐ[μ] fun x => |f x| :=
-  AEEqFun.coeFn_abs _
+theorem coeFn_abs (f : Lp E p μ) : ⇑|f| =ᵐ[μ] fun x => |f x| := by
+  convert ← AEEqFun.coeFn_abs _
+  · simp_rw [abs_eq_max_neg]; rfl
 
 instance instHasSolidNorm [Fact (1 ≤ p)] :
     HasSolidNorm (Lp E p μ) :=

--- a/Mathlib/MeasureTheory/Order/Group/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Group/Lattice.lean
@@ -45,8 +45,10 @@ protected theorem Measurable.leOnePart [MeasurableSup α] (hf : Measurable f) :
 variable [MeasurableSup₂ α]
 
 @[to_additive]
-theorem measurable_mabs : Measurable (mabs : α → α) :=
-  measurable_id'.sup measurable_inv
+theorem measurable_mabs : Measurable (mabs : α → α) := by
+  eta_expand
+  simp_rw [mabs_eq_max_inv]
+  fun_prop
 
 @[to_additive (attr := fun_prop)]
 protected theorem Measurable.mabs (hf : Measurable f) : Measurable fun x ↦ mabs (f x) :=

--- a/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
@@ -67,7 +67,7 @@ theorem χ₄_int_eq_if_mod_four (n : ℤ) :
   have help : ∀ m : ℤ, 0 ≤ m → m < 4 → χ₄ m = if m % 2 = 0 then 0 else if m = 1 then 1 else -1 := by
     decide
   rw [← Int.emod_emod_of_dvd n (by lia : (2 : ℤ) ∣ 4), ← ZMod.intCast_mod n 4]
-  exact help (n % 4) (Int.emod_nonneg n (by lia)) (Int.emod_lt_abs n (by lia))
+  grind
 
 theorem χ₄_nat_eq_if_mod_four (n : ℕ) :
     χ₄ n = if n % 2 = 0 then 0 else if n % 4 = 1 then 1 else -1 :=
@@ -145,7 +145,7 @@ theorem χ₈_int_eq_if_mod_eight (n : ℤ) :
     ∀ m : ℤ, 0 ≤ m → m < 8 → χ₈ m = if m % 2 = 0 then 0 else if m = 1 ∨ m = 7 then 1 else -1 := by
     decide
   rw [← Int.emod_emod_of_dvd n (by lia : (2 : ℤ) ∣ 8), ← ZMod.intCast_mod n 8]
-  exact help (n % 8) (Int.emod_nonneg n (by lia)) (Int.emod_lt_abs n (by lia))
+  grind
 
 theorem χ₈_nat_eq_if_mod_eight (n : ℕ) :
     χ₈ n = if n % 2 = 0 then 0 else if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1 :=
@@ -176,7 +176,7 @@ theorem χ₈'_int_eq_if_mod_eight (n : ℤ) :
     ∀ m : ℤ, 0 ≤ m → m < 8 → χ₈' m = if m % 2 = 0 then 0 else if m = 1 ∨ m = 3 then 1 else -1 := by
     decide
   rw [← Int.emod_emod_of_dvd n (by lia : (2 : ℤ) ∣ 8), ← ZMod.intCast_mod n 8]
-  exact help (n % 8) (Int.emod_nonneg n (by lia)) (Int.emod_lt_abs n (by lia))
+  grind
 
 theorem χ₈'_nat_eq_if_mod_eight (n : ℕ) :
     χ₈' n = if n % 2 = 0 then 0 else if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1 :=

--- a/Mathlib/Order/Filter/FilterProduct.lean
+++ b/Mathlib/Order/Filter/FilterProduct.lean
@@ -100,37 +100,31 @@ instance instIsStrictOrderedRing [Semiring β] [PartialOrder β] [IsStrictOrdere
     coe_lt.2 <| (coe_lt.1 hf).mp <| (coe_lt.1 hgh).mono fun _a ↦ mul_lt_mul_of_pos_right
 
 theorem max_def [LinearOrder β] (x y : β*) : max x y = map₂ max x y :=
-  inductionOn₂ x y fun a b => by
-    rcases le_total (a : β*) b with h | h
-    · rw [max_eq_right h, map₂_coe, coe_eq]
-      exact h.mono fun i hi => (max_eq_right hi).symm
-    · rw [max_eq_left h, map₂_coe, coe_eq]
-      exact h.mono fun i hi => (max_eq_left hi).symm
+  rfl
 
 theorem min_def [K : LinearOrder β] (x y : β*) : min x y = map₂ min x y :=
-  inductionOn₂ x y fun a b => by
-    rcases le_total (a : β*) b with h | h
-    · rw [min_eq_left h, map₂_coe, coe_eq]
-      exact h.mono fun i hi => (min_eq_left hi).symm
-    · rw [min_eq_right h, map₂_coe, coe_eq]
-      exact h.mono fun i hi => (min_eq_right hi).symm
+  rfl
 
 theorem abs_def [AddCommGroup β] [LinearOrder β] (x : β*) :
     |x| = map abs x :=
-  inductionOn x fun _a => rfl
+  inductionOn x fun a => by
+    eta_expand
+    simp_rw [abs_eq_max_neg]
+    rfl
 
 @[simp]
 theorem const_max [LinearOrder β] (x y : β) : (↑(max x y : β) : β*) = max ↑x ↑y := by
-  rw [max_def, map₂_const]
+  rfl
 
 @[simp]
 theorem const_min [LinearOrder β] (x y : β) : (↑(min x y : β) : β*) = min ↑x ↑y := by
-  rw [min_def, map₂_const]
+  rfl
 
 @[simp]
 theorem const_abs [AddCommGroup β] [LinearOrder β] (x : β) :
     (↑|x| : β*) = |↑x| := by
-  rw [abs_def, map_const]
+  rw [abs_def]
+  rfl
 
 end Germ
 

--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -518,8 +518,8 @@ theorem isBoundedUnder_ge_inf [SemilatticeInf α] {f : Filter β} {u v : β → 
 theorem isBoundedUnder_le_abs [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α]
     {f : Filter β} {u : β → α} :
     (f.IsBoundedUnder (· ≤ ·) fun a => |u a|) ↔
-      f.IsBoundedUnder (· ≤ ·) u ∧ f.IsBoundedUnder (· ≥ ·) u :=
-  isBoundedUnder_le_sup.trans <| and_congr Iff.rfl isBoundedUnder_le_neg
+      f.IsBoundedUnder (· ≤ ·) u ∧ f.IsBoundedUnder (· ≥ ·) u := by
+  simp_rw [abs_eq_max_neg, isBoundedUnder_le_sup, isBoundedUnder_le_neg]
 
 /-- Filters are automatically bounded or cobounded in complete lattices. To use the same statements
 in complete and conditionally complete lattices but let automation fill automatically the

--- a/Mathlib/Topology/Algebra/Order/Group.lean
+++ b/Mathlib/Topology/Algebra/Order/Group.lean
@@ -53,8 +53,10 @@ instance (priority := 100) LinearOrderedCommGroup.toIsTopologicalGroup :
       (eventually_mabs_div_lt a ε0).mono fun x hx ↦ by rwa [inv_div_inv, mabs_div_comm]
 
 @[to_additive (attr := continuity)]
-theorem continuous_mabs : Continuous (mabs : G → G) :=
-  continuous_id.max continuous_inv
+theorem continuous_mabs : Continuous (mabs : G → G) := by
+  eta_expand
+  simp_rw [mabs_eq_max_inv]
+  fun_prop
 
 section Tendsto
 

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -491,8 +491,9 @@ section OrderedAddGroup
 variable [TopologicalSpace α] [AddGroup β] [Lattice β] [AddLeftMono β]
 
 protected theorem HasCompactSupport.abs {f : α → β} (hf : HasCompactSupport f) :
-    HasCompactSupport |f| :=
-  hf.comp_left (g := abs) abs_zero
+    HasCompactSupport |f| := by
+  rw [Pi.abs_def]
+  exact hf.comp_left abs_zero
 
 end OrderedAddGroup
 

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -572,14 +572,16 @@ instance instSemilatticeInf : SemilatticeInf (α →ᵇ β) := fast_instance%
 instance instLattice : Lattice (α →ᵇ β) := fast_instance%
   DFunLike.coe_injective.lattice _ .rfl .rfl coe_sup coe_inf
 
-@[simp, norm_cast] lemma coe_abs (f : α →ᵇ β) : ⇑|f| = |⇑f| := rfl
+@[simp, norm_cast] lemma coe_abs (f : α →ᵇ β) : ⇑|f| = |⇑f| := by simp [abs_eq_max_neg]
 @[simp, norm_cast] lemma coe_posPart (f : α →ᵇ β) : ⇑f⁺ = (⇑f)⁺ := rfl
 @[simp, norm_cast] lemma coe_negPart (f : α →ᵇ β) : ⇑f⁻ = (⇑f)⁻ := rfl
 
 instance instHasSolidNorm : HasSolidNorm (α →ᵇ β) :=
   { solid := by
       intro f g h
-      have i1 : ∀ t, ‖f t‖ ≤ ‖g t‖ := fun t => HasSolidNorm.solid (h t)
+      simp_rw [abs_eq_max_neg] at h
+      have i1 : ∀ t, ‖f t‖ ≤ ‖g t‖ :=
+        fun t => HasSolidNorm.solid (by simp_rw [abs_eq_max_neg]; exact h t)
       rw [norm_le (norm_nonneg _)]
       exact fun t => (i1 t).trans (norm_coe_le_norm g t) }
 

--- a/Mathlib/Topology/ContinuousMap/Lattice.lean
+++ b/Mathlib/Topology/ContinuousMap/Lattice.lean
@@ -39,10 +39,13 @@ instance [PartialOrder β] [CommMonoid β] [IsOrderedMonoid β] [ContinuousMul �
 variable [Group β] [IsTopologicalGroup β] [Lattice β] [TopologicalLattice β]
 
 @[to_additive (attr := simp, norm_cast)]
-lemma coe_mabs (f : C(α, β)) : ⇑|f|ₘ = |⇑f|ₘ := rfl
+lemma coe_mabs (f : C(α, β)) : ⇑|f|ₘ = |⇑f|ₘ := by
+  simp [mabs_eq_max_inv]
 
 @[to_additive (attr := simp)]
-lemma mabs_apply (f : C(α, β)) (x : α) : |f|ₘ x = |f x|ₘ := rfl
+lemma mabs_apply (f : C(α, β)) (x : α) : |f|ₘ x = |f x|ₘ := by
+  simp [mabs_eq_max_inv]
+
 
 end Lattice
 

--- a/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
@@ -117,8 +117,11 @@ theorem abs_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f : A) :
     |(f : C(X, ℝ))| ∈ A.topologicalClosure := by
   let f' := attachBound (f : C(X, ℝ))
   let abs : C(Set.Icc (-‖f‖) ‖f‖, ℝ) := { toFun := fun x : Set.Icc (-‖f‖) ‖f‖ => |(x : ℝ)| }
-  change abs.comp f' ∈ A.topologicalClosure
-  apply comp_attachBound_mem_closure
+  convert comp_attachBound_mem_closure _ f abs
+  ext
+  rw [abs_apply]
+  rfl
+
 
 theorem inf_mem_subalgebra_closure (A : Subalgebra ℝ C(X, ℝ)) (f g : A) :
     (f : C(X, ℝ)) ⊓ (g : C(X, ℝ)) ∈ A.topologicalClosure := by


### PR DESCRIPTION
This PR hides the definition of `abs`, which might give a performance improvement.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
