### PR TITLE
[Merged by Bors] - feat(Analysis/Normed): mapping a ball with smul

### DIFF
--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -183,3 +183,37 @@ lemma NormedDivisionRing.toNormSMulClass : NormSMulClass α β where
       _ = ‖r • x‖ := by rw [norm_inv, ← mul_assoc, mul_inv_cancel₀ (mt norm_eq_zero.1 h), one_mul]
 
 end NormedDivisionRing
+
+section Real
+variable {α : Type*} [SeminormedAddCommGroup α] [Module ℝ α] [NormSMulClass ℝ α]
+
+theorem Metric.smul_image_ball {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
+    (s • ·) '' ball x ε = ball (s • x) (|s| * ε) := by
+  ext p
+  simp_rw [Set.mem_image, mem_ball]
+  constructor
+  · rintro ⟨y, h1, rfl⟩
+    simpa [dist_smul₀] using mul_lt_mul_of_pos_left h1 (abs_pos.mpr hs)
+  · refine fun h ↦ ⟨s⁻¹ • p, ?_, by simp [smul_smul, hs]⟩
+    refine lt_of_mul_lt_mul_of_nonneg_left ?_ (norm_nonneg s)
+    rw [← dist_smul₀]
+    simpa [smul_smul, hs] using h
+
+theorem Metric.smul_image_closedBall {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
+    (s • ·) '' closedBall x ε = closedBall (s • x) (|s| * ε) := by
+  ext p
+  simp_rw [Set.mem_image, mem_closedBall]
+  constructor
+  · rintro ⟨y, h1, rfl⟩
+    simpa [dist_smul₀] using mul_le_mul_of_nonneg_left h1 (abs_nonneg s)
+  · refine fun h ↦ ⟨s⁻¹ • p, ?_, by simp [smul_smul, hs]⟩
+    refine le_of_mul_le_mul_of_pos_left ?_ (norm_pos_iff.mpr hs)
+    rw [← dist_smul₀]
+    simpa [smul_smul, hs] using h
+
+theorem Metric.smul_image_sphere {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
+    (s • ·) '' sphere x ε = sphere (s • x) (|s| * ε) := by
+  simp_rw [← Metric.closedBall_diff_ball, Set.image_diff (smul_right_injective α hs),
+    smul_image_ball hs, smul_image_closedBall hs]
+
+end Real

--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -184,36 +184,36 @@ lemma NormedDivisionRing.toNormSMulClass : NormSMulClass α β where
 
 end NormedDivisionRing
 
-section Real
-variable {α : Type*} [SeminormedAddCommGroup α] [Module ℝ α] [NormSMulClass ℝ α]
+section NormdDivisionRingModule
+variable [NormedDivisionRing α] [SeminormedAddCommGroup β] [Module α β] [NormSMulClass α β]
 
-theorem Metric.smul_image_ball {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
-    (s • ·) '' ball x ε = ball (s • x) (|s| * ε) := by
+theorem Metric.smul_image_ball {s : α} (hs : s ≠ 0) (x : β) (ε : ℝ) :
+    (s • ·) '' ball x ε = ball (s • x) (‖s‖ * ε) := by
   ext p
   simp_rw [Set.mem_image, mem_ball]
   constructor
   · rintro ⟨y, h1, rfl⟩
-    simpa [dist_smul₀] using mul_lt_mul_of_pos_left h1 (abs_pos.mpr hs)
+    simpa [dist_smul₀] using mul_lt_mul_of_pos_left h1 (norm_pos_iff.mpr hs)
   · refine fun h ↦ ⟨s⁻¹ • p, ?_, by simp [smul_smul, hs]⟩
     refine lt_of_mul_lt_mul_of_nonneg_left ?_ (norm_nonneg s)
     rw [← dist_smul₀]
     simpa [smul_smul, hs] using h
 
-theorem Metric.smul_image_closedBall {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
-    (s • ·) '' closedBall x ε = closedBall (s • x) (|s| * ε) := by
+theorem Metric.smul_image_closedBall {s : α} (hs : s ≠ 0) (x : β) (ε : ℝ) :
+    (s • ·) '' closedBall x ε = closedBall (s • x) (‖s‖ * ε) := by
   ext p
   simp_rw [Set.mem_image, mem_closedBall]
   constructor
   · rintro ⟨y, h1, rfl⟩
-    simpa [dist_smul₀] using mul_le_mul_of_nonneg_left h1 (abs_nonneg s)
+    simpa [dist_smul₀] using mul_le_mul_of_nonneg_left h1 (norm_nonneg s)
   · refine fun h ↦ ⟨s⁻¹ • p, ?_, by simp [smul_smul, hs]⟩
     refine le_of_mul_le_mul_of_pos_left ?_ (norm_pos_iff.mpr hs)
     rw [← dist_smul₀]
     simpa [smul_smul, hs] using h
 
-theorem Metric.smul_image_sphere {s : ℝ} (hs : s ≠ 0) (x : α) (ε : ℝ) :
-    (s • ·) '' sphere x ε = sphere (s • x) (|s| * ε) := by
-  simp_rw [← Metric.closedBall_diff_ball, Set.image_diff (smul_right_injective α hs),
+theorem Metric.smul_image_sphere {s : α} (hs : s ≠ 0) (x : β) (ε : ℝ) :
+    (s • ·) '' sphere x ε = sphere (s • x) (‖s‖ * ε) := by
+  simp_rw [← Metric.closedBall_diff_ball, Set.image_diff (smul_right_injective β hs),
     smul_image_ball hs, smul_image_closedBall hs]
 
-end Real
+end NormdDivisionRingModule

--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -184,7 +184,7 @@ lemma NormedDivisionRing.toNormSMulClass : NormSMulClass α β where
 
 end NormedDivisionRing
 
-section NormdDivisionRingModule
+section NormedDivisionRingModule
 variable [NormedDivisionRing α] [SeminormedAddCommGroup β] [Module α β] [NormSMulClass α β]
 
 theorem Metric.smul_image_ball {s : α} (hs : s ≠ 0) (x : β) (ε : ℝ) :
@@ -216,4 +216,4 @@ theorem Metric.smul_image_sphere {s : α} (hs : s ≠ 0) (x : β) (ε : ℝ) :
   simp_rw [← Metric.closedBall_diff_ball, Set.image_diff (smul_right_injective β hs),
     smul_image_ball hs, smul_image_closedBall hs]
 
-end NormdDivisionRingModule
+end NormedDivisionRingModule


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
