### PR TITLE
[Merged by Bors] - feat(Data/Finsupp): filtering a single element

### DIFF
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -295,7 +295,7 @@ theorem filter_apply_pos [∀ i, Zero (β i)] {p : ι → Prop} [DecidablePred p
 theorem filter_apply_neg [∀ i, Zero (β i)] {p : ι → Prop} [DecidablePred p] (f : Π₀ i, β i) {i : ι}
     (h : ¬p i) : f.filter p i = 0 := by grind
 
-theorem filter_pos_add_filter_neg [∀ i, AddZeroClass (β i)] (f : Π₀ i, β i) (p : ι → Prop)
+@[simp] theorem filter_add_filter_not [∀ i, AddZeroClass (β i)] (f : Π₀ i, β i) (p : ι → Prop)
     [DecidablePred p] : (f.filter p + f.filter fun i => ¬p i) = f :=
   ext fun i => by
     simp only [add_apply, filter_apply]; split_ifs <;> simp only [add_zero, zero_add]

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -300,6 +300,8 @@ theorem filter_apply_neg [∀ i, Zero (β i)] {p : ι → Prop} [DecidablePred p
   ext fun i => by
     simp only [add_apply, filter_apply]; split_ifs <;> simp only [add_zero, zero_add]
 
+@[deprecated (since := "2026-05-04")] alias filter_pos_add_filter_neg := filter_add_filter_not
+
 @[simp]
 theorem filter_zero [∀ i, Zero (β i)] (p : ι → Prop) [DecidablePred p] :
     (0 : Π₀ i, β i).filter p = 0 := by

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -534,6 +534,17 @@ theorem equivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : β i) :
     (@DFinsupp.equivFunOnFintype ι β _ _).symm (Pi.single i m) = DFinsupp.single i m := by
   simp only [← single_eq_pi_single, equivFunOnFintype_symm_coe]
 
+@[simp] lemma filter_eq (f : Π₀ i, β i) (i : ι) : f.filter (i = ·) = single i (f i) := by
+  ext
+  rw [filter_apply, single_apply]
+  split
+  · subst i
+    simp
+  · simp
+
+@[simp] lemma filter_eq' (f : Π₀ i, β i) (i : ι) : f.filter (· = i) = single i (f i) := by
+  simp [eq_comm]
+
 section SingleAndZipWith
 
 variable [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -641,6 +641,12 @@ def filter (p : α → Prop) [DecidablePred p] (f : α →₀ M) : α →₀ M w
 
 theorem filter_apply (a : α) : f.filter p a = if p a then f a else 0 := rfl
 
+@[simp] lemma filter_eq [DecidableEq α] (f : α →₀ M) (a : α) :
+    f.filter (a = ·) = single a (f a) := by ext; rw [filter_apply, single_apply]; congr!; simp_all
+
+@[simp] lemma filter_eq' [DecidableEq α] (f : α →₀ M) (a : α) :
+    f.filter (· = a) = single a (f a) := by simp [eq_comm]
+
 theorem filter_eq_indicator : ⇑(f.filter p) = Set.indicator { x | p x } f := by
   ext
   simp [filter_apply, Set.indicator_apply]
@@ -692,12 +698,14 @@ theorem prod_div_prod_filter [CommGroup G] (g : α → M → G) :
 
 end Zero
 
-theorem filter_pos_add_filter_neg [AddZeroClass M] (f : α →₀ M) (p : α → Prop) [DecidablePred p] :
-    (f.filter p + f.filter fun a => ¬p a) = f :=
-  DFunLike.coe_injective <| by
-    simp only [coe_add, filter_eq_indicator]
-    exact Set.indicator_self_add_compl { x | p x } f
+section AddCommMonoid
+variable [AddCommMonoid M]
 
+@[simp]
+lemma filter_add_filter_not (f : α →₀ M) (p : α → Prop) [DecidablePred p] :
+    f.filter p + f.filter (¬ p ·) = f := by ext; simp [filter_apply]; split <;> simp
+
+end AddCommMonoid
 end Filter
 
 /-! ### Declarations about `frange` -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -705,6 +705,8 @@ variable [AddCommMonoid M]
 lemma filter_add_filter_not (f : α →₀ M) (p : α → Prop) [DecidablePred p] :
     f.filter p + f.filter (¬ p ·) = f := by ext; simp [filter_apply]; split <;> simp
 
+@[deprecated (since := "2026-05-04")] alias filter_pos_add_filter_neg := filter_add_filter_not
+
 end AddCommMonoid
 end Filter
 


### PR DESCRIPTION
Also rename `filter_pos_add_filter_neg` to `filter_add_filter_not` to match the `Finset` statement.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
