### PR TITLE
[Merged by Bors] - refactor(Analysis/Complex/UpperHalfPlane): deprecate old GL2Pos stuff

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -361,52 +361,6 @@ end UpperHalfPlane
 namespace ModularGroup -- results specific to `SL(2, ℤ)`
 -- TODO: Move these elsewhere, maybe somewhere in the algebra or number theory hierarchies?
 
-section ModularScalarTowers
-
-/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`. -/
-@[coe]
-def coe (g : SL(2, ℤ)) : GL(2, ℝ)⁺ := ((g : SL(2, ℝ)) : GL(2, ℝ)⁺)
-
-@[simp]
-lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
-  refine ⟨fun h ↦ a.ext b fun i j ↦ ?_, congr_arg _⟩
-  simp only [Subtype.ext_iff, GeneralLinearGroup.ext_iff] at h
-  simpa [coe] using h i j
-
-instance : Coe SL(2, ℤ) GL(2, ℝ)⁺ :=
-  ⟨coe⟩
-
-/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`, bundled as a group hom. -/
-def coeHom : SL(2, ℤ) →* GL(2, ℝ)⁺ := toGLPos.comp <| map <| Int.castRingHom _
-
-@[simp] lemma coeHom_apply (g : SL(2, ℤ)) : coeHom g = coe g := rfl
-
-@[simp]
-theorem coe_apply_complex {g : SL(2, ℤ)} {i j : Fin 2} :
-    (Units.val <| Subtype.val <| coe g) i j = (Subtype.val g i j : ℂ) :=
-  rfl
-
-@[simp]
-theorem det_coe {g : SL(2, ℤ)} : det (Units.val <| Subtype.val <| coe g) = 1 := by
-  simp only [SpecialLinearGroup.coe_GLPos_coe_GL_coe_matrix, SpecialLinearGroup.det_coe, coe]
-
-lemma coe_one : coe 1 = 1 := by
-  simp only [coe, map_one]
-
-instance SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
-  ⟨fun s g => s * g⟩
-
-theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
-    (s • g) • z = ((s : GL(2, ℝ)⁺) * g) • z :=
-  rfl
-
-instance SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
-  smul_assoc s g z := by
-    simp only [SLOnGLPos_smul_apply]
-    apply mul_smul'
-
-end ModularScalarTowers
-
 section SLModularAction
 
 variable (g : SL(2, ℤ)) (z : ℍ)
@@ -428,5 +382,62 @@ theorem denom_apply : denom g z = g 1 0 * z + g 1 1 := rfl
 @[simp] lemma denom_S : denom S z = z := by simp [S, denom_apply]
 
 end SLModularAction
+
+section ModularScalarTowers
+
+/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`. -/
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+def coe (g : SL(2, ℤ)) : GL(2, ℝ)⁺ := ((g : SL(2, ℝ)) : GL(2, ℝ)⁺)
+
+set_option linter.deprecated false in
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+lemma coe_inj (a b : SL(2, ℤ)) : coe a = coe b ↔ a = b := by
+  refine ⟨fun h ↦ a.ext b fun i j ↦ ?_, congr_arg _⟩
+  simp only [Subtype.ext_iff, GeneralLinearGroup.ext_iff] at h
+  simpa [coe] using h i j
+
+/-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`, bundled as a group hom. -/
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+def coeHom : SL(2, ℤ) →* GL(2, ℝ)⁺ := toGLPos.comp <| map <| Int.castRingHom _
+
+set_option linter.deprecated false in
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+lemma coeHom_apply (g : SL(2, ℤ)) : coeHom g = coe g := rfl
+
+set_option linter.deprecated false in
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+theorem coe_apply_complex {g : SL(2, ℤ)} {i j : Fin 2} :
+    (Units.val <| Subtype.val <| coe g) i j = (Subtype.val g i j : ℂ) :=
+  rfl
+
+set_option linter.deprecated false in
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+theorem det_coe {g : SL(2, ℤ)} : det (Units.val <| Subtype.val <| coe g) = 1 := by
+  simp only [SpecialLinearGroup.coe_GLPos_coe_GL_coe_matrix, SpecialLinearGroup.det_coe, coe]
+
+set_option linter.deprecated false in
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+lemma coe_one : coe 1 = 1 := by
+  simp only [coe, map_one]
+
+@[reducible, deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+def SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
+  ⟨fun s g => s * g⟩
+
+attribute [local instance] SLOnGLPos
+
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
+    (s • g) • z = ((s : GL(2, ℝ)⁺) * g) • z :=
+  rfl
+
+set_option linter.deprecated false in
+@[reducible, deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+def SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
+  smul_assoc s g z := by
+    simp only [SLOnGLPos_smul_apply]
+    apply mul_smul'
+
+end ModularScalarTowers
 
 end ModularGroup

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -398,6 +398,7 @@ set_option linter.deprecated false in
 lemma coe_one : coe 1 = 1 := by
   simp only [coe, map_one]
 
+/-- Multiplication action of `SL(2, ℤ)` on `GL(2, ℝ)⁺`. -/
 @[reducible, deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
 def SLOnGLPos : SMul SL(2, ℤ) GL(2, ℝ)⁺ :=
   ⟨fun s g => s * g⟩
@@ -410,8 +411,8 @@ theorem SLOnGLPos_smul_apply (s : SL(2, ℤ)) (g : GL(2, ℝ)⁺) (z : ℍ) :
   rfl
 
 set_option linter.deprecated false in
-@[reducible, deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
-def SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
+@[deprecated "use GL(2, ℝ)" (since := "2026-04-29")]
+lemma SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
   smul_assoc s g z := by
     simp only [SLOnGLPos_smul_apply]
     apply mul_smul'

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -361,28 +361,6 @@ end UpperHalfPlane
 namespace ModularGroup -- results specific to `SL(2, ℤ)`
 -- TODO: Move these elsewhere, maybe somewhere in the algebra or number theory hierarchies?
 
-section SLModularAction
-
-variable (g : SL(2, ℤ)) (z : ℍ)
-
-@[simp]
-theorem sl_moeb : g • z = (g : GL (Fin 2) ℝ) • z := rfl
-
-@[simp high]
-theorem SL_neg_smul : -g • z = g • z := by
-  rw [sl_moeb, ← z.neg_smul]
-  congr 1 with i j
-  simp [toGL]
-
-theorem im_smul_eq_div_normSq : (g • z).im = z.im / Complex.normSq (denom g z) := by
-  simpa using z.im_smul_eq_div_normSq g
-
-theorem denom_apply : denom g z = g 1 0 * z + g 1 1 := rfl
-
-@[simp] lemma denom_S : denom S z = z := by simp [S, denom_apply]
-
-end SLModularAction
-
 section ModularScalarTowers
 
 /-- Canonical embedding of `SL(2, ℤ)` into `GL(2, ℝ)⁺`. -/
@@ -439,5 +417,27 @@ def SL_to_GL_tower : IsScalarTower SL(2, ℤ) GL(2, ℝ)⁺ ℍ where
     apply mul_smul'
 
 end ModularScalarTowers
+
+section SLModularAction
+
+variable (g : SL(2, ℤ)) (z : ℍ)
+
+@[simp]
+theorem sl_moeb : g • z = (g : GL (Fin 2) ℝ) • z := rfl
+
+@[simp high]
+theorem SL_neg_smul : -g • z = g • z := by
+  rw [sl_moeb, ← z.neg_smul]
+  congr 1 with i j
+  simp [toGL]
+
+theorem im_smul_eq_div_normSq : (g • z).im = z.im / Complex.normSq (denom g z) := by
+  simpa using z.im_smul_eq_div_normSq g
+
+theorem denom_apply : denom g z = g 1 0 * z + g 1 1 := rfl
+
+@[simp] lemma denom_S : denom S z = z := by simp [S, denom_apply]
+
+end SLModularAction
 
 end ModularGroup


### PR DESCRIPTION
The modular forms code previously used the subtype GL2Pos (2x2 matrices of positive determinant) for actions on the upper half-plane. This has now been changed by extending the action to all of GL(2, R), but some old no-longer-used instances and coercions were left behind. This deprecates them for later removal.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
