### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/CharZero): document `scoped simp` design choice

### DIFF
--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -88,10 +88,11 @@ end Semiring
 section NonAssocRing
 variable [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
-@[simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
+-- `scoped` attribute here and below because the `simp` keys are weak (see PR#15631)
+@[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 
-@[simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
+@[scoped simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
   eq_neg_iff_add_eq_zero.trans add_self_eq_zero
 
 theorem nat_mul_inj {n : ℕ} {a b : R} (h : (n : R) * a = (n : R) * b) : n = 0 ∨ a = b := by

--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -88,10 +88,10 @@ end Semiring
 section NonAssocRing
 variable [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
-@[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
+@[simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 
-@[scoped simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
+@[simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
   eq_neg_iff_add_eq_zero.trans add_self_eq_zero
 
 theorem nat_mul_inj {n : ℕ} {a b : R} (h : (n : R) * a = (n : R) * b) : n = 0 ∨ a = b := by

--- a/Mathlib/Algebra/Ring/CharZero.lean
+++ b/Mathlib/Algebra/Ring/CharZero.lean
@@ -88,7 +88,8 @@ end Semiring
 section NonAssocRing
 variable [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
--- `scoped` attribute here and below because the `simp` keys are weak (see PR#15631)
+-- `scoped` attribute here and below because the `simp` keys are weak
+-- (see https://github.com/leanprover-community/mathlib4/pull/15631)
 @[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
