### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/Block): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Block.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Block.lean
@@ -263,8 +263,7 @@ protected theorem BlockTriangular.det [DecidableEq α] [LinearOrder α] (hM : Bl
     let he : { a // b' a = l } ≃ { a // b a = l } :=
       haveI hc : ∀ i, b i = l → b i ≠ k := fun i hi => ne_of_eq_of_ne hi (ne_of_mem_erase hl)
       Equiv.subtypeSubtypeEquivSubtype @hc
-    simp only [toSquareBlock_def]
-    erw [← Matrix.det_reindex_self he.symm fun i j : { a // b a = l } => M ↑i ↑j]
+    rw [toSquareBlock_def, ← Matrix.det_reindex_self he.symm]
     rfl
   · intro i hi j hj
     apply hM


### PR DESCRIPTION
- rewrites `BlockTriangular.det` to replace a `simp only` plus `erw` pair with a single `rw`
- uses `Matrix.det_reindex_self he.symm` directly in the rewrite chain

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)