### PR TITLE
[Merged by Bors] - chore: tag (almost) all `mono` lemmas as `@[gcongr]`

### DIFF
--- a/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
@@ -113,7 +113,7 @@ theorem of_convergence_epsilon :
       _ ≤ fib n := by exact_mod_cast le_fib_self <| le_trans (le_max_right N' 5) n_ge_N
       _ ≤ fib (n + 1) := by exact_mod_cast fib_le_fib_succ
       _ ≤ fib (n + 1) * fib (n + 1) := by exact_mod_cast (fib (n + 1)).le_mul_self
-      _ ≤ fib (n + 1) * fib (n + 2) := by gcongr; exact_mod_cast fib_le_fib_succ
+      _ ≤ fib (n + 1) * fib (n + 2) := by gcongr; lia
       _ ≤ B * nB := by gcongr
 
 theorem of_convergence [TopologicalSpace K] [OrderTopology K] :

--- a/Mathlib/Algebra/Lie/Ideal.lean
+++ b/Mathlib/Algebra/Lie/Ideal.lean
@@ -209,12 +209,12 @@ theorem map_comap_le : map f (comap f J) ≤ J := by rw [map_le_iff_le_comap]
 /-- See also `LieIdeal.map_comap_eq`. -/
 theorem comap_map_le : I ≤ comap f (map f I) := by rw [← map_le_iff_le_comap]
 
-@[mono]
+@[gcongr, mono]
 theorem map_mono : Monotone (map f) := fun I₁ I₂ h ↦ by
   unfold map
   gcongr; exact h
 
-@[mono]
+@[gcongr, mono]
 theorem comap_mono : Monotone (comap f) := fun J₁ J₂ h ↦ by
   rw [← SetLike.coe_subset_coe] at h ⊢
   dsimp only [SetLike.coe]

--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -36,22 +36,22 @@ variable [Semiring R] [AddCommMonoid M] [Module R M]
 
 variable {p q : Submodule R M}
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_strictMono : StrictMono (toAddSubmonoid : Submodule R M → AddSubmonoid M) :=
   fun _ _ => id
 
 theorem toAddSubmonoid_le : p.toAddSubmonoid ≤ q.toAddSubmonoid ↔ p ≤ q :=
   Iff.rfl
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : Submodule R M → AddSubmonoid M) :=
   toAddSubmonoid_strictMono.monotone
 
-@[mono]
+@[gcongr, mono]
 theorem toSubMulAction_strictMono :
     StrictMono (toSubMulAction : Submodule R M → SubMulAction R M) := fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toSubMulAction_mono : Monotone (toSubMulAction : Submodule R M → SubMulAction R M) :=
   toSubMulAction_strictMono.monotone
 
@@ -123,7 +123,7 @@ variable (p p' : Submodule R M)
 variable {r : R} {x y : M}
 
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubgroup_strictMono : StrictMono (toAddSubgroup : Submodule R M → AddSubgroup M) :=
   fun _ _ => id
 
@@ -131,7 +131,7 @@ theorem toAddSubgroup_strictMono : StrictMono (toAddSubgroup : Submodule R M →
 theorem toAddSubgroup_le : p.toAddSubgroup ≤ p'.toAddSubgroup ↔ p ≤ p' :=
   Iff.rfl
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubgroup_mono : Monotone (toAddSubgroup : Submodule R M → AddSubgroup M) :=
   toAddSubgroup_strictMono.monotone
 

--- a/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
+++ b/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
@@ -92,7 +92,7 @@ def restrictScalarsEmbedding : Submodule R M ↪o Submodule S M where
   inj' := restrictScalars_injective S R M
   map_rel_iff' := restrictScalars_le S
 
-@[mono]
+@[gcongr, mono]
 lemma restrictScalars_monotone : Monotone (restrictScalars S : Submodule R M → Submodule S M) :=
   (restrictScalarsEmbedding S R M).monotone
 

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -197,7 +197,7 @@ theorem kstar_le_of_mul_le_right (hb : 1 ≤ b) : a * b ≤ b → a∗ ≤ b := 
 theorem le_kstar : a ≤ a∗ :=
   le_trans (le_mul_of_one_le_left' one_le_kstar) kstar_mul_le_kstar
 
-@[mono]
+@[gcongr, mono]
 theorem kstar_mono : Monotone (KStar.kstar : α → α) :=
   fun _ _ h ↦
     kstar_le_of_mul_le_left one_le_kstar <| kstar_mul_le (h.trans le_kstar) <| mul_kstar_le_kstar

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -41,11 +41,11 @@ theorem toSubsemiring_le_toSubsemiring {P₁ P₂ : RingPreordering R} :
 theorem toSubsemiring_lt_toSubsemiring {P₁ P₂ : RingPreordering R} :
     P₁.toSubsemiring < P₂.toSubsemiring ↔ P₁ < P₂ := .rfl
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemiring_mono : Monotone (toSubsemiring : RingPreordering R → _) :=
   fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemiring_strictMono : StrictMono (toSubsemiring : RingPreordering R → _) :=
   fun _ _ => id
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -47,19 +47,19 @@ namespace Subsemiring
 
 variable (s : Subsemiring R)
 
-@[mono]
+@[gcongr, mono]
 theorem toSubmonoid_strictMono : StrictMono (toSubmonoid : Subsemiring R → Submonoid R) :=
   fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toSubmonoid_mono : Monotone (toSubmonoid : Subsemiring R → Submonoid R) :=
   toSubmonoid_strictMono.monotone
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_strictMono : StrictMono (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
   fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : Subsemiring R → AddSubmonoid R) :=
   toAddSubmonoid_strictMono.monotone
 

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -635,7 +635,7 @@ theorem starClosure_le_iff {S₁ : NonUnitalSubalgebra R A} {S₂ : NonUnitalSta
     S₁.starClosure ≤ S₂ ↔ S₁ ≤ S₂.toNonUnitalSubalgebra :=
   ⟨fun h => le_sup_left.trans h, starClosure_le⟩
 
-@[mono]
+@[gcongr, mono]
 theorem starClosure_mono : Monotone (starClosure (R := R) (A := A)) :=
   fun _ _ h => starClosure_le <| h.trans le_sup_left
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
@@ -221,7 +221,7 @@ theorem subset_iUnion (h : J ∈ π) : ↑J ⊆ π.iUnion :=
 theorem iUnion_subset : π.iUnion ⊆ I :=
   iUnion₂_subset π.le_of_mem'
 
-@[mono]
+@[gcongr, mono]
 theorem iUnion_mono (h : π₁ ≤ π₂) : π₁.iUnion ⊆ π₂.iUnion := fun _ hx =>
   let ⟨_, hJ₁, hx⟩ := π₁.mem_iUnion.1 hx
   let ⟨J₂, hJ₂, hle⟩ := h hJ₁
@@ -438,7 +438,7 @@ theorem mem_restrict : J₁ ∈ π.restrict J ↔ ∃ J' ∈ π, (J₁ : WithBot
 theorem mem_restrict' : J₁ ∈ π.restrict J ↔ ∃ J' ∈ π, (J₁ : Set (ι → ℝ)) = ↑J ∩ ↑J' := by
   simp only [mem_restrict, ← Box.withBotCoe_inj, Box.coe_inf, Box.coe_coe]
 
-@[mono]
+@[gcongr, mono]
 theorem restrict_mono {π₁ π₂ : Prepartition I} (Hle : π₁ ≤ π₂) : π₁.restrict J ≤ π₂.restrict J := by
   classical
   refine ofWithBot_mono fun J₁ hJ₁ hne => ?_

--- a/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
@@ -335,7 +335,7 @@ theorem MemBaseSet.mono' (h : l₁ ≤ l₂) (hc : c₁ ≤ c₂)
     fun hD => (hπ.4 (le_iff_imp.1 h.2.2 hD)).imp fun _ hπ => ⟨hπ.1, hπ.2.trans hc⟩⟩
 
 variable (I) in
-@[mono]
+@[gcongr, mono]
 theorem MemBaseSet.mono (h : l₁ ≤ l₂) (hc : c₁ ≤ c₂)
     (hr : ∀ x ∈ Box.Icc I, r₁ x ≤ r₂ x) (hπ : l₁.MemBaseSet I c₁ r₁ π) : l₂.MemBaseSet I c₂ r₂ π :=
   hπ.mono' I h hc fun J _ => hr _ <| π.tag_mem_Icc J
@@ -401,7 +401,7 @@ theorem biUnionTagged_memBaseSet {π : Prepartition I} {πi : ∀ J, TaggedPrepa
     rw [π.iUnion_compl, ← π.iUnion_biUnion_partition hp]
     rfl
 
-@[mono]
+@[gcongr, mono]
 theorem RCond.mono {ι : Type*} {r : (ι → ℝ) → Ioi (0 : ℝ)} (h : l₁ ≤ l₂) (hr : l₂.RCond r) :
     l₁.RCond r :=
   fun hR => hr (le_iff_imp.1 h.1 hR)

--- a/Mathlib/Analysis/SpecialFunctions/Sigmoid.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Sigmoid.lean
@@ -82,7 +82,7 @@ lemma sigmoid_lt_one (x : ℝ) : sigmoid x < 1 :=
 @[bound]
 lemma sigmoid_le_one (x : ℝ) : sigmoid x ≤ 1 := (sigmoid_lt_one x).le
 
-@[mono]
+@[gcongr, mono]
 lemma sigmoid_strictMono : StrictMono sigmoid := fun a b hab ↦ by
   simp only [sigmoid]
   gcongr
@@ -97,7 +97,7 @@ lemma sigmoid_lt_iff {a b : ℝ} : sigmoid a < sigmoid b ↔ a < b := sigmoid_st
 @[gcongr]
 lemma sigmoid_lt {a b : ℝ} : a < b → sigmoid a < sigmoid b := sigmoid_lt_iff.mpr
 
-@[mono]
+@[gcongr, mono]
 lemma sigmoid_monotone : Monotone sigmoid := sigmoid_strictMono.monotone
 
 lemma sigmoid_injective : Function.Injective sigmoid := sigmoid_strictMono.injective
@@ -224,7 +224,7 @@ lemma sigmoid_pos (x : ℝ) : 0 < sigmoid x := Real.sigmoid_pos x
 @[bound]
 lemma sigmoid_lt_one (x : ℝ) : sigmoid x < 1 := Real.sigmoid_lt_one x
 
-@[mono]
+@[gcongr, mono]
 lemma sigmoid_strictMono : StrictMono sigmoid := Real.sigmoid_strictMono
 
 lemma sigmoid_le_iff {a b : ℝ} : sigmoid a ≤ sigmoid b ↔ a ≤ b := Real.sigmoid_le_iff
@@ -237,7 +237,7 @@ lemma sigmoid_lt_iff {a b : ℝ} : sigmoid a < sigmoid b ↔ a < b := Real.sigmo
 @[gcongr]
 lemma sigmoid_lt {a b : ℝ} : a < b → sigmoid a < sigmoid b := sigmoid_lt_iff.mpr
 
-@[mono]
+@[gcongr, mono]
 lemma sigmoid_monotone : Monotone sigmoid := sigmoid_strictMono.monotone
 
 lemma sigmoid_injective : Function.Injective sigmoid := sigmoid_strictMono.injective

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -185,7 +185,7 @@ variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 namespace CategoryTheory.Functor
 
 /-- A functor between preorder categories is monotone. -/
-@[mono]
+@[gcongr, mono]
 theorem monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
 
 /-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/

--- a/Mathlib/CategoryTheory/Sites/Closed.lean
+++ b/Mathlib/CategoryTheory/Sites/Closed.lean
@@ -122,7 +122,7 @@ theorem pullback_close {X Y : C} (f : Y ⟶ X) (S : Sieve X) :
     rw [← Sieve.pullback_comp]
     apply hg
 
-@[mono]
+@[gcongr, mono]
 theorem monotone_close {X : C} : Monotone (J₁.close : Sieve X → Sieve X) :=
   (J₁.closureOperator _).monotone
 

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -63,11 +63,11 @@ lemma toSimpleGraphStrict_subgraph_toSimpleGraphInclusive (G : Digraph V) :
     G.toSimpleGraphStrict ≤ G.toSimpleGraphInclusive :=
   fun _ _ h ↦ ⟨h.1, Or.inl h.2.1⟩
 
-@[mono]
+@[gcongr, mono]
 lemma toSimpleGraphInclusive_mono : Monotone (toSimpleGraphInclusive : _ → SimpleGraph V) :=
   fun _ _ h₁ _ _ h₂ ↦ ⟨h₂.1, h₂.2.imp (@h₁ _ _) (@h₁ _ _)⟩
 
-@[mono]
+@[gcongr, mono]
 lemma toSimpleGraphStrict_mono : Monotone (toSimpleGraphStrict : _ → SimpleGraph V) :=
   fun _ _ h₁ _ _ h₂ ↦ ⟨h₂.1, h₁ h₂.2.1, h₁ h₂.2.2⟩
 

--- a/Mathlib/Combinatorics/SetFamily/Intersecting.lean
+++ b/Mathlib/Combinatorics/SetFamily/Intersecting.lean
@@ -46,7 +46,7 @@ variable [SemilatticeInf α] [OrderBot α] {s t : Set α} {a b c : α}
 def Intersecting (s : Set α) : Prop :=
   ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → ¬Disjoint a b
 
-@[mono]
+@[gcongr, mono]
 theorem Intersecting.mono (h : t ⊆ s) (hs : s.Intersecting) : t.Intersecting := fun _a ha _b hb =>
   hs (h ha) (h hb)
 

--- a/Mathlib/Combinatorics/SetFamily/Shadow.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shadow.lean
@@ -83,7 +83,7 @@ theorem shadow_singleton (a : α) : ∂ {{a}} = {∅} := by
   simp [shadow]
 
 /-- The shadow is monotone. -/
-@[mono]
+@[gcongr, mono]
 theorem shadow_monotone : Monotone (shadow : Finset (Finset α) → Finset (Finset α)) := fun _ _ =>
   sup_mono
 
@@ -195,7 +195,7 @@ theorem upShadow_empty : ∂⁺ (∅ : Finset (Finset α)) = ∅ :=
   rfl
 
 /-- The upper shadow is monotone. -/
-@[mono]
+@[gcongr, mono]
 theorem upShadow_monotone : Monotone (upShadow : Finset (Finset α) → Finset (Finset α)) :=
   fun _ _ => sup_mono
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -129,11 +129,11 @@ protected theorem Reachable.map {u v : V} {G : SimpleGraph V} {G' : SimpleGraph 
     (h : G.Reachable u v) : G'.Reachable (f u) (f v) :=
   h.elim fun p => ⟨p.map f⟩
 
-@[mono]
+@[gcongr, mono]
 protected lemma Reachable.mono {u v : V} {G G' : SimpleGraph V}
     (h : G ≤ G') (Guv : G.Reachable u v) : G'.Reachable u v := Guv.map (.ofLE h)
 
-@[mono]
+@[gcongr, mono]
 theorem Reachable.mono' {G G' : SimpleGraph V} (h : G ≤ G') : G.Reachable ≤ G'.Reachable :=
   fun _ _ ↦ Reachable.mono h
 
@@ -230,7 +230,7 @@ theorem Preconnected.map {G : SimpleGraph V} {H : SimpleGraph V'} (f : G →g H)
     (hG : G.Preconnected) : H.Preconnected :=
   hf.forall₂.2 fun _ _ => Nonempty.map (Walk.map _) <| hG _ _
 
-@[mono]
+@[gcongr, mono]
 protected lemma Preconnected.mono {G G' : SimpleGraph V} (h : G ≤ G') (hG : G.Preconnected) :
     G'.Preconnected := fun u v => (hG u v).mono h
 
@@ -329,7 +329,7 @@ theorem Connected.map {G : SimpleGraph V} {H : SimpleGraph V'} (f : G →g H) (h
   haveI := hG.nonempty.map f
   ⟨hG.preconnected.map f hf⟩
 
-@[mono]
+@[gcongr, mono]
 protected lemma Connected.mono {G G' : SimpleGraph V} (h : G ≤ G')
     (hG : G.Connected) : G'.Connected where
   preconnected := hG.preconnected.mono h

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -81,7 +81,7 @@ lemma top_induce_pair_connected_of_adj {u v : V} (huv : G.Adj u v) :
   rw [← subgraphOfAdj_eq_induce huv]
   exact subgraphOfAdj_connected huv
 
-@[mono]
+@[gcongr, mono]
 protected lemma Connected.mono {H H' : G.Subgraph} (hle : H ≤ H') (hv : H.verts = H'.verts)
     (h : H.Connected) : H'.Connected := by
   rw [← Subgraph.copy_eq H' H.verts hv H'.Adj rfl]

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1219,11 +1219,11 @@ theorem induce_mono (hg : G' ≤ G'') (hs : s ⊆ s') : G'.induce s ≤ G''.indu
     intro v w hv hw ha
     exact ⟨hs hv, hs hw, hg.2 ha⟩
 
-@[mono]
+@[gcongr, mono]
 theorem induce_mono_left (hg : G' ≤ G'') : G'.induce s ≤ G''.induce s :=
   induce_mono hg subset_rfl
 
-@[mono]
+@[gcongr, mono]
 theorem induce_mono_right (hs : s ⊆ s') : G'.induce s ≤ G'.induce s' :=
   induce_mono le_rfl hs
 

--- a/Mathlib/Combinatorics/Young/YoungDiagram.lean
+++ b/Mathlib/Combinatorics/Young/YoungDiagram.lean
@@ -225,7 +225,7 @@ theorem transpose_le_iff {μ ν : YoungDiagram} : μ.transpose ≤ ν.transpose 
     rw [← transpose_transpose μ] at h
     exact YoungDiagram.le_of_transpose_le h ⟩
 
-@[mono]
+@[gcongr, mono]
 protected theorem transpose_mono {μ ν : YoungDiagram} (h_le : μ ≤ ν) : μ.transpose ≤ ν.transpose :=
   transpose_le_iff.mpr h_le
 
@@ -287,7 +287,7 @@ theorem row_eq_prod {μ : YoungDiagram} {i : ℕ} : μ.row i = {i} ×ˢ Finset.r
 theorem rowLen_eq_card (μ : YoungDiagram) {i : ℕ} : μ.rowLen i = (μ.row i).card := by
   simp [row_eq_prod]
 
-@[mono]
+@[gcongr, mono]
 theorem rowLen_anti (μ : YoungDiagram) (i1 i2 : ℕ) (hi : i1 ≤ i2) : μ.rowLen i2 ≤ μ.rowLen i1 := by
   by_contra! h_lt
   rw [← lt_self_iff_false (μ.rowLen i1)]
@@ -342,7 +342,7 @@ theorem col_eq_prod {μ : YoungDiagram} {j : ℕ} : μ.col j = Finset.range (μ.
 theorem colLen_eq_card (μ : YoungDiagram) {j : ℕ} : μ.colLen j = (μ.col j).card := by
   simp [col_eq_prod]
 
-@[mono]
+@[gcongr, mono]
 theorem colLen_anti (μ : YoungDiagram) (j1 j2 : ℕ) (hj : j1 ≤ j2) : μ.colLen j2 ≤ μ.colLen j1 := by
   convert μ.transpose.rowLen_anti j1 j2 hj using 1 <;> simp
 

--- a/Mathlib/Data/Finset/Density.lean
+++ b/Mathlib/Data/Finset/Density.lean
@@ -98,8 +98,8 @@ lemma dens_lt_dens (h : s ⊂ t) : dens s < dens t :=
     _ < #t := by gcongr
     _ ≤ Fintype.card α := card_le_univ t
 
-@[mono] lemma dens_mono : Monotone (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_le_dens
-@[mono] lemma dens_strictMono : StrictMono (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_lt_dens
+@[gcongr, mono] lemma dens_mono : Monotone (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_le_dens
+@[gcongr, mono] lemma dens_strictMono : StrictMono (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_lt_dens
 
 lemma dens_map_le [Fintype β] (f : α ↪ β) : dens (s.map f) ≤ dens s := by
   cases isEmpty_or_nonempty α

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -594,7 +594,7 @@ theorem mem_subtype {p : α → Prop} [DecidablePred p] {s : Finset α} :
 theorem subtype_eq_empty {p : α → Prop} [DecidablePred p] {s : Finset α} :
     s.subtype p = ∅ ↔ ∀ x, p x → x ∉ s := by simp [Finset.ext_iff, Subtype.forall]
 
-@[mono]
+@[gcongr, mono]
 theorem subtype_mono {p : α → Prop} [DecidablePred p] : Monotone (Finset.subtype p) :=
   fun _ _ h _ hx => mem_subtype.2 <| h <| mem_subtype.1 hx
 

--- a/Mathlib/Data/Finset/PImage.lean
+++ b/Mathlib/Data/Finset/PImage.lean
@@ -94,7 +94,7 @@ theorem pimage_empty : pimage f ∅ = ∅ := by
 theorem pimage_subset {t : Finset β} : s.pimage f ⊆ t ↔ ∀ x ∈ s, ∀ y ∈ f x, y ∈ t := by
   simp [subset_iff, @forall_comm _ β]
 
-@[mono]
+@[gcongr, mono]
 theorem pimage_mono (h : s ⊆ t) : s.pimage f ⊆ t.pimage f :=
   pimage_subset.2 fun x hx _ hy => mem_pimage.2 ⟨x, h hx, hy⟩
 

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -295,10 +295,10 @@ theorem offDiag_card : (offDiag s).card = s.card * s.card - s.card := by
   rcases s with ⟨⟨s⟩, hs⟩
   apply List.length_offDiag
 
-@[mono]
+@[gcongr, mono]
 theorem diag_mono : Monotone (diag : Finset α → Finset (α × α)) := fun _ _ ↦ by simp [diag]
 
-@[mono]
+@[gcongr, mono]
 theorem offDiag_mono : Monotone (offDiag : Finset α → Finset (α × α)) := fun _ _ h _ hx =>
   mem_offDiag.2 <| And.imp (@h _) (And.imp_left <| @h _) <| mem_offDiag.1 hx
 

--- a/Mathlib/Data/Finset/Sigma.lean
+++ b/Mathlib/Data/Finset/Sigma.lean
@@ -66,7 +66,7 @@ alias ⟨_, Aesop.sigma_nonempty_of_exists_nonempty⟩ := sigma_nonempty
 theorem sigma_eq_empty : s.sigma t = ∅ ↔ ∀ i ∈ s, t i = ∅ := by
   contrapose!; exact sigma_nonempty
 
-@[mono]
+@[gcongr, mono]
 theorem sigma_mono (hs : s₁ ⊆ s₂) (ht : ∀ i, t₁ i ⊆ t₂ i) : s₁.sigma t₁ ⊆ s₂.sigma t₂ :=
   fun ⟨i, _⟩ h =>
   let ⟨hi, ha⟩ := mem_sigma.1 h

--- a/Mathlib/Data/Fintype/Sets.lean
+++ b/Mathlib/Data/Fintype/Sets.lean
@@ -80,7 +80,7 @@ alias ⟨_, Aesop.toFinset_nonempty_of_nonempty⟩ := toFinset_nonempty
 theorem toFinset_inj {s t : Set α} [Fintype s] [Fintype t] : s.toFinset = t.toFinset ↔ s = t :=
   ⟨fun h => by rw [← s.coe_toFinset, h, t.coe_toFinset], fun h => by simp [h]⟩
 
-@[mono]
+@[gcongr, mono]
 theorem toFinset_subset_toFinset [Fintype s] [Fintype t] : s.toFinset ⊆ t.toFinset ↔ s ⊆ t := by
   simp [Finset.subset_iff, Set.subset_def]
 
@@ -96,7 +96,7 @@ theorem subset_toFinset {s : Finset α} [Fintype t] : s ⊆ t.toFinset ↔ ↑s 
 theorem ssubset_toFinset {s : Finset α} [Fintype t] : s ⊂ t.toFinset ↔ ↑s ⊂ t := by
   rw [← Finset.coe_ssubset, coe_toFinset]
 
-@[mono]
+@[gcongr, mono]
 theorem toFinset_ssubset_toFinset [Fintype s] [Fintype t] : s.toFinset ⊂ t.toFinset ↔ s ⊂ t := by
   simp only [Finset.ssubset_def, toFinset_subset_toFinset, ssubset_def]
 

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -271,7 +271,7 @@ theorem clog_one_left (r : R) : clog 1 r = 0 := by
 theorem clog_zpow {b : ℕ} (hb : 1 < b) (z : ℤ) : clog b (b ^ z : R) = z := by
   rw [← neg_log_inv_eq_clog, ← zpow_neg, log_zpow hb, neg_neg]
 
-@[mono]
+@[gcongr, mono]
 theorem clog_mono_right {b : ℕ} {r₁ r₂ : R} (h₀ : 0 < r₁) (h : r₁ ≤ r₂) :
     clog b r₁ ≤ clog b r₂ := by
   have h₀' : 0 < r₂ := lt_of_lt_of_le h₀ h

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -131,7 +131,7 @@ theorem mem_of_mem_toEnumFinset {p : α × ℕ} (h : p ∈ m.toEnumFinset) : p.1
     lia
   exact Nat.le_of_pred_lt (han.trans_lt <| by simpa using hsm hn)
 
-@[mono]
+@[gcongr, mono]
 theorem toEnumFinset_mono {m₁ m₂ : Multiset α} (h : m₁ ≤ m₂) :
     m₁.toEnumFinset ⊆ m₂.toEnumFinset := by
   intro p

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -334,7 +334,7 @@ set_option backward.privateInPublic true in
 @[simp, norm_cast] lemma coe_le_one : (r : ℝ) ≤ 1 ↔ r ≤ 1 := by rw [← coe_le_coe, coe_one]
 @[simp, norm_cast] lemma coe_lt_one : (r : ℝ) < 1 ↔ r < 1 := by rw [← coe_lt_coe, coe_one]
 
-@[mono] lemma coe_mono : Monotone ((↑) : ℝ≥0 → ℝ) := fun _ _ => NNReal.coe_le_coe.2
+@[gcongr, mono] lemma coe_mono : Monotone ((↑) : ℝ≥0 → ℝ) := fun _ _ => NNReal.coe_le_coe.2
 
 protected theorem _root_.Real.toNNReal_monotone : Monotone Real.toNNReal := fun _ _ h =>
   max_le_max_right _ h

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -66,7 +66,7 @@ theorem count_le {n : ℕ} : count p n ≤ n := by
 theorem count_succ (n : ℕ) : count p (n + 1) = count p n + if p n then 1 else 0 := by
   grind [count, List.range_succ]
 
-@[mono]
+@[gcongr, mono]
 theorem count_monotone : Monotone (count p) :=
   monotone_nat_of_le_succ (by grind)
 

--- a/Mathlib/Data/Nat/Digits/Defs.lean
+++ b/Mathlib/Data/Nat/Digits/Defs.lean
@@ -407,7 +407,7 @@ theorem ofDigits_digits_append_digits {b m n : ℕ} :
     ofDigits b (digits b n ++ digits b m) = n + b ^ (digits b n).length * m := by
   rw [ofDigits_append, ofDigits_digits, ofDigits_digits]
 
-@[mono]
+@[gcongr, mono]
 theorem ofDigits_monotone {p q : ℕ} (L : List ℕ) (h : p ≤ q) : ofDigits p L ≤ ofDigits q L := by
   induction L with
   | nil => rfl

--- a/Mathlib/Data/Nat/Fib/Basic.lean
+++ b/Mathlib/Data/Nat/Fib/Basic.lean
@@ -79,7 +79,7 @@ lemma fib_add_one : ∀ {n}, n ≠ 0 → fib (n + 1) = fib (n - 1) + fib n
 
 theorem fib_le_fib_succ {n : ℕ} : fib n ≤ fib (n + 1) := by cases n <;> simp [fib_add_two]
 
-@[mono]
+@[gcongr, mono]
 theorem fib_mono : Monotone fib :=
   monotone_nat_of_le_succ fun _ => fib_le_fib_succ
 

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -37,10 +37,10 @@ theorem one_add_natPred (n : ℕ+) : 1 + n.natPred = n := by
 theorem natPred_add_one (n : ℕ+) : n.natPred + 1 = n :=
   (add_comm _ _).trans n.one_add_natPred
 
-@[mono]
+@[gcongr, mono]
 theorem natPred_strictMono : StrictMono natPred := fun m _ h => Nat.pred_lt_pred m.2.ne' h
 
-@[mono]
+@[gcongr, mono]
 theorem natPred_monotone : Monotone natPred :=
   natPred_strictMono.monotone
 
@@ -73,10 +73,10 @@ end PNat
 
 namespace Nat
 
-@[mono]
+@[gcongr, mono]
 theorem succPNat_strictMono : StrictMono succPNat := fun _ _ => Nat.succ_lt_succ
 
-@[mono]
+@[gcongr, mono]
 theorem succPNat_mono : Monotone succPNat :=
   succPNat_strictMono.monotone
 

--- a/Mathlib/Data/Rat/Cast/Order.lean
+++ b/Mathlib/Data/Rat/Cast/Order.lean
@@ -152,7 +152,7 @@ theorem cast_strictMono : StrictMono ((↑) : ℚ≥0 → K) := fun p q h => by
   · simp
   · simp
 
-@[mono]
+@[gcongr, mono]
 theorem cast_mono : Monotone ((↑) : ℚ≥0 → K) :=
   cast_strictMono.monotone
 

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -75,11 +75,11 @@ theorem toENNReal_lt : (m : ℝ≥0∞) < n ↔ m < n :=
 @[simp, norm_cast]
 lemma toENNReal_lt_top : (n : ℝ≥0∞) < ∞ ↔ n < ⊤ := by simp [← toENNReal_lt]
 
-@[mono]
+@[gcongr, mono]
 theorem toENNReal_mono : Monotone ((↑) : ℕ∞ → ℝ≥0∞) :=
   toENNRealOrderEmbedding.monotone
 
-@[mono]
+@[gcongr, mono]
 theorem toENNReal_strictMono : StrictMono ((↑) : ℕ∞ → ℝ≥0∞) :=
   toENNRealOrderEmbedding.strictMono
 

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -145,11 +145,11 @@ theorem subset_toFinset {s : Finset α} : s ⊆ ht.toFinset ↔ ↑s ⊆ t := by
 theorem ssubset_toFinset {s : Finset α} : s ⊂ ht.toFinset ↔ ↑s ⊂ t := by
   rw [← Finset.coe_ssubset, Finite.coe_toFinset]
 
-@[mono]
+@[gcongr, mono]
 protected theorem toFinset_subset_toFinset : hs.toFinset ⊆ ht.toFinset ↔ s ⊆ t := by
   simp only [← Finset.coe_subset, Finite.coe_toFinset]
 
-@[mono]
+@[gcongr, mono]
 protected theorem toFinset_ssubset_toFinset : hs.toFinset ⊂ ht.toFinset ↔ s ⊂ t := by
   simp only [← Finset.coe_ssubset, Finite.coe_toFinset]
 

--- a/Mathlib/Data/Set/Subset.lean
+++ b/Mathlib/Data/Set/Subset.lean
@@ -134,7 +134,7 @@ lemma image_val_injective : Function.Injective ((↑) : Set A → Set α) :=
 lemma subset_of_image_val_subset_image_val (h : (↑D : Set α) ⊆ ↑E) : D ⊆ E :=
   (image_subset_image_iff Subtype.val_injective).1 h
 
-@[mono]
+@[gcongr, mono]
 lemma image_val_mono (h : D ⊆ E) : (↑D : Set α) ⊆ ↑E :=
   (image_subset_image_iff Subtype.val_injective).2 h
 

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -269,7 +269,7 @@ section Preorder
 
 variable [Preorder A] [IsConcreteLE A B] {p q : A}
 
-@[mono]
+@[gcongr, mono]
 theorem coe_mono : Monotone (SetLike.coe : A → Set B) := fun _ _ => coe_subset_coe.mpr
 
 end Preorder
@@ -281,7 +281,7 @@ variable [PartialOrder A] [IsConcreteLE A B] {p q : A}
 @[simp, norm_cast, gcongr] lemma coe_ssubset_coe {S T : A} : (S : Set B) ⊂ T ↔ S < T := by
   rw [ssubset_iff_subset_ne, lt_iff_le_and_ne, coe_subset_coe, SetLike.coe_ne_coe]
 
-@[mono]
+@[gcongr, mono]
 theorem coe_strictMono : StrictMono (SetLike.coe : A → Set B) := fun _ _ => coe_ssubset_coe.mpr
 
 theorem exists_of_lt : p < q → ∃ x ∈ q, x ∉ p := by

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -147,7 +147,7 @@ variable (f g : CircleDeg1Lift)
 
 protected theorem monotone : Monotone f := f.monotone'
 
-@[mono] theorem mono {x y} (h : x ≤ y) : f x ≤ f y := f.monotone h
+@[gcongr, mono] theorem mono {x y} (h : x ≤ y) : f x ≤ f y := f.monotone h
 
 theorem strictMono_iff_injective : StrictMono f ↔ Injective f :=
   f.monotone.strictMono_iff_injective

--- a/Mathlib/Geometry/Diffeology/Basic.lean
+++ b/Mathlib/Geometry/Diffeology/Basic.lean
@@ -545,7 +545,7 @@ def giGenerateFrom (X : Type*) : GaloisInsertion generateFrom (@toPlots X) where
 
 instance : CompleteLattice (DiffeologicalSpace X) := (giGenerateFrom X).liftCompleteLattice
 
-@[mono]
+@[gcongr, mono]
 theorem generateFrom_mono {g₁ g₂ : Set ((n : ℕ) × (𝔼ⁿ → X))} (h : g₁ ⊆ g₂) :
     generateFrom g₁ ≤ generateFrom g₂ :=
   (gc_generateFrom _).monotone_l h

--- a/Mathlib/LinearAlgebra/Dual/Defs.lean
+++ b/Mathlib/LinearAlgebra/Dual/Defs.lean
@@ -398,12 +398,12 @@ theorem dualAnnihilator_top : (⊤ : Submodule R M).dualAnnihilator = ⊥ := by
 theorem dualCoannihilator_bot : (⊥ : Submodule R (Module.Dual R M)).dualCoannihilator = ⊤ :=
   (dualAnnihilator_gc R M).u_top
 
-@[mono]
+@[gcongr, mono]
 theorem dualAnnihilator_anti {U V : Submodule R M} (hUV : U ≤ V) :
     V.dualAnnihilator ≤ U.dualAnnihilator :=
   (dualAnnihilator_gc R M).monotone_l hUV
 
-@[mono]
+@[gcongr, mono]
 theorem dualCoannihilator_anti {U V : Submodule R (Module.Dual R M)} (hUV : U ≤ V) :
     V.dualCoannihilator ≤ U.dualCoannihilator :=
   (dualAnnihilator_gc R M).monotone_u hUV

--- a/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
@@ -150,7 +150,7 @@ theorem span_le_subspace_iff {S : Set (ℙ K V)} {W : Subspace K V} : span S ≤
 
 /-- If a set of points is a subset of another set of points, then its span will be contained in the
 span of that set. -/
-@[mono]
+@[gcongr, mono]
 theorem monotone_span : Monotone (span : Set (ℙ K V) → Subspace K V) :=
   gi.gc.monotone_l
 

--- a/Mathlib/LinearAlgebra/SModEq/Basic.lean
+++ b/Mathlib/LinearAlgebra/SModEq/Basic.lean
@@ -53,7 +53,7 @@ theorem top : x ≡ y [SMOD (⊤ : Submodule R M)] :=
 theorem bot : x ≡ y [SMOD (⊥ : Submodule R M)] ↔ x = y := by
   rw [SModEq.def, Submodule.Quotient.eq, mem_bot, sub_eq_zero]
 
-@[mono]
+@[gcongr, mono]
 theorem mono (HU : U₁ ≤ U₂) (hxy : x ≡ y [SMOD U₁]) : x ≡ y [SMOD U₂] :=
   (Submodule.Quotient.eq U₂).2 <| HU <| (Submodule.Quotient.eq U₁).1 hxy
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -70,7 +70,7 @@ theorem SimpleFunc.lintegral_eq_lintegral {m : MeasurableSpace α} (f : α →�
   exact le_antisymm (iSup₂_le fun g hg => lintegral_mono hg <| le_rfl)
     (le_iSup₂_of_le f le_rfl le_rfl)
 
-@[mono]
+@[gcongr, mono]
 theorem lintegral_mono' {m : MeasurableSpace α} ⦃μ ν : Measure α⦄ (hμν : μ ≤ ν) ⦃f g : α → ℝ≥0∞⦄
     (hfg : f ≤ g) : ∫⁻ a, f a ∂μ ≤ ∫⁻ a, g a ∂ν := by
   rw [lintegral, lintegral]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -395,7 +395,7 @@ instance : CompleteLattice (MeasurableSpace α) :=
 
 instance : Inhabited (MeasurableSpace α) := ⟨⊤⟩
 
-@[mono]
+@[gcongr, mono]
 theorem generateFrom_mono {s t : Set (Set α)} (h : s ⊆ t) : generateFrom s ≤ generateFrom t :=
   giGenerateFrom.gc.monotone_l h
 

--- a/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
@@ -84,7 +84,7 @@ protected lemma zero (μ : Measure α) : 0 ≪ μ := fun _ _ ↦ by simp
 @[trans]
 protected theorem trans (h1 : μ₁ ≪ μ₂) (h2 : μ₂ ≪ μ₃) : μ₁ ≪ μ₃ := fun _s hs => h1 <| h2 hs
 
-@[mono]
+@[gcongr, mono]
 protected theorem map (h : μ ≪ ν) {f : α → β} (hf : Measurable f) : μ.map f ≪ ν.map f :=
   AbsolutelyContinuous.mk fun s hs => by simpa [hf, hs] using @h _
 

--- a/Mathlib/MeasureTheory/Measure/Map.lean
+++ b/Mathlib/MeasureTheory/Measure/Map.lean
@@ -203,7 +203,7 @@ theorem map_map {g : β → γ} {f : α → β} (hg : Measurable g) (hf : Measur
     (μ.map f).map g = μ.map (g ∘ f) :=
   ext fun s hs => by simp [hf, hg, hs, hg hs, hg.comp hf, ← preimage_comp]
 
-@[mono]
+@[gcongr, mono]
 theorem map_mono {f : α → β} (h : μ ≤ ν) (hf : Measurable f) : μ.map f ≤ ν.map f :=
   le_iff.2 fun s hs ↦ by simp [hf.aemeasurable, hs, h _]
 

--- a/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
@@ -69,7 +69,7 @@ theorem mono_right (h : QuasiMeasurePreserving f μa μb) (ha : μb ≪ μb') :
     QuasiMeasurePreserving f μa μb' :=
   ⟨h.1, h.2.trans ha⟩
 
-@[mono]
+@[gcongr, mono]
 theorem mono (ha : μa' ≪ μa) (hb : μb ≪ μb') (h : QuasiMeasurePreserving f μa μb) :
     QuasiMeasurePreserving f μa' μb' :=
   (h.mono_left ha).mono_right hb

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -480,7 +480,7 @@ theorem filter_mono_ae (h : f ⊓ (ae μ) ≤ g) (hg : μ.FiniteAtFilter g) : μ
 protected theorem measure_mono (h : μ ≤ ν) : ν.FiniteAtFilter f → μ.FiniteAtFilter f :=
   fun ⟨s, hs, hν⟩ => ⟨s, hs, (Measure.le_iff'.1 h s).trans_lt hν⟩
 
-@[mono]
+@[gcongr, mono]
 protected theorem mono (hf : f ≤ g) (hμ : μ ≤ ν) : ν.FiniteAtFilter g → μ.FiniteAtFilter f :=
   fun h => (h.filter_mono hf).measure_mono hμ
 

--- a/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
@@ -329,7 +329,7 @@ theorem trim_congr {m₁ m₂ : OuterMeasure α} (H : ∀ {s : Set α}, Measurab
     m₁.trim = m₂.trim := by
   simp +contextual only [trim, H]
 
-@[mono]
+@[gcongr, mono]
 theorem trim_mono : Monotone (trim : OuterMeasure α → OuterMeasure α) := fun _m₁ _m₂ H _s =>
   iInf₂_mono fun _f _hs => ENNReal.tsum_le_tsum fun _b => iInf_mono fun _hf => H _
 

--- a/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
@@ -225,7 +225,7 @@ theorem map_map {β γ} (f : α → β) (g : β → γ) (m : OuterMeasure α) :
     map g (map f m) = map (g ∘ f) m :=
   ext fun _ => rfl
 
-@[mono]
+@[gcongr, mono]
 theorem map_mono {β} (f : α → β) : Monotone (map f) := fun _ _ h _ => h _
 
 @[simp]
@@ -284,7 +284,7 @@ def comap {β} (f : α → β) : OuterMeasure β →ₗ[ℝ≥0∞] OuterMeasure
 theorem comap_apply {β} (f : α → β) (m : OuterMeasure β) (s : Set α) : comap f m s = m (f '' s) :=
   rfl
 
-@[mono]
+@[gcongr, mono]
 theorem comap_mono {β} (f : α → β) : Monotone (comap f) := fun _ _ h _ => h _
 
 @[simp]

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -331,7 +331,7 @@ theorem ofAntisymmetrization_lt_ofAntisymmetrization_iff {a b : Antisymmetrizati
     ofAntisymmetrization (· ≤ ·) a < ofAntisymmetrization (· ≤ ·) b ↔ a < b :=
   (Quotient.outRelEmbedding _).map_rel_iff
 
-@[mono]
+@[gcongr, mono]
 theorem toAntisymmetrization_mono : Monotone (toAntisymmetrization (α := α) (· ≤ ·)) :=
   fun _ _ => id
 

--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -123,7 +123,7 @@ variable {α} (c : ClosureOperator α)
 theorem ext : ∀ c₁ c₂ : ClosureOperator α, (∀ x, c₁ x = c₂ x) → c₁ = c₂ :=
   DFunLike.ext
 
-@[mono]
+@[gcongr, mono]
 theorem monotone : Monotone c :=
   c.monotone'
 
@@ -341,7 +341,7 @@ theorem ext : ∀ l₁ l₂ : LowerAdjoint u, (l₁ : α → β) = (l₂ : α �
   | ⟨l₁, _⟩, ⟨l₂, _⟩, h => by
     congr
 
-@[mono]
+@[gcongr, mono]
 theorem monotone : Monotone (u ∘ l) :=
   l.gc.monotone_u.comp l.gc.monotone_l
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1189,22 +1189,22 @@ theorem Eventually.lt_top_iff_ne_top [PartialOrder β] [OrderTop β] {l : Filter
     (∀ᶠ x in l, f x < ⊤) ↔ ∀ᶠ x in l, f x ≠ ⊤ :=
   ⟨Eventually.ne_of_lt, Eventually.lt_top_of_ne⟩
 
-@[mono]
+@[gcongr, mono]
 theorem EventuallyLE.inter {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : s' ≤ᶠ[l] t') :
     (s ∩ s' : Set α) ≤ᶠ[l] (t ∩ t' : Set α) :=
   h'.mp <| h.mono fun _ => And.imp
 
-@[mono]
+@[gcongr, mono]
 theorem EventuallyLE.union {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : s' ≤ᶠ[l] t') :
     (s ∪ s' : Set α) ≤ᶠ[l] (t ∪ t' : Set α) :=
   h'.mp <| h.mono fun _ => Or.imp
 
-@[mono]
+@[gcongr, mono]
 theorem EventuallyLE.compl {s t : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) :
     (tᶜ : Set α) ≤ᶠ[l] (sᶜ : Set α) :=
   h.mono fun _ => mt
 
-@[mono]
+@[gcongr, mono]
 theorem EventuallyLE.diff {s t s' t' : Set α} {l : Filter α} (h : s ≤ᶠ[l] t) (h' : t' ≤ᶠ[l] s') :
     (s \ s' : Set α) ≤ᶠ[l] (t \ t' : Set α) :=
   h.inter h'.compl

--- a/Mathlib/Order/Filter/Map.lean
+++ b/Mathlib/Order/Filter/Map.lean
@@ -859,7 +859,7 @@ theorem le_seq {f : Filter (α → β)} {g : Filter α} {h : Filter β}
     (hh : ∀ t ∈ f, ∀ u ∈ g, Set.seq t u ∈ h) : h ≤ seq f g := fun _ ⟨_, ht, _, hu, hs⟩ =>
   mem_of_superset (hh _ ht _ hu) fun _ ⟨_, hm, _, ha, eq⟩ => eq ▸ hs _ hm _ ha
 
-@[mono]
+@[gcongr, mono]
 theorem seq_mono {f₁ f₂ : Filter (α → β)} {g₁ g₂ : Filter α} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) :
     f₁.seq g₁ ≤ f₂.seq g₂ :=
   le_seq fun _ hs _ ht => seq_mem_seq (hf hs) (hg ht)
@@ -968,7 +968,7 @@ theorem bind_le {f : Filter α} {g : α → Filter β} {l : Filter β} (h : ∀�
     f.bind g ≤ l :=
   join_le <| eventually_map.2 h
 
-@[mono]
+@[gcongr, mono]
 theorem bind_mono {f₁ f₂ : Filter α} {g₁ g₂ : α → Filter β} (hf : f₁ ≤ f₂) (hg : g₁ ≤ᶠ[f₁] g₂) :
     bind f₁ g₁ ≤ bind f₂ g₂ := by
   refine le_trans (fun s hs => ?_) (join_mono <| map_mono hf)

--- a/Mathlib/Order/Filter/Pi.lean
+++ b/Mathlib/Order/Filter/Pi.lean
@@ -50,7 +50,7 @@ alias ⟨Tendsto.apply, _⟩ := tendsto_pi
 theorem le_pi {g : Filter (∀ i, α i)} : g ≤ pi f ↔ ∀ i, Tendsto (eval i) g (f i) :=
   tendsto_pi
 
-@[mono]
+@[gcongr, mono]
 theorem pi_mono (h : ∀ i, f₁ i ≤ f₂ i) : pi f₁ ≤ pi f₂ :=
   iInf_mono fun i => comap_mono <| h i
 
@@ -307,7 +307,7 @@ theorem coprodᵢ_neBot [∀ i, Nonempty (α i)] [Nonempty ι] (f : ∀ i, Filte
     [H : ∀ i, NeBot (f i)] : NeBot (Filter.coprodᵢ f) :=
   (H (Classical.arbitrary ι)).coprodᵢ
 
-@[mono]
+@[gcongr, mono]
 theorem coprodᵢ_mono (hf : ∀ i, f₁ i ≤ f₂ i) : Filter.coprodᵢ f₁ ≤ Filter.coprodᵢ f₂ :=
   iSup_mono fun i => comap_mono (hf i)
 

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -462,7 +462,7 @@ theorem compl_mem_coprod {s : Set (α × β)} {la : Filter α} {lb : Filter β} 
     sᶜ ∈ la.coprod lb ↔ (Prod.fst '' s)ᶜ ∈ la ∧ (Prod.snd '' s)ᶜ ∈ lb := by
   simp only [Filter.coprod, mem_sup, compl_mem_comap]
 
-@[mono]
+@[gcongr, mono]
 theorem coprod_mono {f₁ f₂ : Filter α} {g₁ g₂ : Filter β} (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) :
     f₁.coprod g₁ ≤ f₂.coprod g₂ :=
   sup_le_sup (comap_mono hf) (comap_mono hg)

--- a/Mathlib/Order/Filter/SmallSets.lean
+++ b/Mathlib/Order/Filter/SmallSets.lean
@@ -127,7 +127,7 @@ theorem HasAntitoneBasis.tendsto_smallSets {ι} [Preorder ι] {s : ι → Set α
     (hl : l.HasAntitoneBasis s) : Tendsto s atTop l.smallSets :=
   tendsto_smallSets_iff.2 fun _t ht => hl.eventually_subset ht
 
-@[mono]
+@[gcongr, mono]
 theorem monotone_smallSets : Monotone (@smallSets α) :=
   monotone_lift' monotone_id monotone_const
 

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -126,7 +126,7 @@ theorem one_le_chainHeight_iff : 1 ≤ s.chainHeight r ↔ s.Nonempty := by
 theorem chainHeight_of_isEmpty [IsEmpty α] : s.chainHeight r = 0 :=
   chainHeight_eq_zero_iff s r |>.mpr (Subsingleton.elim _ _)
 
-@[mono]
+@[gcongr, mono]
 theorem chainHeight_mono (s t : Set α) (h : s ⊆ t) : s.chainHeight r ≤ t.chainHeight r := by
   refine forall_natCast_le_iff_le.mp fun n hn ↦ ?_
   obtain ⟨a, ha₁, ha₂, ha₃⟩ := exists_isChain_of_le_chainHeight n hn

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -135,7 +135,7 @@ theorem mem_map_iff {b : β} : b ∈ c.map f ↔ ∃ a, a ∈ c ∧ f a = b :=
 theorem map_comp : (c.map f).map g = c.map (g.comp f) :=
   rfl
 
-@[mono]
+@[gcongr, mono]
 theorem map_le_map {g : α →o β} (h : f ≤ g) : c.map f ≤ c.map g := fun _ ↦ ⟨_, h _⟩
 
 /-- `OmegaCompletePartialOrder.Chain.zip` pairs up the elements of two chains
@@ -210,7 +210,7 @@ theorem ωSup_total {c : Chain α} {x : α} (h : ∀ i, c i ≤ x ∨ x ≤ c i)
       have : x ≤ c i := (h i).resolve_left hx
       Or.inr <| le_ωSup_of_le _ this)
 
-@[mono]
+@[gcongr, mono]
 theorem ωSup_le_ωSup_of_le {c₀ c₁ : Chain α} (h : c₀ ≤ c₁) : ωSup c₀ ≤ ωSup c₁ :=
   (ωSup_le _ _) fun i => by
     obtain ⟨_, h⟩ := h i
@@ -540,7 +540,7 @@ protected theorem congr_arg (f : α →𝒄 β) {x y : α} (h : x = y) : f x = f
 protected theorem monotone (f : α →𝒄 β) : Monotone f :=
   f.monotone'
 
-@[mono]
+@[gcongr, mono]
 theorem apply_mono {f g : α →𝒄 β} {x y : α} (h₁ : f ≤ g) (h₂ : x ≤ y) : f x ≤ g y :=
   OrderHom.apply_mono (show (f : α →o β) ≤ g from h₁) h₂
 

--- a/Mathlib/Order/UpperLower/Prod.lean
+++ b/Mathlib/Order/UpperLower/Prod.lean
@@ -99,7 +99,7 @@ theorem prod_sup_prod : s₁ ×ˢ t₁ ⊔ s₂ ×ˢ t₂ = (s₁ ⊔ s₂) ×ˢ
 
 variable {s s₁ s₂ t t₁ t₂}
 
-@[mono]
+@[gcongr, mono]
 theorem prod_mono : s₁ ≤ s₂ → t₁ ≤ t₂ → s₁ ×ˢ t₁ ≤ s₂ ×ˢ t₂ :=
   Set.prod_mono
 

--- a/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Maps.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Maps.lean
@@ -67,7 +67,7 @@ theorem gc_map_comap : GaloisConnection (map f) (comap f) := fun _ _ ↦
 
 @[mono, aesop safe apply] lemma map_mono : Monotone (map f) := (gc_map_comap f).monotone_l
 
-@[mono] lemma comap_mono : Monotone (comap f) := (gc_map_comap f).monotone_u
+@[gcongr, mono] lemma comap_mono : Monotone (comap f) := (gc_map_comap f).monotone_u
 
 @[simp] lemma toIdeal_comap : (J.comap f).toIdeal = J.toIdeal.comap f := rfl
 

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -99,7 +99,7 @@ theorem map_spanIntNorm (I : Ideal S) {T : Type*} [Semiring T] (f : R →+* T) :
   nth_rw 2 [map]
   simp [map_span, Set.image_image]
 
-@[mono]
+@[gcongr, mono]
 theorem spanNorm_mono {I J : Ideal S} (h : I ≤ J) : spanNorm R I ≤ spanNorm R J :=
   Ideal.span_mono (Set.monotone_image h)
 
@@ -302,7 +302,7 @@ theorem map_relNorm (I : Ideal S) {T : Type*} [Semiring T] (f : R →+* T) :
     map f (relNorm R I) = span (f ∘ Algebra.intNorm R S '' (I : Set S)) :=
   map_spanIntNorm R I f
 
-@[mono]
+@[gcongr, mono]
 theorem relNorm_mono {I J : Ideal S} (h : I ≤ J) : relNorm R I ≤ relNorm R J :=
   spanNorm_mono R h
 

--- a/Mathlib/RingTheory/Jacobson/Ideal.lean
+++ b/Mathlib/RingTheory/Jacobson/Ideal.lean
@@ -221,7 +221,7 @@ theorem comap_jacobson_of_surjective {f : R →+* S} (hf : Function.Surjective f
     haveI : J.IsMaximal := hJ.right
     exact sInf_le ⟨comap_mono hJ.left, comap_isMaximal_of_surjective _ hf⟩
 
-@[mono]
+@[gcongr, mono]
 theorem jacobson_mono {I J : Ideal R} : I ≤ J → I.jacobson ≤ J.jacobson := by
   intro h x hx
   rw [jacobson, mem_sInf] at hx ⊢

--- a/Mathlib/RingTheory/Localization/Submodule.lean
+++ b/Mathlib/RingTheory/Localization/Submodule.lean
@@ -97,14 +97,14 @@ section NonZeroDivisors
 variable {R : Type*} [CommRing R] {M : Submonoid R}
   {S : Type*} [CommRing S] [Algebra R S] [IsLocalization M S]
 
-@[mono]
+@[gcongr, mono]
 theorem coeSubmodule_le_coeSubmodule (h : M ≤ nonZeroDivisors R) {I J : Ideal R} :
     coeSubmodule S I ≤ coeSubmodule S J ↔ I ≤ J :=
   -- Note: https://github.com/leanprover-community/mathlib4/pull/8386 had to specify the value of `f` here:
   Submodule.map_le_map_iff_of_injective (f := Algebra.linearMap R S) (IsLocalization.injective _ h)
     _ _
 
-@[mono]
+@[gcongr, mono]
 theorem coeSubmodule_strictMono (h : M ≤ nonZeroDivisors R) :
     StrictMono (coeSubmodule S : Ideal R → Submodule R S) :=
   strictMono_of_le_iff_le fun _ _ => (coeSubmodule_le_coeSubmodule h).symm
@@ -184,7 +184,7 @@ theorem coeSubmodule_le_coeSubmodule {I J : Ideal R} :
     coeSubmodule K I ≤ coeSubmodule K J ↔ I ≤ J :=
   IsLocalization.coeSubmodule_le_coeSubmodule le_rfl
 
-@[mono]
+@[gcongr, mono]
 theorem coeSubmodule_strictMono : StrictMono (coeSubmodule K : Ideal R → Submodule R K) :=
   strictMono_of_le_iff_le fun _ _ => coeSubmodule_le_coeSubmodule.symm
 

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -645,7 +645,7 @@ theorem mem_prod {s : NonUnitalSubring R} {t : NonUnitalSubring S} {p : R × S} 
     p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t :=
   Iff.rfl
 
-@[mono]
+@[gcongr, mono]
 theorem prod_mono ⦃s₁ s₂ : NonUnitalSubring R⦄ (hs : s₁ ≤ s₂) ⦃t₁ t₂ : NonUnitalSubring S⦄
     (ht : t₁ ≤ t₂) : s₁.prod t₁ ≤ s₂.prod t₂ :=
   Set.prod_mono hs ht

--- a/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Defs.lean
@@ -207,12 +207,12 @@ theorem toNonUnitalSubsemiring_injective :
     Function.Injective (toNonUnitalSubsemiring : NonUnitalSubring R → NonUnitalSubsemiring R)
   | _r, _s, h => ext (SetLike.ext_iff.mp h :)
 
-@[mono]
+@[gcongr, mono]
 theorem toNonUnitalSubsemiring_strictMono :
     StrictMono (toNonUnitalSubsemiring : NonUnitalSubring R → NonUnitalSubsemiring R) := fun _ _ =>
   id
 
-@[mono]
+@[gcongr, mono]
 theorem toNonUnitalSubsemiring_mono :
     Monotone (toNonUnitalSubsemiring : NonUnitalSubring R → NonUnitalSubsemiring R) :=
   toNonUnitalSubsemiring_strictMono.monotone
@@ -221,11 +221,11 @@ theorem toAddSubgroup_injective :
     Function.Injective (toAddSubgroup : NonUnitalSubring R → AddSubgroup R)
   | _r, _s, h => ext (SetLike.ext_iff.mp h :)
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubgroup_strictMono :
     StrictMono (toAddSubgroup : NonUnitalSubring R → AddSubgroup R) := fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubgroup_mono : Monotone (toAddSubgroup : NonUnitalSubring R → AddSubgroup R) :=
   toAddSubgroup_strictMono.monotone
 
@@ -233,11 +233,11 @@ theorem toSubsemigroup_injective :
     Function.Injective (toSubsemigroup : NonUnitalSubring R → Subsemigroup R)
   | _r, _s, h => ext (SetLike.ext_iff.mp h :)
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemigroup_strictMono :
     StrictMono (toSubsemigroup : NonUnitalSubring R → Subsemigroup R) := fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemigroup_mono : Monotone (toSubsemigroup : NonUnitalSubring R → Subsemigroup R) :=
   toSubsemigroup_strictMono.monotone
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -35,19 +35,19 @@ variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R] (M
 
 namespace NonUnitalSubsemiring
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemigroup_strictMono :
     StrictMono (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R) := fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toSubsemigroup_mono : Monotone (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R) :=
   toSubsemigroup_strictMono.monotone
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_strictMono :
     StrictMono (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) := fun _ _ => id
 
-@[mono]
+@[gcongr, mono]
 theorem toAddSubmonoid_mono : Monotone (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R) :=
   toAddSubmonoid_strictMono.monotone
 
@@ -582,7 +582,7 @@ theorem mem_prod {s : NonUnitalSubsemiring R} {t : NonUnitalSubsemiring S} {p : 
     p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t :=
   Iff.rfl
 
-@[mono]
+@[gcongr, mono]
 theorem prod_mono ⦃s₁ s₂ : NonUnitalSubsemiring R⦄ (hs : s₁ ≤ s₂) ⦃t₁ t₂ : NonUnitalSubsemiring S⦄
     (ht : t₁ ≤ t₂) : s₁.prod t₁ ≤ s₂.prod t₂ :=
   Set.prod_mono hs ht

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -61,7 +61,7 @@ variable {R}
 theorem mem_degreeLE {n : WithBot ℕ} {f : R[X]} : f ∈ degreeLE R n ↔ degree f ≤ n := by
   simp only [degreeLE, Submodule.mem_iInf, degree_le_iff_coeff_zero, LinearMap.mem_ker]; rfl
 
-@[mono]
+@[gcongr, mono]
 theorem degreeLE_mono {m n : WithBot ℕ} (H : m ≤ n) : degreeLE R m ≤ degreeLE R n := fun _ hf =>
   mem_degreeLE.2 (le_trans (mem_degreeLE.1 hf) H)
 
@@ -88,7 +88,7 @@ theorem degreeLE_eq_span_X_pow [DecidableEq R] {n : ℕ} :
 theorem mem_degreeLT {n : ℕ} {f : R[X]} : f ∈ degreeLT R n ↔ degree f < n := by
   simpa [degreeLT, Submodule.mem_iInf] using (degree_lt_iff_coeff_zero _ _).symm
 
-@[mono]
+@[gcongr, mono]
 theorem degreeLT_mono {m n : ℕ} (H : m ≤ n) : degreeLT R m ≤ degreeLT R n := fun _ hf =>
   mem_degreeLT.2 (lt_of_lt_of_le (mem_degreeLT.1 hf) <| WithBot.coe_le_coe.2 H)
 

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -269,7 +269,7 @@ def mapOfLE (R S : ValuationSubring K) (h : R ≤ S) : R.ValueGroup →*₀ S.Va
   map_one' := rfl
   map_mul' := by rintro ⟨⟩ ⟨⟩; rfl
 
-@[mono]
+@[gcongr, mono]
 theorem monotone_mapOfLE (R S : ValuationSubring K) (h : R ≤ S) : Monotone (R.mapOfLE S h) := by
   rintro ⟨⟩ ⟨⟩ ⟨a, ha⟩; exact ⟨R.inclusion S h a, ha⟩
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1117,11 +1117,11 @@ The converse, however, is false (for instance, `o = ω+1` and `c = ℵ₀`).
 lemma card_le_of_le_ord {o : Ordinal} {c : Cardinal} (ho : o ≤ c.ord) : o.card ≤ c := by
   rw [← card_ord c]; exact Ordinal.card_le_card ho
 
-@[mono]
+@[gcongr, mono]
 theorem ord_strictMono : StrictMono ord :=
   gciOrdCard.strictMono_l
 
-@[mono]
+@[gcongr, mono]
 theorem ord_mono : Monotone ord :=
   gc_ord_card.monotone_l
 

--- a/Mathlib/Tactic/Monotonicity/Attr.lean
+++ b/Mathlib/Tactic/Monotonicity/Attr.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Init
 public meta import Lean.LabelAttribute
 
-/-! # The @[gcongr, mono] attribute -/
+/-! # The @[mono] attribute -/
 
 public meta section
 
@@ -24,7 +24,7 @@ syntax (name := mono) "mono" (ppSpace mono.side)? : attr
 
 -- The following is inlined from `register_label_attr`.
 /- TODO: currently `left`/`right`/`both` is ignored, and e.g. `@[mono left]` means the same as
-`@[gcongr, mono]`. No error is thrown by e.g. `@[mono left]`. -/
+`@[mono]`. No error is thrown by e.g. `@[mono left]`. -/
 -- TODO: possibly extend `register_label_attr` to handle trailing syntax
 
 open Lean in

--- a/Mathlib/Tactic/Monotonicity/Attr.lean
+++ b/Mathlib/Tactic/Monotonicity/Attr.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Init
 public meta import Lean.LabelAttribute
 
-/-! # The @[mono] attribute -/
+/-! # The @[gcongr, mono] attribute -/
 
 public meta section
 
@@ -24,7 +24,7 @@ syntax (name := mono) "mono" (ppSpace mono.side)? : attr
 
 -- The following is inlined from `register_label_attr`.
 /- TODO: currently `left`/`right`/`both` is ignored, and e.g. `@[mono left]` means the same as
-`@[mono]`. No error is thrown by e.g. `@[mono left]`. -/
+`@[gcongr, mono]`. No error is thrown by e.g. `@[mono left]`. -/
 -- TODO: possibly extend `register_label_attr` to handle trailing syntax
 
 open Lean in

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.Monotonicity.Attr
 /-! # Monotonicity tactic
 
 The tactic `mono` applies monotonicity rules (collected through the library by being tagged
-`@[mono]`).
+`@[gcongr, mono]`).
 
 The version of the tactic here is a cheap partial port of the `mono` tactic from Lean 3, which had
 many more options and features.  It is implemented as a wrapper on top of `solve_by_elim`.

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.Monotonicity.Attr
 /-! # Monotonicity tactic
 
 The tactic `mono` applies monotonicity rules (collected through the library by being tagged
-`@[gcongr, mono]`).
+`@[mono]`).
 
 The version of the tactic here is a cheap partial port of the `mono` tactic from Lean 3, which had
 many more options and features.  It is implemented as a wrapper on top of `solve_by_elim`.

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -463,7 +463,7 @@ theorem tsum_lt_tsum {f g : α → ℝ≥0} {i : α} (h : ∀ a : α, f a ≤ g 
     (hg : Summable g) : ∑' n, f n < ∑' n, g n :=
   hasSum_lt h hi (summable_of_le h hg).hasSum hg.hasSum
 
-@[mono]
+@[gcongr, mono]
 theorem tsum_strict_mono {f g : α → ℝ≥0} (hg : Summable g) (h : f < g) : ∑' n, f n < ∑' n, g n :=
   let ⟨hle, _i, hi⟩ := Pi.lt_def.mp h
   tsum_lt_tsum hle hi hg

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -350,7 +350,7 @@ protected theorem isCompact (n : ℕ) : IsCompact (K n) :=
 theorem subset_interior_succ (n : ℕ) : K n ⊆ interior (K (n + 1)) :=
   K.subset_interior_succ' n
 
-@[mono]
+@[gcongr, mono]
 protected theorem subset ⦃m n : ℕ⦄ (h : m ≤ n) : K m ⊆ K n :=
   OrderHomClass.mono K h
 

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -611,7 +611,7 @@ theorem irreducibleComponent_subset_connectedComponent {x : α} :
     irreducibleComponent x ⊆ connectedComponent x :=
   isIrreducible_irreducibleComponent.isConnected.subset_connectedComponent mem_irreducibleComponent
 
-@[mono]
+@[gcongr, mono]
 theorem connectedComponentIn_mono (x : α) {F G : Set α} (h : F ⊆ G) :
     connectedComponentIn F x ⊆ connectedComponentIn G x := by
   by_cases hx : x ∈ F

--- a/Mathlib/Topology/DiscreteQuotient.lean
+++ b/Mathlib/Topology/DiscreteQuotient.lean
@@ -179,7 +179,7 @@ theorem comap_id : S.comap (ContinuousMap.id X) = S := rfl
 theorem comap_comp (S : DiscreteQuotient Z) : S.comap (g.comp f) = (S.comap g).comap f :=
   rfl
 
-@[mono]
+@[gcongr, mono]
 theorem comap_mono {A B : DiscreteQuotient Y} (h : A ≤ B) : A.comap f ≤ B.comap f := by tauto
 
 end Comap
@@ -267,7 +267,7 @@ theorem leComap_id_iff : LEComap (ContinuousMap.id X) A A' ↔ A ≤ A' :=
 
 theorem LEComap.comp : LEComap g B C → LEComap f A B → LEComap (g.comp f) A C := by tauto
 
-@[mono]
+@[gcongr, mono]
 theorem LEComap.mono (h : LEComap f A B) (hA : A' ≤ A) (hB : B ≤ B') : LEComap f A' B' :=
   hA.trans <| h.trans <| comap_mono _ hB
 

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -162,7 +162,7 @@ theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0)
 
 end Measurable
 
-@[mono]
+@[gcongr, mono]
 theorem dimH_mono {s t : Set X} (h : s ⊆ t) : dimH s ≤ dimH t := by
   borelize X
   exact dimH_le fun d hd => le_dimH_of_hausdorffMeasure_eq_top <| top_unique <| hd ▸ measure_mono h

--- a/Mathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/Mathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -122,7 +122,7 @@ protected theorem disjoint (h : AreSeparated s t) : Disjoint s t :=
 theorem subset_compl_right (h : AreSeparated s t) : s ⊆ tᶜ := fun _ hs ht =>
   h.disjoint.le_bot ⟨hs, ht⟩
 
-@[mono]
+@[gcongr, mono]
 theorem mono {s' t'} (hs : s ⊆ s') (ht : t ⊆ t') :
     AreSeparated s' t' → AreSeparated s t := fun ⟨r, r0, hr⟩ =>
   ⟨r, r0, fun x hx y hy => hr x (hs hx) y (ht hy)⟩

--- a/Mathlib/Topology/NhdsKer.lean
+++ b/Mathlib/Topology/NhdsKer.lean
@@ -71,7 +71,7 @@ theorem mem_nhdsKer_iff_specializes : x ∈ nhdsKer s ↔ ∃ y ∈ s, x ⤳ y :
   _ ↔ ∃ y ∈ s, x ⤳ y := by
     simp only [nhdsKer_iUnion, mem_nhdsKer_singleton, mem_iUnion₂, exists_prop]
 
-@[mono] lemma nhdsKer_mono : Monotone (nhdsKer : Set X → Set X) :=
+@[gcongr, mono] lemma nhdsKer_mono : Monotone (nhdsKer : Set X → Set X) :=
   fun _s _t h ↦ ker_mono <| nhdsSet_mono h
 
 /-- This name was used to be used for the `Iff` version,

--- a/Mathlib/Topology/Order/LeftRightLim.lean
+++ b/Mathlib/Topology/Order/LeftRightLim.lean
@@ -308,7 +308,7 @@ theorem le_leftLim (h : x < y) : f x ≤ leftLim f y := by
   intro z hz
   exact hf hz.le
 
-@[mono]
+@[gcongr, mono]
 protected theorem leftLim : Monotone (leftLim f) := by
   intro x y h
   rcases eq_or_lt_of_le h with (rfl | hxy)
@@ -321,7 +321,7 @@ theorem le_rightLim (h : x ≤ y) : f x ≤ rightLim f y :=
 theorem rightLim_le (h : x < y) : rightLim f x ≤ f y :=
   hf.dual.le_leftLim h
 
-@[mono]
+@[gcongr, mono]
 protected theorem rightLim : Monotone (rightLim f) := fun _ _ h => hf.dual.leftLim h
 
 theorem leftLim_le_rightLim (h : x ≤ y) : leftLim f x ≤ rightLim f y :=
@@ -401,7 +401,7 @@ theorem le_leftLim (h : x ≤ y) : f y ≤ leftLim f x :=
 theorem leftLim_le (h : x < y) : leftLim f y ≤ f x :=
   hf.dual_right.le_leftLim h
 
-@[mono]
+@[gcongr, mono]
 protected theorem leftLim : Antitone (leftLim f) :=
   hf.dual_right.leftLim
 
@@ -411,7 +411,7 @@ theorem rightLim_le (h : x ≤ y) : rightLim f y ≤ f x :=
 theorem le_rightLim (h : x < y) : f y ≤ rightLim f x :=
   hf.dual_right.rightLim_le h
 
-@[mono]
+@[gcongr, mono]
 protected theorem rightLim : Antitone (rightLim f) :=
   hf.dual_right.rightLim
 

--- a/MathlibTest/Monotonicity.lean
+++ b/MathlibTest/Monotonicity.lean
@@ -147,7 +147,7 @@ example {x y z w : ℕ} : true := by
 --     apply le_trans h.left h'.left,
 --     apply xs_ih _ h.right h'.right, }
 
--- @[mono]
+-- @[gcongr, mono]
 -- lemma list_le_mono_left {α : Type*} [preorder α] {xs ys zs : list α}
 --     (h : xs ≤ ys) :
 --     xs ++ zs ≤ ys ++ zs := by
@@ -158,7 +158,7 @@ example {x y z w : ℕ} : true := by
 --     revert h; apply and.imp_right
 --     apply xs_ih
 
--- @[mono]
+-- @[gcongr, mono]
 -- lemma list_le_mono_right {α : Type*} [preorder α] {xs ys zs : list α}
 --     (h : xs ≤ ys) :
 --     zs ++ xs ≤ zs ++ ys := by
@@ -202,14 +202,14 @@ example {x y z w : ℕ} : true := by
 -- def P (x : ℕ) := 7 ≤ x
 -- def Q (x : ℕ) := x ≤ 7
 
--- @[mono]
+-- @[gcongr, mono]
 -- lemma P_mono {x y : ℕ}
 --     (h : x ≤ y) :
 --     P x → P y := by
 --   intro h'
 --   apply le_trans h' h
 
--- @[mono]
+-- @[gcongr, mono]
 -- lemma Q_mono {x y : ℕ}
 --     (h : y ≤ x) :
 --     Q x → Q y := by

--- a/MathlibTest/Monotonicity.lean
+++ b/MathlibTest/Monotonicity.lean
@@ -147,7 +147,7 @@ example {x y z w : ℕ} : true := by
 --     apply le_trans h.left h'.left,
 --     apply xs_ih _ h.right h'.right, }
 
--- @[gcongr, mono]
+-- @[mono]
 -- lemma list_le_mono_left {α : Type*} [preorder α] {xs ys zs : list α}
 --     (h : xs ≤ ys) :
 --     xs ++ zs ≤ ys ++ zs := by
@@ -158,7 +158,7 @@ example {x y z w : ℕ} : true := by
 --     revert h; apply and.imp_right
 --     apply xs_ih
 
--- @[gcongr, mono]
+-- @[mono]
 -- lemma list_le_mono_right {α : Type*} [preorder α] {xs ys zs : list α}
 --     (h : xs ≤ ys) :
 --     zs ++ xs ≤ zs ++ ys := by
@@ -202,14 +202,14 @@ example {x y z w : ℕ} : true := by
 -- def P (x : ℕ) := 7 ≤ x
 -- def Q (x : ℕ) := x ≤ 7
 
--- @[gcongr, mono]
+-- @[mono]
 -- lemma P_mono {x y : ℕ}
 --     (h : x ≤ y) :
 --     P x → P y := by
 --   intro h'
 --   apply le_trans h' h
 
--- @[gcongr, mono]
+-- @[mono]
 -- lemma Q_mono {x y : ℕ}
 --     (h : y ≤ x) :
 --     Q x → Q y := by


### PR DESCRIPTION
The few exceptions are the lemmas about `Set` and `Finset` which would make `gcongr` use `≤` instead of `⊆`, and `measure_mono_ae` which feels like a bigger than I want to undertake here, as well as a few lemmas that `gcongr` doesn't want to eat.

From AddCombi


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
