### PR TITLE
feat(Combinatorics/Sperner): abstract door-counting parity theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3499,8 +3499,6 @@ public import Mathlib.Combinatorics.Quiver.SingleObj
 public import Mathlib.Combinatorics.Quiver.Subquiver
 public import Mathlib.Combinatorics.Quiver.Symmetric
 public import Mathlib.Combinatorics.Schnirelmann
-public import Mathlib.Combinatorics.Sperner.Basic
-public import Mathlib.Combinatorics.Sperner.Triangulation
 public import Mathlib.Combinatorics.SetFamily.AhlswedeZhang
 public import Mathlib.Combinatorics.SetFamily.Compression.Down
 public import Mathlib.Combinatorics.SetFamily.Compression.UV
@@ -3584,6 +3582,8 @@ public import Mathlib.Combinatorics.SimpleGraph.Walk.Maps
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Operations
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Subwalks
 public import Mathlib.Combinatorics.SimpleGraph.Walk.Traversal
+public import Mathlib.Combinatorics.Sperner.Basic
+public import Mathlib.Combinatorics.Sperner.Triangulation
 public import Mathlib.Combinatorics.Tiling.Tile
 public import Mathlib.Combinatorics.Young.SemistandardTableau
 public import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3499,6 +3499,8 @@ public import Mathlib.Combinatorics.Quiver.SingleObj
 public import Mathlib.Combinatorics.Quiver.Subquiver
 public import Mathlib.Combinatorics.Quiver.Symmetric
 public import Mathlib.Combinatorics.Schnirelmann
+public import Mathlib.Combinatorics.Sperner.Basic
+public import Mathlib.Combinatorics.Sperner.Triangulation
 public import Mathlib.Combinatorics.SetFamily.AhlswedeZhang
 public import Mathlib.Combinatorics.SetFamily.Compression.Down
 public import Mathlib.Combinatorics.SetFamily.Compression.UV

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -60,11 +60,12 @@ open Finset
 /-- A fixed-point-free involution on a finset has even
 cardinality: every element pairs with its distinct image. -/
 theorem Finset.even_card_of_fpf_invol {α : Type*}
-    [DecidableEq α] (S : Finset α) (f : α → α)
+    (S : Finset α) (f : α → α)
     (hInv : ∀ x ∈ S, f (f x) = x)
     (hMem : ∀ x ∈ S, f x ∈ S)
     (hNe : ∀ x ∈ S, f x ≠ x) :
     Even S.card := by
+  classical
   -- Pair each element with its involution image: ∑ _ ∈ S, (1 : ZMod 2) = 0
   have hsum : ∑ _ ∈ S, (1 : ZMod 2) = 0 :=
     Finset.sum_involution (fun a _ => f a)
@@ -107,10 +108,11 @@ private lemma door_filter_empty_of_missing_color (d : ℕ)
 
 /-- If natural numbers indexed by a finset sum to 1, exactly one
 equals 1 and the rest equal 0. -/
-private lemma exists_of_sum_eq_one {ι : Type*} [DecidableEq ι]
+private lemma exists_of_sum_eq_one {ι : Type*}
     {s : Finset ι} {f : ι → ℕ}
     (hsum : ∑ i ∈ s, f i = 1) :
     ∃ a ∈ s, f a = 1 ∧ ∀ b ∈ s, b ≠ a → f b = 0 := by
+  classical
   have ⟨a, ha, hfa⟩ : ∃ a ∈ s, 0 < f a := by
     by_contra h; push_neg at h
     have := Finset.sum_eq_zero (fun i hi =>
@@ -527,7 +529,7 @@ theorem even_card_interiorDoors
       obtain ⟨s', k'⟩ := sk
       have hadj_back :=
         K.adj_symm p.1 p.2 s' k' hadj_eq
-      show adjMap K (adjMap K p) = p
+      change adjMap K (adjMap K p) = p
       simp only [adjMap, hadj_eq, hadj_back]
   · intro p hp
     simp only [S, mem_filter, mem_univ,
@@ -539,7 +541,7 @@ theorem even_card_interiorDoors
       obtain ⟨s', k'⟩ := sk
       have hadj_back :=
         K.adj_symm p.1 p.2 s' k' hadj_eq
-      show IsDoor c K (adjMap K p).1
+      change IsDoor c K (adjMap K p).1
           (adjMap K p).2 ∧
         K.adj (adjMap K p).1 (adjMap K p).2 ≠ none
       simp only [adjMap, hadj_eq]

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -1,0 +1,732 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+module
+
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Algebra.Ring.Parity
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.ZMod.Basic
+
+/-!
+# Abstract Sperner's Lemma
+
+We prove Sperner's lemma for an abstract cell complex satisfying
+adjacency axioms, via the door-counting parity argument.
+
+## Main definitions
+
+* `CellComplex`: An abstract cell complex with adjacency.
+* `CellComplex.IsPanchromatic`: A cell whose vertices receive
+  all `d + 1` colors.
+* `CellComplex.IsDoor`: A codimension-1 face (door) whose
+  remaining vertices receive colors `{0, ..., d - 1}`.
+
+## Main results
+
+* `CellComplex.sperner_parity`: The panchromatic cell count is
+  congruent mod 2 to the boundary door count.
+* `CellComplex.sperner`: If boundary doors are odd, a
+  panchromatic cell exists.
+
+## Implementation notes
+
+The `CellComplex` structure axiomatizes exactly the adjacency
+properties needed for the door-counting proof, without assuming
+any geometric embedding. This follows the approach suggested by
+Yaël Dillies on mathlib4#25231: prove the combinatorial core
+abstractly, then separately verify that geometric simplicial
+complexes satisfy the axioms.
+
+Interior doors pair via the adjacency involution (even count).
+Boundary doors are unpaired. A per-cell parity argument shows
+total doors ≡ panchromatic cells (mod 2).
+
+## References
+
+* [M. De Longueville, *A Course in Topological Combinatorics*]
+
+## Tags
+
+Sperner, combinatorics, parity, triangulation, door-counting
+-/
+
+open Finset
+
+/-- A fixed-point-free involution on a finset has even
+cardinality: every element pairs with its distinct image. -/
+theorem Finset.even_card_of_fpf_invol {α : Type*}
+    [DecidableEq α] (S : Finset α) (f : α → α)
+    (hInv : ∀ x ∈ S, f (f x) = x)
+    (hMem : ∀ x ∈ S, f x ∈ S)
+    (hNe : ∀ x ∈ S, f x ≠ x) :
+    Even S.card := by
+  -- Pair each element with its involution image: ∑ _ ∈ S, (1 : ZMod 2) = 0
+  have hsum : ∑ _ ∈ S, (1 : ZMod 2) = 0 :=
+    Finset.sum_involution (fun a _ => f a)
+      (fun _ _ => by decide)
+      (fun a ha _ => hNe a ha)
+      hMem hInv
+  simp only [Finset.sum_const, nsmul_eq_mul, mul_one] at hsum
+  obtain ⟨k, hk⟩ := (ZMod.natCast_eq_zero_iff _ 2).mp hsum
+  exact ⟨k, by omega⟩
+
+section DoorCountParity
+
+/-! ### Door count parity
+
+The central combinatorial fact: the number of "door positions"
+of a coloring `f : Fin (d+1) → Fin (d+1)` has parity equal to
+the surjectivity indicator of `f`.
+
+The key invariant is the **fiber structure** of the coloring.
+A surjection `Fin (d+1) → Fin d` has exactly one fiber of
+size 2 (by pigeonhole), giving two door positions (even).
+A bijection `Fin (d+1) → Fin (d+1)` has exactly one door
+position. A non-surjection missing some lower color has none.
+-/
+
+/-- If a lower color `j₀ : Fin d` has no preimage under `f`,
+then no position is a door: we cannot cover all of
+`{0, ..., d-1}` while omitting any vertex. -/
+private lemma door_filter_empty_of_missing_color (d : ℕ)
+    (f : Fin (d + 1) → Fin (d + 1))
+    (j₀ : Fin d)
+    (hmiss : ¬∃ i : Fin (d + 1),
+      f i = ⟨j₀.val, by omega⟩) :
+    (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+        f i = ⟨j.val, by omega⟩)) = ∅ := by
+  rw [filter_eq_empty_iff]
+  intro k _; push_neg
+  exact ⟨j₀, fun i _ h => hmiss ⟨i, h⟩⟩
+
+/-- If natural numbers indexed by a finset sum to 1, exactly one
+equals 1 and the rest equal 0. -/
+private lemma exists_of_sum_eq_one {ι : Type*} [DecidableEq ι]
+    {s : Finset ι} {f : ι → ℕ}
+    (hsum : ∑ i ∈ s, f i = 1) :
+    ∃ a ∈ s, f a = 1 ∧ ∀ b ∈ s, b ≠ a → f b = 0 := by
+  have ⟨a, ha, hfa⟩ : ∃ a ∈ s, 0 < f a := by
+    by_contra h; push_neg at h
+    have := Finset.sum_eq_zero (fun i hi =>
+      Nat.eq_zero_of_le_zero (h i hi))
+    omega
+  have hle : f a ≤ 1 :=
+    hsum ▸ Finset.single_le_sum
+      (fun _ _ => Nat.zero_le _) ha
+  have hfa_eq : f a = 1 := by omega
+  have hrest : ∑ x ∈ s.erase a, f x = 0 := by
+    have := Finset.add_sum_erase s f ha
+    omega
+  exact ⟨a, ha, hfa_eq, fun b hb hne =>
+    Nat.eq_zero_of_le_zero
+      ((Finset.single_le_sum (fun _ _ => Nat.zero_le _)
+        (Finset.mem_erase.mpr ⟨hne, hb⟩)).trans
+        hrest.le)⟩
+
+/-- **Pigeonhole for one extra element**: a surjection
+`Fin (d+1) → Fin d` has exactly one fiber of size 2, with
+all other fibers of size 1. -/
+private lemma surjection_unique_dup_fiber (d : ℕ)
+    (f : Fin (d + 1) → Fin d)
+    (hcov : ∀ j : Fin d, ∃ i, f i = j) :
+    ∃ c₀ : Fin d,
+      (univ.filter
+        (fun i : Fin (d + 1) => f i = c₀)).card = 2 ∧
+      ∀ c ≠ c₀, (univ.filter
+        (fun i : Fin (d + 1) => f i = c)).card =
+        1 := by
+  have hcard_ge : ∀ c : Fin d,
+      (univ.filter
+        (fun i : Fin (d + 1) => f i = c)).card ≥ 1 := by
+    intro c; obtain ⟨i, hi⟩ := hcov c
+    exact Finset.card_pos.mpr
+      ⟨i, mem_filter.mpr ⟨mem_univ _, hi⟩⟩
+  have htotal : ∑ c : Fin d,
+      (univ.filter
+        (fun i : Fin (d + 1) => f i = c)).card =
+      d + 1 := by
+    rw [← Finset.card_biUnion (by
+      intro x _ y _ hxy
+      apply Finset.disjoint_filter.mpr
+      intro i _ h1 h2; exact hxy (h1.symm.trans h2))]
+    have hbU : Finset.biUnion univ (fun c : Fin d =>
+        univ.filter
+          (fun i : Fin (d + 1) => f i = c)) =
+        univ := by
+      ext i; constructor
+      · intro _; exact mem_univ _
+      · intro _
+        rw [mem_biUnion]
+        exact ⟨f i, mem_univ _,
+          mem_filter.mpr ⟨mem_univ _, rfl⟩⟩
+    rw [hbU, card_univ, Fintype.card_fin]
+  have hexcess : ∑ c : Fin d,
+      ((univ.filter
+        (fun i : Fin (d + 1) => f i = c)).card - 1) =
+      1 := by
+    have hadd : ∀ c : Fin d,
+        (univ.filter
+          (fun i : Fin (d + 1) => f i = c)).card -
+          1 + 1 =
+        (univ.filter
+          (fun i : Fin (d + 1) => f i = c)).card := by
+      intro c; have := hcard_ge c; omega
+    have := Finset.sum_congr
+      (show (univ : Finset (Fin d)) = univ from rfl)
+      (fun c _ => hadd c)
+    simp only [Finset.sum_add_distrib,
+      Finset.sum_const, card_univ, Fintype.card_fin,
+      htotal, smul_eq_mul] at this
+    omega
+  obtain ⟨c₀, _, hc₀_eq, hc₀_rest⟩ :=
+    exists_of_sum_eq_one hexcess
+  exact ⟨c₀,
+    by have := hcard_ge c₀; omega,
+    fun c hc => by
+      have := hc₀_rest c (mem_univ _) hc
+      have := hcard_ge c; omega⟩
+
+/-- When `f : Fin (d+1) → Fin d` is surjective, the door
+positions are exactly the two elements of the unique fiber of
+size 2. In particular, the door count is even. -/
+private lemma even_card_doors_of_surjective (d : ℕ)
+    (f : Fin (d + 1) → Fin d)
+    (hcov : ∀ j : Fin d, ∃ i, f i = j) :
+    Even (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d,
+        ∃ i : Fin (d + 1), i ≠ k ∧ f i = j)).card := by
+  obtain ⟨c₀, hc₀_eq, hc₀_rest⟩ :=
+    surjection_unique_dup_fiber d f hcov
+  obtain ⟨k₁, k₂, hk₁, hk₂, hne12, hpair⟩ :
+      ∃ k₁ k₂ : Fin (d + 1),
+        f k₁ = c₀ ∧ f k₂ = c₀ ∧ k₁ ≠ k₂ ∧
+        univ.filter
+          (fun i : Fin (d + 1) => f i = c₀) =
+          {k₁, k₂} := by
+    rw [Finset.card_eq_two] at hc₀_eq
+    obtain ⟨a, b, hab, habset⟩ := hc₀_eq
+    have ha := (mem_filter.mp
+      (habset ▸ mem_insert_self a {b})).2
+    have hb := (mem_filter.mp
+      (habset ▸ mem_insert.mpr
+        (Or.inr (mem_singleton.mpr rfl)))).2
+    exact ⟨a, b, ha, hb, hab, habset⟩
+  suffices hset : univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d,
+        ∃ i : Fin (d + 1), i ≠ k ∧ f i = j) =
+      {k₁, k₂} by
+    rw [hset, card_pair hne12]; exact even_two
+  ext k
+  simp only [mem_filter, mem_univ, true_and,
+    mem_insert, mem_singleton]
+  constructor
+  · intro hk
+    obtain ⟨i, hi_ne, hi_eq⟩ := hk (f k)
+    have hfk : f k = c₀ := by
+      by_contra hne
+      have hmult1 := hc₀_rest (f k) hne
+      rw [Finset.card_eq_one] at hmult1
+      obtain ⟨a, ha⟩ := hmult1
+      have hk_in : k ∈ univ.filter
+          (fun i : Fin (d + 1) => f i = f k) :=
+        mem_filter.mpr ⟨mem_univ _, rfl⟩
+      have hi_in : i ∈ univ.filter
+          (fun i : Fin (d + 1) => f i = f k) :=
+        mem_filter.mpr ⟨mem_univ i, hi_eq⟩
+      rw [ha] at hk_in hi_in
+      rw [Finset.mem_singleton] at hk_in hi_in
+      exact hi_ne (hk_in ▸ hi_in)
+    have hk_mem : k ∈ univ.filter
+        (fun i : Fin (d + 1) => f i = c₀) :=
+      mem_filter.mpr ⟨mem_univ k, hfk⟩
+    rw [hpair] at hk_mem
+    rw [mem_insert, mem_singleton] at hk_mem
+    exact hk_mem
+  · intro hk j
+    obtain ⟨i₀, hi₀⟩ := hcov j
+    by_cases hik : i₀ = k
+    · rcases hk with heq | heq
+      · have hfk : f k = c₀ := heq ▸ hk₁
+        have hj_c0 : j = c₀ := by
+          rw [← hi₀, hik, hfk]
+        exact ⟨k₂, (heq ▸ hne12).symm,
+          by rw [hj_c0, hk₂]⟩
+      · have hfk : f k = c₀ := heq ▸ hk₂
+        have hj_c0 : j = c₀ := by
+          rw [← hi₀, hik, hfk]
+        exact ⟨k₁, heq ▸ hne12,
+          by rw [hj_c0, hk₁]⟩
+    · exact ⟨i₀, hik, hi₀⟩
+
+/-- A bijection `Fin (d+1) → Fin (d+1)` has exactly one door
+position: the unique preimage of the top color `d`. -/
+private lemma door_count_of_surj (d : ℕ)
+    (f : Fin (d + 1) → Fin (d + 1))
+    (hsurj : Function.Surjective f) :
+    (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+        f i = ⟨j.val, by omega⟩)).card = 1 := by
+  have hinj :=
+    Finite.injective_iff_surjective.mpr hsurj
+  obtain ⟨k₀, hk₀⟩ := hsurj ⟨d, by omega⟩
+  have huniq : ∀ k, f k = ⟨d, by omega⟩ → k = k₀ :=
+    fun k hk => hinj (hk.trans hk₀.symm)
+  suffices hset : univ.filter
+      (fun k : Fin (d + 1) =>
+        ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+          f i = ⟨j.val, by omega⟩) = {k₀} by
+    rw [hset, card_singleton]
+  ext k
+  simp only [mem_filter, mem_univ, true_and,
+    mem_singleton]
+  constructor
+  · intro hk; by_contra hne
+    have hfk_ne : f k ≠ ⟨d, by omega⟩ :=
+      fun h => hne (huniq k h)
+    have hfk_val_ne : (f k).val ≠ d :=
+      fun h => hfk_ne (Fin.ext h)
+    have hfk_lt : (f k).val < d := by
+      have := (f k).isLt; omega
+    obtain ⟨i, hi_ne, hi_eq⟩ :=
+      hk ⟨(f k).val, hfk_lt⟩
+    have hval : f i = f k :=
+      Fin.ext (Fin.ext_iff.mp hi_eq)
+    exact hi_ne (hinj hval)
+  · intro hk; subst hk; intro ⟨j, hj⟩
+    obtain ⟨i, hi⟩ := hsurj ⟨j, by omega⟩
+    exact ⟨i,
+      fun hik => by
+        subst hik; rw [hk₀] at hi
+        simp only [Fin.mk.injEq] at hi; omega,
+      by rw [hi]⟩
+
+/-- A non-surjection `Fin (d+1) → Fin (d+1)` has an even
+number of door positions (0 if a lower color is missing,
+or paired via the duplicated fiber if no top color appears
+but the truncation is surjective). -/
+private lemma door_count_even_of_not_surj (d : ℕ)
+    (f : Fin (d + 1) → Fin (d + 1))
+    (hnsurj : ¬Function.Surjective f) :
+    Even (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+        f i = ⟨j.val, by omega⟩)).card := by
+  by_cases hd_app : ∃ i, f i = ⟨d, by omega⟩
+  · -- Top color d has a preimage but f is not surjective,
+    -- so some lower color j₀ is missing. No doors.
+    have ⟨j₀, hj₀⟩ : ∃ j : Fin d,
+        ¬∃ i, f i =
+          ⟨j.val, Nat.lt_succ_of_lt j.isLt⟩ := by
+      by_contra hall; push_neg at hall; apply hnsurj
+      intro ⟨y, hy⟩; by_cases hyd : y = d
+      · subst hyd; exact hd_app
+      · exact hall ⟨y, by omega⟩
+    rw [Finset.card_eq_zero.mpr
+      (door_filter_empty_of_missing_color d f j₀ hj₀)]
+    exact ⟨0, by omega⟩
+  · -- Top color d never appears. Truncate to
+    -- g : Fin (d+1) → Fin d.
+    push_neg at hd_app
+    have hlt : ∀ i, (f i).val < d := by
+      intro i; have := (f i).isLt
+      by_contra h; push_neg at h
+      have hlt2 := (f i).isLt
+      have : (f i).val = d := by omega
+      exact hd_app i (Fin.ext this)
+    let g : Fin (d + 1) → Fin d :=
+      fun i => ⟨(f i).val, hlt i⟩
+    by_cases hgsurj : Function.Surjective g
+    · -- g surjective: doors pair via the duplicated fiber.
+      have heven :=
+        even_card_doors_of_surjective d g hgsurj
+      suffices heq : univ.filter
+          (fun k : Fin (d + 1) =>
+            ∀ j : Fin d,
+              ∃ i : Fin (d + 1), i ≠ k ∧
+                f i = ⟨j.val, by omega⟩) =
+          univ.filter (fun k : Fin (d + 1) =>
+            ∀ j : Fin d,
+              ∃ i : Fin (d + 1),
+                i ≠ k ∧ g i = j) by
+        rw [heq]; exact heven
+      ext k
+      simp only [mem_filter, mem_univ, true_and]
+      constructor <;> intro h j
+      · obtain ⟨i, hi, hfi⟩ := h j
+        refine ⟨i, hi, Fin.ext ?_⟩
+        change (f i).val = j.val
+        exact congr_arg Fin.val hfi
+      · obtain ⟨i, hi, hgi⟩ := h j
+        refine ⟨i, hi, Fin.ext ?_⟩
+        change (f i).val = j.val
+        exact congr_arg Fin.val hgi
+    · -- g not surjective: some lower color missing. No doors.
+      have ⟨j₀, hj₀⟩ :
+          ∃ j : Fin d, ¬∃ i, g i = j := by
+        by_contra h; push_neg at h; exact hgsurj h
+      suffices h0 : (univ.filter
+          (fun k : Fin (d + 1) =>
+            ∀ j : Fin d,
+              ∃ i : Fin (d + 1), i ≠ k ∧
+                f i = ⟨j.val, by omega⟩)).card =
+          0 by rw [h0]; exact ⟨0, by omega⟩
+      rw [Finset.card_eq_zero, filter_eq_empty_iff]
+      intro k _; push_neg
+      exact ⟨j₀, fun i _ h =>
+        hj₀ ⟨i, Fin.ext (show (g i).val = j₀.val by
+          change (f i).val = j₀.val
+          exact congr_arg Fin.val h)⟩⟩
+
+/-- **Door count parity**: the number of door positions of a
+coloring `f : Fin (d+1) → Fin (d+1)` has parity equal to 1
+if `f` is surjective (bijective), and 0 otherwise. -/
+theorem door_count_parity (d : ℕ)
+    (f : Fin (d + 1) → Fin (d + 1)) :
+    (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+        f i = ⟨j.val, by omega⟩)).card % 2 =
+    if Function.Surjective f then 1 else 0 := by
+  by_cases hsurj : Function.Surjective f
+  · rw [if_pos hsurj, door_count_of_surj d f hsurj]
+  · rw [if_neg hsurj]
+    exact Nat.even_iff.mp
+      (door_count_even_of_not_surj d f hsurj)
+
+end DoorCountParity
+
+/-- An abstract cell complex with adjacency, parametrized by
+vertex type `V` and dimension `d`. Each cell has `d + 1`
+vertices from `V`. Interior codimension-1 faces pair via
+`adj`; boundary faces have `adj = none`. -/
+structure CellComplex (V : Type*) [DecidableEq V]
+    (d : ℕ) where
+  /-- The type of top-dimensional cells. -/
+  Cell : Type
+  /-- Decidable equality on cells. -/
+  cellDecEq : DecidableEq Cell
+  /-- Finiteness of cells. -/
+  cellFintype : Fintype Cell
+  /-- The `d + 1` vertices of each cell. -/
+  vertex : Cell → Fin (d + 1) → V
+  /-- Adjacency: the face opposite vertex `k` in cell `s`
+  is shared with another cell, or is a boundary face. -/
+  adj : Cell → Fin (d + 1) →
+    Option (Cell × Fin (d + 1))
+  /-- Adjacency is symmetric. -/
+  adj_symm : ∀ s k s' k',
+    adj s k = some (s', k') →
+    adj s' k' = some (s, k)
+  /-- Adjacent cells share the codimension-1 face. -/
+  adj_vertex : ∀ s k s' k',
+    adj s k = some (s', k') →
+    (univ.erase k).image (vertex s) =
+    (univ.erase k').image (vertex s')
+  /-- Adjacent cells are distinct. -/
+  adj_ne : ∀ s k s' k',
+    adj s k = some (s', k') → s ≠ s'
+
+attribute [instance] CellComplex.cellDecEq
+attribute [instance] CellComplex.cellFintype
+
+namespace CellComplex
+
+variable {V : Type*} [DecidableEq V] {d : ℕ}
+
+/-- A cell is *panchromatic* (fully colored): the coloring
+restricted to its vertices is surjective onto `Fin (d+1)`. -/
+def IsPanchromatic (c : V → Fin (d + 1))
+    (K : CellComplex V d) (s : K.Cell) : Prop :=
+  Function.Surjective (c ∘ K.vertex s)
+
+/-- A facet `(s, k)` is a *door*: removing vertex `k`, the
+remaining `d` vertices carry all colors `{0, ..., d-1}`. -/
+def IsDoor (c : V → Fin (d + 1))
+    (K : CellComplex V d) (s : K.Cell)
+    (k : Fin (d + 1)) : Prop :=
+  ∀ j : Fin d, ∃ i : Fin (d + 1),
+    i ≠ k ∧ c (K.vertex s i) = Fin.castSucc j
+
+instance decidableIsPanchromatic
+    (c : V → Fin (d + 1)) (K : CellComplex V d)
+    (s : K.Cell) :
+    Decidable (IsPanchromatic c K s) := by
+  unfold IsPanchromatic Function.Surjective
+  exact inferInstance
+
+instance decidableIsDoor (c : V → Fin (d + 1))
+    (K : CellComplex V d) (s : K.Cell)
+    (k : Fin (d + 1)) :
+    Decidable (IsDoor c K s k) := by
+  unfold IsDoor; exact inferInstance
+
+/-- The adjacency map: sends `(s, k)` to its adjacent
+cell-face pair, or to itself if on the boundary. -/
+private def adjMap (K : CellComplex V d)
+    (p : K.Cell × Fin (d + 1)) :
+    K.Cell × Fin (d + 1) :=
+  match K.adj p.1 p.2 with
+  | some (s', k') => (s', k')
+  | none => p
+
+/-- A door transfers through a shared face (one direction). -/
+private lemma isDoor_of_shared_face
+    {c : V → Fin (d + 1)} {K : CellComplex V d}
+    {s : K.Cell} {k : Fin (d + 1)}
+    {s' : K.Cell} {k' : Fin (d + 1)}
+    (hvert :
+      (univ.erase k).image (K.vertex s) =
+      (univ.erase k').image (K.vertex s'))
+    (h : IsDoor c K s k) : IsDoor c K s' k' := by
+  intro j
+  obtain ⟨i, hi_ne, hi_eq⟩ := h j
+  have hmem : K.vertex s i ∈
+      (univ.erase k').image (K.vertex s') := by
+    rw [← hvert]
+    exact mem_image.mpr
+      ⟨i, mem_erase.mpr ⟨hi_ne, mem_univ _⟩, rfl⟩
+  obtain ⟨i', hi'_mem, hi'_eq⟩ := mem_image.mp hmem
+  exact ⟨i', (mem_erase.mp hi'_mem).1,
+    by rw [hi'_eq]; exact hi_eq⟩
+
+/-- A door transfers through adjacency (iff version). -/
+private lemma isDoor_iff_of_adj
+    {c : V → Fin (d + 1)} {K : CellComplex V d}
+    {s : K.Cell} {k : Fin (d + 1)}
+    {s' : K.Cell} {k' : Fin (d + 1)}
+    (hadj : K.adj s k = some (s', k')) :
+    IsDoor c K s k ↔ IsDoor c K s' k' :=
+  ⟨isDoor_of_shared_face
+    (K.adj_vertex s k s' k' hadj),
+   isDoor_of_shared_face
+    (K.adj_vertex s k s' k' hadj).symm⟩
+
+/-- Interior doors pair up via the adjacency involution,
+so their count is even. -/
+theorem even_card_interiorDoors
+    (c : V → Fin (d + 1)) (K : CellComplex V d) :
+    Even (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2 ∧
+        K.adj p.1 p.2 ≠ none)).card := by
+  set S := univ.filter
+    (fun p : K.Cell × Fin (d + 1) =>
+      IsDoor c K p.1 p.2 ∧ K.adj p.1 p.2 ≠ none)
+  apply Finset.even_card_of_fpf_invol S (adjMap K)
+  · intro p hp
+    simp only [S, mem_filter, mem_univ,
+      true_and] at hp
+    obtain ⟨_, hadj_ne⟩ := hp
+    cases hadj_eq : K.adj p.1 p.2 with
+    | none => exact absurd hadj_eq hadj_ne
+    | some sk =>
+      obtain ⟨s', k'⟩ := sk
+      have hadj_back :=
+        K.adj_symm p.1 p.2 s' k' hadj_eq
+      show adjMap K (adjMap K p) = p
+      simp only [adjMap, hadj_eq, hadj_back]
+  · intro p hp
+    simp only [S, mem_filter, mem_univ,
+      true_and] at hp ⊢
+    obtain ⟨hdoor, hadj_ne⟩ := hp
+    cases hadj_eq : K.adj p.1 p.2 with
+    | none => exact absurd hadj_eq hadj_ne
+    | some sk =>
+      obtain ⟨s', k'⟩ := sk
+      have hadj_back :=
+        K.adj_symm p.1 p.2 s' k' hadj_eq
+      show IsDoor c K (adjMap K p).1
+          (adjMap K p).2 ∧
+        K.adj (adjMap K p).1 (adjMap K p).2 ≠ none
+      simp only [adjMap, hadj_eq]
+      exact ⟨(isDoor_iff_of_adj hadj_eq).mp hdoor,
+        by rw [hadj_back]; exact Option.noConfusion⟩
+  · intro p hp
+    simp only [S, mem_filter, mem_univ,
+      true_and] at hp
+    obtain ⟨_, hadj_ne⟩ := hp
+    cases hadj_eq : K.adj p.1 p.2 with
+    | none => exact absurd hadj_eq hadj_ne
+    | some sk =>
+      obtain ⟨s', k'⟩ := sk
+      show adjMap K p ≠ p
+      simp only [adjMap, hadj_eq]
+      intro heq
+      exact K.adj_ne p.1 p.2 s' k' hadj_eq
+        (congr_arg Prod.fst heq).symm
+
+/-- Per-cell door parity: the door count of a single cell
+has the same parity as its panchromaticity indicator. -/
+private lemma per_cell_door_parity
+    (c : V → Fin (d + 1)) (K : CellComplex V d)
+    (s : K.Cell) :
+    (univ.filter (fun k : Fin (d + 1) =>
+      IsDoor c K s k)).card % 2 =
+    if IsPanchromatic c K s then 1 else 0 := by
+  have h := door_count_parity d (c ∘ K.vertex s)
+  have h1 : (univ.filter (fun k : Fin (d + 1) =>
+      IsDoor c K s k)) =
+    (univ.filter (fun k : Fin (d + 1) =>
+      ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
+        (c ∘ K.vertex s) i =
+          ⟨j.val, by omega⟩)) := by
+    ext k
+    simp only [mem_filter, mem_univ, true_and]; rfl
+  rw [h1, h]
+  exact if_congr Iff.rfl rfl rfl
+
+private lemma sum_mod_congr {ι : Type*}
+    (S : Finset ι) (a b : ι → ℕ)
+    (h : ∀ i ∈ S, a i % 2 = b i % 2) :
+    (∑ i ∈ S, a i) % 2 =
+    (∑ i ∈ S, b i) % 2 := by
+  induction S using Finset.cons_induction with
+  | empty => rfl
+  | cons x s hx ih =>
+    rw [sum_cons, sum_cons]
+    have hx_eq :=
+      h x (mem_cons_self x s)
+    have hs_eq := ih
+      (fun i hi => h i (mem_cons.mpr (Or.inr hi)))
+    omega
+
+private lemma card_doors_eq_sum
+    (c : V → Fin (d + 1)) (K : CellComplex V d) :
+    (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2)).card =
+    ∑ s : K.Cell, (univ.filter
+      (fun k : Fin (d + 1) =>
+        IsDoor c K s k)).card := by
+  have hlhs : (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2)).card =
+    ∑ p : K.Cell × Fin (d + 1),
+      if IsDoor c K p.1 p.2 then 1 else 0 := by
+    rw [sum_ite, sum_const_zero, add_zero,
+      sum_const, smul_eq_mul, mul_one]
+  have hrhs : ∀ s : K.Cell,
+      (univ.filter (fun k : Fin (d + 1) =>
+        IsDoor c K s k)).card =
+      ∑ k : Fin (d + 1),
+        if IsDoor c K s k then 1 else 0 := by
+    intro s
+    rw [sum_ite, sum_const_zero, add_zero,
+      sum_const, smul_eq_mul, mul_one]
+  rw [hlhs, sum_congr rfl (fun s _ => hrhs s)]
+  rw [← Fintype.sum_prod_type']
+
+private lemma doors_partition
+    (c : V → Fin (d + 1)) (K : CellComplex V d) :
+    (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2)).card =
+    (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2 ∧
+        K.adj p.1 p.2 ≠ none)).card +
+    (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2 ∧
+        K.adj p.1 p.2 = none)).card := by
+  rw [← card_union_of_disjoint]
+  · congr 1; ext p
+    simp only [mem_filter, mem_univ, true_and,
+      mem_union]
+    constructor
+    · intro h
+      by_cases hadj : K.adj p.1 p.2 = none
+      · right; exact ⟨h, hadj⟩
+      · left; exact ⟨h, hadj⟩
+    · rintro (⟨h, _⟩ | ⟨h, _⟩) <;> exact h
+  · rw [disjoint_left]
+    intro p h₁ h₂
+    simp only [mem_filter, mem_univ,
+      true_and] at h₁ h₂
+    exact h₁.2 h₂.2
+
+/-- **Sperner Parity Theorem**: the panchromatic cell count
+is congruent mod 2 to the boundary door count. -/
+theorem sperner_parity (c : V → Fin (d + 1))
+    (K : CellComplex V d) :
+    (univ.filter (fun s : K.Cell =>
+      IsPanchromatic c K s)).card % 2 =
+    (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2 ∧
+        K.adj p.1 p.2 = none)).card % 2 := by
+  have hper := per_cell_door_parity c K
+  have hsum :
+      (∑ s : K.Cell, (univ.filter
+        (fun k => IsDoor c K s k)).card) % 2 =
+      (∑ s : K.Cell,
+        if IsPanchromatic c K s
+        then 1 else 0) % 2 :=
+    sum_mod_congr univ _ _ (fun s _ => by
+      rw [hper s]
+      split_ifs <;> omega)
+  have hfc_sum :
+      (∑ s : K.Cell,
+        if IsPanchromatic c K s
+        then (1 : ℕ) else 0) =
+      (univ.filter
+        (fun s => IsPanchromatic c K s)).card := by
+    rw [sum_ite, sum_const_zero, add_zero,
+      sum_const, smul_eq_mul, mul_one]
+  have hdoor_sum := card_doors_eq_sum c K
+  have hpart := doors_partition c K
+  have heven := even_card_interiorDoors c K
+  obtain ⟨m, hm⟩ := heven
+  calc (univ.filter
+      (fun s => IsPanchromatic c K s)).card % 2
+    _ = (∑ s : K.Cell,
+        if IsPanchromatic c K s
+        then 1 else 0) % 2 := by rw [hfc_sum]
+    _ = (∑ s : K.Cell, (univ.filter
+        (fun k => IsDoor c K s k)).card) % 2 :=
+      hsum.symm
+    _ = (univ.filter
+        (fun p : K.Cell × Fin (d + 1) =>
+          IsDoor c K p.1 p.2)).card % 2 := by
+      rw [hdoor_sum]
+    _ = ((univ.filter
+        (fun p : K.Cell × Fin (d + 1) =>
+          IsDoor c K p.1 p.2 ∧
+          K.adj p.1 p.2 ≠ none)).card +
+       (univ.filter
+        (fun p : K.Cell × Fin (d + 1) =>
+          IsDoor c K p.1 p.2 ∧
+          K.adj p.1 p.2 = none)).card) % 2 := by
+      rw [hpart]
+    _ = (univ.filter
+        (fun p : K.Cell × Fin (d + 1) =>
+          IsDoor c K p.1 p.2 ∧
+          K.adj p.1 p.2 = none)).card % 2 := by
+      rw [hm, Nat.add_mod,
+        show (m + m) % 2 = 0 from by omega,
+        Nat.zero_add, Nat.mod_mod_of_dvd]
+      exact ⟨1, rfl⟩
+
+/-- **Sperner's Lemma**: if boundary doors are odd, a
+panchromatic cell exists. -/
+theorem sperner (c : V → Fin (d + 1))
+    (K : CellComplex V d)
+    (hbdry : Odd (univ.filter
+      (fun p : K.Cell × Fin (d + 1) =>
+        IsDoor c K p.1 p.2 ∧
+        K.adj p.1 p.2 = none)).card) :
+    ∃ s : K.Cell, IsPanchromatic c K s := by
+  have hparity := sperner_parity c K
+  have hodd : Odd (univ.filter
+      (fun s : K.Cell =>
+        IsPanchromatic c K s)).card := by
+    rwa [Nat.odd_iff, hparity, ← Nat.odd_iff]
+  have hpos : 0 < (univ.filter
+      (fun s => IsPanchromatic c K s)).card := by
+    obtain ⟨k, hk⟩ := hodd; omega
+  obtain ⟨s, hs⟩ := Finset.card_pos.mp hpos
+  exact ⟨s, (mem_filter.mp hs).2⟩
+
+end CellComplex

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 RJ Walters. All rights reserved.
+Copyright (c) 2026 Robb Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robb Walters
 -/
@@ -59,7 +59,7 @@ open Finset
 
 /-- A fixed-point-free involution on a finset has even
 cardinality: every element pairs with its distinct image. -/
-theorem Finset.even_card_of_fpf_invol {α : Type*}
+theorem Finset.even_card_of_fixedPointFree_involution {α : Type*}
     (S : Finset α) (f : α → α)
     (hInv : ∀ x ∈ S, f (f x) = x)
     (hMem : ∀ x ∈ S, f x ∈ S)
@@ -518,7 +518,7 @@ theorem even_card_interiorDoors
   set S := univ.filter
     (fun p : K.Cell × Fin (d + 1) =>
       IsDoor c K p.1 p.2 ∧ K.adj p.1 p.2 ≠ none)
-  apply Finset.even_card_of_fpf_invol S (adjMap K)
+  apply Finset.even_card_of_fixedPointFree_involution S (adjMap K)
   · intro p hp
     simp only [S, mem_filter, mem_univ,
       true_and] at hp

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -3,12 +3,11 @@ Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
-module
 
-public import Mathlib.Algebra.Order.BigOperators.Group.Finset
-public import Mathlib.Algebra.Ring.Parity
-public import Mathlib.Data.Fintype.BigOperators
-public import Mathlib.Data.ZMod.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Ring.Parity
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.ZMod.Basic
 
 /-!
 # Abstract Sperner's Lemma
@@ -542,7 +541,7 @@ theorem even_card_interiorDoors
         K.adj (adjMap K p).1 (adjMap K p).2 ≠ none
       simp only [adjMap, hadj_eq]
       exact ⟨(isDoor_iff_of_adj hadj_eq).mp hdoor,
-        by rw [hadj_back]; exact Option.noConfusion⟩
+        by rw [hadj_back]; exact nofun⟩
   · intro p hp
     simp only [S, mem_filter, mem_univ,
       true_and] at hp

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -3,11 +3,12 @@ Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
+module
 
-import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Algebra.Ring.Parity
-import Mathlib.Data.Fintype.BigOperators
-import Mathlib.Data.ZMod.Basic
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Algebra.Ring.Parity
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.ZMod.Basic
 
 /-!
 # Abstract Sperner's Lemma
@@ -51,6 +52,8 @@ total doors ≡ panchromatic cells (mod 2).
 
 Sperner, combinatorics, parity, triangulation, door-counting
 -/
+
+@[expose] public section
 
 open Finset
 

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: RJ Walters
+Authors: Robb Walters
 -/
 module
 

--- a/Mathlib/Combinatorics/Sperner/Basic.lean
+++ b/Mathlib/Combinatorics/Sperner/Basic.lean
@@ -103,7 +103,7 @@ private lemma door_filter_empty_of_missing_color (d : ℕ)
       ∀ j : Fin d, ∃ i : Fin (d + 1), i ≠ k ∧
         f i = ⟨j.val, by omega⟩)) = ∅ := by
   rw [filter_eq_empty_iff]
-  intro k _; push_neg
+  intro k _; push Not
   exact ⟨j₀, fun i _ h => hmiss ⟨i, h⟩⟩
 
 /-- If natural numbers indexed by a finset sum to 1, exactly one
@@ -114,7 +114,7 @@ private lemma exists_of_sum_eq_one {ι : Type*}
     ∃ a ∈ s, f a = 1 ∧ ∀ b ∈ s, b ≠ a → f b = 0 := by
   classical
   have ⟨a, ha, hfa⟩ : ∃ a ∈ s, 0 < f a := by
-    by_contra h; push_neg at h
+    by_contra h; push Not at h
     have := Finset.sum_eq_zero (fun i hi =>
       Nat.eq_zero_of_le_zero (h i hi))
     omega
@@ -324,7 +324,7 @@ private lemma door_count_even_of_not_surj (d : ℕ)
     have ⟨j₀, hj₀⟩ : ∃ j : Fin d,
         ¬∃ i, f i =
           ⟨j.val, Nat.lt_succ_of_lt j.isLt⟩ := by
-      by_contra hall; push_neg at hall; apply hnsurj
+      by_contra hall; push Not at hall; apply hnsurj
       intro ⟨y, hy⟩; by_cases hyd : y = d
       · subst hyd; exact hd_app
       · exact hall ⟨y, by omega⟩
@@ -333,10 +333,10 @@ private lemma door_count_even_of_not_surj (d : ℕ)
     exact ⟨0, by omega⟩
   · -- Top color d never appears. Truncate to
     -- g : Fin (d+1) → Fin d.
-    push_neg at hd_app
+    push Not at hd_app
     have hlt : ∀ i, (f i).val < d := by
       intro i; have := (f i).isLt
-      by_contra h; push_neg at h
+      by_contra h; push Not at h
       have hlt2 := (f i).isLt
       have : (f i).val = d := by omega
       exact hd_app i (Fin.ext this)
@@ -370,7 +370,7 @@ private lemma door_count_even_of_not_surj (d : ℕ)
     · -- g not surjective: some lower color missing. No doors.
       have ⟨j₀, hj₀⟩ :
           ∃ j : Fin d, ¬∃ i, g i = j := by
-        by_contra h; push_neg at h; exact hgsurj h
+        by_contra h; push Not at h; exact hgsurj h
       suffices h0 : (univ.filter
           (fun k : Fin (d + 1) =>
             ∀ j : Fin d,
@@ -378,7 +378,7 @@ private lemma door_count_even_of_not_surj (d : ℕ)
                 f i = ⟨j.val, by omega⟩)).card =
           0 by rw [h0]; exact ⟨0, by omega⟩
       rw [Finset.card_eq_zero, filter_eq_empty_iff]
-      intro k _; push_neg
+      intro k _; push Not
       exact ⟨j₀, fun i _ h =>
         hj₀ ⟨i, Fin.ext (show (g i).val = j₀.val by
           change (f i).val = j₀.val

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -5,6 +5,7 @@ Authors: RJ Walters
 -/
 
 import Mathlib.Combinatorics.Sperner.Basic
+import Mathlib.Data.Finset.Sort
 
 /-!
 # SimplicialComplex to CellComplex Bridge for Sperner's Lemma

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -368,7 +368,7 @@ noncomputable def AbstractSimplicialData.findOppositeIdx
   -- vertex of t is not in f.
   have hex : ∃ k : Fin (n + 1), D.vertexEnum t ht k ∉ f := by
     by_contra hall
-    push_neg at hall
+    push Not at hall
     -- Every vertex of t is in f, so t ⊆ f (contradicting |f| < |t|)
     have hsub : t ⊆ f := by
       intro v hv

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -1,0 +1,1003 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+module
+
+public import Mathlib.Combinatorics.Sperner.Basic
+
+/-!
+# SimplicialComplex to CellComplex Bridge for Sperner's Lemma
+
+This file bridges the gap between simplicial complexes and our
+abstract `CellComplex` structure from `Sperner.Basic`.
+
+## The Architecture
+
+Part 1 (done in Sperner.Basic): Abstract `CellComplex`
+  with adjacency axioms, and the Sperner parity theorem proved
+  for any `CellComplex`.
+
+Part 2 (this file): Show that a triangulation of the standard
+  simplex satisfying a pseudomanifold condition gives rise to a
+  `CellComplex` instance.
+
+## Strategy
+
+We define a `Triangulation` structure that axiomatizes exactly
+what we need: a finite pure simplicial complex with the
+pseudomanifold property. The structure has the same fields as
+`CellComplex` plus vertex injectivity, so the bridge is
+immediate.
+
+We also define `AbstractSimplicialData` for constructing a
+`Triangulation` from unordered simplices (as in Mathlib's
+`Geometry.SimplicialComplex`), and provide a concrete 1-d
+interval example with fully proved axioms.
+
+## Main definitions
+
+* `Triangulation V n`: A triangulation with ordered vertices.
+* `Triangulation.toCellComplex`: The `CellComplex` instance.
+* `AbstractSimplicialData V n`: Unordered simplicial data.
+* `intervalTriangulation m`: Concrete 1-d example.
+
+## Main results
+
+* `Triangulation.sperner`: Sperner's lemma for triangulations.
+* Interval triangulation: all axioms fully proved (0 sorries).
+
+## References
+
+* [M. De Longueville, *A Course in Topological Combinatorics*]
+* Yael Dillies, mathlib4#25231, mathlib4#34310
+
+## Tags
+
+Sperner, simplicial complex, triangulation, cell complex, bridge
+-/
+
+open Finset
+
+/-! ## Triangulation Structure
+
+We axiomatize a finite pure simplicial complex with the
+pseudomanifold property. This is the minimal interface needed
+to construct a `CellComplex`.
+
+The key insight: `Triangulation` has exactly the same fields as
+`CellComplex` plus `vertex_injective`, so the bridge construction
+`toCellComplex` is trivial (just forget the extra field). -/
+
+/-- A `Triangulation V n` is a finite collection of
+top-dimensional simplices (each an ordered `(n+1)`-tuple of
+vertices from `V`) satisfying the pseudomanifold condition:
+each codimension-1 face belongs to at most 2 top simplices.
+
+This is the minimal abstraction needed to instantiate
+`CellComplex` and apply the abstract Sperner theorem. -/
+structure Triangulation (V : Type*) [DecidableEq V]
+    (n : ℕ) where
+  /-- The type of top-dimensional cells (n-simplices). -/
+  Cell : Type
+  /-- Decidable equality on cells. -/
+  cellDecEq : DecidableEq Cell
+  /-- Finiteness of cells. -/
+  cellFintype : Fintype Cell
+  /-- The ordered vertices of each cell: vertex k is the k-th
+  vertex of cell s. Each cell has n+1 distinct vertices. -/
+  vertex : Cell → Fin (n + 1) → V
+  /-- Vertices within a single cell are distinct. -/
+  vertex_injective : ∀ s, Function.Injective (vertex s)
+  /-- Pseudomanifold adjacency: for each cell s and face
+  position k, either there is a unique neighboring cell s'
+  sharing the codim-1 face, or the face is on the boundary. -/
+  adj : Cell → Fin (n + 1) → Option (Cell × Fin (n + 1))
+  /-- Adjacency is symmetric. -/
+  adj_symm : ∀ s k s' k',
+    adj s k = some (s', k') → adj s' k' = some (s, k)
+  /-- Adjacent cells share the codimension-1 face. -/
+  adj_vertex : ∀ s k s' k',
+    adj s k = some (s', k') →
+    (univ.erase k).image (vertex s) =
+    (univ.erase k').image (vertex s')
+  /-- Adjacent cells are distinct. -/
+  adj_ne : ∀ s k s' k',
+    adj s k = some (s', k') → s ≠ s'
+
+attribute [instance] Triangulation.cellDecEq
+attribute [instance] Triangulation.cellFintype
+
+namespace Triangulation
+
+variable {V : Type*} [DecidableEq V] {n : ℕ}
+
+/-! ## CellComplex Instance
+
+The bridge is immediate: `Triangulation` extends `CellComplex`
+with `vertex_injective`, so we just forget it. -/
+
+/-- Every `Triangulation` gives rise to a `CellComplex`. -/
+def toCellComplex (T : Triangulation V n) : CellComplex V n where
+  Cell := T.Cell
+  cellDecEq := T.cellDecEq
+  cellFintype := T.cellFintype
+  vertex := T.vertex
+  adj := T.adj
+  adj_symm := T.adj_symm
+  adj_vertex := T.adj_vertex
+  adj_ne := T.adj_ne
+
+/-! ## Sperner Coloring and Main Theorem -/
+
+/-- A Sperner coloring: if vertex v is on face k (determined by
+the predicate `onFace`), then `c v` is not `k`. -/
+def IsSpernerColoring
+    (c : V → Fin (n + 1))
+    (onFace : V → Fin (n + 1) → Prop) : Prop :=
+  ∀ v k, onFace v k → c v ≠ k
+
+/-- **Sperner's Lemma for Triangulations**: Given a triangulation
+whose boundary doors are odd, a panchromatic cell exists.
+
+This is a direct application of the abstract `CellComplex.sperner`
+theorem via the `toCellComplex` bridge. -/
+theorem sperner (T : Triangulation V n)
+    (c : V → Fin (n + 1))
+    (hbdry : Odd (Finset.univ.filter
+      (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none)).card) :
+    ∃ s : T.Cell,
+      CellComplex.IsPanchromatic c (T.toCellComplex) s :=
+  CellComplex.sperner c T.toCellComplex hbdry
+
+/-! ## Boundary Door Parity
+
+The key geometric fact for the standard simplex: with a Sperner
+coloring, boundary doors are odd. This decomposes by face and
+uses induction on dimension.
+
+We state this with explicit hypotheses that can be discharged
+for any concrete triangulation. -/
+
+/-- **Boundary door parity for triangulations**: Given
+decomposition hypotheses about boundary doors on each geometric
+face, the total boundary door count is odd.
+
+The hypotheses separate doors by which geometric face they lie
+on. Doors on faces 0 through n-1 pair up (even), and doors on
+face n are odd (by induction). -/
+theorem boundary_doors_odd (T : Triangulation V n)
+    (c : V → Fin (n + 1))
+    (onFace : V → Fin (n + 1) → Prop)
+    [∀ v k, Decidable (onFace v k)]
+    (_hSperner : IsSpernerColoring c onFace)
+    (_hBoundaryOnFace : ∀ s k, T.adj s k = none →
+      ∃ faceIdx : Fin (n + 1), ∀ j : Fin (n + 1),
+        j ≠ k → onFace (T.vertex s j) faceIdx)
+    (_hLowerDim : ∀ faceIdx : Fin (n + 1),
+      faceIdx.val < n →
+      Even (Finset.univ.filter (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none ∧
+        (∀ j : Fin (n + 1), j ≠ p.2 →
+          onFace (T.vertex p.1 j) faceIdx))).card)
+    (_hLastFace : Odd (Finset.univ.filter
+      (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none ∧
+        (∀ j : Fin (n + 1), j ≠ p.2 →
+          onFace (T.vertex p.1 j)
+            ⟨n, by omega⟩))).card) :
+    Odd (Finset.univ.filter
+      (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none)).card := by
+  -- Strategy: show S = S_n (every boundary door must be on the last face)
+  -- then |S| = |S_n| is odd by _hLastFace.
+  --
+  -- Key insight: if a boundary door (s,k) is on face faceIdx with faceIdx.val < n,
+  -- the Sperner condition contradicts the door condition (IsDoor requires color
+  -- faceIdx on some non-k vertex, but Sperner forbids it).
+  suffices h : Finset.univ.filter
+      (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none) =
+    Finset.univ.filter
+      (fun p : T.Cell × Fin (n + 1) =>
+        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
+        T.adj p.1 p.2 = none ∧
+        (∀ j : Fin (n + 1), j ≠ p.2 →
+          onFace (T.vertex p.1 j) ⟨n, by omega⟩)) by
+    rw [h]; exact _hLastFace
+  -- Prove the two filter sets are equal
+  ext ⟨s, k⟩
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  constructor
+  · -- S ⊆ S_n: every boundary door is on the last face
+    intro ⟨hDoor, hAdj⟩
+    refine ⟨hDoor, hAdj, ?_⟩
+    -- By _hBoundaryOnFace, this door is on some face faceIdx
+    obtain ⟨faceIdx, hOnFace⟩ := _hBoundaryOnFace s k hAdj
+    -- Show faceIdx = ⟨n, _⟩ by contradiction
+    by_cases hlt : faceIdx.val < n
+    · -- Contradiction: IsDoor requires color faceIdx on some non-k vertex,
+      -- but Sperner forbids it since all non-k vertices are on face faceIdx
+      exfalso
+      -- IsDoor at color index ⟨faceIdx.val, hlt⟩ : Fin n gives a witness
+      have hDoor' := hDoor ⟨faceIdx.val, hlt⟩
+      obtain ⟨i, hi_ne, hi_color⟩ := hDoor'
+      -- Vertex i is on face faceIdx (since i ≠ k)
+      have hOnFace_i := hOnFace i hi_ne
+      -- Sperner says c(vertex s i) ≠ faceIdx
+      have hSperner_i := _hSperner (T.vertex s i) faceIdx hOnFace_i
+      -- But hi_color says c(vertex s i) = castSucc ⟨faceIdx.val, hlt⟩ = faceIdx
+      -- T.toCellComplex.vertex = T.vertex by definition
+      change c (T.vertex s i) = _ at hi_color
+      -- castSucc ⟨faceIdx.val, hlt⟩ = faceIdx since faceIdx.val < n < n+1
+      have hcast : (⟨faceIdx.val, hlt⟩ : Fin n).castSucc = faceIdx :=
+        Fin.ext rfl
+      rw [hcast] at hi_color
+      exact hSperner_i hi_color
+    · -- faceIdx.val ≥ n, and faceIdx : Fin (n+1) so faceIdx.val ≤ n
+      -- Therefore faceIdx.val = n, so faceIdx = ⟨n, _⟩
+      have heq : faceIdx.val = n := by omega
+      have hfaceIdx : faceIdx = ⟨n, by omega⟩ := Fin.ext heq
+      rw [hfaceIdx] at hOnFace
+      exact hOnFace
+  · -- S_n ⊆ S: dropping the extra condition
+    intro ⟨hDoor, hAdj, _⟩
+    exact ⟨hDoor, hAdj⟩
+
+/-! ## Construction from Unordered Simplices
+
+When starting from unordered simplices (Mathlib's
+`Geometry.SimplicialComplex` uses `Finset V`), we need a
+`LinearOrder V` to produce ordered vertices via `Finset.sort`.
+
+`AbstractSimplicialData` packages this construction. -/
+
+/-- Unordered simplicial data: a finite set of top simplices
+with the pseudomanifold property. -/
+structure AbstractSimplicialData (V : Type*) [DecidableEq V]
+    [LinearOrder V] (n : ℕ) where
+  /-- The top-dimensional simplices. -/
+  topSimplices : Finset (Finset V)
+  /-- Each top simplex has exactly n+1 vertices. -/
+  card_eq : ∀ s ∈ topSimplices, s.card = n + 1
+  /-- Pseudomanifold: each codim-1 face is in at most 2 top
+  simplices. -/
+  pseudomanifold : ∀ (face : Finset V),
+    face.card = n →
+    (topSimplices.filter (fun s => face ⊆ s)).card ≤ 2
+
+/-!
+## Face Helper Library
+
+Named helpers for working with codimension-1 faces of top
+simplices. These factor out the key operations needed to
+construct adjacency for `toTriangulation`. -/
+
+section FaceHelpers
+
+variable {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+variable (D : AbstractSimplicialData V n)
+
+/-- The ordered vertex enumeration of a top simplex. -/
+noncomputable def AbstractSimplicialData.vertexEnum
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) : V :=
+  (s.sort (· ≤ ·)).get (k.cast (by rw [Finset.length_sort]; exact (D.card_eq s hs).symm))
+
+/-- The k-th vertex is a member of the simplex. -/
+lemma AbstractSimplicialData.vertexEnum_mem
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.vertexEnum s hs k ∈ s := by
+  unfold vertexEnum
+  have hmem := List.get_mem (s.sort (· ≤ ·))
+    (k.cast (by rw [Finset.length_sort]; exact (D.card_eq s hs).symm))
+  exact (s.mem_sort (· ≤ ·)).mp hmem
+
+/-- The codimension-1 face obtained by deleting the k-th vertex. -/
+noncomputable def AbstractSimplicialData.faceOf
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) : Finset V :=
+  s.erase (D.vertexEnum s hs k)
+
+/-- A face has cardinality n. -/
+lemma AbstractSimplicialData.faceOf_card
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    (D.faceOf s hs k).card = n := by
+  simp only [faceOf]
+  rw [Finset.card_erase_of_mem (D.vertexEnum_mem s hs k)]
+  have := D.card_eq s hs
+  omega
+
+/-- A face is a subset of the simplex. -/
+lemma AbstractSimplicialData.faceOf_subset
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.faceOf s hs k ⊆ s :=
+  Finset.erase_subset _ _
+
+/-- Top simplices containing a given face. -/
+noncomputable def AbstractSimplicialData.containersOf
+    (f : Finset V) : Finset (Finset V) :=
+  D.topSimplices.filter (fun t => f ⊆ t)
+
+/-- The original simplex contains its own face. -/
+lemma AbstractSimplicialData.self_mem_containersOf
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    s ∈ D.containersOf (D.faceOf s hs k) := by
+  simp only [containersOf, Finset.mem_filter]
+  exact ⟨hs, D.faceOf_subset s hs k⟩
+
+/-- Container count is at most 2 (pseudomanifold). -/
+lemma AbstractSimplicialData.containersOf_card_le_two
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    (D.containersOf (D.faceOf s hs k)).card ≤ 2 :=
+  D.pseudomanifold _ (D.faceOf_card s hs k)
+
+/-- Container count is 1 or 2. -/
+lemma AbstractSimplicialData.containersOf_card_one_or_two
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    (D.containersOf (D.faceOf s hs k)).card = 1 ∨
+    (D.containersOf (D.faceOf s hs k)).card = 2 := by
+  have h1 : 0 < (D.containersOf (D.faceOf s hs k)).card :=
+    Finset.card_pos.mpr ⟨s, D.self_mem_containersOf s hs k⟩
+  have h2 := D.containersOf_card_le_two s hs k
+  omega
+
+/-- The difference `t \ f` is nonempty when `t` has `n+1` elements
+and `f` has `n` elements with `f ⊆ t`. -/
+lemma AbstractSimplicialData.sdiff_nonempty
+    (t : Finset V) (ht : t ∈ D.topSimplices)
+    (f : Finset V) (_hf : f ⊆ t) (hfc : f.card = n) :
+    (t \ f).Nonempty := by
+  rw [Finset.nonempty_iff_ne_empty]
+  intro h
+  have hsub := Finset.sdiff_eq_empty_iff_subset.mp h
+  have := D.card_eq t ht
+  have := Finset.card_le_card hsub
+  omega
+
+/-- Given a top simplex `t` containing face `f`, find the index
+in `t`'s sorted vertex list of the unique vertex in `t \ f`.
+Returns the position of the "opposite" vertex. -/
+noncomputable def AbstractSimplicialData.findOppositeIdx
+    (t : Finset V) (ht : t ∈ D.topSimplices)
+    (f : Finset V) (_hf : f ⊆ t) (hfc : f.card = n) :
+    Fin (n + 1) :=
+  -- There exists k such that vertexEnum t ht k is not in f.
+  -- Since t has n+1 vertices and f has n with f ⊆ t, at least one
+  -- vertex of t is not in f.
+  have hex : ∃ k : Fin (n + 1), D.vertexEnum t ht k ∉ f := by
+    by_contra hall
+    push_neg at hall
+    -- Every vertex of t is in f, so t ⊆ f
+    have hsub : t ⊆ f := by
+      intro v hv
+      -- v is in t, so v appears somewhere in t.sort
+      have hv_sort : v ∈ t.sort (· ≤ ·) := (t.mem_sort (· ≤ ·)).mpr hv
+      rw [List.mem_iff_getElem] at hv_sort
+      obtain ⟨idx, hidx_lt, hidx_eq⟩ := hv_sort
+      have hidx_lt' : idx < n + 1 := by
+        rwa [Finset.length_sort, D.card_eq t ht] at hidx_lt
+      have hmem := hall ⟨idx, hidx_lt'⟩
+      -- vertexEnum t ht ⟨idx, hidx_lt'⟩ = (t.sort (· ≤ ·)).get (cast ⟨idx, ...⟩)
+      -- which equals (t.sort (· ≤ ·))[idx] = v
+      -- Use the fact that vertexEnum_mem gives us membership
+      -- and that vertexEnum at index idx equals (t.sort ...)[idx]
+      have heq : D.vertexEnum t ht ⟨idx, hidx_lt'⟩ = v := by
+        simp only [vertexEnum, List.get_eq_getElem]
+        exact hidx_eq
+      rwa [heq] at hmem
+    have := Finset.card_le_card hsub
+    rw [D.card_eq t ht, hfc] at this
+    omega
+  hex.choose
+
+/-- The opposite vertex is not in the face. -/
+lemma AbstractSimplicialData.vertexEnum_findOppositeIdx_not_mem
+    (t : Finset V) (ht : t ∈ D.topSimplices)
+    (f : Finset V) (hf : f ⊆ t) (hfc : f.card = n) :
+    D.vertexEnum t ht (D.findOppositeIdx t ht f hf hfc) ∉ f := by
+  unfold findOppositeIdx
+  generalize_proofs hex
+  exact hex.choose_spec
+
+/-- Erasing the opposite vertex from t gives back f. -/
+lemma AbstractSimplicialData.erase_opposite_eq
+    (t : Finset V) (ht : t ∈ D.topSimplices)
+    (f : Finset V) (hf : f ⊆ t) (hfc : f.card = n) :
+    t.erase (D.vertexEnum t ht (D.findOppositeIdx t ht f hf hfc)) = f := by
+  set v := D.vertexEnum t ht (D.findOppositeIdx t ht f hf hfc) with hv_def
+  have hv_not_f : v ∉ f := D.vertexEnum_findOppositeIdx_not_mem t ht f hf hfc
+  have hv_mem_t : v ∈ t := D.vertexEnum_mem t ht (D.findOppositeIdx t ht f hf hfc)
+  have h_sub : f ⊆ t.erase v := by
+    intro x hx
+    exact Finset.mem_erase.mpr ⟨fun h => hv_not_f (h ▸ hx), hf hx⟩
+  have h_card : (t.erase v).card ≤ f.card := by
+    rw [Finset.card_erase_of_mem hv_mem_t, D.card_eq t ht, hfc]
+    omega
+  exact (Finset.eq_of_subset_of_card_le h_sub h_card).symm
+
+/-- The vertex enumeration of a top simplex is injective. -/
+lemma AbstractSimplicialData.vertexEnum_injective
+    (s : Finset V) (hs : s ∈ D.topSimplices) :
+    Function.Injective (D.vertexEnum s hs) := by
+  intro i j hij
+  have hnd : (s.sort (· ≤ ·)).Nodup := s.sort_nodup (· ≤ ·)
+  set L := s.sort (· ≤ ·) with hL_def
+  set i' : Fin L.length := i.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+  set j' : Fin L.length := j.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+  have hi'j' : L.get i' = L.get j' := hij
+  have key : (i' : ℕ) = (j' : ℕ) := by
+    rw [List.nodup_iff_injective_get] at hnd
+    exact Fin.val_eq_of_eq (hnd hi'j')
+  exact Fin.ext key
+
+/-- The vertex enumeration covers all of s. -/
+lemma AbstractSimplicialData.vertexEnum_image_univ
+    (s : Finset V) (hs : s ∈ D.topSimplices) :
+    Finset.univ.image (D.vertexEnum s hs) = s := by
+  ext v
+  simp only [Finset.mem_image, Finset.mem_univ, true_and]
+  constructor
+  · rintro ⟨k, rfl⟩; exact D.vertexEnum_mem s hs k
+  · intro hv
+    have hv_sort : v ∈ s.sort (· ≤ ·) := (s.mem_sort (· ≤ ·)).mpr hv
+    rw [List.mem_iff_getElem] at hv_sort
+    obtain ⟨idx, hidx_lt, hidx_eq⟩ := hv_sort
+    have hidx_lt' : idx < n + 1 := by
+      rwa [Finset.length_sort, D.card_eq s hs] at hidx_lt
+    exact ⟨⟨idx, hidx_lt'⟩, by show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq⟩
+
+/-- Image of `univ.erase k` under vertexEnum equals faceOf. -/
+lemma AbstractSimplicialData.vertexEnum_image_erase
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    (Finset.univ.erase k).image (D.vertexEnum s hs) = D.faceOf s hs k := by
+  have hinj := D.vertexEnum_injective s hs
+  ext v
+  simp only [Finset.mem_image, Finset.mem_erase, Finset.mem_univ, and_true,
+             faceOf, Finset.mem_erase]
+  constructor
+  · rintro ⟨j, hj_ne, rfl⟩
+    exact ⟨fun h => hj_ne (hinj h), D.vertexEnum_mem s hs j⟩
+  · rintro ⟨hne, hv⟩
+    have hv_sort : v ∈ s.sort (· ≤ ·) := (s.mem_sort (· ≤ ·)).mpr hv
+    rw [List.mem_iff_getElem] at hv_sort
+    obtain ⟨idx, hidx_lt, hidx_eq⟩ := hv_sort
+    have hidx_lt' : idx < n + 1 := by
+      rwa [Finset.length_sort, D.card_eq s hs] at hidx_lt
+    refine ⟨⟨idx, hidx_lt'⟩, ?_, ?_⟩
+    · intro heq
+      apply hne
+      have : D.vertexEnum s hs ⟨idx, hidx_lt'⟩ = v := by
+        show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
+      rw [← this, heq]
+    · show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
+
+/-- Unfold faceOf. -/
+lemma AbstractSimplicialData.faceOf_eq
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n+1)) :
+    D.faceOf s hs k = s.erase (D.vertexEnum s hs k) := rfl
+
+/-- Vertex j is not in face k iff j = k.
+The forward direction: if vertexEnum j is not in s.erase(vertexEnum k),
+then vertexEnum j = vertexEnum k (since vertexEnum j ∈ s), hence j = k by injectivity.
+The backward direction: vertexEnum k ∉ s.erase(vertexEnum k) by Finset.not_mem_erase. -/
+lemma AbstractSimplicialData.vertexEnum_not_mem_faceOf_iff
+    (s : Finset V) (hs : s ∈ D.topSimplices) (j k : Fin (n+1)) :
+    D.vertexEnum s hs j ∉ D.faceOf s hs k ↔ j = k := by
+  simp only [faceOf, Finset.mem_erase, not_and_or, not_not]
+  constructor
+  · intro h
+    cases h with
+    | inl h => exact D.vertexEnum_injective s hs h
+    | inr h => exact absurd (D.vertexEnum_mem s hs j) h
+  · intro h; left; congr 1
+
+/-- findOppositeIdx of the face obtained by removing vertex k gives back k.
+Since the only vertex not in faceOf s hs k is vertexEnum s hs k (at index k),
+and findOppositeIdx picks such an index, it must pick k. -/
+lemma AbstractSimplicialData.findOppositeIdx_eq
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n+1)) :
+    D.findOppositeIdx s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k) = k := by
+  set idx := D.findOppositeIdx s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
+  have h_not_mem : D.vertexEnum s hs idx ∉ D.faceOf s hs k :=
+    D.vertexEnum_findOppositeIdx_not_mem s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
+  exact (D.vertexEnum_not_mem_faceOf_iff s hs idx k).mp h_not_mem
+
+end FaceHelpers
+
+/-!
+## Adjacency Construction
+
+We define adjacency for `AbstractSimplicialData.toTriangulation`
+using the face helper library. For each cell `(s, hs)` and face
+index `k`:
+1. Compute face `f = D.faceOf s hs k`
+2. Compute containers `cs = D.containersOf f`
+3. If `cs.card = 1`: boundary face, return `none`
+4. If `cs.card = 2`: find the other simplex `t != s` in `cs`,
+   compute the opposite index in `t`, return `some (t, k')`
+-/
+
+/-- The adjacency function for `toTriangulation`. Factored out to
+enable standalone reasoning about adj = some results. -/
+noncomputable def AbstractSimplicialData.adjFn
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (p : { s : Finset V // s ∈ D.topSimplices })
+    (k : Fin (n + 1)) :
+    Option ({ s : Finset V // s ∈ D.topSimplices } × Fin (n + 1)) :=
+  let f := D.faceOf p.1 p.2 k
+  let cs := D.containersOf f
+  if _hc : cs.card ≤ 1 then
+    none
+  else
+    let cs_without_s := cs.erase p.1
+    if ht_exists : cs_without_s.Nonempty then
+      let t := ht_exists.choose
+      have ht_mem_erase : t ∈ cs_without_s := ht_exists.choose_spec
+      have ht_mem_cs : t ∈ cs := Finset.mem_of_mem_erase ht_mem_erase
+      have ht_top : t ∈ D.topSimplices := (Finset.mem_filter.mp ht_mem_cs).1
+      have hf_sub_t : f ⊆ t := (Finset.mem_filter.mp ht_mem_cs).2
+      let k' := D.findOppositeIdx t ht_top f hf_sub_t (D.faceOf_card p.1 p.2 k)
+      some (⟨t, ht_top⟩, k')
+    else
+      none
+
+/-- When `adjFn` returns `some`, the shared face sets are equal. -/
+lemma AbstractSimplicialData.adjFn_vertex
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    (Finset.univ.erase k).image (D.vertexEnum s hs) =
+    (Finset.univ.erase k').image (D.vertexEnum s' hs') := by
+  -- Unfold adjFn to expose the dite structure
+  unfold adjFn at hadj
+  simp only at hadj
+  -- split_ifs produces 3 cases from the nested dite; the happy path
+  -- (hc false, hne true) comes first as `case pos`
+  split_ifs at hadj with hc hne
+  · -- Happy path: ¬(cs.card ≤ 1) and (cs.erase s).Nonempty
+    -- hadj : some (⟨t, _⟩, k_adj) = some (⟨s', hs'⟩, k')
+    -- Extract the Subtype and Fin equalities
+    simp only [Option.some.injEq, Prod.mk.injEq] at hadj
+    obtain ⟨hs'_sub_eq, hk'_eq⟩ := hadj
+    -- hs'_sub_eq : ⟨Exists.choose ..., ...⟩ = ⟨s', hs'⟩ (subtype equality)
+    -- Extract value equality from subtype equality
+    have hs'_val : s' = hne.choose := (Subtype.ext_iff.mp hs'_sub_eq).symm
+    -- Both sides equal faceOf s hs k
+    set f := D.faceOf s hs k
+    -- LHS = faceOf s hs k
+    have hLHS : (Finset.univ.erase k).image (D.vertexEnum s hs) = f :=
+      D.vertexEnum_image_erase s hs k
+    -- Extract neighbor data from hne (the Nonempty proof)
+    have ht_mem_erase := hne.choose_spec
+    have ht_mem_cs : hne.choose ∈ D.containersOf f :=
+      Finset.mem_of_mem_erase ht_mem_erase
+    have ht_top : hne.choose ∈ D.topSimplices :=
+      (Finset.mem_filter.mp ht_mem_cs).1
+    have hf_sub_t : f ⊆ hne.choose :=
+      (Finset.mem_filter.mp ht_mem_cs).2
+    -- RHS = faceOf s' hs' k' = f
+    -- We prove this by showing both sides reduce to f
+    have hRHS : (Finset.univ.erase k').image (D.vertexEnum s' hs') = f := by
+      rw [D.vertexEnum_image_erase s' hs' k']
+      -- Goal: faceOf s' hs' k' = f, i.e., s'.erase (vertexEnum s' hs' k') = f
+      simp only [faceOf]
+      subst hs'_val
+      -- After subst: s' = hne.choose
+      -- Goal: hne.choose.erase (vertexEnum hne.choose hs' k') = f
+      -- k' comes from hk'_eq: findOppositeIdx ... = k'
+      -- Rewrite k' back to findOppositeIdx
+      rw [← hk'_eq]
+      -- Goal: hne.choose.erase (vertexEnum hne.choose hs' (findOppositeIdx ...)) = f
+      -- The findOppositeIdx and vertexEnum use proof terms that may differ from ht_top
+      -- but by proof irrelevance they compute the same value
+      -- Use erase_opposite_eq: t.erase (vertexEnum t ht (findOppositeIdx t ht f hf hfc)) = f
+      -- We need to match: vertexEnum hne.choose hs' (findOppositeIdx with other proofs)
+      -- = vertexEnum hne.choose ht_top (findOppositeIdx hne.choose ht_top f hf_sub_t ...)
+      -- All proof arguments are interchangeable by proof irrelevance
+      exact D.erase_opposite_eq hne.choose ht_top f hf_sub_t (D.faceOf_card s hs k)
+    rw [hLHS, hRHS]
+
+/-- When adjFn returns some, the containers of the face have exactly 2 elements. -/
+lemma AbstractSimplicialData.containersOf_card_eq_two_of_adjFn
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    (D.containersOf (D.faceOf s hs k)).card = 2 := by
+  unfold adjFn at hadj
+  simp only at hadj
+  split_ifs at hadj with hc hne
+  · have hcard := D.containersOf_card_one_or_two s hs k
+    omega
+
+/-- When adjFn returns some, the neighbor s' is in containersOf f. -/
+lemma AbstractSimplicialData.adjFn_s'_mem_containers
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    s' ∈ D.containersOf (D.faceOf s hs k) := by
+  simp only [containersOf, Finset.mem_filter]
+  refine ⟨hs', ?_⟩
+  unfold adjFn at hadj
+  simp only at hadj
+  split_ifs at hadj with hc hne
+  · simp only [Option.some.injEq, Prod.mk.injEq] at hadj
+    obtain ⟨hs'_sub_eq, _⟩ := hadj
+    have hs'_val : s' = hne.choose := (Subtype.ext_iff.mp hs'_sub_eq).symm
+    have ht_mem_erase := hne.choose_spec
+    have ht_mem_cs : hne.choose ∈ D.containersOf (D.faceOf s hs k) :=
+      Finset.mem_of_mem_erase ht_mem_erase
+    rw [hs'_val]
+    exact (Finset.mem_filter.mp ht_mem_cs).2
+
+/-- When adjFn returns some, s' != s (as Finset values). -/
+lemma AbstractSimplicialData.adjFn_ne
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    s' ≠ s := by
+  unfold adjFn at hadj
+  simp only at hadj
+  split_ifs at hadj with hc hne
+  · simp only [Option.some.injEq, Prod.mk.injEq] at hadj
+    obtain ⟨hs'_sub_eq, _⟩ := hadj
+    have hs'_val : s' = hne.choose := (Subtype.ext_iff.mp hs'_sub_eq).symm
+    have ht_mem_erase := hne.choose_spec
+    have ht_ne_s : hne.choose ≠ s := (Finset.mem_erase.mp ht_mem_erase).1
+    rw [hs'_val]
+    exact ht_ne_s
+
+/-- When adjFn returns some, faceOf s' hs' k' = faceOf s hs k. -/
+lemma AbstractSimplicialData.adjFn_face_eq
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    D.faceOf s' hs' k' = D.faceOf s hs k := by
+  have himg := D.adjFn_vertex s hs k s' hs' k' hadj
+  rw [D.vertexEnum_image_erase s hs k, D.vertexEnum_image_erase s' hs' k'] at himg
+  exact himg.symm
+
+/-- When adjFn returns some from s, adjFn from s' returns s. -/
+lemma AbstractSimplicialData.adjFn_symm
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n)
+    (s : Finset V) (hs : s ∈ D.topSimplices)
+    (k : Fin (n + 1))
+    (s' : Finset V) (hs' : s' ∈ D.topSimplices)
+    (k' : Fin (n + 1))
+    (hadj : D.adjFn ⟨s, hs⟩ k = some (⟨s', hs'⟩, k')) :
+    D.adjFn ⟨s', hs'⟩ k' = some (⟨s, hs⟩, k) := by
+  -- Key facts
+  set f := D.faceOf s hs k with hf_def
+  have hne : s' ≠ s := D.adjFn_ne s hs k s' hs' k' hadj
+  have hface_eq : D.faceOf s' hs' k' = f := D.adjFn_face_eq s hs k s' hs' k' hadj
+  have hs_cont : s ∈ D.containersOf f := D.self_mem_containersOf s hs k
+  have hs'_cont : s' ∈ D.containersOf f := D.adjFn_s'_mem_containers s hs k s' hs' k' hadj
+  have hcard2 : (D.containersOf f).card = 2 :=
+    D.containersOf_card_eq_two_of_adjFn s hs k s' hs' k' hadj
+  -- Step through the dite chain of adjFn ⟨s', hs'⟩ k'
+  unfold adjFn
+  simp only
+  -- First branch: containers not small (card = 2 > 1)
+  have hcs_not_le_1 : ¬((D.containersOf (D.faceOf s' hs' k')).card ≤ 1) := by
+    rw [hface_eq]; omega
+  rw [dif_neg hcs_not_le_1]
+  -- Second branch: erase s' is nonempty (s is in there)
+  have hne_erase : ((D.containersOf (D.faceOf s' hs' k')).erase s').Nonempty := by
+    rw [hface_eq]
+    exact ⟨s, Finset.mem_erase.mpr ⟨hne.symm, hs_cont⟩⟩
+  rw [dif_pos hne_erase]
+  -- Show hne_erase.choose = s (singleton argument)
+  -- hne_erase.choose is in (containersOf (faceOf s' hs' k')).erase s'
+  -- which equals (containersOf f).erase s' since faceOf s' hs' k' = f
+  have ht_mem_f : hne_erase.choose ∈ (D.containersOf f).erase s' := by
+    have h := hne_erase.choose_spec
+    have hset_eq : (D.containersOf (D.faceOf s' hs' k')).erase s' =
+        (D.containersOf f).erase s' := by rw [hface_eq]
+    rw [← hset_eq]; exact h
+  have ht_in_cs : hne_erase.choose ∈ D.containersOf f :=
+    Finset.mem_of_mem_erase ht_mem_f
+  have h_erase_card : ((D.containersOf f).erase s').card = 1 := by
+    rw [Finset.card_erase_of_mem hs'_cont, hcard2]
+  have hs_in_erase : s ∈ (D.containersOf f).erase s' :=
+    Finset.mem_erase.mpr ⟨hne.symm, hs_cont⟩
+  have ht_eq_s : hne_erase.choose = s := by
+    obtain ⟨a, ha⟩ := Finset.card_eq_one.mp h_erase_card
+    have hs_a : s = a := Finset.mem_singleton.mp (ha ▸ hs_in_erase)
+    have ht_a : hne_erase.choose = a := Finset.mem_singleton.mp (ha ▸ ht_mem_f)
+    exact ht_a.trans hs_a.symm
+  -- Prove the full equality via Option/Prod injectivity
+  simp only [Option.some.injEq, Prod.mk.injEq]
+  refine ⟨Subtype.ext ht_eq_s, ?_⟩
+  -- Fin component: findOppositeIdx hne_erase.choose _ face _ _ = k
+  -- Strategy: the vertex at the chosen index is not in the face.
+  -- Since hne_erase.choose = s and face = faceOf s hs k, use List-level
+  -- reasoning to show the index must be k.
+  -- Fin component: findOppositeIdx hne_erase.choose ht' (faceOf s' hs' k') hf' hfc' = k
+  -- Since hne_erase.choose = s and faceOf s' hs' k' = faceOf s hs k,
+  -- the vertex at the result index is not in faceOf s hs k, so by
+  -- vertexEnum_not_mem_faceOf_iff it must equal k.
+  have h_idx_eq : ∀ (ht' : hne_erase.choose ∈ D.topSimplices)
+      (hf' : D.faceOf s' hs' k' ⊆ hne_erase.choose)
+      (hfc' : (D.faceOf s' hs' k').card = n),
+      D.findOppositeIdx hne_erase.choose ht' (D.faceOf s' hs' k') hf' hfc' = k := by
+    intro ht' hf' hfc'
+    set idx := D.findOppositeIdx hne_erase.choose ht' (D.faceOf s' hs' k') hf' hfc'
+    -- vertexEnum is determined by the Finset sort, not the membership proof
+    have hve : D.vertexEnum hne_erase.choose ht' idx = D.vertexEnum s hs idx := by
+      simp [AbstractSimplicialData.vertexEnum, ht_eq_s]
+    -- Vertex at idx is not in faceOf s' hs' k' = faceOf s hs k
+    have h_nmem : D.vertexEnum s hs idx ∉ D.faceOf s hs k := by
+      have := D.vertexEnum_findOppositeIdx_not_mem hne_erase.choose ht' _ hf' hfc'
+      rwa [hface_eq, hve] at this
+    exact (D.vertexEnum_not_mem_faceOf_iff s hs idx k).mp h_nmem
+  exact h_idx_eq _ _ _
+
+/-- Construct a `Triangulation` from `AbstractSimplicialData`.
+Uses `V : Type` (universe 0) to match `CellComplex.Cell : Type`.
+
+All axioms fully proved: vertex_injective, adj_symm (via adjFn_symm),
+adj_vertex (via adjFn_vertex), adj_ne (via adjFn_ne). -/
+noncomputable def AbstractSimplicialData.toTriangulation
+    {V : Type} [DecidableEq V] [LinearOrder V] {n : ℕ}
+    (D : AbstractSimplicialData V n) :
+    Triangulation V n where
+  Cell := { s : Finset V // s ∈ D.topSimplices }
+  cellDecEq := inferInstance
+  cellFintype := Finset.Subtype.fintype D.topSimplices
+  vertex := fun ⟨s, hs⟩ k => D.vertexEnum s hs k
+  vertex_injective := by
+    intro ⟨s, hs⟩ i j hij
+    have hnd : (s.sort (· ≤ ·)).Nodup := s.sort_nodup (· ≤ ·)
+    set L := s.sort (· ≤ ·) with hL_def
+    set i' : Fin L.length := i.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+    set j' : Fin L.length := j.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+    have hi'j' : L.get i' = L.get j' := hij
+    have key : (i' : ℕ) = (j' : ℕ) := by
+      rw [List.nodup_iff_injective_get] at hnd
+      exact Fin.val_eq_of_eq (hnd hi'j')
+    exact Fin.ext key
+  adj := D.adjFn
+  adj_symm := by
+    intro ⟨s, hs⟩ k ⟨s', hs'⟩ k' hadj
+    exact D.adjFn_symm s hs k s' hs' k' hadj
+  adj_vertex := by
+    intro ⟨s, hs⟩ k ⟨s', hs'⟩ k' hadj
+    exact D.adjFn_vertex s hs k s' hs' k' hadj
+  adj_ne := by
+    intro ⟨s, hs⟩ k ⟨s', hs'⟩ k' hadj heq
+    have hval : s = s' := congr_arg Subtype.val heq
+    exact (D.adjFn_ne s hs k s' hs' k' hadj) hval.symm
+
+/-! ## Example: 1-Dimensional Interval Triangulation
+
+A subdivision of an interval into m segments, with all
+`CellComplex` axioms fully proved (no sorries).
+
+Vertices are natural numbers {0, 1, ..., m}. Cell i (for
+i : Fin m) is the edge [i, i+1] with:
+  vertex 0 = i
+  vertex 1 = i + 1
+
+Adjacency:
+- Face opposite vertex 0 of cell i = {i+1}
+  = face opposite vertex 1 of cell (i+1)
+  So adj i 0 = some (i+1, 1) when i+1 < m
+- Face opposite vertex 1 of cell i = {i}
+  = face opposite vertex 0 of cell (i-1)
+  So adj i 1 = some (i-1, 0) when 0 < i
+-/
+
+section Interval
+
+variable {m : ℕ}
+
+/-- Vertex map for the interval triangulation. -/
+private def ivtx (_ : 0 < m) (i : Fin m) (k : Fin 2) : ℕ :=
+  if k.val = 0 then i.val else i.val + 1
+
+/-- Adjacency for the interval triangulation. Defined as an
+opaque `if/dite` chain. -/
+private def iadj (m : ℕ) (i : Fin m)
+    (k : Fin 2) : Option (Fin m × Fin 2) :=
+  if hk : k.val = 0 then
+    if h : i.val + 1 < m then
+      some (⟨i.val + 1, h⟩, ⟨1, by omega⟩)
+    else
+      none
+  else
+    if h : 0 < i.val then
+      some (⟨i.val - 1, by omega⟩, ⟨0, by omega⟩)
+    else
+      none
+
+/-- Extract data from iadj = some. -/
+private lemma iadj_cases {s s' : Fin m}
+    {k k' : Fin 2}
+    (hadj : iadj m s k = some (s', k')) :
+    (k.val = 0 ∧ s'.val = s.val + 1 ∧ k'.val = 1 ∧
+      s.val + 1 < m) ∨
+    (k.val ≠ 0 ∧ s'.val = s.val - 1 ∧ k'.val = 0 ∧
+      0 < s.val) := by
+  unfold iadj at hadj
+  by_cases hk : k.val = 0
+  · -- k.val = 0
+    rw [dif_pos hk] at hadj
+    by_cases h : s.val + 1 < m
+    · rw [dif_pos h] at hadj
+      left
+      simp only [Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨hs'_eq, hk'_eq⟩ := hadj
+      exact ⟨hk,
+        by have := congr_arg Fin.val hs'_eq; simp at this; omega,
+        by have := congr_arg Fin.val hk'_eq; simp at this; omega,
+        h⟩
+    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
+  · -- k.val ≠ 0
+    rw [dif_neg hk] at hadj
+    by_cases h : (0 : ℕ) < s.val
+    · rw [dif_pos h] at hadj
+      right
+      simp only [Option.some.injEq, Prod.mk.injEq] at hadj
+      obtain ⟨hs'_eq, hk'_eq⟩ := hadj
+      exact ⟨hk,
+        by have := congr_arg Fin.val hs'_eq; simp at this; omega,
+        by have := congr_arg Fin.val hk'_eq; simp at this; omega,
+        h⟩
+    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
+
+private lemma iadj_symm' {s s' : Fin m}
+    {k k' : Fin 2}
+    (hadj : iadj m s k = some (s', k')) :
+    iadj m s' k' = some (s, k) := by
+  obtain (⟨hk, hs', hk', hlt⟩ | ⟨hk, hs', hk', hpos⟩) :=
+    iadj_cases hadj
+  · -- k.val=0, s'=s+1, k'.val=1: need iadj m s' k' = some (s, k)
+    -- i.e. iadj m ⟨s.val+1,_⟩ ⟨1,_⟩ = some (s, ⟨0,_⟩)
+    -- which reduces to: 0 < s'.val → some (⟨s'.val-1,_⟩, ⟨0,_⟩)
+    show iadj m s' k' = some (s, k)
+    unfold iadj
+    have : ¬(k'.val = 0) := by omega
+    rw [dif_neg this]
+    have : (0 : ℕ) < s'.val := by omega
+    rw [dif_pos this]
+    simp only [Option.some.injEq, Prod.mk.injEq]
+    exact ⟨Fin.ext (by simp; omega), Fin.ext (by simp; omega)⟩
+  · -- k.val≠0, s'=s-1, k'.val=0: need iadj m s' k' = some (s, k)
+    show iadj m s' k' = some (s, k)
+    unfold iadj
+    have : k'.val = 0 := by omega
+    rw [dif_pos this]
+    have : s'.val + 1 < m := by omega
+    rw [dif_pos this]
+    simp only [Option.some.injEq, Prod.mk.injEq]
+    exact ⟨Fin.ext (by simp; omega), Fin.ext (by simp; omega)⟩
+
+private lemma iadj_ne' {s s' : Fin m}
+    {k k' : Fin 2}
+    (hadj : iadj m s k = some (s', k')) :
+    s ≠ s' := by
+  obtain (⟨_, hs', _, _⟩ | ⟨_, hs', _, _⟩) := iadj_cases hadj
+  · intro heq; have := congr_arg Fin.val heq; omega
+  · intro heq; have := congr_arg Fin.val heq; omega
+
+private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
+    {k k' : Fin 2}
+    (hadj : iadj m s k = some (s', k')) :
+    (univ.erase k).image (ivtx hm s) =
+    (univ.erase k').image (ivtx hm s') := by
+  obtain (⟨hk, hs', hk', _⟩ | ⟨hk, hs', hk', _⟩) :=
+    iadj_cases hadj
+  · -- k.val=0, s'=s+1, k'.val=1
+    have hkeq : k = ⟨0, by omega⟩ := Fin.ext hk
+    have hk'eq : k' = ⟨1, by omega⟩ := Fin.ext hk'
+    rw [hkeq, hk'eq]
+    ext v; constructor
+    · intro hv
+      rw [mem_image] at hv ⊢
+      obtain ⟨a, ha_mem, ha_eq⟩ := hv
+      rw [mem_erase] at ha_mem
+      have ha1 : a.val = 1 := by have := a.isLt; omega
+      refine ⟨⟨0, by omega⟩,
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
+      rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
+      simp [ivtx] at ha_eq ⊢; omega
+    · intro hv
+      rw [mem_image] at hv ⊢
+      obtain ⟨a, ha_mem, ha_eq⟩ := hv
+      rw [mem_erase] at ha_mem
+      have ha0 : a.val = 0 := by have := a.isLt; omega
+      refine ⟨⟨1, by omega⟩,
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
+      rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
+      simp [ivtx] at ha_eq ⊢; omega
+  · -- k.val≠0 (so k.val=1), s'=s-1, k'.val=0
+    have hk1 : k.val = 1 := by have := k.isLt; omega
+    have hkeq : k = ⟨1, by omega⟩ := Fin.ext hk1
+    have hk'eq : k' = ⟨0, by omega⟩ := Fin.ext hk'
+    rw [hkeq, hk'eq]
+    ext v; constructor
+    · intro hv
+      rw [mem_image] at hv ⊢
+      obtain ⟨a, ha_mem, ha_eq⟩ := hv
+      rw [mem_erase] at ha_mem
+      have ha0 : a.val = 0 := by have := a.isLt; omega
+      refine ⟨⟨1, by omega⟩,
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
+      rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
+      simp [ivtx] at ha_eq ⊢; omega
+    · intro hv
+      rw [mem_image] at hv ⊢
+      obtain ⟨a, ha_mem, ha_eq⟩ := hv
+      rw [mem_erase] at ha_mem
+      have ha1 : a.val = 1 := by have := a.isLt; omega
+      refine ⟨⟨0, by omega⟩,
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
+      rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
+      simp [ivtx] at ha_eq ⊢; omega
+
+/-- A subdivision of [0,m] into m unit intervals, as a
+`Triangulation Nat 1`. All axioms fully proved. -/
+def intervalTriangulation (m : ℕ) (hm : 0 < m) :
+    Triangulation ℕ 1 where
+  Cell := Fin m
+  cellDecEq := inferInstance
+  cellFintype := inferInstance
+  vertex := ivtx hm
+  vertex_injective := by
+    intro i a b hab
+    simp only [ivtx] at hab
+    fin_cases a <;> fin_cases b <;> simp_all
+  adj := iadj m
+  adj_symm := fun s k s' k' hadj => iadj_symm' hadj
+  adj_vertex := fun s k s' k' hadj => iadj_vertex' hadj
+  adj_ne := fun s k s' k' hadj => iadj_ne' hadj
+
+end Interval
+
+/-! ## Interval Sperner's Lemma
+
+As a sanity check, we state the 1-d Sperner theorem for the
+interval triangulation and prove it via the abstract theorem. -/
+
+/-- 1-d Sperner's lemma for intervals: if the boundary doors
+are odd, a panchromatic cell exists. -/
+theorem interval_sperner (m : ℕ) (hm : 0 < m)
+    (c : ℕ → Fin 2)
+    (hbdry : Odd (Finset.univ.filter
+      (fun p : Fin m × Fin 2 =>
+        CellComplex.IsDoor c
+          (intervalTriangulation m hm).toCellComplex p.1 p.2 ∧
+        (intervalTriangulation m hm).adj p.1 p.2 = none)).card) :
+    ∃ s : Fin m,
+      CellComplex.IsPanchromatic c
+        (intervalTriangulation m hm).toCellComplex s :=
+  Triangulation.sperner (intervalTriangulation m hm) c hbdry
+
+end Triangulation

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 RJ Walters. All rights reserved.
+Copyright (c) 2026 Robb Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robb Walters
 -/
@@ -176,18 +176,11 @@ theorem boundary_doors_odd (T : Triangulation V n)
     (c : V → Fin (n + 1))
     (onFace : V → Fin (n + 1) → Prop)
     [∀ v k, Decidable (onFace v k)]
-    (_hSperner : IsSpernerColoring c onFace)
-    (_hBoundaryOnFace : ∀ s k, T.adj s k = none →
+    (hSperner : IsSpernerColoring c onFace)
+    (hBoundaryOnFace : ∀ s k, T.adj s k = none →
       ∃ faceIdx : Fin (n + 1), ∀ j : Fin (n + 1),
         j ≠ k → onFace (T.vertex s j) faceIdx)
-    (_hLowerDim : ∀ faceIdx : Fin (n + 1),
-      faceIdx.val < n →
-      Even (Finset.univ.filter (fun p : T.Cell × Fin (n + 1) =>
-        CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
-        T.adj p.1 p.2 = none ∧
-        (∀ j : Fin (n + 1), j ≠ p.2 →
-          onFace (T.vertex p.1 j) faceIdx))).card)
-    (_hLastFace : Odd (Finset.univ.filter
+    (hLastFace : Odd (Finset.univ.filter
       (fun p : T.Cell × Fin (n + 1) =>
         CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
         T.adj p.1 p.2 = none ∧
@@ -199,7 +192,7 @@ theorem boundary_doors_odd (T : Triangulation V n)
         CellComplex.IsDoor c (T.toCellComplex) p.1 p.2 ∧
         T.adj p.1 p.2 = none)).card := by
   -- Strategy: show S = S_n (every boundary door must be on the last face)
-  -- then |S| = |S_n| is odd by _hLastFace.
+  -- then |S| = |S_n| is odd by hLastFace.
   --
   -- Key insight: if a boundary door (s,k) is on face faceIdx with faceIdx.val < n,
   -- the Sperner condition contradicts the door condition (IsDoor requires color
@@ -214,7 +207,7 @@ theorem boundary_doors_odd (T : Triangulation V n)
         T.adj p.1 p.2 = none ∧
         (∀ j : Fin (n + 1), j ≠ p.2 →
           onFace (T.vertex p.1 j) ⟨n, by omega⟩)) by
-    rw [h]; exact _hLastFace
+    rw [h]; exact hLastFace
   -- Prove the two filter sets are equal
   ext ⟨s, k⟩
   simp only [Finset.mem_filter, Finset.mem_univ, true_and]
@@ -222,8 +215,8 @@ theorem boundary_doors_odd (T : Triangulation V n)
   · -- S ⊆ S_n: every boundary door is on the last face
     intro ⟨hDoor, hAdj⟩
     refine ⟨hDoor, hAdj, ?_⟩
-    -- By _hBoundaryOnFace, this door is on some face faceIdx
-    obtain ⟨faceIdx, hOnFace⟩ := _hBoundaryOnFace s k hAdj
+    -- By hBoundaryOnFace, this door is on some face faceIdx
+    obtain ⟨faceIdx, hOnFace⟩ := hBoundaryOnFace s k hAdj
     -- Show faceIdx = ⟨n, _⟩ by contradiction
     by_cases hlt : faceIdx.val < n
     · -- Contradiction: IsDoor requires color faceIdx on some non-k vertex,
@@ -235,7 +228,7 @@ theorem boundary_doors_odd (T : Triangulation V n)
       -- Vertex i is on face faceIdx (since i ≠ k)
       have hOnFace_i := hOnFace i hi_ne
       -- Sperner says c(vertex s i) ≠ faceIdx
-      have hSperner_i := _hSperner (T.vertex s i) faceIdx hOnFace_i
+      have hSperner_i := hSperner (T.vertex s i) faceIdx hOnFace_i
       -- But hi_color says c(vertex s i) = castSucc ⟨faceIdx.val, hlt⟩ = faceIdx
       -- T.toCellComplex.vertex = T.vertex by definition
       change c (T.vertex s i) = _ at hi_color
@@ -833,12 +826,12 @@ section Interval
 variable {m : ℕ}
 
 /-- Vertex map for the interval triangulation. -/
-def ivtx (i : Fin m) (k : Fin 2) : ℕ :=
+def intervalVertex (i : Fin m) (k : Fin 2) : ℕ :=
   if k.val = 0 then i.val else i.val + 1
 
 /-- Adjacency for the interval triangulation. Defined as an
 opaque `if/dite` chain. -/
-def iadj (m : ℕ) (i : Fin m)
+def intervalAdj (m : ℕ) (i : Fin m)
     (k : Fin 2) : Option (Fin m × Fin 2) :=
   if hk : k.val = 0 then
     if h : i.val + 1 < m then
@@ -851,15 +844,15 @@ def iadj (m : ℕ) (i : Fin m)
     else
       none
 
-/-- Extract data from iadj = some. -/
-lemma iadj_cases {s s' : Fin m}
+/-- Extract data from intervalAdj = some. -/
+lemma intervalAdj_cases {s s' : Fin m}
     {k k' : Fin 2}
-    (hadj : iadj m s k = some (s', k')) :
+    (hadj : intervalAdj m s k = some (s', k')) :
     (k.val = 0 ∧ s'.val = s.val + 1 ∧ k'.val = 1 ∧
       s.val + 1 < m) ∨
     (k.val ≠ 0 ∧ s'.val = s.val - 1 ∧ k'.val = 0 ∧
       0 < s.val) := by
-  unfold iadj at hadj
+  unfold intervalAdj at hadj
   by_cases hk : k.val = 0
   · -- k.val = 0
     rw [dif_pos hk] at hadj
@@ -886,26 +879,26 @@ lemma iadj_cases {s s' : Fin m}
         h⟩
     · rw [dif_neg h] at hadj; exact nomatch hadj
 
-lemma iadj_symm' {s s' : Fin m}
+lemma intervalAdj_symm {s s' : Fin m}
     {k k' : Fin 2}
-    (hadj : iadj m s k = some (s', k')) :
-    iadj m s' k' = some (s, k) := by
+    (hadj : intervalAdj m s k = some (s', k')) :
+    intervalAdj m s' k' = some (s, k) := by
   obtain (⟨hk, hs', hk', hlt⟩ | ⟨hk, hs', hk', hpos⟩) :=
-    iadj_cases hadj
-  · -- k.val=0, s'=s+1, k'.val=1: need iadj m s' k' = some (s, k)
-    -- i.e. iadj m ⟨s.val+1,_⟩ ⟨1,_⟩ = some (s, ⟨0,_⟩)
+    intervalAdj_cases hadj
+  · -- k.val=0, s'=s+1, k'.val=1: need intervalAdj m s' k' = some (s, k)
+    -- i.e. intervalAdj m ⟨s.val+1,_⟩ ⟨1,_⟩ = some (s, ⟨0,_⟩)
     -- which reduces to: 0 < s'.val → some (⟨s'.val-1,_⟩, ⟨0,_⟩)
-    show iadj m s' k' = some (s, k)
-    unfold iadj
+    show intervalAdj m s' k' = some (s, k)
+    unfold intervalAdj
     have : ¬(k'.val = 0) := by omega
     rw [dif_neg this]
     have : (0 : ℕ) < s'.val := by omega
     rw [dif_pos this]
     simp only [Option.some.injEq, Prod.mk.injEq]
     exact ⟨Fin.ext (by simp; omega), Fin.ext (by simp; omega)⟩
-  · -- k.val≠0, s'=s-1, k'.val=0: need iadj m s' k' = some (s, k)
-    show iadj m s' k' = some (s, k)
-    unfold iadj
+  · -- k.val≠0, s'=s-1, k'.val=0: need intervalAdj m s' k' = some (s, k)
+    show intervalAdj m s' k' = some (s, k)
+    unfold intervalAdj
     have : k'.val = 0 := by omega
     rw [dif_pos this]
     have : s'.val + 1 < m := by omega
@@ -913,21 +906,21 @@ lemma iadj_symm' {s s' : Fin m}
     simp only [Option.some.injEq, Prod.mk.injEq]
     exact ⟨Fin.ext (by simp; omega), Fin.ext (by simp; omega)⟩
 
-lemma iadj_ne' {s s' : Fin m}
+lemma intervalAdj_ne {s s' : Fin m}
     {k k' : Fin 2}
-    (hadj : iadj m s k = some (s', k')) :
+    (hadj : intervalAdj m s k = some (s', k')) :
     s ≠ s' := by
-  obtain (⟨_, hs', _, _⟩ | ⟨_, hs', _, _⟩) := iadj_cases hadj
+  obtain (⟨_, hs', _, _⟩ | ⟨_, hs', _, _⟩) := intervalAdj_cases hadj
   · intro heq; have := congr_arg Fin.val heq; omega
   · intro heq; have := congr_arg Fin.val heq; omega
 
-lemma iadj_vertex' {s s' : Fin m}
+lemma intervalAdj_vertex {s s' : Fin m}
     {k k' : Fin 2}
-    (hadj : iadj m s k = some (s', k')) :
-    (univ.erase k).image (ivtx s) =
-    (univ.erase k').image (ivtx s') := by
+    (hadj : intervalAdj m s k = some (s', k')) :
+    (univ.erase k).image (intervalVertex s) =
+    (univ.erase k').image (intervalVertex s') := by
   obtain (⟨hk, hs', hk', _⟩ | ⟨hk, hs', hk', _⟩) :=
-    iadj_cases hadj
+    intervalAdj_cases hadj
   · -- k.val=0, s'=s+1, k'.val=1
     have hkeq : k = ⟨0, by omega⟩ := Fin.ext hk
     have hk'eq : k' = ⟨1, by omega⟩ := Fin.ext hk'
@@ -941,7 +934,7 @@ lemma iadj_vertex' {s s' : Fin m}
       refine ⟨⟨0, by omega⟩,
         mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
-      simp [ivtx] at ha_eq ⊢; omega
+      simp [intervalVertex] at ha_eq ⊢; omega
     · intro hv
       rw [mem_image] at hv ⊢
       obtain ⟨a, ha_mem, ha_eq⟩ := hv
@@ -950,7 +943,7 @@ lemma iadj_vertex' {s s' : Fin m}
       refine ⟨⟨1, by omega⟩,
         mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
-      simp [ivtx] at ha_eq ⊢; omega
+      simp [intervalVertex] at ha_eq ⊢; omega
   · -- k.val≠0 (so k.val=1), s'=s-1, k'.val=0
     have hk1 : k.val = 1 := by have := k.isLt; omega
     have hkeq : k = ⟨1, by omega⟩ := Fin.ext hk1
@@ -965,7 +958,7 @@ lemma iadj_vertex' {s s' : Fin m}
       refine ⟨⟨1, by omega⟩,
         mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
-      simp [ivtx] at ha_eq ⊢; omega
+      simp [intervalVertex] at ha_eq ⊢; omega
     · intro hv
       rw [mem_image] at hv ⊢
       obtain ⟨a, ha_mem, ha_eq⟩ := hv
@@ -974,7 +967,7 @@ lemma iadj_vertex' {s s' : Fin m}
       refine ⟨⟨0, by omega⟩,
         mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
-      simp [ivtx] at ha_eq ⊢; omega
+      simp [intervalVertex] at ha_eq ⊢; omega
 
 /-- A subdivision of [0,m] into m unit intervals, as a
 `Triangulation Nat 1`. All axioms fully proved. -/
@@ -983,15 +976,15 @@ def intervalTriangulation (m : ℕ) :
   Cell := Fin m
   cellDecEq := inferInstance
   cellFintype := inferInstance
-  vertex := ivtx
+  vertex := intervalVertex
   vertex_injective := by
     intro i a b hab
-    simp only [ivtx] at hab
+    simp only [intervalVertex] at hab
     fin_cases a <;> fin_cases b <;> simp_all
-  adj := iadj m
-  adj_symm := fun s k s' k' hadj => iadj_symm' hadj
-  adj_vertex := fun s k s' k' hadj => iadj_vertex' hadj
-  adj_ne := fun s k s' k' hadj => iadj_ne' hadj
+  adj := intervalAdj m
+  adj_symm := fun s k s' k' hadj => intervalAdj_symm hadj
+  adj_vertex := fun s k s' k' hadj => intervalAdj_vertex hadj
+  adj_ne := fun s k s' k' hadj => intervalAdj_ne hadj
 
 end Interval
 

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -3,9 +3,8 @@ Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
-module
 
-public import Mathlib.Combinatorics.Sperner.Basic
+import Mathlib.Combinatorics.Sperner.Basic
 
 /-!
 # SimplicialComplex to CellComplex Bridge for Sperner's Lemma

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: RJ Walters
+Authors: Robb Walters
 -/
 module
 

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -452,7 +452,9 @@ lemma AbstractSimplicialData.vertexEnum_image_univ
     obtain ⟨idx, hidx_lt, hidx_eq⟩ := hv_sort
     have hidx_lt' : idx < n + 1 := by
       rwa [Finset.length_sort, D.card_eq s hs] at hidx_lt
-    exact ⟨⟨idx, hidx_lt'⟩, by show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq⟩
+    exact ⟨⟨idx, hidx_lt'⟩, by
+      change (s.sort (· ≤ ·)).get _ = v
+      simp only [List.get_eq_getElem]; exact hidx_eq⟩
 
 /-- Image of `univ.erase k` under vertexEnum equals faceOf. -/
 lemma AbstractSimplicialData.vertexEnum_image_erase
@@ -475,13 +477,15 @@ lemma AbstractSimplicialData.vertexEnum_image_erase
     · intro heq
       apply hne
       have : D.vertexEnum s hs ⟨idx, hidx_lt'⟩ = v := by
-        show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
+        change (s.sort (· ≤ ·)).get _ = v
+        simp only [List.get_eq_getElem]; exact hidx_eq
       rw [← this, heq]
-    · show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
+    · change (s.sort (· ≤ ·)).get _ = v
+      simp only [List.get_eq_getElem]; exact hidx_eq
 
 /-- Unfold faceOf. -/
 lemma AbstractSimplicialData.faceOf_eq
-    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n+1)) :
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
     D.faceOf s hs k = s.erase (D.vertexEnum s hs k) := rfl
 
 /-- Vertex j is not in face k iff j = k.
@@ -489,7 +493,7 @@ The forward direction: if vertexEnum j is not in s.erase(vertexEnum k),
 then vertexEnum j = vertexEnum k (since vertexEnum j ∈ s), hence j = k by injectivity.
 The backward direction: vertexEnum k ∉ s.erase(vertexEnum k) by Finset.not_mem_erase. -/
 lemma AbstractSimplicialData.vertexEnum_not_mem_faceOf_iff
-    (s : Finset V) (hs : s ∈ D.topSimplices) (j k : Fin (n+1)) :
+    (s : Finset V) (hs : s ∈ D.topSimplices) (j k : Fin (n + 1)) :
     D.vertexEnum s hs j ∉ D.faceOf s hs k ↔ j = k := by
   simp only [faceOf, Finset.mem_erase, not_and_or, not_not]
   constructor

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -501,11 +501,14 @@ lemma AbstractSimplicialData.vertexEnum_not_mem_faceOf_iff
 Since the only vertex not in faceOf s hs k is vertexEnum s hs k (at index k),
 and findOppositeIdx picks such an index, it must pick k. -/
 lemma AbstractSimplicialData.findOppositeIdx_eq
-    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n+1)) :
-    D.findOppositeIdx s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k) = k := by
-  set idx := D.findOppositeIdx s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
+    (s : Finset V) (hs : s ∈ D.topSimplices) (k : Fin (n + 1)) :
+    D.findOppositeIdx s hs (D.faceOf s hs k)
+      (D.faceOf_subset s hs k) (D.faceOf_card s hs k) = k := by
+  set idx := D.findOppositeIdx s hs (D.faceOf s hs k)
+    (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
   have h_not_mem : D.vertexEnum s hs idx ∉ D.faceOf s hs k :=
-    D.vertexEnum_findOppositeIdx_not_mem s hs (D.faceOf s hs k) (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
+    D.vertexEnum_findOppositeIdx_not_mem s hs (D.faceOf s hs k)
+      (D.faceOf_subset s hs k) (D.faceOf_card s hs k)
   exact (D.vertexEnum_not_mem_faceOf_iff s hs idx k).mp h_not_mem
 
 end FaceHelpers
@@ -754,8 +757,10 @@ lemma AbstractSimplicialData.adjFn_symm
       simp [AbstractSimplicialData.vertexEnum, ht_eq_s]
     -- Vertex at idx is not in faceOf s' hs' k' = faceOf s hs k
     have h_nmem : D.vertexEnum s hs idx ∉ D.faceOf s hs k := by
-      have := D.vertexEnum_findOppositeIdx_not_mem hne_erase.choose ht' _ hf' hfc'
-      rwa [hface_eq, hve] at this
+      have h1 := D.vertexEnum_findOppositeIdx_not_mem hne_erase.choose ht' _ hf' hfc'
+      rw [hve] at h1
+      intro hmem
+      exact h1 (by rwa [hface_eq, hf_def])
     exact (D.vertexEnum_not_mem_faceOf_iff s hs idx k).mp h_nmem
   exact h_idx_eq _ _ _
 
@@ -776,8 +781,10 @@ noncomputable def AbstractSimplicialData.toTriangulation
     intro ⟨s, hs⟩ i j hij
     have hnd : (s.sort (· ≤ ·)).Nodup := s.sort_nodup (· ≤ ·)
     set L := s.sort (· ≤ ·) with hL_def
-    set i' : Fin L.length := i.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
-    set j' : Fin L.length := j.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+    set i' : Fin L.length :=
+      i.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
+    set j' : Fin L.length :=
+      j.cast (by rw [hL_def, Finset.length_sort]; exact (D.card_eq s hs).symm)
     have hi'j' : L.get i' = L.get j' := hij
     have key : (i' : ℕ) = (j' : ℕ) := by
       rw [List.nodup_iff_injective_get] at hnd
@@ -858,7 +865,7 @@ private lemma iadj_cases {s s' : Fin m}
         by have := congr_arg Fin.val hs'_eq; simp at this; omega,
         by have := congr_arg Fin.val hk'_eq; simp at this; omega,
         h⟩
-    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
+    · rw [dif_neg h] at hadj; exact nomatch hadj
   · -- k.val ≠ 0
     rw [dif_neg hk] at hadj
     by_cases h : (0 : ℕ) < s.val
@@ -870,7 +877,7 @@ private lemma iadj_cases {s s' : Fin m}
         by have := congr_arg Fin.val hs'_eq; simp at this; omega,
         by have := congr_arg Fin.val hk'_eq; simp at this; omega,
         h⟩
-    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
+    · rw [dif_neg h] at hadj; exact nomatch hadj
 
 private lemma iadj_symm' {s s' : Fin m}
     {k k' : Fin 2}

--- a/Mathlib/Combinatorics/Sperner/Triangulation.lean
+++ b/Mathlib/Combinatorics/Sperner/Triangulation.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
+module
 
-import Mathlib.Combinatorics.Sperner.Basic
-import Mathlib.Data.Finset.Sort
+public import Mathlib.Combinatorics.Sperner.Basic
+public import Mathlib.Data.Finset.Sort
 
 /-!
 # SimplicialComplex to CellComplex Bridge for Sperner's Lemma
@@ -57,6 +58,8 @@ interval example with fully proved axioms.
 
 Sperner, simplicial complex, triangulation, cell complex, bridge
 -/
+
+@[expose] public section
 
 open Finset
 
@@ -365,7 +368,7 @@ in `t`'s sorted vertex list of the unique vertex in `t \ f`.
 Returns the position of the "opposite" vertex. -/
 noncomputable def AbstractSimplicialData.findOppositeIdx
     (t : Finset V) (ht : t ∈ D.topSimplices)
-    (f : Finset V) (_hf : f ⊆ t) (hfc : f.card = n) :
+    (f : Finset V) (hf : f ⊆ t) (hfc : f.card = n) :
     Fin (n + 1) :=
   -- There exists k such that vertexEnum t ht k is not in f.
   -- Since t has n+1 vertices and f has n with f ⊆ t, at least one
@@ -373,7 +376,7 @@ noncomputable def AbstractSimplicialData.findOppositeIdx
   have hex : ∃ k : Fin (n + 1), D.vertexEnum t ht k ∉ f := by
     by_contra hall
     push_neg at hall
-    -- Every vertex of t is in f, so t ⊆ f
+    -- Every vertex of t is in f, so t ⊆ f (contradicting |f| < |t|)
     have hsub : t ⊆ f := by
       intro v hv
       -- v is in t, so v appears somewhere in t.sort
@@ -391,9 +394,8 @@ noncomputable def AbstractSimplicialData.findOppositeIdx
         simp only [vertexEnum, List.get_eq_getElem]
         exact hidx_eq
       rwa [heq] at hmem
-    have := Finset.card_le_card hsub
-    rw [D.card_eq t ht, hfc] at this
-    omega
+    exact absurd (Finset.Subset.antisymm hsub hf |> congrArg Finset.card)
+      (by rw [D.card_eq t ht, hfc]; omega)
   hex.choose
 
 /-- The opposite vertex is not in the face. -/
@@ -821,17 +823,18 @@ Adjacency:
   So adj i 1 = some (i-1, 0) when 0 < i
 -/
 
+
 section Interval
 
 variable {m : ℕ}
 
 /-- Vertex map for the interval triangulation. -/
-private def ivtx (_ : 0 < m) (i : Fin m) (k : Fin 2) : ℕ :=
+def ivtx (i : Fin m) (k : Fin 2) : ℕ :=
   if k.val = 0 then i.val else i.val + 1
 
 /-- Adjacency for the interval triangulation. Defined as an
 opaque `if/dite` chain. -/
-private def iadj (m : ℕ) (i : Fin m)
+def iadj (m : ℕ) (i : Fin m)
     (k : Fin 2) : Option (Fin m × Fin 2) :=
   if hk : k.val = 0 then
     if h : i.val + 1 < m then
@@ -845,7 +848,7 @@ private def iadj (m : ℕ) (i : Fin m)
       none
 
 /-- Extract data from iadj = some. -/
-private lemma iadj_cases {s s' : Fin m}
+lemma iadj_cases {s s' : Fin m}
     {k k' : Fin 2}
     (hadj : iadj m s k = some (s', k')) :
     (k.val = 0 ∧ s'.val = s.val + 1 ∧ k'.val = 1 ∧
@@ -879,7 +882,7 @@ private lemma iadj_cases {s s' : Fin m}
         h⟩
     · rw [dif_neg h] at hadj; exact nomatch hadj
 
-private lemma iadj_symm' {s s' : Fin m}
+lemma iadj_symm' {s s' : Fin m}
     {k k' : Fin 2}
     (hadj : iadj m s k = some (s', k')) :
     iadj m s' k' = some (s, k) := by
@@ -906,7 +909,7 @@ private lemma iadj_symm' {s s' : Fin m}
     simp only [Option.some.injEq, Prod.mk.injEq]
     exact ⟨Fin.ext (by simp; omega), Fin.ext (by simp; omega)⟩
 
-private lemma iadj_ne' {s s' : Fin m}
+lemma iadj_ne' {s s' : Fin m}
     {k k' : Fin 2}
     (hadj : iadj m s k = some (s', k')) :
     s ≠ s' := by
@@ -914,11 +917,11 @@ private lemma iadj_ne' {s s' : Fin m}
   · intro heq; have := congr_arg Fin.val heq; omega
   · intro heq; have := congr_arg Fin.val heq; omega
 
-private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
+lemma iadj_vertex' {s s' : Fin m}
     {k k' : Fin 2}
     (hadj : iadj m s k = some (s', k')) :
-    (univ.erase k).image (ivtx hm s) =
-    (univ.erase k').image (ivtx hm s') := by
+    (univ.erase k).image (ivtx s) =
+    (univ.erase k').image (ivtx s') := by
   obtain (⟨hk, hs', hk', _⟩ | ⟨hk, hs', hk', _⟩) :=
     iadj_cases hadj
   · -- k.val=0, s'=s+1, k'.val=1
@@ -971,12 +974,12 @@ private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
 
 /-- A subdivision of [0,m] into m unit intervals, as a
 `Triangulation Nat 1`. All axioms fully proved. -/
-def intervalTriangulation (m : ℕ) (hm : 0 < m) :
+def intervalTriangulation (m : ℕ) :
     Triangulation ℕ 1 where
   Cell := Fin m
   cellDecEq := inferInstance
   cellFintype := inferInstance
-  vertex := ivtx hm
+  vertex := ivtx
   vertex_injective := by
     intro i a b hab
     simp only [ivtx] at hab
@@ -995,16 +998,16 @@ interval triangulation and prove it via the abstract theorem. -/
 
 /-- 1-d Sperner's lemma for intervals: if the boundary doors
 are odd, a panchromatic cell exists. -/
-theorem interval_sperner (m : ℕ) (hm : 0 < m)
+theorem interval_sperner (m : ℕ)
     (c : ℕ → Fin 2)
     (hbdry : Odd (Finset.univ.filter
       (fun p : Fin m × Fin 2 =>
         CellComplex.IsDoor c
-          (intervalTriangulation m hm).toCellComplex p.1 p.2 ∧
-        (intervalTriangulation m hm).adj p.1 p.2 = none)).card) :
+          (intervalTriangulation m).toCellComplex p.1 p.2 ∧
+        (intervalTriangulation m).adj p.1 p.2 = none)).card) :
     ∃ s : Fin m,
       CellComplex.IsPanchromatic c
-        (intervalTriangulation m hm).toCellComplex s :=
-  Triangulation.sperner (intervalTriangulation m hm) c hbdry
+        (intervalTriangulation m).toCellComplex s :=
+  Triangulation.sperner (intervalTriangulation m) c hbdry
 
 end Triangulation


### PR DESCRIPTION
## Summary

Contributes the abstract combinatorial core toward #25231, following the decomposition suggested by @YaelDillies:

> 1. Prove Sperner's lemma for any set family satisfying said axiom
> 2. Separately show that simplicial complexes satisfy said axiom

This PR addresses both parts at the abstract/combinatorial level. A future PR can connect to `Geometry.SimplicialComplex` for the full geometric statement.

**Note:** This is not the full geometric Sperner theorem. The main result (`CellComplex.sperner`) takes `Odd (boundary door count)` as an *input hypothesis*, not derived from a Sperner boundary coloring. The geometric verification that a Sperner coloring on a triangulation of the standard simplex produces an odd number of boundary doors requires connecting to `Geometry.SimplicialComplex` and is left for a follow-up.

### Files

- **`Combinatorics/Sperner/Basic.lean`**: Abstract `CellComplex` structure with adjacency axioms, and the Sperner parity theorem via door-counting.
- **`Combinatorics/Sperner/Triangulation.lean`**: `Triangulation` → `CellComplex` bridge, `AbstractSimplicialData` (unordered simplices with pseudomanifold property), and a 1-d interval sanity check.

### Main results

- `Finset.even_card_of_fixedPointFree_involution`: a fixed-point-free involution on a finset implies even cardinality (standalone, may be independently useful)
- `door_count_parity`: per-cell door count parity equals surjectivity indicator
- `CellComplex.sperner_parity`: panchromatic cell count ≡ boundary door count (mod 2)
- `CellComplex.sperner`: if boundary doors are odd, a panchromatic cell exists
- `AbstractSimplicialData.toTriangulation`: construction from unordered simplices with all axioms proved
- `intervalTriangulation`: concrete 1-d example

### Proof approach

The classical door-counting argument:
1. Interior doors pair via the adjacency involution (even count, via `Finset.sum_involution`)
2. Boundary doors are unpaired
3. Per-cell parity: door count has same parity as panchromaticity indicator (pigeonhole fiber analysis)
4. Sum over cells gives the global parity theorem

### Status

- 0 sorries, 0 axioms
- Builds within default `maxHeartbeats` (200,000)
- All adjacency axioms for `AbstractSimplicialData.toTriangulation` fully proved

### Naming notes

The structure names (`CellComplex`, `Triangulation`) are provisional — happy to rename based on reviewer preference (e.g., `SpernerComplex`, `FacetAdjacencyComplex`).

### AI disclosure

Proof development by Claude (Anthropic). 

Co-authored-by: Claude <noreply@anthropic.com>