### PR TITLE
[Merged by Bors] - feat(Analysis/Calculus/AddTorsor/AffineMap): smoothness of `AffineMap.lineMap`

### DIFF
--- a/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
@@ -14,9 +14,12 @@ public import Mathlib.Analysis.Normed.Group.AddTorsor
 
 This file contains results about smoothness of affine maps.
 
-## Main definitions:
+## Main results
 
-* `ContinuousAffineMap.contDiff`: a continuous affine map is smooth
+* `ContinuousAffineMap.contDiff`: a continuous affine map is smooth.
+* `AffineMap.lineMap_contDiff_uncurry`, `AffineMap.lineMap_contDiff`,
+  `ContDiff.lineMap` and variants: `AffineMap.lineMap` is smooth in its three
+  arguments, jointly and pointwise.
 
 -/
 
@@ -34,3 +37,53 @@ theorem contDiff {n : WithTop ℕ∞} (f : V →ᴬ[𝕜] W) : ContDiff 𝕜 n f
   exact contDiff_const
 
 end ContinuousAffineMap
+
+namespace AffineMap
+
+variable {𝕜 V : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup V] [NormedSpace 𝕜 V]
+
+/-- `AffineMap.lineMap` is smooth in all three arguments. -/
+@[fun_prop]
+theorem lineMap_contDiff_uncurry {n : WithTop ℕ∞} :
+    ContDiff 𝕜 n (fun pqc : V × V × 𝕜 ↦ AffineMap.lineMap pqc.1 pqc.2.1 pqc.2.2) := by
+  simp only [AffineMap.lineMap_apply_module]
+  fun_prop
+
+/-- `AffineMap.lineMap` is smooth as a function `𝕜 → V`. -/
+theorem lineMap_contDiff (p₀ p₁ : V) {n : WithTop ℕ∞} :
+    ContDiff 𝕜 n (AffineMap.lineMap p₀ p₁ : 𝕜 → V) := by
+  fun_prop
+
+end AffineMap
+
+section LineMapComp
+
+variable {𝕜 V E : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup V] [NormedSpace 𝕜 V]
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {f₁ f₂ : E → V} {g : E → 𝕜} {s : Set E} {x : E} {n : WithTop ℕ∞}
+
+@[fun_prop]
+theorem ContDiffWithinAt.lineMap (h₁ : ContDiffWithinAt 𝕜 n f₁ s x)
+    (h₂ : ContDiffWithinAt 𝕜 n f₂ s x) (hg : ContDiffWithinAt 𝕜 n g s x) :
+    ContDiffWithinAt 𝕜 n (fun x ↦ AffineMap.lineMap (f₁ x) (f₂ x) (g x)) s x := by
+  simp only [AffineMap.lineMap_apply_module]
+  fun_prop
+
+theorem ContDiffAt.lineMap (h₁ : ContDiffAt 𝕜 n f₁ x)
+    (h₂ : ContDiffAt 𝕜 n f₂ x) (hg : ContDiffAt 𝕜 n g x) :
+    ContDiffAt 𝕜 n (fun x ↦ AffineMap.lineMap (f₁ x) (f₂ x) (g x)) x := by
+  fun_prop
+
+theorem ContDiffOn.lineMap (h₁ : ContDiffOn 𝕜 n f₁ s)
+    (h₂ : ContDiffOn 𝕜 n f₂ s) (hg : ContDiffOn 𝕜 n g s) :
+    ContDiffOn 𝕜 n (fun x ↦ AffineMap.lineMap (f₁ x) (f₂ x) (g x)) s := by
+  fun_prop
+
+theorem ContDiff.lineMap (h₁ : ContDiff 𝕜 n f₁)
+    (h₂ : ContDiff 𝕜 n f₂) (hg : ContDiff 𝕜 n g) :
+    ContDiff 𝕜 n (fun x ↦ AffineMap.lineMap (f₁ x) (f₂ x) (g x)) := by
+  fun_prop
+
+end LineMapComp

--- a/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
@@ -17,9 +17,8 @@ This file contains results about smoothness of affine maps.
 ## Main results
 
 * `ContinuousAffineMap.contDiff`: a continuous affine map is smooth.
-* `AffineMap.lineMap_contDiff_uncurry`, `AffineMap.lineMap_contDiff`,
-  `ContDiff.lineMap` and variants: `AffineMap.lineMap` is smooth in its three
-  arguments, jointly and pointwise.
+* `AffineMap.contDiff_lineMap_uncurry`: `AffineMap.lineMap` is smooth in its three arguments,
+  jointly and pointwise.
 
 -/
 
@@ -45,13 +44,13 @@ variable [NormedAddCommGroup V] [NormedSpace 𝕜 V]
 
 /-- `AffineMap.lineMap` is smooth in all three arguments. -/
 @[fun_prop]
-theorem lineMap_contDiff_uncurry {n : WithTop ℕ∞} :
+theorem contDiff_lineMap_uncurry {n : WithTop ℕ∞} :
     ContDiff 𝕜 n (fun pqc : V × V × 𝕜 ↦ AffineMap.lineMap pqc.1 pqc.2.1 pqc.2.2) := by
   simp only [AffineMap.lineMap_apply_module]
   fun_prop
 
 /-- `AffineMap.lineMap` is smooth as a function `𝕜 → V`. -/
-theorem lineMap_contDiff (p₀ p₁ : V) {n : WithTop ℕ∞} :
+theorem contDiff_lineMap (p₀ p₁ : V) {n : WithTop ℕ∞} :
     ContDiff 𝕜 n (AffineMap.lineMap p₀ p₁ : 𝕜 → V) := by
   fun_prop
 

--- a/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
+++ b/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 module
 
+public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 public import Mathlib.Analysis.Calculus.Deriv.Prod
 public import Mathlib.Analysis.Calculus.DiffContOnCl
 public import Mathlib.Analysis.Calculus.FDeriv.Symmetric
@@ -330,8 +331,6 @@ theorem curveIntegral_segment_add_eq_of_hasFDerivWithinAt_symmetric (hs : Convex
       lift y to I using hy
       simp [φ]
     refine .congr ?_ this
-    -- TODO: add `ContDiff.lineMap` etc
-    simp only [AffineMap.lineMap_apply_module]
     fun_prop
 
 variable [CompleteSpace F]

--- a/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
+++ b/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
@@ -5,7 +5,6 @@ Authors: Yury Kudryashov
 -/
 module
 
-public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 public import Mathlib.Analysis.Calculus.Deriv.Prod
 public import Mathlib.Analysis.Calculus.DiffContOnCl
 public import Mathlib.Analysis.Calculus.FDeriv.Symmetric
@@ -13,6 +12,8 @@ public import Mathlib.Analysis.Calculus.TangentCone.Prod
 public import Mathlib.MeasureTheory.Integral.CurveIntegral.Basic
 public import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 public import Mathlib.Topology.Homotopy.Affine
+
+import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 
 /-!
 # Poincaré lemma for 1-forms
@@ -330,8 +331,7 @@ theorem curveIntegral_segment_add_eq_of_hasFDerivWithinAt_symmetric (hs : Convex
       lift x to I using hx
       lift y to I using hy
       simp [φ]
-    refine .congr ?_ this
-    fun_prop
+    exact .congr (by fun_prop) this
 
 variable [CompleteSpace F]
 


### PR DESCRIPTION
Add `AffineMap.lineMap_contDiff_uncurry` (joint smoothness in all three arguments), `AffineMap.lineMap_contDiff` (smoothness in the parameter with fixed endpoints), and the composition family `ContDiff.lineMap`, `ContDiffOn.lineMap`, `ContDiffAt.lineMap`, `ContDiffWithinAt.lineMap`, mirroring the corresponding `Continuous` family in `Mathlib.Topology.Algebra.Affine`. The uncurried and `ContDiffWithinAt` forms are tagged `@[fun_prop]` so the rest are automatically derivable. Closes the TODO at `Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare:333` where the proof now reduces to `fun_prop`.

Co-authored-by: Sebastian Pokutta <23001135+pokutta@users.noreply.github.com>

---

Came up while formalizing the descent lemma for Lipschitz-smooth functions, where `Path.segment a b` being smooth on the unit interval is needed to apply FTC along the segment (#39524); `AffineMap.lineMap_contDiff` is the lemma directly used there. Two things I was genuinely not quite sure about:

1. Should the **three convenience variants** `ContDiffAt.lineMap`, `ContDiffOn.lineMap`, and `ContDiff.lineMap` be included? They are not strictly necessary but they exist for users wanting to write `h₁.lineMap h₂ hg` in dot notation by hand, and they mirror the convention of the `Continuous.lineMap` family.

2. Is `Mathlib.Analysis.Calculus.AddTorsor.AffineMap` the **right home**, and is adding `public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap` to `Poincare.lean` to close the TODO reasonable? The placement mirrors the `Continuous.lineMap` family in `Mathlib.Topology.Algebra.Affine`, but hiding a `@[fun_prop]` in a file at the bottom of the hierarchy and needing to import it feels a bit off.