### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus/Deriv): add deriv_const_op

### DIFF
--- a/Mathlib/Analysis/Analytic/Binomial.lean
+++ b/Mathlib/Analysis/Analytic/Binomial.lean
@@ -139,7 +139,7 @@ theorem one_add_cpow_hasFPowerSeriesOnBall_zero {a : ℂ} :
     intro z hz
     simp only [Nat.cast_add, Nat.cast_one, B, derivWithin_of_isOpen Metric.isOpen_ball hz,
       deriv_const_mul_field']
-    rw [_root_.deriv_cpow_const (by fun_prop), deriv_const_add', deriv_id'', mul_one,
+    rw [_root_.deriv_cpow_const (by fun_prop), deriv_const_add_id, mul_one,
       show a - (n + 1) = a - n - 1 by ring, ← mul_assoc]
     · congr
       simp [descPochhammer_succ_right, Polynomial.smeval_mul, Polynomial.smeval_natCast]

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -439,11 +439,19 @@ theorem derivWithin_const_sub (c : F) :
     derivWithin (fun y ↦ c - f y) s x = -derivWithin f s x := by
   simp [sub_eq_add_neg, derivWithin.fun_neg]
 
-theorem deriv_const_sub (c : F) : deriv (fun y ↦ c - f y) x = -deriv f x := by
+theorem deriv_const_sub (c : F) : deriv (c - f ·) x = -deriv f x := by
   simp only [← derivWithin_univ, derivWithin_const_sub]
 
-theorem deriv_const_sub_id (c : 𝕜) : deriv (fun y ↦ c - y) x = -1 := by
-  simp only [deriv_const_sub c, deriv_id'']
+@[simp]
+theorem deriv_const_sub' (c : F) : deriv (c - f ·) = (-deriv f ·) :=
+  funext fun _ => deriv_const_sub c
+
+theorem deriv_const_sub_id (c : 𝕜) : deriv (c - ·) x = -1 := by
+  rw [deriv_const_sub c, deriv_id'']
+
+@[simp]
+theorem deriv_const_sub_id' (c : 𝕜) : deriv (c - ·) = fun _ => -1 :=
+  funext fun _ => deriv_const_sub_id c
 
 lemma differentiableAt_comp_sub_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x - b)) a ↔ DifferentiableAt 𝕜 f (a - b) := by

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -163,6 +163,13 @@ theorem deriv_const_add (c : F) : deriv (c + f ·) x = deriv f x := by
 theorem deriv_const_add' (c : F) : (deriv (c + f ·)) = deriv f :=
   funext fun _ ↦ deriv_const_add c
 
+theorem deriv_const_add_id (c : 𝕜) : deriv (c + ·) x = 1 := by
+  rw [deriv_const_add c, deriv_id'']
+
+@[simp]
+theorem deriv_const_add_id' (c : 𝕜) : (deriv (c + ·)) = fun _ => 1 :=
+  funext fun _ ↦ deriv_const_add_id c
+
 lemma differentiableAt_comp_add_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x + b)) a ↔ DifferentiableAt 𝕜 f (a + b) := by
   grind [add_comm, differentiableAt_comp_add_left]
@@ -434,6 +441,9 @@ theorem derivWithin_const_sub (c : F) :
 
 theorem deriv_const_sub (c : F) : deriv (fun y ↦ c - f y) x = -deriv f x := by
   simp only [← derivWithin_univ, derivWithin_const_sub]
+
+theorem deriv_const_sub_id (c : 𝕜) : deriv (fun y ↦ c - y) x = -1 := by
+  simp only [deriv_const_sub c, deriv_id'']
 
 lemma differentiableAt_comp_sub_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x - b)) a ↔ DifferentiableAt 𝕜 f (a - b) := by

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -242,15 +242,6 @@ theorem deriv_const_div (c : 𝕜') (hd : DifferentiableAt 𝕜 d x) (hx : d x �
 @[simp]
 theorem deriv_const_div_id (c : 𝕜) :
     deriv (fun x => c / x) x = - c / x ^ 2 := by
-  rcases eq_or_ne x 0 with rfl | hx₀
-  · simp only [zero_pow <| Ne.symm <| Nat.zero_ne_add_one 1, div_zero]
-    rcases eq_or_ne c 0 with rfl | hc₀
-    · simp only [zero_div, deriv_const']
-    · refine deriv_zero_of_not_differentiableAt fun nh =>
-        mt (differentiableAt_inv_iff (𝕜 := 𝕜)).mp (not_not.mpr rfl) ?_
-      replace nh := nh.hasDerivAt.const_mul c⁻¹ |>.differentiableAt
-      revert nh
-      simp [← mul_div_assoc, hc₀]
-  · simp [deriv_const_div c differentiableAt_fun_id hx₀]
+  simp [div_eq_mul_inv]
 
 end Division

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -235,4 +235,23 @@ theorem deriv_div (hc : DifferentiableAt 𝕜 c x) (hd : DifferentiableAt 𝕜 d
     deriv (c / d) x = (deriv c x * d x - c x * deriv d x) / d x ^ 2 :=
   (hc.hasDerivAt.div hd.hasDerivAt hx).deriv
 
+@[simp]
+theorem deriv_const_div (c : 𝕜') (hd : DifferentiableAt 𝕜 d x) (hx : d x ≠ 0) :
+    deriv (fun x => c / d x) x = - c * deriv d x / d x ^ 2 := by
+  simp [deriv_fun_div (differentiableAt_const c) hd hx]
+
+@[simp]
+theorem deriv_const_div_id (c : 𝕜) :
+    deriv (fun x => c / x) x = - c / x ^ 2 := by
+  rcases eq_or_ne x 0 with rfl | hx₀
+  · simp only [zero_pow <| Ne.symm <| Nat.zero_ne_add_one 1, div_zero]
+    rcases eq_or_ne c 0 with rfl | hc₀
+    · simp only [zero_div, deriv_const']
+    · refine deriv_zero_of_not_differentiableAt fun nh =>
+        mt (differentiableAt_inv_iff (𝕜 := 𝕜)).mp (not_not.mpr rfl) ?_
+      replace nh := nh.hasDerivAt.const_mul c⁻¹ |>.differentiableAt
+      revert nh
+      simp [← mul_div_assoc, hc₀]
+  · simp [deriv_const_div c differentiableAt_fun_id hx₀]
+
 end Division

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -235,7 +235,6 @@ theorem deriv_div (hc : DifferentiableAt 𝕜 c x) (hd : DifferentiableAt 𝕜 d
     deriv (c / d) x = (deriv c x * d x - c x * deriv d x) / d x ^ 2 :=
   (hc.hasDerivAt.div hd.hasDerivAt hx).deriv
 
-@[simp]
 theorem deriv_const_div (c : 𝕜') (hd : DifferentiableAt 𝕜 d x) (hx : d x ≠ 0) :
     deriv (fun x => c / d x) x = - c * deriv d x / d x ^ 2 := by
   simp [deriv_fun_div (differentiableAt_const c) hd hx]

--- a/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
@@ -161,7 +161,7 @@ theorem DifferentiableAt.fderiv_norm_self {x : E} (h : DifferentiableAt ℝ (‖
   simp_rw [this]
   rw [deriv_mul_const]
   · conv_lhs => enter [1, 1]; change _root_.abs ∘ (fun t ↦ 1 + t)
-    rw [deriv_comp, deriv_abs, deriv_const_add]
+    rw [deriv_comp, deriv_abs, deriv_const_add_id]
     · simp
     · exact differentiableAt_abs (by simp)
     · exact differentiableAt_id.const_add _

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -339,7 +339,7 @@ lemma deriv2_qaryEntropy :
       · rw [deriv.log differentiableAt_fun_id xne0]
         simp only [deriv_id'', one_div]
         · have {q : ℝ} (p : ℝ) : DifferentiableAt ℝ (fun p => q - p) p := by fun_prop
-          simp [field, sub_ne_zero_of_ne xne1.symm, this, deriv_const_sub_id]
+          simp [field, sub_ne_zero_of_ne xne1.symm, this]
           ring
       · apply DifferentiableAt.add
         · simp only [differentiableAt_const]

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -339,9 +339,7 @@ lemma deriv2_qaryEntropy :
       · rw [deriv.log differentiableAt_fun_id xne0]
         simp only [deriv_id'', one_div]
         · have {q : ℝ} (p : ℝ) : DifferentiableAt ℝ (fun p => q - p) p := by fun_prop
-          have d_oneminus (p : ℝ) : deriv (fun (y : ℝ) ↦ 1 - y) p = -1 := by
-            rw [deriv_const_sub 1, deriv_id'']
-          simp [field, sub_ne_zero_of_ne xne1.symm, this, d_oneminus]
+          simp [field, sub_ne_zero_of_ne xne1.symm, this, deriv_const_sub_id]
           ring
       · apply DifferentiableAt.add
         · simp only [differentiableAt_const]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -743,6 +743,10 @@ theorem deriv_const_rpow (ha : 0 < a) (hf : DifferentiableAt ℝ f x) :
     deriv (a ^ f ·) x = Real.log a * deriv f x * a ^ f x :=
   (hf.hasDerivAt.const_rpow ha).deriv
 
+@[simp]
+theorem deriv_const_rpow_id (ha : 0 < a) :
+    deriv (a ^ ·) x = Real.log a * a ^ x := by
+  rw [deriv_const_rpow ha differentiableAt_fun_id, deriv_id'', mul_one]
 
 end deriv
 

--- a/MathlibTest/Deriv.lean
+++ b/MathlibTest/Deriv.lean
@@ -15,6 +15,9 @@ example (x : ℝ) :
 example (x : ℝ) : deriv (HAdd.hAdd 3) x = 1 := by
   simp
 
+example (x : ℝ) : deriv (HSub.hSub 3) x = -1 := by
+  simp
+
 example (x : ℝ) : deriv (HMul.hMul 3) x = 3 := by
   simp
 
@@ -23,6 +26,24 @@ example (x : ℝ) : deriv (HDiv.hDiv 3) x = -3 / x ^ 2 := by
 
 example (x : ℝ) : deriv (HPow.hPow 3) x = log 3 * 3 ^ x := by
   simp
+
+example {x : ℝ} : deriv (fun x => (3 + x) * 2) x = 2 := by
+  simp
+
+example {x : ℝ} : deriv (fun x => (3 - x) * 2) x = -2 := by
+  simp
+
+example {x : ℝ} : deriv (fun x => (3 * x) * 2) x = 6 := by
+  simp
+  ring
+
+example {x : ℝ} : deriv (fun x => (3 / x) * 2) x = -6 / x ^ 2 := by
+  simp
+  ring
+
+example {x : ℝ} : deriv (fun x => (3 ^ x : ℝ) * 2) x = 2 * Real.log 3 * 3 ^ x := by
+  simp
+  ring
 
 /- for more complicated examples (with more nested functions) you need to increase the
 `maxDischargeDepth`. -/

--- a/MathlibTest/Deriv.lean
+++ b/MathlibTest/Deriv.lean
@@ -12,6 +12,18 @@ example (x : ℝ) :
     deriv (fun x ↦ cos (sin x) * exp x) x = (cos (sin x) - sin (sin x) * cos x) * exp x := by
   simp; ring
 
+example (x : ℝ) : deriv (HAdd.hAdd 3) x = 1 := by
+  simp
+
+example (x : ℝ) : deriv (HMul.hMul 3) x = 3 := by
+  simp
+
+example (x : ℝ) : deriv (HDiv.hDiv 3) x = -3 / x ^ 2 := by
+  simp
+
+example (x : ℝ) : deriv (HPow.hPow 3) x = log 3 * 3 ^ x := by
+  simp
+
 /- for more complicated examples (with more nested functions) you need to increase the
 `maxDischargeDepth`. -/
 


### PR DESCRIPTION
This PR adds some lemmas so `simp` can automatically evaluate derivatives of partially applied heterogeneous operations such as `HAdd.hAdd`, `HSub.hSub`, `HMul.hMul` `HDiv.hDiv`, and `HPow.hPow`.