### PR TITLE
feat(Algebra,GroupTheory): add lift_unique for FreeMagma, FreeSemigroup, CoprodI, GrothendieckGroup

### DIFF
--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -144,6 +144,18 @@ theorem lift_comp_of : lift f ∘ of = f := rfl
 @[to_additive (attr := simp)]
 theorem lift_comp_of' (f : FreeMagma α →ₙ* β) : lift (f ∘ of) = f := lift.apply_symm_apply f
 
+/-- The map from the free magma is unique given its values on generators. -/
+@[to_additive /-- The map from the free additive magma is unique given its values on generators. -/]
+theorem lift_unique {f : FreeMagma α →ₙ* β} {g : α → β}
+    (h : f ∘ of = g) : f = lift g :=
+  lift.apply_symm_apply f ▸ congrArg lift h
+
+/-- Variant of `lift_unique` with pointwise hypothesis. -/
+@[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]
+theorem lift_unique' {f : FreeMagma α →ₙ* β} {g : α → β}
+    (h : ∀ x, f (of x) = g x) : f = lift g :=
+  lift_unique (funext h)
+
 end lift
 
 section Map
@@ -537,6 +549,19 @@ theorem lift_comp_of : lift f ∘ of = f := rfl
 
 @[to_additive (attr := simp)]
 theorem lift_comp_of' (f : FreeSemigroup α →ₙ* β) : lift (f ∘ of) = f := hom_ext rfl
+
+/-- The map from the free semigroup is unique given its values on generators. -/
+@[to_additive /-- The map from the free additive semigroup is unique given its values on
+generators. -/]
+theorem lift_unique {f : FreeSemigroup α →ₙ* β} {g : α → β}
+    (h : f ∘ of = g) : f = lift g :=
+  lift.apply_symm_apply f ▸ congrArg lift h
+
+/-- Variant of `lift_unique` with pointwise hypothesis. -/
+@[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]
+theorem lift_unique' {f : FreeSemigroup α →ₙ* β} {g : α → β}
+    (h : ∀ x, f (of x) = g x) : f = lift g :=
+  lift_unique (funext h)
 
 @[to_additive]
 theorem lift_of_mul (x y) : lift f (of x * y) = f x * lift f y := by rw [map_mul, lift_of]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -334,7 +334,8 @@ theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.a
 @[to_additive /-- The map from the free additive monoid is unique given its values on generators. -/]
 theorem lift_unique {f : FreeMonoid α →* M} {g : α → M}
     (h : f ∘ of = g) : f = lift g := by
-  rw [← lift_restrict f, h]
+  conv_lhs => rw [← lift_restrict f]
+  rw [h]
 
 /-- Variant of `lift_unique` with pointwise hypothesis. -/
 @[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -330,6 +330,18 @@ theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x := rfl
 @[to_additive (attr := simp)]
 theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.apply_symm_apply f
 
+/-- The map from the free monoid is unique given its values on generators. -/
+@[to_additive /-- The map from the free additive monoid is unique given its values on generators. -/]
+theorem lift_unique {f : FreeMonoid α →* M} {g : α → M}
+    (h : f ∘ of = g) : f = lift g :=
+  lift.apply_symm_apply f ▸ congrArg lift h
+
+/-- Variant of `lift_unique` with pointwise hypothesis. -/
+@[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]
+theorem lift_unique' {f : FreeMonoid α →* M} {g : α → M}
+    (h : ∀ x, f (of x) = g x) : f = lift g :=
+  lift_unique (funext h)
+
 @[to_additive]
 theorem comp_lift (g : M →* N) (f : α → M) : g.comp (lift f) = lift (g ∘ f) := by
   ext

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -333,8 +333,8 @@ theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.a
 /-- The map from the free monoid is unique given its values on generators. -/
 @[to_additive /-- The map from the free additive monoid is unique given its values on generators. -/]
 theorem lift_unique {f : FreeMonoid α →* M} {g : α → M}
-    (h : f ∘ of = g) : f = lift g :=
-  lift.apply_symm_apply f ▸ congrArg lift h
+    (h : f ∘ of = g) : f = lift g := by
+  rw [← lift_restrict f, h]
 
 /-- Variant of `lift_unique` with pointwise hypothesis. -/
 @[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -331,7 +331,8 @@ theorem lift_eval_of (f : α → M) (x : α) : lift f (of x) = f x := rfl
 theorem lift_restrict (f : FreeMonoid α →* M) : lift (f ∘ of) = f := lift.apply_symm_apply f
 
 /-- The map from the free monoid is unique given its values on generators. -/
-@[to_additive /-- The map from the free additive monoid is unique given its values on generators. -/]
+@[to_additive
+  /-- The map from the free additive monoid is unique given its values on generators. -/]
 theorem lift_unique {f : FreeMonoid α →* M} {g : α → M}
     (h : f ∘ of = g) : f = lift g := by
   conv_lhs => rw [← lift_restrict f]

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -171,6 +171,17 @@ theorem lift_comp_of' {N} [Monoid N] (f : CoprodI M →* N) :
 theorem lift_of' : lift (fun i ↦ (of : M i →* CoprodI M)) = .id (CoprodI M) :=
   lift_comp_of' (.id _)
 
+/-- The map from the indexed coproduct is unique given its values on the summands.
+This is the uniqueness part of the universal property of `CoprodI`. -/
+theorem lift_unique {N} [Monoid N] {f : CoprodI M →* N} {fi : ∀ i, M i →* N}
+    (h : ∀ i, f.comp of = fi i) : f = lift fi :=
+  (lift_comp_of' f) ▸ congrArg lift (funext h)
+
+/-- Variant of `lift_unique` with pointwise hypothesis. -/
+theorem lift_unique' {N} [Monoid N] {f : CoprodI M →* N} {fi : ∀ i, M i →* N}
+    (h : ∀ i (m : M i), f (of m) = fi i m) : f = lift fi :=
+  lift_unique fun i => MonoidHom.ext (h i)
+
 theorem of_leftInverse [DecidableEq ι] (i : ι) :
     Function.LeftInverse (lift <| Pi.mulSingle i (MonoidHom.id (M i))) of := fun x => by
   simp only [lift_of, Pi.mulSingle_eq_same, MonoidHom.id_apply]

--- a/Mathlib/GroupTheory/MonoidLocalization/GrothendieckGroup.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/GrothendieckGroup.lean
@@ -89,4 +89,17 @@ lemma lift_apply (f : M →* G) (x : GrothendieckGroup M) :
     lift f x = f ((monoidOf ⊤).sec x).1 / f ((monoidOf ⊤).sec x).2 := by
   simp [lift, (monoidOf ⊤).lift_apply, div_eq_mul_inv]; congr
 
+/-- The map from the Grothendieck group is unique given its values on the base monoid. -/
+@[to_additive /-- The map from the Grothendieck group is unique given its values on the
+base additive monoid. -/]
+theorem lift_unique {f : GrothendieckGroup M →* G} {g : M →* G}
+    (h : f.comp of = g) : f = lift g :=
+  lift.apply_symm_apply f ▸ congrArg lift h
+
+/-- Variant of `lift_unique` with pointwise hypothesis. -/
+@[to_additive /-- Variant of `lift_unique` with pointwise hypothesis. -/]
+theorem lift_unique' {f : GrothendieckGroup M →* G} {g : M →* G}
+    (h : ∀ m, f (of m) = g m) : f = lift g :=
+  lift_unique (MonoidHom.ext h)
+
 end Algebra.GrothendieckGroup


### PR DESCRIPTION
Add explicit `lift_unique` theorems for `FreeMonoid`, `FreeMagma`, `FreeSemigroup`, `Monoid.CoprodI`, and `Algebra.GrothendieckGroup`.

These structures define `lift` as an `Equiv`, encoding uniqueness implicitly. These theorems make it explicit, matching the pattern of `FreeGroup.lift.unique`, `FreeAbelianGroup.lift.unique`, `CliffordAlgebra.lift_unique`, `TensorAlgebra.lift_unique`, `ExteriorAlgebra.lift_unique`, etc.

All proofs follow a one-line pattern using `lift.apply_symm_apply` + `congrArg lift`. No new dependencies.

(Now also includes `FreeMonoid.lift_unique` from #38935.)