### PR TITLE
[Merged by Bors] - ci(olean_report): fetch PR oleans from fork's cache

### DIFF
--- a/.github/workflows/olean_report.yaml
+++ b/.github/workflows/olean_report.yaml
@@ -69,11 +69,12 @@ jobs:
         run: |
           pr_json=$(gh pr view "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" \
-            --json headRefOid,baseRefOid,baseRefName)
+            --json headRefOid,baseRefOid,baseRefName,headRepository)
           {
             echo "head_sha=$(echo "$pr_json" | jq -r '.headRefOid')"
             echo "base_sha=$(echo "$pr_json" | jq -r '.baseRefOid')"
             echo "base_ref=$(echo "$pr_json" | jq -r '.baseRefName')"
+            echo "head_repo=$(echo "$pr_json" | jq -r '.headRepository.nameWithOwner')"
           } >> "$GITHUB_OUTPUT"
 
       # Using refs/pull/N/head works for both same-repo and fork PRs, since
@@ -175,6 +176,9 @@ jobs:
         run: |
           cd pr-branch
           lake env "$CACHE_BIN" get
+          # Run again with --repo in case this is a fork PR: fork PRs upload
+          # their oleans to the fork's Azure container, not the upstream one.
+          lake env "$CACHE_BIN" --repo="${{ steps.pr_info.outputs.head_repo }}" get
 
       - name: Check PR head oleans
         id: pr_oleans_check


### PR DESCRIPTION
Fixes an issue noticed in [this comment](https://github.com/leanprover-community/mathlib4/pull/38653#issuecomment-4359342261) where the olean report said that 5066 modules were removed from a PR that only added `to_dual` tags.

The issue is that the `olean_report` workflow only fetched oleans from the `leanprover-community/mathlib4` cache and not the fork cache. We fix this by also fetching the head repo name from `gh pr view --json headRepository` and re-running `cache get --repo=<head_repo>`, mirroring what `build_template.yml` already does for regular CI.

Prepared with Claude code.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
