### PR TITLE
[Merged by Bors] - chore: update deprecated declarations in `*.yaml`s

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -3506,7 +3506,7 @@ Q6799039:
 
 Q6813106:
   title: Mellin inversion theorem
-  decl: mellin_inversion
+  decl: mellinInv_mellin_eq
 
 Q6859627:
   title: Milliken's tree theorem
@@ -3623,7 +3623,6 @@ Q7208500:
   title: Poisson limit theorem
   decls:
     - ProbabilityTheory.tendsto_choose_mul_pow_of_tendsto_mul_atTop
-    - ProbabilityTheory.binomial_tendsto_poissonPMFReal_atTop
   authors: Yi Yuan
   date: 2026
 

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -12,7 +12,7 @@ General algebra:
     presheafed space: 'AlgebraicGeometry.PresheafedSpace'
     sheafed space: 'AlgebraicGeometry.SheafedSpace'
     monoidal category: 'CategoryTheory.MonoidalCategory'
-    Cartesian closed: 'CategoryTheory.CartesianClosed'
+    Cartesian closed: 'CategoryTheory.MonoidalClosed'
     abelian category: 'CategoryTheory.Abelian'
 
   Numbers:
@@ -129,7 +129,7 @@ General algebra:
     splitting field: 'Polynomial.SplittingField'
     perfect closure: 'PerfectClosure'
     Galois correspondence: 'IsGalois.intermediateFieldEquivSubgroup'
-    Abel-Ruffini theorem (one direction): 'solvableByRad.isSolvable'
+    Abel-Ruffini theorem (one direction): 'isSolvable_gal_minpoly'
 
   Homological algebra:
     chain complex: 'ChainComplex'
@@ -146,7 +146,7 @@ General algebra:
     Chevalley-Warning theorem: 'char_dvd_card_solutions'
     "Hensel's lemma (for $\\mathbb{Z}_p$)": 'hensels_lemma'
     ring of Witt vectors: 'WittVector'
-    perfection of a ring: 'Ring.Perfection'
+    perfection of a ring: 'Perfection'
   Transcendental numbers:
     Liouville's theorem on existence of transcendental numbers: 'transcendental_liouvilleNumber'
 
@@ -200,7 +200,7 @@ Linear algebra:
     bilinear form: 'LinearMap.BilinForm'
     alternating bilinear form: 'LinearMap.BilinForm.IsAlt'
     symmetric bilinear form: 'LinearMap.BilinForm.IsSymm'
-    matrix representation: 'BilinForm.toMatrix'
+    matrix representation: 'LinearMap.BilinForm.toMatrix'
     quadratic form: 'QuadraticForm'
     polar form of a quadratic: 'QuadraticMap.polar'
   Finite-dimensional inner product spaces (see also Hilbert spaces, below):
@@ -366,7 +366,7 @@ Analysis:
     principle of isolated zeros: 'AnalyticAt.eventually_eq_zero_or_eventually_ne_zero'
     principle of analytic continuation: 'AnalyticOnNhd.eqOn_of_preconnected_of_frequently_eq'
     analyticity of holomorphic functions: 'DifferentiableOn.analyticAt'
-    Schwarz lemma: 'Complex.norm_le_norm_of_mapsTo_ball_self'
+    Schwarz lemma: 'Complex.norm_le_norm_of_mapsTo_ball'
     removable singularity: 'Complex.differentiableOn_update_limUnder_insert_of_isLittleO'
     Phragmen-Lindelöf principle: 'PhragmenLindelof.horizontal_strip'
     fundamental theorem of algebra: 'Complex.isAlgClosed'
@@ -420,7 +420,7 @@ Probability Theory:
     martingale: 'MeasureTheory.Martingale'
     optional stopping theorem: 'MeasureTheory.submartingale_iff_expected_stoppedValue_mono'
     stopping time: 'MeasureTheory.IsStoppingTime'
-    hitting time: 'MeasureTheory.hitting'
+    hitting time: 'MeasureTheory.hittingBtwn'
     Gaussian processes: 'ProbabilityTheory.IsGaussianProcess'
 
 Geometry:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -197,8 +197,8 @@ Bilinear and Quadratic Forms Over a Vector Space:
     alternating bilinear forms: 'LinearMap.BilinForm.IsAlt'
     symmetric bilinear forms: 'LinearMap.BilinForm.IsSymm'
     nondegenerate forms: 'LinearMap.BilinForm.Nondegenerate'
-    matrix representation: 'BilinForm.toMatrix'
-    change of coordinates: 'BilinForm.toMatrix_comp'
+    matrix representation: 'LinearMap.BilinForm.toMatrix'
+    change of coordinates: 'LinearMap.BilinForm.toMatrix_comp'
     rank of a bilinear form: ''
   Quadratic forms:
     quadratic form: 'QuadraticForm'
@@ -618,8 +618,8 @@ Distribution calculus:
     $L^p$ functions: 'MeasureTheory.Lp.toTemperedDistributionCLM'
     periodic functions: ''
     Dirac comb: ''
-    Fourier transforms: 'TemperedDistribution.fourierTransformCLM'
-    inverse Fourier transform: 'TemperedDistribution.fourierTransformInvCLM'
+    Fourier transforms: 'FourierTransform.fourierCLM'
+    inverse Fourier transform: 'FourierTransform.fourierInvCLM'
     Fourier transform and derivation: ''
     Fourier transform and convolution product: ''
   Applications:


### PR DESCRIPTION
Updates deprecated declarations in `1000.yaml`, `overview.yaml`, and `undergrad.yaml`. Found with #38313.

Note: in 1000.yaml, the removed declaration `ProbabilityTheory.binomial_tendsto_poissonPMFReal_atTop` has been deprecated in favor of the adjacent already-present declaration `ProbabilityTheory.tendsto_choose_mul_pow_of_tendsto_mul_atTop`.

---

Disclosure: I threw the following output:
```
Entries in `docs/undergrad.yaml` refer to 4 declaration(s) that are deprecated. Please update the document to refer to the following declaration(s):
  Bilinear and Quadratic Forms Over a Vector Space :: Bilinear forms :: matrix representation: 'LinearMap.BilinForm.toMatrix' (previously 'BilinForm.toMatrix')
  Bilinear and Quadratic Forms Over a Vector Space :: Bilinear forms :: change of coordinates: 'LinearMap.BilinForm.toMatrix_comp' (previously 'BilinForm.toMatrix_comp')
  Distribution calculus :: Tempered distributions :: Fourier transforms: 'FourierTransform.fourierCLM' (previously 'TemperedDistribution.fourierTransformCLM')
  Distribution calculus :: Tempered distributions :: inverse Fourier transform: 'FourierTransform.fourierInvCLM' (previously 'TemperedDistribution.fourierTransformInvCLM')
Entries in `docs/overview.yaml` refer to 6 declaration(s) that are deprecated. Please update the document to refer to the following declaration(s):
  General algebra :: Category theory :: Cartesian closed: 'CategoryTheory.MonoidalClosed' (previously 'CategoryTheory.CartesianClosed')
  General algebra :: Field theory :: Abel-Ruffini theorem (one direction): 'isSolvable_gal_minpoly' (previously 'solvableByRad.isSolvable')
  General algebra :: Number theory :: perfection of a ring: 'Perfection' (previously 'Ring.Perfection')
  Linear algebra :: Bilinear and quadratic forms :: matrix representation: 'LinearMap.BilinForm.toMatrix' (previously 'BilinForm.toMatrix')
  Analysis :: Complex analysis :: Schwarz lemma: 'Complex.norm_le_norm_of_mapsTo_ball' (previously 'Complex.norm_le_norm_of_mapsTo_ball_self')
  Probability Theory :: Stochastic Processes :: hitting time: 'MeasureTheory.hittingBtwn' (previously 'MeasureTheory.hitting')
Entries in `docs/1000.yaml` refer to 2 declaration(s) that are deprecated. Please update the document to refer to the following declaration(s):
  Q6813106 Mellin inversion theorem: 'mellinInv_mellin_eq' (previously 'mellin_inversion')
  Q7208500 Poisson limit theorem: 'ProbabilityTheory.tendsto_choose_mul_pow_of_tendsto_mul_atTop' (previously 'ProbabilityTheory.binomial_tendsto_poissonPMFReal_atTop')
```
at Claude, then ensured that `lake exe check-yaml` passed after regenerating the json and reviewed the changes.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
