### PR TITLE
[Merged by Bors] - fix(scripts/rm_set_option.py): make more usable in downstream projects

### DIFF
--- a/scripts/dag_traversal.py
+++ b/scripts/dag_traversal.py
@@ -852,13 +852,13 @@ def _cli_main():
         "--dir",
         type=Path,
         default=Path("."),
-        help="Project root directory (default: '.')",
+        help="Project root directory (default: cwd)",
     )
     parser.add_argument(
         "--directories",
         nargs="+",
         default=None,
-        help="Directories to scan (default: '.')",
+        help="Directories to scan (default: '.', relative to project root specified by --dir)",
     )
 
     args = parser.parse_args()

--- a/scripts/dag_traversal.py
+++ b/scripts/dag_traversal.py
@@ -539,7 +539,7 @@ class DAG:
         Uses ``lean --deps-json`` to parse imports correctly.
         """
         if directories is None:
-            directories = ["Mathlib", "MathlibTest", "Archive", "Counterexamples"]
+            directories = ["."]
 
         # Collect all .lean file paths (relative to project_root).
         rel_paths: list[Path] = []
@@ -852,13 +852,13 @@ def _cli_main():
         "--dir",
         type=Path,
         default=Path("."),
-        help="Project root directory (default: cwd)",
+        help="Project root directory (default: '.')",
     )
     parser.add_argument(
         "--directories",
         nargs="+",
         default=None,
-        help="Directories to scan (default: Mathlib MathlibTest Archive Counterexamples)",
+        help="Directories to scan (default: '.')",
     )
 
     args = parser.parse_args()

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -380,7 +380,7 @@ def main():
     start_time = time.time()
 
     # Step 1: lakefile.lean
-    if not args.dry_run and os.path.exists(PROJECT_DIR / "lakefile.lean"):
+    if not args.dry_run and (PROJECT_DIR / "lakefile.lean").exists():
         handle_lakefile(options)
 
     # Step 2: build DAG

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Remove unnecessary `set_option ... false in` from Mathlib.
+Remove unnecessary `set_option ... false in` from a Lean project.
 
 Tries removing each occurrence (that isn't followed by a comment), testing
 whether the file still builds. Processes files in reverse import-DAG order
@@ -11,7 +11,6 @@ import argparse
 import hashlib
 import json
 import os
-import subprocess
 import threading
 import time
 from dataclasses import dataclass
@@ -321,7 +320,9 @@ def write_github_outputs(summary: Summary):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Remove unnecessary set_option ... false in lines"
+        description="Remove unnecessary `set_option ... false in` lines in a Lean project.\n\n"
+                    "Copy `rm_set_option.py`, `dag_traversal.py` and `set_option_utils.py` to "
+                    "a subdirectory of your project named `scripts/` and run from the project root."
     )
     parser.add_argument(
         "--option",

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -353,7 +353,7 @@ def main():
         "--directories",
         nargs="+",
         default=None,
-        help="Directories to scan when building the import DAG (default: Mathlib MathlibTest Archive Counterexamples)",
+        help="Directories to scan when building the import DAG (default: '.')",
     )
     parser.add_argument(
         "--no-initial",

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -323,7 +323,7 @@ def main():
         description="Remove unnecessary `set_option ... false in` lines in a Lean project.\n\n"
                     "To use outside mathlib, copy `rm_set_option.py`, `dag_traversal.py` and "
                     "`set_option_utils.py` to a subdirectory of your project named `scripts/` "
-                    "and then run from the project root with `scripts/rm_set_optyion.py`.",
+                    "and then run from the project root with `scripts/rm_set_option.py`.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -321,8 +321,10 @@ def write_github_outputs(summary: Summary):
 def main():
     parser = argparse.ArgumentParser(
         description="Remove unnecessary `set_option ... false in` lines in a Lean project.\n\n"
-                    "Copy `rm_set_option.py`, `dag_traversal.py` and `set_option_utils.py` to "
-                    "a subdirectory of your project named `scripts/` and run from the project root."
+                    "To use outside mathlib, copy `rm_set_option.py`, `dag_traversal.py` and "
+                    "`set_option_utils.py` to a subdirectory of your project named `scripts/` "
+                    "and then run from the project root with `scripts/rm_set_optyion.py`.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--option",

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -350,6 +350,12 @@ def main():
         help="Only process these files (paths relative to project root)",
     )
     parser.add_argument(
+        "--directories",
+        nargs="+",
+        default=None,
+        help="Directories to scan when building the import DAG (default: Mathlib MathlibTest Archive Counterexamples)",
+    )
+    parser.add_argument(
         "--no-initial",
         action="store_true",
         help="Skip the initial lake build (assumes .oleans are already fresh)",
@@ -373,13 +379,13 @@ def main():
 
     start_time = time.time()
 
-    # Step 1: lakefile
-    if not args.dry_run:
+    # Step 1: lakefile.lean
+    if not args.dry_run and os.path.exists(PROJECT_DIR / "lakefile.lean"):
         handle_lakefile(options)
 
     # Step 2: build DAG
     print("Building import DAG...", flush=True)
-    full_dag = DAG.from_directories(PROJECT_DIR)
+    full_dag = DAG.from_directories(PROJECT_DIR, args.directories)
     print(f"  {len(full_dag.modules)} modules parsed")
 
     # Step 3: scan for removable lines


### PR DESCRIPTION
- Only attempt to process `lakefile.lean` if it exists.
- Added a new `--directories` command-line option to specify which directories to scan (copied from `dag_traversal.py`, and passed directly to that script).

cf. https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/backward.2EisDefEq.2ErespectTransparency/near/590911742

---
