### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Idempotents/Basic): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -146,7 +146,8 @@ theorem Equivalence.isIdempotentComplete {D : Type*} [Category* D] (ε : C ≌ D
   refine ⟨?_⟩
   intro X' p hp
   let φ := ε.counitIso.symm.app X'
-  erw [split_iff_of_iso φ p (φ.inv ≫ p ≫ φ.hom)
+  simp only [Functor.id_obj] at φ
+  rw [split_iff_of_iso φ p (φ.inv ≫ p ≫ φ.hom)
       (by
         slice_rhs 1 2 => rw [φ.hom_inv_id]
         rw [id_comp])]


### PR DESCRIPTION
- rewrites `Equivalence.isIdempotentComplete` by simplifying `φ` before applying `split_iff_of_iso`
- replaces the `erw` step with a direct `rw`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)