### PR TITLE
feat(run_auto_param): tactic to run autoParam tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -7289,6 +7289,7 @@ public import Mathlib.Tactic.Ring.NamePolyVars
 public import Mathlib.Tactic.Ring.NamePowerVars
 public import Mathlib.Tactic.Ring.PNat
 public import Mathlib.Tactic.Ring.RingNF
+public import Mathlib.Tactic.RunAutoParam
 public import Mathlib.Tactic.Sat.FromLRAT
 public import Mathlib.Tactic.Says
 public import Mathlib.Tactic.ScopedNS

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -273,6 +273,7 @@ public import Mathlib.Tactic.Ring.NamePolyVars
 public import Mathlib.Tactic.Ring.NamePowerVars
 public import Mathlib.Tactic.Ring.PNat
 public import Mathlib.Tactic.Ring.RingNF
+public import Mathlib.Tactic.RunAutoParam
 public import Mathlib.Tactic.Sat.FromLRAT
 public import Mathlib.Tactic.Says
 public import Mathlib.Tactic.ScopedNS

--- a/Mathlib/Tactic/RunAutoParam.lean
+++ b/Mathlib/Tactic/RunAutoParam.lean
@@ -3,14 +3,18 @@ Copyright (c) 2026 Tomas Skrivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomas Skrivan
 -/
+module
 
-import Lean
+public meta import Lean
 
 /-!
 # Tactic `run_auto_param` is designed to solve goals in the form `autoParam P tac` by executing
 tactic `tac` on the goal `P`. It is mainly meant to be used as a discharger for other tactics like
 `simp` or `fun_prop`.
 -/
+
+public meta section
+
 open Lean Meta Elab Tactic
 
 namespace Mathlib.Meta

--- a/Mathlib/Tactic/RunAutoParam.lean
+++ b/Mathlib/Tactic/RunAutoParam.lean
@@ -1,11 +1,24 @@
-import Lean
--- import Mathlib
+/-
+Copyright (c) 2026 Tomas Skrivan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomas Skrivan
+-/
 
+import Lean
+
+/-!
+# Tactic `run_auto_param` is designed to solve goals in the form `autoParam P tac` by executing
+tactic `tac` on the goal `P`. It is mainly meant to be used as a discharger for other tactics like
+`simp` or `fun_prop`.
+-/
 open Lean Meta Elab Tactic
 
 namespace Mathlib.Meta
 
-private def tacticToDischarge' (tacticCode : Syntax) : TacticM (IO.Ref Term.State × (Expr → MetaM (Option Expr))) := do
+/-- Turns tactic syntax into `Expr → MetaM (Option Expr)`. This function is a direct copy of
+`simp`'s `tacticToDischarge`.-/
+private def tacticToDischarge' (tacticCode : Syntax) :
+    TacticM (IO.Ref Term.State × (Expr → MetaM (Option Expr))) := do
   let tacticCode : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticCode⟩
   let tacticCode ← `(tactic| try ($tacticCode:tacticSeq))
   let ref ← IO.mkRef (← getThe Term.State)
@@ -15,8 +28,9 @@ private def tacticToDischarge' (tacticCode : Syntax) : TacticM (IO.Ref Term.Stat
     let s ← ref.get
     let runTac? : TermElabM (Option Expr) :=
       try
-        /- We must only save messages and info tree changes. Recall that `simp` uses temporary metavariables (`withNewMCtxDepth`).
-           So, we must not save references to them at `Term.State`.
+        /- We must only save messages and info tree changes. Recall that `simp` uses temporary
+           metavariables (`withNewMCtxDepth`). So, we must not save references to them at
+           `Term.State`.
         -/
         Term.withoutModifyingElabMetaStateWithInfo do
           Term.withSynthesize (postpone := .no) do
@@ -33,9 +47,12 @@ private def tacticToDischarge' (tacticCode : Syntax) : TacticM (IO.Ref Term.Stat
     return result?
   return (ref, disch)
 
+/-- Tactic `run_auto_param` is designed to solve goals in the form `autoParam P tac` by executing
+tactic `tac` on the goal `P`. It is mainly meant to be used as a discharger for other tactics like
+`simp` or `fun_prop`. -/
 syntax (name:=runAutoParamStx) "run_auto_param" : tactic
 
-@[tactic runAutoParamStx]
+@[tactic runAutoParamStx, inherit_doc runAutoParamStx]
 def runAutoParam : Tactic := fun _ => do
 
   let goal ← getMainGoal

--- a/Mathlib/Tactic/RunAutoParam.lean
+++ b/Mathlib/Tactic/RunAutoParam.lean
@@ -58,6 +58,12 @@ def runAutoParam : Tactic := fun _ => do
   let goal ← getMainGoal
   let type ← goal.getType
 
+  -- discharge `optParam`
+  if let some defaultValue := type.getOptParamDefault? then
+    goal.assign defaultValue
+    return ()
+
+  -- discharge `autoParam`
   let some (.const tacticDecl _) := type.getAutoParamTactic?
     | return ()
   let type := type.appFn!.appArg!

--- a/Mathlib/Tactic/RunAutoParam.lean
+++ b/Mathlib/Tactic/RunAutoParam.lean
@@ -1,0 +1,58 @@
+import Lean
+-- import Mathlib
+
+open Lean Meta Elab Tactic
+
+namespace Mathlib.Meta
+
+private def tacticToDischarge' (tacticCode : Syntax) : TacticM (IO.Ref Term.State × (Expr → MetaM (Option Expr))) := do
+  let tacticCode : TSyntax `Lean.Parser.Tactic.tacticSeq := ⟨tacticCode⟩
+  let tacticCode ← `(tactic| try ($tacticCode:tacticSeq))
+  let ref ← IO.mkRef (← getThe Term.State)
+  let ctx ← readThe Term.Context
+  let disch : Expr → MetaM (Option Expr) := fun e => do
+    let mvar ← mkFreshExprSyntheticOpaqueMVar e `simp.discharger
+    let s ← ref.get
+    let runTac? : TermElabM (Option Expr) :=
+      try
+        /- We must only save messages and info tree changes. Recall that `simp` uses temporary metavariables (`withNewMCtxDepth`).
+           So, we must not save references to them at `Term.State`.
+        -/
+        Term.withoutModifyingElabMetaStateWithInfo do
+          Term.withSynthesize (postpone := .no) do
+            Term.runTactic (report := false) mvar.mvarId! tacticCode .term
+          let result ← instantiateMVars mvar
+          if result.hasExprMVar then
+            return none
+          else
+            return some result
+      catch _ =>
+        return none
+    let (result?, s) ← Term.TermElabM.run runTac? ctx s
+    ref.set s
+    return result?
+  return (ref, disch)
+
+syntax (name:=runAutoParamStx) "run_auto_param" : tactic
+
+@[tactic runAutoParamStx]
+def runAutoParam : Tactic := fun _ => do
+
+  let goal ← getMainGoal
+  let type ← goal.getType
+
+  let some (.const tacticDecl _) := type.getAutoParamTactic?
+    | return ()
+  let type := type.appFn!.appArg!
+
+  let env ← getEnv
+  let opts ← getOptions
+  let .ok tacticSyntax := evalSyntaxConstant env  opts tacticDecl
+    | return ()
+
+  let (_, disch) ← tacticToDischarge' tacticSyntax
+
+  let some prf ← disch type
+    | return ()
+
+  goal.assign prf

--- a/MathlibTest/RunAutoParam.lean
+++ b/MathlibTest/RunAutoParam.lean
@@ -1,0 +1,10 @@
+import Mathlib.Tactic.RunAutoParam
+
+open Mathlib.Meta
+
+theorem cancel_self_div (x : Nat) (hx : x ≠ 0 := by grind) : x / x = 1 := by
+  simp (disch:=grind)
+
+example (x y : Nat) (hx : x ≠ 0) (hy : y ≠ 0) : (x + y) / (x + y) = 1 := by
+  fail_if_success simp
+  simp (disch:=run_auto_param) only [cancel_self_div]


### PR DESCRIPTION
Tactic `run_auto_param` is designed to solve goals in the form `autoParam P tac` by executing
tactic `tac` on the goal `P`. It is mainly meant to be used as a discharger for other tactics like
`simp` or `fun_prop`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
