### PR TITLE
fix(Algebra/Module/Injective): changing the universe from the module's to the ring's

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -24,19 +24,20 @@ namespace Module
 theorem injective_object_of_injective_module [inj : Injective R M] :
     CategoryTheory.Injective (ModuleCat.of R M) where
   factors g f m :=
-    have ⟨l, h⟩ := inj.out f.hom ((ModuleCat.mono_iff_injective f).mp m) g.hom
-    ⟨ModuleCat.ofHom l, by ext x; simpa using h x⟩
+    have ⟨l, h⟩ := inj.extension_property R M _ _ f.hom ((ModuleCat.mono_iff_injective f).mp m) g.hom
+    ⟨ModuleCat.ofHom l, by ext x; simpa using DFunLike.congr_fun h x⟩
 
-theorem injective_module_of_injective_object
+theorem injective_module_of_injective_object [Small.{v} R]
     [inj : CategoryTheory.Injective <| ModuleCat.of R M] :
-    Module.Injective R M where
-  out X Y _ _ _ _ f hf g := by
-    have : CategoryTheory.Mono (ModuleCat.ofHom f) := (ModuleCat.mono_iff_injective _).mpr hf
-    obtain ⟨l, h⟩ := inj.factors (ModuleCat.ofHom g) (ModuleCat.ofHom f)
-    obtain rfl := ModuleCat.hom_ext_iff.mp h
-    exact ⟨l.hom, fun _ => rfl⟩
+    Module.Injective R M := by
+  refine Injective.of_extension_property ?_
+  intro X Y _ _ _ _ f hf g
+  have : CategoryTheory.Mono (ModuleCat.ofHom f) := (ModuleCat.mono_iff_injective _).mpr hf
+  obtain ⟨l, h⟩ := inj.factors (ModuleCat.ofHom g) (ModuleCat.ofHom f)
+  obtain rfl := ModuleCat.hom_ext_iff.mp h
+  exact ⟨l.hom, rfl⟩
 
-theorem injective_iff_injective_object :
+theorem injective_iff_injective_object [Small.{v} R] :
     Module.Injective R M ↔
     CategoryTheory.Injective (ModuleCat.of R M) :=
   ⟨fun _ => injective_object_of_injective_module R M,

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -24,7 +24,8 @@ namespace Module
 theorem injective_object_of_injective_module [inj : Injective R M] :
     CategoryTheory.Injective (ModuleCat.of R M) where
   factors g f m :=
-    have ⟨l, h⟩ := inj.extension_property R M _ _ f.hom ((ModuleCat.mono_iff_injective f).mp m) g.hom
+    have ⟨l, h⟩ := inj.extension_property R M _ _ f.hom
+      ((ModuleCat.mono_iff_injective f).mp m) g.hom
     ⟨ModuleCat.ofHom l, by ext x; simpa using DFunLike.congr_fun h x⟩
 
 theorem injective_module_of_injective_object [Small.{v} R]

--- a/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
@@ -92,8 +92,10 @@ instance [Small.{v} R] : (uliftFunctor.{v', v} R).PreservesProjectiveObjects whe
     exact Module.Projective.of_equiv ULift.moduleEquiv.symm
 
 instance [Small.{v} R] : (uliftFunctor.{v', v} R).PreservesInjectiveObjects where
-  injective_obj {M} inj := (Module.injective_iff_injective_object R _).mp
-    (Module.ulift_injective_of_injective R ((Module.injective_iff_injective_object R M).mpr inj))
+  injective_obj {M} inj := by
+    have := small_lift R
+    rw [← Module.injective_iff_injective_object]
+    exact Module.ulift_injective_of_injective R ((Module.injective_iff_injective_object R M).mpr inj)
 
 end Ring
 

--- a/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Ulift.lean
@@ -95,7 +95,8 @@ instance [Small.{v} R] : (uliftFunctor.{v', v} R).PreservesInjectiveObjects wher
   injective_obj {M} inj := by
     have := small_lift R
     rw [← Module.injective_iff_injective_object]
-    exact Module.ulift_injective_of_injective R ((Module.injective_iff_injective_object R M).mpr inj)
+    exact Module.ulift_injective_of_injective R
+      ((Module.injective_iff_injective_object R M).mpr inj)
 
 end Ring
 

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -59,7 +59,7 @@ map to `Q`, i.e. in the following diagram, if `f` is injective then there is an 
   ```
 -/
 @[mk_iff] class Module.Injective : Prop where
-  out : ∀ ⦃X Y : Type v⦄ [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
+  out : ∀ ⦃X Y : Type u⦄ [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
     (f : X →ₗ[R] Y) (_ : Function.Injective f) (g : X →ₗ[R] Q),
     ∃ h : Y →ₗ[R] Q, ∀ x, h (f x) = g x
 
@@ -402,15 +402,12 @@ protected theorem injective (h : Module.Baer R Q) : Module.Injective R Q where
     obtain ⟨h, H⟩ := Module.Baer.extension_property h i hi f
     exact ⟨h, DFunLike.congr_fun H⟩
 
-protected theorem of_injective [Small.{v} R] (inj : Module.Injective R Q) : Module.Baer R Q := by
+protected theorem of_injective (inj : Module.Injective R Q) : Module.Baer R Q := by
   intro I g
-  let eI := Shrink.linearEquiv R I
-  let eR := Shrink.linearEquiv R R
-  obtain ⟨g', hg'⟩ := Module.Injective.out (eR.symm.toLinearMap ∘ₗ I.subtype ∘ₗ eI.toLinearMap)
-    (eR.symm.injective.comp <| Subtype.val_injective.comp eI.injective) (g ∘ₗ eI.toLinearMap)
-  exact ⟨g' ∘ₗ eR.symm.toLinearMap, fun x mx ↦ by simpa [eI, eR] using hg' (equivShrink I ⟨x, mx⟩)⟩
+  obtain ⟨g', hg'⟩ := Module.Injective.out I.subtype Subtype.val_injective g
+  exact ⟨g', fun x mx ↦ hg' ⟨x, mx⟩⟩
 
-protected theorem iff_injective [Small.{v} R] : Module.Baer R Q ↔ Module.Injective R Q :=
+protected theorem iff_injective : Module.Baer R Q ↔ Module.Injective R Q :=
   ⟨Module.Baer.injective, Module.Baer.of_injective⟩
 
 end Module.Baer
@@ -419,7 +416,7 @@ section ULift
 
 variable {M : Type v} [AddCommGroup M] [Module R M]
 
-lemma Module.ulift_injective_of_injective [Small.{v} R]
+lemma Module.ulift_injective_of_injective
     (inj : Module.Injective R M) :
     Module.Injective R (ULift.{v'} M) := Module.Baer.injective fun I g ↦
   have ⟨g', hg'⟩ := Module.Baer.iff_injective.mpr inj I (ULift.moduleEquiv.toLinearMap ∘ₗ g)
@@ -428,15 +425,11 @@ lemma Module.ulift_injective_of_injective [Small.{v} R]
 lemma Module.injective_of_ulift_injective
     (inj : Module.Injective R (ULift.{v'} M)) :
     Module.Injective R M where
-  out X Y _ _ _ _ f hf g :=
-    let eX := ULift.moduleEquiv.{_, _, v'} (R := R) (M := X)
-    have ⟨g', hg'⟩ := inj.out (ULift.moduleEquiv.{_, _, v'}.symm.toLinearMap ∘ₗ f ∘ₗ eX.toLinearMap)
-      (by exact ULift.moduleEquiv.symm.injective.comp <| hf.comp eX.injective)
-      (ULift.moduleEquiv.symm.toLinearMap ∘ₗ g ∘ₗ eX.toLinearMap)
-    ⟨ULift.moduleEquiv.toLinearMap ∘ₗ g' ∘ₗ ULift.moduleEquiv.symm.toLinearMap,
-      fun x ↦ by exact congr(ULift.down $(hg' ⟨x⟩))⟩
+  out _ _ _ _ _ _ f hf g :=
+    have ⟨g', hg'⟩ := inj.out f hf (ULift.moduleEquiv.symm.toLinearMap ∘ₗ g)
+    ⟨ULift.moduleEquiv.toLinearMap ∘ₗ g', fun x ↦ congr(ULift.down $(hg' x))⟩
 
-variable (M) [Small.{v} R]
+variable (M)
 
 lemma Module.injective_iff_ulift_injective :
     Module.Injective R M ↔ Module.Injective R (ULift.{v'} M) :=
@@ -449,7 +442,7 @@ section lifting_property
 
 universe uR uM uP uP'
 
-variable (R : Type uR) [Ring R] [Small.{uM} R]
+variable (R : Type uR) [Ring R]
 variable (M : Type uM) [AddCommGroup M] [Module R M] [inj : Module.Injective R M]
 variable (P : Type uP) [AddCommGroup P] [Module R P]
 variable (P' : Type uP') [AddCommGroup P'] [Module R P']
@@ -464,7 +457,7 @@ end lifting_property
 
 universe w in
 instance Module.Injective.pi
-    (R : Type u) [Ring R] {ι : Type w} (M : ι → Type v) [Small.{v} R]
+    (R : Type u) [Ring R] {ι : Type w} (M : ι → Type v)
     [∀ i, AddCommGroup (M i)] [∀ i, Module R (M i)]
     [∀ i, Module.Injective R (M i)] :
     Module.Injective R (∀ i, M i) :=
@@ -476,7 +469,7 @@ instance Module.Injective.pi
 
 universe u' in
 attribute [local instance] RingHomInvPair.of_ringEquiv in
-theorem Module.Injective.of_ringEquiv {R : Type u} [Ring R] [Small.{v} R] {S : Type u'} [Ring S]
+theorem Module.Injective.of_ringEquiv {R : Type u} [Ring R] {S : Type u'} [Ring S]
     {M : Type v} {N : Type v'} [AddCommGroup M] [AddCommGroup N] [Module R M] [Module S N]
     (e₁ : R ≃+* S) (e₂ : M ≃ₛₗ[RingHomClass.toRingHom e₁] N)
     [inj : Module.Injective R M] : Module.Injective S N := by

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -452,8 +452,25 @@ lemma Module.Injective.extension_property
     (g : P →ₗ[R] M) : ∃ h : P' →ₗ[R] M, h ∘ₗ f = g :=
   (Module.Baer.of_injective inj).extension_property f hf g
 
-end lifting_property
+/-- A variant that we only consider modules over `Type v`.
+  Should be only used when we consider `ModuleCat`s. -/
+lemma Module.Injective.of_extension_property {R : Type u} [Ring R] {M : Type v} [AddCommGroup M]
+    [Module R M] [Small.{v} R]
+    -- If for all injection of `R`-modules `X →ₗ Y`, all maps `X →ₗ M` extend to `Y →ₗ M`,
+    (h : ∀ {X Y : Type v} [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
+      (f : X →ₗ[R] Y) (_ : Function.Injective f) (g : X →ₗ[R] M),
+      ∃ h : Y →ₗ[R] M, h ∘ₗ f = g) :
+    -- then `P` is projective.
+    Injective R M := by
+  refine Module.Baer.injective fun I g ↦ ?_
+  let eI := Shrink.linearEquiv R I
+  let eR := Shrink.linearEquiv R R
+  obtain ⟨g', hg'⟩ := h (eR.symm.toLinearMap ∘ₗ I.subtype ∘ₗ eI.toLinearMap)
+    (eR.symm.injective.comp <| Subtype.val_injective.comp eI.injective) (g ∘ₗ eI.toLinearMap)
+  exact ⟨g' ∘ₗ eR.symm.toLinearMap, fun x mx ↦ by
+    simpa [eI, eR] using DFunLike.congr_fun hg' (equivShrink I ⟨x, mx⟩)⟩
 
+end lifting_property
 
 universe w in
 instance Module.Injective.pi

--- a/Mathlib/RepresentationTheory/FinGroupCharZero.lean
+++ b/Mathlib/RepresentationTheory/FinGroupCharZero.lean
@@ -33,7 +33,7 @@ an algebraically closed field in which the order of `G` is invertible:
 
 public section
 
-universe u v w
+universe u v
 
 variable {k : Type u} [Field k] {G : Type u} [Finite G] [Group G]
 
@@ -47,7 +47,7 @@ variable [NeZero (Nat.card G : k)]
 If `G` is finite and its order is nonzero in the field `k`, then every object of
 `Rep k G` is injective.
 -/
-instance (V : Rep.{w} k G) : Injective V := by
+instance (V : Rep.{u} k G) : Injective V := by
   rw [← Rep.equivalenceModuleMonoidAlgebra.map_injective_iff,
     ← Module.injective_iff_injective_object]
   exact Module.injective_of_isSemisimpleRing _ _

--- a/Mathlib/RingTheory/Flat/Tensor.lean
+++ b/Mathlib/RingTheory/Flat/Tensor.lean
@@ -45,13 +45,13 @@ The character module of `M` is an injective module if and only if
 -/
 lemma injective_characterModule_iff_rTensor_preserves_injective_linearMap :
     Module.Injective R (CharacterModule M) ↔
-    ∀ ⦃N N' : Type v⦄ [AddCommGroup N] [AddCommGroup N'] [Module R N] [Module R N']
+    ∀ ⦃N N' : Type u⦄ [AddCommGroup N] [AddCommGroup N'] [Module R N] [Module R N']
       (f : N →ₗ[R] N'), Function.Injective f → Function.Injective (f.rTensor M) := by
   simp_rw [injective_iff, rTensor_injective_iff_lcomp_surjective, Surjective, DFunLike.ext_iff]; rfl
 
 /-- `CharacterModule M` is an injective module iff `M` is flat.
 See [Lambek_1964] for a self-contained proof. -/
-theorem iff_characterModule_injective [Small.{v} R] :
+theorem iff_characterModule_injective :
     Flat R M ↔ Module.Injective R (CharacterModule M) := by
   rw [injective_characterModule_iff_rTensor_preserves_injective_linearMap,
     iff_rTensor_preserves_injective_linearMap']

--- a/Mathlib/RingTheory/LocalProperties/Injective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Injective.lean
@@ -36,8 +36,8 @@ section
 universe u' v'
 
 open IsLocalizedModule in
-theorem Module.injective_of_isLocalizedModule [Small.{v} R] [IsNoetherianRing R] {Rₛ : Type u'}
-    [Small.{v'} Rₛ] [CommRing Rₛ] [Algebra R Rₛ] {Mₛ : Type v'} [AddCommGroup Mₛ] [Module R Mₛ]
+theorem Module.injective_of_isLocalizedModule [IsNoetherianRing R] {Rₛ : Type u'}
+    [CommRing Rₛ] [Algebra R Rₛ] {Mₛ : Type v'} [AddCommGroup Mₛ] [Module R Mₛ]
     [Module Rₛ Mₛ] [IsScalarTower R Rₛ Mₛ] (f : M →ₗ[R] Mₛ) [IsLocalization S Rₛ]
     [IsLocalizedModule S f] [Module.Injective R M] : Module.Injective Rₛ Mₛ := by
   have MB : Baer R M := Baer.of_injective ‹_›
@@ -59,7 +59,7 @@ theorem Module.injective_of_isLocalizedModule [Small.{v} R] [IsNoetherianRing R]
 
 end
 
-theorem Module.injective_of_localization_maximal [Small.{v} R] [IsNoetherianRing R]
+theorem Module.injective_of_localization_maximal [IsNoetherianRing R]
     (H : ∀ (I : Ideal R) (_ : I.IsMaximal),
       Module.Injective (Localization.AtPrime I) (LocalizedModule I.primeCompl M)) :
     Module.Injective R M := by
@@ -115,7 +115,7 @@ include f in
 /--
 A variant of `Module.injective_of_localization_maximal` that accepts `IsLocalizedModule`.
 -/
-theorem Module.injective_of_localization_maximal' [Small.{v} R] [IsNoetherianRing R]
+theorem Module.injective_of_localization_maximal' [IsNoetherianRing R]
     (H : ∀ (I : Ideal R) (_ : I.IsMaximal), Module.Injective (Rₚ I) (Mₚ I)) :
     Module.Injective R M := by
   apply Module.injective_of_localization_maximal

--- a/Mathlib/RingTheory/LocalProperties/Injective.lean
+++ b/Mathlib/RingTheory/LocalProperties/Injective.lean
@@ -100,7 +100,6 @@ universe u' v'
 variable
   (Rₚ : ∀ (P : Ideal R) [P.IsMaximal], Type u')
   [∀ (P : Ideal R) [P.IsMaximal], CommRing (Rₚ P)]
-  [∀ (P : Ideal R) [P.IsMaximal], Small.{v'} (Rₚ P)]
   [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
   [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
   (Mₚ : ∀ (P : Ideal R) [P.IsMaximal], Type v')


### PR DESCRIPTION
Change the definition of
```lean
class Module.Injective : Prop where
  out : ∀ ⦃X Y : Type v⦄ [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
    (f : X →ₗ[R] Y) (_ : Function.Injective f) (g : X →ₗ[R] Q),
    ∃ h : Y →ₗ[R] Q, ∀ x, h (f x) = g x
```
into
```lean
class Module.Injective : Prop where
  out : ∀ ⦃X Y : Type u⦄ [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
    (f : X →ₗ[R] Y) (_ : Function.Injective f) (g : X →ₗ[R] Q),
    ∃ h : Y →ₗ[R] Q, ∀ x, h (f x) = g x
```
where `u` is the universe of ring, `v` is the universe of module,
to make it agree with `Module.Baer` and real mathematical definition, **without universe issues** (make the theorem [`Module.Baer.of_injective`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Module/Injective.html#Module.Baer.of_injective) not require `Small.{v, u} R` issue).

This type of adaption also appeared in the criterion `Module.Flat`, which also uses `Type u` on testing modules.

See discussions in https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Universe.20issue.20about.20injective.20module .

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
