### PR TITLE
feat(Tactic/FunProp): allow discharging non-prop hypotheses

### DIFF
--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -71,17 +71,19 @@ def synthesizeArgs (thmId : Origin) (xs : Array Expr)
       else
         -- try user provided discharger
         let ctx : Context ← read
-        if (← isProp type) then
-          if let some proof ← ctx.disch type then
-            if (← isDefEq x proof) then
-              continue
-            else do
-              trace[Meta.Tactic.fun_prop]
-                "{← ppOrigin thmId}, failed to assign proof{indentExpr type}"
-              return false
-          else
-            logError s!"Failed to prove necessary assumption `{← ppExpr type}` \
-                        when applying theorem `{← ppOrigin' thmId}`."
+        -- we allow the discharger to both infer propositions (e.g., function properties)
+        -- and data arguments (e.g., models with corners for use with `ContMDiff` in the manifold
+        -- library)
+        if let some proof ← ctx.disch type then
+          if (← isDefEq x proof) then
+            continue
+          else do
+            trace[Meta.Tactic.fun_prop]
+              "{← ppOrigin thmId}, failed to assign proof{indentExpr type}"
+            return false
+        else
+          logError s!"Failed to prove necessary assumption `{← ppExpr type}` \
+                      when applying theorem `{← ppOrigin' thmId}`."
 
       if ¬(← isProp type) then
         postponed := postponed.push x


### PR DESCRIPTION
As suggested by `lecopivo` [on zulip]([#mathlib4 > Making fun_prop support ContMDiff @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Making.20fun_prop.20support.20ContMDiff/near/555522399))

This will allow inferring a model with corners, which in turn enables properly supporting `ContMDiff` and friends in fun_prop.

---

Needs a test, and then a prototype to demonstrates this works!

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
