### PR TITLE
feat(NumberTheory/FLT): Beal conjecture bundle (4 files)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5617,6 +5617,10 @@ public import Mathlib.NumberTheory.EulerProduct.Basic
 public import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
 public import Mathlib.NumberTheory.EulerProduct.ExpLog
 public import Mathlib.NumberTheory.FLT.Basic
+public import Mathlib.NumberTheory.FLT.Beal
+public import Mathlib.NumberTheory.FLT.BealAbcBridge
+public import Mathlib.NumberTheory.FLT.BealEichlerShimura
+public import Mathlib.NumberTheory.FLT.BealFreyCurve
 public import Mathlib.NumberTheory.FLT.Four
 public import Mathlib.NumberTheory.FLT.MasonStothers
 public import Mathlib.NumberTheory.FLT.Polynomial

--- a/Mathlib/NumberTheory/FLT/Beal.lean
+++ b/Mathlib/NumberTheory/FLT/Beal.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 Carles Marín. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Carles Marín
+-/
+module
+
+public import Mathlib.NumberTheory.FLT.Basic
+public import Mathlib.NumberTheory.FLT.Polynomial
+public import Mathlib.Tactic.LinearCombination
+
+/-!
+# Statement of Beal's Conjecture and its polynomial corollary
+
+This file states Beal's conjecture as `Prop` predicates, analogous to
+`FermatLastTheoremFor` and friends in `Mathlib.NumberTheory.FLT.Basic`, and
+derives the polynomial version (coprime case) as a corollary of
+`Polynomial.flt_catalan`.
+
+## Main definitions
+
+* `BealConjectureWith R p q r` : The statement that the only solutions to
+  `a ^ p + b ^ q = c ^ r` in the semiring `R` have `a = 0`, `b = 0` or `c = 0`.
+  Note that this can be false for specific choices of `R, p, q, r` (for example
+  `BealConjectureWith ℕ 0 3 2` is false as `1^0 + 2^3 = 3^2`).
+* `BealConjectureFor p q r` : The same statement over `ℕ`.
+* `BealConjecture` : The full Beal conjecture proper: for all `p, q, r ≥ 3` and
+  coprime positive naturals `a, b, c`, `a^p + b^q ≠ c^r`.
+
+## Main results
+
+* `bealConjectureWith_eq_fermat`, `bealConjectureFor_eq_fermat` : at equal
+  exponents `p = q = r = n`, Beal coincides with `FermatLastTheoremWith` /
+  `FermatLastTheoremFor`.
+* `beal_hyperbolicity` : `q*r + r*p + p*q ≤ p*q*r` whenever `p, q, r ≥ 3`
+  (equivalent to `1/p + 1/q + 1/r ≤ 1`). Required as input to
+  `Polynomial.flt_catalan`.
+* `bealConjecture_polynomial_coprime` : Beal for polynomials over a field, in
+  the coprime case, with characteristic coprime to `p*q*r` and exponents `≥ 3`.
+  Direct specialisation of `Polynomial.flt_catalan` with coefficients `(1, 1, -1)`.
+
+## History
+
+Beal's conjecture was formulated in 1993 by D. Andrew Beal as a generalisation
+of Fermat's Last Theorem. A US$1 000 000 prize, administered by the American
+Mathematical Society, is offered for a proof or counterexample
+(see [A. Mauldin, *A Generalization of Fermat's Last Theorem: The Beal
+Conjecture and Prize Problem*, Notices AMS 44 (1997), 1436-1437]).
+
+Computational verification by Peter Norvig (2000, updated 2015) excludes
+primitive counterexamples with `A, B, C ≤ 250 000` for exponents `≤ 7`, and
+with `A, B, C ≤ 10 000` for exponents `≤ 100`. Many specific exponent
+signatures `(p, q, r)` have been settled by Frey-Hellegouarch curve + modularity
+techniques (Bennett-Chen-Dahmen-Yazdani 2015, Dahmen-Siksek 2014,
+Grechuk-Ratcliffe 2024 catalog over 100 solved signatures).
+
+The non-coprime case of polynomial Beal does not follow trivially from the
+coprime case here, unlike for polynomial Fermat: factoring `gcd(a, b)` out of
+`a^p + b^q = c^r` does not yield a clean equation when the exponents `p, q, r`
+differ. We leave that extension as future work.
+-/
+
+public section
+
+open Polynomial
+
+/-- Statement of Beal's conjecture over a given semiring with specific exponents.
+For nonzero `a b c : R`, the equation `a ^ p + b ^ q = c ^ r` has no solutions.
+
+Note that this statement can be false for certain choices of `R, p, q, r`.
+For example `BealConjectureWith ℕ 0 3 2` is false, as `1^0 + 2^3 = 3^2`. -/
+def BealConjectureWith (R : Type*) [Semiring R] (p q r : ℕ) : Prop :=
+  ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ p + b ^ q ≠ c ^ r
+
+/-- Statement of Beal's conjecture over the naturals for fixed exponents. -/
+def BealConjectureFor (p q r : ℕ) : Prop := BealConjectureWith ℕ p q r
+
+/-- Statement of Beal's conjecture: for all `p, q, r ≥ 3` and coprime positive
+naturals `a, b, c`, the equation `a ^ p + b ^ q = c ^ r` has no solutions.
+
+Encodes primitivity via `Nat.gcd (Nat.gcd a b) c = 1`, equivalent (contrapositive)
+to the original "any solution shares a common prime factor" formulation. -/
+def BealConjecture : Prop :=
+  ∀ p q r : ℕ, 3 ≤ p → 3 ≤ q → 3 ≤ r →
+    ∀ a b c : ℕ, a ≠ 0 → b ≠ 0 → c ≠ 0 →
+      Nat.gcd (Nat.gcd a b) c = 1 → a ^ p + b ^ q ≠ c ^ r
+
+/-- Beal at `p = q = r = n` is exactly Fermat's Last Theorem with exponent `n`. -/
+lemma bealConjectureWith_eq_fermat (R : Type*) [Semiring R] (n : ℕ) :
+    BealConjectureWith R n n n ↔ FermatLastTheoremWith R n := by
+  rfl
+
+/-- Same equivalence over `ℕ`. -/
+lemma bealConjectureFor_eq_fermat (n : ℕ) :
+    BealConjectureFor n n n ↔ FermatLastTheoremFor n := by
+  rfl
+
+/-- `BealConjectureFor 0 3 2` is false: `1^0 + 2^3 = 1 + 8 = 9 = 3^2`. This is
+the simplest witness that dropping the `≥ 3` exponent hypothesis breaks Beal. -/
+lemma not_bealConjectureFor_zero_three_two : ¬ BealConjectureFor 0 3 2 := by
+  intro h
+  exact h 1 2 3 (by decide) (by decide) (by decide) (by decide)
+
+/-- The hyperbolicity inequality `q*r + r*p + p*q ≤ p*q*r` holds whenever
+`p, q, r ≥ 3`. Equivalent to `1/p + 1/q + 1/r ≤ 1` (the Darmon-Granville
+hyperbolic case). Required as a hypothesis of `Polynomial.flt_catalan`. -/
+lemma beal_hyperbolicity {p q r : ℕ} (hp : 3 ≤ p) (hq : 3 ≤ q) (hr : 3 ≤ r) :
+    q * r + r * p + p * q ≤ p * q * r := by
+  zify
+  nlinarith [hp, hq, hr,
+    mul_nonneg (by linarith : (0:ℤ) ≤ (q:ℤ)) (by linarith : (0:ℤ) ≤ (r:ℤ)),
+    mul_nonneg (by linarith : (0:ℤ) ≤ (p:ℤ)) (by linarith : (0:ℤ) ≤ (r:ℤ)),
+    mul_nonneg (by linarith : (0:ℤ) ≤ (p:ℤ)) (by linarith : (0:ℤ) ≤ (q:ℤ))]
+
+variable {k : Type*} [Field k]
+
+/-- **Polynomial Beal (coprime case).** For polynomials `a, b, c` over a field
+`k`, with `p, q, r ≥ 3` coprime to `char k`, `a, b, c` pairwise nonzero, and
+`a, b` coprime: if `a^p + b^q = c^r`, then all three polynomials are constants
+(i.e. `natDegree = 0`).
+
+This is the polynomial version of Beal's conjecture, derived directly from
+`Polynomial.flt_catalan` (specialisation to coefficients `u = 1, v = 1, w = -1`).
+-/
+theorem bealConjecture_polynomial_coprime
+    {p q r : ℕ} (hp : 3 ≤ p) (hq : 3 ≤ q) (hr : 3 ≤ r)
+    (chp : (p : k) ≠ 0) (chq : (q : k) ≠ 0) (chr : (r : k) ≠ 0)
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (heq : a ^ p + b ^ q = c ^ r) :
+    a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 := by
+  have hp' : p ≠ 0 := by omega
+  have hq' : q ≠ 0 := by omega
+  have hr' : r ≠ 0 := by omega
+  have hineq : q * r + r * p + p * q ≤ p * q * r := beal_hyperbolicity hp hq hr
+  -- Restate `a^p + b^q = c^r` as `1·a^p + 1·b^q + (-1)·c^r = 0`
+  -- to match the `flt_catalan` signature.
+  have heq' : C (1 : k) * a ^ p + C (1 : k) * b ^ q + C (-1 : k) * c ^ r = 0 := by
+    simp only [map_one, one_mul, map_neg, neg_mul]
+    linear_combination heq
+  exact Polynomial.flt_catalan hp' hq' hr' hineq chp chq chr ha hb hc hab
+    one_ne_zero one_ne_zero (neg_ne_zero.mpr one_ne_zero) heq'

--- a/Mathlib/NumberTheory/FLT/BealAbcBridge.lean
+++ b/Mathlib/NumberTheory/FLT/BealAbcBridge.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 Carles Marín. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Carles Marín
+-/
+module
+
+public import Mathlib.RingTheory.Radical.NatInt
+public import Mathlib.Analysis.SpecialFunctions.Log.Basic
+public import Mathlib.NumberTheory.FLT.Beal
+
+/-!
+# Bridge: integer Beal counterexample implies high abc-quality
+
+If a primitive integer Beal solution `a^p + b^q = c^r` with `p, q, r ≥ 3`
+existed, the associated abc-triple `(a^p, b^q, c^r)` would have quality
+
+  q = log(c^r) / log(radical(a^p · b^q · c^r)) ≥ pqr / (qr + rp + pq).
+
+By Beal hyperbolicity (`qr + rp + pq ≤ pqr`, see `Beal.beal_hyperbolicity`),
+this is ≥ 1, putting any Beal solution at the boundary of the abc conjecture.
+
+Together with the abc conjecture (in any explicit form), this would either
+exclude Beal counterexamples or bound them.
+
+## Main definitions
+
+* `abcQuality A B C` : log-ratio quantity associated to a triple of natural numbers.
+
+## Main result (drafted, partial proof)
+
+* `beal_solution_implies_abcQuality_bound` : the explicit lower bound on quality
+  for a primitive Beal solution.
+
+## Status
+
+`[NUM-EVIDENCE]` This file is a **draft**. The central theorem statement is correct
+(verified by hand) but the Lean proof uses `sorry` for the algebraic-inequality
+steps that need detailed `nlinarith` / monotonicity machinery. To be filled in
+in a follow-up pass.
+
+The MATHEMATICAL bridge — that a Beal counterexample saturates abc — is established;
+the FORMAL Lean proof is partial.
+-/
+
+@[expose] public section
+
+open UniqueFactorizationMonoid Real
+
+namespace Beal
+
+/-- The abc-quality of a triple `(A, B, C)` of positive naturals.
+
+For an abc-triple (one where `A + B = C` and `gcd(A,B,C) = 1`), the abc
+conjecture (Masser-Oesterlé) asserts that for every `ε > 0`, only finitely
+many such triples satisfy `abcQuality A B C > 1 + ε`.
+
+The radical and max are computed at the `ℕ` level, then cast to `ℝ` for the log. -/
+noncomputable def abcQuality (A B C : ℕ) : ℝ :=
+  Real.log ((max A (max B C) : ℕ) : ℝ) / Real.log ((radical (A * B * C) : ℕ) : ℝ)
+
+/-- Helper: under the Beal hypotheses, the prime-power factors are pairwise
+coprime, so the radical of their product factors as a product. -/
+lemma radical_beal_triple_eq
+    {a b c p q r : ℕ}
+    (hp : p ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
+    (h_pair_ab : Nat.Coprime a b)
+    (h_pair_bc : Nat.Coprime b c)
+    (h_pair_ca : Nat.Coprime c a) :
+    radical (a^p * b^q * c^r) = radical a * radical b * radical c := by
+  -- Coprimality lifts to powers
+  have hab_pow : Nat.Coprime (a ^ p) (b ^ q) := (h_pair_ab.pow_left p).pow_right q
+  have hbc_pow : Nat.Coprime (b ^ q) (c ^ r) := (h_pair_bc.pow_left q).pow_right r
+  have hca_pow : Nat.Coprime (c ^ r) (a ^ p) := (h_pair_ca.pow_left r).pow_right p
+  -- The product a^p * b^q is coprime to c^r
+  have h_apbq_cr : Nat.Coprime (a ^ p * b ^ q) (c ^ r) :=
+    Nat.Coprime.mul_left hca_pow.symm hbc_pow
+  -- Translate to IsRelPrime over ℕ for radical_mul (works on UFDs)
+  have hab_rel : IsRelPrime (a ^ p) (b ^ q) := Nat.coprime_iff_isRelPrime.mp hab_pow
+  have h_abc_rel : IsRelPrime (a ^ p * b ^ q) (c ^ r) :=
+    Nat.coprime_iff_isRelPrime.mp h_apbq_cr
+  -- Compute the radical
+  rw [radical_mul h_abc_rel, radical_mul hab_rel,
+      radical_pow a hp, radical_pow b hq, radical_pow c hr]
+
+/-- A primitive integer Beal solution gives an abc-triple of explicit quality
+bound. Specifically, if `a^p + b^q = c^r` with all `p, q, r ≥ 3`, pairwise coprime
+bases, and `a, b, c ≥ 2`, then the abc-quality of `(a^p, b^q, c^r)` is bounded
+below by `pqr / (qr + rp + pq)`.
+
+In the Beal-hyperbolicity regime (which holds when `p, q, r ≥ 3`, see
+`Beal.beal_hyperbolicity`: `qr + rp + pq ≤ pqr`), the right-hand side is `≥ 1`,
+which puts the triple at the abc-conjecture saturation boundary. -/
+theorem beal_solution_implies_abcQuality_bound
+    {a b c p q r : ℕ}
+    (hp : 3 ≤ p) (hq : 3 ≤ q) (hr : 3 ≤ r)
+    (ha : 2 ≤ a) (hb : 2 ≤ b) (hc : 2 ≤ c)
+    (h_pair_ab : Nat.Coprime a b)
+    (h_pair_bc : Nat.Coprime b c)
+    (h_pair_ca : Nat.Coprime c a)
+    (heq : a ^ p + b ^ q = c ^ r) :
+    abcQuality (a^p) (b^q) (c^r) ≥
+      (p * q * r : ℝ) / ((q * r + r * p + p * q) : ℝ) := by
+  -- Positivity basics
+  have hp_pos : 0 < p := by omega
+  have hq_pos : 0 < q := by omega
+  have hr_pos : 0 < r := by omega
+  have hp_ne : p ≠ 0 := hp_pos.ne'
+  have hq_ne : q ≠ 0 := hq_pos.ne'
+  have hr_ne : r ≠ 0 := hr_pos.ne'
+  have ha_pos : 0 < a := by omega
+  have hb_pos : 0 < b := by omega
+  have hc_pos : 0 < c := by omega
+  -- Step 1: max(a^p, b^q, c^r) = c^r (in ℕ)
+  have h_ap_le : a ^ p ≤ c ^ r := by rw [← heq]; exact Nat.le_add_right _ _
+  have h_bq_le : b ^ q ≤ c ^ r := by rw [← heq]; exact Nat.le_add_left _ _
+  have h_max : max (a^p) (max (b^q) (c^r)) = c^r := by
+    rw [max_eq_right h_bq_le, max_eq_right h_ap_le]
+  -- Step 2: radical factorisation
+  have h_rad_eq : radical (a^p * b^q * c^r) = radical a * radical b * radical c :=
+    radical_beal_triple_eq hp_ne hq_ne hr_ne h_pair_ab h_pair_bc h_pair_ca
+  -- Step 3: arithmetic chain (a*b*c)^(pqr) ≤ (c^r)^(qr+rp+pq) in ℕ
+  have h_ab_pq : (a * b) ^ (p * q) ≤ c ^ (r * (p + q)) := by
+    have h_a_pq : a ^ (p * q) ≤ c ^ (r * q) := by
+      calc a ^ (p * q) = (a ^ p) ^ q := by ring
+        _ ≤ (c ^ r) ^ q := Nat.pow_le_pow_left h_ap_le q
+        _ = c ^ (r * q) := by ring
+    have h_b_pq : b ^ (p * q) ≤ c ^ (r * p) := by
+      calc b ^ (p * q) = (b ^ q) ^ p := by ring
+        _ ≤ (c ^ r) ^ p := Nat.pow_le_pow_left h_bq_le p
+        _ = c ^ (r * p) := by ring
+    calc (a * b) ^ (p * q) = a ^ (p * q) * b ^ (p * q) := by rw [Nat.mul_pow]
+      _ ≤ c ^ (r * q) * c ^ (r * p) := Nat.mul_le_mul h_a_pq h_b_pq
+      _ = c ^ (r * q + r * p) := by rw [← Nat.pow_add]
+      _ = c ^ (r * (p + q)) := by ring_nf
+  have h_abc_chain : (a * b * c) ^ (p * q * r) ≤ (c ^ r) ^ (q * r + r * p + p * q) := by
+    have h_step : ((a * b) ^ (p * q)) ^ r ≤ (c ^ (r * (p + q))) ^ r :=
+      Nat.pow_le_pow_left h_ab_pq r
+    calc (a * b * c) ^ (p * q * r)
+        = ((a * b) ^ (p * q)) ^ r * c ^ (p * q * r) := by
+          rw [Nat.mul_pow, ← Nat.pow_mul]
+      _ ≤ (c ^ (r * (p + q))) ^ r * c ^ (p * q * r) :=
+          Nat.mul_le_mul_right _ h_step
+      _ = c ^ ((r * (p + q)) * r) * c ^ (p * q * r) := by rw [← Nat.pow_mul]
+      _ = c ^ ((r * (p + q)) * r + p * q * r) := by rw [← Nat.pow_add]
+      _ = c ^ (r * (q * r + r * p + p * q)) := by ring_nf
+      _ = (c ^ r) ^ (q * r + r * p + p * q) := by rw [Nat.pow_mul]
+  -- Step 4: radical ≤ identity, transferring the chain
+  have h_rad_le_abc : radical a * radical b * radical c ≤ a * b * c := by
+    have h1 : radical a ≤ a := Nat.le_of_dvd ha_pos radical_dvd_self
+    have h2 : radical b ≤ b := Nat.le_of_dvd hb_pos radical_dvd_self
+    have h3 : radical c ≤ c := Nat.le_of_dvd hc_pos radical_dvd_self
+    exact Nat.mul_le_mul (Nat.mul_le_mul h1 h2) h3
+  have h_rad_pow_le : (radical a * radical b * radical c) ^ (p * q * r) ≤
+      (c ^ r) ^ (q * r + r * p + p * q) :=
+    le_trans (Nat.pow_le_pow_left h_rad_le_abc _) h_abc_chain
+  -- Step 5: positivity for the log step
+  have h_rad_a_ge : 2 ≤ radical a := Nat.two_le_radical_iff.mpr ha
+  have h_rad_b_ge : 2 ≤ radical b := Nat.two_le_radical_iff.mpr hb
+  have h_rad_c_ge : 2 ≤ radical c := Nat.two_le_radical_iff.mpr hc
+  have h_rad_prod_ge : 2 ≤ radical a * radical b * radical c := by
+    have := Nat.mul_le_mul (Nat.mul_le_mul h_rad_a_ge h_rad_b_ge) h_rad_c_ge
+    linarith
+  have h_rad_prod_pos_R : (0 : ℝ) < ((radical a * radical b * radical c : ℕ) : ℝ) := by
+    have : (0 : ℕ) < radical a * radical b * radical c := by linarith
+    exact_mod_cast this
+  have h_rad_prod_one_lt_R :
+      (1 : ℝ) < ((radical a * radical b * radical c : ℕ) : ℝ) := by
+    have : (1 : ℕ) < radical a * radical b * radical c := by linarith
+    exact_mod_cast this
+  have h_log_rad_pos : 0 < Real.log ((radical a * radical b * radical c : ℕ) : ℝ) :=
+    Real.log_pos h_rad_prod_one_lt_R
+  -- Step 6: cast the ℕ inequality to ℝ, take log
+  have h_cast : ((radical a * radical b * radical c : ℕ) : ℝ) ^ (p * q * r) ≤
+      ((c ^ r : ℕ) : ℝ) ^ (q * r + r * p + p * q) := by
+    exact_mod_cast h_rad_pow_le
+  have h_lhs_pos : (0 : ℝ) <
+      ((radical a * radical b * radical c : ℕ) : ℝ) ^ (p * q * r) :=
+    pow_pos h_rad_prod_pos_R _
+  have h_log_le : Real.log (((radical a * radical b * radical c : ℕ) : ℝ) ^ (p * q * r)) ≤
+      Real.log (((c ^ r : ℕ) : ℝ) ^ (q * r + r * p + p * q)) :=
+    Real.log_le_log h_lhs_pos h_cast
+  rw [Real.log_pow, Real.log_pow] at h_log_le
+  -- Step 7: positivity for the denominator on the RHS, in Real form
+  have h_sum_pos : (0 : ℝ) < (q : ℝ) * r + r * p + p * q := by
+    have h_q_pos_R : (0 : ℝ) < q := by exact_mod_cast hq_pos
+    have h_r_pos_R : (0 : ℝ) < r := by exact_mod_cast hr_pos
+    have h_p_pos_R : (0 : ℝ) < p := by exact_mod_cast hp_pos
+    positivity
+  -- Step 8: unfold abcQuality, simplify casts, divide
+  unfold abcQuality
+  rw [h_max, h_rad_eq]
+  push_cast
+  push_cast at h_log_le h_log_rad_pos
+  rw [ge_iff_le, div_le_div_iff₀ h_sum_pos h_log_rad_pos]
+  linarith [h_log_le]
+
+/-- The looser corollary: Beal solutions have abc-quality `≥ 1`. -/
+theorem beal_solution_implies_abcQuality_geq_one
+    {a b c p q r : ℕ}
+    (hp : 3 ≤ p) (hq : 3 ≤ q) (hr : 3 ≤ r)
+    (ha : 2 ≤ a) (hb : 2 ≤ b) (hc : 2 ≤ c)
+    (h_pair_ab : Nat.Coprime a b)
+    (h_pair_bc : Nat.Coprime b c)
+    (h_pair_ca : Nat.Coprime c a)
+    (heq : a ^ p + b ^ q = c ^ r) :
+    abcQuality (a^p) (b^q) (c^r) ≥ 1 := by
+  -- Reduce to the explicit bound + Beal hyperbolicity inequality.
+  -- The chain is: abcQuality ≥ pqr/(qr+rp+pq) ≥ 1, the second by hyperbolicity.
+  have h_bound := beal_solution_implies_abcQuality_bound hp hq hr ha hb hc
+    h_pair_ab h_pair_bc h_pair_ca heq
+  have h_hyp : q * r + r * p + p * q ≤ p * q * r := beal_hyperbolicity hp hq hr
+  have h_pos : (0 : ℝ) < (q * r + r * p + p * q) := by
+    have h_p_pos : 0 < p := by omega
+    have h_q_pos : 0 < q := by omega
+    have h_r_pos : 0 < r := by omega
+    have : 0 < q * r + r * p + p * q := by positivity
+    exact_mod_cast this
+  have h_ratio_ge_one : (1 : ℝ) ≤ (p * q * r : ℝ) / (q * r + r * p + p * q) := by
+    rw [le_div_iff₀ h_pos]
+    rw [one_mul]
+    exact_mod_cast h_hyp
+  linarith [h_bound, h_ratio_ge_one]
+
+-- Note (no theorem): the strong abc conjecture, applied to the bound above,
+-- would imply Beal asymptotically (counterexamples bounded; for sufficiently
+-- large exponents, excluded). abc is conjectural so this is not a theorem
+-- we state in Lean; the implication is mathematical folklore.
+
+end Beal

--- a/Mathlib/NumberTheory/FLT/BealEichlerShimura.lean
+++ b/Mathlib/NumberTheory/FLT/BealEichlerShimura.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 Carles Marín. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Carles Marín
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.LFunction
+public import Mathlib.NumberTheory.FLT.Beal
+
+/-!
+# Modularity statement and Frobenius trace extraction for elliptic curves
+
+This file:
+
+1. Defines the **Frobenius trace** `aₚ` of a Weierstrass curve over `ℚ`,
+   extracted from `WeierstrassCurve.LFunction`. The L-function is built in
+   mathlib via an Euler product of local factors `1 − aₚT + pT²` at good
+   primes; the Dirichlet coefficient at a prime `p` is therefore `aₚ`.
+
+2. States the **Modularity bridge** as a Prop in a form that reflects the
+   mathematical structure (level + coefficient-matching at all `n`), while
+   honestly noting that the typed newform constraint awaits the FLT
+   Project's modular forms ↔ elliptic curves bridge.
+
+## Background
+
+For an elliptic curve `E / ℚ` with conductor `N`, the Modularity Theorem
+(Wiles 1995 / Breuil-Conrad-Diamond-Taylor 2001) states:
+
+> There exists a weight-2 newform `f` for `Γ₀(N)` such that for every
+> natural number `n ≥ 1`, the Dirichlet coefficient `aₙ(L(E))` of the
+> elliptic-curve L-function equals the `n`-th Fourier coefficient `aₙ(f)`.
+
+The pointwise equality `aₚ(E) = aₚ(f)` at primes of good reduction is
+**Eichler-Shimura**.
+
+## What we can state in current mathlib4
+
+- ✅ `aₚ`-extraction via `LFunction`: definable cleanly using mathlib's
+  existing `WeierstrassCurve.LFunction` (defined via Euler product).
+- ✅ Modularity at L-function coefficient level: stable as the existence
+  of a coefficient sequence agreeing with `ap` everywhere.
+- ❌ The TYPED constraint that the coefficient sequence comes from a
+  weight-2 newform of level `N` requires mathlib's modular form ↔ EC
+  bridge, which is in progress (Buzzard FLT Project, Imperial, EPSRC
+  EP/Y022904/1, through 2029).
+
+## Main definitions
+
+* `Beal.ap` — Frobenius trace at `n` (especially at primes), via `LFunction`.
+* `Beal.IsModular` — Prop asserting existence of a coefficient bridge.
+* `Beal.ModularityConjecture` — universal modularity over elliptic curves
+  on `ℚ`.
+
+## Notes
+
+`[CONJECTURED]` The strengthening from the previous placeholder version is
+**structural**, not logical. The `IsModular` Prop is still inhabited by a
+trivial witness (taking the modular coefficients to equal `ap` itself).
+The strengthening makes the **shape** of the Prop match the form the FLT
+Project will instantiate. -/
+
+@[expose] public section
+
+namespace Beal
+
+open WeierstrassCurve ArithmeticFunction
+
+/-! ### Frobenius trace extraction -/
+
+/-- The `aₙ` coefficient of a Weierstrass curve over `ℚ`, defined via the
+L-function (which mathlib constructs from local Euler factors).
+
+For a prime `p` of good reduction, `ap W p = p + 1 − #W(𝔽_p)`. This is the
+Frobenius trace. -/
+noncomputable def ap (W : WeierstrassCurve ℚ) (n : ℕ) : ℤ :=
+  W.LFunction n
+
+/-- The Frobenius trace at a prime is the L-function value at that prime,
+by definition. -/
+lemma ap_eq_LFunction (W : WeierstrassCurve ℚ) (n : ℕ) :
+    ap W n = W.LFunction n := rfl
+
+/-! ### Modularity statement -/
+
+/-- An elliptic curve `W / ℚ` is **modular** if there exists a positive
+integer level `N` and an integer-valued coefficient sequence `(c n)` such
+that `c n = aₙ(W)` for every `n`.
+
+The full Modularity Theorem additionally requires `(c n)` to come from a
+weight-2 newform for `Γ₀(N)`. That constraint requires the typed modular
+forms ↔ elliptic curves bridge — `[CONJECTURED]` in mathlib4 as of 2026,
+to be furnished by the FLT Project.
+
+This Prop is **structurally** the correct statement; logically it is still
+trivially inhabited (take `c = ap W`). -/
+def IsModular (W : WeierstrassCurve ℚ) : Prop :=
+  ∃ (N : ℕ), 0 < N ∧ ∃ (c : ℕ → ℤ), ∀ n : ℕ, ap W n = c n
+
+/-- Trivial inhabitation: every elliptic curve satisfies this placeholder
+predicate because we can always take the level to be 1 and the coefficient
+sequence to equal `ap W` itself.
+
+`[NUM-EVIDENCE]` This proof is **not** a real proof of modularity. It
+inhabits the placeholder because the placeholder is degenerate. The real
+modularity proof requires the FLT Project's typed bridge to constrain the
+coefficient sequence to come from a newform. -/
+theorem IsModular.trivial (W : WeierstrassCurve ℚ) : IsModular W := by
+  refine ⟨1, Nat.one_pos, ap W, ?_⟩
+  intro n
+  rfl
+
+/-- The **Modularity Conjecture** (now Theorem of Wiles-BCDT, 2001) as a
+universal statement over elliptic curves on `ℚ`.
+
+`[CONJECTURED]` as a Lean Prop in mathlib4's current state, pending the
+FLT Project.
+`[PROVEN]` mathematically. -/
+def ModularityConjecture : Prop :=
+  ∀ (W : WeierstrassCurve ℚ), IsModular W
+
+theorem modularityConjecture_trivial : ModularityConjecture :=
+  fun W ↦ IsModular.trivial W
+
+/-! ### Connection to the bundle
+
+When Modularity is properly substantiated (post-FLT-Project), the following
+chain becomes accessible from Pieces 1-3 of this bundle:
+
+1. **Piece 1 → 4:** the `BealConjecture` predicate (Piece 1) restricts to a
+   primitive integer Beal solution that gives a Frey curve (Piece 3) whose
+   `IsModular` invocation produces a weight-2 newform.
+
+2. **Piece 3 + 4:** the Frey curve's conductor is `2·rad(abc)`. Its modular
+   form `f` must therefore live at level `2·rad(abc)`.
+
+3. **Ribet level-lowering (NOT in this bundle):** would force `f` to come
+   from level `2`. But there are no weight-2 newforms of level 2.
+   Contradiction. This is the Wiles attack on FLT, and the same machinery
+   applied to Beal-shape Frey curves drives Dahmen-Siksek-style attacks on
+   specific signatures.
+
+This file thus completes the **statement layer** of the bundle. The deeper
+mathematics — Ribet level-lowering, explicit newform-level case analysis
+— lives in the multi-year Buzzard FLT Project.
+-/
+
+end Beal

--- a/Mathlib/NumberTheory/FLT/BealFreyCurve.lean
+++ b/Mathlib/NumberTheory/FLT/BealFreyCurve.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Carles Marín. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Carles Marín
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass
+public import Mathlib.NumberTheory.FLT.Beal
+
+/-!
+# The Frey-Hellegouarch curve
+
+Given integers `a, b` and an exponent `n ≥ 1`, the **Frey-Hellegouarch curve**
+is the elliptic curve
+
+  `E_{a,b,n} :  y² = x(x - aⁿ)(x + bⁿ)`
+
+expanded into Weierstrass form. It is the key geometric object underlying
+Wiles's proof of Fermat's Last Theorem and the modular method for the
+generalized Fermat / Beal equation.
+
+This file gives the curve as a `WeierstrassCurve ℤ` and computes its
+discriminant, both in its raw polynomial form (depending on `a^n + b^n`)
+and in its simplified form under an FLT-shape relation `a^n + b^n = c^n`.
+
+## Main definitions
+
+* `Beal.freyCurve a b n` — the Frey-Hellegouarch curve as a Weierstrass form.
+
+## Main results
+
+* `Beal.freyCurve_Δ_eq` — explicit formula for the discriminant.
+* `Beal.freyCurve_Δ_of_flt` — under the FLT relation `aⁿ + bⁿ = cⁿ`, the
+  discriminant collapses to `16 · (abc)^{2n}`. This is the formula that
+  drives the entire modular method: the n-th-power structure of the
+  discriminant feeds into level-lowering through Frey-Hellegouarch +
+  Ribet machinery.
+
+## Status
+
+This file is a **definitional/algebraic piece**. It does NOT prove modularity
+or attempt the Wiles-Ribet attack. It provides the cleanly-stated geometric
+object that downstream Lean work (the Buzzard FLT Project, etc.) can consume.
+-/
+
+@[expose] public section
+
+namespace Beal
+
+open WeierstrassCurve
+
+/-- The Frey-Hellegouarch curve associated to `(a, b, n)`.
+
+  In affine Weierstrass form, the equation is
+    `y² = x(x - aⁿ)(x + bⁿ) = x³ + (bⁿ − aⁿ)·x² − (aⁿ·bⁿ)·x`.
+  We encode this as `a₁ = a₃ = a₆ = 0`, `a₂ = bⁿ − aⁿ`, `a₄ = −(aⁿ·bⁿ)`. -/
+def freyCurve (a b : ℤ) (n : ℕ) : WeierstrassCurve ℤ where
+  a₁ := 0
+  a₂ := b ^ n - a ^ n
+  a₃ := 0
+  a₄ := -(a ^ n * b ^ n)
+  a₆ := 0
+
+/-! ### Coefficient accessors (definitional unfoldings) -/
+
+@[simp] lemma freyCurve_a₁ (a b : ℤ) (n : ℕ) : (freyCurve a b n).a₁ = 0 := rfl
+@[simp] lemma freyCurve_a₂ (a b : ℤ) (n : ℕ) :
+    (freyCurve a b n).a₂ = b ^ n - a ^ n := rfl
+@[simp] lemma freyCurve_a₃ (a b : ℤ) (n : ℕ) : (freyCurve a b n).a₃ = 0 := rfl
+@[simp] lemma freyCurve_a₄ (a b : ℤ) (n : ℕ) :
+    (freyCurve a b n).a₄ = -(a ^ n * b ^ n) := rfl
+@[simp] lemma freyCurve_a₆ (a b : ℤ) (n : ℕ) : (freyCurve a b n).a₆ = 0 := rfl
+
+/-! ### Discriminant computation -/
+
+/-- The discriminant of the Frey curve is `16 · (aⁿ · bⁿ · (aⁿ + bⁿ))²`.
+    Under no further assumption on `(a, b, n)`. -/
+theorem freyCurve_Δ_eq (a b : ℤ) (n : ℕ) :
+    (freyCurve a b n).Δ = 16 * (a ^ n * b ^ n * (a ^ n + b ^ n)) ^ 2 := by
+  simp only [WeierstrassCurve.Δ, WeierstrassCurve.b₂, WeierstrassCurve.b₄,
+             WeierstrassCurve.b₆, WeierstrassCurve.b₈,
+             freyCurve_a₁, freyCurve_a₂, freyCurve_a₃, freyCurve_a₄, freyCurve_a₆]
+  ring
+
+/-- Under the FLT-shape relation `aⁿ + bⁿ = cⁿ`, the Frey curve discriminant
+    is exactly `16 · (a · b · c)^(2n)`. This is the formula that makes the
+    Frey curve useful in the modular method: its `n`-th-power discriminant
+    structure forces a level-lowering argument. -/
+theorem freyCurve_Δ_of_flt (a b c : ℤ) (n : ℕ)
+    (heq : a ^ n + b ^ n = c ^ n) :
+    (freyCurve a b n).Δ = 16 * (a * b * c) ^ (2 * n) := by
+  rw [freyCurve_Δ_eq, heq]
+  -- Goal: 16 * (aⁿ · bⁿ · cⁿ)² = 16 * (a·b·c)^(2n)
+  have h_mul_pow : a ^ n * b ^ n * c ^ n = (a * b * c) ^ n := by
+    rw [mul_pow, mul_pow]
+  rw [h_mul_pow]
+  -- Goal: 16 * ((a·b·c)ⁿ)² = 16 * (a·b·c)^(2n)
+  rw [← pow_mul]
+  -- Goal: 16 * (a·b·c)^(n*2) = 16 * (a·b·c)^(2n)
+  ring_nf
+
+end Beal


### PR DESCRIPTION
Adds
  four files to Mathlib/NumberTheory/FLT/ forming a starter bundle for the Beal conjecture and
   its surrounding modular machinery: Beal.lean (BealConjectureWith/For predicates +
  polynomial coprime case via specialisation of Polynomial.flt_catalan), BealAbcBridge.lean
  (abcQuality definition + theorem that a primitive Beal solution gives quality >= 1),
  BealFreyCurve.lean (Frey-Hellegouarch curve as WeierstrassCurve + discriminant under the FLT
   relation), and BealEichlerShimura.lean (ap extraction from WeierstrassCurve.LFunction +
  IsModular placeholder pending typed newform bridge from the FLT Project).


---

AI was used heavily for this project: this is described below, and should be added to this description before any motion to merge it.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

  ## Summary

  Adds four files to `Mathlib/NumberTheory/FLT/` forming a starter bundle for the Beal
  conjecture and its surrounding modular machinery.

  ### What's added

  - **`Beal.lean`** — `BealConjectureWith`, `BealConjectureFor`, `BealConjecture` predicates
  analogous to `FermatLastTheoremWith` / `FermatLastTheoremFor` / `FermatLastTheorem`, for the
   asymmetric-exponent equation `a^p + b^q = c^r`. Plus `bealConjecture_polynomial_coprime`:
  the polynomial coprime case proven by specialising `Polynomial.flt_catalan` (Baek-Lee) with
  coefficients `(1, 1, -1)`.

  - **`BealAbcBridge.lean`** — `abcQuality` definition (log-ratio quality of a triple) and the
   theorem `beal_solution_implies_abcQuality_geq_one`: a primitive integer Beal solution with
  all exponents ≥ 3 gives an abc-triple of quality ≥ 1, saturating the abc conjecture. Uses
  `beal_hyperbolicity` from `Beal.lean`.

  - **`BealFreyCurve.lean`** — the Frey-Hellegouarch curve `y² = x(x − aⁿ)(x + bⁿ)` as a
  `WeierstrassCurve ℤ` definition, with the explicit discriminant formula `Δ = 16 · (aⁿ · bⁿ ·
   (aⁿ + bⁿ))²` and its simplification to `16 · (a·b·c)^(2n)` under the FLT relation `aⁿ + bⁿ
  = cⁿ`.

  - **`BealEichlerShimura.lean`** — `ap` extraction from `WeierstrassCurve.LFunction` and
  `IsModular` Prop capturing the structural form of the Modularity Theorem. **Placeholder**:
  structurally correct but logically trivially inhabited, pending the typed newform bridge
  from the Buzzard FLT Project.

  ### What's NOT in this PR

  - Modularity Theorem (Wiles-BCDT) proper. Out of scope; pending FLT Project.
  - Ribet level-lowering. Out of scope.
  - Conductor formula (Ogg-Saito) for elliptic curves. Out of scope.
  - Integer Beal conjecture proof (the $1M open problem).
  - Polynomial Beal beyond the coprime case (gcd factorisation does not yield a clean equation
   when exponents differ).

  ### Test plan

  - [x] All four files build cleanly against current master.
  - [x] 0 sorry, 0 warnings.
  - [x] No new external imports beyond existing mathlib modules.
  - [x] `IsModular` placeholder documented as such inline.