### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/PontryaginDual): prove compact monoids have discrete duals

### DIFF
--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -120,6 +120,12 @@ def exp : C(ℝ, Circle) where
 @[simp, norm_cast]
 theorem coe_exp (t : ℝ) : exp t = Complex.exp (t * Complex.I) := rfl
 
+theorem cos_eq_cos_of_exp_eq_exp {x y : ℝ} (h : exp x = exp y) : Real.cos x = Real.cos y := by
+  simpa using congr(($h : ℂ).re)
+
+theorem sin_eq_sin_of_exp_eq_exp {x y : ℝ} (h : exp x = exp y) : Real.sin x = Real.sin y := by
+  simpa using congr(($h : ℂ).im)
+
 @[simp]
 theorem exp_zero : exp 0 = 1 :=
   Subtype.ext <| by rw [coe_exp, ofReal_zero, zero_mul, Complex.exp_zero, coe_one]

--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -120,12 +120,6 @@ def exp : C(ℝ, Circle) where
 @[simp, norm_cast]
 theorem coe_exp (t : ℝ) : exp t = Complex.exp (t * Complex.I) := rfl
 
-theorem cos_eq_cos_of_exp_eq_exp {x y : ℝ} (h : exp x = exp y) : Real.cos x = Real.cos y := by
-  simpa using congr(($h : ℂ).re)
-
-theorem sin_eq_sin_of_exp_eq_exp {x y : ℝ} (h : exp x = exp y) : Real.sin x = Real.sin y := by
-  simpa using congr(($h : ℂ).im)
-
 @[simp]
 theorem exp_zero : exp 0 = 1 :=
   Subtype.ext <| by rw [coe_exp, ofReal_zero, zero_mul, Complex.exp_zero, coe_one]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -56,38 +56,32 @@ theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
   have htπ : |t| < π := ht.trans_le hr
   rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
 
-/-- If all positive powers of a point on the circle lie in the right half centered arc,
-then the point is `1`. -/
-theorem eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
-    (hz : ∀ n > 0, z ^ n ∈ centeredArc (π / 2)) : z = 1 := by
-  have exists_pos_cos_mul_nonpos_of_pos :
-      ∀ {θ : ℝ}, 0 < θ → θ ≤ π → ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
-    intro θ hθ0 hθπ
-    refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
-    · grw [← Nat.le_ceil]
-      simp [hθ0.ne']
-    · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
-      simpa [hθ0.ne', add_comm]
-  have exists_pos_cos_mul_nonpos :
-      ∀ {θ : ℝ}, -π < θ → θ ≤ π → θ ≠ 0 →
-        ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
-    intro θ hθ₁ hθ₂ hθ
-    obtain (_hθ | hθ) := hθ.lt_or_gt
-    · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
-    · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
-  rw [← arg_eq_zero]
-  by_contra hθ
-  obtain ⟨n, hn, hcos⟩ := exists_pos_cos_mul_nonpos (neg_pi_lt_arg _) (arg_le_pi _) hθ
-  have hzarg : |arg (z ^ n)| < π / 2 :=
-    (mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
-  have hpow : exp ((n : ℝ) * arg z) = exp (arg (z ^ n)) := by
-    rw [exp_natCast_mul, exp_arg]
-    exact (exp_arg (z ^ n)).symm
-  have : Real.cos ((n : ℝ) * arg z) = Real.cos (arg (z ^ n)) :=
-    cos_eq_cos_of_exp_eq_exp hpow
-  have hzargIoo : arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
-    simpa [Set.mem_Ioo] using abs_lt.mp hzarg
-  linarith [cos_pos_of_mem_Ioo hzargIoo]
+theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
+  contrapose! hr
+  obtain ⟨-, x, hx, rfl⟩ := hr
+  exact (abs_nonneg x).trans_lt hx
+
+@[simp]
+theorem centeredArc_zero : centeredArc 0 = ∅ :=
+  centeredArc_eq_empty le_rfl
+
+theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
+    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
+    z ∈ centeredArc (s / n) := by
+  have hs0 : 0 < s := by
+    contrapose! h2
+    simp [centeredArc_eq_empty h2]
+  have hn0 : n ≠ 0 := by
+    contrapose! h1
+    simp [h1]
+  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
+  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
+    lt_div_iff₀' (one_pos.trans_le hn)]
+  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
+  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
+    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
+    arg_coe_angle_toReal_eq_arg] at h2
+  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
 
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
@@ -451,8 +445,33 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
 
+theorem Circle.hasBasis_centeredArc_div_two_pow :
+    (nhds (1 : Circle)).HasBasis (fun _ ↦ True) (fun n ↦ centeredArc (π / 2 ^ (n + 1))) := by
+  rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
+  refine ((nhds_basis_zero_abs_lt ℝ).to_hasBasis
+      (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
+        fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
+  rw [Set.mem_setOf_eq] at ht ⊢
+  refine lt_of_lt_of_le ht ?_
+  rw [div_le_iff₀' (pow_pos two_pos _), ← div_le_iff₀ hx]
+  refine (Nat.le_ceil (Real.pi / x)).trans ?_
+  exact_mod_cast (Nat.le_succ _).trans Nat.lt_two_pow_self.le
+
 theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
   simpa [centeredArc, abs_lt] using isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo
+
+/-- If all positive powers of a point on the circle lie in the right half centered arc,
+then the point is `1`. -/
+theorem Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ centeredArc (π / 2)) : z = 1 := by
+  have hz1 : z ∈ centeredArc (π / 2) := by simpa using hz 1
+  have h (n : ℕ) : z ∈ centeredArc (π / 2 ^ (n + 1)) := by
+    induction n with
+    | zero => simpa using hz1
+    | succ n ih =>
+        simpa [div_div, ← pow_succ'] using mem_centeredArc_div
+          (div_le_self pi_nonneg one_le_two) (by simpa) (hz (2 ^ (n + 1)) (by positivity))
+  simpa [h] using Set.ext_iff.mp hasBasis_centeredArc_div_two_pow.ker z
 
 /- TODO: this generalizes to a large class of groups, but requires an open mapping theorem for
 topological groups to show the `n`th power map is open (see https://www.mathematik.tu-darmstadt.de/media/mathematik/forschung/preprint/preprints/2480.pdf

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -45,6 +45,17 @@ theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x :
 theorem exp_arg (z : Circle) : exp (arg z) = z :=
   injective_arg <| arg_exp (neg_pi_lt_arg _) (arg_le_pi _)
 
+/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
+def centeredArc (r : ℝ) : Set Circle :=
+  exp '' {x | |x| < r}
+
+theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
+    z ∈ centeredArc r ↔ |arg z| < r := by
+  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
+  rintro ⟨t, ht, rfl⟩
+  have htπ : |t| < π := ht.trans_le hr
+  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
+
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps -fullyApplied]
@@ -406,6 +417,9 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
+
+theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
+  simpa [centeredArc, abs_lt] using isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo
 
 /- TODO: this generalizes to a large class of groups, but requires an open mapping theorem for
 topological groups to show the `n`th power map is open (see https://www.mathematik.tu-darmstadt.de/media/mathematik/forschung/preprint/preprints/2480.pdf

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -34,6 +34,10 @@ theorem injective_arg : Injective fun z : Circle => arg z := fun z w h =>
 theorem arg_eq_arg {z w : Circle} : arg z = arg w ↔ z = w :=
   injective_arg.eq_iff
 
+@[simp]
+theorem arg_eq_zero {z : Circle} : arg z = 0 ↔ z = 1 := by
+  simpa using arg_eq_arg (w := 1)
+
 theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x := by
   rw [coe_exp, exp_mul_I, arg_cos_add_sin_mul_I ⟨h₁, h₂⟩]
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -56,6 +56,39 @@ theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
   have htπ : |t| < π := ht.trans_le hr
   rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
 
+/-- If all positive powers of a point on the circle lie in the right half centered arc,
+then the point is `1`. -/
+theorem eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ centeredArc (π / 2)) : z = 1 := by
+  have exists_pos_cos_mul_nonpos_of_pos :
+      ∀ {θ : ℝ}, 0 < θ → θ ≤ π → ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
+    intro θ hθ0 hθπ
+    refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
+    · grw [← Nat.le_ceil]
+      simp [hθ0.ne']
+    · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
+      simpa [hθ0.ne', add_comm]
+  have exists_pos_cos_mul_nonpos :
+      ∀ {θ : ℝ}, -π < θ → θ ≤ π → θ ≠ 0 →
+        ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
+    intro θ hθ₁ hθ₂ hθ
+    obtain (_hθ | hθ) := hθ.lt_or_gt
+    · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
+    · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
+  rw [← arg_eq_zero]
+  by_contra hθ
+  obtain ⟨n, hn, hcos⟩ := exists_pos_cos_mul_nonpos (neg_pi_lt_arg _) (arg_le_pi _) hθ
+  have hzarg : |arg (z ^ n)| < π / 2 :=
+    (mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
+  have hpow : exp ((n : ℝ) * arg z) = exp (arg (z ^ n)) := by
+    rw [exp_natCast_mul, exp_arg]
+    exact (exp_arg (z ^ n)).symm
+  have : Real.cos ((n : ℝ) * arg z) = Real.cos (arg (z ^ n)) :=
+    cos_eq_cos_of_exp_eq_exp hpow
+  have hzargIoo : arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
+    simpa [Set.mem_Ioo] using abs_lt.mp hzarg
+  linarith [cos_pos_of_mem_Ioo hzargIoo]
+
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps -fullyApplied]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -45,44 +45,6 @@ theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x :
 theorem exp_arg (z : Circle) : exp (arg z) = z :=
   injective_arg <| arg_exp (neg_pi_lt_arg _) (arg_le_pi _)
 
-/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
-def centeredArc (r : ℝ) : Set Circle :=
-  exp '' {x | |x| < r}
-
-theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
-    z ∈ centeredArc r ↔ |arg z| < r := by
-  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
-  rintro ⟨t, ht, rfl⟩
-  have htπ : |t| < π := ht.trans_le hr
-  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
-
-theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
-  contrapose! hr
-  obtain ⟨-, x, hx, rfl⟩ := hr
-  exact (abs_nonneg x).trans_lt hx
-
-@[simp]
-theorem centeredArc_zero : centeredArc 0 = ∅ :=
-  centeredArc_eq_empty le_rfl
-
-theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
-    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
-    z ∈ centeredArc (s / n) := by
-  have hs0 : 0 < s := by
-    contrapose! h2
-    simp [centeredArc_eq_empty h2]
-  have hn0 : n ≠ 0 := by
-    contrapose! h1
-    simp [h1]
-  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
-  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
-    lt_div_iff₀' (one_pos.trans_le hn)]
-  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
-  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
-    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
-    arg_coe_angle_toReal_eq_arg] at h2
-  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
-
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps -fullyApplied]
@@ -153,6 +115,54 @@ lemma exp_injOn_Ico {a b : ℝ} (h : b - a ≤ 2 * π) : InjOn exp (Ico a b) :=
 
 lemma exp_injOn_Ioc {a b : ℝ} (h : b - a ≤ 2 * π) : InjOn exp (Ioc a b) :=
   exp_injOn_of_forall_sub_mem_Ioo <| fun x ⟨hx1, hx2⟩ y ⟨hy1, hy2⟩ ↦ by constructor <;> linarith
+
+/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
+def centeredArc (r : ℝ) : Set Circle :=
+  exp '' {x | |x| < r}
+
+theorem bijOn_exp_Ioo_centeredArc {r : ℝ} (hr : r ≤ π) :
+    BijOn Circle.exp (Ioo (-r) r) (centeredArc r) := by
+  simp_rw [centeredArc, abs_lt, Set.Ioo_def]
+  refine exp_injOn_Ico ?_ |>.mono Ioo_subset_Ico_self |>.bijOn_image
+  grind
+
+theorem centeredArc_mono {r s : ℝ} (h : r ≤ s) : centeredArc r ⊆ centeredArc s := by
+  rintro _ ⟨x, hx, rfl⟩
+  exact ⟨x, hx.trans_le h, rfl⟩
+
+theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
+    z ∈ centeredArc r ↔ |arg z| < r := by
+  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
+  rintro ⟨t, ht, rfl⟩
+  have htπ : |t| < π := ht.trans_le hr
+  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
+
+theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
+  contrapose! hr
+  obtain ⟨-, x, hx, rfl⟩ := hr
+  exact (abs_nonneg x).trans_lt hx
+
+@[simp]
+theorem centeredArc_zero : centeredArc 0 = ∅ :=
+  centeredArc_eq_empty le_rfl
+
+theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
+    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
+    z ∈ centeredArc (s / n) := by
+  have hs0 : 0 < s := by
+    contrapose! h2
+    simp [centeredArc_eq_empty h2]
+  have hn0 : n ≠ 0 := by
+    contrapose! h1
+    simp [h1]
+  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
+  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
+    lt_div_iff₀' (one_pos.trans_le hn)]
+  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
+  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
+    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
+    arg_coe_angle_toReal_eq_arg] at h2
+  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
 
 lemma exp_surjective : Surjective exp := fun z => ⟨z.val.arg, exp_arg z⟩
 
@@ -445,17 +455,19 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
 
+/-- The centered arcs `centeredArc (π / 2 ^ (n + 1))` form a neighborhood basis at `1`.
+This basis is useful because multiplying two sufficiently small arcs stays inside an earlier arc. -/
 theorem Circle.hasBasis_centeredArc_div_two_pow :
     (nhds (1 : Circle)).HasBasis (fun _ ↦ True) (fun n ↦ centeredArc (π / 2 ^ (n + 1))) := by
   rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
-  refine ((nhds_basis_zero_abs_lt ℝ).to_hasBasis
-      (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
-        fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
-  rw [Set.mem_setOf_eq] at ht ⊢
-  refine lt_of_lt_of_le ht ?_
-  rw [div_le_iff₀' (pow_pos two_pos _), ← div_le_iff₀ hx]
-  refine (Nat.le_ceil (Real.pi / x)).trans ?_
-  exact_mod_cast (Nat.le_succ _).trans Nat.lt_two_pow_self.le
+  simp_rw [centeredArc, abs_lt, Set.Ioo_def, ← Real.ball_zero_eq_Ioo]
+  apply Filter.HasBasis.map
+  refine nhds_basis_uniformity <| Metric.mk_uniformity_basis_of_tendsto (l := Filter.atTop)
+    (fun _ _ ↦ by positivity) (by simp) ?_
+  simp_rw [div_eq_mul_inv, pow_succ, mul_inv_rev, ← mul_assoc]
+  rw [← mul_zero (π * 2⁻¹)]
+  exact tendsto_inv_atTop_zero.comp (tendsto_pow_atTop_atTop_of_one_lt (by norm_num))
+    |>.const_mul _
 
 theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
   simpa [centeredArc, abs_lt] using isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -45,44 +45,6 @@ theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x :
 theorem exp_arg (z : Circle) : exp (arg z) = z :=
   injective_arg <| arg_exp (neg_pi_lt_arg _) (arg_le_pi _)
 
-/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
-def centeredArc (r : ℝ) : Set Circle :=
-  exp '' {x | |x| < r}
-
-theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
-    z ∈ centeredArc r ↔ |arg z| < r := by
-  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
-  rintro ⟨t, ht, rfl⟩
-  have htπ : |t| < π := ht.trans_le hr
-  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
-
-theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
-  contrapose! hr
-  obtain ⟨-, x, hx, rfl⟩ := hr
-  exact (abs_nonneg x).trans_lt hx
-
-@[simp]
-theorem centeredArc_zero : centeredArc 0 = ∅ :=
-  centeredArc_eq_empty le_rfl
-
-theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
-    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
-    z ∈ centeredArc (s / n) := by
-  have hs0 : 0 < s := by
-    contrapose! h2
-    simp [centeredArc_eq_empty h2]
-  have hn0 : n ≠ 0 := by
-    contrapose! h1
-    simp [h1]
-  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
-  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
-    lt_div_iff₀' (one_pos.trans_le hn)]
-  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
-  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
-    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
-    arg_coe_angle_toReal_eq_arg] at h2
-  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
-
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps -fullyApplied]
@@ -153,6 +115,54 @@ lemma exp_injOn_Ico {a b : ℝ} (h : b - a ≤ 2 * π) : InjOn exp (Ico a b) :=
 
 lemma exp_injOn_Ioc {a b : ℝ} (h : b - a ≤ 2 * π) : InjOn exp (Ioc a b) :=
   exp_injOn_of_forall_sub_mem_Ioo <| fun x ⟨hx1, hx2⟩ y ⟨hy1, hy2⟩ ↦ by constructor <;> linarith
+
+/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
+def centeredArc (r : ℝ) : Set Circle :=
+  exp '' {x | |x| < r}
+
+theorem bijOn_exp_Ioo_centeredArc {r : ℝ} (hr : r ≤ π) :
+    BijOn Circle.exp (Ioo (-r) r) (centeredArc r) := by
+  simp_rw [centeredArc, abs_lt, Set.Ioo_def]
+  refine exp_injOn_Ico ?_ |>.mono Ioo_subset_Ico_self |>.bijOn_image
+  grind
+
+theorem centeredArc_mono {r s : ℝ} (h : r ≤ s) : centeredArc r ⊆ centeredArc s := by
+  rintro _ ⟨x, hx, rfl⟩
+  exact ⟨x, hx.trans_le h, rfl⟩
+
+theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
+    z ∈ centeredArc r ↔ |arg z| < r := by
+  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
+  rintro ⟨t, ht, rfl⟩
+  have htπ : |t| < π := ht.trans_le hr
+  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
+
+theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
+  contrapose! hr
+  obtain ⟨-, x, hx, rfl⟩ := hr
+  exact (abs_nonneg x).trans_lt hx
+
+@[simp]
+theorem centeredArc_zero : centeredArc 0 = ∅ :=
+  centeredArc_eq_empty le_rfl
+
+theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
+    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
+    z ∈ centeredArc (s / n) := by
+  have hs0 : 0 < s := by
+    contrapose! h2
+    simp [centeredArc_eq_empty h2]
+  have hn0 : n ≠ 0 := by
+    contrapose! h1
+    simp [h1]
+  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
+  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
+    lt_div_iff₀' (one_pos.trans_le hn)]
+  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
+  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
+    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
+    arg_coe_angle_toReal_eq_arg] at h2
+  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
 
 lemma exp_surjective : Surjective exp := fun z => ⟨z.val.arg, exp_arg z⟩
 
@@ -445,17 +455,19 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
 
+/-- The centered arcs `centeredArc (π / 2 ^ (n + 1))` form a neighborhood basis at `1`.
+This basis is useful because multiplying two sufficiently small arcs stays inside an earlier arc. -/
 theorem Circle.hasBasis_centeredArc_div_two_pow :
     (nhds (1 : Circle)).HasBasis (fun _ ↦ True) (fun n ↦ centeredArc (π / 2 ^ (n + 1))) := by
   rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
-  refine ((nhds_basis_zero_abs_lt ℝ).to_hasBasis
-      (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
-        fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
-  rw [Set.mem_setOf_eq] at ht ⊢
-  refine lt_of_lt_of_le ht ?_
-  rw [div_le_iff₀' (pow_pos two_pos _), ← div_le_iff₀ hx]
-  refine (Nat.le_ceil (Real.pi / x)).trans ?_
-  exact_mod_cast (Nat.le_succ _).trans Nat.lt_two_pow_self.le
+  simp_rw [centeredArc, abs_lt, Set.Ioo_def, ← Real.ball_zero_eq_Ioo]
+  apply Filter.HasBasis.map
+  refine nhds_basis_uniformity <| Metric.mk_uniformity_basis_of_tendsto (l := Filter.atTop)
+    (fun _ _ ↦ by positivity) (by simp) ?_
+  simp_rw [div_eq_mul_inv, pow_succ, mul_inv_rev, ← mul_assoc]
+  rw [← mul_zero (π * 2⁻¹)]
+  exact tendsto_inv_atTop_zero.comp (tendsto_pow_atTop_atTop_of_one_lt (by norm_num))
+    |>.const_mul _
 
 theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
   have hset : {x : ℝ | |x| < r} = Ioo (-r) r := by

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -56,38 +56,32 @@ theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
   have htπ : |t| < π := ht.trans_le hr
   rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
 
-/-- If all positive powers of a point on the circle lie in the right half centered arc,
-then the point is `1`. -/
-theorem eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
-    (hz : ∀ n > 0, z ^ n ∈ centeredArc (π / 2)) : z = 1 := by
-  have exists_pos_cos_mul_nonpos_of_pos :
-      ∀ {θ : ℝ}, 0 < θ → θ ≤ π → ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
-    intro θ hθ0 hθπ
-    refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
-    · grw [← Nat.le_ceil]
-      simp [hθ0.ne']
-    · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
-      simpa [hθ0.ne', add_comm]
-  have exists_pos_cos_mul_nonpos :
-      ∀ {θ : ℝ}, -π < θ → θ ≤ π → θ ≠ 0 →
-        ∃ n > (0 : ℕ), Real.cos ((n : ℝ) * θ) ≤ 0 := by
-    intro θ hθ₁ hθ₂ hθ
-    obtain (_hθ | hθ) := hθ.lt_or_gt
-    · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
-    · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
-  rw [← arg_eq_zero]
-  by_contra hθ
-  obtain ⟨n, hn, hcos⟩ := exists_pos_cos_mul_nonpos (neg_pi_lt_arg _) (arg_le_pi _) hθ
-  have hzarg : |arg (z ^ n)| < π / 2 :=
-    (mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
-  have hpow : exp ((n : ℝ) * arg z) = exp (arg (z ^ n)) := by
-    rw [exp_natCast_mul, exp_arg]
-    exact (exp_arg (z ^ n)).symm
-  have : Real.cos ((n : ℝ) * arg z) = Real.cos (arg (z ^ n)) :=
-    cos_eq_cos_of_exp_eq_exp hpow
-  have hzargIoo : arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
-    simpa [Set.mem_Ioo] using abs_lt.mp hzarg
-  linarith [cos_pos_of_mem_Ioo hzargIoo]
+theorem centeredArc_eq_empty {r : ℝ} (hr : r ≤ 0) : centeredArc r = ∅ := by
+  contrapose! hr
+  obtain ⟨-, x, hx, rfl⟩ := hr
+  exact (abs_nonneg x).trans_lt hx
+
+@[simp]
+theorem centeredArc_zero : centeredArc 0 = ∅ :=
+  centeredArc_eq_empty le_rfl
+
+theorem mem_centeredArc_div {z : Circle} {s : ℝ} {n : ℕ} (hs : s ≤ π)
+    (h1 : z ∈ centeredArc (π / n)) (h2 : z ^ n ∈ centeredArc s) :
+    z ∈ centeredArc (s / n) := by
+  have hs0 : 0 < s := by
+    contrapose! h2
+    simp [centeredArc_eq_empty h2]
+  have hn0 : n ≠ 0 := by
+    contrapose! h1
+    simp [h1]
+  have hn : 1 ≤ (n : ℝ) := by simpa [Nat.one_le_iff_ne_zero]
+  rw [mem_centeredArc ((div_le_self hs0.le hn).trans hs),
+    lt_div_iff₀' (one_pos.trans_le hn)]
+  rw [mem_centeredArc (div_le_self pi_nonneg hn)] at h1
+  rwa [mem_centeredArc hs, coe_pow, ← arg_coe_angle_toReal_eq_arg, arg_pow_coe_angle,
+    (Angle.nsmul_toReal_eq_mul hn0).mpr (mem_Ioc_of_Ioo ?_), abs_mul, Nat.abs_cast,
+    arg_coe_angle_toReal_eq_arg] at h2
+  rwa [neg_div, mem_Ioo, ← abs_lt, arg_coe_angle_toReal_eq_arg]
 
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
@@ -451,12 +445,37 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
 
+theorem Circle.hasBasis_centeredArc_div_two_pow :
+    (nhds (1 : Circle)).HasBasis (fun _ ↦ True) (fun n ↦ centeredArc (π / 2 ^ (n + 1))) := by
+  rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
+  refine ((nhds_basis_zero_abs_lt ℝ).to_hasBasis
+      (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
+        fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
+  rw [Set.mem_setOf_eq] at ht ⊢
+  refine lt_of_lt_of_le ht ?_
+  rw [div_le_iff₀' (pow_pos two_pos _), ← div_le_iff₀ hx]
+  refine (Nat.le_ceil (Real.pi / x)).trans ?_
+  exact_mod_cast (Nat.le_succ _).trans Nat.lt_two_pow_self.le
+
 theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
   have hset : {x : ℝ | |x| < r} = Ioo (-r) r := by
     ext x
     simp [abs_lt]
   simpa [centeredArc, hset] using
     isLocalHomeomorph_circleExp.isOpenMap (Ioo (-r) r) isOpen_Ioo
+
+/-- If all positive powers of a point on the circle lie in the right half centered arc,
+then the point is `1`. -/
+theorem Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ centeredArc (π / 2)) : z = 1 := by
+  have hz1 : z ∈ centeredArc (π / 2) := by simpa using hz 1
+  have h (n : ℕ) : z ∈ centeredArc (π / 2 ^ (n + 1)) := by
+    induction n with
+    | zero => simpa using hz1
+    | succ n ih =>
+        simpa [div_div, ← pow_succ'] using mem_centeredArc_div
+          (div_le_self pi_nonneg one_le_two) (by simpa) (hz (2 ^ (n + 1)) (by positivity))
+  simpa [h] using Set.ext_iff.mp hasBasis_centeredArc_div_two_pow.ker z
 
 /- TODO: this generalizes to a large class of groups, but requires an open mapping theorem for
 topological groups to show the `n`th power map is open (see https://www.mathematik.tu-darmstadt.de/media/mathematik/forschung/preprint/preprints/2480.pdf

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -45,6 +45,17 @@ theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x :
 theorem exp_arg (z : Circle) : exp (arg z) = z :=
   injective_arg <| arg_exp (neg_pi_lt_arg _) (arg_le_pi _)
 
+/-- The image under `Circle.exp` of the interval of angles `(-r, r)`. -/
+def centeredArc (r : ℝ) : Set Circle :=
+  exp '' {x | |x| < r}
+
+theorem mem_centeredArc {r : ℝ} (hr : r ≤ π) {z : Circle} :
+    z ∈ centeredArc r ↔ |arg z| < r := by
+  refine ⟨?_, fun hz ↦ ⟨arg z, hz, exp_arg z⟩⟩
+  rintro ⟨t, ht, rfl⟩
+  have htπ : |t| < π := ht.trans_le hr
+  rwa [arg_exp (neg_lt_of_abs_lt htπ) (lt_of_abs_lt htπ).le]
+
 /-- `Complex.arg ∘ (↑)` and `Circle.exp` define a partial equivalence between `Circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps -fullyApplied]
@@ -407,7 +418,14 @@ theorem Circle.isCoveringMap_exp : IsCoveringMap exp := isAddQuotientCoveringMap
 lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp :=
   Circle.isCoveringMap_exp.isLocalHomeomorph
 
-/-- TODO: this generalizes to a large class of groups, but requires an open mapping theorem for
+theorem Circle.isOpen_centeredArc (r : ℝ) : IsOpen (centeredArc r) := by
+  have hset : {x : ℝ | |x| < r} = Ioo (-r) r := by
+    ext x
+    simp [abs_lt]
+  simpa [centeredArc, hset] using
+    isLocalHomeomorph_circleExp.isOpenMap (Ioo (-r) r) isOpen_Ioo
+
+/- TODO: this generalizes to a large class of groups, but requires an open mapping theorem for
 topological groups to show the `n`th power map is open (see https://www.mathematik.tu-darmstadt.de/media/mathematik/forschung/preprint/preprints/2480.pdf
 and https://www.math.uwaterloo.ca/~cgodsil/pdfs/topology/topgr.pdf), and discreteness of the
 kernel (see https://gemini.google.com/share/6e9ab4abcb95). -/

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -37,9 +37,10 @@ def PontryaginDual :=
   A →ₜ* Circle
 deriving TopologicalSpace
 
+private def centeredArc (r : ℝ) : Set Circle := Circle.exp '' {x | |x| < r}
+
 instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
-  let Vn : ℕ → Set Circle :=
-    fun n ↦ Circle.exp '' { x | |x| < Real.pi / 2 ^ (n + 1)}
+  let Vn : ℕ → Set Circle := fun n ↦ centeredArc (Real.pi / 2 ^ (n + 1))
   have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) := by
     refine fun n x ↦ ⟨?_, fun hx ↦ ⟨Complex.arg x, hx, Circle.exp_arg x⟩⟩
     rintro ⟨t, ht : |t| < _, rfl⟩
@@ -70,6 +71,7 @@ variable {A B C G}
 namespace PontryaginDual
 
 open ContinuousMonoidHom
+open Real
 
 #adaptation_note /-- nightly-2026-03-31
 Without this `set_option` we get a PANIC!
@@ -85,6 +87,70 @@ for PontryaginDual A
 
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
+
+private def rightHalfArc : Set Circle := centeredArc (π / 2)
+
+private lemma isOpen_rightHalfArc : IsOpen rightHalfArc := by
+  simpa [rightHalfArc, centeredArc, abs_lt] using
+    isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo
+
+private lemma exists_pos_cos_mul_nonpos_of_pos {θ : ℝ} (hθ0 : 0 < θ) (hθπ : θ ≤ π) :
+    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
+  refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
+  · grw [← Nat.le_ceil]
+    simp [hθ0.ne']
+  · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
+    simpa [hθ0.ne', add_comm]
+
+private lemma exists_pos_cos_mul_nonpos {θ : ℝ} (hθ₁ : -π < θ) (hθ₂ : θ ≤ π)
+    (hθ : θ ≠ 0) :
+    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
+  obtain (_hθ | hθ) := hθ.lt_or_gt
+  · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
+  · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
+
+private lemma eq_one_of_forall_pow_mem_rightHalfArc {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ rightHalfArc) : z = 1 := by
+  rw [← Circle.arg_eq_zero]
+  by_contra hθ
+  obtain ⟨n, hn, hcos⟩ :=
+    exists_pos_cos_mul_nonpos (Complex.neg_pi_lt_arg _) (Complex.arg_le_pi _) hθ
+  obtain ⟨t, ht, hzt⟩ := hz n hn
+  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp t := by
+    rw [Circle.exp_natCast_mul, Circle.exp_arg, ← hzt]
+  have : cos ((n : ℝ) * (z : ℂ).arg) = cos t :=
+    Circle.cos_eq_cos_of_exp_eq_exp hpow
+  have htIoo : t ∈ Set.Ioo (-(π / 2)) (π / 2) := by
+    simpa [Set.mem_Ioo] using (abs_lt.mp ht)
+  linarith [cos_pos_of_mem_Ioo htIoo]
+
+/-- A compact monoid has discrete Pontryagin dual. -/
+instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
+  let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ rightHalfArc}
+  have hVopen : IsOpen V := by
+    dsimp only [V]
+    exact isOpen_induced (ContinuousMap.isOpen_setOf_mapsTo isCompact_univ isOpen_rightHalfArc)
+  have hVeq : V = ({1} : Set (PontryaginDual A)) := by
+    ext ψ
+    refine ⟨fun hψ ↦ ?_, fun hψ ↦ ?_⟩
+    · rw [Set.mem_singleton_iff]
+      apply ContinuousMonoidHom.ext
+      intro a
+      refine eq_one_of_forall_pow_mem_rightHalfArc fun n hn ↦ ?_
+      simpa [map_pow] using hψ (Set.mem_univ (a ^ n))
+    · rw [Set.mem_singleton_iff] at hψ
+      subst ψ
+      intro _ _
+      refine ⟨0, by simp [pi_pos], ?_⟩
+      change Circle.exp 0 = ((1 : A →ₜ* Circle) _)
+      simp
+  exact discreteTopology_of_isOpen_singleton_one (by simpa [hVeq] using hVopen)
+
+instance [DiscreteTopology A] [CompactSpace A] : Finite (PontryaginDual A) :=
+  finite_of_compact_of_discrete
+
+noncomputable instance [DiscreteTopology A] [CompactSpace A] : Fintype (PontryaginDual A) :=
+  .ofFinite _
 
 /-- `PontryaginDual` is a contravariant functor. -/
 def map (f : A →ₜ* B) :

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -52,15 +52,7 @@ instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
     refine h1.trans_le ?_
     gcongr
     exact le_self_pow₀ one_le_two n.succ_ne_zero
-  · rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
-    refine ((nhds_basis_zero_abs_lt ℝ).to_hasBasis
-        (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
-          fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
-    rw [Set.mem_setOf_eq] at ht ⊢
-    refine lt_of_lt_of_le ht ?_
-    rw [div_le_iff₀' (pow_pos two_pos _), ← div_le_iff₀ hx]
-    refine (Nat.le_ceil (Real.pi / x)).trans ?_
-    exact_mod_cast (Nat.le_succ _).trans Nat.lt_two_pow_self.le
+  · simpa [Vn] using Circle.hasBasis_centeredArc_div_two_pow
 
 variable {A B C G}
 

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -37,15 +37,11 @@ def PontryaginDual :=
   A →ₜ* Circle
 deriving TopologicalSpace
 
-private def centeredArc (r : ℝ) : Set Circle := Circle.exp '' {x | |x| < r}
-
 instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
-  let Vn : ℕ → Set Circle := fun n ↦ centeredArc (Real.pi / 2 ^ (n + 1))
-  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) := by
-    refine fun n x ↦ ⟨?_, fun hx ↦ ⟨Complex.arg x, hx, Circle.exp_arg x⟩⟩
-    rintro ⟨t, ht : |t| < _, rfl⟩
-    have ht' := ht.trans_le (div_le_self Real.pi_nonneg (one_le_pow₀ one_le_two))
-    rwa [Circle.arg_exp (neg_lt_of_abs_lt ht') (lt_of_abs_lt ht').le]
+  let Vn : ℕ → Set Circle := fun n ↦ Circle.centeredArc (Real.pi / 2 ^ (n + 1))
+  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) :=
+    fun n x ↦ Circle.mem_centeredArc (z := x)
+      (div_le_self Real.pi_nonneg (one_le_pow₀ one_le_two))
   refine ContinuousMonoidHom.locallyCompactSpace_of_hasBasis Vn ?_ ?_
   · intro n x h1 h2
     rw [hVn] at h1 h2 ⊢
@@ -88,12 +84,6 @@ for PontryaginDual A
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
 
-private def rightHalfArc : Set Circle := centeredArc (π / 2)
-
-private lemma isOpen_rightHalfArc : IsOpen rightHalfArc := by
-  simpa [rightHalfArc, centeredArc, abs_lt] using
-    isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo
-
 private lemma exists_pos_cos_mul_nonpos_of_pos {θ : ℝ} (hθ0 : 0 < θ) (hθπ : θ ≤ π) :
     ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
   refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
@@ -109,41 +99,44 @@ private lemma exists_pos_cos_mul_nonpos {θ : ℝ} (hθ₁ : -π < θ) (hθ₂ :
   · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
   · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
 
-private lemma eq_one_of_forall_pow_mem_rightHalfArc {z : Circle}
-    (hz : ∀ n > 0, z ^ n ∈ rightHalfArc) : z = 1 := by
+private lemma eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ Circle.centeredArc (π / 2)) : z = 1 := by
   rw [← Circle.arg_eq_zero]
   by_contra hθ
   obtain ⟨n, hn, hcos⟩ :=
     exists_pos_cos_mul_nonpos (Complex.neg_pi_lt_arg _) (Complex.arg_le_pi _) hθ
-  obtain ⟨t, ht, hzt⟩ := hz n hn
-  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp t := by
-    rw [Circle.exp_natCast_mul, Circle.exp_arg, ← hzt]
-  have : cos ((n : ℝ) * (z : ℂ).arg) = cos t :=
+  have hzarg : |Complex.arg (z ^ n)| < π / 2 :=
+    (Circle.mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
+  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp (Complex.arg (z ^ n)) := by
+    rw [Circle.exp_natCast_mul, Circle.exp_arg]
+    exact (Circle.exp_arg (z ^ n)).symm
+  have : cos ((n : ℝ) * (z : ℂ).arg) = cos (Complex.arg (z ^ n)) :=
     Circle.cos_eq_cos_of_exp_eq_exp hpow
-  have htIoo : t ∈ Set.Ioo (-(π / 2)) (π / 2) := by
-    simpa [Set.mem_Ioo] using (abs_lt.mp ht)
-  linarith [cos_pos_of_mem_Ioo htIoo]
+  have hzargIoo : Complex.arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
+    simpa [Set.mem_Ioo] using (abs_lt.mp hzarg)
+  linarith [cos_pos_of_mem_Ioo hzargIoo]
 
 /-- A compact monoid has discrete Pontryagin dual. -/
 instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
-  let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ rightHalfArc}
+  let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ (Circle.centeredArc (π / 2))}
   have hVopen : IsOpen V := by
     dsimp only [V]
-    exact isOpen_induced (ContinuousMap.isOpen_setOf_mapsTo isCompact_univ isOpen_rightHalfArc)
+    exact isOpen_induced (ContinuousMap.isOpen_setOf_mapsTo isCompact_univ
+      (Circle.isOpen_centeredArc (π / 2)))
   have hVeq : V = ({1} : Set (PontryaginDual A)) := by
     ext ψ
     refine ⟨fun hψ ↦ ?_, fun hψ ↦ ?_⟩
     · rw [Set.mem_singleton_iff]
       apply ContinuousMonoidHom.ext
       intro a
-      refine eq_one_of_forall_pow_mem_rightHalfArc fun n hn ↦ ?_
+      refine eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
       simpa [map_pow] using hψ (Set.mem_univ (a ^ n))
     · rw [Set.mem_singleton_iff] at hψ
       subst ψ
       intro _ _
-      refine ⟨0, by simp [pi_pos], ?_⟩
-      change Circle.exp 0 = ((1 : A →ₜ* Circle) _)
-      simp
+      change (1 : Circle) ∈ Circle.centeredArc (π / 2)
+      rw [Circle.mem_centeredArc (by linarith [pi_pos])]
+      simp [pi_pos]
   exact discreteTopology_of_isOpen_singleton_one (by simpa [hVeq] using hVopen)
 
 instance [DiscreteTopology A] [CompactSpace A] : Finite (PontryaginDual A) :=

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -84,38 +84,6 @@ for PontryaginDual A
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
 
-private lemma exists_pos_cos_mul_nonpos_of_pos {θ : ℝ} (hθ0 : 0 < θ) (hθπ : θ ≤ π) :
-    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
-  refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
-  · grw [← Nat.le_ceil]
-    simp [hθ0.ne']
-  · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
-    simpa [hθ0.ne', add_comm]
-
-private lemma exists_pos_cos_mul_nonpos {θ : ℝ} (hθ₁ : -π < θ) (hθ₂ : θ ≤ π)
-    (hθ : θ ≠ 0) :
-    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
-  obtain (_hθ | hθ) := hθ.lt_or_gt
-  · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
-  · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
-
-private lemma eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
-    (hz : ∀ n > 0, z ^ n ∈ Circle.centeredArc (π / 2)) : z = 1 := by
-  rw [← Circle.arg_eq_zero]
-  by_contra hθ
-  obtain ⟨n, hn, hcos⟩ :=
-    exists_pos_cos_mul_nonpos (Complex.neg_pi_lt_arg _) (Complex.arg_le_pi _) hθ
-  have hzarg : |Complex.arg (z ^ n)| < π / 2 :=
-    (Circle.mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
-  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp (Complex.arg (z ^ n)) := by
-    rw [Circle.exp_natCast_mul, Circle.exp_arg]
-    exact (Circle.exp_arg (z ^ n)).symm
-  have : cos ((n : ℝ) * (z : ℂ).arg) = cos (Complex.arg (z ^ n)) :=
-    Circle.cos_eq_cos_of_exp_eq_exp hpow
-  have hzargIoo : Complex.arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
-    simpa [Set.mem_Ioo] using (abs_lt.mp hzarg)
-  linarith [cos_pos_of_mem_Ioo hzargIoo]
-
 /-- A compact monoid has discrete Pontryagin dual. -/
 instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
   let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ (Circle.centeredArc (π / 2))}
@@ -129,7 +97,7 @@ instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
     · rw [Set.mem_singleton_iff]
       apply ContinuousMonoidHom.ext
       intro a
-      refine eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
+      refine Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
       simpa [map_pow] using hψ (Set.mem_univ (a ^ n))
     · rw [Set.mem_singleton_iff] at hψ
       subst ψ

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -25,6 +25,7 @@ isomorphic to its double dual.
 @[expose] public section
 
 open scoped Pointwise
+open Real
 
 variable (A B C G H : Type*) [Monoid A] [Monoid B] [Monoid C] [CommGroup G] [Group H]
   [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C]
@@ -38,10 +39,10 @@ def PontryaginDual :=
 deriving TopologicalSpace
 
 instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
-  let Vn : ℕ → Set Circle := fun n ↦ Circle.centeredArc (Real.pi / 2 ^ (n + 1))
-  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) :=
+  let Vn : ℕ → Set Circle := fun n ↦ Circle.centeredArc (π / 2 ^ (n + 1))
+  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < π / 2 ^ (n + 1) :=
     fun n x ↦ Circle.mem_centeredArc (z := x)
-      (div_le_self Real.pi_nonneg (one_le_pow₀ one_le_two))
+      (div_le_self pi_nonneg (one_le_pow₀ one_le_two))
   refine ContinuousMonoidHom.locallyCompactSpace_of_hasBasis Vn ?_ ?_
   · intro n x h1 h2
     rw [hVn] at h1 h2 ⊢
@@ -59,7 +60,6 @@ variable {A B C G}
 namespace PontryaginDual
 
 open ContinuousMonoidHom
-open Real
 
 #adaptation_note /-- nightly-2026-03-31
 Without this `set_option` we get a PANIC!

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -73,6 +73,14 @@ deriving instance
   [DiscreteTopology A] → CompactSpace _
 for PontryaginDual A
 
+@[simp]
+theorem map_pow (ψ : PontryaginDual A) (a : A) (n : ℕ) : ψ (a ^ n) = ψ a ^ n :=
+  _root_.map_pow (ψ : A →ₜ* Circle) a n
+
+@[simp]
+theorem one_apply (a : A) : (1 : PontryaginDual A) a = 1 :=
+  rfl
+
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
 
@@ -85,18 +93,15 @@ instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
       (Circle.isOpen_centeredArc (π / 2)))
   have hVeq : V = ({1} : Set (PontryaginDual A)) := by
     ext ψ
-    refine ⟨fun hψ ↦ ?_, fun hψ ↦ ?_⟩
-    · rw [Set.mem_singleton_iff]
-      apply ContinuousMonoidHom.ext
+    rw [Set.mem_singleton_iff]
+    refine ⟨fun hψ ↦ ?_, ?_⟩
+    · apply ContinuousMonoidHom.ext
       intro a
       refine Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
       change ((ψ : A →ₜ* Circle) a) ^ n ∈ Circle.centeredArc (π / 2)
-      rw [← map_pow (ψ : A →ₜ* Circle) a n]
+      rw [← PontryaginDual.map_pow ψ a n]
       exact hψ (Set.mem_univ (a ^ n))
-    · rw [Set.mem_singleton_iff] at hψ
-      subst ψ
-      intro _ _
-      change (1 : Circle) ∈ Circle.centeredArc (π / 2)
+    · rintro rfl _ _
       rw [Circle.mem_centeredArc (by linarith [pi_pos])]
       simp [pi_pos]
   exact discreteTopology_of_isOpen_singleton_one (by simpa [hVeq] using hVopen)

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -25,6 +25,7 @@ isomorphic to its double dual.
 @[expose] public section
 
 open scoped Pointwise
+open Real
 
 variable (A B C G H : Type*) [Monoid A] [Monoid B] [Monoid C] [CommGroup G] [Group H]
   [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C]
@@ -38,10 +39,10 @@ def PontryaginDual :=
 deriving TopologicalSpace
 
 instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
-  let Vn : ℕ → Set Circle := fun n ↦ Circle.centeredArc (Real.pi / 2 ^ (n + 1))
-  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) :=
+  let Vn : ℕ → Set Circle := fun n ↦ Circle.centeredArc (π / 2 ^ (n + 1))
+  have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < π / 2 ^ (n + 1) :=
     fun n x ↦ Circle.mem_centeredArc (z := x)
-      (div_le_self Real.pi_nonneg (one_le_pow₀ one_le_two))
+      (div_le_self pi_nonneg (one_le_pow₀ one_le_two))
   refine ContinuousMonoidHom.locallyCompactSpace_of_hasBasis Vn ?_ ?_
   · intro n x h1 h2
     rw [hVn] at h1 h2 ⊢
@@ -59,7 +60,6 @@ variable {A B C G}
 namespace PontryaginDual
 
 open ContinuousMonoidHom
-open Real
 
 #adaptation_note /-- nightly-2026-03-31
 This `set_option` is necessary because of a compiler bug.

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -73,9 +73,9 @@ deriving instance
   [DiscreteTopology A] → CompactSpace _
 for PontryaginDual A
 
-@[simp]
-theorem map_pow (ψ : PontryaginDual A) (a : A) (n : ℕ) : ψ (a ^ n) = ψ a ^ n :=
-  _root_.map_pow (ψ : A →ₜ* Circle) a n
+@[ext]
+theorem ext {ψ φ : PontryaginDual A} (h : ∀ a, ψ a = φ a) : ψ = φ :=
+  DFunLike.ext _ _ h
 
 @[simp]
 theorem one_apply (a : A) : (1 : PontryaginDual A) a = 1 :=
@@ -95,12 +95,9 @@ instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
     ext ψ
     rw [Set.mem_singleton_iff]
     refine ⟨fun hψ ↦ ?_, ?_⟩
-    · apply ContinuousMonoidHom.ext
-      intro a
+    · ext1 a
       refine Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
-      change ((ψ : A →ₜ* Circle) a) ^ n ∈ Circle.centeredArc (π / 2)
-      rw [← PontryaginDual.map_pow ψ a n]
-      exact hψ (Set.mem_univ (a ^ n))
+      simpa using hψ (Set.mem_univ (a ^ n))
     · rintro rfl _ _
       rw [Circle.mem_centeredArc (by linarith [pi_pos])]
       simp [pi_pos]
@@ -124,16 +121,16 @@ theorem map_apply (f : A →ₜ* B) (x : PontryaginDual B) (y : A) :
 
 @[simp]
 theorem map_one : map (1 : A →ₜ* B) = 1 :=
-  ext fun x => ext (fun _y => OneHomClass.map_one x)
+  ContinuousMonoidHom.ext fun x => PontryaginDual.ext fun _y => OneHomClass.map_one x
 
 @[simp]
 theorem map_comp (g : B →ₜ* C) (f : A →ₜ* B) :
     map (comp g f) = ContinuousMonoidHom.comp (map f) (map g) :=
-  ext fun _x => ext fun _y => rfl
+  ContinuousMonoidHom.ext fun _x => PontryaginDual.ext fun _y => rfl
 
 @[simp]
 nonrec theorem map_mul (f g : A →ₜ* G) : map (f * g) = map f * map g :=
-  ext fun x => ext fun y => map_mul x (f y) (g y)
+  ContinuousMonoidHom.ext fun x => PontryaginDual.ext fun y => map_mul x (f y) (g y)
 
 variable (A B C G)
 

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -84,38 +84,6 @@ for PontryaginDual A
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
 
-private lemma exists_pos_cos_mul_nonpos_of_pos {θ : ℝ} (hθ0 : 0 < θ) (hθπ : θ ≤ π) :
-    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
-  refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
-  · grw [← Nat.le_ceil]
-    simp [hθ0.ne']
-  · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
-    simpa [hθ0.ne', add_comm]
-
-private lemma exists_pos_cos_mul_nonpos {θ : ℝ} (hθ₁ : -π < θ) (hθ₂ : θ ≤ π)
-    (hθ : θ ≠ 0) :
-    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
-  obtain (_hθ | hθ) := hθ.lt_or_gt
-  · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
-  · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
-
-private lemma eq_one_of_forall_pow_mem_centeredArc_pi_div_two {z : Circle}
-    (hz : ∀ n > 0, z ^ n ∈ Circle.centeredArc (π / 2)) : z = 1 := by
-  rw [← Circle.arg_eq_zero]
-  by_contra hθ
-  obtain ⟨n, hn, hcos⟩ :=
-    exists_pos_cos_mul_nonpos (Complex.neg_pi_lt_arg _) (Complex.arg_le_pi _) hθ
-  have hzarg : |Complex.arg (z ^ n)| < π / 2 :=
-    (Circle.mem_centeredArc (z := z ^ n) (by linarith [pi_pos])).1 (hz n hn)
-  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp (Complex.arg (z ^ n)) := by
-    rw [Circle.exp_natCast_mul, Circle.exp_arg]
-    exact (Circle.exp_arg (z ^ n)).symm
-  have : cos ((n : ℝ) * (z : ℂ).arg) = cos (Complex.arg (z ^ n)) :=
-    Circle.cos_eq_cos_of_exp_eq_exp hpow
-  have hzargIoo : Complex.arg (z ^ n) ∈ Set.Ioo (-(π / 2)) (π / 2) := by
-    simpa [Set.mem_Ioo] using (abs_lt.mp hzarg)
-  linarith [cos_pos_of_mem_Ioo hzargIoo]
-
 /-- A compact monoid has discrete Pontryagin dual. -/
 instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
   let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ (Circle.centeredArc (π / 2))}
@@ -129,8 +97,10 @@ instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
     · rw [Set.mem_singleton_iff]
       apply ContinuousMonoidHom.ext
       intro a
-      refine eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
-      simpa [map_pow] using hψ (Set.mem_univ (a ^ n))
+      refine Circle.eq_one_of_forall_pow_mem_centeredArc_pi_div_two fun n hn ↦ ?_
+      change ((ψ : A →ₜ* Circle) a) ^ n ∈ Circle.centeredArc (π / 2)
+      rw [← map_pow (ψ : A →ₜ* Circle) a n]
+      exact hψ (Set.mem_univ (a ^ n))
     · rw [Set.mem_singleton_iff] at hψ
       subst ψ
       intro _ _

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -37,9 +37,10 @@ def PontryaginDual :=
   A →ₜ* Circle
 deriving TopologicalSpace
 
+private def centeredArc (r : ℝ) : Set Circle := Circle.exp '' {x | |x| < r}
+
 instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
-  let Vn : ℕ → Set Circle :=
-    fun n ↦ Circle.exp '' { x | |x| < Real.pi / 2 ^ (n + 1)}
+  let Vn : ℕ → Set Circle := fun n ↦ centeredArc (Real.pi / 2 ^ (n + 1))
   have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) := by
     refine fun n x ↦ ⟨?_, fun hx ↦ ⟨Complex.arg x, hx, Circle.exp_arg x⟩⟩
     rintro ⟨t, ht : |t| < _, rfl⟩
@@ -70,6 +71,7 @@ variable {A B C G}
 namespace PontryaginDual
 
 open ContinuousMonoidHom
+open Real
 
 #adaptation_note /-- nightly-2026-03-31
 This `set_option` is necessary because of a compiler bug.
@@ -85,6 +87,70 @@ for PontryaginDual A
 
 /-- A discrete monoid has compact Pontryagin dual. -/
 add_decl_doc instLocallyCompactSpacePontryaginDual
+
+private def rightHalfArc : Set Circle := centeredArc (π / 2)
+
+private lemma isOpen_rightHalfArc : IsOpen rightHalfArc := by
+  simpa [rightHalfArc, centeredArc, abs_lt] using
+    isLocalHomeomorph_circleExp.isOpenMap _ isOpen_Ioo
+
+private lemma exists_pos_cos_mul_nonpos_of_pos {θ : ℝ} (hθ0 : 0 < θ) (hθπ : θ ≤ π) :
+    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
+  refine ⟨⌈π / 2 / θ⌉₊, by positivity, cos_nonpos_of_pi_div_two_le_of_le ?_ ?_⟩
+  · grw [← Nat.le_ceil]
+    simp [hθ0.ne']
+  · grw [Nat.ceil_lt_add_one (by positivity), add_one_mul]
+    simpa [hθ0.ne', add_comm]
+
+private lemma exists_pos_cos_mul_nonpos {θ : ℝ} (hθ₁ : -π < θ) (hθ₂ : θ ≤ π)
+    (hθ : θ ≠ 0) :
+    ∃ n > (0 : ℕ), cos ((n : ℝ) * θ) ≤ 0 := by
+  obtain (_hθ | hθ) := hθ.lt_or_gt
+  · simpa using exists_pos_cos_mul_nonpos_of_pos (θ := -θ) (by linarith) (by linarith)
+  · exact exists_pos_cos_mul_nonpos_of_pos hθ hθ₂
+
+private lemma eq_one_of_forall_pow_mem_rightHalfArc {z : Circle}
+    (hz : ∀ n > 0, z ^ n ∈ rightHalfArc) : z = 1 := by
+  rw [← Circle.arg_eq_zero]
+  by_contra hθ
+  obtain ⟨n, hn, hcos⟩ :=
+    exists_pos_cos_mul_nonpos (Complex.neg_pi_lt_arg _) (Complex.arg_le_pi _) hθ
+  obtain ⟨t, ht, hzt⟩ := hz n hn
+  have hpow : Circle.exp ((n : ℝ) * (z : ℂ).arg) = Circle.exp t := by
+    rw [Circle.exp_natCast_mul, Circle.exp_arg, ← hzt]
+  have : cos ((n : ℝ) * (z : ℂ).arg) = cos t :=
+    Circle.cos_eq_cos_of_exp_eq_exp hpow
+  have htIoo : t ∈ Set.Ioo (-(π / 2)) (π / 2) := by
+    simpa [Set.mem_Ioo] using (abs_lt.mp ht)
+  linarith [cos_pos_of_mem_Ioo htIoo]
+
+/-- A compact monoid has discrete Pontryagin dual. -/
+instance [CompactSpace A] : DiscreteTopology (PontryaginDual A) := by
+  let V : Set (PontryaginDual A) := {ψ | Set.MapsTo ψ Set.univ rightHalfArc}
+  have hVopen : IsOpen V := by
+    dsimp only [V]
+    exact isOpen_induced (ContinuousMap.isOpen_setOf_mapsTo isCompact_univ isOpen_rightHalfArc)
+  have hVeq : V = ({1} : Set (PontryaginDual A)) := by
+    ext ψ
+    refine ⟨fun hψ ↦ ?_, fun hψ ↦ ?_⟩
+    · rw [Set.mem_singleton_iff]
+      apply ContinuousMonoidHom.ext
+      intro a
+      refine eq_one_of_forall_pow_mem_rightHalfArc fun n hn ↦ ?_
+      simpa [map_pow] using hψ (Set.mem_univ (a ^ n))
+    · rw [Set.mem_singleton_iff] at hψ
+      subst ψ
+      intro _ _
+      refine ⟨0, by simp [pi_pos], ?_⟩
+      change Circle.exp 0 = ((1 : A →ₜ* Circle) _)
+      simp
+  exact discreteTopology_of_isOpen_singleton_one (by simpa [hVeq] using hVopen)
+
+instance [DiscreteTopology A] [CompactSpace A] : Finite (PontryaginDual A) :=
+  finite_of_compact_of_discrete
+
+noncomputable instance [DiscreteTopology A] [CompactSpace A] : Fintype (PontryaginDual A) :=
+  .ofFinite _
 
 /-- `PontryaginDual` is a contravariant functor. -/
 def map (f : A →ₜ* B) :

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -1207,6 +1207,19 @@ namespace Metric
 
 variable {x y z : α} {ε ε₁ ε₂ : ℝ} {s : Set α}
 
+/-- If `f` is a positive radius tending to zero, then the sets of pairs with distance less than
+`f i` form a basis of the uniformity. -/
+lemma mk_uniformity_basis_of_tendsto {β : Type*} {p : β → Prop} {f : β → ℝ}
+    {l : Filter β} [l.NeBot] (hf₀ : ∀ i, p i → 0 < f i) (hf₁ : ∀ᶠ i in l, p i)
+    (hf : Tendsto f l (𝓝 0)) :
+    (𝓤 α).HasBasis p fun i ↦ {x | dist x.1 x.2 < f i} := by
+  apply Metric.mk_uniformity_basis hf₀
+  rw [nhds_basis_closedBall.tendsto_right_iff] at hf
+  refine fun ε hε ↦ hf₁.and (hf ε hε) |>.exists |>.imp fun i ↦ and_imp.mpr fun hp ↦ ?_
+  intro hi
+  exact ⟨hp, by
+    simpa [Metric.mem_closedBall, Real.dist_eq, abs_of_nonneg (hf₀ i hp).le] using hi⟩
+
 theorem ball_subset_interior_closedBall : ball x ε ⊆ interior (closedBall x ε) :=
   interior_maximal ball_subset_closedBall isOpen_ball
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -1215,8 +1215,7 @@ lemma mk_uniformity_basis_of_tendsto {β : Type*} {p : β → Prop} {f : β → 
     (𝓤 α).HasBasis p fun i ↦ {x | dist x.1 x.2 < f i} := by
   apply Metric.mk_uniformity_basis hf₀
   rw [nhds_basis_closedBall.tendsto_right_iff] at hf
-  refine fun ε hε ↦ hf₁.and (hf ε hε) |>.exists |>.imp fun i ↦ and_imp.mpr fun hp ↦ ?_
-  intro hi
+  refine fun ε hε ↦ hf₁.and (hf ε hε) |>.exists.imp fun i ↦ and_imp.mpr fun hp hi ↦ ?_
   exact ⟨hp, by
     simpa [Metric.mem_closedBall, Real.dist_eq, abs_of_nonneg (hf₀ i hp).le] using hi⟩
 


### PR DESCRIPTION
Proves that the Pontryagin dual of a compact monoid is discrete. As a consequence, it also adds the corresponding finite-type instances for compact discrete monoids.

This upstreams a result first added downstream in [`YaelDillies/APAP`](https://github.com/YaelDillies/APAP), where this fact was needed to close a `sorry`. The proof separates the trivial character from all the others using the right half of the circle and adds a few reusable `Circle` helper lemmas near the existing related API.

The original APAP proof was AI-assisted and then reviewed/rewritten during downstream review. For this PR, I used Codex to help adapt the APAP proof to mathlib and to refactor the supporting lemmas.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)