### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `split_ifs` tactic docstring

### DIFF
--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -136,14 +136,17 @@ private partial def splitIfsCore
     andThenOnSubgoals (splitIf1 cond hName loc) ((splitIfsCore loc hNames (cond::done)) <|>
       pure ())
 
-/-- Splits all if-then-else-expressions into multiple goals.
-Given a goal of the form `g (if p then x else y)`, `split_ifs` will produce
-two goals: `p ⊢ g x` and `¬p ⊢ g y`.
-If there are multiple ite-expressions, then `split_ifs` will split them all,
-starting with a top-most one whose condition does not contain another
-ite-expression.
-`split_ifs at *` splits all ite-expressions in all hypotheses as well as the goal.
-`split_ifs with h₁ h₂ h₃` overrides the default names for the hypotheses.
+/-- `split_ifs` splits the main goal in two goals for every if-then-else expression it contains,
+by applying excluded middle to the condition. If the goal has the form `g (if p then x else y)`,
+`split_ifs` will result in two goals `h✝ : p ⊢ g x` and `h✝ : ¬p ⊢ g y`. If there are multiple
+if-then-else expressions, then `split_ifs` will split them all, starting with a top-most one whose
+condition does not contain another if-then-else expression.
+
+* `split_ifs with h₁ h₂ h₃` names the introduced hypotheses.
+  Note that names are not reused across splits: on a goal of the form
+  `⊢ (if p then 1 else 2) + (if q then 3 else 4)`, use `split_ifs with hp hq hq` to name all
+  the hypotheses.
+* `split_ifs at l` splits the if-then-else expressions at location(s) l.
 -/
 syntax (name := splitIfs) "split_ifs" (location)? (" with" (ppSpace colGt binderIdent)+)? : tactic
 

--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -146,7 +146,7 @@ condition does not contain another if-then-else expression.
   Note that names are not reused across splits: on a goal of the form
   `⊢ (if p then 1 else 2) + (if q then 3 else 4)`, use `split_ifs with hp hq hq` to name all
   the hypotheses.
-* `split_ifs at l` splits the if-then-else expressions at location(s) l.
+* `split_ifs at l` splits the if-then-else expressions at location(s) `l`.
 -/
 syntax (name := splitIfs) "split_ifs" (location)? (" with" (ppSpace colGt binderIdent)+)? : tactic
 


### PR DESCRIPTION
This PR rewrites the docstrings for the `split_ifs` tactic, to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure they are complete while not getting too long.

Most important addition is the fact that hypothesis names are not reused across splits.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
