### PR TITLE
feat(MeasureTheory): `restrict_absolutelyContinuous_restrict`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -144,6 +144,18 @@ theorem restrict_le_self : μ.restrict s ≤ μ :=
 theorem absolutelyContinuous_restrict : μ.restrict s ≪ μ :=
   Measure.absolutelyContinuous_of_le Measure.restrict_le_self
 
+theorem absolutelyContinuous_restrict_subset' {_m0 : MeasurableSpace α} ⦃s s' : Set α⦄
+  ⦃μ ν : Measure α⦄ (hs : s ≤ᵐ[μ] s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' := by
+  refine Measure.AbsolutelyContinuous.mk fun t ht h ↦ ?_
+  rw [restrict_apply ht] at ⊢ h
+  have hv : μ (t ∩ s) ≤ μ (t ∩ s') :=
+    measure_mono_ae <| hs.mono fun _x hx ⟨hxt, hxs⟩ => ⟨hxt, hx hxs⟩
+  simpa [nonpos_iff_eq_zero, hμν.null_mono, h] using hv
+
+theorem absolutelyContinuous_restrict_subset {_m0 : MeasurableSpace α} ⦃s s' : Set α⦄
+  ⦃μ ν : Measure α⦄ (hs : s ≤ s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' := by
+  exact absolutelyContinuous_restrict_subset' (ae_of_all _ hs) hμν
+
 variable (μ)
 
 theorem restrict_eq_self (h : s ⊆ t) : μ.restrict t s = μ s :=

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -144,7 +144,7 @@ theorem restrict_le_self : μ.restrict s ≤ μ :=
 theorem absolutelyContinuous_restrict : μ.restrict s ≪ μ :=
   Measure.absolutelyContinuous_of_le Measure.restrict_le_self
 
-theorem restrict_absolutelyContinuous_restrict' ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+theorem restrict_absolutelyContinuous_restrict' {s s' : Set α} {μ ν : Measure α}
     (hs : (· ∈ s) ≤ᵐ[μ] (· ∈ s')) (hμν : μ ≪ ν) :
     μ.restrict s ≪ ν.restrict s' := by
   refine .mk fun t ht h ↦ ?_
@@ -153,7 +153,7 @@ theorem restrict_absolutelyContinuous_restrict' ⦃s s' : Set α⦄ ⦃μ ν : M
     measure_mono_ae <| hs.mono fun _x hx ⟨hxt, hxs⟩ => ⟨hxt, hx hxs⟩
   simpa [nonpos_iff_eq_zero, hμν.null_mono, h] using hv
 
-theorem restrict_absolutelyContinuous_restrict ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+theorem restrict_absolutelyContinuous_restrict {s s' : Set α} {μ ν : Measure α}
     (hs : s ⊆ s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' :=
   restrict_absolutelyContinuous_restrict' (ae_of_all _ hs) hμν
 
@@ -527,7 +527,7 @@ lemma AbsolutelyContinuous.restrict (h : μ ≪ ν) (s : Set α) : μ.restrict s
   rw [restrict_apply ht] at htν ⊢
   exact h htν
 
-lemma AbsolutelyContinuous.restrict_of_subset ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+lemma AbsolutelyContinuous.restrict_of_subset {s s' : Set α} {μ ν : Measure α}
     (hμν : μ.restrict s' ≪ ν.restrict s') (hs : s ⊆ s') :
     μ.restrict s ≪ ν.restrict s := by
   simpa [hs] using hμν.restrict s

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -144,17 +144,18 @@ theorem restrict_le_self : μ.restrict s ≤ μ :=
 theorem absolutelyContinuous_restrict : μ.restrict s ≪ μ :=
   Measure.absolutelyContinuous_of_le Measure.restrict_le_self
 
-theorem absolutelyContinuous_restrict_subset' {_m0 : MeasurableSpace α} ⦃s s' : Set α⦄
-  ⦃μ ν : Measure α⦄ (hs : s ≤ᵐ[μ] s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' := by
-  refine Measure.AbsolutelyContinuous.mk fun t ht h ↦ ?_
+theorem restrict_absolutelyContinuous_restrict' ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+    (hs : (· ∈ s) ≤ᵐ[μ] (· ∈ s')) (hμν : μ ≪ ν) :
+    μ.restrict s ≪ ν.restrict s' := by
+  refine .mk fun t ht h ↦ ?_
   rw [restrict_apply ht] at ⊢ h
   have hv : μ (t ∩ s) ≤ μ (t ∩ s') :=
     measure_mono_ae <| hs.mono fun _x hx ⟨hxt, hxs⟩ => ⟨hxt, hx hxs⟩
   simpa [nonpos_iff_eq_zero, hμν.null_mono, h] using hv
 
-theorem absolutelyContinuous_restrict_subset {_m0 : MeasurableSpace α} ⦃s s' : Set α⦄
-  ⦃μ ν : Measure α⦄ (hs : s ≤ s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' := by
-  exact absolutelyContinuous_restrict_subset' (ae_of_all _ hs) hμν
+theorem restrict_absolutelyContinuous_restrict ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+    (hs : s ⊆ s') (hμν : μ ≪ ν) : μ.restrict s ≪ ν.restrict s' :=
+  restrict_absolutelyContinuous_restrict' (ae_of_all _ hs) hμν
 
 variable (μ)
 

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -213,6 +213,7 @@ theorem restrict_restrict₀ (hs : NullMeasurableSet s (μ.restrict t)) :
 theorem restrict_restrict (hs : MeasurableSet s) : (μ.restrict t).restrict s = μ.restrict (s ∩ t) :=
   restrict_restrict₀ hs.nullMeasurableSet
 
+@[simp]
 theorem restrict_restrict_of_subset (h : s ⊆ t) : (μ.restrict t).restrict s = μ.restrict s := by
   ext1 u hu
   rw [restrict_apply hu, restrict_apply hu, restrict_eq_self]
@@ -525,6 +526,11 @@ lemma AbsolutelyContinuous.restrict (h : μ ≪ ν) (s : Set α) : μ.restrict s
   refine Measure.AbsolutelyContinuous.mk (fun t ht htν ↦ ?_)
   rw [restrict_apply ht] at htν ⊢
   exact h htν
+
+lemma AbsolutelyContinuous.restrict_of_subset ⦃s s' : Set α⦄ ⦃μ ν : Measure α⦄
+    (hμν : μ.restrict s' ≪ ν.restrict s') (hs : s ⊆ s') :
+    μ.restrict s ≪ ν.restrict s := by
+  simpa [hs] using hμν.restrict s
 
 theorem restrict_iUnion_ae [Countable ι] {s : ι → Set α} (hd : Pairwise (AEDisjoint μ on s))
     (hm : ∀ i, NullMeasurableSet (s i) μ) : μ.restrict (⋃ i, s i) = sum fun i => μ.restrict (s i) :=


### PR DESCRIPTION
Adding three lemmas about absolute continuity of restrictions of measures to subsets.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
