### PR TITLE
[Merged by Bors] - feat: trivial dfinsupp order lemmas

### DIFF
--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 module
 
 public import Mathlib.Algebra.Order.Module.Defs
+public import Mathlib.Algebra.Order.Pi
 public import Mathlib.Algebra.Order.Sub.Basic
 public import Mathlib.Data.DFinsupp.Module
 
@@ -61,7 +62,7 @@ theorem orderEmbeddingToFun_apply {f : Π₀ i, α i} {i : ι} :
 end LE
 
 section Preorder
-variable [∀ i, Preorder (α i)] {f g : Π₀ i, α i}
+variable [∀ i, Preorder (α i)] {f g : Π₀ i, α i} {i : ι} {a b : α i}
 
 instance : Preorder (Π₀ i, α i) :=
   { (inferInstance : LE (DFinsupp α)) with
@@ -74,6 +75,16 @@ lemma lt_def : f < g ↔ f ≤ g ∧ ∃ i, f i < g i := Pi.lt_def
 lemma coe_mono : Monotone ((⇑) : (Π₀ i, α i) → ∀ i, α i) := fun _ _ ↦ id
 
 lemma coe_strictMono : Monotone ((⇑) : (Π₀ i, α i) → ∀ i, α i) := fun _ _ ↦ id
+
+variable [DecidableEq ι]
+
+@[simp, gcongr] lemma single_le_single : single i a ≤ single i b ↔ a ≤ b :=
+  Pi.single_le_single
+
+lemma single_mono : Monotone (single i : α i → Π₀ i, α i) := fun _ _ ↦ single_le_single.2
+
+@[simp] lemma single_nonneg : 0 ≤ single i a ↔ 0 ≤ a := Pi.single_nonneg
+@[simp] lemma single_nonpos : single i a ≤ 0 ↔ a ≤ 0 := Pi.single_nonpos
 
 end Preorder
 


### PR DESCRIPTION
These lemmas already exist for `Finsupp`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
