### PR TITLE
chore(RingTheory): equality of linear map with values in finite module spreads out

### DIFF
--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -9,7 +9,7 @@ public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 public import Mathlib.LinearAlgebra.Isomorphisms
 public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 public import Mathlib.RingTheory.Finiteness.Projective
-public import Mathlib.RingTheory.Localization.BaseChange
+public import Mathlib.RingTheory.Localization.Algebra
 public import Mathlib.RingTheory.Noetherian.Basic
 public import Mathlib.RingTheory.TensorProduct.Finite
 
@@ -421,6 +421,65 @@ lemma Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule
 
 variable {M' : Type*} [AddCommGroup M'] [Module R M'] (f : M →ₗ[R] M') [IsLocalizedModule S f]
 variable {N' : Type*} [AddCommGroup N'] [Module R N'] (g : N →ₗ[R] N') [IsLocalizedModule S g]
+
+lemma Module.Finite.exists_localizedModuleMap_powers_eq [Module.Finite R M] {u v : M →ₗ[R] N}
+    (hf : IsLocalizedModule.map S f g u = IsLocalizedModule.map S f g v) :
+    ∃ r ∈ S, ∀ (t : R),
+      r ∣ t → LocalizedModule.map (.powers t) u = LocalizedModule.map (.powers t) v := by
+  obtain ⟨s, hs⟩ : ∃ (s : S), s • u = s • v := by
+    refine Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule S
+      (N := N) (N' := N') (M := M) g u v ?_
+    ext x
+    simpa using DFunLike.congr_fun hf (f x)
+  refine ⟨s, s.property, fun t ht ↦ LinearMap.restrictScalars_injective R ?_⟩
+  refine IsLocalizedModule.linearMap_ext (.powers t) (LocalizedModule.mkLinearMap _ _)
+    (LocalizedModule.mkLinearMap _ _) ?_
+  ext x
+  dsimp
+  simp only [LocalizedModule.map_mk, LocalizedModule.mk_eq, one_smul, Subtype.exists,
+    Submonoid.mk_smul, exists_prop]
+  refine ⟨t, ⟨1, by simp⟩, ?_⟩
+  obtain ⟨a, rfl⟩ := exists_eq_mul_left_of_dvd ht
+  simp only [mul_smul, ← Submonoid.smul_def, ← LinearMap.smul_apply, hs]
+
+open Localization IsLocalizedModule in
+lemma Module.Finite.exists_lTensor_away_eq [Module.Finite R M] {u v : M →ₗ[R] N}
+    (hf : IsLocalizedModule.map S f g u = IsLocalizedModule.map S f g v) :
+    ∃ r ∈ S, ∀ (t : R), r ∣ t → u.lTensor (Away t) = v.lTensor (Away t) := by
+  obtain ⟨r, hr, h⟩ := exists_localizedModuleMap_powers_eq _ _ _ hf
+  refine ⟨r, hr, fun t ht ↦ ?_⟩
+  rw [← map_tensorProductMk_eq_lTensor (.powers t), ← map_tensorProductMk_eq_lTensor (.powers t),
+    map_eq_map_iff_localizedModule]
+  apply h t ht
+
+lemma Module.Finite.exists_algebraTensorProductMap_id_eq {A B : Type*} [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] [Module.Finite R A] (Rₚ : Type*) (Aₚ Bₚ : Type*) [CommRing Rₚ]
+    [CommRing Aₚ] [CommRing Bₚ] [Algebra R Rₚ] [Algebra R Aₚ] [Algebra R Bₚ] [Algebra Rₚ Aₚ]
+    [Algebra Rₚ Bₚ] [Algebra A Aₚ] [Algebra B Bₚ] [IsScalarTower R A Aₚ] [IsScalarTower R B Bₚ]
+    [IsScalarTower R Rₚ Aₚ] [IsScalarTower R Rₚ Bₚ] [IsLocalization S Rₚ]
+    [IsLocalization (Algebra.algebraMapSubmonoid A S) Aₚ]
+    [IsLocalization (Algebra.algebraMapSubmonoid B S) Bₚ] (f g : A →ₐ[R] B)
+    (hf : IsLocalization.mapₐ S Rₚ Aₚ Bₚ f = IsLocalization.mapₐ S Rₚ Aₚ Bₚ g) :
+    ∃ r ∈ S, ∀ (t : R), r ∣ t →
+      Algebra.TensorProduct.map (.id (Localization.Away t) (Localization.Away t)) f =
+        Algebra.TensorProduct.map (.id (Localization.Away t) (Localization.Away t)) g := by
+  have :
+      IsLocalizedModule.map S
+        (IsScalarTower.toAlgHom _ A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+        f.toLinearMap =
+      IsLocalizedModule.map S
+        (IsScalarTower.toAlgHom R A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+        g.toLinearMap := by
+    apply IsLocalizedModule.linearMap_ext S (IsScalarTower.toAlgHom R A Aₚ).toLinearMap
+        (IsScalarTower.toAlgHom R B Bₚ).toLinearMap
+    ext x
+    simp only [LinearMap.coe_comp, Function.comp_apply, IsLocalizedModule.map_apply]
+    simpa using congr($(hf) (algebraMap A Aₚ x))
+  obtain ⟨r, hr, h⟩ := Module.Finite.exists_lTensor_away_eq S
+    (IsScalarTower.toAlgHom R A Aₚ).toLinearMap (IsScalarTower.toAlgHom R B Bₚ).toLinearMap this
+  refine ⟨r, hr, fun t ht ↦ ?_⟩
+  ext x
+  simpa using congr($(h t ht) (1 ⊗ₜ x))
 
 /--
 Let `M` be a finite `R`-module, and `N` be a finitely presented `R`-module.

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -151,6 +151,16 @@ theorem bijective_linearMap_mul' : Function.Bijective (LinearMap.mul' R A) :=
 
 end IsLocalization
 
+lemma IsLocalizedModule.map_tensorProductMk_eq_lTensor {N : Type*} [AddCommMonoid N] [Module R N]
+    {f : M →ₗ[R] N} :
+    map S (TensorProduct.mk R A M 1) (TensorProduct.mk R A N 1) f = f.lTensor A := by
+  ext a x
+  simp only [AlgebraTensorModule.curry_apply, LinearMap.restrictScalars_self, curry_apply,
+    LinearMap.lTensor_tmul]
+  rw [tmul_eq_smul_one_tmul, ← mk_apply,
+    (IsLocalization.linearMap_compatibleSMul S A _ _).map_smul, map_apply]
+  simp [smul_tmul']
+
 variable (T B : Type*) [CommSemiring T] [CommSemiring B]
   [Algebra R T] [Algebra T B] [Algebra R B] [Algebra A B] [IsScalarTower R T B]
   [IsScalarTower R A B]

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -366,4 +366,9 @@ lemma map_bijective_iff_localizedModuleMap_bijective :
       Function.Bijective (LocalizedModule.map S l) := by
   simp [LocalizedModule.coe_map_eq g₁ g₂]
 
+lemma map_eq_map_iff_localizedModule {f g : M →ₗ[R] N} :
+    map S g₁ g₂ f = map S g₁ g₂ g ↔ LocalizedModule.map S f = LocalizedModule.map S g := by
+  conv_rhs => rw [← LinearMap.restrictScalars_inj R]
+  simp [LocalizedModule.restrictScalars_map_eq _ g₁ g₂]
+
 end IsLocalizedModule


### PR DESCRIPTION
We add some corollaries of `Module.Finite.exists_smul_of_comp_eq_of_isLocalizedModule`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
