### PR TITLE
[Merged by Bors] - chore: golf using `grind`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Decomp.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Decomp.lean
@@ -64,7 +64,7 @@ lemma takeUntil_eq_take (p : G.Walk u v) (h : w ∈ p.support) :
   | nil =>
     simp only [takeUntil, eq_mpr_eq_cast, support_nil, getVert_nil, take, support_copy]
     grind [mem_support_nil_iff, support_nil]
-  | @cons a _ _ _ p ih =>
+  | cons hadj p ih =>
     grind [takeUntil, support, copy_rfl_rfl, take_support_eq_support_take_succ]
 
 lemma length_takeUntil (p : G.Walk u v) (h : w ∈ p.support) :

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Decomp.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Decomp.lean
@@ -65,11 +65,7 @@ lemma takeUntil_eq_take (p : G.Walk u v) (h : w ∈ p.support) :
     simp only [takeUntil, eq_mpr_eq_cast, support_nil, getVert_nil, take, support_copy]
     grind [mem_support_nil_iff, support_nil]
   | @cons a _ _ _ p ih =>
-    by_cases! h' : w = a
-    · grind [List.idxOf_cons_self, take_zero, copy_rfl_rfl, support_nil, takeUntil_first]
-    · rw [take_cons_eq _ _ _ (by grind), takeUntil_cons (List.mem_of_ne_of_mem h' h) h'.symm,
-        support_cons, support_copy, ih (by grind)]
-      grind
+    grind [takeUntil, support, copy_rfl_rfl, take_support_eq_support_take_succ]
 
 lemma length_takeUntil (p : G.Walk u v) (h : w ∈ p.support) :
     (p.takeUntil w h).length = p.support.idxOf w := by


### PR DESCRIPTION
The goal of this PR is to decrease the number of times lemmas are called explicitly. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (differences <30 ms considered measurement noise):
* `✅️ SimpleGraph.Walk.takeUntil_eq_take`: 258 ms before, 206 ms after  🎉

Profiled using `set_option trace.profiler true in`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
