### PR TITLE
[Merged by Bors] - chore(CategoryTheory/EpiMono): use `to_dual`

### DIFF
--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -205,13 +205,15 @@ end
 section
 
 /-- When `f` is an epimorphism, `f ≫ g` is epic iff `g` is. -/
-@[to_dual (attr := simp) /-- When `g` is a monomorphism, `f ≫ g` is monic iff `f` is. -/]
+@[to_dual (attr := simp) (reorder := g f 7)
+/-- When `g` is a monomorphism, `f ≫ g` is monic iff `f` is. -/]
 lemma epi_comp_iff_of_epi {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) :
     Epi (f ≫ g) ↔ Epi g :=
   ⟨fun _ ↦ epi_of_epi f _, fun _ ↦ inferInstance⟩
 
 /-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
-@[to_dual (attr := simp) /-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/]
+@[to_dual (attr := simp) (reorder := g f 8)
+/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/]
 lemma epi_comp_iff_of_isIso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     Epi (f ≫ g) ↔ Epi f := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -24,34 +24,20 @@ namespace CategoryTheory
 
 variable {C : Type u₁} [Category.{v₁} C]
 
-instance unop_mono_of_epi {A B : Cᵒᵖ} (f : A ⟶ B) [Epi f] : Mono f.unop :=
-  ⟨fun _ _ eq => Quiver.Hom.op_inj ((cancel_epi f).1 (Quiver.Hom.unop_inj eq))⟩
-
+@[to_dual unop_mono_of_epi]
 instance unop_epi_of_mono {A B : Cᵒᵖ} (f : A ⟶ B) [Mono f] : Epi f.unop :=
   ⟨fun _ _ eq => Quiver.Hom.op_inj ((cancel_mono f).1 (Quiver.Hom.unop_inj eq))⟩
 
-instance op_mono_of_epi {A B : C} (f : A ⟶ B) [Epi f] : Mono f.op :=
-  ⟨fun _ _ eq => Quiver.Hom.unop_inj ((cancel_epi f).1 (Quiver.Hom.op_inj eq))⟩
-
+@[to_dual op_mono_of_epi]
 instance op_epi_of_mono {A B : C} (f : A ⟶ B) [Mono f] : Epi f.op :=
   ⟨fun _ _ eq => Quiver.Hom.unop_inj ((cancel_mono f).1 (Quiver.Hom.op_inj eq))⟩
 
-@[simp]
-lemma op_mono_iff {X Y : C} (f : X ⟶ Y) :
-    Mono f.op ↔ Epi f :=
-  ⟨fun _ ↦ unop_epi_of_mono f.op, fun _ ↦ inferInstance⟩
-
-@[simp]
+@[to_dual (attr := simp)]
 lemma op_epi_iff {X Y : C} (f : X ⟶ Y) :
     Epi f.op ↔ Mono f :=
   ⟨fun _ ↦ unop_mono_of_epi f.op, fun _ ↦ inferInstance⟩
 
-@[simp]
-lemma unop_mono_iff {X Y : Cᵒᵖ} (f : X ⟶ Y) :
-    Mono f.unop ↔ Epi f :=
-  ⟨fun _ ↦ op_epi_of_mono f.unop, fun _ ↦ inferInstance⟩
-
-@[simp]
+@[to_dual (attr := simp)]
 lemma unop_epi_iff {X Y : Cᵒᵖ} (f : X ⟶ Y) :
     Epi f.unop ↔ Mono f :=
   ⟨fun _ ↦ op_mono_of_epi f.unop, fun _ ↦ inferInstance⟩
@@ -61,29 +47,16 @@ such that `f ≫ retraction f = 𝟙 X`.
 
 Every split monomorphism is a monomorphism.
 -/
-@[ext, aesop apply safe (rule_sets := [CategoryTheory])]
 structure SplitMono {X Y : C} (f : X ⟶ Y) where
   /-- The map splitting `f` -/
   retraction : Y ⟶ X
   /-- `f` composed with `retraction` is the identity -/
   id : f ≫ retraction = 𝟙 X := by cat_disch
 
-attribute [reassoc (attr := simp)] SplitMono.id
-
 /-- `IsSplitMono f` is the assertion that `f` admits a retraction -/
 class IsSplitMono {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitMono : Nonempty (SplitMono f)
-
-/-- A composition of `SplitMono` is a `SplitMono`. -/
-@[simps]
-def SplitMono.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (smf : SplitMono f) (smg : SplitMono g) :
-    SplitMono (f ≫ g) where
-  retraction := smg.retraction ≫ smf.retraction
-
-/-- A constructor for `IsSplitMono f` taking a `SplitMono f` as an argument -/
-theorem IsSplitMono.mk' {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : IsSplitMono f :=
-  ⟨Nonempty.intro sm⟩
 
 /-- A split epimorphism is a morphism `f : X ⟶ Y` with a given section `section_ f : Y ⟶ X`
 such that `section_ f ≫ f = 𝟙 Y`.
@@ -91,117 +64,86 @@ such that `section_ f ≫ f = 𝟙 Y`.
 
 Every split epimorphism is an epimorphism.
 -/
-@[ext, aesop apply safe (rule_sets := [CategoryTheory])]
+@[to_dual (attr := ext, aesop apply safe (rule_sets := [CategoryTheory]))]
 structure SplitEpi {X Y : C} (f : X ⟶ Y) where
   /-- The map splitting `f` -/
   section_ : Y ⟶ X
   /-- `section_` composed with `f` is the identity -/
   id : section_ ≫ f = 𝟙 Y := by cat_disch
 
-attribute [reassoc (attr := simp)] SplitEpi.id
-
 /-- `IsSplitEpi f` is the assertion that `f` admits a section -/
+@[to_dual]
 class IsSplitEpi {X Y : C} (f : X ⟶ Y) : Prop where
   /-- There is a splitting -/
   exists_splitEpi : Nonempty (SplitEpi f)
 
+attribute [reassoc (attr := simp)] SplitMono.id SplitEpi.id
+
 /-- A composition of `SplitEpi` is a split `SplitEpi`. -/
-@[simps]
+@[to_dual (attr := simps) (reorder := X Z, f g, sef seg)
+/-- A composition of `SplitMono` is a `SplitMono`. -/]
 def SplitEpi.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitEpi f) (seg : SplitEpi g) :
     SplitEpi (f ≫ g) where
   section_ := seg.section_ ≫ sef.section_
 
 /-- A constructor for `IsSplitEpi f` taking a `SplitEpi f` as an argument -/
+@[to_dual /-- A constructor for `IsSplitMono f` taking a `SplitMono f` as an argument -/]
 theorem IsSplitEpi.mk' {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) : IsSplitEpi f :=
   ⟨Nonempty.intro se⟩
-
-/-- The chosen retraction of a split monomorphism. -/
-noncomputable def retraction {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f] : Y ⟶ X :=
-  hf.exists_splitMono.some.retraction
-
-@[reassoc (attr := simp)]
-theorem IsSplitMono.id {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f] : f ≫ retraction f = 𝟙 X :=
-  hf.exists_splitMono.some.id
-
-/-- The retraction of a split monomorphism has an obvious section. -/
-def SplitMono.splitEpi {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : SplitEpi sm.retraction where
-  section_ := f
-
-/-- The retraction of a split monomorphism is itself a split epimorphism. -/
-instance retraction_isSplitEpi {X Y : C} (f : X ⟶ Y) [IsSplitMono f] :
-    IsSplitEpi (retraction f) :=
-  IsSplitEpi.mk' (SplitMono.splitEpi _)
-
-/-- A split mono which is epi is an iso. -/
-theorem isIso_of_epi_of_isSplitMono {X Y : C} (f : X ⟶ Y) [IsSplitMono f] [Epi f] : IsIso f :=
-  ⟨⟨retraction f, ⟨by simp, by simp [← cancel_epi f]⟩⟩⟩
 
 /-- The chosen section of a split epimorphism.
 (Note that `section` is a reserved keyword, so we append an underscore.)
 -/
+@[to_dual retraction /-- The chosen retraction of a split monomorphism. -/]
 noncomputable def section_ {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] : Y ⟶ X :=
   hf.exists_splitEpi.some.section_
 
-@[reassoc (attr := simp)]
+@[to_dual (attr := reassoc (attr := simp))]
 theorem IsSplitEpi.id {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] : section_ f ≫ f = 𝟙 Y :=
   hf.exists_splitEpi.some.id
 
 /-- The section of a split epimorphism has an obvious retraction. -/
+@[to_dual splitEpi /-- The retraction of a split monomorphism has an obvious section. -/]
 def SplitEpi.splitMono {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) : SplitMono se.section_ where
   retraction := f
 
 /-- The section of a split epimorphism is itself a split monomorphism. -/
+@[to_dual retraction_isSplitEpi
+/-- The retraction of a split monomorphism is itself a split epimorphism. -/]
 instance section_isSplitMono {X Y : C} (f : X ⟶ Y) [IsSplitEpi f] : IsSplitMono (section_ f) :=
   IsSplitMono.mk' (SplitEpi.splitMono _)
 
 /-- A split epi which is mono is an iso. -/
+@[to_dual isIso_of_epi_of_isSplitMono /-- A split mono which is epi is an iso. -/]
 theorem isIso_of_mono_of_isSplitEpi {X Y : C} (f : X ⟶ Y) [Mono f] [IsSplitEpi f] : IsIso f :=
   ⟨⟨section_ f, ⟨by simp [← cancel_mono f], by simp⟩⟩⟩
 
-/-- Every iso is a split mono. -/
-instance (priority := 100) IsSplitMono.of_iso {X Y : C} (f : X ⟶ Y) [IsIso f] : IsSplitMono f :=
-  IsSplitMono.mk' { retraction := inv f }
-
 /-- Every iso is a split epi. -/
+@[to_dual /-- Every iso is a split mono. -/]
 instance (priority := 100) IsSplitEpi.of_iso {X Y : C} (f : X ⟶ Y) [IsIso f] : IsSplitEpi f :=
   IsSplitEpi.mk' { section_ := inv f }
 
-theorem SplitMono.mono {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) : Mono f :=
-  { right_cancellation := fun g h w => by replace w := w =≫ sm.retraction; simpa using w }
-
-/-- Every split mono is a mono. -/
-instance (priority := 100) IsSplitMono.mono {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f] : Mono f :=
-  hf.exists_splitMono.some.mono
-
+@[to_dual]
 theorem SplitEpi.epi {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) : Epi f :=
   { left_cancellation := fun g h w => by replace w := se.section_ ≫= w; simpa using w }
 
 /-- Every split epi is an epi. -/
+@[to_dual /-- Every split mono is a mono. -/]
 instance (priority := 100) IsSplitEpi.epi {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] : Epi f :=
   hf.exists_splitEpi.some.epi
 
-instance {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [hf : IsSplitMono f] [hg : IsSplitMono g] :
-    IsSplitMono (f ≫ g) := IsSplitMono.mk' <| hf.exists_splitMono.some.comp hg.exists_splitMono.some
-
+@[to_dual]
 instance {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} [hf : IsSplitEpi f] [hg : IsSplitEpi g] :
     IsSplitEpi (f ≫ g) := IsSplitEpi.mk' <| hf.exists_splitEpi.some.comp hg.exists_splitEpi.some
 
-/-- Every split mono whose retraction is mono is an iso. -/
-theorem IsIso.of_mono_retraction' {X Y : C} {f : X ⟶ Y} (hf : SplitMono f) [Mono <| hf.retraction] :
-    IsIso f :=
-  ⟨⟨hf.retraction, ⟨by simp, (cancel_mono_id <| hf.retraction).mp (by simp)⟩⟩⟩
-
-/-- Every split mono whose retraction is mono is an iso. -/
-theorem IsIso.of_mono_retraction {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f]
-    [hf' : Mono <| retraction f] : IsIso f :=
-  @IsIso.of_mono_retraction' _ _ _ _ _ hf.exists_splitMono.some hf'
-
 /-- Every split epi whose section is epi is an iso. -/
+@[to_dual /-- Every split mono whose retraction is mono is an iso. -/]
 theorem IsIso.of_epi_section' {X Y : C} {f : X ⟶ Y} (hf : SplitEpi f) [Epi <| hf.section_] :
     IsIso f :=
   ⟨⟨hf.section_, ⟨(cancel_epi_id <| hf.section_).mp (by simp), by simp⟩⟩⟩
 
 /-- Every split epi whose section is epi is an iso. -/
+@[to_dual /-- Every split mono whose retraction is mono is an iso. -/]
 theorem IsIso.of_epi_section {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] [hf' : Epi <| section_ f] :
     IsIso f :=
   @IsIso.of_epi_section' _ _ _ _ _ hf.exists_splitEpi.some hf'
@@ -227,19 +169,20 @@ class SplitMonoCategory : Prop where
   isSplitMono_of_mono : ∀ {X Y : C} (f : X ⟶ Y) [Mono f], IsSplitMono f
 
 /-- A split epi category is a category in which every epimorphism is split. -/
+@[to_dual]
 class SplitEpiCategory : Prop where
   /-- All epis are split -/
   isSplitEpi_of_epi : ∀ {X Y : C} (f : X ⟶ Y) [Epi f], IsSplitEpi f
 
+attribute [to_dual existing] SplitEpiCategory.isSplitEpi_of_epi SplitEpiCategory.mk
+
 end
 
-/-- In a category in which every monomorphism is split, every monomorphism splits. This is not an
-    instance because it would create an instance loop. -/
-theorem isSplitMono_of_mono [SplitMonoCategory C] {X Y : C} (f : X ⟶ Y) [Mono f] : IsSplitMono f :=
-  SplitMonoCategory.isSplitMono_of_mono _
-
 /-- In a category in which every epimorphism is split, every epimorphism splits. This is not an
-    instance because it would create an instance loop. -/
+instance because it would create an instance loop. -/
+@[to_dual
+/-- In a category in which every monomorphism is split, every monomorphism splits. This is not an
+instance because it would create an instance loop. -/]
 theorem isSplitEpi_of_epi [SplitEpiCategory C] {X Y : C} (f : X ⟶ Y) [Epi f] : IsSplitEpi f :=
   SplitEpiCategory.isSplitEpi_of_epi _
 
@@ -247,21 +190,13 @@ section
 
 variable {D : Type u₂} [Category.{v₂} D]
 
-/-- Split monomorphisms are also absolute monomorphisms. -/
-@[simps]
-def SplitMono.map {X Y : C} {f : X ⟶ Y} (sm : SplitMono f) (F : C ⥤ D) : SplitMono (F.map f) where
-  retraction := F.map sm.retraction
-  id := by rw [← Functor.map_comp, SplitMono.id, Functor.map_id]
-
 /-- Split epimorphisms are also absolute epimorphisms. -/
-@[simps]
+@[to_dual (attr := simps) /-- Split monomorphisms are also absolute monomorphisms. -/]
 def SplitEpi.map {X Y : C} {f : X ⟶ Y} (se : SplitEpi f) (F : C ⥤ D) : SplitEpi (F.map f) where
   section_ := F.map se.section_
   id := by rw [← Functor.map_comp, SplitEpi.id, Functor.map_id]
 
-instance {X Y : C} (f : X ⟶ Y) [hf : IsSplitMono f] (F : C ⥤ D) : IsSplitMono (F.map f) :=
-  IsSplitMono.mk' (hf.exists_splitMono.some.map F)
-
+@[to_dual]
 instance {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] (F : C ⥤ D) : IsSplitEpi (F.map f) :=
   IsSplitEpi.mk' (hf.exists_splitEpi.some.map F)
 
@@ -270,30 +205,17 @@ end
 section
 
 /-- When `f` is an epimorphism, `f ≫ g` is epic iff `g` is. -/
-@[simp]
+@[to_dual (attr := simp) /-- When `g` is a monomorphism, `f ≫ g` is monic iff `f` is. -/]
 lemma epi_comp_iff_of_epi {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) :
     Epi (f ≫ g) ↔ Epi g :=
   ⟨fun _ ↦ epi_of_epi f _, fun _ ↦ inferInstance⟩
 
 /-- When `g` is an isomorphism, `f ≫ g` is epic iff `f` is. -/
-@[simp]
+@[to_dual (attr := simp) /-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/]
 lemma epi_comp_iff_of_isIso {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] :
     Epi (f ≫ g) ↔ Epi f := by
   refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
   simpa using (inferInstance : Epi ((f ≫ g) ≫ inv g))
-
-/-- When `f` is an isomorphism, `f ≫ g` is monic iff `g` is. -/
-@[simp]
-lemma mono_comp_iff_of_isIso {X Y Z : C} (f : X ⟶ Y) [IsIso f] (g : Y ⟶ Z) :
-    Mono (f ≫ g) ↔ Mono g := by
-  refine ⟨fun h ↦ ?_, fun h ↦ inferInstance⟩
-  simpa using (inferInstance : Mono (inv f ≫ f ≫ g))
-
-/-- When `g` is a monomorphism, `f ≫ g` is monic iff `f` is. -/
-@[simp]
-lemma mono_comp_iff_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono g] :
-    Mono (f ≫ g) ↔ Mono f :=
-  ⟨fun _ ↦ mono_of_mono _ g, fun _ ↦ inferInstance⟩
 
 end
 
@@ -301,21 +223,15 @@ section Opposite
 
 variable {X Y : C} {f : X ⟶ Y}
 
-/-- The opposite of a split mono is a split epi. -/
-def SplitMono.op (h : SplitMono f) : SplitEpi f.op where
-  section_ := h.retraction.op
-  id := Quiver.Hom.unop_inj (by simp)
-
 /-- The opposite of a split epi is a split mono. -/
+@[to_dual /-- The opposite of a split mono is a split epi. -/]
 def SplitEpi.op (h : SplitEpi f) : SplitMono f.op where
   retraction := h.section_.op
   id := Quiver.Hom.unop_inj (by simp)
 
+@[to_dual]
 instance [IsSplitMono f] : IsSplitEpi f.op :=
   .mk' IsSplitMono.exists_splitMono.some.op
-
-instance [IsSplitEpi f] : IsSplitMono f.op :=
-  .mk' IsSplitEpi.exists_splitEpi.some.op
 
 end Opposite
 

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -80,7 +80,7 @@ class IsSplitEpi {X Y : C} (f : X ⟶ Y) : Prop where
 attribute [reassoc (attr := simp)] SplitMono.id SplitEpi.id
 
 /-- A composition of `SplitEpi` is a split `SplitEpi`. -/
-@[to_dual (attr := simps) (reorder := X Z, f g, sef seg)
+@[to_dual (attr := simps) (reorder := X Z, f g, sef seg) (rename := f ↔ g, sef → smg, seg → smf)
 /-- A composition of `SplitMono` is a `SplitMono`. -/]
 def SplitEpi.comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} (sef : SplitEpi f) (seg : SplitEpi g) :
     SplitEpi (f ≫ g) where

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -229,6 +229,8 @@ def nameDict : Std.HashMap String (List String) := .ofList [
   ("comonad", ["Monad"]),
   ("monadic", ["Comonadic"]),
   ("comonadic", ["Monadic"]),
+  ("section", ["Retraction"]),
+  ("retraction", ["Section"]),
 ]
 
 @[inherit_doc GuessName.GuessNameData.abbreviationDict]


### PR DESCRIPTION
Generate declarations about `Mono`, `SplitMono` and `SplitMonoCategory` from the epic versions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
