### PR TITLE
[Merged by Bors] - chore(RingTheory): rearrange lemma about square of `IsLocalRing.maximalIdeal`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6607,6 +6607,7 @@ public import Mathlib.RingTheory.LocalRing.Length
 public import Mathlib.RingTheory.LocalRing.LocalSubring
 public import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
 public import Mathlib.RingTheory.LocalRing.MaximalIdeal.Defs
+public import Mathlib.RingTheory.LocalRing.MaximalIdeal.Square
 public import Mathlib.RingTheory.LocalRing.Module
 public import Mathlib.RingTheory.LocalRing.NonLocalRing
 public import Mathlib.RingTheory.LocalRing.Quotient

--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -495,21 +495,3 @@ lemma ringKrullDim_le_spanFinrank_maximalIdeal [IsLocalRing R] :
       Ideal.IsPrime.ne_top'))
 
 end Algebra
-
-variable (R) in
-lemma IsLocalRing.maximalIdeal_sq_lt_maximalIdeal [IsLocalRing R] :
-    maximalIdeal R ^ 2 < maximalIdeal R ↔ ¬ IsField R := by
-  trans ¬ maximalIdeal R ^ 2 = maximalIdeal R
-  · simp [lt_iff_le_and_ne, Ideal.pow_le_self]
-  · rw [IsLocalRing.isField_iff_maximalIdeal_eq, pow_two]
-    refine Iff.not ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
-    exact Submodule.eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator (IsNoetherian.noetherian _)
-      h.symm (maximalIdeal_le_jacobson _)
-
-/-- In a Noetherian local ring of positive Krull dimension,
-the square of the maximal ideal is strictly contained in the maximal ideal. -/
-lemma IsLocalRing.maximalIdeal_sq_lt [IsLocalRing R] (h : 0 < ringKrullDim R) :
-    (maximalIdeal R) ^ 2 < maximalIdeal R := by
-  rw [maximalIdeal_sq_lt_maximalIdeal R, IsLocalRing.isField_iff_maximalIdeal_eq]
-  contrapose h
-  simp [← IsLocalRing.maximalIdeal_height_eq_ringKrullDim, h, Ideal.height_bot]

--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -496,14 +496,20 @@ lemma ringKrullDim_le_spanFinrank_maximalIdeal [IsLocalRing R] :
 
 end Algebra
 
+variable (R) in
+lemma IsLocalRing.maximalIdeal_sq_lt_maximalIdeal [IsLocalRing R] :
+    maximalIdeal R ^ 2 < maximalIdeal R ↔ ¬ IsField R := by
+  trans ¬ maximalIdeal R ^ 2 = maximalIdeal R
+  · simp [lt_iff_le_and_ne, Ideal.pow_le_self]
+  · rw [IsLocalRing.isField_iff_maximalIdeal_eq, pow_two]
+    refine Iff.not ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
+    exact Submodule.eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator (IsNoetherian.noetherian _)
+      h.symm (maximalIdeal_le_jacobson _)
+
 /-- In a Noetherian local ring of positive Krull dimension,
 the square of the maximal ideal is strictly contained in the maximal ideal. -/
 lemma IsLocalRing.maximalIdeal_sq_lt [IsLocalRing R] (h : 0 < ringKrullDim R) :
-    (IsLocalRing.maximalIdeal R) ^ 2 < IsLocalRing.maximalIdeal R := by
-  refine lt_of_le_of_ne (Ideal.pow_le_self two_ne_zero) fun h_eq => h.ne' ?_
-  have : IsLocalRing.maximalIdeal R = ⊥ :=
-    Submodule.eq_bot_of_le_smul_of_le_jacobson_bot _ _
-      (IsNoetherian.noetherian _)
-      (by rw [Ideal.smul_eq_mul, ← sq]; exact h_eq.symm.le)
-      (IsLocalRing.maximalIdeal_le_jacobson ⊥)
-  rw [← IsLocalRing.maximalIdeal_height_eq_ringKrullDim, this, Ideal.height_bot, WithBot.coe_zero]
+    (maximalIdeal R) ^ 2 < maximalIdeal R := by
+  rw [maximalIdeal_sq_lt_maximalIdeal R, IsLocalRing.isField_iff_maximalIdeal_eq]
+  contrapose h
+  simp [← IsLocalRing.maximalIdeal_height_eq_ringKrullDim, h, Ideal.height_bot]

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Square.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Square.lean
@@ -15,7 +15,7 @@ public import Mathlib.RingTheory.Nakayama
 
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} [CommRing R] [IsLocalRing R] [IsNoetherianRing R]
 

--- a/Mathlib/RingTheory/LocalRing/MaximalIdeal/Square.lean
+++ b/Mathlib/RingTheory/LocalRing/MaximalIdeal/Square.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Nailin Guan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nailin Guan
+-/
+module
+
+public import Mathlib.RingTheory.KrullDimension.Field
+public import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+public import Mathlib.RingTheory.Nakayama
+
+/-!
+
+# Lemmas about square of maximal ideal of local ring
+
+-/
+
+@[expose] public section
+
+variable {R : Type*} [CommRing R] [IsLocalRing R] [IsNoetherianRing R]
+
+variable (R) in
+lemma IsLocalRing.maximalIdeal_sq_lt_maximalIdeal :
+    maximalIdeal R ^ 2 < maximalIdeal R ↔ ¬ IsField R := by
+  trans ¬ maximalIdeal R ^ 2 = maximalIdeal R
+  · simp [lt_iff_le_and_ne, Ideal.pow_le_self]
+  · rw [IsLocalRing.isField_iff_maximalIdeal_eq, pow_two]
+    refine Iff.not ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
+    exact Submodule.eq_bot_of_eq_ideal_smul_of_le_jacobson_annihilator (IsNoetherian.noetherian _)
+      h.symm (maximalIdeal_le_jacobson _)
+
+/-- In a Noetherian local ring of positive Krull dimension,
+the square of the maximal ideal is strictly contained in the maximal ideal. -/
+lemma IsLocalRing.maximalIdeal_sq_lt_of_ringKrullDim_ne_zero (h : ringKrullDim R ≠ 0) :
+    (maximalIdeal R) ^ 2 < maximalIdeal R :=
+  (maximalIdeal_sq_lt_maximalIdeal R).mpr (ringKrullDim_eq_zero_of_isField.mt h)
+
+@[deprecated "Use `IsLocalRing.maximalIdeal_sq_lt_of_ringKrullDim_ne_zero` instead"
+  (since := "2026-05-13")]
+lemma IsLocalRing.maximalIdeal_sq_lt (h : 0 < ringKrullDim R) :
+    (maximalIdeal R) ^ 2 < maximalIdeal R :=
+  IsLocalRing.maximalIdeal_sq_lt_of_ringKrullDim_ne_zero h.ne.symm


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
