### PR TITLE
[Merged by Bors] - chore(Analysis/Fourier/FourierTransformDeriv): remove an erw

### DIFF
--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -801,14 +801,11 @@ lemma hasDerivAt_fourier
     rw [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.flip_apply,
       ContinuousLinearMap.mul_apply', one_mul, map_smul]
     exact congr_arg (fun x ↦ v • x) (one_smul ℝ (f v)).symm
-  rw [← VectorFourier.fourierIntegral_convergent_iff continuous_fourierChar L.continuous₂ w]
-    at h_int
   convert (VectorFourier.hasFDerivAt_fourierIntegral L hf hf'' w).hasDerivAt using 1
-  erw [ContinuousLinearMap.integral_apply h_int]
-  simp_rw [ContinuousLinearMap.smul_apply, fourierSMulRight, ContinuousLinearMap.smul_apply,
-    ContinuousLinearMap.smulRight_apply, L, ContinuousLinearMap.flip_apply,
-    ContinuousLinearMap.mul_apply', one_mul, ← neg_mul, mul_smul]
-  rfl
+  rw [fourierIntegral_continuousLinearMap_apply' h_int, VectorFourier.fourierIntegral,
+    fourier_real_eq]
+  simp [fourierSMulRight, L, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.mul_apply', ← neg_mul, mul_smul]
 
 @[deprecated (since := "2025-11-16")]
 alias hasDerivAt_fourierIntegral := hasDerivAt_fourier


### PR DESCRIPTION
- rewrites `hasDerivAt_fourier` to use `fourierIntegral_continuousLinearMap_apply'`, `VectorFourier.fourierIntegral`, and `fourier_real_eq` in place of the former `erw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)