### PR TITLE
[Merged by Bors] - feat(Analysis/Complex): add `HasDerivWithinAt.ofReal_comp`

### DIFF
--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -104,4 +104,9 @@ theorem HasDerivAt.ofReal_comp {f : ℝ → ℝ} {u : ℝ} (hf : HasDerivAt f u 
   simpa only [ofRealCLM_apply, ofReal_one, real_smul, mul_one] using
     ofRealCLM.hasDerivAt.scomp z hf
 
+theorem HasDerivWithinAt.ofReal_comp {f : ℝ → ℝ} {s : Set ℝ} {u : ℝ}
+    (hf : HasDerivWithinAt f u s z) : HasDerivWithinAt (fun y : ℝ => ↑(f y) : ℝ → ℂ) u s z := by
+  simpa only [Function.comp_apply, ofRealCLM_apply] using
+    ofRealCLM.hasFDerivAt.comp_hasDerivWithinAt z hf
+
 end RealDerivOfComplex


### PR DESCRIPTION
---
`HasDerivWithinAt` version of the existing lemma `HasDerivAt.ofReal_comp`

Used in https://github.com/roos-j/lean-oscillatory


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
