### PR TITLE
[Merged by Bors] - feat(Tactic/Linter/Header): make header linter work downstream

### DIFF
--- a/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
+++ b/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2020. All rights reserved.
+Copyright (c) 2020 Jalex Stark, Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jalex Stark, Yury Kudryashov
 -/

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -247,25 +247,28 @@ public def copyrightHeaderChecks (copyright : String) : Array (Syntax × String)
   return output
 
 /--
-`isInMathlib modName` returns `true` if `Mathlib.lean` imports the file `modName` and `false`
-otherwise.
-This is used by the `Header` linter as a heuristic of whether it should inspect the file or not.
+`isInLibraryRoot modName` returns `true` if `<root>.lean` imports the file `modName`, where
+`<root>` is the top-level component of `modName`. For example, for `Mathlib.Foo.Bar` this checks
+`Mathlib.lean`; for `Cslib.Foo.Bar` this checks `Cslib.lean`.
+This is used by the `Header` linter as a heuristic of whether it should inspect the file or not,
+so that the linter works in any project whose library root follows the standard Lean convention
+of being named after the top-level module.
 -/
-def isInMathlib (modName : Name) : IO Bool := do
-  let mlPath := ("Mathlib" : System.FilePath).addExtension "lean"
-  if ← mlPath.pathExists then
-    let res ← parseImports' (← IO.FS.readFile mlPath) ""
-    return (res.imports.map (·.module == modName)).any (·)
+def isInLibraryRoot (modName : Name) : IO Bool := do
+  let rootPath := (modName.getRoot.toString : System.FilePath).addExtension "lean"
+  if ← rootPath.pathExists then
+    let res ← parseImports' (← IO.FS.readFile rootPath) ""
+    return res.imports.any (·.module == modName)
   else return false
 
-/-- `inMathlibRef` is
+/-- `inLibraryRootRef` is
 * `none` at initialization time;
 * `some true` if the `header` linter has already discovered that the current file
-  is imported in `Mathlib.lean`;
+  is imported in the library root file (e.g. `Mathlib.lean`);
 * `some false` if the `header` linter has already discovered that the current file
-  is *not* imported in `Mathlib.lean`.
+  is *not* imported in the library root file.
 -/
-initialize inMathlibRef : IO.Ref (Option Bool) ← IO.mkRef none
+initialize inLibraryRootRef : IO.Ref (Option Bool) ← IO.mkRef none
 
 /--
 The "header" style linter checks that a file starts with
@@ -363,24 +366,25 @@ def headerTestFiles : NameSet := .ofList
 @[inherit_doc Mathlib.Linter.linter.style.header]
 def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let mainModule ← getMainModule
-  let inMathlib? := ← match ← inMathlibRef.get with
+  let inLibraryRoot? := ← match ← inLibraryRootRef.get with
     | some d => return d
     | none => do
-      let val ← isInMathlib mainModule
-      -- We store the answer to the question "is this file in `Mathlib.lean`?" in `inMathlibRef`
-      -- to avoid recomputing its value on every command. This is a performance optimisation.
-      inMathlibRef.set (some val)
+      let val ← isInLibraryRoot mainModule
+      -- We cache the answer to avoid recomputing it on every command. This is a performance
+      -- optimisation; `mainModule` is fixed for the duration of the elaboration.
+      inLibraryRootRef.set (some val)
       return val
-  -- The linter skips files not imported in `Mathlib.lean`, to avoid linting "scratch files".
-  -- It is however active in the test files for the linter itself.
-  unless inMathlib? || headerTestFiles.contains mainModule do return
+  -- The linter skips files not imported in their library root (e.g. `Mathlib.lean`), to avoid
+  -- linting "scratch files". It is however active in the test files for the linter itself.
+  unless inLibraryRoot? || headerTestFiles.contains mainModule do return
   unless getLinterValue linter.style.header (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
     return
-  -- `Mathlib.lean` imports `Mathlib.Tactic`, which the broad imports check below would flag.
-  -- Since that file is imports-only, we can simply skip linting it.
-  if mainModule == `Mathlib then return
+  -- The library root file (e.g. `Mathlib.lean`) imports many modules; in mathlib it imports
+  -- `Mathlib.Tactic`, which the broad imports check below would flag. Since the root file is
+  -- imports-only, we can simply skip linting it.
+  if mainModule == mainModule.getRoot then return
   let fm ← getFileMap
   let mdDocs := (getMainModuleDoc (← getEnv)).toArray
   let versoDocs := (getMainVersoModuleDocs (← getEnv)).snippets

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -381,8 +381,8 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
     return
   if (← get).messages.hasErrors then
     return
-  -- Defensive: skip linting the library root file itself. In practice the
-  -- `inLibraryRoot?` check above already covers this (a well-formed `<root>.lean`
+  -- Skip linting the library root file itself.
+  -- In practice, the `inLibraryRoot?` check above already covers this (a well-formed `<root>.lean`
   -- does not import itself), but a root module could appear in `headerTestFiles`.
   if mainModule == mainModule.getRoot then return
   let fm ← getFileMap

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -381,9 +381,9 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
     return
   if (← get).messages.hasErrors then
     return
-  -- The library root file (e.g. `Mathlib.lean`) imports many modules; in mathlib it imports
-  -- `Mathlib.Tactic`, which the broad imports check below would flag. Since the root file is
-  -- imports-only, we can simply skip linting it.
+  -- Defensive: skip linting the library root file itself. In practice the
+  -- `inLibraryRoot?` check above already covers this (a well-formed `<root>.lean`
+  -- does not import itself), but a root module could appear in `headerTestFiles`.
   if mainModule == mainModule.getRoot then return
   let fm ← getFileMap
   let mdDocs := (getMainModuleDoc (← getEnv)).toArray


### PR DESCRIPTION
This PR makes `linter.style.header` usable in projects downstream of Mathlib. Previously `isInMathlib` hardcoded a lookup of `Mathlib.lean`, so the linter silently exited early in (e.g.) CSLib even when enabled via `linter.mathlibStandardSet`.

The fix uses the root of the current `mainModule` to find the aggregator file, so `Cslib.Foo.Bar` now checks `Cslib.lean`, matching the standard Lean convention that a library named `Foo` has its root file at `Foo.lean`. The "skip the aggregator itself" check is generalised from `mainModule == \`Mathlib` to `mainModule == mainModule.getRoot`.

Reported by Chris Henson on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/usage.20of.20linter.2Estyle.2Eheader.20downstream/near/581415240); cc @chenson2018 @grunweg.

🤖 Prepared with Claude Code