### PR TITLE
[Merged by Bors] - chore: fix spelling typos

### DIFF
--- a/Mathlib/Topology/Algebra/Module/Complement.lean
+++ b/Mathlib/Topology/Algebra/Module/Complement.lean
@@ -13,7 +13,7 @@ public import Mathlib.Topology.Algebra.Module.Equiv
 
 Let `M` be a topological `R`-module. Two submodules `p, q` of `M` are said to be
 *topological complements* (`Submodule.IsTopCompl`) if they are algebraic complements and the
-algebraic isomorphism `M ≃ p × q` is an homeomorphism.
+algebraic isomorphism `M ≃ p × q` is a homeomorphism.
 
 Not all submodules of `M` admit such a topological complements (even if they admit algebraic
 complements). In the literature, such a submodule is called *topologically complemented*
@@ -59,10 +59,10 @@ In general we only include the left version, the right one being accessible thro
 
 There is still a significant part of the algebraic API which should be ported to the
 topological setting. Notably, we should:
-* show that `Submodule.prodEquivOfIsCompl` is an homeomorphism if and only if
+* show that `Submodule.prodEquivOfIsCompl` is a homeomorphism if and only if
   the two subspaces are topological complements, and bundle it as a `ContinuousLinearEquiv` when
   this is the case. (See the existing `ClosedComplemented.exists_submodule_equiv_prod`).
-* show that `Submodule.quotientEquivOfIsCompl` is an homeomorphism if and only if
+* show that `Submodule.quotientEquivOfIsCompl` is a homeomorphism if and only if
   the two subspaces are topological complements, and bundle it as a `ContinuousLinearEquiv` when
   this is the case.
 * define `ContinuousLinearMap.ofIsTopCompl`, analogous to `LinearMap.ofIsCompl`.

--- a/Mathlib/Topology/Homeomorph/Quotient.lean
+++ b/Mathlib/Topology/Homeomorph/Quotient.lean
@@ -19,7 +19,7 @@ variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 namespace Quot
 
-/-- An homeomorphism `e : X ≃ₜ Y` generXtes an homeomorphism between quotient spaces,
+/-- A homeomorphism `e : X ≃ₜ Y` generates a homeomorphism between quotient spaces,
 if `rX x₁ x₂ ↔ rY (e x₁) (e x₂)`. -/
 protected def congr {rX : X → X → Prop} {rY : Y → Y → Prop} (e : X ≃ₜ Y)
     (eq : ∀ x₁ x₂, rX x₁ x₂ ↔ rY (e x₁) (e x₂)) : Quot rX ≃ₜ Quot rY where
@@ -31,7 +31,7 @@ protected def congr {rX : X → X → Prop} {rY : Y → Y → Prop} (e : X ≃�
 protected def congrRight {r r' : X → X → Prop} (eq : ∀ x₁ x₂, r x₁ x₂ ↔ r' x₁ x₂) :
     Quot r ≃ₜ Quot r' := Quot.congr (Homeomorph.refl X) eq
 
-/-- An homeomorphism `e : X ≃ₜ Y` generXtes an equivalence between the quotient space of `X`
+/-- A homeomorphism `e : X ≃ₜ Y` generates an equivalence between the quotient space of `X`
 by a relation `rX` and the quotient space of `Y` by the image of this relation under `e`. -/
 protected def congrLeft {r : X → X → Prop} (e : X ≃ₜ Y) :
     Quot r ≃ₜ Quot fun y₁ y₂ ↦ r (e.symm y₁) (e.symm y₂) :=
@@ -41,7 +41,7 @@ end Quot
 
 namespace Quotient
 
-/-- An homeomorphism `e : X ≃ₜ Y` generXtes an homeomorphism between quotient spaces,
+/-- A homeomorphism `e : X ≃ₜ Y` generates a homeomorphism between quotient spaces,
 if `rX x₁ x₂ ↔ rY (e x₁) (e x₂)`. -/
 protected def congr {rX : Setoid X} {rY : Setoid Y} (e : X ≃ₜ Y)
     (eq : ∀ x₁ x₂, rX x₁ x₂ ↔ rY (e x₁) (e x₂)) :


### PR DESCRIPTION
They mostly were introduced in #39266; also fix the same grammar typo 'an homeomorphism' in the rest of mathlib.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
