### PR TITLE
chore: make `RingHom.id` implicit-reducible

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -382,11 +382,8 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
 
 /-- The identity map inducing an `Algebra` structure. -/
 instance (priority := 1100) id : Algebra R R where
-  -- We override `toFun` and `toSMul` because `RingHom.id` is not reducible and cannot
-  -- be made so without a significant performance hit.
-  -- see library note [reducible non-instances].
   toSMul := instSMulOfMul
-  __ := ({ RingHom.id R with toFun x := x }).toAlgebra
+  __ := (RingHom.id R).toAlgebra
 
 @[simp] lemma linearMap_self : Algebra.linearMap R R = .id := rfl
 

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -506,6 +506,7 @@ def mk' [NonAssocSemiring α] [NonAssocRing β] (f : α →* β)
 variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β}
 
 /-- The identity ring homomorphism from a semiring to itself. -/
+@[implicit_reducible]
 def id (α : Type*) [NonAssocSemiring α] : α →+* α where
   toFun := _root_.id
   map_zero' := rfl


### PR DESCRIPTION
This has no bad performance impact, and is in line with the reducibility change made in #38315. Discussion at [#mathlib4 > backward.isDefEq.respectTransparency: bundled homomorphisms @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/backward.2EisDefEq.2ErespectTransparency.3A.20bundled.20homomorphisms/near/590851625)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
