### PR TITLE
[Merged by Bors] - chore(NumberTheory/Height/NumberField): move positivity extension higher up

### DIFF
--- a/Mathlib/NumberTheory/Height/NumberField.lean
+++ b/Mathlib/NumberTheory/Height/NumberField.lean
@@ -141,6 +141,29 @@ lemma totalWeight_pos : 0 < totalWeight K := by
 end NumberField
 
 /-!
+### Positivity extension for totalWeight on number fields
+-/
+
+namespace Mathlib.Meta.Positivity
+
+open Lean.Meta Qq
+
+/-- Extension for the `positivity` tactic: `Height.totalWeight` is positive for number fields. -/
+@[positivity Height.totalWeight _]
+meta def evalHeightTotalWeight : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(@Height.totalWeight $K $KF $KA) =>
+    -- Check whether there is a `NumberField` instance for `$K` around.
+    match ← trySynthInstanceQ q(NumberField $K) with
+    | .some _instFinite =>
+      assertInstancesCommute
+      return .positive q(NumberField.totalWeight_pos $K)
+    | _ => throwError "field in Height.totalWeight not known to be a number field"
+  | _, _, _ => throwError "not Height.totalWeight"
+
+end Mathlib.Meta.Positivity
+
+/-!
 ### Heights over the rational numbers
 
 We show that the `Height.mulHeight` of a tuple of coprime integers (considered as rational numbers)
@@ -238,28 +261,5 @@ theorem logHeight₁_natCast (n : ℕ) [NeZero n] :
 end mulHeight₁
 
 end Rat
-
-/-!
-### Positivity extension for totalWeight on number fields
--/
-
-namespace Mathlib.Meta.Positivity
-
-open Lean.Meta Qq
-
-/-- Extension for the `positivity` tactic: `Height.totalWeight` is positive for number fields. -/
-@[positivity Height.totalWeight _]
-meta def evalHeightTotalWeight : PositivityExt where eval {u α} _ _ e := do
-  match u, α, e with
-  | 0, ~q(ℕ), ~q(@Height.totalWeight $K $KF $KA) =>
-    -- Check whether there is a `NumberField` instance for `$K` around.
-    match ← trySynthInstanceQ q(NumberField $K) with
-    | .some _instFinite =>
-      assertInstancesCommute
-      return .positive q(NumberField.totalWeight_pos $K)
-    | _ => throwError "field in Height.totalWeight not known to be a number field"
-  | _, _, _ => throwError "not Height.totalWeight"
-
-end Mathlib.Meta.Positivity
 
 end


### PR DESCRIPTION
This just moves the code for the `positivity` extension for `NumberField.totalWeight` before the section on "Heights over the rational numbers", in anticipating of adding code before that section that will need the positivity extension.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
