### PR TITLE
fix(Linter/PrivateModule): only suggest @[expose] if the module has any definitions

### DIFF
--- a/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Positive.lean
@@ -42,7 +42,7 @@ deterministic process.
 * [Moss and Perrone, *A category-theoretic proof of the ergodic decomposition theorem*][moss2023]
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/Tactic/Linter/PrivateModule.lean
+++ b/Mathlib/Tactic/Linter/PrivateModule.lean
@@ -78,6 +78,10 @@ def privateModule : Linter where run stx := do
     if (← getEnv).header.isModule then
       -- Don't lint an imports-only module:
       if !(← getEnv).constants.map₂.isEmpty then
+        let mut hasDef := false
+        for (decl, val) in (← getEnv).constants.map₂ do
+          if val.isDefinition then
+            hasDef := true
         -- Exit if any declaration from the current module is public:
         for (decl, _) in (← getEnv).constants.map₂ do
           -- Ignore both private and reserved names; see implementation notes
@@ -85,9 +89,9 @@ def privateModule : Linter where run stx := do
         -- Lint if all names are private:
         let topOfFileRef := Syntax.atom (.synthetic ⟨0⟩ ⟨0⟩) ""
         logLint linter.privateModule topOfFileRef
-          "The current module only contains private declarations.\n\n\
-          Consider adding `@[expose] public section` at the beginning of the module, \
-          or selectively marking declarations as `public`."
+          s!"The current module only contains private declarations.\n\n\
+          Consider adding `{if hasDef then "@[expose] " else ""}public section` \
+          at the beginning of the module, or selectively marking declarations as `public`."
 
 initialize addLinter privateModule
 

--- a/MathlibTest/PrivateModuleLinter/reservedName2.lean
+++ b/MathlibTest/PrivateModuleLinter/reservedName2.lean
@@ -37,7 +37,7 @@ open Mathlib.Linter Parser in
 /--
 warning: The current module only contains private declarations.
 
-Consider adding `@[expose] public section` at the beginning of the module, or selectively marking declarations as `public`.
+Consider adding `public section` at the beginning of the module, or selectively marking declarations as `public`.
 
 Note: This linter can be disabled with `set_option linter.privateModule false`
 -/


### PR DESCRIPTION
---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
