### PR TITLE
[Merged by Bors] - chore(Tactic): rewrite `subsingleton` tactic docstring

### DIFF
--- a/Mathlib/Tactic/Subsingleton.lean
+++ b/Mathlib/Tactic/Subsingleton.lean
@@ -108,34 +108,21 @@ def Lean.MVarId.subsingleton (g : MVarId) (insts : Array (Term × AbstractMVarsR
 namespace Mathlib.Tactic
 
 /--
-The `subsingleton` tactic tries to prove a goal of the form `x = y` or `x ≍ y`
-using the fact that the types involved are *subsingletons*
-(a type with exactly zero or one terms).
-To a first approximation, it does `apply Subsingleton.elim`.
-As a nicety, `subsingleton` first runs the `intros` tactic.
-
-- If the goal is an equality, it either closes the goal or fails.
-- `subsingleton [inst1, inst2, ...]` can be used to add additional `Subsingleton` instances
-  to the local context. This can be more flexible than
-  `have := inst1; have := inst2; ...; subsingleton` since the tactic does not require that
-  all placeholders be solved for.
+`subsingleton` proves the main goal of the form `∀ a ... b, x = y` or `∀ a ... b, x ≍ y` using the
+fact that the type(s) of `x` and `y` are *subsingletons* (a type with exactly zero or one elements).
+If `subsingleton` cannot close the goal, it fails.
 
 Techniques the `subsingleton` tactic can apply:
 - proof irrelevance
 - heterogeneous proof irrelevance (via `proof_irrel_heq`)
 - using `Subsingleton` (via `Subsingleton.elim`)
-- proving `BEq` instances are equal if they are both lawful (via `lawful_beq_subsingleton`)
+- proving instances of the type `BEq α` are equal if they are both lawful
+  (via `lawful_beq_subsingleton`)
 
-### Properties
-
-The tactic is careful not to accidentally specialize `Sort _` to `Prop`,
-avoiding the following surprising behavior of `apply Subsingleton.elim`:
-```lean
-example (α : Sort _) (x y : α) : x = y := by apply Subsingleton.elim
-```
-The reason this `example` goes through is that
-it applies the `∀ (p : Prop), Subsingleton p` instance,
-specializing the universe level metavariable in `Sort _` to `0`.
+* `subsingleton [inst1, inst2, ...]` can be used to add additional `Subsingleton` instances
+  to the local context. This can be more flexible than
+  `have := inst1; have := inst2; ...; subsingleton` since the tactic does not require that
+  all placeholders be solved for.
 -/
 syntax (name := subsingletonStx) "subsingleton" (ppSpace "[" term,* "]")? : tactic
 


### PR DESCRIPTION
This PR rewrites the docstrings for the `subsingleton` tactic, to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure they are complete while not getting too long.

The remark about `Sort _` being set to `Sort 0` by `apply Subsingleton.elim` does not seem to be true anymore, so I removed it.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
