### PR TITLE
[Merged by Bors] - chore(FinitelyPresentedGroup): Use dot notation by default whenever possible and typo fix

### DIFF
--- a/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
+++ b/Mathlib/GroupTheory/FinitelyPresentedGroup.lean
@@ -21,7 +21,7 @@ This file defines finitely presented groups.
 * `IsFinitelyPresented`: defines when a group is finitely presented.
 
 ## Main results
-* `Subgroup.IsNormalClosureFG_map`: Being the normal closure of a finite set is preserved under
+* `Subgroup.IsNormalClosureFG.map`: Being the normal closure of a finite set is preserved under
   surjective homomorphism.
 * `IsFinitelyPresented.equiv`: finitely presented groups are closed under isomorphism.
 
@@ -33,9 +33,9 @@ finitely presented group, finitely generated normal closure
 
 variable {G H α β : Type*} [Group G] [Group H]
 
-/-- `IsNormalClosureFG N` says that the subgroup `N` is the normal closure of a finitely-generated
+/-- `N.IsNormalClosureFG` says that the subgroup `N` is the normal closure of a finitely-generated
 subgroup. -/
-@[to_additive /-- `IsNormalClosureFG N` says that the additive subgroup `N` is the normal closure
+@[to_additive /-- `N.IsNormalClosureFG` says that the additive subgroup `N` is the normal closure
 of an additive finitely-generated subgroup. -/]
 def Subgroup.IsNormalClosureFG (N : Subgroup G) : Prop :=
   ∃ S : Set G, S.Finite ∧ Subgroup.normalClosure S = N
@@ -45,7 +45,7 @@ namespace Subgroup.IsNormalClosureFG
 /-- Being the normal closure of a finite set is invariant under surjective homomorphism. -/
 @[to_additive /-- Being the additive normal closure of a finite set is invariant under
 surjective homomorphism. -/]
-protected theorem map {N : Subgroup G} (hN : IsNormalClosureFG N)
+protected theorem map {N : Subgroup G} (hN : N.IsNormalClosureFG)
     {f : G →* H} (hf : Function.Surjective f) : (N.map f).IsNormalClosureFG := by
   obtain ⟨S, hSfinite, hSclosure⟩ := hN
   refine ⟨f '' S, hSfinite.image _, ?_⟩
@@ -53,7 +53,7 @@ protected theorem map {N : Subgroup G} (hN : IsNormalClosureFG N)
 
 /-- The trivial group is the normal closure of a finite set of relations. -/
 @[to_additive /-- The trivial additive group is the normal closure of a finite set of relations. -/]
-protected theorem bot : IsNormalClosureFG (⊥ : Subgroup G) :=
+protected theorem bot : (⊥ : Subgroup G).IsNormalClosureFG :=
   ⟨∅, Finite.of_subsingleton, normalClosure_empty⟩
 
 end Subgroup.IsNormalClosureFG
@@ -79,7 +79,7 @@ namespace Group.IsFinitelyPresented
 theorem equiv (iso : G ≃* H) (h : IsFinitelyPresented G) : IsFinitelyPresented H := by
   obtain ⟨n, φ, hφsurj, hNC⟩ := h
   refine ⟨n, (iso : G →* H).comp φ, iso.surjective.comp hφsurj, ?_⟩
-  rwa [MonoidHom.ker_mulEquiv_comp φ iso]
+  rwa [φ.ker_mulEquiv_comp iso]
 
 /-- A free group with a finite number of generators is finitely presented. -/
 @[to_additive /-- A free additive group with a finite number of generators is finitely presented. -/
@@ -88,7 +88,7 @@ instance [Finite α] : IsFinitelyPresented (FreeGroup α) := by
   have ⟨n, _, f, hf_surj, hf_inj⟩ := Finite.exists_equiv_fin α
   refine ⟨n, FreeGroup.map f, FreeGroup.map_surjective hf_surj.surjective, ?_⟩
   · rw [(FreeGroup.map f).ker_eq_bot_iff.mpr (FreeGroup.map_injective hf_inj.injective)]
-    exact Subgroup.IsNormalClosureFG.bot
+    exact .bot
 
 /-- `Multiplicative ℤ` is finitely presented. -/
 instance : IsFinitelyPresented (Multiplicative ℤ) :=


### PR DESCRIPTION
* Changing the usage of `IsNormalClosureFG N` to `N.IsNormalClosureFG` as the use of the latter seems easier to read ("N is finitely generated under normal closure") and is in line with using dot notation for terms. 

* Fix a typo in the main definition docstring regarding the usage of `map`: it should be `.map` instead of `_map`. 

---

I used Copilot + Gemini Pro 3.1 to query about usage and took some of its suggestions. 

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
