### PR TITLE
[Merged by Bors] - perf(Topology/Algebra/Valued/WithVal): add fast_instance%

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -62,7 +62,7 @@ section Ring
 
 variable [Ring R] (v : Valuation R Γ₀)
 
-instance : Ring (WithVal v) := Equiv.ring { toFun := ofVal, invFun := toVal v }
+instance : Ring (WithVal v) := fast_instance% Equiv.ring { toFun := ofVal, invFun := toVal v }
 instance : Inhabited (WithVal v) := ⟨0⟩
 instance : Preorder (WithVal v) := .lift (v ∘ ofVal)
 
@@ -190,7 +190,7 @@ variable [CommRing R] (v : Valuation R Γ₀)
 
 instance : CommRing (WithVal v) := fast_instance% (equiv v).commRing
 
-instance : ValuativeRel (WithVal v) := .ofValuation (valuation v)
+instance : ValuativeRel (WithVal v) := fast_instance% .ofValuation (valuation v)
 
 instance : (valuation v).Compatible := .ofValuation (valuation v)
 
@@ -266,9 +266,9 @@ section left
 
 variable [CommRing R] (v : Valuation R Γ₀) [Semiring S] [Algebra R S]
 
-instance : Algebra (WithVal v) S where
+instance : Algebra (WithVal v) S := fast_instance% {
   __ := (inferInstance : Module (WithVal v) S)
-  __ := Algebra.compHom S (equiv v).toRingHom
+  __ := Algebra.compHom S (equiv v).toRingHom }
 
 theorem algebraMap_left_apply (s : WithVal v) :
     algebraMap (WithVal v) S s = algebraMap R S s.ofVal := rfl
@@ -285,7 +285,7 @@ section right
 
 variable [CommSemiring R] [Ring S] [Algebra R S] (v : Valuation S Γ₀)
 
-instance : Algebra R (WithVal v) := (equiv v).algebra R
+instance : Algebra R (WithVal v) := fast_instance% (equiv v).algebra R
 
 theorem algebraMap_right_apply (r : R) :
     algebraMap R (WithVal v) r = toVal v (algebraMap R S r) := rfl


### PR DESCRIPTION
If `v : Valuation R Γ₀` then `WithVal v` is a type synonym for `R` with `WithVal.equiv` the ring isomorphism between the two types.

The `CommRing` and `Field` instances on `WithVal v` are already `fast_instance%`s via `WithVal.equiv` (see lines 191 and 318 of this file); we make the `Ring` instance also a `fast_instance%`.

The `Module S (WithVal v)` instance (in the presence of `[Module S R]`) is already a `fast_instance%` (see line 240); we make `Algebra S (WithVal v)` and `Algebra (WithVal v) S` (in the presence of the corresponding instances for `R`) `fast_instance%`s too.

Finally, we make `ValuativeRel (WithVal v)` a `fast_instance%`.

Although all of these changes were found and implemented manually by me, the changes have been benchmarked against FLT by AI. The `Ring` and `ValuativeRel` changes both make significant gains (`Ring` alone gives 10% speedup on various declarations in valuation-heavy files which are future PRs to mathlib; adding `ValuativeRel` gives another 10%). The `Algebra` instances are less significant, but still move the needle in the right direction.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
