### PR TITLE
ci: add no-public-api-changes label based on public olean diff

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -405,8 +405,10 @@ jobs:
           cd tools-branch
           ./.lake/build/bin/cache get
 
-      # Validate the fetched baseline the same way the main build does — a bare
-      # `cache get` does not guarantee a warm/consistent cache.
+      # Validate the fetched baseline over the same scope we intend to diff — a
+      # `--no-build` check of a single module (as used elsewhere in this workflow)
+      # would only prove that the cache contains a prefix; a partial cache could
+      # still produce a bogus "public API changed" result from missing files.
       - name: validate master baseline
         id: validate_master_baseline
         if: ${{ steps.fetch_master_oleans.outcome == 'success' }}
@@ -414,7 +416,7 @@ jobs:
         shell: bash
         run: |
           cd tools-branch
-          lake build --no-build -v Mathlib.Init
+          lake build --no-build Mathlib
 
       - name: diff public oleans against master
         id: public_olean_diff
@@ -462,10 +464,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}
+          OWNER: ${{ github.repository_owner }}
           SHA: ${{ github.sha }}
         run: |
-          # For push events we have no PR context, so look up the PR by head branch.
-          pr_json=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" \
+          # For push events we have no PR context, so look up the PR by head
+          # branch. Qualify with the owner so we cannot match a same-named
+          # head branch on an unrelated fork.
+          pr_json=$(gh pr list --repo "${{ github.repository }}" --head "$OWNER:$BRANCH" \
             --state open --json number,headRefOid --jq '.[0] // empty')
           if [ -z "$pr_json" ]; then
             echo "pr_number=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -378,6 +378,103 @@ jobs:
           cd pr-branch
           du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      # Fetch `master`'s cached oleans into `tools-branch` so we can compare public `.olean`
+      # files against the PR's build. With the module system, only changes that affect
+      # exported information (signatures, axioms, exposed definition bodies) touch the
+      # public `.olean`; proof-only changes leave it byte-identical and only update
+      # `.olean.private`. See scripts/public_olean_diff.sh for the comparison logic.
+      - name: fetch master oleans for public-olean diff
+        id: fetch_master_oleans
+        if: ${{ steps.build.outcome == 'success' && github.event_name == 'push' && github.ref != 'refs/heads/master' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          cd tools-branch
+          ./.lake/build/bin/cache get
+
+      - name: diff public oleans against master
+        id: public_olean_diff
+        if: ${{ steps.fetch_master_oleans.outcome == 'success' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          bash pr-branch/scripts/public_olean_diff.sh \
+            tools-branch/.lake/build/lib/lean \
+            pr-branch/.lake/build/lib/lean \
+            public-olean-diff.txt
+          diff_status=$?
+          echo "diff_status=${diff_status}" >> "$GITHUB_OUTPUT"
+          if [ "${diff_status}" = "0" ]; then
+            echo "matches_master=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matches_master=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "::group::public_olean_diff output"
+          head -n 200 public-olean-diff.txt || true
+          echo "::endgroup::"
+          exit 0
+
+      - name: upload public-olean-diff artifact
+        if: ${{ always() && steps.public_olean_diff.outcome != 'skipped' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: public-olean-diff
+          path: public-olean-diff.txt
+          if-no-files-found: ignore
+
+      - name: look up PR number for label management
+        id: pr_lookup
+        if: ${{ steps.public_olean_diff.outcome != 'skipped' && github.event_name == 'push' && github.repository == 'leanprover-community/mathlib4' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          # For push events we have no PR context, so look up the PR by head branch.
+          pr_number=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" \
+            --state open --json number --jq '.[0].number // empty')
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: manage no-public-api-changes label
+        if: ${{ steps.pr_lookup.outcome == 'success' && steps.pr_lookup.outputs.pr_number != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr_lookup.outputs.pr_number }}
+          MATCHES: ${{ steps.public_olean_diff.outputs.matches_master }}
+        run: |
+          if [ "$MATCHES" = "true" ]; then
+            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --add-label "no-public-api-changes"
+          else
+            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --remove-label "no-public-api-changes"
+          fi
+
+      - name: enforce expect-no-public-api-changes label
+        if: ${{ steps.pr_lookup.outcome == 'success' && steps.pr_lookup.outputs.pr_number != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr_lookup.outputs.pr_number }}
+          MATCHES: ${{ steps.public_olean_diff.outputs.matches_master }}
+        run: |
+          expected=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name' | grep -Fx "expect-no-public-api-changes" || true)
+          if [ -n "$expected" ] && [ "$MATCHES" != "true" ]; then
+            echo "❌ This PR is labelled \`expect-no-public-api-changes\`, but the public"
+            echo "   \`.olean\` files differ from master. If these changes are intentional,"
+            echo "   remove the \`expect-no-public-api-changes\` label; otherwise update the"
+            echo "   PR so that only proofs/non-exported information change."
+            echo ""
+            echo "Differing public oleans (truncated to 50):"
+            head -n 50 public-olean-diff.txt || true
+            exit 1
+          fi
+
       # Note: we should not be including `Archive` and `Counterexamples` in the cache.
       # We do this for now for the sake of not rebuilding them in every CI run
       # even when they are not touched.

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -383,18 +383,42 @@ jobs:
       # exported information (signatures, axioms, exposed definition bodies) touch the
       # public `.olean`; proof-only changes leave it byte-identical and only update
       # `.olean.private`. See scripts/public_olean_diff.sh for the comparison logic.
+      #
+      # This block is gated to same-repo PR-branch pushes on leanprover-community/mathlib4
+      # (excluding master, bors' `staging`/`trying`, nightly-testing, and any run that
+      # overrides `tools_branch_ref` to a non-master ref).
       - name: fetch master oleans for public-olean diff
         id: fetch_master_oleans
-        if: ${{ steps.build.outcome == 'success' && github.event_name == 'push' && github.ref != 'refs/heads/master' }}
+        if: >-
+          ${{
+            steps.build.outcome == 'success' &&
+            github.event_name == 'push' &&
+            github.repository == 'leanprover-community/mathlib4' &&
+            github.ref != 'refs/heads/master' &&
+            github.ref != 'refs/heads/staging' &&
+            github.ref != 'refs/heads/trying' &&
+            inputs.tools_branch_ref == ''
+          }}
         continue-on-error: true
         shell: bash
         run: |
           cd tools-branch
           ./.lake/build/bin/cache get
 
+      # Validate the fetched baseline the same way the main build does — a bare
+      # `cache get` does not guarantee a warm/consistent cache.
+      - name: validate master baseline
+        id: validate_master_baseline
+        if: ${{ steps.fetch_master_oleans.outcome == 'success' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          cd tools-branch
+          lake build --no-build -v Mathlib.Init
+
       - name: diff public oleans against master
         id: public_olean_diff
-        if: ${{ steps.fetch_master_oleans.outcome == 'success' }}
+        if: ${{ steps.validate_master_baseline.outcome == 'success' }}
         continue-on-error: true
         shell: bash
         run: |
@@ -405,11 +429,11 @@ jobs:
             public-olean-diff.txt
           diff_status=$?
           echo "diff_status=${diff_status}" >> "$GITHUB_OUTPUT"
-          if [ "${diff_status}" = "0" ]; then
-            echo "matches_master=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "matches_master=false" >> "$GITHUB_OUTPUT"
-          fi
+          case "${diff_status}" in
+            0) echo "state=match" >> "$GITHUB_OUTPUT" ;;
+            1) echo "state=differs" >> "$GITHUB_OUTPUT" ;;
+            *) echo "state=unavailable" >> "$GITHUB_OUTPUT" ;;
+          esac
           echo "::group::public_olean_diff output"
           head -n 200 public-olean-diff.txt || true
           echo "::endgroup::"
@@ -423,18 +447,39 @@ jobs:
           path: public-olean-diff.txt
           if-no-files-found: ignore
 
-      - name: look up PR number for label management
+      # Only proceed with label management when the diff produced a conclusive result.
+      # `unavailable` (infra/script error) leaves existing labels untouched.
+      - name: look up PR for label management
         id: pr_lookup
-        if: ${{ steps.public_olean_diff.outcome != 'skipped' && github.event_name == 'push' && github.repository == 'leanprover-community/mathlib4' }}
+        if: >-
+          ${{
+            steps.public_olean_diff.outcome == 'success' &&
+            (steps.public_olean_diff.outputs.state == 'match' ||
+             steps.public_olean_diff.outputs.state == 'differs')
+          }}
         continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
           # For push events we have no PR context, so look up the PR by head branch.
-          pr_number=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" \
-            --state open --json number --jq '.[0].number // empty')
+          pr_json=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" \
+            --state open --json number,headRefOid --jq '.[0] // empty')
+          if [ -z "$pr_json" ]; then
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_number=$(printf '%s' "$pr_json" | jq -r '.number // empty')
+          head_oid=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
+          # Guard against TOCTOU: the PR head may have advanced past the commit we
+          # built. Only label when the PR still points at exactly this SHA.
+          if [ "$head_oid" != "$SHA" ]; then
+            echo "PR head ($head_oid) has advanced past this run's SHA ($SHA); skipping label updates."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: manage no-public-api-changes label
@@ -444,12 +489,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr_lookup.outputs.pr_number }}
-          MATCHES: ${{ steps.public_olean_diff.outputs.matches_master }}
+          STATE: ${{ steps.public_olean_diff.outputs.state }}
         run: |
-          if [ "$MATCHES" = "true" ]; then
+          if [ "$STATE" = "match" ]; then
             gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
               --add-label "no-public-api-changes"
-          else
+          elif [ "$STATE" = "differs" ]; then
             gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
               --remove-label "no-public-api-changes"
           fi
@@ -460,11 +505,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr_lookup.outputs.pr_number }}
-          MATCHES: ${{ steps.public_olean_diff.outputs.matches_master }}
+          STATE: ${{ steps.public_olean_diff.outputs.state }}
         run: |
           expected=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
             --json labels --jq '.labels[].name' | grep -Fx "expect-no-public-api-changes" || true)
-          if [ -n "$expected" ] && [ "$MATCHES" != "true" ]; then
+          if [ -n "$expected" ] && [ "$STATE" = "differs" ]; then
             echo "❌ This PR is labelled \`expect-no-public-api-changes\`, but the public"
             echo "   \`.olean\` files differ from master. If these changes are intentional,"
             echo "   remove the \`expect-no-public-api-changes\` label; otherwise update the"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -151,6 +151,14 @@ behaviour. They share a common DAG traversal library that parallelises work in i
   Runs `lake build` on a target until `lake build --no-build` succeeds. Used in the main build workflows.
 - `lake-build-wrapper.py`
   A wrapper script for `lake build` which collapses normal build into log groups and saves a build summary JSON file. See file for usage.
+- `public_olean_diff.sh`
+  Compares the public `.olean` files of two Mathlib builds (e.g. master vs a PR branch).
+  In the module system each module produces public, server, and private olean files; theorems are
+  exported as axioms in the public `.olean`, so proof-only changes leave it byte-identical.
+  This script compares public oleans only (skipping `.olean.private`, `.olean.server`, and
+  `.ir.olean`), writing one line per differing module to an output file. Used in CI to
+  automatically add or remove the `no-public-api-changes` label on PRs.
+  Usage: `scripts/public_olean_diff.sh <base_lib_dir> <head_lib_dir> <output_file>`
 - `mk_all.lean`
   run via `lake exe mk_all`, regenerates the import-only files
   `Mathlib.lean`, `Mathlib/Tactic.lean`, `Archive.lean` and `Counterexamples.lean`

--- a/scripts/public_olean_diff.sh
+++ b/scripts/public_olean_diff.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Compare the public `.olean` files of two Mathlib builds.
+#
+# In the module system, each module produces three olean files:
+#   Foo.olean          -- public/exported information (signatures, axioms)
+#   Foo.olean.server   -- docstrings, declaration ranges
+#   Foo.olean.private  -- full private data including proof bodies
+#
+# Theorems are exported as axioms in the public `.olean`, so changing only
+# a proof body should leave the public `.olean` byte-identical. This script
+# compares the public oleans only, skipping `.olean.private`, `.olean.server`,
+# and `.ir.olean`.
+#
+# Usage:
+#   public_olean_diff.sh <base_lib_dir> <head_lib_dir> <output_file>
+#
+# Arguments:
+#   base_lib_dir   path to `.lake/build/lib/lean` for the base (e.g. master)
+#   head_lib_dir   path to `.lake/build/lib/lean` for the PR
+#   output_file    path where the list of differing modules will be written
+#
+# Exit codes:
+#   0  the public oleans are byte-identical for every module present in both builds
+#   1  one or more public oleans differ
+#   2  argument error or missing directories
+#
+# The output file contains one line per module whose public olean differs,
+# in the form `Mathlib/Foo/Bar.olean`. An empty file means "no differences".
+# Modules present in only one of the two builds are also listed (prefixed
+# with `added: ` or `removed: `).
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <base_lib_dir> <head_lib_dir> <output_file>" >&2
+  exit 2
+fi
+
+BASE_DIR="$1"
+HEAD_DIR="$2"
+OUT="$3"
+
+if [ ! -d "$BASE_DIR" ]; then
+  echo "error: base lib dir does not exist: $BASE_DIR" >&2
+  exit 2
+fi
+if [ ! -d "$HEAD_DIR" ]; then
+  echo "error: head lib dir does not exist: $HEAD_DIR" >&2
+  exit 2
+fi
+
+# List public oleans (relative paths) in a directory. We include `*.olean`
+# but exclude the `.olean.private`, `.olean.server`, and `.ir.olean`
+# companions. `find -name '*.olean'` with a negative pattern keeps this
+# simple and robust against file-name variations.
+list_public_oleans() {
+  local dir="$1"
+  ( cd "$dir" && find . -type f -name '*.olean' \
+      ! -name '*.olean.private' \
+      ! -name '*.olean.server' \
+      ! -name '*.ir.olean' \
+      -printf '%P\n' | LC_ALL=C sort )
+}
+
+BASE_LIST="$(mktemp)"
+HEAD_LIST="$(mktemp)"
+trap 'rm -f "$BASE_LIST" "$HEAD_LIST"' EXIT
+
+list_public_oleans "$BASE_DIR" > "$BASE_LIST"
+list_public_oleans "$HEAD_DIR" > "$HEAD_LIST"
+
+: > "$OUT"
+differ=0
+
+# Modules removed in the head build (present in base but not in head).
+while IFS= read -r f; do
+  echo "removed: $f" >> "$OUT"
+  differ=1
+done < <(comm -23 "$BASE_LIST" "$HEAD_LIST")
+
+# Modules added in the head build (present in head but not in base).
+while IFS= read -r f; do
+  echo "added: $f" >> "$OUT"
+  differ=1
+done < <(comm -13 "$BASE_LIST" "$HEAD_LIST")
+
+# Modules present in both: compare byte-by-byte.
+while IFS= read -r f; do
+  if ! cmp -s "$BASE_DIR/$f" "$HEAD_DIR/$f"; then
+    echo "$f" >> "$OUT"
+    differ=1
+  fi
+done < <(comm -12 "$BASE_LIST" "$HEAD_LIST")
+
+if [ "$differ" -eq 0 ]; then
+  echo "public_olean_diff: no public olean differences"
+  exit 0
+else
+  echo "public_olean_diff: $(wc -l < "$OUT") public olean(s) differ"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a CI step that compares the public `.olean` files produced by the PR build against `master`. When they are byte-identical, the label `no-public-api-changes` is applied; otherwise the label is removed.

It also introduces a contributor/reviewer-controlled label `expect-no-public-api-changes`; when present, CI fails unless `no-public-api-changes` also applies. Together these are intended to make proof-only golfing PRs (see the [mathlib-maintainers thread](https://leanprover.zulipchat.com/#narrow/channel/180721-mathlib-maintainers/topic/yuanyi-350.20golfing.20PRs)) cheap to review with confidence that nothing downstream of the touched files is affected.

## ⚠️ Open question before merge

The current implementation fetches master's cached oleans via a second `lake exe cache get` in the existing `tools-branch` checkout. I'd like feedback on whether the steady-state cost is acceptable before investing further.

**Measured cost (sampled from master run [24620430633](https://github.com/leanprover-community/mathlib4/actions/runs/24620430633), 2026-04-19):**

|  | Per PR push |
|---|---|
| `cache get` (8,241 files from Azure) | **~8 s wall-clock** (parallel download, pipelined decompress) |
| `lake build --no-build Mathlib` (baseline validation) | a few seconds |
| `public_olean_diff.sh` (byte-comparison of ~8k files) | a few seconds |
| **Extra wall-clock total** | **≈ 15–30 s** |
| **Additional runner disk** | **≈ 5.8 GB** (a second full `.lake/build/lib/lean/Mathlib`) |
| **Additional Azure egress** | **~1 GB** compressed |

So the wall-clock hit is small, but **disk usage on PR runners roughly doubles** (on top of the ~5.8 GB the PR build already materializes).

**Three concrete questions for reviewers:**

1. Is this disk overhead acceptable as always-on automation? Are any PR runners at risk of hitting their disk ceiling?
2. If not, do we prefer **weaker automation** (make the check opt-in via `expect-no-public-api-changes`, losing the informational `no-public-api-changes` label on most PRs) or **delaying this PR** until we extend `lake exe cache` to fetch public `*.olean` only (and skip `.olean.private`/`.olean.server`/`.ir.olean`, which would cut egress and disk substantially)?
3. Is there interest in a follow-up that moves the diff out of the build job and into a dedicated post-build job with its own checkout — same cost story but clearer ownership?

## How it works

With the module system, a Mathlib build produces three files per module: `Foo.olean` (public/exported), `Foo.olean.server` (server data), and `Foo.olean.private` (full private data). Theorems are exported as axioms in the public `.olean` (see `addDecl` at [`src/Lean/AddDecl.lean:100-104`](https://github.com/leanprover/lean4/blob/master/src/Lean/AddDecl.lean#L100-L104)), so a proof-only change leaves `Foo.olean` byte-identical and only updates `Foo.olean.private`. A byte-level diff of public oleans therefore certifies "nothing exported changed" — signatures, exposed definition bodies, and public environment-extension state all included.

New pieces:
- `scripts/public_olean_diff.sh` — compares two `.lake/build/lib/lean` trees, ignoring `.olean.private`, `.olean.server`, and `.ir.olean`. Tri-state exit: `0=match`, `1=differs`, `2=error/unavailable`.
- New steps in `.github/workflows/build_template.yml`:
  1. Fetch master oleans via `lake exe cache get` inside `tools-branch`.
  2. Validate the baseline with `lake build --no-build Mathlib` over the full diff scope (not just `Mathlib.Init`, which would only prove a prefix is cached).
  3. Run the diff; upload the result as an artifact.
  4. Look up the PR number from the (repo-qualified) head branch, and **verify** the PR head still points at this run's SHA (TOCTOU guard against fast successive pushes).
  5. Add/remove the `no-public-api-changes` label (only when the diff state is `match` or `differs`; `unavailable` leaves existing labels alone).
  6. Fail the job if `expect-no-public-api-changes` is set but the state is `differs`.

Gated to same-repo PR-branch pushes on `leanprover-community/mathlib4`, excluding `master`, bors `staging`/`trying`, and any run overriding `tools_branch_ref`.

## Caveats

- Only main-repo PRs are covered. `build_fork.yml` needs an analogous change in a follow-up.
- Cold master cache or failed baseline validation → the state is `unavailable` and labels are left untouched (no spurious flipping).
- Label updates are best-effort; they skip silently if PR lookup, the TOCTOU SHA check, or token operations fail.
- The two labels must be created once on the repo (`no-public-api-changes`, `expect-no-public-api-changes`).
- Not tested on actual CI yet.

🤖 Prepared with Claude Code