### PR TITLE
[Merged by Bors] - feat(Combinatorics): Pentagonal numbers

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3440,6 +3440,7 @@ public import Mathlib.Combinatorics.Enumerative.Partition
 public import Mathlib.Combinatorics.Enumerative.Partition.Basic
 public import Mathlib.Combinatorics.Enumerative.Partition.GenFun
 public import Mathlib.Combinatorics.Enumerative.Partition.Glaisher
+public import Mathlib.Combinatorics.Enumerative.Pentagonal
 public import Mathlib.Combinatorics.Enumerative.Schroder
 public import Mathlib.Combinatorics.Enumerative.Stirling
 public import Mathlib.Combinatorics.Extremal.RuzsaSzemeredi

--- a/Mathlib/Combinatorics/Enumerative/Partition/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition/Pentagonal.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+module
+
+public import Mathlib.Algebra.Order.Ring.Int
+public import Mathlib.Order.Interval.Set.Defs
+import Mathlib.Tactic.Linarith.Frontend
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Data.Int.SuccPred
+
+/-!
+
+-/
+
+public section
+
+@[expose]
+def pentagonal (k : ℤ) : ℤ := k * (3 * k - 1) / 2
+
+theorem pentagonal_neg (k : ℤ) : pentagonal (-k) = k * (3 * k + 1) / 2 := by
+  grind [pentagonal]
+
+theorem two_pentagonal (k : ℤ) : 2 * pentagonal k = k * (3 * k - 1) :=
+  Int.two_mul_ediv_two_of_even (by grind)
+
+theorem two_pentagonal_neg (k : ℤ) : 2 * pentagonal (-k) = k * (3 * k + 1) := by
+  grind [two_pentagonal]
+
+theorem pentagonal_nonneg (k : ℤ) : 0 ≤ pentagonal k := by
+  simp only [pentagonal, Nat.ofNat_pos, Int.ediv_nonneg_iff_of_pos]
+  obtain h | h := lt_or_ge 0 k
+  · exact mul_nonneg h.le (by linarith)
+  · exact mul_nonneg_of_nonpos_of_nonpos h (by linarith)
+
+theorem pentagonal_injective : Function.Injective pentagonal := by
+  intro x y h
+  replace h := congr(2 * $h)
+  simp_rw [two_pentagonal] at h
+  replace h : (3 * (x + y) - 1) * (x - y) = 0 := by linear_combination h
+  rcases mul_eq_zero.mp h with h | h <;> grind
+
+@[simp]
+theorem pentagonal_inj {x y : ℤ} : pentagonal x = pentagonal y ↔ x = y :=
+  ⟨fun h ↦ pentagonal_injective h, fun h ↦ congrArg _ h⟩
+
+theorem pentagonal_lt_pentagonal_neg {k : ℤ} (h : 0 < k) : pentagonal k < pentagonal (-k) := by
+  grind [pentagonal]
+
+theorem pentagonal_neg_lt_pentagonal_add_one {k : ℤ} (h : 0 ≤ k) :
+    pentagonal (-k) < pentagonal (k + 1) := by
+  grind [pentagonal]
+
+theorem pentagonal_strictMonoOn : StrictMonoOn pentagonal (Set.Ici 0) := by
+  refine strictMonoOn_of_lt_add_one Set.ordConnected_Ici fun k hm h h' ↦ ?_
+  grind [pentagonal]
+
+theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
+  refine strictAntiOn_of_add_one_lt Set.ordConnected_Iic fun k hm h h' ↦ ?_
+  grind [pentagonal]
+
+@[expose]
+def pentagonalNat (k : ℤ) : ℕ := (pentagonal k).toNat
+
+@[simp]
+theorem natCast_pentagonalNat (k : ℤ) : ↑(pentagonalNat k) = pentagonal k := by
+  simp [pentagonalNat, pentagonal_nonneg]
+
+theorem pentagonalNat_injective : Function.Injective pentagonalNat := by
+  intro x y h
+  zify at h
+  simpa using h
+
+@[simp]
+theorem pentagonalNat_inj {x y : ℤ} : pentagonalNat x = pentagonalNat y ↔ x = y :=
+  ⟨fun h ↦ pentagonalNat_injective h, fun h ↦ congrArg _ h⟩

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -23,7 +23,8 @@ convention, but implicitly shows the monotonicity in `pentagonal_lt_pentagonal_n
 
 ## TODO
 
-Show the relation between pentagonal numbers and partitions, including the pentagonal number theorem.
+Show the relation between pentagonal numbers and partitions, including the pentagonal number 
+theorem.
 
 ## References
 

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Int.SuccPred
 
 This file introduces (generalized) pentagonal numbers $k(3k-1)/2$ for integer $k$.
 
-Some source, such as A001318 in the OEIS, orders generalized pentagonal numbers by indices
+Some sources, such as A001318 in the OEIS, order generalized pentagonal numbers by indices
 $k = 0, 1, -1, 2, -2, \cdots$ to form a strictly monotone sequence. This file doesn't follow this
 convention, but implicitly shows the monotonicity by `pentagonal_lt_pentagonal_neg` and
 `pentagonal_neg_lt_pentagonal_add_one`.

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -18,6 +18,7 @@ convention, but implicitly shows the monotonicity in `pentagonal_lt_pentagonal_n
 `pentagonal_neg_lt_pentagonal_add_one`.
 
 ## Main definitions
+
 * `pentagonal`: pentagonal numbers as a function `ℤ → ℕ`.
 
 ## TODO

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -23,7 +23,7 @@ convention, but implicitly shows the monotonicity in `pentagonal_lt_pentagonal_n
 
 ## TODO
 
-Show the relation between pentagonal numbers and partitions, including pentagonal number theorem.
+Show the relation between pentagonal numbers and partitions, including the pentagonal number theorem.
 
 ## References
 

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -23,7 +23,7 @@ convention, but implicitly shows the monotonicity in `pentagonal_lt_pentagonal_n
 
 ## TODO
 
-Show the relation between pentagonal numbers and partitions, including the pentagonal number 
+Show the relation between pentagonal numbers and partitions, including the pentagonal number
 theorem.
 
 ## References

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -14,7 +14,7 @@ This file introduces (generalized) pentagonal numbers $k(3k-1)/2$ for integer $k
 
 Some sources, such as A001318 in the OEIS, order generalized pentagonal numbers by indices
 $k = 0, 1, -1, 2, -2, \cdots$ to form a strictly monotone sequence. This file doesn't follow this
-convention, but implicitly shows the monotonicity by `pentagonal_lt_pentagonal_neg` and
+convention, but implicitly shows the monotonicity in `pentagonal_lt_pentagonal_neg` and
 `pentagonal_neg_lt_pentagonal_add_one`.
 
 ## Main definitions

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Data.Int.SuccPred
 
 /-!
-# Pentagonal number
+# Pentagonal numbers
 
 This file introduces (generalized) pentagonal numbers $k(3k-1)/2$ for integer $k$.
 

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -5,11 +5,7 @@ Authors: Weiyi Wang
 -/
 module
 
-public import Mathlib.Algebra.Order.Ring.Int
-public import Mathlib.Order.Interval.Set.Defs
-import Mathlib.Data.Int.SuccPred
-import Mathlib.Tactic.Linarith.Frontend
-import Mathlib.Tactic.LinearCombination
+public import Mathlib.Data.Int.SuccPred
 
 /-!
 # Pentagonal number
@@ -44,9 +40,7 @@ theorem pentagonal_neg (k : ℤ) : pentagonal (-k) = (k * (3 * k + 1) / 2).toNat
   grind [pentagonal_def]
 
 theorem natCast_pentagonal (k : ℤ) : (pentagonal k : ℤ) = k * (3 * k - 1) / 2 := by
-  simp only [pentagonal_def, Int.ofNat_toNat, sup_eq_left, Nat.ofNat_pos,
-    Int.ediv_nonneg_iff_of_pos]
-  rcases lt_or_ge 0 k with h | h <;> nlinarith
+  rcases k with (_ | _) | _ <;> grind [pentagonal_def]
 
 theorem two_mul_natCast_pentagonal (k : ℤ) : 2 * (pentagonal k : ℤ) = k * (3 * k - 1) := by
   rw [natCast_pentagonal]
@@ -57,30 +51,24 @@ theorem two_mul_natCast_pentagonal_neg (k : ℤ) : 2 * (pentagonal (-k) : ℤ) =
 
 theorem pentagonal_injective : Function.Injective pentagonal := by
   intro x y h
-  replace h := congr(2 * ($h : ℤ))
-  simp_rw [two_mul_natCast_pentagonal] at h
-  replace h : (3 * (x + y) - 1) * (x - y) = 0 := by linear_combination h
-  rcases mul_eq_zero.mp h with h | h <;> grind
+  replace h : (3 * (x + y) - 1) * (x - y) = 0 := by grind [two_mul_natCast_pentagonal]
+  cases mul_eq_zero.mp h <;> grind
 
 @[simp]
 theorem pentagonal_inj {x y : ℤ} : pentagonal x = pentagonal y ↔ x = y :=
   pentagonal_injective.eq_iff
 
 theorem pentagonal_lt_pentagonal_neg {k : ℤ} (h : 0 < k) : pentagonal k < pentagonal (-k) := by
-  zify
   grind [natCast_pentagonal]
 
 theorem pentagonal_neg_lt_pentagonal_add_one {k : ℤ} (h : 0 ≤ k) :
     pentagonal (-k) < pentagonal (k + 1) := by
-  zify
   grind [natCast_pentagonal]
 
 theorem pentagonal_strictMonoOn : StrictMonoOn pentagonal (Set.Ici 0) := by
   apply strictMonoOn_of_lt_add_one Set.ordConnected_Ici
-  zify
   grind [natCast_pentagonal]
 
 theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
   apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
-  zify
   grind [natCast_pentagonal]

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -38,11 +38,12 @@ Show the relation between pentagonal numbers and partitions, including pentagona
 public section
 
 /-- Pentagonal numbers $k(3k-1)/2$ for integer $k$. -/
-@[expose]
 def pentagonal (k : ℤ) : ℤ := k * (3 * k - 1) / 2
 
+theorem pentagonal_def (k : ℤ) : pentagonal k = k * (3 * k - 1) / 2 := by rfl
+
 theorem pentagonal_neg (k : ℤ) : pentagonal (-k) = k * (3 * k + 1) / 2 := by
-  grind [pentagonal]
+  grind [pentagonal_def]
 
 theorem two_pentagonal (k : ℤ) : 2 * pentagonal k = k * (3 * k - 1) :=
   Int.two_mul_ediv_two_of_even (by grind)
@@ -51,7 +52,7 @@ theorem two_pentagonal_neg (k : ℤ) : 2 * pentagonal (-k) = k * (3 * k + 1) := 
   grind [two_pentagonal]
 
 theorem pentagonal_nonneg (k : ℤ) : 0 ≤ pentagonal k := by
-  simp only [pentagonal, Nat.ofNat_pos, Int.ediv_nonneg_iff_of_pos]
+  simp only [pentagonal_def, Nat.ofNat_pos, Int.ediv_nonneg_iff_of_pos]
   rcases lt_or_ge 0 k with h | h <;> nlinarith
 
 theorem pentagonal_injective : Function.Injective pentagonal := by
@@ -66,27 +67,28 @@ theorem pentagonal_inj {x y : ℤ} : pentagonal x = pentagonal y ↔ x = y :=
   pentagonal_injective.eq_iff
 
 theorem pentagonal_lt_pentagonal_neg {k : ℤ} (h : 0 < k) : pentagonal k < pentagonal (-k) := by
-  grind [pentagonal]
+  grind [pentagonal_def]
 
 theorem pentagonal_neg_lt_pentagonal_add_one {k : ℤ} (h : 0 ≤ k) :
     pentagonal (-k) < pentagonal (k + 1) := by
-  grind [pentagonal]
+  grind [pentagonal_def]
 
 theorem pentagonal_strictMonoOn : StrictMonoOn pentagonal (Set.Ici 0) := by
   apply strictMonoOn_of_lt_add_one Set.ordConnected_Ici
-  grind [pentagonal]
+  grind [pentagonal_def]
 
 theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
   apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
-  grind [pentagonal]
+  grind [pentagonal_def]
 
 /-- Pentagonal numbers $k(3k-1)/2$ as `Nat` for integer $k$. -/
-@[expose]
 def pentagonalNat (k : ℤ) : ℕ := (pentagonal k).toNat
+
+theorem pentagonalNat_def (k : ℤ) : pentagonalNat k = (pentagonal k).toNat := by rfl
 
 @[simp]
 theorem natCast_pentagonalNat (k : ℤ) : ↑(pentagonalNat k) = pentagonal k := by
-  simp [pentagonalNat, pentagonal_nonneg]
+  simp [pentagonalNat_def, pentagonal_nonneg]
 
 theorem pentagonalNat_injective : Function.Injective pentagonalNat := by
   intro x y h

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -37,6 +37,7 @@ Show the relation between pentagonal numbers and partitions, including pentagona
 
 public section
 
+/-- Pentagonal numbers $3k(k-1)/2$ for integer $k$. -/
 @[expose]
 def pentagonal (k : ℤ) : ℤ := k * (3 * k - 1) / 2
 
@@ -79,6 +80,7 @@ theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
   apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
   grind [pentagonal]
 
+/-- Pentagonal numbers $3k(k-1)/2$ as `Nat` for integer $k$. -/
 @[expose]
 def pentagonalNat (k : ℤ) : ℕ := (pentagonal k).toNat
 

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -22,9 +22,7 @@ convention, but implicitly shows the monotonicity by `pentagonal_lt_pentagonal_n
 `pentagonal_neg_lt_pentagonal_add_one`.
 
 ## Main definitions
-* `pentagonal`: pentagonal numbers as a function `ℤ → ℤ`.
-* `pentagonalNat`: pentagonal numbers as a function `ℤ → ℕ`, bundling in the fact that pentagonal
-  numbers are all non-negative.
+* `pentagonal`: pentagonal numbers as a function `ℤ → ℕ`.
 
 ## TODO
 
@@ -38,27 +36,29 @@ Show the relation between pentagonal numbers and partitions, including pentagona
 public section
 
 /-- Pentagonal numbers $k(3k-1)/2$ for integer $k$. -/
-def pentagonal (k : ℤ) : ℤ := k * (3 * k - 1) / 2
+def pentagonal (k : ℤ) : ℕ := (k * (3 * k - 1) / 2).toNat
 
-theorem pentagonal_def (k : ℤ) : pentagonal k = k * (3 * k - 1) / 2 := by rfl
+theorem pentagonal_def (k : ℤ) : pentagonal k = (k * (3 * k - 1) / 2).toNat := by rfl
 
-theorem pentagonal_neg (k : ℤ) : pentagonal (-k) = k * (3 * k + 1) / 2 := by
+theorem pentagonal_neg (k : ℤ) : pentagonal (-k) = (k * (3 * k + 1) / 2).toNat := by
   grind [pentagonal_def]
 
-theorem two_pentagonal (k : ℤ) : 2 * pentagonal k = k * (3 * k - 1) :=
-  Int.two_mul_ediv_two_of_even (by grind)
-
-theorem two_pentagonal_neg (k : ℤ) : 2 * pentagonal (-k) = k * (3 * k + 1) := by
-  grind [two_pentagonal]
-
-theorem pentagonal_nonneg (k : ℤ) : 0 ≤ pentagonal k := by
-  simp only [pentagonal_def, Nat.ofNat_pos, Int.ediv_nonneg_iff_of_pos]
+theorem natCast_pentagonal (k : ℤ) : (pentagonal k : ℤ) = k * (3 * k - 1) / 2 := by
+  simp only [pentagonal_def, Int.ofNat_toNat, sup_eq_left, Nat.ofNat_pos,
+    Int.ediv_nonneg_iff_of_pos]
   rcases lt_or_ge 0 k with h | h <;> nlinarith
+
+theorem two_mul_natCast_pentagonal (k : ℤ) : 2 * (pentagonal k : ℤ) = k * (3 * k - 1) := by
+  rw [natCast_pentagonal]
+  exact Int.two_mul_ediv_two_of_even (by grind)
+
+theorem two_mul_natCast_pentagonal_neg (k : ℤ) : 2 * (pentagonal (-k) : ℤ) = k * (3 * k + 1) := by
+  grind [two_mul_natCast_pentagonal]
 
 theorem pentagonal_injective : Function.Injective pentagonal := by
   intro x y h
-  replace h := congr(2 * $h)
-  simp_rw [two_pentagonal] at h
+  replace h := congr(2 * ($h : ℤ))
+  simp_rw [two_mul_natCast_pentagonal] at h
   replace h : (3 * (x + y) - 1) * (x - y) = 0 := by linear_combination h
   rcases mul_eq_zero.mp h with h | h <;> grind
 
@@ -67,34 +67,20 @@ theorem pentagonal_inj {x y : ℤ} : pentagonal x = pentagonal y ↔ x = y :=
   pentagonal_injective.eq_iff
 
 theorem pentagonal_lt_pentagonal_neg {k : ℤ} (h : 0 < k) : pentagonal k < pentagonal (-k) := by
-  grind [pentagonal_def]
+  zify
+  grind [natCast_pentagonal]
 
 theorem pentagonal_neg_lt_pentagonal_add_one {k : ℤ} (h : 0 ≤ k) :
     pentagonal (-k) < pentagonal (k + 1) := by
-  grind [pentagonal_def]
+  zify
+  grind [natCast_pentagonal]
 
 theorem pentagonal_strictMonoOn : StrictMonoOn pentagonal (Set.Ici 0) := by
   apply strictMonoOn_of_lt_add_one Set.ordConnected_Ici
-  grind [pentagonal_def]
+  zify
+  grind [natCast_pentagonal]
 
 theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
   apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
-  grind [pentagonal_def]
-
-/-- Pentagonal numbers $k(3k-1)/2$ as `Nat` for integer $k$. -/
-def pentagonalNat (k : ℤ) : ℕ := (pentagonal k).toNat
-
-theorem pentagonalNat_def (k : ℤ) : pentagonalNat k = (pentagonal k).toNat := by rfl
-
-@[simp]
-theorem natCast_pentagonalNat (k : ℤ) : ↑(pentagonalNat k) = pentagonal k := by
-  simp [pentagonalNat_def, pentagonal_nonneg]
-
-theorem pentagonalNat_injective : Function.Injective pentagonalNat := by
-  intro x y h
-  zify at h
-  simpa using h
-
-@[simp]
-theorem pentagonalNat_inj {x y : ℤ} : pentagonalNat x = pentagonalNat y ↔ x = y :=
-  pentagonalNat_injective.eq_iff
+  zify
+  grind [natCast_pentagonal]

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -14,7 +14,7 @@ import Mathlib.Data.Int.SuccPred
 /-!
 # Pentagonal number
 
-This file introduces (generalized) pentagonal numbers $3k(k-1)/2$ for integer $k$.
+This file introduces (generalized) pentagonal numbers $k(3k-1)/2$ for integer $k$.
 
 Some source, such as A001318 in the OEIS, orders generalized pentagonal numbers by indices
 $k = 0, 1, -1, 2, -2, \cdots$ to form a strictly monotone sequence. This file doesn't follow this
@@ -37,7 +37,7 @@ Show the relation between pentagonal numbers and partitions, including pentagona
 
 public section
 
-/-- Pentagonal numbers $3k(k-1)/2$ for integer $k$. -/
+/-- Pentagonal numbers $k(3k-1)/2$ for integer $k$. -/
 @[expose]
 def pentagonal (k : ℤ) : ℤ := k * (3 * k - 1) / 2
 
@@ -80,7 +80,7 @@ theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
   apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
   grind [pentagonal]
 
-/-- Pentagonal numbers $3k(k-1)/2$ as `Nat` for integer $k$. -/
+/-- Pentagonal numbers $k(3k-1)/2$ as `Nat` for integer $k$. -/
 @[expose]
 def pentagonalNat (k : ℤ) : ℕ := (pentagonal k).toNat
 

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -12,7 +12,27 @@ import Mathlib.Tactic.LinearCombination
 import Mathlib.Data.Int.SuccPred
 
 /-!
+# Pentagonal number
 
+This file introduces (generalized) pentagonal numbers $3k(k-1)/2$ for integer $k$.
+
+Some source, such as A001318 in the OEIS, orders generalized pentagonal numbers by indices
+$k = 0, 1, -1, 2, -2, \cdots$ to form a strictly monotone sequence. This file doesn't follow this
+convention, but implicitly shows the monotonicity by `pentagonal_lt_pentagonal_neg` and
+`pentagonal_neg_lt_pentagonal_add_one`.
+
+## Main definitions
+* `pentagonal`: pentagonal numbers as a function `ℤ → ℤ`.
+* `pentagonalNat`: pentagonal numbers as a function `ℤ → ℕ`, bundling in the fact that pentagonal
+  numbers are all non-negative.
+
+## TODO
+
+Show the relation between pentagonal numbers and partitions, including pentagonal number theorem.
+
+## References
+
+* https://en.wikipedia.org/wiki/Pentagonal_number
 -/
 
 public section
@@ -31,9 +51,7 @@ theorem two_pentagonal_neg (k : ℤ) : 2 * pentagonal (-k) = k * (3 * k + 1) := 
 
 theorem pentagonal_nonneg (k : ℤ) : 0 ≤ pentagonal k := by
   simp only [pentagonal, Nat.ofNat_pos, Int.ediv_nonneg_iff_of_pos]
-  obtain h | h := lt_or_ge 0 k
-  · exact mul_nonneg h.le (by linarith)
-  · exact mul_nonneg_of_nonpos_of_nonpos h (by linarith)
+  rcases lt_or_ge 0 k with h | h <;> nlinarith
 
 theorem pentagonal_injective : Function.Injective pentagonal := by
   intro x y h
@@ -44,7 +62,7 @@ theorem pentagonal_injective : Function.Injective pentagonal := by
 
 @[simp]
 theorem pentagonal_inj {x y : ℤ} : pentagonal x = pentagonal y ↔ x = y :=
-  ⟨fun h ↦ pentagonal_injective h, fun h ↦ congrArg _ h⟩
+  pentagonal_injective.eq_iff
 
 theorem pentagonal_lt_pentagonal_neg {k : ℤ} (h : 0 < k) : pentagonal k < pentagonal (-k) := by
   grind [pentagonal]
@@ -54,11 +72,11 @@ theorem pentagonal_neg_lt_pentagonal_add_one {k : ℤ} (h : 0 ≤ k) :
   grind [pentagonal]
 
 theorem pentagonal_strictMonoOn : StrictMonoOn pentagonal (Set.Ici 0) := by
-  refine strictMonoOn_of_lt_add_one Set.ordConnected_Ici fun k hm h h' ↦ ?_
+  apply strictMonoOn_of_lt_add_one Set.ordConnected_Ici
   grind [pentagonal]
 
 theorem pentagonal_strictAntiOn : StrictAntiOn pentagonal (Set.Iic 0) := by
-  refine strictAntiOn_of_add_one_lt Set.ordConnected_Iic fun k hm h h' ↦ ?_
+  apply strictAntiOn_of_add_one_lt Set.ordConnected_Iic
   grind [pentagonal]
 
 @[expose]
@@ -75,4 +93,4 @@ theorem pentagonalNat_injective : Function.Injective pentagonalNat := by
 
 @[simp]
 theorem pentagonalNat_inj {x y : ℤ} : pentagonalNat x = pentagonalNat y ↔ x = y :=
-  ⟨fun h ↦ pentagonalNat_injective h, fun h ↦ congrArg _ h⟩
+  pentagonalNat_injective.eq_iff

--- a/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
+++ b/Mathlib/Combinatorics/Enumerative/Pentagonal.lean
@@ -7,9 +7,9 @@ module
 
 public import Mathlib.Algebra.Order.Ring.Int
 public import Mathlib.Order.Interval.Set.Defs
+import Mathlib.Data.Int.SuccPred
 import Mathlib.Tactic.Linarith.Frontend
 import Mathlib.Tactic.LinearCombination
-import Mathlib.Data.Int.SuccPred
 
 /-!
 # Pentagonal number


### PR DESCRIPTION
Introduces definition of pentagonal number https://en.wikipedia.org/wiki/Pentagonal_number in preparation for pentagonal number theorem.

---

This is extracted from #33143 as suggested.  I only put a few elementary properties here to limit the code change size. 

The future file structure will be
 - Combinatorics/Enumerative/Pentagonal.lean (this PR)
 - Topology/Algebra/InfiniteSum/Pentagonal.lean + RingTheory/PowerSeries/Pentagonal.lean (#33143, depends on previous one) pentagonal theorem in generic form and for power series
 - Combinatorics/Enumerative/Partition/Pentagonal.lean (future PR, depends on the previous one): connection between partition and pentagonal numbers


This originally comes from my own repo https://github.com/wwylele/PentagonalNumberTheorem. In the past, there were also PR #31156 and #31362 independently worked by @BeibeiX0 on the same topic, and I tried avoiding stepping on each other's toes when making #33143. Then #31156 and #31362 were closed for unclear reason.

As I mostly rewrote the code based on my own repo, I only put my name here, but given that I unavoidably took inspiration from other PRs, if @BeibeiX0 would like his name to be added to co-author and copyright notice, I am happy to do so.


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
