### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Final): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -328,9 +328,8 @@ instance (priority := 100) compCreatesColimit {B : Type u₄} [Category.{v₄} B
     exact (Cocone.whiskering F).mapIso i ≪≫ ((coconesEquiv F (G ⋙ H)).unitIso.app _).symm
 
 instance colimit_pre_isIso [HasColimit G] : IsIso (colimit.pre G F) := by
-  rw [colimit.pre_eq (colimitCoconeComp F (getColimitCocone G)) (getColimitCocone G)]
-  erw [IsColimit.desc_self]
-  dsimp
+  simp only [colimit.pre_eq (colimitCoconeComp F (getColimitCocone G)) (getColimitCocone G),
+    colimitCoconeComp_cocone, IsColimit.desc_self]
   infer_instance
 
 section
@@ -684,8 +683,8 @@ instance (priority := 100) compCreatesLimit {B : Type u₄} [Category.{v₄} B] 
 
 instance limit_pre_isIso [HasLimit G] : IsIso (limit.pre G F) := by
   rw [limit.pre_eq (limitConeComp F (getLimitCone G)) (getLimitCone G)]
-  erw [IsLimit.lift_self]
-  dsimp
+  simp only [limitConeComp_cone, Cone.whisker_pt, limitConeComp_isLimit, IsLimit.lift_self,
+    Category.id_comp, isIso_comp_left_iff]
   infer_instance
 
 section


### PR DESCRIPTION
- rewrites `colimit_pre_isIso` and `limit_pre_isIso` by folding the relevant cocone/cone lemmas into the `simp only` chain
- removes the `erw` steps on `IsColimit.desc_self` and `IsLimit.lift_self`

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)