### PR TITLE
[Merged by Bors] - feat(SimpleGraph): add universal vertex predicate

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1043,6 +1043,9 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
 @[simp] lemma neighborSet_eq_compl_singleton : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by
   grind [insert_neighborSet_eq_univ, notMem_neighborSet_self]
 
+protected alias ⟨IsUniversal.of_neighborSet_eq, IsUniversal.neighborSet_eq⟩ :=
+  neighborSet_eq_compl_singleton
+
 @[simp]
 theorem IsUniversal.of_subsingleton [Subsingleton V] : G.IsUniversal v :=
   fun _ hne ↦ False.elim <| hne (Subsingleton.elim ..)

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1033,8 +1033,20 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
   simp [IsUniversal, Set.ext_iff]
   grind
 
-@[simp] lemma neighborSet_eq_univ_diff : G.neighborSet v = Set.univ \ {v} ↔ G.IsUniversal v := by
+@[simp] lemma neighborSet_eq_compl : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by
   rw [← insert_neighborSet_eq_univ]
   grind [notMem_neighborSet_self]
+
+@[simp]
+theorem IsUniversal.of_subsingleton [Subsingleton V] (G : SimpleGraph V) (v : V) :
+    G.IsUniversal v :=
+  fun _ hne ↦ False.elim <| hne (of_decide_eq_true rfl)
+
+theorem eq_top_iff_forall_isUniversal : G = ⊤ ↔ ∀ v, G.IsUniversal v := by
+  simp [eq_top_iff_forall_ne_adj, IsUniversal]
+
+@[simp]
+theorem isUniversal_top : IsUniversal ⊤ v :=
+  (eq_top_iff_forall_isUniversal _).mp rfl _
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1055,14 +1055,15 @@ theorem IsIsolated.not_isUniversal [Nontrivial V] {v : V} (h : G.IsIsolated v) (
   exact h.not_isIsolated v
 
 variable {G} in
-theorem IsUniversal.compl_isIsolated {v : V} (h : G.IsIsolated v) : Gᶜ.IsUniversal v := by
+theorem IsUniversal.of_isIsolated_compl {v : V} (h : Gᶜ.IsIsolated v) : G.IsUniversal v := by
   intro x hx
-  simp [hx, h x]
+  simpa [hx] using h x
 
 variable {G} in
-theorem IsIsolated.compl_isUniversal {v : V} (h : G.IsUniversal v) : Gᶜ.IsIsolated v := by
+theorem IsIsolated.of_isUniversal_compl {v : V} (h : Gᶜ.IsUniversal v) : G.IsIsolated v := by
   intro x
-  grind [compl_adj, @h x]
+  have := @h x
+  grind [compl_adj, Adj.ne]
 
 theorem eq_top_iff_forall_isUniversal : G = ⊤ ↔ ∀ v, G.IsUniversal v := by
   simp [eq_top_iff_forall_ne_adj, IsUniversal]

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1030,7 +1030,7 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
 
 @[simp] lemma insert_neighborSet_eq_univ :
     insert v (G.neighborSet v) = Set.univ ↔ G.IsUniversal v := by
-  simp [IsUniversal, Set.ext_iff]
+  simp only [Set.ext_iff, Set.mem_insert_iff, mem_neighborSet, IsUniversal]
   grind
 
 @[simp] lemma neighborSet_eq_compl : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1019,7 +1019,7 @@ theorem Adj.not_isIsolated_right (h : G.Adj u v) : ¬G.IsIsolated v :=
   h.symm.not_isIsolated_left
 
 @[simp]
-theorem isIsolated_bot : IsIsolated ⊥ v :=
+protected theorem IsIsolated.bot : IsIsolated ⊥ v :=
   neighborSet_eq_empty _ |>.mp neighborSet_bot
 
 theorem eq_bot_iff_isIsolated : G = ⊥ ↔ ∀ v, G.IsIsolated v := by
@@ -1033,13 +1033,14 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
   simp only [Set.ext_iff, Set.mem_insert_iff, mem_neighborSet, IsUniversal]
   grind
 
-@[simp] lemma neighborSet_eq_compl : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by
+@[simp] lemma neighborSet_eq_compl_singleton : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by
   grind [insert_neighborSet_eq_univ, notMem_neighborSet_self]
 
 @[simp]
 theorem IsUniversal.of_subsingleton [Subsingleton V] (v : V) : G.IsUniversal v :=
   fun _ hne ↦ False.elim <| hne (Subsingleton.elim ..)
 
+variable {G} in
 theorem IsUniversal.not_isIsolated [Nontrivial V] {v : V} (h : G.IsUniversal v) (w : V) :
     ¬G.IsIsolated w := by
   by_cases h' : v = w
@@ -1047,16 +1048,27 @@ theorem IsUniversal.not_isIsolated [Nontrivial V] {v : V} (h : G.IsUniversal v) 
     exact h' ▸ Adj.not_isIsolated_left (h hu.symm)
   · exact Adj.not_isIsolated_right (h h')
 
-theorem IsUniversal.support_eq [Nontrivial V] {v : V} (h : G.IsUniversal v) :
-    G.support = .univ := by
-  refine Set.eq_univ_iff_forall.mpr fun x ↦ mem_support_iff_not_isIsolated _ |>.mpr ?_
-  exact not_isIsolated G h x
+variable {G} in
+theorem IsIsolated.not_isUniversal [Nontrivial V] {v : V} (h : G.IsIsolated v) (w : V) :
+    ¬G.IsUniversal w := by
+  contrapose! h
+  exact h.not_isIsolated v
+
+variable {G} in
+theorem IsUniversal.compl_isIsolated {v : V} (h : G.IsIsolated v) : Gᶜ.IsUniversal v := by
+  intro x hx
+  simp [hx, h x]
+
+variable {G} in
+theorem IsIsolated.compl_isUniversal {v : V} (h : G.IsUniversal v) : Gᶜ.IsIsolated v := by
+  intro x
+  grind [compl_adj, @h x]
 
 theorem eq_top_iff_forall_isUniversal : G = ⊤ ↔ ∀ v, G.IsUniversal v := by
   simp [eq_top_iff_forall_ne_adj, IsUniversal]
 
 @[simp]
-theorem isUniversal_top : IsUniversal ⊤ v :=
+protected theorem IsUniversal.top : IsUniversal ⊤ v :=
   (eq_top_iff_forall_isUniversal _).mp rfl _
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1026,7 +1026,7 @@ theorem eq_bot_iff_isIsolated : G = ⊥ ↔ ∀ v, G.IsIsolated v := by
   simp [eq_bot_iff_forall_not_adj, ← neighborSet_eq_empty, Set.eq_empty_iff_forall_notMem]
 
 /-- A vertex in a graph is universal if it's adjacent to every other vertex. -/
-def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ w, v ≠ w → G.Adj v w
+def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G.Adj v w
 
 @[simp] lemma insert_neighborSet_eq_univ :
     insert v (G.neighborSet v) = Set.univ ↔ G.IsUniversal v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1022,8 +1022,15 @@ theorem Adj.not_isIsolated_right (h : G.Adj u v) : ¬G.IsIsolated v :=
 protected theorem IsIsolated.bot : IsIsolated ⊥ v :=
   neighborSet_eq_empty _ |>.mp neighborSet_bot
 
+@[deprecated (since := "2026-06-19")]
+alias isIsolated_bot := IsIsolated.bot
+
 theorem eq_bot_iff_isIsolated : G = ⊥ ↔ ∀ v, G.IsIsolated v := by
   simp [eq_bot_iff_forall_not_adj, ← neighborSet_eq_empty, Set.eq_empty_iff_forall_notMem]
+
+section IsUniversal
+
+variable {G}
 
 /-- A vertex in a graph is universal if it's adjacent to every other vertex. -/
 def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G.Adj v w
@@ -1037,39 +1044,44 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
   grind [insert_neighborSet_eq_univ, notMem_neighborSet_self]
 
 @[simp]
-theorem IsUniversal.of_subsingleton [Subsingleton V] (v : V) : G.IsUniversal v :=
+theorem IsUniversal.of_subsingleton [Subsingleton V] : G.IsUniversal v :=
   fun _ hne ↦ False.elim <| hne (Subsingleton.elim ..)
 
-variable {G} in
-theorem IsUniversal.not_isIsolated [Nontrivial V] {v : V} (h : G.IsUniversal v) (w : V) :
+theorem IsUniversal.not_isIsolated [Nontrivial V] (h : G.IsUniversal v) (w : V) :
     ¬G.IsIsolated w := by
   by_cases h' : v = w
   · obtain ⟨u, hu⟩ := exists_ne v
     exact h' ▸ Adj.not_isIsolated_left (h hu.symm)
   · exact Adj.not_isIsolated_right (h h')
 
-variable {G} in
-theorem IsIsolated.not_isUniversal [Nontrivial V] {v : V} (h : G.IsIsolated v) (w : V) :
+theorem IsIsolated.not_isUniversal [Nontrivial V] (h : G.IsIsolated v) (w : V) :
     ¬G.IsUniversal w := by
   contrapose! h
   exact h.not_isIsolated v
 
-variable {G} in
-theorem IsUniversal.of_isIsolated_compl {v : V} (h : Gᶜ.IsIsolated v) : G.IsUniversal v := by
-  intro x hx
-  simpa [hx] using h x
+@[simp]
+theorem isUniversal_compl_iff_isIsolated : Gᶜ.IsUniversal v ↔ G.IsIsolated v := by
+  refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩
+  · simpa [hx] using h hx.ne
+  · simpa [hx] using h x
 
-variable {G} in
-theorem IsIsolated.of_isUniversal_compl {v : V} (h : Gᶜ.IsUniversal v) : G.IsIsolated v := by
-  intro x
-  have := @h x
-  grind [compl_adj, Adj.ne]
+alias ⟨IsIsolated.of_isUniversal_compl, _⟩ := isUniversal_compl_iff_isIsolated
+
+@[simp]
+theorem isIsolated_compl_iff_isUniversal : Gᶜ.IsIsolated v ↔ G.IsUniversal v := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simpa using isUniversal_compl_iff_isIsolated.mpr h
+  · exact isUniversal_compl_iff_isIsolated.mp (by simpa)
+
+alias ⟨IsUniversal.of_isIsolated_compl, _⟩ := isIsolated_compl_iff_isUniversal
 
 theorem eq_top_iff_forall_isUniversal : G = ⊤ ↔ ∀ v, G.IsUniversal v := by
   simp [eq_top_iff_forall_ne_adj, IsUniversal]
 
 @[simp]
 protected theorem IsUniversal.top : IsUniversal ⊤ v :=
-  (eq_top_iff_forall_isUniversal _).mp rfl _
+  eq_top_iff_forall_isUniversal.mp rfl v
+
+end IsUniversal
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1034,8 +1034,7 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
   grind
 
 @[simp] lemma neighborSet_eq_compl : G.neighborSet v = {v}ᶜ ↔ G.IsUniversal v := by
-  rw [← insert_neighborSet_eq_univ]
-  grind [notMem_neighborSet_self]
+  grind [insert_neighborSet_eq_univ, notMem_neighborSet_self]
 
 @[simp]
 theorem IsUniversal.of_subsingleton [Subsingleton V] (G : SimpleGraph V) (v : V) :

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1025,4 +1025,16 @@ theorem isIsolated_bot : IsIsolated ⊥ v :=
 theorem eq_bot_iff_isIsolated : G = ⊥ ↔ ∀ v, G.IsIsolated v := by
   simp [eq_bot_iff_forall_not_adj, ← neighborSet_eq_empty, Set.eq_empty_iff_forall_notMem]
 
+/-- A vertex in a graph is universal if it's adjacent to every other vertex. -/
+def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ w, v ≠ w → G.Adj v w
+
+@[simp] lemma insert_neighborSet_eq_univ :
+    insert v (G.neighborSet v) = Set.univ ↔ G.IsUniversal v := by
+  simp [IsUniversal, Set.ext_iff]
+  grind
+
+@[simp] lemma neighborSet_eq_univ_diff : G.neighborSet v = Set.univ \ {v} ↔ G.IsUniversal v := by
+  rw [← insert_neighborSet_eq_univ]
+  grind [notMem_neighborSet_self]
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -1037,9 +1037,20 @@ def IsUniversal (G : SimpleGraph V) (v : V) : Prop := ∀ ⦃w⦄, v ≠ w → G
   grind [insert_neighborSet_eq_univ, notMem_neighborSet_self]
 
 @[simp]
-theorem IsUniversal.of_subsingleton [Subsingleton V] (G : SimpleGraph V) (v : V) :
-    G.IsUniversal v :=
-  fun _ hne ↦ False.elim <| hne (of_decide_eq_true rfl)
+theorem IsUniversal.of_subsingleton [Subsingleton V] (v : V) : G.IsUniversal v :=
+  fun _ hne ↦ False.elim <| hne (Subsingleton.elim ..)
+
+theorem IsUniversal.not_isIsolated [Nontrivial V] {v : V} (h : G.IsUniversal v) (w : V) :
+    ¬G.IsIsolated w := by
+  by_cases h' : v = w
+  · obtain ⟨u, hu⟩ := exists_ne v
+    exact h' ▸ Adj.not_isIsolated_left (h hu.symm)
+  · exact Adj.not_isIsolated_right (h h')
+
+theorem IsUniversal.support_eq [Nontrivial V] {v : V} (h : G.IsUniversal v) :
+    G.support = .univ := by
+  refine Set.eq_univ_iff_forall.mpr fun x ↦ mem_support_iff_not_isIsolated _ |>.mpr ?_
+  exact not_isIsolated G h x
 
 theorem eq_top_iff_forall_isUniversal : G = ⊤ ↔ ∀ v, G.IsUniversal v := by
   simp [eq_top_iff_forall_ne_adj, IsUniversal]

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -380,7 +380,8 @@ theorem connected_or_preconnected_compl : G.Connected ∨ Gᶜ.Preconnected := b
 theorem connected_or_connected_compl [Nonempty V] : G.Connected ∨ Gᶜ.Connected :=
   G.connected_or_preconnected_compl.elim .inl (.inr ⟨·⟩)
 
-lemma Connected.of_isUniversal (v : V) (h : G.IsUniversal v) : G.Connected := by
+variable {G v} in
+lemma Connected.of_isUniversal (h : G.IsUniversal v) : G.Connected := by
   refine connected_iff _ |>.mpr ⟨fun u w ↦ ?_, ⟨v⟩⟩
   exact (Reachable.of_isUniversal u h).symm.trans (Reachable.of_isUniversal w h)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -197,6 +197,12 @@ lemma Reachable.degree_pos_right {G : SimpleGraph V} {u v : V} [Fintype (G.neigh
     (huv : u ≠ v) (hreach : G.Reachable u v) : 0 < G.degree v :=
   hreach.symm.degree_pos_left huv.symm
 
+lemma Reachable.of_isUniversal {G : SimpleGraph V} {u : V} (v : V) (h : G.IsUniversal u) :
+    G.Reachable u v := by
+  by_cases! h' : u = v
+  · exact h' ▸ Reachable.rfl
+  · exact (h h').reachable
+
 lemma not_reachable_of_neighborSet_left_eq_empty {G : SimpleGraph V} {u v : V} (huv : u ≠ v)
     (hu : G.neighborSet u = ∅) : ¬G.Reachable u v :=
   (Reachable.nonempty_neighborSet_left huv).mt (Set.not_nonempty_iff_eq_empty.mpr hu)
@@ -375,11 +381,8 @@ theorem connected_or_connected_compl [Nonempty V] : G.Connected ∨ Gᶜ.Connect
   G.connected_or_preconnected_compl.elim .inl (.inr ⟨·⟩)
 
 lemma Connected.of_isUniversal (v : V) (h : G.IsUniversal v) : G.Connected := by
-  have (u : V) : G.Reachable v u := by
-    by_cases! h' : u = v
-    · exact h' ▸ Reachable.rfl
-    · exact (h h'.symm).reachable
-  exact connected_iff _ |>.mpr ⟨fun u w ↦ (this u).symm.trans (this w), ⟨v⟩⟩
+  refine connected_iff _ |>.mpr ⟨fun u w ↦ ?_, ⟨v⟩⟩
+  exact (Reachable.of_isUniversal u h).symm.trans (Reachable.of_isUniversal w h)
 
 /-- The quotient of `V` by the `SimpleGraph.Reachable` relation gives the connected
 components of a graph. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -378,7 +378,7 @@ lemma Connected.of_isUniversal (v : V) (h : G.IsUniversal v) : G.Connected := by
   have (u : V) : G.Reachable v u := by
     by_cases! h' : u = v
     · exact h' ▸ Reachable.rfl
-    · exact Adj.reachable (h u h'.symm)
+    · exact Adj.reachable (h h'.symm)
   exact connected_iff _ |>.mpr ⟨fun u w ↦ (this u).symm.trans (this w), ⟨v⟩⟩
 
 /-- The quotient of `V` by the `SimpleGraph.Reachable` relation gives the connected

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -374,6 +374,13 @@ theorem connected_or_preconnected_compl : G.Connected ∨ Gᶜ.Preconnected := b
 theorem connected_or_connected_compl [Nonempty V] : G.Connected ∨ Gᶜ.Connected :=
   G.connected_or_preconnected_compl.elim .inl (.inr ⟨·⟩)
 
+lemma Connected.of_isUniversal (v : V) (h : G.IsUniversal v) : G.Connected := by
+  have (u : V) : G.Reachable v u := by
+    by_cases! h' : u = v
+    · exact h' ▸ Reachable.rfl
+    · exact Adj.reachable (h u h'.symm)
+  exact connected_iff _ |>.mpr ⟨fun u w ↦ (this u).symm.trans (this w), ⟨v⟩⟩
+
 /-- The quotient of `V` by the `SimpleGraph.Reachable` relation gives the connected
 components of a graph. -/
 def ConnectedComponent := Quot G.Reachable

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -378,7 +378,7 @@ lemma Connected.of_isUniversal (v : V) (h : G.IsUniversal v) : G.Connected := by
   have (u : V) : G.Reachable v u := by
     by_cases! h' : u = v
     · exact h' ▸ Reachable.rfl
-    · exact Adj.reachable (h h'.symm)
+    · exact (h h'.symm).reachable
   exact connected_iff _ |>.mpr ⟨fun u w ↦ (this u).symm.trans (this w), ⟨v⟩⟩
 
 /-- The quotient of `V` by the `SimpleGraph.Reachable` relation gives the connected

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -549,7 +549,7 @@ theorem card_commonNeighbors_top [DecidableEq V] {v w : V} (h : v ≠ w) :
 
 @[simp] lemma insert_neighborFinset_eq_univ [DecidableEq V] [DecidableRel G.Adj] (v : V) :
     insert v (G.neighborFinset v) = univ ↔ G.IsUniversal v := by
-  simp [IsUniversal, Finset.ext_iff]
+  simp only [Finset.ext_iff, mem_insert, mem_neighborFinset, IsUniversal]
   grind
 
 @[simp] lemma neighborFinset_eq_erase_univ [DecidableEq V] [DecidableRel G.Adj] (v : V) :

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -554,14 +554,13 @@ theorem card_commonNeighbors_top [DecidableEq V] {v w : V} (h : v ≠ w) :
 
 @[simp] lemma neighborFinset_eq_erase_univ [DecidableEq V] [DecidableRel G.Adj] (v : V) :
     G.neighborFinset v = univ.erase v ↔ G.IsUniversal v := by
-  rw [← insert_neighborFinset_eq_univ]
-  grind [notMem_neighborFinset_self]
+  grind [insert_neighborFinset_eq_univ, notMem_neighborFinset_self]
 
 lemma degree_eq_card_sub_one [DecidableRel G.Adj] (v : V) :
     G.degree v = Fintype.card V - 1 ↔ G.IsUniversal v := by
   classical
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · refine (G.insert_neighborFinset_eq_univ v).mp <| (Finset.card_eq_iff_eq_univ _).mp ?_
+  · rw [← G.insert_neighborFinset_eq_univ v, ← Finset.card_eq_iff_eq_univ]
     simp [h, Nat.sub_add_cancel <| Fintype.card_pos_iff.mpr ⟨v⟩]
   · simp [← card_neighborFinset_eq_degree, (G.neighborFinset_eq_erase_univ v).mpr h]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -547,6 +547,28 @@ theorem card_commonNeighbors_top [DecidableEq V] {v w : V} (h : v ≠ w) :
     Fintype.card (commonNeighbors ⊤ v w) = Fintype.card V - 2 := by
   simp [commonNeighbors_top_eq, ← Set.toFinset_card, Finset.card_sdiff, h]
 
+@[simp] lemma insert_neighborFinset_eq_univ [DecidableEq V] [DecidableRel G.Adj] (v : V) :
+    insert v (G.neighborFinset v) = univ ↔ G.IsUniversal v := by
+  simp [IsUniversal, Finset.ext_iff]
+  grind
+
+@[simp] lemma neighborFinset_eq_erase_univ [DecidableEq V] [DecidableRel G.Adj] (v : V) :
+    G.neighborFinset v = univ.erase v ↔ G.IsUniversal v := by
+  rw [← insert_neighborFinset_eq_univ]
+  grind [notMem_neighborFinset_self]
+
+lemma degree_eq_card_sub_one [DecidableRel G.Adj] (v : V) :
+    G.degree v = Fintype.card V - 1 ↔ G.IsUniversal v := by
+  classical
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · refine (G.insert_neighborFinset_eq_univ v).mp <| (Finset.card_eq_iff_eq_univ _).mp ?_
+    simp [h, Nat.sub_add_cancel <| Fintype.card_pos_iff.mpr ⟨v⟩]
+  · simp [← card_neighborFinset_eq_degree, (G.neighborFinset_eq_erase_univ v).mpr h]
+
+lemma degree_lt_card_sub_one [DecidableRel G.Adj] (v : V) :
+    G.degree v < Fintype.card V - 1 ↔ ¬ G.IsUniversal v := by
+  grind [degree_eq_card_sub_one, Nat.le_sub_one_of_lt <| G.degree_lt_card_verts v]
+
 end Finite
 
 namespace Iso

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -556,6 +556,7 @@ theorem card_commonNeighbors_top [DecidableEq V] {v w : V} (h : v ≠ w) :
     G.neighborFinset v = univ.erase v ↔ G.IsUniversal v := by
   grind [insert_neighborFinset_eq_univ, notMem_neighborFinset_self]
 
+@[simp]
 lemma degree_eq_card_sub_one [DecidableRel G.Adj] (v : V) :
     G.degree v = Fintype.card V - 1 ↔ G.IsUniversal v := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -43,6 +43,10 @@ instance [DecidableEq V] (r : V) : DecidableRel (starGraph r).Adj :=
 lemma starGraph_adj {r x y : V} : (starGraph r).Adj x y ↔ x ≠ y ∧ (x = r ∨ y = r) := by
   simp [starGraph, fromRel]
 
+lemma starGraph_isUniversal {r : V} : (starGraph r).IsUniversal r := by
+  intro _ _
+  simpa
+
 /-- On (starGraph r), r is adjacent to v iff v ≠ r. -/
 lemma starGraph_adj_center_iff {r v : V} : (starGraph r).Adj r v ↔ r ≠ v := by simp
 
@@ -52,12 +56,8 @@ lemma starGraph_center_adj {r v : V} (h : r ≠ v) : (starGraph r).Adj r v :=
 lemma starGraph_center_adj' {r v : V} (h : r ≠ v) : (starGraph r).Adj v r :=
   (starGraph_center_adj h).symm
 
-lemma connected_starGraph (r : V) : (starGraph r).Connected := by
-  have (v : V) : (starGraph r).Reachable r v := by
-    by_cases! h : r = v
-    · exact h ▸ Reachable.rfl
-    · exact (starGraph_center_adj h).reachable
-  exact connected_iff _ |>.mpr ⟨fun u v ↦ (this u).symm.trans (this v), ⟨r⟩⟩
+lemma connected_starGraph (r : V) : (starGraph r).Connected :=
+  Connected.of_isUniversal _ _ starGraph_isUniversal
 
 lemma isAcyclic_starGraph (r : V) : (starGraph r).IsAcyclic := by
   refine isAcyclic_iff_forall_adj_isBridge.mpr fun v w hadj ↦ ?_
@@ -80,7 +80,7 @@ lemma degree_starGraph_of_ne_center [Fintype V] [DecidableEq V] {r v : V} (h : v
 
 /-- The center vertex of a starGraph has degree (card V) - 1. -/
 lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
-    (starGraph r).degree r = Fintype.card V - 1 := by
-  simp [degree, neighborFinset_eq_filter (starGraph r), starGraph_adj, Finset.univ.filter_ne r]
+    (starGraph r).degree r = Fintype.card V - 1 :=
+  degree_eq_card_sub_one .. |>.mpr starGraph_isUniversal
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -44,7 +44,7 @@ lemma starGraph_adj {r x y : V} : (starGraph r).Adj x y ↔ x ≠ y ∧ (x = r �
   simp [starGraph, fromRel]
 
 @[simp]
-lemma starGraph_isUniversal {r : V} : (starGraph r).IsUniversal r := by
+lemma isUniversal_starGraph_self {r : V} : (starGraph r).IsUniversal r := by
   intro _ _
   simpa
 
@@ -58,7 +58,7 @@ lemma starGraph_center_adj' {r v : V} (h : r ≠ v) : (starGraph r).Adj v r :=
   (starGraph_center_adj h).symm
 
 lemma connected_starGraph (r : V) : (starGraph r).Connected :=
-  Connected.of_isUniversal _ _ starGraph_isUniversal
+  .of_isUniversal isUniversal_starGraph_self
 
 lemma isAcyclic_starGraph (r : V) : (starGraph r).IsAcyclic := by
   refine isAcyclic_iff_forall_adj_isBridge.mpr fun v w hadj ↦ ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Star.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Star.lean
@@ -43,6 +43,7 @@ instance [DecidableEq V] (r : V) : DecidableRel (starGraph r).Adj :=
 lemma starGraph_adj {r x y : V} : (starGraph r).Adj x y ↔ x ≠ y ∧ (x = r ∨ y = r) := by
   simp [starGraph, fromRel]
 
+@[simp]
 lemma starGraph_isUniversal {r : V} : (starGraph r).IsUniversal r := by
   intro _ _
   simpa
@@ -80,7 +81,7 @@ lemma degree_starGraph_of_ne_center [Fintype V] [DecidableEq V] {r v : V} (h : v
 
 /-- The center vertex of a starGraph has degree (card V) - 1. -/
 lemma degree_starGraph_center [Fintype V] [DecidableEq V] {r : V} :
-    (starGraph r).degree r = Fintype.card V - 1 :=
-  degree_eq_card_sub_one .. |>.mpr starGraph_isUniversal
+    (starGraph r).degree r = Fintype.card V - 1 := by
+  simp
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -306,9 +306,9 @@ lemma exists_isTutteViolator (h : ∀ (M : G.Subgraph), ¬M.IsPerfectMatching)
       simp [hnadjxb, Subtype.val_injective.ne <| Subtype.val_injective.ne hnxb])
     obtain ⟨_, hG2⟩ := hMaximal _ <| left_lt_sup.mpr (by
       rwa [edge_le_iff (v := a.1.1) (w := c), not_or])
-    have hcnex : c ≠ x.val.val := by rintro rfl; exact hc.2 hxa.symm
+    have hcnex : x.val.val ≠ c := by rintro rfl; exact hc.2 hxa.symm
     obtain ⟨Mcon, hMcon⟩ := tutte_exists_isPerfectMatching_of_near_matchings hxa
-      hxb hnadjxb (fun hadj ↦ hc.2 hadj) (by lia) hcnex.symm hc.1 hbnec hG1 hG2
+      hxb hnadjxb (fun hadj ↦ hc.2 hadj) (by lia) hcnex hc.1 hbnec hG1 hG2
     exact hMatchingFree Mcon hMcon
 
 /-- **Tutte's theorem**

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -298,17 +298,17 @@ lemma exists_isTutteViolator (h : ∀ (M : G.Subgraph), ¬M.IsPerfectMatching)
       Subgraph.verts_top, comap_adj, Function.Embedding.coe_subtype,
       Subgraph.coe_adj, Subgraph.induce_adj, Subtype.coe_prop, Subgraph.top_adj, true_and]
       at hxa hxb hnadjxb
-    obtain ⟨c, hc⟩ : ∃ (c : V), (a : V) ≠ c ∧ ¬ Gmax.Adj c a := by
-      simpa [universalVerts] using a.1.2.2
-    have hbnec : b.val.val ≠ c := by rintro rfl; exact hc.2 hxb.symm
+    obtain ⟨c, hc⟩ : ∃ (c : V), (a : V) ≠ c ∧ ¬ Gmax.Adj a c := by
+      simpa [universalVerts, IsUniversal] using a.1.2.2
+    have hbnec : b.val.val ≠ c := by rintro rfl; exact hc.2 hxb
     obtain ⟨_, hG1⟩ := hMaximal _ <| left_lt_sup.mpr (by
       rw [edge_le_iff (v := x.1.1) (w := b.1.1)]
       simp [hnadjxb, Subtype.val_injective.ne <| Subtype.val_injective.ne hnxb])
     obtain ⟨_, hG2⟩ := hMaximal _ <| left_lt_sup.mpr (by
-      rwa [edge_le_iff (v := a.1.1) (w := c), adj_comm, not_or])
-    have hcnex : c ≠ x.val.val := by rintro rfl; exact hc.2 hxa
+      rwa [edge_le_iff (v := a.1.1) (w := c), not_or])
+    have hcnex : c ≠ x.val.val := by rintro rfl; exact hc.2 hxa.symm
     obtain ⟨Mcon, hMcon⟩ := tutte_exists_isPerfectMatching_of_near_matchings hxa
-      hxb hnadjxb (fun hadj ↦ hc.2 hadj.symm) (by lia) hcnex.symm hc.1 hbnec hG1 hG2
+      hxb hnadjxb (fun hadj ↦ hc.2 hadj) (by lia) hcnex.symm hc.1 hbnec hG1 hG2
     exact hMatchingFree Mcon hMcon
 
 /-- **Tutte's theorem**

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -294,7 +294,7 @@ lemma exists_isTutteViolator (h : ∀ (M : G.Subgraph), ¬M.IsPerfectMatching)
     obtain ⟨p, hp⟩ := Reachable.exists_path_of_dist (K.connected_toSimpleGraph x y)
     obtain ⟨x, a, b, hxa, hxb, hnadjxb, hnxb⟩ := Walk.exists_adj_adj_not_adj_ne hp.2
       (p.reachable.one_lt_dist_of_ne_of_not_adj hxy.1 hxy.2)
-    simp only [ConnectedComponent.toSimpleGraph, deleteUniversalVerts, universalVerts, ne_eq,
+    simp only [ConnectedComponent.toSimpleGraph, deleteUniversalVerts, universalVerts,
       Subgraph.verts_top, comap_adj, Function.Embedding.coe_subtype,
       Subgraph.coe_adj, Subgraph.induce_adj, Subtype.coe_prop, Subgraph.top_adj, true_and]
       at hxa hxb hnadjxb

--- a/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/UniversalVerts.lean
@@ -33,10 +33,10 @@ variable {V : Type*} {G : SimpleGraph V}
 /--
 The set of vertices that are connected to all other vertices.
 -/
-def universalVerts (G : SimpleGraph V) : Set V := {v : V | ∀ ⦃w⦄, v ≠ w → G.Adj w v}
+def universalVerts (G : SimpleGraph V) : Set V := {v : V | G.IsUniversal v}
 
 lemma isClique_universalVerts (G : SimpleGraph V) : G.IsClique G.universalVerts :=
-  fun _ _ _ hy hxy ↦ hy hxy.symm
+  fun _ hx _ _ hxy ↦ hx hxy
 
 /--
 The subgraph of `G` with the universal vertices removed.
@@ -53,7 +53,7 @@ lemma Subgraph.IsMatching.exists_of_universalVerts [Finite V] {s : Set V}
   obtain ⟨f⟩ : Nonempty (s ≃ t) := by
     rw [← Cardinal.eq, ← t.cast_ncard t.toFinite, ← s.cast_ncard s.toFinite, ht.2]
   letI hd := Set.disjoint_of_subset_left ht.1 h
-  have hadj (v : s) : G.Adj v (f v) := ht.1 (f v).2 (hd.ne_of_mem (f v).2 v.2)
+  have hadj (v : s) : G.Adj v (f v) := ht.1 (f v).2 (hd.ne_of_mem (f v).2 v.2) |>.symm
   exact Subgraph.IsMatching.exists_of_disjoint_sets_of_equiv hd.symm f hadj
 
 lemma disjoint_image_val_universalVerts (s : Set G.deleteUniversalVerts.verts) :


### PR DESCRIPTION
Add the predicate `G.IsUniversal v` to indicate that `v` is a universal vertex, i.e. connected to all other vertices in `G`. This matches the recently added `G.IsIsolated v` predicate for isolated vertices.

Co-authored-by: Justin Lai <justsoft.jsoft@gmail.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
