### PR TITLE
[Merged by Bors] - feat(RingTheory.DedekindDomain.Factorization): add API for factorization

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Basic
 public import Mathlib.Order.Filter.Cofinite
+public import Mathlib.RingTheory.UniqueFactorizationDomain.Finsupp
 
 /-!
 # Factorization of ideals and fractional ideals of Dedekind domains
@@ -842,3 +843,139 @@ theorem Ideal.map_algebraMap_eq_finsetProd_pow {p : Ideal S} [p.IsMaximal] (hp :
 alias Ideal.map_algebraMap_eq_finset_prod_pow := Ideal.map_algebraMap_eq_finsetProd_pow
 
 end primesOver
+
+/-!
+### Conversion between various multplicities
+-/
+
+section conversion
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+open UniqueFactorizationMonoid in
+/-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
+as `multiplicity p.asIdeal I`. -/
+@[simp]
+lemma count_normalizedFactors_eq_multiplicity [DecidableEq (Ideal R)] {I : Ideal R} (hI : I ≠ ⊥)
+    (p : HeightOneSpectrum R) :
+    Multiset.count p.asIdeal (normalizedFactors I) = multiplicity p.asIdeal I := by
+  have := emultiplicity_eq_count_normalizedFactors (irreducible p) hI
+  rw [normalize_eq p.asIdeal] at this
+  apply_fun ((↑) : ℕ → ℕ∞) using CharZero.cast_injective
+  rw [← this]
+  exact (finiteMultiplicity_of_emultiplicity_eq_natCast this).emultiplicity_eq_multiplicity
+
+/-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
+as `multiplicity p.asIdeal I`. -/
+@[simp]
+lemma maxPowDividing_eq_pow_multiplicity {I : Ideal R} (hI : I ≠ ⊥) (p : HeightOneSpectrum R) :
+    p.maxPowDividing I = p.asIdeal ^ multiplicity p.asIdeal I := by
+  classical
+  rw [maxPowDividing_eq_pow_multiset_count _ hI, count_normalizedFactors_eq_multiplicity hI]
+
+/-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
+as `multiplicity p.asIdeal I`. -/
+@[simp]
+lemma factorization_eq_multiplicity {I : Ideal R} (hI : I ≠ ⊥) (p : HeightOneSpectrum R) :
+    factorization I p.asIdeal = multiplicity p.asIdeal I := by
+  rw [factorization_eq_count, count_normalizedFactors_eq_multiplicity hI]
+
+end IsDedekindDomain.HeightOneSpectrum
+
+end conversion
+
+/-!
+### Lemmas about multiplicities
+
+We collect here lemmas about the multiplicity of a prime ideal `p` in the factorization
+of some ideal `I`.
+These are phrased in terms of `multiplicity p.asIdeal I`.
+-/
+
+section multiplicity
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+
+lemma Ideal.finprod_heightOneSpectrum_pow_multiplicity {I : Ideal R} (hI : I ≠ ⊥) :
+    ∏ᶠ p : HeightOneSpectrum R, p.asIdeal ^ multiplicity p.asIdeal I = I := by
+  simpa only [maxPowDividing_eq_pow_multiplicity hI]
+    using finprod_heightOneSpectrum_factorization hI
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+lemma multiplicity_le_of_ideal_ge (p : HeightOneSpectrum R) {I J : Ideal R} (h : J ≤ I)
+    (hJ : J ≠ ⊥) :
+    multiplicity p.asIdeal I ≤ multiplicity p.asIdeal J := by
+  classical
+  rw [← count_normalizedFactors_eq_multiplicity hJ,
+    ← count_normalizedFactors_eq_multiplicity <| ne_bot_of_le_ne_bot hJ h]
+  exact Ideal.count_le_of_ideal_ge h hJ _
+
+open UniqueFactorizationMonoid Multiset in
+lemma multiplicity_sup (p : HeightOneSpectrum R) {I J : Ideal R} (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
+    multiplicity p.asIdeal (I ⊔ J) = multiplicity p.asIdeal I ⊓ multiplicity p.asIdeal J := by
+  classical
+  rw [Ideal.sup_eq_prod_inf_factors hI hJ, ← count_normalizedFactors_eq_multiplicity ?h,
+    ← count_normalizedFactors_eq_multiplicity hI, ← count_normalizedFactors_eq_multiplicity hJ]
+  -- extracted from the proof of `sup_eq_prod_inf_factors`
+  --   ==> refactor that (Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas)
+  case h =>
+    exact prod_ne_zero_of_prime _
+      fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).1
+  have H : normalizedFactors (normalizedFactors I ∩ normalizedFactors J).prod =
+      normalizedFactors I ∩ normalizedFactors J := by
+    refine normalizedFactors_prod_of_prime fun p hp ↦ ?_
+    rw [Multiset.mem_inter] at hp
+    exact prime_of_normalized_factor p hp.left
+  rw [H]
+  exact count_inter ..
+
+lemma emultiplicity_sup (p : HeightOneSpectrum R) (I J : Ideal R) :
+    emultiplicity p.asIdeal (I ⊔ J) = emultiplicity p.asIdeal I ⊓ emultiplicity p.asIdeal J := by
+  rcases eq_or_ne I ⊥ with rfl | hI
+  · rw [bot_eq_zero, emultiplicity_zero]
+    simp
+  rcases eq_or_ne J ⊥ with rfl | hJ
+  · rw [bot_eq_zero, emultiplicity_zero]
+    simp
+  have : I ⊔ J ≠ ⊥ := by grind
+  have H {I' : Ideal R} (h : I' ≠ ⊥) : FiniteMultiplicity p.asIdeal I' :=
+    FiniteMultiplicity.of_prime_left (prime p) h
+  rw [(H this).emultiplicity_eq_multiplicity, (H hI).emultiplicity_eq_multiplicity,
+    (H hJ).emultiplicity_eq_multiplicity, multiplicity_sup _ hI hJ]
+  norm_cast
+
+lemma emultiplicity_ciSup {ι : Type*} [Finite ι] (p : HeightOneSpectrum R) (I : ι → Ideal R) :
+    emultiplicity p.asIdeal (⨆ i, I i) = ⨅ i, emultiplicity p.asIdeal (I i) := by
+  induction ι using Finite.induction_empty_option with
+  | h_empty =>
+    rw [iSup_of_empty, iInf_of_empty]
+    exact emultiplicity_zero _
+  | of_equiv e ih =>
+    specialize @ih (I ∘ e)
+    rw [← sSup_range, ← sInf_range] at ih ⊢
+    rw [EquivLike.range_comp I e] at ih
+    rw [ih, ← EquivLike.range_comp (fun i ↦ emultiplicity p.asIdeal (I i)) e]
+    rfl
+  | h_option ih =>
+    rw [iSup_option, emultiplicity_sup p .., ih, iInf_option]
+
+lemma multiplicity_ciSup {ι : Type*} [Finite ι] [Nonempty ι] (p : HeightOneSpectrum R)
+    {I : ι → Ideal R} (hI : ∀ i, I i ≠ ⊥) :
+    multiplicity p.asIdeal (⨆ i, I i) = ⨅ i, multiplicity p.asIdeal (I i) := by
+  have H i : FiniteMultiplicity p.asIdeal (I i) :=
+    FiniteMultiplicity.of_prime_left (prime p) <| hI i
+  have H' : FiniteMultiplicity p.asIdeal (⨆ i, I i) := by
+    refine FiniteMultiplicity.of_prime_left (prime p) ?_
+    contrapose! hI
+    rw [← bot_eq_zero, iSup_eq_bot] at hI
+    exact ⟨Classical.ofNonempty, hI _⟩
+  have := emultiplicity_ciSup p I
+  simp only [H'.emultiplicity_eq_multiplicity, (H _).emultiplicity_eq_multiplicity] at this
+  exact_mod_cast this
+
+end IsDedekindDomain.HeightOneSpectrum
+
+end multiplicity

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -845,9 +845,9 @@ alias Ideal.map_algebraMap_eq_finset_prod_pow := Ideal.map_algebraMap_eq_finsetP
 end primesOver
 
 /-!
-### Conversion between various multplicities
+### Conversion between various multiplicities
 
-We provide some `simp` lemmas that convert various ways of expressing the multiplicity of
+We provide some lemmas that convert various ways of expressing the multiplicity of
 a prime ideal `p` in the factorization of some ideal `I` into `multiplicity p.asIdeal I`.
 -/
 
@@ -872,6 +872,8 @@ lemma count_normalizedFactors_eq_multiplicity :
   rw [← this]
   exact (finiteMultiplicity_of_emultiplicity_eq_natCast this).emultiplicity_eq_multiplicity
 
+-- This is not `simp`; otherwise some `aesop` proofs break
+-- in `Mathlib.Algebra.Module.Torsion.PrimaryComponent`.
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
 lemma maxPowDividing_eq_pow_multiplicity :
@@ -944,7 +946,7 @@ lemma emultiplicity_sup :
 
 variable {ι : Type*} [Finite ι]
 
-lemma emultiplicity_ciSup (I : ι → Ideal R) :
+lemma emultiplicity_iSup (I : ι → Ideal R) :
     emultiplicity p.asIdeal (⨆ i, I i) = ⨅ i, emultiplicity p.asIdeal (I i) := by
   induction ι using Finite.induction_empty_option with
   | h_empty =>
@@ -959,7 +961,7 @@ lemma emultiplicity_ciSup (I : ι → Ideal R) :
   | h_option ih =>
     rw [iSup_option, emultiplicity_sup p .., ih, iInf_option]
 
-lemma multiplicity_ciSup [Nonempty ι] {I : ι → Ideal R} (hI : ∀ i, I i ≠ ⊥) :
+lemma multiplicity_iSup [Nonempty ι] {I : ι → Ideal R} (hI : ∀ i, I i ≠ ⊥) :
     multiplicity p.asIdeal (⨆ i, I i) = ⨅ i, multiplicity p.asIdeal (I i) := by
   have H i : FiniteMultiplicity p.asIdeal (I i) :=
     FiniteMultiplicity.of_prime_left (prime p) <| hI i
@@ -968,7 +970,7 @@ lemma multiplicity_ciSup [Nonempty ι] {I : ι → Ideal R} (hI : ∀ i, I i ≠
     contrapose! hI
     rw [← bot_eq_zero, iSup_eq_bot] at hI
     exact ⟨Classical.ofNonempty, hI _⟩
-  have := emultiplicity_ciSup p I
+  have := emultiplicity_iSup p I
   simp only [H'.emultiplicity_eq_multiplicity, (H _).emultiplicity_eq_multiplicity] at this
   exact_mod_cast this
 

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -908,7 +908,6 @@ namespace IsDedekindDomain.HeightOneSpectrum
 lemma multiplicity_le_of_ideal_ge (p : HeightOneSpectrum R) {I J : Ideal R} (h : J ≤ I)
     (hJ : J ≠ ⊥) :
     multiplicity p.asIdeal I ≤ multiplicity p.asIdeal J := by
-  classical
   rw [← count_normalizedFactors_eq_multiplicity hJ,
     ← count_normalizedFactors_eq_multiplicity <| ne_bot_of_le_ne_bot hJ h]
   exact Ideal.count_le_of_ideal_ge h hJ _
@@ -916,20 +915,10 @@ lemma multiplicity_le_of_ideal_ge (p : HeightOneSpectrum R) {I J : Ideal R} (h :
 open UniqueFactorizationMonoid Multiset in
 lemma multiplicity_sup (p : HeightOneSpectrum R) {I J : Ideal R} (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
     multiplicity p.asIdeal (I ⊔ J) = multiplicity p.asIdeal I ⊓ multiplicity p.asIdeal J := by
-  classical
   rw [Ideal.sup_eq_prod_inf_factors hI hJ, ← count_normalizedFactors_eq_multiplicity ?h,
     ← count_normalizedFactors_eq_multiplicity hI, ← count_normalizedFactors_eq_multiplicity hJ]
-  -- extracted from the proof of `sup_eq_prod_inf_factors`
-  --   ==> refactor that (Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas)
-  case h =>
-    exact prod_ne_zero_of_prime _
-      fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).1
-  have H : normalizedFactors (normalizedFactors I ∩ normalizedFactors J).prod =
-      normalizedFactors I ∩ normalizedFactors J := by
-    refine normalizedFactors_prod_of_prime fun p hp ↦ ?_
-    rw [Multiset.mem_inter] at hp
-    exact prime_of_normalized_factor p hp.left
-  rw [H]
+  case h => exact Ideal.prod_inter_normalizedFactors_ne_zero I J
+  rw [Ideal.normalizedFactors_prod_inter_eq_inter]
   exact count_inter ..
 
 lemma emultiplicity_sup (p : HeightOneSpectrum R) (I J : Ideal R) :

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -857,12 +857,14 @@ variable {R : Type*} [CommRing R] [IsDedekindDomain R]
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
+variable {I : Ideal R} (hI : I ≠ ⊥) (p : HeightOneSpectrum R)
+include hI
+
 open UniqueFactorizationMonoid in
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
 @[simp]
-lemma count_normalizedFactors_eq_multiplicity [DecidableEq (Ideal R)] {I : Ideal R} (hI : I ≠ ⊥)
-    (p : HeightOneSpectrum R) :
+lemma count_normalizedFactors_eq_multiplicity :
     Multiset.count p.asIdeal (normalizedFactors I) = multiplicity p.asIdeal I := by
   have := emultiplicity_eq_count_normalizedFactors (irreducible p) hI
   rw [normalize_eq p.asIdeal] at this
@@ -873,7 +875,7 @@ lemma count_normalizedFactors_eq_multiplicity [DecidableEq (Ideal R)] {I : Ideal
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
 @[simp]
-lemma maxPowDividing_eq_pow_multiplicity {I : Ideal R} (hI : I ≠ ⊥) (p : HeightOneSpectrum R) :
+lemma maxPowDividing_eq_pow_multiplicity :
     p.maxPowDividing I = p.asIdeal ^ multiplicity p.asIdeal I := by
   classical
   rw [maxPowDividing_eq_pow_multiset_count _ hI, count_normalizedFactors_eq_multiplicity hI]
@@ -881,7 +883,7 @@ lemma maxPowDividing_eq_pow_multiplicity {I : Ideal R} (hI : I ≠ ⊥) (p : Hei
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
 @[simp]
-lemma factorization_eq_multiplicity {I : Ideal R} (hI : I ≠ ⊥) (p : HeightOneSpectrum R) :
+lemma factorization_eq_multiplicity :
     factorization I p.asIdeal = multiplicity p.asIdeal I := by
   rw [factorization_eq_count, count_normalizedFactors_eq_multiplicity hI]
 

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -905,15 +905,16 @@ lemma Ideal.finprod_heightOneSpectrum_pow_multiplicity {I : Ideal R} (hI : I ≠
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
-lemma multiplicity_le_of_ideal_ge (p : HeightOneSpectrum R) {I J : Ideal R} (h : J ≤ I)
-    (hJ : J ≠ ⊥) :
+variable (p : HeightOneSpectrum R) {I J : Ideal R}
+
+lemma multiplicity_le_of_ideal_ge (h : J ≤ I) (hJ : J ≠ ⊥) :
     multiplicity p.asIdeal I ≤ multiplicity p.asIdeal J := by
   rw [← count_normalizedFactors_eq_multiplicity hJ,
     ← count_normalizedFactors_eq_multiplicity <| ne_bot_of_le_ne_bot hJ h]
   exact Ideal.count_le_of_ideal_ge h hJ _
 
 open UniqueFactorizationMonoid Multiset in
-lemma multiplicity_sup (p : HeightOneSpectrum R) {I J : Ideal R} (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
+lemma multiplicity_sup (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
     multiplicity p.asIdeal (I ⊔ J) = multiplicity p.asIdeal I ⊓ multiplicity p.asIdeal J := by
   rw [Ideal.sup_eq_prod_inf_factors hI hJ, ← count_normalizedFactors_eq_multiplicity ?h,
     ← count_normalizedFactors_eq_multiplicity hI, ← count_normalizedFactors_eq_multiplicity hJ]
@@ -921,7 +922,8 @@ lemma multiplicity_sup (p : HeightOneSpectrum R) {I J : Ideal R} (hI : I ≠ ⊥
   rw [Ideal.normalizedFactors_prod_inter_eq_inter]
   exact count_inter ..
 
-lemma emultiplicity_sup (p : HeightOneSpectrum R) (I J : Ideal R) :
+variable (I J) in
+lemma emultiplicity_sup :
     emultiplicity p.asIdeal (I ⊔ J) = emultiplicity p.asIdeal I ⊓ emultiplicity p.asIdeal J := by
   rcases eq_or_ne I ⊥ with rfl | hI
   · rw [bot_eq_zero, emultiplicity_zero]
@@ -936,23 +938,24 @@ lemma emultiplicity_sup (p : HeightOneSpectrum R) (I J : Ideal R) :
     (H hJ).emultiplicity_eq_multiplicity, multiplicity_sup _ hI hJ]
   norm_cast
 
-lemma emultiplicity_ciSup {ι : Type*} [Finite ι] (p : HeightOneSpectrum R) (I : ι → Ideal R) :
+variable {ι : Type*} [Finite ι]
+
+lemma emultiplicity_ciSup (I : ι → Ideal R) :
     emultiplicity p.asIdeal (⨆ i, I i) = ⨅ i, emultiplicity p.asIdeal (I i) := by
   induction ι using Finite.induction_empty_option with
   | h_empty =>
     rw [iSup_of_empty, iInf_of_empty]
     exact emultiplicity_zero _
   | of_equiv e ih =>
-    specialize @ih (I ∘ e)
+    specialize ih (I ∘ e)
     rw [← sSup_range, ← sInf_range] at ih ⊢
     rw [EquivLike.range_comp I e] at ih
-    rw [ih, ← EquivLike.range_comp (fun i ↦ emultiplicity p.asIdeal (I i)) e]
-    rfl
+    rw [ih]
+    exact congrArg _ <| EquivLike.range_comp (emultiplicity p.asIdeal <| I ·) e
   | h_option ih =>
     rw [iSup_option, emultiplicity_sup p .., ih, iInf_option]
 
-lemma multiplicity_ciSup {ι : Type*} [Finite ι] [Nonempty ι] (p : HeightOneSpectrum R)
-    {I : ι → Ideal R} (hI : ∀ i, I i ≠ ⊥) :
+lemma multiplicity_ciSup [Nonempty ι] {I : ι → Ideal R} (hI : ∀ i, I i ≠ ⊥) :
     multiplicity p.asIdeal (⨆ i, I i) = ⨅ i, multiplicity p.asIdeal (I i) := by
   have H i : FiniteMultiplicity p.asIdeal (I i) :=
     FiniteMultiplicity.of_prime_left (prime p) <| hI i

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -924,8 +924,8 @@ lemma multiplicity_sup (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
     multiplicity p.asIdeal (I ⊔ J) = multiplicity p.asIdeal I ⊓ multiplicity p.asIdeal J := by
   rw [Ideal.sup_eq_prod_inf_factors hI hJ, ← count_normalizedFactors_eq_multiplicity ?h,
     ← count_normalizedFactors_eq_multiplicity hI, ← count_normalizedFactors_eq_multiplicity hJ]
-  case h => exact Ideal.prod_inter_normalizedFactors_ne_zero I J
-  rw [Ideal.normalizedFactors_prod_inter_eq_inter]
+  case h => exact prod_inter_normalizedFactors_ne_zero I J
+  rw [normalizedFactors_prod_inter_eq_inter]
   exact count_inter ..
 
 variable (I J) in

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -846,6 +846,9 @@ end primesOver
 
 /-!
 ### Conversion between various multplicities
+
+We provide some `simp` lemmas that convert various ways of expressing the multiplicity of
+a prime ideal `p` in the factorization of some ideal `I` into `multiplicity p.asIdeal I`.
 -/
 
 section conversion

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -874,7 +874,6 @@ lemma count_normalizedFactors_eq_multiplicity :
 
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
-@[simp]
 lemma maxPowDividing_eq_pow_multiplicity :
     p.maxPowDividing I = p.asIdeal ^ multiplicity p.asIdeal I := by
   classical

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -872,8 +872,6 @@ lemma count_normalizedFactors_eq_multiplicity :
   rw [← this]
   exact (finiteMultiplicity_of_emultiplicity_eq_natCast this).emultiplicity_eq_multiplicity
 
--- This is not `simp`; otherwise some `aesop` proofs break
--- in `Mathlib.Algebra.Module.Torsion.PrimaryComponent`.
 /-- Normalize the multiplicity of a prime ideal `p` in the factorization of `I`
 as `multiplicity p.asIdeal I`. -/
 lemma maxPowDividing_eq_pow_multiplicity :

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -902,6 +902,11 @@ These are phrased in terms of `multiplicity p.asIdeal I`.
 
 section multiplicity
 
+@[simp]
+lemma emultiplicity_bot {R : Type*} [CommSemiring R] (I : Ideal R) :
+    emultiplicity I (⊥ : Ideal R) = ⊤ :=
+  Submodule.zero_eq_bot (R := R) (M := R) ▸ emultiplicity_zero I
+
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
 
 lemma Ideal.finprod_heightOneSpectrum_pow_multiplicity {I : Ideal R} (hI : I ≠ ⊥) :
@@ -932,11 +937,9 @@ variable (I J) in
 lemma emultiplicity_sup :
     emultiplicity p.asIdeal (I ⊔ J) = emultiplicity p.asIdeal I ⊓ emultiplicity p.asIdeal J := by
   rcases eq_or_ne I ⊥ with rfl | hI
-  · rw [bot_eq_zero, emultiplicity_zero]
-    simp
+  · simp
   rcases eq_or_ne J ⊥ with rfl | hJ
-  · rw [bot_eq_zero, emultiplicity_zero]
-    simp
+  · simp
   have : I ⊔ J ≠ ⊥ := by grind
   have H {I' : Ideal R} (h : I' ≠ ⊥) : FiniteMultiplicity p.asIdeal I' :=
     FiniteMultiplicity.of_prime_left (prime p) h

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -903,7 +903,7 @@ These are phrased in terms of `multiplicity p.asIdeal I`.
 section multiplicity
 
 @[simp]
-lemma emultiplicity_bot {R : Type*} [CommSemiring R] (I : Ideal R) :
+lemma Ideal.emultiplicity_bot {R : Type*} [CommSemiring R] (I : Ideal R) :
     emultiplicity I (⊥ : Ideal R) = ⊤ :=
   Submodule.zero_eq_bot (R := R) (M := R) ▸ emultiplicity_zero I
 

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -903,8 +903,7 @@ These are phrased in terms of `multiplicity p.asIdeal I`.
 section multiplicity
 
 @[simp]
-lemma Ideal.emultiplicity_bot {R : Type*} [CommSemiring R] (I : Ideal R) :
-    emultiplicity I (⊥ : Ideal R) = ⊤ :=
+lemma Ideal.emultiplicity_bot {R : Type*} [CommSemiring R] (I : Ideal R) : emultiplicity I ⊥ = ⊤ :=
   Submodule.zero_eq_bot (R := R) (M := R) ▸ emultiplicity_zero I
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -399,21 +399,6 @@ theorem count_le_of_ideal_ge
 
 @[deprecated (since := "2026-04-16")] alias _root_.count_le_of_ideal_ge := count_le_of_ideal_ge
 
-variable (I J) in
-lemma normalizedFactors_prod_inter_eq_inter :
-    normalizedFactors (normalizedFactors I ∩ normalizedFactors J).prod =
-      normalizedFactors I ∩ normalizedFactors J := by
-  apply normalizedFactors_prod_of_prime
-  intro p hp
-  rw [mem_inter] at hp
-  exact prime_of_normalized_factor p hp.left
-
-variable (I J) in
-lemma prod_inter_normalizedFactors_ne_zero :
-    (normalizedFactors I ∩ normalizedFactors J).prod ≠ 0 :=
-  Multiset.prod_ne_zero_of_prime (normalizedFactors I ∩ normalizedFactors J)
-    fun _ h ↦ prime_of_normalized_factor _ (Multiset.mem_inter.1 h).1
-
 theorem sup_eq_prod_inf_factors (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
     I ⊔ J = (normalizedFactors I ∩ normalizedFactors J).prod := by
   have := prod_inter_normalizedFactors_ne_zero I J
@@ -423,9 +408,9 @@ theorem sup_eq_prod_inf_factors (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
       rw [dvd_iff_normalizedFactors_le_normalizedFactors this (by assumption),
         normalizedFactors_prod_inter_eq_inter]
     exacts [inf_le_left, inf_le_right]
-  · rw [← dvd_iff_le, dvd_iff_normalizedFactors_le_normalizedFactors ?H₁ this,
+  · rw [← dvd_iff_le, dvd_iff_normalizedFactors_le_normalizedFactors ?H this,
       normalizedFactors_prod_inter_eq_inter, le_iff_count]
-    case H₁ => exact ne_bot_of_le_ne_bot hI le_sup_left
+    case H => exact ne_bot_of_le_ne_bot hI le_sup_left
     intro a
     rw [Multiset.count_inter]
     exact le_min (count_le_of_ideal_ge le_sup_left hI a) (count_le_of_ideal_ge le_sup_right hJ a)

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -399,33 +399,40 @@ theorem count_le_of_ideal_ge
 
 @[deprecated (since := "2026-04-16")] alias _root_.count_le_of_ideal_ge := count_le_of_ideal_ge
 
+variable (I J) in
+lemma normalizedFactors_prod_inter_eq_inter :
+    normalizedFactors (normalizedFactors I ∩ normalizedFactors J).prod =
+      normalizedFactors I ∩ normalizedFactors J := by
+  apply normalizedFactors_prod_of_prime
+  intro p hp
+  rw [mem_inter] at hp
+  exact prime_of_normalized_factor p hp.left
+
+variable (I J) in
+lemma prod_inter_normalizedFactors_ne_zero :
+    (normalizedFactors I ∩ normalizedFactors J).prod ≠ 0 :=
+  Multiset.prod_ne_zero_of_prime (normalizedFactors I ∩ normalizedFactors J)
+    fun _ h ↦ prime_of_normalized_factor _ (Multiset.mem_inter.1 h).1
+
 theorem sup_eq_prod_inf_factors (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
     I ⊔ J = (normalizedFactors I ∩ normalizedFactors J).prod := by
-  have H : normalizedFactors (normalizedFactors I ∩ normalizedFactors J).prod =
-      normalizedFactors I ∩ normalizedFactors J := by
-    apply normalizedFactors_prod_of_prime
-    intro p hp
-    rw [mem_inter] at hp
-    exact prime_of_normalized_factor p hp.left
-  have := Multiset.prod_ne_zero_of_prime (normalizedFactors I ∩ normalizedFactors J) fun _ h =>
-      prime_of_normalized_factor _ (Multiset.mem_inter.1 h).1
+  have := prod_inter_normalizedFactors_ne_zero I J
   apply le_antisymm
   · rw [sup_le_iff, ← dvd_iff_le, ← dvd_iff_le]
-    constructor
-    · rw [dvd_iff_normalizedFactors_le_normalizedFactors this hI, H]
-      exact inf_le_left
-    · rw [dvd_iff_normalizedFactors_le_normalizedFactors this hJ, H]
-      exact inf_le_right
-  · rw [← dvd_iff_le, dvd_iff_normalizedFactors_le_normalizedFactors,
-      normalizedFactors_prod_of_prime, le_iff_count]
-    · intro a
-      rw [Multiset.count_inter]
-      exact le_min (count_le_of_ideal_ge le_sup_left hI a) (count_le_of_ideal_ge le_sup_right hJ a)
-    · intro p hp
+    constructor <;>
+      rw [dvd_iff_normalizedFactors_le_normalizedFactors this (by assumption),
+        normalizedFactors_prod_inter_eq_inter]
+    exacts [inf_le_left, inf_le_right]
+  · rw [← dvd_iff_le, dvd_iff_normalizedFactors_le_normalizedFactors ?H₁ this,
+      normalizedFactors_prod_of_prime ?H₂, le_iff_count]
+    case H₁ => exact ne_bot_of_le_ne_bot hI le_sup_left
+    case H₂ =>
+      intro p hp
       rw [mem_inter] at hp
       exact prime_of_normalized_factor p hp.left
-    · exact ne_bot_of_le_ne_bot hI le_sup_left
-    · exact this
+    intro a
+    rw [Multiset.count_inter]
+    exact le_min (count_le_of_ideal_ge le_sup_left hI a) (count_le_of_ideal_ge le_sup_right hJ a)
 
 @[deprecated (since := "2026-04-16")]
 alias _root_.sup_eq_prod_inf_factors := sup_eq_prod_inf_factors

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -424,12 +424,8 @@ theorem sup_eq_prod_inf_factors (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
         normalizedFactors_prod_inter_eq_inter]
     exacts [inf_le_left, inf_le_right]
   · rw [← dvd_iff_le, dvd_iff_normalizedFactors_le_normalizedFactors ?H₁ this,
-      normalizedFactors_prod_of_prime ?H₂, le_iff_count]
+      normalizedFactors_prod_inter_eq_inter, le_iff_count]
     case H₁ => exact ne_bot_of_le_ne_bot hI le_sup_left
-    case H₂ =>
-      intro p hp
-      rw [mem_inter] at hp
-      exact prime_of_normalized_factor p hp.left
     intro a
     rw [Multiset.count_inter]
     exact le_min (count_le_of_ideal_ge le_sup_left hI a) (count_le_of_ideal_ge le_sup_right hJ a)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -403,3 +403,21 @@ protected noncomputable def normalizationMonoid : NormalizationMonoid α :=
       apply prod_normalizedFactors hx)
 
 end UniqueFactorizationMonoid
+
+namespace UniqueFactorizationMonoid
+
+open  Multiset
+
+variable {α : Type*} [CommMonoidWithZero α] [UniqueFactorizationMonoid α] [DecidableEq α]
+
+lemma normalizedFactors_prod_inter_eq_inter [Subsingleton αˣ] (a b : α) :
+    normalizedFactors (normalizedFactors a ∩ normalizedFactors b).prod =
+      normalizedFactors a ∩ normalizedFactors b :=
+  normalizedFactors_prod_of_prime
+    fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).left
+
+lemma prod_inter_normalizedFactors_ne_zero [NormalizationMonoid α] [Nontrivial α] (a b : α) :
+    (normalizedFactors a ∩ normalizedFactors b).prod ≠ 0 :=
+  prod_ne_zero_of_prime _ fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).left
+
+end UniqueFactorizationMonoid

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -408,16 +408,27 @@ namespace UniqueFactorizationMonoid
 
 open Multiset
 
-variable {α : Type*} [CommMonoidWithZero α] [UniqueFactorizationMonoid α] [DecidableEq α]
+variable {α : Type*} [CommMonoidWithZero α] [UniqueFactorizationMonoid α]
+
+lemma normalizedFactors_prod_eq_self_of_subset [Subsingleton αˣ] {a : α} {m : Multiset α}
+    (hm : m ⊆ normalizedFactors a) :
+    normalizedFactors m.prod = m :=
+  normalizedFactors_prod_of_prime fun _ h ↦ prime_of_normalized_factor _ (mem_of_subset hm h)
+
+lemma prod_ne_zero_of_subset_normalizedFactors [NormalizationMonoid α] [Nontrivial α] {a : α}
+    {m : Multiset α} (hm : m ⊆ normalizedFactors a) :
+    m.prod ≠ 0 :=
+  prod_ne_zero_of_prime _ fun _ h ↦ prime_of_normalized_factor _ (mem_of_subset hm h)
+
+variable [DecidableEq α]
 
 lemma normalizedFactors_prod_inter_eq_inter [Subsingleton αˣ] (a b : α) :
     normalizedFactors (normalizedFactors a ∩ normalizedFactors b).prod =
       normalizedFactors a ∩ normalizedFactors b :=
-  normalizedFactors_prod_of_prime
-    fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).left
+  normalizedFactors_prod_eq_self_of_subset fun _ h ↦ (mem_inter.mp h).left
 
 lemma prod_inter_normalizedFactors_ne_zero [NormalizationMonoid α] [Nontrivial α] (a b : α) :
     (normalizedFactors a ∩ normalizedFactors b).prod ≠ 0 :=
-  prod_ne_zero_of_prime _ fun _ h ↦ prime_of_normalized_factor _ (mem_inter.mp h).left
+  prod_ne_zero_of_subset_normalizedFactors fun _ h ↦ (mem_inter.mp h).left
 
 end UniqueFactorizationMonoid

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -406,7 +406,7 @@ end UniqueFactorizationMonoid
 
 namespace UniqueFactorizationMonoid
 
-open  Multiset
+open Multiset
 
 variable {α : Type*} [CommMonoidWithZero α] [UniqueFactorizationMonoid α] [DecidableEq α]
 


### PR DESCRIPTION
This PR adds
* `simp` lemmas that convert ways of expressing the multiplicity of a prime ideal `p` in the factorization of an ideal `I` into `multiplicity p.asIdeal I` (see [#Is there code for X? > Results on elements of number fields and ideals @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Results.20on.20elements.20of.20number.20fields.20and.20ideals/near/574739650)),
* API lemmas on multiplicities, expressed in terms of `multiplicity p.asIdeal I`.
* We also refactor a proof in Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas by extracting a couple of lemmas that we can reuse in one of the new lemmas.

These will be useful in proving the Northcott property of heights on number fields.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
