### PR TITLE
[Merged by Bors] - doc: fix Lean 3 namespace in DiophantineApproximation

### DIFF
--- a/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
@@ -55,7 +55,7 @@ in this file, whereas the other, `Real.exists_convs_eq_rat` defined in the file
 ## Implementation notes
 
 We use the namespace `Real` for the results on real numbers and `Rat` for the results
-on rational numbers. We introduce a secondary namespace `real.contfrac_legendre`
+on rational numbers. We introduce a secondary namespace `Real.ContfracLegendre`
 to separate off a definition and some technical auxiliary lemmas used in the proof
 of Legendre's Theorem. For remarks on the proof of Legendre's Theorem, see below.
 


### PR DESCRIPTION
The implementation notes section references the Lean 3 namespace \`real.contfrac_legendre\`, but this was renamed to \`Real.ContfracLegendre\` during the port. This fixes the reference.

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>