### PR TITLE
[Merged by Bors] - feat(Multiset): add powersetCard_self

### DIFF
--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -294,6 +294,12 @@ theorem powersetCard_card_add (s : Multiset α) {i : ℕ} (hi : 0 < i) :
     s.powersetCard (card s + i) = 0 := by
   simp [hi]
 
+@[simp]
+theorem powersetCard_self (s : Multiset α) : powersetCard s.card s = {s} := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons _ _ ih => simp [ih]
+
 theorem powersetCard_map {β : Type*} (f : α → β) (n : ℕ) (s : Multiset α) :
     powersetCard n (s.map f) = (powersetCard n s).map (map f) := by
   induction s using Multiset.induction generalizing n with


### PR DESCRIPTION
this PR adds `Multiset.powersetCard_self`.

a corresponding lemma already exists for `Finset` ([Finset.powersetCard_self](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Finset/Powerset.html#Finset.powersetCard_self)), but was missing for `Multiset`.