### PR TITLE
[Merged by Bors] - refactor(Algebra/Category/ModuleCat/Sheaf/Free): generalize `SheafOfModules.mapFree`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -177,29 +177,34 @@ variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S
   [HasSheafify J' AddCommGrpCat.{u}] [J'.WEqualsLocallyBijective AddCommGrpCat.{u}]
   [J'.HasSheafCompose (forget₂ RingCat.{u} AddCommGrpCat.{u})]
   (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S)
-  (η : F.obj (unit R) ≅ unit S) (I : Type u) (i : I)
-  [PreservesColimitsOfShape (Discrete I) F]
+  (I : Type u) [PreservesColimitsOfShape (Discrete I) F]
+
+noncomputable def mapFree (η : F.obj (unit R) ⟶ unit S) : F.obj (free I) ⟶ free (R := S) I :=
+  (isColimitOfPreserves F (isColimitFreeCofan I)).map (freeCofan I) (Discrete.natTrans fun _ ↦ η)
+
+@[reassoc (attr := simp)]
+lemma map_ιFree_mapFree (η : F.obj (unit R) ⟶ unit S) (i : I) :
+    F.map (ιFree i) ≫ mapFree F I η = η ≫ ιFree i :=
+  IsColimit.ι_map (isColimitOfPreserves F (isColimitFreeCofan I)) (freeCofan I)
+    (Discrete.natTrans fun _ ↦ η) (Discrete.mk i)
+
+@[deprecated (since := "2026-04-21")] alias map_ιFree_mapFree_hom := map_ιFree_mapFree
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
 If `F` preserves coproducts and `F.obj (unit R) ≅ unit S`, then `F` preserves free sheaves of
 modules. -/
-noncomputable def mapFree : F.obj (free I) ≅ free (R := S) I :=
-  (isColimitOfPreserves F (isColimitFreeCofan I)).coconePointsIsoOfEquivalence
-    (isColimitFreeCofan I) CategoryTheory.Equivalence.refl (Discrete.natIso fun _ ↦ η).symm
+noncomputable def mapFreeIso (η : F.obj (unit R) ≅ unit S) : F.obj (free I) ≅ free (R := S) I :=
+  (isColimitOfPreserves F (isColimitFreeCofan I)).coconePointsIsoOfNatIso
+    (isColimitFreeCofan I) (Discrete.natIso fun _ ↦ η)
 
-set_option backward.isDefEq.respectTransparency false in
-@[reassoc (attr := simp)]
-lemma ιFree_mapFree_inv :
-    ιFree i ≫ (mapFree F η I).inv = η.inv ≫ F.map (ιFree i) := by
-  simp [mapFree, ← freeCofan_inj, Cofan.inj]
+lemma mapFreeIso_hom (η : F.obj (unit R) ≅ unit S) :
+    (mapFreeIso F I η).hom = mapFree F I η.hom := rfl
 
 @[reassoc (attr := simp)]
-lemma map_ιFree_mapFree_hom :
-    F.map (ιFree i) ≫ (mapFree F η I).hom = η.hom ≫ ιFree i := by
-  have : η.inv ≫ η.hom ≫ ιFree i = (η.inv ≫ F.map (ιFree i)) ≫ (mapFree F η I).hom := by
-    simp [← ιFree_mapFree_inv]
-  rw [← Iso.hom_inv_id_assoc η (η.hom ≫ ιFree i)]
-  simp [this]
+lemma ιFree_mapFreeIso_inv (η : F.obj (unit R) ≅ unit S) (i : I) :
+    ιFree i ≫ (mapFreeIso F I η).inv = η.inv ≫ F.map (ιFree i) :=
+  IsColimit.ι_map (isColimitFreeCofan I) (F.mapCocone (freeCofan I))
+    (Discrete.natTrans fun _ ↦ η.inv) (Discrete.mk i)
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -190,8 +190,6 @@ lemma ιFree_mapFree (η : unit S ⟶ F.obj (unit R)) (i : I) :
   IsColimit.ι_map (isColimitFreeCofan I) (F.mapCocone (freeCofan I))
     (Discrete.natTrans fun _ ↦ η) (Discrete.mk i)
 
-@[deprecated (since := "2026-04-21")] alias ιFree_mapFree_inv := ιFree_mapFree
-
 variable [PreservesColimitsOfShape (Discrete I) F]
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
@@ -203,6 +201,13 @@ noncomputable def mapFreeIso (η : unit S ≅ F.obj (unit R)) : free (R := S) I 
 
 lemma mapFreeIso_hom (η : unit S ≅ F.obj (unit R)) :
     (mapFreeIso F I η).hom = mapFree F I η.hom := rfl
+
+@[reassoc (attr := simp)]
+lemma ιFree_mapFreeIso_hom (η : unit S ≅ F.obj (unit R)) (i : I) :
+    ιFree i ≫ (mapFreeIso F I η).hom = η.hom ≫ F.map (ιFree i) :=
+  ιFree_mapFree _ _ _ _
+
+@[deprecated (since := "2026-04-21")] alias ιFree_mapFree_inv := ιFree_mapFreeIso_hom
 
 @[reassoc (attr := simp)]
 lemma map_ιFree_mapFreeIso_inv (η : unit S ≅ F.obj (unit R)) (i : I) :

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -179,8 +179,8 @@ variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S
   (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S) (I : Type u)
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
-Then a morphism `η : F.obj (unit R) ⟶ unit S` induces a morphism from `F.obj (free I)` to
-`free (R := S) I`. This is the non-iso version of `mapIsoFree`. -/
+Then a morphism `η : unit S ⟶ F.obj (unit R)` induces a morphism from `free (R := S) I` to
+`F.obj (free I)`. See also `mapIsoFree` for the iso version. -/
 noncomputable def mapFree (η : unit S ⟶ F.obj (unit R)) : free (R := S) I ⟶ F.obj (free I) :=
   (isColimitFreeCofan I).map (F.mapCocone (freeCofan I)) (Discrete.natTrans fun _ ↦ η)
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -180,7 +180,7 @@ variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
 Then a morphism `η : unit S ⟶ F.obj (unit R)` induces a morphism from `free (R := S) I` to
-`F.obj (free I)`. See also `mapIsoFree` for the iso version. -/
+`F.obj (free I)`. See also `mapFreeIso` for the iso version. -/
 noncomputable def mapFree (η : unit S ⟶ F.obj (unit R)) : free (R := S) I ⟶ F.obj (free I) :=
   (isColimitFreeCofan I).map (F.mapCocone (freeCofan I)) (Discrete.natTrans fun _ ↦ η)
 
@@ -197,20 +197,20 @@ variable [PreservesColimitsOfShape (Discrete I) F]
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
 If `F` preserves coproducts and `unit S ≅ F.obj (unit R)`, then `F` preserves free sheaves of
 modules. -/
-noncomputable def mapIsoFree (η : unit S ≅ F.obj (unit R)) : free (R := S) I ≅ F.obj (free I) :=
+noncomputable def mapFreeIso (η : unit S ≅ F.obj (unit R)) : free (R := S) I ≅ F.obj (free I) :=
   (isColimitFreeCofan I).coconePointsIsoOfNatIso (isColimitOfPreserves F (isColimitFreeCofan I))
     (Discrete.natIso fun _ ↦ η)
 
-lemma mapIsoFree_hom (η : unit S ≅ F.obj (unit R)) :
-    (mapIsoFree F I η).hom = mapFree F I η.hom := rfl
+lemma mapFreeIso_hom (η : unit S ≅ F.obj (unit R)) :
+    (mapFreeIso F I η).hom = mapFree F I η.hom := rfl
 
 @[reassoc (attr := simp)]
-lemma map_ιFree_mapIsoFree_inv (η : unit S ≅ F.obj (unit R)) (i : I) :
-    F.map (ιFree i) ≫ (mapIsoFree F I η).inv = η.inv ≫ ιFree i :=
+lemma map_ιFree_mapFreeIso_inv (η : unit S ≅ F.obj (unit R)) (i : I) :
+    F.map (ιFree i) ≫ (mapFreeIso F I η).inv = η.inv ≫ ιFree i :=
   IsColimit.ι_map (isColimitOfPreserves F (isColimitFreeCofan I)) (freeCofan I)
     (Discrete.natTrans fun _ ↦ η.inv) (Discrete.mk i)
 
-@[deprecated (since := "2026-04-21")] alias map_ιFree_mapFree_hom := map_ιFree_mapIsoFree_inv
+@[deprecated (since := "2026-04-21")] alias map_ιFree_mapFree_hom := map_ιFree_mapFreeIso_inv
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -179,6 +179,9 @@ variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S
   (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S)
   (I : Type u) [PreservesColimitsOfShape (Discrete I) F]
 
+/-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
+If `F` preserves coproducts, a morphism `η : F.obj (unit R) ⟶ unit S` induces a morphism
+from `F.obj (free I)` to `free (R := S) I`. This is the non-iso version of `mapFreeIso`. -/
 noncomputable def mapFree (η : F.obj (unit R) ⟶ unit S) : F.obj (free I) ⟶ free (R := S) I :=
   (isColimitOfPreserves F (isColimitFreeCofan I)).map (freeCofan I) (Discrete.natTrans fun _ ↦ η)
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -206,6 +206,8 @@ lemma ιFree_mapFreeIso_inv (η : F.obj (unit R) ≅ unit S) (i : I) :
   IsColimit.ι_map (isColimitFreeCofan I) (F.mapCocone (freeCofan I))
     (Discrete.natTrans fun _ ↦ η.inv) (Discrete.mk i)
 
+@[deprecated (since := "2026-04-21")] alias ιFree_mapFree_inv := ιFree_mapFreeIso_inv
+
 end
 
 end SheafOfModules

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -176,40 +176,41 @@ section
 variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S : Sheaf J' RingCat.{u}}
   [HasSheafify J' AddCommGrpCat.{u}] [J'.WEqualsLocallyBijective AddCommGrpCat.{u}]
   [J'.HasSheafCompose (forget₂ RingCat.{u} AddCommGrpCat.{u})]
-  (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S)
-  (I : Type u) [PreservesColimitsOfShape (Discrete I) F]
+  (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S) (I : Type u)
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
-If `F` preserves coproducts, a morphism `η : F.obj (unit R) ⟶ unit S` induces a morphism
-from `F.obj (free I)` to `free (R := S) I`. This is the non-iso version of `mapFreeIso`. -/
-noncomputable def mapFree (η : F.obj (unit R) ⟶ unit S) : F.obj (free I) ⟶ free (R := S) I :=
-  (isColimitOfPreserves F (isColimitFreeCofan I)).map (freeCofan I) (Discrete.natTrans fun _ ↦ η)
+Then a morphism `η : F.obj (unit R) ⟶ unit S` induces a morphism from `F.obj (free I)` to
+`free (R := S) I`. This is the non-iso version of `mapIsoFree`. -/
+noncomputable def mapFree (η : unit S ⟶ F.obj (unit R)) : free (R := S) I ⟶ F.obj (free I) :=
+  (isColimitFreeCofan I).map (F.mapCocone (freeCofan I)) (Discrete.natTrans fun _ ↦ η)
 
 @[reassoc (attr := simp)]
-lemma map_ιFree_mapFree (η : F.obj (unit R) ⟶ unit S) (i : I) :
-    F.map (ιFree i) ≫ mapFree F I η = η ≫ ιFree i :=
-  IsColimit.ι_map (isColimitOfPreserves F (isColimitFreeCofan I)) (freeCofan I)
+lemma ιFree_mapFree (η : unit S ⟶ F.obj (unit R)) (i : I) :
+    ιFree i ≫ mapFree F I η = η ≫ F.map (ιFree i) :=
+  IsColimit.ι_map (isColimitFreeCofan I) (F.mapCocone (freeCofan I))
     (Discrete.natTrans fun _ ↦ η) (Discrete.mk i)
 
-@[deprecated (since := "2026-04-21")] alias map_ιFree_mapFree_hom := map_ιFree_mapFree
+@[deprecated (since := "2026-04-21")] alias ιFree_mapFree_inv := ιFree_mapFree
+
+variable [PreservesColimitsOfShape (Discrete I) F]
 
 /-- Let `F` be a functor from the category of sheaves of `R`-modules to sheaves of `S`-modules.
-If `F` preserves coproducts and `F.obj (unit R) ≅ unit S`, then `F` preserves free sheaves of
+If `F` preserves coproducts and `unit S ≅ F.obj (unit R)`, then `F` preserves free sheaves of
 modules. -/
-noncomputable def mapFreeIso (η : F.obj (unit R) ≅ unit S) : F.obj (free I) ≅ free (R := S) I :=
-  (isColimitOfPreserves F (isColimitFreeCofan I)).coconePointsIsoOfNatIso
-    (isColimitFreeCofan I) (Discrete.natIso fun _ ↦ η)
+noncomputable def mapIsoFree (η : unit S ≅ F.obj (unit R)) : free (R := S) I ≅ F.obj (free I) :=
+  (isColimitFreeCofan I).coconePointsIsoOfNatIso (isColimitOfPreserves F (isColimitFreeCofan I))
+    (Discrete.natIso fun _ ↦ η)
 
-lemma mapFreeIso_hom (η : F.obj (unit R) ≅ unit S) :
-    (mapFreeIso F I η).hom = mapFree F I η.hom := rfl
+lemma mapIsoFree_hom (η : unit S ≅ F.obj (unit R)) :
+    (mapIsoFree F I η).hom = mapFree F I η.hom := rfl
 
 @[reassoc (attr := simp)]
-lemma ιFree_mapFreeIso_inv (η : F.obj (unit R) ≅ unit S) (i : I) :
-    ιFree i ≫ (mapFreeIso F I η).inv = η.inv ≫ F.map (ιFree i) :=
-  IsColimit.ι_map (isColimitFreeCofan I) (F.mapCocone (freeCofan I))
+lemma map_ιFree_mapIsoFree_inv (η : unit S ≅ F.obj (unit R)) (i : I) :
+    F.map (ιFree i) ≫ (mapIsoFree F I η).inv = η.inv ≫ ιFree i :=
+  IsColimit.ι_map (isColimitOfPreserves F (isColimitFreeCofan I)) (freeCofan I)
     (Discrete.natTrans fun _ ↦ η.inv) (Discrete.mk i)
 
-@[deprecated (since := "2026-04-21")] alias ιFree_mapFree_inv := ιFree_mapFreeIso_inv
+@[deprecated (since := "2026-04-21")] alias map_ιFree_mapFree_hom := map_ιFree_mapIsoFree_inv
 
 end
 

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
@@ -157,14 +157,14 @@ local instance : PreservesColimitsOfSize.{0, 0} F := preservesColimitsOfSize_shr
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 relations of `Presentation (F.obj M)`. -/
 def Presentation.mapRelations : free P.relations.I (R := S) ⟶ free P.generators.I :=
-  (mapIsoFree F P.relations.I η).hom ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
-    F.map (kernel.ι _) ≫ (mapIsoFree F P.generators.I η).inv
+  (mapFreeIso F P.relations.I η).hom ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
+    F.map (kernel.ι _) ≫ (mapFreeIso F P.generators.I η).inv
 
 /-- Let `F` be a functor from sheaf of `R`-module to sheaf of `S`-module, if `F` preserves
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 generators of `Presentation (F.obj M)`. -/
 def Presentation.mapGenerators : free P.generators.I ⟶ F.obj M :=
-  (mapIsoFree F P.generators.I η).hom ≫ F.map (P.generators.π)
+  (mapFreeIso F P.generators.I η).hom ≫ F.map (P.generators.π)
 
 @[reassoc (attr := simp)]
 theorem Presentation.mapRelations_mapGenerators :
@@ -180,13 +180,13 @@ def Presentation.map : Presentation (F.obj M) :=
   presentationOfIsCokernelFree (P.mapRelations F η) (P.mapGenerators F η)
     (P.mapRelations_mapGenerators F η) <| by
     refine IsColimit.equivOfNatIsoOfIso
-      (parallelPairIsoMk (mapIsoFree F _ η).symm (mapIsoFree F _ η).symm
+      (parallelPairIsoMk (mapFreeIso F _ η).symm (mapFreeIso F _ η).symm
         (by simp [Presentation.mapRelations]) (by simp)) _ _ ?_ (isColimitOfPreserves F P.isColimit)
     exact (Cocone.ext (Iso.refl _) <| by rintro (_ | _)
       <;> simp [Presentation.mapRelations, Presentation.mapGenerators, ← Functor.map_comp])
 
 theorem Presentation.map_π_eq :
-    (P.map F η).generators.π = (mapIsoFree F _ η).hom ≫ F.map (P.generators.π) :=
+    (P.map F η).generators.π = (mapFreeIso F _ η).hom ≫ F.map (P.generators.π) :=
   (F.obj M).freeHomEquiv.symm_apply_eq.mpr rfl
 
 end

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
@@ -95,8 +95,8 @@ def relationsOfIsCokernelFree {M : SheafOfModules.{u} R}
     (H' : IsColimit (CokernelCofork.ofπ g H)) :
     (kernel (generatorsOfIsCokernelFree f g H H').π).GeneratingSections where
   I := ι
-  s := (kernel (generatorsOfIsCokernelFree f g H H').π).freeHomEquiv <| kernel.lift
-    (generatorsOfIsCokernelFree f g H H').π f (by simp [H])
+  s := (kernel (generatorsOfIsCokernelFree f g H H').π).freeHomEquiv <|
+    kernel.lift (generatorsOfIsCokernelFree f g H H').π f (by simp [H])
   epi := by
     let h : cokernel f ≅ M := (H'.coconePointUniqueUpToIso (colimit.isColimit _)).symm
     let h' : Abelian.image f ≅ kernel (generatorsOfIsCokernelFree f g H H').π :=
@@ -147,7 +147,7 @@ variable {C' : Type u₂} [Category.{v₂} C'] {J' : GrothendieckTopology C'} {S
 
 variable {M : SheafOfModules.{u} R} (P : Presentation M)
   (F : SheafOfModules.{u} R ⥤ SheafOfModules.{u} S) [PreservesColimitsOfSize.{u, u} F]
-  (η : F.obj (unit R) ≅ unit S)
+  (η : unit S ≅ F.obj (unit R))
 
 -- `preservesColimitsOfSize_shrink` is not a global instance because it loops indefinitely.
 -- But here it is fine as an instance since the universe `u` is inferrable from the type of `F`.
@@ -157,19 +157,19 @@ local instance : PreservesColimitsOfSize.{0, 0} F := preservesColimitsOfSize_shr
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 relations of `Presentation (F.obj M)`. -/
 def Presentation.mapRelations : free P.relations.I (R := S) ⟶ free P.generators.I :=
-  (mapFreeIso F P.relations.I η).inv ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
-    F.map (kernel.ι _) ≫ (mapFreeIso F P.generators.I η).hom
+  (mapIsoFree F P.relations.I η).hom ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
+    F.map (kernel.ι _) ≫ (mapIsoFree F P.generators.I η).inv
 
 /-- Let `F` be a functor from sheaf of `R`-module to sheaf of `S`-module, if `F` preserves
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 generators of `Presentation (F.obj M)`. -/
 def Presentation.mapGenerators : free P.generators.I ⟶ F.obj M :=
-  (mapFreeIso F P.generators.I η).inv ≫ F.map (P.generators.π)
+  (mapIsoFree F P.generators.I η).hom ≫ F.map (P.generators.π)
 
 @[reassoc (attr := simp)]
 theorem Presentation.mapRelations_mapGenerators :
     P.mapRelations F η ≫ P.mapGenerators F η = 0 := by
-  simp only [mapRelations, mapGenerators, Category.assoc, Iso.hom_inv_id_assoc,
+  simp only [mapRelations, mapGenerators, Category.assoc, Iso.inv_hom_id_assoc,
     ← Functor.map_comp, kernel.condition, Functor.map_zero, comp_zero]
 
 /-- Let `F` be a functor from sheaf of `R`-module to sheaf of `S`-module, if `F` preserves
@@ -179,13 +179,14 @@ colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we 
 def Presentation.map : Presentation (F.obj M) :=
   presentationOfIsCokernelFree (P.mapRelations F η) (P.mapGenerators F η)
     (P.mapRelations_mapGenerators F η) <| by
-    refine IsColimit.equivOfNatIsoOfIso (parallelPairIsoMk (mapFreeIso F _ η) (mapFreeIso F _ η)
-      (by simp [Presentation.mapRelations]) (by simp)) _ _ ?_ (isColimitOfPreserves F P.isColimit)
+    refine IsColimit.equivOfNatIsoOfIso
+      (parallelPairIsoMk (mapIsoFree F _ η).symm (mapIsoFree F _ η).symm
+        (by simp [Presentation.mapRelations]) (by simp)) _ _ ?_ (isColimitOfPreserves F P.isColimit)
     exact (Cocone.ext (Iso.refl _) <| by rintro (_ | _)
       <;> simp [Presentation.mapRelations, Presentation.mapGenerators, ← Functor.map_comp])
 
 theorem Presentation.map_π_eq :
-    (P.map F η).generators.π = (mapFreeIso F _ η).inv ≫ F.map (P.generators.π) :=
+    (P.map F η).generators.π = (mapIsoFree F _ η).hom ≫ F.map (P.generators.π) :=
   (F.obj M).freeHomEquiv.symm_apply_eq.mpr rfl
 
 end

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
@@ -157,14 +157,14 @@ local instance : PreservesColimitsOfSize.{0, 0} F := preservesColimitsOfSize_shr
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 relations of `Presentation (F.obj M)`. -/
 def Presentation.mapRelations : free P.relations.I (R := S) ⟶ free P.generators.I :=
-  (mapFree F η P.relations.I).inv ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
-    F.map (kernel.ι _) ≫ (mapFree F η P.generators.I).hom
+  (mapFreeIso F P.relations.I η).inv ≫ F.map ((freeHomEquiv _).symm P.relations.s) ≫
+    F.map (kernel.ι _) ≫ (mapFreeIso F P.generators.I η).hom
 
 /-- Let `F` be a functor from sheaf of `R`-module to sheaf of `S`-module, if `F` preserves
 colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we will obtain
 generators of `Presentation (F.obj M)`. -/
 def Presentation.mapGenerators : free P.generators.I ⟶ F.obj M :=
-  (mapFree F η P.generators.I).inv ≫ F.map (P.generators.π)
+  (mapFreeIso F P.generators.I η).inv ≫ F.map (P.generators.π)
 
 @[reassoc (attr := simp)]
 theorem Presentation.mapRelations_mapGenerators :
@@ -179,13 +179,13 @@ colimits and `F.obj (unit R) ≅ unit S`, given a `P : Presentation M`, then we 
 def Presentation.map : Presentation (F.obj M) :=
   presentationOfIsCokernelFree (P.mapRelations F η) (P.mapGenerators F η)
     (P.mapRelations_mapGenerators F η) <| by
-    refine IsColimit.equivOfNatIsoOfIso (parallelPairIsoMk (mapFree F η _) (mapFree F η _)
+    refine IsColimit.equivOfNatIsoOfIso (parallelPairIsoMk (mapFreeIso F _ η) (mapFreeIso F _ η)
       (by simp [Presentation.mapRelations]) (by simp)) _ _ ?_ (isColimitOfPreserves F P.isColimit)
     exact (Cocone.ext (Iso.refl _) <| by rintro (_ | _)
       <;> simp [Presentation.mapRelations, Presentation.mapGenerators, ← Functor.map_comp])
 
 theorem Presentation.map_π_eq :
-    (P.map F η).generators.π = (mapFree F η _).inv ≫ F.map (P.generators.π) :=
+    (P.map F η).generators.π = (mapFreeIso F _ η).inv ≫ F.map (P.generators.π) :=
   (F.obj M).freeHomEquiv.symm_apply_eq.mpr rfl
 
 end

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Quasicoherent.lean
@@ -95,8 +95,8 @@ def relationsOfIsCokernelFree {M : SheafOfModules.{u} R}
     (H' : IsColimit (CokernelCofork.ofπ g H)) :
     (kernel (generatorsOfIsCokernelFree f g H H').π).GeneratingSections where
   I := ι
-  s := (kernel (generatorsOfIsCokernelFree f g H H').π).freeHomEquiv <|
-    kernel.lift (generatorsOfIsCokernelFree f g H H').π f (by simp [H])
+  s := (kernel (generatorsOfIsCokernelFree f g H H').π).freeHomEquiv <| kernel.lift
+    (generatorsOfIsCokernelFree f g H H').π f (by simp [H])
   epi := by
     let h : cokernel f ≅ M := (H'.coconePointUniqueUpToIso (colimit.isColimit _)).symm
     let h' : Abelian.image f ≅ kernel (generatorsOfIsCokernelFree f g H H').π :=


### PR DESCRIPTION
- Generalize `mapFree` to take in a hom `η : unit S ⟶ F.obj (unit R)` instead of an iso `η : F.obj (unit R) ≅ unit S`. Note that this direction does not require `F` to preserve coproducts, only the inverse does.
- Rename what used to be `mapFree` to `mapFreeIso`
- Simplify the proofs of `ιFree_mapFree_inv` and `map_ιFree_mapFree_hom`, rename them, and create deprecated aliases for the old versions.

**Motivation for this change**:
I want to apply `mapFree` to the existing morphism `unitToPushforwardObjUnit : unit S ⟶ (pushforward.{u} φ).obj (unit R)`, which exactly fits the new type of `η`. Specializing to `φ = 𝟙 (R.over X)`, this will yield the iso `(free I).over X ≅ free (R := R.over X) I` in a later PR.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
