### PR TITLE
[Merged by Bors] - chore: reduce use of continuity

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/TopAdj.lean
@@ -83,7 +83,7 @@ noncomputable def toSSetObj₀Equiv {X : TopCat.{u}} :
     toSSet.obj X _⦋0⦌ ≃ X :=
   (toSSetObjEquiv X _).trans
     { toFun f := f.1 (default : _)
-      invFun x := ⟨fun _ ↦ x, by continuity⟩
+      invFun x := ⟨fun _ ↦ x, by fun_prop⟩
       left_inv _ := by
         ext x
         obtain rfl := Subsingleton.elim x default

--- a/Mathlib/Analysis/Complex/JensenFormula.lean
+++ b/Mathlib/Analysis/Complex/JensenFormula.lean
@@ -144,7 +144,7 @@ private theorem herglotzLogIntegrand_circleAverage_tendsto {ρ w : ℂ} {R : ℝ
     simpa [sub_eq_zero] using
       (countable_singleton ρ).preimage_circleMap 0 (hR.ne') |>.measure_zero _
   · -- IntervalIntegrable bound volume 0 (2 * π)
-    apply (IntervalIntegrable.add (by simp) (by continuity)).add ?_ |>.const_mul
+    apply (IntervalIntegrable.add (by simp) (by simp)).add ?_ |>.const_mul
     exact .abs <| MeromorphicOn.circleIntegrable_log_norm (f := fun z ↦ z - ρ) (by intro; fun_prop)
   · -- Pointwise convergence outside a null set
     have h_measure_zero : volume {θ : ℝ | circleMap 0 R θ = w ∨ circleMap 0 R θ = ρ} = 0 :=

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -288,8 +288,7 @@ theorem approx_Gamma_integral_tendsto_Gamma_integral {s : ℂ} (hs : 0 < re s) :
     apply IntervalIntegrable.continuousOn_mul
     · refine intervalIntegral.intervalIntegrable_cpow' ?_
       rwa [sub_re, one_re, ← zero_sub, sub_lt_sub_iff_right]
-    · apply Continuous.continuousOn
-      continuity
+    · fun_prop
   -- pointwise limit of f
   have f_tends : ∀ x : ℝ, x ∈ Ioi (0 : ℝ) →
       Tendsto (fun n : ℕ => f n x) atTop (𝓝 <| ↑(Real.exp (-x)) * (x : ℂ) ^ (s - 1)) := by

--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -272,7 +272,7 @@ def ContinuousMulEquiv.toProfiniteGrpIso {X Y : ProfiniteGrp} (e : X ≃ₜ* Y) 
 instance : HasForget₂ ProfiniteGrp Profinite where
   forget₂ := {
     obj G := G.toProfinite
-    map f := CompHausLike.ofHom _ ⟨f, by continuity⟩}
+    map f := CompHausLike.ofHom _ ⟨f, by fun_prop⟩}
 
 @[to_additive]
 instance : (forget₂ ProfiniteGrp Profinite).Faithful := {

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -270,7 +270,7 @@ lemma isEmbedding_iff ⦃A X : TopCat⦄ (f : A ⟶ X) : isEmbedding f ↔ Topol
 
 /-- The constant morphism `X ⟶ Y` in `TopCat` given by `y : Y`. -/
 def const {X Y : TopCat.{u}} (y : Y) : X ⟶ Y :=
-  ofHom ⟨fun _ ↦ y, by continuity⟩
+  ofHom ⟨fun _ ↦ y, by fun_prop⟩
 
 @[simp]
 lemma const_apply {X Y : TopCat.{u}} (y : Y) (x : X) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -236,7 +236,7 @@ protected def binaryCofan (X Y : TopCat.{u}) : BinaryCofan X Y :=
 def binaryCofanIsColimit (X Y : TopCat.{u}) : IsColimit (TopCat.binaryCofan X Y) := by
   refine Limits.BinaryCofan.isColimitMk (fun s => ofHom
     { toFun := Sum.elim s.inl s.inr, continuous_toFun := ?_ }) ?_ ?_ ?_
-  · continuity
+  · fun_prop
   · intro s
     ext
     rfl
@@ -286,7 +286,7 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat.{u}} (c : BinaryCofan X Y) :
             convert_to Continuous (f ∘ h₁.isEmbedding.toHomeomorph.symm)
             · ext ⟨x, hx⟩
               exact dif_pos hx
-            continuity
+            fun_prop
           · exact h₁.isOpen_range
         · revert h x
           simp only [← mem_compl_iff]
@@ -301,10 +301,9 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat.{u}} (c : BinaryCofan X Y) :
               exact dif_neg hx
             apply Continuous.comp
             · exact g.hom.continuous_toFun
-            · apply Continuous.comp
-              · continuity
-              · rw [IsEmbedding.subtypeVal.isInducing.continuous_iff]
-                exact continuous_subtype_val
+            · apply Continuous.comp (by fun_prop)
+              rw [IsEmbedding.subtypeVal.isInducing.continuous_iff]
+              exact continuous_subtype_val
           · change IsOpen (Set.range c.inl)ᶜ
             rw [← eq_compl_iff_isCompl.mpr h₃.symm]
             exact h₂.isOpen_range

--- a/Mathlib/Topology/Category/TopCat/Monoidal.lean
+++ b/Mathlib/Topology/Category/TopCat/Monoidal.lean
@@ -132,7 +132,7 @@ lemma ext {x y : I.{u}} (h : homeomorph x = homeomorph y) : x = y :=
 
 /-- The symmetrization map `TopCat.I ⟶ TopCat.I`. -/
 def symm : I.{u} ⟶ I :=
-  ofHom ⟨homeomorph.symm ∘ unitInterval.symm ∘ homeomorph, by continuity⟩
+  ofHom ⟨homeomorph.symm ∘ unitInterval.symm ∘ homeomorph, by fun_prop⟩
 
 @[simp]
 lemma homeomorph_symm (x : I) :

--- a/Mathlib/Topology/Category/TopCommRingCat.lean
+++ b/Mathlib/Topology/Category/TopCommRingCat.lean
@@ -58,13 +58,14 @@ attribute [instance] isCommRing isTopologicalSpace isTopologicalRing
 
 instance : Category TopCommRingCat.{u} where
   Hom R S := { f : R →+* S // Continuous f }
-  id R := ⟨RingHom.id R, by rw [RingHom.id]; continuity⟩
+  id R := ⟨RingHom.id R, by rw [RingHom.id]; dsimp; fun_prop⟩
   comp f g :=
     ⟨g.val.comp f.val, by
       -- TODO automate
       cases f
       cases g
-      continuity⟩
+      dsimp
+      fun_prop⟩
 
 instance (R S : TopCommRingCat.{u}) : FunLike { f : R →+* S // Continuous f } R S where
   coe f := f.val

--- a/Mathlib/Topology/Convenient/ContinuousMapGeneratedBy.lean
+++ b/Mathlib/Topology/Convenient/ContinuousMapGeneratedBy.lean
@@ -129,7 +129,7 @@ def equivSymmAsContinuousMapGeneratedBy :
     rw [continuousGeneratedBy_def]
     intro i f
     rw [IsGeneratedBy.equiv_symm_comp_continuous_iff]
-    continuity
+    fun_prop
 
 @[simp]
 lemma equivSymmAsContinuousMapGeneratedBy_coe :

--- a/Mathlib/Topology/Convenient/GeneratedBy.lean
+++ b/Mathlib/Topology/Convenient/GeneratedBy.lean
@@ -211,7 +211,7 @@ instance : IsGeneratedBy X (WithGeneratedByTopology X Y) where
     rw [continuous_iff X]
     intro j g
     rw [Function.comp_assoc, equiv_symm_comp_continuous_iff]
-    continuity
+    fun_prop
 
 instance : IsGeneratedBy X (PUnit.{v + 1}) := by
   rw [iff_le_generatedBy]

--- a/Mathlib/Topology/Convenient/HomSpace.lean
+++ b/Mathlib/Topology/Convenient/HomSpace.lean
@@ -81,7 +81,7 @@ lemma continuousGeneratedBy_dom_prod_iff [∀ i j, IsGeneratedBy X (X i × X j)]
   · rw [IsGeneratedBy.continuous_iff X]
     intro j p
     let φ : X i₁ × X i₂ → Y × Z := fun (x₁, x₂) ↦ (f₂ x₂, f₁ x₁)
-    replace h := h.comp (show Continuous φ by continuity).continuousGeneratedBy
+    replace h := h.comp (show Continuous φ by fun_prop).continuousGeneratedBy
     rw [continuousGeneratedBy_def] at h
     exact h p
   · rw [continuousGeneratedBy_def]

--- a/Mathlib/Topology/FiberPartition.lean
+++ b/Mathlib/Topology/FiberPartition.lean
@@ -34,7 +34,7 @@ variable [TopologicalSpace S]
 @[simps apply]
 def sigmaIsoHom : C((x : Fiber f) × x.val, S) where
   toFun | ⟨a, x⟩ => x.val
-  continuous_toFun := by continuity
+  continuous_toFun := continuous_sigma (by fun_prop)
 
 lemma sigmaIsoHom_inj : Function.Injective (sigmaIsoHom f) := by
   rintro ⟨⟨_, _, rfl⟩, ⟨_, hx⟩⟩ ⟨⟨_, _, rfl⟩, ⟨_, hy⟩⟩ h

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -516,5 +516,5 @@ open NNReal in
 /-- **Tietze extension theorem** for nonnegative real-valued continuous maps.
 `ℝ≥0` is a `TietzeExtension` space. -/
 instance NNReal.instTietzeExtension : TietzeExtension ℝ≥0 :=
-  .of_retract ⟨((↑) : ℝ≥0 → ℝ), by continuity⟩ ⟨Real.toNNReal, continuous_real_toNNReal⟩ <| by
+  .of_retract ⟨((↑) : ℝ≥0 → ℝ), by fun_prop⟩ ⟨Real.toNNReal, continuous_real_toNNReal⟩ <| by
     ext; simp


### PR DESCRIPTION
All these cases have easy replacements. Split from #39337.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
