### PR TITLE
feat(fun_prop): eager application of transition theorems for fun_prop

### DIFF
--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -47,13 +47,13 @@ initialize
     applicationTime := AttributeApplicationTime.afterCompilation
     add   := fun declName stx attrKind =>
        discard <| MetaM.run do
-       let eagerTransition :=
+       let alwaysTryTransition :=
          match stx with
          | `(attr| fun_prop always_try_transition) => true | _ => false
        let info ← getConstInfo declName
        forallTelescope info.type fun _ b => do
          if b.isProp then
-           addFunPropDecl declName eagerTransition
+           addFunPropDecl declName alwaysTryTransition
          else
            addTheorem declName attrKind
     erase := fun _declName =>

--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -22,10 +22,24 @@ namespace Meta.FunProp
 private def funPropHelpString : String :=
 "`fun_prop` tactic to prove function properties like `Continuous`, `Differentiable`, `IsLinearMap`"
 
+/-- The attribute `fun_prop` is used to marks function property definitions like `Continuous`
+and function property theorems like `Continuous.comp`.
+
+Option `always_try_transition`: some definitions can have `@[fun_prop always_try_transition]`
+
+  By default, for performance reasons, `fun_prop` applies transition theorems like
+  `Differentiable ℝ f → Continuous f` only on functions that can not be further decomposed
+  (i.e. written at `f ∘ g` for nontrivial `f` and `g`). This option allows to apply transition
+  theorems at any stage of the proof search.
+
+  This option is important for some function properties like `Integrable` as it does not have
+  general composition theorem stating `Integrable f → Integrable g → Integrable (f ∘ g)` and
+  very often integrability can be inferred from continuity. Therefore we might want to apply,
+  `IsCompact s → ContinuousOn f s → IntegrableOn f s` very early on.-/
 syntax (name := fun_prop) "fun_prop" (&"always_try_transition")? : attr
 
 
-/-- Initialization of `funProp` attribute -/
+@[inherit_doc fun_prop]
 initialize
   registerBuiltinAttribute {
     name  := `fun_prop

--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -22,7 +22,7 @@ namespace Meta.FunProp
 private def funPropHelpString : String :=
 "`fun_prop` tactic to prove function properties like `Continuous`, `Differentiable`, `IsLinearMap`"
 
-syntax (name:=fun_prop) "fun_prop" (&"eager_transition")? : attr
+syntax (name := fun_prop) "fun_prop" (&"always_try_transition")? : attr
 
 
 /-- Initialization of `funProp` attribute -/
@@ -35,7 +35,7 @@ initialize
        discard <| MetaM.run do
        let eagerTransition :=
          match stx with
-         | `(attr| fun_prop eager_transition) => true | _ => false
+         | `(attr| fun_prop always_try_transition) => true | _ => false
        let info ← getConstInfo declName
        forallTelescope info.type fun _ b => do
          if b.isProp then

--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -22,18 +22,24 @@ namespace Meta.FunProp
 private def funPropHelpString : String :=
 "`fun_prop` tactic to prove function properties like `Continuous`, `Differentiable`, `IsLinearMap`"
 
+syntax (name:=fun_prop) "fun_prop" (&"eager_transition")? : attr
+
+
 /-- Initialization of `funProp` attribute -/
 initialize
   registerBuiltinAttribute {
     name  := `fun_prop
     descr := funPropHelpString
     applicationTime := AttributeApplicationTime.afterCompilation
-    add   := fun declName _stx attrKind =>
+    add   := fun declName stx attrKind =>
        discard <| MetaM.run do
+       let eagerTransition :=
+         match stx with
+         | `(attr| fun_prop eager_transition) => true | _ => false
        let info ← getConstInfo declName
        forallTelescope info.type fun _ b => do
          if b.isProp then
-           addFunPropDecl declName
+           addFunPropDecl declName eagerTransition
          else
            addTheorem declName attrKind
     erase := fun _declName =>

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -593,13 +593,14 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     if let some r ← applyMorRules funPropDecl e fData funProp then
       return r
 
-  if let some (f, g) ← fData.nontrivialDecomposition then
-    trace[Meta.Tactic.fun_prop]
-      s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
-         trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
+  if (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0 then
+    if let some (f, g) ← fData.nontrivialDecomposition then
+      trace[Meta.Tactic.fun_prop]
+        s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
+           trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
 
-    if let some r ← applyCompRule funPropDecl e f g funProp then
-      return r
+      if let some r ← applyCompRule funPropDecl e f g funProp then
+        return r
   else
     trace[Meta.Tactic.fun_prop]
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
@@ -607,7 +608,6 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
     if let some r ← applyTransitionRules e funProp then
       return r
-
 
   return none
 

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -530,8 +530,12 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
 
+  let hasCompTheorems := (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0
+  let dec? ← fData.nontrivialDecomposition
+
   -- fvar theorems are almost exclusively in uncurried form so we decompose if we can
-  if let some (f, g) ← fData.nontrivialDecomposition then
+  if hasCompTheorems && dec?.isSome then
+    let some (f, g) := dec? | unreachable!
     applyCompRule funPropDecl e f g funProp
   else
     let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
@@ -552,9 +556,8 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
       if let some r ← applyMorRules funPropDecl e fData funProp then
         return r
 
-    if (← fData.nontrivialDecomposition).isNone then
-      if let some r ← applyTransitionRules e funProp then
-        return r
+    if let some r ← applyTransitionRules e funProp then
+      return r
 
     if thms.size = 0 then
       logError s!"No theorems found for `{← ppExpr (.fvar id)}` in order to prove `{← ppExpr e}`"
@@ -593,14 +596,18 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     if let some r ← applyMorRules funPropDecl e fData funProp then
       return r
 
-  if (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0 then
-    if let some (f, g) ← fData.nontrivialDecomposition then
-      trace[Meta.Tactic.fun_prop]
-        s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
-           trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
+  let hasCompTheorems := (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0
+  let dec? ← fData.nontrivialDecomposition
 
-      if let some r ← applyCompRule funPropDecl e f g funProp then
-        return r
+  if hasCompTheorems && dec?.isSome then
+    let some (f, g) := dec? | unreachable!
+
+    trace[Meta.Tactic.fun_prop]
+      s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
+         trying again after decomposing function as: `({← ppExpr f}) ∘ ({← ppExpr g})`"
+
+    if let some r ← applyCompRule funPropDecl e f g funProp then
+      return r
   else
     trace[Meta.Tactic.fun_prop]
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -559,7 +559,7 @@ def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     if let some r ← applyMorRules funPropDecl e fData funProp then
       return r
 
-  if dec?.isNone || funPropDecl.eagerTransition then
+  if dec?.isNone || funPropDecl.alwaysTryTransition then
     if let some r ← applyTransitionRules e funProp then
       return r
 
@@ -612,7 +612,7 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     if let some r ← applyCompRule funPropDecl e f g funProp then
       return r
 
-  if dec?.isNone || funPropDecl.eagerTransition then
+  if dec?.isNone || funPropDecl.alwaysTryTransition then
     trace[Meta.Tactic.fun_prop]
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
          now trying to prove `{funPropDecl.funPropName}` from another function property"

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -530,39 +530,42 @@ def tryTheorems (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 def fvarAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     (funProp : Expr → FunPropM (Option Result)) : FunPropM (Option Result) := do
 
-  let hasCompTheorems := (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0
+  -- the logic for fvarAppCase application seems to be unnecesarily different from constAppCase
+
   let dec? ← fData.nontrivialDecomposition
 
   -- fvar theorems are almost exclusively in uncurried form so we decompose if we can
-  if hasCompTheorems && dec?.isSome then
+  if dec?.isSome then
     let some (f, g) := dec? | unreachable!
-    applyCompRule funPropDecl e f g funProp
-  else
-    let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
-    let thms ← getLocalTheorems funPropDecl (.fvar id) fData.mainArgs fData.args.size
-    trace[Meta.Tactic.fun_prop]
-      s!"candidate local theorems for {←ppExpr (.fvar id)} \
-         {← thms.mapM fun thm => ppOrigin' thm.thmOrigin}"
-
-    if let some r ← tryTheorems funPropDecl e fData thms funProp then
+    if let some r ← applyCompRule funPropDecl e f g funProp then
       return r
 
-    if let some f ← fData.unfoldHeadFVar? then
-      let e' := e.setArg funPropDecl.funArgId f
-      if let some r ← funProp e' then
-        return r
+  let .fvar id := fData.fn | throwError "fun_prop bug: invalid use of fvar app case"
+  let thms ← getLocalTheorems funPropDecl (.fvar id) fData.mainArgs fData.args.size
+  trace[Meta.Tactic.fun_prop]
+    s!"candidate local theorems for {←ppExpr (.fvar id)} \
+       {← thms.mapM fun thm => ppOrigin' thm.thmOrigin}"
 
-    if (← fData.isMorApplication) != .none then
-      if let some r ← applyMorRules funPropDecl e fData funProp then
-        return r
+  if let some r ← tryTheorems funPropDecl e fData thms funProp then
+    return r
 
+  if let some f ← fData.unfoldHeadFVar? then
+    let e' := e.setArg funPropDecl.funArgId f
+    if let some r ← funProp e' then
+      return r
+
+  if (← fData.isMorApplication) != .none then
+    if let some r ← applyMorRules funPropDecl e fData funProp then
+      return r
+
+  if dec?.isNone || funPropDecl.eagerTransition then
     if let some r ← applyTransitionRules e funProp then
       return r
 
-    if thms.size = 0 then
-      logError s!"No theorems found for `{← ppExpr (.fvar id)}` in order to prove `{← ppExpr e}`"
+  if thms.size = 0 then
+    logError s!"No theorems found for `{← ppExpr (.fvar id)}` in order to prove `{← ppExpr e}`"
 
-    return none
+  return none
 
 
 /-- Prove function property of `fun x ↦ f x₁ ... xₙ` where `f` is declared function. -/
@@ -596,10 +599,9 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
     if let some r ← applyMorRules funPropDecl e fData funProp then
       return r
 
-  let hasCompTheorems := (← getLambdaTheorems funPropDecl.funPropName .comp).size != 0
   let dec? ← fData.nontrivialDecomposition
 
-  if hasCompTheorems && dec?.isSome then
+  if dec?.isSome then
     let some (f, g) := dec? | unreachable!
 
     trace[Meta.Tactic.fun_prop]
@@ -608,7 +610,8 @@ def constAppCase (funPropDecl : FunPropDecl) (e : Expr) (fData : FunctionData)
 
     if let some r ← applyCompRule funPropDecl e f g funProp then
       return r
-  else
+
+  if dec?.isNone || funPropDecl.eagerTransition then
     trace[Meta.Tactic.fun_prop]
       s!"failed applying `{funPropDecl.funPropName}` theorems for `{funName}`
          now trying to prove `{funPropDecl.funPropName}` from another function property"

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -32,8 +32,16 @@ structure FunPropDecl where
   /-- argument index of a function this function property talks about.
   For example, this would be 4 for `@Continuous α β _ _ f` -/
   funArgId : Nat
-  /-- funciton properties like Integrability should apply transition theorems eagerly -/
-  eagerTransition : Bool := false
+  /-- By default, for performance reasons, `fun_prop` applies transition theorems like
+  `Differentiable ℝ f → Continuous f` only on functions that can not be further decomposed
+  (i.e. written at `f ∘ g` for nontrivial `f` and `g`). This option allows to apply transition
+  theorems at any stage of the proof search.
+
+  This option is important for some function properties like `Integrable` as it does not have
+  general composition theorem stating `Integrable f → Integrable g → Integrable (f ∘ g)` and
+  very often integrability can be inferred from continuity. Therefore we might want to apply,
+  `IsCompact s → ContinuousOn f s → IntegrableOn f s` very early on. -/
+  alwaysTryTransition : Bool := false
   deriving Inhabited, BEq
 
 /-- Discrimination tree for function properties. -/
@@ -57,7 +65,7 @@ initialize funPropDeclsExt : FunPropDeclsExt ←
   }
 
 /-- Register new function property. -/
-def addFunPropDecl (declName : Name) (eagerTransition := false) : MetaM Unit := do
+def addFunPropDecl (declName : Name) (alwaysTryTransition := false) : MetaM Unit := do
 
   let info ← getConstInfo declName
 
@@ -82,7 +90,7 @@ def addFunPropDecl (declName : Name) (eagerTransition := false) : MetaM Unit := 
     funPropName := declName
     path := path
     funArgId := funArgId
-    eagerTransition
+    alwaysTryTransition
   }
 
   modifyEnv fun env => funPropDeclsExt.addEntry env decl

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -32,6 +32,8 @@ structure FunPropDecl where
   /-- argument index of a function this function property talks about.
   For example, this would be 4 for `@Continuous α β _ _ f` -/
   funArgId : Nat
+  /-- funciton properties like Integrability should apply transition theorems eagerly -/
+  eagerTransition : Bool := false
   deriving Inhabited, BEq
 
 /-- Discrimination tree for function properties. -/
@@ -55,7 +57,7 @@ initialize funPropDeclsExt : FunPropDeclsExt ←
   }
 
 /-- Register new function property. -/
-def addFunPropDecl (declName : Name) : MetaM Unit := do
+def addFunPropDecl (declName : Name) (eagerTransition := false) : MetaM Unit := do
 
   let info ← getConstInfo declName
 
@@ -80,6 +82,7 @@ def addFunPropDecl (declName : Name) : MetaM Unit := do
     funPropName := declName
     path := path
     funArgId := funArgId
+    eagerTransition
   }
 
   modifyEnv fun env => funPropDeclsExt.addEntry env decl

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -739,7 +739,7 @@ namespace EagerTransition
 
 
 @[fun_prop] opaque Triv {α β} (f : α → β) : Prop
-@[fun_prop eager_transition] opaque Eager {α β} (f : α → β) : Prop
+@[fun_prop always_try_transition] opaque Eager {α β} (f : α → β) : Prop
 @[fun_prop] opaque NonEager {α β} (f : α → β) : Prop
 
 @[fun_prop]

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -733,10 +733,7 @@ example {f : α → FooHom α} (hf : Con f) : Con fun x ↦ f x (f x x x) x := b
 
 end BundledMorphismWithFunctionValues
 
-
-
-namespace EagerTransition
-
+namespace AlwaysTryTransition
 
 @[fun_prop] opaque Triv {α β} (f : α → β) : Prop
 @[fun_prop always_try_transition] opaque Eager {α β} (f : α → β) : Prop
@@ -756,5 +753,4 @@ example (f : β → γ) (g : α → β) : NonEager (fun x => f (g x)) := by
   fail_if_success fun_prop (config:={maxTransitionDepth:=10})
   apply silentSorry
 
-
-end EagerTransition
+end AlwaysTryTransition

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -732,3 +732,29 @@ example {f : α → FooHom α} (hf : Con f) : Con fun x ↦ f x (f x x x) x := b
   fun_prop
 
 end BundledMorphismWithFunctionValues
+
+
+
+namespace EagerTransition
+
+
+@[fun_prop] opaque Triv {α β} (f : α → β) : Prop
+@[fun_prop eager_transition] opaque Eager {α β} (f : α → β) : Prop
+@[fun_prop] opaque NonEager {α β} (f : α → β) : Prop
+
+@[fun_prop]
+theorem triv (f : α → β) : Triv f := silentSorry
+@[fun_prop]
+theorem eager_triv (f : α → β) (hf : Triv f) : Eager f := silentSorry
+@[fun_prop]
+theorem noneager_triv (f : α → β) (hf : Triv f) : NonEager f := silentSorry
+
+example (f : α → β) : Triv f := by fun_prop
+example (f : β → γ) (g : α → β) : Eager (fun x => f x) := by
+  fun_prop (config:={maxTransitionDepth:=10})
+example (f : β → γ) (g : α → β) : NonEager (fun x => f (g x)) := by
+  fail_if_success fun_prop (config:={maxTransitionDepth:=10})
+  apply silentSorry
+
+
+end EagerTransition


### PR DESCRIPTION
For properties like Integrable we want to apply transition theorems(like Continuous -> Integrable) eagerly

---

This is a change necessary in preparation for making `fun_prop` work for integrability.

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
