### PR TITLE
[Merged by Bors] - chore: clean up `group`

### DIFF
--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -20,6 +20,11 @@ since `ring_nf` can normalize an exponent to zero, leading to a factor that can 
 before collecting exponents again. The simplifier step also uses some extra lemmas to avoid
 some `ring_nf` invocations.
 
+## TODO
+
+- Surface non-progress-related errors from `repeat`.
+- Allow `group`s `ifUnchanged` behavior to be configurable.
+
 ## Tags
 
 group theory

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Commutator  -- shake: keep (tactic dependency)
 public import Mathlib.Algebra.Order.Sub.Basic  -- shake: keep (tactic dependency)
-public meta import Mathlib.Tactic.FailIfNoProgress
+public import Mathlib.Tactic.FailIfNoProgress
 public import Mathlib.Tactic.Ring
 
 /-!
@@ -15,10 +15,10 @@ public import Mathlib.Tactic.Ring
 
 Normalizes expressions in the language of groups. The basic idea is to use the simplifier
 to put everything into a product of group powers (`zpow` which takes a group element and an
-integer), then simplify the exponents using the `ring` tactic. The process needs to be repeated
-since `ring` can normalize an exponent to zero, leading to a factor that can be removed
+integer), then simplify the exponents using the `ring_nf` tactic. The process needs to be repeated
+since `ring_nf` can normalize an exponent to zero, leading to a factor that can be removed
 before collecting exponents again. The simplifier step also uses some extra lemmas to avoid
-some `ring` invocations.
+some `ring_nf` invocations.
 
 ## Tags
 
@@ -29,47 +29,21 @@ public meta section
 
 namespace Mathlib.Tactic.Group
 
-open Lean
-open Lean.Meta
-open Lean.Parser.Tactic
-open Lean.Elab.Tactic
+open Lean Meta Parser Tactic
 
 -- The next three lemmas are not general purpose lemmas, they are intended for use only by
 -- the `group` tactic.
 @[to_additive]
-theorem zpow_trick {G : Type*} [Group G] (a b : G) (n m : ℤ) :
+theorem _zpow_trick {G : Type*} [Group G] (a b : G) (n m : ℤ) :
     a * b ^ n * b ^ m = a * b ^ (n + m) := by rw [mul_assoc, ← zpow_add]
 
-@[to_additive]
-theorem zpow_trick_one {G : Type*} [Group G] (a b : G) (m : ℤ) :
+@[to_additive _zsmul_trick_one]
+theorem _zpow_trick_one {G : Type*} [Group G] (a b : G) (m : ℤ) :
     a * b * b ^ m = a * b ^ (m + 1) := by rw [mul_assoc, mul_self_zpow]
 
-@[to_additive]
-theorem zpow_trick_one' {G : Type*} [Group G] (a b : G) (n : ℤ) :
+@[to_additive _zsmul_trick_one']
+theorem _zpow_trick_one' {G : Type*} [Group G] (a b : G) (n : ℤ) :
     a * b ^ n * b = a * b ^ (n + 1) := by rw [mul_assoc, mul_zpow_self]
-
-/-- Auxiliary tactic for the `group` tactic. Calls the simplifier only. -/
-syntax (name := aux_group₁) "aux_group₁" (location)? : tactic
-
-macro_rules
-| `(tactic| aux_group₁ $[at $location]?) =>
-  `(tactic| simp -decide -failIfUnchanged only
-    [commutatorElement_def, mul_one, one_mul,
-      ← zpow_neg_one, ← zpow_natCast, ← zpow_mul,
-      Int.natCast_add, Int.natCast_mul,
-      Int.mul_neg, Int.neg_mul, neg_neg,
-      one_zpow, zpow_zero, zpow_one, mul_zpow_neg_one,
-      ← mul_assoc,
-      ← zpow_add, ← zpow_add_one, ← zpow_one_add, zpow_trick, zpow_trick_one, zpow_trick_one',
-      tsub_self, sub_self, add_neg_cancel, neg_add_cancel]
-  $[at $location]?)
-
-/-- Auxiliary tactic for the `group` tactic. Calls `ring_nf` to normalize exponents. -/
-syntax (name := aux_group₂) "aux_group₂" (location)? : tactic
-
-macro_rules
-| `(tactic| aux_group₂ $[at $location]?) =>
-  `(tactic| ring_nf (ifUnchanged := .silent) $[at $location]?)
 
 /-- `group` normalizes expressions in multiplicative groups that occur in the goal. `group` does not
 assume commutativity, instead using only the group axioms without any information about which group
@@ -91,8 +65,21 @@ example {G : Type} [Group G] (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*
 syntax (name := group) "group" (location)? : tactic
 
 macro_rules
-| `(tactic| group $[$loc]?) =>
-  `(tactic| repeat (fail_if_no_progress (aux_group₁ $[$loc]? <;> aux_group₂ $[$loc]?)))
+| `(tactic| group $[$loc]?) => do
+  let simpTacStx ← `(tactic| simp -decide -failIfUnchanged only
+    [commutatorElement_def, mul_one, one_mul,
+      ← zpow_neg_one, ← zpow_natCast, ← zpow_mul,
+      Int.natCast_add, Int.natCast_mul,
+      Int.mul_neg, Int.neg_mul, neg_neg,
+      one_zpow, zpow_zero, zpow_one, mul_zpow_neg_one,
+      ← mul_assoc,
+      ← zpow_add, ← zpow_add_one, ← zpow_one_add,
+      _zpow_trick, _zpow_trick_one, _zpow_trick_one',
+      tsub_self, sub_self, add_neg_cancel, neg_add_cancel]
+    $[$loc]?)
+  `(tactic| first
+    | repeat1 fail_if_no_progress ($simpTacStx <;> ring_nf (ifUnchanged := .silent) $[$loc]?)
+    | fail "`group` made no progress")
 
 end Mathlib.Tactic.Group
 

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -70,20 +70,21 @@ example {G : Type} [Group G] (a b c d : G) (h : c = (a*b^2)*((b*b)⁻¹*a⁻¹)*
 syntax (name := group) "group" (location)? : tactic
 
 macro_rules
-| `(tactic| group $[$loc]?) => do
-  let simpTacStx ← `(tactic| simp -decide -failIfUnchanged only
-    [commutatorElement_def, mul_one, one_mul,
-      ← zpow_neg_one, ← zpow_natCast, ← zpow_mul,
-      Int.natCast_add, Int.natCast_mul,
-      Int.mul_neg, Int.neg_mul, neg_neg,
-      one_zpow, zpow_zero, zpow_one, mul_zpow_neg_one,
-      ← mul_assoc,
-      ← zpow_add, ← zpow_add_one, ← zpow_one_add,
-      _zpow_trick, _zpow_trick_one, _zpow_trick_one',
-      tsub_self, sub_self, add_neg_cancel, neg_add_cancel]
-    $[$loc]?)
+| `(tactic| group $[$loc]?) =>
   `(tactic| first
-    | repeat1 fail_if_no_progress ($simpTacStx <;> ring_nf (ifUnchanged := .silent) $[$loc]?)
+    | repeat1 fail_if_no_progress
+        (simp -decide -failIfUnchanged only
+          [commutatorElement_def, mul_one, one_mul,
+            ← zpow_neg_one, ← zpow_natCast, ← zpow_mul,
+            Int.natCast_add, Int.natCast_mul,
+            Int.mul_neg, Int.neg_mul, neg_neg,
+            one_zpow, zpow_zero, zpow_one, mul_zpow_neg_one,
+            ← mul_assoc,
+            ← zpow_add, ← zpow_add_one, ← zpow_one_add,
+            _zpow_trick, _zpow_trick_one, _zpow_trick_one',
+            tsub_self, sub_self, add_neg_cancel, neg_add_cancel]
+          $[$loc]?
+        <;> ring_nf (ifUnchanged := .silent) $[$loc]?)
     | fail "`group` made no progress")
 
 end Mathlib.Tactic.Group

--- a/MathlibTest/Group.lean
+++ b/MathlibTest/Group.lean
@@ -52,7 +52,14 @@ example (n : ℤ) (a b : G) : a^n*b^n*a^n*a^n*a^(-n)*a^(-n)*b^(-n)*a^(-n) = 1 :=
 
 example (x y : G) : (x⁻¹ * (x * y) * y⁻¹)⁻¹ = 1 := by group
 
-set_option linter.unusedTactic false in
+/--
+error: `group` made no progress
+G : Type
+inst✝ : Group G
+x : G
+h : x = 1
+⊢ x = 1
+-/
+#guard_msgs in
 example (x : G) (h : x = 1) : x = 1 := by
   group
-  exact h

--- a/MathlibTest/hintAll.lean
+++ b/MathlibTest/hintAll.lean
@@ -34,9 +34,6 @@ info: Try these:
   [apply] norm_num
   Remaining subgoals:
   ⊢ Q
-  [apply] group
-  Remaining subgoals:
-  ⊢ Q
 -/
 #guard_msgs in
 example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
@@ -45,9 +42,6 @@ example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
 info: Try these:
   [apply] 🎉️ simp_all only [and_self]
   [apply] norm_num
-  Remaining subgoals:
-  ⊢ Q ∧ P ∧ R
-  [apply] group
   Remaining subgoals:
   ⊢ Q ∧ P ∧ R
 -/
@@ -63,9 +57,6 @@ info: Try these:
   [apply] intro
   Remaining subgoals:
   ⊢ False
-  [apply] group
-  Remaining subgoals:
-  ⊢ ¬b < a
   [apply] simp_all only [not_lt]
   Remaining subgoals:
   ⊢ a ≤ b
@@ -103,9 +94,6 @@ info: Try these:
   Remaining subgoals:
   ⊢ ∃ x, P x
   [apply] ring_nf
-  Remaining subgoals:
-  ⊢ ∃ x, P x ∧ 0 ≤ x
-  [apply] group
   Remaining subgoals:
   ⊢ ∃ x, P x ∧ 0 ≤ x
   [apply] simp_all only [zero_le, and_true]
@@ -180,9 +168,6 @@ info: Try these:
   [apply] ring_nf
   Remaining subgoals:
   ⊢ 2 ≤ 1
-  [apply] group
-  Remaining subgoals:
-  ⊢ 2 ≤ 1
   [apply] simp_all only [Nat.not_ofNat_le_one]
   Remaining subgoals:
   ⊢ False
@@ -222,9 +207,6 @@ info: Try these:
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
   [apply] abel_nf
-  Remaining subgoals:
-  ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
-  [apply] group
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
 -/


### PR DESCRIPTION
This PR cleans up the source for the `group` tactic slightly. It
- prefixes the internal lemmas with `_` to hide them from autocomplete (and renames their additivized versions correctly)
- inlines the two internal `aux_group` tactics, which are used exactly once and are not extended (this has the nice side effect of removing them from the tactic documentation page)
- causes `group` to fail if it makes no progress (this helps `hint` be less noisy)
- removes `meta` from an import

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
