### PR TITLE
[Merged by Bors] - feat(Analysis): the trivial inner product space

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -600,10 +600,7 @@ def InnerProductSpace.ofCoreOfTopology [AddCommGroup F] [hF : Module 𝕜 F] [To
 structure HilbertSpace (𝕜 E : Type*) [RCLike 𝕜]
   [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
 
-end
-
 namespace PUnit
-variable {𝕜 : Type*} [RCLike 𝕜]
 
 instance : InnerProductSpace 𝕜 PUnit where
   inner _ _ := 0
@@ -615,3 +612,5 @@ instance : InnerProductSpace 𝕜 PUnit where
 @[simp] lemma inner_eq_zero (x y : PUnit) : inner 𝕜 x y = 0 := rfl
 
 end PUnit
+
+end

--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -601,3 +601,17 @@ structure HilbertSpace (𝕜 E : Type*) [RCLike 𝕜]
   [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
 
 end
+
+namespace PUnit
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+instance : InnerProductSpace 𝕜 PUnit where
+  inner _ _ := 0
+  norm_sq_eq_re_inner := by simp
+  conj_inner_symm := by simp
+  add_left := by simp
+  smul_left := by simp
+
+@[simp] lemma inner_eq_zero (x y : PUnit) : inner 𝕜 x y = 0 := rfl
+
+end PUnit


### PR DESCRIPTION
Provide the `InnerProductSpace 𝕜 PUnit` instance.

From MeanFourier


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
