### PR TITLE
[Merged by Bors] - feat(Order/ConditionallyCompleteLattice/Basic): `ConditionallyCompleteLinearOrderBot` versions of `csSup_union`/`csSup_inter_le`/`csSup_insert`

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -588,6 +588,21 @@ theorem csSup_le_csSup' {s t : Set α} (h₁ : BddAbove t) (h₂ : s ⊆ t) : sS
     exact bot_le
   · exact csSup_le_csSup h₁ h h₂
 
+variable {t : Set α}
+
+theorem csSup_union' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by bddDefault) :
+    sSup (s ∪ t) = sSup s ⊔ sSup t := by
+  rcases s.eq_empty_or_nonempty with (rfl | hne)
+  · simp
+  exact (isLUB_csSup' hs |>.union <| isLUB_csSup' ht).csSup_eq hne.inl
+
+theorem csSup_inter_le' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by bddDefault) :
+    sSup (s ∩ t) ≤ sSup s ⊓ sSup t :=
+  csSup_le' fun _ hx ↦ le_inf (le_csSup hs hx.left) (le_csSup ht hx.right)
+
+theorem csSup_insert' (hs : BddAbove s := by bddDefault) : sSup (insert a s) = a ⊔ sSup s :=
+  isLUB_csSup' hs |>.insert a |>.csSup_eq <| insert_nonempty a s
+
 end ConditionallyCompleteLinearOrderBot
 
 namespace WithTop

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -596,6 +596,10 @@ theorem csSup_union' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by b
   · simp
   exact (isLUB_csSup' hs |>.union <| isLUB_csSup' ht).csSup_eq hne.inl
 
+theorem csSup_union_le : sSup (s ∪ t) ≤ sSup s ⊔ sSup t := by
+  by_cases BddAbove (s ∪ t) <;>
+    grind [csSup_union', bddAbove_union, csSup_of_not_bddAbove]
+
 theorem csSup_inter_le' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by bddDefault) :
     sSup (s ∩ t) ≤ sSup s ⊓ sSup t :=
   csSup_le' fun _ hx ↦ le_inf (le_csSup hs hx.left) (le_csSup ht hx.right)

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -471,6 +471,14 @@ theorem csInf_eq_csInf_of_forall_exists_le {s t : Set α}
     sInf s = sInf t :=
   csSup_eq_csSup_of_forall_exists_le (α := αᵒᵈ) hs ht
 
+theorem csSup_union_le (s t : Set α) : sSup (s ∪ t) ≤ sSup s ⊔ sSup t := by
+  rcases s.eq_empty_or_nonempty with (rfl | hs)
+  · simp
+  rcases t.eq_empty_or_nonempty with (rfl | ht)
+  · simp
+  by_cases BddAbove (s ∪ t) <;>
+    grind [csSup_union, bddAbove_union, csSup_of_not_bddAbove]
+
 lemma sSup_iUnion_Iic (f : ι → α) : sSup (⋃ (i : ι), Iic (f i)) = ⨆ i, f i := by
   apply csSup_eq_csSup_of_forall_exists_le
   · rintro x ⟨-, ⟨i, rfl⟩, hi⟩
@@ -595,10 +603,6 @@ theorem csSup_union' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by b
   rcases s.eq_empty_or_nonempty with (rfl | hne)
   · simp
   exact (isLUB_csSup' hs |>.union <| isLUB_csSup' ht).csSup_eq hne.inl
-
-theorem csSup_union_le : sSup (s ∪ t) ≤ sSup s ⊔ sSup t := by
-  by_cases BddAbove (s ∪ t) <;>
-    grind [csSup_union', bddAbove_union, csSup_of_not_bddAbove]
 
 theorem csSup_inter_le' (hs : BddAbove s := by bddDefault) (ht : BddAbove t := by bddDefault) :
     sSup (s ∩ t) ≤ sSup s ⊓ sSup t :=


### PR DESCRIPTION
`ConditionallyCompleteLinearOrderBot` lets us drop all the `Set.Nonempty` assumptions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
