### PR TITLE
perf(RingTheory/Ideal/Quotient/Defs): clean up `Ring` instances again

### DIFF
--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -60,19 +60,17 @@ protected def ringCon (I : Ideal R) [I.IsTwoSided] : RingCon R where
     rw [Submodule.quotientRel_def] at h₁ h₂ ⊢
     exact mul_sub_mul_mem I h₁ h₂
 
-instance semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
+local instance semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
   inferInstanceAs <| Semiring (Quotient.ringCon I).Quotient
 
 instance ring (I : Ideal R) [I.IsTwoSided] : Ring (R ⧸ I) :=
   inferInstanceAs <| Ring (Quotient.ringCon I).Quotient
 
 instance {R} [CommRing R] (I : Ideal R) : Semiring (R ⧸ I) := semiring I
-
-instance {R} [CommRing R] (I : Ideal R) : Ring (R ⧸ I) := ring I
-
 instance {R} [CommRing R] (I : Ideal R) : CommSemiring (R ⧸ I) where
   mul_comm := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (mul_comm a b)
 
+instance {R} [CommRing R] (I : Ideal R) : Ring (R ⧸ I) := ring I
 instance commRing {R} [CommRing R] (I : Ideal R) : CommRing (R ⧸ I) where
 
 variable [I.IsTwoSided]

--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -61,7 +61,7 @@ protected def ringCon (I : Ideal R) [I.IsTwoSided] : RingCon R where
     exact mul_sub_mul_mem I h₁ h₂
 
 -- Making this an instance breaks some proofs
-@[implicit_reducible]
+@[implicit_reducible, nolint docBlame]
 def semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
   inferInstanceAs <| Semiring (Quotient.ringCon I).Quotient
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -60,15 +60,20 @@ protected def ringCon (I : Ideal R) [I.IsTwoSided] : RingCon R where
     rw [Submodule.quotientRel_def] at h₁ h₂ ⊢
     exact mul_sub_mul_mem I h₁ h₂
 
+instance semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
+  inferInstanceAs <| Semiring (Quotient.ringCon I).Quotient
+
 instance ring (I : Ideal R) [I.IsTwoSided] : Ring (R ⧸ I) :=
   inferInstanceAs <| Ring (Quotient.ringCon I).Quotient
 
-instance semiring {R} [CommRing R] (I : Ideal R) : Semiring (R ⧸ I) := (ring I).toSemiring
-instance commSemiring {R} [CommRing R] (I : Ideal R) : CommSemiring (R ⧸ I) where
-  mul_comm := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (mul_comm a b)
+instance {R} [CommRing R] (I : Ideal R) : Semiring (R ⧸ I) := semiring I
 
 instance {R} [CommRing R] (I : Ideal R) : Ring (R ⧸ I) := ring I
-instance commRing {R} [CommRing R] (I : Ideal R) : CommRing (R ⧸ I) where
+
+instance {R} [CommRing R] (I : Ideal R) : CommSemiring (R ⧸ I) where
+  mul_comm := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (mul_comm a b)
+
+instance {R} [CommRing R] (I : Ideal R) : CommRing (R ⧸ I) where
 
 variable [I.IsTwoSided]
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -60,9 +60,12 @@ protected def ringCon (I : Ideal R) [I.IsTwoSided] : RingCon R where
     rw [Submodule.quotientRel_def] at h₁ h₂ ⊢
     exact mul_sub_mul_mem I h₁ h₂
 
-local instance semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
+-- Making this an instance breaks some proofs
+@[implicit_reducible]
+def semiring (I : Ideal R) [I.IsTwoSided] : Semiring (R ⧸ I) :=
   inferInstanceAs <| Semiring (Quotient.ringCon I).Quotient
 
+attribute [local instance] semiring in
 instance ring (I : Ideal R) [I.IsTwoSided] : Ring (R ⧸ I) :=
   inferInstanceAs <| Ring (Quotient.ringCon I).Quotient
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Defs.lean
@@ -73,7 +73,7 @@ instance {R} [CommRing R] (I : Ideal R) : Ring (R ⧸ I) := ring I
 instance {R} [CommRing R] (I : Ideal R) : CommSemiring (R ⧸ I) where
   mul_comm := by rintro ⟨a⟩ ⟨b⟩; exact congr_arg _ (mul_comm a b)
 
-instance {R} [CommRing R] (I : Ideal R) : CommRing (R ⧸ I) where
+instance commRing {R} [CommRing R] (I : Ideal R) : CommRing (R ⧸ I) where
 
 variable [I.IsTwoSided]
 


### PR DESCRIPTION
I think I didn't do the instances right last time, and this version should be faster.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
