### PR TITLE
feat(Statistics): add DGL-style adversary and no-free-lunch core

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7014,6 +7014,7 @@ public import Mathlib.SetTheory.ZFC.Ordinal
 public import Mathlib.SetTheory.ZFC.PSet
 public import Mathlib.SetTheory.ZFC.Rank
 public import Mathlib.SetTheory.ZFC.VonNeumann
+public import Mathlib.Statistics.NoFreeLunch
 public import Mathlib.Tactic
 public import Mathlib.Tactic.Abel
 public import Mathlib.Tactic.AdaptationNote

--- a/Mathlib/Statistics/NoFreeLunch.lean
+++ b/Mathlib/Statistics/NoFreeLunch.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 Allen Hao Zhu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Allen Hao Zhu
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Tactic.Linarith
+public import Mathlib.Tactic.Positivity
+public import Mathlib.Tactic.Ring
+
+/-!
+# No-free-lunch adversary core (Devroye–Györfi–Lugosi)
+
+This module formalizes the **finite-class algebraic core** of the
+Devroye–Györfi–Lugosi (DGL) adversary argument, following the
+presentation in Devroye, Györfi, Lugosi (1996),
+*A Probabilistic Theory of Pattern Recognition*, Section 7.2, and the
+binary specialization of Shalev-Shwartz, Ben-David (2014),
+*Understanding Machine Learning*, Theorem 5.1.
+
+The DGL adversary argument shows that for any deterministic learning
+rule `A : (X × Y)^n → (X → Y)`, there exists a distribution `D` on
+`X × Y` such that the excess risk of `A` over the Bayes optimum is at
+least a positive absolute constant. The proof proceeds by introducing
+a finite hard hypothesis class `(f_θ)_{θ ∈ Θ}` and taking the uniform
+prior over `Θ`; the algorithm's worst-case risk is then lower bounded
+by its average risk over the prior, and pigeonhole produces the bad
+`θ`.
+
+The contents of this file are the purely algebraic ingredients of that
+argument, isolated from the learning-theoretic semantics. The full
+measure-theoretic DGL adversary is left to a future PR (see "Future
+work" below).
+
+## Main definitions
+
+This file contains no new definitions; it is a collection of bounded
+algebraic lemmas about finite families of real numbers and a single
+existence statement for the uniform prior.
+
+## Main results
+
+* `Statistics.NoFreeLunch.exists_uniform_pmf` —
+  the uniform prior `i ↦ 1 / K` is a probability mass function on
+  `Fin K`.
+* `Statistics.NoFreeLunch.average_le_sup'` —
+  `(∑ i, R i) / K ≤ Finset.univ.sup' _ R` (max dominates the average).
+* `Statistics.NoFreeLunch.exists_index_average_le` —
+  pigeonhole on a real risk vector: some index `i` has
+  `R i ≥ (∑ j, R j) / K`.
+* `Statistics.NoFreeLunch.exists_index_average_le_of_bounded` —
+  same conclusion under the standard `0 ≤ R i ≤ 1` regime used by the
+  DGL no-free-lunch argument.
+* `Statistics.NoFreeLunch.average_le_max_two` —
+  the `K = 2` specialization `(R₀ + R₁) / 2 ≤ max R₀ R₁`, which is the
+  form used in the binary no-free-lunch proof.
+
+## Implementation notes
+
+The lemmas are stated for `R : Fin K → ℝ` rather than for an arbitrary
+finset so that the resulting averages are literal divisions by the
+natural number `K`. This is the form in which the DGL argument is
+usually applied (the index set parameterizes leaves of a hard
+hypothesis tree, typically of size a power of two).
+
+The maximum is expressed using `Finset.sup'` over `Finset.univ`, which
+is the standard way to take a maximum of a nonempty family in Mathlib.
+
+## References
+
+* L. Devroye, L. Györfi, G. Lugosi, *A Probabilistic Theory of Pattern
+  Recognition*, Springer, 1996, Section 7.2 (no-free-lunch adversary).
+* S. Shalev-Shwartz, S. Ben-David, *Understanding Machine Learning:
+  From Theory to Algorithms*, Cambridge University Press, 2014,
+  Section 5.1 / Theorem 5.1 (binary no-free-lunch).
+
+## Tags
+
+no-free-lunch, adversary, learning theory, minimax, pigeonhole
+-/
+
+namespace Statistics.NoFreeLunch
+
+open Finset
+
+@[expose] public section
+
+variable {K : ℕ}
+
+/-- **Uniform prior on `Fin K`.** For any positive `K : ℕ`, the constant
+function `i ↦ 1 / K` is a probability mass function on `Fin K`: it is
+nonnegative, sums to `1`, and equals `1 / K` at every point.
+
+This is the prior used in the DGL adversary construction: against a
+deterministic learning rule we draw the target hypothesis from a
+uniform distribution over a finite hard class, so the algorithm's
+worst-case risk dominates its uniform-prior average risk. -/
+theorem exists_uniform_pmf (hK : 0 < K) :
+    ∃ p : Fin K → ℝ,
+      (∀ i, 0 ≤ p i) ∧ (∑ i, p i = 1) ∧ ∀ i, p i = 1 / (K : ℝ) := by
+  have hKpos : (0 : ℝ) < (K : ℝ) := by exact_mod_cast hK
+  have hKne : (K : ℝ) ≠ 0 := ne_of_gt hKpos
+  refine ⟨fun _ => (1 : ℝ) / (K : ℝ), ?_, ?_, ?_⟩
+  · intro _
+    positivity
+  · have hsum : (∑ _i : Fin K, (1 : ℝ) / (K : ℝ)) = (K : ℝ) * (1 / (K : ℝ)) := by
+      rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+    rw [hsum, mul_one_div, div_self hKne]
+  · intro _; rfl
+
+/-- **Average is bounded by the maximum.** For any nonempty family of
+real numbers `R : Fin K → ℝ`, the average `(∑ i, R i) / K` is at most
+the maximum value `Finset.univ.sup' _ R`.
+
+This is one half of the DGL "worst case dominates the average":
+combined with `Finset.exists_mem_eq_sup'` it yields an index whose risk
+is at least the average. -/
+theorem average_le_sup' (R : Fin K → ℝ) (hK : 0 < K) :
+    (∑ i, R i) / (K : ℝ) ≤
+      (Finset.univ : Finset (Fin K)).sup'
+        (Finset.univ_nonempty_iff.mpr ⟨⟨0, hK⟩⟩) R := by
+  classical
+  set hne : (Finset.univ : Finset (Fin K)).Nonempty :=
+    Finset.univ_nonempty_iff.mpr ⟨⟨0, hK⟩⟩
+  set M : ℝ := (Finset.univ : Finset (Fin K)).sup' hne R with hM
+  have hle : ∀ i ∈ (Finset.univ : Finset (Fin K)), R i ≤ M := by
+    intro i hi
+    exact Finset.le_sup' (f := R) hi
+  have hsum : (∑ i, R i) ≤ (∑ _i : Fin K, M) :=
+    Finset.sum_le_sum hle
+  have hcard : (∑ _i : Fin K, M) = (K : ℝ) * M := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hsum' : (∑ i, R i) ≤ (K : ℝ) * M := by
+    rw [hcard] at hsum; exact hsum
+  have hKpos : (0 : ℝ) < (K : ℝ) := by exact_mod_cast hK
+  exact (div_le_iff₀ hKpos).mpr (by linarith [hsum'])
+
+/-- **Pigeonhole on a real risk vector.** Given a nonempty family of
+real numbers `R : Fin K → ℝ`, some index `i` satisfies
+`R i ≥ (∑ j, R j) / K`.
+
+Operationally, the index attaining the maximum works. Combined with
+`average_le_sup'` this is the DGL adversary step: against any
+algorithm, *some* target hypothesis achieves at least the prior-average
+risk. -/
+theorem exists_index_average_le (R : Fin K → ℝ) (hK : 0 < K) :
+    ∃ i, (∑ j, R j) / (K : ℝ) ≤ R i := by
+  classical
+  set hne : (Finset.univ : Finset (Fin K)).Nonempty :=
+    Finset.univ_nonempty_iff.mpr ⟨⟨0, hK⟩⟩
+  obtain ⟨i, _hi, hieq⟩ :=
+    Finset.exists_mem_eq_sup' (f := R) hne
+  refine ⟨i, ?_⟩
+  have hmax := average_le_sup' (R := R) hK
+  rw [hieq] at hmax
+  exact hmax
+
+/-- **Finite-class DGL adversary, bounded-risk form.** Specialization of
+`exists_index_average_le` to the standard regime in which risks are
+nonnegative and bounded above by `1`. The boundedness assumptions are
+not strictly necessary for the algebraic conclusion, but they match the
+hypotheses used by the DGL adversary argument (where `R i` is the `0-1`
+risk of an algorithm trained on `n` samples).
+
+Concretely: against any deterministic algorithm and any finite hard
+class of size `K`, there exists a hypothesis `i` whose risk is at least
+the uniform-prior average risk. -/
+theorem exists_index_average_le_of_bounded (R : Fin K → ℝ)
+    (hK : 0 < K) (_hRnn : ∀ i, 0 ≤ R i) (_hRle : ∀ i, R i ≤ 1) :
+    ∃ i, (∑ j, R j) / (K : ℝ) ≤ R i :=
+  exists_index_average_le R hK
+
+/-- **Two-class DGL specialization.** The maximum of two real numbers
+dominates their average: `(R₀ + R₁) / 2 ≤ max R₀ R₁`.
+
+This is the form of the DGL inequality used in the binary
+no-free-lunch proof (where `R₀` and `R₁` are the risks attained on the
+two hypotheses of a hard pair). It is the case `K = 2` of
+`average_le_sup'`, but stated directly using `max` to keep it
+elementary. -/
+theorem average_le_max_two (R₀ R₁ : ℝ) : (R₀ + R₁) / 2 ≤ max R₀ R₁ := by
+  rcases le_total R₀ R₁ with h | h
+  · -- `max = R₁`; reduce to `R₀ ≤ R₁`.
+    have : (R₀ + R₁) / 2 ≤ R₁ := by linarith
+    simpa [max_eq_right h] using this
+  · -- `max = R₀`; reduce to `R₁ ≤ R₀`.
+    have : (R₀ + R₁) / 2 ≤ R₀ := by linarith
+    simpa [max_eq_left h] using this
+
+/-! ### Examples / sanity checks -/
+
+/-- For two equal risks, the max equals their average (and equals the
+common value). This is the boundary case of `average_le_max_two`. -/
+example (R : ℝ) : max R R = (R + R) / 2 := by
+  have h₁ : max R R = R := max_self R
+  have h₂ : (R + R) / 2 = R := by ring
+  rw [h₁, h₂]
+
+/-- The `K = 2` specialization of `exists_index_average_le` reproduces
+the basic no-free-lunch form: in any pair of risks, at least one is at
+least the average. -/
+example (R₀ R₁ : ℝ) :
+    ∃ i : Fin 2, (R₀ + R₁) / 2 ≤ ![R₀, R₁] i := by
+  have h := exists_index_average_le (K := 2)
+    (R := ![R₀, R₁]) (by decide)
+  -- Rewrite the sum `∑ j, ![R₀,R₁] j = R₀ + R₁` and the denominator.
+  have hsum : (∑ j : Fin 2, ![R₀, R₁] j) = R₀ + R₁ := by
+    simp [Fin.sum_univ_two]
+  simpa [hsum, show ((2 : ℕ) : ℝ) = 2 from by norm_cast] using h
+
+end
+
+end Statistics.NoFreeLunch


### PR DESCRIPTION
# PR draft: `feat(Statistics): add DGL-style adversary lemma and no-free-lunch core`

**Status:** draft, ready for upstream review.
**Source module:** `LTFP/MathlibExt/Probability/Adversary.lean`
**Proposed Mathlib path:** `Mathlib/Statistics/NoFreeLunch.lean`
**Proposed Mathlib namespace:** `Statistics.NoFreeLunch`

---

## Title

```
feat(Statistics): add DGL-style adversary lemma and no-free-lunch core
```

## Summary

This PR adds the **finite-class algebraic core** of the Devroye-Gyorfi-
Lugosi (DGL) adversary argument, the abstract pigeonhole step that
underlies every no-free-lunch theorem in statistical learning theory.

The new file is small (~200 lines), self-contained, and depends only on
`Mathlib.Algebra.BigOperators.Fin`,
`Mathlib.Algebra.Order.BigOperators.Group.Finset`,
`Mathlib.Data.Fintype.BigOperators`,
`Mathlib.Data.Real.Basic`, and the standard tactics
`linarith`, `positivity`, `ring`. The lemmas are stated in pure real
arithmetic on a finite index set `Fin K`; no measure-theoretic
machinery is introduced, keeping the import surface minimal and the
review burden small.

The deliberately scalar nature of this PR makes it the foundation for
two downstream upstreaming targets already in `LTFP-Lean`:

1. the binary no-free-lunch theorem
   (Shalev-Shwartz & Ben-David 2014, Theorem 5.1), and
2. the full measure-theoretic DGL adversary
   (Devroye-Gyorfi-Lugosi 1996, Theorem 7.2).

See **Future work** below for the planned follow-up PRs.

## Why this belongs in Mathlib

* No-free-lunch results are a textbook prerequisite for stating any
  minimax learning lower bound; the "max >= average" pigeonhole step
  is cited by name in essentially every PAC-learning textbook
  (DGL 1996, Shalev-Shwartz-Ben-David 2014,
  Mohri-Rostamizadeh-Talwalkar 2018).
* Despite this, Mathlib currently has no `Statistics` directory and no
  explicit `max >= average` lemma stated for `Fin K`-indexed families
  of reals. `Finset.sup'` only provides `R i <= sup'`, not the
  converse averaged inequality.
* Bundling the pigeonhole step with the uniform-prior existence
  statement gives a clean, named API (`Statistics.NoFreeLunch.*`)
  that downstream measure-theoretic statements can reuse without
  re-deriving the algebraic core.

## What is added

### New namespace

`Statistics.NoFreeLunch` (proposed as the first inhabitant of a new
`Mathlib/Statistics/` directory, matching the existing
`Mathlib/Probability/` and `Mathlib/Information/` layout).

### New theorems / lemmas

| Name | Statement |
|---|---|
| `exists_uniform_pmf` | For `0 < K`, the constant `i mapsto 1/K` is a probability mass function on `Fin K`. |
| `average_le_sup'` | `(sum_i R i) / K <= Finset.univ.sup' _ R` for `R : Fin K -> R`, `0 < K`. |
| `exists_index_average_le` | Some `i : Fin K` satisfies `(sum_j R j) / K <= R i`. |
| `exists_index_average_le_of_bounded` | Same conclusion under `0 <= R i <= 1` (the DGL learning-theoretic regime). |
| `average_le_max_two` | `(R0 + R1) / 2 <= max R0 R1` (the `K = 2` specialization used in the binary NFL). |

Two `example` blocks at the end double as smoke tests:

* `max R R = (R + R) / 2` -- the boundary case of `average_le_max_two`.
* The `K = 2` specialization of `exists_index_average_le` directly
  reproduces the basic NFL form.

## Comparison to existing Mathlib

Before this PR, Mathlib provides:

* `Finset.le_sup'` -- `R i <= Finset.univ.sup' _ R` (used internally by
  the new file). No `sup' >= average` companion.
* `Finset.exists_mem_eq_sup'` -- extracts an `argmax`. Used here to
  turn the average bound into the existence of a bad index.
* `Finset.sum_const`, `Finset.sum_le_sum` -- the standard averaging
  algebra. No closed-form `sum / card <= sup` lemma exists.

A `grep -R "no_free_lunch\|NoFreeLunch\|adversary\|Adversary"` against
`master` returns no statistical-learning hits; the proposed namespace
is unoccupied.

## Design choices

1. **`Fin K`-indexed rather than `Finset.Nonempty`-indexed.** Avoids
   carrying a nonemptiness witness through every statement and makes
   the denominator `K` a literal natural number, matching DGL's
   "uniform over `2^d` leaves" application. A `Finset`-indexed variant
   is a one-line corollary if desired.
2. **`R`-valued, not `Rge0infty`-valued.** Risks are signed in general
   learning-theoretic statements (e.g. excess risk relative to a
   reference) and the downstream Le Cam two-point bound (already in
   `LTFP-Lean`) is real-valued.
3. **No `IsProbabilityMeasure` / `ProbabilityTheory` imports.** The
   uniform-prior existence statement is stated purely in `R`
   (`p : Fin K -> R` with `forall i, 0 <= p i` and `sum p = 1`),
   keeping this PR independent of the probability hierarchy. A
   measure-theoretic `PMF.uniformOfFintype` follow-up wrapper is one
   line.
4. **Standalone `K = 2` lemma.** `average_le_max_two` is stated
   directly with `max`, not as a `Fin 2` specialization of
   `average_le_sup'`, because `max R0 R1` is the form actually used
   in every textbook NFL proof and in the existing `LeCam.lean`
   module.

## Test / verification notes

* The downstream project that motivated this addition (`LTFP-Lean`,
  a Lean 4 formalization of Bach 2024, *Learning Theory from First
  Principles*) builds the module green:
  `lake build LTFP.MathlibExt.Probability.Adversary` completes with
  no warnings.
* All proofs are short (<= 15 lines); no `sorry`, no `admit`, no
  `decide`-on-trust.
* The `example` blocks exercise both the boundary case `max R R` and
  the `K = 2` specialization of the main pigeonhole lemma.
* A single defensive `classical` is used inside `average_le_sup'` and
  `exists_index_average_le` for the `set` rewrites; it can be removed
  trivially if reviewers prefer.

## Future work

Tracked as TODO items in the `LTFP-Lean` repository:

* **Binary no-free-lunch theorem.** Combine `average_le_max_two` with
  a `tvDist`-style separation argument to produce the
  Shalev-Shwartz-Ben-David Theorem 5.1 lower bound `>= 1/4` for any
  learner on a sample of size `<= |X|/2`. Belongs in a new file
  `Mathlib/Statistics/NoFreeLunchBinary.lean` consuming this PR and
  `Mathlib/MeasureTheory/Measure/TotalVariation.lean` (proposed in a
  sibling PR).
* **Full measure-theoretic DGL adversary** (Devroye-Gyorfi-Lugosi
  1996, Theorem 7.2). For any deterministic learning rule `A` and any
  sample size `n`, there exists a distribution `D` on `X x {0, 1}`
  such that `E_D R(A) >= 1/4 - (n / (2 |X|))^{1/2}`. Requires
  finitely-supported product measures, the Bayes-classifier API, and
  Fano-style entropy inequalities (latter two not yet in Mathlib).
* **Le Cam two-point lower bound.** Already drafted in `LTFP-Lean` as
  `LTFP/MathlibExt/Probability/LeCam.lean`; PR draft in
  `docs/mathlib-prs/le-cam.md` (sibling).
* **Fano inequality.** Multi-hypothesis generalization of the
  pigeonhole step. The `Statistics.NoFreeLunch` namespace is the
  natural home.

## Reviewer checklist

* [ ] Namespace `Statistics.NoFreeLunch` is acceptable (vs.
      `ProbabilityTheory.Adversary` or `Statistics.Adversary`).
* [ ] Naming follows Mathlib conventions
      (`exists_uniform_pmf`, `average_le_sup'`,
      `exists_index_average_le`,
      `exists_index_average_le_of_bounded`, `average_le_max_two`).
* [ ] Imports are minimal; no `MeasureTheory`, no `ProbabilityTheory`.
* [ ] Module docstring covers definitions, results, references, tags.
* [ ] `example` blocks compile and are appropriate smoke tests.
* [ ] No redundant `0 <= R i` / `R i <= 1` hypotheses on lemmas where
      the algebraic conclusion does not require them; the bounded
      variant is exposed as a separate lemma for downstream
      convenience.

## Suggested labels

`t-probability`, `t-statistics`, `new-contributor-friendly`,
`awaiting-review`

## References

* L. Devroye, L. Gyorfi, G. Lugosi, *A Probabilistic Theory of Pattern
  Recognition*, Springer, 1996, Section 7.2 (no-free-lunch adversary).
* S. Shalev-Shwartz, S. Ben-David, *Understanding Machine Learning:
  From Theory to Algorithms*, Cambridge University Press, 2014,
  Section 5.1, Theorem 5.1 (binary no-free-lunch).
* M. Mohri, A. Rostamizadeh, A. Talwalkar, *Foundations of Machine
  Learning*, 2nd ed., MIT Press, 2018, Chapter 3.
* F. Bach, *Learning Theory from First Principles*, MIT Press, 2024,
  Section 3.6 (the downstream consumer that motivated this PR).



---

## AI-assistance disclosure

Per the Mathlib [AI-use policy](https://leanprover-community.github.io/contribute/index.html#use-of-ai):

- **Tool.** Claude Code (Anthropic) with the Claude Sonnet 4.6 model.
- **Use.** I specified the target lemma statements and the proof strategy; the assistant drafted Lean 4 tactic combinations against current Mathlib. I iterated on the proofs, verified each lemma builds under `lake build` from a clean checkout, and read the final code.
- **Vouching.** I have read every declaration in `Mathlib/Statistics/NoFreeLunch.lean` and can defend the proofs without further AI assistance. I welcome reviewer feedback on naming, namespace placement, and stylistic alignment with the surrounding Mathlib modules.