### PR TITLE
[Merged by Bors] - chore: import changes and shake: keep comments required before lake shake

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.Category.Grp.Limits
 public import Mathlib.Algebra.Category.Ring.Basic
 public import Mathlib.Algebra.Ring.Pi
-public import Mathlib.Algebra.Ring.Shrink
+public import Mathlib.Algebra.Ring.Shrink  -- shake: keep (Semiring (Shrink ...)), cf. lean#13417
 public import Mathlib.Algebra.Ring.Subring.Defs
 
 /-!

--- a/Mathlib/Condensed/EffectiveEpi.lean
+++ b/Mathlib/Condensed/EffectiveEpi.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.CategoryTheory.Sites.RegularEpi
 public import Mathlib.Condensed.Epi
 public import Mathlib.Condensed.Functors
-public import Mathlib.Condensed.Limits
+public import Mathlib.Condensed.Limits  -- shake: keep (compHausToCondensed.PreservesEffectiveEpis), cf. lean#13417
 
 /-!
 

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Data.Finset.Lattice.Fold
 public import Mathlib.Data.Finset.Order
-public import Mathlib.Data.Set.Finite.Basic
+public import Mathlib.Data.Set.Finite.Basic  -- shake: keep (IsAtomic α), cf. lean#13417
 public import Mathlib.Data.Set.Finite.Range
 public import Mathlib.Order.Atoms
 

--- a/Mathlib/Data/Real/Hom.lean
+++ b/Mathlib/Data/Real/Hom.lean
@@ -5,7 +5,7 @@ Authors: Alex J. Best
 -/
 module
 
-public import Mathlib.Algebra.Order.Archimedean.Hom
+public import Mathlib.Algebra.Order.Archimedean.Hom  -- shake: keep (Subsingleton (ℝ →+*o ℝ)), cf. lean#13417
 public import Mathlib.Data.Real.Sqrt
 import Mathlib.Algebra.Order.CompleteField
 

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Geometry.Manifold.IsManifold.ExtChartAt
 public import Mathlib.Geometry.Manifold.LocalSourceTargetProperty
-public import Mathlib.Analysis.Normed.Module.Shrink
+public import Mathlib.Analysis.Normed.Module.Shrink  -- shake: keep (NormedAddCommGroup (Shrink ...)), cf. lean#13417
 public import Mathlib.Topology.Algebra.Module.TransferInstance
 
 /-! # Smooth immersions

--- a/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
+++ b/Mathlib/Tactic/Linarith/NNRealPreprocessor.lean
@@ -7,7 +7,7 @@ module
 
 public meta import Mathlib.Tactic.Linarith
 public meta import Mathlib.Tactic.Rify
-public import Mathlib.Data.NNReal.Basic
+public import Mathlib.Data.NNReal.Basic -- shake: keep (tactic dependency)
 
 /-!
 # NNReal linarith preprocessing

--- a/Mathlib/Tactic/Nontriviality/Core.lean
+++ b/Mathlib/Tactic/Nontriviality/Core.lean
@@ -7,6 +7,7 @@ module
 
 public meta import Qq.MetaM
 public import Mathlib.Logic.Nontrivial.Basic -- shake: keep (tactic dependency)
+public import Mathlib.Tactic.Attr.Register -- shake: keep (tactic dependency)
 public meta import Mathlib.Tactic.ToDual
 
 /-! # The `nontriviality` tactic. -/


### PR DESCRIPTION
The first two commits are `shake: keep` / import changes required for tactic dependencies. The third commit 1312ca1922b09a1e87543a19b1e12fca3c64b482 is a number of `shake: keep` required until https://github.com/leanprover/lean4/issues/13417 is fixed.

---

A re-work of #37857