### PR TITLE
[Merged by Bors] - chore(GroupTheory/HNNExtension): remove an erw

### DIFF
--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -657,11 +657,7 @@ theorem exists_normalWord_prod_eq
             (List.head?_eq_some_head _) hS
           rwa [List.head?_eq_some_head hl, Option.map_some, ← this, Option.some_inj] at hx'
         simp at this
-      rw [List.map_cons, mul_smul, of_smul_eq_smul,
-        t_pow_smul_eq_unitsSMul, unitsSMul]
-      rw [dif_neg this]
-      rw [← hw'2]
-      simp [mul_assoc, unitsSMulGroup]
+      simp [mul_smul, of_smul_eq_smul, t_pow_smul_eq_unitsSMul, unitsSMul, dif_neg this, ← hw'2]
 
 /-- Two reduced words representing the same element of the `HNNExtension G A B φ` have the same
 length corresponding list, with the same pattern of occurrences of `t^1` and `t^(-1)`,

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -443,13 +443,10 @@ theorem unitsSMul_neg (u : ℤˣ) (w : NormalWord d) :
       apply NormalWord.ext
       · -- This used to `simp [this]` before https://github.com/leanprover/lean4/pull/2644
         dsimp
-        conv_lhs => erw [IsComplement.equiv_mul_left]
-        rw [map_mul, Submonoid.coe_mul, toSubgroupEquiv_neg_apply, this]
+        rw [IsComplement.equiv_mul_left, map_mul, Submonoid.coe_mul, toSubgroupEquiv_neg_apply,
+          this]
         simp
-      · -- The next two lines were not needed before https://github.com/leanprover/lean4/pull/2644
-        dsimp
-        conv_lhs => erw [IsComplement.equiv_mul_left]
-        simp [Units.ext_iff, (d.compl (-u)).equiv_snd_eq_inv_mul, this,
+      · simp [IsComplement.equiv_mul_left,Units.ext_iff, (d.compl (-u)).equiv_snd_eq_inv_mul, this,
           -SetLike.coe_sort_coe]
 
 /-- the equivalence given by multiplication on the left by `t` -/
@@ -660,9 +657,9 @@ theorem exists_normalWord_prod_eq
             (List.head?_eq_some_head _) hS
           rwa [List.head?_eq_some_head hl, Option.map_some, ← this, Option.some_inj] at hx'
         simp at this
-      rw [List.map_cons, mul_smul, of_smul_eq_smul, NormalWord.group_smul_def,
+      rw [List.map_cons, mul_smul, of_smul_eq_smul,
         t_pow_smul_eq_unitsSMul, unitsSMul]
-      erw [dif_neg this]
+      rw [dif_neg this]
       rw [← hw'2]
       simp [mul_assoc, unitsSMulGroup]
 

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -440,14 +440,8 @@ theorem unitsSMul_neg (u : ℤˣ) (w : NormalWord d) :
       cases hcan2.2
       have : ((d.compl (-u)).equiv w.head).1 = 1 :=
         (d.compl (-u)).equiv_fst_eq_one_of_mem_of_one_mem _ h1
-      apply NormalWord.ext
-      · -- This used to `simp [this]` before https://github.com/leanprover/lean4/pull/2644
-        dsimp
-        rw [IsComplement.equiv_mul_left, map_mul, Submonoid.coe_mul, toSubgroupEquiv_neg_apply,
-          this]
-        simp
-      · simp [IsComplement.equiv_mul_left,Units.ext_iff, (d.compl (-u)).equiv_snd_eq_inv_mul, this,
-          -SetLike.coe_sort_coe]
+      simpa [NormalWord.ext_iff, (d.compl (-u)).equiv_mul_left, Units.ext_iff,
+        (d.compl (-u)).equiv_snd_eq_inv_mul]
 
 /-- the equivalence given by multiplication on the left by `t` -/
 @[simps]


### PR DESCRIPTION
- rewrites the two `unitsSMul_neg` branches to use `rw` and `simp` directly with `IsComplement.equiv_mul_left`, instead of `conv_lhs => erw [...]`
- replaces `erw [dif_neg this]` with `rw [dif_neg this]` in `exists_normalWord_prod_eq`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)