### PR TITLE
[Merged by Bors] - feat(LinearMap, RingHom, FirstOrder.Language.Hom): simp lemma for composing domRestrict and codRestrict

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -174,6 +174,12 @@ theorem subtype_comp_codRestrict (p : Submodule R₂ M₂) (h : ∀ b, f b ∈ p
     p.subtype.comp (codRestrict p f h) = f :=
   ext fun _ => rfl
 
+@[simp]
+theorem domRestrict_comp_codRestrict (f : M →ₛₗ[σ₁₂] M₂) (g : M₂ →ₛₗ[σ₂₃] M₃) (p : Submodule R₂ M₂)
+    (h : ∀ c, f c ∈ p) :
+    g.domRestrict p ∘ₛₗ f.codRestrict p h = g ∘ₛₗ f :=
+  rfl
+
 section
 
 variable {M₂' : Type*} [AddCommMonoid M₂'] [Module R₂ M₂']

--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -175,7 +175,7 @@ theorem subtype_comp_codRestrict (p : Submodule R₂ M₂) (h : ∀ b, f b ∈ p
   ext fun _ => rfl
 
 @[simp]
-theorem domRestrict_comp_codRestrict (f : M →ₛₗ[σ₁₂] M₂) (g : M₂ →ₛₗ[σ₂₃] M₃) (p : Submodule R₂ M₂)
+theorem domRestrict_comp_codRestrict (g : M₂ →ₛₗ[σ₂₃] M₃) (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R₂ M₂)
     (h : ∀ c, f c ∈ p) :
     g.domRestrict p ∘ₛₗ f.codRestrict p h = g ∘ₛₗ f :=
   rfl

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -835,6 +835,11 @@ theorem range_eq_top_of_surjective (f : R →+* S) (hf : Function.Surjective f) 
     f.range = (⊤ : Subring S) :=
   range_eq_top.2 hf
 
+@[simp]
+theorem rangeRestrict_comp_codRestrict (g : S →+* T) (f : R →+* S) :
+    (g.domRestrict f.range).comp (f.rangeRestrict) = g.comp f :=
+  rfl
+
 section eqLocus
 
 variable {S : Type v} [Semiring S]

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -836,7 +836,7 @@ theorem range_eq_top_of_surjective (f : R →+* S) (hf : Function.Surjective f) 
   range_eq_top.2 hf
 
 @[simp]
-theorem rangeRestrict_comp_codRestrict (g : S →+* T) (f : R →+* S) :
+theorem domRestrict_comp_rangeRestrict (g : S →+* T) (f : R →+* S) :
     (g.domRestrict f.range).comp (f.rangeRestrict) = g.comp f :=
   rfl
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -736,6 +736,12 @@ theorem comp_restrict (f : R →+* S) (s' : σR) (s : σS) (h : ∀ x ∈ s', f 
     (SubsemiringClass.subtype s).comp (f.restrict s' s h) = f.comp (SubsemiringClass.subtype s') :=
   rfl
 
+@[simp]
+theorem domRestrict_comp_codRestrict (g : S →+* T) (f : R →+* S) (p : Subsemiring S)
+    (h : ∀ c, f c ∈ p) :
+    (g.domRestrict p).comp (f.codRestrict p h) = g.comp f :=
+  rfl
+
 /-- Restriction of a ring homomorphism to its range interpreted as a subsemiring.
 
 This is the bundled version of `Set.rangeFactorization`. -/

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -787,6 +787,11 @@ theorem map_closureS (f : R →+* S) (s : Set R) : (closure s).map f = closure (
   Set.image_preimage.l_comm_of_u_comm (gc_map_comap f) (Subsemiring.gi S).gc (Subsemiring.gi R).gc
     fun _ ↦ coe_comap _ _
 
+@[simp]
+theorem rangeSRestrict_comp_codRestrict (g : S →+* T) (f : R →+* S) :
+    (g.domRestrict f.rangeS).comp (f.rangeSRestrict) = g.comp f :=
+  rfl
+
 end RingHom
 
 namespace Subsemiring

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -788,7 +788,7 @@ theorem map_closureS (f : R →+* S) (s : Set R) : (closure s).map f = closure (
     fun _ ↦ coe_comap _ _
 
 @[simp]
-theorem rangeSRestrict_comp_codRestrict (g : S →+* T) (f : R →+* S) :
+theorem domRestrict_comp_rangeSRestrict (g : S →+* T) (f : R →+* S) :
     (g.domRestrict f.rangeS).comp (f.rangeSRestrict) = g.comp f :=
   rfl
 

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -783,6 +783,12 @@ theorem subtype_comp_codRestrict (f : M →[L] N) (p : L.Substructure N) (h : �
     p.subtype.toHom.comp (codRestrict p f h) = f :=
   ext fun _ => rfl
 
+@[simp]
+theorem domRestrict_comp_codRestrict (g : N →[L] P) (f : M →[L] N) (p : L.Substructure N)
+    (h : ∀ b, f b ∈ p) :
+    (g.domRestrict p).comp (f.codRestrict p h) = g.comp f :=
+  rfl
+
 /-- The range of a first-order hom `f : M → N` is a submodule of `N`.
 See Note [range copy pattern]. -/
 def range (f : M →[L] N) : L.Substructure N :=


### PR DESCRIPTION

---

~~I am aware that this lemma is true for all function-like classes that has `domRestrict` and `codRestrict`. I didn't add the same for all of them, and only added the one I needed in #37295. Should we manually add this for all function classes? Or there should be some metaprogramming to generate them?~~

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
