### PR TITLE
[Merged by Bors] - refactor(MeasureTheory): golf `Mathlib/MeasureTheory/Integral/CircleTransform`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/CircleTransform.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleTransform.lean
@@ -47,12 +47,7 @@ def circleTransformDeriv (f : ℂ → E) (θ : ℝ) : E :=
 
 theorem circleTransformDeriv_periodic (f : ℂ → E) :
     Periodic (circleTransformDeriv R z w f) (2 * π) := by
-  have := periodic_circleMap
-  simp_rw [Periodic] at *
-  intro x
-  simp_rw [circleTransformDeriv, this]
-  congr 2
-  simp [this]
+  simp [circleTransformDeriv, periodic_circleMap z R _, periodic_circleMap 0 R _]
 
 theorem circleTransformDeriv_eq (f : ℂ → E) : circleTransformDeriv R z w f =
     fun θ => (circleMap z R θ - w)⁻¹ • circleTransform R z w f θ := by


### PR DESCRIPTION
- refactors `Mathlib/MeasureTheory/Integral/CircleTransform` by shortening `circleTransformDeriv_periodic`

Extracted from #38104

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
