### PR TITLE
[Merged by Bors] - feat(Logic/Relation): Std.Symm instances

### DIFF
--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -118,6 +118,9 @@ instance Std.Refl.comap [Std.Refl r] (f : α → β) : Std.Refl (r on f) where
 
 theorem Symmetric.comap (h : Symmetric r) (f : α → β) : Symmetric (r on f) := fun _ _ hab ↦ h hab
 
+instance Std.Symm.comap [Std.Symm r] (f : α → β) : Std.Symm (r on f) where
+  symm _ _ hab := symm_of r hab
+
 instance IsTrans.comap [IsTrans β r] (f : α → β) : IsTrans α (r on f) where
   trans _ _ _ := trans_of r
 
@@ -250,6 +253,10 @@ lemma map_symmetric {r : α → α → Prop} (hr : Symmetric r) (f : α → β) 
     Symmetric (Relation.Map r f f) := by
   rintro _ _ ⟨x, y, hxy, rfl, rfl⟩; exact ⟨_, _, hr hxy, rfl, rfl⟩
 
+instance _root_.Std.Symm.map {r : α → α → Prop} [h : Std.Symm r] (f : α → β) :
+    Std.Symm (Relation.Map r f f) where
+  symm := map_symmetric h.symm f
+
 lemma _root_.IsTrans.map {r : α → α → Prop} [IsTrans α r] {f : α → β}
     (hf : ∀ x y, f x = f y → r x y) : IsTrans β (Relation.Map r f f) := by
   refine ⟨fun _ _ _ ⟨x, y, hxy, hx, hy⟩ ⟨y', z, hyz, hy', hz⟩ ↦ ?_⟩
@@ -321,6 +328,9 @@ inductive ReflGen (r : α → α → Prop) (a : α) : α → Prop
   | refl : ReflGen r a a
   | single {b : α} : r a b → ReflGen r a b
 
+attribute [refl] ReflGen.refl
+attribute [grind =] reflGen_iff
+
 /-- `SymmGen r`: symmetric closure of `r`. This is also the comparability relation, such
   that `SymmGen r a b` means that either `r a b` or `r b a` (see `Mathlib.Order.Comparable`). -/
 def SymmGen (r : α → α → Prop) (a b : α) : Prop :=
@@ -337,8 +347,6 @@ inductive EqvGen : α → α → Prop
 
 attribute [mk_iff] TransGen
 attribute [grind] TransGen
-attribute [refl] ReflGen.refl
-attribute [grind =] reflGen_iff
 
 namespace ReflGen
 
@@ -352,6 +360,20 @@ theorem mono {p : α → α → Prop} (hp : ∀ a b, r a b → p a b) : ∀ {a b
 
 instance : Std.Refl (ReflGen r) :=
   ⟨@refl α r⟩
+
+instance [Std.Symm r] : Std.Symm (ReflGen r) where
+  symm a b h := by
+    induction h with
+    | refl => exact refl
+    | single h => exact single (symm_of r h)
+
+instance [IsTrans α r] : IsTrans α (ReflGen r) where
+  trans a b c h₁ h₂ := by
+    obtain (rfl | h₂) := h₂
+    · exact h₁
+    obtain (rfl | h₁) := h₁
+    · exact single h₂
+    exact single (trans_of r h₁ h₂)
 
 end ReflGen
 
@@ -463,6 +485,12 @@ theorem total_of_right_unique (U : Relator.RightUnique r) (ab : ReflTransGen r a
         exact Or.inl ec
     · exact Or.inr (IH.tail bd)
 
+instance [Std.Symm r] : Std.Symm (ReflTransGen r) where
+  symm _ _ h := by
+    induction h with
+    | refl => exact refl
+    | tail h h' ih => exact ih.head (symm h')
+
 end ReflTransGen
 
 namespace TransGen
@@ -537,8 +565,13 @@ theorem symmetric (hr : Symmetric r) : Symmetric (TransGen r) := by
   | single i => exact .single (hr i)
   | tail _ h₁ h₂ => exact .head (hr h₁) h₂
 
-end TransGen
+instance [Std.Refl r] : Std.Refl (TransGen r) where
+  refl x := .single (refl x)
 
+instance [H : Std.Symm r] : Std.Symm (TransGen r) where
+  symm _ _ h := h.symmetric H.symm
+
+end TransGen
 
 section reflGen
 
@@ -812,6 +845,9 @@ theorem symmetric_join : Symmetric (Join r) := fun _ _ ⟨c, hac, hcb⟩ ↦ ⟨
 
 instance reflexive_join [Std.Refl r] : Std.Refl (Join r) where
   refl a := ⟨a, refl a, refl a⟩
+
+instance : Std.Symm (Join r) where
+  symm := symmetric_join
 
 theorem isTrans_join [IsTrans α r] (h : ∀ a b c, r a b → r a c → Join r b c) :
     IsTrans α (Join r) :=

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -361,11 +361,14 @@ theorem mono {p : α → α → Prop} (hp : ∀ a b, r a b → p a b) : ∀ {a b
 instance : Std.Refl (ReflGen r) :=
   ⟨@refl α r⟩
 
-instance [Std.Symm r] : Std.Symm (ReflGen r) where
-  symm a b h := by
-    induction h with
-    | refl => exact refl
-    | single h => exact single (symm_of r h)
+lemma symmetric (h' : Symmetric r) : Symmetric (ReflGen r) := by
+  intro a b h
+  induction h with
+  | refl => exact refl
+  | single h => exact single (h' h)
+
+instance [H : Std.Symm r] : Std.Symm (ReflGen r) where
+  symm := symmetric H.symm
 
 instance [IsTrans α r] : IsTrans α (ReflGen r) where
   trans a b c h₁ h₂ := by
@@ -439,6 +442,9 @@ theorem symmetric (h : Symmetric r) : Symmetric (ReflTransGen r) := by
   | refl => rfl
   | tail _ b c => apply Relation.ReflTransGen.head (h b) c
 
+instance [H : Std.Symm r] : Std.Symm (ReflTransGen r) where
+  symm := symmetric H.symm
+
 theorem cases_tail : ReflTransGen r a b → b = a ∨ ∃ c, ReflTransGen r a c ∧ r c b :=
   (cases_tail_iff r a b).1
 
@@ -484,12 +490,6 @@ theorem total_of_right_unique (U : Relator.RightUnique r) (ab : ReflTransGen r a
       · cases U bd be
         exact Or.inl ec
     · exact Or.inr (IH.tail bd)
-
-instance [Std.Symm r] : Std.Symm (ReflTransGen r) where
-  symm _ _ h := by
-    induction h with
-    | refl => exact refl
-    | tail h h' ih => exact ih.head (symm h')
 
 end ReflTransGen
 
@@ -569,7 +569,7 @@ instance [Std.Refl r] : Std.Refl (TransGen r) where
   refl x := .single (refl x)
 
 instance [H : Std.Symm r] : Std.Symm (TransGen r) where
-  symm _ _ h := h.symmetric H.symm
+  symm := symmetric H.symm
 
 end TransGen
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
