### PR TITLE
[Merged by Bors] - refactor(Analysis): golf `Mathlib/Analysis/Complex/Spectrum`

### DIFF
--- a/Mathlib/Analysis/Complex/Spectrum.lean
+++ b/Mathlib/Analysis/Complex/Spectrum.lean
@@ -17,13 +17,9 @@ public section
 namespace SpectrumRestricts
 variable {A : Type*} [Ring A]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma real_iff [Algebra ℂ A] {a : A} :
     SpectrumRestricts a Complex.reCLM ↔ ∀ x ∈ spectrum ℂ a, x = x.re := by
-  refine ⟨fun h x hx ↦ ?_, fun h ↦ ?_⟩
-  · obtain ⟨x, -, rfl⟩ := h.algebraMap_image.symm ▸ hx
-    simp
-  · exact .of_subset_range_algebraMap Complex.ofReal_re fun x hx ↦ ⟨x.re, (h x hx).symm⟩
+  simp [spectrumRestricts_iff, Set.LeftInvOn, Function.LeftInverse, eq_comm]
 
 end SpectrumRestricts
 


### PR DESCRIPTION
- golfs `Complex/Spectrum` by proving `SpectrumRestricts.real_iff` directly with `simp`
- removes the local `backward.isDefEq.respectTransparency` option from that proof

Extracted from #37968

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)