### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Dimension/ErdosKaplansky): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
+++ b/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
@@ -125,7 +125,7 @@ theorem lift_rank_lt_rank_dual' {V : Type v} [AddCommGroup V] [Module K V]
   rw [← b.mk_eq_rank'', rank_dual_eq_card_dual_of_aleph0_le_rank' h,
       ← (b.constr ℕ (M' := K)).toEquiv.cardinal_eq, mk_arrow]
   apply cantor'
-  rw [Cardinal.one_lt_lift_iff, Cardinal.one_lt_iff_nontrivial]
+  rw [one_lt_lift_iff, one_lt_iff_nontrivial]
   infer_instance
 
 theorem lift_rank_lt_rank_dual {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]

--- a/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
+++ b/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
@@ -125,7 +125,7 @@ theorem lift_rank_lt_rank_dual' {V : Type v} [AddCommGroup V] [Module K V]
   rw [← b.mk_eq_rank'', rank_dual_eq_card_dual_of_aleph0_le_rank' h,
       ← (b.constr ℕ (M' := K)).toEquiv.cardinal_eq, mk_arrow]
   apply cantor'
-  erw [nat_lt_lift_iff, one_lt_iff_nontrivial]
+  rw [Cardinal.one_lt_lift_iff, Cardinal.one_lt_iff_nontrivial]
   infer_instance
 
 theorem lift_rank_lt_rank_dual {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]


### PR DESCRIPTION
- replaces `erw [nat_lt_lift_iff, one_lt_iff_nontrivial]` with `rw [Cardinal.one_lt_lift_iff, Cardinal.one_lt_iff_nontrivial]` in `lift_rank_lt_rank_dual'`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)