### PR TITLE
chore(LinearAlgebra/TensorProduct): fix diamond in `AddCommGroup` instance

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -53,7 +53,7 @@ A map `f : M →+ N →+ P` additive in both components is `R`-balanced, or midd
 to `R`, if scalar multiplication in either argument is equivalent, `f (r • m) n = f m (r • n)`.
 Note that strictly the first action should be a right-action by `R`, but for now `R` is commutative
 so it doesn't matter. -/
--- TODO: use this to implement `lift` and `SMul.aux`. For now we do not do this as it causes
+-- TODO: use this to implement `SMul.aux`. For now we do not do this as it causes
 -- performance issues elsewhere.
 def liftAddHom (f : M →+ N →+ P)
     (hf : ∀ (r : R) (m : M) (n : N), f (r • m) n = f m (r • n)) :
@@ -400,6 +400,10 @@ instance addCommGroup : AddCommGroup (M ⊗[R] N) where
     rw [← zero_add (_ • x), ← TensorProduct.neg_add_cancel ((n.succ : ℤ) • x), add_assoc,
       ← add_smul, ← sub_eq_add_neg, sub_self, zero_smul, add_zero]
     rfl
+
+example {R S : Type*} [CommRing R] [CommRing S] : (TensorProduct.instSMul : SMul ℤ (R ⊗[ℤ] S)) =
+    SubNegMonoid.toZSMul := by
+  with_reducible_and_instances rfl
 
 theorem neg_tmul (m : M) (n : N) : (-m) ⊗ₜ n = -m ⊗ₜ[R] n :=
   rfl

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -53,8 +53,8 @@ A map `f : M →+ N →+ P` additive in both components is `R`-balanced, or midd
 to `R`, if scalar multiplication in either argument is equivalent, `f (r • m) n = f m (r • n)`.
 Note that strictly the first action should be a right-action by `R`, but for now `R` is commutative
 so it doesn't matter. -/
--- TODO: use this to implement `SMul.aux`. For now we do not do this as it causes
--- performance issues elsewhere.
+-- TODO: use this to implement `SMul.aux`. For now we do not do this has caused
+-- performance issues in the past.
 def liftAddHom (f : M →+ N →+ P)
     (hf : ∀ (r : R) (m : M) (n : N), f (r • m) n = f m (r • n)) :
     M ⊗[R] N →+ P :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -53,7 +53,7 @@ A map `f : M →+ N →+ P` additive in both components is `R`-balanced, or midd
 to `R`, if scalar multiplication in either argument is equivalent, `f (r • m) n = f m (r • n)`.
 Note that strictly the first action should be a right-action by `R`, but for now `R` is commutative
 so it doesn't matter. -/
--- TODO: use this to implement `SMul.aux`. For now we do not do this has caused
+-- TODO: use this to implement `SMul.aux`. For now we do not do this as it has caused
 -- performance issues in the past.
 def liftAddHom (f : M →+ N →+ P)
     (hf : ∀ (r : R) (m : M) (n : N), f (r • m) n = f m (r • n)) :

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -196,9 +196,9 @@ theorem smul_tmul [DistribMulAction R' N] [CompatibleSMul R R' M N] (r : R') (m 
   CompatibleSMul.smul_tmul _ _ _
 
 set_option backward.privateInPublic true in
-@[instance_reducible]
+@[implicit_reducible]
 private def addMonoidWithWrongNSMul : AddMonoid (M ⊗[R] N) :=
-  { (addConGen (TensorProduct.Eqv R M N)).addMonoid with }
+  (addConGen (TensorProduct.Eqv R M N)).addMonoid
 
 attribute [local instance] addMonoidWithWrongNSMul in
 /-- Auxiliary function to defining scalar multiplication on tensor product. -/
@@ -210,6 +210,23 @@ theorem SMul.aux_of {R' : Type*} [SMul R' M] (r : R') (m : M) (n : N) :
   rfl
 
 variable [SMulCommClass R R' M] [SMulCommClass R R'' M]
+
+def leftHasSMul.sMul (r : R') (x : M ⊗[R] N) : M ⊗[R] N :=
+  ((addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r : _ →+ M ⊗[R] N) <|
+    AddCon.addConGen_le fun x y hxy =>
+      match x, y, hxy with
+      | _, _, .of_zero_left n =>
+        (AddCon.ker_rel _).2 <| by simp_rw [map_zero, SMul.aux_of, smul_zero, zero_tmul]
+      | _, _, .of_zero_right m =>
+        (AddCon.ker_rel _).2 <| by simp_rw [map_zero, SMul.aux_of, tmul_zero]
+      | _, _, .of_add_left m₁ m₂ n =>
+        (AddCon.ker_rel _).2 <| by simp_rw [map_add, SMul.aux_of, smul_add, add_tmul]
+      | _, _, .of_add_right m n₁ n₂ =>
+        (AddCon.ker_rel _).2 <| by simp_rw [map_add, SMul.aux_of, tmul_add]
+      | _, _, .of_smul s m n =>
+        (AddCon.ker_rel _).2 <| by rw [SMul.aux_of, SMul.aux_of, ← smul_comm, smul_tmul]
+      | _, _, .add_comm x y =>
+        (AddCon.ker_rel _).2 <| by simp_rw [map_add, add_comm]) x
 
 /-- Given two modules over a commutative semiring `R`, if one of the factors carries a
 (distributive) action of a second type of scalars `R'`, which commutes with the action of `R`, then
@@ -224,31 +241,17 @@ Note that in the special case that `R = R'`, since `R` is commutative, we just g
 action on a tensor product of two modules. This special case is important enough that, for
 performance reasons, we define it explicitly below. -/
 instance leftHasSMul : SMul R' (M ⊗[R] N) :=
-  ⟨fun r =>
-    (addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r : _ →+ M ⊗[R] N) <|
-      AddCon.addConGen_le fun x y hxy =>
-        match x, y, hxy with
-        | _, _, .of_zero_left n =>
-          (AddCon.ker_rel _).2 <| by simp_rw [map_zero, SMul.aux_of, smul_zero, zero_tmul]
-        | _, _, .of_zero_right m =>
-          (AddCon.ker_rel _).2 <| by simp_rw [map_zero, SMul.aux_of, tmul_zero]
-        | _, _, .of_add_left m₁ m₂ n =>
-          (AddCon.ker_rel _).2 <| by simp_rw [map_add, SMul.aux_of, smul_add, add_tmul]
-        | _, _, .of_add_right m n₁ n₂ =>
-          (AddCon.ker_rel _).2 <| by simp_rw [map_add, SMul.aux_of, tmul_add]
-        | _, _, .of_smul s m n =>
-          (AddCon.ker_rel _).2 <| by rw [SMul.aux_of, SMul.aux_of, ← smul_comm, smul_tmul]
-        | _, _, .add_comm x y =>
-          (AddCon.ker_rel _).2 <| by simp_rw [map_add, add_comm]⟩
+  ⟨leftHasSMul.sMul⟩
 
 instance : SMul R (M ⊗[R] N) :=
   TensorProduct.leftHasSMul
 
 protected theorem smul_zero (r : R') : r • (0 : M ⊗[R] N) = 0 :=
-  map_zero _
+  map_zero (SMul.aux r : _ →+ M ⊗[R] N)
 
-protected theorem smul_add (r : R') (x y : M ⊗[R] N) : r • (x + y) = r • x + r • y :=
-  map_add _ _ _
+protected theorem smul_add (r : R') (x y : M ⊗[R] N) : r • (x + y) = r • x + r • y := by
+  simp only [HSMul.hSMul, SMul.smul, leftHasSMul.sMul]
+  exact map_add _ _ _
 
 protected theorem zero_smul (x : M ⊗[R] N) : (0 : R'') • x = 0 :=
   have : ∀ (r : R'') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl

--- a/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Defs.lean
@@ -211,8 +211,8 @@ theorem SMul.aux_of {R' : Type*} [SMul R' M] (r : R') (m : M) (n : N) :
 
 variable [SMulCommClass R R' M] [SMulCommClass R R'' M]
 
-def leftHasSMul.sMul (r : R') (x : M ⊗[R] N) : M ⊗[R] N :=
-  ((addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r : _ →+ M ⊗[R] N) <|
+def leftHasSMul.smul (r : R') (x : M ⊗[R] N) : M ⊗[R] N :=
+  ((addConGen (TensorProduct.Eqv R M N)).lift (SMul.aux r) <|
     AddCon.addConGen_le fun x y hxy =>
       match x, y, hxy with
       | _, _, .of_zero_left n =>
@@ -241,16 +241,16 @@ Note that in the special case that `R = R'`, since `R` is commutative, we just g
 action on a tensor product of two modules. This special case is important enough that, for
 performance reasons, we define it explicitly below. -/
 instance leftHasSMul : SMul R' (M ⊗[R] N) :=
-  ⟨leftHasSMul.sMul⟩
+  ⟨leftHasSMul.smul⟩
 
 instance : SMul R (M ⊗[R] N) :=
   TensorProduct.leftHasSMul
 
 protected theorem smul_zero (r : R') : r • (0 : M ⊗[R] N) = 0 :=
-  map_zero (SMul.aux r : _ →+ M ⊗[R] N)
+  map_zero (SMul.aux r)
 
 protected theorem smul_add (r : R') (x y : M ⊗[R] N) : r • (x + y) = r • x + r • y := by
-  simp only [HSMul.hSMul, SMul.smul, leftHasSMul.sMul]
+  simp only [HSMul.hSMul, SMul.smul, leftHasSMul.smul]
   exact map_add _ _ _
 
 protected theorem zero_smul (x : M ⊗[R] N) : (0 : R'') • x = 0 :=


### PR DESCRIPTION
The `SMul` instance for tensor products directly used `AddCon.lift`, so wasn't type correct at instance transparency. This caused a diamond with the `AddCommGroup` instance on tensor products because after unfolding some types didn't match, so I've wrapped the sMul function in a semireducible def to prevent this.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
