### PR TITLE
[Merged by Bors] - chore(SetTheory/Cardinal/Arithmetic): remove an erw

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -678,8 +678,7 @@ theorem mk_equiv_eq_arrow_of_eq (eq : #α = #β) : #(α ≃ β) = #(α → β) :
   mk_equiv_eq_arrow_of_lift_eq congr(lift $eq)
 
 theorem mk_equiv_of_lift_eq (leq : lift.{v} #α = lift.{u} #β') : #(α ≃ β') = 2 ^ lift.{v} #α := by
-  erw [← (lift_mk_eq'.2 ⟨.equivCongr (.refl α) (lift_mk_eq'.1 leq).some⟩).trans (lift_id'.{u, v} _),
-    lift_umax.{u, v}, mk_perm_eq_two_power, lift_power, lift_natCast]; rfl
+  simp [mk_equiv_eq_arrow_of_lift_eq leq, ← leq, power_self_eq]
 
 theorem mk_equiv_of_eq (eq : #α = #β) : #(α ≃ β) = 2 ^ #α := by
   rw [mk_equiv_of_lift_eq (lift_inj.mpr eq), lift_id]


### PR DESCRIPTION
- replaces the long lifted-equivalence rewrite in `mk_equiv_of_lift_eq` with a short `simp` proof

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)