### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites/CompatibleSheafification): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -63,7 +63,6 @@ noncomputable def sheafificationWhiskerLeftIso (P : Cᵒᵖ ⥤ D)
   refine isoWhiskerRight ?_ _
   exact J.plusFunctorWhiskerLeftIso _
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem sheafificationWhiskerLeftIso_hom_app (P : Cᵒᵖ ⥤ D) (F : D ⥤ E)
     [∀ (F : D ⥤ E) (X : C), PreservesColimitsOfShape (J.Cover X)ᵒᵖ F]
@@ -71,7 +70,7 @@ theorem sheafificationWhiskerLeftIso_hom_app (P : Cᵒᵖ ⥤ D) (F : D ⥤ E)
         PreservesLimit (W.index P).multicospan F] :
     (sheafificationWhiskerLeftIso J P).hom.app F = (J.sheafifyCompIso F P).hom := by
   dsimp [sheafificationWhiskerLeftIso, sheafifyCompIso]
-  rw [Category.comp_id]
+  simp only [sheafify, Category.comp_id]
 
 @[simp]
 theorem sheafificationWhiskerLeftIso_inv_app (P : Cᵒᵖ ⥤ D) (F : D ⥤ E)
@@ -80,7 +79,7 @@ theorem sheafificationWhiskerLeftIso_inv_app (P : Cᵒᵖ ⥤ D) (F : D ⥤ E)
         PreservesLimit (W.index P).multicospan F] :
     (sheafificationWhiskerLeftIso J P).inv.app F = (J.sheafifyCompIso F P).inv := by
   dsimp [sheafificationWhiskerLeftIso, sheafifyCompIso]
-  erw [Category.id_comp]
+  simp only [sheafify, Category.id_comp]
 
 /-- The isomorphism between the sheafification of `P` composed with `F` and
 the sheafification of `P ⋙ F`, functorially in `P`. -/
@@ -93,32 +92,26 @@ noncomputable def sheafificationWhiskerRightIso :
   refine (associator _ _ _).symm ≪≫ ?_
   exact isoWhiskerRight (J.plusFunctorWhiskerRightIso _) (J.plusFunctor E)
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem sheafificationWhiskerRightIso_hom_app :
     (J.sheafificationWhiskerRightIso F).hom.app P = (J.sheafifyCompIso F P).hom := by
   dsimp [sheafificationWhiskerRightIso, sheafifyCompIso]
-  simp only [Category.id_comp, Category.comp_id]
-  erw [Category.id_comp]
+  simp only [sheafify, Category.id_comp, Category.comp_id]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem sheafificationWhiskerRightIso_inv_app :
     (J.sheafificationWhiskerRightIso F).inv.app P = (J.sheafifyCompIso F P).inv := by
   dsimp [sheafificationWhiskerRightIso, sheafifyCompIso]
-  simp only [Category.comp_id]
-  erw [Category.id_comp]
+  simp only [sheafify, Category.id_comp, Category.comp_id]
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp, reassoc]
 theorem whiskerRight_toSheafify_sheafifyCompIso_hom :
     whiskerRight (J.toSheafify _) _ ≫ (J.sheafifyCompIso F P).hom = J.toSheafify _ := by
   dsimp [sheafifyCompIso]
-  erw [whiskerRight_comp, Category.assoc]
+  simp only [toSheafify, sheafify, whiskerRight_comp, Category.assoc]
   slice_lhs 2 3 => rw [plusCompIso_whiskerRight]
   rw [Category.assoc, ← J.plusMap_comp, whiskerRight_toPlus_comp_plusCompIso_hom, ←
     Category.assoc, whiskerRight_toPlus_comp_plusCompIso_hom]
-  rfl
 
 @[simp, reassoc]
 theorem toSheafify_comp_sheafifyCompIso_inv :


### PR DESCRIPTION
- rewrites the sheafification whiskering lemmas with `simp only [sheafify, ...]`, removing the transparency workaround
- rewrites `whiskerRight_toSheafify_sheafifyCompIso_hom` with `simp only [toSheafify, sheafify, ...]` instead of `erw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)