### PR TITLE
[Merged by Bors] - feat: make alias_in work with the module system

### DIFF
--- a/Mathlib/Util/AliasIn.lean
+++ b/Mathlib/Util/AliasIn.lean
@@ -8,6 +8,7 @@ module
 public meta import Mathlib.Lean.Expr.Basic
 public import Batteries.Tactic.Alias
 public import Lean.Exception
+public import Mathlib.Tactic.Core
 
 /-! ## The `@[alias_in]` attribute -/
 
@@ -50,12 +51,15 @@ initialize registerBuiltinAttribute {
       let newNamespace := nm.getId.components
       let num := num.map (·.getNat) |>.getD newNamespace.length
       let components := src.components
+      if (← toModifiers src).visibility.isPrivate then
+        throwError "The `alias_in` attribute cannot be used for private declarations."
       if components.length ≤ num then
         throwError m!"{src} has only {components.length - 1} namespaces, cannot remove {num}.\n\
         Use `@[alias_in {nm} {components.length - 1}]` instead."
       let tgtName := .fromComponents <|
         components.take (components.length - 1 - num) ++ newNamespace ++ [components.getLast!]
-      liftCommandElabM <| elabCommand <| ← `(command| alias $(mkIdent tgtName) := $(mkIdent src))
+      liftCommandElabM <| elabCommand <|
+        ← `(command| public alias $(mkIdent tgtName) := $(mkIdent src))
       -- add mouse-over text
       Term.addTermInfo' nm (← mkConstWithLevelParams tgtName) (isBinder := true) |>.run' |>.run'
     | _, _, _ => throwUnsupportedSyntax }

--- a/MathlibTest/Util/AliasIn/AliasIn.lean
+++ b/MathlibTest/Util/AliasIn/AliasIn.lean
@@ -1,0 +1,18 @@
+import Mathlib.Util.AliasIn
+
+@[alias_in Baz] def Foo.Bar.baz : Nat := 1
+/-- info: Foo.Baz.baz : Nat -/
+#guard_msgs in
+#check Foo.Baz.baz
+
+@[alias_in Baz.Qux 1] def Foo.Bar.baz2 : Nat := 2
+/-- info: Foo.Baz.Qux.baz2 : Nat -/
+#guard_msgs in
+#check Foo.Baz.Qux.baz2
+
+/--
+error: Foo.Bar.baz3 has only 2 namespaces, cannot remove 3.
+Use `@[alias_in Baz.Qux 2]` instead.
+-/
+#guard_msgs in
+@[alias_in Baz.Qux 3] def Foo.Bar.baz3 : Nat := 2

--- a/MathlibTest/Util/AliasIn/AliasIn.lean
+++ b/MathlibTest/Util/AliasIn/AliasIn.lean
@@ -1,5 +1,7 @@
 import Mathlib.Util.AliasIn
 
+/-! Tests for the `@[alias_in]` attribute without the module system -/
+
 @[alias_in Baz] def Foo.Bar.baz : Nat := 1
 /-- info: Foo.Baz.baz : Nat -/
 #guard_msgs in
@@ -16,3 +18,8 @@ Use `@[alias_in Baz.Qux 2]` instead.
 -/
 #guard_msgs in
 @[alias_in Baz.Qux 3] def Foo.Bar.baz3 : Nat := 2
+
+
+/-- error: The `alias_in` attribute cannot be used for private declarations. -/
+#guard_msgs in
+@[alias_in Baz] private def Foo.Bar.baz4 : Nat := 2

--- a/MathlibTest/Util/AliasIn/AliasInModuleSystem.lean
+++ b/MathlibTest/Util/AliasIn/AliasInModuleSystem.lean
@@ -1,4 +1,8 @@
-import Mathlib.Util.AliasIn
+module
+
+public import Mathlib.Util.AliasIn
+
+public section
 
 @[alias_in Baz] def Foo.Bar.baz : Nat := 1
 /-- info: Foo.Baz.baz : Nat -/
@@ -64,3 +68,11 @@ Look at this docstring!
 #guard_msgs in
 open Lean in
 run_cmd logInfo m!"{(← Lean.findDocString? (← getEnv) `Foo.Baz.baz5).get!}"
+
+end
+
+section
+
+/-- error: The `alias_in` attribute cannot be used for private declarations. -/
+#guard_msgs in
+@[alias_in Baz] def Foo.Bar.n := 2

--- a/MathlibTest/Util/AliasIn/AliasInModuleSystem.lean
+++ b/MathlibTest/Util/AliasIn/AliasInModuleSystem.lean
@@ -2,6 +2,8 @@ module
 
 public import Mathlib.Util.AliasIn
 
+/-! Tests for the `@[alias_in]` attribute, within the module system  -/
+
 public section
 
 @[alias_in Baz] def Foo.Bar.baz : Nat := 1
@@ -69,10 +71,24 @@ Look at this docstring!
 open Lean in
 run_cmd logInfo m!"{(← Lean.findDocString? (← getEnv) `Foo.Baz.baz5).get!}"
 
+@[alias_in Baz] public def Foo.Bar.baz6 : Nat := 1
+
+/-- error: The `alias_in` attribute cannot be used for private declarations. -/
+#guard_msgs in
+@[alias_in Baz] private def Foo.Bar.baz7 : Nat := 1
+
 end
 
 section
 
 /-- error: The `alias_in` attribute cannot be used for private declarations. -/
 #guard_msgs in
-@[alias_in Baz] def Foo.Bar.n := 2
+@[alias_in Baz] def Foo.Bar.baz8 : Nat := 2
+
+
+#guard_msgs in
+@[alias_in Baz] public def Foo.Bar.baz9 : Nat := 2
+
+/-- error: The `alias_in` attribute cannot be used for private declarations. -/
+#guard_msgs in
+@[alias_in Baz] private def Foo.Bar.baz10 : Nat := 2


### PR DESCRIPTION
This requires two different fixes:
- deal with `private` aliases: under the module system, a private declaration `Foo.Bar` in module `MyMod` gets a unique name (currently something like `_private.MyMod.Foo.Bar`). This breaks the current logic for counting namespace components. Since we don't see a use for private aliases (they cannot export anything to other modules), we make the attribute error on them.
- for some reason, we have to create `public alias` inside the attribute.

---

I finally have time now to actually make a PR using this attribute for CW complexes but it needs to work with the module system first. Since for private declarations, the namespace is longer and thus the previous approach did not work, the easiest fix was to simply not allow this attribute to be used for private declarations. I don't know why anyone would create private aliases, so I hope this is fine. 

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
