### PR TITLE
[Merged by Bors] - chore(Analysis/Distribution/Support): change `grind` to `fun_prop`

### DIFF
--- a/Mathlib/Analysis/Distribution/Support.lean
+++ b/Mathlib/Analysis/Distribution/Support.lean
@@ -53,6 +53,7 @@ variable [Zero V]
 
 To make this definition work for all types of distributions, we define it for any function from
 a `FunLike` type to a type with zero. -/
+@[fun_prop]
 def IsVanishingOn (f : F → V) (s : Set α) : Prop :=
     ∀ (u : F), tsupport u ⊆ s → f u = 0
 
@@ -176,7 +177,7 @@ namespace IsVanishingOn
 
 open scoped Topology
 
-@[grind .]
+@[fun_prop]
 theorem smulLeftCLM (hf : IsVanishingOn f s) {g : E → ℂ} (hg : g.HasTemperateGrowth) :
     IsVanishingOn (smulLeftCLM F g f) s := by
   intro u hu
@@ -186,14 +187,14 @@ theorem smulLeftCLM (hf : IsVanishingOn f s) {g : E → ℂ} (hg : g.HasTemperat
 
 open LineDeriv
 
-@[grind .]
+@[fun_prop]
 theorem lineDerivOp (hf : IsVanishingOn f s) (m : E) :
     IsVanishingOn (∂_{m} f : 𝓢'(E, F)) s := by
   intro u hu
   simp only [lineDerivOp_apply_apply, map_neg, neg_eq_zero]
   exact hf (∂_{m} u) <| (tsupport_fderiv_apply_subset ℝ m).trans hu
 
-@[grind .]
+@[fun_prop]
 theorem iteratedLineDerivOp {n : ℕ} (hf : IsVanishingOn f s) (m : Fin n → E) :
     IsVanishingOn (∂^{m} f : 𝓢'(E, F)) s := by
   induction n with
@@ -202,7 +203,7 @@ theorem iteratedLineDerivOp {n : ℕ} (hf : IsVanishingOn f s) (m : Fin n → E)
   | succ n IH =>
     exact (IH <| Fin.tail m).lineDerivOp (m 0)
 
-@[grind .]
+@[fun_prop]
 theorem _root_.TemperedDistribution.isVanishingOn_delta (x : E) :
     IsVanishingOn (TemperedDistribution.delta x) {x}ᶜ := by
   intro u hu
@@ -215,16 +216,16 @@ section Support
 
 theorem dsupport_smulLeftCLM_subset {g : E → ℂ} (hg : g.HasTemperateGrowth) :
     dsupport (smulLeftCLM F g f) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr; fun_prop
 
 open LineDeriv
 
 theorem dsupport_lineDerivOp_subset (m : E) : dsupport (∂_{m} f : 𝓢'(E, F)) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr; fun_prop
 
 theorem dsupport_iteratedLineDerivOp_subset {n : ℕ} (m : Fin n → E) :
     dsupport (∂^{m} f : 𝓢'(E, F)) ⊆ dsupport f := by
-  gcongr; grind
+  gcongr; fun_prop
 
 theorem dsupport_delta [FiniteDimensional ℝ E] (x : E) :
     dsupport (TemperedDistribution.delta x) = {x} := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
