### PR TITLE
[Merged by Bors] - feat: `DirSupClosedOn` on linear orders

### DIFF
--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -221,6 +221,27 @@ theorem dirSupClosedOn_singleton (a : α) : DirSupClosedOn D {a} :=
 
 end PartialOrder
 
+namespace LinearOrder
+variable [LinearOrder α]
+
+theorem dirSupClosedOn_iff_of_linearOrder : DirSupClosedOn D s ↔
+    ∀ ⦃d⦄, d ∈ D → d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
+  simp [DirSupClosedOn]
+
+theorem dirSupClosed_iff_of_linearOrder : DirSupClosed s ↔
+    ∀ ⦃d⦄, d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
+  simp [DirSupClosed]
+
+theorem dirSupInaccOn_iff_of_linearOrder : DirSupInaccOn D s ↔
+    ∀ ⦃d⦄, d ∈ D → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
+  simp [DirSupInaccOn]
+
+theorem dirSupInacc_iff_of_linearOrder : DirSupInacc s ↔
+    ∀ ⦃d⦄, d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
+  simp [DirSupInacc]
+
+end LinearOrder
+
 section CompleteLattice
 variable [CompleteLattice α]
 

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -233,7 +233,8 @@ theorem dirSupClosed_iff_of_linearOrder :
   simp [DirSupClosed]
 
 theorem dirSupInaccOn_iff_of_linearOrder :
-    DirSupInaccOn D s ↔ ∀ ⦃d⦄, d ∈ D → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
+    DirSupInaccOn D s ↔
+      ∀ ⦃d⦄, d ∈ D → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
   simp [DirSupInaccOn]
 
 theorem dirSupInacc_iff_of_linearOrder :

--- a/Mathlib/Order/DirSupClosed.lean
+++ b/Mathlib/Order/DirSupClosed.lean
@@ -224,20 +224,20 @@ end PartialOrder
 namespace LinearOrder
 variable [LinearOrder α]
 
-theorem dirSupClosedOn_iff_of_linearOrder : DirSupClosedOn D s ↔
-    ∀ ⦃d⦄, d ∈ D → d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
+theorem dirSupClosedOn_iff_of_linearOrder :
+    DirSupClosedOn D s ↔ ∀ ⦃d⦄, d ∈ D → d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
   simp [DirSupClosedOn]
 
-theorem dirSupClosed_iff_of_linearOrder : DirSupClosed s ↔
-    ∀ ⦃d⦄, d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
+theorem dirSupClosed_iff_of_linearOrder :
+    DirSupClosed s ↔ ∀ ⦃d⦄, d ⊆ s → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s := by
   simp [DirSupClosed]
 
-theorem dirSupInaccOn_iff_of_linearOrder : DirSupInaccOn D s ↔
-    ∀ ⦃d⦄, d ∈ D → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
+theorem dirSupInaccOn_iff_of_linearOrder :
+    DirSupInaccOn D s ↔ ∀ ⦃d⦄, d ∈ D → d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
   simp [DirSupInaccOn]
 
-theorem dirSupInacc_iff_of_linearOrder : DirSupInacc s ↔
-    ∀ ⦃d⦄, d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
+theorem dirSupInacc_iff_of_linearOrder :
+    DirSupInacc s ↔ ∀ ⦃d⦄, d.Nonempty → ∀ ⦃a⦄, IsLUB d a → a ∈ s → (d ∩ s).Nonempty := by
   simp [DirSupInacc]
 
 end LinearOrder

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -132,6 +132,10 @@ theorem Std.Total.directed [Std.Total r] (f : ι → α) : Directed r f := fun i
 theorem Std.Total.directedOn [Std.Total r] (s : Set α) : DirectedOn r s := fun a ha b hb =>
   Or.casesOn (total_of r a b) (fun h => ⟨b, hb, h, refl _⟩) fun h => ⟨a, ha, refl _, h⟩
 
+@[simp]
+theorem directedOn_of_linearOrder [LinearOrder α] (s : Set α) : DirectedOn (· ≤ ·) s :=
+  Std.Total.directedOn s
+
 /-- `IsDirected α r` states that for any elements `a`, `b` there exists an element `c` such that
 `r a c` and `r b c`. -/
 class IsDirected (α : Sort*) (r : α → α → Prop) : Prop where

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -133,7 +133,7 @@ theorem Std.Total.directedOn [Std.Total r] (s : Set α) : DirectedOn r s := fun 
   Or.casesOn (total_of r a b) (fun h => ⟨b, hb, h, refl _⟩) fun h => ⟨a, ha, refl _, h⟩
 
 @[simp]
-theorem directedOn_of_linearOrder [LinearOrder α] (s : Set α) : DirectedOn (· ≤ ·) s :=
+theorem DirectedOn.of_linearOrder [LinearOrder α] (s : Set α) : DirectedOn (· ≤ ·) s :=
   Std.Total.directedOn s
 
 /-- `IsDirected α r` states that for any elements `a`, `b` there exists an element `c` such that


### PR DESCRIPTION
Every subset of a linear order is directed, so we can take off this part of the predicate.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
