### PR TITLE
feat(Analysis/Complex/UpperHalfPlane/Basic): upper half-plane is infinite

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -269,6 +269,15 @@ lemma isOpen_upperHalfPlaneSet : IsOpen ℍₒ := isOpen_lt continuous_const Com
 theorem range_coe : Set.range UpperHalfPlane.coe = ℍₒ := by
   ext; simp [UpperHalfPlane.exists]
 
+/-- The upper half-plane (as a subset of `ℂ`) is infinite. -/
+theorem upperHalfPlaneSet_infinite : Set.Infinite ℍₒ := by
+  rw [← range_coe]
+  exact Set.infinite_range_of_injective UpperHalfPlane.coe_injective
+
+/-- The image of `ℍ` under the canonical map `ℍ → ℂ` is infinite. -/
+theorem range_coe_infinite : Set.Infinite (Set.range ((↑) : ℍ → ℂ)) :=
+  Set.infinite_range_of_injective UpperHalfPlane.coe_injective
+
 end upperHalfPlaneSet
 
 end UpperHalfPlane


### PR DESCRIPTION
Adds two `Set.Infinite` lemmas for the upper half-plane:

\`\`\`
theorem upperHalfPlaneSet_infinite : Set.Infinite upperHalfPlaneSet
theorem range_coe_infinite : Set.Infinite (Set.range ((↑) : ℍ → ℂ))
\`\`\`

Mathlib already has `instance : Infinite ℍ` (talking about the type `ℍ`) and `range_coe : Set.range UpperHalfPlane.coe = upperHalfPlaneSet`. The two lemmas above are the natural `Set.Infinite` companions for the set / range, convenient when composed with `Polynomial.eq_of_infinite_eval_eq` (e.g. "two polynomials in `ℂ[X]` are equal iff they agree on `ℍ`") and similar analytic-continuation / polynomial-uniqueness arguments.

Both follow directly from `Set.infinite_range_of_injective` and the existing `UpperHalfPlane.coe_injective`.