### PR TITLE
feat(Topology/Algebra): lemma about infinite sum on ENat

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7389,6 +7389,7 @@ public import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 public import Mathlib.Topology.Algebra.InfiniteSum.Defs
 public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
+public import Mathlib.Topology.Algebra.InfiniteSum.ENat
 public import Mathlib.Topology.Algebra.InfiniteSum.Field
 public import Mathlib.Topology.Algebra.InfiniteSum.Group
 public import Mathlib.Topology.Algebra.InfiniteSum.GroupCompletion

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -20,7 +20,6 @@ these sums.
 
 ## TODO
 
-+ Once we have a topology on `ENat`, provide an `ENat`-valued version
 + Provide versions which sum over the whole type.
 -/
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENat.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENat.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+module
+
+public import Mathlib.Data.ENat.Lattice
+public import Mathlib.Topology.Algebra.InfiniteSum.Basic
+public import Mathlib.Topology.Instances.ENat
+import Mathlib.Topology.Order.MonotoneConvergence
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+
+/-!
+# Infinite sums in extended natural numbers
+
+This file proves results on infinite sums in `ℕ∞`.
+-/
+
+public section
+
+open Filter Topology
+variable {α ι : Type*} {L : SummationFilter α}
+
+namespace ENat
+
+@[norm_cast]
+protected theorem hasSum_coe {f : α → ℕ} {r : ℕ} :
+    HasSum (fun a ↦ (f a : ℕ∞)) r L ↔ HasSum f r L := by
+  simp_rw [HasSum, ← Nat.cast_sum]
+  exact isOpenEmbedding_natCast.tendsto_nhds_iff.symm
+
+protected theorem tsum_coe_eq [L.NeBot] {f : α → ℕ} {r : ℕ} (h : HasSum f r L) :
+    ∑'[L] a, (f a : ℕ∞) = r :=
+  (ENat.hasSum_coe.2 h).tsum_eq
+
+protected theorem coe_tsum [L.NeBot] {f : α → ℕ} (hf : Summable f L) :
+    ↑(∑'[L] a, f a) = ∑'[L] a, (f a : ℕ∞) := by
+  rw [hf.hasSum.tsum_eq, ENat.tsum_coe_eq hf.hasSum]
+
+end ENat


### PR DESCRIPTION
This works towards resolving a todo in the ENNReal file. I intentionally kept the change short for quicker review, and hopefully this new file can invite future contributions by adding more lemma on demand. Also a lot of existing machinery on ENNReal will be superseded by #38489 and can be reused for ENat.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
