### PR TITLE
[Merged by Bors] - feat: add more API for (rel)index and ideals

### DIFF
--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -78,6 +78,8 @@ theorem lsmul_coe (a : A) : (lsmul R B M a : M → M) = (a • ·) := rfl
 
 lemma lsmul_apply (a : A) (m : M) : lsmul R B M a m = a • m := rfl
 
+lemma lsmul_eq_smul_one (a : A) : lsmul R R M a = a • 1 := rfl
+
 end Algebra
 
 namespace IsScalarTower

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -76,6 +76,8 @@ def lsmul : A →ₐ[R] Module.End B M where
 @[simp]
 theorem lsmul_coe (a : A) : (lsmul R B M a : M → M) = (a • ·) := rfl
 
+lemma lsmul_apply (a : A) (m : M) : lsmul R B M a m = a • m := rfl
+
 end Algebra
 
 namespace IsScalarTower

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -234,7 +234,7 @@ lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R K} {n : ℕ
     B.toAddSubgroup.IsFiniteRelIndex A.toAddSubgroup := by
   have := fg_toAddSubgroup hfg
   have := isFiniteRelIndex_map_nsmulAddMonoidHom_of_fg this hn
-  refine isFiniteRelIndex_of_le_left (H₁ := A.toAddSubgroup.map (nsmulAddMonoidHom n))
+  refine isFiniteRelIndex_of_le_left (H := A.toAddSubgroup.map (nsmulAddMonoidHom n))
     A.toAddSubgroup ?_
   rw [SetLike.le_def] at h ⊢
   simpa using h

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -234,7 +234,8 @@ lemma isFiniteRelIndex_of_map_linearMapMulLeft_le {A B : Submodule R K} {n : ℕ
     B.toAddSubgroup.IsFiniteRelIndex A.toAddSubgroup := by
   have := fg_toAddSubgroup hfg
   have := isFiniteRelIndex_map_nsmulAddMonoidHom_of_fg this hn
-  refine isFiniteRelIndex_of_le (H₁ := A.toAddSubgroup.map (nsmulAddMonoidHom n)) A.toAddSubgroup ?_
+  refine isFiniteRelIndex_of_le_left (H₁ := A.toAddSubgroup.map (nsmulAddMonoidHom n))
+    A.toAddSubgroup ?_
   rw [SetLike.le_def] at h ⊢
   simpa using h
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -696,8 +696,7 @@ theorem finiteIndex_toAddSubgroup_iff : H.toAddSubgroup.FiniteIndex ↔ H.Finite
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
 
 @[to_additive (attr := simp)]
-lemma isFiniteRelIndex_top_iff {H : Subgroup G} :
-    H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
+lemma isFiniteRelIndex_top_iff : H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
   rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
 
 @[simp]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -696,7 +696,7 @@ theorem finiteIndex_toAddSubgroup_iff : H.toAddSubgroup.FiniteIndex ↔ H.Finite
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
 
 @[to_additive (attr := simp)]
-lemma isFiniteRelIndex_top_iff_finiteIndex {H : Subgroup G} :
+lemma isFiniteRelIndex_top_iff {H : Subgroup G} :
     H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
   rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
 
@@ -789,7 +789,7 @@ lemma isFiniteRelIndex_of_le_right {H₁ H₂ H₃ : Subgroup G} (h : H₂ ≤ H
 @[to_additive]
 lemma isFiniteRelIndex_of_finiteIndex {H₁ H₂ : Subgroup G} [h : H₁.FiniteIndex] :
     H₁.IsFiniteRelIndex H₂ := by
-  rw [← isFiniteRelIndex_top_iff_finiteIndex] at h
+  rw [← isFiniteRelIndex_top_iff] at h
   exact isFiniteRelIndex_of_le_right le_top
 
 @[to_additive (attr := gcongr)]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -777,16 +777,15 @@ lemma isFiniteRelIndex_of_le_left (L : Subgroup G) [H.IsFiniteRelIndex L] (h : H
 @[deprecated (since := "2026-05-09")] alias
   _root_.AddSubgroup.isFiniteRelIndex_of_le := AddSubgroup.isFiniteRelIndex_of_le_left
 
+variable (H) in
 @[to_additive]
-lemma isFiniteRelIndex_of_le_right (H₁ : Subgroup G) {H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)
-    [H₁.IsFiniteRelIndex H₃] :
-    H₁.IsFiniteRelIndex H₂ := by
+lemma isFiniteRelIndex_of_le_right {L : Subgroup G} (h : K ≤ L) [H.IsFiniteRelIndex L] :
+    H.IsFiniteRelIndex K := by
   rw [isFiniteRelIndex_iff_relIndex_ne_zero]
   exact mt (relIndex_eq_zero_of_le_right h) relIndex_ne_zero
 
 @[to_additive]
-lemma isFiniteRelIndex_of_finiteIndex {H₁ H₂ : Subgroup G} [h : H₁.FiniteIndex] :
-    H₁.IsFiniteRelIndex H₂ := by
+lemma isFiniteRelIndex_of_finiteIndex [h : H.FiniteIndex] : H.IsFiniteRelIndex K := by
   rw [← isFiniteRelIndex_top_iff] at h
   exact isFiniteRelIndex_of_le_right _ le_top
 

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -779,7 +779,7 @@ lemma isFiniteRelIndex_of_le_left {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [
   _root_.AddSubgroup.isFiniteRelIndex_of_le := AddSubgroup.isFiniteRelIndex_of_le_left
 
 @[to_additive]
-lemma isFiniteRelIndex_of_le_right {H₁ H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)
+lemma isFiniteRelIndex_of_le_right (H₁ : Subgroup G) {H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)
     [H₁.IsFiniteRelIndex H₃] :
     H₁.IsFiniteRelIndex H₂ := by
   have := relIndex_inter_ne_zero (show H₁.relIndex H₃ ≠ 0 from relIndex_ne_zero) H₂
@@ -789,7 +789,7 @@ lemma isFiniteRelIndex_of_le_right {H₁ H₂ H₃ : Subgroup G} (h : H₂ ≤ H
 lemma isFiniteRelIndex_of_finiteIndex {H₁ H₂ : Subgroup G} [h : H₁.FiniteIndex] :
     H₁.IsFiniteRelIndex H₂ := by
   rw [← isFiniteRelIndex_top_iff] at h
-  exact isFiniteRelIndex_of_le_right le_top
+  exact isFiniteRelIndex_of_le_right _ le_top
 
 @[to_additive (attr := gcongr)]
 lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -779,7 +779,7 @@ lemma isFiniteRelIndex_of_le_left (L : Subgroup G) [H.IsFiniteRelIndex L] (h : H
 
 variable (H) in
 @[to_additive]
-lemma isFiniteRelIndex_of_le_right {L : Subgroup G} (h : K ≤ L) [H.IsFiniteRelIndex L] :
+lemma isFiniteRelIndex_of_le_right (h : K ≤ L) [H.IsFiniteRelIndex L] :
     H.IsFiniteRelIndex K := by
   rw [isFiniteRelIndex_iff_relIndex_ne_zero]
   exact mt (relIndex_eq_zero_of_le_right h) relIndex_ne_zero

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -777,7 +777,7 @@ lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.
 
 @[to_additive]
 lemma isFiniteRelIndex_of_le' {H₁ H₂ H₃ : Subgroup G} (h₁₂ : H₁ ≤ H₂) (h₂₃ : H₂ ≤ H₃)
-    [h : H₁.IsFiniteRelIndex H₃] :
+    [H₁.IsFiniteRelIndex H₃] :
     H₁.IsFiniteRelIndex H₂ := by
   have := relIndex_mul_relIndex _ _ _ h₁₂ h₂₃
   grind [isFiniteRelIndex_iff_relIndex_ne_zero]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -782,8 +782,8 @@ lemma isFiniteRelIndex_of_le_left {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [
 lemma isFiniteRelIndex_of_le_right (H₁ : Subgroup G) {H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)
     [H₁.IsFiniteRelIndex H₃] :
     H₁.IsFiniteRelIndex H₂ := by
-  have := relIndex_inter_ne_zero (show H₁.relIndex H₃ ≠ 0 from relIndex_ne_zero) H₂
-  rwa [inf_of_le_right h, inf_relIndex_right, ← isFiniteRelIndex_iff_relIndex_ne_zero] at this
+  rw [isFiniteRelIndex_iff_relIndex_ne_zero]
+  exact mt (relIndex_eq_zero_of_le_right h) relIndex_ne_zero
 
 @[to_additive]
 lemma isFiniteRelIndex_of_finiteIndex {H₁ H₂ : Subgroup G} [h : H₁.FiniteIndex] :

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -776,6 +776,8 @@ lemma isFiniteRelIndex_of_le_left {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [
   exact finiteIndex_of_le <| subgroupOf_mono H₃ h
 
 @[deprecated (since := "2026-05-09")] alias isFiniteRelIndex_of_le := isFiniteRelIndex_of_le_left
+@[deprecated (since := "2026-05-09")] alias
+  _root_.AddSubgroup.isFiniteRelIndex_of_le := AddSubgroup.isFiniteRelIndex_of_le_left
 
 @[to_additive]
 lemma isFiniteRelIndex_of_le_right {H₁ H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -695,6 +695,11 @@ theorem not_finiteIndex_iff : ¬ H.FiniteIndex ↔ H.index = 0 :=
 theorem finiteIndex_toAddSubgroup_iff : H.toAddSubgroup.FiniteIndex ↔ H.FiniteIndex := by
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
 
+@[to_additive]
+lemma finiteIndex_iff_isFiniteRelIndex_top {H : Subgroup G} :
+    H.FiniteIndex ↔ H.IsFiniteRelIndex ⊤ := by
+  rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
+
 @[simp]
 theorem _root_.AddSubgroup.finiteIndex_toSubgroup_iff {G : Type*} [AddGroup G] (H : AddSubgroup G) :
     H.toSubgroup.FiniteIndex ↔ H.FiniteIndex := by
@@ -769,6 +774,20 @@ lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.
     H₂.IsFiniteRelIndex H₃ := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
   exact finiteIndex_of_le <| subgroupOf_mono H₃ h
+
+@[to_additive]
+lemma isFiniteRelIndex_of_le' {H₁ H₂ H₃ : Subgroup G} (h₁₂ : H₁ ≤ H₂) (h₂₃ : H₂ ≤ H₃)
+    [h : H₁.IsFiniteRelIndex H₃] :
+    H₁.IsFiniteRelIndex H₂ := by
+  have := relIndex_mul_relIndex _ _ _ h₁₂ h₂₃
+  grind [isFiniteRelIndex_iff_relIndex_ne_zero]
+
+@[to_additive]
+lemma isFiniteRelIndex_of_le_of_finiteIndex {H₁ H₂ : Subgroup G} (h₁₂ : H₁ ≤ H₂)
+    [h : H₁.FiniteIndex] :
+    H₁.IsFiniteRelIndex H₂ := by
+  rw [finiteIndex_iff_isFiniteRelIndex_top] at h
+  exact isFiniteRelIndex_of_le' h₁₂ le_top
 
 @[to_additive (attr := gcongr)]
 lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -695,9 +695,9 @@ theorem not_finiteIndex_iff : ¬ H.FiniteIndex ↔ H.index = 0 :=
 theorem finiteIndex_toAddSubgroup_iff : H.toAddSubgroup.FiniteIndex ↔ H.FiniteIndex := by
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
 
-@[to_additive]
-lemma finiteIndex_iff_isFiniteRelIndex_top {H : Subgroup G} :
-    H.FiniteIndex ↔ H.IsFiniteRelIndex ⊤ := by
+@[to_additive (attr := simp)]
+lemma isFiniteRelIndex_top_iff_finiteIndex {H : Subgroup G} :
+    H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
   rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
 
 @[simp]
@@ -769,25 +769,26 @@ theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.index_ne_zero (index_dvd_of_le h)⟩
 
 @[to_additive]
-lemma isFiniteRelIndex_of_le {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.IsFiniteRelIndex H₃]
+lemma isFiniteRelIndex_of_le_left {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.IsFiniteRelIndex H₃]
     (h : H₁ ≤ H₂) :
     H₂.IsFiniteRelIndex H₃ := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
   exact finiteIndex_of_le <| subgroupOf_mono H₃ h
 
-@[to_additive]
-lemma isFiniteRelIndex_of_le' {H₁ H₂ H₃ : Subgroup G} (h₁₂ : H₁ ≤ H₂) (h₂₃ : H₂ ≤ H₃)
-    [H₁.IsFiniteRelIndex H₃] :
-    H₁.IsFiniteRelIndex H₂ := by
-  have := relIndex_mul_relIndex _ _ _ h₁₂ h₂₃
-  grind [isFiniteRelIndex_iff_relIndex_ne_zero]
+@[deprecated (since := "2026-05-09")] alias isFiniteRelIndex_of_le := isFiniteRelIndex_of_le_left
 
 @[to_additive]
-lemma isFiniteRelIndex_of_le_of_finiteIndex {H₁ H₂ : Subgroup G} (h₁₂ : H₁ ≤ H₂)
-    [h : H₁.FiniteIndex] :
+lemma isFiniteRelIndex_of_le_right {H₁ H₂ H₃ : Subgroup G} (h : H₂ ≤ H₃)
+    [H₁.IsFiniteRelIndex H₃] :
     H₁.IsFiniteRelIndex H₂ := by
-  rw [finiteIndex_iff_isFiniteRelIndex_top] at h
-  exact isFiniteRelIndex_of_le' h₁₂ le_top
+  have := relIndex_inter_ne_zero (show H₁.relIndex H₃ ≠ 0 from relIndex_ne_zero) H₂
+  rwa [inf_of_le_right h, inf_relIndex_right, ← isFiniteRelIndex_iff_relIndex_ne_zero] at this
+
+@[to_additive]
+lemma isFiniteRelIndex_of_finiteIndex {H₁ H₂ : Subgroup G} [h : H₁.FiniteIndex] :
+    H₁.IsFiniteRelIndex H₂ := by
+  rw [← isFiniteRelIndex_top_iff_finiteIndex] at h
+  exact isFiniteRelIndex_of_le_right le_top
 
 @[to_additive (attr := gcongr)]
 lemma index_antitone (h : H ≤ K) [H.FiniteIndex] : K.index ≤ H.index :=

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -768,11 +768,10 @@ theorem finiteIndex_of_le [FiniteIndex H] (h : H ≤ K) : FiniteIndex K :=
   ⟨ne_zero_of_dvd_ne_zero FiniteIndex.index_ne_zero (index_dvd_of_le h)⟩
 
 @[to_additive]
-lemma isFiniteRelIndex_of_le_left {H₁ H₂ : Subgroup G} (H₃ : Subgroup G) [H₁.IsFiniteRelIndex H₃]
-    (h : H₁ ≤ H₂) :
-    H₂.IsFiniteRelIndex H₃ := by
+lemma isFiniteRelIndex_of_le_left (L : Subgroup G) [H.IsFiniteRelIndex L] (h : H ≤ K) :
+    K.IsFiniteRelIndex L := by
   rw [isFiniteRelIndex_iff_finiteIndex] at *
-  exact finiteIndex_of_le <| subgroupOf_mono H₃ h
+  exact finiteIndex_of_le <| subgroupOf_mono L h
 
 @[deprecated (since := "2026-05-09")] alias isFiniteRelIndex_of_le := isFiniteRelIndex_of_le_left
 @[deprecated (since := "2026-05-09")] alias

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -695,14 +695,14 @@ theorem not_finiteIndex_iff : ¬ H.FiniteIndex ↔ H.index = 0 :=
 theorem finiteIndex_toAddSubgroup_iff : H.toAddSubgroup.FiniteIndex ↔ H.FiniteIndex := by
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
 
-@[to_additive (attr := simp)]
-lemma isFiniteRelIndex_top_iff : H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
-  rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
-
 @[simp]
 theorem _root_.AddSubgroup.finiteIndex_toSubgroup_iff {G : Type*} [AddGroup G] (H : AddSubgroup G) :
     H.toSubgroup.FiniteIndex ↔ H.FiniteIndex := by
   simp [finiteIndex_iff, AddSubgroup.finiteIndex_iff]
+
+@[to_additive (attr := simp)]
+lemma isFiniteRelIndex_top_iff : H.IsFiniteRelIndex ⊤ ↔ H.FiniteIndex := by
+  rw [finiteIndex_iff, isFiniteRelIndex_iff_relIndex_ne_zero, relIndex_top_right]
 
 /-- A finite index subgroup has finite quotient. -/
 @[to_additive (attr := implicit_reducible) /-- A finite index subgroup has finite quotient -/]

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -408,6 +408,14 @@ theorem det_pi [Module.Free R M] [Module.Finite R M] (f : ι → M →ₗ[R] M) 
 
 end LinearMap
 
+namespace Algebra
+
+variable {R S : Type*} [CommRing R] [Ring S] [Algebra R S] [Free R S]
+
+lemma det_lsmul (x : R) : LinearMap.det (lsmul R R S x) = x ^ finrank R S := by
+  rw [lsmul_eq_smul_one, LinearMap.det_smul, map_one, mul_one]
+
+end Algebra
 
 namespace LinearEquiv
 

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -293,10 +293,6 @@ lemma FractionalIdeal.mul_inf (I J K : FractionalIdeal A⁰ K) : I * (J ⊓ K) =
 lemma FractionalIdeal.inf_mul (I J K : FractionalIdeal A⁰ K) : (I ⊓ J) * K = I * K ⊓ J * K :=
   inf_mul₀ (zero_le _) _ _
 
-lemma Ideal.inf_ne_bot_of_ne_bot {I J : Ideal A} (hI : I ≠ ⊥) (hJ : J ≠ ⊥) : I ⊓ J ≠ ⊥ := by
-  grw [← bot_lt_iff_ne_bot, ← mul_le_inf, bot_lt_iff_ne_bot, Ne, mul_eq_bot]
-  exact not_or_intro hI hJ
-
 section Gcd
 
 namespace Ideal

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -293,6 +293,10 @@ lemma FractionalIdeal.mul_inf (I J K : FractionalIdeal A⁰ K) : I * (J ⊓ K) =
 lemma FractionalIdeal.inf_mul (I J K : FractionalIdeal A⁰ K) : (I ⊓ J) * K = I * K ⊓ J * K :=
   inf_mul₀ (zero_le _) _ _
 
+lemma Ideal.inf_ne_bot_of_ne_bot {I J : Ideal A} (hI : I ≠ ⊥) (hJ : J ≠ ⊥) : I ⊓ J ≠ ⊥ := by
+  grw [← bot_lt_iff_ne_bot, ← mul_le_inf, bot_lt_iff_ne_bot, Ne, mul_eq_bot]
+  exact not_or_intro hI hJ
+
 section Gcd
 
 namespace Ideal

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -308,8 +308,7 @@ theorem absNorm_span_singleton (r : S) :
   refine b.ext fun i => ?_
   simp
 
-lemma absNorm_span_nat (n : ℕ) :
-    (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
+lemma absNorm_span_nat (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
   rw [absNorm_span_singleton, Algebra.norm_apply, map_natCast,
     show (n : Module.End ℤ S) = (n : ℤ) by norm_cast, ← zsmul_one, LinearMap.det_smul]
   simp
@@ -360,8 +359,6 @@ lemma finiteIndex {I : Ideal S} (hI : I ≠ ⊥) : I.toAddSubgroup.FiniteIndex :
 open AddSubgroup in
 lemma isFiniteRelIndex {I : Ideal S} (hI : I ≠ ⊥) (J : Ideal S) :
     I.toAddSubgroup.IsFiniteRelIndex J.toAddSubgroup := by
-  rcases eq_or_ne J ⊥ with rfl | hJ
-  · simpa [isFiniteRelIndex_iff_finiteIndex, ← inf_addSubgroupOf_right] using instFiniteIndexTop
   have := finiteIndex hI
   exact isFiniteRelIndex_of_finiteIndex
 

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -360,13 +360,10 @@ lemma finiteIndex {I : Ideal S} (hI : I ≠ ⊥) : I.toAddSubgroup.FiniteIndex :
 open AddSubgroup in
 lemma isFiniteRelIndex {I : Ideal S} (hI : I ≠ ⊥) (J : Ideal S) :
     I.toAddSubgroup.IsFiniteRelIndex J.toAddSubgroup := by
-  rw [isFiniteRelIndex_iff_finiteIndex, ← inf_addSubgroupOf_right]
   rcases eq_or_ne J ⊥ with rfl | hJ
-  · simpa using instFiniteIndexTop
-  change ((I ⊓ J).toAddSubgroup).addSubgroupOf _ |>.FiniteIndex
-  rw [← isFiniteRelIndex_iff_finiteIndex]
-  have := finiteIndex <| inf_ne_bot_of_ne_bot hI hJ
-  exact isFiniteRelIndex_of_le_of_finiteIndex (Submodule.toAddSubgroup_mono inf_le_right)
+  · simpa [isFiniteRelIndex_iff_finiteIndex, ← inf_addSubgroupOf_right] using instFiniteIndexTop
+  have := finiteIndex hI
+  exact isFiniteRelIndex_of_finiteIndex
 
 /-- The norm of a maximal ideal is a prime power.
 The prime is `(P.under ℤ).absNorm` and the exponent is `(P.under ℤ).inertialDeg P`.

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -308,7 +308,6 @@ theorem absNorm_span_singleton (r : S) :
   refine b.ext fun i => ?_
   simp
 
-@[simp]
 lemma absNorm_span_natCast (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
   rw [absNorm_span_singleton, Algebra.norm_natCast]
   simp

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -308,6 +308,7 @@ theorem absNorm_span_singleton (r : S) :
   refine b.ext fun i => ?_
   simp
 
+@[simp]
 lemma absNorm_span_nat (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
   rw [absNorm_span_singleton, Algebra.norm_nat]
   simp

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -309,8 +309,7 @@ theorem absNorm_span_singleton (r : S) :
   simp
 
 lemma absNorm_span_natCast (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
-  rw [absNorm_span_singleton, Algebra.norm_natCast]
-  simp
+  simp [absNorm_span_singleton, Algebra.norm_natCast]
 
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :
     ↑(Ideal.absNorm I) ∣ Algebra.norm ℤ x := by

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -213,6 +213,8 @@ variable [Nontrivial S] [IsDedekindDomain S] [Module.Free ℤ S]
 
 theorem absNorm_apply (I : Ideal S) : absNorm I = cardQuot I := rfl
 
+lemma absNorm_eq_index (I : Ideal S) : absNorm I = I.toAddSubgroup.index := rfl
+
 @[simp]
 theorem absNorm_bot : absNorm (⊥ : Ideal S) = 0 := by rw [← Ideal.zero_eq_bot, map_zero]
 
@@ -306,6 +308,12 @@ theorem absNorm_span_singleton (r : S) :
   refine b.ext fun i => ?_
   simp
 
+lemma absNorm_span_nat (n : ℕ) :
+    (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
+  rw [absNorm_span_singleton, Algebra.norm_apply, map_natCast,
+    show (n : Module.End ℤ S) = (n : ℤ) by norm_cast, ← zsmul_one, LinearMap.det_smul]
+  simp
+
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :
     ↑(Ideal.absNorm I) ∣ Algebra.norm ℤ x := by
   rw [← Int.dvd_natAbs, ← absNorm_span_singleton x, Int.natCast_dvd_natCast]
@@ -345,6 +353,20 @@ theorem absNorm_ne_zero_of_nonZeroDivisors (I : (Ideal S)⁰) : absNorm (I : Ide
 
 theorem absNorm_pos_of_nonZeroDivisors (I : (Ideal S)⁰) : 0 < absNorm (I : Ideal S) :=
   absNorm_pos_iff_mem_nonZeroDivisors.mpr (SetLike.coe_mem I)
+
+lemma finiteIndex {I : Ideal S} (hI : I ≠ ⊥) : I.toAddSubgroup.FiniteIndex := by
+  rwa [AddSubgroup.finiteIndex_iff, ← absNorm_eq_index, Ne, absNorm_eq_zero_iff]
+
+open AddSubgroup in
+lemma isFiniteRelIndex {I : Ideal S} (hI : I ≠ ⊥) (J : Ideal S) :
+    I.toAddSubgroup.IsFiniteRelIndex J.toAddSubgroup := by
+  rw [isFiniteRelIndex_iff_finiteIndex, ← inf_addSubgroupOf_right]
+  rcases eq_or_ne J ⊥ with rfl | hJ
+  · simpa using instFiniteIndexTop
+  change ((I ⊓ J).toAddSubgroup).addSubgroupOf _ |>.FiniteIndex
+  rw [← isFiniteRelIndex_iff_finiteIndex]
+  have := finiteIndex <| inf_ne_bot_of_ne_bot hI hJ
+  exact isFiniteRelIndex_of_le_of_finiteIndex (Submodule.toAddSubgroup_mono inf_le_right)
 
 /-- The norm of a maximal ideal is a prime power.
 The prime is `(P.under ℤ).absNorm` and the exponent is `(P.under ℤ).inertialDeg P`.

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -309,8 +309,7 @@ theorem absNorm_span_singleton (r : S) :
   simp
 
 lemma absNorm_span_nat (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
-  rw [absNorm_span_singleton, Algebra.norm_apply, map_natCast,
-    show (n : Module.End ℤ S) = (n : ℤ) by norm_cast, ← zsmul_one, LinearMap.det_smul]
+  rw [absNorm_span_singleton, Algebra.norm_nat]
   simp
 
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -309,8 +309,8 @@ theorem absNorm_span_singleton (r : S) :
   simp
 
 @[simp]
-lemma absNorm_span_nat (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
-  rw [absNorm_span_singleton, Algebra.norm_nat]
+lemma absNorm_span_natCast (n : ℕ) : (span {(n : S)}).absNorm = n ^ Module.finrank ℤ S := by
+  rw [absNorm_span_singleton, Algebra.norm_natCast]
   simp
 
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -435,6 +435,12 @@ theorem span_singleton_mul_left_inj [IsDomain R] [I.IsTwoSided] [J.IsTwoSided]
 theorem mul_le_inf [I.IsTwoSided] : I * J ≤ I ⊓ J :=
   mul_le.2 fun r hri s hsj => ⟨I.mul_mem_right s hri, J.mul_mem_left r hsj⟩
 
+lemma inf_ne_bot_of_ne_bot [NoZeroDivisors R] {I J : Ideal R} [I.IsTwoSided] [J.IsTwoSided]
+    (hI : I ≠ ⊥) (hJ : J ≠ ⊥) :
+    I ⊓ J ≠ ⊥ := by
+  grw [← bot_lt_iff_ne_bot, ← mul_le_inf, bot_lt_iff_ne_bot, Ne, mul_eq_bot]
+  exact not_or_intro hI hJ
+
 theorem sup_mul_eq_of_coprime_left [I.IsTwoSided] (h : I ⊔ J = ⊤) : I ⊔ J * K = I ⊔ K :=
   le_antisymm (sup_le_sup_left mul_le_left _) fun i hi => by
     rw [eq_top_iff_one] at h; rw [Submodule.mem_sup] at h hi ⊢

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -104,7 +104,7 @@ protected theorem norm_algebraMap (x : R) : norm R (algebraMap R S x) = x ^ finr
   rw [norm_apply, lmul_algebraMap, det_lsmul]
 
 variable (R) in
-lemma norm_nat (n : ℕ) : norm R (n : S) = n ^ Module.finrank R S := by
+protected lemma norm_natCast (n : ℕ) : norm R (n : S) = n ^ Module.finrank R S := by
   rw [← map_natCast (algebraMap R S), Algebra.norm_algebraMap]
 
 end Algebra

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -93,7 +93,7 @@ theorem norm_algebraMap_of_basis [Fintype ι] (b : Basis ι R S) (x : R) :
 variable [Free R S]
 
 lemma det_lsmul (x : R) : LinearMap.det (lsmul R R S x) = x ^ finrank R S := by
-  rw [show lsmul R R S x = x • 1 from rfl, LinearMap.det_smul, map_one, mul_one]
+  rw [lsmul_eq_smul_one, LinearMap.det_smul, map_one, mul_one]
 
 /-- If `x` is in the base ring `R` and `S` is free over `R`, then the norm is `x ^ [S : R]`.
 

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -90,16 +90,17 @@ theorem norm_algebraMap_of_basis [Fintype ι] (b : Basis ι R S) (x : R) :
   rw [norm_apply, ← det_toMatrix b, lmul_algebraMap]
   simp
 
-/-- If `x` is in the base field `K`, then the norm is `x ^ [L : K]`.
+variable [Free R S]
 
-(If `L` is not finite-dimensional over `K`, then `norm = 1 = x ^ 0 = x ^ (finrank L K)`.)
+lemma det_lsmul (x : R) : LinearMap.det (lsmul R R S x) = x ^ finrank R S := by
+  rw [show lsmul R R S x = x • 1 from rfl, LinearMap.det_smul, map_one, mul_one]
+
+/-- If `x` is in the base ring `R` and `S` is free over `R`, then the norm is `x ^ [S : R]`.
+
+(If `S` is not finitely generated over `R`, then `norm = 1 = x ^ 0 = x ^ (finrank R S)`.)
 -/
 @[simp]
-protected theorem norm_algebraMap {L : Type*} [Ring L] [Algebra K L] (x : K) :
-    norm K (algebraMap K L x) = x ^ finrank K L := by
-  by_cases H : ∃ s : Finset L, Nonempty (Basis s K L)
-  · rw [norm_algebraMap_of_basis H.choose_spec.some, finrank_eq_card_basis H.choose_spec.some]
-  · rw [norm_eq_one_of_not_exists_basis K H, finrank_eq_zero_of_not_exists_basis, pow_zero]
-    assumption_mod_cast
+protected theorem norm_algebraMap (x : R) : norm R (algebraMap R S x) = x ^ finrank R S := by
+  rw [norm_apply, lmul_algebraMap, det_lsmul]
 
 end Algebra

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -92,9 +92,6 @@ theorem norm_algebraMap_of_basis [Fintype ι] (b : Basis ι R S) (x : R) :
 
 variable [Free R S]
 
-lemma det_lsmul (x : R) : LinearMap.det (lsmul R R S x) = x ^ finrank R S := by
-  rw [lsmul_eq_smul_one, LinearMap.det_smul, map_one, mul_one]
-
 /-- If `x` is in the base ring `R` and `S` is free over `R`, then the norm is `x ^ [S : R]`.
 
 (If `S` is not finitely generated over `R`, then `norm = 1 = x ^ 0 = x ^ (finrank R S)`.)

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -103,4 +103,8 @@ lemma det_lsmul (x : R) : LinearMap.det (lsmul R R S x) = x ^ finrank R S := by
 protected theorem norm_algebraMap (x : R) : norm R (algebraMap R S x) = x ^ finrank R S := by
   rw [norm_apply, lmul_algebraMap, det_lsmul]
 
+variable (R) in
+lemma norm_nat (n : ℕ) : norm R (n : S) = n ^ Module.finrank R S := by
+  rw [← map_natCast (algebraMap R S), Algebra.norm_algebraMap]
+
 end Algebra


### PR DESCRIPTION
This adds a few more API lemmas for `{Add|}Subgroup.{FiniteIndex|IsFiniteRelIndex}` and connects the index with `Ideal.absNorm`; we also add the fact that (relative) indices of nonzero ideals in a Dedekind domain that is finite and free over the integers are finite.

We also generalize `Algebra.norm_algebraMap` from base fields to commutative rings, assuming the algebra is free over the base ring, and add some more API (`Algebra.del_lsmul`, `Algebra.norm_natCast`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
