### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry/EllipticCurve/Jacobian/Point): remove erws

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -123,8 +123,8 @@ lemma neg_of_Z_eq_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z = 0) 
 
 lemma neg_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.neg P = P z • ![P x / P z ^ 2, W.toAffine.negY (P x / P z ^ 2) (P y / P z ^ 3), 1] := by
-  erw [neg, smul_fin3, mul_div_cancel₀ _ <| pow_ne_zero 2 hPz, ← negY_of_Z_ne_zero hPz,
-    mul_div_cancel₀ _ <| pow_ne_zero 3 hPz, mul_one]
+  simp only [neg, smul_fin3, fin3_def_ext, mul_div_cancel₀ _ <| pow_ne_zero 2 hPz,
+    ← negY_of_Z_ne_zero hPz, mul_div_cancel₀ _ <| pow_ne_zero 3 hPz, mul_one]
 
 private lemma nonsingular_neg_of_Z_ne_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z ≠ 0) :
     W.Nonsingular ![P x / P z ^ 2, W.toAffine.negY (P x / P z ^ 2) (P y / P z ^ 3), 1] :=
@@ -156,8 +156,11 @@ lemma addY_neg {P : Fin 3 → R} (hP : W'.Equation P) : W'.addY P (W'.neg P) = -
 
 lemma addXYZ_neg {P : Fin 3 → R} (hP : W'.Equation P) :
     W'.addXYZ P (W'.neg P) = -W'.dblZ P • ![1, 1, 0] := by
-  erw [addXYZ, addX_neg hP, addY_neg hP, addZ_neg, smul_fin3, neg_sq, mul_one,
-    Odd.neg_pow <| by decide, mul_one, mul_zero]
+  rw [addXYZ, addX_neg hP, addY_neg hP, addZ_neg, smul_fin3]
+  simp only [Matrix.vecCons_inj, fin3_def_ext, mul_zero, mul_one, and_true]
+  constructor
+  · rw [neg_sq]
+  · rw [Odd.neg_pow (show Odd (3 : ℕ) by decide)]
 
 variable (W') in
 /-- The negation of a Jacobian point class on a Weierstrass curve `W`.

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -123,8 +123,10 @@ lemma neg_of_Z_eq_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z = 0) 
 
 lemma neg_of_Z_ne_zero {P : Fin 3 → F} (hPz : P z ≠ 0) :
     W.neg P = P z • ![P x / P z ^ 2, W.toAffine.negY (P x / P z ^ 2) (P y / P z ^ 3), 1] := by
-  simp only [neg, smul_fin3, fin3_def_ext, mul_div_cancel₀ _ <| pow_ne_zero 2 hPz,
-    ← negY_of_Z_ne_zero hPz, mul_div_cancel₀ _ <| pow_ne_zero 3 hPz, mul_one]
+  rw [neg, smul_fin3]
+  simp only [fin3_def_ext]
+  rw [mul_div_cancel₀ _ <| pow_ne_zero 2 hPz, ← negY_of_Z_ne_zero hPz,
+    mul_div_cancel₀ _ <| pow_ne_zero 3 hPz, mul_one]
 
 private lemma nonsingular_neg_of_Z_ne_zero {P : Fin 3 → F} (hP : W.Nonsingular P) (hPz : P z ≠ 0) :
     W.Nonsingular ![P x / P z ^ 2, W.toAffine.negY (P x / P z ^ 2) (P y / P z ^ 3), 1] :=
@@ -157,10 +159,7 @@ lemma addY_neg {P : Fin 3 → R} (hP : W'.Equation P) : W'.addY P (W'.neg P) = -
 lemma addXYZ_neg {P : Fin 3 → R} (hP : W'.Equation P) :
     W'.addXYZ P (W'.neg P) = -W'.dblZ P • ![1, 1, 0] := by
   rw [addXYZ, addX_neg hP, addY_neg hP, addZ_neg, smul_fin3]
-  simp only [Matrix.vecCons_inj, fin3_def_ext, mul_zero, mul_one, and_true]
-  constructor
-  · rw [neg_sq]
-  · rw [Odd.neg_pow (show Odd (3 : ℕ) by decide)]
+  simp +decide [fin3_def_ext, Odd.neg_pow]
 
 variable (W') in
 /-- The negation of a Jacobian point class on a Weierstrass curve `W`.


### PR DESCRIPTION
- rewrites `neg_of_Z_ne_zero` with a `simp only` chain in place of the former `erw`
- rewrites `addXYZ_neg` by splitting the vector equality into coordinate goals handled by `rw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)