### PR TITLE
[Merged by Bors] - chore(Algebra/Homology/ShortComplex/SnakeLemma): remove an erw

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -307,15 +307,11 @@ lemma L₀X₂ToP_comp_φ₁ : S.L₀X₂ToP ≫ S.φ₁ = 0 := by
 
 set_option backward.isDefEq.respectTransparency false in
 lemma L₀_g_δ : S.L₀.g ≫ S.δ = 0 := by
-  rw [← L₀X₂ToP_comp_pullback_snd, assoc]
-  erw [S.L₀'_exact.g_desc]
-  rw [L₀X₂ToP_comp_φ₁_assoc, zero_comp]
+  rw [← L₀X₂ToP_comp_pullback_snd, assoc, S.snd_δ, L₀X₂ToP_comp_φ₁_assoc, zero_comp]
 
 set_option backward.isDefEq.respectTransparency false in
 lemma δ_L₃_f : S.δ ≫ S.L₃.f = 0 := by
-  rw [← cancel_epi S.L₀'.g]
-  erw [S.L₀'_exact.g_desc_assoc]
-  simp [S.v₂₃.comm₁₂, φ₂]
+  simp [← cancel_epi S.L₀'.g, δ, S.v₂₃.comm₁₂, φ₂]
 
 /-- The short complex `L₀.X₂ ⟶ L₀.X₃ ⟶ L₃.X₁`. -/
 @[simps]


### PR DESCRIPTION
- rewrites `L₀_g_δ` to fold `S.snd_δ` into a single `rw` chain instead of using `erw [S.L₀'_exact.g_desc]`
- rewrites `δ_L₃_f` as a `simp` proof over `← cancel_epi S.L₀'.g`, `δ`, `S.v₂₃.comm₁₂`, and `φ₂` instead of using `erw [S.L₀'_exact.g_desc_assoc]`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)