### PR TITLE
[Merged by Bors] - chore(Tactic): update `tauto` and `tauto_set` tactic docs

### DIFF
--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -212,13 +212,13 @@ def tautology : TacticM Unit := focus do
       throwTacticEx `tauto g
 
 /--
-`tauto` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`
+`tauto` proves tautologies in classical propositional logic.
+It breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`
 and splits a goal of the form `_ ∧ _`, `_ ↔ _` or `∃ _, _` until it can be discharged
-using `rfl` or `solve_by_elim`.
+using `rfl`, `contradiction` or `solve_by_elim`.
 This is a finishing tactic: it either closes the goal or raises an error.
 
-The Lean 3 version of this tactic by default attempted to avoid classical reasoning
-where possible. This Lean 4 version makes no such attempt. The `itauto` tactic
+This tactic makes no attempt to avoid classical reasoning. The `itauto` tactic
 is designed for that purpose.
 -/
 syntax (name := tauto) "tauto" optConfig : tactic

--- a/Mathlib/Tactic/TautoSet.lean
+++ b/Mathlib/Tactic/TautoSet.lean
@@ -29,10 +29,12 @@ elab (name := specialize_all) "specialize_all" x:term : tactic => withMainContex
 
 
 /--
-`tauto_set` attempts to prove tautologies involving hypotheses and goals of the form `X ⊆ Y`
-or `X = Y`, where `X`, `Y` are expressions built using ∪, ∩, \, and ᶜ from finitely many
+`tauto_set` proves tautologies involving hypotheses and goals of the form `X ⊆ Y`
+or `X = Y`, where `X`, `Y` are expressions built using `∪`, `∩`, `\`, and `ᶜ` from finitely many
 variables of type `Set α`. It also unfolds expressions of the form `Disjoint A B` and
 `symmDiff A B`.
+In other words, this tactic proves propositional tautologies, expressed in the language of sets.
+This is a finishing tactic: it either closes the goal or raises an error.
 
 Examples:
 ```lean


### PR DESCRIPTION
This PR updates the docstrings for the `tauto` and `tauto_set` tactics, as follows:
* First say that they solve tautologies (expressed in propositional logic and elementary set theory respectively), instead of listing a bunch of operators,
* Clarify that they either close the goal or fail,
* Remove the mention of Lean 3 since we have been on Lean 4 for years now.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
