### PR TITLE
[Merged by Bors] - feat: the intersection of a collection of sets is empty if one of them is empty

### DIFF
--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -919,6 +919,10 @@ theorem iUnion₂_eq_univ_iff {s : ∀ i, κ i → Set α} :
 theorem sUnion_eq_univ_iff {c : Set (Set α)} : ⋃₀ c = univ ↔ ∀ a, ∃ b ∈ c, a ∈ b := by
   simp only [eq_univ_iff_forall, mem_sUnion]
 
+theorem iInter_eq_empty_of_eq_empty {i : ι} {f : ι → Set α} (h : f i = ∅) :
+    ⋂ j, f j = ∅ :=
+  subset_eq_empty (iInter_subset _ i) h
+
 -- classical
 theorem iInter_eq_empty_iff {f : ι → Set α} : ⋂ i, f i = ∅ ↔ ∀ x, ∃ i, x ∉ f i := by
   simp [Set.eq_empty_iff_forall_notMem]

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 module
 
 public import Mathlib.Order.BooleanAlgebra.Set
+public import Mathlib.Order.SetNotation
 public import Mathlib.Order.SymmDiff
 
 /-! # Symmetric differences of sets -/
@@ -17,7 +18,7 @@ assert_not_exists RelIso
 namespace Set
 
 universe u
-variable {α : Type u} {a : α} {s t u v : Set α}
+variable {ι α : Type u} {a : α} {s t u v : Set α}
 
 open scoped symmDiff
 
@@ -57,6 +58,12 @@ lemma symmDiff_union_subset : s ∆ (t ∪ u) ⊆ s ∆ t ∪ s ∆ u := by
   grind
 
 lemma union_symmDiff_union_subset : (s ∪ t) ∆ (u ∪ v) ⊆ s ∆ u ∪ t ∆ v := by
+  grind
+
+lemma iUnion_symmDiff_iUnion_subset {f g : ι → Set α} :
+    (⋃ n, f n) ∆ ⋃ n, g n ⊆ ⋃ n, f n ∆ g n := by
+  intro
+  simp_all [symmDiff]
   grind
 
 end Set

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -62,8 +62,6 @@ lemma union_symmDiff_union_subset : (s ∪ t) ∆ (u ∪ v) ⊆ s ∆ u ∪ t �
 
 lemma iUnion_symmDiff_iUnion_subset {f g : ι → Set α} :
     (⋃ n, f n) ∆ ⋃ n, g n ⊆ ⋃ n, f n ∆ g n := by
-  intro
-  simp_all [symmDiff]
-  grind
+  intro; simp [symmDiff]; grind
 
 end Set

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -6,7 +6,6 @@ Authors: Jeremy Avigad, Leonardo de Moura
 module
 
 public import Mathlib.Order.BooleanAlgebra.Set
-public import Mathlib.Order.SetNotation
 public import Mathlib.Order.SymmDiff
 
 /-! # Symmetric differences of sets -/
@@ -18,7 +17,7 @@ assert_not_exists RelIso
 namespace Set
 
 universe u
-variable {ι α : Type u} {a : α} {s t u v : Set α}
+variable {α : Type u} {a : α} {s t u v : Set α}
 
 open scoped symmDiff
 
@@ -59,9 +58,5 @@ lemma symmDiff_union_subset : s ∆ (t ∪ u) ⊆ s ∆ t ∪ s ∆ u := by
 
 lemma union_symmDiff_union_subset : (s ∪ t) ∆ (u ∪ v) ⊆ s ∆ u ∪ t ∆ v := by
   grind
-
-lemma iUnion_symmDiff_iUnion_subset {f g : ι → Set α} :
-    (⋃ n, f n) ∆ ⋃ n, g n ⊆ ⋃ n, f n ∆ g n := by
-  intro; simp [symmDiff]; grind
 
 end Set


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
