### PR TITLE
feat(Analysis/Normed/Module/Connected): Complement of hyperplane has two components

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2145,6 +2145,7 @@ public import Mathlib.Analysis.Normed.Module.Dual
 public import Mathlib.Analysis.Normed.Module.ENormedSpace
 public import Mathlib.Analysis.Normed.Module.Extr
 public import Mathlib.Analysis.Normed.Module.FiniteDimension
+public import Mathlib.Analysis.Normed.Module.FiniteDimensionConnected
 public import Mathlib.Analysis.Normed.Module.HahnBanach
 public import Mathlib.Analysis.Normed.Module.MStructure
 public import Mathlib.Analysis.Normed.Module.Multilinear.Basic

--- a/Mathlib/Analysis/Normed/Module/Connected.lean
+++ b/Mathlib/Analysis/Normed/Module/Connected.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Convex.Topology
 public import Mathlib.Analysis.Normed.Module.Convex
 public import Mathlib.LinearAlgebra.Dimension.DivisionRing
 public import Mathlib.Topology.Algebra.Module.Cardinality
+public import Mathlib.Topology.Algebra.Module.Equiv
 
 /-!
 # Connectedness of subsets of vector spaces
@@ -24,6 +25,13 @@ We show several results related to the (path)-connectedness of subsets of real v
   of codimension `> 1` is path-connected.
 
 Statements with connectedness instead of path-connectedness are also given.
+
+* `ContinuousLinearMap.connectedComponents_compl_hyperplane_equiv_bool` shows that the complement
+  of a convex hyperplane defined by a surjective continuous linear functional `F →L[ℝ] ℝ` has
+  exactly two connected components (`ConnectedComponents _ ≃ Bool`); a version assuming `f ≠ 0` and
+  cardinality (`Nat.card _ = 2`) are also proved.
+* `ContinuousLinearMap.zerothHomotopy_compl_hyperplane_equiv_bool` is the corresponding
+  path-component statement (`ZerothHomotopy _ ≃ Bool`).
 -/
 
 public section
@@ -31,7 +39,7 @@ public section
 assert_not_exists Subgroup.index Nat.divisors
 -- TODO assert_not_exists Cardinal
 
-open Set Metric
+open Set Function Metric Topology
 open scoped Convex ENNReal
 
 section TopologicalVectorSpace
@@ -248,6 +256,82 @@ theorem isPreconnected_sphere (h : 1 < Module.rank ℝ E) (x : E) (r : ℝ) :
   · simpa [hr] using isPreconnected_empty
 
 end NormedSpace
+
+section CodimensionOne
+
+namespace ContinuousLinearMap
+
+variable {F : Type*} [AddCommGroup F] [Module ℝ F] [TopologicalSpace F] (f : F →L[ℝ] ℝ) (c : ℝ)
+
+private def boolConnectedComponents : Bool → Set ↥({x : F | f x = c}ᶜ)
+| true => {x | c < f x.val}
+| false => {x | f x.val < c}
+
+private lemma boolConnectedComponents_compl (i : Bool) :
+    (boolConnectedComponents f c i)ᶜ = boolConnectedComponents f c !i := by
+  ext x
+  simp only [boolConnectedComponents, mem_compl_iff]
+  grind
+
+private lemma boolConnectedComponents_clopen (i : Bool) :
+    IsClopen (boolConnectedComponents f c i) := by
+  have hopen : ∀ i, IsOpen (boolConnectedComponents f c i) := by
+    intro i
+    fin_cases i
+    · exact isOpen_Ioi.preimage (f.continuous.comp continuous_subtype_val)
+    · exact isOpen_Iio.preimage (f.continuous.comp continuous_subtype_val)
+  have := (hopen !i).isClosed_compl
+  rw [boolConnectedComponents_compl, Bool.not_not] at this
+  exact ⟨this, hopen i⟩
+
+private lemma boolConnectedComponents_disjoint :
+    Pairwise (Disjoint on f.boolConnectedComponents c) := by
+  intro i j _
+  fin_cases i <;> fin_cases j <;> (try contradiction) <;> simp +contextual [
+    disjoint_iff_inter_eq_empty, eq_empty_iff_forall_notMem, boolConnectedComponents, le_of_lt]
+
+private lemma boolConnectedComponents_iUnion : ⋃ i, f.boolConnectedComponents c i = univ := by
+  ext x
+  grind [boolConnectedComponents, mem_iUnion, Bool.exists_bool]
+
+variable [IsTopologicalAddGroup F] [ContinuousSMul ℝ F] {f}
+
+private lemma boolConnectedComponents_pathConnected (hf : Surjective f) (i : Bool) :
+    IsPathConnected (f.boolConnectedComponents c i) := by
+  fin_cases i
+  · haveI : PathConnectedSpace {x : F | c < f x} := isPathConnected_iff_pathConnectedSpace.mp <| by
+      obtain ⟨x, hx⟩ := hf (c + 1)
+      exact (convex_halfSpace_gt f.isLinear c).isPathConnected ⟨x, by simp [hx]⟩
+    have hAs : {x : F | c < f x} ⊆ {x : F | f x = c}ᶜ := fun x hx => ne_of_gt hx
+    have hU0 : boolConnectedComponents f c true = Set.range (Set.inclusion hAs) := by
+      ext x
+      grind [Subtype.exists, boolConnectedComponents]
+    exact hU0 ▸ isPathConnected_range (continuous_inclusion hAs)
+  · haveI : PathConnectedSpace {x : F | f x < c} := isPathConnected_iff_pathConnectedSpace.mp <| by
+      obtain ⟨x, hx⟩ := hf (c - 1)
+      exact (convex_halfSpace_lt f.isLinear c).isPathConnected ⟨x, by simp [hx]⟩
+    have hBs : {x : F | f x < c} ⊆ {x : F | f x = c}ᶜ := fun x hx => ne_of_lt hx
+    have hU1 : boolConnectedComponents f c false = Set.range (Set.inclusion hBs) := by
+      ext x
+      grind [Subtype.exists, boolConnectedComponents]
+    exact hU1 ▸ isPathConnected_range (continuous_inclusion hBs)
+
+theorem connectedComponents_compl_hyperplane_card_eq_two (hf : Surjective f) :
+    Nat.card (ConnectedComponents ↥({x : F | f x = c}ᶜ)) = 2 :=
+  (Nat.card_congr (ConnectedComponents.equivOfIsClopenOfIsConnected
+    (boolConnectedComponents_clopen f c) (boolConnectedComponents_disjoint f c)
+    (boolConnectedComponents_iUnion f c)
+    fun i ↦ (boolConnectedComponents_pathConnected c hf i).isConnected)).trans <| by simp
+
+theorem zerothHomotopy_compl_hyperplane_card_eq_two (hf : Surjective f) :
+    Nat.card (ZerothHomotopy ↥({x : F | f x = c}ᶜ)) = 2 :=
+  (Nat.card_congr (ZerothHomotopy.equivOfIsClopenOfIsPathConnected
+    (boolConnectedComponents_clopen f c) (boolConnectedComponents_disjoint f c)
+    (boolConnectedComponents_iUnion f c) (boolConnectedComponents_pathConnected c hf))).trans
+    <| by simp
+
+end ContinuousLinearMap
+end CodimensionOne
 
 section
 

--- a/Mathlib/Analysis/Normed/Module/FiniteDimensionConnected.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimensionConnected.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.Analysis.Normed.Module.Connected
 public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
-public section
-
 /-!
 # Connectedness of subsets of finite-dimensional vector spaces
 
@@ -21,6 +19,8 @@ public section
   statement for path components (`ZerothHomotopy _ ≃ Bool`).
 
 -/
+
+public section
 
 variable {F : Type*} [AddCommGroup F] [Module ℝ F] [TopologicalSpace F] [IsTopologicalAddGroup F]
   [ContinuousSMul ℝ F] {E : Submodule ℝ F} (hcodim : Module.rank ℝ (F ⧸ E) = 1)

--- a/Mathlib/Analysis/Normed/Module/FiniteDimensionConnected.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimensionConnected.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Jun Kwon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jun Kwon
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Connected
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
+
+public section
+
+/-!
+# Connectedness of subsets of finite-dimensional vector spaces
+
+`Submodule.connectedComponents_compl_equiv_bool_of_isClosed_of_rank_quotient_eq_one` shows that
+  the complement of a closed submodule of codimension `1` has exactly two connected components
+  (`ConnectedComponents _ ≃ Bool`).
+
+`Submodule.zerothHomotopy_compl_equiv_bool_of_isClosed_of_rank_quotient_eq_one` is the analogous
+  statement for path components (`ZerothHomotopy _ ≃ Bool`).
+
+-/
+
+variable {F : Type*} [AddCommGroup F] [Module ℝ F] [TopologicalSpace F] [IsTopologicalAddGroup F]
+  [ContinuousSMul ℝ F] {E : Submodule ℝ F} (hcodim : Module.rank ℝ (F ⧸ E) = 1)
+
+namespace Submodule
+
+theorem connectedComponents_compl_card_eq_two_of_isClosed_of_rank_quotient_eq_one
+    (hE : IsClosed (E : Set F)) (hcodim : Module.rank ℝ (F ⧸ E) = 1) :
+    Nat.card (ConnectedComponents ↥((E : Set F)ᶜ)) = 2 :=
+  have hfin : Module.finrank ℝ (F ⧸ E) = 1 := (Module.rank_eq_one_iff_finrank_eq_one).1 hcodim
+  haveI : FiniteDimensional ℝ (F ⧸ E) := FiniteDimensional.of_finrank_eq_succ hfin
+  let hecl : (F ⧸ E) ≃L[ℝ] ℝ :=
+    ((Module.nonempty_linearEquiv_of_finrank_eq_one hfin).some.symm).toContinuousLinearEquiv
+  let f : F →L[ℝ] ℝ := hecl.toContinuousLinearMap.comp <| ⟨E.mkQ, continuous_quot_mk⟩
+  have hfker : LinearMap.ker f.toLinearMap = E := by simp [f, hecl]
+  have hset : ((E : Set F)ᶜ) = ({x : F | f x = (0 : ℝ)}ᶜ) := by
+    ext x
+    simp [← hfker]
+  hset ▸ f.connectedComponents_compl_hyperplane_card_eq_two 0
+    (hecl.surjective.comp E.mkQ_surjective) |>.trans (by simp)
+
+theorem connectedComponents_compl_card_eq_two_of_rank_quotient_eq_one [T2Space F]
+    [FiniteDimensional ℝ F] (hcodim : Module.rank ℝ (F ⧸ E) = 1) :
+    Nat.card (ConnectedComponents ↥((E : Set F)ᶜ)) = 2 :=
+  connectedComponents_compl_card_eq_two_of_isClosed_of_rank_quotient_eq_one
+    E.closed_of_finiteDimensional hcodim
+
+theorem zerothHomotopy_compl_card_eq_two_of_isClosed_of_rank_quotient_eq_one
+    (hE : IsClosed (E : Set F)) (hcodim : Module.rank ℝ (F ⧸ E) = 1) :
+    Nat.card (ZerothHomotopy ↥((E : Set F)ᶜ)) = 2 :=
+  have hfin : Module.finrank ℝ (F ⧸ E) = 1 := (Module.rank_eq_one_iff_finrank_eq_one).1 hcodim
+  haveI : FiniteDimensional ℝ (F ⧸ E) := FiniteDimensional.of_finrank_eq_succ hfin
+  let hecl : (F ⧸ E) ≃L[ℝ] ℝ :=
+    ((Module.nonempty_linearEquiv_of_finrank_eq_one hfin).some.symm).toContinuousLinearEquiv
+  let f : F →L[ℝ] ℝ := hecl.toContinuousLinearMap.comp <| ⟨E.mkQ, continuous_quot_mk⟩
+  have hfker : LinearMap.ker f.toLinearMap = E := by simp [f, hecl]
+  have hset : ((E : Set F)ᶜ) = ({x : F | f x = (0 : ℝ)}ᶜ) := by
+    ext x
+    simp [← hfker]
+  hset ▸ f.zerothHomotopy_compl_hyperplane_card_eq_two 0
+    (hecl.surjective.comp E.mkQ_surjective) |>.trans (by simp)
+
+theorem zerothHomotopy_compl_card_eq_two_of_rank_quotient_eq_one [T2Space F]
+    [FiniteDimensional ℝ F] (hcodim : Module.rank ℝ (F ⧸ E) = 1) :
+    Nat.card (ZerothHomotopy ↥((E : Set F)ᶜ)) = 2 :=
+  zerothHomotopy_compl_card_eq_two_of_isClosed_of_rank_quotient_eq_one E.closed_of_finiteDimensional
+    hcodim
+
+end Submodule

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -639,12 +639,32 @@ theorem exists_path_through_family' {n : ℕ} (p : Fin (n + 1) → X) :
 
 end PathConnectedSpace
 
+namespace ZerothHomotopy
+
 /-- The preimage of a singleton in `ZerothHomotopy` is the path component of an element in the
 equivalence class. -/
-theorem ZerothHomotopy.preimage_singleton_eq_pathComponent (x : X) :
+theorem preimage_singleton_eq_pathComponent (x : X) :
     ZerothHomotopy.mk ⁻¹' {.mk x} = pathComponent x := by
   ext y
   rw [mem_preimage, mem_singleton_iff, eq_comm, mem_pathComponent_iff]
   exact Quotient.eq
 
 instance [CompactSpace X] : CompactSpace <| ZerothHomotopy X := Quotient.compactSpace
+
+open ConnectedComponents in
+/-- A pairwise disjoint clopen cover by path-connected sets partitions the path components.
+  Analogous to `ConnectedComponents.equivOfIsClopenOfIsConnected`. -/
+noncomputable def equivOfIsClopenOfIsPathConnected {U : ι → Set X} (hclopen : ∀ i, IsClopen (U i))
+    (hdisj : Pairwise (Disjoint on U)) (hunion : ⋃ i, U i = univ)
+    (hpath : ∀ i, IsPathConnected (U i)) : ZerothHomotopy X ≃ ι := by
+  let e : ConnectedComponents X ≃ ι := equivOfIsClopenOfIsConnected hclopen hdisj hunion
+    fun i ↦ (hpath i).isConnected
+  refine ⟨fun x ↦ e x.toConnectedComponents, fun i ↦ mk (hpath i).nonempty.some, fun x ↦ ?_,
+    fun i ↦ equivOfIsClopenOfIsConnected_mk hclopen hdisj hunion
+    (hpath · |>.isConnected) _ (hpath i).nonempty.some_mem⟩
+  obtain ⟨x, rfl⟩ := mk_surjective x
+  obtain ⟨i, hi⟩ := iUnion_eq_univ_iff.mp hunion x
+  have he := equivOfIsClopenOfIsConnected_mk hclopen hdisj hunion (hpath · |>.isConnected) x hi
+  exact Quotient.sound <| he ▸ (hpath i).joinedIn _ (hpath i).nonempty.some_mem _ hi |>.joined
+
+end ZerothHomotopy


### PR DESCRIPTION
This PR proves that the complement of a hyperplane decomposes to two components, both wrt `IsConnected` and `IsPathConnected`. Specifically for subspaces, new file is created as they rely on `FiniteDimensional` which clashes with `assert_not_exists Subgroup.index Nat.divisors`.

 `ZerothHomotopy.equivOfIsClopenOfIsPathConnected` is also proved analogous to `ConnectedComponents.equivOfIsClopenOfIsConnected`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
