### PR TITLE
[Merged by Bors] - chore(CategoryTheory): adding a test about typeclass inference regarding compositions of functors

### DIFF
--- a/MathlibTest/CategoryTheory/FunctorAssoc.lean
+++ b/MathlibTest/CategoryTheory/FunctorAssoc.lean
@@ -1,0 +1,44 @@
+import Mathlib.CategoryTheory.Functor.Basic
+
+namespace CategoryTheory
+
+variable {C₁ C₂ C₃ C₄ : Type*}
+  [Category* C₁] [Category* C₂] [Category* C₃] [Category* C₄]
+
+class Foo (F : C₁ ⥤ C₂) where
+  data : ℕ
+
+variable (F : C₁ ⥤ C₂) (G : C₂ ⥤ C₃) (H : C₃ ⥤ C₄)
+
+/-!
+The purpose of these tests is to prevent diamonds in the situation where
+we have a typeclass (e.g. `Functor.Monoidal` or `Functor.CommShift`)
+for functors such that an instance for a composition of functors
+can be inferred from an instance from each of the functors.
+Taking into account the placement of parentheses, we want to allow
+`(F ⋙ G) ⋙ H` and `F ⋙ (G ⋙ H)` to have their own instances
+(even though they are usually propositionally equal). The following
+tests ensures that for the typeclass `Foo`, no instance
+is inferred on `(F ⋙ G) ⋙ H` from an instance on `F ⋙ (G ⋙ H)`,
+and vice versa.
+-/
+
+/--
+error: failed to synthesize instance of type class
+  Foo ((F ⋙ G) ⋙ H)
+
+Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
+-/
+#guard_msgs in
+example [Foo (F ⋙ (G ⋙ H))] : Foo ((F ⋙ G) ⋙ H) := inferInstance
+
+/--
+error: failed to synthesize instance of type class
+  Foo (F ⋙ G ⋙ H)
+
+Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
+-/
+#guard_msgs in
+example [Foo ((F ⋙ G) ⋙ H)] : Foo (F ⋙ (G ⋙ H)) := inferInstance
+
+end CategoryTheory

--- a/MathlibTest/CategoryTheory/FunctorAssoc.lean
+++ b/MathlibTest/CategoryTheory/FunctorAssoc.lean
@@ -14,7 +14,7 @@ variable (F : C₁ ⥤ C₂) (G : C₂ ⥤ C₃) (H : C₃ ⥤ C₄)
 The purpose of these tests is to prevent diamonds in the situation where
 we have a typeclass (e.g. `Functor.Monoidal` or `Functor.CommShift`)
 for functors such that an instance for a composition of functors
-can be inferred from an instance from each of the functors.
+can be inferred from an instance for each of the functors.
 Taking into account the placement of parentheses, we want to allow
 `(F ⋙ G) ⋙ H` and `F ⋙ (G ⋙ H)` to have their own instances
 (even though they are usually propositionally equal). The following

--- a/MathlibTest/CategoryTheory/FunctorAssoc.lean
+++ b/MathlibTest/CategoryTheory/FunctorAssoc.lean
@@ -54,6 +54,8 @@ instance [F.Foo] [G.Foo] : (F ⋙ G).Foo where
 /- This must succeed with `Nat.add_assoc` as a proof. It would be problematic
 if `rfl` worked. -/
 example [F.Foo] [G.Foo] [H.Foo] :
-    Foo.data ((F ⋙ G) ⋙ H) = Foo.data (F ⋙ (G ⋙ H)) := Nat.add_assoc _ _ _
+    Foo.data ((F ⋙ G) ⋙ H) = Foo.data (F ⋙ (G ⋙ H)) := by
+  fail_if_success rfl
+  exact Nat.add_assoc _ _ _
 
 end CategoryTheory.Functor

--- a/MathlibTest/CategoryTheory/FunctorAssoc.lean
+++ b/MathlibTest/CategoryTheory/FunctorAssoc.lean
@@ -18,7 +18,7 @@ can be inferred from an instance for each of the functors.
 Taking into account the placement of parentheses, we want to allow
 `(F ⋙ G) ⋙ H` and `F ⋙ (G ⋙ H)` to have their own instances
 (even though they are usually propositionally equal). The following
-tests ensures that for the typeclass `Foo`, no instance
+tests ensure that for the typeclass `Foo`, no instance
 is inferred on `(F ⋙ G) ⋙ H` from an instance on `F ⋙ (G ⋙ H)`,
 and vice versa.
 -/

--- a/MathlibTest/CategoryTheory/FunctorAssoc.lean
+++ b/MathlibTest/CategoryTheory/FunctorAssoc.lean
@@ -1,12 +1,12 @@
 import Mathlib.CategoryTheory.Functor.Basic
 
-namespace CategoryTheory
+namespace CategoryTheory.Functor
 
 variable {C₁ C₂ C₃ C₄ : Type*}
   [Category* C₁] [Category* C₂] [Category* C₃] [Category* C₄]
 
 class Foo (F : C₁ ⥤ C₂) where
-  data : ℕ
+  data (F) : ℕ
 
 variable (F : C₁ ⥤ C₂) (G : C₂ ⥤ C₃) (H : C₃ ⥤ C₄)
 
@@ -17,28 +17,43 @@ for functors such that an instance for a composition of functors
 can be inferred from an instance for each of the functors.
 Taking into account the placement of parentheses, we want to allow
 `(F ⋙ G) ⋙ H` and `F ⋙ (G ⋙ H)` to have their own instances
-(even though they are usually propositionally equal). The following
-tests ensure that for the typeclass `Foo`, no instance
-is inferred on `(F ⋙ G) ⋙ H` from an instance on `F ⋙ (G ⋙ H)`,
+(even though they are usually propositionally equal).
+-/
+
+/-! The two following tests ensure that for the typeclass `Foo`,
+no instance is inferred on `(F ⋙ G) ⋙ H` from an instance on `F ⋙ (G ⋙ H)`,
 and vice versa.
 -/
 
 /--
 error: failed to synthesize instance of type class
-  Foo ((F ⋙ G) ⋙ H)
+  ((F ⋙ G) ⋙ H).Foo
 
 Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
 -/
 #guard_msgs in
-example [Foo (F ⋙ (G ⋙ H))] : Foo ((F ⋙ G) ⋙ H) := inferInstance
+example [(F ⋙ (G ⋙ H)).Foo] : ((F ⋙ G) ⋙ H).Foo := inferInstance
 
 /--
 error: failed to synthesize instance of type class
-  Foo (F ⋙ G ⋙ H)
+  (F ⋙ G ⋙ H).Foo
 
 Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
 -/
 #guard_msgs in
-example [Foo ((F ⋙ G) ⋙ H)] : Foo (F ⋙ (G ⋙ H)) := inferInstance
+example [((F ⋙ G) ⋙ H).Foo] : (F ⋙ (G ⋙ H)).Foo := inferInstance
 
-end CategoryTheory
+/-! Assuming a `Foo` instance for a composition of functors can be obtained from a
+`Foo` instance on each functor (by taking the sum in `ℕ`), we check that the
+instances obtained on `(F ⋙ G) ⋙ H` and `F ⋙ (G ⋙ H)` are equal,
+but not defeq (because `Nat.assoc` is not a defeq in general). -/
+
+instance [F.Foo] [G.Foo] : (F ⋙ G).Foo where
+  data := Foo.data F + Foo.data G
+
+/- This must succeed with `Nat.add_assoc` as a proof. It would be problematic
+if `rfl` worked. -/
+example [F.Foo] [G.Foo] [H.Foo] :
+    Foo.data ((F ⋙ G) ⋙ H) = Foo.data (F ⋙ (G ⋙ H)) := Nat.add_assoc _ _ _
+
+end CategoryTheory.Functor


### PR DESCRIPTION
There has been several bona fide attempts (#36652 and #38674) to fix issues with transparency by making the composition of functors more reducible. However, doing this would create diamonds for typeclasses like `Functor.Monoidal` and `Functor.CommShift`. The added tests are an attempt at preventing this in the future.



---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
