### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/FreeModule/Int): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/FreeModule/Int.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Int.lean
@@ -41,7 +41,7 @@ lemma toAddSubgroup_index_eq_pow_mul_prod [Module R M] {N : Submodule R M}
   have snf' : ∀ i, (bN' i : ι → R) = Pi.single (f i) (a i) := by
     intro i
     simp only [map_apply, bN']
-    erw [LinearEquiv.submoduleMap_apply]
+    rw [LinearEquiv.submoduleMap_apply]
     simp only [equivFun_apply, snf, map_smul, repr_self, Finsupp.single_eq_pi_single]
     ext j
     simp [Pi.single_apply]


### PR DESCRIPTION
- rewrites the Smith normal form coordinate calculation with `rw [LinearEquiv.submoduleMap_apply]`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)