### PR TITLE
[Merged by Bors] - feat(CategoryTheory): some lemmas about infima/suprema of morphism properties

### DIFF
--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -90,6 +90,19 @@ lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶
   · rintro ⟨i, hf⟩
     exact ⟨⟨_, i, rfl⟩, hf⟩
 
+@[simp]
+lemma sInf_iff {W : Set (MorphismProperty C)} {X Y : C} (f : X ⟶ Y) :
+    sInf W f ↔ ∀ W' ∈ W, W' f := by
+  suffices h : ∀ {W : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
+      sInf W f ↔ ∀ W' ∈ W, W' f from h
+  simp
+
+@[simp]
+lemma iInf_iff {ι : Type*} {W : ι → MorphismProperty C} {X Y : C} (f : X ⟶ Y) :
+    iInf W f ↔ ∀ i, W i f := by
+  rw [← iInf_range]
+  exact (sInf_iff f).trans (by simp)
+
 /-- The morphism property in `Cᵒᵖ` associated to a morphism property in `C` -/
 @[simp]
 def op (P : MorphismProperty C) : MorphismProperty Cᵒᵖ := fun _ _ f => P f.unop

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -82,26 +82,20 @@ lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
 
 @[simp]
 lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
-    iSup W f ↔ ∃ i, W i f := by
-  apply (sSup_iff (Set.range W) f).trans
-  constructor
-  · rintro ⟨⟨_, i, rfl⟩, hf⟩
-    exact ⟨i, hf⟩
-  · rintro ⟨i, hf⟩
-    exact ⟨⟨_, i, rfl⟩, hf⟩
+    iSup W f ↔ ∃ i, W i f :=
+  (sSup_iff (Set.range W) f).trans (by simp)
 
 @[simp]
-lemma sInf_iff {W : Set (MorphismProperty C)} {X Y : C} (f : X ⟶ Y) :
+lemma sInf_iff (W : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
     sInf W f ↔ ∀ W' ∈ W, W' f := by
   suffices h : ∀ {W : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
       sInf W f ↔ ∀ W' ∈ W, W' f from h
   simp
 
 @[simp]
-lemma iInf_iff {ι : Type*} {W : ι → MorphismProperty C} {X Y : C} (f : X ⟶ Y) :
-    iInf W f ↔ ∀ i, W i f := by
-  rw [← iInf_range]
-  exact (sInf_iff f).trans (by simp)
+lemma iInf_iff {ι : Type*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
+    iInf W f ↔ ∀ i, W i f :=
+  (sInf_iff (Set.range W) f).trans (by simp)
 
 /-- The morphism property in `Cᵒᵖ` associated to a morphism property in `C` -/
 @[simp]

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -71,6 +71,10 @@ lemma of_eq_top {P : MorphismProperty C} (h : P = ⊤) {X Y : C} (f : X ⟶ Y) :
   simp [h]
 
 @[simp]
+lemma sup_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊔ W') f ↔ W f ∨ W' f :=
+  Iff.rfl
+
+@[simp]
 lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
     sSup S f ↔ ∃ (W : S), W.1 f := by
   dsimp [sSup, iSup]
@@ -84,6 +88,10 @@ lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
 lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
     iSup W f ↔ ∃ i, W i f :=
   (sSup_iff (Set.range W) f).trans (by simp)
+
+@[simp]
+lemma inf_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊓ W') f ↔ W f ∧ W' f :=
+  Iff.rfl
 
 @[simp]
 lemma sInf_iff (W : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
@@ -242,6 +250,21 @@ lemma inverseImage_sInf (F : C ⥤ D) (P : Set (MorphismProperty D)) :
     (sInf P).inverseImage F = ⨅ P' ∈ P, P'.inverseImage F :=
   (gc_strictMap F).u_sInf
 
+@[simp]
+lemma inverseImage_sup (F : C ⥤ D) (P P' : MorphismProperty D) :
+    (P ⊔ P').inverseImage F = P.inverseImage F ⊔ P'.inverseImage F :=
+  rfl
+
+@[simp]
+lemma inverseImage_iSup (F : C ⥤ D) {ι : Type*} (P : ι → MorphismProperty D) :
+    (⨆ i, P i).inverseImage F = ⨆ i, (P i).inverseImage F := by
+  ext; simp
+
+@[simp]
+lemma inverseImage_sSup (F : C ⥤ D) (P : Set (MorphismProperty D)) :
+    (sSup P).inverseImage F = ⨆ P' ∈ P, P'.inverseImage F := by
+  ext; simp
+
 /-- The image (up to isomorphisms) of a `MorphismProperty C` by a functor `C ⥤ D` -/
 def map (P : MorphismProperty C) (F : C ⥤ D) : MorphismProperty D := fun _ _ f =>
   ∃ (X' Y' : C) (f' : X' ⟶ Y') (_ : P f'), Nonempty (Arrow.mk (F.map f') ≅ Arrow.mk f)
@@ -382,9 +405,31 @@ instance RespectsLeft.inf (P₁ P₂ Q : MorphismProperty C) [P₁.RespectsLeft 
     [P₂.RespectsLeft Q] : (P₁ ⊓ P₂).RespectsLeft Q where
   precomp i hi f hf := ⟨precomp i hi f hf.left, precomp i hi f hf.right⟩
 
+lemma RespectsLeft.sInf {W : Set (MorphismProperty C)} {Q : MorphismProperty C}
+    (h : ∀ W' ∈ W, W'.RespectsLeft Q) : (sInf W).RespectsLeft Q where
+  precomp _ hi _ hf := by
+    rw [sInf_iff] at hf ⊢
+    exact fun _ hW' ↦ (h _ hW').precomp _ hi _ (hf _ hW')
+
+instance RespectsLeft.iInf {ι : Type*} {W : ι → MorphismProperty C} {Q : MorphismProperty C}
+    [∀ i, (W i).RespectsLeft Q] : (⨅ i, W i).RespectsLeft Q := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
+
 instance RespectsRight.inf (P₁ P₂ Q : MorphismProperty C) [P₁.RespectsRight Q]
     [P₂.RespectsRight Q] : (P₁ ⊓ P₂).RespectsRight Q where
   postcomp i hi f hf := ⟨postcomp i hi f hf.left, postcomp i hi f hf.right⟩
+
+lemma RespectsRight.sInf {W : Set (MorphismProperty C)} {Q : MorphismProperty C}
+    (h : ∀ W' ∈ W, W'.RespectsRight Q) : (sInf W).RespectsRight Q where
+  postcomp _ hi _ hf := by
+    rw [sInf_iff] at hf ⊢
+    exact fun _ hW' ↦ (h _ hW').postcomp _ hi _ (hf _ hW')
+
+instance RespectsRight.iInf {ι : Type*} {W : ι → MorphismProperty C} {Q : MorphismProperty C}
+    [∀ i, (W i).RespectsRight Q] : (⨅ i, W i).RespectsRight Q := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
 
 end
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -83,8 +83,8 @@ lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
 
 @[simp]
 lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
-    iSup W f ↔ ∃ i, W i f :=
-  (sSup_iff (Set.range W) f).trans (by simp)
+    iSup W f ↔ ∃ i, W i f := by
+  simp [← sSup_range]
 
 @[simp]
 lemma inf_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊓ W') f ↔ W f ∧ W' f :=
@@ -99,8 +99,8 @@ lemma sInf_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
 
 @[simp]
 lemma iInf_iff {ι : Type*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
-    iInf W f ↔ ∀ i, W i f :=
-  (sInf_iff (Set.range W) f).trans (by simp)
+    iInf W f ↔ ∀ i, W i f := by
+  simp [← sInf_range]
 
 /-- The morphism property in `Cᵒᵖ` associated to a morphism property in `C` -/
 @[simp]

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -77,9 +77,7 @@ lemma sup_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊔ W') f
 @[simp]
 lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
     sSup S f ↔ ∃ W ∈ S, W f := by
-  suffices h : ∀ {S : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
-      sSup S f ↔ ∃ W ∈ S, W f from h
-  simp
+  simp +instances [MorphismProperty]
 
 @[simp]
 lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
@@ -93,9 +91,7 @@ lemma inf_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊓ W') f
 @[simp]
 lemma sInf_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
     sInf S f ↔ ∀ W ∈ S, W f := by
-  suffices h : ∀ {S : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
-      sInf S f ↔ ∀ W ∈ S, W f from h
-  simp
+  simp +instances [MorphismProperty]
 
 @[simp]
 lemma iInf_iff {ι : Type*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -76,13 +76,10 @@ lemma sup_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊔ W') f
 
 @[simp]
 lemma sSup_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
-    sSup S f ↔ ∃ (W : S), W.1 f := by
-  dsimp [sSup, iSup]
-  constructor
-  · rintro ⟨_, ⟨⟨_, ⟨⟨_, ⟨_, h⟩, rfl⟩, rfl⟩⟩, rfl⟩, hf⟩
-    exact ⟨⟨_, h⟩, hf⟩
-  · rintro ⟨⟨W, hW⟩, hf⟩
-    exact ⟨_, ⟨⟨_, ⟨_, ⟨⟨W, hW⟩, rfl⟩⟩, rfl⟩, rfl⟩, hf⟩
+    sSup S f ↔ ∃ W ∈ S, W f := by
+  suffices h : ∀ {S : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
+      sSup S f ↔ ∃ W ∈ S, W f from h
+  simp
 
 @[simp]
 lemma iSup_iff {ι : Sort*} (W : ι → MorphismProperty C) {X Y : C} (f : X ⟶ Y) :
@@ -94,10 +91,10 @@ lemma inf_iff (W W' : MorphismProperty C) {X Y : C} (f : X ⟶ Y) : (W ⊓ W') f
   Iff.rfl
 
 @[simp]
-lemma sInf_iff (W : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
-    sInf W f ↔ ∀ W' ∈ W, W' f := by
-  suffices h : ∀ {W : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
-      sInf W f ↔ ∀ W' ∈ W, W' f from h
+lemma sInf_iff (S : Set (MorphismProperty C)) {X Y : C} (f : X ⟶ Y) :
+    sInf S f ↔ ∀ W ∈ S, W f := by
+  suffices h : ∀ {S : Set (∀ {X Y : C} (f : X ⟶ Y), Prop)} {X Y : C} {f : X ⟶ Y},
+      sInf S f ↔ ∀ W ∈ S, W f from h
   simp
 
 @[simp]

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -456,7 +456,20 @@ variable {C}
 it is stable under pre- and postcomposition with isomorphisms. -/
 abbrev RespectsIso (P : MorphismProperty C) : Prop := P.Respects (isomorphisms C)
 
-instance inf (P Q : MorphismProperty C) [P.RespectsIso] [Q.RespectsIso] : (P ⊓ Q).RespectsIso where
+instance RespectsIso.inf (P Q : MorphismProperty C) [P.RespectsIso] [Q.RespectsIso] :
+    (P ⊓ Q).RespectsIso where
+
+@[deprecated (since := "2026-05-04")] alias inf := RespectsIso.inf
+
+lemma RespectsIso.sInf {W : Set (MorphismProperty C)} (h : ∀ W' ∈ W, W'.RespectsIso) :
+    (sInf W).RespectsIso where
+  toRespectsLeft := RespectsLeft.sInf (fun W' hW' ↦ (h W' hW').toRespectsLeft)
+  toRespectsRight := RespectsRight.sInf (fun W' hW' ↦ (h W' hW').toRespectsRight)
+
+instance RespectsIso.iInf {ι : Type*} {W : ι → MorphismProperty C} [∀ i, (W i).RespectsIso] :
+    (⨅ i, W i).RespectsIso := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
 
 lemma RespectsIso.mk (P : MorphismProperty C)
     (hprecomp : ∀ {X Y Z : C} (e : X ≅ Y) (f : Y ⟶ Z) (_ : P f), P (e.hom ≫ f))

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -110,6 +110,12 @@ instance IsStableUnderComposition.inf {P Q : MorphismProperty C} [P.IsStableUnde
     (P ⊓ Q).IsStableUnderComposition where
   comp_mem f g hf hg := ⟨P.comp_mem f g hf.left hg.left, Q.comp_mem f g hf.right hg.right⟩
 
+lemma IsStableUnderComposition.sInf {W : Set (MorphismProperty C)}
+    (h : ∀ W' ∈ W, W'.IsStableUnderComposition) : (sInf W).IsStableUnderComposition where
+  comp_mem f g hf hg := by
+    rw [sInf_iff] at hf hg ⊢
+    exact fun W' hW' ↦ (h W' hW').comp_mem _ _ (hf _ hW') (hg _ hW')
+
 /-- A morphism property is `StableUnderInverse` if the inverse of a morphism satisfying
 the property still falls in the class. -/
 def StableUnderInverse (P : MorphismProperty C) : Prop :=

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -63,6 +63,15 @@ instance inf {P Q : MorphismProperty C} [P.ContainsIdentities] [Q.ContainsIdenti
     (P ⊓ Q).ContainsIdentities where
   id_mem X := ⟨P.id_mem X, Q.id_mem X⟩
 
+lemma sInf {W : Set (MorphismProperty C)} (h : ∀ W' ∈ W, W'.ContainsIdentities) :
+    (sInf W).ContainsIdentities where
+  id_mem _ := (sInf_iff _ _).2 fun _ hW' ↦ (h _ hW').id_mem _
+
+instance iInf {ι : Type*} {W : ι → MorphismProperty C}
+    [∀ i, (W i).ContainsIdentities] : (⨅ i, W i).ContainsIdentities := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
+
 end ContainsIdentities
 
 instance Prod.containsIdentities {C₁ C₂ : Type*} [Category* C₁] [Category* C₂]
@@ -115,6 +124,11 @@ lemma IsStableUnderComposition.sInf {W : Set (MorphismProperty C)}
   comp_mem f g hf hg := by
     rw [sInf_iff] at hf hg ⊢
     exact fun W' hW' ↦ (h W' hW').comp_mem _ _ (hf _ hW') (hg _ hW')
+
+instance IsStableUnderComposition.iInf {ι : Type*} {W : ι → MorphismProperty C}
+    [∀ i, (W i).IsStableUnderComposition] : (⨅ i, W i).IsStableUnderComposition := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
 
 /-- A morphism property is `StableUnderInverse` if the inverse of a morphism satisfying
 the property still falls in the class. -/
@@ -211,6 +225,17 @@ instance {P : MorphismProperty D} [P.IsMultiplicative] (F : C ⥤ D) :
 
 instance inf {P Q : MorphismProperty C} [P.IsMultiplicative] [Q.IsMultiplicative] :
     (P ⊓ Q).IsMultiplicative where
+
+lemma sInf {W : Set (MorphismProperty C)} (h : ∀ W' ∈ W, W'.IsMultiplicative) :
+    (sInf W).IsMultiplicative := by
+  have := ContainsIdentities.sInf (fun W' hW' ↦ (h W' hW').toContainsIdentities)
+  have := IsStableUnderComposition.sInf (fun W' hW' ↦ (h W' hW').toIsStableUnderComposition)
+  constructor
+
+instance iInf {ι : Type*} {W : ι → MorphismProperty C}
+    [∀ i, (W i).IsMultiplicative] : (⨅ i, W i).IsMultiplicative := by
+  rw [← sInf_range]
+  exact sInf (by simpa)
 
 instance naturalityProperty {F₁ F₂ : C ⥤ D} (app : ∀ X, F₁.obj X ⟶ F₂.obj X) :
     (naturalityProperty app).IsMultiplicative where


### PR DESCRIPTION
Add some lemmas and instances about arbitrary infima/suprema of morphism properties.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

In particular, this adds the lemmas about `MorphismProperty.inverseImage` preserving suprema that were left out of #38787.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
