### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Subgraph): add `Embedding.ofIsInduced` and `IsInduced.map`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -411,9 +411,7 @@ protected lemma Iso.isIndContained' (e : G ≃g H) : H ⊴ G := e.symm.isIndCont
 
 protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.IsInduced) :
     G'.coe ⊴ G :=
-  ⟨{ toFun := (↑)
-     inj' := Subtype.coe_injective
-     map_rel_iff' := hG'.adj.symm }⟩
+  ⟨Embedding.ofIsInduced G' hG'⟩
 
 @[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
 lemma IsIndContained.rfl : G ⊴ G := .refl _

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -410,8 +410,7 @@ protected lemma Iso.isIndContained (e : G ≃g H) : G ⊴ H := e.toEmbedding.isI
 protected lemma Iso.isIndContained' (e : G ≃g H) : H ⊴ G := e.symm.isIndContained
 
 protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.IsInduced) :
-    G'.coe ⊴ G :=
-  ⟨Embedding.ofIsInduced G' hG'⟩
+    G'.coe ⊴ G := Embedding.ofIsInduced _ hG' |>.isIndContained
 
 @[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
 lemma IsIndContained.rfl : G ⊴ G := .refl _

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -421,9 +421,7 @@ protected lemma Iso.isIndContained' (e : G ≃g H) : H ⊴ G := e.symm.isIndCont
 
 protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.IsInduced) :
     G'.coe ⊴ G :=
-  ⟨{ toFun := (↑)
-     inj' := Subtype.coe_injective
-     map_rel_iff' := hG'.adj.symm }⟩
+  ⟨Embedding.ofIsInduced G' hG'⟩
 
 @[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
 lemma IsIndContained.rfl : G ⊴ G := .refl _

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -420,8 +420,7 @@ protected lemma Iso.isIndContained (e : G ≃g H) : G ⊴ H := e.toEmbedding.isI
 protected lemma Iso.isIndContained' (e : G ≃g H) : H ⊴ G := e.symm.isIndContained
 
 protected lemma Subgraph.IsInduced.isIndContained {G' : G.Subgraph} (hG' : G'.IsInduced) :
-    G'.coe ⊴ G :=
-  ⟨Embedding.ofIsInduced G' hG'⟩
+    G'.coe ⊴ G := Embedding.ofIsInduced _ hG' |>.isIndContained
 
 @[refl] lemma IsIndContained.refl (G : SimpleGraph V) : G ⊴ G := ⟨Embedding.refl⟩
 lemma IsIndContained.rfl : G ⊴ G := .refl _

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -669,6 +669,15 @@ theorem map_sup (f : G →g G') (H₁ H₂ : G.Subgraph) : (H₁ ⊔ H₂).map f
 @[simp] lemma edgeSet_map (f : G →g G') (H : G.Subgraph) :
     (H.map f).edgeSet = Sym2.map f '' H.edgeSet := Sym2.fromRel_relationMap ..
 
+protected lemma IsInduced.map {H : G.Subgraph} (hH : H.IsInduced) (e : G ↪g G') :
+    (H.map e.toHom).IsInduced := by
+  rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ hAdj
+  exact ⟨a, b, hH ha hb (e.map_adj_iff.mp hAdj), rfl, rfl⟩
+
+@[simp] protected lemma IsInduced.map_iff (e : G ≃g G') {H : G.Subgraph} :
+    (H.map e.toHom).IsInduced ↔ H.IsInduced :=
+  ⟨fun h ↦ by simpa [← map_comp] using h.map e.symm.toEmbedding, fun h ↦ h.map e.toEmbedding⟩
+
 end map
 
 /-- Graph homomorphisms induce a contravariant function on subgraphs. -/
@@ -867,6 +876,23 @@ lemma adj_iff_of_neighborSet_equiv {v : V} {H : Subgraph G}
   Set.ext_iff.mp (neighborSet_eq_of_equiv h hfin) _
 
 end Subgraph
+
+/-- The canonical embedding of an induced subgraph into the ambient graph.
+Unlike `Subgraph.hom`, this is an embedding rather than a homomorphism, since induced subgraphs
+reflect adjacency. -/
+def Embedding.ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph) (hG' : G'.IsInduced) :
+    G'.coe ↪g G where
+  toEmbedding := .subtype _
+  map_rel_iff' := hG'.adj.symm
+
+@[simp] lemma Embedding.toHom_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : (Embedding.ofIsInduced G' hG').toHom = G'.hom := rfl
+
+@[simp] lemma Embedding.coe_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : ⇑(Embedding.ofIsInduced G' hG') = (↑) := rfl
+
+@[simp] lemma Embedding.toEmbedding_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : (Embedding.ofIsInduced G' hG').toEmbedding = .subtype _ := rfl
 
 @[simp]
 theorem card_neighborSet_toSubgraph (G H : SimpleGraph V) (h : H ≤ G)

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -668,6 +668,15 @@ theorem map_sup (f : G →g G') (H₁ H₂ : G.Subgraph) : (H₁ ⊔ H₂).map f
 @[simp] lemma edgeSet_map (f : G →g G') (H : G.Subgraph) :
     (H.map f).edgeSet = Sym2.map f '' H.edgeSet := Sym2.fromRel_relationMap ..
 
+protected lemma IsInduced.map {H : G.Subgraph} (hH : H.IsInduced) (e : G ↪g G') :
+    (H.map e.toHom).IsInduced := by
+  rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ hAdj
+  exact ⟨a, b, hH ha hb (e.map_adj_iff.mp hAdj), rfl, rfl⟩
+
+@[simp] protected lemma IsInduced.map_iff (e : G ≃g G') {H : G.Subgraph} :
+    (H.map e.toHom).IsInduced ↔ H.IsInduced :=
+  ⟨fun h ↦ by simpa [← map_comp] using h.map e.symm.toEmbedding, fun h ↦ h.map e.toEmbedding⟩
+
 end map
 
 /-- Graph homomorphisms induce a contravariant function on subgraphs. -/
@@ -863,6 +872,23 @@ lemma adj_iff_of_neighborSet_equiv {v : V} {H : Subgraph G}
   Set.ext_iff.mp (neighborSet_eq_of_equiv h hfin) _
 
 end Subgraph
+
+/-- The canonical embedding of an induced subgraph into the ambient graph.
+Unlike `Subgraph.hom`, this is an embedding rather than a homomorphism, since induced subgraphs
+reflect adjacency. -/
+def Embedding.ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph) (hG' : G'.IsInduced) :
+    G'.coe ↪g G where
+  toEmbedding := .subtype _
+  map_rel_iff' := hG'.adj.symm
+
+@[simp] lemma Embedding.toHom_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : (Embedding.ofIsInduced G' hG').toHom = G'.hom := rfl
+
+@[simp] lemma Embedding.coe_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : ⇑(Embedding.ofIsInduced G' hG') = (↑) := rfl
+
+@[simp] lemma Embedding.toEmbedding_ofIsInduced {G : SimpleGraph V} (G' : G.Subgraph)
+    (hG' : G'.IsInduced) : (Embedding.ofIsInduced G' hG').toEmbedding = .subtype _ := rfl
 
 theorem card_neighborSet_toSubgraph (G H : SimpleGraph V) (h : H ≤ G)
     (v : V) [Fintype ↑((toSubgraph H h).neighborSet v)] [Fintype ↑(H.neighborSet v)] :

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -673,7 +673,7 @@ protected lemma IsInduced.map {H : G.Subgraph} (hH : H.IsInduced) (e : G ↪g G'
   rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ hAdj
   exact ⟨a, b, hH ha hb (e.map_adj_iff.mp hAdj), rfl, rfl⟩
 
-@[simp] protected lemma IsInduced.map_iff (e : G ≃g G') {H : G.Subgraph} :
+@[simp] protected lemma isInduced_map_iso (e : G ≃g G') {H : G.Subgraph} :
     (H.map e.toHom).IsInduced ↔ H.IsInduced :=
   ⟨fun h ↦ by simpa [← map_comp] using h.map e.symm.toEmbedding, fun h ↦ h.map e.toEmbedding⟩
 


### PR DESCRIPTION
Three additions to the `SimpleGraph.Subgraph` API for induced subgraphs. `Embedding.ofIsInduced` is the canonical embedding of an induced subgraph into its ambient graph, paired with `toHom_ofIsInduced` and `ofIsInduced_apply` lemmas. This is the embedding counterpart of `Subgraph.hom`, which only produces a homomorphism because non-induced subgraphs do not reflect adjacency. `Subgraph.IsInduced.map` then records that the image of an induced subgraph under a graph embedding is induced, strengthened to `IsInduced.map_iso` for the iso case.

Co-authored-by: Malte Jackisch  <45597826+MaltyBlanket@users.noreply.github.com>

---

**Orthogonal pre-requisite of the `Copy` / `InducedCopy` refactor-feat stack.**

Extracted as a prerequisite from #38631 that is otherwise independent of the wider `Copy` / `InducedCopy` refactor-feat stack.