### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/GeneralLinearGroup): polynomial functions on matrices over an infinite field are determined by their values on GL

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4985,6 +4985,7 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.FinTwo
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.MvPolynomial
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
 public import Mathlib.LinearAlgebra.Matrix.Gershgorin
 public import Mathlib.LinearAlgebra.Matrix.Hadamard

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
@@ -6,7 +6,6 @@ Authors: Kim Morrison
 module
 
 public import Mathlib.Algebra.MvPolynomial.Funext
-public import Mathlib.LinearAlgebra.Matrix.MvPolynomial
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 /-!
@@ -35,7 +34,6 @@ theorem eq_of_eval_eq_on_gl {m k : Type*} [Fintype m] [DecidableEq m] [Field k] 
            MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) p =
            MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) q) :
     p = q := by
-  classical
   have hdet_ne : Matrix.det (Matrix.mvPolynomialX m m k) ≠ 0 :=
     Matrix.det_mvPolynomialX_ne_zero m k
   have hprod : (p - q) * Matrix.det (Matrix.mvPolynomialX m m k) = 0 := by
@@ -50,19 +48,11 @@ theorem eq_of_eval_eq_on_gl {m k : Type*} [Fintype m] [DecidableEq m] [Field k] 
       ext i j
       simp [Matrix.mvPolynomialX]
     rw [hdet_eval]
-    by_cases hdet_s :
-        Matrix.det (Matrix.of fun i j : m => s (i, j)) = 0
-    · rw [hdet_s, mul_zero]
-    · have hh := h (Matrix.GeneralLinearGroup.mkOfDetNeZero
-        (Matrix.of fun i j : m => s (i, j)) hdet_s)
-      have hs_eq :
-          (fun ij : m × m =>
-              (Matrix.GeneralLinearGroup.mkOfDetNeZero
-                  (Matrix.of fun i j : m => s (i, j)) hdet_s :
-                Matrix m m k) ij.1 ij.2) = s := by
-        funext ij
-        rfl
-      rw [hs_eq] at hh
+    by_cases hs_det : Matrix.det (Matrix.of fun i j : m => s (i, j)) = 0
+    · rw [hs_det, mul_zero]
+    · have hh : (eval s) p = (eval s) q :=
+        h (Matrix.GeneralLinearGroup.mkOfDetNeZero
+          (Matrix.of fun i j : m => s (i, j)) hs_det)
       rw [hh, sub_self, zero_mul]
   exact sub_eq_zero.mp ((mul_eq_zero.mp hprod).resolve_right hdet_ne)
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+module
+
+public import Mathlib.Algebra.MvPolynomial.Funext
+public import Mathlib.LinearAlgebra.Matrix.MvPolynomial
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# Polynomial identities from evaluation at invertible matrices
+
+We prove `MvPolynomial.eq_of_eval_eq_on_gl`: two polynomials in `MvPolynomial (m × m) k` over an
+infinite field `k` are equal if their evaluations agree at every invertible matrix. The proof
+uses that the set of invertible matrices is Zariski-dense in `Matrix m m k`.
+-/
+
+@[expose] public section
+
+namespace MvPolynomial
+
+/-- Two polynomials in `MvPolynomial (m × m) k` over an infinite field `k` are equal if their
+evaluations agree at every invertible matrix.
+
+The proof considers `(p - q) * det(X)`, where `det(X) := Matrix.det (Matrix.mvPolynomialX m m k)`
+is the generic determinant polynomial. Evaluated at any `s : m × m → k`, this product vanishes:
+if `det (Matrix.of fun i j => s (i, j)) = 0` the determinant factor kills it; otherwise the
+matrix is invertible and the hypothesis applies. By `MvPolynomial.funext` the product is zero,
+and since `det(X) ≠ 0` and `MvPolynomial _ k` is an integral domain, `p = q`. -/
+theorem eq_of_eval_eq_on_gl {m k : Type*} [Fintype m] [DecidableEq m] [Field k] [Infinite k]
+    {p q : MvPolynomial (m × m) k}
+    (h : ∀ g : Matrix.GeneralLinearGroup m k,
+           MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) p =
+           MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) q) :
+    p = q := by
+  classical
+  have hdet_ne : Matrix.det (Matrix.mvPolynomialX m m k) ≠ 0 :=
+    Matrix.det_mvPolynomialX_ne_zero m k
+  have hprod : (p - q) * Matrix.det (Matrix.mvPolynomialX m m k) = 0 := by
+    apply MvPolynomial.funext
+    intro s
+    rw [map_mul, map_sub, map_zero]
+    have hdet_eval :
+        MvPolynomial.eval s (Matrix.det (Matrix.mvPolynomialX m m k)) =
+          Matrix.det (Matrix.of fun i j : m => s (i, j)) := by
+      rw [(MvPolynomial.eval s).map_det]
+      congr 1
+      ext i j
+      simp [Matrix.mvPolynomialX]
+    rw [hdet_eval]
+    by_cases hdet_s :
+        Matrix.det (Matrix.of fun i j : m => s (i, j)) = 0
+    · rw [hdet_s, mul_zero]
+    · have hh := h (Matrix.GeneralLinearGroup.mkOfDetNeZero
+        (Matrix.of fun i j : m => s (i, j)) hdet_s)
+      have hs_eq :
+          (fun ij : m × m =>
+              (Matrix.GeneralLinearGroup.mkOfDetNeZero
+                  (Matrix.of fun i j : m => s (i, j)) hdet_s :
+                Matrix m m k) ij.1 ij.2) = s := by
+        funext ij
+        rfl
+      rw [hs_eq] at hh
+      rw [hh, sub_self, zero_mul]
+  exact sub_eq_zero.mp ((mul_eq_zero.mp hprod).resolve_right hdet_ne)
+
+end MvPolynomial

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean
@@ -34,26 +34,17 @@ theorem eq_of_eval_eq_on_gl {m k : Type*} [Fintype m] [DecidableEq m] [Field k] 
            MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) p =
            MvPolynomial.eval (fun ij : m × m => (g : Matrix m m k) ij.1 ij.2) q) :
     p = q := by
-  have hdet_ne : Matrix.det (Matrix.mvPolynomialX m m k) ≠ 0 :=
-    Matrix.det_mvPolynomialX_ne_zero m k
   have hprod : (p - q) * Matrix.det (Matrix.mvPolynomialX m m k) = 0 := by
     apply MvPolynomial.funext
     intro s
-    rw [map_mul, map_sub, map_zero]
-    have hdet_eval :
-        MvPolynomial.eval s (Matrix.det (Matrix.mvPolynomialX m m k)) =
-          Matrix.det (Matrix.of fun i j : m => s (i, j)) := by
-      rw [(MvPolynomial.eval s).map_det]
-      congr 1
-      ext i j
-      simp [Matrix.mvPolynomialX]
-    rw [hdet_eval]
+    rw [map_mul, map_sub, map_zero, Matrix.eval_det_mvPolynomialX]
     by_cases hs_det : Matrix.det (Matrix.of fun i j : m => s (i, j)) = 0
     · rw [hs_det, mul_zero]
     · have hh : (eval s) p = (eval s) q :=
         h (Matrix.GeneralLinearGroup.mkOfDetNeZero
           (Matrix.of fun i j : m => s (i, j)) hs_det)
       rw [hh, sub_self, zero_mul]
-  exact sub_eq_zero.mp ((mul_eq_zero.mp hprod).resolve_right hdet_ne)
+  exact sub_eq_zero.mp
+    ((mul_eq_zero.mp hprod).resolve_right (Matrix.det_mvPolynomialX_ne_zero m k))
 
 end MvPolynomial

--- a/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
@@ -75,4 +75,13 @@ theorem det_mvPolynomialX_ne_zero [DecidableEq m] [Fintype m] [CommRing R] [Nont
   rw [det_one, ← RingHom.map_det, h_det, map_zero] at this
   exact zero_ne_one this
 
+/-- Evaluating the generic determinant polynomial `det (mvPolynomialX m m R)` at a point `s`
+gives the determinant of the matrix obtained by substituting `s`. -/
+theorem eval_det_mvPolynomialX [DecidableEq m] [Fintype m] [CommRing R] (s : m × m → R) :
+    MvPolynomial.eval s (det (mvPolynomialX m m R)) = det (Matrix.of fun i j : m => s (i, j)) := by
+  rw [(MvPolynomial.eval s).map_det]
+  congr 1
+  ext i j
+  simp [mvPolynomialX]
+
 end Matrix


### PR DESCRIPTION
This PR adds `MvPolynomial.eq_of_eval_eq_on_gl`: two polynomials in `MvPolynomial (m × m) k` over an infinite field `k` are equal whenever their evaluations agree at every invertible matrix.

The proof multiplies by the generic determinant `det (Matrix.mvPolynomialX m m k)` so that `MvPolynomial.funext` applies (covering both invertible and non-invertible specializations of the variables), then divides by it (it is nonzero by `Matrix.det_mvPolynomialX_ne_zero`) using that the polynomial ring is an integral domain.

The lemma is useful when reasoning about polynomial representations of `GL n k`, where natural identities are easiest to check on `GL n k` itself but the final statement lives at the level of polynomials.

The lemma is placed in a new file `Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean` because the existing `Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean` is upstream of `Adjugate`, which is itself upstream of `GeneralLinearGroup.Defs` — so we cannot import `GeneralLinearGroup.Defs` from `Matrix.MvPolynomial` without creating a cycle.

🤖 Prepared with Claude Code