### PR TITLE
[Merged by Bors] - chore(Topology/Sheaves/SheafCondition/OpensLeCover): remove `erw`s

### DIFF
--- a/Mathlib/Topology/Sheaves/SheafCondition/OpensLeCover.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/OpensLeCover.lean
@@ -159,14 +159,14 @@ def whiskerIsoMapGenerateCocone (hY : Y = iSup U) :
   hom :=
     { hom := F.map (eqToHom (congr_arg op hY.symm))
       w := fun j => by
-        erw [← F.map_comp]
         dsimp
+        rw [← F.map_comp]
         congr 1 }
   inv :=
     { hom := F.map (eqToHom (congr_arg op hY))
       w := fun j => by
-        erw [← F.map_comp]
         dsimp
+        rw [← F.map_comp]
         congr 1 }
   hom_inv_id := by
     ext


### PR DESCRIPTION
- rewrites both `w` proofs in `whiskerIsoMapGenerateCocone` to replace `erw [← F.map_comp]` with `dsimp` followed by `rw [← F.map_comp]`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)