### PR TITLE
[Merged by Bors] - feat(Analysis/Normed): the `SeminormedRing` structure determined by a `RingSeminorm`

### DIFF
--- a/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
@@ -153,6 +153,12 @@ theorem seminorm_one_eq_one_iff_ne_zero (hp : p 1 ≤ 1) : p 1 = 1 ↔ p ≠ 0 :
   · refine hp.antisymm ((le_mul_iff_one_le_left hp0).1 ?_)
     simpa only [one_mul] using map_mul_le_mul p (1 : R) _
 
+/-- The `SeminormedRing` structure on a ring `R` determined by a `RingSeminorm`. -/
+abbrev toSeminormedRing : SeminormedRing R where
+  __ := ‹Ring R›
+  __ := p.toAddGroupSeminorm.toSeminormedAddCommGroup
+  norm_mul_le := map_mul_le_mul p
+
 end Ring
 
 section CommRing
@@ -259,7 +265,7 @@ instance [DecidableEq R] : Inhabited (RingNorm R) :=
 
 end NonUnitalRing
 
-/-- The `NormedRing` structure on a ring `R` determined by a `RingNorm` -/
+/-- The `NormedRing` structure on a ring `R` determined by a `RingNorm`. -/
 -- See note |reducible non-instances]
 abbrev toNormedRing [Ring R] (f : RingNorm R) : NormedRing R where
   __ := ‹Ring R›


### PR DESCRIPTION
Parallel to [RingNorm.toNormedRing](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.html#RingNorm.toNormedRing), defines the `SeminormedRing` structure on a ring `R` determined by a `RingSeminorm`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
