### PR TITLE
[Merged by Bors] - chore: add SeparationQuotient.continuous_lift and mark as fun_prop

### DIFF
--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -409,7 +409,7 @@ noncomputable def liftCLM {σ : R →+* S} (f : M →SL[σ] N) (hf : ∀ x y, In
   toFun := SeparationQuotient.lift f hf
   map_add' := Quotient.ind₂ <| map_add f
   map_smul' {r} := Quotient.ind <| map_smulₛₗ f r
-  cont := by continuity
+  cont := by fun_prop
 
 @[simp]
 theorem liftCLM_mk {σ : R →+* S} (f : M →SL[σ] N) (hf : ∀ x y, Inseparable x y → f x = f y)

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Hom.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Hom.lean
@@ -32,7 +32,7 @@ noncomputable def liftContinuousMonoidHom [CommMonoid M] [ContinuousMul M] [Comm
   toFun := SeparationQuotient.lift f hf
   map_one' := map_one f
   map_mul' := Quotient.ind₂ <| map_mul f
-  continuous_toFun := continuous_lift_iff.mpr f.2
+  continuous_toFun := continuous_lift f.2
 
 @[to_additive (attr := simp)]
 theorem liftContinuousCommMonoidHom_mk [CommMonoid M] [ContinuousMul M] [CommMonoid N]

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Hom.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Hom.lean
@@ -32,7 +32,7 @@ noncomputable def liftContinuousMonoidHom [CommMonoid M] [ContinuousMul M] [Comm
   toFun := SeparationQuotient.lift f hf
   map_one' := map_one f
   map_mul' := Quotient.ind₂ <| map_mul f
-  continuous_toFun := SeparationQuotient.continuous_lift.mpr f.2
+  continuous_toFun := continuous_lift_iff.mpr f.2
 
 @[to_additive (attr := simp)]
 theorem liftContinuousCommMonoidHom_mk [CommMonoid M] [ContinuousMul M] [CommMonoid N]

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -725,9 +725,12 @@ theorem continuousOn_lift {hf : ∀ x y, (x ~ᵢ y) → f x = f y} {s : Set (Sep
   simp only [ContinuousOn, surjective_mk.forall, continuousWithinAt_lift, mem_preimage]
 
 @[simp]
-theorem continuous_lift {hf : ∀ x y, (x ~ᵢ y) → f x = f y} :
+theorem continuous_lift_iff {hf : ∀ x y, (x ~ᵢ y) → f x = f y} :
     Continuous (lift f hf) ↔ Continuous f := by
   simp only [← continuousOn_univ, continuousOn_lift, preimage_univ]
+
+alias ⟨_, continuous_lift⟩ := continuous_lift_iff
+attribute [fun_prop] continuous_lift
 
 /-- Lift a map `f : X → Y → α` such that `Inseparable a b → Inseparable c d → f a c = f b d` to a
 map `SeparationQuotient X → SeparationQuotient Y → α`. -/


### PR DESCRIPTION
Rename the existing `SeparationQuotient.continuous_lift` (which is an iff) to `continuous_lift_iff`, and add an alias for the converse direction. Use this to golf a proof using fun_prop.

Extracted from #39337.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
