### PR TITLE
[Merged by Bors] - feat(NumberTheory.Height.Northcott): lemmas on compositions

### DIFF
--- a/Mathlib/NumberTheory/Height/Northcott.lean
+++ b/Mathlib/NumberTheory/Height/Northcott.lean
@@ -62,7 +62,7 @@ lemma comp_of_bddAbove [Preorder β] [LE γ] [Northcott h] (H : ∀ c, BddAbove 
     exact (finite_le (h := h) b).subset <| by grind
 
 /-- A composition `h' ∘ h` is Northcott when `h'` is Northcott and the fibers of `h` are finite. -/
-lemma comp_of_fnite_fibers [LE γ] [Northcott h'] (H : ∀ b, (h ⁻¹' {b}).Finite) :
+lemma comp_of_finite_fibers [LE γ] [Northcott h'] (H : ∀ b, (h ⁻¹' {b}).Finite) :
     Northcott (h' ∘ h) where
   finite_le c := by
     refine Set.Finite.of_finite_fibers h ?_ fun x _ ↦ (H x).inter_of_right _

--- a/Mathlib/NumberTheory/Height/Northcott.lean
+++ b/Mathlib/NumberTheory/Height/Northcott.lean
@@ -29,7 +29,7 @@ In number theory, the height function `h` satisfies the *Northcott property* tha
 
 @[expose] public noncomputable section
 
-variable {α β : Type*} (h : α → β)
+variable {α β γ : Type*} (h : α → β) (h' : β → γ)
 
 /-- A function `h : α → β` is Northcott if the sets `{a : α | h a ≤ b}` are all finite. -/
 @[mk_iff]
@@ -44,9 +44,28 @@ theorem northcott_iff_tendsto [LinearOrder β] [NoMaxOrder β] :
   obtain ⟨b', hc⟩ := exists_gt b
   exact (H b').subset fun x hx ↦ lt_of_le_of_lt hx hc
 
-theorem Northcott.exists_min_image [LinearOrder β] [Northcott h] (s : Set α) (hs : s.Nonempty) :
+namespace Northcott
+
+theorem exists_min_image [LinearOrder β] [Northcott h] (s : Set α) (hs : s.Nonempty) :
     ∃ a ∈ s, ∀ a' ∈ s, h a ≤ h a' := by
   obtain ⟨a₁, h₁⟩ := hs
   obtain ⟨a₂, h₂, h₃⟩ := Set.exists_min_image ({a | h a ≤ h a₁} ∩ s) h
     ((finite_le (h a₁)).inter_of_left s) ⟨a₁, le_rfl, h₁⟩
   grind
+
+/-- A composition `h' ∘ h` is Northcott when `h` is Northcott and preimages of bounded above sets
+under `h'` are bounded above. -/
+lemma comp_of_bddAbove [Preorder β] [LE γ] [Northcott h] (H : ∀ c, BddAbove (h' ⁻¹' {x | x ≤ c})) :
+    Northcott (h' ∘ h) where
+  finite_le c := by
+    obtain ⟨b, hb⟩ := bddAbove_def.mp (H c)
+    exact (finite_le (h := h) b).subset <| by grind
+
+/-- A composition `h' ∘ h` is Northcott when `h'` is Northcott and the fibers of `h` are finite. -/
+lemma comp_of_fnite_fibers [LE γ] [Northcott h'] (H : ∀ b, (h ⁻¹' {b}).Finite) :
+    Northcott (h' ∘ h) where
+  finite_le c := by
+    refine Set.Finite.of_finite_fibers h ?_ fun x _ ↦ (H x).inter_of_right _
+    exact (finite_le (h := h') c).subset <| by grind
+
+end Northcott


### PR DESCRIPTION
This adds two lemmas to Mathlib.NumberTheory.Height.Northcott:
* `Northcott.lemma comp_of_bddAbove`: the post-composition of a Northcott function with a function that pulls back bounded above sets to bounded above sets is Northcott
* `Northcott.comp_of_finite_fibers`: the pre-composition of a Northcott function with a function that has finite fibers is Northcott.

They will be useful in the context of heights.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
