### PR TITLE
[Merged by Bors] - chore(SpecificGroups/Alternating/Simple): remove a convert

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -308,7 +308,8 @@ theorem cycleType_extendDomain {β : Type*} [Fintype β] [DecidableEq β] {p : �
   | induction_disjoint σ τ hd _ hσ hτ =>
     rw [hd.cycleType_mul, ← extendDomain_mul, (hd.extendDomain f).cycleType_mul, hσ, hτ]
 
-theorem cycleType_ofSubtype {p : α → Prop} [DecidablePred p] {g : Perm (Subtype p)} :
+theorem cycleType_ofSubtype {p : α → Prop} [DecidablePred p] [Fintype (Subtype p)]
+    {g : Perm (Subtype p)} :
     cycleType (ofSubtype g) = cycleType g :=
   cycleType_extendDomain (Equiv.refl (Subtype p))
 

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Simple.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Simple.lean
@@ -52,7 +52,7 @@ for `n = 3` or `n = 4`, this gives an Iwasawa structure of `alternatingGroup α`
 
 ## TODO
 
-This file contains one uncomfortable use of `convert`: on line 81, to identify `MulAut.conj`
+This file contains one uncomfortable use of `convert`: on line 78, to identify `MulAut.conj`
 and `ConjAct.toConjAct`.
 
 -/

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Simple.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Simple.lean
@@ -52,11 +52,8 @@ for `n = 3` or `n = 4`, this gives an Iwasawa structure of `alternatingGroup α`
 
 ## TODO
 
-This file contains two uncomfortable uses of `convert`:
-
-* on line 81, to identify `MulAut.conj` and `ConjAct.toConjAct`.
-
-* on line 148, to match the subtype coercions for `Finset` and `Set`.
+This file contains one uncomfortable use of `convert`: on line 81, to identify `MulAut.conj`
+and `ConjAct.toConjAct`.
 
 -/
 
@@ -142,10 +139,7 @@ theorem mem_map_kleinFour_ofSubtype {s : Finset α} (hs : s.card = 4) (k : alter
   · obtain ⟨σ, rfl⟩ := (mem_range_ofSubtype_iff s k).mpr hk
     simp_rw [and_iff_right hk, Subgroup.mem_map, ofSubtype_inj, existsAndEq, and_true,
       ← SetLike.mem_coe, coe_kleinFour_of_card_eq_four hs]
-    simp only [Set.singleton_union, Set.mem_insert_iff, Set.mem_setOf_eq, OneMemClass.coe_eq_one,
-      cycleType_ofSubtype, coe_ofSubtype, map_eq_one_iff _ Perm.ofSubtype_injective]
-    apply or_congr_right
-    convert Iff.rfl
+    simp [cycleType_ofSubtype, coe_ofSubtype, map_eq_one_iff _ Perm.ofSubtype_injective]
   · simp_rw [hk, false_and, iff_false]
     contrapose! hk
     exact (mem_range_ofSubtype_iff s k).mp (Subgroup.map_le_range _ _ hk)


### PR DESCRIPTION
As mentioned here https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/support.20of.20permutations.20on.20Type.20instead.20of.20Fintype/with/593547821

I misdiagnosed the issue in that thread, and this PR only fixes one of the issues.
The "issue" in this case was that the lemma `cycleType_ofSubtype` contains a non-variable instance of `Fintype (Subtype p)`, which means that when applying the lemma, the "wrong" instance could be picked. The correct pattern is that if a lemma requires `Fintype _`, then it should be stated *explicitly* in the type, even if that instance is derivable from other hypotheses. (An existing example is https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Fintype/Sets.html#Set.toFinset_union).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
