### PR TITLE
[Merged by Bors] - chore(RingTheory/Localization/Finiteness): change some `CommRing` to `CommSemiring`

### DIFF
--- a/Mathlib/RingTheory/Localization/Finiteness.lean
+++ b/Mathlib/RingTheory/Localization/Finiteness.lean
@@ -184,7 +184,7 @@ See `of_localizationSpan'` for a version without the finite set assumption.
 -/
 theorem of_localizationSpan_finite' (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
     {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
-    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    {Rₚ : ∀ (_ : t), Type*} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
     [∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
     [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
     (f : ∀ (g : t), M →ₗ[R] Mₚ g) [∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]
@@ -220,7 +220,7 @@ See `Module.Finite.of_localizationSpan_finite` for the specialized version.
 -/
 theorem of_localizationSpan' (t : Set R) (ht : Ideal.span t = ⊤)
     {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
-    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    {Rₚ : ∀ (_ : t), Type*} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
     [h₁ : ∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
     [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
     (f : ∀ (g : t), M →ₗ[R] Mₚ g) [h₂ : ∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]

--- a/Mathlib/RingTheory/Localization/Finiteness.lean
+++ b/Mathlib/RingTheory/Localization/Finiteness.lean
@@ -35,8 +35,8 @@ section
 
 open scoped Pointwise
 
-variable {R S : Type*} [CommRing R] [CommRing S] (M : Submonoid R) (f : R →+* S)
-variable (R' S' : Type*) [CommRing R'] [CommRing S']
+variable {R S : Type*} [CommSemiring R] [CommSemiring S] (M : Submonoid R) (f : R →+* S)
+variable (R' S' : Type*) [CommSemiring R'] [CommSemiring S']
 variable [Algebra R R'] [Algebra S S']
 
 open scoped Classical in
@@ -146,14 +146,14 @@ lemma of_isLocalization (R S) {Rₚ Sₚ : Type*} [CommSemiring R] [CommSemiring
   use T.image (algebraMap S Sₚ)
   simpa using span_eq_top_localization_localization Rₚ M Sₚ hT
 
-instance {R S : Type*} [CommRing R] {P : Ideal R} [CommRing S] [Algebra R S]
+instance {R S : Type*} [CommSemiring R] {P : Ideal R} [CommSemiring S] [Algebra R S]
     [Module.Finite R S] [P.IsPrime] :
     Module.Finite (Localization.AtPrime P)
       (Localization (Algebra.algebraMapSubmonoid S P.primeCompl)) :=
   .of_isLocalization R S P.primeCompl
 
 open Algebra nonZeroDivisors in
-instance {A C : Type*} [CommRing A] [CommRing C] [Algebra A C] [Module.Finite A C] :
+instance {A C : Type*} [CommRing A] [CommSemiring C] [Algebra A C] [Module.Finite A C] :
     Module.Finite (FractionRing A) (Localization (algebraMapSubmonoid C A⁰)) :=
   have : IsScalarTower A (FractionRing A) (Localization (algebraMapSubmonoid C A⁰)) :=
     instIsScalarTowerLocalizationAlgebraMapSubmonoid A⁰ C
@@ -171,7 +171,7 @@ instance [Module.Finite R M] : Module.Finite (Localization S) (LocalizedModule S
 
 end
 
-variable {R : Type u} [CommRing R] {M : Type w} [AddCommMonoid M] [Module R M]
+variable {R : Type u} [CommSemiring R] {M : Type w} [AddCommMonoid M] [Module R M]
 
 /--
 If there exists a finite set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
@@ -184,7 +184,7 @@ See `of_localizationSpan'` for a version without the finite set assumption.
 -/
 theorem of_localizationSpan_finite' (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
     {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
-    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommRing (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
     [∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
     [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
     (f : ∀ (g : t), M →ₗ[R] Mₚ g) [∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]
@@ -220,7 +220,7 @@ See `Module.Finite.of_localizationSpan_finite` for the specialized version.
 -/
 theorem of_localizationSpan' (t : Set R) (ht : Ideal.span t = ⊤)
     {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
-    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommRing (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommSemiring (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
     [h₁ : ∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
     [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
     (f : ∀ (g : t), M →ₗ[R] Mₚ g) [h₂ : ∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]
@@ -265,7 +265,7 @@ end Module
 
 namespace Ideal
 
-variable {R : Type u} [CommRing R]
+variable {R : Type u} [CommSemiring R]
 
 /-- If `I` is an ideal such that there exists a set `{ r }` of `R` such
 that the image of `I` in `Rᵣ` is finitely generated for each `r`, then `I` is finitely
@@ -279,7 +279,7 @@ lemma fg_of_localizationSpan {I : Ideal R} (t : Set R) (ht : Ideal.span t = ⊤)
 
 end Ideal
 
-variable {R : Type u} [CommRing R] {S : Type v} [CommRing S] {f : R →+* S}
+variable {R : Type u} [CommSemiring R] {S : Type v} [CommSemiring S] {f : R →+* S}
 
 /--
 To check that the kernel of a ring homomorphism is finitely generated,

--- a/Mathlib/RingTheory/Localization/Finiteness.lean
+++ b/Mathlib/RingTheory/Localization/Finiteness.lean
@@ -153,7 +153,7 @@ instance {R S : Type*} [CommSemiring R] {P : Ideal R} [CommSemiring S] [Algebra 
   .of_isLocalization R S P.primeCompl
 
 open Algebra nonZeroDivisors in
-instance {A C : Type*} [CommRing A] [CommSemiring C] [Algebra A C] [Module.Finite A C] :
+instance {A C : Type*} [CommRing A] [CommRing C] [Algebra A C] [Module.Finite A C] :
     Module.Finite (FractionRing A) (Localization (algebraMapSubmonoid C A⁰)) :=
   have : IsScalarTower A (FractionRing A) (Localization (algebraMapSubmonoid C A⁰)) :=
     instIsScalarTowerLocalizationAlgebraMapSubmonoid A⁰ C


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
