### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/AffineSpace/Combination): remove an erw

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -964,7 +964,7 @@ theorem affineSpan_eq_affineSpan_lineMap_units [Nontrivial k] {s : Set P} {p : P
     rw [this]
   apply le_antisymm
     <;> intro q hq
-    <;> erw [mem_affineSpan_iff_eq_weightedVSubOfPoint_vadd k V _ (⟨p, hp⟩ : s) q] at hq ⊢
+    <;> rw [mem_affineSpan_iff_eq_weightedVSubOfPoint_vadd k V _ (⟨p, hp⟩ : s) q] at hq ⊢
     <;> obtain ⟨t, μ, rfl⟩ := hq
     <;> use t
     <;> [use fun x => μ x * ↑(w x); use fun x => μ x * ↑(w x)⁻¹]


### PR DESCRIPTION
- replaces the `erw` in `affineSpan_eq_affineSpan_lineMap_units` with `rw` on both the hypothesis and the goal

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)