### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Maps): `G →g G.map f`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Coloring/VertexColoring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring/VertexColoring.lean
@@ -179,6 +179,13 @@ theorem isEmpty_of_colorable_zero (h : G.Colorable 0) : IsEmpty V := by
 lemma colorable_zero_iff : G.Colorable 0 ↔ IsEmpty V :=
   ⟨isEmpty_of_colorable_zero, fun _ ↦ .of_isEmpty 0⟩
 
+/-- A coloring of a graph `G` is a homomorphism from it to the mapped graph.
+This is `Hom.map` spelled using colorings. The mapped graph `G.map f` can be thought of as taking
+the original graph `G` and considering every color class (independent set) as a single vertex. -/
+@[simps!]
+def Coloring.homMap {α : Type*} (f : G.Coloring α) : G →g G.map f :=
+  .map f G f.map_adj
+
 /-- If `G` is `n`-colorable, then mapping the vertices of `G` produces an `n`-colorable simple
 graph. -/
 theorem Colorable.map (f : V ↪ β) [NeZero n] (hc : G.Colorable n) : (G.map f).Colorable n := by

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring/VertexColoring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring/VertexColoring.lean
@@ -183,7 +183,7 @@ lemma colorable_zero_iff : G.Colorable 0 ↔ IsEmpty V :=
 This is `Hom.map` spelled using colorings. The mapped graph `G.map f` can be thought of as taking
 the original graph `G` and considering every color class (independent set) as a single vertex. -/
 @[simps!]
-def Coloring.homMap {α : Type*} (f : G.Coloring α) : G →g G.map f :=
+abbrev Coloring.homMap {α : Type*} (f : G.Coloring α) : G →g G.map f :=
   .map f G f.map_adj
 
 /-- If `G` is `n`-colorable, then mapping the vertices of `G` produces an `n`-colorable simple

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -370,6 +370,15 @@ theorem injective_of_top_hom (f : (⊤ : SimpleGraph V) →g G') : Function.Inje
   contrapose! h
   exact G'.ne_of_adj (map_adj _ ((top_adj _ _).mpr h))
 
+/-- A function `f` that is injective on adjacent vertices in a graph `G`
+(equivalently `f` is a valid `W`-coloring of `G`, or `G ≤ comap ⊤ f`)
+is a homomorphism from `G` to the mapped graph. -/
+@[simps]
+protected def map (f : V → W) (G : SimpleGraph V) (h : ∀ {u v}, G.Adj u v → f u ≠ f v) :
+    G →g G.map f where
+  toFun := f
+  map_rel' {u v} hadj := ⟨h hadj, u, v, hadj, rfl, rfl⟩
+
 /-- There is a homomorphism to a graph from a comapped graph.
 When the function is injective, this is an embedding (see `SimpleGraph.Embedding.comap`). -/
 @[simps]


### PR DESCRIPTION
The existing `SimpleGraph.Embedding.map` takes an embedding and lifts it to a graph embedding `G ↪g G.map f`.
#36130 generalized `SimpleGraph.map` from embeddings to functions, so now we can get a graph homomorphism `G →g G.map f` without requiring that `f` is injective, although we still have to require that it is injective on adjacent vertices (aka a valid coloring).
This adds `Coloring.homMap`, and `Hom.map` which is identical but avoids coloring terminology/spelling.

---
I'd love for suggestions to improve the docstring of `Coloring.homMap`, I'm not sure about it :)

Are the two versions a good idea, or should we just have the coloring one? (we have `{Hom,Embedding,Iso}.comap` but only `{Embedding,Iso}.map`)

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
