### PR TITLE
[Merged by Bors] - chore(Tactic): style fixes for `type_check` tactic docstring

### DIFF
--- a/Mathlib/Tactic/TypeCheck.lean
+++ b/Mathlib/Tactic/TypeCheck.lean
@@ -18,7 +18,7 @@ public meta section
 
 open Lean Elab Meta
 
-/-- Type check the given expression, and trace its type. -/
+/-- `type_check e` type checks the term `e` and prints its type to the infoview. -/
 elab tk:"type_check " e:term : tactic => do
   Tactic.withMainContext do
     let e ← Term.elabTermAndSynthesize e none


### PR DESCRIPTION
This PR does a small rewrite in the `type_check` docstring, most importantly replacing the word "trace" with a clearer phrase "print to the infoview". I suppose "trace" here is an abbreviation of "prints a message into the infolog trace", and I've seen it used the same way before in Mathlib. I think though that most users would come away expecting that this means something like `set_option trace.inferType true`.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
