### PR TITLE
[Merged by Bors] - perf: raise prio of various Mul->SMul instances

### DIFF
--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -56,9 +56,17 @@ variable {M N G H α β γ δ : Type*}
 /- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
 attribute [instance 1100, to_additive /-- See also `AddMonoid.toAddAction` -/] instSMulOfMul
 
+/-- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
+@[deprecated instSMulOfMul (since := "2025-10-18"), implicit_reducible]
+def Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(· * ·)⟩
+
+/-- See also `AddMonoid.toAddAction` -/
+@[deprecated instVAddOfAdd (since := "2025-10-18"), implicit_reducible]
+def Add.toVAdd (α : Type*) [Add α] : VAdd α α := ⟨(· + ·)⟩
+
 /-- Like `Mul.toSMul`, but multiplies on the right.
 
-See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
+/- See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
 @[to_additive /-- Like `Add.toVAdd`, but adds on the right.
 
   See also `AddMonoid.toOppositeAddAction`. -/]

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -66,7 +66,7 @@ def Add.toVAdd (α : Type*) [Add α] : VAdd α α := ⟨(· + ·)⟩
 
 /-- Like `Mul.toSMul`, but multiplies on the right.
 
-/- See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
+See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
 @[to_additive /-- Like `Add.toVAdd`, but adds on the right.
 
   See also `AddMonoid.toOppositeAddAction`. -/]

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -53,9 +53,8 @@ open Function (Injective Surjective)
 
 variable {M N G H α β γ δ : Type*}
 
-/-- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
-@[to_additive /-- See also `AddMonoid.toAddAction` -/]
-instance (priority := 1100) Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(· * ·)⟩
+/- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
+attribute [instance 1100, to_additive /-- See also `AddMonoid.toAddAction` -/] instSMulOfMul
 
 /-- Like `Mul.toSMul`, but multiplies on the right.
 

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -463,12 +463,11 @@ variable (M)
 /-- The regular action of a monoid on itself by left multiplication.
 
 This is promoted to a module by `Semiring.toModule`. -/
--- see Note [lower instance priority]
 @[to_additive
 /-- The regular action of a monoid on itself by left addition.
 
 This is promoted to an `AddTorsor` by `addGroup_is_addTorsor`. -/]
-instance (priority := 910) Monoid.toMulAction : MulAction M M where
+instance (priority := 1100) Monoid.toMulAction : MulAction M M where
   smul := (· * ·)
   one_smul := one_mul
   mul_smul := mul_assoc

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -53,6 +53,9 @@ open Function (Injective Surjective)
 
 variable {M N G H α β γ δ : Type*}
 
+-- Note that https://github.com/leanprover/lean4/pull/13554
+-- also makes the instance priority change, so if that is merged then `instance 1100` can
+-- be removed here (we still want `to_additive` though).
 /- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
 attribute [instance 1100, to_additive /-- See also `AddMonoid.toAddAction` -/] instSMulOfMul
 

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -53,12 +53,9 @@ open Function (Injective Surjective)
 
 variable {M N G H α β γ δ : Type*}
 
-attribute [to_additive Add.toVAdd /-- See also `AddMonoid.toAddAction` -/] instSMulOfMul
-
--- see Note [lower instance priority]
 /-- See also `Monoid.toMulAction` and `MulZeroClass.toSMulWithZero`. -/
-@[deprecated instSMulOfMul (since := "2025-10-18"), implicit_reducible]
-def Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(· * ·)⟩
+@[to_additive /-- See also `AddMonoid.toAddAction` -/]
+instance (priority := 1100) Mul.toSMul (α : Type*) [Mul α] : SMul α α := ⟨(· * ·)⟩
 
 /-- Like `Mul.toSMul`, but multiplies on the right.
 

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -79,13 +79,18 @@ instance mulAction' [Group G] [Monoid M] [MulAction G M] [SMulCommClass G M M]
   one_smul _ := Units.ext <| one_smul _ _
   mul_smul _ _ _ := Units.ext <| mul_smul _ _ _
 
-/-- This is not the usual `smul_eq_mul` because `mulAction'` creates a diamond.
+/-- `Units.mulAction' : MulAction G Mˣ` creates a diamond when `G = Mˣ` and `M` is commutative.
 
 Discussed [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/units.2Emul_action'.20diamond/near/246400399). -/
+example {M} [CommMonoid M] :
+    (mulAction'.toSMul : SMul Mˣ Mˣ) = instSMulOfMul := by
+  fail_if_success rfl -- there is an instance diamond here
+  ext
+  rfl
+
 @[simp]
 lemma smul_eq_mul {M} [CommMonoid M] (u₁ u₂ : Mˣ) :
     u₁ • u₂ = u₁ * u₂ := by
-  fail_if_success rfl -- there is an instance diamond here
   ext
   rfl
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -117,7 +117,7 @@ class SMulWithZero [Zero M₀] [Zero A] extends SMulZeroClass M₀ A where
   /-- Scalar multiplication by the scalar `0` is `0`. -/
   zero_smul : ∀ m : A, (0 : M₀) • m = 0
 
-instance MulZeroClass.toSMulWithZero [MulZeroClass M₀] : SMulWithZero M₀ M₀ where
+instance (priority := 1100) MulZeroClass.toSMulWithZero [MulZeroClass M₀] : SMulWithZero M₀ M₀ where
   smul := (· * ·)
   smul_zero := mul_zero
   zero_smul := zero_mul

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -194,7 +194,7 @@ instance (priority := 100) MulActionWithZero.toSMulWithZero (M₀ A) {_ : Monoid
   { m with }
 
 /-- See also `Semiring.toModule` -/
-instance MonoidWithZero.toMulActionWithZero : MulActionWithZero M₀ M₀ :=
+instance (priority := 1100) MonoidWithZero.toMulActionWithZero : MulActionWithZero M₀ M₀ :=
   { MulZeroClass.toSMulWithZero M₀, Monoid.toMulAction M₀ with }
 
 /-- Like `MonoidWithZero.toMulActionWithZero`, but multiplies on the right. See also

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -163,7 +163,6 @@ protected theorem Module.nontrivial (R M : Type*) [MonoidWithZero R] [Nontrivial
     [MulActionWithZero R M] : Nontrivial R :=
   MulActionWithZero.nontrivial R M
 
--- see Note [lower instance priority]
 instance (priority := 1100) Semiring.toModule [Semiring R] : Module R R where
   smul_add := mul_add
   add_smul := add_mul

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -164,7 +164,7 @@ protected theorem Module.nontrivial (R M : Type*) [MonoidWithZero R] [Nontrivial
   MulActionWithZero.nontrivial R M
 
 -- see Note [lower instance priority]
-instance (priority := 910) Semiring.toModule [Semiring R] : Module R R where
+instance (priority := 1100) Semiring.toModule [Semiring R] : Module R R where
   smul_add := mul_add
   add_smul := add_mul
   zero_smul := zero_mul

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -29,9 +29,6 @@ open scoped NNReal ENNReal uniformity
 
 section SeminormedAddCommGroup
 
--- Here, we set a rather high priority for the instance `[NormedSpace 𝕜 E] : Module 𝕜 E`
--- to take precedence over `Semiring.toModule` as this leads to instance paths with better
--- unification properties.
 /-- A normed space over a normed field is a vector space endowed with a norm which satisfies the
 equality `‖c • x‖ = ‖c‖ ‖x‖`. We require only `‖c • x‖ ≤ ‖c‖ ‖x‖` in the definition, then prove
 `‖c • x‖ = ‖c‖ ‖x‖` in `norm_smul`.

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -69,7 +69,6 @@ lemma ofTensorProduct_tmul (r : AdicCompletion I R) (x : M) :
     ofTensorProduct I M (r ⊗ₜ x) = r • of I M x := by
   rfl
 
-set_option backward.isDefEq.respectTransparency false in
 variable {M} in
 /-- `ofTensorProduct` is functorial in `M`. -/
 lemma ofTensorProduct_naturality (f : M →ₗ[R] N) :
@@ -90,6 +89,22 @@ section DecidableEq
 
 variable [Fintype ι] [DecidableEq ι]
 
+/-
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
+variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
+
+-- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
+-- diamonds if `X = Y`.
+example : AdicCompletion.module I = Semiring.toModule := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+
+example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
+    Semiring.toModule.toSMul := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+-/
 set_option backward.isDefEq.respectTransparency false in
 private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
     piEquivOfFintype I (fun _ : ι ↦ R) ∘ₗ ofTensorProduct I (ι → R) =
@@ -99,6 +114,22 @@ private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
     simpa [Pi.single_apply, -smul_eq_mul]
   split <;> simp
 
+/-
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
+variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
+
+-- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
+-- diamonds if `X = Y`.
+example : AdicCompletion.module I = Semiring.toModule := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+
+example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
+    Semiring.toModule.toSMul := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+-/
 set_option backward.isDefEq.respectTransparency false in
 private lemma ofTensorProduct_eq :
     ofTensorProduct I (ι → R) = (piEquivOfFintype I (ι := ι) (fun _ : ι ↦ R)).symm.toLinearMap ∘ₗ
@@ -114,12 +145,28 @@ def ofTensorProductInvOfPiFintype :
   letI g := (TensorProduct.piScalarRight R (AdicCompletion I R) (AdicCompletion I R) ι).symm
   f.trans g
 
+/-
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
+variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
+
+-- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
+-- diamonds if `X = Y`.
+example : AdicCompletion.module I = Semiring.toModule := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+
+example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
+    Semiring.toModule.toSMul := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+-/
 set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProductInvOfPiFintype_comp_ofTensorProduct :
     ofTensorProductInvOfPiFintype I ι ∘ₗ ofTensorProduct I (ι → R) = LinearMap.id := by
-  dsimp only [ofTensorProductInvOfPiFintype]
+  dsimp [ofTensorProductInvOfPiFintype]
   rw [LinearEquiv.coe_trans, LinearMap.comp_assoc, piEquivOfFintype_comp_ofTensorProduct_eq]
-  simp
+  exact LinearEquiv.symm_comp _
 
 set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProduct_comp_ofTensorProductInvOfPiFintype :
@@ -149,7 +196,6 @@ lemma ofTensorProduct_bijective_of_pi_of_fintype [Finite ι] :
 
 end PiFintype
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `M` is a finite `R`-module, then the canonical map
 `AdicCompletion I R ⊗[R] M →ₗ AdicCompletion I M` is surjective. -/
 lemma ofTensorProduct_surjective_of_finite [Module.Finite R M] :
@@ -308,7 +354,6 @@ variable {M : Type u} [AddCommGroup M] [Module R M]
 variable {N : Type u} [AddCommGroup N] [Module R N] (f : M →ₗ[R] N)
 variable [Module.Finite R M] [Module.Finite R N]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma tensor_map_id_left_eq_map :
     (AlgebraTensorModule.map LinearMap.id f) =
       (ofTensorProductEquivOfFiniteNoetherian I N).symm.toLinearMap ∘ₗ

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -62,7 +62,7 @@ def ofTensorProduct : AdicCompletion I R ⊗[R] M →ₗ[AdicCompletion I R] Adi
         simp
       map_smul' r x := by
         apply LinearMap.ext
-        simp }
+        simp [mul_smul] }
 
 @[simp]
 lemma ofTensorProduct_tmul (r : AdicCompletion I R) (x : M) :
@@ -99,6 +99,7 @@ private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
     simpa [Pi.single_apply, -smul_eq_mul]
   split <;> simp
 
+set_option backward.isDefEq.respectTransparency false in
 private lemma ofTensorProduct_eq :
     ofTensorProduct I (ι → R) = (piEquivOfFintype I (ι := ι) (fun _ : ι ↦ R)).symm.toLinearMap ∘ₗ
       (TensorProduct.piScalarRight R (AdicCompletion I R) (AdicCompletion I R) ι).toLinearMap := by
@@ -113,12 +114,14 @@ def ofTensorProductInvOfPiFintype :
   letI g := (TensorProduct.piScalarRight R (AdicCompletion I R) (AdicCompletion I R) ι).symm
   f.trans g
 
+set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProductInvOfPiFintype_comp_ofTensorProduct :
     ofTensorProductInvOfPiFintype I ι ∘ₗ ofTensorProduct I (ι → R) = LinearMap.id := by
   dsimp only [ofTensorProductInvOfPiFintype]
   rw [LinearEquiv.coe_trans, LinearMap.comp_assoc, piEquivOfFintype_comp_ofTensorProduct_eq]
   simp
 
+set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProduct_comp_ofTensorProductInvOfPiFintype :
     ofTensorProduct I (ι → R) ∘ₗ ofTensorProductInvOfPiFintype I ι = LinearMap.id := by
   dsimp only [ofTensorProductInvOfPiFintype]

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -89,22 +89,6 @@ section DecidableEq
 
 variable [Fintype ι] [DecidableEq ι]
 
-/-
-import Mathlib.RingTheory.AdicCompletion.Algebra
-
-variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
-
--- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
--- diamonds if `X = Y`.
-example : AdicCompletion.module I = Semiring.toModule := by
-  fail_if_success with_reducible_and_instances rfl
-  rfl
-
-example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
-    Semiring.toModule.toSMul := by
-  fail_if_success with_reducible_and_instances rfl
-  rfl
--/
 set_option backward.isDefEq.respectTransparency false in
 private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
     piEquivOfFintype I (fun _ : ι ↦ R) ∘ₗ ofTensorProduct I (ι → R) =
@@ -164,10 +148,26 @@ example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCom
 set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProductInvOfPiFintype_comp_ofTensorProduct :
     ofTensorProductInvOfPiFintype I ι ∘ₗ ofTensorProduct I (ι → R) = LinearMap.id := by
-  dsimp [ofTensorProductInvOfPiFintype]
+  dsimp only [ofTensorProductInvOfPiFintype]
   rw [LinearEquiv.coe_trans, LinearMap.comp_assoc, piEquivOfFintype_comp_ofTensorProduct_eq]
-  exact LinearEquiv.symm_comp _
+  simp
 
+/-
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
+variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
+
+-- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
+-- diamonds if `X = Y`.
+example : AdicCompletion.module I = Semiring.toModule := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+
+example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
+    Semiring.toModule.toSMul := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+-/
 set_option backward.isDefEq.respectTransparency false in
 lemma ofTensorProduct_comp_ofTensorProductInvOfPiFintype :
     ofTensorProduct I (ι → R) ∘ₗ ofTensorProductInvOfPiFintype I ι = LinearMap.id := by

--- a/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
@@ -328,12 +328,20 @@ def piEquivFin (n : ℕ) :
   piEquivOfFintype I (ι := Fin n) (fun _ : Fin n ↦ R)
 
 /-
-#defeq_abuse: tactic fails with `backward.isDefEq.respectTransparency true` but succeeds
-  with `false`.
-The following isDefEq checks are the root causes of the failure:
-  ❌️ Quot.lift (fun x ↦ x • (eval I R n) x2✝) ⋯
-  ((eval I R n) x1✝) =?= Ideal.Quotient.ring._aux_1 (I ^ n • ⊤) (↑x1✝ n) (↑x2✝ n)
-  ❌️ { smul := fun x1 x2 ↦ x1 * x2 } =?= smul I
+import Mathlib.RingTheory.AdicCompletion.Algebra
+
+variable {R : Type*} [CommRing R] (I : Ideal R) (ι : Type*) [Fintype ι] [DecidableEq ι]
+
+-- `AdicCompletion.module` has type `Module X Y → Module (F X) (F Y)` so introduces
+-- diamonds if `X = Y`.
+example : AdicCompletion.module I = Semiring.toModule := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
+
+example : ((AdicCompletion.module I).toSMul : SMul (AdicCompletion I R) (AdicCompletion I R)) =
+    Semiring.toModule.toSMul := by
+  fail_if_success with_reducible_and_instances rfl
+  rfl
 -/
 set_option backward.isDefEq.respectTransparency false in
 @[simp]

--- a/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
@@ -327,6 +327,7 @@ def piEquivFin (n : ℕ) :
     AdicCompletion I (Fin n → R) ≃ₗ[AdicCompletion I R] Fin n → AdicCompletion I R :=
   piEquivOfFintype I (ι := Fin n) (fun _ : Fin n ↦ R)
 
+set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem piEquivFin_apply (n : ℕ) (x : AdicCompletion I (Fin n → R)) :
     piEquivFin I n x = pi I (fun _ : Fin n ↦ R) x := by

--- a/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Functoriality.lean
@@ -327,6 +327,14 @@ def piEquivFin (n : ℕ) :
     AdicCompletion I (Fin n → R) ≃ₗ[AdicCompletion I R] Fin n → AdicCompletion I R :=
   piEquivOfFintype I (ι := Fin n) (fun _ : Fin n ↦ R)
 
+/-
+#defeq_abuse: tactic fails with `backward.isDefEq.respectTransparency true` but succeeds
+  with `false`.
+The following isDefEq checks are the root causes of the failure:
+  ❌️ Quot.lift (fun x ↦ x • (eval I R n) x2✝) ⋯
+  ((eval I R n) x1✝) =?= Ideal.Quotient.ring._aux_1 (I ^ n • ⊤) (↑x1✝ n) (↑x2✝ n)
+  ❌️ { smul := fun x1 x2 ↦ x1 * x2 } =?= smul I
+-/
 set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem piEquivFin_apply (n : ℕ) (x : AdicCompletion I (Fin n → R)) :


### PR DESCRIPTION
The instances `instSMulOfMul` /`instVAddOfAdd`, `MulZeroClass.toSMulWithZero`, `Monoid.toMulAction` / `AddMonoid.toAddAction`, `MonoidWithZero.toMulActionWithZero` and `Semiring.toModule` are all of the form `F X -> G X X` (so rarely apply) and are essentially always the right choice when they do apply (I know of no counterexample, in fact). They are also all at lowered priority on master, a decision which came from mathlib3 (which had a very different algorithm for typeclass inference). I have raised them to higher priority than default (in fact to 1100) and this causes a speedup of around 20% in several of the slowest files in mathlib (`Mathlib.RingTheory.Etale.QuasiFinite`, `Mathlib.RingTheory.DedekindDomain.Different`, `Mathlib.RingTheory.ZariskisMainTheorem`,...) and a general speedup in far more files.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

