### PR TITLE
[Merged by Bors] - chore(RingTheory): tensorRight is exact for flat modules

### DIFF
--- a/Mathlib/RingTheory/Flat/CategoryTheory.lean
+++ b/Mathlib/RingTheory/Flat/CategoryTheory.lean
@@ -24,8 +24,6 @@ In this file we prove that tensoring with a flat module is an exact functor.
 
 ## TODO
 
-- Prove that tensoring with a flat module is an exact functor in the sense that it preserves both
-  finite limits and colimits.
 - Relate flatness with `Tor`
 
 -/
@@ -81,5 +79,18 @@ lemma iff_preservesFiniteLimits_tensorLeft :
 instance [Module.Flat R M] : PreservesFiniteLimits <| tensorLeft M := by
   rw [← iff_preservesFiniteLimits_tensorLeft]
   infer_instance
+
+lemma iff_preservesFiniteLimits_tensorRight :
+    Flat R M ↔ PreservesFiniteLimits (tensorRight M) :=
+  ⟨fun _ => preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M),
+  fun _ => by
+    rw [iff_preservesFiniteLimits_tensorLeft]
+    exact preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M).symm⟩
+
+instance [Module.Flat R M] : PreservesFiniteLimits (tensorRight M) :=
+  preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M)
+
+instance : Functor.IsLeftAdjoint (tensorRight M) :=
+  Functor.isLeftAdjoint_of_iso (BraidedCategory.tensorLeftIsoTensorRight M)
 
 end Module.Flat

--- a/Mathlib/RingTheory/Flat/CategoryTheory.lean
+++ b/Mathlib/RingTheory/Flat/CategoryTheory.lean
@@ -81,16 +81,13 @@ instance [Module.Flat R M] : PreservesFiniteLimits <| tensorLeft M := by
   infer_instance
 
 lemma iff_preservesFiniteLimits_tensorRight :
-    Flat R M ↔ PreservesFiniteLimits (tensorRight M) :=
-  ⟨fun _ => preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M),
-  fun _ => by
+    Flat R M ↔ PreservesFiniteLimits (tensorRight M) where
+  mp _ := preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M)
+  mpr _ := by
     rw [iff_preservesFiniteLimits_tensorLeft]
-    exact preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M).symm⟩
+    exact preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M).symm
 
 instance [Module.Flat R M] : PreservesFiniteLimits (tensorRight M) :=
   preservesFiniteLimits_of_natIso (BraidedCategory.tensorLeftIsoTensorRight M)
-
-instance : Functor.IsLeftAdjoint (tensorRight M) :=
-  Functor.isLeftAdjoint_of_iso (BraidedCategory.tensorLeftIsoTensorRight M)
 
 end Module.Flat


### PR DESCRIPTION
Proves that tensorRight in ModuleCat is exact in the category theory sense (preserves finite limits and colimits). This was a TODO but it was essentially already done in #32326.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
