### PR TITLE
feat(CategoryTheory/FiberedCategory/Fibered): Add composition of (strongly) cartesian morphisms and of fibered functors

### DIFF
--- a/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
@@ -171,29 +171,24 @@ instance of_iso_comp {a' : 𝒳} (φ' : a' ≅ a) [IsHomLift p (𝟙 R) φ'.hom]
     apply map_uniq
     simp only [assoc, hτ₂]
 
-lemma Functor.IsCartesian.of_bot [q.IsHomLift φ ψ] [p.IsCartesian f φ]
-    [(q ⋙ p).IsCartesian f ψ] : q.IsCartesian φ ψ := by
-  constructor
-  intro X' φ' hφ'
-  have := IsHomLift.comp_vert q p φ' φ f
-  use Functor.IsCartesian.map (q ⋙ p) f ψ φ', ⟨?_, Functor.IsCartesian.fac ..⟩,?_
-  · have := Functor.IsCartesian.map_isHomLift (q ⋙ p) f ψ φ'
-    subst_hom_lift q φ ψ
-    fapply IsHomLift.of_fac _ _ _ _ rfl _
-    · exact IsHomLift.domain_eq q (q.map ψ) φ'
-    · apply +allowSynthFailures ‹p.IsCartesian f (q.map ψ)›.ext
+lemma of_bot [q.IsHomLift φ ψ] [p.IsCartesian f φ]
+    [(q ⋙ p).IsCartesian f ψ] : q.IsCartesian φ ψ where
+  universal_property φ' hφ' := by
+    have := IsHomLift.comp_vert q p φ' φ f
+    refine ⟨IsCartesian.map (q ⋙ p) f ψ φ', ⟨?_, by simp⟩, fun y' ⟨hy₁, hy₂⟩ ↦ ?_⟩
+    · have := map_isHomLift (q ⋙ p) f ψ φ'
+      subst_hom_lift q φ ψ
+      refine IsHomLift.of_fac _ _ _ (IsHomLift.domain_eq q (q.map ψ) φ') rfl ?_
+      apply +allowSynthFailures IsCartesian.ext p f (q.map ψ)
       · subst_hom_lift p f (q.map ψ)
         infer_instance
-      · exact IsHomLift.of_functor_comp_right q p (Functor.IsCartesian.map (q ⋙ p) f ψ φ') _ _
-      · simp only [Category.id_comp, eqToHom_refl, Category.comp_id, Category.assoc, ← q.map_comp,
-        Functor.IsCartesian.fac]
-        nth_rw 1 [IsHomLift.fac q (q.map ψ) φ']
-        simp
-  intro y' ⟨hy₁,hy₂⟩
-  apply +allowSynthFailures Functor.IsCartesian.map_uniq
-  · cases IsHomLift.domain_eq p f φ
-    exact IsHomLift.comp_vert q p y' (𝟙 a) (𝟙 _)
-  · exact hy₂
+      · exact IsHomLift.of_functor_comp_right q p (IsCartesian.map (q ⋙ p) f ψ φ') _ _
+      · simp [← q.map_comp]
+        simp [IsHomLift.fac q (q.map ψ) φ']
+    have : (q ⋙ p).IsHomLift (𝟙 R) y' := by
+      cases IsHomLift.domain_eq p f φ
+      exact IsHomLift.comp_vert q p y' (𝟙 a) (𝟙 _)
+    exact map_uniq _ _ _ _ _ hy₂
 
 end IsCartesian
 
@@ -362,44 +357,38 @@ variable (f g φ ψ) (η : x ⟶ y)
 
 lemma paste_vert (η : x ⟶ y) (φ : a ⟶ b) (f : R ⟶ S)
     [q.IsStronglyCartesian φ η]
-    [p.IsStronglyCartesian f φ] : (q ⋙ p).IsStronglyCartesian f η := by
-  have := IsHomLift.comp_vert q p η φ f
-  constructor
-  intro X' z' z hz
-  have : p.IsHomLift (z' ≫ f) (q.map z) := IsHomLift.of_functor_comp_right q p z _ _
-  subst_hom_lift q φ η
-  let χ' := ‹p.IsStronglyCartesian f (q.map η)›.map _ _ _ (.refl (z' ≫ f)) (q.map z)
-  use ‹q.IsStronglyCartesian (q.map η) η›.map _ _ _ (g := χ') (f' := q.map z) (by simp [χ']) z
-  simp_rw [Functor.IsStronglyCartesian.fac, and_true, and_imp]
-  refine ⟨IsHomLift.comp_vert q p _ χ' z',?_⟩
-  intro y' hy₁ hy₂
-  have := IsHomLift.of_functor_comp_right q p y' (q.map y') z'
-  apply +allowSynthFailures ‹q.IsStronglyCartesian (q.map η) η›.map_uniq
-  · apply IsHomLift.of_eq
-    exact ‹p.IsStronglyCartesian f (q.map η)›.map_uniq _ _ _ (by simp) _ _
-      (by simp [← q.map_comp, hy₂])
-  · exact hy₂
+    [p.IsStronglyCartesian f φ] : (q ⋙ p).IsStronglyCartesian f η where
+  toIsHomLift := IsHomLift.comp_vert q p η φ f
+  universal_property' z' z hz := by
+    have : p.IsHomLift (z' ≫ f) (q.map z) := IsHomLift.of_functor_comp_right q p z _ _
+    subst_hom_lift q φ η
+    let χ' := ‹p.IsStronglyCartesian f (q.map η)›.map _ _ _ (.refl (z' ≫ f)) (q.map z)
+    use ‹q.IsStronglyCartesian (q.map η) η›.map _ _ _ (g := χ') (f' := q.map z) (by simp [χ']) z
+    simp_rw [Functor.IsStronglyCartesian.fac, and_true, and_imp]
+    refine ⟨IsHomLift.comp_vert q p _ χ' z',fun y' hy₁ hy₂ => ?_⟩
+    have := IsHomLift.of_functor_comp_right q p y' (q.map y') z'
+    have : q.IsHomLift χ' y' :=
+      IsHomLift.of_eq _ <| ‹p.IsStronglyCartesian f (q.map η)›.map_uniq _ _ _ (by simp) _ _
+        (by simp [← q.map_comp, hy₂])
+    exact ‹q.IsStronglyCartesian (q.map η) η›.map_uniq _ _ _ _ _ _ hy₂
 
 lemma of_bot [q.IsHomLift φ η] [p.IsStronglyCartesian f φ]
-    [(q ⋙ p).IsStronglyCartesian f η] : q.IsStronglyCartesian φ η := by
-  constructor
-  intro X' z' z hz
-  have := IsHomLift.comp_vert q p z (z' ≫ φ) (p.map z' ≫ p.map φ)
-  subst_hom_lift p f φ
-  let φ' := ‹(q ⋙ p).IsStronglyCartesian (p.map φ) η›.map _ _ _ (g := p.map z') rfl z
-  use φ'
-  simp_rw [φ', Functor.IsStronglyCartesian.fac, and_true, and_imp]
-  constructor
-  · subst_hom_lift q φ η
-    apply IsHomLift.of_eq
-    apply +allowSynthFailures Functor.IsStronglyCartesian.ext p (p.map (q.map η)) (q.map η)
-    case g => exact (p.map z')
-    · exact IsHomLift.of_functor_comp_right q p φ' _ (p.map z')
-    · infer_instance
-    · simp [← q.map_comp, IsHomLift.eq_of_isHomLift q (z' ≫ q.map η) z]
-  · intro y hy₁ hy₂
-    have := IsHomLift.comp_vert q p y z' (p.map z')
-    exact Functor.IsStronglyCartesian.map_uniq _ _ _ _ _ _ hy₂
+    [(q ⋙ p).IsStronglyCartesian f η] : q.IsStronglyCartesian φ η where
+  universal_property' z' z hz := by
+    have := IsHomLift.comp_vert q p z (z' ≫ φ) (p.map z' ≫ p.map φ)
+    subst_hom_lift p f φ
+    let φ' := ‹(q ⋙ p).IsStronglyCartesian (p.map φ) η›.map _ _ _ (g := p.map z') rfl z
+    use φ'
+    simp_rw [φ', Functor.IsStronglyCartesian.fac, and_true, and_imp]
+    constructor
+    · subst_hom_lift q φ η
+      apply IsHomLift.of_eq
+      have := IsHomLift.of_functor_comp_right q p φ' (q.map φ') (p.map z')
+      apply Functor.IsStronglyCartesian.ext p (p.map (q.map η)) (q.map η) (g := p.map z')
+      simp [← q.map_comp, IsHomLift.eq_of_isHomLift q (z' ≫ q.map η) z]
+    · intro y hy₁ hy₂
+      have := IsHomLift.comp_vert q p y z' (p.map z')
+      exact Functor.IsStronglyCartesian.map_uniq _ _ _ _ _ _ hy₂
 
 end
 
@@ -465,6 +454,36 @@ instance domainUniqueUpToIso_hom_isHomLift (h : f' = g.hom ≫ f) (φ : a ⟶ b)
 end
 
 end IsStronglyCartesian
+
+lemma _root_.CategoryTheory.Equivalence.functor_isStronglyCartesian_of_counit_app_eq_eqToHom
+    (e : 𝒳 ≌ 𝒮) {S : 𝒮} {c : 𝒳} (hS₁ : e.functor.obj (e.inverse.obj S) = S)
+    (hS₂ : dsimp% e.counit.app S = eqToHom hS₁) (g : S ⟶ e.functor.obj c) :
+    e.functor.IsStronglyCartesian g (e.inverse.map g ≫ e.unitInv.app c) where
+  toIsHomLift := by
+    apply IsHomLift.of_fac _ _ _ hS₁ rfl
+    simp [hS₂]
+  universal_property' f' φ hφ := by
+    use e.unit.app _ ≫ e.inverse.map f'
+    simp only [Functor.comp_obj, Category.assoc, and_imp, and_assoc]
+    refine ⟨?_,?_,?_⟩
+    · apply IsHomLift.of_fac _ _ _ rfl hS₁
+      simp only [eqToHom_refl, Functor.map_comp, Equivalence.fun_inv_map, Functor.comp_obj,
+        Functor.id_obj, Equivalence.functor_unit_comp_assoc, Category.assoc, Category.id_comp]
+      rw [← cancel_mono (eqToIso hS₁.symm ≪≫ e.counitIso.app S).hom]
+      simp
+      simp [hS₂]
+    · have := congr(e.inverse.map $(IsHomLift.fac e.functor (f' ≫ g) φ))
+      simp_all
+      simp [reassoc_of% this]
+    · intro y hy₁ _
+      simp [IsHomLift.fac e.functor f' y, ←hS₂]
+
+lemma _root_.CategoryTheory.Equivalence.inverse_isStronglyCartesian_of_unit_app_eq_eqToHom
+    (e : 𝒳 ≌ 𝒮) {b : 𝒳} {T : 𝒮} (hb₁ : b = e.inverse.obj (e.functor.obj b))
+    (hb₂ : dsimp% e.unit.app b = eqToHom hb₁) (g : b ⟶ e.inverse.obj T) :
+    e.inverse.IsStronglyCartesian g (e.functor.map g ≫ e.counit.app T) :=
+  e.symm.functor_isStronglyCartesian_of_counit_app_eq_eqToHom hb₁.symm
+    (Mono.right_cancellation (f := e.unit.app b) _ _ <| by simp; simp [hb₂]) _
 
 namespace IsCartesian
 

--- a/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
@@ -40,13 +40,14 @@ equalities.
 
 @[expose] public section
 
-universe v₁ v₂ u₁ u₂
+universe v₁ v₂ v₃ u₁ u₂ u₃
 
 open CategoryTheory Functor Category IsHomLift
 
 namespace CategoryTheory.Functor
 
-variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category.{v₁} 𝒮] [Category.{v₂} 𝒳] (p : 𝒳 ⥤ 𝒮)
+variable {𝒮 : Type u₁} {𝒳 : Type u₂} {𝒴 : Type u₃} [Category.{v₁} 𝒮] [Category.{v₂} 𝒳]
+  [Category.{v₃} 𝒴] (p : 𝒳 ⥤ 𝒮) (q : 𝒴 ⥤ 𝒳)
 
 section
 
@@ -83,7 +84,7 @@ end
 
 namespace IsCartesian
 
-variable {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [IsCartesian p f φ]
+variable {R S : 𝒮} {a b : 𝒳} {x y : 𝒴} (f : R ⟶ S) (φ : a ⟶ b) (ψ : x ⟶ y) [IsCartesian p f φ]
 
 section
 
@@ -169,6 +170,30 @@ instance of_iso_comp {a' : 𝒳} (φ' : a' ≅ a) [IsHomLift p (𝟙 R) φ'.hom]
     rw [Iso.eq_comp_inv]
     apply map_uniq
     simp only [assoc, hτ₂]
+
+lemma Functor.IsCartesian.of_bot [q.IsHomLift φ ψ] [p.IsCartesian f φ]
+    [(q ⋙ p).IsCartesian f ψ] : q.IsCartesian φ ψ := by
+  constructor
+  intro X' φ' hφ'
+  have := IsHomLift.comp_vert q p φ' φ f
+  use Functor.IsCartesian.map (q ⋙ p) f ψ φ', ⟨?_, Functor.IsCartesian.fac ..⟩,?_
+  · have := Functor.IsCartesian.map_isHomLift (q ⋙ p) f ψ φ'
+    subst_hom_lift q φ ψ
+    fapply IsHomLift.of_fac _ _ _ _ rfl _
+    · exact IsHomLift.domain_eq q (q.map ψ) φ'
+    · apply +allowSynthFailures ‹p.IsCartesian f (q.map ψ)›.ext
+      · subst_hom_lift p f (q.map ψ)
+        infer_instance
+      · exact IsHomLift.of_functor_comp_right q p (Functor.IsCartesian.map (q ⋙ p) f ψ φ') _ _
+      · simp only [Category.id_comp, eqToHom_refl, Category.comp_id, Category.assoc, ← q.map_comp,
+        Functor.IsCartesian.fac]
+        nth_rw 1 [IsHomLift.fac q (q.map ψ) φ']
+        simp
+  intro y' ⟨hy₁,hy₂⟩
+  apply +allowSynthFailures Functor.IsCartesian.map_uniq
+  · cases IsHomLift.domain_eq p f φ
+    exact IsHomLift.comp_vert q p y' (𝟙 a) (𝟙 _)
+  · exact hy₂
 
 end IsCartesian
 
@@ -286,7 +311,7 @@ end
 
 section
 
-variable {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c}
+variable {R S T : 𝒮} {a b c : 𝒳} {x y : 𝒴} {f : R ⟶ S} {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c}
 
 /-- Given two strongly Cartesian morphisms `φ`, `ψ` as follows
 ```
@@ -332,6 +357,49 @@ protected lemma of_comp [IsStronglyCartesian p g ψ] [IsStronglyCartesian p (f �
     · intro π' ⟨hπ'₁, hπ'₂⟩
       apply map_uniq
       simp [hπ'₂.symm]
+
+variable (f g φ ψ) (η : x ⟶ y)
+
+lemma paste_vert (η : x ⟶ y) (φ : a ⟶ b) (f : R ⟶ S)
+    [q.IsStronglyCartesian φ η]
+    [p.IsStronglyCartesian f φ] : (q ⋙ p).IsStronglyCartesian f η := by
+  have := IsHomLift.comp_vert q p η φ f
+  constructor
+  intro X' z' z hz
+  have : p.IsHomLift (z' ≫ f) (q.map z) := IsHomLift.of_functor_comp_right q p z _ _
+  subst_hom_lift q φ η
+  let χ' := ‹p.IsStronglyCartesian f (q.map η)›.map _ _ _ (.refl (z' ≫ f)) (q.map z)
+  use ‹q.IsStronglyCartesian (q.map η) η›.map _ _ _ (g := χ') (f' := q.map z) (by simp [χ']) z
+  simp_rw [Functor.IsStronglyCartesian.fac, and_true, and_imp]
+  refine ⟨IsHomLift.comp_vert q p _ χ' z',?_⟩
+  intro y' hy₁ hy₂
+  have := IsHomLift.of_functor_comp_right q p y' (q.map y') z'
+  apply +allowSynthFailures ‹q.IsStronglyCartesian (q.map η) η›.map_uniq
+  · apply IsHomLift.of_eq
+    exact ‹p.IsStronglyCartesian f (q.map η)›.map_uniq _ _ _ (by simp) _ _
+      (by simp [← q.map_comp, hy₂])
+  · exact hy₂
+
+lemma of_bot [q.IsHomLift φ η] [p.IsStronglyCartesian f φ]
+    [(q ⋙ p).IsStronglyCartesian f η] : q.IsStronglyCartesian φ η := by
+  constructor
+  intro X' z' z hz
+  have := IsHomLift.comp_vert q p z (z' ≫ φ) (p.map z' ≫ p.map φ)
+  subst_hom_lift p f φ
+  let φ' := ‹(q ⋙ p).IsStronglyCartesian (p.map φ) η›.map _ _ _ (g := p.map z') rfl z
+  use φ'
+  simp_rw [φ', Functor.IsStronglyCartesian.fac, and_true, and_imp]
+  constructor
+  · subst_hom_lift q φ η
+    apply IsHomLift.of_eq
+    apply +allowSynthFailures Functor.IsStronglyCartesian.ext p (p.map (q.map η)) (q.map η)
+    case g => exact (p.map z')
+    · exact IsHomLift.of_functor_comp_right q p φ' _ (p.map z')
+    · infer_instance
+    · simp [← q.map_comp, IsHomLift.eq_of_isHomLift q (z' ≫ q.map η) z]
+  · intro y hy₁ hy₂
+    have := IsHomLift.comp_vert q p y z' (p.map z')
+    exact Functor.IsStronglyCartesian.map_uniq _ _ _ _ _ _ hy₂
 
 end
 
@@ -397,5 +465,32 @@ instance domainUniqueUpToIso_hom_isHomLift (h : f' = g.hom ≫ f) (φ : a ⟶ b)
 end
 
 end IsStronglyCartesian
+
+namespace IsCartesian
+
+lemma paste_vert (q : 𝒴 ⥤ 𝒳) (p : 𝒳 ⥤ 𝒮) {X₁ X₂ : 𝒴} {Y₁ Y₂ : 𝒳}
+    {Z₁ Z₂ : 𝒮} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂)
+    [q.IsStronglyCartesian g f] [p.IsCartesian h g] : (q ⋙ p).IsCartesian h f := by
+  have := IsHomLift.comp_vert q p f g h
+  constructor
+  intro X' f' hf'
+  have : p.IsHomLift h (q.map f') :=
+    IsHomLift.of_functor_comp_right q p f' _ _
+  subst_hom_lift q g f
+  let φ := Functor.IsCartesian.map p h (q.map f) (q.map f')
+  use Functor.IsStronglyCartesian.map q (q.map f) f
+      (Functor.IsCartesian.fac p h (q.map f) (q.map f')).symm f',
+    ⟨IsHomLift.comp_vert q p _ φ (𝟙 Z₁),
+      (Functor.IsStronglyCartesian.fac q (q.map f) f _ _)⟩
+  intro y ⟨_, hy⟩
+  have := IsHomLift.of_functor_comp_right q p y (q.map y) (𝟙 Z₁)
+  apply +allowSynthFailures Functor.IsStronglyCartesian.map_uniq
+  · apply IsHomLift.of_fac _ _ _ rfl rfl
+    simp only [eqToHom_refl, Category.comp_id, Category.id_comp, Eq.comm]
+    apply Functor.IsCartesian.map_uniq
+    simp [← q.map_comp, hy]
+  · exact hy
+
+end IsCartesian
 
 end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/FiberedCategory/Fibered.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Fibered.lean
@@ -204,57 +204,17 @@ end Functor.IsFibered
 
 lemma Equivalence.functor_isFibered_of_counit_app_eq_eqToHom {C D : Type*}
     [Category* C] [Category* D] (e : C ≌ D) (he : ∀ Y : D, dsimp% ∃ h, e.counit.app Y = eqToHom h) :
-    e.functor.IsFibered :=
-  .of_exists_isStronglyCartesian fun X₂ Y₁ g => by
-    have he' : e.inverse ⋙ e.functor = 𝟭 _ := Functor.ext
-      (fun x => by obtain ⟨h, _⟩ := he x; exact h)
-      (fun X Y f => by
-        simp only [Functor.comp_obj, Functor.comp_map, Equivalence.fun_inv_map, Functor.id_obj,
-          Functor.id_map, ← Equivalence.cancel_counit_right, Category.assoc,
-          counitIso_inv_hom_id_app, comp_id]
-        obtain ⟨h₁,h₁'⟩ := he X
-        obtain ⟨h₂,h₂'⟩ := he Y
-        rw [h₁',h₂']
-        simp)
-    obtain ⟨hY₁, h'⟩ := he Y₁
-    use e.inverse.obj Y₁
-    use e.inverse.map g ≫ e.unitInv.app X₂
-    have : dsimp% e.functor.IsHomLift g (e.inverse.map g ≫ e.unitInv.app X₂) := by
-      apply IsHomLift.of_fac _ _ _ hY₁ rfl
-      simp [h']
-    constructor
-    intro X' f' φ hφ
-    use e.unit.app _ ≫ e.inverse.map f'
-    simp only [Functor.comp_obj, Category.assoc, and_imp,and_assoc]
-    refine ⟨?_,?_,?_⟩
-    · apply IsHomLift.of_fac _ _ _ rfl hY₁
-      simp only [eqToHom_refl, Functor.map_comp, Equivalence.fun_inv_map, Functor.comp_obj,
-        Functor.id_obj, Equivalence.functor_unit_comp_assoc, Category.assoc, Category.id_comp]
-      rw [← cancel_mono (eqToIso hY₁.symm ≪≫ e.counitIso.app Y₁).hom]
-      simp only [id_obj, Iso.trans_hom, eqToIso.hom, Iso.app_hom, assoc, eqToHom_trans_assoc,
-        eqToHom_refl, id_comp, counitIso_inv_hom_id_app, comp_id]
-      rw [h']
-      simp
-    · have := congr(e.inverse.map $(IsHomLift.fac e.functor (f' ≫ g) φ))
-      simp only [Functor.map_comp, eqToHom_refl, Category.comp_id, Category.id_comp,
-        Equivalence.inv_fun_map, Functor.comp_obj, Functor.id_obj] at this
-      rw [reassoc_of% this]
-      simp
-    · intro y hy₁ _
-      rw [IsHomLift.fac e.functor f' y]
-      simp [← h']
+    e.functor.IsFibered := .of_exists_isStronglyCartesian fun X₂ Y₁ g => by
+  obtain ⟨hY₁, h'⟩ := he Y₁
+  use e.inverse.obj Y₁, e.inverse.map g ≫ e.unitInv.app X₂
+  exact functor_isStronglyCartesian_of_counit_app_eq_eqToHom e hY₁ h' g
 
 lemma Equivalence.inverse_isFibered_of_unit_app_eq_eqToHom {C D : Type*}
     [Category* C] [Category* D] (e : C ≌ D) (he : ∀ X : C, dsimp% ∃ h, e.unit.app X = eqToHom h) :
-    e.inverse.IsFibered := by
-  apply e.symm.functor_isFibered_of_counit_app_eq_eqToHom
-  intro X
-  simp only [symm_functor, symm_inverse, symm_counit]
-  obtain ⟨h₁,h₂⟩ := he X
-  use h₁.symm
-  apply Mono.right_cancellation (f := e.unit.app X)
-  simp_rw [comp_obj, id_obj, dsimp% e.unitIso.inv_hom_id_app,
-    h₂, eqToHom_trans, eqToHom_refl]
+    e.inverse.IsFibered := .of_exists_isStronglyCartesian fun X₂ Y₁ g => by
+  obtain ⟨hX₁,h'⟩ := he Y₁
+  use e.functor.obj Y₁, e.functor.map g ≫ e.counit.app X₂
+  exact inverse_isStronglyCartesian_of_unit_app_eq_eqToHom e hX₁ h' g
 
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/FiberedCategory/Fibered.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Fibered.lean
@@ -41,13 +41,14 @@ equalities.
 
 @[expose] public section
 
-universe v₁ v₂ u₁ u₂
+universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
 open Functor Category IsHomLift
 
-variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category.{v₁} 𝒮] [Category.{v₂} 𝒳]
+variable {𝒮 : Type u₁} {𝒳 : Type u₂} {𝒴 : Type u₃} [Category.{v₁} 𝒮] [Category.{v₂} 𝒳]
+  [Category.{v₃} 𝒴]
 
 /-- Definition of a prefibered category.
 
@@ -118,6 +119,14 @@ instance isStronglyCartesian_of_isCartesian (p : 𝒳 ⥤ 𝒮) [p.IsFibered] {R
     apply map_uniq
     rwa [← assoc, IsCartesian.fac]
 
+instance (p : 𝒴 ⥤ 𝒳) [p.IsFibered] (q : 𝒳 ⥤ 𝒮) [q.IsPreFibered] : (p ⋙ q).IsPreFibered where
+  exists_isCartesian' {X Z} f := by
+    dsimp at f
+    obtain ⟨Y,g,hg⟩ := IsPreFibered.exists_isCartesian q rfl f
+    obtain ⟨X', Z₂, h₂⟩ := IsPreFibered.exists_isCartesian p rfl g
+    use X', Z₂
+    exact Functor.IsCartesian.paste_vert p q Z₂ g f
+
 /-- In a category which admits strongly Cartesian pullbacks, any Cartesian morphism is
 strongly Cartesian. This is a helper-lemma for the fact that admitting strongly Cartesian pullbacks
 implies being fibered. -/
@@ -167,6 +176,15 @@ lemma of_exists_isStronglyCartesian {p : 𝒳 ⥤ 𝒮}
     have : p.IsStronglyCartesian g ψ := isStronglyCartesian_of_exists_isCartesian p h _ _
     inferInstance
 
+instance (p : 𝒴 ⥤ 𝒳) (q : 𝒳 ⥤ 𝒮)
+    [p.IsFibered] [q.IsFibered] : (p ⋙ q).IsFibered := .of_exists_isStronglyCartesian
+  fun X₂ Z h => by
+    dsimp at h
+    obtain ⟨Y₁,g,hg⟩ := ‹q.IsFibered›.exists_isCartesian' h
+    obtain ⟨X₁,f,hf⟩ := ‹p.IsFibered›.exists_isCartesian' g
+    use X₁,f
+    exact .paste_vert q p f g h
+
 /-- Given a diagram
 ```
                   a
@@ -183,5 +201,60 @@ noncomputable def pullbackPullbackIso {p : 𝒳 ⥤ 𝒮} [IsFibered p]
     (pullbackMap ha (g ≫ f))
 
 end Functor.IsFibered
+
+lemma Equivalence.functor_isFibered_of_counit_app_eq_eqToHom {C D : Type*}
+    [Category* C] [Category* D] (e : C ≌ D) (he : ∀ Y : D, dsimp% ∃ h, e.counit.app Y = eqToHom h) :
+    e.functor.IsFibered :=
+  .of_exists_isStronglyCartesian fun X₂ Y₁ g => by
+    have he' : e.inverse ⋙ e.functor = 𝟭 _ := Functor.ext
+      (fun x => by obtain ⟨h, _⟩ := he x; exact h)
+      (fun X Y f => by
+        simp only [Functor.comp_obj, Functor.comp_map, Equivalence.fun_inv_map, Functor.id_obj,
+          Functor.id_map, ← Equivalence.cancel_counit_right, Category.assoc,
+          counitIso_inv_hom_id_app, comp_id]
+        obtain ⟨h₁,h₁'⟩ := he X
+        obtain ⟨h₂,h₂'⟩ := he Y
+        rw [h₁',h₂']
+        simp)
+    obtain ⟨hY₁, h'⟩ := he Y₁
+    use e.inverse.obj Y₁
+    use e.inverse.map g ≫ e.unitInv.app X₂
+    have : dsimp% e.functor.IsHomLift g (e.inverse.map g ≫ e.unitInv.app X₂) := by
+      apply IsHomLift.of_fac _ _ _ hY₁ rfl
+      simp [h']
+    constructor
+    intro X' f' φ hφ
+    use e.unit.app _ ≫ e.inverse.map f'
+    simp only [Functor.comp_obj, Category.assoc, and_imp,and_assoc]
+    refine ⟨?_,?_,?_⟩
+    · apply IsHomLift.of_fac _ _ _ rfl hY₁
+      simp only [eqToHom_refl, Functor.map_comp, Equivalence.fun_inv_map, Functor.comp_obj,
+        Functor.id_obj, Equivalence.functor_unit_comp_assoc, Category.assoc, Category.id_comp]
+      rw [← cancel_mono (eqToIso hY₁.symm ≪≫ e.counitIso.app Y₁).hom]
+      simp only [id_obj, Iso.trans_hom, eqToIso.hom, Iso.app_hom, assoc, eqToHom_trans_assoc,
+        eqToHom_refl, id_comp, counitIso_inv_hom_id_app, comp_id]
+      rw [h']
+      simp
+    · have := congr(e.inverse.map $(IsHomLift.fac e.functor (f' ≫ g) φ))
+      simp only [Functor.map_comp, eqToHom_refl, Category.comp_id, Category.id_comp,
+        Equivalence.inv_fun_map, Functor.comp_obj, Functor.id_obj] at this
+      rw [reassoc_of% this]
+      simp
+    · intro y hy₁ _
+      rw [IsHomLift.fac e.functor f' y]
+      simp [← h']
+
+lemma Equivalence.inverse_isFibered_of_unit_app_eq_eqToHom {C D : Type*}
+    [Category* C] [Category* D] (e : C ≌ D) (he : ∀ X : C, dsimp% ∃ h, e.unit.app X = eqToHom h) :
+    e.inverse.IsFibered := by
+  apply e.symm.functor_isFibered_of_counit_app_eq_eqToHom
+  intro X
+  simp only [symm_functor, symm_inverse, symm_counit]
+  obtain ⟨h₁,h₂⟩ := he X
+  use h₁.symm
+  apply Mono.right_cancellation (f := e.unit.app X)
+  simp_rw [comp_obj, id_obj, dsimp% e.unitIso.inv_hom_id_app,
+    h₂, eqToHom_trans, eqToHom_refl]
+
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -288,8 +288,7 @@ lemma comp_vert {C D E : Type*} [Category* C] [Category* D]
     (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) [F.IsHomLift g f] [G.IsHomLift h g] : (F ⋙ G).IsHomLift h f := by
   subst_hom_lift G h g
   subst_hom_lift F g f
-  rw [← Functor.comp_map]
-  exact .map f
+  simp [← Functor.comp_map, ← Functor.comp_obj]
 
 lemma of_functor_comp_right {C D E : Type*} [Category* C]
     [Category* D] [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X₁ X₂ : C} {Y₁ Y₂ : D} {Z₁ Z₂ : E}
@@ -297,8 +296,7 @@ lemma of_functor_comp_right {C D E : Type*} [Category* C]
     G.IsHomLift h g := by
   subst_hom_lift F g f
   subst_hom_lift (F ⋙ G) h f
-  rw [Functor.comp_map]
-  exact .map (F.map f)
+  simp [Functor.comp_obj]
 
 lemma comp_iff_of_isHomLift_left {C D E : Type*} [Category* C]
     [Category* D] [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X₁ X₂ : C} {Y₁ Y₂ : D} {Z₁ Z₂ : E}
@@ -309,7 +307,7 @@ lemma comp_iff_of_isHomLift_left {C D E : Type*} [Category* C]
 lemma of_eq {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D)
     {X Y : C} {f : X ⟶ Y} {φ : F.obj X ⟶ F.obj Y} (h : F.map f = φ) : F.IsHomLift φ f := by
   cases h
-  exact .map f
+  simp
 
 end IsHomLift
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -283,6 +283,34 @@ instance lift_id_inv_isIso (S : 𝒮) {a b : 𝒳} (φ : a ⟶ b) [IsIso φ] [p.
     p.IsHomLift (𝟙 S) (inv φ) :=
   (IsIso.inv_id (X := S)) ▸ (IsHomLift.inv p _ φ)
 
+lemma comp_vert {C D E : Type*} [Category* C] [Category* D]
+    [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X₁ X₂ : C} {Y₁ Y₂ : D} {Z₁ Z₂ : E} (f : X₁ ⟶ X₂)
+    (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) [F.IsHomLift g f] [G.IsHomLift h g] : (F ⋙ G).IsHomLift h f := by
+  subst_hom_lift G h g
+  subst_hom_lift F g f
+  rw [← Functor.comp_map]
+  exact .map f
+
+lemma of_functor_comp_right {C D E : Type*} [Category* C]
+    [Category* D] [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X₁ X₂ : C} {Y₁ Y₂ : D} {Z₁ Z₂ : E}
+    (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) [F.IsHomLift g f] [(F ⋙ G).IsHomLift h f] :
+    G.IsHomLift h g := by
+  subst_hom_lift F g f
+  subst_hom_lift (F ⋙ G) h f
+  rw [Functor.comp_map]
+  exact .map (F.map f)
+
+lemma comp_iff_of_isHomLift_left {C D E : Type*} [Category* C]
+    [Category* D] [Category* E] (F : C ⥤ D) (G : D ⥤ E) {X₁ X₂ : C} {Y₁ Y₂ : D} {Z₁ Z₂ : E}
+    (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) [F.IsHomLift g f] :
+    (F ⋙ G).IsHomLift h f ↔ G.IsHomLift h g :=
+  ⟨fun _ => IsHomLift.of_functor_comp_right F G f g h,fun _ => IsHomLift.comp_vert F G f g h⟩
+
+lemma of_eq {C D : Type*} [Category* C] [Category* D] (F : C ⥤ D)
+    {X Y : C} {f : X ⟶ Y} {φ : F.obj X ⟶ F.obj Y} (h : F.map f = φ) : F.IsHomLift φ f := by
+  cases h
+  exact .map f
+
 end IsHomLift
 
 end CategoryTheory


### PR DESCRIPTION
This PR defines the "vertical pasting" aspects of homlifts and (strongly) cartesian morphisms, it proves that the composition of fibered functors is fibered, and it proves that if an equivalence of categories has the identity natural transformation as its unit or counit, then the backward or forward directions of that equivalence are fibered functors, respectively.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
