### PR TITLE
[Merged by Bors] - chore(Logic/Function/Basic): avoid defeq abuse of `Set α = α → Prop` in Cantor's theorem

### DIFF
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -357,9 +357,9 @@ theorem exists_fixed_point_of_surjective {α β : Type*} (f : α → α → β)
 
 /-- **Cantor's diagonal argument** implies that there are no surjective functions from `α`
 to `Set α`. -/
-theorem cantor_surjective {α} (f : α → Set α) : ¬Surjective f := fun h =>
-  let ⟨_, hx⟩ := exists_fixed_point_of_surjective f h (¬·)
-  not_iff_self (iff_of_eq hx)
+theorem cantor_surjective {α} (f : α → Set α) : ¬Surjective f := fun hf ↦
+  let ⟨a, ha⟩ := hf {a | a ∉ f a}
+  iff_not_self <| .of_eq <| congrArg (a ∈ ·) ha
 
 /-- **Cantor's diagonal argument** implies that there are no injective functions from `Set α`
 to `α`. -/


### PR DESCRIPTION
#6114 and #35752 removed the defeq abuse in `Function.cantor_surjective`, then #35239 golfed it, reintroducing defeq abuse.
This reverts the golf to avoid defeq abuse, and cleans up a bit.

---
Split from #39110, see [discussion](https://github.com/leanprover-community/mathlib4/pull/39110#discussion_r3214370020).

FWIW this is a proof that uses Lawvere's without `Set` defeq abuse, which makes it more verbose:
```lean
theorem cantor_surjective {α} (f : α → Set α) : ¬Surjective f := fun h ↦
  let ⟨_, hx⟩ := exists_fixed_point_of_surjective (fun a b ↦ b ∈ f a)
    (fun s ↦ (h <| setOf s).imp fun a h ↦ by simp only [h]; rfl) Not
  not_iff_self <| iff_of_eq hx
```

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
