### PR TITLE
[Merged by Bors] - chore(Algebra/HierarchyDesign): tidy up

### DIFF
--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -35,7 +35,7 @@ In mathlib, we try to avoid this by only introducing new algebraic typeclasses e
 2. when there is a meaningful gain in simplicity by factoring out a common substructure.
 
 (As examples, at this point we don't have `Loop`, or `UnitalMagma`,
-but we do have `LieSubmodule` and `TopologicalField`!
+but we do have `LieSubmodule` and `NormedField`!
 We also have `GroupWithZero`, as an exemplar of point 2.)
 
 Generally in mathlib we use the extension mechanism (so `CommRing` extends `Ring`)
@@ -43,7 +43,7 @@ rather than mixins (e.g. with separate `Ring` and `CommMul` classes),
 in part because of the potential blow-up in term sizes described at
 https://www.ralfj.de/blog/2019/05/15/typeclasses-exponential-blowup.html
 However there is tension here, as it results in considerable duplication in the API,
-particularly in the interaction with order structures.
+particularly in the interaction with normed structures.
 
 This library note is not intended as a design document
 justifying and explaining the history of mathlib's algebraic hierarchy!

--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -15,7 +15,7 @@ A library note giving advice on modifying the algebraic hierarchy.
 (It is not intended as a "tour".) This is ported directly from the Lean3 version, so may
 refer to files/types that currently only exist in mathlib3.
 
-TODO: Add sections about interactions with topological typeclasses, and order typeclasses.
+TODO: Add a section about interactions with normed typeclasses.
 
 -/
 

--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -15,7 +15,7 @@ A library note giving advice on modifying the algebraic hierarchy.
 (It is not intended as a "tour".) This is ported directly from the Lean3 version, so may
 refer to files/types that currently only exist in mathlib3.
 
-TODO: Add a section about interactions with normed typeclasses.
+TODO: Add sections about algebra-order and algebra-topology mixins and interactions with normed typeclasses.
 
 -/
 

--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -15,12 +15,14 @@ A library note giving advice on modifying the algebraic hierarchy.
 (It is not intended as a "tour".) This is ported directly from the Lean3 version, so may
 refer to files/types that currently only exist in mathlib3.
 
-TODO: Add sections about algebra-order and algebra-topology mixins and interactions with normed typeclasses.
+## TODO
+
+Add sections about algebra-order and algebra-topology mixins and interactions with
+normed typeclasses.
 
 -/
 
 @[expose] public section
-
 
 library_note «the algebraic hierarchy» /-- # The algebraic hierarchy
 
@@ -34,8 +36,8 @@ In mathlib, we try to avoid this by only introducing new algebraic typeclasses e
 1. when there is "real mathematics" to be done with them, or
 2. when there is a meaningful gain in simplicity by factoring out a common substructure.
 
-(As examples, at this point we don't have `Loop`, or `UnitalMagma`,
-but we do have `LieSubmodule` and `NormedField`!
+(As examples, at this point we don't have `Loop`, or `Quasigroup`,
+but we do have `LieSubmodule`, `NormedField` and `IsTopologicalDivisionRing`!
 We also have `GroupWithZero`, as an exemplar of point 2.)
 
 Generally in mathlib we use the extension mechanism (so `CommRing` extends `Ring`)


### PR DESCRIPTION
We don't have `TopologicalField` any more. I've changed it to a more appropriate example. Also, the TODO in this file was ported from mathlib3 which had `topological_ring` and `ordered_ring`; both of these hierarchies have now been decoupled from the algebra hierarchy now. I changed examples to normed examples as this is still not decoupled (and maybe never will be).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
