### PR TITLE
feat(FunProp): tag `Monotone` and friends

### DIFF
--- a/Mathlib/Order/Monotone/Defs.lean
+++ b/Mathlib/Order/Monotone/Defs.lean
@@ -9,6 +9,7 @@ public import Mathlib.Data.Set.Operations
 public import Mathlib.Logic.Function.Iterate
 public import Mathlib.Order.Basic
 public import Mathlib.Tactic.Coe
+public import Mathlib.Tactic.FunProp
 
 /-!
 # Monotonicity
@@ -59,36 +60,42 @@ section MonotoneDef
 variable [Preorder α] [Preorder β]
 
 /-- A function `f` is monotone if `a ≤ b` implies `f a ≤ f b`. -/
+@[fun_prop]
 def Monotone (f : α → β) : Prop :=
   ∀ ⦃a b⦄, a ≤ b → f a ≤ f b
 
 to_dual_insert_cast Monotone := forall_comm.eq
 
 /-- A function `f` is antitone if `a ≤ b` implies `f b ≤ f a`. -/
+@[fun_prop]
 def Antitone (f : α → β) : Prop :=
   ∀ ⦃a b⦄, a ≤ b → f b ≤ f a
 
 to_dual_insert_cast Antitone := forall_comm.eq
 
 /-- A function `f` is monotone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f a ≤ f b`. -/
+@[fun_prop]
 def MonotoneOn (f : α → β) (s : Set α) : Prop :=
   ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f a ≤ f b
 
 to_dual_insert_cast MonotoneOn := by grind only
 
 /-- A function `f` is antitone on `s` if, for all `a, b ∈ s`, `a ≤ b` implies `f b ≤ f a`. -/
+@[fun_prop]
 def AntitoneOn (f : α → β) (s : Set α) : Prop :=
   ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a ≤ b → f b ≤ f a
 
 to_dual_insert_cast AntitoneOn := by grind only
 
 /-- A function `f` is strictly monotone if `a < b` implies `f a < f b`. -/
+@[fun_prop]
 def StrictMono (f : α → β) : Prop :=
   ∀ ⦃a b⦄, a < b → f a < f b
 
 to_dual_insert_cast StrictMono := forall_comm.eq
 
 /-- A function `f` is strictly antitone if `a < b` implies `f b < f a`. -/
+@[fun_prop]
 def StrictAnti (f : α → β) : Prop :=
   ∀ ⦃a b⦄, a < b → f b < f a
 
@@ -96,6 +103,7 @@ to_dual_insert_cast StrictAnti := forall_comm.eq
 
 /-- A function `f` is strictly monotone on `s` if, for all `a, b ∈ s`, `a < b` implies
 `f a < f b`. -/
+@[fun_prop]
 def StrictMonoOn (f : α → β) (s : Set α) : Prop :=
   ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f a < f b
 
@@ -103,6 +111,7 @@ to_dual_insert_cast StrictMonoOn := by grind only
 
 /-- A function `f` is strictly antitone on `s` if, for all `a, b ∈ s`, `a < b` implies
 `f b < f a`. -/
+@[fun_prop]
 def StrictAntiOn (f : α → β) (s : Set α) : Prop :=
   ∀ ⦃a⦄ (_ : a ∈ s) ⦃b⦄ (_ : b ∈ s), a < b → f b < f a
 
@@ -199,9 +208,11 @@ theorem StrictMono.imp (hf : StrictMono f) (h : a < b) : f a < f b :=
 theorem StrictAnti.imp (hf : StrictAnti f) (h : a < b) : f b < f a :=
   hf h
 
+@[fun_prop]
 protected theorem Monotone.monotoneOn (hf : Monotone f) (s : Set α) : MonotoneOn f s :=
   fun _ _ _ _ ↦ hf.imp
 
+@[fun_prop]
 protected theorem Antitone.antitoneOn (hf : Antitone f) (s : Set α) : AntitoneOn f s :=
   fun _ _ _ _ ↦ hf.imp
 
@@ -211,9 +222,11 @@ protected theorem Antitone.antitoneOn (hf : Antitone f) (s : Set α) : AntitoneO
 @[simp] theorem antitoneOn_univ : AntitoneOn f Set.univ ↔ Antitone f :=
   ⟨fun h _ _ ↦ h trivial trivial, fun h ↦ h.antitoneOn _⟩
 
+@[fun_prop]
 protected theorem StrictMono.strictMonoOn (hf : StrictMono f) (s : Set α) : StrictMonoOn f s :=
   fun _ _ _ _ ↦ hf.imp
 
+@[fun_prop]
 protected theorem StrictAnti.strictAntiOn (hf : StrictAnti f) (s : Set α) : StrictAntiOn f s :=
   fun _ _ _ _ ↦ hf.imp
 
@@ -229,9 +242,11 @@ section PartialOrder
 
 variable [PartialOrder β] {f : α → β}
 
+@[fun_prop]
 theorem Monotone.strictMono_of_injective (h₁ : Monotone f) (h₂ : Injective f) : StrictMono f :=
   fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H
 
+@[fun_prop]
 theorem Antitone.strictAnti_of_injective (h₁ : Antitone f) (h₂ : Injective f) : StrictAnti f :=
   fun _ _ h ↦ (h₁ h.le).lt_of_ne fun H ↦ h.ne <| h₂ H.symm
 
@@ -267,15 +282,19 @@ theorem antitoneOn_iff_forall_lt :
 
 -- `Preorder α` isn't strong enough: if the preorder on `α` is an equivalence relation,
 -- then `StrictMono f` is vacuously true.
+@[fun_prop]
 protected theorem StrictMonoOn.monotoneOn (hf : StrictMonoOn f s) : MonotoneOn f s :=
   monotoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
 
+@[fun_prop]
 protected theorem StrictAntiOn.antitoneOn (hf : StrictAntiOn f s) : AntitoneOn f s :=
   antitoneOn_iff_forall_lt.2 fun _ ha _ hb h ↦ (hf ha hb h).le
 
+@[fun_prop]
 protected theorem StrictMono.monotone (hf : StrictMono f) : Monotone f :=
   monotone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
 
+@[fun_prop]
 protected theorem StrictAnti.antitone (hf : StrictAnti f) : Antitone f :=
   antitone_iff_forall_lt.2 fun _ _ h ↦ (hf h).le
 
@@ -311,24 +330,32 @@ end Subsingleton
 /-! ### Miscellaneous monotonicity results -/
 
 
+@[fun_prop]
 theorem monotone_id [Preorder α] : Monotone (id : α → α) := fun _ _ ↦ id
 
+@[fun_prop]
 theorem monotoneOn_id [Preorder α] {s : Set α} : MonotoneOn id s := fun _ _ _ _ ↦ id
 
+@[fun_prop]
 theorem strictMono_id [Preorder α] : StrictMono (id : α → α) := fun _ _ ↦ id
 
+@[fun_prop]
 theorem strictMonoOn_id [Preorder α] {s : Set α} : StrictMonoOn id s := fun _ _ _ _ ↦ id
 
+@[fun_prop]
 theorem monotone_const [Preorder α] [Preorder β] {c : β} : Monotone fun _ : α ↦ c :=
   fun _ _ _ ↦ le_rfl
 
+@[fun_prop]
 theorem monotoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
     MonotoneOn (fun _ : α ↦ c) s :=
   fun _ _ _ _ _ ↦ le_rfl
 
+@[fun_prop]
 theorem antitone_const [Preorder α] [Preorder β] {c : β} : Antitone fun _ : α ↦ c :=
   fun _ _ _ ↦ le_refl c
 
+@[fun_prop]
 theorem antitoneOn_const [Preorder α] [Preorder β] {c : β} {s : Set α} :
     AntitoneOn (fun _ : α ↦ c) s :=
   fun _ _ _ _ _ ↦ le_rfl
@@ -366,90 +393,116 @@ section Composition
 
 variable [Preorder α] [Preorder β] [Preorder γ] {g : β → γ} {f : α → β} {s : Set α} {t : Set β}
 
+@[fun_prop]
 protected theorem Monotone.comp (hg : Monotone g) (hf : Monotone f) : Monotone (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 theorem Monotone.comp_antitone (hg : Monotone g) (hf : Antitone f) : Antitone (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 protected theorem Antitone.comp (hg : Antitone g) (hf : Antitone f) : Monotone (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 theorem Antitone.comp_monotone (hg : Antitone g) (hf : Monotone f) : Antitone (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 protected theorem Monotone.iterate {f : α → α} (hf : Monotone f) (n : ℕ) : Monotone f^[n] :=
   Nat.recOn n monotone_id fun _ h ↦ h.comp hf
 
+@[fun_prop]
 protected theorem Monotone.comp_monotoneOn (hg : Monotone g) (hf : MonotoneOn f s) :
     MonotoneOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 theorem Monotone.comp_antitoneOn (hg : Monotone g) (hf : AntitoneOn f s) : AntitoneOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 protected theorem Antitone.comp_antitoneOn (hg : Antitone g) (hf : AntitoneOn f s) :
     MonotoneOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 theorem Antitone.comp_monotoneOn (hg : Antitone g) (hf : MonotoneOn f s) : AntitoneOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 protected theorem StrictMono.comp (hg : StrictMono g) (hf : StrictMono f) : StrictMono (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 theorem StrictMono.comp_strictAnti (hg : StrictMono g) (hf : StrictAnti f) : StrictAnti (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 protected theorem StrictAnti.comp (hg : StrictAnti g) (hf : StrictAnti f) : StrictMono (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 theorem StrictAnti.comp_strictMono (hg : StrictAnti g) (hf : StrictMono f) : StrictAnti (g ∘ f) :=
   fun _ _ h ↦ hg (hf h)
 
+@[fun_prop]
 protected theorem StrictMono.iterate {f : α → α} (hf : StrictMono f) (n : ℕ) : StrictMono f^[n] :=
   Nat.recOn n strictMono_id fun _ h ↦ h.comp hf
 
+@[fun_prop]
 protected theorem StrictMono.comp_strictMonoOn (hg : StrictMono g) (hf : StrictMonoOn f s) :
     StrictMonoOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 theorem StrictMono.comp_strictAntiOn (hg : StrictMono g) (hf : StrictAntiOn f s) :
     StrictAntiOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 protected theorem StrictAnti.comp_strictAntiOn (hg : StrictAnti g) (hf : StrictAntiOn f s) :
     StrictMonoOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 theorem StrictAnti.comp_strictMonoOn (hg : StrictAnti g) (hf : StrictMonoOn f s) :
     StrictAntiOn (g ∘ f) s :=
   fun _ ha _ hb h ↦ hg (hf ha hb h)
 
+@[fun_prop]
 lemma MonotoneOn.comp (hg : MonotoneOn g t) (hf : MonotoneOn f s) (hs : Set.MapsTo f s t) :
     MonotoneOn (g ∘ f) s := fun _x hx _y hy hxy ↦ hg (hs hx) (hs hy) <| hf hx hy hxy
 
+@[fun_prop]
 lemma MonotoneOn.comp_AntitoneOn (hg : MonotoneOn g t) (hf : AntitoneOn f s)
     (hs : Set.MapsTo f s t) : AntitoneOn (g ∘ f) s := fun _x hx _y hy hxy ↦
   hg (hs hy) (hs hx) <| hf hx hy hxy
 
+@[fun_prop]
 lemma AntitoneOn.comp (hg : AntitoneOn g t) (hf : AntitoneOn f s) (hs : Set.MapsTo f s t) :
     MonotoneOn (g ∘ f) s := fun _x hx _y hy hxy ↦ hg (hs hy) (hs hx) <| hf hx hy hxy
 
+@[fun_prop]
 lemma AntitoneOn.comp_MonotoneOn (hg : AntitoneOn g t) (hf : MonotoneOn f s)
     (hs : Set.MapsTo f s t) : AntitoneOn (g ∘ f) s := fun _x hx _y hy hxy ↦
   hg (hs hx) (hs hy) <| hf hx hy hxy
 
+@[fun_prop]
 lemma StrictMonoOn.comp (hg : StrictMonoOn g t) (hf : StrictMonoOn f s) (hs : Set.MapsTo f s t) :
     StrictMonoOn (g ∘ f) s := fun _x hx _y hy hxy ↦ hg (hs hx) (hs hy) <| hf hx hy hxy
 
+@[fun_prop]
 lemma StrictMonoOn.comp_strictAntiOn (hg : StrictMonoOn g t) (hf : StrictAntiOn f s)
     (hs : Set.MapsTo f s t) : StrictAntiOn (g ∘ f) s := fun _x hx _y hy hxy ↦
   hg (hs hy) (hs hx) <| hf hx hy hxy
 
+@[fun_prop]
 lemma StrictAntiOn.comp (hg : StrictAntiOn g t) (hf : StrictAntiOn f s) (hs : Set.MapsTo f s t) :
     StrictMonoOn (g ∘ f) s := fun _x hx _y hy hxy ↦ hg (hs hy) (hs hx) <| hf hx hy hxy
 
+@[fun_prop]
 lemma StrictAntiOn.comp_strictMonoOn (hg : StrictAntiOn g t) (hf : StrictMonoOn f s)
     (hs : Set.MapsTo f s t) : StrictAntiOn (g ∘ f) s := fun _x hx _y hy hxy ↦
   hg (hs hx) (hs hy) <| hf hx hy hxy
@@ -491,9 +544,11 @@ end Preorder
 
 end LinearOrder
 
+@[fun_prop]
 theorem Subtype.mono_coe [Preorder α] (p : α → Prop) : Monotone ((↑) : Subtype p → α) :=
   fun _ _ ↦ id
 
+@[fun_prop]
 theorem Subtype.strictMono_coe [Preorder α] (p : α → Prop) :
     StrictMono ((↑) : Subtype p → α) :=
   fun _ _ ↦ id
@@ -502,21 +557,26 @@ section Preorder
 
 variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
 
+@[fun_prop]
 theorem monotone_fst : Monotone (@Prod.fst α β) := fun _ _ ↦ And.left
 
+@[fun_prop]
 theorem monotone_snd : Monotone (@Prod.snd α β) := fun _ _ ↦ And.right
 
 theorem monotone_prodMk_iff {f : γ → α} {g : γ → β} :
     Monotone (fun x => (f x, g x)) ↔ Monotone f ∧ Monotone g := by
   simp_rw [Monotone, Prod.mk_le_mk, forall_and]
 
+@[fun_prop]
 theorem Monotone.prodMk {f : γ → α} {g : γ → β} (hf : Monotone f) (hg : Monotone g) :
     Monotone (fun x => (f x, g x)) :=
   monotone_prodMk_iff.2 ⟨hf, hg⟩
 
+@[fun_prop]
 theorem Monotone.prodMap (hf : Monotone f) (hg : Monotone g) : Monotone (Prod.map f g) :=
   fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
 
+@[fun_prop]
 theorem Antitone.prodMap (hf : Antitone f) (hg : Antitone g) : Antitone (Prod.map f g) :=
   fun _ _ h ↦ ⟨hf h.1, hg h.2⟩
 
@@ -538,11 +598,13 @@ section PartialOrder
 
 variable [PartialOrder α] [PartialOrder β] [Preorder γ] [Preorder δ] {f : α → γ} {g : β → δ}
 
+@[fun_prop]
 theorem StrictMono.prodMap (hf : StrictMono f) (hg : StrictMono g) : StrictMono (Prod.map f g) :=
   fun a b ↦ by
   simp only [Prod.lt_iff]
   exact Or.imp (And.imp hf.imp hg.monotone.imp) (And.imp hf.monotone.imp hg.imp)
 
+@[fun_prop]
 theorem StrictAnti.prodMap (hf : StrictAnti f) (hg : StrictAnti g) : StrictAnti (Prod.map f g) :=
   fun a b ↦ by
   simp only [Prod.lt_iff]
@@ -557,8 +619,10 @@ namespace Function
 variable [Preorder α] [DecidableEq ι] [∀ i, Preorder (π i)] {f : ∀ i, π i} {i : ι}
 
 -- Porting note: Dot notation breaks in `f.update i`
+@[fun_prop]
 theorem update_mono : Monotone (update f i) := fun _ _ => update_le_update_iff'.2
 
+@[fun_prop]
 theorem update_strictMono : StrictMono (update f i) := fun _ _ => update_lt_update_iff.2
 
 theorem const_mono : Monotone (const β : α → β → α) := fun _ _ h _ ↦ h


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
