### PR TITLE
[Merged by Bors] - chore(RingTheory): replace some `disjoint_powers_iff_notMem` with `disjoint_powers_iff_notMem_of_isPrime`

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -183,14 +183,14 @@ theorem mk_mem_carrier (z : HomogeneousLocalization.NumDenSameDeg 𝒜 (.powers 
     IsLocalization.comap_map_of_isPrime_disjoint (.powers f)]
   · rfl
   · infer_instance
-  · exact (disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical inferInstance)).mpr x.2
+  · exact (disjoint_powers_iff_notMem_of_isPrime _).mpr x.2
   · exact isUnit_of_invertible _
 
 theorem isPrime_carrier : Ideal.IsPrime (carrier x) := by
   refine Ideal.IsPrime.comap _ (hK := ?_)
   exact IsLocalization.isPrime_of_isPrime_disjoint
     (Submonoid.powers f) _ _ inferInstance
-    ((disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical inferInstance)).mpr x.2)
+    ((disjoint_powers_iff_notMem_of_isPrime _).mpr x.2)
 
 variable (f)
 

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -6,8 +6,6 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.RingTheory.Polynomial.UniversalFactorizationRing
-public import Mathlib.RingTheory.LocalRing.ResidueField.Fiber
-public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
 public import Mathlib.RingTheory.ZariskisMainTheorem
 
 /-!

--- a/Mathlib/RingTheory/Etale/QuasiFinite.lean
+++ b/Mathlib/RingTheory/Etale/QuasiFinite.lean
@@ -174,7 +174,7 @@ lemma Algebra.exists_notMem_and_isIntegral_forall_mem_of_ne_of_liesOver
   let q's : Ideal (Localization.Away s₂) := q'.map (algebraMap _ _)
   by_contra H
   have hq's : Disjoint (Submonoid.powers s₂ : Set (integralClosure R S)) ↑q' := by
-    rw [Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical ‹_›)]
+    rw [Ideal.disjoint_powers_iff_notMem_of_isPrime]
     contrapose H; exact Ideal.mul_mem_right s₃ _ (Ideal.pow_mem_of_mem _ H m hm0)
   have : q's.IsPrime := IsLocalization.isPrime_of_isPrime_disjoint (.powers s₂) _ _ ‹_› hq's
   have : q's.LiesOver q' := ⟨(IsLocalization.comap_map_of_isPrime_disjoint _ _ ‹_› hq's).symm⟩
@@ -395,9 +395,9 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq
     he₀e P' hP'q H' g hgq hg.2
   let Pf := P.map (algebraMap _ (Localization.Away f))
   have : Pf.IsPrime := IsLocalization.isPrime_of_isPrime_disjoint (.powers f) _ _ ‹_› (by
-    rwa [Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical ‹_›)])
+    rwa [Ideal.disjoint_powers_iff_notMem_of_isPrime])
   have : Pf.LiesOver P := ⟨(IsLocalization.comap_map_of_isPrime_disjoint (.powers f) _ ‹_› (by
-    rwa [Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical ‹_›)])).symm⟩
+    rwa [Ideal.disjoint_powers_iff_notMem_of_isPrime])).symm⟩
   let φ : R' ⊗[R] S →ₐ[R'] Localization.Away f ⊗[R] S :=
     Algebra.TensorProduct.map (Algebra.ofId _ _) (.id _ _)
   let := φ.toAlgebra
@@ -409,7 +409,7 @@ lemma Algebra.exists_etale_isIdempotentElem_forall_liesOver_eq
     ext; simp [RingHom.algebraMap_toAlgebra, φ]
   let P'f := P'.map (algebraMap _ (Localization.Away f ⊗[R] S))
   have hP'f : Disjoint (Submonoid.powers (f ⊗ₜ 1 : R' ⊗[R] S) : Set (R' ⊗[R] S)) ↑P' := by
-    rw [Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical inferInstance)]
+    rw [Ideal.disjoint_powers_iff_notMem_of_isPrime]
     change f ∉ P'.under _
     rwa [← P'.over_def P]
   have : P'f.IsPrime := IsLocalization.isPrime_of_isPrime_disjoint _ _ _ ‹_› hP'f

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -854,11 +854,15 @@ theorem mem_radical_of_pow_mem {I : Ideal R} {x : R} {m : ℕ} (hx : x ^ m ∈ r
   radical_idem I ▸ ⟨m, hx⟩
 
 theorem disjoint_powers_iff_notMem (y : R) (hI : I.IsRadical) :
-    Disjoint (Submonoid.powers y : Set R) ↑I ↔ y ∉ I.1 := by
+    Disjoint (Submonoid.powers y : Set R) ↑I ↔ y ∉ I := by
   refine ⟨fun h => Set.disjoint_left.1 h (Submonoid.mem_powers _),
       fun h => disjoint_iff.mpr (eq_bot_iff.mpr ?_)⟩
   rintro x ⟨⟨n, rfl⟩, hx'⟩
   exact h (hI <| mem_radical_of_pow_mem <| le_radical hx')
+
+theorem disjoint_powers_iff_notMem_of_isPrime [I.IsPrime] (y : R) :
+    Disjoint (Submonoid.powers y : Set R) ↑I ↔ y ∉ I :=
+  disjoint_powers_iff_notMem y (IsPrime.isRadical ‹_›)
 
 variable (I J)
 

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -173,15 +173,15 @@ theorem IsLocalization.isMaximal_iff_isMaximal_disjoint [H : IsJacobsonRing R] (
     have : y ∉ (comap (algebraMap R S) J).1 := Set.disjoint_left.1 hJ.right (Submonoid.mem_powers _)
     rw [← H.out hJ.left.isRadical, jacobson, Submodule.mem_toAddSubmonoid, Ideal.mem_sInf] at this
     push Not at this
-    rcases this with ⟨I, hI, hI'⟩
-    convert hI.right
+    rcases this with ⟨I, ⟨hJI, hIm⟩, hI'⟩
+    convert hIm
     by_cases hJ : J = I.map (algebraMap R S)
-    · rw [hJ, comap_map_of_isPrime_disjoint (powers y) S (IsMaximal.isPrime hI.right)]
-      rwa [disjoint_powers_iff_notMem y hI.right.isPrime.isRadical]
+    · rw [hJ, comap_map_of_isPrime_disjoint (powers y) S hIm.isPrime]
+      rwa [disjoint_powers_iff_notMem_of_isPrime]
     · have hI_p : (I.map (algebraMap R S)).IsPrime := by
-        refine isPrime_of_isPrime_disjoint (powers y) _ I hI.right.isPrime ?_
-        rwa [disjoint_powers_iff_notMem y hI.right.isPrime.isRadical]
-      have : J ≤ I.map (algebraMap R S) := map_comap (Submonoid.powers y) S J ▸ map_mono hI.left
+        refine isPrime_of_isPrime_disjoint (powers y) _ I hIm.isPrime ?_
+        rwa [disjoint_powers_iff_notMem_of_isPrime]
+      have : J ≤ I.map (algebraMap R S) := map_comap (Submonoid.powers y) S J ▸ map_mono hJI
       exact absurd (h.1.2 _ (lt_of_le_of_ne this hJ)) hI_p.1
   · simp only [Ideal.mem_comap, and_imp]
     exact (fun _ _ ↦ IsMaximal.of_isLocalization_of_disjoint (powers y))
@@ -193,10 +193,9 @@ See `le_relIso_of_maximal` for the more general statement, and the reverse of th
 theorem IsLocalization.isMaximal_of_isMaximal_disjoint
     [IsJacobsonRing R] (I : Ideal R) (hI : I.IsMaximal)
     (hy : y ∉ I) : (I.map (algebraMap R S)).IsMaximal := by
-  rw [isMaximal_iff_isMaximal_disjoint S y,
-    comap_map_of_isPrime_disjoint (powers y) S (IsMaximal.isPrime hI)
-      ((disjoint_powers_iff_notMem y hI.isPrime.isRadical).2 hy)]
-  exact ⟨hI, hy⟩
+  rw [isMaximal_iff_isMaximal_disjoint S y, comap_map_of_isPrime_disjoint (powers y) S hI.isPrime]
+  · exact ⟨hI, hy⟩
+  · rwa [disjoint_powers_iff_notMem_of_isPrime]
 
 /-- If `R` is a Jacobson ring, then maximal ideals in the localization at `y`
 correspond to maximal ideals in the original ring `R` that don't contain `y` -/
@@ -205,8 +204,8 @@ def IsLocalization.orderIsoOfMaximal [IsJacobsonRing R] :
   toFun p := ⟨Ideal.comap (algebraMap R S) p.1, (isMaximal_iff_isMaximal_disjoint S y p.1).1 p.2⟩
   invFun p := ⟨Ideal.map (algebraMap R S) p.1, isMaximal_of_isMaximal_disjoint y p.1 p.2.1 p.2.2⟩
   left_inv J := Subtype.ext (map_comap (powers y) S J)
-  right_inv I := Subtype.ext (comap_map_of_isPrime_disjoint _ _ (IsMaximal.isPrime I.2.1)
-    ((disjoint_powers_iff_notMem y I.2.1.isPrime.isRadical).2 I.2.2))
+  right_inv := fun ⟨_, hIm, hI⟩ ↦ Subtype.ext <| comap_map_of_isPrime_disjoint _ S hIm.isPrime
+    ((disjoint_powers_iff_notMem_of_isPrime y).2 hI)
   map_rel_iff' {I I'} := ⟨fun h => show I.val ≤ I'.val from
     map_comap (powers y) S I.val ▸ map_comap (powers y) S I'.val ▸ Ideal.map_mono h,
     fun h _ hx => h hx⟩
@@ -236,11 +235,11 @@ theorem isJacobsonRing_localization [H : IsJacobsonRing R] : IsJacobsonRing S :=
     · exact (hPM.le_bot ⟨Submonoid.mem_powers _, hxy⟩).elim
   refine le_trans ?_ this
   rw [Ideal.jacobson, comap_sInf', sInf_eq_iInf]
-  refine iInf_le_iInf_of_subset fun I hI => ⟨map (algebraMap R S) I, ⟨?_, ?_⟩⟩
-  · exact ⟨le_trans (le_of_eq (IsLocalization.map_comap (powers y) S P').symm) (map_mono hI.1),
-      isMaximal_of_isMaximal_disjoint y _ hI.2.1 hI.2.2⟩
-  · exact IsLocalization.comap_map_of_isPrime_disjoint _ S (IsMaximal.isPrime hI.2.1)
-      ((disjoint_powers_iff_notMem y hI.2.1.isPrime.isRadical).2 hI.2.2)
+  refine iInf_le_iInf_of_subset fun I ⟨hI, hIm, hyI⟩ => ⟨map (algebraMap R S) I, ⟨?_, ?_⟩⟩
+  · exact ⟨le_trans (IsLocalization.map_comap (powers y) S P').symm.le (map_mono hI),
+      isMaximal_of_isMaximal_disjoint y I hIm hyI⟩
+  · exact IsLocalization.comap_map_of_isPrime_disjoint _ S hIm.isPrime <|
+      (disjoint_powers_iff_notMem_of_isPrime y).2 hyI
 
 end Localization
 

--- a/Mathlib/RingTheory/Jacobson/Ring.lean
+++ b/Mathlib/RingTheory/Jacobson/Ring.lean
@@ -5,10 +5,9 @@ Authors: Devon Tuma
 -/
 module
 
-public import Mathlib.RingTheory.Localization.Away.Basic
+public import Mathlib.RingTheory.Artinian.Module
 public import Mathlib.RingTheory.Ideal.GoingUp
 public import Mathlib.RingTheory.Jacobson.Polynomial
-public import Mathlib.RingTheory.Artinian.Module
 
 /-!
 # Jacobson Rings

--- a/Mathlib/RingTheory/Smooth/StandardSmoothOfFree.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothOfFree.lean
@@ -107,7 +107,7 @@ theorem IsSmoothAt.exists_notMem_isStandardSmooth [FinitePresentation R S] (p : 
   · obtain ⟨g, hg, hsm⟩ := IsSmoothAt.exists_notMem_smooth R p
     have _ : (Ideal.map (algebraMap S (Localization.Away g)) p).IsPrime := by
       apply IsLocalization.isPrime_of_isPrime_disjoint (.powers g) _ _ ‹_›
-      rwa [Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical ‹_›)]
+      rwa [Ideal.disjoint_powers_iff_notMem_of_isPrime]
     obtain ⟨g', hg', hstd⟩ := this (R := R) (p.map (algebraMap S (Localization.Away g))) hsm
     have : IsLocalization.Away (g * (IsLocalization.Away.sec g g').1) (Localization.Away g') :=
       .mul_of_associated _ _ g' <| IsLocalization.Away.associated_sec_fst g g'

--- a/Mathlib/RingTheory/Unramified/LocalStructure.lean
+++ b/Mathlib/RingTheory/Unramified/LocalStructure.lean
@@ -5,7 +5,6 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.RingTheory.Etale.Locus
 public import Mathlib.RingTheory.Etale.StandardEtale
 public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
 public import Mathlib.RingTheory.RingHom.StandardSmooth

--- a/Mathlib/RingTheory/Unramified/LocalStructure.lean
+++ b/Mathlib/RingTheory/Unramified/LocalStructure.lean
@@ -392,7 +392,7 @@ theorem IsSmoothAt.exists_isStandardEtale_mvPolynomial
   have := IsScalarTower.of_algebraMap_eq' hgC.symm
   have : (Ideal.map (algebraMap S (Localization.Away f)) p).IsPrime :=
     IsLocalization.isPrime_of_isPrime_disjoint (.powers f) _ _ ‹_›
-      ((Ideal.disjoint_powers_iff_notMem _ (Ideal.IsPrime.isRadical ‹_›)).mpr hfp)
+      ((Ideal.disjoint_powers_iff_notMem_of_isPrime _).mpr hfp)
   obtain ⟨g₀, hg, H⟩ := IsEtaleAt.exists_isStandardEtale (R := (MvPolynomial (Fin n) R))
     (S := (Localization.Away f)) (p.map (algebraMap _ _))
   obtain ⟨g, ⟨_, m, rfl⟩, hg₀⟩ := IsLocalization.exists_mk'_eq (.powers f) g₀


### PR DESCRIPTION
In practice, the ideals in [Ideal.disjoint_powers_iff_notMem](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Ideal/Operations.html#Ideal.disjoint_powers_iff_notMem) are always prime ideals. Therefore, I add the lemma `disjoint_powers_iff_notMem_of_isPrime` and replace some occurrences of `disjoint_powers_iff_notMem` with `disjoint_powers_iff_notMem_of_isPrime`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
