### PR TITLE
[Merged by Bors] - feat: add UniqueFactorizationMonoid.pow_dvd_pow_iff_dvd

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Multiplicity.lean
@@ -149,4 +149,31 @@ lemma finprod_pow_count_eq_of_subsingleton_units [Subsingleton Rˣ] {x : R} (hx 
 
 end multiplicity
 
+lemma dvd_iff_emultiplicity_le {a b : R} (ha : a ≠ 0) :
+    a ∣ b ↔ ∀ p : R, Prime p → emultiplicity p a ≤ emultiplicity p b := by
+  classical
+  refine ⟨fun h _ _ ↦ emultiplicity_le_emultiplicity_of_dvd_right h, fun h ↦ ?_⟩
+  by_cases hb : b = 0
+  · simp_all
+  letI : NormalizationMonoid R := UniqueFactorizationMonoid.normalizationMonoid
+  rw [dvd_iff_normalizedFactors_le_normalizedFactors ha hb, Multiset.le_iff_count]
+  intro q
+  by_cases hq : q ∈ normalizedFactors a
+  · have hqprime : Prime q := prime_of_normalized_factor q hq
+    have h1 := emultiplicity_eq_count_normalizedFactors hqprime.irreducible ha
+    have h2 := emultiplicity_eq_count_normalizedFactors hqprime.irreducible hb
+    rw [normalize_normalized_factor q hq] at h1 h2
+    simpa [h1, h2] using h q hqprime
+  · simp [Multiset.count_eq_zero_of_notMem hq]
+
+lemma pow_dvd_pow_iff_dvd {a b : R} {n : ℕ} (hn : n ≠ 0) : a ^ n ∣ b ^ n ↔ a ∣ b := by
+  by_cases ha : a = 0
+  · simp [ha, hn]
+  refine ⟨?_, fun h ↦ pow_dvd_pow_of_dvd h n⟩
+  rw [dvd_iff_emultiplicity_le (pow_ne_zero n ha), dvd_iff_emultiplicity_le ha]
+  intro H p hp
+  have := H p hp
+  rwa [emultiplicity_pow hp, emultiplicity_pow hp,
+    ENat.mul_le_mul_left_iff (by exact_mod_cast hn) (ENat.coe_ne_top _)] at this
+
 end UniqueFactorizationMonoid


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
