### PR TITLE
feat(InformationTheory/Shannon): define discrete Shannon entropy and max-entropy bound

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4802,6 +4802,7 @@ public import Mathlib.InformationTheory.Hamming
 public import Mathlib.InformationTheory.KullbackLeibler.Basic
 public import Mathlib.InformationTheory.KullbackLeibler.ChainRule
 public import Mathlib.InformationTheory.KullbackLeibler.KLFun
+public import Mathlib.InformationTheory.Shannon
 public import Mathlib.Init
 public import Mathlib.Lean.ContextInfo
 public import Mathlib.Lean.CoreM

--- a/Mathlib/InformationTheory/Shannon.lean
+++ b/Mathlib/InformationTheory/Shannon.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Victor Boscaro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Victor Boscaro
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+public import Mathlib.Analysis.SpecialFunctions.Log.Basic
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Algebra.BigOperators.Ring.Finset
+public import Mathlib.Data.Finset.Card
+
+/-!
+# Discrete Shannon entropy
+
+This file defines the discrete Shannon entropy of a finitely-supported probability
+distribution and proves the maximum-entropy bound: the entropy of any probability
+distribution on a finite set `S` is at most `Real.log |S|`. This is the discrete
+Gibbs inequality with the uniform reference distribution.
+
+## Main definitions
+
+* `Shannon.entropy`: discrete Shannon entropy `∑ x ∈ S, negMulLog (p x)` of a function
+  `p : α → ℝ` over a `Finset`.
+
+## Main results
+
+* `Shannon.entropy_le_log_card`: for any nonneg `p` summing to `1` over a finite set `S`,
+  `Shannon.entropy p S ≤ Real.log S.card`.
+
+## References
+
+* [Shannon, *A Mathematical Theory of Communication*][shannon1948]
+
+## Tags
+
+information theory, entropy, Shannon entropy, maximum entropy
+-/
+
+@[expose] public section
+
+namespace Shannon
+
+/-- Discrete Shannon entropy of `p : α → ℝ` summed over a finite set `S`. -/
+noncomputable def entropy {α : Type*} (p : α → ℝ) (S : Finset α) : ℝ :=
+  ∑ x ∈ S, Real.negMulLog (p x)
+
+/-- **Maximum-entropy bound.** A nonneg function `p : α → ℝ` with total mass `1` over a
+finite set `S` has discrete entropy at most `Real.log |S|`. -/
+theorem entropy_le_log_card {α : Type*} {p : α → ℝ} {S : Finset α}
+    (hp_nn : ∀ x ∈ S, 0 ≤ p x) (hp_sum : ∑ x ∈ S, p x = 1) :
+    entropy p S ≤ Real.log S.card := by
+  have hS_ne : S.Nonempty := by
+    rcases Finset.eq_empty_or_nonempty S with rfl | hne
+    · simp at hp_sum
+    · exact hne
+  set n : ℝ := (S.card : ℝ) with hn_def
+  have hn_pos : 0 < n := by
+    rw [hn_def]; exact_mod_cast Finset.card_pos.mpr hS_ne
+  have key : ∀ x ∈ S, p x * n - 1 ≤ (p x * n) * Real.log (p x * n) := fun x hx =>
+    Real.self_sub_one_le_mul_log (mul_nonneg (hp_nn x hx) hn_pos.le)
+  have sum_ineq : ∑ x ∈ S, (p x * n - 1) ≤ ∑ x ∈ S, (p x * n) * Real.log (p x * n) :=
+    Finset.sum_le_sum key
+  have lhs_zero : ∑ x ∈ S, (p x * n - 1) = 0 := by
+    have h1 : ∑ x ∈ S, p x * n = n := by
+      rw [show (∑ x ∈ S, p x * n) = (∑ x ∈ S, p x) * n from (Finset.sum_mul ..).symm,
+          hp_sum, one_mul]
+    rw [Finset.sum_sub_distrib, h1, Finset.sum_const, Nat.smul_one_eq_cast, hn_def]
+    ring
+  have rhs_pointwise : ∀ x ∈ S, (p x * n) * Real.log (p x * n)
+      = n * (p x * Real.log (p x)) + p x * (n * Real.log n) := by
+    intros x hx
+    rcases eq_or_lt_of_le (hp_nn x hx) with hpx_eq | hpx_pos
+    · rw [← hpx_eq]; simp
+    · rw [Real.log_mul hpx_pos.ne' hn_pos.ne']; ring
+  have rhs_eq : ∑ x ∈ S, (p x * n) * Real.log (p x * n)
+      = n * (∑ x ∈ S, p x * Real.log (p x)) + n * Real.log n := by
+    rw [Finset.sum_congr rfl rhs_pointwise]
+    rw [Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.sum_mul, hp_sum, one_mul]
+  rw [lhs_zero, rhs_eq] at sum_ineq
+  unfold entropy
+  have entropy_neg : ∑ x ∈ S, Real.negMulLog (p x) = -(∑ x ∈ S, p x * Real.log (p x)) := by
+    rw [← Finset.sum_neg_distrib]
+    refine Finset.sum_congr rfl (fun x _ => ?_)
+    rw [Real.negMulLog]; ring
+  rw [entropy_neg]
+  have h_factored : 0 ≤ n * ((∑ x ∈ S, p x * Real.log (p x)) + Real.log n) := by
+    have : n * ((∑ x ∈ S, p x * Real.log (p x)) + Real.log n)
+         = n * (∑ x ∈ S, p x * Real.log (p x)) + n * Real.log n := by ring
+    linarith [this, sum_ineq]
+  have h_div : 0 ≤ (∑ x ∈ S, p x * Real.log (p x)) + Real.log n :=
+    (mul_nonneg_iff_of_pos_left hn_pos).mp h_factored
+  linarith
+
+end Shannon
+
+end

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -5307,6 +5307,16 @@
   year          = {1958}
 }
 
+@Article{         shannon1948,
+  author        = {Shannon, Claude Elwood},
+  title         = {A mathematical theory of communication},
+  journal       = {Bell System Technical Journal},
+  volume        = {27},
+  pages         = {379--423, 623--656},
+  year          = {1948},
+  doi           = {10.1002/j.1538-7305.1948.tb01338.x}
+}
+
 @Book{            silverman2009,
   author        = {Silverman, Joseph},
   publisher     = {Springer New York, NY},


### PR DESCRIPTION
Define the discrete Shannon entropy of a finitely-supported probability distribution
and prove the maximum-entropy bound.

The entropy `∑ x ∈ S, negMulLog (p x)` is at most `Real.log |S|` for any nonneg
function summing to `1` over a nonempty `Finset`. The proof applies
`Real.self_sub_one_le_mul_log` pointwise to scale `p x` by `|S|`, expands
`Real.log_mul` to split `log (p x * n)` into `log (p x) + log n`, then sums over `S`
and uses the normalization hypothesis to collapse the inequality.

Mathlib has `Real.negMulLog` and `Real.binEntropy`, but no general discrete Shannon
entropy definition or max-entropy bound over a `Finset`.

#### Main definitions

* `Shannon.entropy`: `∑ x ∈ S, negMulLog (p x)`

#### Main results

* `Shannon.entropy_le_log_card`: for any nonneg `p : α → ℝ` with `∑ x ∈ S, p x = 1`,
  `Shannon.entropy p S ≤ Real.log S.card`

#### Open questions

* **Module placement**: this file is proposed at `Mathlib/InformationTheory/Shannon.lean`
  to sit alongside `InformationTheory/KullbackLeibler/`. An alternative is
  `Mathlib/Analysis/SpecialFunctions/Log/Shannon.lean`, closer to `NegMulLog` and
  consistent with where `Real.binEntropy` lives. Happy to move it based on reviewer
  preference.