### PR TITLE
feat(Order/CompleteLatticeIntervals): `ConditionallyCompleteLinearOrderBot` for `Set.Iio`

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -325,6 +325,10 @@ theorem isLeast_Ici : IsLeast (Ici a) a :=
   ⟨self_mem_Ici, fun _ => id⟩
 
 @[to_dual]
+theorem isGreatest_Ioi_top [OrderTop α] (ha : ¬ IsMax a) : IsGreatest (Ioi a) ⊤ :=
+  ⟨(not_isMax_iff.1 ha).elim fun _ => lt_top_of_lt, fun _ _ => le_top⟩
+
+@[to_dual]
 theorem isLUB_Iic : IsLUB (Iic a) a :=
   isGreatest_Iic.isLUB
 

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -166,6 +166,58 @@ noncomputable instance ordConnectedSubsetConditionallyCompleteLinearOrder [Inhab
 
 end OrdConnected
 
+section Iio
+
+open Classical in
+/-- Complete lattice structure on `Set.Iio` -/
+noncomputable instance Set.Iio.conditionallyCompleteLinearOrderBot
+    [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)] :
+    ConditionallyCompleteLinearOrderBot (Iio a) where
+  __ := (inferInstance : LinearOrder (Iio a))
+  __ := orderBot
+  __ := (inferInstance : Lattice (Iio a))
+  sSup S := if hS : BddAbove S then ⟨sSup ((↑) '' S), by
+    rcases hS with ⟨b, hb⟩
+    rw [mem_Iio]
+    apply b.2.trans_le'
+    apply csSup_le'
+    simpa [mem_upperBounds] using hb⟩ else ⊥
+  isLUB_csSup S hS hS' := by
+    simp only [hS', ↓reduceDIte]
+    refine IsLUB.of_image (f := Subtype.val) (by simp) (isLUB_csSup' ?_)
+    exact (Subtype.mono_coe _).map_bddAbove hS'
+  csSup_of_not_bddAbove S hS := by simp [hS]
+  csSup_empty := by simp
+  sInf S := if hS : S.Nonempty then ⟨sInf ((↑) '' S), by
+    rcases hS with ⟨b, hb⟩
+    rw [mem_Iio]
+    apply b.2.trans_le'
+    apply csInf_le'
+    simpa using ⟨b.2, hb⟩⟩ else ⊥
+  isGLB_csInf S hS hS' := by
+    simp only [hS, ↓reduceDIte]
+    refine IsGLB.of_image (f := Subtype.val) (by simp) (isGLB_csInf ?_)
+    simpa
+  csInf_of_not_bddBelow := by simp
+
+lemma Set.Iio.coe_sSup [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)]
+    {S : Set (Iio a)} (hS : BddAbove S) : ↑(sSup S) = sSup ((↑) '' S : Set α) :=
+  congrArg Subtype.val (dif_pos hS)
+
+lemma Set.Iio.coe_sInf [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)]
+    {S : Set (Iio a)} (hS : S.Nonempty) : ↑(sInf S) = sInf ((↑) '' S : Set α) :=
+  congrArg Subtype.val (dif_pos hS)
+
+lemma Set.Iio.coe_iSup [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)]
+    {f : ι → Iio a} (hf : BddAbove (range f)) : ↑(iSup f) = (⨆ i, f i : α) :=
+  (coe_sSup hf).trans (congrArg sSup (range_comp Subtype.val f).symm)
+
+lemma Set.Iio.coe_iInf [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)]
+    [Nonempty ι] {f : ι → Iio a} : ↑(iInf f) = (⨅ i, f i : α) :=
+  (coe_sInf (range_nonempty f)).trans (congrArg sInf (range_comp Subtype.val f).symm)
+
+end Iio
+
 section Icc
 
 open Classical in

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -169,7 +169,7 @@ end OrdConnected
 section Iio
 
 open Classical in
-/-- Complete lattice structure on `Set.Iio` -/
+/-- Complete linear order structure on `Set.Iio` -/
 noncomputable instance Set.Iio.conditionallyCompleteLinearOrderBot
     [ConditionallyCompleteLinearOrderBot α] {a : α} [Fact (¬ IsMin a)] :
     ConditionallyCompleteLinearOrderBot (Iio a) where

--- a/Mathlib/Order/LatticeIntervals.lean
+++ b/Mathlib/Order/LatticeIntervals.lean
@@ -67,6 +67,26 @@ protected lemma coe_inf [SemilatticeInf α] {a : α} {x y : Iio a} :
     ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
 
+instance semilatticeSup [SemilatticeSup α] [IsLinearOrder α (· ≤ ·)] {a : α} :
+    SemilatticeSup (Iio a) :=
+  Subtype.semilatticeSup fun x y hx hy =>
+    (Std.Total.total x y).elim (fun h : x ≤ y => by rwa [sup_eq_right.2 h]) fun h => by
+      rwa [sup_eq_left.2 h]
+
+@[simp, norm_cast]
+protected lemma coe_sup [SemilatticeSup α] [IsLinearOrder α (· ≤ ·)] {a : α} {x y : Iio a} :
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
+  rfl
+
+instance [Lattice α] [IsLinearOrder α (· ≤ ·)] {a : α} : Lattice (Iio a) where
+
+instance orderBot [Preorder α] [OrderBot α] {a : α} [Fact (¬ IsMin a)] : OrderBot (Iio a) :=
+  (isLeast_Iio_bot Fact.out).orderBot
+
+@[simp, norm_cast]
+protected lemma coe_bot [Preorder α] [OrderBot α] (a : α) [Fact (¬ IsMin a)] :
+    (⊥ : Iio a) = (⊥ : α) := rfl
+
 end Iio
 
 namespace Ioc


### PR DESCRIPTION
`Set.Iio a` (when it's nonempty) inherits the `ConditionallyCompleteLinearOrderBot` structure from the base type. This is commonly used in set theory, where we consider the ordinals within `a`, and convert `Iio a` from/to `Ordinal`.

There should also be a `ConditionallyCompleteLinearOrder` instance, but adding this seems difficult for now because the junk value may not be the same as bottom (which has been mentioned as "refactor that will allow different
default values for `sSup` and `sInf`" in the module doc). Since my motivation is for the ordinals purely, this PR only adds a single `ConditionallyCompleteLinearOrderBot` instance.

---

I'm not very familiar with the API design here, so any suggestion would be helpful.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #35674

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
