### PR TITLE
[Merged by Bors] - chore: tag floor lemmas with `@[push]`

### DIFF
--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -181,12 +181,12 @@ theorem floor_one : ⌊(1 : R)⌋ = 1 := by rw [← cast_one, floor_intCast]
 @[simp] theorem floor_ofNat (n : ℕ) [n.AtLeastTwo] : ⌊(ofNat(n) : R)⌋ = ofNat(n) :=
   floor_natCast n
 
-@[simp]
+@[simp, push]
 theorem floor_add_intCast (a : R) (z : ℤ) : ⌊a + z⌋ = ⌊a⌋ + z :=
   eq_of_forall_le_iff fun a => by
     rw [le_floor, ← sub_le_iff_le_add, ← sub_le_iff_le_add, le_floor, Int.cast_sub]
 
-@[simp]
+@[simp, push]
 theorem floor_add_one (a : R) : ⌊a + 1⌋ = ⌊a⌋ + 1 := by
   rw [← cast_one, floor_add_intCast]
 
@@ -202,24 +202,24 @@ theorem le_floor_add_floor (a b : R) : ⌊a + b⌋ - 1 ≤ ⌊a⌋ + ⌊b⌋ := 
   rw [sub_le_iff_le_add', ← add_sub_assoc, sub_le_sub_iff_right]
   exact floor_le _
 
-@[simp]
+@[simp, push]
 theorem floor_intCast_add (z : ℤ) (a : R) : ⌊↑z + a⌋ = z + ⌊a⌋ := by
   simpa only [add_comm] using floor_add_intCast a z
 
-@[simp]
+@[simp, push]
 theorem floor_add_natCast (a : R) (n : ℕ) : ⌊a + n⌋ = ⌊a⌋ + n := by
   rw [← Int.cast_natCast, floor_add_intCast]
 
-@[simp]
+@[simp, push]
 theorem floor_add_ofNat (a : R) (n : ℕ) [n.AtLeastTwo] :
     ⌊a + ofNat(n)⌋ = ⌊a⌋ + ofNat(n) :=
   floor_add_natCast a n
 
-@[simp]
+@[simp, push]
 theorem floor_natCast_add (n : ℕ) (a : R) : ⌊↑n + a⌋ = n + ⌊a⌋ := by
   rw [← Int.cast_natCast, floor_intCast_add]
 
-@[simp]
+@[simp, push]
 theorem floor_ofNat_add (n : ℕ) [n.AtLeastTwo] (a : R) :
     ⌊ofNat(n) + a⌋ = ofNat(n) + ⌊a⌋ :=
   floor_natCast_add n a

--- a/Mathlib/Algebra/Order/Floor/Semiring.lean
+++ b/Mathlib/Algebra/Order/Floor/Semiring.lean
@@ -292,6 +292,7 @@ theorem preimage_Iic {a : R} (ha : 0 ≤ a) : (Nat.cast : ℕ → R) ⁻¹' Set.
   ext
   simp [le_floor_iff, ha]
 
+@[push]
 theorem floor_add_natCast [IsStrictOrderedRing R] (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊ + n :=
   eq_of_forall_le_iff fun b => by
     rw [le_floor_iff (add_nonneg ha n.cast_nonneg)]
@@ -306,9 +307,11 @@ theorem floor_add_natCast [IsStrictOrderedRing R] (ha : 0 ≤ a) (n : ℕ) : ⌊
 
 variable [IsStrictOrderedRing R]
 
+@[push]
 theorem floor_add_one (ha : 0 ≤ a) : ⌊a + 1⌋₊ = ⌊a⌋₊ + 1 := by
   rw [← cast_one, floor_add_natCast ha 1]
 
+@[push]
 theorem floor_add_ofNat (ha : 0 ≤ a) (n : ℕ) [n.AtLeastTwo] :
     ⌊a + ofNat(n)⌋₊ = ⌊a⌋₊ + ofNat(n) :=
   floor_add_natCast ha n

--- a/MathlibTest/push.lean
+++ b/MathlibTest/push.lean
@@ -148,3 +148,39 @@ example (a b c : α) (s : Set α) : a ∈ (∅ ∪ (Set.univ ∩ (({b, c} \ sᶜ
   exact test_sorry
 
 end membership
+
+section floor
+
+example (a : ℤ) (n : ℕ) : ⌊a + n⌋ = ⌊a⌋ + n := by
+  push Int.floor
+  rfl
+
+example (a : ℤ) : ⌊a + 3⌋ = ⌊a⌋ + 3 := by
+  push Int.floor
+  rfl
+
+example (a : ℤ) : ⌊a + 2⌋ = ⌊a⌋ + 2 := by
+  push Int.floor
+  rfl
+
+example (a : ℤ) : ⌊a + 1⌋ = ⌊a⌋ + 1 := by
+  push Int.floor
+  rfl
+
+example (a : ℤ) (ha : 0 ≤ a) (n : ℕ) : ⌊a + n⌋₊ = ⌊a⌋₊ + n := by
+  push (disch := positivity) Nat.floor
+  rfl
+
+example (a : ℤ) (ha : 0 ≤ a) : ⌊a + 3⌋₊ = ⌊a⌋₊ + 3 := by
+  push (disch := positivity) Nat.floor
+  rfl
+
+example (a : ℤ) (ha : 0 ≤ a) : ⌊a + 2⌋₊ = ⌊a⌋₊ + 2 := by
+  push (disch := positivity) Nat.floor
+  rfl
+
+example (a : ℤ) (ha : 0 ≤ a) : ⌊a + 1⌋₊ = ⌊a⌋₊ + 1 := by
+  push (disch := positivity) Nat.floor
+  rfl
+
+end floor


### PR DESCRIPTION
Tag lemmas that allow pushing `Int.floor` / `Nat.floor` through addition

I tagged everything matching [Int.floor (_ + _) = _ + _](https://loogle.lean-lang.org/?q=Int.floor+%28_+%2B+_%29+%3D+_+%2B+_) and [Nat.floor (_ + _) = _ + _](https://loogle.lean-lang.org/?q=Nat.floor+%28_+%2B+_%29+%3D+_+%2B+_)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
