### PR TITLE
fix: improve defeqs of comp actions

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -347,6 +347,7 @@ abbrev compHom : Algebra S A where
   commutes' _ _ := Algebra.commutes _ _
   smul_def' _ _ := Algebra.smul_def _ _
 
+@[deprecated SMul.comp_smul_def (since := "2026-05-05")]
 theorem compHom_smul_def (s : S) (x : A) :
     letI := compHom A f
     s • x = f s • x := rfl

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -289,8 +289,15 @@ namespace SMul
 variable [SMul M α]
 
 /-- Auxiliary definition for `SMul.comp`, `MulAction.compHom`,
-`DistribMulAction.compHom`, `Module.compHom`, etc. -/
-@[to_additive (attr := simp) /-- Auxiliary definition for `VAdd.comp`, `AddAction.compHom`, etc. -/]
+`DistribMulAction.compHom`, `Module.compHom`, etc.
+
+We do not make this `reducible`, as we want to prevent `rw` seeing through it.
+However, it must be instance-reducible to avoid diamond downstream when `g := (·)`. -/
+@[to_additive (attr := simp, implicit_reducible)
+/-- Auxiliary definition for `VAdd.comp`, `AddAction.compHom`, etc.
+
+We do not make this `reducible`, as we want to prevent `rw` seeing through it.
+However, it must be instance-reducible to avoid diamond downstream when `g := (·)`. -/]
 def comp.smul (g : N → M) (n : N) (a : α) : α := g n • a
 
 variable (α)

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -305,6 +305,13 @@ abbrev comp (g : N → M) : SMul N α where smul := SMul.comp.smul g
 
 variable {α}
 
+/-- The action from `SMul.comp` is the original action after applying the function. -/
+@[to_additive
+/-- The additive action from `VAdd.comp` is the original action after applying the function. -/]
+theorem comp_smul_def (g : N → M) (n : N) (a : α) :
+    letI := SMul.comp α g; n • a = g n • a :=
+  rfl
+
 /-- Given a tower of scalar actions `M → α → β`, if we use `SMul.comp`
 to pull back both of `M`'s actions by a map `g : N → M`, then we obtain a new
 tower of scalar actions `N → α → β`.

--- a/Mathlib/Algebra/Group/Action/Hom.lean
+++ b/Mathlib/Algebra/Group/Action/Hom.lean
@@ -46,9 +46,9 @@ a multiplicative action of `N` on `α`.
 See note [reducible non-instances]. -/
 @[to_additive]
 abbrev compHom [Monoid N] (g : N →* M) : MulAction N α where
-  smul := SMul.comp.smul g
-  one_smul _ := by simpa [(· • ·)] using one_smul ..
-  mul_smul _ _ _ := by simpa [(· • ·)] using mul_smul ..
+  toSMul := SMul.comp _ g
+  one_smul _ := by simp [SMul.comp_smul_def]
+  mul_smul _ _ _ := by simpa [SMul.comp_smul_def] using mul_smul ..
 
 /-- An additive action of `M` on `α` and an additive monoid homomorphism `N → M` induce
 an additive action of `N` on `α`.
@@ -61,6 +61,9 @@ lemma compHom_smul_def
     {E F G : Type*} [Monoid E] [Monoid F] [MulAction F G] (f : E →* F) (a : E) (x : G) :
     letI : MulAction E G := MulAction.compHom _ f
     a • x = (f a) • x := rfl
+
+attribute [deprecated SMul.comp_smul_def (since := "2026-05-26")] compHom_smul_def
+attribute [deprecated VAdd.comp_vadd_def (since := "2026-05-26")] AddAction.compHom_vadd_def
 
 /-- If an action is transitive, then composing this action with a surjective homomorphism gives
 again a transitive action. -/

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -161,7 +161,7 @@ variable (A)
 /-- Compose a `SMulWithZero` with a `ZeroHom`, with action `f r' • m` -/
 @[implicit_reducible]
 def SMulWithZero.compHom (f : ZeroHom M₀' M₀) : SMulWithZero M₀' A where
-  smul := (f · • ·)
+  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
   smul_zero m := smul_zero (f m)
   zero_smul m := by change (f 0) • m = 0; rw [map_zero, zero_smul]
 
@@ -240,9 +240,10 @@ variable (A)
 /-- Compose a `MulActionWithZero` with a `MonoidWithZeroHom`, with action `f r' • m` -/
 @[implicit_reducible]
 def MulActionWithZero.compHom (f : M₀' →*₀ M₀) : MulActionWithZero M₀' A where
+  toSMul := SMul.comp _ f
   __ := SMulWithZero.compHom A f.toZeroHom
-  mul_smul r s m := by change f (r * s) • m = f r • f s • m; simp [mul_smul]
-  one_smul m := by change f 1 • m = m; simp
+  mul_smul r s m := by simp [SMul.comp_smul_def, mul_smul]
+  one_smul m := by simp [SMul.comp_smul_def]
 
 end MonoidWithZero
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -240,7 +240,7 @@ variable (A)
 /-- Compose a `MulActionWithZero` with a `MonoidWithZeroHom`, with action `f r' • m` -/
 @[implicit_reducible]
 def MulActionWithZero.compHom (f : M₀' →*₀ M₀) : MulActionWithZero M₀' A where
-  toSMul := SMul.comp _ f -- re-supply this to avoid `f.toZeroHom` when unfolding
+  toSMul := SMul.comp _ f  -- resupplied to avoid `⇑↑f`
   __ := SMulWithZero.compHom A f.toZeroHom
   -- `MulAction.compHom` is not imported here, so we reprove these two fields
   mul_smul r s m := by simp [SMul.comp_smul_def, mul_smul]

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -161,7 +161,7 @@ variable (A)
 /-- Compose a `SMulWithZero` with a `ZeroHom`, with action `f r' • m` -/
 @[implicit_reducible]
 def SMulWithZero.compHom (f : ZeroHom M₀' M₀) : SMulWithZero M₀' A where
-  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  toSMul := SMul.comp _ f
   smul_zero m := smul_zero (f m)
   zero_smul m := by change (f 0) • m = 0; rw [map_zero, zero_smul]
 
@@ -240,7 +240,7 @@ variable (A)
 /-- Compose a `MulActionWithZero` with a `MonoidWithZeroHom`, with action `f r' • m` -/
 @[implicit_reducible]
 def MulActionWithZero.compHom (f : M₀' →*₀ M₀) : MulActionWithZero M₀' A where
-  toSMul := SMul.comp _ f
+  toSMul := SMul.comp _ f -- re-supply this to avoid `f.toZeroHom` when unfolding
   __ := SMulWithZero.compHom A f.toZeroHom
   mul_smul r s m := by simp [SMul.comp_smul_def, mul_smul]
   one_smul m := by simp [SMul.comp_smul_def]

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -242,6 +242,7 @@ variable (A)
 def MulActionWithZero.compHom (f : M₀' →*₀ M₀) : MulActionWithZero M₀' A where
   toSMul := SMul.comp _ f -- re-supply this to avoid `f.toZeroHom` when unfolding
   __ := SMulWithZero.compHom A f.toZeroHom
+  -- `MulAction.compHom` is not imported here, so we reprove these two fields
   mul_smul r s m := by simp [SMul.comp_smul_def, mul_smul]
   one_smul m := by simp [SMul.comp_smul_def]
 

--- a/Mathlib/Algebra/GroupWithZero/Action/End.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/End.lean
@@ -36,8 +36,10 @@ variable (A) [AddMonoid A] [Monoid M] [DistribMulAction M A]
 
 /-- Compose a `DistribMulAction` with a `MonoidHom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-abbrev DistribMulAction.compHom [Monoid N] (f : N →* M) : DistribMulAction N A :=
-  { DistribSMul.compFun A f, MulAction.compHom A f with }
+abbrev DistribMulAction.compHom [Monoid N] (f : N →* M) : DistribMulAction N A where
+  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  __ := DistribSMul.compFun A f
+  __ := MulAction.compHom A f
 
 end AddMonoid
 
@@ -47,10 +49,11 @@ variable (A) [Monoid A] [Monoid M] [MulDistribMulAction M A]
 
 /-- Compose a `MulDistribMulAction` with a `MonoidHom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
-abbrev MulDistribMulAction.compHom [Monoid N] (f : N →* M) : MulDistribMulAction N A :=
-  { MulAction.compHom A f with
-    smul_one := fun x => smul_one (f x),
-    smul_mul := fun x => smul_mul' (f x) }
+abbrev MulDistribMulAction.compHom [Monoid N] (f : N →* M) : MulDistribMulAction N A where
+  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  __ := MulAction.compHom A f
+  smul_one x := smul_one (f x)
+  smul_mul x := smul_mul' (f x)
 
 end Monoid
 

--- a/Mathlib/Algebra/GroupWithZero/Action/End.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/End.lean
@@ -37,7 +37,7 @@ variable (A) [AddMonoid A] [Monoid M] [DistribMulAction M A]
 /-- Compose a `DistribMulAction` with a `MonoidHom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
 abbrev DistribMulAction.compHom [Monoid N] (f : N →* M) : DistribMulAction N A where
-  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  toSMul := SMul.comp _ f  -- resupplied to avoid `⇑↑f`
   __ := DistribSMul.compFun A f
   __ := MulAction.compHom A f
 
@@ -50,7 +50,7 @@ variable (A) [Monoid A] [Monoid M] [MulDistribMulAction M A]
 /-- Compose a `MulDistribMulAction` with a `MonoidHom`, with action `f r' • m`.
 See note [reducible non-instances]. -/
 abbrev MulDistribMulAction.compHom [Monoid N] (f : N →* M) : MulDistribMulAction N A where
-  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  toSMul := SMul.comp _ f  -- resupplied to avoid `⇑↑f`
   __ := MulAction.compHom A f
   smul_one x := smul_one (f x)
   smul_mul x := smul_mul' (f x)

--- a/Mathlib/Algebra/Module/RingHom.lean
+++ b/Mathlib/Algebra/Module/RingHom.lean
@@ -54,14 +54,11 @@ variable {R} (M)
 /-- Compose a `Module` with a `RingHom`, with action `f s • m`.
 
 See note [reducible non-instances]. -/
-abbrev Module.compHom [Semiring S] (f : S →+* R) : Module S M :=
-  { MulActionWithZero.compHom M f.toMonoidWithZeroHom, DistribMulAction.compHom M (f : S →* R) with
-    -- Porting note: the `show f (r + s) • x = f r • x + f s • x` wasn't needed in mathlib3.
-    -- Somehow, now that `SMul` is heterogeneous, it can't unfold earlier fields of a definition for
-    -- use in later fields.  See
-    -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Heterogeneous.20scalar.20multiplication
-    -- TODO(jmc): there should be a rw-lemma `smul_comp` close to `SMulZeroClass.compFun`
-    add_smul := fun r s x => show f (r + s) • x = f r • x + f s • x by simp [add_smul] }
+abbrev Module.compHom [Semiring S] (f : S →+* R) : Module S M where
+  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  __ := MulActionWithZero.compHom M f.toMonoidWithZeroHom
+  __ := DistribMulAction.compHom M (f : S →* R)
+  add_smul r s x := by simp [SMul.comp_smul_def, add_smul]
 
 end AddCommMonoid
 

--- a/Mathlib/Algebra/Module/RingHom.lean
+++ b/Mathlib/Algebra/Module/RingHom.lean
@@ -55,7 +55,7 @@ variable {R} (M)
 
 See note [reducible non-instances]. -/
 abbrev Module.compHom [Semiring S] (f : S →+* R) : Module S M where
-  toSMul := SMul.comp _ f  -- to avoid intermediate morphism casts
+  toSMul := SMul.comp _ f  -- resupplied to avoid `⇑↑f`
   __ := MulActionWithZero.compHom M f.toMonoidWithZeroHom
   __ := DistribMulAction.compHom M (f : S →* R)
   add_smul r s x := by simp [SMul.comp_smul_def, add_smul]

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -327,7 +327,7 @@ instance isPretransitiveSL2R : MulAction.IsPretransitive SL(2, ℝ) ℍ :=
 
 /-- `GL(2, ℝ)` acts transitively on the upper half-plane. -/
 instance isPretransitiveGL2R : MulAction.IsPretransitive (GL (Fin 2) ℝ) ℍ :=
-  .of_smul_eq ((↑) : SL(2, ℝ) → _) fun {g z} ↦ (SMul.comp_smul_def _ g z).symm
+  .of_smul_eq ((↑) : SL(2, ℝ) → _) fun {g z} ↦ by exact SMul.comp_smul_def _ g z |>.symm
 
 end toSL2R
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/MoebiusAction.lean
@@ -247,7 +247,7 @@ theorem coe_specialLinearGroup_apply {R : Type*} [CommRing R] [Algebra R ℝ] (g
     ↑(g • z) =
       (((algebraMap R ℝ (g 0 0) : ℂ) * z + (algebraMap R ℝ (g 0 1) : ℂ)) /
       ((algebraMap R ℝ (g 1 0) : ℂ) * z + (algebraMap R ℝ (g 1 1) : ℂ))) := by
-  rw [MulAction.compHom_smul_def, coe_smul_of_det_pos (by simp)]
+  rw [SMul.comp_smul_def, coe_smul_of_det_pos (by simp)]
   rfl
 
 theorem specialLinearGroup_apply {R : Type*} [CommRing R] [Algebra R ℝ] (g : SL(2, R)) (z : ℍ) :
@@ -327,7 +327,7 @@ instance isPretransitiveSL2R : MulAction.IsPretransitive SL(2, ℝ) ℍ :=
 
 /-- `GL(2, ℝ)` acts transitively on the upper half-plane. -/
 instance isPretransitiveGL2R : MulAction.IsPretransitive (GL (Fin 2) ℝ) ℍ :=
-  .of_smul_eq ((↑) : SL(2, ℝ) → _) fun {g z} ↦ (MulAction.compHom_smul_def _ g z).symm
+  .of_smul_eq ((↑) : SL(2, ℝ) → _) fun {g z} ↦ (SMul.comp_smul_def _ g z).symm
 
 end toSL2R
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/ProperAction.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/ProperAction.lean
@@ -77,7 +77,7 @@ private lemma cdsq_le {K : Set ℍ} (hK : IsCompact K) :
     match hK.exists_isMinOn hKne continuous_im.continuousOn with | ⟨z, _, h⟩ => ⟨_, z.im_pos, h⟩
   refine ⟨1 / δ, fun g hg ↦ ?_⟩
   specialize hδK (g • I) hg
-  simp only [MulAction.compHom_smul_def, im_smul_eq_div_normSq, Matrix.SpecialLinearGroup.det_mapGL,
+  simp only [SMul.comp_smul_def, im_smul_eq_div_normSq, Matrix.SpecialLinearGroup.det_mapGL,
     Units.val_one, abs_one, I_im, mul_one] at hδK
   rw [le_div_iff₀ (normSq_denom_pos (Matrix.SpecialLinearGroup.mapGL ℝ g) (show I.im ≠ 0 by simp)),
     mul_comm, ← le_div_iff₀ hδ] at hδK

--- a/Mathlib/Topology/Algebra/Group/OpenMapping.lean
+++ b/Mathlib/Topology/Algebra/Group/OpenMapping.lean
@@ -117,6 +117,6 @@ theorem MonoidHom.isOpenMap_of_sigmaCompact
   let A : MulAction G H := MulAction.compHom _ f
   have : ContinuousSMul G H := continuousSMul_compHom h'f
   have : IsPretransitive G H := isPretransitive_compHom hf
-  have : f = (fun (g : G) ↦ g • (1 : H)) := by simp [A, MulAction.compHom_smul_def]
+  have : f = (fun (g : G) ↦ g • (1 : H)) := by simp [A, SMul.comp_smul_def]
   rw [this]
   exact isOpenMap_smul_of_sigmaCompact _


### PR DESCRIPTION
The (deliberately) non-reducible `SMul.comp.smul` definition caused us to end with these failing unification examples at instance reducibility:
```lean
example : (Module.compHom ℕ (RingHom.id ℕ)).toSMul = SMul.comp ℕ (RingHom.id ℕ) := by
  with_reducible_and_instances rfl

example : (Module.compHom ℕ (RingHom.id ℕ)).toMulAction = MulAction.compHom ℕ (MonoidHom.id ℕ) := by
  with_reducible_and_instances rfl
```
There are two issues this fixes:
* the `compHom` constructors are inconsistent on whether they use `SMul.comp.smul` or reimplement its contents
* we need `SMul.comp.smul` to be instance-reducible, so that when invoked with the identity function it is instance-defeq to the original action.

As a bonus, allowing these to unify means we can have a single `SMul.comp_smul_def` lemma that works for all of the `compHom` definitions.

We could also consider changing `compHom` to take a `HomClass` in order to remove the casts entirely, which would remove the need to add these `SMul.comp` terms. This PR leaves that for possible future work, noting that in the past we have moved away from writing `def`s taking `HomClass`es.

Co-authored-by: Junye Ji <jijunye1@outlook.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Refined from #38777