### PR TITLE
[Merged by Bors] - refactor(Analysis/Calculus/Gradient): ungate `inner_gradient` lemmas

### DIFF
--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -262,21 +262,21 @@ lemma HasGradientWithinAt.fderivWithin_apply
 lemma HasGradientAt.fderiv_apply (h : HasGradientAt f f' x) : fderiv 𝕜 f x y = ⟪f', y⟫ := by
   rw [h.hasFDerivAt.fderiv, toDual_apply_apply]
 
-lemma inner_gradientWithin_left
-    (h : DifferentiableWithinAt 𝕜 f s x) (hs : UniqueDiffWithinAt 𝕜 s x) :
+lemma inner_gradientWithin_left :
     ⟪gradientWithin f s x, y⟫ = fderivWithin 𝕜 f s x y := by
-  rw [h.hasGradientWithinAt.fderivWithin_apply hs]
+  rw [gradientWithin, ← toDual_apply_apply (𝕜 := 𝕜) (E := F),
+      LinearIsometryEquiv.apply_symm_apply]
 
-lemma inner_gradient_left (h : DifferentiableAt 𝕜 f x) : ⟪∇ f x, y⟫ = fderiv 𝕜 f x y := by
-  rw [h.hasGradientAt.fderiv_apply]
+lemma inner_gradient_left : ⟪∇ f x, y⟫ = fderiv 𝕜 f x y := by
+  rw [gradient, ← toDual_apply_apply (𝕜 := 𝕜) (E := F),
+      LinearIsometryEquiv.apply_symm_apply]
 
-lemma inner_gradientWithin_right
-    (h : DifferentiableWithinAt 𝕜 f s y) (hs : UniqueDiffWithinAt 𝕜 s y) :
+lemma inner_gradientWithin_right :
     ⟪x, gradientWithin f s y⟫ = conj (fderivWithin 𝕜 f s y x) := by
-  rw [← inner_conj_symm, inner_gradientWithin_left h hs]
+  rw [← inner_conj_symm, inner_gradientWithin_left]
 
-lemma inner_gradient_right (h : DifferentiableAt 𝕜 f y) : ⟪x, ∇ f y⟫ = conj (fderiv 𝕜 f y x) := by
-  rw [← inner_conj_symm, h.hasGradientAt.fderiv_apply]
+lemma inner_gradient_right : ⟪x, ∇ f y⟫ = conj (fderiv 𝕜 f y x) := by
+  rw [← inner_conj_symm, inner_gradient_left]
 
 end Inner
 

--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -147,6 +147,10 @@ theorem hasGradientWithinAt_univ : HasGradientWithinAt f f' univ x ↔ HasGradie
   rw [hasGradientWithinAt_iff_hasFDerivWithinAt, hasGradientAt_iff_hasFDerivAt]
   exact hasFDerivWithinAt_univ
 
+@[simp]
+lemma gradientWithin_univ : gradientWithin f univ = gradient f := by
+  ext; simp [gradientWithin, gradient]
+
 theorem DifferentiableOn.hasGradientAt (h : DifferentiableOn 𝕜 f s) (hs : s ∈ 𝓝 x) :
     HasGradientAt f (∇ f x) x :=
   (h.hasFDerivAt hs).hasGradientAt
@@ -262,19 +266,22 @@ lemma HasGradientWithinAt.fderivWithin_apply
 lemma HasGradientAt.fderiv_apply (h : HasGradientAt f f' x) : fderiv 𝕜 f x y = ⟪f', y⟫ := by
   rw [h.hasFDerivAt.fderiv, toDual_apply_apply]
 
+@[simp]
 lemma inner_gradientWithin_left :
     ⟪gradientWithin f s x, y⟫ = fderivWithin 𝕜 f s x y := by
   rw [gradientWithin, ← toDual_apply_apply (𝕜 := 𝕜) (E := F),
       LinearIsometryEquiv.apply_symm_apply]
 
+@[simp]
 lemma inner_gradient_left : ⟪∇ f x, y⟫ = fderiv 𝕜 f x y := by
-  rw [gradient, ← toDual_apply_apply (𝕜 := 𝕜) (E := F),
-      LinearIsometryEquiv.apply_symm_apply]
+  simp [← gradientWithin_univ]
 
+@[simp]
 lemma inner_gradientWithin_right :
     ⟪x, gradientWithin f s y⟫ = conj (fderivWithin 𝕜 f s y x) := by
   rw [← inner_conj_symm, inner_gradientWithin_left]
 
+@[simp]
 lemma inner_gradient_right : ⟪x, ∇ f y⟫ = conj (fderiv 𝕜 f y x) := by
   rw [← inner_conj_symm, inner_gradient_left]
 


### PR DESCRIPTION
Removes superfluous differentiability hypotheses (plus `UniqueDiffWithinAt` for the `Within` versions) from the four `inner_gradient[Within]_[left|right]` lemmas: `gradient` is defined as `(toDual 𝕜 F).symm (fderiv 𝕜 f x)`, so `⟪∇ f x, y⟫ = fderiv 𝕜 f x y` holds unconditionally since both sides are zero when `f` is not differentiable at `x`.

Co-authored-by: Sebastian Pokutta <23001135+pokutta@users.noreply.github.com>

---

Genuinely unsure about this one because the only call I currently have in my code itself has the differentiability hypothesis. But including unused (or unnecessary) assumptions seems not intentional? My best guess is  that the hypotheses were included by analogy with `HasGradientAt.fderiv_apply`, which genuinely needs them. This PR drops the hypotheses and rewrites the proofs through the isomorphism directly; no existing mathlib callers pass the now-redundant arguments.