### PR TITLE
[Merged by Bors] - feat(Order/Directed): `Directed` can be expressed using `IsDirected`

### DIFF
--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -42,12 +42,12 @@ variable {α : Type u} {β : Type v} {ι : Sort w} (r r' s : α → α → Prop)
 /-- Local notation for a relation -/
 local infixl:50 " ≼ " => r
 
-/-- A family of elements of α is directed (with respect to a relation `≼` on α)
+/-- A family of elements of `α` is directed (with respect to a relation `≼` on `α`)
   if there is a member of the family `≼`-above any pair in the family. -/
 def Directed (f : ι → α) :=
   ∀ x y, ∃ z, f x ≼ f z ∧ f y ≼ f z
 
-/-- A subset of α is directed if there is an element of the set `≼`-above any
+/-- A subset of `α` is directed if there is an element of the set `≼`-above any
   pair of elements in the set. -/
 def DirectedOn (s : Set α) :=
   ∀ x ∈ s, ∀ y ∈ s, ∃ z ∈ s, x ≼ z ∧ y ≼ z
@@ -134,7 +134,7 @@ theorem Std.Total.directedOn [Std.Total r] (s : Set α) : DirectedOn r s := fun 
 
 /-- `IsDirected α r` states that for any elements `a`, `b` there exists an element `c` such that
 `r a c` and `r b c`. -/
-class IsDirected (α : Type*) (r : α → α → Prop) : Prop where
+class IsDirected (α : Sort*) (r : α → α → Prop) : Prop where
   /-- For every pair of elements `a` and `b` there is a `c` such that `r a c` and `r b c` -/
   directed (a b : α) : ∃ c, r a c ∧ r b c
 
@@ -151,10 +151,13 @@ theorem directed_of₃ (r : α → α → Prop) [IsDirected α r] [IsTrans α r]
   have ⟨f, hef, hcf⟩ := directed_of r e c
   ⟨f, Trans.trans hae hef, Trans.trans hbe hef, hcf⟩
 
+theorem isDirected_onFun {f : ι → α} : IsDirected ι (r on f) ↔ Directed r f :=
+  ⟨(·.directed), (⟨·⟩)⟩
+
 theorem directed_id [IsDirected α r] : Directed r id := directed_of r
 
 theorem directed_id_iff : Directed r id ↔ IsDirected α r :=
-  ⟨fun h => ⟨h⟩, @directed_id _ _⟩
+  isDirected_onFun.symm
 
 theorem directedOn_univ [IsDirected α r] : DirectedOn r Set.univ := fun a _ b _ =>
   let ⟨c, hc⟩ := directed_of r a b


### PR DESCRIPTION
`Directed r f` can be written as `IsDirected ι (r on f)`.
This is the other side of `directed_id_iff` which says that `IsDirected α r` can be written as `Directed r id`.

---
Why do we have so many ways to spell the same thing? This is confusing.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
