### PR TITLE
[Merged by Bors] - feat(CategoryTheory): horizontal composition of Guitart exact squares

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2715,6 +2715,7 @@ public import Mathlib.CategoryTheory.Groupoid.Grpd.Basic
 public import Mathlib.CategoryTheory.Groupoid.Subgroupoid
 public import Mathlib.CategoryTheory.Groupoid.VertexGroup
 public import Mathlib.CategoryTheory.GuitartExact.Basic
+public import Mathlib.CategoryTheory.GuitartExact.HorizontalComposition
 public import Mathlib.CategoryTheory.GuitartExact.KanExtension
 public import Mathlib.CategoryTheory.GuitartExact.Opposite
 public import Mathlib.CategoryTheory.GuitartExact.Over

--- a/Mathlib/CategoryTheory/GuitartExact/Basic.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Basic.lean
@@ -241,6 +241,14 @@ instance [hw : w.GuitartExact] {X₂ : C₂} (g : StructuredArrow (R.obj X₂) B
   rw [guitartExact_iff_isConnected_downwards] at hw
   apply hw
 
+lemma costructuredArrowRightwards_final_iff_of_iso {X₃ X₃' : C₃} (e : X₃ ≅ X₃') :
+    (w.costructuredArrowRightwards X₃).Final ↔
+      (w.costructuredArrowRightwards X₃').Final := by
+  rw [Functor.final_iff_comp_equivalence _ (CostructuredArrow.mapIso (B.mapIso e)).functor,
+    Functor.final_iff_equivalence_comp (CostructuredArrow.mapIso e).functor]
+  exact Functor.final_natIso_iff
+    (NatIso.ofComponents (fun _ ↦ CostructuredArrow.isoMk (Iso.refl _)))
+
 lemma guitartExact_iff_final :
     w.GuitartExact ↔ ∀ (X₃ : C₃), (w.costructuredArrowRightwards X₃).Final :=
   ⟨fun _ _ => ⟨fun _ => inferInstance⟩, fun _ => ⟨fun _ => inferInstance⟩⟩
@@ -249,6 +257,14 @@ instance [hw : w.GuitartExact] (X₃ : C₃) :
     (w.costructuredArrowRightwards X₃).Final := by
   rw [guitartExact_iff_final] at hw
   apply hw
+
+lemma structuredArrowDownwards_initial_iff_of_iso {X₂ X₂' : C₂} (e : X₂ ≅ X₂') :
+    (w.structuredArrowDownwards X₂).Initial ↔
+      (w.structuredArrowDownwards X₂').Initial := by
+  rw [Functor.initial_iff_comp_equivalence _ (StructuredArrow.mapIso (R.mapIso e)).functor,
+    Functor.initial_iff_equivalence_comp (StructuredArrow.mapIso e).functor]
+  exact Functor.initial_natIso_iff
+    (NatIso.ofComponents (fun _ ↦ StructuredArrow.isoMk (Iso.refl _)))
 
 lemma guitartExact_iff_initial :
     w.GuitartExact ↔ ∀ (X₂ : C₂), (w.structuredArrowDownwards X₂).Initial :=

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Joël Riou. All rights reserved.
+Copyright (c) 2026 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
@@ -85,7 +85,7 @@ def hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T�
 
 namespace GuitartExact
 
-instance hComp [hw : w.GuitartExact] [hw' : w'.GuitartExact] :
+instance hComp [w.GuitartExact] [w'.GuitartExact] :
     (w ≫ₕ w').GuitartExact := by
   rw [← guitartExact_op_iff]
   have : (w ≫ₕ w').op = w.op ≫ᵥ w'.op := by ext; simp

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -41,7 +41,7 @@ def whiskerHorizontal (α : T' ⟶ T) (β : B ⟶ B') :
 namespace GuitartExact
 
 /-- A 2-square stays Guitart exact if we replace the top and bottom functors
-by isomorphic functors. See also `whiskerVertical_iff`. -/
+by isomorphic functors. See also `whiskerHorizontal_iff`. -/
 lemma whiskerHorizontal [w.GuitartExact] (α : T ≅ T') (β : B ≅ B') :
     (w.whiskerHorizontal α.inv β.hom).GuitartExact := by
   rw [guitartExact_iff_final]

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -122,6 +122,16 @@ lemma of_hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ �
   rw [whiskerHorizontal_iff] at h
   exact of_hComp w w'
 
+lemma hComp_iff_of_essSurj [B₁.EssSurj] [w.GuitartExact] :
+    (w ≫ₕ w').GuitartExact ↔ w'.GuitartExact :=
+  ⟨fun _ ↦ of_hComp w w', fun _ ↦ inferInstance⟩
+
+lemma hComp'_iff_of_essSurj
+    {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T₂ ≅ T₁₂) (eB : B₁ ⋙ B₂ ≅ B₁₂)
+    [B₁.EssSurj] [w.GuitartExact] :
+    (w.hComp' w' eT eB).GuitartExact ↔ w'.GuitartExact :=
+  ⟨fun _ ↦ of_hComp' w w' eT eB, fun _ ↦ inferInstance⟩
+
 lemma hComp_iff_of_equivalences (eT : C₂ ≌ C₃) (eB : D₂ ≌ D₃)
     (w' : eT.functor ⋙ V₃ ≅ V₂ ⋙ eB.functor) :
     (w ≫ₕ w'.hom).GuitartExact ↔ w.GuitartExact := by

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.GuitartExact.Opposite
+
+/-!
+# Horizontal composition of Guitart exact squares
+
+In this file, we show that the horizontal composition of Guitart exact squares
+is Guitart exact.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+open Category
+
+variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category C₁] [Category C₂] [Category C₃]
+  [Category D₁] [Category D₂] [Category D₃]
+
+namespace TwoSquare
+
+section WhiskerHorizontal
+
+variable {T : C₁ ⥤ D₁} {L : C₁ ⥤ C₂} {R : D₁ ⥤ D₂} {B : C₂ ⥤ D₂} (w : TwoSquare T L R B)
+  {T' : C₁ ⥤ D₁} {B' : C₂ ⥤ D₂}
+
+/-- Given `w : TwoSquare T L R B`, one may obtain a 2-square `TwoSquare T' L R B'` if we
+provide natural transformations `α : T ⟶ T'` and `β : B' ⟶ B`. -/
+@[simps!]
+def whiskerHorizontal (α : T' ⟶ T) (β : B ⟶ B') :
+    TwoSquare T' L R B' :=
+  (w.whiskerTop α).whiskerBottom β
+
+namespace GuitartExact
+
+/-- A 2-square stays Guitart exact if we replace the top and bottom functors
+by isomorphic functors. See also `whiskerVertical_iff`. -/
+lemma whiskerHorizontal [w.GuitartExact] (α : T ≅ T') (β : B ≅ B') :
+    (w.whiskerHorizontal α.inv β.hom).GuitartExact := by
+  rw [guitartExact_iff_final]
+  intro X₂
+  let e : costructuredArrowRightwards (w.whiskerHorizontal α.inv β.hom) X₂ ≅
+      w.costructuredArrowRightwards X₂ ⋙ (CostructuredArrow.mapIso (β.app X₂)).functor :=
+    NatIso.ofComponents (fun f ↦ CostructuredArrow.isoMk (α.symm.app f.left))
+  rw [Functor.final_natIso_iff e]
+  infer_instance
+
+/-- A 2-square is Guitart exact iff it is so after replacing the top and bottom functors by
+isomorphic functors. -/
+@[simp]
+lemma whiskerHorizontal_iff (α : T ≅ T') (β : B ≅ B') :
+    (w.whiskerHorizontal α.inv β.hom).GuitartExact ↔ w.GuitartExact := by
+  rw [← guitartExact_op_iff, ← w.guitartExact_op_iff,
+    ← whiskerVertical_iff w.op (NatIso.op α.symm) (NatIso.op β.symm)]
+  rfl
+
+instance [w.GuitartExact] (α : T' ⟶ T) (β : B ⟶ B')
+    [IsIso α] [IsIso β] : (w.whiskerHorizontal α β).GuitartExact :=
+  whiskerHorizontal w (asIso α).symm (asIso β)
+
+end GuitartExact
+
+end WhiskerHorizontal
+
+section HorizontalComposition
+
+variable {V₁ : C₁ ⥤ D₁} {T₁ : C₁ ⥤ C₂} {B₁ : D₁ ⥤ D₂} {V₂ : C₂ ⥤ D₂}
+  (w : TwoSquare T₁ V₁ V₂ B₁)
+  {T₂ : C₂ ⥤ C₃} {B₂ : D₂ ⥤ D₃} {V₃ : C₃ ⥤ D₃}
+  (w' : TwoSquare T₂ V₂ V₃ B₂)
+
+/-- The horizontal composition of 2-squares. (Variant where we allow the replacement of
+the horizontal compositions by isomorphic functors.) -/
+@[simps!]
+def hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T₂ ≅ T₁₂) (eB : B₁ ⋙ B₂ ≅ B₁₂) :
+    TwoSquare T₁₂ V₁ V₃ B₁₂ :=
+  (w ≫ₕ w').whiskerHorizontal eT.inv eB.hom
+
+namespace GuitartExact
+
+instance hComp [hw : w.GuitartExact] [hw' : w'.GuitartExact] :
+    (w ≫ₕ w').GuitartExact := by
+  rw [← guitartExact_op_iff]
+  have : (w ≫ₕ w').op = w.op ≫ᵥ w'.op := by ext; simp
+  rw [this]
+  exact inferInstanceAs (w.op ≫ᵥ w'.op).GuitartExact
+
+instance hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T₂ ≅ T₁₂) (eB : B₁ ⋙ B₂ ≅ B₁₂)
+    [w.GuitartExact] [w'.GuitartExact] :
+    (w.hComp' w' eT eB).GuitartExact := by
+  dsimp only [TwoSquare.hComp']
+  infer_instance
+
+/-- The canonical isomorphism between
+`w.costructuredArrowRightwards Y₁ ⋙ w'.costructuredArrowRightwards (B₁.obj Y₁)` and
+`(w ≫ₕ w').costructuredArrowRightwards Y₁`. -/
+def costructuredArrowRightwardsComp (Y₁ : D₁) :
+    w.costructuredArrowRightwards Y₁ ⋙ w'.costructuredArrowRightwards (B₁.obj Y₁) ≅
+      (w ≫ₕ w').costructuredArrowRightwards Y₁ :=
+  NatIso.ofComponents (fun _ => CostructuredArrow.isoMk (Iso.refl _))
+
+set_option backward.isDefEq.respectTransparency false in
+lemma of_hComp [B₁.EssSurj] [w.GuitartExact] [(w ≫ₕ w').GuitartExact] :
+    w'.GuitartExact := by
+  rw [guitartExact_iff_final]
+  intro Y₂
+  rw [costructuredArrowRightwards_final_iff_of_iso _ (B₁.objObjPreimageIso Y₂).symm]
+  have := Functor.final_of_natIso (costructuredArrowRightwardsComp w w' (B₁.objPreimage Y₂)).symm
+  exact Functor.final_of_final_comp (w.costructuredArrowRightwards (B₁.objPreimage Y₂)) _
+
+lemma of_hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T₂ ≅ T₁₂) (eB : B₁ ⋙ B₂ ≅ B₁₂)
+    [B₁.EssSurj] [w.GuitartExact] [h : (w.hComp' w' eT eB).GuitartExact] :
+    w'.GuitartExact := by
+  dsimp [TwoSquare.hComp'] at h
+  rw [whiskerHorizontal_iff] at h
+  exact of_hComp w w'
+
+def hComp_iff_of_equivalences (eT : C₂ ≌ C₃) (eB : D₂ ≌ D₃)
+    (w' : eT.functor ⋙ V₃ ≅ V₂ ⋙ eB.functor) :
+    (w ≫ₕ w'.hom).GuitartExact ↔ w.GuitartExact := by
+  let w'' : V₂.op ⋙ eB.op.functor ≅ eT.op.functor ⋙ V₃.op := NatIso.op w'
+  have : (w ≫ₕ w'.hom).op = (w.op ≫ᵥ w''.hom) := by ext; simp [w'']
+  rw [← guitartExact_op_iff, ← guitartExact_op_iff w,
+    ← vComp_iff_of_equivalences _ _ _ w'', this]
+  rfl
+
+lemma hComp'_iff_of_equivalences (E : C₂ ≌ C₃) (E' : D₂ ≌ D₃)
+    (w' : E.functor ⋙ V₃ ≅ V₂ ⋙ E'.functor)
+    {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ E.functor ≅ T₁₂)
+    (eB : B₁ ⋙ E'.functor ≅ B₁₂) :
+    (w.hComp' w'.hom eT eB).GuitartExact ↔ w.GuitartExact := by
+  rw [← hComp_iff_of_equivalences w E E' w', TwoSquare.hComp', whiskerHorizontal_iff]
+
+end GuitartExact
+
+end HorizontalComposition
+
+end TwoSquare
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -122,7 +122,7 @@ lemma of_hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ �
   rw [whiskerHorizontal_iff] at h
   exact of_hComp w w'
 
-def hComp_iff_of_equivalences (eT : C₂ ≌ C₃) (eB : D₂ ≌ D₃)
+lemma hComp_iff_of_equivalences (eT : C₂ ≌ C₃) (eB : D₂ ≌ D₃)
     (w' : eT.functor ⋙ V₃ ≅ V₂ ⋙ eB.functor) :
     (w ≫ₕ w'.hom).GuitartExact ↔ w.GuitartExact := by
   let w'' : V₂.op ⋙ eB.op.functor ≅ eT.op.functor ⋙ V₃.op := NatIso.op w'

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -106,13 +106,14 @@ def costructuredArrowRightwardsComp (Y₁ : D₁) :
       (w ≫ₕ w').costructuredArrowRightwards Y₁ :=
   NatIso.ofComponents (fun _ => CostructuredArrow.isoMk (Iso.refl _))
 
-set_option backward.isDefEq.respectTransparency false in
 lemma of_hComp [B₁.EssSurj] [w.GuitartExact] [(w ≫ₕ w').GuitartExact] :
     w'.GuitartExact := by
   rw [guitartExact_iff_final]
   intro Y₂
   rw [costructuredArrowRightwards_final_iff_of_iso _ (B₁.objObjPreimageIso Y₂).symm]
-  have := Functor.final_of_natIso (costructuredArrowRightwardsComp w w' (B₁.objPreimage Y₂)).symm
+  have : (w.costructuredArrowRightwards (B₁.objPreimage Y₂) ⋙
+      w'.costructuredArrowRightwards (B₁.obj (B₁.objPreimage Y₂))).Final :=
+    (Functor.final_of_natIso (costructuredArrowRightwardsComp w w' _).symm :)
   exact Functor.final_of_final_comp (w.costructuredArrowRightwards (B₁.objPreimage Y₂)) _
 
 lemma of_hComp' {T₁₂ : C₁ ⥤ C₃} {B₁₂ : D₁ ⥤ D₃} (eT : T₁ ⋙ T₂ ≅ T₁₂) (eB : B₁ ⋙ B₂ ≅ B₁₂)

--- a/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/HorizontalComposition.lean
@@ -21,8 +21,8 @@ namespace CategoryTheory
 
 open Category
 
-variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category C₁] [Category C₂] [Category C₃]
-  [Category D₁] [Category D₂] [Category D₃]
+variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category* C₁] [Category* C₂] [Category* C₃]
+  [Category* D₁] [Category* D₂] [Category* D₃]
 
 namespace TwoSquare
 

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -119,6 +119,22 @@ instance vComp' [GuitartExact w] [GuitartExact w'] {L₁₂ : C₁ ⥤ C₃}
   infer_instance
 
 set_option backward.isDefEq.respectTransparency false in
+lemma of_vComp [R₁.EssSurj] [w.GuitartExact] [(w ≫ᵥ w').GuitartExact] :
+    w'.GuitartExact := by
+  rw [guitartExact_iff_initial]
+  intro Y₂
+  rw [structuredArrowDownwards_initial_iff_of_iso _ (R₁.objObjPreimageIso Y₂).symm]
+  have := Functor.initial_of_natIso (structuredArrowDownwardsComp w w' (R₁.objPreimage Y₂)).symm
+  exact Functor.initial_of_initial_comp (w.structuredArrowDownwards (R₁.objPreimage Y₂)) _
+
+lemma of_vComp' {L₁₂ : C₁ ⥤ C₃} {R₁₂ : D₁ ⥤ D₃} (eL : L₁ ⋙ L₂ ≅ L₁₂) (eR : R₁ ⋙ R₂ ≅ R₁₂)
+    [R₁.EssSurj] [w.GuitartExact] [h : (w.vComp' w' eL eR).GuitartExact] :
+    w'.GuitartExact := by
+  dsimp [TwoSquare.vComp'] at h
+  rw [whiskerVertical_iff] at h
+  exact of_vComp w w'
+
+set_option backward.isDefEq.respectTransparency false in
 lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     (w' : H₂ ⋙ eR.functor ≅ eL.functor ⋙ H₃) :
     (w ≫ᵥ w'.hom).GuitartExact ↔ w.GuitartExact := by

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -134,6 +134,16 @@ lemma of_vComp' {L₁₂ : C₁ ⥤ C₃} {R₁₂ : D₁ ⥤ D₃} (eL : L₁ �
   rw [whiskerVertical_iff] at h
   exact of_vComp w w'
 
+lemma vComp_iff_of_essSurj [R₁.EssSurj] [w.GuitartExact] :
+    (w ≫ᵥ w').GuitartExact ↔ w'.GuitartExact :=
+  ⟨fun _ ↦ of_vComp w w', fun _ ↦ inferInstance⟩
+
+lemma vComp'_iff_of_essSurj
+    {L₁₂ : C₁ ⥤ C₃} {R₁₂ : D₁ ⥤ D₃} (eL : L₁ ⋙ L₂ ≅ L₁₂) (eR : R₁ ⋙ R₂ ≅ R₁₂)
+    [R₁.EssSurj] [w.GuitartExact] :
+    (w.vComp' w' eL eR).GuitartExact ↔ w'.GuitartExact :=
+  ⟨fun _ ↦ of_vComp' w w' eL eR, fun _ ↦ inferInstance⟩
+
 set_option backward.isDefEq.respectTransparency false in
 lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     (w' : H₂ ⋙ eR.functor ≅ eL.functor ⋙ H₃) :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
