### PR TITLE
feat(Algebra): finset sums of antiperiodic functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -86,6 +86,7 @@ public import Mathlib.Algebra.BigOperators.ModEq
 public import Mathlib.Algebra.BigOperators.Module
 public import Mathlib.Algebra.BigOperators.NatAntidiagonal
 public import Mathlib.Algebra.BigOperators.Option
+public import Mathlib.Algebra.BigOperators.Periodic
 public import Mathlib.Algebra.BigOperators.Pi
 public import Mathlib.Algebra.BigOperators.Ring.Finset
 public import Mathlib.Algebra.BigOperators.Ring.List

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Jesse Alama. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jesse Alama
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Intervals
+public import Mathlib.Algebra.Ring.Periodic
+
+/-!
+# Sums of antiperiodic functions
+
+This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functions.
+
+## Main results
+
+* `Function.Antiperiodic.sum_map_add_right`: For an antiperiodic function `f` with antiperiod
+  `c`, summing `f` over a Finset shifted by `c` (via `addRightEmbedding c`) negates the sum
+  over the original Finset.
+* `Function.Antiperiodic.sum_Ico_shift`: The specialization to a half-open interval `[a, b)`
+  shifted by `c`.
+* `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: A bilinear cancellation
+  variant: if `w` is antiperiodic with antiperiod `c`, then summing `w k * f k` over
+  `[a + c, b + c)` cancels with summing `w k * f (k + c)` over `[a, b)`.
+-/
+
+public section
+
+open Finset
+
+namespace Function.Antiperiodic
+
+variable {α R : Type*}
+
+/-- For an antiperiodic function `f` with antiperiod `c`, summing `f` over a Finset shifted by
+`c` (via `addRightEmbedding c`) negates the sum over the original Finset. -/
+theorem sum_map_add_right [Add α] [IsRightCancelAdd α] [SubtractionCommMonoid R]
+    {f : α → R} {c : α} (hf : Antiperiodic f c) (s : Finset α) :
+    ∑ k ∈ s.map (addRightEmbedding c), f k = -∑ k ∈ s, f k := by
+  simp only [Finset.sum_map, addRightEmbedding_apply, hf _, Finset.sum_neg_distrib]
+
+variable [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
+  [ExistsAddOfLE α] [LocallyFiniteOrder α]
+
+/-- Shifting the index of summation of an antiperiodic function by its antiperiod negates the
+sum. -/
+theorem sum_Ico_shift [SubtractionCommMonoid R] {f : α → R} {c : α} (hf : Antiperiodic f c)
+    (a b : α) :
+    ∑ k ∈ Ico (a + c) (b + c), f k = -∑ k ∈ Ico a b, f k := by
+  rw [← Finset.map_add_right_Ico, hf.sum_map_add_right]
+
+/-- For `w` antiperiodic with antiperiod `c`, the weighted sum `w k * f k` over `[a + c, b + c)`
+and the shifted-argument weighted sum `w k * f (k + c)` over `[a, b)` add to zero. -/
+theorem sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero [NonAssocRing R]
+    {w : α → R} {c : α} (hw : Antiperiodic w c) (f : α → R) (a b : α) :
+    ∑ k ∈ Ico (a + c) (b + c), w k * f k +
+      ∑ k ∈ Ico a b, w k * f (k + c) = 0 := by
+  rw [← Finset.sum_Ico_add' (fun x => w x * f x) a b c]
+  simp_rw [hw _, neg_mul, Finset.sum_neg_distrib, neg_add_cancel]
+
+end Function.Antiperiodic

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -15,9 +15,9 @@ This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functio
 
 ## Main results
 
-* `Function.Antiperiodic.sum_map_add_right`: For an antiperiodic function `f` with antiperiod
-  `c`, summing `f` over a Finset shifted by `c` (via `addRightEmbedding c`) negates the sum
-  over the original Finset.
+* `Function.Antiperiodic.sum_map_addRightEmbedding`: For an antiperiodic function `f` with
+  antiperiod `c`, summing `f` over a Finset shifted by `c` (via `addRightEmbedding c`) negates
+  the sum over the original Finset.
 * `Function.Antiperiodic.sum_Ico_shift`: The specialization to a half-open interval `[a, b)`
   shifted by `c`.
 * `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: A bilinear cancellation
@@ -35,7 +35,7 @@ variable {α R : Type*}
 
 /-- For an antiperiodic function `f` with antiperiod `c`, summing `f` over a Finset shifted by
 `c` (via `addRightEmbedding c`) negates the sum over the original Finset. -/
-theorem sum_map_add_right [Add α] [IsRightCancelAdd α] [SubtractionCommMonoid R]
+theorem sum_map_addRightEmbedding [Add α] [IsRightCancelAdd α] [SubtractionCommMonoid R]
     {f : α → R} {c : α} (hf : Antiperiodic f c) (s : Finset α) :
     ∑ k ∈ s.map (addRightEmbedding c), f k = -∑ k ∈ s, f k := by
   simp [hf _]
@@ -48,7 +48,7 @@ sum. -/
 theorem sum_Ico_shift [SubtractionCommMonoid R] {f : α → R} {c : α} (hf : Antiperiodic f c)
     (a b : α) :
     ∑ k ∈ Ico (a + c) (b + c), f k = -∑ k ∈ Ico a b, f k := by
-  rw [← Finset.map_add_right_Ico, hf.sum_map_add_right]
+  rw [← Finset.map_add_right_Ico, hf.sum_map_addRightEmbedding]
 
 /-- For `w` antiperiodic with antiperiod `c`, the weighted sum `w k * f k` over `[a + c, b + c)`
 and the shifted-argument weighted sum `w k * f (k + c)` over `[a, b)` add to zero. -/

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -15,11 +15,8 @@ This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functio
 
 ## Main results
 
-* `Function.Antiperiodic.sum_map_addRightEmbedding`: For an antiperiodic function `f` with
-  antiperiod `c`, summing `f` over a Finset shifted by `c` (via `addRightEmbedding c`) negates
-  the sum over the original Finset.
-* `Function.Antiperiodic.sum_Ico_shift`: The specialization to a half-open interval `[a, b)`
-  shifted by `c`.
+* `Function.Antiperiodic.sum_Ico_shift`: Shifting a sum over a half-open interval `[a, b)` by
+  the antiperiod `c` negates the sum.
 * `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: A bilinear cancellation
   variant: if `w` is antiperiodic with antiperiod `c`, then summing `w k * f k` over
   `[a + c, b + c)` cancels with summing `w k * f (k + c)` over `[a, b)`.
@@ -31,16 +28,7 @@ open Finset
 
 namespace Function.Antiperiodic
 
-variable {α R : Type*}
-
-/-- For an antiperiodic function `f` with antiperiod `c`, summing `f` over a Finset shifted by
-`c` (via `addRightEmbedding c`) negates the sum over the original Finset. -/
-theorem sum_map_addRightEmbedding [Add α] [IsRightCancelAdd α] [SubtractionCommMonoid R]
-    {f : α → R} {c : α} (hf : Antiperiodic f c) (s : Finset α) :
-    ∑ k ∈ s.map (addRightEmbedding c), f k = -∑ k ∈ s, f k := by
-  simp [hf _]
-
-variable [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
+variable {α R : Type*} [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
   [ExistsAddOfLE α] [LocallyFiniteOrder α]
 
 /-- Shifting the index of summation of an antiperiodic function by its antiperiod negates the

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -38,7 +38,7 @@ variable {α R : Type*}
 theorem sum_map_add_right [Add α] [IsRightCancelAdd α] [SubtractionCommMonoid R]
     {f : α → R} {c : α} (hf : Antiperiodic f c) (s : Finset α) :
     ∑ k ∈ s.map (addRightEmbedding c), f k = -∑ k ∈ s, f k := by
-  simp only [Finset.sum_map, addRightEmbedding_apply, hf _, Finset.sum_neg_distrib]
+  simp [hf _]
 
 variable [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
   [ExistsAddOfLE α] [LocallyFiniteOrder α]

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -19,9 +19,6 @@ This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functio
   the antiperiod `c` negates the sum.
 * `Function.Antiperiodic.sum_Ico_mul_shift`: for `w` antiperiodic, shifting the summation
   interval of `w k * g k` by `c` negates the sum and shifts the argument of `g` by `c`.
-* `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: the `g = f` case, written as
-  a cancellation: summing `w k * f k` over `[a + c, b + c)` cancels summing `w k * f (k + c)`
-  over `[a, b)`.
 -/
 
 public section
@@ -47,13 +44,5 @@ theorem sum_Ico_mul_shift [NonAssocRing R] {w : α → R} {c : α} (hw : Antiper
     ∑ k ∈ Ico (a + c) (b + c), w k * g k = -∑ k ∈ Ico a b, w k * g (k + c) := by
   rw [← Finset.sum_Ico_add' (fun x => w x * g x) a b c]
   simp_rw [hw _, neg_mul, Finset.sum_neg_distrib]
-
-/-- For `w` antiperiodic with antiperiod `c`, the weighted sum `w k * f k` over `[a + c, b + c)`
-and the shifted-argument weighted sum `w k * f (k + c)` over `[a, b)` add to zero. -/
-theorem sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero [NonAssocRing R]
-    {w : α → R} {c : α} (hw : Antiperiodic w c) (f : α → R) (a b : α) :
-    ∑ k ∈ Ico (a + c) (b + c), w k * f k +
-      ∑ k ∈ Ico a b, w k * f (k + c) = 0 := by
-  rw [sum_Ico_mul_shift hw f, neg_add_cancel]
 
 end Function.Antiperiodic

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -17,9 +17,11 @@ This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functio
 
 * `Function.Antiperiodic.sum_Ico_shift`: Shifting a sum over a half-open interval `[a, b)` by
   the antiperiod `c` negates the sum.
-* `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: A bilinear cancellation
-  variant: if `w` is antiperiodic with antiperiod `c`, then summing `w k * f k` over
-  `[a + c, b + c)` cancels with summing `w k * f (k + c)` over `[a, b)`.
+* `Function.Antiperiodic.sum_Ico_mul_shift`: for `w` antiperiodic, shifting the summation
+  interval of `w k * g k` by `c` negates the sum and shifts the argument of `g` by `c`.
+* `Function.Antiperiodic.sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero`: the `g = f` case, written as
+  a cancellation: summing `w k * f k` over `[a + c, b + c)` cancels summing `w k * f (k + c)`
+  over `[a, b)`.
 -/
 
 public section
@@ -38,13 +40,20 @@ theorem sum_Ico_shift [SubtractionCommMonoid R] {f : α → R} {c : α} (hf : An
     ∑ k ∈ Ico (a + c) (b + c), f k = -∑ k ∈ Ico a b, f k := by
   rw [← Finset.map_add_right_Ico, hf.sum_map_addRightEmbedding]
 
+/-- For `w` antiperiodic with antiperiod `c`, shifting the summation interval of `w k * g k` by
+`c` negates the sum and shifts the argument of `g` by `c`. -/
+theorem sum_Ico_mul_shift [NonAssocRing R] {w : α → R} {c : α} (hw : Antiperiodic w c)
+    (g : α → R) (a b : α) :
+    ∑ k ∈ Ico (a + c) (b + c), w k * g k = -∑ k ∈ Ico a b, w k * g (k + c) := by
+  rw [← Finset.sum_Ico_add' (fun x => w x * g x) a b c]
+  simp_rw [hw _, neg_mul, Finset.sum_neg_distrib]
+
 /-- For `w` antiperiodic with antiperiod `c`, the weighted sum `w k * f k` over `[a + c, b + c)`
 and the shifted-argument weighted sum `w k * f (k + c)` over `[a, b)` add to zero. -/
 theorem sum_Ico_mul_add_sum_Ico_mul_shift_eq_zero [NonAssocRing R]
     {w : α → R} {c : α} (hw : Antiperiodic w c) (f : α → R) (a b : α) :
     ∑ k ∈ Ico (a + c) (b + c), w k * f k +
       ∑ k ∈ Ico a b, w k * f (k + c) = 0 := by
-  rw [← Finset.sum_Ico_add' (fun x => w x * f x) a b c]
-  simp_rw [hw _, neg_mul, Finset.sum_neg_distrib, neg_add_cancel]
+  rw [sum_Ico_mul_shift hw f, neg_add_cancel]
 
 end Function.Antiperiodic

--- a/Mathlib/Algebra/BigOperators/Periodic.lean
+++ b/Mathlib/Algebra/BigOperators/Periodic.lean
@@ -17,8 +17,6 @@ This file collects lemmas about `Finset` sums of `Function.Antiperiodic` functio
 
 * `Function.Antiperiodic.sum_Ico_shift`: Shifting a sum over a half-open interval `[a, b)` by
   the antiperiod `c` negates the sum.
-* `Function.Antiperiodic.sum_Ico_mul_shift`: for `w` antiperiodic, shifting the summation
-  interval of `w k * g k` by `c` negates the sum and shifts the argument of `g` by `c`.
 -/
 
 public section
@@ -36,13 +34,5 @@ theorem sum_Ico_shift [SubtractionCommMonoid R] {f : α → R} {c : α} (hf : An
     (a b : α) :
     ∑ k ∈ Ico (a + c) (b + c), f k = -∑ k ∈ Ico a b, f k := by
   rw [← Finset.map_add_right_Ico, hf.sum_map_addRightEmbedding]
-
-/-- For `w` antiperiodic with antiperiod `c`, shifting the summation interval of `w k * g k` by
-`c` negates the sum and shifts the argument of `g` by `c`. -/
-theorem sum_Ico_mul_shift [NonAssocRing R] {w : α → R} {c : α} (hw : Antiperiodic w c)
-    (g : α → R) (a b : α) :
-    ∑ k ∈ Ico (a + c) (b + c), w k * g k = -∑ k ∈ Ico a b, w k * g (k + c) := by
-  rw [← Finset.sum_Ico_add' (fun x => w x * g x) a b c]
-  simp_rw [hw _, neg_mul, Finset.sum_neg_distrib]
 
 end Function.Antiperiodic


### PR DESCRIPTION
Two lemmas on `Finset` sums of `Function.Antiperiodic` functions, in the new file `Mathlib.Algebra.BigOperators.Periodic`: `sum_Ico_shift`, that shifting a sum over `[a, b)` by the antiperiod negates it; and `sum_Ico_mul_shift`, the analogue for a sum weighted by an antiperiodic function. Spun off from #29713 (Euler-Poincaré formula).
