### PR TITLE
feat(IntervalIntegrable): add `fun_prop` support

### DIFF
--- a/Archive/Wiedijk100Theorems/AreaOfACircle.lean
+++ b/Archive/Wiedijk100Theorems/AreaOfACircle.lean
@@ -124,7 +124,7 @@ theorem area_disc : volume (disc r) = NNReal.pi * r ^ 2 := by
   calc
     ∫ x in -r..r, 2 * f x = F r - F (-r) :=
       integral_eq_sub_of_hasDerivAt_of_le (neg_le_self r.2) (by fun_prop) hderiv
-        (ContinuousOn.intervalIntegrable (by fun_prop))
+        (by fun_prop)
     _ = NNReal.pi * (r : ℝ) ^ 2 := by
       norm_num [F, inv_mul_cancel₀ hlt.ne', ← mul_div_assoc, mul_comm π]
 

--- a/Mathlib/Analysis/Real/Pi/Irrational.lean
+++ b/Mathlib/Analysis/Real/Pi/Irrational.lean
@@ -117,7 +117,8 @@ private lemma recursion' (n : ℕ) :
   · congr 1
     simp_rw [integral_const_mul]
     ring!
-  all_goals exact Continuous.intervalIntegrable (by fun_prop) _ _
+  · fun_prop
+  · fun_prop
 
 /--
 Auxiliary for the proof that `π` is irrational.

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -69,6 +69,7 @@ variable {ι 𝕜 ε ε' E F A : Type*} [NormedAddCommGroup E]
 interval `a..b` if it is integrable on both intervals `(a, b]` and `(b, a]`. One of these
 intervals is always empty, so this property is equivalent to `f` being integrable on
 `(min a b, max a b]`. -/
+@[fun_prop]
 def IntervalIntegrable (f : ℝ → ε) (μ : Measure ℝ) (a b : ℝ) : Prop :=
   IntegrableOn f (Ioc a b) μ ∧ IntegrableOn f (Ioc b a) μ
 
@@ -219,6 +220,7 @@ theorem trans_iterate {a : ℕ → ℝ} {n : ℕ}
     IntervalIntegrable f μ (a 0) (a n) :=
   trans_iterate_Ico bot_le fun k hk => hint k hk.2
 
+@[fun_prop]
 theorem neg {f : ℝ → E} (h : IntervalIntegrable f μ a b) : IntervalIntegrable (-f) μ a b :=
   ⟨h.1.neg, h.2.neg⟩
 
@@ -239,6 +241,7 @@ theorem intervalIntegrable_norm_iff {f : ℝ → E} {μ : Measure ℝ} {a b : �
     IntervalIntegrable (fun t => ‖f t‖) μ a b ↔ IntervalIntegrable f μ a b := by
   simp_rw [intervalIntegrable_iff, IntegrableOn, integrable_norm_iff hf]
 
+@[fun_prop]
 theorem abs {f : ℝ → ℝ} (h : IntervalIntegrable f μ a b) :
     IntervalIntegrable (fun x => |f x|) μ a b :=
   h.norm
@@ -304,17 +307,18 @@ end
 
 variable [NormedRing A] {f g : ℝ → ε} {a b : ℝ} {μ : Measure ℝ}
 
+@[fun_prop]
 theorem smul {R : Type*} [NormedAddCommGroup R] [SMulZeroClass R E] [IsBoundedSMul R E] {f : ℝ → E}
     (h : IntervalIntegrable f μ a b) (r : R) :
     IntervalIntegrable (r • f) μ a b :=
   ⟨h.1.smul r, h.2.smul r⟩
 
-@[simp]
+@[simp, fun_prop]
 theorem add [ContinuousAdd ε] (hf : IntervalIntegrable f μ a b) (hg : IntervalIntegrable g μ a b) :
     IntervalIntegrable (fun x => f x + g x) μ a b :=
   ⟨hf.1.add hg.1, hf.2.add hg.2⟩
 
-@[simp]
+@[simp, fun_prop]
 theorem sub {f g : ℝ → E} (hf : IntervalIntegrable f μ a b) (hg : IntervalIntegrable g μ a b) :
     IntervalIntegrable (fun x => f x - g x) μ a b :=
   ⟨hf.1.sub hg.1, hf.2.sub hg.2⟩
@@ -338,22 +342,24 @@ protected theorem finsum
 
 section Mul
 
+@[fun_prop]
 theorem mul_continuousOn {f g : ℝ → A} (hf : IntervalIntegrable f μ a b)
     (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => f x * g x) μ a b := by
   rw [intervalIntegrable_iff] at hf ⊢
   exact hf.mul_continuousOn_of_subset hg measurableSet_Ioc isCompact_uIcc Ioc_subset_Icc_self
 
+@[fun_prop]
 theorem continuousOn_mul {f g : ℝ → A} (hf : IntervalIntegrable f μ a b)
     (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => g x * f x) μ a b := by
   rw [intervalIntegrable_iff] at hf ⊢
   exact hf.continuousOn_mul_of_subset hg isCompact_uIcc measurableSet_Ioc Ioc_subset_Icc_self
 
-@[simp]
+@[simp, fun_prop]
 theorem const_mul {f : ℝ → A} (hf : IntervalIntegrable f μ a b) (c : A) :
     IntervalIntegrable (fun x => c * f x) μ a b :=
   hf.continuousOn_mul continuousOn_const
 
-@[simp]
+@[simp, fun_prop]
 theorem mul_const {f : ℝ → A} (hf : IntervalIntegrable f μ a b) (c : A) :
     IntervalIntegrable (fun x => f x * c) μ a b :=
   hf.mul_continuousOn continuousOn_const
@@ -364,11 +370,13 @@ section SMul
 
 variable {f : ℝ → 𝕜} {g : ℝ → E} [NormedRing 𝕜] [Module 𝕜 E] [NormSMulClass 𝕜 E]
 
+@[fun_prop]
 theorem smul_continuousOn (hf : IntervalIntegrable f μ a b)
     (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
   rw [intervalIntegrable_iff] at hf ⊢
   exact hf.smul_continuousOn_of_subset hg measurableSet_Ioc isCompact_uIcc Ioc_subset_Icc_self
 
+@[fun_prop]
 theorem continuousOn_smul (hg : IntervalIntegrable g μ a b)
     (hf : ContinuousOn f [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
   rw [intervalIntegrable_iff] at hg ⊢
@@ -490,16 +498,19 @@ section
 
 variable {μ : Measure ℝ} [IsLocallyFiniteMeasure μ]
 
+@[fun_prop]
 theorem ContinuousOn.intervalIntegrable {u : ℝ → E} {a b : ℝ} (hu : ContinuousOn u (uIcc a b)) :
     IntervalIntegrable u μ a b :=
   (ContinuousOn.integrableOn_Icc hu).intervalIntegrable
 
+@[fun_prop]
 theorem ContinuousOn.intervalIntegrable_of_Icc {u : ℝ → E} {a b : ℝ} (h : a ≤ b)
     (hu : ContinuousOn u (Icc a b)) : IntervalIntegrable u μ a b :=
   ContinuousOn.intervalIntegrable ((uIcc_of_le h).symm ▸ hu)
 
 /-- A continuous function on `ℝ` is `IntervalIntegrable` with respect to any locally finite measure
 `ν` on ℝ. -/
+@[fun_prop]
 theorem Continuous.intervalIntegrable {u : ℝ → E} (hu : Continuous u) (a b : ℝ) :
     IntervalIntegrable u μ a b :=
   hu.continuousOn.intervalIntegrable

--- a/MathlibTest/fun_prop.lean
+++ b/MathlibTest/fun_prop.lean
@@ -8,6 +8,7 @@ import Mathlib.MeasureTheory.Constructions.BorelSpace.ContinuousLinearMap
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
 import Mathlib.Analysis.Calculus.ContDiff.Basic
 import Mathlib.Topology.Constructions
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 
 import Mathlib.Tactic.FunProp
 
@@ -234,3 +235,11 @@ example {α : Type*} [MeasurableSpace α] {p q : α → Prop} (hp : Measurable p
 example {α ι : Type*} [MeasurableSpace α] [Countable ι] {p : ι → α → Prop}
     (hp : ∀ i, Measurable (p i)) : Measurable fun x => ∀ i, p i x := by
   fun_prop
+
+/--/
+Test that `fun_prop` works on `IntervalIntegrable`
+-/
+
+example {f g : ℝ → ℝ} (hf : ContinuousOn f (Set.Icc 0 1)) (hg : ContinuousOn g (Set.Icc 0 1)) :
+    IntervalIntegrable (fun x => |(|f x - g x|)|) MeasureTheory.volume 0 1 := by
+  fun_prop (disch := norm_num)


### PR DESCRIPTION
Allow `fun_prop` to work on `IntervalIntegrable` goals

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
