### PR TITLE
feat(Analysis/SpecialFunctions): add ExponentialEnvelope

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2276,6 +2276,7 @@ public import Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass
 public import Mathlib.Analysis.SpecialFunctions.Exp
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.Analysis.SpecialFunctions.Exponential
+public import Mathlib.Analysis.SpecialFunctions.ExponentialEnvelope
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
 public import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup

--- a/Mathlib/Analysis/SpecialFunctions/ExponentialEnvelope.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExponentialEnvelope.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 Lior Horesh. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lior Horesh
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Exp
+public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+
+/-!
+# Exponential envelope for `(1 − p)^k`
+
+This module records the clean primitive
+
+`(1 − p)^k ≤ exp(−p · k)`
+
+for `p ∈ [0, 1]` and `k ∈ ℕ`, together with its real-exponent variant
+`(1 − p)^x ≤ exp(−p · x)` for `x ≥ 0`.  It unifies a boilerplate three-
+line dance (`Real.one_sub_le_exp_neg` + `pow_le_pow_left₀` +
+`Real.exp_nat_mul`) that recurs throughout analysis and probability
+theory and is currently re-inlined at every call site.
+
+## Main results
+
+* `Real.one_sub_pow_le_exp_neg_mul` — natural-exponent envelope.
+* `Real.one_sub_rpow_le_exp_neg_mul` — real-exponent envelope (`rpow`).
+
+## Tags
+
+exponential envelope, one minus p, sub-exponential, concentration
+-/
+
+@[expose] public section
+
+namespace Real
+
+/-- **Exponential envelope — natural exponent.**  For `p ≤ 1` and
+`k : ℕ`, `(1 − p)^k ≤ exp(−p · k)`.
+
+Standard primitive used throughout concentration inequalities
+(Chernoff-bound derivation), depolarizing-channel contraction bounds,
+and random-circuit analysis.  The proof is the composition of
+`Real.one_sub_le_exp_neg` with `pow_le_pow_left₀` and
+`Real.exp_nat_mul`. -/
+theorem one_sub_pow_le_exp_neg_mul
+    {p : ℝ} (hp1 : p ≤ 1) (k : ℕ) :
+    (1 - p) ^ k ≤ Real.exp (-(p * k)) := by
+  have hp0 : 0 ≤ 1 - p := by linarith
+  have h1 : 1 - p ≤ Real.exp (-p) := Real.one_sub_le_exp_neg p
+  have h2 : (1 - p) ^ k ≤ (Real.exp (-p)) ^ k :=
+    pow_le_pow_left₀ hp0 h1 k
+  have h3 : (Real.exp (-p)) ^ k = Real.exp (-(p * k)) := by
+    rw [← Real.exp_nat_mul]
+    ring_nf
+  linarith
+
+/-- **Exponential envelope — real exponent via `rpow`.**  For
+`p ≤ 1` and `x ≥ 0`, `(1 − p)^x ≤ exp(−p · x)`.
+
+`rpow` is preferred over `^ : ℝ → ℝ → ℝ` on the `(1-p) = 0` corner.
+The proof reduces to `Real.rpow_le_rpow` on the base inequality
+`1 − p ≤ exp(−p)`, followed by `Real.exp_mul` on the right-hand side. -/
+theorem one_sub_rpow_le_exp_neg_mul
+    {p : ℝ} (hp1 : p ≤ 1) {x : ℝ} (hx : 0 ≤ x) :
+    (1 - p) ^ x ≤ Real.exp (-(p * x)) := by
+  have h_base_nn : 0 ≤ 1 - p := by linarith
+  have h_base_le : 1 - p ≤ Real.exp (-p) := Real.one_sub_le_exp_neg p
+  have h_mono : (1 - p) ^ x ≤ (Real.exp (-p)) ^ x :=
+    Real.rpow_le_rpow h_base_nn h_base_le hx
+  have h_exp_rpow :
+      (Real.exp (-p)) ^ x = Real.exp (-(p * x)) := by
+    rw [← Real.exp_mul]
+    ring_nf
+  linarith
+
+end Real


### PR DESCRIPTION
Adds two primitives packaging a three-line dance that recurs throughout Mathlib's analysis and probability files:

- `Real.one_sub_pow_le_exp_neg_mul` — natural-exponent envelope `(1 - p) ^ k ≤ exp (-(p * k))` for `p ≤ 1` and `k : ℕ`.
- `Real.one_sub_rpow_le_exp_neg_mul` — real-exponent (`rpow`) variant for `0 ≤ p ≤ 1` and `x ≥ 0`.

Each is the composition of `Real.one_sub_le_exp_neg` with `pow_le_pow_left₀` / `Real.rpow_le_rpow` and `Real.exp_nat_mul` / `Real.exp_mul`.  This idiom is used in Chernoff-bound derivations, depolarizing-channel contraction bounds, and random-circuit analysis; lifting it from inlined three-line proofs to named lemmas removes duplicate effort across downstream files.

Opened as draft so CI can run before pinging maintainers.

---

First-time Mathlib contribution — happy to adjust naming, file placement, or docstring style to match house conventions.