### PR TITLE
refactor(Data/Finsupp/MonomialOrder): remove `.wf` (well foundedness) field from `MonomialOrder`

### DIFF
--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -149,8 +149,7 @@ example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 2) := by
 variable {σ : Type*} [LinearOrder σ]
 
 /-- The lexicographic order on `σ →₀ ℕ`, as a `MonomialOrder` -/
-noncomputable def MonomialOrder.lex :
-    MonomialOrder σ where
+noncomputable def MonomialOrder.lex : MonomialOrder σ where
   syn := Lex (σ →₀ ℕ)
   toSyn :=
   { toEquiv := toLex

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -71,14 +71,17 @@ structure MonomialOrder (σ : Type*) where
   toSyn : (σ →₀ ℕ) ≃+ syn
   /-- `toSyn` is monotone -/
   toSyn_monotone : Monotone toSyn
-  /-- `syn` is a well ordering -/
-  wf : WellFoundedLT syn := by infer_instance
 
-attribute [instance] MonomialOrder.acm MonomialOrder.lo MonomialOrder.iocam MonomialOrder.wf
+attribute [instance] MonomialOrder.acm MonomialOrder.lo MonomialOrder.iocam
 
 namespace MonomialOrder
 
 variable {σ : Type*} (m : MonomialOrder σ)
+
+@[deprecated inferInstance
+  "`MonomialOrder` no longer contains or implies `.wf : WellFoundedLT .syn`"
+  (since := "2026-05-12")]
+lemma wf [inst : WellFoundedLT m.syn] : WellFoundedLT m.syn := inst
 
 lemma le_add_right (a b : σ →₀ ℕ) :
     m.toSyn a ≤ m.toSyn a + m.toSyn b := by
@@ -146,7 +149,7 @@ example : toLex (Finsupp.single 1 1) < toLex (Finsupp.single 0 2) := by
 variable {σ : Type*} [LinearOrder σ]
 
 /-- The lexicographic order on `σ →₀ ℕ`, as a `MonomialOrder` -/
-noncomputable def MonomialOrder.lex [WellFoundedGT σ] :
+noncomputable def MonomialOrder.lex :
     MonomialOrder σ where
   syn := Lex (σ →₀ ℕ)
   toSyn :=
@@ -154,10 +157,13 @@ noncomputable def MonomialOrder.lex [WellFoundedGT σ] :
     map_add' := toLex_add }
   toSyn_monotone := Finsupp.toLex_monotone
 
-theorem MonomialOrder.lex_le_iff [WellFoundedGT σ] {c d : σ →₀ ℕ} :
+instance [WellFoundedGT σ] : WellFoundedLT (MonomialOrder.lex (σ := σ)).syn :=
+  inferInstanceAs <| WellFoundedLT (Lex (σ →₀ ℕ))
+
+theorem MonomialOrder.lex_le_iff {c d : σ →₀ ℕ} :
     c ≼[lex] d ↔ toLex c ≤ toLex d := Iff.rfl
 
-theorem MonomialOrder.lex_lt_iff [WellFoundedGT σ] {c d : σ →₀ ℕ} :
+theorem MonomialOrder.lex_lt_iff {c d : σ →₀ ℕ} :
     c ≺[lex] d ↔ toLex c < toLex d := Iff.rfl
 
 theorem MonomialOrder.lex_lt_iff_of_unique [Unique σ] {c d : σ →₀ ℕ} :

--- a/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
@@ -194,7 +194,7 @@ namespace MonomialOrder
 
 open Finsupp
 
-variable {σ : Type*} [LinearOrder σ] [WellFoundedGT σ]
+variable {σ : Type*} [LinearOrder σ]
 
 /-- The deg-lexicographic order on `σ →₀ ℕ`, as a `MonomialOrder` -/
 noncomputable def degLex :
@@ -208,6 +208,9 @@ noncomputable def degLex :
     · refine Or.inr ⟨le_antisymm ?_ ha, toLex_monotone h⟩
       rw [← add_tsub_cancel_of_le h, map_add]
       exact Nat.le_add_right a.degree (b - a).degree
+
+instance [WellFoundedGT σ] : WellFoundedLT (degLex (σ := σ)).syn :=
+  inferInstanceAs <| WellFoundedLT (DegLex (σ →₀ ℕ))
 
 theorem degLex_le_iff {a b : σ →₀ ℕ} :
     a ≼[degLex] b ↔ toDegLex a ≤ toDegLex b :=

--- a/Mathlib/RingTheory/MvPolynomial/Groebner.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Groebner.lean
@@ -125,7 +125,7 @@ theorem degree_reduce_lt {f b : MvPolynomial σ R} (hb : IsUnit (m.leadingCoeff 
 
 /-- Division by a family of multivariate polynomials
 whose leading coefficients are invertible with respect to a monomial order -/
-theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
+theorem div [WellFoundedLT m.syn] {ι : Type*} {b : ι → MvPolynomial σ R}
     (hb : ∀ i, IsUnit (m.leadingCoeff (b i))) (f : MvPolynomial σ R) :
     ∃ (g : ι →₀ (MvPolynomial σ R)) (r : MvPolynomial σ R),
       f = Finsupp.linearCombination _ b g + r ∧
@@ -210,7 +210,7 @@ theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
       exact bot_le
     · exact (div hb) (m.subLTerm f)
 termination_by WellFounded.wrap
-  ((isWellFounded_iff m.syn fun x x_1 ↦ x < x_1).mp m.wf) (m.toSyn (m.degree f))
+  ((isWellFounded_iff m.syn fun x x_1 ↦ x < x_1).mp inferInstance) (m.toSyn (m.degree f))
 decreasing_by
 · exact deg_reduce
 · apply degree_sub_LTerm_lt
@@ -229,7 +229,7 @@ See https://github.com/leanprover/lean4/issues/12573
 
 /-- Division by a *set* of multivariate polynomials
 whose leading coefficients are invertible with respect to a monomial order -/
-theorem div_set {B : Set (MvPolynomial σ R)}
+theorem div_set [WellFoundedLT m.syn] {B : Set (MvPolynomial σ R)}
     (hB : ∀ b ∈ B, IsUnit (m.leadingCoeff b)) (f : MvPolynomial σ R) :
     ∃ (g : B →₀ (MvPolynomial σ R)) (r : MvPolynomial σ R),
       f = Finsupp.linearCombination _ (fun (b : B) ↦ (b : MvPolynomial σ R)) g + r ∧
@@ -240,7 +240,7 @@ theorem div_set {B : Set (MvPolynomial σ R)}
 
 /-- Division by a multivariate polynomial
 whose leading coefficient is invertible with respect to a monomial order -/
-theorem div_single {b : MvPolynomial σ R}
+theorem div_single [WellFoundedLT m.syn] {b : MvPolynomial σ R}
     (hb : IsUnit (m.leadingCoeff b)) (f : MvPolynomial σ R) :
     ∃ (g : MvPolynomial σ R) (r : MvPolynomial σ R),
       f = g * b + r ∧

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
@@ -26,7 +26,7 @@ variable [CommSemiring R] {f g : MvPolynomial σ R}
 
 section LinearOrder
 
-variable [LinearOrder σ] [WellFoundedGT σ]
+variable [LinearOrder σ]
 
 theorem degree_degLexDegree : (degLex.degree f).degree = f.totalDegree := by
   by_cases hf : f = 0


### PR DESCRIPTION
Many properties still hold without the well-foundedness.

Although Gröbner basis theory requires the monomial order to be well founded for the termination of the division algorithm (formalized in `MonomialOrder.div`), many properties that don't relay on the division or remainder still hold without the well-foundedness.

Even the division algorithm can terminate in some cases where the monomial order isn't well founded. For example, if the divisors set is finite, then the algorithm can terminate w.r.t. `MonomialOrder.lex (σ := Nat)` even though it isn't well founded. Such cases cannot be directly stated if the formalization of monomial order requires well-foundedness.

Deletions:
- MonomialOrder.wf

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #39494

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
