### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Triangulated/TriangleShift): remove an erw

### DIFF
--- a/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
@@ -62,8 +62,8 @@ noncomputable def Triangle.shiftFunctor (n : ℤ) : Triangle C ⥤ Triangle C wh
       comm₃ := by
         dsimp
         rw [Linear.units_smul_comp, Linear.comp_units_smul, ← Functor.map_comp_assoc, ← f.comm₃,
-          Functor.map_comp, assoc, assoc]
-        erw [(shiftFunctorComm C 1 n).hom.naturality]
+          Functor.map_comp, assoc, assoc, ← Functor.comp_map,
+          ← (shiftFunctorComm C 1 n).hom.naturality]
         rfl }
 
 set_option backward.isDefEq.respectTransparency false in
@@ -107,8 +107,7 @@ noncomputable def Triangle.shiftFunctorAdd' (a b n : ℤ) (h : a + b = n) :
         dsimp
         rw [Linear.units_smul_comp, Linear.comp_units_smul, Functor.map_units_smul,
           Linear.units_smul_comp, Linear.comp_units_smul, smul_smul, assoc,
-          Functor.map_comp, assoc]
-        erw [← NatTrans.naturality_assoc]
+          Functor.map_comp, assoc, ← Functor.comp_map, ← NatTrans.naturality_assoc]
         simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, Int.negOnePow_add,
           shiftFunctorComm_hom_app_comp_shift_shiftFunctorAdd_hom_app, add_comm a]))
     (by cat_disch)

--- a/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
@@ -104,8 +104,8 @@ noncomputable def Triangle.shiftFunctorAdd' (a b n : ℤ) (h : a + b = n) :
         subst h
         dsimp
         rw [Linear.units_smul_comp, Linear.comp_units_smul, Functor.map_units_smul,
-          Linear.units_smul_comp, Linear.comp_units_smul, smul_smul, assoc,
-          Functor.map_comp, assoc, ← Functor.comp_map, ← NatTrans.naturality_assoc]
+          Linear.units_smul_comp, Linear.comp_units_smul, smul_smul, assoc, Functor.map_comp, assoc,
+          ← dsimp% (CategoryTheory.shiftFunctorAdd' C a b (a + b) rfl).hom.naturality_assoc]
         simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, Int.negOnePow_add,
           shiftFunctorComm_hom_app_comp_shift_shiftFunctorAdd_hom_app, add_comm a]))
     (by cat_disch)

--- a/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
@@ -62,9 +62,7 @@ noncomputable def Triangle.shiftFunctor (n : ℤ) : Triangle C ⥤ Triangle C wh
       comm₃ := by
         dsimp
         rw [Linear.units_smul_comp, Linear.comp_units_smul, ← Functor.map_comp_assoc, ← f.comm₃,
-          Functor.map_comp, assoc, assoc, ← Functor.comp_map,
-          ← (shiftFunctorComm C 1 n).hom.naturality]
-        rfl }
+          Functor.map_comp, assoc, assoc, dsimp% (shiftFunctorComm C 1 n).hom.naturality] }
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The canonical isomorphism `Triangle.shiftFunctor C 0 ≅ 𝟭 (Triangle C)`. -/


### PR DESCRIPTION
- rewrites the `Triangle.shiftFunctor` and `Triangle.shiftFunctorAdd'` commutativity proofs by moving `Functor.comp_map` and `NatTrans.naturality_assoc` into the `rw` chain
- removes the `erw` steps on the shift commutation naturality proofs

Extracted from #38415

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)