### PR TITLE
[Merged by Bors] - chore(Counterexamples/MapFloor): remove `respectTransparency`

### DIFF
--- a/Counterexamples/MapFloor.lean
+++ b/Counterexamples/MapFloor.lean
@@ -70,7 +70,7 @@ theorem pos_iff {p : ℤ[ε]} : 0 < p ↔ 0 < p.trailingCoeff := by
     (le_natTrailingDegree (by rintro rfl; cases hn.2.false) fun m hm => (hn.1 _ hm).symm)
 
 instance : ZeroLEOneClass ℤ[ε] :=
-  { zero_le_one := by right; exact ⟨0, by simp⟩ }
+  { zero_le_one := Or.inr ⟨0, by simp⟩ }
 
 instance : IsStrictOrderedRing ℤ[X] :=
   .of_mul_pos fun p q => by simp_rw [pos_iff]; rw [trailingCoeff_mul]; exact mul_pos
@@ -83,9 +83,7 @@ instance : FloorRing ℤ[ε] :=
     · split_ifs with h
       · rintro ⟨_ | n, hn⟩
         · apply (sub_one_lt _).trans _
-          simp only [not_lt_zero, comp_apply, Pi.toLex_apply, IsEmpty.forall_iff, implies_true,
-            true_and] at hn
-          rwa [intCast_coeff_zero] at hn
+          simp_all
         · dsimp at hn
           simp only [hn.1 _ n.zero_lt_succ]
           rw [intCast_coeff_zero]; simp

--- a/Counterexamples/MapFloor.lean
+++ b/Counterexamples/MapFloor.lean
@@ -42,8 +42,6 @@ noncomputable section
 
 open Function Int Polynomial
 
-open scoped Polynomial
-
 /-- The integers with infinitesimals adjoined. Higher powers of `ε` are smaller than lower
 powers. -/
 abbrev IntWithEpsilon := ℤ[X]

--- a/Counterexamples/MapFloor.lean
+++ b/Counterexamples/MapFloor.lean
@@ -42,9 +42,11 @@ noncomputable section
 
 open Function Int Polynomial
 
-/-- The integers with infinitesimals adjoined. -/
-def IntWithEpsilon :=
-  ℤ[X] deriving Nontrivial, CommRing, Inhabited
+open scoped Polynomial
+
+/-- The integers with infinitesimals adjoined. Higher powers of `ε` are smaller than lower
+powers. -/
+abbrev IntWithEpsilon := ℤ[X]
 
 local notation "ℤ[ε]" => IntWithEpsilon
 
@@ -69,16 +71,12 @@ theorem pos_iff {p : ℤ[ε]} : 0 < p ↔ 0 < p.trailingCoeff := by
   exact (natTrailingDegree_le_of_ne_zero hn.2.ne').antisymm
     (le_natTrailingDegree (by rintro rfl; cases hn.2.false) fun m hm => (hn.1 _ hm).symm)
 
-set_option backward.isDefEq.respectTransparency false in
 instance : ZeroLEOneClass ℤ[ε] :=
-  { zero_le_one := Or.inr ⟨0, by simp⟩ }
+  { zero_le_one := by right; exact ⟨0, by simp⟩ }
 
-set_option backward.isDefEq.respectTransparency false in
-instance : IsStrictOrderedRing ℤ[ε] :=
+instance : IsStrictOrderedRing ℤ[X] :=
   .of_mul_pos fun p q => by simp_rw [pos_iff]; rw [trailingCoeff_mul]; exact mul_pos
 
-set_option backward.isDefEq.respectTransparency false in
-set_option linter.flexible false in
 instance : FloorRing ℤ[ε] :=
   FloorRing.ofFloor _ (fun p => if (p.coeff 0 : ℤ[ε]) ≤ p then p.coeff 0 else p.coeff 0 - 1)
     fun p q => by
@@ -87,15 +85,16 @@ instance : FloorRing ℤ[ε] :=
     · split_ifs with h
       · rintro ⟨_ | n, hn⟩
         · apply (sub_one_lt _).trans _
-          simp at hn
+          simp only [not_lt_zero, comp_apply, Pi.toLex_apply, IsEmpty.forall_iff, implies_true,
+            true_and] at hn
           rwa [intCast_coeff_zero] at hn
         · dsimp at hn
-          simp [hn.1 _ n.zero_lt_succ]
+          simp only [hn.1 _ n.zero_lt_succ]
           rw [intCast_coeff_zero]; simp
       · exact fun h' => cast_lt.1 ((not_lt.1 h).trans_lt h')
     · split_ifs with h
       · exact fun h' => h.trans_le (cast_le.2 <| sub_one_lt_iff.1 h')
-      · exact fun h' => ⟨0, by simp; rwa [intCast_coeff_zero]⟩
+      · exact fun h' => ⟨0, by simp_all⟩
 
 /-- The ordered ring homomorphisms from `ℤ[ε]` to `ℤ` that "forgets" the `ε`s. -/
 def forgetEpsilons : ℤ[ε] →+*o ℤ where
@@ -114,7 +113,6 @@ def forgetEpsilons : ℤ[ε] →+*o ℤ where
 theorem forgetEpsilons_apply (p : ℤ[ε]) : forgetEpsilons p = coeff p 0 :=
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The floor of `n - ε` is `n - 1` but its image under `forgetEpsilons` is `n`, whose floor is
 itself. -/
 theorem forgetEpsilons_floor_lt (n : ℤ) :


### PR DESCRIPTION
It seemed better to make this an `abbrev` since we want to copy most of the instances over.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
