### PR TITLE
[Merged by Bors] - feat(Order): OrderType cardinality lemmas

### DIFF
--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -104,8 +104,8 @@ open Cardinal
 
 /-- The cardinal of an `OrderType` is the cardinality of any type on which a relation
 with that order type is defined. -/
-def card : OrderType → Cardinal :=
-  fun o ↦ o.liftOn (fun α _ ↦ #α)
+def card (o : OrderType) : Cardinal :=
+  o.liftOn (fun α _ ↦ #α)
     fun _ _ _ _ hab ↦ mk_congr (type_eq_type.mp hab).some.toEquiv
 
 @[simp]

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -124,13 +124,9 @@ theorem card_mono {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card
 
 theorem card_monotone : Monotone card := @card_mono
 
-@[simp]
-theorem card_zero : card 0 = 0 := by
-  simpa using card_type (α := PEmpty)
+@[simp] theorem card_zero : card 0 = 0 := by simpa using card_type (α := PEmpty)
 
-@[simp]
-theorem card_one : card 1 = 1 := by
-  simpa using card_type (α := PUnit)
+@[simp] theorem card_one : card 1 = 1 := by simpa using card_type (α := PUnit)
 
 end Cardinal
 

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -11,6 +11,7 @@ public import Mathlib.Order.Fin.Basic
 public import Mathlib.Order.Hom.Lex
 public import Mathlib.Order.OmegaCompletePartialOrder
 public import Mathlib.Order.Types.Defs
+public import Mathlib.SetTheory.Cardinal.Order
 
 /-!
 
@@ -100,6 +101,38 @@ instance : Monoid OrderType.{u} where
     inductionOn o (fun α _ ↦ by
       simp only [show 1 = type PUnit by rfl, ← type_lex_prod]
       exact (Prod.Lex.uniqueProd PUnit α).type_congr)
+
+section Cardinal
+
+open Cardinal
+
+/-- The cardinal of an `OrderType` is the cardinality of any type on which a relation
+with that order type is defined. -/
+@[expose]
+def card : OrderType → Cardinal :=
+  fun o ↦ o.liftOn (fun α _ ↦ #α)
+    fun _ _ _ _ hab ↦ mk_congr (type_eq_type.mp hab).some.toEquiv
+
+@[simp]
+theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := by
+  rw [card, liftOn_type]
+
+@[gcongr]
+theorem card_mono {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
+  inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ hle ↦ by
+    simp [card, (type_le_type_iff.mp hle).some.cardinal_le]
+
+theorem card_monotone : Monotone card := @card_mono
+
+@[simp]
+theorem card_zero : card 0 = 0 := by
+  simpa using card_type (α := PEmpty)
+
+@[simp]
+theorem card_one : card 1 = 1 := by
+  simpa using card_type (α := PUnit)
+
+end Cardinal
 
 instance (n : Nat) : OfNat OrderType n where
   ofNat := Fin n |> type

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -6,10 +6,6 @@ Authors: Yan Yablonovskiy
 module
 
 public import Mathlib.Data.Real.Basic
-public import Mathlib.Order.CompleteBooleanAlgebra
-public import Mathlib.Order.Fin.Basic
-public import Mathlib.Order.Hom.Lex
-public import Mathlib.Order.OmegaCompletePartialOrder
 public import Mathlib.Order.Types.Defs
 public import Mathlib.SetTheory.Cardinal.Order
 

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -114,7 +114,7 @@ theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := by
 
 @[gcongr]
 theorem card_mono {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
-  inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ hle ↦ by
+  inductionOn₂ o₁ o₂ fun _ _ _ _ hle ↦ by
     simp [card, (type_le_type_iff.mp hle).some.cardinal_le]
 
 theorem card_monotone : Monotone card := @card_mono

--- a/Mathlib/Order/Types/Arithmetic.lean
+++ b/Mathlib/Order/Types/Arithmetic.lean
@@ -104,7 +104,6 @@ open Cardinal
 
 /-- The cardinal of an `OrderType` is the cardinality of any type on which a relation
 with that order type is defined. -/
-@[expose]
 def card : OrderType → Cardinal :=
   fun o ↦ o.liftOn (fun α _ ↦ #α)
     fun _ _ _ _ hab ↦ mk_congr (type_eq_type.mp hab).some.toEquiv

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -5,7 +5,7 @@ Authors: Yan Yablonovskiy
 -/
 module
 
-public import Mathlib.SetTheory.Cardinal.Order
+public import Mathlib.Order.Hom.Basic
 
 /-!
 # Order types
@@ -235,32 +235,6 @@ theorem pos_iff_ne_zero {o : OrderType} : 0 < o ↔ o ≠ 0 where
     have := nonempty_toType_iff.2 ho
     rw [← type_toType o]
     exact ⟨⟨Function.Embedding.ofIsEmpty, nofun⟩, fun ⟨f⟩ ↦ IsEmpty.elim inferInstance f.toFun⟩
-
-section Cardinal
-
-open Cardinal
-
-/-- The cardinal of an `OrderType` is the cardinality of any type on which a relation
-with that order type is defined. -/
-@[expose]
-def card : OrderType → Cardinal :=
-  fun o ↦ o.liftOn (fun α _ ↦ #α)
-    fun _ _ _ _ hab ↦ mk_congr (type_eq_type.mp hab).some.toEquiv
-
-@[simp]
-theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := (rfl)
-
-@[gcongr]
-theorem card_mono {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
-  inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ ⟨f⟩ ↦ ⟨f.toEmbedding⟩
-
-theorem card_monotone : Monotone card := @card_mono
-
-@[simp] theorem card_zero : card 0 = 0 := mk_eq_zero _
-
-@[simp] theorem card_one : card 1 = 1 := mk_eq_one _
-
-end Cardinal
 
 /-- The universe lift operation on order types. You can specify the universes explicitly with
   `lift.{u, v} : OrderType.{v} → OrderType.{max v u}` -/

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -256,8 +256,7 @@ theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := (rfl)
 theorem card_le_card {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
   inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ ⟨f⟩ ↦ ⟨f.toEmbedding⟩
 
-theorem card_mono : Monotone card := by
- rw [Monotone]; exact @card_le_card
+theorem card_mono : Monotone card := @card_le_card
 
 @[simp]
 theorem card_zero : card 0 = 0 := mk_eq_zero _

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -251,10 +251,10 @@ def card : OrderType → Cardinal :=
 theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := (rfl)
 
 @[gcongr]
-theorem card_le_card {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
+theorem card_mono {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
   inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ ⟨f⟩ ↦ ⟨f.toEmbedding⟩
 
-theorem card_mono : Monotone card := @card_le_card
+theorem card_monotone : Monotone card := @card_mono
 
 @[simp] theorem card_zero : card 0 = 0 := mk_eq_zero _
 

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -6,6 +6,8 @@ Authors: Yan Yablonovskiy
 module
 
 public import Mathlib.Order.Hom.Basic
+public import Mathlib.SetTheory.Cardinal.Defs
+public import Mathlib.SetTheory.Cardinal.Order
 
 /-!
 # Order types
@@ -235,6 +237,35 @@ theorem pos_iff_ne_zero {o : OrderType} : 0 < o ↔ o ≠ 0 where
     have := nonempty_toType_iff.2 ho
     rw [← type_toType o]
     exact ⟨⟨Function.Embedding.ofIsEmpty, nofun⟩, fun ⟨f⟩ ↦ IsEmpty.elim inferInstance f.toFun⟩
+
+section Cardinal
+
+open Cardinal
+
+/-- The cardinal of an `OrderType` is the cardinality of any type on which a relation
+with that order type is defined. -/
+@[expose]
+def card : OrderType → Cardinal :=
+  fun o ↦ o.liftOn (fun α _ ↦ #α)
+    fun _ _ _ _ hab ↦ mk_congr (type_eq_type.mp hab).some.toEquiv
+
+@[simp]
+theorem card_type {α : Type u} [LinearOrder α] : card (type α) = #α := (rfl)
+
+@[gcongr]
+theorem card_le_card {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
+  inductionOn o₁ fun _ ↦ inductionOn o₂ fun _ _ ⟨f⟩ ↦ ⟨f.toEmbedding⟩
+
+theorem card_mono : Monotone card := by
+ rw [Monotone]; exact @card_le_card
+
+@[simp]
+theorem card_zero : card 0 = 0 := mk_eq_zero _
+
+@[simp]
+theorem card_one : card 1 = 1 := mk_eq_one _
+
+end Cardinal
 
 /-- The universe lift operation on order types. You can specify the universes explicitly with
   `lift.{u, v} : OrderType.{v} → OrderType.{max v u}` -/

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -5,8 +5,6 @@ Authors: Yan Yablonovskiy
 -/
 module
 
-public import Mathlib.Order.Hom.Basic
-public import Mathlib.SetTheory.Cardinal.Defs
 public import Mathlib.SetTheory.Cardinal.Order
 
 /-!

--- a/Mathlib/Order/Types/Defs.lean
+++ b/Mathlib/Order/Types/Defs.lean
@@ -256,11 +256,9 @@ theorem card_le_card {o₁ o₂ : OrderType} : o₁ ≤ o₂ → card o₁ ≤ c
 
 theorem card_mono : Monotone card := @card_le_card
 
-@[simp]
-theorem card_zero : card 0 = 0 := mk_eq_zero _
+@[simp] theorem card_zero : card 0 = 0 := mk_eq_zero _
 
-@[simp]
-theorem card_one : card 1 = 1 := mk_eq_one _
+@[simp] theorem card_one : card 1 = 1 := mk_eq_one _
 
 end Cardinal
 


### PR DESCRIPTION
Adding some basic lemmas for the cardinality of an order type.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
