### PR TITLE
feat(EReal): simplify nat + ⊤

### DIFF
--- a/Mathlib/Data/EReal/Basic.lean
+++ b/Mathlib/Data/EReal/Basic.lean
@@ -781,9 +781,9 @@ lemma toENNReal_lt_toENNReal {x y : EReal} (hx : 0 ≤ x) (hxy : x < y) :
 
 theorem coe_coe_eq_natCast (n : ℕ) : (n : ℝ) = (n : EReal) := rfl
 
-theorem natCast_ne_bot (n : ℕ) : (n : EReal) ≠ ⊥ := Ne.symm (ne_of_beq_false rfl)
+theorem natCast_ne_bot (n : ℕ) : (n : EReal) ≠ ⊥ := Ne.symm nofun
 
-theorem natCast_ne_top (n : ℕ) : (n : EReal) ≠ ⊤ := Ne.symm (ne_of_beq_false rfl)
+theorem natCast_ne_top (n : ℕ) : (n : EReal) ≠ ⊤ := Ne.symm nofun
 
 @[norm_cast]
 theorem natCast_eq_iff {m n : ℕ} : (m : EReal) = (n : EReal) ↔ m = n := by

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -77,6 +77,19 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_coe _
   · exact top_add_top
 
+
+@[simp]
+theorem one_add_top : (1 : EReal) + ⊤ = ⊤ := rfl
+
+@[simp]
+theorem top_add_one : (⊤ : EReal) + 1 = ⊤ := rfl
+
+@[simp]
+theorem nat_add_top {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) + ⊤ = ⊤ := rfl
+
+@[simp]
+theorem top_add_nat {n : ℕ} [n.AtLeastTwo] : (⊤ : EReal) + ofNat(n) = ⊤ := rfl
+
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/
 theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -79,16 +79,16 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
 
 
 @[simp]
-theorem one_add_top : (1 : EReal) + ⊤ = ⊤ := rfl
+lemma one_add_top : (1 : EReal) + ⊤ = ⊤ := rfl
 
 @[simp]
-theorem top_add_one : (⊤ : EReal) + 1 = ⊤ := rfl
+lemma top_add_one : (⊤ : EReal) + 1 = ⊤ := rfl
 
 @[simp]
-theorem nat_add_top {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) + ⊤ = ⊤ := rfl
+lemma ofNat_add_top {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) + ⊤ = ⊤ := rfl
 
 @[simp]
-theorem top_add_nat {n : ℕ} [n.AtLeastTwo] : (⊤ : EReal) + ofNat(n) = ⊤ := rfl
+lemma top_add_ofNat {n : ℕ} [n.AtLeastTwo] : (⊤ : EReal) + ofNat(n) = ⊤ := rfl
 
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -78,11 +78,10 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_top
 
 @[simp]
-lemma one_ne_bot : (1 : EReal) ≠ ⊥ := ne_of_beq_false rfl
+lemma one_ne_bot : (1 : EReal) ≠ ⊥ := WithBot.coe_ne_bot
 
 @[simp]
-lemma ofNat_ne_bot {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) ≠ ⊥ :=
-  ne_of_beq_false rfl
+lemma ofNat_ne_bot {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) ≠ ⊥ := WithTop.coe_ne_top
 
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -78,16 +78,11 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_top
 
 @[simp]
-lemma one_add_top : (1 : EReal) + ⊤ = ⊤ := rfl
+lemma ofNat_ne_top {n : ℕ} [n.AtLeastTwo] : ⊤ ≠ (ofNat(n) : EReal) :=
+  ne_of_beq_false rfl
 
 @[simp]
-lemma top_add_one : (⊤ : EReal) + 1 = ⊤ := rfl
-
-@[simp]
-lemma ofNat_add_top {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) + ⊤ = ⊤ := rfl
-
-@[simp]
-lemma top_add_ofNat {n : ℕ} [n.AtLeastTwo] : (⊤ : EReal) + ofNat(n) = ⊤ := rfl
+lemma one_ne_top : (1 : EReal) ≠ ⊤ := ne_of_beq_false rfl
 
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -81,7 +81,7 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
 lemma one_ne_bot : (1 : EReal) ≠ ⊥ := WithBot.coe_ne_bot
 
 @[simp]
-lemma ofNat_ne_bot {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) ≠ ⊥ := WithTop.coe_ne_top
+lemma ofNat_ne_bot {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) ≠ ⊥ := WithBot.coe_ne_bot
 
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -77,7 +77,6 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_coe _
   · exact top_add_top
 
-
 @[simp]
 lemma one_add_top : (1 : EReal) + ⊤ = ⊤ := rfl
 

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -78,11 +78,11 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_top
 
 @[simp]
-lemma ofNat_ne_top {n : ℕ} [n.AtLeastTwo] : ⊤ ≠ (ofNat(n) : EReal) :=
-  ne_of_beq_false rfl
+lemma one_ne_bot : (1 : EReal) ≠ ⊥ := ne_of_beq_false rfl
 
 @[simp]
-lemma one_ne_top : (1 : EReal) ≠ ⊤ := ne_of_beq_false rfl
+lemma ofNat_ne_bot {n : ℕ} [n.AtLeastTwo] : (ofNat(n) : EReal) ≠ ⊥ :=
+  ne_of_beq_false rfl
 
 /-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`. -/

--- a/MathlibTest/EReal.lean
+++ b/MathlibTest/EReal.lean
@@ -1,0 +1,20 @@
+module
+
+import Mathlib.Data.EReal.Basic
+import Mathlib.Data.EReal.Operations
+
+example : (0 : EReal) + ⊤ = ⊤ := by simp
+
+example : (1 : EReal) + ⊤ = ⊤ := by simp
+
+example : (2 : EReal) + ⊤ = ⊤ := by simp
+
+example : (3 : EReal) + ⊤ = ⊤ := by simp
+
+example : ⊤ + (0 : EReal) = ⊤ := by simp
+
+example : ⊤ + (1 : EReal) = ⊤ := by simp
+
+example : ⊤ + (2 : EReal) = ⊤ := by simp
+
+example : ⊤ + (3 : EReal) = ⊤ := by simp


### PR DESCRIPTION
Alternative version of https://github.com/leanprover-community/mathlib4/pull/38975

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
