### PR TITLE
chore(Algebra/DirectSum): workaround for `backward.inferInstanceAs`

### DIFF
--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -39,9 +39,6 @@ def DirectSum [∀ i, AddCommMonoid (β i)] : Type _ :=
   Π₀ i, β i
 deriving AddCommMonoid, Inhabited, DFunLike
 
-set_option backward.inferInstanceAs.wrap.data false in
-deriving instance CoeFun for DirectSum
-
 /-- `⨁ i, f i` is notation for `DirectSum _ f` and equals the direct sum of `fun i ↦ f i`.
 Taking the direct sum over multiple arguments is possible, e.g. `⨁ (i) (j), f i j`. -/
 scoped[DirectSum] notation3 "⨁ "(...)", "r:(scoped f => DirectSum _ f) => r
@@ -64,6 +61,12 @@ instance [DecidableEq ι] [∀ i, AddCommMonoid (β i)] [∀ i, DecidableEq (β 
 namespace DirectSum
 
 variable {ι}
+
+/-- Workaround to defeq problems: if we interpret a `DirectSum` as a `DFinsupp`, also transfer the
+`DFunLike` instance. -/
+@[simp]
+theorem funLike_eq [∀ i, AddCommMonoid (β i)] (x : ⨁ i, β i) :
+    DFunLike.coe (self := DFinsupp.instDFunLike) x = x := rfl
 
 /-- Coercion from a `DirectSum` to a pi type is an `AddMonoidHom`. -/
 def coeFnAddMonoidHom [∀ i, AddCommMonoid (β i)] : (⨁ i, β i) →+ (Π i, β i) where
@@ -211,13 +214,10 @@ section ToAddMonoid
 
 variable (φ : ∀ i, β i →+ γ) (ψ : (⨁ i, β i) →+ γ)
 
--- Porting note: The elaborator is struggling with `liftAddHom`. Passing it `β` explicitly helps.
--- This applies to roughly the remainder of the file.
-
 /-- `toAddMonoid φ` is the natural homomorphism from `⨁ i, β i` to `γ`
 induced by a family `φ` of homomorphisms `β i → γ`. -/
 def toAddMonoid : (⨁ i, β i) →+ γ :=
-  DFinsupp.liftAddHom (β := β) φ
+  DFinsupp.liftAddHom φ
 
 @[simp]
 theorem toAddMonoid_of (i) (x : β i) : toAddMonoid φ (of β i x) = φ i x :=
@@ -225,11 +225,8 @@ theorem toAddMonoid_of (i) (x : β i) : toAddMonoid φ (of β i x) = φ i x :=
 
 theorem toAddMonoid.unique (f : ⨁ i, β i) : ψ f = toAddMonoid (fun i => ψ.comp (of β i)) f := by
   congr
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` applies addHom_ext' here, which isn't what we want.
-  apply DFinsupp.addHom_ext'
-  intro
-  simp [toAddMonoid]
-  rfl
+  ext
+  simp
 
 lemma toAddMonoid_injective : Injective (toAddMonoid : (∀ i, β i →+ γ) → (⨁ i, β i) →+ γ) :=
   DFinsupp.liftAddHom.injective
@@ -406,8 +403,7 @@ variable {M S : Type*} [AddCommMonoid M] [SetLike S M] [AddSubmonoidClass S M]
 theorem support_subset [DecidableEq ι] [DecidableEq M] (A : ι → S) (x : DirectSum ι fun i => A i) :
     (Function.support fun i => (x i : M)) ⊆ ↑(DFinsupp.support x) := by
   intro m
-  simp only [Function.mem_support, Finset.mem_coe, DFinsupp.mem_support_toFun, not_imp_not,
-    ZeroMemClass.coe_eq_zero, imp_self]
+  simp
 
 theorem hasFiniteSupport (A : ι → S) (x : DirectSum ι fun i => A i) :
     (fun i => (x i : M)).HasFiniteSupport := by
@@ -458,6 +454,4 @@ set_option backward.isDefEq.respectTransparency false in
 and the corresponding finite product. -/
 def DirectSum.addEquivProd {ι : Type*} [Fintype ι] (G : ι → Type*) [(i : ι) → AddCommMonoid (G i)] :
     DirectSum ι G ≃+ ((i : ι) → G i) :=
-  ⟨DFinsupp.equivFunOnFintype, fun g h ↦ funext fun _ ↦ by
-    simp only [DFinsupp.equivFunOnFintype, Equiv.toFun_as_coe, Equiv.coe_fn_mk, add_apply,
-      Pi.add_apply]⟩
+  ⟨DFinsupp.equivFunOnFintype, fun g h ↦ funext fun _ ↦ by simp [DFinsupp.equivFunOnFintype]⟩

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -146,7 +146,8 @@ theorem coe_mul_apply [AddMonoid ι] [SetLike.GradedMonoid A]
     ((r * r') n : R) =
       ∑ ij ∈ r.support ×ˢ r'.support with ij.1 + ij.2 = n, (r ij.1 * r' ij.2 : R) := by
   rw [mul_eq_sum_support_ghas_mul, DFinsupp.finsetSum_apply, AddSubmonoidClass.coe_finsetSum]
-  simp_rw [coe_of_apply, apply_ite, ZeroMemClass.coe_zero, ← Finset.sum_filter, SetLike.coe_gMul]
+  simp_rw [funLike_eq, coe_of_apply, apply_ite, ZeroMemClass.coe_zero, ← Finset.sum_filter,
+    SetLike.coe_gMul]
 
 set_option backward.isDefEq.respectTransparency false in
 theorem coe_mul_apply_eq_dfinsuppSum [AddMonoid ι] [SetLike.GradedMonoid A]
@@ -184,7 +185,7 @@ theorem coe_of_mul_apply_aux [AddMonoid ι] [SetLike.GradedMonoid A] {i : ι} (r
     simp_rw [DFinsupp.sum, H, Finset.sum_ite_eq']
     split_ifs with h
     · rfl
-    rw [DFinsupp.notMem_support_iff.mp h, ZeroMemClass.coe_zero, mul_zero]
+    rw [← funLike_eq, DFinsupp.notMem_support_iff.mp h, ZeroMemClass.coe_zero, mul_zero]
 
 theorem coe_mul_of_apply_aux [AddMonoid ι] [SetLike.GradedMonoid A] (r : ⨁ i, A i) {i : ι}
     (r' : A i) {j n : ι} (H : ∀ x : ι, x + i = n ↔ x = j) :
@@ -198,7 +199,7 @@ theorem coe_mul_of_apply_aux [AddMonoid ι] [SetLike.GradedMonoid A] (r : ⨁ i,
     simp_rw [DFinsupp.sum, H, Finset.sum_ite_eq']
     split_ifs with h
     · rfl
-    rw [DFinsupp.notMem_support_iff.mp h, ZeroMemClass.coe_zero, zero_mul]
+    rw [← funLike_eq, DFinsupp.notMem_support_iff.mp h, ZeroMemClass.coe_zero, zero_mul]
 
 theorem coe_of_mul_apply_add [AddLeftCancelMonoid ι] [SetLike.GradedMonoid A] {i : ι} (r : A i)
     (r' : ⨁ i, A i) (j : ι) : ((of (fun i => A i) i r * r') (i + j) : R) = r * r' j :=

--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -298,7 +298,7 @@ theorem mul_eq_sum_support_ghas_mul [∀ (i : ι) (x : A i), Decidable (x ≠ 0)
     a * a' =
       ∑ ij ∈ DFinsupp.support a ×ˢ DFinsupp.support a',
         DirectSum.of _ _ (GradedMonoid.GMul.mul (a ij.fst) (a' ij.snd)) := by
-  simp only [mul_eq_dfinsuppSum, DFinsupp.sum, Finset.sum_product]
+  simp [mul_eq_dfinsuppSum, DFinsupp.sum, Finset.sum_product]
 
 end Semiring
 

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -48,13 +48,14 @@ instance : LieRingModule L (⨁ i, M i) where
   bracket x m := m.mapRange (fun _ m' => ⁅x, m'⁆) fun _ => lie_zero x
   add_lie x y m := by
     ext
-    simp only [mapRange_apply, add_apply, add_lie]
+    simp [← funLike_eq, mapRange_apply, add_apply, add_lie]
   lie_add x m n := by
     ext
-    simp only [mapRange_apply, add_apply, lie_add]
+    simp only [← funLike_eq, mapRange_apply, add_apply]
+    simp [lie_add]
   leibniz_lie x y m := by
     ext
-    simp only [mapRange_apply, lie_lie, add_apply, sub_add_cancel]
+    simp only [← funLike_eq, mapRange_apply, lie_lie, add_apply, sub_add_cancel]
 
 @[simp]
 theorem lie_module_bracket_apply (x : L) (m : ⨁ i, M i) (i : ι) : ⁅x, m⁆ i = ⁅x, m i⁆ :=
@@ -83,7 +84,7 @@ def lieModuleOf [DecidableEq ι] (j : ι) : M j →ₗ⁅R,L⁆ ⨁ i, M i :=
         -- The coercion in the goal is `DFunLike.coe (β := fun x ↦ Π₀ (i : ι), M i)`
         -- but the lemma is expecting `DFunLike.coe (β := fun x ↦ ⨁ (i : ι), M i)`
         erw [AddHom.coe_mk]
-        simp [h] }
+        simp [h, ← funLike_eq] }
 
 set_option backward.isDefEq.respectTransparency false in
 /-- The projection map onto one component, as a morphism of Lie modules. -/
@@ -106,16 +107,18 @@ instance lieRing : LieRing (⨁ i, L i) :=
     bracket := zipWith (fun _ => fun x y => ⁅x, y⁆) fun _ => lie_zero 0
     add_lie := fun x y z => by
       ext
-      simp only [zipWith_apply, add_apply, add_lie]
+      simp only [← funLike_eq, zipWith_apply, add_apply]
+      simp [add_lie]
     lie_add := fun x y z => by
       ext
-      simp only [zipWith_apply, add_apply, lie_add]
+      simp only [← funLike_eq, zipWith_apply, add_apply]
+      simp [lie_add]
     lie_self := fun x => by
       ext
-      simp only [zipWith_apply, lie_self, zero_apply]
+      simp only [← funLike_eq, zipWith_apply, lie_self, zero_apply]
     leibniz_lie := fun x y z => by
       ext
-      simp only [zipWith_apply, add_apply]
+      simp only [← funLike_eq, zipWith_apply, add_apply]
       apply leibniz_lie }
 
 @[simp]

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -210,7 +210,7 @@ theorem hahnCoeff_apply {x : seed.baseDomain} {f : Π₀ c, seed.stratum c}
     f.mapRange (fun c x ↦ (⟨⟨x.val, hxm x⟩, by simp⟩ : seed.stratum' c)) (by simp)
   have hf : f c = (seed.baseDomain.subtype.submoduleComap (seed.stratum c)) (f' c) := by
     apply Subtype.ext
-    simp [f']
+    simp [f', ← DirectSum.funLike_eq]
   have hx : x = (decompose seed.stratum').symm f' := by
     change x = f'.coeAddMonoidHom _
     apply Submodule.subtype_injective

--- a/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
@@ -322,7 +322,7 @@ noncomputable abbrev OrthogonalFamily.decomposition
       exact map_zero _
   right_inv x := by
     dsimp only
-    simp_rw [hV.projection_directSum_coeAddHom, DFinsupp.equivFunOnFintype_symm_coe]
+    simp_rw [hV.projection_directSum_coeAddHom, ← funLike_eq, DFinsupp.equivFunOnFintype_symm_coe]
 
 end OrthogonalFamily
 

--- a/Mathlib/Analysis/InnerProductSpace/Subspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Subspace.lean
@@ -113,8 +113,7 @@ theorem OrthogonalFamily.inner_right_dfinsupp
     _ = l.sum fun j => fun w => ite (i = j) ⟪V i v, V j w⟫ 0 :=
       (congr_arg l.sum <| funext fun _ => funext <| hV.eq_ite v)
     _ = ⟪v, l i⟫ := by
-      simp only [DFinsupp.sum, Finset.sum_ite_eq,
-        DFinsupp.mem_support_toFun]
+      simp only [DFinsupp.sum, DirectSum.funLike_eq, Finset.sum_ite_eq, DFinsupp.mem_support_toFun]
       split_ifs with h
       · simp only [LinearIsometry.inner_map_map]
       · simp only [of_not_not h, inner_zero_right]

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -498,7 +498,8 @@ theorem DirectSum.coeLinearMap_eq_finsum [DecidableEq M]
     (DirectSum.coeLinearMap fun i : M => weightedHomogeneousSubmodule R w i) x =
       finsum fun m => x m := by
   classical
-  rw [DirectSum.coeLinearMap_eq_dfinsuppSum, DFinsupp.sum, finsum_eq_sum_of_support_subset]
+  rw [DirectSum.coeLinearMap_eq_dfinsuppSum, ← funLike_eq, DFinsupp.sum,
+    finsum_eq_sum_of_support_subset]
   apply DirectSum.support_subset
 
 theorem weightedHomogeneousComponent_directSum [DecidableEq M]
@@ -508,7 +509,7 @@ theorem weightedHomogeneousComponent_directSum [DecidableEq M]
   classical
   rw [DirectSum.coeLinearMap_eq_dfinsuppSum, DFinsupp.sum, map_sum]
   convert @Finset.sum_eq_single M (MvPolynomial σ R) _ (DFinsupp.support x) _ m _ _
-  · rw [IsWeightedHomogeneous.weightedHomogeneousComponent_same (x m).prop]
+  · rw [funLike_eq, IsWeightedHomogeneous.weightedHomogeneousComponent_same (x m).prop]
   · intro n _ hmn
     exact IsWeightedHomogeneous.weightedHomogeneousComponent_ne m (x n).prop hmn.symm
   · rw [DFinsupp.notMem_support_iff]
@@ -643,12 +644,12 @@ def weightedDecomposition [DecidableEq M] :
     simp only [DFinsupp.mem_support_toFun, ne_eq, Set.Finite.mem_toFinset, Function.mem_support,
       not_iff_not]
     conv_lhs => rw [← Subtype.coe_inj]
-    rw [decompose'_apply, Submodule.coe_zero]
+    rw [DirectSum.funLike_eq, decompose'_apply, Submodule.coe_zero]
   right_inv x := by
     classical
     apply DFinsupp.ext
     intro m
-    rw [← Subtype.coe_inj, decompose'_apply]
+    rw [← Subtype.coe_inj, DirectSum.funLike_eq, decompose'_apply]
     exact weightedHomogeneousComponent_directSum R w x m
 
 

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -168,7 +168,7 @@ theorem exists_maximal_notMem_range_sigmaToPi_of_infinite :
   refine ⟨I, max, fun ⟨⟨i, p⟩, eq⟩ ↦ ?_⟩
   -- then I is not in the range of `sigmaToPi`
   have : ⇑(DFinsupp.single i 1) ∉ (sigmaToPi R ⟨i, p⟩).asIdeal := by
-    simpa using p.1.ne_top_iff_one.mp p.2.ne_top
+    simpa [← DirectSum.funLike_eq] using p.1.ne_top_iff_one.mp p.2.ne_top
   rw [eq] at this
   exact this (le ⟨.single i 1, rfl⟩)
 


### PR DESCRIPTION
This PR works around a `backward.inferInstanceAs` compatibility flag introduced by identifying `DirectSum` with `DFinsupp` in our definitions. We introduce a new dsimp lemma `funLike_eq` that transfers the `FunLike` instances, and now we can use `DirectSum`'s `FunLike` instance, instead of the custom `CoeFun` instance. I unsqueezed a few `simp`s, which all ran pretty much instant on my machine so it shouldn't cause much slowdown. Also we fix two porting notes.

This is not a great approach, but it seems the least painful for the short term. The alternative would be to strictly enforce the defeq barrier between `DirectSum` and `DFinsupp`, which would mean a substantial rewrite of this corner of Mathlib. We can't make `DirectSum` an `@[implicit_reducible]`, because we need different multiplication on it than `DFinsupp` has.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
