### PR TITLE
[Merged by Bors] - feat(MarkovCategory/Positive): Define `PositiveCategory`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2970,6 +2970,7 @@ public import Mathlib.CategoryTheory.LocallyCartesianClosed.Over
 public import Mathlib.CategoryTheory.LocallyCartesianClosed.Sections
 public import Mathlib.CategoryTheory.LocallyDirected
 public import Mathlib.CategoryTheory.MarkovCategory.Basic
+public import Mathlib.CategoryTheory.MarkovCategory.Positive
 public import Mathlib.CategoryTheory.Monad.Adjunction
 public import Mathlib.CategoryTheory.Monad.Algebra
 public import Mathlib.CategoryTheory.Monad.Basic

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -51,10 +51,6 @@ namespace Deterministic
 
 variable {X Y Z : C}
 
-instance {e : X ≅ Y} : Deterministic (e.hom ≫ e.inv) where
-
-instance {e : X ≅ Y} : Deterministic (e.inv ≫ e.hom) where
-
 /-- Deterministic morphisms commute with copying. -/
 lemma copy_natural (f : X ⟶ Y) [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
   IsComonHom.hom_comul f

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -51,6 +51,10 @@ namespace Deterministic
 
 variable {X Y Z : C}
 
+instance {e : X ≅ Y} : Deterministic (e.hom ≫ e.inv) where
+
+instance {e : X ≅ Y} : Deterministic (e.inv ≫ e.hom) where
+
 /-- Deterministic morphisms commute with copying. -/
 lemma copy_natural (f : X ⟶ Y) [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
   IsComonHom.hom_comul f

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -65,20 +65,21 @@ namespace PositiveCategory
 
 variable [PositiveCategory C]
 
-instance {X Y : C} {e : X ≅ Y} : Deterministic e.hom where
+instance {X Y : C} (f : X ⟶ Y) [IsIso f] : Deterministic f where
   hom_comul := by
     calc
-    _ = e.hom ≫ Δ ≫ (e.inv ⊗ₘ 𝟙 Y) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+    _ = f ≫ Δ ≫ (inv f ⊗ₘ 𝟙 Y) ≫ (f ⊗ₘ 𝟙 Y) := by
       cat_disch
-    _ = (e.hom ≫ Δ ≫ (e.inv ⊗ₘ 𝟙 Y)) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+    _ = (f ≫ Δ ≫ (inv f ⊗ₘ 𝟙 Y)) ≫ (f ⊗ₘ 𝟙 Y) := by
       simp
-    _ = (Δ ≫ (𝟙 X ⊗ₘ e.hom)) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
-      simp only [copy_comp_natural, Iso.hom_inv_id]
-    _ = Δ ≫ (𝟙 X ⊗ₘ e.hom) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+    _ = (Δ ≫ (𝟙 X ⊗ₘ f)) ≫ (f ⊗ₘ 𝟙 Y) := by
+      rw [copy_comp_natural (h := by rw [IsIso.hom_inv_id]; infer_instance)]
       simp
-    _ = Δ ≫ ((𝟙 X ≫ e.hom) ⊗ₘ (e.hom ≫ 𝟙 Y)) := by
+    _ = Δ ≫ (𝟙 X ⊗ₘ f) ≫ (f ⊗ₘ 𝟙 Y) := by
+      simp
+    _ = Δ ≫ ((𝟙 X ≫ f) ⊗ₘ (f ≫ 𝟙 Y)) := by
       rw [MonoidalCategory.tensorHom_comp_tensorHom]
-    _ = Δ ≫ (e.hom ⊗ₘ e.hom) := by cat_disch
+    _ = Δ ≫ (f ⊗ₘ f) := by cat_disch
 
 end PositiveCategory
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -39,8 +39,7 @@ deterministic process.
 
 * [Fritz, *A synthetic approach to Markov kernels, conditional independence
   and theorems on sufficient statistics*][fritz2020]
-* [Moss and Perrone, *A category-theoretic proof of the ergodic
-decomposition theorem*][moss2023]
+* [Moss and Perrone, *A category-theoretic proof of the ergodic decomposition theorem*][moss2023]
 -/
 
 @[expose] public section

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -52,7 +52,7 @@ namespace CategoryTheory
 open MonoidalCategory CopyDiscardCategory ComonObj
 
 /-- Markov category where copy is natural given deterministic composition of morphisms. -/
-class PositiveCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] extends
+class PositiveCategory (C : Type u) [Category.{v} C] [MonoidalCategory C] extends
     MarkovCategory C where
   /-- Given morphisms `f : X ⟶ Y` and `g : Y ⟶ Z`, if their composition is deterministic, then
   process `f`, copy and then process `g` equals copy and process `f` and `g` independently. -/

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -59,7 +59,7 @@ class PositiveCategory (C : Type u) [Category.{v} C] [MonoidalCategory C] extend
   copy_comp_natural {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [h : Deterministic (f ≫ g)] :
       f ≫ Δ ≫ (g ⊗ₘ 𝟙 Y) = Δ ≫ (f ≫ g ⊗ₘ f)
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+variable {C : Type u} [Category.{v} C] [MonoidalCategory C]
 
 namespace PositiveCategory
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -63,7 +63,7 @@ variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
 
 namespace PositiveCategory
 
-variable [PositiveCategory C] {X Y : C} {e : X ≅ Y}
+variable [PositiveCategory C]
 
 instance {X Y : C} {e : X ≅ Y} : Deterministic e.hom where
   hom_comul := by

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -56,7 +56,7 @@ class PositiveCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] ex
     MarkovCategory C where
   /-- Given morphisms `f : X ⟶ Y` and `g : Y ⟶ Z`, if their composition is deterministic, then
   process `f`, copy and then process `g` equals copy and process `f` and `g` independently. -/
-  copy_comp_natural {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Deterministic (f ≫ g)) :
+  copy_comp_natural {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [h : Deterministic (f ≫ g)] :
       f ≫ Δ ≫ (g ⊗ₘ 𝟙 Y) = Δ ≫ (f ≫ g ⊗ₘ f)
 
 variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -38,7 +38,7 @@ deterministic process.
 ## References
 
 * [Fritz, *A synthetic approach to Markov kernels, conditional independence
-  and theorems on sufficient statistics*][fritz2020]
+  and theorems on sufficient statistics*, Def. 11.22][fritz2020]
 * [Moss and Perrone, *A category-theoretic proof of the ergodic decomposition theorem*][moss2023]
 -/
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Gaëtan Serré. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gaëtan Serré
+-/
+module
+
+public import Mathlib.CategoryTheory.MarkovCategory.Basic
+public import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
+
+/-!
+# Positive Categories
+
+Markov categories where deletion is natural for all morphisms.
+
+## Main definitions
+
+* `PositiveCategory`: Markov category where copy is natural given deterministic composition of
+  morphisms.
+
+## Main results
+
+* `copy_comp_natural` - Given morphisms `f : X ⟶ Y` and `g : Y ⟶ Z`, if their composition is
+  deterministic, then process `f`, copy and then process `g` equals copy and process `f` and `g`
+  independently.
+
+* All isomorphisms in a positive Markov category are deterministic.
+
+## Implementation notes
+
+The key property `copy_comp_natural : f ≫ Δ ≫ (g ⊗ₘ 𝟙 Y) = Δ ≫ (f ≫ g ⊗ₘ f)`, given
+`Deterministic (f ≫ g)`, means that after processing `f`, copying and then processing `g` is the
+same as copying and processing `f` and `g` independently. The probabilistic interpretation is that
+given a deterministic process that has a stochastic intermediate result, the same distribution over
+both results can be obtained by computing the intermediate result independently of the
+deterministic process.
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+* [Moss and Perrone, *A category-theoretic proof of the ergodic
+decomposition theorem*][moss2023]
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory CopyDiscardCategory ComonObj
+
+/-- Markov category where copy is natural given deterministic composition of morphisms. -/
+class PositiveCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] extends
+    MarkovCategory C where
+  /-- Given morphisms `f : X ⟶ Y` and `g : Y ⟶ Z`, if their composition is deterministic, then
+  process `f`, copy and then process `g` equals copy and process `f` and `g` independently. -/
+  copy_comp_natural {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : Deterministic (f ≫ g)) :
+      f ≫ Δ ≫ (g ⊗ₘ 𝟙 Y) = Δ ≫ (f ≫ g ⊗ₘ f)
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+
+namespace PositiveCategory
+
+variable [PositiveCategory C] {X Y : C} {e : X ≅ Y}
+
+instance : Deterministic (e.hom ≫ e.inv) where
+
+instance : Deterministic (e.inv ≫ e.hom) where
+
+instance {X Y : C} {e : X ≅ Y} : Deterministic e.hom where
+  hom_comul := by
+    calc
+    _ = e.hom ≫ Δ ≫ (e.inv ⊗ₘ 𝟙 Y) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+      cat_disch
+    _ = (e.hom ≫ Δ ≫ (e.inv ⊗ₘ 𝟙 Y)) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+      simp
+    _ = (Δ ≫ (𝟙 X ⊗ₘ e.hom)) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+      simp only [copy_comp_natural, Iso.hom_inv_id]
+    _ = Δ ≫ (𝟙 X ⊗ₘ e.hom) ≫ (e.hom ⊗ₘ 𝟙 Y) := by
+      simp
+    _ = Δ ≫ ((𝟙 X ≫ e.hom) ⊗ₘ (e.hom ≫ 𝟙 Y)) := by
+      rw [MonoidalCategory.tensorHom_comp_tensorHom]
+    _ = Δ ≫ (e.hom ⊗ₘ e.hom) := by cat_disch
+
+end PositiveCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -65,10 +65,6 @@ namespace PositiveCategory
 
 variable [PositiveCategory C] {X Y : C} {e : X ≅ Y}
 
-instance : Deterministic (e.hom ≫ e.inv) where
-
-instance : Deterministic (e.inv ≫ e.hom) where
-
 instance {X Y : C} {e : X ≅ Y} : Deterministic e.hom where
   hom_comul := by
     calc

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -5918,3 +5918,14 @@
   year          = {2003},
   edition       = {31st ed.}
 }
+
+@Article{         moss2023,
+  title         = {A category-theoretic proof of the ergodic decomposition theorem},
+  author        = {Moss, Sean and Perrone, Paolo},
+  journal       = {Ergodic Theory and Dynamical Systems},
+  volume        = {43},
+  number        = {12},
+  pages         = {4166--4192},
+  year          = {2023},
+  publisher     = {Cambridge University Press}
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4040,6 +4040,18 @@
   url           = {https://doi.org/10.1007/s40062-019-00247-y}
 }
 
+@Article{         moss2023,
+  title         = {A category-theoretic proof of the ergodic decomposition
+                  theorem},
+  author        = {Moss, Sean and Perrone, Paolo},
+  journal       = {Ergodic Theory and Dynamical Systems},
+  volume        = {43},
+  number        = {12},
+  pages         = {4166--4192},
+  year          = {2023},
+  publisher     = {Cambridge University Press}
+}
+
 @Article{         MR0236876,
   title         = {A new proof that metric spaces are paracompact},
   author        = {Mary Ellen Rudin},
@@ -5917,15 +5929,4 @@
   author        = {Zwillinger, Daniel},
   year          = {2003},
   edition       = {31st ed.}
-}
-
-@Article{         moss2023,
-  title         = {A category-theoretic proof of the ergodic decomposition theorem},
-  author        = {Moss, Sean and Perrone, Paolo},
-  journal       = {Ergodic Theory and Dynamical Systems},
-  volume        = {43},
-  number        = {12},
-  pages         = {4166--4192},
-  year          = {2023},
-  publisher     = {Cambridge University Press}
 }


### PR DESCRIPTION
Define `PositiviveCategory`: a specific kind of Markov category deeply related to determinism of isomorphisms.

For some additional context, please see #37851.

### References
- Section 11 of [A synthetic approach to Markov kernels, conditional independence and theorems on sufficient statistics, Fritz, 2020](https://arxiv.org/abs/1908.07021)
- Section 3 of [A category-theoretic proof of the ergodic decomposition theorem, Moss and Perrone, 2023](https://arxiv.org/abs/2207.07353)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
