### PR TITLE
[Merged by Bors] - chore(Stoch): Fix namespaces

### DIFF
--- a/Mathlib/Probability/Kernel/Category/Stoch.lean
+++ b/Mathlib/Probability/Kernel/Category/Stoch.lean
@@ -28,7 +28,7 @@ The category of measurable spaces with Markov kernels is a Markov category.
 
 public section
 
-open CategoryTheory ProbabilityTheory MeasureTheory
+open CategoryTheory ProbabilityTheory Kernel
 
 open scoped MonoidalCategory SFinKer
 
@@ -42,14 +42,14 @@ instance : StochHom.IsStableUnderBraiding where
   comp_mem κ η hκ hη := by dsimp [StochHom]; infer_instance
   whiskerLeft X Y Z κ hκ := by dsimp [StochHom]; infer_instance
   whiskerRight κ hκ Y := by dsimp [StochHom]; infer_instance
-  associator_hom_mem X Y Z := Kernel.isMarkovKernel_deterministic <| MeasurableEquiv.measurable _
-  associator_inv_mem X Y Z := Kernel.isMarkovKernel_deterministic <| MeasurableEquiv.measurable _
-  leftUnitor_hom_mem X := Kernel.IsMarkovKernel.map Kernel.id (by fun_prop)
-  leftUnitor_inv_mem X := Kernel.IsMarkovKernel.map Kernel.id (by fun_prop)
-  rightUnitor_hom_mem X := Kernel.IsMarkovKernel.map Kernel.id (by fun_prop)
-  rightUnitor_inv_mem X := Kernel.IsMarkovKernel.map Kernel.id (by fun_prop)
-  braiding_hom_mem X Y := Kernel.instIsMarkovKernelProdSwap
-  braiding_inv_mem X Y := Kernel.instIsMarkovKernelProdSwap
+  associator_hom_mem X Y Z := isMarkovKernel_deterministic <| MeasurableEquiv.measurable _
+  associator_inv_mem X Y Z := isMarkovKernel_deterministic <| MeasurableEquiv.measurable _
+  leftUnitor_hom_mem X := IsMarkovKernel.map Kernel.id (by fun_prop)
+  leftUnitor_inv_mem X := IsMarkovKernel.map Kernel.id (by fun_prop)
+  rightUnitor_hom_mem X := IsMarkovKernel.map Kernel.id (by fun_prop)
+  rightUnitor_inv_mem X := IsMarkovKernel.map Kernel.id (by fun_prop)
+  braiding_hom_mem X Y := instIsMarkovKernelProdSwap
+  braiding_inv_mem X Y := instIsMarkovKernelProdSwap
 
 instance {X} : StochHom.IsStableUnderComonoid X where
   counit_mem := by dsimp [StochHom]; infer_instance


### PR DESCRIPTION
Fix namespaces in Stoch.lean.

See #37851.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
