### PR TITLE
[Merged by Bors] - chore(Algebra): remove some broken dot notation porting notes

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Kernels.lean
@@ -37,8 +37,7 @@ def kernelCone : KernelFork f :=
 def kernelIsLimit : IsLimit (kernelCone f) :=
   Fork.IsLimit.mk _
     (fun s => ofHom <|
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation on LinearMap.ker
-      LinearMap.codRestrict (LinearMap.ker f.hom) (Fork.ι s).hom fun c =>
+      LinearMap.codRestrict f.hom.ker (Fork.ι s).hom fun c =>
         LinearMap.mem_ker.2 <| by simp [← ConcreteCategory.comp_apply])
     (fun _ => hom_ext <| LinearMap.subtype_comp_codRestrict _ _ _) fun s m h =>
       hom_ext <| LinearMap.ext fun x => Subtype.ext_iff.2 (by simp [← h]; rfl)
@@ -64,11 +63,9 @@ def cokernelIsColimit : IsColimit (cokernelCocone f) :=
     (fun s => ofHom <| (LinearMap.range f.hom).liftQ (Cofork.π s).hom <|
       LinearMap.range_le_ker_iff.2 <| ModuleCat.hom_ext_iff.mp <| CokernelCofork.condition s)
     (fun s => hom_ext <| (LinearMap.range f.hom).liftQ_mkQ (Cofork.π s).hom _) fun s m h => by
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-    haveI : Epi (ofHom (LinearMap.range f.hom).mkQ) :=
+    haveI : Epi (ofHom f.hom.range.mkQ) :=
       (epi_iff_range_eq_top _).mpr (Submodule.range_mkQ _)
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-    apply (cancel_epi (ofHom (LinearMap.range f.hom).mkQ)).1
+    apply (cancel_epi (ofHom f.hom.range.mkQ)).1
     exact h
 
 /-- Construct an `IsColimit` structure of cokernels given `Function.Exact`. -/
@@ -105,29 +102,24 @@ variable {G H : ModuleCat.{v} R} (f : G ⟶ H)
 agrees with the usual module-theoretical kernel.
 -/
 noncomputable def kernelIsoKer {G H : ModuleCat.{v} R} (f : G ⟶ H) :
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-    kernel f ≅ ModuleCat.of R (LinearMap.ker f.hom) :=
+    kernel f ≅ ModuleCat.of R f.hom.ker :=
   limit.isoLimitCone ⟨_, kernelIsLimit f⟩
 
 -- We now show this isomorphism commutes with the inclusion of the kernel into the source.
 @[simp, elementwise]
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-theorem kernelIsoKer_inv_kernel_ι : (kernelIsoKer f).inv ≫ kernel.ι f =
-    ofHom (LinearMap.ker f.hom).subtype :=
+theorem kernelIsoKer_inv_kernel_ι : (kernelIsoKer f).inv ≫ kernel.ι f = ofHom f.hom.ker.subtype :=
   limit.isoLimitCone_inv_π _ _
 
 @[simp, elementwise]
 theorem kernelIsoKer_hom_ker_subtype :
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-    (kernelIsoKer f).hom ≫ ofHom (LinearMap.ker f.hom).subtype = kernel.ι f :=
+    (kernelIsoKer f).hom ≫ ofHom f.hom.ker.subtype = kernel.ι f :=
   IsLimit.conePointUniqueUpToIso_inv_comp _ (limit.isLimit _) WalkingParallelPair.zero
 
 /-- The categorical cokernel of a morphism in `ModuleCat`
 agrees with the usual module-theoretical quotient.
 -/
 noncomputable def cokernelIsoRangeQuotient {G H : ModuleCat.{v} R} (f : G ⟶ H) :
-    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation
-    cokernel f ≅ ModuleCat.of R (H ⧸ LinearMap.range f.hom) :=
+    cokernel f ≅ ModuleCat.of R (H ⧸ f.hom.range) :=
   colimit.isoColimitCocone ⟨_, cokernelIsColimit f⟩
 
 -- We now show this isomorphism commutes with the projection of target to the cokernel.

--- a/Mathlib/Algebra/Module/Torsion/Basic.lean
+++ b/Mathlib/Algebra/Module/Torsion/Basic.lean
@@ -83,8 +83,7 @@ variable (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M]
 /-- The torsion ideal of `x`, containing all `a` such that `a • x = 0`. -/
 @[simps!]
 def torsionOf (x : M) : Ideal R :=
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11036): broken dot notation on LinearMap.ker https://github.com/leanprover/lean4/issues/1629
-  LinearMap.ker (LinearMap.toSpanSingleton R M x)
+  (LinearMap.toSpanSingleton R M x).ker
 
 @[simp]
 theorem torsionOf_zero : torsionOf R M (0 : M) = ⊤ := by simp [torsionOf]


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
