### PR TITLE
chore(Logic): rename `Xor'` to `Xor`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -155,10 +155,10 @@ lemma prod_filter_not_mul_prod_filter (s : Finset ι) (p : ι → Prop) [Decidab
 
 @[to_additive]
 theorem prod_filter_xor (p q : ι → Prop) [DecidablePred p] [DecidablePred q] :
-    (∏ x ∈ s with (Xor' (p x) (q x)), f x) =
+    (∏ x ∈ s with (Xor (p x) (q x)), f x) =
       (∏ x ∈ s with (p x ∧ ¬ q x), f x) * (∏ x ∈ s with (q x ∧ ¬ p x), f x) := by
   classical rw [← prod_union (disjoint_filter_and_not_filter _ _), ← filter_or]
-  simp only [Xor']
+  simp only [Xor]
 
 @[to_additive]
 theorem _root_.IsCompl.prod_mul_prod [Fintype ι] {s t : Finset ι} (h : IsCompl s t) (f : ι → M) :

--- a/Mathlib/Algebra/Ring/Int/Parity.lean
+++ b/Mathlib/Algebra/Ring/Int/Parity.lean
@@ -42,13 +42,17 @@ lemma even_or_odd (n : ℤ) : Even n ∨ Odd n := by grind
 lemma even_or_odd' (n : ℤ) : ∃ k, n = 2 * k ∨ n = 2 * k + 1 := by
   simpa only [two_mul, exists_or, Odd, Even] using even_or_odd n
 
-lemma even_xor'_odd (n : ℤ) : Xor' (Even n) (Odd n) := by
+lemma even_xor_odd (n : ℤ) : Xor (Even n) (Odd n) := by
   grind
 
-lemma even_xor'_odd' (n : ℤ) : ∃ k, Xor' (n = 2 * k) (n = 2 * k + 1) := by
+@[deprecated (since := "2026-04-24")] alias even_xor'_odd := even_xor_odd
+
+lemma even_xor_odd' (n : ℤ) : ∃ k, Xor (n = 2 * k) (n = 2 * k + 1) := by
   rcases even_or_odd n with (⟨k, rfl⟩ | ⟨k, rfl⟩) <;>
   · use k
     grind
+
+@[deprecated (since := "2026-04-24")] alias even_xor'_odd' := even_xor_odd'
 
 instance : DecidablePred (Odd : ℤ → Prop) := fun _ => decidable_of_iff _ not_even_iff_odd
 

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -270,14 +270,14 @@ lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by grind
 
 lemma _root_.Odd.not_two_dvd_nat (h : Odd n) : ¬(2 ∣ n) := by grind
 
-lemma even_xor_odd (n : ℕ) : Xor' (Even n) (Odd n) := by grind
+lemma even_xor_odd (n : ℕ) : Xor (Even n) (Odd n) := by grind
 
 lemma even_or_odd (n : ℕ) : Even n ∨ Odd n := (even_xor_odd n).or
 
 lemma even_or_odd' (n : ℕ) : ∃ k, n = 2 * k ∨ n = 2 * k + 1 := by
   simpa only [← two_mul, exists_or, Odd, Even] using even_or_odd n
 
-lemma even_xor_odd' (n : ℕ) : ∃ k, Xor' (n = 2 * k) (n = 2 * k + 1) := by
+lemma even_xor_odd' (n : ℕ) : ∃ k, Xor (n = 2 * k) (n = 2 * k + 1) := by
   obtain ⟨k, rfl⟩ | ⟨k, rfl⟩ := even_or_odd n <;>
   · use k
     grind

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -93,7 +93,7 @@ theorem of_decide_false {p : Prop} [Decidable p] : decide p = false → ¬p :=
 theorem decide_congr {p q : Prop} [Decidable p] [Decidable q] (h : p ↔ q) : decide p = decide q :=
   decide_eq_decide.mpr h
 
-theorem coe_xor_iff (a b : Bool) : xor a b ↔ Xor' (a = true) (b = true) := by grind
+theorem coe_xor_iff (a b : Bool) : xor a b ↔ Xor (a = true) (b = true) := by grind
 
 end
 

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -679,8 +679,8 @@ variable {α : Type*}
 
 theorem mem_union_of_disjoint [DecidableEq α]
     {s t : Finset α} (h : Disjoint s t) {x : α} :
-    x ∈ s ∪ t ↔ Xor' (x ∈ s) (x ∈ t) := by
-  rw [Finset.mem_union, Xor']
+    x ∈ s ∪ t ↔ Xor (x ∈ s) (x ∈ t) := by
+  rw [Finset.mem_union, Xor]
   have := disjoint_left.1 h
   tauto
 

--- a/Mathlib/Data/Set/Disjoint.lean
+++ b/Mathlib/Data/Set/Disjoint.lean
@@ -119,7 +119,7 @@ end Disjoint
 
 namespace Set
 
-theorem mem_union_of_disjoint (h : Disjoint s t) {x : α} : x ∈ s ∪ t ↔ Xor' (x ∈ s) (x ∈ t) := by
-  grind [Xor']
+theorem mem_union_of_disjoint (h : Disjoint s t) {x : α} : x ∈ s ∪ t ↔ Xor (x ∈ s) (x ∈ t) := by
+  grind [Xor]
 
 end Set

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -266,7 +266,7 @@ lemma IsMIntegralCurve.periodic_of_eq [BoundarylessManifold I M]
 lemma IsMIntegralCurve.periodic_xor_injective [BoundarylessManifold I M]
     (hγ : IsMIntegralCurve γ v)
     (hv : CMDiff 1 (fun x ↦ (⟨x, v x⟩ : TangentBundle I M))) :
-    Xor' (∃ T > 0, Periodic γ T) (Injective γ) := by
+    Xor (∃ T > 0, Periodic γ T) (Injective γ) := by
   rw [xor_iff_iff_not]
   refine ⟨fun ⟨T, hT, hf⟩ ↦ hf.not_injective (ne_of_gt hT), ?_⟩
   intro h

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -164,7 +164,7 @@ theorem relIndex_dvd_of_le_left (hHK : H ≤ K) : K.relIndex L ∣ H.relIndex L 
 of `b * a` and `b` belong to `H`. -/
 @[to_additive /-- An additive subgroup has index two if and only if there exists `a` such that
 for all `b`, exactly one of `b + a` and `b` belong to `H`. -/]
-theorem index_eq_two_iff : H.index = 2 ↔ ∃ a, ∀ b, Xor' (b * a ∈ H) (b ∈ H) := by
+theorem index_eq_two_iff : H.index = 2 ↔ ∃ a, ∀ b, Xor (b * a ∈ H) (b ∈ H) := by
   simp only [index, Nat.card_eq_two_iff' ((1 : G) : G ⧸ H), ExistsUnique, inv_mem_iff,
     QuotientGroup.exists_mk, QuotientGroup.forall_mk, Ne, QuotientGroup.eq, mul_one,
     xor_iff_iff_not]
@@ -180,7 +180,7 @@ theorem index_eq_two_iff : H.index = 2 ↔ ∃ a, ∀ b, Xor' (b * a ∈ H) (b �
 of `a * b` and `b` belong to `H`. -/
 @[to_additive /-- An additive subgroup has index two if and only if there exists `a` such that
 for all `b`, exactly one of `a + b` and `b` belong to `H`. -/]
-theorem index_eq_two_iff' : H.index = 2 ↔ ∃ a, ∀ b, Xor' (a * b ∈ H) (b ∈ H) := by
+theorem index_eq_two_iff' : H.index = 2 ↔ ∃ a, ∀ b, Xor (a * b ∈ H) (b ∈ H) := by
   rw [index_eq_two_iff, (Equiv.inv G).exists_congr]
   refine fun a ↦ (Equiv.inv G).forall_congr fun b ↦ ?_
   simp only [Equiv.inv_apply, inv_mem_iff, ← mul_inv_rev]
@@ -207,12 +207,12 @@ lemma index_eq_two_iff_exists_notMem_and' :
 
 /-- Relative version of `Subgroup.index_eq_two_iff`. -/
 @[to_additive /-- Relative version of `AddSubgroup.index_eq_two_iff`. -/]
-theorem relIndex_eq_two_iff : H.relIndex K = 2 ↔ ∃ a ∈ K, ∀ b ∈ K, Xor' (b * a ∈ H) (b ∈ H) := by
+theorem relIndex_eq_two_iff : H.relIndex K = 2 ↔ ∃ a ∈ K, ∀ b ∈ K, Xor (b * a ∈ H) (b ∈ H) := by
   simp [Subgroup.relIndex, Subgroup.index_eq_two_iff, mem_subgroupOf]
 
 /-- Relative version of `Subgroup.index_eq_two_iff'`. -/
 @[to_additive /-- Relative version of `AddSubgroup.index_eq_two_iff'`. -/]
-theorem relIindex_eq_two_iff' : H.relIndex K = 2 ↔ ∃ a ∈ K, ∀ b ∈ K, Xor' (a * b ∈ H) (b ∈ H) := by
+theorem relIindex_eq_two_iff' : H.relIndex K = 2 ↔ ∃ a ∈ K, ∀ b ∈ K, Xor (a * b ∈ H) (b ∈ H) := by
   simp [Subgroup.relIndex, Subgroup.index_eq_two_iff', mem_subgroupOf]
 
 /-- Relative version of `Subgroup.index_eq_two_iff_exists_notMem_and`. -/

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -221,38 +221,34 @@ lemma Iff.ne_left {α β : Sort*} {a b : α} {c d : β} : (a = b ↔ c ≠ d) �
 lemma Iff.ne_right {α β : Sort*} {a b : α} {c d : β} : (a ≠ b ↔ c = d) → (a = b ↔ c ≠ d) :=
   Iff.not_right
 
-/-! ### Declarations about `Xor'` -/
+/-! ### Declarations about `Xor` -/
 
-#adaptation_note
-/--
-2025-07-31. Upstream `Xor` has been renamed to `XorOp`.
-2025-09-16. The deprecation for `Xor` has been removed.
-Anytime after v4.25.0-rc1 lands we rename this back to `Xor`.
--/
-/-- `Xor' a b` is the exclusive-or of propositions. -/
-def Xor' (a b : Prop) := (a ∧ ¬b) ∨ (b ∧ ¬a)
+/-- `Xor a b` is the exclusive-or of propositions. -/
+def Xor (a b : Prop) := (a ∧ ¬b) ∨ (b ∧ ¬a)
 
-@[grind =] theorem xor_def {a b : Prop} : Xor' a b ↔ (a ∧ ¬b) ∨ (b ∧ ¬a) := Iff.rfl
+@[deprecated (since := "2026-04-24")] alias Xor' := Xor
 
-instance [Decidable a] [Decidable b] : Decidable (Xor' a b) := inferInstanceAs (Decidable (Or ..))
+@[grind =] theorem xor_def {a b : Prop} : Xor a b ↔ (a ∧ ¬b) ∨ (b ∧ ¬a) := Iff.rfl
 
-@[simp] theorem xor_true : Xor' True = Not := by grind
+instance [Decidable a] [Decidable b] : Decidable (Xor a b) := inferInstanceAs (Decidable (Or ..))
 
-@[simp] theorem xor_false : Xor' False = id := by grind
+@[simp] theorem xor_true : Xor True = Not := by grind
 
-theorem xor_comm (a b : Prop) : Xor' a b = Xor' b a := by grind
+@[simp] theorem xor_false : Xor False = id := by grind
 
-instance : Std.Commutative Xor' := ⟨xor_comm⟩
+theorem xor_comm (a b : Prop) : Xor a b = Xor b a := by grind
 
-@[simp] theorem xor_self (a : Prop) : Xor' a a = False := by grind
+instance : Std.Commutative Xor := ⟨xor_comm⟩
 
-@[simp] theorem xor_not_left : Xor' (¬a) b ↔ (a ↔ b) := by grind
+@[simp] theorem xor_self (a : Prop) : Xor a a = False := by grind
 
-@[simp] theorem xor_not_right : Xor' a (¬b) ↔ (a ↔ b) := by grind
+@[simp] theorem xor_not_left : Xor (¬a) b ↔ (a ↔ b) := by grind
 
-theorem xor_not_not : Xor' (¬a) (¬b) ↔ Xor' a b := by grind
+@[simp] theorem xor_not_right : Xor a (¬b) ↔ (a ↔ b) := by grind
 
-protected theorem Xor'.or (h : Xor' a b) : a ∨ b := by grind
+theorem xor_not_not : Xor (¬a) (¬b) ↔ Xor a b := by grind
+
+protected theorem Xor.or (h : Xor a b) : a ∨ b := by grind
 
 /-! ### Declarations about `and` -/
 
@@ -352,17 +348,17 @@ theorem or_iff_not_and_not : a ∨ b ↔ ¬(¬a ∧ ¬b) :=
 theorem and_iff_not_or_not : a ∧ b ↔ ¬(¬a ∨ ¬b) :=
   open scoped Classical in Decidable.and_iff_not_not_or_not
 
-@[simp] theorem not_xor (P Q : Prop) : ¬Xor' P Q ↔ (P ↔ Q) := by
-  simp only [not_and, Xor', not_or, not_not, ← iff_iff_implies_and_implies]
+@[simp] theorem not_xor (P Q : Prop) : ¬Xor P Q ↔ (P ↔ Q) := by
+  simp only [not_and, Xor, not_or, not_not, ← iff_iff_implies_and_implies]
 
-theorem xor_iff_not_iff (P Q : Prop) : Xor' P Q ↔ ¬(P ↔ Q) := (not_xor P Q).not_right
+theorem xor_iff_not_iff (P Q : Prop) : Xor P Q ↔ ¬(P ↔ Q) := (not_xor P Q).not_right
 
-theorem xor_iff_iff_not : Xor' a b ↔ (a ↔ ¬b) := by simp only [← @xor_not_right a, not_not]
+theorem xor_iff_iff_not : Xor a b ↔ (a ↔ ¬b) := by simp only [← @xor_not_right a, not_not]
 
-theorem xor_iff_not_iff' : Xor' a b ↔ (¬a ↔ b) := by simp only [← @xor_not_left _ b, not_not]
+theorem xor_iff_not_iff' : Xor a b ↔ (¬a ↔ b) := by simp only [← @xor_not_left _ b, not_not]
 
-theorem xor_iff_or_and_not_and (a b : Prop) : Xor' a b ↔ (a ∨ b) ∧ (¬(a ∧ b)) := by
-  rw [Xor', or_and_right, not_and_or, and_or_left, and_not_self_iff, false_or,
+theorem xor_iff_or_and_not_and (a b : Prop) : Xor a b ↔ (a ∨ b) ∧ (¬(a ∧ b)) := by
+  rw [Xor, or_and_right, not_and_or, and_or_left, and_not_self_iff, false_or,
     and_or_left, and_not_self_iff, or_false]
 
 end Propositional

--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -257,7 +257,7 @@ lemma valuation_isEquiv_adic_of_valuation_X_le_one (hle : v X ≤ 1) :
 A discrete valuation of rank 1 that is trivial on `K` is equivalent either to the valuation
 at infinity or to the `p`-adic valuation for a unique maximal ideal `p` of `K[X]`. -/
 theorem valuation_isEquiv_infty_or_adic [DecidableEq (RatFunc K)] :
-    Xor' (v.IsEquiv (RatFunc.inftyValuation K))
+    Xor (v.IsEquiv (RatFunc.inftyValuation K))
       (∃! (u : HeightOneSpectrum K[X]), v.IsEquiv (u.valuation _)) := by
   rcases lt_or_ge 1 (v X) with hlt | hge
   /- Infinity case -/

--- a/Mathlib/Order/SymmDiff.lean
+++ b/Mathlib/Order/SymmDiff.lean
@@ -17,7 +17,7 @@ This file defines the symmetric difference and bi-implication operators in (co-)
 
 Some examples are
 * The symmetric difference of two sets is the set of elements that are in either but not both.
-* The symmetric difference on propositions is `Xor'`.
+* The symmetric difference on propositions is `Xor`.
 * The symmetric difference on `Bool` is `Bool.xor`.
 * The equivalence of propositions. Two propositions are equivalent if they imply each other.
 * The symmetric difference translates to addition when considering a Boolean algebra as a Boolean
@@ -82,8 +82,10 @@ theorem symmDiff_def [Max α] [SDiff α] (a b : α) : a ∆ b = a \ b ⊔ b \ a 
 theorem bihimp_def [Min α] [HImp α] (a b : α) : a ⇔ b = (b ⇨ a) ⊓ (a ⇨ b) :=
   rfl
 
-theorem symmDiff_eq_Xor' (p q : Prop) : p ∆ q = Xor' p q :=
+theorem symmDiff_eq_xor (p q : Prop) : p ∆ q = Xor p q :=
   rfl
+
+@[deprecated (since := "2026-04-24")] alias symmDiff_eq_Xor' := symmDiff_eq_xor
 
 @[simp]
 theorem bihimp_iff_iff {p q : Prop} : p ⇔ q ↔ (p ↔ q) :=

--- a/Mathlib/Tactic/ITauto.lean
+++ b/Mathlib/Tactic/ITauto.lean
@@ -21,7 +21,7 @@ The `itauto` tactic will prove any intuitionistic tautology. It implements the w
 [Dyckhoff, *Contraction-free sequent calculi for intuitionistic logic*][dyckhoff_1992].
 
 All built in propositional connectives are supported: `True`, `False`, `And`, `Or`, `→`,
-`Not`, `Iff`, `Xor'`, as well as `Eq` and `Ne` on propositions. Anything else, including definitions
+`Not`, `Iff`, `Xor`, as well as `Eq` and `Ne` on propositions. Anything else, including definitions
 and predicate logical connectives (`∀` and `∃`), are not supported, and will have to be
 simplified or instantiated before calling this tactic.
 
@@ -73,8 +73,8 @@ The intuitionistic logic rules are separated into three groups:
 This covers the core algorithm, which only handles `True`, `False`, `And`, `Or`, and `→`.
 For `Iff` and `Eq`, we treat them essentially the same as `(p → q) ∧ (q → p)`, although we use
 a different `IProp` representation because we have to remember to apply different theorems during
-replay. For definitions like `Not` and `Xor'`, we just eagerly unfold them. (This could potentially
-cause a blowup issue for `Xor'`, but it isn't used very often anyway. We could add it to the `IProp`
+replay. For definitions like `Not` and `Xor`, we just eagerly unfold them. (This could potentially
+cause a blowup issue for `Xor`, but it isn't used very often anyway. We could add it to the `IProp`
 grammar if it matters.)
 
 ## Tags
@@ -487,7 +487,7 @@ partial def reify (e : Q(Prop)) : AtomM IProp :=
   | ~q($a ∧ $b) => return .and (← reify a) (← reify b)
   | ~q($a ∨ $b) => return .or (← reify a) (← reify b)
   | ~q($a ↔ $b) => return .iff (← reify a) (← reify b)
-  | ~q(Xor' $a $b) => return .xor (← reify a) (← reify b)
+  | ~q(Xor $a $b) => return .xor (← reify a) (← reify b)
   | ~q(@Eq Prop $a $b) => return .eq (← reify a) (← reify b)
   | ~q(@Ne Prop $a $b) => return .not (.eq (← reify a) (← reify b))
   | e =>

--- a/Mathlib/Topology/Algebra/Order/Archimedean.lean
+++ b/Mathlib/Topology/Algebra/Order/Archimedean.lean
@@ -89,14 +89,14 @@ variable [Nontrivial G] [DenselyOrdered G]
 a subgroup is either dense or is cyclic, but not both.
 
 For a non-exclusive `Or` version with weaker assumptions, see `Subgroup.dense_or_cyclic` above. -/
-@[to_additive dense_xor'_cyclic
+@[to_additive dense_xor_cyclic
 /-- In a nontrivial densely linear ordered archimedean topological additive group,
 a subgroup is either dense or is cyclic, but not both.
 
 For a non-exclusive `Or` version with weaker assumptions, see `AddSubgroup.dense_or_cyclic` above.
 -/]
-theorem dense_xor'_cyclic (s : Subgroup G) :
-    Xor' (Dense (s : Set G)) (∃ a, s = .zpowers a) := by
+theorem dense_xor_cyclic (s : Subgroup G) :
+    Xor (Dense (s : Set G)) (∃ a, s = .zpowers a) := by
   if hd : Dense (s : Set G) then
     simp only [hd, xor_true]
     rintro ⟨a, rfl⟩
@@ -105,9 +105,12 @@ theorem dense_xor'_cyclic (s : Subgroup G) :
     simp only [hd, xor_false, id, zpowers_eq_closure]
     exact s.dense_or_cyclic.resolve_left hd
 
+@[to_additive (attr := deprecated dense_xor_cyclic (since := "2026-04-24"))]
+alias dense_xor_cyclic' := dense_xor_cyclic
+
 @[to_additive]
 theorem dense_iff_ne_zpowers {s : Subgroup G} :
     Dense (s : Set G) ↔ ∀ a, s ≠ .zpowers a := by
-  simp [xor_iff_iff_not.1 s.dense_xor'_cyclic]
+  simp [xor_iff_iff_not.1 s.dense_xor_cyclic]
 
 end Subgroup

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -457,7 +457,7 @@ theorem inseparable_iff_forall_isOpen : (x ~ᵢ y) ↔ ∀ s : Set X, IsOpen s �
     Iff.comm]
 
 theorem not_inseparable_iff_exists_open :
-    ¬(x ~ᵢ y) ↔ ∃ s : Set X, IsOpen s ∧ Xor' (x ∈ s) (y ∈ s) := by
+    ¬(x ~ᵢ y) ↔ ∃ s : Set X, IsOpen s ∧ Xor (x ∈ s) (y ∈ s) := by
   simp [inseparable_iff_forall_isOpen, ← xor_iff_not_iff]
 
 theorem inseparable_iff_forall_isClosed : (x ~ᵢ y) ↔ ∀ s : Set X, IsClosed s → (x ∈ s ↔ y ∈ s) := by

--- a/Mathlib/Topology/Instances/AddCircle/DenseSubgroup.lean
+++ b/Mathlib/Topology/Instances/AddCircle/DenseSubgroup.lean
@@ -79,7 +79,7 @@ theorem dense_addSubgroup_iff_ne_zmultiples {p : ℝ} [Fact (0 < p)] {s : AddSub
     contrapose! h
     obtain ⟨a, rfl⟩ : ∃ a, s = .zmultiples a := by
       rw [← QuotientAddGroup.dense_preimage_mk, ← QuotientAddGroup.coe_mk',
-        ← AddSubgroup.coe_comap, xor_iff_not_iff'.1 (AddSubgroup.dense_xor'_cyclic _)] at h
+        ← AddSubgroup.coe_comap, xor_iff_not_iff'.1 (AddSubgroup.dense_xor_cyclic _)] at h
       rcases h with ⟨a, ha⟩
       use a
       rw [← QuotientAddGroup.coe_mk', ← AddMonoidHom.map_zmultiples, ← ha,

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -132,14 +132,20 @@ theorem TopologicalSpace.IsTopologicalBasis.eq_iff [T0Space X] {b : Set (Set X)}
     (hb : IsTopologicalBasis b) {x y : X} : x = y ↔ ∀ s ∈ b, (x ∈ s ↔ y ∈ s) :=
   inseparable_iff_eq.symm.trans hb.inseparable_iff
 
-theorem t0Space_iff_exists_isOpen_xor'_mem (X : Type u) [TopologicalSpace X] :
-    T0Space X ↔ Pairwise fun x y => ∃ U : Set X, IsOpen U ∧ Xor' (x ∈ U) (y ∈ U) := by
+theorem t0Space_iff_exists_isOpen_xor_mem (X : Type u) [TopologicalSpace X] :
+    T0Space X ↔ Pairwise fun x y => ∃ U : Set X, IsOpen U ∧ Xor (x ∈ U) (y ∈ U) := by
   simp only [t0Space_iff_not_inseparable, xor_iff_not_iff, not_forall, exists_prop,
     inseparable_iff_forall_isOpen, Pairwise]
 
-theorem exists_isOpen_xor'_mem [T0Space X] {x y : X} (h : x ≠ y) :
-    ∃ U : Set X, IsOpen U ∧ Xor' (x ∈ U) (y ∈ U) :=
-  (t0Space_iff_exists_isOpen_xor'_mem X).1 ‹_› h
+@[deprecated (since := "2026-04-24")] alias t0Space_iff_exists_isOpen_xor'_mem :=
+  t0Space_iff_exists_isOpen_xor_mem
+
+theorem exists_isOpen_xor_mem [T0Space X] {x y : X} (h : x ≠ y) :
+    ∃ U : Set X, IsOpen U ∧ Xor (x ∈ U) (y ∈ U) :=
+  (t0Space_iff_exists_isOpen_xor_mem X).1 ‹_› h
+
+@[deprecated (since := "2026-04-24")] alias exists_isOpen_xor'_mem :=
+  exists_isOpen_xor_mem
 
 /-- Specialization forms a partial order on a t0 topological space. -/
 @[instance_reducible]
@@ -153,7 +159,7 @@ instance SeparationQuotient.instT0Space : T0Space (SeparationQuotient X) :=
 theorem minimal_nonempty_closed_subsingleton [T0Space X] {s : Set X} (hs : IsClosed s)
     (hmin : ∀ t, t ⊆ s → t.Nonempty → IsClosed t → t = s) : s.Subsingleton := by
   refine fun x hx y hy => of_not_not fun hxy => ?_
-  rcases exists_isOpen_xor'_mem hxy with ⟨U, hUo, hU⟩
+  rcases exists_isOpen_xor_mem hxy with ⟨U, hUo, hU⟩
   wlog h : x ∈ U ∧ y ∉ U
   · refine this hs hmin y hy x hx (Ne.symm hxy) U hUo hU.symm (hU.resolve_left h)
   obtain ⟨hxU, hyU⟩ := h
@@ -176,7 +182,7 @@ theorem IsClosed.exists_closed_singleton [T0Space X] [CompactSpace X] {S : Set X
 theorem minimal_nonempty_open_subsingleton [T0Space X] {s : Set X} (hs : IsOpen s)
     (hmin : ∀ t, t ⊆ s → t.Nonempty → IsOpen t → t = s) : s.Subsingleton := by
   refine fun x hx y hy => of_not_not fun hxy => ?_
-  rcases exists_isOpen_xor'_mem hxy with ⟨U, hUo, hU⟩
+  rcases exists_isOpen_xor_mem hxy with ⟨U, hUo, hU⟩
   wlog h : x ∈ U ∧ y ∉ U
   · exact this hs hmin y hy x hx (Ne.symm hxy) U hUo hU.symm (hU.resolve_left h)
   obtain ⟨hxU, hyU⟩ := h

--- a/Mathlib/Topology/Separation/Profinite.lean
+++ b/Mathlib/Topology/Separation/Profinite.lean
@@ -28,7 +28,7 @@ theorem totallySeparatedSpace_of_t0_of_basis_clopen [T0Space X]
     (h : IsTopologicalBasis { s : Set X | IsClopen s }) : TotallySeparatedSpace X := by
   constructor
   rintro x - y - hxy
-  choose U hU using exists_isOpen_xor'_mem hxy
+  choose U hU using exists_isOpen_xor_mem hxy
   obtain ⟨hU₀, hU₁⟩ := hU
   rcases hU₁ with hx | hy
   · choose V hV using h.isOpen_iff.mp hU₀ x hx.1

--- a/MathlibTest/itauto.lean
+++ b/MathlibTest/itauto.lean
@@ -31,8 +31,8 @@ example (p q : Prop) (h : ¬(p ↔ q)) (h' : q) : ¬p := by itauto
 example (p q : Prop) (h : ¬(p ↔ q)) (h' : ¬q) (h'' : ¬p) : False := by itauto
 example (p q r : Prop) (h : p ↔ q) (h' : r ↔ q) (h'' : ¬r) : ¬p := by itauto
 example (p q r : Prop) (h : p ↔ q) (h' : r ↔ q) : p ↔ r := by itauto
-example (p q : Prop) : Xor' p q → (p ↔ ¬q) := by itauto
-example (p q : Prop) : Xor' p q → Xor' q p := by itauto
+example (p q : Prop) : Xor p q → (p ↔ ¬q) := by itauto
+example (p q : Prop) : Xor p q → Xor q p := by itauto
 
 example (p q r : Prop) (h : ¬(p ↔ q)) (h' : r ↔ q) : ¬(p ↔ r) := by itauto
 


### PR DESCRIPTION
This PR solves an old adaptation note and renames the logical exclusive or from `Xor'` to `Xor`, after the name became freed up in core Lean. The downstream renames were done by searching for `xor'` (case insensitive) and manually replacing where appropriate.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
