### PR TITLE
feat(LinearAlgebra/BilinearForm): add indefinite metrics

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4848,6 +4848,7 @@ public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.LinearAlgebra.BilinearForm.Basic
 public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
 public import Mathlib.LinearAlgebra.BilinearForm.Hom
+public import Mathlib.LinearAlgebra.BilinearForm.IndefiniteMetric
 public import Mathlib.LinearAlgebra.BilinearForm.Isometry
 public import Mathlib.LinearAlgebra.BilinearForm.IsometryEquiv
 public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal

--- a/Mathlib/LinearAlgebra/BilinearForm/IndefiniteMetric.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/IndefiniteMetric.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Ryan Nolan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ryan Nolan
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Basic
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
+public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+
+/-!
+# Indefinite Metrics
+
+This file defines indefinite metrics over modules. An indefinite metric is formalized as a
+symmetric bilinear form that is not required to be positive-definite. This provides the
+algebraic foundation for indefinite inner product spaces.
+
+## Main definitions
+
+* `IndefiniteMetric`: A structure bundling a bilinear form with a proof of its symmetry.
+* `IndefiniteMetric.toQuadraticForm`: The quadratic form associated with an indefinite metric.
+-/
+
+@[expose] public section
+
+variable {R : Type*} [CommRing R]
+variable {M : Type*} [AddCommGroup M] [Module R M]
+
+/-- An indefinite metric on a module `M` over a commutative ring `R` is a symmetric
+bilinear form. It drops the positive-definite requirement of standard inner products. -/
+structure IndefiniteMetric (R : Type*) (M : Type*) [CommRing R] [AddCommGroup M] [Module R M] where
+  /-- The underlying bilinear form. -/
+  bilin : LinearMap.BilinForm R M
+  /-- Proof that the bilinear form is symmetric. -/
+  symm : bilin.IsSymm
+
+namespace IndefiniteMetric
+
+variable (K : IndefiniteMetric R M)
+
+/-- The quadratic form associated with an indefinite metric. -/
+def toQuadraticForm : QuadraticForm R M :=
+  LinearMap.BilinMap.toQuadraticMap K.bilin
+
+end IndefiniteMetric


### PR DESCRIPTION
Add the `IndefiniteMetric` structure to support vector spaces equipped with a non-degenerate, symmetric, indefinite bilinear form.

Provide the algebraic foundation for indefinite inner product spaces by formalizing the metric via `LinearMap.BilinForm` and extracting its associated quadratic form without enforcing the `IsPosSemidef` typeclass.

Previously, mathlib required strictly positive-definite metrics to instantiate inner product spaces (`InnerProductSpace`), which prevented the formalization of indefinite geometries without causing typeclass inference failures. Bridge this gap by isolating the symmetric bilinear form from topological and positivity constraints, allowing the library to handle generalized indefinite metric spaces safely.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
