### PR TITLE
feat(SimpleGraph): add no-bridge theorem for even degree graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -6,6 +6,7 @@ Authors: Youheng Luo
 module
 
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 public import Mathlib.Data.Set.Card
 
 /-!
@@ -22,6 +23,8 @@ This file defines k-edge-connectivity for simple graphs.
 -/
 
 @[expose] public section
+
+open Finset
 
 namespace SimpleGraph
 
@@ -135,6 +138,125 @@ lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
     by_cases hx : s(u, v) = x
     · exact hx ▸ hr
     exact deleteEdges_adj.mpr ⟨hadj, hx⟩ |>.reachable
+
+/-- A finite graph in which every vertex has even degree has no bridge. -/
+theorem not_isBridge_of_even_degree [Fintype V] [DecidableRel G.Adj]
+    (hG : ∀ v, Even (G.degree v)) {e : Sym2 V} : ¬ G.IsBridge e := by
+  classical
+  cases e with
+  | h u v =>
+    rw [isBridge_iff]
+    rintro ⟨huv, hb⟩
+    let H := G.deleteEdges {s(u, v)}
+    let C : H.ConnectedComponent := H.connectedComponentMk u
+    have huC : u ∈ C := by rfl
+    have hvC : v ∉ C := by
+      intro hv
+      exact hb <| C.reachable_of_mem_supp huC hv
+    let uC : C := ⟨u, huC⟩
+    have degree_toSimpleGraph (D : H.ConnectedComponent) (x : D) :
+        D.toSimpleGraph.degree x = H.degree (x : V) := by
+      rw [← card_neighborSet_eq_degree, ← card_neighborSet_eq_degree]
+      exact Fintype.card_congr
+        { toFun := fun y ↦ ⟨(y : D), y.prop⟩
+          invFun := fun y ↦ ⟨⟨y, (D.mem_supp_congr_adj y.prop).mp x.prop⟩, y.prop⟩
+          left_inv := by
+            intro y
+            ext
+            rfl
+          right_inv := by
+            intro y
+            ext
+            rfl }
+    have hH_degree_u : H.degree u = G.degree u - 1 := by
+      rw [← card_neighborSet_eq_degree]
+      calc
+        Fintype.card (H.neighborSet u) = Fintype.card {w // G.Adj u w ∧ w ≠ v} := by
+          exact Fintype.card_congr
+            { toFun := fun w ↦
+                ⟨w, by
+                  have hwH : H.Adj u (w : V) := w.prop
+                  have hw : G.Adj u w ∧ s(u, (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) := by
+                    simpa [H] using hwH
+                  refine ⟨hw.1, ?_⟩
+                  intro hwv
+                  exact hw.2 (by simp [hwv])⟩
+              invFun := fun w ↦
+                ⟨w, by
+                  have hnot : s(u, (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) := by
+                    rw [Set.mem_singleton_iff, Sym2.eq_iff]
+                    rintro (h | h)
+                    · exact w.2.2 h.2
+                    · exact huv.ne h.1
+                  change H.Adj u (w : V)
+                  simpa [H] using
+                    (show G.Adj u (w : V) ∧
+                        s(u, (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) from ⟨w.2.1, hnot⟩)
+                ⟩
+              left_inv := by
+                intro w
+                ext
+                rfl
+              right_inv := by
+                intro w
+                ext
+                rfl }
+        _ = #(G.neighborFinset u \ {v}) := by
+          rw [Fintype.card_of_subtype (G.neighborFinset u \ {v})]
+          intro w
+          simp
+        _ = G.degree u - 1 := by
+          rw [card_sdiff_of_subset]
+          · simp
+          · simp [huv]
+    have hdegree_u : C.toSimpleGraph.degree uC = G.degree u - 1 := by
+      rw [degree_toSimpleGraph C uC, hH_degree_u]
+    have hodd_u : Odd (C.toSimpleGraph.degree uC) := by
+      rw [hdegree_u]
+      exact Nat.Even.sub_odd (by simpa using huv.degree_pos_left) (hG u) odd_one
+    have hdegree_ne (x : C) (hx : x ≠ uC) : C.toSimpleGraph.degree x = G.degree (x : V) := by
+      rw [degree_toSimpleGraph C x]
+      rw [← card_neighborSet_eq_degree, ← card_neighborSet_eq_degree]
+      exact Fintype.card_congr
+        { toFun := fun w ↦
+            ⟨w, by
+              have hwH : H.Adj (x : V) (w : V) := w.prop
+              have hw : G.Adj (x : V) w ∧
+                  s((x : V), (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) := by
+                simpa [H] using hwH
+              exact hw.1⟩
+          invFun := fun w ↦
+            ⟨w, by
+              have hx_ne_u : (x : V) ≠ u := by
+                intro hxu
+                exact hx <| Subtype.ext hxu
+              have hx_ne_v : (x : V) ≠ v := by
+                intro hxv
+                exact hvC (hxv ▸ x.prop)
+              have hnot : s((x : V), (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) := by
+                rw [Set.mem_singleton_iff, Sym2.eq_iff]
+                rintro (h | h)
+                · exact hx_ne_u h.1
+                · exact hx_ne_v h.1
+              change H.Adj (x : V) (w : V)
+              simpa [H] using
+                (show G.Adj (x : V) (w : V) ∧
+                    s((x : V), (w : V)) ∉ ({s(u, v)} : Set (Sym2 V)) from ⟨w.2, hnot⟩)
+            ⟩
+          left_inv := by
+            intro w
+            ext
+            rfl
+          right_inv := by
+            intro w
+            ext
+            rfl }
+    rcases C.toSimpleGraph.exists_ne_odd_degree_of_exists_odd_degree uC hodd_u with
+      ⟨x, hx_ne, hx_odd⟩
+    have hx_even : Even (C.toSimpleGraph.degree x) := by
+      rw [hdegree_ne x hx_ne]
+      exact hG x
+    exact (Nat.not_even_iff_odd.mpr hx_odd) hx_even
 
 lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e}).Reachable u v := by
   simp [isEdgeReachable_add_one]

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -169,4 +169,25 @@ theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Ad
   rw [mem_filter_univ] at hw
   exact ⟨w, hw⟩
 
+/-- The number of vertices of odd degree is not equal to one. -/
+theorem card_odd_degree_vertices_ne_one [Fintype V] [DecidableRel G.Adj] :
+    #{v | Odd (G.degree v)} ≠ 1 := by
+  intro h
+  exact Nat.not_even_one (h ▸ G.even_card_odd_degree_vertices)
+
+/-- There is no unique vertex of odd degree. -/
+theorem not_existsUnique_odd_degree [Fintype V] [DecidableRel G.Adj] :
+    ¬ ∃! v : V, Odd (G.degree v) := by
+  rintro ⟨v, hv, huniq⟩
+  rcases G.exists_ne_odd_degree_of_exists_odd_degree v hv with ⟨w, hwne, hwodd⟩
+  exact hwne (huniq w hwodd)
+
+/-- If every vertex except `v` has even degree, then `v` also has even degree. -/
+theorem even_degree_of_forall_ne_even_degree [Fintype V] [DecidableRel G.Adj] (v : V)
+    (h : ∀ w, w ≠ v → Even (G.degree w)) : Even (G.degree v) := by
+  by_contra hv
+  rw [Nat.not_even_iff_odd] at hv
+  rcases G.exists_ne_odd_degree_of_exists_odd_degree v hv with ⟨w, hwne, hwodd⟩
+  exact Nat.not_even_iff_odd.mpr hwodd (h w hwne)
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -169,9 +169,4 @@ theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Ad
   rw [mem_filter_univ] at hw
   exact ⟨w, hw⟩
 
-/-- The number of vertices of odd degree is not equal to one. -/
-theorem card_odd_degree_vertices_ne_one [Fintype V] [DecidableRel G.Adj] :
-    #{v | Odd (G.degree v)} ≠ 1 :=
-  (Nat.not_even_one <| · ▸ G.even_card_odd_degree_vertices)
-
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -171,8 +171,7 @@ theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Ad
 
 /-- The number of vertices of odd degree is not equal to one. -/
 theorem card_odd_degree_vertices_ne_one [Fintype V] [DecidableRel G.Adj] :
-    #{v | Odd (G.degree v)} ≠ 1 := by
-  intro h
-  exact Nat.not_even_one (h ▸ G.even_card_odd_degree_vertices)
+    #{v | Odd (G.degree v)} ≠ 1 :=
+  (Nat.not_even_one <| · ▸ G.even_card_odd_degree_vertices)
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -175,19 +175,4 @@ theorem card_odd_degree_vertices_ne_one [Fintype V] [DecidableRel G.Adj] :
   intro h
   exact Nat.not_even_one (h ▸ G.even_card_odd_degree_vertices)
 
-/-- There is no unique vertex of odd degree. -/
-theorem not_existsUnique_odd_degree [Fintype V] [DecidableRel G.Adj] :
-    ¬ ∃! v : V, Odd (G.degree v) := by
-  rintro ⟨v, hv, huniq⟩
-  rcases G.exists_ne_odd_degree_of_exists_odd_degree v hv with ⟨w, hwne, hwodd⟩
-  exact hwne (huniq w hwodd)
-
-/-- If every vertex except `v` has even degree, then `v` also has even degree. -/
-theorem even_degree_of_forall_ne_even_degree [Fintype V] [DecidableRel G.Adj] (v : V)
-    (h : ∀ w, w ≠ v → Even (G.degree w)) : Even (G.degree v) := by
-  by_contra hv
-  rw [Nat.not_even_iff_odd] at hv
-  rcases G.exists_ne_odd_degree_of_exists_odd_degree v hv with ⟨w, hwne, hwodd⟩
-  exact Nat.not_even_iff_odd.mpr hwodd (h w hwne)
-
 end SimpleGraph


### PR DESCRIPTION
This PR proves that a finite graph in which every vertex has even degree has no bridge.

It adds:

* `SimpleGraph.not_isBridge_of_even_degree`

The proof argues by contradiction: if an edge is a bridge, delete it and look at the connected component containing one endpoint. In that component, the endpoint has odd degree, while any other odd-degree vertex would contradict the bridge assumption and the even-degree hypothesis. This contradicts the handshaking lemma via the existing odd-degree API.

Local checks:

```bash
lake build Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
lake exe lint-style Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
lake exe runLinter Mathlib.Combinatorics.SimpleGraph.Connectivity.EdgeConnectivity
```

## AI usage disclosure

I used OpenClaw/Codex while developing this PR. Much of the Lean proof of `not_isBridge_of_even_degree` was drafted with AI assistance, including API search and proof refactoring. I reviewed the generated code, made edits, ran the local checks above, and understand and take responsibility for the final statement and proof.