### PR TITLE
[Merged by Bors] - refactor(MeasureTheory): golf `Mathlib/MeasureTheory/Function/LpSeminorm/Count`

### DIFF
--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Count.lean
@@ -34,22 +34,12 @@ lemma enorm_le_eLpNorm_count (f : α → ε) (i : α) (hp : p ≠ 0) :
       _ = eLpNorm f p (count.restrict {i}) := by simp
       _ ≤ eLpNorm f p count := eLpNorm_restrict_le ..
 
-lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) :
-    eLpNorm f p .count < ∞ := by
-  letI _ := Fintype.ofFinite α
-  simp_rw [eLpNorm]
-  split_ifs with h2 h3
-  · exact ENNReal.zero_lt_top
-  · refine (essSup_le_of_ae_le (Finset.univ.sup (‖f ·‖ₑ)) ?_).trans_lt ?_
-    · filter_upwards with x
-      exact Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ _)
-    · simp_rw [Finset.sup_lt_iff ENNReal.zero_lt_top, h, implies_true]
-  · refine (ENNReal.rpow_lt_top_iff_of_pos ?_).mpr ?_
-    · rw [one_div, inv_pos]
-      exact ENNReal.toReal_pos h2 h3
-    · simp_rw [lintegral_count, tsum_eq_sum (s := Finset.univ) (by simp), ENNReal.sum_lt_top,
-        Finset.mem_univ, forall_const, ENNReal.rpow_lt_top_iff_of_pos (ENNReal.toReal_pos h2 h3), h,
-        implies_true]
+omit [MeasurableSingletonClass α] in
+lemma eLpNorm_count_lt_top_of_lt [Finite α] (h : ∀ i, ‖f i‖ₑ < ∞) : eLpNorm f p .count < ∞ := by
+  haveI := Fintype.ofFinite α
+  refine (eLpNorm_mono_enorm (g := fun _ ↦ Finset.univ.sup (‖f ·‖ₑ)) ?_).trans_lt ?_
+  · exact fun x ↦ Finset.le_sup (f := (‖f ·‖ₑ)) (Finset.mem_univ x)
+  · exact (memLp_const_enorm <| by simp [h, LT.lt.ne]).eLpNorm_lt_top
 
 lemma eLpNorm_count_lt_top [Finite α] (hp : p ≠ 0) :
     eLpNorm f p .count < ∞ ↔ ∀ i, ‖f i‖ₑ < ∞ :=


### PR DESCRIPTION
- rewrites `eLpNorm_count_lt_top_of_lt` using `eLpNorm_mono_enorm` with the finite supremum bound instead of splitting on the definition of `eLpNorm`
- closes the finiteness goal with `memLp_const_enorm` rather than a manual `lintegral_count` computation

Extracted from #38104

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)