### PR TITLE
[Merged by Bors] - feat(fun_prop): apply other rules when constant or identity rules do not work

### DIFF
--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -686,21 +686,24 @@ mutual
       let e := e.setArg funPropDecl.funArgId (← fData.toExpr) -- update e with reduced f
 
       if fData.isIdentityFun then
-        applyIdRule funPropDecl e funProp
-      else if fData.isConstantFun then
-        applyConstRule funPropDecl e funProp
-      else
-        match fData.fn with
-        | .fvar id =>
-          if id == fData.mainVar.fvarId! then
-            bvarAppCase funPropDecl e fData funProp
-          else
-            fvarAppCase funPropDecl e fData funProp
-        | .const .. | .proj .. => do
-          constAppCase funPropDecl e fData funProp
-        | _ =>
-          trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: {f.ctorName}\n{e}"
-          return none
+        if let some r ← applyIdRule funPropDecl e funProp then
+          return r
+
+      if fData.isConstantFun then
+        if let some r ← applyConstRule funPropDecl e funProp then
+          return r
+
+      match fData.fn with
+      | .fvar id =>
+        if id == fData.mainVar.fvarId! then
+          bvarAppCase funPropDecl e fData funProp
+        else
+          fvarAppCase funPropDecl e fData funProp
+      | .const .. | .proj .. => do
+        constAppCase funPropDecl e fData funProp
+      | _ =>
+        trace[Debug.Meta.Tactic.fun_prop] "unknown case, ctor: {f.ctorName}\n{e}"
+        return none
 
 end
 

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -231,6 +231,10 @@ def FunctionData.nontrivialDecomposition (fData : FunctionData) : MetaM (Option 
     if fn.containsFVar xId then
       return ← fData.peeloffArgDecomposition
 
+    -- constant function can't be decomposed
+    if fData.mainArgs.size == 0 then
+      return none
+
     let mut yVals : Array Expr := #[]
     let mut yVars : Array Expr := #[]
 

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -732,3 +732,8 @@ example {f : α → FooHom α} (hf : Con f) : Con fun x ↦ f x (f x x x) x := b
   fun_prop
 
 end BundledMorphismWithFunctionValues
+
+
+-- this use to fail when we did not apply other rules when constant lambda rule did not work
+example {β} [Zero β] (f : β → γ) (hf : Lin f) :
+  Lin (fun x : α => f 0) := by fun_prop

--- a/MathlibTest/FunPropMinimal.lean
+++ b/MathlibTest/FunPropMinimal.lean
@@ -737,3 +737,6 @@ end BundledMorphismWithFunctionValues
 -- this use to fail when we did not apply other rules when constant lambda rule did not work
 example {β} [Zero β] (f : β → γ) (hf : Lin f) :
   Lin (fun x : α => f 0) := by fun_prop
+
+example {β} [Zero β] [Add β] :
+  Lin (fun x : α => 0 + 0) := by fun_prop


### PR DESCRIPTION
Function like `fun x => 0 + 0` is linear but applying constant rule `IsLinearMap (fun _ => 0)` would not work and we should apply theorem of add. This change applies other theorems when constant rule fails.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
