### PR TITLE
feat(Order/ConditionallyCompleteLattice): ConditionallyCompleteSemiLatticeInf

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -163,8 +163,8 @@ namespace OrderDual
 
 instance instConditionallyCompleteLattice (α : Type*) [ConditionallyCompleteLattice α] :
     ConditionallyCompleteLattice αᵒᵈ where
-  isLUB_csSup := ConditionallyCompleteLattice.isGLB_csInf (α := α)
-  isGLB_csInf := ConditionallyCompleteLattice.isLUB_csSup (α := α)
+  isLUB_csSup _ hn hb := isGLB_csInf (α := α) hn hb
+  isGLB_csInf _ hn hb := isLUB_csSup (α := α) hn hb
 
 instance (α : Type*) [ConditionallyCompleteLinearOrder α] :
     ConditionallyCompleteLinearOrder αᵒᵈ where
@@ -178,10 +178,6 @@ end OrderDual
 section ConditionallyCompleteLattice
 
 variable [ConditionallyCompleteLattice α] {s t : Set α} {a b : α}
-
-@[to_dual]
-theorem isLUB_csSup (hn : s.Nonempty) (hb : BddAbove s := by bddDefault) : IsLUB s (sSup s) :=
-  ConditionallyCompleteLattice.isLUB_csSup _ hn hb
 
 theorem le_csSup (h₁ : BddAbove s) (h₂ : a ∈ s) : a ≤ sSup s :=
   (isLUB_csSup (nonempty_of_mem h₂) h₁).1 h₂
@@ -223,7 +219,7 @@ theorem IsLUB.csSup_eq (H : IsLUB s a) (ne : s.Nonempty) : sSup s = a :=
 instance (priority := 100) ConditionallyCompleteLattice.toConditionallyCompletePartialOrder :
     ConditionallyCompletePartialOrder α where
   isGLB_csInf_of_directed _ _ := isGLB_csInf _
-  isLUB_csSup_of_directed _ _ := isLUB_csSup _
+  isLUB_csSup_of_directed _ _ hn hb := isLUB_csSup (α := α) hn hb
 
 theorem subset_Icc_csInf_csSup (hb : BddBelow s) (ha : BddAbove s) : s ⊆ Icc (sInf s) (sSup s) :=
   fun _ hx => ⟨csInf_le hb hx, le_csSup ha hx⟩
@@ -543,10 +539,6 @@ theorem csInf_univ [ConditionallyCompleteLattice α] [OrderBot α] : sInf (univ 
   isLeast_univ.csInf_eq
 
 variable [ConditionallyCompleteLinearOrderBot α] {s : Set α} {a : α}
-
-@[simp]
-theorem csSup_empty : (sSup ∅ : α) = ⊥ :=
-  ConditionallyCompleteLinearOrderBot.csSup_empty
 
 theorem isLUB_csSup' {s : Set α} (hs : BddAbove s) : IsLUB s (sSup s) := by
   rcases eq_empty_or_nonempty s with (rfl | hne)

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -44,6 +44,8 @@ boundedness. -/
 class ConditionallyCompleteSemilatticeSup (α : Type*) extends SemilatticeSup α, SupSet α where
   /-- Every nonempty subset which is bounded above has a least upper bound. -/
   isLUB_csSup : ∀ s : Set α, s.Nonempty → BddAbove s → IsLUB s (sSup s)
+  /-- If the lattice has a bottom element, then `sSup ∅` is the bottom element. -/
+  csSup_empty : ∀ ⦃x⦄, IsBot x -> sSup ∅ = x
 
 /-- A conditionally complete semilattice is a semilattice in which every nonempty subset which is
 bounded below has a greatest lower bound.
@@ -56,6 +58,8 @@ boundedness. -/
 class ConditionallyCompleteSemilatticeInf (α : Type*) extends SemilatticeInf α, InfSet α where
   /-- Every nonempty subset which is bounded below has a greatest lower bound. -/
   isGLB_csInf : ∀ s : Set α, s.Nonempty → BddBelow s → IsGLB s (sInf s)
+  /-- If the lattice has a top element, then `sInf ∅` is the top element. -/
+  csInf_empty : ∀ ⦃x⦄, IsTop x -> sInf ∅ = x
 
 attribute [to_dual existing] ConditionallyCompleteSemilatticeInf.isGLB_csInf
   ConditionallyCompleteSemilatticeInf.toSemilatticeInf
@@ -66,40 +70,16 @@ instance OrderDual.instConditionallyCompleteSemilatticeSup (α)
     [h : ConditionallyCompleteSemilatticeInf α] : ConditionallyCompleteSemilatticeSup αᵒᵈ where
   sSup := sInf (α := α)
   isLUB_csSup := h.isGLB_csInf (α := α)
+  csSup_empty := h.csInf_empty (α := α)
 
 @[to_dual]
 theorem isGLB_csInf [ConditionallyCompleteSemilatticeInf α] {s : Set α} (hn : s.Nonempty)
     (hb : BddBelow s := by bddDefault) : IsGLB s (sInf s) :=
   ConditionallyCompleteSemilatticeInf.isGLB_csInf s hn hb
 
-/-- A conditionally complete semilattice with `Top` is a semilattice with greatest element, in which
-  every nonempty subset (necessarily bounded above) has a supremum.
-
-To differentiate the statements from the corresponding statements in (unconditional)
-complete lattices, we prefix `sSup` by a `c` everywhere. The same statements should
-hold in both worlds, sometimes with additional assumptions of nonemptiness or
-boundedness. -/
-class ConditionallyCompleteSemilatticeSupBot (α : Type*) extends
-  ConditionallyCompleteSemilatticeSup α, OrderBot α where
-  /-- The supremum of the empty set is `⊥`. -/
-  csSup_empty : sSup ∅ = (⊥ : α)
-
-/-- A conditionally complete semilattice with `Bot` is a semilattice with least element, in which
-  every nonempty subset (necessarily bounded below) has an infimum.
-
-To differentiate the statements from the corresponding statements in (unconditional)
-complete lattices, we prefix `sInf` by a `c` everywhere. The same statements should
-hold in both worlds, sometimes with additional assumptions of nonemptiness or
-boundedness. -/
-@[to_dual existing]
-class ConditionallyCompleteSemilatticeInfTop (α : Type*) extends
-  ConditionallyCompleteSemilatticeInf α, OrderTop α where
-  /-- The infimum of the empty set is `⊥`. -/
-  csInf_empty : sInf ∅ = (⊤ : α)
-
 @[to_dual, simp]
-theorem csSup_empty [ConditionallyCompleteSemilatticeSupBot α] : sSup ∅ = (⊥ : α) :=
-  ConditionallyCompleteSemilatticeSupBot.csSup_empty
+theorem csSup_empty [ConditionallyCompleteSemilatticeSup α] {x : α} (h : IsBot x) : sSup ∅ = x :=
+  ConditionallyCompleteSemilatticeSup.csSup_empty h
 
 /-- A conditionally complete lattice is a lattice in which
 every nonempty subset which is bounded above has a supremum, and
@@ -153,14 +133,9 @@ hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
 class ConditionallyCompleteLinearOrderBot (α : Type*) extends ConditionallyCompleteLinearOrder α,
     OrderBot α where
-  /-- The supremum of the empty set is special-cased to `⊥` -/
-  csSup_empty : sSup ∅ = ⊥
 
 -- see Note [lower instance priority]
 attribute [instance 100] ConditionallyCompleteLinearOrderBot.toOrderBot
-
-instance [ConditionallyCompleteLinearOrderBot α] : ConditionallyCompleteSemilatticeSupBot α where
-  csSup_empty := ConditionallyCompleteLinearOrderBot.csSup_empty
 
 /-- Create a `ConditionallyCompleteSemilatticeInf` from a `PartialOrder` and `sInf` function
 that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
@@ -173,12 +148,14 @@ constructor provides poor definitional equalities.  If other fields are known ex
 should be provided. -/]
 def conditionallyCompleteSemilatticeInfOfsInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
-    (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s)) :
+    (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s))
+    (csInf_empty : ∀ ⦃x : α⦄, IsTop x -> sInf ∅ = x):
     ConditionallyCompleteSemilatticeInf α where
   __ := H2
   __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
     (fun a b ↦ isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _))
   isGLB_csInf _ hn hb := isGLB_sInf _ hb hn
+  csInf_empty := csInf_empty
 
 /-- Create a `ConditionallyCompleteSemilatticeInfBot` from a `PartialOrder`, `OrderBot` and `sInf`
 function that returns the greatest lower bound of a nonempty set. Usually this constructor provides
@@ -190,13 +167,13 @@ poor definitional equalities.  If other fields are known explicitly, they should
 def conditionallyCompleteSemilatticeInfOfsInfTop (α : Type*) [PartialOrder α] [H1 : InfSet α]
     [H2 : OrderTop α] (sInf_empty : sInf ∅ = (⊤ : α))
     (isGLB_sInf : ∀ s : Set α, s.Nonempty → IsGLB s (sInf s)) :
-    ConditionallyCompleteSemilatticeInfTop α where
+    ConditionallyCompleteSemilatticeInf α where
   __ := H1
   __ := H2
   __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
     (fun a b ↦ isGLB_sInf {a, b} (insert_nonempty _ _))
   isGLB_csInf _ hn _ := isGLB_sInf _ hn
-  csInf_empty := sInf_empty
+  csInf_empty _ hx := hx.eq_top ▸ sInf_empty
 
 /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sSup` function
 that returns the least upper bound of a nonempty set which is bounded above. Usually this
@@ -232,7 +209,8 @@ instance : ConditionallyCompleteLattice my_T :=
 def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
     (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
-    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
+    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s))
+    (csSup_empty : ∀ ⦃x : α⦄, IsBot x -> sSup ∅ = x) :
     ConditionallyCompleteLattice α where
   __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
     (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
@@ -242,6 +220,11 @@ def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 :
   sInf s := sSup (lowerBounds s)
   isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
   isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
+  csSup_empty := csSup_empty
+  csInf_empty x hx := by
+    rw [lowerBounds_empty]
+    exact isLUB_sSup univ ⟨x, fun ⦃a⦄ a_1 ↦ hx a⟩ ⟨x, mem_univ x⟩ |>.isLeast_iff_eq.mp
+      ⟨fun ⦃a⦄ a_1 ↦ hx a, fun y hy ↦ hy <| mem_univ x⟩
 
 /-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
 
@@ -251,13 +234,13 @@ This should only be used when it is both hard and unnecessary to provide `sInf` 
 
 This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
 def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
-    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
-    ConditionallyCompleteLattice α :=
-  { H1,
-    conditionallyCompleteLatticeOfsSup α
-      (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
-      (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
-      isLUB_sSup with }
+    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s))
+    (csSup_empty : ∀ ⦃x : α⦄, IsBot x -> sSup ∅ = x) : ConditionallyCompleteLattice α :=
+  {__ := H1,
+   __ := conditionallyCompleteLatticeOfsSup α
+    (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
+    (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
+    isLUB_sSup csSup_empty}
 
 open scoped Classical in
 /-- A well-founded linear order is conditionally complete, with a bottom element. -/

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -41,7 +41,7 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix `sSup` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-class ConditionallyCompleteSemiLatticeSup (α : Type*) extends SemilatticeSup α, SupSet α where
+class ConditionallyCompleteSemilatticeSup (α : Type*) extends SemilatticeSup α, SupSet α where
   /-- Every nonempty subset which is bounded above has a least upper bound. -/
   isLUB_csSup : ∀ s : Set α, s.Nonempty → BddAbove s → IsLUB s (sSup s)
 
@@ -52,25 +52,25 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix `sInf` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-@[to_dual]
-class ConditionallyCompleteSemiLatticeInf (α : Type*) extends SemilatticeInf α, InfSet α where
+@[to_dual existing]
+class ConditionallyCompleteSemilatticeInf (α : Type*) extends SemilatticeInf α, InfSet α where
   /-- Every nonempty subset which is bounded below has a greatest lower bound. -/
   isGLB_csInf : ∀ s : Set α, s.Nonempty → BddBelow s → IsGLB s (sInf s)
 
-attribute [to_dual existing] ConditionallyCompleteSemiLatticeInf.isGLB_csInf
-  ConditionallyCompleteSemiLatticeInf.toSemilatticeInf
-  ConditionallyCompleteSemiLatticeInf.toInfSet
+attribute [to_dual existing] ConditionallyCompleteSemilatticeInf.isGLB_csInf
+  ConditionallyCompleteSemilatticeInf.toSemilatticeInf
+  ConditionallyCompleteSemilatticeInf.toInfSet
 
 @[to_dual]
-instance OrderDual.instConditionallyCompleteSemiLatticeSup (α)
-    [h : ConditionallyCompleteSemiLatticeInf α] : ConditionallyCompleteSemiLatticeSup αᵒᵈ where
+instance OrderDual.instConditionallyCompleteSemilatticeSup (α)
+    [h : ConditionallyCompleteSemilatticeInf α] : ConditionallyCompleteSemilatticeSup αᵒᵈ where
   sSup := sInf (α := α)
   isLUB_csSup := h.isGLB_csInf (α := α)
 
 @[to_dual]
-theorem isGLB_csInf [ConditionallyCompleteSemiLatticeInf α] {s : Set α} (hn : s.Nonempty)
+theorem isGLB_csInf [ConditionallyCompleteSemilatticeInf α] {s : Set α} (hn : s.Nonempty)
     (hb : BddBelow s := by bddDefault) : IsGLB s (sInf s) :=
-  ConditionallyCompleteSemiLatticeInf.isGLB_csInf s hn hb
+  ConditionallyCompleteSemilatticeInf.isGLB_csInf s hn hb
 
 /-- A conditionally complete semilattice with `Top` is a semilattice with greatest element, in which
   every nonempty subset (necessarily bounded above) has a supremum.
@@ -79,8 +79,8 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix `sSup` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-class ConditionallyCompleteSemiLatticeSupBot (α : Type*) extends
-  ConditionallyCompleteSemiLatticeSup α, OrderBot α where
+class ConditionallyCompleteSemilatticeSupBot (α : Type*) extends
+  ConditionallyCompleteSemilatticeSup α, OrderBot α where
   /-- The supremum of the empty set is `⊥`. -/
   csSup_empty : sSup ∅ = (⊥ : α)
 
@@ -91,15 +91,15 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix `sInf` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-@[to_dual]
-class ConditionallyCompleteSemiLatticeInfTop (α : Type*) extends
-  ConditionallyCompleteSemiLatticeInf α, OrderTop α where
+@[to_dual existing]
+class ConditionallyCompleteSemilatticeInfTop (α : Type*) extends
+  ConditionallyCompleteSemilatticeInf α, OrderTop α where
   /-- The infimum of the empty set is `⊥`. -/
   csInf_empty : sInf ∅ = (⊤ : α)
 
 @[to_dual, simp]
-theorem csSup_empty [ConditionallyCompleteSemiLatticeSupBot α] : sSup ∅ = (⊥ : α) :=
-  ConditionallyCompleteSemiLatticeSupBot.csSup_empty
+theorem csSup_empty [ConditionallyCompleteSemilatticeSupBot α] : sSup ∅ = (⊥ : α) :=
+  ConditionallyCompleteSemilatticeSupBot.csSup_empty
 
 /-- A conditionally complete lattice is a lattice in which
 every nonempty subset which is bounded above has a supremum, and
@@ -111,9 +111,9 @@ complete lattices, we prefix `sInf` and `sSup` by a `c` everywhere. The same sta
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
 class ConditionallyCompleteLattice (α : Type*) extends
-  ConditionallyCompleteSemiLatticeSup α, ConditionallyCompleteSemiLatticeInf α
+  ConditionallyCompleteSemilatticeSup α, ConditionallyCompleteSemilatticeInf α
 
-attribute [to_dual existing] ConditionallyCompleteLattice.toConditionallyCompleteSemiLatticeInf
+attribute [to_dual existing] ConditionallyCompleteLattice.toConditionallyCompleteSemilatticeInf
 
 /-- A conditionally complete linear order is a linear order in which
 every nonempty subset which is bounded above has a supremum, and
@@ -159,40 +159,40 @@ class ConditionallyCompleteLinearOrderBot (α : Type*) extends ConditionallyComp
 -- see Note [lower instance priority]
 attribute [instance 100] ConditionallyCompleteLinearOrderBot.toOrderBot
 
-instance [ConditionallyCompleteLinearOrderBot α] : ConditionallyCompleteSemiLatticeSupBot α where
+instance [ConditionallyCompleteLinearOrderBot α] : ConditionallyCompleteSemilatticeSupBot α where
   csSup_empty := ConditionallyCompleteLinearOrderBot.csSup_empty
 
-/-- Create a `ConditionallyCompleteSemiLatticeInf` from a `PartialOrder` and `sInf` function
+/-- Create a `ConditionallyCompleteSemilatticeInf` from a `PartialOrder` and `sInf` function
 that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
 constructor provides poor definitional equalities.  If other fields are known explicitly, they
 should be provided. -/
 @[to_dual (attr := implicit_reducible)
-/-- Create a `ConditionallyCompleteSemiLatticeSup` from a `PartialOrder` and `sSup` function
+/-- Create a `ConditionallyCompleteSemilatticeSup` from a `PartialOrder` and `sSup` function
 that returns the least upper bound of a nonempty set which is bounded above. Usually this
 constructor provides poor definitional equalities.  If other fields are known explicitly, they
 should be provided. -/]
-def conditionallyCompleteSemiLatticeInfOfsInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
+def conditionallyCompleteSemilatticeInfOfsInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
     (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s)) :
-    ConditionallyCompleteSemiLatticeInf α where
+    ConditionallyCompleteSemilatticeInf α where
   __ := H2
   __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
     (fun a b ↦ isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _))
   isGLB_csInf _ hn hb := isGLB_sInf _ hb hn
 
-/-- Create a `ConditionallyCompleteSemiLatticeInfBot` from a `PartialOrder`, `OrderBot` and `sInf`
+/-- Create a `ConditionallyCompleteSemilatticeInfBot` from a `PartialOrder`, `OrderBot` and `sInf`
 function that returns the greatest lower bound of a nonempty set. Usually this constructor provides
 poor definitional equalities.  If other fields are known explicitly, they should be provided. -/
 @[to_dual (attr := implicit_reducible)
-/-- Create a `ConditionallyCompleteSemiLatticeSupTop` from a `PartialOrder`, `OrderTop` and `sSup`
+/-- Create a `ConditionallyCompleteSemilatticeSupTop` from a `PartialOrder`, `OrderTop` and `sSup`
 function that returns the least upper bound of a nonempty set. Usually this constructor provides
 poor definitional equalities.  If other fields are known explicitly, they should be provided. -/]
-def conditionallyCompleteSemiLatticeInfOfsInfTop (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
-    [H3 : OrderTop α] (sInf_empty : sInf ∅ = (⊤ : α))
+def conditionallyCompleteSemilatticeInfOfsInfTop (α : Type*) [PartialOrder α] [H1 : InfSet α]
+    [H2 : OrderTop α] (sInf_empty : sInf ∅ = (⊤ : α))
     (isGLB_sInf : ∀ s : Set α, s.Nonempty → IsGLB s (sInf s)) :
-    ConditionallyCompleteSemiLatticeInfTop α where
+    ConditionallyCompleteSemilatticeInfTop α where
+  __ := H1
   __ := H2
-  __ := H3
   __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
     (fun a b ↦ isGLB_sInf {a, b} (insert_nonempty _ _))
   isGLB_csInf _ hn _ := isGLB_sInf _ hn
@@ -213,7 +213,7 @@ instance : ConditionallyCompleteLattice my_T where
   __ := conditionallyCompleteLatticeOfsSup my_T ...
 ```
 -/
-@[to_dual (attr := implicit_reducible) (reorder := H1 H2)
+@[to_dual (attr := implicit_reducible)
 /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
 that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
 constructor provides poor definitional equalities.  If other fields are known explicitly, they

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -34,6 +34,73 @@ open Set
 
 variable {α β γ : Type*} {ι : Sort*}
 
+/-- A conditionally complete semilattice is a semilattice in which every nonempty subset which is
+  bounded above has a least upper bound.
+
+To differentiate the statements from the corresponding statements in (unconditional)
+complete lattices, we prefix `sSup` by a `c` everywhere. The same statements should
+hold in both worlds, sometimes with additional assumptions of nonemptiness or
+boundedness. -/
+class ConditionallyCompleteSemiLatticeSup (α : Type*) extends SemilatticeSup α, SupSet α where
+  /-- Every nonempty subset which is bounded above has a least upper bound. -/
+  isLUB_csSup : ∀ s : Set α, s.Nonempty → BddAbove s → IsLUB s (sSup s)
+
+/-- A conditionally complete semilattice is a semilattice in which every nonempty subset which is
+bounded below has a greatest lower bound.
+
+To differentiate the statements from the corresponding statements in (unconditional)
+complete lattices, we prefix `sInf` by a `c` everywhere. The same statements should
+hold in both worlds, sometimes with additional assumptions of nonemptiness or
+boundedness. -/
+@[to_dual]
+class ConditionallyCompleteSemiLatticeInf (α : Type*) extends SemilatticeInf α, InfSet α where
+  /-- Every nonempty subset which is bounded below has a greatest lower bound. -/
+  isGLB_csInf : ∀ s : Set α, s.Nonempty → BddBelow s → IsGLB s (sInf s)
+
+attribute [to_dual existing] ConditionallyCompleteSemiLatticeInf.isGLB_csInf
+  ConditionallyCompleteSemiLatticeInf.toSemilatticeInf
+  ConditionallyCompleteSemiLatticeInf.toInfSet
+
+@[to_dual]
+instance OrderDual.instConditionallyCompleteSemiLatticeSup (α)
+    [h : ConditionallyCompleteSemiLatticeInf α] : ConditionallyCompleteSemiLatticeSup αᵒᵈ where
+  sSup := sInf (α := α)
+  isLUB_csSup := h.isGLB_csInf (α := α)
+
+@[to_dual]
+theorem isGLB_csInf [ConditionallyCompleteSemiLatticeInf α] {s : Set α} (hn : s.Nonempty)
+    (hb : BddBelow s := by bddDefault) : IsGLB s (sInf s) :=
+  ConditionallyCompleteSemiLatticeInf.isGLB_csInf s hn hb
+
+/-- A conditionally complete semilattice with `Top` is a semilattice with greatest element, in which
+  every nonempty subset (necessarily bounded above) has a supremum.
+
+To differentiate the statements from the corresponding statements in (unconditional)
+complete lattices, we prefix `sSup` by a `c` everywhere. The same statements should
+hold in both worlds, sometimes with additional assumptions of nonemptiness or
+boundedness. -/
+class ConditionallyCompleteSemiLatticeSupBot (α : Type*) extends
+  ConditionallyCompleteSemiLatticeSup α, OrderBot α where
+  /-- The supremum of the empty set is `⊥`. -/
+  csSup_empty : sSup ∅ = (⊥ : α)
+
+/-- A conditionally complete semilattice with `Bot` is a semilattice with least element, in which
+  every nonempty subset (necessarily bounded below) has an infimum.
+
+To differentiate the statements from the corresponding statements in (unconditional)
+complete lattices, we prefix `sInf` by a `c` everywhere. The same statements should
+hold in both worlds, sometimes with additional assumptions of nonemptiness or
+boundedness. -/
+@[to_dual]
+class ConditionallyCompleteSemiLatticeInfTop (α : Type*) extends
+  ConditionallyCompleteSemiLatticeInf α, OrderTop α where
+  /-- The infimum of the empty set is `⊥`. -/
+  csInf_empty : sInf ∅ = (⊤ : α)
+
+@[to_dual, simp]
+theorem csSup_empty [ConditionallyCompleteSemiLatticeSupBot α] : sSup ∅ = (⊥ : α) :=
+  ConditionallyCompleteSemiLatticeSupBot.csSup_empty
+
 /-- A conditionally complete lattice is a lattice in which
 every nonempty subset which is bounded above has a supremum, and
 every nonempty subset which is bounded below has an infimum.
@@ -43,15 +110,10 @@ To differentiate the statements from the corresponding statements in (unconditio
 complete lattices, we prefix `sInf` and `sSup` by a `c` everywhere. The same statements should
 hold in both worlds, sometimes with additional assumptions of nonemptiness or
 boundedness. -/
-class ConditionallyCompleteLattice (α : Type*) extends Lattice α, SupSet α, InfSet α where
-  /-- Every nonempty subset which is bounded above has a least upper bound. -/
-  isLUB_csSup : ∀ s : Set α, s.Nonempty → BddAbove s → IsLUB s (sSup s)
-  /-- Every nonempty subset which is bounded below has a greatest lower bound. -/
-  isGLB_csInf : ∀ s : Set α, s.Nonempty → BddBelow s → IsGLB s (sInf s)
+class ConditionallyCompleteLattice (α : Type*) extends
+  ConditionallyCompleteSemiLatticeSup α, ConditionallyCompleteSemiLatticeInf α
 
-attribute [to_dual self (reorder := 3 4, 5 6)] ConditionallyCompleteLattice.mk
-attribute [to_dual existing] ConditionallyCompleteLattice.toSupSet
-attribute [to_dual existing] ConditionallyCompleteLattice.isLUB_csSup
+attribute [to_dual existing] ConditionallyCompleteLattice.toConditionallyCompleteSemiLatticeInf
 
 /-- A conditionally complete linear order is a linear order in which
 every nonempty subset which is bounded above has a supremum, and
@@ -97,82 +159,121 @@ class ConditionallyCompleteLinearOrderBot (α : Type*) extends ConditionallyComp
 -- see Note [lower instance priority]
 attribute [instance 100] ConditionallyCompleteLinearOrderBot.toOrderBot
 
-/-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sup` function
-that returns the least upper bound of a nonempty set which is bounded above. Usually this
-constructor provides poor definitional equalities.  If other fields are known explicitly, they
-should be provided; for example, if `inf` is known explicitly, construct the
-`ConditionallyCompleteLattice` instance as
-```
-instance : ConditionallyCompleteLattice my_T where
-  inf := better_inf
-  le_inf := ...
-  inf_le_right := ...
-  inf_le_left := ...
-  -- don't care to fix sup, sInf
-  __ := conditionallyCompleteLatticeOfsSup my_T ...
-```
--/
-@[to_dual (attr := implicit_reducible) (reorder := 4 5)
-/-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
+instance [ConditionallyCompleteLinearOrderBot α] : ConditionallyCompleteSemiLatticeSupBot α where
+  csSup_empty := ConditionallyCompleteLinearOrderBot.csSup_empty
+
+/-- Create a `ConditionallyCompleteSemiLatticeInf` from a `PartialOrder` and `sInf` function
 that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
 constructor provides poor definitional equalities.  If other fields are known explicitly, they
-should be provided; for example, if `inf` is known explicitly, construct the
-`ConditionallyCompleteLattice` instance as
-```
-instance : ConditionallyCompleteLattice my_T :=
-  inf := better_inf
-  le_inf := ...
-  inf_le_right := ...
-  inf_le_left := ...
-  -- don't care to fix sup, sSup
-  __ := conditionallyCompleteLatticeOfsInf my_T ...
-```
--/]
-def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
-    (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
-    (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
-    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
-    ConditionallyCompleteLattice α where
-  __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
-    (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
-    (fun a b ↦ isLUB_lowerBounds.mp <| isLUB_sSup (lowerBounds {a, b})
-      (insert_nonempty _ _).bddAbove_lowerBounds (bddBelow_pair a b))
-  __ := H2
-  sInf s := sSup (lowerBounds s)
-  isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
-  isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
-
-/-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
-
-This should only be used when it is both hard and unnecessary to provide `sInf` explicitly. -/
+should be provided. -/
 @[to_dual (attr := implicit_reducible)
-/-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
+/-- Create a `ConditionallyCompleteSemiLatticeSup` from a `PartialOrder` and `sSup` function
+that returns the least upper bound of a nonempty set which is bounded above. Usually this
+constructor provides poor definitional equalities.  If other fields are known explicitly, they
+should be provided. -/]
+def conditionallyCompleteSemiLatticeInfOfsInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
+    (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
+    (isGLB_sInf : ∀ s : Set α, BddBelow s → s.Nonempty → IsGLB s (sInf s)) :
+    ConditionallyCompleteSemiLatticeInf α where
+  __ := H2
+  __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
+    (fun a b ↦ isGLB_sInf {a, b} (bddBelow_pair a b) (insert_nonempty _ _))
+  isGLB_csInf _ hn hb := isGLB_sInf _ hb hn
 
-This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
-def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
-    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
-    ConditionallyCompleteLattice α :=
-  { H1,
-    conditionallyCompleteLatticeOfsSup α
-      (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
-      (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
-      isLUB_sSup with }
+/-- Create a `ConditionallyCompleteSemiLatticeInfBot` from a `PartialOrder`, `OrderBot` and `sInf`
+function that returns the greatest lower bound of a nonempty set. Usually this constructor provides
+poor definitional equalities.  If other fields are known explicitly, they should be provided. -/
+@[to_dual (attr := implicit_reducible)
+/-- Create a `ConditionallyCompleteSemiLatticeSupTop` from a `PartialOrder`, `OrderTop` and `sSup`
+function that returns the least upper bound of a nonempty set. Usually this constructor provides
+poor definitional equalities.  If other fields are known explicitly, they should be provided. -/]
+def conditionallyCompleteSemiLatticeInfOfsInfTop (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
+    [H3 : OrderTop α] (sInf_empty : sInf ∅ = (⊤ : α))
+    (isGLB_sInf : ∀ s : Set α, s.Nonempty → IsGLB s (sInf s)) :
+    ConditionallyCompleteSemiLatticeInfTop α where
+  __ := H2
+  __ := H3
+  __ := SemilatticeInf.ofIsGLB (fun a b ↦ sInf {a, b})
+    (fun a b ↦ isGLB_sInf {a, b} (insert_nonempty _ _))
+  isGLB_csInf _ hn _ := isGLB_sInf _ hn
+  csInf_empty := sInf_empty
 
-open scoped Classical in
-/-- A well-founded linear order is conditionally complete, with a bottom element. -/
-noncomputable abbrev WellFoundedLT.conditionallyCompleteLinearOrderBot (α : Type*)
-    [i₁ : LinearOrder α] [i₂ : OrderBot α] [h : WellFoundedLT α] :
-    ConditionallyCompleteLinearOrderBot α where
-  __ := i₁
-  __ := i₂
-  __ := LinearOrder.toLattice
-  __ :=
-    letI : InfSet α := ⟨fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥⟩
-    conditionallyCompleteLatticeOfLatticeOfsInf _ fun s _ hn ↦ by
-      simp only [dif_pos hn]
-      exact IsLeast.isGLB ⟨h.wf.min_mem s hn, fun _ hx ↦ h.wf.min_le hx⟩
-  csSup_empty := by simp [sSup, bot_unique (WellFounded.min_le _ (mem_univ _))]
-  csSup_of_not_bddAbove s H := by
-    rw [BddAbove] at H
-    simp [sSup, H, bot_unique (WellFounded.min_le _ (mem_univ _))]
-  csInf_of_not_bddBelow s H := (H (OrderBot.bddBelow s)).elim
+-- /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sSup` function
+-- that returns the least upper bound of a nonempty set which is bounded above. Usually this
+-- constructor provides poor definitional equalities.  If other fields are known explicitly, they
+-- should be provided; for example, if `inf` is known explicitly, construct the
+-- `ConditionallyCompleteLattice` instance as
+-- ```
+-- instance : ConditionallyCompleteLattice my_T where
+--   inf := better_inf
+--   le_inf := ...
+--   inf_le_right := ...
+--   inf_le_left := ...
+--   -- don't care to fix sup, sInf
+--   __ := conditionallyCompleteLatticeOfsSup my_T ...
+-- ```
+-- -/
+-- @[to_dual (attr := implicit_reducible) (reorder := H1 H2)
+-- /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
+-- that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
+-- constructor provides poor definitional equalities.  If other fields are known explicitly, they
+-- should be provided; for example, if `inf` is known explicitly, construct the
+-- `ConditionallyCompleteLattice` instance as
+-- ```
+-- instance : ConditionallyCompleteLattice my_T :=
+--   inf := better_inf
+--   le_inf := ...
+--   inf_le_right := ...
+--   inf_le_left := ...
+--   -- don't care to fix sup, sSup
+--   __ := conditionallyCompleteLatticeOfsInf my_T ...
+-- ```
+-- -/]
+-- def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
+--     (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
+--     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
+--     (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
+--     ConditionallyCompleteLattice α where
+--   __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
+--     (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
+--     (fun a b ↦ isLUB_lowerBounds.mp <| isLUB_sSup (lowerBounds {a, b})
+--       (insert_nonempty _ _).bddAbove_lowerBounds (bddBelow_pair a b))
+--   __ := H2
+--   sInf s := sSup (lowerBounds s)
+--   isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
+--   isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
+
+-- /-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
+
+-- This should only be used when it is both hard and unnecessary to provide `sInf` explicitly. -/
+-- @[to_dual (attr := implicit_reducible)
+-- /-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
+
+-- This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
+-- def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
+--     (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
+--     ConditionallyCompleteLattice α :=
+--   { H1,
+--     conditionallyCompleteLatticeOfsSup α
+--       (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
+--       (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
+--       isLUB_sSup with }
+
+-- open scoped Classical in
+-- /-- A well-founded linear order is conditionally complete, with a bottom element. -/
+-- noncomputable abbrev WellFoundedLT.conditionallyCompleteLinearOrderBot (α : Type*)
+--     [i₁ : LinearOrder α] [i₂ : OrderBot α] [h : WellFoundedLT α] :
+--     ConditionallyCompleteLinearOrderBot α where
+--   __ := i₁
+--   __ := i₂
+--   __ := LinearOrder.toLattice
+--   __ :=
+--     letI : InfSet α := ⟨fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥⟩
+--     conditionallyCompleteLatticeOfLatticeOfsInf _ fun s _ hn ↦ by
+--       simp only [dif_pos hn]
+--       exact IsLeast.isGLB ⟨h.wf.min_mem s hn, fun _ hx ↦ h.wf.min_le hx⟩
+--   csSup_empty := by simp [sSup, bot_unique (WellFounded.min_le _ (mem_univ _))]
+--   csSup_of_not_bddAbove s H := by
+--     rw [BddAbove] at H
+--     simp [sSup, H, bot_unique (WellFounded.min_le _ (mem_univ _))]
+--   csInf_of_not_bddBelow s H := (H (OrderBot.bddBelow s)).elim

--- a/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Defs.lean
@@ -198,82 +198,82 @@ def conditionallyCompleteSemiLatticeInfOfsInfTop (α : Type*) [H1 : PartialOrder
   isGLB_csInf _ hn _ := isGLB_sInf _ hn
   csInf_empty := sInf_empty
 
--- /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sSup` function
--- that returns the least upper bound of a nonempty set which is bounded above. Usually this
--- constructor provides poor definitional equalities.  If other fields are known explicitly, they
--- should be provided; for example, if `inf` is known explicitly, construct the
--- `ConditionallyCompleteLattice` instance as
--- ```
--- instance : ConditionallyCompleteLattice my_T where
---   inf := better_inf
---   le_inf := ...
---   inf_le_right := ...
---   inf_le_left := ...
---   -- don't care to fix sup, sInf
---   __ := conditionallyCompleteLatticeOfsSup my_T ...
--- ```
--- -/
--- @[to_dual (attr := implicit_reducible) (reorder := H1 H2)
--- /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
--- that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
--- constructor provides poor definitional equalities.  If other fields are known explicitly, they
--- should be provided; for example, if `inf` is known explicitly, construct the
--- `ConditionallyCompleteLattice` instance as
--- ```
--- instance : ConditionallyCompleteLattice my_T :=
---   inf := better_inf
---   le_inf := ...
---   inf_le_right := ...
---   inf_le_left := ...
---   -- don't care to fix sup, sSup
---   __ := conditionallyCompleteLatticeOfsInf my_T ...
--- ```
--- -/]
--- def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
---     (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
---     (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
---     (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
---     ConditionallyCompleteLattice α where
---   __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
---     (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
---     (fun a b ↦ isLUB_lowerBounds.mp <| isLUB_sSup (lowerBounds {a, b})
---       (insert_nonempty _ _).bddAbove_lowerBounds (bddBelow_pair a b))
---   __ := H2
---   sInf s := sSup (lowerBounds s)
---   isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
---   isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
+/-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sSup` function
+that returns the least upper bound of a nonempty set which is bounded above. Usually this
+constructor provides poor definitional equalities.  If other fields are known explicitly, they
+should be provided; for example, if `inf` is known explicitly, construct the
+`ConditionallyCompleteLattice` instance as
+```
+instance : ConditionallyCompleteLattice my_T where
+  inf := better_inf
+  le_inf := ...
+  inf_le_right := ...
+  inf_le_left := ...
+  -- don't care to fix sup, sInf
+  __ := conditionallyCompleteLatticeOfsSup my_T ...
+```
+-/
+@[to_dual (attr := implicit_reducible) (reorder := H1 H2)
+/-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sInf` function
+that returns the greatest lower bound of a nonempty set which is bounded below. Usually this
+constructor provides poor definitional equalities.  If other fields are known explicitly, they
+should be provided; for example, if `inf` is known explicitly, construct the
+`ConditionallyCompleteLattice` instance as
+```
+instance : ConditionallyCompleteLattice my_T :=
+  inf := better_inf
+  le_inf := ...
+  inf_le_right := ...
+  inf_le_left := ...
+  -- don't care to fix sup, sSup
+  __ := conditionallyCompleteLatticeOfsInf my_T ...
+```
+-/]
+def conditionallyCompleteLatticeOfsSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
+    (bddAbove_pair : ∀ a b : α, BddAbove ({a, b} : Set α))
+    (bddBelow_pair : ∀ a b : α, BddBelow ({a, b} : Set α))
+    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
+    ConditionallyCompleteLattice α where
+  __ := Lattice.ofIsLUBofIsGLB (fun a b ↦ sSup {a, b}) (fun a b ↦ sSup (lowerBounds {a, b}))
+    (fun a b ↦ isLUB_sSup {a, b} (bddAbove_pair a b) (insert_nonempty _ _))
+    (fun a b ↦ isLUB_lowerBounds.mp <| isLUB_sSup (lowerBounds {a, b})
+      (insert_nonempty _ _).bddAbove_lowerBounds (bddBelow_pair a b))
+  __ := H2
+  sInf s := sSup (lowerBounds s)
+  isLUB_csSup _ hn hb := isLUB_sSup _ hb hn
+  isGLB_csInf _ hn hb := isLUB_lowerBounds.mp (isLUB_sSup _ hn.bddAbove_lowerBounds hb)
 
--- /-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
+/-- A version of `conditionallyCompleteLatticeOfsSup` when we already know that `α` is a lattice.
 
--- This should only be used when it is both hard and unnecessary to provide `sInf` explicitly. -/
--- @[to_dual (attr := implicit_reducible)
--- /-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
+This should only be used when it is both hard and unnecessary to provide `sInf` explicitly. -/
+@[to_dual (attr := implicit_reducible)
+/-- A version of `conditionallyCompleteLatticeOfsInf` when we already know that `α` is a lattice.
 
--- This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
--- def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
---     (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
---     ConditionallyCompleteLattice α :=
---   { H1,
---     conditionallyCompleteLatticeOfsSup α
---       (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
---       (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
---       isLUB_sSup with }
+This should only be used when it is both hard and unnecessary to provide `sSup` explicitly. -/]
+def conditionallyCompleteLatticeOfLatticeOfsSup (α : Type*) [H1 : Lattice α] [SupSet α]
+    (isLUB_sSup : ∀ s : Set α, BddAbove s → s.Nonempty → IsLUB s (sSup s)) :
+    ConditionallyCompleteLattice α :=
+  { H1,
+    conditionallyCompleteLatticeOfsSup α
+      (fun a b => ⟨a ⊔ b, forall_insert_of_forall (forall_eq.mpr le_sup_right) le_sup_left⟩)
+      (fun a b => ⟨a ⊓ b, forall_insert_of_forall (forall_eq.mpr inf_le_right) inf_le_left⟩)
+      isLUB_sSup with }
 
--- open scoped Classical in
--- /-- A well-founded linear order is conditionally complete, with a bottom element. -/
--- noncomputable abbrev WellFoundedLT.conditionallyCompleteLinearOrderBot (α : Type*)
---     [i₁ : LinearOrder α] [i₂ : OrderBot α] [h : WellFoundedLT α] :
---     ConditionallyCompleteLinearOrderBot α where
---   __ := i₁
---   __ := i₂
---   __ := LinearOrder.toLattice
---   __ :=
---     letI : InfSet α := ⟨fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥⟩
---     conditionallyCompleteLatticeOfLatticeOfsInf _ fun s _ hn ↦ by
---       simp only [dif_pos hn]
---       exact IsLeast.isGLB ⟨h.wf.min_mem s hn, fun _ hx ↦ h.wf.min_le hx⟩
---   csSup_empty := by simp [sSup, bot_unique (WellFounded.min_le _ (mem_univ _))]
---   csSup_of_not_bddAbove s H := by
---     rw [BddAbove] at H
---     simp [sSup, H, bot_unique (WellFounded.min_le _ (mem_univ _))]
---   csInf_of_not_bddBelow s H := (H (OrderBot.bddBelow s)).elim
+open scoped Classical in
+/-- A well-founded linear order is conditionally complete, with a bottom element. -/
+noncomputable abbrev WellFoundedLT.conditionallyCompleteLinearOrderBot (α : Type*)
+    [i₁ : LinearOrder α] [i₂ : OrderBot α] [h : WellFoundedLT α] :
+    ConditionallyCompleteLinearOrderBot α where
+  __ := i₁
+  __ := i₂
+  __ := LinearOrder.toLattice
+  __ :=
+    letI : InfSet α := ⟨fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥⟩
+    conditionallyCompleteLatticeOfLatticeOfsInf _ fun s _ hn ↦ by
+      simp only [dif_pos hn]
+      exact IsLeast.isGLB ⟨h.wf.min_mem s hn, fun _ hx ↦ h.wf.min_le hx⟩
+  csSup_empty := by simp [sSup, bot_unique (WellFounded.min_le _ (mem_univ _))]
+  csSup_of_not_bddAbove s H := by
+    rw [BddAbove] at H
+    simp [sSup, H, bot_unique (WellFounded.min_le _ (mem_univ _))]
+  csInf_of_not_bddBelow s H := (H (OrderBot.bddBelow s)).elim

--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -259,8 +259,8 @@ def ConditionallyCompleteLattice.copy (c : ConditionallyCompleteLattice α)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
     ConditionallyCompleteLattice α where
-  toLattice := Lattice.copy (@ConditionallyCompleteLattice.toLattice α c)
-    le eq_le sup eq_sup inf eq_inf
+  -- toLattice := Lattice.copy (@ConditionallyCompleteLattice.toLattice α c)
+  --   le eq_le sup eq_sup inf eq_inf
   sSup := sSup
   sInf := sInf
   isLUB_csSup := by subst_vars; exact c.isLUB_csSup


### PR DESCRIPTION
This PR introduces `ConditionallyCompleteSemilatticeSup/Inf`, Sup/Inf only versions of `ConditionallyCompleteLattice`. 

This is a preliminary PR for #37620, showing that `Graph` forms a `ConditionallyCompleteSemilatticeInf`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
