### PR TITLE
[Merged by Bors] - chore(Algebra/Lie/Classical): remove an erw

### DIFF
--- a/Mathlib/Algebra/Lie/Classical.lean
+++ b/Mathlib/Algebra/Lie/Classical.lean
@@ -232,7 +232,8 @@ theorem soIndefiniteEquiv_apply {i : R} (hi : i * i = -1) (A : so' p q R) :
     (soIndefiniteEquiv p q R hi A : Matrix (p ⊕ q) (p ⊕ q) R) =
       (Pso p q R i)⁻¹ * (A : Matrix (p ⊕ q) (p ⊕ q) R) * Pso p q R i := by
   rw [soIndefiniteEquiv, LieEquiv.trans_apply, LieEquiv.ofEq_apply]
-  erw [skewAdjointMatricesLieSubalgebraEquiv_apply]
+  simp only [so']
+  rw [skewAdjointMatricesLieSubalgebraEquiv_apply]
 
 /-- A matrix defining a canonical even-rank symmetric bilinear form.
 

--- a/Mathlib/Algebra/Lie/Classical.lean
+++ b/Mathlib/Algebra/Lie/Classical.lean
@@ -232,8 +232,7 @@ theorem soIndefiniteEquiv_apply {i : R} (hi : i * i = -1) (A : so' p q R) :
     (soIndefiniteEquiv p q R hi A : Matrix (p ⊕ q) (p ⊕ q) R) =
       (Pso p q R i)⁻¹ * (A : Matrix (p ⊕ q) (p ⊕ q) R) * Pso p q R i := by
   rw [soIndefiniteEquiv, LieEquiv.trans_apply, LieEquiv.ofEq_apply]
-  simp only [so']
-  rw [skewAdjointMatricesLieSubalgebraEquiv_apply]
+  simp only [so', skewAdjointMatricesLieSubalgebraEquiv_apply]
 
 /-- A matrix defining a canonical even-rank symmetric bilinear form.
 


### PR DESCRIPTION
- unfolds `so'` before `skewAdjointMatricesLieSubalgebraEquiv_apply`, so the proof closes with a plain `rw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)