### PR TITLE
[Merged by Bors] - feat(Logic/Function/Defs): generalize bicomp to `Sort*`

### DIFF
--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -68,7 +68,7 @@ theorem Injective.beq_eq {α β : Type*} [BEq α] [LawfulBEq α] [BEq β] [Lawfu
 
 section Bicomp
 
-variable {α β γ δ ε : Type*}
+variable {α β γ δ ε : Sort*}
 
 /-- Compose a binary function `f` with a pair of unary functions `g` and `h`.
 If both arguments of `f` have the same type and `g = h`, then `bicompl f g g = f on g`. -/
@@ -82,10 +82,10 @@ def bicompr (f : γ → δ) (g : α → β → γ) (a b) :=
 -- Suggested local notation:
 local notation f " ∘₂ " g => bicompr f g
 
-theorem uncurry_bicompr (f : α → β → γ) (g : γ → δ) : uncurry (g ∘₂ f) = g ∘ uncurry f :=
+theorem uncurry_bicompr {α β γ δ} (f : α → β → γ) (g : γ → δ) : uncurry (g ∘₂ f) = g ∘ uncurry f :=
   rfl
 
-theorem uncurry_bicompl (f : γ → δ → ε) (g : α → γ) (h : β → δ) :
+theorem uncurry_bicompl {α β γ δ ε} (f : γ → δ → ε) (g : α → γ) (h : β → δ) :
     uncurry (bicompl f g h) = uncurry f ∘ Prod.map g h :=
   rfl
 


### PR DESCRIPTION
Like `Function.comp` and `Function.onFun`, these are general combinators that can work with `Sort*`.

---
The two lemmas that use `uncurry` need some of the variables to be `Type*` since `Prod` doesn't accept `Sort`, so they can't use the `variable`s.

I encountered this while trying to generalize some `onFun` lemmas to `bicompl`.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
