### PR TITLE
[Merged by Bors] - feat(Topology): ENat.toENNReal is a closed embedding

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7725,6 +7725,7 @@ public import Mathlib.Topology.Instances.AddCircle.Real
 public import Mathlib.Topology.Instances.CantorSet
 public import Mathlib.Topology.Instances.Complex
 public import Mathlib.Topology.Instances.Discrete
+public import Mathlib.Topology.Instances.ENNReal.ENatENNReal
 public import Mathlib.Topology.Instances.ENNReal.Lemmas
 public import Mathlib.Topology.Instances.ENat
 public import Mathlib.Topology.Instances.EReal.Lemmas

--- a/Mathlib/Algebra/Order/Floor/Extended.lean
+++ b/Mathlib/Algebra/Order/Floor/Extended.lean
@@ -216,6 +216,30 @@ lemma ceil_add_le : ∀ (r s : ℝ≥0∞), ⌈r + s⌉ₑ ≤ ⌈r⌉ₑ + ⌈s
 @[simp] lemma toENNReal_iInf {ι : Sort*} (f : ι → ℕ∞) :
     toENNReal (⨅ i, f i) = ⨅ i, toENNReal (f i) := eq_of_forall_le_iff fun _ ↦ by simp [← ceil_le]
 
+@[simp] lemma preimage_toENNReal_Ioi (a : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Ioi a = Set.Ioi ⌊a⌋ₑ := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Iio (a : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Iio a = Set.Iio ⌈a⌉ₑ := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Iic (a : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Iic a = Set.Iic ⌊a⌋ₑ := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Ici (a : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Ici a = Set.Ici ⌈a⌉ₑ := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Icc (a b : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Icc a b = Set.Icc ⌈a⌉ₑ ⌊b⌋ₑ  := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Ico (a b : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Ico a b = Set.Ico ⌈a⌉ₑ ⌈b⌉ₑ  := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Ioc (a b : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Ioc a b = Set.Ioc ⌊a⌋ₑ ⌊b⌋ₑ  := by ext; simp
+
+@[simp] lemma preimage_toENNReal_Ioo (a b : ℝ≥0∞) :
+    toENNReal ⁻¹' Set.Ioo a b = Set.Ioo ⌊a⌋ₑ ⌈b⌉ₑ  := by ext; simp
+
 end ENat
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/Algebra/Order/Floor/Extended.lean
+++ b/Mathlib/Algebra/Order/Floor/Extended.lean
@@ -229,16 +229,16 @@ lemma ceil_add_le : ∀ (r s : ℝ≥0∞), ⌈r + s⌉ₑ ≤ ⌈r⌉ₑ + ⌈s
     toENNReal ⁻¹' Set.Ici a = Set.Ici ⌈a⌉ₑ := by ext; simp
 
 @[simp] lemma preimage_toENNReal_Icc (a b : ℝ≥0∞) :
-    toENNReal ⁻¹' Set.Icc a b = Set.Icc ⌈a⌉ₑ ⌊b⌋ₑ  := by ext; simp
+    toENNReal ⁻¹' Set.Icc a b = Set.Icc ⌈a⌉ₑ ⌊b⌋ₑ := by ext; simp
 
 @[simp] lemma preimage_toENNReal_Ico (a b : ℝ≥0∞) :
-    toENNReal ⁻¹' Set.Ico a b = Set.Ico ⌈a⌉ₑ ⌈b⌉ₑ  := by ext; simp
+    toENNReal ⁻¹' Set.Ico a b = Set.Ico ⌈a⌉ₑ ⌈b⌉ₑ := by ext; simp
 
 @[simp] lemma preimage_toENNReal_Ioc (a b : ℝ≥0∞) :
-    toENNReal ⁻¹' Set.Ioc a b = Set.Ioc ⌊a⌋ₑ ⌊b⌋ₑ  := by ext; simp
+    toENNReal ⁻¹' Set.Ioc a b = Set.Ioc ⌊a⌋ₑ ⌊b⌋ₑ := by ext; simp
 
 @[simp] lemma preimage_toENNReal_Ioo (a b : ℝ≥0∞) :
-    toENNReal ⁻¹' Set.Ioo a b = Set.Ioo ⌊a⌋ₑ ⌈b⌉ₑ  := by ext; simp
+    toENNReal ⁻¹' Set.Ioo a b = Set.Ioo ⌊a⌋ₑ ⌈b⌉ₑ := by ext; simp
 
 end ENat
 

--- a/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
@@ -24,8 +24,7 @@ namespace ENat
 theorem continuous_toENNReal : Continuous toENNReal := by
   refine OrderTopology.continuous_iff.mpr fun a ↦ ⟨?_, ?_⟩
   · simpa using isOpen_Ioi
-  · have : toENNReal ⁻¹' Set.Iio a = Set.Iio ⌈a⌉ₑ := by ext; simp
-    simpa using isOpen_Iio
+  · simpa using isOpen_Iio
 
 theorem isClosedEmbedding_toENNReal : Topology.IsClosedEmbedding toENNReal :=
   continuous_toENNReal.isClosedEmbedding toENNReal_strictMono.injective

--- a/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+module
+
+public import Mathlib.Data.Real.ENatENNReal
+public import Mathlib.Topology.Instances.ENat
+public import Mathlib.Topology.Instances.ENNReal.Lemmas
+import Mathlib.Algebra.Order.Floor.Extended
+
+/-!
+# Topology lemma for `ENat.toENNReal`
+
+This file shows `ENat.toENNReal` is a closed embedding.
+-/
+
+public section
+
+namespace ENat
+
+theorem continuous_toENNReal : Continuous toENNReal := by
+  refine OrderTopology.continuous_iff.mpr fun a ↦ ⟨?_, ?_⟩
+  · have : toENNReal ⁻¹' Set.Ioi a = Set.Ioi ⌊a⌋ₑ := by ext; simp
+    simpa [this] using isOpen_Ioi
+  · have : toENNReal ⁻¹' Set.Iio a = Set.Iio ⌈a⌉ₑ := by ext; simp
+    simpa [this] using isOpen_Iio
+
+theorem isClosedEmbedding_toENNReal : Topology.IsClosedEmbedding toENNReal :=
+  continuous_toENNReal.isClosedEmbedding toENNReal_strictMono.injective
+
+end ENat

--- a/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal/ENatENNReal.lean
@@ -20,12 +20,12 @@ public section
 
 namespace ENat
 
+@[continuity]
 theorem continuous_toENNReal : Continuous toENNReal := by
   refine OrderTopology.continuous_iff.mpr fun a ↦ ⟨?_, ?_⟩
-  · have : toENNReal ⁻¹' Set.Ioi a = Set.Ioi ⌊a⌋ₑ := by ext; simp
-    simpa [this] using isOpen_Ioi
+  · simpa using isOpen_Ioi
   · have : toENNReal ⁻¹' Set.Iio a = Set.Iio ⌈a⌉ₑ := by ext; simp
-    simpa [this] using isOpen_Iio
+    simpa using isOpen_Iio
 
 theorem isClosedEmbedding_toENNReal : Topology.IsClosedEmbedding toENNReal :=
   continuous_toENNReal.isClosedEmbedding toENNReal_strictMono.injective


### PR DESCRIPTION
This is put in a new file because it needs combined import from Topology/ENat and Topology/ENNReal, and the existing Topoloty/ENNReal/Lemmas file is pretty deep in the tree so I don't want to increase the import to it.

AI usage disclosure: the statement were verified by Aristotle. The proof was completely rewritten by me.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
