### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/CliffordAlgebra/SpinGroup): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/CliffordAlgebra/SpinGroup.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/SpinGroup.lean
@@ -136,7 +136,7 @@ theorem conjAct_smul_range_ι {x : (CliffordAlgebra Q)ˣ} (hx : x ∈ lipschitzG
       refine Eq.trans_le ?_ this
       simp only [map_inv, smul_inv_smul]
   intro x hx
-  erw [Submodule.map_le_iff_le_comap]
+  rw [Submodule.pointwise_smul_def, Submodule.map_le_iff_le_comap]
   rintro _ ⟨m, rfl⟩
   exact conjAct_smul_ι_mem_range_ι hx _
 


### PR DESCRIPTION
- inserts `Submodule.pointwise_smul_def` before `Submodule.map_le_iff_le_comap`, so the proof no longer needs `erw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)