### PR TITLE
chore(GroupTheory/Finiteness): make `Subgroup.FG` a class

### DIFF
--- a/Mathlib/GroupTheory/Commutator/Finite.lean
+++ b/Mathlib/GroupTheory/Commutator/Finite.lean
@@ -41,7 +41,7 @@ theorem commutator_pi_pi_of_finite {η : Type*} [Finite η] {Gs : η → Type*} 
 
 variable [Finite (commutatorSet G)]
 
-instance : Group.FG (_root_.commutator G) := by
+instance : (_root_.commutator G).FG := by
   rw [commutator_eq_closure]; apply Group.closure_finite_fg
 
 variable (G) in
@@ -82,7 +82,7 @@ variable [Finite (commutatorSet G)]
 
 instance : Finite (commutatorRepresentatives G) := Set.finite_coe_iff.mpr (Set.finite_range _)
 
-instance closureCommutatorRepresentatives_fg : Group.FG (closureCommutatorRepresentatives G) :=
+instance closureCommutatorRepresentatives_fg : (closureCommutatorRepresentatives G).FG :=
   Group.closure_finite_fg _
 
 variable (G) in

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -308,7 +308,8 @@ section Subgroup
 class Subgroup.FG (P : Subgroup G) : Prop where
   out : ∃ S : Finset G, Subgroup.closure S = P
 
-/-- A subgroup of `G` is finitely generated if it is the closure of a finite subset of `G`. -/
+/-- A additive subgroup of `G` is finitely generated if it is the closure of a\
+finite subset of `G`. -/
 class AddSubgroup.FG (P : AddSubgroup H) : Prop where
   out : ∃ S : Finset H, AddSubgroup.closure S = P
 

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -44,10 +44,15 @@ section Submonoid
 variable [Monoid N] {P : Submonoid M} {Q : Submonoid N}
 
 /-- A submonoid of `M` is finitely generated if it is the closure of a finite subset of `M`. -/
-@[to_additive /-- An additive submonoid of `N` is finitely generated if it is the closure of a
-finite subset of `M`. -/]
-def Submonoid.FG (P : Submonoid M) : Prop :=
-  ∃ S : Finset M, Submonoid.closure ↑S = P
+class Submonoid.FG (P : Submonoid M) : Prop where
+  out : ∃ S : Finset M, Submonoid.closure S = P
+
+/-- An additive submonoid of `N` is finitely generated if it is the closure of a
+finite subset of `M`. -/
+class AddSubmonoid.FG {M : Type*} [AddMonoid M] (P : AddSubmonoid M) : Prop where
+  out : ∃ S : Finset M, AddSubmonoid.closure S = P
+
+attribute [to_additive existing] Submonoid.FG
 
 /-- An equivalent expression of `Submonoid.FG` in terms of `Set.Finite` instead of `Finset`. -/
 @[to_additive /-- An equivalent expression of `AddSubmonoid.FG` in terms of `Set.Finite` instead of
@@ -61,7 +66,7 @@ theorem Submonoid.fg_iff (P : Submonoid M) :
 @[to_additive /-- A finitely generated submonoid has a minimal generating set. -/]
 lemma Submonoid.FG.exists_minimal_closure_eq (hP : P.FG) :
     ∃ S : Finset M, Minimal (fun S : Finset M ↦ closure S = P) S :=
-  exists_minimal_of_wellFoundedLT _ hP
+  exists_minimal_of_wellFoundedLT _ hP.out
 
 theorem Submonoid.fg_iff_add_fg (P : Submonoid M) : P.FG ↔ P.toAddSubmonoid.FG :=
   ⟨fun h =>
@@ -137,6 +142,7 @@ theorem Submonoid.iSup_map_mulSingle [DecidableEq ι] :
 theorem Submonoid.FG.pi (hP : ∀ i, (P i).FG) : (pi Set.univ P).FG := by
   classical
   haveI := Fintype.ofFinite ι
+  replace hP i := (hP i).out
   choose s hs using hP
   refine ⟨Finset.univ.biUnion fun i => (s i).image (MonoidHom.mulSingle M i), ?_⟩
   simp_rw [Finset.coe_biUnion, Finset.coe_univ, Set.biUnion_univ, closure_iUnion, Finset.coe_image,
@@ -299,9 +305,14 @@ variable {G H : Type*} [Group G] [AddGroup H]
 section Subgroup
 
 /-- A subgroup of `G` is finitely generated if it is the closure of a finite subset of `G`. -/
-@[to_additive]
-def Subgroup.FG (P : Subgroup G) : Prop :=
-  ∃ S : Finset G, Subgroup.closure ↑S = P
+class Subgroup.FG (P : Subgroup G) : Prop where
+  out : ∃ S : Finset G, Subgroup.closure S = P
+
+/-- A subgroup of `G` is finitely generated if it is the closure of a finite subset of `G`. -/
+class AddSubgroup.FG (P : AddSubgroup H) : Prop where
+  out : ∃ S : Finset H, AddSubgroup.closure S = P
+
+attribute [to_additive existing] Subgroup.FG
 
 /-- An additive subgroup of `H` is finitely generated if it is the closure of a finite subset of
 `H`. -/
@@ -437,6 +448,10 @@ theorem Group.fg_iff_subgroup_fg (H : Subgroup G) : Group.FG H ↔ H.FG :=
   (fg_iff_monoid_fg.trans (Monoid.fg_iff_submonoid_fg _)).trans
     (Subgroup.fg_iff_submonoid_fg _).symm
 
+@[to_additive]
+instance (H : Subgroup G) [H.FG] : Group.FG H :=
+  (Group.fg_iff_subgroup_fg H).mpr ‹_›
+
 theorem GroupFG.iff_add_fg : Group.FG G ↔ AddGroup.FG (Additive G) :=
   ⟨fun h => ⟨(Subgroup.fg_iff_add_fg ⊤).1 h.out⟩, fun h => ⟨(Subgroup.fg_iff_add_fg ⊤).2 h.out⟩⟩
 
@@ -493,16 +508,15 @@ theorem Group.fg_iff_exists_freeGroup_hom_surjective_finite :
     exact Group.fg_of_surjective hφ
 
 @[to_additive]
-instance Group.fg_range {G' : Type*} [Group G'] [Group.FG G] (f : G →* G') : Group.FG f.range :=
-  Group.fg_of_surjective f.rangeRestrict_surjective
+instance Group.fg_range {G' : Type*} [Group G'] [Group.FG G] (f : G →* G') : f.range.FG :=
+  (Group.fg_iff_subgroup_fg f.range).mp (Group.fg_of_surjective f.rangeRestrict_surjective)
 
 @[to_additive]
-instance Group.closure_finset_fg (s : Finset G) : Group.FG (Subgroup.closure (s : Set G)) := by
-  refine ⟨⟨s.preimage Subtype.val Subtype.coe_injective.injOn, ?_⟩⟩
-  rw [Finset.coe_preimage, ← Subgroup.coe_subtype, Subgroup.closure_preimage_eq_top]
+instance Group.closure_finset_fg (s : Finset G) : (Subgroup.closure (s : Set G)).FG :=
+  ⟨s, rfl⟩
 
 @[to_additive]
-instance Group.closure_finite_fg (s : Set G) [Finite s] : Group.FG (Subgroup.closure s) :=
+instance Group.closure_finite_fg (s : Set G) [Finite s] : (Subgroup.closure s).FG :=
   haveI := Fintype.ofFinite s
   s.coe_toFinset ▸ Group.closure_finset_fg s.toFinset
 

--- a/Mathlib/GroupTheory/Rank.lean
+++ b/Mathlib/GroupTheory/Rank.lean
@@ -64,7 +64,7 @@ end Group
 namespace Subgroup
 
 @[to_additive]
-lemma rank_congr {H K : Subgroup G} [Group.FG H] [Group.FG K] (h : H = K) : rank H = rank K := by
+lemma rank_congr {H K : Subgroup G} [H.FG] [K.FG] (h : H = K) : rank H = rank K := by
   subst h; rfl
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Schreier.lean
+++ b/Mathlib/GroupTheory/Schreier.lean
@@ -150,14 +150,16 @@ theorem exists_finset_card_le_mul [FiniteIndex H] {S : Finset G} (hS : closure (
 
 /-- **Schreier's Lemma**: A finite index subgroup of a finitely generated
   group is finitely generated. -/
-instance fg_of_index_ne_zero [hG : Group.FG G] [FiniteIndex H] : Group.FG H := by
+instance fg_of_finiteIndex [hG : Group.FG G] [FiniteIndex H] : H.FG := by
   obtain ⟨S, hS⟩ := hG.1
   obtain ⟨T, -, hT⟩ := exists_finset_card_le_mul H hS
-  exact ⟨⟨T, hT⟩⟩
+  exact (Group.fg_iff_subgroup_fg H).mp ⟨⟨T, hT⟩⟩
+
+@[deprecated (since := "2026-04-17")] alias fg_of_index_ne_zero := fg_of_finiteIndex
 
 theorem rank_le_index_mul_rank [hG : Group.FG G] [FiniteIndex H] :
     Group.rank H ≤ H.index * Group.rank G := by
-  haveI := H.fg_of_index_ne_zero
+  haveI := H.fg_of_finiteIndex
   obtain ⟨S, hS₀, hS⟩ := Group.rank_spec G
   obtain ⟨T, hT₀, hT⟩ := exists_finset_card_le_mul H hS
   calc


### PR DESCRIPTION
This PR refactors `Subgroup.FG` to be a class to match `Group.FG`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
