### PR TITLE
wip, chore: rename Directed -> Predirected [please-adopt]

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -976,7 +976,7 @@ section SuprLift
 variable {ι : Sort*}
 
 theorem coe_iSup_of_directed [Nonempty ι] {S : ι → NonUnitalSubalgebra R A}
-    (dir : Directed (· ≤ ·) S) : ↑(iSup S) = ⋃ i, (S i : Set A) :=
+    (dir : Predirected (· ≤ ·) S) : ↑(iSup S) = ⋃ i, (S i : Set A) :=
   let K : NonUnitalSubalgebra R A :=
     { __ := NonUnitalSubsemiring.copy _ _ (NonUnitalSubsemiring.coe_iSup_of_directed dir).symm
       smul_mem' := fun r _x hx ↦
@@ -989,7 +989,7 @@ theorem coe_iSup_of_directed [Nonempty ι] {S : ι → NonUnitalSubalgebra R A}
 /-- Define an algebra homomorphism on a directed supremum of non-unital subalgebras by defining
 it on each non-unital subalgebra, and proving that it agrees on the intersection of
 non-unital subalgebras. -/
-noncomputable def iSupLift [Nonempty ι] (K : ι → NonUnitalSubalgebra R A) (dir : Directed (· ≤ ·) K)
+noncomputable def iSupLift [Nonempty ι] (K : ι → NonUnitalSubalgebra R A) (dir : Predirected (· ≤ ·) K)
     (f : ∀ i, K i →ₙₐ[R] B) (hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h))
     (T : NonUnitalSubalgebra R A) (hT : T = iSup K) : ↥T →ₙₐ[R] B := by
   subst hT
@@ -1019,7 +1019,7 @@ noncomputable def iSupLift [Nonempty ι] (K : ι → NonUnitalSubalgebra R A) (d
             (fun _ _ => rfl)
           all_goals simp }
 
-variable [Nonempty ι] {K : ι → NonUnitalSubalgebra R A} {dir : Directed (· ≤ ·) K}
+variable [Nonempty ι] {K : ι → NonUnitalSubalgebra R A} {dir : Predirected (· ≤ ·) K}
   {f : ∀ i, K i →ₙₐ[R] B} {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
   {T : NonUnitalSubalgebra R A} {hT : T = iSup K}
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
@@ -29,7 +29,7 @@ variable (S : Subalgebra R A)
 
 variable {ι : Type*} [Nonempty ι] {K : ι → Subalgebra R A}
 
-theorem coe_iSup_of_directed (dir : Directed (· ≤ ·) K) : ↑(iSup K) = ⋃ i, (K i : Set A) := by
+theorem coe_iSup_of_directed (dir : Predirected (· ≤ ·) K) : ↑(iSup K) = ⋃ i, (K i : Set A) := by
   let s : Subalgebra R A :=
     { __ := Subsemiring.copy _ _ (Subsemiring.coe_iSup_of_directed dir).symm
       algebraMap_mem' := fun _ ↦ Set.mem_iUnion.2
@@ -42,7 +42,7 @@ variable (K)
 
 /-- Define an algebra homomorphism on a directed supremum of subalgebras by defining
 it on each subalgebra, and proving that it agrees on the intersection of subalgebras. -/
-noncomputable def iSupLift (dir : Directed (· ≤ ·) K) (f : ∀ i, K i →ₐ[R] B)
+noncomputable def iSupLift (dir : Predirected (· ≤ ·) K) (f : ∀ i, K i →ₐ[R] B)
     (hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h))
     (T : Subalgebra R A) (hT : T ≤ iSup K) : ↥T →ₐ[R] B := by
   let compat :
@@ -78,7 +78,7 @@ noncomputable def iSupLift (dir : Directed (· ≤ ·) K) (f : ∀ i, K i →ₐ
 
 
 @[simp]
-theorem iSupLift_inclusion {dir : Directed (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
+theorem iSupLift_inclusion {dir : Predirected (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
     {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
     {T : Subalgebra R A} {hT : T ≤ iSup K} {i : ι} (x : K i) (h : K i ≤ T) :
     iSupLift K dir f hf T hT (inclusion h x) = f i x := by
@@ -87,20 +87,20 @@ theorem iSupLift_inclusion {dir : Directed (· ≤ ·) K} {f : ∀ i, K i →ₐ
   exact SetLike.coe_subset_coe.mpr <| h.trans hT
 
 @[simp]
-theorem iSupLift_comp_inclusion {dir : Directed (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
+theorem iSupLift_comp_inclusion {dir : Predirected (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
     {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
     {T : Subalgebra R A} {hT : T ≤ iSup K} {i : ι} (h : K i ≤ T) :
     (iSupLift K dir f hf T hT).comp (inclusion h) = f i := by ext; simp
 
 @[simp]
-theorem iSupLift_mk {dir : Directed (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
+theorem iSupLift_mk {dir : Predirected (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
     {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
     {T : Subalgebra R A} {hT : T ≤ iSup K} {i : ι} (x : K i) (hx : (x : A) ∈ T) :
     iSupLift K dir f hf T hT ⟨x, hx⟩ = f i x := by
   dsimp [iSupLift, inclusion]
   rw [Set.iUnionLift_mk]
 
-theorem iSupLift_of_mem {dir : Directed (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
+theorem iSupLift_of_mem {dir : Predirected (· ≤ ·) K} {f : ∀ i, K i →ₐ[R] B}
     {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
     {T : Subalgebra R A} {hT : T ≤ iSup K} {i : ι} (x : T) (hx : (x : A) ∈ K i) :
     iSupLift K dir f hf T hT x = f i ⟨x, hx⟩ := by

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -408,7 +408,7 @@ theorem comap_top (f : K →+* L) : (⊤ : Subfield L).comap f = ⊤ :=
 /-- The underlying set of a non-empty directed sSup of subfields is just a union of the subfields.
   Note that this fails without the directedness assumption (the union of two subfields is
   typically not a subfield) -/
-theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subfield K} (hS : Directed (· ≤ ·) S)
+theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subfield K} (hS : Predirected (· ≤ ·) S)
     {x : K} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   let s : Subfield K :=
     { __ := Subring.copy _ _ (Subring.coe_iSup_of_directed hS).symm
@@ -418,7 +418,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subfield K} (h
     (iSup_le fun i ↦ le_iSup (fun i ↦ (S i : Set K)) i) (Set.iUnion_subset fun _ ↦ le_iSup S _)
   exact this ▸ Set.mem_iUnion
 
-theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subfield K} (hS : Directed (· ≤ ·) S) :
+theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subfield K} (hS : Predirected (· ≤ ·) S) :
     ((⨆ i, S i : Subfield K) : Set K) = ⋃ i, ↑(S i) :=
   Set.ext fun x => by simp [mem_iSup_of_directed hS]
 

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -548,14 +548,14 @@ theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Subgroup G} {
     simp [hi, hi']
 
 @[to_additive]
-theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Directed (· ≤ ·) K)
+theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Predirected (· ≤ ·) K)
     {x : G} : x ∈ (iSup K : Subgroup G) ↔ ∃ i, x ∈ K i := by
   have : iSup K = ⨆ i : PLift ι, ⨆ (_ : True), K i.down := by simp [iSup_plift_down]
   rw [this, mem_biSup_of_directedOn trivial]
   · simp
   · simp only [setOf_true]
     rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
-    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
+    -- `Predirected.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
     intro i
     simp only [PLift.exists]
     intro j
@@ -570,7 +570,7 @@ theorem mem_iSup_prop {p : Prop} {K : p → Subgroup G} {x : G} :
   simp +contextual [h]
 
 @[to_additive]
-theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Subgroup G} (hS : Directed (· ≤ ·) S) :
+theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Subgroup G} (hS : Predirected (· ≤ ·) S) :
     ((⨆ i, S i : Subgroup G) : Set G) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -69,14 +69,14 @@ theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Submonoid M} 
 -- TODO: this section can be generalized to `[SubmonoidClass B M] [CompleteLattice B]`
 -- such that `CompleteLattice.LE` coincides with `SetLike.LE`
 @[to_additive]
-theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Submonoid M} (hS : Directed (· ≤ ·) S)
+theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Submonoid M} (hS : Predirected (· ≤ ·) S)
     {x : M} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   have : iSup S = ⨆ i : PLift ι, ⨆ (_ : True), S i.down := by simp [iSup_plift_down]
   rw [this, mem_biSup_of_directedOn trivial]
   · simp
   · simp only [setOf_true]
     rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
-    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
+    -- `Predirected.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
     intro i
     simp only [PLift.exists]
     intro j
@@ -91,7 +91,7 @@ theorem mem_iSup_prop {p : Prop} {S : p → Submonoid M} {x : M} :
   simp +contextual [h]
 
 @[to_additive]
-theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Submonoid M} (hS : Directed (· ≤ ·) S) :
+theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Submonoid M} (hS : Predirected (· ≤ ·) S) :
     ((⨆ i, S i : Submonoid M) : Set M) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -61,14 +61,14 @@ theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Subsemigroup 
 -- TODO: this section can be generalized to `[MulMemClass B M] [CompleteLattice B]`
 -- such that `complete_lattice.le` coincides with `set_like.le`
 @[to_additive]
-theorem mem_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ ·) S) {x : M} :
+theorem mem_iSup_of_directed {S : ι → Subsemigroup M} (hS : Predirected (· ≤ ·) S) {x : M} :
     (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   have : iSup S = ⨆ i : PLift ι, ⨆ (_ : True), S i.down := by simp [iSup_plift_down]
   rw [this, mem_biSup_of_directedOn]
   · simp
   · simp only [setOf_true]
     rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
-    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
+    -- `Predirected.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
     intro i
     simp only [PLift.exists]
     intro j
@@ -83,7 +83,7 @@ theorem mem_iSup_prop {p : Prop} {S : p → Subsemigroup M} {x : M} :
   · simpa [h] using id
 
 @[to_additive]
-theorem coe_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ ·) S) :
+theorem coe_iSup_of_directed {S : ι → Subsemigroup M} (hS : Predirected (· ≤ ·) S) :
     ((⨆ i, S i : Subsemigroup M) : Set M) = ⋃ i, S i :=
   Set.ext fun x => by simp [mem_iSup_of_directed hS]
 

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -768,7 +768,7 @@ def prodEquiv (s : Subring R) (t : Subring S) : s.prod t ≃+* s × t :=
 /-- The underlying set of a non-empty directed sSup of subrings is just a union of the subrings.
   Note that this fails without the directedness assumption (the union of two subrings is
   typically not a subring) -/
-theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subring R} (hS : Directed (· ≤ ·) S)
+theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subring R} (hS : Predirected (· ≤ ·) S)
     {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
   let U : Subring R :=
@@ -777,7 +777,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subring R} (hS
   suffices ⨆ i, S i ≤ U by simpa [U] using @this x
   exact iSup_le fun i x hx ↦ Set.mem_iUnion.2 ⟨i, hx⟩
 
-theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subring R} (hS : Directed (· ≤ ·) S) :
+theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subring R} (hS : Predirected (· ≤ ·) S) :
     ((⨆ i, S i : Subring R) : Set R) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -668,7 +668,7 @@ def prodEquiv (s : Subsemiring R) (t : Subsemiring S) : s.prod t ≃+* s × t :=
     map_mul' := fun _ _ => rfl
     map_add' := fun _ _ => rfl }
 
-theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subsemiring R} (hS : Directed (· ≤ ·) S)
+theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subsemiring R} (hS : Predirected (· ≤ ·) S)
     {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
   let U : Subsemiring R :=
@@ -679,7 +679,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subsemiring R}
   exact iSup_le fun i x hx ↦ Set.mem_iUnion.2 ⟨i, hx⟩
 
 theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Subsemiring R}
-    (hS : Directed (· ≤ ·) S) : ((⨆ i, S i : Subsemiring R) : Set R) = ⋃ i, S i :=
+    (hS : Predirected (· ≤ ·) S) : ((⨆ i, S i : Subsemiring R) : Set R) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 
 theorem mem_sSup_of_directedOn {S : Set (Subsemiring R)} (Sne : S.Nonempty)

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -1027,7 +1027,7 @@ section StarSubalgebraB
 variable [IsScalarTower R B B] [SMulCommClass R B B] [StarModule R B]
 
 theorem coe_iSup_of_directed [Nonempty ι] {S : ι → NonUnitalStarSubalgebra R A}
-    (dir : Directed (· ≤ ·) S) : ↑(iSup S) = ⋃ i, (S i : Set A) :=
+    (dir : Predirected (· ≤ ·) S) : ↑(iSup S) = ⋃ i, (S i : Set A) :=
   let K : NonUnitalStarSubalgebra R A :=
     { __ := NonUnitalSubalgebra.copy _ _ (NonUnitalSubalgebra.coe_iSup_of_directed dir).symm
       star_mem' := fun hx ↦
@@ -1041,7 +1041,7 @@ theorem coe_iSup_of_directed [Nonempty ι] {S : ι → NonUnitalStarSubalgebra R
 subalgebras by defining it on each non-unital star subalgebra, and proving that it agrees on the
 intersection of non-unital star subalgebras. -/
 noncomputable def iSupLift [Nonempty ι] (K : ι → NonUnitalStarSubalgebra R A)
-    (dir : Directed (· ≤ ·) K) (f : ∀ i, K i →⋆ₙₐ[R] B)
+    (dir : Predirected (· ≤ ·) K) (f : ∀ i, K i →⋆ₙₐ[R] B)
     (hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h))
     (T : NonUnitalStarSubalgebra R A) (hT : T = iSup K) : ↥T →⋆ₙₐ[R] B := by
   subst hT
@@ -1087,7 +1087,7 @@ noncomputable def iSupLift [Nonempty ι] (K : ι → NonUnitalStarSubalgebra R A
 
 end StarSubalgebraB
 
-variable [Nonempty ι] {K : ι → NonUnitalStarSubalgebra R A} {dir : Directed (· ≤ ·) K}
+variable [Nonempty ι] {K : ι → NonUnitalStarSubalgebra R A} {dir : Predirected (· ≤ ·) K}
   {f : ∀ i, K i →⋆ₙₐ[R] B} {hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h)}
   {T : NonUnitalStarSubalgebra R A} {hT : T = iSup K}
 

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -108,7 +108,7 @@ theorem convex_pi {ι : Type*} {E : ι → Type*} [∀ i, AddCommMonoid (E i)] [
     {s : Set ι} {t : ∀ i, Set (E i)} (ht : ∀ ⦃i⦄, i ∈ s → Convex 𝕜 (t i)) : Convex 𝕜 (s.pi t) :=
   fun _ hx => starConvex_pi fun _ hi => ht hi <| hx _ hi
 
-theorem Directed.convex_iUnion {ι : Sort*} {s : ι → Set E} (hdir : Directed (· ⊆ ·) s)
+theorem Predirected.convex_iUnion {ι : Sort*} {s : ι → Set E} (hdir : Predirected (· ⊆ ·) s)
     (hc : ∀ ⦃i : ι⦄, Convex 𝕜 (s i)) : Convex 𝕜 (⋃ i, s i) := by
   rintro x hx y hy a b ha hb hab
   rw [mem_iUnion] at hx hy ⊢

--- a/Mathlib/Analysis/Convex/Strict.lean
+++ b/Mathlib/Analysis/Convex/Strict.lean
@@ -77,7 +77,7 @@ protected theorem StrictConvex.inter {t : Set E} (hs : StrictConvex 𝕜 s) (ht 
   rw [interior_inter]
   exact ⟨hs hx.1 hy.1 hxy ha hb hab, ht hx.2 hy.2 hxy ha hb hab⟩
 
-theorem Directed.strictConvex_iUnion {ι : Sort*} {s : ι → Set E} (hdir : Directed (· ⊆ ·) s)
+theorem Predirected.strictConvex_iUnion {ι : Sort*} {s : ι → Set E} (hdir : Predirected (· ⊆ ·) s)
     (hs : ∀ ⦃i : ι⦄, StrictConvex 𝕜 (s i)) : StrictConvex 𝕜 (⋃ i, s i) := by
   rintro x hx y hy hxy a b ha hb hab
   rw [mem_iUnion] at hx hy

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -242,7 +242,7 @@ theorem orthonormal_empty : Orthonormal 𝕜 (fun x => x : (∅ : Set E) → E) 
 
 variable {𝕜 E}
 
-theorem orthonormal_iUnion_of_directed {η : Type*} {s : η → Set E} (hs : Directed (· ⊆ ·) s)
+theorem orthonormal_iUnion_of_directed {η : Type*} {s : η → Set E} (hs : Predirected (· ⊆ ·) s)
     (h : ∀ i, Orthonormal 𝕜 (fun x => x : s i → E)) :
     Orthonormal 𝕜 (fun x => x : (⋃ i, s i) → E) := by
   classical

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -680,7 +680,7 @@ theorem cospan {i j j' : C} (f : j ⟶ i) (f' : j' ⟶ i) :
   ⟨k, e ≫ G, e ≫ G', by simpa only [Category.assoc] using he⟩
 
 theorem _root_.CategoryTheory.Functor.ranges_directed (F : C ⥤ Type*) (j : C) :
-    Directed (· ⊇ ·) fun f : Σ' i, i ⟶ j => Set.range (F.map f.2) := fun ⟨i, ij⟩ ⟨k, kj⟩ => by
+    Predirected (· ⊇ ·) fun f : Σ' i, i ⟶ j => Set.range (F.map f.2) := fun ⟨i, ij⟩ ⟨k, kj⟩ => by
   let ⟨l, li, lk, e⟩ := cospan ij kj
   refine ⟨⟨l, lk ≫ kj⟩, e ▸ ?_, ?_⟩ <;>
     simp_rw [F.map_comp] <;>

--- a/Mathlib/Data/Finset/Order.lean
+++ b/Mathlib/Data/Finset/Order.lean
@@ -20,8 +20,8 @@ universe u v w
 
 variable {α : Type u}
 
-theorem Directed.finset_le {r : α → α → Prop} [IsTrans α r] {ι} [hι : Nonempty ι] {f : ι → α}
-    (D : Directed r f) (s : Finset ι) : ∃ z, ∀ i ∈ s, r (f i) (f z) :=
+theorem Predirected.finset_le {r : α → α → Prop} [IsTrans α r] {ι} [hι : Nonempty ι] {f : ι → α}
+    (D : Predirected r f) (s : Finset ι) : ∃ z, ∀ i ∈ s, r (f i) (f z) :=
   show ∃ z, ∀ i ∈ s.1, r (f i) (f z) from
     Multiset.induction_on s.1 (let ⟨z⟩ := hι; ⟨z, fun _ ↦ by simp⟩)
       fun i _ ⟨j, H⟩ ↦

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -185,11 +185,11 @@ section DirectedOrders
 variable {α : Type*} {r : α → α → Prop} [IsTrans α r] {β γ : Type*} [Nonempty γ] {f : γ → α}
   [Finite β]
 
-theorem Directed.finite_set_le (D : Directed r f) {s : Set γ} (hs : s.Finite) :
+theorem Predirected.finite_set_le (D : Predirected r f) {s : Set γ} (hs : s.Finite) :
     ∃ z, ∀ i ∈ s, r (f i) (f z) := by
   convert D.finset_le hs.toFinset using 3; rw [Set.Finite.mem_toFinset]
 
-theorem Directed.finite_le (D : Directed r f) (g : β → γ) : ∃ z, ∀ i, r (f (g i)) (f z) := by
+theorem Predirected.finite_le (D : Predirected r f) (g : β → γ) : ∃ z, ∀ i, r (f (g i)) (f z) := by
   classical
     obtain ⟨z, hz⟩ := D.finite_set_le (Set.finite_range g)
     exact ⟨z, fun i => hz (g i) ⟨i, rfl⟩⟩

--- a/Mathlib/Data/Set/Accumulate.lean
+++ b/Mathlib/Data/Set/Accumulate.lean
@@ -97,7 +97,7 @@ lemma partialSups_eq_accumulate (f : ℕ → Set α) :
 /-- For a directed set of sets `s : ℕ → Set α` and `n : ℕ`, there exists `m : ℕ` (maybe
 larger than `n`) such that `accumulate s n ⊆ s m`. -/
 lemma exists_subset_accumulate_of_directed {s : ℕ → Set α}
-  (hd : Directed (· ⊆ ·) s) (n : ℕ) : ∃ m, accumulate s n ⊆ s m := by
+  (hd : Predirected (· ⊆ ·) s) (n : ℕ) : ∃ m, accumulate s n ⊆ s m := by
   induction n with
   | zero => use 0; simp [accumulate_def]
   | succ n hn =>
@@ -106,10 +106,10 @@ lemma exists_subset_accumulate_of_directed {s : ℕ → Set α}
     simp at hk
     exact ⟨k, by simp; grind⟩
 
-lemma directed_accumulate {s : ℕ → Set α} : Directed (· ⊆ ·) (accumulate s) :=
+lemma directed_accumulate {s : ℕ → Set α} : Predirected (· ⊆ ·) (accumulate s) :=
   monotone_accumulate.directed_le
 
-lemma exists_accumulate_eq_univ_iff_of_directed {s : ℕ → Set α} (hd : Directed (· ⊆ ·) s) :
+lemma exists_accumulate_eq_univ_iff_of_directed {s : ℕ → Set α} (hd : Predirected (· ⊆ ·) s) :
     (∃ n, accumulate s n = univ) ↔ ∃ n, s n = univ := by
   refine ⟨?_, fun ⟨n, hn⟩ ↦ ⟨n,
     subset_antisymm (subset_univ _) (hn.symm.le.trans subset_accumulate)⟩⟩

--- a/Mathlib/Data/Set/Dissipate.lean
+++ b/Mathlib/Data/Set/Dissipate.lean
@@ -86,7 +86,7 @@ theorem dissipate_succ (s : ℕ → Set α) (n : ℕ) :
 /-- For a directed set of sets `s : ℕ → Set α` and `n : ℕ`, there exists `m : ℕ` (maybe
 larger than `n`) such that `s m ⊆ dissipate s n`. -/
 lemma exists_subset_dissipate_of_directed {s : ℕ → Set α}
-  (hd : Directed (· ⊇ ·) s) (n : ℕ) : ∃ m, s m ⊆ dissipate s n := by
+  (hd : Predirected (· ⊇ ·) s) (n : ℕ) : ∃ m, s m ⊆ dissipate s n := by
   induction n with
   | zero => use 0; simp [dissipate_def]
   | succ n hn =>
@@ -94,10 +94,10 @@ lemma exists_subset_dissipate_of_directed {s : ℕ → Set α}
     obtain ⟨k, hk⟩ := hd m (n + 1)
     exact ⟨k, by simp; grind⟩
 
-lemma directed_dissipate {s : ℕ → Set α} : Directed (· ⊇ ·) (dissipate s) :=
+lemma directed_dissipate {s : ℕ → Set α} : Predirected (· ⊇ ·) (dissipate s) :=
   antitone_dissipate.directed_ge
 
-lemma exists_dissipate_eq_empty_iff_of_directed {s : ℕ → Set α} (hd : Directed (· ⊇ ·) s) :
+lemma exists_dissipate_eq_empty_iff_of_directed {s : ℕ → Set α} (hd : Predirected (· ⊇ ·) s) :
     (∃ n, dissipate s n = ∅) ↔ ∃ n, s n = ∅ := by
   refine ⟨?_, fun ⟨n, hn⟩ ↦ ⟨n, subset_eq_empty (dissipate_subset le_rfl) hn⟩⟩
   contrapose!

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -450,8 +450,8 @@ lemma Set.finite_diff_iUnion_Ioo (s : Set α) : (s \ ⋃ (x ∈ s) (y ∈ s), Io
 lemma Set.finite_diff_iUnion_Ioo' (s : Set α) : (s \ ⋃ x : s × s, Ioo x.1 x.2).Finite := by
   simpa only [iUnion, iSup_prod, iSup_subtype] using s.finite_diff_iUnion_Ioo
 
-lemma Directed.exists_mem_subset_of_finset_subset_biUnion {α ι : Type*} [Nonempty ι]
-    {f : ι → Set α} (h : Directed (· ⊆ ·) f) {s : Finset α} (hs : (s : Set α) ⊆ ⋃ i, f i) :
+lemma Predirected.exists_mem_subset_of_finset_subset_biUnion {α ι : Type*} [Nonempty ι]
+    {f : ι → Set α} (h : Predirected (· ⊆ ·) f) {s : Finset α} (hs : (s : Set α) ⊆ ⋃ i, f i) :
     ∃ i, (s : Set α) ⊆ f i := by
   induction s using Finset.cons_induction with
   | empty => simp

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1174,7 +1174,7 @@ end Pi
 
 section Directed
 
-theorem directedOn_iUnion {r} {f : ι → Set α} (hd : Directed (· ⊆ ·) f)
+theorem directedOn_iUnion {r} {f : ι → Set α} (hd : Predirected (· ⊆ ·) f)
     (h : ∀ x, DirectedOn r (f x)) : DirectedOn r (⋃ x, f x) := by
   simp only [DirectedOn, mem_iUnion, exists_imp]
   exact fun a₁ b₁ fb₁ a₂ b₂ fb₂ =>

--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -244,7 +244,7 @@ theorem image_iInter {f : α → β} (hf : Bijective f) (s : ι → Set α) :
 theorem image_iInter₂ {f : α → β} (hf : Bijective f) (s : ∀ i, κ i → Set α) :
     (f '' ⋂ (i) (j), s i j) = ⋂ (i) (j), f '' s i j := by simp_rw [image_iInter hf]
 
-theorem inj_on_iUnion_of_directed {s : ι → Set α} (hs : Directed (· ⊆ ·) s) {f : α → β}
+theorem inj_on_iUnion_of_directed {s : ι → Set α} (hs : Predirected (· ⊆ ·) s) {f : α → β}
     (hf : ∀ i, InjOn f (s i)) : InjOn f (⋃ i, s i) := by
   intro x hx y hy hxy
   rcases mem_iUnion.1 hx with ⟨i, hx⟩
@@ -297,11 +297,11 @@ theorem bijOn_iInter [hi : Nonempty ι] {s : ι → Set α} {t : ι → Set β} 
     hi.elim fun i => (H i).injOn.mono (iInter_subset _ _),
     surjOn_iInter_iInter (fun i => (H i).surjOn) Hinj⟩
 
-theorem bijOn_iUnion_of_directed {s : ι → Set α} (hs : Directed (· ⊆ ·) s) {t : ι → Set β}
+theorem bijOn_iUnion_of_directed {s : ι → Set α} (hs : Predirected (· ⊆ ·) s) {t : ι → Set β}
     {f : α → β} (H : ∀ i, BijOn f (s i) (t i)) : BijOn f (⋃ i, s i) (⋃ i, t i) :=
   bijOn_iUnion H <| inj_on_iUnion_of_directed hs fun i => (H i).injOn
 
-theorem bijOn_iInter_of_directed [Nonempty ι] {s : ι → Set α} (hs : Directed (· ⊆ ·) s)
+theorem bijOn_iInter_of_directed [Nonempty ι] {s : ι → Set α} (hs : Predirected (· ⊆ ·) s)
     {t : ι → Set β} {f : α → β} (H : ∀ i, BijOn f (s i) (t i)) : BijOn f (⋂ i, s i) (⋂ i, t i) :=
   bijOn_iInter H <| inj_on_iUnion_of_directed hs fun i => (H i).injOn
 

--- a/Mathlib/Data/Set/Pairwise/Lattice.lean
+++ b/Mathlib/Data/Set/Pairwise/Lattice.lean
@@ -27,7 +27,7 @@ variable {f : ι → α} {s : Set α}
 namespace Set
 
 -- TODO: fix naming inconsistency with the iUnion₂ theorems below.
-theorem pairwise_iUnion {f : κ → Set α} (hd : Directed (· ⊆ ·) f) :
+theorem pairwise_iUnion {f : κ → Set α} (hd : Predirected (· ⊆ ·) f) :
     (⋃ n, f n).Pairwise r ↔ ∀ n, (f n).Pairwise r := by
   constructor
   · intro H n
@@ -64,7 +64,7 @@ section PartialOrderBot
 
 variable [PartialOrder α] [OrderBot α] {s : Set ι} {f : ι → α}
 
-theorem pairwiseDisjoint_iUnion {g : ι' → Set ι} (h : Directed (· ⊆ ·) g) :
+theorem pairwiseDisjoint_iUnion {g : ι' → Set ι} (h : Predirected (· ⊆ ·) g) :
     (⋃ n, g n).PairwiseDisjoint f ↔ ∀ ⦃n⦄, (g n).PairwiseDisjoint f :=
   pairwise_iUnion h
 

--- a/Mathlib/Data/Set/UnionLift.lean
+++ b/Mathlib/Data/Set/UnionLift.lean
@@ -119,7 +119,7 @@ theorem iUnionLift_unary (u : T → T) (ui : ∀ i, S i → S i)
   of algebraic structures when defined on the Union of algebraic subobjects.
   For example, it could be used to prove that the lift of a collection
   of group homomorphisms on a union of subgroups preserves `*`. -/
-theorem iUnionLift_binary (dir : Directed (· ≤ ·) S) (op : T → T → T) (opi : ∀ i, S i → S i → S i)
+theorem iUnionLift_binary (dir : Predirected (· ≤ ·) S) (op : T → T → T) (opi : ∀ i, S i → S i → S i)
     (hopi :
       ∀ i x y,
         Set.inclusion (show S i ⊆ T from hT'.symm ▸ Set.subset_iUnion S i) (opi i x y) =

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -28,7 +28,7 @@ variable {α : Type*} {f : α → α} {x y : α}
 
 open Function (Commute)
 
-theorem directed_ptsOfPeriod_pnat (f : α → α) : Directed (· ⊆ ·) fun n : ℕ+ => ptsOfPeriod f n :=
+theorem directed_ptsOfPeriod_pnat (f : α → α) : Predirected (· ⊆ ·) fun n : ℕ+ => ptsOfPeriod f n :=
   fun m n => ⟨m * n, fun _ hx => hx.mul_const n, fun _ hx => hx.const_mul m⟩
 
 variable (f) in

--- a/Mathlib/FieldTheory/CardinalEmb.lean
+++ b/Mathlib/FieldTheory/CardinalEmb.lean
@@ -256,7 +256,7 @@ section Lim
 
 variable {i : WithTop (Module.rank F E).ord.ToType} -- WithTop ι doesn't work
 
-theorem directed_filtration : Directed (· ≤ ·) fun j : Iio i ↦ filtration j.1 :=
+theorem directed_filtration : Predirected (· ≤ ·) fun j : Iio i ↦ filtration j.1 :=
   (filtration.monotone.comp <| Subtype.mono_coe _).directed_le
 
 variable (hi : IsSuccPrelimit i)

--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -111,7 +111,7 @@ variable (c : Set (Lifts F E K)) (hc : IsChain (· ≤ ·) c)
 noncomputable def union : Lifts F E K :=
   let t (i : ↑(insert ⊥ c)) := i.val.carrier
   have hc := hc.insert fun _ _ _ ↦ .inl bot_le
-  have dir : Directed (· ≤ ·) t := hc.directedOn.directed_val.mono_comp _ fun _ _ h ↦ h.1
+  have dir : Predirected (· ≤ ·) t := hc.directedOn.directed_val.mono_comp _ fun _ _ h ↦ h.1
   ⟨iSup t, (Subalgebra.iSupLift (toSubalgebra <| t ·) dir (·.val.emb) (fun i j h ↦
     AlgHom.ext fun x ↦ (hc.total i.2 j.2).elim (fun hij ↦ (hij.snd x).symm) fun hji ↦ by
       rw [AlgHom.comp_apply, ← inclusion]

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -111,7 +111,7 @@ theorem finrank_sup_le :
 
 variable {ι : Type*} {t : ι → IntermediateField K L}
 
-theorem coe_iSup_of_directed [Nonempty ι] (dir : Directed (· ≤ ·) t) :
+theorem coe_iSup_of_directed [Nonempty ι] (dir : Predirected (· ≤ ·) t) :
     ↑(iSup t) = ⋃ i, (t i : Set L) :=
   let M : IntermediateField K L :=
     { __ := Subalgebra.copy _ _ (Subalgebra.coe_iSup_of_directed dir).symm
@@ -121,7 +121,7 @@ theorem coe_iSup_of_directed [Nonempty ι] (dir : Directed (· ≤ ·) t) :
     (iSup_le fun i ↦ le_iSup (fun i ↦ (t i : Set L)) i) (Set.iUnion_subset fun _ ↦ le_iSup t _)
   this.symm ▸ rfl
 
-theorem toSubalgebra_iSup_of_directed (dir : Directed (· ≤ ·) t) :
+theorem toSubalgebra_iSup_of_directed (dir : Predirected (· ≤ ·) t) :
     (iSup t).toSubalgebra = ⨆ i, (t i).toSubalgebra := by
   cases isEmpty_or_nonempty ι
   · simp_rw [iSup_of_empty, bot_toSubalgebra]

--- a/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
@@ -77,13 +77,13 @@ def genEigenspace (f : End R M) (μ : R) : ℕ∞ →o Submodule R M where
 lemma mem_genEigenspace {f : End R M} {μ : R} {k : ℕ∞} {x : M} :
     x ∈ f.genEigenspace μ k ↔ ∃ l : ℕ, l ≤ k ∧ x ∈ LinearMap.ker ((f - μ • 1) ^ l) := by
   have : Nonempty {l : ℕ // l ≤ k} := ⟨⟨0, zero_le⟩⟩
-  have : Directed (ι := { i : ℕ // i ≤ k }) (· ≤ ·) fun i ↦ LinearMap.ker ((f - μ • 1) ^ (i : ℕ)) :=
+  have : Predirected (ι := { i : ℕ // i ≤ k }) (· ≤ ·) fun i ↦ LinearMap.ker ((f - μ • 1) ^ (i : ℕ)) :=
     Monotone.directed_le fun m n h ↦ by simpa using (f - μ • 1).iterateKer.monotone h
   simp_rw [genEigenspace, OrderHom.coe_mk, LinearMap.mem_ker, iSup_subtype',
     Submodule.mem_iSup_of_directed _ this, LinearMap.mem_ker, Subtype.exists, exists_prop]
 
 lemma genEigenspace_directed {f : End R M} {μ : R} {k : ℕ∞} :
-    Directed (· ≤ ·) (fun l : {l : ℕ // l ≤ k} ↦ f.genEigenspace μ l) := by
+    Predirected (· ≤ ·) (fun l : {l : ℕ // l ≤ k} ↦ f.genEigenspace μ l) := by
   have aux : Monotone ((↑) : {l : ℕ // l ≤ k} → ℕ∞) := fun x y h ↦ by simpa using h
   exact ((genEigenspace f μ).monotone.comp aux).directed_le
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -104,7 +104,7 @@ lemma LinearIndependent.eq_zero_of_pair {x y : M} (h : LinearIndependent R ![x, 
 
 section Indexed
 
-theorem linearIndepOn_iUnion_of_directed {η : Type*} {s : η → Set ι} (hs : Directed (· ⊆ ·) s)
+theorem linearIndepOn_iUnion_of_directed {η : Type*} {s : η → Set ι} (hs : Predirected (· ⊆ ·) s)
     (h : ∀ i, LinearIndepOn R v (s i)) : LinearIndepOn R v (⋃ i, s i) := by
   by_cases hη : Nonempty η
   · refine linearIndepOn_of_finite (⋃ i, s i) fun t ht ft => ?_

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -345,7 +345,7 @@ theorem subset_span_trans {U V W : Set M} (hUV : U ⊆ Submodule.span R V)
 
 @[simp]
 theorem coe_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M)
-    (H : Directed (· ≤ ·) S) : ((iSup S : Submodule R M) : Set M) = ⋃ i, S i :=
+    (H : Predirected (· ≤ ·) S) : ((iSup S : Submodule R M) : Set M) = ⋃ i, S i :=
   let s : Submodule R M :=
     { __ := AddSubmonoid.copy _ _ (AddSubmonoid.coe_iSup_of_directed H).symm
       smul_mem' := fun r _ hx ↦ have ⟨i, hi⟩ := Set.mem_iUnion.mp hx
@@ -355,7 +355,7 @@ theorem coe_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M)
   this.symm ▸ rfl
 
 @[simp]
-theorem mem_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M) (H : Directed (· ≤ ·) S) {x} :
+theorem mem_iSup_of_directed {ι} [Nonempty ι] (S : ι → Submodule R M) (H : Predirected (· ≤ ·) S) {x} :
     x ∈ iSup S ↔ ∃ i, x ∈ S i := by
   rw [← SetLike.mem_coe, coe_iSup_of_directed S H, mem_iUnion]
   rfl

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -542,7 +542,8 @@ instance {α} [Encodable α] : Std.Total (Encodable.encode' α ⁻¹'o (· ≤ �
 
 end Encodable
 
-namespace Directed
+namespace Predirected
+
 
 open Encodable
 
@@ -551,32 +552,32 @@ variable {α : Type*} {β : Type*} [Encodable α] [Inhabited α]
 /-- Given a `Directed r` function `f : α → β` defined on an encodable inhabited type,
 construct a noncomputable sequence such that `r (f (x n)) (f (x (n + 1)))`
 and `r (f a) (f (x (encode a + 1))`. -/
-protected noncomputable def sequence {r : β → β → Prop} (f : α → β) (hf : Directed r f) : ℕ → α
+protected noncomputable def sequence {r : β → β → Prop} (f : α → β) (hf : Predirected r f) : ℕ → α
   | 0 => default
   | n + 1 =>
-    let p := Directed.sequence f hf n
+    let p := Predirected.sequence f hf n
     match (decode n : Option α) with
     | none => Classical.choose (hf p p)
     | some a => Classical.choose (hf p a)
 
-theorem sequence_mono_nat {r : β → β → Prop} {f : α → β} (hf : Directed r f) (n : ℕ) :
+theorem sequence_mono_nat {r : β → β → Prop} {f : α → β} (hf : Predirected r f) (n : ℕ) :
     r (f (hf.sequence f n)) (f (hf.sequence f (n + 1))) := by
-  dsimp [Directed.sequence]
+  dsimp [Predirected.sequence]
   generalize hf.sequence f n = p
   rcases (decode n : Option α) with - | a
   · exact (Classical.choose_spec (hf p p)).1
   · exact (Classical.choose_spec (hf p a)).1
 
-theorem rel_sequence {r : β → β → Prop} {f : α → β} (hf : Directed r f) (a : α) :
+theorem rel_sequence {r : β → β → Prop} {f : α → β} (hf : Predirected r f) (a : α) :
     r (f a) (f (hf.sequence f (encode a + 1))) := by
-  simp only [Directed.sequence, encodek]
+  simp only [Predirected.sequence, encodek]
   exact (Classical.choose_spec (hf _ a)).2
 
 variable [Preorder β] {f : α → β}
 
 section
 
-variable (hf : Directed (· ≤ ·) f)
+variable (hf : Predirected (· ≤ ·) f)
 
 theorem sequence_mono : Monotone (f ∘ hf.sequence f) :=
   monotone_nat_of_le_succ <| hf.sequence_mono_nat
@@ -588,7 +589,7 @@ end
 
 section
 
-variable (hf : Directed (· ≥ ·) f)
+variable (hf : Predirected (· ≥ ·) f)
 
 theorem sequence_anti : Antitone (f ∘ hf.sequence f) :=
   antitone_nat_of_succ_le <| hf.sequence_mono_nat
@@ -598,7 +599,7 @@ theorem sequence_le (a : α) : f (hf.sequence f (Encodable.encode a + 1)) ≤ f 
 
 end
 
-end Directed
+end Predirected
 
 section Quotient
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1056,7 +1056,7 @@ theorem restrict_lintegral_eq_lintegral_restrict (f : α →ₛ ℝ≥0∞) {s :
   rw [f.restrict_lintegral hs, lintegral_restrict]
 
 theorem lintegral_restrict_iUnion_of_directed {ι : Type*} [Countable ι]
-    (f : α →ₛ ℝ≥0∞) {s : ι → Set α} (hd : Directed (· ⊆ ·) s) (μ : Measure α) :
+    (f : α →ₛ ℝ≥0∞) {s : ι → Set α} (hd : Predirected (· ⊆ ·) s) (μ : Measure α) :
     f.lintegral (μ.restrict (⋃ i, s i)) = ⨆ i, f.lintegral (μ.restrict (s i)) := by
   simp only [lintegral, Measure.restrict_iUnion_apply_eq_iSup hd (measurableSet_preimage ..),
     ENNReal.mul_iSup]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
@@ -150,7 +150,7 @@ open Encodable in
 /-- **Monotone convergence theorem** for a supremum over a directed family and indexed by a
 countable type. -/
 theorem lintegral_iSup_directed_of_measurable [Countable β] {f : β → α → ℝ≥0∞}
-    (hf : ∀ b, Measurable (f b)) (h_directed : Directed (· ≤ ·) f) :
+    (hf : ∀ b, Measurable (f b)) (h_directed : Predirected (· ≤ ·) f) :
     ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ := by
   cases nonempty_encodable β
   cases isEmpty_or_nonempty β
@@ -172,14 +172,14 @@ theorem lintegral_iSup_directed_of_measurable [Countable β] {f : β → α → 
 /-- **Monotone convergence theorem** for a supremum over a directed family and indexed by a
 countable type. -/
 theorem lintegral_iSup_directed [Countable β] {f : β → α → ℝ≥0∞} (hf : ∀ b, AEMeasurable (f b) μ)
-    (h_directed : Directed (· ≤ ·) f) : ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ := by
+    (h_directed : Predirected (· ≤ ·) f) : ∫⁻ a, ⨆ b, f b a ∂μ = ⨆ b, ∫⁻ a, f b a ∂μ := by
   simp_rw [← iSup_apply]
-  let p : α → (β → ENNReal) → Prop := fun x f' => Directed LE.le f'
+  let p : α → (β → ENNReal) → Prop := fun x f' => Predirected LE.le f'
   have hp : ∀ᵐ x ∂μ, p x fun i => f i x := by
     filter_upwards [] with x i j
     obtain ⟨z, hz₁, hz₂⟩ := h_directed i j
     exact ⟨z, hz₁ x, hz₂ x⟩
-  have h_ae_seq_directed : Directed LE.le (aeSeq hf p) := by
+  have h_ae_seq_directed : Predirected LE.le (aeSeq hf p) := by
     intro b₁ b₂
     obtain ⟨z, hz₁, hz₂⟩ := h_directed b₁ b₂
     refine ⟨z, ?_, ?_⟩ <;>

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -639,7 +639,7 @@ theorem setLIntegral_compl {f : α → ℝ≥0∞} {s : Set α} (hsm : Measurabl
   rw [← lintegral_add_compl (μ := μ) f hsm, ENNReal.add_sub_cancel_left hfs]
 
 theorem setLIntegral_iUnion_of_directed {ι : Type*} [Countable ι]
-    (f : α → ℝ≥0∞) {s : ι → Set α} (hd : Directed (· ⊆ ·) s) :
+    (f : α → ℝ≥0∞) {s : ι → Set α} (hd : Predirected (· ⊆ ·) s) :
     ∫⁻ x in ⋃ i, s i, f x ∂μ = ⨆ i, ∫⁻ x in s i, f x ∂μ := by
   simp only [lintegral_def, iSup_comm (ι := ι),
     SimpleFunc.lintegral_restrict_iUnion_of_directed _ hd]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
@@ -106,7 +106,7 @@ theorem lintegral_iInf' {f : ℕ → α → ℝ≥0∞} (h_meas : ∀ n, AEMeasu
 countable type. -/
 theorem lintegral_iInf_directed_of_measurable [Countable β]
     {f : β → α → ℝ≥0∞} {μ : Measure α} (hμ : μ ≠ 0) (hf : ∀ b, Measurable (f b))
-    (hf_int : ∀ b, ∫⁻ a, f b a ∂μ ≠ ∞) (h_directed : Directed (· ≥ ·) f) :
+    (hf_int : ∀ b, ∫⁻ a, f b a ∂μ ≠ ∞) (h_directed : Predirected (· ≥ ·) f) :
     ∫⁻ a, ⨅ b, f b a ∂μ = ⨅ b, ∫⁻ a, f b a ∂μ := by
   cases nonempty_encodable β
   cases isEmpty_or_nonempty β

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -447,12 +447,12 @@ theorem nonempty_inter_of_measure_lt_add' {m : MeasurableSpace α} (μ : Measure
 /-- Continuity from below:
 the measure of the union of a directed sequence of (not necessarily measurable) sets
 is the supremum of the measures. -/
-theorem _root_.Directed.measure_iUnion [Countable ι] {s : ι → Set α} (hd : Directed (· ⊆ ·) s) :
+theorem _root_.Predirected.measure_iUnion [Countable ι] {s : ι → Set α} (hd : Predirected (· ⊆ ·) s) :
     μ (⋃ i, s i) = ⨆ i, μ (s i) := by
   -- WLOG, `ι = ℕ`
   rcases Countable.exists_injective_nat ι with ⟨e, he⟩
   generalize ht : Function.extend e s ⊥ = t
-  replace hd : Directed (· ⊆ ·) t := ht ▸ hd.extend_bot he
+  replace hd : Predirected (· ⊆ ·) t := ht ▸ hd.extend_bot he
   suffices μ (⋃ n, t n) = ⨆ n, μ (t n) by
     simp only [← ht, Function.apply_extend μ, ← iSup_eq_iUnion, iSup_extend_bot he,
       Function.comp_def, Pi.bot_apply, bot_eq_empty, measure_empty] at this
@@ -513,15 +513,15 @@ theorem measure_biUnion_eq_iSup {s : ι → Set α} {t : Set ι} (ht : t.Countab
 /-- **Continuity from above**:
 the measure of the intersection of a directed downwards countable family of measurable sets
 is the infimum of the measures. -/
-theorem _root_.Directed.measure_iInter [Countable ι] {s : ι → Set α}
-    (h : ∀ i, NullMeasurableSet (s i) μ) (hd : Directed (· ⊇ ·) s) (hfin : ∃ i, μ (s i) ≠ ∞) :
+theorem _root_.Predirected.measure_iInter [Countable ι] {s : ι → Set α}
+    (h : ∀ i, NullMeasurableSet (s i) μ) (hd : Predirected (· ⊇ ·) s) (hfin : ∃ i, μ (s i) ≠ ∞) :
     μ (⋂ i, s i) = ⨅ i, μ (s i) := by
   rcases hfin with ⟨k, hk⟩
   have : ∀ t ⊆ s k, μ t ≠ ∞ := fun t ht => ne_top_of_le_ne_top hk (measure_mono ht)
   rw [← ENNReal.sub_sub_cancel hk (iInf_le (fun i => μ (s i)) k), ENNReal.sub_iInf, ←
     ENNReal.sub_sub_cancel hk (measure_mono (iInter_subset _ k)), ←
     measure_diff (iInter_subset _ k) (.iInter h) (this _ (iInter_subset _ k)),
-    diff_iInter, Directed.measure_iUnion]
+    diff_iInter, Predirected.measure_iUnion]
   · congr 1
     refine le_antisymm (iSup_mono' fun i => ?_) (iSup_mono fun i => le_measure_diff)
     rcases hd i k with ⟨j, hji, hjk⟩

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -307,10 +307,10 @@ theorem restrict_iUnion_apply [Countable ι] {s : ι → Set α} (hd : Pairwise 
     μ.restrict (⋃ i, s i) t = ∑' i, μ.restrict (s i) t :=
   restrict_iUnion_apply_ae hd.aedisjoint (fun i => (hm i).nullMeasurableSet) ht
 
-theorem restrict_iUnion_apply_eq_iSup [Countable ι] {s : ι → Set α} (hd : Directed (· ⊆ ·) s)
+theorem restrict_iUnion_apply_eq_iSup [Countable ι] {s : ι → Set α} (hd : Predirected (· ⊆ ·) s)
     {t : Set α} (ht : MeasurableSet t) : μ.restrict (⋃ i, s i) t = ⨆ i, μ.restrict (s i) t := by
   simp only [restrict_apply ht, inter_iUnion]
-  rw [Directed.measure_iUnion]
+  rw [Predirected.measure_iUnion]
   exacts [hd.mono_comp _ fun s₁ s₂ => inter_subset_inter_right _]
 
 /-- The restriction of the pushforward measure is the pushforward of the restriction. For a version
@@ -384,7 +384,7 @@ theorem restrict_iUnion_congr [Countable ι] {s : ι → Set α} :
     μ.restrict (⋃ i, s i) = ν.restrict (⋃ i, s i) ↔ ∀ i, μ.restrict (s i) = ν.restrict (s i) := by
   refine ⟨fun h i => restrict_congr_mono (subset_iUnion _ _) h, fun h => ?_⟩
   ext1 t ht
-  have D : Directed (· ⊆ ·) fun t : Finset ι => ⋃ i ∈ t, s i :=
+  have D : Predirected (· ⊆ ·) fun t : Finset ι => ⋃ i ∈ t, s i :=
     Monotone.directed_le fun t₁ t₂ ht => biUnion_subset_biUnion_left ht
   rw [iUnion_eq_iUnion_finset]
   simp only [restrict_iUnion_apply_eq_iSup D ht, restrict_biUnion_finset_congr.2 fun i _ => h i]

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -120,7 +120,7 @@ lemma IsPiSystem.dissipate_mem {s : ℕ → Set α} {C : Set (Set α)}
     exact hC (dissipate s n) (hn h'.left) (s (n + 1)) (h (n + 1)) h'
 
 theorem isPiSystem_iUnion_of_directed_le {α ι} (p : ι → Set (Set α))
-    (hp_pi : ∀ n, IsPiSystem (p n)) (hp_directed : Directed (· ≤ ·) p) :
+    (hp_pi : ∀ n, IsPiSystem (p n)) (hp_directed : Predirected (· ≤ ·) p) :
     IsPiSystem (⋃ n, p n) := by
   intro t1 ht1 t2 ht2 h
   rw [Set.mem_iUnion] at ht1 ht2 ⊢

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -119,7 +119,7 @@ theorem isSatisfiable_iff_isFinitelySatisfiable {T : L.Theory} :
       exact ⟨ModelType.of T M'⟩⟩
 
 theorem isSatisfiable_directed_union_iff {ι : Type*} [Nonempty ι] {T : ι → L.Theory}
-    (h : Directed (· ⊆ ·) T) : Theory.IsSatisfiable (⋃ i, T i) ↔ ∀ i, (T i).IsSatisfiable := by
+    (h : Predirected (· ⊆ ·) T) : Theory.IsSatisfiable (⋃ i, T i) ↔ ∀ i, (T i).IsSatisfiable := by
   refine ⟨fun h' i => h'.mono (Set.subset_iUnion _ _), fun h' => ?_⟩
   rw [isSatisfiable_iff_isFinitelySatisfiable, IsFinitelySatisfiable]
   intro T0 hT0
@@ -183,7 +183,7 @@ theorem isSatisfiable_iUnion_iff_isSatisfiable_iUnion_finset {ι : Type*} (T : �
     rw [isSatisfiable_iff_isFinitelySatisfiable]
     intro s hs
     rw [Set.iUnion_eq_iUnion_finset] at hs
-    obtain ⟨t, ht⟩ := Directed.exists_mem_subset_of_finset_subset_biUnion (by
+    obtain ⟨t, ht⟩ := Predirected.exists_mem_subset_of_finset_subset_biUnion (by
       exact Monotone.directed_le fun t1 t2 (h : ∀ ⦃x⦄, x ∈ t1 → x ∈ t2) =>
         Set.iUnion_mono fun _ => Set.iUnion_mono' fun h1 => ⟨h h1, refl _⟩) hs
     exact (h t).mono ht

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -386,7 +386,7 @@ theorem iSup_eq_closure {ι : Sort*} (S : ι → L.Substructure M) :
 
 -- This proof uses the fact that `Substructure.closure` is finitary.
 theorem mem_iSup_of_directed {ι : Type*} [hι : Nonempty ι] {S : ι → L.Substructure M}
-    (hS : Directed (· ≤ ·) S) {x : M} :
+    (hS : Predirected (· ≤ ·) S) {x : M} :
     x ∈ ⨆ i, S i ↔ ∃ i, x ∈ S i := by
   refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
   suffices x ∈ closure L (⋃ i, (S i : Set M)) → ∃ i, x ∈ S i by

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -881,7 +881,7 @@ theorem monotone_distinctConstantsTheory :
   L.distinctConstantsTheory_mono st
 
 theorem directed_distinctConstantsTheory :
-    Directed (· ⊆ ·) (L.distinctConstantsTheory : Set α → L[[α]].Theory) :=
+    Predirected (· ⊆ ·) (L.distinctConstantsTheory : Set α → L[[α]].Theory) :=
   Monotone.directed_le monotone_distinctConstantsTheory
 
 theorem distinctConstantsTheory_eq_iUnion (s : Set α) :

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -392,11 +392,11 @@ protected theorem DirectedOn.sSup_inf_eq (h : DirectedOn (· ≤ ·) s) :
     sSup s ⊓ a = ⨆ b ∈ s, b ⊓ a := by
   simp_rw [inf_comm _ a, h.inf_sSup_eq]
 
-protected theorem Directed.inf_iSup_eq (h : Directed (· ≤ ·) f) :
+protected theorem Predirected.inf_iSup_eq (h : Predirected (· ≤ ·) f) :
     (a ⊓ ⨆ i, f i) = ⨆ i, a ⊓ f i := by
   rw [iSup, h.directedOn_range.inf_sSup_eq, iSup_range]
 
-protected theorem Directed.iSup_inf_eq (h : Directed (· ≤ ·) f) :
+protected theorem Predirected.iSup_inf_eq (h : Predirected (· ≤ ·) f) :
     (⨆ i, f i) ⊓ a = ⨆ i, f i ⊓ a := by
   rw [iSup, h.directedOn_range.sSup_inf_eq, iSup_range]
 
@@ -408,11 +408,11 @@ protected theorem DirectedOn.disjoint_sSup_left (h : DirectedOn (· ≤ ·) s) :
     Disjoint (sSup s) a ↔ ∀ ⦃b⦄, b ∈ s → Disjoint b a := by
   simp_rw [disjoint_iff, h.sSup_inf_eq, iSup_eq_bot]
 
-protected theorem Directed.disjoint_iSup_right (h : Directed (· ≤ ·) f) :
+protected theorem Predirected.disjoint_iSup_right (h : Predirected (· ≤ ·) f) :
     Disjoint a (⨆ i, f i) ↔ ∀ i, Disjoint a (f i) := by
   simp_rw [disjoint_iff, h.inf_iSup_eq, iSup_eq_bot]
 
-protected theorem Directed.disjoint_iSup_left (h : Directed (· ≤ ·) f) :
+protected theorem Predirected.disjoint_iSup_left (h : Predirected (· ≤ ·) f) :
     Disjoint (⨆ i, f i) a ↔ ∀ i, Disjoint (f i) a := by
   simp_rw [disjoint_iff, h.iSup_inf_eq, iSup_eq_bot]
 
@@ -500,7 +500,7 @@ lemma iSupIndep_iff_supIndep_of_injOn {ι : Type*} {f : ι → α}
   exact h i (Finset.mem_insert_self i _)
 
 theorem sSupIndep_iUnion_of_directed {η : Type*} {s : η → Set α}
-    (hs : Directed (· ⊆ ·) s) (h : ∀ i, sSupIndep (s i)) :
+    (hs : Predirected (· ⊆ ·) s) (h : ∀ i, sSupIndep (s i)) :
     sSupIndep (⋃ i, s i) := by
   by_cases hη : Nonempty η
   · rw [sSupIndep_iff_finite]

--- a/Mathlib/Order/CompletePartialOrder.lean
+++ b/Mathlib/Order/CompletePartialOrder.lean
@@ -72,10 +72,10 @@ hd.isLUB_sSup.1 ha
 protected lemma DirectedOn.sSup_le (hd : DirectedOn (· ≤ ·) d) (ha : ∀ b ∈ d, b ≤ a) : sSup d ≤ a :=
 hd.isLUB_sSup.2 ha
 
-protected lemma Directed.le_iSup (hf : Directed (· ≤ ·) f) (i : ι) : f i ≤ ⨆ j, f j :=
+protected lemma Predirected.le_iSup (hf : Predirected (· ≤ ·) f) (i : ι) : f i ≤ ⨆ j, f j :=
 hf.directedOn_range.le_sSup <| Set.mem_range_self _
 
-protected lemma Directed.iSup_le (hf : Directed (· ≤ ·) f) (ha : ∀ i, f i ≤ a) : ⨆ i, f i ≤ a :=
+protected lemma Predirected.iSup_le (hf : Predirected (· ≤ ·) f) (ha : ∀ i, f i ≤ a) : ⨆ i, f i ≤ a :=
 hf.directedOn_range.sSup_le <| Set.forall_mem_range.2 ha
 
 --TODO: We could mimic more `sSup`/`iSup` lemmas

--- a/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
+++ b/Mathlib/Order/ConditionallyCompletePartialOrder/Defs.lean
@@ -91,11 +91,11 @@ protected lemma DirectedOn.csSup_le (hd : DirectedOn (· ≤ ·) s) (h_non : s.N
   (hd.isLUB_csSup h_non ⟨a, ha⟩).2 ha
 
 @[to_dual ciInf_le]
-protected lemma Directed.le_ciSup (hf : Directed (· ≤ ·) f)
+protected lemma Predirected.le_ciSup (hf : Predirected (· ≤ ·) f)
     (hf_bdd : BddAbove (Set.range f)) (i : ι) : f i ≤ ⨆ j, f j :=
   hf.directedOn_range.le_csSup hf_bdd <| Set.mem_range_self _
 
 @[to_dual le_ciInf]
-protected lemma Directed.ciSup_le [Nonempty ι] (hf : Directed (· ≤ ·) f)
+protected lemma Predirected.ciSup_le [Nonempty ι] (hf : Predirected (· ≤ ·) f)
     (ha : ∀ i, f i ≤ a) : ⨆ i, f i ≤ a :=
   hf.directedOn_range.csSup_le (Set.range_nonempty _) <| Set.forall_mem_range.2 ha

--- a/Mathlib/Order/ConditionallyCompletePartialOrder/Indexed.lean
+++ b/Mathlib/Order/ConditionallyCompletePartialOrder/Indexed.lean
@@ -34,7 +34,7 @@ section ConditionallyCompletePartialOrderSup
 variable [ConditionallyCompletePartialOrderSup α] {a b : α}
 
 @[to_dual]
-theorem Directed.isLUB_ciSup [Nonempty ι] {f : ι → α} (hd : Directed (· ≤ ·) f)
+theorem Predirected.isLUB_ciSup [Nonempty ι] {f : ι → α} (hd : Predirected (· ≤ ·) f)
     (H : BddAbove (range f)) : IsLUB (range f) (⨆ i, f i) :=
   hd.directedOn_range.isLUB_csSup (range_nonempty f) H
 
@@ -45,9 +45,9 @@ theorem DirectedOn.isLUB_ciSup_set {f : β → α} {s : Set β} (hd : DirectedOn
   rw [← sSup_image']
   exact hd.isLUB_csSup (Hne.image _) H
 
-@[to_dual Directed.le_ciInf_iff]
-theorem Directed.ciSup_le_iff [Nonempty ι] {f : ι → α} {a : α}
-    (hd : Directed (· ≤ ·) f) (hf : BddAbove (range f)) :
+@[to_dual Predirected.le_ciInf_iff]
+theorem Predirected.ciSup_le_iff [Nonempty ι] {f : ι → α} {a : α}
+    (hd : Predirected (· ≤ ·) f) (hf : BddAbove (range f)) :
     iSup f ≤ a ↔ ∀ i, f i ≤ a :=
   (isLUB_le_iff <| hd.isLUB_ciSup hf).trans forall_mem_range
 
@@ -57,8 +57,8 @@ theorem DirectedOn.ciSup_set_le_iff {ι : Type*} {s : Set ι} {f : ι → α} {a
     ⨆ i : s, f i ≤ a ↔ ∀ i ∈ s, f i ≤ a :=
   (isLUB_le_iff <| hd.isLUB_ciSup_set hf hs).trans forall_mem_image
 
-@[to_dual Directed.ciInf_le_of_le]
-theorem Directed.le_ciSup_of_le {f : ι → α} (hd : Directed (· ≤ ·) f)
+@[to_dual Predirected.ciInf_le_of_le]
+theorem Predirected.le_ciSup_of_le {f : ι → α} (hd : Predirected (· ≤ ·) f)
     (H : BddAbove (range f)) (c : ι) (h : a ≤ f c) : a ≤ iSup f :=
   le_trans h (hd.le_ciSup H c)
 
@@ -66,8 +66,8 @@ theorem Directed.le_ciSup_of_le {f : ι → α} (hd : Directed (· ≤ ·) f)
 @[to_dual (attr := gcongr low)
 /-- The indexed infimum of two functions are comparable if the functions are pointwise
 comparable -/]
-theorem Directed.ciSup_mono {f g : ι → α} (hdf : Directed (· ≤ ·) f)
-    (hdg : Directed (· ≤ ·) g) (B : BddAbove (range g)) (H : ∀ x, f x ≤ g x) :
+theorem Predirected.ciSup_mono {f g : ι → α} (hdf : Predirected (· ≤ ·) f)
+    (hdg : Predirected (· ≤ ·) g) (B : BddAbove (range g)) (H : ∀ x, f x ≤ g x) :
     iSup f ≤ iSup g := by
   cases isEmpty_or_nonempty ι
   · rw [iSup_of_empty', iSup_of_empty']
@@ -134,12 +134,12 @@ theorem cbiSup_empty {f : β → α} : ⨆ i ∈ (∅ : Set β), f i = sSup ∅ 
 /-- Introduction rule to prove that `b` is the supremum of `f`: it suffices to check that `b`
 is larger than `f i` for all `i`, and that this is not the case of any `w<b`.
 See `iSup_eq_of_forall_le_of_forall_lt_exists_gt` for a version in complete lattices. -/
-@[to_dual Directed.ciInf_eq_of_forall_ge_of_forall_gt_exists_lt
+@[to_dual Predirected.ciInf_eq_of_forall_ge_of_forall_gt_exists_lt
 /-- Introduction rule to prove that `b` is the infimum of `f`: it suffices to check that `b`
 is smaller than `f i` for all `i`, and that this is not the case of any `w>b`.
 See `iInf_eq_of_forall_ge_of_forall_gt_exists_lt` for a version in complete lattices. -/]
-theorem Directed.ciSup_eq_of_forall_le_of_forall_lt_exists_gt [Nonempty ι] {f : ι → α}
-    (hd : Directed (· ≤ ·) f) (h₁ : ∀ i, f i ≤ b) (h₂ : ∀ w, w < b → ∃ i, w < f i) :
+theorem Predirected.ciSup_eq_of_forall_le_of_forall_lt_exists_gt [Nonempty ι] {f : ι → α}
+    (hd : Predirected (· ≤ ·) f) (h₁ : ∀ i, f i ≤ b) (h₂ : ∀ w, w < b → ∃ i, w < f i) :
     ⨆ i : ι, f i = b :=
   hd.directedOn_range.csSup_eq_of_forall_le_of_forall_lt_exists_gt (range_nonempty f)
     (forall_mem_range.mpr h₁) fun w hw => exists_range_iff.mpr <| h₂ w hw
@@ -152,7 +152,7 @@ theorem Monotone.ciSup_mem_iInter_Icc_of_antitone [Preorder β] [IsDirectedOrder
   refine mem_iInter.2 fun n => ?_
   haveI : Nonempty β := ⟨n⟩
   have h₁ : ∀ m, f m ≤ g n := fun m => hf.forall_le_of_antitone hg h m n
-  have h₂ : Directed (· ≤ ·) f := hf.directed_le
+  have h₂ : Predirected (· ≤ ·) f := hf.directed_le
   exact ⟨h₂.le_ciSup ⟨g <| n, forall_mem_range.2 h₁⟩ _, h₂.ciSup_le h₁⟩
 
 /-- Nested intervals lemma: if `[f n, g n]` is an antitone sequence of nonempty
@@ -165,7 +165,7 @@ theorem ciSup_mem_iInter_Icc_of_antitone_Icc [Preorder β] [IsDirectedOrder β] 
     (fun _ n hmn => ((Icc_subset_Icc_iff (h' n)).1 (h hmn)).2) h'
 
 @[to_dual]
-lemma Directed.Ici_ciSup [Nonempty ι] {f : ι → α} (hd : Directed (· ≤ ·) f)
+lemma Predirected.Ici_ciSup [Nonempty ι] {f : ι → α} (hd : Predirected (· ≤ ·) f)
     (hf : BddAbove (range f)) : Ici (⨆ i, f i) = ⋂ i, Ici (f i) := by
   ext
   simpa using hd.ciSup_le_iff hf
@@ -173,7 +173,7 @@ lemma Directed.Ici_ciSup [Nonempty ι] {f : ι → α} (hd : Directed (· ≤ ·
 @[to_dual]
 theorem ciSup_Iic [Preorder β] {f : β → α} (a : β) (hf : Monotone f) :
     ⨆ x : Iic a, f x = f a := by
-  have hd : Directed (· ≤ ·) (fun x : Iic a ↦ f x) := fun x y ↦ ⟨⟨a, le_refl a⟩, ⟨hf x.2, hf y.2⟩⟩
+  have hd : Predirected (· ≤ ·) (fun x : Iic a ↦ f x) := fun x y ↦ ⟨⟨a, le_refl a⟩, ⟨hf x.2, hf y.2⟩⟩
   have H : BddAbove (range fun x : Iic a ↦ f x) := ⟨f a, fun _ ↦ by aesop⟩
   apply (hd.le_ciSup H (⟨a, le_refl a⟩ : Iic a)).antisymm'
   rw [hd.ciSup_le_iff H]
@@ -182,9 +182,9 @@ theorem ciSup_Iic [Preorder β] {f : β → α} (a : β) (hf : Monotone f) :
 
 end ConditionallyCompletePartialOrderSup
 
-lemma Directed.ciInf_le_ciSup [ConditionallyCompletePartialOrder α] [Nonempty ι] {f : ι → α}
-    (hd : Directed (· ≥ ·) f) (hf : BddBelow (range f))
-    (hd' : Directed (· ≤ ·) f) (hf' : BddAbove (range f)) :
+lemma Predirected.ciInf_le_ciSup [ConditionallyCompletePartialOrder α] [Nonempty ι] {f : ι → α}
+    (hd : Predirected (· ≥ ·) f) (hf : BddBelow (range f))
+    (hd' : Predirected (· ≤ ·) f) (hf' : BddAbove (range f)) :
     ⨅ i, f i ≤ ⨆ i, f i :=
   (hd.ciInf_le hf (Classical.arbitrary _)).trans <| hd'.le_ciSup hf' (Classical.arbitrary _)
 
@@ -206,7 +206,7 @@ theorem l_csSup_of_directedOn (gc : GaloisConnection l u) {s : Set α} (hd : Dir
   simpa only [← comp_def, ← sSup_range, range_comp, Subtype.range_coe_subtype, setOf_mem_eq]
     using gc.l_csSup_of_directedOn' hd hne hbdd
 
-theorem l_ciSup_of_directed (gc : GaloisConnection l u) {f : ι → α} (hd : Directed (· ≤ ·) f)
+theorem l_ciSup_of_directed (gc : GaloisConnection l u) {f : ι → α} (hd : Predirected (· ≤ ·) f)
     (hf : BddAbove (range f)) : l (⨆ i, f i) = ⨆ i, l (f i) := by
   rw [iSup, gc.l_csSup_of_directedOn hd.directedOn_range (range_nonempty _) hf, iSup_range']
 
@@ -235,7 +235,7 @@ theorem u_csInf_of_directedOn' (gc : GaloisConnection l u) {s : Set β} (hd : Di
     u (sInf s) = sInf (u '' s) :=
   gc.dual.l_csSup_of_directedOn' hd hne hbdd
 
-theorem u_ciInf_of_directed (gc : GaloisConnection l u) {f : ι → β} (hd : Directed (· ≥ ·) f)
+theorem u_ciInf_of_directed (gc : GaloisConnection l u) {f : ι → β} (hd : Predirected (· ≥ ·) f)
     (hf : BddBelow (range f)) :
     u (⨅ i, f i) = ⨅ i, u (f i) :=
   gc.dual.l_ciSup_of_directed hd hf
@@ -265,7 +265,7 @@ theorem map_csSup_of_directedOn' (e : α ≃o β) {s : Set α} (hd : DirectedOn 
     (hne : s.Nonempty) (hbdd : BddAbove s) : e (sSup s) = sSup (e '' s) :=
   e.to_galoisConnection.l_csSup_of_directedOn' hd hne hbdd
 
-theorem map_ciSup_of_directed (e : α ≃o β) {f : ι → α} (hd : Directed (· ≤ ·) f)
+theorem map_ciSup_of_directed (e : α ≃o β) {f : ι → α} (hd : Predirected (· ≤ ·) f)
     (hf : BddAbove (range f)) : e (⨆ i, f i) = ⨆ i, e (f i) :=
   e.to_galoisConnection.l_ciSup_of_directed hd hf
 
@@ -291,7 +291,7 @@ theorem map_csInf_of_directedOn' (e : α ≃o β) {s : Set α} (hd : DirectedOn 
     e (sInf s) = sInf (e '' s) :=
   e.dual.map_csSup_of_directedOn' hd hne hbdd
 
-theorem map_ciInf_of_directed (e : α ≃o β) {f : ι → α} (hd : Directed (· ≥ ·) f)
+theorem map_ciInf_of_directed (e : α ≃o β) {f : ι → α} (hd : Predirected (· ≥ ·) f)
     (hf : BddBelow (range f)) :
     e (⨅ i, f i) = ⨅ i, e (f i) :=
   e.dual.map_ciSup_of_directed hd hf

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -44,7 +44,7 @@ local infixl:50 " ≼ " => r
 
 /-- A family of elements of `α` is directed (with respect to a relation `≼` on `α`)
   if there is a member of the family `≼`-above any pair in the family. -/
-def Directed (f : ι → α) :=
+def Predirected (f : ι → α) :=
   ∀ x y, ∃ z, f x ≼ f z ∧ f y ≼ f z
 
 /-- A subset of `α` is directed if there is an element of the set `≼`-above any
@@ -54,16 +54,16 @@ def DirectedOn (s : Set α) :=
 
 variable {r r'}
 
-theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype.val : s → α) := by
-  simp only [DirectedOn, Directed, Subtype.exists, exists_and_left, exists_prop, Subtype.forall]
+theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Predirected r (Subtype.val : s → α) := by
+  simp only [DirectedOn, Predirected, Subtype.exists, exists_and_left, exists_prop, Subtype.forall]
   exact forall₂_congr fun x _ => by simp [And.comm, and_assoc]
 
 alias ⟨DirectedOn.directed_val, _⟩ := directedOn_iff_directed
 
-theorem directedOn_range {f : ι → α} : Directed r f ↔ DirectedOn r (Set.range f) := by
-  simp_rw [Directed, DirectedOn, Set.forall_mem_range, Set.exists_range_iff]
+theorem directedOn_range {f : ι → α} : Predirected r f ↔ DirectedOn r (Set.range f) := by
+  simp_rw [Predirected, DirectedOn, Set.forall_mem_range, Set.exists_range_iff]
 
-protected alias ⟨Directed.directedOn_range, _⟩ := directedOn_range
+protected alias ⟨Predirected.directedOn_range, _⟩ := directedOn_range
 
 theorem directedOn_image {s : Set β} {f : β → α} :
     DirectedOn r (f '' s) ↔ DirectedOn (f ⁻¹'o r) s := by
@@ -79,16 +79,16 @@ theorem DirectedOn.mono {s : Set α} (h : DirectedOn r s) (H : ∀ ⦃a b⦄, r 
     DirectedOn r' s :=
   h.mono' fun _ _ _ _ h ↦ H h
 
-theorem directed_comp {ι} {f : ι → β} {g : β → α} : Directed r (g ∘ f) ↔ Directed (g ⁻¹'o r) f :=
+theorem directed_comp {ι} {f : ι → β} {g : β → α} : Predirected r (g ∘ f) ↔ Predirected (g ⁻¹'o r) f :=
   Iff.rfl
 
-theorem Directed.mono {s : α → α → Prop} {ι} {f : ι → α} (H : ∀ a b, r a b → s a b)
-    (h : Directed r f) : Directed s f := fun a b =>
+theorem Predirected.mono {s : α → α → Prop} {ι} {f : ι → α} (H : ∀ a b, r a b → s a b)
+    (h : Predirected r f) : Predirected s f := fun a b =>
   let ⟨c, h₁, h₂⟩ := h a b
   ⟨c, H _ _ h₁, H _ _ h₂⟩
 
-theorem Directed.mono_comp (r : α → α → Prop) {ι} {rb : β → β → Prop} {g : α → β} {f : ι → α}
-    (hg : ∀ ⦃x y⦄, r x y → rb (g x) (g y)) (hf : Directed r f) : Directed rb (g ∘ f) :=
+theorem Predirected.mono_comp (r : α → α → Prop) {ι} {rb : β → β → Prop} {g : α → β} {f : ι → α}
+    (hg : ∀ ⦃x y⦄, r x y → rb (g x) (g y)) (hf : Predirected r f) : Predirected rb (g ∘ f) :=
   directed_comp.2 <| hf.mono hg
 
 theorem DirectedOn.mono_comp {r : α → α → Prop} {rb : β → β → Prop} {g : α → β} {s : Set α}
@@ -107,9 +107,9 @@ theorem directedOn_of_sup_mem [SemilatticeSup α] {S : Set α}
     (H : ∀ ⦃i j⦄, i ∈ S → j ∈ S → i ⊔ j ∈ S) : DirectedOn (· ≤ ·) S := fun a ha b hb =>
   ⟨a ⊔ b, H ha hb, le_sup_left, le_sup_right⟩
 
-theorem Directed.extend_bot [Preorder α] [OrderBot α] {e : ι → β} {f : ι → α}
-    (hf : Directed (· ≤ ·) f) (he : Function.Injective e) :
-    Directed (· ≤ ·) (Function.extend e f ⊥) := by
+theorem Predirected.extend_bot [Preorder α] [OrderBot α] {e : ι → β} {f : ι → α}
+    (hf : Predirected (· ≤ ·) f) (he : Function.Injective e) :
+    Predirected (· ≤ ·) (Function.extend e f ⊥) := by
   intro a b
   rcases (em (∃ i, e i = a)).symm with (ha | ⟨i, rfl⟩)
   · use b
@@ -126,7 +126,7 @@ theorem directedOn_of_inf_mem [SemilatticeInf α] {S : Set α}
     (H : ∀ ⦃i j⦄, i ∈ S → j ∈ S → i ⊓ j ∈ S) : DirectedOn (· ≥ ·) S :=
   directedOn_of_sup_mem (α := αᵒᵈ) H
 
-theorem Std.Total.directed [Std.Total r] (f : ι → α) : Directed r f := fun i j =>
+theorem Std.Total.directed [Std.Total r] (f : ι → α) : Predirected r f := fun i j =>
   Or.casesOn (total_of r (f i) (f j)) (fun h => ⟨j, h, refl _⟩) fun h => ⟨i, refl _, h⟩
 
 theorem Std.Total.directedOn [Std.Total r] (s : Set α) : DirectedOn r s := fun a ha b hb =>
@@ -151,12 +151,12 @@ theorem directed_of₃ (r : α → α → Prop) [IsDirected α r] [IsTrans α r]
   have ⟨f, hef, hcf⟩ := directed_of r e c
   ⟨f, Trans.trans hae hef, Trans.trans hbe hef, hcf⟩
 
-theorem isDirected_onFun {f : ι → α} : IsDirected ι (r on f) ↔ Directed r f :=
+theorem isDirected_onFun {f : ι → α} : IsDirected ι (r on f) ↔ Predirected r f :=
   ⟨(·.directed), (⟨·⟩)⟩
 
-theorem directed_id [IsDirected α r] : Directed r id := directed_of r
+theorem directed_id [IsDirected α r] : Predirected r id := directed_of r
 
-theorem directed_id_iff : Directed r id ↔ IsDirected α r :=
+theorem directed_id_iff : Predirected r id ↔ IsDirected α r :=
   isDirected_onFun.symm
 
 theorem directedOn_univ [IsDirected α r] : DirectedOn r Set.univ := fun a _ b _ =>
@@ -191,17 +191,17 @@ instance OrderDual.isDirected_ge [LE α] [IsDirectedOrder α] : IsCodirectedOrde
 @[to_dual (reorder := H (i j)) directed_of_isDirected_ge
 /-- An antitone function on a downwards-directed type is directed. -/]
 theorem directed_of_isDirected_le [LE α] [IsDirectedOrder α] {f : α → β} {r : β → β → Prop}
-    (H : ∀ ⦃i j⦄, i ≤ j → r (f i) (f j)) : Directed r f :=
+    (H : ∀ ⦃i j⦄, i ≤ j → r (f i) (f j)) : Predirected r f :=
   directed_id.mono_comp _ H
 
 @[to_dual directed_ge]
 theorem Monotone.directed_le [Preorder α] [IsDirectedOrder α] [Preorder β] {f : α → β} :
-    Monotone f → Directed (· ≤ ·) f :=
+    Monotone f → Predirected (· ≤ ·) f :=
   directed_of_isDirected_le
 
 @[to_dual directed_ge]
 theorem Antitone.directed_le [Preorder α] [IsCodirectedOrder α] [Preorder β] {f : α → β}
-    (hf : Antitone f) : Directed (· ≤ ·) f :=
+    (hf : Antitone f) : Predirected (· ≤ ·) f :=
   directed_of_isDirected_ge hf
 
 @[to_dual]

--- a/Mathlib/Order/Filter/Bases/Basic.lean
+++ b/Mathlib/Order/Filter/Bases/Basic.lean
@@ -161,7 +161,7 @@ theorem mem_filter_of_mem (B : FilterBasis α) {U : Set α} : U ∈ B → U ∈ 
   ⟨U, U_in, Subset.refl _⟩
 
 theorem eq_iInf_principal (B : FilterBasis α) : B.filter = ⨅ s : B.sets, 𝓟 s := by
-  have : Directed (· ≥ ·) fun s : B.sets => 𝓟 (s : Set α) := by
+  have : Predirected (· ≥ ·) fun s : B.sets => 𝓟 (s : Set α) := by
     rintro ⟨U, U_in⟩ ⟨V, V_in⟩
     rcases B.inter_sets U_in V_in with ⟨W, W_in, W_sub⟩
     use ⟨W, W_in⟩
@@ -409,7 +409,7 @@ theorem HasBasis.inf {ι ι' : Type*} {p : ι → Prop} {s : ι → Set α} {p' 
 
 theorem hasBasis_iInf_of_directed' {ι : Type*} {ι' : ι → Sort _} [Nonempty ι] {l : ι → Filter α}
     (s : ∀ i, ι' i → Set α) (p : ∀ i, ι' i → Prop) (hl : ∀ i, (l i).HasBasis (p i) (s i))
-    (h : Directed (· ≥ ·) l) :
+    (h : Predirected (· ≥ ·) l) :
     (⨅ i, l i).HasBasis (fun ii' : Σ i, ι' i => p ii'.1 ii'.2) fun ii' => s ii'.1 ii'.2 := by
   refine ⟨fun t => ?_⟩
   rw [mem_iInf_of_directed h, Sigma.exists]
@@ -417,7 +417,7 @@ theorem hasBasis_iInf_of_directed' {ι : Type*} {ι' : ι → Sort _} [Nonempty 
 
 theorem hasBasis_iInf_of_directed {ι : Type*} {ι' : Sort _} [Nonempty ι] {l : ι → Filter α}
     (s : ι → ι' → Set α) (p : ι → ι' → Prop) (hl : ∀ i, (l i).HasBasis (p i) (s i))
-    (h : Directed (· ≥ ·) l) :
+    (h : Predirected (· ≥ ·) l) :
     (⨅ i, l i).HasBasis (fun ii' : ι × ι' => p ii'.1 ii'.2) fun ii' => s ii'.1 ii'.2 := by
   refine ⟨fun t => ?_⟩
   rw [mem_iInf_of_directed h, Prod.exists]
@@ -573,7 +573,7 @@ theorem HasBasis.eq_biInf (h : l.HasBasis p s) : l = ⨅ (i) (_ : p i), 𝓟 (s 
 theorem HasBasis.eq_iInf (h : l.HasBasis (fun _ => True) s) : l = ⨅ i, 𝓟 (s i) := by
   simpa only [iInf_true] using h.eq_biInf
 
-theorem hasBasis_iInf_principal {s : ι → Set α} (h : Directed (· ≥ ·) s) [Nonempty ι] :
+theorem hasBasis_iInf_principal {s : ι → Set α} (h : Predirected (· ≥ ·) s) [Nonempty ι] :
     (⨅ i, 𝓟 (s i)).HasBasis (fun _ => True) s :=
   ⟨fun t => by
     simpa only [true_and] using mem_iInf_of_directed (h.mono_comp _ monotone_principal.dual) t⟩

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -462,7 +462,7 @@ theorem eq_biInf_of_mem_iff_exists_mem {f : ι → Filter α} {p : ι → Prop} 
   rw [iInf_subtype']
   exact eq_iInf_of_mem_iff_exists_mem fun {_} => by simp only [Subtype.exists, h, exists_prop]
 
-theorem iInf_sets_eq {f : ι → Filter α} (h : Directed (· ≥ ·) f) [ne : Nonempty ι] :
+theorem iInf_sets_eq {f : ι → Filter α} (h : Predirected (· ≥ ·) f) [ne : Nonempty ι] :
     (iInf f).sets = ⋃ i, (f i).sets :=
   let ⟨i⟩ := ne
   let u :=
@@ -479,7 +479,7 @@ theorem iInf_sets_eq {f : ι → Filter α} (h : Directed (· ≥ ·) f) [ne : N
   have : u = iInf f := eq_iInf_of_mem_iff_exists_mem mem_iUnion
   congr_arg Filter.sets this.symm
 
-theorem mem_iInf_of_directed {f : ι → Filter α} (h : Directed (· ≥ ·) f) [Nonempty ι] (s) :
+theorem mem_iInf_of_directed {f : ι → Filter α} (h : Predirected (· ≥ ·) f) [Nonempty ι] (s) :
     s ∈ iInf f ↔ ∃ i, s ∈ f i := by
   simp only [← Filter.mem_sets, iInf_sets_eq h, mem_iUnion]
 
@@ -514,14 +514,14 @@ instance instCoframe : Coframe (Filter α) where
 
 /-- If `f : ι → Filter α` is directed, `ι` is not empty, and `∀ i, f i ≠ ⊥`, then `iInf f ≠ ⊥`.
 See also `iInf_neBot_of_directed` for a version assuming `Nonempty α` instead of `Nonempty ι`. -/
-theorem iInf_neBot_of_directed' {f : ι → Filter α} [Nonempty ι] (hd : Directed (· ≥ ·) f) :
+theorem iInf_neBot_of_directed' {f : ι → Filter α} [Nonempty ι] (hd : Predirected (· ≥ ·) f) :
     (∀ i, NeBot (f i)) → NeBot (iInf f) :=
   not_imp_not.1 <| by simpa only [not_forall, not_neBot, ← empty_mem_iff_bot,
     mem_iInf_of_directed hd] using id
 
 /-- If `f : ι → Filter α` is directed, `α` is not empty, and `∀ i, f i ≠ ⊥`, then `iInf f ≠ ⊥`.
 See also `iInf_neBot_of_directed'` for a version assuming `Nonempty ι` instead of `Nonempty α`. -/
-theorem iInf_neBot_of_directed {f : ι → Filter α} [hn : Nonempty α] (hd : Directed (· ≥ ·) f)
+theorem iInf_neBot_of_directed {f : ι → Filter α} [hn : Nonempty α] (hd : Predirected (· ≥ ·) f)
     (hb : ∀ i, NeBot (f i)) : NeBot (iInf f) := by
   cases isEmpty_or_nonempty ι
   · constructor
@@ -539,11 +539,11 @@ theorem sInf_neBot_of_directed [Nonempty α] {s : Set (Filter α)} (hd : Directe
   (sInf_eq_iInf' s).symm ▸
     iInf_neBot_of_directed hd.directed_val fun ⟨_, hf⟩ => ⟨ne_of_mem_of_not_mem hf hbot⟩
 
-theorem iInf_neBot_iff_of_directed' {f : ι → Filter α} [Nonempty ι] (hd : Directed (· ≥ ·) f) :
+theorem iInf_neBot_iff_of_directed' {f : ι → Filter α} [Nonempty ι] (hd : Predirected (· ≥ ·) f) :
     NeBot (iInf f) ↔ ∀ i, NeBot (f i) :=
   ⟨fun H i => H.mono (iInf_le _ i), iInf_neBot_of_directed' hd⟩
 
-theorem iInf_neBot_iff_of_directed {f : ι → Filter α} [Nonempty α] (hd : Directed (· ≥ ·) f) :
+theorem iInf_neBot_iff_of_directed {f : ι → Filter α} [Nonempty α] (hd : Predirected (· ≥ ·) f) :
     NeBot (iInf f) ↔ ∀ i, NeBot (f i) :=
   ⟨fun H i => H.mono (iInf_le _ i), iInf_neBot_of_directed hd⟩
 

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -186,7 +186,7 @@ theorem lift_iInf [Nonempty ι] {f : ι → Filter α} {g : Set α → Filter β
   exact fun t ht hs => H t ht hs
 
 theorem lift_iInf_of_directed [Nonempty ι] {f : ι → Filter α} {g : Set α → Filter β}
-    (hf : Directed (· ≥ ·) f) (hg : Monotone g) : (iInf f).lift g = ⨅ i, (f i).lift g :=
+    (hf : Predirected (· ≥ ·) f) (hg : Monotone g) : (iInf f).lift g = ⨅ i, (f i).lift g :=
   lift_iInf_le.antisymm fun s => by
     simp only [mem_lift_sets hg, exists_imp, and_imp, mem_iInf_of_directed hf]
     exact fun t i ht hs => mem_iInf_of_mem i <| mem_lift ht hs

--- a/Mathlib/Order/Filter/Map.lean
+++ b/Mathlib/Order/Filter/Map.lean
@@ -703,7 +703,7 @@ end Map
 theorem map_iInf_le {f : ι → Filter α} {m : α → β} : map m (iInf f) ≤ ⨅ i, map m (f i) :=
   le_iInf fun _ => map_mono <| iInf_le _ _
 
-theorem map_iInf_eq {f : ι → Filter α} {m : α → β} (hf : Directed (· ≥ ·) f) [Nonempty ι] :
+theorem map_iInf_eq {f : ι → Filter α} {m : α → β} (hf : Predirected (· ≥ ·) f) [Nonempty ι] :
     map m (iInf f) = ⨅ i, map m (f i) :=
   map_iInf_le.antisymm fun s (hs : m ⁻¹' s ∈ iInf f) =>
     let ⟨i, hi⟩ := (mem_iInf_of_directed hf _).1 hs

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -105,7 +105,7 @@ instance instLE : LE (Chain α) where le x y := ∀ i, ∃ j, x i ≤ y j
 
 lemma isChain_range : IsChain (· ≤ ·) (Set.range c) := Monotone.isChain_range (OrderHomClass.mono c)
 
-lemma directed : Directed (· ≤ ·) c := directedOn_range.2 c.isChain_range.directedOn
+lemma directed : Predirected (· ≤ ·) c := directedOn_range.2 c.isChain_range.directedOn
 
 /-- `map` function for `Chain` -/
 @[simps toOrderHom]

--- a/Mathlib/Order/Preorder/Chain.lean
+++ b/Mathlib/Order/Preorder/Chain.lean
@@ -204,7 +204,7 @@ theorem IsChain.directedOn (H : IsChain r s) : DirectedOn r s := fun x hx y hy =
   ((H.total hx hy).elim fun h => ⟨y, hy, h, refl _⟩) fun h => ⟨x, hx, refl _, h⟩
 
 protected theorem IsChain.directed {f : β → α} {c : Set β} (h : IsChain (f ⁻¹'o r) c) :
-    Directed r fun x : { a : β // a ∈ c } => f x :=
+    Predirected r fun x : { a : β // a ∈ c } => f x :=
   fun ⟨a, ha⟩ ⟨b, hb⟩ =>
     (by_cases fun hab : a = b => by
       simp only [hab, exists_prop, and_self_iff, Subtype.exists]

--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -41,7 +41,7 @@ theorem map_sup [SemilatticeSup α] [LinearOrder β] [FunLike F β α]
   map_inf (α := αᵒᵈ) (β := βᵒᵈ) _ _ _
 
 theorem directed [FunLike F α β] [RelHomClass F r s] {ι : Sort*} {a : ι → α} {f : F}
-    (ha : Directed r a) : Directed s (f ∘ a) :=
+    (ha : Predirected r a) : Predirected s (f ∘ a) :=
   ha.mono_comp _ fun _ _ h ↦ map_rel f h
 
 theorem directedOn [FunLike F α β] [RelHomClass F r s] {f : F}

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -513,7 +513,7 @@ theorem indep_iSup_of_disjoint
 
 theorem indep_iSup_of_directed_le
     [IsZeroOrProbabilityMeasure μ] (h_indep : ∀ i, Indep (m i) m1 μ)
-    (h_le : ∀ i, m i ≤ _mΩ) (h_le' : m1 ≤ _mΩ) (hm : Directed (· ≤ ·) m) :
+    (h_le : ∀ i, m i ≤ _mΩ) (h_le' : m1 ≤ _mΩ) (hm : Predirected (· ≤ ·) m) :
     Indep (⨆ i, m i) m1 μ :=
   Kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
 

--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -573,7 +573,7 @@ theorem condIndep_iSup_of_disjoint {m : ι → MeasurableSpace Ω}
 
 theorem condIndep_iSup_of_directed_le {m : ι → MeasurableSpace Ω}
     (h_indep : ∀ i, CondIndep m' (m i) m₁ hm' μ)
-    (h_le : ∀ i, m i ≤ mΩ) (h_le' : m₁ ≤ mΩ) (hm : Directed (· ≤ ·) m) :
+    (h_le : ∀ i, m i ≤ mΩ) (h_le' : m₁ ≤ mΩ) (hm : Predirected (· ≤ ·) m) :
     CondIndep m' (⨆ i, m i) m₁ hm' μ :=
   Kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
 

--- a/Mathlib/Probability/Independence/Kernel/Indep.lean
+++ b/Mathlib/Probability/Independence/Kernel/Indep.lean
@@ -618,7 +618,7 @@ theorem indep_iSup_of_disjoint {m : ι → MeasurableSpace Ω}
 
 theorem indep_iSup_of_directed_le {Ω} {m : ι → MeasurableSpace Ω} {m' m0 : MeasurableSpace Ω}
     {κ : Kernel α Ω} {μ : Measure α} [IsZeroOrMarkovKernel κ] (h_indep : ∀ i, Indep (m i) m' κ μ)
-    (h_le : ∀ i, m i ≤ m0) (h_le' : m' ≤ m0) (hm : Directed (· ≤ ·) m) :
+    (h_le : ∀ i, m i ≤ m0) (h_le' : m' ≤ m0) (hm : Predirected (· ≤ ·) m) :
     Indep (⨆ i, m i) m' κ μ := by
   let p : ι → Set (Set Ω) := fun n => { t | MeasurableSet[m n] t }
   have hp : ∀ n, IsPiSystem (p n) := fun n => @isPiSystem_measurableSet Ω (m n)

--- a/Mathlib/Probability/Independence/ZeroOne.lean
+++ b/Mathlib/Probability/Independence/ZeroOne.lean
@@ -129,7 +129,7 @@ theorem condIndep_biSup_limsup [StandardBorelSpace Ω]
   Kernel.indep_biSup_limsup h_le h_indep hf ht
 
 theorem Kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     Indep (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) κ μα := by
   rcases eq_or_ne μα 0 with rfl | hμ
   · simp
@@ -149,20 +149,20 @@ theorem Kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : 
 
 theorem indep_iSup_directed_limsup
     (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     Indep (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) μ :=
   Kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
 
 theorem condIndep_iSup_directed_limsup [StandardBorelSpace Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     CondIndep m (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) hm μ :=
   Kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
 
 theorem Kernel.indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (⨆ n, s n) (limsup s f) κ μα := by
   suffices (⨆ a, ⨆ n ∈ ns a, s n) = ⨆ n, s n by
     rw [← this]
@@ -175,39 +175,39 @@ theorem Kernel.indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s 
 
 theorem indep_iSup_limsup
     (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (⨆ n, s n) (limsup s f) μ :=
   Kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
 
 theorem condIndep_iSup_limsup [StandardBorelSpace Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     CondIndep m (⨆ n, s n) (limsup s f) hm μ :=
   Kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
 
 theorem Kernel.indep_limsup_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (limsup s f) (limsup s f) κ μα :=
   indep_of_indep_of_le_left (indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ) limsup_le_iSup
 
 theorem indep_limsup_self
     (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (limsup s f) (limsup s f) μ :=
   Kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
 
 theorem condIndep_limsup_self [StandardBorelSpace Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (hf : ∀ t, p t → tᶜ ∈ f)
-    (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
+    (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     CondIndep m (limsup s f) (limsup s f) hm μ :=
   Kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
 
 theorem Kernel.measure_zero_or_one_of_measurableSet_limsup (h_le : ∀ n, s n ≤ m0)
     (h_indep : iIndep s κ μα)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
     ∀ᵐ a ∂μα, κ a t = 0 ∨ κ a t = 1 := by
   apply measure_eq_zero_or_one_of_indepSet_self' ?_
@@ -217,7 +217,7 @@ theorem Kernel.measure_zero_or_one_of_measurableSet_limsup (h_le : ∀ n, s n �
 
 theorem measure_zero_or_one_of_measurableSet_limsup
     (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
     μ t = 0 ∨ μ t = 1 := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
@@ -227,7 +227,7 @@ theorem measure_zero_or_one_of_measurableSet_limsup
 theorem condExp_zero_or_one_of_measurableSet_limsup [StandardBorelSpace Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ)
-    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
+    (hf : ∀ t, p t → tᶜ ∈ f) (hns : Predirected (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
     ∀ᵐ ω ∂μ, (μ⟦t | m⟧) ω = 0 ∨ (μ⟦t | m⟧) ω = 1 := by
   have h := ae_of_ae_trim hm

--- a/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
@@ -483,10 +483,10 @@ lemma setLIntegral_toKernel_univ [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ 
     (a : α) {s : Set β} (hs : MeasurableSet s) :
     ∫⁻ b in s, hf.toKernel f (a, b) univ ∂(ν a) = κ a (s ×ˢ univ) := by
   rw [← Real.iUnion_Iic_rat, prod_iUnion]
-  have h_dir : Directed (fun x y ↦ x ⊆ y) fun q : ℚ ↦ Iic (q : ℝ) := by
+  have h_dir : Predirected (fun x y ↦ x ⊆ y) fun q : ℚ ↦ Iic (q : ℝ) := by
     refine Monotone.directed_le fun r r' hrr' ↦ Iic_subset_Iic.mpr ?_
     exact mod_cast hrr'
-  have h_dir_prod : Directed (fun x y ↦ x ⊆ y) fun q : ℚ ↦ s ×ˢ Iic (q : ℝ) := by
+  have h_dir_prod : Predirected (fun x y ↦ x ⊆ y) fun q : ℚ ↦ s ×ˢ Iic (q : ℝ) := by
     refine Monotone.directed_le fun i j hij ↦ ?_
     refine prod_subset_prod_iff.mpr (Or.inl ⟨subset_rfl, Iic_subset_Iic.mpr ?_⟩)
     exact mod_cast hij

--- a/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
@@ -402,7 +402,7 @@ theorem AlgebraicIndependent.image {ι} {s : Set ι} {f : ι → A}
   convert AlgebraicIndependent.image_of_comp s f id hs
 
 theorem algebraicIndependent_iUnion_of_directed {η : Type*} [Nonempty η] {s : η → Set A}
-    (hs : Directed (· ⊆ ·) s) (h : ∀ i, AlgebraicIndependent R ((↑) : s i → A)) :
+    (hs : Predirected (· ⊆ ·) s) (h : ∀ i, AlgebraicIndependent R ((↑) : s i → A)) :
     AlgebraicIndependent R ((↑) : (⋃ i, s i) → A) := by
   refine algebraicIndependent_of_finite (⋃ i, s i) fun t ht ft => ?_
   rcases finite_subset_iUnion ft ht with ⟨I, fi, hI⟩

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -679,7 +679,7 @@ def prodEquiv (s : NonUnitalSubring R) (t : NonUnitalSubring S) : s.prod t ≃+*
 `NonUnitalSubring`s. Note that this fails without the directedness assumption (the union of two
 `NonUnitalSubring`s is typically not a `NonUnitalSubring`) -/
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubring R}
-    (hS : Directed (· ≤ ·) S) {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
+    (hS : Predirected (· ≤ ·) S) {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
   let U : NonUnitalSubring R :=
     NonUnitalSubring.mk' (⋃ i, (S i : Set R)) (⨆ i, (S i).toSubsemigroup) (⨆ i, (S i).toAddSubgroup)
@@ -688,7 +688,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubri
   exact iSup_le fun i x hx ↦ Set.mem_iUnion.2 ⟨i, hx⟩
 
 theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → NonUnitalSubring R}
-    (hS : Directed (· ≤ ·) S) : ((⨆ i, S i : NonUnitalSubring R) : Set R) = ⋃ i, S i :=
+    (hS : Predirected (· ≤ ·) S) : ((⨆ i, S i : NonUnitalSubring R) : Set R) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 
 theorem mem_sSup_of_directedOn {S : Set (NonUnitalSubring R)} (Sne : S.Nonempty)

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -613,7 +613,7 @@ def prodEquiv (s : NonUnitalSubsemiring R) (t : NonUnitalSubsemiring S) : s.prod
     map_add' := fun _ _ => rfl }
 
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubsemiring R}
-    (hS : Directed (· ≤ ·) S) {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
+    (hS : Predirected (· ≤ ·) S) {x : R} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
   refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
   let U : NonUnitalSubsemiring R :=
     NonUnitalSubsemiring.mk' (⋃ i, (S i : Set R))
@@ -623,7 +623,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubse
   exact iSup_le fun i x hx => Set.mem_iUnion.2 ⟨i, hx⟩
 
 theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubsemiring R}
-    (hS : Directed (· ≤ ·) S) : ((⨆ i, S i : NonUnitalSubsemiring R) : Set R) = ⋃ i, S i :=
+    (hS : Predirected (· ≤ ·) S) : ((⨆ i, S i : NonUnitalSubsemiring R) : Set R) = ⋃ i, S i :=
   Set.ext fun x ↦ by simp [mem_iSup_of_directed hS]
 
 theorem mem_sSup_of_directedOn {S : Set (NonUnitalSubsemiring R)} (Sne : S.Nonempty)

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -192,7 +192,7 @@ def toNormedField : NormedField L :=
           apply lt_trans _ hu
           rw [NNReal.coe_lt_coe, ← neg_sub, Valuation.map_neg]
           exact (RankOne.strictMono Valued.v).lt_iff_lt.mpr hx
-      · simp only [Directed]
+      · simp only [Predirected]
         intro x y
         use min x y
         simp only [le_principal_iff, mem_principal, setOf_subset_setOf, Prod.forall]

--- a/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
@@ -84,7 +84,7 @@ theorem partialSections.nonempty [IsCofilteredOrEmpty J] [h : ∀ j : J, Nonempt
 set_option backward.privateInPublic true in
 set_option backward.privateInPublic.warn false in
 theorem partialSections.directed :
-    Directed Superset fun G : FiniteDiagram J => partialSections F G.2 := by
+    Predirected Superset fun G : FiniteDiagram J => partialSections F G.2 := by
   classical
   intro A B
   let ιA : FiniteDiagramArrow A.1 → FiniteDiagramArrow (A.1 ⊔ B.1) := fun f =>

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -166,7 +166,7 @@ lemma IsCompact.tendsto_nhds_of_unique_mapClusterPt {Y} {l : Filter Y} {y : X} {
 /-- For every open directed cover of a compact set, there exists a single element of the
 cover which itself includes the set. -/
 theorem IsCompact.elim_directed_cover {ι : Type v} [hι : Nonempty ι] (hs : IsCompact s)
-    (U : ι → Set X) (hUo : ∀ i, IsOpen (U i)) (hsU : s ⊆ ⋃ i, U i) (hdU : Directed (· ⊆ ·) U) :
+    (U : ι → Set X) (hUo : ∀ i, IsOpen (U i)) (hsU : s ⊆ ⋃ i, U i) (hdU : Predirected (· ⊆ ·) U) :
     ∃ i, s ⊆ U i :=
   hι.elim fun i₀ =>
     IsCompact.induction_on hs ⟨i₀, empty_subset _⟩ (fun _ _ hs ⟨i, hi⟩ => ⟨i, hs.trans hi⟩)
@@ -248,7 +248,7 @@ theorem IsCompact.disjoint_nhdsSet_right {l : Filter X} (hs : IsCompact s) :
 there exists a single element of the family which itself avoids this compact set. -/
 theorem IsCompact.elim_directed_family_closed {ι : Type v} [Nonempty ι] (hs : IsCompact s)
     (t : ι → Set X) (htc : ∀ i, IsClosed (t i)) (hst : (s ∩ ⋂ i, t i) = ∅)
-    (hdt : Directed (· ⊇ ·) t) : ∃ i : ι, s ∩ t i = ∅ :=
+    (hdt : Predirected (· ⊇ ·) t) : ∃ i : ι, s ∩ t i = ∅ :=
   let ⟨t, ht⟩ :=
     hs.elim_directed_cover (compl ∘ t) (fun i => (htc i).isOpen_compl)
       (by
@@ -291,7 +291,7 @@ lemma CompactSpace.nonempty_sInter [CompactSpace X] {s : Set (Set X)} (hsc : ∀
 /-- Cantor's intersection theorem for `iInter`:
 the intersection of a directed family of nonempty compact closed sets is nonempty. -/
 theorem IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed
-    {ι : Type v} [hι : Nonempty ι] (t : ι → Set X) (htd : Directed (· ⊇ ·) t)
+    {ι : Type v} [hι : Nonempty ι] (t : ι → Set X) (htd : Predirected (· ⊇ ·) t)
     (htn : ∀ i, (t i).Nonempty) (htc : ∀ i, IsCompact (t i)) (htcl : ∀ i, IsClosed (t i)) :
     (⋂ i, t i).Nonempty := by
   let i₀ := hι.some
@@ -320,7 +320,7 @@ theorem IsCompact.nonempty_iInter_of_sequence_nonempty_isCompact_isClosed (t : �
     (htd : ∀ i, t (i + 1) ⊆ t i) (htn : ∀ i, (t i).Nonempty) (ht0 : IsCompact (t 0))
     (htcl : ∀ i, IsClosed (t i)) : (⋂ i, t i).Nonempty :=
   have tmono : Antitone t := antitone_nat_of_succ_le htd
-  have htd : Directed (· ⊇ ·) t := tmono.directed_ge
+  have htd : Predirected (· ⊇ ·) t := tmono.directed_ge
   have : ∀ i, t i ⊆ t 0 := fun i => tmono <| Nat.zero_le i
   have htc : ∀ i, IsCompact (t i) := fun i => ht0.of_isClosed_subset (htcl i) (this i)
   IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t htd htn htc htcl
@@ -506,7 +506,7 @@ protected theorem IsCompact.insert (hs : IsCompact s) (a) : IsCompact (insert a 
 `⋂ i, V i` contains some `V i`. We assume each `V i` is compact *and* closed because `X` is
 not assumed to be Hausdorff. See `exists_subset_nhds_of_compact` for version assuming this. -/
 theorem exists_subset_nhds_of_isCompact' [Nonempty ι] {V : ι → Set X}
-    (hV : Directed (· ⊇ ·) V) (hV_cpct : ∀ i, IsCompact (V i)) (hV_closed : ∀ i, IsClosed (V i))
+    (hV : Predirected (· ⊇ ·) V) (hV_cpct : ∀ i, IsCompact (V i)) (hV_closed : ∀ i, IsClosed (V i))
     {U : Set X} (hU : ∀ x ∈ ⋂ i, V i, U ∈ 𝓝 x) : ∃ i, V i ⊆ U := by
   obtain ⟨W, hsubW, W_op, hWU⟩ := exists_open_set_nhds hU
   suffices ∃ i, V i ⊆ W from this.imp fun i hi => hi.trans hWU
@@ -948,7 +948,7 @@ theorem isCompact_diagonal [CompactSpace X] : IsCompact (diagonal X) :=
   @range_diag X ▸ isCompact_range (continuous_id.prodMk continuous_id)
 
 theorem exists_subset_nhds_of_compactSpace [CompactSpace X] [Nonempty ι]
-    {V : ι → Set X} (hV : Directed (· ⊇ ·) V) (hV_closed : ∀ i, IsClosed (V i)) {U : Set X}
+    {V : ι → Set X} (hV : Predirected (· ⊇ ·) V) (hV_closed : ∀ i, IsClosed (V i)) {U : Set X}
     (hU : ∀ x ∈ ⋂ i, V i, U ∈ 𝓝 x) : ∃ i, V i ⊆ U :=
   exists_subset_nhds_of_isCompact' hV (fun i => (hV_closed i).isCompact) hV_closed hU
 

--- a/Mathlib/Topology/Compactness/CompactSystem.lean
+++ b/Mathlib/Topology/Compactness/CompactSystem.lean
@@ -130,7 +130,7 @@ lemma isCompactSystem_insert_univ_iff : IsCompactSystem (insert univ S) ↔ IsCo
 sets. -/
 theorem isCompactSystem_iff_of_directed (hpi : IsPiSystem S) :
     IsCompactSystem S ↔
-      ∀ (C : ℕ → Set α), Directed (· ⊇ ·) C → (∀ i, C i ∈ S) → ⋂ i, C i = ∅ → ∃ n, C n = ∅ := by
+      ∀ (C : ℕ → Set α), Predirected (· ⊇ ·) C → (∀ i, C i ∈ S) → ⋂ i, C i = ∅ → ∃ n, C n = ∅ := by
   rw [← isCompactSystem_insert_empty_iff]
   refine ⟨fun h ↦ fun C hdi hi ↦ ?_, fun h C h1 h2 ↦ ?_⟩
   · rw [← exists_dissipate_eq_empty_iff_of_directed hdi]
@@ -150,7 +150,7 @@ theorem isCompactSystem_iff_of_directed (hpi : IsPiSystem S) :
 sets. -/
 theorem isCompactSystem_iff_nonempty_iInter_of_directed (hpi : IsPiSystem S) :
     IsCompactSystem S ↔
-    ∀ (C : ℕ → Set α), (Directed (· ⊇ ·) C) → (∀ i, C i ∈ S) → (∀ n, (C n).Nonempty) →
+    ∀ (C : ℕ → Set α), (Predirected (· ⊇ ·) C) → (∀ i, C i ∈ S) → (∀ n, (C n).Nonempty) →
       (⋂ i, C i).Nonempty := by
   rw [isCompactSystem_iff_of_directed hpi]
   refine ⟨fun h1 C h3 h4 ↦ ?_, fun h1 C h3 s ↦ ?_⟩ <;> contrapose!

--- a/Mathlib/Topology/Compactness/CountablyCompact.lean
+++ b/Mathlib/Topology/Compactness/CountablyCompact.lean
@@ -100,9 +100,9 @@ alias ⟨IsCountablyCompact.seq_clusterPt,
 element of the cover which itself includes the set. -/
 theorem IsCountablyCompact.elim_directed_cover [Countable ι] [Nonempty ι]
     (hA : IsCountablyCompact A) (U : ι → Set E) (hUo : ∀ i, IsOpen (U i))
-    (hAU : A ⊆ ⋃ i, U i) (hdU : Directed (· ⊆ ·) U) : ∃ i, A ⊆ U i := by
+    (hAU : A ⊆ ⋃ i, U i) (hdU : Predirected (· ⊆ ·) U) : ∃ i, A ⊆ U i := by
   by_contra! h
-  have hdir : Directed (· ≥ ·) fun i => 𝓟 (A \ U i) :=
+  have hdir : Predirected (· ≥ ·) fun i => 𝓟 (A \ U i) :=
     fun i j => (hdU i j).imp fun _ ⟨hi, hj⟩ => ⟨principal_mono.mpr <| diff_subset_diff_right hi,
       principal_mono.mpr <| diff_subset_diff_right hj⟩
   have : NeBot (⨅ i, 𝓟 (A \ U i)) :=

--- a/Mathlib/Topology/Semicontinuity/Basic.lean
+++ b/Mathlib/Topology/Semicontinuity/Basic.lean
@@ -84,8 +84,8 @@ theorem LowerSemicontinuousOn.exists_isMinOn {s : Set α} (ne_s : s.Nonempty)
   let ℱ : Filter α := ⨅ a : s, φ (f a)
   have : ℱ.NeBot := by
     apply iInf_neBot_of_directed _ _
-    · change Directed GE.ge (fun x ↦ (φ ∘ (fun (a : s) ↦ f ↑a)) x)
-      exact Directed.mono_comp GE.ge (fun x y hxy ↦
+    · change Predirected GE.ge (fun x ↦ (φ ∘ (fun (a : s) ↦ f ↑a)) x)
+      exact Predirected.mono_comp GE.ge (fun x y hxy ↦
         principal_mono.mpr (inter_subset_inter_right _ (preimage_mono <| Iic_subset_Iic.mpr hxy)))
         (Std.Total.directed _)
     · intro x

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -608,7 +608,7 @@ lemma Pi.isCompact_closure_iff {ι : Type*} {X : ι → Type*} [∀ i, Topologic
 don't need to assume each `V i` closed because it follows from compactness since `X` is
 assumed to be Hausdorff. -/
 theorem exists_subset_nhds_of_isCompact [T2Space X] {ι : Type*} [Nonempty ι] {V : ι → Set X}
-    (hV : Directed (· ⊇ ·) V) (hV_cpct : ∀ i, IsCompact (V i)) {U : Set X}
+    (hV : Predirected (· ⊇ ·) V) (hV_cpct : ∀ i, IsCompact (V i)) {U : Set X}
     (hU : ∀ x ∈ ⋂ i, V i, U ∈ 𝓝 x) : ∃ i, V i ⊆ U :=
   exists_subset_nhds_of_isCompact' hV hV_cpct (fun i => (hV_cpct i).isClosed) hU
 

--- a/Mathlib/Topology/Separation/Profinite.lean
+++ b/Mathlib/Topology/Separation/Profinite.lean
@@ -52,7 +52,7 @@ theorem nhds_basis_clopen (x : X) : (𝓝 x).HasBasis (fun s : Set X => x ∈ s 
       · exact ⟨s, ⟨hs', hs⟩, hs''⟩
       haveI : Nonempty N := ⟨⟨univ, isClopen_univ, mem_univ x⟩⟩
       have hNcl : ∀ s : N, IsClosed s.val := fun s => s.property.1.1
-      have hdir : Directed Superset fun s : N => s.val := by
+      have hdir : Predirected Superset fun s : N => s.val := by
         rintro ⟨s, hs, hxs⟩ ⟨t, ht, hxt⟩
         exact ⟨⟨s ∩ t, hs.inter ht, ⟨hxs, hxt⟩⟩, inter_subset_left, inter_subset_right⟩
       have h_nhds : ∀ y ∈ ⋂ s : N, s.val, U ∈ 𝓝 y := fun y y_in => by

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -670,7 +670,7 @@ Let `V` bounded by `p` be a basis of entourages of `β`.
 Then `UniformOnFun.gen 𝔖 (t i) (V j)` bounded by `p j` is a basis of entourages of `α →ᵤ[𝔖] β`. -/
 protected theorem hasBasis_uniformity_of_covering_of_basis {ι ι' : Type*} [Nonempty ι]
     {t : ι → Set α} {p : ι' → Prop} {V : ι' → Set (β × β)} (ht : ∀ i, t i ∈ 𝔖)
-    (hdir : Directed (· ⊆ ·) t) (hex : ∀ s ∈ 𝔖, ∃ i, s ⊆ t i) (hb : HasBasis (𝓤 β) p V) :
+    (hdir : Predirected (· ⊆ ·) t) (hex : ∀ s ∈ 𝔖, ∃ i, s ⊆ t i) (hb : HasBasis (𝓤 β) p V) :
     (𝓤 (α →ᵤ[𝔖] β)).HasBasis (fun i : ι × ι' ↦ p i.2) fun i ↦
       UniformOnFun.gen 𝔖 (t i.1) (V i.2) := by
   have hne : 𝔖.Nonempty := (range_nonempty t).mono (range_subset_iff.2 ht)


### PR DESCRIPTION
This **incomplete** PR renames `Directed` to `Predirected`.

As [discussed in Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.3E.20complete.20partial.20order.20and.20domain.20theory.20formalization/near/592156927), `Directed` misleadingly mismatches the literature. (The literature says a directed set is nonempty, and we do not.) 

#### f19d3e79 Rename Directed -> Predirected (class + namespace)

Automated changes:
- LSP code action renaming `Directed` to `Predirected`
- with the affected 69 files open in [lean.nvim](https://github.com/julian/lean.nvim), a series of commands roughly equivalent to
  ```nvim
  :bufdo :silent %s/\(theorem \|lemma \|to_dual \)Directed\>/\1Predirected/ge
  :bufdo :silent %s/\<Directed\>\./Predirected./ge
  :bufdo :w
  ```

EDIT: manual changes
- one `namespace Directed` replaced.

### Corners cut:
- line-length linting has **not** been resolved.
- no snake-cased `directed` has been renamed.
- only tested via `lake build --old`, plus maybe ten minutes of `lake build` before I (@openendings ) got bored and wanted my CPU back.

---

WIP
please-adopt
t-order

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
