### PR TITLE
feat(Analysis/DirichletEigenvalue): Dirichlet eigenvalues of a set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1932,6 +1932,7 @@ public import Mathlib.Analysis.Convex.TotallyBounded
 public import Mathlib.Analysis.Convex.Uniform
 public import Mathlib.Analysis.Convex.Visible
 public import Mathlib.Analysis.Convolution
+public import Mathlib.Analysis.DirichletEigenvalue
 public import Mathlib.Analysis.Distribution.AEEqOfIntegralContDiff
 public import Mathlib.Analysis.Distribution.ContDiffMapSupportedIn
 public import Mathlib.Analysis.Distribution.DerivNotation

--- a/Mathlib/Analysis/DirichletEigenvalue.lean
+++ b/Mathlib/Analysis/DirichletEigenvalue.lean
@@ -42,9 +42,14 @@ structure DirichletEigenfunction : Prop where
   vanishing : ∀ x ∈ frontier S, u x = 0
 
 /-- A Dirichlet eigenvalue of a set `S` is a value of `t` for which there exists a nonzero
-real-valued function `u` satisfying `Δ u + λ u = 0` on `S` and `u = 0` on `∂S`. -/
+real-valued function `u` satisfying `Δ u + t u = 0` on `S` and `u = 0` on `∂S`. -/
 def dirichletEigenvalues : Set ℝ :=
-  { t | ∃ u : X → ℝ, DirichletEigenfunction S u t}
+  { t | ∃ u, DirichletEigenfunction S u t}
+
+variable {S t} in
+theorem mem_dirichletEigenvalues_iff :
+    t ∈ dirichletEigenvalues S ↔ ∃ u, DirichletEigenfunction S u t :=
+  .rfl
 
 theorem dirichletEigenvalues_empty : dirichletEigenvalues (∅ : Set X) = ∅ := by
   by_contra! h

--- a/Mathlib/Analysis/DirichletEigenvalue.lean
+++ b/Mathlib/Analysis/DirichletEigenvalue.lean
@@ -5,7 +5,7 @@ Authors: Thomas Browning
 -/
 module
 
-public import Mathlib
+public import Mathlib.Analysis.InnerProductSpace.Laplacian
 
 /-!
 # Dirichlet Eigenvalues
@@ -14,45 +14,39 @@ In this file we define Dirichlet eigenvalues.
 
 ## Main Definitions
 
-* `MeasureTheory.mlconvolution f g μ x = (f ⋆ₘₗ[μ] g) x = ∫⁻ y, (f y) * (g (y⁻¹ * x)) ∂μ`
-  is the multiplicative convolution of `f` and `g` w.r.t. the measure `μ`.
-* `MeasureTheory.lconvolution f g μ x = (f ⋆ₗ[μ] g) x = ∫⁻ y, (f y) * (g (-y + x)) ∂μ`
-  is the additive convolution of `f` and `g` w.r.t. the measure `μ`.
+* `DirichletEigenfunction`: A predicate stating that a function `u` is a Dirichlet eigenfunction.
+* `dirichletEigenvalues`: The set of Dirichlet eigenvalues of a set `S`.
+
+## TODO
+* Prove that Dirichlet eigenvalues are positive (requires a more general divergence theorem).
 -/
 
 @[expose] public section
 
 open scoped Laplacian
 
-variable {X E : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [Laplacian (X → ℝ) (X → ℝ)]
+variable {X E : Type*} [NormedAddCommGroup X] [InnerProductSpace ℝ X] [FiniteDimensional ℝ X]
   (S : Set X) (u : X → ℝ) (t : ℝ)
 
-/-- A real-valued function `u` is a Dirichlet eigenfunction on a set `S` if `u` is nonzero on `S`,
-satisfies `Δ u + t u = 0` on `S`, and vanishes on the boundary of `S`.
-
-[Automatically have smoothness on nonzero connected component, so get union?] -/
+/-- A real-valued function `u` is a Dirichlet eigenfunction on a set `S` if:
+1) `u` is not identically zero on `S`,
+2) `u` is continuous on the closure of `S`,
+3) `u` is twice continuously differentiable on the interior of `S`,
+4) `u` satisfies `Δ u + t u = 0` on the interior of `S`,
+5) `u` vanishes on the boundary of `S`. -/
 structure DirichletEigenfunction : Prop where
   nonzero : ∃ x ∈ S, u x ≠ 0
-  smooth : ContDiffOn ℝ 2 u S
+  continuous : ContinuousOn u (closure S)
+  smooth : ContDiffOn ℝ 2 u (interior S)
   eigenfunction : ∀ x ∈ interior S, Δ u x + t * u x = 0
   vanishing : ∀ x ∈ frontier S, u x = 0
 
-namespace DirichletEigenfunction
-
-theorem smooth (h : DirichletEigenfunction S u t) : False := by
-  sorry
-
-end DirichletEigenfunction
-
-
-/-- A Dirichlet eigenvalue of a set `S` is a value of `λ` for which there exists a nonzero
+/-- A Dirichlet eigenvalue of a set `S` is a value of `t` for which there exists a nonzero
 real-valued function `u` satisfying `Δ u + λ u = 0` on `S` and `u = 0` on `∂S`. -/
 def dirichletEigenvalues : Set ℝ :=
-  { t | ∃ u : X → ℝ, (∃ x ∈ S, u x ≠ 0) ∧ (∀ x ∈ S, Δ u + t • u = 0) ∧ ∀ x ∈ frontier S, u x = 0}
+  { t | ∃ u : X → ℝ, DirichletEigenfunction S u t}
 
 theorem dirichletEigenvalues_empty : dirichletEigenvalues (∅ : Set X) = ∅ := by
   by_contra! h
-  obtain ⟨t, u, ⟨x, ⟨⟩, hux⟩, huS, hu0⟩ := h
-
-theorem nonneg_of_mem_dirichletEigenvalues {t : ℝ} (ht : t ∈ dirichletEigenvalues S) : 0 ≤ t := by
-  sorry
+  obtain ⟨t, u, hu⟩ := h
+  obtain ⟨x, ⟨⟩, hux⟩ := hu.nonzero

--- a/Mathlib/Analysis/DirichletEigenvalue.lean
+++ b/Mathlib/Analysis/DirichletEigenvalue.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+module
+
+public import Mathlib
+
+/-!
+# Dirichlet Eigenvalues
+
+In this file we define Dirichlet eigenvalues.
+
+## Main Definitions
+
+* `MeasureTheory.mlconvolution f g μ x = (f ⋆ₘₗ[μ] g) x = ∫⁻ y, (f y) * (g (y⁻¹ * x)) ∂μ`
+  is the multiplicative convolution of `f` and `g` w.r.t. the measure `μ`.
+* `MeasureTheory.lconvolution f g μ x = (f ⋆ₗ[μ] g) x = ∫⁻ y, (f y) * (g (-y + x)) ∂μ`
+  is the additive convolution of `f` and `g` w.r.t. the measure `μ`.
+-/
+
+@[expose] public section
+
+open scoped Laplacian
+
+variable {X E : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [Laplacian (X → ℝ) (X → ℝ)]
+  (S : Set X) (u : X → ℝ) (t : ℝ)
+
+/-- A real-valued function `u` is a Dirichlet eigenfunction on a set `S` if `u` is nonzero on `S`,
+satisfies `Δ u + t u = 0` on `S`, and vanishes on the boundary of `S`.
+
+[Automatically have smoothness on nonzero connected component, so get union?] -/
+structure DirichletEigenfunction : Prop where
+  nonzero : ∃ x ∈ S, u x ≠ 0
+  smooth : ContDiffOn ℝ 2 u S
+  eigenfunction : ∀ x ∈ interior S, Δ u x + t * u x = 0
+  vanishing : ∀ x ∈ frontier S, u x = 0
+
+namespace DirichletEigenfunction
+
+theorem smooth (h : DirichletEigenfunction S u t) : False := by
+  sorry
+
+end DirichletEigenfunction
+
+
+/-- A Dirichlet eigenvalue of a set `S` is a value of `λ` for which there exists a nonzero
+real-valued function `u` satisfying `Δ u + λ u = 0` on `S` and `u = 0` on `∂S`. -/
+def dirichletEigenvalues : Set ℝ :=
+  { t | ∃ u : X → ℝ, (∃ x ∈ S, u x ≠ 0) ∧ (∀ x ∈ S, Δ u + t • u = 0) ∧ ∀ x ∈ frontier S, u x = 0}
+
+theorem dirichletEigenvalues_empty : dirichletEigenvalues (∅ : Set X) = ∅ := by
+  by_contra! h
+  obtain ⟨t, u, ⟨x, ⟨⟩, hux⟩, huS, hu0⟩ := h
+
+theorem nonneg_of_mem_dirichletEigenvalues {t : ℝ} (ht : t ∈ dirichletEigenvalues S) : 0 ≤ t := by
+  sorry


### PR DESCRIPTION
This PR defines the Dirichlet eigenvalues of a set (in the sense of "can you hear the shape of a drum").

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
