### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial/Module): workaround for backward.inferInstanceAs

### DIFF
--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -42,13 +42,16 @@ for the full discussion.
 def PolynomialModule (R M : Type*) [CommRing R] [AddCommGroup M] [Module R M] := ℕ →₀ M
 deriving Inhabited, FunLike, AddCommGroup
 
-set_option backward.inferInstanceAs.wrap.data false in
-deriving instance CoeFun for PolynomialModule
-
 variable (R : Type*) {M : Type*} [CommRing R] [AddCommGroup M] [Module R M] (I : Ideal R)
 variable {S : Type*} [CommSemiring S] [Algebra S R] [Module S M] [IsScalarTower S R M]
 
 namespace PolynomialModule
+
+/-- Workaround to defeq problems: if we interpret a `PolynomialModule` as a `Finsupp`, also transfer
+the `DFunLike` instance. -/
+@[simp]
+theorem funLike_eq (x : PolynomialModule R M) :
+    DFunLike.coe (self := Finsupp.instFunLike) x = x := rfl
 
 /-- This is required to have the `IsScalarTower S R M` instance to avoid diamonds. -/
 instance : Module S (PolynomialModule R M) :=
@@ -174,8 +177,8 @@ def equivPolynomialSelf : PolynomialModule R R ≃ₗ[R[X]] R[X] :=
       | add _ _ hp hq => rw [smul_add, map_add, map_add, mul_add, hp, hq]
       | single n a =>
         ext i
-        simp_rw [toFinsuppIso_symm_apply, coeff_ofFinsupp, coeff_mul, smul_single_apply,
-          smul_eq_mul, coeff_ofFinsupp, single_apply, mul_ite, mul_zero]
+        simp_rw [toFinsuppIso_symm_apply, coeff_ofFinsupp, coeff_mul, funLike_eq, smul_single_apply,
+          smul_eq_mul, coeff_ofFinsupp, funLike_eq, single_apply, mul_ite, mul_zero]
         split_ifs with hn
         · rw [Finset.sum_eq_single (i - n, n)]
           · simp only [ite_true]


### PR DESCRIPTION
This PR, like #38990, works around a `backward.inferInstanceAs` compatibility flag introduced by identifying `PolynomialModule` with `Finsupp` in our definitions. We introduce a new dsimp lemma `funLike_eq` that transfers the `FunLike` instances, and now we can use `PolynomialModule`'s `FunLike` instance, instead of the custom `CoeFun` instance.

This is not a great approach, but it seems the least painful for the short term. The alternative would be to strictly enforce the defeq barrier between `PolynomialModule` and `Finsupp`, which would mean a substantial rewrite of this corner of Mathlib. We can't make `PolynomialModule` an `@[implicit_reducible]`, because we need different multiplication on it than `Finsupp` has.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
