### PR TITLE
refactor: deprecate `Mathlib.LinearAlgebra.FreeModule.StrongRankCondition`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 If `A` is a domain, and a finite-dimensional algebra over a field `F`, with prime dimension,

--- a/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
@@ -5,10 +5,9 @@ Authors: Kenny Lau
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import Mathlib.Data.Nat.Prime.Defs
 public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 
 /-!
 If `A` is a domain, and a finite-dimensional algebra over a field `F`, with prime dimension,

--- a/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 If `A` is a domain, and a finite-dimensional algebra over a field `F`, with prime dimension,

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.Free
 public import Mathlib.LinearAlgebra.Dimension.Subsingleton
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.Free
 public import Mathlib.LinearAlgebra.Dimension.Subsingleton
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -6,8 +6,6 @@ Authors: Jz Pan
 module
 
 public import Mathlib.LinearAlgebra.Dimension.Free
-public import Mathlib.LinearAlgebra.Dimension.Subsingleton
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
 
 /-!

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
 
 /-!

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.Algebra.Lie.OfAssociative
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.Algebra.MvPolynomial.Monad
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Matrix.Charpoly.Univ
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import Mathlib.RingTheory.TensorProduct.Free

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.Algebra.MvPolynomial.Monad
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Matrix.Charpoly.Univ
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import Mathlib.RingTheory.TensorProduct.Free

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.Algebra.MvPolynomial.Monad
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Matrix.Charpoly.Univ
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import Mathlib.RingTheory.TensorProduct.Free

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.FieldTheory.Minpoly.Basic
 public import Mathlib.FieldTheory.Tower
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Algebraic.Integral
 
 /-!

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.FieldTheory.Minpoly.Basic
 public import Mathlib.FieldTheory.Tower
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Algebraic.Integral
 
 /-!

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.FieldTheory.Minpoly.Basic
 public import Mathlib.FieldTheory.Tower
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.Algebraic.Integral
 
 /-!

--- a/Mathlib/GroupTheory/IndexNSmul.lean
+++ b/Mathlib/GroupTheory/IndexNSmul.lean
@@ -13,7 +13,8 @@ public import Mathlib.RingTheory.Finiteness.Defs
 import Mathlib.Algebra.Group.Subgroup.ZPowers.Lemmas
 import Mathlib.Data.ZMod.QuotientGroup
 import Mathlib.LinearAlgebra.Dimension.Constructions
-import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+import Mathlib.LinearAlgebra.InvariantBasisNumber
+import Mathlib.RingTheory.FiniteType
 
 /-!
 # Lemmas about index and multiplication-by-n

--- a/Mathlib/GroupTheory/IndexNSmul.lean
+++ b/Mathlib/GroupTheory/IndexNSmul.lean
@@ -10,11 +10,10 @@ public import Mathlib.LinearAlgebra.Dimension.Finrank
 public import Mathlib.LinearAlgebra.FreeModule.Basic
 public import Mathlib.RingTheory.Finiteness.Defs
 
+import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Group.Subgroup.ZPowers.Lemmas
 import Mathlib.Data.ZMod.QuotientGroup
 import Mathlib.LinearAlgebra.Dimension.Constructions
-import Mathlib.LinearAlgebra.InvariantBasisNumber
-import Mathlib.RingTheory.FiniteType
 
 /-!
 # Lemmas about index and multiplication-by-n

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -6,8 +6,8 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 module
 
 public import Mathlib.LinearAlgebra.Dual.Basis
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Matrix.Basis
 public import Mathlib.LinearAlgebra.Matrix.Dual

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -6,7 +6,8 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 module
 
 public import Mathlib.LinearAlgebra.Dual.Basis
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Matrix.Basis
 public import Mathlib.LinearAlgebra.Matrix.Dual

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -5,17 +5,10 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 module
 
-public import Mathlib.LinearAlgebra.Dual.Basis
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
-public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Matrix.Basis
 public import Mathlib.LinearAlgebra.Matrix.Dual
-public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
-public import Mathlib.LinearAlgebra.Matrix.Reindex
 public import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
-public import Mathlib.RingTheory.Finiteness.Cardinality
-public import Mathlib.Tactic.FieldSimp
+public import Mathlib.RingTheory.FiniteType
 
 import Mathlib.LinearAlgebra.GeneralLinearGroup.AlgEquiv
 

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -11,8 +11,8 @@ public import Mathlib.LinearAlgebra.Dimension.ErdosKaplansky
 public import Mathlib.LinearAlgebra.Dual.Basis
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Projection
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -11,7 +11,8 @@ public import Mathlib.LinearAlgebra.Dimension.ErdosKaplansky
 public import Mathlib.LinearAlgebra.Dual.Basis
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Projection
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -6,15 +6,10 @@ Authors: Johan Commelin, Fabian Glöckle, Kyle Miller
 module
 
 public import Mathlib.Algebra.Module.LinearMap.DivisionRing
-public import Mathlib.LinearAlgebra.Basis.Basic
 public import Mathlib.LinearAlgebra.Dimension.ErdosKaplansky
 public import Mathlib.LinearAlgebra.Dual.Basis
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber
-public import Mathlib.LinearAlgebra.Projection
 public import Mathlib.LinearAlgebra.SesquilinearForm.Basic
 public import Mathlib.RingTheory.Finiteness.Projective
 public import Mathlib.RingTheory.LocalRing.Basic

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -9,8 +9,8 @@ public import Mathlib.Algebra.Order.Archimedean.Basic
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Artinian.Module
 
 /-!

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -7,10 +7,7 @@ module
 
 public import Mathlib.Algebra.Order.Archimedean.Basic
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
-public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Artinian.Module
 
 /-!

--- a/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Zero.lean
@@ -9,7 +9,8 @@ public import Mathlib.Algebra.Order.Archimedean.Basic
 public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.Artinian.Module
 
 /-!

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.RingTheory.Finiteness.Subalgebra
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 # Constructs a basis for exterior powers

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.RingTheory.Finiteness.Subalgebra
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 # Constructs a basis for exterior powers

--- a/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/Basis.lean
@@ -5,11 +5,9 @@ Authors: Sophie Morel, Daniel Morrison
 -/
 module
 
-public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
-public import Mathlib.RingTheory.Finiteness.Subalgebra
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
+public import Mathlib.RingTheory.Finiteness.Subalgebra
 
 /-!
 # Constructs a basis for exterior powers

--- a/Mathlib/LinearAlgebra/FreeAlgebra.lean
+++ b/Mathlib/LinearAlgebra/FreeAlgebra.lean
@@ -11,8 +11,8 @@ public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 public import Mathlib.LinearAlgebra.Dimension.Subsingleton
 public import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 public import Mathlib.LinearAlgebra.FreeModule.Basic
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 # Linear algebra properties of `FreeAlgebra R X`

--- a/Mathlib/LinearAlgebra/FreeAlgebra.lean
+++ b/Mathlib/LinearAlgebra/FreeAlgebra.lean
@@ -11,7 +11,8 @@ public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 public import Mathlib.LinearAlgebra.Dimension.Subsingleton
 public import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 public import Mathlib.LinearAlgebra.FreeModule.Basic
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 # Linear algebra properties of `FreeAlgebra R X`

--- a/Mathlib/LinearAlgebra/FreeAlgebra.lean
+++ b/Mathlib/LinearAlgebra/FreeAlgebra.lean
@@ -5,13 +5,7 @@ Authors: Eric Wieser
 -/
 module
 
-public import Mathlib.Algebra.FreeAlgebra
-public import Mathlib.LinearAlgebra.Basis.Cardinality
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-public import Mathlib.LinearAlgebra.Dimension.Subsingleton
-public import Mathlib.LinearAlgebra.Finsupp.VectorSpace
-public import Mathlib.LinearAlgebra.FreeModule.Basic
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
 
 /-!

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -5,7 +5,8 @@ Authors: Riccardo Brasca
 -/
 module
 
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -5,9 +5,8 @@ Authors: Riccardo Brasca
 -/
 module
 
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Dimension.Finite
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 # Finite and free modules using matrices

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -5,8 +5,8 @@ Authors: Riccardo Brasca
 -/
 module
 
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.Data.ZMod.QuotientRing
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Quotient.Pi
 
 /-! # Quotient of submodules of full rank in free finite modules over PIDs

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.Data.ZMod.QuotientRing
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Quotient.Pi
 
 /-! # Quotient of submodules of full rank in free finite modules over PIDs

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Quotient.lean
@@ -8,9 +8,8 @@ module
 public import Mathlib.Data.ZMod.QuotientRing
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Quotient.Pi
+public import Mathlib.RingTheory.FiniteType
 
 /-! # Quotient of submodules of full rank in free finite modules over PIDs
 

--- a/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
@@ -12,6 +12,7 @@ deprecated_module (since := "2026-04-18")
 
 @[expose] public section
 
-@[deprecated "instance already exists" (since := "2026-04-18")]
+@[deprecated "instance already exists: import `Mathlib.LinearAlgebra.InvariantBasisNumber` and
+`Mathlib.RingTheory.FiniteType`" (since := "2026-04-18")]
 instance (priority := 100) commRing_strongRankCondition (R : Type*) [CommRing R] [Nontrivial R] :
     StrongRankCondition R := inferInstance

--- a/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
@@ -37,6 +37,8 @@ is injective.
 
 -/
 
+deprecated_module (since := "2026-04-18")
+
 @[expose] public section
 
 

--- a/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
@@ -3,47 +3,15 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
-module
+module -- shake: keep-all
 
 public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
-
-/-!
-
-# Strong rank condition for commutative rings
-
-We prove that any nontrivial commutative ring satisfies `StrongRankCondition`, meaning that
-if there is an injective linear map `(Fin n → R) →ₗ[R] Fin m → R`, then `n ≤ m`. This implies that
-any commutative ring satisfies `InvariantBasisNumber`: the rank of a finitely generated free
-module is well defined.
-
-## Main result
-
-* `commRing_strongRankCondition R` : `R` has the `StrongRankCondition`.
-
-The `commRing_strongRankCondition` comes from `CommRing.orzechProperty`, proved in
-`Mathlib/RingTheory/FiniteType.lean`, which states that any commutative ring satisfies
-the `OrzechProperty`, that is, for any finitely generated
-`R`-module `M`, any surjective homomorphism `f : N → M` from a submodule `N` of `M` to `M`
-is injective.
-
-
-## References
-
-* [Orzech, Morris. *Onto endomorphisms are isomorphisms*][orzech1971]
-* [Djoković, D. Ž. *Epimorphisms of modules which must be isomorphisms*][djokovic1973]
-* [Ribenboim, Paulo. *Épimorphismes de modules qui sont nécessairement
-  des isomorphismes*][ribenboim1971]
-
--/
 
 deprecated_module (since := "2026-04-18")
 
 @[expose] public section
 
-
-variable (R : Type*) [CommRing R] [Nontrivial R]
-
-/-- Any nontrivial commutative ring satisfies the `StrongRankCondition`. -/
-instance (priority := 100) commRing_strongRankCondition : StrongRankCondition R :=
-  inferInstance
+@[deprecated "instance already exists" (since := "2026-04-18")]
+instance (priority := 100) commRing_strongRankCondition (R : Type*) [CommRing R] [Nontrivial R] :
+    StrongRankCondition R := inferInstance

--- a/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/StrongRankCondition.lean
@@ -5,8 +5,8 @@ Authors: Riccardo Brasca
 -/
 module -- shake: keep-all
 
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 
 deprecated_module (since := "2026-04-18")
 

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -304,8 +304,8 @@ There are two stronger results in mathlib:
     and hence that nontrivial commutative rings satisfy the strong rank condition
     (by `strongRankCondition_of_orzechProperty`).
 2.  `rankCondition_of_nontrivial_of_commSemiring` in
-    `Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber`, which says that any
-    nontrivial commutative semiring satisfies the rank condition.
+    `Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber`, which says that
+    any nontrivial commutative semiring satisfies the rank condition.
 
 We prove this instance here anyway to reduce the required imports.
 -/

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -296,16 +296,18 @@ section
 attribute [local instance] Ideal.Quotient.field
 
 /--
-Nontrivial commutative rings have the invariant basis number property.
+Nontrivial commutative rings satisfy the invariant basis number property.
 
 There are two stronger results in mathlib:
-1.  `CommRing.orzechProperty`, which says that any commutative ring satisfies the Orzech property,
-    and hence, if it's nontrivial, satisfies the strong rank condition by
-    `strongRankCondition_of_orzechProperty`.
-2.  `rankCondition_of_nontrivial_of_commSemiring`, which says that
-    any nontrivial commutative semiring satisfies the rank condition.
+1.  `CommRing.orzechProperty` in `Mathlib.RingTheory.FiniteType`,
+    which says that any commutative ring satisfies the Orzech property,
+    and hence that nontrivial commutative rings satisfy the strong rank condition
+    (by `strongRankCondition_of_orzechProperty`).
+2.  `rankCondition_of_nontrivial_of_commSemiring` in
+    `Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber`, which says that any
+    nontrivial commutative semiring satisfies the rank condition.
 
-We prove this instance separately to signficantly reduce the required imports.
+We prove this instance here anyway to reduce the required imports.
 -/
 instance (priority := 100) invariantBasisNumber_of_nontrivial_of_commRing {R : Type u} [CommRing R]
     [Nontrivial R] : InvariantBasisNumber R :=

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -265,7 +265,6 @@ end
      `R^n ≃ R^m`.
 -/
 
-
 section
 
 variable {R : Type u} [CommRing R] (I : Ideal R) {ι : Type v} [Fintype ι] {ι' : Type w}
@@ -296,15 +295,18 @@ section
 
 attribute [local instance] Ideal.Quotient.field
 
-/-- Nontrivial commutative rings have the invariant basis number property.
+/--
+Nontrivial commutative rings have the invariant basis number property.
 
-There are two stronger results in mathlib: `commRing_strongRankCondition`, which says that any
-nontrivial commutative ring satisfies the strong rank condition, and
-`rankCondition_of_nontrivial_of_commSemiring`, which says that any nontrivial commutative semiring
-satisfies the rank condition.
+There are two stronger results in mathlib:
+1.  `CommRing.orzechProperty`, which says that any commutative ring satisfies the Orzech property,
+    and hence, if it's nontrivial, satisfies the strong rank condition by
+    `strongRankCondition_of_orzechProperty`.
+2.  `rankCondition_of_nontrivial_of_commSemiring`, which says that
+    any nontrivial commutative semiring satisfies the rank condition.
 
-We prove this instance separately to avoid dependency on
-`Mathlib/LinearAlgebra/Charpoly/Basic.lean` or `Mathlib/LinearAlgebra/Matrix/ToLin.lean`. -/
+We prove this instance separately to signficantly reduce the required imports.
+-/
 instance (priority := 100) invariantBasisNumber_of_nontrivial_of_commRing {R : Type u} [CommRing R]
     [Nontrivial R] : InvariantBasisNumber R :=
   ⟨fun e =>

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -5,12 +5,12 @@ Authors: Scott Carnahan
 -/
 module
 
-public import Mathlib.LinearAlgebra.BilinearForm.Basic
 public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import Mathlib.LinearAlgebra.Dimension.Localization
 public import Mathlib.LinearAlgebra.QuadraticForm.Basic
 public import Mathlib.LinearAlgebra.RootSystem.BaseChange
 public import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
+public import Mathlib.RingTheory.FiniteType
 
 /-!
 # Nondegeneracy of the polarization on a finite root pairing

--- a/Mathlib/LinearAlgebra/Span/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Span/TensorProduct.lean
@@ -14,8 +14,8 @@ public import Mathlib.Combinatorics.Matroid.Init
 public import Mathlib.Data.Nat.Totient
 public import Mathlib.Data.Sym.Sym2
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.Tactic.NormNum.GCD
 public import Mathlib.Tactic.Positivity
 

--- a/Mathlib/LinearAlgebra/Span/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Span/TensorProduct.lean
@@ -6,18 +6,8 @@ Authors: Oliver Nash
 module
 
 public import Mathlib.Algebra.Algebra.Epi
-public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-public import Mathlib.LinearAlgebra.Finsupp.LinearCombination
-public import Mathlib.LinearAlgebra.Span.Basic
-public import Mathlib.RingTheory.Flat.Basic
-public import Mathlib.Combinatorics.Matroid.Init
-public import Mathlib.Data.Nat.Totient
-public import Mathlib.Data.Sym.Sym2
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
-public import Mathlib.Tactic.NormNum.GCD
-public import Mathlib.Tactic.Positivity
+public import Mathlib.RingTheory.Flat.Basic
 
 /-!
 # The interaction of linear span and tensor product for mixed scalars.

--- a/Mathlib/LinearAlgebra/Span/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Span/TensorProduct.lean
@@ -14,7 +14,8 @@ public import Mathlib.Combinatorics.Matroid.Init
 public import Mathlib.Data.Nat.Totient
 public import Mathlib.Data.Sym.Sym2
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.Tactic.NormNum.GCD
 public import Mathlib.Tactic.Positivity
 

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Contraction
 public import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
 public import Mathlib.RingTheory.Finiteness.Prod
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import Mathlib.RingTheory.TensorProduct.Free
 

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -5,8 +5,8 @@ Authors: Antoine Labelle
 -/
 module
 
+public import Mathlib.Algebra.MonoidAlgebra.Basic
 public import Mathlib.LinearAlgebra.Contraction
-public import Mathlib.Algebra.Group.Equiv.TypeTags
 
 /-!
 # Monoid representations

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -612,7 +612,8 @@ end MonoidAlgebra
 section Orzech
 
 open Submodule Module Module.Finite in
-/-- Any commutative ring `R` satisfies the `OrzechProperty`, that is, for any finitely generated
+/--
+Any commutative ring `R` satisfies the `OrzechProperty`, that is, for any finitely generated
 `R`-module `M`, any surjective homomorphism `f : N →ₗ[R] M` from a submodule `N` of `M` to `M`
 is injective.
 
@@ -631,7 +632,11 @@ then it's easy to see that `i` and `f` restrict to `N' →ₗ[A] M'`,
 and the restricted version of `f` is surjective, hence by Noetherian case,
 it is also injective, in particular, if `f n = 0`, then `n = 0`.
 
-See also Orzech's original paper: *Onto endomorphisms are isomorphisms* [orzech1971]. -/
+See also Orzech's original paper: *Onto endomorphisms are isomorphisms* [orzech1971].
+
+This implies that nontrivial commutative rings satisfy the strong rank condition:
+see `strongRankCondition_of_orzechProperty` in `Mathlib.LinearAlgebra.InvariantBasisNumber`.
+-/
 instance (priority := 100) CommRing.orzechProperty
     (R : Type*) [CommRing R] : OrzechProperty R := by
   refine ⟨fun {M} _ _ _ {N} f hf ↦ ?_⟩

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.Algebra.Module.FinitePresentation
 public import Mathlib.Algebra.Module.Projective
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.LocalProperties.Submodule
 
 /-!

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.Algebra.Module.FinitePresentation
 public import Mathlib.Algebra.Module.Projective
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.LocalProperties.Submodule
 
 /-!

--- a/Mathlib/RingTheory/LocalProperties/Projective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Projective.lean
@@ -6,9 +6,7 @@ Authors: Andrew Yang, David Swinarski
 module
 
 public import Mathlib.Algebra.Module.FinitePresentation
-public import Mathlib.Algebra.Module.Projective
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.LocalProperties.Submodule
 

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -16,7 +16,8 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
 public import Mathlib.RingTheory.Nakayama
 public import Mathlib.RingTheory.Support
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 # Finite modules over local rings

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -5,18 +5,13 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.Algebra.Module.FinitePresentation
 public import Mathlib.Algebra.Module.Torsion.Basic
-public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.RingTheory.Flat.EquationalCriterion
 public import Mathlib.RingTheory.Ideal.Quotient.ChineseRemainder
 public import Mathlib.RingTheory.LocalProperties.Exactness
-public import Mathlib.RingTheory.LocalRing.ResidueField.Basic
 public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
-public import Mathlib.RingTheory.Nakayama
 public import Mathlib.RingTheory.Support
-public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!
 # Finite modules over local rings

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -16,7 +16,6 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
 public import Mathlib.RingTheory.Nakayama
 public import Mathlib.RingTheory.Support
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
 
 /-!

--- a/Mathlib/RingTheory/LocalRing/Quotient.lean
+++ b/Mathlib/RingTheory/LocalRing/Quotient.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.OrzechProperty
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.Artinian.Ring
 public import Mathlib.RingTheory.Ideal.Over
 public import Mathlib.RingTheory.Ideal.Quotient.Index

--- a/Mathlib/RingTheory/LocalRing/Quotient.lean
+++ b/Mathlib/RingTheory/LocalRing/Quotient.lean
@@ -7,10 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.OrzechProperty
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Artinian.Ring
-public import Mathlib.RingTheory.Ideal.Over
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Ideal.Quotient.Index
 public import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 public import Mathlib.RingTheory.LocalRing.RingHom.Basic

--- a/Mathlib/RingTheory/LocalRing/Quotient.lean
+++ b/Mathlib/RingTheory/LocalRing/Quotient.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.OrzechProperty
 public import Mathlib.LinearAlgebra.FreeModule.PID
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Artinian.Ring
 public import Mathlib.RingTheory.Ideal.Over
 public import Mathlib.RingTheory.Ideal.Quotient.Index

--- a/Mathlib/RingTheory/Localization/Free.lean
+++ b/Mathlib/RingTheory/Localization/Free.lean
@@ -7,7 +7,8 @@ module
 
 public import Mathlib.Algebra.Module.FinitePresentation
 public import Mathlib.RingTheory.Localization.Finiteness
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!

--- a/Mathlib/RingTheory/Localization/Free.lean
+++ b/Mathlib/RingTheory/Localization/Free.lean
@@ -6,10 +6,9 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.Algebra.Module.FinitePresentation
-public import Mathlib.RingTheory.Localization.Finiteness
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.RingTheory.Localization.Finiteness
 
 /-!
 # Free modules and localization

--- a/Mathlib/RingTheory/Localization/Free.lean
+++ b/Mathlib/RingTheory/Localization/Free.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.Algebra.Module.FinitePresentation
 public import Mathlib.RingTheory.Localization.Finiteness
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!

--- a/Mathlib/RingTheory/MvPolynomial.lean
+++ b/Mathlib/RingTheory/MvPolynomial.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.Algebra.MvPolynomial.CommRing
 public import Mathlib.LinearAlgebra.Dimension.Finite
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.LinearAlgebra.InvariantBasisNumber
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.MvPolynomial.Basic
 
 /-!

--- a/Mathlib/RingTheory/MvPolynomial.lean
+++ b/Mathlib/RingTheory/MvPolynomial.lean
@@ -8,7 +8,8 @@ module
 public import Mathlib.Algebra.MvPolynomial.CommRing
 public import Mathlib.LinearAlgebra.Dimension.Finite
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.MvPolynomial.Basic
 
 /-!

--- a/Mathlib/RingTheory/MvPolynomial.lean
+++ b/Mathlib/RingTheory/MvPolynomial.lean
@@ -5,10 +5,7 @@ Authors: Johannes Hölzl
 -/
 module
 
-public import Mathlib.Algebra.MvPolynomial.CommRing
 public import Mathlib.LinearAlgebra.Dimension.Finite
-public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-public import Mathlib.LinearAlgebra.InvariantBasisNumber
 public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.MvPolynomial.Basic
 


### PR DESCRIPTION
* Deprecate `Mathlib.LinearAlgebra.FreeModule.StrongRankCondition`
* Minimise imports of files that used to import it

This file contains a single declaration, which is an instance whose proof is `inferInstance`.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib.2ELinearAlgebra.2EFreeModule.2EStrongRankCondition/with/586164258

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
