### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Weight): add `Finsupp.degree_mapDomain`

### DIFF
--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -266,13 +266,14 @@ lemma range_single_one :
     obtain ⟨a, rfl⟩ := (Finsupp.sum_eq_one_iff _).mp hp
     use a
 
-theorem degree_mapDomain_eq_of_subsingletonAddUnits {τ : Type*} (f : σ → τ) [AddCommMonoid M]
-    [Subsingleton (AddUnits M)] (x : σ →₀ M) : degree (x.mapDomain f) = degree x := by
-  classical
-  trans (x.mapDomain f).sum (fun _ ↦ id)
-  · simp [degree, sum]
-  · simpa [sum, mapDomain_support_of_subsingletonAddUnits, degree] using Finset.sum_image' _
-      (fun _ _ ↦ mapDomain_apply_eq_sum ..)
+@[simp]
+theorem degree_mapDomain {τ : Type*} (f : σ → τ) [AddCommMonoid M] (x : σ →₀ M) :
+    degree (x.mapDomain f) = degree x := by
+  simp [mapDomain, sum]
+  rfl
+
+@[deprecated (since := "2026-04-27")]
+alias degree_mapDomain_eq_of_subsingletonAddUnits := degree_mapDomain
 
 theorem degree_comapDomain_le_of_canonicallyOrderedAdd {τ : Type*} {f : σ → τ} [AddCommMonoid M]
     [PartialOrder M] [CanonicallyOrderedAdd M] {x : τ →₀ M} (hf : Set.InjOn f (f ⁻¹' x.support)) :

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -270,7 +270,7 @@ lemma range_single_one :
 theorem degree_mapDomain {τ : Type*} (f : σ → τ) [AddCommMonoid M] (x : σ →₀ M) :
     degree (x.mapDomain f) = degree x := by
   simp [mapDomain, sum]
-  rfl
+  dsimp [degree_apply]
 
 @[deprecated (since := "2026-04-27")]
 alias degree_mapDomain_eq_of_subsingletonAddUnits := degree_mapDomain

--- a/Mathlib/Order/Filter/TendstoCofinite.lean
+++ b/Mathlib/Order/Filter/TendstoCofinite.lean
@@ -117,7 +117,7 @@ theorem Finsupp.mapDomain_tendstoCofinite [TendstoCofinite f] :
   simp only [Set.subset_def, Set.mem_preimage, Set.mem_singleton_iff, Set.mem_image,
     Set.mem_setOf_eq]
   refine fun y hy ↦ ⟨y.comapDomain e e.injective.injOn, ?_, embDomain_comapDomain ?_⟩
-  · rw [← hy, degree_mapDomain_eq_of_subsingletonAddUnits]
+  · rw [← hy, degree_mapDomain]
     exact degree_comapDomain_le_of_canonicallyOrderedAdd ..
   · suffices y.support ⊆ s by simpa [e]
     simpa [← hy, mapDomain, sum, Finset.subset_iff, single_apply, s] using


### PR DESCRIPTION
Generalize a result by removing an unnecessary hypothesis.  Also simplifies the proof.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
