### PR TITLE
[Merged by Bors] - chore: more import / namespaces fixes for shake

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.Category.ModuleCat.Basic
 public import Mathlib.Algebra.Category.Grp.Limits
 public import Mathlib.Algebra.Colimit.Module
-public import Mathlib.Algebra.Module.Shrink
+public import Mathlib.Algebra.Module.Shrink -- shake: keep (Module R (Shrink.{w, max v w} ↥(sectionsSubmodule F))), cf. lean#13417
 
 /-!
 # The category of R-modules has all limits

--- a/Mathlib/NumberTheory/ModularForms/CuspFormSubmodule.lean
+++ b/Mathlib/NumberTheory/ModularForms/CuspFormSubmodule.lean
@@ -102,8 +102,6 @@ lemma isZeroAtImInfty_of_valueAtInfty_eq_zero {F : Type*} [FunLike F ℍ ℂ]
 
 section SL2Z
 
-open EisensteinSeries
-
 variable {k : ℤ}
 
 /-- An `𝒮ℒ` modular form with vanishing q-expansion constant term vanishes at every cusp. -/

--- a/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
+++ b/Mathlib/NumberTheory/RatFunc/Ostrowski.lean
@@ -32,7 +32,7 @@ namespace RatFunc
 
 section Infinity
 
-open FunctionField Polynomial Valuation
+open Polynomial Valuation
 
 lemma valuation_eq_valuation_X_zpow_intDegree_of_one_lt_valuation_X {f : RatFunc K}
     [v.IsTrivialOn K] (hlt : 1 < v X) (hf : f ≠ 0) : v f = v RatFunc.X ^ f.intDegree := by
@@ -58,7 +58,7 @@ lemma valuation_isEquiv_inftyValuation_of_one_lt_valuation_X [v.IsTrivialOn K] (
 
 end Infinity
 
-open IsDedekindDomain HeightOneSpectrum Set Valuation FunctionField Polynomial
+open IsDedekindDomain HeightOneSpectrum Set Valuation Polynomial
 
 lemma setOf_polynomial_valuation_lt_one_and_ne_zero_nonempty [v.IsNontrivial] [v.IsTrivialOn K]
     (hle : v RatFunc.X ≤ 1) : {p : K[X] | v p < 1 ∧ p ≠ 0}.Nonempty := by


### PR DESCRIPTION
We remove two unused namespaces and add a `shake: keep` for https://github.com/leanprover/lean4/issues/13417.

Along the same lines as #38569. Discovered when working on #38605.