### PR TITLE
[Merged by Bors] - fix(NumberTheory/ADEInequality): capitalize `Admissible` in docstrings

### DIFF
--- a/Mathlib/NumberTheory/ADEInequality.lean
+++ b/Mathlib/NumberTheory/ADEInequality.lean
@@ -110,7 +110,7 @@ theorem sumInv_pqr (p q r : ℕ+) : sumInv {p, q, r} = (p : ℚ)⁻¹ + (q : ℚ
   simp only [sumInv, insert_eq_cons, add_assoc, map_cons, sum_cons,
     map_singleton, sum_singleton]
 
-/-- A multiset `pqr` of positive natural numbers is `admissible`
+/-- A multiset `pqr` of positive natural numbers is `Admissible`
 if it is equal to `A' q r`, or `D' r`, or one of `E6`, `E7`, or `E8`. -/
 def Admissible (pqr : Multiset ℕ+) : Prop :=
   (∃ q r, A' q r = pqr) ∨ (∃ r, D' r = pqr) ∨ E' 3 = pqr ∨ E' 4 = pqr ∨ E' 5 = pqr
@@ -222,7 +222,7 @@ theorem admissible_of_one_lt_sumInv {p q r : ℕ+} (H : 1 < sumInv {p, q, r}) :
 
 /-- A multiset `{p,q,r}` of positive natural numbers
 is a solution to `(p⁻¹ + q⁻¹ + r⁻¹ : ℚ) > 1` if and only if
-it is `admissible` which means it is one of:
+it is `Admissible` which means it is one of:
 
 * `A' q r := {1,q,r}`
 * `D' r := {2,2,r}`


### PR DESCRIPTION
The docstrings for `Admissible` and `admissible_iff` reference `admissible` (lowercase), but the actual definition is `Admissible` (capitalized). This fixes the case to match.

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>