### PR TITLE
[Merged by Bors] - chore(Condensed/Light/Epi): remove an erw

### DIFF
--- a/Mathlib/Condensed/Light/Epi.lean
+++ b/Mathlib/Condensed/Light/Epi.lean
@@ -134,18 +134,14 @@ instance : Epi (Limits.Pi.map f) :=
       Functor.ofOpSequence_map_homOfLE_succ]
     infer_instance)
 
-set_option backward.isDefEq.respectTransparency false in
 instance : (lim (J := Discrete ℕ) (C := LightCondMod R)).PreservesEpimorphisms where
   preserves f _ := by
     have : lim.map f = (Pi.isoLimit _).inv ≫ Limits.Pi.map (f.app ⟨·⟩) ≫ (Pi.isoLimit _).hom := by
       apply limit.hom_ext
       intro ⟨n⟩
-      simp only [lim_obj, lim_map, limMap, IsLimit.map, limit.isLimit_lift, limit.lift_π,
-        Cone.postcompose_obj_pt, limit.cone_x, Cone.postcompose_obj_π, NatTrans.comp_app,
-        Functor.const_obj_obj, limit.cone_π, Limits.Pi.map, Category.assoc,
-        Pi.isoLimit_hom_π, Pi.isoLimit_inv_π_assoc]
-      rfl
+      simp
     rw [this]
+    simp only [lim_obj, epi_comp_iff_of_epi, MorphismProperty.epimorphisms.iff]
     infer_instance
 
 end LightCondensed

--- a/Mathlib/Condensed/Light/Epi.lean
+++ b/Mathlib/Condensed/Light/Epi.lean
@@ -141,7 +141,7 @@ instance : (lim (J := Discrete ℕ) (C := LightCondMod R)).PreservesEpimorphisms
       intro ⟨n⟩
       simp
     rw [this]
-    simp only [lim_obj, epi_comp_iff_of_epi, MorphismProperty.epimorphisms.iff]
+    dsimp
     infer_instance
 
 end LightCondensed

--- a/Mathlib/Condensed/Light/Epi.lean
+++ b/Mathlib/Condensed/Light/Epi.lean
@@ -142,10 +142,8 @@ instance : (lim (J := Discrete ℕ) (C := LightCondMod R)).PreservesEpimorphisms
       intro ⟨n⟩
       simp only [lim_obj, lim_map, limMap, IsLimit.map, limit.isLimit_lift, limit.lift_π,
         Cone.postcompose_obj_pt, limit.cone_x, Cone.postcompose_obj_π, NatTrans.comp_app,
-        Functor.const_obj_obj, limit.cone_π, Pi.isoLimit, Limits.Pi.map, Category.assoc,
-        limit.conePointUniqueUpToIso_hom_comp, Pi.cone_pt, Pi.cone_π, Discrete.natTrans_app,
-        Discrete.functor_obj_eq_as]
-      erw [IsLimit.conePointUniqueUpToIso_inv_comp_assoc]
+        Functor.const_obj_obj, limit.cone_π, Limits.Pi.map, Category.assoc,
+        Pi.isoLimit_hom_π, Pi.isoLimit_inv_π_assoc]
       rfl
     rw [this]
     infer_instance


### PR DESCRIPTION
Removes an `erw` that is now handled by `simp`.

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)