### PR TITLE
[Merged by Bors] - chore(GroupTheory): deduplicate RootableBy.surjective_pow

### DIFF
--- a/Mathlib/GroupTheory/Divisible.lean
+++ b/Mathlib/GroupTheory/Divisible.lean
@@ -110,10 +110,16 @@ class RootableBy where
   root_zero : ∀ a, root a 0 = 1
   root_cancel : ∀ {n : α} (a : A), n ≠ 0 → root a n ^ n = a
 
-@[to_additive smul_right_surj_of_divisibleBy]
-theorem pow_left_surj_of_rootableBy [RootableBy A α] {n : α} (hn : n ≠ 0) :
+@[to_additive DivisibleBy.surjective_smul]
+theorem RootableBy.surjective_pow [RootableBy A α] {n : α} (hn : n ≠ 0) :
     Function.Surjective (fun a => a ^ n : A → A) := fun x =>
   ⟨RootableBy.root x n, RootableBy.root_cancel _ hn⟩
+
+@[deprecated (since := "2026-04-19")] alias pow_left_surj_of_rootableBy :=
+  RootableBy.surjective_pow
+
+@[deprecated (since := "2026-04-19")] alias smul_right_surj_of_divisibleBy :=
+  DivisibleBy.surjective_smul
 
 /--
 A `Monoid A` is `α`-rootable iff the `pow _ n` function is surjective, i.e. the constructive version
@@ -251,11 +257,6 @@ noncomputable def Function.Surjective.rootableBy (hf : Function.Surjective f)
     let ⟨y, hy⟩ := hf x
     ⟨f <| RootableBy.root y n,
       (by rw [← hpow (RootableBy.root y n) n, RootableBy.root_cancel _ hn, hy] : _ ^ n = x)⟩
-
-@[to_additive DivisibleBy.surjective_smul]
-theorem RootableBy.surjective_pow (A α : Type*) [Monoid A] [Pow A α] [Zero α] [RootableBy A α]
-    {n : α} (hn : n ≠ 0) : Function.Surjective fun a : A => a ^ n := fun a =>
-  ⟨RootableBy.root a n, RootableBy.root_cancel a hn⟩
 
 end Hom
 

--- a/Mathlib/GroupTheory/Divisible.lean
+++ b/Mathlib/GroupTheory/Divisible.lean
@@ -112,7 +112,7 @@ class RootableBy where
 
 @[to_additive DivisibleBy.surjective_smul]
 theorem RootableBy.surjective_pow [RootableBy A α] {n : α} (hn : n ≠ 0) :
-    Function.Surjective (fun a => a ^ n : A → A) := fun x =>
+    Function.Surjective fun a : A => a ^ n := fun x =>
   ⟨RootableBy.root x n, RootableBy.root_cancel _ hn⟩
 
 @[deprecated (since := "2026-04-19")] alias pow_left_surj_of_rootableBy :=


### PR DESCRIPTION
[pow_left_surj_of_rootableBy](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Divisible.html#pow_left_surj_of_rootableBy) and [RootableBy.surjective_pow](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Divisible.html#RootableBy.surjective_pow) have the same statement, so this PR deprecates one of them. I kept the one with better naming (`surj` is not a widely used abbrev)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
