### PR TITLE
[Merged by Bors] - doc(Algebra/HierarchyDesign): fix typo in library note

### DIFF
--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -232,7 +232,7 @@ Certain instances always apply during type-class resolution. For example, the in
 resolution problems of the form `AddGroup _`, and type-class inference will then do an
 exhaustive search to find a commutative group. These instances take a long time to fail.
 Other instances will only apply if the goal has a certain shape. For example
-`Int.instAddGroupInt : AddGroup ℤ` or
+`Int.instAddGroup : AddGroup ℤ` or
 `Prod.instAddGroup {α β} [AddGroup α] [AddGroup β] : AddGroup (α × β)`. Usually these instances
 will fail quickly, and when they apply, they are almost always the desired instance.
 For this reason, we want the instances of the second type (that only apply in specific cases) to


### PR DESCRIPTION
Fix instance name (error was possibly caused by the change in the instance naming algorithm).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Maybe it was called that under the old instance naming algorithm? But it's called https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Int/Defs.html#Int.instAddGroup now.