### PR TITLE
feat(RingTheory): algebra maps between finite étale algebras are locally finite split

### DIFF
--- a/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Pi.lean
@@ -126,6 +126,19 @@ protected def compLeft (f : A →ₐ[R] B) (ι : Type*) : (ι → A) →ₐ[R] �
       ext
       exact f.commutes' c }
 
+variable (R) in
+/-- Reindex a family of algebras. -/
+@[expose, simps!]
+protected def compRight {ι : Type*} (S : ι → Type*) [CommRing R] [∀ i, CommRing (S i)]
+    [∀ i, Algebra R (S i)] {σ : Type*} (f : σ → ι) :
+    (Π i, S i) →ₐ[R] Π i, S (f i) :=
+  Pi.algHom R _ fun x ↦ Pi.evalAlgHom R _ (f x)
+
+lemma compRight_apply_eq {ι : Type*} (S : ι → Type*) [CommRing R] [∀ i, CommRing (S i)]
+    [∀ i, Algebra R (S i)] {σ : Type*} (f : σ → ι) (x : Π i, S i) :
+    AlgHom.compRight R S f x = fun i ↦ x (f i) :=
+  rfl
+
 end AlgHom
 
 namespace AlgEquiv

--- a/Mathlib/Algebra/Group/Idempotent.lean
+++ b/Mathlib/Algebra/Group/Idempotent.lean
@@ -99,6 +99,8 @@ theorem iff_eq_one_of_isUnit (h : IsUnit a) : IsIdempotentElem a ↔ a = 1 where
     rw [← eq, ← idem.eq, ← mul_assoc, eq, one_mul, idem.eq]
   mpr := by rintro rfl; exact .one
 
+alias ⟨eq_one_of_isUnit, _⟩ := iff_eq_one_of_isUnit
+
 end Monoid
 
 section CancelMonoid

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -9,7 +9,7 @@ public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 public import Mathlib.LinearAlgebra.Isomorphisms
 public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 public import Mathlib.RingTheory.Finiteness.Projective
-public import Mathlib.RingTheory.Localization.BaseChange
+public import Mathlib.RingTheory.Localization.Algebra
 public import Mathlib.RingTheory.Noetherian.Basic
 public import Mathlib.RingTheory.TensorProduct.Finite
 
@@ -421,6 +421,65 @@ lemma Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule
 
 variable {M' : Type*} [AddCommGroup M'] [Module R M'] (f : M →ₗ[R] M') [IsLocalizedModule S f]
 variable {N' : Type*} [AddCommGroup N'] [Module R N'] (g : N →ₗ[R] N') [IsLocalizedModule S g]
+
+lemma Module.Finite.exists_localizedModuleMap_powers_eq [Module.Finite R M] {u v : M →ₗ[R] N}
+    (hf : IsLocalizedModule.map S f g u = IsLocalizedModule.map S f g v) :
+    ∃ r ∈ S, ∀ (t : R),
+      r ∣ t → LocalizedModule.map (.powers t) u = LocalizedModule.map (.powers t) v := by
+  obtain ⟨s, hs⟩ : ∃ (s : S), s • u = s • v := by
+    refine Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule S
+      (N := N) (N' := N') (M := M) g u v ?_
+    ext x
+    simpa using DFunLike.congr_fun hf (f x)
+  refine ⟨s, s.property, fun t ht ↦ LinearMap.restrictScalars_injective R ?_⟩
+  refine IsLocalizedModule.linearMap_ext (.powers t) (LocalizedModule.mkLinearMap _ _)
+    (LocalizedModule.mkLinearMap _ _) ?_
+  ext x
+  dsimp
+  simp only [LocalizedModule.map_mk, LocalizedModule.mk_eq, one_smul, Subtype.exists,
+    Submonoid.mk_smul, exists_prop]
+  refine ⟨t, ⟨1, by simp⟩, ?_⟩
+  obtain ⟨a, rfl⟩ := exists_eq_mul_left_of_dvd ht
+  simp only [mul_smul, ← Submonoid.smul_def, ← LinearMap.smul_apply, hs]
+
+open Localization IsLocalizedModule in
+lemma Module.Finite.exists_lTensor_away_eq [Module.Finite R M] {u v : M →ₗ[R] N}
+    (hf : IsLocalizedModule.map S f g u = IsLocalizedModule.map S f g v) :
+    ∃ r ∈ S, ∀ (t : R), r ∣ t → u.lTensor (Away t) = v.lTensor (Away t) := by
+  obtain ⟨r, hr, h⟩ := exists_localizedModuleMap_powers_eq _ _ _ hf
+  refine ⟨r, hr, fun t ht ↦ ?_⟩
+  rw [← map_tensorProductMk_eq_lTensor (.powers t), ← map_tensorProductMk_eq_lTensor (.powers t),
+    map_eq_map_iff_localizedModule]
+  apply h t ht
+
+lemma Module.Finite.exists_algebraTensorProductMap_id_eq {A B : Type*} [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] [Module.Finite R A] (Rₚ : Type*) (Aₚ Bₚ : Type*) [CommRing Rₚ]
+    [CommRing Aₚ] [CommRing Bₚ] [Algebra R Rₚ] [Algebra R Aₚ] [Algebra R Bₚ] [Algebra Rₚ Aₚ]
+    [Algebra Rₚ Bₚ] [Algebra A Aₚ] [Algebra B Bₚ] [IsScalarTower R A Aₚ] [IsScalarTower R B Bₚ]
+    [IsScalarTower R Rₚ Aₚ] [IsScalarTower R Rₚ Bₚ] [IsLocalization S Rₚ]
+    [IsLocalization (Algebra.algebraMapSubmonoid A S) Aₚ]
+    [IsLocalization (Algebra.algebraMapSubmonoid B S) Bₚ] (f g : A →ₐ[R] B)
+    (hf : IsLocalization.mapₐ S Rₚ Aₚ Bₚ f = IsLocalization.mapₐ S Rₚ Aₚ Bₚ g) :
+    ∃ r ∈ S, ∀ (t : R), r ∣ t →
+      Algebra.TensorProduct.map (.id (Localization.Away t) (Localization.Away t)) f =
+        Algebra.TensorProduct.map (.id (Localization.Away t) (Localization.Away t)) g := by
+  have :
+      IsLocalizedModule.map S
+        (IsScalarTower.toAlgHom _ A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+        f.toLinearMap =
+      IsLocalizedModule.map S
+        (IsScalarTower.toAlgHom R A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+        g.toLinearMap := by
+    apply IsLocalizedModule.linearMap_ext S (IsScalarTower.toAlgHom R A Aₚ).toLinearMap
+        (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+    ext x
+    simp only [LinearMap.coe_comp, Function.comp_apply, IsLocalizedModule.map_apply]
+    simpa using congr($(hf) (algebraMap A Aₚ x))
+  obtain ⟨r, hr, h⟩ := Module.Finite.exists_lTensor_away_eq S
+    (IsScalarTower.toAlgHom R A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap this
+  refine ⟨r, hr, fun t ht ↦ ?_⟩
+  ext x
+  simpa using congr($(h t ht) (1 ⊗ₜ x))
 
 /--
 Let `M` be a finite `R`-module, and `N` be a finitely presented `R`-module.

--- a/Mathlib/RingTheory/LocalRing/Basic.lean
+++ b/Mathlib/RingTheory/LocalRing/Basic.lean
@@ -110,6 +110,13 @@ theorem of_surjective' [Ring S] [Nontrivial S] (f : R →+* S) (hf : Function.Su
     rw [← f.map_one, ← f.map_sub]
     apply f.isUnit_map)
 
+lemma isIdempotentElem_iff_eq_zero_or_eq_one {e : R} : IsIdempotentElem e ↔ e = 0 ∨ e = 1 := by
+  refine ⟨fun he ↦ ?_, ?_⟩
+  · obtain (h | h) := IsLocalRing.isUnit_or_isUnit_one_sub_self e
+    · exact Or.inr (he.eq_one_of_isUnit h)
+    · exact Or.inl (by simpa using he.one_sub.eq_one_of_isUnit h)
+  · grind [IsIdempotentElem.zero, IsIdempotentElem.one]
+
 end CommRing
 
 end IsLocalRing

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -151,6 +151,16 @@ theorem bijective_linearMap_mul' : Function.Bijective (LinearMap.mul' R A) :=
 
 end IsLocalization
 
+lemma IsLocalizedModule.map_tensorProductMk_eq_lTensor {N : Type*} [AddCommMonoid N] [Module R N]
+    {f : M →ₗ[R] N} :
+    map S (TensorProduct.mk R A M 1) (TensorProduct.mk R A N 1) f = f.lTensor A := by
+  ext a x
+  simp only [AlgebraTensorModule.curry_apply, LinearMap.restrictScalars_self, curry_apply,
+    LinearMap.lTensor_tmul]
+  rw [tmul_eq_smul_one_tmul, ← mk_apply,
+    (IsLocalization.linearMap_compatibleSMul S A _ _).map_smul, map_apply]
+  simp [smul_tmul']
+
 variable (T B : Type*) [CommSemiring T] [CommSemiring B]
   [Algebra R T] [Algebra T B] [Algebra R B] [Algebra A B] [IsScalarTower R T B]
   [IsScalarTower R A B]

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -366,4 +366,9 @@ lemma map_bijective_iff_localizedModuleMap_bijective :
       Function.Bijective (LocalizedModule.map S l) := by
   simp [LocalizedModule.coe_map_eq g₁ g₂]
 
+lemma map_eq_map_iff_localizedModule {f g : M →ₗ[R] N} :
+    map S g₁ g₂ f = map S g₁ g₂ g ↔ LocalizedModule.map S f = LocalizedModule.map S g := by
+  conv_rhs => rw [← LinearMap.restrictScalars_inj R]
+  simp [LocalizedModule.restrictScalars_map_eq _ g₁ g₂]
+
 end IsLocalizedModule

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -365,4 +365,20 @@ lemma rankAtStalk_eq (p : PrimeSpectrum R) :
     AlgebraTensorModule.cancelBaseChange _ _ _ _ _
   rw [← e.finrank_eq, finrank_baseChange, rankAtStalk_eq_finrank_tensorProduct]
 
+variable (M) in
+lemma exists_notMem_rankAtStalk_eq [FinitePresentation R M] (p : Ideal R) [p.IsPrime] :
+    ∃ r ∉ p,
+      rankAtStalk (R := Localization.Away r) (Localization.Away r ⊗[R] M) =
+        rankAtStalk M ⟨p, inferInstance⟩ := by
+  obtain ⟨U, hU, hp, heq⟩ := (isLocallyConstant_rankAtStalk (M := M)).exists_open ⟨p, ‹_›⟩
+  obtain ⟨V, ⟨r, rfl⟩, (hr : r ∉ p), hrU⟩ :=
+    PrimeSpectrum.isTopologicalBasis_basic_opens.exists_subset_of_mem_open hp hU
+  refine ⟨r, hr, ?_⟩
+  ext ⟨q, hq⟩
+  rw [Module.rankAtStalk_baseChange]
+  refine heq _ (hrU ?_)
+  rw [IsLocalization.isPrime_iff_isPrime_disjoint (.powers r) _ q, Set.disjoint_left] at hq
+  apply hq.right
+  simp
+
 end Module

--- a/Mathlib/RingTheory/TotallySplit.lean
+++ b/Mathlib/RingTheory/TotallySplit.lean
@@ -300,54 +300,9 @@ lemma AlgHom.eq_compRight_of_isLocalRing [IsLocalRing R] (f : (E → R) →ₐ[R
   refine f.eq_compRight_of_forall_or_of_isIdempotentElem fun e he ↦ ?_
   rwa [IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one] at he
 
-end
-
 open Localization in
-lemma AlgHom.exists_cover_eq_of_eq {R A B : Type*} [CommRing R] (S : Submonoid R)
-    [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
-    [Module.Finite R A]
-    (Rₚ : Type*) (Aₚ Bₚ : Type u) [CommRing Rₚ] [CommRing Aₚ] [CommRing Bₚ]
-    [Algebra R Rₚ] [Algebra R Aₚ] [Algebra R Bₚ] [Algebra Rₚ Aₚ] [Algebra Rₚ Bₚ]
-    [Algebra A Aₚ] [Algebra B Bₚ]
-    [IsScalarTower R A Aₚ] [IsScalarTower R B Bₚ] [IsScalarTower R Rₚ Aₚ] [IsScalarTower R Rₚ Bₚ]
-    [IsLocalization S Rₚ] [IsLocalization (Algebra.algebraMapSubmonoid A S) Aₚ]
-    [IsLocalization (Algebra.algebraMapSubmonoid B S) Bₚ]
-    (f g : A →ₐ[R] B) (hf : IsLocalization.mapₐ S Rₚ Aₚ Bₚ f = IsLocalization.mapₐ S Rₚ Aₚ Bₚ g) :
-    ∃ (r : S),
-      Algebra.TensorProduct.map (.id (Away r.val) (Away r.val)) f =
-        Algebra.TensorProduct.map (.id (Away r.val) (Away r.val)) g := by
-  let u : B →ₗ[R] Bₚ := (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
-  have : IsLocalizedModule S u := by
-    simp only [u]
-    rw [isLocalizedModule_iff_isLocalization]
-    infer_instance
-  obtain ⟨s, hs⟩ := by
-    refine Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule S
-      (N := B) (N' := Bₚ) (M := A) u f g ?_
-    ext x
-    simpa using DFunLike.congr_fun hf (algebraMap A Aₚ x)
-  use s
-  ext a
-  simp only [Algebra.TensorProduct.map_restrictScalars_comp_includeRight, coe_comp,
-    Function.comp_apply, Algebra.TensorProduct.includeRight_apply]
-  have hun : IsUnit ((algebraMap R (Away s.val ⊗[R] B) s)) := by
-    rw [IsScalarTower.algebraMap_apply R (Away s.val) _]
-    apply (IsLocalization.Away.algebraMap_isUnit s.val).map
-  suffices s.val • ((1 : Away s.val) ⊗ₜ[R] f a) = s.val • (1 ⊗ₜ[R] g a) by
-    apply hun.mul_left_cancel
-    rwa [← Algebra.smul_def, ← Algebra.smul_def]
-  have := DFunLike.congr_fun hs a
-  dsimp at this
-  rw [← TensorProduct.tmul_smul]
-  rw [← TensorProduct.tmul_smul]
-  rw [← Submonoid.smul_def, this, ← Submonoid.smul_def]
-
--- TODO: fix `IsLocalization.mapₐ` to have the correct universe generality
-open Localization in
-lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
-    [_root_.Finite E] [_root_.Finite F]
-    [CommRing R]
-    (f : (E → R) →ₐ[R] F → R) (p : Ideal R) [p.IsPrime] :
+lemma AlgHom.exists_notMem_eq_compRight [_root_.Finite F] (f : (E → R) →ₐ[R] F → R)
+    (p : Ideal R) [p.IsPrime] :
     ∃ r ∉ p, ∃ (σ : F → E),
       Algebra.TensorProduct.map (.id (Away r) (Away r)) f =
         Algebra.TensorProduct.map (.id (Away r) (Away r)) (.compRight _ _ σ) := by
@@ -362,13 +317,11 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
     convert IsLocalizedModule.pi p.primeCompl (fun _ ↦ Algebra.linearMap R (Localization.AtPrime p))
     infer_instance
   let fₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
-    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
-      (E → Localization.AtPrime p)
+    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p) (E → Localization.AtPrime p)
       (F → Localization.AtPrime p) f
   obtain ⟨σ, hσ⟩ := fₚ.eq_compRight_of_isLocalRing
   let gₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
-    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
-      (E → Localization.AtPrime p)
+    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p) (E → Localization.AtPrime p)
       (F → Localization.AtPrime p) (.compRight R (fun _ ↦ R) σ)
   have : fₚ = gₚ := by
     rw [hσ]
@@ -378,12 +331,16 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
     simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
       AlgHom.compRight_apply, IsLocalization.mapₐ_coe, IsLocalization.map_eq, gₚ]
     rfl
-  obtain ⟨⟨r, hr⟩, heq⟩ := AlgHom.exists_cover_eq_of_eq _ _ _ _ f (.compRight R _ σ) this
-  exact ⟨r, hr, σ, heq⟩
+  obtain ⟨r, hr, heq⟩ := Module.Finite.exists_algebraTensorProductMap_id_eq _ _ _ _
+    f (.compRight R _ σ) this
+  exact ⟨r, hr, σ, heq _ (by rfl)⟩
+
+end
 
 variable {R S A B : Type u} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
   [Algebra R A] [Algebra R S] [Algebra R B]
 
+/-- Any algebra map between finite étale algebras, is étale locally finite split. -/
 lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Finite R B]
     [Algebra.Etale R B] (f : A →ₐ[R] B) (p : PrimeSpectrum R) :
     ∃ (S : Type u) (_ : CommRing S) (_ : Algebra R S),
@@ -397,9 +354,8 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
     obtain ⟨S', _, _, _, ⟨q, rfl⟩, hS'⟩ := this (Algebra.TensorProduct.map (.id S S) f) p hS
     let _ : Algebra R S' := Algebra.compHom S' (algebraMap R S)
     have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
-    refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
-    · exact .comp _ S _
-    · rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
+    refine ⟨S', inferInstance, inferInstance, .comp _ S _, ⟨q, rfl⟩, ?_⟩
+    rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
   wlog hB : Algebra.IsFiniteSplit R B
   · obtain ⟨S, _, _, _, ⟨p, rfl⟩, hS⟩ := Algebra.IsFiniteSplit.exists_tensorProduct_of_etale p
       (S := B)
@@ -408,19 +364,16 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
       (Algebra.TensorProduct.map (.id S S) f) p inferInstance hS
     let _ : Algebra R S' := Algebra.compHom S' (algebraMap R S)
     have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
-    refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
-    · exact .comp _ S _
-    · rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
+    refine ⟨S', inferInstance, inferInstance, .comp _ S _, ⟨q, rfl⟩, ?_⟩
+    rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
   obtain ⟨n, ⟨eA⟩⟩ := hA
   obtain ⟨m, ⟨eB⟩⟩ := hB
   let f' : (Fin n → R) →ₐ[R] Fin m → R := eB.toAlgHom.comp (f.comp eA.symm.toAlgHom)
-  obtain ⟨r, hr, σ, hσ⟩ := AlgHom.exists_cover_eq_compRight'' f' p.asIdeal
-  refine ⟨Localization.Away r, inferInstance, inferInstance, ?_, ?_, ?_⟩
-  · infer_instance
-  · change p ∈ Set.range (PrimeSpectrum.comap <| algebraMap R (Localization.Away r))
-    rwa [PrimeSpectrum.localization_away_comap_range _ r]
+  obtain ⟨r, hr, σ, hσ⟩ := AlgHom.exists_notMem_eq_compRight f' p.asIdeal
+  refine ⟨Localization.Away r, inferInstance, inferInstance, inferInstance, ?_, ?_⟩
+  · rwa [PrimeSpectrum.localization_away_comap_range _ r]
   · let e := TensorProduct.piScalarRight R (Localization.Away r) (Localization.Away r) (Fin m)
-    apply AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _
+    apply AlgHom.IsFiniteSplit.mk _
       (Algebra.TensorProduct.congr .refl eA |>.trans (Algebra.TensorProduct.piScalarRight ..))
       (Algebra.TensorProduct.congr .refl eB |>.trans (Algebra.TensorProduct.piScalarRight ..)) σ
     ext a : 2

--- a/Mathlib/RingTheory/TotallySplit.lean
+++ b/Mathlib/RingTheory/TotallySplit.lean
@@ -157,38 +157,13 @@ lemma exists_tensorProduct_of_etale_of_rankAtStalk [Etale R S] [Module.Finite R 
     · exact Algebra.Etale.comp R S V
     · exact .of_algEquiv e.symm
 
--- TODO: move me
-lemma _root_.Algebra.exists_cover_rankAtStalk_eq {R : Type*} (S : Type*) [CommRing R] [CommRing S]
-    [Algebra R S] [Module.FinitePresentation R S] [Module.Flat R S] (p : Ideal R) [p.IsPrime] :
-    ∃ r ∉ p,
-      Module.rankAtStalk (R := Localization.Away r) (Localization.Away r ⊗[R] S) =
-        Module.rankAtStalk S ⟨p, inferInstance⟩ := by
-  obtain ⟨U, hU, hp, heq⟩ := (Module.isLocallyConstant_rankAtStalk (M := S)).exists_open ⟨p, ‹_›⟩
-  obtain ⟨V, ⟨r, rfl⟩, (hr : r ∉ p), hrU⟩ :=
-    PrimeSpectrum.isTopologicalBasis_basic_opens.exists_subset_of_mem_open hp hU
-  refine ⟨r, hr, ?_⟩
-  ext q
-  rw [Module.rankAtStalk_baseChange]
-  apply heq
-  apply hrU
-  simp only [PrimeSpectrum.basicOpen_eq_zeroLocus_compl, Set.mem_compl_iff,
-    PrimeSpectrum.mem_zeroLocus, Set.singleton_subset_iff,
-    SetLike.mem_coe]
-  obtain ⟨-, b⟩ := (IsLocalization.isPrime_iff_isPrime_disjoint (.powers r) _ q.asIdeal).mp q.2
-  rw [Set.disjoint_left] at b
-  simp only [SetLike.mem_coe, Ideal.coe_comap, Set.mem_preimage] at b
-  apply b
-  use 1
-  simp
-
 attribute [local instance] Module.FinitePresentation.of_finite_of_finitePresentation in
 lemma exists_tensorProduct_of_etale [Module.Finite R S] [Etale R S] (p : PrimeSpectrum R) :
-    ∃ (T : Type u) (_ : CommRing T) (_ : Algebra R T),
-      Etale R T ∧
+    ∃ (T : Type u) (_ : CommRing T) (_ : Algebra R T), Etale R T ∧
       p ∈ Set.range (PrimeSpectrum.comap (algebraMap R T)) ∧
       IsFiniteSplit T (T ⊗[R] S) := by
   wlog h : ∃ (n : ℕ), Module.rankAtStalk (R := R) S = n
-  · obtain ⟨r, hr, hn⟩ := Algebra.exists_cover_rankAtStalk_eq S p.asIdeal
+  · obtain ⟨r, hr, hn⟩ := Module.exists_notMem_rankAtStalk_eq S p.asIdeal
     obtain ⟨p', rfl⟩ : p ∈ Set.range
         (PrimeSpectrum.comap <| algebraMap R (Localization.Away r)) := by
       rwa [PrimeSpectrum.localization_away_comap_range _ r]
@@ -211,7 +186,7 @@ end Algebra
 
 section
 
-variable {R S A B : Type u} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
+variable {R S A B : Type*} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
   [Algebra R A] [Algebra R S] [Algebra R B]
 
 /-- A homomorphism of `R`-algebras `f : A →ₐ[R] B` is split if there exist `n`, `m` such
@@ -229,139 +204,103 @@ lemma AlgHom.IsFiniteSplit.mk (f : A →ₐ[R] B) {E F : Type*} [_root_.Finite E
   cases nonempty_fintype F
   let eE := Fintype.equivFin E
   let eF := Fintype.equivFin F
-  refine ⟨Fintype.card E, Fintype.card F, eA.trans ?_, eB.trans ?_, eE ∘ σ ∘ eF.symm, ?_⟩
-  · exact AlgEquiv.piCongrLeft R (fun _ ↦ R) eE
-  · exact AlgEquiv.piCongrLeft R (fun _ ↦ R) eF
-  · ext x
-    apply eB.injective
-    have := DFunLike.congr_fun h x
-    simp only [AlgEquiv.toAlgHom_eq_coe, coe_comp, AlgHom.coe_coe, Function.comp_apply] at this
-    ext i
-    simp [this, AlgHom.compRight]
+  refine ⟨Fintype.card E, Fintype.card F, eA.trans <| .piCongrLeft R (fun _ ↦ R) eE,
+    eB.trans <| .piCongrLeft R (fun _ ↦ R) eF, eE ∘ σ ∘ eF.symm, ?_⟩
+  ext x
+  apply eB.injective
+  ext i
+  simp [dsimp% congr($h x), AlgHom.compRight]
 
 variable (S) in
 lemma AlgHom.IsFiniteSplit.tensorProductMap {f : A →ₐ[R] B} (hf : f.IsFiniteSplit) :
     (Algebra.TensorProduct.map (.id S S) f).IsFiniteSplit := by
   obtain ⟨n, m, eA, eB, σ, hf⟩ := hf
-  refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _
+  refine .mk _
     ((Algebra.TensorProduct.congr .refl eA).trans (Algebra.TensorProduct.piScalarRight ..))
     ((Algebra.TensorProduct.congr .refl eB).trans (Algebra.TensorProduct.piScalarRight ..)) σ ?_
-  ext a
+  ext
   simp [hf]
 
 variable (S) in
 lemma AlgHom.IsFiniteSplit.iff_of_isScalarTower
-    (T : Type u) [CommRing T] [Algebra R T] [Algebra S T]
-    [IsScalarTower R S T] (f : A →ₐ[R] B) :
+    (T : Type*) [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T] (f : A →ₐ[R] B) :
     (Algebra.TensorProduct.map (.id T T) f).IsFiniteSplit ↔
       (Algebra.TensorProduct.map (.id T T)
         (Algebra.TensorProduct.map (.id S S) f)).IsFiniteSplit := by
-  refine ⟨?_, ?_⟩
-  · rintro ⟨n, m, eA, eB, σ, hf⟩
-    refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+  refine ⟨fun ⟨n, m, eA, eB, σ, hf⟩ ↦ ?_, fun ⟨n, m, eA, eB, σ, hf⟩ ↦ ?_⟩
+  · refine .mk _ ?_ ?_ σ ?_
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eA
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eB
-    ext a i
-    have := DFunLike.congr_fun hf (1 ⊗ₜ a)
-    simp only [Algebra.TensorProduct.map_tmul, coe_id, id_eq, AlgEquiv.toAlgHom_eq_coe, coe_comp,
-      AlgHom.coe_coe, Function.comp_apply] at this
-    simp [this]
-  · rintro ⟨n, m, eA, eB, σ, hf⟩
-    refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+    · ext a i
+      simp [dsimp% congr($hf (1 ⊗ₜ a))]
+  · refine .mk _ ?_ ?_ σ ?_
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eA
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eB
-    ext a i
-    have := DFunLike.congr_fun hf (1 ⊗ₜ (1 ⊗ₜ a))
-    simp only [Algebra.TensorProduct.map_tmul, coe_id, id_eq, AlgEquiv.toAlgHom_eq_coe, coe_comp,
-      AlgHom.coe_coe, Function.comp_apply] at this
-    simp [this]
+    · ext a i
+      simp [dsimp% congr($hf (1 ⊗ₜ (1 ⊗ₜ a)))]
 
-lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem {R E F : Type*} [_root_.Finite E]
-    [Nonempty E] [CommRing R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
-    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R _ σ := by
+end
+
+section
+
+variable {R E F : Type*} [_root_.Finite E] [CommRing R]
+
+/--
+If `R` has no non-trivial idempotents, any algebra map `(E → R) → (F → R)` is given by
+reindexing.
+This lemma assumes `Nonempty E`. For a version assuming `Nontrivial R` instead, see
+`AlgHom.eq_compRight_of_forall_isIdempotentElem_or`.
+-/
+lemma AlgHom.eq_compRight_of_forall_or_of_isIdempotentElem_of_nonempty [Nonempty E]
+    (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1) (f : (E → R) →ₐ[R] F → R) :
+    ∃ (σ : F → E), f = .compRight R _ σ := by
+  classical
   nontriviality R
   cases nonempty_fintype E
-  classical
   have hor (i) (j) : f (Pi.single j 1) i = 0 ∨ f (Pi.single j 1) i = 1 := by
     apply H
-    unfold IsIdempotentElem
-    rw [← Pi.mul_apply, ← map_mul, ← Pi.single_mul_left]
+    rw [IsIdempotentElem, ← Pi.mul_apply, ← map_mul, ← Pi.single_mul_left]
     simp
-  have (x : F) : ∃ (y : E), f (Pi.single y 1) x = 1 := by
-    by_contra! hc
-    replace hc (y : E) : f (Pi.single y 1) x = 0 := by
-      obtain (h|h) := hor x y
-      · assumption
-      · simp [hc] at h
-    have : 1 = ∑ y : E, f (Pi.single y 1) x := by
-      rw [← Fintype.sum_apply]
-      rw [← map_sum, Finset.univ_sum_single, ← Pi.one_def, map_one, Pi.one_apply]
-    simp_rw [hc] at this
-    simp at this
   have (x : F) : ∃! (y : E), f (Pi.single y 1) x = 1 := by
-    apply existsUnique_of_exists_of_unique
-    · exact this x
-    · intro a b ha hb
-      by_contra! h
-      have : (Pi.single a 1) * (Pi.single b 1 : E → R) = 0 := by
-        simp [← Pi.single_mul_left, h]
-      apply_fun ((f ·) · x) at this
+    refine existsUnique_of_exists_of_unique ?_ fun a b ha hb ↦ ?_
+    · by_contra! hc
+      replace hc (y : E) : f (Pi.single y 1) x = 0 := by grind
+      have : 1 = ∑ y : E, f (Pi.single y 1) x := by
+        rw [← Fintype.sum_apply, ← map_sum, Finset.univ_sum_single, ← Pi.one_def, map_one,
+          Pi.one_apply]
+      simp [hc] at this
+    · by_contra! h
+      have : f (Pi.single a 1 * Pi.single b 1) x = f 0 x := by simp [← Pi.single_mul_left, h]
       simp [ha, hb] at this
   choose σ hσ hun using this
   use σ
-  simp only at hσ
   ext x i
   induction x using Pi.single_induction with
   | zero => simp
   | add x y hx hy => simp [hx, hy]
   | single j r =>
-      have : Pi.single j r = r • (Pi.single j 1 : E → R) := by simp [← Pi.single_smul]
-      rw [this]
-      simp only [map_smul, Pi.smul_apply, smul_eq_mul, AlgHom.compRight_apply]
-      congr
-      obtain (h|h) := hor i j
-      · have : j ≠ σ i := by
-          intro hj
-          subst hj
-          simp [hσ] at h
-        simp [this, h]
-      · have := hun i j h
-        subst this
-        simp [hσ]
+    rw [← mul_one r, ← smul_eq_mul, Pi.single_smul, map_smul, Pi.smul_apply, smul_eq_mul,
+      compRight_apply]
+    obtain (h | h) := hor i j <;> grind [Pi.smul_apply, smul_eq_mul]
 
-lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem' {R E F : Type*} [_root_.Finite E]
-    [CommRing R] [Nontrivial R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
-    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R _ σ := by
+/-- Variant of `AlgHom.eq_compRight_of_forall_or_of_isIdempotentElem_of_nonempty` that assumes
+`Nontrivial R` instead. -/
+lemma AlgHom.eq_compRight_of_forall_or_of_isIdempotentElem [Nontrivial R]
+    (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1) (f : (E → R) →ₐ[R] F → R) :
+    ∃ (σ : F → E), f = .compRight R _ σ := by
   cases isEmpty_or_nonempty E
   · have : Subsingleton (F → R) := f.codomain_trivial
     cases isEmpty_or_nonempty F
-    · use default
-      apply Subsingleton.elim
+    · use default, Subsingleton.elim _ _
     · simpa using false_of_nontrivial_of_subsingleton (F → R)
-  · apply eq_compRight_of_no_nontrivial_isIdempotentElem H
+  · exact f.eq_compRight_of_forall_or_of_isIdempotentElem_of_nonempty H
 
-lemma IsIdempotentElem.eq_one_of_isUnit {R : Type*} [CommRing R]
-    {e : R} (he : IsIdempotentElem e) (heu : IsUnit e) : e = 1 := by
-  rw [eq_comm, ← sub_eq_zero]
-  apply heu.mul_left_cancel
-  simp [he]
-
-lemma IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one {R : Type*} [CommRing R] [IsLocalRing R]
-    {e : R} : IsIdempotentElem e ↔ e = 0 ∨ e = 1 := by
-  refine ⟨fun he ↦ ?_, ?_⟩
-  · obtain (h|h) := IsLocalRing.isUnit_or_isUnit_one_sub_self e
-    · exact Or.inr (he.eq_one_of_isUnit h)
-    · exact Or.inl (by simpa using he.one_sub.eq_one_of_isUnit h)
-  · rintro (h|h) <;> subst h
-    · exact IsIdempotentElem.zero
-    · exact IsIdempotentElem.one
-
-lemma RingHom.eq_compRight_of_isLocalHom {R E F : Type*} [_root_.Finite E] [CommRing R]
-    (f : (E → R) →ₐ[R] F → R) [IsLocalRing R] :
+lemma AlgHom.eq_compRight_of_isLocalRing [IsLocalRing R] (f : (E → R) →ₐ[R] F → R) :
     ∃ (σ : F → E), f = .compRight R _ σ := by
-  apply AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem'
-  intro e he
+  refine f.eq_compRight_of_forall_or_of_isIdempotentElem fun e he ↦ ?_
   rwa [IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one] at he
+
+end
 
 open Localization in
 lemma AlgHom.exists_cover_eq_of_eq {R A B : Type*} [CommRing R] (S : Submonoid R)
@@ -426,7 +365,7 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
     IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
       (E → Localization.AtPrime p)
       (F → Localization.AtPrime p) f
-  obtain ⟨σ, hσ⟩ := RingHom.eq_compRight_of_isLocalHom fₚ
+  obtain ⟨σ, hσ⟩ := fₚ.eq_compRight_of_isLocalRing
   let gₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
     IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
       (E → Localization.AtPrime p)
@@ -441,6 +380,9 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
     rfl
   obtain ⟨⟨r, hr⟩, heq⟩ := AlgHom.exists_cover_eq_of_eq _ _ _ _ f (.compRight R _ σ) this
   exact ⟨r, hr, σ, heq⟩
+
+variable {R S A B : Type u} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
+  [Algebra R A] [Algebra R S] [Algebra R B]
 
 lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Finite R B]
     [Algebra.Etale R B] (f : A →ₐ[R] B) (p : PrimeSpectrum R) :

--- a/Mathlib/RingTheory/TotallySplit.lean
+++ b/Mathlib/RingTheory/TotallySplit.lean
@@ -9,6 +9,7 @@ public import Mathlib.RingTheory.Etale.Pi
 public import Mathlib.RingTheory.Flat.Rank
 public import Mathlib.RingTheory.Smooth.Flat
 public import Mathlib.RingTheory.TensorProduct.Pi
+public import Mathlib.RingTheory.Finiteness.ModuleFinitePresentation
 
 /-!
 # Totally split algebras
@@ -90,7 +91,7 @@ over `T`.
 This is the commutative algebra version of
 [Lenstra, Galois theory for schemes, 5.10][lenstraGSchemes].
 -/
-lemma exists_tensorProduct_of_etale [Etale R S] [Module.Finite R S] {n : ℕ}
+lemma exists_tensorProduct_of_etale_of_rankAtStalk [Etale R S] [Module.Finite R S] {n : ℕ}
     (hn : Module.rankAtStalk (R := R) S = n) :
     ∃ (T : Type u) (_ : CommRing T) (_ : Algebra R T)
       (_ : Module.FaithfullyFlat R T) (_ : Module.Finite R T) (_ : Algebra.Etale R T),
@@ -156,6 +157,342 @@ lemma exists_tensorProduct_of_etale [Etale R S] [Module.Finite R S] {n : ℕ}
     · exact Algebra.Etale.comp R S V
     · exact .of_algEquiv e.symm
 
+-- TODO: move me
+lemma _root_.Algebra.exists_cover_rankAtStalk_eq {R : Type*} (S : Type*) [CommRing R] [CommRing S]
+    [Algebra R S] [Module.FinitePresentation R S] [Module.Flat R S] (p : Ideal R) [p.IsPrime] :
+    ∃ r ∉ p,
+      Module.rankAtStalk (R := Localization.Away r) (Localization.Away r ⊗[R] S) =
+        Module.rankAtStalk S ⟨p, inferInstance⟩ := by
+  obtain ⟨U, hU, hp, heq⟩ := (Module.isLocallyConstant_rankAtStalk (M := S)).exists_open ⟨p, ‹_›⟩
+  obtain ⟨V, ⟨r, rfl⟩, (hr : r ∉ p), hrU⟩ :=
+    PrimeSpectrum.isTopologicalBasis_basic_opens.exists_subset_of_mem_open hp hU
+  refine ⟨r, hr, ?_⟩
+  ext q
+  rw [Module.rankAtStalk_baseChange]
+  apply heq
+  apply hrU
+  simp only [PrimeSpectrum.basicOpen_eq_zeroLocus_compl, Set.mem_compl_iff,
+    PrimeSpectrum.mem_zeroLocus, Set.singleton_subset_iff,
+    SetLike.mem_coe]
+  obtain ⟨-, b⟩ := (IsLocalization.isPrime_iff_isPrime_disjoint (.powers r) _ q.asIdeal).mp q.2
+  rw [Set.disjoint_left] at b
+  simp only [SetLike.mem_coe, Ideal.coe_comap, Set.mem_preimage] at b
+  apply b
+  use 1
+  simp
+
+attribute [local instance] Module.FinitePresentation.of_finite_of_finitePresentation in
+lemma exists_tensorProduct_of_etale [Module.Finite R S] [Etale R S] (p : PrimeSpectrum R) :
+    ∃ (T : Type u) (_ : CommRing T) (_ : Algebra R T),
+      Etale R T ∧
+      p ∈ Set.range (PrimeSpectrum.comap (algebraMap R T)) ∧
+      IsFiniteSplit T (T ⊗[R] S) := by
+  wlog h : ∃ (n : ℕ), Module.rankAtStalk (R := R) S = n
+  · obtain ⟨r, hr, hn⟩ := Algebra.exists_cover_rankAtStalk_eq S p.asIdeal
+    obtain ⟨p', rfl⟩ : p ∈ Set.range
+        (PrimeSpectrum.comap <| algebraMap R (Localization.Away r)) := by
+      rwa [PrimeSpectrum.localization_away_comap_range _ r]
+    obtain ⟨T, _, _, _, ⟨q, rfl⟩, h⟩ := this p' ⟨_, hn⟩
+    let _ : Algebra R T := Algebra.compHom T (algebraMap R (Localization.Away r))
+    have : IsScalarTower R (Localization.Away r) T := IsScalarTower.of_algebraMap_eq' rfl
+    let e : T ⊗[Localization.Away r] (Localization.Away r ⊗[R] S) ≃ₐ[T] T ⊗[R] S :=
+      TensorProduct.cancelBaseChange ..
+    refine ⟨T, inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
+    · exact .comp _ (Localization.Away r) _
+    · exact IsFiniteSplit.of_algEquiv (S := T ⊗[Localization.Away r] (Localization.Away r ⊗[R] S)) e
+  obtain ⟨n, hn⟩ := h
+  obtain ⟨S, _, _, _, _, _, hS⟩ := exists_tensorProduct_of_etale_of_rankAtStalk hn
+  obtain ⟨p, rfl⟩ := PrimeSpectrum.comap_surjective_of_faithfullyFlat (B := S) p
+  exact ⟨S, inferInstance, inferInstance, inferInstance, ⟨p, rfl⟩, hS⟩
+
 end IsFiniteSplit
 
 end Algebra
+
+section
+
+variable {R S A B : Type u} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
+  [Algebra R A] [Algebra R S] [Algebra R B]
+
+@[expose, simps!]
+def AlgHom.compRight {E F : Type*} (R S : Type*) [CommRing R] [CommRing S] [Algebra R S]
+    (σ : E → F) :
+    (F → S) →ₐ[R] E → S :=
+  Pi.algHom R _ (fun f ↦ Pi.evalAlgHom R _ (σ f))
+
+/-- A homomorphism of `R`-algebras `f : A →ₐ[R] B` is split if there exist `n`, `m` such
+that `A ≃ₐ[R] Fin n → R` and `B ≃ₐ[R] Fin m → R` and modulo these isomorphisms, `f` is induced
+by a reindexing `σ : Fin m → Fin n`. -/
+def AlgHom.IsSplit (f : A →ₐ[R] B) : Prop :=
+  ∃ (n m : ℕ) (eA : A ≃ₐ[R] Fin n → R) (eB : B ≃ₐ[R] Fin m → R) (σ : Fin m → Fin n),
+    f = eB.symm.toAlgHom.comp ((AlgHom.compRight R R σ).comp eA)
+
+lemma AlgHom.IsSplit.mk (f : A →ₐ[R] B) {E F : Type*} [_root_.Finite E] [_root_.Finite F]
+    (eA : A ≃ₐ[R] (E → R)) (eB : B ≃ₐ[R] (F → R)) (σ : F → E)
+    (h : eB.toAlgHom.comp f = (AlgHom.compRight R R σ).comp eA.toAlgHom) :
+    f.IsSplit := by
+  cases nonempty_fintype E
+  cases nonempty_fintype F
+  let eE := Fintype.equivFin E
+  let eF := Fintype.equivFin F
+  refine ⟨Fintype.card E, Fintype.card F, eA.trans ?_, eB.trans ?_, eE ∘ σ ∘ eF.symm, ?_⟩
+  · exact AlgEquiv.piCongrLeft R (fun _ ↦ R) eE
+  · exact AlgEquiv.piCongrLeft R (fun _ ↦ R) eF
+  · ext x
+    apply eB.injective
+    have := DFunLike.congr_fun h x
+    simp only [AlgEquiv.toAlgHom_eq_coe, coe_comp, AlgHom.coe_coe, Function.comp_apply] at this
+    ext i
+    simp [this, AlgHom.compRight]
+
+lemma AlgHom.compRight_apply' {E F : Type*} (R S : Type*) [CommRing R] [CommRing S] [Algebra R S]
+    (σ : E → F) (x : F → S) :
+    AlgHom.compRight R S σ x = fun i ↦ x (σ i) :=
+  rfl
+
+variable (S) in
+lemma AlgHom.IsSplit.tensorProductMap {f : A →ₐ[R] B} (hf : f.IsSplit) :
+    (Algebra.TensorProduct.map (.id S S) f).IsSplit := by
+  obtain ⟨n, m, eA, eB, σ, hf⟩ := hf
+  refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _
+    ((Algebra.TensorProduct.congr .refl eA).trans (Algebra.TensorProduct.piScalarRight ..))
+    ((Algebra.TensorProduct.congr .refl eB).trans (Algebra.TensorProduct.piScalarRight ..)) σ ?_
+  ext a
+  simp [hf]
+
+variable (S) in
+lemma AlgHom.IsSplit.iff_of_isScalarTower
+    (T : Type u) [CommRing T] [Algebra R T] [Algebra S T]
+    [IsScalarTower R S T] (f : A →ₐ[R] B) :
+    (Algebra.TensorProduct.map (.id T T) f).IsSplit ↔
+      (Algebra.TensorProduct.map (.id T T)
+        (Algebra.TensorProduct.map (.id S S) f)).IsSplit := by
+  refine ⟨?_, ?_⟩
+  · rintro ⟨n, m, eA, eB, σ, hf⟩
+    refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+    · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eA
+    · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eB
+    ext a i
+    have := DFunLike.congr_fun hf (1 ⊗ₜ a)
+    simp only [Algebra.TensorProduct.map_tmul, coe_id, id_eq, AlgEquiv.toAlgHom_eq_coe, coe_comp,
+      AlgHom.coe_coe, Function.comp_apply] at this
+    simp [this]
+  · rintro ⟨n, m, eA, eB, σ, hf⟩
+    refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+    · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eA
+    · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eB
+    ext a i
+    have := DFunLike.congr_fun hf (1 ⊗ₜ (1 ⊗ₜ a))
+    simp only [Algebra.TensorProduct.map_tmul, coe_id, id_eq, AlgEquiv.toAlgHom_eq_coe, coe_comp,
+      AlgHom.coe_coe, Function.comp_apply] at this
+    simp [this]
+
+lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem {R E F : Type*} [_root_.Finite E]
+    [Nonempty E] [CommRing R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
+    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R R σ := by
+  nontriviality R
+  cases nonempty_fintype E
+  classical
+  have hor (i) (j) : f (Pi.single j 1) i = 0 ∨ f (Pi.single j 1) i = 1 := by
+    apply H
+    unfold IsIdempotentElem
+    rw [← Pi.mul_apply, ← map_mul, ← Pi.single_mul_left]
+    simp
+  have (x : F) : ∃ (y : E), f (Pi.single y 1) x = 1 := by
+    by_contra! hc
+    replace hc (y : E) : f (Pi.single y 1) x = 0 := by
+      obtain (h|h) := hor x y
+      · assumption
+      · simp [hc] at h
+    have : 1 = ∑ y : E, f (Pi.single y 1) x := by
+      rw [← Fintype.sum_apply]
+      rw [← map_sum, Finset.univ_sum_single, ← Pi.one_def, map_one, Pi.one_apply]
+    simp_rw [hc] at this
+    simp at this
+  have (x : F) : ∃! (y : E), f (Pi.single y 1) x = 1 := by
+    apply existsUnique_of_exists_of_unique
+    · exact this x
+    · intro a b ha hb
+      by_contra! h
+      have : (Pi.single a 1) * (Pi.single b 1 : E → R) = 0 := by
+        simp [← Pi.single_mul_left, h]
+      apply_fun ((f ·) · x) at this
+      simp [ha, hb] at this
+  choose σ hσ hun using this
+  use σ
+  simp only at hσ
+  ext x i
+  induction x using Pi.single_induction with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | single j r =>
+      have : Pi.single j r = r • (Pi.single j 1 : E → R) := by simp [← Pi.single_smul]
+      rw [this]
+      simp only [map_smul, Pi.smul_apply, smul_eq_mul, AlgHom.compRight_apply]
+      congr
+      obtain (h|h) := hor i j
+      · have : j ≠ σ i := by
+          intro hj
+          subst hj
+          simp [hσ] at h
+        simp [this, h]
+      · have := hun i j h
+        subst this
+        simp [hσ]
+
+lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem' {R E F : Type*} [_root_.Finite E]
+    [CommRing R] [Nontrivial R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
+    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R R σ := by
+  cases isEmpty_or_nonempty E
+  · have : Subsingleton (F → R) := f.codomain_trivial
+    cases isEmpty_or_nonempty F
+    · use default
+      apply Subsingleton.elim
+    · simpa using false_of_nontrivial_of_subsingleton (F → R)
+  · apply eq_compRight_of_no_nontrivial_isIdempotentElem H
+
+lemma IsIdempotentElem.eq_one_of_isUnit {R : Type*} [CommRing R]
+    {e : R} (he : IsIdempotentElem e) (heu : IsUnit e) : e = 1 := by
+  rw [eq_comm, ← sub_eq_zero]
+  apply heu.mul_left_cancel
+  simp [he]
+
+lemma IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one {R : Type*} [CommRing R] [IsLocalRing R]
+    {e : R} : IsIdempotentElem e ↔ e = 0 ∨ e = 1 := by
+  refine ⟨fun he ↦ ?_, ?_⟩
+  · obtain (h|h) := IsLocalRing.isUnit_or_isUnit_one_sub_self e
+    · exact Or.inr (he.eq_one_of_isUnit h)
+    · exact Or.inl (by simpa using he.one_sub.eq_one_of_isUnit h)
+  · rintro (h|h) <;> subst h
+    · exact IsIdempotentElem.zero
+    · exact IsIdempotentElem.one
+
+lemma RingHom.eq_compRight_of_isLocalHom {R E F : Type*} [_root_.Finite E] [CommRing R]
+    (f : (E → R) →ₐ[R] F → R) [IsLocalRing R] :
+    ∃ (σ : F → E), f = .compRight R R σ := by
+  apply AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem'
+  intro e he
+  rwa [IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one] at he
+
+open Localization in
+lemma AlgHom.exists_cover_eq_of_eq {R A B : Type*} [CommRing R] (S : Submonoid R)
+    [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    [Module.Finite R A]
+    (Rₚ : Type*) (Aₚ Bₚ : Type u) [CommRing Rₚ] [CommRing Aₚ] [CommRing Bₚ]
+    [Algebra R Rₚ] [Algebra R Aₚ] [Algebra R Bₚ] [Algebra Rₚ Aₚ] [Algebra Rₚ Bₚ]
+    [Algebra A Aₚ] [Algebra B Bₚ]
+    [IsScalarTower R A Aₚ] [IsScalarTower R B Bₚ] [IsScalarTower R Rₚ Aₚ] [IsScalarTower R Rₚ Bₚ]
+    [IsLocalization S Rₚ] [IsLocalization (Algebra.algebraMapSubmonoid A S) Aₚ]
+    [IsLocalization (Algebra.algebraMapSubmonoid B S) Bₚ]
+    (f g : A →ₐ[R] B) (hf : IsLocalization.mapₐ S Rₚ Aₚ Bₚ f = IsLocalization.mapₐ S Rₚ Aₚ Bₚ g) :
+    ∃ (r : S),
+      Algebra.TensorProduct.map (.id (Away r.val) (Away r.val)) f =
+        Algebra.TensorProduct.map (.id (Away r.val) (Away r.val)) g := by
+  let u : B →ₗ[R] Bₚ := (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+  have : IsLocalizedModule S u := by
+    simp only [u]
+    rw [isLocalizedModule_iff_isLocalization]
+    infer_instance
+  obtain ⟨s, hs⟩ := by
+    refine Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule S
+      (N := B) (N' := Bₚ) (M := A) u f g ?_
+    ext x
+    simpa using DFunLike.congr_fun hf (algebraMap A Aₚ x)
+  use s
+  ext a
+  simp only [Algebra.TensorProduct.map_restrictScalars_comp_includeRight, coe_comp,
+    Function.comp_apply, Algebra.TensorProduct.includeRight_apply]
+  have hun : IsUnit ((algebraMap R (Away s.val ⊗[R] B) s)) := by
+    rw [IsScalarTower.algebraMap_apply R (Away s.val) _]
+    apply (IsLocalization.Away.algebraMap_isUnit s.val).map
+  suffices s.val • ((1 : Away s.val) ⊗ₜ[R] f a) = s.val • (1 ⊗ₜ[R] g a) by
+    apply hun.mul_left_cancel
+    rwa [← Algebra.smul_def, ← Algebra.smul_def]
+  have := DFunLike.congr_fun hs a
+  dsimp at this
+  rw [← TensorProduct.tmul_smul]
+  rw [← TensorProduct.tmul_smul]
+  rw [← Submonoid.smul_def, this, ← Submonoid.smul_def]
+
+-- TODO: fix `IsLocalization.mapₐ` to have the correct universe generality
+open Localization in
+lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
+    [_root_.Finite E] [_root_.Finite F]
+    [CommRing R]
+    (f : (E → R) →ₐ[R] F → R) (p : Ideal R) [p.IsPrime] :
+    ∃ r ∉ p, ∃ (σ : F → E),
+      Algebra.TensorProduct.map (.id (Away r) (Away r)) f =
+        Algebra.TensorProduct.map (.id (Away r) (Away r)) (.compRight _ _ σ) := by
+  have : IsLocalization (Algebra.algebraMapSubmonoid (E → R) p.primeCompl)
+      (E → Localization.AtPrime p) := by
+    rw [← isLocalizedModule_iff_isLocalization]
+    convert IsLocalizedModule.pi p.primeCompl (fun _ ↦ Algebra.linearMap R (Localization.AtPrime p))
+    infer_instance
+  have : IsLocalization (Algebra.algebraMapSubmonoid (F → R) p.primeCompl)
+      (F → Localization.AtPrime p) := by
+    rw [← isLocalizedModule_iff_isLocalization]
+    convert IsLocalizedModule.pi p.primeCompl (fun _ ↦ Algebra.linearMap R (Localization.AtPrime p))
+    infer_instance
+  let fₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
+    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
+      (E → Localization.AtPrime p)
+      (F → Localization.AtPrime p) f
+  obtain ⟨σ, hσ⟩ := RingHom.eq_compRight_of_isLocalHom fₚ
+  let gₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
+    IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
+      (E → Localization.AtPrime p)
+      (F → Localization.AtPrime p) (.compRight R R σ)
+  have : fₚ = gₚ := by
+    rw [hσ]
+    apply AlgHom.coe_ringHom_injective
+    apply IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid (E → R) p.primeCompl)
+    ext x i
+    simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
+      AlgHom.compRight_apply, IsLocalization.mapₐ_coe, IsLocalization.map_eq, gₚ]
+    rfl
+  obtain ⟨⟨r, hr⟩, heq⟩ := AlgHom.exists_cover_eq_of_eq _ _ _ _ f (.compRight R R σ) this
+  exact ⟨r, hr, σ, heq⟩
+
+lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Finite R B]
+    [Algebra.Etale R B] (f : A →ₐ[R] B) (p : PrimeSpectrum R) :
+    ∃ (S : Type u) (_ : CommRing S) (_ : Algebra R S),
+      Algebra.Etale R S ∧
+      p ∈ Set.range (PrimeSpectrum.comap (algebraMap R S)) ∧
+      (Algebra.TensorProduct.map (AlgHom.id S S) f).IsSplit := by
+  classical
+  wlog hA : Algebra.IsFiniteSplit R A
+  · obtain ⟨S, _, _, _, ⟨p, rfl⟩, hS⟩ := Algebra.IsFiniteSplit.exists_tensorProduct_of_etale p
+      (S := A)
+    obtain ⟨S', _, _, _, ⟨q, rfl⟩, hS'⟩ := this (Algebra.TensorProduct.map (.id S S) f) p hS
+    let _ : Algebra R S' := Algebra.compHom S' (algebraMap R S)
+    have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
+    refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
+    · exact .comp _ S _
+    · rwa [AlgHom.IsSplit.iff_of_isScalarTower S]
+  wlog hB : Algebra.IsFiniteSplit R B
+  · obtain ⟨S, _, _, _, ⟨p, rfl⟩, hS⟩ := Algebra.IsFiniteSplit.exists_tensorProduct_of_etale p
+      (S := B)
+    obtain ⟨S', _, _, _, ⟨q, rfl⟩, hS'⟩ := this
+      (A := S ⊗[R] A) (B := S ⊗[R] B) (R := S)
+      (Algebra.TensorProduct.map (.id S S) f) p inferInstance hS
+    let _ : Algebra R S' := Algebra.compHom S' (algebraMap R S)
+    have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
+    refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
+    · exact .comp _ S _
+    · rwa [AlgHom.IsSplit.iff_of_isScalarTower S]
+  obtain ⟨n, ⟨eA⟩⟩ := hA
+  obtain ⟨m, ⟨eB⟩⟩ := hB
+  let f' : (Fin n → R) →ₐ[R] Fin m → R := eB.toAlgHom.comp (f.comp eA.symm.toAlgHom)
+  obtain ⟨r, hr, σ, hσ⟩ := AlgHom.exists_cover_eq_compRight'' f' p.asIdeal
+  refine ⟨Localization.Away r, inferInstance, inferInstance, ?_, ?_, ?_⟩
+  · infer_instance
+  · change p ∈ Set.range (PrimeSpectrum.comap <| algebraMap R (Localization.Away r))
+    rwa [PrimeSpectrum.localization_away_comap_range _ r]
+  · let e := TensorProduct.piScalarRight R (Localization.Away r) (Localization.Away r) (Fin m)
+    apply AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _
+      (Algebra.TensorProduct.congr .refl eA |>.trans (Algebra.TensorProduct.piScalarRight ..))
+      (Algebra.TensorProduct.congr .refl eB |>.trans (Algebra.TensorProduct.piScalarRight ..)) σ
+    ext a : 2
+    simpa [Algebra.TensorProduct.piScalarRight_tmul, f', e] using congr(e ($(hσ) (1 ⊗ₜ eA a)))
+
+end

--- a/Mathlib/RingTheory/TotallySplit.lean
+++ b/Mathlib/RingTheory/TotallySplit.lean
@@ -214,23 +214,17 @@ section
 variable {R S A B : Type u} [CommRing R] [CommRing S] [CommRing A] [CommRing B]
   [Algebra R A] [Algebra R S] [Algebra R B]
 
-@[expose, simps!]
-def AlgHom.compRight {E F : Type*} (R S : Type*) [CommRing R] [CommRing S] [Algebra R S]
-    (σ : E → F) :
-    (F → S) →ₐ[R] E → S :=
-  Pi.algHom R _ (fun f ↦ Pi.evalAlgHom R _ (σ f))
-
 /-- A homomorphism of `R`-algebras `f : A →ₐ[R] B` is split if there exist `n`, `m` such
 that `A ≃ₐ[R] Fin n → R` and `B ≃ₐ[R] Fin m → R` and modulo these isomorphisms, `f` is induced
 by a reindexing `σ : Fin m → Fin n`. -/
-def AlgHom.IsSplit (f : A →ₐ[R] B) : Prop :=
+def AlgHom.IsFiniteSplit (f : A →ₐ[R] B) : Prop :=
   ∃ (n m : ℕ) (eA : A ≃ₐ[R] Fin n → R) (eB : B ≃ₐ[R] Fin m → R) (σ : Fin m → Fin n),
-    f = eB.symm.toAlgHom.comp ((AlgHom.compRight R R σ).comp eA)
+    f = eB.symm.toAlgHom.comp ((AlgHom.compRight R (fun _ ↦ R) σ).comp eA)
 
-lemma AlgHom.IsSplit.mk (f : A →ₐ[R] B) {E F : Type*} [_root_.Finite E] [_root_.Finite F]
+lemma AlgHom.IsFiniteSplit.mk (f : A →ₐ[R] B) {E F : Type*} [_root_.Finite E] [_root_.Finite F]
     (eA : A ≃ₐ[R] (E → R)) (eB : B ≃ₐ[R] (F → R)) (σ : F → E)
-    (h : eB.toAlgHom.comp f = (AlgHom.compRight R R σ).comp eA.toAlgHom) :
-    f.IsSplit := by
+    (h : eB.toAlgHom.comp f = (AlgHom.compRight R _ σ).comp eA.toAlgHom) :
+    f.IsFiniteSplit := by
   cases nonempty_fintype E
   cases nonempty_fintype F
   let eE := Fintype.equivFin E
@@ -245,31 +239,26 @@ lemma AlgHom.IsSplit.mk (f : A →ₐ[R] B) {E F : Type*} [_root_.Finite E] [_ro
     ext i
     simp [this, AlgHom.compRight]
 
-lemma AlgHom.compRight_apply' {E F : Type*} (R S : Type*) [CommRing R] [CommRing S] [Algebra R S]
-    (σ : E → F) (x : F → S) :
-    AlgHom.compRight R S σ x = fun i ↦ x (σ i) :=
-  rfl
-
 variable (S) in
-lemma AlgHom.IsSplit.tensorProductMap {f : A →ₐ[R] B} (hf : f.IsSplit) :
-    (Algebra.TensorProduct.map (.id S S) f).IsSplit := by
+lemma AlgHom.IsFiniteSplit.tensorProductMap {f : A →ₐ[R] B} (hf : f.IsFiniteSplit) :
+    (Algebra.TensorProduct.map (.id S S) f).IsFiniteSplit := by
   obtain ⟨n, m, eA, eB, σ, hf⟩ := hf
-  refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _
+  refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _
     ((Algebra.TensorProduct.congr .refl eA).trans (Algebra.TensorProduct.piScalarRight ..))
     ((Algebra.TensorProduct.congr .refl eB).trans (Algebra.TensorProduct.piScalarRight ..)) σ ?_
   ext a
   simp [hf]
 
 variable (S) in
-lemma AlgHom.IsSplit.iff_of_isScalarTower
+lemma AlgHom.IsFiniteSplit.iff_of_isScalarTower
     (T : Type u) [CommRing T] [Algebra R T] [Algebra S T]
     [IsScalarTower R S T] (f : A →ₐ[R] B) :
-    (Algebra.TensorProduct.map (.id T T) f).IsSplit ↔
+    (Algebra.TensorProduct.map (.id T T) f).IsFiniteSplit ↔
       (Algebra.TensorProduct.map (.id T T)
-        (Algebra.TensorProduct.map (.id S S) f)).IsSplit := by
+        (Algebra.TensorProduct.map (.id S S) f)).IsFiniteSplit := by
   refine ⟨?_, ?_⟩
   · rintro ⟨n, m, eA, eB, σ, hf⟩
-    refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+    refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eA
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).trans eB
     ext a i
@@ -278,7 +267,7 @@ lemma AlgHom.IsSplit.iff_of_isScalarTower
       AlgHom.coe_coe, Function.comp_apply] at this
     simp [this]
   · rintro ⟨n, m, eA, eB, σ, hf⟩
-    refine AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
+    refine AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _ ?_ ?_ σ ?_
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eA
     · exact (Algebra.TensorProduct.cancelBaseChange _ _ _ _ _).symm.trans eB
     ext a i
@@ -289,7 +278,7 @@ lemma AlgHom.IsSplit.iff_of_isScalarTower
 
 lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem {R E F : Type*} [_root_.Finite E]
     [Nonempty E] [CommRing R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
-    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R R σ := by
+    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R _ σ := by
   nontriviality R
   cases nonempty_fintype E
   classical
@@ -342,7 +331,7 @@ lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem {R E F : Type*} [_ro
 
 lemma AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem' {R E F : Type*} [_root_.Finite E]
     [CommRing R] [Nontrivial R] (H : ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1)
-    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R R σ := by
+    (f : (E → R) →ₐ[R] F → R) : ∃ (σ : F → E), f = .compRight R _ σ := by
   cases isEmpty_or_nonempty E
   · have : Subsingleton (F → R) := f.codomain_trivial
     cases isEmpty_or_nonempty F
@@ -369,7 +358,7 @@ lemma IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one {R : Type*} [CommRing R
 
 lemma RingHom.eq_compRight_of_isLocalHom {R E F : Type*} [_root_.Finite E] [CommRing R]
     (f : (E → R) →ₐ[R] F → R) [IsLocalRing R] :
-    ∃ (σ : F → E), f = .compRight R R σ := by
+    ∃ (σ : F → E), f = .compRight R _ σ := by
   apply AlgHom.eq_compRight_of_no_nontrivial_isIdempotentElem'
   intro e he
   rwa [IsLocalRing.isIdempotentElem_iff_eq_zero_or_eq_one] at he
@@ -441,7 +430,7 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
   let gₚ : (E → Localization.AtPrime p) →ₐ[Localization.AtPrime p] F → Localization.AtPrime p :=
     IsLocalization.mapₐ p.primeCompl (Localization.AtPrime p)
       (E → Localization.AtPrime p)
-      (F → Localization.AtPrime p) (.compRight R R σ)
+      (F → Localization.AtPrime p) (.compRight R (fun _ ↦ R) σ)
   have : fₚ = gₚ := by
     rw [hσ]
     apply AlgHom.coe_ringHom_injective
@@ -450,7 +439,7 @@ lemma AlgHom.exists_cover_eq_compRight'' {R : Type*} {E F : Type u}
     simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
       AlgHom.compRight_apply, IsLocalization.mapₐ_coe, IsLocalization.map_eq, gₚ]
     rfl
-  obtain ⟨⟨r, hr⟩, heq⟩ := AlgHom.exists_cover_eq_of_eq _ _ _ _ f (.compRight R R σ) this
+  obtain ⟨⟨r, hr⟩, heq⟩ := AlgHom.exists_cover_eq_of_eq _ _ _ _ f (.compRight R _ σ) this
   exact ⟨r, hr, σ, heq⟩
 
 lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Finite R B]
@@ -458,7 +447,7 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
     ∃ (S : Type u) (_ : CommRing S) (_ : Algebra R S),
       Algebra.Etale R S ∧
       p ∈ Set.range (PrimeSpectrum.comap (algebraMap R S)) ∧
-      (Algebra.TensorProduct.map (AlgHom.id S S) f).IsSplit := by
+      (Algebra.TensorProduct.map (AlgHom.id S S) f).IsFiniteSplit := by
   classical
   wlog hA : Algebra.IsFiniteSplit R A
   · obtain ⟨S, _, _, _, ⟨p, rfl⟩, hS⟩ := Algebra.IsFiniteSplit.exists_tensorProduct_of_etale p
@@ -468,7 +457,7 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
     have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
     refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
     · exact .comp _ S _
-    · rwa [AlgHom.IsSplit.iff_of_isScalarTower S]
+    · rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
   wlog hB : Algebra.IsFiniteSplit R B
   · obtain ⟨S, _, _, _, ⟨p, rfl⟩, hS⟩ := Algebra.IsFiniteSplit.exists_tensorProduct_of_etale p
       (S := B)
@@ -479,7 +468,7 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
     have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
     refine ⟨S', inferInstance, inferInstance, ?_, ⟨q, rfl⟩, ?_⟩
     · exact .comp _ S _
-    · rwa [AlgHom.IsSplit.iff_of_isScalarTower S]
+    · rwa [AlgHom.IsFiniteSplit.iff_of_isScalarTower S]
   obtain ⟨n, ⟨eA⟩⟩ := hA
   obtain ⟨m, ⟨eB⟩⟩ := hB
   let f' : (Fin n → R) →ₐ[R] Fin m → R := eB.toAlgHom.comp (f.comp eA.symm.toAlgHom)
@@ -489,7 +478,7 @@ lemma AlgHom.exists_isSplit [Module.Finite R A] [Algebra.Etale R A] [Module.Fini
   · change p ∈ Set.range (PrimeSpectrum.comap <| algebraMap R (Localization.Away r))
     rwa [PrimeSpectrum.localization_away_comap_range _ r]
   · let e := TensorProduct.piScalarRight R (Localization.Away r) (Localization.Away r) (Fin m)
-    apply AlgHom.IsSplit.mk (E := Fin n) (F := Fin m) _
+    apply AlgHom.IsFiniteSplit.mk (E := Fin n) (F := Fin m) _
       (Algebra.TensorProduct.congr .refl eA |>.trans (Algebra.TensorProduct.piScalarRight ..))
       (Algebra.TensorProduct.congr .refl eB |>.trans (Algebra.TensorProduct.piScalarRight ..)) σ
     ext a : 2


### PR DESCRIPTION
From Pi1.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #38649 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
