### PR TITLE
[Merged by Bors] - chore: use `backticks` in the flexible linter error messages

### DIFF
--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -519,23 +519,23 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
     -- Emit warning and suggestion
     let msg := match stainStx.getKind with
       | ``Lean.Parser.Tactic.simp =>
-        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
-          Try 'simp?' and use the suggested 'simp only [...]'. \
+        m!"`{stainStr}` is a flexible tactic modifying `{d}`. \
+          Try `simp?` and use the suggested `simp only [...]`. \
           Alternatively, use `suffices` to explicitly state the simplified form."
       | ``Lean.Parser.Tactic.simpAll =>
-        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
-          Try 'simp_all?' and use the suggested 'simp_all only [...]'. \
+        m!"`{stainStr}` is a flexible tactic modifying `{d}`. \
+          Try `simp_all?` and use the suggested `simp_all only [...]`. \
           Alternatively, use `suffices` to explicitly state the simplified form."
       | `Aesop.Frontend.Parser.aesopTactic =>
-        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
-          Try 'aesop?' and use the suggested proof."
+        m!"`{stainStr}` is a flexible tactic modifying `{d}`. \
+          Try `aesop?` and use the suggested proof."
       | _ =>
-        m!"'{stainStr}' is a flexible tactic modifying '{d}'."
+        m!"'{stainStr}' is a flexible tactic modifying `{d}`."
     Linter.logLint linter.flexible stainStx msg
     if let some suggStx := suggestion? then
       liftCoreM <| Lean.Meta.Tactic.TryThis.addSuggestion stainStx
         { suggestion := .tsyntax (kind := `tactic) ⟨suggStx⟩ } (origSpan? := stainStx)
-    logInfoAt s m!"'{s}' uses '{d}'!"
+    logInfoAt s m!"`{s}` uses `{d}`!"
 
 initialize addLinter flexibleLinter
 

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -530,7 +530,7 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
         m!"`{stainStr}` is a flexible tactic modifying `{d}`. \
           Try `aesop?` and use the suggested proof."
       | _ =>
-        m!"'{stainStr}' is a flexible tactic modifying `{d}`."
+        m!"`{stainStr}` is a flexible tactic modifying `{d}`."
     Linter.logLint linter.flexible stainStx msg
     if let some suggStx := suggestion? then
       liftCoreM <| Lean.Meta.Tactic.TryThis.addSuggestion stainStx

--- a/MathlibTest/FlexibleLinter.lean
+++ b/MathlibTest/FlexibleLinter.lean
@@ -28,11 +28,11 @@ example : n = m := by
   simp [m]
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'exact h' uses 'h'!
+info: `exact h` uses `h`!
 -/
 #guard_msgs in
 example (h : 0 + 0 = 0) : True := by
@@ -40,14 +40,14 @@ example (h : 0 + 0 = 0) : True := by
   try exact h
 
 /--
-warning: 'simp_all' is a flexible tactic modifying '⊢'. Try 'simp_all?' and use the suggested 'simp_all only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp_all` is a flexible tactic modifying `⊢`. Try `simp_all?` and use the suggested `simp_all only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp_all only [Nat.add_zero]
 ---
-info: 'exact Nat.le_succ_of_le h' uses '⊢'!
+info: `exact Nat.le_succ_of_le h` uses `⊢`!
 -/
 #guard_msgs in
 example {a b : Nat} (h : a ≤ b) : a + 0 ≤ b + 1 := by
@@ -71,23 +71,23 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
 
 -- `induction` does not use the goal
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.add_zero]
 ---
-info: 'assumption' uses '⊢'!
+info: `assumption` uses `⊢`!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.add_zero]
 ---
-info: 'assumption' uses '⊢'!
+info: `assumption` uses `⊢`!
 -/
 #guard_msgs in
 example {a b : Nat} (h : a = b) : a + 0 = b := by
@@ -95,11 +95,11 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
   induction a <;> assumption
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'exact h' uses 'h'!
+info: `exact h` uses `h`!
 -/
 #guard_msgs in
 example (h : 0 = 0 ∨ 0 = 0) : True := by
@@ -110,23 +110,23 @@ example (h : 0 = 0 ∨ 0 = 0) : True := by
   · assumption --exact h
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one, and_self]
 ---
-info: 'on_goal 2 => · contradiction' uses '⊢'!
+info: `on_goal 2 => · contradiction` uses `⊢`!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one, and_self]
 ---
-info: 'contradiction' uses '⊢'!
+info: `contradiction` uses `⊢`!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -139,23 +139,23 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
 example {a : Nat} : a + 1 + 0 = 1 + a := by simp; all_goals lia
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one, and_self]
 ---
-info: 'contradiction' uses '⊢'!
+info: `contradiction` uses `⊢`!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one, and_self]
 ---
-info: 'contradiction' uses '⊢'!
+info: `contradiction` uses `⊢`!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -164,17 +164,17 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
   · contradiction
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h k` is a flexible tactic modifying `k`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
+info: `rw [← Classical.not_not (a := True)] at k` uses `k`!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h k` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: `rw [← Classical.not_not (a := True)] at h` uses `h`!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -194,14 +194,14 @@ example {a b : Nat} (h : ∀ c, c + a + b = a + c) : (0 + 2 + 1 + a + b) = a + 3
   simp_all
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.add_zero]
 ---
-info: 'exact h.symm' uses '⊢'!
+info: `exact h.symm` uses `⊢`!
 -/
 #guard_msgs in
 -- `congr` is allowed after `simp`, but "passes along the stain".
@@ -241,14 +241,14 @@ example {x y : Nat} : 0 + x + (y + x) = x + x + y := by
   lia
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one, and_self]
 ---
-info: 'contradiction' uses '⊢'!
+info: `contradiction` uses `⊢`!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -270,14 +270,14 @@ example (n : Nat) : n + 1 = 1 + n := by
     exact Nat.add_comm ..
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [not_true_eq_false, not_false_eq_true] at h
 ---
-info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: `rw [← Classical.not_not (a := True)] at h` uses `h`!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -290,17 +290,17 @@ example {h : 0 = 0} {k : 1 = 1} : ¬ ¬ True := by
   assumption
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h k` is a flexible tactic modifying `k`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
+info: `rw [← Classical.not_not (a := True)] at k` uses `k`!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h k` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: `rw [← Classical.not_not (a := True)] at h` uses `h`!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -313,11 +313,11 @@ example {h : 0 = 0} {k : 1 = 1} : True := by
   assumption
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp at h` is a flexible tactic modifying `h`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: `rw [← Classical.not_not (a := True)] at h` uses `h`!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -329,14 +329,14 @@ example {h : 0 = 0} : True := by
   assumption
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one]
 ---
-info: 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
+info: `rwa [← Classical.not_not (a := False)]` uses `⊢`!
 -/
 #guard_msgs in
 example {h : False} : 0 = 1 := by
@@ -346,14 +346,14 @@ example {h : False} : 0 = 1 := by
   rwa [← Classical.not_not (a := False)]
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Nat.zero_ne_one]
 ---
-info: 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
+info: `rwa [← Classical.not_not (a := False)]` uses `⊢`!
 -/
 #guard_msgs in
 example {h : False} : 0 = 1 ∧ 0 = 1 := by

--- a/MathlibTest/ImportHeavyFlexibleLinter.lean
+++ b/MathlibTest/ImportHeavyFlexibleLinter.lean
@@ -39,15 +39,14 @@ example : (0 + 2 : Rat) + 1 = 3 := by
 /-! ## further flexible tactics -/
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [zero_add]
 ---
-info: 'rw [add_comm]' uses '⊢'!
-
+info: `rw [add_comm]` uses `⊢`!
 -/
 #guard_msgs in
 -- `norm_num` is allowed after `simp`, but "passes along the stain".
@@ -75,14 +74,14 @@ example (h : False) : False ∧ True := by
 -- Currently, `positivity` is not marked as flexible (as it only applies to goals in a very
 -- particular shape). We use this test to record the current behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [mul_zero, add_zero]
 ---
-info: 'positivity' uses '⊢'!
+info: `positivity` uses `⊢`!
 -/
 #guard_msgs in
 example {k l : ℤ} : 0 ≤ k ^ 2 + 4 * l * 0 := by
@@ -118,14 +117,14 @@ example {X : Type*} [TopologicalSpace X] {f : X → ℕ} {g : ℕ → X}
 -- shape of the goal, and e.g. changing the goal to a defeq one could break the proof).
 -- This test documents this behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
+warning: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: Try this:
   [apply] simp only [Function.comp_apply, add_zero]
 ---
-info: 'fun_prop' uses '⊢'!
+info: `fun_prop` uses `⊢`!
 -/
 #guard_msgs in
 example {X : Type*} [TopologicalSpace X] {f : X → ℕ} {g : ℕ → X}


### PR DESCRIPTION
As required in our style guide; the linter was just not compliant.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
