### PR TITLE
[Merged by Bors] - feat(Algebra/Ring/BooleanRing): definitional lemmas for `Bool` ring operations

### DIFF
--- a/Mathlib/Algebra/Ring/BooleanRing.lean
+++ b/Mathlib/Algebra/Ring/BooleanRing.lean
@@ -541,3 +541,15 @@ instance : BooleanRing Bool where
   mul_zero a := by cases a <;> rfl
   nsmul := nsmulRec
   zsmul := zsmulRec
+
+theorem Bool.zero_eq_false : 0 = false := rfl
+
+theorem Bool.one_eq_true : 1 = true := rfl
+
+theorem Bool.add_eq_xor (b c : Bool) : b + c = (b ^^ c) := rfl
+
+theorem Bool.neg_eq_id (b : Bool) : -b = b := rfl
+
+theorem Bool.sub_eq_xor (b c : Bool) : b - c = (b ^^ c) := rfl
+
+theorem Bool.mul_eq_and (b c : Bool) : b * c = (b && c) := rfl


### PR DESCRIPTION
Mathlib defines a ring structure on `Bool` but is missing definitional lemmas for the arithmetic operations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Discussed on Zulip ([#Is there code for X? > &#96;Bool.xor&#96; same as &#96;+&#96; @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60Bool.2Exor.60.20same.20as.20.60.2B.60/near/590927417)), in particular, it's not immediately intuitive to everyone what the operations do.

Note that the parentheses around `^^` and `&&` are needed due to operator precedence w.r.t. `=`, see also https://github.com/leanprover-community/mathlib4/pull/38539.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
