### PR TITLE
feat(Combinatorics/Graph): supremum

### DIFF
--- a/Mathlib/Combinatorics/Graph/Lattice.lean
+++ b/Mathlib/Combinatorics/Graph/Lattice.lean
@@ -15,12 +15,18 @@ This file defines the lattice-like structures on graphs.
 ## Main results
 
 - `SemilatticeInf (Graph α β)`
+- `Max (Graph α β)`
+- `compatible_iff_le_le`
 
 ## Implementation notes
 
 Intersections are defined here as the maximal mutual subgraph of the given graphs.
 This has the effect of, when taking the intersection of non-compatible graphs,
 **any non-compatible edges are removed**.
+
+Union is defined here as left-preferred, meaning that any non-compatible edges
+**follow the incidence in the left graph**. The union of non-compatible graphs unfortuantely does
+not form a semilattice. The left-preference retains associativity at the cost of commutativity.
 
 ## TODO
 
@@ -33,7 +39,7 @@ public section
 
 open Function Set
 
-variable {α β : Type*} {x y : α} {e : β} {G H : Graph α β}
+variable {α β : Type*} {x y : α} {e : β} {G G' H : Graph α β}
 
 namespace Graph
 
@@ -88,5 +94,84 @@ protected lemma disjoint_iff : Disjoint G H ↔ Disjoint V(G) V(H) := by
 protected lemma Compatible.edgeSet_inf (h : G.Compatible H) : E(G ⊓ H) = E(G) ∩ E(H) := by
   rw [G.edgeSet_inf]
   exact le_antisymm (fun e he ↦ he.1) fun e he ↦ ⟨he, fun _ _ ↦ h.isLink_congr he.1 he.2⟩
+
+lemma inf_isInducedSubgraph (h : G ≤i H) (h' : G' ≤i H) : G ⊓ G' ≤i H where
+  le := inf_le_left.trans <| show G ≤ H by exact h.le
+  isLink_of_mem_mem _ _ _ hxy hx hy := by
+    simp [h.isLink_of_mem_mem hxy hx.1 hy.1, h'.isLink_of_mem_mem hxy hx.2 hy.2]
+
+lemma inf_isSpanningSubgraph (h : G ≤s H) (h' : G' ≤s H) : G ⊓ G' ≤s H where
+  le := inf_le_left.trans <| show G ≤ H by exact h.le
+  vertexSet_eq := by simp [h.vertexSet_eq, h'.vertexSet_eq]
+
+lemma inf_isClosedSubgraph (h : G ≤c H) (h' : G' ≤c H) : G ⊓ G' ≤c H where
+  isInducedSubgraph := inf_isInducedSubgraph h.isInducedSubgraph h'.isInducedSubgraph
+  closed _ _ he hx := by
+    simp [h.closed he hx.1, h'.closed he hx.2, Compatible.of_le_le h.le h'.le |>.edgeSet_inf]
+
+/-- Left-preferred sup of two graphs `G` and `H`. For any incompatible edges, incidence in the
+left graph is used in the sup. Due to incompatibility, this does not form a semilattice.
+Left-preference retains associativity at the cost of commutativity. -/
+instance : Max (Graph α β) where
+  max G H := {
+    vertexSet := V(G) ∪ V(H)
+    edgeSet := E(G) ∪ E(H)
+    IsLink e x y := G.IsLink e x y ∨ e ∉ E(G) ∧ H.IsLink e x y
+    isLink_symm _ _ _ _ h := by grind [G.isLink_comm, H.isLink_comm]
+    eq_or_eq_of_isLink_of_isLink e _ _ _ _ h h' := by
+      by_cases he : e ∈ E(G) <;> grind [eq_or_eq_of_isLink_of_isLink, IsLink.edge_mem]
+    edge_mem_iff_exists_isLink e := by
+      refine ⟨fun h ↦ ?_, fun ⟨x, y, he⟩ ↦ by grind [IsLink.edge_mem]⟩
+      by_cases he : e ∈ E(G) <;> [obtain ⟨x, y, he⟩ := exists_isLink_of_mem_edgeSet he;
+        obtain ⟨x, y, he⟩ := exists_isLink_of_mem_edgeSet <| h.resolve_left he] <;> grind}
+
+@[simp, grind =]
+lemma sup_vertexSet (G H : Graph α β) : V(G ⊔ H) = V(G) ∪ V(H) := rfl
+
+@[simp, grind =]
+lemma sup_edgeSet (G H : Graph α β) : E(G ⊔ H) = E(G) ∪ E(H) := rfl
+
+@[grind =]
+lemma sup_isLink : (G ⊔ H).IsLink e x y ↔ G.IsLink e x y ∨ (e ∉ E(G) ∧ H.IsLink e x y) := Iff.rfl
+
+@[simp] protected lemma left_le_sup (G H : Graph α β) : G ≤ G ⊔ H := by constructor <;> grind
+
+protected lemma sup_le (h : G ≤ H) (h' : G' ≤ H) : G ⊔ G' ≤ H where
+  vertexSet_mono := by grind [h.vertexSet_mono, h'.vertexSet_mono]
+  isLink_mono := by grind [h.isLink_mono, h'.isLink_mono]
+
+@[simp]
+protected lemma sup_self (G : Graph α β) : G ⊔ G = G :=
+  (Graph.sup_le le_rfl le_rfl).antisymm <| Graph.left_le_sup ..
+
+protected lemma sup_assoc (G₁ G₂ G₃ : Graph α β) : (G₁ ⊔ G₂) ⊔ G₃ = G₁ ⊔ (G₂ ⊔ G₃) := by
+  refine Graph.ext (Set.union_assoc ..) fun e x y ↦ ?_
+  simp [sup_isLink]
+  tauto
+
+instance : Std.Associative (α := Graph α β) (· ⊔ ·) where
+  assoc := Graph.sup_assoc
+
+lemma Compatible.sup_isLink (h : G.Compatible H) :
+    (G ⊔ H).IsLink e x y ↔ G.IsLink e x y ∨ H.IsLink e x y := by
+  by_cases heG : e ∈ E(G)
+  · simp only [Graph.sup_isLink, heG, not_true_eq_false, false_and, or_false, iff_self_or]
+    exact fun he ↦ by rwa [h.isLink_congr heG he.edge_mem]
+  simp [heG, Graph.sup_isLink]
+
+lemma Compatible.sup_comm (h : Compatible G H) : G ⊔ H = H ⊔ G :=
+  Graph.ext (Set.union_comm ..) fun _ _ _ ↦ by rw [h.sup_isLink, h.symm.sup_isLink, or_comm]
+
+lemma Compatible.right_le_sup (h : G.Compatible H) : H ≤ G ⊔ H := by
+  simp [h.sup_comm]
+
+lemma Compatible.sup_le_iff (hc : G.Compatible G') : G ⊔ G' ≤ H ↔ G ≤ H ∧ G' ≤ H :=
+  ⟨fun h ↦ ⟨G.left_le_sup _ |>.trans h, hc.right_le_sup.trans h⟩, fun ⟨hG, hG'⟩ ↦ G.sup_le hG hG'⟩
+
+/-- Two graphs are compatible if and only if they have a common supergraph. This shows that
+  arbitrary unions of graphs are well-behaved under `BddAbove`. -/
+lemma compatible_iff_le_le : G.Compatible G' ↔ ∃ H, G ≤ H ∧ G' ≤ H :=
+  ⟨fun h ↦ ⟨G ⊔ G', G.left_le_sup _, h.right_le_sup⟩,
+    fun ⟨_, hG, hG'⟩ ↦ Compatible.of_le_le hG hG'⟩
 
 end Graph


### PR DESCRIPTION
This PR introduces the union of `Graph`, as `sup`. 

Due to compatibility issue, in general, `sup` is not very well-behaved: `SemilatticeSup` is not true. In the case of incompatible edge, unlike `inf` which simply removed such edge, we include it following its incidence in the left graph. This has the benefit of associativity being true in general at the cost of commutativity. 

Assuming compatibility or existence of mutual supergraph, which are shown to be equivalent in this PR, everything behaves nicely.

Co-authored-by: Peter Nelson <apn.uni@gmail.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
