### PR TITLE
[Merged by Bors] - feat(GroupTheory/Perm/Fin): Add `(cycleIcc i j) ∘ j.succAbove = i.succAbove` for `i ≤ j`

### DIFF
--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -446,6 +446,21 @@ theorem cycleIcc_zero_eq_cycleRange (i : Fin n) [NeZero n] : cycleIcc 0 i = cycl
   · simp [-cycleIcc_def_le, ch]
   · simp [-cycleIcc_def_le, cycleIcc_of_gt ch, cycleRange_of_gt ch]
 
+theorem cycleIcc_comp_succAbove {n : ℕ} (i j : Fin (n + 1)) (hij : i ≤ j) :
+    (cycleIcc i j) ∘ j.succAbove = i.succAbove := by
+  ext k
+  rw [Function.comp_apply]
+  by_cases hk : k.castSucc < i
+  · have hjk : k.castSucc < j := lt_of_lt_of_le hk hij
+    rw [succAbove_of_castSucc_lt _ _ hjk, cycleIcc_of_lt hk, succAbove_of_castSucc_lt _ _ hk]
+  · have hki : i ≤ k.castSucc := le_of_not_gt hk
+    by_cases hkj : k.castSucc < j
+    · simp [succAbove_of_castSucc_lt _ _ hkj, cycleIcc_of_ge_of_lt hki hkj,
+        succAbove_of_le_castSucc _ _ hki]
+    · have hjk : j ≤ k.castSucc := le_of_not_gt hkj
+      rw [succAbove_of_le_castSucc _ _ hjk, cycleIcc_of_gt (le_castSucc_iff.mp hjk),
+        succAbove_of_le_castSucc _ _ hki]
+
 theorem cycleIcc.trans [NeZero n] (hij : i ≤ j) (hjk : j ≤ k) :
     (cycleIcc i j) ∘ (cycleIcc j k) = (cycleIcc i k) := by
   ext x

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -446,7 +446,6 @@ theorem cycleIcc_zero_eq_cycleRange (i : Fin n) [NeZero n] : cycleIcc 0 i = cycl
   · simp [-cycleIcc_def_le, ch]
   · simp [-cycleIcc_def_le, cycleIcc_of_gt ch, cycleRange_of_gt ch]
 
-@[simp]
 theorem cycleIcc_comp_succAbove {n : ℕ} (i j : Fin (n + 1)) (hij : i ≤ j) :
     (cycleIcc i j) ∘ j.succAbove = i.succAbove := by
   grind [cycleIcc_of_lt, succAbove_of_castSucc_lt, cycleIcc_of_ge_of_lt,

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -446,6 +446,7 @@ theorem cycleIcc_zero_eq_cycleRange (i : Fin n) [NeZero n] : cycleIcc 0 i = cycl
   · simp [-cycleIcc_def_le, ch]
   · simp [-cycleIcc_def_le, cycleIcc_of_gt ch, cycleRange_of_gt ch]
 
+@[simp]
 theorem cycleIcc_comp_succAbove {n : ℕ} (i j : Fin (n + 1)) (hij : i ≤ j) :
     (cycleIcc i j) ∘ j.succAbove = i.succAbove := by
   grind [cycleIcc_of_lt, succAbove_of_castSucc_lt, cycleIcc_of_ge_of_lt,

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -448,18 +448,8 @@ theorem cycleIcc_zero_eq_cycleRange (i : Fin n) [NeZero n] : cycleIcc 0 i = cycl
 
 theorem cycleIcc_comp_succAbove {n : ℕ} (i j : Fin (n + 1)) (hij : i ≤ j) :
     (cycleIcc i j) ∘ j.succAbove = i.succAbove := by
-  ext k
-  rw [Function.comp_apply]
-  by_cases hk : k.castSucc < i
-  · have hjk : k.castSucc < j := lt_of_lt_of_le hk hij
-    rw [succAbove_of_castSucc_lt _ _ hjk, cycleIcc_of_lt hk, succAbove_of_castSucc_lt _ _ hk]
-  · have hki : i ≤ k.castSucc := le_of_not_gt hk
-    by_cases hkj : k.castSucc < j
-    · simp [succAbove_of_castSucc_lt _ _ hkj, cycleIcc_of_ge_of_lt hki hkj,
-        succAbove_of_le_castSucc _ _ hki]
-    · have hjk : j ≤ k.castSucc := le_of_not_gt hkj
-      rw [succAbove_of_le_castSucc _ _ hjk, cycleIcc_of_gt (le_castSucc_iff.mp hjk),
-        succAbove_of_le_castSucc _ _ hki]
+  grind [cycleIcc_of_lt, succAbove_of_castSucc_lt, cycleIcc_of_ge_of_lt,
+    succAbove_of_le_castSucc, coeSucc_eq_succ, cycleIcc_of_gt]
 
 theorem cycleIcc.trans [NeZero n] (hij : i ≤ j) (hjk : j ≤ k) :
     (cycleIcc i j) ∘ (cycleIcc j k) = (cycleIcc i k) := by


### PR DESCRIPTION
- proves `(cycleIcc i j) ∘ j.succAbove = i.succAbove` for `i ≤ j`, giving the expected `succAbove` compatibility for `cycleIcc`
