### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/TensorProduct/Subalgebra): remove erws

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Subalgebra.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Subalgebra.lean
@@ -64,11 +64,9 @@ def lTensorBot : (⊥ : Subalgebra R S) ⊗[R] A ≃ₐ[R] A := by
     replace hx : algebraMap R _ x' = x := Subtype.val_injective hx
     obtain ⟨y', hy⟩ := Algebra.mem_bot.1 y.2
     replace hy : algebraMap R _ y' = y := Subtype.val_injective hy
-    rw [← hx, ← hy, ← map_mul]
-    erw [(toSubmodule A).lTensorOne_tmul x' a,
-      (toSubmodule A).lTensorOne_tmul y' b,
-      (toSubmodule A).lTensorOne_tmul (x' * y') (a * b)]
-    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm x' y']
+    rw [← hx, ← hy, ← map_mul, (toSubmodule A).lTensorOne_tmul x' a,
+      (toSubmodule A).lTensorOne_tmul y' b, (toSubmodule A).lTensorOne_tmul (x' * y') (a * b),
+      Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm x' y']
   · exact Submodule.lTensorOne_one_tmul _
 
 variable {A}
@@ -98,7 +96,7 @@ def rTensorBot : A ⊗[R] (⊥ : Subalgebra R S) ≃ₐ[R] A := by
     obtain ⟨y', hy⟩ := Algebra.mem_bot.1 y.2
     replace hy : algebraMap R _ y' = y := Subtype.val_injective hy
     rw [← hx, ← hy, ← map_mul]
-    erw [(toSubmodule A).rTensorOne_tmul x' a,
+    rw [(toSubmodule A).rTensorOne_tmul x' a,
       (toSubmodule A).rTensorOne_tmul y' b,
       (toSubmodule A).rTensorOne_tmul (x' * y') (a * b)]
     rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm x' y']

--- a/Mathlib/LinearAlgebra/TensorProduct/Subalgebra.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Subalgebra.lean
@@ -95,11 +95,9 @@ def rTensorBot : A ⊗[R] (⊥ : Subalgebra R S) ≃ₐ[R] A := by
     replace hx : algebraMap R _ x' = x := Subtype.val_injective hx
     obtain ⟨y', hy⟩ := Algebra.mem_bot.1 y.2
     replace hy : algebraMap R _ y' = y := Subtype.val_injective hy
-    rw [← hx, ← hy, ← map_mul]
-    rw [(toSubmodule A).rTensorOne_tmul x' a,
-      (toSubmodule A).rTensorOne_tmul y' b,
-      (toSubmodule A).rTensorOne_tmul (x' * y') (a * b)]
-    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm x' y']
+    rw [← hx, ← hy, ← map_mul, (toSubmodule A).rTensorOne_tmul x' a,
+      (toSubmodule A).rTensorOne_tmul y' b, (toSubmodule A).rTensorOne_tmul (x' * y') (a * b),
+      Algebra.mul_smul_comm, Algebra.smul_mul_assoc, smul_smul, mul_comm x' y']
   · exact Submodule.rTensorOne_tmul_one _
 
 @[simp]


### PR DESCRIPTION
- rewrites `lTensorBot` and `rTensorBot` by folding the former `erw` steps into the surrounding `rw` chains

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)