### PR TITLE
[Merged by Bors] - fix(NumberTheory/ADEInequality): fix docstring to match definition name

### DIFF
--- a/Mathlib/NumberTheory/ADEInequality.lean
+++ b/Mathlib/NumberTheory/ADEInequality.lean
@@ -99,7 +99,7 @@ This solution is related to the Dynkin diagrams $E_8$. -/
 def E8 : Multiset ℕ+ :=
   E' 5
 
-/-- `sum_inv pqr` for a `pqr : Multiset ℕ+` is the sum of the inverses
+/-- `sumInv pqr` for a `pqr : Multiset ℕ+` is the sum of the inverses
 of the elements of `pqr`, as rational number.
 
 The intended argument is a multiset `{p,q,r}` of cardinality `3`. -/


### PR DESCRIPTION
The docstring for `sumInv` references `sum_inv` (Lean 3 snake_case), but the definition was renamed to `sumInv` during the port. This fixes the docstring to match.

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>