### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): the splitting of a simplicial set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1561,6 +1561,7 @@ public import Mathlib.AlgebraicTopology.SimplicialSet.RegularEpi
 public import Mathlib.AlgebraicTopology.SimplicialSet.RelativeMorphism
 public import Mathlib.AlgebraicTopology.SimplicialSet.Simplices
 public import Mathlib.AlgebraicTopology.SimplicialSet.Skeleton
+public import Mathlib.AlgebraicTopology.SimplicialSet.Splitting
 public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplex
 public import Mathlib.AlgebraicTopology.SimplicialSet.StdSimplexOne
 public import Mathlib.AlgebraicTopology.SimplicialSet.StrictSegal

--- a/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/SplitSimplicialObject.lean
@@ -24,11 +24,9 @@ when `C` is a preadditive category with finite coproducts, and get an isomorphis
 @[expose] public section
 
 
-open CategoryTheory CategoryTheory.Limits CategoryTheory.Category CategoryTheory.Preadditive
-  CategoryTheory.Idempotents Opposite AlgebraicTopology AlgebraicTopology.DoldKan
-  Simplicial DoldKan
+namespace CategoryTheory.SimplicialObject
 
-namespace SimplicialObject
+open AlgebraicTopology Limits Category Preadditive Idempotents Opposite DoldKan Simplicial
 
 namespace Splitting
 
@@ -273,4 +271,4 @@ noncomputable def toKaroubiNondegComplexFunctorIsoN₁ :
 
 end Split
 
-end SimplicialObject
+end CategoryTheory.SimplicialObject

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -47,7 +47,7 @@ universe u
 
 variable {C : Type*} [Category* C]
 
-namespace SimplicialObject
+namespace CategoryTheory.SimplicialObject
 
 namespace Splitting
 
@@ -195,7 +195,7 @@ def summand (A : IndexSet Δ) : C :=
   N A.1.unop.len
 
 /-- The cofan for `summand N Δ` induced by morphisms `N n ⟶ X _⦋n⦌` for all `n : ℕ`. -/
-def cofan' (Δ : SimplexCategoryᵒᵖ) : Cofan (summand N Δ) :=
+abbrev cofan' (Δ : SimplexCategoryᵒᵖ) : Cofan (summand N Δ) :=
   Cofan.mk (X.obj Δ) (fun A => φ A.1.unop.len ≫ X.map A.e.op)
 
 end Splitting
@@ -212,6 +212,8 @@ structure Splitting (X : SimplicialObject C) where
   /-- For each `Δ`, `X.obj Δ` identifies to the coproduct of the objects `N A.1.unop.len`
   for all `A : IndexSet Δ`. -/
   isColimit' : ∀ Δ : SimplexCategoryᵒᵖ, IsColimit (Splitting.cofan' N X ι Δ)
+
+initialize_simps_projections Splitting (-isColimit')
 
 namespace Splitting
 
@@ -413,4 +415,4 @@ def natTransCofanInj {Δ : SimplexCategoryᵒᵖ} (A : Splitting.IndexSet Δ) :
 
 end Split
 
-end SimplicialObject
+end CategoryTheory.SimplicialObject

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Splitting.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Splitting.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.AlgebraicTopology.SimplicialObject.Split
+public import Mathlib.AlgebraicTopology.SimplicialSet.Degenerate
+public import Mathlib.CategoryTheory.Limits.Types.Coproducts
+
+/-!
+# The splitting of a simplicial set
+
+Let `X` be a simplicial set. The fact that any simplex `x : X _⦋n⦌` can be
+written in a unique way as `X.map f.op y` for an epimorphism `f : ⦋n⦌ ⟶ ⦋m⦌`
+and a nondegenerate simplex `y : X _⦋m⦌` is translated in this file
+as the data of a splitting of `X`.
+
+-/
+
+@[expose] public section
+
+universe u
+
+open CategoryTheory TypeCat Limits Simplicial
+
+namespace SSet
+
+variable (X : SSet.{u})
+
+/-- The canonical splitting of a simplicial set that is given
+by the nondegenerate simplices. -/
+@[simps]
+noncomputable def splitting : X.Splitting where
+  N n := X.nonDegenerate n
+  ι n := ↾Subtype.val
+  isColimit' := fun ⟨⟨n⟩⟩ ↦ Nonempty.some (by
+    rw [← Limits.Cofan.isColimit_cofanTypes_iff]
+    refine CofanTypes.isColimit_mk _ (fun x ↦ ?_) (fun ⟨⟨⟨m⟩⟩, f, _⟩ x y h ↦ ?_)
+      (fun ⟨⟨⟨m⟩⟩, f, _⟩ ⟨⟨⟨p⟩⟩, g, _⟩ x y h ↦ ?_)
+    · obtain ⟨m, f, _, y, rfl⟩ := X.exists_nonDegenerate x
+      exact ⟨.mk f, y, rfl⟩
+    · exact unique_nonDegenerate_simplex _ _ _ _ rfl _ _ h
+    · obtain rfl : m = p := unique_nonDegenerate_dim _ _ _ _ rfl _ _ h
+      obtain rfl : x = y := unique_nonDegenerate_simplex _ _ _ _ rfl _ _ h
+      obtain rfl : f = g := unique_nonDegenerate_map _ _ _ _ rfl _ _ h
+      dsimp)
+
+end SSet

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Splitting.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Splitting.lean
@@ -43,7 +43,6 @@ noncomputable def splitting : X.Splitting where
       exact ⟨.mk f, y, rfl⟩
     · exact unique_nonDegenerate_simplex _ _ _ _ rfl _ _ h
     · obtain rfl : m = p := unique_nonDegenerate_dim _ _ _ _ rfl _ _ h
-      obtain rfl : x = y := unique_nonDegenerate_simplex _ _ _ _ rfl _ _ h
       obtain rfl : f = g := unique_nonDegenerate_map _ _ _ _ rfl _ _ h
       dsimp)
 


### PR DESCRIPTION
Let `X` be a simplicial set. The fact that any simplex `x : X _⦋n⦌` can be written in a unique way as `X.map f.op y` for an epimorphism `f : ⦋n⦌ ⟶ ⦋m⦌` and a nondegenerate simplex `y : X _⦋m⦌` is translated in this PR as the data of a splitting of `X`.
(The namespace where `SimplicialObject.Splitting` lies is also fixed.)


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
