### PR TITLE
feat(Data/Nat/Cast/Order/Basic): introduce new class `IsMonotoneNatCast`

### DIFF
--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -167,8 +167,8 @@ theorem ofNat_lt :
 
 end Nat
 
-instance [AddMonoidWithOne α] [CharZero α] : Nontrivial α where exists_pair_ne :=
-  ⟨1, 0, (Nat.cast_one (R := α) ▸ Nat.cast_ne_zero.2 (by decide))⟩
+instance [AddMonoidWithOne α] [CharZero α] : Nontrivial α :=
+  NeZero.nontrivial (1 : α)
 
 section RingHomClass
 

--- a/Mathlib/Data/Nat/Cast/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Basic.lean
@@ -22,20 +22,25 @@ assert_not_exists IsOrderedMonoid
 
 variable {α : Type*}
 
+/-- A typeclass that asserts `Nat.cast : ℕ → α` is monotone. -/
+class IsMonotoneNatCast (α) [AddMonoidWithOne α] [Preorder α] where
+  natCast_mono : Monotone (Nat.cast : ℕ → α)
+
+instance [AddMonoidWithOne α] [Preorder α] [AddLeftMono α] [ZeroLEOneClass α] :
+    IsMonotoneNatCast α where
+  natCast_mono := monotone_nat_of_le_succ fun n ↦
+    Nat.cast_succ (R := α) n ▸ le_add_of_nonneg_right zero_le_one
+
+
 namespace Nat
 
-section OrderedSemiring
-/- Note: even though the section indicates `OrderedSemiring`, which is the common use case,
-we use a generic collection of instances so that it applies in other settings (e.g., in a
-`StarOrderedRing`, or the `selfAdjoint` or `StarOrderedRing.positive` parts thereof). -/
+section
 
-variable [AddMonoidWithOne α] [PartialOrder α]
-variable [AddLeftMono α] [ZeroLEOneClass α]
+variable [AddMonoidWithOne α] [Preorder α] [IsMonotoneNatCast α]
 
 @[gcongr, mono]
 theorem mono_cast : Monotone (Nat.cast : ℕ → α) :=
-  monotone_nat_of_le_succ fun n ↦ by
-    rw [Nat.cast_succ]; exact le_add_of_nonneg_right zero_le_one
+  IsMonotoneNatCast.natCast_mono
 
 /-- See also `Nat.cast_nonneg`, specialised for an `OrderedSemiring`. -/
 @[simp low]
@@ -46,20 +51,27 @@ theorem cast_nonneg' (n : ℕ) : 0 ≤ (n : α) :=
 @[simp low]
 theorem ofNat_nonneg' (n : ℕ) [n.AtLeastTwo] : 0 ≤ (ofNat(n) : α) := cast_nonneg' n
 
-section Nontrivial
+instance : ZeroLEOneClass α where
+  zero_le_one := by simpa only [cast_one] using cast_nonneg' 1
+
+end
+
+
+variable [AddMonoidWithOne α] [PartialOrder α] [IsMonotoneNatCast α]
+
+section
 
 variable [NeZero (1 : α)]
 
-theorem cast_add_one_pos (n : ℕ) : 0 < (n : α) + 1 := by
-  apply zero_lt_one.trans_le
-  convert (@mono_cast α _).imp (?_ : 1 ≤ n + 1)
-  <;> simp
+theorem cast_add_one_pos (n : ℕ) : 0 < (n : α) + 1 :=
+  zero_lt_one.trans_le (by simpa using mono_cast (le_add_left 1 n : 1 ≤ n + 1))
 
 /-- See also `Nat.cast_pos`, specialised for an `OrderedSemiring`. -/
 @[simp low]
 theorem cast_pos' {n : ℕ} : (0 : α) < n ↔ 0 < n := by cases n <;> simp [cast_add_one_pos]
 
-end Nontrivial
+end
+
 
 variable [CharZero α] {m n : ℕ}
 
@@ -152,8 +164,6 @@ theorem ofNat_le :
 theorem ofNat_lt :
     (ofNat(m) : α) < (ofNat(n) : α) ↔ (OfNat.ofNat m : ℕ) < OfNat.ofNat n :=
   cast_lt
-
-end OrderedSemiring
 
 end Nat
 


### PR DESCRIPTION
The class says that `Nat.cast` is monotone in an `AddMonoidWithOne`. Basically, we use this class when we only care about comparing the elements of a monoid that comes from the `Nat`s (so we do not have to care about the compatibility between the additive structure of the monoid and its order structure).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Other than that, I'm also reorganizing some section naming, and I change the proof of the `Nontrivial` instance at the bottom to using `NeZero.nontrivial`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
