### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Shift/ShiftedHom): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHom.lean
@@ -214,9 +214,8 @@ lemma map_comp {a b c : M} (f : ShiftedHom X Y a) (g : ShiftedHom Y Z b)
     (h : b + a = c) (F : C ⥤ D) [F.CommShift M] :
     (f.comp g h).map F = (f.map F).comp (g.map F) h := by
   dsimp [comp, map]
-  simp only [Functor.map_comp, assoc]
-  erw [← NatTrans.naturality_assoc]
-  simp only [Functor.comp_map, F.commShiftIso_add' h, Functor.CommShift.isoAdd'_hom_app,
+  simp only [Functor.map_comp, assoc, ← Functor.commShiftIso_hom_naturality_assoc]
+  simp only [F.commShiftIso_add' h, Functor.CommShift.isoAdd'_hom_app,
     ← Functor.map_comp_assoc, Iso.inv_hom_id_app, Functor.comp_obj, comp_id]
 
 section Preadditive


### PR DESCRIPTION
- folds the naturality step into `Functor.commShiftIso_hom_naturality_assoc` so `map_comp` uses `simp only` throughout

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)