### PR TITLE
[Merged by Bors] - doc(CategoryTheory): fix category docstrings

### DIFF
--- a/Mathlib/CategoryTheory/Discrete/SumsProducts.lean
+++ b/Mathlib/CategoryTheory/Discrete/SumsProducts.lean
@@ -73,7 +73,7 @@ instance prod : IsDiscrete (C × D) where
   subsingleton x y := inferInstanceAs (Subsingleton ((x.1 ⟶ y.1) × (x.2 ⟶ y.2)))
   eq_of_hom f := Prod.ext (IsDiscrete.eq_of_hom f.1) (IsDiscrete.eq_of_hom f.2)
 
-/-- A product of discrete categories is discrete. -/
+/-- A sum of discrete categories is discrete. -/
 instance sum : IsDiscrete (C ⊕ C') where
   subsingleton x y :=
     { allEq f g := by

--- a/Mathlib/CategoryTheory/Enriched/Limits/HasConicalPullbacks.lean
+++ b/Mathlib/CategoryTheory/Enriched/Limits/HasConicalPullbacks.lean
@@ -22,7 +22,7 @@ open Limits
 variable (V : Type u') [Category.{v'} V] [MonoidalCategory V]
 variable {C : Type u} [Category.{v} C] [EnrichedOrdinaryCategory V C]
 
-/-- `HasPullback f g` represents the mere existence of a conical limit cone for the pair
+/-- `HasConicalPullback f g` represents the mere existence of a conical limit cone for the pair
 of morphisms `f : X ⟶ Z` and `g : Y ⟶ Z` -/
 abbrev HasConicalPullback {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :=
   HasConicalLimit V (cospan f g)

--- a/Mathlib/CategoryTheory/FinCategory/AsType.lean
+++ b/Mathlib/CategoryTheory/FinCategory/AsType.lean
@@ -74,7 +74,7 @@ noncomputable def asTypeEquivObjAsType : AsType α ≌ ObjAsType α where
 noncomputable instance asTypeFinCategory : FinCategory (AsType α) where
   fintypeHom := fun _ _ => show Fintype (Fin _) from inferInstance
 
-/-- The constructed category (`ObjAsType α`) is indeed equivalent to `α`. -/
+/-- The constructed category (`AsType α`) is indeed equivalent to `α`. -/
 noncomputable def equivAsType : AsType α ≌ α :=
   (asTypeEquivObjAsType α).trans (objAsTypeEquiv α)
 


### PR DESCRIPTION
- fixes the docstring for discrete sums to refer to sums rather than products
- fixes the conical pullback docstring to name `HasConicalPullback`
- fixes the `AsType` equivalence docstring to refer to `AsType α`

Extracted from #38413

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)