### PR TITLE
chore(AlgebraicTopology/GroupTheory/LinearAlgebra): remove erws

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -430,9 +430,8 @@ def toArrow : Augmented C ⥤ Arrow C where
       right := point.map η
       w := by
         dsimp
-        rw [← NatTrans.comp_app]
-        erw [η.w]
-        rfl }
+        rw [← NatTrans.comp_app, ← Functor.id_map η.left, ← Functor.const_map_app
+          (J := SimplexCategoryᵒᵖ) η.right (op ⦋0⦌), ← NatTrans.comp_app, congr_app η.w (op ⦋0⦌)] }
 
 /-- The compatibility of a morphism with the augmentation, on 0-simplices -/
 @[reassoc]
@@ -458,8 +457,8 @@ def whiskeringObj (D : Type*) [Category* D] (F : C ⥤ D) : Augmented C ⥤ Augm
         ext
         dsimp [whiskerRight]
         simp only [Category.comp_id, ← F.map_comp, ← NatTrans.comp_app]
-        erw [η.w]
-        rfl }
+        rw [← Functor.id_map η.left, ← Functor.const_map_app (J := SimplexCategoryᵒᵖ)
+          η.right _, ← NatTrans.comp_app, η.w] }
 
 /-- Functor composition induces a functor on augmented simplicial objects. -/
 @[simps]
@@ -803,9 +802,8 @@ def toArrow : Augmented C ⥤ Arrow C where
       right := (drop.map η).app _
       w := by
         dsimp
-        rw [← NatTrans.comp_app]
-        erw [← η.w]
-        rfl }
+        rw [← NatTrans.comp_app, ← Functor.const_map_app (J := SimplexCategory) η.left _,
+          ← Functor.id_map η.right, ← NatTrans.comp_app, congr_app η.w ⦋0⦌] }
 
 variable (C)
 
@@ -823,9 +821,9 @@ def whiskeringObj (D : Type*) [Category* D] (F : C ⥤ D) : Augmented C ⥤ Augm
       w := by
         ext
         dsimp
-        rw [Category.id_comp, Category.id_comp, ← F.map_comp, ← F.map_comp, ← NatTrans.comp_app]
-        erw [← η.w]
-        rfl }
+        rw [Category.id_comp, Category.id_comp, ← F.map_comp, ← F.map_comp, ← NatTrans.comp_app,
+          ← Functor.const_map_app (J := SimplexCategory) η.left _, ← Functor.id_map η.right,
+          ← NatTrans.comp_app, ← η.w] }
 
 /-- Functor composition induces a functor on augmented cosimplicial objects. -/
 @[simps]

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -443,13 +443,10 @@ theorem unitsSMul_neg (u : ℤˣ) (w : NormalWord d) :
       apply NormalWord.ext
       · -- This used to `simp [this]` before https://github.com/leanprover/lean4/pull/2644
         dsimp
-        conv_lhs => erw [IsComplement.equiv_mul_left]
-        rw [map_mul, Submonoid.coe_mul, toSubgroupEquiv_neg_apply, this]
+        rw [IsComplement.equiv_mul_left, map_mul, Submonoid.coe_mul, toSubgroupEquiv_neg_apply,
+          this]
         simp
-      · -- The next two lines were not needed before https://github.com/leanprover/lean4/pull/2644
-        dsimp
-        conv_lhs => erw [IsComplement.equiv_mul_left]
-        simp [Units.ext_iff, (d.compl (-u)).equiv_snd_eq_inv_mul, this,
+      · simp [IsComplement.equiv_mul_left,Units.ext_iff, (d.compl (-u)).equiv_snd_eq_inv_mul, this,
           -SetLike.coe_sort_coe]
 
 /-- the equivalence given by multiplication on the left by `t` -/
@@ -660,9 +657,9 @@ theorem exists_normalWord_prod_eq
             (List.head?_eq_some_head _) hS
           rwa [List.head?_eq_some_head hl, Option.map_some, ← this, Option.some_inj] at hx'
         simp at this
-      rw [List.map_cons, mul_smul, of_smul_eq_smul, NormalWord.group_smul_def,
+      rw [List.map_cons, mul_smul, of_smul_eq_smul,
         t_pow_smul_eq_unitsSMul, unitsSMul]
-      erw [dif_neg this]
+      rw [dif_neg this]
       rw [← hw'2]
       simp [mul_assoc, unitsSMulGroup]
 

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -359,9 +359,9 @@ theorem eq_one_of_smul_normalized (w : CoprodI.Word G) {i : ι} (h : H)
         equiv_mul_left_of_mem (d.compl i) ⟨_, rfl⟩, hhead, Subtype.ext_iff,
         Prod.ext_iff] at h
       rcases h with ⟨h₁, h₂⟩
-      rw [h₂, equiv_one (d.compl i) (one_mem _) (d.one_mem _)] at h₁
-      erw [mul_one] at h₁
-      simp only [((injective_iff_map_eq_one' _).1 (d.injective i))] at h₁
+      simp only [h₂, equiv_one (d.compl i) (one_mem _) (d.one_mem _),
+        ← OneMemClass.one_def ((φ i).range), mul_one,
+        (injective_iff_map_eq_one' _).1 (d.injective i)] at h₁
       contradiction
     · rw [Word.equivPair_head]
       dsimp

--- a/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
+++ b/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
@@ -125,7 +125,7 @@ theorem lift_rank_lt_rank_dual' {V : Type v} [AddCommGroup V] [Module K V]
   rw [← b.mk_eq_rank'', rank_dual_eq_card_dual_of_aleph0_le_rank' h,
       ← (b.constr ℕ (M' := K)).toEquiv.cardinal_eq, mk_arrow]
   apply cantor'
-  erw [nat_lt_lift_iff, one_lt_iff_nontrivial]
+  rw [Cardinal.one_lt_lift_iff, Cardinal.one_lt_iff_nontrivial]
   infer_instance
 
 theorem lift_rank_lt_rank_dual {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]

--- a/Mathlib/LinearAlgebra/FreeModule/Norm.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Norm.lean
@@ -44,8 +44,7 @@ theorem associated_norm_prod_smith [Fintype ι] (b : Basis ι R S) {f : S} (hf :
     Finsupp.single_eq_pi_single, Matrix.diagonal_mulVec_single, Pi.single_apply, ite_smul,
     zero_smul, Finset.sum_ite_eq', mul_one, if_pos (Finset.mem_univ _), b'.equiv_apply]
   change _ = f * _
-  rw [mul_comm, ← smul_eq_mul, LinearEquiv.restrictScalars_apply]
-  erw [LinearEquiv.coord_apply_smul]
+  rw [mul_comm, ← smul_eq_mul, LinearEquiv.restrictScalars_apply, LinearEquiv.coord_apply_smul]
   grind [Ideal.selfBasis_def]
 
 end CommRing


### PR DESCRIPTION
- rewrites the augmentation compatibility proofs in `SimplicialObject/Basic` as explicit `rw` chains using `Functor.id_map`, `Functor.const_map_app`, and `NatTrans.comp_app`
- folds the `IsComplement.equiv_mul_left` and `dif_neg` steps in `HNNExtension` into ordinary `rw`/`simp`
- rewrites the normalized-word contradiction in `PushoutI` as a single `simp only` block
- replaces the `erw` in `ErdosKaplansky` with explicit `Cardinal.one_lt_*` rewrites
- folds `LinearEquiv.coord_apply_smul` into the main `rw` chain in `FreeModule/Norm`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)