### PR TITLE
[Merged by Bors] - feat: missing lemmas for `ContT.run`

### DIFF
--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -62,7 +62,7 @@ export MonadCont (Label goto)
 
 variable {r : Type u} {m : Type u → Type v} {α β : Type w}
 
-/-- Built a `ContT` from a function taking a continuation callback. -/
+/-- Build a `ContT` from a function taking a continuation callback. -/
 def mk (f : (α → m r) → m r) : ContT r m α := f
 
 /-- Run a `ContT` with a provided callback. -/

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -28,8 +28,12 @@ universe u v w u₀ u₁ v₀ v₁
 structure MonadCont.Label (α : Type w) (m : Type u → Type v) (β : Type u) where
   apply : α → m β
 
-def MonadCont.goto {α β} {m : Type u → Type v} (f : MonadCont.Label α m β) (x : α) :=
+abbrev MonadCont.goto {α β} {m : Type u → Type v} (f : MonadCont.Label α m β) (x : α) :=
   f.apply x
+
+@[simp]
+theorem MonadCont.goto_mk {α β} {m : Type u → Type v} (f : α → m β) (a : α) :
+    goto ⟨f⟩ a = f a := rfl
 
 class MonadCont (m : Type u → Type v) where
   callCC : ∀ {α β}, (MonadCont.Label α m β → m α) → m α
@@ -128,7 +132,11 @@ theorem monadLift_bind [Monad m] [LawfulMonad m] {α β} (x : m α) (f : α → 
   simp only [bind_assoc, run_bind, run_monadLift, Function.comp_apply]
 
 instance : MonadCont (ContT r m) where
-  callCC f g := f ⟨fun x _ => g x⟩ g
+  callCC f := .mk fun k => f ⟨fun x => .mk fun _ => k x⟩ k
+
+@[simp]
+theorem run_callCC (f : Label α (ContT r m) β → ContT r m α) (k : α → m r) :
+    (callCC f).run k = (f ⟨fun x => .mk fun _ => k x⟩).run k := rfl
 
 instance : LawfulMonadCont (ContT r m) where
   callCC_bind_right := by intros; ext; rfl

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -31,10 +31,6 @@ structure MonadCont.Label (α : Type w) (m : Type u → Type v) (β : Type u) wh
 abbrev MonadCont.goto {α β} {m : Type u → Type v} (f : MonadCont.Label α m β) (x : α) :=
   f.apply x
 
-@[simp]
-theorem MonadCont.goto_mk {α β} {m : Type u → Type v} (f : α → m β) (a : α) :
-    goto ⟨f⟩ a = f a := rfl
-
 class MonadCont (m : Type u → Type v) where
   callCC : ∀ {α β}, (MonadCont.Label α m β → m α) → m α
 

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -58,8 +58,11 @@ export MonadCont (Label goto)
 
 variable {r : Type u} {m : Type u → Type v} {α β : Type w}
 
-def run : ContT r m α → (α → m r) → m r :=
-  id
+/-- Built a `ContT` from a function taking a continuation callback. -/
+def mk (f : (α → m r) → m r) : ContT r m α := f
+
+/-- Run a `ContT` with a provided callback. -/
+def run (x : ContT r m α) : (α → m r) → m r := x
 
 def map (f : m r → m r) (x : ContT r m α) : ContT r m α :=
   f ∘ x
@@ -82,8 +85,10 @@ instance : Monad (ContT r m) where
   bind x f g := x fun i => f i g
 
 @[simp]
-theorem run_pure (a : α) (k : α → m r) :
-    (pure a : ContT r m α).run k = k a := rfl
+theorem run_mk (f : (α → m r) → m r) (k : α → m r) : (.mk f : ContT r m α).run k = f k := rfl
+
+@[simp]
+theorem run_pure (a : α) (k : α → m r) : (pure a : ContT r m α).run k = k a := rfl
 
 @[simp]
 theorem run_bind (x : ContT r m α) (f : α → ContT r m β) (k : β → m r) :

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -115,16 +115,17 @@ instance : LawfulMonad (ContT r m) := LawfulMonad.mk'
   (pure_bind := by intros; ext; rfl)
   (bind_assoc := by intros; ext; rfl)
 
-def monadLift [Monad m] {α} : m α → ContT r m α := fun x f => x >>= f
-
 instance [Monad m] : MonadLift m (ContT r m) where
-  monadLift := ContT.monadLift
+  monadLift x := .mk fun k => x >>= k
+
+@[simp]
+theorem run_monadLift [Monad m] {α} (x : m α) (k : α → m r) :
+    (monadLift x : ContT r m α).run k = x >>= k := rfl
 
 theorem monadLift_bind [Monad m] [LawfulMonad m] {α β} (x : m α) (f : α → m β) :
     (monadLift (x >>= f) : ContT r m β) = monadLift x >>= monadLift ∘ f := by
   ext
-  simp only [monadLift, (· ∘ ·), (· >>= ·), bind_assoc, id, run,
-    ContT.monadLift]
+  simp only [bind_assoc, run_bind, run_monadLift, Function.comp_apply]
 
 instance : MonadCont (ContT r m) where
   callCC f g := f ⟨fun x _ => g x⟩ g
@@ -150,8 +151,8 @@ See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topi
 for further discussion.
 -/
 instance (ε) [MonadExceptOf ε m] : MonadExceptOf ε (ContT r m) where
-  throw e _ := throw e
-  tryCatch act h f := tryCatch (act.run f) fun e => (h e).run f
+  throw e := .mk fun _ => throw e
+  tryCatch act h := .mk fun k => tryCatch (act.run k) fun e => (h e).run k
 
 @[simp]
 theorem run_throw {ε} [MonadExceptOf ε m]

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -81,6 +81,30 @@ instance : Monad (ContT r m) where
   pure x f := f x
   bind x f g := x fun i => f i g
 
+@[simp]
+theorem run_pure (a : α) (k : α → m r) :
+    (pure a : ContT r m α).run k = k a := rfl
+
+@[simp]
+theorem run_bind (x : ContT r m α) (f : α → ContT r m β) (k : β → m r) :
+    (x >>= f).run k = x.run fun x => (f x).run k := rfl
+
+@[simp]
+theorem run_map (f : α → β) (x : ContT r m α) (k : β → m r) :
+    (f <$> x).run k = x.run (k ∘ f) := rfl
+
+@[simp]
+theorem run_seq (f : ContT r m (α → β)) (x : ContT r m α) (k : β → m r) :
+    (f <*> x).run k = f.run fun f => x.run (k ∘ f) := rfl
+
+@[simp]
+theorem run_seqLeft (x : ContT r m α) (y : ContT r m β) (k : α → m r) :
+    (x <* y).run k = x.run fun x => y.run fun _ => k x := rfl
+
+@[simp]
+theorem run_seqRight (x : ContT r m α) (y : ContT r m β) (k : β → m r) :
+    (x *> y).run k = x.run fun _ => y.run k := rfl
+
 instance : LawfulMonad (ContT r m) := LawfulMonad.mk'
   (id_map := by intros; rfl)
   (pure_bind := by intros; ext; rfl)


### PR DESCRIPTION
This PR also adds `ContT.mk (f : (α → m r) → m r) : ContT r m α := f` for explicitly constructing a `ContT` action from a function that requires a callback, which allows a `run_mk` lemmas to eliminate `ContT` entirely from certain terms.

This also makes `MonadCont.goto` an `abbrev`, to avoid needing a lemma about `MonadCont.goto (Label.mk goto) = goto`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
