### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Localization/Construction): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -330,9 +330,7 @@ def unitIso : 𝟭 (W.Localization ⥤ D) ≅ functor W D ⋙ inverse W D :=
     (by
       refine Functor.ext (fun G => ?_) fun G₁ G₂ τ => ?_
       · apply uniq
-        dsimp [Functor]
-        erw [fac]
-        rfl
+        simp [functor, inverse, fac]
       · apply natTrans_hcomp_injective
         ext X
         simp)


### PR DESCRIPTION
- shortens the `uniq` proof in `unitIso` to `simp [functor, inverse, fac]`, removing the `dsimp` plus `erw [fac]` sequence

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)