### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/Adjugate): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -348,7 +348,7 @@ theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.c
   apply mul_left_cancel₀ (show A'.det ≠ 0 from det_mvPolynomialX_ne_zero n ℤ)
   calc
     A'.det * A'.adjugate.det = (A' * adjugate A').det := (det_mul _ _).symm
-    _ = A'.det ^ Fintype.card n := by erw [mul_adjugate A']; rw [det_smul, det_one, mul_one]
+    _ = A'.det ^ Fintype.card n := by rw [mul_adjugate A', det_smul, det_one, mul_one]
     _ = A'.det * A'.det ^ (Fintype.card n - 1) := by rw [← pow_succ', h_card]
 
 @[simp]


### PR DESCRIPTION
- merges the `mul_adjugate` rewrite into the determinant calculation, so `det_adjugate` uses a plain `rw` chain

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)