### PR TITLE
[Merged by Bors] - perf(Algebra/Lie): un-`simp` two theorems

### DIFF
--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -40,7 +40,6 @@ universe u v w w₁ w₂
 class LieModule.IsTrivial (L : Type v) (M : Type w) [Bracket L M] [Zero M] : Prop where
   trivial : ∀ (x : L) (m : M), ⁅x, m⁆ = 0
 
-@[simp]
 theorem trivial_lie_zero (L : Type v) (M : Type w) [Bracket L M] [Zero M] [LieModule.IsTrivial L M]
     (x : L) (m : M) : ⁅x, m⁆ = 0 :=
   LieModule.IsTrivial.trivial x m
@@ -97,8 +96,8 @@ alias commutative_ring_iff_abelian_lie_ring := isMulCommutative_iff_isLieAbelian
   refine ⟨fun h x hx y hy ↦ ?_, fun h ↦ ⟨fun ⟨x, hx⟩ ⟨y, hy⟩ ↦ ?_⟩⟩
   · let x' : lieSpan R L s := ⟨x, subset_lieSpan hx⟩
     let y' : lieSpan R L s := ⟨y, subset_lieSpan hy⟩
-    suffices ⁅x', y'⁆ = 0 by simpa [x', y', Subtype.ext_iff, -trivial_lie_zero] using this
-    simp
+    suffices ⁅x', y'⁆ = 0 by simpa [x', y', Subtype.ext_iff] using this
+    simp [trivial_lie_zero]
   · induction hx using lieSpan_induction with
     | mem w hw =>
       induction hy using lieSpan_induction with
@@ -211,7 +210,7 @@ def maxTrivHom (f : M →ₗ⁅R,L⁆ N) : maxTrivSubmodule R L M →ₗ⁅R,L�
       (congr_arg f (m.property x)).trans (map_zero _)⟩
   map_add' m n := by ext; simp
   map_smul' t m := by ext; simp
-  map_lie' {x m} := by simp
+  map_lie' {x m} := by simp [trivial_lie_zero]
 
 @[norm_cast, simp]
 theorem coe_maxTrivHom_apply (f : M →ₗ⁅R,L⁆ N) (m : maxTrivSubmodule R L M) :
@@ -395,8 +394,8 @@ instance : LieModule.IsTrivial L (TrivialLieModule R L M) where
   trivial _ _ := rfl
 
 instance : LieModule R L (TrivialLieModule R L M) where
-  smul_lie := by simp
-  lie_smul := by simp
+  smul_lie := by simp [trivial_lie_zero]
+  lie_smul := by simp [trivial_lie_zero]
 
 end TrivialLieModule
 

--- a/Mathlib/Algebra/Lie/Cochain.lean
+++ b/Mathlib/Algebra/Lie/Cochain.lean
@@ -115,7 +115,7 @@ lemma d₁₂_apply_apply (f : oneCochain R L M) (x y : L) :
 
 lemma d₁₂_apply_apply_ofTrivial [LieModule.IsTrivial L M] (f : oneCochain R L M) (x y : L) :
     d₁₂ R L M f x y = - f ⁅x, y⁆ := by
-  simp
+  simp [trivial_lie_zero]
 
 set_option backward.privateInPublic true in
 /-- The coboundary operator taking degree 2 cochains to a space containing degree 3 cochains. -/

--- a/Mathlib/Algebra/Lie/Extension.lean
+++ b/Mathlib/Algebra/Lie/Extension.lean
@@ -247,7 +247,7 @@ def ofTwoCocycle : Extension R M L where
     { toFun x := ofProd c (0, x)
       map_add' _ _ := by simp [← of_add]
       map_smul' _ _ := by simp [← of_smul]
-      map_lie' {_ _} := by simp [bracket_ofTwoCocycle] }
+      map_lie' {_ _} := by simp [trivial_lie_zero, bracket_ofTwoCocycle] }
   proj :=
     { toFun x := ((ofProd c).symm x).1
       map_add' _ _ := by simp

--- a/Mathlib/Algebra/Lie/LieTheorem.lean
+++ b/Mathlib/Algebra/Lie/LieTheorem.lean
@@ -216,7 +216,7 @@ private lemma exists_forall_lie_eq_smul_of_isSolvable_of_finite
   obtain H | ⟨A, hA, hAL⟩ := eq_top_or_exists_le_coatom (derivedSeries k L 1).toSubmodule
   · obtain _ | _ := subsingleton_or_nontrivial L
     · use 0
-      simpa [mem_weightSpace, nontrivial_iff] using exists_pair_ne V
+      simpa [trivial_lie_zero, mem_weightSpace, nontrivial_iff] using exists_pair_ne V
     · rw [LieSubmodule.toSubmodule_eq_top] at H
       exact ((derivedSeries_lt_top_of_solvable k L).ne H).elim
   lift A to LieIdeal k L

--- a/Mathlib/Algebra/Lie/Loop.lean
+++ b/Mathlib/Algebra/Lie/Loop.lean
@@ -155,7 +155,8 @@ def twoCocycleOfBilinear [CommRing A] [IsAddTorsionFree R] [Algebra A R]
         b • Φ (Finsupp.single (a + c) ⁅x, z⁆ (-b)) y =
         c • Φ (Finsupp.single (a + b) ⁅x, y⁆ (-c)) z +
         a • Φ (Finsupp.single (b + c) ⁅y, z⁆ (-a)) x by
-      simpa [sub_eq_zero, neg_add_eq_iff_eq_add, ← LinearEquiv.map_add, -LinearEquiv.map_add]
+      simpa [trivial_lie_zero, sub_eq_zero, neg_add_eq_iff_eq_add, ← LinearEquiv.map_add,
+        -LinearEquiv.map_add]
     by_cases h0 : a + b + c = 0
     · suffices b • Φ ⁅x, z⁆ y = c • Φ ⁅x, y⁆ z + a • Φ ⁅y, z⁆ x by
         simpa only [show a + b = -c by grind, show a + c = -b by grind, show b + c = -a by grind,

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -174,12 +174,12 @@ lemma traceForm_apply_eq_zero_of_mem_lcs_of_mem_center {x y : L}
   · simpa using hy
 
 -- This is barely worth having: it usually follows from `LieModule.traceForm_eq_zero_of_isNilpotent`
-@[simp] lemma traceForm_eq_zero_of_isTrivial [IsTrivial L M] :
+lemma traceForm_eq_zero_of_isTrivial [IsTrivial L M] :
     traceForm R L M = 0 := by
   ext x y
   suffices φ x ∘ₗ φ y = 0 by simp [traceForm_apply_apply, this]
   ext m
-  simp
+  simp [trivial_lie_zero]
 
 /-- Given a bilinear form `B` on a representation `M` of a nilpotent Lie algebra `L`, if `B` is
 invariant (in the sense that the action of `L` is skew-adjoint w.r.t. `B`) then components of the

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -222,7 +222,7 @@ lemma corootSpace_zero_eq_bot :
   rintro - ⟨y, hy, z, hz, rfl⟩
   suffices ⁅(⟨y, hy⟩ : H), (⟨z, hz⟩ : H)⁆ = 0 by
     simpa only [Subtype.ext_iff, LieSubalgebra.coe_bracket, ZeroMemClass.coe_zero] using this
-  simp
+  simp [trivial_lie_zero]
 
 variable {K L} in
 /-- The restriction of the Killing form to a Cartan subalgebra, as a linear equivalence to the

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basic.lean
@@ -328,8 +328,8 @@ instance : IsLieAbelian (cartanSubalgebra' b) := by
   refine ⟨fun ⟨⟨x, hx⟩, hx'⟩ ⟨⟨y, hy⟩, hy'⟩ ↦ ?_⟩
   let x' : cartanSubalgebra b := ⟨x, hx'⟩
   let y' : cartanSubalgebra b := ⟨y, hy'⟩
-  suffices ⁅x', y'⁆ = 0 by simpa [x', y', Subtype.ext_iff, -trivial_lie_zero] using this
-  simp
+  suffices ⁅x', y'⁆ = 0 by simpa [x', y', Subtype.ext_iff] using this
+  simp [trivial_lie_zero]
 
 instance : LieModule.IsTriangularizable R (cartanSubalgebra' b) (b.support ⊕ ι → R) := by
   refine ⟨fun ⟨⟨x, hx'⟩, hx⟩ ↦ ?_⟩


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
