### PR TITLE
chore: de-continuity

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
@@ -99,7 +99,7 @@ lemma toSSet_map_const (X : TopCat.{u}) {Y : TopCat.{u}} (y : Y) :
 lemma toSSetObjEquiv_symm_naturality {X : TopCat.{u}} {n m : SimplexCategory} (f : n ⟶ m)
     (g : C((stdSimplex ℝ (Fin (m.len + 1))), X)) :
     (toSSet.obj X).map f.op ((X.toSSetObjEquiv _).symm g) =
-      (X.toSSetObjEquiv _).symm (g.comp ⟨stdSimplex.map f, by sorry⟩) := -- XXX was continuity!
+      (X.toSSetObjEquiv _).symm (g.comp ⟨stdSimplex.map f, by fun_prop⟩) :=
   rfl
 
 @[simp]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
@@ -99,7 +99,7 @@ lemma toSSet_map_const (X : TopCat.{u}) {Y : TopCat.{u}} (y : Y) :
 lemma toSSetObjEquiv_symm_naturality {X : TopCat.{u}} {n m : SimplexCategory} (f : n ⟶ m)
     (g : C((stdSimplex ℝ (Fin (m.len + 1))), X)) :
     (toSSet.obj X).map f.op ((X.toSSetObjEquiv _).symm g) =
-      (X.toSSetObjEquiv _).symm (g.comp ⟨stdSimplex.map f, by continuity⟩) :=
+      (X.toSSetObjEquiv _).symm (g.comp ⟨stdSimplex.map f, by sorry⟩) := -- XXX was continuity!
   rfl
 
 @[simp]

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -347,7 +347,7 @@ lemma map_vertex [DecidableEq X] [DecidableEq Y] (f : X → Y) (x : X) :
     map (S := S) f (vertex x) = vertex (f x) := by
   aesop
 
-@[continuity]
+@[continuity, fun_prop]
 lemma continuous_map [TopologicalSpace S] [IsTopologicalSemiring S] (f : X → Y) :
     Continuous (map (S := S) f) :=
   Continuous.subtype_mk ((FunOnFinite.continuous_linearMap S S f).comp continuous_induced_dom) _

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -87,7 +87,8 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u}) : X.toLightCondSet.toT
   { toFun x := x.1 PUnit.unit
     continuous_toFun := by
       rw [continuous_coinduced_dom]
-      continuity }
+      -- XXX: check here! was continuity
+      sorry }
 
 /-- The counit of the adjunction `lightCondSetToTopCat ⊣ topCatToLightCondSet` is always bijective,
 but not an isomorphism in general (the inverse isn't continuous unless `X` is sequential).

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -87,8 +87,14 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u}) : X.toLightCondSet.toT
   { toFun x := x.1 PUnit.unit
     continuous_toFun := by
       rw [continuous_coinduced_dom]
+      apply continuous_sigma
+      intro i
+      --apply Sigma.casesOn
+      --fun_prop
+      --grind [Sigma.casesOn]
+      show_term continuity
       -- XXX: check here! was continuity
-      sorry }
+       }
 
 /-- The counit of the adjunction `lightCondSetToTopCat ⊣ topCatToLightCondSet` is always bijective,
 but not an isomorphism in general (the inverse isn't continuous unless `X` is sequential).

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -88,6 +88,9 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u + 1}) : X.toCondensedSet
   { toFun x := x.1 PUnit.unit
     continuous_toFun := by
       rw [continuous_coinduced_dom]
+      apply continuous_sigma
+      intro i
+      dsimp
       -- XXX: check here! was continuity
       sorry }
 

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -88,7 +88,8 @@ noncomputable def topCatAdjunctionCounit (X : TopCat.{u + 1}) : X.toCondensedSet
   { toFun x := x.1 PUnit.unit
     continuous_toFun := by
       rw [continuous_coinduced_dom]
-      continuity }
+      -- XXX: check here! was continuity
+      sorry }
 
 /-- `simp`-normal form of the lemma that `@[simps]` would generate. -/
 @[simp] lemma topCatAdjunctionCounit_hom_apply (X : TopCat) (x) :

--- a/Mathlib/Topology/Algebra/MvPolynomial.lean
+++ b/Mathlib/Topology/Algebra/MvPolynomial.lean
@@ -26,4 +26,4 @@ variable {X σ : Type*} [TopologicalSpace X] [CommSemiring X] [IsTopologicalSemi
   (p : MvPolynomial σ X)
 
 theorem MvPolynomial.continuous_eval : Continuous fun x ↦ eval x p := by
-  continuity
+  sorry --continuity -- XXX: todo!

--- a/Mathlib/Topology/Algebra/MvPolynomial.lean
+++ b/Mathlib/Topology/Algebra/MvPolynomial.lean
@@ -25,5 +25,9 @@ public section
 variable {X σ : Type*} [TopologicalSpace X] [CommSemiring X] [IsTopologicalSemiring X]
   (p : MvPolynomial σ X)
 
+attribute [fun_prop] continuous_finsetSum continuous_finsetProd
 theorem MvPolynomial.continuous_eval : Continuous fun x ↦ eval x p := by
-  sorry --continuity -- XXX: todo!
+  apply continuous_finsetSum -- was all just `continuity`, TODO!
+  intro i a
+  apply Continuous.comp' (by fun_prop)
+  apply continuous_finsetProd; fun_prop

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
@@ -37,7 +37,8 @@ theorem exists_out_continuousLinearMap :
   rcases (mkCLM K E).toLinearMap.exists_rightInverse_of_surjective
     (LinearMap.range_eq_top.mpr surjective_mk) with ⟨f, hf⟩
   replace hf : mk ∘ f = id := congr_arg DFunLike.coe hf
-  exact ⟨⟨f, isInducing_mk.continuous_iff.2 (by continuity)⟩, DFunLike.ext' hf⟩
+  -- XXX: check here!
+  exact ⟨⟨f, isInducing_mk.continuous_iff.2 (by sorry)⟩, DFunLike.ext' hf⟩
 
 /-- A continuous `K`-linear map from `SeparationQuotient E` to `E`
 such that `mk (outCLM x) = x` for all `x`. -/

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -86,7 +86,10 @@ def sigmaCofan {ι : Type v} (α : ι → TopCat.{max v u}) : Cofan α :=
 def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCat.{max v u}) : IsColimit (sigmaCofan β) where
   desc S := ofHom
     { toFun := fun (s : of (Σ i, β i)) => S.ι.app ⟨s.1⟩ s.2
-      continuous_toFun := by continuity }
+      continuous_toFun := by
+        simp only [Discrete.functor_obj_eq_as, Functor.const_obj_obj, continuous_sigma_iff]
+        intro i
+        exact map_continuous (ConcreteCategory.hom (S.ι.app { as := i })) }
   uniq := by
     intro S m h
     ext ⟨i, x⟩

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -75,7 +75,8 @@ theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
   refine ofHom (ContinuousMap.mk ?_ ?_)
   · apply Sigma.mk i
-  · sorry -- XXX continuity
+  · dsimp -- TODO: make fun_prop after the compositional form bug is fixed!
+    exact continuous_sigmaMk
 
 /-- The explicit cofan of a family of topological spaces given by the sigma type. -/
 @[simps! pt ι_app]

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -75,7 +75,7 @@ theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
   refine ofHom (ContinuousMap.mk ?_ ?_)
   · apply Sigma.mk i
-  · continuity
+  · sorry -- XXX continuity
 
 /-- The explicit cofan of a family of topological spaces given by the sigma type. -/
 @[simps! pt ι_app]

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -75,8 +75,7 @@ theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
   refine ofHom (ContinuousMap.mk ?_ ?_)
   · apply Sigma.mk i
-  · dsimp -- TODO: make fun_prop after the compositional form bug is fixed!
-    exact continuous_sigmaMk
+  · exact continuous_sigmaMk -- unclear why fun_prop can't do this!
 
 /-- The explicit cofan of a family of topological spaces given by the sigma type. -/
 @[simps! pt ι_app]

--- a/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
+++ b/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
@@ -70,7 +70,8 @@ lemma continuous_from_compactlyGenerated [TopologicalSpace X] [t : TopologicalSp
     (h : ∀ (S : CompHaus.{u}) (g : C(S, X)), Continuous (f ∘ g)) :
         Continuous[compactlyGenerated.{u} X, t] f := by
   rw [continuous_coinduced_dom]
-  continuity
+  dsimp
+  sorry -- XXX continuity
 
 /--
 A topological space `X` is compactly generated if its topology is finer than (and thus equal to)

--- a/Mathlib/Topology/ContinuousMap/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Basic.lean
@@ -219,7 +219,16 @@ each term. This is `Sigma.uncurry` for continuous maps.
 @[simps]
 def sigma (f : ∀ i, C(X i, A)) : C((Σ i, X i), A) where
   toFun ig := f ig.fst ig.snd
-  continuous_toFun := by continuity
+  continuous_toFun := continuous_sigma (by grind [map_continuous])
+    --show_term continuity
+    --intro i
+    --have : Continuous (f i) := by show_term fun_prop
+    --show_term continuity
+    --grind [map_continuous]
+    --dsimp
+    --show_term fun_prop
+    --#check continuous_sigma_iff
+    --sorry--dsimp; fun_prop
 
 variable (A X) in
 /--


### PR DESCRIPTION
---

- [x] depends on: #39343
- [x] depends on: #39358
- [x] depends on: #39359

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
