### PR TITLE
[Merged by Bors] - feat(Tactic/Linter): make the longLine linter configurable

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -418,16 +418,20 @@ end Style.longFile
 
 /-! ### The "longLine linter" -/
 
-/-- The "longLine" linter emits a warning on lines longer than 100 characters.
+/-- The "longLine" linter emits a warning on lines longer than
+`linter.style.longLine.maxLineLength` (which defaults to 100) characters.
 We allow lines containing URLs to be longer, though. -/
 public register_option linter.style.longLine : Bool := {
   defValue := false
   descr := "enable the longLine linter"
 }
 
-public register_option linter.style.longLine.maxLineWidth : Nat := {
+/-- Configuration option for the "longLine" linter. This option determines the
+maximum allowed length of a line before the linter emits a warning.
+This defaults to 100. -/
+public register_option linter.style.longLine.maxLineLength : Nat := {
   defValue := 100
-  descr := "maximum line width before the longLine linter emits a warning"
+  descr := "maximum line length before the longLine linter emits a warning"
 }
 
 namespace Style.longLine
@@ -459,9 +463,9 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       else return stx
     let sstr := stx.getSubstring?
     let fm ← getFileMap
-    let maxWidth : Nat := linter.style.longLine.maxLineWidth.get (← getOptions)
+    let maxLineLength : Nat := linter.style.longLine.maxLineLength.get (← getOptions)
     let longLines := ((sstr.getD default).splitOn "\n").filter fun line ↦
-      (maxWidth < (fm.toPosition line.stopPos).column)
+      (maxLineLength < (fm.toPosition line.stopPos).column)
     for line in longLines do
       if (line.splitOn "http").length ≤ 1 && !(isImport line.toString) then
         let stringMsg := if line.contains '"' then
@@ -469,8 +473,9 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
           using a '\\' at the end of a line allows you to continue the string on the following \
           line, removing all intervening whitespace."
         else ""
-        Linter.logLint linter.style.longLine (.ofRange ⟨(line.drop maxWidth).startPos, line.stopPos⟩)
-          m!"This line exceeds the {maxWidth} character limit, please shorten it!{stringMsg}"
+        Linter.logLint linter.style.longLine
+          (.ofRange ⟨(line.drop maxLineLength).startPos, line.stopPos⟩)
+          m!"This line exceeds the {maxLineLength} character limit, please shorten it!{stringMsg}"
 
 initialize addLinter longLineLinter
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -425,6 +425,11 @@ public register_option linter.style.longLine : Bool := {
   descr := "enable the longLine linter"
 }
 
+public register_option linter.style.longLine.maxLineWidth : Nat := {
+  defValue := 100
+  descr := "maximum line width before the longLine linter emits a warning"
+}
+
 namespace Style.longLine
 
 def isImport (s : String) : Bool :=
@@ -454,8 +459,9 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       else return stx
     let sstr := stx.getSubstring?
     let fm ← getFileMap
+    let maxWidth : Nat := linter.style.longLine.maxLineWidth.get (← getOptions)
     let longLines := ((sstr.getD default).splitOn "\n").filter fun line ↦
-      (100 < (fm.toPosition line.stopPos).column)
+      (maxWidth < (fm.toPosition line.stopPos).column)
     for line in longLines do
       if (line.splitOn "http").length ≤ 1 && !(isImport line.toString) then
         let stringMsg := if line.contains '"' then
@@ -463,8 +469,9 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
           using a '\\' at the end of a line allows you to continue the string on the following \
           line, removing all intervening whitespace."
         else ""
-        Linter.logLint linter.style.longLine (.ofRange ⟨(line.drop 100).startPos, line.stopPos⟩)
-          m!"This line exceeds the 100 character limit, please shorten it!{stringMsg}"
+        Linter.logLint linter.style.longLine (.ofRange ⟨(line.drop maxWidth).startPos, line.stopPos⟩)
+          m!"This line exceeds the {maxWidth} character limit, please shorten it!{stringMsg}"
+
 initialize addLinter longLineLinter
 
 end Style.longLine

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -463,7 +463,7 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       else return stx
     let sstr := stx.getSubstring?
     let fm ← getFileMap
-    let maxLineLength : Nat := linter.style.longLine.maxLineLength.get (← getOptions)
+    let maxLineLength := linter.style.longLine.maxLineLength.get (← getOptions)
     let longLines := ((sstr.getD default).splitOn "\n").filter fun line ↦
       (maxLineLength < (fm.toPosition line.stopPos).column)
     for line in longLines do

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -410,6 +410,15 @@ Note: This linter can be disabled with `set_option linter.style.longLine false`
 #guard_msgs in
 /-!                                                                                                -/
 
+set_option linter.style.longLine.maxLineWidth 80 in
+/--
+warning: This line exceeds the 80 character limit, please shorten it!
+
+Note: This linter can be disabled with `set_option linter.style.longLine false`
+-/
+#guard_msgs in
+/-!                                                                                 -/
+
 #guard_msgs in
 -- Lines with more than 100 characters containing URLs are allowed.
 /-!  http                                                                                          -/

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -410,7 +410,7 @@ Note: This linter can be disabled with `set_option linter.style.longLine false`
 #guard_msgs in
 /-!                                                                                                -/
 
-set_option linter.style.longLine.maxLineWidth 80 in
+set_option linter.style.longLine.maxLineLength 80 in
 /--
 warning: This line exceeds the 80 character limit, please shorten it!
 


### PR DESCRIPTION
This PR adds an option `linter.style.longLine.maxLineLength`, whose value defaults at 100, and modifies the `longLine` linter so that it uses this value when determining whether a line is too long.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Projects downstream of Mathlib may want to have their own style conventions about line length. The currently hardcoded value of 100 does not let them use this linter in the case where they want a different convention. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
