### PR TITLE
[Merged by Bors] - feat: Cartan's criterion for semisimplicity

### DIFF
--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -223,9 +223,9 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
     apply LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L) (x := ⟨x, hx⟩)
-    exact (isNilpotent_iff_forall' (R := K)).mp module_nilp
-      ⟨⟨x, LieSubmodule.lie_le_left DI DI hx⟩, by
-        rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]; exact hx⟩
+    refine (isNilpotent_iff_forall' (R := K)).mp module_nilp
+      ⟨⟨x, LieSubmodule.lie_le_left DI DI hx⟩, ?_⟩
+    rwa [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [derivedSeries_eq_bot_iff] at hk
   refine .mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -40,7 +40,7 @@ via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 
 ## TODO
 
-* The converse direction of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`, i.e.
+* Add the converse direction of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`, i.e.
   `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Together with the
   sufficient direction it would give the iff form of Cartan's criterion for solvability.
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -230,10 +230,8 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
   have ddi_nilpotent : LieRing.IsNilpotent DDI := by
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
-    have ad_eq : ad K DDI ⟨x, hx⟩ = (ad K L x).restrict (fun _ hy ↦ DDI.lie_mem hy) := by
-      ext ⟨_, _⟩; rfl
-    rw [ad_eq]
-    exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
+    exact LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L)
+      (x := ⟨x, hx⟩) (ad_nil x hx)
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [derivedSeries_eq_bot_iff] at hk
   refine .mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -28,20 +28,21 @@ criterion.
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
   as a `⁅L, L⁆`-module.
-* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**
-  (sufficient direction). For an ideal `I` of a finite-dimensional Lie algebra `L` over a field
-  of characteristic zero, if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is
-  solvable.
+* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**.
+  For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
+  if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
 * `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
   Lie algebra over a field of characteristic zero is contained in the solvable radical.
-* `LieAlgebra.HasTrivialRadical.instIsKilling`: **Cartan's criterion for semisimplicity**
-  (sufficient direction). A finite-dimensional Lie algebra over a field of characteristic zero
-  with trivial radical has non-degenerate Killing form.
+* `LieAlgebra.HasTrivialRadical.instIsKilling`: converse of
+  `LieAlgebra.IsKilling.instHasTrivialRadical` in the finite-dimensional, characteristic-zero
+  setting. Together they give the iff `HasTrivialRadical ↔ IsKilling`, which is
+  **Cartan's criterion for semisimplicity**.
 
 ## TODO
 
-* The **necessary direction of Cartan's criterion for solvability**:
-  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`.
+* The converse direction of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`, i.e.
+  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Together with the
+  sufficient direction it gives the iff form of Cartan's criterion for solvability.
 
 ## References
 
@@ -204,9 +205,10 @@ open LieAlgebra LieModule LinearMap Module
 variable {K L : Type*} [Field K] [CharZero K]
   [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
-/-- **Cartan's criterion for solvability** (sufficient direction, ideal version).
+/-- **Cartan's criterion for solvability** (ideal version).
 For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
-if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. -/
+if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
+The converse is left as a TODO; together they give the iff form. -/
 public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     (I : LieIdeal K L)
     (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0) :
@@ -259,10 +261,11 @@ public lemma killingCompl_top_le_radical :
   rw [LieModule.traceForm_comm]
   exact (LieIdeal.mem_killingCompl K L ⊤).mp hx y (LieSubmodule.mem_top y)
 
-/-- **Cartan's criterion for semisimplicity** (sufficient direction): in characteristic zero,
-a finite-dimensional Lie algebra with trivial radical has non-degenerate Killing form.
-The converse `IsKilling → HasTrivialRadical` is also true, it is
-`LieAlgebra.IsKilling.instHasTrivialRadical`. -/
+/-- A finite-dimensional Lie algebra over a field of characteristic zero with trivial radical
+has non-degenerate Killing form. This is the converse of
+`LieAlgebra.IsKilling.instHasTrivialRadical` in the finite-dimensional, characteristic-zero
+setting; together they give the iff `HasTrivialRadical ↔ IsKilling`, which is
+**Cartan's criterion for semisimplicity**. -/
 public instance HasTrivialRadical.instIsKilling [HasTrivialRadical K L] : IsKilling K L where
   killingCompl_top_eq_bot := by
     have h := killingCompl_top_le_radical K L

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -247,8 +247,7 @@ end LieIdeal
 
 namespace LieAlgebra
 
-variable (K L : Type*) [Field K] [CharZero K]
-  [LieRing L] [LieAlgebra K L] [Module.Finite K L]
+variable (K L : Type*) [Field K] [CharZero K] [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
 /-- The kernel of the Killing form of a finite-dimensional Lie algebra over a field of
 characteristic zero is contained in the solvable radical. -/

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -27,30 +27,18 @@ criterion.
 
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
-  as a `⁅L, L⁆`-module. This is the technical engine behind both Cartan criteria below.
+  as a `⁅L, L⁆`-module.
 * `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**
-  (sufficient direction, ideal version). For an ideal `I` of a finite-dimensional Lie algebra `L`
-  over a field of characteristic zero: if the Killing form of `L` vanishes on `I × ⁅I, I⁆`,
-  then `I` is solvable. Specialising to `I = ⊤` recovers the classical Cartan iff for `L`
-  itself; specialising to `I = LieIdeal.killingCompl K L ⊤` yields `killingCompl_top_le_radical`.
+  Desc here
 * `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
   Lie algebra over a field of characteristic zero is contained in the solvable radical.
 * `LieAlgebra.HasTrivialRadical.instIsKilling`: **Cartan's criterion for semisimplicity**
-  (sufficient direction). A finite-dimensional Lie algebra with trivial radical, over a field
-  of characteristic zero, has non-degenerate Killing form. The converse is already in Mathlib
-  as `LieAlgebra.IsKilling.instHasTrivialRadical`, so combining the two gives the iff statement
-  `HasTrivialRadical ↔ IsKilling` in this setting.
+  Desc here
 
 ## TODO
 
 * The **necessary direction of Cartan's criterion for solvability**:
-  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Standard proofs go via
-  Lie's theorem in upper-triangularization form (basis in which `ad I` is upper-triangular,
-  hence `ad ⁅I,I⁆` is strictly upper-triangular, hence `Tr(ad x ∘ ad y) = 0`). At the time of
-  writing Mathlib only has Lie's theorem in common-eigenvector form (see
-  `LieModule.exists_nontrivial_weightSpace_of_isSolvable` in `Mathlib.Algebra.Lie.LieTheorem`);
-  building the upper-triangularization corollary is an independent piece of work.
-* The combined iff `LieIdeal.isSolvable_iff_killingForm_apply_lie_eq_zero`.
+  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Desc here.
 
 ## References
 
@@ -215,14 +203,7 @@ variable {K L : Type*} [Field K] [CharZero K]
 
 /-- **Cartan's criterion for solvability** (sufficient direction, ideal version).
 For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
-if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
-
-The proof applies the trace-nilpotency engine
-`LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero` to `⁅I, I⁆` acting on `L` (the
-hypothesis on `I × ⁅I, I⁆` restricts to vanishing on `⁅I, I⁆ × ⁅I, I⁆`, which is what the
-engine consumes). The conclusion gives `⁅⁅I, I⁆, ⁅I, I⁆⁆` acting nilpotently on `L`; Engel's
-theorem then upgrades this to nilpotency, hence solvability, of `⁅⁅I, I⁆, ⁅I, I⁆⁆`, and two
-derived-series layers climb back to `I`. -/
+if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. -/
 public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     (I : LieIdeal K L)
     (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0) :
@@ -266,10 +247,7 @@ variable (K L : Type*) [Field K] [CharZero K]
   [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
 /-- The kernel of the Killing form of a finite-dimensional Lie algebra over a field of
-characteristic zero is contained in the solvable radical.
-
-Direct corollary of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero` applied to
-`I = LieIdeal.killingCompl K L ⊤`. -/
+characteristic zero is contained in the solvable radical. -/
 public lemma killingCompl_top_le_radical :
     LieIdeal.killingCompl K L ⊤ ≤ radical K L := by
   rw [← LieIdeal.solvable_iff_le_radical]
@@ -280,10 +258,8 @@ public lemma killingCompl_top_le_radical :
 
 /-- **Cartan's criterion for semisimplicity** (sufficient direction): in characteristic zero,
 a finite-dimensional Lie algebra with trivial radical has non-degenerate Killing form.
-
-The converse `IsKilling → HasTrivialRadical` is `LieAlgebra.IsKilling.instHasTrivialRadical`,
-so combined they give `HasTrivialRadical ↔ IsKilling` for finite-dimensional Lie algebras
-over fields of characteristic zero. -/
+The converse `IsKilling → HasTrivialRadical` is also true, it is
+`LieAlgebra.IsKilling.instHasTrivialRadical`. -/
 public instance HasTrivialRadical.instIsKilling [HasTrivialRadical K L] : IsKilling K L where
   killingCompl_top_eq_bot := by
     have h := killingCompl_top_le_radical K L

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -37,7 +37,7 @@ via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 * `LieAlgebra.HasTrivialRadical.instIsKilling`: a finite-dimensional Lie algebra over a field of
   characteristic zero with trivial radical has non-degenerate Killing form. This is one direction
   of **Cartan's criterion for semisimplicity**; the converse is the existing
-  `LieAlgebra.IsKilling.instHasTrivialRadical`.
+  `LieAlgebra.IsKilling.instHasTrivialRadical` (which holds in greater generality, over any PID).
 
 ## TODO
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -42,7 +42,7 @@ via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 
 * The converse direction of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`, i.e.
   `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Together with the
-  sufficient direction it gives the iff form of Cartan's criterion for solvability.
+  sufficient direction it would give the iff form of Cartan's criterion for solvability.
 
 ## References
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.Lie.AdjointAction.JordanChevalley
+public import Mathlib.Algebra.Lie.Engel
+public import Mathlib.Algebra.Lie.Killing
 public import Mathlib.Algebra.Lie.TraceForm
 public import Mathlib.LinearAlgebra.Eigenspace.Matrix
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
@@ -26,11 +28,10 @@ criterion.
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
   as a `⁅L, L⁆`-module.
-
-## TODO
-
-* Add Cartan's criterion for solvability.
-* Add Cartan's criterion for semisimplicity.
+* `LieAlgebra.killingCompl_top_le_radical`: in characteristic zero, the kernel of the Killing form
+  of a finite-dimensional Lie algebra is contained in the solvable radical.
+* `LieAlgebra.HasTrivialRadical.instIsKilling`: in characteristic zero, any finite-dimensional Lie
+  algebra with trivial radical has non-degenerate Killing form.
 
 ## References
 
@@ -185,3 +186,54 @@ public theorem isNilpotent_derivedSeries_of_traceForm_eq_zero (h : traceForm R L
   exact nilp_ext ⟨_, hx_ext⟩
 
 end LieModule
+
+namespace LieAlgebra
+
+open LieModule LinearMap Module
+
+variable (K L : Type*) [Field K] [CharZero K]
+  [LieRing L] [LieAlgebra K L] [Module.Finite K L]
+
+/-- **Cartan's criterion for solvability**: in characteristic zero, the kernel of the Killing form
+of a finite-dimensional Lie algebra is contained in the solvable radical. -/
+public lemma killingCompl_top_le_radical :
+    LieIdeal.killingCompl K L ⊤ ≤ radical K L := by
+  rw [← LieIdeal.solvable_iff_le_radical]
+  set S := LieIdeal.killingCompl K L ⊤
+  set SS : LieIdeal K L := ⁅S, S⁆
+  let ad_lin : L →ₗ[K] End K L := ad K L
+  have hS_tf : LieModule.traceForm K ↥S L = 0 := by
+    ext ⟨x, hxS⟩ ⟨y, hyS⟩
+    change trace K L ((ad K L) x ∘ₗ (ad K L) y) = 0
+    rw [← killingForm_apply_apply, LieModule.traceForm_comm]
+    exact (LieIdeal.mem_killingCompl K L ⊤).mp hxS y (LieSubmodule.mem_top y)
+  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K ↥S 1) L :=
+    LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero hS_tf
+  rw [LieModule.isNilpotent_iff_forall' (R := K)] at key
+  have ad_nil : ∀ x ∈ (SS : LieSubmodule K L L).toSubmodule, IsNilpotent (ad_lin x) := by
+    intro x hx
+    have hxS : x ∈ S := LieSubmodule.lie_le_left S S hx
+    have hxDS : (⟨x, hxS⟩ : ↥S) ∈ LieAlgebra.derivedSeries K ↥S 1 := by
+      rw [LieIdeal.derivedSeries_eq_derivedSeriesOfIdeal_comap, LieIdeal.mem_comap]
+      exact hx
+    exact key ⟨⟨x, hxS⟩, hxDS⟩
+  have ss_nilpotent : LieRing.IsNilpotent ↥SS := by
+    have : IsNoetherian K ↥SS := isNoetherian_submodule' (SS : LieSubmodule K L L).toSubmodule
+    rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
+    rintro ⟨x, hx⟩
+    rw [show ad K ↥SS ⟨x, hx⟩ = (ad_lin x).restrict fun _ hy ↦ SS.lie_mem hy from
+      by ext ⟨_, _⟩; rfl]
+    exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
+  obtain ⟨k, hk⟩ := IsSolvable.solvable K ↥SS
+  rw [LieIdeal.derivedSeries_eq_bot_iff] at hk
+  refine .mk (k := k + 1) ((LieIdeal.derivedSeries_eq_bot_iff S (k + 1)).mpr ?_)
+  rw [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_zero]; exact hk
+
+/-- **Cartan's criterion for semisimplicity**: in characteristic zero, any finite-dimensional Lie
+algebra with trivial radical has non-degenerate Killing form. -/
+public instance HasTrivialRadical.instIsKilling [HasTrivialRadical K L] : IsKilling K L where
+  killingCompl_top_eq_bot := by
+    have h := killingCompl_top_le_radical K L
+    rwa [HasTrivialRadical.radical_eq_bot, le_bot_iff] at h
+
+end LieAlgebra

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -203,8 +203,7 @@ namespace LieIdeal
 
 open LieAlgebra LieModule LinearMap Module
 
-variable {K L : Type*} [Field K] [CharZero K]
-  [LieRing L] [LieAlgebra K L] [Module.Finite K L]
+variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
 /-- For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
 if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. The converse is
@@ -215,29 +214,29 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     IsSolvable I := by
   set DI : LieIdeal K L := ⁅I, I⁆
   set DDI : LieIdeal K L := ⁅DI, DI⁆
-  have h_tf : LieModule.traceForm K ↥DI L = 0 := by
+  have h_tf : LieModule.traceForm K DI L = 0 := by
     ext ⟨x, hx⟩ ⟨y, hy⟩
     change trace K L ((ad K L) x ∘ₗ (ad K L) y) = 0
     rw [← killingForm_apply_apply]
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
-  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K ↥DI 1) L :=
+  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
     LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
   rw [LieModule.isNilpotent_iff_forall' (R := K)] at key
   have ad_nil : ∀ x ∈ (DDI : LieSubmodule K L L).toSubmodule, IsNilpotent (ad K L x) := by
     intro x hx
     have hxDI : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
-    have hxDS : (⟨x, hxDI⟩ : ↥DI) ∈ LieAlgebra.derivedSeries K ↥DI 1 := by
+    have hxDS : (⟨x, hxDI⟩ : DI) ∈ LieAlgebra.derivedSeries K DI 1 := by
       rw [LieIdeal.derivedSeries_eq_derivedSeriesOfIdeal_comap, LieIdeal.mem_comap]
       exact hx
     exact key ⟨⟨x, hxDI⟩, hxDS⟩
-  have ddi_nilpotent : LieRing.IsNilpotent ↥DDI := by
-    have : IsNoetherian K ↥DDI := isNoetherian_submodule' (DDI : LieSubmodule K L L).toSubmodule
+  have ddi_nilpotent : LieRing.IsNilpotent DDI := by
+    have : IsNoetherian K DDI := isNoetherian_submodule' (DDI : LieSubmodule K L L).toSubmodule
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
-    rw [show ad K ↥DDI ⟨x, hx⟩ = (ad K L x).restrict fun _ hy ↦ DDI.lie_mem hy from
+    rw [show ad K DDI ⟨x, hx⟩ = (ad K L x).restrict fun _ hy ↦ DDI.lie_mem hy from
       by ext ⟨_, _⟩; rfl]
     exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
-  obtain ⟨k, hk⟩ := IsSolvable.solvable K ↥DDI
+  obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [LieIdeal.derivedSeries_eq_bot_iff] at hk
   refine .mk (k := k + 2) ((LieIdeal.derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
   rw [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -19,9 +19,9 @@ public import Mathlib.RingTheory.Flat.Localization
 /-!
 # Cartan's criteria
 
-If the trace form of a finite-dimensional representation `M` of a Lie algebra `L` is zero,
-then the `⁅L, L⁆`-module `M` is nilpotent. This is the key technical lemma behind Cartan's
-criterion.
+The two **Cartan criteria** characterise solvability and semisimplicity of finite-dimensional
+Lie algebras over fields of characteristic zero in terms of the Killing form: solvability
+via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 
 ## Main results
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -228,7 +228,7 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     rwa [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [derivedSeries_eq_bot_iff] at hk
-  refine .mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
+  refine IsSolvable.mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
   rwa [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,
     derivedSeriesOfIdeal_zero]
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -27,11 +27,30 @@ criterion.
 
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
-  as a `⁅L, L⁆`-module.
-* `LieAlgebra.killingCompl_top_le_radical`: in characteristic zero, the kernel of the Killing form
-  of a finite-dimensional Lie algebra is contained in the solvable radical.
-* `LieAlgebra.HasTrivialRadical.instIsKilling`: in characteristic zero, any finite-dimensional Lie
-  algebra with trivial radical has non-degenerate Killing form.
+  as a `⁅L, L⁆`-module. This is the technical engine behind both Cartan criteria below.
+* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**
+  (sufficient direction, ideal version). For an ideal `I` of a finite-dimensional Lie algebra `L`
+  over a field of characteristic zero: if the Killing form of `L` vanishes on `I × ⁅I, I⁆`,
+  then `I` is solvable. Specialising to `I = ⊤` recovers the classical Cartan iff for `L`
+  itself; specialising to `I = LieIdeal.killingCompl K L ⊤` yields `killingCompl_top_le_radical`.
+* `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
+  Lie algebra over a field of characteristic zero is contained in the solvable radical.
+* `LieAlgebra.HasTrivialRadical.instIsKilling`: **Cartan's criterion for semisimplicity**
+  (sufficient direction). A finite-dimensional Lie algebra with trivial radical, over a field
+  of characteristic zero, has non-degenerate Killing form. The converse is already in Mathlib
+  as `LieAlgebra.IsKilling.instHasTrivialRadical`, so combining the two gives the iff statement
+  `HasTrivialRadical ↔ IsKilling` in this setting.
+
+## TODO
+
+* The **necessary direction of Cartan's criterion for solvability**:
+  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Standard proofs go via
+  Lie's theorem in upper-triangularization form (basis in which `ad I` is upper-triangular,
+  hence `ad ⁅I,I⁆` is strictly upper-triangular, hence `Tr(ad x ∘ ad y) = 0`). At the time of
+  writing Mathlib only has Lie's theorem in common-eigenvector form (see
+  `LieModule.exists_nontrivial_weightSpace_of_isSolvable` in `Mathlib.Algebra.Lie.LieTheorem`);
+  building the upper-triangularization corollary is an independent piece of work.
+* The combined iff `LieIdeal.isSolvable_iff_killingForm_apply_lie_eq_zero`.
 
 ## References
 
@@ -187,50 +206,84 @@ public theorem isNilpotent_derivedSeries_of_traceForm_eq_zero (h : traceForm R L
 
 end LieModule
 
-namespace LieAlgebra
+namespace LieIdeal
 
-open LieModule LinearMap Module
+open LieAlgebra LieModule LinearMap Module
+
+variable {K L : Type*} [Field K] [CharZero K]
+  [LieRing L] [LieAlgebra K L] [Module.Finite K L]
+
+/-- **Cartan's criterion for solvability** (sufficient direction, ideal version).
+For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
+if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
+
+The proof applies the trace-nilpotency engine
+`LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero` to `⁅I, I⁆` acting on `L` (the
+hypothesis on `I × ⁅I, I⁆` restricts to vanishing on `⁅I, I⁆ × ⁅I, I⁆`, which is what the
+engine consumes). The conclusion gives `⁅⁅I, I⁆, ⁅I, I⁆⁆` acting nilpotently on `L`; Engel's
+theorem then upgrades this to nilpotency, hence solvability, of `⁅⁅I, I⁆, ⁅I, I⁆⁆`, and two
+derived-series layers climb back to `I`. -/
+public theorem isSolvable_of_killingForm_apply_lie_eq_zero
+    (I : LieIdeal K L)
+    (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0) :
+    IsSolvable I := by
+  set DI : LieIdeal K L := ⁅I, I⁆
+  set DDI : LieIdeal K L := ⁅DI, DI⁆
+  have h_tf : LieModule.traceForm K ↥DI L = 0 := by
+    ext ⟨x, hx⟩ ⟨y, hy⟩
+    change trace K L ((ad K L) x ∘ₗ (ad K L) y) = 0
+    rw [← killingForm_apply_apply]
+    exact h x (LieSubmodule.lie_le_left I I hx) y hy
+  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K ↥DI 1) L :=
+    LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
+  rw [LieModule.isNilpotent_iff_forall' (R := K)] at key
+  have ad_nil : ∀ x ∈ (DDI : LieSubmodule K L L).toSubmodule, IsNilpotent (ad K L x) := by
+    intro x hx
+    have hxDI : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
+    have hxDS : (⟨x, hxDI⟩ : ↥DI) ∈ LieAlgebra.derivedSeries K ↥DI 1 := by
+      rw [LieIdeal.derivedSeries_eq_derivedSeriesOfIdeal_comap, LieIdeal.mem_comap]
+      exact hx
+    exact key ⟨⟨x, hxDI⟩, hxDS⟩
+  have ddi_nilpotent : LieRing.IsNilpotent ↥DDI := by
+    have : IsNoetherian K ↥DDI := isNoetherian_submodule' (DDI : LieSubmodule K L L).toSubmodule
+    rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
+    rintro ⟨x, hx⟩
+    rw [show ad K ↥DDI ⟨x, hx⟩ = (ad K L x).restrict fun _ hy ↦ DDI.lie_mem hy from
+      by ext ⟨_, _⟩; rfl]
+    exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
+  obtain ⟨k, hk⟩ := IsSolvable.solvable K ↥DDI
+  rw [LieIdeal.derivedSeries_eq_bot_iff] at hk
+  refine .mk (k := k + 2) ((LieIdeal.derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
+  rw [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,
+    derivedSeriesOfIdeal_zero]
+  exact hk
+
+end LieIdeal
+
+namespace LieAlgebra
 
 variable (K L : Type*) [Field K] [CharZero K]
   [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
-/-- **Cartan's criterion for solvability**: in characteristic zero, the kernel of the Killing form
-of a finite-dimensional Lie algebra is contained in the solvable radical. -/
+/-- The kernel of the Killing form of a finite-dimensional Lie algebra over a field of
+characteristic zero is contained in the solvable radical.
+
+Direct corollary of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero` applied to
+`I = LieIdeal.killingCompl K L ⊤`. -/
 public lemma killingCompl_top_le_radical :
     LieIdeal.killingCompl K L ⊤ ≤ radical K L := by
   rw [← LieIdeal.solvable_iff_le_radical]
-  set S := LieIdeal.killingCompl K L ⊤
-  set SS : LieIdeal K L := ⁅S, S⁆
-  let ad_lin : L →ₗ[K] End K L := ad K L
-  have hS_tf : LieModule.traceForm K ↥S L = 0 := by
-    ext ⟨x, hxS⟩ ⟨y, hyS⟩
-    change trace K L ((ad K L) x ∘ₗ (ad K L) y) = 0
-    rw [← killingForm_apply_apply, LieModule.traceForm_comm]
-    exact (LieIdeal.mem_killingCompl K L ⊤).mp hxS y (LieSubmodule.mem_top y)
-  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K ↥S 1) L :=
-    LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero hS_tf
-  rw [LieModule.isNilpotent_iff_forall' (R := K)] at key
-  have ad_nil : ∀ x ∈ (SS : LieSubmodule K L L).toSubmodule, IsNilpotent (ad_lin x) := by
-    intro x hx
-    have hxS : x ∈ S := LieSubmodule.lie_le_left S S hx
-    have hxDS : (⟨x, hxS⟩ : ↥S) ∈ LieAlgebra.derivedSeries K ↥S 1 := by
-      rw [LieIdeal.derivedSeries_eq_derivedSeriesOfIdeal_comap, LieIdeal.mem_comap]
-      exact hx
-    exact key ⟨⟨x, hxS⟩, hxDS⟩
-  have ss_nilpotent : LieRing.IsNilpotent ↥SS := by
-    have : IsNoetherian K ↥SS := isNoetherian_submodule' (SS : LieSubmodule K L L).toSubmodule
-    rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
-    rintro ⟨x, hx⟩
-    rw [show ad K ↥SS ⟨x, hx⟩ = (ad_lin x).restrict fun _ hy ↦ SS.lie_mem hy from
-      by ext ⟨_, _⟩; rfl]
-    exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
-  obtain ⟨k, hk⟩ := IsSolvable.solvable K ↥SS
-  rw [LieIdeal.derivedSeries_eq_bot_iff] at hk
-  refine .mk (k := k + 1) ((LieIdeal.derivedSeries_eq_bot_iff S (k + 1)).mpr ?_)
-  rw [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_zero]; exact hk
+  refine LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero _ ?_
+  intro x hx y _
+  rw [LieModule.traceForm_comm]
+  exact (LieIdeal.mem_killingCompl K L ⊤).mp hx y (LieSubmodule.mem_top y)
 
-/-- **Cartan's criterion for semisimplicity**: in characteristic zero, any finite-dimensional Lie
-algebra with trivial radical has non-degenerate Killing form. -/
+/-- **Cartan's criterion for semisimplicity** (sufficient direction): in characteristic zero,
+a finite-dimensional Lie algebra with trivial radical has non-degenerate Killing form.
+
+The converse `IsKilling → HasTrivialRadical` is `LieAlgebra.IsKilling.instHasTrivialRadical`,
+so combined they give `HasTrivialRadical ↔ IsKilling` for finite-dimensional Lie algebras
+over fields of characteristic zero. -/
 public instance HasTrivialRadical.instIsKilling [HasTrivialRadical K L] : IsKilling K L where
   killingCompl_top_eq_bot := by
     have h := killingCompl_top_le_radical K L

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.Lie.AdjointAction.JordanChevalley
-public import Mathlib.Algebra.Lie.Engel
 public import Mathlib.Algebra.Lie.Killing
 public import Mathlib.Algebra.Lie.TraceForm
 public import Mathlib.LinearAlgebra.Eigenspace.Matrix
@@ -220,13 +219,13 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     rw [← killingForm_apply_apply]
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
   have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
-    LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
-  rw [LieModule.isNilpotent_iff_forall' (R := K)] at key
+    isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
+  rw [isNilpotent_iff_forall' (R := K)] at key
   have ad_nil : ∀ x ∈ (DDI : LieSubmodule K L L).toSubmodule, IsNilpotent (ad K L x) := by
     intro x hx
     have hxDI : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
-    have hxDS : (⟨x, hxDI⟩ : DI) ∈ LieAlgebra.derivedSeries K DI 1 := by
-      rw [LieIdeal.derivedSeries_eq_derivedSeriesOfIdeal_comap, LieIdeal.mem_comap]
+    have hxDS : (⟨x, hxDI⟩ : DI) ∈ derivedSeries K DI 1 := by
+      rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
       exact hx
     exact key ⟨⟨x, hxDI⟩, hxDS⟩
   have ddi_nilpotent : LieRing.IsNilpotent DDI := by
@@ -237,11 +236,10 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
       by ext ⟨_, _⟩; rfl]
     exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
-  rw [LieIdeal.derivedSeries_eq_bot_iff] at hk
-  refine .mk (k := k + 2) ((LieIdeal.derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
-  rw [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,
+  rw [derivedSeries_eq_bot_iff] at hk
+  refine .mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
+  rwa [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,
     derivedSeriesOfIdeal_zero]
-  exact hk
 
 end LieIdeal
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -206,10 +206,9 @@ open LieAlgebra LieModule LinearMap Module
 variable {K L : Type*} [Field K] [CharZero K]
   [LieRing L] [LieAlgebra K L] [Module.Finite K L]
 
-/-- **Cartan's criterion for solvability** (ideal version).
-For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
-if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
-The converse is left as a TODO; together they give the iff form. -/
+/-- For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
+if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. The converse is
+left as a TODO; together they give the iff form of **Cartan's criterion for solvability**. -/
 public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     (I : LieIdeal K L)
     (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0) :

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -27,22 +27,18 @@ via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
   as a `⁅L, L⁆`-module.
-* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: for an ideal `I` of a
-  finite-dimensional Lie algebra `L` over a field of characteristic zero, if the Killing form
-  of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. This is one direction of
-  **Cartan's criterion for solvability**; the converse is left as a TODO.
-* `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
-  Lie algebra over a field of characteristic zero is contained in the solvable radical.
-* `LieAlgebra.HasTrivialRadical.instIsKilling`: a finite-dimensional Lie algebra over a field of
-  characteristic zero with trivial radical has non-degenerate Killing form. This is one direction
-  of **Cartan's criterion for semisimplicity**; the converse is the existing
-  `LieAlgebra.IsKilling.instHasTrivialRadical` (which holds in greater generality, over any PID).
+* `LieAlgebra.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**:
+  if the Killing form of a Lie algebra `L` vanishes on `L × ⁅L, L⁆`, then `L` is solvable.
+* `LieAlgebra.killingCompl_top_le_radical`: the Killing radical of a finite-dimensional Lie algebra
+  is contained in the solvable radical.
+* `LieAlgebra.HasTrivialRadical.instIsKilling`: **Cartan's criterion for semisimplicity**: if a
+  finite-dimensional Lie algebra has trivial solvable radical, then its Killing form is
+  non-degenerate.
 
 ## TODO
 
-* Add the converse direction of `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`, i.e.
-  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Together with the
-  sufficient direction it would give the iff form of Cartan's criterion for solvability.
+* Add the converse direction of `LieAlgebra.isSolvable_of_killingForm_apply_lie_eq_zero` by proving
+  `radical R L = (derivedSeries R L 1).killingCompl R L`.
 
 ## References
 
@@ -50,16 +46,9 @@ via its vanishing on `L × ⁅L, L⁆`, semisimplicity via its non-degeneracy.
 * [J. Humphreys, *Introduction to Lie Algebras and ...*](humphreys1972) Chapter II 4.3
 -/
 
+variable {R L M : Type*} [CommRing R] [CharZero R] [IsDomain R] [LieRing L] [LieAlgebra R L]
+
 namespace LieModule
-
-variable {R K L M : Type*}
-  [Field K] [CharZero K]
-  [LieRing L] [LieAlgebra K L]
-  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [FiniteDimensional K M]
-  [CommRing R] [CharZero R] [IsDomain R]
-  [LieAlgebra R L] [Module R M] [LieModule R L M] [IsNoetherian R M] [Module.Free R M]
-
-local notation "φ" => toEnd K L M
 
 open Algebra Function LieAlgebra LinearMap Module Module.End Polynomial
 open scoped TensorProduct
@@ -78,11 +67,16 @@ lemma exists_polynomial_eval_sub_aux
   have heq : (⟨a i, ha i⟩ - ⟨a j, ha j⟩ : E) = ⟨a k, ha k⟩ - ⟨a l, ha l⟩ := Subtype.ext hij
   rw [← (algebraMap R K).map_sub, ← (algebraMap R K).map_sub, ← map_sub, ← map_sub, heq]
 
+variable [AddCommGroup M] [LieRingModule L M]
+
 /-- An auxiliary lemma used to prove `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`
 which proves the same result except without the algebraically closed assumption. -/
-theorem isNilpotent_derivedSeries_of_traceForm_eq_zero_aux [IsAlgClosed K]
+theorem isNilpotent_derivedSeries_of_traceForm_eq_zero_aux {K : Type*}
+    [Field K] [CharZero K] [IsAlgClosed K]
+    [LieAlgebra K L] [Module K M] [LieModule K L M] [FiniteDimensional K M]
     (h : traceForm K L M = 0) :
     IsNilpotent (derivedSeries K L 1) M := by
+  set φ := toEnd K L M
   /- By Engel's theorem it suffices to prove that `⁅L, L⁆` acts nilpotently on `M`. -/
   suffices ∀ x ∈ derivedSeries K L 1, _root_.IsNilpotent (φ x) from
     isNilpotent_iff_forall'.mpr fun ⟨x, hx⟩ ↦ this x hx
@@ -178,7 +172,9 @@ theorem isNilpotent_derivedSeries_of_traceForm_eq_zero_aux [IsAlgClosed K]
   rw [hX_ns, add_mul, map_add, htr_n, htr_s, zero_add]
 
 /-- If the trace form of `M` is zero, then the `⁅L, L⁆`-module `M` is nilpotent. -/
-public theorem isNilpotent_derivedSeries_of_traceForm_eq_zero (h : traceForm R L M = 0) :
+public theorem isNilpotent_derivedSeries_of_traceForm_eq_zero
+    [Module R M] [LieModule R L M] [IsNoetherian R M] [Module.Free R M]
+    (h : traceForm R L M = 0) :
     IsNilpotent (derivedSeries R L 1) M := by
   set A := AlgebraicClosure (FractionRing R)
   have _i : FaithfulSMul R A := FaithfulSMul.trans R (FractionRing R) A
@@ -198,64 +194,75 @@ public theorem isNilpotent_derivedSeries_of_traceForm_eq_zero (h : traceForm R L
 
 end LieModule
 
-namespace LieIdeal
+variable [IsNoetherian R L] [Module.Free R L]
 
-open LieAlgebra LieModule LinearMap Module
+open LieAlgebra in
+/-- A convenience variation of `LieAlgebra.isSolvable_of_forall_derived_killingForm_eq_zero` for
+working with ideals.
 
-variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L] [Module.Finite K L]
-
-/-- For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
-if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. The converse is
-left as a TODO; together they give the iff form of **Cartan's criterion for solvability**. -/
-public theorem isSolvable_of_killingForm_apply_lie_eq_zero
-    (I : LieIdeal K L)
-    (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0) :
+Over a principal ideal domain by `LieIdeal.killingForm_eq` this is just a specialisation of
+`LieAlgebra.isSolvable_of_killingForm_apply_lie_eq_zero` but since it does not require the PID
+assumption, it is a slightly stronger result. -/
+public theorem LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero (I : LieIdeal R L)
+    (h : ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm R L x y = 0) :
     IsSolvable I := by
-  set DI : LieIdeal K L := ⁅I, I⁆
-  set DDI : LieIdeal K L := ⁅DI, DI⁆
-  have tf_eq_zero : LieModule.traceForm K DI L = 0 := by
+  set DI : LieIdeal R L := ⁅I, I⁆
+  set DDI : LieIdeal R L := ⁅DI, DI⁆
+  have tf_eq_zero : LieModule.traceForm R DI L = 0 := by
     ext ⟨x, hx⟩ ⟨y, hy⟩
-    change killingForm K L x y = 0
+    change killingForm R L x y = 0
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
-  have module_nilp : LieModule.IsNilpotent (derivedSeries K DI 1) L :=
-    isNilpotent_derivedSeries_of_traceForm_eq_zero tf_eq_zero
+  have module_nilp : LieModule.IsNilpotent (derivedSeries R DI 1) L :=
+    LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero tf_eq_zero
   have ring_nilp : LieRing.IsNilpotent DDI := by
-    rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
+    rw [LieAlgebra.isNilpotent_iff_forall (R := R)]
     rintro ⟨x, hx⟩
-    apply LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L) (x := ⟨x, hx⟩)
-    refine (LieModule.isNilpotent_iff_forall' (R := K)).mp module_nilp
+    apply LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra R L) (x := ⟨x, hx⟩)
+    refine (LieModule.isNilpotent_iff_forall' (R := R)).mp module_nilp
       ⟨⟨x, LieSubmodule.lie_le_left DI DI hx⟩, ?_⟩
     rwa [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
-  obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
+  obtain ⟨k, hk⟩ := IsSolvable.solvable R DDI
   rw [derivedSeries_eq_bot_iff] at hk
   refine IsSolvable.mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)
   rwa [derivedSeriesOfIdeal_add, derivedSeriesOfIdeal_succ, derivedSeriesOfIdeal_succ,
     derivedSeriesOfIdeal_zero]
 
-end LieIdeal
-
 namespace LieAlgebra
 
-variable (K L : Type*) [Field K] [CharZero K] [LieRing L] [LieAlgebra K L] [Module.Finite K L]
+/-- **Cartan's criterion for solvability**: if the Killing form of `L` vanishes on `L × ⁅L, L⁆`,
+then `L` is solvable. -/
+lemma isSolvable_of_killingForm_apply_lie_eq_zero
+    (h : ∀ x, ∀ y ∈ derivedSeries R L 1, killingForm R L x y = 0) :
+    IsSolvable L := by
+  suffices IsSolvable (⊤ : LieIdeal R L) by
+    rwa [← solvable_iff_equiv_solvable LieSubalgebra.topEquiv (R := R)]
+  apply LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero
+  aesop
 
-/-- The kernel of the Killing form of a finite-dimensional Lie algebra over a field of
-characteristic zero is contained in the solvable radical. -/
+variable (R L)
+
+/-- The Killing radical of a finite-dimensional Lie algebra is contained in the solvable radical. -/
 public lemma killingCompl_top_le_radical :
-    LieIdeal.killingCompl K L ⊤ ≤ radical K L := by
+    LieIdeal.killingCompl R L ⊤ ≤ radical R L := by
   rw [← LieIdeal.solvable_iff_le_radical]
   refine LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero _ ?_
   intro x hx y _
   rw [LieModule.traceForm_comm]
-  exact (LieIdeal.mem_killingCompl K L ⊤).mp hx y (LieSubmodule.mem_top y)
+  exact (LieIdeal.mem_killingCompl R L ⊤).mp hx y (LieSubmodule.mem_top y)
 
-/-- A finite-dimensional Lie algebra over a field of characteristic zero with trivial radical
-has non-degenerate Killing form. This is the converse of
-`LieAlgebra.IsKilling.instHasTrivialRadical` in the finite-dimensional, characteristic-zero
-setting; together they give the iff `HasTrivialRadical ↔ IsKilling`, which is
-**Cartan's criterion for semisimplicity**. -/
-public instance HasTrivialRadical.instIsKilling [HasTrivialRadical K L] : IsKilling K L where
-  killingCompl_top_eq_bot := by
-    have h := killingCompl_top_le_radical K L
-    rwa [HasTrivialRadical.radical_eq_bot, le_bot_iff] at h
+/-- **Cartan's criterion for semisimplicity**: if a finite-dimensional Lie algebra has trivial
+solvable radical, then its Killing form is non-degenerate.
+
+See also `LieAlgebra.hasTrivialRadical_iff_isKilling`. -/
+public instance HasTrivialRadical.instIsKilling [HasTrivialRadical R L] : IsKilling R L where
+  killingCompl_top_eq_bot := by simpa using killingCompl_top_le_radical R L
+
+lemma hasTrivialRadical_iff_isKilling [IsPrincipalIdealRing R] :
+    HasTrivialRadical R L ↔ IsKilling R L :=
+  ⟨fun _ ↦ inferInstance, fun _ ↦ inferInstance⟩
+
+example (A : Type*) [LieRing A] [Module.Finite ℤ A] [Module.Free ℤ A] :
+    HasTrivialRadical ℤ A ↔ IsKilling ℤ A :=
+  hasTrivialRadical_iff_isKilling ℤ A
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -215,21 +215,20 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
   set DDI : LieIdeal K L := ⁅DI, DI⁆
   have h_tf : LieModule.traceForm K DI L = 0 := by
     ext ⟨x, hx⟩ ⟨y, hy⟩
-    change trace K L ((ad K L) x ∘ₗ (ad K L) y) = 0
-    rw [← killingForm_apply_apply]
+    change killingForm K L x y = 0
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
-  have key : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
+  have h_nilp : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
     isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
-  rw [isNilpotent_iff_forall' (R := K)] at key
-  have ad_nil : ∀ x ∈ (DDI : LieSubmodule K L L).toSubmodule, IsNilpotent (ad K L x) := by
+  rw [isNilpotent_iff_forall' (R := K)] at h_nilp
+  have ad_nil : ∀ x ∈ DDI.toSubmodule, IsNilpotent (ad K L x) := by
     intro x hx
     have hxDI : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
     have hxDS : (⟨x, hxDI⟩ : DI) ∈ derivedSeries K DI 1 := by
       rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
       exact hx
-    exact key ⟨⟨x, hxDI⟩, hxDS⟩
+    exact h_nilp ⟨⟨x, hxDI⟩, hxDS⟩
   have ddi_nilpotent : LieRing.IsNilpotent DDI := by
-    have : IsNoetherian K DDI := isNoetherian_submodule' (DDI : LieSubmodule K L L).toSubmodule
+    have : IsNoetherian K DDI := isNoetherian_submodule' DDI.toSubmodule
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
     rw [show ad K DDI ⟨x, hx⟩ = (ad K L x).restrict fun _ hy ↦ DDI.lie_mem hy from

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -29,16 +29,19 @@ criterion.
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
   as a `⁅L, L⁆`-module.
 * `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**
-  Desc here
+  (sufficient direction). For an ideal `I` of a finite-dimensional Lie algebra `L` over a field
+  of characteristic zero, if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is
+  solvable.
 * `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
   Lie algebra over a field of characteristic zero is contained in the solvable radical.
 * `LieAlgebra.HasTrivialRadical.instIsKilling`: **Cartan's criterion for semisimplicity**
-  Desc here
+  (sufficient direction). A finite-dimensional Lie algebra over a field of characteristic zero
+  with trivial radical has non-degenerate Killing form.
 
 ## TODO
 
 * The **necessary direction of Cartan's criterion for solvability**:
-  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`. Desc here.
+  `IsSolvable I → ∀ x ∈ I, ∀ y ∈ ⁅I, I⁆, killingForm K L x y = 0`.
 
 ## References
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -28,15 +28,16 @@ criterion.
 * `LieModule.isNilpotent_derivedSeries_of_traceForm_eq_zero`: over a field of characteristic zero,
   if a finite-dimensional representation `M` of `L` has trivial trace form, then `M` is nilpotent
   as a `⁅L, L⁆`-module.
-* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: **Cartan's criterion for solvability**.
-  For an ideal `I` of a finite-dimensional Lie algebra `L` over a field of characteristic zero,
-  if the Killing form of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable.
+* `LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`: for an ideal `I` of a
+  finite-dimensional Lie algebra `L` over a field of characteristic zero, if the Killing form
+  of `L` vanishes on `I × ⁅I, I⁆`, then `I` is solvable. This is one direction of
+  **Cartan's criterion for solvability**; the converse is left as a TODO.
 * `LieAlgebra.killingCompl_top_le_radical`: the kernel of the Killing form of a finite-dimensional
   Lie algebra over a field of characteristic zero is contained in the solvable radical.
-* `LieAlgebra.HasTrivialRadical.instIsKilling`: converse of
-  `LieAlgebra.IsKilling.instHasTrivialRadical` in the finite-dimensional, characteristic-zero
-  setting. Together they give the iff `HasTrivialRadical ↔ IsKilling`, which is
-  **Cartan's criterion for semisimplicity**.
+* `LieAlgebra.HasTrivialRadical.instIsKilling`: a finite-dimensional Lie algebra over a field of
+  characteristic zero with trivial radical has non-degenerate Killing form. This is one direction
+  of **Cartan's criterion for semisimplicity**; the converse is the existing
+  `LieAlgebra.IsKilling.instHasTrivialRadical`.
 
 ## TODO
 

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -217,21 +217,15 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     ext ⟨x, hx⟩ ⟨y, hy⟩
     change killingForm K L x y = 0
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
-  have h_nilp : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
+  have module_nilp : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
     isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
-  rw [isNilpotent_iff_forall' (R := K)] at h_nilp
-  have ad_nil : ∀ x ∈ DDI.toSubmodule, IsNilpotent (ad K L x) := by
-    intro x hx
-    have hx_di : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
-    have hx_der : (⟨x, hx_di⟩ : DI) ∈ derivedSeries K DI 1 := by
-      rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
-      exact hx
-    exact h_nilp ⟨⟨x, hx_di⟩, hx_der⟩
-  have ddi_nilpotent : LieRing.IsNilpotent DDI := by
+  have ring_nilp : LieRing.IsNilpotent DDI := by
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
-    exact LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L)
-      (x := ⟨x, hx⟩) (ad_nil x hx)
+    apply LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L) (x := ⟨x, hx⟩)
+    exact (isNilpotent_iff_forall' (R := K)).mp module_nilp
+      ⟨⟨x, LieSubmodule.lie_le_left DI DI hx⟩, by
+        rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]; exact hx⟩
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [derivedSeries_eq_bot_iff] at hk
   refine .mk (k := k + 2) ((derivedSeries_eq_bot_iff I (k + 2)).mpr ?_)

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -213,17 +213,17 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
     IsSolvable I := by
   set DI : LieIdeal K L := ⁅I, I⁆
   set DDI : LieIdeal K L := ⁅DI, DI⁆
-  have h_tf : LieModule.traceForm K DI L = 0 := by
+  have tf_eq_zero : LieModule.traceForm K DI L = 0 := by
     ext ⟨x, hx⟩ ⟨y, hy⟩
     change killingForm K L x y = 0
     exact h x (LieSubmodule.lie_le_left I I hx) y hy
-  have module_nilp : LieModule.IsNilpotent (LieAlgebra.derivedSeries K DI 1) L :=
-    isNilpotent_derivedSeries_of_traceForm_eq_zero h_tf
+  have module_nilp : LieModule.IsNilpotent (derivedSeries K DI 1) L :=
+    isNilpotent_derivedSeries_of_traceForm_eq_zero tf_eq_zero
   have ring_nilp : LieRing.IsNilpotent DDI := by
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
     apply LieSubalgebra.isNilpotent_ad_of_isNilpotent_ad (DDI : LieSubalgebra K L) (x := ⟨x, hx⟩)
-    refine (isNilpotent_iff_forall' (R := K)).mp module_nilp
+    refine (LieModule.isNilpotent_iff_forall' (R := K)).mp module_nilp
       ⟨⟨x, LieSubmodule.lie_le_left DI DI hx⟩, ?_⟩
     rwa [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI

--- a/Mathlib/Algebra/Lie/CartanCriterion.lean
+++ b/Mathlib/Algebra/Lie/CartanCriterion.lean
@@ -222,17 +222,17 @@ public theorem isSolvable_of_killingForm_apply_lie_eq_zero
   rw [isNilpotent_iff_forall' (R := K)] at h_nilp
   have ad_nil : ∀ x ∈ DDI.toSubmodule, IsNilpotent (ad K L x) := by
     intro x hx
-    have hxDI : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
-    have hxDS : (⟨x, hxDI⟩ : DI) ∈ derivedSeries K DI 1 := by
+    have hx_di : x ∈ DI := LieSubmodule.lie_le_left DI DI hx
+    have hx_der : (⟨x, hx_di⟩ : DI) ∈ derivedSeries K DI 1 := by
       rw [derivedSeries_eq_derivedSeriesOfIdeal_comap, mem_comap]
       exact hx
-    exact h_nilp ⟨⟨x, hxDI⟩, hxDS⟩
+    exact h_nilp ⟨⟨x, hx_di⟩, hx_der⟩
   have ddi_nilpotent : LieRing.IsNilpotent DDI := by
-    have : IsNoetherian K DDI := isNoetherian_submodule' DDI.toSubmodule
     rw [LieAlgebra.isNilpotent_iff_forall (R := K)]
     rintro ⟨x, hx⟩
-    rw [show ad K DDI ⟨x, hx⟩ = (ad K L x).restrict fun _ hy ↦ DDI.lie_mem hy from
-      by ext ⟨_, _⟩; rfl]
+    have ad_eq : ad K DDI ⟨x, hx⟩ = (ad K L x).restrict (fun _ hy ↦ DDI.lie_mem hy) := by
+      ext ⟨_, _⟩; rfl
+    rw [ad_eq]
     exact Module.End.isNilpotent.restrict _ (ad_nil x hx)
   obtain ⟨k, hk⟩ := IsSolvable.solvable K DDI
   rw [derivedSeries_eq_bot_iff] at hk

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -36,10 +36,6 @@ This file contains basic definitions and results for such Lie algebras.
 * `LieIdeal.isCompl_killingCompl`: if a Lie algebra has non-singular Killing form then for all
   ideals, an ideal and its Killing orthogonal complement are complements.
 
-## TODO
-
-* Prove that in characteristic zero, a semisimple Lie algebra has non-singular Killing form.
-
 -/
 
 public section
@@ -86,7 +82,8 @@ instance instSemisimple [IsKilling K L] [Module.Finite K L] : IsSemisimple K L :
   · intro I h₁ h₂
     exact h₁.1 <| IsKilling.ideal_eq_bot_of_isLieAbelian I
 
-/-- The converse of this is true over a field of characteristic zero. There are counterexamples
+/-- The converse of this is true over a field of characteristic zero, it is
+`LieAlgebra.HasTrivialRadical.instIsKilling`. There are counterexamples
 over fields with positive characteristic.
 
 Note that when the coefficients are a field this instance is redundant since we have

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -82,7 +82,7 @@ instance instSemisimple [IsKilling K L] [Module.Finite K L] : IsSemisimple K L :
   · intro I h₁ h₂
     exact h₁.1 <| IsKilling.ideal_eq_bot_of_isLieAbelian I
 
-/-- The converse of this is true over a field of characteristic zero, it is
+/-- The converse of this is true over a field of characteristic zero; it is
 `LieAlgebra.HasTrivialRadical.instIsKilling`. There are counterexamples
 over fields with positive characteristic.
 

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -82,7 +82,7 @@ instance instSemisimple [IsKilling K L] [Module.Finite K L] : IsSemisimple K L :
   · intro I h₁ h₂
     exact h₁.1 <| IsKilling.ideal_eq_bot_of_isLieAbelian I
 
-/-- The converse of this is true over a field of characteristic zero; it is
+/-- The converse of this is true in characteristic zero; it is
 `LieAlgebra.HasTrivialRadical.instIsKilling`. There are counterexamples
 over fields with positive characteristic.
 


### PR DESCRIPTION
Cartan's criterion for semisimplicity
---
PR adds, for finite-dimensional Lie algebras over fields of characteristic zero, one direction of Cartan's criterion for solvability (`LieIdeal.isSolvable_of_killingForm_apply_lie_eq_zero`) and `LieAlgebra.HasTrivialRadical.instIsKilling`, the missing converse of `LieAlgebra.IsKilling.instHasTrivialRadical`, which together close Cartan's criterion for semisimplicity.

The other direction of the solvability criterion is left as a TODO.
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
