### PR TITLE
feat(ModelTheory): add `DefinablePred` for `fun_prop` automation

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Classes.lean
+++ b/Mathlib/ModelTheory/Algebra/Classes.lean
@@ -251,7 +251,7 @@ theorem DefinableFun.natCast [ZeroConstant L] [OneConstant L] [AddFunction L] [A
   convert (n : Term L α).definableFun_realize.of_empty
   simp
 
-@[to_additive]
+@[to_additive (attr := fun_prop)]
 theorem DefinableFun.npow [OneConstant L] [MulFunction L] [Monoid M] [CompatibleOne L M]
     [CompatibleMul L M] {n : ℕ} (hf : A.DefinableFun L f) :
     A.DefinableFun L fun v => (f v) ^ n := by

--- a/Mathlib/ModelTheory/Algebra/Classes.lean
+++ b/Mathlib/ModelTheory/Algebra/Classes.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2025 Dexin Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dexin Zhang
+-/
+module
+
+public import Mathlib.ModelTheory.Definability
+
+/-!
+# Typeclasses for first-order languages
+
+This file defines typeclasses for first-order languages contaning certain algebraic symbols, as well
+as instances of `Add`, `Mul`, etc. on terms in the language.
+
+## Main definitions
+
+* `FirstOrder.Language.ZeroContants` etc.: typeclasses for first-order languages that have certain
+  symbols.
+* `FirstOrder.Language.Structure.CompatibleZero` etc.: typeclasses stating that a first-order
+  structure `M` interprets first-order language symbols the same as its algebraic structure
+  instance.
+-/
+
+@[expose] public section
+
+namespace FirstOrder.Language
+
+attribute [to_additive_ignore_args 2] Term
+
+variable {L : Language} {α : Type*} {t t₁ t₂ : L.Term α}
+
+/-- Type class for first-order langauges that have a constant symbol `0` for zero. -/
+class ZeroConstant (L : Language) where
+  zero : L.Constants
+
+/-- Type class for first-order langauges that have a constant symbol `1` for one. -/
+@[to_additive]
+class OneConstant (L : Language) where
+  one : L.Constants
+
+/-- Constant `1`. -/
+@[to_additive /-- Constant `0`. -/]
+def Constants.one [OneConstant L] : L.Constants := OneConstant.one
+
+/-- Type class for first-order languages that have a binary function symbol `+` for addition. -/
+class AddFunction (L : Language) where
+  add : L.Functions 2
+
+/-- Type class for first-order languages that have a binary function symbol `*` for
+multiplication. -/
+@[to_additive]
+class MulFunction (L : Language) where
+  mul : L.Functions 2
+
+/-- Binary function `*`. -/
+@[to_additive /-- Binary function `+`. -/]
+def Functions.mul [MulFunction L] : L.Functions 2 := MulFunction.mul
+
+/-- Type class for first-order languages that have a unary function symbol `-` for negation. -/
+class NegFunction (L : Language) where
+  neg : L.Functions 1
+
+/-- Type class for first-order languages that have a unary function symbol `⁻¹` for inverse. -/
+@[to_additive]
+class InvFunction (L : Language) where
+  inv : L.Functions 1
+
+/-- Unary function `⁻¹`. -/
+@[to_additive /-- Unary function `-`. -/]
+def Functions.inv [InvFunction L] : L.Functions 1 := InvFunction.inv
+
+namespace Term
+
+@[to_additive]
+instance [OneConstant L] : One (L.Term α) where
+  one := Constants.one.term
+
+@[to_additive]
+theorem one_def [OneConstant L] : (1 : L.Term α) = Constants.one.term := rfl
+
+@[to_additive]
+instance [MulFunction L] : Mul (L.Term α) where
+  mul := Functions.mul.apply₂
+
+@[to_additive]
+theorem mul_def [MulFunction L] : t₁ * t₂ = Functions.mul.apply₂ t₁ t₂ := rfl
+
+@[to_additive]
+instance [InvFunction L] : Inv (L.Term α) where
+  inv := Functions.inv.apply₁
+
+@[to_additive]
+theorem inv_def [InvFunction L] : t⁻¹ = Functions.inv.apply₁ t := rfl
+
+section
+
+variable [ZeroConstant L] [OneConstant L] [AddFunction L]
+
+instance : NatCast (L.Term α) where
+  natCast := Nat.unaryCast
+
+@[simp, norm_cast] theorem natCast_zero : (0 : ℕ) = (0 : L.Term α) := rfl
+
+@[simp, norm_cast] theorem natCast_succ (n : ℕ) : (n + 1 : ℕ) = (n : L.Term α) + 1 := rfl
+
+end
+
+section
+
+variable [OneConstant L] [MulFunction L]
+
+@[to_additive]
+instance : Pow (L.Term α) ℕ where
+  pow t n := npowRec n t
+
+@[to_additive (attr := simp)]
+theorem pow_zero : t ^ 0 = 1 := rfl
+
+@[to_additive (attr := simp)]
+theorem pow_succ {n : ℕ} : t ^ (n + 1) = t ^ n * t := rfl
+
+/-- Product over a finite set of terms.
+
+It is defined via choice, so the result only makes sense when the structure satisfies commutativity
+(see `realize_prod`). -/
+@[to_additive /-- Summation over a finite set of terms.
+It is defined via choice, so the result only makes sense when the structure satisfies commutativity
+(see `realize_sum`). -/]
+noncomputable def prod {β : Type*} (s : Finset β) (f : β → L.Term α) :
+    L.Term α := (s.toList.map f).prod
+
+end
+
+end Term
+
+namespace Structure
+
+variable (L) (M : Type*) [L.Structure M]
+
+/-- Type class stating that a first-order structure `M` interprets symbol `0` the same as its `Zero`
+instance. -/
+class CompatibleZero [ZeroConstant L] [Zero M] where
+  funMap_zero : ∀ x, funMap (L := L) (M := M) Constants.zero x = 0
+
+/-- Type class stating that a first-order structure `M` interprets symbol `1` the same as its `One`
+instance. -/
+@[to_additive]
+class CompatibleOne [OneConstant L] [One M] where
+  funMap_one : ∀ x, funMap (L := L) (M := M) Constants.one x = 1
+
+/-- Type class stating that a first-order structure `M` interprets symbol `+` the same as its `Add`
+instance. -/
+class CompatibleAdd [AddFunction L] [Add M] where
+  funMap_add : ∀ x, funMap (L := L) (M := M) Functions.add x = x 0 + x 1
+
+/-- Type class stating that a first-order structure `M` interprets symbol `1` the same as its `One`
+instance. -/
+@[to_additive]
+class CompatibleMul [MulFunction L] [Mul M] where
+  funMap_mul : ∀ x, funMap (L := L) (M := M) Functions.mul x = x 0 * x 1
+
+/-- Type class stating that a first-order structure `M` interprets symbol `-` the same as its `Neg`
+instance. -/
+class CompatibleNeg [NegFunction L] [Neg M] where
+  funMap_neg : ∀ x, funMap (L := L) (M := M) Functions.neg x = -x 0
+
+/-- Type class stating that a first-order structure `M` interprets symbol `⁻¹` the same as its `Inv`
+instance. -/
+@[to_additive]
+class CompatibleInv [InvFunction L] [Inv M] where
+  funMap_inv : ∀ x, funMap (L := L) (M := M) Functions.inv x = (x 0)⁻¹
+
+attribute [simp] CompatibleZero.funMap_zero CompatibleOne.funMap_one CompatibleAdd.funMap_add
+  CompatibleMul.funMap_mul CompatibleNeg.funMap_neg CompatibleInv.funMap_inv
+
+variable {L M} {v : α → M}
+
+@[to_additive (attr := simp)]
+theorem realize_one [OneConstant L] [One M] [CompatibleOne L M] :
+    Term.realize v (1 : L.Term α) = 1 := by
+  simp [Term.one_def, constantMap]
+
+@[to_additive (attr := simp)]
+theorem realize_mul [MulFunction L] [Mul M] [CompatibleMul L M] :
+    Term.realize v (t₁ * t₂) = Term.realize v t₁ * Term.realize v t₂ := by
+  simp [Term.mul_def]
+
+@[to_additive (attr := simp)]
+theorem realize_inv [InvFunction L] [Inv M] [CompatibleInv L M] :
+    Term.realize v t⁻¹ = (Term.realize v t)⁻¹ := by
+  simp [Term.inv_def]
+
+@[simp]
+theorem realize_natCast [ZeroConstant L] [OneConstant L] [AddFunction L] [AddMonoidWithOne M]
+    [CompatibleZero L M] [CompatibleOne L M] [CompatibleAdd L M] {n : ℕ} :
+    Term.realize v (n : L.Term α) = n := by
+  induction n <;> simp [*]
+
+@[to_additive (attr := simp)]
+theorem realize_npow [OneConstant L] [MulFunction L] [Monoid M] [CompatibleOne L M]
+    [CompatibleMul L M] {n : ℕ} :
+    Term.realize v (t ^ n) = Term.realize v t ^ n := by
+  induction n <;> simp [pow_add, *]
+
+@[to_additive (attr := simp)]
+theorem realize_prod [OneConstant L] [MulFunction L] [CommMonoid M] [CompatibleOne L M]
+    [CompatibleMul L M] {ι : Type*} {s : Finset ι} {f : ι → L.Term α} :
+    Term.realize v (Term.prod s f) = ∏ i ∈ s, Term.realize v (f i) := by
+  classical
+  simp only [Term.prod]
+  conv => rhs; rw [← s.toList_toFinset, List.prod_toFinset _ s.nodup_toList]
+  generalize s.toList = l
+  induction l with simp [*]
+
+end FirstOrder.Language.Structure
+
+open FirstOrder Language Structure
+
+namespace Set
+
+variable {L : Language} {M : Type*} [L.Structure M] {A : Set M} {α : Type*} {f g : (α → M) → M}
+
+@[to_additive (attr := fun_prop)]
+theorem DefinableFun.one [OneConstant L] [One M] [CompatibleOne L M] :
+    A.DefinableFun L fun _ : α → M => 1 := by
+  convert (1 : Term L α).definableFun_realize.of_empty
+  simp
+
+@[to_additive (attr := fun_prop)]
+theorem DefinableFun.mul [MulFunction L] [Mul M] [CompatibleMul L M]
+    (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) :
+    A.DefinableFun L fun v => f v * g v := by
+  apply comp (g := fun v => ![f v, g v]) (f := fun v => v 0 * v 1)
+  · simp [DefinableMap, *]
+  · convert (DefinableFun.fun_symbol (L := L) Functions.mul).of_empty
+    simp
+
+@[to_additive (attr := fun_prop)]
+theorem DefinableFun.inv [InvFunction L] [Inv M] [CompatibleInv L M] (hf : A.DefinableFun L f) :
+    A.DefinableFun L fun v => (f v)⁻¹ := by
+  apply comp (g := fun v => ![f v]) (f := fun v => (v 0)⁻¹)
+  · simp [DefinableMap, *]
+  · convert (DefinableFun.fun_symbol (L := L) Functions.inv).of_empty
+    simp
+
+@[fun_prop]
+theorem DefinableFun.natCast [ZeroConstant L] [OneConstant L] [AddFunction L] [AddMonoidWithOne M]
+    [CompatibleZero L M] [CompatibleOne L M] [CompatibleAdd L M] {n : ℕ} :
+    A.DefinableFun L fun _ : α → M => n := by
+  convert (n : Term L α).definableFun_realize.of_empty
+  simp
+
+@[to_additive]
+theorem DefinableFun.npow [OneConstant L] [MulFunction L] [Monoid M] [CompatibleOne L M]
+    [CompatibleMul L M] {n : ℕ} (hf : A.DefinableFun L f) :
+    A.DefinableFun L fun v => (f v) ^ n := by
+  apply comp (g := fun v => ![f v]) (f := fun v => v 0 ^ n)
+  · simp [DefinableMap, *]
+  · convert (Term.var 0 ^ n : Term L (Fin 1)).definableFun_realize.of_empty
+    simp only [Fin.isValue, realize_npow, Term.realize_var]
+
+@[to_additive (attr := fun_prop)]
+theorem DefinableFun.finsetProd [OneConstant L] [MulFunction L] [CommMonoid M] [CompatibleOne L M]
+    [CompatibleMul L M] {ι : Type*} {s : Finset ι} {f : ι → (α → M) → M}
+    (hf : ∀ i ∈ s, A.DefinableFun L (f i)) :
+    A.DefinableFun L fun v => ∏ i ∈ s, f i v := by
+  conv in (Finset.prod _ _) => rw [← Finset.prod_coe_sort]
+  apply comp
+  · simp [DefinableMap, *]
+  · convert (Term.prod .univ (L := L) fun i : s => Term.var i).definableFun_realize.of_empty
+    simp
+
+end Set

--- a/Mathlib/ModelTheory/Algebra/Classes.lean
+++ b/Mathlib/ModelTheory/Algebra/Classes.lean
@@ -233,7 +233,7 @@ theorem DefinableFun.mul [MulFunction L] [Mul M] [CompatibleMul L M]
     (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) :
     A.DefinableFun L fun v => f v * g v := by
   apply comp (g := fun v => ![f v, g v]) (f := fun v => v 0 * v 1)
-  · simp [DefinableMap, *]
+  · simp [*]
   · convert (DefinableFun.fun_symbol (L := L) Functions.mul).of_empty
     simp
 
@@ -241,7 +241,7 @@ theorem DefinableFun.mul [MulFunction L] [Mul M] [CompatibleMul L M]
 theorem DefinableFun.inv [InvFunction L] [Inv M] [CompatibleInv L M] (hf : A.DefinableFun L f) :
     A.DefinableFun L fun v => (f v)⁻¹ := by
   apply comp (g := fun v => ![f v]) (f := fun v => (v 0)⁻¹)
-  · simp [DefinableMap, *]
+  · simp [*]
   · convert (DefinableFun.fun_symbol (L := L) Functions.inv).of_empty
     simp
 
@@ -257,9 +257,21 @@ theorem DefinableFun.npow [OneConstant L] [MulFunction L] [Monoid M] [Compatible
     [CompatibleMul L M] {n : ℕ} (hf : A.DefinableFun L f) :
     A.DefinableFun L fun v => (f v) ^ n := by
   apply comp (g := fun v => ![f v]) (f := fun v => v 0 ^ n)
-  · simp [DefinableMap, *]
+  · simp [*]
   · convert (Term.var 0 ^ n : Term L (Fin 1)).definableFun_realize.of_empty
     simp only [Fin.isValue, realize_npow, Term.realize_var]
+
+@[fun_prop]
+theorem DefinableFun.nat_mul [ZeroConstant L] [AddFunction L] [NonAssocSemiring M]
+    [CompatibleZero L M] [CompatibleAdd L M] {n : ℕ} (hf : A.DefinableFun L f) :
+    A.DefinableFun L fun v => n * f v := by
+  simpa only [nsmul_eq_mul] using hf.nsmul
+
+@[fun_prop]
+theorem DefinableFun.mul_nat [ZeroConstant L] [AddFunction L] [NonAssocSemiring M]
+    [CompatibleZero L M] [CompatibleAdd L M] {n : ℕ} (hf : A.DefinableFun L f) :
+    A.DefinableFun L fun v => f v * n := by
+  simpa only [nsmul_eq_mul'] using hf.nsmul
 
 @[to_additive (attr := fun_prop)]
 theorem DefinableFun.finsetProd [OneConstant L] [MulFunction L] [CommMonoid M] [CompatibleOne L M]
@@ -268,7 +280,7 @@ theorem DefinableFun.finsetProd [OneConstant L] [MulFunction L] [CommMonoid M] [
     A.DefinableFun L fun v => ∏ i ∈ s, f i v := by
   conv in Finset.prod _ _ => rw [← Finset.prod_coe_sort]
   apply comp
-  · simp [DefinableMap, *]
+  · simpa
   · convert (Term.prod .univ (L := L) fun i : s => Term.var i).definableFun_realize.of_empty
     simp
 

--- a/Mathlib/ModelTheory/Algebra/Classes.lean
+++ b/Mathlib/ModelTheory/Algebra/Classes.lean
@@ -125,10 +125,11 @@ theorem pow_succ {n : ℕ} : t ^ (n + 1) = t ^ n * t := rfl
 It is defined via choice, so the result only makes sense when the structure satisfies commutativity
 (see `realize_prod`). -/
 @[to_additive /-- Summation over a finite set of terms.
+
 It is defined via choice, so the result only makes sense when the structure satisfies commutativity
 (see `realize_sum`). -/]
-noncomputable def prod {β : Type*} (s : Finset β) (f : β → L.Term α) :
-    L.Term α := (s.toList.map f).prod
+noncomputable def prod {β : Type*} (s : Finset β) (f : β → L.Term α) : L.Term α :=
+  (s.toList.map f).prod
 
 end
 
@@ -265,7 +266,7 @@ theorem DefinableFun.finsetProd [OneConstant L] [MulFunction L] [CommMonoid M] [
     [CompatibleMul L M] {ι : Type*} {s : Finset ι} {f : ι → (α → M) → M}
     (hf : ∀ i ∈ s, A.DefinableFun L (f i)) :
     A.DefinableFun L fun v => ∏ i ∈ s, f i v := by
-  conv in (Finset.prod _ _) => rw [← Finset.prod_coe_sort]
+  conv in Finset.prod _ _ => rw [← Finset.prod_coe_sort]
   apply comp
   · simp [DefinableMap, *]
   · convert (Term.prod .univ (L := L) fun i : s => Term.var i).definableFun_realize.of_empty

--- a/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
@@ -201,7 +201,7 @@ theorem finite_ACF_prime_not_realize_of_ACF_zero_realize
       have := charP_of_model_fieldOfChar q K
       simp only [eqZero, Term.equal, BoundedFormula.realize_not, BoundedFormula.realize_bdEqual,
         Term.realize_relabel, Sum.elim_comp_inl, realize_termOfFreeCommRing, map_natCast,
-        realize_zero, ← CharP.charP_iff_prime_eq_zero hp]
+        Structure.realize_zero, ← CharP.charP_iff_prime_eq_zero hp]
       intro _
       exact hqp <| CharP.eq K this inferInstance
   let s : Finset Nat.Primes := T0.attach.biUnion (fun φ => f φ.1 (hT0 φ.2))

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -80,11 +80,11 @@ instance : AddFunction ring := ⟨ringFunc.add⟩
 instance : MulFunction ring := ⟨ringFunc.mul⟩
 instance : NegFunction ring := ⟨ringFunc.neg⟩
 
-@[simp] theorem zero_def : ringFunc.zero = Constants.zero (L := ring) := rfl
-@[simp] theorem one_def : ringFunc.one = Constants.one (L := ring) := rfl
-@[simp] theorem add_def : ringFunc.add = Functions.add (L := ring) := rfl
-@[simp] theorem mul_def : ringFunc.mul = Functions.mul (L := ring) := rfl
-@[simp] theorem neg_def : ringFunc.neg = Functions.neg (L := ring) := rfl
+@[simp] theorem zero_eq : ringFunc.zero = Constants.zero (L := ring) := rfl
+@[simp] theorem one_eq : ringFunc.one = Constants.one (L := ring) := rfl
+@[simp] theorem add_eq : ringFunc.add = Functions.add (L := ring) := rfl
+@[simp] theorem mul_eq : ringFunc.mul = Functions.mul (L := ring) := rfl
+@[simp] theorem neg_eq : ringFunc.neg = Functions.neg (L := ring) := rfl
 
 instance : Fintype Language.ring.Symbols :=
   ⟨⟨Multiset.ofList
@@ -93,7 +93,7 @@ instance : Fintype Language.ring.Symbols :=
        Sum.inl ⟨1, .neg⟩,
        Sum.inl ⟨0, Constants.zero⟩,
        Sum.inl ⟨0, Constants.one⟩], by
-    simp [← zero_def, ← one_def, ← add_def, ← mul_def]⟩, by
+    simp [← zero_eq, ← one_eq, ← add_eq, ← mul_eq]⟩, by
     rintro (⟨_, f⟩ | ⟨_, f⟩) <;> cases f <;> simp⟩
 
 @[simp]

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -5,9 +5,8 @@ Authors: Chris Hughes
 -/
 module
 
-public import Mathlib.ModelTheory.Syntax
-public import Mathlib.ModelTheory.Semantics
 public import Mathlib.Algebra.Ring.Equiv
+public import Mathlib.ModelTheory.Algebra.Classes
 
 /-!
 # First-Order Language of Rings
@@ -64,7 +63,7 @@ def Language.ring : Language :=
 
 namespace Ring
 
-open ringFunc Language
+open Language
 
 set_option backward.isDefEq.respectTransparency false in
 /-- This instance does not get inferred without `instDecidableEqFunctions` in
@@ -75,68 +74,27 @@ example (n : ℕ) : DecidableEq (Language.ring.Functions n) := inferInstance
 `ModelTheory/Basic`. -/
 example (n : ℕ) : DecidableEq (Language.ring.Relations n) := inferInstance
 
-/-- `RingFunc.add`, but with the defeq type `Language.ring.Functions 2` instead
-of `RingFunc 2` -/
-abbrev addFunc : Language.ring.Functions 2 := add
+instance : ZeroConstant ring := ⟨ringFunc.zero⟩
+instance : OneConstant ring := ⟨ringFunc.one⟩
+instance : AddFunction ring := ⟨ringFunc.add⟩
+instance : MulFunction ring := ⟨ringFunc.mul⟩
+instance : NegFunction ring := ⟨ringFunc.neg⟩
 
-/-- `RingFunc.mul`, but with the defeq type `Language.ring.Functions 2` instead
-of `RingFunc 2` -/
-abbrev mulFunc : Language.ring.Functions 2 := mul
+@[simp] theorem zero_def : ringFunc.zero = Constants.zero (L := ring) := rfl
+@[simp] theorem one_def : ringFunc.one = Constants.one (L := ring) := rfl
+@[simp] theorem add_def : ringFunc.add = Functions.add (L := ring) := rfl
+@[simp] theorem mul_def : ringFunc.mul = Functions.mul (L := ring) := rfl
+@[simp] theorem neg_def : ringFunc.neg = Functions.neg (L := ring) := rfl
 
-/-- `RingFunc.neg`, but with the defeq type `Language.ring.Functions 1` instead
-of `RingFunc 1` -/
-abbrev negFunc : Language.ring.Functions 1 := neg
-
-/-- `RingFunc.zero`, but with the defeq type `Language.ring.Functions 0` instead
-of `RingFunc 0` -/
-abbrev zeroFunc : Language.ring.Functions 0 := zero
-
-/-- `RingFunc.one`, but with the defeq type `Language.ring.Functions 0` instead
-of `RingFunc 0` -/
-abbrev oneFunc : Language.ring.Functions 0 := one
-
-instance (α : Type*) : Zero (Language.ring.Term α) :=
-{ zero := Constants.term zeroFunc }
-
-theorem zero_def (α : Type*) : (0 : Language.ring.Term α) = Constants.term zeroFunc := rfl
-
-instance (α : Type*) : One (Language.ring.Term α) :=
-{ one := Constants.term oneFunc }
-
-theorem one_def (α : Type*) : (1 : Language.ring.Term α) = Constants.term oneFunc := rfl
-
-instance (α : Type*) : Add (Language.ring.Term α) :=
-{ add := addFunc.apply₂ }
-
-theorem add_def (α : Type*) (t₁ t₂ : Language.ring.Term α) :
-    t₁ + t₂ = addFunc.apply₂ t₁ t₂ := rfl
-
-instance (α : Type*) : Mul (Language.ring.Term α) :=
-{ mul := mulFunc.apply₂ }
-
-theorem mul_def (α : Type*) (t₁ t₂ : Language.ring.Term α) :
-    t₁ * t₂ = mulFunc.apply₂ t₁ t₂ := rfl
-
-instance (α : Type*) : Neg (Language.ring.Term α) :=
-{ neg := negFunc.apply₁ }
-
-theorem neg_def (α : Type*) (t : Language.ring.Term α) :
-    -t = negFunc.apply₁ t := rfl
-
-set_option backward.isDefEq.respectTransparency false in
 instance : Fintype Language.ring.Symbols :=
   ⟨⟨Multiset.ofList
       [Sum.inl ⟨2, .add⟩,
        Sum.inl ⟨2, .mul⟩,
        Sum.inl ⟨1, .neg⟩,
-       Sum.inl ⟨0, .zero⟩,
-       Sum.inl ⟨0, .one⟩], by
-    dsimp [Language.Symbols]; decide⟩, by
-    intro x
-    dsimp [Language.Symbols]
-    rcases x with ⟨_, f⟩ | ⟨_, f⟩
-    · cases f <;> decide
-    · cases f ⟩
+       Sum.inl ⟨0, Constants.zero⟩,
+       Sum.inl ⟨0, Constants.one⟩], by
+    simp [← zero_def, ← one_def, ← add_def, ← mul_def]⟩, by
+    rintro (⟨_, f⟩ | ⟨_, f⟩) <;> cases f <;> simp⟩
 
 @[simp]
 theorem card_ring : card Language.ring = 5 := by
@@ -155,55 +113,8 @@ requires a type to have be both a `Ring` (or `Field` etc.) and a
 combination with a `Ring`, or `Field` instance without having multiple different
 `Add` structures on the Type. -/
 class CompatibleRing (R : Type*) [Add R] [Mul R] [Neg R] [One R] [Zero R]
-    extends Language.ring.Structure R where
-  /-- Addition in the `Language.ring.Structure` is the same as the addition given by the
-  `Add` instance -/
-  funMap_add : ∀ x, funMap addFunc x = x 0 + x 1
-  /-- Multiplication in the `Language.ring.Structure` is the same as the multiplication given by the
-  `Mul` instance -/
-  funMap_mul : ∀ x, funMap mulFunc x = x 0 * x 1
-  /-- Negation in the `Language.ring.Structure` is the same as the negation given by the
-  `Neg` instance -/
-  funMap_neg : ∀ x, funMap negFunc x = -x 0
-  /-- The constant `0` in the `Language.ring.Structure` is the same as the constant given by the
-  `Zero` instance -/
-  funMap_zero : ∀ x, funMap (zeroFunc : Language.ring.Constants) x = 0
-  /-- The constant `1` in the `Language.ring.Structure` is the same as the constant given by the
-  `One` instance -/
-  funMap_one : ∀ x, funMap (oneFunc : Language.ring.Constants) x = 1
-
-open CompatibleRing
-
-attribute [simp] funMap_add funMap_mul funMap_neg funMap_zero funMap_one
-
-section
-
-variable {R : Type*} [Add R] [Mul R] [Neg R] [One R] [Zero R] [CompatibleRing R]
-
-@[simp]
-theorem realize_add (x y : ring.Term α) (v : α → R) :
-    Term.realize v (x + y) = Term.realize v x + Term.realize v y := by
-  simp [add_def, funMap_add]
-
-@[simp]
-theorem realize_mul (x y : ring.Term α) (v : α → R) :
-    Term.realize v (x * y) = Term.realize v x * Term.realize v y := by
-  simp [mul_def, funMap_mul]
-
-@[simp]
-theorem realize_neg (x : ring.Term α) (v : α → R) :
-    Term.realize v (-x) = -Term.realize v x := by
-  simp [neg_def, funMap_neg]
-
-@[simp]
-theorem realize_zero (v : α → R) : Term.realize v (0 : ring.Term α) = 0 := by
-  simp [zero_def, funMap_zero, constantMap]
-
-@[simp]
-theorem realize_one (v : α → R) : Term.realize v (1 : ring.Term α) = 1 := by
-  simp [one_def, funMap_one, constantMap]
-
-end
+    extends ring.Structure R, CompatibleAdd ring R, CompatibleMul ring R, CompatibleNeg ring R,
+      CompatibleOne ring R, CompatibleZero ring R
 
 /-- Given a Type `R` with instances for each of the `Ring` operations, make a
 `Language.ring.Structure R` instance, along with a proof that the operations given
@@ -243,17 +154,12 @@ def languageEquivEquivRingEquiv {R S : Type*}
     (Language.ring.Equiv R S) ≃ (R ≃+* S) :=
   { toFun f :=
     { f with
-      map_add' := by
-        intro x y
-        simpa using f.map_fun addFunc ![x, y]
-      map_mul' := by
-        intro x y
-        simpa using f.map_fun mulFunc ![x, y] }
+      map_add' x y := by simpa using f.map_fun .add ![x, y]
+      map_mul' x y := by simpa using f.map_fun .mul ![x, y] }
     invFun f :=
     { f with
-      map_fun' := fun {n} f => by
-        cases f <;> simp
-      map_rel' := fun {n} f => by cases f } }
+      map_fun' f := by cases f <;> simp
+      map_rel' f := by cases f } }
 
 variable (R : Type*) [Language.ring.Structure R]
 
@@ -262,35 +168,35 @@ variable (R : Type*) [Language.ring.Structure R]
 To be used sparingly, usually only when defining a more useful definition like,
 `[Language.ring.Structure K] -> [Theory.field.Model K] -> Field K` -/
 abbrev addOfRingStructure : Add R :=
-  { add := fun x y => funMap addFunc ![x, y] }
+  { add := fun x y => funMap (L := ring) .add ![x, y] }
 
 /-- A def to put an `Mul` instance on a type with a `Language.ring.Structure` instance.
 
 To be used sparingly, usually only when defining a more useful definition like,
 `[Language.ring.Structure K] -> [Theory.field.Model K] -> Field K` -/
 abbrev mulOfRingStructure : Mul R :=
-  { mul := fun x y => funMap mulFunc ![x, y] }
+  { mul := fun x y => funMap (L := ring) .mul ![x, y] }
 
 /-- A def to put an `Neg` instance on a type with a `Language.ring.Structure` instance.
 
 To be used sparingly, usually only when defining a more useful definition like,
 `[Language.ring.Structure K] -> [Theory.field.Model K] -> Field K` -/
 abbrev negOfRingStructure : Neg R :=
-  { neg := fun x => funMap negFunc ![x] }
+  { neg := fun x => funMap (L := ring) .neg ![x] }
 
 /-- A def to put an `Zero` instance on a type with a `Language.ring.Structure` instance.
 
 To be used sparingly, usually only when defining a more useful definition like,
 `[Language.ring.Structure K] -> [Theory.field.Model K] -> Field K` -/
 abbrev zeroOfRingStructure : Zero R :=
-  { zero := funMap zeroFunc ![] }
+  { zero := funMap (L := ring) .zero ![] }
 
 /-- A def to put an `One` instance on a type with a `Language.ring.Structure` instance.
 
 To be used sparingly, usually only when defining a more useful definition like,
 `[Language.ring.Structure K] -> [Theory.field.Model K] -> Field K` -/
 abbrev oneOfRingStructure : One R :=
-  { one := funMap oneFunc ![] }
+  { one := funMap (L := ring) .one ![] }
 
 attribute [local instance] addOfRingStructure mulOfRingStructure negOfRingStructure
   zeroOfRingStructure oneOfRingStructure

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Basic
 public import Mathlib.Algebra.Module.NatInt
-public import Mathlib.ModelTheory.Semantics
+public import Mathlib.ModelTheory.Algebra.Classes
 
 /-!
 # Presburger arithmetic
@@ -20,8 +20,6 @@ This file defines the first-order language of Presburger arithmetic as (0,1,+).
 
 ## TODO
 
-- Generalize `presburger.sum` (maybe also `NatCast` and `SMul`) for classes like
-  `FirstOrder.Language.IsOrdered`.
 - Define the theory of Presburger arithmetic and prove its properties (quantifier elimination,
   completeness, etc).
 -/
@@ -47,83 +45,36 @@ def Language.presburger : Language :=
 
 namespace Language.presburger
 
-variable {t t₁ t₂ : presburger.Term α}
+instance : ZeroConstant presburger where
+  zero := presburgerFunc.zero
 
-instance : Zero (presburger.Term α) where
-  zero := Constants.term .zero
+instance : OneConstant presburger where
+  one := presburgerFunc.one
 
-instance : One (presburger.Term α) where
-  one := Constants.term .one
+instance : AddFunction presburger where
+  add := presburgerFunc.add
 
-instance : Add (presburger.Term α) where
-  add := Functions.apply₂ .add
+@[simp] theorem zero_def : presburgerFunc.zero = Constants.zero (L := presburger) := rfl
 
-instance : NatCast (presburger.Term α) where
-  natCast := Nat.unaryCast
+@[simp] theorem one_def : presburgerFunc.one = Constants.one (L := presburger) := rfl
 
-@[simp, norm_cast] theorem natCast_zero : (0 : ℕ) = (0 : presburger.Term α) := rfl
+@[simp] theorem add_def : presburgerFunc.add = Functions.add (L := presburger) := rfl
 
-@[simp, norm_cast] theorem natCast_succ (n : ℕ) : (n + 1 : ℕ) = (n : presburger.Term α) + 1 := rfl
+open Structure
 
-instance : SMul ℕ (presburger.Term α) where
-  smul := nsmulRec
+class CompatibleStructure (M : Type*) [Zero M] [One M] [Add M]
+    extends presburger.Structure M, CompatibleZero presburger M, CompatibleOne presburger M,
+      CompatibleAdd presburger M
 
-@[simp] theorem zero_nsmul : 0 • t = 0 := rfl
-
-@[simp] theorem succ_nsmul {n : ℕ} : (n + 1) • t = n • t + t := rfl
-
-/-- Summation over a finite set of terms in Presburger arithmetic.
-
-It is defined via choice, so the result only makes sense when the structure satisfies
-commutativity (see `realize_sum`). -/
-noncomputable def sum {β : Type*} (s : Finset β) (f : β → presburger.Term α) : presburger.Term α :=
-  (s.toList.map f).sum
-
-variable {M : Type*} {v : α → M}
-
-section
-
-variable [Zero M] [One M] [Add M]
-
-instance : presburger.Structure M where
+instance {M : Type*} [Zero M] [One M] [Add M] : presburger.Structure M where
   funMap
   | .zero, _ => 0
   | .one, v => 1
   | .add, v => v 0 + v 1
 
-@[simp] theorem funMap_zero {v} :
-    Structure.funMap (L := presburger) (M := M) presburgerFunc.zero v = 0 := rfl
-
-@[simp] theorem funMap_one {v} :
-    Structure.funMap (L := presburger) (M := M) presburgerFunc.one v = 1 := rfl
-
-@[simp] theorem funMap_add {v} :
-    Structure.funMap (L := presburger) (M := M) presburgerFunc.add v = v 0 + v 1 := rfl
-
-@[simp] theorem realize_zero : Term.realize v (0 : presburger.Term α) = 0 := rfl
-
-@[simp] theorem realize_one : Term.realize v (1 : presburger.Term α) = 1 := rfl
-
-@[simp] theorem realize_add :
-    Term.realize v (t₁ + t₂) = Term.realize v t₁ + Term.realize v t₂ := rfl
-
-end
-
-@[simp] theorem realize_natCast [AddMonoidWithOne M] {n : ℕ} :
-    Term.realize v (n : presburger.Term α) = n := by
-  induction n with simp [*]
-
-@[simp] theorem realize_nsmul [AddMonoidWithOne M] {n : ℕ} :
-    Term.realize v (n • t) = n • Term.realize v t := by
-  induction n with simp [*, add_nsmul]
-
-@[simp] theorem realize_sum [AddCommMonoidWithOne M]
-    {β : Type*} {s : Finset β} {f : β → presburger.Term α} :
-    Term.realize v (sum s f) = ∑ i ∈ s, Term.realize v (f i) := by
-  classical
-  simp only [sum]
-  conv => rhs; rw [← s.toList_toFinset, List.sum_toFinset _ s.nodup_toList]
-  generalize s.toList = l
-  induction l with simp [*]
+instance {M : Type*} [Zero M] [One M] [Add M] : CompatibleStructure M where
+  funMap_zero _ := rfl
+  funMap_one _ := rfl
+  funMap_add _ := rfl
 
 end FirstOrder.Language.presburger

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -45,26 +45,15 @@ def Language.presburger : Language :=
 
 namespace Language.presburger
 
-instance : ZeroConstant presburger where
-  zero := presburgerFunc.zero
+instance : ZeroConstant presburger := ⟨presburgerFunc.zero⟩
+instance : OneConstant presburger := ⟨presburgerFunc.one⟩
+instance : AddFunction presburger := ⟨presburgerFunc.add⟩
 
-instance : OneConstant presburger where
-  one := presburgerFunc.one
-
-instance : AddFunction presburger where
-  add := presburgerFunc.add
-
-@[simp] theorem zero_def : presburgerFunc.zero = Constants.zero (L := presburger) := rfl
-
-@[simp] theorem one_def : presburgerFunc.one = Constants.one (L := presburger) := rfl
-
-@[simp] theorem add_def : presburgerFunc.add = Functions.add (L := presburger) := rfl
+@[simp] theorem zero_eq : presburgerFunc.zero = Constants.zero (L := presburger) := rfl
+@[simp] theorem one_eq : presburgerFunc.one = Constants.one (L := presburger) := rfl
+@[simp] theorem add_eq : presburgerFunc.add = Functions.add (L := presburger) := rfl
 
 open Structure
-
-class CompatibleStructure (M : Type*) [Zero M] [One M] [Add M]
-    extends presburger.Structure M, CompatibleZero presburger M, CompatibleOne presburger M,
-      CompatibleAdd presburger M
 
 instance {M : Type*} [Zero M] [One M] [Add M] : presburger.Structure M where
   funMap
@@ -72,9 +61,13 @@ instance {M : Type*} [Zero M] [One M] [Add M] : presburger.Structure M where
   | .one, v => 1
   | .add, v => v 0 + v 1
 
-instance {M : Type*} [Zero M] [One M] [Add M] : CompatibleStructure M where
+instance {M : Type*} [Zero M] [One M] [Add M] : CompatibleZero presburger M where
   funMap_zero _ := rfl
+
+instance {M : Type*} [Zero M] [One M] [Add M] : CompatibleOne presburger M where
   funMap_one _ := rfl
+
+instance {M : Type*} [Zero M] [One M] [Add M] : CompatibleAdd presburger M where
   funMap_add _ := rfl
 
 end FirstOrder.Language.presburger

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
@@ -45,32 +45,18 @@ open Set FirstOrder Language
 theorem IsLinearSet.definable [Finite α] (hs : IsLinearSet s) : A.Definable presburger s := by
   rw [isLinearSet_iff] at hs
   rcases hs with ⟨v, t, rfl⟩
-  refine ⟨Formula.iExs t (Formula.iInf fun i : α =>
-    (Term.var (Sum.inl i)).equal
-      (Term.varsToConstants
-        ((v i : presburger.Term _) + Term.sum Finset.univ fun x : t =>
-          x.1 i • Term.var (Sum.inr (Sum.inr x))))), ?_⟩
-  ext x
-  simp only [mem_vadd_set, SetLike.mem_coe, AddSubmonoid.mem_closure_finset', Finset.univ_eq_attach,
-    nsmul_eq_mul, vadd_eq_add, ↓existsAndEq, true_and, mem_setOf_eq, Formula.realize_iExs,
-    Formula.realize_iInf, Formula.realize_equal, Term.realize_var, Sum.elim_inl,
-    Term.realize_varsToConstants, coe_con, Structure.realize_add, Structure.realize_natCast,
-    Nat.cast_id, Structure.realize_sum, Structure.realize_nsmul, Sum.elim_inr, smul_eq_mul]
-  congr! with a
-  simp_rw [Eq.comm (b := x), fun x : t => mul_comm (a x : α → ℕ) x, funext_iff]
-  congr! 1 with i
-  simp
+  apply Definable.of_definablePred
+  simp only [mem_vadd_set, SetLike.mem_coe, AddSubmonoid.mem_closure_finset', nsmul_eq_mul,
+    funext_iff, Finset.sum_apply, Pi.mul_apply, Pi.natCast_apply, Nat.cast_id, vadd_eq_add,
+    Pi.add_apply]
+  fun_prop
 
 theorem IsSemilinearSet.definable [Finite α] (hs : IsSemilinearSet s) :
     A.Definable presburger s := by
   rw [isSemilinearSet_iff] at hs
   rcases hs with ⟨S, hS, rfl⟩
-  choose φ hφ using fun s : S => (hS s.1 s.2).definable
-  refine ⟨Formula.iSup φ, ?_⟩
-  ext x
-  have := fun s hs x => Set.ext_iff.1 (hφ ⟨s, hs⟩).symm x
-  simp only [mem_setOf_eq] at this
-  simp [this]
+  simp_rw [sUnion_eq_biUnion, SetLike.mem_coe]
+  exact definable_biUnion_finset _ (fun s hs => (hS s hs).definable)
 
 namespace FirstOrder.Language.presburger
 

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Definability.lean
@@ -48,14 +48,14 @@ theorem IsLinearSet.definable [Finite α] (hs : IsLinearSet s) : A.Definable pre
   refine ⟨Formula.iExs t (Formula.iInf fun i : α =>
     (Term.var (Sum.inl i)).equal
       (Term.varsToConstants
-        ((v i : presburger.Term _) + presburger.sum Finset.univ fun x : t =>
+        ((v i : presburger.Term _) + Term.sum Finset.univ fun x : t =>
           x.1 i • Term.var (Sum.inr (Sum.inr x))))), ?_⟩
   ext x
   simp only [mem_vadd_set, SetLike.mem_coe, AddSubmonoid.mem_closure_finset', Finset.univ_eq_attach,
     nsmul_eq_mul, vadd_eq_add, ↓existsAndEq, true_and, mem_setOf_eq, Formula.realize_iExs,
     Formula.realize_iInf, Formula.realize_equal, Term.realize_var, Sum.elim_inl,
-    Term.realize_varsToConstants, coe_con, presburger.realize_add, presburger.realize_natCast,
-    Nat.cast_id, presburger.realize_sum, presburger.realize_nsmul, Sum.elim_inr, smul_eq_mul]
+    Term.realize_varsToConstants, coe_con, Structure.realize_add, Structure.realize_natCast,
+    Nat.cast_id, Structure.realize_sum, Structure.realize_nsmul, Sum.elim_inr, smul_eq_mul]
   congr! with a
   simp_rw [Eq.comm (b := x), fun x : t => mul_comm (a x : α → ℕ) x, funext_iff]
   congr! 1 with i

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -525,8 +525,12 @@ theorem DefinablePred.exists {p : M → (α → M) → Prop}
   simp_rw [(Equiv.funUnique Unit M).symm.exists_congr_left]
   exact (hp.preimage_comp (Equiv.optionEquivSumPUnit.{0} α)).exists_of_finite
 
+theorem _root_.FirstOrder.Language.Formula.definablePred_realize (φ : L.Formula α) :
+    A.DefinablePred L φ.Realize :=
+  .of_definable <| (empty_definable_iff.2 ⟨φ, rfl⟩).mono (empty_subset A)
+
 theorem DefinablePred.rel {n} (r : L.Relations n) : A.DefinablePred L (Structure.RelMap r) :=
-  .of_definable (by rw [definable_iff_exists_formula_sum]; exists (r.formula (Term.var ∘ Sum.inr)))
+  (r.formula Term.var).definablePred_realize
 
 variable (A L) in
 /-- A function from tuples of elements of `M` to `M` is definable if its graph is definable. -/
@@ -606,6 +610,10 @@ lemma Definable.preimage_map
   convert Definable.exists_of_finite (Definable.inter h_graph h_cyl) using 1
   ext v
   simp [← funext_iff]
+
+theorem DefinablePred.comp [Finite α] {f : (β → M) → α → M} (hf : A.DefinableMap L f)
+    (hp : A.DefinablePred L p) : A.DefinablePred L fun v => p (f v) :=
+  hp.preimage_map hf
 
 @[fun_prop]
 theorem DefinableFun.comp [Finite α] {g : (β → M) → α → M}

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -451,9 +451,9 @@ variable (A L) in
 def DefinablePred (p : (α → M) → Prop) : Prop :=
   A.Definable L (setOf p)
 
-def DefinablePred.of_definable (h : A.Definable L (setOf p)) : A.DefinablePred L p := h
+theorem DefinablePred.of_definable (h : A.Definable L (setOf p)) : A.DefinablePred L p := h
 
-def Definable.of_definablePred {s : Set (α → M)} (h : A.DefinablePred L (· ∈ s)) :
+theorem Definable.of_definablePred {s : Set (α → M)} (h : A.DefinablePred L (· ∈ s)) :
     A.Definable L s := h
 
 @[fun_prop]

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -123,41 +123,43 @@ theorem Definable.union {f g : Set (α → M)} (hf : A.Definable L f) (hg : A.De
   ext
   rw [hφ, hθ, mem_setOf_eq, Formula.realize_sup, mem_union, mem_setOf_eq, mem_setOf_eq]
 
-theorem definable_finset_inf {ι : Type*} {f : ι → Set (α → M)} (hf : ∀ i, A.Definable L (f i))
-    (s : Finset ι) : A.Definable L (s.inf f) := by
+theorem definable_finset_inf {ι : Type*} {f : ι → Set (α → M)} (s : Finset ι)
+    (hf : ∀ i ∈ s, A.Definable L (f i)) : A.Definable L (s.inf f) := by
   classical
-    refine Finset.induction definable_univ (fun i s _ h => ?_) s
+  induction s using Finset.induction with
+  | empty => simp
+  | insert i s _ ih =>
     rw [Finset.inf_insert]
-    exact (hf i).inter h
+    exact (hf i (by simp)).inter (ih (by grind))
 
-theorem definable_finset_sup {ι : Type*} {f : ι → Set (α → M)} (hf : ∀ i, A.Definable L (f i))
-    (s : Finset ι) : A.Definable L (s.sup f) := by
+theorem definable_finset_sup {ι : Type*} {f : ι → Set (α → M)} (s : Finset ι)
+    (hf : ∀ i ∈ s, A.Definable L (f i)) : A.Definable L (s.sup f) := by
   classical
-    refine Finset.induction definable_empty (fun i s _ h => ?_) s
+  induction s using Finset.induction with
+  | empty => simp
+  | insert i s _ ih =>
     rw [Finset.sup_insert]
-    exact (hf i).union h
+    exact (hf i (by simp)).union (ih (by grind))
 
-theorem definable_biInter_finset {ι : Type*} {f : ι → Set (α → M)}
-    (hf : ∀ i, A.Definable L (f i)) (s : Finset ι) : A.Definable L (⋂ i ∈ s, f i) := by
+theorem definable_biInter_finset {ι : Type*} {f : ι → Set (α → M)} (s : Finset ι)
+    (hf : ∀ i ∈ s, A.Definable L (f i)) : A.Definable L (⋂ i ∈ s, f i) := by
   rw [← Finset.inf_set_eq_iInter]
-  exact definable_finset_inf hf s
+  exact definable_finset_inf s hf
 
-theorem definable_biUnion_finset {ι : Type*} {f : ι → Set (α → M)}
-    (hf : ∀ i, A.Definable L (f i)) (s : Finset ι) : A.Definable L (⋃ i ∈ s, f i) := by
+theorem definable_biUnion_finset {ι : Type*} {f : ι → Set (α → M)} (s : Finset ι)
+    (hf : ∀ i ∈ s, A.Definable L (f i)) : A.Definable L (⋃ i ∈ s, f i) := by
   rw [← Finset.sup_set_eq_biUnion]
-  exact definable_finset_sup hf s
+  exact definable_finset_sup s hf
 
 theorem definable_iInter_of_finite {ι : Type*} [Finite ι] {f : ι → Set (α → M)}
     (hf : ∀ i, A.Definable L (f i)) : A.Definable L (⋂ i, f i) := by
   haveI := Fintype.ofFinite ι
-  convert definable_finset_inf hf Finset.univ using 1
-  simp
+  simpa using definable_finset_inf Finset.univ fun i _ => hf i
 
 theorem definable_iUnion_of_finite {ι : Type*} [Finite ι] {f : ι → Set (α → M)}
     (hf : ∀ i, A.Definable L (f i)) : A.Definable L (⋃ i, f i) := by
   haveI := Fintype.ofFinite ι
-  convert definable_finset_sup hf Finset.univ using 1
-  simp
+  simpa using definable_finset_sup Finset.univ fun i _ => hf i
 
 @[simp]
 theorem Definable.compl {s : Set (α → M)} (hf : A.Definable L s) : A.Definable L sᶜ := by
@@ -256,7 +258,7 @@ theorem Definable.image_comp {s : Set (β → M)} (h : A.Definable L s) (f : α 
         A.Definable L { x : α → M | x a = x (rangeSplitting f (rangeFactorization f a)) } := by
           refine fun a => ⟨(var a).equal (var (rangeSplitting f (rangeFactorization f a))), ext ?_⟩
           simp
-      refine (congr rfl (ext ?_)).mp (definable_biInter_finset h' Finset.univ)
+      refine (congr rfl (ext ?_)).mp (definable_iInter_of_finite h')
       simp
     refine (congr rfl (ext fun x => ?_)).mp (h.inter h')
     simp only [mem_inter_iff, mem_preimage, mem_image, exists_exists_and_eq_and,
@@ -436,32 +438,112 @@ end Language
 
 end FirstOrder
 
-section
+namespace Set
 
 open FirstOrder FirstOrder.Language Set Function
 
-variable {M : Type*} (L : Language) [L.Structure M]
-variable {α β : Type*} (A : Set M)
+variable {M : Type*} {A : Set M} {L : Language} [L.Structure M]
+  {α β : Type*} {f g : (α → M) → M} {p q : (α → M) → Prop}
 
-namespace Set
+variable (A L) in
+/-- The predicate version of `Set.Definable`, to allow `fun_prop`. -/
+@[fun_prop]
+def DefinablePred (p : (α → M) → Prop) : Prop :=
+  A.Definable L (setOf p)
 
+def DefinablePred.of_definable (h : A.Definable L (setOf p)) : A.DefinablePred L p := h
+
+def Definable.of_definablePred {s : Set (α → M)} (h : A.DefinablePred L (· ∈ s)) :
+    A.Definable L s := h
+
+@[fun_prop]
+theorem DefinablePred.const {h : Prop} : A.DefinablePred L fun _ : α → M => h := by
+  rcases Classical.prop_complete h with rfl | rfl
+  · exact definable_univ
+  · exact definable_empty
+
+@[fun_prop]
+theorem DefinablePred.not (hp : A.DefinablePred L p) : A.DefinablePred L fun v => ¬ p v :=
+  hp.compl
+
+@[fun_prop]
+theorem DefinablePred.and (hp : A.DefinablePred L p) (hq : A.DefinablePred L q) :
+    A.DefinablePred L fun v => p v ∧ q v :=
+  hp.inter hq
+
+@[fun_prop]
+theorem DefinablePred.or (hp : A.DefinablePred L p) (hq : A.DefinablePred L q) :
+    A.DefinablePred L fun v => p v ∨ q v :=
+  hp.union hq
+
+@[fun_prop]
+theorem DefinablePred.imp (hp : A.DefinablePred L p) (hq : A.DefinablePred L q) :
+    A.DefinablePred L fun v => p v → q v :=
+  hp.himp hq
+
+@[fun_prop]
+theorem DefinablePred.iff (hp : A.DefinablePred L p) (hq : A.DefinablePred L q) :
+    A.DefinablePred L fun v => p v ↔ q v := by
+  simp_rw [iff_iff_implies_and_implies]
+  fun_prop
+
+@[fun_prop]
+theorem DefinablePred.forall_finite [Finite β] {p : β → (α → M) → Prop}
+    (hp : ∀ i, A.DefinablePred L fun v => p i v) :
+    A.DefinablePred L fun v => ∀ i, p i v :=
+  .of_definable (by convert definable_iInter_of_finite hp; ext; simp)
+
+@[fun_prop]
+theorem DefinablePred.exists_finite [Finite β] {p : β → (α → M) → Prop}
+    (hp : ∀ i, A.DefinablePred L fun v => p i v) :
+    A.DefinablePred L fun v => ∃ i, p i v :=
+  .of_definable (by convert definable_iUnion_of_finite hp; ext; simp)
+
+@[fun_prop]
+theorem DefinablePred.forall_pi [Finite β] {p : (β → M) → (α → M) → Prop}
+    (hp : A.DefinablePred L fun v : α ⊕ β → M => p (v ∘ Sum.inr) (v ∘ Sum.inl)) :
+    A.DefinablePred L fun v => ∀ w, p w v :=
+  hp.forall_of_finite
+
+@[fun_prop]
+theorem DefinablePred.exists_pi [Finite β] {p : (β → M) → (α → M) → Prop}
+    (hp : A.DefinablePred L fun v : α ⊕ β → M => p (v ∘ Sum.inr) (v ∘ Sum.inl)) :
+    A.DefinablePred L fun v => ∃ w, p w v :=
+  hp.exists_of_finite
+
+@[fun_prop]
+theorem DefinablePred.forall {p : M → (α → M) → Prop}
+    (hp : A.DefinablePred L fun v : Option α → M => p (v none) (v ∘ some)) :
+    A.DefinablePred L fun v => ∀ x, p x v := by
+  simp_rw [(Equiv.funUnique Unit M).symm.forall_congr_left]
+  exact (hp.preimage_comp (Equiv.optionEquivSumPUnit.{0} α)).forall_of_finite
+
+@[fun_prop]
+theorem DefinablePred.exists {p : M → (α → M) → Prop}
+    (hp : A.DefinablePred L fun v : Option α → M => p (v none) (v ∘ some)) :
+    A.DefinablePred L fun v => ∃ x, p x v := by
+  simp_rw [(Equiv.funUnique Unit M).symm.exists_congr_left]
+  exact (hp.preimage_comp (Equiv.optionEquivSumPUnit.{0} α)).exists_of_finite
+
+theorem DefinablePred.rel {n} (r : L.Relations n) : A.DefinablePred L (Structure.RelMap r) :=
+  .of_definable (by rw [definable_iff_exists_formula_sum]; exists (r.formula (Term.var ∘ Sum.inr)))
+
+variable (A L) in
 /-- A function from tuples of elements of `M` to `M` is definable if its graph is definable. -/
 @[fun_prop]
 def DefinableFun (f : (α → M) → M) : Prop :=
   A.Definable L f.tupleGraph
 
+variable (A L) in
 /-- A family of functions is definable when each coordinate is definable. -/
-def DefinableMap (F : (α → M) → (β → M)) : Prop :=
+abbrev DefinableMap (F : (α → M) → (β → M)) : Prop :=
   ∀ i : β, A.DefinableFun L (fun x => F x i)
 
-variable {L A} {f : (α → M) → M}
-
-@[fun_prop, gcongr]
+@[gcongr]
 theorem DefinableFun.mono {B : Set M} (hAs : A.DefinableFun L f) (hAB : A ⊆ B) :
     B.DefinableFun L f :=
   Set.Definable.mono hAs hAB
 
-@[fun_prop]
 theorem DefinableFun.of_empty (hAs : (∅ : Set M).DefinableFun L f) :
     A.DefinableFun L f := Set.Definable.mono hAs (empty_subset A)
 
@@ -475,7 +557,6 @@ theorem definableFun_iff_empty_definableFun_with_params :
   empty_definable_iff.symm
 
 /-- A term is a definable function. -/
-@[fun_prop]
 theorem _root_.FirstOrder.Language.Term.definableFun_realize (t : L.Term α) :
     (∅ : Set M).DefinableFun L (t.realize) := by
   rw [empty_definableFun_iff]
@@ -484,15 +565,12 @@ theorem _root_.FirstOrder.Language.Term.definableFun_realize (t : L.Term α) :
   simp [tupleGraph]
 
 /-- A function symbol is a definable function. -/
-@[fun_prop]
 theorem DefinableFun.fun_symbol {n : ℕ} (f : L.Functions n) :
     (∅ : Set M).DefinableFun L (Structure.funMap f) :=
   (Term.func f Term.var).definableFun_realize
 
-variable (L)
-
+variable (L) in
 /-- A coordinate projection is a definable function. -/
-@[fun_prop]
 theorem _root_.FirstOrder.Language.definableFun_var (i : α) :
     (∅ : Set M).DefinableFun L (fun v => v i) :=
   (Term.var i).definableFun_realize
@@ -501,18 +579,20 @@ theorem _root_.FirstOrder.Language.definableFun_var (i : α) :
 theorem DefinableFun.proj {i : α} : A.DefinableFun L fun v => v i :=
   of_empty <| L.definableFun_var i
 
+variable (L) in
 /-- A constant function is a definable function. -/
-@[fun_prop]
 theorem _root_.FirstOrder.Language.definableFun_const {A : Set M} {a : M}
     (γ : Type*) (ha : a ∈ A) :
     A.DefinableFun L (fun _ : γ → M => a) := by
   rw [definableFun_iff_empty_definableFun_with_params]
   exact ((L.con (⟨a,ha⟩ : ↑A)).term).definableFun_realize
 
-variable {L}
+@[fun_prop]
+theorem DefinableFun.const {a : M} : univ.DefinableFun L fun _ : α → M => a :=
+  definableFun_const _ _ (mem_univ _)
 
 /-- The preimage of a definable set under a definable map is definable. -/
-lemma _root_.Set.Definable.preimage_map
+lemma Definable.preimage_map
     {α β : Type*} [Finite β] {F : (α → M) → (β → M)} (hF : A.DefinableMap L F)
     {S : Set (β → M)} (hS : A.Definable L S) :
     A.Definable L (F ⁻¹' S) := by
@@ -545,9 +625,9 @@ theorem DefinableFun.comp [Finite α] {g : (β → M) → α → M}
   simpa [DefinableFun, G, tupleGraph] using hf.preimage_map hG
 
 @[fun_prop]
-theorem DefinableFun.ite {p : (α → M) → Prop} {g} [DecidablePred p]
-    (hp : A.Definable L (setOf p)) (hf : DefinableFun L A f) (hg : DefinableFun L A g) :
-    DefinableFun L A fun v => if p v then f v else g v := by
+theorem DefinableFun.ite [DecidablePred p] (hp : A.DefinablePred L p) (hf : A.DefinableFun L f)
+    (hg : A.DefinableFun L g) :
+    A.DefinableFun L fun v => if p v then f v else g v := by
   let P : Set (Option α → M) := {w | p (w ∘ some)}
   have hP : A.Definable L P := hp.preimage_comp some
   simp only [DefinableFun]
@@ -556,21 +636,31 @@ theorem DefinableFun.ite {p : (α → M) → Prop} {g} [DecidablePred p]
   by_cases h : p (w ∘ some) <;> simp [tupleGraph, P, h]
 
 /-- The set where two definable functions agree is definable. -/
-lemma DefinableFun.setOf_eq {f g : (α → M) → M}
-    (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) :
-    A.Definable L {v : α → M | f v = g v} := by
-  have hF : A.DefinableMap L (fun v => ![f v, g v]) := by
-    simp [DefinableMap, *]
-  exact (Definable.diagonal L A).preimage_map hF
+lemma DefinableFun.setOf_eq (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) :
+    A.Definable L {v : α → M | f v = g v} :=
+  (Definable.diagonal L A).preimage_map (F := fun v => ![f v, g v]) (by simp [*])
 
 /-- The preimage of a constant under a definable function is definable. -/
 lemma DefinableFun.setOf_eq_const {f : (α → M) → M} (hf : A.DefinableFun L f) {a : M} (ha : a ∈ A) :
     A.Definable L {v : α → M | f v = a} :=
   hf.setOf_eq (L.definableFun_const α ha)
 
-end Set
+@[fun_prop]
+theorem DefinablePred.eq (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) :
+    A.DefinablePred L fun v => f v = g v :=
+  hf.setOf_eq hg
 
-end
+@[fun_prop]
+theorem DefinablePred.eq_const {a : M} (hf : Set.univ.DefinableFun L f) :
+    Set.univ.DefinablePred L fun v => f v = a :=
+  .eq hf .const
+
+@[fun_prop]
+theorem DefinablePred.const_eq {a : M} (hf : Set.univ.DefinableFun L f) :
+    Set.univ.DefinablePred L fun v => a = f v :=
+  .eq .const hf
+
+end Set
 
 namespace Set
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -246,6 +246,15 @@ theorem Term.realize_le {t₁ t₂ : L.Term (α ⊕ (Fin n))} {v : α → M}
     (t₁.le t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) ≤ t₂.realize (Sum.elim v xs) := by
   simp [Term.le]
 
+@[fun_prop]
+theorem _root_.Set.DefinablePred.le {A : Set M} {f g : (α → M) → M}
+    (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) : A.DefinablePred L fun v => f v ≤ g v := by
+  apply Set.DefinablePred.comp (f := fun v => ![f v, g v]) (p := fun v => v 0 ≤ v 1)
+  · simp [*]
+  · convert Formula.definablePred_realize (L := L) (α := Fin 2)
+      ((Term.var (Sum.inl 0)).le (Term.var (Sum.inl 1)))
+    simp [Formula.Realize]
+
 theorem realize_noTopOrder_iff : M ⊨ L.noTopOrderSentence ↔ NoTopOrder M := by
   simp only [noTopOrderSentence, Sentence.Realize, Formula.Realize, BoundedFormula.realize_all,
     BoundedFormula.realize_ex, BoundedFormula.realize_not, Term.realize_le]
@@ -301,6 +310,15 @@ theorem Term.realize_lt {t₁ t₂ : L.Term (α ⊕ (Fin n))}
     {v : α → M} {xs : Fin n → M} :
     (t₁.lt t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) < t₂.realize (Sum.elim v xs) := by
   simp [Term.lt, lt_iff_le_not_ge]
+
+@[fun_prop]
+theorem _root_.Set.DefinablePred.lt {A : Set M} {f g : (α → M) → M}
+    (hf : A.DefinableFun L f) (hg : A.DefinableFun L g) : A.DefinablePred L fun v => f v < g v := by
+  apply Set.DefinablePred.comp (f := fun v => ![f v, g v]) (p := fun v => v 0 < v 1)
+  · simp [*]
+  · convert Formula.definablePred_realize (L := L) (α := Fin 2)
+      ((Term.var (Sum.inl 0)).lt (Term.var (Sum.inl 1)))
+    simp [Formula.Realize]
 
 theorem realize_denselyOrdered_iff :
     M ⊨ L.denselyOrderedSentence ↔ DenselyOrdered M := by


### PR DESCRIPTION
This PR adds `DefinablePred`. It is the same as `Definable`, except the latter applies on `Set (α → M)` and the former applies on `(α → M) → Prop`. There main reason to add this is that I want to automate the definability proof of predicates, and that `fun_prop` works on functions (that include predicates) but not on sets.

For example, with appropriate `fun_prop` lemmas added, one can automate definability result like this:
```lean4
theorem IsLinearSet.definable [Finite α] (hs : IsLinearSet s) : A.Definable presburger s := by
  ...
  -- ⊢ A.DefinablePred presburger fun x ↦
  --   ∃ y, (∃ a, ∀ (x : α), y x = ∑ x_1, a x_1 * ↑x_1 x) ∧ ∀ (x_1 : α), v x_1 + y x_1 = x x_1
  fun_prop
```

This PR also removes certain `fun_prop` tags that would or should not be used in automation.

---

Note: one may argue that we don't need a new definition if we use `aesop` instead of `fun_prop`. However, in that case, we still need to write lemmas for `{x | p x}` targets (e.g. for `{x | p x ∧ q x}`), which have almost no difference with lemmas on `p` or `fun x => p x ∧ q x` directly.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #38393


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
