### PR TITLE
feat: define maximal cliques and independent sets

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -700,21 +700,36 @@ theorem isMaximumClique_iff [Finite α] {s : Finset α} :
   ⟨fun h ↦ ⟨h.1, h.2⟩, fun h ↦ ⟨h.1, h.2⟩⟩
 
 /-- A maximal clique in a graph `G` is a clique that cannot be extended by adding more vertices. -/
-theorem isMaximalClique_iff {s : Set α} :
-    Maximal G.IsClique s ↔ G.IsClique s ∧ ∀ t : Set α, G.IsClique t → s ⊆ t → t ⊆ s :=
-  Iff.rfl
+@[mk_iff]
+structure IsMaximalClique (G : SimpleGraph α) (s : Set α) : Prop where
+  isClique : G.IsClique s
+  maximal : ∀ t : Set α, G.IsClique t → s ⊆ t → t ⊆ s
+
+/-- A maximal clique in a graph `G` is a clique that cannot be extended by adding more vertices. -/
+theorem maximal_isClique_iff_isMaximalClique {s : Set α} :
+    Maximal G.IsClique s ↔ G.IsMaximalClique s := by
+  constructor
+  · rintro ⟨hs, hmax⟩
+    exact ⟨hs, fun t ht hst => hmax ht hst⟩
+  · intro h
+    exact ⟨h.isClique, fun t ht hst => h.maximal t ht hst⟩
+
+lemma IsMaximumClique.toIsMaximalClique [Finite α] (s : Finset α) (M : G.IsMaximumClique s) :
+    G.IsMaximalClique s :=
+  maximal_isClique_iff_isMaximalClique.mp <|
+    ⟨ M.isClique,
+      fun t ht hsub => by
+        by_contra hc
+        have fint := ofFinite t
+        have ne : s ≠ t.toFinset := fun a ↦ by subst a; simp_all[Set.coe_toFinset, not_true_eq_false]
+        have hle : #t.toFinset ≤ #s := M.maximum t.toFinset (by simp [Set.coe_toFinset, ht])
+        have hlt : #s < #t.toFinset :=
+          card_lt_card (ssubset_of_ne_of_subset ne (Set.subset_toFinset.mpr hsub))
+        exact lt_irrefl _ (lt_of_lt_of_le hlt hle) ⟩
 
 lemma IsMaximumClique.isMaximalClique [Finite α] (s : Finset α) (M : G.IsMaximumClique s) :
     Maximal G.IsClique s :=
-  ⟨ M.isClique,
-    fun t ht hsub => by
-      by_contra hc
-      have fint := ofFinite t
-      have ne : s ≠ t.toFinset := fun a ↦ by subst a; simp_all[Set.coe_toFinset, not_true_eq_false]
-      have hle : #t.toFinset ≤ #s := M.maximum t.toFinset (by simp [Set.coe_toFinset, ht])
-      have hlt : #s < #t.toFinset :=
-        card_lt_card (ssubset_of_ne_of_subset ne (Set.subset_toFinset.mpr hsub))
-      exact lt_irrefl _ (lt_of_lt_of_le hlt hle) ⟩
+  maximal_isClique_iff_isMaximalClique.mpr <| M.toIsMaximalClique s
 
 lemma maximumClique_card_eq_cliqueNum [Finite α] (s : Finset α) (sm : G.IsMaximumClique s) :
     #s = G.cliqueNum := by
@@ -961,23 +976,46 @@ structure IsMaximumIndepSet [Finite α] (G : SimpleGraph α) (s : Finset α) : P
   simp [isMaximumIndepSet_iff, isMaximumClique_iff]
 
 /-- An independent set in a graph `G` that cannot be extended by adding more vertices. -/
-theorem isMaximalIndepSet_iff {s : Set α} :
-    Maximal G.IsIndepSet s ↔ G.IsIndepSet s ∧ ∀ t : Set α, G.IsIndepSet t → s ⊆ t → t ⊆ s :=
-  Iff.rfl
+@[mk_iff]
+structure IsMaximalIndepSet (G : SimpleGraph α) (s : Set α) : Prop where
+  isIndepSet : G.IsIndepSet s
+  maximal : ∀ t : Set α, G.IsIndepSet t → s ⊆ t → t ⊆ s
 
-@[simp] lemma isMaximalClique_compl (s : Finset α) :
+/-- An independent set in a graph `G` that cannot be extended by adding more vertices. -/
+theorem maximal_isIndepSet_iff_isMaximalIndepSet {s : Set α} :
+    Maximal G.IsIndepSet s ↔ G.IsMaximalIndepSet s := by
+  constructor
+  · rintro ⟨hs, hmax⟩
+    exact ⟨hs, fun t ht hst => hmax ht hst⟩
+  · intro h
+    exact ⟨h.isIndepSet, fun t ht hst => h.maximal t ht hst⟩
+
+@[simp] lemma isMaximalClique_compl (s : Set α) :
+    Gᶜ.IsMaximalClique s ↔ G.IsMaximalIndepSet s := by
+  simp [isMaximalClique_iff, isMaximalIndepSet_iff]
+
+@[simp] lemma isMaximalIndepSet_compl (s : Set α) :
+    Gᶜ.IsMaximalIndepSet s ↔ G.IsMaximalClique s := by
+  simp [isMaximalClique_iff, isMaximalIndepSet_iff]
+
+@[simp] lemma isMaximalClique_compl' (s : Finset α) :
     Maximal Gᶜ.IsClique s ↔ Maximal G.IsIndepSet s := by
-  simp [isMaximalIndepSet_iff, isMaximalClique_iff]
+  simp [maximal_isIndepSet_iff_isMaximalIndepSet, maximal_isClique_iff_isMaximalClique]
 
-@[simp] lemma isMaximalIndepSet_compl (s : Finset α) :
+@[simp] lemma isMaximalIndepSet_compl' (s : Finset α) :
     Maximal Gᶜ.IsIndepSet s ↔ Maximal G.IsClique s := by
-  simp [isMaximalIndepSet_iff, isMaximalClique_iff]
+  simp [maximal_isIndepSet_iff_isMaximalIndepSet, maximal_isClique_iff_isMaximalClique]
 
-lemma IsMaximumIndepSet.isMaximalIndepSet
-    [Finite α] (s : Finset α) (M : G.IsMaximumIndepSet s) : Maximal G.IsIndepSet s := by
+lemma IsMaximumIndepSet.toIsMaximalIndepSet
+    [Finite α] (s : Finset α) (M : G.IsMaximumIndepSet s) : G.IsMaximalIndepSet s :=
+  by
   rw [← isMaximalClique_compl]
   rw [← isMaximumClique_compl] at M
-  exact IsMaximumClique.isMaximalClique s M
+  exact (M.toIsMaximalClique s)
+
+lemma IsMaximumIndepSet.isMaximalIndepSet
+    [Finite α] (s : Finset α) (M : G.IsMaximumIndepSet s) : Maximal G.IsIndepSet s :=
+  maximal_isIndepSet_iff_isMaximalIndepSet.mpr <| M.toIsMaximalIndepSet s
 
 theorem maximumIndepSet_card_eq_indepNum
     [Finite α] (t : Finset α) (tmc : G.IsMaximumIndepSet t) : #t = G.indepNum := by


### PR DESCRIPTION
This PR adds explicit predicates for maximal cliques and maximal independent sets:

- `SimpleGraph.IsMaximalClique`
- `SimpleGraph.IsMaximalIndepSet`

It also adds conversion lemmas to and from the existing `Maximal G.IsClique` and `Maximal G.IsIndepSet` formulations, plus basic complement and maximum-to-maximal lemmas.

Towards #34962.

The formalization was developed with the help of Doubao-Seed-2.0-code and manually checked in Lean.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)