### PR TITLE
[Merged by Bors] - feat(Data/ZMod/Basic): unit characterization for ZMod (p ^ d)

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -824,6 +824,18 @@ lemma isUnit_prime_iff_not_dvd {n p : ℕ} (hp : p.Prime) : IsUnit (p : ZMod n) 
 lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) :=
   (isUnit_prime_iff_not_dvd hp).mpr h
 
+/-- In `ZMod (p ^ d)`, a natural number not divisible by the prime `p` is a unit. -/
+theorem isUnit_natCast_of_not_dvd_pow {p d a : ℕ} (hp : p.Prime) (ha : ¬ p ∣ a) :
+    IsUnit (a : ZMod (p ^ d)) := by
+  rw [isUnit_iff_coprime]
+  exact (hp.coprime_iff_not_dvd.mpr ha).symm.pow_right d
+
+/-- In `ZMod (p ^ d)` with `d ≥ 1`, the prime `p` is not a unit. -/
+theorem prime_natCast_not_isUnit_pow {p d : ℕ} (hp : p.Prime) (hd : 0 < d) :
+    ¬ IsUnit ((p : ℕ) : ZMod (p ^ d)) := by
+  rw [isUnit_prime_iff_not_dvd hp]
+  exact not_not.mpr (dvd_pow_self p (Nat.ne_zero_of_lt hd))
+
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by
   have := congr_arg ((↑) : ℕ → ZMod n) (val_coe_unit_coprime u)

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -824,17 +824,17 @@ lemma isUnit_prime_iff_not_dvd {n p : ℕ} (hp : p.Prime) : IsUnit (p : ZMod n) 
 lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) :=
   (isUnit_prime_iff_not_dvd hp).mpr h
 
-/-- In `ZMod (p ^ d)`, a natural number not divisible by the prime `p` is a unit. -/
-theorem isUnit_natCast_of_not_dvd_pow {p d a : ℕ} (hp : p.Prime) (ha : ¬ p ∣ a) :
-    IsUnit (a : ZMod (p ^ d)) := by
-  rw [isUnit_iff_coprime]
-  exact (hp.coprime_iff_not_dvd.mpr ha).symm.pow_right d
+/-- In `ZMod (p ^ d)` with `d ≥ 1`, a natural number is a unit iff `p` does not divide it. -/
+theorem isUnit_natCast_iff_not_dvd_pow {p d a : ℕ} (hp : p.Prime) (hd : 0 < d) :
+    IsUnit (a : ZMod (p ^ d)) ↔ ¬ p ∣ a := by
+  rw [isUnit_iff_coprime, Nat.coprime_pow_right_iff hd, Nat.coprime_comm,
+    hp.coprime_iff_not_dvd]
 
 /-- In `ZMod (p ^ d)` with `d ≥ 1`, the prime `p` is not a unit. -/
 theorem prime_natCast_not_isUnit_pow {p d : ℕ} (hp : p.Prime) (hd : 0 < d) :
     ¬ IsUnit ((p : ℕ) : ZMod (p ^ d)) := by
-  rw [isUnit_prime_iff_not_dvd hp]
-  exact not_not.mpr (dvd_pow_self p (Nat.ne_zero_of_lt hd))
+  simp [isUnit_prime_iff_not_dvd hp]
+  lia
 
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -824,13 +824,13 @@ lemma isUnit_prime_iff_not_dvd {n p : ℕ} (hp : p.Prime) : IsUnit (p : ZMod n) 
 lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) :=
   (isUnit_prime_iff_not_dvd hp).mpr h
 
-/-- In `ZMod (p ^ d)` with `d ≥ 1`, a natural number is a unit iff `p` does not divide it. -/
+/-- In `ZMod (p ^ d)` with `0 < d`, a natural number is a unit iff `p` does not divide it. -/
 theorem isUnit_natCast_iff_not_dvd_pow {p d a : ℕ} (hp : p.Prime) (hd : 0 < d) :
     IsUnit (a : ZMod (p ^ d)) ↔ ¬ p ∣ a := by
   rw [isUnit_iff_coprime, Nat.coprime_pow_right_iff hd, Nat.coprime_comm,
     hp.coprime_iff_not_dvd]
 
-/-- In `ZMod (p ^ d)` with `d ≥ 1`, the prime `p` is not a unit. -/
+/-- In `ZMod (p ^ d)` with `0 < d`, the prime `p` is not a unit. -/
 theorem prime_natCast_not_isUnit_pow {p d : ℕ} (hp : p.Prime) (hd : 0 < d) :
     ¬ IsUnit ((p : ℕ) : ZMod (p ^ d)) := by
   simp [isUnit_prime_iff_not_dvd hp]


### PR DESCRIPTION
Add two lemmas characterizing units in `ZMod (p ^ d)` for a prime `p`:

* `ZMod.isUnit_natCast_of_not_dvd_pow`: a natural number not divisible by `p` is a unit in `ZMod (p ^ d)`.
* `ZMod.prime_natCast_not_isUnit_pow`: the prime `p` is not a unit in `ZMod (p ^ d)` when `d ≥ 1`.

These complement the existing `isUnit_prime_iff_not_dvd` (which characterizes when a *prime* is a unit in `ZMod n`) by characterizing when an *arbitrary* natural number is a unit in `ZMod (p ^ d)`.

**Motivation.** Arithmetic verification over fixed-width bitvectors works in `ZMod (2 ^ d)`. A Gröbner basis solver over this ring needs to know which constants are invertible: odd constants are units (enabling algebraic simplification), while even constants are not (requiring fallback to SAT). These lemmas formalize that characterization for any prime, not just 2.

Further work related to Gröbner basis will be published once #29203 (and, before that, #34873) have been merged.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
