### PR TITLE
[Merged by Bors] - feat(GroupTheory/Rank): nontrivial groups have positive rank

### DIFF
--- a/Mathlib/GroupTheory/Rank.lean
+++ b/Mathlib/GroupTheory/Rank.lean
@@ -41,6 +41,19 @@ lemma rank_spec [h : FG G] : ∃ S : Finset G, S.card = rank G ∧ .closure S = 
 lemma rank_le [h : FG G] {S : Finset G} (hS : .closure S = (⊤ : Subgroup G)) : rank G ≤ S.card :=
   @Nat.find_le _ _ (Classical.decPred _) (fg_iff'.mp h) ⟨S, rfl, hS⟩
 
+variable (G) in
+@[to_additive]
+theorem rank_eq_zero [Subsingleton G] : rank G = 0 := by
+  rw [← le_zero_iff, ← Finset.card_empty]
+  exact rank_le (Subsingleton.elim _ _)
+
+@[to_additive]
+theorem rank_eq_zero_iff [FG G] : rank G = 0 ↔ Subsingleton G := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ rank_eq_zero G⟩
+  obtain ⟨s, hs, hs'⟩ := rank_spec G
+  rw [h, Finset.card_eq_zero] at hs
+  simpa [hs, subsingleton_iff_bot_eq_top] using hs'
+
 @[to_additive]
 lemma rank_le_of_surjective [FG G] [FG H] (f : G →* H) (hf : Surjective f) : rank H ≤ rank G := by
   classical

--- a/Mathlib/GroupTheory/Rank.lean
+++ b/Mathlib/GroupTheory/Rank.lean
@@ -54,6 +54,11 @@ theorem rank_eq_zero_iff [FG G] : rank G = 0 ↔ Subsingleton G := by
   rw [h, Finset.card_eq_zero] at hs
   simpa [hs, subsingleton_iff_bot_eq_top] using hs'
 
+variable (G) in
+@[to_additive]
+theorem rank_pos [Nontrivial G] [FG G] : 0 < rank G := by
+  rwa [pos_iff_ne_zero, ne_eq, rank_eq_zero_iff, not_subsingleton_iff_nontrivial]
+
 @[to_additive]
 lemma rank_le_of_surjective [FG G] [FG H] (f : G →* H) (hf : Surjective f) : rank H ≤ rank G := by
   classical

--- a/Mathlib/GroupTheory/Rank.lean
+++ b/Mathlib/GroupTheory/Rank.lean
@@ -42,7 +42,7 @@ lemma rank_le [h : FG G] {S : Finset G} (hS : .closure S = (⊤ : Subgroup G)) :
   @Nat.find_le _ _ (Classical.decPred _) (fg_iff'.mp h) ⟨S, rfl, hS⟩
 
 variable (G) in
-@[to_additive]
+@[to_additive (attr := nontriviality)]
 theorem rank_eq_zero [Subsingleton G] : rank G = 0 := by
   rw [← le_zero_iff, ← Finset.card_empty]
   exact rank_le (Subsingleton.elim _ _)


### PR DESCRIPTION
This PR proves that nontrivial groups have positive rank.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
