### PR TITLE
refactor: golf `Gaussian/GaussianIntegral`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
@@ -292,16 +292,12 @@ theorem integral_gaussian_complex_Ioi {b : ℂ} (hb : 0 < re b) :
   have full_integral := integral_gaussian_complex hb
   have h_eq : ∫ x : ℝ in Iic 0, f x = ∫ x : ℝ in Ioi 0, f x := by
     calc
-      ∫ x : ℝ in Iic 0, f x = ∫ x : ℝ in Ioi 0, f (-x) := by
-        simpa [f] using (integral_comp_neg_Ioi (c := 0) (f := f)).symm
-      _ = ∫ x : ℝ in Ioi 0, f x := by
-        refine setIntegral_congr_fun measurableSet_Ioi ?_
-        intro x hx
-        simp [f]
+      _ = ∫ x : ℝ in Ioi 0, f (-x) := by simp
+      _ = _ := setIntegral_congr_fun measurableSet_Ioi fun x hx ↦ by simp [f]
   have hmeas : MeasurableSet (Ioi (0 : ℝ)) := measurableSet_Ioi
   rw [← integral_add_compl hmeas (integrable_cexp_neg_mul_sq hb), compl_Ioi, h_eq, ← mul_two]
     at full_integral
-  exact (eq_div_iff two_ne_zero).2 (by simpa [mul_comm] using full_integral)
+  exact (eq_div_iff two_ne_zero).2 (by simpa using full_integral)
 
 -- The Gaussian integral on the half-line, `∫ x in Ioi 0, exp (-b * x^2)`, for real `b`.
 theorem integral_gaussian_Ioi (b : ℝ) :

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
@@ -288,27 +288,20 @@ theorem integral_gaussian_complex {b : ℂ} (hb : 0 < re b) :
 -- The Gaussian integral on the half-line, `∫ x in Ioi 0, exp (-b * x^2)`, for complex `b`.
 theorem integral_gaussian_complex_Ioi {b : ℂ} (hb : 0 < re b) :
     ∫ x : ℝ in Ioi 0, cexp (-b * (x : ℂ) ^ 2) = (π / b) ^ (1 / 2 : ℂ) / 2 := by
+  let f : ℝ → ℂ := fun x => cexp (-b * (x : ℂ) ^ 2)
   have full_integral := integral_gaussian_complex hb
-  have : MeasurableSet (Ioi (0 : ℝ)) := measurableSet_Ioi
-  rw [← integral_add_compl this (integrable_cexp_neg_mul_sq hb), compl_Ioi] at full_integral
-  suffices ∫ x : ℝ in Iic 0, cexp (-b * (x : ℂ) ^ 2) = ∫ x : ℝ in Ioi 0, cexp (-b * (x : ℂ) ^ 2) by
-    rw [this, ← mul_two] at full_integral
-    rwa [eq_div_iff]; exact two_ne_zero
-  have : ∀ c : ℝ, ∫ x in (0 : ℝ)..c, cexp (-b * (x : ℂ) ^ 2) =
-      ∫ x in -c..0, cexp (-b * (x : ℂ) ^ 2) := by
-    intro c
-    have := intervalIntegral.integral_comp_sub_left (a := 0) (b := c)
-      (fun x => cexp (-b * (x : ℂ) ^ 2)) 0
-    simpa [zero_sub, neg_sq, neg_zero] using this
-  have t1 :=
-    intervalIntegral_tendsto_integral_Ioi 0 (integrable_cexp_neg_mul_sq hb).integrableOn tendsto_id
-  have t2 :
-    Tendsto (fun c : ℝ => ∫ x : ℝ in (0 : ℝ)..c, cexp (-b * (x : ℂ) ^ 2)) atTop
-      (𝓝 (∫ x : ℝ in Iic 0, cexp (-b * (x : ℂ) ^ 2))) := by
-    simp_rw [this]
-    refine intervalIntegral_tendsto_integral_Iic _ ?_ tendsto_neg_atTop_atBot
-    apply (integrable_cexp_neg_mul_sq hb).integrableOn
-  exact tendsto_nhds_unique t2 t1
+  have h_eq : ∫ x : ℝ in Iic 0, f x = ∫ x : ℝ in Ioi 0, f x := by
+    calc
+      ∫ x : ℝ in Iic 0, f x = ∫ x : ℝ in Ioi 0, f (-x) := by
+        simpa [f] using (integral_comp_neg_Ioi (c := 0) (f := f)).symm
+      _ = ∫ x : ℝ in Ioi 0, f x := by
+        refine setIntegral_congr_fun measurableSet_Ioi ?_
+        intro x hx
+        simp [f]
+  have hmeas : MeasurableSet (Ioi (0 : ℝ)) := measurableSet_Ioi
+  rw [← integral_add_compl hmeas (integrable_cexp_neg_mul_sq hb), compl_Ioi, h_eq, ← mul_two]
+    at full_integral
+  exact (eq_div_iff two_ne_zero).2 (by simpa [mul_comm] using full_integral)
 
 -- The Gaussian integral on the half-line, `∫ x in Ioi 0, exp (-b * x^2)`, for real `b`.
 theorem integral_gaussian_Ioi (b : ℝ) :


### PR DESCRIPTION
This PR selectively ports part of #37968 and only migrates the changes in:

- `Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean`

Concretely, this PR:

- rewrites `integral_gaussian_complex_Ioi` by introducing the integrand as a local `f` and identifying the `Iic 0` and `Ioi 0` integrals via `integral_comp_neg_Ioi`
- replaces the previous interval-integral limit argument with a shorter proof using `integral_add_compl` and the symmetry of the Gaussian integrand on the half-line
