### PR TITLE
[Merged by Bors] - feat(MeasureTheory): use pseudometric in measurableSet_exists_tendsto

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -991,14 +991,14 @@ lemma MeasureTheory.measurableSet_tendsto_fun [MeasurableSpace γ] [Countable ι
 
 /-- The set of points for which a measurable sequence of functions converges is measurable. -/
 @[measurability]
-theorem MeasureTheory.measurableSet_exists_tendsto
-    [TopologicalSpace γ] [PolishSpace γ] [MeasurableSpace γ]
+theorem MeasureTheory.measurableSet_exists_tendsto [TopologicalSpace γ]
+    [IsCompletelyPseudoMetrizableSpace γ] [SecondCountableTopology γ] [MeasurableSpace γ]
     [hγ : OpensMeasurableSpace γ] [Countable ι] {l : Filter ι}
     [l.IsCountablyGenerated] {f : ι → β → γ} (hf : ∀ i, Measurable (f i)) :
     MeasurableSet { x | ∃ c, Tendsto (fun n => f n x) l (𝓝 c) } := by
   rcases l.eq_or_neBot with rfl | hl
   · simp
-  letI := TopologicalSpace.upgradeIsCompletelyMetrizable γ
+  letI := TopologicalSpace.upgradeIsCompletelyPseudoMetrizable γ
   rcases l.exists_antitone_basis with ⟨u, hu⟩
   simp_rw [← cauchy_map_iff_exists_tendsto]
   change MeasurableSet { x | _ ∧ _ }

--- a/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
@@ -27,22 +27,22 @@ open Filter MeasureTheory Set TopologicalSpace
 
 open scoped Topology
 
-variable {ι X E : Type*} [MeasurableSpace X] [TopologicalSpace E] [IsCompletelyMetrizableSpace E]
-  [Countable ι] {l : Filter ι} [l.IsCountablyGenerated] {f : ι → X → E}
+variable {ι X E : Type*} [MeasurableSpace X] [TopologicalSpace E] [Countable ι] {l : Filter ι}
+  [l.IsCountablyGenerated] {f : ι → X → E}
 
 namespace MeasureTheory.StronglyMeasurable
 
-theorem measurableSet_exists_tendsto (hf : ∀ i, StronglyMeasurable (f i)) :
+theorem measurableSet_exists_tendsto [IsCompletelyPseudoMetrizableSpace E]
+    (hf : ∀ i, StronglyMeasurable (f i)) :
     MeasurableSet {x | ∃ c, Tendsto (f · x) l (𝓝 c)} := by
   obtain rfl | hl := eq_or_neBot l
   · simp_all
   borelize E
-  letI := upgradeIsCompletelyMetrizable E
+  letI := upgradeIsCompletelyPseudoMetrizable E
   let s := closure (⋃ i, range (f i))
-  have : PolishSpace s :=
-    { toSecondCountableTopology := @UniformSpace.secondCountable_of_separable s _ _
-        (IsSeparable.iUnion (fun i ↦ (hf i).isSeparable_range)).closure.separableSpace
-      toIsCompletelyMetrizableSpace := isClosed_closure.isCompletelyMetrizableSpace }
+  have : SecondCountableTopology s := @UniformSpace.secondCountable_of_separable s _ _
+    (IsSeparable.iUnion (fun i ↦ (hf i).isSeparable_range)).closure.separableSpace
+  have : IsCompletelyPseudoMetrizableSpace s := isClosed_closure.isCompletelyPseudoMetrizableSpace
   let g i x : s := ⟨f i x, subset_closure <| mem_iUnion.2 ⟨i, ⟨x, rfl⟩⟩⟩
   have mg i : Measurable (g i) := (hf i).measurable.subtype_mk
   convert MeasureTheory.measurableSet_exists_tendsto (l := l) mg with x
@@ -50,7 +50,8 @@ theorem measurableSet_exists_tendsto (hf : ∀ i, StronglyMeasurable (f i)) :
     fun ⟨c, hc⟩ ↦ ⟨c, tendsto_subtype_rng.1 hc⟩⟩
   exact mem_closure_of_tendsto hc (Eventually.of_forall fun i ↦ mem_iUnion.2 ⟨i, ⟨x, rfl⟩⟩)
 
-protected theorem limUnder [hE : Nonempty E] (hf : ∀ i, StronglyMeasurable (f i)) :
+protected theorem limUnder [hE : Nonempty E] [IsCompletelyMetrizableSpace E]
+    (hf : ∀ i, StronglyMeasurable (f i)) :
     StronglyMeasurable (fun x ↦ limUnder l (f · x)) := by
   obtain rfl | hl := eq_or_neBot l
   · simpa [limUnder, Filter.map_bot] using stronglyMeasurable_const

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -663,7 +663,7 @@ theorem _root_.Measurable.stronglyMeasurable [TopologicalSpace β] [PseudoMetriz
     SimpleFunc.tendsto_approxOn hf (Set.mem_univ _) (by simp)⟩
 
 /-- In a space with second countable topology, strongly measurable and measurable are equivalent. -/
-theorem _root_.stronglyMeasurable_iff_measurable [TopologicalSpace β] [MetrizableSpace β]
+theorem _root_.stronglyMeasurable_iff_measurable [TopologicalSpace β] [PseudoMetrizableSpace β]
     [BorelSpace β] [SecondCountableTopology β] : StronglyMeasurable f ↔ Measurable f :=
   ⟨fun h => h.measurable, fun h => Measurable.stronglyMeasurable h⟩
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
