### PR TITLE
[Merged by Bors] - chore(NumberTheory/Divisors): golf `Int.mem_divisorsAntidiag`

### DIFF
--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -692,19 +692,15 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
   simp
 
 @[simp]
-lemma mem_divisorsAntidiag :
-    ∀ {z} {xy : ℤ × ℤ}, xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0
-  | (n : ℕ), ((x : ℕ), (y : ℕ))
-  | (n : ℕ), (-[x+1], -[y+1])
-  | (n : ℕ), ((x : ℕ), -[y+1])
-  | (n : ℕ), (-[x+1], (y : ℕ))
-  | -[n+1], ((x : ℕ), (y : ℕ))
-  | -[n+1], (-[x+1], -[y+1])
-  | -[n+1], ((x : ℕ), -[y+1])
-  | -[n+1], (-[x+1], (y : ℕ)) => by
-    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
-    norm_cast
-    try simp +contextual [eq_comm]
+lemma mem_divisorsAntidiag {z} {xy : ℤ × ℤ} :
+    xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
+  rcases z, xy with ⟨_ | _, ⟨_ | _, _ | _⟩⟩
+  case ofNat.negSucc.negSucc =>
+    simp [divisorsAntidiag]
+    grind [Nat.cast_inj]
+  all_goals
+    simp [divisorsAntidiag]
+    grind only
 
 theorem image_fst_divisorsAntidiag : z.divisorsAntidiag.image Prod.fst = z.divisors := by
   ext

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -693,24 +693,14 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
 
 @[simp]
 lemma mem_divisorsAntidiag : xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
-  rcases z with z | z
-  · suffices
-        (∃ x y, (x * y = z ∧ ¬z = 0) ∧ ((↑x, ↑y) = xy ∨ (-↑x, -↑y) = xy)) ↔
-          xy.1 * xy.2 = ↑z ∧ ¬z = 0 by
-      simpa [divisorsAntidiag, ← exists_or, ← and_or_left]
-    constructor
-    · rintro ⟨x, y, ⟨⟨hdvd, hz⟩, rfl | rfl⟩⟩ <;> simp only [neg_mul_neg] <;> norm_cast
-    · rintro ⟨hdvd, hz⟩
-      use xy.1.natAbs, xy.2.natAbs
-      rcases xy with ⟨x | x, y | y⟩ <;> simp at hdvd ⊢ <;> norm_cast at hdvd <;> grind
-  · suffices (∃ x y, x * y = z + 1 ∧ ((↑x, -↑y) = xy ∨ (-↑x, ↑y) = xy)) ↔ xy.1 * xy.2 = -[z+1] by
-      simpa [divisorsAntidiag, ← exists_or, ← and_or_left]
-    constructor
-    · rintro ⟨x, y, ⟨hdvd, rfl | rfl⟩⟩ <;>
-      simp only [mul_neg, neg_mul, negSucc_eq, neg_inj] <;> norm_cast
-    · rintro hdvd
-      use xy.1.natAbs, xy.2.natAbs
-      rcases xy with ⟨x | x, y | y⟩ <;> simp at hdvd ⊢ <;> norm_cast at hdvd <;> grind
+  rcases z, xy with ⟨_ | _, ⟨_ | _, _ | _⟩⟩
+  --  splitting this case takes about 1770 heartbeats less i.e. 12.5% faster
+  case ofNat.negSucc.negSucc =>
+    simp [divisorsAntidiag]
+    grind [Nat.cast_inj]
+  all_goals
+    simp [divisorsAntidiag]
+    grind
 
 theorem image_fst_divisorsAntidiag : z.divisorsAntidiag.image Prod.fst = z.divisors := by
   ext

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -692,15 +692,25 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
   simp
 
 @[simp]
-lemma mem_divisorsAntidiag {z} {xy : ℤ × ℤ} :
-    xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
-  rcases z, xy with ⟨_ | _, ⟨_ | _, _ | _⟩⟩
-  case ofNat.negSucc.negSucc =>
-    simp [divisorsAntidiag]
-    grind [Nat.cast_inj]
-  all_goals
-    simp [divisorsAntidiag]
-    grind only
+lemma mem_divisorsAntidiag : xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
+  rcases z with z | z
+  · suffices
+        (∃ x y, (x * y = z ∧ ¬z = 0) ∧ ((↑x, ↑y) = xy ∨ (-↑x, -↑y) = xy)) ↔
+          xy.1 * xy.2 = ↑z ∧ ¬z = 0 by
+      simpa [divisorsAntidiag, ← exists_or, ← and_or_left]
+    constructor
+    · rintro ⟨x, y, ⟨⟨hdvd, hz⟩, rfl | rfl⟩⟩ <;> simp only [neg_mul_neg] <;> norm_cast
+    · rintro ⟨hdvd, hz⟩
+      use xy.1.natAbs, xy.2.natAbs
+      rcases xy with ⟨x | x, y | y⟩ <;> simp at hdvd ⊢ <;> norm_cast at hdvd <;> grind
+  · suffices (∃ x y, x * y = z + 1 ∧ ((↑x, -↑y) = xy ∨ (-↑x, ↑y) = xy)) ↔ xy.1 * xy.2 = -[z+1] by
+      simpa [divisorsAntidiag, ← exists_or, ← and_or_left]
+    constructor
+    · rintro ⟨x, y, ⟨hdvd, rfl | rfl⟩⟩ <;>
+      simp only [mul_neg, neg_mul, negSucc_eq, neg_inj] <;> norm_cast
+    · rintro hdvd
+      use xy.1.natAbs, xy.2.natAbs
+      rcases xy with ⟨x | x, y | y⟩ <;> simp at hdvd ⊢ <;> norm_cast at hdvd <;> grind
 
 theorem image_fst_divisorsAntidiag : z.divisorsAntidiag.image Prod.fst = z.divisors := by
   ext

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -694,42 +694,17 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
 @[simp]
 lemma mem_divisorsAntidiag :
     ∀ {z} {xy : ℤ × ℤ}, xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0
-  | (n : ℕ), ((x : ℕ), (y : ℕ)) => by
-    simp [divisorsAntidiag]
-    norm_cast
-    simp +contextual [eq_comm]
-  | (n : ℕ), (negSucc x, negSucc y) => by
-    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
-    norm_cast
-    simp +contextual [eq_comm]
-  | (n : ℕ), ((x : ℕ), negSucc y) => by
-    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
-    norm_cast
-    aesop
-  | (n : ℕ), (negSucc x, (y : ℕ)) => by
-    suffices
-      (∃ a, (n = a * y ∧ ¬n = 0) ∧ (a : ℤ) = -1 + -↑x) ↔ (n : ℤ) = (-1 + -↑x) * ↑y ∧ ¬n = 0 by
-      simpa [divisorsAntidiag, eq_comm, negSucc_eq]
-    simp only [← Int.neg_add, Int.add_comm 1, Int.neg_mul, Int.add_mul]
-    norm_cast
-    match n with
-    | 0 => simp
-    | n + 1 => simp
-  | .negSucc n, ((x : ℕ), (y : ℕ)) => by
-    simp [divisorsAntidiag]
-    norm_cast
-  | .negSucc n, (negSucc x, negSucc y) => by
-    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
-    norm_cast
-    simp +contextual
-  | .negSucc n, ((x : ℕ), negSucc y) => by
-    simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
-    norm_cast
-    aesop
+  | (n : ℕ), ((x : ℕ), (y : ℕ))
+  | (n : ℕ), (negSucc x, negSucc y)
+  | (n : ℕ), ((x : ℕ), negSucc y)
+  | (n : ℕ), (negSucc x, (y : ℕ))
+  | .negSucc n, ((x : ℕ), (y : ℕ))
+  | .negSucc n, (negSucc x, negSucc y)
+  | .negSucc n, ((x : ℕ), negSucc y)
   | .negSucc n, (negSucc x, (y : ℕ)) => by
     simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
     norm_cast
-    simp +contextual [eq_comm]
+    try simp +contextual [eq_comm]
 
 theorem image_fst_divisorsAntidiag : z.divisorsAntidiag.image Prod.fst = z.divisors := by
   ext

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -695,13 +695,13 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
 lemma mem_divisorsAntidiag :
     ∀ {z} {xy : ℤ × ℤ}, xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0
   | (n : ℕ), ((x : ℕ), (y : ℕ))
-  | (n : ℕ), (negSucc x, negSucc y)
-  | (n : ℕ), ((x : ℕ), negSucc y)
-  | (n : ℕ), (negSucc x, (y : ℕ))
-  | .negSucc n, ((x : ℕ), (y : ℕ))
-  | .negSucc n, (negSucc x, negSucc y)
-  | .negSucc n, ((x : ℕ), negSucc y)
-  | .negSucc n, (negSucc x, (y : ℕ)) => by
+  | (n : ℕ), (-[x+1], -[y+1])
+  | (n : ℕ), ((x : ℕ), -[y+1])
+  | (n : ℕ), (-[x+1], (y : ℕ))
+  | -[n+1], ((x : ℕ), (y : ℕ))
+  | -[n+1], (-[x+1], -[y+1])
+  | -[n+1], ((x : ℕ), -[y+1])
+  | -[n+1], (-[x+1], (y : ℕ)) => by
     simp [divisorsAntidiag, negSucc_eq, -neg_add_rev]
     norm_cast
     try simp +contextual [eq_comm]

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -694,7 +694,7 @@ lemma mem_divisors_self (hz : z ≠ 0) : z ∈ divisors z :=
 @[simp]
 lemma mem_divisorsAntidiag : xy ∈ divisorsAntidiag z ↔ xy.fst * xy.snd = z ∧ z ≠ 0 := by
   rcases z, xy with ⟨_ | _, ⟨_ | _, _ | _⟩⟩
-  --  splitting this case takes about 1770 heartbeats less i.e. 12.5% faster
+  -- splitting this case saves about 1770 heartbeats i.e. 12.5% faster
   case ofNat.negSucc.negSucc =>
     simp [divisorsAntidiag]
     grind [Nat.cast_inj]


### PR DESCRIPTION
This PR merges the case split and removes duplicated proofs in `Int.mem_divisorsAntidiag`.