### PR TITLE
[Merged by Bors] - feat(Analysis/innerProductSpace/GramMatrix): Add Gram.posSemidef_of_mapL

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -134,15 +134,12 @@ theorem gram_eq_conjTranspose_mul {ι : Type*} [Fintype ι] (b : OrthonormalBasi
   ext i j
   simp [mul_apply, b.repr_apply_apply, b.sum_inner_mul_inner]
 
-open scoped MatrixOrder in
 omit [Finite n] in
 /-- Inequality `‖f x‖ ≤ ‖f‖ * ‖x‖` lifted to Gram matrices. -/
-theorem posSemidef_of_mapL {F} [NormedAddCommGroup F] [InnerProductSpace 𝕜 F] (v : n → E)
-    (f : E →L[𝕜] F) : (‖f‖^2 • gram 𝕜 v - gram 𝕜 (f ∘ v)).PosSemidef := by
-  refine ⟨(isHermitian_gram 𝕜 v).smul
-    (IsSelfAdjoint.pow (IsSelfAdjoint.apply (Pi.isSelfAdjoint.mpr (congrFun rfl)) f) 2)
-    |>.sub (isHermitian_gram 𝕜 (f ∘ v)), ?_⟩
-  intro c
+theorem posSemidef_opNorm_smul_gram_sub_gram {F} [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
+    (v : n → E)(f : E →L[𝕜] F) : (‖f‖ ^ 2 • gram 𝕜 v - gram 𝕜 (f ∘ v)).PosSemidef := by
+  refine ⟨(isHermitian_gram 𝕜 v).smul (((Pi.isSelfAdjoint.mpr (congrFun rfl)).apply f).pow 2)
+    |>.sub (isHermitian_gram 𝕜 (f ∘ v)), fun c ↦ ?_⟩
   simp_rw [Finsupp.sum, Matrix.sub_apply, Matrix.smul_apply, mul_sub, sub_mul,
     Finset.sum_sub_distrib, sub_nonneg, Algebra.mul_smul_comm, gram_apply, ← starRingEnd_apply,
     ← inner_smul_left, mul_comm _ (c _), Algebra.mul_smul_comm, ← Finset.smul_sum,

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -134,6 +134,23 @@ theorem gram_eq_conjTranspose_mul {ι : Type*} [Fintype ι] (b : OrthonormalBasi
   ext i j
   simp [mul_apply, b.repr_apply_apply, b.sum_inner_mul_inner]
 
+open scoped MatrixOrder in
+omit [Finite n] in
+/-- Inequality `‖f x‖ ≤ ‖f‖ * ‖x‖` lifted to Gram matrices. -/
+theorem posSemidef_of_mapL {F} [NormedAddCommGroup F] [InnerProductSpace 𝕜 F] (v : n → E)
+    (f : E →L[𝕜] F) : (‖f‖^2 • gram 𝕜 v - gram 𝕜 (f ∘ v)).PosSemidef := by
+  refine ⟨(isHermitian_gram 𝕜 v).smul
+    (IsSelfAdjoint.pow (IsSelfAdjoint.apply (Pi.isSelfAdjoint.mpr (congrFun rfl)) f) 2)
+    |>.sub (isHermitian_gram 𝕜 (f ∘ v)), ?_⟩
+  intro c
+  simp_rw [Finsupp.sum, Matrix.sub_apply, Matrix.smul_apply, mul_sub, sub_mul,
+    Finset.sum_sub_distrib, sub_nonneg, Algebra.mul_smul_comm, gram_apply, ← starRingEnd_apply,
+    ← inner_smul_left, mul_comm _ (c _), Algebra.mul_smul_comm, ← Finset.smul_sum,
+    ← inner_smul_right, ← inner_sum, ← sum_inner, inner_self_eq_norm_sq_to_K, Function.comp_apply,
+    ← map_smul, ← map_sum]
+  norm_cast
+  grw [f.le_opNorm _, smul_eq_mul, ← mul_pow]
+
 end NormedInnerProductSpace
 
 end Matrix

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -137,7 +137,7 @@ theorem gram_eq_conjTranspose_mul {ι : Type*} [Fintype ι] (b : OrthonormalBasi
 omit [Finite n] in
 /-- Inequality `‖f x‖ ≤ ‖f‖ * ‖x‖` lifted to Gram matrices. -/
 theorem posSemidef_opNorm_smul_gram_sub_gram {F} [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
-    (v : n → E)(f : E →L[𝕜] F) : (‖f‖ ^ 2 • gram 𝕜 v - gram 𝕜 (f ∘ v)).PosSemidef := by
+    (v : n → E) (f : E →L[𝕜] F) : (‖f‖ ^ 2 • gram 𝕜 v - gram 𝕜 (f ∘ v)).PosSemidef := by
   refine ⟨(isHermitian_gram 𝕜 v).smul (((Pi.isSelfAdjoint.mpr (congrFun rfl)).apply f).pow 2)
     |>.sub (isHermitian_gram 𝕜 (f ∘ v)), fun c ↦ ?_⟩
   simp_rw [Finsupp.sum, Matrix.sub_apply, Matrix.smul_apply, mul_sub, sub_mul,

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -141,12 +141,19 @@ theorem posSemidef_opNorm_smul_gram_sub_gram {F} [NormedAddCommGroup F] [InnerPr
   refine ⟨(isHermitian_gram 𝕜 v).smul (((Pi.isSelfAdjoint.mpr (congrFun rfl)).apply f).pow 2)
     |>.sub (isHermitian_gram 𝕜 (f ∘ v)), fun c ↦ ?_⟩
   simp_rw [Finsupp.sum, Matrix.sub_apply, Matrix.smul_apply, mul_sub, sub_mul,
-    Finset.sum_sub_distrib, sub_nonneg, Algebra.mul_smul_comm, gram_apply, ← starRingEnd_apply,
-    ← inner_smul_left, mul_comm _ (c _), Algebra.mul_smul_comm, ← Finset.smul_sum,
-    ← inner_smul_right, ← inner_sum, ← sum_inner, inner_self_eq_norm_sq_to_K, Function.comp_apply,
-    ← map_smul, ← map_sum]
-  norm_cast
-  grw [f.le_opNorm _, smul_eq_mul, ← mul_pow]
+    Finset.sum_sub_distrib, sub_nonneg]
+  calc
+    ∑ x ∈ c.support, ∑ y ∈ c.support, star (c x) * gram 𝕜 (f ∘ v) x y * c y
+    _ = (‖f (∑ x ∈ c.support, c x • v x)‖ : 𝕜) ^ 2 := ?h1
+    _ ≤ ‖f‖ ^ 2 • (‖∑ i ∈ c.support, c i • v i‖ : 𝕜) ^ 2 := by
+      norm_cast
+      grw [f.le_opNorm _, smul_eq_mul, ← mul_pow]
+    _ = ∑ x ∈ c.support, ∑ y ∈ c.support, star (c x) * ‖f‖ ^ 2 • gram 𝕜 v x y * c y := ?h2
+  all_goals
+    rw [Finset.sum_comm]
+    simp [← inner_self_eq_norm_sq_to_K, inner_sum, sum_inner, inner_smul_left, inner_smul_right,
+      Finset.mul_sum, Finset.smul_sum, RCLike.real_smul_eq_coe_mul]
+    grind
 
 end NormedInnerProductSpace
 


### PR DESCRIPTION
---

`Analysis/innerProductSpace/TensorProduct` has a TODO for a continuous version of `TensorProduct.map`. One place which contains a proof for this is at [stack](https://math.stackexchange.com/a/3934668). This PR is lemma 1 of that.

It is written with `.PosSemidef` instead of `≤` because the Löwner Order on matrices is only defined in lean for matrices with values in `𝕜`. 

No AI used. 


<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
