### PR TITLE
[Merged by Bors] - refactor(NumberTheory): golf `Mathlib/NumberTheory/FrobeniusNumber`

### DIFF
--- a/Mathlib/NumberTheory/FrobeniusNumber.lean
+++ b/Mathlib/NumberTheory/FrobeniusNumber.lean
@@ -72,18 +72,9 @@ theorem frobeniusNumber_pair (cop : Coprime m n) (hm : 1 < m) (hn : 1 < n) :
   · intro k hk
     dsimp at hk
     contrapose! hk
-    let x := chineseRemainder cop 0 k
-    have hx : x.val < m * n := chineseRemainder_lt_mul cop 0 k (ne_bot_of_gt hm) (ne_bot_of_gt hn)
-    suffices key : x.1 ≤ k by
-      obtain ⟨a, ha⟩ := modEq_zero_iff_dvd.mp x.2.1
-      obtain ⟨b, hb⟩ := (modEq_iff_dvd' key).mp x.2.2
-      exact ⟨a, b, by rw [mul_comm, ← ha, mul_comm, ← hb, Nat.add_sub_of_le key]⟩
-    refine x.2.2.le_of_lt_add (lt_of_le_of_lt ?_ (add_lt_add_left hk n))
-    rw [Nat.sub_add_cancel (le_tsub_of_add_le_left hmn)]
-    exact
-      ModEq.le_of_lt_add
-        (x.2.1.trans (modEq_zero_iff_dvd.mpr (Nat.dvd_sub (dvd_mul_right m n) dvd_rfl)).symm)
-        (lt_of_lt_of_le hx le_tsub_add)
+    obtain ⟨a, b, h⟩ := Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le m n k
+      (by simp [cop.gcd_eq_one]) (by grind [Nat.pred_mul, Nat.mul_pred, Nat.pred_eq_sub_one])
+    exact ⟨a, b, succ_inj.mp (congrArg succ h)⟩
 
 namespace Nat
 

--- a/Mathlib/NumberTheory/FrobeniusNumber.lean
+++ b/Mathlib/NumberTheory/FrobeniusNumber.lean
@@ -72,8 +72,8 @@ theorem frobeniusNumber_pair (cop : Coprime m n) (hm : 1 < m) (hn : 1 < n) :
   · intro k hk
     dsimp at hk
     contrapose! hk
-    obtain ⟨a, b, h⟩ := Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le m n k
-      (by simp [cop.gcd_eq_one]) (by grind [Nat.pred_mul, Nat.mul_pred, Nat.pred_eq_sub_one])
+    obtain ⟨a, b, h⟩ := exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le m n k
+      (by simp [cop.gcd_eq_one]) (by grind [pred_mul, mul_pred, pred_eq_sub_one])
     exact ⟨a, b, succ_inj.mp (congrArg succ h)⟩
 
 namespace Nat


### PR DESCRIPTION
- rewrites `frobeniusNumber_pair` to use `Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le` instead of constructing the witnesses via the Chinese remainder argument
- closes the final witness equality by applying `succ_inj` to the resulting additive decomposition

Extracted from #38144

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)