### PR TITLE
[Merged by Bors] - ci(shake.yaml): do not shake Archive and Counterexamples yet

### DIFF
--- a/.github/workflows/shake.yaml
+++ b/.github/workflows/shake.yaml
@@ -35,14 +35,15 @@ jobs:
           use-github-cache: false
           use-mathlib-cache: true
 
-      - name: lake build
-        run: |
-          lake build Mathlib Archive Counterexamples
+      # - name: lake build
+      #   run: |
+      #     lake build Mathlib Archive Counterexamples
 
       - name: lake shake
         id: shake
         run: |
-          lake shake --add-public --keep-implied --keep-prefix --fix --explain Mathlib Archive Counterexamples > explain.txt 2>&1
+          # Add back Archive and Counterexamples when they've been modulized
+          lake shake --add-public --keep-implied --keep-prefix --fix --explain Mathlib > explain.txt 2>&1
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/shake.yaml
+++ b/.github/workflows/shake.yaml
@@ -144,7 +144,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'nightly-testing'
+          to: 'nightly-testing-mathlib'
           type: 'stream'
           topic: 'Mathlib `shake --fix`'
           content: |

--- a/.github/workflows/shake.yaml
+++ b/.github/workflows/shake.yaml
@@ -37,7 +37,7 @@ jobs:
 
       # - name: lake build
       #   run: |
-      #     lake build Mathlib Archive Counterexamples
+      #     lake build Archive Counterexamples
 
       - name: lake shake
         id: shake


### PR DESCRIPTION
Turns out they can't be shaken because thy're not modulized yet.