### PR TITLE
[Merged by Bors] - chore(CategoryTheory/GlueData): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -299,8 +299,7 @@ def gluedIso : F.obj D.glued ≅ (D.mapGlueData F).glued :=
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 theorem ι_gluedIso_hom (i : D.J) : F.map (D.ι i) ≫ (D.gluedIso F).hom = (D.mapGlueData F).ι i := by
-  simp only [gluedIso, Iso.trans_hom]
-  simp [GlueData.ι]
+  simp [gluedIso, GlueData.ι]
 
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -299,7 +299,7 @@ def gluedIso : F.obj D.glued ≅ (D.mapGlueData F).glued :=
 set_option backward.isDefEq.respectTransparency false in
 @[reassoc (attr := simp)]
 theorem ι_gluedIso_hom (i : D.J) : F.map (D.ι i) ≫ (D.gluedIso F).hom = (D.mapGlueData F).ι i := by
-  erw [ι_preservesColimitIso_hom_assoc]
+  simp only [gluedIso, Iso.trans_hom]
   simp [GlueData.ι]
 
 set_option backward.isDefEq.respectTransparency false in


### PR DESCRIPTION
- expands `gluedIso` so `ι_gluedIso_hom` closes with `simp` instead of `erw [ι_preservesColimitIso_hom_assoc]`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)