### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction/PartialAdjoint): remove erws

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
+++ b/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
@@ -125,17 +125,10 @@ noncomputable def partialLeftAdjoint : F.PartialLeftAdjointSource ⥤ D where
   map := F.partialLeftAdjointMap
   map_id X := by
     apply F.partialLeftAdjointHomEquiv.injective
-    dsimp
-    rw [partialLeftAdjointHomEquiv_map]
-    erw [id_comp]
+    simp [partialLeftAdjointHomEquiv_map]
   map_comp {X Y Z} f g := by
     apply F.partialLeftAdjointHomEquiv.injective
-    dsimp
-    rw [partialLeftAdjointHomEquiv_map, partialLeftAdjointHomEquiv_comp,
-      partialLeftAdjointHomEquiv_map, assoc]
-    erw [assoc]
-    rw [← F.partialLeftAdjointHomEquiv_comp, id_comp,
-      partialLeftAdjointHomEquiv_map]
+    simp [partialLeftAdjointHomEquiv_comp, ← F.partialLeftAdjointHomEquiv_comp]
 
 variable {F}
 
@@ -281,17 +274,10 @@ noncomputable def partialRightAdjoint : F.PartialRightAdjointSource ⥤ C where
   map := F.partialRightAdjointMap
   map_id X := by
     apply F.partialRightAdjointHomEquiv.injective
-    dsimp
-    rw [partialRightAdjointHomEquiv_map]
-    erw [comp_id]
+    simp [partialRightAdjointHomEquiv_map]
   map_comp {X Y Z} f g := by
     apply F.partialRightAdjointHomEquiv.injective
-    dsimp
-    rw [partialRightAdjointHomEquiv_map, partialRightAdjointHomEquiv_comp,
-      partialRightAdjointHomEquiv_map, ← assoc]
-    erw [← assoc]
-    rw [← F.partialRightAdjointHomEquiv_comp, comp_id,
-      partialRightAdjointHomEquiv_map]
+    simp [partialRightAdjointHomEquiv_comp, ← assoc, ← F.partialRightAdjointHomEquiv_comp]
 
 variable {F}
 


### PR DESCRIPTION
- rewrites the `partialLeftAdjoint` and `partialRightAdjoint` functor laws with direct `simp` proofs through the hom-equivalence lemmas

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)