### PR TITLE
[Merged by Bors] - chore(mk_all): infer module style from existing aggregator file

### DIFF
--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -36,6 +36,43 @@ def getLeanLibs : IO (Array String) := do
   else
     libs
 
+/-- Skip leading ASCII whitespace and Lean comments (line `-- ...` and nested `/- ... -/` block
+comments) from the start of `s`, returning the remaining slice. -/
+partial def skipWsAndComments (s : String.Slice) : String.Slice := Id.run do
+  let s := s.trimAsciiStart
+  if s.startsWith "--" then
+    let mut t := s.drop 2
+    while !t.isEmpty && t.front != '\n' do
+      t := t.drop 1
+    return skipWsAndComments t
+  if s.startsWith "/-" then
+    let mut t := s.drop 2
+    let mut depth := 1
+    while depth > 0 && !t.isEmpty do
+      if t.startsWith "/-" then
+        depth := depth + 1
+        t := t.drop 2
+      else if t.startsWith "-/" then
+        depth := depth - 1
+        t := t.drop 2
+      else
+        t := t.drop 1
+    return skipWsAndComments t
+  return s
+
+/-- Decide whether the given aggregator-file contents use the module system,
+by checking if the first non-comment, non-whitespace token is the `module` keyword. -/
+def usesModuleSystem (content : String) : Bool :=
+  -- Strip an optional UTF-8 BOM before scanning.
+  let bom := (Char.ofNat 0xfeff).toString
+  let content := if content.startsWith bom then content.drop bom.length else content.toSlice
+  let rest := skipWsAndComments content
+  if rest.startsWith "module" then
+    let after := rest.drop "module".length
+    after.isEmpty || !(after.front.isAlphanum || after.front == '_')
+  else
+    false
+
 open IO.FS IO.Process Name Cli in
 /-- Implementation of the `mk_all` command line program.
 The exit code is the number of files that the command updates/creates. -/
@@ -44,7 +81,9 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
   let git := (args.flag? "git").isSome
   -- Check whether we only verify the files, or update them in-place.
   let check := (args.flag? "check").isSome
-  let useModule := (args.flag? "module").isSome
+  -- The `--module` flag only affects newly created aggregator files; for existing files,
+  -- module-ness is inferred from the first non-comment, non-whitespace token.
+  let moduleFlag := (args.flag? "module").isSome
   -- Check whether the `--lib` flag was set. If so, build the file corresponding to the library
   -- passed to `--lib`. Else build all the libraries of the package.
   -- If the package is `mathlib`, then it removes the libraries `Cache` and `MathlibTest` and it
@@ -54,8 +93,12 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
               | none => getLeanLibs
   let mut updates := 0
   for d in libs.reverse do  -- reverse to create `Mathlib/Tactic.lean` before `Mathlib.lean`
-    let useModule := useModule || d.startsWith "Mathlib"
     let fileName := addExtension d "lean"
+    let fileExists ← pathExists fileName
+    let existingContent ← if fileExists then IO.FS.readFile fileName else pure ""
+    -- If the aggregator file already exists, infer whether it uses the module system;
+    -- otherwise, fall back to the `--module` flag.
+    let useModule := if fileExists then usesModuleSystem existingContent else moduleFlag
     let mut allFiles ← getAllModulesSorted git d
     -- mathlib exception: manually import Std and Batteries in `Mathlib.lean`
     if d == "Mathlib" then
@@ -64,18 +107,17 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
       ("\n".intercalate (allFiles.map ((if useModule then "public " else "") ++ "import " ++ ·)).toList) ++
       (if d == "Mathlib" then "\n\nset_option linter.style.longLine false" else "") ++
       "\n"
-    if !(← pathExists fileName) then
+    if !fileExists then
       if check then
         IO.println s!"File '{fileName}' does not exist"
       else
         IO.println s!"Creating '{fileName}'"
         IO.FS.writeFile fileName fileContent
       updates := updates + 1
-    else if (← IO.FS.readFile fileName) != fileContent then
+    else if existingContent != fileContent then
       if check then
         IO.println s!"The file '{fileName}' is out of date: \
-          run `lake exe mk_all{if git then " --git" else ""}{if useModule then " --module" else ""}` \
-          to update it"
+          run `lake exe mk_all{if git then " --git" else ""}` to update it"
       else
         IO.println s!"Updating '{fileName}'"
         IO.FS.writeFile fileName fileContent
@@ -100,7 +142,9 @@ def mkAll : Cmd := `[Cli|
     lib : String; "Create a folder importing all Lean files from the specified library/subfolder."
     git;          "Use the folder content information from git."
     check;        "Only check if the files are up-to-date; print an error if not"
-    module;       "Generate `module` files with `public` imports."
+    module;       "When creating a new aggregator file, generate it as a `module` with \
+                   `public` imports. Existing files keep their current style (module or plain), \
+                   inferred from their first non-comment, non-whitespace token."
 ]
 
 /-- The entrypoint to the `lake exe mk_all` command. -/

--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -36,43 +36,6 @@ def getLeanLibs : IO (Array String) := do
   else
     libs
 
-/-- Skip leading ASCII whitespace and Lean comments (line `-- ...` and nested `/- ... -/` block
-comments) from the start of `s`, returning the remaining slice. -/
-partial def skipWsAndComments (s : String.Slice) : String.Slice := Id.run do
-  let s := s.trimAsciiStart
-  if s.startsWith "--" then
-    let mut t := s.drop 2
-    while !t.isEmpty && t.front != '\n' do
-      t := t.drop 1
-    return skipWsAndComments t
-  if s.startsWith "/-" then
-    let mut t := s.drop 2
-    let mut depth := 1
-    while depth > 0 && !t.isEmpty do
-      if t.startsWith "/-" then
-        depth := depth + 1
-        t := t.drop 2
-      else if t.startsWith "-/" then
-        depth := depth - 1
-        t := t.drop 2
-      else
-        t := t.drop 1
-    return skipWsAndComments t
-  return s
-
-/-- Decide whether the given aggregator-file contents use the module system,
-by checking if the first non-comment, non-whitespace token is the `module` keyword. -/
-def usesModuleSystem (content : String) : Bool :=
-  -- Strip an optional UTF-8 BOM before scanning.
-  let bom := (Char.ofNat 0xfeff).toString
-  let content := if content.startsWith bom then content.drop bom.length else content.toSlice
-  let rest := skipWsAndComments content
-  if rest.startsWith "module" then
-    let after := rest.drop "module".length
-    after.isEmpty || !(after.front.isAlphanum || after.front == '_')
-  else
-    false
-
 open IO.FS IO.Process Name Cli in
 /-- Implementation of the `mk_all` command line program.
 The exit code is the number of files that the command updates/creates. -/
@@ -98,7 +61,10 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
     let existingContent ← if fileExists then IO.FS.readFile fileName else pure ""
     -- If the aggregator file already exists, infer whether it uses the module system;
     -- otherwise, fall back to the `--module` flag.
-    let useModule := if fileExists then usesModuleSystem existingContent else moduleFlag
+    let useModule ← if fileExists then do
+      let header ← Lean.parseImports' existingContent fileName.toString
+      pure header.isModule
+    else pure moduleFlag
     let mut allFiles ← getAllModulesSorted git d
     -- mathlib exception: manually import Std and Batteries in `Mathlib.lean`
     if d == "Mathlib" then

--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -44,8 +44,8 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
   let git := (args.flag? "git").isSome
   -- Check whether we only verify the files, or update them in-place.
   let check := (args.flag? "check").isSome
-  -- The `--module` flag only affects newly created aggregator files; for existing files,
-  -- module-ness is inferred by parsing the header with `Lean.parseImports'`.
+  -- If `--module` is passed, force module style; otherwise infer from the existing
+  -- aggregator file (when present), or default to plain.
   let moduleFlag := (args.flag? "module").isSome
   -- Check whether the `--lib` flag was set. If so, build the file corresponding to the library
   -- passed to `--lib`. Else build all the libraries of the package.
@@ -59,19 +59,20 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
     let fileName := addExtension d "lean"
     let fileExists ← pathExists fileName
     let existingContent ← if fileExists then IO.FS.readFile fileName else pure ""
-    -- If the aggregator file already exists, infer whether it uses the module system;
-    -- otherwise, fall back to the `--module` flag.
-    let useModule ← if fileExists then
-      try
-        let header ← Lean.parseImports' existingContent fileName.toString
-        pure header.isModule
-      catch e =>
-        throw <| IO.userError s!"\
-          Could not parse the header of '{fileName}' to determine whether it should be a \
-          module file: {e.toString}\n\
-          Fix or delete the file, then re-run `mk_all` (with `--module` if you want a \
-          module-style aggregator)."
-    else pure moduleFlag
+    -- If `--module` was passed explicitly, honor it. Otherwise, if the aggregator file already
+    -- exists, infer whether it uses the module system; if not, default to plain.
+    let useModule ← if moduleFlag then pure true
+      else if fileExists then
+        try
+          let header ← Lean.parseImports' existingContent fileName.toString
+          pure header.isModule
+        catch e =>
+          throw <| IO.userError s!"\
+            Could not parse the header of '{fileName}' to determine whether it should be a \
+            module file: {e.toString}\n\
+            Fix or delete the file, then re-run `mk_all` (with `--module` if you want a \
+            module-style aggregator)."
+      else pure false
     let mut allFiles ← getAllModulesSorted git d
     -- mathlib exception: manually import Std and Batteries in `Mathlib.lean`
     if d == "Mathlib" then
@@ -115,9 +116,10 @@ def mkAll : Cmd := `[Cli|
     lib : String; "Create a folder importing all Lean files from the specified library/subfolder."
     git;          "Use the folder content information from git."
     check;        "Only check if the files are up-to-date; print an error if not"
-    module;       "When creating a new aggregator file, generate it as a `module` with \
-                   `public` imports. Existing files keep their current style (module or plain), \
-                   inferred by parsing the existing header with `Lean.parseImports'`."
+    module;       "Force the aggregator file to be generated as a `module` with `public` imports. \
+                   When this flag is omitted, the style is inferred from the existing file by \
+                   parsing its header with `Lean.parseImports'`, or defaults to plain for new \
+                   files."
 ]
 
 /-- The entrypoint to the `lake exe mk_all` command. -/

--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -45,7 +45,7 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
   -- Check whether we only verify the files, or update them in-place.
   let check := (args.flag? "check").isSome
   -- The `--module` flag only affects newly created aggregator files; for existing files,
-  -- module-ness is inferred from the first non-comment, non-whitespace token.
+  -- module-ness is inferred by parsing the header with `Lean.parseImports'`.
   let moduleFlag := (args.flag? "module").isSome
   -- Check whether the `--lib` flag was set. If so, build the file corresponding to the library
   -- passed to `--lib`. Else build all the libraries of the package.
@@ -61,9 +61,16 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
     let existingContent ← if fileExists then IO.FS.readFile fileName else pure ""
     -- If the aggregator file already exists, infer whether it uses the module system;
     -- otherwise, fall back to the `--module` flag.
-    let useModule ← if fileExists then do
-      let header ← Lean.parseImports' existingContent fileName.toString
-      pure header.isModule
+    let useModule ← if fileExists then
+      try
+        let header ← Lean.parseImports' existingContent fileName.toString
+        pure header.isModule
+      catch e =>
+        throw <| IO.userError s!"\
+          Could not parse the header of '{fileName}' to determine whether it should be a \
+          module file: {e.toString}\n\
+          Fix or delete the file, then re-run `mk_all` (with `--module` if you want a \
+          module-style aggregator)."
     else pure moduleFlag
     let mut allFiles ← getAllModulesSorted git d
     -- mathlib exception: manually import Std and Batteries in `Mathlib.lean`
@@ -110,7 +117,7 @@ def mkAll : Cmd := `[Cli|
     check;        "Only check if the files are up-to-date; print an error if not"
     module;       "When creating a new aggregator file, generate it as a `module` with \
                    `public` imports. Existing files keep their current style (module or plain), \
-                   inferred from their first non-comment, non-whitespace token."
+                   inferred by parsing the existing header with `Lean.parseImports'`."
 ]
 
 /-- The entrypoint to the `lake exe mk_all` command. -/


### PR DESCRIPTION
This PR makes `lake exe mk_all` infer whether each aggregator file should use module syntax (`module` header and `public import` lines) by parsing the existing file's header with `Lean.parseImports'`. Previously the choice came from a hardcoded `d.startsWith "Mathlib"` rule plus a `--module` flag, which meant downstream projects (e.g. FLT) that had modulized their aggregator file would have it silently reverted by `mk_all` (see [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/module.20system.20questions/near/588595297)).

The `--module` flag is still honored: when passed, it forces module style. Otherwise the style is inferred from the existing file, or defaults to plain for new files.

One behavior change worth noting: creating a *new* `Mathlib/Foo` aggregator (e.g. via `lake exe mk_all --lib Mathlib/Foo` for a fresh subfolder) no longer auto-modulizes — pass `--module` once on first creation.

🤖 Prepared with Claude Code