### PR TITLE
[Merged by Bors] - ci(shake.yaml): run lake build and post messages to nightly-testing-mathlib

### DIFF
--- a/.github/workflows/shake.yaml
+++ b/.github/workflows/shake.yaml
@@ -35,6 +35,10 @@ jobs:
           use-github-cache: false
           use-mathlib-cache: true
 
+      - name: lake build
+        run: |
+          lake build Mathlib Archive Counterexamples
+
       - name: lake shake
         id: shake
         run: |
@@ -53,7 +57,7 @@ jobs:
 
       - name: Upload explain.txt
         id: upload-artifact
-        if: steps.shake.outputs.changed == 'true'
+        if: failure() || steps.shake.outputs.changed == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: shake-explain
@@ -123,7 +127,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'nightly-testing'
+          to: 'nightly-testing-mathlib'
           type: 'stream'
           topic: 'Mathlib `shake --fix`'
           content: |


### PR DESCRIPTION
Follow-up to #39085. The cache doesn't contain oleans for Archive and Counterexamples so we need to run `lake build`.

Also upload the `explain.txt` in case of workflow failure for better diagnostics, and post Zulip messages to the new `nightly-testing-mathlib` stream.