### PR TITLE
chore: fix diamonds in separation quotient

### DIFF
--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -127,7 +127,7 @@ def mkMonoidHom [MulOneClass M] [ContinuousMul M] : M →* SeparationQuotient M 
 
 instance (priority := 900) instNSMul [AddMonoid M] [ContinuousAdd M] :
     SMul ℕ (SeparationQuotient M) :=
-  inferInstance
+  inferInstanceAs (SMul ℕ (SeparationQuotient M))
 
 @[to_additive existing]
 instance instPow [Monoid M] [ContinuousMul M] : Pow (SeparationQuotient M) ℕ where
@@ -183,7 +183,7 @@ instance instContinuousDiv [Div G] [ContinuousDiv G] : ContinuousDiv (Separation
   continuous_div' := isQuotientMap_prodMap_mk.continuous_iff.2 <| continuous_mk.comp continuous_div'
 
 instance instZSMul [AddGroup G] [IsTopologicalAddGroup G] : SMul ℤ (SeparationQuotient G) :=
-  inferInstance
+  inferInstanceAs (SMul ℤ (SeparationQuotient G))
 
 @[to_additive existing]
 instance instZPow [Group G] [IsTopologicalGroup G] : Pow (SeparationQuotient G) ℤ where


### PR DESCRIPTION
The following two fail on master but succeed on the branch:
```
example [AddMonoid M] [ContinuousAdd M] : instNSMul (M := M) = AddMonoid.toNSMul := by
  with_reducible_and_instances rfl

example [AddGroup G] [IsTopologicalAddGroup G] : instZSMul (G := G) = SubNegMonoid.toZSMul := by
  with_reducible_and_instances rfl
```

---

I am not sure whether this solution is better, or just deleting the instances. Especially a low-priority `inferInstance` instance seems a bit weird.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
