### PR TITLE
feat(Data/List): `foldl` (`foldr`) is preserved under rotation if `RightCommutative` (`LeftCommutative`)

### DIFF
--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Yakov Pechersky
 -/
 module
 
+public import Mathlib.Data.List.Fold
 public import Mathlib.Data.List.Nodup
 public import Mathlib.Data.List.Infix
 public import Mathlib.Data.Quot
@@ -353,6 +354,20 @@ theorem Nodup.rotate_eq_self_iff {l : List α} (hl : l.Nodup) {n : ℕ} :
     l.rotate n = l ↔ n % l.length = 0 ∨ l = [] := by
   rw [← zero_mod, ← hl.rotate_congr_iff, rotate_zero]
 
+@[simp]
+lemma foldl_rotate {β} (f : β → α → β) [RightCommutative f] (b : β) (n : ℕ) (l : List α) :
+    (l.rotate n).foldl f b = l.foldl f b := by
+  induction n generalizing l with | zero => simp | succ n ih => _
+  match l with | [] => simp | a :: as => _
+  simp only [rotate_cons_succ, foldl_cons_eq_apply_foldl, ih, foldl_concat]
+
+@[simp]
+lemma foldr_rotate {β} (f : α → β → β) [LeftCommutative f] (b : β) (n : ℕ) (l : List α) :
+    (l.rotate n).foldr f b = l.foldr f b := by
+  induction n generalizing l with | zero => simp | succ n ih => _
+  match l with | [] => simp | a :: as => _
+  simp only [rotate_cons_succ, foldr_cons_eq_foldr_apply, ih, foldr_concat]
+
 section IsRotated
 
 variable (l l' : List α)
@@ -486,6 +501,16 @@ theorem IsRotated.dropLast_tail {α}
   | a :: b :: L => by
     simp only [head_cons, ne_eq, reduceCtorEq, not_false_eq_true, getLast_cons] at hL'
     simp [hL', IsRotated.cons_getLast_dropLast]
+
+theorem IsRotated.foldl {β} (h : l ~r l') (f : β → α → β) [RightCommutative f] (b : β) :
+    l.foldl f b = l'.foldl f b := by
+  obtain ⟨n, rfl⟩ := h
+  rw [foldl_rotate]
+
+theorem IsRotated.foldr {β} (h : l ~r l') (f : α → β → β) [LeftCommutative f] (b : β) :
+    l.foldr f b = l'.foldr f b := by
+  obtain ⟨n, rfl⟩ := h
+  rw [foldr_rotate]
 
 /-- List of all cyclic permutations of `l`.
 The `cyclicPermutations` of a nonempty list `l` will always contain `List.length l` elements.


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
