### PR TITLE
[Merged by Bors] - chore(Tactic): deprecate `substs` and replace it with `subst`

### DIFF
--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -65,13 +65,13 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
             · congr
               ext w
               by_cases h : w = v
-              · substs h
+              · subst h
                 simp_all
               · simp_all
             · congr
               ext w
               by_cases h : w = v
-              · substs h
+              · subst h
                 simp_all
               · simp_all
           · simp only [cond_true, h, ht₁]
@@ -79,13 +79,13 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
             · congr
               ext w
               by_cases h : w = v
-              · substs h
+              · subst h
                 simp_all
               · simp_all
             · congr
               ext w
               by_cases h : w = v
-              · substs h
+              · subst h
                 simp_all
               · simp_all
         · have := ht₃ v

--- a/Mathlib/Algebra/Homology/DifferentialObject.lean
+++ b/Mathlib/Algebra/Homology/DifferentialObject.lean
@@ -88,7 +88,7 @@ def dgoToHomologicalComplex :
         if h : i + b = j then X.d i ≫ X.objEqToHom (show i + (1 : ℤ) • b = j by simp [h]) else 0
       shape := fun i j w => by dsimp at w; convert dif_neg w
       d_comp_d' := fun i j k hij hjk => by
-        dsimp at hij hjk; substs hij hjk
+        dsimp at hij hjk; subst hij hjk
         simp [objEqToHom_d_assoc] }
   map {X Y} f :=
     { f := f.f

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -644,7 +644,7 @@ abbrev of (X : α → V) (d : ∀ n, X (n + 1) ⟶ X n) (sq : ∀ n, d (n + 1) �
     shape := fun i j w => by simp [of.d, (Ne.symm w)]
     d_comp_d' := fun i j k hij hjk => by
       dsimp [of.d] at hij hjk ⊢
-      substs hij hjk
+      subst hij hjk
       simp only [eqToHom_refl, id_comp, dite_eq_ite, ite_true, sq] }
 
 variable (X : α → V) (d : ∀ n, X (n + 1) ⟶ X n) (sq : ∀ n, d (n + 1) ≫ d n = 0)
@@ -902,7 +902,7 @@ abbrev of (X : α → V) (d : ∀ n, X n ⟶ X (n + 1)) (sq : ∀ n, d n ≫ d (
     d_comp_d' := fun i j k => by
       dsimp [of.d]
       split_ifs with h h' h'
-      · substs h h'
+      · subst h h'
         simp [sq]
       all_goals simp }
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -256,7 +256,7 @@ lemma comp_assoc {n₁ n₂ n₃ n₁₂ n₂₃ n₁₂₃ : ℤ}
     (h₁₂ : n₁ + n₂ = n₁₂) (h₂₃ : n₂ + n₃ = n₂₃) (h₁₂₃ : n₁ + n₂ + n₃ = n₁₂₃) :
     (z₁.comp z₂ h₁₂).comp z₃ (show n₁₂ + n₃ = n₁₂₃ by rw [← h₁₂, h₁₂₃]) =
       z₁.comp (z₂.comp z₃ h₂₃) (by rw [← h₂₃, ← h₁₂₃, add_assoc]) := by
-  substs h₁₂ h₂₃ h₁₂₃
+  subst h₁₂ h₂₃ h₁₂₃
   ext p q hpq
   rw [comp_v _ _ rfl p (p + n₁ + n₂) q (add_assoc _ _ _).symm (by lia),
     comp_v z₁ z₂ rfl p (p + n₁) (p + n₁ + n₂) (by lia) (by lia),

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -342,7 +342,7 @@ theorem const_ext {f₁ f₂ : M} {g₁ g₂ : R} {U hu₁ hu₂} (h : g₂ • 
   Subtype.ext <| funext fun x ↦ LocalizedModule.mk_eq.mpr (by simp [h, Submonoid.smul_def])
 
 theorem const_congr {f₁ f₂ : M} {g₁ g₂ : R} {U hu} (hf : f₁ = f₂) (hg : g₁ = g₂) :
-    const f₁ g₁ U hu = const f₂ g₂ U (hg ▸ hu) := by substs hf hg; rfl
+    const f₁ g₁ U hu = const f₂ g₂ U (hg ▸ hu) := by subst hf hg; rfl
 
 theorem const_mul_rev (f g : R) (U hu₁ hu₂) : const f g U hu₁ * const g f U hu₂ = 1 := by
   rw [const_mul, const_congr rfl (mul_comm g f), const_self]

--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -179,7 +179,7 @@ def shift {n : ℕ} {Δ : SimplexCategory} (f : ⦋n⦌ ⟶ Δ) : ⦋n + 1⦌ �
             exact h₁ (le_antisymm hi (Fin.zero_le _))
           obtain ⟨j₁, hj₁⟩ := Fin.eq_succ_of_ne_zero h₁
           obtain ⟨j₂, hj₂⟩ := Fin.eq_succ_of_ne_zero h₂
-          substs hj₁ hj₂
+          subst hj₁ hj₂
           simpa only [shiftFun_succ] using f.toOrderHom.monotone (Fin.succ_le_succ_iff.mp hi) }
 
 set_option backward.isDefEq.respectTransparency false in

--- a/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
@@ -176,7 +176,7 @@ theorem fderivWithin_comp₃ {g' : G → G'} {g : F → G} {t : Set F} {u : Set 
     (h3f : f x = y) (hxs : UniqueDiffWithinAt 𝕜 s x) :
     fderivWithin 𝕜 (g' ∘ g ∘ f) s x =
       (fderivWithin 𝕜 g' u y').comp ((fderivWithin 𝕜 g t y).comp (fderivWithin 𝕜 f s x)) := by
-  substs h3g h3f
+  subst h3g h3f
   exact (hg'.hasFDerivWithinAt.comp x (hg.hasFDerivWithinAt.comp x hf.hasFDerivWithinAt h2f) <|
     h2g.comp h2f).fderivWithin hxs
 

--- a/Mathlib/CategoryTheory/Preadditive/Mat.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Mat.lean
@@ -180,14 +180,14 @@ instance hasFiniteBiproducts : HasFiniteBiproducts (Mat_ C) where
               refine if h : x.1 = j then ?_ else 0
               refine if h' : @Eq.ndrec (Fin n) x.1 (fun j => (f j).ι) x.2 _ h = y then ?_ else 0
               apply eqToHom
-              substs h h'
+              subst h h'
               rfl
             -- Notice we were careful not to use `subst` until we had a goal in `Prop`.
             ι := fun j x y => by
               refine if h : y.1 = j then ?_ else 0
               refine if h' : @Eq.ndrec _ y.1 (fun j => (f j).ι) y.2 _ h = x then ?_ else 0
               apply eqToHom
-              substs h h'
+              subst h h'
               rfl
             ι_π := fun j j' => by
               ext x y
@@ -200,7 +200,7 @@ instance hasFiniteBiproducts : HasFiniteBiproducts (Mat_ C) where
               simp only [if_true, Finset.sum_dite_irrel, Finset.mem_univ,
                 Finset.sum_const_zero, Finset.sum_dite_eq']
               split_ifs with h h'
-              · substs h h'
+              · subst h h'
                 simp only [CategoryTheory.eqToHom_refl, CategoryTheory.Mat_.id_apply_self]
               · subst h
                 rw [eqToHom_refl, id_apply_of_ne _ _ _ h']

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -183,7 +183,7 @@ theorem pumping_lemma [Fintype σ] {x : List α} (hx : x ∈ M.accepts)
   rw [Language.mem_mul] at hab
   rcases hab with ⟨a', ha', b', hb', rfl⟩
   rw [Set.mem_singleton_iff] at ha' hc'
-  substs ha' hc'
+  subst ha' hc'
   have h := M.evalFrom_of_pow hb hb'
   rwa [mem_accepts, eval, evalFrom_of_append, evalFrom_of_append, h, hc]
 

--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -222,7 +222,7 @@ protected def sup {f g : Filter α} (F : f.Realizer) (G : g.Realizer) : (f ⊔ g
       inf := fun ⟨a, a'⟩ ⟨b, b'⟩ ↦ (F.F.inf a b, G.F.inf a' b')
       inf_le_left := fun _ _ ↦ union_subset_union (F.F.inf_le_left _ _) (G.F.inf_le_left _ _)
       inf_le_right := fun _ _ ↦ union_subset_union (F.F.inf_le_right _ _) (G.F.inf_le_right _ _) },
-    filter_eq <| Set.ext fun _ ↦ by cases F; cases G; substs f g; simp [CFilter.toFilter]⟩
+    filter_eq <| Set.ext fun _ ↦ by cases F; cases G; subst f g; simp [CFilter.toFilter]⟩
 
 /-- Construct a realizer for the inf of two filters -/
 protected def inf {f g : Filter α} (F : f.Realizer) (G : g.Realizer) : (f ⊓ g).Realizer :=
@@ -233,7 +233,7 @@ protected def inf {f g : Filter α} (F : f.Realizer) (G : g.Realizer) : (f ⊓ g
       inf_le_left := fun _ _ ↦ inter_subset_inter (F.F.inf_le_left _ _) (G.F.inf_le_left _ _)
       inf_le_right := fun _ _ ↦ inter_subset_inter (F.F.inf_le_right _ _) (G.F.inf_le_right _ _) },
     by
-      cases F; cases G; substs f g; simp only [CFilter.toFilter, Prod.exists]; ext
+      cases F; cases G; subst f g; simp only [CFilter.toFilter, Prod.exists]; ext
       constructor
       · rintro ⟨s, t, h⟩
         apply mem_inf_of_inter _ _ h

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -283,7 +283,7 @@ and only if `i = j`. Since they can be defined on a priori not defeq types `Fin 
 theorem orderEmbOfFin_eq_orderEmbOfFin_iff {k l : ℕ} {s : Finset α} {i : Fin k} {j : Fin l}
     {h : s.card = k} {h' : s.card = l} :
     s.orderEmbOfFin h i = s.orderEmbOfFin h' j ↔ (i : ℕ) = (j : ℕ) := by
-  substs k l
+  subst k l
   exact (s.orderEmbOfFin rfl).eq_iff_eq.trans Fin.ext_iff
 
 /-- Given a finset `s` of size at least `k` in a linear order `α`, the map `orderEmbOfCardLe`

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -508,7 +508,7 @@ theorem dlookup_kerase_ne {a a'} {l : List (Sigma β)} (h : a ≠ a') :
   | cons hd tl ih =>
     obtain ⟨ah, bh⟩ := hd
     by_cases h₁ : a = ah <;> by_cases h₂ : a' = ah
-    · substs h₁ h₂
+    · subst h₁ h₂
       cases Ne.irrefl h
     · subst h₁
       simp [h₂]

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -701,7 +701,7 @@ theorem exists_of_mem_join {a : α} : ∀ {S : WSeq (WSeq α)}, a ∈ join S →
       intro ej m <;> simp at ej <;> have := congr_arg Seq.destruct ej <;>
       simp at this; cases this
     case cons.intro b' s =>
-      substs b' ss
+      subst b' ss
       simp? at m ⊢ says simp only [cons_append, mem_cons_iff] at m ⊢
       rcases o with e | IH
       · simp [e]

--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -138,7 +138,7 @@ theorem congr {X Y : PresheafedSpace.{_, _, v} C} (α β : X ⟶ Y)
       eqToHom (show Y.presheaf.stalk (α.base x) = Y.presheaf.stalk (β.base x') by rw [h₁, h₂]) ≫
         β.stalkMap x' := by
   ext
-  substs h₁ h₂
+  subst h₁ h₂
   simp
 
 theorem congr_hom {X Y : PresheafedSpace.{_, _, v} C} (α β : X ⟶ Y) (h : α = β) (x : X) :

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -100,7 +100,7 @@ theorem domCoprod.summand_eq_zero_of_smul_invariant (a : Mᵢ [⋀^ιa]→ₗ[R'
   intro hσ
   obtain ⟨⟨sl, sr⟩, hσ⟩ := QuotientGroup.leftRel_apply.mp (Quotient.exact' hσ)
   rcases hi : σ⁻¹ i with i' | i' <;> rcases hj : σ⁻¹ j with j' | j' <;>
-    rw [Perm.inv_eq_iff_eq] at hi hj <;> substs hi hj
+    rw [Perm.inv_eq_iff_eq] at hi hj <;> subst hi hj
   -- the term pairs with and cancels another term
   case inl.inr => simpa using Equiv.congr_fun hσ (Sum.inl i')
   case inr.inl => simpa using Equiv.congr_fun hσ (Sum.inr i')

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -286,7 +286,7 @@ theorem cast_symm {α β} (h : α = β) : Equiv.cast h.symm = (Equiv.cast h).sym
 
 theorem cast_trans {α β γ} (h : α = β) (h2 : β = γ) :
     Equiv.cast (h.trans h2) = (Equiv.cast h).trans (Equiv.cast h2) :=
-  ext fun x => by substs h h2; rfl
+  ext fun x => by subst h h2; rfl
 
 theorem cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : Equiv.cast h a = b ↔ a ≍ b := by
   subst h; simp

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -265,7 +265,7 @@ def copy (e : PartialEquiv α β) (f : α → β) (hf : ⇑e = f) (g : β → α
 theorem copy_eq (e : PartialEquiv α β) (f : α → β) (hf : ⇑e = f) (g : β → α) (hg : ⇑e.symm = g)
     (s : Set α) (hs : e.source = s) (t : Set β) (ht : e.target = t) :
     e.copy f hf g hg s hs t ht = e := by
-  substs f g s t
+  subst f g s t
   cases e
   rfl
 

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -281,14 +281,14 @@ attribute [simp] upperPolar_extent lowerPolar_intent
 theorem ext (h : c.extent = d.extent) : c = d := by
   obtain ⟨s₁, t₁, rfl, _⟩ := c
   obtain ⟨s₂, t₂, rfl, _⟩ := d
-  substs h
+  subst h
   rfl
 
 /-- See `Concept.ext` for a version using the extent. -/
 theorem ext' (h : c.intent = d.intent) : c = d := by
   obtain ⟨s₁, t₁, _, rfl⟩ := c
   obtain ⟨s₂, t₂, _, rfl⟩ := d
-  substs h
+  subst h
   rfl
 
 theorem extent_injective : Injective (@extent α β r) := fun _ _ => ext

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -109,11 +109,11 @@ theorem isMaximal_inf_right_of_isMaximal_sup {x y : X} (hxz : IsMaximal x (x ⊔
 theorem isMaximal_of_eq_inf (x b : X) {a y : X} (ha : x ⊓ y = a) (hxy : x ≠ y) (hxb : IsMaximal x b)
     (hyb : IsMaximal y b) : IsMaximal a y := by
   have hb : x ⊔ y = b := sup_eq_of_isMaximal hxb hyb hxy
-  substs a b
+  subst a b
   exact isMaximal_inf_right_of_isMaximal_sup hxb hyb
 
 theorem second_iso_of_eq {x y a b : X} (hm : IsMaximal x a) (ha : x ⊔ y = a) (hb : x ⊓ y = b) :
-    Iso (x, a) (b, y) := by substs a b; exact second_iso hm
+    Iso (x, a) (b, y) := by subst a b; exact second_iso hm
 
 theorem IsMaximal.iso_refl {x y : X} (h : IsMaximal x y) : Iso (x, y) (x, y) :=
   second_iso_of_eq h (sup_eq_right.2 (le_of_lt (lt_of_isMaximal h)))

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -633,7 +633,7 @@ theorem opow_def (o₁ o₂ : ONote) : o₁ ^ o₂ = opowAux2 o₂ (split o₁) 
   rfl
 
 theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → split o = (scale 1 o', m)
-  | 0, o', m, _, p => by injection p; substs o' m; rfl
+  | 0, o', m, _, p => by injection p; subst o' m; rfl
   | oadd e n a, o', m, h, p => by
     by_cases e0 : e = 0 <;> simp only [split', e0, ↓reduceIte, Prod.mk.injEq, split] at p ⊢
     · rcases p with ⟨rfl, rfl⟩
@@ -649,11 +649,11 @@ theorem split_eq_scale_split' : ∀ {o o' m} [NF o], split' o = (o', m) → spli
         have := mt repr_inj.1 e0
         exact Ordinal.add_sub_cancel_of_le <| one_le_iff_ne_zero.2 this
       intros
-      substs o' m
+      subst o' m
       simp [scale, this]
 
 theorem nf_repr_split' : ∀ {o o' m} [NF o], split' o = (o', m) → NF o' ∧ repr o = ω * repr o' + m
-  | 0, o', m, _, p => by injection p; substs o' m; simp [NF.zero]
+  | 0, o', m, _, p => by injection p; subst o' m; simp [NF.zero]
   | oadd e n a, o', m, h, p => by
     by_cases e0 : e = 0 <;>
       simp only [split', e0, ↓reduceIte, Prod.mk.injEq, repr, repr_zero, opow_zero, one_mul] at p ⊢
@@ -666,7 +666,7 @@ theorem nf_repr_split' : ∀ {o o' m} [NF o], split' o = (o', m) → NF o' ∧ r
       obtain ⟨IH₁, IH₂⟩ := nf_repr_split' h'
       simp only [IH₂, and_imp]
       intros
-      substs o' m
+      subst o' m
       have : (ω : Ordinal.{0}) ^ repr e = ω ^ (1 : Ordinal.{0}) * ω ^ (repr e - 1) := by
         have := mt repr_inj.1 e0
         rw [← opow_add, Ordinal.add_sub_cancel_of_le (one_le_iff_ne_zero.2 this)]
@@ -702,7 +702,7 @@ theorem nf_repr_split {o o' m} [NF o] (h : split o = (o', m)) : NF o' ∧ repr o
   rcases e : split' o with ⟨a, n⟩
   obtain ⟨s₁, s₂⟩ := nf_repr_split' e
   rw [split_eq_scale_split' e] at h
-  injection h; substs o' n
+  injection h; subst o' n
   simp only [repr_scale, repr_one, Nat.cast_one, opow_one, ← s₂, and_true]
   infer_instance
 

--- a/Mathlib/Tactic/Substs.lean
+++ b/Mathlib/Tactic/Substs.lean
@@ -10,21 +10,25 @@ public import Mathlib.Init
 /-!
 # The `substs` macro
 
-The `substs` macro applies the `subst` tactic to a list of hypothesis, in left to right order.
+The `substs` macro is a deprecated version of the `subst` tactic that allowed for more than one
+hypothesis. Since `subst` now also supports multiple hypotheses, `substs` is deprecated.
 -/
 
 public meta section
 
 namespace Mathlib.Tactic.Substs
 
-
-/--
-Applies the `subst` tactic to all given hypotheses from left to right.
--/
+/-- Deprecated: this functionality exists in `subst` now. -/
 syntax (name := substs) "substs" (colGt ppSpace ident)* : tactic
 
-macro_rules
-| `(tactic| substs $xs:ident*) => `(tactic| ($[subst $xs]*))
+open Lean Meta Elab.Tactic Meta.Tactic.TryThis in
+elab_rules : tactic
+| `(tactic| substs%$tk $xs:ident*) => withMainContext do
+  let stx ← getRef
+  let tac ← `(tactic| subst $[$xs]*)
+  Lean.logWarningAt tk m!"Deprecation warning: `substs` can be replaced with `subst`."
+  Lean.Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := stx)
+  evalTactic tac
 
 end Substs
 

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -132,7 +132,7 @@ theorem rel_equiv : Equivalence D.Rel :=
     clear_value z
     use (pullback.fst _ _ : _ ⟶ D.V (i, k)) (D.t' _ _ _ z)
     dsimp +instances only at *
-    substs eq₁ eq₂ e₁ e₃ e₄
+    subst eq₁ eq₂ e₁ e₃ e₄
     have h₁ : D.t' j i k ≫ pullback.fst _ _ ≫ D.f i k = pullback.fst _ _ ≫ D.t j i ≫ D.f i j := by
       rw [← 𝖣.t_fac_assoc]; congr 1; exact pullback.condition
     have h₂ : D.t' j i k ≫ pullback.fst _ _ ≫ D.t i k ≫ D.f k i =
@@ -219,7 +219,7 @@ theorem image_inter (i j : D.J) :
   constructor
   · rintro ⟨⟨x₁, eq₁⟩, ⟨x₂, eq₂⟩⟩
     obtain ⟨y, e₁, -⟩ := (D.ι_eq_iff_rel _ _ _ _).mp (eq₁.trans eq₂.symm)
-    · substs eq₁
+    · subst eq₁
       exact ⟨y, by simp [e₁]⟩
   · rintro ⟨x, hx⟩
     refine ⟨⟨D.f i j x, hx⟩, ⟨D.f j i (D.t _ _ x), ?_⟩⟩


### PR DESCRIPTION
The `substs` tactic was a wrapper around `subst` to call it multiple times for different hypotheses. But `subst` now supports multiple hypotheses, so we can deprecate `substs` and replace it with `subst`.

I added a deprecation warning using a `Try this:` message.

Spotted while checking tactic docstrings.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
