### PR TITLE
bench: `haveI'` -> `have`

### DIFF
--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -134,8 +134,8 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα e := do
     | .app (.app (.app (.const `OfNat.ofNat _) _) (.lit (Literal.natVal n))) _ =>
       guard (n % 2 = 0)
       have m : Q(ℕ) := mkRawNatLit (n / 2)
-      haveI' : $b =Q $m + $m := ⟨⟩
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $b =Q $m + $m := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       pure (.nonnegative q(Even.zpow_nonneg (Even.add_self _) $a))
     | .app (.app (.app (.const `Neg.neg _) _) _) b' =>
       let b' ← whnfR b'
@@ -143,8 +143,8 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα e := do
       let some n := (b'.getRevArg! 1).rawNatLit? | throwError "not a ^ -n where n is a literal"
       guard (n % 2 = 0)
       have m : Q(ℕ) := mkRawNatLit (n / 2)
-      haveI' : $b =Q (-$m) + (-$m) := ⟨⟩
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $b =Q (-$m) + (-$m) := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       pure (.nonnegative q(Even.zpow_nonneg (Even.add_self _) $a))
     | _ => throwError "not a ^ n where n is a literal or a negated literal"
   orElse result do
@@ -152,11 +152,11 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα e := do
     let ofNonneg (pa : Q(0 ≤ $a))
         (_oα : Q(Semifield $α)) (_oα : Q(LinearOrder $α)) (_oα : Q(IsStrictOrderedRing $α)) :
         MetaM (Strictness zα pα e) := do
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       assumeInstancesCommute
       pure (.nonnegative q(zpow_nonneg $pa $b))
     let ofNonzero (pa : Q($a ≠ 0)) (_oα : Q(GroupWithZero $α)) : MetaM (Strictness zα pα e) := do
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       let _a ← synthInstanceQ q(GroupWithZero $α)
       assumeInstancesCommute
       pure (.nonzero q(zpow_ne_zero $b $pa))
@@ -167,7 +167,7 @@ meta def evalZPow : PositivityExt where eval {u α} zα pα e := do
         let _a ← synthInstanceQ q(LinearOrder $α)
         let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
         assumeInstancesCommute
-        haveI' : $e =Q $a ^ $b := ⟨⟩
+        have : $e =Q $a ^ $b := ⟨⟩
         pure (.positive q(zpow_pos $pa $b))
       catch e : Exception =>
         trace[Tactic.positivity.failure] "{e.toMessageData}"

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -706,14 +706,14 @@ meta def evalLucasLehmerTest : NormNumExt where eval {_ _} e := do
   let np := ep.natLit!
   unless 1 < np do
     failure
-  haveI' h1ltp : Nat.blt 1 $ep =Q true := ⟨⟩
+  have h1ltp : Nat.blt 1 $ep =Q true := ⟨⟩
   if sModNatTR (2 ^ np - 1) (np - 2) = 0 then
-    haveI' hs : sModNatTR (2 ^ $ep - 1) ($ep - 2) =Q 0 := ⟨⟩
+    have hs : sModNatTR (2 ^ $ep - 1) ($ep - 2) =Q 0 := ⟨⟩
     have pf : Q(LucasLehmerTest $ep) := q(testTrueHelper $ep $h1ltp $hs)
     have pf' : Q(LucasLehmerTest $p) := q(isNat_lucasLehmerTest $hp $pf)
     return .isTrue pf'
   else
-    haveI' hs : Nat.ble 1 (sModNatTR (2 ^ $ep - 1) ($ep - 2)) =Q true := ⟨⟩
+    have hs : Nat.ble 1 (sModNatTR (2 ^ $ep - 1) ($ep - 2)) =Q true := ⟨⟩
     have pf : Q(¬ LucasLehmerTest $ep) := q(testFalseHelper $ep $h1ltp $hs)
     have pf' : Q(¬ LucasLehmerTest $p) := q(isNat_not_lucasLehmerTest $hp $pf)
     return .isFalse pf'

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -69,13 +69,13 @@ and `b ≤ n`. Returns the list of subgoals `?gi : a ≡ i [ZMOD n] → p`.
 partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (p : Q(Sort u)) :
     MetaM (Q(OnModCases $n $a $b $p) × List MVarId) := do
   if n.natLit! ≤ b.natLit! then
-    haveI' : $b =Q $n := ⟨⟩
+    have : $b =Q $n := ⟨⟩
     pure (q(onModCases_stop $p $n $a), [])
   else
     let ty := q($a ≡ OfNat.ofNat $b [ZMOD OfNat.ofNat $n] → $p)
     let g ← mkFreshExprMVarQ ty
     have b1 : Q(ℕ) := mkRawNatLit (b.natLit! + 1)
-    haveI' : $b1 =Q ($b).succ := ⟨⟩
+    have : $b1 =Q ($b).succ := ⟨⟩
     let (pr, acc) ← proveOnModCases n a b1 p
     pure (q(onModCases_succ $b $g $pr), g.mvarId! :: acc)
 

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -91,11 +91,11 @@ theorem isNat_intOfNat : {n n' : ℕ} → IsNat n n' → IsNat (Int.ofNat n) n'
 `norm_num` successfully recognizes `n`, returning `n`. -/
 @[norm_num Int.ofNat _] def evalIntOfNat : NormNumExt where eval {u α} e := do
   let .app (.const ``Int.ofNat _) (n : Q(ℕ)) ← whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q Int := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q Int := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let sℤ : Q(AddMonoidWithOne ℤ) := q(instAddMonoidWithOne)
   let ⟨n', p⟩ ← deriveNat n sℕ
-  haveI' x : $e =Q Int.ofNat $n := ⟨⟩
+  have x : $e =Q Int.ofNat $n := ⟨⟩
   return .isNat sℤ n' q(isNat_intOfNat $p)
 
 theorem isInt_negOfNat (m n : ℕ) (h : IsNat m n) : IsInt (Int.negOfNat m) (.negOfNat n) :=
@@ -122,8 +122,8 @@ theorem isNat_natAbs_neg : {n : ℤ} → {a : ℕ} → IsInt n (.negOfNat a) →
 `norm_num` successfully recognizes `n`. -/
 @[norm_num Int.natAbs (_ : ℤ)] def evalIntNatAbs : NormNumExt where eval {u α} e := do
   let .app (.const ``Int.natAbs _) (x : Q(ℤ)) ← whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Int.natAbs $x := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Int.natAbs $x := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   match ← derive (u := .zero) x with
   | .isNat    _ a p => assumeInstancesCommute; return .isNat sℕ a q(isNat_natAbs_pos $p)
@@ -141,7 +141,7 @@ theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
   let .app n (a : Q(ℕ)) ← whnfR e | failure
   guard <|← withNewMCtxDepth <| isDefEq n q(Nat.cast (R := $α))
   let ⟨na, pa⟩ ← deriveNat a q(Nat.instAddMonoidWithOne)
-  haveI' : $e =Q $a := ⟨⟩
+  have : $e =Q $a := ⟨⟩
   return .isNat sα na q(isNat_natCast $a $na $pa)
 
 theorem isNat_intCast {R} [Ring R] (n : ℤ) (m : ℕ) :
@@ -158,11 +158,11 @@ theorem isintCast {R} [Ring R] (n m : ℤ) :
   match ← derive (α := q(ℤ)) a with
   | .isNat _ na pa =>
     assumeInstancesCommute
-    haveI' : $e =Q Int.cast $a := ⟨⟩
+    have : $e =Q Int.cast $a := ⟨⟩
     return .isNat _ na q(isNat_intCast $a $na $pa)
   | .isNegNat _ na pa =>
     assumeInstancesCommute
-    haveI' : $e =Q Int.cast $a := ⟨⟩
+    have : $e =Q Int.cast $a := ⟨⟩
     return .isNegNat _ na q(isintCast $a (.negOfNat $na) $pa)
   | _ => failure
 
@@ -252,7 +252,7 @@ def Result.add {u : Level} {α : Q(Type u)} {a b : Q($α)} (ra : Result q($a)) (
     let ⟨za, na, pa⟩ ← ra.toInt _; let ⟨zb, nb, pb⟩ ← rb.toInt _
     let zc := za + zb
     have c := mkRawIntLit zc
-    haveI' : Int.add $na $nb =Q $c := ⟨⟩
+    have : Int.add $na $nb =Q $c := ⟨⟩
     return .isInt rα c zc q(isInt_add (.refl _) $pa $pb (.refl $c))
   let rec nnratArm (dsα : Q(DivisionSemiring $α)) : MetaM (Result _) := do
     assumeInstancesCommute
@@ -299,7 +299,7 @@ def Result.add {u : Level} {α : Q(Type u)} {a b : Q($α)} (ra : Result q($a)) (
   | .isNat _ na pa, .isNat sα nb pb =>
     assumeInstancesCommute
     have c : Q(ℕ) := mkRawNatLit (na.natLit! + nb.natLit!)
-    haveI' : Nat.add $na $nb =Q $c := ⟨⟩
+    have : Nat.add $na $nb =Q $c := ⟨⟩
     return .isNat sα c q(isNat_add (.refl _) $pa $pb (.refl $c))
 
 attribute [local instance] monadLiftOptionMetaM in
@@ -341,14 +341,14 @@ def Result.neg {u : Level} {α : Q(Type u)} {a : Q($α)} (ra : Result q($a))
     let ⟨za, na, pa⟩ ← ra.toInt rα
     let zb := -za
     have b := mkRawIntLit zb
-    haveI' : Int.neg $na =Q $b := ⟨⟩
+    have : Int.neg $na =Q $b := ⟨⟩
     return .isInt rα b zb q(isInt_neg (.refl _) $pa (.refl $b))
   let ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
     assumeInstancesCommute
     let ⟨qa, na, da, pa⟩ ← ra.toRat' dα
     let qb := -qa
     have nb := mkRawIntLit qb.num
-    haveI' : Int.neg $na =Q $nb := ⟨⟩
+    have : Int.neg $na =Q $nb := ⟨⟩
     return .isRat dα qb nb da q(isRat_neg (.refl _) $pa (.refl $nb))
   match ra with
   | .isBool _ .. => failure
@@ -365,7 +365,7 @@ such that `norm_num` successfully recognises `a`. -/
   let ra ← derive a
   let rα ← inferRing α
   let ⟨(_f_eq : $f =Q Neg.neg)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
-  haveI' _e_eq : $e =Q -$a := ⟨⟩
+  have _e_eq : $e =Q -$a := ⟨⟩
   ra.neg
 
 -- see note [norm_num lemma function equality]
@@ -393,7 +393,7 @@ def Result.sub {u : Level} {α : Q(Type u)} {a b : Q($α)} (ra : Result q($a)) (
     let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
     let zc := za - zb
     have c := mkRawIntLit zc
-    haveI' : Int.sub $na $nb =Q $c := ⟨⟩
+    have : Int.sub $na $nb =Q $c := ⟨⟩
     return Result.isInt rα c zc q(isInt_sub (.refl _) $pa $pb (.refl $c))
   let ratArm (dα : Q(DivisionRing $α)) : MetaM (Result _) := do
     assumeInstancesCommute
@@ -428,7 +428,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let rα ← inferRing α
   let ⟨(_f_eq : $f =Q HSub.hSub)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
   let ra ← derive a; let rb ← derive b
-  haveI' _e_eq : $e =Q $a - $b := ⟨⟩
+  have _e_eq : $e =Q $a - $b := ⟨⟩
   ra.sub rb
 
 -- see note [norm_num lemma function equality]
@@ -491,7 +491,7 @@ def Result.mul {u : Level} {α : Q(Type u)} {a b : Q($α)} (ra : Result q($a)) (
     let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
     let zc := za * zb
     have c := mkRawIntLit zc
-    haveI' : Int.mul $na $nb =Q $c := ⟨⟩
+    have : Int.mul $na $nb =Q $c := ⟨⟩
     return .isInt rα c zc q(isInt_mul (.refl _) $pa $pb (.refl $c))
   let nnratArm (dsα : Q(DivisionSemiring $α)) : Option (Result _) := do
     assumeInstancesCommute
@@ -534,10 +534,10 @@ def Result.mul {u : Level} {α : Q(Type u)} {a b : Q($α)} (ra : Result q($a)) (
     nnratArm dsα
   | .isNegNat rα .., _ | _, .isNegNat rα .. => intArm rα
   | .isNat mα' na pa, .isNat mα nb pb => do
-    haveI' : $mα =Q by clear! $mα $mα'; apply AddCommMonoidWithOne.toAddMonoidWithOne := ⟨⟩
+    have : $mα =Q by clear! $mα $mα'; apply AddCommMonoidWithOne.toAddMonoidWithOne := ⟨⟩
     assumeInstancesCommute
     have c : Q(ℕ) := mkRawNatLit (na.natLit! * nb.natLit!)
-    haveI' : Nat.mul $na $nb =Q $c := ⟨⟩
+    have : Nat.mul $na $nb =Q $c := ⟨⟩
     return .isNat mα c q(isNat_mul (.refl _) $pa $pb (.refl $c))
 
 /-- The `norm_num` extension which identifies expressions of the form `a * b`,
@@ -547,8 +547,8 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let sα ← inferSemiring α
   let ra ← derive a; let rb ← derive b
   guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
-  haveI' : $f =Q HMul.hMul := ⟨⟩
-  haveI' : $e =Q $a * $b := ⟨⟩
+  have : $f =Q HMul.hMul := ⟨⟩
+  have : $e =Q $a * $b := ⟨⟩
   ra.mul rb
 
 theorem isNNRat_div {α : Type u} [DivisionSemiring α] : {a b : α} → {cn : ℕ} → {cd : ℕ} →
@@ -573,7 +573,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ / _] def evalDiv : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q($α))) (b : Q($α)) ← whnfR e | failure
   let dsα ← inferDivisionSemiring α
-  haveI' : $e =Q $a / $b := ⟨⟩
+  have : $e =Q $a / $b := ⟨⟩
   guard <| ← withNewMCtxDepth <| isDefEq f q(HDiv.hDiv (α := $α))
   let rab ← derive (q($a * $b⁻¹) : Q($α))
   if let some ⟨qa, na, da, pa⟩ := rab.toNNRat' dsα then
@@ -643,12 +643,12 @@ such that `norm_num` successfully recognises `a`. -/
 @[norm_num Nat.succ _] def evalNatSucc : NormNumExt where eval {u α} e := do
   let .app f (a : Q(ℕ)) ← whnfR e | failure
   guard <|← withNewMCtxDepth <| isDefEq f q(Nat.succ)
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Nat.succ $a := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Nat.succ $a := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit!.succ)
-  haveI' : $nc =Q ($na).succ := ⟨⟩
+  have : $nc =Q ($na).succ := ⟨⟩
   return .isNat sℕ nc q(isNat_natSucc $pa (.refl $nc))
 
 theorem isNat_natSub : {a b : ℕ} → {a' b' c : ℕ} →
@@ -662,12 +662,12 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let .app (.app f (a : Q(ℕ))) (b : Q(ℕ)) ← whnfR e | failure
   -- We assert that the default instance for `HSub` is `Nat.sub` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HSub.hSub (α := ℕ))
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q $a - $b := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q $a - $b := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! - nb.natLit!)
-  haveI' : Nat.sub $na $nb =Q $nc := ⟨⟩
+  have : Nat.sub $na $nb =Q $nc := ⟨⟩
   return .isNat sℕ nc q(isNat_natSub $pa $pb (.refl $nc))
 
 theorem isNat_natMod : {a b : ℕ} → {a' b' c : ℕ} →
@@ -679,14 +679,14 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℕ) % _] def evalNatMod :
     NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q(ℕ))) (b : Q(ℕ)) ← whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q $a % $b := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q $a % $b := ⟨⟩
   -- We assert that the default instance for `HMod` is `Nat.mod` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HMod.hMod (α := ℕ))
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! % nb.natLit!)
-  haveI' : Nat.mod $na $nb =Q $nc := ⟨⟩
+  have : Nat.mod $na $nb =Q $nc := ⟨⟩
   return .isNat sℕ nc q(isNat_natMod $pa $pb (.refl $nc))
 
 theorem isNat_natDiv : {a b : ℕ} → {a' b' c : ℕ} →
@@ -698,14 +698,14 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℕ) / _]
 def evalNatDiv : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q(ℕ))) (b : Q(ℕ)) ← whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q $a / $b := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q $a / $b := ⟨⟩
   -- We assert that the default instance for `HDiv` is `Nat.div` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HDiv.hDiv (α := ℕ))
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨na, pa⟩ ← deriveNat a sℕ; let ⟨nb, pb⟩ ← deriveNat b sℕ
   have nc : Q(ℕ) := mkRawNatLit (na.natLit! / nb.natLit!)
-  haveI' : Nat.div $na $nb =Q $nc := ⟨⟩
+  have : Nat.div $na $nb =Q $nc := ⟨⟩
   return .isNat sℕ nc q(isNat_natDiv $pa $pb (.refl $nc))
 
 theorem isNat_dvd_true : {a b : ℕ} → {a' b' : ℕ} →

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -121,10 +121,10 @@ partial def List.proveNilOrCons {u : Level} {α : Q(Type u)} (s : Q(List $α)) :
   | (_, ``List.range, #[(n : Q(ℕ))]) =>
     have s : Q(List ℕ) := s; .uncheckedCast _ _ <$> show MetaM (ProveNilOrConsResult s) from do
     let ⟨nn, pn⟩ ← NormNum.deriveNat n _
-    haveI' : $s =Q .range $n := ⟨⟩
+    have : $s =Q .range $n := ⟨⟩
     let nnL := nn.natLit!
     if nnL = 0 then
-      haveI' : $nn =Q 0 := ⟨⟩
+      have : $nn =Q 0 := ⟨⟩
       return .nil q(List.range_zero' $pn)
     else
       have n' : Q(ℕ) := mkRawNatLit (nnL - 1)
@@ -133,12 +133,12 @@ partial def List.proveNilOrCons {u : Level} {α : Q(Type u)} (s : Q(List $α)) :
   | (_, ``List.finRange, #[(n : Q(ℕ))]) =>
     have s : Q(List (Fin $n)) := s
     .uncheckedCast _ _ <$> show MetaM (ProveNilOrConsResult s) from do
-    haveI' : $s =Q .finRange $n := ⟨⟩
+    have : $s =Q .finRange $n := ⟨⟩
     return match ← Nat.unifyZeroOrSucc n with -- We want definitional equality on `n`.
     | .zero _pf => .nil q(List.finRange_zero)
     | .succ n' _pf => .cons _ _ q(List.finRange_succ)
   | (.const ``List.map [v, _], _, #[(β : Q(Type v)), _, (f : Q($β → $α)), (xxs : Q(List $β))]) => do
-    haveI' : $s =Q ($xxs).map $f := ⟨⟩
+    have : $s =Q ($xxs).map $f := ⟨⟩
     return match ← List.proveNilOrCons xxs with
     | .nil pf => .nil q(($pf ▸ List.map_nil : List.map _ _ = _))
     | .cons x xs pf => .cons q($f $x) q(($xs).map $f)
@@ -203,14 +203,14 @@ partial def Multiset.proveZeroOrCons {α : Q(Type u)} (s : Q(Multiset $α)) :
   | (``Multiset.range, #[(n : Q(ℕ))]) => do
     have s : Q(Multiset ℕ) := s; .uncheckedCast _ _ <$> show MetaM (ProveZeroOrConsResult s) from do
     let ⟨nn, pn⟩ ← NormNum.deriveNat n _
-    haveI' : $s =Q .range $n := ⟨⟩
+    have : $s =Q .range $n := ⟨⟩
     let nnL := nn.natLit!
     if nnL = 0 then
-      haveI' : $nn =Q 0 := ⟨⟩
+      have : $nn =Q 0 := ⟨⟩
       return .zero q(Multiset.range_zero' $pn)
     else
       have n' : Q(ℕ) := mkRawNatLit (nnL - 1)
-      haveI' : $nn =Q ($n').succ := ⟨⟩
+      have : $nn =Q ($n').succ := ⟨⟩
       return .cons _ _ q(Multiset.range_succ' $pn rfl)
   | (fn, args) =>
     throwError "Multiset.proveZeroOrCons: unsupported multiset expression {s} ({fn}, {args})"
@@ -280,17 +280,17 @@ partial def Finset.proveEmptyOrCons {α : Q(Type u)} (s : Q(Finset $α)) :
   | (``Finset.range, #[(n : Q(ℕ))]) =>
     have s : Q(Finset ℕ) := s; .uncheckedCast _ _ <$> show MetaM (ProveEmptyOrConsResult s) from do
     let ⟨nn, pn⟩ ← NormNum.deriveNat n _
-    haveI' : $s =Q .range $n := ⟨⟩
+    have : $s =Q .range $n := ⟨⟩
     let nnL := nn.natLit!
     if nnL = 0 then
       haveI : $nn =Q 0 := ⟨⟩
       return .empty q(Finset.range_zero' $pn)
     else
       have n' : Q(ℕ) := mkRawNatLit (nnL - 1)
-      haveI' : $nn =Q ($n').succ := ⟨⟩
+      have : $nn =Q ($n').succ := ⟨⟩
       return .cons n' _ _ q(Finset.range_succ' $pn (.refl $nn))
   | (``Finset.univ, #[_, (instFT : Q(Fintype $α))]) => do
-    haveI' : $s =Q .univ := ⟨⟩
+    have : $s =Q .univ := ⟨⟩
     match (← whnfI instFT).getAppFnArgs with
     | (``Fintype.mk, #[_, (elems : Q(Finset $α)), (complete : Q(∀ x : $α, x ∈ $elems))]) => do
       let res ← Finset.proveEmptyOrCons elems

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -49,8 +49,8 @@ partial def evalIntDiv : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q(ℤ))) (b : Q(ℤ)) ← whnfR e | failure
   -- We assert that the default instance for `HDiv` is `Int.div` when the first parameter is `ℤ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HDiv.hDiv (α := ℤ))
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℤ := ⟨⟩
-  haveI' : $e =Q ($a / $b) := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℤ := ⟨⟩
+  have : $e =Q ($a / $b) := ⟨⟩
   let rℤ : Q(Ring ℤ) := q(Int.instRing)
   let ⟨za, na, pa⟩ ← (← derive a).toInt rℤ
   match ← derive (u := .zero) b with
@@ -108,8 +108,8 @@ partial def evalIntMod : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q(ℤ))) (b : Q(ℤ)) ← whnfR e | failure
   -- We assert that the default instance for `HMod` is `Int.mod` when the first parameter is `ℤ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(HMod.hMod (α := ℤ))
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℤ := ⟨⟩
-  haveI' : $e =Q ($a % $b) := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℤ := ⟨⟩
+  have : $e =Q ($a % $b) := ⟨⟩
   let rℤ : Q(Ring ℤ) := q(Int.instRing)
   let some ⟨za, na, pa⟩ := (← derive a).toInt rℤ | failure
   go a na za pa b (← derive (u := .zero) b)
@@ -160,8 +160,8 @@ attribute [local instance] monadLiftOptionMetaM in
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num (_ : ℤ) ∣ _] def evalIntDvd : NormNumExt where eval {u α} e := do
   let .app (.app f (a : Q(ℤ))) (b : Q(ℤ)) ← whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q Prop := ⟨⟩
-  haveI' : $e =Q ($a ∣ $b) := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q Prop := ⟨⟩
+  have : $e =Q ($a ∣ $b) := ⟨⟩
   -- We assert that the default instance for `Dvd` is `Int.dvd` when the first parameter is `ℕ`.
   guard <|← withNewMCtxDepth <| isDefEq f q(Dvd.dvd (α := ℤ))
   let rℤ : Q(Ring ℤ) := q(Int.instRing)
@@ -170,7 +170,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   if zb % za == 0 then
     let zc := zb / za
     have c := mkRawIntLit zc
-    haveI' : Int.mul $na $c =Q $nb := ⟨⟩
+    have : Int.mul $na $c =Q $nb := ⟨⟩
     return .isTrue q(isInt_dvd_true $pa $pb (.refl $nb))
   else
     have : Q(Int.emod $nb $na != 0) := (q(Eq.refl true) : Expr)

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -53,17 +53,17 @@ attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a = b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ = _] def evalEq : NormNumExt where eval {v β} e := do
-  haveI' : v =QL 0 := ⟨⟩; haveI' : $β =Q Prop := ⟨⟩
+  have : v =QL 0 := ⟨⟩; have : $β =Q Prop := ⟨⟩
   let .app (.app f a) b ← whnfR e | failure
   let ⟨u, α, a⟩ ← inferTypeQ' a
   have b : Q($α) := b
-  haveI' : $e =Q ($a = $b) := ⟨⟩
+  have : $e =Q ($a = $b) := ⟨⟩
   guard <|← withNewMCtxDepth <| isDefEq f q(Eq (α := $α))
   let ra ← derive a; let rb ← derive b
   let rec intArm (rα : Q(Ring $α)) := do
     let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
     if za = zb then
-      haveI' : $na =Q $nb := ⟨⟩
+      have : $na =Q $nb := ⟨⟩
       return .isTrue q(isInt_eq_true $pa $pb)
     else if let some _i ← inferCharZeroOfRing? rα then
       let r : Q(decide ($na = $nb) = false) := (q(Eq.refl false) : Expr)
@@ -73,8 +73,8 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let rec nnratArm (dsα : Q(DivisionSemiring $α)) := do
     let ⟨qa, na, da, pa⟩ ← ra.toNNRat' dsα; let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' dsα
     if qa = qb then
-      haveI' : $na =Q $nb := ⟨⟩
-      haveI' : $da =Q $db := ⟨⟩
+      have : $na =Q $nb := ⟨⟩
+      have : $da =Q $db := ⟨⟩
       return .isTrue q(isNNRat_eq_true $pa $pb)
     else if let some _i ← inferCharZeroOfDivisionSemiring? dsα then
       let r : Q(decide (Nat.mul $na $db = Nat.mul $nb $da) = false) :=
@@ -85,8 +85,8 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let rec ratArm (dα : Q(DivisionRing $α)) := do
     let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
     if qa = qb then
-      haveI' : $na =Q $nb := ⟨⟩
-      haveI' : $da =Q $db := ⟨⟩
+      have : $na =Q $nb := ⟨⟩
+      have : $da =Q $db := ⟨⟩
       return .isTrue q(isRat_eq_true $pa $pb)
     else if let some _i ← inferCharZeroOfDivisionRing? dα then
       let r : Q(decide (Int.mul $na (.ofNat $db) = Int.mul $nb (.ofNat $da)) = false) :=
@@ -118,7 +118,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   | .isNat _ na pa, .isNat mα nb pb =>
     assumeInstancesCommute
     if na.natLit! = nb.natLit! then
-      haveI' : $na =Q $nb := ⟨⟩
+      have : $na =Q $nb := ⟨⟩
       return .isTrue q(isNat_eq_true $pa $pb)
     else if let some _i ← inferCharZeroOfAddMonoidWithOne? mα then
       let r : Q(Nat.beq $na $nb = false) := (q(Eq.refl false) : Expr)

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -133,8 +133,8 @@ def proveNatGCD (ex ey : Q(ℕ)) : (ed : Q(ℕ)) × Q(Nat.gcd $ex $ey = $ed) :=
 @[norm_num Nat.gcd _ _]
 def evalNatGCD : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Nat.gcd $x $y := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Nat.gcd $x $y := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, q⟩ ← deriveNat y sℕ
@@ -162,8 +162,8 @@ def proveNatLCM (ex ey : Q(ℕ)) : (ed : Q(ℕ)) × Q(Nat.lcm $ex $ey = $ed) :=
 @[norm_num Nat.lcm _ _]
 def evalNatLCM : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Nat.lcm $x $y := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Nat.lcm $x $y := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(Nat.instAddMonoidWithOne)
   let ⟨ex, p⟩ ← deriveNat x sℕ
   let ⟨ey, q⟩ ← deriveNat y sℕ
@@ -184,8 +184,8 @@ def evalIntGCD : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℤ))) (y : Q(ℤ)) ← Meta.whnfR e | failure
   let ⟨ex, p⟩ ← deriveInt x _
   let ⟨ey, q⟩ ← deriveInt y _
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Int.gcd $x $y := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Int.gcd $x $y := ⟨⟩
   let ⟨ed, pf⟩ := proveIntGCD ex ey
   return .isNat _ ed q(isInt_gcd $p $q $pf)
 
@@ -203,8 +203,8 @@ def evalIntLCM : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℤ))) (y : Q(ℤ)) ← Meta.whnfR e | failure
   let ⟨ex, p⟩ ← deriveInt x _
   let ⟨ey, q⟩ ← deriveInt y _
-  haveI' : u =QL 0 := ⟨⟩; haveI' : $α =Q ℕ := ⟨⟩
-  haveI' : $e =Q Int.lcm $x $y := ⟨⟩
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Int.lcm $x $y := ⟨⟩
   let ⟨ed, pf⟩ := proveIntLCM ex ey
   return .isNat _ ed q(isInt_lcm $p $q $pf)
 

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -182,7 +182,7 @@ attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a ≤ b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ ≤ _] def evalLE : NormNumExt where eval {v β} e := do
-  haveI' : v =QL 0 := ⟨⟩; haveI' : $β =Q Prop := ⟨⟩
+  have : v =QL 0 := ⟨⟩; have : $β =Q Prop := ⟨⟩
   let .app (.app f a) b ← whnfR e | failure
   let ⟨u, α, a⟩ ← inferTypeQ' a
   have b : Q($α) := b
@@ -198,7 +198,7 @@ where
   let e := q($a ≤ $b)
   let rec intArm : MetaM (Result e) := do
     let ⟨_ir, _, _i⟩ ← inferOrderedRing α
-    haveI' : $e =Q ($a ≤ $b) := ⟨⟩
+    have : $e =Q ($a ≤ $b) := ⟨⟩
     let ⟨za, na, pa⟩ ← ra.toInt q($_ir)
     let ⟨zb, nb, pb⟩ ← rb.toInt q($_ir)
     assumeInstancesCommute
@@ -212,7 +212,7 @@ where
       failure
   let rec ratArm : MetaM (Result e) := do
     let ⟨_if, _, _i⟩ ← inferLinearOrderedField α
-    haveI' : $e =Q ($a ≤ $b) := ⟨⟩
+    have : $e =Q ($a ≤ $b) := ⟨⟩
     let ⟨qa, na, da, pa⟩ ← ra.toRat' q(Field.toDivisionRing)
     let ⟨qb, nb, db, pb⟩ ← rb.toRat' q(Field.toDivisionRing)
     assumeInstancesCommute
@@ -230,9 +230,9 @@ where
   | .isNegNat _ .., _ | _, .isNegNat _ .. => intArm
   | .isNat ra na pa, .isNat rb nb pb =>
     let ⟨_, _, _i⟩ ← inferOrderedSemiring α
-    haveI' : $ra =Q by clear! $ra $rb; infer_instance := ⟨⟩
-    haveI' : $rb =Q by clear! $ra $rb; infer_instance := ⟨⟩
-    haveI' : $e =Q ($a ≤ $b) := ⟨⟩
+    have : $ra =Q by clear! $ra $rb; infer_instance := ⟨⟩
+    have : $rb =Q by clear! $ra $rb; infer_instance := ⟨⟩
+    have : $e =Q ($a ≤ $b) := ⟨⟩
     assumeInstancesCommute
     if na.natLit! ≤ nb.natLit! then
       let r : Q(Nat.ble $na $nb = true) := (q(Eq.refl true) : Expr)
@@ -247,7 +247,7 @@ attribute [local instance] monadLiftOptionMetaM in
 /-- The `norm_num` extension which identifies expressions of the form `a < b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ < _] def evalLT : NormNumExt where eval {v β} e := do
-  haveI' : v =QL 0 := ⟨⟩; haveI' : $β =Q Prop := ⟨⟩
+  have : v =QL 0 := ⟨⟩; have : $β =Q Prop := ⟨⟩
   let .app (.app f a) b ← whnfR e | failure
   let ⟨u, α, a⟩ ← inferTypeQ' a
   have b : Q($α) := b
@@ -263,7 +263,7 @@ where
   let e := q($a < $b)
   let rec intArm : MetaM (Result e) := do
     let ⟨_ir, _, _i⟩ ← inferOrderedRing α
-    haveI' : $e =Q ($a < $b) := ⟨⟩
+    have : $e =Q ($a < $b) := ⟨⟩
     let ⟨za, na, pa⟩ ← ra.toInt q($_ir)
     let ⟨zb, nb, pb⟩ ← rb.toInt q($_ir)
     assumeInstancesCommute
@@ -284,7 +284,7 @@ where
     -/
     let ⟨_, _, _⟩ ← inferLinearOrderedSemifield α
     assumeInstancesCommute
-    haveI' : $e =Q ($a < $b) := ⟨⟩
+    have : $e =Q ($a < $b) := ⟨⟩
     let ⟨qa, na, da, pa⟩ ← ra.toNNRat' q(Semifield.toDivisionSemiring)
     let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' q(Semifield.toDivisionSemiring)
     if qa < qb then
@@ -301,7 +301,7 @@ where
     -/
     let ⟨_, _, _i⟩ ← inferLinearOrderedField α
     assumeInstancesCommute
-    haveI' : $e =Q ($a < $b) := ⟨⟩
+    have : $e =Q ($a < $b) := ⟨⟩
     let ⟨qa, na, da, pa⟩ ← ra.toRat' q(Field.toDivisionRing)
     let ⟨qb, nb, db, pb⟩ ← rb.toRat' q(Field.toDivisionRing)
     if qa < qb then
@@ -319,9 +319,9 @@ where
   | .isNegNat _ .., _ | _, .isNegNat _ .. => intArm
   | .isNat ra na pa, .isNat rb nb pb =>
     let ⟨_, _, _i⟩ ← inferOrderedSemiring α
-    haveI' : $ra =Q by clear! $ra $rb; infer_instance := ⟨⟩
-    haveI' : $rb =Q by clear! $ra $rb; infer_instance := ⟨⟩
-    haveI' : $e =Q ($a < $b) := ⟨⟩
+    have : $ra =Q by clear! $ra $rb; infer_instance := ⟨⟩
+    have : $rb =Q by clear! $ra $rb; infer_instance := ⟨⟩
+    have : $e =Q ($a < $b) := ⟨⟩
     assumeInstancesCommute
     if na.natLit! < nb.natLit! then
       if let .some _i ← trySynthInstanceQ q(CharZero $α) then

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -72,7 +72,7 @@ such that `norm_num` successfully recognises both `a` and `b`, and returns `a / 
 @[norm_num mkRat _ _]
 def evalMkRat : NormNumExt where eval {u α} (e : Q(ℚ)) : MetaM (Result e) := do
   let .app (.app (.const ``mkRat _) (a : Q(ℤ))) (b : Q(ℕ)) ← whnfR e | failure
-  haveI' : $e =Q mkRat $a $b := ⟨⟩
+  have : $e =Q mkRat $a $b := ⟨⟩
   let ra ← derive a
   let some ⟨_, na, pa⟩ := ra.toInt (q(Int.instRing) : Q(Ring Int)) | failure
   let ⟨nb, pb⟩ ← deriveNat q($b) q(AddCommMonoidWithOne.toAddMonoidWithOne)
@@ -103,7 +103,7 @@ recognizes `q`, returning the cast of `q`. -/
   let .app r (a : Q(ℚ)) ← whnfR e | failure
   guard <|← withNewMCtxDepth <| isDefEq r q(Rat.cast (K := $α))
   let r ← derive q($a)
-  haveI' : $e =Q Rat.cast $a := ⟨⟩
+  have : $e =Q Rat.cast $a := ⟨⟩
   match r with
   | .isNat _ na pa =>
     assumeInstancesCommute
@@ -171,12 +171,12 @@ def Result.inv {u : Level} {α : Q(Type u)} {a : Q($α)} (ra : Result a)
       else
         guard (qa = 1)
         let .isNat inst n pa := ra | failure
-        haveI' : $n =Q nat_lit 1 := ⟨⟩
+        have : $n =Q nat_lit 1 := ⟨⟩
         assumeInstancesCommute
         return .isNat inst n q(isNat_inv_one $pa)
     else
       let .isNat inst n pa := ra | failure
-      haveI' : $n =Q nat_lit 0 := ⟨⟩
+      have : $n =Q nat_lit 0 := ⟨⟩
       assumeInstancesCommute
       return .isNat inst n q(isNat_inv_zero $pa)
   else
@@ -194,7 +194,7 @@ def Result.inv {u : Level} {α : Q(Type u)} {a : Q($α)} (ra : Result a)
     else
       guard (qa = -1)
       let .isNegNat inst n pa := ra | failure
-      haveI' : $n =Q nat_lit 1 := ⟨⟩
+      have : $n =Q nat_lit 1 := ⟨⟩
       assumeInstancesCommute
       return .isNegNat inst n q(isInt_inv_neg_one $pa)
 
@@ -205,7 +205,7 @@ such that `norm_num` successfully recognises `a`. -/
   let ra ← derive a
   let dsα ← inferDivisionSemiring α
   guard <| ← withNewMCtxDepth <| isDefEq f q(Inv.inv (α := $α))
-  haveI' : $e =Q $a⁻¹ := ⟨⟩
+  have : $e =Q $a⁻¹ := ⟨⟩
   assumeInstancesCommute
   ra.inv q($dsα) (← inferCharZeroOfDivisionSemiring? dsα)
 

--- a/Mathlib/Tactic/NormNum/LegendreSymbol.lean
+++ b/Mathlib/Tactic/NormNum/LegendreSymbol.lean
@@ -372,9 +372,9 @@ def evalJacobiSym : NormNumExt where eval {u α} e := do
     let .app (.app _ (a : Q(ℤ))) (b : Q(ℕ)) ← Meta.whnfR e | failure
     let ⟨ea, pa⟩ ← deriveInt a _
     let ⟨eb, pb⟩ ← deriveNat b _
-    haveI' : u =QL 0 := ⟨⟩ haveI' : $α =Q ℤ := ⟨⟩
+    have : u =QL 0 := ⟨⟩ have : $α =Q ℤ := ⟨⟩
     have ⟨er, pr⟩ := proveJacobiSym ea eb
-    haveI' : $e =Q jacobiSym $a $b := ⟨⟩
+    have : $e =Q jacobiSym $a $b := ⟨⟩
     return .isInt _ er er.intLit! q(isInt_jacobiSym $pa $pb $pr)
 
 /-- This is the `norm_num` plug-in that evaluates Jacobi symbols on natural numbers. -/
@@ -383,9 +383,9 @@ def evalJacobiSymNat : NormNumExt where eval {u α} e := do
     let .app (.app _ (a : Q(ℕ))) (b : Q(ℕ)) ← Meta.whnfR e | failure
     let ⟨ea, pa⟩ ← deriveNat a _
     let ⟨eb, pb⟩ ← deriveNat b _
-    haveI' : u =QL 0 := ⟨⟩ haveI' : $α =Q ℤ := ⟨⟩
+    have : u =QL 0 := ⟨⟩ have : $α =Q ℤ := ⟨⟩
     have ⟨er, pr⟩ := proveJacobiSymNat ea eb
-    haveI' : $e =Q jacobiSymNat $a $b := ⟨⟩
+    have : $e =Q jacobiSymNat $a $b := ⟨⟩
     return .isInt _ er er.intLit!  q(isInt_jacobiSymNat $pa $pb $pr)
 
 /-- This is the `norm_num` plug-in that evaluates Legendre symbols. -/
@@ -395,9 +395,9 @@ def evalLegendreSym : NormNumExt where eval {u α} e := do
       failure
     let ⟨ea, pa⟩ ← deriveInt a _
     let ⟨ep, pp⟩ ← deriveNat p _
-    haveI' : u =QL 0 := ⟨⟩ haveI' : $α =Q ℤ := ⟨⟩
+    have : u =QL 0 := ⟨⟩ have : $α =Q ℤ := ⟨⟩
     have ⟨er, pr⟩ := proveJacobiSym ea ep
-    haveI' : $e =Q legendreSym $p $a := ⟨⟩
+    have : $e =Q legendreSym $p $a := ⟨⟩
     return .isInt _ er er.intLit!
       q(LegendreSym.to_jacobiSym $p $fp $a $er (isInt_jacobiSym $pa $pp $pr))
 

--- a/Mathlib/Tactic/NormNum/OfScientific.lean
+++ b/Mathlib/Tactic/NormNum/OfScientific.lean
@@ -48,7 +48,7 @@ to rat casts if the scientific notation is inherited from the one for rationals.
   let dα ← inferDivisionRing α
   guard <|← withNewMCtxDepth <| isDefEq f q(OfScientific.ofScientific (α := $α))
   assumeInstancesCommute
-  haveI' : $e =Q OfScientific.ofScientific $m $b $exp := ⟨⟩
+  have : $e =Q OfScientific.ofScientific $m $b $exp := ⟨⟩
   match b with
   | ~q(true) =>
     let rme ← derive (q(mkRat $m (10 ^ $exp)) : Q($α))

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -39,7 +39,7 @@ lemma isNat_ordinalMul.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
 def evalOrdinalMul : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) * ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
@@ -123,7 +123,7 @@ lemma isNat_ordinalSub.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
 def evalOrdinalSub : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) - ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
@@ -147,7 +147,7 @@ lemma isNat_ordinalDiv.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
 def evalOrdinalDiv : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) / ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
@@ -171,7 +171,7 @@ lemma isNat_ordinalMod.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
 def evalOrdinalMod : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) % ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
@@ -191,7 +191,7 @@ lemma isNat_ordinalOPow.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
 def evalOrdinalOPow : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) ^ ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
@@ -215,7 +215,7 @@ lemma isNat_ordinalNPow.{u} : ∀ {a : Ordinal.{u}} {b an bn rn : ℕ},
 def evalOrdinalNPow : NormNumExt where
   eval {u α} e := do
     let some u' := u.dec | throwError "level is not succ"
-    haveI' : u =QL u' + 1 := ⟨⟩
+    have : u =QL u' + 1 := ⟨⟩
     match α, e with
     | ~q(Ordinal.{u'}), ~q(($a : Ordinal) ^ ($b : ℕ)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -183,8 +183,8 @@ theorem isNNRat_pow {α} [Semiring α] {f : α → ℕ → α} {a : α} {an cn :
 def evalPow.core {u : Level} {α : Q(Type u)} (e : Q(«$α»)) (f : Q(«$α» → ℕ → «$α»)) (a : Q(«$α»))
     (b nb : Q(ℕ)) (pb : Q(IsNat «$b» «$nb»)) (sα : Q(Semiring «$α»)) (ra : Result a) :
     OptionT CoreM (Result e) := do
-  haveI' : $e =Q $a ^ $b := ⟨⟩
-  haveI' : $f =Q HPow.hPow := ⟨⟩
+  have : $e =Q $a ^ $b := ⟨⟩
+  have : $f =Q HPow.hPow := ⟨⟩
   match ra with
   | .isBool .. => failure
   | .isNat sα na pa =>
@@ -218,8 +218,8 @@ def evalPow : NormNumExt where eval {u α} e := do
   let sα ← inferSemiring α
   let ra ← derive a
   guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
-  haveI' : $e =Q $a ^ $b := ⟨⟩
-  haveI' : $f =Q HPow.hPow := ⟨⟩
+  have : $e =Q $a ^ $b := ⟨⟩
+  have : $f =Q HPow.hPow := ⟨⟩
   let .some r ←
     liftM <| OptionT.run (evalPow.core q($e) q($f) q($a) q($b) q($nb) q($pb) q($sα) ra) | failure
   return r

--- a/Mathlib/Tactic/NormNum/Prime.lean
+++ b/Mathlib/Tactic/NormNum/Prime.lean
@@ -186,8 +186,8 @@ theorem isNat_not_prime {n n' : ℕ} (h : IsNat n n') : ¬n'.Prime → ¬n.Prime
   -- to compute it, which is a lot quicker
   let rec core : MetaM (Result q(Nat.Prime $n)) := do
     match n' with
-    | 0 => haveI' : $nn =Q 0 := ⟨⟩; return .isFalse q(isNat_prime_0 $pn)
-    | 1 => haveI' : $nn =Q 1 := ⟨⟩; return .isFalse q(isNat_prime_1 $pn)
+    | 0 => have : $nn =Q 0 := ⟨⟩; return .isFalse q(isNat_prime_0 $pn)
+    | 1 => have : $nn =Q 1 := ⟨⟩; return .isFalse q(isNat_prime_1 $pn)
     | _ =>
       let d := n'.minFac
       if d < n' then

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -61,7 +61,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
 @[positivity ite _ _ _] def evalIte : PositivityExt where eval {u α} zα pα e := do
   let .app (.app (.app (.app f (p : Q(Prop))) (_ : Q(Decidable $p))) (a : Q($α))) (b : Q($α))
     ← whnfR e | throwError "not ite"
-  haveI' : $e =Q ite $p $a $b := ⟨⟩
+  have : $e =Q ite $p $a $b := ⟨⟩
   let ra ← core zα pα a; let rb ← core zα pα b
   guard <|← withDefault <| withNewMCtxDepth <| isDefEq f q(ite (α := $α))
   match ra, rb with
@@ -311,23 +311,23 @@ meta def evalPow : PositivityExt where eval {u α} zα pα e := do
     let some n := (b.getRevArg! 1).rawNatLit? | throwError "not a ^ n where n is a literal"
     guard (n % 2 = 0)
     have m : Q(ℕ) := mkRawNatLit (n / 2)
-    haveI' : $b =Q 2 * $m := ⟨⟩
+    have : $b =Q 2 * $m := ⟨⟩
     let _a ← synthInstanceQ q(Ring $α)
     let _a ← synthInstanceQ q(LinearOrder $α)
     let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
     assumeInstancesCommute
-    haveI' : $e =Q $a ^ $b := ⟨⟩
+    have : $e =Q $a ^ $b := ⟨⟩
     pure (.nonnegative q((even_two_mul $m).pow_nonneg $a))
   orElse result do
     let ra ← core zα pα a
     let ofNonneg (pa : Q(0 ≤ $a)) (_rα : Q(Semiring $α)) (_oα : Q(IsOrderedRing $α)) :
         MetaM (Strictness zα pα e) := do
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       assumeInstancesCommute
       pure (.nonnegative q(pow_nonneg $pa $b))
     let ofNonzero (pa : Q($a ≠ 0)) (_rα : Q(Semiring $α)) (_oα : Q(IsOrderedRing $α)) :
         MetaM (Strictness zα pα e) := do
-      haveI' : $e =Q $a ^ $b := ⟨⟩
+      have : $e =Q $a ^ $b := ⟨⟩
       assumeInstancesCommute
       let _a ← synthInstanceQ q(NoZeroDivisors $α)
       pure (.nonzero q(pow_ne_zero $b $pa))
@@ -337,7 +337,7 @@ meta def evalPow : PositivityExt where eval {u α} zα pα e := do
         let _a ← synthInstanceQ q(Semiring $α)
         let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
         assumeInstancesCommute
-        haveI' : $e =Q $a ^ $b := ⟨⟩
+        have : $e =Q $a ^ $b := ⟨⟩
         pure (.positive q(pow_pos $pa $b))
       catch e : Exception =>
         trace[Tactic.positivity.failure] "{e.toMessageData}"

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -42,7 +42,7 @@ Example:
 @[positivity ite _ _ _] def evalIte : PositivityExt where eval {u α} zα pα e := do
   let .app (.app (.app (.app f (p : Q(Prop))) (_ : Q(Decidable $p))) (a : Q($α))) (b : Q($α))
     ← withReducible (whnf e) | throwError "not ite"
-  haveI' : $e =Q ite $p $a $b := ⟨⟩
+  have : $e =Q ite $p $a $b := ⟨⟩
   guard <| ← withDefault <| withNewMCtxDepth <| isDefEq f q(ite (α := $α))
   let ra ← core zα pα a; let rb ← core zα pα b
   ...
@@ -245,7 +245,7 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
         let _a ← synthInstanceQ q(Nontrivial $α)
         assumeInstancesCommute
         have p : Q(NormNum.IsNat $e $lit) := p
-        haveI' p' : Nat.ble 1 $lit =Q true := ⟨⟩
+        have p' : Nat.ble 1 $lit =Q true := ⟨⟩
         pure (.positive q(pos_of_isNat (A := $α) $p $p'))
       catch e : Exception =>
         trace[Tactic.positivity.failure] "{e.toMessageData}"
@@ -256,7 +256,7 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
         let _a ← synthInstanceQ q(NeZero (1 : $α))
         assumeInstancesCommute
         have p : Q(NormNum.IsNat $e $lit) := p
-        haveI' p' : Nat.ble 1 $lit =Q true := ⟨⟩
+        have p' : Nat.ble 1 $lit =Q true := ⟨⟩
         pure (.positive q(pos_of_isNat' (A := $α) $p $p'))
     else
       -- NB. The `try` branch is actually a special case of the `catch` branch,
@@ -284,7 +284,7 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
     let _a ← synthInstanceQ q(IsStrictOrderedRing $α)
     assumeInstancesCommute
     have p : Q(NormNum.IsInt $e (Int.negOfNat $lit)) := p
-    haveI' p' : Nat.ble 1 $lit =Q true := ⟨⟩
+    have p' : Nat.ble 1 $lit =Q true := ⟨⟩
     pure (.nonzero q(nz_of_isNegNat $p $p'))
   | .isNNRat _i q n d p =>
     let _a ← synthInstanceQ q(Semiring $α)
@@ -293,10 +293,10 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
     assumeInstancesCommute
     have p : Q(NormNum.IsNNRat $e $n $d) := p
     if 0 < q then
-      haveI' w : decide (0 < $n) =Q true := ⟨⟩
+      have w : decide (0 < $n) =Q true := ⟨⟩
       pure (.positive q(pos_of_isNNRat $p $w))
     else -- should not be reachable, but just in case
-      haveI' w : decide ($n = 0) =Q true := ⟨⟩
+      have w : decide ($n = 0) =Q true := ⟨⟩
       pure (.nonnegative q(nonneg_of_isNNRat $p $w))
   | .isNegNNRat _i q n d p =>
     let _a ← synthInstanceQ q(Ring $α)
@@ -305,10 +305,10 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
     assumeInstancesCommute
     have p : Q(NormNum.IsRat $e (.negOfNat $n) $d) := p
     if q < 0 then
-      haveI' w : decide (Int.negOfNat $n < 0) =Q true := ⟨⟩
+      have w : decide (Int.negOfNat $n < 0) =Q true := ⟨⟩
       pure (.nonzero q(nz_of_isRat $p $w))
     else -- should not be reachable, but just in case
-      haveI' w : decide (Int.negOfNat $n = 0) =Q true := ⟨⟩
+      have w : decide (Int.negOfNat $n = 0) =Q true := ⟨⟩
       pure (.nonnegative q(nonneg_of_isRat $p $w))
 
 /-- Attempts to prove that `e ≥ 0` using `zero_le` in a `CanonicallyOrderedAdd` monoid. -/

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -81,8 +81,8 @@ mutual
     let .isNat sα na pa ← normIntNumeral' n n' pn a _ instCharP | failure
     let ⟨nb, pb⟩ ← Mathlib.Meta.NormNum.deriveNat b q(Nat.instAddMonoidWithOne)
     guard <|← withNewMCtxDepth <| isDefEq f q(HPow.hPow (α := $α))
-    haveI' : $e =Q $a ^ $b := ⟨⟩
-    haveI' : $f =Q HPow.hPow := ⟨⟩
+    have : $e =Q $a ^ $b := ⟨⟩
+    have : $f =Q HPow.hPow := ⟨⟩
     have ⟨c, r⟩ := evalNatPowMod na nb n'
     assumeInstancesCommute
     return .isNat sα c q(CharP.isNat_pow (f := $f) $instCharP (.refl $f) $pa $pb $pn $r)


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
