### PR TITLE
chore(ci): bump lint-style-action pin to 91923b04

### DIFF
--- a/.github/workflows/bot_fix_style.yaml
+++ b/.github/workflows/bot_fix_style.yaml
@@ -27,7 +27,7 @@ jobs:
     # && (startsWith(github.event.comment.body, 'bot fix style') || contains(toJSON(github.event.comment.body), '\nbot fix style'))
     runs-on: ubuntu-latest
     steps:
-      - uses: leanprover-community/lint-style-action@a7e7428fa44f9635d6eb8e01919d16fd498d387a # 2025-08-18
+      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
         with:
           mode: fix
           lint-bib-file: true

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -770,7 +770,7 @@ jobs:
     name: Lint style
     runs-on: ubuntu-latest
     steps:
-      - uses: leanprover-community/lint-style-action@a7e7428fa44f9635d6eb8e01919d16fd498d387a # 2025-08-18
+      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
         with:
           mode: check
           lint-bib-file: true

--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -9,7 +9,7 @@ jobs:
     name: Lint and suggest
     runs-on: ubuntu-latest
     steps:
-      - uses: leanprover-community/lint-style-action@a7e7428fa44f9635d6eb8e01919d16fd498d387a # 2025-08-18
+      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
         with:
           mode: suggest
           lint-bib-file: true


### PR DESCRIPTION
This PR bumps the `leanprover-community/lint-style-action` SHA pin from `a7e7428` (2025-08-18) to `91923b04` (2026-05-12) across the three workflows that consume it: `build_template.yml`, `lint_and_suggest_pr.yml`, and `bot_fix_style.yaml`.

The new pin includes https://github.com/leanprover-community/lint-style-action/pull/5 - feat(install-bibtool): use --no-install-recommends with apt-get, which drops the `apt-get install bibtool` download from ~168 MB to ~16.8 MB on every run of the Lint style job. `bibtool` only declares `texlive-base` as `Recommends:` (not `Depends:`), and the action invokes `bibtool` directly on `references.bib` without going through TeX, so the recommended packages are not needed.

No-op for everything else — same action, same inputs, same behaviour.

🤖 Prepared with Claude Code