### PR TITLE
[Merged by Bors] - chore(scripts): add module-level set_option helpers and simp-arg / long-line fixers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -146,6 +146,28 @@ behaviour. They share a common DAG traversal library that parallelises work in i
   falls back to one-at-a-time removal.
   Usage: `python3 scripts/rm_set_option.py [--option NAME] [--dry-run] [--max-workers N] [--files FILE ...] [--resume]`
 
+- `add_module_set_option.py`, `rm_module_set_option.py`
+  File-level variants of `add_set_option.py` / `rm_set_option.py`: they insert or remove a
+  `set_option ...` at the top of the file rather than scoped to individual declarations.
+
+- `fix_nonlocal_set_option.py`
+  Helper that bisects the import DAG to find the upstream file whose missing
+  `set_option ...` is causing a downstream failure — useful when the direct fix is in a
+  different module than the one reporting the error.
+
+- `fix_unused_simp_args.py`
+  Parses `lake build` warnings of the form `This simp argument is unused: X` and removes `X`
+  from the corresponding `simp`/`simp only` call. For `← X` arguments it rewrites to `- X`
+  instead, because the `←` form has side effects on the simp set even when the rewrite itself
+  is unused.
+  Usage: `lake build 2>&1 | scripts/fix_unused_simp_args.py`
+
+- `fix_long_lines.py`
+  Breaks a too-long line at the last comma before column 100 and indents the continuation.
+  Takes `path:line` pairs as arguments; intended as a follow-up to scripts that rewrite simp
+  lists (which occasionally leave lines over the 100-char limit).
+  Usage: `scripts/fix_long_lines.py path:line ...`
+
 **CI workflow**
 - `lake-build-with-retry.sh`
   Runs `lake build` on a target until `lake build --no-build` succeeds. Used in the main build workflows.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,13 +106,20 @@ file used by the library's own linters.
 These scripts help with testing Lean PRs that change backward-compatibility option
 behaviour. They share a common DAG traversal library that parallelises work in import-graph order.
 
-To use these scripts outside mathlib, copy `dag_traversal.py`, `set_option_utils.py`,
-and the script(s) you need into a `scripts/` directory in your project, then run from
-the project root.  `fix_nonlocal_set_option.py` additionally requires
-`add_module_set_option.py` and `rm_module_set_option.py`.  Pass `--directories <root>`
-if your source files aren't directly under the project root.  Module-name derivation
-assumes a Mathlib-style layout where `Foo/Bar.lean` corresponds to module `Foo.Bar`
-(no `srcDir` indirection).
+***Using these scripts in a downstream project.***  Each script depends on sibling
+files in the same directory.  Minimally:
+
+1. Copy the script you want plus `dag_traversal.py` and `set_option_utils.py` into
+   a `scripts/` directory in your project.  `fix_nonlocal_set_option.py` additionally
+   requires `add_module_set_option.py` and `rm_module_set_option.py`.
+2. From the project root, run e.g. `python3 scripts/rm_set_option.py --dry-run --option <name>`.
+3. If you see "warning: no .lean files found", pass `--directories <your-source-dir>`
+   (e.g. `--directories FLT`).
+4. If you have a `lakefile.toml` and have configured the option in `leanOptions`,
+   remove the entry manually — these scripts only edit `lakefile.lean`.
+
+Module-name derivation assumes a Mathlib-style layout where `Foo/Bar.lean` corresponds
+to module `Foo.Bar` (no `srcDir` indirection).
 
 - `dag_traversal.py`
   Reusable parallel DAG traversal for Lean import graphs. Parses the import DAG from `.lean`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,6 +106,14 @@ file used by the library's own linters.
 These scripts help with testing Lean PRs that change backward-compatibility option
 behaviour. They share a common DAG traversal library that parallelises work in import-graph order.
 
+To use these scripts outside mathlib, copy `dag_traversal.py`, `set_option_utils.py`,
+and the script(s) you need into a `scripts/` directory in your project, then run from
+the project root.  `fix_nonlocal_set_option.py` additionally requires
+`add_module_set_option.py` and `rm_module_set_option.py`.  Pass `--directories <root>`
+if your source files aren't directly under the project root.  Module-name derivation
+assumes a Mathlib-style layout where `Foo/Bar.lean` corresponds to module `Foo.Bar`
+(no `srcDir` indirection).
+
 - `dag_traversal.py`
   Reusable parallel DAG traversal for Lean import graphs. Parses the import DAG from `.lean`
   source files and parallelises an action over a forward or backward traversal. Each module is
@@ -149,11 +157,14 @@ behaviour. They share a common DAG traversal library that parallelises work in i
 - `add_module_set_option.py`, `rm_module_set_option.py`
   File-level variants of `add_set_option.py` / `rm_set_option.py`: they insert or remove a
   `set_option ...` at the top of the file rather than scoped to individual declarations.
+  Both accept `--directories <root>` for downstream projects whose source files aren't
+  directly under the project root.
 
 - `fix_nonlocal_set_option.py`
   Helper that bisects the import DAG to find the upstream file whose missing
   `set_option ...` is causing a downstream failure — useful when the direct fix is in a
-  different module than the one reporting the error.
+  different module than the one reporting the error.  Accepts `--directories <root>` for
+  downstream projects.
 
 - `fix_unused_simp_args.py`
   Parses `lake build` warnings of the form `This simp argument is unused: X` and removes `X`

--- a/scripts/add_module_set_option.py
+++ b/scripts/add_module_set_option.py
@@ -21,7 +21,18 @@ import re
 import sys
 from pathlib import Path
 
-from set_option_utils import PROJECT_DIR, lakefile_pattern
+try:
+    from set_option_utils import PROJECT_DIR, lakefile_pattern
+    from dag_traversal import DAG
+except ImportError as _e:
+    raise SystemExit(
+        f"error: {_e}\n\n"
+        f"  This script depends on sibling Python files in {Path(__file__).parent}:\n"
+        "    - dag_traversal.py\n"
+        "    - set_option_utils.py\n"
+        "  These are mathlib scripts, not pip packages.  Copy them into your\n"
+        "  `scripts/` directory alongside this script."
+    )
 
 DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
 
@@ -168,11 +179,14 @@ def main():
                 if not args.dry_run:
                     lakefile.write_text(new_content)
                 print(f"Removed {option} from lakefile.lean")
+        elif (PROJECT_DIR / "lakefile.toml").exists():
+            print(
+                f"Note: lakefile.toml detected.  If {option} is set in `leanOptions`\n"
+                "  there, you'll need to remove the entry manually — this script only\n"
+                "  edits lakefile.lean."
+            )
 
     # Step 2: determine which files to process via the import DAG
-    sys.path.insert(0, str(Path(__file__).parent))
-    from dag_traversal import DAG
-
     dag = DAG.from_directories(PROJECT_DIR, args.directories)
 
     if args.deps_of:

--- a/scripts/add_module_set_option.py
+++ b/scripts/add_module_set_option.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 """
-Add module-level `set_option` lines to every Mathlib file.
+Add module-level `set_option` lines to every Lean file in the project.
 
 Inserts `set_option <option> false` (module-scoped, no `in`) after the last
-import line in each .lean file under Mathlib/.  Also removes the corresponding
+import line in each .lean file in the project.  Also removes the corresponding
 entry from lakefile.lean if present.
+
+To use outside mathlib, copy `add_module_set_option.py`, `dag_traversal.py` and
+`set_option_utils.py` to a subdirectory of your project named `scripts/` and
+then run from the project root with `scripts/add_module_set_option.py`.  Pass
+`--directories <root>` if your source files aren't directly under the project
+root.
 
 Usage:
     python3 scripts/add_module_set_option.py [--option NAME] [--dry-run]
@@ -112,7 +118,7 @@ def add_to_file(filepath: Path, option: str, value: str, dry_run: bool) -> bool:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Add module-level set_option to every Mathlib file."
+        description="Add module-level set_option to every Lean file in the project."
     )
     parser.add_argument(
         "--option",
@@ -128,6 +134,12 @@ def main():
         "--dry-run",
         action="store_true",
         help="Report without modifying files",
+    )
+    parser.add_argument(
+        "--directories",
+        nargs="+",
+        default=None,
+        help="Directories to scan for .lean files (default: '.')",
     )
     parser.add_argument(
         "--deps-of",
@@ -157,13 +169,13 @@ def main():
                     lakefile.write_text(new_content)
                 print(f"Removed {option} from lakefile.lean")
 
-    # Step 2: determine which files to process
-    if args.deps_of:
-        # Import DAG to find dependencies
-        sys.path.insert(0, str(Path(__file__).parent))
-        from dag_traversal import DAG
+    # Step 2: determine which files to process via the import DAG
+    sys.path.insert(0, str(Path(__file__).parent))
+    from dag_traversal import DAG
 
-        dag = DAG.from_directories(PROJECT_DIR)
+    dag = DAG.from_directories(PROJECT_DIR, args.directories)
+
+    if args.deps_of:
         deps_set: set[str] = set()
         for mod in args.deps_of:
             # Collect transitive dependencies
@@ -181,18 +193,21 @@ def main():
                             next_frontier.add(imp)
                 frontier = next_frontier
             deps_set |= visited
-        # Convert module names to file paths
         files = []
         for name in sorted(deps_set):
             info = dag.modules.get(name)
-            if info and info.filepath.startswith("Mathlib/"):
+            if info:
                 fp = dag.project_root / info.filepath
                 if fp.exists():
                     files.append(fp)
         print(f"  {len(files)} dependencies of {', '.join(args.deps_of)}")
     else:
-        mathlib_dir = PROJECT_DIR / "Mathlib"
-        files = sorted(mathlib_dir.rglob("*.lean"))
+        files = []
+        for name in sorted(dag.modules):
+            info = dag.modules[name]
+            fp = dag.project_root / info.filepath
+            if fp.exists():
+                files.append(fp)
 
     modified = 0
     for filepath in files:

--- a/scripts/add_module_set_option.py
+++ b/scripts/add_module_set_option.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Add module-level `set_option` lines to every Mathlib file.
+
+Inserts `set_option <option> false` (module-scoped, no `in`) after the last
+import line in each .lean file under Mathlib/.  Also removes the corresponding
+entry from lakefile.lean if present.
+
+Usage:
+    python3 scripts/add_module_set_option.py [--option NAME] [--dry-run]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from set_option_utils import PROJECT_DIR, lakefile_pattern
+
+DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
+
+
+def find_insert_point(lines: list[str]) -> int:
+    """Find the line index after imports and module docstring.
+
+    Inserts after the module docstring (/-! ... -/) if present right after
+    imports, otherwise after the last import. The linter requires the module
+    docstring to be the first command after imports, so set_option must come
+    after it.
+
+    Falls back to after `module` if no imports, or line 0.
+    """
+    import_re = re.compile(r"^(?:public\s+)?(?:meta\s+)?import\s")
+    last_import = -1
+    module_line = -1
+    in_block_comment = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        # Track block comments
+        if in_block_comment:
+            if "-/" in stripped:
+                in_block_comment = False
+            continue
+        if stripped.startswith("/-"):
+            if "-/" not in stripped[2:]:
+                in_block_comment = True
+            continue
+        # Track module line
+        if stripped == "module" or stripped.startswith("module ") or stripped.startswith("module\t"):
+            module_line = i
+            continue
+        # Skip blank lines and line comments
+        if stripped == "" or stripped.startswith("--"):
+            continue
+        # Check for import
+        if import_re.match(stripped):
+            last_import = i
+            continue
+        # Any other content after we've seen imports means header is done
+        if last_import >= 0:
+            break
+    if last_import < 0:
+        if module_line >= 0:
+            return module_line + 1
+        return 0
+    # We have the last import at last_import. Now look for a module docstring
+    # (/-! ... -/) immediately following (possibly separated by blank lines).
+    idx = last_import + 1
+    # Skip blank lines
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    # Check for module docstring
+    if idx < len(lines) and lines[idx].strip().startswith("/-!"):
+        # Find the end of this block comment
+        if "-/" in lines[idx].strip()[3:]:
+            # Single-line module docstring
+            return idx + 1
+        # Multi-line: scan for closing -/
+        idx += 1
+        while idx < len(lines):
+            if "-/" in lines[idx]:
+                return idx + 1
+            idx += 1
+    # No module docstring, insert after imports
+    return last_import + 1
+
+
+def add_to_file(filepath: Path, option: str, value: str, dry_run: bool) -> bool:
+    """Add module-level set_option to a file. Returns True if modified."""
+    text = filepath.read_text()
+    line = f"set_option {option} {value}"
+
+    # Skip if already present as a module-level option (not `set_option ... in`)
+    if re.search(rf"^{re.escape(line)}$", text, re.MULTILINE):
+        return False
+
+    lines = text.splitlines(keepends=True)
+    idx = find_insert_point(lines)
+
+    # Insert a blank line + the set_option + blank line
+    insert = f"\n{line}\n"
+    # If there's already a blank line after imports, don't double-blank
+    if idx < len(lines) and lines[idx].strip() == "":
+        insert = f"{line}\n"
+
+    new_lines = lines[:idx] + [insert] + lines[idx:]
+
+    if not dry_run:
+        filepath.write_text("".join(new_lines))
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add module-level set_option to every Mathlib file."
+    )
+    parser.add_argument(
+        "--option",
+        default=DEFAULT_OPTION,
+        help=f"Option name (default: {DEFAULT_OPTION})",
+    )
+    parser.add_argument(
+        "--value",
+        default="false",
+        help="Value of the option (default: false)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report without modifying files",
+    )
+    parser.add_argument(
+        "--deps-of",
+        nargs="*",
+        metavar="MODULE",
+        help="Only add to transitive dependencies of these modules "
+             "(module names like Mathlib.Foo.Bar)",
+    )
+    parser.add_argument(
+        "--no-lakefile",
+        action="store_true",
+        help="Skip removing the option from lakefile.lean",
+    )
+    args = parser.parse_args()
+
+    option = args.option
+
+    # Step 1: remove from lakefile
+    if not args.no_lakefile:
+        lakefile = PROJECT_DIR / "lakefile.lean"
+        if lakefile.exists():
+            content = lakefile.read_text()
+            pat = lakefile_pattern(option, args.value)
+            new_content = pat.sub("", content)
+            if new_content != content:
+                if not args.dry_run:
+                    lakefile.write_text(new_content)
+                print(f"Removed {option} from lakefile.lean")
+
+    # Step 2: determine which files to process
+    if args.deps_of:
+        # Import DAG to find dependencies
+        sys.path.insert(0, str(Path(__file__).parent))
+        from dag_traversal import DAG
+
+        dag = DAG.from_directories(PROJECT_DIR)
+        deps_set: set[str] = set()
+        for mod in args.deps_of:
+            # Collect transitive dependencies
+            frontier = {mod}
+            visited: set[str] = set()
+            while frontier:
+                next_frontier: set[str] = set()
+                for m in frontier:
+                    info = dag.modules.get(m)
+                    if info is None:
+                        continue
+                    for imp in info.imports:
+                        if imp not in visited and imp != mod:
+                            visited.add(imp)
+                            next_frontier.add(imp)
+                frontier = next_frontier
+            deps_set |= visited
+        # Convert module names to file paths
+        files = []
+        for name in sorted(deps_set):
+            info = dag.modules.get(name)
+            if info and info.filepath.startswith("Mathlib/"):
+                fp = dag.project_root / info.filepath
+                if fp.exists():
+                    files.append(fp)
+        print(f"  {len(files)} dependencies of {', '.join(args.deps_of)}")
+    else:
+        mathlib_dir = PROJECT_DIR / "Mathlib"
+        files = sorted(mathlib_dir.rglob("*.lean"))
+
+    modified = 0
+    for filepath in files:
+        if add_to_file(filepath, option, args.value, args.dry_run):
+            modified += 1
+
+    action = "Would modify" if args.dry_run else "Modified"
+    print(f"{action} {modified}/{len(files)} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/add_set_option.py
+++ b/scripts/add_set_option.py
@@ -17,18 +17,28 @@ from pathlib import Path
 from threading import Lock
 from typing import Callable
 
-from dag_traversal import (
-    DAG,
-    DAGTraverser,
-    Display,
-    TraversalResult,
-)
-from set_option_utils import (
-    DEFAULT_OPTIONS,
-    PROJECT_DIR,
-    lake_build_with_progress,
-    set_option_line,
-)
+try:
+    from dag_traversal import (
+        DAG,
+        DAGTraverser,
+        Display,
+        TraversalResult,
+    )
+    from set_option_utils import (
+        DEFAULT_OPTIONS,
+        PROJECT_DIR,
+        lake_build_with_progress,
+        set_option_line,
+    )
+except ImportError as _e:
+    raise SystemExit(
+        f"error: {_e}\n\n"
+        f"  This script depends on sibling Python files in {Path(__file__).parent}:\n"
+        "    - dag_traversal.py\n"
+        "    - set_option_utils.py\n"
+        "  These are mathlib scripts, not pip packages.  Copy them into your\n"
+        "  `scripts/` directory alongside this script."
+    )
 
 
 @dataclass

--- a/scripts/add_set_option.py
+++ b/scripts/add_set_option.py
@@ -394,7 +394,11 @@ def print_summary(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Add set_option ... false in before failing declarations."
+        description="Add `set_option ... false in` before failing declarations.\n\n"
+                    "To use outside mathlib, copy `add_set_option.py`, `dag_traversal.py` and "
+                    "`set_option_utils.py` to a subdirectory of your project named `scripts/` "
+                    "and then run from the project root with `scripts/add_set_option.py`.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--option",
@@ -423,6 +427,12 @@ def main():
         help="Only process these files (paths relative to project root)",
     )
     parser.add_argument(
+        "--directories",
+        nargs="+",
+        default=None,
+        help="Directories to scan when building the import DAG (default: '.')",
+    )
+    parser.add_argument(
         "--no-initial",
         action="store_true",
         help="Skip the initial build (build every module individually)",
@@ -440,7 +450,7 @@ def main():
 
     # Build DAG
     print("Building import DAG...", flush=True)
-    dag = DAG.from_directories(PROJECT_DIR)
+    dag = DAG.from_directories(PROJECT_DIR, args.directories)
     print(f"  {len(dag.modules)} modules parsed")
 
     # Filter to requested files

--- a/scripts/add_set_option.py
+++ b/scripts/add_set_option.py
@@ -193,6 +193,7 @@ def make_process_module(
     options: list[str],
     timeout: int,
     traverser: DAGTraverser,
+    value: str = "false",
 ) -> Callable:
     """Create the per-module action callback."""
 
@@ -220,7 +221,7 @@ def make_process_module(
         while idx < len(lines):
             found = False
             for opt in options:
-                needle = set_option_line(opt).strip()
+                needle = set_option_line(opt, value).strip()
                 if needle in lines[idx]:
                     present.add(opt)
                     found = True
@@ -299,7 +300,7 @@ def make_process_module(
                 # Try each candidate combination of missing options
                 succeeded = False
                 for combo in candidates(missing):
-                    insert = [set_option_line(opt) for opt in combo]
+                    insert = [set_option_line(opt, value) for opt in combo]
                     new_lines = lines[:decl_start] + insert + lines[decl_start:]
                     filepath.write_text("".join(new_lines))
                     ok, try_output = traverser.lake_build(module_name, PROJECT_DIR, timeout)
@@ -400,6 +401,11 @@ def main():
         help="Only use this specific option (default: try all known options)",
     )
     parser.add_argument(
+        "--value",
+        default="false",
+        help="Value to set the option to (default: false)",
+    )
+    parser.add_argument(
         "--max-workers",
         type=int,
         default=None,
@@ -472,7 +478,7 @@ def main():
     # Traverse forward
     traverser = DAGTraverser()
     display = _AddDisplay(dag, open_on_failure=args.open)
-    action = make_process_module(options, args.timeout, traverser)
+    action = make_process_module(options, args.timeout, traverser, value=args.value)
 
     display.start(len(dag.modules))
     try:

--- a/scripts/dag_traversal.py
+++ b/scripts/dag_traversal.py
@@ -557,6 +557,16 @@ class DAG:
                     full_path = Path(root) / fname
                     rel_paths.append(full_path.relative_to(project_root))
 
+        if not rel_paths:
+            import sys as _sys
+            _sys.stderr.write(
+                f"warning: no .lean files found under {project_root} "
+                f"(directories={list(directories)}).\n"
+                "  hint: pass --directories <your-source-dir> if your files\n"
+                "  aren't directly under the project root.\n"
+            )
+            return DAG({}, project_root.resolve())
+
         # Batch-parse imports using lean --deps-json.
         all_imports = _parse_all_imports(rel_paths, project_root)
 

--- a/scripts/dag_traversal.py
+++ b/scripts/dag_traversal.py
@@ -542,12 +542,15 @@ class DAG:
             directories = ["."]
 
         # Collect all .lean file paths (relative to project_root).
+        # Skip the Lake build directory (`.lake/`); it contains vendored
+        # dependencies that we don't want to modify or build directly.
         rel_paths: list[Path] = []
         for directory in directories:
             dir_path = project_root / directory
             if not dir_path.exists():
                 continue
-            for root, _, files in os.walk(dir_path):
+            for root, dirs, files in os.walk(dir_path):
+                dirs[:] = [d for d in dirs if d != ".lake"]
                 for fname in files:
                     if not fname.endswith(".lean"):
                         continue

--- a/scripts/fix_long_lines.py
+++ b/scripts/fix_long_lines.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Break too-long lines at the last comma before column 100.
+
+Usage: scripts/fix_long_lines.py <path>:<line> ...
+
+For each specified (path, line) pair, if that line exceeds 100 chars,
+find the last comma before column 100 and break there, indenting the
+continuation with the original indent + 2 spaces. If that doesn't bring
+the line under 100, keep cutting at earlier commas.
+"""
+import sys
+from pathlib import Path
+
+
+def fix_line(text: str, lineno: int) -> str:
+    lines = text.splitlines(keepends=True)
+    if lineno - 1 >= len(lines):
+        return text
+    line = lines[lineno - 1].rstrip("\n")
+    if len(line) <= 100:
+        return text
+    indent = len(line) - len(line.lstrip())
+    leading = line[:indent]
+    # Find last comma at or before col 99 (0-indexed 98)
+    cut = line.rfind(",", 0, 100)
+    if cut == -1:
+        return text
+    head = line[: cut + 1]
+    tail = line[cut + 1 :].lstrip()
+    new_line = head + "\n" + leading + "  " + tail + "\n"
+    lines[lineno - 1] = new_line
+    return "".join(lines)
+
+
+def main() -> int:
+    seen = set()
+    by_file: dict[str, list[int]] = {}
+    for a in sys.argv[1:]:
+        if ":" not in a:
+            continue
+        path, ln = a.rsplit(":", 1)
+        by_file.setdefault(path, []).append(int(ln))
+
+    total_fixed = 0
+    for path, lns in by_file.items():
+        p = Path(path)
+        if not p.exists():
+            print(f"  skip (missing): {path}", file=sys.stderr)
+            continue
+        text = p.read_text()
+        # Process in reverse order so line numbers stay valid after insertion
+        for ln in sorted(set(lns), reverse=True):
+            new = fix_line(text, ln)
+            if new != text:
+                text = new
+                total_fixed += 1
+        p.write_text(text)
+    print(f"Fixed {total_fixed} long lines", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_nonlocal_set_option.py
+++ b/scripts/fix_nonlocal_set_option.py
@@ -8,6 +8,13 @@ For each failing module A:
 3. Binary-search remove unnecessary options from deps of A,
    checking that A (and all previously-fixed modules) still build
 
+To use outside mathlib, copy `fix_nonlocal_set_option.py`,
+`add_module_set_option.py`, `rm_module_set_option.py`, `dag_traversal.py` and
+`set_option_utils.py` to a subdirectory of your project named `scripts/` and
+then run from the project root with `scripts/fix_nonlocal_set_option.py`.
+Pass `--directories <root>` if your source files aren't directly under the
+project root.
+
 Usage:
     python3 scripts/fix_nonlocal_set_option.py MODULE1 MODULE2 ...
 """
@@ -217,13 +224,19 @@ def main():
         default=600,
         help="Build timeout per module in seconds (default: 600)",
     )
+    parser.add_argument(
+        "--directories",
+        nargs="+",
+        default=None,
+        help="Directories to scan when building the import DAG (default: '.')",
+    )
     args = parser.parse_args()
 
     option = args.option
     value = args.value
 
     print("Building import DAG...", flush=True)
-    dag = DAG.from_directories(PROJECT_DIR)
+    dag = DAG.from_directories(PROJECT_DIR, args.directories)
     print(f"  {len(dag.modules)} modules parsed")
 
     check_modules = list(args.modules)
@@ -233,16 +246,9 @@ def main():
     for mod in args.modules:
         all_deps |= collect_all_dependencies(dag, mod)
 
-    # Filter to Mathlib files
-    mathlib_deps = []
-    for d in sorted(all_deps):
-        info = dag.modules.get(d)
-        if info and str(info.filepath).startswith("Mathlib/"):
-            mathlib_deps.append(d)
-
     # Step 2: add option to all deps that don't already have it
     added = []
-    for d in mathlib_deps:
+    for d in sorted(all_deps):
         info = dag.modules.get(d)
         if info is None:
             continue

--- a/scripts/fix_nonlocal_set_option.py
+++ b/scripts/fix_nonlocal_set_option.py
@@ -25,10 +25,22 @@ import subprocess
 import sys
 from pathlib import Path
 
-from dag_traversal import DAG
-from set_option_utils import PROJECT_DIR
-from add_module_set_option import add_to_file, find_insert_point
-from rm_module_set_option import module_set_option_pattern, scan_files
+try:
+    from dag_traversal import DAG
+    from set_option_utils import PROJECT_DIR
+    from add_module_set_option import add_to_file, find_insert_point
+    from rm_module_set_option import module_set_option_pattern, scan_files
+except ImportError as _e:
+    raise SystemExit(
+        f"error: {_e}\n\n"
+        f"  This script depends on sibling Python files in {Path(__file__).parent}:\n"
+        "    - dag_traversal.py\n"
+        "    - set_option_utils.py\n"
+        "    - add_module_set_option.py\n"
+        "    - rm_module_set_option.py\n"
+        "  These are mathlib scripts, not pip packages.  Copy them into your\n"
+        "  `scripts/` directory alongside this script."
+    )
 
 DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
 

--- a/scripts/fix_nonlocal_set_option.py
+++ b/scripts/fix_nonlocal_set_option.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Fix non-local breakage from set_option removal.
+
+For each failing module A:
+1. Add the option to all dependencies of A
+2. Verify A builds
+3. Binary-search remove unnecessary options from deps of A,
+   checking that A (and all previously-fixed modules) still build
+
+Usage:
+    python3 scripts/fix_nonlocal_set_option.py MODULE1 MODULE2 ...
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from dag_traversal import DAG
+from set_option_utils import PROJECT_DIR
+from add_module_set_option import add_to_file, find_insert_point
+from rm_module_set_option import module_set_option_pattern, scan_files
+
+DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
+
+
+def collect_all_dependencies(dag: DAG, module_name: str) -> set[str]:
+    """Collect all transitive dependencies (imports) of a module."""
+    collected: set[str] = set()
+    frontier = {module_name}
+    while frontier:
+        next_frontier: set[str] = set()
+        for m in frontier:
+            info = dag.modules.get(m)
+            if info is None:
+                continue
+            for imp in info.imports:
+                if imp not in collected and imp != module_name:
+                    collected.add(imp)
+                    next_frontier.add(imp)
+        frontier = next_frontier
+    return collected
+
+
+def lake_build_modules(modules: list[str], timeout: int = 600) -> bool:
+    """Build specific modules. Returns True if all succeed."""
+    for mod in modules:
+        result = subprocess.run(
+            ["lake", "build", mod],
+            cwd=PROJECT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return False
+    return True
+
+
+def has_option(filepath: Path, option: str) -> bool:
+    """Check if a file has the module-level set_option line."""
+    pat = module_set_option_pattern(option)
+    text = filepath.read_text()
+    for line in text.splitlines():
+        if pat.match(line):
+            return True
+    return False
+
+
+def remove_option(filepath: Path, option: str) -> str | None:
+    """Remove the module-level set_option line. Returns original text or None."""
+    pat = module_set_option_pattern(option)
+    text = filepath.read_text()
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if pat.match(line.rstrip('\n')):
+            new_lines = list(lines)
+            del new_lines[i]
+            # Remove double blank line
+            if (i < len(new_lines) and i > 0
+                    and new_lines[i - 1].strip() == ""
+                    and new_lines[i].strip() == ""):
+                del new_lines[i]
+            filepath.write_text("".join(new_lines))
+            return text
+    return None
+
+
+def restore_file(filepath: Path, original_text: str):
+    """Restore a file to its original content."""
+    filepath.write_text(original_text)
+
+
+def bisect_remove(
+    dag: DAG,
+    candidates: list[str],
+    check_modules: list[str],
+    option: str,
+    timeout: int,
+) -> list[str]:
+    """Binary-search remove options from candidates while check_modules build.
+
+    Returns list of modules that must keep the option.
+    """
+    if not candidates:
+        return []
+
+    # Try removing all at once
+    print(f"    Trying to remove all {len(candidates)} at once...", flush=True)
+    originals: dict[str, str] = {}
+    for mod in candidates:
+        info = dag.modules.get(mod)
+        if info is None:
+            continue
+        fp = dag.project_root / info.filepath
+        orig = remove_option(fp, option)
+        if orig is not None:
+            originals[mod] = orig
+
+    if lake_build_modules(check_modules, timeout):
+        print(f"    All {len(candidates)} removed successfully!", flush=True)
+        return []
+
+    # Revert all
+    for mod, orig in originals.items():
+        info = dag.modules.get(mod)
+        if info:
+            restore_file(dag.project_root / info.filepath, orig)
+    # Rebuild to restore oleans
+    lake_build_modules(check_modules, timeout)
+
+    if len(candidates) == 1:
+        print(f"    Must keep: {candidates[0]}", flush=True)
+        return candidates
+
+    # Split and recurse
+    mid = len(candidates) // 2
+    left = candidates[:mid]
+    right = candidates[mid:]
+
+    print(f"    Bisecting: trying left half ({len(left)})...", flush=True)
+    # Try removing left half
+    left_originals: dict[str, str] = {}
+    for mod in left:
+        info = dag.modules.get(mod)
+        if info is None:
+            continue
+        fp = dag.project_root / info.filepath
+        orig = remove_option(fp, option)
+        if orig is not None:
+            left_originals[mod] = orig
+
+    left_ok = lake_build_modules(check_modules, timeout)
+    if not left_ok:
+        # Revert left, some in left are needed
+        for mod, orig in left_originals.items():
+            info = dag.modules.get(mod)
+            if info:
+                restore_file(dag.project_root / info.filepath, orig)
+        lake_build_modules(check_modules, timeout)
+        needed_left = bisect_remove(dag, left, check_modules, option, timeout)
+    else:
+        needed_left = []
+
+    # Now try right half (left removals that succeeded are still in effect)
+    print(f"    Bisecting: trying right half ({len(right)})...", flush=True)
+    right_originals: dict[str, str] = {}
+    for mod in right:
+        info = dag.modules.get(mod)
+        if info is None:
+            continue
+        fp = dag.project_root / info.filepath
+        orig = remove_option(fp, option)
+        if orig is not None:
+            right_originals[mod] = orig
+
+    right_ok = lake_build_modules(check_modules, timeout)
+    if not right_ok:
+        # Revert right, some in right are needed
+        for mod, orig in right_originals.items():
+            info = dag.modules.get(mod)
+            if info:
+                restore_file(dag.project_root / info.filepath, orig)
+        lake_build_modules(check_modules, timeout)
+        needed_right = bisect_remove(dag, right, check_modules, option, timeout)
+    else:
+        needed_right = []
+
+    return needed_left + needed_right
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fix non-local breakage by adding+minimizing set_option in deps"
+    )
+    parser.add_argument(
+        "modules",
+        nargs="+",
+        help="Failing module names (e.g. Mathlib.Foo.Bar)",
+    )
+    parser.add_argument(
+        "--option",
+        default=DEFAULT_OPTION,
+        help=f"Option name (default: {DEFAULT_OPTION})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Build timeout per module in seconds (default: 600)",
+    )
+    args = parser.parse_args()
+
+    option = args.option
+
+    print("Building import DAG...", flush=True)
+    dag = DAG.from_directories(PROJECT_DIR)
+    print(f"  {len(dag.modules)} modules parsed")
+
+    check_modules = list(args.modules)
+
+    # Step 1: collect all deps of all failing modules
+    all_deps: set[str] = set()
+    for mod in args.modules:
+        all_deps |= collect_all_dependencies(dag, mod)
+
+    # Filter to Mathlib files
+    mathlib_deps = []
+    for d in sorted(all_deps):
+        info = dag.modules.get(d)
+        if info and str(info.filepath).startswith("Mathlib/"):
+            mathlib_deps.append(d)
+
+    # Step 2: add option to all deps that don't already have it
+    added = []
+    for d in mathlib_deps:
+        info = dag.modules.get(d)
+        if info is None:
+            continue
+        fp = dag.project_root / info.filepath
+        if not has_option(fp, option):
+            if add_to_file(fp, option, dry_run=False):
+                added.append(d)
+    print(f"  Added option to {len(added)} dependencies of {len(args.modules)} modules",
+          flush=True)
+
+    # Step 3: verify all check modules build
+    print(f"  Verifying build of {check_modules}...", flush=True)
+    if not lake_build_modules(check_modules, args.timeout):
+        print("  ERROR: modules still fail after adding option to all deps!")
+        print("  Cannot proceed.")
+        return
+
+    print(f"  Build OK. Now minimizing {len(added)} additions...", flush=True)
+
+    # Step 4: binary search remove unnecessary options
+    needed = bisect_remove(dag, added, check_modules, option, args.timeout)
+
+    removed_count = len(added) - len(needed)
+    print(f"\n{'='*60}")
+    print("RESULT")
+    print(f"{'='*60}")
+    print(f"  Check modules:       {len(check_modules)}")
+    print(f"  Dependencies added:  {len(added)}")
+    print(f"  Removed (unnecessary): {removed_count}")
+    print(f"  Kept (needed):       {len(needed)}")
+    if needed:
+        print("\n  Needed modules:")
+        for n in needed:
+            print(f"    - {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_nonlocal_set_option.py
+++ b/scripts/fix_nonlocal_set_option.py
@@ -59,9 +59,9 @@ def lake_build_modules(modules: list[str], timeout: int = 600) -> bool:
     return True
 
 
-def has_option(filepath: Path, option: str) -> bool:
+def has_option(filepath: Path, option: str, value: str) -> bool:
     """Check if a file has the module-level set_option line."""
-    pat = module_set_option_pattern(option)
+    pat = module_set_option_pattern(option, value)
     text = filepath.read_text()
     for line in text.splitlines():
         if pat.match(line):
@@ -69,9 +69,9 @@ def has_option(filepath: Path, option: str) -> bool:
     return False
 
 
-def remove_option(filepath: Path, option: str) -> str | None:
+def remove_option(filepath: Path, option: str, value: str) -> str | None:
     """Remove the module-level set_option line. Returns original text or None."""
-    pat = module_set_option_pattern(option)
+    pat = module_set_option_pattern(option, value)
     text = filepath.read_text()
     lines = text.splitlines(keepends=True)
     for i, line in enumerate(lines):
@@ -98,6 +98,7 @@ def bisect_remove(
     candidates: list[str],
     check_modules: list[str],
     option: str,
+    value: str,
     timeout: int,
 ) -> list[str]:
     """Binary-search remove options from candidates while check_modules build.
@@ -115,7 +116,7 @@ def bisect_remove(
         if info is None:
             continue
         fp = dag.project_root / info.filepath
-        orig = remove_option(fp, option)
+        orig = remove_option(fp, option, value)
         if orig is not None:
             originals[mod] = orig
 
@@ -148,7 +149,7 @@ def bisect_remove(
         if info is None:
             continue
         fp = dag.project_root / info.filepath
-        orig = remove_option(fp, option)
+        orig = remove_option(fp, option, value)
         if orig is not None:
             left_originals[mod] = orig
 
@@ -160,7 +161,7 @@ def bisect_remove(
             if info:
                 restore_file(dag.project_root / info.filepath, orig)
         lake_build_modules(check_modules, timeout)
-        needed_left = bisect_remove(dag, left, check_modules, option, timeout)
+        needed_left = bisect_remove(dag, left, check_modules, option, value, timeout)
     else:
         needed_left = []
 
@@ -172,7 +173,7 @@ def bisect_remove(
         if info is None:
             continue
         fp = dag.project_root / info.filepath
-        orig = remove_option(fp, option)
+        orig = remove_option(fp, option, value)
         if orig is not None:
             right_originals[mod] = orig
 
@@ -184,7 +185,7 @@ def bisect_remove(
             if info:
                 restore_file(dag.project_root / info.filepath, orig)
         lake_build_modules(check_modules, timeout)
-        needed_right = bisect_remove(dag, right, check_modules, option, timeout)
+        needed_right = bisect_remove(dag, right, check_modules, option, value, timeout)
     else:
         needed_right = []
 
@@ -206,6 +207,11 @@ def main():
         help=f"Option name (default: {DEFAULT_OPTION})",
     )
     parser.add_argument(
+        "--value",
+        default="true",
+        help="Value to set the option to (default: true)",
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=600,
@@ -214,6 +220,7 @@ def main():
     args = parser.parse_args()
 
     option = args.option
+    value = args.value
 
     print("Building import DAG...", flush=True)
     dag = DAG.from_directories(PROJECT_DIR)
@@ -240,8 +247,8 @@ def main():
         if info is None:
             continue
         fp = dag.project_root / info.filepath
-        if not has_option(fp, option):
-            if add_to_file(fp, option, dry_run=False):
+        if not has_option(fp, option, value):
+            if add_to_file(fp, option, value, dry_run=False):
                 added.append(d)
     print(f"  Added option to {len(added)} dependencies of {len(args.modules)} modules",
           flush=True)
@@ -256,7 +263,7 @@ def main():
     print(f"  Build OK. Now minimizing {len(added)} additions...", flush=True)
 
     # Step 4: binary search remove unnecessary options
-    needed = bisect_remove(dag, added, check_modules, option, args.timeout)
+    needed = bisect_remove(dag, added, check_modules, option, value, args.timeout)
 
     removed_count = len(added) - len(needed)
     print(f"\n{'='*60}")

--- a/scripts/fix_unused_simp_args.py
+++ b/scripts/fix_unused_simp_args.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Remove unused-simp-argument warnings from Mathlib.
+
+Usage: lake build 2>&1 | scripts/fix_unused_simp_args.py
+   or: scripts/fix_unused_simp_args.py <build-log>
+
+Parses warnings of the form
+    warning: path:line:col: This simp argument is unused:
+      <arg-name>
+and rewrites the simp call at path:line to drop <arg-name>
+from its argument list.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+WARNING_RE = re.compile(
+    r"^warning: (?P<path>[^:]+\.lean):(?P<line>\d+):(?P<col>\d+): "
+    r"This simp argument is unused:\s*$"
+)
+
+
+def parse_log(lines: list[str]) -> list[dict]:
+    """Return list of {'path','line','col','arg'} dicts."""
+    warnings = []
+    i = 0
+    while i < len(lines):
+        m = WARNING_RE.match(lines[i])
+        if m:
+            # Next non-blank line is the arg name (indented).
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == "":
+                j += 1
+            if j < len(lines):
+                arg = lines[j].strip()
+                warnings.append(
+                    {
+                        "path": m["path"],
+                        "line": int(m["line"]),
+                        "col": int(m["col"]),
+                        "arg": arg,
+                    }
+                )
+            i = j + 1
+        else:
+            i += 1
+    return warnings
+
+
+def find_simp_call(
+    text: str, warn_line: int, warn_col: int
+) -> tuple[int, int] | None:
+    """Find the `[...]` span of the simp call at warn_line:warn_col (1-indexed).
+
+    Returns (start_offset, end_offset) both inclusive of the brackets,
+    or None if not found.
+    """
+    # Convert line:col (1-indexed) to absolute offset
+    lines = text.splitlines(keepends=True)
+    if warn_line - 1 >= len(lines):
+        return None
+    offset = sum(len(x) for x in lines[: warn_line - 1]) + warn_col
+
+    # Walk forward from warn_col-ish to find `[`.
+    # Scan backward to start of `simp` call though — warn_col points at arg,
+    # so we walk back to find the opening `[`.
+    i = offset
+    depth = 0
+    while i >= 0 and i < len(text):
+        ch = text[i]
+        if ch == "]":
+            depth += 1
+        elif ch == "[":
+            if depth == 0:
+                start = i
+                break
+            depth -= 1
+        i -= 1
+    else:
+        return None
+
+    # Walk forward from start to find matching `]`
+    depth = 0
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return (start, i)
+        i += 1
+    return None
+
+
+def split_top_level(args_text: str) -> list[tuple[int, int]]:
+    """Split a bracket-body into (start, end) offsets of comma-separated items.
+
+    Offsets are relative to args_text. Respects nested brackets.
+    """
+    items = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(args_text):
+        if ch in "([{⟨":
+            depth += 1
+        elif ch in ")]}⟩":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            items.append((start, i))
+            start = i + 1
+    items.append((start, len(args_text)))
+    return items
+
+
+def _bare_name(s: str) -> tuple[str, str]:
+    """Strip leading `←`/`-` (and whitespace) from a simp arg.
+
+    Returns (prefix, bare_name) where prefix is one of '', '←', '-'.
+    """
+    stripped = s.strip()
+    m = re.match(r"^(←|-)\s*(.*)$", stripped)
+    if m:
+        return m.group(1), m.group(2).strip()
+    return "", stripped
+
+
+def arg_matches(item_text: str, target_arg: str) -> bool:
+    _, item_bare = _bare_name(item_text)
+    _, target_bare = _bare_name(target_arg)
+    return item_bare == target_bare
+
+
+def remove_arg(
+    text: str, span: tuple[int, int], target_arg: str
+) -> tuple[str, bool]:
+    """Remove (or `-`-ify) the first occurrence of target_arg in the span.
+
+    If the item starts with `←`, rewrite it to `-` instead of removing
+    (simp's own hint says the `←` is load-bearing for simp-set manipulation
+    even when the rewrite itself is unused).
+
+    Returns (new_text, success).
+    """
+    lb, rb = span
+    inner = text[lb + 1 : rb]
+    items = split_top_level(inner)
+    for idx, (a, b) in enumerate(items):
+        item_text = inner[a:b]
+        if not arg_matches(item_text, target_arg):
+            continue
+        prefix, bare = _bare_name(item_text)
+        if prefix == "←":
+            # Replace `← X` with `- X` (keep leading whitespace).
+            leading_ws = item_text[: len(item_text) - len(item_text.lstrip())]
+            replacement = f"{leading_ws}- {bare}"
+            new_inner = inner[:a] + replacement + inner[b:]
+            return text[: lb + 1] + new_inner + text[rb:], True
+        # Plain removal: also take out a comma separator
+        if idx < len(items) - 1:
+            remove_start = a
+            remove_end = items[idx + 1][0]
+        elif idx > 0:
+            prev_end = items[idx - 1][1]
+            remove_start = prev_end
+            remove_end = b
+        else:
+            remove_start = a
+            remove_end = b
+        new_inner = inner[:remove_start] + inner[remove_end:]
+        return text[: lb + 1] + new_inner + text[rb:], True
+    return text, False
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            lines = f.read().splitlines()
+    else:
+        lines = sys.stdin.read().splitlines()
+
+    warnings = parse_log(lines)
+    print(f"Parsed {len(warnings)} unused-simp-arg warnings", file=sys.stderr)
+
+    # Group by file
+    by_file: dict[str, list[dict]] = defaultdict(list)
+    for w in warnings:
+        by_file[w["path"]].append(w)
+
+    total_fixed = 0
+    total_failed = 0
+    for path, ws in by_file.items():
+        p = Path(path)
+        if not p.exists():
+            print(f"  skip (missing): {path}", file=sys.stderr)
+            continue
+        text = p.read_text()
+        # Process warnings in reverse order so earlier offsets stay valid
+        ws_sorted = sorted(
+            ws, key=lambda w: (w["line"], w["col"]), reverse=True
+        )
+        file_fixed = 0
+        file_failed = 0
+        for w in ws_sorted:
+            span = find_simp_call(text, w["line"], w["col"])
+            if span is None:
+                file_failed += 1
+                continue
+            new_text, ok = remove_arg(text, span, w["arg"])
+            if ok:
+                text = new_text
+                file_fixed += 1
+            else:
+                file_failed += 1
+        if file_fixed > 0:
+            p.write_text(text)
+            print(f"  {path}: fixed {file_fixed}"
+                  + (f", failed {file_failed}" if file_failed else ""))
+        else:
+            print(f"  {path}: all {file_failed} failed")
+        total_fixed += file_fixed
+        total_failed += file_failed
+
+    print(
+        f"\nTotal: fixed {total_fixed}, failed {total_failed}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rm_module_set_option.py
+++ b/scripts/rm_module_set_option.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+Remove unnecessary module-level `set_option` lines from Mathlib.
+
+Traverses the import DAG **backward** (downstream first) so removing an
+option from an upstream file doesn't invalidate cached .oleans of already-
+processed downstream files.
+
+For each file that contains the target line, tries removing it and building
+the module.  If the build succeeds the line stays removed; otherwise it is
+restored.
+
+Usage:
+    python3 scripts/rm_module_set_option.py [--option NAME] [--dry-run] [--resume] ...
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+
+from dag_traversal import (
+    DAG,
+    DAGTraverser,
+    Display,
+    ShutdownError,
+)
+from set_option_utils import (
+    PROJECT_DIR,
+    lake_build_with_progress,
+)
+
+DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
+
+PROGRESS_FILE = PROJECT_DIR / "scripts" / ".rm_module_set_option_progress.jsonl"
+
+_progress_lock = Lock()
+
+
+def _current_toolchain() -> str:
+    return (PROJECT_DIR / "lean-toolchain").read_text().strip()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_progress() -> dict[str, str] | None:
+    """Load progress file. Returns {module: sha256} or None if invalid."""
+    if not PROGRESS_FILE.exists():
+        return None
+    progress: dict[str, str] = {}
+    toolchain = _current_toolchain()
+    with open(PROGRESS_FILE) as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if i == 0:
+                if record.get("toolchain") != toolchain:
+                    return None
+                continue
+            if "module" in record and "sha256" in record:
+                progress[record["module"]] = record["sha256"]
+    return progress
+
+
+def init_progress():
+    with open(PROGRESS_FILE, "w") as f:
+        json.dump({"toolchain": _current_toolchain()}, f)
+        f.write("\n")
+
+
+def save_progress(module: str, sha256: str):
+    with _progress_lock:
+        with open(PROGRESS_FILE, "a") as f:
+            json.dump({"module": module, "sha256": sha256}, f)
+            f.write("\n")
+
+
+def module_set_option_pattern(option: str, value: str = "false") -> re.Pattern:
+    """Match module-level `set_option <option> <value>` (no trailing `in`)."""
+    escaped = re.escape(option)
+    escaped_val = re.escape(value)
+    return re.compile(rf"^set_option {escaped} {escaped_val}\s*$")
+
+
+@dataclass
+class FileResult:
+    removed: bool = False
+    kept: bool = False
+
+
+class _RemoveDisplay(Display):
+    def __init__(self):
+        super().__init__()
+        self.total_removed = 0
+        self.total_kept = 0
+
+    def _status_line(self) -> str:
+        return (
+            f"[{self.completed}/{self.total}]  "
+            f"Working on: {self.inflight}  "
+            f"Removed: {self.total_removed}  Kept: {self.total_kept}"
+        )
+
+    def on_module(self, module_name: str, result: FileResult | None, error: Exception | None):
+        with self.lock:
+            if result:
+                if result.removed:
+                    self.total_removed += 1
+                    sym = "\u2713"
+                elif result.kept:
+                    self.total_kept += 1
+                    sym = "x"
+                else:
+                    sym = "\u00b7"
+                detail = "removed" if result.removed else ("kept" if result.kept else "")
+                self.messages.append(f"  {sym} {module_name} {detail}")
+            elif error:
+                self.messages.append(f"  ! {module_name}: {error}")
+            self._redraw()
+
+
+def scan_files(dag: DAG, option: str, value: str = "false") -> dict[str, int]:
+    """Find files with the module-level set_option line.
+
+    Returns dict of module_name -> 0-indexed line number.
+    """
+    pat = module_set_option_pattern(option, value)
+    results: dict[str, int] = {}
+    for name, info in dag.modules.items():
+        filepath = dag.project_root / info.filepath
+        if not filepath.exists():
+            continue
+        for i, line in enumerate(filepath.read_text().splitlines()):
+            if pat.match(line):
+                results[name] = i
+                break
+    return results
+
+
+def _collect_all_dependents(dag: DAG, module_name: str) -> list[str]:
+    """Collect all transitive reverse dependencies (importers) of a module."""
+    collected_set: set[str] = set()
+    collected: list[str] = []
+    frontier = {module_name}
+    while frontier:
+        next_frontier: set[str] = set()
+        for mod in frontier:
+            info = dag.modules.get(mod)
+            if info is None:
+                continue
+            for imp in info.importers:
+                if imp not in collected_set and imp != module_name:
+                    collected_set.add(imp)
+                    collected.append(imp)
+                    next_frontier.add(imp)
+        frontier = next_frontier
+    return collected
+
+
+def _collect_all_dependencies(dag: DAG, module_name: str) -> set[str]:
+    """Collect all transitive dependencies (imports) of a module."""
+    collected: set[str] = set()
+    frontier = {module_name}
+    while frontier:
+        next_frontier: set[str] = set()
+        for mod in frontier:
+            info = dag.modules.get(mod)
+            if info is None:
+                continue
+            for imp in info.imports:
+                if imp not in collected and imp != module_name:
+                    collected.add(imp)
+                    next_frontier.add(imp)
+        frontier = next_frontier
+    return collected
+
+
+def make_process_file(
+    removable_map: dict[str, int],
+    timeout: int,
+    traverser: DAGTraverser,
+    dag: DAG | None = None,
+    build_dependents: bool = False,
+    check_modules: list[str] | None = None,
+):
+    def process_file(module_name: str, filepath: Path) -> FileResult:
+        if module_name not in removable_map:
+            save_progress(module_name, file_sha256(filepath))
+            return FileResult()
+
+        line_idx = removable_map[module_name]
+        original_text = filepath.read_text()
+        lines = original_text.splitlines(keepends=True)
+
+        traverser.inflight_register(filepath, original_text)
+        try:
+            # Remove the set_option line and any following blank line
+            new_lines = list(lines)
+            del new_lines[line_idx]
+            # If removal left a double blank line, remove one
+            if (line_idx < len(new_lines) and line_idx > 0
+                    and new_lines[line_idx - 1].strip() == ""
+                    and new_lines[line_idx].strip() == ""):
+                del new_lines[line_idx]
+
+            filepath.write_text("".join(new_lines))
+
+            # Build the module itself
+            ok, _ = traverser.lake_build(module_name, PROJECT_DIR, timeout)
+
+            # Build specific check modules if requested
+            if ok and check_modules:
+                for cm in check_modules:
+                    if traverser.shutdown_event.is_set():
+                        break
+                    cm_ok, _ = traverser.lake_build(cm, PROJECT_DIR, timeout)
+                    if not cm_ok:
+                        ok = False
+                        break
+
+            # Also build dependents (reverse dependencies) if requested
+            if ok and build_dependents and dag is not None:
+                dependents = _collect_all_dependents(dag, module_name)
+                for dep in dependents:
+                    if traverser.shutdown_event.is_set():
+                        break
+                    dep_ok, _ = traverser.lake_build(dep, PROJECT_DIR, timeout)
+                    if not dep_ok:
+                        ok = False
+                        break
+
+            if ok:
+                save_progress(module_name, file_sha256(filepath))
+                return FileResult(removed=True)
+
+            # Revert
+            filepath.write_text(original_text)
+            # Rebuild the module with the option restored so oleans are correct
+            traverser.lake_build(module_name, PROJECT_DIR, timeout)
+            save_progress(module_name, file_sha256(filepath))
+            return FileResult(kept=True)
+        except BaseException:
+            filepath.write_text(original_text)
+            raise
+        finally:
+            traverser.inflight_unregister(filepath)
+
+    return process_file
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove unnecessary module-level set_option lines"
+    )
+    parser.add_argument(
+        "--option",
+        default=DEFAULT_OPTION,
+        help=f"Option name (default: {DEFAULT_OPTION})",
+    )
+    parser.add_argument(
+        "--value",
+        default="false",
+        help="Value of the option (default: false)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan and report without modifying files",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Max parallel workers (default: cpu_count)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Build timeout per module in seconds (default: 600)",
+    )
+    parser.add_argument(
+        "--no-initial",
+        action="store_true",
+        help="Skip the initial lake build",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from previous run",
+    )
+    parser.add_argument(
+        "--build-dependents",
+        action="store_true",
+        help="After removing the option, also build all transitive reverse "
+             "dependencies (importers). Catches non-local breakage from "
+             "option removal.",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        help="Only process these files",
+    )
+    parser.add_argument(
+        "--deps-of",
+        nargs="*",
+        metavar="MODULE",
+        help="Only process transitive dependencies of these modules "
+             "(module names like Mathlib.Foo.Bar)",
+    )
+    parser.add_argument(
+        "--check-module",
+        nargs="*",
+        metavar="MODULE",
+        help="After removing an option, also build these modules to verify "
+             "they still work (module names like Mathlib.Foo.Bar)",
+    )
+    args = parser.parse_args()
+
+    option = args.option
+    start_time = time.time()
+
+    # Build DAG
+    print("Building import DAG...", flush=True)
+    full_dag = DAG.from_directories(PROJECT_DIR)
+    print(f"  {len(full_dag.modules)} modules parsed")
+
+    # Scan for removable lines
+    print("Scanning for module-level set_option lines...", flush=True)
+    removable_map = scan_files(full_dag, option, args.value)
+
+    if args.files:
+        requested = set()
+        for f in args.files:
+            mod = f.replace("/", ".").removesuffix(".lean")
+            requested.add(mod)
+        removable_map = {k: v for k, v in removable_map.items() if k in requested}
+
+    if args.deps_of:
+        deps_set: set[str] = set()
+        for mod in args.deps_of:
+            deps_set |= _collect_all_dependencies(full_dag, mod)
+        removable_map = {k: v for k, v in removable_map.items() if k in deps_set}
+
+    print(f"  {len(removable_map)} files with the option set")
+
+    # Resume filtering
+    resumed = 0
+    if args.resume:
+        progress = load_progress()
+        if progress:
+            to_skip = []
+            for name in list(removable_map):
+                if name in progress:
+                    fp = full_dag.project_root / full_dag.modules[name].filepath
+                    if fp.exists() and file_sha256(fp) == progress[name]:
+                        to_skip.append(name)
+            for name in to_skip:
+                del removable_map[name]
+            resumed = len(to_skip)
+            if resumed:
+                print(f"  Resuming: skipped {resumed} already-processed modules"
+                      f" ({len(removable_map)} remaining)")
+
+    if not removable_map:
+        print("Nothing to do.")
+        return
+
+    if args.dry_run:
+        print(f"\n{len(removable_map)} files would be tested for removal")
+        print("(dry run — no changes made)")
+        return
+
+    # Initial build
+    if not args.no_initial:
+        print("Running initial build...", flush=True)
+        returncode, _ = lake_build_with_progress(PROJECT_DIR)
+        if returncode != 0:
+            print("  (initial build had errors — continuing anyway)")
+
+    # Initialize progress
+    if not PROGRESS_FILE.exists() or resumed == 0:
+        init_progress()
+
+    # Traverse backward
+    target_modules = set(removable_map.keys())
+    skip_modules = set(full_dag.modules.keys()) - target_modules
+
+    traverser = DAGTraverser()
+    display = _RemoveDisplay()
+    action = make_process_file(
+        removable_map, args.timeout, traverser,
+        dag=full_dag, build_dependents=args.build_dependents,
+        check_modules=args.check_module,
+    )
+
+    display.start(len(full_dag.modules))
+    try:
+        results = traverser.traverse(
+            full_dag,
+            action,
+            direction="backward",
+            max_workers=args.max_workers,
+            progress_callback=display.on_progress,
+            module_callback=display.on_module,
+            skip=skip_modules,
+        )
+    except KeyboardInterrupt:
+        display.stop()
+        print("\nInterrupted.", flush=True)
+        traverser.force_exit(1)
+    finally:
+        display.stop()
+
+    # Summary
+    target_results = [tr for tr in results if tr.module_name in target_modules]
+    total_removed = sum(1 for tr in target_results if tr.result and tr.result.removed)
+    total_kept = sum(1 for tr in target_results if tr.result and tr.result.kept)
+    errors = sum(1 for tr in target_results if tr.error)
+    duration = time.time() - start_time
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Files tested:     {len(target_results)}")
+    print(f"  Option removed:   {total_removed}")
+    print(f"  Option kept:      {total_kept}")
+    print(f"  Errors:           {errors}")
+    print(f"  Duration:         {duration:.0f}s")
+
+    if errors:
+        print("\nErrors:")
+        for tr in target_results:
+            if tr.error:
+                print(f"  {tr.module_name}: {tr.error}")
+
+    # Clean up progress
+    if errors == 0 and PROGRESS_FILE.exists():
+        PROGRESS_FILE.unlink()
+        print("  (progress file cleaned up)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rm_module_set_option.py
+++ b/scripts/rm_module_set_option.py
@@ -30,16 +30,26 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 
-from dag_traversal import (
-    DAG,
-    DAGTraverser,
-    Display,
-    ShutdownError,
-)
-from set_option_utils import (
-    PROJECT_DIR,
-    lake_build_with_progress,
-)
+try:
+    from dag_traversal import (
+        DAG,
+        DAGTraverser,
+        Display,
+        ShutdownError,
+    )
+    from set_option_utils import (
+        PROJECT_DIR,
+        lake_build_with_progress,
+    )
+except ImportError as _e:
+    raise SystemExit(
+        f"error: {_e}\n\n"
+        f"  This script depends on sibling Python files in {Path(__file__).parent}:\n"
+        "    - dag_traversal.py\n"
+        "    - set_option_utils.py\n"
+        "  These are mathlib scripts, not pip packages.  Copy them into your\n"
+        "  `scripts/` directory alongside this script."
+    )
 
 DEFAULT_OPTION = "backward.defeq.atInstanceTransparency"
 

--- a/scripts/rm_module_set_option.py
+++ b/scripts/rm_module_set_option.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Remove unnecessary module-level `set_option` lines from Mathlib.
+Remove unnecessary module-level `set_option` lines from a Lean project.
 
 Traverses the import DAG **backward** (downstream first) so removing an
 option from an upstream file doesn't invalidate cached .oleans of already-
@@ -9,6 +9,12 @@ processed downstream files.
 For each file that contains the target line, tries removing it and building
 the module.  If the build succeeds the line stays removed; otherwise it is
 restored.
+
+To use outside mathlib, copy `rm_module_set_option.py`, `dag_traversal.py` and
+`set_option_utils.py` to a subdirectory of your project named `scripts/` and
+then run from the project root with `scripts/rm_module_set_option.py`.  Pass
+`--directories <root>` if your source files aren't directly under the project
+root.
 
 Usage:
     python3 scripts/rm_module_set_option.py [--option NAME] [--dry-run] [--resume] ...
@@ -292,6 +298,12 @@ def main():
         help="Build timeout per module in seconds (default: 600)",
     )
     parser.add_argument(
+        "--directories",
+        nargs="+",
+        default=None,
+        help="Directories to scan when building the import DAG (default: '.')",
+    )
+    parser.add_argument(
         "--no-initial",
         action="store_true",
         help="Skip the initial lake build",
@@ -334,7 +346,7 @@ def main():
 
     # Build DAG
     print("Building import DAG...", flush=True)
-    full_dag = DAG.from_directories(PROJECT_DIR)
+    full_dag = DAG.from_directories(PROJECT_DIR, args.directories)
     print(f"  {len(full_dag.modules)} modules parsed")
 
     # Scan for removable lines

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -18,20 +18,30 @@ from pathlib import Path
 from threading import Lock
 from typing import Callable
 
-from dag_traversal import (
-    DAG,
-    DAGTraverser,
-    Display,
-    ShutdownError,
-)
-from set_option_utils import (
-    DEFAULT_OPTIONS,
-    PROJECT_DIR,
-    commented_pattern,
-    lake_build_with_progress,
-    lakefile_pattern,
-    removable_pattern,
-)
+try:
+    from dag_traversal import (
+        DAG,
+        DAGTraverser,
+        Display,
+        ShutdownError,
+    )
+    from set_option_utils import (
+        DEFAULT_OPTIONS,
+        PROJECT_DIR,
+        commented_pattern,
+        lake_build_with_progress,
+        lakefile_pattern,
+        removable_pattern,
+    )
+except ImportError as _e:
+    raise SystemExit(
+        f"error: {_e}\n\n"
+        f"  This script depends on sibling Python files in {Path(__file__).parent}:\n"
+        "    - dag_traversal.py\n"
+        "    - set_option_utils.py\n"
+        "  These are mathlib scripts, not pip packages.  Copy them into your\n"
+        "  `scripts/` directory alongside this script."
+    )
 
 
 PROGRESS_FILE = PROJECT_DIR / "scripts" / ".rm_set_option_progress.jsonl"
@@ -391,6 +401,13 @@ def main():
     # Step 1: lakefile.lean
     if not args.dry_run and (PROJECT_DIR / "lakefile.lean").exists():
         handle_lakefile(options, args.value)
+    elif (PROJECT_DIR / "lakefile.toml").exists():
+        opts_str = ", ".join(options)
+        print(
+            f"Note: lakefile.toml detected.  If {opts_str} is set in `leanOptions`\n"
+            "  there, you'll need to remove the entry manually — this script only\n"
+            "  edits lakefile.lean."
+        )
 
     # Step 2: build DAG
     print("Building import DAG...", flush=True)

--- a/scripts/rm_set_option.py
+++ b/scripts/rm_set_option.py
@@ -152,7 +152,7 @@ class _RemoveDisplay(Display):
             self._redraw()
 
 
-def handle_lakefile(options: list[str]) -> bool:
+def handle_lakefile(options: list[str], value: str = "false") -> bool:
     """Check and remove options from lakefile.lean. Returns True if changed."""
     lakefile = PROJECT_DIR / "lakefile.lean"
     content = lakefile.read_text()
@@ -160,7 +160,7 @@ def handle_lakefile(options: list[str]) -> bool:
     for opt in options:
         if opt not in content:
             continue
-        pat = lakefile_pattern(opt)
+        pat = lakefile_pattern(opt, value)
         new_content = pat.sub("", content)
         if new_content != content:
             content = new_content
@@ -171,13 +171,13 @@ def handle_lakefile(options: list[str]) -> bool:
     return changed
 
 
-def scan_files(dag: DAG, options: list[str]) -> dict[str, list[int]]:
+def scan_files(dag: DAG, options: list[str], value: str = "false") -> dict[str, list[int]]:
     """Find files with removable set_option lines.
 
     Returns dict of module_name -> list of 0-indexed line numbers.
     """
-    removable_pats = [removable_pattern(opt) for opt in options]
-    commented_pats = [commented_pattern(opt) for opt in options]
+    removable_pats = [removable_pattern(opt, value) for opt in options]
+    commented_pats = [commented_pattern(opt, value) for opt in options]
     results: dict[str, list[int]] = {}
     for name, info in dag.modules.items():
         filepath = dag.project_root / info.filepath
@@ -195,9 +195,9 @@ def scan_files(dag: DAG, options: list[str]) -> dict[str, list[int]]:
     return results
 
 
-def count_skipped(filepath: Path, options: list[str]) -> int:
+def count_skipped(filepath: Path, options: list[str], value: str = "false") -> int:
     """Count set_option lines with trailing comments."""
-    commented_pats = [commented_pattern(opt) for opt in options]
+    commented_pats = [commented_pattern(opt, value) for opt in options]
     count = 0
     for line in filepath.read_text().splitlines():
         if any(p.match(line) for p in commented_pats):
@@ -222,13 +222,14 @@ def make_process_file(
     options: list[str],
     timeout: int,
     traverser: DAGTraverser,
+    value: str = "false",
 ) -> Callable:
     """Create the per-file action callback."""
 
     def process_file(module_name: str, filepath: Path) -> FileResult:
         abs_path = filepath
         removable_lines = removable_map.get(module_name, [])
-        skipped = count_skipped(abs_path, options)
+        skipped = count_skipped(abs_path, options, value)
 
         if not removable_lines:
             save_progress(module_name, file_sha256(abs_path))
@@ -331,6 +332,11 @@ def main():
         help="Only scan/remove this specific option (default: all known options)",
     )
     parser.add_argument(
+        "--value",
+        default="false",
+        help="Value of the option to scan/remove (default: false)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Scan and report without modifying files or building",
@@ -384,7 +390,7 @@ def main():
 
     # Step 1: lakefile.lean
     if not args.dry_run and (PROJECT_DIR / "lakefile.lean").exists():
-        handle_lakefile(options)
+        handle_lakefile(options, args.value)
 
     # Step 2: build DAG
     print("Building import DAG...", flush=True)
@@ -393,7 +399,7 @@ def main():
 
     # Step 3: scan for removable lines
     print("Scanning for removable set_option lines...", flush=True)
-    removable_map = scan_files(full_dag, options)
+    removable_map = scan_files(full_dag, options, args.value)
 
     if args.files:
         # Filter to requested files
@@ -484,7 +490,7 @@ def main():
         _timer.start()
 
     display = _RemoveDisplay()
-    action = make_process_file(removable_map, options, args.timeout, traverser)
+    action = make_process_file(removable_map, options, args.timeout, traverser, args.value)
 
     display.start(len(full_dag.modules))
     try:


### PR DESCRIPTION
This PR cherry-picks a set of adaptation-helper scripts that @nomeata developed on the `lean-pr-testing-13492` branch during the adaptation for https://github.com/leanprover/lean4/pull/13492 (now merged). He flagged on Zulip ([thread](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/lean.2313492.2C.20stricter.20.40.5Bdefeq.5D.20inference/near/591078800)) that he plans to delete them from the adaptation branch and offered them up for adoption.

Changes:

- `scripts/add_set_option.py`, `scripts/rm_set_option.py`: new `--value` flag, so the scripts work for options whose default is `false` (where you want to insert `set_option X true in`) as well as the existing `false` case.
- `scripts/add_module_set_option.py` (new): file-level variant of `add_set_option.py` — inserts a module-scoped `set_option` after the imports (and module docstring, if present) rather than scoped to a declaration. Needed for eqn-affecting options.
- `scripts/rm_module_set_option.py` (new): file-level variant of `rm_set_option.py`. Traverses the import DAG backward, with resume support keyed on toolchain.
- `scripts/fix_nonlocal_set_option.py` (new): given failing modules, adds the option to all transitive deps then binary-search minimizes back to the smallest set whose modules need it.
- `scripts/fix_unused_simp_args.py` (new): parses `This simp argument is unused: X` warnings from `lake build` and removes `X` from the corresponding `simp` / `simp only` call. For `← X` it rewrites to `- X` because the `←` has simp-set side effects.
- `scripts/fix_long_lines.py` (new): breaks too-long lines at the last comma before column 100 and indents the continuation. Useful as a follow-up to scripts that rewrite simp lists.
- `scripts/README.md`: documents all of the above.

The defaults for `--option` in the new module-level scripts point at `backward.defeq.atInstanceTransparency` (the option from https://github.com/leanprover/lean4/pull/13492); for current options pass `--option <name>` explicitly.

Original commits from `lean-pr-testing-13492`:
- `6f1a3512906` chore(scripts): add `--value` flag to add/rm_set_option.py (had a small conflict with #38532's `lakefile.lean` existence check; resolved by combining)
- `36625b2a675` chore(scripts): bring back module-level / nonlocal scripts
- `de2a59b5839` chore(scripts): thread `--value` through `fix_nonlocal_set_option.py`
- `45f3ee41b94` (extracted) `fix_unused_simp_args.py`
- `4278b885305` (extracted) `fix_long_lines.py`
- `80852596213` doc(scripts): document new helpers

I sanity-checked each script: all parse, all `--help`s render, and `fix_long_lines.py` / `fix_unused_simp_args.py` produce the expected output on synthetic inputs.

🤖 Prepared with Claude Code