### PR TITLE
[Merged by Bors] - feat(CategoryTheory): add `MorphismProperty.paths`

### DIFF
--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -5,7 +5,6 @@ Authors: Kim Morrison, Robin Carlier
 -/
 module
 
-public import Mathlib.CategoryTheory.MorphismProperty.Composition
 public import Mathlib.CategoryTheory.Quotient
 
 /-!
@@ -284,99 +283,5 @@ def quotientPathsEquiv : Quotient (pathsHomRel C) ≌ C where
     rfl
 
 end
-
-namespace MorphismProperty
-
-variable {C : Type*} [Category* C]
-
-open Quiver
-
-/-- For any morphism property `W` on `C`, `W.paths` is the morphism property on `Paths C`
-containing all paths of morphisms in `W`. -/
-def paths (W : MorphismProperty C) : MorphismProperty (Paths C) :=
-  fun _ _ p ↦ p.rec True fun _ f P ↦ P ∧ W f
-
-@[simp]
-lemma nil_mem_paths {W : MorphismProperty C} {X : C} : W.paths (.nil (a := X)) := trivial
-
-lemma cons_mem_paths {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z}
-    (hp : W.paths p) (hf : W f) : W.paths (p.cons f) :=
-  ⟨hp, hf⟩
-
-@[simp]
-lemma cons_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z} :
-    W.paths (p.cons f) ↔ W.paths p ∧ W f :=
-  Iff.rfl
-
-lemma toPath_mem_paths {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} (hf : W f) :
-    W.paths f.toPath :=
-  ⟨trivial, hf⟩
-
-@[simp]
-lemma toPath_mem_paths_iff {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} :
-    W.paths f.toPath ↔ W f :=
-  ⟨fun h ↦ h.2, fun h ↦ ⟨trivial, h⟩⟩
-
-@[simp]
-lemma comp_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {q : Path Y Z} :
-    W.paths (p.comp q) ↔ W.paths p ∧ W.paths q := by
-  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨hp, hq⟩ ↦ ?_⟩
-  · induction q with
-    | nil => simpa using h
-    | cons q' f h' =>
-      rw [Path.comp_cons] at h
-      exact h' h.1
-  · induction q with
-    | nil => simp
-    | cons q' f h' =>
-      rw [Path.comp_cons] at h
-      exact ⟨h' h.1, h.2⟩
-  · induction q with
-    | nil => exact hp
-    | cons q q' h => exact ⟨h ⟨hp, hq.1⟩ hq.1, hq.2⟩
-
-instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
-  id_mem _ := nil_mem_paths
-  comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
-
-/-- If `W` and `W'` are morphism properties on `C` such that `W ≤ W'`, then `W.paths ≤ W'.paths`. -/
-@[gcongr]
-lemma monotone_paths : Monotone (paths (C := C)) :=
-  fun _ _ h _ _ p ↦ p.rec (fun _ ↦ trivial) (fun _ _ hp' hp ↦ ⟨hp' hp.1, h _ hp.2⟩)
-
-lemma composePath_mem_of_id_mem (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
-    {p : Path X Y} (hp : W.paths p) (h : W (𝟙 X)) : W (composePath p) := by
-  revert hp
-  exact p.rec (by simpa) fun p f hp hp' ↦ W.comp_mem _ _ (hp hp'.1) hp'.2
-
-lemma composePath_mem_of_length_pos (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
-    {p : Path X Y} (hp : W.paths p) (h : 0 < p.length) : W (composePath p) := by
-  revert hp h
-  refine p.rec (by simp) fun p f hp hp' hp'' ↦ ?_
-  cases p
-  · simpa [paths] using hp'
-  · refine W.comp_mem _ _ (hp hp'.1 (by simp)) hp'.2
-
-lemma composePath_mem (W : MorphismProperty C) [W.IsMultiplicative] {X Y : C}
-    {p : Path X Y} (hp : W.paths p) : W (composePath p) :=
-  W.composePath_mem_of_id_mem hp <| W.id_mem X
-
-lemma paths_le_inverseImage (W : MorphismProperty C) [W.IsMultiplicative] :
-    W.paths ≤ W.inverseImage (pathComposition C) :=
-  fun _ _ _ ↦ W.composePath_mem
-
-instance (W : MorphismProperty C) : IsMultiplicative (W.paths.strictMap (pathComposition C)) where
-  id_mem X := W.paths.map_mem_strictMap (pathComposition C) _ (W.paths.id_mem X)
-  comp_mem := fun _ _ ⟨hp⟩ ⟨hq⟩ ↦ by
-    simpa using W.paths.map_mem_strictMap (pathComposition C) _ <| W.paths.comp_mem _ _ hp hq
-
-lemma multiplicativeClosure_eq_strictMap_paths (W : MorphismProperty C) :
-    W.multiplicativeClosure = W.paths.strictMap (pathComposition C) := by
-  refine le_antisymm ?_ fun _ _ _ ⟨h⟩ ↦ ?_
-  · refine (W.multiplicativeClosure_le_iff _).2 fun X Y f hf ↦ ?_
-    simpa using W.paths.map_mem_strictMap (pathComposition C) f.toPath (by simpa)
-  · exact composePath_mem _ <| monotone_paths W.le_multiplicativeClosure _ h
-
-end MorphismProperty
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -362,6 +362,18 @@ lemma paths_le_inverseImage (W : MorphismProperty C) [W.IsMultiplicative] :
     W.paths ≤ W.inverseImage (pathComposition C) :=
   fun _ _ _ ↦ W.composePath_mem
 
+instance (W : MorphismProperty C) : IsMultiplicative (W.paths.strictMap (pathComposition C)) where
+  id_mem X := W.paths.map_mem_strictMap (pathComposition C) _ (W.paths.id_mem X)
+  comp_mem := fun _ _ ⟨hp⟩ ⟨hq⟩ ↦ by
+    simpa using W.paths.map_mem_strictMap (pathComposition C) _ <| W.paths.comp_mem _ _ hp hq
+
+lemma multiplicativeClosure_eq_strictMap_paths (W : MorphismProperty C) :
+    W.multiplicativeClosure = W.paths.strictMap (pathComposition C) := by
+  refine le_antisymm ?_ fun _ _ _ ⟨h⟩ ↦ ?_
+  · refine (W.multiplicativeClosure_le_iff _).2 fun X Y f hf ↦ ?_
+    simpa using W.paths.map_mem_strictMap (pathComposition C) f.toPath (by simpa)
+  · exact composePath_mem _ <| monotone_paths W.le_multiplicativeClosure _ h
+
 end MorphismProperty
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -5,10 +5,8 @@ Authors: Kim Morrison, Robin Carlier
 -/
 module
 
-public import Mathlib.CategoryTheory.EqToHom
 public import Mathlib.CategoryTheory.MorphismProperty.Composition
 public import Mathlib.CategoryTheory.Quotient
-public import Mathlib.Combinatorics.Quiver.Path
 
 /-!
 # The category paths on a quiver.
@@ -301,6 +299,15 @@ def paths (W : MorphismProperty C) : MorphismProperty (Paths C) :=
 @[simp]
 lemma nil_mem_paths {W : MorphismProperty C} {X : C} : W.paths (.nil (a := X)) := trivial
 
+lemma cons_mem_paths {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z}
+    (hp : W.paths p) (hf : W f) : W.paths (p.cons f) :=
+  ⟨hp, hf⟩
+
+@[simp]
+lemma cons_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z} :
+    W.paths (p.cons f) ↔ W.paths p ∧ W f :=
+  Iff.rfl
+
 lemma toPath_mem_paths {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} (hf : W f) :
     W.paths f.toPath :=
   ⟨trivial, hf⟩
@@ -332,6 +339,7 @@ instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
   id_mem _ := nil_mem_paths
   comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
 
+@[gcongr]
 lemma monotone_paths : Monotone (paths (C := C)) :=
   fun _ _ h _ _ p ↦ p.rec (fun _ ↦ trivial) (fun _ _ hp' hp ↦ ⟨hp' hp.1, h _ hp.2⟩)
 
@@ -349,6 +357,10 @@ lemma composePath_mem' (W : MorphismProperty C) [W.IsStableUnderComposition] {X 
 lemma composePath_mem (W : MorphismProperty C) [W.IsMultiplicative] {X Y : C}
     {p : Path X Y} (hp : W.paths p) : W (composePath p) :=
   W.composePath_mem' hp <| .inr (W.id_mem X)
+
+lemma paths_le_inverseImage (W : MorphismProperty C) [W.IsMultiplicative] :
+    W.paths ≤ W.inverseImage (pathComposition C) :=
+  fun _ _ _ ↦ W.composePath_mem
 
 end MorphismProperty
 

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -339,24 +339,27 @@ instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
   id_mem _ := nil_mem_paths
   comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
 
+/-- If `W` and `W'` are morphism properties on `C` such that `W ≤ W'`, then `W.paths ≤ W'.paths`. -/
 @[gcongr]
 lemma monotone_paths : Monotone (paths (C := C)) :=
   fun _ _ h _ _ p ↦ p.rec (fun _ ↦ trivial) (fun _ _ hp' hp ↦ ⟨hp' hp.1, h _ hp.2⟩)
 
-lemma composePath_mem' (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
-    {p : Path X Y} (hp : W.paths p) (h : 0 < p.length ∨ W (𝟙 X)) : W (composePath p) := by
-  obtain hp' | hX := h
-  · revert hp hp'
-    refine p.rec (by simp) fun p f hp hp' hp'' ↦ ?_
-    cases p
-    · simpa [paths] using hp'
-    · refine W.comp_mem _ _ (hp hp'.1 (by simp)) hp'.2
-  · revert hp
-    exact p.rec (fun _ ↦ hX) fun p f hp hp' ↦ W.comp_mem _ _ (hp hp'.1) hp'.2
+lemma composePath_mem_of_id_mem (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) (h : W (𝟙 X)) : W (composePath p) := by
+  revert hp
+  exact p.rec (by simpa) fun p f hp hp' ↦ W.comp_mem _ _ (hp hp'.1) hp'.2
+
+lemma composePath_mem_of_length_pos (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) (h : 0 < p.length) : W (composePath p) := by
+  revert hp h
+  refine p.rec (by simp) fun p f hp hp' hp'' ↦ ?_
+  cases p
+  · simpa [paths] using hp'
+  · refine W.comp_mem _ _ (hp hp'.1 (by simp)) hp'.2
 
 lemma composePath_mem (W : MorphismProperty C) [W.IsMultiplicative] {X Y : C}
     {p : Path X Y} (hp : W.paths p) : W (composePath p) :=
-  W.composePath_mem' hp <| .inr (W.id_mem X)
+  W.composePath_mem_of_id_mem hp <| W.id_mem X
 
 lemma paths_le_inverseImage (W : MorphismProperty C) [W.IsMultiplicative] :
     W.paths ≤ W.inverseImage (pathComposition C) :=

--- a/Mathlib/CategoryTheory/PathCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/PathCategory/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison, Robin Carlier
 module
 
 public import Mathlib.CategoryTheory.EqToHom
+public import Mathlib.CategoryTheory.MorphismProperty.Composition
 public import Mathlib.CategoryTheory.Quotient
 public import Mathlib.Combinatorics.Quiver.Path
 
@@ -21,7 +22,6 @@ We check that the quotient of the path category of a category by the canonical r
 -/
 
 @[expose] public section
-
 
 universe v₁ v₂ u₁ u₂
 
@@ -286,5 +286,70 @@ def quotientPathsEquiv : Quotient (pathsHomRel C) ≌ C where
     rfl
 
 end
+
+namespace MorphismProperty
+
+variable {C : Type*} [Category* C]
+
+open Quiver
+
+/-- For any morphism property `W` on `C`, `W.paths` is the morphism property on `Paths C`
+containing all paths of morphisms in `W`. -/
+def paths (W : MorphismProperty C) : MorphismProperty (Paths C) :=
+  fun _ _ p ↦ p.rec True fun _ f P ↦ P ∧ W f
+
+@[simp]
+lemma nil_mem_paths {W : MorphismProperty C} {X : C} : W.paths (.nil (a := X)) := trivial
+
+lemma toPath_mem_paths {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} (hf : W f) :
+    W.paths f.toPath :=
+  ⟨trivial, hf⟩
+
+@[simp]
+lemma toPath_mem_paths_iff {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} :
+    W.paths f.toPath ↔ W f :=
+  ⟨fun h ↦ h.2, fun h ↦ ⟨trivial, h⟩⟩
+
+@[simp]
+lemma comp_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {q : Path Y Z} :
+    W.paths (p.comp q) ↔ W.paths p ∧ W.paths q := by
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨hp, hq⟩ ↦ ?_⟩
+  · induction q with
+    | nil => simpa using h
+    | cons q' f h' =>
+      rw [Path.comp_cons] at h
+      exact h' h.1
+  · induction q with
+    | nil => simp
+    | cons q' f h' =>
+      rw [Path.comp_cons] at h
+      exact ⟨h' h.1, h.2⟩
+  · induction q with
+    | nil => exact hp
+    | cons q q' h => exact ⟨h ⟨hp, hq.1⟩ hq.1, hq.2⟩
+
+instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
+  id_mem _ := nil_mem_paths
+  comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
+
+lemma monotone_paths : Monotone (paths (C := C)) :=
+  fun _ _ h _ _ p ↦ p.rec (fun _ ↦ trivial) (fun _ _ hp' hp ↦ ⟨hp' hp.1, h _ hp.2⟩)
+
+lemma composePath_mem' (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) (h : 0 < p.length ∨ W (𝟙 X)) : W (composePath p) := by
+  obtain hp' | hX := h
+  · revert hp hp'
+    refine p.rec (by simp) fun p f hp hp' hp'' ↦ ?_
+    cases p
+    · simpa [paths] using hp'
+    · refine W.comp_mem _ _ (hp hp'.1 (by simp)) hp'.2
+  · revert hp
+    exact p.rec (fun _ ↦ hX) fun p f hp hp' ↦ W.comp_mem _ _ (hp hp'.1) hp'.2
+
+lemma composePath_mem (W : MorphismProperty C) [W.IsMultiplicative] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) : W (composePath p) :=
+  W.composePath_mem' hp <| .inr (W.id_mem X)
+
+end MorphismProperty
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
@@ -13,7 +13,10 @@ public import Mathlib.CategoryTheory.MorphismProperty.Composition
 
 We provide a formulation of induction principles for morphisms in a path category in terms of
 `MorphismProperty`. This file is separate from `Mathlib/CategoryTheory/PathCategory/Basic.lean` in
-order to reduce transitive imports. -/
+order to reduce transitive imports.
+
+We also define a morpism property `W.paths : MorphismProperty (Paths C)` for any
+`W : MorphismProperty C`, consisting of all paths in `C` that consist only of morphisms in `W`. -/
 
 @[expose] public section
 
@@ -80,3 +83,97 @@ def liftNatIso {C} [Category* C] {F G : Paths V ⥤ C} (α_app : (v : V) → (F.
 end
 
 end CategoryTheory.Paths
+
+namespace CategoryTheory.MorphismProperty
+
+variable {C : Type*} [Category* C]
+
+open Quiver
+
+/-- For any morphism property `W` on `C`, `W.paths` is the morphism property on `Paths C`
+containing all paths of morphisms in `W`. -/
+def paths (W : MorphismProperty C) : MorphismProperty (Paths C) :=
+  fun _ _ p ↦ p.rec True fun _ f P ↦ P ∧ W f
+
+@[simp]
+lemma nil_mem_paths {W : MorphismProperty C} {X : C} : W.paths (.nil (a := X)) := trivial
+
+lemma cons_mem_paths {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z}
+    (hp : W.paths p) (hf : W f) : W.paths (p.cons f) :=
+  ⟨hp, hf⟩
+
+@[simp]
+lemma cons_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {f : Y ⟶ Z} :
+    W.paths (p.cons f) ↔ W.paths p ∧ W f :=
+  Iff.rfl
+
+lemma toPath_mem_paths {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} (hf : W f) :
+    W.paths f.toPath :=
+  ⟨trivial, hf⟩
+
+@[simp]
+lemma toPath_mem_paths_iff {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} :
+    W.paths f.toPath ↔ W f :=
+  ⟨fun h ↦ h.2, fun h ↦ ⟨trivial, h⟩⟩
+
+@[simp]
+lemma comp_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {q : Path Y Z} :
+    W.paths (p.comp q) ↔ W.paths p ∧ W.paths q := by
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨hp, hq⟩ ↦ ?_⟩
+  · induction q with
+    | nil => simpa using h
+    | cons q' f h' =>
+      rw [Path.comp_cons] at h
+      exact h' h.1
+  · induction q with
+    | nil => simp
+    | cons q' f h' =>
+      rw [Path.comp_cons] at h
+      exact ⟨h' h.1, h.2⟩
+  · induction q with
+    | nil => exact hp
+    | cons q q' h => exact ⟨h ⟨hp, hq.1⟩ hq.1, hq.2⟩
+
+instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
+  id_mem _ := nil_mem_paths
+  comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
+
+/-- If `W` and `W'` are morphism properties on `C` such that `W ≤ W'`, then `W.paths ≤ W'.paths`. -/
+@[gcongr]
+lemma monotone_paths : Monotone (paths (C := C)) :=
+  fun _ _ h _ _ p ↦ p.rec (fun _ ↦ trivial) (fun _ _ hp' hp ↦ ⟨hp' hp.1, h _ hp.2⟩)
+
+lemma composePath_mem_of_id_mem (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) (h : W (𝟙 X)) : W (composePath p) := by
+  revert hp
+  exact p.rec (by simpa) fun p f hp hp' ↦ W.comp_mem _ _ (hp hp'.1) hp'.2
+
+lemma composePath_mem_of_length_pos (W : MorphismProperty C) [W.IsStableUnderComposition] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) (h : 0 < p.length) : W (composePath p) := by
+  revert hp h
+  refine p.rec (by simp) fun p f hp hp' hp'' ↦ ?_
+  cases p
+  · simpa [paths] using hp'
+  · refine W.comp_mem _ _ (hp hp'.1 (by simp)) hp'.2
+
+lemma composePath_mem (W : MorphismProperty C) [W.IsMultiplicative] {X Y : C}
+    {p : Path X Y} (hp : W.paths p) : W (composePath p) :=
+  W.composePath_mem_of_id_mem hp <| W.id_mem X
+
+lemma paths_le_inverseImage (W : MorphismProperty C) [W.IsMultiplicative] :
+    W.paths ≤ W.inverseImage (pathComposition C) :=
+  fun _ _ _ ↦ W.composePath_mem
+
+instance (W : MorphismProperty C) : IsMultiplicative (W.paths.strictMap (pathComposition C)) where
+  id_mem X := W.paths.map_mem_strictMap (pathComposition C) _ (W.paths.id_mem X)
+  comp_mem := fun _ _ ⟨hp⟩ ⟨hq⟩ ↦ by
+    simpa using W.paths.map_mem_strictMap (pathComposition C) _ <| W.paths.comp_mem _ _ hp hq
+
+lemma multiplicativeClosure_eq_strictMap_paths (W : MorphismProperty C) :
+    W.multiplicativeClosure = W.paths.strictMap (pathComposition C) := by
+  refine le_antisymm ?_ fun _ _ _ ⟨h⟩ ↦ ?_
+  · refine (W.multiplicativeClosure_le_iff _).2 fun X Y f hf ↦ ?_
+    simpa using W.paths.map_mem_strictMap (pathComposition C) f.toPath (by simpa)
+  · exact composePath_mem _ <| monotone_paths W.le_multiplicativeClosure _ h
+
+end CategoryTheory.MorphismProperty

--- a/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
@@ -134,9 +134,14 @@ lemma comp_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {q 
     | nil => exact hp
     | cons q q' h => exact ⟨h ⟨hp, hq.1⟩ hq.1, hq.2⟩
 
+@[simp]
+lemma comp_mem_paths_iff' {W : MorphismProperty C} {X Y Z : Paths C} {p : X ⟶ Y} {q : Y ⟶ Z} :
+    W.paths (p ≫ q) ↔ W.paths p ∧ W.paths q :=
+  W.comp_mem_paths_iff
+
 instance (W : MorphismProperty C) : W.paths.IsMultiplicative where
   id_mem _ := nil_mem_paths
-  comp_mem _ _ hf hg := W.comp_mem_paths_iff.2 ⟨hf, hg⟩
+  comp_mem _ _ hf hg := W.comp_mem_paths_iff'.2 ⟨hf, hg⟩
 
 /-- If `W` and `W'` are morphism properties on `C` such that `W ≤ W'`, then `W.paths ≤ W'.paths`. -/
 @[gcongr]

--- a/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/PathCategory/MorphismProperty.lean
@@ -114,7 +114,7 @@ lemma toPath_mem_paths {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} (hf : W 
 @[simp]
 lemma toPath_mem_paths_iff {W : MorphismProperty C} {X Y : C} {f : X ⟶ Y} :
     W.paths f.toPath ↔ W f :=
-  ⟨fun h ↦ h.2, fun h ↦ ⟨trivial, h⟩⟩
+  ⟨fun h ↦ h.2, toPath_mem_paths⟩
 
 @[simp]
 lemma comp_mem_paths_iff {W : MorphismProperty C} {X Y Z : C} {p : Path X Y} {q : Path Y Z} :


### PR DESCRIPTION
For any `W : MorphismProperty C`, we define `W.paths : MorphismProperty (Paths C)` as the morphism property containing those paths that consist entirely of morphisms in `W`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I'm currently preparing a PR defining replete subcategories and showing that the replete subcategories of any fixed category form a complete lattice; this API was written because it is helpful to characterise the subcategory generated by a class of morphisms `W` as (up to some issues regarding identities) consisting of those morphisms `f` which are the concatenation of a finitely many morphisms in `W`, i.e. for which there exists a path `p` with `composePath p = f` and `W.paths p`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
