### PR TITLE
feat(Tactic): simproc for `Eq.rec`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7255,6 +7255,7 @@ public import Mathlib.Tactic.Set
 public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SimpIntro
 public import Mathlib.Tactic.SimpRw
+public import Mathlib.Tactic.Simproc.CastData
 public import Mathlib.Tactic.Simproc.Divisors
 public import Mathlib.Tactic.Simproc.ExistsAndEq
 public import Mathlib.Tactic.Simproc.Factors

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -486,7 +486,7 @@ noncomputable def shrinkFunctorHomEquiv [LocallySmall.{w} C] {F : Cᵒᵖ ⥤ Ty
     ext
     dsimp
     rw! [Equiv.apply_symm_apply]
-    simp
+    rfl
 
 @[deprecated "In terms of `Sieve.shrinkFunctor`" (since := "2026-03-13")]
 alias natTransEquivCompatibleFamily := shrinkFunctorHomEquiv

--- a/Mathlib/CategoryTheory/WithTerminal/Basic.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Basic.lean
@@ -466,7 +466,7 @@ def widePullbackShapeEquiv {J : Type*} : WidePullbackShape J ≌ WithTerminal (D
   inverse.obj := widePullbackShapeEquivObj.symm
   inverse.map f := (widePullbackShapeEquivMap _ _).symm (eqToHom (by simp) ≫ f ≫ eqToHom (by simp))
   unitIso := NatIso.ofComponents fun x ↦ eqToIso (by aesop)
-  counitIso := NatIso.ofComponents fun x ↦ eqToIso (by aesop)
+  counitIso := NatIso.ofComponents fun x ↦ eqToIso (by grind)
 
 end WithTerminal
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk/Basic.lean
@@ -84,7 +84,7 @@ theorem exists_eq_cons_of_ne {u v : V} (hne : u ≠ v) :
   | cons h p' => ⟨_, h, p', rfl⟩
 
 /-- The length of a walk is the number of edges/darts along it. -/
-def length {u v : V} : G.Walk u v → ℕ
+@[cast_data] def length {u v : V} : G.Walk u v → ℕ
   | nil => 0
   | cons _ q => q.length.succ
 
@@ -113,18 +113,18 @@ lemma exists_length_eq_one_iff {u v : V} : (∃ (p : G.Walk u v), p.length = 1) 
 theorem length_eq_zero_iff {u : V} {p : G.Walk u u} : p.length = 0 ↔ p = nil := by cases p <;> simp
 
 /-- The `support` of a walk is the list of vertices it visits in order. -/
-def support {u v : V} : G.Walk u v → List V
+@[cast_data] def support {u v : V} : G.Walk u v → List V
   | nil => [u]
   | cons _ p => u :: p.support
 
 /-- The `darts` of a walk is the list of darts it visits in order. -/
-def darts {u v : V} : G.Walk u v → List G.Dart
+@[cast_data] def darts {u v : V} : G.Walk u v → List G.Dart
   | nil => []
   | cons h p => ⟨(u, _), h⟩ :: p.darts
 
 /-- The `edges` of a walk is the list of edges it visits in order.
 This is defined to be the list of edges underlying `SimpleGraph.Walk.darts`. -/
-def edges {u v : V} (p : G.Walk u v) : List (Sym2 V) := p.darts.map Dart.edge
+@[cast_data] def edges {u v : V} (p : G.Walk u v) : List (Sym2 V) := p.darts.map Dart.edge
 
 @[simp]
 theorem support_nil {u : V} : (nil : G.Walk u u).support = [u] := rfl

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -174,8 +174,6 @@ run_cmd Lean.Elab.Command.liftTermElabM do
   Lean.Meta.registerCoercion ``DFunLike.coe
     (some { numArgs := 5, coercee := 4, type := .coeFun })
 
-attribute [cast_data] DFunLike.coe
-
 theorem coe_eq_coe_fn : (DFunLike.coe (F := F)) = (fun f => ↑f) := rfl
 
 theorem coe_injective : Function.Injective (fun f : F ↦ (f : ∀ a : α, β a)) :=

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -11,6 +11,7 @@ public import Mathlib.Logic.Unique
 public import Mathlib.Util.CompileInductive
 public import Mathlib.Tactic.Simps.NotationClass
 public import Mathlib.Tactic.SplitIfs
+public import Mathlib.Tactic.Simproc.CastData
 
 /-!
 # Typeclass for a type `F` with an injective map to `A → B`
@@ -172,6 +173,8 @@ instance (priority := 100) hasCoeToFun : CoeFun F (fun _ ↦ ∀ a : α, β a) w
 run_cmd Lean.Elab.Command.liftTermElabM do
   Lean.Meta.registerCoercion ``DFunLike.coe
     (some { numArgs := 5, coercee := 4, type := .coeFun })
+
+attribute [cast_data] DFunLike.coe
 
 theorem coe_eq_coe_fn : (DFunLike.coe (F := F)) = (fun f => ↑f) := rfl
 

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -109,7 +109,7 @@ class SetLike (A : Type*) (B : outParam Type*) where
   /-- The coercion from a term of a `SetLike` to its corresponding `Set` is injective. -/
   protected coe_injective' : Function.Injective coe
 
-attribute [coe] SetLike.coe
+attribute [coe, cast_data] SetLike.coe
 
 namespace SetLike
 

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Logic.Function.Basic
 public import Mathlib.Tactic.AdaptationNote
 public import Mathlib.Tactic.Simps.Basic
+public import Mathlib.Tactic.Simproc.CastData
 
 /-!
 # Subtypes
@@ -53,6 +54,7 @@ protected theorem forall' {q : ∀ x, p x → Prop} : (∀ x h, q x h) ↔ ∀ x
 protected theorem exists' {q : ∀ x, p x → Prop} : (∃ x h, q x h) ↔ ∃ x : { a // p a }, q x x.2 :=
   (@Subtype.exists _ _ fun x ↦ q x.1 x.2).symm
 
+@[simp]
 theorem heq_iff_coe_eq (h : ∀ x, p x ↔ q x) {a1 : { x // p x }} {a2 : { x // q x }} :
     a1 ≍ a2 ↔ (a1 : α) = (a2 : α) :=
   Eq.rec

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -280,6 +280,7 @@ public import Mathlib.Tactic.Set
 public import Mathlib.Tactic.SetLike
 public import Mathlib.Tactic.SimpIntro
 public import Mathlib.Tactic.SimpRw
+public import Mathlib.Tactic.Simproc.CastData
 public import Mathlib.Tactic.Simproc.Divisors
 public import Mathlib.Tactic.Simproc.ExistsAndEq
 public import Mathlib.Tactic.Simproc.Factors

--- a/Mathlib/Tactic/Simproc/CastData.lean
+++ b/Mathlib/Tactic/Simproc/CastData.lean
@@ -91,16 +91,20 @@ simproc castData (_) := fun e => do
   let .lam _ _ (.lam _ _ body _) _ := motive | return .continue
   if body.hasLooseBVar 0 then return .continue
   let β := Expr.lam `i ι (body.lowerLooseBVars 1 1) .default
-  -- Build `f : (i : ι) → β i → γ` by abstracting `b` in the earlier args of `e`.
+  -- Build the proof speculatively: if the tagged constant is not actually invariant under
+  -- `Eq.rec`, the kernel will reject `congr_eqRec` and `mkAppM` throws. We catch the failure
+  -- so the simproc degrades to `.continue` instead of erroring out of `simp`.
   let earlyArgs := args.pop
-  let earlyArgsKab ← earlyArgs.mapM (kabstract · b)
-  let f ← withTransparency .all <| withLocalDeclD `i ι fun iVar => do
-    let earlyArgsAtI := earlyArgsKab.map (·.instantiate1 iVar)
-    withLocalDeclD `z (β.beta #[iVar]) fun zVar => do
-      mkLambdaFVars #[iVar, zVar] <| mkAppN head (earlyArgsAtI.push zVar)
-  -- Apply `congr_eqRec` to produce the rewrite proof: `f b (Eq.rec x h) = f a x`.
-  let proof ← withTransparency .all <| mkAppM ``congr_eqRec #[f, h, x]
-  let earlyArgsAtA := earlyArgsKab.map (·.instantiate1 a)
-  return .visit { expr := mkAppN head (earlyArgsAtA.push x), proof? := some proof }
+  try
+    let earlyArgsKab ← earlyArgs.mapM (kabstract · b)
+    let f ← withTransparency .all <| withLocalDeclD `i ι fun iVar => do
+      let earlyArgsAtI := earlyArgsKab.map (·.instantiate1 iVar)
+      withLocalDeclD `z (β.beta #[iVar]) fun zVar => do
+        mkLambdaFVars #[iVar, zVar] <| mkAppN head (earlyArgsAtI.push zVar)
+    let proof ← withTransparency .all <| mkAppM ``congr_eqRec #[f, h, x]
+    let earlyArgsAtA := earlyArgsKab.map (·.instantiate1 a)
+    return .visit { expr := mkAppN head (earlyArgsAtA.push x), proof? := some proof }
+  catch _ =>
+    return .continue
 
 end

--- a/Mathlib/Tactic/Simproc/CastData.lean
+++ b/Mathlib/Tactic/Simproc/CastData.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Jun Kwon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jun Kwon
+-/
+module
+
+public import Mathlib.Init
+public import Lean.Meta.Tactic.Simp
+public import Batteries.Logic
+
+/-!
+# `@[cast_data]` attribute and simproc for data projections through `Eq.rec`
+
+This module defines the `@[cast_data]` attribute and a registered simproc that simplifies
+expressions of the form `f ... (h ▸ x)` to `f ... x` for any constant `f` whose value is
+independent of indices that may change under `Eq.rec`. Common examples include `Subtype.val`
+and projection-style functions on indexed inductive types such as `GraphLike.Walk.edges`.
+
+## Usage
+
+```
+attribute [cast_data] Subtype.val Walk.edges Walk.darts
+```
+
+After registration, ordinary `simp` will rewrite `(h ▸ x).val ↦ x.val` and similar through any
+number of nested `Eq.rec` transports.
+
+## Implementation
+
+The rewrite is justified by the universal lemma `congr_eqRec` from Batteries, which has the
+shape `f x' (Eq.rec y h) = f x y`. The simproc reconstructs the per-index family `f` from the
+original expression by `kabstract`ing the changed index in the earlier arguments of the
+projection. Soundness is enforced by the kernel: if a tagged constant is not actually invariant
+under transport, the generated proof fails to typecheck and the simproc silently aborts.
+
+The simproc only inspects the final argument of the projection, peeling one `Eq.rec` per
+invocation. Nested transports (such as `hv ▸ hu ▸ p`) are handled by repeated `simp` passes.
+-/
+
+public meta section
+
+open Lean Meta Simp
+
+namespace Mathlib.Tactic.CastData
+
+/-- Environment extension storing names of constants registered as `cast_data` projections. -/
+initialize castDataExt : SimpleScopedEnvExtension Name NameSet ←
+  registerSimpleScopedEnvExtension {
+    initial := NameSet.insert {`Subtype.val} `Fin.val
+    addEntry := fun s n => s.insert n
+  }
+
+/-- Returns `true` iff `n` is registered as a `cast_data` projection. -/
+def isCastData (n : Name) : CoreM Bool :=
+  return (castDataExt.getState (← getEnv)).contains n
+
+/-- The `@[cast_data]` attribute marks a constant `f` as a "data projection" that is invariant
+under `Eq.rec` transport of its final argument. The associated simproc then rewrites
+`f ... (h ▸ x)` to `f ... x` whenever `f` is registered.
+
+Soundness is enforced by the kernel via `congr_eqRec`: if `f`'s output actually depends on the
+casted index, the generated proof will fail to typecheck and the simproc aborts. -/
+syntax (name := castDataAttr) "cast_data" : attr
+
+initialize registerBuiltinAttribute {
+  name := `castDataAttr
+  descr := "register a constant as a data projection invariant under Eq.rec"
+  add := fun declName _ kind => MetaM.run' do
+    castDataExt.add declName kind
+}
+
+end Mathlib.Tactic.CastData
+
+open Mathlib.Tactic.CastData
+
+/-- Simproc that rewrites `f ... (h ▸ x) ↦ f ... x` for any constant `f` registered via
+`@[cast_data]`. Uses the universal `congr_eqRec` as the underlying lemma. -/
+simproc castData (_) := fun e => do
+  let head := e.getAppFn
+  let .const dataName _ := head | return .continue
+  unless ← isCastData dataName do return .continue
+  let args := e.getAppArgs
+  if args.isEmpty then return .continue
+  let castArg ← withTransparency .all <| whnf args[args.size - 1]!
+  unless castArg.isAppOfArity ``Eq.rec 6 do return .continue
+  let #[ι, a, motive, x, b, h] := castArg.getAppArgs | return .continue
+  -- Recover `β : ι → Sort _` from `motive : (i : ι) → a = i → Sort _`,
+  -- assuming `motive`'s body does not depend on the equality binder. This is the standard form
+  -- elaborated by `▸` for index transport.
+  let .lam _ _ (.lam _ _ body _) _ := motive | return .continue
+  if body.hasLooseBVar 0 then return .continue
+  let β := Expr.lam `i ι (body.lowerLooseBVars 1 1) .default
+  -- Build `f : (i : ι) → β i → γ` by abstracting `b` in the earlier args of `e`.
+  let earlyArgs := args.pop
+  let earlyArgsKab ← earlyArgs.mapM (kabstract · b)
+  let f ← withTransparency .all <| withLocalDeclD `i ι fun iVar => do
+    let earlyArgsAtI := earlyArgsKab.map (·.instantiate1 iVar)
+    withLocalDeclD `z (β.beta #[iVar]) fun zVar => do
+      mkLambdaFVars #[iVar, zVar] <| mkAppN head (earlyArgsAtI.push zVar)
+  -- Apply `congr_eqRec` to produce the rewrite proof: `f b (Eq.rec x h) = f a x`.
+  let proof ← withTransparency .all <| mkAppM ``congr_eqRec #[f, h, x]
+  let earlyArgsAtA := earlyArgsKab.map (·.instantiate1 a)
+  return .visit { expr := mkAppN head (earlyArgsAtA.push x), proof? := some proof }
+
+end

--- a/Mathlib/Tactic/Simproc/CastData.lean
+++ b/Mathlib/Tactic/Simproc/CastData.lean
@@ -15,7 +15,7 @@ public import Batteries.Logic
 This module defines the `@[cast_data]` attribute and a registered simproc that simplifies
 expressions of the form `f ... (h ▸ x)` to `f ... x` for any constant `f` whose value is
 independent of indices that may change under `Eq.rec`. Common examples include `Subtype.val`
-and projection-style functions on indexed inductive types such as `GraphLike.Walk.edges`.
+and projection-style functions on indexed inductive types such as `SimpleGraph.Walk.edges`.
 
 ## Usage
 


### PR DESCRIPTION
Note: This PR was written with a lot of help from AI (Opus 4.7). I am still learning Lean meta programming. I would very much welcome any feedback.

Problem: There are a lot of `cast` like functions for various definitions in Mathlib: [`Fin.cast`](https://leanprover-community.github.io/mathlib4_docs/Init/Data/Fin/Basic.html#Fin.cast), [`List.Vector.congr`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Vector/Defs.html#List.Vector.congr), [`SimpleGraph.Walk.copy`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/SimpleGraph/Walk/Operations.html#SimpleGraph.Walk.copy), [`Path.cast`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Path.html#Path.cast), [`Sym.cast`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Sym/Basic.html#Sym.cast), [`Partition.copy`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Partition/Basic.html#Partition.copy), [`Finpartition.copy`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Partition/Finpartition.html#Finpartition.copy) & etc. All of these functions does the same as `h ▸ a` where `h` is a proof of equality of something in the type of `a`. I think this is caused because proving the properties about `h ▸ a` is too difficult without extra tooling.

All of the above follows the pattern where it is an indexed type where it contains
* some data
* proof that the data is related to the index 

and casting only changes the second part. The trouble happens when I would like to talk about the data of the casted object. There is `congr_eqRec` lemma in Battery that are exactly for this situation but even after adding `simp` tag to it, it is not being used. [Here](https://live.lean-lang.org/#codez=JYWwDg9gTgLgBAWQIYwBYBtgCMBQeCmAHkuOvnAN6CNwHAFxwAqAnmPgFQC%2BlYdcNgSYR84ggApQIYLhSRwsvKlwAUhXgGUArlhgtyinkgCUBuItS8ZAXlnH6puIA7SOIQMA6AG5J0cK4Xee6VlhMcDhwcADOoDwA2gDGEAB2AOZQAPr4AI4ASvixALoExKTkFAlwILyAqIRKPPQAYsBlimUA1HAAjEYmZvRlViA23Q5wYK4eXlZgfl60gcGhEVFwcYkp6dm5BThEJGBklABqvMysnJQA4mpRZOdQSGBmB1LqcG5wAO68TyYA6rznLh%2BngA1nAXm5jHZ6C8rO9BnZHD9XPgACZJfDhbxwH4uVHozGzWTzMKRcDLeLJNKZHL5BYAWjpcCg%2BAAZo1yBS1tTcnAAPypOBmH6FXb7ajHHRnCiY%2BD0VT4eAKEwiXgiJCwYAwYCJCKQnoRLEweEIuAq%2BhqjVanVGtQKkzyxVdKxmuYhElRXnk1ZUjb5N1wBlM1nsuCcn00vkCswiPA4IA), all of these simp tactics fail. 

Solution: This PR introduces a simproc `castData` (I would welcome a name suggestion) and attribute `cast_data`. When it sees `f ... (h ▸ x)` where `f` is tagged with `cast_data`, `castData` will try to simplify to `f ... x`. This simproc proves all 4 examples linked above. Hopefully this removes the need for all the `cast`-like definition and their APIs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
