### PR TITLE
[Merged by Bors] - ci: use leanprover-community-scoped token for batteries-pr-testing branches

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -576,10 +576,12 @@ jobs:
         id: lean-pr-testing-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.MATHLIB_LEAN_PR_TESTING_APP_ID }}
-          private-key: ${{ secrets.MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY }}
-          owner: leanprover
-          repositories: lean4
+          # `batteries-pr-testing-*` branches need a token scoped to `leanprover-community/batteries`
+          # for the labelling API; `lean-pr-testing-*` branches need one scoped to `leanprover/lean4`.
+          app-id: ${{ startsWith(github.ref_name, 'batteries-pr-testing-') && secrets.MATHLIB_NIGHTLY_TESTING_APP_ID || secrets.MATHLIB_LEAN_PR_TESTING_APP_ID }}
+          private-key: ${{ startsWith(github.ref_name, 'batteries-pr-testing-') && secrets.MATHLIB_NIGHTLY_TESTING_PRIVATE_KEY || secrets.MATHLIB_LEAN_PR_TESTING_PRIVATE_KEY }}
+          owner: ${{ startsWith(github.ref_name, 'batteries-pr-testing-') && 'leanprover-community' || 'leanprover' }}
+          repositories: ${{ startsWith(github.ref_name, 'batteries-pr-testing-') && 'batteries' || 'lean4' }}
       # The create-github-app-token README states that this token is masked and will not be logged accidentally.
       - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
         if: ${{ always() && github.repository == 'leanprover-community/mathlib4-nightly-testing' && (startsWith(github.ref_name, 'lean-pr-testing-') || startsWith(github.ref_name, 'batteries-pr-testing-')) }}


### PR DESCRIPTION
This PR fixes the `lean-pr-testing-token` step in `.github/workflows/build_template.yml` so that label/comment automation works on batteries PRs.

The token was hardcoded to `owner: leanprover, repositories: lean4`, so the resulting GitHub App token had no permissions on `leanprover-community/batteries`. The `curl -s ...` calls in `lean-pr-testing-comments.sh` therefore silently failed when posting labels/comments on batteries PRs (the `-s` swallows the 4xx body and the script doesn't check exit codes). Symptom: a `breaks-mathlib` label on a batteries PR never gets removed even after CI on the corresponding `batteries-pr-testing-NNNN` branch goes green; conversely `builds-mathlib` is never added.

The fix selects the App, owner, and repositories conditionally on the branch prefix:

- `batteries-pr-testing-*` branches → `mathlib-nightly-testing` App (already used by `batteries/.github/workflows/test_mathlib.yml`), scoped to `leanprover-community/batteries`
- `lean-pr-testing-*` branches → unchanged: `mathlib-lean-pr-testing` App, scoped to `leanprover/lean4`

The `mathlib-nightly-testing` App is owned by `leanprover-community`, has `pull_requests:write`, and is already installed on `batteries`. Both secrets (`MATHLIB_NIGHTLY_TESTING_APP_ID` / `_PRIVATE_KEY`) are already present in the `mathlib4-nightly-testing` repo.

A follow-up PR to `leanprover-community/mathlib-ci` should switch `lean-pr-testing-comments.sh` to `curl --fail-with-body` so future label-API failures are loud rather than silent — this bug went unnoticed since the batteries-pr-testing automation was first wired up.

🤖 Prepared with Claude Code