### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Pow/Continuity): add Filter.Tendsto.rpow_const_nhds_zero

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -247,6 +247,11 @@ theorem Filter.Tendsto.rpow_const {l : Filter α} {f : α → ℝ} {x p : ℝ} (
   if h0 : 0 = p then h0 ▸ by simp [tendsto_const_nhds]
   else hf.rpow tendsto_const_nhds (h.imp id fun h' => h'.lt_of_ne h0)
 
+theorem Filter.Tendsto.rpow_const_nhds_zero {l : Filter α} {f : α → ℝ} {p : ℝ}
+    (hf : Tendsto f l (𝓝 0)) (hp : 0 < p) :
+    Tendsto (fun t ↦ f t ^ p) l (𝓝 0) :=
+  Real.zero_rpow hp.ne' ▸ hf.rpow_const (.inr hp.le)
+
 variable [TopologicalSpace α] {f g : α → ℝ} {s : Set α} {x : α} {p : ℝ}
 
 nonrec theorem ContinuousAt.rpow (hf : ContinuousAt f x) (hg : ContinuousAt g x)

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -215,9 +215,8 @@ lemma term_tsum_of_lt {s : ℝ} (hs : 1 < s) :
     · exact_mod_cast (summable_nat_add_iff 1).mpr (summable_one_div_nat_rpow.mpr hs)
     · apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
       · change Tendsto (fun n : ℕ ↦ (1 / ↑(n + 1) : ℝ) ^ (s - 1)) ..
-        rw [show 𝓝 (0 : ℝ) = 𝓝 (0 ^ (s - 1)) by rw [zero_rpow]; linarith]
-        refine Tendsto.rpow_const ?_ (Or.inr <| by linarith)
-        exact (tendsto_const_div_atTop_nhds_zero_nat _).comp (tendsto_add_atTop_nat _)
+        exact ((tendsto_const_div_atTop_nhds_zero_nat _).comp
+          (tendsto_add_atTop_nat _)).rpow_const_nhds_zero (by linarith)
       · intro n
         positivity
       · intro n


### PR DESCRIPTION
Specialises `Filter.Tendsto.rpow_const` to base `→ 0`. The strict `0 < p` (rather than `0 ≤ p` from the parent) is needed to identify `0 ^ p` with `0`. Refactors the one in-tree call site (`ZetaAsymp.term_tsum_of_lt`).

Co-authored-by: Sebastian Pokutta <23001135+pokutta@users.noreply.github.com>

---

This came out of a Frank–Wolfe convergence formalisation, where gap rates of the form `f t ^ p → 0` recur and manually discharging the disjunction together with the `0 ^ p = 0` rewrite every time is a bit of a nuisance. A sweep over mathlib turned up `ZetaAsymp.term_tsum_of_lt` as the one place the same pattern already appears in the library.

I am not 100% sure on what the convention of adding these single-line specializations is, but this specific case did seem worth adding to me.