### PR TITLE
feat(Analysis/SpecialFunctions/Complex/Log): log of negation on half-planes

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -114,6 +114,20 @@ theorem log_I : log I = π / 2 * I := by simp [log]
 
 theorem log_neg_I : log (-I) = -(π / 2) * I := by simp [log]
 
+/-- If `0 < z.im`, then `log (-z) = log z - π * I`. -/
+theorem log_neg_eq_log_sub_pi_I_of_im_pos {z : ℂ} (hz : 0 < z.im) :
+    log (-z) = log z - π * I := by
+  apply Complex.ext
+  · simp [log_re]
+  · simp [log_im, arg_neg_eq_arg_sub_pi_of_im_pos hz]
+
+/-- If `z.im < 0`, then `log (-z) = log z + π * I`. -/
+theorem log_neg_eq_log_add_pi_I_of_im_neg {z : ℂ} (hz : z.im < 0) :
+    log (-z) = log z + π * I := by
+  apply Complex.ext
+  · simp [log_re]
+  · simp [log_im, arg_neg_eq_arg_add_pi_of_im_neg hz]
+
 theorem log_conj_eq_ite (x : ℂ) : log (conj x) = if x.arg = π then log x else conj (log x) := by
   simp_rw [log, norm_conj, arg_conj, map_add, map_mul, conj_ofReal]
   split_ifs with hx


### PR DESCRIPTION
Adds two companion lemmas giving the closed-form value of `Complex.log (-z)` in terms of `Complex.log z` on each open half-plane:

\`\`\`
theorem log_neg_eq_log_sub_pi_I_of_im_pos {z : ℂ} (hz : 0 < z.im) :
    log (-z) = log z - π * I

theorem log_neg_eq_log_add_pi_I_of_im_neg {z : ℂ} (hz : z.im < 0) :
    log (-z) = log z + π * I
\`\`\`

These are the log-level statements companion to the existing `Complex.arg_neg_eq_arg_sub_pi_of_im_pos` / `Complex.arg_neg_eq_arg_add_pi_of_im_neg` pair. Mathlib has `log_neg_one`, `log_neg_I` (specific values) and the arg-level negation lemmas; the explicit `log(-z)` closed form on each half-plane was missing.

Both proofs follow the same two-step pattern as `arg_neg_eq_arg_sub_pi_of_im_pos`: split on `re` (handled by `log_re` + norm invariance under negation) and `im` (handled by the existing `arg_neg_eq_arg_*_of_im_*` lemmas).