### PR TITLE
[Merged by Bors] - feat(Geometry/Manifold): add `ContMDiffSMul` typeclass

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4493,6 +4493,7 @@ public import Mathlib.Geometry.Group.Growth.QuotientInter
 public import Mathlib.Geometry.Manifold.Algebra.LeftInvariantDerivation
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
 public import Mathlib.Geometry.Manifold.Algebra.Monoid
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.Algebra.SmoothFunctions
 public import Mathlib.Geometry.Manifold.Algebra.Structures
 public import Mathlib.Geometry.Manifold.Bordism

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -83,10 +83,10 @@ lemma mdifferentiable_iff {f : ℍ → ℂ} :
      <| isOpen_upperHalfPlaneSet.mem_nhds hz⟩
 
 lemma contMDiff_num (g : GL (Fin 2) ℝ) : CMDiff n (fun τ : ℍ ↦ num g τ) :=
-  (contMDiff_const.smul contMDiff_coe).add contMDiff_const
+  (contMDiff_const.mul contMDiff_coe).add contMDiff_const
 
 lemma contMDiff_denom (g : GL (Fin 2) ℝ) : CMDiff n (fun τ : ℍ ↦ denom g τ) :=
-  (contMDiff_const.smul contMDiff_coe).add contMDiff_const
+  (contMDiff_const.mul contMDiff_coe).add contMDiff_const
 
 lemma contMDiff_denom_zpow (g : GL (Fin 2) ℝ) (k : ℤ) : CMDiff n (denom g · ^ k : ℍ → ℂ) := by
   intro τ

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -45,7 +45,9 @@ library_note «Design choices about smooth algebraic structures» /--
 -- See note [Design choices about smooth algebraic structures]
 /-- Basic hypothesis to talk about a `C^n` (Lie) additive monoid or a `C^n` additive
 semigroup. A `C^n` additive monoid over `G`, for example, is obtained by requiring both the
-instances `AddMonoid G` and `ContMDiffAdd I n G`. -/
+instances `AddMonoid G` and `ContMDiffAdd I n G`.
+
+See also `ContMDiffVAdd I I' n G M` for `C^n` actions of `G` on a manifold `M`. -/
 class ContMDiffAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     (I : ModelWithCorners 𝕜 E H) (n : ℕ∞ω)
@@ -56,7 +58,9 @@ class ContMDiffAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [To
 -- See note [Design choices about smooth algebraic structures]
 /-- Basic hypothesis to talk about a `C^n` (Lie) monoid or a `C^n` semigroup.
 A `C^n` monoid over `G`, for example, is obtained by requiring both the instances `Monoid G`
-and `ContMDiffMul I n G`. -/
+and `ContMDiffMul I n G`.
+
+See also `ContMDiffSMul I I' n G M` for `C^n` actions of `G` on a manifold `M`. -/
 @[to_additive]
 class ContMDiffMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -5,7 +5,6 @@ Authors: Ben Eltschig
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Diffeomorph
 public import Mathlib.Geometry.Manifold.Instances.UnitsOfNormedAlgebra
 
 /-!
@@ -152,15 +151,18 @@ instance Units.contMDiffSMul {R : Type*} [NormedRing R] [CompleteSpace R] [Norme
 /-- The scalar multiplication `𝕜 × E → E` of any normed vector space `E` over `𝕜` is smooth. -/
 instance {n : ℕ∞ω} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
   contMDiff_smul := by
-    rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
-    exact contDiff_smul.contMDiff
+    have h : ContMDiff (𝓘(𝕜).prod 𝓘(𝕜, E)) 𝓘(𝕜, 𝕜 × E) n (@id (𝕜 × E)) := by
+      rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]; exact contMDiff_id
+    exact contDiff_smul.contMDiff.comp h
 
 /-- The monoid `E →L[𝕜] E` of continuous linear endomorphisms of `E` acts smoothly on `E`. -/
 instance [CompleteSpace E] {n : ℕ∞ω} :
     ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E) E where
   contMDiff_smul := by
-    rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
-    exact isBoundedBilinearMap_apply.contDiff.contMDiff
+    have h : ContMDiff (𝓘(𝕜, E →L[𝕜] E).prod 𝓘(𝕜, E)) 𝓘(𝕜, (E →L[𝕜] E) × E) n
+        (@id ((E →L[𝕜] E) × E)) := by
+      rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]; exact contMDiff_id
+    exact isBoundedBilinearMap_apply.contDiff.contMDiff.comp h
 
 /-- The general linear group `(E →L[𝕜] E)ˣ` on `E` acts smoothly on `E`. -/
 example [CompleteSpace E] (n : ℕ∞ω) :

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -115,11 +115,11 @@ nonrec theorem ContMDiffAt.smul (hf : CMDiffAt n f x) (hg : CMDiffAt n g x) :
 
 @[to_additive]
 theorem ContMDiffOn.smul (hf : CMDiff[s] n f) (hg : CMDiff[s] n g) :
-    CMDiff[s] n (f • g) := fun x hx => (hf x hx).smul (hg x hx)
+    CMDiff[s] n (f • g) := fun x hx ↦ (hf x hx).smul (hg x hx)
 
 @[to_additive]
 theorem ContMDiff.smul (hf : CMDiff n f) (hg : CMDiff n g) :
-    CMDiff n (f • g) := fun x => (hf x).smul (hg x)
+    CMDiff n (f • g) := fun x ↦ (hf x).smul (hg x)
 
 end
 

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -97,30 +97,30 @@ variable [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
   {f : N → G} {g : N → M} {s : Set N} {x : N}
 
 @[to_additive]
-theorem ContMDiffWithinAt.smul' (hf : ContMDiffWithinAt I'' I n f s x)
+theorem ContMDiffWithinAt.smul (hf : ContMDiffWithinAt I'' I n f s x)
     (hg : ContMDiffWithinAt I'' I' n g s x) : ContMDiffWithinAt I'' I' n (f • g) s x :=
   (contMDiff_smul (I := I) (I' := I')).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
 
 @[to_additive]
-nonrec theorem ContMDiffAt.smul' (hf : ContMDiffAt I'' I n f x) (hg : ContMDiffAt I'' I' n g x) :
+nonrec theorem ContMDiffAt.smul (hf : ContMDiffAt I'' I n f x) (hg : ContMDiffAt I'' I' n g x) :
     ContMDiffAt I'' I' n (f • g) x :=
-  hf.smul' hg
+  hf.smul hg
 
 @[to_additive]
-theorem ContMDiffOn.smul' (hf : ContMDiffOn I'' I n f s) (hg : ContMDiffOn I'' I' n g s) :
-    ContMDiffOn I'' I' n (f • g) s := fun x hx => (hf x hx).smul' (hg x hx)
+theorem ContMDiffOn.smul (hf : ContMDiffOn I'' I n f s) (hg : ContMDiffOn I'' I' n g s) :
+    ContMDiffOn I'' I' n (f • g) s := fun x hx => (hf x hx).smul (hg x hx)
 
 @[to_additive]
-theorem ContMDiff.smul' (hf : ContMDiff I'' I n f) (hg : ContMDiff I'' I' n g) :
-    ContMDiff I'' I' n (f • g) := fun x => (hf x).smul' (hg x)
+theorem ContMDiff.smul (hf : ContMDiff I'' I n f) (hg : ContMDiff I'' I' n g) :
+    ContMDiff I'' I' n (f • g) := fun x => (hf x).smul (hg x)
 
 end
 
 @[to_additive prod]
 instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
     [ContMDiffSMul I I'' n G N] : ContMDiffSMul I (I'.prod I'') n G (M × N) where
-  contMDiff_smul := (contMDiff_fst.smul' <| contMDiff_fst.comp contMDiff_snd).prodMk <|
-      contMDiff_fst.smul' <| contMDiff_snd.comp contMDiff_snd
+  contMDiff_smul := (contMDiff_fst.smul <| contMDiff_fst.comp contMDiff_snd).prodMk <|
+      contMDiff_fst.smul <| contMDiff_snd.comp contMDiff_snd
 
 /-- If `G` acts continuously differentiably on `G'` and `G'` acts continuously differentiably on
 `M`, then `G` acts continuously differentiably on `M`. -/
@@ -129,7 +129,7 @@ lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpa
     [ContMDiffSMul I I'' n G G'] [ContMDiffSMul I'' I' n G' M] : ContMDiffSMul I I' n G M where
   contMDiff_smul := by
     suffices ContMDiff (I.prod I') I' n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
-    exact (contMDiff_fst.smul' contMDiff_const).smul' (I := I'') contMDiff_snd
+    exact (contMDiff_fst.smul contMDiff_const).smul (I := I'') contMDiff_snd
 
 /-- If an action is continuously differentiable, then composing this action with a continuously
 differentiable homomorphism gives again a continuous action. -/
@@ -140,7 +140,7 @@ theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : WithTop 
     letI : MulAction G' M := MulAction.compHom _ f
     ContMDiffSMul I'' I' n G' M := by
   let _ : MulAction G' M := MulAction.compHom _ f
-  exact ⟨(hf.comp contMDiff_fst).smul' contMDiff_snd⟩
+  exact ⟨(hf.comp contMDiff_fst).smul contMDiff_snd⟩
 
 /-- If a complete normed ring acts continuously differentiably on a manifold `M`, its submanifold
 of units does as well. -/
@@ -159,13 +159,18 @@ def Diffeomorph.modelWithCornersSelfProdComparison {n : WithTop ℕ∞} :
     rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]
     exact contMDiff_id
 
+/-- The scalar multiplication `𝕜 × E → E` of any normed vector space `E` over `𝕜` is smooth. -/
+instance {n : WithTop ℕ∞} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
+  contMDiff_smul := by
+    rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
+    exact contDiff_smul.contMDiff
+
 /-- The monoid `E →L[𝕜] E` of continuous linear endomorphisms of `E` acts smoothly on `E`. -/
 instance [CompleteSpace E] {n : WithTop ℕ∞} :
     ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E) E where
   contMDiff_smul := by
     rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
-    refine ContDiff.contMDiff ?_
-    exact isBoundedBilinearMap_apply.contDiff
+    exact isBoundedBilinearMap_apply.contDiff.contMDiff
 
 /-- The general linear group `(E →L[𝕜] E)ˣ` on `E` acts smoothly on `E`. -/
 example [CompleteSpace E] (n : WithTop ℕ∞) :

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -5,13 +5,16 @@ Authors: Ben Eltschig
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Instances.UnitsOfNormedAlgebra
+public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
 
 /-!
 # Cⁿ monoid actions
 In this file we define Cⁿ actions on manifolds: we say `ContMDiffSMul I I' n G M` if `G` acts
 multiplicatively on `M` and the action map `fun p : G × M ↦ p.1 • p.2` is Cⁿ. We also provide API
 for additive actions using `@[to_additive]`.
+
+We also provide `ContMDiffSMul` instances for scalar multiplication in normed spaces and for
+the action of the monoid `E →L[𝕜] E` of continuous linear maps on any normed space `E`.
 -/
 
 open scoped Manifold ContDiff
@@ -141,13 +144,6 @@ theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : ℕ∞ω
   let _ : MulAction G' M := MulAction.compHom _ f
   exact ⟨(hf.comp contMDiff_fst).smul contMDiff_snd⟩
 
-/-- If a complete normed ring acts continuously differentiably on a manifold `M`, its submanifold
-of units does as well. -/
-instance Units.contMDiffSMul {R : Type*} [NormedRing R] [CompleteSpace R] [NormedAlgebra 𝕜 R]
-    [MulAction R M] {n : ℕ∞ω} [ContMDiffSMul 𝓘(𝕜, R) I' n R M] :
-    ContMDiffSMul 𝓘(𝕜, R) I' n Rˣ M :=
-  MulAction.contMDiffSMul_compHom (f := coeHom R) contMDiff_val
-
 /-- The scalar multiplication `𝕜 × E → E` of any normed vector space `E` over `𝕜` is smooth. -/
 instance {n : ℕ∞ω} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
   contMDiff_smul := by
@@ -163,8 +159,3 @@ instance [CompleteSpace E] {n : ℕ∞ω} :
         (@id ((E →L[𝕜] E) × E)) := by
       rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]; exact contMDiff_id
     exact isBoundedBilinearMap_apply.contDiff.contMDiff.comp h
-
-/-- The general linear group `(E →L[𝕜] E)ˣ` on `E` acts smoothly on `E`. -/
-example [CompleteSpace E] (n : ℕ∞ω) :
-    ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E)ˣ E :=
-  inferInstance

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -6,20 +6,24 @@ Authors: Ben Eltschig
 module
 
 public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
+public import Mathlib.Geometry.Manifold.Notation
 
 /-!
 # Cⁿ monoid actions
+
 In this file we define Cⁿ actions on manifolds: we say `ContMDiffSMul I I' n G M` if `G` acts
 multiplicatively on `M` and the action map `fun p : G × M ↦ p.1 • p.2` is Cⁿ. We also provide API
 for additive actions using `@[to_additive]`.
 
 We also provide `ContMDiffSMul` instances for scalar multiplication in normed spaces and for
 the action of the monoid `E →L[𝕜] E` of continuous linear maps on any normed space `E`.
+
+Unlike for continuous actions, we do not have a class `ContMDiffConstSMul` yet.
 -/
 
 open scoped Manifold ContDiff
 
-@[expose] public section
+public section
 
 /-- Basic typeclass stating that the additive action of `G` on `M` has smoothness degree `n`.
 Unlike with `ContMDiffAdd`, we do not extend `IsManifold` because `ContMDiffVAdd` contains more
@@ -34,7 +38,7 @@ class ContMDiffVAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [T
     (I' : ModelWithCorners 𝕜 E' H') (n : ℕ∞ω)
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
     (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [VAdd G M] : Prop where
-  contMDiff_vadd : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 +ᵥ p.2
+  contMDiff_vadd : CMDiff n fun p : G × M ↦ p.1 +ᵥ p.2
 
 /-- Basic typeclass stating that the action of `G` on `M` has smoothness degree `n`.
 Unlike with `ContMDiffMul`, we do not extend `IsManifold` because `ContMDiffSMul` contains more
@@ -50,7 +54,7 @@ class ContMDiffSMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [T
     (I' : ModelWithCorners 𝕜 E' H') (n : ℕ∞ω)
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
     (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [SMul G M] : Prop where
-  contMDiff_smul : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 • p.2
+  contMDiff_smul : CMDiff n fun p : G × M ↦ p.1 • p.2
 
 export ContMDiffVAdd (contMDiff_vadd)
 
@@ -87,7 +91,8 @@ instance [SMul G M] [ContMDiffSMul I I' 2 G M] : ContMDiffSMul I I' 1 G M :=
   .of_le one_le_two
 
 /-- If an action is Cⁿ for some `n`, it is also continuous. This has to be a theorem instead of an
-instance for technical reasons. -/
+instance because `ContMDiffSMul` depends on parameters `I`, `I'` and `n` that `ContinuousSMul`
+doesn't. -/
 @[to_additive]
 lemma ContMDiffSMul.continuousSMul [SMul G M] (n : ℕ∞ω) [ContMDiffSMul I I' n G M] :
     ContinuousSMul G M :=
@@ -99,22 +104,22 @@ variable [SMul G M] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
   {f : N → G} {g : N → M} {s : Set N} {x : N}
 
 @[to_additive]
-theorem ContMDiffWithinAt.smul (hf : ContMDiffWithinAt I'' I n f s x)
-    (hg : ContMDiffWithinAt I'' I' n g s x) : ContMDiffWithinAt I'' I' n (f • g) s x :=
+theorem ContMDiffWithinAt.smul (hf : CMDiffAt[s] n f x)
+    (hg : CMDiffAt[s] n g x) : CMDiffAt[s] n (f • g) x :=
   (contMDiff_smul (I := I) (I' := I')).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
 
 @[to_additive]
-nonrec theorem ContMDiffAt.smul (hf : ContMDiffAt I'' I n f x) (hg : ContMDiffAt I'' I' n g x) :
-    ContMDiffAt I'' I' n (f • g) x :=
+nonrec theorem ContMDiffAt.smul (hf : CMDiffAt n f x) (hg : CMDiffAt n g x) :
+    CMDiffAt n (f • g) x :=
   hf.smul hg
 
 @[to_additive]
-theorem ContMDiffOn.smul (hf : ContMDiffOn I'' I n f s) (hg : ContMDiffOn I'' I' n g s) :
-    ContMDiffOn I'' I' n (f • g) s := fun x hx => (hf x hx).smul (hg x hx)
+theorem ContMDiffOn.smul (hf : CMDiff[s] n f) (hg : CMDiff[s] n g) :
+    CMDiff[s] n (f • g) := fun x hx => (hf x hx).smul (hg x hx)
 
 @[to_additive]
-theorem ContMDiff.smul (hf : ContMDiff I'' I n f) (hg : ContMDiff I'' I' n g) :
-    ContMDiff I'' I' n (f • g) := fun x => (hf x).smul (hg x)
+theorem ContMDiff.smul (hf : CMDiff n f) (hg : CMDiff n g) :
+    CMDiff n (f • g) := fun x => (hf x).smul (hg x)
 
 end
 
@@ -130,7 +135,7 @@ lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpa
     [Monoid G'] [SMul G G'] [MulAction G' M] [SMul G M] [IsScalarTower G G' M] {n : ℕ∞ω}
     [ContMDiffSMul I I'' n G G'] [ContMDiffSMul I'' I' n G' M] : ContMDiffSMul I I' n G M where
   contMDiff_smul := by
-    suffices ContMDiff (I.prod I') I' n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
+    suffices CMDiff n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
     exact (contMDiff_fst.smul contMDiff_const).smul (I := I'') contMDiff_snd
 
 /-- If an action is continuously differentiable, then composing this action with a continuously
@@ -138,7 +143,7 @@ differentiable homomorphism gives again a continuous action. -/
 @[to_additive]
 theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : ℕ∞ω}
     [ContMDiffSMul I I' n G M] {G' : Type*} [TopologicalSpace G'] [ChartedSpace H'' G'] [Monoid G']
-    {f : G' →* G} (hf : ContMDiff I'' I n f) :
+    {f : G' →* G} (hf : CMDiff n f) :
     letI : MulAction G' M := MulAction.compHom _ f
     ContMDiffSMul I'' I' n G' M := by
   let _ : MulAction G' M := MulAction.compHom _ f

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -149,16 +149,6 @@ instance Units.contMDiffSMul {R : Type*} [NormedRing R] [CompleteSpace R] [Norme
     ContMDiffSMul 𝓘(𝕜, R) I' n Rˣ M :=
   MulAction.contMDiffSMul_compHom (f := coeHom R) contMDiff_val
 
-@[simps!]
-def Diffeomorph.modelWithCornersSelfProdComparison {n : ℕ∞ω} :
-    Diffeomorph 𝓘(𝕜, E × E') (𝓘(𝕜, E).prod 𝓘(𝕜, E')) (E × E') (E × E') n where
-  toEquiv := .refl _
-  contMDiff_toFun :=
-    (ContinuousLinearMap.fst 𝕜 E E').contMDiff.prodMk (ContinuousLinearMap.snd 𝕜 E E').contMDiff
-  contMDiff_invFun := by
-    rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]
-    exact contMDiff_id
-
 /-- The scalar multiplication `𝕜 × E → E` of any normed vector space `E` over `𝕜` is smooth. -/
 instance {n : ℕ∞ω} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
   contMDiff_smul := by

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 Ben Eltschig. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ben Eltschig
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Diffeomorph
+public import Mathlib.Geometry.Manifold.Instances.UnitsOfNormedAlgebra
+
+/-!
+# Cⁿ monoid actions
+In this file we define Cⁿ actions on manifolds: we say `ContMDiffSMul I I' n G M` if `G` acts
+multiplicatively on `M` and the action map `fun p : G × M ↦ p.1 • p.2` is Cⁿ. We also provide API
+for additive actions using `@[to_additive]`.
+-/
+
+open scoped Manifold ContDiff
+
+@[expose] public section
+
+/-- Basic typeclass stating that the additive action of `G` on `M` has smoothness degree `n`.
+Unlike with `ContMDiffAdd`, we do not extend `IsManifold` because `ContMDiffVAdd` contains more
+explicit arguments than `IsManifold` and so `ContMDiffVAdd.toIsManifold` could not be an instance
+anyway: this means that in order for `ContMDiffVAdd` to be meaningful, smoothness of `G` and `M` has
+to be required separately. For example, to state that `G` is a Cⁿ additive Lie group with a Cⁿ
+additive action on a Cⁿ manifold `M`, one can use the typeclasses
+`[LieAddGroup I n G] [IsManifold I' n M] [ContMDiffVAdd I I' n G M]`. -/
+class ContMDiffVAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H)
+    {H' : Type*} [TopologicalSpace H'] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+    (I' : ModelWithCorners 𝕜 E' H') (n : WithTop ℕ∞)
+    (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
+    (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [VAdd G M] : Prop where
+  contMDiff_vadd : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 +ᵥ p.2
+
+/-- Basic typeclass stating that the action of `G` on `M` has smoothness degree `n`.
+Unlike with `ContMDiffMul`, we do not extend `IsManifold` because `ContMDiffSMul` contains more
+explicit arguments than `IsManifold` and so `ContMDiffSMul.toIsManifold` could not be an instance
+anyway: this means that in order for `ContMDiffSMul` to be meaningful, smoothness of `G` and `M` has
+to be required separately. For example, to state that `G` is a Cⁿ Lie group with a Cⁿ action on a Cⁿ
+manifold `M`, one can use the typeclasses
+`[LieGroup I n G] [IsManifold I' n M] [ContMDiffSMul I I' n G M]`. -/
+@[to_additive]
+class ContMDiffSMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H)
+    {H' : Type*} [TopologicalSpace H'] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+    (I' : ModelWithCorners 𝕜 E' H') (n : WithTop ℕ∞)
+    (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
+    (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [SMul G M] : Prop where
+  contMDiff_smul : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 • p.2
+
+export ContMDiffVAdd (contMDiff_vadd)
+
+export ContMDiffSMul (contMDiff_smul)
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {I : ModelWithCorners 𝕜 E H}
+  {H' : Type*} [TopologicalSpace H'] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {I' : ModelWithCorners 𝕜 E' H'} {H'' : Type*} [TopologicalSpace H''] {E'' : Type*}
+  [NormedAddCommGroup E''] [NormedSpace 𝕜 E''] {I'' : ModelWithCorners 𝕜 E'' H''}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G]
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H' M]
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H'' N]
+
+@[to_additive]
+protected theorem ContMDiffSMul.of_le [SMul G M] {n m : WithTop ℕ∞} (h : n ≤ m)
+    [ContMDiffSMul I I' m G M] : ContMDiffSMul I I' n G M := ⟨contMDiff_smul.of_le h⟩
+
+@[to_additive]
+instance [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' ∞ G M] [ENat.LEInfty n] :
+    ContMDiffSMul I I' n G M :=
+  .of_le ENat.LEInfty.out
+
+@[to_additive]
+instance [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' ω G M] : ContMDiffSMul I I' n G M :=
+  .of_le le_top
+
+@[to_additive]
+instance [SMul G M] [ContinuousSMul G M] : ContMDiffSMul I I' 0 G M :=
+  ⟨contMDiff_zero_iff.2 continuous_smul⟩
+
+@[to_additive]
+instance [SMul G M] [ContMDiffSMul I I' 2 G M] : ContMDiffSMul I I' 1 G M :=
+  .of_le one_le_two
+
+/-- If an action is Cⁿ for some `n`, it is also continuous. This has to be a theorem instead of an
+instance for technical reasons. -/
+@[to_additive]
+lemma ContMDiffSMul.continuousSMul [SMul G M] (n : WithTop ℕ∞) [ContMDiffSMul I I' n G M] :
+    ContinuousSMul G M :=
+  ⟨(contMDiff_smul (I := I) (I' := I') (n := n)).continuous⟩
+
+section
+
+variable [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
+  {f : N → G} {g : N → M} {s : Set N} {x : N}
+
+@[to_additive]
+theorem ContMDiffWithinAt.smul' (hf : ContMDiffWithinAt I'' I n f s x)
+    (hg : ContMDiffWithinAt I'' I' n g s x) : ContMDiffWithinAt I'' I' n (f • g) s x :=
+  (contMDiff_smul (I := I) (I' := I')).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
+
+@[to_additive]
+nonrec theorem ContMDiffAt.smul' (hf : ContMDiffAt I'' I n f x) (hg : ContMDiffAt I'' I' n g x) :
+    ContMDiffAt I'' I' n (f • g) x :=
+  hf.smul' hg
+
+@[to_additive]
+theorem ContMDiffOn.smul' (hf : ContMDiffOn I'' I n f s) (hg : ContMDiffOn I'' I' n g s) :
+    ContMDiffOn I'' I' n (f • g) s := fun x hx => (hf x hx).smul' (hg x hx)
+
+@[to_additive]
+theorem ContMDiff.smul' (hf : ContMDiff I'' I n f) (hg : ContMDiff I'' I' n g) :
+    ContMDiff I'' I' n (f • g) := fun x => (hf x).smul' (hg x)
+
+end
+
+@[to_additive prod]
+instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
+    [ContMDiffSMul I I'' n G N] : ContMDiffSMul I (I'.prod I'') n G (M × N) where
+  contMDiff_smul := (contMDiff_fst.smul' <| contMDiff_fst.comp contMDiff_snd).prodMk <|
+      contMDiff_fst.smul' <| contMDiff_snd.comp contMDiff_snd
+
+/-- If `G` acts continuously differentiably on `G'` and `G'` acts continuously differentiably on
+`M`, then `G` acts continuously differentiably on `M`. -/
+lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpace H'' G']
+    [Monoid G'] [SMul G G'] [MulAction G' M] [SMul G M] [IsScalarTower G G' M] {n : WithTop ℕ∞}
+    [ContMDiffSMul I I'' n G G'] [ContMDiffSMul I'' I' n G' M] : ContMDiffSMul I I' n G M where
+  contMDiff_smul := by
+    suffices ContMDiff (I.prod I') I' n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
+    exact (contMDiff_fst.smul' contMDiff_const).smul' (I := I'') contMDiff_snd
+
+/-- If an action is continuously differentiable, then composing this action with a continuously
+differentiable homomorphism gives again a continuous action. -/
+@[to_additive]
+theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : WithTop ℕ∞}
+    [ContMDiffSMul I I' n G M] {G' : Type*} [TopologicalSpace G'] [ChartedSpace H'' G'] [Monoid G']
+    {f : G' →* G} (hf : ContMDiff I'' I n f) :
+    letI : MulAction G' M := MulAction.compHom _ f
+    ContMDiffSMul I'' I' n G' M := by
+  let _ : MulAction G' M := MulAction.compHom _ f
+  exact ⟨(hf.comp contMDiff_fst).smul' contMDiff_snd⟩
+
+/-- If a complete normed ring acts continuously differentiably on a manifold `M`, its submanifold
+of units does as well. -/
+instance Units.contMDiffSMul {R : Type*} [NormedRing R] [CompleteSpace R] [NormedAlgebra 𝕜 R]
+    [MulAction R M] {n : WithTop ℕ∞} [ContMDiffSMul 𝓘(𝕜, R) I' n R M] :
+    ContMDiffSMul 𝓘(𝕜, R) I' n Rˣ M :=
+  MulAction.contMDiffSMul_compHom (f := coeHom R) contMDiff_val
+
+@[simps!]
+def Diffeomorph.modelWithCornersSelfProdComparison {n : WithTop ℕ∞} :
+    Diffeomorph 𝓘(𝕜, E × E') (𝓘(𝕜, E).prod 𝓘(𝕜, E')) (E × E') (E × E') n where
+  toEquiv := .refl _
+  contMDiff_toFun :=
+    (ContinuousLinearMap.fst 𝕜 E E').contMDiff.prodMk (ContinuousLinearMap.snd 𝕜 E E').contMDiff
+  contMDiff_invFun := by
+    rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]
+    exact contMDiff_id
+
+/-- The monoid `E →L[𝕜] E` of continuous linear endomorphisms of `E` acts smoothly on `E`. -/
+instance [CompleteSpace E] {n : WithTop ℕ∞} :
+    ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E) E where
+  contMDiff_smul := by
+    rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
+    refine ContDiff.contMDiff ?_
+    exact isBoundedBilinearMap_apply.contDiff
+
+/-- The general linear group `(E →L[𝕜] E)ˣ` on `E` acts smoothly on `E`. -/
+example [CompleteSpace E] (n : WithTop ℕ∞) :
+    ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E)ˣ E :=
+  inferInstance

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -29,7 +29,7 @@ additive action on a Cⁿ manifold `M`, one can use the typeclasses
 class ContMDiffVAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H)
     {H' : Type*} [TopologicalSpace H'] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
-    (I' : ModelWithCorners 𝕜 E' H') (n : WithTop ℕ∞)
+    (I' : ModelWithCorners 𝕜 E' H') (n : ℕ∞ω)
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
     (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [VAdd G M] : Prop where
   contMDiff_vadd : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 +ᵥ p.2
@@ -45,7 +45,7 @@ manifold `M`, one can use the typeclasses
 class ContMDiffSMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H)
     {H' : Type*} [TopologicalSpace H'] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
-    (I' : ModelWithCorners 𝕜 E' H') (n : WithTop ℕ∞)
+    (I' : ModelWithCorners 𝕜 E' H') (n : ℕ∞ω)
     (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
     (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [SMul G M] : Prop where
   contMDiff_smul : ContMDiff (I.prod I') I' n fun p : G × M ↦ p.1 • p.2
@@ -64,16 +64,16 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
   {N : Type*} [TopologicalSpace N] [ChartedSpace H'' N]
 
 @[to_additive]
-protected theorem ContMDiffSMul.of_le [SMul G M] {n m : WithTop ℕ∞} (h : n ≤ m)
+protected theorem ContMDiffSMul.of_le [SMul G M] {n m : ℕ∞ω} (h : n ≤ m)
     [ContMDiffSMul I I' m G M] : ContMDiffSMul I I' n G M := ⟨contMDiff_smul.of_le h⟩
 
 @[to_additive]
-instance [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' ∞ G M] [ENat.LEInfty n] :
+instance [SMul G M] {n : ℕ∞ω} [ContMDiffSMul I I' ∞ G M] [ENat.LEInfty n] :
     ContMDiffSMul I I' n G M :=
   .of_le ENat.LEInfty.out
 
 @[to_additive]
-instance [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' ω G M] : ContMDiffSMul I I' n G M :=
+instance [SMul G M] {n : ℕ∞ω} [ContMDiffSMul I I' ω G M] : ContMDiffSMul I I' n G M :=
   .of_le le_top
 
 @[to_additive]
@@ -87,13 +87,13 @@ instance [SMul G M] [ContMDiffSMul I I' 2 G M] : ContMDiffSMul I I' 1 G M :=
 /-- If an action is Cⁿ for some `n`, it is also continuous. This has to be a theorem instead of an
 instance for technical reasons. -/
 @[to_additive]
-lemma ContMDiffSMul.continuousSMul [SMul G M] (n : WithTop ℕ∞) [ContMDiffSMul I I' n G M] :
+lemma ContMDiffSMul.continuousSMul [SMul G M] (n : ℕ∞ω) [ContMDiffSMul I I' n G M] :
     ContinuousSMul G M :=
   ⟨(contMDiff_smul (I := I) (I' := I') (n := n)).continuous⟩
 
 section
 
-variable [SMul G M] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
+variable [SMul G M] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
   {f : N → G} {g : N → M} {s : Set N} {x : N}
 
 @[to_additive]
@@ -117,7 +117,7 @@ theorem ContMDiff.smul (hf : ContMDiff I'' I n f) (hg : ContMDiff I'' I' n g) :
 end
 
 @[to_additive prod]
-instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : WithTop ℕ∞} [ContMDiffSMul I I' n G M]
+instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
     [ContMDiffSMul I I'' n G N] : ContMDiffSMul I (I'.prod I'') n G (M × N) where
   contMDiff_smul := (contMDiff_fst.smul <| contMDiff_fst.comp contMDiff_snd).prodMk <|
       contMDiff_fst.smul <| contMDiff_snd.comp contMDiff_snd
@@ -125,7 +125,7 @@ instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : WithTop ℕ∞} [ContMDif
 /-- If `G` acts continuously differentiably on `G'` and `G'` acts continuously differentiably on
 `M`, then `G` acts continuously differentiably on `M`. -/
 lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpace H'' G']
-    [Monoid G'] [SMul G G'] [MulAction G' M] [SMul G M] [IsScalarTower G G' M] {n : WithTop ℕ∞}
+    [Monoid G'] [SMul G G'] [MulAction G' M] [SMul G M] [IsScalarTower G G' M] {n : ℕ∞ω}
     [ContMDiffSMul I I'' n G G'] [ContMDiffSMul I'' I' n G' M] : ContMDiffSMul I I' n G M where
   contMDiff_smul := by
     suffices ContMDiff (I.prod I') I' n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
@@ -134,7 +134,7 @@ lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpa
 /-- If an action is continuously differentiable, then composing this action with a continuously
 differentiable homomorphism gives again a continuous action. -/
 @[to_additive]
-theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : WithTop ℕ∞}
+theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : ℕ∞ω}
     [ContMDiffSMul I I' n G M] {G' : Type*} [TopologicalSpace G'] [ChartedSpace H'' G'] [Monoid G']
     {f : G' →* G} (hf : ContMDiff I'' I n f) :
     letI : MulAction G' M := MulAction.compHom _ f
@@ -145,12 +145,12 @@ theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : WithTop 
 /-- If a complete normed ring acts continuously differentiably on a manifold `M`, its submanifold
 of units does as well. -/
 instance Units.contMDiffSMul {R : Type*} [NormedRing R] [CompleteSpace R] [NormedAlgebra 𝕜 R]
-    [MulAction R M] {n : WithTop ℕ∞} [ContMDiffSMul 𝓘(𝕜, R) I' n R M] :
+    [MulAction R M] {n : ℕ∞ω} [ContMDiffSMul 𝓘(𝕜, R) I' n R M] :
     ContMDiffSMul 𝓘(𝕜, R) I' n Rˣ M :=
   MulAction.contMDiffSMul_compHom (f := coeHom R) contMDiff_val
 
 @[simps!]
-def Diffeomorph.modelWithCornersSelfProdComparison {n : WithTop ℕ∞} :
+def Diffeomorph.modelWithCornersSelfProdComparison {n : ℕ∞ω} :
     Diffeomorph 𝓘(𝕜, E × E') (𝓘(𝕜, E).prod 𝓘(𝕜, E')) (E × E') (E × E') n where
   toEquiv := .refl _
   contMDiff_toFun :=
@@ -160,19 +160,19 @@ def Diffeomorph.modelWithCornersSelfProdComparison {n : WithTop ℕ∞} :
     exact contMDiff_id
 
 /-- The scalar multiplication `𝕜 × E → E` of any normed vector space `E` over `𝕜` is smooth. -/
-instance {n : WithTop ℕ∞} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
+instance {n : ℕ∞ω} : ContMDiffSMul 𝓘(𝕜) 𝓘(𝕜, E) n 𝕜 E where
   contMDiff_smul := by
     rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
     exact contDiff_smul.contMDiff
 
 /-- The monoid `E →L[𝕜] E` of continuous linear endomorphisms of `E` acts smoothly on `E`. -/
-instance [CompleteSpace E] {n : WithTop ℕ∞} :
+instance [CompleteSpace E] {n : ℕ∞ω} :
     ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E) E where
   contMDiff_smul := by
     rw [← Diffeomorph.modelWithCornersSelfProdComparison.contMDiff_comp_diffeomorph_iff le_rfl]
     exact isBoundedBilinearMap_apply.contDiff.contMDiff
 
 /-- The general linear group `(E →L[𝕜] E)ˣ` on `E` acts smoothly on `E`. -/
-example [CompleteSpace E] (n : WithTop ℕ∞) :
+example [CompleteSpace E] (n : ℕ∞ω) :
     ContMDiffSMul 𝓘(𝕜, E →L[𝕜] E) 𝓘(𝕜, E) n (E →L[𝕜] E)ˣ E :=
   inferInstance

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -5,8 +5,7 @@ Authors: Ben Eltschig
 -/
 module
 
-public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
-public import Mathlib.Geometry.Manifold.Notation
+public import Mathlib.Geometry.Manifold.Algebra.Monoid
 
 /-!
 # Cⁿ monoid actions
@@ -18,6 +17,11 @@ for additive actions using `@[to_additive]`.
 We also provide `ContMDiffSMul` instances for scalar multiplication in normed spaces and for
 the action of the monoid `E →L[𝕜] E` of continuous linear maps on any normed space `E`.
 
+See also:
+* `ContMDiffMul I n G` for continuous differentiability of multiplication `G × G → G` in a single
+  type `G`,
+* `ContinuousSMul G M` for continuity of an action `G × M → M`.
+
 Unlike for continuous actions, we do not have a class `ContMDiffConstSMul` yet.
 -/
 
@@ -25,11 +29,12 @@ open scoped Manifold ContDiff
 
 public section
 
-/-- Basic typeclass stating that the additive action of `G` on `M` has smoothness degree `n`.
-Unlike with `ContMDiffAdd`, we do not extend `IsManifold` because `ContMDiffVAdd` contains more
+/-- Basic typeclass stating that the additive action of `G` on `M` is Cⁿ as a function `G × M → M`.
+Unlike with `ContMDiffAdd` (the class stating that addition `G × G → G` within a single type `G` is
+Cⁿ), we do not extend `IsManifold` because `ContMDiffVAdd` contains more
 explicit arguments than `IsManifold` and so `ContMDiffVAdd.toIsManifold` could not be an instance
-anyway: this means that in order for `ContMDiffVAdd` to be meaningful, smoothness of `G` and `M` has
-to be required separately. For example, to state that `G` is a Cⁿ additive Lie group with a Cⁿ
+anyway: this means that in order for `ContMDiffVAdd` to be meaningful, smoothness of `G` and `M`
+have to be required separately. For example, to state that `G` is a Cⁿ additive Lie group with a Cⁿ
 additive action on a Cⁿ manifold `M`, one can use the typeclasses
 `[LieAddGroup I n G] [IsManifold I' n M] [ContMDiffVAdd I I' n G M]`. -/
 class ContMDiffVAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
@@ -40,12 +45,13 @@ class ContMDiffVAdd {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [T
     (M : Type*) [TopologicalSpace M] [ChartedSpace H' M] [VAdd G M] : Prop where
   contMDiff_vadd : CMDiff n fun p : G × M ↦ p.1 +ᵥ p.2
 
-/-- Basic typeclass stating that the action of `G` on `M` has smoothness degree `n`.
-Unlike with `ContMDiffMul`, we do not extend `IsManifold` because `ContMDiffSMul` contains more
+/-- Basic typeclass stating that the action of `G` on `M` is Cⁿ as a function `G × M → M`.
+Unlike with `ContMDiffMul` (the class stating that multiplication `G × G → G` within a single type
+`G` is Cⁿ), we do not extend `IsManifold` because `ContMDiffSMul` contains more
 explicit arguments than `IsManifold` and so `ContMDiffSMul.toIsManifold` could not be an instance
-anyway: this means that in order for `ContMDiffSMul` to be meaningful, smoothness of `G` and `M` has
-to be required separately. For example, to state that `G` is a Cⁿ Lie group with a Cⁿ action on a Cⁿ
-manifold `M`, one can use the typeclasses
+anyway: this means that in order for `ContMDiffSMul` to be meaningful, smoothness of `G` and `M`
+have to be required separately. For example, to state that `G` is a Cⁿ Lie group with a Cⁿ action on
+a Cⁿ manifold `M`, one can use the typeclasses
 `[LieGroup I n G] [IsManifold I' n M] [ContMDiffSMul I I' n G M]`. -/
 @[to_additive]
 class ContMDiffSMul {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
@@ -98,14 +104,20 @@ lemma ContMDiffSMul.continuousSMul [SMul G M] (n : ℕ∞ω) [ContMDiffSMul I I'
     ContinuousSMul G M :=
   ⟨(contMDiff_smul (I := I) (I' := I') (n := n)).continuous⟩
 
+/-- For any `G` in which multiplication is Cⁿ, the action of `G` on itself via left multiplication
+is Cⁿ too. -/
+instance ContMDiffMul.contMDiffSMul [Mul G] {n : ℕ∞ω} [ContMDiffMul I n G] :
+    ContMDiffSMul I I n G G where
+  contMDiff_smul := contMDiff_mul
+
 section
 
 variable [SMul G M] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
   {f : N → G} {g : N → M} {s : Set N} {x : N}
 
 @[to_additive]
-theorem ContMDiffWithinAt.smul (hf : CMDiffAt[s] n f x)
-    (hg : CMDiffAt[s] n g x) : CMDiffAt[s] n (f • g) x :=
+theorem ContMDiffWithinAt.smul (hf : CMDiffAt[s] n f x) (hg : CMDiffAt[s] n g x) :
+    CMDiffAt[s] n (f • g) x :=
   (contMDiff_smul (I := I) (I' := I')).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
 
 @[to_additive]
@@ -124,7 +136,7 @@ theorem ContMDiff.smul (hf : CMDiff n f) (hg : CMDiff n g) :
 end
 
 @[to_additive prod]
-instance ContMDiffSMul.prod [SMul G M] [SMul G N] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
+instance Prod.contMDiffSMul [SMul G M] [SMul G N] {n : ℕ∞ω} [ContMDiffSMul I I' n G M]
     [ContMDiffSMul I I'' n G N] : ContMDiffSMul I (I'.prod I'') n G (M × N) where
   contMDiff_smul := (contMDiff_fst.smul <| contMDiff_fst.comp contMDiff_snd).prodMk <|
       contMDiff_fst.smul <| contMDiff_snd.comp contMDiff_snd
@@ -138,8 +150,8 @@ lemma IsScalarTower.contMDiffSMul (G' : Type*) [TopologicalSpace G'] [ChartedSpa
     suffices CMDiff n (fun p : G × M ↦ (p.1 • (1 : G')) • p.2) by simpa
     exact (contMDiff_fst.smul contMDiff_const).smul (I := I'') contMDiff_snd
 
-/-- If an action is continuously differentiable, then composing this action with a continuously
-differentiable homomorphism gives again a continuous action. -/
+/-- If an action is continuously differentiable, then post-composing this action with a continuously
+differentiable homomorphism gives again a continuously differentiable action. -/
 @[to_additive]
 theorem MulAction.contMDiffSMul_compHom [Monoid G] [MulAction G M] {n : ℕ∞ω}
     [ContMDiffSMul I I' n G M] {G' : Type*} [TopologicalSpace G'] [ChartedSpace H'' G'] [Monoid G']

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -10,9 +10,9 @@ public import Mathlib.Geometry.Manifold.Algebra.Monoid
 /-!
 # Cⁿ monoid actions
 
-In this file we define Cⁿ actions on manifolds: we say `ContMDiffSMul I I' n G M` if `G` acts
-multiplicatively on `M` and the action map `fun p : G × M ↦ p.1 • p.2` is Cⁿ. We also provide API
-for additive actions using `@[to_additive]`.
+In this file we define Cⁿ actions (e.g. by Lie groups or monoids) on manifolds: we say
+`ContMDiffSMul I I' n G M` if `G` acts multiplicatively on `M` and the action map
+`fun p : G × M ↦ p.1 • p.2` is Cⁿ. We also provide API for additive actions using `@[to_additive]`.
 
 We also provide `ContMDiffSMul` instances for scalar multiplication in normed spaces and for
 the action of the monoid `E →L[𝕜] E` of continuous linear maps on any normed space `E`.

--- a/Mathlib/Geometry/Manifold/Algebra/SMul.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SMul.lean
@@ -22,7 +22,11 @@ See also:
   type `G`,
 * `ContinuousSMul G M` for continuity of an action `G × M → M`.
 
-Unlike for continuous actions, we do not have a class `ContMDiffConstSMul` yet.
+Unlike for continuous actions, we do not currently have a class `ContMDiffConstSMul`. If there are
+interesting examples satisfying `ContMDiffConstSMul` but not `ContMDiffSMul`, this can be added
+later. (Note that such examples may be harder to find: in fact, a continuous action of a
+Lie group `G` on a finite-dimensional manifold `M` is `C^n` provided it is `C^n` in the
+second variable.)
 -/
 
 open scoped Manifold ContDiff

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -5,6 +5,7 @@ Authors: Nicolò Cavalleri
 -/
 module
 
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.Algebra.Structures
 
 /-!
@@ -235,7 +236,7 @@ field `𝕜` inherit a vector space structure.
 
 instance instSMul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] :
     SMul 𝕜 C^n⟮I, N; 𝓘(𝕜, V), V⟯ :=
-  ⟨fun r f => ⟨r • ⇑f, contMDiff_const.smul f.contMDiff⟩⟩
+  ⟨fun r f => ⟨r • ⇑f, contMDiff_const.smul (I := 𝓘(𝕜, 𝕜)) f.contMDiff⟩⟩
 
 @[simp]
 theorem coe_smul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] (r : 𝕜)
@@ -282,7 +283,7 @@ def C : 𝕜 →+* C^n⟮I, N; 𝓘(𝕜, A), A⟯ where
   map_add' c₁ c₂ := by ext; exact (algebraMap 𝕜 A).map_add _ _
 
 instance algebra : Algebra 𝕜 C^n⟮I, N; 𝓘(𝕜, A), A⟯ where
-  smul := fun r f => ⟨r • f, contMDiff_const.smul f.contMDiff⟩
+  smul := fun r f => ⟨r • f, contMDiff_const.smul (I := 𝓘(𝕜, 𝕜)) f.contMDiff⟩
   algebraMap := ContMDiffMap.C
   commutes' := fun c f => by ext x; exact Algebra.commutes' _ _
   smul_def' := fun c f => by ext x; exact Algebra.smul_def' _ _

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -236,7 +236,7 @@ field `𝕜` inherit a vector space structure.
 
 instance instSMul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] :
     SMul 𝕜 C^n⟮I, N; 𝓘(𝕜, V), V⟯ :=
-  ⟨fun r f => ⟨r • ⇑f, contMDiff_const.smul (I := 𝓘(𝕜, 𝕜)) f.contMDiff⟩⟩
+  ⟨fun r f ↦ ⟨r • ⇑f, contMDiff_const.smul (I := 𝓘(𝕜)) f.contMDiff⟩⟩
 
 @[simp]
 theorem coe_smul {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] (r : 𝕜)
@@ -283,7 +283,7 @@ def C : 𝕜 →+* C^n⟮I, N; 𝓘(𝕜, A), A⟯ where
   map_add' c₁ c₂ := by ext; exact (algebraMap 𝕜 A).map_add _ _
 
 instance algebra : Algebra 𝕜 C^n⟮I, N; 𝓘(𝕜, A), A⟯ where
-  smul := fun r f => ⟨r • f, contMDiff_const.smul (I := 𝓘(𝕜, 𝕜)) f.contMDiff⟩
+  smul := fun r f ↦ ⟨r • f, contMDiff_const.smul (I := 𝓘(𝕜)) f.contMDiff⟩
   algebraMap := ContMDiffMap.C
   commutes' := fun c f => by ext x; exact Algebra.commutes' _ _
   smul_def' := fun c f => by ext x; exact Algebra.smul_def' _ _

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 module
 
 public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.ContMDiff.Atlas
 public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
 public import Mathlib.Geometry.Manifold.Notation

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -13,7 +13,9 @@ public import Mathlib.Analysis.Normed.Operator.Prod
 * `contMDiff_iff_contDiff`: for functions between vector spaces,
   manifold-smoothness is equivalent to usual smoothness.
 * `ContinuousLinearMap.contMDiff`: continuous linear maps between normed spaces are smooth
-* `smooth_smul`: multiplication by scalars is a smooth operation
+
+Smoothness of addition and scalar multiplication in normed spaces is proven only in later files in
+the form of `AddLieGroup` and `ContMDiffSMul` instances.
 
 -/
 
@@ -259,28 +261,3 @@ theorem ContMDiff.clm_prodMap {g : M → F₁ →L[𝕜] F₃} {f : M → F₂ �
     (hg : ContMDiff I 𝓘(𝕜, F₁ →L[𝕜] F₃) n g) (hf : ContMDiff I 𝓘(𝕜, F₂ →L[𝕜] F₄) n f) :
     ContMDiff I 𝓘(𝕜, F₁ × F₂ →L[𝕜] F₃ × F₄) n fun x => (g x).prodMap (f x) := fun x =>
   (hg x).clm_prodMap (hf x)
-
-/-! ### Smoothness of scalar multiplication -/
-
-variable {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V]
-
-/-- On any vector space, multiplication by a scalar is a smooth operation. -/
-theorem contMDiff_smul : ContMDiff (𝓘(𝕜).prod 𝓘(𝕜, V)) 𝓘(𝕜, V) ⊤ fun p : 𝕜 × V => p.1 • p.2 :=
-  contMDiff_iff.2 ⟨continuous_smul, fun _ _ => contDiff_smul.contDiffOn⟩
-
-theorem ContMDiffWithinAt.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiffWithinAt I 𝓘(𝕜) n f s x)
-    (hg : ContMDiffWithinAt I 𝓘(𝕜, V) n g s x) :
-    ContMDiffWithinAt I 𝓘(𝕜, V) n (fun p => f p • g p) s x :=
-  (contMDiff_smul.of_le le_top).contMDiffAt.comp_contMDiffWithinAt x (hf.prodMk hg)
-
-nonrec theorem ContMDiffAt.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiffAt I 𝓘(𝕜) n f x)
-    (hg : ContMDiffAt I 𝓘(𝕜, V) n g x) : ContMDiffAt I 𝓘(𝕜, V) n (fun p => f p • g p) x :=
-  hf.smul hg
-
-theorem ContMDiffOn.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiffOn I 𝓘(𝕜) n f s)
-    (hg : ContMDiffOn I 𝓘(𝕜, V) n g s) : ContMDiffOn I 𝓘(𝕜, V) n (fun p => f p • g p) s :=
-  fun x hx => (hf x hx).smul (hg x hx)
-
-theorem ContMDiff.smul {f : M → 𝕜} {g : M → V} (hf : ContMDiff I 𝓘(𝕜) n f)
-    (hg : ContMDiff I 𝓘(𝕜, V) n g) : ContMDiff I 𝓘(𝕜, V) n fun p => f p • g p := fun x =>
-  (hf x).smul (hg x)

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -14,7 +14,8 @@ public import Mathlib.Analysis.Normed.Operator.Prod
   manifold-smoothness is equivalent to usual smoothness.
 * `ContinuousLinearMap.contMDiff`: continuous linear maps between normed spaces are smooth
 
-Smoothness of addition and scalar multiplication in normed spaces is proven only in later files in
+Smoothness of addition and scalar multiplication in normed spaces is proven not here but in
+`Mathlib/Geometry/Manifold/Algebra/SMul.lean` and `Mathlib/Geometry/Manifold/Algebra/LieGroup.lean`
 the form of `AddLieGroup` and `ContMDiffSMul` instances.
 
 -/

--- a/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/NormedSpace.lean
@@ -15,8 +15,8 @@ public import Mathlib.Analysis.Normed.Operator.Prod
 * `ContinuousLinearMap.contMDiff`: continuous linear maps between normed spaces are smooth
 
 Smoothness of addition and scalar multiplication in normed spaces is proven not here but in
-`Mathlib/Geometry/Manifold/Algebra/SMul.lean` and `Mathlib/Geometry/Manifold/Algebra/LieGroup.lean`
-the form of `AddLieGroup` and `ContMDiffSMul` instances.
+`Mathlib/Geometry/Manifold/Algebra/LieGroup.lean` and `Mathlib/Geometry/Manifold/Algebra/SMul.lean`
+in the form of `LieAddGroup` and `ContMDiffSMul` instances.
 
 -/
 

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -577,6 +577,21 @@ def prodAssoc : ((M × N) × N') ≃ₘ^n⟮(I.prod J).prod J', I.prod (J.prod J
       (contMDiff_snd.comp contMDiff_snd)
   toEquiv := Equiv.prodAssoc M N N'
 
+/-- The identity diffeomorphism between the product of two normed spaces `E` and `E'` with the
+model `𝓘(𝕜, E × E')` and the same product with the model `𝓘(𝕜, E).prod 𝓘(𝕜, E')`.
+This can be used in combination with `Diffeomorph.contMDiff_comp_diffeomorph_iff` and
+`Diffeomorph.contMDiff_diffeomorph_comp_iff` to prove that a map involving such a product is
+smooth with respect to one model iff it is with respect to the other. -/
+@[simps!]
+def modelWithCornersSelfProdComparison {n : ℕ∞ω} :
+    Diffeomorph 𝓘(𝕜, E × E') (𝓘(𝕜, E).prod 𝓘(𝕜, E')) (E × E') (E × E') n where
+  toEquiv := .refl _
+  contMDiff_toFun :=
+    (ContinuousLinearMap.fst 𝕜 E E').contMDiff.prodMk (ContinuousLinearMap.snd 𝕜 E E').contMDiff
+  contMDiff_invFun := by
+    rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]
+    exact contMDiff_id
+
 end
 
 end Product

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -577,21 +577,6 @@ def prodAssoc : ((M × N) × N') ≃ₘ^n⟮(I.prod J).prod J', I.prod (J.prod J
       (contMDiff_snd.comp contMDiff_snd)
   toEquiv := Equiv.prodAssoc M N N'
 
-/-- The identity diffeomorphism between the product of two normed spaces `E` and `E'` with the
-model `𝓘(𝕜, E × E')` and the same product with the model `𝓘(𝕜, E).prod 𝓘(𝕜, E')`.
-This can be used in combination with `Diffeomorph.contMDiff_comp_diffeomorph_iff` and
-`Diffeomorph.contMDiff_diffeomorph_comp_iff` to prove that a map involving such a product is
-smooth with respect to one model iff it is with respect to the other. -/
-@[simps!]
-def modelWithCornersSelfProdComparison {n : ℕ∞ω} :
-    Diffeomorph 𝓘(𝕜, E × E') (𝓘(𝕜, E).prod 𝓘(𝕜, E')) (E × E') (E × E') n where
-  toEquiv := .refl _
-  contMDiff_toFun :=
-    (ContinuousLinearMap.fst 𝕜 E E').contMDiff.prodMk (ContinuousLinearMap.snd 𝕜 E E').contMDiff
-  contMDiff_invFun := by
-    rw [contMDiff_prod_module_iff, ← contMDiff_prod_iff]
-    exact contMDiff_id
-
 end
 
 end Product

--- a/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
@@ -6,6 +6,7 @@ Authors: Nicolò Cavalleri, Heather Macbeth, Winston Yin
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 
 /-!
 # Units of a normed algebra
@@ -23,6 +24,9 @@ its group of units, the general linear group GL(`𝕜`, `V`), as demonstrated by
 example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] (n : ℕ∞ω) :
     LieGroup 𝓘(𝕜, V →L[𝕜] V) n (V →L[𝕜] V)ˣ := inferInstance
 ```
+
+We also prove that if `R` acts smoothly on a manifold, its group of units does as well;
+in particular, the general linear group `(V →L[𝕜] V)ˣ` is a Lie group acting smoothly on `V`.
 -/
 
 public section
@@ -45,6 +49,8 @@ theorem chartAt_source {a : Rˣ} : (chartAt R a).source = Set.univ :=
   rfl
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [NormedAlgebra 𝕜 R]
+  {H : Type*} [TopologicalSpace H] {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
 instance : IsManifold 𝓘(𝕜, R) n Rˣ :=
   isOpenEmbedding_val.isManifold_singleton
@@ -75,7 +81,19 @@ instance : LieGroup 𝓘(𝕜, R) n Rˣ where
     rw [contMDiffAt_iff_contDiffAt]
     exact contDiffAt_ringInverse _ _
 
+/-- If a complete normed ring `R` acts continuously differentiably on a manifold `M`, its
+submanifold of units does as well. -/
+instance contMDiffSMul [MulAction R M] [ContMDiffSMul 𝓘(𝕜, R) I n R M] :
+    ContMDiffSMul 𝓘(𝕜, R) I n Rˣ M :=
+  MulAction.contMDiffSMul_compHom (f := coeHom R) contMDiff_val
+
+/-- The general linear group `(V →L[𝕜] V)ˣ` of a Banach space `V` is a Lie group. -/
 example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] (n : ℕ∞ω) :
     LieGroup 𝓘(𝕜, V →L[𝕜] V) n (V →L[𝕜] V)ˣ := inferInstance
+
+/-- The general linear group `(V →L[𝕜] V)ˣ` of a Banach space `V` acts smoothly on `V`. -/
+example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] (n : ℕ∞ω) :
+    ContMDiffSMul 𝓘(𝕜, V →L[𝕜] V) 𝓘(𝕜, V) n (V →L[𝕜] V)ˣ V :=
+  inferInstance
 
 end Units

--- a/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/NormedSpace.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 module
 
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
 public import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -5,6 +5,7 @@ Authors: Heather Macbeth, Floris van Doorn, Michael Rothgang
 -/
 module
 
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
 public import Mathlib.Geometry.Manifold.MFDeriv.Basic
 public import Mathlib.Topology.ContinuousMap.Basic


### PR DESCRIPTION
Introduce typeclasses `ContMDiffVAdd` and `ContMDiffSMul` for continuously differentiable actions on manifolds.

As an application, we prove that the general linear group `(V →L[𝕜] V)ˣ` of any Banach space `V` acts smoothly on `V`.

---

- [x] depends on: #38620
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

See also #38527 that adds an analogous `ContDiffSMul` for actions of normed vector spaces.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
