### PR TITLE
[Merged by Bors] - chore: untag duplicated `gcongr` lemmas

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -131,7 +131,7 @@ theorem toAddSubgroup_strictMono : StrictMono (toAddSubgroup : Submodule R M →
 theorem toAddSubgroup_le : p.toAddSubgroup ≤ p'.toAddSubgroup ↔ p ≤ p' :=
   Iff.rfl
 
-@[gcongr, mono]
+@[mono]
 theorem toAddSubgroup_mono : Monotone (toAddSubgroup : Submodule R M → AddSubgroup M) :=
   toAddSubgroup_strictMono.monotone
 

--- a/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
+++ b/Mathlib/Algebra/Module/Submodule/RestrictScalars.lean
@@ -75,11 +75,13 @@ instance restrictScalars.isScalarTower (p : Submodule R M) :
   smul_assoc r s x := Subtype.ext <| smul_assoc r s (x : M)
 
 variable {R M} in
+@[gcongr]
 lemma restrictScalars_le {s t : Submodule R M} :
     s.restrictScalars S ≤ t.restrictScalars S ↔ s ≤ t :=
   Iff.rfl
 
 variable {R M} in
+@[gcongr]
 lemma restrictScalars_lt {s t : Submodule R M} :
     s.restrictScalars S < t.restrictScalars S ↔ s < t :=
   Iff.rfl
@@ -92,7 +94,7 @@ def restrictScalarsEmbedding : Submodule R M ↪o Submodule S M where
   inj' := restrictScalars_injective S R M
   map_rel_iff' := restrictScalars_le S
 
-@[gcongr, mono]
+@[mono]
 lemma restrictScalars_monotone : Monotone (restrictScalars S : Submodule R M → Submodule S M) :=
   (restrictScalarsEmbedding S R M).monotone
 

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -41,11 +41,11 @@ theorem toSubsemiring_le_toSubsemiring {P₁ P₂ : RingPreordering R} :
 theorem toSubsemiring_lt_toSubsemiring {P₁ P₂ : RingPreordering R} :
     P₁.toSubsemiring < P₂.toSubsemiring ↔ P₁ < P₂ := .rfl
 
-@[gcongr, mono]
+@[mono]
 theorem toSubsemiring_mono : Monotone (toSubsemiring : RingPreordering R → _) :=
   fun _ _ => id
 
-@[gcongr, mono]
+@[mono]
 theorem toSubsemiring_strictMono : StrictMono (toSubsemiring : RingPreordering R → _) :=
   fun _ _ => id
 

--- a/Mathlib/Analysis/SpecialFunctions/Sigmoid.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Sigmoid.lean
@@ -97,7 +97,7 @@ lemma sigmoid_lt_iff {a b : ℝ} : sigmoid a < sigmoid b ↔ a < b := sigmoid_st
 @[gcongr]
 lemma sigmoid_lt {a b : ℝ} : a < b → sigmoid a < sigmoid b := sigmoid_lt_iff.mpr
 
-@[gcongr, mono]
+@[mono]
 lemma sigmoid_monotone : Monotone sigmoid := sigmoid_strictMono.monotone
 
 lemma sigmoid_injective : Function.Injective sigmoid := sigmoid_strictMono.injective
@@ -237,7 +237,7 @@ lemma sigmoid_lt_iff {a b : ℝ} : sigmoid a < sigmoid b ↔ a < b := Real.sigmo
 @[gcongr]
 lemma sigmoid_lt {a b : ℝ} : a < b → sigmoid a < sigmoid b := sigmoid_lt_iff.mpr
 
-@[gcongr, mono]
+@[mono]
 lemma sigmoid_monotone : Monotone sigmoid := sigmoid_strictMono.monotone
 
 lemma sigmoid_injective : Function.Injective sigmoid := sigmoid_strictMono.injective

--- a/Mathlib/Data/Finset/Density.lean
+++ b/Mathlib/Data/Finset/Density.lean
@@ -98,8 +98,8 @@ lemma dens_lt_dens (h : s ⊂ t) : dens s < dens t :=
     _ < #t := by gcongr
     _ ≤ Fintype.card α := card_le_univ t
 
-@[gcongr, mono] lemma dens_mono : Monotone (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_le_dens
-@[gcongr, mono] lemma dens_strictMono : StrictMono (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_lt_dens
+@[mono] lemma dens_mono : Monotone (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_le_dens
+@[mono] lemma dens_strictMono : StrictMono (dens : Finset α → ℚ≥0) := fun _ _ ↦ dens_lt_dens
 
 lemma dens_map_le [Fintype β] (f : α ↪ β) : dens (s.map f) ≤ dens s := by
   cases isEmpty_or_nonempty α

--- a/Mathlib/RingTheory/Localization/Submodule.lean
+++ b/Mathlib/RingTheory/Localization/Submodule.lean
@@ -179,7 +179,7 @@ section CommRing
 
 variable [CommRing R] [CommRing K] [Algebra R K] [IsFractionRing R K]
 
-@[simp, mono]
+@[simp, mono, gcongr]
 theorem coeSubmodule_le_coeSubmodule {I J : Ideal R} :
     coeSubmodule K I ≤ coeSubmodule K J ↔ I ≤ J :=
   IsLocalization.coeSubmodule_le_coeSubmodule le_rfl


### PR DESCRIPTION
Follow-up to #38793


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
