### PR TITLE
[Merged by Bors] - chore: centralise fun_prop tests

### DIFF
--- a/MathlibTest/fun_prop.lean
+++ b/MathlibTest/fun_prop.lean
@@ -11,9 +11,9 @@ import Mathlib.Topology.Constructions
 
 import Mathlib.Tactic.FunProp
 
+/-! # A file with fun_prop tests... sth sth sth! -/
 
 open Mathlib
-
 
 /-!
 The first step in using `fun_prop` is to mark desired function property with `fun_prop` attribute.
@@ -220,17 +220,3 @@ If possible, `fun_prop` theorem about `DFunLike.coe` should be state in this way
 
 That should be all about `fun_prop`, I hope you will enjoy using it :)
 -/
-
-
-
-/-! Test that `fun_prop` should work on `→` and `∀` -/
-
-attribute [fun_prop] Measurable.imp Measurable.forall
-
-example {α : Type*} [MeasurableSpace α] {p q : α → Prop} (hp : Measurable p) (hq : Measurable q) :
-    Measurable fun x => p x → q x := by
-  fun_prop
-
-example {α ι : Type*} [MeasurableSpace α] [Countable ι] {p : ι → α → Prop}
-    (hp : ∀ i, Measurable (p i)) : Measurable fun x => ∀ i, p i x := by
-  fun_prop

--- a/MathlibTest/fun_prop.lean
+++ b/MathlibTest/fun_prop.lean
@@ -11,7 +11,11 @@ import Mathlib.Topology.Constructions
 
 import Mathlib.Tactic.FunProp
 
-/-! # A file with fun_prop tests... sth sth sth! -/
+/-! # Literate documentation for `fun_prop`
+
+This file serves as a user's guide for `fun_prop` written in automatically checked Lean.
+For adding more test cases that are not part of documentation, please use `MathlibTest/fun_prop2.lean`.
+-/
 
 open Mathlib
 

--- a/MathlibTest/fun_prop2.lean
+++ b/MathlibTest/fun_prop2.lean
@@ -108,3 +108,15 @@ example {α : Type*} {m₀ : MeasurableSpace α} {μ : MeasureTheory.Measure α}
     (hl : ∀ f ∈ l, MeasureTheory.AEStronglyMeasurable f μ) :
     MeasureTheory.AEStronglyMeasurable l.prod μ := by
   fun_prop (disch := assumption)
+
+/-! Test that `fun_prop` should work on `→` and `∀` -/
+
+attribute [fun_prop] Measurable.imp Measurable.forall
+
+example {α : Type*} [MeasurableSpace α] {p q : α → Prop} (hp : Measurable p) (hq : Measurable q) :
+    Measurable fun x => p x → q x := by
+  fun_prop
+
+example {α ι : Type*} [MeasurableSpace α] [Countable ι] {p : ι → α → Prop}
+    (hp : ∀ i, Measurable (p i)) : Measurable fun x => ∀ i, p i x := by
+  fun_prop

--- a/MathlibTest/fun_prop2.lean
+++ b/MathlibTest/fun_prop2.lean
@@ -7,6 +7,12 @@ import Mathlib.Analysis.Complex.Trigonometric
 import Mathlib.Analysis.Meromorphic.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
 
+/-! # Main test file for fun_prop
+
+Use this file for `fun_prop` tests that depend on mathlib
+`fun_prop_dev` is for unit and synthetic tests avoiding mathlib.
+-/
+
 noncomputable
 def foo (x : ℝ) := x * (Real.log x) ^ 2 - Real.exp x / x
 


### PR DESCRIPTION
The `fun_prop.lean` test file is rather meant to be literate documentation of fun_prop.
One last addition to the file should moved to the main test file instead.
While at it, document the main test file as being that.

Developed at the ICERM workshop, in-person approved by `lecopivo`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
