### PR TITLE
feat(Analysis/Calculus/DifferentialForm): Stokes theorem on boxes for differential forms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1727,8 +1727,8 @@ public import Mathlib.Analysis.Calculus.DerivativeTest
 public import Mathlib.Analysis.Calculus.DiffContOnCl
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 public import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
-public import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
 public import Mathlib.Analysis.Calculus.DifferentialForm.FullSpaceStokes
+public import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
 public import Mathlib.Analysis.Calculus.DifferentialForm.VectorField
 public import Mathlib.Analysis.Calculus.FDeriv.Add
 public import Mathlib.Analysis.Calculus.FDeriv.Affine

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1728,6 +1728,7 @@ public import Mathlib.Analysis.Calculus.DiffContOnCl
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 public import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
 public import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
+public import Mathlib.Analysis.Calculus.DifferentialForm.FullSpaceStokes
 public import Mathlib.Analysis.Calculus.DifferentialForm.VectorField
 public import Mathlib.Analysis.Calculus.FDeriv.Add
 public import Mathlib.Analysis.Calculus.FDeriv.Affine

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1726,6 +1726,8 @@ public import Mathlib.Analysis.Calculus.Deriv.ZPow
 public import Mathlib.Analysis.Calculus.DerivativeTest
 public import Mathlib.Analysis.Calculus.DiffContOnCl
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
+public import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
+public import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
 public import Mathlib.Analysis.Calculus.DifferentialForm.VectorField
 public import Mathlib.Analysis.Calculus.FDeriv.Add
 public import Mathlib.Analysis.Calculus.FDeriv.Affine

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -4,15 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
 module
-import Mathlib.Analysis.Calculus.DifferentialForm.Basic
-import Mathlib.MeasureTheory.Integral.DivergenceTheorem
-import Mathlib.LinearAlgebra.Determinant
-import Mathlib.Data.Fintype.Perm
-import Mathlib.Data.Fintype.Card
-import Mathlib.Algebra.BigOperators.Fin
-import Mathlib.Algebra.Order.BigOperators.Ring.Finset
-import Mathlib.Algebra.Order.Ring.Cast
-import Mathlib.Data.Int.Cast.Lemmas
+public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
+public import Mathlib.MeasureTheory.Integral.DivergenceTheorem
+public import Mathlib.LinearAlgebra.Determinant
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.Fintype.Card
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+public import Mathlib.Algebra.Order.Ring.Cast
+public import Mathlib.Data.Int.Cast.Lemmas
 
 /-!
 # Stokes' theorem on rectangular boxes in Euclidean space

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -50,7 +50,7 @@ Stokes theorem, differential form, exterior derivative, box, divergence theorem
 
 noncomputable section
 
-open ContinuousAlternatingMap Fin Set MeasureTheory Measure Matrix
+open ContinuousAlternatingMap Equiv Fin Set MeasureTheory Measure Matrix
 open scoped Topology
 
 namespace DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -47,6 +47,8 @@ integral of `dω` over the box into a sum of face integrals.
 Stokes theorem, differential form, exterior derivative, box, divergence theorem
 -/
 
+@[expose] public section
+
 noncomputable section
 
 open ContinuousAlternatingMap Equiv Fin Set MeasureTheory Measure Matrix

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Haoen Feng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
+module
 import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 import Mathlib.LinearAlgebra.Determinant

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2025 Haoen Feng. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Haoen Feng
+-/
+module
+
+import Mathlib.Analysis.Calculus.DifferentialForm.Basic
+import Mathlib.MeasureTheory.Integral.DivergenceTheorem
+import Mathlib.LinearAlgebra.Determinant
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Data.Fintype.Card
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.Ring.Cast
+import Mathlib.Data.Int.Cast.Lemmas
+
+/-!
+# Stokes' theorem on rectangular boxes in Euclidean space
+
+This file proves the generalized Stokes theorem for differential forms on rectangular
+boxes `[a, b] ⊂ ℝ^(m+1)`.  The proof reduces the top-degree case to Mathlib's
+divergence theorem for boxes.
+
+Let `ω` be an `m`-form on `ℝ^(m+1)`.  We extract the `i`-th signed face component
+(`boxFaceComponent ω i`), a scalar function whose divergence equals the top-form
+density of the exterior derivative `dω`.  The divergence theorem then turns the
+integral of `dω` over the box into a sum of face integrals.
+
+## Main definitions
+
+* `topFormDensity`: the density function of a top-form field.
+* `topFormIntegral`: the integral of a top-form field over a measurable set.
+* `boxFaceComponent`: extracts the `i`-th signed face component from an `m`-form on
+  `ℝ^(m+1)`.
+* `boxBoundaryIntegral`: the signed boundary integral of an `m`-form over `∂[a,b]`.
+
+## Main results
+
+* `topFormDensity_extDeriv_eq_boxFaceComponent_divergence`: the top-form density of
+  `dω` equals the divergence of the face components.
+* `box_stokes_of_hasFDerivAt`: Stokes' theorem on a box with pointwise
+  differentiability hypotheses.
+* `box_stokes_of_contDiff`: a convenient `C¹` formulation.
+
+## Tags
+
+Stokes theorem, differential form, exterior derivative, box, divergence theorem
+-/
+
+noncomputable section
+
+open ContinuousAlternatingMap Fin Set MeasureTheory Measure Matrix
+open scoped Topology
+
+namespace DifferentialForm
+
+/-! ## Top-Form Density and Integration -/
+
+/-- The determinant as a continuous alternating map on `Fin n → ℝ`.
+
+We promote the algebraic alternating map `detRowAlternating` to a continuous one
+using a Hadamard-style bound. -/
+noncomputable def detTopForm (n : ℕ) :
+    (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ :=
+  AlternatingMap.mkContinuous
+    (Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ)
+    ((Fintype.card (Fin n)).factorial)
+    (fun m => by
+      show ‖(Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ) m‖ ≤
+           ↑(Fintype.card (Fin n)).factorial * ∏ i, ‖m i‖
+      rw [show (Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ) m =
+            (Matrix.of m).det from rfl]
+      rw [Matrix.det_apply]
+      calc ‖(∑ σ : Perm (Fin n), Equiv.Perm.sign σ • ∏ i : Fin n, Matrix.of m (σ i) i)‖
+          ≤ ∑ σ : Perm (Fin n), ‖Equiv.Perm.sign σ • ∏ i : Fin n, Matrix.of m (σ i) i‖ :=
+            norm_sum_le _ _
+        _ ≤ ∑ σ : Perm (Fin n), (1 : ℝ) * ∏ i : Fin n, ‖m (σ i)‖ := by
+            refine Finset.sum_le_sum (fun σ _ => ?_)
+            simp only [Matrix.of_apply]
+            show ‖(Equiv.Perm.sign σ : ℤ) • ∏ x : Fin n, m (σ x) x‖ ≤
+                 (1 : ℝ) * ∏ i : Fin n, ‖m (σ i)‖
+            rw [zsmul_eq_mul, norm_mul, Real.norm_eq_abs, Real.norm_eq_abs]
+            rw [← Int.cast_abs, Equiv.Perm.sign_abs, Int.cast_one]
+            simp only [one_mul]
+            rw [Finset.abs_prod Finset.univ (fun x => m (σ x) x)]
+            have h_each : ∀ i : Fin n, (|m (σ i) i| : ℝ) ≤ ‖m (σ i)‖ := fun i => by
+              have := norm_le_pi_norm (m (σ i)) i
+              rw [Real.norm_eq_abs] at this
+              exact this
+            refine Finset.induction_on (Finset.univ : Finset (Fin n)) ?_ ?_
+            · simp
+            · intro a s ha ih
+              simp only [Finset.prod_insert ha]
+              exact mul_le_mul (h_each a) ih (Finset.prod_nonneg
+                (fun i _ => abs_nonneg _)) (norm_nonneg _)
+        _ ≤ ∑ σ : Perm (Fin n), (1 : ℝ) * ∏ i : Fin n, ‖m i‖ := by
+            exact le_of_eq (Finset.sum_congr rfl
+              (fun σ _ => congrArg (fun p => (1 : ℝ) * p)
+                (Equiv.Perm.prod_comp σ Finset.univ (fun j => (‖m j‖ : ℝ))
+                  (by intro a _; exact Finset.mem_univ a))))
+        _ = ↑(Fintype.card (Fin n)).factorial * ∏ i : Fin n, ‖m i‖ := by
+            simp only [Finset.sum_const, nsmul_eq_mul, one_mul,
+              Fintype.card_perm, Finset.card_univ])
+
+@[simp]
+theorem detTopForm_one (n : ℕ) :
+    detTopForm n (1 : Matrix (Fin n) (Fin n) ℝ) = 1 :=
+  det_one
+
+/-- Extract the density function from a top form: `ω` evaluated at the identity matrix. -/
+noncomputable def toTopFormFun (n : ℕ) (ω : (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) : ℝ :=
+  ω (1 : Matrix (Fin n) (Fin n) ℝ)
+
+@[simp]
+theorem toTopFormFun_add (n : ℕ) (ω₁ ω₂ : (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) :
+    toTopFormFun n (ω₁ + ω₂) = toTopFormFun n ω₁ + toTopFormFun n ω₂ := by
+  simp [toTopFormFun]
+
+@[simp]
+theorem toTopFormFun_smul (n : ℕ) (c : ℝ) (ω : (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) :
+    toTopFormFun n (c • ω) = c * toTopFormFun n ω := by
+  simp [toTopFormFun, smul_eq_mul]
+
+@[simp]
+theorem toTopFormFun_zero (n : ℕ) :
+    toTopFormFun n (0 : (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) = 0 := rfl
+
+/-- Construct a top form from scalar `c`: `ω = c · detTopForm`. -/
+noncomputable def fromTopFormFun (n : ℕ) (c : ℝ) : (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ :=
+  c • detTopForm n
+
+/-- The density function of a top-form field: `x ↦ toTopFormFun (ω x)`. -/
+noncomputable def topFormDensity {n : ℕ}
+    (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) (x : Fin n → ℝ) : ℝ :=
+  toTopFormFun n (ω x)
+
+/-- The integral of a top-form field over a measurable set: `∫_s ω = ∫_{x ∈ s} topFormDensity ω x dx`. -/
+noncomputable def topFormIntegral {n : ℕ}
+    (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ)
+    (s : Set (Fin n → ℝ)) : ℝ :=
+  ∫ x in s, topFormDensity ω x
+
+variable {m : ℕ}
+
+/-! ## Coordinate Components of an `m`-Form on `ℝ^(m+1)` -/
+
+/-- The `i`-th row of the identity matrix is the `i`-th standard basis vector. -/
+theorem matrix_one_row_eq_single (i : Fin (m + 1)) :
+    (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ) i = Pi.single i 1 := by
+  ext j
+  simp only [Matrix.one_apply, Pi.single_apply]
+  by_cases h : i = j <;> simp [h, eq_comm]
+
+/-- The signed component of an `m`-form on `ℝ^(m+1)` normal to the `i`-th face.
+
+If `ω` is an `m`-form and the ambient dimension is `m + 1`, then
+`boxFaceComponent ω i` is the scalar function
+`(-1)^i ω(e_0,...,ê_i,...,e_m)`.  Its divergence is the top-form
+density of `dω`. -/
+noncomputable def boxFaceComponent
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (i : Fin (m + 1)) (x : Fin (m + 1) → ℝ) : ℝ :=
+  ((-1 : ℤ) ^ (i : ℕ)) •
+    ω x (Fin.removeNth i (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))
+
+/-- Differentiability of a face component follows from differentiability of the form field. -/
+theorem boxFaceComponent_differentiableAt
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    {x : Fin (m + 1) → ℝ} (i : Fin (m + 1))
+    (hω : DifferentiableAt ℝ ω x) :
+    DifferentiableAt ℝ (boxFaceComponent ω i) x := by
+  unfold boxFaceComponent
+  exact (hω.continuousAlternatingMap_apply fun _ => differentiableAt_const _).const_smul
+    ((-1 : ℤ) ^ (i : ℕ))
+
+/-- A face component is as smooth as the underlying form field. -/
+theorem boxFaceComponent_contDiff {n : WithTop ℕ∞}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (i : Fin (m + 1)) (hω : ContDiff ℝ n ω) :
+    ContDiff ℝ n (boxFaceComponent ω i) := by
+  unfold boxFaceComponent
+  have happ : ContDiff ℝ n
+      (fun x =>
+        (ContinuousAlternatingMap.apply ℝ (Fin (m + 1) → ℝ) ℝ
+          (Fin.removeNth i (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))) (ω x)) :=
+    (ContinuousAlternatingMap.apply ℝ (Fin (m + 1) → ℝ) ℝ
+      (Fin.removeNth i (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))).contDiff.comp hω
+  simpa [ContinuousAlternatingMap.apply_apply] using
+    happ.const_smul ((-1 : ℤ) ^ (i : ℕ))
+
+/-! ## Top-Form Density as Divergence -/
+
+/-- The top-form density of `dω` is the divergence of the signed face components.
+
+This is the key identity that bridges the exterior-derivative world and the
+divergence-theorem world. -/
+theorem topFormDensity_extDeriv_eq_boxFaceComponent_divergence
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    {x : Fin (m + 1) → ℝ} (hω : DifferentiableAt ℝ ω x) :
+    topFormDensity (extDeriv ω) x =
+      ∑ i : Fin (m + 1),
+        fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1) := by
+  simp only [topFormDensity, toTopFormFun]
+  rw [extDeriv_apply hω]
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  rw [matrix_one_row_eq_single i]
+  have hraw : DifferentiableAt ℝ
+      (fun y => ω y (Fin.removeNth i (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))) x :=
+    hω.continuousAlternatingMap_apply fun _ => differentiableAt_const _
+  unfold boxFaceComponent
+  rw [fderiv_fun_const_smul hraw]
+  rw [ContinuousLinearMap.smul_apply]
+
+/-! ## Boundary Integral on a Box -/
+
+/-- The signed boundary integral of an `m`-form over the boundary of a box.
+
+Each coordinate direction contributes the integral over the front face
+`xᵢ = bᵢ` minus the integral over the back face `xᵢ = aᵢ`, with the
+orientation sign already included in `boxFaceComponent`. -/
+noncomputable def boxBoundaryIntegral
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (a b : Fin (m + 1) → ℝ) : ℝ :=
+  ∑ i : Fin (m + 1),
+    ((∫ x in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i (b i) x)) -
+      ∫ x in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i (a i) x))
+
+/-! ## Stokes on Boxes -/
+
+/-- **Generalized Stokes theorem on rectangular boxes in `ℝ^(m+1)`.**
+
+This is a genuine proved Stokes formula for Euclidean boxes.  The proof is:
+
+1. rewrite the density of `dω` as the divergence of the signed face
+   components of `ω`;
+2. apply Mathlib's divergence theorem on boxes.
+
+The hypotheses are exactly the analytic hypotheses required by the
+divergence theorem: continuity of face components on the closed box,
+differentiability of `ω` on the closed box, and integrability of the
+resulting divergence. -/
+theorem box_stokes_of_hasFDerivAt
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (a b : Fin (m + 1) → ℝ) (hle : a ≤ b)
+    (Hc : ∀ i : Fin (m + 1), ContinuousOn (boxFaceComponent ω i) (Icc a b))
+    (Hdω : ∀ x ∈ Icc a b, DifferentiableAt ℝ ω x)
+    (Hi : IntegrableOn
+      (fun x => ∑ i : Fin (m + 1),
+        fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1)) (Icc a b)) :
+    topFormIntegral (extDeriv ω) (Icc a b) = boxBoundaryIntegral ω a b := by
+  unfold topFormIntegral boxBoundaryIntegral
+  calc
+    ∫ x in Icc a b, topFormDensity (extDeriv ω) x =
+        ∫ x in Icc a b,
+          ∑ i : Fin (m + 1),
+            fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1) := by
+      exact setIntegral_congr_fun measurableSet_Icc fun x hx =>
+        topFormDensity_extDeriv_eq_boxFaceComponent_divergence ω (Hdω x hx)
+    _ = ∑ i : Fin (m + 1),
+        ((∫ x in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+            boxFaceComponent ω i (Fin.insertNth i (b i) x)) -
+          ∫ x in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+            boxFaceComponent ω i (Fin.insertNth i (a i) x)) := by
+      refine MeasureTheory.integral_divergence_of_hasFDerivAt_off_countable'
+        a b hle (fun i => boxFaceComponent ω i)
+        (fun i x => fderiv ℝ (boxFaceComponent ω i) x)
+        (∅ : Set (Fin (m + 1) → ℝ)) (by simp) Hc ?_ Hi
+      intro x hx i
+      refine (boxFaceComponent_differentiableAt ω i (Hdω x ?_)).hasFDerivAt
+      have hxIoo : x ∈ Set.pi Set.univ fun j : Fin (m + 1) => Ioo (a j) (b j) := by
+        simpa [diff_empty] using hx
+      rw [mem_Icc]
+      constructor <;> intro j
+      · exact (mem_Icc_of_Ioo (hxIoo j trivial)).1
+      · exact (mem_Icc_of_Ioo (hxIoo j trivial)).2
+
+/-- A convenient `C¹` form of Stokes on rectangular boxes.
+
+The lower-level theorem `box_stokes_of_hasFDerivAt` mirrors Mathlib's
+divergence theorem hypotheses.  This wrapper derives those hypotheses from
+the usual mathematical assumption that the form field is `C¹`. -/
+theorem box_stokes_of_contDiff
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (a b : Fin (m + 1) → ℝ) (hle : a ≤ b)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω) :
+    topFormIntegral (extDeriv ω) (Icc a b) = boxBoundaryIntegral ω a b := by
+  refine box_stokes_of_hasFDerivAt ω a b hle ?_ ?_ ?_
+  · -- Continuity of face components from C¹ smoothness
+    intro i
+    exact (boxFaceComponent_contDiff ω i hω).continuous.continuousOn
+  · -- Differentiability of ω everywhere
+    intro _x _hx
+    exact (hω.differentiable one_ne_zero).differentiableAt
+  · -- Integrability of divergence from continuity
+    have hdiv_cont : Continuous
+        (fun x => ∑ i : Fin (m + 1),
+          fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1)) := by
+      refine continuous_finset_sum _ ?_
+      intro i _
+      have hface : ContDiff ℝ (1 : ℕ∞) (boxFaceComponent ω i) :=
+        boxFaceComponent_contDiff ω i hω
+      exact (hface.continuous_fderiv_apply one_ne_zero).comp
+        (continuous_id.prodMk continuous_const)
+    exact hdiv_cont.integrableOn_Icc
+
+end DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -3,8 +3,6 @@ Copyright (c) 2025 Haoen Feng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
-module
-
 import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 import Mathlib.LinearAlgebra.Determinant
@@ -73,7 +71,8 @@ noncomputable def detTopForm (n : ℕ) :
             (Matrix.of m).det from rfl]
       rw [Matrix.det_apply]
       calc ‖(∑ σ : Perm (Fin n), Equiv.Perm.sign σ • ∏ i : Fin n, Matrix.of m (σ i) i)‖
-          ≤ ∑ σ : Perm (Fin n), ‖Equiv.Perm.sign σ • ∏ i : Fin n, Matrix.of m (σ i) i‖ :=
+          ≤ ∑ σ : Perm (Fin n),
+            ‖Equiv.Perm.sign σ • ∏ i : Fin n, Matrix.of m (σ i) i‖ :=
             norm_sum_le _ _
         _ ≤ ∑ σ : Perm (Fin n), (1 : ℝ) * ∏ i : Fin n, ‖m (σ i)‖ := by
             refine Finset.sum_le_sum (fun σ _ => ?_)
@@ -135,7 +134,8 @@ noncomputable def topFormDensity {n : ℕ}
     (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) (x : Fin n → ℝ) : ℝ :=
   toTopFormFun n (ω x)
 
-/-- The integral of a top-form field over a measurable set: `∫_s ω = ∫_{x ∈ s} topFormDensity ω x dx`. -/
+/-- The integral of a top-form field over a measurable set:
+`∫_s ω = ∫_{x ∈ s} topFormDensity ω x dx`. -/
 noncomputable def topFormIntegral {n : ℕ}
     (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ)
     (s : Set (Fin n → ℝ)) : ℝ :=
@@ -299,7 +299,7 @@ theorem box_stokes_of_contDiff
     have hdiv_cont : Continuous
         (fun x => ∑ i : Fin (m + 1),
           fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1)) := by
-      refine continuous_finset_sum _ ?_
+      refine continuous_finsetSum _ ?_
       intro i _
       have hface : ContDiff ℝ (1 : ℕ∞) (boxFaceComponent ω i) :=
         boxFaceComponent_contDiff ω i hω

--- a/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/BoxStokes.lean
@@ -68,7 +68,7 @@ noncomputable def detTopForm (n : ℕ) :
     (Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ)
     ((Fintype.card (Fin n)).factorial)
     (fun m => by
-      show ‖(Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ) m‖ ≤
+      change ‖(Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ) m‖ ≤
            ↑(Fintype.card (Fin n)).factorial * ∏ i, ‖m i‖
       rw [show (Matrix.detRowAlternating : (Fin n → ℝ) [⋀^Fin n]→ₗ[ℝ] ℝ) m =
             (Matrix.of m).det from rfl]
@@ -80,7 +80,7 @@ noncomputable def detTopForm (n : ℕ) :
         _ ≤ ∑ σ : Perm (Fin n), (1 : ℝ) * ∏ i : Fin n, ‖m (σ i)‖ := by
             refine Finset.sum_le_sum (fun σ _ => ?_)
             simp only [Matrix.of_apply]
-            show ‖(Equiv.Perm.sign σ : ℤ) • ∏ x : Fin n, m (σ x) x‖ ≤
+            change ‖(Equiv.Perm.sign σ : ℤ) • ∏ x : Fin n, m (σ x) x‖ ≤
                  (1 : ℝ) * ∏ i : Fin n, ‖m (σ i)‖
             rw [zsmul_eq_mul, norm_mul, Real.norm_eq_abs, Real.norm_eq_abs]
             rw [← Int.cast_abs, Equiv.Perm.sign_abs, Int.cast_one]

--- a/Mathlib/Analysis/Calculus/DifferentialForm/FullSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/FullSpaceStokes.lean
@@ -3,11 +3,8 @@ Copyright (c) 2025 Haoen Feng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
-
-import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
-import Mathlib.Analysis.Calculus.FDeriv.Const
-import Mathlib.Analysis.Calculus.FDeriv.Mul
-import Mathlib.Analysis.Calculus.FDeriv.Add
+module
+public import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
 
 /-!
 # Stokes' theorem on the full space ℝⁿ and product rule for differential forms
@@ -38,6 +35,8 @@ of `d(f · ω)` and the partition-of-unity telescoping identity.
 Stokes theorem, full space, differential form, exterior derivative, product rule,
 partition of unity, wedge density
 -/
+
+@[expose] public section
 
 
 noncomputable section
@@ -201,7 +200,6 @@ theorem fullSpace_stokes (m : ℕ)
   have hR_pos : (0 : ℝ) < R :=
     lt_of_lt_of_le (by positivity) (le_max_right (max Rω Rd) 1)
   have hR_nneg : (0 : ℝ) ≤ R := le_of_lt hR_pos
-
   -- Apply box_stokes
   have hle : (fun _ : Fin (m + 1) => -(R : ℝ)) ≤
       (fun _ : Fin (m + 1) => (R : ℝ)) := by
@@ -209,7 +207,6 @@ theorem fullSpace_stokes (m : ℕ)
   have h_box := box_stokes_of_contDiff ω
     (fun _ : Fin (m + 1) => -(R : ℝ))
     (fun _ : Fin (m + 1) => (R : ℝ)) hle hω
-
   -- All face integrals vanish for large R
   have h_face_pos (i : Fin (m + 1)) :
       (∫ x : Fin m → ℝ in
@@ -231,7 +228,6 @@ theorem fullSpace_stokes (m : ℕ)
     exact faceIntegral_eq_zero_of_large_v ω Rω hRω
       (fun _ : Fin (m + 1) => -(R : ℝ))
       (fun _ : Fin (m + 1) => (R : ℝ)) i (-(R : ℝ)) hRω_le_abs
-
   -- Boundary integral = sum over (front - back) = 0 for all faces
   have h_boundary_eq_zero : boxBoundaryIntegral ω
       (fun _ : Fin (m + 1) => -(R : ℝ))
@@ -239,10 +235,8 @@ theorem fullSpace_stokes (m : ℕ)
     unfold boxBoundaryIntegral
     rw [Finset.sum_eq_zero]
     intro i _
-    simp only [show (fun _ : Fin (m + 1) => (R : ℝ)) i = (R : ℝ) from rfl,
-      show (fun _ : Fin (m + 1) => -(R : ℝ)) i = -(R : ℝ) from rfl]
+    -- After unfold, (fun _ => R) i and (fun _ => -R) i reduce to R and -R by rfl
     rw [h_face_pos i, h_face_neg i, sub_zero]
-
   -- Density = 0 outside Icc(-R, R) since R ≥ Rd
   have h_density_outside : ∀ x : Fin (m + 1) → ℝ,
       x ∉ Icc (fun _ : Fin (m + 1) => -(R : ℝ))
@@ -251,7 +245,7 @@ theorem fullSpace_stokes (m : ℕ)
     intro x hx
     have hnorm : Rd ≤ ‖x‖ := by
       by_contra h_lt
-      push_neg at h_lt
+      push Not at h_lt
       have h_in_box : x ∈ Icc
           (fun _ : Fin (m + 1) => -(R : ℝ))
           (fun _ : Fin (m + 1) => (R : ℝ)) := by
@@ -269,9 +263,8 @@ theorem fullSpace_stokes (m : ℕ)
           linarith [abs_le.mp (le_of_lt this)]
       exact hx h_in_box
     exact hRd x hnorm
-
   have h_cont : Continuous (topFormDensity (extDeriv ω)) := by
-    refine (continuous_finset_sum _ fun i _ => ?_).congr
+    refine (continuous_finsetSum _ fun i _ => ?_).congr
       (fun x => (topFormDensity_extDeriv_eq_boxFaceComponent_divergence
         ω ((hω.differentiable one_ne_zero).differentiableAt)).symm)
     exact (boxFaceComponent_contDiff ω i hω).continuous_fderiv_apply
@@ -314,7 +307,7 @@ theorem continuous_topFormDensity_extDeriv {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     (hω : ContDiff ℝ (1 : ℕ∞) ω) :
     Continuous (topFormDensity (extDeriv ω)) := by
-  refine (continuous_finset_sum Finset.univ fun i _ => ?_).congr
+  refine (continuous_finsetSum Finset.univ fun i _ => ?_).congr
     (fun x => (topFormDensity_extDeriv_eq_boxFaceComponent_divergence
       ω ((hω.differentiable one_ne_zero).differentiableAt)).symm)
   exact (boxFaceComponent_contDiff ω i hω).continuous_fderiv_apply

--- a/Mathlib/Analysis/Calculus/DifferentialForm/FullSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/FullSpaceStokes.lean
@@ -1,0 +1,429 @@
+/-
+Copyright (c) 2025 Haoen Feng. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Haoen Feng
+-/
+
+import Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes
+import Mathlib.Analysis.Calculus.FDeriv.Const
+import Mathlib.Analysis.Calculus.FDeriv.Mul
+import Mathlib.Analysis.Calculus.FDeriv.Add
+
+/-!
+# Stokes' theorem on the full space ℝⁿ and product rule for differential forms
+
+This file proves the full-space Stokes theorem for compactly supported `C¹`
+differential forms, together with the product rule for the top-form density
+of `d(f · ω)` and the partition-of-unity telescoping identity.
+
+## Main definitions
+
+* `wedgeDensity f ω x`: the scalar contribution of `df ∧ ω` to the top-form
+  density, expressed coordinate-wise as `∑ᵢ (∂f/∂xᵢ)(x) · boxFaceComponent ω i x`.
+
+## Main results
+
+* `fullSpace_stokes`: For a compactly supported `C¹` `m`-form `ω` on `ℝ^(m+1)`,
+  `∫_{ℝ^(m+1)} dω = 0`.
+* `topFormDensity_extDeriv_smul`: Product rule for `d(f · ω)` in density form.
+* `poTelescoping`: If `∑ ρᵢ = 1` then `∑ wedgeDensity ρᵢ ω = 0`.
+* `continuous_topFormDensity_extDeriv`: Continuity of `topFormDensity (extDeriv ω)`.
+* `topFormDensity_add`, `topFormDensity_smul`, `topFormDensity_fun_smul`:
+  Linearity of `topFormDensity`.
+* `extDeriv_sum`: `extDeriv` commutes with finite sums.
+* `integral_extDeriv_add`: `∫ d(ω₁ + ω₂) = ∫ dω₁ + ∫ dω₂`.
+
+## Tags
+
+Stokes theorem, full space, differential form, exterior derivative, product rule,
+partition of unity, wedge density
+-/
+
+
+noncomputable section
+
+open ContinuousAlternatingMap Fin Set MeasureTheory Measure Function
+open scoped Topology BigOperators
+
+namespace DifferentialForm
+
+variable {m : ℕ}
+
+/-! ## Wedge Density and Product Rule -/
+
+/-- The "wedge density" term: the contribution of `df ∧ ω` to the top-form
+    density of `d(f · ω)`. In coordinates:
+      `wedgeDensity f ω x = ∑ᵢ (∂f/∂xᵢ)(x) · boxFaceComponent ω i x`
+
+    This is a scalar replacement for the abstract wedge product `df ∧ ω`,
+    valid for `(m)`-forms on `ℝ^(m+1)` where the result is a top `(m+1)`-form. -/
+noncomputable def wedgeDensity
+    (f : (Fin (m + 1) → ℝ) → ℝ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (x : Fin (m + 1) → ℝ) : ℝ :=
+  ∑ i : Fin (m + 1),
+    fderiv ℝ f x (Pi.single i 1) * boxFaceComponent ω i x
+
+/-- `boxFaceComponent` distributes over scalar multiplication by a function. -/
+lemma boxFaceComponent_fun_smul
+    (f : (Fin (m + 1) → ℝ) → ℝ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (i : Fin (m + 1)) (x : Fin (m + 1) → ℝ) :
+    boxFaceComponent (fun y => f y • ω y) i x =
+      f x * boxFaceComponent ω i x := by
+  unfold boxFaceComponent
+  simp only [ContinuousAlternatingMap.smul_apply]
+  rw [zsmul_eq_mul, zsmul_eq_mul, mul_left_comm, smul_eq_mul]
+
+/-- **Product rule for top-form density** (the core lemma).
+
+    For a `C¹` function `f` and a `C¹` `m`-form `ω` on `ℝ^(m+1)`:
+      `topFormDensity (extDeriv (fun x => f x · ω x)) x
+        = f x · topFormDensity (extDeriv ω) x + wedgeDensity f ω x`
+
+    This is proved via the `boxFaceComponent` divergence decomposition:
+    each face component of `f · ω` satisfies the product rule for derivatives. -/
+theorem topFormDensity_extDeriv_smul
+    (f : (Fin (m + 1) → ℝ) → ℝ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (x : Fin (m + 1) → ℝ)
+    (hf : DifferentiableAt ℝ f x)
+    (hω : DifferentiableAt ℝ ω x) :
+    topFormDensity (extDeriv (fun y => f y • ω y)) x =
+      f x * topFormDensity (extDeriv ω) x + wedgeDensity f ω x := by
+  have hsmul : DifferentiableAt ℝ (fun y => f y • ω y) x := hf.smul hω
+  have hfi : DifferentiableAt ℝ f x := hf
+  have hbi (i) : DifferentiableAt ℝ (boxFaceComponent ω i) x :=
+    boxFaceComponent_differentiableAt ω i hω
+  -- Product rule for each face component
+  have h_prod (i : Fin (m + 1)) :
+      fderiv ℝ (fun y => f y * boxFaceComponent ω i y) x (Pi.single i 1) =
+      f x * fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1) +
+      boxFaceComponent ω i x * fderiv ℝ f x (Pi.single i 1) := by
+    have h := fderiv_fun_mul hfi (hbi i)
+    rw [h]
+    rw [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+      ContinuousLinearMap.smul_apply, smul_eq_mul, smul_eq_mul]
+  -- Use divergence decomposition + product rule
+  have h_div_smul := topFormDensity_extDeriv_eq_boxFaceComponent_divergence
+    (fun y => f y • ω y) hsmul
+  have h_div_ω := topFormDensity_extDeriv_eq_boxFaceComponent_divergence ω hω
+  change topFormDensity (extDeriv (fun y => f y • ω y)) x =
+      f x * topFormDensity (extDeriv ω) x + wedgeDensity f ω x
+  rw [h_div_smul, h_div_ω]
+  unfold wedgeDensity
+  have h_smul_face (i : Fin (m + 1)) :
+      fderiv ℝ (fun y => f y * boxFaceComponent ω i y) x (Pi.single i 1) =
+      f x * fderiv ℝ (boxFaceComponent ω i) x (Pi.single i 1) +
+      boxFaceComponent ω i x * fderiv ℝ f x (Pi.single i 1) := h_prod i
+  have h_rewrite (i : Fin (m + 1)) :
+      fderiv ℝ (boxFaceComponent (fun y => f y • ω y) i) x =
+      fderiv ℝ (fun y => f y * boxFaceComponent ω i y) x := by
+    congr 1; funext y
+    exact boxFaceComponent_fun_smul f ω i y
+  simp only [h_rewrite, h_smul_face, Finset.mul_sum, Finset.sum_add_distrib]
+  congr 1
+  exact Finset.sum_congr rfl (fun i _ => mul_comm _ _)
+
+/-! ## Partition-of-Unity Telescoping -/
+
+/-- **Partition-of-unity telescoping** — density version.
+
+    If `∑ᶠ i, ρᵢ = 1`, then for any `m`-form `ω`:
+      `∑ᶠ i, wedgeDensity (ρᵢ) ω x = 0`
+
+    Proof: `∑ (∂ρᵢ/∂xⱼ) · boxFaceComponent ω j x`
+         `= (∑ ∂ρᵢ/∂xⱼ) · boxFaceComponent ω j x`   (by rearranging sums)
+         `= (∂(∑ ρᵢ)/∂xⱼ) · boxFaceComponent ω j x`   (by linearity of `d`)
+         `= (∂1/∂xⱼ) · boxFaceComponent ω j x = 0`      (derivative of const) -/
+theorem poTelescoping {ι : Type*} [Fintype ι]
+    (ρ : ι → (Fin (m + 1) → ℝ) → ℝ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (h_sum : ∀ x, ∑ i, ρ i x = 1)
+    (x : Fin (m + 1) → ℝ)
+    (hdiff : ∀ i, DifferentiableAt ℝ (ρ i) x) :
+    (∑ i, wedgeDensity (ρ i) ω x) = 0 := by
+  simp only [wedgeDensity]
+  rw [Finset.sum_comm]
+  refine Finset.sum_eq_zero fun j _ => ?_
+  have h_deriv_sum : fderiv ℝ (fun y => ∑ i, ρ i y) x =
+      ∑ i, fderiv ℝ (ρ i) x :=
+    fderiv_fun_sum fun i _ => hdiff i
+  have h_const_deriv : fderiv ℝ (fun y => ∑ i, ρ i y) x = 0 := by
+    have : (fun y => ∑ i, ρ i y) = (fun _ => (1 : ℝ)) := funext h_sum
+    rw [this]
+    exact fderiv_const_apply (1 : ℝ)
+  have h_sum_zero : ∑ i, (fderiv ℝ (ρ i) x) (Pi.single j 1) = 0 := by
+    have h : (∑ i, fderiv ℝ (ρ i) x) (Pi.single j 1) = 0 := by
+      rw [← h_deriv_sum, h_const_deriv]; rfl
+    rw [ContinuousLinearMap.sum_apply] at h
+    exact h
+  rw [show ∑ i, (fderiv ℝ (ρ i) x) (Pi.single j 1) * boxFaceComponent ω j x =
+        (∑ i, (fderiv ℝ (ρ i) x) (Pi.single j 1)) * boxFaceComponent ω j x from
+    (Finset.sum_mul (Finset.univ : Finset ι)
+      (fun i => (fderiv ℝ (ρ i) x) (Pi.single j 1))
+      (boxFaceComponent ω j x)).symm]
+  rw [h_sum_zero, zero_mul]
+
+/-! ## Full-Space Stokes Theorem
+
+  A compactly supported `(n-1)`-form on `ℝⁿ` has `∫ dω = 0`.
+  This follows from the box Stokes theorem by choosing a large enough box
+  that contains the support, so all face integrals vanish.
+-/
+
+/-- **Full-space Stokes theorem for compactly supported forms**.
+
+    For a `C¹` `m`-form `ω` on `ℝ^(m+1)` with compact support:
+      `∫_{ℝ^(m+1)} dω = 0`
+
+    Proof: By `box_stokes_of_contDiff`, `∫_{Icc(-R,R)^n} dω`
+    equals the boundary sum over all faces. For large enough `R`,
+    each face integral vanishes because the support of `ω` is compact.
+    And `∫_ℝⁿ dω = ∫_{Icc} dω` for large `R` since `dω` also has
+    compact support. -/
+theorem fullSpace_stokes (m : ℕ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) :
+    (∫ x in Set.univ, topFormDensity (extDeriv ω) x) = 0 := by
+  -- Get R large enough for ω support (face integrals) and density support
+  obtain ⟨Rω, hRω⟩ :=
+    exists_norm_bound_of_hasCompactSupport_form ω hω_support
+  have hf_comp : HasCompactSupport (topFormDensity (extDeriv ω)) :=
+    hasCompactSupport_topFormDensity_extDeriv ω hω hω_support
+  obtain ⟨Rd, hRd⟩ := exists_norm_bound_of_compact_support _ hf_comp
+  let R := max (max Rω Rd) 1
+  have hRω_le : Rω ≤ R :=
+    le_trans (le_max_left Rω Rd) (le_max_left (max Rω Rd) 1)
+  have hRd_le : Rd ≤ R :=
+    le_trans (le_max_right Rω Rd) (le_max_left (max Rω Rd) 1)
+  have hR_pos : (0 : ℝ) < R :=
+    lt_of_lt_of_le (by positivity) (le_max_right (max Rω Rd) 1)
+  have hR_nneg : (0 : ℝ) ≤ R := le_of_lt hR_pos
+
+  -- Apply box_stokes
+  have hle : (fun _ : Fin (m + 1) => -(R : ℝ)) ≤
+      (fun _ : Fin (m + 1) => (R : ℝ)) := by
+    intro i; exact neg_le_self hR_nneg
+  have h_box := box_stokes_of_contDiff ω
+    (fun _ : Fin (m + 1) => -(R : ℝ))
+    (fun _ : Fin (m + 1) => (R : ℝ)) hle hω
+
+  -- All face integrals vanish for large R
+  have h_face_pos (i : Fin (m + 1)) :
+      (∫ x : Fin m → ℝ in
+        Icc ((fun _ : Fin (m + 1) => -(R : ℝ)) ∘ Fin.succAbove i)
+          ((fun _ : Fin (m + 1) => (R : ℝ)) ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i (R : ℝ) x)) = 0 :=
+    faceIntegral_eq_zero_of_large_v ω Rω hRω
+      (fun _ : Fin (m + 1) => -(R : ℝ))
+      (fun _ : Fin (m + 1) => (R : ℝ)) i (R : ℝ)
+      (le_trans hRω_le (ge_of_eq (abs_of_pos hR_pos)))
+  have h_face_neg (i : Fin (m + 1)) :
+      (∫ x : Fin m → ℝ in
+        Icc ((fun _ : Fin (m + 1) => -(R : ℝ)) ∘ Fin.succAbove i)
+          ((fun _ : Fin (m + 1) => (R : ℝ)) ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i (-(R : ℝ)) x)) = 0 := by
+    have hRω_le_abs : Rω ≤ |-(R : ℝ)| := by
+      rw [abs_neg]
+      exact le_trans hRω_le (le_abs_self R)
+    exact faceIntegral_eq_zero_of_large_v ω Rω hRω
+      (fun _ : Fin (m + 1) => -(R : ℝ))
+      (fun _ : Fin (m + 1) => (R : ℝ)) i (-(R : ℝ)) hRω_le_abs
+
+  -- Boundary integral = sum over (front - back) = 0 for all faces
+  have h_boundary_eq_zero : boxBoundaryIntegral ω
+      (fun _ : Fin (m + 1) => -(R : ℝ))
+      (fun _ : Fin (m + 1) => (R : ℝ)) = 0 := by
+    unfold boxBoundaryIntegral
+    rw [Finset.sum_eq_zero]
+    intro i _
+    simp only [show (fun _ : Fin (m + 1) => (R : ℝ)) i = (R : ℝ) from rfl,
+      show (fun _ : Fin (m + 1) => -(R : ℝ)) i = -(R : ℝ) from rfl]
+    rw [h_face_pos i, h_face_neg i, sub_zero]
+
+  -- Density = 0 outside Icc(-R, R) since R ≥ Rd
+  have h_density_outside : ∀ x : Fin (m + 1) → ℝ,
+      x ∉ Icc (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ)) →
+      topFormDensity (extDeriv ω) x = 0 := by
+    intro x hx
+    have hnorm : Rd ≤ ‖x‖ := by
+      by_contra h_lt
+      push_neg at h_lt
+      have h_in_box : x ∈ Icc
+          (fun _ : Fin (m + 1) => -(R : ℝ))
+          (fun _ : Fin (m + 1) => (R : ℝ)) := by
+        simp only [mem_Icc, Pi.le_def]
+        constructor <;> intro i
+        · have hxi := norm_le_pi_norm x i
+          rw [Real.norm_eq_abs] at hxi
+          have : |x i| < R :=
+            lt_of_le_of_lt hxi (lt_of_lt_of_le h_lt hRd_le)
+          linarith [abs_le.mp (le_of_lt this)]
+        · have hxi := norm_le_pi_norm x i
+          rw [Real.norm_eq_abs] at hxi
+          have : |x i| < R :=
+            lt_of_le_of_lt hxi (lt_of_lt_of_le h_lt hRd_le)
+          linarith [abs_le.mp (le_of_lt this)]
+      exact hx h_in_box
+    exact hRd x hnorm
+
+  have h_cont : Continuous (topFormDensity (extDeriv ω)) := by
+    refine (continuous_finset_sum _ fun i _ => ?_).congr
+      (fun x => (topFormDensity_extDeriv_eq_boxFaceComponent_divergence
+        ω ((hω.differentiable one_ne_zero).differentiableAt)).symm)
+    exact (boxFaceComponent_contDiff ω i hω).continuous_fderiv_apply
+      one_ne_zero |>.comp (continuous_id.prodMk continuous_const)
+  have hf_int : Integrable (topFormDensity (extDeriv ω)) :=
+    h_cont.integrable_of_hasCompactSupport hf_comp
+  have h_box_meas : MeasurableSet
+      (Icc (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ))) := measurableSet_Icc
+  have h_univ_meas : MeasurableSet (Set.univ : Set (Fin (m + 1) → ℝ)) :=
+    MeasurableSet.univ
+  have h_box_subset :
+      (Icc (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ))) ⊆
+      (Set.univ : Set (Fin (m + 1) → ℝ)) :=
+    fun _ _ => Set.mem_univ _
+  -- ∫_{ℝⁿ} f = ∫_{Icc} f since f = 0 on ℝⁿ \ Icc
+  have h_eq : (∫ x in Set.univ, topFormDensity (extDeriv ω) x) =
+      ∫ x in Icc (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ)),
+        topFormDensity (extDeriv ω) x :=
+    setIntegral_eq_of_zero_on_diff (topFormDensity (extDeriv ω))
+      h_box_meas h_univ_meas h_box_subset
+      (by intro x ⟨_, hx⟩; exact h_density_outside x hx)
+      hf_int.integrableOn
+  rw [h_eq]
+  have h_box' : (∫ x in Icc (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ)),
+        topFormDensity (extDeriv ω) x) =
+      boxBoundaryIntegral ω
+        (fun _ : Fin (m + 1) => -(R : ℝ))
+        (fun _ : Fin (m + 1) => (R : ℝ)) := h_box
+  rw [h_box', h_boundary_eq_zero]
+
+/-! ## Continuity and Linearity Utilities -/
+
+/-- Continuity of `topFormDensity (extDeriv ω)` when `ω` is `C¹`.
+    Follows from the box face decomposition of the divergence. -/
+theorem continuous_topFormDensity_extDeriv {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω) :
+    Continuous (topFormDensity (extDeriv ω)) := by
+  refine (continuous_finset_sum Finset.univ fun i _ => ?_).congr
+    (fun x => (topFormDensity_extDeriv_eq_boxFaceComponent_divergence
+      ω ((hω.differentiable one_ne_zero).differentiableAt)).symm)
+  exact (boxFaceComponent_contDiff ω i hω).continuous_fderiv_apply
+    one_ne_zero |>.comp (continuous_id.prodMk continuous_const)
+
+/-- **Interior chart lemma**: the integral of `dω` over `ℝⁿ` is zero
+    when `ω` is compactly supported.
+
+    This is the "no-boundary" case of Stokes' theorem.
+    In the manifold PoU proof, this handles all interior charts. -/
+theorem interiorChartZero (m : ℕ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) :
+    (∫ x in Set.univ, topFormDensity (extDeriv ω) x) = 0 :=
+  fullSpace_stokes m ω hω hω_support
+
+/-! ### `topFormDensity` Linearity
+
+  Basic properties of the top-form density under pointwise operations.
+  These are needed to relate `d(∑ φᵢ · ω)` to `∑ d(φᵢ · ω)`.
+-/
+
+/-- `topFormDensity` distributes over pointwise addition for top forms. -/
+lemma topFormDensity_add {n : ℕ}
+    (ω₁ ω₂ : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) :
+    topFormDensity (fun x => ω₁ x + ω₂ x) =
+      fun x => topFormDensity ω₁ x + topFormDensity ω₂ x := by
+  unfold topFormDensity; funext x; simp [toTopFormFun_add]
+
+/-- `topFormDensity` distributes over pointwise scalar multiplication
+    for top forms. -/
+lemma topFormDensity_smul {n : ℕ} (c : ℝ)
+    (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) :
+    topFormDensity (fun x => c • ω x) =
+      fun x => c * topFormDensity ω x := by
+  unfold topFormDensity; funext x; simp [toTopFormFun_smul]
+
+/-- `topFormDensity` of a function-weighted top form:
+    `topFormDensity (fun x => f x • ω x) = fun x => f x * topFormDensity ω x`. -/
+lemma topFormDensity_fun_smul {n : ℕ}
+    (f : (Fin n → ℝ) → ℝ)
+    (ω : (Fin n → ℝ) → (Fin n → ℝ) [⋀^Fin n]→L[ℝ] ℝ) :
+    topFormDensity (fun x => f x • ω x) =
+      fun x => f x * topFormDensity ω x := by
+  unfold topFormDensity; funext x; simp [toTopFormFun_smul]
+
+/-! ### `extDeriv` and Sums -/
+
+/-- `extDeriv` of a sum of `m`-forms equals the sum of `extDeriv`'s
+    (when all forms are everywhere differentiable). -/
+theorem extDeriv_sum {m : ℕ} {ι : Type*} [Fintype ι]
+    (ω : ι → (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hdiff : ∀ i x, DifferentiableAt ℝ (ω i) x)
+    (x : Fin (m + 1) → ℝ) :
+    extDeriv (fun y => ∑ i, ω i y) x =
+      ∑ i, extDeriv (ω i) x := by
+  classical
+  have h : ∀ (s : Finset ι),
+      extDeriv (∑ i ∈ s, ω i) x = ∑ i ∈ s, extDeriv (ω i) x := by
+    intro s
+    induction s using Finset.induction_on with
+    | empty =>
+      simp only [Finset.sum_empty]
+      unfold extDeriv
+      rw [fderiv_zero]
+      exact map_zero (alternatizeUncurryFinCLM ℝ _ _)
+    | insert j s' hj ih =>
+      simp only [Finset.sum_insert hj]
+      have hd_j := hdiff j x
+      have hd_s : DifferentiableAt ℝ (∑ i ∈ s', ω i) x :=
+        DifferentiableAt.sum (fun i (_ : i ∈ s') => hdiff i x)
+      rw [extDeriv_add hd_j hd_s, ih]
+  specialize h Finset.univ
+  convert h using 2
+  ext y
+  simp [Finset.sum_apply]
+
+/-! ### Integral Linearity for `extDeriv` -/
+
+/-- The integral of `topFormDensity (extDeriv ω)` over `ℝⁿ` is additive
+    when both forms are `C¹` with compact support.
+    This follows from `extDeriv` linearity + integral linearity. -/
+theorem integral_extDeriv_add {m : ℕ}
+    (ω₁ ω₂ : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (h₁ : ContDiff ℝ (1 : ℕ∞) ω₁) (h₂ : ContDiff ℝ (1 : ℕ∞) ω₂)
+    (hc₁ : HasCompactSupport ω₁) (hc₂ : HasCompactSupport ω₂) :
+    (∫ x in Set.univ, topFormDensity
+      (extDeriv (fun y => ω₁ y + ω₂ y)) x) =
+      (∫ x in Set.univ, topFormDensity (extDeriv ω₁) x) +
+      (∫ x in Set.univ, topFormDensity (extDeriv ω₂) x) := by
+  have h₁d (x) := (h₁.differentiable one_ne_zero).differentiableAt (x := x)
+  have h₂d (x) := (h₂.differentiable one_ne_zero).differentiableAt (x := x)
+  have hden : ∀ x, topFormDensity (extDeriv (fun y => ω₁ y + ω₂ y)) x =
+      topFormDensity (extDeriv ω₁) x + topFormDensity (extDeriv ω₂) x := by
+    intro x
+    have h := extDeriv_fun_add (h₁d x) (h₂d x)
+    unfold topFormDensity at *
+    rw [h]
+    exact toTopFormFun_add (m + 1) (extDeriv ω₁ x) (extDeriv ω₂ x)
+  conv_lhs => rw [funext hden]
+  have hf₁ : Integrable (topFormDensity (extDeriv ω₁)) := by
+    refine Continuous.integrable_of_hasCompactSupport ?_ ?_
+    · exact continuous_topFormDensity_extDeriv ω₁ h₁
+    · exact hasCompactSupport_topFormDensity_extDeriv ω₁ h₁ hc₁
+  have hf₂ : Integrable (topFormDensity (extDeriv ω₂)) := by
+    refine Continuous.integrable_of_hasCompactSupport ?_ ?_
+    · exact continuous_topFormDensity_extDeriv ω₂ h₂
+    · exact hasCompactSupport_topFormDensity_extDeriv ω₂ h₂ hc₂
+  exact integral_add hf₁.integrableOn hf₂.integrableOn
+
+end DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -94,6 +94,7 @@ noncomputable def halfSpaceBoxLower (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
   fun i => if i = lastCoord m then (0 : ℝ) else -(R : ℝ)
 
 /-- Upper corner of the half-space box: `(R, ..., R)`. -/
+@[nolint unusedArguments]
 noncomputable def halfSpaceBoxUpper (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
   fun _ => (R : ℝ)
 

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Haoen Feng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
+module
 import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
 import Mathlib.Analysis.Calculus.FDeriv.Const
 import Mathlib.Analysis.Normed.Module.Alternating.Basic
@@ -220,8 +221,7 @@ lemma topFormDensity_eq_zero_of_extDeriv_eq_zero {m : ℕ}
 /-- The topFormDensity of dω has compact support when ω is C¹ with compact support. -/
 lemma hasCompactSupport_topFormDensity_extDeriv {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
-    (hω : ContDiff ℝ (1 : ℕ∞) ω)
-    (hω_support : HasCompactSupport ω) :
+    (_hω : ContDiff ℝ (1 : ℕ∞) ω) :
     HasCompactSupport (topFormDensity (extDeriv ω)) := by
   obtain ⟨R, hR⟩ := exists_norm_bound_of_hasCompactSupport_form ω hω_support
   have h_density_vanishes : ∀ x : Fin (m + 1) → ℝ, R < ‖x‖ →
@@ -276,7 +276,7 @@ lemma setIntegral_eq_of_zero_on_diff {n : ℕ}
 /-! ## Half-Space Box Properties -/
 
 /-- The half-space box is contained in the half-space. -/
-lemma halfSpaceBox_subset_halfSpace {m : ℕ} {R : ℝ} (hR : (0 : ℝ) ≤ R) :
+lemma halfSpaceBox_subset_halfSpace {m : ℕ} {R : ℝ} (_hR : (0 : ℝ) ≤ R) :
     Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) ⊆ HalfSpace m := by
   intro x hx
   rw [mem_Icc] at hx
@@ -286,14 +286,14 @@ lemma halfSpaceBox_subset_halfSpace {m : ℕ} {R : ℝ} (hR : (0 : ℝ) ≤ R) :
 
 /-- HalfSpace is a measurable set. -/
 lemma measurableSet_halfSpace (m : ℕ) : MeasurableSet (HalfSpace m) := by
-  simp only [HalfSpace, mem_setOf_eq]
+  simp only [HalfSpace]
   exact measurableSet_le measurable_const (measurable_pi_apply (lastCoord m))
 
 /-- For large R, the topFormDensity of dω vanishes outside the half-space box. -/
 lemma topFormDensity_extDeriv_vanishes_outside_box {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
-    (hω : ContDiff ℝ (1 : ℕ∞) ω)
-    (hω_support : HasCompactSupport ω) (R : ℝ) (hR : (0 : ℝ) < R)
+    (_hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (_hω_support : HasCompactSupport ω) (R : ℝ) (hR : (0 : ℝ) < R)
     (hR_large : ∀ x : Fin (m + 1) → ℝ, R ≤ ‖x‖ → topFormDensity (extDeriv ω) x = 0) :
     ∀ x ∈ HalfSpace m \ Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R),
       topFormDensity (extDeriv ω) x = 0 := by
@@ -313,7 +313,7 @@ lemma topFormDensity_extDeriv_vanishes_outside_box {m : ℕ}
     · have hlow : halfSpaceBoxLower m R i = -(R : ℝ) := by
         simp [halfSpaceBoxLower, heq, if_neg (Ne.symm heq)]
       rw [hlow] at hi
-      push_neg at hi
+      push Not at hi
       have habs : R < |x i| := by
         rw [abs_of_neg (by linarith : (0 : ℝ) > x i)]; linarith
       exact hR_large x (le_of_lt (lt_of_lt_of_le habs (norm_le_pi_norm x i)))

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -3,11 +3,13 @@ Copyright (c) 2025 Haoen Feng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
-module
-
 import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
 import Mathlib.Analysis.Calculus.FDeriv.Const
-import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+import Mathlib.Analysis.Normed.Module.Alternating.Basic
+import Mathlib.Topology.MetricSpace.ProperSpace
+import Mathlib.Topology.Support
+import Mathlib.MeasureTheory.Integral.Bochner
+import Mathlib.MeasureTheory.Integral.SetIntegral
 
 /-!
 # Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_m ≥ 0}`
@@ -123,7 +125,8 @@ theorem halfSpaceBoxLower_le_upper (m : ℕ) {R : ℝ} (hR : (0 : ℝ) ≤ R) :
 lemma norm_insertNth_ge_norm {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
     ‖x‖ ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ := by
   show Finset.univ.sup (fun b : Fin m => ‖(x : Fin m → ℝ) b‖₊) ≤
-       Finset.univ.sup (fun b : Fin (m + 1) => ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ) b‖₊)
+      Finset.univ.sup (fun b : Fin (m + 1) =>
+        ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ) b‖₊)
   exact Finset.sup_le fun j _ => by
     have h_val : (Fin.insertNth i v x : Fin (m + 1) → ℝ) (Fin.succAbove i j) = x j := by simp
     rw [← h_val]
@@ -142,7 +145,8 @@ lemma norm_insertNth_ge {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ
 
 /-! ## Form Field Vanishing -/
 
-/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at `insertNth i v x` when `‖x‖ ≥ Rω`. -/
+/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at
+`insertNth i v x` when `‖x‖ ≥ Rω`. -/
 lemma formField_vanishes_at_insertNth_norm {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     {Rω : ℝ} (hRω : ∀ y, Rω ≤ ‖y‖ → ω y = 0)
@@ -151,7 +155,8 @@ lemma formField_vanishes_at_insertNth_norm {m : ℕ}
     ω (Fin.insertNth i v x) = 0 :=
   hRω _ (le_trans hx (norm_insertNth_ge_norm i v x))
 
-/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at `insertNth i v x` when `|v| ≥ Rω`. -/
+/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at
+`insertNth i v x` when `|v| ≥ Rω`. -/
 lemma formField_vanishes_at_insertNth {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     {Rω : ℝ} (hRω : ∀ y, Rω ≤ ‖y‖ → ω y = 0)
@@ -354,7 +359,8 @@ For `ω` a compactly supported `C¹` `m`-form on `ℝ^{m+1}`:
 3. `∫_{HalfSpace} f = ∫_{Icc} f` (since `Icc ⊆ HalfSpace` and `f = 0` on `HalfSpace \ Icc`).
 4. `box_stokes_of_contDiff` gives `∫_{Icc} f = boxBoundaryIntegral ω lower upper`.
 5. For `i ≠ lastCoord m`: both front and back vanish (compact support, values at `±R`).
-6. For `i = lastCoord m`: front at `x_m = R` vanishes; back at `x_m = 0` equals `boundaryIntegral`. -/
+6. For `i = lastCoord m`: front at `x_m = R` vanishes;
+   back at `x_m = 0` equals `boundaryIntegral`. -/
 theorem halfSpace_stokes (m : ℕ)
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     (hω : ContDiff ℝ (1 : ℕ∞) ω)
@@ -448,7 +454,8 @@ theorem halfSpace_stokes (m : ℕ)
       rw [show halfSpaceBoxUpper m R ∘ Fin.succAbove (lastCoord m) = fun _ => (R : ℝ) from rfl]
       congr 1
       -- ∫_{Icc(-R,R)^m} f = ∫ f (f vanishes outside Icc)
-      have h_meas : MeasurableSet (Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ)) : Set (Fin m → ℝ)) :=
+      have h_meas : MeasurableSet
+          (Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ)) : Set (Fin m → ℝ)) :=
         measurableSet_Icc
       have h_vanish : ∀ x : Fin m → ℝ,
           x ∈ (Set.univ \ Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ))) →

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -395,7 +395,7 @@ theorem halfSpace_stokes (m : ℕ)
   have hf_cont : Continuous (topFormDensity (extDeriv ω)) := by
     have h_diff : ∀ x, DifferentiableAt ℝ ω x :=
       fun x => (hω.differentiable one_ne_zero).differentiableAt
-    refine (continuous_finset_sum _ fun i _ => by
+    refine (continuous_finsetSum _ fun i _ => by
       have hface : ContDiff ℝ (1 : ℕ∞) (boxFaceComponent ω i) :=
         boxFaceComponent_contDiff ω i hω
       exact (hface.continuous_fderiv_apply one_ne_zero).comp
@@ -480,7 +480,7 @@ theorem halfSpace_stokes (m : ℕ)
       have h_f_cont : Continuous fun x : Fin m → ℝ =>
           boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) := by
         have h_comp := (boxFaceComponent_contDiff ω (lastCoord m) hω).continuous
-        exact h_comp.comp (continuous_const.finInsertNth continuous_id)
+        exact h_comp.comp (continuous_const.finInsertNth (lastCoord m) continuous_id)
       have h_f_compact : HasCompactSupport fun x : Fin m → ℝ =>
           boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) := by
         refine HasCompactSupport.intro (K := Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ))) ?_ ?_

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -223,7 +223,8 @@ lemma topFormDensity_eq_zero_of_extDeriv_eq_zero {m : ℕ}
 /-- The topFormDensity of dω has compact support when ω is C¹ with compact support. -/
 lemma hasCompactSupport_topFormDensity_extDeriv {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
-    (_hω : ContDiff ℝ (1 : ℕ∞) ω) :
+    (_hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) :
     HasCompactSupport (topFormDensity (extDeriv ω)) := by
   obtain ⟨R, hR⟩ := exists_norm_bound_of_hasCompactSupport_form ω hω_support
   have h_density_vanishes : ∀ x : Fin (m + 1) → ℝ, R < ‖x‖ →
@@ -313,7 +314,7 @@ lemma topFormDensity_extDeriv_vanishes_outside_box {m : ℕ}
       have hge : (0 : ℝ) ≤ x i := heq ▸ (by simp [HalfSpace] at hx_hs; exact hx_hs)
       exact hi hge
     · have hlow : halfSpaceBoxLower m R i = -(R : ℝ) := by
-        simp [halfSpaceBoxLower, heq, if_neg (Ne.symm heq)]
+        simp [halfSpaceBoxLower, heq]
       rw [hlow] at hi
       push Not at hi
       have habs : R < |x i| := by

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -38,6 +38,8 @@ The proof strategy:
 Stokes theorem, half-space, differential form, exterior derivative, boundary integral
 -/
 
+@[expose] public section
+
 noncomputable section
 
 open ContinuousAlternatingMap Fin Set MeasureTheory Measure Matrix DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haoen Feng
 -/
 module
-import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
-import Mathlib.Analysis.Calculus.FDeriv.Const
-import Mathlib.Analysis.Normed.Module.Alternating.Basic
-import Mathlib.Topology.MetricSpace.ProperSpace
-import Mathlib.Topology.Algebra.Support
-import Mathlib.MeasureTheory.Integral.Bochner.Set
-import Mathlib.MeasureTheory.Integral.Bochner.Basic
+public import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
+public import Mathlib.Analysis.Calculus.FDeriv.Const
+public import Mathlib.Analysis.Normed.Module.Alternating.Basic
+public import Mathlib.Topology.MetricSpace.ProperSpace
+public import Mathlib.Topology.Algebra.Support
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_m ≥ 0}`

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.Calculus.FDeriv.Const
 import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 
 /-!
-# Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_n ≥ 0}`
+# Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_m ≥ 0}`
 
 This file proves the generalized Stokes theorem for compactly supported `C¹`
 differential forms on the upper half-space `{x : Fin (m + 1) → ℝ | x (lastCoord m) ≥ 0}`.
@@ -30,14 +30,6 @@ The proof strategy:
 * `halfSpace_stokes`: For a compactly supported `C¹` `m`-form `ω` on `ℝ^{m+1}`,
   `∫_{ℝ^{m+1}_+} dω = ∫_{∂ℝ^{m+1}_+} ω`.
 
-## TODO
-
-* The proof of `halfSpace_stokes` is complete in a downstream project.
-  This file contains the infrastructure and the main theorem statement.
-  The full proof will be completed once a few supporting API lemmas are
-  upstreamed (in particular, `Fin.isClosedEmbedding_insertNth` and
-  `extDeriv` vanishing at zeros of the form).
-
 ## Tags
 
 Stokes theorem, half-space, differential form, exterior derivative, boundary integral
@@ -53,10 +45,12 @@ namespace DifferentialForm
 /-! ## The Last Coordinate Index -/
 
 /-- The index of the last coordinate: `lastCoord m = Fin.last m`. -/
-def lastCoord (m : ℕ) : Fin (m + 1) := Fin.last m
+def lastCoord (m : ℕ) : Fin (m + 1) := ⟨m, Nat.lt_succ_self m⟩
 
 @[simp]
-theorem lastCoord_val (m : ℕ) : (lastCoord m : ℕ) = m := Fin.last_def _
+theorem lastCoord_val (m : ℕ) : (lastCoord m : ℕ) = m := rfl
+
+/-! ## Boundary Inclusion -/
 
 /-- The boundary inclusion `y ↦ Fin.insertNth (lastCoord m) 0 y` maps
 `Fin m → ℝ` into the face `x_m = 0` of the half-space. -/
@@ -65,57 +59,67 @@ def boundaryInclusion (m : ℕ) (y : Fin m → ℝ) : Fin (m + 1) → ℝ :=
 
 @[simp]
 theorem boundaryInclusion_last (m : ℕ) (y : Fin m → ℝ) :
-    boundaryInclusion m y (lastCoord m) = 0 := by
-  simp [boundaryInclusion, lastCoord]
+    boundaryInclusion m y (lastCoord m) = (0 : ℝ) := by
+  simp [boundaryInclusion]
 
+@[simp]
 theorem boundaryInclusion_succAbove (m : ℕ) (y : Fin m → ℝ) (i : Fin m) :
     boundaryInclusion m y (Fin.succAbove (lastCoord m) i) = y i := by
-  simp [boundaryInclusion, lastCoord]
+  simp [boundaryInclusion]
+
+/-! ## Half-Space Definitions -/
+
+/-- The upper half-space `{x : x_m ≥ 0}` in `Fin (m + 1) → ℝ`. -/
+def HalfSpace (m : ℕ) : Set (Fin (m + 1) → ℝ) :=
+  {x | (0 : ℝ) ≤ x (lastCoord m)}
+
+/-- The integral of an `m`-form over the boundary of the half-space.
+
+The boundary `∂ℝ^{m+1}_+` is identified with `Fin m → ℝ` via
+`boundaryInclusion m = Fin.insertNth (lastCoord m) 0`. -/
+noncomputable def boundaryIntegral (m : ℕ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ) : ℝ :=
+  -(∫ y : Fin m → ℝ,
+      boxFaceComponent ω (lastCoord m) (boundaryInclusion m y))
 
 /-! ## Half-Space Boxes -/
 
-/-- The lower bound of the half-space box `[-R, R]^m × [0, R]`. -/
-def halfSpaceBoxLower (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
-  Fin.insertNth (lastCoord m) (-(R : ℝ)) fun _ : Fin m => -(R : ℝ)
+/-- Lower corner of the half-space box: `(-R, ..., -R, 0)`. -/
+noncomputable def halfSpaceBoxLower (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
+  fun i => if i = lastCoord m then (0 : ℝ) else -(R : ℝ)
 
-/-- The upper bound of the half-space box `[-R, R]^m × [0, R]`. -/
-def halfSpaceBoxUpper (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
-  Fin.insertNth (lastCoord m) (R : ℝ) fun _ : Fin m => (R : ℝ)
+/-- Upper corner of the half-space box: `(R, ..., R)`. -/
+noncomputable def halfSpaceBoxUpper (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
+  fun _ => (R : ℝ)
 
 @[simp]
 theorem halfSpaceBoxLower_last (m : ℕ) (R : ℝ) :
-    halfSpaceBoxLower m R (lastCoord m) = -(R : ℝ) := by
-  simp [halfSpaceBoxLower, lastCoord]
+    halfSpaceBoxLower m R (lastCoord m) = (0 : ℝ) := by
+  simp [halfSpaceBoxLower]
 
 @[simp]
-theorem halfSpaceBoxUpper_last (m : ℕ) (R : ℝ) :
-    halfSpaceBoxUpper m R (lastCoord m) = (R : ℝ) := by
-  simp [halfSpaceBoxUpper, lastCoord]
+theorem halfSpaceBoxUpper_apply (m : ℕ) (R : ℝ) (i : Fin (m + 1)) :
+    halfSpaceBoxUpper m R i = (R : ℝ) := rfl
 
-@[simp]
 theorem halfSpaceBoxLower_succAbove (m : ℕ) (R : ℝ) (i : Fin m) :
     halfSpaceBoxLower m R (Fin.succAbove (lastCoord m) i) = -(R : ℝ) := by
-  simp [halfSpaceBoxLower, lastCoord]
+  have hne := Fin.succAbove_ne (lastCoord m) i
+  simp [halfSpaceBoxLower, hne]
 
 @[simp]
 theorem halfSpaceBoxUpper_succAbove (m : ℕ) (R : ℝ) (i : Fin m) :
-    halfSpaceBoxUpper m R (Fin.succAbove (lastCoord m) i) = (R : ℝ) := by
-  simp [halfSpaceBoxUpper, lastCoord]
+    halfSpaceBoxUpper m R (Fin.succAbove (lastCoord m) i) = (R : ℝ) := rfl
 
 theorem halfSpaceBoxLower_le_upper (m : ℕ) {R : ℝ} (hR : (0 : ℝ) ≤ R) :
     halfSpaceBoxLower m R ≤ halfSpaceBoxUpper m R := by
-  intro i
-  simp only [halfSpaceBoxLower, halfSpaceBoxUpper, Fin.insertNth_apply]
-  split_ifs with h
+  intro i; simp only [halfSpaceBoxUpper_apply]
+  by_cases h : i = lastCoord m
   · subst h; simp [hR]
-  · simp
+  · simp only [halfSpaceBoxLower, h]; exact neg_le_self hR
 
 /-! ## Norm Bounds -/
 
-/-- `‖Fin.insertNth i v x‖ ≥ ‖x‖` for the sup norm on finite products.
-
-This follows from the fact that every component of `x` appears in
-`Fin.insertNth i v x` via `Fin.succAbove`. -/
+/-- `‖Fin.insertNth i v x‖ ≥ ‖x‖` for the sup norm on finite products. -/
 lemma norm_insertNth_ge_norm {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
     ‖x‖ ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ := by
   show Finset.univ.sup (fun b : Fin m => ‖(x : Fin m → ℝ) b‖₊) ≤
@@ -128,9 +132,13 @@ lemma norm_insertNth_ge_norm {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m �
 
 /-- `‖Fin.insertNth i v x‖ ≥ |v|`. -/
 lemma norm_insertNth_ge {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
-    |v| ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ :=
-  le_trans (le_trans (le_abs_self v) (by rw [Real.norm_eq_abs];
-    exact norm_le_pi_norm _ i)) (norm_insertNth_ge_norm i v x)
+    |v| ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ := by
+  have hval : (Fin.insertNth i v x : Fin (m + 1) → ℝ) i = v := by simp
+  have hnorm : ‖((Fin.insertNth i v x : Fin (m + 1) → ℝ) i : ℝ)‖ ≤
+      ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ :=
+    norm_le_pi_norm _ i
+  rw [hval, Real.norm_eq_abs v] at hnorm
+  exact hnorm
 
 /-! ## Form Field Vanishing -/
 
@@ -160,65 +168,322 @@ lemma boxFaceComponent_eq_zero_of_formField_eq_zero {m : ℕ}
     boxFaceComponent ω i x = 0 := by
   unfold boxFaceComponent; simp [h]
 
+/-! ## Compact Support Lemmas -/
+
+/-- A function with compact support vanishes outside a large enough ball. -/
+lemma exists_norm_bound_of_compact_support {n : ℕ}
+    (f : (Fin n → ℝ) → ℝ) (hf : HasCompactSupport f) :
+    ∃ R₀ : ℝ, ∀ x : Fin n → ℝ, R₀ ≤ ‖x‖ → f x = 0 := by
+  have h_norm_comp : IsCompact ((fun x : Fin n → ℝ => ‖x‖) '' tsupport f) :=
+    hf.image continuous_norm
+  have h_bdd : BddAbove ((fun x => ‖x‖) '' tsupport f) := h_norm_comp.bddAbove
+  obtain ⟨C, hC⟩ := h_bdd
+  use C + 1
+  intro x hx
+  have hnx : x ∉ tsupport f := fun hmem => by
+    have : ‖x‖ ≤ C := hC ⟨x, hmem, rfl⟩
+    linarith
+  contrapose! hnx
+  exact subset_tsupport f (by simpa using hnx)
+
+/-- A compactly supported form field vanishes outside a large ball. -/
+lemma exists_norm_bound_of_hasCompactSupport_form {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : HasCompactSupport ω) :
+    ∃ R₀ : ℝ, ∀ x : Fin (m + 1) → ℝ, R₀ ≤ ‖x‖ → ω x = 0 :=
+  exists_norm_bound_of_compact_support (fun x => ω x (Fin.removeNth (lastCoord m)
+    (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))) <| by
+    refine HasCompactSupport.mono ?_ (fun x hx => by dsimp at hx; exact hx)
+    exact hω.comp isClosedEmbedding_finInsertNth_of_succ _
+
 /-! ## Top-Form Density Properties -/
 
-/-- The top-form density vanishes where the form field is zero. -/
-lemma topFormDensity_eq_zero_of_formField_eq_zero {m : ℕ}
-    {ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin (m + 1)]→L[ℝ] ℝ}
-    {x : Fin (m + 1) → ℝ} (h : ω x = 0) :
-    topFormDensity ω x = 0 :=
-  show toTopFormFun _ (ω x) = 0 by rw [h]; rfl
+/-- The top-form density vanishes where `extDeriv ω x = 0`. -/
+lemma topFormDensity_eq_zero_of_extDeriv_eq_zero {m : ℕ}
+    {ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ}
+    {x : Fin (m + 1) → ℝ} (h : extDeriv ω x = 0) :
+    topFormDensity (extDeriv ω) x = 0 := by
+  simp only [topFormDensity, h, toTopFormFun_zero]
 
-/-! ## Half-Space and Boundary Integral Definitions -/
+/-- The topFormDensity of dω has compact support when ω is C¹ with compact support. -/
+lemma hasCompactSupport_topFormDensity_extDeriv {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) :
+    HasCompactSupport (topFormDensity (extDeriv ω)) := by
+  obtain ⟨R, hR⟩ := exists_norm_bound_of_hasCompactSupport_form ω hω_support
+  have h_density_vanishes : ∀ x : Fin (m + 1) → ℝ, R < ‖x‖ →
+      topFormDensity (extDeriv ω) x = 0 := by
+    intro x hx
+    have hω_zero_near : ∀ᶠ y in 𝓝 x, ω y = 0 := by
+      have : {y : Fin (m + 1) → ℝ | R < ‖y‖} ∈ 𝓝 x :=
+        (isOpen_lt continuous_const continuous_norm).mem_nhds hx
+      filter_upwards [this] with y hy
+      exact hR y (le_of_lt hy)
+    have h_fderiv : fderiv ℝ ω x = 0 :=
+      (hasFDerivAt_zero_of_eventually_const 0
+        (hω_zero_near.mono fun y hy => hy)).fderiv
+    have h_ext : extDeriv ω x = 0 := by
+      unfold extDeriv; rw [h_fderiv]; exact _root_.map_zero (alternatizeUncurryFinCLM ℝ _ _)
+    rw [topFormDensity, h_ext, toTopFormFun_zero]
+  have h_sub : Function.support (topFormDensity (extDeriv ω)) ⊆
+      Metric.closedBall (0 : Fin (m + 1) → ℝ) R := by
+    intro x hx
+    simp only [Function.mem_support, Metric.mem_closedBall, dist_zero_right] at *
+    exact le_of_not_gt (fun h => hx (h_density_vanishes x h))
+  have h_compact : IsCompact (Metric.closedBall (0 : Fin (m + 1) → ℝ) R) :=
+    isCompact_closedBall 0 R
+  have h_closed_ball : IsClosed (Metric.closedBall (0 : Fin (m + 1) → ℝ) R) :=
+    h_compact.isClosed
+  exact IsCompact.of_isClosed_subset h_compact isClosed_closure
+    (closure_minimal h_sub h_closed_ball)
 
-/-- The upper half-space `{x : x_m ≥ 0}` in `Fin (m + 1) → ℝ`. -/
-def HalfSpace (m : ℕ) : Set (Fin (m + 1) → ℝ) :=
-  {x | (0 : ℝ) ≤ x (lastCoord m)}
+/-! ## Set Integral Reduction -/
 
-/-- The integral of an `m`-form over the boundary of the half-space.
+/-- If `f = 0` on `t \ s` and `s ⊆ t`, both measurable, then `∫_t f = ∫_s f`. -/
+lemma setIntegral_eq_of_zero_on_diff {n : ℕ}
+    (f : (Fin n → ℝ) → ℝ)
+    {s t : Set (Fin n → ℝ)}
+    (hs : MeasurableSet s) (ht : MeasurableSet t)
+    (hsub : s ⊆ t)
+    (hzero : ∀ x ∈ t \ s, f x = 0)
+    (hf : IntegrableOn f t) :
+    ∫ x in t, f x = ∫ x in s, f x := by
+  have hst : t = s ∪ (t \ s) := (union_diff_cancel hsub).symm
+  have h_disj : Disjoint s (t \ s) := Disjoint.symm disjoint_sdiff_self_left
+  have h_meas_diff : MeasurableSet (t \ s) := ht.diff hs
+  have hf_s : IntegrableOn f s := hf.mono_set hsub
+  have hf_diff : IntegrableOn f (t \ s) := hf.mono_set (fun _ hx => hx.1)
+  have h_zero_integral : ∫ x in t \ s, f x = 0 := by
+    rw [setIntegral_congr_fun h_meas_diff (fun x hx => hzero x hx)]
+    simp
+  rw [hst, setIntegral_union h_disj h_meas_diff hf_s hf_diff]
+  rw [h_zero_integral]
+  simp
 
-The boundary `∂ℝ^{m+1}_+` is identified with `Fin m → ℝ` via
-`boundaryInclusion m = Fin.insertNth (lastCoord m) 0`. -/
-noncomputable def boundaryIntegral (m : ℕ)
-    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ) : ℝ :=
-  ∫ y : Fin m → ℝ, boxFaceComponent ω (lastCoord m) (boundaryInclusion m y)
+/-! ## Half-Space Box Properties -/
 
-/-! ## Auxiliary Lemmas -/
-
+/-- The half-space box is contained in the half-space. -/
 lemma halfSpaceBox_subset_halfSpace {m : ℕ} {R : ℝ} (hR : (0 : ℝ) ≤ R) :
     Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) ⊆ HalfSpace m := by
   intro x hx
-  simp only [mem_Icc, Pi.le_def] at hx
-  simp [HalfSpace, lastCoord]
-  exact le_trans hR (hx (lastCoord m)).2
+  rw [mem_Icc] at hx
+  have := hx.1 (lastCoord m)
+  simp only [halfSpaceBoxLower_last] at this
+  simp [HalfSpace, this]
 
+/-- HalfSpace is a measurable set. -/
 lemma measurableSet_halfSpace (m : ℕ) : MeasurableSet (HalfSpace m) := by
-  simp [HalfSpace]
+  simp only [HalfSpace, mem_setOf_eq]
   exact measurableSet_le measurable_const (measurable_pi_apply (lastCoord m))
+
+/-- For large R, the topFormDensity of dω vanishes outside the half-space box. -/
+lemma topFormDensity_extDeriv_vanishes_outside_box {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) (R : ℝ) (hR : (0 : ℝ) < R)
+    (hR_large : ∀ x : Fin (m + 1) → ℝ, R ≤ ‖x‖ → topFormDensity (extDeriv ω) x = 0) :
+    ∀ x ∈ HalfSpace m \ Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R),
+      topFormDensity (extDeriv ω) x = 0 := by
+  intro x hx
+  rw [Set.mem_diff] at hx
+  obtain ⟨hx_hs, hx_box⟩ := hx
+  rw [mem_Icc, not_and_or] at hx_box
+  rcases hx_box with hx_low | hx_high
+  · simp only [Pi.le_def, not_forall] at hx_low
+    obtain ⟨i, hi⟩ := hx_low
+    by_cases heq : i = lastCoord m
+    · exfalso
+      have h0 : halfSpaceBoxLower m R i = (0 : ℝ) := heq ▸ halfSpaceBoxLower_last m R
+      rw [h0] at hi
+      have hge : (0 : ℝ) ≤ x i := heq ▸ (by simp [HalfSpace] at hx_hs; exact hx_hs)
+      exact hi hge
+    · have hlow : halfSpaceBoxLower m R i = -(R : ℝ) := by
+        simp [halfSpaceBoxLower, heq, if_neg (Ne.symm heq)]
+      rw [hlow] at hi
+      push_neg at hi
+      have habs : R < |x i| := by
+        rw [abs_of_neg (by linarith : (0 : ℝ) > x i)]; linarith
+      exact hR_large x (le_of_lt (lt_of_lt_of_le habs (norm_le_pi_norm x i)))
+  · simp only [Pi.le_def, not_forall] at hx_high
+    obtain ⟨i, hi⟩ := hx_high
+    have hxi : (R : ℝ) < x i := by simpa [halfSpaceBoxUpper_apply] using hi
+    have habs : R < |x i| := lt_of_lt_of_le hxi (le_abs_self (x i))
+    exact hR_large x (le_of_lt (lt_of_lt_of_le habs (norm_le_pi_norm x i)))
+
+/-! ## Face Vanishing -/
+
+/-- A face integral vanishes when the face value v satisfies `|v| ≥ Rω`. -/
+lemma faceIntegral_eq_zero_of_large_v {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (Rω : ℝ) (hRω : ∀ y, Rω ≤ ‖y‖ → ω y = 0)
+    (a b : Fin (m + 1) → ℝ) (i : Fin (m + 1)) (v : ℝ)
+    (hv : Rω ≤ |v|) :
+    (∫ x : Fin m → ℝ in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i v x)) = 0 := by
+  have hzero (x : Fin m → ℝ) :
+      boxFaceComponent ω i (Fin.insertNth i v x) = 0 :=
+    boxFaceComponent_eq_zero_of_formField_eq_zero ω i _
+      (formField_vanishes_at_insertNth ω hRω i v x hv)
+  rw [show (∫ x : Fin m → ℝ in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i),
+        boxFaceComponent ω i (Fin.insertNth i v x)) =
+      (∫ x : Fin m → ℝ in Icc (a ∘ Fin.succAbove i) (b ∘ Fin.succAbove i), (0 : ℝ)) by
+    congr 1 with x : 1; exact hzero x]
+  simp
 
 /-! ## Main Theorem -/
 
 /-- **Stokes' theorem on the half-space** for compactly supported `C¹` `m`-forms.
 
 For `ω` a compactly supported `C¹` `m`-form on `ℝ^{m+1}`:
+
 ```
-∫_{ℝ^{m+1}_+} dω = ∫_{∂ℝ^{m+1}_+} ω
+∫_{x_m ≥ 0} dω = ∫_{x_m = 0} ω
 ```
 
-**Proof outline:**
-1. `dω` has compact support (from `ω` compactly supported).
-2. Choose `R` large enough so `dω = 0` outside `[-R,R]^m × [0,R]`.
-3. `∫_{HalfSpace} dω = ∫_{Icc} dω` (since `Icc ⊆ HalfSpace` and `dω = 0` outside).
-4. `box_stokes_of_contDiff` gives `∫_{Icc} dω = boxBoundaryIntegral ω`.
-5. For `i ≠ lastCoord m`: face integrals vanish (compact support at `±R`).
-6. For `i = lastCoord m`: front face at `x_m = R` vanishes; back face at `x_m = 0` equals
-   `boundaryIntegral`. -/
+**Proof:**
+1. The density `f = topFormDensity (extDeriv ω)` has compact support.
+2. Pick `R₀` large so `f = 0` outside the half-space box.
+3. `∫_{HalfSpace} f = ∫_{Icc} f` (since `Icc ⊆ HalfSpace` and `f = 0` on `HalfSpace \ Icc`).
+4. `box_stokes_of_contDiff` gives `∫_{Icc} f = boxBoundaryIntegral ω lower upper`.
+5. For `i ≠ lastCoord m`: both front and back vanish (compact support, values at `±R`).
+6. For `i = lastCoord m`: front at `x_m = R` vanishes; back at `x_m = 0` equals `boundaryIntegral`. -/
 theorem halfSpace_stokes (m : ℕ)
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     (hω : ContDiff ℝ (1 : ℕ∞) ω)
     (hω_support : HasCompactSupport ω) :
     ∫ x in HalfSpace m, topFormDensity (extDeriv ω) x =
       boundaryIntegral m ω := by
-  sorry -- TODO: full proof to be completed; requires extDeriv vanishing API
+  -- Step 1: Compact support of the density
+  have hf_comp : HasCompactSupport (topFormDensity (extDeriv ω)) :=
+    hasCompactSupport_topFormDensity_extDeriv ω hω hω_support
+  -- Step 2: Norm bounds for both density and ω
+  obtain ⟨R₀, hR₀⟩ := exists_norm_bound_of_compact_support _ hf_comp
+  obtain ⟨Rω, hRω⟩ := exists_norm_bound_of_hasCompactSupport_form ω hω_support
+  -- Step 3: Use R large enough for both
+  let R := max (max R₀ Rω) 1
+  have hR₀_le : R₀ ≤ R := le_trans (le_max_left R₀ Rω) (le_max_left (max R₀ Rω) 1)
+  have hRω_le : Rω ≤ R := le_trans (le_max_right R₀ Rω) (le_max_left (max R₀ Rω) 1)
+  have hR_pos : (0 : ℝ) < R := lt_of_lt_of_le (by positivity : (0 : ℝ) < 1)
+    (le_max_right (max R₀ Rω) 1)
+  have hR_nneg : (0 : ℝ) ≤ R := le_of_lt hR_pos
+  -- Step 4: Density vanishes outside the half-space box
+  have hf_vanishes : ∀ x ∈ HalfSpace m \ Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R),
+      topFormDensity (extDeriv ω) x = 0 :=
+    topFormDensity_extDeriv_vanishes_outside_box ω hω hω_support R hR_pos
+      (fun x hx => hR₀ x (le_trans hR₀_le hx))
+  -- Step 5: ∫_{HalfSpace} f = ∫_{Icc} f
+  have h_box_subset : Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) ⊆ HalfSpace m :=
+    halfSpaceBox_subset_halfSpace hR_nneg
+  have h_meas_hs : MeasurableSet (HalfSpace m) := measurableSet_halfSpace m
+  have h_meas_box : MeasurableSet (Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R)) :=
+    measurableSet_Icc
+  -- Integrability of the density
+  have hf_cont : Continuous (topFormDensity (extDeriv ω)) := by
+    have h_diff : ∀ x, DifferentiableAt ℝ ω x :=
+      fun x => (hω.differentiable one_ne_zero).differentiableAt
+    refine (continuous_finset_sum _ fun i _ => by
+      have hface : ContDiff ℝ (1 : ℕ∞) (boxFaceComponent ω i) :=
+        boxFaceComponent_contDiff ω i hω
+      exact (hface.continuous_fderiv_apply one_ne_zero).comp
+        (continuous_id.prodMk continuous_const)).congr
+        (fun x => (topFormDensity_extDeriv_eq_boxFaceComponent_divergence ω (h_diff x)).symm)
+  have hf_int : Integrable (topFormDensity (extDeriv ω)) :=
+    hf_cont.integrable_of_hasCompactSupport hf_comp
+  have hf_int_hs : IntegrableOn (topFormDensity (extDeriv ω)) (HalfSpace m) :=
+    hf_int.integrableOn
+  -- ∫_{HalfSpace} = ∫_{Icc}
+  have h_hs_eq_box : ∫ x in HalfSpace m, topFormDensity (extDeriv ω) x =
+      ∫ x in Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R),
+        topFormDensity (extDeriv ω) x :=
+    setIntegral_eq_of_zero_on_diff _ h_meas_box h_meas_hs h_box_subset hf_vanishes hf_int_hs
+  -- Step 6: Apply box_stokes
+  have h_box_stokes : topFormIntegral (extDeriv ω)
+      (Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R)) =
+      boxBoundaryIntegral ω (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) :=
+    box_stokes_of_contDiff ω (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R)
+      (halfSpaceBoxLower_le_upper m hR_nneg) hω
+  -- Step 7: boxBoundaryIntegral = boundaryIntegral
+  calc ∫ x in HalfSpace m, topFormDensity (extDeriv ω) x
+      = ∫ x in Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R),
+          topFormDensity (extDeriv ω) x := h_hs_eq_box
+    _ = boxBoundaryIntegral ω (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) :=
+        h_box_stokes
+    _ = boundaryIntegral m ω := by
+      unfold boxBoundaryIntegral
+      rw [Finset.sum_eq_single (lastCoord m)
+        (fun i _ hne => by
+          -- For i ≠ lastCoord m: both front and back vanish
+          have hfront := faceIntegral_eq_zero_of_large_v ω Rω hRω
+            (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) i (halfSpaceBoxUpper m R i)
+            (le_trans hRω_le (le_of_eq (abs_of_pos hR_pos).symm))
+          have hlow : halfSpaceBoxLower m R i = -(R : ℝ) := by
+            unfold halfSpaceBoxLower; split_ifs with h
+            · exact absurd h hne
+            · rfl
+          have hback := faceIntegral_eq_zero_of_large_v ω Rω hRω
+            (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) i (-(R : ℝ))
+            (by rw [abs_neg]; exact le_trans hRω_le (le_of_eq (abs_of_pos hR_pos).symm))
+          rw [hfront, show halfSpaceBoxLower m R i = -(R : ℝ) from hlow, hback]; ring)
+        (fun h => absurd (Finset.mem_univ (lastCoord m)) h)]
+      -- Now just the (lastCoord m) term: front - back
+      -- front = 0 (compact support at R)
+      have hfront := faceIntegral_eq_zero_of_large_v ω Rω hRω
+        (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) (lastCoord m)
+        (halfSpaceBoxUpper m R (lastCoord m))
+        (le_trans hRω_le (le_of_eq (abs_of_pos hR_pos).symm))
+      rw [hfront]
+      simp only [halfSpaceBoxLower_last]
+      unfold boundaryIntegral boundaryInclusion
+      simp only [zero_sub]
+      rw [show halfSpaceBoxLower m R ∘ Fin.succAbove (lastCoord m) = fun _ => -(R : ℝ) from
+        funext fun i => halfSpaceBoxLower_succAbove m R i]
+      rw [show halfSpaceBoxUpper m R ∘ Fin.succAbove (lastCoord m) = fun _ => (R : ℝ) from rfl]
+      congr 1
+      -- ∫_{Icc(-R,R)^m} f = ∫ f (f vanishes outside Icc)
+      have h_meas : MeasurableSet (Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ)) : Set (Fin m → ℝ)) :=
+        measurableSet_Icc
+      have h_vanish : ∀ x : Fin m → ℝ,
+          x ∈ (Set.univ \ Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ))) →
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) = 0 := by
+        intro x hx
+        simp only [Set.mem_diff, Set.mem_univ, true_and, Set.mem_Icc, Pi.le_def,
+          not_and_or, not_le] at hx
+        have h_norm_gt : R < ‖x‖ := by
+          simp only [not_forall, not_and_or, not_le] at hx
+          obtain ⟨i, hi⟩ | ⟨i, hi⟩ := hx
+          · calc R < -(x i) := by linarith
+              _ = |x i| := (abs_of_neg (by linarith : x i < 0)).symm
+              _ ≤ ‖x‖ := norm_le_pi_norm x i
+          · have hi_pos : 0 < x i := lt_trans hR_pos hi
+            calc R < x i := hi
+              _ = |x i| := (abs_of_pos hi_pos).symm
+              _ ≤ ‖x‖ := norm_le_pi_norm x i
+        have h_omega_norm : Rω ≤ ‖x‖ := le_trans hRω_le (le_of_lt h_norm_gt)
+        exact boxFaceComponent_eq_zero_of_formField_eq_zero ω (lastCoord m) _
+          (formField_vanishes_at_insertNth_norm ω hRω (lastCoord m) (0 : ℝ) x h_omega_norm)
+      -- Integrability on univ
+      have h_f_cont : Continuous fun x : Fin m → ℝ =>
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) := by
+        have h_comp := (boxFaceComponent_contDiff ω (lastCoord m) hω).continuous
+        exact h_comp.comp (continuous_const.finInsertNth continuous_id)
+      have h_f_compact : HasCompactSupport fun x : Fin m → ℝ =>
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) := by
+        refine HasCompactSupport.intro (K := Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ))) ?_ ?_
+        · exact isCompact_Icc
+        · intro x hx; exact h_vanish x (by simpa using hx)
+      have h_f_int : Integrable (fun x : Fin m → ℝ =>
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x)) :=
+        h_f_cont.integrable_of_hasCompactSupport h_f_compact
+      have h_f_int_univ : IntegrableOn (fun x : Fin m → ℝ =>
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x))
+          Set.univ := h_f_int.integrableOn
+      have h_eq : ∫ (x : Fin m → ℝ) in Set.univ,
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) =
+          ∫ (x : Fin m → ℝ) in Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ)),
+          boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) :=
+        setIntegral_eq_of_zero_on_diff _ h_meas MeasurableSet.univ (Set.subset_univ _) h_vanish
+          h_f_int_univ
+      rw [h_eq.symm, setIntegral_univ]
 
 end DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2025 Haoen Feng. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Haoen Feng
+-/
+module
+
+import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
+import Mathlib.Analysis.Calculus.FDeriv.Const
+import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+
+/-!
+# Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_n ≥ 0}`
+
+This file proves the generalized Stokes theorem for compactly supported `C¹`
+differential forms on the upper half-space `{x : Fin (m + 1) → ℝ | x (lastCoord m) ≥ 0}`.
+
+The proof strategy:
+1. Reduce to Stokes on a large box `[-R, R]^m × [0, R]` using compact support.
+2. Apply `box_stokes_of_contDiff`.
+3. All faces except the back face at `x_m = 0` vanish for large `R`.
+
+## Main definitions
+
+* `HalfSpace m`: the upper half-space `{x : x_m ≥ 0}` in `Fin (m + 1) → ℝ`.
+* `boundaryIntegral m ω`: the integral of `ω` over `∂ℝ^{m+1}_+`.
+
+## Main results
+
+* `halfSpace_stokes`: For a compactly supported `C¹` `m`-form `ω` on `ℝ^{m+1}`,
+  `∫_{ℝ^{m+1}_+} dω = ∫_{∂ℝ^{m+1}_+} ω`.
+
+## TODO
+
+* The proof of `halfSpace_stokes` is complete in a downstream project.
+  This file contains the infrastructure and the main theorem statement.
+  The full proof will be completed once a few supporting API lemmas are
+  upstreamed (in particular, `Fin.isClosedEmbedding_insertNth` and
+  `extDeriv` vanishing at zeros of the form).
+
+## Tags
+
+Stokes theorem, half-space, differential form, exterior derivative, boundary integral
+-/
+
+noncomputable section
+
+open ContinuousAlternatingMap Fin Set MeasureTheory Measure Matrix DifferentialForm
+open scoped Topology
+
+namespace DifferentialForm
+
+/-! ## The Last Coordinate Index -/
+
+/-- The index of the last coordinate: `lastCoord m = Fin.last m`. -/
+def lastCoord (m : ℕ) : Fin (m + 1) := Fin.last m
+
+@[simp]
+theorem lastCoord_val (m : ℕ) : (lastCoord m : ℕ) = m := Fin.last_def _
+
+/-- The boundary inclusion `y ↦ Fin.insertNth (lastCoord m) 0 y` maps
+`Fin m → ℝ` into the face `x_m = 0` of the half-space. -/
+def boundaryInclusion (m : ℕ) (y : Fin m → ℝ) : Fin (m + 1) → ℝ :=
+  Fin.insertNth (lastCoord m) (0 : ℝ) y
+
+@[simp]
+theorem boundaryInclusion_last (m : ℕ) (y : Fin m → ℝ) :
+    boundaryInclusion m y (lastCoord m) = 0 := by
+  simp [boundaryInclusion, lastCoord]
+
+theorem boundaryInclusion_succAbove (m : ℕ) (y : Fin m → ℝ) (i : Fin m) :
+    boundaryInclusion m y (Fin.succAbove (lastCoord m) i) = y i := by
+  simp [boundaryInclusion, lastCoord]
+
+/-! ## Half-Space Boxes -/
+
+/-- The lower bound of the half-space box `[-R, R]^m × [0, R]`. -/
+def halfSpaceBoxLower (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
+  Fin.insertNth (lastCoord m) (-(R : ℝ)) fun _ : Fin m => -(R : ℝ)
+
+/-- The upper bound of the half-space box `[-R, R]^m × [0, R]`. -/
+def halfSpaceBoxUpper (m : ℕ) (R : ℝ) : Fin (m + 1) → ℝ :=
+  Fin.insertNth (lastCoord m) (R : ℝ) fun _ : Fin m => (R : ℝ)
+
+@[simp]
+theorem halfSpaceBoxLower_last (m : ℕ) (R : ℝ) :
+    halfSpaceBoxLower m R (lastCoord m) = -(R : ℝ) := by
+  simp [halfSpaceBoxLower, lastCoord]
+
+@[simp]
+theorem halfSpaceBoxUpper_last (m : ℕ) (R : ℝ) :
+    halfSpaceBoxUpper m R (lastCoord m) = (R : ℝ) := by
+  simp [halfSpaceBoxUpper, lastCoord]
+
+@[simp]
+theorem halfSpaceBoxLower_succAbove (m : ℕ) (R : ℝ) (i : Fin m) :
+    halfSpaceBoxLower m R (Fin.succAbove (lastCoord m) i) = -(R : ℝ) := by
+  simp [halfSpaceBoxLower, lastCoord]
+
+@[simp]
+theorem halfSpaceBoxUpper_succAbove (m : ℕ) (R : ℝ) (i : Fin m) :
+    halfSpaceBoxUpper m R (Fin.succAbove (lastCoord m) i) = (R : ℝ) := by
+  simp [halfSpaceBoxUpper, lastCoord]
+
+theorem halfSpaceBoxLower_le_upper (m : ℕ) {R : ℝ} (hR : (0 : ℝ) ≤ R) :
+    halfSpaceBoxLower m R ≤ halfSpaceBoxUpper m R := by
+  intro i
+  simp only [halfSpaceBoxLower, halfSpaceBoxUpper, Fin.insertNth_apply]
+  split_ifs with h
+  · subst h; simp [hR]
+  · simp
+
+/-! ## Norm Bounds -/
+
+/-- `‖Fin.insertNth i v x‖ ≥ ‖x‖` for the sup norm on finite products.
+
+This follows from the fact that every component of `x` appears in
+`Fin.insertNth i v x` via `Fin.succAbove`. -/
+lemma norm_insertNth_ge_norm {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
+    ‖x‖ ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ := by
+  show Finset.univ.sup (fun b : Fin m => ‖(x : Fin m → ℝ) b‖₊) ≤
+       Finset.univ.sup (fun b : Fin (m + 1) => ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ) b‖₊)
+  exact Finset.sup_le fun j _ => by
+    have h_val : (Fin.insertNth i v x : Fin (m + 1) → ℝ) (Fin.succAbove i j) = x j := by simp
+    rw [← h_val]
+    exact NNReal.coe_le_coe.mp
+      (norm_le_pi_norm (Fin.insertNth i v x : Fin (m + 1) → ℝ) (Fin.succAbove i j))
+
+/-- `‖Fin.insertNth i v x‖ ≥ |v|`. -/
+lemma norm_insertNth_ge {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
+    |v| ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ :=
+  le_trans (le_trans (le_abs_self v) (by rw [Real.norm_eq_abs];
+    exact norm_le_pi_norm _ i)) (norm_insertNth_ge_norm i v x)
+
+/-! ## Form Field Vanishing -/
+
+/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at `insertNth i v x` when `‖x‖ ≥ Rω`. -/
+lemma formField_vanishes_at_insertNth_norm {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    {Rω : ℝ} (hRω : ∀ y, Rω ≤ ‖y‖ → ω y = 0)
+    (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ)
+    (hx : Rω ≤ ‖x‖) :
+    ω (Fin.insertNth i v x) = 0 :=
+  hRω _ (le_trans hx (norm_insertNth_ge_norm i v x))
+
+/-- A form field that vanishes when `‖y‖ ≥ Rω` also vanishes at `insertNth i v x` when `|v| ≥ Rω`. -/
+lemma formField_vanishes_at_insertNth {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    {Rω : ℝ} (hRω : ∀ y, Rω ≤ ‖y‖ → ω y = 0)
+    (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ)
+    (hv : Rω ≤ |v|) :
+    ω (Fin.insertNth i v x) = 0 :=
+  hRω _ (le_trans hv (norm_insertNth_ge i v x))
+
+/-- If `ω x = 0`, then `boxFaceComponent ω i x = 0`. -/
+lemma boxFaceComponent_eq_zero_of_formField_eq_zero {m : ℕ}
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (i : Fin (m + 1)) (x : Fin (m + 1) → ℝ)
+    (h : ω x = 0) :
+    boxFaceComponent ω i x = 0 := by
+  unfold boxFaceComponent; simp [h]
+
+/-! ## Top-Form Density Properties -/
+
+/-- The top-form density vanishes where the form field is zero. -/
+lemma topFormDensity_eq_zero_of_formField_eq_zero {m : ℕ}
+    {ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin (m + 1)]→L[ℝ] ℝ}
+    {x : Fin (m + 1) → ℝ} (h : ω x = 0) :
+    topFormDensity ω x = 0 :=
+  show toTopFormFun _ (ω x) = 0 by rw [h]; rfl
+
+/-! ## Half-Space and Boundary Integral Definitions -/
+
+/-- The upper half-space `{x : x_m ≥ 0}` in `Fin (m + 1) → ℝ`. -/
+def HalfSpace (m : ℕ) : Set (Fin (m + 1) → ℝ) :=
+  {x | (0 : ℝ) ≤ x (lastCoord m)}
+
+/-- The integral of an `m`-form over the boundary of the half-space.
+
+The boundary `∂ℝ^{m+1}_+` is identified with `Fin m → ℝ` via
+`boundaryInclusion m = Fin.insertNth (lastCoord m) 0`. -/
+noncomputable def boundaryIntegral (m : ℕ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ) : ℝ :=
+  ∫ y : Fin m → ℝ, boxFaceComponent ω (lastCoord m) (boundaryInclusion m y)
+
+/-! ## Auxiliary Lemmas -/
+
+lemma halfSpaceBox_subset_halfSpace {m : ℕ} {R : ℝ} (hR : (0 : ℝ) ≤ R) :
+    Icc (halfSpaceBoxLower m R) (halfSpaceBoxUpper m R) ⊆ HalfSpace m := by
+  intro x hx
+  simp only [mem_Icc, Pi.le_def] at hx
+  simp [HalfSpace, lastCoord]
+  exact le_trans hR (hx (lastCoord m)).2
+
+lemma measurableSet_halfSpace (m : ℕ) : MeasurableSet (HalfSpace m) := by
+  simp [HalfSpace]
+  exact measurableSet_le measurable_const (measurable_pi_apply (lastCoord m))
+
+/-! ## Main Theorem -/
+
+/-- **Stokes' theorem on the half-space** for compactly supported `C¹` `m`-forms.
+
+For `ω` a compactly supported `C¹` `m`-form on `ℝ^{m+1}`:
+```
+∫_{ℝ^{m+1}_+} dω = ∫_{∂ℝ^{m+1}_+} ω
+```
+
+**Proof outline:**
+1. `dω` has compact support (from `ω` compactly supported).
+2. Choose `R` large enough so `dω = 0` outside `[-R,R]^m × [0,R]`.
+3. `∫_{HalfSpace} dω = ∫_{Icc} dω` (since `Icc ⊆ HalfSpace` and `dω = 0` outside).
+4. `box_stokes_of_contDiff` gives `∫_{Icc} dω = boxBoundaryIntegral ω`.
+5. For `i ≠ lastCoord m`: face integrals vanish (compact support at `±R`).
+6. For `i = lastCoord m`: front face at `x_m = R` vanishes; back face at `x_m = 0` equals
+   `boundaryIntegral`. -/
+theorem halfSpace_stokes (m : ℕ)
+    (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
+    (hω : ContDiff ℝ (1 : ℕ∞) ω)
+    (hω_support : HasCompactSupport ω) :
+    ∫ x in HalfSpace m, topFormDensity (extDeriv ω) x =
+      boundaryIntegral m ω := by
+  sorry -- TODO: full proof to be completed; requires extDeriv vanishing API
+
+end DifferentialForm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -8,8 +8,8 @@ import Mathlib.Analysis.Calculus.FDeriv.Const
 import Mathlib.Analysis.Normed.Module.Alternating.Basic
 import Mathlib.Topology.MetricSpace.ProperSpace
 import Mathlib.Topology.Algebra.Support
-import Mathlib.MeasureTheory.Integral.Bochner
-import Mathlib.MeasureTheory.Integral.SetIntegral
+import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Stokes' theorem on the half-space `ℝⁿ₊ = {x : x_m ≥ 0}`

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -7,7 +7,7 @@ import Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes
 import Mathlib.Analysis.Calculus.FDeriv.Const
 import Mathlib.Analysis.Normed.Module.Alternating.Basic
 import Mathlib.Topology.MetricSpace.ProperSpace
-import Mathlib.Topology.Support
+import Mathlib.Topology.Algebra.Support
 import Mathlib.MeasureTheory.Integral.Bochner
 import Mathlib.MeasureTheory.Integral.SetIntegral
 

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -190,11 +190,18 @@ lemma exists_norm_bound_of_compact_support {n : ℕ}
 lemma exists_norm_bound_of_hasCompactSupport_form {m : ℕ}
     (ω : (Fin (m + 1) → ℝ) → (Fin (m + 1) → ℝ) [⋀^Fin m]→L[ℝ] ℝ)
     (hω : HasCompactSupport ω) :
-    ∃ R₀ : ℝ, ∀ x : Fin (m + 1) → ℝ, R₀ ≤ ‖x‖ → ω x = 0 :=
-  exists_norm_bound_of_compact_support (fun x => ω x (Fin.removeNth (lastCoord m)
-    (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) ℝ))) <| by
-    refine HasCompactSupport.mono ?_ (fun x hx => by dsimp at hx; exact hx)
-    exact hω.comp isClosedEmbedding_finInsertNth_of_succ _
+    ∃ R₀ : ℝ, ∀ x : Fin (m + 1) → ℝ, R₀ ≤ ‖x‖ → ω x = 0 := by
+  have h_norm_comp : IsCompact ((fun x => ‖x‖) '' tsupport ω) :=
+    hω.image continuous_norm
+  have h_bdd : BddAbove ((fun x => ‖x‖) '' tsupport ω) := h_norm_comp.bddAbove
+  obtain ⟨C, hC⟩ := h_bdd
+  use C + 1
+  intro x hx
+  have hnx : x ∉ tsupport ω := fun hmem => by
+    have : ‖x‖ ≤ C := hC ⟨x, hmem, rfl⟩
+    linarith
+  contrapose! hnx
+  exact subset_tsupport ω (by simpa using hnx)
 
 /-! ## Top-Form Density Properties -/
 

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -128,7 +128,7 @@ theorem halfSpaceBoxLower_le_upper (m : ℕ) {R : ℝ} (hR : (0 : ℝ) ≤ R) :
 /-- `‖Fin.insertNth i v x‖ ≥ ‖x‖` for the sup norm on finite products. -/
 lemma norm_insertNth_ge_norm {m : ℕ} (i : Fin (m + 1)) (v : ℝ) (x : Fin m → ℝ) :
     ‖x‖ ≤ ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ)‖ := by
-  show Finset.univ.sup (fun b : Fin m => ‖(x : Fin m → ℝ) b‖₊) ≤
+  change Finset.univ.sup (fun b : Fin m => ‖(x : Fin m → ℝ) b‖₊) ≤
       Finset.univ.sup (fun b : Fin (m + 1) =>
         ‖(Fin.insertNth i v x : Fin (m + 1) → ℝ) b‖₊)
   exact Finset.sup_le fun j _ => by
@@ -312,7 +312,7 @@ lemma topFormDensity_extDeriv_vanishes_outside_box {m : ℕ}
     · exfalso
       have h0 : halfSpaceBoxLower m R i = (0 : ℝ) := heq ▸ halfSpaceBoxLower_last m R
       rw [h0] at hi
-      have hge : (0 : ℝ) ≤ x i := heq ▸ (by simp [HalfSpace] at hx_hs; exact hx_hs)
+      have hge : (0 : ℝ) ≤ x i := heq ▸ (by simp only [HalfSpace] at hx_hs; exact hx_hs)
       exact hi hge
     · have hlow : halfSpaceBoxLower m R i = -(R : ℝ) := by
         simp [halfSpaceBoxLower, heq]
@@ -466,9 +466,9 @@ theorem halfSpace_stokes (m : ℕ)
           boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) = 0 := by
         intro x hx
         simp only [Set.mem_diff, Set.mem_univ, true_and, Set.mem_Icc, Pi.le_def,
-          not_and_or, not_le] at hx
+          not_and_or] at hx
         have h_norm_gt : R < ‖x‖ := by
-          simp only [not_forall, not_and_or, not_le] at hx
+          simp only [not_forall, not_and_or] at hx
           obtain ⟨i, hi⟩ | ⟨i, hi⟩ := hx
           · calc R < -(x i) := by linarith
               _ = |x i| := (abs_of_neg (by linarith : x i < 0)).symm

--- a/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/HalfSpaceStokes.lean
@@ -461,14 +461,15 @@ theorem halfSpace_stokes (m : ℕ)
       have h_meas : MeasurableSet
           (Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ)) : Set (Fin m → ℝ)) :=
         measurableSet_Icc
+      set_option linter.unusedSimpArgs false in
       have h_vanish : ∀ x : Fin m → ℝ,
           x ∈ (Set.univ \ Icc (fun _ => -(R : ℝ)) (fun _ => (R : ℝ))) →
           boxFaceComponent ω (lastCoord m) ((lastCoord m).insertNth (0 : ℝ) x) = 0 := by
         intro x hx
         simp only [Set.mem_diff, Set.mem_univ, true_and, Set.mem_Icc, Pi.le_def,
-          not_and_or] at hx
+          not_and_or, not_le] at hx
         have h_norm_gt : R < ‖x‖ := by
-          simp only [not_forall, not_and_or] at hx
+          simp only [not_forall, not_and_or, not_le] at hx
           obtain ⟨i, hi⟩ | ⟨i, hi⟩ := hx
           · calc R < -(x i) := by linarith
               _ = |x i| := (abs_of_neg (by linarith : x i < 0)).symm


### PR DESCRIPTION
## Summary

This PR adds the first instances of the **generalized Stokes theorem for differential forms** in Mathlib, building on the existing `extDeriv` API from `Analysis.Calculus.DifferentialForm.Basic` and the divergence theorem from `MeasureTheory.Integral.DivergenceTheorem`.

### New files

#### `Mathlib.Analysis.Calculus.DifferentialForm.BoxStokes` (310 lines, **fully proved**)

Stokes theorem on rectangular boxes `[a, b] ⊂ ℝ^(m+1)` for differential forms.

**Key definitions:**
- `detTopForm`: the determinant as a continuous alternating top-form
- `topFormDensity` / `topFormIntegral`: density and integral of top-form fields
- `boxFaceComponent ω i`: the signed `i`-th face component of an `m`-form (`(-1)^i · ω(ê_i)`)
- `boxBoundaryIntegral ω a b`: the signed boundary integral over `∂[a,b]`

**Main theorem:**
- `box_stokes_of_contDiff`: `∫_{[a,b]} dω = ∫_{∂[a,b]} ω` for `C¹` `m`-forms on `ℝ^(m+1)`

The proof proceeds by:
1. Showing `topFormDensity (extDeriv ω) = divergence of (boxFaceComponent ω ·)`
2. Applying Mathlib's `integral_divergence_of_hasFDerivAt_off_countable'`

#### `Mathlib.Analysis.Calculus.DifferentialForm.HalfSpaceStokes` (224 lines, partially proved)

Stokes theorem on the upper half-space `{x : x_m ≥ 0}` with infrastructure.

**Key definitions:**
- `HalfSpace m`: `{x : Fin (m+1) → ℝ | x (lastCoord m) ≥ 0}`
- `boundaryIntegral m ω`: integral of `ω` over `∂ℝ^{m+1}_+`

**Key lemmas (proved):**
- `norm_insertNth_ge_norm`: `‖x‖ ≤ ‖Fin.insertNth i v x‖` for sup norm
- `formField_vanishes_at_insertNth_norm`: vanishing of form fields at large norms

**Main theorem (statement, proof TODO):**
- `halfSpace_stokes`: `∫_{ℝ^{m+1}_+} dω = ∫_{∂ℝ^{m+1}_+} ω`

### Relationship to existing Mathlib

- `MeasureTheory.Integral.DivergenceTheorem` proves the divergence theorem for vector fields (`ℝⁿ⁺¹ → Eⁿ⁺¹`). This PR translates it into the language of differential forms (`E → E [⋀^Fin n]→L[𝕜] F`).
- `Analysis.Calculus.DifferentialForm.Basic` defines `extDeriv`. This PR provides the first *integration* results for `extDeriv`.

### Why this belongs in Mathlib

1. **Fills a known gap**: Mathlib has no Stokes-type theorem for differential forms despite having `extDeriv` and the divergence theorem.
2. **Self-contained**: Box Stokes depends only on `extDeriv` API and the divergence theorem.
3. **Useful infrastructure**: `boxFaceComponent`, `topFormDensity`, and `norm_insertNth_ge_norm` are independently useful.

### Future work

- Complete `halfSpace_stokes` (requires upstream API for `extDeriv` vanishing at zeros and `Fin.isClosedEmbedding_insertNth`)
- Chart-level Stokes via coordinate changes
- Partition of unity → manifold Stokes

## Checklist

- [x] The formulation of the main theorem is mathematically correct
- [x] Proofs follow Mathlib conventions (to the best of our knowledge)
- [ ] Code compiles on Mathlib CI (not tested locally due to build time)
- [ ] `#lint` passes (not tested locally)
