### PR TITLE
feat: make showLinter detect tactics that assign metavariables

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -598,7 +598,7 @@ def showLinter : Linter where run := withSetOptionIn fun stx => do
         let (goal :: goals) := tac.goalsBefore | return
         let (goal' :: goals') := tac.goalsAfter | return
         if goals != goals' then return -- `show` didn't act on first goal -> can't replace with `change`
-        if goal == goal' then return -- same goal, no need to check
+        -- Even if `goal == goal'`, the tactic may have assigned metavariables.
         let diff ← ci.runCoreM do
           let before ← (do instantiateMVars (← goal.getType)).run' {} { mctx := tac.mctxBefore }
           let after ← (do instantiateMVars (← goal'.getType)).run' {} { mctx := tac.mctxAfter }


### PR DESCRIPTION
This PR removes a short-circuit in `showLinter` that suppressed the
linter whenever the syntactic goal was unchanged by a `show` tactic.
A `show` invocation can still have side-effects on the metavariable
context — tactic elaboration may assign metavariables while leaving
the goal type unchanged — so the existing `instantiateMVars`-based
diff check should run unconditionally. The fast path for the genuine
no-op case is preserved: if `before` and `after` types still match
after `instantiateMVars`, the linter doesn't fire.

This was discovered while adapting Mathlib to nightly-2026-05-03 in
https://github.com/leanprover-community/mathlib4-nightly-testing/pull/215
and is being extracted here so it can land independently of that bump.

🤖 Prepared with Claude Code