### PR TITLE
feat: `#scope`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7982,6 +7982,7 @@ public import Mathlib.Util.PPOptions
 public import Mathlib.Util.ParseCommand
 public import Mathlib.Util.PrintSorries
 public import Mathlib.Util.Qq
+public import Mathlib.Util.Scope
 public import Mathlib.Util.Simp
 public import Mathlib.Util.SleepHeartbeats
 public import Mathlib.Util.Superscript

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4767,6 +4767,7 @@ public import Mathlib.Init
 public import Mathlib.Lean.ContextInfo
 public import Mathlib.Lean.CoreM
 public import Mathlib.Lean.Elab.InfoTree
+public import Mathlib.Lean.Elab.Options
 public import Mathlib.Lean.Elab.Tactic.Basic
 public import Mathlib.Lean.Elab.Tactic.Meta
 public import Mathlib.Lean.Elab.Term

--- a/Mathlib/Lean/Elab/Options.lean
+++ b/Mathlib/Lean/Elab/Options.lean
@@ -5,6 +5,7 @@ Authors: Thomas R. Murrills
 -/
 module
 
+import Mathlib.Init
 public import Lean.Data.KVMap
 
 /-! # Additional utilities for managing `Options` -/
@@ -31,3 +32,5 @@ def DataValue.toSetOptionValueSyntax? : DataValue → Option (TSyntax [`str, `nu
   | .ofBool b     => some ⟨Syntax.atom .none (toString b)⟩
   | .ofString str => some ⟨Syntax.mkStrLit str⟩
   | _ => none
+
+end Lean

--- a/Mathlib/Lean/Elab/Options.lean
+++ b/Mathlib/Lean/Elab/Options.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
+module
+
+public import Lean.Data.KVMap
+
+/-! # Additional utilities for managing `Options` -/
+
+public section
+
+namespace Lean
+
+/--
+Converts a `DataValue` that may appear as the value of some `set_option` to appropriate `Syntax`.
+This only returns `some _` on user-writable `set_option` `DataValue`s (`.ofBool`, `.ofNat`,
+`.ofString`) and `none` on the rest.
+
+Note that the parser responsible for the option values is
+```
+def Parser.Command.optionValue :=
+  nonReservedSymbol "true" <|> nonReservedSymbol "false" <|> strLit <|> numLit
+```
+but this is not a `leading_parser`, and creates no corresponding syntax node. Instead, syntax
+quotations constructing a `set_option` expect a ``TSyntax [`str, `num]``.
+-/
+def DataValue.toSetOptionValueSyntax? : DataValue → Option (TSyntax [`str, `num])
+  | .ofNat n      => some ⟨Syntax.mkNumLit (toString n)⟩
+  | .ofBool b     => some ⟨Syntax.atom .none (toString b)⟩
+  | .ofString str => some ⟨Syntax.mkStrLit str⟩
+  | _ => none

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison
+Authors: Kim Morrison, Thomas R. Murrills
 -/
 module
 
@@ -52,8 +52,27 @@ def allNamesByModule (p : Name → Bool) : CoreM (Std.HashMap Name (Array Name))
     else
       return names
 
+namespace Lean.Name
+
+/--
+Folds `f` over the prefixes of `Name`, starting with the longest. E.g.
+``(`a.b.c).foldrPrefix init f`` results in
+```
+let v₁ := f `a.b.c init
+let v₂ := f `a.b v₁
+let v₄ := f `a v₃
+f .anonymous v₄
+```
+This is useful for certain `namespace`-related operations.
+-/
+@[specialize f] def foldrPrefix {α} (n : Name) (init : α) (f : Name → α → α) :=
+  let val := f n init
+  match n with
+  | .anonymous => val
+  | .str pre _ | .num pre _ => pre.foldrPrefix val f
+
 /-- Decapitalize the last component of a name. -/
-def Lean.Name.decapitalize (n : Name) : Name :=
+def decapitalize (n : Name) : Name :=
   n.modifyBase fun
     | .str p s => .str p s.decapitalize
     | n       => n
@@ -70,7 +89,7 @@ the name will definitely round trip. (The converse is not guaranteed.) Any devia
 behavior is a bug which should be fixed.
 -/
 -- See also [Zulip](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Check.20if.20a.20.60Lean.2EName.60.20is.20roundtrippable/with/565735560)
-meta def Lean.Name.willRoundTrip (n : Name) : Bool :=
+meta def willRoundTrip (n : Name) : Bool :=
   !n.isAnonymous -- anonymous names do not roundtrip
     && !n.hasMacroScopes -- names with macroscopes do not roundtrip
     && !maybePseudoSyntax -- names which might be "pseudo-syntax" do not roundtrip

--- a/Mathlib/Lean/Name.lean
+++ b/Mathlib/Lean/Name.lean
@@ -117,3 +117,5 @@ where
       "#".isPrefixOf s || "?".isPrefixOf s
     else
       false
+
+end Lean.Name

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -327,12 +327,12 @@ syntax "#scope" (ppLine scopeStx)? : command
 
 elab_rules : command
 | `(#scope%$tk) => do
-  let stx ← `(command|#scope%$tk $(← reifyScope))
+  let stx ← `(command| #scope%$tk $(← reifyScope))
   liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk stx
 | `(#scope%$tk $scopeStx) => do
   let scopeStx' ← withRef scopeStx reifyScope
   unless scopeStx.raw.structEq scopeStx' do
-    let stx ← `(command|#scope%$tk $scopeStx')
+    let stx ← `(command| #scope%$tk $scopeStx')
     liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk (origSpan? := (← getRef)) stx
       (diffGranularity := .word)
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -42,10 +42,10 @@ public section parsers
 /-! The "inlinable" parsers in this section exist to enable syntax quotations, which help with
 constructing and processing these later. -/
 
-/-- `open (from → @fullyResolvedName)` in reified syntax represents the results of ordinary
-Lean syntax of the form `open ns renaming from → to, ...` and `open ns (id₁ id₂ ...)`. Internally,
-both of these produce the same kind of effect: they record mapping(s) from an unresolved identifier
-to a fully resolved name. (`ns` is not directly recorded in this mapping.) -/
+/-- `(from → @fullyResolvedName)` in reified `open` syntax unambiguously represents the result of
+ordinary Lean syntax of the form `open ns renaming from → to, ...` and `open ns (id₁ id₂ ...)`.
+Internally, both of these produce the same kind of effect: they record mapping(s) from an
+unresolved identifier to a fully resolved name. (`ns` is not directly recorded in this mapping.) -/
 syntax reifiedExplicitOpenStx := ident " → " &"@" noWs ident
 syntax reifiedSimpleOpenIdent := &"@" noWs ident
 syntax reifiedSimpleOpenHidingStx := &"@" noWs ident " hiding " ident*

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -191,13 +191,13 @@ end header
 section openDecls
 
 /-- Lean may duplicate open declarations occasionally due to leanprover/lean4#13353. This function
-deduplicates exactly-duplicated `OpenDecl`s. -/
+deduplicates exactly-duplicated `OpenDecl`s by removing the later occurrences. -/
 @[inline] private def deduplicateOpenDecls (openDecls : List OpenDecl) : List OpenDecl :=
-  -- Note that the innermost openDecls come first and affect name resolution first due to `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in openDecls)
+  /- Note that the innermost openDecls come first and affect name resolution first due to `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in openDecls) -/
   -- TODO: find something more efficient, which means basically just about anything else.
   openDecls.reverse.eraseDups.reverse
 
-/-- Convert `OpenDecl`s into reified `open @id₁ @id₂ ...` syntax for portability. -/
+/-- Convert `OpenDecl`s into reified `open @id₁ @id₂ ...` syntax. -/
 def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) (dedup := true) :
     m (Option (TSyntax ``reifiedOpenStx)) := do
   let openDecls := if dedup then deduplicateOpenDecls openDecls else openDecls

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -159,21 +159,29 @@ def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) 
 
 section openScoped
 
-@[inline] def _root_.Lean.NameSet.minus (current minus : NameSet) : NameSet := Id.run do
-  if minus.isEmpty then current else current.filter (!minus.contains ·)
+/-- `current.minus without` yields a `NameSet` containing the elements of `current` not present in
+`without`. -/
+@[inline] private def _root_.Lean.NameSet.minus (current without : NameSet) : NameSet :=
+  if without.isEmpty then current else current.filter (!without.contains ·)
 
 /-- An extension we can trust to always be present, whose active scopes reflect the result of
-`open`s. -/
-@[inline] def scopeTestExt := Parser.parserExtension.ext
+`open`s and are likely not altered separately from the rest of the scoped environment extensions by
+some metaprogram. -/
+@[inline] private def referenceScopedExt := Parser.parserExtension.ext
 
+/-- The active scopes in scoped environment extensions, as determined by a reference
+extension. Does not account for alterations to individual environment extensions that may
+be performed by some metaprograms. -/
 def _root_.Lean.Environment.activeScopes (env : Environment) : NameSet :=
-  match scopeTestExt.getState (asyncMode := .local) env |>.stateStack with
+  match referenceScopedExt.getState (asyncMode := .local) env |>.stateStack with
   | s :: _ => s.activeScopes
   | _ => {}
 
-/-- Gets the activated scopes in a (standard) scoped env extension that are *not* implied by the
-current namespace and open decls. I.e., the extra `open scoped` that exist somewhere. -/
-protected def _root_.Lean.Environment.extraScoped (env : Environment)
+/-- The active scopes in scoped env extensions that are *not* implied by the
+given namespace and open decls (as determined by the active scopes in a reference environment
+extension). These extra active scopes are typically produced by `open scoped`. See also
+`Lean.Elab.Command.extraScoped : CommandElabM NameSet`. -/
+protected def _root_.Lean.Environment.extraActiveScopes (env : Environment)
     (currNamespace : Name) (openDecls : List OpenDecl) : NameSet := Id.run do
   -- Note that each `open` that adds `.simple` activates the corresponding scopes.
   let impliedScopes : NameSet := openDecls.foldl (init := {}) fun
@@ -186,14 +194,22 @@ protected def _root_.Lean.Environment.extraScoped (env : Environment)
     if n.isAnonymous then acc else acc.insert n
   return env.activeScopes.minus impliedScopes
 
-def extraScoped : CommandElabM NameSet := do
-  return (← getEnv).extraScoped (← getCurrNamespace) (← getScope).openDecls
+/-- The active scopes in scoped env extensions that are *not* implied by the current namespace and
+open decls (as determined by the active scopes in a reference environment extension). These extra
+active scopes are typically produced by `open scoped`. -/
+def _root_.Lean.Elab.Command.extraActiveScopes : CommandElabM NameSet :=
+  return (← getEnv).extraActiveScopes (← getCurrNamespace) (← getOpenDecls)
+
+/-- Converts the extra active scopes into reified `open scoped` syntax. -/
+def reifyExtraOpenScopes : CommandElabM (Option (TSyntax ``reifiedOpenScopedStx)) := do
+  let extra ← extraActiveScopes
+  if extra.isEmpty then return none
+  let extraScoped ← extra.toArray.mapM fun n => `(reifiedSimpleOpenIdent| @$(mkIdent n))
+  `(reifiedOpenScopedStx| open scoped $extraScoped*)
 
 end openScoped
 
 end openDecls
-
--- TODO: `reify*` instead of `mk*Stx`
 
 section setOption
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -76,7 +76,7 @@ syntax reifiedSetOptionsStx := withPosition("set_options " ppIndent(reifiedOptio
 /--
 A scope specification of the form
 ```
-(@[expose])? (public)? (noncomputable)? (section)? (scope)?
+(@[expose])? (public)? (noncomputable)? (section)? scope
   (universe ...)?
   (namespace ...)?
   (open @id₁ @id₂ ...)?

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -73,6 +73,10 @@ syntax reifiedOptionKeyValue := ppSpace colGt ident ppSpace optionValue
 /-- `set_options key₁ val₁, key₂ val₂, ...` renders the options set in a single line. -/
 syntax reifiedSetOptionsStx := withPosition("set_options " ppIndent(reifiedOptionKeyValue,*))
 
+-- We don't want docstrings on these parsers, since they would clutter hovers.
+attribute [nolint docBlame] reifiedSimpleOpenIdent reifiedSimpleOpenHidingStx reifiedOpenDecl
+  reifiedVarStx reifiedOptionKeyValue
+
 /--
 A scope specification of the form
 ```

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -42,18 +42,22 @@ public section parsers
 /-! The "inlinable" parsers in this section exist to enable syntax quotations, which help with
 constructing and processing these later. -/
 
-/-- An unambiguous rendering of the result of `open ns renaming from → to, ...` and
-`open ns (id₁ id₂ ...)`, which both do not record `ns`, but only the mapping from unresolved
-identifier to fully resolved name(s). -/
-syntax reifiedExplicitOpenStx := ident " → " ident
+/-- `open (from → @fullyResolvedName)` in reified syntax represents the results of ordinary
+Lean syntax of the form `open ns renaming from → to, ...` and `open ns (id₁ id₂ ...)`. Internally,
+both of these produce the same kind of effect: they record mapping(s) from an unresolved identifier
+to a fully resolved name. (`ns` is not directly recorded in this mapping.) -/
+syntax reifiedExplicitOpenStx := ident " → " &"@" noWs ident
 syntax reifiedSimpleOpenIdent := &"@" noWs ident
 syntax reifiedSimpleOpenHidingStx := &"@" noWs ident " hiding " ident*
 syntax reifiedOpenDecl := ppSpace colGt
   (reifiedSimpleOpenIdent <|> ("(" reifiedSimpleOpenHidingStx <|> reifiedExplicitOpenStx ")"))
 /-- Renders the result of `open` by prefixing identifiers with `@` to indicate that this syntax
-only renders fully-resolved namespaces. Surrounded by `()` when `hiding` is present.
-Uses `(... → ...)` to render the mappings produced by `open ns renaming from → to, ...` and
-`open ns (id₁ id₂ ...)`. -/
+only renders fully-resolved namespaces and identifiers. (Surrounded by `()` when `hiding` is
+present.)
+
+Uses `(... → @...)` to render the mappings produced by ordinary Lean syntax such as
+`open ns renaming from → to, ...` and `open ns (id₁ id₂ ...)`, which internally both produce the
+same sort of mapping(s) from an unresolved identifier to a fully-resolved name. -/
 syntax reifiedOpenStx := withPosition(
   atomic("open" notFollowedBy("scoped")) ppIndent(reifiedOpenDecl*))
 
@@ -154,7 +158,7 @@ def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) 
   for openDecl in openDecls do
     let reified ← match openDecl with
       | .explicit id declName =>
-        `(reifiedOpenDecl| ($(mkIdent id) → $(mkIdent declName)))
+        `(reifiedOpenDecl| ($(mkIdent id) → @$(mkIdent declName)))
       | .simple ns except =>
         if except.isEmpty then `(reifiedOpenDecl| @$(mkIdent ns)) else
           let except := except.toArray.map mkIdent

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -1,13 +1,7 @@
 module
 
-public import Lean
 public meta import Mathlib.Lean.Elab.Options
 public meta import Mathlib.Lean.Name
-public meta import Lean.Elab.BuiltinCommand
-public meta import Lean.PrettyPrinter.Delaborator
-import Batteries
-public meta import Mathlib.Lean.Elab.InfoTree
-public meta import Aesop.Util.Basic -- Name.ofComponents...
 
 /-!
 # Scope manipulation tools

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -51,8 +51,8 @@ syntax reifiedSimpleOpenHidingStx := &"@" noWs ident " hiding " ident*
 syntax reifiedOpenDecl := ppSpace colGt
   (reifiedSimpleOpenIdent <|> ("(" reifiedSimpleOpenHidingStx <|> reifiedExplicitOpenStx ")"))
 /-- Renders the result of `open` by prefixing identifiers with `@` to indicate that this syntax
-only renders fully-resolved namespaces. Surrounded by `()` when `hiding` is present. Uses `→` to
-render the mappings produced by `open ns renaming from → to, ...` and
+only renders fully-resolved namespaces. Surrounded by `()` when `hiding` is present.
+Uses `(... → ...)` to render the mappings produced by `open ns renaming from → to, ...` and
 `open ns (id₁ id₂ ...)`. -/
 syntax reifiedOpenStx := withPosition(
   atomic("open" notFollowedBy("scoped")) ppIndent(reifiedOpenDecl*))

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -215,38 +215,6 @@ def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) 
   if reifiedOpens.isEmpty then return none else
     `(reifiedOpenStx| open $reifiedOpens.toArray*)
 
-/-- Activates scopes associated with an `OpenDecl` as `open` would when creating that `OpenDecl`. -/
-def _root_.Lean.OpenDecl.activate {m : Type → Type}
-    [Monad m] [MonadEnv m] [MonadLiftT (ST IO.RealWorld) m] :
-    OpenDecl → m Unit
-  | .simple ns _  => activateScoped ns
-  | .explicit _ _ => pure () -- `open` never activates scopes when creating these
-
-/-- Turns reified syntax for a single `open` such as `@foo.bar` into an `OpenDecl`, activating
-scopes as `open` would if `activateScopes := true` (the default). -/
-def unreifyOpenDecl (openDecl : TSyntax ``reifiedOpenDecl) (activateScopes := true) :
-    CommandElabM OpenDecl :=
-  match openDecl with
-  | `(reifiedOpenDecl| @$id) => do
-    if activateScopes then activateScoped id.getId
-    return .simple id.getId []
-  | `(reifiedOpenDecl| (@$id hiding $hidden*)) => do
-    if activateScopes then activateScoped id.getId
-    return .simple id.getId <| (hidden.map (·.getId)).toList
-  | `(reifiedOpenDecl| ($id → $decl)) =>
-    -- `open` never activates scopes in these cases. See `elabOpenDecl`.
-    return .explicit id.getId decl.getId
-  | _ => throwUnsupportedSyntax
-
-/-- Turns reified syntax for `open @id ...` such as `open @foo.bar ...` into `OpenDecl`s
-(activating scopes as appropriate) and modifies the current scope to use exactly those open
-declarations (erasing whatever open declarations were present before). Note that the resulting
-`openDecls` do not depend on the original `openDecls` or original scope in any way. -/
-def unreifyOpenDecls (openDeclsStx : TSyntaxArray ``reifiedOpenDecl) : CommandElabM Unit := do
-  let openDecls ← openDeclsStx.foldlM (init := []) fun openDecls openDeclStx =>
-    return (← unreifyOpenDecl openDeclStx) :: openDecls
-  modifyScope fun s => { s with openDecls }
-
 section openScoped
 
 def _root_.Lean.Name.foldrPrefix {α} (n : Name) (init : α) (f : Name → α → α) :=

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -10,7 +10,7 @@ public meta import Aesop.Util.Basic -- Name.ofComponents...
 
 open Lean Meta Elab Command
 
-public section
+public meta section
 
 namespace Mathlib.Tactic.Scope
 
@@ -35,6 +35,7 @@ syntax reifiedOpenScopedStx := withPosition("open " "scoped"
   ppIndent((ppSpace colGt reifiedSimpleOpenIdent)*))
 
 -- Parser of convenience, since we handle these together.
+-- TODO: technically this may be influenced by open scopes. It needs to incorporate that in the parser.
 syntax reifiedVarStx := Parser.Command.variable (ppLine Parser.Command.include)? (ppLine Parser.Command.omit)?
 
 syntax reifiedOptionKeyValue := ppSpace colGt ident ppSpace optionValue
@@ -60,7 +61,7 @@ Note also that this is intended to reify semantic and instantaneous aspects of a
 and not the entire scope stack. This means that `section`s and local scopes are not
 accounted for here.
 -/
-syntax scopeStx := Parser.Command.sectionHeader &"scope"
+syntax scopeStx := Parser.Command.sectionHeader -- &"scope"
   (ppLine colGt Parser.Command.universe)?
   (ppLine colGt Parser.Command.namespace)?
   atomic((ppLine colGt reifiedOpenStx)?)
@@ -243,24 +244,144 @@ def unreifyOpenDecls (openDeclsStx : TSyntaxArray ``reifiedOpenDecl) : CommandEl
 
 section openScoped
 
+def _root_.Lean.Name.foldrPrefix {α} (n : Name) (init : α) (f : Name → α → α) :=
+  let val := f n init
+  match n with
+  | .anonymous => val
+  | .str pre _ | .num pre _ => pre.foldrPrefix val f
+
+@[inline] def _root_.Lean.NameSet.minus (current minus : NameSet) : NameSet := Id.run do
+  if minus.isEmpty then current else current.filter (!minus.contains ·)
+
+/-- An extension we can trust to always be present, whose active scopes reflect the result of `open`s. -/
+@[inline] def scopeTestExt := Parser.parserExtension.ext
+
+def _root_.Lean.Environment.activeScopes (env : Environment) : NameSet :=
+  match scopeTestExt.getState (asyncMode := .local) env |>.stateStack with
+  | s :: _ => s.activeScopes
+  | _ => {}
+
+/-- Gets the activated scopes in a (standard) scoped env extension that are *not* implied by the current namespace and open decls. I.e., the extra `open scoped` that exist somewhere. -/
+protected def _root_.Lean.Environment.extraScoped (env : Environment)
+    (currNamespace : Name) (openDecls : List OpenDecl) : NameSet := Id.run do
+  -- Note that each `open` that adds `.simple` activates the corresponding scopes.
+  let impliedScopes : NameSet := openDecls.foldl (init := {}) fun
+    | acc, .simple ns _ => if ns.isAnonymous then acc else acc.insert ns
+    | acc, _ => acc
+  -- When `namespace ns` happened (or whatever sequence of `namespace`s), `addScopes` traversed all prefixes of `ns`. So we expect those to be there.
+  -- Note that `addScope` in `elabNamespace` does not add to the open decls, so this is necessary.
+  let impliedScopes := currNamespace.foldrPrefix (init := impliedScopes) fun n acc =>
+    if n.isAnonymous then acc else acc.insert n
+  return env.activeScopes.minus impliedScopes
+
+def extraScoped : CommandElabM NameSet := do
+  return (← getEnv).extraScoped (← getCurrNamespace) (← getScope).openDecls
+
 end openScoped
 
 end openDecls
 
+-- TODO: `reify*` instead of `mk*Stx`
+
+section setOption
+
+def _root_.Lean.DataValue.toSetOptionValueSyntax? : DataValue → Option Syntax
+  | .ofNat n      => Syntax.mkNumLit (toString n)
+  | .ofBool b  => Syntax.atom .none (toString b)
+  | .ofString str => Syntax.mkStrLit str
+  | _ => none
+
+/--
+info: [(Elab.async, true), (maxSynthPendingDepth, 3), (linter.style.header, true), (Elab.inServer, true), (pp.unicode.fun, true), (autoImplicit, false)]
+-/
+#guard_msgs in
+run_cmd do
+  logInfo m!"{← getOptions}"
+
+/- Note: Ideally we would like to not include all the lake build options. But these are commingled
+with any `set_option`s in the base scope, so without doing something like "checking the lakefile"
+or "recording the options at the top of the file via linter" we can't distinguish between options
+set by lake and options set in the file. -/
+/-- Erases the options set by Lean itself, and `Elab.async` if it has not been changed by the user.
+However, still includes the options set in the lakefile. -/
+def getUserOptions : CommandElabM Options := do
+  let opts := (← getOptions).erase `internal.cmdlineSnapshots |>.erase `Elab.inServer
+  if opts.get? `Elab.async |>.isEqSome true then return opts.erase `Elab.async else return opts
+
+def reifySetOptions? (opts : Options) : CommandElabM (Option (TSyntax ``reifiedSetOptionsStx)) := do
+  let mut kvs := #[]
+  for (key, val) in opts do
+    let some val := val.toSetOptionValueSyntax? | continue
+    kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $(⟨val⟩))
+  if kvs.isEmpty then pure none else some <$> `(reifiedSetOptionsStx| set_options $kvs,*)
+
+-- def _root_.Lean.Options.toSyntax (opts : Options) :
+--     CommandElabM (Array (TSyntax ``Parser.Command.set_option)) := do
+--   let mut optStx := #[]
+--   for (key, val) in opts do
+--     let some valStx := val.toSetOptionValueSyntax? | continue
+--     -- Note: this is a bit of a hack since it might be an `.atom`, and `TSyntax` only recognizes stra and num
+--     optStx := optStx.push <|← `(Parser.Command.set_option| set_option $(mkIdent key) $(⟨valStx⟩))
+--   return optStx
+
+end setOption
+
 section universes
 
-
+def reifyUniverses? : CommandElabM (Option <| TSyntax ``Parser.Command.universe) := do
+  let levelNames := (← getScope).levelNames
+  if levelNames.isEmpty then pure none else
+    some <$> `(Parser.Command.universe| universe $(levelNames.toArray.map mkIdent)*)
 
 end universes
 
+section namespaces
+
+def reifyCurrNamespace? : CommandElabM (Option (TSyntax ``Parser.Command.namespace)) := do
+  let ns ← getCurrNamespace
+  if ns.isAnonymous then pure none else `(Parser.Command.namespace| namespace $(mkIdent ns))
+
+end namespaces
+
+section variables
+
+def reifyVariables? : CommandElabM (Option (TSyntax ``Parser.Command.variable)) := do
+  let { varDecls .. } ← getScope
+  if varDecls.isEmpty then return none
+  `(Parser.Command.variable| variable $varDecls*)
+
+def reifyInclude? : CommandElabM (Option (TSyntax ``Parser.Command.include)) := do
+  let { includedVars .. } ← getScope
+  if includedVars.isEmpty then return none
+  -- TODO: the `Name`s are `varUIDs` with hygiene, but should we strip that in making the idents?
+  `(Parser.Command.include| include $(includedVars.toArray.map mkIdent)*)
+
+def reifyOmit? : CommandElabM (Option (TSyntax ``Parser.Command.omit)) := do
+  let { omittedVars, varUIds, varDecls .. } ← getScope
+  if omittedVars.isEmpty then return none
+  let mut omittedIdentOrBinder : TSyntaxArray [`ident, `Lean.Parser.Term.instBinder] := #[]
+  for var in omittedVars do
+    for uid in varUIds, stx in varDecls do
+      if uid = var then
+        if stx.raw.isOfKind ``Parser.Term.instBinder then
+          omittedIdentOrBinder := omittedIdentOrBinder.push ⟨stx.raw⟩
+        else
+          -- TODO: remove scopes?
+          omittedIdentOrBinder := omittedIdentOrBinder.push (mkIdent uid)
+        break
+  -- TODO: the `Name`s are `varUIDs` with hygiene, but should we strip that in making the idents?
+  `(Parser.Command.omit| omit $(omittedIdentOrBinder)*)
+
+end variables
+
 def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
   let sectionHeader ← (← getScope).toSectionHeader.toSyntax
-  let universes ← getUniverseStx
-  let namespaceStx ← getCurrNamespaceSyntax
+  let universes ← reifyUniverses?
+  let namespaceStx ← reifyCurrNamespace?
   let opens ← reifyOpenDecls (← getScope).openDecls
 
-  let variables ← (← getVariableSyntax?).mapM fun vars => do
-    `(reifiedVarStx| $vars $(← getIncludeSyntax?)? $(← getOmitSyntax?)?)
+  let variables ← (← reifyVariables?).mapM fun vars => do
+    `(reifiedVarStx| $vars $(← reifyInclude?)? $(← reifyOmit?)?)
 
   let extraScopedNames ← extraScoped
   let extraScoped ← if extraScopedNames.isEmpty then pure none else
@@ -268,15 +389,9 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
       `(reifiedSimpleOpenIdent| @$(mkIdent n))
     some <$> `(reifiedOpenScopedStx| open scoped $extraScoped*)
 
-  let newOpts ← getNewOptions -- TODO: actually, the base scope may be polluted, right? So maybe just list all of them.
-  let setOptions ← do
-    let mut kvs := #[]
-    for (key, val) in newOpts do
-      let some val := val.toSetOptionValueSyntax? | continue
-      kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $(⟨val⟩))
-    if kvs.isEmpty then pure none else some <$> `(reifiedSetOptionsStx| set_options $kvs,*)
+  let setOptions ← reifySetOptions? (← getUserOptions)
 
-  `(scopeStx| $sectionHeader scope
+  `(scopeStx| $sectionHeader -- scope
     $[$universes]?
     $[$namespaceStx]?
     $[$opens]?
@@ -285,3 +400,23 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
     $[$variables]?) -- TODO: technically the variable parsing could change if a scope is opened earlier. This is probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a parser for `scope` that opens the named scopes!
 
     -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.
+
+syntax "#scope" (ppLine scopeStx)? : command
+
+elab_rules : command
+| `(#scope%$tk) => do
+  let stx ← `(command|#scope%$tk $(← reifyScope))
+  liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk stx
+| `(#scope%$tk $scopeStx) => do
+  let scopeStx' ← withRef scopeStx reifyScope
+  unless scopeStx.raw.structEq scopeStx' do
+    let stx ← `(command|#scope%$tk $scopeStx')
+    liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk (origSpan? := (← getRef)) stx
+      (diffGranularity := .word)
+
+#scope
+  public meta
+  namespace Mathlib.Tactic.Scope
+  open @Lean @Lean.Meta @Lean.Elab @Lean.Elab.Command
+  set_options maxSynthPendingDepth 3, linter.style.header true, pp.unicode.fun true, autoImplicit
+    false

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -285,13 +285,6 @@ end openDecls
 
 section setOption
 
-def _root_.Lean.DataValue.toSetOptionValueSyntax? : DataValue → Option Syntax
-  | .ofNat n      => Syntax.mkNumLit (toString n)
-  | .ofBool b  => Syntax.atom .none (toString b)
-  | .ofString str => Syntax.mkStrLit str
-  | _ => none
-
-
 /- Note: Ideally we would like to not include all the lake build options. But these are commingled
 with any `set_option`s in the base scope, so without doing something like "checking the lakefile"
 or "recording the options at the top of the file via linter" we can't distinguish between options

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -291,12 +291,6 @@ def _root_.Lean.DataValue.toSetOptionValueSyntax? : DataValue → Option Syntax
   | .ofString str => Syntax.mkStrLit str
   | _ => none
 
-/--
-info: [(Elab.async, true), (maxSynthPendingDepth, 3), (linter.style.header, true), (Elab.inServer, true), (pp.unicode.fun, true), (autoImplicit, false)]
--/
-#guard_msgs in
-run_cmd do
-  logInfo m!"{← getOptions}"
 
 /- Note: Ideally we would like to not include all the lake build options. But these are commingled
 with any `set_option`s in the base scope, so without doing something like "checking the lakefile"
@@ -314,15 +308,6 @@ def reifySetOptions? (opts : Options) : CommandElabM (Option (TSyntax ``reifiedS
     let some val := val.toSetOptionValueSyntax? | continue
     kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $(⟨val⟩))
   if kvs.isEmpty then pure none else some <$> `(reifiedSetOptionsStx| set_options $kvs,*)
-
--- def _root_.Lean.Options.toSyntax (opts : Options) :
---     CommandElabM (Array (TSyntax ``Parser.Command.set_option)) := do
---   let mut optStx := #[]
---   for (key, val) in opts do
---     let some valStx := val.toSetOptionValueSyntax? | continue
---     -- Note: this is a bit of a hack since it might be an `.atom`, and `TSyntax` only recognizes stra and num
---     optStx := optStx.push <|← `(Parser.Command.set_option| set_option $(mkIdent key) $(⟨valStx⟩))
---   return optStx
 
 end setOption
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -1,0 +1,287 @@
+module
+
+public import Lean
+public meta import Lean.Elab.BuiltinCommand
+public meta import Lean.PrettyPrinter.Delaborator
+import Batteries
+public meta import Mathlib.Lean.Elab.InfoTree
+public meta import Aesop.Util.Basic -- Name.ofComponents...
+
+
+open Lean Meta Elab Command
+
+public section
+
+namespace Mathlib.Tactic.Scope
+
+-- The "inlinable" parsers in this section exist to enable syntax quotations.
+
+/-- An unambiguous rendering of the result of `open ns renaming from → to, ...` and
+`open ns (id₁ id₂ ...)`, which both do not record `ns`, but only the mapping from unresolved
+identifier to fully resolved name(s). -/
+syntax reifiedExplicitOpenStx := ident " → " ident
+syntax reifiedSimpleOpenIdent := &"@" noWs ident
+syntax reifiedSimpleOpenHidingStx := &"@" noWs ident " hiding " ident*
+syntax reifiedOpenDecl := ppSpace colGt
+  (reifiedSimpleOpenIdent <|> ("(" reifiedSimpleOpenHidingStx <|> reifiedExplicitOpenStx ")"))
+/-- Renders the result of `open` by prefixing identifiers with `@` to indicate that this syntax
+only renders fully-resolved namespaces. Surrounded by `()` when `hiding` is present. Uses `→` to
+render the mappings produced by `open ns renaming from → to, ...` and
+`open ns (id₁ id₂ ...)`. -/
+syntax reifiedOpenStx := withPosition(atomic("open" notFollowedBy("scoped")) ppIndent(reifiedOpenDecl*))
+
+/-- Renders the open scopes that are not accounted for by generic `open`s. Prefixes identifiers with `@` to show the fully-resolved name. -/
+syntax reifiedOpenScopedStx := withPosition("open " "scoped"
+  ppIndent((ppSpace colGt reifiedSimpleOpenIdent)*))
+
+-- Parser of convenience, since we handle these together.
+syntax reifiedVarStx := Parser.Command.variable (ppLine Parser.Command.include)? (ppLine Parser.Command.omit)?
+
+syntax reifiedOptionKeyValue := ppSpace colGt ident ppSpace optionValue
+/-- `set_options key₁ val₁, key₂ val₂, ...` renders the options set in a single line. -/
+syntax reifiedSetOptionsStx := withPosition("set_options " ppIndent(reifiedOptionKeyValue,*))
+
+/--
+A scope specification of the form
+```
+(@[expose])? (public)? (noncomputable)? (section)? scope
+  (universe ...)?
+  (namespace ...)?
+  (open @id₁ @id₂ ...)?
+  (open scoped @id₁ @id₂ ...)?
+  (set_options key₁ val₁, key₂ val₂ ...)?
+  (variable ...)?
+  (include ...)?
+  (omit ...)?
+```
+Notice the differences from typical scope syntax.
+
+Note also that this is intended to reify semantic and instantaneous aspects of a given scope,
+and not the entire scope stack. This means that `section`s and local scopes are not
+accounted for here.
+-/
+syntax scopeStx := Parser.Command.sectionHeader &"scope"
+  (ppLine colGt Parser.Command.universe)?
+  (ppLine colGt Parser.Command.namespace)?
+  atomic((ppLine colGt reifiedOpenStx)?)
+  (ppLine colGt reifiedOpenScopedStx)? -- TODO: local?
+  (ppLine colGt reifiedSetOptionsStx)?
+  (ppLine colGt reifiedVarStx)?
+
+section header
+
+open Parser.Command
+
+/--
+Encodes scope section headers: `(@[expose])? (public)? (noncomputable)? (meta)?`.
+-/
+structure SectionHeader where
+  /-- Whether the scope uses `@[expose]`. -/
+  expose : Bool := false -- TODO: `Option Syntax`?
+  /-- Whether the scope uses `public`. -/
+  isPublic : Bool := false
+  /-- Whether the scope uses `noncomputable`. -/
+  isNoncomputable : Bool := false
+  /-- Whether the scope uses `meta`. -/
+  isMeta : Bool := false
+deriving BEq, Inhabited, Repr
+
+/-- Encodes scope section headers, and associates syntax position information to them. -/
+structure SectionHeaderRef where
+  /-- The full ref of the whole section header. -/
+  ref : Syntax := .missing
+  /-- The token `expose`. Does not include brackets. -/
+  exposeTk : Option Syntax := none
+  /-- The token `public`. -/
+  publicTk : Option Syntax := none
+  /-- The token `noncomputable`. -/
+  noncomputableTk : Option Syntax := none
+  /-- The token `meta`. -/
+  metaTk : Option Syntax := none
+
+/-- Converts syntax representing a section header ref to a `SectionHeader`. -/
+@[inline] def SectionHeaderRef.toSectionHeader : SectionHeaderRef → SectionHeader
+  | { exposeTk, publicTk, noncomputableTk, metaTk, .. } => {
+    expose := exposeTk.isSome
+    isPublic := publicTk.isSome
+    isNoncomputable := noncomputableTk.isSome
+    isMeta := metaTk.isSome
+  }
+
+/-- Recreates `(@[expose])? (public)? (noncomputable)? (meta)?` syntax from the given
+`SectionHeaderRef`. -/
+def SectionHeaderRef.toSyntax {m} [Monad m] [MonadQuotation m] :
+    SectionHeaderRef → m (TSyntax ``sectionHeader)
+  | { exposeTk, publicTk, noncomputableTk, metaTk, ref } => withRef ref `(sectionHeader|
+      $[@[expose%$exposeTk]]?
+      $[public%$publicTk]?
+      $[noncomputable%$noncomputableTk]?
+      $[meta%$metaTk]?)
+
+/-- Organizes `sectionHeader` syntax into a `SectionHeaderRef`. -/
+def SectionHeaderRef.ofSyntax? : TSyntax ``sectionHeader → Option SectionHeaderRef
+  | ref@`(sectionHeader|
+      $[@[expose%$exposeTk]]?
+      $[public%$publicTk]?
+      $[noncomputable%$noncomputableTk]?
+      $[meta%$metaTk]?) =>
+    some { ref, exposeTk, publicTk, noncomputableTk, metaTk }
+  | _ => none
+
+/-- Creates `(@[expose])? (public)? (noncomputable)? (meta)?` syntax from the given
+`SectionHeader`. Uses the current ref for position information on each token. -/
+def SectionHeader.toSyntax {m} [Monad m] [MonadQuotation m] :
+    SectionHeader → m (TSyntax ``sectionHeader)
+  | { expose, isPublic, isNoncomputable, isMeta } => do
+    -- This is a hack to exploit antiquotations. `$[$foo%$tk]?` yields `foo` iff `tk.isSome`.
+    let r ← getRef
+    letI toDummyOptional? (b : Bool) : Option Syntax :=
+      if b then some r else none
+    let pubTk    := toDummyOptional? isPublic
+    let metaTk   := toDummyOptional? isMeta
+    let exposeTk := toDummyOptional? expose
+    let ncTk     := toDummyOptional? isNoncomputable
+    `(sectionHeader|
+      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?)
+
+/-- Extracts a `SectionHeader` structure from `(@[expose])? (public)? (noncomputable)? (meta)?`
+syntax. -/
+@[inline] def SectionHeader.ofSyntax? : TSyntax ``sectionHeader → Option SectionHeader
+  | `(sectionHeader|
+      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?) =>
+    some {
+      expose := exposeTk.isSome
+      isPublic := pubTk.isSome
+      isNoncomputable := ncTk.isSome
+      isMeta := metaTk.isSome
+    }
+  | _ => none
+
+/-- Isolates the part of a `Scope` that contains `SectionHeader` information. -/
+@[inline] def _root_.Lean.Elab.Command.Scope.toSectionHeader : Scope → SectionHeader
+  | { isPublic, isMeta, isNoncomputable, attrs .. } =>
+    -- Currently, `attrs` only ever holds `@[expose]`.
+    { isPublic, isMeta, isNoncomputable, expose := !attrs.isEmpty }
+
+/-- Applies a `sectionHeader` syntax of the form `(@[expose])? (public)? (noncomputable)? (meta)?`
+to the current scope, overwriting the values (rather than merging them). For instance, if `public`
+is absent, the resulting scope now has `isPublic := false`, even if it was `true` before. -/
+def unreifySectionHeaderStx : TSyntax ``Parser.Command.sectionHeader → CommandElabM Unit
+  | `(Parser.Command.sectionHeader|
+      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?) => do
+      let isPublic := pubTk.isSome
+      let isMeta := metaTk.isSome
+      -- `sectionHeader` parses `expose` directly, not as an `attrInstance`.
+      let attrs : List (TSyntax ``Parser.Term.attrInstance) ←
+        if let some exposeTk := exposeTk then
+          pure [← withRef exposeTk `(Parser.Term.attrInstance| expose)] else pure []
+      let isNoncomputable := ncTk.isSome
+      modifyScope fun s => { s with isPublic, isMeta, isNoncomputable, attrs }
+  | _ => throwUnsupportedSyntax
+
+end header
+
+section openDecls
+
+/-- Lean may duplicate open declarations occasionally due to leanprover/lean4#13353. This function
+deduplicates exactly-duplicated `OpenDecl`s. -/
+@[inline] private def deduplicateOpenDecls (openDecls : List OpenDecl) : List OpenDecl :=
+  -- Note that the innermost openDecls come first and affect name resolution first due to `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in openDecls)
+  -- TODO: find something more efficient, which means basically just about anything else.
+  openDecls.reverse.eraseDups.reverse
+
+/-- Convert `OpenDecl`s into reified `open @id₁ @id₂ ...` syntax for portability. -/
+def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) (dedup := true) :
+    m (Option (TSyntax ``reifiedOpenStx)) := do
+  let openDecls := if dedup then deduplicateOpenDecls openDecls else openDecls
+  -- Note that the last element of `openDecls` becomes the first element of `reifiedOpens`,
+  -- since the outermost `OpenDecl` is the most recent.
+  let mut reifiedOpens := []
+  for openDecl in openDecls do
+    let reified ← match openDecl with
+      | .explicit id declName =>
+        `(reifiedOpenDecl| ($(mkIdent id) → $(mkIdent declName)))
+      | .simple ns except =>
+        if except.isEmpty then `(reifiedOpenDecl| @$(mkIdent ns)) else
+          let except := except.toArray.map mkIdent
+          `(reifiedOpenDecl| (@$(mkIdent ns) hiding $except*))
+    reifiedOpens := reified :: reifiedOpens
+  if reifiedOpens.isEmpty then return none else
+    `(reifiedOpenStx| open $reifiedOpens.toArray*)
+
+/-- Activates scopes associated with an `OpenDecl` as `open` would when creating that `OpenDecl`. -/
+def _root_.Lean.OpenDecl.activate {m : Type → Type}
+    [Monad m] [MonadEnv m] [MonadLiftT (ST IO.RealWorld) m] :
+    OpenDecl → m Unit
+  | .simple ns _  => activateScoped ns
+  | .explicit _ _ => pure () -- `open` never activates scopes when creating these
+
+/-- Turns reified syntax for a single `open` such as `@foo.bar` into an `OpenDecl`, activating
+scopes as `open` would if `activateScopes := true` (the default). -/
+def unreifyOpenDecl (openDecl : TSyntax ``reifiedOpenDecl) (activateScopes := true) :
+    CommandElabM OpenDecl :=
+  match openDecl with
+  | `(reifiedOpenDecl| @$id) => do
+    if activateScopes then activateScoped id.getId
+    return .simple id.getId []
+  | `(reifiedOpenDecl| (@$id hiding $hidden*)) => do
+    if activateScopes then activateScoped id.getId
+    return .simple id.getId <| (hidden.map (·.getId)).toList
+  | `(reifiedOpenDecl| ($id → $decl)) =>
+    -- `open` never activates scopes in these cases. See `elabOpenDecl`.
+    return .explicit id.getId decl.getId
+  | _ => throwUnsupportedSyntax
+
+/-- Turns reified syntax for `open @id ...` such as `open @foo.bar ...` into `OpenDecl`s
+(activating scopes as appropriate) and modifies the current scope to use exactly those open
+declarations (erasing whatever open declarations were present before). Note that the resulting
+`openDecls` do not depend on the original `openDecls` or original scope in any way. -/
+def unreifyOpenDecls (openDeclsStx : TSyntaxArray ``reifiedOpenDecl) : CommandElabM Unit := do
+  let openDecls ← openDeclsStx.foldlM (init := []) fun openDecls openDeclStx =>
+    return (← unreifyOpenDecl openDeclStx) :: openDecls
+  modifyScope fun s => { s with openDecls }
+
+section openScoped
+
+end openScoped
+
+end openDecls
+
+section universes
+
+
+
+end universes
+
+def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
+  let sectionHeader ← (← getScope).toSectionHeader.toSyntax
+  let universes ← getUniverseStx
+  let namespaceStx ← getCurrNamespaceSyntax
+  let opens ← reifyOpenDecls (← getScope).openDecls
+
+  let variables ← (← getVariableSyntax?).mapM fun vars => do
+    `(reifiedVarStx| $vars $(← getIncludeSyntax?)? $(← getOmitSyntax?)?)
+
+  let extraScopedNames ← extraScoped
+  let extraScoped ← if extraScopedNames.isEmpty then pure none else
+    let extraScoped ← extraScopedNames.toArray.mapM fun n =>
+      `(reifiedSimpleOpenIdent| @$(mkIdent n))
+    some <$> `(reifiedOpenScopedStx| open scoped $extraScoped*)
+
+  let newOpts ← getNewOptions -- TODO: actually, the base scope may be polluted, right? So maybe just list all of them.
+  let setOptions ← do
+    let mut kvs := #[]
+    for (key, val) in newOpts do
+      let some val := val.toSetOptionValueSyntax? | continue
+      kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $(⟨val⟩))
+    if kvs.isEmpty then pure none else some <$> `(reifiedSetOptionsStx| set_options $kvs,*)
+
+  `(scopeStx| $sectionHeader scope
+    $[$universes]?
+    $[$namespaceStx]?
+    $[$opens]?
+    $[$extraScoped]?
+    $[$setOptions]?
+    $[$variables]?) -- TODO: technically the variable parsing could change if a scope is opened earlier. This is probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a parser for `scope` that opens the named scopes!
+
+    -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -46,7 +46,7 @@ syntax reifiedSetOptionsStx := withPosition("set_options " ppIndent(reifiedOptio
 /--
 A scope specification of the form
 ```
-(@[expose])? (public)? (noncomputable)? (section)? scope
+(@[expose])? (public)? (noncomputable)? (section)? (scope)?
   (universe ...)?
   (namespace ...)?
   (open @id₁ @id₂ ...)?
@@ -56,13 +56,16 @@ A scope specification of the form
   (include ...)?
   (omit ...)?
 ```
-Notice the differences from typical scope syntax.
+Notice the differences from typical scope-related syntax, especially in the usage of `@` in
+identifiers for `open` and the use of `set_options` instead of `set_option`.
 
-Note also that this is intended to reify semantic and instantaneous aspects of a given scope,
-and not the entire scope stack. This means that `section`s and local scopes are not
-accounted for here.
+Note also that this is intended to reify semantic and instantaneous aspects of a given scope for
+transportation purposes, and is *not* intended to reify the entire scope stack. This means that
+the effects of `section`s and local scopes are not accounted for here.
+
+This syntax is not a command itself, but is used within other commands, such as `#scope`.
 -/
-syntax scopeStx := Parser.Command.sectionHeader -- &"scope"
+syntax scopeStx := Parser.Command.sectionHeader &"scope"
   (ppLine colGt Parser.Command.universe)?
   (ppLine colGt Parser.Command.namespace)?
   atomic((ppLine colGt reifiedOpenStx)?)
@@ -370,13 +373,13 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
 
   let setOptions ← reifySetOptions? (← getUserOptions)
 
-  `(scopeStx| $sectionHeader -- scope
+  `(scopeStx| $sectionHeader scope
     $[$universes]?
     $[$namespaceStx]?
     $[$opens]?
     $[$extraScoped]?
     $[$setOptions]?
-    $[$variables]?) -- TODO: technically the variable parsing could change if a scope is opened earlier. This is probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a parser for `scope` that opens the named scopes!
+    $[$variables]?) -- TODO: technically the variable parsing could change if a scope is opened earlier. This is probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a more detailed parser for `scopeStx` that opens the named scopes!
 
     -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -241,7 +241,7 @@ section universes
 def reifyLevelNames? : CommandElabM (Option (TSyntax ``Parser.Command.universe)) := do
   let levelNames ← getLevelNames
   if levelNames.isEmpty then pure none else
-    some <$> `(Parser.Command.universe| universe $(levelNames.toArray.map mkIdent)*)
+    some <$> `(Parser.Command.universe| universe $(levelNames.toArray.reverse.map mkIdent)*)
 
 end universes
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
 module
 
 public meta import Mathlib.Lean.Elab.Options

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -139,23 +139,22 @@ end header
 
 section openDecls
 
-/-- Lean may duplicate open declarations occasionally due to leanprover/lean4#13353. This function
-deduplicates exactly-duplicated `OpenDecl`s by removing the later occurrences. -/
-@[inline] private def deduplicateOpenDecls (openDecls : List OpenDecl) : List OpenDecl :=
-  /- Note that the innermost openDecls come first and affect name resolution first due to
-  `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in
-  openDecls) -/
-  -- TODO: find something more efficient, which means basically just about anything else.
-  openDecls.reverse.eraseDups.reverse
-
 /-- Convert `OpenDecl`s into reified `open @id₁ @id₂ ...` syntax. -/
 def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) (dedup := true) :
     m (Option (TSyntax ``reifiedOpenStx)) := do
-  let openDecls := if dedup then deduplicateOpenDecls openDecls else openDecls
+  if openDecls.isEmpty then return none
+  /- The outermost elements of `openDecls` are the most recent, and should come last in an `open` -/
+  let revOpenDecls := openDecls.reverse
+  /- Lean may duplicate open declarations occasionally due to leanprover/lean4#13353. This function
+  deduplicates exactly-duplicated `OpenDecl`s by removing the later occurrences.
+
+  The innermost elements of `openDecls` actually affect name resolution first, so we want to keep
+  the first instances of duplicate elements in `revOpenDecls`, not in `openDecls`. -/
+  -- TODO: consider a better approach than `eraseDups` if possible
+  let revOpenDecls := if dedup then revOpenDecls.eraseDups else revOpenDecls
   -- Note that the last element of `openDecls` becomes the first element of `reifiedOpens`,
   -- since the outermost `OpenDecl` is the most recent.
-  let mut reifiedOpens := []
-  for openDecl in openDecls do
+  let reifiedOpens ← revOpenDecls.toArray.mapM fun openDecl => do
     let reified ← match openDecl with
       | .explicit id declName =>
         `(reifiedOpenDecl| ($(mkIdent id) → @$(mkIdent declName)))
@@ -163,9 +162,7 @@ def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) 
         if except.isEmpty then `(reifiedOpenDecl| @$(mkIdent ns)) else
           let except := except.toArray.map mkIdent
           `(reifiedOpenDecl| (@$(mkIdent ns) hiding $except*))
-    reifiedOpens := reified :: reifiedOpens
-  if reifiedOpens.isEmpty then return none else
-    `(reifiedOpenStx| open $reifiedOpens.toArray*)
+  `(reifiedOpenStx| open $reifiedOpens*)
 
 section openScoped
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -213,16 +213,19 @@ end openDecls
 
 section setOption
 
-/- Note: Ideally we would like to not include all the lake build options. But these are commingled
-with any `set_option`s in the base scope, so without doing something like "checking the lakefile"
-or "recording the options at the top of the file via linter" we can't distinguish between options
-set by lake and options set in the file. -/
-/-- Erases the options set by Lean itself, and `Elab.async` if it has not been changed by the user.
-However, still includes the options set in the lakefile. -/
+/- Note: lakefile options are commingled in the base scope with options set in the module, so it is
+not easy to split them up. Further, including the lakefile options is arguably better for
+transportation between libraries. -/
+/-- Gets the current options after erasing the options set by Lean itself, including `Elab.async`
+if it has not been changed by the user from the default of `true`. Note that this includes the
+options set in the lakefile.
+
+The result should be the same in both the language server and `lake build`. -/
 def getUserOptions : CommandElabM Options := do
   let opts := (← getOptions).erase `internal.cmdlineSnapshots |>.erase `Elab.inServer
   if opts.get? `Elab.async |>.isEqSome true then return opts.erase `Elab.async else return opts
 
+/-- Reifies the given `Options` into `set_options ...` syntax if there are any. -/
 def reifySetOptions? (opts : Options) : CommandElabM (Option (TSyntax ``reifiedSetOptionsStx)) := do
   let mut kvs := #[]
   for (key, val) in opts do
@@ -234,8 +237,9 @@ end setOption
 
 section universes
 
-def reifyUniverses? : CommandElabM (Option <| TSyntax ``Parser.Command.universe) := do
-  let levelNames := (← getScope).levelNames
+/-- Reifies the current level names into `universe ...` syntax if there are any. -/
+def reifyLevelNames? : CommandElabM (Option (TSyntax ``Parser.Command.universe)) := do
+  let levelNames ← getLevelNames
   if levelNames.isEmpty then pure none else
     some <$> `(Parser.Command.universe| universe $(levelNames.toArray.map mkIdent)*)
 
@@ -243,6 +247,7 @@ end universes
 
 section namespaces
 
+/-- Reifies the current namespace into `namespace ...` syntax if not in the root namespace. -/
 def reifyCurrNamespace? : CommandElabM (Option (TSyntax ``Parser.Command.namespace)) := do
   let ns ← getCurrNamespace
   if ns.isAnonymous then pure none else `(Parser.Command.namespace| namespace $(mkIdent ns))
@@ -251,17 +256,20 @@ end namespaces
 
 section variables
 
+/-- Reifies current section variables into `variable ...` syntax if there are any. -/
 def reifyVariables? : CommandElabM (Option (TSyntax ``Parser.Command.variable)) := do
   let { varDecls .. } ← getScope
   if varDecls.isEmpty then return none
   `(Parser.Command.variable| variable $varDecls*)
 
+/-- Reifies current `include`d section variables into `include ...` syntax if there are any. -/
 def reifyInclude? : CommandElabM (Option (TSyntax ``Parser.Command.include)) := do
   let { includedVars .. } ← getScope
   if includedVars.isEmpty then return none
   -- TODO: the `Name`s are `varUIDs` with hygiene, but should we strip that in making the idents?
   `(Parser.Command.include| include $(includedVars.toArray.map mkIdent)*)
 
+/-- Reifies current `omit`ted section variables into `omit ...` syntax if there are any. -/
 def reifyOmit? : CommandElabM (Option (TSyntax ``Parser.Command.omit)) := do
   let { omittedVars, varUIds, varDecls .. } ← getScope
   if omittedVars.isEmpty then return none
@@ -280,28 +288,21 @@ def reifyOmit? : CommandElabM (Option (TSyntax ``Parser.Command.omit)) := do
 
 end variables
 
+/-- Reifies aspects of the current scope into a `scopeStx` scope specification. See `scopeStx`. -/
 def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
-  let sectionHeader ← (← getScope).toSectionHeader.toSyntax
-  let universes ← reifyUniverses?
+  let sectionHeader ← reifySectionHeader (← getScope)
+  let universes ← reifyLevelNames?
   let namespaceStx ← reifyCurrNamespace?
-  let opens ← reifyOpenDecls (← getScope).openDecls
-
+  let opens ← reifyOpenDecls (← getOpenDecls)
+  let extraOpenScoped ← reifyExtraOpenScopes
+  let setOptions ← reifySetOptions? (← getUserOptions)
   let variables ← (← reifyVariables?).mapM fun vars => do
     `(reifiedVarStx| $vars $(← reifyInclude?)? $(← reifyOmit?)?)
-
-  let extraScopedNames ← extraScoped
-  let extraScoped ← if extraScopedNames.isEmpty then pure none else
-    let extraScoped ← extraScopedNames.toArray.mapM fun n =>
-      `(reifiedSimpleOpenIdent| @$(mkIdent n))
-    some <$> `(reifiedOpenScopedStx| open scoped $extraScoped*)
-
-  let setOptions ← reifySetOptions? (← getUserOptions)
-
   `(scopeStx| $sectionHeader scope
     $[$universes]?
     $[$namespaceStx]?
     $[$opens]?
-    $[$extraScoped]?
+    $[$extraOpenScoped]?
     $[$setOptions]?
     $[$variables]?)
     /- TODO: technically the variable parsing could change if a scope is opened earlier. This is

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -2,6 +2,7 @@ module
 
 public import Lean
 public meta import Mathlib.Lean.Elab.Options
+public meta import Mathlib.Lean.Name
 public meta import Lean.Elab.BuiltinCommand
 public meta import Lean.PrettyPrinter.Delaborator
 import Batteries
@@ -217,12 +218,6 @@ def reifyOpenDecls {m} [Monad m] [MonadQuotation m] (openDecls : List OpenDecl) 
     `(reifiedOpenStx| open $reifiedOpens.toArray*)
 
 section openScoped
-
-def _root_.Lean.Name.foldrPrefix {α} (n : Name) (init : α) (f : Name → α → α) :=
-  let val := f n init
-  match n with
-  | .anonymous => val
-  | .str pre _ | .num pre _ => pre.foldrPrefix val f
 
 @[inline] def _root_.Lean.NameSet.minus (current minus : NameSet) : NameSet := Id.run do
   if minus.isEmpty then current else current.filter (!minus.contains ·)

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -260,14 +260,14 @@ section variables
 def reifyVariables? : CommandElabM (Option (TSyntax ``Parser.Command.variable)) := do
   let { varDecls .. } ← getScope
   if varDecls.isEmpty then return none
+  let varDecls := varDecls.map (⟨·.raw.unsetTrailing⟩)
   `(Parser.Command.variable| variable $varDecls*)
 
 /-- Reifies current `include`d section variables into `include ...` syntax if there are any. -/
 def reifyInclude? : CommandElabM (Option (TSyntax ``Parser.Command.include)) := do
   let { includedVars .. } ← getScope
   if includedVars.isEmpty then return none
-  -- TODO: the `Name`s are `varUIDs` with hygiene, but should we strip that in making the idents?
-  `(Parser.Command.include| include $(includedVars.toArray.map mkIdent)*)
+  `(Parser.Command.include| include $(includedVars.toArray.map (mkIdent ·.eraseMacroScopes))*)
 
 /-- Reifies current `omit`ted section variables into `omit ...` syntax if there are any. -/
 def reifyOmit? : CommandElabM (Option (TSyntax ``Parser.Command.omit)) := do
@@ -278,12 +278,10 @@ def reifyOmit? : CommandElabM (Option (TSyntax ``Parser.Command.omit)) := do
     for uid in varUIds, stx in varDecls do
       if uid = var then
         if stx.raw.isOfKind ``Parser.Term.instBinder then
-          omittedIdentOrBinder := omittedIdentOrBinder.push ⟨stx.raw⟩
+          omittedIdentOrBinder := omittedIdentOrBinder.push ⟨stx.raw.unsetTrailing⟩
         else
-          -- TODO: remove scopes?
-          omittedIdentOrBinder := omittedIdentOrBinder.push (mkIdent uid)
+          omittedIdentOrBinder := omittedIdentOrBinder.push (mkIdent uid.eraseMacroScopes)
         break
-  -- TODO: the `Name`s are `varUIDs` with hygiene, but should we strip that in making the idents?
   `(Parser.Command.omit| omit $(omittedIdentOrBinder)*)
 
 end variables

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -28,6 +28,8 @@ public meta section
 
 namespace Mathlib.Tactic.Scope
 
+section parsers
+
 /-! The "inlinable" parsers in this section exist to enable syntax quotations, which help with
 constructing and processing these later. -/
 
@@ -83,9 +85,11 @@ syntax scopeStx := Parser.Command.sectionHeader &"scope"
   (ppLine colGt Parser.Command.universe)?
   (ppLine colGt Parser.Command.namespace)?
   atomic((ppLine colGt reifiedOpenStx)?)
-  (ppLine colGt reifiedOpenScopedStx)? -- TODO: local?
+  (ppLine colGt reifiedOpenScopedStx)?
   (ppLine colGt reifiedSetOptionsStx)?
   (ppLine colGt reifiedVarStx)?
+
+end parsers
 
 section header
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -413,10 +413,3 @@ elab_rules : command
     let stx ← `(command|#scope%$tk $scopeStx')
     liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk (origSpan? := (← getRef)) stx
       (diffGranularity := .word)
-
-#scope
-  public meta
-  namespace Mathlib.Tactic.Scope
-  open @Lean @Lean.Meta @Lean.Elab @Lean.Elab.Command
-  set_options maxSynthPendingDepth 3, linter.style.header true, pp.unicode.fun true, autoImplicit
-    false

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -14,7 +14,8 @@ public meta section
 
 namespace Mathlib.Tactic.Scope
 
--- The "inlinable" parsers in this section exist to enable syntax quotations.
+/-! The "inlinable" parsers in this section exist to enable syntax quotations, which help with
+constructing and processing these later. -/
 
 /-- An unambiguous rendering of the result of `open ns renaming from → to, ...` and
 `open ns (id₁ id₂ ...)`, which both do not record `ns`, but only the mapping from unresolved

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -23,13 +23,16 @@ to be easy to act on with metaprogramming automation. In this sense it is not tr
   full scope specification with the current scope
 -/
 
+/- Note: some declarations are marked `private` despite already living in private sections. These
+should stay private or be carefully considered even if the API becomes public. -/
+
 open Lean Meta Elab Command
 
-public meta section
+meta section
 
 namespace Mathlib.Tactic.Scope
 
-section parsers
+public section parsers
 
 /-! The "inlinable" parsers in this section exist to enable syntax quotations, which help with
 constructing and processing these later. -/

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -326,12 +326,13 @@ syntax "#scope" (ppLine scopeStx)? : command
 elab_rules : command
 | `(#scope%$tk) => do
   let stx ← `(command| #scope%$tk $(← reifyScope))
-  liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk stx
+  -- Note: we use `getRef` to expand the range on which the code action works.
+  liftCoreM <| Meta.Tactic.TryThis.addSuggestion (← getRef) stx
 | `(#scope%$tk $scopeStx) => do
   let scopeStx' ← withRef scopeStx reifyScope
   unless scopeStx.raw.structEq scopeStx' do
     let stx ← `(command| #scope%$tk $scopeStx')
-    liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk (origSpan? := (← getRef)) stx
+    liftCoreM <| Meta.Tactic.TryThis.addSuggestion (← getRef) (origSpan? := (← getRef)) stx
       (diffGranularity := .word)
 
 end Mathlib.Tactic.Scope

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -311,6 +311,18 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
 
     -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.
 
+/--
+`#scope` reifies the current scope into syntax so that it can be transported into another file,
+e.g. along with a following declaration that depends on this scope. (No use of `in` is needed.)
+
+`#scope` will log a try-this suggestion suggesting reified syntax that matches the current scope,
+or else remain silent. If the reified scope syntax no longer matches the current scope, `#scope`
+suggests an updated replacement.
+
+NOTE: `#scope` is currently in development. Soon, `#scope!` and `#scope?` will provide more
+features for (1) replacing the current scope with the recorded scope (2) suggesting new ordinary
+scope syntax to merge the two scopes.
+-/
 syntax "#scope" (ppLine scopeStx)? : command
 
 elab_rules : command

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -8,6 +8,19 @@ import Batteries
 public meta import Mathlib.Lean.Elab.InfoTree
 public meta import Aesop.Util.Basic -- Name.ofComponents...
 
+/-!
+# Scope manipulation tools
+
+This module provides utilities for fully capturing the effectful parts of the current scope (namespaces, open declarations, options, etc.) and transporting it between modules. Specifically, it provides `#scope`, which reifies the semantically-relevant parts of the current scope into portable syntax capturing the current scope that may be moved between files.
+
+This is not intended to capture `section` behavior, nor is it intended to be used for user-friendly visibility into the current scope structure. The reified scope specification is primarily intended to be easy to act on with metaprogramming automation. In this sense it is not trying to replace `#where`.
+
+## TODO
+
+- `#scope! (<scope specification>)` for effecting the given scope specification
+- `#scope? (<scope specification>)` for producing appropriate Lean commands to integrate the given
+  full scope specification with the current scope
+-/
 
 open Lean Meta Elab Command
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -12,9 +12,15 @@ public meta import Aesop.Util.Basic -- Name.ofComponents...
 /-!
 # Scope manipulation tools
 
-This module provides utilities for fully capturing the effectful parts of the current scope (namespaces, open declarations, options, etc.) and transporting it between modules. Specifically, it provides `#scope`, which reifies the semantically-relevant parts of the current scope into portable syntax capturing the current scope that may be moved between files.
+This module provides utilities for fully capturing the effectful parts of the current scope
+(namespaces, open declarations, options, etc.) and transporting it between modules. Specifically,
+it provides `#scope`, which reifies the semantically-relevant parts of the current scope into
+portable syntax capturing the current scope that may be moved between files.
 
-This is not intended to capture `section` behavior, nor is it intended to be used for user-friendly visibility into the current scope structure. The reified scope specification is primarily intended to be easy to act on with metaprogramming automation. In this sense it is not trying to replace `#where`.
+This is not intended to capture `section` behavior, nor is it intended to be used for user-friendly
+visibility into the current scope structure. The reified scope specification is primarily intended
+to be easy to act on with metaprogramming automation. In this sense it is not trying to replace
+`#where`.
 
 ## TODO
 
@@ -46,15 +52,20 @@ syntax reifiedOpenDecl := ppSpace colGt
 only renders fully-resolved namespaces. Surrounded by `()` when `hiding` is present. Uses `→` to
 render the mappings produced by `open ns renaming from → to, ...` and
 `open ns (id₁ id₂ ...)`. -/
-syntax reifiedOpenStx := withPosition(atomic("open" notFollowedBy("scoped")) ppIndent(reifiedOpenDecl*))
+syntax reifiedOpenStx := withPosition(
+  atomic("open" notFollowedBy("scoped")) ppIndent(reifiedOpenDecl*))
 
-/-- Renders the open scopes that are not accounted for by generic `open`s. Prefixes identifiers with `@` to show the fully-resolved name. -/
+/-- Renders the open scopes that are not accounted for by generic `open`s. Prefixes identifiers
+with `@` to show the fully-resolved name. -/
 syntax reifiedOpenScopedStx := withPosition("open " "scoped"
   ppIndent((ppSpace colGt reifiedSimpleOpenIdent)*))
 
 -- Parser of convenience, since we handle these together.
--- TODO: technically this may be influenced by open scopes. It needs to incorporate that in the parser.
-syntax reifiedVarStx := Parser.Command.variable (ppLine Parser.Command.include)? (ppLine Parser.Command.omit)?
+-- TODO: technically this may be influenced by open scopes.
+-- It needs to incorporate that in the parser.
+syntax reifiedVarStx := Parser.Command.variable
+  (ppLine Parser.Command.include)?
+  (ppLine Parser.Command.omit)?
 
 syntax reifiedOptionKeyValue := ppSpace colGt ident ppSpace optionValue
 /-- `set_options key₁ val₁, key₂ val₂, ...` renders the options set in a single line. -/
@@ -194,7 +205,9 @@ section openDecls
 /-- Lean may duplicate open declarations occasionally due to leanprover/lean4#13353. This function
 deduplicates exactly-duplicated `OpenDecl`s by removing the later occurrences. -/
 @[inline] private def deduplicateOpenDecls (openDecls : List OpenDecl) : List OpenDecl :=
-  /- Note that the innermost openDecls come first and affect name resolution first due to `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in openDecls) -/
+  /- Note that the innermost openDecls come first and affect name resolution first due to
+  `eraseDups` affecting resolved ids by first occurrence (corresponding to later occurrences in
+  openDecls) -/
   -- TODO: find something more efficient, which means basically just about anything else.
   openDecls.reverse.eraseDups.reverse
 
@@ -222,7 +235,8 @@ section openScoped
 @[inline] def _root_.Lean.NameSet.minus (current minus : NameSet) : NameSet := Id.run do
   if minus.isEmpty then current else current.filter (!minus.contains ·)
 
-/-- An extension we can trust to always be present, whose active scopes reflect the result of `open`s. -/
+/-- An extension we can trust to always be present, whose active scopes reflect the result of
+`open`s. -/
 @[inline] def scopeTestExt := Parser.parserExtension.ext
 
 def _root_.Lean.Environment.activeScopes (env : Environment) : NameSet :=
@@ -230,14 +244,16 @@ def _root_.Lean.Environment.activeScopes (env : Environment) : NameSet :=
   | s :: _ => s.activeScopes
   | _ => {}
 
-/-- Gets the activated scopes in a (standard) scoped env extension that are *not* implied by the current namespace and open decls. I.e., the extra `open scoped` that exist somewhere. -/
+/-- Gets the activated scopes in a (standard) scoped env extension that are *not* implied by the
+current namespace and open decls. I.e., the extra `open scoped` that exist somewhere. -/
 protected def _root_.Lean.Environment.extraScoped (env : Environment)
     (currNamespace : Name) (openDecls : List OpenDecl) : NameSet := Id.run do
   -- Note that each `open` that adds `.simple` activates the corresponding scopes.
   let impliedScopes : NameSet := openDecls.foldl (init := {}) fun
     | acc, .simple ns _ => if ns.isAnonymous then acc else acc.insert ns
     | acc, _ => acc
-  -- When `namespace ns` happened (or whatever sequence of `namespace`s), `addScopes` traversed all prefixes of `ns`. So we expect those to be there.
+  -- When `namespace ns` happened (or whatever sequence of `namespace`s), `addScopes` traversed all
+  -- prefixes of `ns`. So we expect those to be there.
   -- Note that `addScope` in `elabNamespace` does not add to the open decls, so this is necessary.
   let impliedScopes := currNamespace.foldrPrefix (init := impliedScopes) fun n acc =>
     if n.isAnonymous then acc else acc.insert n
@@ -344,7 +360,10 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
     $[$opens]?
     $[$extraScoped]?
     $[$setOptions]?
-    $[$variables]?) -- TODO: technically the variable parsing could change if a scope is opened earlier. This is probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a more detailed parser for `scopeStx` that opens the named scopes!
+    $[$variables]?)
+    /- TODO: technically the variable parsing could change if a scope is opened earlier. This is
+    probably important...it'll mean (1) detecting if any variable syntax is scoped (2) writing a
+    more detailed parser for `scopeStx` that opens the named scopes! -/
 
     -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.
 
@@ -360,3 +379,5 @@ elab_rules : command
     let stx ← `(command|#scope%$tk $scopeStx')
     liftCoreM <| Meta.Tactic.TryThis.addSuggestion tk (origSpan? := (← getRef)) stx
       (diffGranularity := .word)
+
+end Mathlib.Tactic.Scope

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -107,96 +107,23 @@ section header
 
 open Parser.Command
 
-/--
-Encodes scope section headers: `(@[expose])? (public)? (noncomputable)? (meta)?`.
--/
-structure SectionHeader where
-  /-- Whether the scope uses `@[expose]`. -/
-  expose : Bool := false -- TODO: `Option Syntax`?
-  /-- Whether the scope uses `public`. -/
-  isPublic : Bool := false
-  /-- Whether the scope uses `noncomputable`. -/
-  isNoncomputable : Bool := false
-  /-- Whether the scope uses `meta`. -/
-  isMeta : Bool := false
-deriving BEq, Inhabited, Repr
-
-/-- Encodes scope section headers, and associates syntax position information to them. -/
-structure SectionHeaderRef where
-  /-- The full ref of the whole section header. -/
-  ref : Syntax := .missing
-  /-- The token `expose`. Does not include brackets. -/
-  exposeTk : Option Syntax := none
-  /-- The token `public`. -/
-  publicTk : Option Syntax := none
-  /-- The token `noncomputable`. -/
-  noncomputableTk : Option Syntax := none
-  /-- The token `meta`. -/
-  metaTk : Option Syntax := none
-
-/-- Converts syntax representing a section header ref to a `SectionHeader`. -/
-@[inline] def SectionHeaderRef.toSectionHeader : SectionHeaderRef → SectionHeader
-  | { exposeTk, publicTk, noncomputableTk, metaTk, .. } => {
-    expose := exposeTk.isSome
-    isPublic := publicTk.isSome
-    isNoncomputable := noncomputableTk.isSome
-    isMeta := metaTk.isSome
-  }
-
-/-- Recreates `(@[expose])? (public)? (noncomputable)? (meta)?` syntax from the given
-`SectionHeaderRef`. -/
-def SectionHeaderRef.toSyntax {m} [Monad m] [MonadQuotation m] :
-    SectionHeaderRef → m (TSyntax ``sectionHeader)
-  | { exposeTk, publicTk, noncomputableTk, metaTk, ref } => withRef ref `(sectionHeader|
-      $[@[expose%$exposeTk]]?
-      $[public%$publicTk]?
-      $[noncomputable%$noncomputableTk]?
-      $[meta%$metaTk]?)
-
-/-- Organizes `sectionHeader` syntax into a `SectionHeaderRef`. -/
-def SectionHeaderRef.ofSyntax? : TSyntax ``sectionHeader → Option SectionHeaderRef
-  | ref@`(sectionHeader|
-      $[@[expose%$exposeTk]]?
-      $[public%$publicTk]?
-      $[noncomputable%$noncomputableTk]?
-      $[meta%$metaTk]?) =>
-    some { ref, exposeTk, publicTk, noncomputableTk, metaTk }
-  | _ => none
-
-/-- Creates `(@[expose])? (public)? (noncomputable)? (meta)?` syntax from the given
-`SectionHeader`. Uses the current ref for position information on each token. -/
-def SectionHeader.toSyntax {m} [Monad m] [MonadQuotation m] :
-    SectionHeader → m (TSyntax ``sectionHeader)
-  | { expose, isPublic, isNoncomputable, isMeta } => do
+/-- Isolates the part of a `Scope` that contains `SectionHeader` information. -/
+@[inline] def reifySectionHeader {m} [Monad m] [MonadQuotation m] :
+    Scope → m (TSyntax ``sectionHeader)
+  | { isPublic, isMeta, isNoncomputable, attrs .. } => do
+    -- Currently `attrs` holds at most `expose`, but we match for future-proofing.
+    let exposeTk? := attrs.find? fun stx => match stx.raw with
+      | `(Parser.Term.attrInstance| expose) => true
+      | _ => false
     -- This is a hack to exploit antiquotations. `$[$foo%$tk]?` yields `foo` iff `tk.isSome`.
     let r ← getRef
     letI toDummyOptional? (b : Bool) : Option Syntax :=
       if b then some r else none
     let pubTk    := toDummyOptional? isPublic
     let metaTk   := toDummyOptional? isMeta
-    let exposeTk := toDummyOptional? expose
     let ncTk     := toDummyOptional? isNoncomputable
     `(sectionHeader|
-      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?)
-
-/-- Extracts a `SectionHeader` structure from `(@[expose])? (public)? (noncomputable)? (meta)?`
-syntax. -/
-@[inline] def SectionHeader.ofSyntax? : TSyntax ``sectionHeader → Option SectionHeader
-  | `(sectionHeader|
-      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?) =>
-    some {
-      expose := exposeTk.isSome
-      isPublic := pubTk.isSome
-      isNoncomputable := ncTk.isSome
-      isMeta := metaTk.isSome
-    }
-  | _ => none
-
-/-- Isolates the part of a `Scope` that contains `SectionHeader` information. -/
-@[inline] def _root_.Lean.Elab.Command.Scope.toSectionHeader : Scope → SectionHeader
-  | { isPublic, isMeta, isNoncomputable, attrs .. } =>
-    -- Currently, `attrs` only ever holds `@[expose]`.
-    { isPublic, isMeta, isNoncomputable, expose := !attrs.isEmpty }
+      $[@[expose%$exposeTk?]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?)
 
 end header
 

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -1,6 +1,7 @@
 module
 
 public import Lean
+public meta import Mathlib.Lean.Elab.Options
 public meta import Lean.Elab.BuiltinCommand
 public meta import Lean.PrettyPrinter.Delaborator
 import Batteries
@@ -303,7 +304,7 @@ def reifySetOptions? (opts : Options) : CommandElabM (Option (TSyntax ``reifiedS
   let mut kvs := #[]
   for (key, val) in opts do
     let some val := val.toSetOptionValueSyntax? | continue
-    kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $(⟨val⟩))
+    kvs := kvs.push <|← `(reifiedOptionKeyValue| $(mkIdent key) $val)
   if kvs.isEmpty then pure none else some <$> `(reifiedSetOptionsStx| set_options $kvs,*)
 
 end setOption

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -311,6 +311,8 @@ def reifyScope : CommandElabM (TSyntax ``scopeStx) := do
 
     -- We also could account for `open (scoped) ... in variable` but it would have to be ad-hoc.
 
+public section
+
 /--
 `#scope` reifies the current scope into syntax so that it can be transported into another file,
 e.g. along with a following declaration that depends on this scope. (No use of `in` is needed.)
@@ -336,5 +338,7 @@ elab_rules : command
     let stx ← `(command| #scope%$tk $scopeStx')
     liftCoreM <| Meta.Tactic.TryThis.addSuggestion (← getRef) (origSpan? := (← getRef)) stx
       (diffGranularity := .word)
+
+end
 
 end Mathlib.Tactic.Scope

--- a/Mathlib/Util/Scope.lean
+++ b/Mathlib/Util/Scope.lean
@@ -186,22 +186,6 @@ syntax. -/
     -- Currently, `attrs` only ever holds `@[expose]`.
     { isPublic, isMeta, isNoncomputable, expose := !attrs.isEmpty }
 
-/-- Applies a `sectionHeader` syntax of the form `(@[expose])? (public)? (noncomputable)? (meta)?`
-to the current scope, overwriting the values (rather than merging them). For instance, if `public`
-is absent, the resulting scope now has `isPublic := false`, even if it was `true` before. -/
-def unreifySectionHeaderStx : TSyntax ``Parser.Command.sectionHeader → CommandElabM Unit
-  | `(Parser.Command.sectionHeader|
-      $[@[expose%$exposeTk]]? $[public%$pubTk]? $[noncomputable%$ncTk]? $[meta%$metaTk]?) => do
-      let isPublic := pubTk.isSome
-      let isMeta := metaTk.isSome
-      -- `sectionHeader` parses `expose` directly, not as an `attrInstance`.
-      let attrs : List (TSyntax ``Parser.Term.attrInstance) ←
-        if let some exposeTk := exposeTk then
-          pure [← withRef exposeTk `(Parser.Term.attrInstance| expose)] else pure []
-      let isNoncomputable := ncTk.isSome
-      modifyScope fun s => { s with isPublic, isMeta, isNoncomputable, attrs }
-  | _ => throwUnsupportedSyntax
-
 end header
 
 section openDecls

--- a/MathlibTest/Scope.lean
+++ b/MathlibTest/Scope.lean
@@ -1,0 +1,60 @@
+module
+
+import Mathlib.Util.Scope
+
+#scope
+  scope
+
+set_option pp.mvars.anonymous false
+
+set_option pp.mvars.delayed false
+
+public meta section
+
+#scope
+  public meta scope
+  set_options pp.mvars.anonymous false, pp.mvars.delayed false
+
+/--
+info: Try this:
+  #scope
+    @̵[̵e̵x̵p̵o̵s̵e̵]̵ ̵public m̲e̲t̲a̲ ̲scope
+    set_options p̵p̵.̵u̵n̵i̵c̵o̵d̵e̵p̲p̲.̲m̲v̲a̲r̲s̲.̲a̲n̲o̲n̲y̲m̲o̲u̲s̲ ̲f̲a̲l̲s̲e̲,̲ ̲p̲p̲.̲m̲v̲a̲r̲s̲.̲d̲e̲l̲a̲y̲e̲d̲ false
+-/
+#guard_msgs in
+#scope
+  @[expose] public scope
+  set_options pp.unicode false
+
+universe u v w
+
+namespace Foo
+namespace Bar
+
+@[expose] noncomputable section
+
+section
+
+open Bool
+
+open scoped Nat
+
+open Lean Elab Parser Command
+
+/- Ignores whitespace: -/
+variable (x : Nat := by exact (Nat.add /- hmm -/ 0 0)) (y : Nat) [Nonempty False] -- some comment
+
+include x
+
+omit y [Nonempty False] -- other comment
+
+#scope
+  @[expose] public noncomputable meta scope
+  universe u v w
+  namespace Foo.Bar
+  open @Bool @Lean @Lean.Elab @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
+  open scoped @Nat
+  set_options pp.mvars.anonymous false, pp.mvars.delayed false
+  variable (x : Nat := by exact (Nat.add 0 0)) (y : Nat) [Nonempty False]
+  include x
+  omit y [Nonempty False]

--- a/MathlibTest/Scope.lean
+++ b/MathlibTest/Scope.lean
@@ -33,6 +33,15 @@ namespace Bar
 
 @[expose] noncomputable section
 
+open scoped List
+
+#scope
+  @[expose] public noncomputable meta scope
+  universe u v w
+  namespace Foo.Bar
+  open scoped @List
+  set_options pp.mvars.anonymous false, pp.mvars.delayed false
+
 section
 
 open Bool
@@ -40,6 +49,10 @@ open Bool
 open scoped Nat
 
 open Lean Elab Parser Command
+
+open Array renaming foldl → foldLeft
+
+open Array hiding foldr
 
 /- Ignores whitespace: -/
 variable (x : Nat := by exact (Nat.add /- hmm -/ 0 0)) (y : Nat) [Nonempty False] -- some comment
@@ -52,8 +65,9 @@ omit y [Nonempty False] -- other comment
   @[expose] public noncomputable meta scope
   universe u v w
   namespace Foo.Bar
-  open @Bool @Lean @Lean.Elab @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
-  open scoped @Nat
+  open @Bool @Lean @Lean.Elab @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command (foldLeft →
+    Array.foldl) (@Array hiding foldr)
+  open scoped @List @Nat
   set_options pp.mvars.anonymous false, pp.mvars.delayed false
   variable (x : Nat := by exact (Nat.add 0 0)) (y : Nat) [Nonempty False]
   include x

--- a/MathlibTest/Scope.lean
+++ b/MathlibTest/Scope.lean
@@ -58,3 +58,30 @@ omit y [Nonempty False] -- other comment
   variable (x : Nat := by exact (Nat.add 0 0)) (y : Nat) [Nonempty False]
   include x
   omit y [Nonempty False]
+
+/- Note: depending on your font, the `#guard_msgs` rendering may actually look slightly wrong here,
+with underlines extending past the end of what is visible as colored according to the "added" part
+of the diff in the infoview. This is due to issues with using combining marks on spaces. -/
+/--
+info: Try this:
+  #scope
+    @̲[̲e̲x̲p̲o̲s̲e̲]̲ ̲public noncomputable m̲e̲t̲a̲ ̲scope
+    universe u v̲ ̲w
+    namespace B̵a̵z̵F̲o̲o̲.̲B̲a̲r̲
+    open @Bool @Lean @̲L̲e̲a̲n̲.̲E̲l̲a̲b̲ ̲@Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
+    open scoped @Nat
+    set_options pp.mvars.anonymous f̲a̲l̲s̲e̲,̲ ̲p̲p̲.̲m̲v̲a̲r̲s̲.̲d̲e̲l̲a̲y̲e̲d̲ ̲false
+    variable (x : Nat := by exact (Nat.add 0 0)) (̲y̲ ̲:̲ ̲N̲a̲t̲)̲ ̲[Nonempty False]
+    o̵m̵i̵t̵ ̵y̵i̲n̲c̲l̲u̲d̲e̲ ̲x̲
+  ̲ ̲ ̲o̲m̲i̲t̲ ̲y̲ ̲[̲N̲o̲n̲e̲m̲p̲t̲y̲ ̲F̲a̲l̲s̲e̲]̲
+-/
+#guard_msgs in
+#scope
+  public noncomputable scope
+  universe u w
+  namespace Baz
+  open @Bool @Lean @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
+  open scoped @Nat
+  set_options pp.mvars.anonymous false
+  variable (x : Nat := by exact (Nat.add 0 0)) [Nonempty False]
+  omit y

--- a/MathlibTest/Scope.lean
+++ b/MathlibTest/Scope.lean
@@ -82,8 +82,9 @@ info: Try this:
     @̲[̲e̲x̲p̲o̲s̲e̲]̲ ̲public noncomputable m̲e̲t̲a̲ ̲scope
     universe u v̲ ̲w
     namespace B̵a̵z̵F̲o̲o̲.̲B̲a̲r̲
-    open @Bool @Lean @̲L̲e̲a̲n̲.̲E̲l̲a̲b̲ ̲@Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
-    open scoped @Nat
+    open @Bool @Lean @̲L̲e̲a̲n̲.̲E̲l̲a̲b̲ ̲@Lean.Parser @Lean.Parser.Command @Lean.Elab.Command (̲f̲o̲l̲d̲L̲e̲f̲t̲ ̲→̲
+  ̲ ̲ ̲ ̲ ̲A̲r̲r̲a̲y̲.̲f̲o̲l̲d̲l̲)̲ ̲(̲@̲A̲r̲r̲a̲y̲ ̲h̲i̲d̲i̲n̲g̲ ̲f̲o̲l̲d̲r̲)̲
+  ̲ ̲ ̲open scoped @̲L̲i̲s̲t̲ ̲@Nat
     set_options pp.mvars.anonymous f̲a̲l̲s̲e̲,̲ ̲p̲p̲.̲m̲v̲a̲r̲s̲.̲d̲e̲l̲a̲y̲e̲d̲ ̲false
     variable (x : Nat := by exact (Nat.add 0 0)) (̲y̲ ̲:̲ ̲N̲a̲t̲)̲ ̲[Nonempty False]
     o̵m̵i̵t̵ ̵y̵i̲n̲c̲l̲u̲d̲e̲ ̲x̲

--- a/MathlibTest/Scope.lean
+++ b/MathlibTest/Scope.lean
@@ -65,8 +65,8 @@ omit y [Nonempty False] -- other comment
   @[expose] public noncomputable meta scope
   universe u v w
   namespace Foo.Bar
-  open @Bool @Lean @Lean.Elab @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command (foldLeft →
-    Array.foldl) (@Array hiding foldr)
+  open @Bool @Lean @Lean.Elab @Lean.Parser @Lean.Parser.Command @Lean.Elab.Command
+    (foldLeft → @Array.foldl) (@Array hiding foldr)
   open scoped @List @Nat
   set_options pp.mvars.anonymous false, pp.mvars.delayed false
   variable (x : Nat := by exact (Nat.add 0 0)) (y : Nat) [Nonempty False]
@@ -83,7 +83,7 @@ info: Try this:
     universe u v̲ ̲w
     namespace B̵a̵z̵F̲o̲o̲.̲B̲a̲r̲
     open @Bool @Lean @̲L̲e̲a̲n̲.̲E̲l̲a̲b̲ ̲@Lean.Parser @Lean.Parser.Command @Lean.Elab.Command (̲f̲o̲l̲d̲L̲e̲f̲t̲ ̲→̲
-  ̲ ̲ ̲ ̲ ̲A̲r̲r̲a̲y̲.̲f̲o̲l̲d̲l̲)̲ ̲(̲@̲A̲r̲r̲a̲y̲ ̲h̲i̲d̲i̲n̲g̲ ̲f̲o̲l̲d̲r̲)̲
+  ̲ ̲ ̲ ̲ ̲@̲A̲r̲r̲a̲y̲.̲f̲o̲l̲d̲l̲)̲ ̲(̲@̲A̲r̲r̲a̲y̲ ̲h̲i̲d̲i̲n̲g̲ ̲f̲o̲l̲d̲r̲)̲
   ̲ ̲ ̲open scoped @̲L̲i̲s̲t̲ ̲@Nat
     set_options pp.mvars.anonymous f̲a̲l̲s̲e̲,̲ ̲p̲p̲.̲m̲v̲a̲r̲s̲.̲d̲e̲l̲a̲y̲e̲d̲ ̲false
     variable (x : Nat := by exact (Nat.add 0 0)) (̲y̲ ̲:̲ ̲N̲a̲t̲)̲ ̲[Nonempty False]


### PR DESCRIPTION
This PR is the first step in creating a toolset of (transient) utilities for assisting with moving declaration commands between files (including sorting out their dependencies, and integrating their needs into the new location).

Capturing the current scope necessary for the command is the first task, and to that end this PR contributes the command `#scope`, which reifies the current scope into portable syntax. `#scope` by itself produces a try-this suggestion placing a scope specification after `#scope`, of the following form:
```
#scope
  (@[expose])? (public)? (noncomputable)? (section)? scope
  (universe ...)?
  (namespace ...)?
  (open @id₁ @id₂ ...)?
  (open scoped @id₁ @id₂ ...)?
  (set_options key₁ val₁, key₂ val₂ ...)?
  (variable ...)?
  (include ...)?
  (omit ...)?
```
This is intended to fully capture the "semantic" aspects of the current scope, but not the full scope stack (and so e.g. disregards `section`s). Likewise this slightly-unusual syntax (e.g. `open @Foo` instead of `open Foo`) is intended to act as a portable record of the open declaration which can be acted on by automation, and to discourage interpretation as a "normal" `open` statement.

By itself, this is only a slightly odd `#where`. Future PRs (e.g. #38900) will build on this in order to provide a suite of tools for transporting scopes between files and managing them once there, making it easier to move declarations.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
