### PR TITLE
[Merged by Bors] - refactor(NumberTheory): golf `Mathlib/NumberTheory/Zsqrtd/GaussianInt`

### DIFF
--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -177,10 +177,8 @@ theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
     (him : |x.im| ≤ |y.im|) : Complex.normSq x ≤ Complex.normSq y := by
-  rw [normSq_apply, normSq_apply, ← _root_.abs_mul_self, _root_.abs_mul, ←
-      _root_.abs_mul_self y.re, _root_.abs_mul y.re, ← _root_.abs_mul_self x.im,
-      _root_.abs_mul x.im, ← _root_.abs_mul_self y.im, _root_.abs_mul y.im]
-  gcongr
+  rw [Complex.normSq_apply, Complex.normSq_apply]
+  nlinarith [sq_le_sq.mpr hre, sq_le_sq.mpr him]
 
 theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :
     Complex.normSq ((x / y : ℂ) - ((x / y : ℤ[i]) : ℂ)) < 1 :=

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -177,8 +177,8 @@ theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
     (him : |x.im| ≤ |y.im|) : normSq x ≤ normSq y := by
-  rw [Complex.normSq_apply, Complex.normSq_apply]
-  nlinarith [sq_le_sq.mpr hre, sq_le_sq.mpr him]
+  simp only [normSq_apply]
+  gcongr
 
 theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :
     Complex.normSq ((x / y : ℂ) - ((x / y : ℤ[i]) : ℂ)) < 1 :=

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -176,7 +176,7 @@ theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x
   simp [-Rat.round_cast, mul_assoc, div_eq_mul_inv, add_mul]
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
-    (him : |x.im| ≤ |y.im|) : Complex.normSq x ≤ Complex.normSq y := by
+    (him : |x.im| ≤ |y.im|) : normSq x ≤ normSq y := by
   rw [Complex.normSq_apply, Complex.normSq_apply]
   nlinarith [sq_le_sq.mpr hre, sq_le_sq.mpr him]
 

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -177,8 +177,8 @@ theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
     (him : |x.im| ≤ |y.im|) : normSq x ≤ normSq y := by
-  simp only [normSq_apply]
-  gcongr
+  simp only [Complex.normSq_apply]
+  nlinarith [sq_le_sq.mpr hre, sq_le_sq.mpr him]
 
 theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :
     Complex.normSq ((x / y : ℂ) - ((x / y : ℤ[i]) : ℂ)) < 1 :=

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -177,7 +177,7 @@ theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
     (him : |x.im| ≤ |y.im|) : normSq x ≤ normSq y := by
-  simp only [Complex.normSq_apply]
+  simp only [normSq_apply]
   nlinarith [sq_le_sq.mpr hre, sq_le_sq.mpr him]
 
 theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :


### PR DESCRIPTION
- rewrites `normSq_le_normSq_of_re_le_of_im_le` to reduce to the squared-coordinate inequalities and finish with `nlinarith`

Extracted from #38144

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)