### PR TITLE
ci: block merging PRs that increase technical debt unless reviewed

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -2,6 +2,7 @@ name: Post PR summary comment
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:
@@ -13,7 +14,10 @@ jobs:
   build:
     name: "post-or-update-summary-comment"
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: >-
+      github.repository == 'leanprover-community/mathlib4' &&
+      github.event.action != 'labeled' &&
+      github.event.action != 'unlabeled'
 
     steps:
     - name: Checkout code
@@ -293,3 +297,75 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/file-removed \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
         fi
+
+  # This job gates merging via the `blocked-by-large-import` label in bors.toml.
+  #
+  # Why a separate label instead of putting `large-import` directly in
+  # block_labels?  Because bors's block_labels has no conditional logic: if
+  # the label exists, merge is blocked, period.  We need "blocked unless a
+  # reviewer has added `allow-large-import`", which requires a label whose
+  # presence tracks the *conjunction* of `large-import` AND NOT
+  # `allow-large-import`.  That is `blocked-by-large-import`.
+  #
+  # Three labels, each managed by exactly one actor — no fighting:
+  #   - `large-import`            — managed by the `build` job (import analysis)
+  #   - `blocked-by-large-import` — managed by this job (label logic)
+  #   - `allow-large-import`      — managed by the reviewer
+  #
+  # On opened/synchronize/reopened events this job waits for the `build` job
+  # (which manages `large-import`) so there is no race condition.
+  #
+  # On labeled/unlabeled events the `build` job is skipped, but this job still
+  # runs (if: always()) so that adding `allow-large-import` immediately
+  # removes the block.
+  check-large-import:
+    name: "Check large import"
+    needs: build
+    runs-on: ubuntu-latest
+    if: always() && github.repository == 'leanprover-community/mathlib4'
+
+    steps:
+    - name: Check for large-import label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+
+        has_large_import=false
+        has_allow=false
+
+        if printf '%s\n' "$labels" | grep -qx "large-import"; then
+          has_large_import=true
+        fi
+
+        if printf '%s\n' "$labels" | grep -qx "allow-large-import"; then
+          has_allow=true
+        fi
+
+        if [ "$has_large_import" = true ] && [ "$has_allow" = false ]; then
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label blocked-by-large-import
+          echo "::error::This PR significantly increases transitive imports. Add the 'allow-large-import' label after review to unblock."
+          echo ""
+          echo "This PR has the 'large-import' label, indicating that it significantly"
+          echo "increases transitive imports for one or more files."
+          echo ""
+          echo "To unblock this PR, a reviewer should:"
+          echo "  1. Check whether the import increase is reasonable."
+          echo "  2. Consider whether the PR could be improved by:"
+          echo "     - splitting large files into smaller, more focused modules"
+          echo "     - rearranging material to reduce cross-module dependencies"
+          echo "     - creating new intermediate files to break dependency chains"
+          echo "  3. If the increase is acceptable, add the 'allow-large-import' label."
+          echo ""
+          echo "Note: the 'large-import' criteria are heuristic (>2% increase in transitive"
+          echo "imports for any modified file) and are not perfect. If you believe this is a"
+          echo "false positive, please report it on the mathlib4 Zulip channel:"
+          echo "https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/large-import.20label"
+          exit 1
+        else
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label blocked-by-large-import
+        fi
+
+        echo "Import check passed."

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -226,6 +226,16 @@ jobs:
         echo "Compute technical debt changes"
         techDebtVar="$("${CI_SCRIPTS_DIR}/reporting/technical-debt-metrics.sh" pr_summary)"
 
+        # If technical debt did NOT increase, remove the label; otherwise add it.
+        # We test for the *safe* patterns rather than the *unsafe* one so that if
+        # mathlib-ci changes the script's output wording we fail closed (label added)
+        # rather than open (label silently not added).
+        if printf '%s' "${techDebtVar}" | grep -qE 'Decrease in tech debt:|No changes to technical debt\.'; then
+          gh pr edit "${PR}" --remove-label increases-technical-debt
+        else
+          gh pr edit "${PR}" --add-label increases-technical-debt
+        fi
+
         echo "Compute documentation reminder"
         workflowFilesChanged="$(grep '^\.github/workflows/' changed_files.txt || true)"
         if [ -n "${workflowFilesChanged}" ]
@@ -369,3 +379,53 @@ jobs:
         fi
 
         echo "Import check passed."
+
+  # Same pattern as check-large-import, but for technical debt.
+  # See the comment on check-large-import for the rationale.
+  check-technical-debt:
+    name: "Check technical debt"
+    needs: build
+    runs-on: ubuntu-latest
+    if: always() && github.repository == 'leanprover-community/mathlib4'
+
+    steps:
+    - name: Check for increases-technical-debt label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+
+        has_increases=false
+        has_allow=false
+
+        if printf '%s\n' "$labels" | grep -qx "increases-technical-debt"; then
+          has_increases=true
+        fi
+
+        if printf '%s\n' "$labels" | grep -qx "allow-increases-technical-debt"; then
+          has_allow=true
+        fi
+
+        if [ "$has_increases" = true ] && [ "$has_allow" = false ]; then
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label blocked-by-increases-technical-debt
+          echo "::error::This PR increases technical debt. Add the 'allow-increases-technical-debt' label after review to unblock."
+          echo ""
+          echo "This PR has the 'increases-technical-debt' label, indicating that it"
+          echo "increases one or more technical debt metrics."
+          echo ""
+          echo "To unblock this PR, a reviewer should:"
+          echo "  1. Check the PR summary comment for the technical debt changes."
+          echo "  2. Consider whether the increase can be avoided."
+          echo "  3. If the increase is acceptable, add the 'allow-increases-technical-debt' label."
+          echo ""
+          echo "Note: not all technical debt increases are avoidable. If you believe this"
+          echo "check is too aggressive, please report it on the mathlib4 Zulip channel:"
+          echo "https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/increases-technical-debt.20label"
+          exit 1
+        else
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label blocked-by-increases-technical-debt
+        fi
+
+        echo "Technical debt check passed."

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = ["ci (staging) / Build", "ci (staging) / Lint style", "ci (staging) / Post-Build Step", "ci (staging) / Post-CI job"]
 use_squash_merge = true
 timeout_sec = 7200
-block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
+block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI", "blocked-by-large-import"]
 delete_merged_branches = true
 update_base_for_deletes = true
 cut_body_after = "\n---"

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = ["ci (staging) / Build", "ci (staging) / Lint style", "ci (staging) / Post-Build Step", "ci (staging) / Post-CI job"]
 use_squash_merge = true
 timeout_sec = 7200
-block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI", "blocked-by-large-import"]
+block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI", "blocked-by-large-import", "blocked-by-increases-technical-debt"]
 delete_merged_branches = true
 update_base_for_deletes = true
 cut_body_after = "\n---"


### PR DESCRIPTION
This PR adds a merge gate for technical debt increases, using the same pattern as #38225 (the large-import gate).

When the existing technical debt metrics script reports an increase, the `build` job now adds an `increases-technical-debt` label. A `check-technical-debt` job then adds `blocked-by-increases-technical-debt`, which blocks bors.

A reviewer can add `allow-increases-technical-debt` to unblock after confirming the increase is acceptable.

### Labels (same three-label pattern as the large-import gate)

| Label | Managed by | Purpose |
|---|---|---|
| `increases-technical-debt` | `build` job (tech debt script) | Factual: this PR increases debt |
| `blocked-by-increases-technical-debt` | `check-technical-debt` job | Operational: blocks bors |
| `allow-increases-technical-debt` | Reviewer | Override: reviewer approves the increase |

False positives can be reported on the [mathlib4 Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/increases-technical-debt.20label).

- [ ] depends on: #38225

🤖 Prepared with Claude Code